### PR TITLE
refactor(reader): Rename memoryPool_ to pool_ in SelectiveColumnReader hierarchy

### DIFF
--- a/velox/dwio/common/SelectiveColumnReader.cpp
+++ b/velox/dwio/common/SelectiveColumnReader.cpp
@@ -47,17 +47,17 @@ SelectiveColumnReader::SelectiveColumnReader(
     std::shared_ptr<const dwio::common::TypeWithId> fileType,
     dwio::common::FormatParams& params,
     velox::common::ScanSpec& scanSpec)
-    : memoryPool_(&params.pool()),
+    : pool_(&params.pool()),
       requestedType_(requestedType),
       fileType_(fileType),
       formatData_(params.toFormatData(fileType, scanSpec)),
       scanSpec_(&scanSpec),
-      outputRows_(memoryPool_),
-      valueRows_(memoryPool_),
-      outerNonNullRows_(memoryPool_),
-      innerNonNullRows_(memoryPool_) {
-  scanState_.rowsCopy = raw_vector<vector_size_t>(memoryPool_);
-  scanState_.filterCache = raw_vector<uint8_t>(memoryPool_);
+      outputRows_(pool_),
+      valueRows_(pool_),
+      outerNonNullRows_(pool_),
+      innerNonNullRows_(pool_) {
+  scanState_.rowsCopy = raw_vector<vector_size_t>(pool_);
+  scanState_.filterCache = raw_vector<uint8_t>(pool_);
   // Initialize per-column metrics if collection is enabled.
   if (params.runtimeStatistics().columnMetricsSet) {
     columnMetrics_ = params.runtimeStatistics().columnMetricsSet->getOrCreate(
@@ -150,8 +150,8 @@ void SelectiveColumnReader::prepareNulls(
       resultNulls_->capacity() >= bits::nbytes(numRows) + simd::kPadding) {
     resultNulls_->setSize(bits::nbytes(numRows));
   } else {
-    resultNulls_ = AlignedBuffer::allocate<bool>(
-        numRows + (simd::kPadding * 8), memoryPool_);
+    resultNulls_ =
+        AlignedBuffer::allocate<bool>(numRows + (simd::kPadding * 8), pool_);
     rawResultNulls_ = resultNulls_->asMutable<uint64_t>();
   }
   anyNulls_ = false;
@@ -171,7 +171,7 @@ const uint64_t* SelectiveColumnReader::shouldMoveNulls(const RowSet& rows) {
     if (!(resultNulls_ && resultNulls_->unique() &&
           resultNulls_->capacity() >= rows.size() + simd::kPadding)) {
       resultNulls_ = AlignedBuffer::allocate<bool>(
-          rows.size() + (simd::kPadding * 8), memoryPool_);
+          rows.size() + (simd::kPadding * 8), pool_);
       rawResultNulls_ = resultNulls_->asMutable<uint64_t>();
     }
     moveFrom = nullsInReadRange_->as<uint64_t>();
@@ -387,8 +387,7 @@ void SelectiveColumnReader::getFlatValues<int8_t, bool>(
   constexpr int32_t kWidth = xsimd::batch<int8_t>::size;
   VELOX_CHECK_EQ(valueSize_, sizeof(int8_t));
   compactScalarValues<int8_t, int8_t>(rows, isFinal);
-  auto boolValues =
-      AlignedBuffer::allocate<bool>(numValues_, memoryPool_, false);
+  auto boolValues = AlignedBuffer::allocate<bool>(numValues_, pool_, false);
   auto rawBytes = values_->as<int8_t>();
   auto zero = xsimd::broadcast<int8_t>(0);
   if constexpr (kWidth == 32) {
@@ -406,7 +405,7 @@ void SelectiveColumnReader::getFlatValues<int8_t, bool>(
     }
   }
   *result = std::make_shared<FlatVector<bool>>(
-      memoryPool_,
+      pool_,
       type,
       resultNulls(),
       numValues_,
@@ -457,7 +456,7 @@ char* SelectiveColumnReader::copyStringValue(std::string_view value) {
   uint64_t size = value.size();
   if (stringBuffers_.empty() || rawStringUsed_ + size > rawStringSize_) {
     auto bytes = std::max(size, kStringBufferSize);
-    BufferPtr buffer = AlignedBuffer::allocate<char>(bytes, memoryPool_);
+    BufferPtr buffer = AlignedBuffer::allocate<char>(bytes, pool_);
     // Use the preferred size instead of the requested one to improve memory
     // efficiency.
     buffer->setSize(buffer->capacity());

--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -257,7 +257,7 @@ class SelectiveColumnReader {
   uint64_t* mutableNulls(int32_t size) {
     if (!resultNulls_->unique()) {
       resultNulls_ = AlignedBuffer::allocate<bool>(
-          numValues_ + size, memoryPool_, bits::kNotNull);
+          numValues_ + size, pool_, bits::kNotNull);
       rawResultNulls_ = resultNulls_->asMutable<uint64_t>();
     }
     if (resultNulls_->capacity() * 8 < numValues_ + size) {
@@ -518,7 +518,7 @@ class SelectiveColumnReader {
   }
 
   memory::MemoryPool* memoryPool() const {
-    return memoryPool_;
+    return pool_;
   }
 
  protected:
@@ -643,7 +643,7 @@ class SelectiveColumnReader {
     return scanSpec_->hasFilter() || hasDeletion();
   }
 
-  memory::MemoryPool* const memoryPool_;
+  memory::MemoryPool* const pool_;
 
   // The requested data type
   const TypePtr requestedType_;

--- a/velox/dwio/common/SelectiveColumnReaderInternal.h
+++ b/velox/dwio/common/SelectiveColumnReaderInternal.h
@@ -46,8 +46,8 @@ void SelectiveColumnReader::ensureValuesCapacity(
           BaseVector::byteSize<T>(numRows) + simd::kPadding) {
     return;
   }
-  auto newValues = AlignedBuffer::allocate<T>(
-      numRows + simd::kPadding / sizeof(T), memoryPool_);
+  auto newValues =
+      AlignedBuffer::allocate<T>(numRows + simd::kPadding / sizeof(T), pool_);
   if (preserveData) {
     std::memcpy(
         newValues->template asMutable<char>(), rawValues_, values_->capacity());
@@ -137,12 +137,12 @@ void SelectiveColumnReader::getFlatValues(
       } else {
         flatMapValueConstantNullValues_ =
             std::make_shared<ConstantVector<TVector>>(
-                memoryPool_, rows.size(), true, type, TVector());
+                pool_, rows.size(), true, type, TVector());
       }
       *result = flatMapValueConstantNullValues_;
     } else {
       *result = std::make_shared<ConstantVector<TVector>>(
-          memoryPool_, rows.size(), true, type, TVector());
+          pool_, rows.size(), true, type, TVector());
     }
     return;
   }
@@ -164,7 +164,7 @@ void SelectiveColumnReader::getFlatValues(
       flat->setStringBuffers(std::move(stringBuffers_));
     } else {
       flatMapValueFlatValues_ = std::make_shared<FlatVector<TVector>>(
-          memoryPool_,
+          pool_,
           type,
           resultNulls(),
           numValues_,
@@ -174,7 +174,7 @@ void SelectiveColumnReader::getFlatValues(
     *result = flatMapValueFlatValues_;
   } else {
     *result = std::make_shared<FlatVector<TVector>>(
-        memoryPool_,
+        pool_,
         type,
         resultNulls(),
         numValues_,

--- a/velox/dwio/common/SelectiveRepeatedColumnReader.cpp
+++ b/velox/dwio/common/SelectiveRepeatedColumnReader.cpp
@@ -80,7 +80,7 @@ void prepareResult(
 void SelectiveRepeatedColumnReader::ensureAllLengthsBuffer(vector_size_t size) {
   if (!allLengthsHolder_ ||
       allLengthsHolder_->capacity() < size * sizeof(vector_size_t)) {
-    allLengthsHolder_ = allocateIndices(size, memoryPool_);
+    allLengthsHolder_ = allocateIndices(size, pool_);
     allLengths_ = allLengthsHolder_->asMutable<vector_size_t>();
   }
 }
@@ -266,7 +266,7 @@ void SelectiveListColumnReader::getValues(
     const RowSet& rows,
     VectorPtr* result) {
   VELOX_DCHECK_NOT_NULL(result);
-  prepareResult(*result, requestedType_, rows.size(), memoryPool_);
+  prepareResult(*result, requestedType_, rows.size(), pool_);
   auto* resultArray = result->get()->asUnchecked<ArrayVector>();
   makeOffsetsAndSizes(rows, *resultArray);
   setComplexNulls(rows, *result);
@@ -370,7 +370,7 @@ void SelectiveMapColumnReader::getValues(
       !result->get() || result->get()->type()->isMap(),
       "Expect MAP result vector, got {}",
       result->get()->type()->toString());
-  prepareResult(*result, requestedType_, rows.size(), memoryPool_);
+  prepareResult(*result, requestedType_, rows.size(), pool_);
   auto* resultMap = result->get()->asUnchecked<MapVector>();
   makeOffsetsAndSizes(rows, *resultMap);
   setComplexNulls(rows, *result);

--- a/velox/dwio/common/SelectiveRepeatedColumnReader.h
+++ b/velox/dwio/common/SelectiveRepeatedColumnReader.h
@@ -42,7 +42,7 @@ class SelectiveRepeatedColumnReader : public SelectiveColumnReader {
       velox::common::ScanSpec& scanSpec,
       std::shared_ptr<const dwio::common::TypeWithId> type)
       : SelectiveColumnReader(requestedType, std::move(type), params, scanSpec),
-        nestedRowsHolder_(memoryPool_) {}
+        nestedRowsHolder_(pool_) {}
 
   /// Reads 'numLengths' next lengths into 'result'. If 'nulls' is
   /// non-null, each kNull bit signifies a null with a length of 0 to
@@ -62,7 +62,7 @@ class SelectiveRepeatedColumnReader : public SelectiveColumnReader {
   /// Creates a struct if '*result' is empty and 'type' is a row.
   void prepareStructResult(const TypePtr& type, VectorPtr* result) {
     if (!*result && type->kind() == TypeKind::ROW) {
-      *result = BaseVector::create(type, 0, memoryPool_);
+      *result = BaseVector::create(type, 0, pool_);
     }
   }
 

--- a/velox/dwio/common/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/common/SelectiveStructColumnReader.cpp
@@ -577,7 +577,7 @@ void SelectiveStructColumnReaderBase::getValues(
                 this, children_[index], numReads_),
             resultRow->type()->childAt(channel),
             rows.size(),
-            memoryPool_,
+            pool_,
             childResult);
       }
       continue;
@@ -622,7 +622,7 @@ void SelectiveStructColumnReaderBase::getValues(
         makeColumnLoader(index),
         resultRow->type()->childAt(channel),
         rows.size(),
-        memoryPool_,
+        pool_,
         childResult);
   }
   resultRow->updateContainsLazyNotLoaded();

--- a/velox/dwio/common/SelectiveStructColumnReader.h
+++ b/velox/dwio/common/SelectiveStructColumnReader.h
@@ -124,7 +124,7 @@ class SelectiveStructColumnReaderBase : public SelectiveColumnReader {
             getExceptionContext().message(VeloxException::Type::kSystem)),
         isRoot_(isRoot),
         generateLazyChildren_(generateLazyChildren),
-        rows_(memoryPool_) {}
+        rows_(pool_) {}
 
   bool hasDeletion() const final {
     return hasDeletion_;
@@ -249,7 +249,7 @@ class SelectiveFlatMapColumnReaderHelper {
       reader_.children_[i]->setIsFlatMapValue(true);
     }
     if (auto type = reader_.requestedType_->childAt(1); type->isRow()) {
-      childValues_ = BaseVector::create(type, 0, reader_.memoryPool_);
+      childValues_ = BaseVector::create(type, 0, reader_.pool_);
     }
   }
 
@@ -265,8 +265,7 @@ class SelectiveFlatMapColumnReaderHelper {
       result->resize(size);
     } else {
       VLOG(1) << "Reallocating result MAP vector of size " << size;
-      result =
-          BaseVector::create(reader_.requestedType_, size, reader_.memoryPool_);
+      result = BaseVector::create(reader_.requestedType_, size, reader_.pool_);
     }
     return *result->asUnchecked<MapVector>();
   }
@@ -502,7 +501,7 @@ void SelectiveFlatMapColumnReaderHelper<T, KeyNode, FormatData>::copyValues(
       }
     }
     if (strKeySize > 0) {
-      auto buf = AlignedBuffer::allocate<char>(strKeySize, reader_.memoryPool_);
+      auto buf = AlignedBuffer::allocate<char>(strKeySize, reader_.pool_);
       rawStrKeyBuffer = buf->template asMutable<char>();
       flatKeys->addStringBuffer(buf);
       strKeySize = 0;

--- a/velox/dwio/common/tests/SelectiveColumnReaderTest.cpp
+++ b/velox/dwio/common/tests/SelectiveColumnReaderTest.cpp
@@ -158,7 +158,7 @@ class TestColumnReader : public SelectiveColumnReader {
     const auto n = static_cast<vector_size_t>(data.size());
     anyNulls_ = true;
     resultNulls_ = AlignedBuffer::allocate<bool>(
-        n + simd::kPadding * 8, memoryPool_, bits::kNotNull);
+        n + simd::kPadding * 8, pool_, bits::kNotNull);
     rawResultNulls_ = resultNulls_->asMutable<uint64_t>();
     for (int32_t i = 0; i < n; ++i) {
       bits::setBit(rawResultNulls_, i, !nulls[i]);

--- a/velox/dwio/dwrf/reader/SelectiveDecimalColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveDecimalColumnReader.cpp
@@ -51,7 +51,7 @@ SelectiveDecimalColumnReader<DataT>::SelectiveDecimalColumnReader(
   scaleDecoder_ = createRleDecoder</*isSigned*/ true>(
       stripe.getStream(secondary, params.streamLabels().label(), true),
       version_,
-      *memoryPool_,
+      *pool_,
       stripe.getUseVInts(secondary),
       LONG_BYTE_SIZE);
 }
@@ -95,7 +95,7 @@ void SelectiveDecimalColumnReader<DataT>::readHelper(
   }
 
   // copy scales into scaleBuffer_
-  ensureCapacity<int64_t>(scaleBuffer_, numValues_, memoryPool_);
+  ensureCapacity<int64_t>(scaleBuffer_, numValues_, pool_);
   scaleBuffer_->setSize(numValues_ * sizeof(int64_t));
   memcpy(
       scaleBuffer_->asMutable<char>(),
@@ -249,7 +249,7 @@ void SelectiveDecimalColumnReader<DataT>::read(
     // Make sure a dedicated resultNulls_ is allocated with enough capacity as
     // RleDecoder always assumes it is available and 'prepareRead' skips
     // allocation when the column is not projected.
-    resultNulls_ = AlignedBuffer::allocate<bool>(rows.size(), memoryPool_);
+    resultNulls_ = AlignedBuffer::allocate<bool>(rows.size(), pool_);
     rawResultNulls_ = resultNulls_->asMutable<uint64_t>();
   }
   rawValues_ = values_->asMutable<char>();

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.cpp
@@ -45,7 +45,7 @@ SelectiveIntegerDictionaryColumnReader::SelectiveIntegerDictionaryColumnReader(
   dataReader_ = createRleDecoder</*isSigned=*/false>(
       stripe.getStream(si, params.streamLabels().label(), true),
       rleVersion_,
-      *memoryPool_,
+      *pool_,
       dataVInts,
       numBytes);
 
@@ -95,7 +95,7 @@ void SelectiveIntegerDictionaryColumnReader::read(
         ? bits::countNonNulls(nullsInReadRange_->as<uint64_t>(), 0, end)
         : end;
     dwio::common::ensureCapacity<uint64_t>(
-        scanState_.inDictionary, bits::nwords(numFlags), memoryPool_);
+        scanState_.inDictionary, bits::nwords(numFlags), pool_);
     // The in dict buffer may have changed. If no change in
     // dictionary, the raw state will not be updated elsewhere.
     scanState_.rawState.inDictionary = scanState_.inDictionary->as<uint64_t>();

--- a/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.cpp
@@ -59,7 +59,7 @@ SelectiveListColumnReader::SelectiveListColumnReader(
           fileType,
           params,
           scanSpec),
-      length_(makeLengthDecoder(*fileType_, params, *memoryPool_)) {
+      length_(makeLengthDecoder(*fileType_, params, *pool_)) {
   EncodingKey encodingKey{fileType_->id(), params.flatMapContext().sequence};
   auto& stripe = params.stripeStreams();
   // count the number of selected sub-columns
@@ -133,7 +133,7 @@ SelectiveMapColumnReader::SelectiveMapColumnReader(
           fileType,
           params,
           scanSpec),
-      length_(makeLengthDecoder(*fileType_, params, *memoryPool_)) {
+      length_(makeLengthDecoder(*fileType_, params, *pool_)) {
   makeMapChildrenReaders(
       *fileType_,
       *requestedType_,
@@ -156,7 +156,7 @@ SelectiveMapAsStructColumnReader::SelectiveMapAsStructColumnReader(
           fileType,
           params,
           scanSpec),
-      length_(makeLengthDecoder(*fileType_, params, *memoryPool_)) {
+      length_(makeLengthDecoder(*fileType_, params, *pool_)) {
   makeMapChildrenReaders(
       *fileType_,
       *requestedType_,

--- a/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
@@ -46,7 +46,7 @@ SelectiveStringDictionaryColumnReader::SelectiveStringDictionaryColumnReader(
   dictIndex_ = createRleDecoder</*isSigned*/ false>(
       stripe.getStream(dataId, params.streamLabels().label(), true),
       version_,
-      *memoryPool_,
+      *pool_,
       dictVInts,
       dwio::common::INT_BYTE_SIZE);
 
@@ -59,7 +59,7 @@ SelectiveStringDictionaryColumnReader::SelectiveStringDictionaryColumnReader(
   lengthDecoder_ = createRleDecoder</*isSigned*/ false>(
       stripe.getStream(lenId, params.streamLabels().label(), false),
       version_,
-      *memoryPool_,
+      *pool_,
       lenVInts,
       dwio::common::INT_BYTE_SIZE);
 
@@ -96,7 +96,7 @@ SelectiveStringDictionaryColumnReader::SelectiveStringDictionaryColumnReader(
     strideDictLengthDecoder_ = createRleDecoder</*isSigned*/ false>(
         stripe.getStream(strideDictLenId, params.streamLabels().label(), true),
         version_,
-        *memoryPool_,
+        *pool_,
         strideLenVInt,
         dwio::common::INT_BYTE_SIZE);
   }
@@ -118,7 +118,7 @@ void SelectiveStringDictionaryColumnReader::loadDictionary(
     DictionaryValues& values) {
   // read lengths from length reader
   dwio::common::ensureCapacity<StringView>(
-      values.values, values.numValues, memoryPool_);
+      values.values, values.numValues, pool_);
   // The lengths are read in the low addresses of the string views array.
   auto* lengths = values.values->asMutable<int32_t>();
   lengthDecoder.nextLengths(lengths, values.numValues);
@@ -127,7 +127,7 @@ void SelectiveStringDictionaryColumnReader::loadDictionary(
     stringsBytes += lengths[i];
   }
   // read bytes from underlying string
-  values.strings = AlignedBuffer::allocate<char>(stringsBytes, memoryPool_);
+  values.strings = AlignedBuffer::allocate<char>(stringsBytes, pool_);
   data.readFully(values.strings->asMutable<char>(), stringsBytes);
   // fill the values with StringViews over the strings. 'strings' will
   // exist even if 'stringsBytes' is 0, which can happen if the only
@@ -182,7 +182,7 @@ void SelectiveStringDictionaryColumnReader::makeDictionaryBaseVector() {
   if (scanState_.dictionary2.numValues) {
     BufferPtr values = AlignedBuffer::allocate<StringView>(
         scanState_.dictionary.numValues + scanState_.dictionary2.numValues,
-        memoryPool_);
+        pool_);
     auto* valuesPtr = values->asMutable<StringView>();
     memcpy(
         valuesPtr,
@@ -194,7 +194,7 @@ void SelectiveStringDictionaryColumnReader::makeDictionaryBaseVector() {
         scanState_.dictionary2.numValues * sizeof(StringView));
 
     dictionaryValues_ = std::make_shared<FlatVector<StringView>>(
-        memoryPool_,
+        pool_,
         fileType_->type(),
         BufferPtr(nullptr), // TODO nulls
         scanState_.dictionary.numValues +
@@ -204,7 +204,7 @@ void SelectiveStringDictionaryColumnReader::makeDictionaryBaseVector() {
             scanState_.dictionary.strings, scanState_.dictionary2.strings});
   } else {
     dictionaryValues_ = std::make_shared<FlatVector<StringView>>(
-        memoryPool_,
+        pool_,
         fileType_->type(),
         BufferPtr(nullptr), // TODO nulls
         scanState_.dictionary.numValues /*length*/,
@@ -230,7 +230,7 @@ void SelectiveStringDictionaryColumnReader::read(
         ? bits::countNonNulls(nullsInReadRange_->as<uint64_t>(), 0, end)
         : end;
     dwio::common::ensureCapacity<uint64_t>(
-        scanState_.inDictionary, bits::nwords(numFlags), memoryPool_);
+        scanState_.inDictionary, bits::nwords(numFlags), pool_);
     // The in dict buffer may have changed. If no change in
     // dictionary, the raw state will not be updated elsewhere.
     scanState_.rawState.inDictionary = scanState_.inDictionary->as<uint64_t>();
@@ -253,7 +253,7 @@ void SelectiveStringDictionaryColumnReader::read(
 
 void SelectiveStringDictionaryColumnReader::makeFlat(VectorPtr* result) {
   auto* indices = reinterpret_cast<const vector_size_t*>(rawValues_);
-  auto values = AlignedBuffer::allocate<StringView>(numValues_, memoryPool_);
+  auto values = AlignedBuffer::allocate<StringView>(numValues_, pool_);
   auto* stringViews = values->asMutable<StringView>();
   std::vector<BufferPtr> stringBuffers;
   auto* stripeDict = scanState_.dictionary.values->as<StringView>();
@@ -278,7 +278,7 @@ void SelectiveStringDictionaryColumnReader::makeFlat(VectorPtr* result) {
     }
   }
   *result = std::make_shared<FlatVector<StringView>>(
-      memoryPool_,
+      pool_,
       requestedType(),
       std::move(nulls),
       numValues_,
@@ -308,7 +308,7 @@ void SelectiveStringDictionaryColumnReader::getValues(
     makeDictionaryBaseVector();
   }
   *result = std::make_shared<DictionaryVector<StringView>>(
-      memoryPool_, resultNulls(), numValues_, dictionaryValues_, values_);
+      pool_, resultNulls(), numValues_, dictionaryValues_, values_);
 }
 
 void SelectiveStringDictionaryColumnReader::ensureInitialized() {

--- a/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
@@ -39,7 +39,7 @@ SelectiveStringDirectColumnReader::SelectiveStringDirectColumnReader(
   lengthDecoder_ = createRleDecoder</*isSigned*/ false>(
       stripe.getStream(lenId, params.streamLabels().label(), true),
       rleVersion,
-      *memoryPool_,
+      *pool_,
       lenVInts,
       dwio::common::INT_BYTE_SIZE);
   blobStream_ = stripe.getStream(
@@ -54,7 +54,7 @@ SelectiveStringDirectColumnReader::SelectiveStringDirectColumnReader(
 
 uint64_t SelectiveStringDirectColumnReader::skip(uint64_t numValues) {
   numValues = SelectiveColumnReader::skip(numValues);
-  dwio::common::ensureCapacity<uint32_t>(lengths_, numValues, memoryPool_);
+  dwio::common::ensureCapacity<uint32_t>(lengths_, numValues, pool_);
   lengthDecoder_->nextLengths(lengths_->asMutable<int32_t>(), numValues);
   rawLengths_ = lengths_->as<uint32_t>();
   for (auto i = 0; i < numValues; ++i) {
@@ -477,8 +477,7 @@ void SelectiveStringDirectColumnReader::read(
   auto numNulls = nullsInReadRange_
       ? BaseVector::countNulls(nullsInReadRange_, 0, numRows)
       : 0;
-  dwio::common::ensureCapacity<int32_t>(
-      lengths_, numRows - numNulls, memoryPool_);
+  dwio::common::ensureCapacity<int32_t>(lengths_, numRows - numNulls, pool_);
   lengthDecoder_->nextLengths(
       lengths_->asMutable<int32_t>(), numRows - numNulls);
   rawLengths_ = lengths_->as<uint32_t>();

--- a/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.cpp
@@ -41,7 +41,7 @@ SelectiveTimestampColumnReader::SelectiveTimestampColumnReader(
   seconds_ = createRleDecoder</*isSigned=*/true>(
       stripe.getStream(data, params.streamLabels().label(), true),
       version_,
-      *memoryPool_,
+      *pool_,
       vints,
       LONG_BYTE_SIZE);
   auto nanoData = StripeStreamsUtil::getStreamForKind(
@@ -53,7 +53,7 @@ SelectiveTimestampColumnReader::SelectiveTimestampColumnReader(
   nano_ = createRleDecoder</*isSigned=*/false>(
       stripe.getStream(nanoData, params.streamLabels().label(), true),
       version_,
-      *memoryPool_,
+      *pool_,
       nanoVInts,
       LONG_BYTE_SIZE);
 }
@@ -86,7 +86,7 @@ void SelectiveTimestampColumnReader::read(
       resultNulls_->capacity() * 8 < rows.size()) {
     // Make sure a dedicated resultNulls_ is allocated with enough capacity as
     // RleDecoder always assumes it is available.
-    resultNulls_ = AlignedBuffer::allocate<bool>(rows.size(), memoryPool_);
+    resultNulls_ = AlignedBuffer::allocate<bool>(rows.size(), pool_);
     rawResultNulls_ = resultNulls_->asMutable<uint64_t>();
   }
   bool isDense = rows.back() == rows.size() - 1;
@@ -119,8 +119,7 @@ void SelectiveTimestampColumnReader::readHelper(
 
   // Save the seconds into their own buffer before reading nanos into
   // 'values_'
-  dwio::common::ensureCapacity<uint64_t>(
-      secondsValues_, numValues_, memoryPool_);
+  dwio::common::ensureCapacity<uint64_t>(secondsValues_, numValues_, pool_);
   secondsValues_->setSize(numValues_ * sizeof(int64_t));
   memcpy(
       secondsValues_->asMutable<char>(),
@@ -141,7 +140,7 @@ void SelectiveTimestampColumnReader::readHelper(
   const auto rawNulls = nullsInReadRange_
       ? (isDense ? nullsInReadRange_->as<uint64_t>() : rawResultNulls_)
       : nullptr;
-  auto tsValues = AlignedBuffer::allocate<Timestamp>(numValues_, memoryPool_);
+  auto tsValues = AlignedBuffer::allocate<Timestamp>(numValues_, pool_);
   auto rawTs = tsValues->asMutable<Timestamp>();
 
   for (vector_size_t i = 0; i < numValues_; i++) {

--- a/velox/dwio/parquet/reader/RepeatedColumnReader.cpp
+++ b/velox/dwio/parquet/reader/RepeatedColumnReader.cpp
@@ -171,10 +171,10 @@ void MapColumnReader::setLengthsFromRepDefs(PageReader& pageReader) {
   auto repDefRange = pageReader.repDefRange();
   int32_t numRepDefs = repDefRange.second - repDefRange.first;
   BufferPtr lengths = std::move(lengths_.lengths());
-  dwio::common::ensureCapacity<int32_t>(lengths, numRepDefs, memoryPool_);
+  dwio::common::ensureCapacity<int32_t>(lengths, numRepDefs, pool_);
   memset(lengths->asMutable<uint64_t>(), 0, lengths->size());
   dwio::common::ensureCapacity<uint64_t>(
-      nullsInReadRange_, bits::nwords(numRepDefs), memoryPool_);
+      nullsInReadRange_, bits::nwords(numRepDefs), pool_);
   auto numLists = pageReader.getLengthsAndNulls(
       LevelMode::kList,
       levelInfo_,
@@ -280,10 +280,10 @@ void ListColumnReader::setLengthsFromRepDefs(PageReader& pageReader) {
   auto repDefRange = pageReader.repDefRange();
   int32_t numRepDefs = repDefRange.second - repDefRange.first;
   BufferPtr lengths = std::move(lengths_.lengths());
-  dwio::common::ensureCapacity<int32_t>(lengths, numRepDefs + 1, memoryPool_);
+  dwio::common::ensureCapacity<int32_t>(lengths, numRepDefs + 1, pool_);
   memset(lengths->asMutable<uint64_t>(), 0, lengths->size());
   dwio::common::ensureCapacity<uint64_t>(
-      nullsInReadRange_, bits::nwords(numRepDefs + 1), memoryPool_);
+      nullsInReadRange_, bits::nwords(numRepDefs + 1), pool_);
   auto numLists = pageReader.getLengthsAndNulls(
       LevelMode::kList,
       levelInfo_,

--- a/velox/dwio/parquet/reader/StringColumnReader.cpp
+++ b/velox/dwio/parquet/reader/StringColumnReader.cpp
@@ -50,7 +50,7 @@ void StringColumnReader::getValues(const RowSet& rows, VectorPtr* result) {
     compactScalarValues<int32_t, int32_t>(rows, false);
 
     *result = std::make_shared<DictionaryVector<StringView>>(
-        memoryPool_, resultNulls(), numValues_, dictionaryValues, values_);
+        pool_, resultNulls(), numValues_, dictionaryValues, values_);
     return;
   }
   rawStringBuffer_ = nullptr;

--- a/velox/dwio/parquet/reader/StructColumnReader.cpp
+++ b/velox/dwio/parquet/reader/StructColumnReader.cpp
@@ -186,7 +186,7 @@ void StructColumnReader::setNullsFromRepDefs(PageReader& pageReader) {
   auto repDefRange = pageReader.repDefRange();
   int32_t numRepDefs = repDefRange.second - repDefRange.first;
   dwio::common::ensureCapacity<uint64_t>(
-      nullsInReadRange_, bits::nwords(numRepDefs), memoryPool_);
+      nullsInReadRange_, bits::nwords(numRepDefs), pool_);
   auto numStructs = pageReader.getLengthsAndNulls(
       levelMode_,
       levelInfo_,


### PR DESCRIPTION
Summary:
Rename the protected member `memoryPool_` to `pool_` across the `SelectiveColumnReader` class hierarchy. The public accessor `memoryPool()` retains its name so external callers are unaffected.

This is a mechanical rename across 21 files spanning Velox common, DWRF selective readers, Parquet readers, and Nimble selective readers. The DWRF non-selective `ColumnReader` hierarchy has its own separate `memoryPool_` member and is intentionally left unchanged.

Differential Revision: D101539025


