### PR TITLE
Fix ARRAY_FREQUENCY for NaN values

### DIFF
--- a/velox/functions/prestosql/ArrayFunctions.h
+++ b/velox/functions/prestosql/ArrayFunctions.h
@@ -607,7 +607,8 @@ struct ArrayFrequencyFunction {
   }
 
  private:
-  folly::F14FastMap<arg_type<T>, int> frequencyCount_;
+  typename util::floating_point::HashMapNaNAwareTypeTraits<arg_type<T>, int>::
+      Type frequencyCount_;
 };
 
 template <typename TExecParams, typename T>

--- a/velox/functions/prestosql/tests/ArrayFrequencyTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayFrequencyTest.cpp
@@ -103,4 +103,29 @@ TEST_F(ArrayFrequencyTest, varcharArrayWithoutNull) {
   testArrayFrequency(expected, array);
 }
 
+TEST_F(ArrayFrequencyTest, floatArrayWithNaN) {
+  auto array = makeNullableArrayVector<float>(
+      {{std::nanf(""), std::nanf(""), std::nanf("")},
+       {1.0f, std::nanf(""), 2.0f, 1.0f},
+       {std::nanf(""), 1.0f}});
+
+  auto expected = makeMapVector<float, int>(
+      {{{std::nanf(""), 3}},
+       {{1.0f, 2}, {std::nanf(""), 1}, {2.0f, 1}},
+       {{std::nanf(""), 1}, {1.0f, 1}}});
+
+  testArrayFrequency(expected, array);
+}
+
+TEST_F(ArrayFrequencyTest, doubleArrayWithNaN) {
+  auto array = makeNullableArrayVector<double>(
+      {{std::nan(""), std::nan(""), std::nan("")},
+       {1.0, std::nan(""), 2.0, 1.0}});
+
+  auto expected = makeMapVector<double, int>(
+      {{{std::nan(""), 3}}, {{1.0, 2}, {std::nan(""), 1}, {2.0, 1}}});
+
+  testArrayFrequency(expected, array);
+}
+
 } // namespace facebook::velox::functions::test


### PR DESCRIPTION
Summary:
Use NaN-aware hash and equality in ArrayFrequencyFunction to correctly handle IEEE 754 NaN values in floating-point arrays.

ArrayFrequencyFunction uses an F14FastMap internally. Under standard hash/equality, NaN != NaN, so NaN entries are silently dropped from the frequency map. This caused a production data warehouse pipeline crash when the result was an empty map and downstream code accessed [1] on it.

The fix uses HashMapNaNAwareTypeTraits from FloatingPointUtil.h, which automatically selects NaN-aware hash/equality for float/double types and default hash/equality for all other types. This pattern is already used by other array functions like ArrayUnionFunction.

Differential Revision: D101338894


