### PR TITLE
fix(cudf): Preserve null literals in AST expressions

### DIFF
--- a/velox/experimental/cudf/expression/AstExpressionUtils.h
+++ b/velox/experimental/cudf/expression/AstExpressionUtils.h
@@ -50,7 +50,12 @@ cudf::ast::literal createLiteral(
   variant value =
       VELOX_DYNAMIC_TYPE_DISPATCH(getVariant, kind, vector, atIndex);
   return VELOX_DYNAMIC_TYPE_DISPATCH_ALL(
-      makeScalarAndLiteral, kind, type, value, scalars);
+      makeScalarAndLiteral,
+      kind,
+      type,
+      value,
+      vector->isNullAt(atIndex),
+      scalars);
 }
 
 // Helper function to extract literals from array elements based on type
@@ -542,11 +547,17 @@ cudf::ast::expression const& AstContext::pushExprToTree(
     auto value = c->value();
     VELOX_CHECK(value->isConstantEncoding());
 
+    // Materialize NULL literals via make_column_from_scalar so the output
+    // column preserves nullness for downstream operators like count(column).
+    //
+    // Also keep the standalone literal workaround: cudf::compute_column can
+    // produce spurious nulls for root literal expressions. See comment below.
+    //
     // TODO: There is a scalar stream synchronization bug that causes
     // cudf::compute_column to produce spurious nulls for standalone
     // literal expressions.  Work around it by materialising via
     // make_column_from_scalar instead.
-    if (expr == rootExpr) {
+    if (value->isNullAt(0) || expr == rootExpr) {
       // convert to cudf scalar and store it
       createLiteral(value, scalars);
       // The scalar index is scalars.size() - 1 since we just added it

--- a/velox/experimental/cudf/expression/AstUtils.h
+++ b/velox/experimental/cudf/expression/AstUtils.h
@@ -198,15 +198,29 @@ template <TypeKind kind>
 cudf::ast::literal makeScalarAndLiteral(
     const TypePtr& type,
     const variant& var,
+    bool isNull,
     std::vector<std::unique_ptr<cudf::scalar>>& scalars) {
   using T = typename TypeTraits<kind>::NativeType;
   if constexpr (cudf::is_fixed_width<T>() || kind == TypeKind::VARCHAR) {
+    if (isNull) {
+      auto scalar = makeScalarFromValue<T>(type, T{}, true);
+      scalars.emplace_back(std::move(scalar));
+      return makeLiteralFromScalar<T>(*(scalars.back()), type);
+    }
     auto value = var.value<T>();
     auto scalar = makeScalarFromValue(type, value, false);
     scalars.emplace_back(std::move(scalar));
     return makeLiteralFromScalar<T>(*(scalars.back()), type);
   }
   VELOX_NYI("Scalar creation not implemented for type {}", type->toString());
+}
+
+template <TypeKind kind>
+cudf::ast::literal makeScalarAndLiteral(
+    const TypePtr& type,
+    const variant& var,
+    std::vector<std::unique_ptr<cudf::scalar>>& scalars) {
+  return makeScalarAndLiteral<kind>(type, var, false, scalars);
 }
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/tests/AggregationTest.cpp
+++ b/velox/experimental/cudf/tests/AggregationTest.cpp
@@ -727,6 +727,32 @@ TEST_P(CountAggregationStepsTest, countStarVsCountColumnGroupByNulls) {
       GetParam());
 }
 
+TEST_P(CountAggregationStepsTest, countNullConstantMarkerForIntersectShape) {
+  auto data = makeRowVector({
+      makeFlatVector<StringView>({"left_only", "left_only", "both"}),
+  });
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .project({
+                      "true AS left_marker",
+                      "cast(null AS boolean) AS right_marker",
+                      "c0 AS key",
+                  })
+                  .partialAggregation(
+                      {"key"}, {"count(left_marker)", "count(right_marker)"})
+                  .finalAggregation()
+                  .filter("a0 >= 1 AND a1 = 0")
+                  .project({"key", "a0"})
+                  .planNode();
+
+  auto expected = makeRowVector({
+      makeFlatVector<StringView>({"left_only", "both"}),
+      makeFlatVector<int64_t>({2, 1}),
+  });
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
 TEST_P(CountAggregationStepsTest, countConstantGlobalNulls) {
   auto data = makeRowVector({
       makeNullableFlatVector<int64_t>({1, std::nullopt, 2, std::nullopt}),


### PR DESCRIPTION
* Materialize null literals through scalar-filled columns so downstream cuDF operators see the correct null mask.

* Add a regression test for count over projected null boolean markers, matching the TPC-DS Q8 intersect pattern.