### PR TITLE
feat: Add runtime stats for index lookup join (#17286)

### DIFF
--- a/velox/connectors/hive/FileIndexReader.cpp
+++ b/velox/connectors/hive/FileIndexReader.cpp
@@ -420,13 +420,27 @@ bool FileIndexReader::hasNext() {
 std::unique_ptr<FileIndexReader::Result> FileIndexReader::next(
     vector_size_t maxOutputRows) {
   VELOX_CHECK_NOT_NULL(indexReader_);
-  return indexReader_->next(maxOutputRows);
+  auto result = indexReader_->next(maxOutputRows);
+  if (result != nullptr) {
+    numIndexOutputRows_ += result->size();
+  }
+  return result;
 }
 
 std::unordered_map<std::string, RuntimeMetric> FileIndexReader::runtimeStats() {
-  // TODO: Populate with format-specific stats in a follow-up.
-  // File-based IO stats are tracked externally via IoStatistics.
-  return {};
+  std::unordered_map<std::string, RuntimeMetric> stats;
+  if (numIndexOutputRows_ != 0) {
+    stats[std::string(kNumIndexReaderOutputRows)] = RuntimeMetric(
+        static_cast<int64_t>(numIndexOutputRows_), RuntimeCounter::Unit::kNone);
+  }
+  if (indexReader_ != nullptr) {
+    for (auto& [key, metric] : indexReader_->stats()) {
+      auto [_, inserted] = stats.emplace(key, metric);
+      VELOX_CHECK(
+          inserted, "Duplicate runtime stat '{}' from index reader", key);
+    }
+  }
+  return stats;
 }
 
 std::string FileIndexReader::toString() const {

--- a/velox/connectors/hive/FileIndexReader.h
+++ b/velox/connectors/hive/FileIndexReader.h
@@ -148,6 +148,8 @@ class FileIndexReader : public SplitIndexReader {
   // Reusable column vectors for building index bounds.
   std::vector<VectorPtr> lowerBoundColumns_;
   std::vector<VectorPtr> upperBoundColumns_;
+
+  uint64_t numIndexOutputRows_{0};
 };
 
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveIndexSource.cpp
+++ b/velox/connectors/hive/HiveIndexSource.cpp
@@ -15,8 +15,11 @@
  */
 #include "velox/connectors/hive/HiveIndexSource.h"
 
+#include <folly/ScopeGuard.h>
 #include "velox/common/base/RuntimeMetrics.h"
+#include "velox/common/time/CpuWallTimer.h"
 #include "velox/common/time/Timer.h"
+#include "velox/connectors/hive/FileDataSource.h"
 #include "velox/connectors/hive/FileIndexReader.h"
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/HiveConnectorUtil.h"
@@ -430,6 +433,22 @@ class UnionResultIterator : public IndexSource::ResultIterator {
 
 } // namespace
 
+// Scope-attached timer that accumulates wall and CPU time into the
+// corresponding iterationStats fields when the attached block exits.
+// Expects a local variable named 'iterationStats' of type
+// HiveIndexSource::IterationStats.
+//
+// Usage:
+//   RECORD_CPU_WALL(setup) {
+//     // timed work
+//   }
+#define RECORD_CPU_WALL(name)                                        \
+  if (DeltaCpuWallTimer _timer_##name([&](const CpuWallTiming& _t) { \
+        iterationStats.name##WallNs += _t.wallNanos;                 \
+        iterationStats.name##CpuNs += _t.cpuNanos;                   \
+      });                                                            \
+      true)
+
 /// Iterates over results from a SplitIndexReader and applies HiveIndexSource's
 /// format-agnostic orchestration: remaining filter evaluation and output
 /// projection.
@@ -456,9 +475,16 @@ class HiveLookupIterator : public IndexSource::ResultIterator {
       return nullptr;
     }
 
+    HiveIndexSource::IterationStats iterationStats;
+    SCOPE_EXIT {
+      indexSource_->recordIterationStats(iterationStats);
+    };
+
     // Initialize lookup on first call.
     if (state_ == State::kInit) {
-      indexReader_->startLookup(request_, options_);
+      RECORD_CPU_WALL(setup) {
+        indexReader_->startLookup(request_, options_);
+      }
       setState(State::kRead);
     }
 
@@ -466,7 +492,7 @@ class HiveLookupIterator : public IndexSource::ResultIterator {
       setState(State::kEnd);
       return nullptr;
     }
-    return getOutput(size);
+    return getOutput(size, iterationStats);
   }
 
  private:
