### PR TITLE
refactor: Move selective Nimble reader config from QueryConfig to FileConfig (#17297)

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -533,10 +533,12 @@ class ConnectorQueryCtx {
     return cancellationToken_;
   }
 
+  /// Deprecated: Use FileConfig::kSelectiveNimbleReaderEnabledSession instead.
   bool selectiveNimbleReaderEnabled() const {
     return selectiveNimbleReaderEnabled_;
   }
 
+  /// Deprecated: Use connector session properties instead.
   void setSelectiveNimbleReaderEnabled(bool value) {
     selectiveNimbleReaderEnabled_ = value;
   }

--- a/velox/connectors/hive/FileConfig.cpp
+++ b/velox/connectors/hive/FileConfig.cpp
@@ -43,6 +43,7 @@ const std::vector<config::ConfigProperty>& FileConfig::registeredProperties() {
     VELOX_HIVE_CONFIG_REGISTER(kIndexEnabledSession);
     VELOX_HIVE_CONFIG_REGISTER(kFileMetadataCacheEnabledSession);
     VELOX_HIVE_CONFIG_REGISTER(kPinFileMetadataSession);
+    VELOX_HIVE_CONFIG_REGISTER(kSelectiveNimbleReaderEnabledSession);
     VELOX_HIVE_CONFIG_REGISTER(kMaxCoalescedDistanceSession);
     VELOX_HIVE_CONFIG_REGISTER(kParallelUnitLoadCountSession);
     VELOX_HIVE_CONFIG_REGISTER(kReadTimestampUnitSession);

--- a/velox/connectors/hive/FileConfig.h
+++ b/velox/connectors/hive/FileConfig.h
@@ -203,6 +203,14 @@ class FileConfig {
       "Pin parsed metadata objects in reader cache.")
   static constexpr const char* kPinFileMetadata = "pin-file-metadata";
 
+  VELOX_HIVE_CONFIG(
+      kSelectiveNimbleReaderEnabledSession,
+      selectiveNimbleReaderEnabled,
+      "selective_nimble_reader_enabled",
+      bool,
+      true,
+      "Enable selective Nimble reader.")
+
   // --- VELOX_HIVE_CONFIG_PROPERTY properties ---
 
   VELOX_HIVE_CONFIG_PROPERTY(

--- a/velox/connectors/hive/FileConnectorUtil.cpp
+++ b/velox/connectors/hive/FileConnectorUtil.cpp
@@ -86,8 +86,17 @@ void configureReaderOptions(
   }
   readerOptions.setAdjustTimestampToTimezone(
       connectorQueryCtx->adjustTimestampToTimezone());
-  readerOptions.setSelectiveNimbleReaderEnabled(
-      connectorQueryCtx->selectiveNimbleReaderEnabled());
+  // Prefer connector session property (FileConfig). Fall back to
+  // ConnectorQueryCtx (threaded from QueryConfig) for backward compatibility
+  // with callers that set it as a query config.
+  if (sessionProperties->valueExists(
+          FileConfig::kSelectiveNimbleReaderEnabledSession)) {
+    readerOptions.setSelectiveNimbleReaderEnabled(
+        fileConfig->selectiveNimbleReaderEnabled(sessionProperties));
+  } else {
+    readerOptions.setSelectiveNimbleReaderEnabled(
+        connectorQueryCtx->selectiveNimbleReaderEnabled());
+  }
   readerOptions.setFileMetadataCacheEnabled(
       fileConfig->fileMetadataCacheEnabled(sessionProperties));
   readerOptions.setPinFileMetadata(

--- a/velox/core/QueryConfig.cpp
+++ b/velox/core/QueryConfig.cpp
@@ -204,7 +204,7 @@ const std::vector<config::ConfigProperty>& QueryConfig::registeredProperties() {
     VELOX_REGISTER_QUERY_CONFIG(kDebugLambdaFunctionEvaluationBatchSize);
     VELOX_REGISTER_QUERY_CONFIG(kDebugBingTileChildrenMaxZoomShift);
 
-    // Nimble.
+    // Nimble (deprecated, kept for backward compatibility).
     VELOX_REGISTER_QUERY_CONFIG(kSelectiveNimbleReaderEnabled);
 
     // Scale writer.

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -1233,7 +1233,8 @@ class QueryConfig {
       7,
       "Maximum zoom level difference for bing_tile_children.")
 
-  /// Temporary flag to control whether selective Nimble reader should be used.
+  /// Deprecated: Use FileConfig::kSelectiveNimbleReaderEnabledSession instead.
+  /// Kept for backward compatibility with Presto session properties.
   VELOX_QUERY_CONFIG(
       kSelectiveNimbleReaderEnabled,
       selectiveNimbleReaderEnabled,


### PR DESCRIPTION
Summary:

QueryConfig should be agnostic of connectors and file formats. The `kSelectiveNimbleReaderEnabled` config is Nimble-specific and was threaded through QueryConfig -> Operator.cpp -> ConnectorQueryCtx -> FileConnectorUtil, which unnecessarily coupled the core query layer to a connector-specific detail.

This moves the config to FileConfig (the Hive connector config base class), where other format-specific reader settings already live (e.g., Nimble footer speculative IO size, ORC/Parquet column name settings).

Changes:
- Added `kSelectiveNimbleReaderEnabledSession` to FileConfig using the `VELOX_HIVE_CONFIG` macro, with the same session key (`selective_nimble_reader_enabled`) and default (`true`) for backward compatibility.
- Registered the property in `FileConfig::registeredProperties()`.
- Updated `FileConnectorUtil::configureReaderOptions()` to read from `FileConfig` + session properties instead of `ConnectorQueryCtx`.
- Removed the config definition, accessor, and registration from `QueryConfig.h` / `QueryConfig.cpp`.
- Removed the getter, setter, and member variable from `ConnectorQueryCtx` in `Connector.h`.
- Removed the threading line from `Operator.cpp`.
- Updated all internal downstream consumers (fb_velox tests, dwio tools, instagram joiner) to use `FileConfig::kSelectiveNimbleReaderEnabledSession`.

Fixes
https://github.com/facebookincubator/velox/issues/17284

Reviewed By: mbasmanova

Differential Revision: D101924982
