### PR TITLE
feat(cudf): Add stateful GPU function factory for constant-arg functions

### DIFF
--- a/velox/experimental/cudf/exec/GpuSfiExpression.cpp
+++ b/velox/experimental/cudf/exec/GpuSfiExpression.cpp
@@ -36,6 +36,10 @@
 
 #include <atomic>
 
+namespace {
+std::atomic<uint64_t> constExtractPoolCounter{0};
+} // namespace
+
 namespace facebook::velox::gpu {
 void registerAllPrestoGpuFunctions() __attribute__((weak));
 } // namespace facebook::velox::gpu
@@ -212,6 +216,93 @@ std::unique_ptr<gpu::GpuExprNode> convertExpr(
           resultTypeId, convertExpr(inputs.at(0), schema));
     }
     return buildCpuFallback();
+  }
+
+  // -- Stateful function dispatch: for functions with constant arguments --
+  // Mirrors Velox CPU's VectorFunctionFactory pattern: extract constant values
+  // from ConstantExpr children, pass them to the factory at compile time,
+  // and the factory bakes them into the function instance.
+  {
+    bool hasConstant = false;
+    for (const auto& input : inputs) {
+      if (std::dynamic_pointer_cast<velox::exec::ConstantExpr>(input)) {
+        hasConstant = true;
+        break;
+      }
+    }
+
+    if (hasConstant &&
+        gpu::GpuFunctionRegistry::instance().hasStatefulFunction(name)) {
+      std::vector<gpu::GpuFunctionArg> gpuArgs;
+      gpuArgs.reserve(inputs.size());
+      std::vector<std::unique_ptr<gpu::GpuExprNode>> nonConstChildren;
+
+      for (const auto& input : inputs) {
+        auto typeId = veloxTypeToCudfTypeId(input->type());
+        if (auto cexpr =
+                std::dynamic_pointer_cast<velox::exec::ConstantExpr>(input)) {
+          auto value = cexpr->value();
+          std::shared_ptr<cudf::column> deviceCol;
+          std::optional<std::string> constStr;
+          if (value && !value->isNullAt(0)) {
+            // Extract host-side string for scalar string constants.
+            if (value->typeKind() == TypeKind::VARCHAR ||
+                value->typeKind() == TypeKind::VARBINARY) {
+              auto sv =
+                  value->as<SimpleVector<StringView>>()->valueAt(0);
+              constStr = std::string(sv.data(), sv.size());
+            }
+
+            // For ARRAY constants (e.g. IN-list), extract the elements
+            // as a flat vector and transfer those to device.
+            VectorPtr toTransfer = value;
+            TypePtr transferType = value->type();
+            if (value->typeKind() == TypeKind::ARRAY) {
+              auto constInput = value->as<ConstantVector<ComplexType>>();
+              auto arrayVec = constInput->valueVector()->as<ArrayVector>();
+              auto offset = arrayVec->offsetAt(constInput->index());
+              auto size = arrayVec->sizeAt(constInput->index());
+              toTransfer = arrayVec->elements()->slice(offset, size);
+              transferType = toTransfer->type();
+              typeId = veloxTypeToCudfTypeId(transferType);
+            }
+
+            auto pool = velox::memory::memoryManager()->addLeafPool(
+                fmt::format(
+                    "gpu_sfi_const_{}",
+                    constExtractPoolCounter.fetch_add(1)));
+            auto constRow = std::make_shared<RowVector>(
+                pool.get(),
+                ROW({"_c"}, {transferType}),
+                nullptr,
+                toTransfer->size(),
+                std::vector<VectorPtr>{toTransfer});
+            auto constTable = with_arrow::toCudfTable(
+                constRow,
+                pool.get(),
+                rmm::cuda_stream_default,
+                cudf::get_current_device_resource_ref());
+            rmm::cuda_stream_default.synchronize();
+            auto cols = constTable->release();
+            deviceCol = std::move(cols[0]);
+          }
+          gpuArgs.push_back(
+              {typeId, std::move(deviceCol), std::move(constStr)});
+        } else {
+          gpuArgs.push_back({typeId, nullptr, std::nullopt});
+          nonConstChildren.push_back(convertExpr(input, schema));
+        }
+      }
+
+      auto fn = gpu::GpuFunctionRegistry::instance().resolveStatefulFunction(
+          name, gpuArgs);
+      if (fn) {
+        auto node = gpu::makeFunctionCall(
+            name, resultTypeId, std::move(nonConstChildren));
+        node->ownedFunction = std::move(fn);
+        return node;
+      }
+    }
   }
 
   // -- Regular function call: check GPU dispatch availability --

