### PR TITLE
fix(dwio/text): Support oversized payloads in BufferedWriterSink

### DIFF
--- a/velox/dwio/text/tests/writer/BufferedWriterSinkTest.cpp
+++ b/velox/dwio/text/tests/writer/BufferedWriterSinkTest.cpp
@@ -81,4 +81,103 @@ TEST_F(BufferedWriterSinkTest, abort) {
   uint64_t result = readFile(tempPath_->getPath(), filename);
   EXPECT_EQ(result, 10);
 }
+
+TEST_F(BufferedWriterSinkTest, oversizedWriteBypassesBuffer) {
+  // Regression test: a write whose payload exceeds the flush buffer size must
+  // drain anything buffered (preserving order) and forward the oversized
+  // payload directly to the underlying sink, instead of asserting.
+  constexpr uint64_t kFlushBufferSize = 16;
+  const std::string oversized(64, 'x');
+
+  const auto tempPath = tempPath_->getPath();
+  const auto filename = "test_buffered_oversized.txt";
+
+  auto filePath = fs::path(fmt::format("{}/{}", tempPath, filename));
+  auto sink = std::make_unique<dwio::common::LocalFileSink>(
+      filePath, dwio::common::FileSink::Options{.pool = leafPool_.get()});
+
+  auto bufferedWriterSink = std::make_unique<BufferedWriterSink>(
+      std::move(sink),
+      rootPool_->addLeafChild("bufferedWriterSinkTest"),
+      kFlushBufferSize);
+
+  // Small write that fits in the buffer, then an oversized write that must
+  // first drain the small one and then write directly to the sink.
+  const std::string prefix = "head:";
+  bufferedWriterSink->write(prefix.data(), prefix.size());
+  bufferedWriterSink->write(oversized.data(), oversized.size());
+  // Another small write after the bypass to confirm buffering still works.
+  const std::string suffix = ":tail";
+  bufferedWriterSink->write(suffix.data(), suffix.size());
+  bufferedWriterSink->close();
+
+  const auto fs = filesystems::getFileSystem(tempPath, nullptr);
+  const auto& file = fs->openFileForRead(filePath.string());
+  const auto fileSize = file->size();
+  std::string contents(fileSize, '\0');
+  file->pread(0, fileSize, contents.data());
+
+  EXPECT_EQ(contents, prefix + oversized + suffix);
+}
+
+namespace {
+// Reads the file at 'path/name' into a string.
+std::string readFileBytes(const std::string& path, const std::string& name) {
+  const auto fs = filesystems::getFileSystem(path, nullptr);
+  const auto filePath = fs::path(fmt::format("{}/{}", path, name));
+  const auto& file = fs->openFileForRead(filePath.string());
+  const auto fileSize = file->size();
+  std::string out(fileSize, '\0');
+  if (fileSize > 0) {
+    file->pread(0, fileSize, out.data());
+  }
+  return out;
+}
+} // namespace
+
+TEST_F(BufferedWriterSinkTest, writeEqualToFlushBufferUsesBufferedPath) {
+  // Boundary: a write of exactly flushBufferSize_ bytes is *not* oversized
+  // (the bypass condition is strict `size > flushBufferSize_`); it must go
+  // through the buffered path and land on disk intact after close().
+  constexpr uint64_t kFlushBufferSize = 16;
+  const std::string exact(kFlushBufferSize, 'a');
+
+  const auto tempPath = tempPath_->getPath();
+  const auto filename = "test_buffered_equal.txt";
+  auto filePath = fs::path(fmt::format("{}/{}", tempPath, filename));
+  auto sink = std::make_unique<dwio::common::LocalFileSink>(
+      filePath, dwio::common::FileSink::Options{.pool = leafPool_.get()});
+  auto bufferedWriterSink = std::make_unique<BufferedWriterSink>(
+      std::move(sink),
+      rootPool_->addLeafChild("bufferedWriterSinkTest"),
+      kFlushBufferSize);
+
+  bufferedWriterSink->write(exact.data(), exact.size());
+  bufferedWriterSink->close();
+
+  EXPECT_EQ(readFileBytes(tempPath, filename), exact);
+}
+
+TEST_F(BufferedWriterSinkTest, writeOneByteOverFlushBufferTriggersBypass) {
+  // Boundary: a write of flushBufferSize_ + 1 bytes is the smallest oversized
+  // write and must hit the bypass path. The buffer is empty so the flush() is
+  // a no-op; verify the payload still lands on disk in full.
+  constexpr uint64_t kFlushBufferSize = 16;
+  const std::string oneOver(kFlushBufferSize + 1, 'b');
+
+  const auto tempPath = tempPath_->getPath();
+  const auto filename = "test_buffered_one_over.txt";
+  auto filePath = fs::path(fmt::format("{}/{}", tempPath, filename));
+  auto sink = std::make_unique<dwio::common::LocalFileSink>(
+      filePath, dwio::common::FileSink::Options{.pool = leafPool_.get()});
+  auto bufferedWriterSink = std::make_unique<BufferedWriterSink>(
+      std::move(sink),
+      rootPool_->addLeafChild("bufferedWriterSinkTest"),
+      kFlushBufferSize);
+
+  bufferedWriterSink->write(oneOver.data(), oneOver.size());
+  bufferedWriterSink->close();
+
+  EXPECT_EQ(readFileBytes(tempPath, filename), oneOver);
+}
 } // namespace facebook::velox::text

--- a/velox/dwio/text/writer/BufferedWriterSink.cpp
+++ b/velox/dwio/text/writer/BufferedWriterSink.cpp
@@ -41,15 +41,20 @@ void BufferedWriterSink::write(char value) {
 }
 
 void BufferedWriterSink::write(const char* data, uint64_t size) {
-  // TODO Add logic for when size is larger than flushCount_
-  VELOX_CHECK_GE(
-      flushBufferSize_,
-      size,
-      "write data size exceeds flush buffer size limit");
-
   if (buf_->size() + size > flushBufferSize_) {
     flush();
   }
+
+  if (size > flushBufferSize_) {
+    // Oversized payload: grow the (now-empty) buffer to fit, fill it, then
+    // flush directly to the sink. flush() resets the buffer back to
+    // flushBufferSize_ on the way out via reserveBuffer().
+    buf_->reserve(size);
+    buf_->append(0, data, size);
+    flush();
+    return;
+  }
+
   buf_->append(buf_->size(), data, size);
 }
 


### PR DESCRIPTION
Summary:
`BufferedWriterSink::write(const char*, uint64_t size)` previously asserted
`size <= flushBufferSize_`, so any single payload larger than the configured
flush buffer (10 KiB by default in `text::WriterOptions`) would crash the
writer. `TextWriter::writeCellValue` writes one whole cell value per call,
which means any single VARCHAR/VARBINARY cell larger than 10 KiB (after escape
encoding, or after Base64 inflation for VARBINARY) trips the check and aborts
the query. We hit this from Presto when writing wide text columns.

Implement the TODO that was sitting in this code path: if the incoming write
exceeds the buffer capacity, drain whatever is currently buffered (to preserve
write ordering) and forward the oversized payload directly to the underlying
`FileSink`, skipping the fixed-size buffer. This makes the writer correct for
arbitrarily large cells without inflating the steady-state buffer reservation.

Differential Revision: D101900006


