### PR TITLE
feat: Make Spark CAST(string as REAL/DOUBLE) ANSI-compliant

### DIFF
--- a/velox/docs/functions/spark/conversion.rst
+++ b/velox/docs/functions/spark/conversion.rst
@@ -181,6 +181,43 @@ Invalid examples
   SELECT cast(cast('2025-02-25 08:00:26.88' as timestamp) as smallint); -- NULL (ANSI OFF) / ERROR (ANSI ON)
   SELECT cast(cast('2025-02-25 08:00:26.88' as timestamp) as tinyint); -- NULL (ANSI OFF) / ERROR (ANSI ON)
 
+Cast to Floating-Point Types
+----------------------------
+
+From strings
+^^^^^^^^^^^^
+
+*(ANSI compliant)*
+
+Casting a string to ``REAL`` or ``DOUBLE`` accepts decimal and scientific
+notation, an optional leading sign, and the case-insensitive special literals
+``nan``, ``inf``, ``infinity`` (optionally signed). Values that overflow the
+target type produce ``Infinity`` rather than an error, matching Spark.
+
+Casting from invalid strings returns NULL when ANSI mode is disabled; throws an
+error otherwise.
+
+Valid examples
+
+::
+
+  SELECT cast('1.5' as double); -- 1.5
+  SELECT cast('-3.14E-2' as real); -- -0.0314
+  SELECT cast('1.5e10' as double); -- 1.5E10
+  SELECT cast('nan' as double); -- NaN (case insensitive)
+  SELECT cast('-Infinity' as double); -- -Infinity (case insensitive)
+  SELECT cast('1e39' as real); -- Infinity (overflow)
+  SELECT cast('1e309' as double); -- Infinity (overflow)
+
+Invalid examples
+
+::
+
+  SELECT cast('abc' as double); -- NULL (ANSI OFF) / ERROR (ANSI ON)
+  SELECT cast('1.2a' as double); -- NULL (ANSI OFF) / ERROR (ANSI ON)
+  SELECT cast('1.2.3' as real); -- NULL (ANSI OFF) / ERROR (ANSI ON)
+  SELECT cast('' as double); -- NULL (ANSI OFF) / ERROR (ANSI ON)
+
 Cast to Boolean
 ---------------
 

--- a/velox/functions/sparksql/specialforms/SparkCastExpr.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastExpr.cpp
@@ -24,19 +24,30 @@ bool isIntegralType(const TypePtr& type) {
       type == BIGINT();
 }
 
