### PR TITLE
feat: Add expression-level tracing support to Velox (#17369) (#17369)

### DIFF
--- a/velox/exec/FilterProject.cpp
+++ b/velox/exec/FilterProject.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/exec/FilterProject.h"
 #include "velox/core/Expressions.h"
+#include "velox/exec/Driver.h"
 #include "velox/exec/OperatorType.h"
 #include "velox/expression/Expr.h"
 #include "velox/expression/FieldReference.h"
@@ -208,6 +209,11 @@ void FilterProject::initialize() {
   }
   filter_.reset();
   project_.reset();
+
+  if (const auto* traceCtx = operatorCtx_->driverCtx()->traceCtx();
+      traceCtx && traceCtx->shouldTrace(*this)) {
+    exprs_->maybeSetupTracers(*this, *traceCtx);
+  }
 }
 
 void FilterProject::addInput(RowVectorPtr input) {

--- a/velox/exec/FilterProject.h
+++ b/velox/exec/FilterProject.h
@@ -59,6 +59,7 @@ class FilterProject : public Operator {
   void close() override {
     Operator::close();
     if (exprs_ != nullptr) {
+      exprs_->finishTracers();
       exprs_->clear();
     } else {
       VELOX_CHECK(!initialized_);

--- a/velox/exec/tests/CustomTraceTest.cpp
+++ b/velox/exec/tests/CustomTraceTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <fmt/format.h>
 #include <gtest/gtest.h>
 #include <unordered_map>
 #include <utility>
@@ -82,6 +83,63 @@ class TestTraceCtx : public TraceCtx {
   TCapturedVectors& tracedVectors_;
 };
 
+// Captures expression output vectors keyed by function name.
+using TExprCapturedVectors = std::unordered_map<std::string, VectorPtr>;
+
+// A test trace implementation for expression-level tracing. Traces output
+// batches from named expression functions listed in tracedExprs.
+class ExprTestTraceCtx : public TraceCtx {
+ public:
+  ExprTestTraceCtx(
+      const std::vector<std::string>& tracedExprs,
+      TExprCapturedVectors& capturedVectors,
+      bool shouldTraceOp = true)
+      : TraceCtx(false),
+        shouldTraceOp_(shouldTraceOp),
+        tracedExprs_(tracedExprs.begin(), tracedExprs.end()),
+        capturedVectors_(capturedVectors) {}
+
+  bool shouldTrace(const Operator& /*op*/) const override {
+    return shouldTraceOp_;
+  }
+
+  bool shouldTraceExpr(std::string_view functionName) const override {
+    return tracedExprs_.contains(std::string(functionName));
+  }
+
+  std::unique_ptr<TraceExprWriter> createExprOutputTracer(
+      const Operator& /*op*/,
+      std::string_view functionName,
+      int instanceIndex) const override {
+    auto key = fmt::format("{}_{}", functionName, instanceIndex);
+    return std::make_unique<TestExprWriter>(std::move(key), capturedVectors_);
+  }
+
+ private:
+  class TestExprWriter : public TraceExprWriter {
+   public:
+    TestExprWriter(
+        std::string functionName,
+        TExprCapturedVectors& capturedVectors)
+        : functionName_(std::move(functionName)),
+          capturedVectors_(capturedVectors) {}
+
+    void write(const VectorPtr& vector) override {
+      capturedVectors_[functionName_] = vector;
+    }
+
+    void finish() override {}
+
+   private:
+    const std::string functionName_;
+    TExprCapturedVectors& capturedVectors_;
+  };
+
+  const bool shouldTraceOp_;
+  std::unordered_set<std::string> tracedExprs_;
+  TExprCapturedVectors& capturedVectors_;
+};
+
 class CustomTraceTest : public exec::test::HiveConnectorTestBase {};
 
 TEST_F(CustomTraceTest, customTrace) {
@@ -135,6 +193,266 @@ TEST_F(CustomTraceTest, customTrace) {
 
   // Vectors need to be destructed before the pool in the task dies.
   tracedVectors.clear();
+}
+
+TEST_F(CustomTraceTest, exprOutputTrace) {
+  auto vector = makeRowVector(
+      {"a"}, {makeFlatVector<int64_t>(10, [](auto row) { return row; })});
+
+  auto plan =
+      PlanBuilder().values({vector}).project({"a * 10 as a"}).planNode();
+
+  TExprCapturedVectors capturedVectors;
+  auto queryCtx =
+      core::QueryCtx::Builder()
+          .executor(executor_.get())
+          .traceCtxProvider([&](core::QueryCtx&, const core::PlanFragment&) {
+            return std::make_unique<ExprTestTraceCtx>(
+                std::vector<std::string>{"multiply"}, capturedVectors);
+          })
+          .build();
+
+  std::shared_ptr<Task> task;
+  AssertQueryBuilder(plan)
+      .config(core::QueryConfig::kQueryTraceEnabled, true)
+      .queryCtx(queryCtx)
+      .countResults(task);
+
+  auto iterator = capturedVectors.find("multiply_0");
+  ASSERT_TRUE(iterator != capturedVectors.end());
+
+  auto expected =
+      makeFlatVector<int64_t>(10, [](auto row) { return row * 10; });
+  assertEqualVectors(iterator->second, expected);
+
+  capturedVectors.clear();
+}
+
+TEST_F(CustomTraceTest, exprTraceOnlyMatchingFunctions) {
+  auto vector = makeRowVector(
+      {"a"}, {makeFlatVector<int64_t>(10, [](auto row) { return row; })});
+
+  // Two projections: multiply then plus. Only trace "plus".
+  auto plan = PlanBuilder()
+                  .values({vector})
+                  .project({"a * 10 as b", "a + 5 as c"})
+                  .planNode();
+
+  TExprCapturedVectors capturedVectors;
+  auto queryCtx =
+      core::QueryCtx::Builder()
+          .executor(executor_.get())
+          .traceCtxProvider([&](core::QueryCtx&, const core::PlanFragment&) {
+            return std::make_unique<ExprTestTraceCtx>(
+                std::vector<std::string>{"plus"}, capturedVectors);
+          })
+          .build();
+
+  std::shared_ptr<Task> task;
+  AssertQueryBuilder(plan)
+      .config(core::QueryConfig::kQueryTraceEnabled, true)
+      .queryCtx(queryCtx)
+      .countResults(task);
+
+  // "plus" should be captured.
+  EXPECT_TRUE(capturedVectors.contains("plus_0"));
+
+  // "multiply" should not be captured.
+  EXPECT_FALSE(capturedVectors.contains("multiply_0"));
+
+  capturedVectors.clear();
+}
+
+TEST_F(CustomTraceTest, exprTraceMultipleInstances) {
+  auto vector = makeRowVector(
+      {"a", "b"},
+      {makeFlatVector<int64_t>(10, [](auto row) { return row; }),
+       makeFlatVector<int64_t>(10, [](auto row) { return row + 100; })});
+
+  auto plan = PlanBuilder()
+                  .values({vector})
+                  .project({"a * 10 as c", "b * 20 as d"})
+                  .planNode();
+
+  TExprCapturedVectors capturedVectors;
+  auto queryCtx =
+      core::QueryCtx::Builder()
+          .executor(executor_.get())
+          .traceCtxProvider([&](core::QueryCtx&, const core::PlanFragment&) {
+            return std::make_unique<ExprTestTraceCtx>(
+                std::vector<std::string>{"multiply"}, capturedVectors);
+          })
+          .build();
+
+  std::shared_ptr<Task> task;
+  AssertQueryBuilder(plan)
+      .config(core::QueryConfig::kQueryTraceEnabled, true)
+      .queryCtx(queryCtx)
+      .countResults(task);
+
+  ASSERT_TRUE(capturedVectors.contains("multiply_0"));
+  ASSERT_TRUE(capturedVectors.contains("multiply_1"));
+
+  auto expected0 =
+      makeFlatVector<int64_t>(10, [](auto row) { return row * 10; });
+  auto expected1 =
+      makeFlatVector<int64_t>(10, [](auto row) { return (row + 100) * 20; });
+
+  assertEqualVectors(capturedVectors.at("multiply_0"), expected0);
+  assertEqualVectors(capturedVectors.at("multiply_1"), expected1);
+
+  capturedVectors.clear();
+}
+
+TEST_F(CustomTraceTest, exprTraceCseSharedNode) {
+  auto vector = makeRowVector(
+      {"a"}, {makeFlatVector<int64_t>(10, [](auto row) { return row; })});
+
+  // Both projections share the "a * 10" subexpression (CSE). The visited set
+  // should ensure the shared multiply node is only traced once.
+  auto plan = PlanBuilder()
+                  .values({vector})
+                  .project({"a * 10 + 1 as b", "a * 10 + 2 as c"})
+                  .planNode();
+
+  TExprCapturedVectors capturedVectors;
+  auto queryCtx =
+      core::QueryCtx::Builder()
+          .executor(executor_.get())
+          .traceCtxProvider([&](core::QueryCtx&, const core::PlanFragment&) {
+            return std::make_unique<ExprTestTraceCtx>(
+                std::vector<std::string>{"multiply"}, capturedVectors);
+          })
+          .build();
+
+  std::shared_ptr<Task> task;
+  AssertQueryBuilder(plan)
+      .config(core::QueryConfig::kQueryTraceEnabled, true)
+      .queryCtx(queryCtx)
+      .countResults(task);
+
+  // The shared CSE node should produce exactly one multiply instance.
+  EXPECT_TRUE(capturedVectors.contains("multiply_0"));
+  EXPECT_FALSE(capturedVectors.contains("multiply_1"));
+
+  capturedVectors.clear();
+}
+
+TEST_F(CustomTraceTest, exprTraceNullResult) {
+  auto vector = makeRowVector(
+      {"a"},
+      {makeNullableFlatVector<int64_t>({1, std::nullopt, 3, std::nullopt, 5})});
+
+  // try(a / 0) produces all nulls without throwing.
+  auto plan =
+      PlanBuilder().values({vector}).project({"try(a / 0) as b"}).planNode();
+
+  TExprCapturedVectors capturedVectors;
+  auto queryCtx =
+      core::QueryCtx::Builder()
+          .executor(executor_.get())
+          .traceCtxProvider([&](core::QueryCtx&, const core::PlanFragment&) {
+            return std::make_unique<ExprTestTraceCtx>(
+                std::vector<std::string>{"divide"}, capturedVectors);
+          })
+          .build();
+
+  std::shared_ptr<Task> task;
+  AssertQueryBuilder(plan)
+      .config(core::QueryConfig::kQueryTraceEnabled, true)
+      .queryCtx(queryCtx)
+      .countResults(task);
+
+  // divide is inside try() which catches the error and produces nulls.
+  // The tracer should still capture output (the null vector).
+  EXPECT_TRUE(capturedVectors.contains("divide_0"));
+
+  capturedVectors.clear();
+}
+
+TEST_F(CustomTraceTest, exprTraceOperatorScoping) {
+  auto vector = makeRowVector(
+      {"a"}, {makeFlatVector<int64_t>(10, [](auto row) { return row; })});
+
+  auto plan =
+      PlanBuilder().values({vector}).project({"a * 10 as b"}).planNode();
+
+  TExprCapturedVectors capturedVectors;
+  auto queryCtx =
+      core::QueryCtx::Builder()
+          .executor(executor_.get())
+          .traceCtxProvider([&](core::QueryCtx&, const core::PlanFragment&) {
+            return std::make_unique<ExprTestTraceCtx>(
+                std::vector<std::string>{"multiply"}, capturedVectors, false);
+          })
+          .build();
+
+  std::shared_ptr<Task> task;
+  AssertQueryBuilder(plan)
+      .config(core::QueryConfig::kQueryTraceEnabled, true)
+      .queryCtx(queryCtx)
+      .countResults(task);
+
+  EXPECT_TRUE(capturedVectors.empty());
+}
+
+// A trace context that creates writers which throw from write() and finish().
+class ThrowingExprTraceCtx : public TraceCtx {
+ public:
+  explicit ThrowingExprTraceCtx(const std::vector<std::string>& tracedExprs)
+      : TraceCtx(false), tracedExprs_(tracedExprs.begin(), tracedExprs.end()) {}
+
+  bool shouldTrace(const Operator& /*op*/) const override {
+    return true;
+  }
+
+  bool shouldTraceExpr(std::string_view functionName) const override {
+    return tracedExprs_.contains(std::string(functionName));
+  }
+
+  std::unique_ptr<TraceExprWriter> createExprOutputTracer(
+      const Operator& /*op*/,
+      std::string_view /*functionName*/,
+      int /*instanceIndex*/) const override {
+    return std::make_unique<ThrowingExprWriter>();
+  }
+
+ private:
+  class ThrowingExprWriter : public TraceExprWriter {
+   public:
+    void write(const VectorPtr& /*result*/) override {
+      throw std::runtime_error("write failed");
+    }
+
+    void finish() override {
+      throw std::runtime_error("finish failed");
+    }
+  };
+
+  std::unordered_set<std::string> tracedExprs_;
+};
+
+TEST_F(CustomTraceTest, exprTraceThrowingWriter) {
+  auto vector = makeRowVector(
+      {"a"}, {makeFlatVector<int64_t>(10, [](auto row) { return row; })});
+
+  auto plan =
+      PlanBuilder().values({vector}).project({"a * 10 as a"}).planNode();
+
+  auto queryCtx =
+      core::QueryCtx::Builder()
+          .executor(executor_.get())
+          .traceCtxProvider([&](core::QueryCtx&, const core::PlanFragment&) {
+            return std::make_unique<ThrowingExprTraceCtx>(
+                std::vector<std::string>{"multiply"});
+          })
+          .build();
+
+  std::shared_ptr<Task> task;
+  ASSERT_NO_THROW(AssertQueryBuilder(plan)
+                      .config(core::QueryConfig::kQueryTraceEnabled, true)
+                      .queryCtx(queryCtx)
+                      .countResults(task));
 }
 
 // Helper to convert a vector of plan node IDs to a breakpoints map with null

--- a/velox/exec/trace/TraceCtx.h
+++ b/velox/exec/trace/TraceCtx.h
@@ -19,6 +19,7 @@
 #include <cstdint>
 #include <functional>
 #include <string>
+#include <string_view>
 #include "velox/exec/trace/TraceWriter.h"
 
 namespace facebook::velox::exec {
@@ -50,10 +51,27 @@ class TraceCtx {
     return nullptr;
   }
 
-  /// Whether a particular operator should be traced. Called before the task
-  /// starts execution, when operators are instantiated.
+  /// Returns whether a particular operator should be traced. Called before the
+  /// task starts execution, when operators are instantiated.
   virtual bool shouldTrace(const Operator&) const {
     return false;
+  }
+
+  /// Returns whether a particular expression function should be traced. Called
+  /// during operator initialization in Expr::maybeSetupTracer().
+  virtual bool shouldTraceExpr(std::string_view /*functionName*/) const {
+    return false;
+  }
+
+  /// Creates a writer for capturing output batches from a traced expression.
+  /// The instanceIndex distinguishes multiple Expr nodes with the same
+  /// function name within a single operator. Ownership is transferred to the
+  /// caller.
+  virtual std::unique_ptr<trace::TraceExprWriter> createExprOutputTracer(
+      const Operator& /*op*/,
+      std::string_view /*functionName*/,
+      int /*instanceIndex*/) const {
+    return nullptr;
   }
 
   bool dryRun() const {

--- a/velox/exec/trace/TraceWriter.h
+++ b/velox/exec/trace/TraceWriter.h
@@ -45,6 +45,21 @@ class TraceInputWriter {
   virtual void finish() = 0;
 };
 
+/// Abstract interface for capturing traced expression output. Implementations
+/// are responsible for processing individual expression result vectors during
+/// query execution tracing.
+class TraceExprWriter {
+ public:
+  virtual ~TraceExprWriter() = default;
+
+  /// Writes a single expression output vector. Expression tracing runs inside
+  /// Expr::apply(), which has no mechanism to block the driver pipeline.
+  virtual void write(const VectorPtr& result) = 0;
+
+  /// Closes the data file and writes out the data summary.
+  virtual void finish() = 0;
+};
+
 /// Abstract interface for capturing traced split information. Implementations
 /// are responsible for processing and/or recording the splits found during
 /// query execution tracing, enabling replay and analysis of query input

--- a/velox/expression/CMakeLists.txt
+++ b/velox/expression/CMakeLists.txt
@@ -125,6 +125,7 @@ velox_link_libraries(
   velox_common_base
   velox_expression_functions
   velox_functions_util
+  velox_trace
   velox_type_tz
   double-conversion::double-conversion
   Folly::folly

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -25,6 +25,7 @@
 #include "velox/common/base/SuccinctPrinter.h"
 #include "velox/common/process/ThreadDebugInfo.h"
 #include "velox/common/testutil/TestValue.h"
+#include "velox/exec/trace/TraceCtx.h"
 #include "velox/expression/CastExpr.h"
 
 #include "velox/common/EnumDefine.h"
@@ -546,6 +547,8 @@ void Expr::evalSimplifiedImpl(
 
   // Make sure the returned vector has its null bitmap properly set.
   addNulls(rows, remainingRows.rows().asRange().bits(), context, result);
+
+  traceOutput(result);
 }
 
 namespace {
@@ -1761,6 +1764,8 @@ void Expr::applyFunction(
 
   invokeApplyWithListeners(rows, context, result);
 
+  traceOutput(result);
+
   if (!result) {
     MutableRemainingRows remainingRows(rows, context);
 
@@ -2058,6 +2063,74 @@ ExprSet::ExprSet(
   for (auto& expr : exprs_) {
     Expr::mergeFields(
         distinctFields_, multiplyReferencedFields_, expr->distinctFields());
+  }
+}
+
+void ExprSet::maybeSetupTracers(
+    const Operator& op,
+    const trace::TraceCtx& traceCtx) {
+  exprTracingEnabled_ = true;
+  std::unordered_set<Expr*> visited;
+  std::unordered_map<std::string, int> instanceCounts;
+  for (auto& expr : exprs_) {
+    expr->maybeSetupTracer(op, traceCtx, visited, instanceCounts);
+  }
+}
+
+void Expr::maybeSetupTracer(
+    const Operator& op,
+    const trace::TraceCtx& traceCtx,
+    std::unordered_set<Expr*>& visited,
+    std::unordered_map<std::string, int>& instanceCounts) {
+  if (!visited.insert(this).second) {
+    return;
+  }
+  if (traceCtx.shouldTraceExpr(name_)) {
+    const int index = instanceCounts[name_]++;
+    try {
+      outputTracer_ = traceCtx.createExprOutputTracer(op, name_, index);
+    } catch (const std::exception& e) {
+      LOG(ERROR) << "Failed to create expression output tracer: " << e.what();
+    }
+  }
+  for (auto& input : inputs_) {
+    input->maybeSetupTracer(op, traceCtx, visited, instanceCounts);
+  }
+}
+
+void ExprSet::finishTracers() {
+  if (!exprTracingEnabled_) {
+    return;
+  }
+  std::unordered_set<Expr*> visited;
+  for (auto& expr : exprs_) {
+    expr->finishTracer(visited);
+  }
+}
+
+void Expr::finishTracer(std::unordered_set<Expr*>& visited) {
+  if (!visited.insert(this).second) {
+    return;
+  }
+  if (outputTracer_) {
+    try {
+      outputTracer_->finish();
+    } catch (const std::exception& e) {
+      LOG(ERROR) << "Failed to finish expression output tracer: " << e.what();
+    }
+  }
+  for (auto& input : inputs_) {
+    input->finishTracer(visited);
+  }
+}
+
+FOLLY_ALWAYS_INLINE void Expr::traceOutput(const VectorPtr& result) {
+  if (FOLLY_UNLIKELY(outputTracer_ != nullptr) && result) {
+    try {
+      outputTracer_->write(result);
+    } catch (const std::exception& e) {
+      LOG(ERROR) << "Failed to trace expression output: " << e.what();
+    }
   }
 }
 

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -23,6 +23,7 @@
 
 #include "velox/common/time/CpuWallTimer.h"
 #include "velox/core/ExpressionEvaluator.h"
+#include "velox/exec/trace/TraceWriter.h"
 #include "velox/expression/EvalCtx.h"
 #include "velox/expression/ExprStats.h"
 #include "velox/expression/VectorFunction.h"
@@ -30,10 +31,15 @@
 #include "velox/type/Subfield.h"
 #include "velox/vector/SimpleVector.h"
 
+namespace facebook::velox::exec::trace {
+class TraceCtx;
+} // namespace facebook::velox::exec::trace
+
 namespace facebook::velox::exec {
 
 class ExprSet;
 class FieldReference;
+class Operator;
 class VectorFunction;
 
 /// Maintains a set of rows for evaluation and removes rows with
@@ -438,6 +444,21 @@ class Expr {
     return inputValues_;
   }
 
+  /// Sets up expression-level output tracer if the given TraceCtx indicates
+  /// this expression should be traced. Called once during operator
+  /// initialization. Uses a visited set to avoid redundant traversal of
+  /// shared CSE nodes.
+  void maybeSetupTracer(
+      const Operator& op,
+      const trace::TraceCtx& traceCtx,
+      std::unordered_set<Expr*>& visited,
+      std::unordered_map<std::string, int>& instanceCounts);
+
+  /// Finishes expression-level output tracing by calling finish() on the
+  /// cached tracer. Uses a visited set to avoid redundant traversal of
+  /// shared CSE nodes.
+  void finishTracer(std::unordered_set<Expr*>& visited);
+
   void setAllNulls(
       const SelectivityVector& rows,
       EvalCtx& context,
@@ -526,6 +547,9 @@ class Expr {
       const SelectivityVector& rows,
       EvalCtx& context,
       VectorPtr& result);
+
+  // Traces expression output if a tracer is configured.
+  FOLLY_ALWAYS_INLINE void traceOutput(const VectorPtr& result);
 
   // Returns true if values in 'distinctFields_' have nulls that are
   // worth skipping. If so, the rows in 'rows' with at least one sure
@@ -785,6 +809,9 @@ class Expr {
   // True if distinctFields_ are identical to at least one of the parent
   // expression's distinct fields.
   bool sameAsParentDistinctFields_ = false;
+
+  // Cached output tracer set up during expression initialization.
+  std::unique_ptr<trace::TraceExprWriter> outputTracer_;
 };
 
 /// Generate a selectivity vector of a single row.
@@ -871,6 +898,13 @@ class ExprSet {
     memoizingExprs_.insert(expr);
   }
 
+  /// Sets up expression-level tracers on all expressions in this set.
+  void maybeSetupTracers(const Operator& op, const trace::TraceCtx& traceCtx);
+
+  /// Finishes expression-level tracers on all expressions in this set.
+  /// Called during operator close.
+  void finishTracers();
+
   /// Returns text representation of the expression set.
   /// @param compact If true, uses one-line representation for each expression.
   /// Otherwise, prints a tree of expressions one node per line.
@@ -908,6 +942,10 @@ class ExprSet {
   std::unordered_set<Expr*> memoizingExprs_;
   core::ExecCtx* const execCtx_;
   const bool lazyDereference_;
+
+  // Set to true when expression-level tracers are configured for this ExprSet.
+  // Cached to avoid re-querying TraceCtx at close time.
+  bool exprTracingEnabled_{false};
 
   // Cached from QueryConfig at construction time to avoid repeated map lookups.
   const bool adaptiveCpuSampling_;


### PR DESCRIPTION
Summary:
Extends the Velox tracing framework with expression-level tracing, enabling callers to trace output batches from named expression functions (e.g., UDFs).

Changes:
- TraceCtx: Added virtual methods shouldTraceExpr() and createExprOutputTracer(op, functionName, instanceIndex) for expression-level tracing decisions and writer creation
- Expr: Added maybeSetupTracer() to create and cache a tracer during operator initialization, stored as a unique_ptr member. Uses a visited set to avoid redundant traversal of shared CSE nodes, and an instance counter to distinguish multiple Expr nodes with the same function name within a single operator
- ExprSet: Added maybeSetupTracers() to walk all expressions and set up tracers
- FilterProject: Calls ExprSet::maybeSetupTracers() during initialize(), scoped to operators where shouldTrace() returns true — expression tracing is only set up inside traced operators
- EvalCtx: Removed traceCtx plumbing (no longer needed since tracers are owned by Expr nodes)

Performance: Tracers are created once at initialization and owned by each Expr node as a unique_ptr, following the same pattern as Operator::inputTracer_. The hot path uses FOLLY_UNLIKELY on a null pointer check.

Examples:

1. Single instance: A FilterProject operator "proj-5" with projection `a * 10 as b` and tracing configured for "multiply" creates one tracer identified as ("proj-5", "multiply", 0).

2. Multiple instances of the same function: Projections `a * 10 as b, c * 20 as d` with tracing configured for "multiply" creates two tracers: ("proj-5", "multiply", 0) and ("proj-5", "multiply", 1), each producing a distinct output stream.

3. Selective tracing: Projections `a * 10 as b, a + 5 as c` with tracing configured for "multiply" only traces the multiply expression. The plus expression is skipped since it is not in the trace configuration.

4. Operator scoping: If operator "proj-5" is not in the traced operators list, none of its UDFs are traced regardless of the UDF trace configuration.


Test Plan: buck2 test @//mode/dev-nosan fbcode//velox/exec/tests:test -- CustomTraceTest.exprOutputTrace CustomTraceTest.exprTraceOnlyMatchingFunctions

Reviewed By: bikramSingh91

Differential Revision: D102552818

Pulled By: patrickstuedi


