### PR TITLE
Add Presto FNV-1 hash functions fnv1_32/fnv1a_32/fnv1_64/fnv1a_64

### DIFF
--- a/velox/docs/functions/presto/binary.rst
+++ b/velox/docs/functions/presto/binary.rst
@@ -175,3 +175,19 @@ Binary Functions
 .. function:: xxhash64(binary, bigint) -> varbinary
 
     Computes the xxhash64 hash of ``binary`` with ``bigint`` seed.
+
+.. function:: fnv1_32(binary) -> bigint
+
+    Computes the 32-bit FNV-1 hash of ``binary``.
+
+.. function:: fnv1a_32(binary) -> bigint
+
+    Computes the 32-bit FNV-1a hash of  ``binary``.
+
+.. function:: fnv1_64(binary) -> bigint
+
+   Computes the 64-bit FNV-1 hash of ``binary``.
+
+.. function:: fnv1a_64(binary) -> bigint
+
+    Computes the 64-bit FNV-1a hash of ``binary``.

--- a/velox/functions/prestosql/BinaryFunctions.h
+++ b/velox/functions/prestosql/BinaryFunctions.h
@@ -605,4 +605,87 @@ struct Fnv1a_64Function {
   }
 };
 
+inline constexpr uint32_t kFNV32OffsetBasis = 0x811c9dc5;
+inline constexpr uint64_t kFNV64OffsetBasis = 0xcbf29ce484222325lu;
+
+/// fnv1_32(varbinary) -> bigint
+template <typename T>
+struct Fnv132Function {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<int64_t>& result,
+      const arg_type<Varbinary>& data) {
+    int32_t tmp = kFNV32OffsetBasis;
+    const unsigned char* input =
+        reinterpret_cast<const unsigned char*>(data.data());
+    for (auto i = 0; i < data.size(); ++i) {
+      // equals to tmp = tmp * (2^24 + 2^8 + 0x93), this maybe a litter faster
+      tmp += (tmp << 1) + (tmp << 4) + (tmp << 7) + (tmp << 8) + (tmp << 24);
+      tmp ^= *input++;
+    }
+    result = tmp;
+  }
+};
+
+/// fnv1a_32(varbinary) -> bigint
+template <typename T>
+struct Fnv1a32Function {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<int64_t>& result,
+      const arg_type<Varbinary>& data) {
+    int32_t tmp = kFNV32OffsetBasis;
+    const unsigned char* input =
+        reinterpret_cast<const unsigned char*>(data.data());
+    for (auto i = 0; i < data.size(); ++i) {
+      tmp ^= *input++;
+      // tmp = tmp * (2^24 + 2^8 + 0x93);
+      tmp += (tmp << 1) + (tmp << 4) + (tmp << 7) + (tmp << 8) + (tmp << 24);
+    }
+    result = tmp;
+  }
+};
+
+/// fnv1_64(varbinary) -> bigint
+template <typename T>
+struct Fnv164Function {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<int64_t>& result,
+      const arg_type<Varbinary>& data) {
+    result = kFNV64OffsetBasis;
+    const unsigned char* input =
+        reinterpret_cast<const unsigned char*>(data.data());
+    for (auto i = 0; i < data.size(); ++i) {
+      // result = result * (2^40 + 2^8 + 0xb3)
+      result += (result << 1) + (result << 4) + (result << 5) + (result << 7) +
+          (result << 8) + (result << 40);
+      result ^= *input++;
+    }
+  }
+};
+
+/// fnv1a_64(varbinary) -> bigint
+template <typename T>
+struct Fnv1a64Function {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<int64_t>& result,
+      const arg_type<Varbinary>& data) {
+    result = kFNV64OffsetBasis;
+    const unsigned char* input =
+        reinterpret_cast<const unsigned char*>(data.data());
+    for (auto i = 0; i < data.size(); ++i) {
+      result ^= *input++;
+      // result = result * (2^40 + 2^8 + 0xb3)
+      result += (result << 1) + (result << 4) + (result << 5) + (result << 7) +
+          (result << 8) + (result << 40);
+    }
+  }
+};
+
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/BinaryFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/BinaryFunctionsRegistration.cpp
@@ -101,6 +101,11 @@ void registerSimpleFunctions(const std::string& prefix) {
       Varbinary,
       int64_t,
       Varbinary>({prefix + "rpad"});
+
+  registerFunction<Fnv132Function, int64_t, Varbinary>({prefix + "fnv1_32"});
+  registerFunction<Fnv1a32Function, int64_t, Varbinary>({prefix + "fnv1a_32"});
+  registerFunction<Fnv164Function, int64_t, Varbinary>({prefix + "fnv1_64"});
+  registerFunction<Fnv1a64Function, int64_t, Varbinary>({prefix + "fnv1a_64"});
 }
 } // namespace
 