@@ -523,25 +549,37 @@ class HiveLookupIterator : public IndexSource::ResultIterator {
     }
   }
 
-  std::unique_ptr<IndexSource::Result> getOutput(vector_size_t size) {
-    auto result = indexReader_->next(size);
+  std::unique_ptr<IndexSource::Result> getOutput(
+      vector_size_t size,
+      HiveIndexSource::IterationStats& iterationStats) {
+    std::unique_ptr<IndexSource::Result> result;
+    RECORD_CPU_WALL(read) {
+      result = indexReader_->next(size);
+    }
     if (result == nullptr) {
       VELOX_CHECK(!indexReader_->hasNext());
       setState(State::kEnd);
       return nullptr;
     }
     if (indexSource_->remainingFilterExprSet_ == nullptr) {
-      result->output = indexSource_->projectOutput(
-          result->output->size(), nullptr, result->output);
-      return result;
+      RECORD_CPU_WALL(output) {
+        result->output = indexSource_->projectOutput(
+            result->output->size(), nullptr, result->output);
+      }
+    } else {
+      result = evaluateRemainingFilter(std::move(result), iterationStats);
     }
-    return evaluateRemainingFilter(std::move(result));
+    return result;
   }
 
   std::unique_ptr<IndexSource::Result> evaluateRemainingFilter(
-      std::unique_ptr<IndexSource::Result> result) {
+      std::unique_ptr<IndexSource::Result> result,
+      HiveIndexSource::IterationStats& iterationStats) {
     auto& output = result->output;
-    const auto numRemainingRows = indexSource_->evaluateRemainingFilter(output);
+    vector_size_t numRemainingRows;
+    RECORD_CPU_WALL(filter) {
+      numRemainingRows = indexSource_->evaluateRemainingFilter(output);
+    }
 
     if (numRemainingRows == 0) {
       return getEmptyResult();
@@ -556,8 +594,10 @@ class HiveLookupIterator : public IndexSource::ResultIterator {
           result->inputHits,
           indexSource_->pool_);
     }
-    output =
-        indexSource_->projectOutput(numRemainingRows, remainingIndices, output);
+    RECORD_CPU_WALL(output) {
+      output = indexSource_->projectOutput(
+          numRemainingRows, remainingIndices, output);
+    }
     return result;
   }
 
@@ -909,11 +949,14 @@ HiveIndexSource::createUnionLookupIterator(
 }
 
 std::unordered_map<std::string, RuntimeMetric> HiveIndexSource::runtimeStats() {
-  std::unordered_map<std::string, RuntimeMetric> stats;
+  // Start with accumulated per-call timing stats.
+  auto stats = runtimeStats_;
+
   if (remainingFilterTimeNs_ != 0) {
     stats[std::string(Connector::kTotalRemainingFilterTime)] =
         RuntimeMetric(remainingFilterTimeNs_, RuntimeCounter::Unit::kNanos);
   }
+
   // Merge stats from all readers.
   for (auto& reader : readers_) {
     for (auto& [key, metric] : reader->runtimeStats()) {
@@ -925,6 +968,41 @@ std::unordered_map<std::string, RuntimeMetric> HiveIndexSource::runtimeStats() {
       }
     }
   }
+  // Add I/O stats from ioStatistics_ (storage read, ram cache, ssd cache).
+  if (ioStatistics_) {
+    const auto& read = ioStatistics_->read();
+    if (read.count() > 0) {
+      stats[std::string(FileDataSource::kStorageReadBytes)] = RuntimeMetric(
+          static_cast<int64_t>(read.sum()),
+          read.count(),
+          static_cast<int64_t>(read.min()),
+          static_cast<int64_t>(read.max()),
+          RuntimeCounter::Unit::kBytes);
+    }
+    const auto& ramHit = ioStatistics_->ramHit();
+    if (ramHit.count() > 0) {
+      stats[std::string(FileDataSource::kNumRamRead)] =
+          RuntimeMetric(static_cast<int64_t>(ramHit.count()));
+      stats[std::string(FileDataSource::kRamReadBytes)] = RuntimeMetric(
+          static_cast<int64_t>(ramHit.sum()),
+          ramHit.count(),
+          static_cast<int64_t>(ramHit.min()),
+          static_cast<int64_t>(ramHit.max()),
+          RuntimeCounter::Unit::kBytes);
+    }
+    const auto& ssdRead = ioStatistics_->ssdRead();
+    if (ssdRead.count() > 0) {
+      stats[std::string(FileDataSource::kNumLocalRead)] =
+          RuntimeMetric(static_cast<int64_t>(ssdRead.count()));
+      stats[std::string(FileDataSource::kLocalReadBytes)] = RuntimeMetric(
+          static_cast<int64_t>(ssdRead.sum()),
+          ssdRead.count(),
+          static_cast<int64_t>(ssdRead.min()),
+          static_cast<int64_t>(ssdRead.max()),
+          RuntimeCounter::Unit::kBytes);
+    }
+  }
+
   return stats;
 }
 
@@ -956,6 +1034,76 @@ vector_size_t HiveIndexSource::evaluateRemainingFilter(
   }
   remainingFilterTimeNs_ += filterTimeNs;
   return numRemainingRows;
+}
+
+void HiveIndexSource::recordIterationStats(
+    const IterationStats& iterationStats) {
+  const auto totalWallNs = iterationStats.setupWallNs +
+      iterationStats.readWallNs + iterationStats.outputWallNs +
+      iterationStats.filterWallNs;
+  if (totalWallNs != 0) {
+    exec::addOperatorRuntimeStats(
+        IterationStats::kConnectorLookupWallNanos,
+        RuntimeCounter(
+            static_cast<int64_t>(totalWallNs), RuntimeCounter::Unit::kNanos),
+        runtimeStats_);
+  }
+  if (iterationStats.setupWallNs != 0) {
+    exec::addOperatorRuntimeStats(
+        IterationStats::kIndexSetupWallNanos,
+        RuntimeCounter(
+            static_cast<int64_t>(iterationStats.setupWallNs),
+            RuntimeCounter::Unit::kNanos),
+        runtimeStats_);
+  }
+  if (iterationStats.setupCpuNs != 0) {
+    exec::addOperatorRuntimeStats(
+        IterationStats::kIndexSetupCpuNanos,
+        RuntimeCounter(
+            static_cast<int64_t>(iterationStats.setupCpuNs),
+            RuntimeCounter::Unit::kNanos),
+        runtimeStats_);
+  }
+  if (iterationStats.readWallNs != 0) {
+    exec::addOperatorRuntimeStats(
+        IterationStats::kIndexReadWallNanos,
+        RuntimeCounter(
+            static_cast<int64_t>(iterationStats.readWallNs),
+            RuntimeCounter::Unit::kNanos),
+        runtimeStats_);
+  }
+  if (iterationStats.readCpuNs != 0) {
+    exec::addOperatorRuntimeStats(
+        IterationStats::kIndexReadCpuNanos,
+        RuntimeCounter(
+            static_cast<int64_t>(iterationStats.readCpuNs),
+            RuntimeCounter::Unit::kNanos),
+        runtimeStats_);
+  }
+  if (iterationStats.outputCpuNs != 0) {
+    exec::addOperatorRuntimeStats(
+        IterationStats::kConnectorResultPrepareCpuNanos,
+        RuntimeCounter(
+            static_cast<int64_t>(iterationStats.outputCpuNs),
+            RuntimeCounter::Unit::kNanos),
+        runtimeStats_);
+  }
+  if (iterationStats.filterWallNs != 0) {
+    exec::addOperatorRuntimeStats(
+        IterationStats::kPostFilterWallNanos,
+        RuntimeCounter(
+            static_cast<int64_t>(iterationStats.filterWallNs),
+            RuntimeCounter::Unit::kNanos),
+        runtimeStats_);
+  }
+  if (iterationStats.filterCpuNs != 0) {
+    exec::addOperatorRuntimeStats(
+        IterationStats::kPostFilterCpuNanos,
+        RuntimeCounter(
+            static_cast<int64_t>(iterationStats.filterCpuNs),
+            RuntimeCounter::Unit::kNanos),
+        runtimeStats_);
+  }
 }
 
 RowVectorPtr HiveIndexSource::projectOutput(

--- a/velox/connectors/hive/HiveIndexSource.h
+++ b/velox/connectors/hive/HiveIndexSource.h
@@ -125,6 +125,39 @@ class HiveIndexSource : public IndexSource,
   // Creates a FileIndexReader for a single split.
   void createFileIndexReader(std::shared_ptr<const HiveConnectorSplit> split);
 
+  // Per-iteration timing breakdown for index lookups.
+  struct IterationStats {
+    uint64_t setupWallNs{0};
+    uint64_t setupCpuNs{0};
+    uint64_t readWallNs{0};
+    uint64_t readCpuNs{0};
+    uint64_t outputWallNs{0};
+    uint64_t outputCpuNs{0};
+    uint64_t filterWallNs{0};
+    uint64_t filterCpuNs{0};
+
+    static constexpr std::string_view kConnectorLookupWallNanos{
+        "connectorLookupWallNanos"};
+    static constexpr std::string_view kConnectorResultPrepareCpuNanos{
+        "connectorResultPrepareCpuNanos"};
+    static constexpr std::string_view kIndexSetupWallNanos{
+        "connectorIndexSetupWallNanos"};
+    static constexpr std::string_view kIndexSetupCpuNanos{
+        "connectorIndexSetupCpuNanos"};
+    static constexpr std::string_view kIndexReadWallNanos{
+        "connectorIndexReadWallNanos"};
+    static constexpr std::string_view kIndexReadCpuNanos{
+        "connectorIndexReadCpuNanos"};
+    static constexpr std::string_view kPostFilterWallNanos{
+        "connectorPostFilterWallNanos"};
+    static constexpr std::string_view kPostFilterCpuNanos{
+        "connectorPostFilterCpuNanos"};
+  };
+
+  // Records per-iteration timing breakdown using addOperatorRuntimeStats to
+  // preserve per-call count/min/max granularity.
+  void recordIterationStats(const IterationStats& iterationStats);
+
   FileHandleFactory* const fileHandleFactory_;
   ConnectorQueryCtx* const connectorQueryCtx_;
   const std::shared_ptr<HiveConfig> hiveConfig_;
@@ -183,6 +216,9 @@ class HiveIndexSource : public IndexSource,
 
   std::shared_ptr<io::IoStatistics> ioStatistics_;
   std::shared_ptr<IoStats> ioStats_;
+
+  // Per-call timing stats accumulated via addOperatorRuntimeStats().
+  std::unordered_map<std::string, RuntimeMetric> runtimeStats_;
 };
 
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/IndexReader.h
+++ b/velox/connectors/hive/IndexReader.h
@@ -45,6 +45,10 @@ class SplitIndexReader {
   using Result = IndexSource::Result;
   using Options = dwio::common::IndexReader::Options;
 
+  /// The total number of output rows returned across all next() calls.
+  static constexpr std::string_view kNumIndexReaderOutputRows{
+      "numIndexReaderOutputRows"};
+
   virtual ~SplitIndexReader() = default;
 
   /// Initializes a lookup for the given probe request.

--- a/velox/docs/monitoring/stats.rst
+++ b/velox/docs/monitoring/stats.rst
@@ -162,17 +162,34 @@ These stats are reported only by IndexLookupJoin operator
    * - Stats
      - Unit
      - Description
+   * - connectorIndexReadCpuNanos
+     - nanos
+     - CPU time spent reading index data from the index reader (e.g. stripe I/O, decoding).
+   * - connectorIndexReadWallNanos
+     - nanos
+     - Wall time spent reading index data from the index reader (e.g. stripe I/O, decoding).
+   * - connectorIndexSetupCpuNanos
+     - nanos
+     - CPU time spent initializing the index lookup (startLookup).
+   * - connectorIndexSetupWallNanos
+     - nanos
+     - Wall time spent initializing the index lookup (startLookup).
    * - connectorlookupWallNanos
      - nanos
-     - The end-to-end walltime in nanoseconds that the index connector do the lookup.
+     - End-to-end wall time for the index connector lookup (sum of setup, read, output, and filter).
    * - connectorlookupWaitWallNanos
      - nanos
      - The walltime in nanoseconds that the index connector wait for the lookup from
        remote storage.
+   * - connectorPostFilterCpuNanos
+     - nanos
+     - CPU time spent evaluating the remaining filter on index lookup results.
+   * - connectorPostFilterWallNanos
+     - nanos
+     - Wall time spent evaluating the remaining filter on index lookup results.
    * - connectorResultPrepareCpuNanos
      - nanos
-     - The cpu time in nanoseconds that the index connector process response from storages
-       client for followup processing by index join operator.
+     - CPU time spent projecting output columns from index reader results.
    * - clientlookupWaitWallNanos
      - nanos
      - The walltime in nanoseconds that the storage client wait for the lookup from remote storage.
@@ -197,6 +214,9 @@ These stats are reported only by IndexLookupJoin operator
    * - clientNumLazyDecodedResultBatches
      -
      - The number of lazy decoded result batches returned from the storage client.
+   * - numIndexSplits
+     -
+     - The number of index splits provided for index lookup.
 
 Merge
 -----
@@ -380,17 +400,24 @@ These stats are reported only by connector data or index sources.
    * - totalRemainingFilterCpuNanos
      - nanos
      - The total CPU time in nanoseconds that the data or index connector do the remaining filtering.
+   * - numIndexReaderOutputRows
+     -
+     - The total number of output rows returned across all next() calls from the
+       index reader. This is the final row count after cluster index bounds
+       and ScanSpec filter pushdown.
    * - numIndexFilterConversions
      -
      - The number of index columns that were converted from ScanSpec filters to
        index bounds for index-based filtering (e.g., cluster index pruning in
        Nimble). A value greater than zero indicates filters were successfully
        converted to leverage file index structures for row pruning.
-   * - numStripeLoads
+   * - numIndexLookupReadSegments
      -
-     - The number of times a stripe has been loaded during index lookup. This
-       metric helps track the I/O efficiency of index-based reads, where lower
-       values indicate better stripe reuse across lookups.
+     - The total number of read segments across all stripes during index lookup.
+       A read segment is a contiguous row range within a stripe that needs to be
+       read. When filters are present, overlapping request ranges are split at
+       boundaries to enable per-request output tracking. Without filters,
+       overlapping ranges are merged to minimize I/O.
    * - numIndexLookupRequests
      -
      - The number of index lookup requests submitted in startLookup(). Each
@@ -401,13 +428,23 @@ These stats are reported only by connector data or index sources.
      - The total number of stripes that need to be read for all index lookup
        requests. Multiple requests may share the same stripe, and each shared
        stripe is counted once per request that needs it.
-   * - numIndexLookupReadSegments
+   * - numIndexMatchedRows
      -
-     - The total number of read segments across all stripes during index lookup.
-       A read segment is a contiguous row range within a stripe that needs to be
-       read. When filters are present, overlapping request ranges are split at
-       boundaries to enable per-request output tracking. Without filters,
-       overlapping ranges are merged to minimize I/O.
+     - The total number of rows matched by the cluster index across all stripes.
+       These are the rows identified as matching the lookup bounds within each
+       stripe, before any ScanSpec filter pushdown. Comparing with actual output
+       rows shows filter selectivity.
+   * - numIndexScannedRows
+     -
+     - The total number of rows in all loaded stripes during index lookup.
+       Measures the full stripe row count regardless of how many rows are
+       actually needed. Comparing with numIndexMatchedRows shows cluster index
+       selectivity within stripes.
+   * - numStripeLoads
+     -
+     - The number of times a stripe has been loaded during index lookup. This
+       metric helps track the I/O efficiency of index-based reads, where lower
+       values indicate better stripe reuse across lookups.
 
 FileBasedDataSource
 -------------------

--- a/velox/dwio/common/Reader.h
+++ b/velox/dwio/common/Reader.h
@@ -21,6 +21,8 @@
 #include <optional>
 #include <string>
 
+#include <folly/container/F14Map.h>
+
 #include "velox/connectors/Connector.h"
 #include "velox/dwio/common/InputStream.h"
 #include "velox/dwio/common/Mutation.h"
@@ -247,6 +249,20 @@ class IndexReader {
   static constexpr std::string_view kNumIndexLookupStripes =
       "numIndexLookupStripes";
 
+  /// Tracks the total number of rows in all loaded stripes. Measures the full
+  /// stripe row count regardless of how many rows are actually needed by
+  /// index lookups. Comparing with kNumIndexMatchedRows shows cluster index
+  /// selectivity within stripes.
+  static constexpr std::string_view kNumIndexScannedRows =
+      "numIndexScannedRows";
+
+  /// Tracks the total number of rows matched by the cluster index across all
+  /// stripes. These are the rows identified as matching the lookup bounds
+  /// within each stripe, before any ScanSpec filter pushdown. Comparing with
+  /// actual output rows shows filter selectivity.
+  static constexpr std::string_view kNumIndexMatchedRows =
+      "numIndexMatchedRows";
+
   /// Tracks the total number of read segments across all stripes. A read
   /// segment is a contiguous row range within a stripe that needs to be read.
   /// When filters are present, overlapping request ranges are split at
@@ -256,6 +272,11 @@ class IndexReader {
       "numIndexLookupReadSegments";
 
   virtual ~IndexReader() = default;
+
+  /// Returns runtime statistics accumulated by this index reader.
+  virtual folly::F14FastMap<std::string, RuntimeMetric> stats() const {
+    return {};
+  }
 
   /// Options for controlling index reader behavior.
   struct Options {

--- a/velox/exec/IndexLookupJoin.cpp
+++ b/velox/exec/IndexLookupJoin.cpp
@@ -281,6 +281,14 @@ std::vector<OperatorStats> IndexLookupJoin::splitStats(
   joinStats.runtimeStats.erase(std::string(LazyVector::kCpuNanos));
   joinStats.runtimeStats.erase(std::string(LazyVector::kWallNanos));
 
+  // Remove index source stats from join stats. recordConnectorStats copies
+  // these into the operator's runtimeStats (prefixed with "indexSource.") so
+  // they flow through the task-level stats path, but they belong to the
+  // IndexSource node, not the join node.
+  for (const auto& [name, _] : indexSourceStatWriter.runtimeStats()) {
+    joinStats.runtimeStats.erase(fmt::format("indexSource.{}", name));
+  }
+
   return {std::move(joinStats), std::move(indexSourceStats)};
 }
 
@@ -665,6 +673,14 @@ bool IndexLookupJoin::collectIndexSplits(ContinueFuture* future) {
       VELOX_CHECK(!hasNoIndexSplits_);
       VELOX_CHECK_NOT_NULL(joinBridge_);
       joinBridge_->setIndexSplits(indexSplits_);
+      {
+        auto lockedStats = stats_.wlock();
+        lockedStats->addRuntimeStat(
+            kNumIndexSplits,
+            RuntimeCounter(
+                static_cast<int64_t>(indexSplits_.size()),
+                RuntimeCounter::Unit::kNone));
+      }
       if (indexSplits_.empty()) {
         hasNoIndexSplits_ = true;
       } else {
@@ -1670,6 +1686,15 @@ void IndexLookupJoin::recordConnectorStats() {
                 connectorStats[std::string(kClientRequestProcessTime)].sum +
                 connectorStats[std::string(kClientResultProcessTime)].sum),
             RuntimeCounter::Unit::kNanos));
+  }
+  // Copy index source stats into the operator's own runtimeStats so they are
+  // visible through the task-level runtime stats path.
+  const auto indexSourceStats = indexStatWriter_->runtimeStats();
+  {
+    auto lockedStats = stats_.wlock();
+    for (const auto& [name, value] : indexSourceStats) {
+      lockedStats->runtimeStats[fmt::format("indexSource.{}", name)] = value;
+    }
   }
 }
 } // namespace facebook::velox::exec

--- a/velox/exec/IndexLookupJoin.h
+++ b/velox/exec/IndexLookupJoin.h
@@ -83,6 +83,8 @@ class IndexLookupJoin : public Operator {
   /// The number of lookup results received from remote storage with error.
   static constexpr std::string_view kClientNumErrorResults{
       "clientNumErrorResults"};
+  /// The number of index splits provided for index lookup.
+  static constexpr std::string_view kNumIndexSplits{"numIndexSplits"};
 
  private:
   // Intercepts runtime stats emitted during index-side operations (getOutput /

--- a/velox/exec/tests/IndexLookupJoinTestExtra.cpp
+++ b/velox/exec/tests/IndexLookupJoinTestExtra.cpp
@@ -528,6 +528,37 @@ DEBUG_ONLY_TEST_P(IndexLookupJoinTest, statsSplitter) {
   EXPECT_EQ(joinStats.backgroundTiming.count, 0);
   EXPECT_EQ(joinStats.backgroundTiming.cpuNanos, 0);
   EXPECT_EQ(joinStats.backgroundTiming.wallNanos, 0);
+
+  // Verify that index source stats are present in the raw operator-level
+  // Verify index source stats are copied into the operator's runtimeStats
+  // with the "indexSource." prefix for task-level stats visibility.
+  const auto rawTaskStats = task->taskStats();
+  bool foundJoinOp = false;
+  for (const auto& pipeline : rawTaskStats.pipelineStats) {
+    for (const auto& opStats : pipeline.operatorStats) {
+      if (opStats.operatorType == "IndexLookupJoin") {
+        foundJoinOp = true;
+        EXPECT_TRUE(opStats.runtimeStats.count(
+            fmt::format(
+                "indexSource.{}", IndexLookupJoin::kConnectorLookupWallTime)))
+            << "IndexLookupJoin operator runtimeStats should contain index "
+               "source stats for task-level stats reporting";
+        break;
+      }
+    }
+    if (foundJoinOp) {
+      break;
+    }
+  }
+  EXPECT_TRUE(foundJoinOp) << "IndexLookupJoin operator not found in raw stats";
+
+  // After splitStats (via toPlanStats above), the join node's customStats
+  // should NOT contain index source stats — they belong to IndexSource.
+  EXPECT_EQ(
+      joinStats.customStats.count(
+          std::string(IndexLookupJoin::kConnectorLookupWallTime)),
+      0)
+      << "Join node should not have index source stats after splitStats";
 }
 
 /// Verifies that IndexSource stats report rows BEFORE the join filter is


### PR DESCRIPTION
Summary:

Add comprehensive runtime stats across the index lookup join pipeline to make performance visible in the Presto UI.

**Task-level stats visibility fix:**
A recent refactor moved nimbleIndex* stats from the IndexLookupJoin operator's runtimeStats map into a separate indexStatWriter_ map. This made them invisible because the task-level stats path reads from the operator's runtimeStats map, not indexStatWriter_. Fix: copy indexStatWriter_ stats into the operator's own runtimeStats in recordConnectorStats() with an `indexSource.` prefix to avoid naming conflicts, and remove them from the join node's copy in splitStats() to avoid duplication.

**HiveIndexSource per-iteration timing:**
IterationStats struct captures wall and CPU time for each phase: setup (startLookup), read (next), output (projection), and post-filter (remaining filter). Stats are emitted as connectorIndex{Setup,Read}WallNanos/CpuNanos and connectorPostFilter{Wall,Cpu}Nanos. Also surfaces I/O stats (storage reads, RAM/SSD cache hits) from ioStatistics_.

**FileIndexReader counters:**
numFileIndexLookupRequests and numFileIndexOutputRows track lookup volume.

**IndexLookupJoin:**
numIndexSplits records the number of index splits provided.

**IndexReader base class:**
Added virtual stats() method and new stat name constants (numIndexScannedRows, numIndexMatchedRows) for cluster index selectivity tracking. Deprecated kNumIndexLookupStripes (kept for backward compatibility, removed in follow-up).

**Monitoring docs:**
Updated velox/docs/monitoring/stats.rst with new Connector metrics: connectorIndex{Setup,Read}{Wall,Cpu}Nanos, connectorPostFilter{Wall,Cpu}Nanos, numFileIndexOutputRows, numIndexLookupReadSegments, numIndexLookupRequests, numIndexMatchedRows, numIndexScannedRows, numStripeLoads.

Reviewed By: xiaoxmeng

Differential Revision: D101748405


