### PR TITLE
perf:  Avoid re-hashing overflow rows in parallelJoinBuild (#17330)

### DIFF
--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -1101,14 +1101,26 @@ void HashTable<ignoreNullKeys>::parallelJoinBuild() {
   }
   syncWorkItems(partitionSteps, parallelJoinBuildStats_.partitionTimings, true);
 
-  // The parallel table building step.
+  // The parallel table building step. Each partition collects overflow rows
+  // (rows whose target bucket falls outside its [start, end) range) along
+  // with their hashes, so the final serial re-insertion phase below does
+  // not need to recompute them.
   std::vector<std::vector<char*>> overflowPerPartition(numPartitions);
+  std::vector<std::vector<uint64_t>> overflowHashesPerPartition(numPartitions);
   for (auto i = 0; i < numPartitions; ++i) {
     bool last = i == numPartitions - 1;
     runStep(
         buildSteps,
-        [this, i, &overflowPerPartition, &rowPartitions] {
-          buildJoinPartition(i, rowPartitions, overflowPerPartition[i]);
+        [this,
+         i,
+         &overflowPerPartition,
+         &overflowHashesPerPartition,
+         &rowPartitions] {
+          buildJoinPartition(
+              i,
+              rowPartitions,
+              overflowPerPartition[i],
+              overflowHashesPerPartition[i]);
         },
         // run last partition on current thread to avoid wasting current thread
         // on just waiting
@@ -1174,16 +1186,16 @@ void HashTable<ignoreNullKeys>::parallelJoinBuild() {
     }
   }
 
-  raw_vector<uint64_t> hashes(pool_);
+  // Serially re-insert overflow rows that didn't fit in any partition's
+  // bucket range. Hashes were captured during the parallel build phase, so
+  // we reuse them instead of re-hashing.
   for (auto i = 0; i < numPartitions; ++i) {
     auto& overflows = overflowPerPartition[i];
-    hashes.resize(overflows.size());
-    VELOX_CHECK(hashRows(
-        folly::Range<char**>(overflows.data(), overflows.size()),
-        false,
-        hashes));
-    auto table = i == 0 ? this : otherTables_[i - 1].get();
-    insertForJoin(overflows.data(), hashes.data(), overflows.size(), nullptr);
+    auto& overflowHashes = overflowHashesPerPartition[i];
+    VELOX_CHECK_EQ(overflows.size(), overflowHashes.size());
+    insertForJoin(
+        overflows.data(), overflowHashes.data(), overflows.size(), nullptr);
+    auto* table = i == 0 ? this : otherTables_[i - 1].get();
     VELOX_CHECK_EQ(table->rows()->numRows(), table->numParallelBuildRows_);
   }
 }
@@ -1241,14 +1253,16 @@ template <bool ignoreNullKeys>
 void HashTable<ignoreNullKeys>::buildJoinPartition(
     uint8_t partition,
     const std::vector<std::unique_ptr<RowPartitions>>& rowPartitions,
-    std::vector<char*>& overflow) {
+    std::vector<char*>& overflow,
+    std::vector<uint64_t>& overflowHashes) {
   raw_vector<char*> rows(kHashBatchSize, pool_);
   raw_vector<uint64_t> hashes(kHashBatchSize, pool_);
   const int32_t numPartitions = 1 + otherTables_.size();
   TableInsertPartitionInfo partitionInfo{
       buildPartitionBounds_[partition],
       buildPartitionBounds_[partition + 1],
-      overflow};
+      overflow,
+      overflowHashes};
   for (auto i = 0; i < numPartitions; ++i) {
     auto* table = i == 0 ? this : otherTables_[i - 1].get();
     RowContainerIterator iter;
@@ -1413,7 +1427,7 @@ FOLLY_ALWAYS_INLINE void HashTable<ignoreNullKeys>::buildFullProbe(
       -static_cast<int32_t>(sizeof(normalized_key_t));
   auto insertFn = [&](int32_t /*row*/, PartitionBoundIndexType index) {
     if (partitionInfo != nullptr && !partitionInfo->inRange(index)) {
-      partitionInfo->addOverflow(inserted);
+      partitionInfo->addOverflow(inserted, hash);
       return nullptr;
     }
     storeRowPointer(index, hash, inserted);

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -29,15 +29,22 @@ struct TableInsertPartitionInfo {
   /// ['start', 'end') specifies the insert range of this table partition.
   PartitionBoundIndexType start;
   PartitionBoundIndexType end;
-  /// Used to contains the overflowed rows which can't be inserted into the
-  /// given table partition range.
+  /// Holds overflowed rows that can't be inserted into the given table
+  /// partition range. Re-inserted serially after all partitions finish.
   std::vector<char*>& overflows;
+  /// Hashes of the rows in 'overflows', stored 1:1. Carried through so
+  /// the serial re-insertion phase does not need to re-hash overflow rows.
+  std::vector<uint64_t>& overflowHashes;
 
   TableInsertPartitionInfo(
       PartitionBoundIndexType _start,
       PartitionBoundIndexType _end,
-      std::vector<char*>& _overflows)
-      : start(_start), end(_end), overflows(_overflows) {
+      std::vector<char*>& _overflows,
+      std::vector<uint64_t>& _overflowHashes)
+      : start(_start),
+        end(_end),
+        overflows(_overflows),
+        overflowHashes(_overflowHashes) {
     VELOX_CHECK_GE(start, 0);
     VELOX_CHECK_LT(start, end);
   }
@@ -47,9 +54,10 @@ struct TableInsertPartitionInfo {
     return index >= start && index < end;
   }
 
-  /// Adds 'row' falls outside of this partititon range into 'overflows'.
-  void addOverflow(char* row) {
+  /// Records 'row' (with its already-computed 'hash') as an overflow.
+  void addOverflow(char* row, uint64_t hash) {
     overflows.push_back(row);
+    overflowHashes.push_back(hash);
   }
 };
 
@@ -1002,12 +1010,14 @@ class HashTable : public BaseHashTable {
   void parallelJoinBuild();
 
   // Inserts the rows in 'partition' from this and 'otherTables' into 'this'.
-  // The rows that would have gone past the end of the partition are returned in
-  // 'overflow'.
+  // The rows that would have gone past the end of the partition are returned
+  // in 'overflow', along with their already-computed hashes in
+  // 'overflowHashes' so the caller can re-insert without re-hashing.
   void buildJoinPartition(
       uint8_t partition,
       const std::vector<std::unique_ptr<RowPartitions>>& rowPartitions,
-      std::vector<char*>& overflow);
+      std::vector<char*>& overflow,
+      std::vector<uint64_t>& overflowHashes);
 
   // Assigns a partition to each row of 'subtable' in RowPartitions of
   // subtable's RowContainer. If 'hashMode_' is kNormalizedKeys, records the

--- a/velox/exec/tests/HashTableTest.cpp
+++ b/velox/exec/tests/HashTableTest.cpp
@@ -1297,9 +1297,10 @@ TEST_P(HashTableTest, toStringMultipleKeys) {
 
 TEST(HashTableTest, tableInsertPartitionInfo) {
   std::vector<char*> overflows;
+  std::vector<uint64_t> overflowHashes;
   const auto testFn = [&](PartitionBoundIndexType start,
                           PartitionBoundIndexType end) {
-    TableInsertPartitionInfo info{start, end, overflows};
+    TableInsertPartitionInfo info{start, end, overflows, overflowHashes};
   };
   struct {
     PartitionBoundIndexType start;
@@ -1315,8 +1316,9 @@ TEST(HashTableTest, tableInsertPartitionInfo) {
     VELOX_ASSERT_THROW(testFn(badData.start, badData.end), "");
   }
   ASSERT_TRUE(overflows.empty());
+  ASSERT_TRUE(overflowHashes.empty());
 
-  TableInsertPartitionInfo info{1, 1000, overflows};
+  TableInsertPartitionInfo info{1, 1000, overflows, overflowHashes};
   ASSERT_TRUE(info.inRange(1));
   ASSERT_FALSE(info.inRange(0));
   ASSERT_FALSE(info.inRange(-1));
@@ -1324,17 +1326,23 @@ TEST(HashTableTest, tableInsertPartitionInfo) {
   ASSERT_FALSE(info.inRange(1'000));
   ASSERT_FALSE(info.inRange(12'000));
   ASSERT_TRUE(overflows.empty());
+  ASSERT_TRUE(overflowHashes.empty());
 
   const std::vector<uint64_t> insertBuffers{100, 200, 300, 500};
-  for (const auto insertBuffer : insertBuffers) {
-    info.addOverflow(reinterpret_cast<char*>(insertBuffer));
+  const std::vector<uint64_t> insertHashes{0xAA, 0xBB, 0xCC, 0xDD};
+  for (int i = 0; i < insertBuffers.size(); ++i) {
+    info.addOverflow(
+        reinterpret_cast<char*>(insertBuffers[i]), insertHashes[i]);
   }
   ASSERT_EQ(overflows.size(), insertBuffers.size());
+  ASSERT_EQ(overflowHashes.size(), insertHashes.size());
   for (int i = 0; i < insertBuffers.size(); ++i) {
     ASSERT_EQ(insertBuffers[i], reinterpret_cast<uint64_t>(info.overflows[i]));
+    ASSERT_EQ(insertHashes[i], info.overflowHashes[i]);
   }
   for (int i = 0; i < overflows.size(); ++i) {
     ASSERT_EQ(overflows[i], info.overflows[i]);
+    ASSERT_EQ(overflowHashes[i], info.overflowHashes[i]);
   }
 }
 } // namespace facebook::velox::exec::test


### PR DESCRIPTION
Summary:

After all parallel workers finish, the serial overflow re-insertion loop in `parallelJoinBuild` re-hashes every overflow row from scratch via another `hashRows` call before inserting it into the table. 
That re-hash is pure waste — the hash was already computed microseconds earlier in `buildJoinPartition` and discarded. 
One redundant hashRows() call eliminated,

Reviewed By: tanjialiang

Differential Revision: D102363737


