### PR TITLE
feat(tdigest): Add approx_winsorize window function for per-row winsorized values (#17346)

### DIFF
--- a/velox/functions/prestosql/window/ApproxWinsorize.cpp
+++ b/velox/functions/prestosql/window/ApproxWinsorize.cpp
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/WindowFunction.h"
+#include "velox/expression/FunctionSignature.h"
+#include "velox/functions/lib/TDigest.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::velox::window::prestosql {
+
+namespace {
+
+constexpr double kMinCompression = 10.0;
+constexpr double kMaxCompression = 1'000.0;
+constexpr double kDefaultCompression = 100.0;
+
+// Returns per-row winsorized values using a TDigest
+// sketch built over the entire partition. Values below the lower quantile
+// boundary are replaced with that boundary value; values above the upper
+// quantile boundary are replaced with that boundary value.
+//
+// This eliminates the common two-pass pattern:
+//   Pass 1: APPROX_PERCENTILE(col, p) -> threshold
+//   Pass 2: LEAST(col, threshold) per row
+// by building the sketch once in resetPartition() and clamping per row
+// in apply().
+//
+// Signatures:
+//   approx_winsorize(value DOUBLE, lower DOUBLE, upper DOUBLE) OVER (...)
+//   approx_winsorize(value DOUBLE, lower DOUBLE, upper DOUBLE,
+//                    compression DOUBLE) OVER (...)
+class ApproxWinsorizeFunction : public exec::WindowFunction {
+ public:
+  ApproxWinsorizeFunction(
+      const std::vector<exec::WindowFunctionArg>& args,
+      const TypePtr& resultType,
+      memory::MemoryPool* pool,
+      HashStringAllocator* stringAllocator)
+      : WindowFunction(resultType, pool, stringAllocator) {
+    // Argument 0: value column (not constant).
+    VELOX_USER_CHECK(
+        args[0].index.has_value(),
+        "First argument (value) must be a column, not a constant");
+    valueIndex_ = args[0].index.value();
+
+    // Arguments 1-2: lower and upper quantile bounds (must be constants).
+    VELOX_USER_CHECK(
+        args[1].constantValue != nullptr,
+        "Lower quantile bound must be a constant");
+    VELOX_USER_CHECK(
+        args[2].constantValue != nullptr,
+        "Upper quantile bound must be a constant");
+
+    lowerQuantile_ =
+        args[1].constantValue->as<ConstantVector<double>>()->valueAt(0);
+    upperQuantile_ =
+        args[2].constantValue->as<ConstantVector<double>>()->valueAt(0);
+
+    VELOX_USER_CHECK(
+        !std::isnan(lowerQuantile_) && !std::isnan(upperQuantile_),
+        "Quantile bounds must not be NaN");
+    VELOX_USER_CHECK_GE(
+        lowerQuantile_, 0.0, "Lower quantile bound must be >= 0");
+    VELOX_USER_CHECK_LE(
+        lowerQuantile_, 1.0, "Lower quantile bound must be <= 1");
+    VELOX_USER_CHECK_GE(
+        upperQuantile_, 0.0, "Upper quantile bound must be >= 0");
+    VELOX_USER_CHECK_LE(
+        upperQuantile_, 1.0, "Upper quantile bound must be <= 1");
+    VELOX_USER_CHECK_LE(
+        lowerQuantile_,
+        upperQuantile_,
+        "Lower quantile bound must be <= upper quantile bound");
+
+    // Argument 3 (optional): compression factor.
+    if (args.size() > 3) {
+      VELOX_USER_CHECK(
+          args[3].constantValue != nullptr,
+          "Compression factor must be a constant");
+      compression_ =
+          args[3].constantValue->as<ConstantVector<double>>()->valueAt(0);
+      VELOX_USER_CHECK(
+          !std::isnan(compression_), "Compression factor must not be NaN");
+      VELOX_USER_CHECK_GT(
+          compression_, 0.0, "Compression factor must be positive");
+      VELOX_USER_CHECK_LE(
+          compression_,
+          kMaxCompression,
+          "Compression must be at most {}",
+          kMaxCompression);
+      compression_ = std::max(compression_, kMinCompression);
+    }
+  }
+
+  void resetPartition(const exec::WindowPartition* partition) override {
+    partition_ = partition;
+    numPartitionRows_ = partition->numRows();
+    rowOffset_ = 0;
+
+    if (numPartitionRows_ == 0) {
+      lowerBound_ = 0.0;
+      upperBound_ = 0.0;
+      return;
+    }
+
+    // Extract all values from the partition.
+    auto values = BaseVector::create(DOUBLE(), numPartitionRows_, pool_);
+    partition_->extractColumn(
+        static_cast<int32_t>(valueIndex_), 0, numPartitionRows_, 0, values);
+    auto* flatValues = values->asFlatVector<double>();
+
+    // Build a TDigest from all non-null values.
+    functions::TDigest<> digest;
+    digest.setCompression(compression_);
+    std::vector<int16_t> positions;
+    for (vector_size_t i = 0; i < numPartitionRows_; ++i) {
+      if (!flatValues->isNullAt(i)) {
+        double inputValue{flatValues->valueAt(i)};
+        VELOX_USER_CHECK(
+            !std::isnan(inputValue), "Cannot add NaN to approx_winsorize");
+        digest.add(positions, inputValue);
+      }
+    }
+
+    if (digest.size() == 0) {
+      // All values are null; bounds don't matter.
+      lowerBound_ = 0.0;
+      upperBound_ = 0.0;
+      return;
+    }
+
+    digest.compress(positions);
+
+    // Compute quantile boundaries once for the entire partition.
+    lowerBound_ = digest.estimateQuantile(lowerQuantile_);
+    upperBound_ = digest.estimateQuantile(upperQuantile_);
+  }
+
+  void apply(
+      const BufferPtr& peerGroupStarts,
+      const BufferPtr& /*peerGroupEnds*/,
+      const BufferPtr& /*frameStarts*/,
+      const BufferPtr& /*frameEnds*/,
+      const SelectivityVector& validRows,
+      vector_size_t resultOffset,
+      const VectorPtr& result) override {
+    // Derive batch size from the peerGroupStarts buffer, matching the pattern
+    // used by CumeDist and other window functions.
+    auto numRows = static_cast<vector_size_t>(
+        peerGroupStarts->size() / sizeof(vector_size_t));
+    auto* flatResult = result->asFlatVector<double>();
+
+    // Extract the value column for this batch.
+    auto values = BaseVector::create(DOUBLE(), numRows, pool_);
+    partition_->extractColumn(
+        static_cast<int32_t>(valueIndex_), rowOffset_, numRows, 0, values);
+    auto* flatValues = values->asFlatVector<double>();
+
+    for (vector_size_t i = 0; i < numRows; ++i) {
+      if (!validRows.isValid(i) || flatValues->isNullAt(i)) {
+        flatResult->setNull(resultOffset + i, true);
+      } else {
+        double inputValue{flatValues->valueAt(i)};
+        flatResult->set(
+            resultOffset + i,
+            std::max(lowerBound_, std::min(upperBound_, inputValue)));
+      }
+    }
+
+    rowOffset_ += numRows;
+  }
+
+ private:
+  column_index_t valueIndex_;
+  double lowerQuantile_;
+  double upperQuantile_;
+  double compression_{kDefaultCompression};
+
+  const exec::WindowPartition* partition_{nullptr};
+  vector_size_t numPartitionRows_{0};
+  vector_size_t rowOffset_{0};
+
+  // Quantile boundary values computed once per partition.
+  double lowerBound_{0.0};
+  double upperBound_{0.0};
+};
+
+} // namespace
+
+void registerApproxWinsorize(const std::string& name) {
+  std::vector<exec::FunctionSignaturePtr> signatures;
+  // (value DOUBLE, lower DOUBLE, upper DOUBLE) -> DOUBLE
+  signatures.push_back(
+      exec::FunctionSignatureBuilder()
+          .returnType("double")
+          .argumentType("double")
+          .argumentType("double")
+          .argumentType("double")
+          .build());
+  // (value DOUBLE, lower DOUBLE, upper DOUBLE, compression DOUBLE) -> DOUBLE
+  signatures.push_back(
+      exec::FunctionSignatureBuilder()
+          .returnType("double")
+          .argumentType("double")
+          .argumentType("double")
+          .argumentType("double")
+          .argumentType("double")
+          .build());
+
+  exec::registerWindowFunction(
+      name,
+      std::move(signatures),
+      exec::WindowFunction::Metadata::defaultMetadata(),
+      [name](
+          const std::vector<exec::WindowFunctionArg>& args,
+          const TypePtr& resultType,
+          bool /*ignoreNulls*/,
+          memory::MemoryPool* pool,
+          HashStringAllocator* stringAllocator,
+          const core::QueryConfig& /*queryConfig*/)
+          -> std::unique_ptr<exec::WindowFunction> {
+        return std::make_unique<ApproxWinsorizeFunction>(
+            args, resultType, pool, stringAllocator);
+      });
+}
+
+} // namespace facebook::velox::window::prestosql

