### PR TITLE
fix(exec): Avoid LOG(ERROR) noise from Task::terminate() on cancellation (#17361)

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -2520,13 +2520,18 @@ ContinueFuture Task::terminate(TaskState terminalState) {
         "Termination time has already been set, this should only happen once.");
     taskStats_.terminationTimeMs = getCurrentTimeMs();
     if (state_ == TaskState::kCanceled || state_ == TaskState::kAborted) {
-      try {
-        VELOX_FAIL(
-            state_ == TaskState::kCanceled ? "Cancelled"
-                                           : "Aborted for external error");
-      } catch (const std::exception&) {
-        exception_ = std::current_exception();
-      }
+      // Construct the exception directly instead of going through VELOX_FAIL to
+      // avoid error log when cancellation is expected.
+      exception_ = std::make_exception_ptr(VeloxRuntimeError(
+          __FILE__,
+          __LINE__,
+          __FUNCTION__,
+          /*expression=*/"",
+          state_ == TaskState::kCanceled ? "Cancelled"
+                                         : "Aborted for external error",
+          error_source::kErrorSourceRuntime,
+          error_code::kInvalidState,
+          /*isRetriable=*/false));
     }
     if (state_ != TaskState::kFinished) {
       VELOX_CHECK(!cancellationSource_.isCancellationRequested());


### PR DESCRIPTION
Summary:

`Task::terminate()` calls `VELOX_FAIL("Cancelled")` inside a `try/catch`
purely to harvest an `exception_ptr` for `Task::error()`. The throw goes
through `veloxCheckFail()` (fbcode/velox/common/base/Exceptions.h:48-72)
which unconditionally emits a `LOG(ERROR)` for any non-`VeloxUserError`
throw. The result: every `kCanceled` / `kAborted` transition produces a
`Task.cpp:NNNN ... terminate ... Expression: Cancelled` ERROR log line,
even when cancellation is the expected, caller-driven outcome (RPC
deadline, client disconnect, normal cursor teardown).

Replace the `try { VELOX_FAIL } catch` pattern with a direct
`std::make_exception_ptr(VeloxRuntimeError(...))` construction. The
captured `exception_ptr` content is preserved field-by-field; only the
`expression` literal differs (it has no semantic meaning at this call
site). The `LOG(ERROR)` from `veloxCheckFail` is bypassed entirely.

Note: this also bypasses the `++threadNumVeloxThrow()` thread-local counter 
in `veloxCheckFail()`, which tracks Velox throw frequency for debugging/observability. 
Skipping it for expected cancellation paths is intentionally correct — these are not 
real errors, so they should not inflate the throw counter.

Reviewed By: kagamiori

Differential Revision: D101628675


