### PR TITLE
fix: Arrow export overflow from timestamps masked by parent nulls

### DIFF
--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -1304,6 +1304,7 @@ void exportConstant(
     rows.apply([&](vector_size_t i) {
       if (!bits::isBitNull(rawNulls, i)) {
         allRowsNull = false;
+        return;
       }
     });
   }

--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -1199,7 +1199,7 @@ void exportDictionary(
     auto* rawNulls = nulls->as<uint64_t>();
     auto* rawIndices = vec.wrapInfo()->as<vector_size_t>();
     rows.apply([&](vector_size_t i) {
-      if (!bits::isBitNull(rawNulls, i)) {
+      if (!bits::isBitNull(rawNulls, i) && !vec.isNullAt(i)) {
         bits::setNull(rawDictionaryNulls, rawIndices[i], false);
       }
     });
@@ -1348,8 +1348,9 @@ void exportToArrowImpl(
   out.length = rows.count();
   out.offset = 0;
   out.dictionary = nullptr;
+  const bool isConstant = vec.encoding() == VectorEncoding::Simple::CONSTANT;
   BufferPtr ownNulls;
-  if (vec.mayHaveNulls() && vec.getNullCount() != 0) {
+  if (!isConstant && vec.mayHaveNulls() && vec.getNullCount() != 0) {
     ownNulls = vec.nulls();
   }
 
@@ -1357,7 +1358,7 @@ void exportToArrowImpl(
   // nodes. Arrow validity for this array still uses only this vector's own
   // nulls.
   auto effectiveNulls = parentNulls != nullptr ? parentNulls : ownNulls;
-  if (parentNulls != nullptr && ownNulls != nullptr) {
+  if (!isConstant && parentNulls != nullptr && ownNulls != nullptr) {
     auto mergedNulls =
         AlignedBuffer::allocate<bool>(vec.size(), pool, bits::kNotNull);
     bits::andBits(
@@ -1422,9 +1423,8 @@ void exportToArrowImpl(
     case VectorEncoding::Simple::CONSTANT:
       options.flattenConstant
           ? exportFlattenedVector(
-                vec, rows, options, out, pool, *holder, effectiveNulls)
-          : exportConstant(
-                vec, rows, options, out, pool, *holder, effectiveNulls);
+                vec, rows, options, out, pool, *holder, parentNulls)
+          : exportConstant(vec, rows, options, out, pool, *holder, parentNulls);
       break;
     default:
       VELOX_NYI("{} cannot be exported to Arrow yet.", vec.encoding());

--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -407,6 +407,27 @@ struct Selection {
   vector_size_t total_;
 };
 
+template <TypeKind kind>
+VectorPtr makeFlatVectorWithNulls(const BaseVector& vec, BufferPtr nulls) {
+  using T = typename TypeTraits<kind>::NativeType;
+  auto flat = vec.asUnchecked<FlatVector<T>>();
+  std::vector<BufferPtr> stringBuffers;
+  if constexpr (std::is_same_v<T, StringView>) {
+    stringBuffers = std::vector<BufferPtr>(
+        flat->stringBuffers().begin(), flat->stringBuffers().end());
+  }
+  return std::make_shared<FlatVector<T>>(
+      flat->pool(),
+      flat->type(),
+      std::move(nulls),
+      flat->size(),
+      flat->values(),
+      std::move(stringBuffers),
+      SimpleVectorStats<T>{},
+      std::nullopt,
+      std::nullopt);
+}
+
 // Gather values from time buffer. Nulls are skipped.
 // TIME is stored as int64_t milliseconds in Velox, converted to int32_t
 // milliseconds for Arrow time32.
@@ -990,7 +1011,8 @@ void exportToArrowImpl(
     const Selection&,
     const ArrowOptions& options,
     ArrowArray&,
-    memory::MemoryPool*);
+    memory::MemoryPool*,
+    const BufferPtr& parentNulls = nullptr);
 
 void exportRows(
     const RowVector& vec,
@@ -998,7 +1020,8 @@ void exportRows(
     const ArrowOptions& options,
     ArrowArray& out,
     memory::MemoryPool* pool,
-    VeloxToArrowBridgeHolder& holder) {
+    VeloxToArrowBridgeHolder& holder,
+    const BufferPtr& nulls) {
   out.n_buffers = 1;
   holder.resizeChildren(vec.childrenSize());
   out.n_children = vec.childrenSize();
@@ -1010,7 +1033,8 @@ void exportRows(
           rows,
           options,
           *holder.allocateChild(i),
-          pool);
+          pool,
+          nulls);
     } catch (const VeloxException&) {
       for (column_index_t j = 0; j < i; ++j) {
         // When exception is thrown, i th child is guaranteed unset.
@@ -1038,14 +1062,15 @@ void exportOffsets(
     ArrowArray& out,
     memory::MemoryPool* pool,
     VeloxToArrowBridgeHolder& holder,
-    Selection& childRows) {
+    Selection& childRows,
+    const BufferPtr& nulls) {
   VELOX_CHECK_GE(vec.size(), rows.count());
 
   auto offsets = AlignedBuffer::allocate<vector_size_t>(
       checkedPlus<size_t>(out.length, 1), pool);
   auto rawOffsets = offsets->asMutable<vector_size_t>();
 
-  if (!rows.changed() && isCompact(vec)) {
+  if (nulls == nullptr && !rows.changed() && isCompact(vec)) {
     vector_size_t rowCount = rows.count();
     memcpy(rawOffsets, vec.rawOffsets(), sizeof(vector_size_t) * rowCount);
     rawOffsets[rowCount] = rowCount == 0
@@ -1053,12 +1078,13 @@ void exportOffsets(
         : vec.offsetAt(rowCount - 1) + vec.sizeAt(rowCount - 1);
   } else {
     childRows.clearAll();
+    auto rawNulls = nulls == nullptr ? nullptr : nulls->as<uint64_t>();
     // j: Index of element we are writing.
     // k: Total size so far.
     vector_size_t j = 0, k = 0;
     rows.apply([&](vector_size_t i) {
       rawOffsets[j++] = k;
-      if (!vec.isNullAt(i)) {
+      if (rawNulls == nullptr || !bits::isBitNull(rawNulls, i)) {
         childRows.addRange(vec.offsetAt(i), vec.sizeAt(i));
         k += vec.sizeAt(i);
       }
@@ -1076,9 +1102,10 @@ void exportArrays(
     const ArrowOptions& options,
     ArrowArray& out,
     memory::MemoryPool* pool,
-    VeloxToArrowBridgeHolder& holder) {
+    VeloxToArrowBridgeHolder& holder,
+    const BufferPtr& nulls) {
   Selection childRows(vec.elements()->size());
-  exportOffsets(vec, rows, out, pool, holder, childRows);
+  exportOffsets(vec, rows, out, pool, holder, childRows, nulls);
   holder.resizeChildren(1);
   exportToArrowImpl(
       *vec.elements()->loadedVector(),
@@ -1096,7 +1123,8 @@ void exportMaps(
     const ArrowOptions& options,
     ArrowArray& out,
     memory::MemoryPool* pool,
-    VeloxToArrowBridgeHolder& holder) {
+    VeloxToArrowBridgeHolder& holder,
+    const BufferPtr& nulls) {
   RowVector child(
       pool,
       ROW({"key", "value"}, {vec.mapKeys()->type(), vec.mapValues()->type()}),
@@ -1104,7 +1132,7 @@ void exportMaps(
       vec.mapKeys()->size(),
       {vec.mapKeys(), vec.mapValues()});
   Selection childRows(child.size());
-  exportOffsets(vec, rows, out, pool, holder, childRows);
+  exportOffsets(vec, rows, out, pool, holder, childRows, nulls);
   holder.resizeChildren(1);
   exportToArrowImpl(child, childRows, options, *holder.allocateChild(0), pool);
   out.n_children = 1;
@@ -1118,16 +1146,18 @@ void flattenAndExport(
     const ArrowOptions& options,
     ArrowArray& out,
     memory::MemoryPool* pool,
-    VeloxToArrowBridgeHolder& holder) {
+    VeloxToArrowBridgeHolder& holder,
+    const BufferPtr& nulls) {
   using NativeType = typename velox::TypeTraits<kind>::NativeType;
   SelectivityVector allRows(vec.size());
   DecodedVector decoded(vec, allRows);
   auto flatVector = BaseVector::create<FlatVector<NativeType>>(
       vec.type(), decoded.size(), pool);
 
-  if (decoded.mayHaveNulls()) {
+  if (decoded.mayHaveNulls() || nulls != nullptr) {
     allRows.applyToSelected([&](vector_size_t row) {
-      if (decoded.isNullAt(row)) {
+      if ((nulls != nullptr && bits::isBitNull(nulls->as<uint64_t>(), row)) ||
+          (decoded.mayHaveNulls() && decoded.isNullAt(row))) {
         flatVector->setNull(row, true);
       } else {
         flatVector->set(row, decoded.valueAt<NativeType>(row));
@@ -1171,13 +1201,22 @@ void exportFlattenedVector(
     const ArrowOptions& options,
     ArrowArray& out,
     memory::MemoryPool* pool,
-    VeloxToArrowBridgeHolder& holder) {
+    VeloxToArrowBridgeHolder& holder,
+    const BufferPtr& nulls) {
   VELOX_CHECK(
       vec.valueVector() == nullptr || vec.wrappedVector()->isFlatEncoding(),
       "An unsupported nested encoding was found.");
   VELOX_CHECK(vec.isScalar(), "Flattening is only supported for scalar types.");
   VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
-      flattenAndExport, vec.typeKind(), vec, rows, options, out, pool, holder);
+      flattenAndExport,
+      vec.typeKind(),
+      vec,
+      rows,
+      options,
+      out,
+      pool,
+      holder,
+      nulls);
 }
 
 void exportConstantValue(
@@ -1265,38 +1304,88 @@ void exportToArrowImpl(
     const Selection& rows,
     const ArrowOptions& options,
     ArrowArray& out,
-    memory::MemoryPool* pool) {
+    memory::MemoryPool* pool,
+    const BufferPtr& parentNulls) {
   auto holder = std::make_unique<VeloxToArrowBridgeHolder>();
   out.buffers = holder->getArrowBuffers();
   out.length = rows.count();
   out.offset = 0;
   out.dictionary = nullptr;
+  BufferPtr ownNulls;
+  if (vec.mayHaveNulls() && vec.getNullCount() != 0) {
+    ownNulls = vec.nulls();
+  }
+
+  // Calculate the effective nulls buffer used to skip values masked by parent
+  // nodes. Arrow validity for this array still uses only this vector's own
+  // nulls.
+  auto effectiveNulls = parentNulls != nullptr ? parentNulls : ownNulls;
+  if (parentNulls != nullptr && ownNulls != nullptr) {
+    auto mergedNulls =
+        AlignedBuffer::allocate<bool>(vec.size(), pool, bits::kNotNull);
+    bits::copyBits(
+        vec.rawNulls(), 0, mergedNulls->asMutable<uint64_t>(), 0, vec.size());
+    bits::andBits(
+        mergedNulls->asMutable<uint64_t>(),
+        parentNulls->as<uint64_t>(),
+        0,
+        vec.size());
+    effectiveNulls = std::move(mergedNulls);
+  }
   exportValidityBitmap(vec, rows, options, out, pool, *holder);
 
   switch (vec.encoding()) {
-    case VectorEncoding::Simple::FLAT:
-      exportFlat(vec, rows, options, out, pool, *holder);
+    case VectorEncoding::Simple::FLAT: {
+      VectorPtr flatWithNulls;
+      auto flat = &vec;
+      if (effectiveNulls != ownNulls && vec.typeKind() != TypeKind::UNKNOWN) {
+        flatWithNulls = VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+            makeFlatVectorWithNulls, vec.typeKind(), vec, effectiveNulls);
+        flat = flatWithNulls.get();
+      }
+      exportFlat(*flat, rows, options, out, pool, *holder);
       break;
+    }
     case VectorEncoding::Simple::ROW:
       exportRows(
-          *vec.asUnchecked<RowVector>(), rows, options, out, pool, *holder);
+          *vec.asUnchecked<RowVector>(),
+          rows,
+          options,
+          out,
+          pool,
+          *holder,
+          effectiveNulls);
       break;
     case VectorEncoding::Simple::ARRAY:
       exportArrays(
-          *vec.asUnchecked<ArrayVector>(), rows, options, out, pool, *holder);
+          *vec.asUnchecked<ArrayVector>(),
+          rows,
+          options,
+          out,
+          pool,
+          *holder,
+          effectiveNulls);
       break;
     case VectorEncoding::Simple::MAP:
       exportMaps(
-          *vec.asUnchecked<MapVector>(), rows, options, out, pool, *holder);
+          *vec.asUnchecked<MapVector>(),
+          rows,
+          options,
+          out,
+          pool,
+          *holder,
+          effectiveNulls);
       break;
     case VectorEncoding::Simple::DICTIONARY:
       options.flattenDictionary
-          ? exportFlattenedVector(vec, rows, options, out, pool, *holder)
+          ? exportFlattenedVector(
+                vec, rows, options, out, pool, *holder, effectiveNulls)
           : exportDictionary(vec, rows, options, out, pool, *holder);
       break;
     case VectorEncoding::Simple::CONSTANT:
       options.flattenConstant
-          ? exportFlattenedVector(vec, rows, options, out, pool, *holder)
+          ? exportFlattenedVector(
+                vec, rows, options, out, pool, *holder, effectiveNulls)
           : exportConstant(vec, rows, options, out, pool, *holder);
       break;
     default:

--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -796,26 +796,6 @@ bool isFlatScalarZeroCopy(const TypePtr& type, const ArrowOptions& options) {
       !needsTimeConversion;
 }
 
-// Returns the size of a single element of a given `type` in the target arrow
-// buffer.
-size_t getArrowElementSize(const TypePtr& type, const ArrowOptions& options) {
-  if (type->isShortDecimal() && !options.useDecimalTypeWidth) {
-    return sizeof(int128_t);
-  } else if (type->isTimestamp()) {
-    VELOX_DCHECK(type->equivalent(*TIMESTAMP()));
-    return sizeof(int64_t);
-  } else if (type->isTime()) {
-    if (type->equivalent(*TIME())) {
-      // TIME is exported as Arrow time32 (int32_t).
-      return sizeof(int32_t);
-    }
-    VELOX_DCHECK(type->equivalent(*TIME_MICRO_UTC()));
-    // TIME MICRO UTC is exported as Arrow time64 (int64_t).
-    return sizeof(int64_t);
-  }
-  return type->cppSizeInBytes();
-}
-
 void exportValues(
     const BaseVector& vec,
     const Selection& rows,
@@ -1216,16 +1196,15 @@ void exportDictionary(
     holder.setBuffer(1, vec.wrapInfo());
   }
   auto& values = *vec.valueVector()->loadedVector();
-  BufferPtr dictionaryNulls;
+  BufferPtr baseNulls;
   if (nulls != nullptr) {
-    dictionaryNulls =
-        AlignedBuffer::allocate<bool>(values.size(), pool, bits::kNull);
-    auto* rawDictionaryNulls = dictionaryNulls->asMutable<uint64_t>();
+    baseNulls = AlignedBuffer::allocate<bool>(values.size(), pool, bits::kNull);
+    auto* rawBaseNulls = baseNulls->asMutable<uint64_t>();
     auto* rawNulls = nulls->as<uint64_t>();
     auto* rawIndices = vec.wrapInfo()->as<vector_size_t>();
     rows.apply([&](vector_size_t i) {
       if (!bits::isBitNull(rawNulls, i)) {
-        bits::setNull(rawDictionaryNulls, rawIndices[i], false);
+        bits::setNull(rawBaseNulls, rawIndices[i], false);
       }
     });
   }
@@ -1236,7 +1215,7 @@ void exportDictionary(
       options,
       *out.dictionary,
       pool,
-      dictionaryNulls);
+      baseNulls);
 }
 
 void exportFlattenedVector(

--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -518,6 +518,27 @@ void gatherFromTimestampBuffer(
   }
 }
 
+// Returns the size of a single element of a given `type` in the target arrow
+// buffer.
+size_t getArrowElementSize(const Type& type, const ArrowOptions& options) {
+  if (type.isShortDecimal() && !options.useDecimalTypeWidth) {
+    return sizeof(int128_t);
+  }
+  if (type.isTimestamp()) {
+    return sizeof(int64_t);
+  }
+  if (type.isTime()) {
+    VELOX_DCHECK(type.equivalent(*TIME()));
+    // TIME is exported as Arrow time32 (int32_t).
+    return sizeof(int32_t);
+  }
+  if ((type.isVarchar() || type.isVarbinary()) && options.exportToStringView) {
+    return sizeof(StringView);
+  }
+
+  return type.cppSizeInBytes();
+}
+
 void gatherFromBuffer(
     const Type& type,
     const Buffer& buf,
@@ -538,7 +559,7 @@ void gatherFromBuffer(
       memcpy(dst + (j++) * sizeof(int128_t), &value, sizeof(int128_t));
     });
   } else {
-    auto typeSize = type.cppSizeInBytes();
+    auto typeSize = getArrowElementSize(type, options);
     rows.apply([&](vector_size_t i) {
       memcpy(dst + (j++) * typeSize, src + i * typeSize, typeSize);
     });
@@ -815,7 +836,7 @@ void exportValues(
   }
 
   // Otherwise we will need a new buffer and copy the data.
-  auto size = getArrowElementSize(type, options);
+  auto size = getArrowElementSize(*type, options);
   auto values = type->isBoolean()
       ? AlignedBuffer::allocate<bool>(out.length, pool)
       : AlignedBuffer::allocate<uint8_t>(
@@ -895,9 +916,11 @@ void exportViews(
   int32_t bufferIdxCache = 0;
   uint64_t bufferAddrCache = 0;
 
+  vector_size_t j = 0;
   rows.apply([&](vector_size_t i) {
+    const auto outputRow = j++;
     auto view = const_cast<uint32_t*>(
-        reinterpret_cast<const uint32_t*>(&utf8Views[2 * i]));
+        reinterpret_cast<const uint32_t*>(&utf8Views[2 * outputRow]));
     if (!vec.isNullAt(i) && view[0] > 12) {
       const uint64_t currAddr = *reinterpret_cast<uint64_t*>(&view[2]);
       // 2. Search for correct index with the buffer-pointer as key. Cache the

--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -1177,10 +1177,12 @@ void flattenAndExport(
   auto flatVector = BaseVector::create<FlatVector<NativeType>>(
       vec.type(), decoded.size(), pool);
 
-  if (decoded.mayHaveNulls() || nulls != nullptr) {
+  const auto mayHaveNulls = decoded.mayHaveNulls();
+  const auto* rawNulls = nulls == nullptr ? nullptr : nulls->as<uint64_t>();
+  if (mayHaveNulls || rawNulls != nullptr) {
     allRows.applyToSelected([&](vector_size_t row) {
-      if ((nulls != nullptr && bits::isBitNull(nulls->as<uint64_t>(), row)) ||
-          (decoded.mayHaveNulls() && decoded.isNullAt(row))) {
+      if ((rawNulls != nullptr && bits::isBitNull(rawNulls, row)) ||
+          (mayHaveNulls && decoded.isNullAt(row))) {
         flatVector->setNull(row, true);
       } else {
         flatVector->set(row, decoded.valueAt<NativeType>(row));
@@ -1222,7 +1224,7 @@ void exportDictionary(
     auto* rawNulls = nulls->as<uint64_t>();
     auto* rawIndices = vec.wrapInfo()->as<vector_size_t>();
     rows.apply([&](vector_size_t i) {
-      if (!bits::isBitNull(rawNulls, i) && !vec.isNullAt(i)) {
+      if (!bits::isBitNull(rawNulls, i)) {
         bits::setNull(rawDictionaryNulls, rawIndices[i], false);
       }
     });
@@ -1327,7 +1329,6 @@ void exportConstant(
     rows.apply([&](vector_size_t i) {
       if (!bits::isBitNull(rawNulls, i)) {
         allRowsNull = false;
-        return;
       }
     });
   }
@@ -1385,6 +1386,10 @@ void exportToArrowImpl(
     ownNulls = vec.nulls();
   }
 
+  // Keep this ArrowArray's validity bitmap aligned with the vector's own nulls.
+  // Parent nulls are only used to mask child/value export.
+  exportValidityBitmap(vec, rows, options, out, pool, *holder);
+
   // Calculate the effective nulls buffer used to skip values masked by parent
   // nodes. Arrow validity for this array still uses only this vector's own
   // nulls.
@@ -1400,7 +1405,6 @@ void exportToArrowImpl(
         vec.size());
     effectiveNulls = std::move(mergedNulls);
   }
-  exportValidityBitmap(vec, rows, options, out, pool, *holder);
 
   switch (vec.encoding()) {
     case VectorEncoding::Simple::FLAT: {

--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -1179,7 +1179,8 @@ void exportDictionary(
     const ArrowOptions& options,
     ArrowArray& out,
     memory::MemoryPool* pool,
-    VeloxToArrowBridgeHolder& holder) {
+    VeloxToArrowBridgeHolder& holder,
+    const BufferPtr& nulls) {
   out.n_buffers = 2;
   out.n_children = 0;
   if (rows.changed()) {
@@ -1190,9 +1191,27 @@ void exportDictionary(
     holder.setBuffer(1, vec.wrapInfo());
   }
   auto& values = *vec.valueVector()->loadedVector();
+  BufferPtr dictionaryNulls;
+  if (nulls != nullptr) {
+    dictionaryNulls =
+        AlignedBuffer::allocate<bool>(values.size(), pool, bits::kNull);
+    auto* rawDictionaryNulls = dictionaryNulls->asMutable<uint64_t>();
+    auto* rawNulls = nulls->as<uint64_t>();
+    auto* rawIndices = vec.wrapInfo()->as<vector_size_t>();
+    rows.apply([&](vector_size_t i) {
+      if (!bits::isBitNull(rawNulls, i)) {
+        bits::setNull(rawDictionaryNulls, rawIndices[i], false);
+      }
+    });
+  }
   out.dictionary = holder.allocateDictionary();
   exportToArrowImpl(
-      values, Selection(values.size()), options, *out.dictionary, pool);
+      values,
+      Selection(values.size()),
+      options,
+      *out.dictionary,
+      pool,
+      dictionaryNulls);
 }
 
 void exportFlattenedVector(
@@ -1266,7 +1285,8 @@ void exportConstant(
     const ArrowOptions& options,
     ArrowArray& out,
     memory::MemoryPool* pool,
-    VeloxToArrowBridgeHolder& holder) {
+    VeloxToArrowBridgeHolder& holder,
+    const BufferPtr& nulls) {
   // As per Arrow spec, REE has zero buffers and two children, `run_ends` and
   // `values`.
   out.n_buffers = 0;
@@ -1275,7 +1295,24 @@ void exportConstant(
   out.n_children = 2;
   holder.resizeChildren(2);
   out.children = holder.getChildrenArrays();
-  exportConstantValue(vec, options, *holder.allocateChild(1), pool);
+
+  // REE (Run-End Encoded) has one value child. Use a null placeholder only
+  // when all selected rows are masked null.
+  bool allRowsNull = nulls != nullptr;
+  if (allRowsNull) {
+    auto* rawNulls = nulls->as<uint64_t>();
+    rows.apply([&](vector_size_t i) {
+      if (!bits::isBitNull(rawNulls, i)) {
+        allRowsNull = false;
+      }
+    });
+  }
+  if (allRowsNull) {
+    auto nullValue = BaseVector::createNullConstant(vec.type(), 1, pool);
+    exportConstantValue(*nullValue, options, *holder.allocateChild(1), pool);
+  } else {
+    exportConstantValue(vec, options, *holder.allocateChild(1), pool);
+  }
 
   // Create the run ends child.
   auto* runEnds = holder.allocateChild(0);
@@ -1323,10 +1360,9 @@ void exportToArrowImpl(
   if (parentNulls != nullptr && ownNulls != nullptr) {
     auto mergedNulls =
         AlignedBuffer::allocate<bool>(vec.size(), pool, bits::kNotNull);
-    bits::copyBits(
-        vec.rawNulls(), 0, mergedNulls->asMutable<uint64_t>(), 0, vec.size());
     bits::andBits(
         mergedNulls->asMutable<uint64_t>(),
+        vec.rawNulls(),
         parentNulls->as<uint64_t>(),
         0,
         vec.size());
@@ -1380,13 +1416,15 @@ void exportToArrowImpl(
       options.flattenDictionary
           ? exportFlattenedVector(
                 vec, rows, options, out, pool, *holder, effectiveNulls)
-          : exportDictionary(vec, rows, options, out, pool, *holder);
+          : exportDictionary(
+                vec, rows, options, out, pool, *holder, effectiveNulls);
       break;
     case VectorEncoding::Simple::CONSTANT:
       options.flattenConstant
           ? exportFlattenedVector(
                 vec, rows, options, out, pool, *holder, effectiveNulls)
-          : exportConstant(vec, rows, options, out, pool, *holder);
+          : exportConstant(
+                vec, rows, options, out, pool, *holder, effectiveNulls);
       break;
     default:
       VELOX_NYI("{} cannot be exported to Arrow yet.", vec.encoding());

--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -1308,10 +1308,17 @@ void exportConstant(
       }
     });
   }
-  if (allRowsNull) {
+  if (rows.count() == 0) {
+    // values.length = 0
+    auto emptyValue = BaseVector::create(vec.type(), 0, pool);
+    exportToArrowImpl(
+        *emptyValue, Selection(0), options, *holder.allocateChild(1), pool);
+  } else if (allRowsNull) {
+    // values.length = 1, values[0] = null
     auto nullValue = BaseVector::createNullConstant(vec.type(), 1, pool);
     exportConstantValue(*nullValue, options, *holder.allocateChild(1), pool);
   } else {
+    // values.length = 1, values[0] = actual constant
     exportConstantValue(vec, options, *holder.allocateChild(1), pool);
   }
 
@@ -1320,7 +1327,7 @@ void exportConstant(
   auto runEndsHolder = std::make_unique<VeloxToArrowBridgeHolder>();
 
   runEnds->buffers = runEndsHolder->getArrowBuffers();
-  runEnds->length = 1;
+  runEnds->length = rows.count() > 0 ? 1 : 0;
   runEnds->offset = 0;
   runEnds->null_count = 0;
   runEnds->n_buffers = 2;
@@ -1330,7 +1337,7 @@ void exportConstant(
 
   // Allocate single runs buffer with the run set as size.
   auto runsBuffer = AlignedBuffer::allocate<int32_t>(1, pool);
-  runsBuffer->asMutable<int32_t>()[0] = vec.size();
+  runsBuffer->asMutable<int32_t>()[0] = rows.count();
   runEndsHolder->setBuffer(1, runsBuffer);
 
   runEnds->private_data = runEndsHolder.release();

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -814,6 +814,28 @@ TEST_F(ArrowBridgeArrayExportTest, parentNullsMaskTimestampOverflow) {
           EXPECT_TRUE(structArray.IsNull(row));
         }
       });
+
+  // ARRAY<CONSTANT<TIMESTAMP>>
+  constant = BaseVector::createConstant(
+      TIMESTAMP(), variant(overflowingTimestamp), 3, pool_.get());
+  auto nulls = AlignedBuffer::allocate<bool>(3, pool_.get(), bits::kNull);
+  vector = std::make_shared<ArrayVector>(
+      pool_.get(),
+      ARRAY(TIMESTAMP()),
+      nulls,
+      3,
+      makeOffsets(),
+      makeSizes(),
+      constant,
+      3);
+  assertExportsWithoutOverflow(
+      vector, [&](const arrow::Array& array, TimestampUnit) {
+        const auto& listArray = dynamic_cast<const arrow::ListArray&>(array);
+        ASSERT_EQ(listArray.null_count(), vector->size());
+        for (int64_t row = 0; row < listArray.length(); ++row) {
+          EXPECT_TRUE(listArray.IsNull(row));
+        }
+      });
 }
 
 TEST_F(ArrowBridgeArrayExportTest, flatTime) {

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -622,10 +622,11 @@ TEST_F(ArrowBridgeArrayExportTest, parentNullsMaskTimestampOverflow) {
   vector->setNullCount(1);
   assertExportsWithoutOverflow(
       vector, [&](const arrow::Array& array, TimestampUnit unit) {
-        const auto& structArray = static_cast<const arrow::StructArray&>(array);
+        const auto& structArray =
+            dynamic_cast<const arrow::StructArray&>(array);
         ASSERT_TRUE(structArray.IsNull(1));
         const auto& values =
-            static_cast<const arrow::TimestampArray&>(*structArray.field(0));
+            dynamic_cast<const arrow::TimestampArray&>(*structArray.field(0));
         assertTimestampValues(values, 0, 2, unit);
       });
 
@@ -636,12 +637,13 @@ TEST_F(ArrowBridgeArrayExportTest, parentNullsMaskTimestampOverflow) {
   vector->setNullCount(1);
   assertExportsWithoutOverflow(
       vector, [&](const arrow::Array& array, TimestampUnit unit) {
-        const auto& structArray = static_cast<const arrow::StructArray&>(array);
+        const auto& structArray =
+            dynamic_cast<const arrow::StructArray&>(array);
         ASSERT_TRUE(structArray.IsNull(1));
         const auto& inner =
-            static_cast<const arrow::StructArray&>(*structArray.field(0));
+            dynamic_cast<const arrow::StructArray&>(*structArray.field(0));
         const auto& values =
-            static_cast<const arrow::TimestampArray&>(*inner.field(0));
+            dynamic_cast<const arrow::TimestampArray&>(*inner.field(0));
         assertTimestampValues(values, 0, 2, unit);
       });
 
@@ -659,12 +661,13 @@ TEST_F(ArrowBridgeArrayExportTest, parentNullsMaskTimestampOverflow) {
   vector->setNullCount(1);
   assertExportsWithoutOverflow(
       vector, [&](const arrow::Array& array, TimestampUnit unit) {
-        const auto& structArray = static_cast<const arrow::StructArray&>(array);
+        const auto& structArray =
+            dynamic_cast<const arrow::StructArray&>(array);
         ASSERT_TRUE(structArray.IsNull(1));
         const auto& listArray =
-            static_cast<const arrow::ListArray&>(*structArray.field(0));
+            dynamic_cast<const arrow::ListArray&>(*structArray.field(0));
         const auto& values =
-            static_cast<const arrow::TimestampArray&>(*listArray.values());
+            dynamic_cast<const arrow::TimestampArray&>(*listArray.values());
         assertTimestampValues(
             values, listArray.value_offset(0), listArray.value_offset(2), unit);
       });
@@ -684,12 +687,13 @@ TEST_F(ArrowBridgeArrayExportTest, parentNullsMaskTimestampOverflow) {
   vector->setNullCount(1);
   assertExportsWithoutOverflow(
       vector, [&](const arrow::Array& array, TimestampUnit unit) {
-        const auto& structArray = static_cast<const arrow::StructArray&>(array);
+        const auto& structArray =
+            dynamic_cast<const arrow::StructArray&>(array);
         ASSERT_TRUE(structArray.IsNull(1));
         const auto& mapArray =
-            static_cast<const arrow::MapArray&>(*structArray.field(0));
+            dynamic_cast<const arrow::MapArray&>(*structArray.field(0));
         const auto& values =
-            static_cast<const arrow::TimestampArray&>(*mapArray.items());
+            dynamic_cast<const arrow::TimestampArray&>(*mapArray.items());
         assertTimestampValues(
             values, mapArray.value_offset(0), mapArray.value_offset(2), unit);
       });
@@ -710,12 +714,12 @@ TEST_F(ArrowBridgeArrayExportTest, parentNullsMaskTimestampOverflow) {
       1);
   assertExportsWithoutOverflow(
       vector, [&](const arrow::Array& array, TimestampUnit unit) {
-        const auto& listArray = static_cast<const arrow::ListArray&>(array);
+        const auto& listArray = dynamic_cast<const arrow::ListArray&>(array);
         ASSERT_TRUE(listArray.IsNull(1));
         const auto& rows =
-            static_cast<const arrow::StructArray&>(*listArray.values());
+            dynamic_cast<const arrow::StructArray&>(*listArray.values());
         const auto& values =
-            static_cast<const arrow::TimestampArray&>(*rows.field(0));
+            dynamic_cast<const arrow::TimestampArray&>(*rows.field(0));
         assertTimestampValues(
             values, listArray.value_offset(0), listArray.value_offset(2), unit);
       });
@@ -736,12 +740,12 @@ TEST_F(ArrowBridgeArrayExportTest, parentNullsMaskTimestampOverflow) {
       1);
   assertExportsWithoutOverflow(
       vector, [&](const arrow::Array& array, TimestampUnit unit) {
-        const auto& mapArray = static_cast<const arrow::MapArray&>(array);
+        const auto& mapArray = dynamic_cast<const arrow::MapArray&>(array);
         ASSERT_TRUE(mapArray.IsNull(1));
         const auto& rows =
-            static_cast<const arrow::StructArray&>(*mapArray.items());
+            dynamic_cast<const arrow::StructArray&>(*mapArray.items());
         const auto& values =
-            static_cast<const arrow::TimestampArray&>(*rows.field(0));
+            dynamic_cast<const arrow::TimestampArray&>(*rows.field(0));
         assertTimestampValues(
             values, mapArray.value_offset(0), mapArray.value_offset(2), unit);
       });
@@ -756,10 +760,11 @@ TEST_F(ArrowBridgeArrayExportTest, parentNullsMaskTimestampOverflow) {
   options_.flattenDictionary = true;
   assertExportsWithoutOverflow(
       vector, [&](const arrow::Array& array, TimestampUnit unit) {
-        const auto& structArray = static_cast<const arrow::StructArray&>(array);
+        const auto& structArray =
+            dynamic_cast<const arrow::StructArray&>(array);
         ASSERT_TRUE(structArray.IsNull(1));
         const auto& values =
-            static_cast<const arrow::TimestampArray&>(*structArray.field(0));
+            dynamic_cast<const arrow::TimestampArray&>(*structArray.field(0));
         assertTimestampValues(values, 0, 2, unit);
       });
   options_.flattenDictionary = false;
@@ -772,15 +777,16 @@ TEST_F(ArrowBridgeArrayExportTest, parentNullsMaskTimestampOverflow) {
   vector->setNullCount(1);
   assertExportsWithoutOverflow(
       vector, [&](const arrow::Array& array, TimestampUnit unit) {
-        const auto& structArray = static_cast<const arrow::StructArray&>(array);
+        const auto& structArray =
+            dynamic_cast<const arrow::StructArray&>(array);
         ASSERT_TRUE(structArray.IsNull(1));
         const auto& dictionaryArray =
-            static_cast<const arrow::DictionaryArray&>(*structArray.field(0));
+            dynamic_cast<const arrow::DictionaryArray&>(*structArray.field(0));
         const auto& dictionaryValues =
-            static_cast<const arrow::TimestampArray&>(
+            dynamic_cast<const arrow::TimestampArray&>(
                 *dictionaryArray.dictionary());
         const auto& dictionaryIndices =
-            static_cast<const arrow::Int32Array&>(*dictionaryArray.indices());
+            dynamic_cast<const arrow::Int32Array&>(*dictionaryArray.indices());
         ASSERT_FALSE(dictionaryIndices.IsNull(0));
         EXPECT_EQ(
             dictionaryValues.Value(dictionaryIndices.Value(0)),
@@ -801,7 +807,8 @@ TEST_F(ArrowBridgeArrayExportTest, parentNullsMaskTimestampOverflow) {
   vector->setNullCount(vector->size());
   assertExportsWithoutOverflow(
       vector, [&](const arrow::Array& array, TimestampUnit) {
-        const auto& structArray = static_cast<const arrow::StructArray&>(array);
+        const auto& structArray =
+            dynamic_cast<const arrow::StructArray&>(array);
         ASSERT_EQ(structArray.null_count(), vector->size());
         for (int64_t row = 0; row < structArray.length(); ++row) {
           EXPECT_TRUE(structArray.IsNull(row));
@@ -1282,6 +1289,25 @@ TEST_F(ArrowBridgeArrayExportTest, dictionarySimple) {
   EXPECT_EQ(values.Value(2), 3);
 }
 
+TEST_F(ArrowBridgeArrayExportTest, dictionaryNullConstantValues) {
+  auto values = BaseVector::createNullConstant(TINYINT(), 2048, pool_.get());
+  auto nulls = AlignedBuffer::allocate<bool>(3, pool_.get(), bits::kNotNull);
+  auto indices = makeBuffer<vector_size_t>({0, 1, 2});
+  auto vec = BaseVector::wrapInDictionary(nulls, indices, 3, values);
+
+  ArrowArray arrowArray;
+  velox::exportToArrow(vec, arrowArray, pool_.get(), options_);
+
+  EXPECT_EQ(vec->size(), arrowArray.length);
+  ASSERT_NE(nullptr, arrowArray.dictionary);
+  EXPECT_EQ(values->size(), arrowArray.dictionary->length);
+  ASSERT_NE(nullptr, arrowArray.release);
+
+  arrowArray.release(&arrowArray);
+  EXPECT_EQ(nullptr, arrowArray.release);
+  EXPECT_EQ(nullptr, arrowArray.private_data);
+}
+
 TEST_F(ArrowBridgeArrayExportTest, dictionaryNested) {
   auto vec = ({
     auto indices = makeBuffer<vector_size_t>({1, 2, 0});
@@ -1330,6 +1356,25 @@ TEST_F(ArrowBridgeArrayExportTest, constants) {
       BaseVector::createNullConstant(TINYINT(), 2048, pool_.get());
   testConstantVector<true, int8_t>(
       vector, std::vector<std::optional<int8_t>>{std::nullopt});
+}
+
+TEST_F(ArrowBridgeArrayExportTest, flattenNullConstant) {
+  options_.flattenConstant = true;
+
+  VectorPtr vector =
+      BaseVector::createNullConstant(TINYINT(), 2048, pool_.get());
+  ArrowArray arrowArray;
+  velox::exportToArrow(vector, arrowArray, pool_.get(), options_);
+
+  EXPECT_EQ(vector->size(), arrowArray.length);
+  EXPECT_EQ(vector->size(), arrowArray.null_count);
+  EXPECT_EQ(2, arrowArray.n_buffers);
+  EXPECT_EQ(0, arrowArray.n_children);
+  ASSERT_NE(nullptr, arrowArray.release);
+
+  arrowArray.release(&arrowArray);
+  EXPECT_EQ(nullptr, arrowArray.release);
+  EXPECT_EQ(nullptr, arrowArray.private_data);
 }
 
 TEST_F(ArrowBridgeArrayExportTest, constantComplex) {

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -558,6 +558,107 @@ TEST_F(ArrowBridgeArrayExportTest, flatTimestamp) {
       VeloxUserError);
 }
 
+TEST_F(ArrowBridgeArrayExportTest, parentNullsMaskTimestampOverflow) {
+  const int64_t overflowingSeconds =
+      std::numeric_limits<int64_t>::max() / 1'000;
+  const auto overflowingTimestamp = Timestamp(overflowingSeconds, 0);
+
+  auto makeTimestampVector = [&]() {
+    return vectorMaker_.flatVector<Timestamp>(
+        {Timestamp(1, 0), overflowingTimestamp, Timestamp(2, 0)});
+  };
+
+  auto makeOffsets = [&]() { return makeBuffer<vector_size_t>({0, 1, 2}); };
+  auto makeSizes = [&]() { return makeBuffer<vector_size_t>({1, 1, 1}); };
+
+  auto assertExportsWithoutOverflow = [&](const VectorPtr& vector) {
+    for (const auto unit : {TimestampUnit::kMicro, TimestampUnit::kNano}) {
+      options_.timestampUnit = unit;
+
+      ArrowArray arrowArray;
+      ASSERT_NO_THROW(
+          velox::exportToArrow(vector, arrowArray, pool_.get(), options_));
+      arrowArray.release(&arrowArray);
+    }
+  };
+
+  VectorPtr vector;
+
+  // ROW<ts: TIMESTAMP>
+  vector = vectorMaker_.rowVector({"ts"}, {makeTimestampVector()});
+  vector->setNull(1, true);
+  vector->setNullCount(1);
+  assertExportsWithoutOverflow(vector);
+
+  // ROW<inner: ROW<ts: TIMESTAMP>>
+  auto innerStruct = vectorMaker_.rowVector({"ts"}, {makeTimestampVector()});
+  vector = vectorMaker_.rowVector({"inner"}, {innerStruct});
+  vector->setNull(1, true);
+  vector->setNullCount(1);
+  assertExportsWithoutOverflow(vector);
+
+  // ROW<items: ARRAY<TIMESTAMP>>
+  auto arrayChild = std::make_shared<ArrayVector>(
+      pool_.get(),
+      ARRAY(TIMESTAMP()),
+      nullptr,
+      3,
+      makeOffsets(),
+      makeSizes(),
+      makeTimestampVector());
+  vector = vectorMaker_.rowVector({"items"}, {arrayChild});
+  vector->setNull(1, true);
+  vector->setNullCount(1);
+  assertExportsWithoutOverflow(vector);
+
+  // ROW<items: MAP<INTEGER, TIMESTAMP>>
+  auto mapChild = std::make_shared<MapVector>(
+      pool_.get(),
+      MAP(INTEGER(), TIMESTAMP()),
+      nullptr,
+      3,
+      makeOffsets(),
+      makeSizes(),
+      vectorMaker_.flatVector<int32_t>({0, 1, 2}),
+      makeTimestampVector());
+  vector = vectorMaker_.rowVector({"items"}, {mapChild});
+  vector->setNull(1, true);
+  vector->setNullCount(1);
+  assertExportsWithoutOverflow(vector);
+
+  // ARRAY<ROW<ts: TIMESTAMP>>
+  auto elements = vectorMaker_.rowVector({"ts"}, {makeTimestampVector()});
+  auto arrayNulls =
+      AlignedBuffer::allocate<bool>(3, pool_.get(), bits::kNotNull);
+  bits::setNull(arrayNulls->asMutable<uint64_t>(), 1, true);
+  vector = std::make_shared<ArrayVector>(
+      pool_.get(),
+      ARRAY(elements->type()),
+      arrayNulls,
+      3,
+      makeOffsets(),
+      makeSizes(),
+      elements,
+      1);
+  assertExportsWithoutOverflow(vector);
+
+  // MAP<INTEGER, ROW<ts: TIMESTAMP>>
+  auto values = vectorMaker_.rowVector({"ts"}, {makeTimestampVector()});
+  auto mapNulls = AlignedBuffer::allocate<bool>(3, pool_.get(), bits::kNotNull);
+  bits::setNull(mapNulls->asMutable<uint64_t>(), 1, true);
+  vector = std::make_shared<MapVector>(
+      pool_.get(),
+      MAP(INTEGER(), values->type()),
+      mapNulls,
+      3,
+      makeOffsets(),
+      makeSizes(),
+      vectorMaker_.flatVector<int32_t>({0, 1, 2}),
+      values,
+      1);
+  assertExportsWithoutOverflow(vector);
+}
+
 TEST_F(ArrowBridgeArrayExportTest, flatTime) {
   std::vector<std::optional<int64_t>> inputData = {
       0L,

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -43,6 +43,22 @@ struct VeloxToArrowType<Timestamp> {
   using type = int64_t;
 };
 
+// Converts timestamp as bigint according to unit.
+int64_t timestampValue(Timestamp timestamp, TimestampUnit unit) {
+  switch (unit) {
+    case TimestampUnit::kSecond:
+      return timestamp.getSeconds();
+    case TimestampUnit::kMilli:
+      return timestamp.toMillis();
+    case TimestampUnit::kMicro:
+      return timestamp.toMicros();
+    case TimestampUnit::kNano:
+      return timestamp.toNanos();
+    default:
+      VELOX_UNREACHABLE();
+  }
+}
+
 class ArrowBridgeArrayExportTest : public testing::Test {
  protected:
   static void SetUpTestCase() {
@@ -169,8 +185,9 @@ class ArrowBridgeArrayExportTest : public testing::Test {
               bits::isBitSet(reinterpret_cast<const uint64_t*>(values), i))
               << "mismatch at index " << i;
         } else if constexpr (std::is_same_v<T, Timestamp>) {
-          EXPECT_TRUE(validateTimestamp(
-              inputData[i].value(), options_.timestampUnit, values[i]))
+          EXPECT_EQ(
+              timestampValue(inputData[i].value(), options_.timestampUnit),
+              values[i])
               << "mismatch at index " << i;
         } else {
           EXPECT_EQ(inputData[i], values[i]) << "mismatch at index " << i;
@@ -376,31 +393,6 @@ class ArrowBridgeArrayExportTest : public testing::Test {
       memory::memoryManager()->addLeafPool()};
   core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};
   facebook::velox::test::VectorMaker vectorMaker_{execCtx_.pool()};
-
- private:
-  // Converts timestamp as bigint according to unit, and compares it with the
-  // actual value.
-  bool
-  validateTimestamp(Timestamp ts, TimestampUnit unit, int64_t actualValue) {
-    int64_t expectedValue;
-    switch (unit) {
-      case TimestampUnit::kSecond:
-        expectedValue = ts.getSeconds();
-        break;
-      case TimestampUnit::kMilli:
-        expectedValue = ts.toMillis();
-        break;
-      case TimestampUnit::kMicro:
-        expectedValue = ts.toMicros();
-        break;
-      case TimestampUnit::kNano:
-        expectedValue = ts.toNanos();
-        break;
-      default:
-        VELOX_UNREACHABLE();
-    }
-    return expectedValue == actualValue;
-  }
 };
 
 TEST_F(ArrowBridgeArrayExportTest, flatNotNull) {
@@ -572,21 +564,6 @@ TEST_F(ArrowBridgeArrayExportTest, parentNullsMaskTimestampOverflow) {
 
   auto makeOffsets = [&]() { return makeBuffer<vector_size_t>({0, 1, 2}); };
   auto makeSizes = [&]() { return makeBuffer<vector_size_t>({1, 1, 1}); };
-
-  auto timestampValue = [](Timestamp timestamp, TimestampUnit unit) {
-    switch (unit) {
-      case TimestampUnit::kSecond:
-        return timestamp.getSeconds();
-      case TimestampUnit::kMilli:
-        return timestamp.toMillis();
-      case TimestampUnit::kMicro:
-        return timestamp.toMicros();
-      case TimestampUnit::kNano:
-        return timestamp.toNanos();
-      default:
-        VELOX_UNREACHABLE();
-    }
-  };
 
   auto assertTimestampValues = [&](const arrow::TimestampArray& values,
                                    vector_size_t firstIndex,
@@ -1420,6 +1397,47 @@ TEST_F(ArrowBridgeArrayExportTest, constants) {
       BaseVector::createNullConstant(TINYINT(), 2048, pool_.get());
   testConstantVector<true, int8_t>(
       vector, std::vector<std::optional<int8_t>>{std::nullopt});
+}
+
+TEST_F(ArrowBridgeArrayExportTest, constantTimestamp) {
+  const auto value = Timestamp(2, 123'456'789);
+
+  for (const auto unit :
+       {TimestampUnit::kSecond,
+        TimestampUnit::kMilli,
+        TimestampUnit::kMicro,
+        TimestampUnit::kNano}) {
+    options_.timestampUnit = unit;
+
+    auto constant =
+        BaseVector::createConstant(TIMESTAMP(), variant(value), 3, pool_.get());
+    auto vector = vectorMaker_.rowVector({"ts"}, {constant});
+    vector->setNull(1, true);
+    vector->setNullCount(1);
+
+    auto array = toArrow(vector, options_, pool_.get());
+    ASSERT_OK(array->ValidateFull());
+
+    const auto& structArray = dynamic_cast<const arrow::StructArray&>(*array);
+    ASSERT_EQ(structArray.null_count(), 1);
+    ASSERT_FALSE(structArray.IsNull(0));
+    ASSERT_TRUE(structArray.IsNull(1));
+    ASSERT_FALSE(structArray.IsNull(2));
+
+    const auto& reeArray =
+        dynamic_cast<const arrow::RunEndEncodedArray&>(*structArray.field(0));
+    const auto& runEnds =
+        dynamic_cast<const arrow::Int32Array&>(*reeArray.run_ends());
+    const auto& values =
+        dynamic_cast<const arrow::TimestampArray&>(*reeArray.values());
+
+    ASSERT_EQ(runEnds.length(), 1);
+    EXPECT_EQ(runEnds.Value(0), static_cast<int32_t>(vector->size()));
+
+    ASSERT_EQ(values.length(), 1);
+    ASSERT_FALSE(values.IsNull(0));
+    EXPECT_EQ(values.Value(0), timestampValue(value, unit));
+  }
 }
 
 TEST_F(ArrowBridgeArrayExportTest, flattenNullConstant) {

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -1176,6 +1176,44 @@ TEST_F(ArrowBridgeArrayExportTest, arrayNested) {
   EXPECT_EQ(values.Value(1), 1);
 }
 
+TEST_F(ArrowBridgeArrayExportTest, arrayStringViewSkipsNullChildRows) {
+  options_.exportToStringView = true;
+
+  auto elements = vectorMaker_.flatVector<StringView>({
+      "short",
+      "masked string longer than inline",
+      "last string longer than inline",
+  });
+  auto nulls = AlignedBuffer::allocate<bool>(3, pool_.get(), bits::kNotNull);
+  bits::setNull(nulls->asMutable<uint64_t>(), 1, true);
+  auto vector = std::make_shared<ArrayVector>(
+      pool_.get(),
+      ARRAY(VARCHAR()),
+      nulls,
+      3,
+      makeBuffer<vector_size_t>({0, 1, 2}),
+      makeBuffer<vector_size_t>({1, 1, 1}),
+      elements,
+      1);
+
+  auto array = toArrow(vector, options_, pool_.get());
+  ASSERT_OK(array->ValidateFull());
+  ASSERT_EQ(*array->type(), *arrow::list(arrow::utf8_view()));
+
+  const auto& listArray = dynamic_cast<const arrow::ListArray&>(*array);
+  ASSERT_EQ(listArray.length(), 3);
+  ASSERT_FALSE(listArray.IsNull(0));
+  ASSERT_TRUE(listArray.IsNull(1));
+  ASSERT_FALSE(listArray.IsNull(2));
+  validateOffsets(listArray, {0, 1, 1, 2});
+
+  const auto& values =
+      dynamic_cast<const arrow::StringViewArray&>(*listArray.values());
+  ASSERT_EQ(values.length(), 2);
+  EXPECT_EQ(values.GetView(0), "short");
+  EXPECT_EQ(values.GetView(1), "last string longer than inline");
+}
+
 TEST_F(ArrowBridgeArrayExportTest, mapSimple) {
   auto allOnes = [](vector_size_t) { return 1; };
   auto vec =

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -561,24 +561,56 @@ TEST_F(ArrowBridgeArrayExportTest, flatTimestamp) {
 TEST_F(ArrowBridgeArrayExportTest, parentNullsMaskTimestampOverflow) {
   const int64_t overflowingSeconds =
       std::numeric_limits<int64_t>::max() / 1'000;
+  const auto firstTimestamp = Timestamp(1, 0);
   const auto overflowingTimestamp = Timestamp(overflowingSeconds, 0);
+  const auto secondTimestamp = Timestamp(2, 0);
 
   auto makeTimestampVector = [&]() {
     return vectorMaker_.flatVector<Timestamp>(
-        {Timestamp(1, 0), overflowingTimestamp, Timestamp(2, 0)});
+        {firstTimestamp, overflowingTimestamp, secondTimestamp});
   };
 
   auto makeOffsets = [&]() { return makeBuffer<vector_size_t>({0, 1, 2}); };
   auto makeSizes = [&]() { return makeBuffer<vector_size_t>({1, 1, 1}); };
 
-  auto assertExportsWithoutOverflow = [&](const VectorPtr& vector) {
+  auto timestampValue = [](Timestamp timestamp, TimestampUnit unit) {
+    switch (unit) {
+      case TimestampUnit::kSecond:
+        return timestamp.getSeconds();
+      case TimestampUnit::kMilli:
+        return timestamp.toMillis();
+      case TimestampUnit::kMicro:
+        return timestamp.toMicros();
+      case TimestampUnit::kNano:
+        return timestamp.toNanos();
+      default:
+        VELOX_UNREACHABLE();
+    }
+  };
+
+  auto assertTimestampValues = [&](const arrow::TimestampArray& values,
+                                   vector_size_t firstIndex,
+                                   vector_size_t secondIndex,
+                                   TimestampUnit unit) {
+    ASSERT_FALSE(values.IsNull(firstIndex));
+    EXPECT_EQ(values.Value(firstIndex), timestampValue(firstTimestamp, unit));
+    ASSERT_FALSE(values.IsNull(secondIndex));
+    EXPECT_EQ(values.Value(secondIndex), timestampValue(secondTimestamp, unit));
+  };
+
+  auto assertExportsWithoutOverflow = [&](const VectorPtr& vector,
+                                          auto validateValues) {
     for (const auto unit : {TimestampUnit::kMicro, TimestampUnit::kNano}) {
       options_.timestampUnit = unit;
 
-      ArrowArray arrowArray;
-      ASSERT_NO_THROW(
-          velox::exportToArrow(vector, arrowArray, pool_.get(), options_));
-      arrowArray.release(&arrowArray);
+      ArrowSchema schema;
+      ArrowArray data;
+      velox::exportToArrow(vector, schema, options_);
+      velox::exportToArrow(vector, data, pool_.get(), options_);
+      EXPECT_OK_AND_ASSIGN(auto type, arrow::ImportType(&schema));
+      EXPECT_OK_AND_ASSIGN(auto arrowArray, arrow::ImportArray(&data, type));
+      ASSERT_OK(arrowArray->ValidateFull());
+      ASSERT_NO_FATAL_FAILURE(validateValues(*arrowArray, unit));
     }
   };
 
@@ -588,14 +620,30 @@ TEST_F(ArrowBridgeArrayExportTest, parentNullsMaskTimestampOverflow) {
   vector = vectorMaker_.rowVector({"ts"}, {makeTimestampVector()});
   vector->setNull(1, true);
   vector->setNullCount(1);
-  assertExportsWithoutOverflow(vector);
+  assertExportsWithoutOverflow(
+      vector, [&](const arrow::Array& array, TimestampUnit unit) {
+        const auto& structArray = static_cast<const arrow::StructArray&>(array);
+        ASSERT_TRUE(structArray.IsNull(1));
+        const auto& values =
+            static_cast<const arrow::TimestampArray&>(*structArray.field(0));
+        assertTimestampValues(values, 0, 2, unit);
+      });
 
   // ROW<inner: ROW<ts: TIMESTAMP>>
   auto innerStruct = vectorMaker_.rowVector({"ts"}, {makeTimestampVector()});
   vector = vectorMaker_.rowVector({"inner"}, {innerStruct});
   vector->setNull(1, true);
   vector->setNullCount(1);
-  assertExportsWithoutOverflow(vector);
+  assertExportsWithoutOverflow(
+      vector, [&](const arrow::Array& array, TimestampUnit unit) {
+        const auto& structArray = static_cast<const arrow::StructArray&>(array);
+        ASSERT_TRUE(structArray.IsNull(1));
+        const auto& inner =
+            static_cast<const arrow::StructArray&>(*structArray.field(0));
+        const auto& values =
+            static_cast<const arrow::TimestampArray&>(*inner.field(0));
+        assertTimestampValues(values, 0, 2, unit);
+      });
 
   // ROW<items: ARRAY<TIMESTAMP>>
   auto arrayChild = std::make_shared<ArrayVector>(
@@ -609,7 +657,17 @@ TEST_F(ArrowBridgeArrayExportTest, parentNullsMaskTimestampOverflow) {
   vector = vectorMaker_.rowVector({"items"}, {arrayChild});
   vector->setNull(1, true);
   vector->setNullCount(1);
-  assertExportsWithoutOverflow(vector);
+  assertExportsWithoutOverflow(
+      vector, [&](const arrow::Array& array, TimestampUnit unit) {
+        const auto& structArray = static_cast<const arrow::StructArray&>(array);
+        ASSERT_TRUE(structArray.IsNull(1));
+        const auto& listArray =
+            static_cast<const arrow::ListArray&>(*structArray.field(0));
+        const auto& values =
+            static_cast<const arrow::TimestampArray&>(*listArray.values());
+        assertTimestampValues(
+            values, listArray.value_offset(0), listArray.value_offset(2), unit);
+      });
 
   // ROW<items: MAP<INTEGER, TIMESTAMP>>
   auto mapChild = std::make_shared<MapVector>(
@@ -624,7 +682,17 @@ TEST_F(ArrowBridgeArrayExportTest, parentNullsMaskTimestampOverflow) {
   vector = vectorMaker_.rowVector({"items"}, {mapChild});
   vector->setNull(1, true);
   vector->setNullCount(1);
-  assertExportsWithoutOverflow(vector);
+  assertExportsWithoutOverflow(
+      vector, [&](const arrow::Array& array, TimestampUnit unit) {
+        const auto& structArray = static_cast<const arrow::StructArray&>(array);
+        ASSERT_TRUE(structArray.IsNull(1));
+        const auto& mapArray =
+            static_cast<const arrow::MapArray&>(*structArray.field(0));
+        const auto& values =
+            static_cast<const arrow::TimestampArray&>(*mapArray.items());
+        assertTimestampValues(
+            values, mapArray.value_offset(0), mapArray.value_offset(2), unit);
+      });
 
   // ARRAY<ROW<ts: TIMESTAMP>>
   auto elements = vectorMaker_.rowVector({"ts"}, {makeTimestampVector()});
@@ -640,7 +708,17 @@ TEST_F(ArrowBridgeArrayExportTest, parentNullsMaskTimestampOverflow) {
       makeSizes(),
       elements,
       1);
-  assertExportsWithoutOverflow(vector);
+  assertExportsWithoutOverflow(
+      vector, [&](const arrow::Array& array, TimestampUnit unit) {
+        const auto& listArray = static_cast<const arrow::ListArray&>(array);
+        ASSERT_TRUE(listArray.IsNull(1));
+        const auto& rows =
+            static_cast<const arrow::StructArray&>(*listArray.values());
+        const auto& values =
+            static_cast<const arrow::TimestampArray&>(*rows.field(0));
+        assertTimestampValues(
+            values, listArray.value_offset(0), listArray.value_offset(2), unit);
+      });
 
   // MAP<INTEGER, ROW<ts: TIMESTAMP>>
   auto values = vectorMaker_.rowVector({"ts"}, {makeTimestampVector()});
@@ -656,7 +734,79 @@ TEST_F(ArrowBridgeArrayExportTest, parentNullsMaskTimestampOverflow) {
       vectorMaker_.flatVector<int32_t>({0, 1, 2}),
       values,
       1);
-  assertExportsWithoutOverflow(vector);
+  assertExportsWithoutOverflow(
+      vector, [&](const arrow::Array& array, TimestampUnit unit) {
+        const auto& mapArray = static_cast<const arrow::MapArray&>(array);
+        ASSERT_TRUE(mapArray.IsNull(1));
+        const auto& rows =
+            static_cast<const arrow::StructArray&>(*mapArray.items());
+        const auto& values =
+            static_cast<const arrow::TimestampArray&>(*rows.field(0));
+        assertTimestampValues(
+            values, mapArray.value_offset(0), mapArray.value_offset(2), unit);
+      });
+
+  // ROW<ts: DICTIONARY<TIMESTAMP>>, flattenDictionary=true
+  auto indices = makeBuffer<vector_size_t>({0, 1, 2});
+  auto dictionary =
+      BaseVector::wrapInDictionary(nullptr, indices, 3, makeTimestampVector());
+  vector = vectorMaker_.rowVector({"ts"}, {dictionary});
+  vector->setNull(1, true);
+  vector->setNullCount(1);
+  options_.flattenDictionary = true;
+  assertExportsWithoutOverflow(
+      vector, [&](const arrow::Array& array, TimestampUnit unit) {
+        const auto& structArray = static_cast<const arrow::StructArray&>(array);
+        ASSERT_TRUE(structArray.IsNull(1));
+        const auto& values =
+            static_cast<const arrow::TimestampArray&>(*structArray.field(0));
+        assertTimestampValues(values, 0, 2, unit);
+      });
+  options_.flattenDictionary = false;
+
+  // ROW<ts: DICTIONARY<TIMESTAMP>>
+  dictionary =
+      BaseVector::wrapInDictionary(nullptr, indices, 3, makeTimestampVector());
+  vector = vectorMaker_.rowVector({"ts"}, {dictionary});
+  vector->setNull(1, true);
+  vector->setNullCount(1);
+  assertExportsWithoutOverflow(
+      vector, [&](const arrow::Array& array, TimestampUnit unit) {
+        const auto& structArray = static_cast<const arrow::StructArray&>(array);
+        ASSERT_TRUE(structArray.IsNull(1));
+        const auto& dictionaryArray =
+            static_cast<const arrow::DictionaryArray&>(*structArray.field(0));
+        const auto& dictionaryValues =
+            static_cast<const arrow::TimestampArray&>(
+                *dictionaryArray.dictionary());
+        const auto& dictionaryIndices =
+            static_cast<const arrow::Int32Array&>(*dictionaryArray.indices());
+        ASSERT_FALSE(dictionaryIndices.IsNull(0));
+        EXPECT_EQ(
+            dictionaryValues.Value(dictionaryIndices.Value(0)),
+            timestampValue(firstTimestamp, unit));
+        ASSERT_FALSE(dictionaryIndices.IsNull(2));
+        EXPECT_EQ(
+            dictionaryValues.Value(dictionaryIndices.Value(2)),
+            timestampValue(secondTimestamp, unit));
+      });
+
+  // ROW<ts: CONSTANT<TIMESTAMP>>
+  auto constant = BaseVector::createConstant(
+      TIMESTAMP(), variant(overflowingTimestamp), 3, pool_.get());
+  vector = vectorMaker_.rowVector({"ts"}, {constant});
+  for (vector_size_t row = 0; row < vector->size(); ++row) {
+    vector->setNull(row, true);
+  }
+  vector->setNullCount(vector->size());
+  assertExportsWithoutOverflow(
+      vector, [&](const arrow::Array& array, TimestampUnit) {
+        const auto& structArray = static_cast<const arrow::StructArray&>(array);
+        ASSERT_EQ(structArray.null_count(), vector->size());
+        for (int64_t row = 0; row < structArray.length(); ++row) {
+          EXPECT_TRUE(structArray.IsNull(row));
+        }
+      });
 }
 
 TEST_F(ArrowBridgeArrayExportTest, flatTime) {

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -757,17 +757,21 @@ TEST_F(ArrowBridgeArrayExportTest, parentNullsMaskTimestampOverflow) {
   vector = vectorMaker_.rowVector({"ts"}, {dictionary});
   vector->setNull(1, true);
   vector->setNullCount(1);
-  options_.flattenDictionary = true;
-  assertExportsWithoutOverflow(
-      vector, [&](const arrow::Array& array, TimestampUnit unit) {
-        const auto& structArray =
-            dynamic_cast<const arrow::StructArray&>(array);
-        ASSERT_TRUE(structArray.IsNull(1));
-        const auto& values =
-            dynamic_cast<const arrow::TimestampArray&>(*structArray.field(0));
-        assertTimestampValues(values, 0, 2, unit);
-      });
-  options_.flattenDictionary = false;
+  {
+    options_.flattenDictionary = true;
+    SCOPE_EXIT {
+      options_.flattenDictionary = false;
+    };
+    assertExportsWithoutOverflow(
+        vector, [&](const arrow::Array& array, TimestampUnit unit) {
+          const auto& structArray =
+              dynamic_cast<const arrow::StructArray&>(array);
+          ASSERT_TRUE(structArray.IsNull(1));
+          const auto& values =
+              dynamic_cast<const arrow::TimestampArray&>(*structArray.field(0));
+          assertTimestampValues(values, 0, 2, unit);
+        });
+  }
 
   // ROW<ts: DICTIONARY<TIMESTAMP>>
   dictionary =


### PR DESCRIPTION
## Summary
Fix Arrow export for nested vectors whose parent row is null but child values are undefined.

When exporting complex Velox vectors to Arrow, child vectors can be visited even for rows masked by a null parent. 

Timestamp export skips conversion for null values, but previously it only considered the child vector's own nulls. This could still convert timestamp values that are unreachable because an ancestor row is null, causing overflow errors when exporting to microsecond or nanosecond Arrow timestamp units.

Fix https://github.com/apache/gluten/issues/11985.

## Changes
- Compute an effective null mask for value export so values hidden by parent nulls are skipped during scalar conversion.
- Update array/map offset export so null parents do not contribute child ranges.
- Make flattened scalar export respect parent null masks.