### PR TITLE
fix: HashAggregation with preGroupedKeys drops distinct rows on batch boundaries (#17264)

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -178,6 +178,7 @@ bool equalKeys(
 } // namespace
 
 void GroupingSet::addInput(const RowVectorPtr& input, bool mayPushdown) {
+  drainedNewGroups_ = {};
   if (isGlobal_) {
     addGlobalAggregationInput(input, mayPushdown);
     return;
@@ -211,6 +212,7 @@ void GroupingSet::addInput(const RowVectorPtr& input, bool mayPushdown) {
 }
 
 void GroupingSet::noMoreInput() {
+  drainedNewGroups_ = {};
   noMoreInput_ = true;
 
   if (remainingInput_) {
@@ -358,6 +360,23 @@ void GroupingSet::addRemainingInput() {
   activeRows_.updateBounds();
 
   addInputForActiveRows(remainingInput_, remainingMayPushdown_);
+
+  if (isDistinct() && !preGroupedKeyChannels_.empty()) {
+    // Pre-grouped distinct aggregation does not currently spill
+    // (AggregationNode::canSpill returns false when preGroupedKeys is
+    // non-empty; see velox#3264). The captured row pointers below
+    // reference table_->rows() and would dangle after table_->clear() in
+    // any spill path. If spill becomes enabled here, restore a
+    // materialize-before-clear path or otherwise preserve these rows.
+    VELOX_CHECK(!hasSpilled());
+    const auto& newGroups = lookup_->newGroups;
+    drainedNewGroups_.clear();
+    drainedNewGroups_.reserve(newGroups.size());
+    for (auto idx : newGroups) {
+      drainedNewGroups_.push_back(lookup_->hits[idx]);
+    }
+  }
+
   remainingInput_.reset();
 }
 
@@ -851,6 +870,30 @@ void GroupingSet::extractGroups(
       aggregation->extractValues(groups, result);
     }
   }
+}
+
+bool GroupingSet::hasDrainedNewGroups() const {
+  return !drainedNewGroups_.empty();
+}
+
+vector_size_t GroupingSet::drainedNewGroupsCount() const {
+  return static_cast<vector_size_t>(drainedNewGroups_.size());
+}
+
+void GroupingSet::extractDrainedNewGroups(const RowVectorPtr& result) {
+  VELOX_CHECK(isDistinct());
+  VELOX_DCHECK(!drainedNewGroups_.empty());
+  result->resize(drainedNewGroups_.size());
+  auto* rowContainer = table_->rows();
+  for (vector_size_t i = 0; i < result->childrenSize(); ++i) {
+    auto& keyVector = result->childAt(i);
+    rowContainer->extractColumn(
+        drainedNewGroups_.data(),
+        drainedNewGroups_.size(),
+        groupingKeyOutputProjections_[i],
+        keyVector);
+  }
+  drainedNewGroups_.clear();
 }
 
 void GroupingSet::resetTable(bool freeTable) {

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -114,6 +114,18 @@ class GroupingSet {
 
   const HashLookup& hashLookup() const;
 
+  /// Returns true if there are pending new-group rows from the most recent
+  /// tail auto-drain that have not yet been consumed.
+  bool hasDrainedNewGroups() const;
+
+  /// Returns the number of pending drained new-group rows.
+  vector_size_t drainedNewGroupsCount() const;
+
+  /// Extracts the pending drained new-group rows into 'result' by reading
+  /// directly from row-container pointers. Clears the pending state after
+  /// extraction.
+  void extractDrainedNewGroups(const RowVectorPtr& result);
+
   /// Spills all the rows in container.
   void spill();
 
@@ -376,6 +388,12 @@ class GroupingSet {
 
   // First row in remainingInput_ that needs to be processed.
   vector_size_t firstRemainingRow_;
+
+  // Populated by addRemainingInput(); reset at top of addInput()/noMoreInput().
+  // Pointers reference table_->rows() and remain valid only while no spill
+  // path runs. Pre-grouped distinct aggregation does not currently spill, so
+  // the row container is not cleared between capture and consumption.
+  std::vector<char*> drainedNewGroups_;
 
   // In case of distinct aggregation without aggregates and the grouping key
   // reordered, the spilled data is first loaded into

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -354,7 +354,7 @@ RowVectorPtr HashAggregation::getOutput() {
   // - distinct aggregation has new keys;
   // - running in partial streaming mode and have some output ready.
   if (!noMoreInput_ && !partialFull_ && !newDistincts_ &&
-      !groupingSet_->hasOutput()) {
+      !groupingSet_->hasDrainedNewGroups() && !groupingSet_->hasOutput()) {
     input_ = nullptr;
     return nullptr;
   }
@@ -389,6 +389,15 @@ RowVectorPtr HashAggregation::getOutput() {
 RowVectorPtr HashAggregation::getDistinctOutput() {
   VELOX_CHECK(isDistinct_);
   VELOX_CHECK(!finished_);
+
+  if (groupingSet_->hasDrainedNewGroups()) {
+    auto size = groupingSet_->drainedNewGroupsCount();
+    prepareOutput(size);
+    groupingSet_->extractDrainedNewGroups(output_);
+    numOutputRows_ += size;
+    resetPartialOutputIfNeed();
+    return output_;
+  }
 
   if (newDistincts_) {
     VELOX_CHECK_NOT_NULL(input_);

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -2443,6 +2443,52 @@ TEST_F(AggregationTest, spillPrefixSortOptimization) {
   }
 }
 
+TEST_F(AggregationTest, distinctWithProperPrefixPreGroupedKeys) {
+  std::vector<RowVectorPtr> vectors;
+  vectors.push_back(makeRowVector({
+      makeFlatVector<int64_t>({0, 0, 1, 1, 2}),
+      makeFlatVector<int64_t>({0, 1, 10, 11, 20}),
+  }));
+  createDuckDbTable(vectors);
+  auto plan = PlanBuilder()
+                  .values(vectors)
+                  .aggregation(
+                      {"c0", "c1"},
+                      {"c0"},
+                      {},
+                      {},
+                      core::AggregationNode::Step::kSingle,
+                      false)
+                  .planNode();
+  AssertQueryBuilder(plan, duckDbQueryRunner_)
+      .assertResults("SELECT DISTINCT c0, c1 FROM tmp");
+}
+
+TEST_F(AggregationTest, distinctWithPreGroupedKeysAcrossBatches) {
+  std::vector<RowVectorPtr> vectors;
+  vectors.push_back(makeRowVector({
+      makeFlatVector<int64_t>({0, 0, 1, 1}),
+      makeFlatVector<int64_t>({0, 1, 10, 11}),
+  }));
+  vectors.push_back(makeRowVector({
+      makeFlatVector<int64_t>({1, 1, 2, 2}),
+      makeFlatVector<int64_t>({12, 13, 20, 21}),
+  }));
+  createDuckDbTable(vectors);
+  auto plan = PlanBuilder()
+                  .values(vectors)
+                  .aggregation(
+                      {"c0", "c1"},
+                      {"c0"},
+                      {},
+                      {},
+                      core::AggregationNode::Step::kSingle,
+                      false)
+                  .planNode();
+  AssertQueryBuilder(plan, duckDbQueryRunner_)
+      .assertResults("SELECT DISTINCT c0, c1 FROM tmp");
+}
+
 TEST_F(AggregationTest, preGroupedAggregationWithSpilling) {
   std::vector<RowVectorPtr> vectors;
   int64_t val = 0;


### PR DESCRIPTION
Summary:

Distinct `HashAggregation` with `preGroupedKeys` as a proper prefix of `groupingKeys` silently drops rows whose pre-grouped key spans a batch boundary. The auto-drain populates `HashLookup::newGroups` for the deferred tail, but the next batch's `prepareForGroupProbe()` clobbers it before `getOutput` can read it.

Fix: capture the tail's row pointers into a new `drainedNewGroups_` field (`std::vector<char*>` into the `RowContainer`) inside `addRemainingInput()`, and emit them from `HashAggregation::getDistinctOutput` ahead of the `newDistincts_` path via a new `extractDistinctKeys()` helper.

Spill safety: `AggregationNode::canSpill` returns false when `preGroupedKeys` is non-empty (velox#3264), so `table_->clear()` never runs between capture and consumption and the captured pointers cannot dangle. The capture site asserts this with `VELOX_CHECK(!hasSpilled())` so any future change to enable spill on this path fails loudly.

Reviewed By: tanjialiang, Yuhta

Differential Revision: D101458612


