### PR TITLE
fix(spark): Align split() with empty delimiter to Spark 4.1+ 

### DIFF
--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -1328,6 +1328,16 @@ Spark-specific Configuration
      - bool
      - true
      - If true, Spark ``collect_list`` aggregate function ignores nulls in the input.
+   * - spark.legacy_split_empty_pattern
+     - bool
+     - true
+     - If true (default), ``split`` with an empty delimiter keeps the pre SPARK-49968 (Spark < 4.1)
+       behavior: when ``limit`` is positive and smaller than the string's character count, the
+       result only contains the first ``limit`` single-character elements and the trailing
+       substring is discarded, e.g. ``split('ab', '', 1)`` returns ``["a"]``.
+       If false, the behavior aligns with SPARK-49968 (Spark 4.1+): the last element
+       contains all remaining input that exceeds ``limit``, e.g. ``split('ab', '', 1)`` returns
+       ``["ab"]``.
 
 Tracing
 --------

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -394,19 +394,38 @@ String Functions
     which controls the number of times the regex is applied. By default, ``limit`` is -1. When ``limit`` > 0,
     the resulting array's length will not be more than ``limit``, and the resulting array's last entry will
     contain all input beyond the last matched regex. When ``limit`` <= 0, ``regex`` will be applied as many
-    times as possible, and the resulting array can be of any size. When ``delimiter`` is empty, if ``limit``
-    is smaller than the size of ``string``, the resulting array only contains ``limit`` number of single characters
-    splitting from ``string``, if ``limit`` is not provided or is larger than the size of ``string``, the resulting
-    array contains all the single characters of ``string`` and does not include an empty tail character.
-    The split function align with vanilla spark 3.4+ split function. ::
+    times as possible, and the resulting array can be of any size.
+    The split function align with vanilla spark 3.4+ split function.
+
+    **Empty Delimiter Behavior** (controlled by ``spark.legacy_split_empty_pattern``):
+
+    When ``spark.legacy_split_empty_pattern=true`` (default, aligned with the legacy behavior
+    pre-SPARK-49968 / Spark < 4.1), when ``limit`` is positive and smaller than the string's
+    character count, the result only contains the first ``limit`` single-character elements
+    and the trailing substring is discarded. ::
+
+        -- With spark.legacy_split_empty_pattern=true (default):
+        SELECT split('abcd', ''); -- ["a","b","c","d"]
+        SELECT split('abcd', '', 3); -- ["a","b","c"]
+        SELECT split('abcd', '', 5); -- ["a","b","c","d"]
+        SELECT split('ab', '', 1); -- ["a"]
+
+    When ``spark.legacy_split_empty_pattern=false``, the fixed behavior introduced by SPARK-49968
+    (Spark 4.1+) is used: the last element contains all remaining input when ``limit`` is
+    reached. ::
+
+        -- With spark.legacy_split_empty_pattern=false:
+        SELECT split('abcd', ''); -- ["a","b","c","d"]
+        SELECT split('abcd', '', 3); -- ["a","b","cd"]
+        SELECT split('abcd', '', 5); -- ["a","b","c","d"]
+        SELECT split('ab', '', 1); -- ["ab"]
+
+    Examples with non-empty delimiters (not affected by the configuration above): ::
 
         SELECT split('oneAtwoBthreeC', '[ABC]'); -- ["one","two","three",""]
         SELECT split('oneAtwoBthreeC', '[ABC]', 2); -- ["one","twoBthreeC"]
         SELECT split('oneAtwoBthreeC', '[ABC]', 5); -- ["one","two","three",""]
         SELECT split('one', '1'); -- ["one"]
-        SELECT split('abcd', ''); -- ["a","b","c","d"]
-        SELECT split('abcd', '', 3); -- ["a","b","c"]
-        SELECT split('abcd', '', 5); -- ["a","b","c","d"]
 
 .. spark:function:: startswith(left, right) -> boolean
 

