### PR TITLE
perf: Avoid temporary std::string construction (#17324)

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -426,10 +426,14 @@ CpuWallTiming Driver::processLazyIoStats(
   if (&op == operators_[0].get()) {
     return timing;
   }
+  static const std::string kCpuNanosKey(LazyVector::kCpuNanos);
+  static const std::string kWallNanosKey(LazyVector::kWallNanos);
+  static const std::string kInputBytesKey(LazyVector::kInputBytes);
+
   auto lockStats = op.stats().wlock();
 
   // Checks and tries to update cpu time from lazy loads.
-  auto it = lockStats->runtimeStats.find(std::string(LazyVector::kCpuNanos));
+  auto it = lockStats->runtimeStats.find(kCpuNanosKey);
   if (it == lockStats->runtimeStats.end()) {
     // Return early if no lazy activity.  Lazy CPU and wall times are recorded
     // together, checking one is enough.
@@ -447,7 +451,7 @@ CpuWallTiming Driver::processLazyIoStats(
 
   // Checks and tries to update wall time from lazy loads.
   int64_t wallDelta = 0;
-  it = lockStats->runtimeStats.find(std::string(LazyVector::kWallNanos));
+  it = lockStats->runtimeStats.find(kWallNanosKey);
   if (it != lockStats->runtimeStats.end()) {
     const int64_t wall = it->second.sum;
     wallDelta = std::max<int64_t>(0, wall - lockStats->lastLazyWallNanos);
@@ -458,7 +462,7 @@ CpuWallTiming Driver::processLazyIoStats(
 
   // Checks and tries to update input bytes from lazy loads.
   int64_t inputBytesDelta = 0;
-  it = lockStats->runtimeStats.find(std::string(LazyVector::kInputBytes));
+  it = lockStats->runtimeStats.find(kInputBytesKey);
   if (it != lockStats->runtimeStats.end()) {
     const int64_t inputBytes = it->second.sum;
     inputBytesDelta = inputBytes - lockStats->lastLazyInputBytes;


### PR DESCRIPTION
Summary:

This change was generated by pointing an AI agent at hot functions showing up in our internal profiles. It was reviewed by a human (outside the velox team):

Optimized `Driver::processLazyIoStats` by replacing three temporary `std::string` constructions (`std::string(LazyVector::kCpuNanos)`, `std::string(LazyVector::kWallNanos)`, `std::string(LazyVector::kInputBytes)`) with `static const std::string` variables. These are initialized once on first call and reused on subsequent calls, avoiding heap allocations on every invocation of this frequently-called function. The static strings are declared before the write lock is acquired, also slightly reducing lock duration.

Differential Revision: D102102047


