### PR TITLE
fix: Handle empty index splits in IndexLookupJoin

### DIFF
--- a/velox/exec/IndexLookupJoin.cpp
+++ b/velox/exec/IndexLookupJoin.cpp
@@ -662,11 +662,14 @@ bool IndexLookupJoin::collectIndexSplits(ContinueFuture* future) {
 
     if (!split.hasConnectorSplit()) {
       noMoreIndexSplits_ = true;
-      VELOX_CHECK(!indexSplits_.empty());
-      // Publish splits to the bridge for followers before consuming locally.
+      VELOX_CHECK(!hasNoIndexSplits_);
       VELOX_CHECK_NOT_NULL(joinBridge_);
       joinBridge_->setIndexSplits(indexSplits_);
-      indexSource_->addSplits(std::move(indexSplits_));
+      if (indexSplits_.empty()) {
+        hasNoIndexSplits_ = true;
+      } else {
+        indexSource_->addSplits(std::move(indexSplits_));
+      }
       return true;
     }
 
@@ -681,11 +684,15 @@ bool IndexLookupJoin::waitForIndexSplits(ContinueFuture* future) {
   VELOX_CHECK(indexSplits_.empty());
 
   auto splits = joinBridge_->splitsOrFuture(future);
-  if (splits.empty()) {
+  if (future->valid()) {
     return false;
   }
   noMoreIndexSplits_ = true;
-  indexSource_->addSplits(std::move(splits));
+  if (splits.empty()) {
+    hasNoIndexSplits_ = true;
+  } else {
+    indexSource_->addSplits(std::move(splits));
+  }
   return true;
 }
 
@@ -699,6 +706,9 @@ bool IndexLookupJoin::needsInput() const {
   }
   // Don't accept input until we have collected all splits for index source.
   if (needsIndexSplits()) {
+    return false;
+  }
+  if (shouldSkipInput()) {
     return false;
   }
   if (numInputBatches() >= maxNumInputBatches_) {
@@ -766,6 +776,7 @@ void IndexLookupJoin::endLookupBlockWait() {
 
 void IndexLookupJoin::addInput(RowVectorPtr input) {
   VELOX_CHECK_GT(input->size(), 0);
+  VELOX_CHECK(!shouldSkipInput());
   auto& batch = nextInputBatch();
   VELOX_CHECK_LE(numInputBatches(), maxNumInputBatches_);
   batch.input = std::move(input);
@@ -997,8 +1008,7 @@ void IndexLookupJoin::startLookup(InputBatchState& batch) {
   VELOX_CHECK_NULL(batch.lookupResult);
   VELOX_CHECK(!batch.lookupFuture.valid());
 
-  if (batch.lookupInput->size() == 0) {
-    // No need to start lookup for empty lookup input.
+  if (shouldSkipLookup(batch)) {
     return;
   }
 
@@ -1012,10 +1022,11 @@ void IndexLookupJoin::startLookup(InputBatchState& batch) {
 RowVectorPtr IndexLookupJoin::getOutputFromLookupResult(
     InputBatchState& batch) {
   VELOX_CHECK(!batch.empty());
+  VELOX_CHECK(!shouldSkipInput());
   VELOX_CHECK(!batch.lookupFuture.valid() || batch.lookupFuture.isReady());
   batch.lookupFuture = ContinueFuture::makeEmpty();
 
-  if (batch.lookupInput->size() == 0) {
+  if (shouldSkipLookup(batch)) {
     return produceRemainingOutput(batch);
   }
 
@@ -1177,8 +1188,8 @@ bool IndexLookupJoin::hasRemainingOutputForLeftJoin(
 
 void IndexLookupJoin::finishInput(InputBatchState& batch) {
   VELOX_CHECK_NOT_NULL(batch.input);
-  VELOX_CHECK_EQ(
-      batch.lookupInput->size() == 0, batch.lookupResultIter == nullptr);
+  VELOX_CHECK(!shouldSkipInput());
+  VELOX_CHECK_EQ(shouldSkipLookup(batch), batch.lookupResultIter == nullptr);
   VELOX_CHECK(!batch.lookupFuture.valid());
 
   batch.input = nullptr;
@@ -1196,7 +1207,7 @@ void IndexLookupJoin::finishInput(InputBatchState& batch) {
       VELOX_CHECK(!nextBatch.lookupFuture.valid());
     } else {
       VELOX_CHECK_EQ(
-          nextBatch.lookupInput->size() != 0, nextBatch.lookupFuture.valid());
+          !shouldSkipLookup(nextBatch), nextBatch.lookupFuture.valid());
     }
   }
 }

--- a/velox/exec/IndexLookupJoin.h
+++ b/velox/exec/IndexLookupJoin.h
@@ -41,7 +41,7 @@ class IndexLookupJoin : public Operator {
   RowVectorPtr getOutput() override;
 
   bool isFinished() override {
-    return noMoreInput_ && (numInputBatches() == 0);
+    return (noMoreInput_ || shouldSkipInput()) && (numInputBatches() == 0);
   }
 
   void close() override;
@@ -298,6 +298,19 @@ class IndexLookupJoin : public Operator {
     return lookupTableHandle_->needsIndexSplit() && !noMoreIndexSplits_;
   }
 
+  // Returns true if input processing can be skipped entirely. This is the case
+  // for INNER JOIN when there are no index splits — every probe row will be
+  // discarded since there can be no matches.
+  bool shouldSkipInput() const {
+    return hasNoIndexSplits_ && joinType_ == core::JoinType::kInner;
+  }
+
+  // Returns true if lookup should be skipped for the given batch, either
+  // because the index source has no splits or because all probe keys are null.
+  bool shouldSkipLookup(const InputBatchState& batch) const {
+    return hasNoIndexSplits_ || batch.lookupInput->size() == 0;
+  }
+
   // Returns the number of input batches to process.
   size_t numInputBatches() const {
     VELOX_CHECK_LE(startBatchIndex_, endBatchIndex_);
@@ -433,6 +446,9 @@ class IndexLookupJoin : public Operator {
   // Split collection state for index sources that require splits.
   // True if we have received the no-more-splits signal for the index source.
   bool noMoreIndexSplits_{false};
+  // True if the index source received zero splits (e.g., partition pruning
+  // eliminated all index partitions). When set, lookups are skipped entirely.
+  bool hasNoIndexSplits_{false};
   // The future to wait for the next index split.
   ContinueFuture indexSplitFuture_;
   // The collected splits for the index source. It is passed to index source

--- a/velox/exec/IndexLookupJoinBridge.cpp
+++ b/velox/exec/IndexLookupJoinBridge.cpp
@@ -25,9 +25,8 @@ void IndexLookupJoinBridge::setIndexSplits(
     VELOX_CHECK(started_, "Bridge must be started before setting index splits");
     VELOX_CHECK(
         !cancelled_, "Setting index splits after the bridge is cancelled");
-    VELOX_CHECK(
-        indexSplits_.empty(), "setIndexSplits must be called only once");
-    VELOX_CHECK(!splits.empty(), "Index splits must not be empty");
+    VELOX_CHECK(!splitsSet_, "setIndexSplits must be called only once");
+    splitsSet_ = true;
     indexSplits_ = std::move(splits);
     promises = std::move(promises_);
   }
@@ -39,7 +38,7 @@ IndexLookupJoinBridge::splitsOrFuture(ContinueFuture* future) {
   std::lock_guard<std::mutex> l(mutex_);
   VELOX_CHECK(
       !cancelled_, "Getting index splits after the bridge is cancelled");
-  if (!indexSplits_.empty()) {
+  if (splitsSet_) {
     return indexSplits_;
   }
   promises_.emplace_back("IndexLookupJoinBridge::splitsOrFuture");

--- a/velox/exec/IndexLookupJoinBridge.h
+++ b/velox/exec/IndexLookupJoinBridge.h
@@ -28,16 +28,20 @@ class IndexLookupJoinBridge : public JoinBridge {
  public:
   /// Called by the leader operator after collecting all index splits. Stores
   /// the splits and notifies all waiting followers. Must be called only once.
+  /// May be called with an empty vector (e.g., when partition pruning
+  /// eliminates all index partitions for a split group).
   void setIndexSplits(
       std::vector<std::shared_ptr<connector::ConnectorSplit>> splits);
 
-  /// Returns splits if already available, otherwise sets 'future' and returns
-  /// an empty vector. The caller should block on the future and retry.
+  /// Returns the index splits if the leader has called setIndexSplits(),
+  /// otherwise sets 'future' and returns an empty vector. The caller should
+  /// check future->valid() to distinguish "not ready" (future set) from
+  /// "ready with 0 splits" (future not set, empty vector).
   std::vector<std::shared_ptr<connector::ConnectorSplit>> splitsOrFuture(
       ContinueFuture* future);
 
  private:
-  // Empty until the leader calls setIndexSplits() with a non-empty vector.
+  bool splitsSet_{false};
   std::vector<std::shared_ptr<connector::ConnectorSplit>> indexSplits_;
 };
 

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -1687,18 +1687,12 @@ void Task::addSplitToStoreLocked(
     uint32_t groupId,
     const exec::Split& split,
     std::vector<ContinuePromise>& promises) {
-  auto& splitsStore = splitsState.groupSplitsStores[groupId];
-  if (!splitsStore) {
-    setSplitsStore(
-        splitsStore,
-        std::make_unique<QueueSplitsStore>(!splitsState.sourceIsTableScan));
-  }
+  auto* splitsStore = getOrCreateSplitsStoreLocked(splitsState, groupId);
   if (split.isBarrier()) {
     splitsStore->requestBarrier(split.barrier->numDrivers, promises);
     return;
   }
-  auto* queueSplitsStore =
-      checkedPointerCast<QueueSplitsStore>(splitsStore.get());
+  auto* queueSplitsStore = checkedPointerCast<QueueSplitsStore>(splitsStore);
   queueSplitsStore->addSplit(split, promises);
 }
 
@@ -1712,7 +1706,7 @@ void Task::noMoreSplitsForGroup(
 
     auto& splitsState = getPlanNodeSplitsStateLocked(planNodeId);
     noMoreSplitsForStore(
-        splitsState.groupSplitsStores[splitGroupId].get(), promises);
+        getOrCreateSplitsStoreLocked(splitsState, splitGroupId), promises);
 
     // There were no splits in this group, hence, no active drivers. Mark the
     // group complete.
@@ -1807,6 +1801,18 @@ void Task::setSplitsStore(
   splitsStore = std::move(newSplitsStore);
   splitsStore->setTaskStats(taskStats_);
   splitsStore->setPreloadingSplits(preloadingSplits_);
+}
+
+SplitsStore* Task::getOrCreateSplitsStoreLocked(
+    SplitsState& splitsState,
+    uint32_t splitGroupId) {
+  auto& splitsStore = splitsState.groupSplitsStores[splitGroupId];
+  if (!splitsStore) {
+    setSplitsStore(
+        splitsStore,
+        std::make_unique<QueueSplitsStore>(!splitsState.sourceIsTableScan));
+  }
+  return splitsStore.get();
 }
 
 ContinueFuture Task::requestBarrier() {
@@ -2022,12 +2028,7 @@ BlockingReason Task::getSplitOrFuture(
     ContinueFuture& future) {
   std::lock_guard<std::timed_mutex> l(mutex_);
   auto& splitsState = getPlanNodeSplitsStateLocked(planNodeId);
-  auto& splitsStore = splitsState.groupSplitsStores[splitGroupId];
-  if (!splitsStore) {
-    setSplitsStore(
-        splitsStore,
-        std::make_unique<QueueSplitsStore>(!splitsState.sourceIsTableScan));
-  }
+  auto* splitsStore = getOrCreateSplitsStoreLocked(splitsState, splitGroupId);
   return splitsStore->nextSplit(
              driverId, maxPreloadSplits, preload, split, future)
       ? BlockingReason::kNotBlocked

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -1060,6 +1060,12 @@ class Task : public std::enable_shared_from_this<Task> {
       std::unique_ptr<SplitsStore>& splitsStore,
       std::unique_ptr<SplitsStore> newSplitsStore);
 
+  // Returns the splits store for the given group, creating one if it doesn't
+  // exist.
+  SplitsStore* getOrCreateSplitsStoreLocked(
+      SplitsState& splitsState,
+      uint32_t splitGroupId);
+
   // Invoked when all the driver threads are off thread. The function returns
   // 'threadFinishPromises_' to fulfill.
   std::vector<ContinuePromise> allThreadsFinishedLocked();

--- a/velox/exec/tests/IndexLookupJoinBridgeTest.cpp
+++ b/velox/exec/tests/IndexLookupJoinBridgeTest.cpp
@@ -58,9 +58,8 @@ TEST_F(IndexLookupJoinBridgeTest, setAndGetSplits) {
 
   ContinueFuture future = ContinueFuture::makeEmpty();
   auto result = bridge->splitsOrFuture(&future);
-  ASSERT_FALSE(result.empty());
-  ASSERT_EQ(result.size(), expectedSize);
   ASSERT_FALSE(future.valid());
+  ASSERT_EQ(result.size(), expectedSize);
 }
 
 TEST_F(IndexLookupJoinBridgeTest, splitsOrFutureBlocks) {
@@ -68,8 +67,8 @@ TEST_F(IndexLookupJoinBridgeTest, splitsOrFutureBlocks) {
 
   ContinueFuture future = ContinueFuture::makeEmpty();
   auto result = bridge->splitsOrFuture(&future);
-  ASSERT_TRUE(result.empty());
   ASSERT_TRUE(future.valid());
+  ASSERT_TRUE(result.empty());
 
   // Set splits and verify the future is fulfilled.
   auto splits = makeFakeSplits(2);
@@ -81,9 +80,8 @@ TEST_F(IndexLookupJoinBridgeTest, splitsOrFutureBlocks) {
   for (int i = 0; i < 3; ++i) {
     ContinueFuture future2 = ContinueFuture::makeEmpty();
     auto result2 = bridge->splitsOrFuture(&future2);
-    ASSERT_FALSE(result2.empty());
-    ASSERT_EQ(result2.size(), 2);
     ASSERT_FALSE(future2.valid());
+    ASSERT_EQ(result2.size(), 2);
   }
 }
 
@@ -96,8 +94,8 @@ TEST_F(IndexLookupJoinBridgeTest, multipleFollowers) {
   for (int i = 0; i < numFollowers; ++i) {
     ContinueFuture future = ContinueFuture::makeEmpty();
     auto result = bridge->splitsOrFuture(&future);
-    ASSERT_TRUE(result.empty());
     ASSERT_TRUE(future.valid());
+    ASSERT_TRUE(result.empty());
     futures.push_back(std::move(future));
   }
 
@@ -113,9 +111,8 @@ TEST_F(IndexLookupJoinBridgeTest, multipleFollowers) {
   for (int i = 0; i < numFollowers; ++i) {
     ContinueFuture future = ContinueFuture::makeEmpty();
     auto result = bridge->splitsOrFuture(&future);
-    ASSERT_FALSE(result.empty());
-    ASSERT_EQ(result.size(), 5);
     ASSERT_FALSE(future.valid());
+    ASSERT_EQ(result.size(), 5);
   }
 }
 
@@ -129,9 +126,8 @@ TEST_F(IndexLookupJoinBridgeTest, setBeforeGet) {
   for (int i = 0; i < 3; ++i) {
     ContinueFuture future = ContinueFuture::makeEmpty();
     auto result = bridge->splitsOrFuture(&future);
-    ASSERT_FALSE(result.empty());
-    ASSERT_EQ(result.size(), 3);
     ASSERT_FALSE(future.valid());
+    ASSERT_EQ(result.size(), 3);
   }
 }
 
@@ -144,11 +140,40 @@ TEST_F(IndexLookupJoinBridgeTest, setTwiceThrows) {
       "setIndexSplits must be called only once");
 }
 
-TEST_F(IndexLookupJoinBridgeTest, setEmptySplitsThrows) {
+TEST_F(IndexLookupJoinBridgeTest, setEmptyTwiceThrows) {
   auto bridge = createBridge();
+  bridge->setIndexSplits({});
 
   VELOX_ASSERT_THROW(
-      bridge->setIndexSplits({}), "Index splits must not be empty");
+      bridge->setIndexSplits({}), "setIndexSplits must be called only once");
+}
+
+TEST_F(IndexLookupJoinBridgeTest, setEmptySplits) {
+  auto bridge = createBridge();
+  bridge->setIndexSplits({});
+
+  ContinueFuture future = ContinueFuture::makeEmpty();
+  auto result = bridge->splitsOrFuture(&future);
+  ASSERT_FALSE(future.valid());
+  ASSERT_TRUE(result.empty());
+}
+
+TEST_F(IndexLookupJoinBridgeTest, emptySplitsUnblockFollowers) {
+  auto bridge = createBridge();
+
+  ContinueFuture future = ContinueFuture::makeEmpty();
+  auto result = bridge->splitsOrFuture(&future);
+  ASSERT_TRUE(future.valid());
+  ASSERT_TRUE(result.empty());
+
+  bridge->setIndexSplits({});
+
+  std::move(future).via(&folly::InlineExecutor::instance()).get();
+
+  ContinueFuture future2 = ContinueFuture::makeEmpty();
+  auto result2 = bridge->splitsOrFuture(&future2);
+  ASSERT_FALSE(future2.valid());
+  ASSERT_TRUE(result2.empty());
 }
 
 TEST_F(IndexLookupJoinBridgeTest, setBeforeStartThrows) {
@@ -165,7 +190,6 @@ TEST_F(IndexLookupJoinBridgeTest, cancelUnblocksFollowers) {
 
   ContinueFuture future = ContinueFuture::makeEmpty();
   auto result = bridge->splitsOrFuture(&future);
-  ASSERT_TRUE(result.empty());
   ASSERT_TRUE(future.valid());
 
   bridge->cancel();
@@ -208,15 +232,14 @@ TEST_F(IndexLookupJoinBridgeTest, concurrentSetAndGet) {
     threads.emplace_back([&bridge, &successCount, &stop, numSplits]() {
       ContinueFuture future = ContinueFuture::makeEmpty();
       auto result = bridge->splitsOrFuture(&future);
-      if (result.empty()) {
+      if (future.valid()) {
         std::move(future).via(&folly::InlineExecutor::instance()).get();
       }
       while (!stop.load()) {
         ContinueFuture f = ContinueFuture::makeEmpty();
         auto r = bridge->splitsOrFuture(&f);
-        ASSERT_FALSE(r.empty());
-        ASSERT_EQ(r.size(), numSplits);
         ASSERT_FALSE(f.valid());
+        ASSERT_EQ(r.size(), numSplits);
         ++successCount;
       }
     });

--- a/velox/exec/tests/IndexLookupJoinTestExtra.cpp
+++ b/velox/exec/tests/IndexLookupJoinTestExtra.cpp
@@ -1330,8 +1330,8 @@ TEST_P(IndexLookupJoinTest, mixedFilterBatches) {
 // Tests the index split handling behavior of the IndexLookupJoin operator.
 // When needsIndexSplit is true:
 // - The operator blocks waiting for splits until it receives them
-// - Works correctly with various split counts (1, 2, 3 splits)
-// - Fails when no splits are provided before the no-more-splits signal
+// - Works correctly with various split counts (0, 1, 2, 3 splits)
+// - With 0 splits (partition pruning), LEFT JOIN emits probe rows with nulls
 // This test only runs when GetParam().needsIndexSplit is true.
 DEBUG_ONLY_TEST_P(IndexLookupJoinTest, needsIndexSplit) {
   if (!GetParam().needsIndexSplit) {
@@ -1361,19 +1361,15 @@ DEBUG_ONLY_TEST_P(IndexLookupJoinTest, needsIndexSplit) {
 
   struct {
     int numIndexSplits;
-    bool expectFailure;
 
     std::string debugString() const {
-      return fmt::format(
-          "numIndexSplits: {}, expectFailure: {}",
-          numIndexSplits,
-          expectFailure);
+      return fmt::format("numIndexSplits: {}", numIndexSplits);
     }
   } testSettings[] = {
-      {1, false}, // One split - should succeed
-      {2, false}, // Two splits - should succeed
-      {3, false}, // Three splits - should succeed
-      {0, true}, // No splits - should fail
+      {1},
+      {2},
+      {3},
+      {0},
   };
 
   for (const auto& testData : testSettings) {
@@ -1423,20 +1419,19 @@ DEBUG_ONLY_TEST_P(IndexLookupJoinTest, needsIndexSplit) {
               ++collectSplitCallCount;
             }));
 
+    // For 0 splits, the LEFT JOIN should produce all probe rows with nulls
+    // on the lookup side.
+    const auto expectedSql = testData.numIndexSplits == 0
+        ? "SELECT t.c0, t.c1, NULL, NULL FROM t"
+        : duckDbVerifySql;
+
     // Run the query in a separate thread without providing index splits
     // upfront. The main thread will provide splits after the task starts.
     std::thread queryThread([&] {
       AssertQueryBuilder queryBuilder(duckDbQueryRunner_);
-      queryBuilder.plan(plan).splits(
-          probeScanNodeId_, makeHiveConnectorSplits(probeFiles));
-      // Do NOT provide index splits here - they will be provided by the
-      // main thread after the task starts.
-
-      if (testData.expectFailure) {
-        VELOX_ASSERT_THROW(queryBuilder.copyResults(pool()), "");
-      } else {
-        queryBuilder.assertResults(duckDbVerifySql);
-      }
+      queryBuilder.plan(plan)
+          .splits(probeScanNodeId_, makeHiveConnectorSplits(probeFiles))
+          .assertResults(expectedSql);
     });
 
     // Wait for collectIndexSplits to be called.
@@ -1450,32 +1445,23 @@ DEBUG_ONLY_TEST_P(IndexLookupJoinTest, needsIndexSplit) {
       ASSERT_EQ(task->state(), TaskState::kRunning)
           << "Task should still be running while waiting for splits";
 
-      if (testData.expectFailure) {
-        // Signal no more splits immediately to trigger the failure.
-        task->noMoreSplits(indexScanNodeId_);
-      } else {
-        // Add the specified number of index splits.
-        for (int i = 0; i < testData.numIndexSplits; ++i) {
-          task->addSplit(
-              indexScanNodeId_,
-              Split(
-                  std::make_shared<TestIndexConnectorSplit>(
-                      kTestIndexConnectorName)));
-        }
-        // Signal no more splits to allow the task to finish.
-        task->noMoreSplits(indexScanNodeId_);
+      for (int i = 0; i < testData.numIndexSplits; ++i) {
+        task->addSplit(
+            indexScanNodeId_,
+            Split(
+                std::make_shared<TestIndexConnectorSplit>(
+                    kTestIndexConnectorName)));
       }
+      task->noMoreSplits(indexScanNodeId_);
     }
 
     queryThread.join();
 
-    if (!testData.expectFailure) {
-      // Verify collectIndexSplits was called the expected number of times:
-      // once initially when blocked, plus once after splits are available.
-      ASSERT_EQ(collectSplitCallCount.load(), 2)
-          << "collectIndexSplits should be called once initially (blocked), "
-             "then once when splits are available";
-    }
+    // Verify collectIndexSplits was called the expected number of times:
+    // once initially when blocked, plus once after splits are available.
+    ASSERT_EQ(collectSplitCallCount.load(), 2)
+        << "collectIndexSplits should be called once initially (blocked), "
+           "then once when splits are available";
   }
 }
 
@@ -1971,6 +1957,120 @@ TEST_P(IndexLookupJoinTest, groupedExecution) {
     }
 
     // Consume output via OutputBufferManager.
+    auto outputBufferManager = exec::OutputBufferManager::getInstanceRef();
+    outputBufferManager->deleteResults(task->taskId(), 0);
+
+    waitForTaskCompletion(task.get());
+    ASSERT_EQ(task->state(), TaskState::kFinished);
+
+    auto taskStats = toPlanStats(task->taskStats());
+    ASSERT_EQ(
+        taskStats.at(joinNodeId_).numDrivers, numDrivers * numSplitGroups);
+  }
+}
+
+// Verifies that grouped execution completes correctly when some split groups
+// receive no index splits (e.g., partition pruning eliminates all index
+// partitions for a group). For INNER JOIN, the pruned group produces no
+// output. For LEFT JOIN, the pruned group emits probe rows with nulls.
+TEST_P(IndexLookupJoinTest, groupedExecutionWithEmptyIndexSplits) {
+  if (GetParam().serialExecution || !GetParam().needsIndexSplit) {
+    return;
+  }
+  IndexTableData tableData;
+  generateIndexTableData({100, 1, 1}, tableData, pool_);
+  const int numProbeSplitsPerGroup{1};
+  const int numSplitGroups{3};
+  const int numDrivers{2};
+  const auto probeVectors = generateProbeInput(
+      numProbeSplitsPerGroup * numSplitGroups,
+      256,
+      1,
+      tableData,
+      pool_,
+      {"t0", "t1", "t2"},
+      GetParam().hasNullKeys,
+      {},
+      {},
+      100);
+  const auto probeFiles = createProbeFiles(probeVectors);
+
+  const auto indexTable = TestIndexTable::create(
+      /*numEqualJoinKeys=*/3,
+      tableData.keyVectors,
+      tableData.valueVectors,
+      *pool());
+  const auto indexTableHandle = makeIndexTableHandle(
+      indexTable, GetParam().asyncLookup, GetParam().needsIndexSplit);
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  const auto indexScanNode = makeIndexScanNode(
+      planNodeIdGenerator,
+      indexTableHandle,
+      makeScanOutputType({"u0", "u1", "u2", "u3", "u5"}),
+      makeIndexColumnHandles({"u0", "u1", "u2", "u3", "u5"}));
+
+  for (const auto joinType : {core::JoinType::kInner, core::JoinType::kLeft}) {
+    SCOPED_TRACE(
+        fmt::format("joinType: {}", core::JoinTypeName::toName(joinType)));
+    auto outputLayout = std::vector<std::string>{"u3", "t5"};
+    auto plan = PlanBuilder(planNodeIdGenerator, pool())
+                    .tableScan(probeType_)
+                    .capturePlanNodeId(probeScanNodeId_)
+                    .startIndexLookupJoin()
+                    .leftKeys({"t0", "t1", "t2"})
+                    .rightKeys({"u0", "u1", "u2"})
+                    .indexSource(indexScanNode)
+                    .outputLayout(outputLayout)
+                    .joinType(joinType)
+                    .endIndexLookupJoin()
+                    .capturePlanNodeId(joinNodeId_)
+                    .partitionedOutput({}, 1, outputLayout)
+                    .planFragment();
+
+    plan.executionStrategy = core::ExecutionStrategy::kGrouped;
+    plan.groupedExecutionLeafNodeIds.emplace(probeScanNodeId_);
+    plan.groupedExecutionLeafNodeIds.emplace(indexScanNodeId_);
+    plan.numSplitGroups = numSplitGroups;
+
+    auto queryCtx = core::QueryCtx::create(executor_.get());
+    std::unordered_map<std::string, std::string> configs;
+    configs[QueryConfig::kIndexLookupJoinMaxPrefetchBatches] =
+        std::to_string(GetParam().numPrefetches);
+    queryCtx->testingOverrideConfigUnsafe(std::move(configs));
+
+    auto task = exec::Task::create(
+        fmt::format("grouped-empty-index-splits-{}", joinType),
+        std::move(plan),
+        0,
+        std::move(queryCtx),
+        Task::ExecutionMode::kParallel);
+    task->start(numDrivers, /*concurrentSplitGroups=*/2);
+
+    // Add probe splits for all groups.
+    int fileIdx = 0;
+    for (int group = 0; group < numSplitGroups; ++group) {
+      for (int j = 0; j < numProbeSplitsPerGroup; ++j) {
+        task->addSplit(
+            probeScanNodeId_,
+            Split(
+                makeHiveConnectorSplit(probeFiles[fileIdx++]->getPath()),
+                group));
+      }
+      task->noMoreSplitsForGroup(probeScanNodeId_, group);
+    }
+    task->noMoreSplits(probeScanNodeId_);
+
+    // Add index splits only for group 0. Groups 1 and 2 get no index splits,
+    // simulating partition pruning.
+    task->addSplit(
+        indexScanNodeId_,
+        Split(
+            std::make_shared<TestIndexConnectorSplit>(kTestIndexConnectorName),
+            0));
+    task->noMoreSplitsForGroup(indexScanNodeId_, 0);
+    task->noMoreSplitsForGroup(indexScanNodeId_, 1);
+    task->noMoreSplitsForGroup(indexScanNodeId_, 2);
+
     auto outputBufferManager = exec::OutputBufferManager::getInstanceRef();
     outputBufferManager->deleteResults(task->taskId(), 0);
 


### PR DESCRIPTION
Summary:
Properly handle the case where partition pruning eliminates all index partitions for a split group, resulting in zero index splits. Previously, this case was handled with workaround null-iterator checks in the lookup path.

This fix addresses the problem at the source:

**IndexLookupJoinBridge**: Added `splitsSet_` flag so `setIndexSplits()` accepts empty split vectors. Previously it checked `indexSplits_.empty()` which conflated "not set yet" with "set with 0 splits". Callers use `future->valid()` after `splitsOrFuture()` to distinguish "not ready" from "ready with 0 splits".

**IndexLookupJoin operator**: Both `collectIndexSplits` (leader) and `waitForIndexSplits` (follower) now set `hasNoIndexSplits_` when receiving an empty split set, skipping `indexSource_->addSplits()`. A `shouldSkipLookup()` helper gates `startLookup` and `getOutputFromLookupResult` — when skipping, LEFT JOIN emits probe rows with null build columns, INNER JOIN produces nothing. A `shouldSkipInput()` helper (INNER JOIN + no index splits) short-circuits `needsInput()` and `isFinished()` so the upstream TableScan is skipped entirely — no probe data is read when the result is guaranteed to be empty.

**Task split store**: Added `Task::getOrCreateSplitsStoreLocked()` to consolidate split store creation. Fixed `noMoreSplitsForGroup` to eagerly create the store so the no-more-splits signal is not lost when called for groups that never received splits (e.g., partition pruning).

**Tests**: Bridge tests updated for empty-split semantics. `needsIndexSplit` test case updated so 0-split LEFT JOIN succeeds (produces probe + nulls). New `groupedExecutionWithEmptyIndexSplits` test covers 3 split groups where only group 0 has index data.

Reviewed By: xiaoxmeng

Differential Revision: D101921884


