### PR TITLE
fix: Split Enums.h into EnumDeclare.h and EnumDefine.h (#17239)

### DIFF
--- a/velox/common/CMakeLists.txt
+++ b/velox/common/CMakeLists.txt
@@ -34,7 +34,9 @@ if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)
 endif()
 
-velox_add_library(velox_enums INTERFACE HEADERS Enums.h)
+velox_add_library(velox_enum_declare INTERFACE HEADERS EnumDeclare.h)
+
+velox_add_library(velox_enum_define INTERFACE HEADERS EnumDefine.h)
 
 velox_add_library(velox_casts INTERFACE HEADERS Casts.h)
 

--- a/velox/common/EnumDeclare.h
+++ b/velox/common/EnumDeclare.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <iosfwd>
+#include <optional>
+#include <string_view>
+
+/// Lightweight declaration macros for enum-to-name mappings.
+///
+/// Include this header in .h files. Include EnumDefine.h only in .cpp files
+/// that use the DEFINE macros. EnumDefine.h pulls in heavy transitive includes
+/// (folly/F14Map.h, Exceptions.h, ~8M preprocessed) that propagate to every
+/// file that includes your header.
+///
+/// Usage:
+///
+/// In the header file, define the enum and declare its name mapping:
+///
+/// #include "velox/common/EnumDeclare.h"
+///
+/// enum class Foo {...};
+///
+/// VELOX_DECLARE_ENUM_NAME(Foo);
+///
+/// In the .cpp file, define the mapping:
+///
+/// #include "velox/common/EnumDefine.h"
+///
+/// namespace {
+/// const auto& fooNames() {
+///   static const folly::F14FastMap<Foo, std::string_view> kNames = {
+///       {Foo::kFirst, "FIRST"},
+///       {Foo::kSecond, "SECOND"},
+///        ...
+///   };
+///   return kNames;
+/// }
+/// } // namespace
+///
+/// VELOX_DEFINE_ENUM_NAME(Foo, fooNames);
+///
+/// In client code, use FooName::toName(Foo::kFirst) to get the name of the
+/// enum and FooName::toFoo("FIRST") or FooName::tryToFoo("FIRST") to get the
+/// enum value. toFoo throws an exception if the input is not a valid name,
+/// while tryToFoo returns std::nullopt.
+///
+/// Use _EMBEDDED_ versions of the macros to define enums embedded in other
+/// classes.
+
+#define VELOX_DECLARE_ENUM_NAME(EnumType)                                  \
+  struct EnumType##Name {                                                  \
+    static std::string_view toName(EnumType value);                        \
+    static EnumType to##EnumType(std::string_view name);                   \
+    static std::optional<EnumType> tryTo##EnumType(std::string_view name); \
+  };                                                                       \
+  std::ostream& operator<<(std::ostream& os, const EnumType& value);
+
+#define VELOX_DECLARE_EMBEDDED_ENUM_NAME(EnumType)     \
+  static std::string_view toName(EnumType value);      \
+  static EnumType to##EnumType(std::string_view name); \
+  static std::optional<EnumType> tryTo##EnumType(std::string_view name);

--- a/velox/common/EnumDefine.h
+++ b/velox/common/EnumDefine.h
@@ -37,49 +37,9 @@ struct Enums {
 
 } // namespace facebook::velox
 
-/// Helper macros to implement bi-direction mappings between enum values and
-/// names.
+/// DEFINE macros for enum-to-name mappings. Include only in .cpp files.
 ///
-/// Usage:
-///
-/// In the header file, define the enum:
-///
-/// #include "velox/common/Enums.h"
-///
-/// enum class Foo {...};
-///
-/// VELOX_DECLARE_ENUM_NAME(Foo);
-///
-/// In the cpp file, define the mapping:
-///
-/// namespace {
-/// const auto& fooNames() {
-///   static const folly::F14FastMap<Foo, std::string_view> kNames = {
-///       {Foo::kFirst, "FIRST"},
-///       {Foo::kSecond, "SECOND"},
-///        ...
-///   };
-///   return kNames;
-/// }
-/// } // namespace
-///
-/// VELOX_DEFINE_ENUM_NAME(Foo, fooNames);
-///
-/// In the client code, use FooName::toName(Foo::kFirst) to get the name of the
-/// enum and FooName::toFoo("FIRST") or FooName::tryToFoo("FIRST") to get the
-/// enum value. toFoo throws an exception if input is not a valid name, while
-/// tryToFoo returns a std::nullopt.
-///
-/// Use _EMBEDDED_ versions of the macros to define enums embedded in other
-/// classes.
-
-#define VELOX_DECLARE_ENUM_NAME(EnumType)                                  \
-  struct EnumType##Name {                                                  \
-    static std::string_view toName(EnumType value);                        \
-    static EnumType to##EnumType(std::string_view name);                   \
-    static std::optional<EnumType> tryTo##EnumType(std::string_view name); \
-  };                                                                       \
-  std::ostream& operator<<(std::ostream& os, const EnumType& value);
+/// See EnumDeclare.h for full usage documentation and the DECLARE macros.
 
 #define VELOX_DEFINE_ENUM_NAME(EnumType, Names)                             \
   std::string_view EnumType##Name::toName(EnumType value) {                 \