--- a/velox/functions/prestosql/tests/BinaryFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/BinaryFunctionsTest.cpp
@@ -1013,4 +1013,65 @@ TEST_F(BinaryFunctionsTest, fromBase32) {
       fromBase32("NBSWY3DPEB3W64"), "Invalid input length 14");
 }
 
+// ground truth results of the following fnv hash function tests are based on
+// presto-main/src/test/java/com/facebook/presto/operator/scalar/TestVarbinaryFunctions.java
+TEST_F(BinaryFunctionsTest, fnv1_32) {
+  const auto fnv1_32 = [&](std::optional<std::string> value) {
+    return evaluateOnce<int64_t, std::string>(
+        "fnv1_32(from_hex(cast(c0 as varchar)))", {value});
+  };
+  EXPECT_EQ(std::nullopt, fnv1_32(std::nullopt));
+  EXPECT_EQ(0x811c9dc5L + std::numeric_limits<int>::min() * 2L, fnv1_32(""));
+  EXPECT_EQ(0x050c5d06L, fnv1_32("19"));
+  EXPECT_EQ(0x050c5deaL, fnv1_32("F5"));
+  EXPECT_EQ(0x087689bbL, fnv1_32("0919"));
+  EXPECT_EQ(0x67a7fdecL, fnv1_32("F50919"));
+  EXPECT_EQ(
+      0x9f2263f3L + std::numeric_limits<int>::min() * 2L,
+      fnv1_32("232706FC6BF50919"));
+}
+
+TEST_F(BinaryFunctionsTest, fnv1a_32) {
+  const auto fnv1a_32 = [&](std::optional<std::string> value) {
+    return evaluateOnce<int64_t, std::string>(
+        "fnv1a_32(from_hex(cast(c0 as varchar)))", {value});
+  };
+  EXPECT_EQ(std::nullopt, fnv1a_32(std::nullopt));
+  EXPECT_EQ(0x811c9dc5L + std::numeric_limits<int>::min() * 2L, fnv1a_32(""));
+  EXPECT_EQ(0x1c0c8154L, fnv1a_32("19"));
+  EXPECT_EQ(0x700b7290L, fnv1a_32("F5"));
+  EXPECT_EQ(0x34881807L, fnv1a_32("0919"));
+  EXPECT_EQ(
+      0xeb80c366L + std::numeric_limits<int>::min() * 2L, fnv1a_32("F50919"));
+  EXPECT_EQ(0x0951d55fL, fnv1a_32("232706FC6BF50919"));
+}
+
+TEST_F(BinaryFunctionsTest, fnv1_64) {
+  const auto fnv1_64 = [&](std::optional<std::string> value) {
+    return evaluateOnce<int64_t, std::string>(
+        "fnv1_64(from_hex(cast(c0 as varchar)))", {value});
+  };
+  EXPECT_EQ(std::nullopt, fnv1_64(std::nullopt));
+  EXPECT_EQ(0xcbf29ce484222325L, fnv1_64(""));
+  EXPECT_EQ(0xaf63bd4c8601b7c6L, fnv1_64("19"));
+  EXPECT_EQ(0xaf63bd4c8601b72aL, fnv1_64("F5"));
+  EXPECT_EQ(0x08327f07b4eb60bbL, fnv1_64("0919"));
+  EXPECT_EQ(0xd6e5ed186a0487ccL, fnv1_64("F50919"));
+  EXPECT_EQ(0x4a65ff96675a9f33L, fnv1_64("232706FC6BF50919"));
+}
+
+TEST_F(BinaryFunctionsTest, fnv1a_64) {
+  const auto fnv1a_64 = [&](std::optional<std::string> value) {
+    return evaluateOnce<int64_t, std::string>(
+        "fnv1a_64(from_hex(cast(c0 as varchar)))", {value});
+  };
+  EXPECT_EQ(std::nullopt, fnv1a_64(std::nullopt));
+  EXPECT_EQ(0xcbf29ce484222325L, fnv1a_64(""));
+  EXPECT_EQ(0xaf63d44c8601def4L, fnv1a_64("19"));
+  EXPECT_EQ(0xaf64684c8602da70L, fnv1a_64("F5"));
+  EXPECT_EQ(0x084a6b07b4ffd087L, fnv1a_64("0919"));
+  EXPECT_EQ(0xa2a0b81bb3201de6L, fnv1a_64("F50919"));
+  EXPECT_EQ(0x68addc0b0febac5fL, fnv1a_64("232706FC6BF50919"));
+}
+
 } // namespace


### PR DESCRIPTION
This PR continues the work from abandoned [PR](https://github.com/facebookincubator/velox/pull/5435)

xImplements the  FNV-1 hash functions:
* `fnv1_32`
* `fnv1a_32`
* `fnv1_64`
* `fnv1a_64`

Resolves #5434 

The implements refers: http://www.isthe.com/chongo/tech/comp/fnv/index.html