--- a/velox/functions/sparksql/SparkQueryConfig.cpp
+++ b/velox/functions/sparksql/SparkQueryConfig.cpp
@@ -35,6 +35,7 @@ SparkQueryConfig::registeredProperties() {
     VELOX_REGISTER_SPARK_CONFIG(kLegacyStatisticalAggregate);
     VELOX_REGISTER_SPARK_CONFIG(kJsonIgnoreNullFields);
     VELOX_REGISTER_SPARK_CONFIG(kCollectListIgnoreNulls);
+    VELOX_REGISTER_SPARK_CONFIG(kLegacySplitEmptyPattern);
 
 #undef VELOX_REGISTER_SPARK_CONFIG
 

--- a/velox/functions/sparksql/SparkQueryConfig.h
+++ b/velox/functions/sparksql/SparkQueryConfig.h
@@ -162,6 +162,20 @@ class SparkQueryConfig {
       true,
       "If true, Spark collect_list() ignores nulls in the input.")
 
+  /// If true (default), keep the legacy (pre SPARK-49968, i.e. Spark < 4.1)
+  /// behavior for split() with an empty delimiter: the result only contains
+  /// the first `limit` characters and the trailing substring is discarded,
+  /// e.g. split('ab', '', 1) -> ["a"]. If false, the fixed behavior is used:
+  /// the last element contains all remaining input, e.g.
+  /// split('ab', '', 1) -> ["ab"].
+  VELOX_SPARK_CONFIG(
+      kLegacySplitEmptyPattern,
+      legacySplitEmptyPattern,
+      "legacy_split_empty_pattern",
+      bool,
+      true,
+      "Use pre-SPARK-49968 behavior for split() with an empty delimiter.")
+
   /// Returns all registered Spark config properties. Property names are
   /// unqualified (no "spark." prefix).
   static const std::vector<config::ConfigProperty>& registeredProperties();

--- a/velox/functions/sparksql/Split.h
+++ b/velox/functions/sparksql/Split.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "velox/functions/lib/Utf8Utils.h"
+#include "velox/functions/sparksql/SparkQueryConfig.h"
 
 namespace facebook::velox::functions::sparksql {
 
@@ -50,6 +51,11 @@ struct Split {
       const arg_type<Varchar>* delimiter,
       const arg_type<int32_t>* /*limit*/) {
     cache_.setMaxCompiledRegexes(config.exprMaxCompiledRegexes());
+    // When true (default), keeps the pre SPARK-49968 (Spark < 4.1) behavior
+    // for split() with an empty delimiter: the trailing substring beyond
+    // `limit` chars is discarded. When false, the last element contains all
+    // remaining input, matching Spark 4.1+.
+    legacySplitEmptyPattern_ = SparkQueryConfig{config}.legacySplitEmptyPattern();
     if (delimiter) {
       initializeFastPath(delimiter->data(), delimiter->size());
       isConstantDelimiter_ = true;
@@ -107,9 +113,16 @@ struct Split {
   // When pattern is empty, split each character out. Since Spark 3.4, when
   // delimiter is empty, the result does not include an empty tail string, e.g.
   // split('abc', '') outputs ["a", "b", "c"] instead of ["a", "b", "c", ""].
-  // The result does not include remaining string when limit is smaller than the
-  // string size, e.g. split('abc', '', 2) outputs ["a", "b"] instead of ["a",
-  // "bc"].
+  //
+  // Behavior when limit is positive and smaller than the string's character
+  // count is controlled by `spark.legacy_split_empty_pattern`:
+  //  - legacy=true (default, pre SPARK-49968 / Spark < 4.1): the result only
+  //    contains the first `limit` single-character elements and the tail is
+  //    discarded. e.g. split('abc', '', 2) outputs ["a", "b"];
+  //    split('ab', '', 1) outputs ["a"].
+  //  - legacy=false (aligned with SPARK-49968 / Spark 4.1+): the last
+  //    element contains all remaining input. e.g. split('abc', '', 2)
+  //    outputs ["a", "bc"]; split('ab', '', 1) outputs ["ab"].
   void splitEmptyDelimiter(
       out_type<Array<Varchar>>& result,
       const arg_type<Varchar>& input,
@@ -123,17 +136,32 @@ struct Split {
     const char* start = input.data();
     size_t pos = 0;
     int32_t count = 0;
-    while (pos < end && count < limit) {
+    auto emitNextChar = [&]() {
+      // Emits the next UTF-8 character at `pos` as a single element and
+      // advances `pos`/`count`. For invalid UTF-8 character, the length is
+      // the absolute value of result of `tryGetUtf8CharLength`, so that
+      // scanning always makes progress.
       int32_t codePoint;
       auto charLength = tryGetUtf8CharLength(start + pos, end - pos, codePoint);
       if (charLength <= 0) {
-        // Invalid UTF-8 character, the length of the invalid
-        // character is the absolute value of result of `tryGetUtf8CharLength`.
         charLength = -charLength;
       }
       result.add_item().setNoCopy(StringView(start + pos, charLength));
       pos += charLength;
       count += 1;
+    };
+
+    // Always append the first limit - 1 items to the result.
+    while (pos < end && count + 1 < limit) {
+      emitNextChar();
+    }
+
+    if (pos < end) {
+      if (legacySplitEmptyPattern_) {
+        emitNextChar();
+      } else {
+        result.add_item().setNoCopy(StringView(start + pos, end - pos));
+      }
     }
   }
 
@@ -265,5 +293,10 @@ struct Split {
   // Single character delimiter for fast path.
   char singleCharDelimiter_;
   bool isConstantDelimiter_{false};
+  // Whether to use the legacy (pre SPARK-49968) behavior for split() with an
+  // empty delimiter. Cached from `spark.legacy_split_empty_pattern` at
+  // initialization time. Defaults to true to align with the legacy Spark
+  // behavior.
+  bool legacySplitEmptyPattern_{true};
 };
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/tests/SplitTest.cpp
+++ b/velox/functions/sparksql/tests/SplitTest.cpp
@@ -13,7 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <folly/ScopeGuard.h>
+
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/sparksql/SparkQueryConfig.h"
 #include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
 #include "velox/type/Type.h"
 
@@ -142,7 +145,110 @@ TEST_F(SplitTest, basic) {
   testSplit(input, "A", std::nullopt, numRows, expected);
 }
 
-TEST_F(SplitTest, emptyDelimiter) {
+TEST_F(SplitTest, emptyDelimiterNonLegacy) {
+  queryCtx_->testingOverrideConfigUnsafe(
+      {{SparkQueryConfig::qualify(SparkQueryConfig::kLegacySplitEmptyPattern),
+        "false"}});
+  auto guard = folly::makeGuard([&]() {
+    queryCtx_->testingOverrideConfigUnsafe({});
+  });
+
+  auto numRows = 4;
+  auto input = std::vector<std::string>{
+      {"I,he,she,they"}, // Simple
+      {"one,,,four,"}, // Empty strings
+      {"a\xED\xA0@123"}, // Not a well-formed UTF-8 string
+      {""}, // The whole string is empty
+  };
+  auto expected = std::vector<std::vector<std::string>>({
+      {"I", ",", "h", "e", ",", "s", "h", "e", ",", "t", "h", "e", "y"},
+      {"o", "n", "e", ",", ",", ",", "f", "o", "u", "r", ","},
+      {"a", "\xED\xA0", "@", "1", "2", "3"},
+      {""},
+  });
+
+  // No limit provided.
+  testSplit(input, "", std::nullopt, numRows, expected);
+
+  // Limit <= 0.
+  testSplit(input, "", -1, numRows, expected);
+
+  // High limit, the limit greater than the input string size.
+  testSplit(input, "", 20, numRows, expected);
+
+  // Small limit, the limit is smaller than or equals to input string size.
+  // Non-legacy behavior: the last element contains all remaining input.
+  expected = {
+      {"I", ",", "he,she,they"},
+      {"o", "n", "e,,,four,"},
+      {"a", "\xED\xA0", "@123"},
+      {""},
+  };
+  testSplit(input, "", 3, numRows, expected);
+
+  // limit = 1, the resulting array only has one entry to contain all input.
+  expected = {
+      {"I,he,she,they"},
+      {"one,,,four,"},
+      {"a\xED\xA0@123"},
+      {""},
+  };
+  testSplit(input, "", 1, numRows, expected);
+
+  // Non-ascii, empty delimiter.
+  input = std::vector<std::string>{
+      {"синяя赤いトマト緑の"},
+      {"Hello世界🙂"},
+      {"a\xED\xA0@123"}, // Not a well-formed UTF-8 string
+      {""},
+  };
+  expected = {
+      {"с", "и", "н", "я", "я", "赤", "い", "ト", "マ", "ト", "緑", "の"},
+      {"H", "e", "l", "l", "o", "世", "界", "🙂"},
+      {"a", "\xED\xA0", "@", "1", "2", "3"},
+      {""},
+  };
+  testSplit(input, "", std::nullopt, numRows, expected);
+
+  // Non-legacy behavior: last element keeps the remaining substring.
+  expected = {
+      {"с", "иняя赤いトマト緑の"},
+      {"H", "ello世界🙂"},
+      {"a", "\xED\xA0@123"},
+      {""},
+  };
+  testSplit(input, "", 2, numRows, expected);
+
+  // Additional single-row cases.
+  numRows = 1;
+
+  // split('hello', '', 1) -> ["hello"]
+  testSplit({"hello"}, "", 1, numRows, {{"hello"}});
+
+  // split('hello', '', 3) -> ["h", "e", "llo"]
+  testSplit({"hello"}, "", 3, numRows, {{"h", "e", "llo"}});
+
+  // split('hello', '', 5) -> ["h", "e", "l", "l", "o"]
+  testSplit({"hello"}, "", 5, numRows, {{"h", "e", "l", "l", "o"}});
+
+  // split('hello', '', 100) -> ["h", "e", "l", "l", "o"] (no empty tail)
+  testSplit({"hello"}, "", 100, numRows, {{"h", "e", "l", "l", "o"}});
+
+  // split('1A2A3A4', '', 3) -> ["1", "A", "2A3A4"]
+  testSplit({"1A2A3A4"}, "", 3, numRows, {{"1", "A", "2A3A4"}});
+
+  // split('ab', '', 1) -> ["ab"]
+  testSplit({"ab"}, "", 1, numRows, {{"ab"}});
+
+  // Empty string with positive limit still yields a single empty element.
+  testSplit({""},  "", 1, numRows, {{""}});
+  testSplit({""},  "", 3, numRows, {{""}});
+}
+
+// Tests the legacy behavior (the default) for split() with an empty
+// delimiter: only the first `limit` single-character elements are returned
+// and the trailing substring is dropped.
+TEST_F(SplitTest, emptyDelimiterLegacy) {
   auto numRows = 4;
   auto input = std::vector<std::string>{
       {"I,he,she,they"}, // Simple


### PR DESCRIPTION

## Summary

Align Velox's Spark `split(str, regex, limit)` with Spark 4.1+ (SPARK-49968) when
the delimiter is an empty string and `limit` is positive and smaller than the
input's character count.

Before this change, Velox produced `limit` single-character elements and dropped
the tail, which diverges from current Spark. After this change, the last element
contains all remaining input, matching Spark 4.1+.

A session-level switch `spark.legacy_split_empty_pattern` is introduced (default
`false`) so users still running on older Spark versions (3.x / 4.0) can opt into
the legacy behavior — consistent with the existing `spark.legacy_date_formatter`
/ `spark.legacy_statistical_aggregate` pattern.

## Motivation

- Upstream Spark JIRA: https://issues.apache.org/jira/browse/SPARK-49968
- Upstream Spark PR: [https://github.com/apache/spark/pull/48470]
- Reported behavior divergence:

  | Expression                  | Spark 4.1+ (expected) | Velox (before) | Velox (after) |
  |-----------------------------|-----------------------|----------------|---------------|
  | `split('ab', '', 1)`        | `["ab"]`              | `["a"]`        | `["ab"]`      |
  | `split('hello', '', 3)`     | `["h","e","llo"]`     | `["h","e","l"]`| `["h","e","llo"]` |
  | `split('1A2A3A4', '', 3)`   | `["1","A","2A3A4"]`   | `["1","A","2"]`| `["1","A","2A3A4"]` |

## Changes

- `velox/core/QueryConfig.{h,cpp}`
  - Add `spark.legacy_split_empty_pattern` (bool, default `false`).
  - Expose `QueryConfig::sparkLegacySplitEmptyPattern()`.
- `velox/functions/sparksql/Split.h`
  - Cache the flag in `initialize()`.
  - In `splitEmptyDelimiter`, branch on the flag:
    - `false` (default / SPARK-49968): emit `limit - 1` single-character
      elements and put the remaining substring as the last element.
    - `true` (legacy): keep the pre-fix behavior (truncate tail).
- `velox/functions/sparksql/tests/SplitTest.cpp`
  - New cases covering both branches, empty input, high limit, and multibyte
    UTF-8 strings.
- `velox/docs/configs.rst`
  - Document the new config.

## Out of scope

Propagating the corresponding Spark SQLConf (e.g.
`spark.gluten.sql.legacy.split.emptyPattern` in Gluten) to the Velox `QueryCtx`
is the integration layer's responsibility (Gluten / Prestissimo / custom
backend) and is **not** part of this PR.

## Testing

- Added unit tests in `velox/functions/sparksql/tests/SplitTest.cpp`.
- Full sparksql function tests:

## Related issue

https://github.com/facebookincubator/velox/issues/17326

  