### PR TITLE
fix: Resolve UNKNOWN coercion to parameterized signatures (#17290)

### DIFF
--- a/velox/exec/tests/AggregateFunctionRegistryTest.cpp
+++ b/velox/exec/tests/AggregateFunctionRegistryTest.cpp
@@ -133,6 +133,40 @@ TEST_F(AggregateFunctionRegistryTest, coercions) {
       "aggregate_func", {INTEGER(), DOUBLE()}, BIGINT(), {BIGINT(), nullptr});
 }
 
+TEST_F(AggregateFunctionRegistryTest, unknownArgTieStaysAmbiguous) {
+  // Aggregate signatures carry no null-on-null metadata, so an UNKNOWN-induced
+  // tie stays ambiguous even when both overloads share a return type.
+  registerAggregateFunction(
+      "unknown_tie",
+      {exec::AggregateFunctionSignatureBuilder()
+           .typeVariable("T")
+           .returnType("bigint")
+           .intermediateType("bigint")
+           .argumentType("array(T)")
+           .build(),
+       exec::AggregateFunctionSignatureBuilder()
+           .typeVariable("K")
+           .typeVariable("V")
+           .returnType("bigint")
+           .intermediateType("bigint")
+           .argumentType("map(K,V)")
+           .build()},
+      [](core::AggregationNode::Step,
+         const std::vector<TypePtr>&,
+         const TypePtr& resultType,
+         const core::QueryConfig&) -> std::unique_ptr<exec::Aggregate> {
+        return std::make_unique<AggregateFunc>(resultType);
+      },
+      /*registerCompanionFunctions*/ false,
+      /*overwrite*/ true);
+
+  std::vector<TypePtr> coercions;
+  VELOX_ASSERT_THROW(
+      resolveResultTypeWithCoercions(
+          "unknown_tie", {UNKNOWN()}, coercions, TypeCoercer::defaults()),
+      "Aggregate function signature is not supported");
+}
+
 TEST_F(AggregateFunctionRegistryTest, functionNameInMixedCase) {
   testResolve(
       "aggregatE_funC", {BIGINT(), DOUBLE()}, BIGINT(), ARRAY(BIGINT()));

--- a/velox/expression/SignatureBinder.cpp
+++ b/velox/expression/SignatureBinder.cpp
@@ -374,6 +374,17 @@ bool SignatureBinder::tryBindVariablesWithCoercion(
   }
 
   const auto& params = typeSignature.parameters();
+
+  // Bind the type variables to UNKNOWN so the parameterized formal resolves.
+  if (actualType->isUnknown()) {
+    for (const auto& param : params) {
+      if (!tryBindVariablesWithCoercion(param, UNKNOWN())) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   if (params.size() != actualType->parameters().size()) {
     return false;
   }
@@ -409,6 +420,24 @@ bool SignatureBinderBase::tryBind(
   const auto& baseName = typeSignature.baseName();
   auto typeName = boost::algorithm::to_upper_copy(baseName);
   if (!boost::algorithm::iequals(typeName, actualType->name())) {
+    if (allowCoercion && actualType->isUnknown() &&
+        !typeSignature.parameters().empty()) {
+      auto resolvedType = SignatureBinder::tryResolveType(
+          typeSignature,
+          variables(),
+          typeVariablesBindings_,
+          integerVariablesBindings_,
+          longEnumVariablesBindings_,
+          varcharEnumVariablesBindings_);
+      // This path only coerces UNKNOWN to complex types.
+      if (!resolvedType || resolvedType->size() == 0) {
+        return false;
+      }
+      auto availableCoercion = coercer_.coerce(UNKNOWN(), resolvedType);
+      VELOX_CHECK(availableCoercion.has_value());
+      coercion = availableCoercion.value();
+      return true;
+    }
     if (allowCoercion && typeSignature.parameters().empty()) {
       if (auto availableCoercion =
               coercer_.coerceTypeBase(actualType, typeName)) {
@@ -638,6 +667,8 @@ TypePtr tryResolveReturnTypeWithCoercions(
     }
   }
 
+  // Aggregate/window signatures don't model null-on-null, so UNKNOWN ties stay
+  // ambiguous here (no tie-break).
   if (auto index = Coercion::pickLowestCost(candidates)) {
     const auto& requiredCoercions = candidates[index.value()].first;
     coercions.reserve(requiredCoercions.size());

--- a/velox/expression/SimpleFunctionRegistry.cpp
+++ b/velox/expression/SimpleFunctionRegistry.cpp
@@ -247,7 +247,16 @@ SimpleFunctionRegistry::resolveFunction(
 
       if (!candidates.empty()) {
         if (allowCoercion) {
-          if (auto index = Coercion::pickLowestCost(candidates)) {
+          auto index = Coercion::pickLowestCost(
+              candidates, argTypes, [&](size_t candidateIndex) {
+                return Coercion::CandidateMetadata{
+                    .returnType = candidates[candidateIndex].second.second,
+                    .nullOnNull = candidates[candidateIndex]
+                                      .second.first->getMetadata()
+                                      .defaultNullBehavior()};
+              });
+
+          if (index) {
             selectedCandidate = candidates[index.value()].second;
 
             const auto& selectedCoercions = candidates[index.value()].first;

--- a/velox/expression/VectorFunction.cpp
+++ b/velox/expression/VectorFunction.cpp
@@ -148,6 +148,7 @@ resolveVectorFunctionWithMetadataWithCoercions(
           std::vector<Coercion> requiredCoercions;
           if (binder.tryBindWithCoercions(requiredCoercions)) {
             auto type = binder.tryResolveReturnType();
+            VELOX_CHECK_NOT_NULL(type);
             if (!hasCoercion(requiredCoercions)) {
               coercions.resize(argTypes.size(), nullptr);
               return {{type, entry.metadata}};
@@ -157,7 +158,15 @@ resolveVectorFunctionWithMetadataWithCoercions(
           }
         }
 
-        if (auto index = Coercion::pickLowestCost(candidates)) {
+        // All signatures share one metadata, so null behavior is uniform.
+        auto index = Coercion::pickLowestCost(
+            candidates, argTypes, [&](size_t candidateIndex) {
+              return Coercion::CandidateMetadata{
+                  .returnType = candidates[candidateIndex].second,
+                  .nullOnNull = entry.metadata.defaultNullBehavior};
+            });
+
+        if (index) {
           const auto& requiredCoercions = candidates[index.value()].first;
           coercions.reserve(requiredCoercions.size());
           for (const auto& coercion : requiredCoercions) {

--- a/velox/expression/tests/SignatureBinderTest.cpp
+++ b/velox/expression/tests/SignatureBinderTest.cpp
@@ -1680,6 +1680,255 @@ TEST(SignatureBinderTest, unknownInComplexTypes) {
   }
 }
 
+TEST(SignatureBinderTest, unknownCoercesToComplexType) {
+  auto makeSignature = [](const std::string& returnType,
+                          const std::string& argType,
+                          const std::vector<std::string>& typeVariables) {
+    exec::FunctionSignatureBuilder builder;
+    for (const auto& variable : typeVariables) {
+      builder.typeVariable(variable);
+    }
+    return builder.returnType(returnType).argumentType(argType).build();
+  };
+
+  testCoercions(
+      makeSignature("bigint", "array(T)", {"T"}),
+      {UNKNOWN()},
+      {ARRAY(UNKNOWN())},
+      BIGINT());
+
+  testCoercions(
+      makeSignature("bigint", "map(K,V)", {"K", "V"}),
+      {UNKNOWN()},
+      {MAP(UNKNOWN(), UNKNOWN())},
+      BIGINT());
+
+  // Return type depends on the type variable, which stays UNKNOWN.
+  testCoercions(
+      makeSignature("T", "array(T)", {"T"}),
+      {UNKNOWN()},
+      {ARRAY(UNKNOWN())},
+      UNKNOWN());
+
+  testCoercions(
+      makeSignature("array(T)", "array(T)", {"T"}),
+      {UNKNOWN()},
+      {ARRAY(UNKNOWN())},
+      ARRAY(UNKNOWN()));
+}
+
+TEST(SignatureBinderTest, unknownDoesNotBindWithoutCoercion) {
+  // Exact bind must fail; only coercion can map UNKNOWN to array(T).
+  auto signature = exec::FunctionSignatureBuilder()
+                       .typeVariable("T")
+                       .returnType("bigint")
+                       .argumentType("array(T)")
+                       .build();
+
+  assertCannotBind(signature, {UNKNOWN()});
+
+  // decimal(P,S) leaves precision and scale unbound, so even coercion fails.
+  auto decimalSignature = exec::FunctionSignatureBuilder()
+                              .integerVariable("a_precision")
+                              .integerVariable("a_scale")
+                              .returnType("bigint")
+                              .argumentType("decimal(a_precision, a_scale)")
+                              .build();
+
+  assertCannotBind(decimalSignature, {UNKNOWN()}, /*allowCoercion=*/true);
+
+  // Shared (p, s) resolves the UNKNOWN arg to a decimal scalar; no coercion.
+  auto boundDecimalSignature = exec::FunctionSignatureBuilder()
+                                   .integerVariable("p")
+                                   .integerVariable("s")
+                                   .returnType("decimal(p, s)")
+                                   .argumentType("decimal(p, s)")
+                                   .argumentType("decimal(p, s)")
+                                   .build();
+
+  assertCannotBind(
+      boundDecimalSignature,
+      {DECIMAL(10, 2), UNKNOWN()},
+      /*allowCoercion=*/true);
+}
+
+TEST(SignatureBinderTest, unknownArgUnifiesWithConcreteArg) {
+  // foo(array(T), T): the concrete INTEGER pins T, so UNKNOWN coerces to
+  // array(INTEGER). Order independent.
+  auto signature = exec::FunctionSignatureBuilder()
+                       .typeVariable("T")
+                       .returnType("T")
+                       .argumentType("array(T)")
+                       .argumentType("T")
+                       .build();
+
+  testCoercions(
+      signature,
+      {UNKNOWN(), INTEGER()},
+      {ARRAY(INTEGER()), nullptr},
+      INTEGER());
+
+  auto reversed = exec::FunctionSignatureBuilder()
+                      .typeVariable("T")
+                      .returnType("T")
+                      .argumentType("T")
+                      .argumentType("array(T)")
+                      .build();
+
+  testCoercions(
+      reversed, {INTEGER(), UNKNOWN()}, {nullptr, ARRAY(INTEGER())}, INTEGER());
+
+  // Two type variables: foo(map(K,V), V). The concrete INTEGER pins V; K has no
+  // concrete arg, so the UNKNOWN map coerces to map(UNKNOWN, INTEGER). Order
+  // independent.
+  auto twoVariables = exec::FunctionSignatureBuilder()
+                          .typeVariable("K")
+                          .typeVariable("V")
+                          .returnType("V")
+                          .argumentType("map(K,V)")
+                          .argumentType("V")
+                          .build();
+
+  testCoercions(
+      twoVariables,
+      {UNKNOWN(), INTEGER()},
+      {MAP(UNKNOWN(), INTEGER()), nullptr},
+      INTEGER());
+
+  auto twoVariablesReversed = exec::FunctionSignatureBuilder()
+                                  .typeVariable("K")
+                                  .typeVariable("V")
+                                  .returnType("V")
+                                  .argumentType("V")
+                                  .argumentType("map(K,V)")
+                                  .build();
+
+  testCoercions(
+      twoVariablesReversed,
+      {INTEGER(), UNKNOWN()},
+      {nullptr, MAP(UNKNOWN(), INTEGER())},
+      INTEGER());
+}
+
+TEST(SignatureBinderTest, pickLowestCostUnknownTie) {
+  using Candidate =
+      std::pair<std::vector<Coercion>, Coercion::CandidateMetadata>;
+
+  auto resolutionAt = [](const std::vector<Candidate>& candidates) {
+    return [&candidates](size_t candidateIndex) {
+      return candidates[candidateIndex].second;
+    };
+  };
+
+  // Exactly one unknown-only-coercion candidate in the tie resolves to it.
+  {
+    std::vector<TypePtr> argTypes{UNKNOWN(), BIGINT()};
+    std::vector<Candidate> candidates{
+        // Not unknown-only: coercion on the non-UNKNOWN position.
+        {{Coercion{}, Coercion{.type = DOUBLE(), .cost = 1}},
+         Coercion::CandidateMetadata{
+             .returnType = BIGINT(), .nullOnNull = true}},
+        // Unknown-only: coercion on the UNKNOWN position.
+        {{Coercion{.type = BIGINT(), .cost = 1}, Coercion{}},
+         Coercion::CandidateMetadata{
+             .returnType = VARCHAR(), .nullOnNull = true}},
+    };
+
+    auto index = Coercion::pickLowestCost(
+        candidates, argTypes, resolutionAt(candidates));
+    ASSERT_TRUE(index.has_value());
+    EXPECT_EQ(index.value(), 1);
+  }
+
+  // Two unknown-only candidates with one shared null-on-null return type are
+  // interchangeable, so the lowest index resolves.
+  {
+    std::vector<TypePtr> argTypes{UNKNOWN()};
+    std::vector<Candidate> candidates{
+        {{Coercion{.type = BIGINT(), .cost = 1}},
+         Coercion::CandidateMetadata{
+             .returnType = BIGINT(), .nullOnNull = true}},
+        {{Coercion{.type = VARCHAR(), .cost = 1}},
+         Coercion::CandidateMetadata{
+             .returnType = BIGINT(), .nullOnNull = true}},
+    };
+
+    auto index = Coercion::pickLowestCost(
+        candidates, argTypes, resolutionAt(candidates));
+    ASSERT_TRUE(index.has_value());
+    EXPECT_EQ(index.value(), 0);
+  }
+
+  // Two unknown-only candidates sharing a return type but not all null-on-null
+  // stay ambiguous.
+  {
+    std::vector<TypePtr> argTypes{UNKNOWN()};
+    std::vector<Candidate> candidates{
+        {{Coercion{.type = BIGINT(), .cost = 1}},
+         Coercion::CandidateMetadata{
+             .returnType = BIGINT(), .nullOnNull = true}},
+        {{Coercion{.type = VARCHAR(), .cost = 1}},
+         Coercion::CandidateMetadata{
+             .returnType = BIGINT(), .nullOnNull = false}},
+    };
+
+    EXPECT_FALSE(
+        Coercion::pickLowestCost(candidates, argTypes, resolutionAt(candidates))
+            .has_value());
+  }
+
+  // Two unknown-only candidates with differing return types stay ambiguous.
+  {
+    std::vector<TypePtr> argTypes{UNKNOWN()};
+    std::vector<Candidate> candidates{
+        {{Coercion{.type = BIGINT(), .cost = 1}},
+         Coercion::CandidateMetadata{
+             .returnType = BIGINT(), .nullOnNull = true}},
+        {{Coercion{.type = VARCHAR(), .cost = 1}},
+         Coercion::CandidateMetadata{
+             .returnType = VARCHAR(), .nullOnNull = true}},
+    };
+
+    EXPECT_FALSE(
+        Coercion::pickLowestCost(candidates, argTypes, resolutionAt(candidates))
+            .has_value());
+  }
+
+  // No unknown-only candidate in the tie stays ambiguous.
+  {
+    std::vector<TypePtr> argTypes{BIGINT()};
+    std::vector<Candidate> candidates{
+        {{Coercion{.type = DOUBLE(), .cost = 1}},
+         Coercion::CandidateMetadata{
+             .returnType = BIGINT(), .nullOnNull = true}},
+        {{Coercion{.type = DOUBLE(), .cost = 1}},
+         Coercion::CandidateMetadata{
+             .returnType = BIGINT(), .nullOnNull = true}},
+    };
+
+    EXPECT_FALSE(
+        Coercion::pickLowestCost(candidates, argTypes, resolutionAt(candidates))
+            .has_value());
+  }
+
+  // Two cost-0 exact-bind candidates with no coercions stay ambiguous.
+  {
+    std::vector<TypePtr> argTypes{BIGINT()};
+    std::vector<Candidate> candidates{
+        {{Coercion{}},
+         Coercion::CandidateMetadata{
+             .returnType = BIGINT(), .nullOnNull = true}},
+        {{Coercion{}},
+         Coercion::CandidateMetadata{
+             .returnType = BIGINT(), .nullOnNull = true}},
+    };
+
+    EXPECT_FALSE(
+        Coercion::pickLowestCost(candidates, argTypes, resolutionAt(candidates))
+            .has_value());
+  }
+}
+
 TEST(SignatureBinderTest, tryResolveReturnTypeWithCoercions) {
   auto makeSignature = [](const std::string& returnType,
                           const std::vector<std::string>& argTypes) {
@@ -1768,6 +2017,32 @@ TEST(SignatureBinderTest, tryResolveReturnTypeWithCoercions) {
     VELOX_ASSERT_EQ_TYPES(coercions[0], BIGINT());
     ASSERT_EQ(coercions[1], nullptr);
   }
+}
+
+TEST(SignatureBinderTest, aggregateUnknownArgTieStaysAmbiguous) {
+  // Aggregate mirror of the scalar cardinality(null) carve-out: aggregate and
+  // window signatures don't model null-on-null, so an UNKNOWN argument matching
+  // both array(T) and map(K,V) (both returning bigint) stays ambiguous.
+  std::vector<exec::FunctionSignaturePtr> signatures{
+      exec::AggregateFunctionSignatureBuilder()
+          .typeVariable("T")
+          .returnType("bigint")
+          .intermediateType("bigint")
+          .argumentType("array(T)")
+          .build(),
+      exec::AggregateFunctionSignatureBuilder()
+          .typeVariable("K")
+          .typeVariable("V")
+          .returnType("bigint")
+          .intermediateType("bigint")
+          .argumentType("map(K,V)")
+          .build(),
+  };
+
+  std::vector<TypePtr> coercions;
+  auto type = exec::tryResolveReturnTypeWithCoercions(
+      signatures, {UNKNOWN()}, coercions, TypeCoercer::defaults());
+  ASSERT_EQ(type, nullptr);
 }
 
 } // namespace

--- a/velox/functions/tests/FunctionRegistryTest.cpp
+++ b/velox/functions/tests/FunctionRegistryTest.cpp
@@ -210,6 +210,21 @@ class FunctionRegistryTest : public testing::Test {
     }
   }
 
+  // Asserts resolution to 'expectedReturnType' with a coercion applied, without
+  // pinning the coerced types. Use when the overload choice is immaterial.
+  void testCoercionResolvesInt(
+      const std::string& name,
+      const std::vector<TypePtr>& argTypes,
+      const ResolveFuncs& resolveFuncs,
+      const TypePtr& expectedReturnType) {
+    std::vector<TypePtr> coercions;
+    auto type =
+        resolveFuncs.resolveWithCoercionsFunc(name, argTypes, coercions);
+    VELOX_EXPECT_EQ_TYPES(type, expectedReturnType);
+    EXPECT_EQ(coercions.size(), argTypes.size());
+    EXPECT_THAT(coercions, testing::Contains(testing::Ne(nullptr)));
+  }
+
   void testCannotResolveInt(
       const std::string& name,
       const std::vector<TypePtr>& argTypes,
@@ -240,6 +255,14 @@ class FunctionRegistryTest : public testing::Test {
       const std::vector<TypePtr>& argTypes,
       const TypePtr& expectedReturnType) {
     testNoCoercionsInt(
+        name, argTypes, ResolveFuncs::function(), expectedReturnType);
+  }
+
+  void testCoercionResolves(
+      const std::string& name,
+      const std::vector<TypePtr>& argTypes,
+      const TypePtr& expectedReturnType) {
+    testCoercionResolvesInt(
         name, argTypes, ResolveFuncs::function(), expectedReturnType);
   }
 
@@ -805,6 +828,23 @@ struct DummySimpleFunction {
   void call(T&, const T&, const T&) {}
 };
 
+// Two overloads that tie on a bare UNKNOWN argument but return different
+// types.
+template <typename TExec>
+struct TiedComplexReturnFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  void call(int64_t& out, const arg_type<Array<Generic<T1>>>&) {
+    out = 0;
+  }
+
+  void call(
+      out_type<Varchar>& out,
+      const arg_type<Map<Generic<T1>, Generic<T2>>>&) {
+    out.copy_from("0"_sv);
+  }
+};
+
 TEST_F(FunctionRegistryTest, resolveFunctionWithCoercions) {
   removeFunction("foo");
 
@@ -1061,6 +1101,97 @@ TEST_F(FunctionRegistryTest, resolveCoalesceWithCoercions) {
       {SMALLINT(), INTEGER(), BIGINT(), TINYINT()},
       BIGINT(),
       {BIGINT(), BIGINT(), nullptr, BIGINT()});
+}
+
+TEST_F(FunctionRegistryTest, unknownArgToParameterizedFunction) {
+  functions::prestosql::registerAllScalarFunctions();
+
+  // cardinality(UNKNOWN) resolves to bigint. The array(T) and map(K,V)
+  // overloads are interchangeable, so the coerced container is immaterial.
+  testCoercionResolves("cardinality", {UNKNOWN()}, BIGINT());
+
+  // map_keys(UNKNOWN) — bare NULL to map(K,V) -> array(K).
+  testCoercions(
+      "map_keys", {UNKNOWN()}, ARRAY(UNKNOWN()), {MAP(UNKNOWN(), UNKNOWN())});
+
+  // A scalar overload outranks a complex one on a bare null. varbinary (the
+  // highest-cost scalar UNKNOWN coercion) still beats array(T) because
+  // unknownToComplexCost is one above it.
+  {
+    SCOPE_EXIT {
+      removeFunction("foo");
+    };
+
+    exec::registerVectorFunction(
+        "foo",
+        {makeSignature("varbinary", {"varbinary"}),
+         exec::FunctionSignatureBuilder()
+             .typeVariable("T")
+             .returnType("bigint")
+             .argumentType("array(T)")
+             .build()},
+        std::make_unique<DummyVectorFunction>());
+
+    testCoercions("foo", {UNKNOWN()}, VARBINARY(), {VARBINARY()});
+  }
+
+  // Vector resolver: differing return types stay ambiguous.
+  {
+    SCOPE_EXIT {
+      removeFunction("foo");
+    };
+
+    exec::registerVectorFunction(
+        "foo",
+        {exec::FunctionSignatureBuilder()
+             .typeVariable("T")
+             .returnType("bigint")
+             .argumentType("array(T)")
+             .build(),
+         exec::FunctionSignatureBuilder()
+             .typeVariable("K")
+             .typeVariable("V")
+             .returnType("varchar")
+             .argumentType("map(K,V)")
+             .build()},
+        std::make_unique<DummyVectorFunction>());
+
+    testCannotResolve("foo", {UNKNOWN()});
+  }
+
+  // Simple-function resolver: differing return types stay ambiguous.
+  {
+    SCOPE_EXIT {
+      removeFunction("foo");
+    };
+
+    registerFunction<TiedComplexReturnFunction, int64_t, Array<Generic<T1>>>(
+        {"foo"});
+    registerFunction<
+        TiedComplexReturnFunction,
+        Varchar,
+        Map<Generic<T1>, Generic<T2>>>({"foo"});
+
+    testCannotResolve("foo", {UNKNOWN()});
+  }
+}
+
+TEST_F(FunctionRegistryTest, nonUnknownTieStaysAmbiguous) {
+  // A cost tie not caused by UNKNOWN arguments stays ambiguous even when the
+  // tied overloads share a return type and are null-on-null.
+  SCOPE_EXIT {
+    removeFunction("foo");
+  };
+
+  exec::registerVectorFunction(
+      "foo",
+      {
+          makeSignature("bigint", {"tinyint", "bigint"}),
+          makeSignature("bigint", {"bigint", "tinyint"}),
+      },
+      std::make_unique<DummyVectorFunction>());
+
+  testCannotResolve("foo", {TINYINT(), TINYINT()});
 }
 
 TEST_F(FunctionRegistryTest, resolveRowConstructor) {

--- a/velox/type/TypeCoercer.cpp
+++ b/velox/type/TypeCoercer.cpp
@@ -30,6 +30,22 @@ int64_t Coercion::overallCost(const std::vector<Coercion>& coercions) {
   return cost;
 }
 
+bool Coercion::isUnknownOnlyCoercion(
+    const std::vector<Coercion>& coercions,
+    const std::vector<TypePtr>& argTypes) {
+  VELOX_DCHECK_EQ(coercions.size(), argTypes.size());
+  bool hasCoercion{false};
+  for (auto i = 0; i < coercions.size(); ++i) {
+    if (coercions[i].type != nullptr) {
+      if (!argTypes[i]->isUnknown()) {
+        return false;
+      }
+      hasCoercion = true;
+    }
+  }
+  return hasCoercion;
+}
+
 namespace {
 
 std::vector<CoercionEntry> defaultRules() {
@@ -69,6 +85,9 @@ std::vector<CoercionEntry> defaultRules() {
 TypeCoercer::TypeCoercer(const std::vector<CoercionEntry>& rules) {
   // Tracks costs already used for a given source type to enforce uniqueness.
   std::unordered_map<std::string, std::unordered_set<int32_t>> costsByFrom;
+
+  // Highest UNKNOWN->scalar cost in this rule set.
+  int32_t maxUnknownCost{0};
 
   for (const auto& entry : rules) {
     VELOX_CHECK_NOT_NULL(entry.from, "CoercionEntry.from must not be null");
@@ -129,6 +148,10 @@ TypeCoercer::TypeCoercer(const std::vector<CoercionEntry>& rules) {
         entry.cost,
         entry.from->name());
 
+    if (entry.from->isUnknown() && entry.cost > maxUnknownCost) {
+      maxUnknownCost = entry.cost;
+    }
+
     // Reject duplicate (fromName, toName) pairs. This guards in particular
     // against the common DECIMAL footgun: all decimals share the same name,
     // so multiple {SOURCE, DECIMAL(p, s), cost} entries with different
@@ -143,12 +166,23 @@ TypeCoercer::TypeCoercer(const std::vector<CoercionEntry>& rules) {
         entry.from->name(),
         entry.to->name());
   }
+
+  unknownToComplexCost_ = maxUnknownCost + 1;
 }
 
 // static
 const TypeCoercer& TypeCoercer::defaults() {
   static const TypeCoercer instance{defaultRules()};
   return instance;
+}
+
+std::optional<Coercion> TypeCoercer::coerce(
+    const TypePtr& fromType,
+    const TypePtr& toType) const {
+  if (fromType->isUnknown() && toType->size() > 0) {
+    return Coercion{.type = toType, .cost = unknownToComplexCost_};
+  }
+  return coerceTypeBase(fromType, toType);
 }
 
 std::optional<Coercion> TypeCoercer::coerceTypeBase(

--- a/velox/type/TypeCoercer.h
+++ b/velox/type/TypeCoercer.h
@@ -16,6 +16,8 @@
 #pragma once
 
 #include <folly/hash/Hash.h>
+#include <algorithm>
+#include <span>
 #include "velox/type/Type.h"
 
 namespace facebook::velox {
@@ -41,34 +43,112 @@ struct Coercion {
   /// Returns overall cost of a list of coercions by adding up individual costs.
   static int64_t overallCost(const std::vector<Coercion>& coercions);
 
-  /// Returns an index of the lowest cost coercion in 'candidates' or nullptr if
-  /// 'candidates' is empty or there is a tie.
+  /// Resolved return type and default null behavior of a function signature.
+  /// The return type is never null. A bound candidate always resolves one.
+  struct CandidateMetadata {
+    TypePtr returnType;
+    bool nullOnNull{false};
+  };
+
+  /// Returns the index of the strictly-lowest-cost candidate, or std::nullopt
+  /// if 'candidates' is empty or two or more tie for lowest cost.
   template <typename T>
   static std::optional<size_t> pickLowestCost(
       const std::vector<std::pair<std::vector<Coercion>, T>>& candidates) {
-    if (candidates.empty()) {
+    const auto tied = minCostCandidates(candidates);
+    return tied.size() == 1 ? std::optional<size_t>(tied[0]) : std::nullopt;
+  }
+
+  /// Resolves a lowest-cost tie between candidates when the tie is caused only
+  /// by bare UNKNOWN (untyped null) arguments. Returns the winning candidate's
+  /// index, or std::nullopt when the tie is genuinely ambiguous.
+  ///
+  /// Looks only at "unknown-only-coercion" candidates -- those whose coercions
+  /// fall solely on UNKNOWN positions, coercing nothing but the nulls. They are
+  /// more specific than candidates that also widen a real argument. Among them:
+  ///   - exactly one      -> it wins;
+  ///   - several, but interchangeable -> lowest index wins;
+  ///   - anything else    -> ambiguous (std::nullopt).
+  ///
+  /// Interchangeable means they share the same return type and all return null
+  /// on a null argument, so the pick cannot change the result.
+  ///
+  /// 'argTypes' are the call's actual argument types, used to locate the
+  /// UNKNOWN positions. 'resolutionAt(i)' returns candidate i's
+  /// CandidateMetadata.
+  template <typename T, typename ResolutionAt>
+  static std::optional<size_t> pickLowestCost(
+      const std::vector<std::pair<std::vector<Coercion>, T>>& candidates,
+      const std::vector<TypePtr>& argTypes,
+      ResolutionAt&& resolutionAt) {
+    const auto tied = minCostCandidates(candidates);
+    if (tied.size() == 1) {
+      return tied[0];
+    }
+    return tryResolveTie(
+        candidates, tied, argTypes, std::forward<ResolutionAt>(resolutionAt));
+  }
+
+ private:
+  // Returns true if 'coercions' has at least one coercion and every coercion
+  // falls on an UNKNOWN position of 'argTypes' (an exact bind has none).
+  static bool isUnknownOnlyCoercion(
+      const std::vector<Coercion>& coercions,
+      const std::vector<TypePtr>& argTypes);
+
+  // Returns the indices of the candidates tied at the lowest summed cost.
+  template <typename T>
+  static std::vector<size_t> minCostCandidates(
+      const std::vector<std::pair<std::vector<Coercion>, T>>& candidates) {
+    std::vector<size_t> tied;
+    int64_t minCost{0};
+    for (auto i = 0; i < candidates.size(); ++i) {
+      const auto cost = overallCost(candidates[i].first);
+      if (tied.empty() || cost < minCost) {
+        minCost = cost;
+        tied.clear();
+        tied.push_back(i);
+      } else if (cost == minCost) {
+        tied.push_back(i);
+      }
+    }
+    return tied;
+  }
+
+  // Resolves only an UNKNOWN-induced tie: keeps the unknown-only-coercion
+  // candidates among 'tied' and returns the winner, else std::nullopt.
+  template <typename T, typename ResolutionAt>
+  static std::optional<size_t> tryResolveTie(
+      const std::vector<std::pair<std::vector<Coercion>, T>>& candidates,
+      std::span<const size_t> tied,
+      const std::vector<TypePtr>& argTypes,
+      ResolutionAt&& resolutionAt) {
+    std::vector<size_t> unknownOnly;
+    for (auto index : tied) {
+      if (isUnknownOnlyCoercion(candidates[index].first, argTypes)) {
+        unknownOnly.push_back(index);
+      }
+    }
+    if (unknownOnly.empty()) {
       return std::nullopt;
     }
 
-    if (candidates.size() == 1) {
-      return 0;
+    // Lowest index, so the pick is deterministic regardless of candidate order.
+    const size_t selectedIndex =
+        *std::min_element(unknownOnly.begin(), unknownOnly.end());
+    if (unknownOnly.size() == 1) {
+      return selectedIndex;
     }
 
-    std::vector<std::pair<size_t, int64_t>> costs;
-    costs.reserve(candidates.size());
-    for (auto i = 0; i < candidates.size(); ++i) {
-      costs.emplace_back(i, overallCost(candidates[i].first));
+    const auto selectedReturnType = resolutionAt(selectedIndex).returnType;
+    VELOX_DCHECK_NOT_NULL(selectedReturnType);
+    for (auto index : unknownOnly) {
+      const auto metadata = resolutionAt(index);
+      if (!metadata.nullOnNull || *metadata.returnType != *selectedReturnType) {
+        return std::nullopt;
+      }
     }
-
-    std::sort(costs.begin(), costs.end(), [](const auto& a, const auto& b) {
-      return a.second < b.second;
-    });
-
-    if (costs[0].second < costs[1].second) {
-      return costs[0].first;
-    }
-
-    return std::nullopt;
+    return selectedIndex;
   }
 };
 
@@ -165,6 +245,12 @@ class TypeCoercer {
   /// Used by callers that have not selected a dialect-specific coercer.
   static const TypeCoercer& defaults();
 
+  /// Returns the coercion from 'fromType' to 'toType', or std::nullopt. A bare
+  /// UNKNOWN coerces to any complex target at a cost above every
+  /// UNKNOWN->scalar coercion; all other cases defer to coerceTypeBase().
+  std::optional<Coercion> coerce(const TypePtr& fromType, const TypePtr& toType)
+      const;
+
   /// Checks if 'fromType' can be implicitly converted to 'toType' via a
   /// single rule lookup. Does NOT recurse into container children -- for
   /// container coercibility (e.g., ARRAY<INT> vs ARRAY<BIGINT>), use
@@ -224,6 +310,9 @@ class TypeCoercer {
   // Flat map: (fromName, toName) -> Coercion{type, cost}.
   std::unordered_map<std::pair<std::string, std::string>, Coercion, PairHash>
       rules_;
+
+  // Derived from the rule set at construction (max UNKNOWN->scalar cost + 1).
+  int32_t unknownToComplexCost_{1};
 };
 
 } // namespace facebook::velox


### PR DESCRIPTION
Summary:

`cardinality(null)` failed to resolve:

    SELECT cardinality(null)
    → Scalar function signature is not supported: cardinality(UNKNOWN)

Velox coerces a bare UNKNOWN (an untyped null) to scalar types such as BIGINT, but not to parameterized types such as ARRAY or MAP. Two problems blocked it.

First, the coercion target was the bare UNKNOWN, not the resolved formal type. `cardinality(UNKNOWN)` matches no implementation; `cardinality(ARRAY(UNKNOWN))` does. The signature's type variables now bind to UNKNOWN, the formal type is resolved, and that resolved type becomes the coercion target.

The resolved formal can be a scalar, not a complex type. A decimal comparison reuses one precision and scale across both arguments, so

    SELECT CAST(1 AS DECIMAL(10, 2)) = null

binds the null to `decimal(10, 2)`, a scalar with no UNKNOWN coercion. The branch returns no match when the resolved type is a scalar, instead of assuming a coercion exists. The same guard covers tdigest and qdigest, the other parameterized scalars.

Second, an untyped null is ambiguous. `cardinality` accepts both `array(T)` and `map(K,V)`, and a bare null fits either, so the overloads tie on cost and the call was left unresolved. UNKNOWN-to-parameterized coercions now share one cost, so the candidates tie on purpose, and a second `pickLowestCost` overload breaks a tie caused by UNKNOWN arguments. Among the tied candidates it keeps only those that cast just the bare-null arguments, then resolves when exactly one remains (the most specific) or when several are interchangeable: identical resolved return type and all null-on-null. A tie that involves a non-UNKNOWN argument, or candidates that differ in return type or null behavior, still fails as ambiguous rather than guess.

The tie-break runs for scalar functions. Aggregate and window resolution keeps the ambiguous result, because their signatures do not carry null-on-null behavior to prove the candidates interchangeable.

Reviewed By: mbasmanova

Differential Revision: D101874413


