### PR TITLE
perf(operator): Gate TableScan::getOutput estimateFlatSize behind enableOperatorBatchSizeStats (#17231)

### DIFF
--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -224,7 +224,11 @@ RowVectorPtr TableScan::getOutput() {
       if (data != nullptr && !shouldDropOutput()) {
         constexpr int kMaxSelectiveBatchSizeMultiplier = 4;
         if (data->size() > 0) {
-          lockedStats->addInputVector(data->estimateFlatSize(), data->size());
+          uint64_t flatSize = 0;
+          if (driverCtx_->driver->enableOperatorBatchSizeStats()) {
+            flatSize = data->estimateFlatSize();
+          }
+          lockedStats->addInputVector(flatSize, data->size());
           maxFilteringRatio_ = std::max(
               {maxFilteringRatio_,
                1.0 * data->size() / readBatchSize,
@@ -233,8 +237,9 @@ RowVectorPtr TableScan::getOutput() {
             RECORD_METRIC_VALUE(
                 velox::kMetricTableScanBatchProcessTimeMs, ioTimeUs / 1'000);
           }
-          RECORD_METRIC_VALUE(
-              velox::kMetricTableScanBatchBytes, data->estimateFlatSize());
+          if (driverCtx_->driver->enableOperatorBatchSizeStats()) {
+            RECORD_METRIC_VALUE(velox::kMetricTableScanBatchBytes, flatSize);
+          }
           return data;
         } else {
           maxFilteringRatio_ = std::max(


### PR DESCRIPTION
Summary:

CONTEXT: RowVector::estimateFlatSize() recursively walks all column vectors to
estimate batch memory size. For wide schemas this is very expensive — profiling
shows it consuming ~33% of total CPU in certain data pipelines, called
unconditionally twice per batch in TableScan::getOutput.

WHAT: Gate the estimateFlatSize call in TableScan::getOutput behind the existing
enableOperatorBatchSizeStats config flag, matching the pattern already used in
Driver::runInternal. When disabled (the default), both addInputVector and
RECORD_METRIC_VALUE receive 0 bytes — row counts are still tracked. Also
deduplicates the computation from two calls to one.

Reviewed By: Yuhta

Differential Revision: D98855710


