### PR TITLE
refactor: Move selective Nimble reader config from QueryConfig to FileConfig (#17292)

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -533,14 +533,6 @@ class ConnectorQueryCtx {
     return cancellationToken_;
   }
 
-  bool selectiveNimbleReaderEnabled() const {
-    return selectiveNimbleReaderEnabled_;
-  }
-
-  void setSelectiveNimbleReaderEnabled(bool value) {
-    selectiveNimbleReaderEnabled_ = value;
-  }
-
   core::QueryConfig::RowSizeTrackingMode rowSizeTrackingMode() const {
     return rowSizeTrackingEnabled_;
   }
@@ -570,7 +562,6 @@ class ConnectorQueryCtx {
   const bool adjustTimestampToTimezone_;
   const folly::CancellationToken cancellationToken_;
   const std::shared_ptr<filesystems::TokenProvider> fsTokenProvider_;
-  bool selectiveNimbleReaderEnabled_{false};
   core::QueryConfig::RowSizeTrackingMode rowSizeTrackingEnabled_{
       core::QueryConfig::RowSizeTrackingMode::ENABLED_FOR_ALL};
 };

--- a/velox/connectors/hive/FileConfig.cpp
+++ b/velox/connectors/hive/FileConfig.cpp
@@ -43,6 +43,7 @@ const std::vector<config::ConfigProperty>& FileConfig::registeredProperties() {
     VELOX_HIVE_CONFIG_REGISTER(kIndexEnabledSession);
     VELOX_HIVE_CONFIG_REGISTER(kFileMetadataCacheEnabledSession);
     VELOX_HIVE_CONFIG_REGISTER(kPinFileMetadataSession);
+    VELOX_HIVE_CONFIG_REGISTER(kSelectiveNimbleReaderEnabledSession);
     VELOX_HIVE_CONFIG_REGISTER(kMaxCoalescedDistanceSession);
     VELOX_HIVE_CONFIG_REGISTER(kParallelUnitLoadCountSession);
     VELOX_HIVE_CONFIG_REGISTER(kReadTimestampUnitSession);

--- a/velox/connectors/hive/FileConfig.h
+++ b/velox/connectors/hive/FileConfig.h
@@ -203,6 +203,14 @@ class FileConfig {
       "Pin parsed metadata objects in reader cache.")
   static constexpr const char* kPinFileMetadata = "pin-file-metadata";
 
+  VELOX_HIVE_CONFIG(
+      kSelectiveNimbleReaderEnabledSession,
+      selectiveNimbleReaderEnabled,
+      "selective_nimble_reader_enabled",
+      bool,
+      true,
+      "Enable selective Nimble reader.")
+
   // --- VELOX_HIVE_CONFIG_PROPERTY properties ---
 
   VELOX_HIVE_CONFIG_PROPERTY(

--- a/velox/connectors/hive/FileConnectorUtil.cpp
+++ b/velox/connectors/hive/FileConnectorUtil.cpp
@@ -87,7 +87,7 @@ void configureReaderOptions(
   readerOptions.setAdjustTimestampToTimezone(
       connectorQueryCtx->adjustTimestampToTimezone());
   readerOptions.setSelectiveNimbleReaderEnabled(
-      connectorQueryCtx->selectiveNimbleReaderEnabled());
+      fileConfig->selectiveNimbleReaderEnabled(sessionProperties));
   readerOptions.setFileMetadataCacheEnabled(
       fileConfig->fileMetadataCacheEnabled(sessionProperties));
   readerOptions.setPinFileMetadata(

--- a/velox/core/QueryConfig.cpp
+++ b/velox/core/QueryConfig.cpp
@@ -204,9 +204,6 @@ const std::vector<config::ConfigProperty>& QueryConfig::registeredProperties() {
     VELOX_REGISTER_QUERY_CONFIG(kDebugLambdaFunctionEvaluationBatchSize);
     VELOX_REGISTER_QUERY_CONFIG(kDebugBingTileChildrenMaxZoomShift);
 
-    // Nimble.
-    VELOX_REGISTER_QUERY_CONFIG(kSelectiveNimbleReaderEnabled);
-
     // Scale writer.
     VELOX_REGISTER_QUERY_CONFIG(kScaleWriterRebalanceMaxMemoryUsageRatio);
     VELOX_REGISTER_QUERY_CONFIG(kScaleWriterMaxPartitionsPerWriter);

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -1222,15 +1222,6 @@ class QueryConfig {
       7,
       "Maximum zoom level difference for bing_tile_children.")
 
-  /// Temporary flag to control whether selective Nimble reader should be used.
-  VELOX_QUERY_CONFIG(
-      kSelectiveNimbleReaderEnabled,
-      selectiveNimbleReaderEnabled,
-      "selective_nimble_reader_enabled",
-      bool,
-      true,
-      "Enable selective Nimble reader.")
-
   /// The max ratio of query memory usage to max capacity for scale writer
   /// exchange to stop scaling.
   VELOX_QUERY_CONFIG(

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -71,8 +71,6 @@ OperatorCtx::createConnectorQueryCtx(
       driverCtx_->queryConfig().adjustTimestampToTimezone(),
       task->getCancellationToken(),
       task->queryCtx()->fsTokenProvider());
-  connectorQueryCtx->setSelectiveNimbleReaderEnabled(
-      driverCtx_->queryConfig().selectiveNimbleReaderEnabled());
   connectorQueryCtx->setRowSizeTrackingMode(
       driverCtx_->queryConfig().rowSizeTrackingMode());
   return connectorQueryCtx;


### PR DESCRIPTION
Summary:

QueryConfig should be agnostic of connectors and file formats. The `kSelectiveNimbleReaderEnabled` config is Nimble-specific and was threaded through QueryConfig -> Operator.cpp -> ConnectorQueryCtx -> FileConnectorUtil, which unnecessarily coupled the core query layer to a connector-specific detail.

This moves the config to FileConfig (the Hive connector config base class), where other format-specific reader settings already live (e.g., Nimble footer speculative IO size, ORC/Parquet column name settings).

Changes:
- Added `kSelectiveNimbleReaderEnabledSession` to FileConfig using the `VELOX_HIVE_CONFIG` macro, with the same session key (`selective_nimble_reader_enabled`) and default (`true`) for backward compatibility.
- Registered the property in `FileConfig::registeredProperties()`.
- Updated `FileConnectorUtil::configureReaderOptions()` to read from `FileConfig` + session properties instead of `ConnectorQueryCtx`.
- Removed the accessor and registration from `QueryConfig.h` / `QueryConfig.cpp`, keeping only a deprecated `static constexpr` string constant for downstream compatibility.
- Removed the getter, setter, and member variable from `ConnectorQueryCtx` in `Connector.h`.
- Removed the threading line from `Operator.cpp`.

Differential Revision: D101893418


