### PR TITLE
Enable Pyrefly in fbcode/velox

### DIFF
--- a/python/pyvelox/utils/data_generator.py
+++ b/python/pyvelox/utils/data_generator.py
@@ -68,6 +68,7 @@ def generate_tpch_data(
     plan_builder.tpch_gen(
         table_name=table,
         connector_id=TPCH_CONNECTOR_NAME,
+        # pyrefly: ignore [bad-argument-type]
         scale_factor=scale_factor,
         num_parts=num_files,
     ).table_write(

--- a/python/test/test_arrow.py
+++ b/python/test/test_arrow.py
@@ -24,9 +24,11 @@ from pyvelox.vector import Vector
 class TestPyVeloxArrow(unittest.TestCase):
     def test_vector_simple(self):
         array = pyarrow.array([1, 2, 3, 4, 5, 6])
+        # pyrefly: ignore [bad-argument-type]
         vector = to_velox(array)
 
         self.assertTrue(isinstance(vector, Vector))
+        # pyrefly: ignore [bad-argument-type]
         self.assertEqual(len(vector), 6)
 
         # TODO: For now we only return the values as strings for printing.
@@ -35,6 +37,7 @@ class TestPyVeloxArrow(unittest.TestCase):
 
     def test_roundtrip(self):
         array = pyarrow.array([2, 2, 3, 4, 4, 0])
+        # pyrefly: ignore [bad-argument-type]
         array2 = to_arrow(to_velox(array))
 
         self.assertTrue(isinstance(array2, pyarrow.Array))
@@ -42,6 +45,7 @@ class TestPyVeloxArrow(unittest.TestCase):
 
     def test_struct_roundtrip(self):
         struct_array = pyarrow.StructArray.from_arrays(
+            # pyrefly: ignore [bad-argument-type]
             [
                 pyarrow.array([1, 2, 3]),
                 pyarrow.array(["a", "b", "c"]),
@@ -64,10 +68,12 @@ class TestPyVeloxArrow(unittest.TestCase):
             names=["col1", "col2"],
         )
         vector = to_velox(record_batch)
+        # pyrefly: ignore [missing-attribute]
         self.assertEqual(str(vector.type()), "ROW<col1:BIGINT,col2:VARCHAR>")
 
         struct_array = to_arrow(vector)
         self.assertTrue(isinstance(struct_array, pyarrow.StructArray))
+        # pyrefly: ignore [missing-attribute]
         self.assertEqual(struct_array, record_batch.to_struct_array())
 
     def test_empty(self):

--- a/python/test/test_debugger_runner.py
+++ b/python/test/test_debugger_runner.py
@@ -111,6 +111,7 @@ class TestPyVeloxDebuggerRunner(unittest.TestCase):
         # Create data with some duplicates for aggregation.
         values = [i % 10 for i in range(batch_size)]
         array = pyarrow.array(values)
+        # pyrefly: ignore [bad-argument-type]
         batch = pyarrow.record_batch([array], names=["c0"])
         vector = to_velox(batch)
 
@@ -126,19 +127,26 @@ class TestPyVeloxDebuggerRunner(unittest.TestCase):
         it = runner.execute()
 
         # Get aggregate first input, 100 records.
+        # pyrefly: ignore [missing-attribute]
         it.step()
+        # pyrefly: ignore [missing-attribute]
         self.assertEqual(it.current().size(), 100)
 
         # Get aggregate second input, 100 records.
+        # pyrefly: ignore [missing-attribute]
         it.step()
+        # pyrefly: ignore [missing-attribute]
         self.assertEqual(it.current().size(), 100)
 
         # Ignore next aggregate input and move to the task output, 10 records.
+        # pyrefly: ignore [missing-attribute]
         it.next()
+        # pyrefly: ignore [missing-attribute]
         self.assertEqual(it.current().size(), 10)
 
         # Should be done now.
         with self.assertRaises(StopIteration):
+            # pyrefly: ignore [missing-attribute]
             it.next()
 
     def test_iterator_at(self):
@@ -147,34 +155,52 @@ class TestPyVeloxDebuggerRunner(unittest.TestCase):
         runner.set_breakpoint(self._node_ids[8])
 
         it = runner.execute()
+        # pyrefly: ignore [missing-attribute]
         self.assertEqual(it.at(), "")
 
+        # pyrefly: ignore [missing-attribute]
         it.step()
+        # pyrefly: ignore [missing-attribute]
         self.assertEqual(it.at(), self._node_ids[3])
 
+        # pyrefly: ignore [missing-attribute]
         it.step()
+        # pyrefly: ignore [missing-attribute]
         self.assertEqual(it.at(), self._node_ids[8])
 
+        # pyrefly: ignore [missing-attribute]
         it.step()
+        # pyrefly: ignore [missing-attribute]
         self.assertEqual(it.at(), "")
 
+        # pyrefly: ignore [missing-attribute]
         it.step()
+        # pyrefly: ignore [missing-attribute]
         self.assertEqual(it.at(), self._node_ids[3])
 
+        # pyrefly: ignore [missing-attribute]
         it.next()
+        # pyrefly: ignore [missing-attribute]
         self.assertEqual(it.at(), "")
 
+        # pyrefly: ignore [missing-attribute]
         it.next()
+        # pyrefly: ignore [missing-attribute]
         self.assertEqual(it.at(), "")
 
+        # pyrefly: ignore [missing-attribute]
         it.step()
+        # pyrefly: ignore [missing-attribute]
         self.assertEqual(it.at(), self._node_ids[3])
 
     def test_hook_always_stop(self):
         """Hook that always returns True should behave like set_breakpoint."""
         runner = LocalDebuggerRunner(self._plan_node)
+        # pyrefly: ignore [missing-attribute]
         runner.set_hook(self._node_ids[3], lambda v: True)
+        # pyrefly: ignore [missing-attribute]
         runner.set_hook(self._node_ids[5], lambda v: True)
+        # pyrefly: ignore [missing-attribute]
         runner.set_hook(self._node_ids[8], lambda v: True)
         self.assertEqual(
             self._count_step(runner), self._batch_size * self._num_batches * 4
@@ -183,8 +209,11 @@ class TestPyVeloxDebuggerRunner(unittest.TestCase):
     def test_hook_never_stop(self):
         """Hook that always returns False should skip the breakpoint."""
         runner = LocalDebuggerRunner(self._plan_node)
+        # pyrefly: ignore [missing-attribute]
         runner.set_hook(self._node_ids[3], lambda v: False)
+        # pyrefly: ignore [missing-attribute]
         runner.set_hook(self._node_ids[5], lambda v: False)
+        # pyrefly: ignore [missing-attribute]
         runner.set_hook(self._node_ids[8], lambda v: False)
         # Since all hooks return False, step() should behave like next()
         self.assertEqual(self._count_step(runner), self._batch_size * self._num_batches)
@@ -202,6 +231,7 @@ class TestPyVeloxDebuggerRunner(unittest.TestCase):
             # Stop only on odd calls.
             return call_count % 2 == 1
 
+        # pyrefly: ignore [missing-attribute]
         runner.set_hook(self._node_ids[5], conditional_hook)
 
         # The hook is called for each batch (10 batches).
@@ -218,9 +248,11 @@ class TestPyVeloxDebuggerRunner(unittest.TestCase):
         runner.set_breakpoint(self._node_ids[3])
 
         # set_hook that never stops.
+        # pyrefly: ignore [missing-attribute]
         runner.set_hook(self._node_ids[5], lambda v: False)
 
         # set_hook that always stops.
+        # pyrefly: ignore [missing-attribute]
         runner.set_hook(self._node_ids[8], lambda v: True)
 
         # node_ids[3] stops (10 batches), node_ids[8] stops (10 batches),
@@ -239,6 +271,7 @@ class TestPyVeloxDebuggerRunner(unittest.TestCase):
             received_sizes.append(vector.size())
             return True
 
+        # pyrefly: ignore [missing-attribute]
         runner.set_hook(self._node_ids[5], inspect_hook)
 
         it = runner.execute()
@@ -246,6 +279,7 @@ class TestPyVeloxDebuggerRunner(unittest.TestCase):
         # Consume all output.
         while True:
             try:
+                # pyrefly: ignore [missing-attribute]
                 it.step()
             except StopIteration:
                 break
@@ -266,17 +300,23 @@ class TestPyVeloxDebuggerRunner(unittest.TestCase):
 
         # Step targeting node_ids[5] should skip node_ids[3] and stop at
         # node_ids[5].
+        # pyrefly: ignore [missing-attribute]
         it.step(self._node_ids[5])
+        # pyrefly: ignore [missing-attribute]
         self.assertEqual(it.at(), self._node_ids[5])
 
         # Step targeting node_ids[8] should skip node_ids[5] (remaining) and
         # stop at node_ids[8].
+        # pyrefly: ignore [missing-attribute]
         it.step(self._node_ids[8])
+        # pyrefly: ignore [missing-attribute]
         self.assertEqual(it.at(), self._node_ids[8])
 
         # Step with no filter (default) stops at the next breakpoint or task
         # output.
+        # pyrefly: ignore [missing-attribute]
         it.step()
+        # pyrefly: ignore [missing-attribute]
         self.assertEqual(it.at(), "")
 
     def test_step_with_plan_id_counts(self):
@@ -292,6 +332,7 @@ class TestPyVeloxDebuggerRunner(unittest.TestCase):
         # Only step to node_ids[5], skipping node_ids[3].
         while True:
             try:
+                # pyrefly: ignore [missing-attribute]
                 vector = it.step(self._node_ids[5])
                 total_size += vector.size()
             except StopIteration:

--- a/python/test/test_plan_builder.py
+++ b/python/test/test_plan_builder.py
@@ -45,8 +45,10 @@ class TestPyVeloxPlanBuidler(unittest.TestCase):
 
         # Filter.
         self.assertRaises(
+            # pyrefly: ignore [missing-attribute]
             RuntimeError, plan_builder.filter, "c0 > 1"
         )  # c0 non-existent.
+        # pyrefly: ignore [missing-attribute]
         plan_builder.filter("d0 - 10 > 100")
         filter_node = plan_builder.get_plan_node()
         self.assertEqual(filter_node.name(), "Filter")
@@ -86,6 +88,7 @@ class TestPyVeloxPlanBuidler(unittest.TestCase):
 
     def test_plan_serialization(self):
         plan_builder = (
+            # pyrefly: ignore [missing-attribute]
             PlanBuilder()
             .table_scan(ROW(["c0"], [BIGINT()]))
             .project(["c0 + 1 AS d0", "100"])

--- a/python/test/test_runner.py
+++ b/python/test/test_runner.py
@@ -41,6 +41,7 @@ class TestPyVeloxRunner(unittest.TestCase):
         unregister_all()
 
     def test_empty(self):
+        # pyrefly: ignore [missing-argument]
         plan_builder = PlanBuilder().values()
         runner = LocalRunner(plan_builder.get_plan_node())
         total_size = 0
@@ -51,12 +52,14 @@ class TestPyVeloxRunner(unittest.TestCase):
 
     def test_not_executed(self):
         # Ensure it won't hang on destruction when it was not executed.
+        # pyrefly: ignore [missing-argument]
         plan_builder = PlanBuilder().values()
         LocalRunner(plan_builder.get_plan_node())
 
     def test_execute_twice(self):
         # Ensure a runner can be executed twice.
         vector = to_velox(
+            # pyrefly: ignore [bad-argument-type]
             pyarrow.record_batch([pyarrow.array(list(range(10)))], names=["c0"])
         )
 
@@ -80,6 +83,7 @@ class TestPyVeloxRunner(unittest.TestCase):
 
         for i in range(num_batches):
             array = pyarrow.array(list(range(i * batch_size, (i + 1) * batch_size)))
+            # pyrefly: ignore [bad-argument-type]
             batch = pyarrow.record_batch([array], names=["c0"])
             vectors.append(to_velox(batch))
 
@@ -98,10 +102,12 @@ class TestPyVeloxRunner(unittest.TestCase):
 
         for i in range(num_batches):
             array = pyarrow.array(list(range(i * batch_size, (i + 1) * batch_size)))
+            # pyrefly: ignore [bad-argument-type]
             batch = pyarrow.record_batch([array], names=["c0"])
             vectors.append(to_velox(batch))
 
         plan_builder = (
+            # pyrefly: ignore [missing-attribute]
             PlanBuilder().values(vectors).order_by(["c0 DESC"]).limit(5, offset=2)
         )
         runner = LocalRunner(plan_builder.get_plan_node())
@@ -111,6 +117,7 @@ class TestPyVeloxRunner(unittest.TestCase):
         self.assertRaises(StopIteration, next, iterator)
 
         expected_result = to_velox(
+            # pyrefly: ignore [bad-argument-type]
             pyarrow.record_batch([pyarrow.array([97, 96, 95, 94, 93])], names=["c0"])
         )
         self.assertEqual(output, expected_result)
@@ -118,6 +125,7 @@ class TestPyVeloxRunner(unittest.TestCase):
     def test_mark_sorted(self):
         # Sorted data: marker column should be all True.
         vector = to_velox(
+            # pyrefly: ignore [bad-argument-type]
             pyarrow.record_batch([pyarrow.array([1, 2, 3, 4, 5])], names=["c0"])
         )
 
@@ -143,6 +151,7 @@ class TestPyVeloxRunner(unittest.TestCase):
     def test_mark_sorted_unsorted(self):
         # Unsorted data: row at index 2 breaks sort order (3 -> 2).
         vector = to_velox(
+            # pyrefly: ignore [bad-argument-type]
             pyarrow.record_batch([pyarrow.array([1, 3, 2, 4, 5])], names=["c0"])
         )
 
@@ -172,9 +181,11 @@ class TestPyVeloxRunner(unittest.TestCase):
         random.shuffle(build)
 
         probe_vector = to_velox(
+            # pyrefly: ignore [bad-argument-type]
             pyarrow.record_batch([pyarrow.array(probe)], names=["c0"])
         )
         build_vector = to_velox(
+            # pyrefly: ignore [bad-argument-type]
             pyarrow.record_batch([pyarrow.array(build)], names=["c1"])
         )
 
@@ -187,6 +198,7 @@ class TestPyVeloxRunner(unittest.TestCase):
             ),
             output=["c0"],
         )
+        # pyrefly: ignore [missing-argument]
         plan_builder.aggregate(aggregations=["sum(c0)"])
 
         runner = LocalRunner(plan_builder.get_plan_node())
@@ -202,9 +214,11 @@ class TestPyVeloxRunner(unittest.TestCase):
     def test_merge_join(self):
         batch_size = 10
         array = pyarrow.array([42] * batch_size)
+        # pyrefly: ignore [bad-argument-type]
         batch = to_velox(pyarrow.record_batch([array], names=["c0"]))
 
         plan_builder = PlanBuilder()
+        # pyrefly: ignore [missing-attribute]
         plan_builder.values([batch]).merge_join(
             left_keys=["c0"],
             right_keys=["c0"],
@@ -222,9 +236,11 @@ class TestPyVeloxRunner(unittest.TestCase):
 
     def test_merge_sort(self):
         array = pyarrow.array([0, 1, 2, 3, 4])
+        # pyrefly: ignore [bad-argument-type]
         batch = to_velox(pyarrow.record_batch([array], names=["c0"]))
 
         plan_builder = PlanBuilder()
+        # pyrefly: ignore [missing-attribute]
         plan_builder.sorted_merge(
             keys=["c0"],
             sources=(
@@ -242,6 +258,7 @@ class TestPyVeloxRunner(unittest.TestCase):
         expected = to_velox(
             pyarrow.record_batch(
                 [pyarrow.array([0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4])],
+                # pyrefly: ignore [bad-argument-type]
                 names=["c0"],
             )
         )
@@ -252,6 +269,7 @@ class TestPyVeloxRunner(unittest.TestCase):
         base = list(range(batch_size))
 
         input_vector = to_velox(
+            # pyrefly: ignore [bad-argument-type]
             pyarrow.record_batch([pyarrow.array([base])], names=["c0"])
         )
         # Single row containing an array column with `batch_size` elements.
@@ -299,11 +317,13 @@ class TestPyVeloxRunner(unittest.TestCase):
     def test_write_read_file(self):
         # Test writing a batch of data to a dwrf file on disk, then
         # reading it back.
+        # pyrefly: ignore [missing-argument]
         register_hive()
 
         # Generate input data.
         batch_size = 10
         array = pyarrow.array([42] * batch_size)
+        # pyrefly: ignore [bad-argument-type]
         input_batch = to_velox(pyarrow.record_batch([array], names=["c0"]))
 
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -376,6 +396,7 @@ class TestPyVeloxRunner(unittest.TestCase):
             plan_builder.tpch_gen(
                 table_name="lineitem",
                 connector_id="tpch",
+                # pyrefly: ignore [bad-argument-type]
                 scale_factor=0.001,
                 num_parts=num_output_files,
                 columns=["l_orderkey", "l_partkey", "l_quantity", "l_comment"],

--- a/python/test/test_vector2.py
+++ b/python/test/test_vector2.py
@@ -25,12 +25,15 @@ from pyvelox.vector import restore_from_file
 
 class TestPyVeloxVector(unittest.TestCase):
     def test_vector_size(self):
+        # pyrefly: ignore [bad-argument-type]
         vector = to_velox(pyarrow.array([1, 2, 3, 4, 5, 6]))
+        # pyrefly: ignore [bad-argument-type]
         self.assertEqual(len(vector), 6)
         self.assertEqual(vector.size(), 6)
 
     def test_vector_nulls(self):
         data = [1, 2, None, 4, 5, 6, None, 9, 10]
+        # pyrefly: ignore [bad-argument-type]
         vector = to_velox(pyarrow.array(data))
         self.assertEqual(vector.null_count(), 2)
 
@@ -42,24 +45,29 @@ class TestPyVeloxVector(unittest.TestCase):
 
     def test_vector_compare(self):
         data = [1, 2, 3, 4, 5, 6, 7, 9, 10]
+        # pyrefly: ignore [bad-argument-type]
         vector1 = to_velox(pyarrow.array(data))
         vector2 = to_velox(to_arrow(vector1))
 
         # First compare each element.
         for i in range(len(data)):
+            # pyrefly: ignore [missing-attribute]
             self.assertEqual(vector1.compare(vector2, i, i), 0)
 
         # Then the entire objects at once (__eq__).
         self.assertEqual(vector1, vector2)
 
         # Failures.
+        # pyrefly: ignore [bad-argument-type]
         vector3 = to_velox(pyarrow.array([1, 2, 3, 4, 5]))
         self.assertNotEqual(vector1, vector3)
 
+        # pyrefly: ignore [bad-argument-type]
         vector4 = to_velox(pyarrow.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))
         self.assertNotEqual(vector1, vector4)
 
     def test_vector_print(self):
+        # pyrefly: ignore [bad-argument-type]
         vector = to_velox(pyarrow.array([1, 2]))
 
         expected_header = "[FLAT BIGINT: 2 elements, no nulls]"
@@ -72,12 +80,14 @@ class TestPyVeloxVector(unittest.TestCase):
     def test_vector_complex(self):
         # Array/lists.
         data = [[1, 2, 3], [4, None, 6], None, [7]]
+        # pyrefly: ignore [bad-argument-type]
         vector = to_velox(pyarrow.array(data))
         self.assertEqual(str(vector), "[ARRAY ARRAY<BIGINT>: 4 elements, 1 nulls]")
 
         # Maps.
         data = [[{"key": "a", "value": 1}, {"key": "b", "value": 2}]]
         map_type = pyarrow.map_(pyarrow.string(), pyarrow.int32())
+        # pyrefly: ignore [bad-argument-type]
         vector = to_velox(pyarrow.array(data, type=map_type))
         self.assertEqual(
             str(vector), "[MAP MAP<VARCHAR,INTEGER>: 1 elements, no nulls]"
@@ -85,9 +95,11 @@ class TestPyVeloxVector(unittest.TestCase):
 
         # Row/structs.
         struct_type = pyarrow.struct(
+            # pyrefly: ignore [bad-argument-type]
             [("name", pyarrow.string()), ("age", pyarrow.int32())]
         )
         data = [{"name": "John", "age": 23}, {"name": "Mike", "age": 32}]
+        # pyrefly: ignore [bad-argument-type]
         vector = to_velox(pyarrow.array(data, type=struct_type))
         self.assertEqual(
             str(vector), "[ROW ROW<name:VARCHAR,age:INTEGER>: 2 elements, no nulls]"
@@ -103,12 +115,15 @@ class TestPyVeloxVector(unittest.TestCase):
 
     def test_vector_type(self):
         data = [1.9, 2.45]
+        # pyrefly: ignore [bad-argument-type]
         vector = to_velox(pyarrow.array(data))
+        # pyrefly: ignore [missing-attribute]
         self.assertEqual(vector.type(), DOUBLE())
 
     def test_vector_save_restore(self):
         input_vector = to_velox(
             pyarrow.StructArray.from_arrays(
+                # pyrefly: ignore [bad-argument-type]
                 [
                     pyarrow.array([1, 2, 3]),
                     pyarrow.array(["a", "b", "c"]),


### PR DESCRIPTION
Summary:
Automated migration to enable Pyrefly type checking for `fbcode/velox`.

- Added `python.set_pyrefly(True)` to PACKAGE file
- Suppressed pre-existing type errors

Pyrefly is Meta's next-generation Python type checker, replacing Pyre.

If you encounter issues, you can revert the PACKAGE change by removing
the `python.set_pyrefly(True)` line.
#pyreupgrade

Differential Revision: D102366937


