### PR TITLE
feat(cursor): Honor outputPool and copyResult in SingleThreadedTaskCursor (#17343)

### DIFF
--- a/velox/exec/Cursor.cpp
+++ b/velox/exec/Cursor.cpp
@@ -454,7 +454,12 @@ class MultiThreadedTaskCursor : public TaskCursorBase {
 class SingleThreadedTaskCursor : public TaskCursorBase {
  public:
   explicit SingleThreadedTaskCursor(const CursorParameters& params)
-      : TaskCursorBase(params, nullptr) {
+      : TaskCursorBase(params, nullptr),
+        outputPool_{
+            (params.outputPool != nullptr || !params.copyResult)
+                ? params.outputPool
+                : memory::memoryManager()->addLeafPool()},
+        copyResult_{params.copyResult} {
     VELOX_CHECK(params.serialExecution);
     VELOX_CHECK(
         !queryCtx_->isExecutorSupplied(),
@@ -509,7 +514,13 @@ class SingleThreadedTaskCursor : public TaskCursorBase {
       ContinueFuture future = ContinueFuture::makeEmpty();
       RowVectorPtr next = task_->next(&future);
       if (next != nullptr) {
-        current_ = next;
+        if (outputPool_ && copyResult_) {
+          VectorPtr copy = encodedVectorCopy(
+              {.pool = outputPool_.get(), .reuseSource = false}, next);
+          current_ = std::static_pointer_cast<RowVector>(std::move(copy));
+        } else {
+          current_ = next;
+        }
         return true;
       }
       // When next is returned from task as a null pointer.
@@ -549,6 +560,8 @@ class SingleThreadedTaskCursor : public TaskCursorBase {
 
  private:
   std::shared_ptr<exec::Task> task_;
+  std::shared_ptr<memory::MemoryPool> outputPool_;
+  bool copyResult_{false};
   bool noMoreSplits_{false};
   RowVectorPtr current_;
   std::exception_ptr error_;

--- a/velox/exec/Cursor.h
+++ b/velox/exec/Cursor.h
@@ -45,10 +45,10 @@ struct CursorParameters {
 
   uint64_t bufferedBytes{512 * 1024};
 
-  /// An optional memory pool to be used to allocate vectors returned by
-  /// MultiThreadedTaskCursor. A new pool is created if not specified.
-  ///
-  /// Only used if serialExecution is false.
+  /// An optional memory pool to be used to allocate vectors returned by the
+  /// task cursor. If null and `copyResult` is true, the cursor creates a new
+  /// leaf pool internally. If `copyResult` is false, vectors are returned
+  /// without copy and outputPool is ignored.
   std::shared_ptr<memory::MemoryPool> outputPool;
 
   /// Ungrouped (by default) or grouped (bucketed) execution.

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -1061,6 +1061,43 @@ TEST_F(TaskTest, serialExecution) {
   VELOX_ASSERT_THROW(executeSerial(plan), "division by zero");
 }
 
+TEST_F(TaskTest, serialExecutionOutputPool) {
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>(10, [](auto row) { return row; }),
+  });
+
+  auto outputPool =
+      memory::memoryManager()->addLeafPool("serialExecutionOutputPool");
+
+  CursorParameters params;
+  params.serialExecution = true;
+  params.outputPool = outputPool;
+  params.planNode = PlanBuilder().values({data}).planNode();
+
+  auto cursor = TaskCursor::create(params);
+  ASSERT_TRUE(cursor->moveNext());
+  EXPECT_EQ(cursor->current()->pool(), outputPool.get());
+}
+
+TEST_F(TaskTest, serialExecutionOutputPoolZeroCopy) {
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>(10, [](auto row) { return row; }),
+  });
+
+  auto outputPool =
+      memory::memoryManager()->addLeafPool("serialExecutionOutputPoolZeroCopy");
+
+  CursorParameters params;
+  params.serialExecution = true;
+  params.outputPool = outputPool;
+  params.copyResult = false;
+  params.planNode = PlanBuilder().values({data}).planNode();
+
+  auto cursor = TaskCursor::create(params);
+  ASSERT_TRUE(cursor->moveNext());
+  EXPECT_NE(cursor->current()->pool(), outputPool.get());
+}
+
 // The purpose of the test is to check the running task list APIs.
 TEST_F(TaskTest, runningTaskList) {
   const auto data = makeRowVector({

--- a/velox/type/tz/TimeZoneMap.cpp
+++ b/velox/type/tz/TimeZoneMap.cpp
@@ -38,6 +38,24 @@ using TTimeZoneIndex = folly::F14FastMap<std::string, const TimeZone*>;
 extern const std::vector<std::pair<int16_t, std::string>>& getTimeZoneEntries();
 
 namespace {
+
+// Returns true if the OS-level IANA timezone database can be loaded via
+// tzdb::get_tzdb(). Result is cached in a static; supports TestValue injection
+// for exercising the missing-database fallback in tests.
+bool hasTimeZoneDatabase() {
+  static const bool available = [] {
+    try {
+      (void)tzdb::get_tzdb();
+      return true;
+    } catch (...) {
+      return false;
+    }
+  }();
+  bool result = available;
+  TestValue::adjust("facebook::velox::tz::hasTimeZoneDatabase", &result);
+  return result;
+}
+
 // Returns the offset in minutes for a specific time zone offset in the
 // database. Do not call for tzID 0 (UTC / "+00:00").
 inline std::chrono::minutes getTimeZoneOffset(int16_t tzID) {
@@ -63,16 +81,20 @@ TTimeZoneDatabase buildTimeZoneDatabase(
     std::unique_ptr<TimeZone> timeZonePtr;
 
     if (entry.first == 0) {
-      timeZonePtr =
-          std::make_unique<TimeZone>("UTC", entry.first, locateZoneImpl("UTC"));
+      if (hasTimeZoneDatabase()) {
+        timeZonePtr = std::make_unique<TimeZone>(
+            "UTC", entry.first, locateZoneImpl("UTC"));
+      } else {
+        timeZonePtr = std::make_unique<TimeZone>(
+            "UTC", entry.first, std::chrono::minutes{0});
+      }
     } else if (entry.first <= 1680) {
-      std::chrono::minutes offset = getTimeZoneOffset(entry.first);
-      timeZonePtr =
-          std::make_unique<TimeZone>(entry.second, entry.first, offset);
+      timeZonePtr = std::make_unique<TimeZone>(
+          entry.second, entry.first, getTimeZoneOffset(entry.first));
     }
     // Every single other time zone entry (outside of offsets) needs to be
     // available in external/date or this will throw.
-    else {
+    else if (hasTimeZoneDatabase()) {
       const tzdb::time_zone* zone;
       try {
         zone = locateZoneImpl(entry.second);
@@ -501,4 +523,11 @@ std::string TimeZone::getLongName(
     TimeZone::TChoose choose) const {
   return getName<true>(timestamp, choose, tz_, timeZoneName_);
 }
+
+// Exposed for testing only; see header for full documentation.
+std::vector<std::unique_ptr<TimeZone>> testingBuildTimeZoneDatabase(
+    const std::vector<std::pair<int16_t, std::string>>& dbInput) {
+  return buildTimeZoneDatabase(dbInput);
+}
+
 } // namespace facebook::velox::tz

--- a/velox/type/tz/TimeZoneMap.h
+++ b/velox/type/tz/TimeZoneMap.h
@@ -17,8 +17,10 @@
 #pragma once
 
 #include <chrono>
+#include <memory>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace facebook::velox::tzdb {
@@ -199,5 +201,11 @@ class TimeZone {
   const std::string timeZoneName_;
   const int16_t timeZoneID_;
 };
+
+/// Builds a TimeZone database vector from the input list of (id, name) pairs.
+/// Exposed only for testing the missing-tzdb fallback path; production code
+/// uses the cached database returned by locateZone().
+std::vector<std::unique_ptr<TimeZone>> testingBuildTimeZoneDatabase(
+    const std::vector<std::pair<int16_t, std::string>>& dbInput);
 
 } // namespace facebook::velox::tz

--- a/velox/type/tz/tests/TimeZoneMapTest.cpp
+++ b/velox/type/tz/tests/TimeZoneMapTest.cpp
@@ -18,8 +18,11 @@
 
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/testutil/TestValue.h"
 #include "velox/external/date/date.h"
 #include "velox/type/tz/TimeZoneMap.h"
+
+using facebook::velox::common::testutil::TestValue;
 
 namespace facebook::velox::tz {
 namespace {
@@ -64,6 +67,97 @@ TEST(TimeZoneMapTest, locateZoneUTCAlias) {
   EXPECT_EQ("UTC", locateZoneID("uct"));
   EXPECT_EQ("UTC", locateZoneID("+00:00"));
   EXPECT_EQ("UTC", locateZoneID("-00:00"));
+}
+
+TEST(TimeZoneMapTest, utcAsOffsetTimezone) {
+  {
+    const auto* tz = locateZone("UTC");
+    ASSERT_NE(tz, nullptr);
+    EXPECT_NE(tz->tz(), nullptr);
+    EXPECT_FALSE(tz->offset().has_value());
+  }
+
+  {
+    TimeZone tz("UTC", 0, minutes(0));
+    EXPECT_EQ("UTC", tz.name());
+    EXPECT_EQ(0, tz.id());
+    EXPECT_EQ(tz.tz(), nullptr);
+    ASSERT_TRUE(tz.offset().has_value());
+    EXPECT_EQ(0, tz.offset()->count());
+
+    EXPECT_EQ(0, tz.to_sys(seconds{0}).count());
+    EXPECT_EQ(0, tz.to_local(seconds{0}).count());
+    EXPECT_EQ(1'000'000, tz.to_sys(seconds{1'000'000}).count());
+    EXPECT_EQ(1'000'000, tz.to_local(seconds{1'000'000}).count());
+
+    EXPECT_EQ("UTC", tz.getShortName(milliseconds{0}));
+    EXPECT_EQ("UTC", tz.getLongName(milliseconds{0}));
+  }
+}
+
+TEST(TimeZoneMapTest, buildTimeZoneDatabase) {
+  const std::vector<std::pair<int16_t, std::string>> input = {
+      {0, "UTC"},
+      {1, "-14:00"},
+      {1680, "+14:00"},
+      {1720, "Africa/Maseru"},
+  };
+
+  const auto database = testingBuildTimeZoneDatabase(input);
+  ASSERT_EQ(database.size(), 1721);
+
+  // UTC is tzdb-backed: tz() is non-null and offset() is empty.
+  ASSERT_NE(database[0], nullptr);
+  EXPECT_EQ("UTC", database[0]->name());
+  EXPECT_EQ(0, database[0]->id());
+  EXPECT_NE(nullptr, database[0]->tz());
+  EXPECT_FALSE(database[0]->offset().has_value());
+
+  // Fixed-offset zones are offset-based.
+  ASSERT_NE(database[1], nullptr);
+  EXPECT_EQ("-14:00", database[1]->name());
+  ASSERT_NE(database[1680], nullptr);
+  EXPECT_EQ("+14:00", database[1680]->name());
+
+  // Named zone is tzdb-backed.
+  ASSERT_NE(database[1720], nullptr);
+  EXPECT_EQ("Africa/Maseru", database[1720]->name());
+  EXPECT_NE(nullptr, database[1720]->tz());
+}
+
+DEBUG_ONLY_TEST(TimeZoneMapTest, buildTimeZoneDatabaseNoTzdb) {
+  TestValue::enable();
+
+  const std::vector<std::pair<int16_t, std::string>> input = {
+      {0, "UTC"},
+      {1, "-14:00"},
+      {1680, "+14:00"},
+      {1720, "Africa/Maseru"},
+  };
+
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::tz::hasTimeZoneDatabase",
+      std::function<void(bool*)>([](bool* available) { *available = false; }));
+
+  const auto database = testingBuildTimeZoneDatabase(input);
+  ASSERT_EQ(database.size(), 1721);
+
+  // UTC falls back to a fixed-offset TimeZone (tz()==nullptr, offset==0).
+  ASSERT_NE(database[0], nullptr);
+  EXPECT_EQ("UTC", database[0]->name());
+  EXPECT_EQ(0, database[0]->id());
+  EXPECT_EQ(nullptr, database[0]->tz());
+  ASSERT_TRUE(database[0]->offset().has_value());
+  EXPECT_EQ(0, database[0]->offset()->count());
+
+  // Fixed-offset zones are still present.
+  ASSERT_NE(database[1], nullptr);
+  EXPECT_EQ("-14:00", database[1]->name());
+  ASSERT_NE(database[1680], nullptr);
+  EXPECT_EQ("+14:00", database[1680]->name());
+
+  // Named zones are skipped, leaving a nullptr slot.
+  EXPECT_EQ(nullptr, database[1720]);
 }
 
 TEST(TimeZoneMapTest, offsetToLocal) {
@@ -366,5 +460,6 @@ TEST(TimeZoneMapTest, getLongName) {
   ts = 1704096000000;
   EXPECT_EQ("Pacific Standard Time", toLongName("America/Los_Angeles", ts));
 }
+
 } // namespace
 } // namespace facebook::velox::tz


### PR DESCRIPTION
Summary:

SingleThreadedTaskCursor previously ignored params.outputPool and params.copyResult. Vectors returned from moveNext() referenced operator memory pools owned by the underlying Task and would dangle once the task was destroyed (e.g. when the cursor was reset, or when the caller held the result vectors past the runner's lifetime). MultiThreadedTaskCursor handles this in its consumer callback by copying each batch into params.outputPool via encodedVectorCopy, gated on params.copyResult.

This change makes SingleThreadedTaskCursor follow the same convention. When params.outputPool is supplied and params.copyResult is true (default), each batch is copied into outputPool inside moveNext() before being stored in current_. When outputPool is null or copyResult is false, the original vector is returned as before, so existing zero-copy callers (cudf, trace replay, tests that explicitly opt out) keep their semantics.

Updated the Cursor.h doc comment on outputPool to describe the new behavior in both modes.

Reviewed By: kevinwilfong

Differential Revision: D102422372


