### PR TITLE
build: Allow meta-codesync bot to trigger CI failure analysis

### DIFF
--- a/.github/workflows/ci-failure-comment.yml
+++ b/.github/workflows/ci-failure-comment.yml
@@ -178,5 +178,10 @@ jobs:
           github_token: ${{ github.token }}
           claude_args: --model claude-opus-4-6 --allowedTools Bash Read Grep Glob
           prompt: ${{ steps.prompt.outputs.value }}
+          # Most Velox PRs are exported from Phabricator and pushed to GitHub
+          # by the meta-codesync bot, so the upstream workflow_run's `actor`
+          # is a Bot. Without this allowlist, claude-code-action refuses to
+          # run for those PRs and the failure analysis is silently dropped.
+          allowed_bots: meta-codesync
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Summary:
The CI Failure Comment workflow currently dies at the "Analyze failures with Claude" step for almost every Phabricator-exported PR. The Claude action's prepare-step rejects any workflow_run whose `actor` (commit pusher) is a Bot, with: "Workflow initiated by non-human actor: meta-codesync (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots."


Auto exported Velox PRs from Phabricator are pushed to GitHub by `meta-codesync[bot]`, so the upstream Linux Build / Fuzzer Jobs `workflow_run.actor` is `meta-codesync[bot]` and the analysis step bails. The few PRs where it currently works are the accidental subset where the contributor's own GitHub identity pushed the commit, making `actor` a User.

Add `allowed_bots: meta-codesync` to the `izaitsevfb/claude-code-action` invocation so failures on Phabricator-exported PRs also get analyzed and commented on.

Concrete repro: PR #17320 had two failing upstream runs (Linux Build 24859584491, Fuzzer Jobs 24859584516); both spawned CI Failure Comment runs (24862015059, 24861842963) that completed with `failure` at the Claude step with exactly the bot-actor error above. PR #17260 (mine, pushed under my own GitHub identity) succeeded at the same step on the same workflow code, confirming the only differentiator is the upstream actor.

Differential Revision: D102240572