+bool isFloatingPointType(const TypePtr& type) {
+  return type == REAL() || type == DOUBLE();
+}
+
 } // namespace
 
 bool SparkCastCallToSpecialForm::isAnsiSupported(
     const TypePtr& fromType,
     const TypePtr& toType) {
-  // String to Boolean, Integer, or Date types support ANSI mode.
   if (fromType->isVarchar()) {
+    // String to Boolean or Date types support ANSI mode.
     if (toType->isBoolean() || toType->isDate()) {
       return true;
     }
     if (isIntegralType(toType)) {
       // For string-to-integral casts, ANSI mode rejects invalid formats (e.g.
       // decimal points) instead of returning NULL.
+      return true;
+    }
+    // String to float/double casts support ANSI mode (invalid format strings
+    // throw instead of returning NULL). Note: allowOverflow_ will also be false
+    // when ANSI is active, but castStringToReal/Double correctly produce
+    // Infinity for overflow per Spark semantics without consulting truncate().
+    if (isFloatingPointType(toType)) {
       return true;
     }
   }

--- a/velox/functions/sparksql/specialforms/SparkCastExpr.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastExpr.cpp
@@ -125,6 +125,12 @@ bool SparkCastCallToSpecialForm::isAnsiSupported(
       // decimal points) instead of returning NULL.
       return true;
     }
+    // String to float/double casts support ANSI mode: invalid format strings
+    // throw instead of returning NULL. Overflow values like "1e39" produce
+    // Infinity per Spark semantics.
+    if (isFloatingPointType(toType)) {
+      return true;
+    }
   }
   if (fromType->isTimestamp() && isIntegralType(toType)) {
     return true;

--- a/velox/functions/sparksql/specialforms/SparkCastExpr.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastExpr.cpp
@@ -125,9 +125,6 @@ bool SparkCastCallToSpecialForm::isAnsiSupported(
       // decimal points) instead of returning NULL.
       return true;
     }
-    // String to float/double casts support ANSI mode: invalid format strings
-    // throw instead of returning NULL. Overflow values like "1e39" produce
-    // Infinity per Spark semantics.
     if (isFloatingPointType(toType)) {
       return true;
     }

--- a/velox/functions/sparksql/specialforms/SparkCastExpr.h
+++ b/velox/functions/sparksql/specialforms/SparkCastExpr.h
@@ -47,6 +47,9 @@ class SparkCastCallToSpecialForm : public exec::CastCallToSpecialForm {
 
  private:
   /// Determines if ANSI mode is supported for casting from fromType to toType.
+  /// Currently supported:
+  ///   - varchar -> boolean, date, integral (existing)
+  ///   - varchar -> float/double (invalid-format errors)
   /// TODO: Remove this function once all cast operations support ANSI mode.
   /// @param fromType The source type of the cast
   /// @param toType The target type of the cast

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -1592,5 +1592,154 @@ TEST_F(SparkCastExprTestAnsiOff, overflow) {
 TEST_F(SparkCastExprTestAnsiOff, recursiveTryCast) {
   testRecursiveTryCast();
 }
+
+// ============================================================================
+// ANSI ON — String to Float/Double Tests
+// ============================================================================
+
+TEST_F(SparkCastExprTestAnsiOn, stringToRealDoubleAnsiInvalidThrows) {
+  auto testThrows = [this](
+                        const std::string& type,
+                        const std::string& value,
+                        const std::string& errorFragment) {
+    auto input = makeRowVector({makeFlatVector<std::string>({value})});
+    VELOX_ASSERT_THROW(
+        (evaluate(fmt::format("cast(c0 as {})", type), input)), errorFragment);
+  };
+
+  // Invalid format strings should throw in ANSI mode.
+  testThrows("real", "abc", "Number format error");
+  testThrows("real", "1.2a", "Number format error");
+  testThrows("real", "1.2.3", "Number format error");
+  testThrows("double", "abc", "Number format error");
+  testThrows("double", "1.2.3", "Number format error");
+  testThrows("double", "xyz123", "Number format error");
+
+  // Empty strings throw a different error message.
+  testThrows("real", "", "Empty string");
+  testThrows("double", "", "Empty string");
+
+  // Whitespace-only strings trim to empty and should also throw.
+  testThrows("real", "   ", "Empty string");
+  testThrows("double", "   ", "Empty string");
+  testThrows("real", "\t\n", "Empty string");
+  testThrows("double", "\t\n", "Empty string");
+}
+
+TEST_F(SparkCastExprTestAnsiOn, stringToRealDoubleAnsiValidFormats) {
+  auto kNan = std::numeric_limits<float>::quiet_NaN();
+  auto kInf = std::numeric_limits<float>::infinity();
+  auto kDNan = std::numeric_limits<double>::quiet_NaN();
+  auto kDInf = std::numeric_limits<double>::infinity();
+
+  // Basic valid values.
+  testCast<std::string, float>("real", {"1.5"}, {1.5f});
+  testCast<std::string, double>("double", {"1.5"}, {1.5});
+
+  // Special literals (case variants).
+  testCast<std::string, float>("real", {"nan"}, {kNan});
+  testCast<std::string, float>("real", {"NaN"}, {kNan});
+  testCast<std::string, float>("real", {"infinity"}, {kInf});
+  testCast<std::string, float>("real", {"Infinity"}, {kInf});
+  testCast<std::string, float>("real", {"-infinity"}, {-kInf});
+  testCast<std::string, float>("real", {"-Infinity"}, {-kInf});
+  testCast<std::string, double>("double", {"nan"}, {kDNan});
+  testCast<std::string, double>("double", {"NaN"}, {kDNan});
+  testCast<std::string, double>("double", {"infinity"}, {kDInf});
+  testCast<std::string, double>("double", {"Infinity"}, {kDInf});
+  testCast<std::string, double>("double", {"-infinity"}, {-kDInf});
+  testCast<std::string, double>("double", {"-Infinity"}, {-kDInf});
+
+  // Scientific notation.
+  testCast<std::string, float>("real", {"1.5e2"}, {150.0f});
+  testCast<std::string, float>("real", {"-3.14E-2"}, {-0.0314f});
+  testCast<std::string, double>("double", {"1.5e10"}, {1.5e10});
+  testCast<std::string, double>("double", {"-3.14E-5"}, {-3.14e-5});
+
+  // Signed values and zeros.
+  testCast<std::string, float>("real", {"+1.5"}, {1.5f});
+  testCast<std::string, float>("real", {"-1.5"}, {-1.5f});
+  testCast<std::string, float>("real", {"+0"}, {0.0f});
+  testCast<std::string, float>("real", {"-0"}, {-0.0f});
+  testCast<std::string, double>("double", {"+1.5"}, {1.5});
+  testCast<std::string, double>("double", {"-0"}, {-0.0});
+
+  // Overflow → Infinity (not error, per Spark behavior).
+  testCast<std::string, float>("real", {"1e39"}, {kInf});
+  testCast<std::string, float>("real", {"-1e39"}, {-kInf});
+  testCast<std::string, double>("double", {"1e309"}, {kDInf});
+  testCast<std::string, double>("double", {"-1e309"}, {-kDInf});
+}
+
+TEST_F(SparkCastExprTestAnsiOn, tryCastStringToRealDoubleAnsiReturnsNull) {
+  // TRY_CAST should return NULL on invalid input even with ANSI ON.
+  auto result = evaluateOnce<float>(
+      "try_cast(c0 as real)",
+      makeRowVector({makeFlatVector<std::string>({"abc"})}));
+  EXPECT_FALSE(result.has_value());
+  auto resultDouble = evaluateOnce<double>(
+      "try_cast(c0 as double)",
+      makeRowVector({makeFlatVector<std::string>({"abc"})}));
+  EXPECT_FALSE(resultDouble.has_value());
+}
+
+TEST_F(SparkCastExprTestAnsiOn, stringToRealDoubleAnsiMultiRow) {
+  // Multi-row vector with mix of valid, invalid, and null values.
+  // CAST with ANSI ON should throw on the first invalid value.
+  auto input = makeRowVector({makeNullableFlatVector<std::string>(
+      {std::nullopt, "1.5", "abc", "nan"})});
+  VELOX_ASSERT_THROW(
+      (evaluate("cast(c0 as real)", input)), "Number format error");
+
+  // TRY_CAST with ANSI ON should return null for invalid, preserve valid.
+  auto expected = makeNullableFlatVector<float>(
+      {std::nullopt,
+       1.5f,
+       std::nullopt,
+       std::numeric_limits<float>::quiet_NaN()});
+  auto result = evaluate("try_cast(c0 as real)", input);
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(SparkCastExprTestAnsiOn, stringToDoubleAnsiMultiRow) {
+  // Multi-row vector for DOUBLE (mirrors REAL multi-row test above).
+  auto input = makeRowVector({makeNullableFlatVector<std::string>(
+      {std::nullopt, "1.5", "abc", "nan"})});
+  VELOX_ASSERT_THROW(
+      (evaluate("cast(c0 as double)", input)), "Number format error");
+
+  auto expected = makeNullableFlatVector<double>(
+      {std::nullopt,
+       1.5,
+       std::nullopt,
+       std::numeric_limits<double>::quiet_NaN()});
+  auto result = evaluate("try_cast(c0 as double)", input);
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(SparkCastExprTestAnsiOn, stringToRealDoubleAnsiNullInput) {
+  // NULL input should return NULL, not throw.
+  auto input =
+      makeRowVector({makeNullableFlatVector<std::string>({std::nullopt})});
+  auto resultFloat = evaluateOnce<float>("cast(c0 as real)", input);
+  EXPECT_FALSE(resultFloat.has_value());
+  auto resultDouble = evaluateOnce<double>("cast(c0 as double)", input);
+  EXPECT_FALSE(resultDouble.has_value());
+}
+
+// ============================================================================
+// ANSI OFF — String to Float/Double Tests (legacy behavior)
+// ============================================================================
+
+TEST_F(SparkCastExprTestAnsiOff, stringToFloatInvalidLegacy) {
+  // Invalid format strings should return NULL in legacy (ANSI off) mode.
+  testCast<std::string, float>("real", {"abc"}, {std::nullopt});
+  testCast<std::string, float>("real", {""}, {std::nullopt});
+  testCast<std::string, float>("real", {"1.2a"}, {std::nullopt});
+  testCast<std::string, float>("real", {"1.2.3"}, {std::nullopt});
+  testCast<std::string, double>("double", {"abc"}, {std::nullopt});
+  testCast<std::string, double>("double", {""}, {std::nullopt});
+  testCast<std::string, double>("double", {"1.2.3"}, {std::nullopt});
+}
 } // namespace
 } // namespace facebook::velox::test

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <folly/ScopeGuard.h>
+#include <cmath>
 #include "velox/core/Expressions.h"
 #include "velox/core/QueryConfig.h"
 #include "velox/functions/prestosql/tests/CastBaseTest.h"
@@ -1556,6 +1557,81 @@ class SparkCastExprTest : public functions::test::CastBaseTest {
         makeConstant<float>(std::numeric_limits<float>::min(), 1),
         makeConstant<int128_t>(0, 1, DECIMAL(38, 2)));
   }
+
+  // Valid string-to-real/double conversions produce identical results whether
+  // ANSI mode is on or off, so both fixtures share these assertions.
+  void testStringToRealDoubleValidFormats() {
+    // kNan/kInf (float) are inherited from CastBaseTest; the double equivalents
+    // have no base-class constant, so they are defined locally.
+    const auto doubleNan = std::numeric_limits<double>::quiet_NaN();
+    const auto doubleInfinity = std::numeric_limits<double>::infinity();
+
+    // Basic valid values.
+    testCast<std::string, float>("real", {"1.5"}, {1.5f});
+    testCast<std::string, double>("double", {"1.5"}, {1.5});
+
+    // Special literals (case variants).
+    testCast<std::string, float>("real", {"nan"}, {kNan});
+    testCast<std::string, float>("real", {"NaN"}, {kNan});
+    testCast<std::string, float>("real", {"inf"}, {kInf});
+    testCast<std::string, float>("real", {"Inf"}, {kInf});
+    testCast<std::string, float>("real", {"-inf"}, {-kInf});
+    testCast<std::string, float>("real", {"-Inf"}, {-kInf});
+    testCast<std::string, float>("real", {"infinity"}, {kInf});
+    testCast<std::string, float>("real", {"Infinity"}, {kInf});
+    testCast<std::string, float>("real", {"-infinity"}, {-kInf});
+    testCast<std::string, float>("real", {"-Infinity"}, {-kInf});
+    testCast<std::string, double>("double", {"nan"}, {doubleNan});
+    testCast<std::string, double>("double", {"NaN"}, {doubleNan});
+    testCast<std::string, double>("double", {"inf"}, {doubleInfinity});
+    testCast<std::string, double>("double", {"Inf"}, {doubleInfinity});
+    testCast<std::string, double>("double", {"-inf"}, {-doubleInfinity});
+    testCast<std::string, double>("double", {"-Inf"}, {-doubleInfinity});
+    testCast<std::string, double>("double", {"infinity"}, {doubleInfinity});
+    testCast<std::string, double>("double", {"Infinity"}, {doubleInfinity});
+    testCast<std::string, double>("double", {"-infinity"}, {-doubleInfinity});
+    testCast<std::string, double>("double", {"-Infinity"}, {-doubleInfinity});
+
+    // Scientific notation.
+    testCast<std::string, float>("real", {"1.5e2"}, {150.0f});
+    testCast<std::string, float>("real", {"-3.14E-2"}, {-0.0314f});
+    testCast<std::string, double>("double", {"1.5e10"}, {1.5e10});
+    testCast<std::string, double>("double", {"-3.14E-5"}, {-3.14e-5});
+
+    // Signed values.
+    testCast<std::string, float>("real", {"+1.5"}, {1.5f});
+    testCast<std::string, float>("real", {"-1.5"}, {-1.5f});
+    testCast<std::string, double>("double", {"+1.5"}, {1.5});
+
+    // Signed zeros: value equality does not distinguish +0 from -0, so assert
+    // the sign bit explicitly.
+    auto realSignBit = [this](const std::string& value) {
+      auto input = makeRowVector({makeFlatVector<std::string>({value})});
+      return std::signbit(
+          evaluateOnce<float>("cast(c0 as real)", input).value());
+    };
+    auto doubleSignBit = [this](const std::string& value) {
+      auto input = makeRowVector({makeFlatVector<std::string>({value})});
+      return std::signbit(
+          evaluateOnce<double>("cast(c0 as double)", input).value());
+    };
+    EXPECT_FALSE(realSignBit("+0"));
+    EXPECT_TRUE(realSignBit("-0"));
+    EXPECT_FALSE(doubleSignBit("+0"));
+    EXPECT_TRUE(doubleSignBit("-0"));
+
+    // Overflow yields Infinity rather than an error, matching Spark.
+    testCast<std::string, float>("real", {"1e39"}, {kInf});
+    testCast<std::string, float>("real", {"-1e39"}, {-kInf});
+    testCast<std::string, double>("double", {"1e309"}, {doubleInfinity});
+    testCast<std::string, double>("double", {"-1e309"}, {-doubleInfinity});
+  }
+
+  // Malformed string-to-real/double inputs. ANSI mode throws on these; legacy
+  // mode returns NULL. Both fixtures share this input set.
+  static std::vector<std::string> invalidStringToRealDoubleInputs() {
+    return {"abc", "1.2a", "1.2.3", "xyz123"};
+  }
 };
 
 class SparkCastExprTestAnsiOn : public SparkCastExprTest {
@@ -1878,6 +1954,69 @@ TEST_F(SparkCastExprTestAnsiOn, stringToTime) {
   testInvalidString("12:30:45.1234567");
   testInvalidString("abc");
   testInvalidString("");
+}
+
+TEST_F(SparkCastExprTestAnsiOn, stringToRealDoubleInvalidThrows) {
+  // Invalid format strings throw in ANSI mode. The message follows the standard
+  // Velox Spark cast convention: "Cannot cast VARCHAR '<v>' to <T>. ...".
+  for (const auto& type : {"real", "double"}) {
+    for (const auto& value : invalidStringToRealDoubleInputs()) {
+      SCOPED_TRACE(fmt::format("cast('{}' as {})", value, type));
+      auto input = makeRowVector({makeFlatVector<std::string>({value})});
+      VELOX_ASSERT_THROW(
+          (evaluate(fmt::format("cast(c0 as {})", type), input)),
+          "Cannot cast");
+    }
+  }
+
+  // Empty and whitespace-only strings (trimmed to empty) throw "Empty string".
+  for (const auto& type : {"real", "double"}) {
+    for (const auto& value : {"", "   ", "\t\n"}) {
+      SCOPED_TRACE(fmt::format("cast('{}' as {})", value, type));
+      auto input = makeRowVector({makeFlatVector<std::string>({value})});
+      VELOX_ASSERT_THROW(
+          (evaluate(fmt::format("cast(c0 as {})", type), input)),
+          "Empty string");
+    }
+  }
+}
+
+TEST_F(SparkCastExprTestAnsiOn, stringToRealDoubleValidFormats) {
+  testStringToRealDoubleValidFormats();
+}
+
+TEST_F(SparkCastExprTestAnsiOn, stringToRealDoubleMixedRows) {
+  // A vector mixing null, valid, invalid, and special values: CAST throws on
+  // the first invalid value, while TRY_CAST nulls invalid rows and preserves
+  // the rest, both with ANSI on.
+  auto input = makeRowVector({makeNullableFlatVector<std::string>(
+      {std::nullopt, "1.5", "abc", "nan"})});
+
+  {
+    SCOPED_TRACE("real");
+    VELOX_ASSERT_THROW((evaluate("cast(c0 as real)", input)), "Cannot cast");
+    auto expected =
+        makeNullableFlatVector<float>({std::nullopt, 1.5f, std::nullopt, kNan});
+    assertEqualVectors(expected, evaluate("try_cast(c0 as real)", input));
+  }
+  {
+    SCOPED_TRACE("double");
+    VELOX_ASSERT_THROW((evaluate("cast(c0 as double)", input)), "Cannot cast");
+    auto expected = makeNullableFlatVector<double>(
+        {std::nullopt,
+         1.5,
+         std::nullopt,
+         std::numeric_limits<double>::quiet_NaN()});
+    assertEqualVectors(expected, evaluate("try_cast(c0 as double)", input));
+  }
+}
+
+TEST_F(SparkCastExprTestAnsiOn, stringToRealDoubleNullInput) {
+  // NULL input returns NULL, not an error.
+  auto input =
+      makeRowVector({makeNullableFlatVector<std::string>({std::nullopt})});
+  EXPECT_FALSE(evaluateOnce<float>("cast(c0 as real)", input).has_value());
+  EXPECT_FALSE(evaluateOnce<double>("cast(c0 as double)", input).has_value());
 }
 
 TEST_F(SparkCastExprTestAnsiOn, fromString) {
@@ -3115,6 +3254,26 @@ TEST_F(SparkCastExprTestAnsiOff, tryCastFloatToIntegralSaturation) {
   // In-range values truncate toward zero.
   testTryCast<float, int8_t>("tinyint", {100.5f}, {100});
   testTryCast<double, int64_t>("bigint", {42.7}, {42});
+}
+
+TEST_F(SparkCastExprTestAnsiOff, stringToRealDoubleValidFormats) {
+  // Valid inputs parse identically whether ANSI mode is on or off.
+  testStringToRealDoubleValidFormats();
+}
+
+TEST_F(SparkCastExprTestAnsiOff, stringToRealDoubleInvalidReturnsNull) {
+  // Invalid format strings return NULL in legacy (ANSI off) mode. Empty and
+  // whitespace-only strings (trimmed to empty) return NULL as well.
+  for (const auto& value : invalidStringToRealDoubleInputs()) {
+    SCOPED_TRACE(value);
+    testCast<std::string, float>("real", {value}, {std::nullopt});
+    testCast<std::string, double>("double", {value}, {std::nullopt});
+  }
+  for (const auto& value : {"", "   ", "\t\n"}) {
+    SCOPED_TRACE(value);
+    testCast<std::string, float>("real", {value}, {std::nullopt});
+    testCast<std::string, double>("double", {value}, {std::nullopt});
+  }
 }
 } // namespace
 } // namespace facebook::velox::test

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -1957,9 +1957,11 @@ TEST_F(SparkCastExprTestAnsiOn, stringToTime) {
 }
 
 TEST_F(SparkCastExprTestAnsiOn, stringToRealDoubleInvalidThrows) {
+  const std::vector<TypePtr> types{REAL(), DOUBLE()};
+
   // Invalid format strings throw in ANSI mode. The message follows the standard
   // Velox Spark cast convention: "Cannot cast VARCHAR '<v>' to <T>. ...".
-  for (const auto& type : {REAL(), DOUBLE()}) {
+  for (const auto& type : types) {
     for (const auto& value : invalidStringToRealDoubleInputs()) {
       SCOPED_TRACE(fmt::format("cast('{}' as {})", value, type->toString()));
       testThrow<std::string>(
@@ -1972,7 +1974,7 @@ TEST_F(SparkCastExprTestAnsiOn, stringToRealDoubleInvalidThrows) {
   }
 
   // Empty and whitespace-only strings are trimmed to empty before throwing.
-  for (const auto& type : {REAL(), DOUBLE()}) {
+  for (const auto& type : types) {
     for (const auto& value : {"", "   ", "\t\n"}) {
       SCOPED_TRACE(fmt::format("cast('{}' as {})", value, type->toString()));
       testThrow<std::string>(

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -2011,14 +2011,6 @@ TEST_F(SparkCastExprTestAnsiOn, stringToRealDoubleMixedRows) {
   }
 }
 
-TEST_F(SparkCastExprTestAnsiOn, stringToRealDoubleNullInput) {
-  // NULL input returns NULL, not an error.
-  auto input =
-      makeRowVector({makeNullableFlatVector<std::string>({std::nullopt})});
-  EXPECT_FALSE(evaluateOnce<float>("cast(c0 as real)", input).has_value());
-  EXPECT_FALSE(evaluateOnce<double>("cast(c0 as double)", input).has_value());
-}
-
 TEST_F(SparkCastExprTestAnsiOn, fromString) {
   testFromString();
 }

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -1959,24 +1959,30 @@ TEST_F(SparkCastExprTestAnsiOn, stringToTime) {
 TEST_F(SparkCastExprTestAnsiOn, stringToRealDoubleInvalidThrows) {
   // Invalid format strings throw in ANSI mode. The message follows the standard
   // Velox Spark cast convention: "Cannot cast VARCHAR '<v>' to <T>. ...".
-  for (const auto& type : {"real", "double"}) {
+  for (const auto& type : {REAL(), DOUBLE()}) {
     for (const auto& value : invalidStringToRealDoubleInputs()) {
-      SCOPED_TRACE(fmt::format("cast('{}' as {})", value, type));
-      auto input = makeRowVector({makeFlatVector<std::string>({value})});
-      VELOX_ASSERT_THROW(
-          (evaluate(fmt::format("cast(c0 as {})", type), input)),
-          "Cannot cast");
+      SCOPED_TRACE(fmt::format("cast('{}' as {})", value, type->toString()));
+      testThrow<std::string>(
+          VARCHAR(),
+          type,
+          {value},
+          fmt::format(
+              "Cannot cast VARCHAR '{}' to {}", value, type->toString()));
     }
   }
 
-  // Empty and whitespace-only strings (trimmed to empty) throw "Empty string".
-  for (const auto& type : {"real", "double"}) {
+  // Empty and whitespace-only strings are trimmed to empty before throwing.
+  for (const auto& type : {REAL(), DOUBLE()}) {
     for (const auto& value : {"", "   ", "\t\n"}) {
-      SCOPED_TRACE(fmt::format("cast('{}' as {})", value, type));
-      auto input = makeRowVector({makeFlatVector<std::string>({value})});
-      VELOX_ASSERT_THROW(
-          (evaluate(fmt::format("cast(c0 as {})", type), input)),
-          "Empty string");
+      SCOPED_TRACE(fmt::format("cast('{}' as {})", value, type->toString()));
+      testThrow<std::string>(
+          VARCHAR(),
+          type,
+          {value},
+          fmt::format(
+              "Cannot cast VARCHAR '{}' to {}. Empty string",
+              value,
+              type->toString()));
     }
   }
 }
@@ -1989,19 +1995,22 @@ TEST_F(SparkCastExprTestAnsiOn, stringToRealDoubleMixedRows) {
   // A vector mixing null, valid, invalid, and special values: CAST throws on
   // the first invalid value, while TRY_CAST nulls invalid rows and preserves
   // the rest, both with ANSI on.
-  auto input = makeRowVector({makeNullableFlatVector<std::string>(
-      {std::nullopt, "1.5", "abc", "nan"})});
+  const std::vector<std::optional<std::string>> values{
+      std::nullopt, "1.5", "abc", "nan"};
+  auto input = makeRowVector({makeNullableFlatVector<std::string>(values)});
 
   {
     SCOPED_TRACE("real");
-    VELOX_ASSERT_THROW((evaluate("cast(c0 as real)", input)), "Cannot cast");
+    testThrow<std::string>(
+        VARCHAR(), REAL(), values, "Cannot cast VARCHAR 'abc' to REAL");
     auto expected =
         makeNullableFlatVector<float>({std::nullopt, 1.5f, std::nullopt, kNan});
     assertEqualVectors(expected, evaluate("try_cast(c0 as real)", input));
   }
   {
     SCOPED_TRACE("double");
-    VELOX_ASSERT_THROW((evaluate("cast(c0 as double)", input)), "Cannot cast");
+    testThrow<std::string>(
+        VARCHAR(), DOUBLE(), values, "Cannot cast VARCHAR 'abc' to DOUBLE");
     auto expected = makeNullableFlatVector<double>(
         {std::nullopt,
          1.5,


### PR DESCRIPTION
## Summary

With Spark ANSI mode enabled (`spark.ansi_enabled`), casting a malformed string to `REAL` or `DOUBLE` now raises an error instead of returning NULL, matching Spark. For example, with ANSI on:

```
CAST('abc' AS DOUBLE)
```

now fails with `Cannot cast VARCHAR 'abc' to DOUBLE` rather than producing NULL. `TRY_CAST` is unaffected and still returns NULL on failure. Numeric overflow such as `CAST('1e309' AS DOUBLE)` still produces `Infinity`, per Spark semantics.

The change adds `varchar -> real/double` to `SparkCastCallToSpecialForm::isAnsiSupported()`, the incremental gate that decides which cast pairs use ANSI (throwing) behavior. Cast pairs that are not yet listed there continue to fall back to legacy NULL-returning behavior even when ANSI mode is on.

## Behavior

| Mode | Expression | Result |
|------|------------|--------|
| ANSI off | `CAST('abc' AS DOUBLE)` | NULL |
| ANSI on | `CAST('abc' AS DOUBLE)` | Error |
| ANSI on | `CAST('1e309' AS DOUBLE)` | Infinity |
| any | `TRY_CAST('abc' AS DOUBLE)` | NULL |