### PR TITLE
fix: Remove misleading comments for parallel hash table build (#17340)

### DIFF
--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -906,8 +906,6 @@ bool HashBuild::finishHashBuild() {
     pool()->release();
   };
 
-  // TODO: Re-enable parallel join build with spilling triggered after
-  //  https://github.com/facebookincubator/velox/issues/3567 is fixed.
   CpuWallTiming timing;
   {
     CpuWallTimer cpuWallTimer{timing};


### PR DESCRIPTION
Summary:

the todo comment is misleading. 
When spill has been triggered, the table is empty — reclaim() extracts all rows into spill files and clears the table to free memory. Parallel join build reads from the table, not from spill  files, so there is nothing to parallelize.

Differential Revision: D102408236


