### PR TITLE
feat: Fold DATE, ROW, and struct constants in DuckDB parser (#17318)

### DIFF
--- a/velox/duckdb/conversion/DuckParser.cpp
+++ b/velox/duckdb/conversion/DuckParser.cpp
@@ -269,6 +269,55 @@ std::shared_ptr<const core::ConstantExpr> tryParseInterval(
       INTERVAL_DAY_TIME(), Variant(value.value() * multiplier), alias);
 }
 
+// DuckDB parses struct literals {'x': 1, 'y': 2} as struct_pack(1 AS x, 2 AS
+// y) and ROW(1, 2) as row(1, 2). Folds into a ROW constant when all arguments
+// are constants. Returns nullptr otherwise.
+core::ExprPtr tryFoldRowConstant(
+    const std::vector<core::ExprPtr>& inputs,
+    const std::optional<std::string>& alias) {
+  std::vector<std::string> names;
+  std::vector<TypePtr> types;
+  std::vector<Variant> values;
+  names.reserve(inputs.size());
+  types.reserve(inputs.size());
+  values.reserve(inputs.size());
+  for (const auto& input : inputs) {
+    auto* constant = input->as<core::ConstantExpr>();
+    if (!constant) {
+      return nullptr;
+    }
+    names.push_back(constant->alias().value_or(""));
+    types.push_back(constant->type());
+    values.push_back(constant->value());
+  }
+  return std::make_shared<const core::ConstantExpr>(
+      ROW(std::move(names), std::move(types)),
+      Variant::row(std::move(values)),
+      alias);
+}
+
+// DuckDB parses [1, 2, 3] as list_value(1, 2, 3). Folds into an ARRAY constant
+// when all arguments are constants. Returns nullptr otherwise.
+core::ExprPtr tryFoldArrayConstant(
+    const std::vector<core::ExprPtr>& inputs,
+    const std::optional<std::string>& alias) {
+  std::vector<Variant> elements;
+  elements.reserve(inputs.size());
+  TypePtr elementType = UNKNOWN();
+  for (const auto& input : inputs) {
+    auto* constant = input->as<core::ConstantExpr>();
+    if (!constant) {
+      return nullptr;
+    }
+    elements.push_back(constant->value());
+    if (!constant->value().isNull()) {
+      elementType = constant->type();
+    }
+  }
+  return std::make_shared<const core::ConstantExpr>(
+      ARRAY(elementType), Variant::array(std::move(elements)), alias);
+}
+
 // Parse a function call (avg(a), func(1, b), etc).
 // Arithmetic operators also follow this path (a + b, a * b, etc).
 core::ExprPtr parseFunctionExpr(
@@ -286,6 +335,20 @@ core::ExprPtr parseFunctionExpr(
   if (params.size() == 1) {
     if (auto interval = tryParseInterval(func, params[0], getAlias(expr))) {
       return interval;
+    }
+  }
+
+  if (func == "struct_pack" || func == "row") {
+    if (auto rowConstant = tryFoldRowConstant(params, getAlias(expr))) {
+      return rowConstant;
+    }
+  }
+
+  // DuckDB parses [1, 2, 3] as list_value(1, 2, 3). Fold into an ARRAY
+  // constant when all arguments are constants.
+  if (func == "list_value") {
+    if (auto arrayConstant = tryFoldArrayConstant(params, getAlias(expr))) {
+      return arrayConstant;
     }
   }
 
@@ -391,6 +454,10 @@ core::ExprPtr parseOperatorExpr(
         if (auto constantExpr =
                 dynamic_cast<ConstantExpression*>(child.get())) {
           auto& value = constantExpr->value;
+          if (value.type().id() == LogicalTypeId::INTEGER &&
+              options.parseIntegerAsBigint) {
+            value = Value::BIGINT(value.GetValue<int32_t>());
+          }
           if (options.parseDecimalAsDouble &&
               value.type().id() == duckdb::LogicalTypeId::DECIMAL) {
             value = Value::DOUBLE(value.GetValue<double>());
@@ -606,6 +673,23 @@ core::ExprPtr parseCastExpr(
             Variant::create<TypeKind::BOOLEAN>(false),
             getAlias(expr));
       }
+    }
+
+    // DuckDB parses DATE '...' and '...'::date as cast(varchar as DATE).
+    // Fold into a DATE constant.
+    if (targetType->isDate() && constant->type()->isVarchar()) {
+      const auto& value = constant->value().value<TypeKind::VARCHAR>();
+      return std::make_shared<const core::ConstantExpr>(
+          DATE(),
+          Variant::create<TypeKind::INTEGER>(DATE()->toDays(value)),
+          getAlias(expr));
+    }
+
+    // ROW(1, 2)::struct(x bigint, y bigint) — re-type the ROW constant with
+    // the target type (which carries field names). Child types must match.
+    if (targetType->isRow() && targetType->equivalent(*constant->type())) {
+      return std::make_shared<const core::ConstantExpr>(
+          targetType, constant->value(), getAlias(expr));
     }
   }
 

--- a/velox/duckdb/conversion/tests/DuckParserTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckParserTest.cpp
@@ -764,3 +764,128 @@ TEST(DuckParserTest, lambda) {
       parseExpr("filter(a, if (b > 0, x -> (x = 10), x -> (x = 20)))")
           ->toString());
 }
+
+TEST(DuckParserTest, arrayLiteral) {
+  {
+    auto expr = parseExpr("ARRAY[1, 2, 3]");
+    EXPECT_TRUE(expr->is(core::IExpr::Kind::kConstant));
+    VELOX_EXPECT_EQ_TYPES(
+        expr->as<core::ConstantExpr>()->type(), ARRAY(BIGINT()));
+    EXPECT_EQ("{1, 2, 3}", expr->toString());
+  }
+
+  {
+    auto expr = parseExpr("[1, 2, 3]");
+    EXPECT_TRUE(expr->is(core::IExpr::Kind::kConstant));
+    VELOX_EXPECT_EQ_TYPES(
+        expr->as<core::ConstantExpr>()->type(), ARRAY(BIGINT()));
+    EXPECT_EQ("{1, 2, 3}", expr->toString());
+  }
+
+  // Array with null elements.
+  {
+    auto expr = parseExpr("[1, null, 3]");
+    EXPECT_TRUE(expr->is(core::IExpr::Kind::kConstant));
+    VELOX_EXPECT_EQ_TYPES(
+        expr->as<core::ConstantExpr>()->type(), ARRAY(BIGINT()));
+    EXPECT_EQ("{1, null, 3}", expr->toString());
+  }
+
+  // All-null array.
+  {
+    auto expr = parseExpr("[null, null]");
+    EXPECT_TRUE(expr->is(core::IExpr::Kind::kConstant));
+    VELOX_EXPECT_EQ_TYPES(
+        expr->as<core::ConstantExpr>()->type(), ARRAY(UNKNOWN()));
+    EXPECT_EQ("{null, null}", expr->toString());
+  }
+
+  // Empty array.
+  {
+    auto expr = parseExpr("[]");
+    EXPECT_TRUE(expr->is(core::IExpr::Kind::kConstant));
+    VELOX_EXPECT_EQ_TYPES(
+        expr->as<core::ConstantExpr>()->type(), ARRAY(UNKNOWN()));
+    EXPECT_EQ("<empty>", expr->toString());
+  }
+
+  // Nested array.
+  {
+    auto expr = parseExpr("[[1, 2], [3, 4]]");
+    EXPECT_TRUE(expr->is(core::IExpr::Kind::kConstant));
+    VELOX_EXPECT_EQ_TYPES(
+        expr->as<core::ConstantExpr>()->type(), ARRAY(ARRAY(BIGINT())));
+    EXPECT_EQ("{{1, 2}, {3, 4}}", expr->toString());
+  }
+
+  // Non-constant argument stays a function call.
+  {
+    auto expr = parseExpr("[a, 1, 2]");
+    EXPECT_TRUE(expr->is(core::IExpr::Kind::kCall));
+    EXPECT_EQ("list_value(\"a\",1,2)", expr->toString());
+  }
+}
+
+TEST(DuckParserTest, structLiteral) {
+  // {'x': 1, 'y': 2} becomes a ROW constant with named fields.
+  {
+    auto expr = parseExpr("{'x': 1, 'y': 2}");
+    EXPECT_TRUE(expr->is(core::IExpr::Kind::kConstant));
+    VELOX_EXPECT_EQ_TYPES(
+        expr->as<core::ConstantExpr>()->type(),
+        ROW({"x", "y"}, {BIGINT(), BIGINT()}));
+    EXPECT_EQ("{1, 2}", expr->toString());
+  }
+
+  // ROW(1, 2) becomes a ROW constant with unnamed fields.
+  {
+    auto expr = parseExpr("ROW(1, 2)");
+    EXPECT_TRUE(expr->is(core::IExpr::Kind::kConstant));
+    VELOX_EXPECT_EQ_TYPES(
+        expr->as<core::ConstantExpr>()->type(), ROW({"", ""}, BIGINT()));
+    EXPECT_EQ("{1, 2}", expr->toString());
+  }
+
+  // ROW(a, 2) with a non-constant argument stays a function call.
+  {
+    auto expr = parseExpr("ROW(a, 2)");
+    EXPECT_TRUE(expr->is(core::IExpr::Kind::kCall));
+    EXPECT_EQ("row(\"a\",2)", expr->toString());
+  }
+
+  // ROW(1, 2)::struct(x bigint, y bigint) becomes a named ROW constant.
+  {
+    auto expr = parseExpr("ROW(1, 2)::struct(x bigint, y bigint)");
+    EXPECT_TRUE(expr->is(core::IExpr::Kind::kConstant));
+    VELOX_EXPECT_EQ_TYPES(
+        expr->as<core::ConstantExpr>()->type(), ROW({"x", "y"}, BIGINT()));
+    EXPECT_EQ("{1, 2}", expr->toString());
+  }
+
+  // ROW(1, 2)::struct(x varchar, y bigint) with mismatched child types stays a
+  // cast.
+  {
+    auto expr = parseExpr("ROW(1, 2)::struct(x varchar, y bigint)");
+    EXPECT_TRUE(expr->is(core::IExpr::Kind::kCast));
+    EXPECT_EQ("cast({1, 2} as ROW<x:VARCHAR,y:BIGINT>)", expr->toString());
+  }
+}
+
+TEST(DuckParserTest, dateLiteral) {
+  for (const auto& sql : {"'1994-01-01'::date", "DATE '1994-01-01'"}) {
+    SCOPED_TRACE(sql);
+    auto expr = parseExpr(sql);
+    EXPECT_TRUE(expr->is(core::IExpr::Kind::kConstant));
+
+    auto* constant = expr->as<core::ConstantExpr>();
+    EXPECT_EQ(*constant->type(), *DATE());
+    EXPECT_EQ(constant->value().value<int32_t>(), DATE()->toDays("1994-01-01"));
+
+    EXPECT_EQ("1994-01-01", expr->toString());
+  }
+
+  // Invalid date string.
+  VELOX_ASSERT_THROW(
+      parseExpr("DATE 'not-a-date'"),
+      "Unable to parse date value: \"not-a-date\"");
+}

--- a/velox/exec/tests/ExpandTest.cpp
+++ b/velox/exec/tests/ExpandTest.cpp
@@ -41,10 +41,10 @@ TEST_F(ExpandTest, complexConstant) {
   auto data = makeRowVectorData(3);
   auto children = data->children();
   auto arrayVector =
-      makeArrayVector<int32_t>({{1, 2, 3}, {1, 2, 3}, {1, 2, 3}});
+      makeArrayVector<int64_t>({{1, 2, 3}, {1, 2, 3}, {1, 2, 3}});
   children.push_back(arrayVector);
-  children.push_back(makeAllNullArrayVector(3, INTEGER()));
-  children.push_back(makeNullConstant(TypeKind::INTEGER, 3));
+  children.push_back(makeAllNullArrayVector(3, BIGINT()));
+  children.push_back(makeNullConstant(TypeKind::BIGINT, 3));
   auto expected = makeRowVector(children);
 
   auto plan = PlanBuilder(pool())
@@ -55,8 +55,8 @@ TEST_F(ExpandTest, complexConstant) {
                         "a",
                         "b",
                         "ARRAY[1, 2, 3] as c",
-                        "null::integer[] as d",
-                        "null::integer as e"}})
+                        "null::bigint[] as d",
+                        "null::bigint as e"}})
                   .planNode();
 
   assertQuery(plan, expected);

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -4099,7 +4099,7 @@ TEST_P(ParameterizedExprTest, cseUnderTryWithIf) {
   // errors when combined with TRY. In this case a VectorFunction sizes the
   // result based on rows.end(), can throw user exceptions, and doesn't resize
   // the result Vector to include rows that produced exceptions. If that
-  // funciton is evaluated as part of CSE, e.g. on both sides of an if
+  // function is evaluated as part of CSE, e.g. on both sides of an if
   // statement, and the last row produces an exception, the result Vector will
   // be smaller than rows.size(). This test validates that in CSE we can
   // tolerate this and does not rely on the fact the result Vector is at least
@@ -5321,9 +5321,8 @@ TEST_F(ExprTest, evaluateConstantExpression) {
       makeArrayVectorFromJson<int64_t>({"[2, 2, 2]"}));
 
   assertEqualVectors(
-      eval(
-          "try(coalesce(array_min_by(array[1, 2, 3], x -> x / 0), 0::INTEGER))"),
-      makeNullConstant(TypeKind::INTEGER, 1));
+      eval("try(coalesce(array_min_by(array[1, 2, 3], x -> x / 0), 0))"),
+      makeNullConstant(TypeKind::BIGINT, 1));
 
   // Verify that constant folding takes into account query config.
   setQueryTimeZone("America/Los_Angeles");
