### PR TITLE
fix(abfs): Avoid extra copy in preadv

### DIFF
--- a/velox/connectors/hive/storage_adapters/abfs/AbfsReadFile.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/AbfsReadFile.cpp
@@ -19,11 +19,14 @@
 #include "velox/connectors/hive/storage_adapters/abfs/AbfsUtil.h"
 #include "velox/connectors/hive/storage_adapters/abfs/AzureClientProviderFactories.h"
 
+#include <algorithm>
+
 namespace facebook::velox::filesystems {
 
 class AbfsReadFile::Impl {
-  constexpr static uint64_t kNaturalReadSize = 4 << 20; // 4M
+  constexpr static uint64_t kNaturalReadSize = 4'194'304; // 4M
   constexpr static uint64_t kReadConcurrency = 8;
+  constexpr static size_t kDiscardBufferSize = 262'144; // 256K
 
  public:
   explicit Impl(std::string_view path, const config::ConfigBase& config) {
@@ -73,20 +76,11 @@ class AbfsReadFile::Impl {
       uint64_t offset,
       const std::vector<folly::Range<char*>>& buffers,
       const FileIoContext& context) const {
-    size_t length = 0;
-    auto size = buffers.size();
-    for (auto& range : buffers) {
+    size_t length{0};
+    for (const auto& range : buffers) {
       length += range.size();
     }
-    std::string result(length, 0);
-    preadInternal(offset, length, static_cast<char*>(result.data()));
-    size_t resultOffset = 0;
-    for (auto range : buffers) {
-      if (range.data()) {
-        memcpy(range.data(), &(result.data()[resultOffset]), range.size());
-      }
-      resultOffset += range.size();
-    }
+    preadvInternal(offset, length, buffers);
 
     return length;
   }
@@ -133,14 +127,48 @@ class AbfsReadFile::Impl {
   void preadInternal(uint64_t offset, uint64_t length, char* position) const {
     // Read the desired range of bytes.
     Azure::Core::Http::HttpRange range;
-    range.Offset = offset;
-    range.Length = length;
+    range.Offset = static_cast<int64_t>(offset);
+    range.Length = static_cast<int64_t>(length);
 
     Azure::Storage::Blobs::DownloadBlobOptions blob;
     blob.Range = range;
     auto response = fileClient_->download(blob);
     response.Value.BodyStream->ReadToCount(
         reinterpret_cast<uint8_t*>(position), length);
+  }
+
+  void preadvInternal(
+      uint64_t offset,
+      uint64_t length,
+      const std::vector<folly::Range<char*>>& buffers) const {
+    Azure::Core::Http::HttpRange range;
+    range.Offset = static_cast<int64_t>(offset);
+    range.Length = static_cast<int64_t>(length);
+
+    Azure::Storage::Blobs::DownloadBlobOptions blob;
+    blob.Range = range;
+    auto response = fileClient_->download(blob);
+
+    std::vector<uint8_t> discardBuffer;
+    for (const auto& buffer : buffers) {
+      auto remaining = buffer.size();
+      if (buffer.data() != nullptr) {
+        response.Value.BodyStream->ReadToCount(
+            reinterpret_cast<uint8_t*>(buffer.data()), remaining);
+        continue;
+      }
+
+      const auto discardBufferSize = std::min(remaining, kDiscardBufferSize);
+      if (discardBuffer.size() < discardBufferSize) {
+        discardBuffer.resize(discardBufferSize);
+      }
+
+      while (remaining > 0) {
+        const auto readSize = std::min(remaining, discardBuffer.size());
+        response.Value.BodyStream->ReadToCount(discardBuffer.data(), readSize);
+        remaining -= readSize;
+      }
+    }
   }
 
   std::string filePath_;
@@ -155,7 +183,7 @@ AbfsReadFile::AbfsReadFile(
 }
 
 void AbfsReadFile::initialize(const FileOptions& options) {
-  return impl_->initialize(options);
+  impl_->initialize(options);
 }
 
 std::string_view AbfsReadFile::pread(

--- a/velox/connectors/hive/storage_adapters/abfs/tests/AbfsFileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/tests/AbfsFileSystemTest.cpp
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
+#include <azure/core/io/body_stream.hpp>
 #include <gtest/gtest.h>
 #include <atomic>
-#include <filesystem>
 #include <random>
+#include <string_view>
 
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/config/Config.h"
@@ -46,7 +47,79 @@ using ::facebook::velox::common::Region;
 
 namespace {
 
-constexpr int kOneMB = 1 << 20;
+constexpr int kOneMB = 1'048'576;
+
+struct RecordedDownload {
+  int64_t offset{0};
+  int64_t length{0};
+};
+
+struct InMemoryReadState {
+  std::string data;
+  std::vector<RecordedDownload> downloads;
+};
+
+class InMemoryAzureBlobClient final : public AzureBlobClient {
+ public:
+  explicit InMemoryAzureBlobClient(std::shared_ptr<InMemoryReadState> state)
+      : state_(std::move(state)) {}
+
+  Azure::Response<Azure::Storage::Blobs::Models::BlobProperties> getProperties()
+      override {
+    VELOX_FAIL("Unexpected getProperties call.");
+  }
+
+  Azure::Response<Azure::Storage::Blobs::Models::DownloadBlobResult> download(
+      const Azure::Storage::Blobs::DownloadBlobOptions& options) override {
+    const auto& range = options.Range.Value();
+    const auto offset = range.Offset;
+    const auto length = range.Length.Value();
+
+    VELOX_CHECK_GE(offset, 0);
+    VELOX_CHECK_GE(length, 0);
+    VELOX_CHECK_LE(offset + length, static_cast<int64_t>(state_->data.size()));
+
+    state_->downloads.push_back({offset, length});
+
+    Azure::Storage::Blobs::Models::DownloadBlobResult result;
+    result.BodyStream = std::make_unique<Azure::Core::IO::MemoryBodyStream>(
+        reinterpret_cast<const uint8_t*>(state_->data.data() + offset),
+        static_cast<size_t>(length));
+    return Azure::Response<Azure::Storage::Blobs::Models::DownloadBlobResult>(
+        std::move(result), nullptr);
+  }
+
+  std::string getUrl() override {
+    return std::string{kUrl};
+  }
+
+ private:
+  static constexpr std::string_view kUrl =
+      "https://unit.blob.core.windows.net/container/test-file";
+
+  std::shared_ptr<InMemoryReadState> state_;
+};
+
+class InMemoryAzureClientProvider final : public AzureClientProvider {
+ public:
+  explicit InMemoryAzureClientProvider(std::shared_ptr<InMemoryReadState> state)
+      : state_(std::move(state)) {}
+
+  std::unique_ptr<AzureBlobClient> getReadFileClient(
+      const std::shared_ptr<AbfsPath>& path,
+      const config::ConfigBase& config) override {
+    return std::make_unique<InMemoryAzureBlobClient>(state_);
+  }
+
+  std::unique_ptr<AzureDataLakeFileClient> getWriteFileClient(
+      const std::shared_ptr<AbfsPath>& path,
+      const config::ConfigBase& config) override {
+    VELOX_FAIL("Unexpected getWriteFileClient call.");
+  }
+
+ private:
+  std::shared_ptr<InMemoryReadState> state_;
+};
 
 class TestAzureClientProvider final : public AzureClientProvider {
  public:
@@ -98,14 +171,16 @@ class AbfsFileSystemTest : public testing::Test {
   }
 
   static std::string generateRandomData(int size) {
-    static const char charset[] =
+    static constexpr std::string_view kCharacters =
         "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    std::mt19937 generator(std::random_device{}());
+    std::uniform_int_distribution<size_t> distribution(
+        0, kCharacters.size() - 1);
 
     std::string data(size, ' ');
 
     for (int i = 0; i < size; ++i) {
-      int index = rand() % (sizeof(charset) - 1);
-      data[i] = charset[index];
+      data[i] = kCharacters[distribution(generator)];
     }
 
     return data;
@@ -121,6 +196,8 @@ class AbfsFileSystemTest : public testing::Test {
     return tempFile;
   }
 };
+
+namespace {
 
 void readData(ReadFile* readFile) {
   ASSERT_EQ(readFile->size(), 15 + kOneMB);
@@ -170,6 +247,8 @@ void readData(ReadFile* readFile) {
       "ccccc");
 }
 
+} // namespace
+
 TEST_F(AbfsFileSystemTest, readFile) {
   auto readFile = abfs_->openFileForRead(azuriteServer_->fileURI());
   readData(readFile.get());
@@ -180,6 +259,74 @@ TEST_F(AbfsFileSystemTest, openFileForReadWithOptions) {
   options.fileSize = 15 + kOneMB;
   auto readFile = abfs_->openFileForRead(azuriteServer_->fileURI(), options);
   readData(readFile.get());
+}
+
+TEST(AbfsReadFileTest, preadvUsesSingleDownloadForBuffersWithGaps) {
+  auto state = std::make_shared<InMemoryReadState>();
+  state->data = "0123456789abcdefghijklmn";
+
+  registerAzureClientProviderFactory("unit", [state](const std::string&) {
+    return std::make_unique<InMemoryAzureClientProvider>(state);
+  });
+
+  AbfsReadFile readFile{
+      "abfs://container@unit.dfs.core.windows.net/test-file",
+      config::ConfigBase({})};
+  FileOptions options;
+  options.fileSize = state->data.size();
+  readFile.initialize(options);
+
+  char firstBuffer[5];
+  char secondBuffer[5];
+  const std::vector<folly::Range<char*>> buffers = {
+      folly::Range<char*>(firstBuffer, sizeof(firstBuffer)),
+      folly::Range<char*>(nullptr, 7),
+      folly::Range<char*>(secondBuffer, sizeof(secondBuffer)),
+  };
+
+  ASSERT_EQ(17, readFile.preadv(2, buffers));
+  ASSERT_EQ(state->downloads.size(), 1);
+  EXPECT_EQ(state->downloads[0].offset, 2);
+  EXPECT_EQ(state->downloads[0].length, 17);
+  EXPECT_EQ(std::string_view(firstBuffer, sizeof(firstBuffer)), "23456");
+  EXPECT_EQ(std::string_view(secondBuffer, sizeof(secondBuffer)), "efghi");
+}
+
+TEST(AbfsReadFileTest, preadvUsesSingleDownloadForDefaultCoalescedGap) {
+  constexpr size_t kLeadingReadSize = 4;
+  constexpr size_t kGapSize = static_cast<size_t>(512) * 1'024;
+  constexpr size_t kTrailingReadSize = 4;
+
+  auto state = std::make_shared<InMemoryReadState>();
+  state->data = std::string(kLeadingReadSize, 'a') +
+      std::string(kGapSize, 'x') + std::string(kTrailingReadSize, 'b');
+
+  registerAzureClientProviderFactory(
+      "unit-large-gap", [state](const std::string&) {
+        return std::make_unique<InMemoryAzureClientProvider>(state);
+      });
+
+  AbfsReadFile readFile{
+      "abfs://container@unit-large-gap.dfs.core.windows.net/test-file",
+      config::ConfigBase({})};
+  FileOptions options;
+  options.fileSize = state->data.size();
+  readFile.initialize(options);
+
+  char firstBuffer[kLeadingReadSize];
+  char secondBuffer[kTrailingReadSize];
+  const std::vector<folly::Range<char*>> buffers = {
+      folly::Range<char*>(firstBuffer, sizeof(firstBuffer)),
+      folly::Range<char*>(nullptr, kGapSize),
+      folly::Range<char*>(secondBuffer, sizeof(secondBuffer)),
+  };
+
+  ASSERT_EQ(state->data.size(), readFile.preadv(0, buffers));
+  ASSERT_EQ(state->downloads.size(), 1);
+  EXPECT_EQ(state->downloads[0].offset, 0);
+  EXPECT_EQ(state->downloads[0].length, state->data.size());
+  EXPECT_EQ(std::string_view(firstBuffer, sizeof(firstBuffer)), "aaaa");
+  EXPECT_EQ(std::string_view(secondBuffer, sizeof(secondBuffer)), "bbbb");
 }
 
 TEST_F(AbfsFileSystemTest, openFileForReadWithInvalidOptions) {
@@ -212,7 +359,7 @@ TEST_F(AbfsFileSystemTest, multipleThreadsWithReadFile) {
       0, sleepTimesInMicroseconds.size() - 1);
   for (int i = 0; i < 10; i++) {
     auto thread = std::thread([&] {
-      int index = distribution(generator);
+      const auto index = distribution(generator);
       while (!startThreads) {
         std::this_thread::yield();
       }
@@ -244,10 +391,9 @@ TEST(AbfsWriteFileTest, openFileForWriteTest) {
       reinterpret_cast<MockDataLakeFileClient*>(mockClient.get())->path();
   AbfsWriteFile abfsWriteFile(kAbfsFile, mockClient);
   EXPECT_EQ(abfsWriteFile.size(), 0);
-  std::string dataContent = "";
+  std::string dataContent;
   uint64_t totalSize = 0;
-  std::string randomData =
-      AbfsFileSystemTest::generateRandomData(1 * 1024 * 1024);
+  std::string randomData = AbfsFileSystemTest::generateRandomData(kOneMB);
   for (int i = 0; i < 8; ++i) {
     abfsWriteFile.append(randomData);
     dataContent += randomData;
@@ -256,11 +402,11 @@ TEST(AbfsWriteFileTest, openFileForWriteTest) {
   abfsWriteFile.flush();
   EXPECT_EQ(abfsWriteFile.size(), totalSize);
 
-  randomData = AbfsFileSystemTest::generateRandomData(9 * 1024 * 1024);
+  randomData = AbfsFileSystemTest::generateRandomData(9 * kOneMB);
   dataContent += randomData;
   abfsWriteFile.append(randomData);
   totalSize += randomData.size();
-  randomData = AbfsFileSystemTest::generateRandomData(2 * 1024 * 1024);
+  randomData = AbfsFileSystemTest::generateRandomData(2 * kOneMB);
   dataContent += randomData;
   totalSize += randomData.size();
   abfsWriteFile.append(randomData);
@@ -302,7 +448,7 @@ TEST_F(AbfsFileSystemTest, clientProviderFactoryNotRegistered) {
 }
 
 TEST_F(AbfsFileSystemTest, registerAbfsFileSink) {
-  static const std::vector<std::string> paths = {
+  const std::vector<std::string> paths = {
       "abfs://test@test.dfs.core.windows.net/test",
       "abfss://test@test.dfs.core.windows.net/test"};
   std::unordered_map<std::string, std::string> config(


### PR DESCRIPTION
Avoid allocating a contiguous temporary buffer in ABFS preadv.

Read the requested Azure range once and stream bytes directly into the
caller-provided buffers. For null gap ranges, consume the skipped bytes
with a reusable thread-local discard buffer so later buffers stay aligned
without changing the number of remote reads.

Add a fake Azure client unit test to verify preadv issues a single
download for buffers with gaps and fills the non-null ranges correctly.