--- a/velox/functions/prestosql/window/CMakeLists.txt
+++ b/velox/functions/prestosql/window/CMakeLists.txt
@@ -17,6 +17,7 @@ endif()
 
 velox_add_library(
   velox_window
+  ApproxWinsorize.cpp
   CumeDist.cpp
   FirstLastValue.cpp
   LeadLag.cpp
@@ -25,4 +26,11 @@ velox_add_library(
   WindowFunctionsRegistration.h
 )
 
-velox_link_libraries(velox_window velox_buffer velox_exec velox_functions_window Folly::folly)
+velox_link_libraries(
+  velox_window
+  velox_buffer
+  velox_exec
+  velox_functions_window
+  velox_tdigest
+  Folly::folly
+)

--- a/velox/functions/prestosql/window/WindowFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/window/WindowFunctionsRegistration.cpp
@@ -20,6 +20,7 @@ namespace facebook::velox::window {
 
 namespace prestosql {
 
+extern void registerApproxWinsorize(const std::string& name);
 extern void registerCumeDist(const std::string& name);
 extern void registerNtileBigint(const std::string& name);
 extern void registerFirstValue(const std::string& name);
@@ -28,6 +29,7 @@ extern void registerLag(const std::string& name);
 extern void registerLead(const std::string& name);
 
 void registerAllWindowFunctions(const std::string& prefix) {
+  registerApproxWinsorize(prefix + "approx_winsorize");
   functions::window::registerRowNumberBigint(prefix + "row_number");
   functions::window::registerRankBigint(prefix + "rank");
   functions::window::registerDenseRankBigint(prefix + "dense_rank");

--- a/velox/functions/prestosql/window/tests/ApproxWinsorizeTest.cpp
+++ b/velox/functions/prestosql/window/tests/ApproxWinsorizeTest.cpp
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <random>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
+#include "velox/functions/prestosql/window/WindowFunctionsRegistration.h"
+
+using namespace facebook::velox::exec::test;
+using namespace facebook::velox::functions::aggregate::test;
+
+namespace facebook::velox::window::test {
+
+class ApproxWinsorizeTest : public AggregationTestBase {
+ protected:
+  void SetUp() override {
+    AggregationTestBase::SetUp();
+    window::prestosql::registerAllWindowFunctions();
+  }
+
+  RowVectorPtr runWindow(
+      const RowVectorPtr& input,
+      const std::string& functionCall,
+      const std::string& overClause) {
+    return AssertQueryBuilder(
+               PlanBuilder()
+                   .values({input})
+                   .window({functionCall + " " + overClause + " as w"})
+                   .planNode())
+        .copyResults(pool());
+  }
+};
+
+TEST_F(ApproxWinsorizeTest, fullRange) {
+  // With bounds (0.0, 1.0), no clamping — values pass through unchanged.
+  auto input = makeRowVector({
+      makeFlatVector<double>({1.0, 2.0, 3.0, 4.0, 5.0}),
+  });
+  auto result = runWindow(input, "approx_winsorize(c0, 0.0, 1.0)", "OVER ()");
+  auto originalCol = result->childAt(0)->asFlatVector<double>();
+  auto winsorized = result->childAt(1)->asFlatVector<double>();
+  for (int i = 0; i < 5; ++i) {
+    ASSERT_NEAR(winsorized->valueAt(i), originalCol->valueAt(i), 0.1);
+  }
+}
+
+TEST_F(ApproxWinsorizeTest, upperCapping) {
+  // Upper winsorization should cap outliers.
+  constexpr int kNumValues = 100;
+  std::vector<double> values(kNumValues);
+  for (int i = 0; i < kNumValues - 1; ++i) {
+    values[i] = static_cast<double>(i);
+  }
+  values[kNumValues - 1] = 1'000.0; // outlier
+  auto input = makeRowVector({makeFlatVector<double>(values)});
+  auto result = runWindow(input, "approx_winsorize(c0, 0.0, 0.95)", "OVER ()");
+  auto originalCol = result->childAt(0)->asFlatVector<double>();
+  auto winsorized = result->childAt(1)->asFlatVector<double>();
+  for (int i = 0; i < kNumValues; ++i) {
+    double originalValue{originalCol->valueAt(i)};
+    double winsorizedValue{winsorized->valueAt(i)};
+    if (originalValue == 1'000.0) {
+      // The outlier should be capped.
+      ASSERT_LT(winsorizedValue, 1'000.0);
+    } else if (originalValue < 50) {
+      // Low values are unchanged (lower bound is 0.0).
+      ASSERT_NEAR(winsorizedValue, originalValue, 1.0);
+    }
+  }
+}
+
+TEST_F(ApproxWinsorizeTest, twoSidedCapping) {
+  // Two-sided winsorization with enough data for TDigest resolution.
+  // Verify per-row invariant: each winsorized value is clamped to
+  // [lowerBound, upperBound] and middle values are unchanged.
+  constexpr int kNumValues = 1'000;
+  std::vector<double> values(kNumValues);
+  for (int i = 0; i < kNumValues; ++i) {
+    values[i] = static_cast<double>(i);
+  }
+  auto input = makeRowVector({makeFlatVector<double>(values)});
+  auto result = runWindow(input, "approx_winsorize(c0, 0.05, 0.95)", "OVER ()");
+  auto originalCol = result->childAt(0)->asFlatVector<double>();
+  auto winsorized = result->childAt(1)->asFlatVector<double>();
+  double minWinsorized{winsorized->valueAt(0)};
+  double maxWinsorized{winsorized->valueAt(0)};
+  for (int i = 0; i < kNumValues; ++i) {
+    double winsorizedValue{winsorized->valueAt(i)};
+    double originalValue{originalCol->valueAt(i)};
+    minWinsorized = std::min(minWinsorized, winsorizedValue);
+    maxWinsorized = std::max(maxWinsorized, winsorizedValue);
+    // If original is in the middle, winsorized should equal original.
+    if (originalValue > 100 && originalValue < 900) {
+      ASSERT_NEAR(winsorizedValue, originalValue, 1.0);
+    }
+  }
+  // The range of winsorized values should be narrower than original.
+  ASSERT_GE(minWinsorized, 30.0);
+  ASSERT_LE(maxWinsorized, 970.0);
+}
+
+TEST_F(ApproxWinsorizeTest, partitionBy) {
+  // Test with PARTITION BY — each group gets its own TDigest.
+  constexpr int perGroup = 100;
+  std::vector<int32_t> keys(2 * perGroup);
+  std::vector<double> values(2 * perGroup);
+  for (int i = 0; i < perGroup; ++i) {
+    keys[i] = 1;
+    values[i] = static_cast<double>(i);
+  }
+  values[perGroup - 1] = 1'000.0; // outlier in group 1
+  for (int i = 0; i < perGroup; ++i) {
+    keys[perGroup + i] = 2;
+    values[perGroup + i] = static_cast<double>(i + 10);
+  }
+  auto input = makeRowVector({
+      makeFlatVector<int32_t>(keys),
+      makeFlatVector<double>(values),
+  });
+  auto result = runWindow(
+      input, "approx_winsorize(c1, 0.0, 0.95)", "OVER (PARTITION BY c0)");
+  // Row order may change. Check invariants per row.
+  auto originalCol = result->childAt(1)->asFlatVector<double>();
+  auto winsorized = result->childAt(2)->asFlatVector<double>();
+  bool foundCappedOutlier{false};
+  for (int i = 0; i < 2 * perGroup; ++i) {
+    double originalValue{originalCol->valueAt(i)};
+    double winsorizedValue{winsorized->valueAt(i)};
+    if (originalValue == 1'000.0) {
+      ASSERT_LT(winsorizedValue, 1'000.0);
+      foundCappedOutlier = true;
+    }
+    // Winsorized value should never exceed original for upper-only capping.
+    ASSERT_LE(winsorizedValue, originalValue + 1.0);
+  }
+  ASSERT_TRUE(foundCappedOutlier);
+}
+
+TEST_F(ApproxWinsorizeTest, nullHandling) {
+  auto input = makeRowVector({
+      makeNullableFlatVector<double>(
+          {1.0, std::nullopt, 3.0, std::nullopt, 5.0}),
+  });
+  auto result = runWindow(input, "approx_winsorize(c0, 0.0, 1.0)", "OVER ()");
+  auto originalCol = result->childAt(0);
+  auto winsorized = result->childAt(1);
+  int nullCount{0};
+  int nonNullCount{0};
+  for (int i = 0; i < 5; ++i) {
+    if (originalCol->isNullAt(i)) {
+      // Null input should produce null output.
+      ASSERT_TRUE(winsorized->isNullAt(i));
+      ++nullCount;
+    } else {
+      ASSERT_FALSE(winsorized->isNullAt(i));
+      ++nonNullCount;
+    }
+  }
+  ASSERT_EQ(nullCount, 2);
+  ASSERT_EQ(nonNullCount, 3);
+}
+
+TEST_F(ApproxWinsorizeTest, allNulls) {
+  auto input = makeRowVector({
+      makeNullableFlatVector<double>(
+          {std::nullopt, std::nullopt, std::nullopt}),
+  });
+  auto result = runWindow(input, "approx_winsorize(c0, 0.0, 1.0)", "OVER ()");
+  auto winsorized = result->childAt(1);
+  for (int i = 0; i < 3; ++i) {
+    ASSERT_TRUE(winsorized->isNullAt(i));
+  }
+}
+
+TEST_F(ApproxWinsorizeTest, withCompression) {
+  constexpr int kNumValues = 1'000;
+  std::vector<double> values(kNumValues);
+  for (int i = 0; i < kNumValues; ++i) {
+    values[i] = static_cast<double>(i);
+  }
+  auto input = makeRowVector({makeFlatVector<double>(values)});
+  auto result =
+      runWindow(input, "approx_winsorize(c0, 0.05, 0.95, 200.0)", "OVER ()");
+  auto originalCol = result->childAt(0)->asFlatVector<double>();
+  auto winsorized = result->childAt(1)->asFlatVector<double>();
+  double minWinsorized{winsorized->valueAt(0)};
+  double maxWinsorized{winsorized->valueAt(0)};
+  for (int i = 0; i < kNumValues; ++i) {
+    double originalValue{originalCol->valueAt(i)};
+    double winsorizedValue{winsorized->valueAt(i)};
+    minWinsorized = std::min(minWinsorized, winsorizedValue);
+    maxWinsorized = std::max(maxWinsorized, winsorizedValue);
+    // Middle values should be unchanged.
+    if (originalValue > 100 && originalValue < 900) {
+      ASSERT_NEAR(winsorizedValue, originalValue, 1.0);
+    }
+  }
+  // Range should be narrowed by winsorization.
+  ASSERT_GE(minWinsorized, 30.0);
+  ASSERT_LE(maxWinsorized, 970.0);
+}
+
+TEST_F(ApproxWinsorizeTest, invalidBounds) {
+  auto input = makeRowVector({makeFlatVector<double>({1.0, 2.0, 3.0})});
+  VELOX_ASSERT_THROW(
+      runWindow(input, "approx_winsorize(c0, -0.1, 0.5)", "OVER ()"), ">= 0");
+}
+
+TEST_F(ApproxWinsorizeTest, boundsReversed) {
+  auto input = makeRowVector({makeFlatVector<double>({1.0, 2.0, 3.0})});
+  VELOX_ASSERT_THROW(
+      runWindow(input, "approx_winsorize(c0, 0.9, 0.1)", "OVER ()"), "<=");
+}
+
+TEST_F(ApproxWinsorizeTest, nanInput) {
+  auto input = makeRowVector({
+      makeFlatVector<double>({1.0, std::numeric_limits<double>::quiet_NaN()}),
+  });
+  VELOX_ASSERT_THROW(
+      runWindow(input, "approx_winsorize(c0, 0.0, 1.0)", "OVER ()"), "NaN");
+}
+
+TEST_F(ApproxWinsorizeTest, accuracy) {
+  // Accuracy test: compare approx_winsorize output against exact computation.
+  constexpr int kNumValues = 10'000;
+  std::vector<double> values(kNumValues);
+  std::default_random_engine generator(42);
+  std::lognormal_distribution<> distribution(0, 1.0);
+  for (int i = 0; i < kNumValues; ++i) {
+    values[i] = distribution(generator);
+  }
+
+  auto input = makeRowVector({makeFlatVector<double>(values)});
+  auto result = runWindow(input, "approx_winsorize(c0, 0.01, 0.99)", "OVER ()");
+  auto originalCol = result->childAt(0)->asFlatVector<double>();
+  auto winsorized = result->childAt(1)->asFlatVector<double>();
+
+  // Compute exact winsorized values from the original column.
+  auto sorted = values;
+  std::sort(sorted.begin(), sorted.end());
+  double exactLower{sorted[static_cast<int>(kNumValues * 0.01)]};
+  double exactUpper{sorted[static_cast<int>(kNumValues * 0.99)]};
+
+  // Check that the mean of winsorized values is close to exact.
+  double approxSum{0};
+  double exactSum{0};
+  for (int i = 0; i < kNumValues; ++i) {
+    approxSum += winsorized->valueAt(i);
+    double originalValue{originalCol->valueAt(i)};
+    exactSum += std::max(exactLower, std::min(exactUpper, originalValue));
+  }
+  double approxMean{approxSum / kNumValues};
+  double exactMean{exactSum / kNumValues};
+  ASSERT_NEAR(approxMean, exactMean, std::abs(exactMean) * 0.05);
+}
+
+} // namespace facebook::velox::window::test

--- a/velox/functions/prestosql/window/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/window/tests/CMakeLists.txt
@@ -49,3 +49,21 @@ add_executable(velox_windows_agg_test AggregateWindowTest.cpp ${CMAKE_WINDOW_TES
 add_test(NAME velox_windows_agg_test COMMAND velox_windows_agg_test WORKING_DIRECTORY .)
 
 target_link_libraries(velox_windows_agg_test ${CMAKE_WINDOW_TEST_LINK_LIBRARIES})
+
+add_executable(
+  velox_windows_approx_winsorize_test
+  ApproxWinsorizeTest.cpp
+  ${CMAKE_WINDOW_TEST_MAIN_FILES}
+)
+
+add_test(
+  NAME velox_windows_approx_winsorize_test
+  COMMAND velox_windows_approx_winsorize_test
+  WORKING_DIRECTORY .
+)
+
+target_link_libraries(
+  velox_windows_approx_winsorize_test
+  ${CMAKE_WINDOW_TEST_LINK_LIBRARIES}
+  velox_functions_aggregates_test_lib
+)


### PR DESCRIPTION
Summary:

Add `approx_winsorize(value, lower_quantile, upper_quantile[, compression]) OVER (PARTITION BY ...)` — a custom window function that returns per-row winsorized values using a TDigest sketch built over the entire partition.

This eliminates the common two-pass winsorization pattern:
  Pass 1: APPROX_PERCENTILE(col, p) → threshold (full scan to build sketch)
  Pass 2: LEAST(col, threshold) per row (second full scan + JOIN)
With a single pass: approx_winsorize(col, 0.0, 0.9995) OVER (PARTITION BY key)

Unlike the approx_winsorized_mean aggregate which returns a single scalar mean, this window function returns the capped value for each individual row. This enables downstream per-row computation (variance, covariance, discount factors) that the aggregate cannot support.

Implementation uses the WindowFunction two-phase API:
- resetPartition(): extracts all values, builds TDigest, computes quantile boundaries once
- apply(): clamps each row's value to [lowerBound, upperBound] — O(1) per row

Key design decisions:
- Uses ProcessMode::kPartition to ensure full partition is available before processing
- Constant argument validation in constructor (same pattern as approx_winsorized_mean)
- NaN rejection with user-friendly error messages
- kMinCompression/kMaxCompression constants (no magic numbers)
- Uniform initialization throughout (double foo{0.0})
- Digit separators for large numeric literals

Differential Revision: D102450369


