### PR TITLE
fix: Type deserialization of the `NullIfTypedExpr`

### DIFF
--- a/velox/core/Expressions.cpp
+++ b/velox/core/Expressions.cpp
@@ -740,7 +740,7 @@ folly::dynamic NullIfTypedExpr::serialize() const {
 TypedExprPtr NullIfTypedExpr::create(const folly::dynamic& obj, void* context) {
   auto type = core::deserializeType(obj, context);
   auto inputs = deserializeInputs(obj, context);
-  auto commonType = Type::create(obj["commonType"]);
+  auto commonType = ISerializable::deserialize<Type>(obj["commonType"]);
 
   VELOX_CHECK_EQ(inputs.size(), 2);
   return std::make_shared<NullIfTypedExpr>(

--- a/velox/core/tests/TypedExprSerdeTest.cpp
+++ b/velox/core/tests/TypedExprSerdeTest.cpp
@@ -156,4 +156,30 @@ TEST_F(TypedExprSerDeTest, lambda) {
   testSerde(expression);
 }
 
+TEST_F(TypedExprSerDeTest, nullIf) {
+  TypedExprPtr expression = std::make_shared<NullIfTypedExpr>(
+      std::make_shared<FieldAccessTypedExpr>(INTERVAL_DAY_TIME(), "a"),
+      std::make_shared<FieldAccessTypedExpr>(INTERVAL_DAY_TIME(), "b"),
+      INTERVAL_DAY_TIME());
+  testSerde(expression);
+
+  expression = std::make_shared<NullIfTypedExpr>(
+      std::make_shared<FieldAccessTypedExpr>(DATE(), "a"),
+      std::make_shared<FieldAccessTypedExpr>(DATE(), "b"),
+      DATE());
+  testSerde(expression);
+
+  expression = std::make_shared<NullIfTypedExpr>(
+      std::make_shared<FieldAccessTypedExpr>(TIME(), "a"),
+      std::make_shared<FieldAccessTypedExpr>(TIME(), "b"),
+      TIME());
+  testSerde(expression);
+
+  expression = std::make_shared<NullIfTypedExpr>(
+      std::make_shared<FieldAccessTypedExpr>(TIME_MICRO_UTC(), "a"),
+      std::make_shared<FieldAccessTypedExpr>(TIME_MICRO_UTC(), "b"),
+      TIME_MICRO_UTC());
+  testSerde(expression);
+}
+
 } // namespace facebook::velox::core::test


### PR DESCRIPTION
Switches `NullIf` commonType deserialization from `Type::create(...)` to
`ISerializable::deserialize<Type>(...)`. `Type::create` is only registered for 
deserializing a subset of types, leaving others unhandled, whereas
`ISerializable::deserialize<Type>` uses the registered serde path.