### PR TITLE
fix(cudf): Fix AST/Function mode switching during Expression Evaluation

### DIFF
--- a/velox/experimental/cudf/expression/AstExpression.cpp
+++ b/velox/experimental/cudf/expression/AstExpression.cpp
@@ -125,9 +125,7 @@ ColumnOrView ASTExpression::eval(
 }
 
 bool ASTExpression::canEvaluate(std::shared_ptr<velox::exec::Expr> expr) {
-  return std::dynamic_pointer_cast<velox::exec::FieldReference>(expr) !=
-      nullptr ||
-      detail::isAstExprSupported(expr);
+  return detail::isAstExprSupported(expr);
 }
 
 void registerAstEvaluator(int priority) {

--- a/velox/experimental/cudf/expression/AstExpressionUtils.h
+++ b/velox/experimental/cudf/expression/AstExpressionUtils.h
@@ -501,6 +501,22 @@ cudf::ast::expression const& AstContext::pushExprToTree(
 
   const auto name =
       stripPrefix(expr->name(), CudfConfig::getInstance().functionNamePrefix);
+
+  if (!detail::isAstExprSupported(expr)) {
+    if (canBeEvaluatedByCudf(expr, /*deep=*/false)) {
+      // Shallow check: only verify this operation is supported
+      // Children will be recursively handled by createCudfExpression
+      // Determine which side this expression references
+      int sideIdx = findExpressionSide(expr);
+      if (sideIdx < 0) {
+        sideIdx = 0; // Default to left side if no fields found
+      }
+      auto node = createCudfExpression(expr, inputRowSchema[sideIdx]);
+      return addPrecomputeInstructionOnSide(sideIdx, 0, name, "", node);
+    }
+    VELOX_FAIL("Unsupported expression: {}", name);
+  }
+
   auto len = expr->inputs().size();
   auto& type = expr->type();
 
@@ -632,19 +648,8 @@ cudf::ast::expression const& AstContext::pushExprToTree(
       }
     }
     VELOX_FAIL("Field not found: {}", name);
-  } else if (!allowPureAstOnly && canBeEvaluatedByCudf(expr, /*deep=*/false)) {
-    // Shallow check: only verify this operation is supported
-    // Children will be recursively handled by createCudfExpression
-    // Determine which side this expression references
-    int sideIdx = findExpressionSide(expr);
-    if (sideIdx < 0) {
-      sideIdx = 0; // Default to left side if no fields found
-    }
-    auto node =
-        createCudfExpression(expr, inputRowSchema[sideIdx], kAstEvaluatorName);
-    return addPrecomputeInstructionOnSide(sideIdx, 0, name, "", node);
   } else {
-    VELOX_FAIL("Unsupported expression: {}", name);
+    VELOX_UNREACHABLE("Unsupported expression: {}", name);
   }
 }
 

--- a/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
@@ -1133,16 +1133,12 @@ bool canBeEvaluatedByCudf(std::shared_ptr<velox::exec::Expr> expr, bool deep) {
 
 std::shared_ptr<CudfExpression> createCudfExpression(
     std::shared_ptr<velox::exec::Expr> expr,
-    const RowTypePtr& inputRowSchema,
-    std::optional<std::string> except) {
+    const RowTypePtr& inputRowSchema) {
   ensureBuiltinExpressionEvaluatorsRegistered();
   const auto& registry = getCudfExpressionEvaluatorRegistry();
 
   const CudfExpressionEvaluatorEntry* best = nullptr;
   for (const auto& [name, entry] : registry) {
-    if (except && name == *except) {
-      continue;
-    }
     if (entry.canEvaluate && entry.canEvaluate(expr)) {
       if (best == nullptr || entry.priority > best->priority) {
         best = &entry;

--- a/velox/experimental/cudf/expression/ExpressionEvaluator.h
+++ b/velox/experimental/cudf/expression/ExpressionEvaluator.h
@@ -160,8 +160,7 @@ class FunctionExpression : public CudfExpression {
 
 std::shared_ptr<CudfExpression> createCudfExpression(
     std::shared_ptr<velox::exec::Expr> expr,
-    const RowTypePtr& inputRowSchema,
-    std::optional<std::string> except = std::nullopt);
+    const RowTypePtr& inputRowSchema);
 
 /// Lightweight check if an expression tree is supported by any CUDF evaluator
 /// without initializing CudfExpression objects.


### PR DESCRIPTION
Check ast support before pushExprToTree adds the next expression node.

Removed except arg from createCudfExpression because it shouldn't be needed now.

(cherry picked from commit 9dbc09cce8751028fefaab5e697797cd014e874a)