### PR TITLE
fix: Add generic CRC32 software fallback in SimdUtil (#17230)

### DIFF
--- a/scripts/checks/run-clang-tidy.py
+++ b/scripts/checks/run-clang-tidy.py
@@ -46,7 +46,11 @@ def git_changed_lines(commit):
         if match:
             matched_file = match.group(1)
             # Exclude all files in cudf directories
-            if "cudf/" not in matched_file:
+            # Exclude *-inl.h files: they are designed to be included from
+            # their corresponding header (e.g., SimdUtil-inl.h is included by
+            # SimdUtil.h) and cannot be compiled as standalone translation
+            # units.
+            if "cudf/" not in matched_file and not matched_file.endswith("-inl.h"):
                 file = matched_file
 
         match = re.match(r"^@@", line)
@@ -76,6 +80,11 @@ def tidy(args):
     # Exclude all files in cudf directories
     # as clang-tidy doesn't support CUDA compiler flags and CUDA headers
     files = [file for file in files if "cudf/" not in file]
+
+    # Exclude *-inl.h files: they are designed to be included from their
+    # corresponding header and cannot be compiled as standalone translation
+    # units (see git_changed_lines for rationale).
+    files = [file for file in files if not file.endswith("-inl.h")]
 
     in_gha = os.environ.get("GITHUB_ACTIONS") is not None
     changed_lines = git_changed_lines(args.commit)

--- a/velox/common/base/CMakeLists.txt
+++ b/velox/common/base/CMakeLists.txt
@@ -78,6 +78,7 @@ velox_add_library(
   StatsReporter.h
   SuccinctPrinter.h
   TreeOfLosers.h
+  XxHashInline.h
 )
 
 velox_link_libraries(

--- a/velox/common/base/SimdUtil-inl.h
+++ b/velox/common/base/SimdUtil-inl.h
@@ -1385,6 +1385,19 @@ struct Filter<T, A, 8> {
 
 template <typename A>
 struct Crc32<uint64_t, A> {
+  static uint32_t
+  apply(uint32_t checksum, uint64_t value, const xsimd::generic&) {
+    checksum ^= static_cast<uint32_t>(value);
+    for (int i = 0; i < 32; ++i) {
+      checksum = (checksum >> 1) ^ (0x82F63B78 & -(checksum & 1));
+    }
+    checksum ^= static_cast<uint32_t>(value >> 32);
+    for (int i = 0; i < 32; ++i) {
+      checksum = (checksum >> 1) ^ (0x82F63B78 & -(checksum & 1));
+    }
+    return checksum;
+  }
+
 #if XSIMD_WITH_SSE4_2
   static uint32_t
   apply(uint32_t checksum, uint64_t value, const xsimd::sse4_2&) {

--- a/velox/common/base/XxHashInline.h
+++ b/velox/common/base/XxHashInline.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#define XXH_INLINE_ALL
+#include <xxhash.h> // @manual=third-party//xxHash:xxhash

--- a/velox/common/base/tests/SimdUtilTest.cpp
+++ b/velox/common/base/tests/SimdUtilTest.cpp
@@ -387,6 +387,10 @@ TEST_F(SimdUtilTest, crc32) {
   EXPECT_EQ(checksum, 3531890030);
   checksum = simd::crc32U64(0, 987654321);
   EXPECT_EQ(checksum, 121285919);
+  checksum = simd::crc32U64(0, 123456789, xsimd::generic{});
+  EXPECT_EQ(checksum, 3531890030);
+  checksum = simd::crc32U64(0, 987654321, xsimd::generic{});
+  EXPECT_EQ(checksum, 121285919);
 }
 
 TEST_F(SimdUtilTest, Batch64_assign) {

--- a/velox/common/hyperloglog/benchmarks/DenseHll.cpp
+++ b/velox/common/hyperloglog/benchmarks/DenseHll.cpp
@@ -18,8 +18,7 @@
 #include <folly/init/Init.h>
 #include "velox/common/memory/HashStringAllocator.h"
 
-#define XXH_INLINE_ALL
-#include <xxhash.h>
+#include "velox/common/base/XxHashInline.h"
 
 using namespace facebook::velox;
 

--- a/velox/common/hyperloglog/tests/DenseHllTest.cpp
+++ b/velox/common/hyperloglog/tests/DenseHllTest.cpp
@@ -19,8 +19,7 @@
 #include <gtest/gtest.h>
 #include <vector>
 
-#define XXH_INLINE_ALL
-#include <xxhash.h>
+#include "velox/common/base/XxHashInline.h"
 
 #include "velox/common/encode/Base64.h"
 

--- a/velox/common/hyperloglog/tests/SparseHllTest.cpp
+++ b/velox/common/hyperloglog/tests/SparseHllTest.cpp
@@ -15,8 +15,7 @@
  */
 #include "velox/common/hyperloglog/SparseHll.h"
 
-#define XXH_INLINE_ALL
-#include <xxhash.h>
+#include "velox/common/base/XxHashInline.h"
 
 #include <gtest/gtest-typed-test.h>
 #include <gtest/gtest.h>

--- a/velox/dwio/dwrf/common/Checksum.h
+++ b/velox/dwio/dwrf/common/Checksum.h
@@ -20,8 +20,7 @@
 #include "velox/dwio/dwrf/common/wrap/dwrf-proto-wrapper.h"
 
 #include <boost/crc.hpp>
-#define XXH_INLINE_ALL
-#include <xxhash.h>
+#include "velox/common/base/XxHashInline.h"
 
 namespace facebook::velox::dwrf {
 

--- a/velox/dwio/parquet/common/XxHasher.cpp
+++ b/velox/dwio/parquet/common/XxHasher.cpp
@@ -18,8 +18,7 @@
 
 #include "XxHasher.h"
 
-#define XXH_INLINE_ALL
-#include <xxhash.h>
+#include "velox/common/base/XxHashInline.h"
 
 namespace facebook::velox::parquet {
 

--- a/velox/dwio/parquet/writer/arrow/tests/XxHasher.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/XxHasher.cpp
@@ -18,8 +18,7 @@
 
 #include "velox/dwio/parquet/writer/arrow/tests/XxHasher.h"
 
-#define XXH_INLINE_ALL
-#include <xxhash.h>
+#include "velox/common/base/XxHashInline.h"
 
 namespace facebook::velox::parquet::arrow {
 

--- a/velox/dwio/parquet/writer/arrow/util/Hashing.h
+++ b/velox/dwio/parquet/writer/arrow/util/Hashing.h
@@ -46,9 +46,7 @@
 
 #include "velox/common/base/Exceptions.h"
 
-#define XXH_INLINE_ALL
-
-#include <xxhash.h>
+#include "velox/common/base/XxHashInline.h"
 
 namespace facebook::velox::parquet::arrow::internal {
 

--- a/velox/exec/HashPartitionFunction.cpp
+++ b/velox/exec/HashPartitionFunction.cpp
@@ -16,8 +16,7 @@
 #include <velox/exec/HashPartitionFunction.h>
 #include <velox/exec/VectorHasher.h>
 
-#define XXH_INLINE_ALL
-#include <xxhash.h> // @manual=third-party//xxHash:xxhash
+#include "velox/common/base/XxHashInline.h"
 
 namespace facebook::velox::exec {
 namespace {

--- a/velox/functions/lib/HllAccumulator.h
+++ b/velox/functions/lib/HllAccumulator.h
@@ -15,10 +15,8 @@
  */
 #pragma once
 
-#define XXH_INLINE_ALL
-
-#include <xxhash.h>
 #include <cmath>
+#include "velox/common/base/XxHashInline.h"
 
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/hyperloglog/DenseHll.h"

--- a/velox/functions/lib/sfm/SfmSketch.h
+++ b/velox/functions/lib/sfm/SfmSketch.h
@@ -16,8 +16,7 @@
 
 #pragma once
 
-#define XXH_INLINE_ALL
-#include <xxhash.h> // @manual=third-party//xxHash:xxhash
+#include "velox/common/base/XxHashInline.h"
 
 #include <folly/Range.h>
 #include <cstdint>

--- a/velox/functions/lib/tests/HllAccumulatorTest.cpp
+++ b/velox/functions/lib/tests/HllAccumulatorTest.cpp
@@ -15,8 +15,7 @@
  */
 #include "velox/functions/lib/HllAccumulator.h"
 
-#define XXH_INLINE_ALL
-#include <xxhash.h>
+#include "velox/common/base/XxHashInline.h"
 
 #include <gtest/gtest-typed-test.h>
 #include <gtest/gtest.h>

--- a/velox/functions/prestosql/BinaryFunctions.h
+++ b/velox/functions/prestosql/BinaryFunctions.h
@@ -16,8 +16,7 @@
 #pragma once
 
 #include <folly/hash/Checksum.h>
-#define XXH_INLINE_ALL
-#include <xxhash.h>
+#include "velox/common/base/XxHashInline.h"
 
 #include "folly/ssl/OpenSSLHash.h"
 #include "velox/common/base/BitUtil.h"

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -15,11 +15,10 @@
  */
 #pragma once
 
-#define XXH_INLINE_ALL
 #include <fast_float/fast_float.h>
 #include <re2/re2.h>
-#include <xxhash.h>
 #include <string_view>
+#include "velox/common/base/XxHashInline.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/lib/DateTimeFormatter.h"
 #include "velox/functions/lib/TimeUtils.h"

--- a/velox/functions/prestosql/FloatingPointFunctions.h
+++ b/velox/functions/prestosql/FloatingPointFunctions.h
@@ -15,8 +15,7 @@
  */
 #pragma once
 
-#define XXH_INLINE_ALL
-#include <xxhash.h>
+#include "velox/common/base/XxHashInline.h"
 
 #include "velox/functions/Udf.h"
 #include "velox/type/Type.h"

--- a/velox/functions/prestosql/IntegerFunctions.h
+++ b/velox/functions/prestosql/IntegerFunctions.h
@@ -15,8 +15,7 @@
  */
 #pragma once
 
-#define XXH_INLINE_ALL
-#include <xxhash.h>
+#include "velox/common/base/XxHashInline.h"
 
 #include "velox/functions/Udf.h"
 #include "velox/type/Type.h"

--- a/velox/functions/prestosql/StringFunctions.h
+++ b/velox/functions/prestosql/StringFunctions.h
@@ -15,8 +15,7 @@
  */
 #pragma once
 
-#define XXH_INLINE_ALL
-#include <xxhash.h>
+#include "velox/common/base/XxHashInline.h"
 
 #include "velox/functions/Udf.h"
 #include "velox/functions/lib/string/StringCore.h"

--- a/velox/functions/prestosql/aggregates/ChecksumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ChecksumAggregate.cpp
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#define XXH_INLINE_ALL
-#include <xxhash.h> // @manual=third-party//xxHash:xxhash
+#include "velox/common/base/XxHashInline.h"
 
 #include "velox/exec/Aggregate.h"
 #include "velox/expression/FunctionSignature.h"

--- a/velox/functions/prestosql/aggregates/HyperLogLogAggregate.h
+++ b/velox/functions/prestosql/aggregates/HyperLogLogAggregate.h
@@ -15,8 +15,7 @@
  */
 #pragma once
 
-#define XXH_INLINE_ALL
-#include <xxhash.h> // @manual=third-party//xxHash:xxhash
+#include "velox/common/base/XxHashInline.h"
 
 #include "velox/common/hyperloglog/HllUtils.h"
 #include "velox/common/hyperloglog/SparseHll.h"

--- a/velox/functions/prestosql/aggregates/PrestoHasher.cpp
+++ b/velox/functions/prestosql/aggregates/PrestoHasher.cpp
@@ -17,8 +17,7 @@
 
 #include <type_traits>
 
-#define XXH_INLINE_ALL
-#include <xxhash.h> // @manual=third-party//xxHash:xxhash
+#include "velox/common/base/XxHashInline.h"
 
 #include "velox/functions/lib/RowsTranslationUtil.h"
 #include "velox/functions/prestosql/types/IPAddressType.h"

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#define XXH_INLINE_ALL
-#include <xxhash.h>
+#include "velox/common/base/XxHashInline.h"
 
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/external/tzdb/zoned_time.h"

--- a/velox/functions/prestosql/tests/HyperLogLogFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/HyperLogLogFunctionsTest.cpp
@@ -13,12 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/common/base/XxHashInline.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/hyperloglog/SparseHll.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 #include "velox/functions/prestosql/types/HyperLogLogType.h"
-#define XXH_INLINE_ALL
-#include <xxhash.h>
 
 using namespace facebook::velox::common::hll;
 


### PR DESCRIPTION
Summary:

Crc32<uint64_t> only has specializations for SSE4.2, AVX, SVE, and NEON. Add an xsimd::generic overload providing a portable bit-by-bit CRC32-C software fallback using polynomial 0x82F63B78, enabling compilation on platforms without hardware CRC32 support.

Reviewed By: Yuhta

Differential Revision: D100733537


