### PR TITLE
fix: Ambiguous QueryConfig constructor call in QueryConfigTest

### DIFF
--- a/velox/core/tests/QueryConfigTest.cpp
+++ b/velox/core/tests/QueryConfigTest.cpp
@@ -208,8 +208,10 @@ TEST_F(QueryConfigTest, expressionEvaluationRelatedConfigs) {
   // Verify minRowsForPeeling: peeling is suppressed when the number of
   // selected rows is below the threshold.
   {
-    auto queryCtx = core::QueryCtx::create(
-        nullptr, QueryConfig({{core::QueryConfig::kMinRowsForPeeling, "50"}}));
+    std::unordered_map<std::string, std::string> configData(
+        {{core::QueryConfig::kMinRowsForPeeling, "50"}});
+    auto queryCtx =
+        core::QueryCtx::create(nullptr, QueryConfig{std::move(configData)});
     auto execCtx = std::make_shared<core::ExecCtx>(pool.get(), queryCtx.get());
     auto evalCtx = std::make_shared<exec::EvalCtx>(execCtx.get());
 


### PR DESCRIPTION
Summary: Disambiguate the `QueryConfig({{kMinRowsForPeeling, "50"}})` call by constructing the `std::unordered_map` explicitly before passing it to the constructor. The brace-enclosed initializer list was ambiguous between the map constructor and the copy/move constructors.

Reviewed By: kagamiori

Differential Revision: D102229087


