### PR TITLE
perf: Lazy per-column I/O for projected columns in Nimble (#17350)

### DIFF
--- a/velox/connectors/hive/FileConfig.cpp
+++ b/velox/connectors/hive/FileConfig.cpp
@@ -44,6 +44,7 @@ const std::vector<config::ConfigProperty>& FileConfig::registeredProperties() {
     VELOX_HIVE_CONFIG_REGISTER(kLoadQuantumSession);
     VELOX_HIVE_CONFIG_REGISTER(kReadStatsBasedFilterReorderDisabledSession);
     VELOX_HIVE_CONFIG_REGISTER(kIndexEnabledSession);
+    VELOX_HIVE_CONFIG_REGISTER(kLazyColumnIoSession);
     VELOX_HIVE_CONFIG_REGISTER(kCacheMetadataSession);
     VELOX_HIVE_CONFIG_REGISTER(kPinMetadataSession);
     VELOX_HIVE_CONFIG_REGISTER(kCacheIndexSession);

--- a/velox/connectors/hive/FileConfig.h
+++ b/velox/connectors/hive/FileConfig.h
@@ -206,6 +206,14 @@ class FileConfig {
   static constexpr const char* kIndexEnabled = "index-enabled";
 
   VELOX_HIVE_CONFIG(
+      kLazyColumnIoSession,
+      lazyColumnIo,
+      "nimble.lazy_column_io",
+      bool,
+      false,
+      "Defer I/O for projected columns without pushdown filters, remaining filters, or transforms.")
+
+  VELOX_HIVE_CONFIG(
       kCacheMetadataSession,
       cacheMetadata,
       "cache_metadata",

--- a/velox/connectors/hive/FileConnectorUtil.cpp
+++ b/velox/connectors/hive/FileConnectorUtil.cpp
@@ -168,6 +168,8 @@ void configureRowReaderOptions(
         fileConfig->parallelUnitLoadCount(sessionProperties));
     rowReaderOptions.setIndexEnabled(
         fileConfig->indexEnabled(sessionProperties));
+    rowReaderOptions.setLazyColumnIo(
+        fileConfig->lazyColumnIo(sessionProperties));
     rowReaderOptions.setCollectColumnCpuMetrics(
         fileConfig->readerCollectColumnCpuMetrics(sessionProperties));
   }

--- a/velox/connectors/hive/FileDataSource.cpp
+++ b/velox/connectors/hive/FileDataSource.cpp
@@ -272,7 +272,12 @@ FileDataSource::FileDataSource(
     for (int i = 0; i < readColumnNames.size(); ++i) {
       columnNames[readColumnNames[i]] = i;
     }
+    // Capture top-level column names referenced by the remaining filter.
+    // These columns must be loaded eagerly (not lazily) so the filter
+    // can evaluate before lazy columns are accessed.
+    folly::F14FastSet<std::string> remainingFilterColumns;
     for (auto& input : remainingFilterExpr->distinctFields()) {
+      remainingFilterColumns.insert(input->field());
       auto it = columnNames.find(input->field());
       if (it != columnNames.end()) {
         if (shouldEagerlyMaterialize(*remainingFilterExpr, *input)) {
@@ -286,6 +291,7 @@ FileDataSource::FileDataSource(
       readColumnNames.push_back(input->field());
       readColumnTypes.push_back(input->type());
     }
+    remainingFilterColumns_ = std::move(remainingFilterColumns);
     remainingFilterSubfields_ = remainingFilterExpr->extractSubfields();
     if (VLOG_IS_ON(1)) {
       VLOG(1) << fmt::format(
@@ -517,6 +523,7 @@ void FileDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
   // Split reader subclasses may need to use the reader options in prepareSplit
   // so we initialize it beforehand.
   splitReader_->configureReaderOptions(randomSkip_);
+  splitReader_->setRemainingFilterColumns(remainingFilterColumns_);
   splitReader_->prepareSplit(metadataFilter_, runtimeStats_);
   readerOutputType_ = splitReader_->readerOutputType();
 }

--- a/velox/connectors/hive/FileDataSource.h
+++ b/velox/connectors/hive/FileDataSource.h
@@ -15,6 +15,9 @@
  */
 #pragma once
 
+#include <folly/container/F14Set.h>
+#include <unordered_set>
+
 #include "velox/common/base/RandomUtil.h"
 #include "velox/common/file/FileSystems.h"
 #include "velox/common/io/IoStatistics.h"
@@ -218,6 +221,9 @@ class FileDataSource : public DataSource {
   /// Field indices referenced in both remaining filter and output type. These
   /// columns need to be materialized eagerly to avoid missing values in output.
   std::vector<column_index_t> multiReferencedFields_;
+
+  // Column names referenced by the remaining filter expression.
+  folly::F14FastSet<std::string> remainingFilterColumns_;
 
   std::shared_ptr<random::RandomSkipTracker> randomSkip_;
 

--- a/velox/connectors/hive/FileSplitReader.cpp
+++ b/velox/connectors/hive/FileSplitReader.cpp
@@ -167,6 +167,11 @@ FileSplitReader::FileSplitReader(
   baseReaderOpts_.setMetadataIoStats(metadataIoStats_);
 }
 
+void FileSplitReader::setRemainingFilterColumns(
+    const folly::F14FastSet<std::string>& columns) {
+  baseRowReaderOpts_.setRemainingFilterColumns(columns);
+}
+
 void FileSplitReader::configureReaderOptions(
     std::shared_ptr<velox::random::RandomSkipTracker> randomSkip) {
   configureBaseReaderOptions();

--- a/velox/connectors/hive/FileSplitReader.h
+++ b/velox/connectors/hive/FileSplitReader.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <folly/container/F14Set.h>
 #include "velox/common/base/RandomUtil.h"
 #include "velox/common/file/FileSystems.h"
 #include "velox/connectors/hive/FileColumnHandle.h"
@@ -102,6 +103,8 @@ class FileSplitReader {
 
   void configureReaderOptions(
       std::shared_ptr<random::RandomSkipTracker> randomSkip);
+
+  void setRemainingFilterColumns(const folly::F14FastSet<std::string>& columns);
 
   /// This function is used by different table formats like Iceberg and Hudi to
   /// do additional preparations before reading the split, e.g. Open delete

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -962,6 +962,15 @@ must be specified as raw byte counts.
      - Speculative tail-read size in bytes when opening Nimble files. Controls how many bytes are read from the end
        of the file to load the footer and nearby metadata in a single IO operation.
        Set to 0 for adaptive mode.
+   * - nimble.lazy-column-io
+     - nimble.lazy_column_io
+     - boolean
+     - false
+     - Lazy IO for Nimble projected columns without pushdown filters, remaining filters, or transforms.
+       Lazy IO columns are loaded through a separate buffered input other than the one used by early
+       materialization during the scan. If all rows from a stripe have been filtered out, lazy IO will
+       not be triggered. NOTE: lazy IO applies the same restriction as lazy materialization which doesn't
+       allow lazy IO across stripes.
 
 ``ORC File Format Configuration``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -16,9 +16,11 @@
 
 #pragma once
 
+#include <folly/container/F14Set.h>
 #include <limits>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -349,7 +351,7 @@ class RowReaderOptions {
     ioExecutor_ = ioExecutor;
   }
 
-  const size_t parallelUnitLoadCount() const {
+  size_t parallelUnitLoadCount() const {
     return parallelUnitLoadCount_;
   }
 
@@ -540,6 +542,23 @@ class RowReaderOptions {
     nimblePreserveDictionaryEncoding_ = value;
   }
 
+  bool lazyColumnIo() const {
+    return lazyColumnIo_;
+  }
+
+  void setLazyColumnIo(bool lazyColumnIo) {
+    lazyColumnIo_ = lazyColumnIo;
+  }
+
+  const folly::F14FastSet<std::string>& remainingFilterColumns() const {
+    return remainingFilterColumns_;
+  }
+
+  void setRemainingFilterColumns(
+      const folly::F14FastSet<std::string>& columns) {
+    remainingFilterColumns_ = columns;
+  }
+
   bool collectColumnCpuMetrics() const {
     return collectColumnCpuMetrics_;
   }
@@ -619,8 +638,11 @@ class RowReaderOptions {
   // using the non-legacy encoding path. Controlled via session property.
   bool stringDecoderZeroCopy_{false};
   // Controls whether dictionary-encoded Nimble string columns return
-  // DictionaryVector instead of FlatVector. Controlled via session property.
+  // DictionaryVector instead of FlatVector.
   bool nimblePreserveDictionaryEncoding_{false};
+  // Defers I/O for projected columns without pushdown or remaining filters.
+  bool lazyColumnIo_{false};
+  folly::F14FastSet<std::string> remainingFilterColumns_;
   bool collectColumnCpuMetrics_{false};
 };
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/nimble/pull/677

Today, the Nimble selective reader loads all column streams upfront during stripe init — including columns wrapped in LazyVectors. The lazy contract only defers decoding; the underlying I/O is still eager. When a high-selectivity remaining filter eliminates most rows, the eagerly-loaded data for output-only columns is never decoded — but the I/O cost was already paid.

This diff extends laziness from decoding to I/O for all projected columns (scalar and complex) that have no pushdown filter, are not referenced by the remaining filter, and have no extraction transform. Qualifying columns share a single cloned BufferedInput per stripe, loaded only on first downstream access via TrackedColumnLoader. If the filter eliminates all rows in a stripe, the deferred columns' load() is never called — zero I/O for those columns in that stripe.

How it works:
- `computeLazyColumns()` runs once per split and precomputes the set of columns eligible for lazy I/O based on: no pushdown filter, not in remaining filter, no extraction transform, and projected in output.
- All lazy columns share a single cloned BufferedInput per stripe (via `createLazyInput()`), so their streams are coalesced into one WS read instead of N separate reads.
- Stream routing is explicit: `NimbleParams::setLazyTarget()` sets the clone as the target input for lazy columns. `enqueueStream()` routes to the clone or main input based on `lazyTarget_`. Nested children inherit the target via `makeChildParams()`.
- The shared clone is loaded via TrackedColumnLoader when any lazy column's LazyVector is first accessed. The idempotent `LazyInput::load()` guard ensures the clone is loaded at most once per stripe.
- Columns referenced by the remaining filter are excluded from lazy I/O to prevent loading the clone before the filter evaluates.
- Columns with extraction transforms are excluded since TransformColumnLoader does not call LazyInput::load().
- Batch size estimation: lazy columns cause estimateMaterializedSize() to return false (their ChunkedDecoders have no buffered data to peek at). This falls through to either file-level vectorized stats (preferred) or RowSizeTracker (learns actual row size after the first batch materializes lazy columns).

Gated behind the `lazy_column_io` session property (default off).

Reviewed By: HuamengJiang, xiaoxmeng

Differential Revision: D100277342


