### PR TITLE
feat: Add FunctionDecorator hook to QueryCtx for wrapping resolved VectorFunctions

### DIFF
--- a/velox/core/QueryCtx.cpp
+++ b/velox/core/QueryCtx.cpp
@@ -54,7 +54,8 @@ std::shared_ptr<QueryCtx> QueryCtx::Builder::build() {
       spillExecutor_,
       std::move(queryId_),
       std::move(tokenProvider_),
-      std::move(traceCtxProvider_)));
+      std::move(traceCtxProvider_),
+      std::move(functionDecorator_)));
   queryCtx->maybeSetReclaimer();
   for (auto& cb : releaseCallbacks_) {
     queryCtx->addReleaseCallback(std::move(cb));
@@ -72,7 +73,8 @@ QueryCtx::QueryCtx(
     folly::Executor* spillExecutor,
     const std::string& queryId,
     std::shared_ptr<filesystems::TokenProvider> tokenProvider,
-    TraceCtxProvider traceCtxProvider)
+    TraceCtxProvider traceCtxProvider,
+    FunctionDecorator functionDecorator)
     : queryId_(queryId),
       executor_(executor),
       spillExecutor_(spillExecutor),
@@ -81,7 +83,8 @@ QueryCtx::QueryCtx(
       pool_(std::move(pool)),
       queryConfig_{std::move(queryConfig)},
       fsTokenProvider_(std::move(tokenProvider)),
-      traceCtxProvider_(std::move(traceCtxProvider)) {
+      traceCtxProvider_(std::move(traceCtxProvider)),
+      functionDecorator_(std::move(functionDecorator)) {
   initPool(queryId);
 }
 

--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -30,9 +30,13 @@
 #include "velox/vector/DecodedVector.h"
 #include "velox/vector/VectorPool.h"
 
-namespace facebook::velox::exec::trace {
+namespace facebook::velox::exec {
+class VectorFunction;
+struct VectorFunctionMetadata;
+namespace trace {
 class TraceCtx;
-}
+} // namespace trace
+} // namespace facebook::velox::exec
 
 namespace facebook::velox::core {
 
@@ -85,6 +89,23 @@ class QueryCtx : public std::enable_shared_from_this<QueryCtx> {
   using TraceCtxProvider = std::function<std::unique_ptr<exec::trace::TraceCtx>(
       core::QueryCtx&,
       const core::PlanFragment&)>;
+
+  /// Callback that optionally wraps a resolved VectorFunction before it is
+  /// handed to an Expr node. Enables cross-cutting concerns like monitoring
+  /// or access control without modifying function implementations.
+  ///
+  /// Returns both the (possibly wrapped) VectorFunction and updated metadata.
+  /// Decorators that alter behavioral properties (e.g. wrapping a deterministic
+  /// function in a non-deterministic wrapper) must return updated metadata to
+  /// avoid incorrect CSE optimization.
+  ///
+  /// The returned VectorFunction must not be null.
+  using FunctionDecorator = std::function<std::pair<
+      std::shared_ptr<exec::VectorFunction>,
+      exec::VectorFunctionMetadata>(
+      std::string_view name,
+      std::shared_ptr<exec::VectorFunction> original,
+      const exec::VectorFunctionMetadata& metadata)>;
 
   ~QueryCtx();
 
@@ -191,6 +212,11 @@ class QueryCtx : public std::enable_shared_from_this<QueryCtx> {
       return *this;
     }
 
+    Builder& functionDecorator(FunctionDecorator decorator) {
+      functionDecorator_ = std::move(decorator);
+      return *this;
+    }
+
     /// Constructs and returns a QueryCtx with the configured parameters.
     ///
     /// @return Shared pointer to the newly created QueryCtx instance
@@ -208,6 +234,8 @@ class QueryCtx : public std::enable_shared_from_this<QueryCtx> {
     std::shared_ptr<filesystems::TokenProvider> tokenProvider_;
     std::deque<ReleaseCallback> releaseCallbacks_;
     TraceCtxProvider traceCtxProvider_;
+    // Optional callback to wrap resolved VectorFunction instances.
+    FunctionDecorator functionDecorator_;
   };
 
   /// Generates a unique memory pool name for a query.
@@ -321,6 +349,17 @@ class QueryCtx : public std::enable_shared_from_this<QueryCtx> {
     traceCtxProvider_ = std::move(provider);
   }
 
+  /// Returns the function decorator, if set.
+  const FunctionDecorator& functionDecorator() const {
+    return functionDecorator_;
+  }
+
+  /// Sets an optional decorator applied to each resolved VectorFunction
+  /// during expression compilation.
+  void setFunctionDecorator(FunctionDecorator decorator) {
+    functionDecorator_ = std::move(decorator);
+  }
+
   /// Store a per-query registry override. Each subsystem defines its own key
   /// (e.g., "connectors", "vectorFunctions"). The registry is stored as a
   /// type-erased shared_ptr; callers must use the same type T for setRegistry
@@ -394,7 +433,8 @@ class QueryCtx : public std::enable_shared_from_this<QueryCtx> {
       folly::Executor* spillExecutor = nullptr,
       const std::string& queryId = "",
       std::shared_ptr<filesystems::TokenProvider> tokenProvider = {},
-      TraceCtxProvider traceCtxProvider = nullptr);
+      TraceCtxProvider traceCtxProvider = nullptr,
+      FunctionDecorator functionDecorator = nullptr);
 
   class MemoryReclaimer : public memory::MemoryReclaimer {
    public:
@@ -476,6 +516,9 @@ class QueryCtx : public std::enable_shared_from_this<QueryCtx> {
 
   // A function that constructs a custom trace ctx object.
   TraceCtxProvider traceCtxProvider_;
+
+  // Optional callback to wrap resolved VectorFunction instances.
+  FunctionDecorator functionDecorator_;
 
   // Type-erased registry entry for per-query overrides.
   struct RegistryEntry {

--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -293,21 +293,18 @@ ExprPtr compileCall(
         ctx.queryCtx->queryConfig());
   }
 
+  std::shared_ptr<VectorFunction> vectorFunction;
+  VectorFunctionMetadata metadata;
+
   if (auto functionWithMetadata = getVectorFunctionWithMetadata(
           call->name(),
           inputTypes,
           getConstantInputs(inputs),
           ctx.queryCtx->queryConfig())) {
-    return std::make_shared<Expr>(
-        resultType,
-        std::move(inputs),
-        functionWithMetadata->first,
-        functionWithMetadata->second,
-        call->name(),
-        trackCpuUsage);
-  }
-
-  if (auto simpleFunctionEntry =
+    vectorFunction = functionWithMetadata->first;
+    metadata = functionWithMetadata->second;
+  } else if (
+      auto simpleFunctionEntry =
           simpleFunctions().resolveFunction(call->name(), inputTypes)) {
     VELOX_USER_CHECK(
         resultType->equivalent(*simpleFunctionEntry->type().get()),
@@ -318,49 +315,63 @@ ExprPtr compileCall(
         resultType,
         folly::join(", ", inputTypes));
 
-    auto func = simpleFunctionEntry->createFunction()->createVectorFunction(
-        inputTypes,
-        getConstantInputs(inputs),
-        ctx.queryCtx->queryConfig(),
-        ctx.pool);
-    return std::make_shared<Expr>(
-        resultType,
-        std::move(inputs),
-        std::move(func),
-        simpleFunctionEntry->metadata(),
-        call->name(),
-        trackCpuUsage);
-  }
+    vectorFunction =
+        simpleFunctionEntry->createFunction()->createVectorFunction(
+            inputTypes,
+            getConstantInputs(inputs),
+            ctx.queryCtx->queryConfig(),
+            ctx.pool);
+    metadata = simpleFunctionEntry->metadata();
+  } else {
+    const auto& functionName = call->name();
+    auto vectorFunctionSignatures = getVectorFunctionSignatures(functionName);
+    auto simpleFunctionSignatures =
+        simpleFunctions().getFunctionSignatures(functionName);
+    std::vector<std::string> signatures;
 
-  const auto& functionName = call->name();
-  auto vectorFunctionSignatures = getVectorFunctionSignatures(functionName);
-  auto simpleFunctionSignatures =
-      simpleFunctions().getFunctionSignatures(functionName);
-  std::vector<std::string> signatures;
+    if (vectorFunctionSignatures.has_value()) {
+      for (const auto& signature : vectorFunctionSignatures.value()) {
+        signatures.push_back(fmt::format("({})", signature->toString()));
+      }
+    }
 
-  if (vectorFunctionSignatures.has_value()) {
-    for (const auto& signature : vectorFunctionSignatures.value()) {
+    for (const auto& signature : simpleFunctionSignatures) {
       signatures.push_back(fmt::format("({})", signature->toString()));
+    }
+
+    if (signatures.empty()) {
+      VELOX_USER_FAIL(
+          "Scalar function name not registered: {}, called with arguments: ({}).",
+          call->name(),
+          folly::join(", ", inputTypes));
+    } else {
+      VELOX_USER_FAIL(
+          "Scalar function {} not registered with arguments: ({}). "
+          "Found function registered with the following signatures:\n{}",
+          call->name(),
+          folly::join(", ", inputTypes),
+          folly::join("\n", signatures));
     }
   }
 
-  for (const auto& signature : simpleFunctionSignatures) {
-    signatures.push_back(fmt::format("({})", signature->toString()));
+  if (const auto& decorator = ctx.queryCtx->functionDecorator()) {
+    auto [decoratedFunction, decoratedMetadata] =
+        decorator(call->name(), std::move(vectorFunction), metadata);
+    VELOX_CHECK_NOT_NULL(
+        decoratedFunction,
+        "FunctionDecorator must return a non-null VectorFunction for: {}",
+        call->name());
+    vectorFunction = std::move(decoratedFunction);
+    metadata = decoratedMetadata;
   }
 
-  if (signatures.empty()) {
-    VELOX_USER_FAIL(
-        "Scalar function name not registered: {}, called with arguments: ({}).",
-        call->name(),
-        folly::join(", ", inputTypes));
-  } else {
-    VELOX_USER_FAIL(
-        "Scalar function {} not registered with arguments: ({}). "
-        "Found function registered with the following signatures:\n{}",
-        call->name(),
-        folly::join(", ", inputTypes),
-        folly::join("\n", signatures));
-  }
+  return std::make_shared<Expr>(
+      resultType,
+      std::move(inputs),
+      std::move(vectorFunction),
+      metadata,
+      call->name(),
+      trackCpuUsage);
 }
 
 ExprPtr compileCast(

--- a/velox/expression/tests/ExprCompilerTest.cpp
+++ b/velox/expression/tests/ExprCompilerTest.cpp
@@ -18,6 +18,7 @@
 #include "velox/core/Expressions.h"
 #include "velox/expression/Expr.h"
 #include "velox/expression/FieldReference.h"
+#include "velox/expression/FunctionMetadata.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/functions/prestosql/types/JsonType.h"
 #include "velox/parse/ExpressionsParser.h"
@@ -441,6 +442,160 @@ TEST_F(ExprCompilerTest, simpleFunctionMemoryPool) {
 
   auto stringView = decoded.valueAt<StringView>(0);
   ASSERT_GT(stringView.size(), 0) << "HLL sketch is empty";
+}
+
+TEST_F(ExprCompilerTest, functionDecorator) {
+  auto rowType = ROW({"a"}, {BIGINT()});
+  auto field = makeField(rowType);
+
+  std::vector<std::string> decoratedFunctions;
+  queryCtx_->setFunctionDecorator(
+      [&](std::string_view name,
+          std::shared_ptr<VectorFunction> original,
+          const VectorFunctionMetadata& metadata)
+          -> std::
+              pair<std::shared_ptr<VectorFunction>, VectorFunctionMetadata> {
+                decoratedFunctions.emplace_back(name);
+                return {std::move(original), metadata};
+              });
+
+  auto expression = call("plus", {field("a"), bigint(1)});
+  auto exprSet = compile(expression);
+  ASSERT_EQ(decoratedFunctions.size(), 1);
+  EXPECT_EQ(decoratedFunctions[0], "plus");
+
+  auto input = makeRowVector({"a"}, {makeFlatVector<int64_t>({1, 2, 3})});
+  SelectivityVector rows(3);
+  EvalCtx evalCtx(execCtx_.get(), exprSet.get(), input.get());
+  std::vector<VectorPtr> results(1);
+  exprSet->eval(rows, evalCtx, results);
+
+  auto expected = makeFlatVector<int64_t>({2, 3, 4});
+  velox::test::assertEqualVectors(expected, results[0]);
+}
+
+TEST_F(ExprCompilerTest, functionDecoratorNotCalledForSpecialForms) {
+  auto rowType = ROW({"a", "b"}, {BOOLEAN(), BOOLEAN()});
+  auto field = makeField(rowType);
+
+  std::vector<std::string> decoratedFunctions;
+  queryCtx_->setFunctionDecorator(
+      [&](std::string_view name,
+          std::shared_ptr<VectorFunction> original,
+          const VectorFunctionMetadata& metadata)
+          -> std::
+              pair<std::shared_ptr<VectorFunction>, VectorFunctionMetadata> {
+                decoratedFunctions.emplace_back(name);
+                return {std::move(original), metadata};
+              });
+
+  auto expression = andCall(field("a"), field("b"));
+  compile(expression);
+
+  EXPECT_TRUE(decoratedFunctions.empty());
+}
+
+TEST_F(ExprCompilerTest, functionDecoratorWrapping) {
+  class CountingWrapper : public VectorFunction {
+   public:
+    CountingWrapper(
+        std::shared_ptr<VectorFunction> inner,
+        std::shared_ptr<std::atomic<int>> counter)
+        : inner_(std::move(inner)), counter_(std::move(counter)) {}
+
+    void apply(
+        const SelectivityVector& rows,
+        std::vector<VectorPtr>& args,
+        const TypePtr& outputType,
+        EvalCtx& context,
+        VectorPtr& result) const override {
+      ++(*counter_);
+      inner_->apply(rows, args, outputType, context, result);
+    }
+
+    bool supportsFlatNoNullsFastPath() const override {
+      return inner_->supportsFlatNoNullsFastPath();
+    }
+
+   private:
+    std::shared_ptr<VectorFunction> inner_;
+    std::shared_ptr<std::atomic<int>> counter_;
+  };
+
+  auto rowType = ROW({"a"}, {BIGINT()});
+  auto field = makeField(rowType);
+
+  auto callCount = std::make_shared<std::atomic<int>>(0);
+  queryCtx_->setFunctionDecorator(
+      [callCount](
+          std::string_view /*name*/,
+          std::shared_ptr<VectorFunction> original,
+          const VectorFunctionMetadata& metadata)
+          -> std::
+              pair<std::shared_ptr<VectorFunction>, VectorFunctionMetadata> {
+                return {
+                    std::make_shared<CountingWrapper>(
+                        std::move(original), callCount),
+                    metadata,
+                };
+              });
+
+  auto expression = call("plus", {field("a"), bigint(1)});
+  auto exprSet = compile(expression);
+
+  auto input = makeRowVector({"a"}, {makeFlatVector<int64_t>({1, 2, 3})});
+  SelectivityVector rows(3);
+  EvalCtx evalCtx(execCtx_.get(), exprSet.get(), input.get());
+  std::vector<VectorPtr> results(1);
+  exprSet->eval(rows, evalCtx, results);
+
+  EXPECT_EQ(callCount->load(), 1);
+  auto expected = makeFlatVector<int64_t>({2, 3, 4});
+  velox::test::assertEqualVectors(expected, results[0]);
+}
+
+TEST_F(ExprCompilerTest, functionDecoratorReturningNullptr) {
+  auto rowType = ROW({"a"}, {BIGINT()});
+  auto field = makeField(rowType);
+
+  queryCtx_->setFunctionDecorator(
+      [](std::string_view /*name*/,
+         std::shared_ptr<VectorFunction> /*original*/,
+         const VectorFunctionMetadata& metadata)
+          -> std::
+              pair<std::shared_ptr<VectorFunction>, VectorFunctionMetadata> {
+                return {nullptr, metadata};
+              });
+
+  auto expression = call("plus", {field("a"), bigint(1)});
+  VELOX_ASSERT_THROW(compile(expression), "FunctionDecorator must return");
+}
+
+TEST_F(ExprCompilerTest, functionDecoratorViaBuilder) {
+  auto rowType = ROW({"a"}, {BIGINT()});
+
+  std::vector<std::string> decoratedFunctions;
+  auto queryCtx = core::QueryCtx::Builder()
+                      .functionDecorator(
+                          [&](std::string_view name,
+                              std::shared_ptr<VectorFunction> original,
+                              const VectorFunctionMetadata& metadata)
+                              -> std::pair<
+                                  std::shared_ptr<VectorFunction>,
+                                  VectorFunctionMetadata> {
+                            decoratedFunctions.emplace_back(name);
+                            return {std::move(original), metadata};
+                          })
+                      .build();
+  auto execCtx = std::make_unique<core::ExecCtx>(pool_.get(), queryCtx.get());
+
+  auto field = makeField(rowType);
+  auto expression = call("plus", {field("a"), bigint(1)});
+  auto exprSet = std::make_unique<ExprSet>(
+      std::vector<core::TypedExprPtr>{expression}, execCtx.get());
+
+  ASSERT_EQ(decoratedFunctions.size(), 1);
+  EXPECT_EQ(decoratedFunctions[0], "plus");
 }
 
 } // namespace facebook::velox::exec::test


### PR DESCRIPTION
Summary:
Add a generic FunctionDecorator callback on QueryCtx that can optionally wrap any resolved VectorFunction before it is handed to an Expr node during expression compilation. This provides a clean extension point for cross-cutting concerns like monitoring, caching, or access control without requiring changes to Velox internals.

The decorator is applied in ExprCompiler::compileCall() after both the vector function and simple function resolution paths converge, but before the Expr node is constructed. Special forms (AND, OR, etc.) bypass the decorator since they do not produce a VectorFunction.

The decorator receives the function name, the resolved VectorFunction, and the VectorFunctionMetadata, and returns a (possibly wrapped) VectorFunction.

Differential Revision: D102443868
