### PR TITLE
fix: Replace folly::grow_capacity_by with std::vector::reserve in PrestoSerializerEstimationUtils (#17288)

### DIFF
--- a/velox/serializers/PrestoSerializerEstimationUtils.cpp
+++ b/velox/serializers/PrestoSerializerEstimationUtils.cpp
@@ -18,8 +18,6 @@
 #include "velox/vector/FlatVector.h"
 #include "velox/vector/VectorTypeUtils.h"
 
-#include <folly/container/Reserve.h>
-
 namespace facebook::velox::serializer::presto::detail {
 namespace {
 template <TypeKind Kind>
@@ -364,8 +362,8 @@ void estimateWrapperSerializedSize(
     for (int32_t i = 0; i < ranges.size(); ++i) {
       totalSize += ranges[i].size;
     }
-    folly::grow_capacity_by(newRanges, totalSize);
-    folly::grow_capacity_by(newSizes, totalSize);
+    newRanges.reserve(totalSize);
+    newSizes.reserve(totalSize);
   }
   for (int32_t i = 0; i < ranges.size(); ++i) {
     int32_t numNulls = 0;
@@ -396,8 +394,8 @@ void expandRepeatedRanges(
     for (int32_t i = 0; i < ranges.size(); ++i) {
       totalSize += ranges[i].size;
     }
-    folly::grow_capacity_by(*childRanges, totalSize);
-    folly::grow_capacity_by(*childSizes, totalSize);
+    childRanges->reserve(totalSize);
+    childSizes->reserve(totalSize);
   }
   for (int32_t i = 0; i < ranges.size(); ++i) {
     int32_t begin = ranges[i].begin;


### PR DESCRIPTION
Summary:

Replace all usages of `folly::grow_capacity_by` with `std::vector::reserve` in `PrestoSerializerEstimationUtils.cpp`. Since the vectors start empty in both `estimateWrapperSerializedSize` and `expandRepeatedRanges`, `reserve` is functionally identical and simpler. This removes the dependency on `folly/container/Reserve.h` from this file, supporting Velox's ongoing effort to reduce Folly dependencies.

Addresses post-land review comment on D98150572.

Differential Revision: D101866359
