### PR TITLE
feat(serializers): Add min_shuffle_compression_page_size_bytes to skip shuffle compression on small pages

### DIFF
--- a/velox/core/QueryConfig.cpp
+++ b/velox/core/QueryConfig.cpp
@@ -221,6 +221,7 @@ const std::vector<config::ConfigProperty>& QueryConfig::registeredProperties() {
 
     // Shuffle.
     VELOX_REGISTER_QUERY_CONFIG(kShuffleCompressionKind);
+    VELOX_REGISTER_QUERY_CONFIG(kMinShuffleCompressionPageSizeBytes);
 
     // Map.
     VELOX_REGISTER_QUERY_CONFIG(kThrowExceptionOnDuplicateMapKeys);

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -1296,6 +1296,15 @@ class QueryConfig {
       "none",
       "Compression codec for shuffle data.")
 
+  /// Minimum serialized page size in bytes to attempt shuffle compression.
+  VELOX_QUERY_CONFIG(
+      kMinShuffleCompressionPageSizeBytes,
+      minShuffleCompressionPageSizeBytes,
+      "min_shuffle_compression_page_size_bytes",
+      int32_t,
+      0,
+      "Minimum serialized page size in bytes to attempt shuffle compression.")
+
   /// When true, throw exception on duplicate map key.
   VELOX_QUERY_CONFIG(
       kThrowExceptionOnDuplicateMapKeys,

--- a/velox/exec/Exchange.cpp
+++ b/velox/exec/Exchange.cpp
@@ -77,7 +77,11 @@ Exchange::Exchange(
           common::stringToCompressionKind(operatorCtx_->driverCtx()
                                               ->queryConfig()
                                               .shuffleCompressionKind()),
-          serdeKind_)},
+          serdeKind_,
+          std::nullopt,
+          operatorCtx_->driverCtx()
+              ->queryConfig()
+              .minShuffleCompressionPageSizeBytes())},
       processSplits_{operatorCtx_->driverCtx()->driverId == 0},
       driverId_{driverCtx->driverId},
       exchangeClient_{std::move(exchangeClient)} {}

--- a/velox/exec/Merge.cpp
+++ b/velox/exec/Merge.cpp
@@ -784,7 +784,9 @@ MergeExchange::MergeExchange(
       serdeOptions_(getVectorSerdeOptions(
           common::stringToCompressionKind(
               driverCtx->queryConfig().shuffleCompressionKind()),
-          mergeExchangeNode->serdeKind())) {}
+          mergeExchangeNode->serdeKind(),
+          std::nullopt,
+          driverCtx->queryConfig().minShuffleCompressionPageSizeBytes())) {}
 
 BlockingReason MergeExchange::addMergeSources(ContinueFuture* future) {
   if (operatorCtx_->driverCtx()->driverId != 0) {

--- a/velox/exec/OperatorUtils.cpp
+++ b/velox/exec/OperatorUtils.cpp
@@ -586,7 +586,8 @@ std::unique_ptr<Operator> BlockedOperatorFactory::toOperator(
 std::unique_ptr<VectorSerde::Options> getVectorSerdeOptions(
     common::CompressionKind compressionKind,
     const std::string& kind,
-    std::optional<float> minCompressionRatio) {
+    std::optional<float> minCompressionRatio,
+    int32_t minCompressionPageSizeBytes) {
   std::unique_ptr<VectorSerde::Options> options = kind == "Presto"
       ? std::make_unique<serializer::presto::PrestoVectorSerde::PrestoOptions>()
       : std::make_unique<VectorSerde::Options>();
@@ -594,6 +595,7 @@ std::unique_ptr<VectorSerde::Options> getVectorSerdeOptions(
   if (minCompressionRatio.has_value()) {
     options->minCompressionRatio = minCompressionRatio.value();
   }
+  options->minCompressionPageSizeBytes = minCompressionPageSizeBytes;
   return options;
 }
 

--- a/velox/exec/OperatorUtils.h
+++ b/velox/exec/OperatorUtils.h
@@ -322,6 +322,7 @@ class BlockedOperatorFactory : public Operator::PlanNodeTranslator {
 std::unique_ptr<VectorSerde::Options> getVectorSerdeOptions(
     common::CompressionKind compressionKind,
     const std::string& kind,
-    std::optional<float> minCompressionRatio = std::nullopt);
+    std::optional<float> minCompressionRatio = std::nullopt,
+    int32_t minCompressionPageSizeBytes = 0);
 
 } // namespace facebook::velox::exec

--- a/velox/exec/PartitionedOutput.cpp
+++ b/velox/exec/PartitionedOutput.cpp
@@ -233,7 +233,10 @@ PartitionedOutput::PartitionedOutput(
                                               ->queryConfig()
                                               .shuffleCompressionKind()),
           planNode->serdeKind(),
-          PartitionedOutput::minCompressionRatio())) {
+          PartitionedOutput::minCompressionRatio(),
+          operatorCtx_->driverCtx()
+              ->queryConfig()
+              .minShuffleCompressionPageSizeBytes())) {
   if (!planNode->isPartitioned()) {
     VELOX_USER_CHECK_EQ(numDestinations_, 1);
   }

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -3125,6 +3125,63 @@ TEST_P(MultiFragmentTest, compression) {
     }
   }
 }
