### PR TITLE
refactor(reader): Rename pass string buffer config (#17348)

### DIFF
--- a/velox/dwio/common/FormatData.h
+++ b/velox/dwio/common/FormatData.h
@@ -127,12 +127,12 @@ class FormatData {
     return false;
   }
 
-  bool getStringBuffersFromDecoder() const {
-    return getStringBuffersFromDecoder_;
+  bool stringDecoderZeroCopy() const {
+    return stringDecoderZeroCopy_;
   }
 
  protected:
-  bool getStringBuffersFromDecoder_{false};
+  bool stringDecoderZeroCopy_{false};
 };
 
 /// Base class for format-specific reader initialization arguments.

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -468,12 +468,12 @@ class RowReaderOptions {
     indexEnabled_ = enabled;
   }
 
-  bool passStringBuffersFromDecoder() const {
-    return passStringBuffersFromDecoder_;
+  bool stringDecoderZeroCopy() const {
+    return stringDecoderZeroCopy_;
   }
 
-  void setPassStringBuffersFromDecoder(bool passStringBuffersFromDecoder) {
-    passStringBuffersFromDecoder_ = passStringBuffersFromDecoder;
+  void setStringDecoderZeroCopy(bool stringDecoderZeroCopy) {
+    stringDecoderZeroCopy_ = stringDecoderZeroCopy;
   }
 
   bool collectColumnCpuMetrics() const {
@@ -553,7 +553,7 @@ class RowReaderOptions {
   bool indexEnabled_{false};
   // NOTE: we will control this option with a session property
   // for prod. Tests are parameterized on both branches.
-  bool passStringBuffersFromDecoder_{false};
+  bool stringDecoderZeroCopy_{false};
   bool collectColumnCpuMetrics_{false};
 };
 

--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -500,7 +500,7 @@ class SelectiveColumnReader {
 
   StringView copyStringValueIfNeed(std::string_view value) {
     if (value.size() <= StringView::kInlineSize ||
-        formatData().getStringBuffersFromDecoder()) {
+        formatData().stringDecoderZeroCopy()) {
       return StringView(value);
     }
 
@@ -761,8 +761,7 @@ class SelectiveColumnReader {
 template <>
 inline void SelectiveColumnReader::addValue(const std::string_view value) {
   const uint64_t size = value.size();
-  if (formatData().getStringBuffersFromDecoder() ||
-      size <= StringView::kInlineSize) {
+  if (formatData().stringDecoderZeroCopy() || size <= StringView::kInlineSize) {
     reinterpret_cast<StringView*>(rawValues_)[numValues_++] =
         StringView(value.data(), size);
     return;


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/nimble/pull/675


Rename the `passStringBufferFromDecoder` row reader option to `stringDecoderZeroCopy` per review feedback!

Changing definition, call sites and tests.

Reviewed By: xiaoxmeng

Differential Revision: D102536107