--- a/velox/experimental/cudf/functions/CudfLibraryFunctions.cpp
+++ b/velox/experimental/cudf/functions/CudfLibraryFunctions.cpp
@@ -20,10 +20,11 @@
 
 #include <cudf/binaryop.hpp>
 #include <cudf/column/column_view.hpp>
-#include <cudf/scalar/scalar_factories.hpp>
 #include <cudf/datetime.hpp>
 #include <cudf/hashing.hpp>
 #include <cudf/scalar/scalar.hpp>
+#include <cudf/scalar/scalar_factories.hpp>
+#include <cudf/search.hpp>
 #include <cudf/strings/attributes.hpp>
 #include <cudf/strings/case.hpp>
 #include <cudf/strings/combine.hpp>
@@ -327,23 +328,33 @@ void registerCudfDateTimeFunctions() {
   using DC = cudf::datetime::datetime_component;
 
   auto registerExtract = [](const std::string& name, DC component) {
-    // date_type is TIMESTAMP_DAYS (INT32) for DATE
     for (auto dateType :
          {cudf::type_id::TIMESTAMP_DAYS,
           cudf::type_id::TIMESTAMP_SECONDS,
           cudf::type_id::TIMESTAMP_MILLISECONDS}) {
-      registerCudfLibFn(
-          name,
-          cudf::type_id::INT32,
-          {dateType},
-          [component](
-              const std::vector<cudf::column_view>& inputs,
-              cudf::size_type,
-              rmm::cuda_stream_view stream,
-              rmm::device_async_resource_ref mr) {
-            return cudf::datetime::extract_datetime_component(
-                inputs[0], component, stream, mr);
-          });
+      // cuDF extract returns INT16; Velox expects BIGINT (INT64).
+      // Register for both INT32 and INT64 return types, casting as needed.
+      for (auto retType :
+           {cudf::type_id::INT16, cudf::type_id::INT32,
+            cudf::type_id::INT64}) {
+        registerCudfLibFn(
+            name,
+            retType,
+            {dateType},
+            [component, retType](
+                const std::vector<cudf::column_view>& inputs,
+                cudf::size_type,
+                rmm::cuda_stream_view stream,
+                rmm::device_async_resource_ref mr) {
+              auto result = cudf::datetime::extract_datetime_component(
+                  inputs[0], component, stream, mr);
+              if (retType != cudf::type_id::INT16) {
+                return cudf::cast(
+                    result->view(), cudf::data_type{retType}, stream, mr);
+              }
+              return result;
+            });
+      }
     }
   };
 
@@ -382,6 +393,88 @@ void registerCudfHashFunctions() {
         cudf::table_view tv(inputs);
         return cudf::hashing::sha256(tv, stream, mr);
       });