+
+TEST_P(MultiFragmentTest, compressionPageSizeSkip) {
+  if (GetParam().compressionKind == common::CompressionKind_NONE) {
+    GTEST_SKIP() << "Page size skip only applies with compression enabled";
+  }
+  if (GetParam().serdeKind != "Presto") {
+    GTEST_SKIP()
+        << "Page size skip only implemented in PrestoIterativeVectorSerializer";
+  }
+
+  const auto data = makeRowVector({makeFlatVector<int64_t>({1, 2, 3})});
+
+  const auto producerPlan =
+      test::PlanBuilder()
+          .values({data})
+          .partitionedOutput({}, 1, /*outputLayout=*/{}, GetParam().serdeKind)
+          .planNode();
+
+  const auto plan = test::PlanBuilder()
+                        .exchange(asRowType(data->type()), GetParam().serdeKind)
+                        .singleAggregation({}, {"sum(c0)"})
+                        .planNode();
+
+  const auto expected =
+      makeRowVector({makeFlatVector<int64_t>(std::vector<int64_t>{6})});
+
+  std::unordered_map<std::string, std::string> producerConfig;
+  producerConfig[core::QueryConfig::kShuffleCompressionKind] =
+      common::compressionKindToString(GetParam().compressionKind);
+  producerConfig[core::QueryConfig::kMinShuffleCompressionPageSizeBytes] =
+      std::to_string(1 << 30);
+
+  auto producerTask =
+      makeTask("local://pageSizeSkip", producerPlan, producerConfig);
+  producerTask->start(1);
+
+  auto consumerTask =
+      test::AssertQueryBuilder(plan)
+          .split(remoteSplit("local://pageSizeSkip"))
+          .config(
+              core::QueryConfig::kShuffleCompressionKind,
+              common::compressionKindToString(GetParam().compressionKind))
+          .destination(0)
+          .assertResults(expected);
+
+  auto producerTaskStats = exec::toPlanStats(producerTask->taskStats());
+  const auto& producerStats = producerTaskStats.at("1");
+  ASSERT_GT(
+      producerStats.customStats.count(
+          std::string(IterativeVectorSerializer::kCompressionSkippedBytes)),
+      0);
+  ASSERT_EQ(
+      producerStats.customStats.count(
+          std::string(IterativeVectorSerializer::kCompressionInputBytes)),
+      0);
+}
+
 TEST_P(MultiFragmentTest, scaledTableScan) {
   const int numSplits = 20;
   std::vector<std::shared_ptr<TempFilePath>> splitFiles;

--- a/velox/serializers/PrestoIterativeVectorSerializer.cpp
+++ b/velox/serializers/PrestoIterativeVectorSerializer.cpp
@@ -91,9 +91,17 @@ void PrestoIterativeVectorSerializer::flush(OutputStream* out) {
         opts_.minCompressionRatio,
         out);
   } else {
-    if (numCompressionToSkip_ > 0) {
-      const auto noCompressionCodec = common::compressionKindToCodec(
-          common::CompressionKind::CompressionKind_NONE);
+    // Safe to share across threads because NoCompressionCodec is stateless.
+    // Do NOT change to a different CompressionKind without removing 'static'.
+    static const auto noCompressionCodec = common::compressionKindToCodec(
+        common::CompressionKind::CompressionKind_NONE);
+    if (opts_.minCompressionPageSizeBytes > 0 &&
+        streamArena_->size() <
+            static_cast<size_t>(opts_.minCompressionPageSizeBytes)) {
+      auto [size, ignore] = flushStreams(
+          streams_, numRows_, *streamArena_, *noCompressionCodec, 1, out);
+      stats_.compressionSkippedBytes += size;
+    } else if (numCompressionToSkip_ > 0) {
       auto [size, ignore] = flushStreams(
           streams_, numRows_, *streamArena_, *noCompressionCodec, 1, out);
       stats_.compressionSkippedBytes += size;

--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -1756,6 +1756,108 @@ TEST_P(PrestoSerializerTest, checksum) {
       "Received corrupted serialized page.");
 }
 
+TEST_P(PrestoSerializerTest, minCompressionPageSizeBytes) {
+  if (GetParam() == common::CompressionKind::CompressionKind_NONE) {
+    GTEST_SKIP() << "Compression skip only applies with compression enabled";
+  }
+
+  auto rowVector = makeTestVector(10);
+  auto rowType = asRowType(rowVector->type());
+
+  auto options = getParamSerdeOptions(nullptr);
+  options.minCompressionPageSizeBytes = 1 << 30;
+
+  auto arena = std::make_unique<StreamArena>(pool_.get());
+  auto serializer = serde_->createIterativeSerializer(
+      rowType, rowVector->size(), arena.get(), &options);
+  serializer->append(rowVector);
+  facebook::velox::serializer::presto::PrestoOutputStreamListener listener;
+  std::ostringstream output;
+  OStreamOutputStream out(&output, &listener);
+  serializer->flush(&out);
+
+  auto stats = serializer->runtimeStats();
+  EXPECT_GT(stats.count("compressionSkippedBytes"), 0);
+  EXPECT_EQ(stats.count("compressionInputBytes"), 0);
+
+  auto arena2 = std::make_unique<StreamArena>(pool_.get());
+  options.minCompressionPageSizeBytes = 1;
+  auto serializer2 = serde_->createIterativeSerializer(
+      rowType, rowVector->size(), arena2.get(), &options);
+  serializer2->append(rowVector);
+  std::ostringstream output2;
+  OStreamOutputStream out2(&output2, &listener);
+  serializer2->flush(&out2);
+
+  auto stats2 = serializer2->runtimeStats();
+  EXPECT_GT(stats2.count("compressionInputBytes"), 0);
+  EXPECT_EQ(stats2.count("compressionSkippedBytes"), 0);
+}
+
+TEST_P(PrestoSerializerTest, minCompressionPageSizeBytesDisabledAtZero) {
+  if (GetParam() == common::CompressionKind::CompressionKind_NONE) {
+    GTEST_SKIP() << "Compression skip only applies with compression enabled";
+  }
+
+  auto rowVector = makeTestVector(10);
+  auto rowType = asRowType(rowVector->type());
+
+  auto options = getParamSerdeOptions(nullptr);
+  options.minCompressionPageSizeBytes = 0;
+
+  auto arena = std::make_unique<StreamArena>(pool_.get());
+  auto serializer = serde_->createIterativeSerializer(
+      rowType, rowVector->size(), arena.get(), &options);
+  serializer->append(rowVector);
+  facebook::velox::serializer::presto::PrestoOutputStreamListener listener;
+  std::ostringstream output;
+  OStreamOutputStream out(&output, &listener);
+  serializer->flush(&out);
+
+  auto stats = serializer->runtimeStats();
+  EXPECT_GT(stats.count("compressionInputBytes"), 0);
+  EXPECT_EQ(stats.count("compressionSkippedBytes"), 0);
+}
+
+TEST_P(PrestoSerializerTest, minCompressionPageSizeBytesAtBoundary) {
+  if (GetParam() == common::CompressionKind::CompressionKind_NONE) {
+    GTEST_SKIP() << "Compression skip only applies with compression enabled";
+  }
+
+  auto rowVector = makeTestVector(10);
+  auto rowType = asRowType(rowVector->type());
+  facebook::velox::serializer::presto::PrestoOutputStreamListener listener;
+
+  auto options = getParamSerdeOptions(nullptr);
+  options.minCompressionPageSizeBytes = 0;
+
+  // Measure the arena size produced by appending the row vector. Flush is
+  // unnecessary because the arena is filled by append and the size check in
+  // flush() reads the same value.
+  auto measureArena = std::make_unique<StreamArena>(pool_.get());
+  auto measureSerializer = serde_->createIterativeSerializer(
+      rowType, rowVector->size(), measureArena.get(), &options);
+  measureSerializer->append(rowVector);
+  const auto pageSize = measureArena->size();
+
+  options.minCompressionPageSizeBytes = static_cast<int32_t>(pageSize);
+  auto arena = std::make_unique<StreamArena>(pool_.get());
+  auto serializer = serde_->createIterativeSerializer(
+      rowType, rowVector->size(), arena.get(), &options);
+  serializer->append(rowVector);
+  ASSERT_EQ(arena->size(), pageSize)
+      << "Arena size after append must match measured size for the boundary "
+         "comparison to be meaningful";
+  std::ostringstream output;
+  OStreamOutputStream out(&output, &listener);
+  serializer->flush(&out);
+
+  auto stats = serializer->runtimeStats();
+  EXPECT_GT(stats.count("compressionInputBytes"), 0)
+      << "Page size exactly at threshold should attempt compression (strict <)";
+  EXPECT_EQ(stats.count("compressionSkippedBytes"), 0);
+}
+
 INSTANTIATE_TEST_SUITE_P(
     PrestoSerializerTest,
     PrestoSerializerTest,

--- a/velox/vector/VectorStream.h
+++ b/velox/vector/VectorStream.h
@@ -237,6 +237,9 @@ class VectorSerde {
     /// than this causes subsequent compression attempts to be skipped. The more
     /// times compression misses the target the less frequently it is tried.
     float minCompressionRatio{0.8};
+
+    /// Minimum page size to attempt compression.
+    int32_t minCompressionPageSizeBytes{0};
   };
 
   const std::string& kind() const {


### PR DESCRIPTION
Summary:
The minimum compression ratio is not fully expressive enough to avoid wasteful compression. For production workloads, analysis revealed that the page size distribution skews very small (P50 < 1K) such that even best case compression is not likely to reduce the number of packets transmitted over the network but does introduce additional serialization overhead and CPU consumption. As a result of this, exchange compression will tend to degrade latency even in a network bound environment.

However, if we disable compression up to some multiple of the network MTU, we can limit compression to cases where it is likely to be beneficial. There are two reasons this may benefit execution latency:

1. queries exchanging lots of data directly benefit from a reduced network transfer bottleneck
2. the noisy neighbor effect from exchange-heavy queries on well-behaved queries is reduced, since they will chew up less network bandwidth

This new option to disable page compression when the page size is below some threshold is propagated similarly to the minimum compression parameter. The new size-based skip uses arena size at flush time and is independent of the existing probe-based heuristic in PrestoIterativeVectorSerializer; it survives the PartitionedOutput flow that recreates the serializer between flushes (which resets the probe counter).

Differential Revision: D100420559


