### PR TITLE
fix: Read parquet array<struct<>> field throws exception

### DIFF
--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -75,6 +75,50 @@ bool isCompatible(
        isCompatibleFunc(requestedType->asArray().elementType()));
 }
 
+// Velox ROW used to interpret *direct* children of the current Parquet node:
+// either the requested type is ROW, or it is an unannotated ARRAY<ROW>
+// (repeated group without LIST) and this node is that repeated group.
+RowTypePtr rowTypeForDirectParquetFieldMapping(
+    const TypePtr& requestedType,
+    bool parentParquetNodeIsRepeated) {
+  if (!requestedType) {
+    return nullptr;
+  }
+  if (requestedType->isRow()) {
+    return std::dynamic_pointer_cast<const velox::RowType>(requestedType);
+  }
+  if (requestedType->isArray() && parentParquetNodeIsRepeated &&
+      requestedType->asArray().elementType()->isRow()) {
+    return std::dynamic_pointer_cast<const velox::RowType>(
+        requestedType->asArray().elementType());
+  }
+  return nullptr;
+}
+
+// Annotated 3-level LIST<struct>: one repeated child, then one optional group
+// that contains every struct column. Used to fix index mapping (first field
+// type wrongly assigned to the envelope) and to skip narrowing on that group.
+bool parquetChildIsListStructEnvelopeIndexMode(
+    bool mapChildrenByName,
+    const RowTypePtr& tableRow,
+    int32_t childIndex,
+    int32_t parquetParentNumChildren,
+    const thrift::SchemaElement& parquetChild) {
+  if (mapChildrenByName || !tableRow) {
+    return false;
+  }
+  if (childIndex < 0 || childIndex >= static_cast<int32_t>(tableRow->size())) {
+    return false;
+  }
+  if (parquetParentNumChildren != 1 || parquetChild.__isset.type) {
+    return false;
+  }
+  if (!parquetChild.__isset.num_children) {
+    return false;
+  }
+  return parquetChild.num_children == static_cast<int32_t>(tableRow->size());
+}
+
 // Checks if a decimal type has enough integer precision to hold all values
 // of the given Parquet physical int type.
 bool hasEnoughDecimalPrecision(const TypePtr& type, int32_t minIntegerDigits) {
@@ -431,52 +475,113 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
 
       TypePtr childRequestedType = nullptr;
       bool followChild = true;
+      // Set in Step 1 when index-based mapping appends a field name to
+      // columnNames for this child; used by Step 4 to roll back that append
+      // when the child is later recognized as a LIST wrapper, not a real field.
+      bool pushedMappedNameForIndexChild = false;
+      const bool mapChildrenByName = options_.useColumnNamesForColumnMapping();
 
-      {
-        RowTypePtr requestedRowType = nullptr;
-        if (requestedType) {
-          if (requestedType->isRow()) {
-            requestedRowType =
-                std::dynamic_pointer_cast<const velox::RowType>(requestedType);
-          } else if (
-              requestedType->isArray() && isRepeated &&
-              requestedType->asArray().elementType()->isRow()) {
-            // Handle the case of unannotated array of structs (repeated group
-            // without LIST annotation).
-            requestedRowType = std::dynamic_pointer_cast<const velox::RowType>(
-                requestedType->asArray().elementType());
+      // Step 1 — Table ROW (or legacy repeated ARRAY<ROW>) vs each Parquet
+      // child: pick the Velox field type for this child (name or index).
+      RowTypePtr rowForDirectFields =
+          rowTypeForDirectParquetFieldMapping(requestedType, isRepeated);
+      if (rowForDirectFields) {
+        if (mapChildrenByName) {
+          if (const auto idx =
+                  rowForDirectFields->getChildIdxIfExists(childName)) {
+            childRequestedType = rowForDirectFields->childAt(*idx);
           }
-        }
-
-        if (requestedRowType) {
-          if (options_.useColumnNamesForColumnMapping()) {
-            auto fileTypeIdx = requestedRowType->getChildIdxIfExists(childName);
-            if (fileTypeIdx.has_value()) {
-              childRequestedType = requestedRowType->childAt(*fileTypeIdx);
-            }
-          } else {
-            // Handle schema evolution.
-            if (i < requestedRowType->size()) {
-              columnNames.push_back(requestedRowType->nameOf(i));
-              childRequestedType = requestedRowType->childAt(i);
-            } else {
-              followChild = false;
-            }
-          }
+        } else if (i < rowForDirectFields->size()) {
+          columnNames.push_back(rowForDirectFields->nameOf(i));
+          pushedMappedNameForIndexChild = true;
+          childRequestedType = rowForDirectFields->childAt(i);
+        } else {
+          followChild = false;
         }
       }
 
-      // Handling elements of ARRAY/MAP
+      // Step 2 — Annotated LIST<ROW<...>>: the repeated "bag"/"list" child is
+      // not a struct column; attach the element ROW when name does not match
+      // any field (by name) or for the first physical child (by index).
+      if (!childRequestedType && requestedType && requestedType->isArray() &&
+          requestedType->asArray().elementType()->isRow()) {
+        const auto elementRow = std::dynamic_pointer_cast<const velox::RowType>(
+            requestedType->asArray().elementType());
+        if (mapChildrenByName) {
+          if (!elementRow->getChildIdxIfExists(childName)) {
+            childRequestedType = requestedType->asArray().elementType();
+          }
+        } else if (i == 0) {
+          childRequestedType = requestedType->asArray().elementType();
+        }
+      }
+
+      // Step 3 — No table type at this depth: inherit ARRAY element type or
+      // MAP key/value types from the parent (e.g. column-name mapping).
       if (!requestedType && parentRequestedType) {
-        if (parentRequestedType->isArray()) {
+        if (parentRequestedType->isArray() &&
+            schemaElement.__isset.num_children &&
+            schemaElement.num_children == 1) {
           childRequestedType = parentRequestedType->asArray().elementType();
         } else if (parentRequestedType->isMap()) {
-          auto mapType = parentRequestedType->asMap();
+          const auto mapType = parentRequestedType->asMap();
           // Processing map keys
           if (i == 0) {
             childRequestedType = mapType.keyType();
           } else {
             childRequestedType = mapType.valueType();
+          }
+        }
+      }
+
+      // Step 4 — Index mode, LIST<struct>: if we mapped the first *field* type
+      // onto the optional envelope group, replace with the full element ROW.
+      const auto& parquetChild = schema[schemaIdx];
+      RowTypePtr tableRow = requestedType && requestedType->isRow()
+          ? std::dynamic_pointer_cast<const velox::RowType>(requestedType)
+          : nullptr;
+      const bool listStructEnvelope = parquetChildIsListStructEnvelopeIndexMode(
+          mapChildrenByName,
+          tableRow,
+          i,
+          schemaElement.num_children,
+          parquetChild);
+      if (listStructEnvelope && childRequestedType == tableRow->childAt(i)) {
+        childRequestedType = requestedType;
+        if (pushedMappedNameForIndexChild && !columnNames.empty()) {
+          columnNames.pop_back();
+          pushedMappedNameForIndexChild = false;
+        }
+      }
+
+      // Step 5 — If we still have a ROW, narrow to the single field that this
+      // Parquet child represents (skip index narrow on the LIST envelope from
+      // step 4: it already is the full element ROW).
+      if (childRequestedType && childRequestedType->isRow()) {
+        const auto narrowRow =
+            std::dynamic_pointer_cast<const velox::RowType>(childRequestedType);
+        const bool parquetChildIsGroup = !parquetChild.__isset.type;
+        const bool groupHoldsWholeStructRow = parquetChildIsGroup &&
+            parquetChild.__isset.num_children &&
+            parquetChild.num_children ==
+                static_cast<int32_t>(narrowRow->size());
+        if (mapChildrenByName) {
+          if (const auto idx = narrowRow->getChildIdxIfExists(childName)) {
+            childRequestedType = narrowRow->childAt(*idx);
+          }
+        } else {
+          const bool arrayRowListBagWrapper = requestedType &&
+              requestedType->isArray() &&
+              requestedType->asArray().elementType()->isRow() &&
+              parquetChildIsGroup && parquetChild.__isset.num_children &&
+              parquetChild.num_children == 1 &&
+              (childName == "list" || childName == "bag" ||
+               childName == "array");
+          const bool skipIndexNarrow =
+              (listStructEnvelope && requestedType == childRequestedType) ||
+              groupHoldsWholeStructRow || arrayRowListBagWrapper;
+          if (!skipIndexNarrow && i < narrowRow->size()) {
+            childRequestedType = narrowRow->childAt(i);
           }
         }
       }

--- a/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -735,6 +735,41 @@ TEST_F(ParquetTableScanTest, array) {
       .assertResults(expected);
 }
 
+// LIST-style ARRAY<ROW<...>> in Parquet: outer LIST group is not REPEATED, and
+// inner names like "array" are not struct fields. Reader must pass the element
+// ROW through the wrapper and map each leaf to the right field type (e.g.
+// BIGINT vs whole ROW in convertType). Written with Velox writer, read with
+// parquet column names enabled and tableScan dataColumns.
+TEST_F(ParquetTableScanTest, listAnnotatedArrayOfStructByColumnName) {
+  const RowTypePtr elementType =
+      ROW({"c1", "c2", "c3"}, {INTEGER(), VARCHAR(), BIGINT()});
+  const RowTypePtr tableType = ROW({"c0"}, {ARRAY(elementType)});
+
+  const std::vector<std::vector<Variant>> arrayData = {
+      {variant::row({1, "a", int64_t(10)}),
+       variant::row({2, "b", int64_t(20)})},
+      {variant::row({3, "c", int64_t(30)})},
+  };
+  const auto c0Vector = makeArrayOfRowVector(elementType, arrayData);
+  const auto input = makeRowVector({"c0"}, {c0Vector});
+
+  const auto filePath = TempFilePath::create();
+  WriterOptions options;
+  writeToParquetFile(filePath->getPath(), {input}, options);
+
+  auto plan = PlanBuilder(pool_.get())
+                  .tableScan(tableType, {}, "", tableType, {})
+                  .planNode();
+
+  AssertQueryBuilder(plan)
+      .connectorSessionProperty(
+          kHiveConnectorId,
+          connector::hive::HiveConfig::kParquetUseColumnNamesSession,
+          "true")
+      .splits({makeSplit(filePath->getPath())})
+      .assertResults(input);
+}
+
 // Optional array with required elements.
 TEST_F(ParquetTableScanTest, optArrayReqEle) {
   auto vector = makeArrayVector<StringView>({});


### PR DESCRIPTION
gluten+velox read parquet data with array<struct<>> field throws exception:

26/04/27 11:37:32 ERROR TaskResources: Task 2583 failed by error:
org.apache.gluten.exception.GlutenException: org.apache.gluten.exception.GlutenException: Error during calling Java code from native code: org.apache.gluten.exception.GlutenException: org.apache.gluten.exception.GlutenException: Exception: VeloxRuntimeError
Error Source: RUNTIME
Error Code: INVALID_STATE
Reason: Converted type BIGINT is not allowed for requested type ROW<position:INTEGER,slottype:VARCHAR,businesstype:VARCHAR,contentid:BIGINT,iswarmup:BOOLEAN,contenttype:VARCHAR>
Retriable: False
Expression: !requestedType || isCompatible( requestedType, isRepeated, [](const TypePtr& type) { return type->kind() == TypeKind::TINYINT || type->kind() == TypeKind::SMALLINT || type->kind() == TypeKind::INTEGER || type->kind() == TypeKind::BIGINT; })
Context: Split [Hive: hdfs://hdfs01:8020/user/tc_warehouse/tables/dw_rec.db/dwd_dist_server_request_response_log_detail_pd/p_date=2026-04-22/p_hour=17/part-00548-fe710ab9-7a38-493b-a885-86fe7a0b49fb.c000.zstd.parquet 0 - 114907672] Task Gluten_Stage_11_TID_2583_VTID_8
Additional Context: Operator: TableScan[0] 0
Function: convertType
File: /home/lifulong/incubator-gluten/ep/build-velox/build/velox_ep/velox/dwio/parquet/reader/ParquetReader.cpp

parquet tools get field schema is
<img width="380" height="173" alt="image" src="https://github.com/user-attachments/assets/391cab02-4412-406d-a24c-7cb1eae728d4" />
hive table meta is array<struct<position:int,slotType:string,businessType:string,contentId:bigint,isWarmup:boolean,contentType:string>>

The error happens because of the array<struct> field type in Parquet files. When ARRAY<ROW<...>> sets childRequestedType = elementType() for each sub-column via !requestedType && parentRequestedType, the child type ends up being the full ROW<...>—but the leaf column’s convertType needs a scalar type (like BIGINT), not an entire struct.