### PR TITLE
feat(cudf): Add endswith expression support

### DIFF
--- a/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
@@ -1155,9 +1155,9 @@ class LikeFunction : public CudfFunction {
   std::string pattern_;
 };
 
-class BinaryStringMatchFunction : public CudfFunction {
+class StringPatternPredicateFunction : public CudfFunction {
  public:
-  explicit BinaryStringMatchFunction(
+  explicit StringPatternPredicateFunction(
       const std::shared_ptr<velox::exec::Expr>& expr,
       std::string_view functionName) {
     using velox::exec::ConstantExpr;
@@ -1216,14 +1216,14 @@ class BinaryStringMatchFunction : public CudfFunction {
             nullScalar, inputCol.size(), stream, mr);
       }
       cudf::string_scalar patternScalar(pattern_, true, stream, mr);
-      return evalWithScalar(inputCol, patternScalar, stream, mr);
+      return evaluateMatch(inputCol, patternScalar, stream, mr);
     }
 
     auto patternCol = asView(inputColumns[nextInput]);
-    auto result = evalWithColumn(inputCol, patternCol, stream, mr);
-    // Restore Spark null semantics for column/column evaluation: cuDF can
-    // return a valid false when the pattern row is null, but Spark expects the
-    // result to be null if either side is null.
+    auto result = evaluateMatch(inputCol, patternCol, stream, mr);
+    // Match Velox CPU null propagation for column/column evaluation: libcudf
+    // can return a valid false when the pattern row is null, but Velox returns
+    // null if either side is null.
     auto [nullMask, nullCount] =
         cudf::bitmask_and(cudf::table_view({inputCol, patternCol}), stream, mr);
     result->set_null_mask(std::move(nullMask), nullCount);
@@ -1231,13 +1231,13 @@ class BinaryStringMatchFunction : public CudfFunction {
   }
 
  protected:
-  virtual std::unique_ptr<cudf::column> evalWithScalar(
+  virtual std::unique_ptr<cudf::column> evaluateMatch(
       cudf::column_view inputCol,
       cudf::string_scalar const& patternScalar,
       rmm::cuda_stream_view stream,
       rmm::device_async_resource_ref mr) const = 0;
 
-  virtual std::unique_ptr<cudf::column> evalWithColumn(
+  virtual std::unique_ptr<cudf::column> evaluateMatch(
       cudf::column_view inputCol,
       cudf::column_view patternCol,
       rmm::cuda_stream_view stream,
@@ -1251,13 +1251,13 @@ class BinaryStringMatchFunction : public CudfFunction {
   std::string pattern_;
 };
 
-class StartswithFunction : public BinaryStringMatchFunction {
+class StartswithFunction : public StringPatternPredicateFunction {
  public:
   explicit StartswithFunction(const std::shared_ptr<velox::exec::Expr>& expr)
-      : BinaryStringMatchFunction(expr, "startswith") {}
+      : StringPatternPredicateFunction(expr, "startswith") {}
 
  protected:
-  std::unique_ptr<cudf::column> evalWithScalar(
+  std::unique_ptr<cudf::column> evaluateMatch(
       cudf::column_view inputCol,
       cudf::string_scalar const& patternScalar,
       rmm::cuda_stream_view stream,
@@ -1265,7 +1265,7 @@ class StartswithFunction : public BinaryStringMatchFunction {
     return cudf::strings::starts_with(inputCol, patternScalar, stream, mr);
   }
 
-  std::unique_ptr<cudf::column> evalWithColumn(
+  std::unique_ptr<cudf::column> evaluateMatch(
       cudf::column_view inputCol,
       cudf::column_view patternCol,
       rmm::cuda_stream_view stream,
@@ -1274,13 +1274,13 @@ class StartswithFunction : public BinaryStringMatchFunction {
   }
 };
 
-class EndswithFunction : public BinaryStringMatchFunction {
+class EndswithFunction : public StringPatternPredicateFunction {
  public:
   explicit EndswithFunction(const std::shared_ptr<velox::exec::Expr>& expr)
-      : BinaryStringMatchFunction(expr, "endswith") {}
+      : StringPatternPredicateFunction(expr, "endswith") {}
 
  protected:
-  std::unique_ptr<cudf::column> evalWithScalar(
+  std::unique_ptr<cudf::column> evaluateMatch(
       cudf::column_view inputCol,
       cudf::string_scalar const& patternScalar,
       rmm::cuda_stream_view stream,
@@ -1288,7 +1288,7 @@ class EndswithFunction : public BinaryStringMatchFunction {
     return cudf::strings::ends_with(inputCol, patternScalar, stream, mr);
   }
 
-  std::unique_ptr<cudf::column> evalWithColumn(
+  std::unique_ptr<cudf::column> evaluateMatch(
       cudf::column_view inputCol,
       cudf::column_view patternCol,
       rmm::cuda_stream_view stream,

--- a/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
@@ -1155,11 +1155,14 @@ class LikeFunction : public CudfFunction {
   std::string pattern_;
 };
 
-class StartswithFunction : public CudfFunction {
+class BinaryStringMatchFunction : public CudfFunction {
  public:
-  explicit StartswithFunction(const std::shared_ptr<velox::exec::Expr>& expr) {
+  explicit BinaryStringMatchFunction(
+      const std::shared_ptr<velox::exec::Expr>& expr,
+      std::string_view functionName) {
     using velox::exec::ConstantExpr;
-    VELOX_CHECK_EQ(expr->inputs().size(), 2, "startswith expects 2 inputs");
+    VELOX_CHECK_EQ(
+        expr->inputs().size(), 2, "{} expects 2 inputs", functionName);
 
     if (auto inputExpr =
             std::dynamic_pointer_cast<ConstantExpr>(expr->inputs()[0])) {
@@ -1179,11 +1182,12 @@ class StartswithFunction : public CudfFunction {
       }
     }
 
-    // Fully constant startswith stays off the cuDF path because the function
+    // Fully constant string-match calls stay off the cuDF path because the
     // evaluator has no input column to derive the output row count from.
     VELOX_CHECK(
         !(inputIsConstant_ && patternIsConstant_),
-        "startswith with two constant inputs is not supported by the cuDF evaluator");
+        "{} with two constant inputs is not supported by the cuDF evaluator",
+        functionName);
   }
 
   ColumnOrView eval(
@@ -1212,18 +1216,33 @@ class StartswithFunction : public CudfFunction {
             nullScalar, inputCol.size(), stream, mr);
       }
       cudf::string_scalar patternScalar(pattern_, true, stream, mr);
-      return cudf::strings::starts_with(inputCol, patternScalar, stream, mr);
+      return evalWithScalar(inputCol, patternScalar, stream, mr);
     }
 
     auto patternCol = asView(inputColumns[nextInput]);
-    auto result = cudf::strings::starts_with(inputCol, patternCol, stream, mr);
+    auto result = evalWithColumn(inputCol, patternCol, stream, mr);
+    // Restore Spark null semantics for column/column evaluation: cuDF can
+    // return a valid false when the pattern row is null, but Spark expects the
+    // result to be null if either side is null.
     auto [nullMask, nullCount] =
         cudf::bitmask_and(cudf::table_view({inputCol, patternCol}), stream, mr);
     result->set_null_mask(std::move(nullMask), nullCount);
     return result;
   }
 
- private:
+ protected:
+  virtual std::unique_ptr<cudf::column> evalWithScalar(
+      cudf::column_view inputCol,
+      cudf::string_scalar const& patternScalar,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) const = 0;
+
+  virtual std::unique_ptr<cudf::column> evalWithColumn(
+      cudf::column_view inputCol,
+      cudf::column_view patternCol,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) const = 0;
+
   bool inputIsConstant_{false};
   bool inputIsNull_{false};
   bool patternIsNull_{false};
@@ -1232,29 +1251,50 @@ class StartswithFunction : public CudfFunction {
   std::string pattern_;
 };
 
-class EndswithFunction : public CudfFunction {
+class StartswithFunction : public BinaryStringMatchFunction {
  public:
-  explicit EndswithFunction(const std::shared_ptr<velox::exec::Expr>& expr) {
-    using velox::exec::ConstantExpr;
-    VELOX_CHECK_EQ(expr->inputs().size(), 2, "endswith expects 2 inputs");
+  explicit StartswithFunction(const std::shared_ptr<velox::exec::Expr>& expr)
+      : BinaryStringMatchFunction(expr, "startswith") {}
 
-    auto patternExpr =
-        std::dynamic_pointer_cast<ConstantExpr>(expr->inputs()[1]);
-    VELOX_CHECK_NOT_NULL(patternExpr, "endswith pattern must be a constant");
-    pattern_ = patternExpr->value()->toString(0);
-  }
-
-  ColumnOrView eval(
-      std::vector<ColumnOrView>& inputColumns,
+ protected:
+  std::unique_ptr<cudf::column> evalWithScalar(
+      cudf::column_view inputCol,
+      cudf::string_scalar const& patternScalar,
       rmm::cuda_stream_view stream,
       rmm::device_async_resource_ref mr) const override {
-    auto inputCol = asView(inputColumns[0]);
-    cudf::string_scalar patternScalar(pattern_, true, stream, mr);
+    return cudf::strings::starts_with(inputCol, patternScalar, stream, mr);
+  }
+
+  std::unique_ptr<cudf::column> evalWithColumn(
+      cudf::column_view inputCol,
+      cudf::column_view patternCol,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) const override {
+    return cudf::strings::starts_with(inputCol, patternCol, stream, mr);
+  }
+};
+
+class EndswithFunction : public BinaryStringMatchFunction {
+ public:
+  explicit EndswithFunction(const std::shared_ptr<velox::exec::Expr>& expr)
+      : BinaryStringMatchFunction(expr, "endswith") {}
+
+ protected:
+  std::unique_ptr<cudf::column> evalWithScalar(
+      cudf::column_view inputCol,
+      cudf::string_scalar const& patternScalar,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) const override {
     return cudf::strings::ends_with(inputCol, patternScalar, stream, mr);
   }
 
- private:
-  std::string pattern_;
+  std::unique_ptr<cudf::column> evalWithColumn(
+      cudf::column_view inputCol,
+      cudf::column_view patternCol,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) const override {
+    return cudf::strings::ends_with(inputCol, patternCol, stream, mr);
+  }
 };
 
 class ContainsFunction : public CudfFunction {
@@ -1566,6 +1606,17 @@ bool registerBuiltinFunctions(const std::string& prefix) {
       prefix + "startswith",
       [](const std::string&, const std::shared_ptr<velox::exec::Expr>& expr) {
         return std::make_shared<StartswithFunction>(expr);
+      },
+      {FunctionSignatureBuilder()
+           .returnType("boolean")
+           .argumentType("varchar")
+           .argumentType("varchar")
+           .build()});
+
+  registerCudfFunction(
+      prefix + "endswith",
+      [](const std::string&, const std::shared_ptr<velox::exec::Expr>& expr) {
+        return std::make_shared<EndswithFunction>(expr);
       },
       {FunctionSignatureBuilder()
            .returnType("boolean")

--- a/velox/experimental/cudf/tests/ExpressionEvaluatorSelectionTest.cpp
+++ b/velox/experimental/cudf/tests/ExpressionEvaluatorSelectionTest.cpp
@@ -189,8 +189,7 @@ TEST_F(CudfExpressionSelectionTest, signatureAllowsColumnArgsStartswith) {
 
 TEST_F(CudfExpressionSelectionTest, signatureAllowsColumnArgsEndswith) {
   // OK: pattern is a constant
-  auto ok =
-      compileExecExpr("endswith(name, 'ab')", rowType_, execCtx_.get());
+  auto ok = compileExecExpr("endswith(name, 'ab')", rowType_, execCtx_.get());
   ASSERT_TRUE(canBeEvaluatedByCudf(ok, /*deep=*/true));
 
   // OK: the input can also be a constant.

--- a/velox/experimental/cudf/tests/ExpressionEvaluatorSelectionTest.cpp
+++ b/velox/experimental/cudf/tests/ExpressionEvaluatorSelectionTest.cpp
@@ -187,6 +187,28 @@ TEST_F(CudfExpressionSelectionTest, signatureAllowsColumnArgsStartswith) {
   ASSERT_TRUE(canBeEvaluatedByCudf(okColumn, /*deep=*/true));
 }
 
+TEST_F(CudfExpressionSelectionTest, signatureAllowsColumnArgsEndswith) {
+  // OK: pattern is a constant
+  auto ok =
+      compileExecExpr("endswith(name, 'ab')", rowType_, execCtx_.get());
+  ASSERT_TRUE(canBeEvaluatedByCudf(ok, /*deep=*/true));
+
+  // OK: the input can also be a constant.
+  auto okConstantInput =
+      compileExecExpr("endswith('ab', name)", rowType_, execCtx_.get());
+  ASSERT_TRUE(canBeEvaluatedByCudf(okConstantInput, /*deep=*/true));
+
+  // OK: null pattern is still a constant and should remain on the cuDF path.
+  auto okNull = compileExecExpr(
+      "endswith(name, cast(null as varchar))", rowType_, execCtx_.get());
+  ASSERT_TRUE(canBeEvaluatedByCudf(okNull, /*deep=*/true));
+
+  // OK: pattern can also come from a column.
+  auto okColumn =
+      compileExecExpr("endswith(name, name)", rowType_, execCtx_.get());
+  ASSERT_TRUE(canBeEvaluatedByCudf(okColumn, /*deep=*/true));
+}
+
 TEST_F(CudfExpressionSelectionTest, signatureArityAndConstantsSubstr) {
   // OK: 2-arg substr with constant start
   auto ok2 = compileExecExpr("substr(name, 1)", rowType_, execCtx_.get());

--- a/velox/experimental/cudf/tests/sparksql/FilterProjectTest.cpp
+++ b/velox/experimental/cudf/tests/sparksql/FilterProjectTest.cpp
@@ -197,8 +197,7 @@ TEST_F(CudfFilterProjectTest, startswithColumnPattern) {
       makeNullableFlatVector<bool>(
           {true, false, std::nullopt, std::nullopt, true, false, false}),
   });
-  auto result = AssertQueryBuilder(plan).copyResults(pool());
-  facebook::velox::test::assertEqualVectors(expected, result);
+  AssertQueryBuilder(plan).assertResults(expected);
 }
 
 TEST_F(CudfFilterProjectTest, startswithConstantInput) {
@@ -212,6 +211,23 @@ TEST_F(CudfFilterProjectTest, startswithConstantInput) {
   auto result = evaluate(exprSet, data);
   auto expected =
       makeNullableFlatVector<bool>({true, true, std::nullopt, true, false});
+  facebook::velox::test::assertEqualVectors(expected, result);
+}
+
+TEST_F(CudfFilterProjectTest, startswithConstantNullInput) {
+  auto pattern =
+      makeNullableFlatVector<std::string>({"a", "ab", std::nullopt, "", "abc"});
+  auto data = makeRowVector({pattern});
+  auto typed = test_utils::parseAndInferTypedExpr(
+      "startswith(cast(null as varchar), c0)",
+      data->rowType(),
+      &execCtx_,
+      options_);
+  exec::ExprSet exprSet({typed}, &execCtx_, /*enableConstantFolding*/ false);
+
+  auto result = evaluate(exprSet, data);
+  auto expected = makeNullableFlatVector<bool>(
+      {std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt});
   facebook::velox::test::assertEqualVectors(expected, result);
 }
 
@@ -242,6 +258,150 @@ TEST_F(CudfFilterProjectTest, startswithColumnPatternNullPattern) {
                   .planNode();
 
   auto expected = makeRowVector({makeNullableFlatVector<bool>({std::nullopt})});
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+TEST_F(CudfFilterProjectTest, endswith) {
+  auto input = makeNullableFlatVector<std::string>(
+      {"abc", "zabc", std::nullopt, "ab", "", "xyz", "abz"});
+  auto data = makeRowVector({input});
+
+  auto plan = PlanBuilder()
+                  .setParseOptions(options_)
+                  .values({data})
+                  .project({"endswith(c0, 'ab') AS c1"})
+                  .planNode();
+
+  auto expected = makeRowVector({
+      makeNullableFlatVector<bool>(
+          {false, false, std::nullopt, true, false, false, false}),
+  });
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+TEST_F(CudfFilterProjectTest, endswithNullPattern) {
+  auto input = makeNullableFlatVector<std::string>(
+      {"abc", "zabc", std::nullopt, "ab", "", "xyz", "abz"});
+  auto data = makeRowVector({input});
+
+  auto plan = PlanBuilder()
+                  .setParseOptions(options_)
+                  .values({data})
+                  .project({"endswith(c0, cast(null as varchar)) AS c1"})
+                  .planNode();
+
+  auto expected = makeRowVector({
+      makeNullableFlatVector<bool>({
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+      }),
+  });
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+TEST_F(CudfFilterProjectTest, endswithEmptyPattern) {
+  auto input = makeNullableFlatVector<std::string>(
+      {"abc", "zabc", std::nullopt, "ab", "", "xyz", "abz"});
+  auto data = makeRowVector({input});
+
+  auto plan = PlanBuilder()
+                  .setParseOptions(options_)
+                  .values({data})
+                  .project({"endswith(c0, '') AS c1"})
+                  .planNode();
+
+  auto expected = makeRowVector({
+      makeNullableFlatVector<bool>(
+          {true, true, std::nullopt, true, true, true, true}),
+  });
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+TEST_F(CudfFilterProjectTest, endswithColumnPattern) {
+  auto input = makeNullableFlatVector<std::string>(
+      {"abc", "zabc", std::nullopt, "ab", "", "xyz", "abz"});
+  auto pattern = makeNullableFlatVector<std::string>(
+      {"bc", "bc", "bc", std::nullopt, "", "yz", "zz"});
+  auto data = makeRowVector({input, pattern});
+
+  auto plan = PlanBuilder()
+                  .setParseOptions(options_)
+                  .values({data})
+                  .project({"endswith(c0, c1) AS c2"})
+                  .planNode();
+
+  auto expected = makeRowVector({
+      makeNullableFlatVector<bool>(
+          {true, true, std::nullopt, std::nullopt, true, true, false}),
+  });
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+TEST_F(CudfFilterProjectTest, endswithConstantInput) {
+  auto pattern =
+      makeNullableFlatVector<std::string>({"b", "ab", std::nullopt, "", "abc"});
+  auto data = makeRowVector({pattern});
+  auto typed = test_utils::parseAndInferTypedExpr(
+      "endswith('ab', c0)", data->rowType(), &execCtx_, options_);
+  exec::ExprSet exprSet({typed}, &execCtx_, /*enableConstantFolding*/ false);
+
+  auto result = evaluate(exprSet, data);
+  auto expected = makeNullableFlatVector<bool>(
+      {true, true, std::nullopt, true, false});
+  facebook::velox::test::assertEqualVectors(expected, result);
+}
+
+TEST_F(CudfFilterProjectTest, endswithConstantNullInput) {
+  auto pattern =
+      makeNullableFlatVector<std::string>({"b", "ab", std::nullopt, "", "abc"});
+  auto data = makeRowVector({pattern});
+  auto typed = test_utils::parseAndInferTypedExpr(
+      "endswith(cast(null as varchar), c0)",
+      data->rowType(),
+      &execCtx_,
+      options_);
+  exec::ExprSet exprSet({typed}, &execCtx_, /*enableConstantFolding*/ false);
+
+  auto result = evaluate(exprSet, data);
+  auto expected = makeNullableFlatVector<bool>(
+      {std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt});
+  facebook::velox::test::assertEqualVectors(expected, result);
+}
+
+TEST_F(CudfFilterProjectTest, endswithColumnPatternNullInput) {
+  auto input = makeNullableFlatVector<std::string>({std::nullopt});
+  auto pattern = makeNullableFlatVector<std::string>({"ab"});
+  auto data = makeRowVector({input, pattern});
+
+  auto plan = PlanBuilder()
+                  .setParseOptions(options_)
+                  .values({data})
+                  .project({"endswith(c0, c1) AS c2"})
+                  .planNode();
+
+  auto expected =
+      makeRowVector({makeNullableFlatVector<bool>({std::nullopt})});
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+TEST_F(CudfFilterProjectTest, endswithColumnPatternNullPattern) {
+  auto input = makeNullableFlatVector<std::string>({"ab"});
+  auto pattern = makeNullableFlatVector<std::string>({std::nullopt});
+  auto data = makeRowVector({input, pattern});
+
+  auto plan = PlanBuilder()
+                  .setParseOptions(options_)
+                  .values({data})
+                  .project({"endswith(c0, c1) AS c2"})
+                  .planNode();
+
+  auto expected =
+      makeRowVector({makeNullableFlatVector<bool>({std::nullopt})});
   AssertQueryBuilder(plan).assertResults(expected);
 }
 

--- a/velox/experimental/cudf/tests/sparksql/FilterProjectTest.cpp
+++ b/velox/experimental/cudf/tests/sparksql/FilterProjectTest.cpp
@@ -351,8 +351,8 @@ TEST_F(CudfFilterProjectTest, endswithConstantInput) {
   exec::ExprSet exprSet({typed}, &execCtx_, /*enableConstantFolding*/ false);
 
   auto result = evaluate(exprSet, data);
-  auto expected = makeNullableFlatVector<bool>(
-      {true, true, std::nullopt, true, false});
+  auto expected =
+      makeNullableFlatVector<bool>({true, true, std::nullopt, true, false});
   facebook::velox::test::assertEqualVectors(expected, result);
 }
 
@@ -384,8 +384,7 @@ TEST_F(CudfFilterProjectTest, endswithColumnPatternNullInput) {
                   .project({"endswith(c0, c1) AS c2"})
                   .planNode();
 
-  auto expected =
-      makeRowVector({makeNullableFlatVector<bool>({std::nullopt})});
+  auto expected = makeRowVector({makeNullableFlatVector<bool>({std::nullopt})});
   AssertQueryBuilder(plan).assertResults(expected);
 }
 
@@ -400,8 +399,7 @@ TEST_F(CudfFilterProjectTest, endswithColumnPatternNullPattern) {
                   .project({"endswith(c0, c1) AS c2"})
                   .planNode();
 
-  auto expected =
-      makeRowVector({makeNullableFlatVector<bool>({std::nullopt})});
+  auto expected = makeRowVector({makeNullableFlatVector<bool>({std::nullopt})});
   AssertQueryBuilder(plan).assertResults(expected);
 }
 


### PR DESCRIPTION
## Summary
- refactor cuDF string pattern predicate evaluation so `startswith` and `endswith` share constant and column handling with Velox CPU null propagation
- register `endswith` in the cuDF evaluator and add GPU selection coverage for the supported expression shapes
- add focused `endswith` coverage for constant-input, column-pattern, and null-handling cases

## Test plan
- [x] clean build in `gluten_cudf_build`
- [x] run focused expression selection tests for `startswith` and `endswith`
- [x] run focused filter/project tests for `startswith` and `endswith`