### PR TITLE
fix(build): Fix for Presto build

### DIFF
--- a/velox/common/config/CMakeLists.txt
+++ b/velox/common/config/CMakeLists.txt
@@ -26,4 +26,4 @@ velox_add_library(
   ConfigProperty.h
   ConfigProvider.h
 )
-velox_link_libraries(velox_config_property PUBLIC velox_enums velox_exception)
+velox_link_libraries(velox_config_property PUBLIC velox_enum_declare velox_enum_define velox_exception)


### PR DESCRIPTION
Use the two new lib names in link of `libvelox_config_property`.

This was likely missed from #17239 as it does not seem to affect the Velox build, but does break Presto.