+}
+
+// -- Stateful Functions (constant arguments baked at compile time) --
+
+namespace {
+
+// IN predicate: wraps cudf::contains(haystack, needles).
+// The constant IN-list (haystack) is baked in at creation time.
+class GpuInFunction : public GpuVectorFunction {
+ public:
+  explicit GpuInFunction(std::shared_ptr<cudf::column> inList)
+      : inList_(std::move(inList)) {}
+
+  std::unique_ptr<cudf::column> apply(
+      const std::vector<cudf::column_view>& inputs,
+      cudf::size_type /*numRows*/,
+      const cudf::bitmask_type* /*activeRows*/,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) override {
+    // inputs[0] = the data column (needles)
+    // inList_ = the constant values to search in (haystack)
+    return cudf::contains(inList_->view(), inputs[0], stream, mr);
+  }
+
+ private:
+  std::shared_ptr<cudf::column> inList_;
+};
+
+// LIKE pattern matching: wraps cudf::strings::like(input, pattern, escape).
+// The constant pattern (and optional escape char) are baked in at creation time.
+class GpuLikeFunction : public GpuVectorFunction {
+ public:
+  GpuLikeFunction(std::string pattern, std::string escape)
+      : pattern_(std::move(pattern)), escape_(std::move(escape)) {}
+
+  std::unique_ptr<cudf::column> apply(
+      const std::vector<cudf::column_view>& inputs,
+      cudf::size_type /*numRows*/,
+      const cudf::bitmask_type* /*activeRows*/,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) override {
+    cudf::strings_column_view scv(inputs[0]);
+    return cudf::strings::like(scv, pattern_, escape_, stream, mr);
+  }
+
+ private:
+  std::string pattern_;
+  std::string escape_;
+};
+
+std::unique_ptr<GpuVectorFunction> makeInFactory(
+    const std::string& /*name*/,
+    const std::vector<GpuFunctionArg>& inputArgs) {
+  if (inputArgs.size() < 2 || !inputArgs[1].constantValue) {
+    return nullptr;
+  }
+  return std::make_unique<GpuInFunction>(inputArgs[1].constantValue);
+}
+
+std::unique_ptr<GpuVectorFunction> makeLikeFactory(
+    const std::string& /*name*/,
+    const std::vector<GpuFunctionArg>& inputArgs) {
+  if (inputArgs.size() < 2 || !inputArgs[1].constantString) {
+    return nullptr;
+  }
+
+  std::string pattern = *inputArgs[1].constantString;
+
+  std::string escape;
+  if (inputArgs.size() >= 3 && inputArgs[2].constantString) {
+    escape = *inputArgs[2].constantString;
+  }
+
+  return std::make_unique<GpuLikeFunction>(std::move(pattern), std::move(escape));
+}
+
+} // namespace
+
+void registerCudfStatefulFunctions() {
+  auto& registry = GpuFunctionRegistry::instance();
+  registry.registerStatefulFunction("in", makeInFactory);
+  registry.registerStatefulFunction("like", makeLikeFactory);
 }
 
 } // namespace facebook::velox::gpu

--- a/velox/experimental/cudf/functions/CudfLibraryFunctions.h
+++ b/velox/experimental/cudf/functions/CudfLibraryFunctions.h
@@ -24,5 +24,6 @@ namespace facebook::velox::gpu {
 void registerCudfStringFunctions();
 void registerCudfDateTimeFunctions();
 void registerCudfHashFunctions();
+void registerCudfStatefulFunctions();
 
 } // namespace facebook::velox::gpu

--- a/velox/experimental/cudf/functions/GpuExprEvaluator.cpp
+++ b/velox/experimental/cudf/functions/GpuExprEvaluator.cpp
@@ -98,6 +98,15 @@ GpuExprEvaluator::EvalResult GpuExprEvaluator::evalFunctionCall(
     argTypes.push_back(childViews.back().type().id());
   }
 
+  // If the node has a stateful function with constants baked in, use it
+  // directly (mirrors Velox CPU's VectorFunctionFactory pattern).
+  if (node.ownedFunction) {
+    auto col = node.ownedFunction->apply(
+        childViews, input.num_rows(), nullptr, stream, mr);
+    auto view = col->view();
+    return {std::move(col), view};
+  }
+
   auto dispatch = dispatchGpuFunction(
       node.functionName, node.resultType, argTypes);
 
