### PR TITLE
fix(build): Add -fsized-deallocation for s2geometry on Clang (#17323)

### DIFF
--- a/CMake/resolve_dependency_modules/s2geometry.cmake
+++ b/CMake/resolve_dependency_modules/s2geometry.cmake
@@ -56,5 +56,11 @@ block()
 
   FetchContent_MakeAvailable(s2geometry)
 
+  # Clang does not enable C++14 sized deallocation by default, unlike GCC.
+  # s2geometry's port.h uses ::operator delete(ptr, size) which requires it.
+  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    target_compile_options(s2 PRIVATE -fsized-deallocation)
+  endif()
+
   add_library(s2::s2 ALIAS s2)
 endblock()


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/nimble/pull/673


The Nimble OSS Linux CI build fails when compiling s2geometry v0.12.0 with clang-15 and GCC 12's libstdc++. s2geometry's `port.h` uses C++14 sized deallocation (`::operator delete(ptr, size)`), but Clang does not enable this by default unlike GCC.

This adds `-fsized-deallocation` to the `s2` CMake target when building with Clang, matching what Meta does internally for Clang builds across fbcode.

Reviewed By: xiaoxmeng, apurva-meta

Differential Revision: D102265942


