### PR TITLE
[WIP] refactor HiveDataSink

### DIFF
--- a/velox/connectors/hive/BucketSortingWriter.cpp
+++ b/velox/connectors/hive/BucketSortingWriter.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/BucketSortingWriter.h"
+
+#include "velox/connectors/hive/HiveWriterTypes.h"
+#include "velox/dwio/common/SortingWriter.h"
+#include "velox/exec/SortBuffer.h"
+
+namespace facebook::velox::connector::hive {
+
+BucketSortingWriter::BucketSortingWriter(
+    RowTypePtr dataType,
+    std::vector<column_index_t> sortColumnIndices,
+    std::vector<CompareFlags> sortCompareFlags,
+    uint64_t finishTimeSliceLimitMs,
+    uint64_t maxOutputRows,
+    uint64_t maxOutputBytes,
+    common::PrefixSortConfig prefixSortConfig,
+    const common::SpillConfig* spillConfig)
+    : dataType_(std::move(dataType)),
+      sortColumnIndices_(std::move(sortColumnIndices)),
+      sortCompareFlags_(std::move(sortCompareFlags)),
+      finishTimeSliceLimitMs_(finishTimeSliceLimitMs),
+      maxOutputRows_(maxOutputRows),
+      maxOutputBytes_(maxOutputBytes),
+      prefixSortConfig_(prefixSortConfig),
+      spillConfig_(spillConfig) {}
+
+std::unique_ptr<dwio::common::Writer> BucketSortingWriter::wrap(
+    HiveWriterInfo* writerInfo,
+    std::unique_ptr<dwio::common::Writer> writer) {
+  VELOX_CHECK_NOT_NULL(writerInfo);
+  if (!enabled()) {
+    return writer;
+  }
+
+  auto* sortPool = writerInfo->sortPool.get();
+  VELOX_CHECK_NOT_NULL(sortPool);
+  auto sortBuffer = std::make_unique<exec::SortBuffer>(
+      dataType_,
+      sortColumnIndices_,
+      sortCompareFlags_,
+      sortPool,
+      writerInfo->nonReclaimableSectionHolder.get(),
+      prefixSortConfig_,
+      spillConfig_,
+      writerInfo->spillStats.get());
+
+  return std::make_unique<dwio::common::SortingWriter>(
+      std::move(writer),
+      std::move(sortBuffer),
+      maxOutputRows_,
+      maxOutputBytes_,
+      finishTimeSliceLimitMs_);
+}
+
+} // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/BucketSortingWriter.h
+++ b/velox/connectors/hive/BucketSortingWriter.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "velox/common/base/SpillConfig.h"
+#include "velox/exec/PrefixSort.h"
+#include "velox/type/Type.h"
+#include "velox/vector/ComplexVector.h"
+
+namespace facebook::velox::dwio::common {
+class Writer;
+} // namespace facebook::velox::dwio::common
+
+namespace facebook::velox::connector::hive {
+
+struct HiveWriterInfo;
+
+/// Encapsulates bucket sort configuration and wraps format writers with
+/// SortingWriter when bucket sorting is enabled. Sits at the same layer as
+/// PartitionWriter — owns the sort configuration and provides the wrapping
+/// logic used during writer creation.
+class BucketSortingWriter {
+ public:
+  /// @param dataType Schema of the data columns (non-partition columns).
+  /// @param sortColumnIndices Indices of sort columns within dataType.
+  /// @param sortCompareFlags Sort order flags for each sort column.
+  /// @param finishTimeSliceLimitMs Time slice limit for finish processing.
+  /// @param maxOutputRows Maximum rows per output batch from SortingWriter.
+  /// @param maxOutputBytes Maximum bytes per output batch from SortingWriter.
+  /// @param prefixSortConfig Prefix sort configuration.
+  /// @param spillConfig Spill configuration (nullptr if spilling disabled).
+  BucketSortingWriter(
+      RowTypePtr dataType,
+      std::vector<column_index_t> sortColumnIndices,
+      std::vector<CompareFlags> sortCompareFlags,
+      uint64_t finishTimeSliceLimitMs,
+      uint64_t maxOutputRows,
+      uint64_t maxOutputBytes,
+      common::PrefixSortConfig prefixSortConfig,
+      const common::SpillConfig* spillConfig);
+
+  /// Returns true if bucket sorting is enabled.
+  bool enabled() const {
+    return !sortColumnIndices_.empty();
+  }
+
+  /// Returns the finish time slice limit in milliseconds.
+  uint64_t finishTimeSliceLimitMs() const {
+    return finishTimeSliceLimitMs_;
+  }
+
+  /// Wraps a format writer with SortingWriter if sorting is enabled.
+  /// Returns the writer unchanged if sorting is not enabled.
+  std::unique_ptr<dwio::common::Writer> wrap(
+      HiveWriterInfo* writerInfo,
+      std::unique_ptr<dwio::common::Writer> writer);
+
+ private:
+  const RowTypePtr dataType_;
+  const std::vector<column_index_t> sortColumnIndices_;
+  const std::vector<CompareFlags> sortCompareFlags_;
+  const uint64_t finishTimeSliceLimitMs_;
+  const uint64_t maxOutputRows_;
+  const uint64_t maxOutputBytes_;
+  const common::PrefixSortConfig prefixSortConfig_;
+  const common::SpillConfig* const spillConfig_;
+};
+
+} // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/CMakeLists.txt
+++ b/velox/connectors/hive/CMakeLists.txt
@@ -21,6 +21,7 @@ add_subdirectory(paimon)
 velox_add_library(
   velox_hive_connector
   OBJECT
+  BucketSortingWriter.cpp
   BufferedInputBuilder.cpp
   ExtractionUtils.cpp
   ExtractionUtils.h
@@ -39,9 +40,13 @@ velox_add_library(
   HiveDataSink.cpp
   HiveDataSource.cpp
   HiveIndexSource.cpp
+  HiveInsertTableHandle.cpp
   HivePartitionName.cpp
   HiveSplitReader.cpp
+  HiveWriterTypes.cpp
   PartitionIdGenerator.cpp
+  PartitionWriter.cpp
+  RotationWriter.cpp
   TableHandle.cpp
   HEADERS
   BufferedInputBuilder.h
@@ -62,13 +67,17 @@ velox_add_library(
   HiveConnector.h
   HiveConnectorSplit.h
   HiveConnectorUtil.h
+  HiveCommitMessage.h
   HiveDataSink.h
   HiveDataSource.h
   HiveIndexSource.h
+  HiveInsertTableHandle.h
   HivePartitionFunction.h
   HivePartitionName.h
   HiveSplitReader.h
+  HiveWriterTypes.h
   IndexReader.h
+  PartitionWriterInterface.h
   PartitionIdGenerator.h
   TableHandle.h
 )

--- a/velox/connectors/hive/HiveCommitMessage.h
+++ b/velox/connectors/hive/HiveCommitMessage.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+namespace facebook::velox::connector::hive {
+
+/// JSON field names for the partition update object produced by each writer
+/// and consumed by the Presto coordinator to finalize files and update the
+/// metastore.
+///
+/// JSON structure:
+/// {
+///   "name":                        "<partition key, e.g. ds=2024-01-01>",
+///   "updateMode":                  "NEW" | "APPEND" | "OVERWRITE",
+///   "writePath":                   "<staging directory>",
+///   "targetPath":                  "<final directory>",
+///   "fileWriteInfos": [
+///     {
+///       "writeFileName":           "<temp filename in writePath>",
+///       "targetFileName":          "<final filename in targetPath>",
+///       "fileSize":                <bytes>
+///     }
+///   ],
+///   "rowCount":                    <total rows>,
+///   "inMemoryDataSizeInBytes":     <uncompressed bytes>,
+///   "onDiskDataSizeInBytes":       <compressed bytes on disk>,
+///   "containsNumberedFileNames":   true | false
+/// }
+struct HiveCommitMessage {
+  /// Partition directory name in Hive format (e.g., "ds=2024-01-01/region=us").
+  /// Empty string for unpartitioned tables.
+  static constexpr const char* kName = "name";
+  /// Write mode: "NEW", "APPEND", or "OVERWRITE". Controls how the committer
+  /// handles metastore updates and existing file conflicts.
+  static constexpr const char* kUpdateMode = "updateMode";
+  /// Staging directory where files were written during execution.
+  static constexpr const char* kWritePath = "writePath";
+  /// Final destination directory. Files are renamed from writePath to
+  /// targetPath during commit.
+  static constexpr const char* kTargetPath = "targetPath";
+  /// Array of per-file metadata objects. One entry per file written, including
+  /// rotated files.
+  static constexpr const char* kFileWriteInfos = "fileWriteInfos";
+  /// Temporary filename used during writing (in the staging directory).
+  static constexpr const char* kWriteFileName = "writeFileName";
+  /// Final filename after commit (in the target directory).
+  static constexpr const char* kTargetFileName = "targetFileName";
+  /// Size of individual file in bytes.
+  static constexpr const char* kFileSize = "fileSize";
+  /// Total rows written to this partition across all files.
+  static constexpr const char* kRowCount = "rowCount";
+  /// Uncompressed input data size in bytes.
+  static constexpr const char* kInMemoryDataSizeInBytes =
+      "inMemoryDataSizeInBytes";
+  /// Compressed bytes written to disk.
+  static constexpr const char* kOnDiskDataSizeInBytes = "onDiskDataSizeInBytes";
+  /// Whether filenames follow a numbered sequence from file rotation.
+  static constexpr const char* kContainsNumberedFileNames =
+      "containsNumberedFileNames";
+};
+
+} // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -20,6 +20,7 @@
 #include "velox/connectors/hive/HiveConfigProvider.h"
 #include "velox/connectors/hive/HiveDataSink.h"
 #include "velox/connectors/hive/HiveDataSource.h"
+#include "velox/connectors/hive/HiveInsertTableHandle.h"
 #include "velox/connectors/hive/HiveIndexSource.h"
 #include "velox/connectors/hive/HivePartitionFunction.h"
 

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -16,31 +16,25 @@
 
 #include "velox/connectors/hive/HiveDataSink.h"
 
+#include "velox/connectors/hive/BucketSortingWriter.h"
+#include "velox/connectors/hive/PartitionWriter.h"
+#include "velox/connectors/hive/RotationWriter.h"
+#include "velox/connectors/hive/HiveInsertTableHandle.h"
+
 #include "velox/common/base/Counters.h"
 #include "velox/common/base/Fs.h"
 #include "velox/common/base/StatsReporter.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/connectors/hive/HiveConfig.h"
-#include "velox/connectors/hive/HiveConnectorUtil.h"
 #include "velox/connectors/hive/HivePartitionFunction.h"
-#include "velox/connectors/hive/TableHandle.h"
+#include "velox/connectors/hive/HivePartitionName.h"
 #include "velox/dwio/common/Options.h"
-#include "velox/dwio/common/SortingWriter.h"
 #include "velox/exec/OperatorUtils.h"
-#include "velox/exec/SortBuffer.h"
-
-#include <boost/lexical_cast.hpp>
-#include <boost/uuid/uuid_generators.hpp>
-#include <boost/uuid/uuid_io.hpp>
-#include <re2/re2.h>
 
 using facebook::velox::common::testutil::TestValue;
 
 namespace facebook::velox::connector::hive {
 namespace {
-#define WRITER_NON_RECLAIMABLE_SECTION_GUARD(index)       \
-  memory::NonReclaimableSectionGuard nonReclaimableGuard( \
-      writerInfo_[(index)]->nonReclaimableSectionHolder.get())
 
 // Appends a sequence number to a filename for file rotation.
 // Returns the original filename if sequenceNumber is 0 (no rotation yet).
@@ -103,23 +97,10 @@ RowTypePtr getNonPartitionTypes(
   return ROW(std::move(childNames), std::move(childTypes));
 }
 
-// Filters out partition columns if there is any.
-RowVectorPtr makeDataInput(
-    const std::vector<column_index_t>& dataCols,
-    const RowVectorPtr& input) {
-  std::vector<VectorPtr> childVectors;
-  childVectors.reserve(dataCols.size());
-  for (int dataCol : dataCols) {
-    childVectors.push_back(input->childAt(dataCol));
-  }
-
-  return std::make_shared<RowVector>(
-      input->pool(),
-      getNonPartitionTypes(dataCols, asRowType(input->type())),
-      input->nulls(),
-      input->size(),
-      std::move(childVectors),
-      input->getNullCount());
+std::shared_ptr<dwio::common::WriterOptions> cloneWriterOptions(
+    const std::shared_ptr<dwio::common::WriterOptions>& writerOptions) {
+  VELOX_CHECK_NOT_NULL(writerOptions);
+  return writerOptions->clone();
 }
 
 // Creates a PartitionIdGenerator if the table is partitioned, otherwise returns
@@ -150,26 +131,6 @@ std::string makePartitionDirectory(
   return tableDirectory;
 }
 
-std::string makeUuid() {
-  return boost::lexical_cast<std::string>(boost::uuids::random_generator()());
-}
-
-std::unordered_map<LocationHandle::TableType, std::string> tableTypeNames() {
-  return {
-      {LocationHandle::TableType::kNew, "kNew"},
-      {LocationHandle::TableType::kExisting, "kExisting"},
-  };
-}
-
-template <typename K, typename V>
-std::unordered_map<V, K> invertMap(const std::unordered_map<K, V>& mapping) {
-  std::unordered_map<V, K> inverted;
-  for (const auto& [key, value] : mapping) {
-    inverted.emplace(value, key);
-  }
-  return inverted;
-}
-
 std::unique_ptr<core::PartitionFunction> createBucketFunction(
     const HiveBucketProperty& bucketProperty,
     const RowTypePtr& inputType) {
@@ -193,17 +154,6 @@ std::unique_ptr<core::PartitionFunction> createBucketFunction(
   }
   return std::make_unique<HivePartitionFunction>(
       bucketProperty.bucketCount(), bucketedByChannels);
-}
-
-std::string computeBucketedFileName(
-    const std::string& queryId,
-    uint32_t maxBucketCount,
-    uint32_t bucket) {
-  const uint32_t kMaxBucketCountPadding =
-      std::to_string(maxBucketCount - 1).size();
-  const std::string bucketValueStr = std::to_string(bucket);
-  return fmt::format(
-      "0{:0>{}}_0_{}", bucketValueStr, kMaxBucketCountPadding, queryId);
 }
 
 std::shared_ptr<memory::MemoryPool> createSinkPool(
@@ -233,240 +183,7 @@ getBucketCount(const HiveBucketProperty* bucketProperty) {
   return bucketProperty == nullptr ? 0 : bucketProperty->bucketCount();
 }
 
-std::vector<column_index_t> computePartitionChannels(
-    const std::vector<std::shared_ptr<const HiveColumnHandle>>& inputColumns) {
-  std::vector<column_index_t> channels;
-  for (auto i = 0; i < inputColumns.size(); i++) {
-    if (inputColumns[i]->isPartitionKey()) {
-      channels.push_back(i);
-    }
-  }
-  return channels;
-}
-
-std::vector<column_index_t> computeNonPartitionChannels(
-    const std::vector<std::shared_ptr<const HiveColumnHandle>>& inputColumns) {
-  std::vector<column_index_t> channels;
-  for (auto i = 0; i < inputColumns.size(); i++) {
-    if (!inputColumns[i]->isPartitionKey()) {
-      channels.push_back(i);
-    }
-  }
-  return channels;
-}
-
 } // namespace
-
-const HiveWriterId& HiveWriterId::unpartitionedId() {
-  static const HiveWriterId writerId{0};
-  return writerId;
-}
-
-std::string HiveWriterId::toString() const {
-  if (partitionId.has_value() && bucketId.has_value()) {
-    return fmt::format("part[{}.{}]", partitionId.value(), bucketId.value());
-  }
-
-  if (partitionId.has_value() && !bucketId.has_value()) {
-    return fmt::format("part[{}]", partitionId.value());
-  }
-
-  // This WriterId is used to add an identifier in the MemoryPools. This could
-  // indicate unpart, but the bucket number needs to be disambiguated. So
-  // creating a new label using bucket.
-  if (!partitionId.has_value() && bucketId.has_value()) {
-    return fmt::format("bucket[{}]", bucketId.value());
-  }
-
-  return "unpart";
-}
-
-const std::string LocationHandle::tableTypeName(
-    LocationHandle::TableType type) {
-  static const auto tableTypes = tableTypeNames();
-  return tableTypes.at(type);
-}
-
-LocationHandle::TableType LocationHandle::tableTypeFromName(
-    const std::string& name) {
-  static const auto nameTableTypes = invertMap(tableTypeNames());
-  return nameTableTypes.at(name);
-}
-
-HiveSortingColumn::HiveSortingColumn(
-    const std::string& sortColumn,
-    const core::SortOrder& sortOrder)
-    : sortColumn_(sortColumn), sortOrder_(sortOrder) {
-  VELOX_USER_CHECK(!sortColumn_.empty(), "hive sort column must be set");
-
-  if (FOLLY_UNLIKELY(
-          (sortOrder_.isAscending() && !sortOrder_.isNullsFirst()) ||
-          (!sortOrder_.isAscending() && sortOrder_.isNullsFirst()))) {
-    VELOX_USER_FAIL("Bad hive sort order: {}", toString());
-  }
-}
-
-folly::dynamic HiveSortingColumn::serialize() const {
-  folly::dynamic obj = folly::dynamic::object;
-  obj["name"] = "HiveSortingColumn";
-  obj["columnName"] = sortColumn_;
-  obj["sortOrder"] = sortOrder_.serialize();
-  return obj;
-}
-
-std::shared_ptr<HiveSortingColumn> HiveSortingColumn::deserialize(
-    const folly::dynamic& obj,
-    void* context) {
-  const std::string columnName = obj["columnName"].asString();
-  const auto sortOrder = core::SortOrder::deserialize(obj["sortOrder"]);
-  return std::make_shared<HiveSortingColumn>(columnName, sortOrder);
-}
-
-std::string HiveSortingColumn::toString() const {
-  return fmt::format(
-      "[COLUMN[{}] ORDER[{}]]", sortColumn_, sortOrder_.toString());
-}
-
-void HiveSortingColumn::registerSerDe() {
-  auto& registry = DeserializationWithContextRegistryForSharedPtr();
-  registry.Register("HiveSortingColumn", HiveSortingColumn::deserialize);
-}
-
-HiveBucketProperty::HiveBucketProperty(
-    Kind kind,
-    int32_t bucketCount,
-    const std::vector<std::string>& bucketedBy,
-    const std::vector<TypePtr>& bucketTypes,
-    const std::vector<std::shared_ptr<const HiveSortingColumn>>& sortedBy)
-    : kind_(kind),
-      bucketCount_(bucketCount),
-      bucketedBy_(bucketedBy),
-      bucketTypes_(bucketTypes),
-      sortedBy_(sortedBy) {
-  validate();
-}
-
-void HiveBucketProperty::validate() const {
-  VELOX_USER_CHECK_GT(bucketCount_, 0, "Hive bucket count can't be zero");
-  VELOX_USER_CHECK(!bucketedBy_.empty(), "Hive bucket columns must be set");
-  VELOX_USER_CHECK_EQ(
-      bucketedBy_.size(),
-      bucketTypes_.size(),
-      "The number of hive bucket columns and types do not match {}",
-      toString());
-}
-
-std::string HiveBucketProperty::kindString(Kind kind) {
-  switch (kind) {
-    case Kind::kHiveCompatible:
-      return "HIVE_COMPATIBLE";
-    case Kind::kPrestoNative:
-      return "PRESTO_NATIVE";
-    default:
-      return fmt::format("UNKNOWN {}", static_cast<int>(kind));
-  }
-}
-
-folly::dynamic HiveBucketProperty::serialize() const {
-  folly::dynamic obj = folly::dynamic::object;
-  obj["name"] = "HiveBucketProperty";
-  obj["kind"] = static_cast<int64_t>(kind_);
-  obj["bucketCount"] = bucketCount_;
-  obj["bucketedBy"] = ISerializable::serialize(bucketedBy_);
-  obj["bucketedTypes"] = ISerializable::serialize(bucketTypes_);
-  obj["sortedBy"] = ISerializable::serialize(sortedBy_);
-  return obj;
-}
-
-std::shared_ptr<HiveBucketProperty> HiveBucketProperty::deserialize(
-    const folly::dynamic& obj,
-    void* context) {
-  const Kind kind = static_cast<Kind>(obj["kind"].asInt());
-  const int32_t bucketCount = obj["bucketCount"].asInt();
-  const auto buckectedBy =
-      ISerializable::deserialize<std::vector<std::string>>(obj["bucketedBy"]);
-  const auto bucketedTypes = ISerializable::deserialize<std::vector<Type>>(
-      obj["bucketedTypes"], context);
-  const auto sortedBy =
-      ISerializable::deserialize<std::vector<HiveSortingColumn>>(
-          obj["sortedBy"], context);
-  return std::make_shared<HiveBucketProperty>(
-      kind, bucketCount, buckectedBy, bucketedTypes, sortedBy);
-}
-
-void HiveBucketProperty::registerSerDe() {
-  auto& registry = DeserializationWithContextRegistryForSharedPtr();
-  registry.Register("HiveBucketProperty", HiveBucketProperty::deserialize);
-}
-
-std::string HiveBucketProperty::toString() const {
-  std::stringstream out;
-  out << "\nHiveBucketProperty[<" << kind_ << " " << bucketCount_ << ">\n";
-  out << "\tBucket Columns:\n";
-  for (const auto& column : bucketedBy_) {
-    out << "\t\t" << column << "\n";
-  }
-  out << "\tBucket Types:\n";
-  for (const auto& type : bucketTypes_) {
-    out << "\t\t" << type->toString() << "\n";
-  }
-  if (!sortedBy_.empty()) {
-    out << "\tSortedBy Columns:\n";
-    for (const auto& sortColum : sortedBy_) {
-      out << "\t\t" << sortColum->toString() << "\n";
-    }
-  }
-  out << "]\n";
-  return out.str();
-}
-
-HiveInsertTableHandle::HiveInsertTableHandle(
-    std::vector<std::shared_ptr<const HiveColumnHandle>> inputColumns,
-    std::shared_ptr<const LocationHandle> locationHandle,
-    dwio::common::FileFormat storageFormat,
-    std::shared_ptr<const HiveBucketProperty> bucketProperty,
-    std::optional<common::CompressionKind> compressionKind,
-    const std::unordered_map<std::string, std::string>& serdeParameters,
-    const std::shared_ptr<dwio::common::WriterOptions>& writerOptions,
-    // When this option is set the HiveDataSink will always write a file even
-    // if there's no data. This is useful when the table is bucketed, but the
-    // engine handles ensuring a 1 to 1 mapping from task to bucket.
-    const bool ensureFiles,
-    std::shared_ptr<const FileNameGenerator> fileNameGenerator,
-    const std::unordered_map<std::string, std::string>& storageParameters)
-    : inputColumns_(std::move(inputColumns)),
-      locationHandle_(std::move(locationHandle)),
-      storageFormat_(storageFormat),
-      bucketProperty_(std::move(bucketProperty)),
-      compressionKind_(compressionKind),
-      serdeParameters_(serdeParameters),
-      writerOptions_(writerOptions),
-      ensureFiles_(ensureFiles),
-      fileNameGenerator_(std::move(fileNameGenerator)),
-      storageParameters_(storageParameters),
-      partitionChannels_(computePartitionChannels(inputColumns_)),
-      nonPartitionChannels_(computeNonPartitionChannels(inputColumns_)) {
-  if (compressionKind.has_value()) {
-    VELOX_CHECK(
-        compressionKind.value() != common::CompressionKind_MAX,
-        "Unsupported compression type: CompressionKind_MAX");
-  }
-
-  if (ensureFiles_) {
-    // If ensureFiles is set and either the bucketProperty is set or some
-    // partition keys are in the data, there is not a 1:1 mapping from Task to
-    // files so we can't proactively create writers.
-    VELOX_CHECK(
-        bucketProperty_ == nullptr || bucketProperty_->bucketCount() == 0,
-        "ensureFiles is not supported with bucketing");
-
-    for (const auto& inputColumn : inputColumns_) {
-      VELOX_CHECK(
-          !inputColumn->isPartitionKey(),
-          "ensureFiles is not supported with partition keys in the data");
-    }
-  }
-}
 
 HiveDataSink::HiveDataSink(
     RowTypePtr inputType,
@@ -521,9 +238,6 @@ HiveDataSink::HiveDataSink(
       writerFactory_(
           dwio::common::getWriterFactory(insertTableHandle_->storageFormat())),
       spillConfig_(connectorQueryCtx->spillConfig()),
-      sortWriterFinishTimeSliceLimitMs_(getFinishTimeSliceLimitMsFromHiveConfig(
-          hiveConfig_,
-          connectorQueryCtx->sessionProperties())),
       maxTargetFileBytes_(hiveConfig_->maxTargetFileSizeBytes(
           connectorQueryCtx->sessionProperties())),
       partitionKeyAsLowerCase_(hiveConfig_->isPartitionPathAsLowerCase(
@@ -543,35 +257,64 @@ HiveDataSink::HiveDataSink(
       "Unsupported commit strategy: {}",
       CommitStrategyName::toName(commitStrategy_));
 
+  // Compute the data column type once, used by BucketSortingWriter and
+  // PartitionWriter.
+  auto dataType = getNonPartitionTypes(dataChannels_, inputType_);
+
+  // Build bucket sort configuration.
+  std::vector<column_index_t> sortColumnIndices;
+  std::vector<CompareFlags> sortCompareFlags;
+  if (isBucketed()) {
+    const auto& sortedProperty =
+        insertTableHandle_->bucketProperty()->sortedBy();
+    if (!sortedProperty.empty()) {
+      sortColumnIndices.reserve(sortedProperty.size());
+      sortCompareFlags.reserve(sortedProperty.size());
+      for (int i = 0; i < sortedProperty.size(); ++i) {
+        auto columnIndex =
+            dataType->getChildIdxIfExists(sortedProperty.at(i)->sortColumn());
+        if (columnIndex.has_value()) {
+          sortColumnIndices.push_back(columnIndex.value());
+          sortCompareFlags.push_back(
+              {sortedProperty.at(i)->sortOrder().isNullsFirst(),
+               sortedProperty.at(i)->sortOrder().isAscending(),
+               false,
+               CompareFlags::NullHandlingMode::kNullAsValue});
+        }
+      }
+    }
+  }
+  bucketSortingWriter_ = std::make_unique<BucketSortingWriter>(
+      dataType,
+      std::move(sortColumnIndices),
+      std::move(sortCompareFlags),
+      getFinishTimeSliceLimitMsFromHiveConfig(
+          hiveConfig_, connectorQueryCtx->sessionProperties()),
+      hiveConfig_->sortWriterMaxOutputRows(
+          connectorQueryCtx->sessionProperties()),
+      hiveConfig_->sortWriterMaxOutputBytes(
+          connectorQueryCtx->sessionProperties()),
+      connectorQueryCtx_->prefixSortConfig(),
+      spillConfig_);
+
+  partitionWriter_ = std::make_unique<PartitionWriter>(
+      maxOpenWriters_,
+      dataChannels_,
+      std::move(dataType),
+      [this](const HiveWriterId& id, uint32_t writerIndex) {
+        return createRotationWriter(id, writerIndex);
+      },
+      connectorQueryCtx_->memoryPool());
+
   if (insertTableHandle_->ensureFiles()) {
     VELOX_CHECK(
         !isPartitioned() && !isBucketed(),
         "ensureFiles is not supported with bucketing or partition keys in the data");
-    ensureWriter(HiveWriterId::unpartitionedId());
-  }
-
-  if (!isBucketed()) {
-    return;
-  }
-  const auto& sortedProperty = insertTableHandle_->bucketProperty()->sortedBy();
-  if (!sortedProperty.empty()) {
-    sortColumnIndices_.reserve(sortedProperty.size());
-    sortCompareFlags_.reserve(sortedProperty.size());
-    for (int i = 0; i < sortedProperty.size(); ++i) {
-      auto columnIndex =
-          getNonPartitionTypes(dataChannels_, inputType_)
-              ->getChildIdxIfExists(sortedProperty.at(i)->sortColumn());
-      if (columnIndex.has_value()) {
-        sortColumnIndices_.push_back(columnIndex.value());
-        sortCompareFlags_.push_back(
-            {sortedProperty.at(i)->sortOrder().isNullsFirst(),
-             sortedProperty.at(i)->sortOrder().isAscending(),
-             false,
-             CompareFlags::NullHandlingMode::kNullAsValue});
-      }
-    }
+    partitionWriter_->ensureWriter(HiveWriterId::unpartitionedId());
   }
 }
+
+HiveDataSink::~HiveDataSink() = default;
 
 bool HiveDataSink::canReclaim() const {
   // Currently, we only support memory reclaim on dwrf file writer.
@@ -588,8 +331,7 @@ void HiveDataSink::appendData(RowVectorPtr input) {
 
   // Write to unpartitioned (and unbucketed) table.
   if (!isPartitioned() && !isBucketed()) {
-    const auto index = ensureWriter(HiveWriterId::unpartitionedId());
-    write(index, input);
+    partitionWriter_->write(HiveWriterId::unpartitionedId(), input);
     return;
   }
 
@@ -599,109 +341,12 @@ void HiveDataSink::appendData(RowVectorPtr input) {
   // All inputs belong to a single non-bucketed partition. The partition id
   // must be zero.
   if (!isBucketed() && partitionIdGenerator_->numPartitions() == 1) {
-    const auto index = ensureWriter(HiveWriterId{0});
-    write(index, input);
+    partitionWriter_->write(HiveWriterId{0}, input);
     return;
   }
 
-  splitInputRowsAndEnsureWriters();
-
-  for (auto index = 0; index < writers_.size(); ++index) {
-    const vector_size_t partitionSize = partitionSizes_[index];
-    if (partitionSize == 0) {
-      continue;
-    }
-
-    RowVectorPtr writerInput = partitionSize == input->size()
-        ? input
-        : exec::wrap(partitionSize, partitionRows_[index], input);
-    write(index, writerInput);
-  }
-}
-
-void HiveDataSink::write(size_t index, RowVectorPtr input) {
-  WRITER_NON_RECLAIMABLE_SECTION_GUARD(index);
-  auto dataInput = makeDataInput(dataChannels_, input);
-
-  if (writers_[index] == nullptr) {
-    writers_[index] = createWriterForIndex(index);
-  }
-
-  writers_[index]->write(dataInput);
-  writerInfo_[index]->inputSizeInBytes += dataInput->estimateFlatSize();
-  writerInfo_[index]->numWrittenRows += dataInput->size();
-  writerInfo_[index]->currentFileWrittenRows += dataInput->size();
-
-  // File rotation is not supported for bucketed tables (require one file per
-  // bucket with predictable name) or sorted writes (SortingWriter not
-  // recreated).
-  if (maxTargetFileBytes_ == 0 || isBucketed() || sortWrite()) {
-    return;
-  }
-
-  const auto currentFileBytes = getCurrentFileBytes(index);
-  if (currentFileBytes >= maxTargetFileBytes_) {
-    rotateWriter(index);
-  }
-}
-
-uint64_t HiveDataSink::getCurrentFileBytes(size_t writerIndex) const {
-  VELOX_CHECK_LT(writerIndex, ioStats_.size());
-  VELOX_CHECK_LT(writerIndex, writerInfo_.size());
-  const auto totalBytes = ioStats_[writerIndex]->rawBytesWritten();
-  const auto baselineBytes = writerInfo_[writerIndex]->cumulativeWrittenBytes;
-  // Sanity check: total should always be >= baseline since ioStats is
-  // never reset and cumulative is a snapshot of rawBytesWritten at rotation.
-  VELOX_DCHECK_GE(totalBytes, baselineBytes);
-  return totalBytes - baselineBytes;
-}
-
-void HiveDataSink::finalizeWriterFile(size_t index) {
-  VELOX_CHECK_LT(index, writerInfo_.size());
-  VELOX_CHECK_LT(index, ioStats_.size());
-
-  auto& info = writerInfo_[index];
-
-  // Capture current file stats AFTER close to include footer bytes.
-  const auto currentFileBytes = getCurrentFileBytes(index);
-
-  // Finalize the current file into writtenFiles using the stored names.
-  if (currentFileBytes > 0) {
-    HiveFileInfo fileInfo;
-    fileInfo.writeFileName = info->currentWriteFileName;
-    fileInfo.targetFileName = info->currentTargetFileName;
-    fileInfo.fileSize = currentFileBytes;
-    fileInfo.numRows = info->currentFileWrittenRows;
-    // Reset for next file.
-    info->currentFileWrittenRows = 0;
-    info->writtenFiles.push_back(std::move(fileInfo));
-  }
-
-  // Update cumulative stats as a snapshot of total stats so far.
-  // This becomes the baseline for the next file.
-  info->cumulativeWrittenBytes = ioStats_[index]->rawBytesWritten();
-}
-
-// Rotates the current writer to a new file when the file size exceeds the
-// threshold. This enables writing multiple smaller files instead of one large
-// file, which improves downstream read performance and parallel processing.
-void HiveDataSink::rotateWriter(size_t index) {
-  VELOX_CHECK_LT(index, writers_.size());
-  VELOX_CHECK_LT(index, writerInfo_.size());
-
-  auto& info = writerInfo_[index];
-
-  // Close the writer first to flush all data including footer.
-  writers_[index]->close();
-
-  // Finalize the current file state.
-  finalizeWriterFile(index);
-
-  // Release old writer's memory pools. The new writer will be created lazily
-  // on the next write to avoid creating empty files.
-  writers_[index].reset();
-
-  ++info->fileSequenceNumber;
+  partitionWriter_->write(
+      input, partitionIds_, bucketIds_, isPartitioned(), isBucketed());
 }
 
 std::string HiveDataSink::stateString(State state) {
@@ -751,9 +396,10 @@ DataSink::Stats HiveDataSink::stats() const {
     return stats;
   }
 
-  for (const auto& ioStats : ioStats_) {
-    stats.numWrittenBytes += ioStats->rawBytesWritten();
-    stats.writeIOTimeUs += ioStats->writeIOTimeUs();
+  const auto& writers = partitionWriter_->writers();
+  for (const auto& writer : writers) {
+    stats.numWrittenBytes += writer->ioStats()->rawBytesWritten();
+    stats.writeIOTimeUs += writer->ioStats()->writeIOTimeUs();
   }
 
   if (state_ != State::kClosed) {
@@ -762,8 +408,8 @@ DataSink::Stats HiveDataSink::stats() const {
 
   // Count total files written, including rotated files.
   stats.numWrittenFiles = 0;
-  for (size_t i = 0; i < writerInfo_.size(); ++i) {
-    const auto& info = writerInfo_.at(i);
+  for (const auto& writer : writers) {
+    const auto& info = writer->writerInfo();
     VELOX_CHECK_NOT_NULL(info);
     stats.numWrittenFiles += info->writtenFiles.size();
     if (!info->spillStats->empty()) {
@@ -842,22 +488,12 @@ bool HiveDataSink::finish() {
 
   // As for now, only sorted writer needs flush buffered data. For non-sorted
   // writer, data is directly written to the underlying file writer.
-  if (!sortWrite()) {
+  if (!bucketSortingWriter_->enabled()) {
     return true;
   }
 
-  // TODO: we might refactor to move the data sorting logic into hive data sink.
-  const uint64_t startTimeMs = getCurrentTimeMs();
-  for (auto i = 0; i < writers_.size(); ++i) {
-    WRITER_NON_RECLAIMABLE_SECTION_GUARD(i);
-    if (!writers_[i]->finish()) {
-      return false;
-    }
-    if (getCurrentTimeMs() - startTimeMs > sortWriterFinishTimeSliceLimitMs_) {
-      return false;
-    }
-  }
-  return true;
+  return partitionWriter_->finish(
+      bucketSortingWriter_->finishTimeSliceLimitMs());
 }
 
 std::vector<std::string> HiveDataSink::close() {
@@ -867,10 +503,11 @@ std::vector<std::string> HiveDataSink::close() {
 }
 
 std::vector<std::string> HiveDataSink::commitMessage() const {
+  const auto& writers = partitionWriter_->writers();
   std::vector<std::string> partitionUpdates;
-  partitionUpdates.reserve(writerInfo_.size());
-  for (int i = 0; i < writerInfo_.size(); ++i) {
-    const auto& info = writerInfo_.at(i);
+  partitionUpdates.reserve(writers.size());
+  for (size_t i = 0; i < writers.size(); ++i) {
+    const auto& info = writers.at(i)->writerInfo();
     VELOX_CHECK_NOT_NULL(info);
 
     folly::dynamic fileWriteInfosArray = folly::dynamic::array;
@@ -894,7 +531,7 @@ std::vector<std::string> HiveDataSink::commitMessage() const {
           (HiveCommitMessage::kFileWriteInfos, std::move(fileWriteInfosArray))
           (HiveCommitMessage::kRowCount, info->numWrittenRows)
           (HiveCommitMessage::kInMemoryDataSizeInBytes, info->inputSizeInBytes)
-          (HiveCommitMessage::kOnDiskDataSizeInBytes, ioStats_.at(i)->rawBytesWritten())
+          (HiveCommitMessage::kOnDiskDataSizeInBytes, writers.at(i)->ioStats()->rawBytesWritten())
           (HiveCommitMessage::kContainsNumberedFileNames, true));
     // clang-format on
     partitionUpdates.push_back(partitionUpdateJson);
@@ -914,52 +551,24 @@ void HiveDataSink::closeInternal() {
   TestValue::adjust(
       "facebook::velox::connector::hive::HiveDataSink::closeInternal", this);
 
-  // NOTE: writers_[i] can be nullptr during file rotation. In rotateWriter(),
-  // we call writers_[index].reset() to release the old writer before creating
-  // a new one. If an error occurs during new writer creation, or if abort is
-  // called during this window, the writer slot may be empty.
   if (state_ == State::kClosed) {
-    for (int i = 0; i < writers_.size(); ++i) {
-      if (writers_[i] == nullptr) {
-        continue;
-      }
-      WRITER_NON_RECLAIMABLE_SECTION_GUARD(i);
-      writers_[i]->close();
-      finalizeWriterFile(i);
-    }
+    partitionWriter_->close();
   } else {
-    for (int i = 0; i < writers_.size(); ++i) {
-      if (writers_[i] == nullptr) {
-        continue;
-      }
-      WRITER_NON_RECLAIMABLE_SECTION_GUARD(i);
-      writers_[i]->abort();
-    }
+    partitionWriter_->abort();
   }
-}
-
-uint32_t HiveDataSink::ensureWriter(const HiveWriterId& id) {
-  auto it = writerIndexMap_.find(id);
-  if (it != writerIndexMap_.end()) {
-    return it->second;
-  }
-  return appendWriter(id);
-}
-
-std::shared_ptr<dwio::common::WriterOptions> HiveDataSink::createWriterOptions()
-    const {
-  // Default: use the last writer's info (for appendWriter which just added it)
-  return createWriterOptions(writerInfo_.size() - 1);
 }
 
 std::shared_ptr<dwio::common::WriterOptions> HiveDataSink::createWriterOptions(
-    size_t writerIndex) const {
-  VELOX_CHECK_LT(writerIndex, writerInfo_.size());
+    const HiveWriterInfo* writerInfo) const {
+  VELOX_CHECK_NOT_NULL(writerInfo);
 
-  // Take the writer options provided by the user as a starting point, or
-  // allocate a new one.
-  auto options = insertTableHandle_->writerOptions();
-  if (!options) {
+  // Clone writer options for each writer instance to avoid sharing mutable
+  // writer-scoped state (e.g. memoryPool, nonReclaimableSection) across
+  // different partition writers.
+  std::shared_ptr<dwio::common::WriterOptions> options;
+  if (insertTableHandle_->writerOptions() != nullptr) {
+    options = cloneWriterOptions(insertTableHandle_->writerOptions());
+  } else {
     options = writerFactory_->createWriterOptions();
   }
 
@@ -972,7 +581,7 @@ std::shared_ptr<dwio::common::WriterOptions> HiveDataSink::createWriterOptions(
   }
 
   if (options->memoryPool == nullptr) {
-    options->memoryPool = writerInfo_[writerIndex]->writerPool.get();
+    options->memoryPool = writerInfo->writerPool.get();
   }
 
   if (!options->compressionKind) {
@@ -984,10 +593,8 @@ std::shared_ptr<dwio::common::WriterOptions> HiveDataSink::createWriterOptions(
   }
 
   // Always set nonReclaimableSection to the current writer's holder.
-  // Since insertTableHandle_->writerOptions() returns a shared_ptr, we need
-  // to ensure each writer has its own nonReclaimableSection pointer.
   options->nonReclaimableSection =
-      writerInfo_[writerIndex]->nonReclaimableSectionHolder.get();
+      writerInfo->nonReclaimableSectionHolder.get();
 
   if (options->memoryReclaimerFactory == nullptr ||
       options->memoryReclaimerFactory() == nullptr) {
@@ -1009,12 +616,10 @@ std::shared_ptr<dwio::common::WriterOptions> HiveDataSink::createWriterOptions(
   return options;
 }
 
-uint32_t HiveDataSink::appendWriter(const HiveWriterId& id) {
-  // Check max open writers.
-  VELOX_USER_CHECK_LE(
-      writers_.size(), maxOpenWriters_, "Exceeded open writer limit");
-  VELOX_CHECK_EQ(writers_.size(), writerInfo_.size());
-  VELOX_CHECK_EQ(writerIndexMap_.size(), writerInfo_.size());
+std::unique_ptr<PartitionWriterInterface> HiveDataSink::createRotationWriter(
+    const HiveWriterId& id,
+    uint32_t writerIndex) {
+  (void)writerIndex;
 
   std::optional<std::string> partitionName;
   if (isPartitioned()) {
@@ -1027,64 +632,74 @@ uint32_t HiveDataSink::appendWriter(const HiveWriterId& id) {
   auto writerPool = createWriterPool(id);
   auto sinkPool = createSinkPool(writerPool);
   std::shared_ptr<memory::MemoryPool> sortPool{nullptr};
-  if (sortWrite()) {
+  if (bucketSortingWriter_->enabled()) {
     sortPool = createSortPool(writerPool);
   }
-  writerInfo_.emplace_back(
-      std::make_shared<HiveWriterInfo>(
-          std::move(writerParameters),
-          std::move(writerPool),
-          std::move(sinkPool),
-          std::move(sortPool)));
-  ioStats_.emplace_back(std::make_unique<io::IoStatistics>());
+  auto writerInfo = std::make_shared<HiveWriterInfo>(
+      std::move(writerParameters),
+      std::move(writerPool),
+      std::move(sinkPool),
+      std::move(sortPool));
+  auto ioStats = std::make_unique<io::IoStatistics>();
 
-  setMemoryReclaimers(writerInfo_.back().get(), ioStats_.back().get());
-  writers_.emplace_back(createWriterForIndex(writerInfo_.size() - 1));
+  setMemoryReclaimers(writerInfo.get(), ioStats.get());
+
+  auto formatWriter = createFormatWriter(writerInfo.get(), ioStats.get());
+  auto* ioStatsPtr = ioStats.get();
+
+  const bool canRotate = !isBucketed() && !bucketSortingWriter_->enabled();
+  auto rotationWriter = std::make_unique<RotationWriter>(
+      std::move(formatWriter),
+      writerInfo,
+      std::move(ioStats),
+      maxTargetFileBytes_,
+      canRotate,
+      [this, writerInfo, ioStatsPtr]() {
+        return createFormatWriter(writerInfo.get(), ioStatsPtr);
+      });
+
   addThreadLocalRuntimeStat(
       fmt::format(
           "{}WriterCount",
           dwio::common::toString(insertTableHandle_->storageFormat())),
       RuntimeCounter(1));
-  // Extends the buffer used for partition rows calculations.
-  partitionSizes_.emplace_back(0);
-  partitionRows_.emplace_back(nullptr);
-  rawPartitionRows_.emplace_back(nullptr);
 
-  writerIndexMap_.emplace(id, writers_.size() - 1);
-  return writerIndexMap_[id];
+  return rotationWriter;
 }
 
-std::unique_ptr<dwio::common::Writer> HiveDataSink::createWriterForIndex(
-    size_t writerIndex) {
-  VELOX_CHECK_LT(writerIndex, writerInfo_.size());
-  VELOX_CHECK_LT(writerIndex, ioStats_.size());
+std::unique_ptr<dwio::common::Writer> HiveDataSink::createFormatWriter(
+    HiveWriterInfo* writerInfo,
+    io::IoStatistics* ioStats) {
+  VELOX_CHECK_NOT_NULL(writerInfo);
+  VELOX_CHECK_NOT_NULL(ioStats);
 
-  auto& info = writerInfo_[writerIndex];
-  const auto& params = info->writerParameters;
+  const auto& params = writerInfo->writerParameters;
 
   // Compute and store the new file names.
-  info->currentWriteFileName =
-      makeSequencedFileName(params.writeFileName(), info->fileSequenceNumber);
-  info->currentTargetFileName =
-      makeSequencedFileName(params.targetFileName(), info->fileSequenceNumber);
+  writerInfo->currentWriteFileName = makeSequencedFileName(
+      params.writeFileName(), writerInfo->fileSequenceNumber);
+  writerInfo->currentTargetFileName = makeSequencedFileName(
+      params.targetFileName(), writerInfo->fileSequenceNumber);
 
   const auto writePath =
-      (fs::path(params.writeDirectory()) / info->currentWriteFileName).string();
+      (fs::path(params.writeDirectory()) / writerInfo->currentWriteFileName)
+          .string();
 
-  auto options = createWriterOptions(writerIndex);
+  auto options = createWriterOptions(writerInfo);
 
   // Prevents the memory allocation during the writer creation.
-  WRITER_NON_RECLAIMABLE_SECTION_GUARD(writerIndex);
+  memory::NonReclaimableSectionGuard nonReclaimableGuard(
+      writerInfo->nonReclaimableSectionHolder.get());
   auto writer = writerFactory_->createWriter(
       createHiveFileSink(
           writePath,
           hiveConfig_,
-          info->sinkPool.get(),
-          ioStats_[writerIndex].get(),
+          writerInfo->sinkPool.get(),
+          ioStats,
           fileSystemStats_.get(),
           insertTableHandle_->storageParameters()),
       options);
-  return maybeCreateBucketSortWriter(writerIndex, std::move(writer));
+  return bucketSortingWriter_->wrap(writerInfo, std::move(writer));
 }
 
 std::string HiveDataSink::getPartitionName(uint32_t partitionId) const {
@@ -1094,91 +709,6 @@ std::string HiveDataSink::getPartitionName(uint32_t partitionId) const {
       partitionId,
       partitionIdGenerator_->partitionValues(),
       partitionKeyAsLowerCase_);
-}
-
-std::unique_ptr<facebook::velox::dwio::common::Writer>
-HiveDataSink::maybeCreateBucketSortWriter(
-    size_t writerIndex,
-    std::unique_ptr<facebook::velox::dwio::common::Writer> writer) {
-  if (!sortWrite()) {
-    return writer;
-  }
-  auto* sortPool = writerInfo_[writerIndex]->sortPool.get();
-  VELOX_CHECK_NOT_NULL(sortPool);
-  auto sortBuffer = std::make_unique<exec::SortBuffer>(
-      getNonPartitionTypes(dataChannels_, inputType_),
-      sortColumnIndices_,
-      sortCompareFlags_,
-      sortPool,
-      writerInfo_[writerIndex]->nonReclaimableSectionHolder.get(),
-      connectorQueryCtx_->prefixSortConfig(),
-      spillConfig_,
-      writerInfo_[writerIndex]->spillStats.get());
-
-  return std::make_unique<dwio::common::SortingWriter>(
-      std::move(writer),
-      std::move(sortBuffer),
-      hiveConfig_->sortWriterMaxOutputRows(
-          connectorQueryCtx_->sessionProperties()),
-      hiveConfig_->sortWriterMaxOutputBytes(
-          connectorQueryCtx_->sessionProperties()),
-      sortWriterFinishTimeSliceLimitMs_);
-}
-
-HiveWriterId HiveDataSink::getWriterId(size_t row) const {
-  std::optional<int32_t> partitionId;
-  if (isPartitioned()) {
-    VELOX_CHECK_LT(partitionIds_[row], std::numeric_limits<uint32_t>::max());
-    partitionId = static_cast<uint32_t>(partitionIds_[row]);
-  }
-
-  std::optional<int32_t> bucketId;
-  if (isBucketed()) {
-    bucketId = bucketIds_[row];
-  }
-  return HiveWriterId{partitionId, bucketId};
-}
-
-void HiveDataSink::updatePartitionRows(
-    uint32_t index,
-    vector_size_t numRows,
-    vector_size_t row) {
-  VELOX_DCHECK_LT(index, partitionSizes_.size());
-  VELOX_DCHECK_EQ(partitionSizes_.size(), partitionRows_.size());
-  VELOX_DCHECK_EQ(partitionRows_.size(), rawPartitionRows_.size());
-  if (FOLLY_UNLIKELY(partitionRows_[index] == nullptr) ||
-      (partitionRows_[index]->capacity() < numRows * sizeof(vector_size_t))) {
-    partitionRows_[index] =
-        allocateIndices(numRows, connectorQueryCtx_->memoryPool());
-    rawPartitionRows_[index] =
-        partitionRows_[index]->asMutable<vector_size_t>();
-  }
-  rawPartitionRows_[index][partitionSizes_[index]] = row;
-  ++partitionSizes_[index];
-}
-
-void HiveDataSink::splitInputRowsAndEnsureWriters() {
-  VELOX_CHECK(isPartitioned() || isBucketed());
-  if (isBucketed() && isPartitioned()) {
-    VELOX_CHECK_EQ(bucketIds_.size(), partitionIds_.size());
-  }
-
-  std::fill(partitionSizes_.begin(), partitionSizes_.end(), 0);
-
-  const auto numRows =
-      isPartitioned() ? partitionIds_.size() : bucketIds_.size();
-  for (auto row = 0; row < numRows; ++row) {
-    const auto id = getWriterId(row);
-    const uint32_t index = ensureWriter(id);
-    updatePartitionRows(index, numRows, row);
-  }
-
-  for (uint32_t i = 0; i < partitionSizes_.size(); ++i) {
-    if (partitionSizes_[i] != 0) {
-      VELOX_CHECK_NOT_NULL(partitionRows_[i]);
-      partitionRows_[i]->setSize(partitionSizes_[i] * sizeof(vector_size_t));
-    }
-  }
 }
 
 HiveWriterParameters HiveDataSink::getWriterParameters(
@@ -1214,95 +744,6 @@ std::pair<std::string, std::string> HiveDataSink::getWriterFileNames(
       bucketId, insertTableHandle_, *connectorQueryCtx_, isCommitRequired());
 }
 
-std::pair<std::string, std::string> HiveInsertFileNameGenerator::gen(
-    std::optional<uint32_t> bucketId,
-    const std::shared_ptr<const HiveInsertTableHandle> insertTableHandle,
-    const ConnectorQueryCtx& connectorQueryCtx,
-    bool commitRequired) const {
-  auto defaultHiveConfig =
-      std::make_shared<const HiveConfig>(std::make_shared<config::ConfigBase>(
-          std::unordered_map<std::string, std::string>()));
-
-  return this->gen(
-      bucketId,
-      insertTableHandle,
-      connectorQueryCtx,
-      defaultHiveConfig,
-      commitRequired);
-}
-
-std::pair<std::string, std::string> HiveInsertFileNameGenerator::gen(
-    std::optional<uint32_t> bucketId,
-    const std::shared_ptr<const HiveInsertTableHandle> insertTableHandle,
-    const ConnectorQueryCtx& connectorQueryCtx,
-    const std::shared_ptr<const HiveConfig>& hiveConfig,
-    bool commitRequired) const {
-  auto targetFileName = insertTableHandle->locationHandle()->targetFileName();
-  const bool generateFileName = targetFileName.empty();
-  if (bucketId.has_value()) {
-    VELOX_CHECK(generateFileName);
-    // TODO: add hive.file_renaming_enabled support.
-    targetFileName = computeBucketedFileName(
-        connectorQueryCtx.queryId(),
-        hiveConfig->maxBucketCount(connectorQueryCtx.sessionProperties()),
-        bucketId.value());
-    // queryId may contain unsafe characters.
-    sanitizeFileName(targetFileName);
-  } else if (generateFileName) {
-    // targetFileName includes planNodeId and Uuid. As a result, different
-    // table writers run by the same task driver or the same table writer
-    // run in different task tries would have different targetFileNames.
-    targetFileName = fmt::format(
-        "{}_{}_{}_{}",
-        connectorQueryCtx.taskId(),
-        connectorQueryCtx.driverId(),
-        connectorQueryCtx.planNodeId(),
-        makeUuid());
-    // taskId, planNodeId may contain unsafe characters.
-    sanitizeFileName(targetFileName);
-  }
-  // do not try to sanitize user provided targetFileName
-  VELOX_CHECK(!targetFileName.empty());
-  const std::string writeFileName = commitRequired
-      ? fmt::format(".tmp.velox.{}_{}", targetFileName, makeUuid())
-      : targetFileName;
-  if (generateFileName &&
-      insertTableHandle->storageFormat() == dwio::common::FileFormat::PARQUET) {
-    return {
-        fmt::format("{}{}", targetFileName, ".parquet"),
-        fmt::format("{}{}", writeFileName, ".parquet")};
-  }
-  return {targetFileName, writeFileName};
-}
-
-void HiveInsertFileNameGenerator::sanitizeFileName(std::string& name) {
-  static const re2::RE2 re("[^a-zA-Z0-9._-]");
-  re2::RE2::GlobalReplace(&name, re, "_");
-}
-
-folly::dynamic HiveInsertFileNameGenerator::serialize() const {
-  folly::dynamic obj = folly::dynamic::object;
-  obj["name"] = "HiveInsertFileNameGenerator";
-  return obj;
-}
-
-std::shared_ptr<HiveInsertFileNameGenerator>
-HiveInsertFileNameGenerator::deserialize(
-    const folly::dynamic& /* obj */,
-    void* /* context */) {
-  return std::make_shared<HiveInsertFileNameGenerator>();
-}
-
-void HiveInsertFileNameGenerator::registerSerDe() {
-  auto& registry = DeserializationWithContextRegistryForSharedPtr();
-  registry.Register(
-      "HiveInsertFileNameGenerator", HiveInsertFileNameGenerator::deserialize);
-}
-
-std::string HiveInsertFileNameGenerator::toString() const {
-  return "HiveInsertFileNameGenerator";
-}
-
 HiveWriterParameters::UpdateMode HiveDataSink::getUpdateMode() const {
   if (insertTableHandle_->isExistingTable()) {
     if (insertTableHandle_->isPartitioned()) {
@@ -1328,180 +769,6 @@ HiveWriterParameters::UpdateMode HiveDataSink::getUpdateMode() const {
   } else {
     return HiveWriterParameters::UpdateMode::kNew;
   }
-}
-
-bool HiveInsertTableHandle::isPartitioned() const {
-  return std::any_of(
-      inputColumns_.begin(), inputColumns_.end(), [](auto column) {
-        return column->isPartitionKey();
-      });
-}
-
-const HiveBucketProperty* HiveInsertTableHandle::bucketProperty() const {
-  return bucketProperty_.get();
-}
-
-bool HiveInsertTableHandle::isBucketed() const {
-  return bucketProperty() != nullptr;
-}
-
-bool HiveInsertTableHandle::isExistingTable() const {
-  return locationHandle_->tableType() == LocationHandle::TableType::kExisting;
-}
-
-folly::dynamic HiveInsertTableHandle::serialize() const {
-  folly::dynamic obj = folly::dynamic::object;
-  obj["name"] = "HiveInsertTableHandle";
-  folly::dynamic arr = folly::dynamic::array;
-  for (const auto& ic : inputColumns_) {
-    arr.push_back(ic->serialize());
-  }
-
-  obj["inputColumns"] = arr;
-  obj["locationHandle"] = locationHandle_->serialize();
-  obj["tableStorageFormat"] = dwio::common::toString(storageFormat_);
-
-  if (bucketProperty_) {
-    obj["bucketProperty"] = bucketProperty_->serialize();
-  }
-
-  if (compressionKind_.has_value()) {
-    obj["compressionKind"] = common::compressionKindToString(*compressionKind_);
-  }
-
-  folly::dynamic params = folly::dynamic::object;
-  for (const auto& [key, value] : serdeParameters_) {
-    params[key] = value;
-  }
-  obj["serdeParameters"] = params;
-
-  folly::dynamic storageParams = folly::dynamic::object;
-  for (const auto& [key, value] : storageParameters_) {
-    storageParams[key] = value;
-  }
-  obj["storageParameters"] = storageParams;
-
-  obj["ensureFiles"] = ensureFiles_;
-  obj["fileNameGenerator"] = fileNameGenerator_->serialize();
-  return obj;
-}
-
-HiveInsertTableHandlePtr HiveInsertTableHandle::create(
-    const folly::dynamic& obj) {
-  auto inputColumns = ISerializable::deserialize<std::vector<HiveColumnHandle>>(
-      obj["inputColumns"]);
-  auto locationHandle =
-      ISerializable::deserialize<LocationHandle>(obj["locationHandle"]);
-  auto storageFormat =
-      dwio::common::toFileFormat(obj["tableStorageFormat"].asString());
-
-  std::optional<common::CompressionKind> compressionKind = std::nullopt;
-  if (obj.count("compressionKind") > 0) {
-    compressionKind =
-        common::stringToCompressionKind(obj["compressionKind"].asString());
-  }
-
-  std::shared_ptr<const HiveBucketProperty> bucketProperty;
-  if (obj.count("bucketProperty") > 0) {
-    bucketProperty =
-        ISerializable::deserialize<HiveBucketProperty>(obj["bucketProperty"]);
-  }
-
-  std::unordered_map<std::string, std::string> serdeParameters;
-  for (const auto& pair : obj["serdeParameters"].items()) {
-    serdeParameters.emplace(pair.first.asString(), pair.second.asString());
-  }
-
-  std::unordered_map<std::string, std::string> storageParameters;
-  if (obj.count("storageParameters") > 0) {
-    for (const auto& pair : obj["storageParameters"].items()) {
-      storageParameters.emplace(pair.first.asString(), pair.second.asString());
-    }
-  }
-
-  bool ensureFiles = obj["ensureFiles"].asBool();
-
-  auto fileNameGenerator =
-      ISerializable::deserialize<FileNameGenerator>(obj["fileNameGenerator"]);
-  return std::make_shared<HiveInsertTableHandle>(
-      inputColumns,
-      locationHandle,
-      storageFormat,
-      bucketProperty,
-      compressionKind,
-      serdeParameters,
-      nullptr, // writerOptions is not serializable
-      ensureFiles,
-      fileNameGenerator,
-      storageParameters);
-}
-
-void HiveInsertTableHandle::registerSerDe() {
-  auto& registry = DeserializationRegistryForSharedPtr();
-  registry.Register("HiveInsertTableHandle", HiveInsertTableHandle::create);
-}
-
-std::string HiveInsertTableHandle::toString() const {
-  std::ostringstream out;
-  out << "HiveInsertTableHandle [" << dwio::common::toString(storageFormat_);
-  if (compressionKind_.has_value()) {
-    out << " " << common::compressionKindToString(compressionKind_.value());
-  } else {
-    out << " none";
-  }
-  out << "], [inputColumns: [";
-  for (const auto& i : inputColumns_) {
-    out << " " << i->toString();
-  }
-  out << " ], locationHandle: " << locationHandle_->toString();
-  if (bucketProperty_) {
-    out << ", bucketProperty: " << bucketProperty_->toString();
-  }
-
-  if (serdeParameters_.size() > 0) {
-    std::map<std::string, std::string> sortedSerdeParams(
-        serdeParameters_.begin(), serdeParameters_.end());
-    out << ", serdeParameters: ";
-    for (const auto& [key, value] : sortedSerdeParams) {
-      out << "[" << key << ", " << value << "] ";
-    }
-  }
-  out << ", fileNameGenerator: " << fileNameGenerator_->toString();
-  out << "]";
-  return out.str();
-}
-
-std::string LocationHandle::toString() const {
-  return fmt::format(
-      "LocationHandle [targetPath: {}, writePath: {}, tableType: {}, tableFileName: {}]",
-      targetPath_,
-      writePath_,
-      tableTypeName(tableType_),
-      targetFileName_);
-}
-
-void LocationHandle::registerSerDe() {
-  auto& registry = DeserializationRegistryForSharedPtr();
-  registry.Register("LocationHandle", LocationHandle::create);
-}
-
-folly::dynamic LocationHandle::serialize() const {
-  folly::dynamic obj = folly::dynamic::object;
-  obj["name"] = "LocationHandle";
-  obj["targetPath"] = targetPath_;
-  obj["writePath"] = writePath_;
-  obj["tableType"] = tableTypeName(tableType_);
-  obj["targetFileName"] = targetFileName_;
-  return obj;
-}
-
-LocationHandlePtr LocationHandle::create(const folly::dynamic& obj) {
-  auto targetPath = obj["targetPath"].asString();
-  auto writePath = obj["writePath"].asString();
-  auto tableType = tableTypeFromName(obj["tableType"].asString());
-  auto targetFileName = obj["targetFileName"].asString();
-  return std::make_shared<LocationHandle>(
-      targetPath, writePath, tableType, targetFileName);
 }
 
 std::unique_ptr<memory::MemoryReclaimer> HiveDataSink::WriterReclaimer::create(

--- a/velox/connectors/hive/HiveDataSink.h
+++ b/velox/connectors/hive/HiveDataSink.h
@@ -17,578 +17,26 @@
 
 #include "velox/common/compression/Compression.h"
 #include "velox/connectors/Connector.h"
+#include "velox/connectors/hive/HiveCommitMessage.h"
 #include "velox/connectors/hive/HiveConfig.h"
-#include "velox/connectors/hive/HivePartitionName.h"
+#include "velox/connectors/hive/HiveWriterTypes.h"
 #include "velox/connectors/hive/PartitionIdGenerator.h"
-#include "velox/connectors/hive/TableHandle.h"
 #include "velox/dwio/common/Options.h"
-#include "velox/dwio/common/Writer.h"
 #include "velox/dwio/common/WriterFactory.h"
 #include "velox/exec/MemoryReclaimer.h"
 
 namespace facebook::velox::connector::hive {
 
-class LocationHandle;
-using LocationHandlePtr = std::shared_ptr<const LocationHandle>;
-
-/// Location related properties of the Hive table to be written.
-class LocationHandle : public ISerializable {
- public:
-  enum class TableType {
-    /// Write to a new table to be created.
-    kNew,
-    /// Write to an existing table.
-    kExisting,
-  };
-
-  LocationHandle(
-      std::string targetPath,
-      std::string writePath,
-      TableType tableType,
-      std::string targetFileName = "")
-      : targetPath_(std::move(targetPath)),
-        targetFileName_(std::move(targetFileName)),
-        writePath_(std::move(writePath)),
-        tableType_(tableType) {}
-
-  const std::string& targetPath() const {
-    return targetPath_;
-  }
-
-  const std::string& targetFileName() const {
-    return targetFileName_;
-  }
-
-  const std::string& writePath() const {
-    return writePath_;
-  }
-
-  TableType tableType() const {
-    return tableType_;
-  }
-
-  std::string toString() const;
-
-  static void registerSerDe();
-
-  folly::dynamic serialize() const override;
-
-  static LocationHandlePtr create(const folly::dynamic& obj);
-
-  static const std::string tableTypeName(LocationHandle::TableType type);
-
-  static LocationHandle::TableType tableTypeFromName(const std::string& name);
-
- private:
-  // Target directory path.
-  const std::string targetPath_;
-  // If non-empty, use this name instead of generating our own.
-  const std::string targetFileName_;
-  // Staging directory path.
-  const std::string writePath_;
-  // Whether the table to be written is new, already existing or temporary.
-  const TableType tableType_;
-};
-
-class HiveSortingColumn : public ISerializable {
- public:
-  HiveSortingColumn(
-      const std::string& sortColumn,
-      const core::SortOrder& sortOrder);
-
-  const std::string& sortColumn() const {
-    return sortColumn_;
-  }
-
-  core::SortOrder sortOrder() const {
-    return sortOrder_;
-  }
-
-  folly::dynamic serialize() const override;
-
-  static std::shared_ptr<HiveSortingColumn> deserialize(
-      const folly::dynamic& obj,
-      void* context);
-
-  std::string toString() const;
-
-  static void registerSerDe();
-
- private:
-  const std::string sortColumn_;
-  const core::SortOrder sortOrder_;
-};
-
-class HiveBucketProperty : public ISerializable {
- public:
-  enum class Kind { kHiveCompatible, kPrestoNative };
-
-  HiveBucketProperty(
-      Kind kind,
-      int32_t bucketCount,
-      const std::vector<std::string>& bucketedBy,
-      const std::vector<TypePtr>& bucketedTypes,
-      const std::vector<std::shared_ptr<const HiveSortingColumn>>& sortedBy);
-
-  Kind kind() const {
-    return kind_;
-  }
-
-  static std::string kindString(Kind kind);
-
-  /// Returns the number of bucket count.
-  int32_t bucketCount() const {
-    return bucketCount_;
-  }
-
-  /// Returns the bucketed by column names.
-  const std::vector<std::string>& bucketedBy() const {
-    return bucketedBy_;
-  }
-
-  /// Returns the bucketed by column types.
-  const std::vector<TypePtr>& bucketedTypes() const {
-    return bucketTypes_;
-  }
-
-  /// Returns the hive sorting columns if not empty.
-  const std::vector<std::shared_ptr<const HiveSortingColumn>>& sortedBy()
-      const {
-    return sortedBy_;
-  }
-
-  folly::dynamic serialize() const override;
-
-  static std::shared_ptr<HiveBucketProperty> deserialize(
-      const folly::dynamic& obj,
-      void* context);
-
-  bool operator==(const HiveBucketProperty& other) const {
-    return true;
-  }
-
-  static void registerSerDe();
-
-  std::string toString() const;
-
- private:
-  void validate() const;
-
-  const Kind kind_;
-  const int32_t bucketCount_;
-  const std::vector<std::string> bucketedBy_;
-  const std::vector<TypePtr> bucketTypes_;
-  const std::vector<std::shared_ptr<const HiveSortingColumn>> sortedBy_;
-};
-
-FOLLY_ALWAYS_INLINE std::ostream& operator<<(
-    std::ostream& os,
-    HiveBucketProperty::Kind kind) {
-  os << HiveBucketProperty::kindString(kind);
-  return os;
-}
-
+class FileNameGenerator;
 class HiveInsertTableHandle;
-using HiveInsertTableHandlePtr = std::shared_ptr<HiveInsertTableHandle>;
+class PartitionWriterInterface;
 
-class FileNameGenerator : public ISerializable {
- public:
-  virtual ~FileNameGenerator() = default;
-
-  virtual std::pair<std::string, std::string> gen(
-      std::optional<uint32_t> bucketId,
-      const std::shared_ptr<const HiveInsertTableHandle> insertTableHandle,
-      const ConnectorQueryCtx& connectorQueryCtx,
-      bool commitRequired) const = 0;
-
-  virtual std::string toString() const = 0;
-};
-
-class HiveInsertFileNameGenerator : public FileNameGenerator {
- public:
-  HiveInsertFileNameGenerator() {}
-
-  std::pair<std::string, std::string> gen(
-      std::optional<uint32_t> bucketId,
-      const std::shared_ptr<const HiveInsertTableHandle> insertTableHandle,
-      const ConnectorQueryCtx& connectorQueryCtx,
-      bool commitRequired) const override;
-
-  /// Version of file generation that takes hiveConfig into account when
-  /// generating file names
-  std::pair<std::string, std::string> gen(
-      std::optional<uint32_t> bucketId,
-      const std::shared_ptr<const HiveInsertTableHandle> insertTableHandle,
-      const ConnectorQueryCtx& connectorQueryCtx,
-      const std::shared_ptr<const HiveConfig>& hiveConfig,
-      bool commitRequired) const;
-
-  static void registerSerDe();
-
-  folly::dynamic serialize() const override;
-
-  static std::shared_ptr<HiveInsertFileNameGenerator> deserialize(
-      const folly::dynamic& obj,
-      void* context);
-
-  std::string toString() const override;
-
-  /// Replaces potentially unsafe characters in a file name with underscores
-  static void sanitizeFileName(std::string& name);
-};
-
-/// Represents a request for Hive write.
-class HiveInsertTableHandle : public ConnectorInsertTableHandle {
- public:
-  HiveInsertTableHandle(
-      std::vector<std::shared_ptr<const HiveColumnHandle>> inputColumns,
-      std::shared_ptr<const LocationHandle> locationHandle,
-      dwio::common::FileFormat storageFormat = dwio::common::FileFormat::DWRF,
-      std::shared_ptr<const HiveBucketProperty> bucketProperty = nullptr,
-      std::optional<common::CompressionKind> compressionKind = {},
-      const std::unordered_map<std::string, std::string>& serdeParameters = {},
-      const std::shared_ptr<dwio::common::WriterOptions>& writerOptions =
-          nullptr,
-      // When this option is set the HiveDataSink will always write a file even
-      // if there's no data. This is useful when the table is bucketed, but the
-      // engine handles ensuring a 1 to 1 mapping from task to bucket.
-      const bool ensureFiles = false,
-      std::shared_ptr<const FileNameGenerator> fileNameGenerator =
-          std::make_shared<const HiveInsertFileNameGenerator>(),
-      const std::unordered_map<std::string, std::string>& storageParameters =
-          {});
-
-  virtual ~HiveInsertTableHandle() = default;
-
-  const std::vector<std::shared_ptr<const HiveColumnHandle>>& inputColumns()
-      const {
-    return inputColumns_;
-  }
-
-  const std::shared_ptr<const LocationHandle>& locationHandle() const {
-    return locationHandle_;
-  }
-
-  std::optional<common::CompressionKind> compressionKind() const {
-    return compressionKind_;
-  }
-
-  dwio::common::FileFormat storageFormat() const {
-    return storageFormat_;
-  }
-
-  /// Format specific options.
-  const std::unordered_map<std::string, std::string>& serdeParameters() const {
-    return serdeParameters_;
-  }
-
-  /// Storage specific options.
-  const std::unordered_map<std::string, std::string>& storageParameters()
-      const {
-    return storageParameters_;
-  }
-
-  /// Avoid this in future usages. Format specific change should go through
-  /// serdeParameters.
-  const std::shared_ptr<dwio::common::WriterOptions>& writerOptions() const {
-    return writerOptions_;
-  }
-
-  bool ensureFiles() const {
-    return ensureFiles_;
-  }
-
-  const std::shared_ptr<const FileNameGenerator>& fileNameGenerator() const {
-    return fileNameGenerator_;
-  }
-
-  bool supportsMultiThreading() const override {
-    return true;
-  }
-
-  bool isPartitioned() const;
-
-  bool isBucketed() const;
-
-  const HiveBucketProperty* bucketProperty() const;
-
-  bool isExistingTable() const;
-
-  /// Returns a subset of column indices corresponding to partition keys.
-  const std::vector<column_index_t>& partitionChannels() const {
-    return partitionChannels_;
-  }
-
-  /// Returns the column indices of non-partition data columns.
-  const std::vector<column_index_t>& nonPartitionChannels() const {
-    return nonPartitionChannels_;
-  }
-
-  folly::dynamic serialize() const override;
-
-  static HiveInsertTableHandlePtr create(const folly::dynamic& obj);
-
-  static void registerSerDe();
-
-  std::string toString() const override;
-
- protected:
-  const std::vector<std::shared_ptr<const HiveColumnHandle>> inputColumns_;
-  const std::shared_ptr<const LocationHandle> locationHandle_;
-
- private:
-  const dwio::common::FileFormat storageFormat_;
-  const std::shared_ptr<const HiveBucketProperty> bucketProperty_;
-  const std::optional<common::CompressionKind> compressionKind_;
-  const std::unordered_map<std::string, std::string> serdeParameters_;
-  const std::shared_ptr<dwio::common::WriterOptions> writerOptions_;
-  const bool ensureFiles_;
-  const std::shared_ptr<const FileNameGenerator> fileNameGenerator_;
-  const std::unordered_map<std::string, std::string> storageParameters_;
-  const std::vector<column_index_t> partitionChannels_;
-  const std::vector<column_index_t> nonPartitionChannels_;
-};
-
-/// Parameters for Hive writers.
-class HiveWriterParameters {
- public:
-  enum class UpdateMode {
-    kNew, // Write files to a new directory.
-    kOverwrite, // Overwrite an existing directory.
-    // Append mode is currently only supported for unpartitioned tables.
-    kAppend, // Append to an unpartitioned table.
-  };
-
-  /// @param updateMode Write the files to a new directory, or append to an
-  /// existing directory or overwrite an existing directory.
-  /// @param partitionName Partition name in the typical Hive style, which is
-  /// also the partition subdirectory part of the partition path.
-  /// @param targetFileName The final name of a file after committing.
-  /// @param targetDirectory The final directory that a file should be in after
-  /// committing.
-  /// @param writeFileName The temporary name of the file that a running writer
-  /// writes to. If a running writer writes directory to the target file, set
-  /// writeFileName to targetFileName by default.
-  /// @param writeDirectory The temporary directory that a running writer writes
-  /// to. If a running writer writes directory to the target directory, set
-  /// writeDirectory to targetDirectory by default.
-  HiveWriterParameters(
-      UpdateMode updateMode,
-      std::optional<std::string> partitionName,
-      std::string targetFileName,
-      std::string targetDirectory,
-      std::optional<std::string> writeFileName = std::nullopt,
-      std::optional<std::string> writeDirectory = std::nullopt)
-      : updateMode_(updateMode),
-        partitionName_(std::move(partitionName)),
-        targetFileName_(std::move(targetFileName)),
-        targetDirectory_(std::move(targetDirectory)),
-        writeFileName_(writeFileName.value_or(targetFileName_)),
-        writeDirectory_(writeDirectory.value_or(targetDirectory_)) {}
-
-  UpdateMode updateMode() const {
-    return updateMode_;
-  }
-
-  static std::string updateModeToString(UpdateMode updateMode) {
-    switch (updateMode) {
-      case UpdateMode::kNew:
-        return "NEW";
-      case UpdateMode::kOverwrite:
-        return "OVERWRITE";
-      case UpdateMode::kAppend:
-        return "APPEND";
-      default:
-        VELOX_UNSUPPORTED("Unsupported update mode.");
-    }
-  }
-
-  const std::optional<std::string>& partitionName() const {
-    return partitionName_;
-  }
-
-  const std::string& targetFileName() const {
-    return targetFileName_;
-  }
-
-  const std::string& writeFileName() const {
-    return writeFileName_;
-  }
-
-  const std::string& targetDirectory() const {
-    return targetDirectory_;
-  }
-
-  const std::string& writeDirectory() const {
-    return writeDirectory_;
-  }
-
- private:
-  const UpdateMode updateMode_;
-  const std::optional<std::string> partitionName_;
-  const std::string targetFileName_;
-  const std::string targetDirectory_;
-  const std::string writeFileName_;
-  const std::string writeDirectory_;
-};
-
-/// Information about a single file written as part of a writer's output.
-/// When file rotation occurs, multiple HiveFileInfo entries are created.
-struct HiveFileInfo {
-  /// The temporary file name used during writing (in the staging directory).
-  std::string writeFileName;
-  /// The final file name after commit (in the target directory).
-  std::string targetFileName;
-  /// Size of the file in bytes.
-  uint64_t fileSize{0};
-  /// Number of rows in the file.
-  uint64_t numRows{0};
-};
-
-struct HiveWriterInfo {
-  HiveWriterInfo(
-      HiveWriterParameters parameters,
-      std::shared_ptr<memory::MemoryPool> _writerPool,
-      std::shared_ptr<memory::MemoryPool> _sinkPool,
-      std::shared_ptr<memory::MemoryPool> _sortPool)
-      : writerParameters(std::move(parameters)),
-        nonReclaimableSectionHolder(new tsan_atomic<bool>(false)),
-        spillStats(std::make_unique<exec::SpillStats>()),
-        writerPool(std::move(_writerPool)),
-        sinkPool(std::move(_sinkPool)),
-        sortPool(std::move(_sortPool)) {}
-
-  const HiveWriterParameters writerParameters;
-  const std::unique_ptr<tsan_atomic<bool>> nonReclaimableSectionHolder;
-  /// Collects the spill stats from sort writer if the spilling has been
-  /// triggered.
-  const std::unique_ptr<exec::SpillStats> spillStats;
-  const std::shared_ptr<memory::MemoryPool> writerPool;
-  const std::shared_ptr<memory::MemoryPool> sinkPool;
-  const std::shared_ptr<memory::MemoryPool> sortPool;
-  /// Total rows written by this writer across all files.
-  uint64_t numWrittenRows = 0;
-  /// Rows written to the current file; reset to 0 when the file is finalized.
-  uint64_t currentFileWrittenRows{0};
-  uint64_t inputSizeInBytes = 0;
-  /// File sequence number for tracking multiple files written due to size-based
-  /// splitting. Incremented each time the writer rotates to a new file.
-  /// Used to generate sequenced file names (e.g., file_1.orc, file_2.orc).
-  /// Invariant during write: fileSequenceNumber == writtenFiles.size()
-  /// After close: fileSequenceNumber + 1 == writtenFiles.size() (final file
-  /// added)
-  uint32_t fileSequenceNumber{0};
-  /// Tracks all files written by this writer.
-  /// During write: contains only rotated (completed) files.
-  /// After close: contains all files including the final one (via
-  /// finalizeWriterFile).
-  std::vector<HiveFileInfo> writtenFiles;
-  /// Snapshot of total bytes written at the start of the current file.
-  /// Used as baseline to calculate current file size: rawBytesWritten() - this.
-  /// Updated to ioStats->rawBytesWritten() after each rotation.
-  uint64_t cumulativeWrittenBytes{0};
-  /// Current file's write filename (set when file is created/rotated).
-  /// This avoids recomputing makeSequencedFileName() in commitMessage().
-  std::string currentWriteFileName;
-  /// Current file's target filename (set when file is created/rotated).
-  std::string currentTargetFileName;
-};
-
-/// Identifies a hive writer.
-struct HiveWriterId {
-  std::optional<uint32_t> partitionId{std::nullopt};
-  std::optional<uint32_t> bucketId{std::nullopt};
-
-  HiveWriterId() = default;
-
-  HiveWriterId(
-      std::optional<uint32_t> _partitionId,
-      std::optional<uint32_t> _bucketId = std::nullopt)
-      : partitionId(_partitionId), bucketId(_bucketId) {}
-
-  /// Returns the special writer id for the un-partitioned (and non-bucketed)
-  /// table.
-  static const HiveWriterId& unpartitionedId();
-
-  std::string toString() const;
-
-  bool operator==(const HiveWriterId& other) const {
-    return std::tie(partitionId, bucketId) ==
-        std::tie(other.partitionId, other.bucketId);
-  }
-};
-
-struct HiveWriterIdHasher {
-  std::size_t operator()(const HiveWriterId& id) const {
-    return bits::hashMix(
-        id.partitionId.value_or(std::numeric_limits<uint32_t>::max()),
-        id.bucketId.value_or(std::numeric_limits<uint32_t>::max()));
-  }
-};
-
-struct HiveWriterIdEq {
-  bool operator()(const HiveWriterId& lhs, const HiveWriterId& rhs) const {
-    return lhs == rhs;
-  }
-};
-
-/// JSON field names for the partition update object produced by each writer
-/// and consumed by the Presto coordinator to finalize files and update the
-/// metastore.
-///
-/// JSON structure:
-/// {
-///   "name":                        "<partition key, e.g. ds=2024-01-01>",
-///   "updateMode":                  "NEW" | "APPEND" | "OVERWRITE",
-///   "writePath":                   "<staging directory>",
-///   "targetPath":                  "<final directory>",
-///   "fileWriteInfos": [
-///     {
-///       "writeFileName":           "<temp filename in writePath>",
-///       "targetFileName":          "<final filename in targetPath>",
-///       "fileSize":                <bytes>
-///     }
-///   ],
-///   "rowCount":                    <total rows>,
-///   "inMemoryDataSizeInBytes":     <uncompressed bytes>,
-///   "onDiskDataSizeInBytes":       <compressed bytes on disk>,
-///   "containsNumberedFileNames":   true | false
-/// }
-struct HiveCommitMessage {
-  /// Partition directory name in Hive format (e.g., "ds=2024-01-01/region=us").
-  /// Empty string for unpartitioned tables.
-  static constexpr const char* kName = "name";
-  /// Write mode: "NEW", "APPEND", or "OVERWRITE". Controls how the committer
-  /// handles metastore updates and existing file conflicts.
-  static constexpr const char* kUpdateMode = "updateMode";
-  /// Staging directory where files were written during execution.
-  static constexpr const char* kWritePath = "writePath";
-  /// Final destination directory. Files are renamed from writePath to
-  /// targetPath during commit.
-  static constexpr const char* kTargetPath = "targetPath";
-  /// Array of per-file metadata objects. One entry per file written, including
-  /// rotated files.
-  static constexpr const char* kFileWriteInfos = "fileWriteInfos";
-  /// Temporary filename used during writing (in the staging directory).
-  static constexpr const char* kWriteFileName = "writeFileName";
-  /// Final filename after commit (in the target directory).
-  static constexpr const char* kTargetFileName = "targetFileName";
-  /// Size of individual file in bytes.
-  static constexpr const char* kFileSize = "fileSize";
-  /// Total rows written to this partition across all files.
-  static constexpr const char* kRowCount = "rowCount";
-  /// Uncompressed input data size in bytes.
-  static constexpr const char* kInMemoryDataSizeInBytes =
-      "inMemoryDataSizeInBytes";
-  /// Compressed bytes written to disk.
-  static constexpr const char* kOnDiskDataSizeInBytes = "onDiskDataSizeInBytes";
-  /// Whether filenames follow a numbered sequence from file rotation.
-  static constexpr const char* kContainsNumberedFileNames =
-      "containsNumberedFileNames";
-};
+class BucketSortingWriter;
+class PartitionWriter;
 
 class HiveDataSink : public DataSink {
  public:
+  ~HiveDataSink() override;
   /// The list of runtime stats reported by hive data sink
   static constexpr const char* kEarlyFlushedRawBytes = "earlyFlushedRawBytes";
 
@@ -724,10 +172,6 @@ class HiveDataSink : public DataSink {
     io::IoStatistics* const ioStats_;
   };
 
-  FOLLY_ALWAYS_INLINE bool sortWrite() const {
-    return !sortColumnIndices_.empty();
-  }
-
   // Returns true if the table is partitioned.
   FOLLY_ALWAYS_INLINE bool isPartitioned() const {
     return partitionIdGenerator_ != nullptr;
@@ -749,68 +193,31 @@ class HiveDataSink : public DataSink {
       HiveWriterInfo* writerInfo,
       io::IoStatistics* ioStats);
 
-  // Returns the bytes written to the current file for the specified writer.
-  // This is calculated as total bytes minus cumulative bytes from rotated
-  // files. Use this instead of rawBytesWritten() when you need current file
-  // size.
-  uint64_t getCurrentFileBytes(size_t writerIndex) const;
-
   // Compute the partition id and bucket id for each row in 'input'.
   virtual void computePartitionAndBucketIds(const RowVectorPtr& input);
 
-  // Get the HiveWriter corresponding to the row
-  // from partitionIds and bucketIds.
-  HiveWriterId getWriterId(size_t row) const;
+  // Creates a partition writer for the given writer ID and index. Called by
+  // the PartitionWriter's WriterFactory to create new writers on demand.
+  std::unique_ptr<PartitionWriterInterface> createRotationWriter(
+      const HiveWriterId& id,
+      uint32_t writerIndex);
 
-  // Computes the number of input rows as well as the actual input row indices
-  // to each corresponding (bucketed) partition based on the partition and
-  // bucket ids calculated by 'computePartitionAndBucketIds'. The function also
-  // ensures that there is a writer created for each (bucketed) partition.
-  void splitInputRowsAndEnsureWriters();
+  // Creates a format writer (optionally wrapped in SortingWriter) for the
+  // given writer info and IO stats. Updates file names based on the current
+  // file sequence number.
+  std::unique_ptr<facebook::velox::dwio::common::Writer> createFormatWriter(
+      HiveWriterInfo* writerInfo,
+      io::IoStatistics* ioStats);
 
-  // Makes sure to create one writer for the given writer id. The function
-  // returns the corresponding index in 'writers_'.
-  virtual uint32_t ensureWriter(const HiveWriterId& id);
-
-  // Appends a new writer for the given 'id'. The function returns the index of
-  // the newly created writer in 'writers_'.
-  uint32_t appendWriter(const HiveWriterId& id);
-
-  // Creates a writer for the given index using the current file sequence.
-  std::unique_ptr<facebook::velox::dwio::common::Writer> createWriterForIndex(
-      size_t writerIndex);
-
-  // Creates and configures WriterOptions based on file format.
-  // Sets up compression, schema, and other writer configuration based on the
-  // insert table handle and connector settings.
-  // The no-argument overload uses the last writer's info (for appendWriter).
-  virtual std::shared_ptr<dwio::common::WriterOptions> createWriterOptions()
-      const;
-
-  // Creates WriterOptions for a specific writer index. Use this overload
-  // during writer rotation to ensure the correct writer's memory pool and
-  // nonReclaimableSection are used.
-  std::shared_ptr<dwio::common::WriterOptions> createWriterOptions(
-      size_t writerIndex) const;
+  // Creates and configures WriterOptions for a specific writer.
+  virtual std::shared_ptr<dwio::common::WriterOptions> createWriterOptions(
+      const HiveWriterInfo* writerInfo) const;
 
   // Returns the Hive partition directory name for the given partition ID.
   // Converts the partition values associated with the partition ID into a
   // Hive-formatted directory path. Returns std::nullopt if the table is
   // unpartitioned. Should be called only when writing to a partitioned table.
   virtual std::string getPartitionName(uint32_t partitionId) const;
-
-  std::unique_ptr<facebook::velox::dwio::common::Writer>
-  maybeCreateBucketSortWriter(
-      size_t writerIndex,
-      std::unique_ptr<facebook::velox::dwio::common::Writer> writer);
-
-  // Records a row index for a specific partition. This method maintains the
-  // mapping of which input rows belong to which partition by storing row
-  // indices in partition-specific buffers. If the buffer for the partition
-  // doesn't exist or is too small, it allocates/reallocates the buffer to
-  // accommodate all rows.
-  void
-  updatePartitionRows(uint32_t index, vector_size_t numRows, vector_size_t row);
 
   HiveWriterParameters getWriterParameters(
       const std::optional<std::string>& partition,
@@ -832,28 +239,9 @@ class HiveDataSink : public DataSink {
     VELOX_CHECK_EQ(state_, State::kRunning, "Hive data sink is not running");
   }
 
-  // Invoked to write 'input' to the specified file writer.
-  void write(size_t index, RowVectorPtr input);
+  virtual void closeInternal();
 
-  /// Rotates the writer at the given index to a new file. This is called when
-  /// the current file exceeds maxTargetFileBytes_. The old writer is closed
-  /// and a new writer is created for the same partition/bucket.
-  void rotateWriter(size_t index);
-
-  /// Finalizes the current file for the writer at the given index.
-  /// Captures file stats and adds the file info to writtenFiles.
-  /// Called by rotateWriter() and closeInternal().
-  void finalizeWriterFile(size_t index);
-
-  void closeInternal();
-
-  // IMPORTANT NOTE: these are passed to writers as raw pointers. HiveDataSink
-  // owns the lifetime of these objects, and therefore must destroy them last.
-  // Additionally, we must assume that no objects which hold a reference to
-  // these stats will outlive the HiveDataSink instance. This is a reasonable
-  // assumption given the semantics of these stats objects.
-  std::vector<std::unique_ptr<io::IoStatistics>> ioStats_;
-  // Generic filesystem stats, exposed as RuntimeStats
+  // Generic filesystem stats, exposed as RuntimeStats.
   std::unique_ptr<IoStats> fileSystemStats_;
 
   const RowTypePtr inputType_;
@@ -871,33 +259,20 @@ class HiveDataSink : public DataSink {
   const std::unique_ptr<core::PartitionFunction> bucketFunction_;
   const std::shared_ptr<dwio::common::WriterFactory> writerFactory_;
   const common::SpillConfig* const spillConfig_;
-  const uint64_t sortWriterFinishTimeSliceLimitMs_{0};
   const uint64_t maxTargetFileBytes_{0};
   const bool partitionKeyAsLowerCase_;
 
-  std::vector<column_index_t> sortColumnIndices_;
-  std::vector<CompareFlags> sortCompareFlags_;
-
   State state_{State::kRunning};
 
-  tsan_atomic<bool> nonReclaimableSection_{false};
+  // Wraps format writers with SortingWriter when bucket sorting is enabled.
+  std::unique_ptr<BucketSortingWriter> bucketSortingWriter_;
 
-  // The map from writer id to the writer index in 'writers_' and 'writerInfo_'.
-  folly::F14FastMap<HiveWriterId, uint32_t, HiveWriterIdHasher, HiveWriterIdEq>
-      writerIndexMap_;
-
-  // Below are structures for partitions from all inputs. writerInfo_ and
-  // writers_ are both indexed by partitionId.
-  std::vector<std::shared_ptr<HiveWriterInfo>> writerInfo_;
-  std::vector<std::unique_ptr<dwio::common::Writer>> writers_;
+  // Routes rows to writers by partition/bucket and owns partition writers.
+  std::unique_ptr<PartitionWriter> partitionWriter_;
 
   // Below are structures updated when processing current input. partitionIds_
-  // are indexed by the row of input_. partitionRows_, rawPartitionRows_ and
-  // partitionSizes_ are indexed by partitionId.
+  // are indexed by the row of input_.
   raw_vector<uint64_t> partitionIds_;
-  std::vector<BufferPtr> partitionRows_;
-  std::vector<vector_size_t*> rawPartitionRows_;
-  std::vector<vector_size_t> partitionSizes_;
 
   // Reusable buffers for bucket id calculations.
   std::vector<uint32_t> bucketIds_;
@@ -922,16 +297,5 @@ struct fmt::formatter<facebook::velox::connector::hive::HiveDataSink::State>
       format_context& ctx) const {
     return formatter<std::string>::format(
         facebook::velox::connector::hive::HiveDataSink::stateString(s), ctx);
-  }
-};
-
-template <>
-struct fmt::formatter<
-    facebook::velox::connector::hive::LocationHandle::TableType>
-    : formatter<int> {
-  auto format(
-      facebook::velox::connector::hive::LocationHandle::TableType s,
-      format_context& ctx) const {
-    return formatter<int>::format(static_cast<int>(s), ctx);
   }
 };

--- a/velox/connectors/hive/HiveInsertTableHandle.cpp
+++ b/velox/connectors/hive/HiveInsertTableHandle.cpp
@@ -1,0 +1,579 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/HiveInsertTableHandle.h"
+
+#include "velox/connectors/hive/HiveConfig.h"
+#include "velox/connectors/hive/TableHandle.h"
+
+#include <algorithm>
+#include <map>
+#include <sstream>
+
+#include <boost/lexical_cast.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include <re2/re2.h>
+
+namespace facebook::velox::connector::hive {
+namespace {
+
+std::vector<column_index_t> computePartitionChannels(
+    const std::vector<std::shared_ptr<const HiveColumnHandle>>& inputColumns) {
+  std::vector<column_index_t> channels;
+  for (auto i = 0; i < inputColumns.size(); i++) {
+    if (inputColumns[i]->isPartitionKey()) {
+      channels.push_back(i);
+    }
+  }
+  return channels;
+}
+
+std::vector<column_index_t> computeNonPartitionChannels(
+    const std::vector<std::shared_ptr<const HiveColumnHandle>>& inputColumns) {
+  std::vector<column_index_t> channels;
+  for (auto i = 0; i < inputColumns.size(); i++) {
+    if (!inputColumns[i]->isPartitionKey()) {
+      channels.push_back(i);
+    }
+  }
+  return channels;
+}
+
+std::string makeUuid() {
+  return boost::lexical_cast<std::string>(boost::uuids::random_generator()());
+}
+
+std::unordered_map<LocationHandle::TableType, std::string> tableTypeNames() {
+  return {
+      {LocationHandle::TableType::kNew, "kNew"},
+      {LocationHandle::TableType::kExisting, "kExisting"},
+  };
+}
+
+template <typename K, typename V>
+std::unordered_map<V, K> invertMap(const std::unordered_map<K, V>& mapping) {
+  std::unordered_map<V, K> inverted;
+  for (const auto& [key, value] : mapping) {
+    inverted.emplace(value, key);
+  }
+  return inverted;
+}
+
+std::string computeBucketedFileName(
+    const std::string& queryId,
+    uint32_t maxBucketCount,
+    uint32_t bucket) {
+  const uint32_t kMaxBucketCountPadding =
+      std::to_string(maxBucketCount - 1).size();
+  const std::string bucketValueStr = std::to_string(bucket);
+  return fmt::format(
+      "0{:0>{}}_0_{}", bucketValueStr, kMaxBucketCountPadding, queryId);
+}
+
+} // namespace
+
+const std::string LocationHandle::tableTypeName(LocationHandle::TableType type) {
+  static const auto tableTypes = tableTypeNames();
+  return tableTypes.at(type);
+}
+
+LocationHandle::TableType LocationHandle::tableTypeFromName(
+    const std::string& name) {
+  static const auto nameTableTypes = invertMap(tableTypeNames());
+  return nameTableTypes.at(name);
+}
+
+std::string LocationHandle::toString() const {
+  return fmt::format(
+      "LocationHandle [targetPath: {}, writePath: {}, tableType: {}, tableFileName: {}]",
+      targetPath_,
+      writePath_,
+      tableTypeName(tableType_),
+      targetFileName_);
+}
+
+void LocationHandle::registerSerDe() {
+  auto& registry = DeserializationRegistryForSharedPtr();
+  registry.Register("LocationHandle", LocationHandle::create);
+}
+
+folly::dynamic LocationHandle::serialize() const {
+  folly::dynamic obj = folly::dynamic::object;
+  obj["name"] = "LocationHandle";
+  obj["targetPath"] = targetPath_;
+  obj["writePath"] = writePath_;
+  obj["tableType"] = tableTypeName(tableType_);
+  obj["targetFileName"] = targetFileName_;
+  return obj;
+}
+
+LocationHandlePtr LocationHandle::create(const folly::dynamic& obj) {
+  auto targetPath = obj["targetPath"].asString();
+  auto writePath = obj["writePath"].asString();
+  auto tableType = tableTypeFromName(obj["tableType"].asString());
+  auto targetFileName = obj["targetFileName"].asString();
+  return std::make_shared<LocationHandle>(
+      targetPath, writePath, tableType, targetFileName);
+}
+
+HiveSortingColumn::HiveSortingColumn(
+    const std::string& sortColumn,
+    const core::SortOrder& sortOrder)
+    : sortColumn_(sortColumn), sortOrder_(sortOrder) {
+  VELOX_USER_CHECK(!sortColumn_.empty(), "hive sort column must be set");
+
+  if (FOLLY_UNLIKELY(
+          (sortOrder_.isAscending() && !sortOrder_.isNullsFirst()) ||
+          (!sortOrder_.isAscending() && sortOrder_.isNullsFirst()))) {
+    VELOX_USER_FAIL("Bad hive sort order: {}", toString());
+  }
+}
+
+folly::dynamic HiveSortingColumn::serialize() const {
+  folly::dynamic obj = folly::dynamic::object;
+  obj["name"] = "HiveSortingColumn";
+  obj["columnName"] = sortColumn_;
+  obj["sortOrder"] = sortOrder_.serialize();
+  return obj;
+}
+
+std::shared_ptr<HiveSortingColumn> HiveSortingColumn::deserialize(
+    const folly::dynamic& obj,
+    void* /*context*/) {
+  const std::string columnName = obj["columnName"].asString();
+  const auto sortOrder = core::SortOrder::deserialize(obj["sortOrder"]);
+  return std::make_shared<HiveSortingColumn>(columnName, sortOrder);
+}
+
+std::string HiveSortingColumn::toString() const {
+  return fmt::format(
+      "[COLUMN[{}] ORDER[{}]]", sortColumn_, sortOrder_.toString());
+}
+
+void HiveSortingColumn::registerSerDe() {
+  auto& registry = DeserializationWithContextRegistryForSharedPtr();
+  registry.Register("HiveSortingColumn", HiveSortingColumn::deserialize);
+}
+
+HiveBucketProperty::HiveBucketProperty(
+    Kind kind,
+    int32_t bucketCount,
+    const std::vector<std::string>& bucketedBy,
+    const std::vector<TypePtr>& bucketTypes,
+    const std::vector<std::shared_ptr<const HiveSortingColumn>>& sortedBy)
+    : kind_(kind),
+      bucketCount_(bucketCount),
+      bucketedBy_(bucketedBy),
+      bucketTypes_(bucketTypes),
+      sortedBy_(sortedBy) {
+  validate();
+}
+
+void HiveBucketProperty::validate() const {
+  VELOX_USER_CHECK_GT(bucketCount_, 0, "Hive bucket count can't be zero");
+  VELOX_USER_CHECK(!bucketedBy_.empty(), "Hive bucket columns must be set");
+  VELOX_USER_CHECK_EQ(
+      bucketedBy_.size(),
+      bucketTypes_.size(),
+      "The number of hive bucket columns and types do not match {}",
+      toString());
+}
+
+std::string HiveBucketProperty::kindString(Kind kind) {
+  switch (kind) {
+    case Kind::kHiveCompatible:
+      return "HIVE_COMPATIBLE";
+    case Kind::kPrestoNative:
+      return "PRESTO_NATIVE";
+    default:
+      return fmt::format("UNKNOWN {}", static_cast<int>(kind));
+  }
+}
+
+folly::dynamic HiveBucketProperty::serialize() const {
+  folly::dynamic obj = folly::dynamic::object;
+  obj["name"] = "HiveBucketProperty";
+  obj["kind"] = static_cast<int64_t>(kind_);
+  obj["bucketCount"] = bucketCount_;
+  obj["bucketedBy"] = ISerializable::serialize(bucketedBy_);
+  obj["bucketedTypes"] = ISerializable::serialize(bucketTypes_);
+  obj["sortedBy"] = ISerializable::serialize(sortedBy_);
+  return obj;
+}
+
+std::shared_ptr<HiveBucketProperty> HiveBucketProperty::deserialize(
+    const folly::dynamic& obj,
+    void* context) {
+  const Kind kind = static_cast<Kind>(obj["kind"].asInt());
+  const int32_t bucketCount = obj["bucketCount"].asInt();
+  const auto buckectedBy =
+      ISerializable::deserialize<std::vector<std::string>>(obj["bucketedBy"]);
+  const auto bucketedTypes = ISerializable::deserialize<std::vector<Type>>(
+      obj["bucketedTypes"], context);
+  const auto sortedBy =
+      ISerializable::deserialize<std::vector<HiveSortingColumn>>(
+          obj["sortedBy"], context);
+  return std::make_shared<HiveBucketProperty>(
+      kind, bucketCount, buckectedBy, bucketedTypes, sortedBy);
+}
+
+bool HiveBucketProperty::operator==(const HiveBucketProperty& other) const {
+  if (kind_ != other.kind_ || bucketCount_ != other.bucketCount_ ||
+      bucketedBy_ != other.bucketedBy_) {
+    return false;
+  }
+
+  if (bucketTypes_.size() != other.bucketTypes_.size()) {
+    return false;
+  }
+  for (auto i = 0; i < bucketTypes_.size(); ++i) {
+    if (bucketTypes_[i] == nullptr || other.bucketTypes_[i] == nullptr) {
+      if (bucketTypes_[i] != other.bucketTypes_[i]) {
+        return false;
+      }
+      continue;
+    }
+    if (!bucketTypes_[i]->equivalent(*other.bucketTypes_[i])) {
+      return false;
+    }
+  }
+
+  if (sortedBy_.size() != other.sortedBy_.size()) {
+    return false;
+  }
+  for (auto i = 0; i < sortedBy_.size(); ++i) {
+    const auto& lhs = sortedBy_[i];
+    const auto& rhs = other.sortedBy_[i];
+    if (lhs == nullptr || rhs == nullptr) {
+      if (lhs != rhs) {
+        return false;
+      }
+      continue;
+    }
+    if (lhs->sortColumn() != rhs->sortColumn() ||
+        lhs->sortOrder() != rhs->sortOrder()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+void HiveBucketProperty::registerSerDe() {
+  auto& registry = DeserializationWithContextRegistryForSharedPtr();
+  registry.Register("HiveBucketProperty", HiveBucketProperty::deserialize);
+}
+
+std::string HiveBucketProperty::toString() const {
+  std::stringstream out;
+  out << "\nHiveBucketProperty[<" << kind_ << " " << bucketCount_ << ">\n";
+  out << "\tBucket Columns:\n";
+  for (const auto& column : bucketedBy_) {
+    out << "\t\t" << column << "\n";
+  }
+  out << "\tBucket Types:\n";
+  for (const auto& type : bucketTypes_) {
+    out << "\t\t" << type->toString() << "\n";
+  }
+  if (!sortedBy_.empty()) {
+    out << "\tSortedBy Columns:\n";
+    for (const auto& sortColum : sortedBy_) {
+      out << "\t\t" << sortColum->toString() << "\n";
+    }
+  }
+  out << "]\n";
+  return out.str();
+}
+
+HiveInsertTableHandle::HiveInsertTableHandle(
+    std::vector<std::shared_ptr<const HiveColumnHandle>> inputColumns,
+    std::shared_ptr<const LocationHandle> locationHandle,
+    dwio::common::FileFormat storageFormat,
+    std::shared_ptr<const HiveBucketProperty> bucketProperty,
+    std::optional<common::CompressionKind> compressionKind,
+    const std::unordered_map<std::string, std::string>& serdeParameters,
+    const std::shared_ptr<dwio::common::WriterOptions>& writerOptions,
+    // When this option is set the HiveDataSink will always write a file even
+    // if there's no data. This is useful when the table is bucketed, but the
+    // engine handles ensuring a 1 to 1 mapping from task to bucket.
+    const bool ensureFiles,
+    std::shared_ptr<const FileNameGenerator> fileNameGenerator,
+    const std::unordered_map<std::string, std::string>& storageParameters)
+    : inputColumns_(std::move(inputColumns)),
+      locationHandle_(std::move(locationHandle)),
+      storageFormat_(storageFormat),
+      bucketProperty_(std::move(bucketProperty)),
+      compressionKind_(compressionKind),
+      serdeParameters_(serdeParameters),
+      writerOptions_(writerOptions),
+      ensureFiles_(ensureFiles),
+      fileNameGenerator_(std::move(fileNameGenerator)),
+      storageParameters_(storageParameters),
+      partitionChannels_(computePartitionChannels(inputColumns_)),
+      nonPartitionChannels_(computeNonPartitionChannels(inputColumns_)) {
+  if (compressionKind.has_value()) {
+    VELOX_CHECK(
+        compressionKind.value() != common::CompressionKind_MAX,
+        "Unsupported compression type: CompressionKind_MAX");
+  }
+
+  if (ensureFiles_) {
+    // If ensureFiles is set and either the bucketProperty is set or some
+    // partition keys are in the data, there is not a 1:1 mapping from Task to
+    // files so we can't proactively create writers.
+    VELOX_CHECK(
+        bucketProperty_ == nullptr || bucketProperty_->bucketCount() == 0,
+        "ensureFiles is not supported with bucketing");
+
+    for (const auto& inputColumn : inputColumns_) {
+      VELOX_CHECK(
+          !inputColumn->isPartitionKey(),
+          "ensureFiles is not supported with partition keys in the data");
+    }
+  }
+}
+
+std::pair<std::string, std::string> HiveInsertFileNameGenerator::gen(
+    std::optional<uint32_t> bucketId,
+    const std::shared_ptr<const HiveInsertTableHandle> insertTableHandle,
+    const ConnectorQueryCtx& connectorQueryCtx,
+    bool commitRequired) const {
+  auto defaultHiveConfig =
+      std::make_shared<const HiveConfig>(std::make_shared<config::ConfigBase>(
+          std::unordered_map<std::string, std::string>()));
+
+  return this->gen(
+      bucketId,
+      insertTableHandle,
+      connectorQueryCtx,
+      defaultHiveConfig,
+      commitRequired);
+}
+
+std::pair<std::string, std::string> HiveInsertFileNameGenerator::gen(
+    std::optional<uint32_t> bucketId,
+    const std::shared_ptr<const HiveInsertTableHandle> insertTableHandle,
+    const ConnectorQueryCtx& connectorQueryCtx,
+    const std::shared_ptr<const HiveConfig>& hiveConfig,
+    bool commitRequired) const {
+  auto targetFileName = insertTableHandle->locationHandle()->targetFileName();
+  const bool generateFileName = targetFileName.empty();
+  if (bucketId.has_value()) {
+    VELOX_CHECK(generateFileName);
+    // TODO: add hive.file_renaming_enabled support.
+    targetFileName = computeBucketedFileName(
+        connectorQueryCtx.queryId(),
+        hiveConfig->maxBucketCount(connectorQueryCtx.sessionProperties()),
+        bucketId.value());
+    // queryId may contain unsafe characters.
+    sanitizeFileName(targetFileName);
+  } else if (generateFileName) {
+    // targetFileName includes planNodeId and Uuid. As a result, different
+    // table writers run by the same task driver or the same table writer
+    // run in different task tries would have different targetFileNames.
+    targetFileName = fmt::format(
+        "{}_{}_{}_{}",
+        connectorQueryCtx.taskId(),
+        connectorQueryCtx.driverId(),
+        connectorQueryCtx.planNodeId(),
+        makeUuid());
+    // taskId, planNodeId may contain unsafe characters.
+    sanitizeFileName(targetFileName);
+  }
+  // do not try to sanitize user provided targetFileName
+  VELOX_CHECK(!targetFileName.empty());
+  const std::string writeFileName = commitRequired
+      ? fmt::format(".tmp.velox.{}_{}", targetFileName, makeUuid())
+      : targetFileName;
+  if (generateFileName &&
+      insertTableHandle->storageFormat() == dwio::common::FileFormat::PARQUET) {
+    return {
+        fmt::format("{}{}", targetFileName, ".parquet"),
+        fmt::format("{}{}", writeFileName, ".parquet")};
+  }
+  return {targetFileName, writeFileName};
+}
+
+void HiveInsertFileNameGenerator::sanitizeFileName(std::string& name) {
+  static const re2::RE2 re("[^a-zA-Z0-9._-]");
+  re2::RE2::GlobalReplace(&name, re, "_");
+}
+
+folly::dynamic HiveInsertFileNameGenerator::serialize() const {
+  folly::dynamic obj = folly::dynamic::object;
+  obj["name"] = "HiveInsertFileNameGenerator";
+  return obj;
+}
+
+std::shared_ptr<HiveInsertFileNameGenerator>
+HiveInsertFileNameGenerator::deserialize(
+    const folly::dynamic& /* obj */,
+    void* /* context */) {
+  return std::make_shared<HiveInsertFileNameGenerator>();
+}
+
+void HiveInsertFileNameGenerator::registerSerDe() {
+  auto& registry = DeserializationWithContextRegistryForSharedPtr();
+  registry.Register(
+      "HiveInsertFileNameGenerator", HiveInsertFileNameGenerator::deserialize);
+}
+
+std::string HiveInsertFileNameGenerator::toString() const {
+  return "HiveInsertFileNameGenerator";
+}
+
+bool HiveInsertTableHandle::isPartitioned() const {
+  return std::any_of(
+      inputColumns_.begin(), inputColumns_.end(), [](auto column) {
+        return column->isPartitionKey();
+      });
+}
+
+const HiveBucketProperty* HiveInsertTableHandle::bucketProperty() const {
+  return bucketProperty_.get();
+}
+
+bool HiveInsertTableHandle::isBucketed() const {
+  return bucketProperty() != nullptr;
+}
+
+bool HiveInsertTableHandle::isExistingTable() const {
+  return locationHandle_->tableType() == LocationHandle::TableType::kExisting;
+}
+
+folly::dynamic HiveInsertTableHandle::serialize() const {
+  folly::dynamic obj = folly::dynamic::object;
+  obj["name"] = "HiveInsertTableHandle";
+  folly::dynamic arr = folly::dynamic::array;
+  for (const auto& ic : inputColumns_) {
+    arr.push_back(ic->serialize());
+  }
+
+  obj["inputColumns"] = arr;
+  obj["locationHandle"] = locationHandle_->serialize();
+  obj["tableStorageFormat"] = dwio::common::toString(storageFormat_);
+
+  if (bucketProperty_) {
+    obj["bucketProperty"] = bucketProperty_->serialize();
+  }
+
+  if (compressionKind_.has_value()) {
+    obj["compressionKind"] = common::compressionKindToString(*compressionKind_);
+  }
+
+  folly::dynamic params = folly::dynamic::object;
+  for (const auto& [key, value] : serdeParameters_) {
+    params[key] = value;
+  }
+  obj["serdeParameters"] = params;
+
+  folly::dynamic storageParams = folly::dynamic::object;
+  for (const auto& [key, value] : storageParameters_) {
+    storageParams[key] = value;
+  }
+  obj["storageParameters"] = storageParams;
+
+  obj["ensureFiles"] = ensureFiles_;
+  obj["fileNameGenerator"] = fileNameGenerator_->serialize();
+  return obj;
+}
+
+HiveInsertTableHandlePtr HiveInsertTableHandle::create(
+    const folly::dynamic& obj) {
+  auto inputColumns = ISerializable::deserialize<std::vector<HiveColumnHandle>>(
+      obj["inputColumns"]);
+  auto locationHandle =
+      ISerializable::deserialize<LocationHandle>(obj["locationHandle"]);
+  auto storageFormat =
+      dwio::common::toFileFormat(obj["tableStorageFormat"].asString());
+
+  std::optional<common::CompressionKind> compressionKind = std::nullopt;
+  if (obj.count("compressionKind") > 0) {
+    compressionKind =
+        common::stringToCompressionKind(obj["compressionKind"].asString());
+  }
+
+  std::shared_ptr<const HiveBucketProperty> bucketProperty;
+  if (obj.count("bucketProperty") > 0) {
+    bucketProperty =
+        ISerializable::deserialize<HiveBucketProperty>(obj["bucketProperty"]);
+  }
+
+  std::unordered_map<std::string, std::string> serdeParameters;
+  for (const auto& pair : obj["serdeParameters"].items()) {
+    serdeParameters.emplace(pair.first.asString(), pair.second.asString());
+  }
+
+  std::unordered_map<std::string, std::string> storageParameters;
+  if (obj.count("storageParameters") > 0) {
+    for (const auto& pair : obj["storageParameters"].items()) {
+      storageParameters.emplace(pair.first.asString(), pair.second.asString());
+    }
+  }
+
+  bool ensureFiles = obj["ensureFiles"].asBool();
+
+  auto fileNameGenerator =
+      ISerializable::deserialize<FileNameGenerator>(obj["fileNameGenerator"]);
+  return std::make_shared<HiveInsertTableHandle>(
+      inputColumns,
+      locationHandle,
+      storageFormat,
+      bucketProperty,
+      compressionKind,
+      serdeParameters,
+      nullptr, // writerOptions is not serializable
+      ensureFiles,
+      fileNameGenerator,
+      storageParameters);
+}
+
+void HiveInsertTableHandle::registerSerDe() {
+  auto& registry = DeserializationRegistryForSharedPtr();
+  registry.Register("HiveInsertTableHandle", HiveInsertTableHandle::create);
+}
+
+std::string HiveInsertTableHandle::toString() const {
+  std::ostringstream out;
+  out << "HiveInsertTableHandle [" << dwio::common::toString(storageFormat_);
+  if (compressionKind_.has_value()) {
+    out << " " << common::compressionKindToString(compressionKind_.value());
+  } else {
+    out << " none";
+  }
+  out << "], [inputColumns: [";
+  for (const auto& i : inputColumns_) {
+    out << " " << i->toString();
+  }
+  out << " ], locationHandle: " << locationHandle_->toString();
+  if (bucketProperty_) {
+    out << ", bucketProperty: " << bucketProperty_->toString();
+  }
+
+  if (serdeParameters_.size() > 0) {
+    std::map<std::string, std::string> sortedSerdeParams(
+        serdeParameters_.begin(), serdeParameters_.end());
+    out << ", serdeParameters: ";
+    for (const auto& [key, value] : sortedSerdeParams) {
+      out << "[" << key << ", " << value << "] ";
+    }
+  }
+  out << ", fileNameGenerator: " << fileNameGenerator_->toString();
+  out << "]";
+  return out.str();
+}
+
+} // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveInsertTableHandle.h
+++ b/velox/connectors/hive/HiveInsertTableHandle.h
@@ -1,0 +1,364 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <ostream>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/base/Portability.h"
+#include "velox/common/compression/Compression.h"
+#include "velox/connectors/Connector.h"
+#include "velox/connectors/hive/TableHandle.h"
+#include "velox/core/PlanNode.h"
+#include "velox/dwio/common/Options.h"
+
+namespace facebook::velox::connector::hive {
+
+class HiveConfig;
+class LocationHandle;
+using LocationHandlePtr = std::shared_ptr<const LocationHandle>;
+
+/// Location related properties of the Hive table to be written.
+class LocationHandle : public ISerializable {
+ public:
+  enum class TableType {
+    /// Write to a new table to be created.
+    kNew,
+    /// Write to an existing table.
+    kExisting,
+  };
+
+  LocationHandle(
+      std::string targetPath,
+      std::string writePath,
+      TableType tableType,
+      std::string targetFileName = "")
+      : targetPath_(std::move(targetPath)),
+        targetFileName_(std::move(targetFileName)),
+        writePath_(std::move(writePath)),
+        tableType_(tableType) {}
+
+  const std::string& targetPath() const {
+    return targetPath_;
+  }
+
+  const std::string& targetFileName() const {
+    return targetFileName_;
+  }
+
+  const std::string& writePath() const {
+    return writePath_;
+  }
+
+  TableType tableType() const {
+    return tableType_;
+  }
+
+  std::string toString() const;
+
+  static void registerSerDe();
+
+  folly::dynamic serialize() const override;
+
+  static LocationHandlePtr create(const folly::dynamic& obj);
+
+  static const std::string tableTypeName(LocationHandle::TableType type);
+
+  static LocationHandle::TableType tableTypeFromName(const std::string& name);
+
+ private:
+  // Target directory path.
+  const std::string targetPath_;
+  // If non-empty, use this name instead of generating our own.
+  const std::string targetFileName_;
+  // Staging directory path.
+  const std::string writePath_;
+  // Whether the table to be written is new, already existing or temporary.
+  const TableType tableType_;
+};
+
+class HiveSortingColumn : public ISerializable {
+ public:
+  HiveSortingColumn(
+      const std::string& sortColumn,
+      const core::SortOrder& sortOrder);
+
+  const std::string& sortColumn() const {
+    return sortColumn_;
+  }
+
+  core::SortOrder sortOrder() const {
+    return sortOrder_;
+  }
+
+  folly::dynamic serialize() const override;
+
+  static std::shared_ptr<HiveSortingColumn> deserialize(
+      const folly::dynamic& obj,
+      void* context);
+
+  std::string toString() const;
+
+  static void registerSerDe();
+
+ private:
+  const std::string sortColumn_;
+  const core::SortOrder sortOrder_;
+};
+
+class HiveBucketProperty : public ISerializable {
+ public:
+  enum class Kind { kHiveCompatible, kPrestoNative };
+
+  HiveBucketProperty(
+      Kind kind,
+      int32_t bucketCount,
+      const std::vector<std::string>& bucketedBy,
+      const std::vector<TypePtr>& bucketedTypes,
+      const std::vector<std::shared_ptr<const HiveSortingColumn>>& sortedBy);
+
+  Kind kind() const {
+    return kind_;
+  }
+
+  static std::string kindString(Kind kind);
+
+  /// Returns the number of bucket count.
+  int32_t bucketCount() const {
+    return bucketCount_;
+  }
+
+  /// Returns the bucketed by column names.
+  const std::vector<std::string>& bucketedBy() const {
+    return bucketedBy_;
+  }
+
+  /// Returns the bucketed by column types.
+  const std::vector<TypePtr>& bucketedTypes() const {
+    return bucketTypes_;
+  }
+
+  /// Returns the hive sorting columns if not empty.
+  const std::vector<std::shared_ptr<const HiveSortingColumn>>& sortedBy()
+      const {
+    return sortedBy_;
+  }
+
+  folly::dynamic serialize() const override;
+
+  static std::shared_ptr<HiveBucketProperty> deserialize(
+      const folly::dynamic& obj,
+      void* context);
+
+  bool operator==(const HiveBucketProperty& other) const;
+
+  static void registerSerDe();
+
+  std::string toString() const;
+
+ private:
+  void validate() const;
+
+  const Kind kind_;
+  const int32_t bucketCount_;
+  const std::vector<std::string> bucketedBy_;
+  const std::vector<TypePtr> bucketTypes_;
+  const std::vector<std::shared_ptr<const HiveSortingColumn>> sortedBy_;
+};
+
+FOLLY_ALWAYS_INLINE std::ostream& operator<<(
+    std::ostream& os,
+    HiveBucketProperty::Kind kind) {
+  os << HiveBucketProperty::kindString(kind);
+  return os;
+}
+
+class HiveInsertTableHandle;
+using HiveInsertTableHandlePtr = std::shared_ptr<HiveInsertTableHandle>;
+
+class FileNameGenerator : public ISerializable {
+ public:
+  virtual ~FileNameGenerator() = default;
+
+  virtual std::pair<std::string, std::string> gen(
+      std::optional<uint32_t> bucketId,
+      const std::shared_ptr<const HiveInsertTableHandle> insertTableHandle,
+      const ConnectorQueryCtx& connectorQueryCtx,
+      bool commitRequired) const = 0;
+
+  virtual std::string toString() const = 0;
+};
+
+class HiveInsertFileNameGenerator : public FileNameGenerator {
+ public:
+  HiveInsertFileNameGenerator() {}
+
+  std::pair<std::string, std::string> gen(
+      std::optional<uint32_t> bucketId,
+      const std::shared_ptr<const HiveInsertTableHandle> insertTableHandle,
+      const ConnectorQueryCtx& connectorQueryCtx,
+      bool commitRequired) const override;
+
+  /// Version of file generation that takes hiveConfig into account when
+  /// generating file names.
+  std::pair<std::string, std::string> gen(
+      std::optional<uint32_t> bucketId,
+      const std::shared_ptr<const HiveInsertTableHandle> insertTableHandle,
+      const ConnectorQueryCtx& connectorQueryCtx,
+      const std::shared_ptr<const HiveConfig>& hiveConfig,
+      bool commitRequired) const;
+
+  static void registerSerDe();
+
+  folly::dynamic serialize() const override;
+
+  static std::shared_ptr<HiveInsertFileNameGenerator> deserialize(
+      const folly::dynamic& obj,
+      void* context);
+
+  std::string toString() const override;
+
+  /// Replaces potentially unsafe characters in a file name with underscores.
+  static void sanitizeFileName(std::string& name);
+};
+
+/// Represents a request for Hive write.
+class HiveInsertTableHandle : public ConnectorInsertTableHandle {
+ public:
+  HiveInsertTableHandle(
+      std::vector<std::shared_ptr<const HiveColumnHandle>> inputColumns,
+      std::shared_ptr<const LocationHandle> locationHandle,
+      dwio::common::FileFormat storageFormat = dwio::common::FileFormat::DWRF,
+      std::shared_ptr<const HiveBucketProperty> bucketProperty = nullptr,
+      std::optional<common::CompressionKind> compressionKind = {},
+      const std::unordered_map<std::string, std::string>& serdeParameters = {},
+      const std::shared_ptr<dwio::common::WriterOptions>& writerOptions =
+          nullptr,
+      // When this option is set the HiveDataSink will always write a file even
+      // if there's no data. This is useful when the table is bucketed, but the
+      // engine handles ensuring a 1 to 1 mapping from task to bucket.
+      bool ensureFiles = false,
+      std::shared_ptr<const FileNameGenerator> fileNameGenerator =
+          std::make_shared<const HiveInsertFileNameGenerator>(),
+      const std::unordered_map<std::string, std::string>& storageParameters =
+          {});
+
+  virtual ~HiveInsertTableHandle() = default;
+
+  const std::vector<std::shared_ptr<const HiveColumnHandle>>& inputColumns()
+      const {
+    return inputColumns_;
+  }
+
+  const std::shared_ptr<const LocationHandle>& locationHandle() const {
+    return locationHandle_;
+  }
+
+  std::optional<common::CompressionKind> compressionKind() const {
+    return compressionKind_;
+  }
+
+  dwio::common::FileFormat storageFormat() const {
+    return storageFormat_;
+  }
+
+  const std::unordered_map<std::string, std::string>& serdeParameters() const {
+    return serdeParameters_;
+  }
+
+  /// Returns storage specific options.
+  const std::unordered_map<std::string, std::string>& storageParameters()
+      const {
+    return storageParameters_;
+  }
+
+  const std::shared_ptr<dwio::common::WriterOptions>& writerOptions() const {
+    return writerOptions_;
+  }
+
+  bool ensureFiles() const {
+    return ensureFiles_;
+  }
+
+  const std::shared_ptr<const FileNameGenerator>& fileNameGenerator() const {
+    return fileNameGenerator_;
+  }
+
+  bool supportsMultiThreading() const override {
+    return true;
+  }
+
+  bool isPartitioned() const;
+
+  bool isBucketed() const;
+
+  const HiveBucketProperty* bucketProperty() const;
+
+  bool isExistingTable() const;
+
+  /// Returns a subset of column indices corresponding to partition keys.
+  const std::vector<column_index_t>& partitionChannels() const {
+    return partitionChannels_;
+  }
+
+  /// Returns the column indices of non-partition data columns.
+  const std::vector<column_index_t>& nonPartitionChannels() const {
+    return nonPartitionChannels_;
+  }
+
+  folly::dynamic serialize() const override;
+
+  static HiveInsertTableHandlePtr create(const folly::dynamic& obj);
+
+  static void registerSerDe();
+
+  std::string toString() const override;
+
+ protected:
+  const std::vector<std::shared_ptr<const HiveColumnHandle>> inputColumns_;
+  const std::shared_ptr<const LocationHandle> locationHandle_;
+
+ private:
+  const dwio::common::FileFormat storageFormat_;
+  const std::shared_ptr<const HiveBucketProperty> bucketProperty_;
+  const std::optional<common::CompressionKind> compressionKind_;
+  const std::unordered_map<std::string, std::string> serdeParameters_;
+  const std::shared_ptr<dwio::common::WriterOptions> writerOptions_;
+  const bool ensureFiles_;
+  const std::shared_ptr<const FileNameGenerator> fileNameGenerator_;
+  const std::unordered_map<std::string, std::string> storageParameters_;
+  const std::vector<column_index_t> partitionChannels_;
+  const std::vector<column_index_t> nonPartitionChannels_;
+};
+
+} // namespace facebook::velox::connector::hive
+
+template <>
+struct fmt::formatter<
+    facebook::velox::connector::hive::LocationHandle::TableType>
+    : formatter<int> {
+  auto format(
+      facebook::velox::connector::hive::LocationHandle::TableType s,
+      format_context& ctx) const {
+    return formatter<int>::format(static_cast<int>(s), ctx);
+  }
+};

--- a/velox/connectors/hive/HiveWriterTypes.cpp
+++ b/velox/connectors/hive/HiveWriterTypes.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/HiveWriterTypes.h"
+
+namespace facebook::velox::connector::hive {
+
+const HiveWriterId& HiveWriterId::unpartitionedId() {
+  static const HiveWriterId writerId{0};
+  return writerId;
+}
+
+std::string HiveWriterId::toString() const {
+  if (partitionId.has_value() && bucketId.has_value()) {
+    return fmt::format("part[{}.{}]", partitionId.value(), bucketId.value());
+  }
+
+  if (partitionId.has_value() && !bucketId.has_value()) {
+    return fmt::format("part[{}]", partitionId.value());
+  }
+
+  // This WriterId is used to add an identifier in the MemoryPools. This could
+  // indicate unpart, but the bucket number needs to be disambiguated. So
+  // creating a new label using bucket.
+  if (!partitionId.has_value() && bucketId.has_value()) {
+    return fmt::format("bucket[{}]", bucketId.value());
+  }
+
+  return "unpart";
+}
+
+} // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveWriterTypes.h
+++ b/velox/connectors/hive/HiveWriterTypes.h
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "velox/common/base/BitUtil.h"
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/base/Portability.h"
+#include "velox/common/memory/MemoryPool.h"
+#include "velox/exec/SpillStats.h"
+
+namespace facebook::velox::connector::hive {
+
+/// Identifies a hive writer.
+struct HiveWriterId {
+  std::optional<uint32_t> partitionId{std::nullopt};
+  std::optional<uint32_t> bucketId{std::nullopt};
+
+  HiveWriterId() = default;
+
+  HiveWriterId(
+      std::optional<uint32_t> _partitionId,
+      std::optional<uint32_t> _bucketId = std::nullopt)
+      : partitionId(_partitionId), bucketId(_bucketId) {}
+
+  /// Returns the special writer id for the un-partitioned (and non-bucketed)
+  /// table.
+  static const HiveWriterId& unpartitionedId();
+
+  std::string toString() const;
+
+  bool operator==(const HiveWriterId& other) const {
+    return std::tie(partitionId, bucketId) ==
+        std::tie(other.partitionId, other.bucketId);
+  }
+};
+
+struct HiveWriterIdHasher {
+  std::size_t operator()(const HiveWriterId& id) const {
+    return bits::hashMix(
+        id.partitionId.value_or(std::numeric_limits<uint32_t>::max()),
+        id.bucketId.value_or(std::numeric_limits<uint32_t>::max()));
+  }
+};
+
+struct HiveWriterIdEq {
+  bool operator()(const HiveWriterId& lhs, const HiveWriterId& rhs) const {
+    return lhs == rhs;
+  }
+};
+
+/// Parameters for Hive writers.
+class HiveWriterParameters {
+ public:
+  enum class UpdateMode {
+    kNew, // Write files to a new directory.
+    kOverwrite, // Overwrite an existing directory.
+    // Append mode is currently only supported for unpartitioned tables.
+    kAppend, // Append to an unpartitioned table.
+  };
+
+  /// @param updateMode Write the files to a new directory, or append to an
+  /// existing directory or overwrite an existing directory.
+  /// @param partitionName Partition name in the typical Hive style, which is
+  /// also the partition subdirectory part of the partition path.
+  /// @param targetFileName The final name of a file after committing.
+  /// @param targetDirectory The final directory that a file should be in after
+  /// committing.
+  /// @param writeFileName The temporary name of the file that a running writer
+  /// writes to. If a running writer writes directory to the target file, set
+  /// writeFileName to targetFileName by default.
+  /// @param writeDirectory The temporary directory that a running writer writes
+  /// to. If a running writer writes directory to the target directory, set
+  /// writeDirectory to targetDirectory by default.
+  HiveWriterParameters(
+      UpdateMode updateMode,
+      std::optional<std::string> partitionName,
+      std::string targetFileName,
+      std::string targetDirectory,
+      std::optional<std::string> writeFileName = std::nullopt,
+      std::optional<std::string> writeDirectory = std::nullopt)
+      : updateMode_(updateMode),
+        partitionName_(std::move(partitionName)),
+        targetFileName_(std::move(targetFileName)),
+        targetDirectory_(std::move(targetDirectory)),
+        writeFileName_(writeFileName.value_or(targetFileName_)),
+        writeDirectory_(writeDirectory.value_or(targetDirectory_)) {}
+
+  UpdateMode updateMode() const {
+    return updateMode_;
+  }
+
+  static std::string updateModeToString(UpdateMode updateMode) {
+    switch (updateMode) {
+      case UpdateMode::kNew:
+        return "NEW";
+      case UpdateMode::kOverwrite:
+        return "OVERWRITE";
+      case UpdateMode::kAppend:
+        return "APPEND";
+      default:
+        VELOX_UNSUPPORTED("Unsupported update mode.");
+    }
+  }
+
+  const std::optional<std::string>& partitionName() const {
+    return partitionName_;
+  }
+
+  const std::string& targetFileName() const {
+    return targetFileName_;
+  }
+
+  const std::string& writeFileName() const {
+    return writeFileName_;
+  }
+
+  const std::string& targetDirectory() const {
+    return targetDirectory_;
+  }
+
+  const std::string& writeDirectory() const {
+    return writeDirectory_;
+  }
+
+ private:
+  const UpdateMode updateMode_;
+  const std::optional<std::string> partitionName_;
+  const std::string targetFileName_;
+  const std::string targetDirectory_;
+  const std::string writeFileName_;
+  const std::string writeDirectory_;
+};
+
+/// Information about a single file written as part of a writer's output.
+/// When file rotation occurs, multiple HiveFileInfo entries are created.
+struct HiveFileInfo {
+  /// The temporary file name used during writing (in the staging directory).
+  std::string writeFileName;
+  /// The final file name after commit (in the target directory).
+  std::string targetFileName;
+  /// Size of the file in bytes.
+  uint64_t fileSize{0};
+  /// Number of rows in the file.
+  uint64_t numRows{0};
+};
+
+struct HiveWriterInfo {
+  HiveWriterInfo(
+      HiveWriterParameters parameters,
+      std::shared_ptr<memory::MemoryPool> _writerPool,
+      std::shared_ptr<memory::MemoryPool> _sinkPool,
+      std::shared_ptr<memory::MemoryPool> _sortPool)
+      : writerParameters(std::move(parameters)),
+        nonReclaimableSectionHolder(new tsan_atomic<bool>(false)),
+        spillStats(std::make_unique<exec::SpillStats>()),
+        writerPool(std::move(_writerPool)),
+        sinkPool(std::move(_sinkPool)),
+        sortPool(std::move(_sortPool)) {}
+
+  const HiveWriterParameters writerParameters;
+  const std::unique_ptr<tsan_atomic<bool>> nonReclaimableSectionHolder;
+  /// Collects the spill stats from sort writer if the spilling has been
+  /// triggered.
+  const std::unique_ptr<exec::SpillStats> spillStats;
+  const std::shared_ptr<memory::MemoryPool> writerPool;
+  const std::shared_ptr<memory::MemoryPool> sinkPool;
+  const std::shared_ptr<memory::MemoryPool> sortPool;
+  /// Total rows written by this writer across all files.
+  uint64_t numWrittenRows = 0;
+  /// Rows written to the current file; reset to 0 when the file is finalized.
+  uint64_t currentFileWrittenRows{0};
+  uint64_t inputSizeInBytes = 0;
+  /// File sequence number for tracking multiple files written due to size-based
+  /// splitting. Incremented each time the writer rotates to a new file.
+  /// Used to generate sequenced file names (e.g., file_1.orc, file_2.orc).
+  /// Invariant during write: fileSequenceNumber == writtenFiles.size()
+  /// After close: fileSequenceNumber + 1 == writtenFiles.size() (final file
+  /// added)
+  uint32_t fileSequenceNumber{0};
+  /// Tracks all files written by this writer.
+  /// During write: contains only rotated (completed) files.
+  /// After close: contains all files including the final one (via
+  /// finalizeWriterFile).
+  std::vector<HiveFileInfo> writtenFiles;
+  /// Snapshot of total bytes written at the start of the current file.
+  /// Used as baseline to calculate current file size: rawBytesWritten() - this.
+  /// Updated to ioStats->rawBytesWritten() after each rotation.
+  uint64_t cumulativeWrittenBytes{0};
+  /// Current file's write filename (set when file is created/rotated).
+  /// This avoids recomputing makeSequencedFileName() in commitMessage().
+  std::string currentWriteFileName;
+  /// Current file's target filename (set when file is created/rotated).
+  std::string currentTargetFileName;
+};
+
+} // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/PartitionWriter.cpp
+++ b/velox/connectors/hive/PartitionWriter.cpp
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/PartitionWriter.h"
+
+#include "velox/common/time/Timer.h"
+#include "velox/exec/OperatorUtils.h"
+
+namespace facebook::velox::connector::hive {
+namespace {
+
+/// Extract data columns from input, producing a RowVector with only the
+/// non-partition columns.
+RowVectorPtr makeDataInput(
+    const std::vector<column_index_t>& dataCols,
+    const RowTypePtr& dataType,
+    const RowVectorPtr& input) {
+  std::vector<VectorPtr> childVectors;
+  childVectors.reserve(dataCols.size());
+  for (int dataCol : dataCols) {
+    childVectors.push_back(input->childAt(dataCol));
+  }
+  return std::make_shared<RowVector>(
+      input->pool(),
+      dataType,
+      input->nulls(),
+      input->size(),
+      std::move(childVectors),
+      input->getNullCount());
+}
+
+} // namespace
+
+PartitionWriter::PartitionWriter(
+    uint32_t maxOpenWriters,
+    const std::vector<column_index_t>& dataChannels,
+    RowTypePtr dataType,
+    WriterFactory writerFactory,
+    memory::MemoryPool* pool)
+    : maxOpenWriters_(maxOpenWriters),
+      dataChannels_(dataChannels),
+      dataType_(std::move(dataType)),
+      writerFactory_(std::move(writerFactory)),
+      pool_(pool) {
+  VELOX_CHECK_NOT_NULL(dataType_);
+  VELOX_CHECK(writerFactory_);
+  VELOX_CHECK_NOT_NULL(pool_);
+}
+
+void PartitionWriter::write(const HiveWriterId& id, RowVectorPtr input) {
+  const auto index = ensureWriter(id);
+  writeToWriter(index, input);
+}
+
+void PartitionWriter::write(
+    RowVectorPtr input,
+    const raw_vector<uint64_t>& partitionIds,
+    const std::vector<uint32_t>& bucketIds,
+    bool isPartitioned,
+    bool isBucketed) {
+  splitInputRowsAndEnsureWriters(
+      partitionIds, bucketIds, isPartitioned, isBucketed);
+
+  for (auto index = 0; index < writers_.size(); ++index) {
+    const vector_size_t partitionSize = partitionSizes_[index];
+    if (partitionSize == 0) {
+      continue;
+    }
+
+    RowVectorPtr writerInput = partitionSize == input->size()
+        ? input
+        : exec::wrap(partitionSize, partitionRows_[index], input);
+    writeToWriter(index, writerInput);
+  }
+}
+
+bool PartitionWriter::finish(uint64_t timeSliceLimitMs) {
+  const uint64_t startTimeMs = getCurrentTimeMs();
+  for (auto& writer : writers_) {
+    if (!writer->finish()) {
+      return false;
+    }
+    if (getCurrentTimeMs() - startTimeMs > timeSliceLimitMs) {
+      return false;
+    }
+  }
+  return true;
+}
+
+void PartitionWriter::close() {
+  for (auto& writer : writers_) {
+    writer->close();
+  }
+}
+
+void PartitionWriter::abort() {
+  for (auto& writer : writers_) {
+    writer->abort();
+  }
+}
+
+uint32_t PartitionWriter::ensureWriter(const HiveWriterId& id) {
+  auto it = writerIndexMap_.find(id);
+  if (it != writerIndexMap_.end()) {
+    return it->second;
+  }
+
+  VELOX_USER_CHECK_LT(
+      writers_.size(), maxOpenWriters_, "Exceeded open writer limit");
+  VELOX_CHECK_EQ(writerIndexMap_.size(), writers_.size());
+
+  const auto writerIndex = writers_.size();
+  auto writer = writerFactory_(id, writerIndex);
+  VELOX_CHECK_NOT_NULL(writer);
+  writers_.emplace_back(std::move(writer));
+
+  partitionSizes_.emplace_back(0);
+  partitionRows_.emplace_back(nullptr);
+  rawPartitionRows_.emplace_back(nullptr);
+
+  writerIndexMap_.emplace(id, writerIndex);
+
+  if (onWriterCreated_) {
+    onWriterCreated_(writerIndex, id);
+  }
+
+  return writerIndex;
+}
+
+void PartitionWriter::writeToWriter(size_t index, RowVectorPtr input) {
+  auto dataInput = makeDataInput(dataChannels_, dataType_, input);
+  writers_[index]->write(dataInput);
+}
+
+HiveWriterId PartitionWriter::getWriterId(
+    size_t row,
+    const raw_vector<uint64_t>& partitionIds,
+    const std::vector<uint32_t>& bucketIds,
+    bool isPartitioned,
+    bool isBucketed) const {
+  std::optional<uint32_t> partitionId;
+  if (isPartitioned) {
+    VELOX_CHECK_LT(partitionIds[row], std::numeric_limits<uint32_t>::max());
+    partitionId = static_cast<uint32_t>(partitionIds[row]);
+  }
+
+  std::optional<uint32_t> bucketId;
+  if (isBucketed) {
+    bucketId = bucketIds[row];
+  }
+  return HiveWriterId{partitionId, bucketId};
+}
+
+void PartitionWriter::splitInputRowsAndEnsureWriters(
+    const raw_vector<uint64_t>& partitionIds,
+    const std::vector<uint32_t>& bucketIds,
+    bool isPartitioned,
+    bool isBucketed) {
+  VELOX_CHECK(isPartitioned || isBucketed);
+  if (isBucketed && isPartitioned) {
+    VELOX_CHECK_EQ(bucketIds.size(), partitionIds.size());
+  }
+
+  std::fill(partitionSizes_.begin(), partitionSizes_.end(), 0);
+
+  const auto numRows = isPartitioned ? partitionIds.size() : bucketIds.size();
+  for (auto row = 0; row < numRows; ++row) {
+    const auto id =
+        getWriterId(row, partitionIds, bucketIds, isPartitioned, isBucketed);
+    const uint32_t index = ensureWriter(id);
+    updatePartitionRows(index, numRows, row);
+  }
+
+  for (uint32_t i = 0; i < partitionSizes_.size(); ++i) {
+    if (partitionSizes_[i] != 0) {
+      VELOX_CHECK_NOT_NULL(partitionRows_[i]);
+      partitionRows_[i]->setSize(partitionSizes_[i] * sizeof(vector_size_t));
+    }
+  }
+}
+
+void PartitionWriter::updatePartitionRows(
+    uint32_t index,
+    vector_size_t numRows,
+    vector_size_t row) {
+  VELOX_DCHECK_LT(index, partitionSizes_.size());
+  VELOX_DCHECK_EQ(partitionSizes_.size(), partitionRows_.size());
+  VELOX_DCHECK_EQ(partitionRows_.size(), rawPartitionRows_.size());
+  if (FOLLY_UNLIKELY(partitionRows_[index] == nullptr) ||
+      (partitionRows_[index]->capacity() < numRows * sizeof(vector_size_t))) {
+    partitionRows_[index] = allocateIndices(numRows, pool_);
+    rawPartitionRows_[index] =
+        partitionRows_[index]->asMutable<vector_size_t>();
+  }
+  rawPartitionRows_[index][partitionSizes_[index]] = row;
+  ++partitionSizes_[index];
+}
+
+} // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/PartitionWriter.h
+++ b/velox/connectors/hive/PartitionWriter.h
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <vector>
+
+#include "velox/common/memory/RawVector.h"
+#include "velox/connectors/hive/HiveWriterTypes.h"
+#include "velox/connectors/hive/PartitionWriterInterface.h"
+#include "velox/vector/ComplexVector.h"
+
+namespace facebook::velox::connector::hive {
+
+/// Routes rows to the correct partition writer based on partition and bucket
+/// IDs. Owns a collection of partition writers and handles the fan-out of
+/// input rows to writers by partition/bucket assignment.
+class PartitionWriter {
+ public:
+  /// Factory to create a partition writer for a given writer ID and index.
+  using WriterFactory = std::function<std::unique_ptr<PartitionWriterInterface>(
+      const HiveWriterId& id,
+      uint32_t writerIndex)>;
+
+  /// Callback invoked after a new writer is created.
+  using OnWriterCreated =
+      std::function<void(uint32_t writerIndex, const HiveWriterId& id)>;
+
+  /// @param maxOpenWriters Maximum number of open writers allowed.
+  /// @param dataChannels Column indices for data columns to write.
+  /// @param dataType Schema of the data columns (non-partition columns).
+  /// @param writerFactory Factory to create per-partition writers.
+  /// @param pool Memory pool for partition row index buffers.
+  PartitionWriter(
+      uint32_t maxOpenWriters,
+      const std::vector<column_index_t>& dataChannels,
+      RowTypePtr dataType,
+      WriterFactory writerFactory,
+      memory::MemoryPool* pool);
+
+  /// Write all rows to a single writer identified by 'id'.
+  void write(const HiveWriterId& id, RowVectorPtr input);
+
+  /// Route rows to writers by partition/bucket IDs.
+  void write(
+      RowVectorPtr input,
+      const raw_vector<uint64_t>& partitionIds,
+      const std::vector<uint32_t>& bucketIds,
+      bool isPartitioned,
+      bool isBucketed);
+
+  /// Flush buffered data with time-slicing. Returns true when complete.
+  bool finish(uint64_t timeSliceLimitMs);
+
+  /// Close all writers after successful completion.
+  void close();
+
+  /// Abort all writers for error cleanup.
+  void abort();
+
+  /// Ensure a writer exists for the given ID. Returns writer index.
+  uint32_t ensureWriter(const HiveWriterId& id);
+
+  /// Access the underlying writers.
+  const std::vector<std::unique_ptr<PartitionWriterInterface>>& writers() const {
+    return writers_;
+  }
+
+  /// Set callback invoked when a new writer is created.
+  void setOnWriterCreated(OnWriterCreated callback) {
+    onWriterCreated_ = std::move(callback);
+  }
+
+ private:
+  /// Extract data columns from input and write to the specified writer.
+  void writeToWriter(size_t index, RowVectorPtr input);
+
+  /// Compute the writer ID for a given row from partition/bucket IDs.
+  HiveWriterId getWriterId(
+      size_t row,
+      const raw_vector<uint64_t>& partitionIds,
+      const std::vector<uint32_t>& bucketIds,
+      bool isPartitioned,
+      bool isBucketed) const;
+
+  /// Split input rows by partition/bucket and ensure writers exist.
+  void splitInputRowsAndEnsureWriters(
+      const raw_vector<uint64_t>& partitionIds,
+      const std::vector<uint32_t>& bucketIds,
+      bool isPartitioned,
+      bool isBucketed);
+
+  /// Record a row index for a specific partition.
+  void
+  updatePartitionRows(uint32_t index, vector_size_t numRows, vector_size_t row);
+
+  const uint32_t maxOpenWriters_;
+  const std::vector<column_index_t> dataChannels_;
+  const RowTypePtr dataType_;
+  WriterFactory writerFactory_;
+  memory::MemoryPool* pool_;
+
+  /// Map from writer ID to index in writers_.
+  folly::F14FastMap<HiveWriterId, uint32_t, HiveWriterIdHasher, HiveWriterIdEq>
+      writerIndexMap_;
+
+  /// Per-partition (or per-partition+bucket) writers.
+  std::vector<std::unique_ptr<PartitionWriterInterface>> writers_;
+
+  /// Partition row index buffers, indexed by writer index.
+  std::vector<BufferPtr> partitionRows_;
+  std::vector<vector_size_t*> rawPartitionRows_;
+  std::vector<vector_size_t> partitionSizes_;
+
+  OnWriterCreated onWriterCreated_;
+};
+
+} // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/PartitionWriterInterface.h
+++ b/velox/connectors/hive/PartitionWriterInterface.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <memory>
+
+#include "velox/common/io/IoStatistics.h"
+#include "velox/connectors/hive/HiveWriterTypes.h"
+#include "velox/vector/BaseVector.h"
+
+namespace facebook::velox::connector::hive {
+
+/// Defines the per-partition writer contract used by PartitionWriter.
+/// Implementations can provide different write behaviors (e.g. rolling,
+/// sorted, or non-rolling) without changing the routing logic.
+class PartitionWriterInterface {
+ public:
+  virtual ~PartitionWriterInterface() = default;
+
+  virtual void write(const VectorPtr& data) = 0;
+  virtual bool finish() = 0;
+  virtual void close() = 0;
+  virtual void abort() = 0;
+
+  virtual const std::shared_ptr<HiveWriterInfo>& writerInfo() const = 0;
+  virtual io::IoStatistics* ioStats() const = 0;
+};
+
+} // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/RotationWriter.cpp
+++ b/velox/connectors/hive/RotationWriter.cpp
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/RotationWriter.h"
+
+#include "velox/common/memory/MemoryArbitrator.h"
+
+namespace facebook::velox::connector::hive {
+
+RotationWriter::RotationWriter(
+    std::unique_ptr<dwio::common::Writer> writer,
+    std::shared_ptr<HiveWriterInfo> writerInfo,
+    std::unique_ptr<io::IoStatistics> ioStats,
+    uint64_t maxTargetFileBytes,
+    bool canRotate,
+    WriterCreator writerCreator)
+    : writerInfo_(std::move(writerInfo)),
+      ioStats_(std::move(ioStats)),
+      writer_(std::move(writer)),
+      maxTargetFileBytes_(maxTargetFileBytes),
+      canRotate_(canRotate),
+      writerCreator_(std::move(writerCreator)) {
+  VELOX_CHECK_NOT_NULL(writerInfo_);
+  VELOX_CHECK_NOT_NULL(ioStats_);
+  VELOX_CHECK_NOT_NULL(writerCreator_);
+}
+
+void RotationWriter::write(const VectorPtr& data) {
+  memory::NonReclaimableSectionGuard nonReclaimableGuard(
+      writerInfo_->nonReclaimableSectionHolder.get());
+
+  ensureWriter();
+
+  writer_->write(data);
+  const auto numRows = data->size();
+  writerInfo_->numWrittenRows += numRows;
+  writerInfo_->currentFileWrittenRows += numRows;
+  writerInfo_->inputSizeInBytes += data->estimateFlatSize();
+
+  if (!canRotate_ || maxTargetFileBytes_ == 0) {
+    return;
+  }
+
+  const auto currentFileBytes = getCurrentFileBytes();
+  if (currentFileBytes >= maxTargetFileBytes_) {
+    rotateWriter();
+  }
+}
+
+void RotationWriter::flush() {
+  if (writer_ != nullptr) {
+    writer_->flush();
+  }
+}
+
+bool RotationWriter::finish() {
+  if (writer_ == nullptr) {
+    return true;
+  }
+  memory::NonReclaimableSectionGuard nonReclaimableGuard(
+      writerInfo_->nonReclaimableSectionHolder.get());
+  return writer_->finish();
+}
+
+void RotationWriter::close() {
+  if (writer_ != nullptr) {
+    memory::NonReclaimableSectionGuard nonReclaimableGuard(
+        writerInfo_->nonReclaimableSectionHolder.get());
+    writer_->close();
+    finalizeWriterFile();
+  }
+}
+
+void RotationWriter::abort() {
+  if (writer_ != nullptr) {
+    memory::NonReclaimableSectionGuard nonReclaimableGuard(
+        writerInfo_->nonReclaimableSectionHolder.get());
+    writer_->abort();
+  }
+}
+
+void RotationWriter::ensureWriter() {
+  if (writer_ == nullptr) {
+    writer_ = writerCreator_();
+    VELOX_CHECK_NOT_NULL(writer_);
+  }
+}
+
+void RotationWriter::rotateWriter() {
+  VELOX_CHECK_NOT_NULL(writer_);
+
+  // Close the writer first to flush all data including footer.
+  writer_->close();
+
+  // Finalize the current file state.
+  finalizeWriterFile();
+
+  // Release old writer's memory pools. The new writer will be created lazily
+  // on the next write to avoid creating empty files.
+  writer_.reset();
+
+  ++writerInfo_->fileSequenceNumber;
+}
+
+void RotationWriter::finalizeWriterFile() {
+  // Capture current file stats AFTER close to include footer bytes.
+  const auto currentFileBytes = getCurrentFileBytes();
+
+  // Finalize the current file into writtenFiles using the stored names.
+  if (currentFileBytes > 0) {
+    HiveFileInfo fileInfo;
+    fileInfo.writeFileName = writerInfo_->currentWriteFileName;
+    fileInfo.targetFileName = writerInfo_->currentTargetFileName;
+    fileInfo.fileSize = currentFileBytes;
+    fileInfo.numRows = writerInfo_->currentFileWrittenRows;
+    // Reset for next file.
+    writerInfo_->currentFileWrittenRows = 0;
+    writerInfo_->writtenFiles.push_back(std::move(fileInfo));
+  }
+
+  // Update cumulative stats as a snapshot of total stats so far.
+  // This becomes the baseline for the next file.
+  writerInfo_->cumulativeWrittenBytes = ioStats_->rawBytesWritten();
+}
+
+uint64_t RotationWriter::getCurrentFileBytes() const {
+  const auto totalBytes = ioStats_->rawBytesWritten();
+  const auto baselineBytes = writerInfo_->cumulativeWrittenBytes;
+  // Sanity check: total should always be >= baseline since ioStats is
+  // never reset and cumulative is a snapshot of rawBytesWritten at rotation.
+  VELOX_DCHECK_GE(totalBytes, baselineBytes);
+  return totalBytes - baselineBytes;
+}
+
+} // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/RotationWriter.h
+++ b/velox/connectors/hive/RotationWriter.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <functional>
+#include <memory>
+
+#include "velox/common/io/IoStatistics.h"
+#include "velox/connectors/hive/HiveWriterTypes.h"
+#include "velox/connectors/hive/PartitionWriterInterface.h"
+#include "velox/dwio/common/Writer.h"
+
+namespace facebook::velox::connector::hive {
+
+/// Decorates a dwio::common::Writer with file size-based rotation.
+/// When the current file exceeds maxTargetFileBytes, closes it and
+/// opens a new one via the writerCreator callback. Tracks all written
+/// files and their metadata (HiveFileInfo) in HiveWriterInfo.
+class RotationWriter : public dwio::common::Writer,
+                       public PartitionWriterInterface {
+ public:
+  /// Callback to create a new underlying writer on rotation or lazy creation.
+  using WriterCreator = std::function<std::unique_ptr<dwio::common::Writer>()>;
+
+  /// @param writer Initial underlying writer (may be nullptr for lazy
+  /// creation).
+  /// @param writerInfo Tracks per-writer state (parameters, stats, files).
+  /// @param ioStats IO statistics for the underlying writer.
+  /// @param maxTargetFileBytes File size threshold for rotation. 0 disables
+  /// rotation.
+  /// @param canRotate Whether rotation is allowed (false for bucketed/sorted
+  /// writes).
+  /// @param writerCreator Factory to create new underlying writers on rotation.
+  RotationWriter(
+      std::unique_ptr<dwio::common::Writer> writer,
+      std::shared_ptr<HiveWriterInfo> writerInfo,
+      std::unique_ptr<io::IoStatistics> ioStats,
+      uint64_t maxTargetFileBytes,
+      bool canRotate,
+      WriterCreator writerCreator);
+
+  void write(const VectorPtr& data) override;
+  void flush() override;
+  bool finish() override;
+  void close() override;
+  void abort() override;
+
+  /// Access writer info for commit message generation.
+  const std::shared_ptr<HiveWriterInfo>& writerInfo() const override {
+    return writerInfo_;
+  }
+
+  /// Access IO statistics.
+  io::IoStatistics* ioStats() const override {
+    return ioStats_.get();
+  }
+
+ private:
+  void ensureWriter();
+  void rotateWriter();
+  void finalizeWriterFile();
+  uint64_t getCurrentFileBytes() const;
+
+  // writerInfo_ and ioStats_ must be declared before writer_ so they outlive
+  // it. The inner writer (e.g., SortingWriter) holds raw pointers to pools
+  // owned by writerInfo_, so writer_ must be destroyed first.
+  std::shared_ptr<HiveWriterInfo> writerInfo_;
+  std::unique_ptr<io::IoStatistics> ioStats_;
+  std::unique_ptr<dwio::common::Writer> writer_;
+  uint64_t maxTargetFileBytes_;
+  bool canRotate_;
+  WriterCreator writerCreator_;
+};
+
+} // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/iceberg/IcebergConnector.cpp
+++ b/velox/connectors/hive/iceberg/IcebergConnector.cpp
@@ -68,6 +68,9 @@ std::unique_ptr<DataSink> IcebergConnector::createDataSink(
     ConnectorInsertTableHandlePtr connectorInsertTableHandle,
     ConnectorQueryCtx* connectorQueryCtx,
     CommitStrategy commitStrategy) {
+  VELOX_USER_CHECK(
+      commitStrategy == CommitStrategy::kNoCommit,
+      "Iceberg connector supports only no-commit write strategy.");
   auto icebergInsertHandle = checkedPointerCast<const IcebergInsertTableHandle>(
       connectorInsertTableHandle);
 

--- a/velox/connectors/hive/iceberg/IcebergDataSink.cpp
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/connectors/hive/iceberg/IcebergDataSink.h"
 
+#include "velox/connectors/hive/PartitionWriter.h"
+
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
@@ -83,10 +85,10 @@ std::string makeUuid() {
 }
 
 std::pair<std::string, std::string> IcebergFileNameGenerator::gen(
-    std::optional<uint32_t> bucketId,
+    std::optional<uint32_t> /*bucketId*/,
     const std::shared_ptr<const HiveInsertTableHandle> insertTableHandle,
-    const ConnectorQueryCtx& connectorQueryCtx,
-    bool commitRequired) const {
+    const ConnectorQueryCtx& /*connectorQueryCtx*/,
+    bool /*commitRequired*/) const {
   auto targetFileName = insertTableHandle->locationHandle()->targetFileName();
   if (targetFileName.empty()) {
     targetFileName = fmt::format("{}", makeUuid());
@@ -126,7 +128,7 @@ IcebergInsertTableHandle::IcebergInsertTableHandle(
           serdeParameters,
           nullptr,
           false,
-          std::make_shared<const HiveInsertFileNameGenerator>()),
+          std::make_shared<const IcebergFileNameGenerator>()),
       partitionSpec_(partitionSpec) {
   VELOX_USER_CHECK(
       !inputColumns_.empty(),
@@ -303,19 +305,32 @@ IcebergDataSink::IcebergDataSink(
               ? std::make_unique<IcebergPartitionName>(partitionSpec_)
               : nullptr),
       partitionRowType_(std::move(partitionRowType)) {
+  VELOX_USER_CHECK(
+      commitStrategy == CommitStrategy::kNoCommit,
+      "Iceberg connector supports only no-commit write strategy.");
   commitPartitionValue_.resize(maxOpenWriters_);
+  if (isPartitioned()) {
+    partitionWriter_->setOnWriterCreated(
+        [this](uint32_t writerIndex, const HiveWriterId& /*id*/) {
+          if (commitPartitionValue_[writerIndex].isNull()) {
+            commitPartitionValue_[writerIndex] =
+                makeCommitPartitionValue(writerIndex);
+          }
+        });
+  }
 }
 
 std::vector<std::string> IcebergDataSink::commitMessage() const {
+  const auto& writers = partitionWriter_->writers();
   std::vector<std::string> commitTasks;
-  commitTasks.reserve(writerInfo_.size());
+  commitTasks.reserve(writers.size());
 
   auto icebergInsertTableHandle =
       std::dynamic_pointer_cast<const IcebergInsertTableHandle>(
           insertTableHandle_);
 
-  for (auto i = 0; i < writerInfo_.size(); ++i) {
-    const auto& writerInfo = writerInfo_.at(i);
+  for (auto i = 0; i < writers.size(); ++i) {
+    const auto& writerInfo = writers[i]->writerInfo();
     VELOX_CHECK_NOT_NULL(writerInfo);
 
     // Following metadata (json format) is consumed by Presto CommitTaskData.
@@ -375,17 +390,9 @@ std::string IcebergDataSink::getPartitionName(uint32_t partitionId) const {
       partitionKeyAsLowerCase_);
 }
 
-uint32_t IcebergDataSink::ensureWriter(const HiveWriterId& id) {
-  auto writerId = HiveDataSink::ensureWriter(id);
-  if (commitPartitionValue_[writerId].isNull()) {
-    commitPartitionValue_[writerId] = makeCommitPartitionValue(writerId);
-  }
-  return writerId;
-}
-
 std::shared_ptr<dwio::common::WriterOptions>
-IcebergDataSink::createWriterOptions() const {
-  auto options = HiveDataSink::createWriterOptions();
+IcebergDataSink::createWriterOptions(const HiveWriterInfo* writerInfo) const {
+  auto options = HiveDataSink::createWriterOptions(writerInfo);
   // Per Iceberg specification (https://iceberg.apache.org/spec/#parquet):
   // - Timestamps must be stored with microsecond precision.
   // - Timestamps must NOT be adjusted to UTC timezone; they should be written

--- a/velox/connectors/hive/iceberg/IcebergDataSink.h
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.h
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "velox/connectors/hive/HiveDataSink.h"
+#include "velox/connectors/hive/HiveInsertTableHandle.h"
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
 #include "velox/connectors/hive/iceberg/IcebergConfig.h"
@@ -143,19 +144,12 @@ class IcebergDataSink : public HiveDataSink {
   // (e.g., "date_year=2023/id_bucket=5").
   std::string getPartitionName(uint32_t partitionId) const override;
 
-  // Ensures a writer exists for the given writer ID and returns its index.
-  // If the writer doesn't exist, creates it by calling appendWriter().
-  // Additionally, extracts and stores the transformed partition values for
-  // the writer in commitPartitionValue_ if not already set, which will be
-  // included in the commit message as "partitionDataJson".
-  uint32_t ensureWriter(const HiveWriterId& id) override;
-
   // Creates writer options configured for Iceberg table writes. Extends the
   // base HiveDataSink writer options with Iceberg-specific settings:
   // - Sets timestamp timezone to nullopt (UTC) for Iceberg compliance.
   // - Sets timestamp precision to microseconds.
-  std::shared_ptr<dwio::common::WriterOptions> createWriterOptions()
-      const override;
+  std::shared_ptr<dwio::common::WriterOptions> createWriterOptions(
+      const HiveWriterInfo* writerInfo) const override;
 
   // Extracts partition values for a specific writer to be included in the
   // commit message. Converts the transformed partition values from columnar

--- a/velox/connectors/hive/storage_adapters/test_common/InsertTest.h
+++ b/velox/connectors/hive/storage_adapters/test_common/InsertTest.h
@@ -20,7 +20,7 @@
 #include "velox/common/memory/Memory.h"
 #include "velox/connectors/ConnectorRegistry.h"
 #include "velox/connectors/hive/HiveConnector.h"
-#include "velox/connectors/hive/HiveDataSink.h"
+#include "velox/connectors/hive/HiveCommitMessage.h"
 #include "velox/dwio/parquet/RegisterParquetReader.h"
 #include "velox/dwio/parquet/RegisterParquetWriter.h"
 #include "velox/exec/TableWriter.h"

--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -27,6 +27,7 @@
 #include "velox/connectors/ConnectorRegistry.h"
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/hive/HiveDataSink.h"
+#include "velox/connectors/hive/HiveInsertTableHandle.h"
 #include "velox/dwio/common/BufferedInput.h"
 #include "velox/dwio/common/Options.h"
 #include "velox/dwio/dwrf/reader/DwrfReader.h"

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -861,6 +861,12 @@ struct WriterOptions {
       const config::ConfigBase& connectorConfig,
       const config::ConfigBase& session) {}
 
+  // Creates a deep copy of this writer options object, preserving the dynamic
+  // type for derived options classes.
+  virtual std::shared_ptr<WriterOptions> clone() const {
+    return std::make_shared<WriterOptions>(*this);
+  }
+
   virtual ~WriterOptions() = default;
 };
 

--- a/velox/dwio/dwrf/writer/Writer.h
+++ b/velox/dwio/dwrf/writer/Writer.h
@@ -49,6 +49,10 @@ struct WriterOptions : public dwio::common::WriterOptions {
   void processConfigs(
       const config::ConfigBase& connectorConfig,
       const config::ConfigBase& session) override;
+
+  std::shared_ptr<dwio::common::WriterOptions> clone() const override {
+    return std::make_shared<WriterOptions>(*this);
+  }
 };
 
 class Writer : public dwio::common::Writer {

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -160,6 +160,10 @@ struct WriterOptions : public dwio::common::WriterOptions {
   void processConfigs(
       const config::ConfigBase& connectorConfig,
       const config::ConfigBase& session) override;
+
+  std::shared_ptr<dwio::common::WriterOptions> clone() const override {
+    return std::make_shared<WriterOptions>(*this);
+  }
 };
 
 // Writes Velox vectors into  a DataSink using Arrow Parquet writer.

--- a/velox/dwio/text/writer/TextWriter.h
+++ b/velox/dwio/text/writer/TextWriter.h
@@ -30,6 +30,10 @@ struct WriterOptions : public dwio::common::WriterOptions {
   int64_t defaultFlushCount = 10 << 10;
   uint8_t headerLineCount =
       0; // number of lines in the header, currently only support 0 or 1
+
+  std::shared_ptr<dwio::common::WriterOptions> clone() const override {
+    return std::make_shared<WriterOptions>(*this);
+  }
 };
 
 /// Encodes Velox vectors in TextFormat and writes into a FileSink.

--- a/velox/exec/fuzzer/PrestoQueryRunnerToSqlPlanNodeVisitor.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunnerToSqlPlanNodeVisitor.cpp
@@ -15,7 +15,7 @@
  */
 
 #include "velox/exec/fuzzer/PrestoQueryRunnerToSqlPlanNodeVisitor.h"
-#include "velox/connectors/hive/HiveDataSink.h"
+#include "velox/connectors/hive/HiveInsertTableHandle.h"
 #include "velox/exec/fuzzer/PrestoQueryRunner.h"
 
 using namespace facebook::velox;

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -18,6 +18,7 @@
 #include "velox/common/testutil/TempFilePath.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/connectors/hive/HiveDataSink.h"
+#include "velox/connectors/hive/HiveInsertTableHandle.h"
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/dwio/dwrf/common/Config.h"
 #include "velox/dwio/dwrf/writer/FlushPolicy.h"

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -20,7 +20,7 @@
 #include <velox/core/ITypedExpr.h>
 #include <velox/core/PlanFragment.h>
 #include <velox/core/PlanNode.h>
-#include "velox/connectors/hive/HiveDataSink.h"
+#include "velox/connectors/hive/HiveInsertTableHandle.h"
 #include "velox/parse/ExpressionsParser.h"
 #include "velox/parse/IExpr.h"
 #include "velox/parse/PlanNodeIdGenerator.h"

--- a/velox/experimental/cudf/connectors/hive/WriterOptions.h
+++ b/velox/experimental/cudf/connectors/hive/WriterOptions.h
@@ -85,6 +85,11 @@ struct CudfHiveWriterOptions
 
   // Sorting columns
   std::vector<sorting_column> sortingColumns;
+
+  std::shared_ptr<facebook::velox::dwio::common::WriterOptions> clone()
+      const override {
+    return std::make_shared<CudfHiveWriterOptions>(*this);
+  }
 };
 
 } // namespace facebook::velox::cudf_velox::connector::hive


### PR DESCRIPTION
HiveDataSink had accumulated too many responsibilities in one class:

- Table-level orchestration and state management
- Partition/bucket row routing
- Per-writer lifecycle and memory-reclaimer wiring
- File rotation and file metadata tracking
- Sort wrapping logic
- Commit message assembly


New writer behaviors required touching core sink logic
Format-specific side effects leaked into routing paths
Header bloat increased compile-time dependencies and reduced reuse

This refactor decomposes those concerns into explicit layers so each can evolve independently.