### PR TITLE
refactor: Extract FileDataSink base class from HiveDataSink (#17345)

### DIFF
--- a/velox/connectors/hive/CMakeLists.txt
+++ b/velox/connectors/hive/CMakeLists.txt
@@ -27,6 +27,7 @@ velox_add_library(
   FileColumnHandle.cpp
   FileConfig.cpp
   FileConnectorUtil.cpp
+  FileDataSink.cpp
   FileDataSource.cpp
   FileHandle.cpp
   FileIndexReader.cpp
@@ -49,6 +50,7 @@ velox_add_library(
   FileConfig.h
   FileConnectorSplit.h
   FileConnectorUtil.h
+  FileDataSink.h
   FileDataSource.h
   FileHandle.h
   FileIndexReader.h

--- a/velox/connectors/hive/FileDataSink.cpp
+++ b/velox/connectors/hive/FileDataSink.cpp
@@ -1,0 +1,523 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/FileDataSink.h"
+
+#include "velox/common/testutil/TestValue.h"
+#include "velox/exec/OperatorUtils.h"
+
+using facebook::velox::common::testutil::TestValue;
+
+namespace facebook::velox::connector::hive {
+namespace {
+#define WRITER_NON_RECLAIMABLE_SECTION_GUARD(index)       \
+  memory::NonReclaimableSectionGuard nonReclaimableGuard( \
+      writerInfo_[(index)]->nonReclaimableSectionHolder.get())
+
+std::shared_ptr<memory::MemoryPool> createSinkPool(
+    const std::shared_ptr<memory::MemoryPool>& writerPool) {
+  return writerPool->addLeafChild(fmt::format("{}.sink", writerPool->name()));
+}
+
+std::shared_ptr<memory::MemoryPool> createSortPool(
+    const std::shared_ptr<memory::MemoryPool>& writerPool) {
+  return writerPool->addLeafChild(fmt::format("{}.sort", writerPool->name()));
+}
+} // namespace
+
+const WriterId& WriterId::unpartitionedId() {
+  static const WriterId writerId{0};
+  return writerId;
+}
+
+std::string WriterId::toString() const {
+  if (partitionId.has_value() && bucketId.has_value()) {
+    return fmt::format("part[{}.{}]", partitionId.value(), bucketId.value());
+  }
+
+  if (partitionId.has_value() && !bucketId.has_value()) {
+    return fmt::format("part[{}]", partitionId.value());
+  }
+
+  // This WriterId is used to add an identifier in the MemoryPools. This could
+  // indicate unpart, but the bucket number needs to be disambiguated. So
+  // creating a new label using bucket.
+  if (!partitionId.has_value() && bucketId.has_value()) {
+    return fmt::format("bucket[{}]", bucketId.value());
+  }
+
+  return "unpart";
+}
+
+RowTypePtr FileDataSink::getNonPartitionTypes(
+    const std::vector<column_index_t>& dataCols,
+    const RowTypePtr& inputType) {
+  std::vector<std::string> childNames;
+  std::vector<TypePtr> childTypes;
+  const auto& dataSize = dataCols.size();
+  childNames.reserve(dataSize);
+  childTypes.reserve(dataSize);
+  for (auto dataCol : dataCols) {
+    childNames.push_back(inputType->nameOf(dataCol));
+    childTypes.push_back(inputType->childAt(dataCol));
+  }
+
+  return ROW(std::move(childNames), std::move(childTypes));
+}
+
+RowVectorPtr FileDataSink::makeDataInput(
+    const std::vector<column_index_t>& dataCols,
+    const RowVectorPtr& input) {
+  std::vector<VectorPtr> childVectors;
+  childVectors.reserve(dataCols.size());
+  for (auto dataCol : dataCols) {
+    childVectors.push_back(input->childAt(dataCol));
+  }
+
+  return std::make_shared<RowVector>(
+      input->pool(),
+      getNonPartitionTypes(dataCols, asRowType(input->type())),
+      input->nulls(),
+      input->size(),
+      std::move(childVectors),
+      input->getNullCount());
+}
+
+FileDataSink::FileDataSink(
+    RowTypePtr inputType,
+    const ConnectorQueryCtx* connectorQueryCtx,
+    CommitStrategy commitStrategy,
+    dwio::common::FileFormat storageFormat,
+    uint32_t maxOpenWriters,
+    std::vector<column_index_t> partitionChannels,
+    std::vector<column_index_t> dataChannels,
+    int32_t bucketCount,
+    std::unique_ptr<core::PartitionFunction> bucketFunction,
+    std::unique_ptr<PartitionIdGenerator> partitionIdGenerator,
+    std::shared_ptr<dwio::common::WriterFactory> writerFactory,
+    uint64_t maxTargetFileBytes,
+    bool partitionKeyAsLowerCase,
+    const common::SpillConfig* spillConfig,
+    uint64_t sortWriterFinishTimeSliceLimitMs)
+    : inputType_(std::move(inputType)),
+      connectorQueryCtx_(connectorQueryCtx),
+      commitStrategy_(commitStrategy),
+      storageFormat_(storageFormat),
+      maxOpenWriters_(maxOpenWriters),
+      partitionChannels_(std::move(partitionChannels)),
+      partitionIdGenerator_(std::move(partitionIdGenerator)),
+      dataChannels_(std::move(dataChannels)),
+      bucketCount_(bucketCount),
+      bucketFunction_(std::move(bucketFunction)),
+      writerFactory_(std::move(writerFactory)),
+      spillConfig_(spillConfig),
+      sortWriterFinishTimeSliceLimitMs_(sortWriterFinishTimeSliceLimitMs),
+      maxTargetFileBytes_(maxTargetFileBytes),
+      partitionKeyAsLowerCase_(partitionKeyAsLowerCase) {
+  fileSystemStats_ = std::make_unique<IoStats>();
+}
+
+void FileDataSink::appendData(RowVectorPtr input) {
+  checkRunning();
+
+  // Lazy load all the input columns.
+  input->loadedVector();
+
+  // Write to unpartitioned (and unbucketed) table.
+  if (!isPartitioned() && !isBucketed()) {
+    const auto index = ensureWriter(WriterId::unpartitionedId());
+    write(index, input);
+    return;
+  }
+
+  // Compute partition and bucket numbers.
+  computePartitionAndBucketIds(input);
+
+  // All inputs belong to a single non-bucketed partition. The partition id
+  // must be zero.
+  if (!isBucketed() && partitionIdGenerator_->numPartitions() == 1) {
+    const auto index = ensureWriter(WriterId{0});
+    write(index, input);
+    return;
+  }
+
+  splitInputRowsAndEnsureWriters();
+
+  for (auto index = 0; index < writers_.size(); ++index) {
+    const vector_size_t partitionSize = partitionSizes_[index];
+    if (partitionSize == 0) {
+      continue;
+    }
+
+    RowVectorPtr writerInput = partitionSize == input->size()
+        ? input
+        : exec::wrap(partitionSize, partitionRows_[index], input);
+    write(index, writerInput);
+  }
+}
+
+void FileDataSink::write(size_t index, RowVectorPtr input) {
+  WRITER_NON_RECLAIMABLE_SECTION_GUARD(index);
+  auto dataInput = makeDataInput(dataChannels_, input);
+
+  if (writers_[index] == nullptr) {
+    writers_[index] = createWriterForIndex(index);
+  }
+
+  writers_[index]->write(dataInput);
+  writerInfo_[index]->inputSizeInBytes += dataInput->estimateFlatSize();
+  writerInfo_[index]->numWrittenRows += dataInput->size();
+  writerInfo_[index]->currentFileWrittenRows += dataInput->size();
+
+  // File rotation is not supported for bucketed tables (require one file per
+  // bucket with predictable name) or sorted writes (SortingWriter not
+  // recreated).
+  if (maxTargetFileBytes_ == 0 || isBucketed() || sortWrite()) {
+    return;
+  }
+
+  const auto currentFileBytes = getCurrentFileBytes(index);
+  if (currentFileBytes >= maxTargetFileBytes_) {
+    rotateWriter(index);
+  }
+}
+
+uint64_t FileDataSink::getCurrentFileBytes(size_t writerIndex) const {
+  VELOX_CHECK_LT(writerIndex, ioStats_.size());
+  VELOX_CHECK_LT(writerIndex, writerInfo_.size());
+  const auto totalBytes = ioStats_[writerIndex]->rawBytesWritten();
+  const auto baselineBytes = writerInfo_[writerIndex]->cumulativeWrittenBytes;
+  // Sanity check: total should always be >= baseline since ioStats is
+  // never reset and cumulative is a snapshot of rawBytesWritten at rotation.
+  VELOX_DCHECK_GE(totalBytes, baselineBytes);
+  return totalBytes - baselineBytes;
+}
+
+void FileDataSink::finalizeWriterFile(size_t index) {
+  VELOX_CHECK_LT(index, writerInfo_.size());
+  VELOX_CHECK_LT(index, ioStats_.size());
+
+  auto& info = writerInfo_[index];
+
+  // Capture current file stats AFTER close to include footer bytes.
+  const auto currentFileBytes = getCurrentFileBytes(index);
+
+  // Finalize the current file into writtenFiles using the stored names.
+  if (currentFileBytes > 0) {
+    FileInfo fileInfo;
+    fileInfo.writeFileName = info->currentWriteFileName;
+    fileInfo.targetFileName = info->currentTargetFileName;
+    fileInfo.fileSize = currentFileBytes;
+    fileInfo.numRows = info->currentFileWrittenRows;
+    // Reset for next file.
+    info->currentFileWrittenRows = 0;
+    info->writtenFiles.push_back(std::move(fileInfo));
+  }
+
+  // Update cumulative stats as a snapshot of total stats so far.
+  // This becomes the baseline for the next file.
+  info->cumulativeWrittenBytes = ioStats_[index]->rawBytesWritten();
+}
+
+void FileDataSink::rotateWriter(size_t index) {
+  VELOX_CHECK_LT(index, writers_.size());
+  VELOX_CHECK_LT(index, writerInfo_.size());
+
+  auto& info = writerInfo_[index];
+
+  // Close the writer first to flush all data including footer.
+  writers_[index]->close();
+
+  // Finalize the current file state.
+  finalizeWriterFile(index);
+
+  // Release old writer's memory pools. The new writer will be created lazily
+  // on the next write to avoid creating empty files.
+  writers_[index].reset();
+
+  ++info->fileSequenceNumber;
+}
+
+std::string FileDataSink::stateString(State state) {
+  switch (state) {
+    case State::kRunning:
+      return "RUNNING";
+    case State::kFinishing:
+      return "FLUSHING";
+    case State::kClosed:
+      return "CLOSED";
+    case State::kAborted:
+      return "ABORTED";
+    default:
+      VELOX_UNREACHABLE("BAD STATE: {}", static_cast<int>(state));
+  }
+}
+
+DataSink::Stats FileDataSink::stats() const {
+  Stats stats;
+  if (state_ == State::kAborted) {
+    return stats;
+  }
+
+  for (const auto& ioStats : ioStats_) {
+    stats.numWrittenBytes += ioStats->rawBytesWritten();
+    stats.writeIOTimeUs += ioStats->writeIOTimeUs();
+  }
+
+  if (state_ != State::kClosed) {
+    return stats;
+  }
+
+  // Count total files written, including rotated files.
+  stats.numWrittenFiles = 0;
+  for (size_t i = 0; i < writerInfo_.size(); ++i) {
+    const auto& info = writerInfo_.at(i);
+    VELOX_CHECK_NOT_NULL(info);
+    stats.numWrittenFiles += info->writtenFiles.size();
+    if (!info->spillStats->empty()) {
+      stats.spillStats += *info->spillStats;
+    }
+  }
+  return stats;
+}
+
+std::unordered_map<std::string, RuntimeCounter> FileDataSink::runtimeStats()
+    const {
+  std::unordered_map<std::string, RuntimeCounter> runtimeStats;
+
+  const auto fsStatsMap = fileSystemStats_->stats();
+  for (const auto& [statName, statValue] : fsStatsMap) {
+    runtimeStats.emplace(
+        statName, RuntimeCounter(statValue.sum, statValue.unit));
+  }
+
+  return runtimeStats;
+}
+
+std::shared_ptr<memory::MemoryPool> FileDataSink::createWriterPool(
+    const WriterId& writerId) {
+  auto* connectorPool = connectorQueryCtx_->connectorMemoryPool();
+  return connectorPool->addAggregateChild(
+      fmt::format("{}.{}", connectorPool->name(), writerId.toString()));
+}
+
+void FileDataSink::setMemoryReclaimers(
+    WriterInfo* /*writerInfo*/,
+    io::IoStatistics* /*ioStats*/) {
+  // Default no-op. Subclasses override to set up format-specific reclaimers.
+}
+
+void FileDataSink::setState(State newState) {
+  checkStateTransition(state_, newState);
+  state_ = newState;
+}
+
+void FileDataSink::checkStateTransition(State oldState, State newState) {
+  switch (oldState) {
+    case State::kRunning:
+      if (newState == State::kAborted || newState == State::kFinishing) {
+        return;
+      }
+      break;
+    case State::kFinishing:
+      if (newState == State::kAborted || newState == State::kClosed ||
+          // The finishing state is reentry state if we yield in the middle of
+          // finish processing if a single run takes too long.
+          newState == State::kFinishing) {
+        return;
+      }
+      [[fallthrough]];
+    case State::kAborted:
+    case State::kClosed:
+    default:
+      break;
+  }
+  VELOX_FAIL("Unexpected state transition from {} to {}", oldState, newState);
+}
+
+bool FileDataSink::finish() {
+  // Flush is reentry state.
+  setState(State::kFinishing);
+
+  // As for now, only sorted writer needs flush buffered data. For non-sorted
+  // writer, data is directly written to the underlying file writer.
+  if (!sortWrite()) {
+    return true;
+  }
+
+  const uint64_t startTimeMs = getCurrentTimeMs();
+  for (auto i = 0; i < writers_.size(); ++i) {
+    WRITER_NON_RECLAIMABLE_SECTION_GUARD(i);
+    if (!writers_[i]->finish()) {
+      return false;
+    }
+    if (getCurrentTimeMs() - startTimeMs > sortWriterFinishTimeSliceLimitMs_) {
+      return false;
+    }
+  }
+  return true;
+}
+
+std::vector<std::string> FileDataSink::close() {
+  setState(State::kClosed);
+  closeInternal();
+  return commitMessage();
+}
+
+void FileDataSink::abort() {
+  setState(State::kAborted);
+  closeInternal();
+}
+
+void FileDataSink::closeInternal() {
+  VELOX_CHECK_NE(state_, State::kRunning);
+  VELOX_CHECK_NE(state_, State::kFinishing);
+
+  TestValue::adjust(
+      "facebook::velox::connector::hive::FileDataSink::closeInternal", this);
+
+  // NOTE: writers_[i] can be nullptr during file rotation. In rotateWriter(),
+  // we call writers_[index].reset() to release the old writer before creating
+  // a new one. If an error occurs during new writer creation, or if abort is
+  // called during this window, the writer slot may be empty.
+  if (state_ == State::kClosed) {
+    for (int i = 0; i < writers_.size(); ++i) {
+      if (writers_[i] == nullptr) {
+        continue;
+      }
+      WRITER_NON_RECLAIMABLE_SECTION_GUARD(i);
+      writers_[i]->close();
+      finalizeWriterFile(i);
+    }
+  } else {
+    for (int i = 0; i < writers_.size(); ++i) {
+      if (writers_[i] == nullptr) {
+        continue;
+      }
+      WRITER_NON_RECLAIMABLE_SECTION_GUARD(i);
+      writers_[i]->abort();
+    }
+  }
+}
+
+uint32_t FileDataSink::ensureWriter(const WriterId& id) {
+  auto it = writerIndexMap_.find(id);
+  if (it != writerIndexMap_.end()) {
+    return it->second;
+  }
+  return appendWriter(id);
+}
+
+uint32_t FileDataSink::appendWriter(const WriterId& id) {
+  // Check max open writers.
+  VELOX_USER_CHECK_LE(
+      writers_.size(), maxOpenWriters_, "Exceeded open writer limit");
+  VELOX_CHECK_EQ(writers_.size(), writerInfo_.size());
+  VELOX_CHECK_EQ(writerIndexMap_.size(), writerInfo_.size());
+
+  std::optional<std::string> partitionName;
+  if (isPartitioned()) {
+    partitionName = getPartitionName(id.partitionId.value());
+  }
+
+  // Without explicitly setting flush policy, the default memory based flush
+  // policy is used.
+  auto writerParameters = getWriterParameters(partitionName, id.bucketId);
+  auto writerPool = createWriterPool(id);
+  auto sinkPool = createSinkPool(writerPool);
+  std::shared_ptr<memory::MemoryPool> sortPool{nullptr};
+  if (sortWrite()) {
+    sortPool = createSortPool(writerPool);
+  }
+  writerInfo_.emplace_back(
+      std::make_shared<WriterInfo>(
+          std::move(writerParameters),
+          std::move(writerPool),
+          std::move(sinkPool),
+          std::move(sortPool)));
+  ioStats_.emplace_back(std::make_unique<io::IoStatistics>());
+
+  setMemoryReclaimers(writerInfo_.back().get(), ioStats_.back().get());
+  writers_.emplace_back(createWriterForIndex(writerInfo_.size() - 1));
+  addThreadLocalRuntimeStat(
+      fmt::format("{}WriterCount", dwio::common::toString(storageFormat_)),
+      RuntimeCounter(1));
+  // Extends the buffer used for partition rows calculations.
+  partitionSizes_.emplace_back(0);
+  partitionRows_.emplace_back(nullptr);
+  rawPartitionRows_.emplace_back(nullptr);
+
+  writerIndexMap_.emplace(id, writers_.size() - 1);
+  return writerIndexMap_[id];
+}
+
+WriterId FileDataSink::getWriterId(vector_size_t row) const {
+  std::optional<uint32_t> partitionId;
+  if (isPartitioned()) {
+    VELOX_CHECK_LT(partitionIds_[row], std::numeric_limits<uint32_t>::max());
+    partitionId = static_cast<uint32_t>(partitionIds_[row]);
+  }
+
+  std::optional<uint32_t> bucketId;
+  if (isBucketed()) {
+    bucketId = bucketIds_[row];
+  }
+  return WriterId{partitionId, bucketId};
+}
+
+void FileDataSink::updatePartitionRows(
+    uint32_t index,
+    vector_size_t numRows,
+    vector_size_t row) {
+  VELOX_DCHECK_LT(index, partitionSizes_.size());
+  VELOX_DCHECK_EQ(partitionSizes_.size(), partitionRows_.size());
+  VELOX_DCHECK_EQ(partitionRows_.size(), rawPartitionRows_.size());
+  if (FOLLY_UNLIKELY(partitionRows_[index] == nullptr) ||
+      (partitionRows_[index]->capacity() < numRows * sizeof(vector_size_t))) {
+    partitionRows_[index] =
+        allocateIndices(numRows, connectorQueryCtx_->memoryPool());
+    rawPartitionRows_[index] =
+        partitionRows_[index]->asMutable<vector_size_t>();
+  }
+  rawPartitionRows_[index][partitionSizes_[index]] = row;
+  ++partitionSizes_[index];
+}
+
+void FileDataSink::splitInputRowsAndEnsureWriters() {
+  VELOX_CHECK(isPartitioned() || isBucketed());
+  if (isBucketed() && isPartitioned()) {
+    VELOX_CHECK_EQ(bucketIds_.size(), partitionIds_.size());
+  }
+
+  std::fill(partitionSizes_.begin(), partitionSizes_.end(), 0);
+
+  const auto numRows = static_cast<vector_size_t>(
+      isPartitioned() ? partitionIds_.size() : bucketIds_.size());
+  for (vector_size_t row = 0; row < numRows; ++row) {
+    const auto id = getWriterId(row);
+    const uint32_t index = ensureWriter(id);
+    updatePartitionRows(index, numRows, row);
+  }
+
+  for (uint32_t i = 0; i < partitionSizes_.size(); ++i) {
+    if (partitionSizes_[i] != 0) {
+      VELOX_CHECK_NOT_NULL(partitionRows_[i]);
+      partitionRows_[i]->setSize(partitionSizes_[i] * sizeof(vector_size_t));
+    }
+  }
+}
+
+} // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/FileDataSink.h
+++ b/velox/connectors/hive/FileDataSink.h
@@ -1,0 +1,447 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/connectors/Connector.h"
+#include "velox/connectors/hive/PartitionIdGenerator.h"
+#include "velox/dwio/common/Options.h"
+#include "velox/dwio/common/Writer.h"
+#include "velox/dwio/common/WriterFactory.h"
+#include "velox/exec/MemoryReclaimer.h"
+
+namespace facebook::velox::connector::hive {
+
+/// Parameters for file writers.
+class WriterParameters {
+ public:
+  enum class UpdateMode {
+    kNew, // Write files to a new directory.
+    kOverwrite, // Overwrite an existing directory.
+    // Append mode is currently only supported for unpartitioned tables.
+    kAppend, // Append to an unpartitioned table.
+  };
+
+  /// @param updateMode Write the files to a new directory, or append to an
+  /// existing directory or overwrite an existing directory.
+  /// @param partitionName Partition name in the typical Hive style, which is
+  /// also the partition subdirectory part of the partition path.
+  /// @param targetFileName The final name of a file after committing.
+  /// @param targetDirectory The final directory that a file should be in after
+  /// committing.
+  /// @param writeFileName The temporary name of the file that a running writer
+  /// writes to. If a running writer writes directory to the target file, set
+  /// writeFileName to targetFileName by default.
+  /// @param writeDirectory The temporary directory that a running writer writes
+  /// to. If a running writer writes directory to the target directory, set
+  /// writeDirectory to targetDirectory by default.
+  WriterParameters(
+      UpdateMode updateMode,
+      std::optional<std::string> partitionName,
+      std::string targetFileName,
+      std::string targetDirectory,
+      const std::optional<std::string>& writeFileName = std::nullopt,
+      const std::optional<std::string>& writeDirectory = std::nullopt)
+      : updateMode_(updateMode),
+        partitionName_(std::move(partitionName)),
+        targetFileName_(std::move(targetFileName)),
+        targetDirectory_(std::move(targetDirectory)),
+        writeFileName_(writeFileName.value_or(targetFileName_)),
+        writeDirectory_(writeDirectory.value_or(targetDirectory_)) {}
+
+  UpdateMode updateMode() const {
+    return updateMode_;
+  }
+
+  static std::string updateModeToString(UpdateMode updateMode) {
+    switch (updateMode) {
+      case UpdateMode::kNew:
+        return "NEW";
+      case UpdateMode::kOverwrite:
+        return "OVERWRITE";
+      case UpdateMode::kAppend:
+        return "APPEND";
+      default:
+        VELOX_UNSUPPORTED("Unsupported update mode.");
+    }
+  }
+
+  const std::optional<std::string>& partitionName() const {
+    return partitionName_;
+  }
+
+  const std::string& targetFileName() const {
+    return targetFileName_;
+  }
+
+  const std::string& writeFileName() const {
+    return writeFileName_;
+  }
+
+  const std::string& targetDirectory() const {
+    return targetDirectory_;
+  }
+
+  const std::string& writeDirectory() const {
+    return writeDirectory_;
+  }
+
+ private:
+  const UpdateMode updateMode_;
+  const std::optional<std::string> partitionName_;
+  const std::string targetFileName_;
+  const std::string targetDirectory_;
+  const std::string writeFileName_;
+  const std::string writeDirectory_;
+};
+
+/// Information about a single file written as part of a writer's output.
+/// When file rotation occurs, multiple FileInfo entries are created.
+struct FileInfo {
+  /// The temporary file name used during writing (in the staging directory).
+  std::string writeFileName;
+  /// The final file name after commit (in the target directory).
+  std::string targetFileName;
+  /// Size of the file in bytes.
+  uint64_t fileSize{0};
+  /// Number of rows in the file.
+  uint64_t numRows{0};
+};
+
+struct WriterInfo {
+  WriterInfo(
+      WriterParameters parameters,
+      std::shared_ptr<memory::MemoryPool> _writerPool,
+      std::shared_ptr<memory::MemoryPool> _sinkPool,
+      std::shared_ptr<memory::MemoryPool> _sortPool)
+      : writerParameters(std::move(parameters)),
+        nonReclaimableSectionHolder(new tsan_atomic<bool>(false)),
+        spillStats(std::make_unique<exec::SpillStats>()),
+        writerPool(std::move(_writerPool)),
+        sinkPool(std::move(_sinkPool)),
+        sortPool(std::move(_sortPool)) {}
+
+  // Writer configuration: update mode, partition, file paths.
+  const WriterParameters writerParameters;
+  // Guards non-reclaimable sections during write operations.
+  const std::unique_ptr<tsan_atomic<bool>> nonReclaimableSectionHolder;
+  // Collects the spill stats from sort writer if the spilling has been
+  // triggered.
+  const std::unique_ptr<exec::SpillStats> spillStats;
+  // Memory pool for the writer itself.
+  const std::shared_ptr<memory::MemoryPool> writerPool;
+  // Memory pool for the file sink (serialization layer).
+  const std::shared_ptr<memory::MemoryPool> sinkPool;
+  // Memory pool for sort buffers (nullptr if not a sorted write).
+  const std::shared_ptr<memory::MemoryPool> sortPool;
+  // Total rows written by this writer across all files.
+  uint64_t numWrittenRows{0};
+  // Rows written to the current file; reset to 0 when the file is finalized.
+  uint64_t currentFileWrittenRows{0};
+  uint64_t inputSizeInBytes{0};
+  /// File sequence number for tracking multiple files written due to size-based
+  /// splitting. Incremented each time the writer rotates to a new file.
+  /// Used to generate sequenced file names (e.g., file_1.orc, file_2.orc).
+  /// Invariant during write: fileSequenceNumber == writtenFiles.size()
+  /// After close: fileSequenceNumber + 1 == writtenFiles.size() (final file
+  /// added)
+  uint32_t fileSequenceNumber{0};
+  /// Tracks all files written by this writer.
+  /// During write: contains only rotated (completed) files.
+  /// After close: contains all files including the final one (via
+  /// finalizeWriterFile).
+  std::vector<FileInfo> writtenFiles;
+  /// Snapshot of total bytes written at the start of the current file.
+  /// Used as baseline to calculate current file size: rawBytesWritten() - this.
+  /// Updated to ioStats->rawBytesWritten() after each rotation.
+  uint64_t cumulativeWrittenBytes{0};
+  /// Current file's write filename (set when file is created/rotated).
+  /// This avoids recomputing makeSequencedFileName() in commitMessage().
+  std::string currentWriteFileName;
+  /// Current file's target filename (set when file is created/rotated).
+  std::string currentTargetFileName;
+};
+
+/// Identifies a writer by partition and bucket.
+struct WriterId {
+  std::optional<uint32_t> partitionId{std::nullopt};
+  std::optional<uint32_t> bucketId{std::nullopt};
+
+  WriterId() = default;
+
+  explicit WriterId(
+      std::optional<uint32_t> _partitionId,
+      std::optional<uint32_t> _bucketId = std::nullopt)
+      : partitionId(_partitionId), bucketId(_bucketId) {}
+
+  /// Returns the special writer id for the un-partitioned (and non-bucketed)
+  /// table.
+  static const WriterId& unpartitionedId();
+
+  std::string toString() const;
+
+  bool operator==(const WriterId& other) const {
+    return std::tie(partitionId, bucketId) ==
+        std::tie(other.partitionId, other.bucketId);
+  }
+};
+
+struct WriterIdHasher {
+  std::size_t operator()(const WriterId& id) const {
+    return bits::hashMix(
+        id.partitionId.value_or(std::numeric_limits<uint32_t>::max()),
+        id.bucketId.value_or(std::numeric_limits<uint32_t>::max()));
+  }
+};
+
+struct WriterIdEq {
+  bool operator()(const WriterId& lhs, const WriterId& rhs) const {
+    return lhs == rhs;
+  }
+};
+
+/// Base class for file-based data sinks that write data to columnar file
+/// formats (ORC, Parquet, etc.). Provides the generic write pipeline: state
+/// machine, row routing to writers, file rotation, and stats aggregation.
+///
+/// Connector-specific data sinks (Hive, Paimon, etc.) extend this class to
+/// add format-specific behavior like commit protocols, partition naming,
+/// writer creation, and memory reclamation.
+class FileDataSink : public DataSink {
+ public:
+  /// Defines the execution states of a file data sink.
+  enum class State {
+    /// The data sink accepts new append data in this state.
+    kRunning = 0,
+    /// The data sink flushes any buffered data to the underlying file writer
+    /// but no more data can be appended.
+    kFinishing = 1,
+    /// The data sink is aborted on error and no more data can be appended.
+    kAborted = 2,
+    /// The data sink is closed on error and no more data can be appended.
+    kClosed = 3
+  };
+  static std::string stateString(State state);
+
+  FileDataSink(
+      RowTypePtr inputType,
+      const ConnectorQueryCtx* connectorQueryCtx,
+      CommitStrategy commitStrategy,
+      dwio::common::FileFormat storageFormat,
+      uint32_t maxOpenWriters,
+      std::vector<column_index_t> partitionChannels,
+      std::vector<column_index_t> dataChannels,
+      int32_t bucketCount,
+      std::unique_ptr<core::PartitionFunction> bucketFunction,
+      std::unique_ptr<PartitionIdGenerator> partitionIdGenerator,
+      std::shared_ptr<dwio::common::WriterFactory> writerFactory,
+      uint64_t maxTargetFileBytes,
+      bool partitionKeyAsLowerCase,
+      const common::SpillConfig* spillConfig,
+      uint64_t sortWriterFinishTimeSliceLimitMs);
+
+  void appendData(RowVectorPtr input) override;
+
+  bool finish() override;
+
+  Stats stats() const override;
+
+  std::unordered_map<std::string, RuntimeCounter> runtimeStats() const override;
+
+  std::vector<std::string> close() override;
+
+  void abort() override;
+
+ protected:
+  // Validates the state transition from 'oldState' to 'newState'.
+  void checkStateTransition(State oldState, State newState);
+  void setState(State newState);
+
+  // Generates commit messages for all writers containing metadata about written
+  // files. Creates a JSON object for each writer with partition name,
+  // file paths, file names, data sizes, and row counts. This metadata is used
+  // by the coordinator to commit the transaction and update the metastore.
+  //
+  // @return Vector of JSON strings, one per writer.
+  virtual std::vector<std::string> commitMessage() const = 0;
+
+  // Returns the type of non-partition data columns.
+  static RowTypePtr getNonPartitionTypes(
+      const std::vector<column_index_t>& dataCols,
+      const RowTypePtr& inputType);
+
+  // Filters out partition columns from the input, returning only data columns.
+  static RowVectorPtr makeDataInput(
+      const std::vector<column_index_t>& dataCols,
+      const RowVectorPtr& input);
+
+  FOLLY_ALWAYS_INLINE bool sortWrite() const {
+    return sortWrite_;
+  }
+
+  // Returns true if the table is partitioned.
+  FOLLY_ALWAYS_INLINE bool isPartitioned() const {
+    return partitionIdGenerator_ != nullptr;
+  }
+
+  // Returns true if the table is bucketed.
+  FOLLY_ALWAYS_INLINE bool isBucketed() const {
+    return bucketCount_ != 0;
+  }
+
+  FOLLY_ALWAYS_INLINE bool isCommitRequired() const {
+    return commitStrategy_ != CommitStrategy::kNoCommit;
+  }
+
+  std::shared_ptr<memory::MemoryPool> createWriterPool(
+      const WriterId& writerId);
+
+  // Sets up memory reclaimers for writer pools. Override to install
+  // format-specific reclaimers. Default is a no-op.
+  virtual void setMemoryReclaimers(
+      WriterInfo* writerInfo,
+      io::IoStatistics* ioStats);
+
+  // Returns the bytes written to the current file for the specified writer.
+  uint64_t getCurrentFileBytes(size_t writerIndex) const;
+
+  // Compute the partition id and bucket id for each row in 'input'.
+  virtual void computePartitionAndBucketIds(const RowVectorPtr& input) = 0;
+
+  // Get the HiveWriter corresponding to the row
+  // from partitionIds and bucketIds.
+  WriterId getWriterId(vector_size_t row) const;
+
+  // Computes the number of input rows as well as the actual input row indices
+  // to each corresponding (bucketed) partition based on the partition and
+  // bucket ids calculated by 'computePartitionAndBucketIds'.
+  void splitInputRowsAndEnsureWriters();
+
+  // Makes sure to create one writer for the given writer id. The function
+  // returns the corresponding index in 'writers_'.
+  virtual uint32_t ensureWriter(const WriterId& id);
+
+  // Appends a new writer for the given 'id'. The function returns the index of
+  // the newly created writer in 'writers_'.
+  uint32_t appendWriter(const WriterId& id);
+
+  // Creates a writer for the given index using the current file sequence.
+  virtual std::unique_ptr<facebook::velox::dwio::common::Writer>
+  createWriterForIndex(size_t writerIndex) = 0;
+
+  // Creates and configures WriterOptions based on file format.
+  virtual std::shared_ptr<dwio::common::WriterOptions> createWriterOptions()
+      const = 0;
+
+  virtual std::shared_ptr<dwio::common::WriterOptions> createWriterOptions(
+      size_t writerIndex) const = 0;
+
+  // Returns the partition directory name for the given partition ID.
+  virtual std::string getPartitionName(uint32_t partitionId) const = 0;
+
+  // Returns writer parameters for the given partition and bucket.
+  virtual WriterParameters getWriterParameters(
+      const std::optional<std::string>& partition,
+      std::optional<uint32_t> bucketId) const = 0;
+
+  // Records a row index for a specific partition.
+  void
+  updatePartitionRows(uint32_t index, vector_size_t numRows, vector_size_t row);
+
+  FOLLY_ALWAYS_INLINE void checkRunning() const {
+    VELOX_CHECK_EQ(state_, State::kRunning, "File data sink is not running");
+  }
+
+  // Invoked to write 'input' to the specified file writer.
+  void write(size_t index, RowVectorPtr input);
+
+  // Rotates the writer at the given index to a new file.
+  virtual void rotateWriter(size_t index);
+
+  // Finalizes the current file for the writer at the given index.
+  void finalizeWriterFile(size_t index);
+
+  virtual void closeInternal();
+
+  // IMPORTANT NOTE: these are passed to writers as raw pointers. FileDataSink
+  // owns the lifetime of these objects, and therefore must destroy them last.
+  std::vector<std::unique_ptr<io::IoStatistics>> ioStats_;
+  // Generic filesystem stats, exposed as RuntimeStats
+  std::unique_ptr<IoStats> fileSystemStats_;
+
+  const RowTypePtr inputType_;
+  const ConnectorQueryCtx* const connectorQueryCtx_;
+  const CommitStrategy commitStrategy_;
+  const dwio::common::FileFormat storageFormat_;
+  const uint32_t maxOpenWriters_;
+  const std::vector<column_index_t> partitionChannels_;
+  const std::unique_ptr<PartitionIdGenerator> partitionIdGenerator_;
+  // Indices of dataChannel are stored in ascending order
+  const std::vector<column_index_t> dataChannels_;
+  const int32_t bucketCount_{0};
+  const std::unique_ptr<core::PartitionFunction> bucketFunction_;
+  const std::shared_ptr<dwio::common::WriterFactory> writerFactory_;
+  const common::SpillConfig* const spillConfig_;
+  const uint64_t sortWriterFinishTimeSliceLimitMs_{0};
+  const uint64_t maxTargetFileBytes_{0};
+  const bool partitionKeyAsLowerCase_;
+
+  /// Whether this sink uses sorted writes. Set by subclass after computing
+  /// sort columns in its constructor.
+  bool sortWrite_{false};
+
+  State state_{State::kRunning};
+
+  tsan_atomic<bool> nonReclaimableSection_{false};
+
+  // The map from writer id to the writer index in 'writers_' and 'writerInfo_'.
+  folly::F14FastMap<WriterId, uint32_t, WriterIdHasher, WriterIdEq>
+      writerIndexMap_;
+
+  // Below are structures for partitions from all inputs. writerInfo_ and
+  // writers_ are both indexed by partitionId.
+  std::vector<std::shared_ptr<WriterInfo>> writerInfo_;
+  std::vector<std::unique_ptr<dwio::common::Writer>> writers_;
+
+  // Below are structures updated when processing current input. partitionIds_
+  // are indexed by the row of input_. partitionRows_, rawPartitionRows_ and
+  // partitionSizes_ are indexed by partitionId.
+  raw_vector<uint64_t> partitionIds_;
+  std::vector<BufferPtr> partitionRows_;
+  std::vector<vector_size_t*> rawPartitionRows_;
+  std::vector<vector_size_t> partitionSizes_;
+
+  // Reusable buffers for bucket id calculations.
+  std::vector<uint32_t> bucketIds_;
+};
+
+FOLLY_ALWAYS_INLINE std::ostream& operator<<(
+    std::ostream& os,
+    FileDataSink::State state) {
+  os << FileDataSink::stateString(state);
+  return os;
+}
+} // namespace facebook::velox::connector::hive
+
+template <>
+struct fmt::formatter<facebook::velox::connector::hive::FileDataSink::State>
+    : formatter<std::string> {
+  auto format(
+      facebook::velox::connector::hive::FileDataSink::State s,
+      format_context& ctx) const {
+    return formatter<std::string>::format(
+        facebook::velox::connector::hive::FileDataSink::stateString(s), ctx);
+  }
+};

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -19,22 +19,17 @@
 #include "velox/common/base/Counters.h"
 #include "velox/common/base/Fs.h"
 #include "velox/common/base/StatsReporter.h"
-#include "velox/common/testutil/TestValue.h"
 #include "velox/connectors/hive/HiveConfig.h"
-#include "velox/connectors/hive/HiveConnectorUtil.h"
 #include "velox/connectors/hive/HivePartitionFunction.h"
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/dwio/common/Options.h"
 #include "velox/dwio/common/SortingWriter.h"
-#include "velox/exec/OperatorUtils.h"
 #include "velox/exec/SortBuffer.h"
 
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <re2/re2.h>
-
-using facebook::velox::common::testutil::TestValue;
 
 namespace facebook::velox::connector::hive {
 namespace {
@@ -84,42 +79,6 @@ std::unique_ptr<dwio::common::FileSink> createHiveFileSink(
           .fileSystemStats = fileSystemStats,
           .storageParameters = storageParameters,
       });
-}
-
-// Returns the type of non-partition data columns.
-RowTypePtr getNonPartitionTypes(
-    const std::vector<column_index_t>& dataCols,
-    const RowTypePtr& inputType) {
-  std::vector<std::string> childNames;
-  std::vector<TypePtr> childTypes;
-  const auto& dataSize = dataCols.size();
-  childNames.reserve(dataSize);
-  childTypes.reserve(dataSize);
-  for (int dataCol : dataCols) {
-    childNames.push_back(inputType->nameOf(dataCol));
-    childTypes.push_back(inputType->childAt(dataCol));
-  }
-
-  return ROW(std::move(childNames), std::move(childTypes));
-}
-
-// Filters out partition columns if there is any.
-RowVectorPtr makeDataInput(
-    const std::vector<column_index_t>& dataCols,
-    const RowVectorPtr& input) {
-  std::vector<VectorPtr> childVectors;
-  childVectors.reserve(dataCols.size());
-  for (int dataCol : dataCols) {
-    childVectors.push_back(input->childAt(dataCol));
-  }
-
-  return std::make_shared<RowVector>(
-      input->pool(),
-      getNonPartitionTypes(dataCols, asRowType(input->type())),
-      input->nulls(),
-      input->size(),
-      std::move(childVectors),
-      input->getNullCount());
 }
 
 // Creates a PartitionIdGenerator if the table is partitioned, otherwise returns
@@ -206,16 +165,6 @@ std::string computeBucketedFileName(
       "0{:0>{}}_0_{}", bucketValueStr, kMaxBucketCountPadding, queryId);
 }
 
-std::shared_ptr<memory::MemoryPool> createSinkPool(
-    const std::shared_ptr<memory::MemoryPool>& writerPool) {
-  return writerPool->addLeafChild(fmt::format("{}.sink", writerPool->name()));
-}
-
-std::shared_ptr<memory::MemoryPool> createSortPool(
-    const std::shared_ptr<memory::MemoryPool>& writerPool) {
-  return writerPool->addLeafChild(fmt::format("{}.sort", writerPool->name()));
-}
-
 uint64_t getFinishTimeSliceLimitMsFromHiveConfig(
     const std::shared_ptr<const HiveConfig>& config,
     const config::ConfigBase* sessions) {
@@ -256,30 +205,6 @@ std::vector<column_index_t> computeNonPartitionChannels(
 }
 
 } // namespace
-
-const HiveWriterId& HiveWriterId::unpartitionedId() {
-  static const HiveWriterId writerId{0};
-  return writerId;
-}
-
-std::string HiveWriterId::toString() const {
-  if (partitionId.has_value() && bucketId.has_value()) {
-    return fmt::format("part[{}.{}]", partitionId.value(), bucketId.value());
-  }
-
-  if (partitionId.has_value() && !bucketId.has_value()) {
-    return fmt::format("part[{}]", partitionId.value());
-  }
-
-  // This WriterId is used to add an identifier in the MemoryPools. This could
-  // indicate unpart, but the bucket number needs to be disambiguated. So
-  // creating a new label using bucket.
-  if (!partitionId.has_value() && bucketId.has_value()) {
-    return fmt::format("bucket[{}]", bucketId.value());
-  }
-
-  return "unpart";
-}
 
 const std::string LocationHandle::tableTypeName(
     LocationHandle::TableType type) {
@@ -505,32 +430,31 @@ HiveDataSink::HiveDataSink(
     const std::vector<column_index_t>& partitionChannels,
     const std::vector<column_index_t>& dataChannels,
     std::unique_ptr<PartitionIdGenerator> partitionIdGenerator)
-    : inputType_(std::move(inputType)),
+    : FileDataSink(
+          std::move(inputType),
+          connectorQueryCtx,
+          commitStrategy,
+          insertTableHandle->storageFormat(),
+          hiveConfig->maxPartitionsPerWriters(
+              connectorQueryCtx->sessionProperties()),
+          partitionChannels,
+          dataChannels,
+          static_cast<int32_t>(bucketCount),
+          std::move(bucketFunction),
+          std::move(partitionIdGenerator),
+          dwio::common::getWriterFactory(insertTableHandle->storageFormat()),
+          hiveConfig->maxTargetFileSizeBytes(
+              connectorQueryCtx->sessionProperties()),
+          hiveConfig->isPartitionPathAsLowerCase(
+              connectorQueryCtx->sessionProperties()),
+          connectorQueryCtx->spillConfig(),
+          getFinishTimeSliceLimitMsFromHiveConfig(
+              hiveConfig,
+              connectorQueryCtx->sessionProperties())),
       insertTableHandle_(std::move(insertTableHandle)),
-      connectorQueryCtx_(connectorQueryCtx),
-      commitStrategy_(commitStrategy),
       hiveConfig_(hiveConfig),
       updateMode_(getUpdateMode()),
-      maxOpenWriters_(hiveConfig_->maxPartitionsPerWriters(
-          connectorQueryCtx->sessionProperties())),
-      partitionChannels_(partitionChannels),
-      partitionIdGenerator_(std::move(partitionIdGenerator)),
-      dataChannels_(dataChannels),
-      bucketCount_(static_cast<int32_t>(bucketCount)),
-      bucketFunction_(std::move(bucketFunction)),
-      writerFactory_(
-          dwio::common::getWriterFactory(insertTableHandle_->storageFormat())),
-      spillConfig_(connectorQueryCtx->spillConfig()),
-      sortWriterFinishTimeSliceLimitMs_(getFinishTimeSliceLimitMsFromHiveConfig(
-          hiveConfig_,
-          connectorQueryCtx->sessionProperties())),
-      maxTargetFileBytes_(hiveConfig_->maxTargetFileSizeBytes(
-          connectorQueryCtx->sessionProperties())),
-      partitionKeyAsLowerCase_(hiveConfig_->isPartitionPathAsLowerCase(
-          connectorQueryCtx_->sessionProperties())),
       fileNameGenerator_(insertTableHandle_->fileNameGenerator()) {
-  fileSystemStats_ = std::make_unique<IoStats>();
-
   if (isBucketed()) {
     VELOX_USER_CHECK_LT(
         bucketCount_,
@@ -547,7 +471,7 @@ HiveDataSink::HiveDataSink(
     VELOX_CHECK(
         !isPartitioned() && !isBucketed(),
         "ensureFiles is not supported with bucketing or partition keys in the data");
-    ensureWriter(HiveWriterId::unpartitionedId());
+    ensureWriter(WriterId::unpartitionedId());
   }
 
   if (!isBucketed()) {
@@ -570,6 +494,7 @@ HiveDataSink::HiveDataSink(
              CompareFlags::NullHandlingMode::kNullAsValue});
       }
     }
+    sortWrite_ = !sortColumnIndices_.empty();
   }
 }
 
@@ -578,145 +503,6 @@ bool HiveDataSink::canReclaim() const {
   return (spillConfig_ != nullptr) &&
       (insertTableHandle_->storageFormat() == dwio::common::FileFormat::DWRF ||
        insertTableHandle_->storageFormat() == dwio::common::FileFormat::NIMBLE);
-}
-
-void HiveDataSink::appendData(RowVectorPtr input) {
-  checkRunning();
-
-  // Lazy load all the input columns.
-  input->loadedVector();
-
-  // Write to unpartitioned (and unbucketed) table.
-  if (!isPartitioned() && !isBucketed()) {
-    const auto index = ensureWriter(HiveWriterId::unpartitionedId());
-    write(index, input);
-    return;
-  }
-
-  // Compute partition and bucket numbers.
-  computePartitionAndBucketIds(input);
-
-  // All inputs belong to a single non-bucketed partition. The partition id
-  // must be zero.
-  if (!isBucketed() && partitionIdGenerator_->numPartitions() == 1) {
-    const auto index = ensureWriter(HiveWriterId{0});
-    write(index, input);
-    return;
-  }
-
-  splitInputRowsAndEnsureWriters();
-
-  for (auto index = 0; index < writers_.size(); ++index) {
-    const vector_size_t partitionSize = partitionSizes_[index];
-    if (partitionSize == 0) {
-      continue;
-    }
-
-    RowVectorPtr writerInput = partitionSize == input->size()
-        ? input
-        : exec::wrap(partitionSize, partitionRows_[index], input);
-    write(index, writerInput);
-  }
-}
-
-void HiveDataSink::write(size_t index, RowVectorPtr input) {
-  WRITER_NON_RECLAIMABLE_SECTION_GUARD(index);
-  auto dataInput = makeDataInput(dataChannels_, input);
-
-  if (writers_[index] == nullptr) {
-    writers_[index] = createWriterForIndex(index);
-  }
-
-  writers_[index]->write(dataInput);
-  writerInfo_[index]->inputSizeInBytes += dataInput->estimateFlatSize();
-  writerInfo_[index]->numWrittenRows += dataInput->size();
-  writerInfo_[index]->currentFileWrittenRows += dataInput->size();
-
-  // File rotation is not supported for bucketed tables (require one file per
-  // bucket with predictable name) or sorted writes (SortingWriter not
-  // recreated).
-  if (maxTargetFileBytes_ == 0 || isBucketed() || sortWrite()) {
-    return;
-  }
-
-  const auto currentFileBytes = getCurrentFileBytes(index);
-  if (currentFileBytes >= maxTargetFileBytes_) {
-    rotateWriter(index);
-  }
-}
-
-uint64_t HiveDataSink::getCurrentFileBytes(size_t writerIndex) const {
-  VELOX_CHECK_LT(writerIndex, ioStats_.size());
-  VELOX_CHECK_LT(writerIndex, writerInfo_.size());
-  const auto totalBytes = ioStats_[writerIndex]->rawBytesWritten();
-  const auto baselineBytes = writerInfo_[writerIndex]->cumulativeWrittenBytes;
-  // Sanity check: total should always be >= baseline since ioStats is
-  // never reset and cumulative is a snapshot of rawBytesWritten at rotation.
-  VELOX_DCHECK_GE(totalBytes, baselineBytes);
-  return totalBytes - baselineBytes;
-}
-
-void HiveDataSink::finalizeWriterFile(size_t index) {
-  VELOX_CHECK_LT(index, writerInfo_.size());
-  VELOX_CHECK_LT(index, ioStats_.size());
-
-  auto& info = writerInfo_[index];
-
-  // Capture current file stats AFTER close to include footer bytes.
-  const auto currentFileBytes = getCurrentFileBytes(index);
-
-  // Finalize the current file into writtenFiles using the stored names.
-  if (currentFileBytes > 0) {
-    HiveFileInfo fileInfo;
-    fileInfo.writeFileName = info->currentWriteFileName;
-    fileInfo.targetFileName = info->currentTargetFileName;
-    fileInfo.fileSize = currentFileBytes;
-    fileInfo.numRows = info->currentFileWrittenRows;
-    // Reset for next file.
-    info->currentFileWrittenRows = 0;
-    info->writtenFiles.push_back(std::move(fileInfo));
-  }
-
-  // Update cumulative stats as a snapshot of total stats so far.
-  // This becomes the baseline for the next file.
-  info->cumulativeWrittenBytes = ioStats_[index]->rawBytesWritten();
-}
-
-// Rotates the current writer to a new file when the file size exceeds the
-// threshold. This enables writing multiple smaller files instead of one large
-// file, which improves downstream read performance and parallel processing.
-void HiveDataSink::rotateWriter(size_t index) {
-  VELOX_CHECK_LT(index, writers_.size());
-  VELOX_CHECK_LT(index, writerInfo_.size());
-
-  auto& info = writerInfo_[index];
-
-  // Close the writer first to flush all data including footer.
-  writers_[index]->close();
-
-  // Finalize the current file state.
-  finalizeWriterFile(index);
-
-  // Release old writer's memory pools. The new writer will be created lazily
-  // on the next write to avoid creating empty files.
-  writers_[index].reset();
-
-  ++info->fileSequenceNumber;
-}
-
-std::string HiveDataSink::stateString(State state) {
-  switch (state) {
-    case State::kRunning:
-      return "RUNNING";
-    case State::kFinishing:
-      return "FLUSHING";
-    case State::kClosed:
-      return "CLOSED";
-    case State::kAborted:
-      return "ABORTED";
-    default:
-      VELOX_UNREACHABLE("BAD STATE: {}", static_cast<int>(state));
-  }
 }
 
 void HiveDataSink::computePartitionAndBucketIds(const RowVectorPtr& input) {
@@ -745,56 +531,8 @@ void HiveDataSink::computePartitionAndBucketIds(const RowVectorPtr& input) {
   }
 }
 
-DataSink::Stats HiveDataSink::stats() const {
-  Stats stats;
-  if (state_ == State::kAborted) {
-    return stats;
-  }
-
-  for (const auto& ioStats : ioStats_) {
-    stats.numWrittenBytes += ioStats->rawBytesWritten();
-    stats.writeIOTimeUs += ioStats->writeIOTimeUs();
-  }
-
-  if (state_ != State::kClosed) {
-    return stats;
-  }
-
-  // Count total files written, including rotated files.
-  stats.numWrittenFiles = 0;
-  for (size_t i = 0; i < writerInfo_.size(); ++i) {
-    const auto& info = writerInfo_.at(i);
-    VELOX_CHECK_NOT_NULL(info);
-    stats.numWrittenFiles += info->writtenFiles.size();
-    if (!info->spillStats->empty()) {
-      stats.spillStats += *info->spillStats;
-    }
-  }
-  return stats;
-}
-
-std::unordered_map<std::string, RuntimeCounter> HiveDataSink::runtimeStats()
-    const {
-  std::unordered_map<std::string, RuntimeCounter> runtimeStats;
-
-  const auto fsStatsMap = fileSystemStats_->stats();
-  for (const auto& [statName, statValue] : fsStatsMap) {
-    runtimeStats.emplace(
-        statName, RuntimeCounter(statValue.sum, statValue.unit));
-  }
-
-  return runtimeStats;
-}
-
-std::shared_ptr<memory::MemoryPool> HiveDataSink::createWriterPool(
-    const HiveWriterId& writerId) {
-  auto* connectorPool = connectorQueryCtx_->connectorMemoryPool();
-  return connectorPool->addAggregateChild(
-      fmt::format("{}.{}", connectorPool->name(), writerId.toString()));
-}
-
 void HiveDataSink::setMemoryReclaimers(
-    HiveWriterInfo* writerInfo,
+    WriterInfo* writerInfo,
     io::IoStatistics* ioStats) {
   auto* connectorPool = connectorQueryCtx_->connectorMemoryPool();
   if (connectorPool->reclaimer() == nullptr) {
@@ -805,65 +543,6 @@ void HiveDataSink::setMemoryReclaimers(
   writerInfo->sinkPool->setReclaimer(exec::MemoryReclaimer::create());
   // NOTE: we set the memory reclaimer for sort pool when we construct the sort
   // writer.
-}
-
-void HiveDataSink::setState(State newState) {
-  checkStateTransition(state_, newState);
-  state_ = newState;
-}
-
-/// Validates the state transition from 'oldState' to 'newState'.
-void HiveDataSink::checkStateTransition(State oldState, State newState) {
-  switch (oldState) {
-    case State::kRunning:
-      if (newState == State::kAborted || newState == State::kFinishing) {
-        return;
-      }
-      break;
-    case State::kFinishing:
-      if (newState == State::kAborted || newState == State::kClosed ||
-          // The finishing state is reentry state if we yield in the middle of
-          // finish processing if a single run takes too long.
-          newState == State::kFinishing) {
-        return;
-      }
-      [[fallthrough]];
-    case State::kAborted:
-    case State::kClosed:
-    default:
-      break;
-  }
-  VELOX_FAIL("Unexpected state transition from {} to {}", oldState, newState);
-}
-
-bool HiveDataSink::finish() {
-  // Flush is reentry state.
-  setState(State::kFinishing);
-
-  // As for now, only sorted writer needs flush buffered data. For non-sorted
-  // writer, data is directly written to the underlying file writer.
-  if (!sortWrite()) {
-    return true;
-  }
-
-  // TODO: we might refactor to move the data sorting logic into hive data sink.
-  const uint64_t startTimeMs = getCurrentTimeMs();
-  for (auto i = 0; i < writers_.size(); ++i) {
-    WRITER_NON_RECLAIMABLE_SECTION_GUARD(i);
-    if (!writers_[i]->finish()) {
-      return false;
-    }
-    if (getCurrentTimeMs() - startTimeMs > sortWriterFinishTimeSliceLimitMs_) {
-      return false;
-    }
-  }
-  return true;
-}
-
-std::vector<std::string> HiveDataSink::close() {
-  setState(State::kClosed);
-  closeInternal();
-  return commitMessage();
 }
 
 std::vector<std::string> HiveDataSink::commitMessage() const {
@@ -887,7 +566,7 @@ std::vector<std::string> HiveDataSink::commitMessage() const {
        folly::dynamic::object
           (HiveCommitMessage::kName, info->writerParameters.partitionName().value_or(""))
           (HiveCommitMessage::kUpdateMode,
-            HiveWriterParameters::updateModeToString(
+            WriterParameters::updateModeToString(
               info->writerParameters.updateMode()))
           (HiveCommitMessage::kWritePath, info->writerParameters.writeDirectory())
           (HiveCommitMessage::kTargetPath, info->writerParameters.targetDirectory())
@@ -900,50 +579,6 @@ std::vector<std::string> HiveDataSink::commitMessage() const {
     partitionUpdates.push_back(partitionUpdateJson);
   }
   return partitionUpdates;
-}
-
-void HiveDataSink::abort() {
-  setState(State::kAborted);
-  closeInternal();
-}
-
-void HiveDataSink::closeInternal() {
-  VELOX_CHECK_NE(state_, State::kRunning);
-  VELOX_CHECK_NE(state_, State::kFinishing);
-
-  TestValue::adjust(
-      "facebook::velox::connector::hive::HiveDataSink::closeInternal", this);
-
-  // NOTE: writers_[i] can be nullptr during file rotation. In rotateWriter(),
-  // we call writers_[index].reset() to release the old writer before creating
-  // a new one. If an error occurs during new writer creation, or if abort is
-  // called during this window, the writer slot may be empty.
-  if (state_ == State::kClosed) {
-    for (int i = 0; i < writers_.size(); ++i) {
-      if (writers_[i] == nullptr) {
-        continue;
-      }
-      WRITER_NON_RECLAIMABLE_SECTION_GUARD(i);
-      writers_[i]->close();
-      finalizeWriterFile(i);
-    }
-  } else {
-    for (int i = 0; i < writers_.size(); ++i) {
-      if (writers_[i] == nullptr) {
-        continue;
-      }
-      WRITER_NON_RECLAIMABLE_SECTION_GUARD(i);
-      writers_[i]->abort();
-    }
-  }
-}
-
-uint32_t HiveDataSink::ensureWriter(const HiveWriterId& id) {
-  auto it = writerIndexMap_.find(id);
-  if (it != writerIndexMap_.end()) {
-    return it->second;
-  }
-  return appendWriter(id);
 }
 
 std::shared_ptr<dwio::common::WriterOptions> HiveDataSink::createWriterOptions()
@@ -1007,51 +642,6 @@ std::shared_ptr<dwio::common::WriterOptions> HiveDataSink::createWriterOptions(
       connectorQueryCtx_->adjustTimestampToTimezone();
   options->processConfigs(*hiveConfig_->config(), *connectorSessionProperties);
   return options;
-}
-
-uint32_t HiveDataSink::appendWriter(const HiveWriterId& id) {
-  // Check max open writers.
-  VELOX_USER_CHECK_LE(
-      writers_.size(), maxOpenWriters_, "Exceeded open writer limit");
-  VELOX_CHECK_EQ(writers_.size(), writerInfo_.size());
-  VELOX_CHECK_EQ(writerIndexMap_.size(), writerInfo_.size());
-
-  std::optional<std::string> partitionName;
-  if (isPartitioned()) {
-    partitionName = getPartitionName(id.partitionId.value());
-  }
-
-  // Without explicitly setting flush policy, the default memory based flush
-  // policy is used.
-  auto writerParameters = getWriterParameters(partitionName, id.bucketId);
-  auto writerPool = createWriterPool(id);
-  auto sinkPool = createSinkPool(writerPool);
-  std::shared_ptr<memory::MemoryPool> sortPool{nullptr};
-  if (sortWrite()) {
-    sortPool = createSortPool(writerPool);
-  }
-  writerInfo_.emplace_back(
-      std::make_shared<HiveWriterInfo>(
-          std::move(writerParameters),
-          std::move(writerPool),
-          std::move(sinkPool),
-          std::move(sortPool)));
-  ioStats_.emplace_back(std::make_unique<io::IoStatistics>());
-
-  setMemoryReclaimers(writerInfo_.back().get(), ioStats_.back().get());
-  writers_.emplace_back(createWriterForIndex(writerInfo_.size() - 1));
-  addThreadLocalRuntimeStat(
-      fmt::format(
-          "{}WriterCount",
-          dwio::common::toString(insertTableHandle_->storageFormat())),
-      RuntimeCounter(1));
-  // Extends the buffer used for partition rows calculations.
-  partitionSizes_.emplace_back(0);
-  partitionRows_.emplace_back(nullptr);
-  rawPartitionRows_.emplace_back(nullptr);
-
-  writerIndexMap_.emplace(id, writers_.size() - 1);
-  return writerIndexMap_[id];
 }
 
 std::unique_ptr<dwio::common::Writer> HiveDataSink::createWriterForIndex(
@@ -1125,68 +715,12 @@ HiveDataSink::maybeCreateBucketSortWriter(
       sortWriterFinishTimeSliceLimitMs_);
 }
 
-HiveWriterId HiveDataSink::getWriterId(size_t row) const {
-  std::optional<int32_t> partitionId;
-  if (isPartitioned()) {
-    VELOX_CHECK_LT(partitionIds_[row], std::numeric_limits<uint32_t>::max());
-    partitionId = static_cast<uint32_t>(partitionIds_[row]);
-  }
-
-  std::optional<int32_t> bucketId;
-  if (isBucketed()) {
-    bucketId = bucketIds_[row];
-  }
-  return HiveWriterId{partitionId, bucketId};
-}
-
-void HiveDataSink::updatePartitionRows(
-    uint32_t index,
-    vector_size_t numRows,
-    vector_size_t row) {
-  VELOX_DCHECK_LT(index, partitionSizes_.size());
-  VELOX_DCHECK_EQ(partitionSizes_.size(), partitionRows_.size());
-  VELOX_DCHECK_EQ(partitionRows_.size(), rawPartitionRows_.size());
-  if (FOLLY_UNLIKELY(partitionRows_[index] == nullptr) ||
-      (partitionRows_[index]->capacity() < numRows * sizeof(vector_size_t))) {
-    partitionRows_[index] =
-        allocateIndices(numRows, connectorQueryCtx_->memoryPool());
-    rawPartitionRows_[index] =
-        partitionRows_[index]->asMutable<vector_size_t>();
-  }
-  rawPartitionRows_[index][partitionSizes_[index]] = row;
-  ++partitionSizes_[index];
-}
-
-void HiveDataSink::splitInputRowsAndEnsureWriters() {
-  VELOX_CHECK(isPartitioned() || isBucketed());
-  if (isBucketed() && isPartitioned()) {
-    VELOX_CHECK_EQ(bucketIds_.size(), partitionIds_.size());
-  }
-
-  std::fill(partitionSizes_.begin(), partitionSizes_.end(), 0);
-
-  const auto numRows =
-      isPartitioned() ? partitionIds_.size() : bucketIds_.size();
-  for (auto row = 0; row < numRows; ++row) {
-    const auto id = getWriterId(row);
-    const uint32_t index = ensureWriter(id);
-    updatePartitionRows(index, numRows, row);
-  }
-
-  for (uint32_t i = 0; i < partitionSizes_.size(); ++i) {
-    if (partitionSizes_[i] != 0) {
-      VELOX_CHECK_NOT_NULL(partitionRows_[i]);
-      partitionRows_[i]->setSize(partitionSizes_[i] * sizeof(vector_size_t));
-    }
-  }
-}
-
-HiveWriterParameters HiveDataSink::getWriterParameters(
+WriterParameters HiveDataSink::getWriterParameters(
     const std::optional<std::string>& partition,
     std::optional<uint32_t> bucketId) const {
   auto [targetFileName, writeFileName] = getWriterFileNames(bucketId);
 
-  return HiveWriterParameters{
+  return WriterParameters{
       updateMode_,
       partition,
       targetFileName,
@@ -1303,16 +837,16 @@ std::string HiveInsertFileNameGenerator::toString() const {
   return "HiveInsertFileNameGenerator";
 }
 
-HiveWriterParameters::UpdateMode HiveDataSink::getUpdateMode() const {
+WriterParameters::UpdateMode HiveDataSink::getUpdateMode() const {
   if (insertTableHandle_->isExistingTable()) {
     if (insertTableHandle_->isPartitioned()) {
       const auto insertBehavior = hiveConfig_->insertExistingPartitionsBehavior(
           connectorQueryCtx_->sessionProperties());
       switch (insertBehavior) {
         case HiveConfig::InsertExistingPartitionsBehavior::kOverwrite:
-          return HiveWriterParameters::UpdateMode::kOverwrite;
+          return WriterParameters::UpdateMode::kOverwrite;
         case HiveConfig::InsertExistingPartitionsBehavior::kError:
-          return HiveWriterParameters::UpdateMode::kNew;
+          return WriterParameters::UpdateMode::kNew;
         default:
           VELOX_UNSUPPORTED(
               "Unsupported insert existing partitions behavior: {}",
@@ -1323,10 +857,10 @@ HiveWriterParameters::UpdateMode HiveDataSink::getUpdateMode() const {
       if (hiveConfig_->immutablePartitions()) {
         VELOX_USER_FAIL("Unpartitioned Hive tables are immutable.");
       }
-      return HiveWriterParameters::UpdateMode::kAppend;
+      return WriterParameters::UpdateMode::kAppend;
     }
   } else {
-    return HiveWriterParameters::UpdateMode::kNew;
+    return WriterParameters::UpdateMode::kNew;
   }
 }
 
@@ -1506,7 +1040,7 @@ LocationHandlePtr LocationHandle::create(const folly::dynamic& obj) {
 
 std::unique_ptr<memory::MemoryReclaimer> HiveDataSink::WriterReclaimer::create(
     HiveDataSink* dataSink,
-    HiveWriterInfo* writerInfo,
+    WriterInfo* writerInfo,
     io::IoStatistics* ioStats) {
   return std::unique_ptr<memory::MemoryReclaimer>(
       new HiveDataSink::WriterReclaimer(dataSink, writerInfo, ioStats));

--- a/velox/connectors/hive/HiveDataSink.h
+++ b/velox/connectors/hive/HiveDataSink.h
@@ -17,6 +17,7 @@
 
 #include "velox/common/compression/Compression.h"
 #include "velox/connectors/Connector.h"
+#include "velox/connectors/hive/FileDataSink.h"
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/HivePartitionName.h"
 #include "velox/connectors/hive/PartitionIdGenerator.h"
@@ -349,189 +350,6 @@ class HiveInsertTableHandle : public ConnectorInsertTableHandle {
   const std::vector<column_index_t> nonPartitionChannels_;
 };
 
-/// Parameters for Hive writers.
-class HiveWriterParameters {
- public:
-  enum class UpdateMode {
-    kNew, // Write files to a new directory.
-    kOverwrite, // Overwrite an existing directory.
-    // Append mode is currently only supported for unpartitioned tables.
-    kAppend, // Append to an unpartitioned table.
-  };
-
-  /// @param updateMode Write the files to a new directory, or append to an
-  /// existing directory or overwrite an existing directory.
-  /// @param partitionName Partition name in the typical Hive style, which is
-  /// also the partition subdirectory part of the partition path.
-  /// @param targetFileName The final name of a file after committing.
-  /// @param targetDirectory The final directory that a file should be in after
-  /// committing.
-  /// @param writeFileName The temporary name of the file that a running writer
-  /// writes to. If a running writer writes directory to the target file, set
-  /// writeFileName to targetFileName by default.
-  /// @param writeDirectory The temporary directory that a running writer writes
-  /// to. If a running writer writes directory to the target directory, set
-  /// writeDirectory to targetDirectory by default.
-  HiveWriterParameters(
-      UpdateMode updateMode,
-      std::optional<std::string> partitionName,
-      std::string targetFileName,
-      std::string targetDirectory,
-      std::optional<std::string> writeFileName = std::nullopt,
-      std::optional<std::string> writeDirectory = std::nullopt)
-      : updateMode_(updateMode),
-        partitionName_(std::move(partitionName)),
-        targetFileName_(std::move(targetFileName)),
-        targetDirectory_(std::move(targetDirectory)),
-        writeFileName_(writeFileName.value_or(targetFileName_)),
-        writeDirectory_(writeDirectory.value_or(targetDirectory_)) {}
-
-  UpdateMode updateMode() const {
-    return updateMode_;
-  }
-
-  static std::string updateModeToString(UpdateMode updateMode) {
-    switch (updateMode) {
-      case UpdateMode::kNew:
-        return "NEW";
-      case UpdateMode::kOverwrite:
-        return "OVERWRITE";
-      case UpdateMode::kAppend:
-        return "APPEND";
-      default:
-        VELOX_UNSUPPORTED("Unsupported update mode.");
-    }
-  }
-
-  const std::optional<std::string>& partitionName() const {
-    return partitionName_;
-  }
-
-  const std::string& targetFileName() const {
-    return targetFileName_;
-  }
-
-  const std::string& writeFileName() const {
-    return writeFileName_;
-  }
-
-  const std::string& targetDirectory() const {
-    return targetDirectory_;
-  }
-
-  const std::string& writeDirectory() const {
-    return writeDirectory_;
-  }
-
- private:
-  const UpdateMode updateMode_;
-  const std::optional<std::string> partitionName_;
-  const std::string targetFileName_;
-  const std::string targetDirectory_;
-  const std::string writeFileName_;
-  const std::string writeDirectory_;
-};
-
-/// Information about a single file written as part of a writer's output.
-/// When file rotation occurs, multiple HiveFileInfo entries are created.
-struct HiveFileInfo {
-  /// The temporary file name used during writing (in the staging directory).
-  std::string writeFileName;
-  /// The final file name after commit (in the target directory).
-  std::string targetFileName;
-  /// Size of the file in bytes.
-  uint64_t fileSize{0};
-  /// Number of rows in the file.
-  uint64_t numRows{0};
-};
-
-struct HiveWriterInfo {
-  HiveWriterInfo(
-      HiveWriterParameters parameters,
-      std::shared_ptr<memory::MemoryPool> _writerPool,
-      std::shared_ptr<memory::MemoryPool> _sinkPool,
-      std::shared_ptr<memory::MemoryPool> _sortPool)
-      : writerParameters(std::move(parameters)),
-        nonReclaimableSectionHolder(new tsan_atomic<bool>(false)),
-        spillStats(std::make_unique<exec::SpillStats>()),
-        writerPool(std::move(_writerPool)),
-        sinkPool(std::move(_sinkPool)),
-        sortPool(std::move(_sortPool)) {}
-
-  const HiveWriterParameters writerParameters;
-  const std::unique_ptr<tsan_atomic<bool>> nonReclaimableSectionHolder;
-  /// Collects the spill stats from sort writer if the spilling has been
-  /// triggered.
-  const std::unique_ptr<exec::SpillStats> spillStats;
-  const std::shared_ptr<memory::MemoryPool> writerPool;
-  const std::shared_ptr<memory::MemoryPool> sinkPool;
-  const std::shared_ptr<memory::MemoryPool> sortPool;
-  /// Total rows written by this writer across all files.
-  uint64_t numWrittenRows = 0;
-  /// Rows written to the current file; reset to 0 when the file is finalized.
-  uint64_t currentFileWrittenRows{0};
-  uint64_t inputSizeInBytes = 0;
-  /// File sequence number for tracking multiple files written due to size-based
-  /// splitting. Incremented each time the writer rotates to a new file.
-  /// Used to generate sequenced file names (e.g., file_1.orc, file_2.orc).
-  /// Invariant during write: fileSequenceNumber == writtenFiles.size()
-  /// After close: fileSequenceNumber + 1 == writtenFiles.size() (final file
-  /// added)
-  uint32_t fileSequenceNumber{0};
-  /// Tracks all files written by this writer.
-  /// During write: contains only rotated (completed) files.
-  /// After close: contains all files including the final one (via
-  /// finalizeWriterFile).
-  std::vector<HiveFileInfo> writtenFiles;
-  /// Snapshot of total bytes written at the start of the current file.
-  /// Used as baseline to calculate current file size: rawBytesWritten() - this.
-  /// Updated to ioStats->rawBytesWritten() after each rotation.
-  uint64_t cumulativeWrittenBytes{0};
-  /// Current file's write filename (set when file is created/rotated).
-  /// This avoids recomputing makeSequencedFileName() in commitMessage().
-  std::string currentWriteFileName;
-  /// Current file's target filename (set when file is created/rotated).
-  std::string currentTargetFileName;
-};
-
-/// Identifies a hive writer.
-struct HiveWriterId {
-  std::optional<uint32_t> partitionId{std::nullopt};
-  std::optional<uint32_t> bucketId{std::nullopt};
-
-  HiveWriterId() = default;
-
-  HiveWriterId(
-      std::optional<uint32_t> _partitionId,
-      std::optional<uint32_t> _bucketId = std::nullopt)
-      : partitionId(_partitionId), bucketId(_bucketId) {}
-
-  /// Returns the special writer id for the un-partitioned (and non-bucketed)
-  /// table.
-  static const HiveWriterId& unpartitionedId();
-
-  std::string toString() const;
-
-  bool operator==(const HiveWriterId& other) const {
-    return std::tie(partitionId, bucketId) ==
-        std::tie(other.partitionId, other.bucketId);
-  }
-};
-
-struct HiveWriterIdHasher {
-  std::size_t operator()(const HiveWriterId& id) const {
-    return bits::hashMix(
-        id.partitionId.value_or(std::numeric_limits<uint32_t>::max()),
-        id.bucketId.value_or(std::numeric_limits<uint32_t>::max()));
-  }
-};
-
-struct HiveWriterIdEq {
-  bool operator()(const HiveWriterId& lhs, const HiveWriterId& rhs) const {
-    return lhs == rhs;
-  }
-};
-
 /// JSON field names for the partition update object produced by each writer
 /// and consumed by the Presto coordinator to finalize files and update the
 /// metastore.
@@ -587,24 +405,10 @@ struct HiveCommitMessage {
       "containsNumberedFileNames";
 };
 
-class HiveDataSink : public DataSink {
+class HiveDataSink : public FileDataSink {
  public:
   /// The list of runtime stats reported by hive data sink
   static constexpr const char* kEarlyFlushedRawBytes = "earlyFlushedRawBytes";
-
-  /// Defines the execution states of a hive data sink running internally.
-  enum class State {
-    /// The data sink accepts new append data in this state.
-    kRunning = 0,
-    /// The data sink flushes any buffered data to the underlying file writer
-    /// but no more data can be appended.
-    kFinishing = 1,
-    /// The data sink is aborted on error and no more data can be appended.
-    kAborted = 2,
-    /// The data sink is closed on error and no more data can be appended.
-    kClosed = 3
-  };
-  static std::string stateString(State state);
 
   /// Creates a HiveDataSink for writing data to Hive table files.
   ///
@@ -661,38 +465,16 @@ class HiveDataSink : public DataSink {
       const std::vector<column_index_t>& dataChannels,
       std::unique_ptr<PartitionIdGenerator> partitionIdGenerator);
 
-  void appendData(RowVectorPtr input) override;
-
-  bool finish() override;
-
-  Stats stats() const override;
-
-  std::unordered_map<std::string, RuntimeCounter> runtimeStats() const override;
-
-  std::vector<std::string> close() override;
-
-  void abort() override;
-
   bool canReclaim() const;
 
  protected:
-  // Validates the state transition from 'oldState' to 'newState'.
-  void checkStateTransition(State oldState, State newState);
-  void setState(State newState);
-
-  // Generates commit messages for all writers containing metadata about written
-  // files. Creates a JSON object for each writer with partition name,
-  // file paths, file names, data sizes, and row counts. This metadata is used
-  // by the coordinator to commit the transaction and update the metastore.
-  //
-  // @return Vector of JSON strings, one per writer.
-  virtual std::vector<std::string> commitMessage() const;
+  std::vector<std::string> commitMessage() const override;
 
   class WriterReclaimer : public exec::MemoryReclaimer {
    public:
     static std::unique_ptr<memory::MemoryReclaimer> create(
         HiveDataSink* dataSink,
-        HiveWriterInfo* writerInfo,
+        WriterInfo* writerInfo,
         io::IoStatistics* ioStats);
 
     bool reclaimableBytes(
@@ -708,7 +490,7 @@ class HiveDataSink : public DataSink {
    private:
     WriterReclaimer(
         HiveDataSink* dataSink,
-        HiveWriterInfo* writerInfo,
+        WriterInfo* writerInfo,
         io::IoStatistics* ioStats)
         : exec::MemoryReclaimer(0),
           dataSink_(dataSink),
@@ -720,210 +502,56 @@ class HiveDataSink : public DataSink {
     }
 
     HiveDataSink* const dataSink_;
-    HiveWriterInfo* const writerInfo_;
+    WriterInfo* const writerInfo_;
     io::IoStatistics* const ioStats_;
   };
 
-  FOLLY_ALWAYS_INLINE bool sortWrite() const {
-    return !sortColumnIndices_.empty();
-  }
-
-  // Returns true if the table is partitioned.
-  FOLLY_ALWAYS_INLINE bool isPartitioned() const {
-    return partitionIdGenerator_ != nullptr;
-  }
-
-  // Returns true if the table is bucketed.
-  FOLLY_ALWAYS_INLINE bool isBucketed() const {
-    return bucketCount_ != 0;
-  }
-
-  FOLLY_ALWAYS_INLINE bool isCommitRequired() const {
-    return commitStrategy_ != CommitStrategy::kNoCommit;
-  }
-
-  std::shared_ptr<memory::MemoryPool> createWriterPool(
-      const HiveWriterId& writerId);
-
-  void setMemoryReclaimers(
-      HiveWriterInfo* writerInfo,
-      io::IoStatistics* ioStats);
-
-  // Returns the bytes written to the current file for the specified writer.
-  // This is calculated as total bytes minus cumulative bytes from rotated
-  // files. Use this instead of rawBytesWritten() when you need current file
-  // size.
-  uint64_t getCurrentFileBytes(size_t writerIndex) const;
+  void setMemoryReclaimers(WriterInfo* writerInfo, io::IoStatistics* ioStats)
+      override;
 
   // Compute the partition id and bucket id for each row in 'input'.
-  virtual void computePartitionAndBucketIds(const RowVectorPtr& input);
+  void computePartitionAndBucketIds(const RowVectorPtr& input) override;
 
-  // Get the HiveWriter corresponding to the row
-  // from partitionIds and bucketIds.
-  HiveWriterId getWriterId(size_t row) const;
-
-  // Computes the number of input rows as well as the actual input row indices
-  // to each corresponding (bucketed) partition based on the partition and
-  // bucket ids calculated by 'computePartitionAndBucketIds'. The function also
-  // ensures that there is a writer created for each (bucketed) partition.
-  void splitInputRowsAndEnsureWriters();
-
-  // Makes sure to create one writer for the given writer id. The function
-  // returns the corresponding index in 'writers_'.
-  virtual uint32_t ensureWriter(const HiveWriterId& id);
-
-  // Appends a new writer for the given 'id'. The function returns the index of
-  // the newly created writer in 'writers_'.
-  uint32_t appendWriter(const HiveWriterId& id);
-
-  // Creates a writer for the given index using the current file sequence.
   std::unique_ptr<facebook::velox::dwio::common::Writer> createWriterForIndex(
-      size_t writerIndex);
+      size_t writerIndex) override;
 
   // Creates and configures WriterOptions based on file format.
-  // Sets up compression, schema, and other writer configuration based on the
-  // insert table handle and connector settings.
-  // The no-argument overload uses the last writer's info (for appendWriter).
-  virtual std::shared_ptr<dwio::common::WriterOptions> createWriterOptions()
-      const;
+  std::shared_ptr<dwio::common::WriterOptions> createWriterOptions()
+      const override;
 
-  // Creates WriterOptions for a specific writer index. Use this overload
-  // during writer rotation to ensure the correct writer's memory pool and
-  // nonReclaimableSection are used.
-  std::shared_ptr<dwio::common::WriterOptions> createWriterOptions(
-      size_t writerIndex) const;
+  virtual std::shared_ptr<dwio::common::WriterOptions> createWriterOptions(
+      size_t writerIndex) const override;
 
   // Returns the Hive partition directory name for the given partition ID.
-  // Converts the partition values associated with the partition ID into a
-  // Hive-formatted directory path. Returns std::nullopt if the table is
-  // unpartitioned. Should be called only when writing to a partitioned table.
-  virtual std::string getPartitionName(uint32_t partitionId) const;
+  virtual std::string getPartitionName(uint32_t partitionId) const override;
 
   std::unique_ptr<facebook::velox::dwio::common::Writer>
   maybeCreateBucketSortWriter(
       size_t writerIndex,
       std::unique_ptr<facebook::velox::dwio::common::Writer> writer);
 
-  // Records a row index for a specific partition. This method maintains the
-  // mapping of which input rows belong to which partition by storing row
-  // indices in partition-specific buffers. If the buffer for the partition
-  // doesn't exist or is too small, it allocates/reallocates the buffer to
-  // accommodate all rows.
-  void
-  updatePartitionRows(uint32_t index, vector_size_t numRows, vector_size_t row);
-
-  HiveWriterParameters getWriterParameters(
+  WriterParameters getWriterParameters(
       const std::optional<std::string>& partition,
-      std::optional<uint32_t> bucketId) const;
+      std::optional<uint32_t> bucketId) const override;
 
-  // Gets write and target file names for a writer based on the table commit
-  // strategy as well as table partitioned type. If commit is not required, the
-  // write file and target file has the same name. If not, add a temp file
-  // prefix to the target file for write file name. The coordinator (or driver
-  // for Presto on spark) will rename the write file to target file to commit
-  // the table write when update the metadata store. If it is a bucketed table,
-  // the file name encodes the corresponding bucket id.
+  // Gets write and target file names for a writer.
   std::pair<std::string, std::string> getWriterFileNames(
       std::optional<uint32_t> bucketId) const;
 
-  HiveWriterParameters::UpdateMode getUpdateMode() const;
+  WriterParameters::UpdateMode getUpdateMode() const;
 
-  FOLLY_ALWAYS_INLINE void checkRunning() const {
-    VELOX_CHECK_EQ(state_, State::kRunning, "Hive data sink is not running");
-  }
-
-  // Invoked to write 'input' to the specified file writer.
-  void write(size_t index, RowVectorPtr input);
-
-  /// Rotates the writer at the given index to a new file. This is called when
-  /// the current file exceeds maxTargetFileBytes_. The old writer is closed
-  /// and a new writer is created for the same partition/bucket.
-  void rotateWriter(size_t index);
-
-  /// Finalizes the current file for the writer at the given index.
-  /// Captures file stats and adds the file info to writtenFiles.
-  /// Called by rotateWriter() and closeInternal().
-  void finalizeWriterFile(size_t index);
-
-  void closeInternal();
-
-  // IMPORTANT NOTE: these are passed to writers as raw pointers. HiveDataSink
-  // owns the lifetime of these objects, and therefore must destroy them last.
-  // Additionally, we must assume that no objects which hold a reference to
-  // these stats will outlive the HiveDataSink instance. This is a reasonable
-  // assumption given the semantics of these stats objects.
-  std::vector<std::unique_ptr<io::IoStatistics>> ioStats_;
-  // Generic filesystem stats, exposed as RuntimeStats
-  std::unique_ptr<IoStats> fileSystemStats_;
-
-  const RowTypePtr inputType_;
   const std::shared_ptr<const HiveInsertTableHandle> insertTableHandle_;
-  const ConnectorQueryCtx* const connectorQueryCtx_;
-  const CommitStrategy commitStrategy_;
   const std::shared_ptr<const HiveConfig> hiveConfig_;
-  const HiveWriterParameters::UpdateMode updateMode_;
-  const uint32_t maxOpenWriters_;
-  const std::vector<column_index_t> partitionChannels_;
-  const std::unique_ptr<PartitionIdGenerator> partitionIdGenerator_;
-  // Indices of dataChannel are stored in ascending order
-  const std::vector<column_index_t> dataChannels_;
-  const int32_t bucketCount_{0};
-  const std::unique_ptr<core::PartitionFunction> bucketFunction_;
-  const std::shared_ptr<dwio::common::WriterFactory> writerFactory_;
-  const common::SpillConfig* const spillConfig_;
-  const uint64_t sortWriterFinishTimeSliceLimitMs_{0};
-  const uint64_t maxTargetFileBytes_{0};
-  const bool partitionKeyAsLowerCase_;
+  const WriterParameters::UpdateMode updateMode_;
 
   std::vector<column_index_t> sortColumnIndices_;
   std::vector<CompareFlags> sortCompareFlags_;
-
-  State state_{State::kRunning};
-
-  tsan_atomic<bool> nonReclaimableSection_{false};
-
-  // The map from writer id to the writer index in 'writers_' and 'writerInfo_'.
-  folly::F14FastMap<HiveWriterId, uint32_t, HiveWriterIdHasher, HiveWriterIdEq>
-      writerIndexMap_;
-
-  // Below are structures for partitions from all inputs. writerInfo_ and
-  // writers_ are both indexed by partitionId.
-  std::vector<std::shared_ptr<HiveWriterInfo>> writerInfo_;
-  std::vector<std::unique_ptr<dwio::common::Writer>> writers_;
-
-  // Below are structures updated when processing current input. partitionIds_
-  // are indexed by the row of input_. partitionRows_, rawPartitionRows_ and
-  // partitionSizes_ are indexed by partitionId.
-  raw_vector<uint64_t> partitionIds_;
-  std::vector<BufferPtr> partitionRows_;
-  std::vector<vector_size_t*> rawPartitionRows_;
-  std::vector<vector_size_t> partitionSizes_;
-
-  // Reusable buffers for bucket id calculations.
-  std::vector<uint32_t> bucketIds_;
 
   // Strategy for naming writer files
   std::shared_ptr<const FileNameGenerator> fileNameGenerator_;
 };
 
-FOLLY_ALWAYS_INLINE std::ostream& operator<<(
-    std::ostream& os,
-    HiveDataSink::State state) {
-  os << HiveDataSink::stateString(state);
-  return os;
-}
 } // namespace facebook::velox::connector::hive
-
-template <>
-struct fmt::formatter<facebook::velox::connector::hive::HiveDataSink::State>
-    : formatter<std::string> {
-  auto format(
-      facebook::velox::connector::hive::HiveDataSink::State s,
-      format_context& ctx) const {
-    return formatter<std::string>::format(
-        facebook::velox::connector::hive::HiveDataSink::stateString(s), ctx);
-  }
-};
 
 template <>
 struct fmt::formatter<

--- a/velox/connectors/hive/iceberg/IcebergDataSink.cpp
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.cpp
@@ -377,7 +377,7 @@ std::string IcebergDataSink::getPartitionName(uint32_t partitionId) const {
       partitionKeyAsLowerCase_);
 }
 
-uint32_t IcebergDataSink::ensureWriter(const HiveWriterId& id) {
+uint32_t IcebergDataSink::ensureWriter(const WriterId& id) {
   auto writerId = HiveDataSink::ensureWriter(id);
   if (isPartitioned() && commitPartitionValue_[writerId].isNull()) {
     commitPartitionValue_[writerId] = makeCommitPartitionValue(writerId);

--- a/velox/connectors/hive/iceberg/IcebergDataSink.h
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.h
@@ -150,7 +150,7 @@ class IcebergDataSink : public HiveDataSink {
   // Additionally, extracts and stores the transformed partition values for
   // the writer in commitPartitionValue_ if not already set, which will be
   // included in the commit message as "partitionDataJson".
-  uint32_t ensureWriter(const HiveWriterId& id) override;
+  uint32_t ensureWriter(const WriterId& id) override;
 
   // Creates writer options configured for Iceberg table writes. Extends the
   // base HiveDataSink writer options with Iceberg-specific settings:

--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -620,7 +620,7 @@ TEST_F(HiveDataSinkTest, close) {
     const auto partitions = dataSink->close();
     // Can't append after close.
     VELOX_ASSERT_THROW(
-        dataSink->appendData(vectors.back()), "Hive data sink is not running");
+        dataSink->appendData(vectors.back()), "File data sink is not running");
     VELOX_ASSERT_THROW(
         dataSink->close(), "Unexpected state transition from CLOSED to CLOSED");
     VELOX_ASSERT_THROW(
@@ -668,7 +668,7 @@ TEST_F(HiveDataSinkTest, abort) {
         "Unexpected state transition from ABORTED to ABORTED");
     // Can't append after abort.
     VELOX_ASSERT_THROW(
-        dataSink->appendData(vectors.back()), "Hive data sink is not running");
+        dataSink->appendData(vectors.back()), "File data sink is not running");
   }
 }
 

--- a/velox/exec/tests/TableWriterTest.cpp
+++ b/velox/exec/tests/TableWriterTest.cpp
@@ -2752,9 +2752,9 @@ DEBUG_ONLY_TEST_P(UnpartitionedTableWriterTest, dataSinkAbortError) {
 
   std::atomic<bool> triggerAbortErrorOnce{true};
   SCOPED_TESTVALUE_SET(
-      "facebook::velox::connector::hive::HiveDataSink::closeInternal",
-      std::function<void(const HiveDataSink*)>(
-          [&](const HiveDataSink* /*unused*/) {
+      "facebook::velox::connector::hive::FileDataSink::closeInternal",
+      std::function<void(const FileDataSink*)>(
+          [&](const FileDataSink* /*unused*/) {
             if (!triggerAbortErrorOnce.exchange(false)) {
               return;
             }


### PR DESCRIPTION
Summary:

Extract a generic `FileDataSink` base class from `HiveDataSink` to enable reuse of the write pipeline by other table format connectors (e.g., Paimon).

This follows the same pattern as the read-side extraction (`FileDataSource`/`FileSplitReader` → `HiveDataSource`/`HiveSplitReader`).

**What moves to FileDataSink (base class):**
- State machine (kRunning/kFinishing/kAborted/kClosed)
- Row routing to writers (`appendData`, `splitInputRowsAndEnsureWriters`)
- Writer lifecycle (`ensureWriter`, `appendWriter`, `write`, `rotateWriter`, `finalizeWriterFile`)
- File rotation based on `maxTargetFileBytes`
- Stats aggregation (`stats`, `runtimeStats`)
- `finish()` with sort writer time slicing
- `close()`/`abort()` orchestration
- Supporting types: `HiveWriterParameters`, `HiveWriterInfo`, `HiveFileInfo`, `HiveWriterId`

**What stays in HiveDataSink (subclass):**
- `commitMessage()` — Hive/Presto JSON commit protocol
- `computePartitionAndBucketIds()` — null partition key handling via `HiveConfig`
- `createWriterForIndex()` — Hive file sink creation with `LocationHandle` staging paths
- `createWriterOptions()` — Hive-specific writer options
- `getPartitionName()` / `getWriterParameters()` — Hive partition naming and update modes
- `setMemoryReclaimers()` — `WriterReclaimer` with DWRF/NIMBLE format checks
- `LocationHandle`, `HiveInsertTableHandle`, `HiveBucketProperty`, `HiveSortingColumn`
- `FileNameGenerator`, `HiveInsertFileNameGenerator`, `HiveCommitMessage`

**IcebergDataSink** continues to extend `HiveDataSink` — no changes needed.

This is a pure refactor with no behavior changes.

Reviewed By: xiaoxmeng

Differential Revision: D99814921


