### PR TITLE
fix(cudf): Add back cudf_interop test

### DIFF
--- a/velox/experimental/cudf/tests/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(velox_cudf_hash_join_test HashJoinTest.cpp Main.cpp)
 add_executable(velox_cudf_limit_test Main.cpp LimitTest.cpp)
 add_executable(velox_cudf_local_partition_test Main.cpp LocalPartitionTest.cpp)
 add_executable(velox_cudf_order_by_test Main.cpp OrderByTest.cpp)
+add_executable(velox_cudf_interop_test Main.cpp InteropTest.cpp)
 if(VELOX_ENABLE_S3)
   add_executable(velox_cudf_s3_read_test Main.cpp S3ReadTest.cpp)
 endif()
@@ -108,6 +109,12 @@ add_test(
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
+add_test(
+  NAME velox_cudf_interop_test
+  COMMAND velox_cudf_interop_test
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
 if(VELOX_ENABLE_S3)
   add_test(
     NAME velox_cudf_s3_read_test
@@ -185,6 +192,7 @@ set_tests_properties(velox_cudf_hash_join_test PROPERTIES LABELS cuda_driver TIM
 set_tests_properties(velox_cudf_limit_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
 set_tests_properties(velox_cudf_local_partition_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
 set_tests_properties(velox_cudf_order_by_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
+set_tests_properties(velox_cudf_interop_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
 if(VELOX_ENABLE_S3)
   set_tests_properties(velox_cudf_s3_read_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
 endif()
@@ -314,6 +322,14 @@ target_link_libraries(
   gtest
   gtest_main
   fmt::fmt
+)
+
+target_link_libraries(
+  velox_cudf_interop_test
+  velox_cudf_exec
+  velox_test_util
+  gtest
+  gtest_main
 )
 
 if(VELOX_ENABLE_S3)

--- a/velox/experimental/cudf/tests/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/CMakeLists.txt
@@ -327,6 +327,8 @@ target_link_libraries(
 target_link_libraries(
   velox_cudf_interop_test
   velox_cudf_exec
+  velox_exec
+  velox_exec_test_lib
   velox_test_util
   gtest
   gtest_main


### PR DESCRIPTION
This PR https://github.com/facebookincubator/velox/pull/16974/changes#diff-f254eef827851069f639f89d2c895f02b91c3bc3192a539713116ca5e2af597a happens dropped the test, add it back