### PR TITLE
fix(iceberg): Augment scanSpec for equality-delete columns not in projection (#17287)

### DIFF
--- a/velox/connectors/hive/iceberg/EqualityDeleteFileReader.cpp
+++ b/velox/connectors/hive/iceberg/EqualityDeleteFileReader.cpp
@@ -312,7 +312,10 @@ EqualityDeleteFileReader::resolveOutputColumnIndices(
     outputColumnIndices_.reserve(equalityColumnNames_.size());
     for (const auto& colName : equalityColumnNames_) {
       auto colIdx = rowType.getChildIdxIfExists(colName);
-      VELOX_CHECK(colIdx.has_value(), "Column not found in row: {}", colName);
+      VELOX_CHECK(
+          colIdx.has_value(),
+          "Equality delete column not found in the output columns: {}",
+          colName);
       outputColumnIndices_.push_back(static_cast<column_index_t>(*colIdx));
     }
   }

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/connectors/hive/iceberg/IcebergSplitReader.h"
 
+#include <algorithm>
+
 #include <folly/lang/Bits.h>
 
 #include "velox/common/base/Exceptions.h"
@@ -91,6 +93,9 @@ void IcebergSplitReader::prepareSplit(
   if (emptySplit_) {
     return;
   }
+
+  configureEqualityDeleteColumns();
+
   auto rowType = getAdaptedRowType();
 
   if (checkIfSplitIsEmpty(runtimeStats)) {
@@ -159,31 +164,8 @@ void IcebergSplitReader::prepareSplit(
           continue;
         }
 
-        // Resolve equalityFieldIds to column names and types. In Iceberg,
-        // field IDs for top-level columns are assigned sequentially starting
-        // from 1, matching the column order in the table schema.
-        std::vector<std::string> equalityColumnNames;
-        std::vector<TypePtr> equalityColumnTypes;
-
-        const auto& dataColumns = tableHandle_->dataColumns();
-        VELOX_CHECK(
-            dataColumns != nullptr,
-            "Iceberg equality delete file '{}' cannot be processed because "
-            "table data columns are not available in HiveTableHandle.",
-            deleteFile.filePath);
-        for (const auto& eqFieldId : deleteFile.equalityFieldIds) {
-          // Field IDs are 1-based sequential for non-evolved schemas.
-          auto colIdx = static_cast<uint32_t>(eqFieldId - 1);
-          VELOX_CHECK_LT(
-              colIdx,
-              dataColumns->size(),
-              "Equality delete field ID {} out of range. This may indicate "
-              "schema evolution with non-sequential field IDs, which is "
-              "not yet supported.",
-              eqFieldId);
-          equalityColumnNames.push_back(dataColumns->nameOf(colIdx));
-          equalityColumnTypes.push_back(dataColumns->childAt(colIdx));
-        }
+        auto [equalityColumnNames, equalityColumnTypes] =
+            resolveEqualityColumns(deleteFile);
 
         if (!equalityColumnNames.empty()) {
           equalityDeleteFileReaders_.push_back(
@@ -221,6 +203,141 @@ void IcebergSplitReader::prepareSplit(
           static_cast<int>(deleteFile.content));
     }
   }
+}
+
+void IcebergSplitReader::configureEqualityDeleteColumns() {
+  // Reset partition-column tracking from any prior split before re-augmenting.
+  equalityAugmentedPartitionColumns_.clear();
+
+  std::vector<std::string> extraEqualityColumns;
+  std::vector<std::string> extraNames;
+  std::vector<TypePtr> extraTypes;
+  const auto& deleteFiles = icebergSplit_->deleteFiles;
+  const auto& splitPartitionKeys = icebergSplit_->partitionKeys;
+
+  for (const auto& deleteFile : deleteFiles) {
+    if (deleteFile.content != FileContent::kEqualityDeletes ||
+        deleteFile.recordCount == 0 || deleteFile.equalityFieldIds.empty()) {
+      continue;
+    }
+    if (shouldSkipBySequenceNumber(
+            deleteFile.dataSequenceNumber,
+            icebergSplit_->dataSequenceNumber,
+            /*isEqualityDelete=*/true)) {
+      continue;
+    }
+
+    auto [equalityColumnNames, equalityColumnTypes] =
+        resolveEqualityColumns(deleteFile);
+    for (size_t i = 0; i < equalityColumnNames.size(); ++i) {
+      const auto& name = equalityColumnNames[i];
+      // Skip if this column was already added by a previous delete file.
+      if (std::find(
+              extraEqualityColumns.begin(), extraEqualityColumns.end(), name) !=
+          extraEqualityColumns.end()) {
+        continue;
+      }
+      auto* fieldSpec = scanSpec_->childByName(name);
+      const bool alreadyInOutput =
+          readerOutputType_->getChildIdxIfExists(name).has_value();
+      if (fieldSpec != nullptr && fieldSpec->projectOut() && alreadyInOutput) {
+        // Already projected by the user (or a previous augmentation) AND
+        // present in the output type by name. The equality-delete reader can
+        // probe it directly.
+        continue;
+      }
+      // Either no spec exists, or one exists but is filter-only, or the
+      // scan-spec child is projected but the column is missing from
+      // 'readerOutputType_'. In all cases ensure the column ends up in
+      // 'readerOutputType_' AND has a projected scan-spec child with a
+      // non-conflicting channel.
+      if (fieldSpec == nullptr) {
+        fieldSpec = scanSpec_->getOrCreateChild(name);
+      }
+      fieldSpec->setProjectOut(true);
+      fieldSpec->setChannel(
+          static_cast<column_index_t>(
+              readerOutputType_->size() + extraEqualityColumns.size()));
+
+      // For partition columns set the partition value directly as a constant
+      // on the scan-spec child. This is independent of whether the data file
+      // contains the partition column physically. With the constant set
+      // up-front, 'adaptColumns' does not need any special-case logic for
+      // augmented partition columns and the read does not depend on the
+      // writer's choice of including the partition column in the file.
+      auto partitionIt = splitPartitionKeys.find(name);
+      if (partitionIt != splitPartitionKeys.end()) {
+        // Iceberg encodes DATE partition values as the integer number of
+        // days since the Unix epoch (e.g. "19345"). The standard
+        // 'setPartitionValue' helper learns this from the planner-supplied
+        // ColumnHandle via 'isPartitionDateValueDaysSinceEpoch()', but no
+        // ColumnHandle is available here when the partition column is not
+        // in the user's projection. Derive the flag from the column type
+        // instead — Iceberg always uses days-since-epoch for DATE.
+        const bool isDaysSinceEpoch = equalityColumnTypes[i]->isDate();
+        auto constant = newConstantFromString(
+            equalityColumnTypes[i],
+            partitionIt->second,
+            connectorQueryCtx_->memoryPool(),
+            fileConfig_->readTimestampPartitionValueAsLocalTime(
+                connectorQueryCtx_->sessionProperties()),
+            isDaysSinceEpoch);
+        fieldSpec->setConstantValue(constant);
+        // Mirror Java's PARTITION_KEY column-type marking: this column's
+        // value MUST come from the partition metadata, never from the file
+        // body. Track it so 'adaptColumns' Branch 1 does not later wipe the
+        // constant when the file happens to also carry the column.
+        equalityAugmentedPartitionColumns_.insert(name);
+      }
+
+      extraEqualityColumns.push_back(name);
+      extraNames.push_back(name);
+      extraTypes.push_back(equalityColumnTypes[i]);
+    }
+  }
+
+  if (extraEqualityColumns.empty()) {
+    return;
+  }
+
+  // Extend 'readerOutputType_' so the upstream FileDataSource allocates the
+  // output RowVector wide enough for the augmented scan-spec channels. The
+  // original projection columns remain at indices [0, originalSize), so
+  // FileDataSource's positional projection still returns exactly the
+  // user-requested columns.
+  auto names = readerOutputType_->names();
+  auto types = readerOutputType_->children();
+  names.insert(names.end(), extraNames.begin(), extraNames.end());
+  types.insert(types.end(), extraTypes.begin(), extraTypes.end());
+  readerOutputType_ = ROW(std::move(names), std::move(types));
+}
+
+std::pair<std::vector<std::string>, std::vector<TypePtr>>
+IcebergSplitReader::resolveEqualityColumns(
+    const IcebergDeleteFile& deleteFile) const {
+  std::vector<std::string> equalityColumnNames;
+  std::vector<TypePtr> equalityColumnTypes;
+
+  const auto& dataColumns = tableHandle_->dataColumns();
+  VELOX_CHECK(
+      dataColumns != nullptr,
+      "Iceberg equality delete file '{}' cannot be processed because "
+      "table data columns are not available in HiveTableHandle.",
+      deleteFile.filePath);
+  for (const auto& eqFieldId : deleteFile.equalityFieldIds) {
+    // Field IDs are 1-based sequential for non-evolved schemas.
+    auto colIdx = static_cast<uint32_t>(eqFieldId - 1);
+    VELOX_CHECK_LT(
+        colIdx,
+        dataColumns->size(),
+        "Equality delete field ID {} out of range. This may indicate "
+        "schema evolution with non-sequential field IDs, which is "
+        "not yet supported.",
+        eqFieldId);
+    equalityColumnNames.push_back(dataColumns->nameOf(colIdx));
+    equalityColumnTypes.push_back(dataColumns->childAt(colIdx));
+  }
+  return {std::move(equalityColumnNames), std::move(equalityColumnTypes)};
 }
 
 uint64_t IcebergSplitReader::next(uint64_t size, VectorPtr& output) {
@@ -366,17 +483,34 @@ std::vector<TypePtr> IcebergSplitReader::adaptColumns(
       auto fileTypeIdx = fileType->getChildIdxIfExists(fieldName);
       auto outputTypeIdx = readerOutputType_->getChildIdxIfExists(fieldName);
       if (outputTypeIdx.has_value() && fileTypeIdx.has_value()) {
+        if (equalityAugmentedPartitionColumns_.count(fieldName) > 0) {
+          // This column was pre-installed as a partition-value constant by
+          // 'configureEqualityDeleteColumns'. Mirror Java's PARTITION_KEY
+          // semantics — the value comes from partition metadata, never from
+          // the file body, even though the file body happens to carry the
+          // column. Leave the constant in place; the column type entry for
+          // the file column index stays as the file type so Velox does not
+          // try to bind this output channel to a file read.
+          continue;
+        }
         childSpec->setConstantValue(nullptr);
         auto& outputType = readerOutputType_->childAt(*outputTypeIdx);
         columnTypes[*fileTypeIdx] = outputType;
       } else if (!fileTypeIdx.has_value()) {
-        // Handle columns missing from the data file in two scenarios:
+        // Handle columns missing from the data file in three scenarios:
         // 1. Schema evolution: Column was added after the data file was
-        // written and doesn't exist in older data files.
-        // 2. Partition columns: Hive migrated table. In Hive-written data
-        // files, partition column values are stored in partition metadata
-        // rather than in the data file itself, following Hive's partitioning
-        // convention.
+        //    written and doesn't exist in older data files.
+        // 2. Partition columns from a Hive-migrated table where partition
+        //    column values are stored in partition metadata rather than in
+        //    the data file itself.
+        // 3. Equality-delete partition columns not in the user's projection:
+        //    'configureEqualityDeleteColumns' has already pre-installed the
+        //    partition value as a constant, so this branch leaves it alone.
+        if (childSpec->isConstant()) {
+          // Constant already set (case 3, or set on a previous prepareSplit
+          // call for the same scanSpec). Nothing to do.
+          continue;
+        }
         auto partitionIt = fileSplit_->partitionKeys.find(fieldName);
         if (partitionIt != fileSplit_->partitionKeys.end()) {
           setPartitionValue(childSpec.get(), fieldName, partitionIt->second);

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.h
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <folly/container/F14Set.h>
+
 #include "velox/connectors/Connector.h"
 #include "velox/connectors/hive/FileSplitReader.h"
 #include "velox/connectors/hive/iceberg/DeletionVectorReader.h"
@@ -96,6 +98,37 @@ class IcebergSplitReader : public FileSplitReader {
   std::vector<TypePtr> adaptColumns(
       const RowTypePtr& fileType,
       const RowTypePtr& tableSchema) const override;
+
+  // Resolves the equality field IDs of an equality-delete file to the
+  // corresponding column names and types in the table schema. In Iceberg,
+  // field IDs for top-level columns are assigned sequentially starting from
+  // 1, matching the column order in the table schema.
+  std::pair<std::vector<std::string>, std::vector<TypePtr>>
+  resolveEqualityColumns(const IcebergDeleteFile& deleteFile) const;
+
+  // Discovers equality-delete columns that are not in the user's projection
+  // and augments 'scanSpec_' and 'readerOutputType_' so they are physically
+  // read and made available in the output RowVector. For partition columns
+  // the partition value is set as a constant on the scan-spec child so the
+  // augmentation works regardless of whether the data file physically
+  // contains the partition column. Augmented columns are appended at the end
+  // of 'readerOutputType_' so the upstream FileDataSource's positional
+  // projection naturally drops them from the operator output.
+  void configureEqualityDeleteColumns();
+
+  // Names of scan-spec children that 'configureEqualityDeleteColumns'
+  // pre-installed a partition-value constant on for the current split.
+  // Mirrors the Java 'PARTITION_KEY' column-type distinction in
+  // 'IcebergUtil.getColumns(fields, schema, partitionSpec, typeManager)':
+  // for an equality-delete column that is also an identity-partition
+  // column, the value MUST come from the split's partition metadata, never
+  // from the data file body — even if the file body physically contains
+  // the column. 'adaptColumns' uses this set to skip clearing the partition
+  // constant on Branch 1, which would otherwise leave the column stuck as
+  // a constant null and break equality-delete matching after schema
+  // evolution adds new columns at indices that shift the augmented column
+  // out of its file-natural position.
+  folly::F14FastSet<std::string> equalityAugmentedPartitionColumns_;
 
   const std::shared_ptr<const HiveIcebergSplit> icebergSplit_;
 

--- a/velox/connectors/hive/iceberg/tests/EqualityDeleteFileReaderTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/EqualityDeleteFileReaderTest.cpp
@@ -85,6 +85,22 @@ class EqualityDeleteFileReaderTest : public HiveConnectorTestBase {
       const std::string& dataFilePath,
       const std::vector<IcebergDeleteFile>& deleteFiles = {},
       int64_t dataSequenceNumber = 0) {
+    return makeSplits(
+        dataFilePath,
+        /*partitionKeys=*/{},
+        deleteFiles,
+        dataSequenceNumber);
+  }
+
+  /// Creates splits with equality delete files and partition keys attached.
+  /// Use this overload to exercise the equality-delete augmentation for
+  /// partition columns missing from the user's projection.
+  std::vector<std::shared_ptr<ConnectorSplit>> makeSplits(
+      const std::string& dataFilePath,
+      const std::unordered_map<std::string, std::optional<std::string>>&
+          partitionKeys,
+      const std::vector<IcebergDeleteFile>& deleteFiles,
+      int64_t dataSequenceNumber = 0) {
     auto fileSize = getFileSize(dataFilePath);
     return {std::make_shared<HiveIcebergSplit>(
         kIcebergConnectorId,
@@ -92,7 +108,7 @@ class EqualityDeleteFileReaderTest : public HiveConnectorTestBase {
         dwio::common::FileFormat::DWRF,
         0,
         fileSize,
-        std::unordered_map<std::string, std::optional<std::string>>{},
+        partitionKeys,
         std::nullopt,
         std::unordered_map<std::string, std::string>{},
         nullptr,
@@ -105,11 +121,22 @@ class EqualityDeleteFileReaderTest : public HiveConnectorTestBase {
 
   /// Builds a table scan plan node with the given schema.
   core::PlanNodePtr makeTableScanPlan(const RowTypePtr& rowType) {
+    return makeTableScanPlan(rowType, rowType);
+  }
+
+  /// Builds a table scan plan node with separate output and table column
+  /// schemas. Use this when the user's projection ('outputType') does not
+  /// contain every column referenced by an equality delete file
+  /// ('dataColumns' must contain the full table schema so the equality
+  /// column resolution can map field IDs to names).
+  core::PlanNodePtr makeTableScanPlan(
+      const RowTypePtr& outputType,
+      const RowTypePtr& dataColumns) {
     return PlanBuilder()
         .startTableScan()
         .connectorId(kIcebergConnectorId)
-        .outputType(rowType)
-        .dataColumns(rowType)
+        .outputType(outputType)
+        .dataColumns(dataColumns)
         .endTableScan()
         .planNode();
   }
@@ -153,6 +180,525 @@ TEST_F(EqualityDeleteFileReaderTest, basicSingleColumnDelete) {
       {
           makeFlatVector<int64_t>({0, 1, 2, 4, 5, 6, 8, 9}),
           makeFlatVector<std::string>({"a", "b", "c", "e", "f", "g", "i", "j"}),
+      });
+
+  assertEqualResults({expected}, {result});
+}
+
+/// Regression test for the bug where IcebergSplitReader fails with
+/// "Column not found in row: <name>" when an equality-delete column is not
+/// part of the user's projection. The reader must augment its scan spec to
+/// physically read the equality-delete column, apply the delete, and then
+/// project the column away from the output before returning to the operator.
+TEST_F(EqualityDeleteFileReaderTest, equalityColumnNotInProjection) {
+  auto tableType = ROW({"id", "value"}, {BIGINT(), VARCHAR()});
+  // The user only selects 'value'. The equality delete is on 'id', which is
+  // NOT in the projection — this is the case that previously failed.
+  auto outputType = ROW({"value"}, {VARCHAR()});
+
+  auto baseData = makeRowVector(
+      {"id", "value"},
+      {
+          makeFlatVector<int64_t>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}),
+          makeFlatVector<std::string>(
+              {"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"}),
+      });
+  auto dataFile = writeDataFile({baseData});
+
+  // Delete rows where id == 3 or id == 7.
+  auto deleteData = makeRowVector(
+      {"id"},
+      {
+          makeFlatVector<int64_t>({3, 7}),
+      });
+  auto eqDeleteFile = writeEqDeleteFile({deleteData});
+
+  IcebergDeleteFile icebergDeleteFile(
+      FileContent::kEqualityDeletes,
+      eqDeleteFile->getPath(),
+      dwio::common::FileFormat::DWRF,
+      2,
+      getFileSize(eqDeleteFile->getPath()),
+      /*equalityFieldIds=*/{1}); // field ID 1 = column 0 = "id"
+
+  auto splits = makeSplits(dataFile->getPath(), {icebergDeleteFile});
+  auto plan = makeTableScanPlan(outputType, tableType);
+  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
+
+  // The 'id' column must not appear in the output; only 'value' is projected.
+  // Rows with id=3 ("d") and id=7 ("h") are removed by the equality delete.
+  auto expected = makeRowVector(
+      {"value"},
+      {
+          makeFlatVector<std::string>({"a", "b", "c", "e", "f", "g", "i", "j"}),
+      });
+
+  assertEqualResults({expected}, {result});
+}
+
+/// Verifies that two equality-delete files referencing the SAME column not in
+/// the user's projection only augment 'scanSpec_' once. Exercises the
+/// de-duplication branch in 'IcebergSplitReader::prepareSplit'.
+TEST_F(EqualityDeleteFileReaderTest, multipleDeleteFilesSameMissingColumn) {
+  auto tableType = ROW({"id", "value"}, {BIGINT(), VARCHAR()});
+  auto outputType = ROW({"value"}, {VARCHAR()});
+
+  auto baseData = makeRowVector(
+      {"id", "value"},
+      {
+          makeFlatVector<int64_t>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}),
+          makeFlatVector<std::string>(
+              {"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"}),
+      });
+  auto dataFile = writeDataFile({baseData});
+
+  // Two delete files, both targeting 'id' (which is NOT in the projection).
+  auto deleteData1 = makeRowVector(
+      {"id"},
+      {
+          makeFlatVector<int64_t>({2, 5}),
+      });
+  auto eqDeleteFile1 = writeEqDeleteFile({deleteData1});
+  IcebergDeleteFile icebergDeleteFile1(
+      FileContent::kEqualityDeletes,
+      eqDeleteFile1->getPath(),
+      dwio::common::FileFormat::DWRF,
+      2,
+      getFileSize(eqDeleteFile1->getPath()),
+      /*equalityFieldIds=*/{1});
+
+  auto deleteData2 = makeRowVector(
+      {"id"},
+      {
+          makeFlatVector<int64_t>({0, 9}),
+      });
+  auto eqDeleteFile2 = writeEqDeleteFile({deleteData2});
+  IcebergDeleteFile icebergDeleteFile2(
+      FileContent::kEqualityDeletes,
+      eqDeleteFile2->getPath(),
+      dwio::common::FileFormat::DWRF,
+      2,
+      getFileSize(eqDeleteFile2->getPath()),
+      /*equalityFieldIds=*/{1});
+
+  auto splits =
+      makeSplits(dataFile->getPath(), {icebergDeleteFile1, icebergDeleteFile2});
+  auto plan = makeTableScanPlan(outputType, tableType);
+  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
+
+  // Rows with id=0, 2, 5, 9 are removed (across both delete files).
+  auto expected = makeRowVector(
+      {"value"},
+      {
+          makeFlatVector<std::string>({"b", "d", "e", "g", "h", "i"}),
+      });
+
+  assertEqualResults({expected}, {result});
+}
+
+/// Verifies a multi-column equality-delete file where some columns ARE in the
+/// user's projection and some are NOT. Both must end up in the read output for
+/// the equality probe to succeed, while only the projected columns appear in
+/// the operator-visible result.
+TEST_F(EqualityDeleteFileReaderTest, equalityMixedInAndOutOfProjection) {
+  auto tableType = ROW({"a", "b", "c"}, {INTEGER(), VARCHAR(), BIGINT()});
+  // User selects only 'b' and 'c'. 'a' is referenced by the equality delete
+  // but not part of the projection.
+  auto outputType = ROW({"b", "c"}, {VARCHAR(), BIGINT()});
+
+  auto baseData = makeRowVector(
+      {"a", "b", "c"},
+      {
+          makeFlatVector<int32_t>({1, 2, 3, 4, 5}),
+          makeFlatVector<std::string>({"x", "y", "z", "x", "y"}),
+          makeFlatVector<int64_t>({10, 20, 30, 40, 50}),
+      });
+  auto dataFile = writeDataFile({baseData});
+
+  // Delete rows where (a=2, b="y") -- removes row 1.
+  // Also (a=1, b="y") -- no match (row with a=1 has b="x").
+  auto deleteData = makeRowVector(
+      {"a", "b"},
+      {
+          makeFlatVector<int32_t>({2, 1}),
+          makeFlatVector<std::string>({"y", "y"}),
+      });
+  auto eqDeleteFile = writeEqDeleteFile({deleteData});
+
+  IcebergDeleteFile icebergDeleteFile(
+      FileContent::kEqualityDeletes,
+      eqDeleteFile->getPath(),
+      dwio::common::FileFormat::DWRF,
+      3,
+      getFileSize(eqDeleteFile->getPath()),
+      /*equalityFieldIds=*/{1, 2}); // field IDs 1,2 = columns "a","b"
+
+  auto splits = makeSplits(dataFile->getPath(), {icebergDeleteFile});
+  auto plan = makeTableScanPlan(outputType, tableType);
+  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
+
+  // Row 1 (a=2, b="y", c=20) is deleted. The remaining rows project to
+  // (b, c).
+  auto expected = makeRowVector(
+      {"b", "c"},
+      {
+          makeFlatVector<std::string>({"x", "z", "x", "y"}),
+          makeFlatVector<int64_t>({10, 30, 40, 50}),
+      });
+
+  assertEqualResults({expected}, {result});
+}
+
+/// Verifies that an equality delete on a partition column that IS in the data
+/// file (Iceberg-style) but NOT in the user's projection works correctly. The
+/// augmentation should set the partition value as a constant; the file-read
+/// path should then leave the constant in place because the column is present
+/// in 'fileType'.
+TEST_F(
+    EqualityDeleteFileReaderTest,
+    equalityPartitionColumnInFileNotInProjection) {
+  auto tableType = ROW({"part", "value"}, {INTEGER(), VARCHAR()});
+  auto outputType = ROW({"value"}, {VARCHAR()});
+
+  // Data file contains both 'part' and 'value', all rows in partition 2.
+  auto baseData = makeRowVector(
+      {"part", "value"},
+      {
+          makeFlatVector<int32_t>({2, 2, 2, 2}),
+          makeFlatVector<std::string>({"a", "b", "c", "d"}),
+      });
+  auto dataFile = writeDataFile({baseData});
+
+  auto deleteData = makeRowVector(
+      {"part", "value"},
+      {
+          makeFlatVector<int32_t>({2, 2}),
+          makeFlatVector<std::string>({"b", "d"}),
+      });
+  auto eqDeleteFile = writeEqDeleteFile({deleteData});
+
+  IcebergDeleteFile icebergDeleteFile(
+      FileContent::kEqualityDeletes,
+      eqDeleteFile->getPath(),
+      dwio::common::FileFormat::DWRF,
+      2,
+      getFileSize(eqDeleteFile->getPath()),
+      /*equalityFieldIds=*/{1, 2});
+
+  auto splits = makeSplits(
+      dataFile->getPath(),
+      /*partitionKeys=*/{{"part", std::optional<std::string>{"2"}}},
+      {icebergDeleteFile});
+  auto plan = makeTableScanPlan(outputType, tableType);
+  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
+
+  auto expected = makeRowVector(
+      {"value"},
+      {
+          makeFlatVector<std::string>({"a", "c"}),
+      });
+
+  assertEqualResults({expected}, {result});
+}
+
+/// Same as above but the partition value does NOT match the equality-delete
+/// value, so no rows should be removed.
+TEST_F(
+    EqualityDeleteFileReaderTest,
+    equalityPartitionColumnNonMatchingPartition) {
+  auto tableType = ROW({"part", "value"}, {INTEGER(), VARCHAR()});
+  auto outputType = ROW({"value"}, {VARCHAR()});
+
+  // Data file holds rows in partition 2.
+  auto baseData = makeRowVector(
+      {"part", "value"},
+      {
+          makeFlatVector<int32_t>({2, 2, 2}),
+          makeFlatVector<std::string>({"a", "b", "c"}),
+      });
+  auto dataFile = writeDataFile({baseData});
+
+  // Delete (part=99, value="b"). No file row matches part=99.
+  auto deleteData = makeRowVector(
+      {"part", "value"},
+      {
+          makeFlatVector<int32_t>({99}),
+          makeFlatVector<std::string>({"b"}),
+      });
+  auto eqDeleteFile = writeEqDeleteFile({deleteData});
+
+  IcebergDeleteFile icebergDeleteFile(
+      FileContent::kEqualityDeletes,
+      eqDeleteFile->getPath(),
+      dwio::common::FileFormat::DWRF,
+      1,
+      getFileSize(eqDeleteFile->getPath()),
+      /*equalityFieldIds=*/{1, 2});
+
+  auto splits = makeSplits(
+      dataFile->getPath(),
+      /*partitionKeys=*/{{"part", std::optional<std::string>{"2"}}},
+      {icebergDeleteFile});
+  auto plan = makeTableScanPlan(outputType, tableType);
+  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
+
+  auto expected = makeRowVector(
+      {"value"},
+      {
+          makeFlatVector<std::string>({"a", "b", "c"}),
+      });
+
+  assertEqualResults({expected}, {result});
+}
+
+/// Multi-column equality delete where ONE column is a partition column not in
+/// the projection and ANOTHER is a regular data column not in the projection.
+/// Both must be augmented; the partition column gets a constant value, the
+/// regular column is read from the file.
+TEST_F(
+    EqualityDeleteFileReaderTest,
+    equalityMixedPartitionAndRegularNotInProjection) {
+  auto tableType =
+      ROW({"part", "id", "value"}, {INTEGER(), BIGINT(), VARCHAR()});
+  auto outputType = ROW({"value"}, {VARCHAR()});
+
+  // Data file contains all three columns, all rows in partition 7.
+  auto baseData = makeRowVector(
+      {"part", "id", "value"},
+      {
+          makeFlatVector<int32_t>({7, 7, 7, 7}),
+          makeFlatVector<int64_t>({10, 20, 30, 40}),
+          makeFlatVector<std::string>({"a", "b", "c", "d"}),
+      });
+  auto dataFile = writeDataFile({baseData});
+
+  // Delete (part=7, id=20) and (part=7, id=40). Should remove "b" and "d".
+  auto deleteData = makeRowVector(
+      {"part", "id"},
+      {
+          makeFlatVector<int32_t>({7, 7}),
+          makeFlatVector<int64_t>({20, 40}),
+      });
+  auto eqDeleteFile = writeEqDeleteFile({deleteData});
+
+  IcebergDeleteFile icebergDeleteFile(
+      FileContent::kEqualityDeletes,
+      eqDeleteFile->getPath(),
+      dwio::common::FileFormat::DWRF,
+      2,
+      getFileSize(eqDeleteFile->getPath()),
+      /*equalityFieldIds=*/{1, 2}); // field IDs 1,2 = part, id
+
+  auto splits = makeSplits(
+      dataFile->getPath(),
+      /*partitionKeys=*/{{"part", std::optional<std::string>{"7"}}},
+      {icebergDeleteFile});
+  auto plan = makeTableScanPlan(outputType, tableType);
+  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
+
+  auto expected = makeRowVector(
+      {"value"},
+      {
+          makeFlatVector<std::string>({"a", "c"}),
+      });
+
+  assertEqualResults({expected}, {result});
+}
+
+/// Verifies equality delete on a DATE partition column not in projection.
+/// Iceberg encodes DATE partition values as days-since-epoch (e.g. "19345").
+/// This exercises the type-derived 'isDaysSinceEpoch' flag in
+/// 'configureEqualityDeleteColumns' — for DATE columns the partition string
+/// must be parsed as an integer day count, NOT as an ISO-8601 date string.
+TEST_F(
+    EqualityDeleteFileReaderTest,
+    equalityDatePartitionColumnNotInProjection) {
+  auto tableType = ROW({"part_date", "value"}, {DATE(), VARCHAR()});
+  auto outputType = ROW({"value"}, {VARCHAR()});
+
+  // 19345 days since 1970-01-01 == 2022-12-22. All file rows belong to that
+  // partition.
+  constexpr int32_t kPartitionDays = 19345;
+  auto baseData = makeRowVector(
+      {"part_date", "value"},
+      {
+          makeFlatVector<int32_t>(
+              {kPartitionDays, kPartitionDays, kPartitionDays}, DATE()),
+          makeFlatVector<std::string>({"a", "b", "c"}),
+      });
+  auto dataFile = writeDataFile({baseData});
+
+  // Delete (part_date=19345, value="b").
+  auto deleteData = makeRowVector(
+      {"part_date", "value"},
+      {
+          makeFlatVector<int32_t>({kPartitionDays}, DATE()),
+          makeFlatVector<std::string>({"b"}),
+      });
+  auto eqDeleteFile = writeEqDeleteFile({deleteData});
+
+  IcebergDeleteFile icebergDeleteFile(
+      FileContent::kEqualityDeletes,
+      eqDeleteFile->getPath(),
+      dwio::common::FileFormat::DWRF,
+      1,
+      getFileSize(eqDeleteFile->getPath()),
+      /*equalityFieldIds=*/{1, 2});
+
+  auto splits = makeSplits(
+      dataFile->getPath(),
+      /*partitionKeys=*/
+      {{"part_date",
+        std::optional<std::string>{std::to_string(kPartitionDays)}}},
+      {icebergDeleteFile});
+  auto plan = makeTableScanPlan(outputType, tableType);
+  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
+
+  auto expected = makeRowVector(
+      {"value"},
+      {
+          makeFlatVector<std::string>({"a", "c"}),
+      });
+
+  assertEqualResults({expected}, {result});
+}
+
+/// Exercises the filter-only column upgrade path in
+/// 'configureEqualityDeleteColumns'. The equality-delete column 'id' is
+/// referenced by a WHERE predicate (so the planner installs a scan-spec
+/// child with 'projectOut=false') but is NOT in the user's SELECT
+/// projection. The augmentation must upgrade the existing scan-spec child
+/// from filter-only to 'projectOut=true' and assign a non-conflicting
+/// channel so the equality-delete reader can probe by name.
+TEST_F(EqualityDeleteFileReaderTest, equalityFilterOnlyColumnNotInProjection) {
+  auto tableType = ROW({"id", "value"}, {BIGINT(), VARCHAR()});
+  auto outputType = ROW({"value"}, {VARCHAR()});
+
+  auto baseData = makeRowVector(
+      {"id", "value"},
+      {
+          makeFlatVector<int64_t>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}),
+          makeFlatVector<std::string>(
+              {"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"}),
+      });
+  auto dataFile = writeDataFile({baseData});
+
+  // Equality delete removes id == 4 and id == 8.
+  auto deleteData = makeRowVector(
+      {"id"},
+      {
+          makeFlatVector<int64_t>({4, 8}),
+      });
+  auto eqDeleteFile = writeEqDeleteFile({deleteData});
+
+  IcebergDeleteFile icebergDeleteFile(
+      FileContent::kEqualityDeletes,
+      eqDeleteFile->getPath(),
+      dwio::common::FileFormat::DWRF,
+      2,
+      getFileSize(eqDeleteFile->getPath()),
+      /*equalityFieldIds=*/{1}); // field ID 1 = "id"
+
+  auto splits = makeSplits(dataFile->getPath(), {icebergDeleteFile});
+  // WHERE id >= 3 keeps rows {3,4,5,6,7,8,9} from the file; the equality
+  // delete then removes id=4 and id=8, leaving values {d->skipped} no, we
+  // expect surviving values for ids {3,5,6,7,9}, projected as 'value' only.
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kIcebergConnectorId)
+                  .outputType(outputType)
+                  .dataColumns(tableType)
+                  .subfieldFilter("id >= 3")
+                  .endTableScan()
+                  .planNode();
+  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
+
+  auto expected = makeRowVector(
+      {"value"},
+      {
+          makeFlatVector<std::string>({"d", "f", "g", "h", "j"}),
+      });
+
+  assertEqualResults({expected}, {result});
+}
+
+/// Regression test for the schema-evolution +
+/// partition-column-not-in-projection scenario surfaced by the Presto Iceberg
+/// integration test 'testEqualityDeleteWithPartitionColumnMissingInSelect'.
+///
+/// Setup (mirrors the Presto test for the older data file):
+///   - Full table schema: (a, b, c, d) with a, c, d as partition columns.
+///   - The data file under test was written BEFORE 'd' was added, so it
+///     physically contains only (a, b, c).
+///   - User projection: (a, b, d). 'd' must be NULL-filled (not in file);
+///     'c' is NOT in the projection but IS referenced by the equality
+///     delete and IS the file's identity-partition column.
+///
+/// The equality delete (a=6, c=2, b=1006) targets the file row
+/// (6, '1006', 2). The augmentation must:
+///   1. Add 'c' to 'scanSpec_' / 'readerOutputType_' so the eq-delete
+///      probe can find it by name.
+///   2. Leave 'd' alone — 'd' is in the user projection and gets the
+///      standard schema-evolution NULL-fill from 'adaptColumns'.
+///   3. Honour the existing partition-key constant on 'c' regardless of
+///      whether the file physically contains 'c'.
+TEST_F(
+    EqualityDeleteFileReaderTest,
+    equalityPartitionColumnNotInProjectionWithEvolvedSchema) {
+  // Full evolved table schema (after 'ALTER TABLE ADD COLUMN d').
+  auto tableType =
+      ROW({"a", "b", "c", "d"}, {INTEGER(), VARCHAR(), INTEGER(), VARCHAR()});
+  // User selects 'a', 'b', 'd'. Note 'c' is NOT projected.
+  auto outputType = ROW({"a", "b", "d"}, {INTEGER(), VARCHAR(), VARCHAR()});
+
+  // Data file contains only (a, b, c) — written before 'd' was added.
+  // Both rows are in the (a=6, c=2) partition.
+  auto baseData = makeRowVector(
+      {"a", "b", "c"},
+      {
+          makeFlatVector<int32_t>({6, 6}),
+          makeFlatVector<std::string>({"1006", "1009"}),
+          makeFlatVector<int32_t>({2, 2}),
+      });
+  auto dataFile = writeDataFile({baseData});
+
+  // Equality delete on (a, b, c) with values (6, '1006', 2). Field IDs
+  // are in field-id order = [1, 2, 3].
+  auto deleteData = makeRowVector(
+      {"a", "b", "c"},
+      {
+          makeFlatVector<int32_t>({6}),
+          makeFlatVector<std::string>({"1006"}),
+          makeFlatVector<int32_t>({2}),
+      });
+  auto eqDeleteFile = writeEqDeleteFile({deleteData});
+
+  IcebergDeleteFile icebergDeleteFile(
+      FileContent::kEqualityDeletes,
+      eqDeleteFile->getPath(),
+      dwio::common::FileFormat::DWRF,
+      1,
+      getFileSize(eqDeleteFile->getPath()),
+      /*equalityFieldIds=*/{1, 2, 3});
+
+  auto splits = makeSplits(
+      dataFile->getPath(),
+      /*partitionKeys=*/
+      {{"a", std::optional<std::string>{"6"}},
+       {"c", std::optional<std::string>{"2"}}},
+      {icebergDeleteFile});
+  auto plan = makeTableScanPlan(outputType, tableType);
+  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
+
+  // Row (6, '1006', 2) is deleted by the equality delete; (6, '1009', 2)
+  // survives. 'd' is NULL because the data file was written before 'd'
+  // was added.
+  auto expected = makeRowVector(
+      {"a", "b", "d"},
+      {
+          makeFlatVector<int32_t>({6}),
+          makeFlatVector<std::string>({"1009"}),
+          makeNullableFlatVector<std::string>({std::nullopt}),
       });
 
   assertEqualResults({expected}, {result});


### PR DESCRIPTION
Summary:

When an Iceberg query reads through `IcebergSplitReader` and the table has an
equality-delete file that references a column NOT in the user's `SELECT`
projection, the query previously failed deterministically with:

```
Column not found in row: <equality-delete-column-name>
```

Example: equality delete on `regionkey`, query is `SELECT nationkey FROM
nation` — fails. Same query with `SELECT regionkey, nationkey` works.

A second, more subtle wrong-result variant was also fixed (see step 6 below):
even when the augmentation correctly added the missing column, queries that
hit a data file written under an OLDER partition spec — with the augmented
column being an identity-partition column — would silently lose the
partition value and return extra rows that should have been deleted.

## Root cause

In `IcebergSplitReader::prepareSplit`, the original ordering was:
1. `getAdaptedRowType()` — finalises `scanSpec_` based on the user's projection.
2. `createRowReader(...)` — builds the row reader against that spec.
3. Walks `deleteFiles` to construct equality-delete readers.

By the time step 3 discovered which equality-delete columns existed, the row
reader was already locked in. `EqualityDeleteFileReader::applyDeletes` then
tried to look up its required columns by name in the data-scan output
`RowVector` — and threw via `VELOX_CHECK` because the column wasn't read.

## Fix

Mirror Trino's `IcebergPageSourceProvider` + `ProjectionsAdapter` pattern,
contained entirely inside `IcebergSplitReader`:

1. Discover equality-delete column names in `prepareSplit` BEFORE
   `getAdaptedRowType()` via a new helper `resolveEqualityColumns()`.
2. For each missing or filter-only column, set `projectOut(true)` on the
   scan-spec child (creating it if absent) with a channel beyond the original
   projection.
3. Extend `readerOutputType_` by appending the extra columns at the END so
   the upstream `FileDataSource` allocates a wide-enough output `RowVector`.
   `FileDataSource`'s positional projection (`childAt(i)` for `i in [0,
   outputType_->size())`) naturally drops the extras from the operator
   output, so no caller change is required.
4. Filter-only columns (already in `scanSpec_` with `projectOut == false`,
   e.g. referenced by a `WHERE` predicate) are also upgraded to
   `projectOut == true` and appended to `readerOutputType_`.
5. Improved the `VELOX_CHECK` message in `EqualityDeleteFileReader.cpp` so
   any future regression is easier to diagnose.
6. **Preserve partition-value constants for augmented partition columns.**
   When `configureEqualityDeleteColumns` pre-installs a partition-value
   constant on an augmented column (because the column is also an identity
   partition key), the existing `adaptColumns` Branch 1 used to call
   `setConstantValue(nullptr)` whenever the column also existed in the file
   body — intending to switch to file-read mode. In Velox's `ScanSpec`
   semantics, `setConstantValue(nullptr)` does NOT clear constant mode; it
   leaves the column stuck as a constant null. Result: equality-delete
   hashing produced no match for older data files written under earlier
   partition specs, and rows that should have been deleted survived.

   The fix mirrors Java's `IcebergUtil.getColumns(fields, schema,
   partitionSpec, typeManager)` `PARTITION_KEY` vs `REGULAR` distinction:
   for an equality-delete column that is also an identity-partition column,
   the value MUST come from the split's partition metadata, never from the
   file body. Track these columns in a new member set
   `equalityAugmentedPartitionColumns_` (cleared per-split in
   `configureEqualityDeleteColumns`); `adaptColumns` Branch 1 skips the
   `setConstantValue(nullptr)` clearing for tracked columns, preserving
   the partition value across splits regardless of whether the file body
   carries the column.

## Why the bug shipped

Every existing test in `EqualityDeleteFileReaderTest.cpp` projected the
equality-delete column. The plan-builder helper `makeTableScanPlan` reused
the same `rowType` for both `outputType` and `dataColumns`, so the
missing-column path was never exercised. The bug was introduced in
D100061160 (the Velox-side V3 DV + equality-delete feature commit) and
shipped silently.

The partition-column variant (step 6) was even more hidden: it required
both an augmented equality-delete column AND multiple `ALTER TABLE ADD
COLUMN` operations evolving the partition spec across snapshots, so that
the augmented column lands at an output index beyond the file-natural
positions. None of the existing native-equality-delete tests exercised
multi-snapshot partition evolution.

Reviewed By: raymondlin1

Differential Revision: D101858175