@@ -106,7 +115,6 @@ GpuExprEvaluator::EvalResult GpuExprEvaluator::evalFunctionCall(
         "No GPU implementation found for function: " + node.functionName);
   }
 
-  // Retain owned to keep the function object alive through apply().
   auto ownedFn = std::move(dispatch.owned);
   GpuVectorFunction* fn = ownedFn ? ownedFn.get() : dispatch.function;
 

--- a/velox/experimental/cudf/functions/GpuExprEvaluator.h
+++ b/velox/experimental/cudf/functions/GpuExprEvaluator.h
@@ -68,6 +68,11 @@ struct GpuExprNode {
   // Holds shared_ptr<exec::Expr> and shared_ptr<RowType> respectively.
   std::shared_ptr<void> fallbackExpr;
   std::shared_ptr<void> fallbackSchema;
+
+  // For kFunctionCall with stateful functions: owns a per-expression function
+  // instance created by GpuStatefulFunctionFactory with constants baked in.
+  // When set, evalFunctionCall uses this directly instead of dispatch.
+  std::unique_ptr<GpuVectorFunction> ownedFunction;
 };
 
 using CpuFallbackFn = std::function<std::unique_ptr<cudf::column>(

--- a/velox/experimental/cudf/functions/GpuFunctionRegistry.cpp
+++ b/velox/experimental/cudf/functions/GpuFunctionRegistry.cpp
@@ -55,15 +55,39 @@ bool GpuFunctionRegistry::hasFunction(const GpuFunctionKey& key) const {
   return factories_.count(key) > 0;
 }
 
+void GpuFunctionRegistry::registerStatefulFunction(
+    const std::string& name,
+    GpuStatefulFunctionFactory factory) {
+  std::lock_guard<std::mutex> lock(mu_);
+  statefulFactories_[name] = std::move(factory);
+}
+
+std::unique_ptr<GpuVectorFunction> GpuFunctionRegistry::resolveStatefulFunction(
+    const std::string& name,
+    const std::vector<GpuFunctionArg>& inputArgs) const {
+  std::lock_guard<std::mutex> lock(mu_);
+  auto it = statefulFactories_.find(name);
+  if (it == statefulFactories_.end()) {
+    return nullptr;
+  }
+  return it->second(name, inputArgs);
+}
+
+bool GpuFunctionRegistry::hasStatefulFunction(const std::string& name) const {
+  std::lock_guard<std::mutex> lock(mu_);
+  return statefulFactories_.count(name) > 0;
+}
+
 size_t GpuFunctionRegistry::size() const {
   std::lock_guard<std::mutex> lock(mu_);
-  return factories_.size();
+  return factories_.size() + statefulFactories_.size();
 }
 
 void GpuFunctionRegistry::clear() {
   std::lock_guard<std::mutex> lock(mu_);
   factories_.clear();
   resolved_.clear();
+  statefulFactories_.clear();
 }
 
 } // namespace facebook::velox::gpu

--- a/velox/experimental/cudf/functions/GpuFunctionRegistry.h
+++ b/velox/experimental/cudf/functions/GpuFunctionRegistry.h
@@ -15,11 +15,13 @@
  */
 #pragma once
 
+#include <cudf/column/column.hpp>
 #include <cudf/types.hpp>
 
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -37,6 +39,27 @@ struct GpuFunctionKey {
   }
 };
 
