### PR TITLE
fix: Remove fmt/format.h from ConfigProperty.h (#17311)

### DIFF
--- a/velox/common/config/ConfigProperty.cpp
+++ b/velox/common/config/ConfigProperty.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/common/config/ConfigProperty.h"
 
+#include <fmt/format.h>
 #include "velox/common/EnumDefine.h"
 
 namespace facebook::velox::config {
@@ -35,5 +36,13 @@ const auto& configPropertyTypeNames() {
 } // namespace
 
 VELOX_DEFINE_ENUM_NAME(ConfigPropertyType, configPropertyTypeNames);
+
+namespace detail {
+
+std::string toStringValue(double value) {
+  return fmt::format("{}", value);
+}
+
+} // namespace detail
 
 } // namespace facebook::velox::config

--- a/velox/common/config/ConfigProperty.h
+++ b/velox/common/config/ConfigProperty.h
@@ -17,9 +17,9 @@
 
 #include <optional>
 #include <string>
+#include <type_traits>
 #include <vector>
 
-#include <fmt/format.h>
 #include "velox/common/EnumDeclare.h"
 
 namespace facebook::velox::config {
@@ -50,6 +50,8 @@ struct ConfigProperty {
 
 namespace detail {
 
+std::string toStringValue(double value);
+
 template <typename T>
 constexpr ConfigPropertyType configPropertyTypeOf() {
   if constexpr (std::is_same_v<T, bool>) {
@@ -68,7 +70,12 @@ std::string configPropertyDefaultToString(const T& value) {
   if constexpr (std::is_same_v<T, bool>) {
     return value ? "true" : "false";
   } else if constexpr (std::is_arithmetic_v<T>) {
-    return fmt::format("{}", value);
+    if constexpr (std::is_floating_point_v<T>) {
+      return toStringValue(static_cast<double>(value));
+    } else {
+      static_assert(!std::is_same_v<T, char>, "Use int, not char.");
+      return std::to_string(value);
+    }
   } else {
     return std::string(value);
   }


### PR DESCRIPTION
Summary:

Remove the <fmt/format.h> include from ConfigProperty.h by using std::to_string for integral types directly in the template. Floating-point types dispatch to a detail::toStringValue(double) helper defined in ConfigProperty.cpp that uses fmt::format internally to preserve the existing shortest-round-trip output format. This keeps fmt as a private (non-exported) dependency.

A static_assert prevents accidental instantiation with char.


Reviewed By: mbasmanova

Differential Revision: D101575226


