### PR TITLE
feat(iceberg): Add DWRF file format support for Iceberg data sink (#17235)

### DIFF
--- a/velox/connectors/hive/iceberg/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/CMakeLists.txt
@@ -28,6 +28,7 @@ set(
   PositionalDeleteFileReader.cpp
   TransformEvaluator.cpp
   TransformExprBuilder.cpp
+  WriterOptionsAdapter.cpp
 )
 
 velox_add_library(
@@ -51,12 +52,14 @@ velox_add_library(
   PositionalDeleteFileReader.h
   TransformEvaluator.h
   TransformExprBuilder.h
+  WriterOptionsAdapter.h
 )
 
 velox_link_libraries(
   velox_hive_iceberg_splitreader
   velox_connector
   velox_functions_iceberg
+  velox_dwio_dwrf_writer
   Folly::folly
 )
 

--- a/velox/connectors/hive/iceberg/IcebergDataSink.cpp
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.cpp
@@ -29,6 +29,7 @@
 #include "velox/connectors/hive/PartitionIdGenerator.h"
 #include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
 #include "velox/connectors/hive/iceberg/TransformExprBuilder.h"
+#include "velox/connectors/hive/iceberg/WriterOptionsAdapter.h"
 #include "velox/exec/OperatorUtils.h"
 
 namespace facebook::velox::connector::hive::iceberg {
@@ -133,10 +134,10 @@ IcebergInsertTableHandle::IcebergInsertTableHandle(
       "Input columns cannot be empty for Iceberg tables.");
   VELOX_USER_CHECK_NOT_NULL(
       locationHandle_, "Location handle is required for Iceberg tables.");
-  VELOX_USER_CHECK_EQ(
-      tableStorageFormat,
-      dwio::common::FileFormat::PARQUET,
-      "Only Parquet file format is supported when writing Iceberg tables.");
+  VELOX_USER_CHECK(
+      isSupportedFileFormat(tableStorageFormat),
+      "Unsupported file format for writing Iceberg tables: {}",
+      dwio::common::toString(tableStorageFormat));
 }
 
 namespace {
@@ -333,7 +334,8 @@ std::vector<std::string> IcebergDataSink::commitMessage() const {
         ("partitionSpecJson",
           icebergInsertTableHandle->partitionSpec() ?
             icebergInsertTableHandle->partitionSpec()->specId : 0)
-        ("fileFormat", "PARQUET")
+        ("fileFormat",
+          toManifestFormatString(icebergInsertTableHandle->storageFormat()))
         ("content", "DATA");
       // clang-format on
       if (!commitPartitionValue_.empty() &&
@@ -377,7 +379,7 @@ std::string IcebergDataSink::getPartitionName(uint32_t partitionId) const {
 
 uint32_t IcebergDataSink::ensureWriter(const HiveWriterId& id) {
   auto writerId = HiveDataSink::ensureWriter(id);
-  if (commitPartitionValue_[writerId].isNull()) {
+  if (isPartitioned() && commitPartitionValue_[writerId].isNull()) {
     commitPartitionValue_[writerId] = makeCommitPartitionValue(writerId);
   }
   return writerId;
@@ -386,21 +388,25 @@ uint32_t IcebergDataSink::ensureWriter(const HiveWriterId& id) {
 std::shared_ptr<dwio::common::WriterOptions>
 IcebergDataSink::createWriterOptions() const {
   auto options = HiveDataSink::createWriterOptions();
-  // Per Iceberg specification (https://iceberg.apache.org/spec/#parquet):
-  // - Timestamps must be stored with microsecond precision.
-  // - Timestamps must NOT be adjusted to UTC timezone; they should be written
-  //   as-is without timezone conversion (empty string disables conversion).
-  //
-  // These settings are passed via serdeParameters to avoid including
-  // parquet-specific headers. The keys must match kParquetSerdeTimestampUnit
-  // and kParquetSerdeTimestampTimezone defined in
-  // velox/dwio/parquet/writer/Writer.h. The value "6" represents microseconds
-  // (TimestampPrecision::kMicroseconds).
-  options->serdeParameters["parquet.writer.timestamp.unit"] = "6";
-  options->serdeParameters["parquet.writer.timestamp.timezone"] = "";
-  // Re-process configs to apply the serde parameters we just set.
+  auto icebergInsertTableHandle =
+      std::dynamic_pointer_cast<const IcebergInsertTableHandle>(
+          insertTableHandle_);
+  const auto storageFormat = icebergInsertTableHandle
+      ? icebergInsertTableHandle->storageFormat()
+      : dwio::common::FileFormat::UNKNOWN;
+
+  // Format support is enforced in the constructor; the adapter must not
+  // be null here.
+  auto adapter = createWriterOptionsAdapter(storageFormat);
+  VELOX_CHECK_NOT_NULL(
+      adapter,
+      "Unsupported file format for Iceberg writer: {}",
+      dwio::common::toString(storageFormat));
+
+  adapter->applyPreConfigs(*options);
   options->processConfigs(
       *hiveConfig_->config(), *connectorQueryCtx_->sessionProperties());
+  adapter->applyPostConfigs(*options);
   return options;
 }
 

--- a/velox/connectors/hive/iceberg/IcebergDataSink.h
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.h
@@ -91,7 +91,9 @@ class IcebergDataSink : public HiveDataSink {
   /// - fileSizeInBytes: raw bytes written to disk.
   /// - metrics: object with recordCount (number of rows written).
   /// - partitionSpecJson: partition specification.
-  /// - fileFormat: storage format (e.g., "PARQUET").
+  /// - fileFormat: storage format. Either "PARQUET" or "ORC". DWRF files
+  ///   are reported as "ORC" because Iceberg's file-format vocabulary has
+  ///   no DWRF enum.
   /// - content: file content type ("DATA" for data files).
   ///
   /// See

--- a/velox/connectors/hive/iceberg/WriterOptionsAdapter.cpp
+++ b/velox/connectors/hive/iceberg/WriterOptionsAdapter.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/WriterOptionsAdapter.h"
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/dwio/dwrf/writer/Writer.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+namespace {
+
+class ParquetWriterOptionsAdapter : public WriterOptionsAdapter {
+ public:
+  std::string manifestFormatString() const override {
+    return "PARQUET";
+  }
+
+  void applyPreConfigs(dwio::common::WriterOptions& options) const override {
+    // Per Iceberg spec (https://iceberg.apache.org/spec/#parquet):
+    // - Timestamps must be stored with microsecond precision.
+    // - Timestamps must NOT be adjusted to UTC; written as-is without
+    //   timezone conversion (empty string disables conversion).
+    //
+    // Settings are routed through serdeParameters to avoid pulling in
+    // parquet-specific headers. Keys must match
+    // kParquetSerdeTimestampUnit and kParquetSerdeTimestampTimezone in
+    // velox/dwio/parquet/writer/Writer.h. The value "6" represents
+    // microseconds (TimestampPrecision::kMicroseconds).
+    options.serdeParameters["parquet.writer.timestamp.unit"] = "6";
+    options.serdeParameters["parquet.writer.timestamp.timezone"] = "";
+  }
+};
+
+class DwrfWriterOptionsAdapter : public WriterOptionsAdapter {
+ public:
+  std::string manifestFormatString() const override {
+    return "ORC";
+  }
+
+  void applyPostConfigs(dwio::common::WriterOptions& options) const override {
+    // DWRF stores microsecond-precision timestamps natively, so no
+    // precision conversion is required; only timezone adjustment must be
+    // disabled per the Iceberg spec. Unlike Parquet, DWRF exposes
+    // timestamp configuration as direct fields on dwrf::WriterOptions
+    // rather than serdeParameters.
+    auto* dwrfOptions = dynamic_cast<dwrf::WriterOptions*>(&options);
+    if (dwrfOptions == nullptr) {
+      return;
+    }
+    dwrfOptions->adjustTimestampToTimezone = false;
+    dwrfOptions->sessionTimezone = nullptr;
+  }
+};
+
+} // namespace
+
+std::unique_ptr<WriterOptionsAdapter> createWriterOptionsAdapter(
+    dwio::common::FileFormat format) {
+  // ORC is intentionally excluded until a dedicated ORC end-to-end test
+  // exists.
+  // NOLINTNEXTLINE(clang-diagnostic-switch-enum)
+  switch (format) {
+    case dwio::common::FileFormat::PARQUET:
+      return std::make_unique<ParquetWriterOptionsAdapter>();
+    case dwio::common::FileFormat::DWRF:
+      return std::make_unique<DwrfWriterOptionsAdapter>();
+    default:
+      return nullptr;
+  }
+}
+
+bool isSupportedFileFormat(dwio::common::FileFormat format) {
+  return createWriterOptionsAdapter(format) != nullptr;
+}
+
+std::string toManifestFormatString(dwio::common::FileFormat format) {
+  auto adapter = createWriterOptionsAdapter(format);
+  VELOX_CHECK_NOT_NULL(
+      adapter,
+      "Unsupported file format for Iceberg manifest: {}",
+      dwio::common::toString(format));
+  return adapter->manifestFormatString();
+}
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/WriterOptionsAdapter.h
+++ b/velox/connectors/hive/iceberg/WriterOptionsAdapter.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "velox/dwio/common/Options.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+/// Format-specific adapter for an Iceberg-bound WriterOptions instance.
+/// Encapsulates the per-file-format behavior (manifest format string,
+/// pre/post-processConfigs hooks on the writer options) behind a virtual
+/// interface. Dispatched at runtime via createWriterOptionsAdapter() based
+/// on the table's storage format.
+class WriterOptionsAdapter {
+ public:
+  virtual ~WriterOptionsAdapter() = default;
+
+  /// Identifier reported in Iceberg manifest commit messages. Iceberg's
+  /// file-format vocabulary has no DWRF enum; per the Iceberg SDK
+  /// convention, DWRF files are reported as "ORC" so downstream consumers
+  /// (Presto coordinator, catalog) can interpret the commit message.
+  virtual std::string manifestFormatString() const = 0;
+
+  /// Hook applied to WriterOptions BEFORE processConfigs() runs. Used for
+  /// settings that flow through serdeParameters.
+  virtual void applyPreConfigs(dwio::common::WriterOptions& /*options*/) const {
+  }
+
+  /// Hook applied to WriterOptions AFTER processConfigs() runs. Used for
+  /// direct field assignments that must not be overwritten by
+  /// config-driven processing.
+  virtual void applyPostConfigs(
+      dwio::common::WriterOptions& /*options*/) const {}
+};
+
+/// Returns the adapter for the given file format, or nullptr for
+/// unsupported formats. Single source of truth for which file formats the
+/// Iceberg DataSink supports on the write path.
+std::unique_ptr<WriterOptionsAdapter> createWriterOptionsAdapter(
+    dwio::common::FileFormat format);
+
+/// True if the Iceberg DataSink can write the given file format.
+bool isSupportedFileFormat(dwio::common::FileFormat format);
+
+/// Maps a Velox file format to the string used in Iceberg manifest commit
+/// messages. Throws if the format is not supported.
+std::string toManifestFormatString(dwio::common::FileFormat format);
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/tests/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/tests/CMakeLists.txt
@@ -136,4 +136,24 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
     GTest::gtest
     GTest::gtest_main
   )
+
+  add_executable(
+    velox_hive_iceberg_dwrf_insert_test
+    IcebergDwrfInsertTest.cpp
+    IcebergTestBase.cpp
+    Main.cpp
+  )
+  add_test(velox_hive_iceberg_dwrf_insert_test velox_hive_iceberg_dwrf_insert_test)
+
+  target_link_libraries(
+    velox_hive_iceberg_dwrf_insert_test
+    velox_hive_connector
+    velox_hive_iceberg_splitreader
+    velox_exec_test_lib
+    velox_dwio_common_test_utils
+    velox_dwio_dwrf_reader
+    velox_dwio_dwrf_writer
+    GTest::gtest
+    GTest::gtest_main
+  )
 endif()

--- a/velox/connectors/hive/iceberg/tests/IcebergDwrfInsertTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergDwrfInsertTest.cpp
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/HiveConfig.h"
+#include "velox/connectors/hive/iceberg/tests/IcebergTestBase.h"
+#include "velox/dwio/dwrf/RegisterDwrfReader.h"
+#include "velox/dwio/dwrf/RegisterDwrfWriter.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+using namespace facebook::velox::common::testutil;
+
+namespace facebook::velox::connector::hive::iceberg {
+namespace {
+
+/// End-to-end tests for writing and reading Iceberg tables using the DWRF file
+/// format. Exercises the full write path (IcebergDataSink -> DWRF writer) and
+/// the full read path (IcebergSplitReader -> DWRF reader), verifying data
+/// round-trip correctness.
+class IcebergDwrfInsertTest : public test::IcebergTestBase {
+ protected:
+  void SetUp() override {
+    IcebergTestBase::SetUp();
+    dwrf::registerDwrfReaderFactory();
+    dwrf::registerDwrfWriterFactory();
+    fileFormat_ = dwio::common::FileFormat::DWRF;
+  }
+
+  /// Write test data using DWRF format, then read it back and verify results.
+  void test(const RowTypePtr& rowType, double nullRatio = 0.0) {
+    const auto outputDirectory = TempDirectoryPath::create();
+    const auto dataPath = outputDirectory->getPath();
+    constexpr int32_t numBatches = 10;
+    constexpr int32_t vectorSize = 5'000;
+    const auto vectors =
+        createTestData(rowType, numBatches, vectorSize, nullRatio);
+    const auto dataSink = createDataSinkAndAppendData(vectors, dataPath);
+    const auto commitTasks = dataSink->close();
+
+    auto splits = createSplitsForDirectory(dataPath);
+    ASSERT_EQ(splits.size(), commitTasks.size());
+    auto plan = exec::test::PlanBuilder()
+                    .startTableScan()
+                    .connectorId(test::kIcebergConnectorId)
+                    .outputType(rowType)
+                    .endTableScan()
+                    .planNode();
+    exec::test::AssertQueryBuilder(plan).splits(splits).assertResults(vectors);
+  }
+};
+
+TEST_F(IcebergDwrfInsertTest, basic) {
+  auto rowType =
+      ROW({"c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8"},
+          {BIGINT(),
+           INTEGER(),
+           SMALLINT(),
+           BOOLEAN(),
+           REAL(),
+           VARCHAR(),
+           VARBINARY(),
+           DOUBLE()});
+  test(rowType, 0.2);
+}
+
+TEST_F(IcebergDwrfInsertTest, mapAndArray) {
+  auto rowType =
+      ROW({"c1", "c2"}, {MAP(INTEGER(), VARCHAR()), ARRAY(VARCHAR())});
+  test(rowType);
+}
+
+/// Verify the commit message maps DWRF format to "ORC" per Iceberg SDK
+/// convention (Iceberg has no DWRF enum; DWRF files use the ORC identifier).
+TEST_F(IcebergDwrfInsertTest, commitMessageFormat) {
+  const auto outputDirectory = TempDirectoryPath::create();
+  const auto dataPath = outputDirectory->getPath();
+  auto rowType = ROW({"c1", "c2"}, {BIGINT(), VARCHAR()});
+  const auto vectors = createTestData(rowType, 2, 100);
+  const auto dataSink = createDataSinkAndAppendData(vectors, dataPath);
+  const auto commitTasks = dataSink->close();
+
+  ASSERT_GT(commitTasks.size(), 0);
+  for (const auto& task : commitTasks) {
+    auto taskJson = folly::parseJson(task);
+    ASSERT_TRUE(taskJson.count("fileFormat") > 0);
+    ASSERT_EQ(taskJson["fileFormat"].asString(), "ORC");
+  }
+}
+
+/// Verify TIMESTAMP values round-trip unchanged through the DWRF write path
+/// even when the session is configured with a non-UTC timezone and
+/// adjustTimestampToTimezone=true. The Iceberg spec requires timestamps NOT
+/// be adjusted to UTC; the DataSink enforces this by overriding the DWRF
+/// WriterOptions fields. If that override regresses, timestamps would
+/// silently shift by the session-timezone offset and assertResults() would
+/// fail.
+TEST_F(IcebergDwrfInsertTest, timestampRoundTrip) {
+  recreateConnectorQueryCtx(
+      /*sessionTimezone=*/"America/Los_Angeles",
+      /*adjustTimestampToTimezone=*/true);
+  auto rowType = ROW({"c1", "c2"}, {BIGINT(), TIMESTAMP()});
+  test(rowType);
+}
+
+/// End-to-end test for partitioned DWRF writes. Mirrors the identity-
+/// transform partition coverage that exists for Parquet and exercises the
+/// commitPartitionValue_ accounting on the DWRF code path.
+TEST_F(IcebergDwrfInsertTest, partitioned) {
+  auto rowType = ROW({"c1", "c2"}, {BIGINT(), VARCHAR()});
+  const auto outputDirectory = TempDirectoryPath::create();
+  const auto dataPath = outputDirectory->getPath();
+  const auto vectors = createTestData(rowType, 2, 50, 0.2);
+
+  std::vector<test::PartitionField> partitionTransforms = {
+      {0, TransformType::kIdentity, std::nullopt}};
+  const auto dataSink =
+      createDataSinkAndAppendData(vectors, dataPath, partitionTransforms);
+  const auto commitTasks = dataSink->close();
+  ASSERT_GT(commitTasks.size(), 0);
+
+  for (const auto& task : commitTasks) {
+    auto taskJson = folly::parseJson(task);
+    ASSERT_EQ(taskJson["fileFormat"].asString(), "ORC");
+    EXPECT_GT(taskJson.count("partitionDataJson"), 0);
+  }
+
+  auto splits = createSplitsForDirectory(dataPath);
+  ASSERT_EQ(splits.size(), commitTasks.size());
+  auto plan = exec::test::PlanBuilder()
+                  .startTableScan()
+                  .connectorId(test::kIcebergConnectorId)
+                  .outputType(rowType)
+                  .endTableScan()
+                  .planNode();
+  exec::test::AssertQueryBuilder(plan).splits(splits).assertResults(vectors);
+}
+
+/// Regression test for the isPartitioned() guard added to ensureWriter().
+/// Without the guard, calling ensureWriter() on a non-partitioned table
+/// invoked makeCommitPartitionValue(), which dereferences
+/// partitionIdGenerator_ — null for unpartitioned tables — causing a crash.
+/// Exercises the unpartitioned write path explicitly so any future
+/// regression is caught with a named test.
+TEST_F(IcebergDwrfInsertTest, ensureWriterNonPartitioned) {
+  auto rowType = ROW({"c1", "c2"}, {BIGINT(), VARCHAR()});
+  const auto outputDirectory = TempDirectoryPath::create();
+  const auto dataPath = outputDirectory->getPath();
+  const auto vectors = createTestData(rowType, 1, 50);
+
+  // No partitionFields => unpartitioned table, partitionIdGenerator_ stays
+  // null inside the sink. appendData triggers ensureWriter().
+  const auto dataSink = createDataSinkAndAppendData(vectors, dataPath);
+  const auto commitTasks = dataSink->close();
+
+  ASSERT_EQ(commitTasks.size(), 1);
+  auto taskJson = folly::parseJson(commitTasks[0]);
+  // Unpartitioned tables must not emit partitionDataJson.
+  EXPECT_EQ(taskJson.count("partitionDataJson"), 0);
+}
+
+} // namespace
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/tests/IcebergTestBase.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergTestBase.cpp
@@ -93,6 +93,15 @@ void IcebergTestBase::setupMemoryPools() {
   connectorPool_ =
       root_->addAggregateChild("connector", exec::MemoryReclaimer::create());
 
+  recreateConnectorQueryCtx(/*sessionTimezone=*/"", false);
+}
+
+void IcebergTestBase::recreateConnectorQueryCtx(
+    const std::string& sessionTimezone,
+    bool adjustTimestampToTimezone) {
+  connectorQueryCtx_.reset();
+  queryCtx_.reset();
+
   queryCtx_ = core::QueryCtx::create(nullptr, core::QueryConfig({}));
   auto expressionEvaluator = std::make_unique<exec::SimpleExpressionEvaluator>(
       queryCtx_.get(), opPool_.get());
@@ -109,7 +118,8 @@ void IcebergTestBase::setupMemoryPools() {
       "task.IcebergTest",
       "planNodeId.IcebergTest",
       0,
-      "");
+      sessionTimezone,
+      adjustTimestampToTimezone);
 }
 
 std::vector<RowVectorPtr> IcebergTestBase::createTestData(

--- a/velox/connectors/hive/iceberg/tests/IcebergTestBase.h
+++ b/velox/connectors/hive/iceberg/tests/IcebergTestBase.h
@@ -79,6 +79,13 @@ class IcebergTestBase : public exec::test::HiveConnectorTestBase {
       const std::string& key,
       const std::string& value);
 
+  /// Recreates the connector query context with the given session timezone
+  /// and timestamp-adjustment flag. Tests use this to exercise non-UTC
+  /// session configurations and verify timezone-sensitive behavior.
+  void recreateConnectorQueryCtx(
+      const std::string& sessionTimezone,
+      bool adjustTimestampToTimezone);
+
   /// Extracts partition key-value pairs from a file path.
   /// Returns a map where keys are partition column names and values are
   /// partition values (std::nullopt for null values).


### PR DESCRIPTION
Summary:

Add DWRF file format support for Iceberg data sink. Velox supports DWRF file format, so adding support to Iceberg connector to leverage it.

Part of https://github.com/prestodb/presto/issues/27198

Reviewed By: srsuryadev

Differential Revision: D100061159