+class GpuVectorFunction;
+
+// Mirrors Velox's VectorFunctionArg: describes one argument to a GPU function.
+// For constant arguments (e.g. pattern in LIKE, values in IN), constantValue
+// holds a cuDF column containing the constant data on device.
+// For scalar string constants (e.g. LIKE pattern), constantString stores the
+// host-side value to avoid unnecessary D-to-H transfers.
+struct GpuFunctionArg {
+  cudf::type_id type;
+  std::shared_ptr<cudf::column> constantValue;
+  std::optional<std::string> constantString;
+};
+
+// Mirrors Velox's VectorFunctionFactory: receives the function name and
+// argument descriptors (including constants) at compile time, returns a
+// GpuVectorFunction instance with constants baked in.
+using GpuStatefulFunctionFactory = std::function<
+    std::unique_ptr<GpuVectorFunction>(
+        const std::string& name,
+        const std::vector<GpuFunctionArg>& inputArgs)>;
+
 struct GpuFunctionKeyHash {
   size_t operator()(const GpuFunctionKey& key) const {
     size_t h = std::hash<std::string>{}(key.name);
@@ -50,8 +73,6 @@ struct GpuFunctionKeyHash {
   }
 };
 
-class GpuVectorFunction;
-
 using GpuFunctionFactory =
     std::function<std::unique_ptr<GpuVectorFunction>()>;
 
@@ -64,6 +85,21 @@ class GpuFunctionRegistry {
   GpuVectorFunction* resolveFunction(const GpuFunctionKey& key) const;
 
   bool hasFunction(const GpuFunctionKey& key) const;
+
+  // Stateful function support: register a factory keyed by name only.
+  // The factory receives constant argument descriptors and produces a
+  // per-expression function instance with constants baked in.
+  void registerStatefulFunction(
+      const std::string& name,
+      GpuStatefulFunctionFactory factory);
+
+  // Try to create a stateful function instance. Returns nullptr if no
+  // stateful factory is registered for the given name.
+  std::unique_ptr<GpuVectorFunction> resolveStatefulFunction(
+      const std::string& name,
+      const std::vector<GpuFunctionArg>& inputArgs) const;
+
+  bool hasStatefulFunction(const std::string& name) const;
 
   size_t size() const;
 
@@ -80,6 +116,8 @@ class GpuFunctionRegistry {
       resolved_;
   std::unordered_map<GpuFunctionKey, GpuFunctionFactory, GpuFunctionKeyHash>
       factories_;
+  std::unordered_map<std::string, GpuStatefulFunctionFactory>
+      statefulFactories_;
 };
 
 } // namespace facebook::velox::gpu

--- a/velox/experimental/cudf/functions/GpuPrestoFunctions.cu
+++ b/velox/experimental/cudf/functions/GpuPrestoFunctions.cu
@@ -249,6 +249,7 @@ void registerAllPrestoGpuFunctions() {
   registerCudfStringFunctions();
   registerCudfDateTimeFunctions();
   registerCudfHashFunctions();
+  registerCudfStatefulFunctions();
 }
 
 } // namespace facebook::velox::gpu


### PR DESCRIPTION
## Summary
- Mirrors Velox's `VectorFunctionFactory` pattern: adds `GpuStatefulFunctionFactory` that receives `GpuFunctionArg` descriptors (including constant values) at compile time and returns a `GpuVectorFunction` instance with constants baked in.
- Eliminates the need for per-function `GpuExprNodeKind` variants -- provides a scalable registration mechanism for any function with constant arguments.
- Implements `GpuInFunction`: wraps `cudf::contains` with baked-in IN-list column on device.
- Implements `GpuLikeFunction`: wraps `cudf::strings::like` with baked-in pattern string.
- Fixes datetime return type: registers `year`/`month`/`day`/etc. for INT64 return (matching Velox's BIGINT), with cast from cuDF's INT16.
- Adds constant-arg extraction in `convertExpr()` bridge with `ArrayVector` flattening support for IN-lists.

## Stack
- Part 14 of the GPU SFI stack
- Base: `gpu-sfi/13-expression-engine` (#17304)

## Test plan
- [x] All 7 integration tests pass
- [x] **22/22 TPC-H queries pass with zero CPU fallbacks**


Made with [Cursor](https://cursor.com)