### PR TITLE
fix(build): Replace undefined target velox_enums

### DIFF
--- a/velox/common/config/CMakeLists.txt
+++ b/velox/common/config/CMakeLists.txt
@@ -26,4 +26,7 @@ velox_add_library(
   ConfigProperty.h
   ConfigProvider.h
 )
-velox_link_libraries(velox_config_property PUBLIC velox_enums velox_exception)
+velox_link_libraries(
+  velox_config_property
+  PUBLIC velox_enum_declare velox_enum_define velox_exception
+)


### PR DESCRIPTION
PR #17239 split velox_enums into two targets.
But it missed to update the velox_config_property target that still used the previous velox_enums target.  velox_enums is, however, now undefined.

Because the CI builds the mono library this change was missed. However, if you are building without the mono library a build error occurs due to the target being undefined (missing library) , e.g. when building Prestissimo.