### PR TITLE
fix: Remove duplicate TDigestAccumulator causing ODR violation and SIGSEGV (#17247)

### DIFF
--- a/velox/functions/prestosql/aggregates/MergeTDigestAggregate.h
+++ b/velox/functions/prestosql/aggregates/MergeTDigestAggregate.h
@@ -17,39 +17,11 @@
 #pragma once
 
 #include "velox/exec/Aggregate.h"
-#include "velox/functions/lib/TDigest.h"
+#include "velox/functions/prestosql/aggregates/TDigestAccumulator.h"
 #include "velox/vector/DecodedVector.h"
 #include "velox/vector/FlatVector.h"
 
 namespace facebook::velox::aggregate::prestosql {
-
-// TDigest accumulator for merge operations
-struct TDigestAccumulator {
-  explicit TDigestAccumulator(HashStringAllocator* allocator)
-      : digest_(StlAllocator<double>(allocator)) {}
-
-  void mergeWith(
-      StringView serialized,
-      HashStringAllocator* /*allocator*/,
-      std::vector<int16_t>& positions) {
-    if (serialized.empty()) {
-      return;
-    }
-    digest_.mergeDeserialized(positions, serialized.data());
-  }
-
-  int64_t serializedSize(std::vector<int16_t>& positions) {
-    digest_.compress(positions);
-    return digest_.serializedByteSize();
-  }
-
-  void serialize(char* outputBuffer) {
-    digest_.serialize(outputBuffer);
-  }
-
- private:
-  facebook::velox::functions::TDigest<StlAllocator<double>> digest_;
-};
 
 class MergeTDigestAggregate : public exec::Aggregate {
  public:
@@ -98,15 +70,16 @@ class MergeTDigestAggregate : public exec::Aggregate {
         [&](TDigestAccumulator* accumulator,
             FlatVector<StringView>* result,
             vector_size_t index) {
-          auto size = accumulator->serializedSize(positions);
+          accumulator->digest.compress(positions);
+          auto size = accumulator->digest.serializedByteSize();
           StringView serialized;
           if (StringView::isInline(size)) {
             std::string buffer(size, '\0');
-            accumulator->serialize(buffer.data());
+            accumulator->digest.serialize(buffer.data());
             serialized = StringView::makeInline(buffer);
           } else {
             char* rawBuffer = flatResult->getRawStringBufferWithSpace(size);
-            accumulator->serialize(rawBuffer);
+            accumulator->digest.serialize(rawBuffer);
             serialized = StringView(rawBuffer, size);
           }
           result->setNoCopy(index, serialized);
@@ -191,8 +164,11 @@ class MergeTDigestAggregate : public exec::Aggregate {
       const vector_size_t row,
       std::vector<int16_t>& positions) {
     auto serialized = decodedTDigest_.valueAt<StringView>(row);
-    TDigestAccumulator* accumulator = value<TDigestAccumulator>(group);
-    accumulator->mergeWith(serialized, allocator_, positions);
+    if (serialized.empty()) {
+      return;
+    }
+    auto* accumulator = value<TDigestAccumulator>(group);
+    accumulator->digest.mergeDeserialized(positions, serialized.data());
   }
 
   template <typename ExtractResult, typename ExtractFunc>

--- a/velox/functions/prestosql/aggregates/tests/MergeAggregateTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MergeAggregateTest.cpp
@@ -20,6 +20,7 @@
 #include "velox/functions/lib/TDigest.h"
 #include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
 #include "velox/functions/lib/sfm/SfmSketch.h"
+#include "velox/functions/prestosql/aggregates/TDigestAccumulator.h"
 #include "velox/functions/prestosql/types/QDigestRegistration.h"
 #include "velox/functions/prestosql/types/QDigestType.h"
 #include "velox/functions/prestosql/types/SfmSketchRegistration.h"
@@ -32,6 +33,16 @@ using namespace facebook::velox::exec::test;
 using namespace facebook::velox::functions::aggregate::test;
 using namespace facebook::velox::functions::qdigest;
 using SfmSketchIn = facebook::velox::functions::sfm::SfmSketch;
+
+// Verify that TDigestAccumulator has a single, consistent definition. A
+// duplicate struct in the same namespace with a different layout would cause an
+// ODR violation, leading to memory corruption and SIGSEGV during aggregate
+// cleanup (see D101577660).
+static_assert(
+    sizeof(facebook::velox::aggregate::prestosql::TDigestAccumulator) ==
+    sizeof(double) +
+        sizeof(facebook::velox::functions::TDigest<
+               facebook::velox::StlAllocator<double>>));
 
 namespace facebook::velox::aggregate::test {
 namespace {


### PR DESCRIPTION
Summary:

D100855055 introduced TDigestAccumulator.h with layout {double compression, TDigest digest} and updated TDigestAggregate.cpp to use it, but did NOT update MergeTDigestAggregate.h. This left two conflicting TDigestAccumulator structs in the same namespace (facebook::velox::aggregate::prestosql) with different memory layouts.

Both translation units instantiate the template Aggregate::destroyAccumulators<TDigestAccumulator> as weak symbols. The linker deduplicates to one instantiation, which uses the wrong sizeof(T) for one of the two callers. The memset in destroyAccumulators writes past the end of the accumulator, corrupting adjacent memory.

Crash chain in production:
1. Query uses merge(CAST(tdigest_... AS tdigest(double))) triggering MergeTDigestAggregate
2. TDigest compression_ reads as 0 (should be 100) due to wrong struct layout offsets
3. VELOX_USER_CHECK_EQ throws: "100 vs. 0 Cannot merge TDigests with different compression parameters"
4. During cleanup, ~TDigest() calls HashStringAllocator::freeToPool() which hits SIGSEGV — memory corrupted by wrong-sized memset

Fix: Remove the duplicate TDigestAccumulator from MergeTDigestAggregate.h and include TDigestAccumulator.h instead. Update member access from digest_ (private) to digest (public).

Reviewed By: natashasehgal, talgalili

Differential Revision: D101577660


