### PR TITLE
refactor: Use char literals for newline/tab in MemoryManager::toString

### DIFF
--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -386,23 +386,23 @@ std::string MemoryManager::toString(bool detail) const {
                                           : succinctBytes(allocatorCapacity))
       << " alignment " << succinctBytes(alignment_) << " usedBytes "
       << succinctBytes(getTotalBytes()) << " number of pools " << numPools()
-      << "\n";
+      << '\n';
   out << "List of root pools:\n";
   if (detail) {
     out << sysRoot_->treeMemoryUsage(false);
   } else {
-    out << "\t" << sysRoot_->name() << "\n";
+    out << '\t' << sysRoot_->name() << '\n';
   }
   std::vector<std::shared_ptr<MemoryPool>> pools = getAlivePools();
   for (const auto& pool : pools) {
     if (detail) {
       out << pool->treeMemoryUsage(false);
     } else {
-      out << "\t" << pool->name() << "\n";
+      out << '\t' << pool->name() << '\n';
     }
-    out << "\trefcount " << pool.use_count() << "\n";
+    out << "\trefcount " << pool.use_count() << '\n';
   }
-  out << allocator_->toString() << "\n";
+  out << allocator_->toString() << '\n';
   out << arbitrator_->toString();
   out << "]";
   return out.str();


### PR DESCRIPTION
In `MemoryManager::toString()`, single-character string literals "\n"
and "\t" were streamed to std::ostream. Prefer char literals '\n' and
'\t' for single characters, as `operator<<(const char*)` requires a
strlen call while operator<<(char) writes the character directly.