### PR TITLE
perf(simd): Add arch-aware boolean mask helpers

### DIFF
--- a/velox/common/base/SimdUtil.h
+++ b/velox/common/base/SimdUtil.h
@@ -367,6 +367,29 @@ auto toBitMask(xsimd::batch_bool<T, A> mask, const A& arch = {}) {
   return detail::BitMask<T, A>::toBitMask(mask, arch);
 }
 
+/// Returns true if at least one lane in the mask is true.
+template <typename T, typename A = xsimd::default_arch>
+inline bool any(xsimd::batch_bool<T, A> mask, const A& arch = {}) {
+#if XSIMD_WITH_AVX2
+  // x86 bitmasks perform better than xsimd reductions.
+  return toBitMask<T, A>(mask, arch) != 0;
+#else
+  (void)arch;
+  return xsimd::any<T, A>(mask);
+#endif
+}
+
+/// Returns true if no lanes in the mask are true.
+template <typename T, typename A = xsimd::default_arch>
+inline bool none(xsimd::batch_bool<T, A> mask, const A& arch = {}) {
+#if XSIMD_WITH_AVX2
+  return toBitMask<T, A>(mask, arch) == 0;
+#else
+  (void)arch;
+  return xsimd::none<T, A>(mask);
+#endif
+}
+
 // Get a vector mask from bit mask.
 template <typename T, typename BitMaskType, typename A = xsimd::default_arch>
 xsimd::batch_bool<T, A> fromBitMask(BitMaskType bitMask, const A& arch = {}) {
@@ -378,6 +401,17 @@ xsimd::batch_bool<T, A> fromBitMask(BitMaskType bitMask, const A& arch = {}) {
 template <typename T, typename A = xsimd::default_arch>
 auto allSetBitMask(const A& = {}) {
   return detail::BitMask<T, A>::kAllSet;
+}
+
+/// Returns true if every lane in the mask is true.
+template <typename T, typename A = xsimd::default_arch>
+inline bool all(xsimd::batch_bool<T, A> mask, const A& arch = {}) {
+#if XSIMD_WITH_AVX2
+  return toBitMask<T, A>(mask, arch) == allSetBitMask<T>(arch);
+#else
+  (void)arch;
+  return xsimd::all<T, A>(mask);
+#endif
 }
 
 namespace detail {

--- a/velox/common/memory/MmapAllocator.cpp
+++ b/velox/common/memory/MmapAllocator.cpp
@@ -677,8 +677,7 @@ bool MmapAllocator::SizeClass::allocateLocked(
 
 namespace {
 bool isAllZero(xsimd::batch<uint64_t> bits) {
-  return simd::allSetBitMask<uint64_t>() ==
-      simd::toBitMask(bits == xsimd::broadcast<uint64_t>(0));
+  return simd::all(bits == xsimd::broadcast<uint64_t>(0));
 }
 } // namespace
 

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -242,8 +242,7 @@ class ProbeState {
     int64_t numProbedBuckets = 0;
     while (numProbedBuckets < table.numBuckets()) {
       if (!hits_) {
-        const uint16_t empty = simd::toBitMask(tagsInTable_ == kEmptyGroup);
-        if (empty) {
+        if (simd::any(tagsInTable_ == kEmptyGroup)) {
           return nullptr;
         }
       } else {
@@ -283,8 +282,7 @@ class ProbeState {
   template <typename Table>
   void eraseHit(Table& table, int64_t& numTombstones) {
     const auto kEmptyGroup = BaseHashTable::TagVector::broadcast(kEmptyTag);
-    const bool hasEmptyGroup =
-        simd::toBitMask(tagsInTable_ == kEmptyGroup) != 0;
+    const bool hasEmptyGroup = simd::any(tagsInTable_ == kEmptyGroup);
 
     table.bucketAt(bucketOffset_)
         ->setTag(indexInTags_, hasEmptyGroup ? 0 : kTombstoneTag);

--- a/velox/exec/VectorHasher-inl.h
+++ b/velox/exec/VectorHasher-inl.h
@@ -28,14 +28,14 @@ bool VectorHasher::tryMapToRangeSimd(
   constexpr int kWidth = xsimd::batch<T>::size;
   for (; row + kWidth <= rows.end(); row += kWidth) {
     auto data = xsimd::load_unaligned(values + row);
-    int32_t gtMax = simd::toBitMask(data > allHigh);
-    int32_t ltMin = simd::toBitMask(data < allLow);
+    bool gtMax = simd::any(data > allHigh);
+    bool ltMin = simd::any(data < allLow);
     // value - (low - 1) doesn't work when low is the lowest possible (e.g.
     // std::numeric_limits<int64_t>::min())
     if constexpr (sizeof(T) == sizeof(uint64_t)) {
       (data - allLow + allOne).store_unaligned(result + row);
     }
-    if ((gtMax | ltMin) != 0) {
+    if (gtMax || ltMin) {
       inRange = false;
       break;
     }

--- a/velox/serializers/KeyEncoder.cpp
+++ b/velox/serializers/KeyEncoder.cpp
@@ -245,9 +245,9 @@ encodeString(const char* data, size_t size, bool descending, char*& out) {
 
       // Check which bytes need escaping (are 0 or 1)
       const auto needsEscape = (batch == zero) | (batch == one);
-      const auto escapeMask = simd::toBitMask(needsEscape);
+      const auto hasEscapes = !simd::none(needsEscape);
 
-      if (escapeMask == 0) {
+      if (!hasEscapes) {
         // Fast path: no bytes need escaping, bulk copy the entire batch
         // Apply descending transformation branchlessly (no-op if xorBatch is
         // all zeros)

--- a/velox/type/Filter.h
+++ b/velox/type/Filter.h
@@ -1050,7 +1050,7 @@ class BigintValuesUsingHashTable final : public Filter {
   xsimd::batch_bool<int64_t> testValues(xsimd::batch<int64_t> x) const final {
     auto outOfRange = (x < xsimd::broadcast<int64_t>(min_)) |
         (x > xsimd::broadcast<int64_t>(max_));
-    if (simd::toBitMask(outOfRange) == simd::allSetBitMask<int64_t>()) {
+    if (simd::all(outOfRange)) {
       return xsimd::batch_bool<int64_t>(false);
     }
     if (containsEmptyMarker_) {
@@ -1090,11 +1090,11 @@ class BigintValuesUsingHashTable final : public Filter {
       for (;;) {
         auto line = xsimd::load_unaligned(hashTable_.data() + index);
 
-        if (simd::toBitMask(line == allValue)) {
+        if (simd::any(line == allValue)) {
           resultBits |= 1 << lane;
           break;
         }
-        if (simd::toBitMask(line == allEmpty)) {
+        if (simd::any(line == allEmpty)) {
           resultBits &= ~(1 << lane);
           break;
         }


### PR DESCRIPTION
Added simd::any, simd::none, and simd::all in SimdUtil.h for boolean-only SIMD mask checks.

On AArch64, these helpers use xsimd::any/none/all directly. On x86, they preserve the
previous behavior by reducing through simd::toBitMask so code generation stays aligned
with the original path.

On Arm Neon, xsimd::any is one instruction: vmaxvq_u64, whereas simd::toBitMask is two
instructions: vandq_u64 + vaddvq_u64. On x86 AVX2, both are only one instruction, and
our experiment shows simd::toBitMask gives a better performance on AVX2 due to better
further optimization by the compiler. So, this PR only changes what's used outside x86.
We have verified that the instructions generated on x86 remain unchanged.

Switch the boolean-only toBitMask call sites in:

MmapAllocator
HashTable
VectorHasher-inl
KeyEncoder
Filter

Leaving toBitMask unchanged at sites that still need exact lane masks for bit operations such
as ctz, popcount, filtering, or packed-bit writes.

This improves performance on Arm for the relevant boolean-only reduction paths, while
preserving the previous x86 behavior.
