### PR TITLE
feat(dwio): Add session properties for Nimble reader string optimizations (#17347)

### DIFF
--- a/velox/connectors/hive/FileConfig.cpp
+++ b/velox/connectors/hive/FileConfig.cpp
@@ -35,6 +35,8 @@ const std::vector<config::ConfigProperty>& FileConfig::registeredProperties() {
     VELOX_HIVE_CONFIG_REGISTER(kOrcFooterSpeculativeIoSizeSession);
     VELOX_HIVE_CONFIG_REGISTER(kParquetFooterSpeculativeIoSizeSession);
     VELOX_HIVE_CONFIG_REGISTER(kNimbleFooterSpeculativeIoSizeSession);
+    VELOX_HIVE_CONFIG_REGISTER(kNimbleStringDecoderZeroCopySession);
+    VELOX_HIVE_CONFIG_REGISTER(kNimblePreserveDictionaryEncodingSession);
     VELOX_HIVE_CONFIG_REGISTER(kFileColumnNamesReadAsLowerCaseSession);
     VELOX_HIVE_CONFIG_REGISTER(kIgnoreMissingFilesSession);
     VELOX_HIVE_CONFIG_REGISTER(kMaxCoalescedBytesSession);

--- a/velox/connectors/hive/FileConfig.h
+++ b/velox/connectors/hive/FileConfig.h
@@ -123,6 +123,26 @@ class FileConfig {
       8UL << 20,
       "Speculative tail-read size in bytes for Nimble files.")
 
+  VELOX_HIVE_CONFIG_LEGACY(
+      kNimbleStringDecoderZeroCopySession,
+      kNimbleStringDecoderZeroCopy,
+      nimbleStringDecoderZeroCopy,
+      "nimble_string_decoder_zero_copy",
+      "nimble.string-decoder-zero-copy",
+      bool,
+      false,
+      "Enable zero-copy string decoding in Nimble selective reader.")
+
+  VELOX_HIVE_CONFIG_LEGACY(
+      kNimblePreserveDictionaryEncodingSession,
+      kNimblePreserveDictionaryEncoding,
+      nimblePreserveDictionaryEncoding,
+      "nimble_preserve_dictionary_encoding",
+      "nimble.preserve-dictionary-encoding",
+      bool,
+      false,
+      "Preserve dictionary encoding for Nimble string column reads.")
+
   // --- VELOX_HIVE_CONFIG properties ---
 
   VELOX_HIVE_CONFIG(

--- a/velox/connectors/hive/FileSplitReader.cpp
+++ b/velox/connectors/hive/FileSplitReader.cpp
@@ -364,6 +364,12 @@ void FileSplitReader::createRowReader(
     std::optional<bool> rowSizeTrackingEnabled) {
   VELOX_CHECK_NULL(baseRowReader_);
   configureBaseRowReaderOptions(std::move(metadataFilter), std::move(rowType));
+  baseRowReaderOpts_.setStringDecoderZeroCopy(
+      fileConfig_->nimbleStringDecoderZeroCopy(
+          connectorQueryCtx_->sessionProperties()));
+  baseRowReaderOpts_.setNimblePreserveDictionaryEncoding(
+      fileConfig_->nimblePreserveDictionaryEncoding(
+          connectorQueryCtx_->sessionProperties()));
   baseRowReaderOpts_.setTrackRowSize(
       rowSizeTrackingEnabled.has_value()
           ? *rowSizeTrackingEnabled

--- a/velox/connectors/hive/tests/FileConfigTest.cpp
+++ b/velox/connectors/hive/tests/FileConfigTest.cpp
@@ -53,6 +53,8 @@ TEST(FileConfigTest, defaultConfig) {
       config.parquetFooterSpeculativeIoSize(emptySession.get()), 256UL << 10);
   EXPECT_EQ(
       config.nimbleFooterSpeculativeIoSize(emptySession.get()), 8UL << 20);
+  EXPECT_FALSE(config.nimbleStringDecoderZeroCopy(emptySession.get()));
+  EXPECT_FALSE(config.nimblePreserveDictionaryEncoding(emptySession.get()));
 }
 
 TEST(FileConfigTest, overrideConfig) {
@@ -74,6 +76,8 @@ TEST(FileConfigTest, overrideConfig) {
       {FileConfig::kOrcFooterSpeculativeIoSize, std::to_string(512UL << 10)},
       {FileConfig::kParquetFooterSpeculativeIoSize, std::to_string(1UL << 20)},
       {FileConfig::kNimbleFooterSpeculativeIoSize, std::to_string(4UL << 20)},
+      {FileConfig::kNimbleStringDecoderZeroCopy, "true"},
+      {FileConfig::kNimblePreserveDictionaryEncoding, "true"},
   };
   FileConfig config(
       std::make_shared<config::ConfigBase>(std::move(configFromFile)));
@@ -99,6 +103,8 @@ TEST(FileConfigTest, overrideConfig) {
       config.parquetFooterSpeculativeIoSize(emptySession.get()), 1UL << 20);
   EXPECT_EQ(
       config.nimbleFooterSpeculativeIoSize(emptySession.get()), 4UL << 20);
+  EXPECT_TRUE(config.nimbleStringDecoderZeroCopy(emptySession.get()));
+  EXPECT_TRUE(config.nimblePreserveDictionaryEncoding(emptySession.get()));
 }
 
 TEST(FileConfigTest, overrideSession) {
@@ -124,6 +130,8 @@ TEST(FileConfigTest, overrideSession) {
        std::to_string(512UL << 10)},
       {FileConfig::kNimbleFooterSpeculativeIoSizeSession,
        std::to_string(2UL << 20)},
+      {FileConfig::kNimbleStringDecoderZeroCopySession, "true"},
+      {FileConfig::kNimblePreserveDictionaryEncodingSession, "true"},
   };
   const auto session =
       std::make_unique<config::ConfigBase>(std::move(sessionOverride));
@@ -143,6 +151,8 @@ TEST(FileConfigTest, overrideSession) {
   EXPECT_EQ(config.orcFooterSpeculativeIoSize(session.get()), 128UL << 10);
   EXPECT_EQ(config.parquetFooterSpeculativeIoSize(session.get()), 512UL << 10);
   EXPECT_EQ(config.nimbleFooterSpeculativeIoSize(session.get()), 2UL << 20);
+  EXPECT_TRUE(config.nimbleStringDecoderZeroCopy(session.get()));
+  EXPECT_TRUE(config.nimblePreserveDictionaryEncoding(session.get()));
 }
 
 TEST(FileConfigTest, nullConfig) {

--- a/velox/connectors/hive/tests/HiveConfigTest.cpp
+++ b/velox/connectors/hive/tests/HiveConfigTest.cpp
@@ -64,6 +64,8 @@ TEST(HiveConfigTest, defaultConfig) {
       256UL << 10);
   ASSERT_EQ(
       hiveConfig.nimbleFooterSpeculativeIoSize(emptySession.get()), 8UL << 20);
+  ASSERT_FALSE(hiveConfig.nimbleStringDecoderZeroCopy(emptySession.get()));
+  ASSERT_FALSE(hiveConfig.nimblePreserveDictionaryEncoding(emptySession.get()));
 }
 
 TEST(HiveConfigTest, overrideConfig) {
@@ -92,7 +94,10 @@ TEST(HiveConfigTest, overrideConfig) {
       {HiveConfig::kFileMetadataCacheEnabled, "true"},
       {HiveConfig::kOrcFooterSpeculativeIoSize, std::to_string(512UL << 10)},
       {HiveConfig::kParquetFooterSpeculativeIoSize, std::to_string(1UL << 20)},
-      {HiveConfig::kNimbleFooterSpeculativeIoSize, std::to_string(4UL << 20)}};
+      {HiveConfig::kNimbleFooterSpeculativeIoSize, std::to_string(4UL << 20)},
+      {HiveConfig::kNimbleStringDecoderZeroCopy, "true"},
+      {HiveConfig::kNimblePreserveDictionaryEncoding, "true"},
+  };
   HiveConfig hiveConfig(
       std::make_shared<config::ConfigBase>(std::move(configFromFile)));
   auto emptySession = std::make_shared<config::ConfigBase>(
@@ -132,6 +137,8 @@ TEST(HiveConfigTest, overrideConfig) {
       hiveConfig.parquetFooterSpeculativeIoSize(emptySession.get()), 1UL << 20);
   ASSERT_EQ(
       hiveConfig.nimbleFooterSpeculativeIoSize(emptySession.get()), 4UL << 20);
+  ASSERT_TRUE(hiveConfig.nimbleStringDecoderZeroCopy(emptySession.get()));
+  ASSERT_TRUE(hiveConfig.nimblePreserveDictionaryEncoding(emptySession.get()));
 }
 
 TEST(HiveConfigTest, overrideSession) {
@@ -160,6 +167,8 @@ TEST(HiveConfigTest, overrideSession) {
        std::to_string(512UL << 10)},
       {HiveConfig::kNimbleFooterSpeculativeIoSizeSession,
        std::to_string(2UL << 20)},
+      {HiveConfig::kNimbleStringDecoderZeroCopySession, "true"},
+      {HiveConfig::kNimblePreserveDictionaryEncodingSession, "true"},
   };
   const auto session =
       std::make_unique<config::ConfigBase>(std::move(sessionOverride));
@@ -193,4 +202,6 @@ TEST(HiveConfigTest, overrideSession) {
   ASSERT_EQ(
       hiveConfig.parquetFooterSpeculativeIoSize(session.get()), 512UL << 10);
   ASSERT_EQ(hiveConfig.nimbleFooterSpeculativeIoSize(session.get()), 2UL << 20);
+  ASSERT_TRUE(hiveConfig.nimbleStringDecoderZeroCopy(session.get()));
+  ASSERT_TRUE(hiveConfig.nimblePreserveDictionaryEncoding(session.get()));
 }

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -476,6 +476,14 @@ class RowReaderOptions {
     stringDecoderZeroCopy_ = stringDecoderZeroCopy;
   }
 
+  bool nimblePreserveDictionaryEncoding() const {
+    return nimblePreserveDictionaryEncoding_;
+  }
+
+  void setNimblePreserveDictionaryEncoding(bool value) {
+    nimblePreserveDictionaryEncoding_ = value;
+  }
+
   bool collectColumnCpuMetrics() const {
     return collectColumnCpuMetrics_;
   }
@@ -551,9 +559,12 @@ class RowReaderOptions {
   std::shared_ptr<FormatSpecificOptions> formatSpecificOptions_;
   bool trackRowSize_{false};
   bool indexEnabled_{false};
-  // NOTE: we will control this option with a session property
-  // for prod. Tests are parameterized on both branches.
+  // Enables zero-copy string decoding in the Nimble selective reader,
+  // using the non-legacy encoding path. Controlled via session property.
   bool stringDecoderZeroCopy_{false};
+  // Controls whether dictionary-encoded Nimble string columns return
+  // DictionaryVector instead of FlatVector. Controlled via session property.
+  bool nimblePreserveDictionaryEncoding_{false};
   bool collectColumnCpuMetrics_{false};
 };
 


### PR DESCRIPTION
Summary:

Add two session properties to control Nimble selective reader string optimizations:

1. `pass_string_buffers_from_decoder` (default true): Controls whether the Nimble decoder passes string buffers directly to output vectors, enabling the non-legacy encoding path. Previously hardcoded to true in the connector.

2. `preserve_dictionary_encoding` (default false): Controls whether dictionary-encoded string columns return DictionaryVector instead of FlatVector. This is the gate for the dictionary vector preservation optimization stack.

Both properties are wired end-to-end: QueryConfig → ConnectorQueryCtx → RowReaderOptions → FormatData → StringColumnReader.

These session properties enable A/B testing of the string optimization stack via the Presto Verifier (using -tsp to set different values on control vs test).

Reviewed By: zzhao0

Differential Revision: D102464969


