### PR TITLE
feat: Add partition-based cluster index with LookupRequest API

### DIFF
--- a/velox/connectors/hive/FileIndexReader.cpp
+++ b/velox/connectors/hive/FileIndexReader.cpp
@@ -314,6 +314,10 @@ FileIndexReader::createIndexReader() {
 void FileIndexReader::startLookup(
     const Request& request,
     const Options& options) {
+  // Empty files have no cluster index, so indexReader_ is null.
+  if (indexReader_ == nullptr) {
+    return;
+  }
   VELOX_CHECK(
       !indexReader_->hasNext(),
       "Previous request not finished. Call next() first.");
@@ -410,11 +414,12 @@ serializer::IndexBounds FileIndexReader::buildRequestIndexBounds(
 }
 
 bool FileIndexReader::hasNext() {
-  return indexReader_->hasNext();
+  return indexReader_ != nullptr && indexReader_->hasNext();
 }
 
 std::unique_ptr<FileIndexReader::Result> FileIndexReader::next(
     vector_size_t maxOutputRows) {
+  VELOX_CHECK_NOT_NULL(indexReader_);
   return indexReader_->next(maxOutputRows);
 }
 


### PR DESCRIPTION
Summary:
CONTEXT: The cluster index is being refactored from the old stripe-level StripeLocation lookup to a partition-based architecture with chunk-level precision. This enables both point lookups (for dense index) and range scans (for cluster index) through a unified LookupRequest API.

WHAT:

ClusterIndex API:
- Partition-based ClusterIndex with LookupRequest API (pointLookup/rangeScan factory methods)
- On-demand partition metadata loading with chunk-level key binary search
- Public numPartitions() and partitionSection() accessors
- Separate pointKeys_/rangeBounds_ storage with pointKey()/rangeBound() accessors

Encoding seek API:
- Add seek(value, inclusive) to Encoding — no default for inclusive parameter
- PrefixEncoding: split loops for inclusive/exclusive (no branch per iteration)
- TrivialEncoding: lower_bound vs upper_bound based on inclusive

NimbleIndexProjector refactor:
- Simplify structs: RequestStripeRange -> StripeRequest, StripeLookupResult -> StripeLookup
- Extract pruneStripeRequests() for maxRowsPerRequest filtering
- Inline truncation logic into buildStripeResult(), remove computeStripeRowRanges()
- Remove redundant RequestRange struct

SelectiveNimbleIndexReader refactor:
- Use TabletReader APIs (stripeStartRow/stripeRowCount) instead of building redundant stripeRowOffsets_
- Remove initReadRange() and stripeRowOffsets_ member

TabletReader cleanup:
- Remove redundant stripeRowCounts_ pointer -- compute from stripeRows_ prefix sum
- Rename cumulativeStripeRows_ -> stripeRows_
- Add NIMBLE_CHECK bounds checks to stripeRowCount() and stripeStartRow()

Naming cleanup:
- indexGroups -> indexPartitions across FileLayout, TabletReader, tests
- LoadPartitionMetadataFn -> LoadMetadataFn (in tablet/Callbacks.h)
- LoadKeyStreamFn -> LoadDataFn (in tablet/Callbacks.h)
- IndexTestUtils -> ClusterIndexTestUtils (file rename)
- ClusterIndexWriterTestParam -> ClusterIndexWriterDataTestParam
- Remove dead code: IndexUtils.h (unused resolveRowLocation)

Callback refactor:
- Create tablet/Callbacks.h for load callbacks (LoadMetadataFn, LoadDataFn)
- Write callbacks remain in MetadataBuffer.h for backward compatibility

Test additions:
- ClusterIndexLookupTest parameterized with chunk sizes 1, 3, 9 (18 test cases)
- ClusterIndexWriterChunkTest parameterized with maxRowsPerKeyChunk 0, 1, 32, 1024
- fileLayoutOrdering test verifying physical section ordering
- stripeStartRow/stripeRowCount unit tests with bounds checks
- Update VeloxWriterTest to use new LookupRequest API

Benchmark updates:
- Default maxRowsPerStripe to 1024 in benchmark converter
- Disable rawStripeSize when rows_per_stripe is set in NimbleIndexFileGenerator
- Use VELOX_CHECK in NimbleIndexFileGenerator

Reviewed By: tanjialiang

Differential Revision: D102001733