@@ -5342,7 +5341,9 @@ TEST_F(ExprTest, evaluateConstantExpression) {
 
   EXPECT_TRUE(eval("transform(array[1, 2, 3], x -> (x * 2) + a)") == nullptr);
 
-  EXPECT_TRUE(eval("transform(array[1, 2, 3], x -> x + rand())") == nullptr);
+  EXPECT_TRUE(
+      eval("transform(array[1, 2, 3], x -> cast(x as double) + rand())") ==
+      nullptr);
 
   VELOX_ASSERT_THROW(eval("5 / 0"), "division by zero");
   EXPECT_TRUE(evalNoThrow("5 / 0") == nullptr);

--- a/velox/functions/prestosql/tests/ArrayExceptTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayExceptTest.cpp
@@ -346,20 +346,20 @@ TEST_F(ArrayExceptTest, complexTypeRow) {
 
 // When one of the arrays is constant.
 TEST_F(ArrayExceptTest, constant) {
-  auto array1 = makeNullableArrayVector<int32_t>({
+  auto array1 = makeNullableArrayVector<int64_t>({
       {1, -2, 3, std::nullopt, 4, 5, 6, std::nullopt},
       {1, 2, -2, 1},
       {3, 8, std::nullopt},
       {1, 1, -2, -2, -2, 4, 8},
   });
-  auto expected = makeNullableArrayVector<int32_t>({
+  auto expected = makeNullableArrayVector<int64_t>({
       {3, std::nullopt, 5, 6},
       {2},
       {3, 8, std::nullopt},
       {8},
   });
   testExpr(expected, "array_except(C0, ARRAY[1,-2,4])", {array1});
-  expected = makeNullableArrayVector<int32_t>({
+  expected = makeNullableArrayVector<int64_t>({
       {},
       {4},
       {1, -2, 4},
@@ -369,7 +369,7 @@ TEST_F(ArrayExceptTest, constant) {
   testExpr(expected, "array_except(ARRAY[1,1,-2,1,-2,4,1,4,4], C0)", {array1});
 
   // Array containing NULLs.
-  expected = makeNullableArrayVector<int32_t>({
+  expected = makeNullableArrayVector<int64_t>({
       {-2, 3, 5, 6},
       {2, -2},
       {3, 8},
@@ -377,7 +377,7 @@ TEST_F(ArrayExceptTest, constant) {
   });
   testExpr(expected, "array_except(C0, ARRAY[1,NULL,4])", {array1});
 
-  expected = makeNullableArrayVector<int32_t>({
+  expected = makeNullableArrayVector<int64_t>({
       {},
       {std::nullopt, 4},
       {1, 4},

--- a/velox/functions/prestosql/tests/ArrayIntersectTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayIntersectTest.cpp
@@ -555,13 +555,13 @@ TEST_F(ArrayIntersectTest, complexTypeRowNestedArrays) {
 
 // When one of the arrays is constant.
 TEST_F(ArrayIntersectTest, constant) {
-  auto array1 = makeNullableArrayVector<int32_t>({
+  auto array1 = makeNullableArrayVector<int64_t>({
       {1, -2, 3, std::nullopt, 4, 5, 6, std::nullopt},
       {1, 2, -2, 1},
       {3, 8, std::nullopt},
       {1, 1, -2, -2, -2, 4, 8},
   });
-  auto expected = makeNullableArrayVector<int32_t>({
+  auto expected = makeNullableArrayVector<int64_t>({
       {1, -2, 4},
       {1, -2},
       {},
@@ -573,7 +573,7 @@ TEST_F(ArrayIntersectTest, constant) {
       expected, "array_intersect(ARRAY[1,1,-2,1,-2,4,1,4,4], C0)", {array1});
 
   // Array containing NULLs.
-  expected = makeNullableArrayVector<int32_t>({
+  expected = makeNullableArrayVector<int64_t>({
       {1, std::nullopt, 4},
       {1},
       {std::nullopt},
@@ -586,17 +586,17 @@ TEST_F(ArrayIntersectTest, constant) {
 // Check that results are deterministic regardless of the encoding; literals
 // (constant exprs) and regular columns should always return the same results.
 TEST_F(ArrayIntersectTest, deterministic) {
-  auto c0 = makeNullableArrayVector<int32_t>({
+  auto c0 = makeNullableArrayVector<int64_t>({
       {1, -2, 3, std::nullopt, 4, 5, 6, std::nullopt},
       {4, -2, 6, std::nullopt, 1},
   });
-  auto c1 = makeNullableArrayVector<int32_t>({
+  auto c1 = makeNullableArrayVector<int64_t>({
       {1, 4, -2},
       {1, 4, -2},
   });
 
   // C0 then C1.
-  auto expectedC0C1 = makeNullableArrayVector<int32_t>({
+  auto expectedC0C1 = makeNullableArrayVector<int64_t>({
       {1, -2, 4},
       {4, -2, 1},
   });
@@ -604,7 +604,7 @@ TEST_F(ArrayIntersectTest, deterministic) {
   testExpr(expectedC0C1, "array_intersect(C0, C1)", {c0, c1});
 
   // C1 then C0.
-  auto expectedC1C0 = makeNullableArrayVector<int32_t>({
+  auto expectedC1C0 = makeNullableArrayVector<int64_t>({
       {1, 4, -2},
       {1, 4, -2},
   });
@@ -618,8 +618,8 @@ TEST_F(ArrayIntersectTest, dictionaryEncodedElementsInConstant) {
       test::TestingDictionaryArrayElementsFunction::signatures(),
       std::make_unique<test::TestingDictionaryArrayElementsFunction>());
 
-  auto array = makeArrayVector<int32_t>({{1, 3}, {2, 5}, {0, 6}});
-  auto expected = makeArrayVector<int32_t>({{1, 3}, {2}, {}});
+  auto array = makeArrayVector<int64_t>({{1, 3}, {2, 5}, {0, 6}});
+  auto expected = makeArrayVector<int64_t>({{1, 3}, {2}, {}});
   testExpr(
       expected,
       "array_intersect(c0, testing_dictionary_array_elements(ARRAY [2, 2, 3, 1, 2, 2]))",

--- a/velox/functions/prestosql/tests/MapTest.cpp
+++ b/velox/functions/prestosql/tests/MapTest.cpp
@@ -308,7 +308,7 @@ TEST_F(MapTest, fewerValuesThanKeysInLast) {
       "try("
       "   if(c0, "
       "       map(c1, c2), "
-      "       cast(null as map(integer, integer))))",
+      "       cast(null as map(bigint, bigint))))",
       makeRowVector({condition, keys2, values2}));
   EXPECT_EQ(0, result->offsetAt(0));
   EXPECT_EQ(3, result->offsetAt(2));

--- a/velox/parse/Expressions.h
+++ b/velox/parse/Expressions.h
@@ -346,14 +346,14 @@ class WindowCallExpr : public CallExpr {
 class ConstantExpr : public IExpr,
                      public std::enable_shared_from_this<ConstantExpr> {
  public:
-  ConstantExpr(TypePtr type, variant value, std::optional<std::string> alias)
+  ConstantExpr(TypePtr type, Variant value, std::optional<std::string> alias)
       : IExpr{IExpr::Kind::kConstant, {}, std::move(alias)},
         type_{std::move(type)},
         value_{std::move(value)} {}
 
   std::string toString() const override;
 
-  const variant& value() const {
+  const Variant& value() const {
     return value_;
   }
 
@@ -382,7 +382,7 @@ class ConstantExpr : public IExpr,
 
  private:
   const TypePtr type_;
-  const variant value_;
+  const Variant value_;
 };
 
 class CastExpr : public IExpr, public std::enable_shared_from_this<CastExpr> {


### PR DESCRIPTION
Summary:

Fold constant expressions during parsing to allow specifying constants using SQL:
- {'x': 1, 'y': 2} becomes a ROW constant with named fields.
- ROW(1, 2) becomes a ROW constant with unnamed fields.
- ROW(1, 2)::struct(x bigint, y bigint) becomes a ROW constant with named fields.
- DATE '1994-01-01' and '1994-01-01'::date become DATE constants.

Reviewed By: peterenescu

Differential Revision: D101358791


