### PR TITLE
feat(cudf): Add GPU SFI integration bridge with Velox CPU fallback

### DIFF
--- a/velox/experimental/cudf/CudfConfig.h
+++ b/velox/experimental/cudf/CudfConfig.h
@@ -40,6 +40,10 @@ struct CudfConfig {
       "cudf.jit_expression_enabled"};
   static constexpr const char* kCudfJitExpressionPriority{
       "cudf.jit_expression_priority"};
+  static constexpr const char* kCudfGpuSfiExpressionEnabled{
+      "cudf.gpu_sfi_expression_enabled"};
+  static constexpr const char* kCudfGpuSfiExpressionPriority{
+      "cudf.gpu_sfi_expression_priority"};
   static constexpr const char* kCudfOutputMr{"cudf.output_mr"};
   static constexpr const char* kCudfAllowCpuFallback{"cudf.allow_cpu_fallback"};
   static constexpr const char* kCudfLogFallback{"cudf.log_fallback"};
@@ -103,6 +107,14 @@ struct CudfConfig {
 
   /// Priority of JIT expression.
   int jitExpressionPriority{101};
+
+  /// Enable GPU SFI (Simple Function Interface) expression evaluator.
+  /// When enabled, Velox simple functions compiled for GPU are used for
+  /// expression evaluation with the highest priority.
+  bool gpuSfiExpressionEnabled{true};
+
+  /// Priority of GPU SFI expression evaluator.
+  int gpuSfiExpressionPriority{200};
 
   /// Whether to log a reason for falling back to Velox CPU execution.
   bool logFallback{true};

--- a/velox/experimental/cudf/benchmarks/CMakeLists.txt
+++ b/velox/experimental/cudf/benchmarks/CMakeLists.txt
@@ -18,5 +18,6 @@ target_link_libraries(
   velox_cudf_tpch_benchmark
   velox_cudf_exec
   velox_cudf_exec_test_lib
+  velox_cudf_gpu_presto_functions
   velox_tpch_benchmark_lib
 )

--- a/velox/experimental/cudf/exec/CMakeLists.txt
+++ b/velox/experimental/cudf/exec/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(
   CudfTopN.cpp
   DebugUtil.cpp
   GpuResources.cpp
+  GpuSfiExpression.cpp
   OperatorAdapters.cpp
   PrestoAggregateFunctions.cpp
   SparkAggregateFunctions.cpp
@@ -49,6 +50,7 @@ target_link_libraries(
     velox_exec
     velox_cudf_hive_connector
     velox_cudf_expression
+    velox_cudf_gpu_registry
 )
 
 target_compile_options(velox_cudf_exec PRIVATE -Wno-missing-field-initializers)

--- a/velox/experimental/cudf/exec/GpuSfiExpression.cpp
+++ b/velox/experimental/cudf/exec/GpuSfiExpression.cpp
@@ -1,0 +1,320 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/experimental/cudf/exec/GpuSfiExpression.h"
+
+#include "velox/common/memory/Memory.h"
+#include "velox/core/Expressions.h"
+#include "velox/core/QueryCtx.h"
+#include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
+#include "velox/experimental/cudf/functions/GpuFunctionDispatch.h"
+#include "velox/expression/ConstantExpr.h"
+#include "velox/expression/Expr.h"
+#include "velox/expression/FieldReference.h"
+#include "velox/type/Type.h"
+#include "velox/vector/ComplexVector.h"
+
+#include <cudf/table/table.hpp>
+
+#include <fmt/format.h>
+#include <glog/logging.h>
+
+#include <atomic>
+
+namespace facebook::velox::gpu {
+void registerAllPrestoGpuFunctions() __attribute__((weak));
+} // namespace facebook::velox::gpu
+
+namespace facebook::velox::cudf_velox {
+
+namespace {
+
+constexpr const char* kGpuSfiEvaluatorName = "gpu_sfi";
+
+cudf::type_id veloxTypeToCudfTypeId(const TypePtr& type) {
+  return veloxToCudfDataType(type).id();
+}
+
+bool canDispatchOnGpu(
+    const std::string& name,
+    cudf::type_id returnType,
+    const std::vector<cudf::type_id>& argTypes) {
+  auto result = gpu::dispatchGpuFunction(name, returnType, argTypes);
+  return result.function != nullptr;
+}
+
+// Reconstruct a Velox uncompiled TypedExprPtr from a compiled exec::Expr.
+// Handles field references, constants, cast, and generic function calls.
+core::TypedExprPtr exprToTypedExpr(
+    const std::shared_ptr<velox::exec::Expr>& expr) {
+  if (auto fieldRef =
+          std::dynamic_pointer_cast<velox::exec::FieldReference>(expr)) {
+    return std::make_shared<core::FieldAccessTypedExpr>(
+        fieldRef->type(), fieldRef->field());
+  }
+
+  if (auto constExpr =
+          std::dynamic_pointer_cast<velox::exec::ConstantExpr>(expr)) {
+    return std::make_shared<core::ConstantTypedExpr>(constExpr->value());
+  }
+
+  // Recursively reconstruct children.
+  std::vector<core::TypedExprPtr> childTypedExprs;
+  childTypedExprs.reserve(expr->inputs().size());
+  for (const auto& child : expr->inputs()) {
+    childTypedExprs.push_back(exprToTypedExpr(child));
+  }
+
+  // Handle cast / try_cast via CastTypedExpr.
+  if (expr->name() == "cast" || expr->name() == "try_cast") {
+    bool isTryCast = (expr->name() == "try_cast");
+    return std::make_shared<core::CastTypedExpr>(
+        expr->type(), childTypedExprs.at(0), isTryCast);
+  }
+
+  // Generic function call (covers regular functions, special forms like
+  // and, or, if, switch, coalesce, in, between, etc.).
+  return std::make_shared<core::CallTypedExpr>(
+      expr->type(), std::move(childTypedExprs), expr->name());
+}
+
+std::unique_ptr<gpu::GpuExprNode> convertExpr(
+    const std::shared_ptr<velox::exec::Expr>& expr,
+    const RowTypePtr& schema) {
+  // Field access: leaf input column.
+  if (auto fieldRef =
+          std::dynamic_pointer_cast<velox::exec::FieldReference>(expr)) {
+    auto fieldName = fieldRef->field();
+    auto idx = schema->getChildIdx(fieldName);
+    auto typeId = veloxTypeToCudfTypeId(fieldRef->type());
+    return gpu::makeFieldAccess(idx, typeId);
+  }
+
+  // Constant / literal.
+  if (auto constExpr =
+          std::dynamic_pointer_cast<velox::exec::ConstantExpr>(expr)) {
+    auto value = constExpr->value();
+    auto typeId = veloxTypeToCudfTypeId(expr->type());
+
+    if (value->isNullAt(0)) {
+      LOG(WARNING) << "[GPU SFI] CPU fallback (compile): null literal '"
+                   << expr->toString() << "'";
+      auto typedExpr = exprToTypedExpr(expr);
+      return gpu::makeCpuFallback(
+          typeId,
+          std::shared_ptr<void>(
+              std::make_shared<core::TypedExprPtr>(std::move(typedExpr))),
+          std::static_pointer_cast<void>(
+              std::const_pointer_cast<RowType>(schema)));
+    }
+
+    switch (expr->type()->kind()) {
+      case TypeKind::DOUBLE:
+        return gpu::makeLiteralDouble(
+            value->as<SimpleVector<double>>()->valueAt(0));
+      case TypeKind::REAL:
+        return gpu::makeLiteralDouble(
+            static_cast<double>(
+                value->as<SimpleVector<float>>()->valueAt(0)));
+      case TypeKind::BIGINT:
+        return gpu::makeLiteralInt64(
+            value->as<SimpleVector<int64_t>>()->valueAt(0));
+      case TypeKind::INTEGER:
+        return gpu::makeLiteralInt64(
+            static_cast<int64_t>(
+                value->as<SimpleVector<int32_t>>()->valueAt(0)));
+      case TypeKind::SMALLINT:
+        return gpu::makeLiteralInt64(
+            static_cast<int64_t>(
+                value->as<SimpleVector<int16_t>>()->valueAt(0)));
+      case TypeKind::TINYINT:
+        return gpu::makeLiteralInt64(
+            static_cast<int64_t>(
+                value->as<SimpleVector<int8_t>>()->valueAt(0)));
+      case TypeKind::BOOLEAN: {
+        auto node = std::make_unique<gpu::GpuExprNode>();
+        node->kind = gpu::GpuExprNodeKind::kLiteral;
+        node->resultType = cudf::type_id::BOOL8;
+        node->literalBool =
+            value->as<SimpleVector<bool>>()->valueAt(0);
+        return node;
+      }
+      default:
+        LOG(WARNING) << "[GPU SFI] CPU fallback (compile): unsupported "
+                     << "literal type " << expr->type()->toString()
+                     << " in '" << expr->toString() << "'";
+        auto typedExpr = exprToTypedExpr(expr);
+        return gpu::makeCpuFallback(
+            typeId,
+            std::shared_ptr<void>(
+                std::make_shared<core::TypedExprPtr>(std::move(typedExpr))),
+            std::static_pointer_cast<void>(
+                std::const_pointer_cast<RowType>(schema)));
+    }
+  }
+
+  // Function call: check if GPU dispatch is available.
+  auto resultTypeId = veloxTypeToCudfTypeId(expr->type());
+  const auto& inputs = expr->inputs();
+
+  std::vector<cudf::type_id> argTypes;
+  argTypes.reserve(inputs.size());
+  for (const auto& input : inputs) {
+    argTypes.push_back(veloxTypeToCudfTypeId(input->type()));
+  }
+
+  bool gpuAvailable =
+      canDispatchOnGpu(expr->name(), resultTypeId, argTypes);
+
+  if (!gpuAvailable) {
+    LOG(WARNING) << "[GPU SFI] CPU fallback (compile): no GPU impl for '"
+                 << expr->name() << "' -- " << expr->toString();
+    auto typedExpr = exprToTypedExpr(expr);
+    return gpu::makeCpuFallback(
+        resultTypeId,
+        std::shared_ptr<void>(
+            std::make_shared<core::TypedExprPtr>(std::move(typedExpr))),
+        std::static_pointer_cast<void>(
+            std::const_pointer_cast<RowType>(schema)));
+  }
+
+  // Recursively convert children.
+  std::vector<std::unique_ptr<gpu::GpuExprNode>> children;
+  children.reserve(inputs.size());
+  for (const auto& input : inputs) {
+    children.push_back(convertExpr(input, schema));
+  }
+
+  return gpu::makeFunctionCall(
+      expr->name(), resultTypeId, std::move(children));
+}
+
+} // namespace
+
+bool GpuSfiExpression::canEvaluate(
+    std::shared_ptr<velox::exec::Expr> /*expr*/) {
+  // Always claim the expression -- unsupported sub-trees become kCpuFallback
+  // nodes that are evaluated on CPU transparently.
+  return true;
+}
+
+std::shared_ptr<CudfExpression> GpuSfiExpression::create(
+    std::shared_ptr<velox::exec::Expr> expr,
+    const RowTypePtr& inputRowSchema) {
+  auto node = std::make_shared<GpuSfiExpression>();
+  node->root_ = convertExpr(expr, inputRowSchema);
+
+  node->evaluator_.setCpuFallbackHandler(
+      [](const gpu::GpuExprNode& fbNode,
+         const cudf::table_view& input,
+         rmm::cuda_stream_view stream,
+         rmm::device_async_resource_ref mr) -> std::unique_ptr<cudf::column> {
+        auto& typedExpr = *std::static_pointer_cast<core::TypedExprPtr>(
+            fbNode.fallbackExpr);
+        auto fbSchema = std::static_pointer_cast<const velox::RowType>(
+            fbNode.fallbackSchema);
+
+        LOG(WARNING) << "[GPU SFI] CPU fallback (eval): evaluating '"
+                     << typedExpr->toString() << "' on Velox CPU engine "
+                     << "(D->H->eval->H->D, " << input.num_rows()
+                     << " rows)";
+
+        static std::atomic<uint64_t> poolCounter{0};
+        auto poolName =
+            fmt::format("gpu_sfi_fallback_{}", poolCounter.fetch_add(1));
+        auto pool =
+            velox::memory::memoryManager()->addLeafPool(poolName);
+
+        // D-to-H: GPU columns -> Velox RowVector. Uses the TypePtr overload
+        // which preserves original field names from the schema so that
+        // ExprSet can resolve FieldReference nodes.
+        auto veloxInput = with_arrow::toVeloxColumn(
+            input,
+            pool.get(),
+            std::static_pointer_cast<const Type>(fbSchema),
+            stream,
+            mr);
+        stream.synchronize();
+
+        // Evaluate on Velox CPU engine using ExprSet.
+        auto queryCtx = core::QueryCtx::create();
+        core::ExecCtx execCtx(pool.get(), queryCtx.get());
+
+        exec::ExprSet exprSet({typedExpr}, &execCtx);
+        exec::EvalCtx evalCtx(&execCtx, &exprSet, veloxInput.get());
+
+        SelectivityVector allRows(veloxInput->size());
+        std::vector<VectorPtr> results(1);
+        exprSet.eval(allRows, evalCtx, results);
+
+        // Wrap result into a single-column RowVector for H-to-D transfer.
+        auto resultRow = std::make_shared<RowVector>(
+            pool.get(),
+            ROW({"_result"}, {results[0]->type()}),
+            nullptr,
+            results[0]->size(),
+            std::vector<VectorPtr>{results[0]});
+
+        // H-to-D: Velox result -> cuDF column.
+        auto resultTable =
+            with_arrow::toCudfTable(resultRow, pool.get(), stream, mr);
+        stream.synchronize();
+
+        // Extract the single result column from the table.
+        auto columns = resultTable->release();
+        VELOX_CHECK_EQ(columns.size(), 1);
+        return std::move(columns[0]);
+      });
+
+  return node;
+}
+
+ColumnOrView GpuSfiExpression::eval(
+    std::vector<cudf::column_view> inputColumnViews,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr,
+    bool /*finalize*/) {
+  std::vector<cudf::column_view> views(
+      inputColumnViews.begin(), inputColumnViews.end());
+  cudf::table_view input(views);
+
+  auto result = evaluator_.evaluate(*root_, input, stream, mr);
+  return std::move(result);
+}
+
+void GpuSfiExpression::close() {
+  root_.reset();
+}
+
+void registerGpuSfiEvaluator(int priority) {
+  if (!&gpu::registerAllPrestoGpuFunctions) {
+    LOG(WARNING) << "GPU SFI evaluator skipped: "
+                    "velox_cudf_gpu_presto_functions not linked";
+    return;
+  }
+  gpu::registerAllPrestoGpuFunctions();
+  registerCudfExpressionEvaluator(
+      kGpuSfiEvaluatorName,
+      priority,
+      [](std::shared_ptr<velox::exec::Expr> expr) {
+        return GpuSfiExpression::canEvaluate(std::move(expr));
+      },
+      [](std::shared_ptr<velox::exec::Expr> expr, const RowTypePtr& row) {
+        return GpuSfiExpression::create(std::move(expr), row);
+      },
+      /*overwrite=*/false);
+}
+
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/GpuSfiExpression.h
+++ b/velox/experimental/cudf/exec/GpuSfiExpression.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Bridge between the existing CudfExpression evaluator pipeline and the
+// GPU SFI engine (PRs 1-11).  GpuSfiExpression converts a Velox exec::Expr
+// tree into a GpuExprNode tree at compile time (create()), then evaluates
+// it on GPU using GpuExprEvaluator at runtime (eval()).
+#pragma once
+
+#include "velox/experimental/cudf/expression/ExpressionEvaluator.h"
+#include "velox/experimental/cudf/functions/GpuExprEvaluator.h"
+
+namespace facebook::velox::cudf_velox {
+
+class GpuSfiExpression : public CudfExpression {
+ public:
+  static bool canEvaluate(std::shared_ptr<velox::exec::Expr> expr);
+
+  static std::shared_ptr<CudfExpression> create(
+      std::shared_ptr<velox::exec::Expr> expr,
+      const RowTypePtr& inputRowSchema);
+
+  ColumnOrView eval(
+      std::vector<cudf::column_view> inputColumnViews,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr,
+      bool finalize = false) override;
+
+  void close() override;
+
+ private:
+  std::unique_ptr<gpu::GpuExprNode> root_;
+  gpu::GpuExprEvaluator evaluator_;
+};
+
+void registerGpuSfiEvaluator(int priority);
+
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -27,6 +27,7 @@
 #include "velox/experimental/cudf/expression/AstExpression.h"
 #include "velox/experimental/cudf/expression/ExpressionEvaluator.h"
 #include "velox/experimental/cudf/expression/JitExpression.h"
+#include "velox/experimental/cudf/exec/GpuSfiExpression.h"
 
 #include "folly/Conv.h"
 #include "velox/exec/Driver.h"
@@ -339,6 +340,11 @@ void registerCudf() {
     registerJitEvaluator(CudfConfig::getInstance().jitExpressionPriority);
   }
 
+  if (CudfConfig::getInstance().gpuSfiExpressionEnabled) {
+    registerGpuSfiEvaluator(
+        CudfConfig::getInstance().gpuSfiExpressionPriority);
+  }
+
   isCudfRegistered = true;
 }
 
@@ -403,6 +409,14 @@ void CudfConfig::initialize(
   if (config.find(kCudfAstExpressionPriority) != config.end()) {
     astExpressionPriority =
         folly::to<int32_t>(config[kCudfAstExpressionPriority]);
+  }
+  if (config.find(kCudfGpuSfiExpressionEnabled) != config.end()) {
+    gpuSfiExpressionEnabled =
+        folly::to<bool>(config[kCudfGpuSfiExpressionEnabled]);
+  }
+  if (config.find(kCudfGpuSfiExpressionPriority) != config.end()) {
+    gpuSfiExpressionPriority =
+        folly::to<int32_t>(config[kCudfGpuSfiExpressionPriority]);
   }
   if (config.find(kCudfAllowCpuFallback) != config.end()) {
     allowCpuFallback = folly::to<bool>(config[kCudfAllowCpuFallback]);

--- a/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/exec/Validation.h"
 #include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
 #include "velox/experimental/cudf/expression/AstUtils.h"
@@ -1138,18 +1139,29 @@ std::shared_ptr<CudfExpression> createCudfExpression(
   const auto& registry = getCudfExpressionEvaluatorRegistry();
 
   const CudfExpressionEvaluatorEntry* best = nullptr;
+  std::string bestName;
   for (const auto& [name, entry] : registry) {
     if (entry.canEvaluate && entry.canEvaluate(expr)) {
       if (best == nullptr || entry.priority > best->priority) {
         best = &entry;
+        bestName = name;
       }
     }
   }
 
   if (best != nullptr) {
+    if (CudfConfig::getInstance().debugEnabled) {
+      LOG(INFO) << "createCudfExpression: evaluator='" << bestName
+                << "' (priority=" << best->priority
+                << ") for: " << expr->toString();
+    }
     return best->create(expr, inputRowSchema);
   }
 
+  if (CudfConfig::getInstance().debugEnabled) {
+    LOG(INFO) << "createCudfExpression: evaluator='FunctionExpression'"
+              << " (default) for: " << expr->toString();
+  }
   return FunctionExpression::create(expr, inputRowSchema);
 }
 

--- a/velox/experimental/cudf/functions/GpuExprEvaluator.cpp
+++ b/velox/experimental/cudf/functions/GpuExprEvaluator.cpp
@@ -50,6 +50,8 @@ GpuExprEvaluator::EvalResult GpuExprEvaluator::evalNode(
       return evalFunctionCall(node, input, stream, mr);
     case GpuExprNodeKind::kLiteral:
       return evalLiteral(node, input.num_rows(), stream, mr);
+    case GpuExprNodeKind::kCpuFallback:
+      return evalCpuFallback(node, input, stream, mr);
   }
   throw std::runtime_error("Unknown GpuExprNode kind");
 }
@@ -88,8 +90,11 @@ GpuExprEvaluator::EvalResult GpuExprEvaluator::evalFunctionCall(
         "No GPU implementation found for function: " + node.functionName);
   }
 
-  auto col = dispatch.function->apply(
-      childViews, input.num_rows(), nullptr, stream, mr);
+  // Retain owned to keep the function object alive through apply().
+  auto ownedFn = std::move(dispatch.owned);
+  GpuVectorFunction* fn = ownedFn ? ownedFn.get() : dispatch.function;
+
+  auto col = fn->apply(childViews, input.num_rows(), nullptr, stream, mr);
   auto view = col->view();
   return {std::move(col), view};
 }
@@ -164,6 +169,32 @@ std::unique_ptr<GpuExprNode> makeLiteralInt64(int64_t value) {
   node->resultType = cudf::type_id::INT64;
   node->literalInt64 = value;
   return node;
+}
+
+std::unique_ptr<GpuExprNode> makeCpuFallback(
+    cudf::type_id resultType,
+    std::shared_ptr<void> fallbackExpr,
+    std::shared_ptr<void> fallbackSchema) {
+  auto node = std::make_unique<GpuExprNode>();
+  node->kind = GpuExprNodeKind::kCpuFallback;
+  node->resultType = resultType;
+  node->fallbackExpr = std::move(fallbackExpr);
+  node->fallbackSchema = std::move(fallbackSchema);
+  return node;
+}
+
+GpuExprEvaluator::EvalResult GpuExprEvaluator::evalCpuFallback(
+    const GpuExprNode& node,
+    const cudf::table_view& input,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  if (!cpuFallbackHandler_) {
+    throw std::runtime_error(
+        "kCpuFallback node encountered but no CPU fallback handler is set");
+  }
+  auto col = cpuFallbackHandler_(node, input, stream, mr);
+  auto view = col->view();
+  return {std::move(col), view};
 }
 
 } // namespace facebook::velox::gpu

--- a/velox/experimental/cudf/functions/GpuExprEvaluator.h
+++ b/velox/experimental/cudf/functions/GpuExprEvaluator.h
@@ -28,6 +28,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
+#include <functional>
 #include <memory>
 #include <string>
 #include <variant>
@@ -39,6 +40,7 @@ enum class GpuExprNodeKind {
   kFieldAccess,
   kFunctionCall,
   kLiteral,
+  kCpuFallback,
 };
 
 struct GpuExprNode {
@@ -53,10 +55,25 @@ struct GpuExprNode {
   double literalDouble{0.0};
   int64_t literalInt64{0};
   bool literalBool{false};
+
+  // For kCpuFallback: type-erased pointers to avoid Velox header deps here.
+  // Holds shared_ptr<exec::Expr> and shared_ptr<RowType> respectively.
+  std::shared_ptr<void> fallbackExpr;
+  std::shared_ptr<void> fallbackSchema;
 };
+
+using CpuFallbackFn = std::function<std::unique_ptr<cudf::column>(
+    const GpuExprNode& node,
+    const cudf::table_view& input,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr)>;
 
 class GpuExprEvaluator {
  public:
+  void setCpuFallbackHandler(CpuFallbackFn handler) {
+    cpuFallbackHandler_ = std::move(handler);
+  }
+
   std::unique_ptr<cudf::column> evaluate(
       const GpuExprNode& expr,
       const cudf::table_view& input,
@@ -90,6 +107,14 @@ class GpuExprEvaluator {
       cudf::size_type numRows,
       rmm::cuda_stream_view stream,
       rmm::device_async_resource_ref mr);
+
+  EvalResult evalCpuFallback(
+      const GpuExprNode& node,
+      const cudf::table_view& input,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr);
+
+  CpuFallbackFn cpuFallbackHandler_;
 };
 
 std::unique_ptr<GpuExprNode> makeFieldAccess(
@@ -103,5 +128,10 @@ std::unique_ptr<GpuExprNode> makeFunctionCall(
 
 std::unique_ptr<GpuExprNode> makeLiteralDouble(double value);
 std::unique_ptr<GpuExprNode> makeLiteralInt64(int64_t value);
+
+std::unique_ptr<GpuExprNode> makeCpuFallback(
+    cudf::type_id resultType,
+    std::shared_ptr<void> fallbackExpr,
+    std::shared_ptr<void> fallbackSchema);
 
 } // namespace facebook::velox::gpu

--- a/velox/experimental/cudf/tests/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/CMakeLists.txt
@@ -412,6 +412,29 @@ target_link_libraries(
   velox_cudf_exec
 )
 
+# GPU SFI Integration test: bridge between CudfExpression pipeline and GPU SFI engine
+add_executable(velox_cudf_gpu_sfi_integration_test Main.cpp GpuSfiIntegrationTest.cpp)
+
+add_test(
+  NAME velox_cudf_gpu_sfi_integration_test
+  COMMAND velox_cudf_gpu_sfi_integration_test
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+set_tests_properties(velox_cudf_gpu_sfi_integration_test PROPERTIES LABELS cuda_driver TIMEOUT 300)
+
+target_link_libraries(
+  velox_cudf_gpu_sfi_integration_test
+  velox_cudf_exec
+  velox_cudf_gpu_presto_functions
+  velox_exec
+  velox_exec_test_lib
+  velox_test_util
+  gtest
+  gtest_main
+  Folly::folly
+)
+
 add_executable(velox_cudf_gpu_types_test GpuTypesTest.cpp)
 
 add_test(

--- a/velox/experimental/cudf/tests/GpuSfiIntegrationTest.cpp
+++ b/velox/experimental/cudf/tests/GpuSfiIntegrationTest.cpp
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/cudf/CudfConfig.h"
+#include "velox/experimental/cudf/exec/GpuSfiExpression.h"
+#include "velox/experimental/cudf/exec/ToCudf.h"
+#include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
+#include "velox/experimental/cudf/expression/ExpressionEvaluator.h"
+#include "velox/experimental/cudf/tests/utils/ExpressionTestUtil.h"
+
+#include "velox/common/memory/Memory.h"
+#include "velox/core/QueryCtx.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/parse/TypeResolver.h"
+
+#include <cudf/column/column_factories.hpp>
+#include <cudf/utilities/memory_resource.hpp>
+#include <cuda_runtime.h>
+#include <rmm/cuda_stream_view.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace facebook::velox;
+using namespace facebook::velox::cudf_velox;
+using namespace facebook::velox::cudf_velox::test_utils;
+
+class GpuSfiIntegrationTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+    functions::prestosql::registerAllScalarFunctions();
+  }
+
+  void SetUp() override {
+    cudaSetDevice(0);
+    pool_ = memory::memoryManager()->addLeafPool("", false);
+    queryCtx_ = core::QueryCtx::create();
+    execCtx_ = std::make_unique<core::ExecCtx>(pool_.get(), queryCtx_.get());
+
+    CudfConfig::getInstance().gpuSfiExpressionEnabled = true;
+    CudfConfig::getInstance().gpuSfiExpressionPriority = 200;
+    CudfConfig::getInstance().memoryResource = "cuda";
+    registerCudf();
+
+    rowType_ = ROW({{"a", DOUBLE()}, {"b", DOUBLE()}, {"c", BIGINT()}});
+    parse::registerTypeResolver();
+  }
+
+  void TearDown() override {
+    unregisterFunctions();
+    unregisterCudf();
+    execCtx_.reset();
+    queryCtx_.reset();
+    pool_.reset();
+  }
+
+  std::unique_ptr<cudf::column> makeDoubleColumn(
+      const std::vector<double>& data) {
+    auto col = cudf::make_fixed_width_column(
+        cudf::data_type{cudf::type_id::FLOAT64},
+        data.size(),
+        cudf::mask_state::UNALLOCATED,
+        stream_,
+        mr());
+    cudaMemcpy(
+        col->mutable_view().data<double>(),
+        data.data(),
+        data.size() * sizeof(double),
+        cudaMemcpyHostToDevice);
+    return col;
+  }
+
+  std::unique_ptr<cudf::column> makeInt64Column(
+      const std::vector<int64_t>& data) {
+    auto col = cudf::make_fixed_width_column(
+        cudf::data_type{cudf::type_id::INT64},
+        data.size(),
+        cudf::mask_state::UNALLOCATED,
+        stream_,
+        mr());
+    cudaMemcpy(
+        col->mutable_view().data<int64_t>(),
+        data.data(),
+        data.size() * sizeof(int64_t),
+        cudaMemcpyHostToDevice);
+    return col;
+  }
+
+  std::vector<double> readDouble(const cudf::column_view& col) {
+    std::vector<double> result(col.size());
+    cudaMemcpy(
+        result.data(),
+        col.data<double>(),
+        col.size() * sizeof(double),
+        cudaMemcpyDeviceToHost);
+    return result;
+  }
+
+  rmm::device_async_resource_ref mr() {
+    return cudf::get_current_device_resource_ref();
+  }
+
+  std::shared_ptr<memory::MemoryPool> pool_;
+  std::shared_ptr<core::QueryCtx> queryCtx_;
+  std::unique_ptr<core::ExecCtx> execCtx_;
+  RowTypePtr rowType_;
+  rmm::cuda_stream_view stream_ = rmm::cuda_stream_default;
+};
+
+TEST_F(GpuSfiIntegrationTest, gpuSfiIsHighestPriority) {
+  auto expr = compileExecExpr("a + b", rowType_, execCtx_.get());
+  auto cudfExpr = createCudfExpression(expr, rowType_);
+  auto* sfiExpr = dynamic_cast<GpuSfiExpression*>(cudfExpr.get());
+  ASSERT_NE(sfiExpr, nullptr)
+      << "GPU SFI should be selected as highest priority evaluator for a + b";
+}
+
+TEST_F(GpuSfiIntegrationTest, gpuSfiClaimsAllExpressions) {
+  EXPECT_TRUE(GpuSfiExpression::canEvaluate(nullptr));
+
+  auto expr = compileExecExpr("lower(cast(c as varchar))", rowType_, execCtx_.get());
+  EXPECT_TRUE(GpuSfiExpression::canEvaluate(expr));
+}
+
+TEST_F(GpuSfiIntegrationTest, endToEndArithmetic) {
+  auto expr = compileExecExpr("a + b", rowType_, execCtx_.get());
+  auto cudfExpr = createCudfExpression(expr, rowType_);
+
+  auto colA = makeDoubleColumn({1.0, 2.0, 3.0});
+  auto colB = makeDoubleColumn({10.0, 20.0, 30.0});
+  auto colC = makeInt64Column({100, 200, 300});
+
+  std::vector<cudf::column_view> inputViews = {
+      colA->view(), colB->view(), colC->view()};
+
+  auto result = cudfExpr->eval(inputViews, stream_, mr());
+  auto view = asView(result);
+  auto hostResult = readDouble(view);
+
+  EXPECT_DOUBLE_EQ(11.0, hostResult[0]);
+  EXPECT_DOUBLE_EQ(22.0, hostResult[1]);
+  EXPECT_DOUBLE_EQ(33.0, hostResult[2]);
+}
+
+TEST_F(GpuSfiIntegrationTest, endToEndCompound) {
+  // a * (1.0 - b)  -- TPC-H revenue pattern
+  auto expr = compileExecExpr(
+      "a * (1.0e0 - b)", rowType_, execCtx_.get());
+  auto cudfExpr = createCudfExpression(expr, rowType_);
+
+  auto colA = makeDoubleColumn({100.0, 200.0, 300.0});
+  auto colB = makeDoubleColumn({0.05, 0.10, 0.0});
+  auto colC = makeInt64Column({0, 0, 0});
+
+  std::vector<cudf::column_view> inputViews = {
+      colA->view(), colB->view(), colC->view()};
+
+  auto result = cudfExpr->eval(inputViews, stream_, mr());
+  auto view = asView(result);
+  auto hostResult = readDouble(view);
+
+  EXPECT_DOUBLE_EQ(95.0, hostResult[0]);
+  EXPECT_DOUBLE_EQ(180.0, hostResult[1]);
+  EXPECT_DOUBLE_EQ(300.0, hostResult[2]);
+}
+
+TEST_F(GpuSfiIntegrationTest, cpuFallbackForUnsupportedExpr) {
+  // "coalesce" has no GPU SFI implementation, so it should fall back to
+  // CPU Velox's expression engine via D->H->eval->H->D.
+  auto expr = compileExecExpr(
+      "coalesce(a, b)", rowType_, execCtx_.get());
+  auto cudfExpr = createCudfExpression(expr, rowType_);
+
+  auto colA = makeDoubleColumn({1.0, 2.0, 3.0});
+  auto colB = makeDoubleColumn({10.0, 20.0, 30.0});
+  auto colC = makeInt64Column({100, 200, 300});
+
+  std::vector<cudf::column_view> inputViews = {
+      colA->view(), colB->view(), colC->view()};
+
+  auto result = cudfExpr->eval(inputViews, stream_, mr());
+  auto view = asView(result);
+  auto hostResult = readDouble(view);
+
+  // coalesce(a, b) returns a when a is non-null.
+  EXPECT_DOUBLE_EQ(1.0, hostResult[0]);
+  EXPECT_DOUBLE_EQ(2.0, hostResult[1]);
+  EXPECT_DOUBLE_EQ(3.0, hostResult[2]);
+}
+
+TEST_F(GpuSfiIntegrationTest, cpuFallbackMixedGpuAndCpu) {
+  // "a + b" runs on GPU, but the overall expression includes a cast
+  // that may need CPU fallback. Tests mixed GPU/CPU expression trees.
+  auto mixedType = ROW({{"a", DOUBLE()}, {"b", DOUBLE()}, {"c", BIGINT()}});
+  // "if(c > 150, a + b, 0.0)" -- 'if' likely falls back, but 'a + b' can
+  // run on GPU. The entire expression should produce correct results
+  // regardless of where each sub-tree runs.
+  auto expr = compileExecExpr(
+      "if(c > 150, a + b, 0.0e0)", mixedType, execCtx_.get());
+  auto cudfExpr = createCudfExpression(expr, mixedType);
+
+  auto colA = makeDoubleColumn({1.0, 2.0, 3.0});
+  auto colB = makeDoubleColumn({10.0, 20.0, 30.0});
+  auto colC = makeInt64Column({100, 200, 300});
+
+  std::vector<cudf::column_view> inputViews = {
+      colA->view(), colB->view(), colC->view()};
+
+  auto result = cudfExpr->eval(inputViews, stream_, mr());
+  auto view = asView(result);
+  auto hostResult = readDouble(view);
+
+  // c=100 (<=150): 0.0, c=200 (>150): 2+20=22, c=300 (>150): 3+30=33
+  EXPECT_DOUBLE_EQ(0.0, hostResult[0]);
+  EXPECT_DOUBLE_EQ(22.0, hostResult[1]);
+  EXPECT_DOUBLE_EQ(33.0, hostResult[2]);
+}
+
+TEST_F(GpuSfiIntegrationTest, configKeys) {
+  EXPECT_TRUE(CudfConfig::getInstance().gpuSfiExpressionEnabled);
+  EXPECT_EQ(200, CudfConfig::getInstance().gpuSfiExpressionPriority);
+
+  EXPECT_STREQ(
+      "cudf.gpu_sfi_expression_enabled",
+      CudfConfig::kCudfGpuSfiExpressionEnabled);
+  EXPECT_STREQ(
+      "cudf.gpu_sfi_expression_priority",
+      CudfConfig::kCudfGpuSfiExpressionPriority);
+}


### PR DESCRIPTION
## Summary
- Implements `GpuSfiExpression` bridge that integrates the GPU SFI expression engine into the cuDF expression evaluator pipeline as the highest-priority evaluator (priority 200).
- Converts Velox compiled expression trees (`exec::Expr`) to GPU SFI's `GpuExprNode` representation at compile time.
- Adds an independent CPU fallback path using Velox's native `exec::ExprSet` (D-to-H transfer, eval, H-to-D transfer) with explicit logging for every fallback -- completely independent of existing cuDF evaluators.
- Implements `exprToTypedExpr()` helper to reconstruct `core::TypedExprPtr` from compiled `exec::Expr` for the CPU fallback path.
- Adds config knob `cudf.gpu_sfi_expression_enabled` (default: true) and `cudf.gpu_sfi_expression_priority` (default: 200).

## Stack
- Part 12 of the GPU SFI stack
- Base: `gpu-sfi/11-registrations` (#17277)

## Test plan
- [x] `velox_cudf_gpu_sfi_integration_test` (7 tests covering priority, expression claiming, arithmetic, compound expressions, CPU fallback, mixed GPU/CPU, config keys)
- [x] TPC-H Q1, Q6 pass end-to-end


Made with [Cursor](https://cursor.com)