### PR TITLE
Allow map_subset/map_intersect/map_except to take a map as the 2nd argument

### DIFF
--- a/velox/functions/prestosql/MapExcept.h
+++ b/velox/functions/prestosql/MapExcept.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "velox/core/QueryConfig.h"
 #include "velox/expression/ComplexViewTypes.h"
 #include "velox/functions/Udf.h"
 #include "velox/type/FloatingPointUtil.h"
@@ -110,6 +111,124 @@ struct MapExceptVarcharFunction {
       searchKeys_.clear();
       for (const auto& key : keys.skipNulls()) {
         searchKeys_.emplace(key);
+      }
+    }
+
+    for (const auto& entry : inputMap) {
+      if (searchKeys_.contains(entry.first)) {
+        continue;
+      }
+
+      if (!entry.second.has_value()) {
+        auto& keyWriter = out.add_null();
+        keyWriter.copy_from(entry.first);
+      } else {
+        auto [keyWriter, valueWriter] = out.add_item();
+        keyWriter.copy_from(entry.first);
+        valueWriter.copy_from(entry.second.value());
+      }
+    }
+  }
+
+ private:
+  bool constantSearchKeys_{false};
+  folly::F14FastSet<StringView> searchKeys_;
+  std::vector<std::string> searchKeyStrings_;
+};
+
+/// Fast path for constant primitive type keys when the second argument is a
+/// map: map_except(m, map(...)). Only the keys of the second map are used; its
+/// values are ignored.
+template <typename TExec, typename Key>
+struct MapExceptMapPrimitiveFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& /*config*/,
+      const arg_type<Map<Key, Generic<T1>>>* /*inputMap*/,
+      const arg_type<Map<Key, Generic<T2>>>* keysMap) {
+    if (keysMap != nullptr) {
+      constantSearchKeys_ = true;
+      searchKeys_.clear();
+      addKeysFromMap(*keysMap);
+    }
+  }
+
+  void call(
+      out_type<Map<Key, Generic<T1>>>& out,
+      const arg_type<Map<Key, Generic<T1>>>& inputMap,
+      const arg_type<Map<Key, Generic<T2>>>& keysMap) {
+    if (!constantSearchKeys_) {
+      searchKeys_.clear();
+      addKeysFromMap(keysMap);
+    }
+
+    for (const auto& entry : inputMap) {
+      if (searchKeys_.contains(entry.first)) {
+        continue;
+      }
+
+      if (!entry.second.has_value()) {
+        auto& keyWriter = out.add_null();
+        keyWriter = entry.first;
+      } else {
+        auto [keyWriter, valueWriter] = out.add_item();
+        keyWriter = entry.first;
+        valueWriter.copy_from(entry.second.value());
+      }
+    }
+  }
+
+ private:
+  void addKeysFromMap(const arg_type<Map<Key, Generic<T2>>>& keysMap) {
+    for (const auto& entry : keysMap) {
+      searchKeys_.emplace(entry.first);
+    }
+  }
+
+  bool constantSearchKeys_{false};
+  util::floating_point::HashSetNaNAware<arg_type<Key>> searchKeys_;
+};
+
+/// Fast path for constant string keys when the second argument is a map:
+/// map_except(m, map(...)).
+template <typename TExec>
+struct MapExceptMapVarcharFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& /*config*/,
+      const arg_type<Map<Varchar, Generic<T1>>>* /*inputMap*/,
+      const arg_type<Map<Varchar, Generic<T2>>>* keysMap) {
+    if (keysMap != nullptr) {
+      constantSearchKeys_ = true;
+      searchKeys_.clear();
+      searchKeyStrings_.clear();
+
+      searchKeys_.reserve(keysMap->size());
+      searchKeyStrings_.reserve(keysMap->size());
+      for (const auto& entry : *keysMap) {
+        const auto& key = entry.first;
+        if (key.isInline()) {
+          searchKeys_.emplace(key);
+        } else if (!searchKeys_.contains(key)) {
+          searchKeyStrings_.push_back(key.str());
+          searchKeys_.emplace(StringView(searchKeyStrings_.back()));
+        }
+      }
+    }
+  }
+
+  void call(
+      out_type<Map<Varchar, Generic<T1>>>& out,
+      const arg_type<Map<Varchar, Generic<T1>>>& inputMap,
+      const arg_type<Map<Varchar, Generic<T2>>>& keysMap) {
+    if (!constantSearchKeys_) {
+      searchKeys_.clear();
+      for (const auto& entry : keysMap) {
+        searchKeys_.emplace(entry.first);
       }
     }
 

--- a/velox/functions/prestosql/MapIntersect.h
+++ b/velox/functions/prestosql/MapIntersect.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "velox/core/QueryConfig.h"
 #include "velox/expression/ComplexViewTypes.h"
 #include "velox/functions/Udf.h"
 #include "velox/type/FloatingPointUtil.h"
@@ -119,6 +120,136 @@ struct MapIntersectVarcharFunction {
       searchKeys_.clear();
       for (const auto& key : keys.skipNulls()) {
         searchKeys_.emplace(key);
+      }
+    }
+
+    if (searchKeys_.empty()) {
+      return;
+    }
+
+    for (const auto& entry : inputMap) {
+      if (!searchKeys_.contains(entry.first)) {
+        continue;
+      }
+
+      if (!entry.second.has_value()) {
+        auto& keyWriter = out.add_null();
+        keyWriter.copy_from(entry.first);
+      } else {
+        auto [keyWriter, valueWriter] = out.add_item();
+        keyWriter.copy_from(entry.first);
+        valueWriter.copy_from(entry.second.value());
+      }
+    }
+  }
+
+ private:
+  bool constantSearchKeys_{false};
+  folly::F14FastSet<StringView> searchKeys_;
+  std::vector<std::string> searchKeyStrings_;
+};
+
+/// Fast path for constant primitive type keys when the second argument is a
+/// map: map_intersect(m, map(...)). Only the keys of the second map are used;
+/// its values are ignored.
+template <typename TExec, typename Key>
+struct MapIntersectMapPrimitiveFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& /*config*/,
+      const arg_type<Map<Key, Generic<T1>>>* /*inputMap*/,
+      const arg_type<Map<Key, Generic<T2>>>* keysMap) {
+    if (keysMap != nullptr) {
+      constantSearchKeys_ = true;
+      addKeysFromMap(*keysMap);
+    }
+  }
+
+  void call(
+      out_type<Map<Key, Generic<T1>>>& out,
+      const arg_type<Map<Key, Generic<T1>>>& inputMap,
+      const arg_type<Map<Key, Generic<T2>>>& keysMap) {
+    if (keysMap.empty()) {
+      return;
+    }
+
+    if (!constantSearchKeys_) {
+      searchKeys_.clear();
+      addKeysFromMap(keysMap);
+    }
+
+    if (searchKeys_.empty()) {
+      return;
+    }
+
+    for (const auto& entry : inputMap) {
+      if (!searchKeys_.contains(entry.first)) {
+        continue;
+      }
+
+      if (!entry.second.has_value()) {
+        auto& keyWriter = out.add_null();
+        keyWriter = entry.first;
+      } else {
+        auto [keyWriter, valueWriter] = out.add_item();
+        keyWriter = entry.first;
+        valueWriter.copy_from(entry.second.value());
+      }
+    }
+  }
+
+ private:
+  void addKeysFromMap(const arg_type<Map<Key, Generic<T2>>>& keysMap) {
+    for (const auto& entry : keysMap) {
+      searchKeys_.emplace(entry.first);
+    }
+  }
+
+  bool constantSearchKeys_{false};
+  util::floating_point::HashSetNaNAware<arg_type<Key>> searchKeys_;
+};
+
+/// Fast path for constant string keys when the second argument is a map:
+/// map_intersect(m, map(...)).
+template <typename TExec>
+struct MapIntersectMapVarcharFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& /*config*/,
+      const arg_type<Map<Varchar, Generic<T1>>>* /*inputMap*/,
+      const arg_type<Map<Varchar, Generic<T2>>>* keysMap) {
+    if (keysMap != nullptr) {
+      constantSearchKeys_ = true;
+
+      searchKeyStrings_.reserve(keysMap->size());
+      for (const auto& entry : *keysMap) {
+        const auto& key = entry.first;
+        if (key.isInline()) {
+          searchKeys_.emplace(key);
+        } else if (!searchKeys_.contains(key)) {
+          searchKeyStrings_.push_back(key.str());
+          searchKeys_.emplace(StringView(searchKeyStrings_.back()));
+        }
+      }
+    }
+  }
+
+  void call(
+      out_type<Map<Varchar, Generic<T1>>>& out,
+      const arg_type<Map<Varchar, Generic<T1>>>& inputMap,
+      const arg_type<Map<Varchar, Generic<T2>>>& keysMap) {
+    if (keysMap.empty()) {
+      return;
+    }
+
+    if (!constantSearchKeys_) {
+      searchKeys_.clear();
+      for (const auto& entry : keysMap) {
+        searchKeys_.emplace(entry.first);
       }
     }
 

--- a/velox/functions/prestosql/MapSubset.cpp
+++ b/velox/functions/prestosql/MapSubset.cpp
@@ -27,6 +27,15 @@ void registerMapSubsetPrimitive(const std::string& name) {
       Array<T>>({name});
 }
 
+template <typename T>
+void registerMapSubsetMapPrimitive(const std::string& name) {
+  registerFunction<
+      ParameterBinder<MapSubsetMapPrimitiveFunction, T>,
+      Map<T, Generic<T1>>,
+      Map<T, Generic<T1>>,
+      Map<T, Generic<T2>>>({name});
+}
+
 void registerMapSubset(const std::string& name) {
   registerMapSubsetPrimitive<bool>(name);
   registerMapSubsetPrimitive<int8_t>(name);
@@ -49,5 +58,29 @@ void registerMapSubset(const std::string& name) {
       Map<Generic<T1>, Generic<T2>>,
       Map<Generic<T1>, Generic<T2>>,
       Array<Generic<T1>>>({name});
+
+  // Overloads with a Map as the second argument. Only the keys of the second
+  // map are used for the membership decision; its values are ignored.
+  registerMapSubsetMapPrimitive<bool>(name);
+  registerMapSubsetMapPrimitive<int8_t>(name);
+  registerMapSubsetMapPrimitive<int16_t>(name);
+  registerMapSubsetMapPrimitive<int32_t>(name);
+  registerMapSubsetMapPrimitive<int64_t>(name);
+  registerMapSubsetMapPrimitive<float>(name);
+  registerMapSubsetMapPrimitive<double>(name);
+  registerMapSubsetMapPrimitive<Timestamp>(name);
+  registerMapSubsetMapPrimitive<Date>(name);
+
+  registerFunction<
+      MapSubsetMapVarcharFunction,
+      Map<Varchar, Generic<T1>>,
+      Map<Varchar, Generic<T1>>,
+      Map<Varchar, Generic<T2>>>({name});
+
+  registerFunction<
+      MapSubsetMapFunction,
+      Map<Generic<T1>, Generic<T2>>,
+      Map<Generic<T1>, Generic<T2>>,
+      Map<Generic<T1>, Any>>({name});
 }
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/MapSubset.h
+++ b/velox/functions/prestosql/MapSubset.h
@@ -162,6 +162,150 @@ struct MapSubsetVarcharFunction {
   std::vector<std::string> searchKeyStrings_;
 };
 
+/// Fast path for constant primitive type keys when the second argument is a
+/// map: map_subset(m, map(...)). Only the keys of the second map are used; its
+/// values are ignored.
+template <typename TExec, typename Key>
+struct MapSubsetMapPrimitiveFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& /*config*/,
+      const arg_type<Map<Key, Generic<T1>>>* /*inputMap*/,
+      const arg_type<Map<Key, Generic<T2>>>* keysMap) {
+    if (keysMap != nullptr) {
+      constantSearchKeys_ = true;
+      addKeysFromMap(*keysMap);
+    }
+  }
+
+  void call(
+      out_type<Map<Key, Generic<T1>>>& out,
+      const arg_type<Map<Key, Generic<T1>>>& inputMap,
+      const arg_type<Map<Key, Generic<T2>>>& keysMap) {
+    if (keysMap.empty()) {
+      return;
+    }
+
+    if (!constantSearchKeys_) {
+      searchKeys_.clear();
+      addKeysFromMap(keysMap);
+    }
+
+    if (searchKeys_.empty()) {
+      return;
+    }
+
+    auto toFind = searchKeys_.size();
+
+    for (const auto& entry : inputMap) {
+      if (!searchKeys_.contains(entry.first)) {
+        continue;
+      }
+
+      if (!entry.second.has_value()) {
+        auto& keyWriter = out.add_null();
+        keyWriter = entry.first;
+      } else {
+        auto [keyWriter, valueWriter] = out.add_item();
+        keyWriter = entry.first;
+        valueWriter.copy_from(entry.second.value());
+      }
+
+      --toFind;
+      if (toFind == 0) {
+        break;
+      }
+    }
+  }
+
+ private:
+  void addKeysFromMap(const arg_type<Map<Key, Generic<T2>>>& keysMap) {
+    for (const auto& entry : keysMap) {
+      searchKeys_.emplace(entry.first);
+    }
+  }
+
+  bool constantSearchKeys_{false};
+  util::floating_point::HashSetNaNAware<arg_type<Key>> searchKeys_;
+};
+
+/// Fast path for constant string keys when the second argument is a map:
+/// map_subset(m, map(...)).
+template <typename TExec>
+struct MapSubsetMapVarcharFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& /*config*/,
+      const arg_type<Map<Varchar, Generic<T1>>>* /*inputMap*/,
+      const arg_type<Map<Varchar, Generic<T2>>>* keysMap) {
+    if (keysMap != nullptr) {
+      constantSearchKeys_ = true;
+
+      searchKeyStrings_.reserve(keysMap->size());
+      for (const auto& entry : *keysMap) {
+        const auto& key = entry.first;
+        if (key.isInline()) {
+          searchKeys_.emplace(key);
+        } else if (!searchKeys_.contains(key)) {
+          searchKeyStrings_.push_back(key.str());
+          searchKeys_.emplace(StringView(searchKeyStrings_.back()));
+        }
+      }
+    }
+  }
+
+  void call(
+      out_type<Map<Varchar, Generic<T1>>>& out,
+      const arg_type<Map<Varchar, Generic<T1>>>& inputMap,
+      const arg_type<Map<Varchar, Generic<T2>>>& keysMap) {
+    if (keysMap.empty()) {
+      return;
+    }
+
+    if (!constantSearchKeys_) {
+      searchKeys_.clear();
+      for (const auto& entry : keysMap) {
+        searchKeys_.emplace(entry.first);
+      }
+    }
+
+    if (searchKeys_.empty()) {
+      return;
+    }
+
+    auto toFind = searchKeys_.size();
+
+    for (const auto& entry : inputMap) {
+      if (!searchKeys_.contains(entry.first)) {
+        continue;
+      }
+
+      if (!entry.second.has_value()) {
+        auto& keyWriter = out.add_null();
+        keyWriter.copy_from(entry.first);
+      } else {
+        auto [keyWriter, valueWriter] = out.add_item();
+        keyWriter.copy_from(entry.first);
+        valueWriter.copy_from(entry.second.value());
+      }
+
+      --toFind;
+      if (toFind == 0) {
+        break;
+      }
+    }
+  }
+
+ private:
+  bool constantSearchKeys_{false};
+  folly::F14FastSet<StringView> searchKeys_;
+  std::vector<std::string> searchKeyStrings_;
+};
+
 struct MapSubsetFunctionEqualComparator {
   bool operator()(const exec::GenericView& lhs, const exec::GenericView& rhs)
       const {
@@ -198,6 +342,60 @@ struct MapSubsetFunction {
     searchKeys_.clear();
     for (const auto& key : keys.skipNulls()) {
       searchKeys_.emplace(key);
+    }
+
+    if (searchKeys_.empty()) {
+      return;
+    }
+
+    auto toFind = searchKeys_.size();
+
+    for (const auto& entry : inputMap) {
+      if (!searchKeys_.contains(entry.first)) {
+        continue;
+      }
+
+      if (!entry.second.has_value()) {
+        auto& keyWriter = out.add_null();
+        keyWriter.copy_from(entry.first);
+      } else {
+        auto [keyWriter, valueWriter] = out.add_item();
+        keyWriter.copy_from(entry.first);
+        valueWriter.copy_from(entry.second.value());
+      }
+
+      --toFind;
+      if (toFind == 0) {
+        break;
+      }
+    }
+  }
+
+ private:
+  folly::F14FastSet<
+      exec::GenericView,
+      std::hash<exec::GenericView>,
+      MapSubsetFunctionEqualComparator>
+      searchKeys_;
+};
+
+/// Generic implementation when the second argument is a map. Doesn't provide
+/// an optimization for constant search keys.
+template <typename TExec>
+struct MapSubsetMapFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  void call(
+      out_type<Map<Generic<T1>, Generic<T2>>>& out,
+      const arg_type<Map<Generic<T1>, Generic<T2>>>& inputMap,
+      const arg_type<Map<Generic<T1>, Any>>& keysMap) {
+    if (keysMap.empty()) {
+      return;
+    }
+
+    searchKeys_.clear();
+    for (const auto& entry : keysMap) {
+      searchKeys_.emplace(entry.first);
     }
 
     if (searchKeys_.empty()) {

--- a/velox/functions/prestosql/registration/MapFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/MapFunctionsRegistration.cpp
@@ -84,6 +84,15 @@ void registerMapIntersectPrimitive(const std::string& prefix) {
       Array<T>>({prefix + "map_intersect"});
 }
 
+template <typename T>
+void registerMapIntersectMapPrimitive(const std::string& prefix) {
+  registerFunction<
+      ParameterBinder<MapIntersectMapPrimitiveFunction, T>,
+      Map<T, Generic<T1>>,
+      Map<T, Generic<T1>>,
+      Map<T, Generic<T2>>>({prefix + "map_intersect"});
+}
+
 void registerMapIntersect(const std::string& prefix) {
   registerMapIntersectPrimitive<bool>(prefix);
   registerMapIntersectPrimitive<int8_t>(prefix);
@@ -100,6 +109,24 @@ void registerMapIntersect(const std::string& prefix) {
       Map<Varchar, Generic<T1>>,
       Map<Varchar, Generic<T1>>,
       Array<Varchar>>({prefix + "map_intersect"});
+
+  // Overloads with a Map as the second argument. Only the keys of the second
+  // map are used; its values are ignored.
+  registerMapIntersectMapPrimitive<bool>(prefix);
+  registerMapIntersectMapPrimitive<int8_t>(prefix);
+  registerMapIntersectMapPrimitive<int16_t>(prefix);
+  registerMapIntersectMapPrimitive<int32_t>(prefix);
+  registerMapIntersectMapPrimitive<int64_t>(prefix);
+  registerMapIntersectMapPrimitive<float>(prefix);
+  registerMapIntersectMapPrimitive<double>(prefix);
+  registerMapIntersectMapPrimitive<Timestamp>(prefix);
+  registerMapIntersectMapPrimitive<Date>(prefix);
+
+  registerFunction<
+      MapIntersectMapVarcharFunction,
+      Map<Varchar, Generic<T1>>,
+      Map<Varchar, Generic<T1>>,
+      Map<Varchar, Generic<T2>>>({prefix + "map_intersect"});
 }
 
 template <typename T>
@@ -109,6 +136,15 @@ void registerMapExceptPrimitive(const std::string& prefix) {
       Map<T, Generic<T1>>,
       Map<T, Generic<T1>>,
       Array<T>>({prefix + "map_except"});
+}
+
+template <typename T>
+void registerMapExceptMapPrimitive(const std::string& prefix) {
+  registerFunction<
+      ParameterBinder<MapExceptMapPrimitiveFunction, T>,
+      Map<T, Generic<T1>>,
+      Map<T, Generic<T1>>,
+      Map<T, Generic<T2>>>({prefix + "map_except"});
 }
 
 void registerMapExcept(const std::string& prefix) {
@@ -127,6 +163,24 @@ void registerMapExcept(const std::string& prefix) {
       Map<Varchar, Generic<T1>>,
       Map<Varchar, Generic<T1>>,
       Array<Varchar>>({prefix + "map_except"});
+
+  // Overloads with a Map as the second argument. Only the keys of the second
+  // map are used; its values are ignored.
+  registerMapExceptMapPrimitive<bool>(prefix);
+  registerMapExceptMapPrimitive<int8_t>(prefix);
+  registerMapExceptMapPrimitive<int16_t>(prefix);
+  registerMapExceptMapPrimitive<int32_t>(prefix);
+  registerMapExceptMapPrimitive<int64_t>(prefix);
+  registerMapExceptMapPrimitive<float>(prefix);
+  registerMapExceptMapPrimitive<double>(prefix);
+  registerMapExceptMapPrimitive<Timestamp>(prefix);
+  registerMapExceptMapPrimitive<Date>(prefix);
+
+  registerFunction<
+      MapExceptMapVarcharFunction,
+      Map<Varchar, Generic<T1>>,
+      Map<Varchar, Generic<T1>>,
+      Map<Varchar, Generic<T2>>>({prefix + "map_except"});
 }
 
 template <typename T>

--- a/velox/functions/prestosql/tests/MapExceptTest.cpp
+++ b/velox/functions/prestosql/tests/MapExceptTest.cpp
@@ -378,5 +378,83 @@ TEST_F(MapExceptFuzzerTest, fuzzLargeVectors) {
        .iterations = 5});
 }
 
+TEST_F(MapExceptTest, bigintKeyMapSecondArg) {
+  auto data = makeRowVector({
+      makeMapVectorFromJson<int64_t, int32_t>({
+          "{1:10, 2:20, 3:null, 4:40, 5:50, 6:60}",
+          "{1:10, 2:20, 4:40, 5:50}",
+          "{}",
+          "{2:20, 4:40, 6:60}",
+      }),
+      // The values of the second map are intentionally unrelated to the input
+      // map to verify that only the keys are used.
+      makeMapVectorFromJson<int64_t, std::string>({
+          "{1:\"a\", 3:\"b\", 5:\"c\"}",
+          "{1:\"a\", 3:\"b\", 5:\"c\", 7:\"d\"}",
+          "{3:\"a\", 5:\"b\"}",
+          "{1:\"a\", 3:\"b\"}",
+      }),
+  });
+
+  auto expected = makeMapVectorFromJson<int64_t, int32_t>({
+      "{2:20, 4:40, 6:60}",
+      "{2:20, 4:40}",
+      "{}",
+      "{2:20, 4:40, 6:60}",
+  });
+
+  // Non-constant second arg.
+  auto result = evaluate("map_except(c0, c1)", data);
+  assertEqualVectors(expected, result);
+
+  // Constant second arg.
+  result = evaluate(
+      "map_except(c0, map(array[1, 3, 5], array['a', 'b', 'c']))", data);
+  assertEqualVectors(expected, result);
+
+  // Empty second map. Expect all map entries returned.
+  result =
+      evaluate("map_except(c0, cast(map() as map(bigint, varchar)))", data);
+  expected = makeMapVectorFromJson<int64_t, int32_t>({
+      "{1:10, 2:20, 3:null, 4:40, 5:50, 6:60}",
+      "{1:10, 2:20, 4:40, 5:50}",
+      "{}",
+      "{2:20, 4:40, 6:60}",
+  });
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(MapExceptTest, varcharKeyMapSecondArg) {
+  auto data = makeRowVector({
+      makeMapVectorFromJson<std::string, int32_t>({
+          R"({"apple": 1, "banana": 2, "Cucurbitaceae": null, "date": 4, "eggplant": 5, "fig": 6})",
+          R"({"banana": 2, "orange": 4})",
+          R"({"banana": 2, "fig": 4, "date": 5})",
+      }),
+      makeMapVectorFromJson<std::string, int64_t>({
+          R"({"apple": 1, "Cucurbitaceae": 2, "fig": 3})",
+          R"({"apple": 1, "Cucurbitaceae": 2, "date": 3, "eggplant": 4})",
+          R"({"fig": 1})",
+      }),
+  });
+
+  auto expected = makeMapVectorFromJson<std::string, int32_t>({
+      R"({"banana": 2, "date": 4, "eggplant": 5})",
+      R"({"banana": 2, "orange": 4})",
+      R"({"banana": 2, "date": 5})",
+  });
+
+  // Non-constant second arg.
+  auto result = evaluate("map_except(c0, c1)", data);
+  assertEqualVectors(expected, result);
+
+  // Constant second arg with a long key value (not inline) to exercise the
+  // string ownership path.
+  result = evaluate(
+      "map_except(c0, map(array['apple', 'some very looooong name', 'fig', 'Cucurbitaceae'], array[1, 2, 3, 4]))",
+      data);
+  assertEqualVectors(expected, result);
+}
+
 } // namespace
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/MapIntersectTest.cpp
+++ b/velox/functions/prestosql/tests/MapIntersectTest.cpp
@@ -314,6 +314,111 @@ TEST_F(MapIntersectTest, basicTest) {
   assertEqualVectors(expected, result);
 }
 
+TEST_F(MapIntersectTest, mapSecondArgInteger) {
+  auto inputMap = makeMapVector<int32_t, int32_t>({
+      {{1, 10}, {2, 20}, {3, 30}, {4, 40}},
+      {{5, 50}, {6, 60}, {7, 70}},
+      {},
+      {{8, 80}, {9, 90}},
+  });
+
+  // The second map's values are intentionally unrelated to verify only keys are
+  // used.
+  auto keysMap = makeMapVector<int32_t, int64_t>({
+      {{1, 100}, {3, 300}},
+      {{5, 500}, {7, 700}, {8, 800}},
+      {{1, 100}, {2, 200}},
+      {{8, 800}, {9, 900}, {10, 1000}},
+  });
+
+  auto expected = makeMapVector<int32_t, int32_t>({
+      {{1, 10}, {3, 30}},
+      {{5, 50}, {7, 70}},
+      {},
+      {{8, 80}, {9, 90}},
+  });
+
+  testMapIntersect("map_intersect(c0, c1)", {inputMap, keysMap}, expected);
+}
+
+TEST_F(MapIntersectTest, mapSecondArgConstant) {
+  auto inputMap = makeMapVector<int32_t, int32_t>({
+      {{1, 10}, {2, 20}, {3, 30}, {4, 40}, {5, 50}},
+      {{1, 100}, {2, 200}, {3, 300}},
+  });
+
+  auto expected = makeMapVector<int32_t, int32_t>({
+      {{1, 10}, {3, 30}, {5, 50}},
+      {{1, 100}, {3, 300}},
+  });
+
+  auto result = evaluate(
+      "map_intersect(c0, map(array[cast(1 as integer), cast(3 as integer), cast(5 as integer)], array['a', 'b', 'c']))",
+      makeRowVector({inputMap}));
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(MapIntersectTest, mapSecondArgEmpty) {
+  auto inputMap = makeMapVector<int32_t, int32_t>({
+      {{1, 10}, {2, 20}, {3, 30}},
+      {{4, 40}, {5, 50}},
+  });
+
+  auto keysMap = makeMapVector<int32_t, int32_t>({
+      {},
+      {},
+  });
+
+  auto expected = makeMapVector<int32_t, int32_t>({
+      {},
+      {},
+  });
+
+  testMapIntersect("map_intersect(c0, c1)", {inputMap, keysMap}, expected);
+}
+
+TEST_F(MapIntersectTest, mapSecondArgVarcharKey) {
+  auto inputMap = makeMapVector<StringView, int32_t>({
+      {{"apple", 1}, {"banana", 2}, {"cherry", 3}, {"date", 4}},
+      {{"hello", 10}, {"world", 20}},
+  });
+
+  auto keysMap = makeMapVector<StringView, int32_t>({
+      {{"banana", 0}, {"date", 0}, {"apple", 0}},
+      {{"hello", 0}, {"foo", 0}},
+  });
+
+  auto expected = makeMapVector<StringView, int32_t>({
+      {{"apple", 1}, {"banana", 2}, {"date", 4}},
+      {{"hello", 10}},
+  });
+
+  testMapIntersect("map_intersect(c0, c1)", {inputMap, keysMap}, expected);
+}
+
+TEST_F(MapIntersectTest, mapSecondArgNullArguments) {
+  auto inputMap =
+      makeMapVector<int32_t, int32_t>({{{1, 10}, {2, 20}, {3, 30}}});
+  auto keysMap = makeMapVector<int32_t, int32_t>({{{1, 0}, {2, 0}}});
+
+  auto nullMap =
+      BaseVector::createNullConstant(MAP(INTEGER(), INTEGER()), 1, pool());
+  auto nullKeysMap =
+      BaseVector::createNullConstant(MAP(INTEGER(), INTEGER()), 1, pool());
+
+  auto result1 =
+      evaluate("map_intersect(c0, c1)", makeRowVector({nullMap, keysMap}));
+  auto expected1 =
+      BaseVector::createNullConstant(MAP(INTEGER(), INTEGER()), 1, pool());
+  assertEqualVectors(expected1, result1);
+
+  auto result2 =
+      evaluate("map_intersect(c0, c1)", makeRowVector({inputMap, nullKeysMap}));
+  auto expected2 =
+      BaseVector::createNullConstant(MAP(INTEGER(), INTEGER()), 1, pool());
+  assertEqualVectors(expected2, result2);
+}
+
 } // namespace
 
 class MapIntersectFuzzerTest : public test::FunctionBaseTest {

--- a/velox/functions/prestosql/tests/MapSubsetTest.cpp
+++ b/velox/functions/prestosql/tests/MapSubsetTest.cpp
@@ -291,5 +291,115 @@ TEST_F(MapSubsetTest, timestampWithTimeZone) {
   assertEqualVectors(expectedWithRowKeys, result);
 }
 
+TEST_F(MapSubsetTest, bigintKeyMapSecondArg) {
+  auto data = makeRowVector({
+      makeMapVectorFromJson<int64_t, int32_t>({
+          "{1:10, 2:20, 3:null, 4:40, 5:50, 6:60}",
+          "{1:10, 2:20, 4:40, 5:50}",
+          "{}",
+          "{2:20, 4:40, 6:60}",
+      }),
+      // The values of the second map are intentionally unrelated to the input
+      // map to verify that only the keys are used.
+      makeMapVectorFromJson<int64_t, std::string>({
+          "{1:\"a\", 3:\"b\", 5:\"c\"}",
+          "{1:\"a\", 3:\"b\", 5:\"c\", 7:\"d\"}",
+          "{3:\"a\", 5:\"b\"}",
+          "{1:\"a\", 3:\"b\"}",
+      }),
+  });
+
+  auto expected = makeMapVectorFromJson<int64_t, int32_t>({
+      "{1:10, 3:null, 5:50}",
+      "{1:10, 5:50}",
+      "{}",
+      "{}",
+  });
+
+  // Non-constant second arg.
+  auto result = evaluate("map_subset(c0, c1)", data);
+  assertEqualVectors(expected, result);
+
+  // Constant second arg.
+  result = evaluate(
+      "map_subset(c0, map(array[1, 3, 5], array['a', 'b', 'c']))", data);
+  assertEqualVectors(expected, result);
+
+  // Empty second map. Expect empty maps.
+  result =
+      evaluate("map_subset(c0, cast(map() as map(bigint, varchar)))", data);
+  expected = makeMapVectorFromJson<int64_t, int32_t>({"{}", "{}", "{}", "{}"});
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(MapSubsetTest, varcharKeyMapSecondArg) {
+  auto data = makeRowVector({
+      makeMapVectorFromJson<std::string, int32_t>({
+          "{\"apple\": 1, \"banana\": 2, \"Cucurbitaceae\": null, \"date\": 4, \"eggplant\": 5, \"fig\": 6}",
+          "{\"banana\": 2, \"orange\": 4}",
+          "{\"banana\": 2, \"fig\": 4, \"date\": 5}",
+      }),
+      makeMapVectorFromJson<std::string, int64_t>({
+          "{\"apple\": 1, \"Cucurbitaceae\": 2, \"fig\": 3}",
+          "{\"apple\": 1, \"Cucurbitaceae\": 2, \"date\": 3, \"eggplant\": 4}",
+          "{\"fig\": 1}",
+      }),
+  });
+
+  auto expected = makeMapVectorFromJson<std::string, int32_t>({
+      "{\"apple\": 1, \"Cucurbitaceae\": null, \"fig\": 6}",
+      "{}",
+      "{\"fig\": 4}",
+  });
+
+  // Non-constant second arg.
+  auto result = evaluate("map_subset(c0, c1)", data);
+  assertEqualVectors(expected, result);
+
+  // Constant second arg with a long key value (not inline) to exercise the
+  // string ownership path.
+  result = evaluate(
+      "map_subset(c0, map(array['apple', 'some very looooong name', 'fig', 'Cucurbitaceae'], array[1, 2, 3, 4]))",
+      data);
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(MapSubsetTest, complexKeyMapSecondArg) {
+  // Map keys are arrays; second arg is a map with the same complex key type.
+  auto data = makeRowVector({
+      makeMapVector(
+          {0, 2},
+          makeArrayVectorFromJson<int32_t>({
+              "[1, 2, 3]",
+              "[4, 5]",
+              "[]",
+              "[1, 2]",
+          }),
+          makeFlatVector<std::string>(
+              {"apple", "orange", "Cucurbitaceae", "date"})),
+      makeMapVector(
+          {0, 2},
+          makeArrayVectorFromJson<int32_t>({
+              "[1, 2, 3]",
+              "[4, 5, 6]",
+              "[1, 2, 3]",
+              "[]",
+          }),
+          makeFlatVector<int64_t>({100, 200, 300, 400})),
+  });
+
+  auto result = evaluate("map_subset(c0, c1)", data);
+
+  auto expected = makeMapVector(
+      {0, 1},
+      makeArrayVectorFromJson<int32_t>({
+          "[1, 2, 3]",
+          "[]",
+      }),
+      makeFlatVector<std::string>({"apple", "Cucurbitaceae"}));
+
+  assertEqualVectors(expected, result);
+}
+
 } // namespace
 } // namespace facebook::velox::functions


### PR DESCRIPTION
Summary:
Add overloads to map_subset, map_intersect and map_except so that the second
argument can be a Map<K, V2> in addition to the existing Array<K> overloads.
Only the keys of the second map are used for the membership decision; its
values are ignored. All other semantics (insertion order from the first map,
null value handling) match the existing array overloads.

The new overloads are registered for the same primitive key types currently
registered for the array versions (bool, tinyint, smallint, integer, bigint,
real, double, timestamp, date, varchar). For map_subset, a generic complex
key overload is also registered, mirroring the existing array generic
overload.

Differential Revision: D102693453


