### PR TITLE
perf(expr): Add EvalCtx constructor with pre-computed inputFlatNoNulls flag (#17232)

### DIFF
--- a/velox/expression/EvalCtx.cpp
+++ b/velox/expression/EvalCtx.cpp
@@ -39,14 +39,39 @@ EvalCtx::EvalCtx(
   VELOX_CHECK_NOT_NULL(exprSet);
   VELOX_CHECK_NOT_NULL(row);
 
-  inputFlatNoNulls_ = true;
-  for (const auto& child : row->children()) {
+  inputFlatNoNulls_ = computeInputFlatNoNulls(*row);
+}
+
+EvalCtx::EvalCtx(
+    core::ExecCtx* execCtx,
+    ExprSet* exprSet,
+    const RowVector* row,
+    bool inputFlatNoNulls,
+    bool lazyDereference)
+    : execCtx_(execCtx),
+      exprSet_(exprSet),
+      row_(row),
+      lazyDereference_(lazyDereference),
+      inputFlatNoNulls_(inputFlatNoNulls) {
+  VELOX_CHECK_NOT_NULL(execCtx);
+  VELOX_CHECK_NOT_NULL(exprSet);
+  VELOX_CHECK_NOT_NULL(row);
+  VELOX_DCHECK_EQ(
+      inputFlatNoNulls,
+      computeInputFlatNoNulls(*row),
+      "Pre-computed inputFlatNoNulls does not match actual RowVector state");
+}
+
+// static
+bool EvalCtx::computeInputFlatNoNulls(const RowVector& row) {
+  for (const auto& child : row.children()) {
     VELOX_CHECK_NOT_NULL(child);
     if ((!child->isFlatEncoding() && !child->isConstantEncoding()) ||
         child->mayHaveNulls()) {
-      inputFlatNoNulls_ = false;
+      return false;
     }
   }
+  return true;
 }
 
 EvalCtx::EvalCtx(core::ExecCtx* execCtx)

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -224,6 +224,22 @@ class EvalCtx {
       const RowVector* row,
       bool lazyDereference = false);
 
+  /// Creates an EvalCtx with a pre-computed inputFlatNoNulls flag, skipping
+  /// the per-column loop when the caller has already computed the flag via
+  /// computeInputFlatNoNulls(). Intended for multi-threaded use cases where
+  /// the same RowVector is evaluated across many EvalCtx instances (each bound
+  /// to a different ExprSet), so the flag can be computed once and shared.
+  EvalCtx(
+      core::ExecCtx* execCtx,
+      ExprSet* exprSet,
+      const RowVector* row,
+      bool inputFlatNoNulls,
+      bool lazyDereference);
+
+  /// Computes the inputFlatNoNulls flag for a RowVector. Returns true if all
+  /// children are flat or constant encoded and have no nulls.
+  static bool computeInputFlatNoNulls(const RowVector& row);
+
   /// For testing only.
   explicit EvalCtx(core::ExecCtx* execCtx);
 
@@ -632,7 +648,7 @@ class EvalCtx {
 
   // If isFinalSelection_ is false, the set of rows for the upper-most IF or
   // OR. Used to determine the set of rows for loading lazy vectors.
-  const SelectivityVector* finalSelection_;
+  const SelectivityVector* finalSelection_{nullptr};
 
   // Stores exceptions encountered during expression evaluation.
   // If 'captureErrorDetails()' is false, stores flags indicating which rows had

--- a/velox/expression/tests/EvalCtxTest.cpp
+++ b/velox/expression/tests/EvalCtxTest.cpp
@@ -237,3 +237,34 @@ TEST_F(EvalCtxTest, inputFlatNoNulls) {
   EvalCtx context(&execCtx_);
   ASSERT_FALSE(context.inputFlatNoNulls());
 }
+
+TEST_F(EvalCtxTest, computeInputFlatNoNulls) {
+  // All flat, no nulls -> true.
+  auto flat = makeRowVector({
+      makeFlatVector<int64_t>({1, 2, 3}),
+      makeFlatVector<int64_t>({4, 5, 6}),
+  });
+  ASSERT_TRUE(EvalCtx::computeInputFlatNoNulls(*flat));
+
+  // Flat with nulls -> false.
+  auto withNulls = makeRowVector({
+      makeFlatVector<int64_t>({1, 2, 3}),
+      makeNullableFlatVector<int64_t>({1, std::nullopt, 3}),
+  });
+  ASSERT_FALSE(EvalCtx::computeInputFlatNoNulls(*withNulls));
+
+  // Constant encoding, no nulls -> true.
+  auto withConstant = makeRowVector({
+      makeFlatVector<int64_t>({1, 2, 3}),
+      makeConstant<int64_t>(42, 3),
+  });
+  ASSERT_TRUE(EvalCtx::computeInputFlatNoNulls(*withConstant));
+
+  // Dictionary encoding -> false.
+  auto indices = makeIndices({0, 1, 2});
+  auto withDict = makeRowVector({
+      makeFlatVector<int64_t>({1, 2, 3}),
+      wrapInDictionary(indices, makeFlatVector<int64_t>({4, 5, 6})),
+  });
+  ASSERT_FALSE(EvalCtx::computeInputFlatNoNulls(*withDict));
+}


### PR DESCRIPTION
Summary:

CONTEXT: When the same RowVector is evaluated across many ExprSet instances (e.g. ~1800 times in some cases), the EvalCtx constructor's per-column isFlatEncoding/mayHaveNulls loop runs redundantly for each new instance of EvalCtx, even though the data is the same — 39% of CPU in production.

WHAT: Add a new EvalCtx constructor overload that accepts a pre-computed inputFlatNoNulls flag, plus a static computeInputFlatNoNulls() helper. This lets callers compute the flag once and reuse it across all EvalCtx instances for the same RowVector. The original constructor now delegates to computeInputFlatNoNulls() to avoid code duplication.

Differential Revision: D101418306