@@ -112,11 +72,6 @@ struct Enums {
     VELOX_CHECK(maybeType, "Invalid enum name: {}", name);                  \
     return *maybeType;                                                      \
   }
-
-#define VELOX_DECLARE_EMBEDDED_ENUM_NAME(EnumType)     \
-  static std::string_view toName(EnumType value);      \
-  static EnumType to##EnumType(std::string_view name); \
-  static std::optional<EnumType> tryTo##EnumType(std::string_view name);
 
 #define VELOX_DEFINE_EMBEDDED_ENUM_NAME(Class, EnumType, Names)             \
   std::string_view Class::toName(Class::EnumType value) {                   \

--- a/velox/common/config/ConfigProperty.cpp
+++ b/velox/common/config/ConfigProperty.cpp
@@ -15,6 +15,8 @@
  */
 #include "velox/common/config/ConfigProperty.h"
 
+#include "velox/common/EnumDefine.h"
+
 namespace facebook::velox::config {
 
 namespace {

--- a/velox/common/config/ConfigProperty.h
+++ b/velox/common/config/ConfigProperty.h
@@ -20,7 +20,7 @@
 #include <vector>
 
 #include <fmt/format.h>
-#include "velox/common/Enums.h"
+#include "velox/common/EnumDeclare.h"
 
 namespace facebook::velox::config {
 

--- a/velox/connectors/Connector.cpp
+++ b/velox/connectors/Connector.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/connectors/Connector.h"
 
+#include "velox/common/EnumDefine.h"
+
 #include <memory>
 #include <string>
 

--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -16,7 +16,7 @@
 #pragma once
 
 #include "folly/CancellationToken.h"
-#include "velox/common/Enums.h"
+#include "velox/common/EnumDeclare.h"
 #include "velox/common/base/AsyncSource.h"
 #include "velox/common/base/PrefixSortConfig.h"
 #include "velox/common/base/RuntimeMetrics.h"

--- a/velox/connectors/hive/iceberg/PartitionSpec.cpp
+++ b/velox/connectors/hive/iceberg/PartitionSpec.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/connectors/hive/iceberg/PartitionSpec.h"
 
+#include "velox/common/EnumDefine.h"
+
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 
 namespace facebook::velox::connector::hive::iceberg {

--- a/velox/core/ITypedExpr.cpp
+++ b/velox/core/ITypedExpr.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/core/ITypedExpr.h"
 
+#include "velox/common/EnumDefine.h"
+
 namespace facebook::velox::core {
 
 namespace {

--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -18,6 +18,8 @@
 #include "velox/common/Casts.h"
 #include "velox/common/encode/Base64.h"
 #include "velox/core/PlanNode.h"
+
+#include "velox/common/EnumDefine.h"
 #include "velox/core/TableWriteTraits.h"
 #include "velox/vector/VectorSaver.h"
 

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -19,7 +19,7 @@
 
 #include <utility>
 
-#include "velox/common/Enums.h"
+#include "velox/common/EnumDeclare.h"
 #include "velox/common/rpc/RPCTypes.h"
 #include "velox/connectors/Connector.h"
 #include "velox/core/Expressions.h"

--- a/velox/exec/BlockingReason.cpp
+++ b/velox/exec/BlockingReason.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/exec/BlockingReason.h"
 
+#include "velox/common/EnumDefine.h"
+
 namespace facebook::velox::exec {
 
 namespace {

--- a/velox/exec/BlockingReason.h
+++ b/velox/exec/BlockingReason.h
@@ -16,7 +16,8 @@
 
 #pragma once
 
-#include "velox/common/Enums.h"
+#include <fmt/format.h>
+#include "velox/common/EnumDeclare.h"
 
 namespace facebook::velox::exec {
 

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -24,6 +24,8 @@
 #include "velox/common/process/ThreadDebugInfo.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/expression/CastExpr.h"
+
+#include "velox/common/EnumDefine.h"
 #include "velox/expression/ConstantExpr.h"
 #include "velox/expression/Expr.h"
 #include "velox/expression/ExprCompiler.h"

--- a/velox/parse/Expressions.cpp
+++ b/velox/parse/Expressions.cpp
@@ -15,6 +15,8 @@
  */
 #include "velox/parse/Expressions.h"
 
+#include "velox/common/EnumDefine.h"
+
 namespace facebook::velox::core {
 
 namespace {

--- a/velox/parse/Expressions.h
+++ b/velox/parse/Expressions.h
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include "velox/common/Enums.h"
+#include "velox/common/EnumDeclare.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/parse/IExpr.h"
 #include "velox/type/Variant.h"

--- a/velox/parse/IExpr.h
+++ b/velox/parse/IExpr.h
@@ -22,7 +22,7 @@
 #include <optional>
 #include <string>
 #include <vector>
-#include "velox/common/Enums.h"
+#include "velox/common/EnumDeclare.h"
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/base/Exceptions.h"
 

--- a/velox/type/Filter.cpp
+++ b/velox/type/Filter.cpp
@@ -22,6 +22,8 @@
 
 #include "velox/type/Filter.h"
 
+#include "velox/common/EnumDefine.h"
+
 namespace facebook::velox::common {
 
 namespace {

--- a/velox/type/Filter.h
+++ b/velox/type/Filter.h
@@ -18,7 +18,7 @@
 #include <folly/Range.h>
 #include <folly/container/F14Set.h>
 #include <xsimd/xsimd.hpp>
-#include "velox/common/Enums.h"
+#include "velox/common/EnumDeclare.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/SimdUtil.h"
 #include "velox/common/base/SplitBlockBloomFilter.h"

--- a/velox/type/Subfield.cpp
+++ b/velox/type/Subfield.cpp
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 #include "velox/type/Subfield.h"
+
 #include <boost/algorithm/string/replace.hpp>
 #include <folly/container/F14Map.h>
+#include "velox/common/EnumDefine.h"
 #include "velox/type/Tokenizer.h"
 
 namespace facebook::velox::common {

--- a/velox/type/Subfield.h
+++ b/velox/type/Subfield.h
@@ -19,7 +19,7 @@
 #include <folly/hash/Hash.h>
 #include <ostream>
 
-#include "velox/common/Enums.h"
+#include "velox/common/EnumDeclare.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/Macros.h"
 

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -16,6 +16,8 @@
 
 #include <velox/type/Type.h>
 
+#include "velox/common/EnumDefine.h"
+
 #include <boost/algorithm/string.hpp>
 #include <fmt/format.h>
 #include <folly/Demangle.h>

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -33,7 +33,7 @@
 #include <typeindex>
 #include <vector>
 
-#include <velox/common/Enums.h>
+#include <velox/common/EnumDeclare.h>
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/base/ClassName.h"
 #include "velox/common/base/Exceptions.h"


### PR DESCRIPTION
Summary:
Rename EnumsDeclare.h to EnumDeclare.h and Enums.h to EnumDefine.h for symmetric naming that makes clear these are a matched pair — EnumDeclare.h in every .h, EnumDefine.h in the corresponding .cpp. The old naming (Enums.h / EnumsDeclare.h) made Enums.h look like the main header and EnumsDeclare.h look auxiliary, tempting people to just include Enums.h.

The declare macros (VELOX_DECLARE_ENUM_NAME, VELOX_DECLARE_EMBEDDED_ENUM_NAME) live in the lightweight EnumDeclare.h that only needs <iosfwd>, <optional>, <string_view>. The define macros stay in EnumDefine.h with their heavy transitive includes (folly/container/F14Map.h and velox/common/base/Exceptions.h, together ~8M preprocessed). The two headers are independent.

All velox headers include EnumDeclare.h for the DECLARE macros. The corresponding .cpp files include EnumDefine.h for the DEFINE macros. BUCK targets updated accordingly: enums_declare is an exported dep for headers, enums is a private dep for .cpp files.

ConfigProperty.h includes EnumDeclare.h instead of Enums.h, cutting ~8M of preprocessed includes from every consumer.


Reviewed By: mbasmanova

Differential Revision: D101462826
