### PR TITLE
perf(type): Speed up date extraction using Neri-Schneider algorithm

### DIFF
--- a/velox/benchmarks/basic/CMakeLists.txt
+++ b/velox/benchmarks/basic/CMakeLists.txt
@@ -126,3 +126,12 @@ target_link_libraries(
   velox_functions_prestosql
   velox_row_fast
 )
+
+add_executable(velox_date_extract_benchmark DateExtractBenchmark.cpp)
+target_link_libraries(
+  velox_date_extract_benchmark
+  ${velox_benchmark_deps}
+  velox_vector_test_lib
+  velox_functions_prestosql
+  velox_functions_spark
+)

--- a/velox/benchmarks/basic/DateExtractBenchmark.cpp
+++ b/velox/benchmarks/basic/DateExtractBenchmark.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include "velox/benchmarks/ExpressionBenchmarkBuilder.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/functions/sparksql/registration/Register.h"
+
+using namespace facebook;
+using namespace facebook::velox;
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+  memory::MemoryManager::initialize(memory::MemoryManager::Options{});
+  functions::prestosql::registerDateTimeFunctions("");
+  functions::sparksql::registerFunctions("spark_");
+
+  ExpressionBenchmarkBuilder benchmarkBuilder;
+  VectorFuzzer::Options options;
+  options.vectorSize = 1024;
+  options.nullRatio = 0;
+  auto* pool = benchmarkBuilder.pool();
+  VectorFuzzer fuzzer(options, pool);
+  auto vectorMaker = benchmarkBuilder.vectorMaker();
+
+  // Each set runs a different extraction expression on the same fuzzed input,
+  // exercising Timestamp::epochToCalendarUtc through getDateTime in
+  // velox/functions/lib/TimeUtils.h.
+
+  // DATE inputs (int32 days since epoch).
+  benchmarkBuilder
+      .addBenchmarkSet("year_date", vectorMaker.rowVector({fuzzer.fuzz(DATE())}))
+      .addExpression("year", "year(c0)")
+      .disableTesting();
+
+  benchmarkBuilder
+      .addBenchmarkSet("month_date", vectorMaker.rowVector({fuzzer.fuzz(DATE())}))
+      .addExpression("month", "month(c0)")
+      .disableTesting();
+
+  benchmarkBuilder
+      .addBenchmarkSet("day_date", vectorMaker.rowVector({fuzzer.fuzz(DATE())}))
+      .addExpression("day", "day(c0)")
+      .disableTesting();
+
+  benchmarkBuilder
+      .addBenchmarkSet(
+          "quarter_date", vectorMaker.rowVector({fuzzer.fuzz(DATE())}))
+      .addExpression("quarter", "quarter(c0)")
+      .disableTesting();
+
+  benchmarkBuilder
+      .addBenchmarkSet(
+          "day_of_year_date", vectorMaker.rowVector({fuzzer.fuzz(DATE())}))
+      .addExpression("day_of_year", "day_of_year(c0)")
+      .disableTesting();
+
+  benchmarkBuilder
+      .addBenchmarkSet(
+          "last_day_of_month_date",
+          vectorMaker.rowVector({fuzzer.fuzz(DATE())}))
+      .addExpression("last_day_of_month", "last_day_of_month(c0)")
+      .disableTesting();
+
+  // TIMESTAMP inputs (seconds + nanos).
+  benchmarkBuilder
+      .addBenchmarkSet(
+          "year_timestamp", vectorMaker.rowVector({fuzzer.fuzz(TIMESTAMP())}))
+      .addExpression("year", "year(c0)")
+      .disableTesting();
+
+  benchmarkBuilder
+      .addBenchmarkSet(
+          "month_timestamp", vectorMaker.rowVector({fuzzer.fuzz(TIMESTAMP())}))
+      .addExpression("month", "month(c0)")
+      .disableTesting();
+
+  benchmarkBuilder
+      .addBenchmarkSet(
+          "day_timestamp", vectorMaker.rowVector({fuzzer.fuzz(TIMESTAMP())}))
+      .addExpression("day", "day(c0)")
+      .disableTesting();
+
+  // Inverse direction: (year, month, day) -> Date via Spark make_date.
+  // Three INTEGER columns of small valid year/month/day values.
+  VectorFuzzer::Options yearOpts = options;
+  yearOpts.dataSpec.includeNaN = false;
+  VectorFuzzer yearFuzzer(yearOpts, pool);
+  benchmarkBuilder
+      .addBenchmarkSet(
+          "make_date",
+          vectorMaker.rowVector(
+              {"y", "m", "d"},
+              {vectorMaker.flatVector<int32_t>(
+                   1024, [](auto i) { return 1970 + (int)(i % 80); }),
+               vectorMaker.flatVector<int32_t>(
+                   1024, [](auto i) { return 1 + (int)(i % 12); }),
+               vectorMaker.flatVector<int32_t>(
+                   1024, [](auto i) { return 1 + (int)(i % 28); })}))
+      .addExpression("make_date", "spark_make_date(y, m, d)")
+      .disableTesting();
+
+  benchmarkBuilder.registerBenchmarks();
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/benchmarks/basic/DateExtractBenchmark.cpp
+++ b/velox/benchmarks/basic/DateExtractBenchmark.cpp
@@ -43,12 +43,14 @@ int main(int argc, char** argv) {
 
   // DATE inputs (int32 days since epoch).
   benchmarkBuilder
-      .addBenchmarkSet("year_date", vectorMaker.rowVector({fuzzer.fuzz(DATE())}))
+      .addBenchmarkSet(
+          "year_date", vectorMaker.rowVector({fuzzer.fuzz(DATE())}))
       .addExpression("year", "year(c0)")
       .disableTesting();
 
   benchmarkBuilder
-      .addBenchmarkSet("month_date", vectorMaker.rowVector({fuzzer.fuzz(DATE())}))
+      .addBenchmarkSet(
+          "month_date", vectorMaker.rowVector({fuzzer.fuzz(DATE())}))
       .addExpression("month", "month(c0)")
       .disableTesting();
 

--- a/velox/type/CMakeLists.txt
+++ b/velox/type/CMakeLists.txt
@@ -44,6 +44,7 @@ velox_add_library(
   Conversions.h
   CppToType.h
   DecimalUtil.h
+  FastDate.h
   Filter.h
   FloatingPointUtil.h
   HugeInt.h

--- a/velox/type/CMakeLists.txt
+++ b/velox/type/CMakeLists.txt
@@ -38,6 +38,7 @@ velox_add_library(
   TypeEncodingUtil.cpp
   TypeUtil.cpp
   Variant.cpp
+  WideRangeDateConversion.cpp
   HEADERS
   CastRegistry.h
   CastRule.h
@@ -61,6 +62,7 @@ velox_add_library(
   TypeEncodingUtil.h
   TypeUtil.h
   Variant.h
+  WideRangeDateConversion.h
 )
 
 velox_link_libraries(

--- a/velox/type/FastDate.h
+++ b/velox/type/FastDate.h
@@ -63,47 +63,79 @@ inline constexpr int32_t kYearMax = 2'906'945;
 /// [fast_date::kRataDieMin, fast_date::kRataDieMax]; results outside that
 /// range are undefined. The supported range covers ~3 million years
 /// centered on the epoch — vastly wider than any practical Velox DATE.
+///
+/// Variable mapping (Neri-Schneider 2022, §5):
+///   Paper | Local                | Meaning
+///   ------|----------------------|---------------------------------------
+///   N     | shiftedDay           | day-since-epoch rebased to be non-neg
+///   N_1   | centuryNumerator     | numerator for the century division
+///   C     | century              | century within the era
+///   N_C   | dayWithinCentury     | day within the century
+///   N_2   | yearNumerator        | numerator for year-within-century
+///   P_2   | yearProduct          | 64-bit multiply-shift reciprocal
+///   Z     | yearWithinCentury    | year within the century
+///   N_Y   | dayWithinYear        | day within the (March-based) year
+///   Y     | yearWithinEra        | year within the era
+///   N_3   | monthNumerator       | numerator for the month/day division
+///   M     | monthFromMarch       | month index counted from March
+///   D     | dayOfMonthZeroBased  | zero-based day-of-month
+///   J     | janFebAdjust         | 1 if Jan/Feb of next calendar year
 inline YearMonthDay daysToYmd(int32_t dayNumber) {
   using namespace fast_date;
-  const uint32_t N = static_cast<uint32_t>(dayNumber) + kK;
+  const uint32_t shiftedDay = static_cast<uint32_t>(dayNumber) + kK;
   // Century.
-  const uint32_t N_1 = 4u * N + 3u;
-  const uint32_t C = N_1 / 146097u;
-  const uint32_t N_C = N_1 % 146097u / 4u;
+  const uint32_t centuryNumerator = 4u * shiftedDay + 3u;
+  const uint32_t century = centuryNumerator / 146097u;
+  const uint32_t dayWithinCentury = centuryNumerator % 146097u / 4u;
   // Year within century.
-  const uint32_t N_2 = 4u * N_C + 3u;
-  const uint64_t P_2 = uint64_t{2939745u} * N_2;
-  const uint32_t Z = static_cast<uint32_t>(P_2 >> 32);
-  const uint32_t N_Y = static_cast<uint32_t>(P_2 & 0xFFFF'FFFFull) / 2939745u / 4u;
-  const uint32_t Y = 100u * C + Z;
-  // Month and day within year.
-  const uint32_t N_3 = 2141u * N_Y + 197913u;
-  const uint32_t M = N_3 / 65536u;
-  const uint32_t D = N_3 % 65536u / 2141u;
-  // Map: years are counted from March, so January/February belong to next
+  const uint32_t yearNumerator = 4u * dayWithinCentury + 3u;
+  const uint64_t yearProduct = uint64_t{2939745u} * yearNumerator;
+  const uint32_t yearWithinCentury = static_cast<uint32_t>(yearProduct >> 32);
+  const uint32_t dayWithinYear =
+      static_cast<uint32_t>(yearProduct & 0xFFFF'FFFFull) / 2939745u / 4u;
+  const uint32_t yearWithinEra = 100u * century + yearWithinCentury;
+  // Month and day within year (year here starts at March).
+  const uint32_t monthNumerator = 2141u * dayWithinYear + 197913u;
+  const uint32_t monthFromMarch = monthNumerator / 65536u;
+  const uint32_t dayOfMonthZeroBased = monthNumerator % 65536u / 2141u;
+  // Years are counted from March, so January/February belong to the next
   // calendar year; correct that here.
-  const uint32_t J = N_Y >= 306u ? 1u : 0u;
+  const uint32_t janFebAdjust = dayWithinYear >= 306u ? 1u : 0u;
   YearMonthDay out;
-  out.year = static_cast<int32_t>(Y - kL) + static_cast<int32_t>(J);
-  out.month = J ? M - 12u : M;
-  out.day = D + 1u;
+  out.year =
+      static_cast<int32_t>(yearWithinEra - kL) + static_cast<int32_t>(janFebAdjust);
+  out.month = janFebAdjust ? monthFromMarch - 12u : monthFromMarch;
+  out.day = dayOfMonthZeroBased + 1u;
   return out;
 }
 
 /// Inverse of daysToYmd. Year domain is
 /// [fast_date::kYearMin, fast_date::kYearMax]; results outside that range
 /// are undefined.
+///
+/// Variable mapping (Neri-Schneider 2022, §6):
+///   Paper  | Local                | Meaning
+///   -------|----------------------|--------------------------------------
+///   J      | janFebAdjust         | 1 if input month is Jan/Feb
+///   Y      | shiftedYear          | year within the era after Jan/Feb fix
+///   M      | monthFromMarch       | month index counted from March
+///   D      | dayOfMonthZeroBased  | zero-based day-of-month
+///   C      | century              | century within the era
+///   y_star | yearDays             | days from era start to year start
+///   m_star | monthDays            | days from year start to month start
+///   N      | shiftedRataDie       | shifted day-since-epoch (pre-offset)
 inline int32_t ymdToDays(int32_t year, uint32_t month, uint32_t day) {
   using namespace fast_date;
-  const uint32_t J = month <= 2u ? 1u : 0u;
-  const uint32_t Y = (static_cast<uint32_t>(year) + kL) - J;
-  const uint32_t M = J ? month + 12u : month;
-  const uint32_t D = day - 1u;
-  const uint32_t C = Y / 100u;
-  const uint32_t y_star = 1461u * Y / 4u - C + C / 4u;
-  const uint32_t m_star = (979u * M - 2919u) / 32u;
-  const uint32_t N = y_star + m_star + D;
-  return static_cast<int32_t>(N - kK);
+  const uint32_t janFebAdjust = month <= 2u ? 1u : 0u;
+  const uint32_t shiftedYear =
+      (static_cast<uint32_t>(year) + kL) - janFebAdjust;
+  const uint32_t monthFromMarch = janFebAdjust ? month + 12u : month;
+  const uint32_t dayOfMonthZeroBased = day - 1u;
+  const uint32_t century = shiftedYear / 100u;
+  const uint32_t yearDays = 1461u * shiftedYear / 4u - century + century / 4u;
+  const uint32_t monthDays = (979u * monthFromMarch - 2919u) / 32u;
+  const uint32_t shiftedRataDie = yearDays + monthDays + dayOfMonthZeroBased;
+  return static_cast<int32_t>(shiftedRataDie - kK);
 }
 
 } // namespace facebook::velox

--- a/velox/type/FastDate.h
+++ b/velox/type/FastDate.h
@@ -44,11 +44,19 @@ struct YearMonthDay {
 
 namespace fast_date {
 
-// Era shift used by the Neri-Schneider algorithm. s = 82 chosen so the
-// supported range covers everything Velox can natively store.
-inline constexpr uint32_t kS = 82u;
-inline constexpr uint32_t kK = 719468u + 146097u * kS;
-inline constexpr uint32_t kL = 400u * kS;
+// Era shift used by the Neri-Schneider algorithm. The paper calls this
+// `s`; 82 was chosen so the supported range covers everything Velox can
+// natively store.
+inline constexpr uint32_t kEraShift = 82u;
+
+// Epoch-day offset (paper's `K`): added to dayNumber so the algorithm
+// operates on a non-negative integer for the entire supported range.
+inline constexpr uint32_t kEpochOffset = 719468u + 146097u * kEraShift;
+
+// Year offset (paper's `L`): subtracted from the algorithm's internal
+// "year-within-era" representation to recover a real proleptic-Gregorian
+// year.
+inline constexpr uint32_t kYearOffset = 400u * kEraShift;
 
 // Supported input ranges (computed from the algorithm's affine arithmetic).
 inline constexpr int32_t kRataDieMin = -12'699'422; // 1 Mar -32800
@@ -82,7 +90,7 @@ inline constexpr int32_t kYearMax = 2'906'945;
 ///   J     | janFebAdjust         | 1 if Jan/Feb of next calendar year
 inline YearMonthDay daysToYmd(int32_t dayNumber) {
   using namespace fast_date;
-  const uint32_t shiftedDay = static_cast<uint32_t>(dayNumber) + kK;
+  const uint32_t shiftedDay = static_cast<uint32_t>(dayNumber) + kEpochOffset;
   // Century.
   const uint32_t centuryNumerator = 4u * shiftedDay + 3u;
   const uint32_t century = centuryNumerator / 146097u;
@@ -103,7 +111,8 @@ inline YearMonthDay daysToYmd(int32_t dayNumber) {
   const uint32_t janFebAdjust = dayWithinYear >= 306u ? 1u : 0u;
   YearMonthDay out;
   out.year =
-      static_cast<int32_t>(yearWithinEra - kL) + static_cast<int32_t>(janFebAdjust);
+      static_cast<int32_t>(yearWithinEra - kYearOffset) +
+      static_cast<int32_t>(janFebAdjust);
   out.month = janFebAdjust ? monthFromMarch - 12u : monthFromMarch;
   out.day = dayOfMonthZeroBased + 1u;
   return out;
@@ -128,14 +137,14 @@ inline int32_t ymdToDays(int32_t year, uint32_t month, uint32_t day) {
   using namespace fast_date;
   const uint32_t janFebAdjust = month <= 2u ? 1u : 0u;
   const uint32_t shiftedYear =
-      (static_cast<uint32_t>(year) + kL) - janFebAdjust;
+      (static_cast<uint32_t>(year) + kYearOffset) - janFebAdjust;
   const uint32_t monthFromMarch = janFebAdjust ? month + 12u : month;
   const uint32_t dayOfMonthZeroBased = day - 1u;
   const uint32_t century = shiftedYear / 100u;
   const uint32_t yearDays = 1461u * shiftedYear / 4u - century + century / 4u;
   const uint32_t monthDays = (979u * monthFromMarch - 2919u) / 32u;
   const uint32_t shiftedRataDie = yearDays + monthDays + dayOfMonthZeroBased;
-  return static_cast<int32_t>(shiftedRataDie - kK);
+  return static_cast<int32_t>(shiftedRataDie - kEpochOffset);
 }
 
 } // namespace facebook::velox

--- a/velox/type/FastDate.h
+++ b/velox/type/FastDate.h
@@ -59,6 +59,13 @@ inline constexpr uint32_t kEpochOffset = 719468u + 146097u * kEraShift;
 inline constexpr uint32_t kYearOffset = 400u * kEraShift;
 
 // Supported input ranges (computed from the algorithm's affine arithmetic).
+//
+// Note on the boundary years: the algorithm is parameterized from March,
+// not January. Its exact range is [Mar 1 kYearMin, Feb 28 kYearMax], not
+// [Jan 1 kYearMin, Dec 31 kYearMax]. For the inverse direction, callers
+// should restrict to year ∈ (kYearMin, kYearMax) — strictly excluding the
+// boundary years — to avoid the month-dependent wrinkle. The forward
+// direction has no such caveat because rata-die is monotonic.
 inline constexpr int32_t kRataDieMin = -12'699'422; // 1 Mar -32800
 inline constexpr int32_t kRataDieMax = 1'061'042'401; // 28 Feb 2906945
 inline constexpr int32_t kYearMin = -32800;
@@ -118,9 +125,11 @@ inline YearMonthDay daysToYmd(int32_t dayNumber) {
   return out;
 }
 
-/// Inverse of daysToYmd. Year domain is
-/// [fast_date::kYearMin, fast_date::kYearMax]; results outside that range
-/// are undefined.
+/// Inverse of daysToYmd. Safe for year ∈ (fast_date::kYearMin,
+/// fast_date::kYearMax) — strictly between the two boundaries — for any
+/// month and day. At the boundary years themselves, only the algorithm's
+/// March-based partial year is exact (see the constants' comment); use
+/// WideRangeDateConversion::daysSinceEpochFromDate for those instead.
 ///
 /// Variable mapping (Neri-Schneider 2022, §6):
 ///   Paper  | Local                | Meaning

--- a/velox/type/FastDate.h
+++ b/velox/type/FastDate.h
@@ -117,8 +117,7 @@ inline YearMonthDay daysToYmd(int32_t dayNumber) {
   // calendar year; correct that here.
   const uint32_t janFebAdjust = dayWithinYear >= 306u ? 1u : 0u;
   YearMonthDay out;
-  out.year =
-      static_cast<int32_t>(yearWithinEra - kYearOffset) +
+  out.year = static_cast<int32_t>(yearWithinEra - kYearOffset) +
       static_cast<int32_t>(janFebAdjust);
   out.month = janFebAdjust ? monthFromMarch - 12u : monthFromMarch;
   out.day = dayOfMonthZeroBased + 1u;

--- a/velox/type/FastDate.h
+++ b/velox/type/FastDate.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+// The Gregorian-date algorithms below are adapted from supplementary code
+// to the paper:
+//
+//   Cassio Neri and Lorenz Schneider,
+//   "Euclidean Affine Functions and their Application to Calendar
+//   Algorithms" (2022).
+//
+// Original source:
+//   https://github.com/benjoffe/fast-date-benchmarks/blob/main/algorithms/neri_schneider.hpp
+//   (which mirrors the reference implementation from the paper)
+//
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2022 Cassio Neri <cassio.neri@gmail.com>
+// SPDX-FileCopyrightText: 2022 Lorenz Schneider <schneider@em-lyon.com>
+
+#include <cstdint>
+
+namespace facebook::velox {
+
+/// Result of converting an epoch-day to a Gregorian (year, month, day).
+/// Year is signed (proleptic Gregorian), month is 1-12, day is 1-31.
+struct YearMonthDay {
+  int32_t year;
+  uint32_t month;
+  uint32_t day;
+};
+
+namespace fast_date {
+
+// Era shift used by the Neri-Schneider algorithm. s = 82 chosen so the
+// supported range covers everything Velox can natively store.
+inline constexpr uint32_t kS = 82u;
+inline constexpr uint32_t kK = 719468u + 146097u * kS;
+inline constexpr uint32_t kL = 400u * kS;
+
+// Supported input ranges (computed from the algorithm's affine arithmetic).
+inline constexpr int32_t kRataDieMin = -12'699'422; // 1 Mar -32800
+inline constexpr int32_t kRataDieMax = 1'061'042'401; // 28 Feb 2906945
+inline constexpr int32_t kYearMin = -32800;
+inline constexpr int32_t kYearMax = 2'906'945;
+
+} // namespace fast_date
+
+/// Converts an epoch-day count (days since 1970-01-01) to the corresponding
+/// proleptic Gregorian (year, month, day). Exact for any dayNumber in
+/// [fast_date::kRataDieMin, fast_date::kRataDieMax]; results outside that
+/// range are undefined. The supported range covers ~3 million years
+/// centered on the epoch — vastly wider than any practical Velox DATE.
+inline YearMonthDay daysToYmd(int32_t dayNumber) {
+  using namespace fast_date;
+  const uint32_t N = static_cast<uint32_t>(dayNumber) + kK;
+  // Century.
+  const uint32_t N_1 = 4u * N + 3u;
+  const uint32_t C = N_1 / 146097u;
+  const uint32_t N_C = N_1 % 146097u / 4u;
+  // Year within century.
+  const uint32_t N_2 = 4u * N_C + 3u;
+  const uint64_t P_2 = uint64_t{2939745u} * N_2;
+  const uint32_t Z = static_cast<uint32_t>(P_2 >> 32);
+  const uint32_t N_Y = static_cast<uint32_t>(P_2 & 0xFFFF'FFFFull) / 2939745u / 4u;
+  const uint32_t Y = 100u * C + Z;
+  // Month and day within year.
+  const uint32_t N_3 = 2141u * N_Y + 197913u;
+  const uint32_t M = N_3 / 65536u;
+  const uint32_t D = N_3 % 65536u / 2141u;
+  // Map: years are counted from March, so January/February belong to next
+  // calendar year; correct that here.
+  const uint32_t J = N_Y >= 306u ? 1u : 0u;
+  YearMonthDay out;
+  out.year = static_cast<int32_t>(Y - kL) + static_cast<int32_t>(J);
+  out.month = J ? M - 12u : M;
+  out.day = D + 1u;
+  return out;
+}
+
+/// Inverse of daysToYmd. Year domain is
+/// [fast_date::kYearMin, fast_date::kYearMax]; results outside that range
+/// are undefined.
+inline int32_t ymdToDays(int32_t year, uint32_t month, uint32_t day) {
+  using namespace fast_date;
+  const uint32_t J = month <= 2u ? 1u : 0u;
+  const uint32_t Y = (static_cast<uint32_t>(year) + kL) - J;
+  const uint32_t M = J ? month + 12u : month;
+  const uint32_t D = day - 1u;
+  const uint32_t C = Y / 100u;
+  const uint32_t y_star = 1461u * Y / 4u - C + C / 4u;
+  const uint32_t m_star = (979u * M - 2919u) / 32u;
+  const uint32_t N = y_star + m_star + D;
+  return static_cast<int32_t>(N - kK);
+}
+
+} // namespace facebook::velox

--- a/velox/type/Timestamp.cpp
+++ b/velox/type/Timestamp.cpp
@@ -163,8 +163,7 @@ bool Timestamp::epochToCalendarUtc(int64_t epoch, std::tm& tm) {
       return false;
     }
     tm.tm_year = static_cast<int>(y);
-    const auto* monthOffsets =
-        daysBeforeFirstDayOfMonth[isLeap(ymd.year)];
+    const auto* monthOffsets = daysBeforeFirstDayOfMonth[isLeap(ymd.year)];
     tm.tm_mon = static_cast<int>(ymd.month) - 1;
     tm.tm_mday = static_cast<int>(ymd.day);
     tm.tm_yday = monthOffsets[tm.tm_mon] + tm.tm_mday - 1;

--- a/velox/type/Timestamp.cpp
+++ b/velox/type/Timestamp.cpp
@@ -18,6 +18,7 @@
 #include <chrono>
 #include "velox/common/base/CountBits.h"
 #include "velox/external/tzdb/exception.h"
+#include "velox/type/FastDate.h"
 #include "velox/type/tz/TimeZoneMap.h"
 
 namespace facebook::velox {
@@ -135,10 +136,9 @@ const int16_t daysBeforeFirstDayOfMonth[][12] = {
 } // namespace
 
 bool Timestamp::epochToCalendarUtc(int64_t epoch, std::tm& tm) {
-  constexpr int kDaysPerYear = 365;
   int64_t days = epoch / kSecondsPerDay;
   int64_t rem = epoch % kSecondsPerDay;
-  while (rem < 0) {
+  if (rem < 0) {
     rem += kSecondsPerDay;
     --days;
   }
@@ -150,6 +150,28 @@ bool Timestamp::epochToCalendarUtc(int64_t epoch, std::tm& tm) {
   if (tm.tm_wday < 0) {
     tm.tm_wday += 7;
   }
+  // Fast path: Neri-Schneider 2022 covers ~3 million years centered on the
+  // epoch — vastly wider than any practical Velox DATE / TIMESTAMP.
+  if (FOLLY_LIKELY(
+          days >= fast_date::kRataDieMin && days <= fast_date::kRataDieMax)) {
+    const auto ymd = daysToYmd(static_cast<int32_t>(days));
+    const int64_t y = static_cast<int64_t>(ymd.year) - kTmYearBase;
+    if (y > std::numeric_limits<decltype(tm.tm_year)>::max() ||
+        y < std::numeric_limits<decltype(tm.tm_year)>::min()) {
+      return false;
+    }
+    tm.tm_year = static_cast<int>(y);
+    const auto* monthOffsets =
+        daysBeforeFirstDayOfMonth[isLeap(ymd.year)];
+    tm.tm_mon = static_cast<int>(ymd.month) - 1;
+    tm.tm_mday = static_cast<int>(ymd.day);
+    tm.tm_yday = monthOffsets[tm.tm_mon] + tm.tm_mday - 1;
+    tm.tm_isdst = 0;
+    return true;
+  }
+  // Fallback: input outside the fast path's exact range. Iterates once per
+  // century, but only reachable from synthetic / extreme epoch values.
+  constexpr int kDaysPerYear = 365;
   int64_t y = 1970;
   if (y + days / kDaysPerYear <= -kLeapYearOffset + 10) {
     return false;

--- a/velox/type/Timestamp.cpp
+++ b/velox/type/Timestamp.cpp
@@ -19,6 +19,7 @@
 #include "velox/common/base/CountBits.h"
 #include "velox/external/tzdb/exception.h"
 #include "velox/type/FastDate.h"
+#include "velox/type/WideRangeDateConversion.h"
 #include "velox/type/tz/TimeZoneMap.h"
 
 namespace facebook::velox {
@@ -142,18 +143,19 @@ bool Timestamp::epochToCalendarUtc(int64_t epoch, std::tm& tm) {
     rem += kSecondsPerDay;
     --days;
   }
-  tm.tm_hour = rem / kSecondsPerHour;
-  rem = rem % kSecondsPerHour;
-  tm.tm_min = rem / 60;
-  tm.tm_sec = rem % 60;
-  tm.tm_wday = (4 + days) % 7;
-  if (tm.tm_wday < 0) {
-    tm.tm_wday += 7;
-  }
   // Fast path: Neri-Schneider 2022 covers ~3 million years centered on the
   // epoch — vastly wider than any practical Velox DATE / TIMESTAMP.
+  // Inputs outside this range delegate to WideRangeDateConversion.
   if (FOLLY_LIKELY(
           days >= fast_date::kRataDieMin && days <= fast_date::kRataDieMax)) {
+    tm.tm_hour = rem / kSecondsPerHour;
+    rem = rem % kSecondsPerHour;
+    tm.tm_min = rem / 60;
+    tm.tm_sec = rem % 60;
+    tm.tm_wday = (4 + days) % 7;
+    if (tm.tm_wday < 0) {
+      tm.tm_wday += 7;
+    }
     const auto ymd = daysToYmd(static_cast<int32_t>(days));
     const int64_t y = static_cast<int64_t>(ymd.year) - kTmYearBase;
     if (y > std::numeric_limits<decltype(tm.tm_year)>::max() ||
@@ -169,31 +171,7 @@ bool Timestamp::epochToCalendarUtc(int64_t epoch, std::tm& tm) {
     tm.tm_isdst = 0;
     return true;
   }
-  // Fallback: input outside the fast path's exact range. Iterates once per
-  // century, but only reachable from synthetic / extreme epoch values.
-  constexpr int kDaysPerYear = 365;
-  int64_t y = 1970;
-  if (y + days / kDaysPerYear <= -kLeapYearOffset + 10) {
-    return false;
-  }
-  bool leapYear;
-  while (days < 0 || days >= kDaysPerYear + (leapYear = isLeap(y))) {
-    auto newy = y + days / kDaysPerYear - (days < 0);
-    days -= daysBetweenYears(y, newy);
-    y = newy;
-  }
-  y -= kTmYearBase;
-  if (y > std::numeric_limits<decltype(tm.tm_year)>::max() ||
-      y < std::numeric_limits<decltype(tm.tm_year)>::min()) {
-    return false;
-  }
-  tm.tm_year = y;
-  tm.tm_yday = days;
-  auto* months = daysBeforeFirstDayOfMonth[leapYear];
-  tm.tm_mon = std::upper_bound(months, months + 12, days) - months - 1;
-  tm.tm_mday = days - months[tm.tm_mon] + 1;
-  tm.tm_isdst = 0;
-  return true;
+  return WideRangeDateConversion::epochToCalendarUtc(epoch, tm);
 }
 
 // static

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -694,13 +694,16 @@ int32_t getMaxDayOfMonth(int32_t year, int32_t month) {
 
 Expected<int64_t>
 daysSinceEpochFromDate(int32_t year, int32_t month, int32_t day) {
-  // Fast path: years inside the fast-date inverse algorithm's exact domain.
-  // Covers any DATE that fits in int32 days plus several million years on
-  // either side — anything Velox can practically carry. Years outside this
-  // range delegate to WideRangeDateConversion, which validates and handles
-  // the full [kMinYear, kMaxYear] domain via the loop-based fallback.
+  // Fast path: years strictly inside the fast-date inverse algorithm's
+  // exact domain. The algorithm's date range is bounded by Mar 1 kYearMin
+  // and Feb 28 kYearMax, not the full calendar year on either end, so the
+  // boundary years are excluded entirely to avoid the month-dependent
+  // wrinkle. Loses 2 years of fast-path coverage out of ~3 million —
+  // negligible. Years outside the strict range delegate to
+  // WideRangeDateConversion, which validates and handles the full
+  // [kMinYear, kMaxYear] domain via the loop-based fallback.
   if (FOLLY_LIKELY(
-          year >= fast_date::kYearMin && year <= fast_date::kYearMax)) {
+          year > fast_date::kYearMin && year < fast_date::kYearMax)) {
     if (!isValidDate(year, month, day)) {
       if (threadSkipErrorDetails()) {
         return folly::makeUnexpected(Status::UserError());

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -46,6 +46,7 @@
 #include "velox/common/base/Exceptions.h"
 #include "velox/type/FastDate.h"
 #include "velox/type/HugeInt.h"
+#include "velox/type/WideRangeDateConversion.h"
 #include "velox/type/tz/TimeZoneMap.h"
 
 namespace facebook::velox::util {
@@ -54,58 +55,6 @@ constexpr int32_t kLeapDays[] =
     {0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
 constexpr int32_t kNormalDays[] =
     {0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
-constexpr int32_t kCumulativeDays[] =
-    {0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365};
-constexpr int32_t kCumulativeLeapDays[] =
-    {0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366};
-
-constexpr int32_t kCumulativeYearDays[] = {
-    0,      365,    730,    1096,   1461,   1826,   2191,   2557,   2922,
-    3287,   3652,   4018,   4383,   4748,   5113,   5479,   5844,   6209,
-    6574,   6940,   7305,   7670,   8035,   8401,   8766,   9131,   9496,
-    9862,   10227,  10592,  10957,  11323,  11688,  12053,  12418,  12784,
-    13149,  13514,  13879,  14245,  14610,  14975,  15340,  15706,  16071,
-    16436,  16801,  17167,  17532,  17897,  18262,  18628,  18993,  19358,
-    19723,  20089,  20454,  20819,  21184,  21550,  21915,  22280,  22645,
-    23011,  23376,  23741,  24106,  24472,  24837,  25202,  25567,  25933,
-    26298,  26663,  27028,  27394,  27759,  28124,  28489,  28855,  29220,
-    29585,  29950,  30316,  30681,  31046,  31411,  31777,  32142,  32507,
-    32872,  33238,  33603,  33968,  34333,  34699,  35064,  35429,  35794,
-    36160,  36525,  36890,  37255,  37621,  37986,  38351,  38716,  39082,
-    39447,  39812,  40177,  40543,  40908,  41273,  41638,  42004,  42369,
-    42734,  43099,  43465,  43830,  44195,  44560,  44926,  45291,  45656,
-    46021,  46387,  46752,  47117,  47482,  47847,  48212,  48577,  48942,
-    49308,  49673,  50038,  50403,  50769,  51134,  51499,  51864,  52230,
-    52595,  52960,  53325,  53691,  54056,  54421,  54786,  55152,  55517,
-    55882,  56247,  56613,  56978,  57343,  57708,  58074,  58439,  58804,
-    59169,  59535,  59900,  60265,  60630,  60996,  61361,  61726,  62091,
-    62457,  62822,  63187,  63552,  63918,  64283,  64648,  65013,  65379,
-    65744,  66109,  66474,  66840,  67205,  67570,  67935,  68301,  68666,
-    69031,  69396,  69762,  70127,  70492,  70857,  71223,  71588,  71953,
-    72318,  72684,  73049,  73414,  73779,  74145,  74510,  74875,  75240,
-    75606,  75971,  76336,  76701,  77067,  77432,  77797,  78162,  78528,
-    78893,  79258,  79623,  79989,  80354,  80719,  81084,  81450,  81815,
-    82180,  82545,  82911,  83276,  83641,  84006,  84371,  84736,  85101,
-    85466,  85832,  86197,  86562,  86927,  87293,  87658,  88023,  88388,
-    88754,  89119,  89484,  89849,  90215,  90580,  90945,  91310,  91676,
-    92041,  92406,  92771,  93137,  93502,  93867,  94232,  94598,  94963,
-    95328,  95693,  96059,  96424,  96789,  97154,  97520,  97885,  98250,
-    98615,  98981,  99346,  99711,  100076, 100442, 100807, 101172, 101537,
-    101903, 102268, 102633, 102998, 103364, 103729, 104094, 104459, 104825,
-    105190, 105555, 105920, 106286, 106651, 107016, 107381, 107747, 108112,
-    108477, 108842, 109208, 109573, 109938, 110303, 110669, 111034, 111399,
-    111764, 112130, 112495, 112860, 113225, 113591, 113956, 114321, 114686,
-    115052, 115417, 115782, 116147, 116513, 116878, 117243, 117608, 117974,
-    118339, 118704, 119069, 119435, 119800, 120165, 120530, 120895, 121260,
-    121625, 121990, 122356, 122721, 123086, 123451, 123817, 124182, 124547,
-    124912, 125278, 125643, 126008, 126373, 126739, 127104, 127469, 127834,
-    128200, 128565, 128930, 129295, 129661, 130026, 130391, 130756, 131122,
-    131487, 131852, 132217, 132583, 132948, 133313, 133678, 134044, 134409,
-    134774, 135139, 135505, 135870, 136235, 136600, 136966, 137331, 137696,
-    138061, 138427, 138792, 139157, 139522, 139888, 140253, 140618, 140983,
-    141349, 141714, 142079, 142444, 142810, 143175, 143540, 143905, 144271,
-    144636, 145001, 145366, 145732, 146097,
-};
 
 namespace {
 
@@ -745,37 +694,24 @@ int32_t getMaxDayOfMonth(int32_t year, int32_t month) {
 
 Expected<int64_t>
 daysSinceEpochFromDate(int32_t year, int32_t month, int32_t day) {
-  if (!isValidDate(year, month, day)) {
-    if (threadSkipErrorDetails()) {
-      return folly::makeUnexpected(Status::UserError());
-    }
-    return folly::makeUnexpected(
-        Status::UserError("Date out of range: {}-{}-{}", year, month, day));
-  }
   // Fast path: years inside the fast-date inverse algorithm's exact domain.
   // Covers any DATE that fits in int32 days plus several million years on
-  // either side — anything Velox can practically carry.
+  // either side — anything Velox can practically carry. Years outside this
+  // range delegate to WideRangeDateConversion, which validates and handles
+  // the full [kMinYear, kMaxYear] domain via the loop-based fallback.
   if (FOLLY_LIKELY(
           year >= fast_date::kYearMin && year <= fast_date::kYearMax)) {
-    return static_cast<int64_t>(
-        ymdToDays(year, static_cast<uint32_t>(month), static_cast<uint32_t>(day)));
+    if (!isValidDate(year, month, day)) {
+      if (threadSkipErrorDetails()) {
+        return folly::makeUnexpected(Status::UserError());
+      }
+      return folly::makeUnexpected(Status::UserError(
+          "Date out of range: {}-{}-{}", year, month, day));
+    }
+    return static_cast<int64_t>(ymdToDays(
+        year, static_cast<uint32_t>(month), static_cast<uint32_t>(day)));
   }
-  // Fallback for pathological years up to kMaxYear / kMinYear. Iterates once
-  // per 400-year era; only reachable from explicit user-constructed dates.
-  int64_t daysSinceEpoch = 0;
-  while (year < 1970) {
-    year += kYearInterval;
-    daysSinceEpoch -= kDaysPerYearInterval;
-  }
-  while (year >= 2370) {
-    year -= kYearInterval;
-    daysSinceEpoch += kDaysPerYearInterval;
-  }
-  daysSinceEpoch += kCumulativeYearDays[year - 1970];
-  daysSinceEpoch += isLeapYear(year) ? kCumulativeLeapDays[month - 1]
-                                     : kCumulativeDays[month - 1];
-  daysSinceEpoch += day - 1;
-  return daysSinceEpoch;
+  return WideRangeDateConversion::daysSinceEpochFromDate(year, month, day);
 }
 
 Expected<int64_t> daysSinceEpochFromWeekDate(

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -44,6 +44,7 @@
 #include <folly/Expected.h>
 #include "velox/common/base/CheckedArithmetic.h"
 #include "velox/common/base/Exceptions.h"
+#include "velox/type/FastDate.h"
 #include "velox/type/HugeInt.h"
 #include "velox/type/tz/TimeZoneMap.h"
 
@@ -744,8 +745,6 @@ int32_t getMaxDayOfMonth(int32_t year, int32_t month) {
 
 Expected<int64_t>
 daysSinceEpochFromDate(int32_t year, int32_t month, int32_t day) {
-  int64_t daysSinceEpoch = 0;
-
   if (!isValidDate(year, month, day)) {
     if (threadSkipErrorDetails()) {
       return folly::makeUnexpected(Status::UserError());
@@ -753,6 +752,17 @@ daysSinceEpochFromDate(int32_t year, int32_t month, int32_t day) {
     return folly::makeUnexpected(
         Status::UserError("Date out of range: {}-{}-{}", year, month, day));
   }
+  // Fast path: years inside the fast-date inverse algorithm's exact domain.
+  // Covers any DATE that fits in int32 days plus several million years on
+  // either side — anything Velox can practically carry.
+  if (FOLLY_LIKELY(
+          year >= fast_date::kYearMin && year <= fast_date::kYearMax)) {
+    return static_cast<int64_t>(
+        ymdToDays(year, static_cast<uint32_t>(month), static_cast<uint32_t>(day)));
+  }
+  // Fallback for pathological years up to kMaxYear / kMinYear. Iterates once
+  // per 400-year era; only reachable from explicit user-constructed dates.
+  int64_t daysSinceEpoch = 0;
   while (year < 1970) {
     year += kYearInterval;
     daysSinceEpoch -= kDaysPerYearInterval;

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -702,14 +702,13 @@ daysSinceEpochFromDate(int32_t year, int32_t month, int32_t day) {
   // negligible. Years outside the strict range delegate to
   // WideRangeDateConversion, which validates and handles the full
   // [kMinYear, kMaxYear] domain via the loop-based fallback.
-  if (FOLLY_LIKELY(
-          year > fast_date::kYearMin && year < fast_date::kYearMax)) {
+  if (FOLLY_LIKELY(year > fast_date::kYearMin && year < fast_date::kYearMax)) {
     if (!isValidDate(year, month, day)) {
       if (threadSkipErrorDetails()) {
         return folly::makeUnexpected(Status::UserError());
       }
-      return folly::makeUnexpected(Status::UserError(
-          "Date out of range: {}-{}-{}", year, month, day));
+      return folly::makeUnexpected(
+          Status::UserError("Date out of range: {}-{}-{}", year, month, day));
     }
     return static_cast<int64_t>(ymdToDays(
         year, static_cast<uint32_t>(month), static_cast<uint32_t>(day)));

--- a/velox/type/WideRangeDateConversion.cpp
+++ b/velox/type/WideRangeDateConversion.cpp
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/type/WideRangeDateConversion.h"
+
+#include <algorithm>
+#include <limits>
+#include "velox/common/base/VeloxException.h"
+#include "velox/type/TimestampConversion.h"
+
+namespace facebook::velox {
+namespace {
+
+constexpr int kTmYearBase = 1900;
+constexpr int64_t kLeapYearOffset = 4'000'000'000LL;
+constexpr int64_t kSecondsPerHour = 3600;
+constexpr int64_t kSecondsPerDay = 24 * kSecondsPerHour;
+
+inline bool isLeap(int64_t y) {
+  return y % 4 == 0 && (y % 100 != 0 || y % 400 == 0);
+}
+
+inline int64_t leapThroughEndOf(int64_t y) {
+  // Add a large offset so the calculation works for negative years.
+  y += kLeapYearOffset;
+  return y / 4 - y / 100 + y / 400;
+}
+
+inline int64_t daysBetweenYears(int64_t y1, int64_t y2) {
+  return 365 * (y2 - y1) + leapThroughEndOf(y2 - 1) - leapThroughEndOf(y1 - 1);
+}
+
+constexpr int16_t kDaysBeforeFirstDayOfMonth[][12] = {
+    {0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334},
+    {0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335},
+};
+
+constexpr int32_t kCumulativeDays[] =
+    {0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365};
+constexpr int32_t kCumulativeLeapDays[] =
+    {0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366};
+
+// Days from 1970-01-01 to the start of each year in [1970, 2370].
+// The inverse path uses this table for years inside the era and
+// 400-year-step loops for years outside it.
+constexpr int32_t kCumulativeYearDays[] = {
+    0,      365,    730,    1096,   1461,   1826,   2191,   2557,   2922,
+    3287,   3652,   4018,   4383,   4748,   5113,   5479,   5844,   6209,
+    6574,   6940,   7305,   7670,   8035,   8401,   8766,   9131,   9496,
+    9862,   10227,  10592,  10957,  11323,  11688,  12053,  12418,  12784,
+    13149,  13514,  13879,  14245,  14610,  14975,  15340,  15706,  16071,
+    16436,  16801,  17167,  17532,  17897,  18262,  18628,  18993,  19358,
+    19723,  20089,  20454,  20819,  21184,  21550,  21915,  22280,  22645,
+    23011,  23376,  23741,  24106,  24472,  24837,  25202,  25567,  25933,
+    26298,  26663,  27028,  27394,  27759,  28124,  28489,  28855,  29220,
+    29585,  29950,  30316,  30681,  31046,  31411,  31777,  32142,  32507,
+    32872,  33238,  33603,  33968,  34333,  34699,  35064,  35429,  35794,
+    36160,  36525,  36890,  37255,  37621,  37986,  38351,  38716,  39082,
+    39447,  39812,  40177,  40543,  40908,  41273,  41638,  42004,  42369,
+    42734,  43099,  43465,  43830,  44195,  44560,  44926,  45291,  45656,
+    46021,  46387,  46752,  47117,  47482,  47847,  48212,  48577,  48942,
+    49308,  49673,  50038,  50403,  50769,  51134,  51499,  51864,  52230,
+    52595,  52960,  53325,  53691,  54056,  54421,  54786,  55152,  55517,
+    55882,  56247,  56613,  56978,  57343,  57708,  58074,  58439,  58804,
+    59169,  59535,  59900,  60265,  60630,  60996,  61361,  61726,  62091,
+    62457,  62822,  63187,  63552,  63918,  64283,  64648,  65013,  65379,
+    65744,  66109,  66474,  66840,  67205,  67570,  67935,  68301,  68666,
+    69031,  69396,  69762,  70127,  70492,  70857,  71223,  71588,  71953,
+    72318,  72684,  73049,  73414,  73779,  74145,  74510,  74875,  75240,
+    75606,  75971,  76336,  76701,  77067,  77432,  77797,  78162,  78528,
+    78893,  79258,  79623,  79989,  80354,  80719,  81084,  81450,  81815,
+    82180,  82545,  82911,  83276,  83641,  84006,  84371,  84736,  85101,
+    85466,  85832,  86197,  86562,  86927,  87293,  87658,  88023,  88388,
+    88754,  89119,  89484,  89849,  90215,  90580,  90945,  91310,  91676,
+    92041,  92406,  92771,  93137,  93502,  93867,  94232,  94598,  94963,
+    95328,  95693,  96059,  96424,  96789,  97154,  97520,  97885,  98250,
+    98615,  98981,  99346,  99711,  100076, 100442, 100807, 101172, 101537,
+    101903, 102268, 102633, 102998, 103364, 103729, 104094, 104459, 104825,
+    105190, 105555, 105920, 106286, 106651, 107016, 107381, 107747, 108112,
+    108477, 108842, 109208, 109573, 109938, 110303, 110669, 111034, 111399,
+    111764, 112130, 112495, 112860, 113225, 113591, 113956, 114321, 114686,
+    115052, 115417, 115782, 116147, 116513, 116878, 117243, 117608, 117974,
+    118339, 118704, 119069, 119435, 119800, 120165, 120530, 120895, 121260,
+    121625, 121990, 122356, 122721, 123086, 123451, 123817, 124182, 124547,
+    124912, 125278, 125643, 126008, 126373, 126739, 127104, 127469, 127834,
+    128200, 128565, 128930, 129295, 129661, 130026, 130391, 130756, 131122,
+    131487, 131852, 132217, 132583, 132948, 133313, 133678, 134044, 134409,
+    134774, 135139, 135505, 135870, 136235, 136600, 136966, 137331, 137696,
+    138061, 138427, 138792, 139157, 139522, 139888, 140253, 140618, 140983,
+    141349, 141714, 142079, 142444, 142810, 143175, 143540, 143905, 144271,
+    144636, 145001, 145366, 145732, 146097,
+};
+
+} // namespace
+
+bool WideRangeDateConversion::epochToCalendarUtc(int64_t epoch, std::tm& tm) {
+  constexpr int kDaysPerYear = 365;
+  int64_t days = epoch / kSecondsPerDay;
+  int64_t rem = epoch % kSecondsPerDay;
+  if (rem < 0) {
+    rem += kSecondsPerDay;
+    --days;
+  }
+  tm.tm_hour = rem / kSecondsPerHour;
+  rem = rem % kSecondsPerHour;
+  tm.tm_min = rem / 60;
+  tm.tm_sec = rem % 60;
+  tm.tm_wday = (4 + days) % 7;
+  if (tm.tm_wday < 0) {
+    tm.tm_wday += 7;
+  }
+  int64_t y = 1970;
+  if (y + days / kDaysPerYear <= -kLeapYearOffset + 10) {
+    return false;
+  }
+  bool leapYear;
+  while (days < 0 || days >= kDaysPerYear + (leapYear = isLeap(y))) {
+    auto newy = y + days / kDaysPerYear - (days < 0);
+    days -= daysBetweenYears(y, newy);
+    y = newy;
+  }
+  y -= kTmYearBase;
+  if (y > std::numeric_limits<decltype(tm.tm_year)>::max() ||
+      y < std::numeric_limits<decltype(tm.tm_year)>::min()) {
+    return false;
+  }
+  tm.tm_year = y;
+  tm.tm_yday = days;
+  const auto* months = kDaysBeforeFirstDayOfMonth[leapYear];
+  tm.tm_mon = std::upper_bound(months, months + 12, days) - months - 1;
+  tm.tm_mday = days - months[tm.tm_mon] + 1;
+  tm.tm_isdst = 0;
+  return true;
+}
+
+Expected<int64_t> WideRangeDateConversion::daysSinceEpochFromDate(
+    int32_t year,
+    int32_t month,
+    int32_t day) {
+  if (!util::isValidDate(year, month, day)) {
+    if (threadSkipErrorDetails()) {
+      return folly::makeUnexpected(Status::UserError());
+    }
+    return folly::makeUnexpected(
+        Status::UserError("Date out of range: {}-{}-{}", year, month, day));
+  }
+  int64_t daysSinceEpoch = 0;
+  while (year < 1970) {
+    year += util::kYearInterval;
+    daysSinceEpoch -= util::kDaysPerYearInterval;
+  }
+  while (year >= 2370) {
+    year -= util::kYearInterval;
+    daysSinceEpoch += util::kDaysPerYearInterval;
+  }
+  daysSinceEpoch += kCumulativeYearDays[year - 1970];
+  daysSinceEpoch += util::isLeapYear(year) ? kCumulativeLeapDays[month - 1]
+                                           : kCumulativeDays[month - 1];
+  daysSinceEpoch += day - 1;
+  return daysSinceEpoch;
+}
+
+} // namespace facebook::velox

--- a/velox/type/WideRangeDateConversion.h
+++ b/velox/type/WideRangeDateConversion.h
@@ -15,8 +15,8 @@
  */
 #pragma once
 
-#include <ctime>
 #include <cstdint>
+#include <ctime>
 #include "velox/common/base/Status.h"
 
 namespace facebook::velox {
@@ -41,10 +41,8 @@ class WideRangeDateConversion {
   /// loop-based path. Validates the input against [kMinYear, kMaxYear];
   /// returns Status::UserError ("Date out of range: ...") on invalid
   /// input.
-  static Expected<int64_t> daysSinceEpochFromDate(
-      int32_t year,
-      int32_t month,
-      int32_t day);
+  static Expected<int64_t>
+  daysSinceEpochFromDate(int32_t year, int32_t month, int32_t day);
 };
 
 } // namespace facebook::velox

--- a/velox/type/WideRangeDateConversion.h
+++ b/velox/type/WideRangeDateConversion.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <ctime>
+#include <cstdint>
+#include "velox/common/base/Status.h"
+
+namespace facebook::velox {
+
+/// Loop-based date conversion that handles the full validation range
+/// [kMinYear, kMaxYear]. Slower than the Neri-Schneider fast path in
+/// FastDate.h, but covers inputs outside that fast path's exact domain
+/// (~3M years centered on the epoch). Used as the fallback inside
+/// Timestamp::epochToCalendarUtc and util::daysSinceEpochFromDate.
+///
+/// Exposed as a real production class (not a test-only helper) so the
+/// fast/fallback equivalence can be asserted directly from tests, and so
+/// the benchmark file can compare without duplicating the loop body.
+class WideRangeDateConversion {
+ public:
+  /// Converts seconds-since-epoch to a calendar-UTC std::tm using the
+  /// loop-based path. Returns false if the result year does not fit in
+  /// std::tm::tm_year or the input is otherwise unrepresentable.
+  static bool epochToCalendarUtc(int64_t epoch, std::tm& tm);
+
+  /// Converts a (year, month, day) triple to days-since-epoch using the
+  /// loop-based path. Validates the input against [kMinYear, kMaxYear];
+  /// returns Status::UserError ("Date out of range: ...") on invalid
+  /// input.
+  static Expected<int64_t> daysSinceEpochFromDate(
+      int32_t year,
+      int32_t month,
+      int32_t day);
+};
+
+} // namespace facebook::velox

--- a/velox/type/tests/CMakeLists.txt
+++ b/velox/type/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(
   CastRegistryTest.cpp
   ConversionsTest.cpp
   DecimalTest.cpp
+  FastDateTest.cpp
   FilterTest.cpp
   FilterSerDeTest.cpp
   FloatingPointUtilTest.cpp
@@ -121,6 +122,17 @@ if(VELOX_ENABLE_BENCHMARKS)
     Folly::follybenchmark
     GTest::gtest
     GTest::gtest_main
+    glog::glog
+  )
+
+  add_executable(velox_date_conversion_benchmark DateConversionBenchmark.cpp)
+
+  target_link_libraries(
+    velox_date_conversion_benchmark
+    velox_type
+    velox_external_date
+    Folly::folly
+    Folly::follybenchmark
     glog::glog
   )
 endif()

--- a/velox/type/tests/DateConversionBenchmark.cpp
+++ b/velox/type/tests/DateConversionBenchmark.cpp
@@ -21,6 +21,7 @@
 #include "velox/type/FastDate.h"
 #include "velox/type/Timestamp.h"
 #include "velox/type/TimestampConversion.h"
+#include "velox/type/WideRangeDateConversion.h"
 
 using namespace facebook::velox;
 
@@ -30,8 +31,8 @@ constexpr int32_t kNumValues = 1'000'000;
 
 // Workloads with different ranges of input days. "Tight" represents typical
 // query data; "wide" exercises the algorithm closer to its limits.
-std::vector<int32_t> tightDays; // ~+/- 70 years from epoch.
-std::vector<int32_t> wideDays; // full int32 range.
+std::vector<int32_t> tightDays;
+std::vector<int32_t> wideDays;
 
 struct Ymd {
   int32_t year;
@@ -63,81 +64,23 @@ void fillYmd(std::vector<Ymd>& out, const std::vector<int32_t>& days) {
   }
 }
 
-// --- Velox's pre-patch implementation, inlined ---------------------------
-// Verbatim copy of the loop-based body that lived in
-// velox/type/Timestamp.cpp:epochToCalendarUtc before this PR. Kept here so
-// the bench can keep reproducing the "before" number after the patch lands;
-// otherwise calling Timestamp::epochToCalendarUtc directly would just
-// measure the new fast path again.
-namespace legacy_loop {
-constexpr int kTmYearBase = 1900;
-constexpr int64_t kLeapYearOffset = 4'000'000'000LL;
-constexpr int64_t kSecondsPerHour = 3600;
-constexpr int64_t kSecondsPerDay = 24 * kSecondsPerHour;
+// --- Forward direction: epoch-seconds -> std::tm -------------------------
+// Two contestants:
+//   wide_range  → WideRangeDateConversion::epochToCalendarUtc
+//                 (the loop-based fallback that lived inline in
+//                 Timestamp::epochToCalendarUtc before this PR).
+//   neri_schneider → Timestamp::epochToCalendarUtc (the patched public API,
+//                 which uses the Neri-Schneider 2022 fast path for in-range
+//                 inputs).
+// Both fill the full std::tm including tm_hour/tm_min/tm_sec/tm_wday, so
+// the only differing component is the calendar-conversion algorithm.
 
-inline bool isLeap(int64_t y) {
-  return y % 4 == 0 && (y % 100 != 0 || y % 400 == 0);
-}
-inline int64_t leapThroughEndOf(int64_t y) {
-  y += kLeapYearOffset;
-  return y / 4 - y / 100 + y / 400;
-}
-inline int64_t daysBetweenYears(int64_t y1, int64_t y2) {
-  return 365 * (y2 - y1) + leapThroughEndOf(y2 - 1) - leapThroughEndOf(y1 - 1);
-}
-const int16_t daysBeforeFirstDayOfMonth[][12] = {
-    {0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334},
-    {0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335},
-};
-
-// noinline so we pay one function-call layer here too, matching the
-// non-inlined Timestamp::epochToCalendarUtc on the patched side (its
-// definition lives in a separate TU, so it can't be inlined into the
-// bench's runNeriSchneider wrapper).
-__attribute__((noinline)) bool epochToCalendarUtc(int64_t epoch, std::tm& tm) {
-  constexpr int kDaysPerYear = 365;
-  int64_t days = epoch / kSecondsPerDay;
-  int64_t rem = epoch % kSecondsPerDay;
-  while (rem < 0) {
-    rem += kSecondsPerDay;
-    --days;
-  }
-  tm.tm_hour = rem / kSecondsPerHour;
-  rem = rem % kSecondsPerHour;
-  tm.tm_min = rem / 60;
-  tm.tm_sec = rem % 60;
-  tm.tm_wday = (4 + days) % 7;
-  if (tm.tm_wday < 0) {
-    tm.tm_wday += 7;
-  }
-  int64_t y = 1970;
-  if (y + days / kDaysPerYear <= -kLeapYearOffset + 10) {
-    return false;
-  }
-  bool leapYear;
-  while (days < 0 || days >= kDaysPerYear + (leapYear = isLeap(y))) {
-    auto newy = y + days / kDaysPerYear - (days < 0);
-    days -= daysBetweenYears(y, newy);
-    y = newy;
-  }
-  y -= kTmYearBase;
-  tm.tm_year = static_cast<int>(y);
-  tm.tm_yday = static_cast<int>(days);
-  const auto* months = daysBeforeFirstDayOfMonth[leapYear];
-  tm.tm_mon = static_cast<int>(
-      std::upper_bound(months, months + 12, days) - months - 1);
-  tm.tm_mday = static_cast<int>(days - months[tm.tm_mon] + 1);
-  tm.tm_isdst = 0;
-  return true;
-}
-} // namespace legacy_loop
-
-__attribute__((noinline)) uint64_t runLegacyLoop(
+__attribute__((noinline)) uint64_t runWideRange(
     const std::vector<int32_t>& days) {
   uint64_t sum = 0;
   std::tm tm;
   for (int32_t d : days) {
-    legacy_loop::epochToCalendarUtc(int64_t{d} * 86400, tm);
+    WideRangeDateConversion::epochToCalendarUtc(int64_t{d} * 86400, tm);
     sum += static_cast<uint64_t>(tm.tm_year) +
         static_cast<uint64_t>(tm.tm_mon) +
         static_cast<uint64_t>(tm.tm_mday);
@@ -145,10 +88,6 @@ __attribute__((noinline)) uint64_t runLegacyLoop(
   return sum;
 }
 
-// --- Chosen path: the patched public API (Timestamp::epochToCalendarUtc) --
-// Calling the production API rather than daysToYmd directly so the ratio
-// against legacy_loop is apples-to-apples — both fill a full std::tm and
-// pay the fast-path range check.
 __attribute__((noinline)) uint64_t runNeriSchneider(
     const std::vector<int32_t>& days) {
   uint64_t sum = 0;
@@ -162,8 +101,8 @@ __attribute__((noinline)) uint64_t runNeriSchneider(
   return sum;
 }
 
-BENCHMARK(legacy_loop_tight) {
-  folly::doNotOptimizeAway(runLegacyLoop(tightDays));
+BENCHMARK(wide_range_tight) {
+  folly::doNotOptimizeAway(runWideRange(tightDays));
 }
 BENCHMARK_RELATIVE(neri_schneider_tight) {
   folly::doNotOptimizeAway(runNeriSchneider(tightDays));
@@ -171,8 +110,8 @@ BENCHMARK_RELATIVE(neri_schneider_tight) {
 
 BENCHMARK_DRAW_LINE();
 
-BENCHMARK(legacy_loop_wide) {
-  folly::doNotOptimizeAway(runLegacyLoop(wideDays));
+BENCHMARK(wide_range_wide) {
+  folly::doNotOptimizeAway(runWideRange(wideDays));
 }
 BENCHMARK_RELATIVE(neri_schneider_wide) {
   folly::doNotOptimizeAway(runNeriSchneider(wideDays));
@@ -180,150 +119,34 @@ BENCHMARK_RELATIVE(neri_schneider_wide) {
 
 BENCHMARK_DRAW_LINE();
 
-// --- Inverse direction: (year, month, day) -> epoch-days ----------------
+// --- Inverse direction: (year, month, day) -> epoch-days -----------------
+// Same contestant pair, both validating via isValidDate and wrapping the
+// result in Expected<int64_t>.
 
-// Verbatim copy of the pre-patch body of util::daysSinceEpochFromDate
-// (validation + loop + table). Kept here so the bench can keep reproducing
-// the "before" number after the patch lands; calling the live API would
-// just measure the new fast path. Same validation and Expected<> wrapping
-// as the production code so the comparison against the patched API is
-// apples-to-apples.
-namespace legacy_loop_inv {
-constexpr int32_t kYearInterval = 400;
-constexpr int32_t kDaysPerYearInterval = 146097;
-constexpr int32_t kCumulativeDays[] =
-    {0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365};
-constexpr int32_t kCumulativeLeapDays[] =
-    {0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366};
-// For isValidDate: days-in-month tables and proleptic year bounds. These
-// values are identical to the production constants in TimestampConversion.h
-// and are validated by FastDateTest.
-constexpr int32_t kLeapDays[] =
-    {0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
-constexpr int32_t kNormalDays[] =
-    {0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
-constexpr int32_t kMinYear = -292'275'055;
-constexpr int32_t kMaxYear = 292'278'994;
-constexpr int32_t kCumulativeYearDays[] = {
-    0,      365,    730,    1096,   1461,   1826,   2191,   2557,   2922,
-    3287,   3652,   4018,   4383,   4748,   5113,   5479,   5844,   6209,
-    6574,   6940,   7305,   7670,   8035,   8401,   8766,   9131,   9496,
-    9862,   10227,  10592,  10957,  11323,  11688,  12053,  12418,  12784,
-    13149,  13514,  13879,  14245,  14610,  14975,  15340,  15706,  16071,
-    16436,  16801,  17167,  17532,  17897,  18262,  18628,  18993,  19358,
-    19723,  20089,  20454,  20819,  21184,  21550,  21915,  22280,  22645,
-    23011,  23376,  23741,  24106,  24472,  24837,  25202,  25567,  25933,
-    26298,  26663,  27028,  27394,  27759,  28124,  28489,  28855,  29220,
-    29585,  29950,  30316,  30681,  31046,  31411,  31777,  32142,  32507,
-    32872,  33238,  33603,  33968,  34333,  34699,  35064,  35429,  35794,
-    36160,  36525,  36890,  37255,  37621,  37986,  38351,  38716,  39082,
-    39447,  39812,  40177,  40543,  40908,  41273,  41638,  42004,  42369,
-    42734,  43099,  43465,  43830,  44195,  44560,  44926,  45291,  45656,
-    46021,  46387,  46752,  47117,  47482,  47847,  48212,  48577,  48942,
-    49308,  49673,  50038,  50403,  50769,  51134,  51499,  51864,  52230,
-    52595,  52960,  53325,  53691,  54056,  54421,  54786,  55152,  55517,
-    55882,  56247,  56613,  56978,  57343,  57708,  58074,  58439,  58804,
-    59169,  59535,  59900,  60265,  60630,  60996,  61361,  61726,  62091,
-    62457,  62822,  63187,  63552,  63918,  64283,  64648,  65013,  65379,
-    65744,  66109,  66474,  66840,  67205,  67570,  67935,  68301,  68666,
-    69031,  69396,  69762,  70127,  70492,  70857,  71223,  71588,  71953,
-    72318,  72684,  73049,  73414,  73779,  74145,  74510,  74875,  75240,
-    75606,  75971,  76336,  76701,  77067,  77432,  77797,  78162,  78528,
-    78893,  79258,  79623,  79989,  80354,  80719,  81084,  81450,  81815,
-    82180,  82545,  82911,  83276,  83641,  84006,  84371,  84736,  85101,
-    85466,  85832,  86197,  86562,  86927,  87293,  87658,  88023,  88388,
-    88754,  89119,  89484,  89849,  90215,  90580,  90945,  91310,  91676,
-    92041,  92406,  92771,  93137,  93502,  93867,  94232,  94598,  94963,
-    95328,  95693,  96059,  96424,  96789,  97154,  97520,  97885,  98250,
-    98615,  98981,  99346,  99711,  100076, 100442, 100807, 101172, 101537,
-    101903, 102268, 102633, 102998, 103364, 103729, 104094, 104459, 104825,
-    105190, 105555, 105920, 106286, 106651, 107016, 107381, 107747, 108112,
-    108477, 108842, 109208, 109573, 109938, 110303, 110669, 111034, 111399,
-    111764, 112130, 112495, 112860, 113225, 113591, 113956, 114321, 114686,
-    115052, 115417, 115782, 116147, 116513, 116878, 117243, 117608, 117974,
-    118339, 118704, 119069, 119435, 119800, 120165, 120530, 120895, 121260,
-    121625, 121990, 122356, 122721, 123086, 123451, 123817, 124182, 124547,
-    124912, 125278, 125643, 126008, 126373, 126739, 127104, 127469, 127834,
-    128200, 128565, 128930, 129295, 129661, 130026, 130391, 130756, 131122,
-    131487, 131852, 132217, 132583, 132948, 133313, 133678, 134044, 134409,
-    134774, 135139, 135505, 135870, 136235, 136600, 136966, 137331, 137696,
-    138061, 138427, 138792, 139157, 139522, 139888, 140253, 140618, 140983,
-    141349, 141714, 142079, 142444, 142810, 143175, 143540, 143905, 144271,
-    144636, 145001, 145366, 145732, 146097,
-};
-
-inline bool isLeapYear(int32_t y) {
-  return y % 4 == 0 && (y % 100 != 0 || y % 400 == 0);
-}
-
-inline bool isValidDate(int32_t year, int32_t month, int32_t day) {
-  if (month < 1 || month > 12) {
-    return false;
-  }
-  if (year < kMinYear || year > kMaxYear) {
-    return false;
-  }
-  if (day < 1) {
-    return false;
-  }
-  return isLeapYear(year) ? day <= kLeapDays[month]
-                          : day <= kNormalDays[month];
-}
-
-// noinline for the same reason as legacy_loop::epochToCalendarUtc above:
-// match the non-inlinable production util::daysSinceEpochFromDate on the
-// patched side.
-__attribute__((noinline)) facebook::velox::Expected<int64_t>
-daysSinceEpochFromDate(int32_t year, int32_t month, int32_t day) {
-  if (!isValidDate(year, month, day)) {
-    return folly::makeUnexpected(facebook::velox::Status::UserError(
-        "Date out of range: {}-{}-{}", year, month, day));
-  }
-  int64_t daysSinceEpoch = 0;
-  while (year < 1970) {
-    year += kYearInterval;
-    daysSinceEpoch -= kDaysPerYearInterval;
-  }
-  while (year >= 2370) {
-    year -= kYearInterval;
-    daysSinceEpoch += kDaysPerYearInterval;
-  }
-  daysSinceEpoch += kCumulativeYearDays[year - 1970];
-  daysSinceEpoch += isLeapYear(year) ? kCumulativeLeapDays[month - 1]
-                                     : kCumulativeDays[month - 1];
-  daysSinceEpoch += day - 1;
-  return daysSinceEpoch;
-}
-} // namespace legacy_loop_inv
-
-__attribute__((noinline)) uint64_t runLegacyLoopInv(
+__attribute__((noinline)) uint64_t runWideRangeInv(
     const std::vector<Ymd>& v) {
   uint64_t s = 0;
   for (const auto& x : v) {
     s += static_cast<uint64_t>(
-        legacy_loop_inv::daysSinceEpochFromDate(x.year, x.month, x.day)
-            .value());
-  }
-  return s;
-}
-
-// Calling the patched public API so the comparison against legacy_loop_inv
-// is apples-to-apples — both contestants run isValidDate, both wrap the
-// result in Expected<>, the only difference is the conversion algorithm.
-__attribute__((noinline)) uint64_t runNeriSchneiderInv(
-    const std::vector<Ymd>& v) {
-  uint64_t s = 0;
-  for (const auto& x : v) {
-    s += static_cast<uint64_t>(
-        facebook::velox::util::daysSinceEpochFromDate(
+        WideRangeDateConversion::daysSinceEpochFromDate(
             x.year, x.month, x.day)
             .value());
   }
   return s;
 }
 
-BENCHMARK(legacy_loop_inv_tight) {
-  folly::doNotOptimizeAway(runLegacyLoopInv(tightYmd));
+__attribute__((noinline)) uint64_t runNeriSchneiderInv(
+    const std::vector<Ymd>& v) {
+  uint64_t s = 0;
+  for (const auto& x : v) {
+    s += static_cast<uint64_t>(
+        util::daysSinceEpochFromDate(x.year, x.month, x.day).value());
+  }
+  return s;
+}
+
+BENCHMARK(wide_range_inv_tight) {
+  folly::doNotOptimizeAway(runWideRangeInv(tightYmd));
 }
 BENCHMARK_RELATIVE(neri_schneider_inv_tight) {
   folly::doNotOptimizeAway(runNeriSchneiderInv(tightYmd));
@@ -331,8 +154,8 @@ BENCHMARK_RELATIVE(neri_schneider_inv_tight) {
 
 BENCHMARK_DRAW_LINE();
 
-BENCHMARK(legacy_loop_inv_wide) {
-  folly::doNotOptimizeAway(runLegacyLoopInv(wideYmd));
+BENCHMARK(wide_range_inv_wide) {
+  folly::doNotOptimizeAway(runWideRangeInv(wideYmd));
 }
 BENCHMARK_RELATIVE(neri_schneider_inv_wide) {
   folly::doNotOptimizeAway(runNeriSchneiderInv(wideYmd));
@@ -354,26 +177,6 @@ int main(int argc, char** argv) {
   // ground-truth reference, not as a bench contestant).
   fillYmd(tightYmd, tightDays);
   fillYmd(wideYmd, wideDays);
-
-  // Sanity-check that the legacy and patched paths agree on the tight
-  // workload — catches integration bugs where the patched
-  // Timestamp::epochToCalendarUtc fails to fill std::tm correctly.
-  for (size_t i = 0; i < std::min<size_t>(tightDays.size(), 1000); ++i) {
-    const int32_t d = tightDays[i];
-    std::tm legacyTm;
-    std::tm patchedTm;
-    if (!legacy_loop::epochToCalendarUtc(int64_t{d} * 86400, legacyTm)) {
-      continue;
-    }
-    if (!Timestamp::epochToCalendarUtc(int64_t{d} * 86400, patchedTm)) {
-      LOG(FATAL) << "patched epochToCalendarUtc returned false at day=" << d;
-    }
-    if (legacyTm.tm_year != patchedTm.tm_year ||
-        legacyTm.tm_mon != patchedTm.tm_mon ||
-        legacyTm.tm_mday != patchedTm.tm_mday) {
-      LOG(FATAL) << "legacy/patched disagree at day=" << d;
-    }
-  }
 
   folly::runBenchmarks();
   return 0;

--- a/velox/type/tests/DateConversionBenchmark.cpp
+++ b/velox/type/tests/DateConversionBenchmark.cpp
@@ -56,11 +56,12 @@ void fillYmd(std::vector<Ymd>& out, const std::vector<int32_t>& days) {
   out.reserve(days.size());
   for (int32_t d : days) {
     const date::year_month_day ymd{date::sys_days{date::days{d}}};
-    out.push_back(Ymd{
-        static_cast<int32_t>(static_cast<int64_t>(ymd.year())),
-        static_cast<unsigned>(ymd.month()),
-        static_cast<unsigned>(ymd.day()),
-    });
+    out.push_back(
+        Ymd{
+            static_cast<int32_t>(static_cast<int64_t>(ymd.year())),
+            static_cast<unsigned>(ymd.month()),
+            static_cast<unsigned>(ymd.day()),
+        });
   }
 }
 
@@ -75,28 +76,26 @@ void fillYmd(std::vector<Ymd>& out, const std::vector<int32_t>& days) {
 // Both fill the full std::tm including tm_hour/tm_min/tm_sec/tm_wday, so
 // the only differing component is the calendar-conversion algorithm.
 
-__attribute__((noinline)) uint64_t runWideRange(
-    const std::vector<int32_t>& days) {
+__attribute__((noinline)) uint64_t
+runWideRange(const std::vector<int32_t>& days) {
   uint64_t sum = 0;
   std::tm tm;
   for (int32_t d : days) {
     WideRangeDateConversion::epochToCalendarUtc(int64_t{d} * 86400, tm);
     sum += static_cast<uint64_t>(tm.tm_year) +
-        static_cast<uint64_t>(tm.tm_mon) +
-        static_cast<uint64_t>(tm.tm_mday);
+        static_cast<uint64_t>(tm.tm_mon) + static_cast<uint64_t>(tm.tm_mday);
   }
   return sum;
 }
 
-__attribute__((noinline)) uint64_t runNeriSchneider(
-    const std::vector<int32_t>& days) {
+__attribute__((noinline)) uint64_t
+runNeriSchneider(const std::vector<int32_t>& days) {
   uint64_t sum = 0;
   std::tm tm;
   for (int32_t d : days) {
     Timestamp::epochToCalendarUtc(int64_t{d} * 86400, tm);
     sum += static_cast<uint64_t>(tm.tm_year) +
-        static_cast<uint64_t>(tm.tm_mon) +
-        static_cast<uint64_t>(tm.tm_mday);
+        static_cast<uint64_t>(tm.tm_mon) + static_cast<uint64_t>(tm.tm_mday);
   }
   return sum;
 }
@@ -123,20 +122,18 @@ BENCHMARK_DRAW_LINE();
 // Same contestant pair, both validating via isValidDate and wrapping the
 // result in Expected<int64_t>.
 
-__attribute__((noinline)) uint64_t runWideRangeInv(
-    const std::vector<Ymd>& v) {
+__attribute__((noinline)) uint64_t runWideRangeInv(const std::vector<Ymd>& v) {
   uint64_t s = 0;
   for (const auto& x : v) {
     s += static_cast<uint64_t>(
-        WideRangeDateConversion::daysSinceEpochFromDate(
-            x.year, x.month, x.day)
+        WideRangeDateConversion::daysSinceEpochFromDate(x.year, x.month, x.day)
             .value());
   }
   return s;
 }
 
-__attribute__((noinline)) uint64_t runNeriSchneiderInv(
-    const std::vector<Ymd>& v) {
+__attribute__((noinline)) uint64_t
+runNeriSchneiderInv(const std::vector<Ymd>& v) {
   uint64_t s = 0;
   for (const auto& x : v) {
     s += static_cast<uint64_t>(

--- a/velox/type/tests/DateConversionBenchmark.cpp
+++ b/velox/type/tests/DateConversionBenchmark.cpp
@@ -1,0 +1,380 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include <random>
+#include "velox/external/date/date.h"
+#include "velox/type/FastDate.h"
+#include "velox/type/Timestamp.h"
+#include "velox/type/TimestampConversion.h"
+
+using namespace facebook::velox;
+
+namespace {
+
+constexpr int32_t kNumValues = 1'000'000;
+
+// Workloads with different ranges of input days. "Tight" represents typical
+// query data; "wide" exercises the algorithm closer to its limits.
+std::vector<int32_t> tightDays; // ~+/- 70 years from epoch.
+std::vector<int32_t> wideDays; // full int32 range.
+
+struct Ymd {
+  int32_t year;
+  uint32_t month;
+  uint32_t day;
+};
+std::vector<Ymd> tightYmd;
+std::vector<Ymd> wideYmd;
+
+void fillDays(std::vector<int32_t>& out, int32_t lo, int32_t hi) {
+  std::mt19937 rng{0xBEEF};
+  std::uniform_int_distribution<int32_t> dist{lo, hi};
+  out.resize(kNumValues);
+  for (auto& d : out) {
+    d = dist(rng);
+  }
+}
+
+void fillYmd(std::vector<Ymd>& out, const std::vector<int32_t>& days) {
+  out.clear();
+  out.reserve(days.size());
+  for (int32_t d : days) {
+    const date::year_month_day ymd{date::sys_days{date::days{d}}};
+    out.push_back(Ymd{
+        static_cast<int32_t>(static_cast<int64_t>(ymd.year())),
+        static_cast<unsigned>(ymd.month()),
+        static_cast<unsigned>(ymd.day()),
+    });
+  }
+}
+
+// --- Velox's pre-patch implementation, inlined ---------------------------
+// Verbatim copy of the loop-based body that lived in
+// velox/type/Timestamp.cpp:epochToCalendarUtc before this PR. Kept here so
+// the bench can keep reproducing the "before" number after the patch lands;
+// otherwise calling Timestamp::epochToCalendarUtc directly would just
+// measure the new fast path again.
+namespace legacy_loop {
+constexpr int kTmYearBase = 1900;
+constexpr int64_t kLeapYearOffset = 4'000'000'000LL;
+constexpr int64_t kSecondsPerHour = 3600;
+constexpr int64_t kSecondsPerDay = 24 * kSecondsPerHour;
+
+inline bool isLeap(int64_t y) {
+  return y % 4 == 0 && (y % 100 != 0 || y % 400 == 0);
+}
+inline int64_t leapThroughEndOf(int64_t y) {
+  y += kLeapYearOffset;
+  return y / 4 - y / 100 + y / 400;
+}
+inline int64_t daysBetweenYears(int64_t y1, int64_t y2) {
+  return 365 * (y2 - y1) + leapThroughEndOf(y2 - 1) - leapThroughEndOf(y1 - 1);
+}
+const int16_t daysBeforeFirstDayOfMonth[][12] = {
+    {0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334},
+    {0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335},
+};
+
+// noinline so we pay one function-call layer here too, matching the
+// non-inlined Timestamp::epochToCalendarUtc on the patched side (its
+// definition lives in a separate TU, so it can't be inlined into the
+// bench's runNeriSchneider wrapper).
+__attribute__((noinline)) bool epochToCalendarUtc(int64_t epoch, std::tm& tm) {
+  constexpr int kDaysPerYear = 365;
+  int64_t days = epoch / kSecondsPerDay;
+  int64_t rem = epoch % kSecondsPerDay;
+  while (rem < 0) {
+    rem += kSecondsPerDay;
+    --days;
+  }
+  tm.tm_hour = rem / kSecondsPerHour;
+  rem = rem % kSecondsPerHour;
+  tm.tm_min = rem / 60;
+  tm.tm_sec = rem % 60;
+  tm.tm_wday = (4 + days) % 7;
+  if (tm.tm_wday < 0) {
+    tm.tm_wday += 7;
+  }
+  int64_t y = 1970;
+  if (y + days / kDaysPerYear <= -kLeapYearOffset + 10) {
+    return false;
+  }
+  bool leapYear;
+  while (days < 0 || days >= kDaysPerYear + (leapYear = isLeap(y))) {
+    auto newy = y + days / kDaysPerYear - (days < 0);
+    days -= daysBetweenYears(y, newy);
+    y = newy;
+  }
+  y -= kTmYearBase;
+  tm.tm_year = static_cast<int>(y);
+  tm.tm_yday = static_cast<int>(days);
+  const auto* months = daysBeforeFirstDayOfMonth[leapYear];
+  tm.tm_mon = static_cast<int>(
+      std::upper_bound(months, months + 12, days) - months - 1);
+  tm.tm_mday = static_cast<int>(days - months[tm.tm_mon] + 1);
+  tm.tm_isdst = 0;
+  return true;
+}
+} // namespace legacy_loop
+
+__attribute__((noinline)) uint64_t runLegacyLoop(
+    const std::vector<int32_t>& days) {
+  uint64_t sum = 0;
+  std::tm tm;
+  for (int32_t d : days) {
+    legacy_loop::epochToCalendarUtc(int64_t{d} * 86400, tm);
+    sum += static_cast<uint64_t>(tm.tm_year) +
+        static_cast<uint64_t>(tm.tm_mon) +
+        static_cast<uint64_t>(tm.tm_mday);
+  }
+  return sum;
+}
+
+// --- Chosen path: the patched public API (Timestamp::epochToCalendarUtc) --
+// Calling the production API rather than daysToYmd directly so the ratio
+// against legacy_loop is apples-to-apples — both fill a full std::tm and
+// pay the fast-path range check.
+__attribute__((noinline)) uint64_t runNeriSchneider(
+    const std::vector<int32_t>& days) {
+  uint64_t sum = 0;
+  std::tm tm;
+  for (int32_t d : days) {
+    Timestamp::epochToCalendarUtc(int64_t{d} * 86400, tm);
+    sum += static_cast<uint64_t>(tm.tm_year) +
+        static_cast<uint64_t>(tm.tm_mon) +
+        static_cast<uint64_t>(tm.tm_mday);
+  }
+  return sum;
+}
+
+BENCHMARK(legacy_loop_tight) {
+  folly::doNotOptimizeAway(runLegacyLoop(tightDays));
+}
+BENCHMARK_RELATIVE(neri_schneider_tight) {
+  folly::doNotOptimizeAway(runNeriSchneider(tightDays));
+}
+
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK(legacy_loop_wide) {
+  folly::doNotOptimizeAway(runLegacyLoop(wideDays));
+}
+BENCHMARK_RELATIVE(neri_schneider_wide) {
+  folly::doNotOptimizeAway(runNeriSchneider(wideDays));
+}
+
+BENCHMARK_DRAW_LINE();
+
+// --- Inverse direction: (year, month, day) -> epoch-days ----------------
+
+// Verbatim copy of the pre-patch body of util::daysSinceEpochFromDate
+// (validation + loop + table). Kept here so the bench can keep reproducing
+// the "before" number after the patch lands; calling the live API would
+// just measure the new fast path. Same validation and Expected<> wrapping
+// as the production code so the comparison against the patched API is
+// apples-to-apples.
+namespace legacy_loop_inv {
+constexpr int32_t kYearInterval = 400;
+constexpr int32_t kDaysPerYearInterval = 146097;
+constexpr int32_t kCumulativeDays[] =
+    {0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365};
+constexpr int32_t kCumulativeLeapDays[] =
+    {0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366};
+// For isValidDate: days-in-month tables and proleptic year bounds. These
+// values are identical to the production constants in TimestampConversion.h
+// and are validated by FastDateTest.
+constexpr int32_t kLeapDays[] =
+    {0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+constexpr int32_t kNormalDays[] =
+    {0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+constexpr int32_t kMinYear = -292'275'055;
+constexpr int32_t kMaxYear = 292'278'994;
+constexpr int32_t kCumulativeYearDays[] = {
+    0,      365,    730,    1096,   1461,   1826,   2191,   2557,   2922,
+    3287,   3652,   4018,   4383,   4748,   5113,   5479,   5844,   6209,
+    6574,   6940,   7305,   7670,   8035,   8401,   8766,   9131,   9496,
+    9862,   10227,  10592,  10957,  11323,  11688,  12053,  12418,  12784,
+    13149,  13514,  13879,  14245,  14610,  14975,  15340,  15706,  16071,
+    16436,  16801,  17167,  17532,  17897,  18262,  18628,  18993,  19358,
+    19723,  20089,  20454,  20819,  21184,  21550,  21915,  22280,  22645,
+    23011,  23376,  23741,  24106,  24472,  24837,  25202,  25567,  25933,
+    26298,  26663,  27028,  27394,  27759,  28124,  28489,  28855,  29220,
+    29585,  29950,  30316,  30681,  31046,  31411,  31777,  32142,  32507,
+    32872,  33238,  33603,  33968,  34333,  34699,  35064,  35429,  35794,
+    36160,  36525,  36890,  37255,  37621,  37986,  38351,  38716,  39082,
+    39447,  39812,  40177,  40543,  40908,  41273,  41638,  42004,  42369,
+    42734,  43099,  43465,  43830,  44195,  44560,  44926,  45291,  45656,
+    46021,  46387,  46752,  47117,  47482,  47847,  48212,  48577,  48942,
+    49308,  49673,  50038,  50403,  50769,  51134,  51499,  51864,  52230,
+    52595,  52960,  53325,  53691,  54056,  54421,  54786,  55152,  55517,
+    55882,  56247,  56613,  56978,  57343,  57708,  58074,  58439,  58804,
+    59169,  59535,  59900,  60265,  60630,  60996,  61361,  61726,  62091,
+    62457,  62822,  63187,  63552,  63918,  64283,  64648,  65013,  65379,
+    65744,  66109,  66474,  66840,  67205,  67570,  67935,  68301,  68666,
+    69031,  69396,  69762,  70127,  70492,  70857,  71223,  71588,  71953,
+    72318,  72684,  73049,  73414,  73779,  74145,  74510,  74875,  75240,
+    75606,  75971,  76336,  76701,  77067,  77432,  77797,  78162,  78528,
+    78893,  79258,  79623,  79989,  80354,  80719,  81084,  81450,  81815,
+    82180,  82545,  82911,  83276,  83641,  84006,  84371,  84736,  85101,
+    85466,  85832,  86197,  86562,  86927,  87293,  87658,  88023,  88388,
+    88754,  89119,  89484,  89849,  90215,  90580,  90945,  91310,  91676,
+    92041,  92406,  92771,  93137,  93502,  93867,  94232,  94598,  94963,
+    95328,  95693,  96059,  96424,  96789,  97154,  97520,  97885,  98250,
+    98615,  98981,  99346,  99711,  100076, 100442, 100807, 101172, 101537,
+    101903, 102268, 102633, 102998, 103364, 103729, 104094, 104459, 104825,
+    105190, 105555, 105920, 106286, 106651, 107016, 107381, 107747, 108112,
+    108477, 108842, 109208, 109573, 109938, 110303, 110669, 111034, 111399,
+    111764, 112130, 112495, 112860, 113225, 113591, 113956, 114321, 114686,
+    115052, 115417, 115782, 116147, 116513, 116878, 117243, 117608, 117974,
+    118339, 118704, 119069, 119435, 119800, 120165, 120530, 120895, 121260,
+    121625, 121990, 122356, 122721, 123086, 123451, 123817, 124182, 124547,
+    124912, 125278, 125643, 126008, 126373, 126739, 127104, 127469, 127834,
+    128200, 128565, 128930, 129295, 129661, 130026, 130391, 130756, 131122,
+    131487, 131852, 132217, 132583, 132948, 133313, 133678, 134044, 134409,
+    134774, 135139, 135505, 135870, 136235, 136600, 136966, 137331, 137696,
+    138061, 138427, 138792, 139157, 139522, 139888, 140253, 140618, 140983,
+    141349, 141714, 142079, 142444, 142810, 143175, 143540, 143905, 144271,
+    144636, 145001, 145366, 145732, 146097,
+};
+
+inline bool isLeapYear(int32_t y) {
+  return y % 4 == 0 && (y % 100 != 0 || y % 400 == 0);
+}
+
+inline bool isValidDate(int32_t year, int32_t month, int32_t day) {
+  if (month < 1 || month > 12) {
+    return false;
+  }
+  if (year < kMinYear || year > kMaxYear) {
+    return false;
+  }
+  if (day < 1) {
+    return false;
+  }
+  return isLeapYear(year) ? day <= kLeapDays[month]
+                          : day <= kNormalDays[month];
+}
+
+// noinline for the same reason as legacy_loop::epochToCalendarUtc above:
+// match the non-inlinable production util::daysSinceEpochFromDate on the
+// patched side.
+__attribute__((noinline)) facebook::velox::Expected<int64_t>
+daysSinceEpochFromDate(int32_t year, int32_t month, int32_t day) {
+  if (!isValidDate(year, month, day)) {
+    return folly::makeUnexpected(facebook::velox::Status::UserError(
+        "Date out of range: {}-{}-{}", year, month, day));
+  }
+  int64_t daysSinceEpoch = 0;
+  while (year < 1970) {
+    year += kYearInterval;
+    daysSinceEpoch -= kDaysPerYearInterval;
+  }
+  while (year >= 2370) {
+    year -= kYearInterval;
+    daysSinceEpoch += kDaysPerYearInterval;
+  }
+  daysSinceEpoch += kCumulativeYearDays[year - 1970];
+  daysSinceEpoch += isLeapYear(year) ? kCumulativeLeapDays[month - 1]
+                                     : kCumulativeDays[month - 1];
+  daysSinceEpoch += day - 1;
+  return daysSinceEpoch;
+}
+} // namespace legacy_loop_inv
+
+__attribute__((noinline)) uint64_t runLegacyLoopInv(
+    const std::vector<Ymd>& v) {
+  uint64_t s = 0;
+  for (const auto& x : v) {
+    s += static_cast<uint64_t>(
+        legacy_loop_inv::daysSinceEpochFromDate(x.year, x.month, x.day)
+            .value());
+  }
+  return s;
+}
+
+// Calling the patched public API so the comparison against legacy_loop_inv
+// is apples-to-apples — both contestants run isValidDate, both wrap the
+// result in Expected<>, the only difference is the conversion algorithm.
+__attribute__((noinline)) uint64_t runNeriSchneiderInv(
+    const std::vector<Ymd>& v) {
+  uint64_t s = 0;
+  for (const auto& x : v) {
+    s += static_cast<uint64_t>(
+        facebook::velox::util::daysSinceEpochFromDate(
+            x.year, x.month, x.day)
+            .value());
+  }
+  return s;
+}
+
+BENCHMARK(legacy_loop_inv_tight) {
+  folly::doNotOptimizeAway(runLegacyLoopInv(tightYmd));
+}
+BENCHMARK_RELATIVE(neri_schneider_inv_tight) {
+  folly::doNotOptimizeAway(runNeriSchneiderInv(tightYmd));
+}
+
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK(legacy_loop_inv_wide) {
+  folly::doNotOptimizeAway(runLegacyLoopInv(wideYmd));
+}
+BENCHMARK_RELATIVE(neri_schneider_inv_wide) {
+  folly::doNotOptimizeAway(runNeriSchneiderInv(wideYmd));
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  folly::Init init{&argc, &argv};
+
+  // Tight workload: roughly 1900-2040.
+  fillDays(tightDays, -25'567, 25'567);
+  // Wide workload: bounded by the algorithm's exact range. Still spans
+  // ~3 million years, far wider than any practical Velox DATE.
+  fillDays(wideDays, fast_date::kRataDieMin, fast_date::kRataDieMax);
+
+  // Build matching y/m/d inputs for the inverse direction by running the
+  // same days through the vendored Hinnant date library (used as the
+  // ground-truth reference, not as a bench contestant).
+  fillYmd(tightYmd, tightDays);
+  fillYmd(wideYmd, wideDays);
+
+  // Sanity-check that the legacy and patched paths agree on the tight
+  // workload — catches integration bugs where the patched
+  // Timestamp::epochToCalendarUtc fails to fill std::tm correctly.
+  for (size_t i = 0; i < std::min<size_t>(tightDays.size(), 1000); ++i) {
+    const int32_t d = tightDays[i];
+    std::tm legacyTm;
+    std::tm patchedTm;
+    if (!legacy_loop::epochToCalendarUtc(int64_t{d} * 86400, legacyTm)) {
+      continue;
+    }
+    if (!Timestamp::epochToCalendarUtc(int64_t{d} * 86400, patchedTm)) {
+      LOG(FATAL) << "patched epochToCalendarUtc returned false at day=" << d;
+    }
+    if (legacyTm.tm_year != patchedTm.tm_year ||
+        legacyTm.tm_mon != patchedTm.tm_mon ||
+        legacyTm.tm_mday != patchedTm.tm_mday) {
+      LOG(FATAL) << "legacy/patched disagree at day=" << d;
+    }
+  }
+
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/type/tests/FastDateTest.cpp
+++ b/velox/type/tests/FastDateTest.cpp
@@ -22,6 +22,7 @@
 #include "velox/external/date/date.h"
 #include "velox/type/Timestamp.h"
 #include "velox/type/TimestampConversion.h"
+#include "velox/type/WideRangeDateConversion.h"
 
 namespace facebook::velox::test {
 namespace {
@@ -155,6 +156,20 @@ ReferenceYmd hinnantRef(int64_t days) {
       static_cast<unsigned>(ymd.day()),
   };
 }
+
+// Asserts that two std::tm structs agree on every field a caller of
+// epochToCalendarUtc could observe. tm_isdst is set to 0 by both paths.
+void expectTmEqual(const std::tm& a, const std::tm& b, int64_t epoch) {
+  EXPECT_EQ(a.tm_year, b.tm_year) << "epoch=" << epoch;
+  EXPECT_EQ(a.tm_mon, b.tm_mon) << "epoch=" << epoch;
+  EXPECT_EQ(a.tm_mday, b.tm_mday) << "epoch=" << epoch;
+  EXPECT_EQ(a.tm_yday, b.tm_yday) << "epoch=" << epoch;
+  EXPECT_EQ(a.tm_wday, b.tm_wday) << "epoch=" << epoch;
+  EXPECT_EQ(a.tm_hour, b.tm_hour) << "epoch=" << epoch;
+  EXPECT_EQ(a.tm_min, b.tm_min) << "epoch=" << epoch;
+  EXPECT_EQ(a.tm_sec, b.tm_sec) << "epoch=" << epoch;
+  EXPECT_EQ(a.tm_isdst, b.tm_isdst) << "epoch=" << epoch;
+}
 } // namespace
 
 TEST(FastDateTest, fuzzEpochToCalendarUtcMatchesHinnant) {
@@ -172,29 +187,40 @@ TEST(FastDateTest, fuzzEpochToCalendarUtcMatchesHinnant) {
       -(static_cast<int64_t>(fast_date::kYearMax) + 100'000) * 365 *
           kSecondsPerDay,
       -static_cast<int64_t>(fast_date::kRataDieMin - 1) * kSecondsPerDay};
+  // Random non-zero seconds-of-day so tm_hour/tm_min/tm_sec are exercised.
+  std::uniform_int_distribution<int64_t> secondsOfDay{0, kSecondsPerDay - 1};
 
   auto check = [](int64_t epoch) {
-    std::tm tm;
-    if (!Timestamp::epochToCalendarUtc(epoch, tm)) {
-      // Out-of-range outputs are an acceptable "false" return; just skip.
+    std::tm fastTm;
+    std::tm wideTm;
+    if (!Timestamp::epochToCalendarUtc(epoch, fastTm)) {
+      // Out-of-range outputs are an acceptable "false" return on both
+      // paths; just verify the wide path agrees and skip.
+      ASSERT_FALSE(WideRangeDateConversion::epochToCalendarUtc(epoch, wideTm))
+          << "epoch=" << epoch;
       return;
     }
-    const int64_t days = epochToDays(epoch);
-    const auto want = hinnantRef(days);
-    ASSERT_EQ(tm.tm_year + 1900, want.year) << "epoch=" << epoch;
-    ASSERT_EQ(tm.tm_mon + 1, want.month) << "epoch=" << epoch;
-    ASSERT_EQ(static_cast<unsigned>(tm.tm_mday), want.day) << "epoch=" << epoch;
+    ASSERT_TRUE(WideRangeDateConversion::epochToCalendarUtc(epoch, wideTm))
+        << "epoch=" << epoch;
+    // Full std::tm equality: y/m/d, yday, wday, hour, min, sec, isdst.
+    expectTmEqual(fastTm, wideTm, epoch);
+    // Independent cross-check of the date fields against Hinnant.
+    const auto want = hinnantRef(epochToDays(epoch));
+    ASSERT_EQ(fastTm.tm_year + 1900, want.year) << "epoch=" << epoch;
+    ASSERT_EQ(fastTm.tm_mon + 1, want.month) << "epoch=" << epoch;
+    ASSERT_EQ(static_cast<unsigned>(fastTm.tm_mday), want.day)
+        << "epoch=" << epoch;
   };
 
   for (int i = 0; i < 2'000'000; ++i) {
-    check(tight(rng));
+    check(tight(rng) + secondsOfDay(rng));
   }
   for (int i = 0; i < 2'000'000; ++i) {
-    check(wide(rng));
+    check(wide(rng) + secondsOfDay(rng));
   }
   // Fewer fallback samples: per-call cost is much higher (legacy loop).
   for (int i = 0; i < 500'000; ++i) {
-    check(fallback(rng));
+    check(fallback(rng) + secondsOfDay(rng));
   }
 }
 

--- a/velox/type/tests/FastDateTest.cpp
+++ b/velox/type/tests/FastDateTest.cpp
@@ -276,5 +276,48 @@ TEST(FastDateTest, fuzzDaysSinceEpochFromDateMatchesHinnant) {
   }
 }
 
+// Verifies that the patched fast path agrees with WideRangeDateConversion
+// at every value within ±10 of the four range boundaries. An off-by-one
+// in the dispatch range or in the algorithm's stated exact range would
+// silently route a few inputs to the wrong branch — this catches that.
+TEST(FastDateTest, fastEqualsWideRangeAtBoundaries) {
+  // Forward direction: ±10 days around kRataDieMin and kRataDieMax.
+  const int32_t forwardBoundaries[] = {
+      fast_date::kRataDieMin, fast_date::kRataDieMax};
+  for (int32_t boundary : forwardBoundaries) {
+    for (int32_t delta = -10; delta <= 10; ++delta) {
+      const int32_t days = boundary + delta;
+      // Mix in non-trivial seconds-of-day: 12:34:56 UTC.
+      const int64_t epoch =
+          static_cast<int64_t>(days) * kSecondsPerDay + 45'296;
+      std::tm fastTm;
+      std::tm wideTm;
+      ASSERT_TRUE(Timestamp::epochToCalendarUtc(epoch, fastTm))
+          << "days=" << days;
+      ASSERT_TRUE(WideRangeDateConversion::epochToCalendarUtc(epoch, wideTm))
+          << "days=" << days;
+      expectTmEqual(fastTm, wideTm, epoch);
+    }
+  }
+
+  // Inverse direction: ±10 years around kYearMin and kYearMax.
+  const int32_t inverseBoundaries[] = {
+      fast_date::kYearMin, fast_date::kYearMax};
+  for (int32_t boundary : inverseBoundaries) {
+    for (int32_t delta = -10; delta <= 10; ++delta) {
+      const int32_t year = boundary + delta;
+      // Use March 1 — same date as the forward boundaries above for
+      // visual cross-reference, and not affected by month-end edge cases.
+      const auto fastResult = util::daysSinceEpochFromDate(year, 3, 1);
+      const auto wideResult =
+          WideRangeDateConversion::daysSinceEpochFromDate(year, 3, 1);
+      ASSERT_EQ(fastResult.hasError(), wideResult.hasError()) << "y=" << year;
+      if (!fastResult.hasError()) {
+        EXPECT_EQ(fastResult.value(), wideResult.value()) << "y=" << year;
+      }
+    }
+  }
+}
+
 } // namespace
 } // namespace facebook::velox::test

--- a/velox/type/tests/FastDateTest.cpp
+++ b/velox/type/tests/FastDateTest.cpp
@@ -108,8 +108,8 @@ TEST(FastDateTest, boundaries) {
   for (int32_t centuryYear = fast_date::kYearMin + 100;
        centuryYear <= fast_date::kYearMax - 100;
        centuryYear += 100) {
-    const auto sd = date::sys_days{
-        date::year{centuryYear} / date::month{3} / date::day{1}};
+    const auto sd =
+        date::sys_days{date::year{centuryYear} / date::month{3} / date::day{1}};
     const int32_t d = sd.time_since_epoch().count();
     const auto got = daysToYmd(d);
     const auto want = hinnantYmd(d);

--- a/velox/type/tests/FastDateTest.cpp
+++ b/velox/type/tests/FastDateTest.cpp
@@ -181,12 +181,24 @@ TEST(FastDateTest, fuzzEpochToCalendarUtcMatchesHinnant) {
   std::uniform_int_distribution<int64_t> wide{
       static_cast<int64_t>(fast_date::kRataDieMin) * kSecondsPerDay,
       static_cast<int64_t>(fast_date::kRataDieMax) * kSecondsPerDay};
-  // Fallback: outside the algorithm range, exercising the legacy loop.
-  // Limit to int64 / 86400 so seconds * 86400 doesn't overflow on the way in.
-  std::uniform_int_distribution<int64_t> fallback{
+  // Fallback: outside the algorithm range on both sides of the epoch,
+  // exercising the legacy 400-year-step loop. Bound by the generous
+  // validation range (~+/- 290M years) but kept far enough from int64
+  // limits that seconds * 86400 doesn't overflow.
+  const int64_t fallbackPositiveStart =
+      static_cast<int64_t>(fast_date::kRataDieMax + 1) * kSecondsPerDay;
+  const int64_t fallbackPositiveEnd =
+      (static_cast<int64_t>(fast_date::kYearMax) + 100'000) * 365 *
+      kSecondsPerDay;
+  const int64_t fallbackNegativeEnd =
+      static_cast<int64_t>(fast_date::kRataDieMin - 1) * kSecondsPerDay;
+  const int64_t fallbackNegativeStart =
       -(static_cast<int64_t>(fast_date::kYearMax) + 100'000) * 365 *
-          kSecondsPerDay,
-      -static_cast<int64_t>(fast_date::kRataDieMin - 1) * kSecondsPerDay};
+      kSecondsPerDay;
+  std::uniform_int_distribution<int64_t> fallbackPositive{
+      fallbackPositiveStart, fallbackPositiveEnd};
+  std::uniform_int_distribution<int64_t> fallbackNegative{
+      fallbackNegativeStart, fallbackNegativeEnd};
   // Random non-zero seconds-of-day so tm_hour/tm_min/tm_sec are exercised.
   std::uniform_int_distribution<int64_t> secondsOfDay{0, kSecondsPerDay - 1};
 
@@ -218,9 +230,13 @@ TEST(FastDateTest, fuzzEpochToCalendarUtcMatchesHinnant) {
   for (int i = 0; i < 2'000'000; ++i) {
     check(wide(rng) + secondsOfDay(rng));
   }
-  // Fewer fallback samples: per-call cost is much higher (legacy loop).
+  // Fewer fallback samples per side — per-call cost is much higher (the
+  // legacy loop runs many iterations for years far from epoch).
   for (int i = 0; i < 500'000; ++i) {
-    check(fallback(rng) + secondsOfDay(rng));
+    check(fallbackPositive(rng) + secondsOfDay(rng));
+  }
+  for (int i = 0; i < 500'000; ++i) {
+    check(fallbackNegative(rng) + secondsOfDay(rng));
   }
 }
 
@@ -244,10 +260,13 @@ TEST(FastDateTest, fuzzDaysSinceEpochFromDateMatchesHinnant) {
   // Wide: algorithm domain.
   std::uniform_int_distribution<int32_t> wideYear{
       fast_date::kYearMin, fast_date::kYearMax};
-  // Fallback: outside the algorithm range, exercising the legacy 400-year
-  // step loop (year still within isValidDate's accepted range).
-  std::uniform_int_distribution<int32_t> fallbackYear{
+  // Fallback: outside the algorithm range on both sides, exercising the
+  // legacy 400-year step loops. Year stays within isValidDate's accepted
+  // [kMinYear, kMaxYear] range.
+  std::uniform_int_distribution<int32_t> fallbackPositiveYear{
       fast_date::kYearMax + 1, fast_date::kYearMax + 1'000'000};
+  std::uniform_int_distribution<int32_t> fallbackNegativeYear{
+      fast_date::kYearMin - 1'000'000, fast_date::kYearMin - 1};
 
   // Pick a valid day for the (year, month) pair so we don't trip
   // isValidDate's "31 Feb"-style rejections.
@@ -271,7 +290,11 @@ TEST(FastDateTest, fuzzDaysSinceEpochFromDateMatchesHinnant) {
     check(y, m, d);
   }
   for (int i = 0; i < 500'000; ++i) {
-    auto [y, m, d] = sample(fallbackYear(rng));
+    auto [y, m, d] = sample(fallbackPositiveYear(rng));
+    check(y, m, d);
+  }
+  for (int i = 0; i < 500'000; ++i) {
+    auto [y, m, d] = sample(fallbackNegativeYear(rng));
     check(y, m, d);
   }
 }

--- a/velox/type/tests/FastDateTest.cpp
+++ b/velox/type/tests/FastDateTest.cpp
@@ -323,17 +323,31 @@ TEST(FastDateTest, fastEqualsWideRangeAtBoundaries) {
     }
   }
 
-  // Inverse direction: ±10 years around kYearMin and kYearMax.
-  const int32_t inverseBoundaries[] = {
-      fast_date::kYearMin, fast_date::kYearMax};
-  for (int32_t boundary : inverseBoundaries) {
+  // Inverse direction: ±10 years around kYearMin and kYearMax. The date
+  // is chosen per boundary to lie *one day outside* the algorithm's
+  // exact range [Mar 1 kYearMin, Feb 28 kYearMax] at the boundary year:
+  //   kYearMin → Feb 28 — one day before Mar 1 kYearMin
+  //   kYearMax → Mar  1 — one day after  Feb 28 kYearMax
+  // This way, a future relaxation of the dispatch from strict (`<`) to
+  // inclusive (`<=`) would route a UB input to the fast path at either
+  // boundary, and the fast/wide mismatch (or crash) would fail this
+  // test. A single in-range date for both boundaries would only catch
+  // the regression at one end.
+  const struct {
+    int32_t boundary;
+    uint32_t month;
+    uint32_t day;
+  } inverseBoundaries[] = {
+      {fast_date::kYearMin, 2u, 28u},
+      {fast_date::kYearMax, 3u, 1u},
+  };
+  for (const auto& bound : inverseBoundaries) {
     for (int32_t delta = -10; delta <= 10; ++delta) {
-      const int32_t year = boundary + delta;
-      // Use March 1 — same date as the forward boundaries above for
-      // visual cross-reference, and not affected by month-end edge cases.
-      const auto fastResult = util::daysSinceEpochFromDate(year, 3, 1);
-      const auto wideResult =
-          WideRangeDateConversion::daysSinceEpochFromDate(year, 3, 1);
+      const int32_t year = bound.boundary + delta;
+      const auto fastResult =
+          util::daysSinceEpochFromDate(year, bound.month, bound.day);
+      const auto wideResult = WideRangeDateConversion::daysSinceEpochFromDate(
+          year, bound.month, bound.day);
       ASSERT_EQ(fastResult.hasError(), wideResult.hasError()) << "y=" << year;
       if (!fastResult.hasError()) {
         EXPECT_EQ(fastResult.value(), wideResult.value()) << "y=" << year;

--- a/velox/type/tests/FastDateTest.cpp
+++ b/velox/type/tests/FastDateTest.cpp
@@ -1,0 +1,254 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/type/FastDate.h"
+
+#include <gtest/gtest.h>
+#include <array>
+#include <random>
+#include "velox/external/date/date.h"
+#include "velox/type/Timestamp.h"
+#include "velox/type/TimestampConversion.h"
+
+namespace facebook::velox::test {
+namespace {
+
+// Returns the (year, month, day) computed by Howard Hinnant's date library,
+// which we use as the ground truth.
+YearMonthDay hinnantYmd(int32_t dayNumber) {
+  const date::sys_days sd{date::days{dayNumber}};
+  const date::year_month_day ymd{sd};
+  return YearMonthDay{
+      static_cast<int32_t>(static_cast<int64_t>(ymd.year())),
+      static_cast<unsigned>(ymd.month()),
+      static_cast<unsigned>(ymd.day()),
+  };
+}
+
+void expectEq(int32_t dayNumber, YearMonthDay got, YearMonthDay want) {
+  EXPECT_EQ(got.year, want.year) << "day=" << dayNumber;
+  EXPECT_EQ(got.month, want.month) << "day=" << dayNumber;
+  EXPECT_EQ(got.day, want.day) << "day=" << dayNumber;
+}
+
+TEST(FastDateTest, knownDates) {
+  // (input days since epoch, expected y, m, d). Hand-verifiable cases.
+  const std::array<std::tuple<int32_t, int32_t, uint32_t, uint32_t>, 9> cases =
+      {{
+          {0, 1970, 1, 1}, // Epoch.
+          {1, 1970, 1, 2},
+          {-1, 1969, 12, 31},
+          {31, 1970, 2, 1},
+          {59, 1970, 3, 1}, // 1970 not a leap year.
+          {365, 1971, 1, 1},
+          {-365, 1969, 1, 1},
+          {11016, 2000, 2, 29}, // Leap day in a 400-year leap year.
+          {-25509, 1900, 2, 28}, // 1900 not a leap year (no Feb 29).
+      }};
+
+  for (const auto& [d, y, m, day] : cases) {
+    SCOPED_TRACE(testing::Message() << "dayNumber=" << d);
+    const auto got = daysToYmd(d);
+    EXPECT_EQ(got.year, y);
+    EXPECT_EQ(got.month, m);
+    EXPECT_EQ(got.day, day);
+  }
+}
+
+TEST(FastDateTest, matchesHinnantOnTightRange) {
+  // Walk every day across roughly +/- 600 years from epoch. This covers all
+  // Gregorian rule transitions of practical interest (centuries, 400-year
+  // boundaries, leap years).
+  for (int32_t d = -219145; d <= 219145; ++d) {
+    const auto got = daysToYmd(d);
+    const auto want = hinnantYmd(d);
+    if (got.year != want.year || got.month != want.month ||
+        got.day != want.day) {
+      FAIL() << "Mismatch at day=" << d << ": got " << got.year << '-'
+             << got.month << '-' << got.day << " want " << want.year << '-'
+             << want.month << '-' << want.day;
+    }
+  }
+}
+
+TEST(FastDateTest, matchesHinnantOnRandomFullRange) {
+  // 2M random days uniformly across the algorithm's exact range. Spans
+  // roughly 3 million years centered on the epoch; behavior outside this
+  // range is undefined per FastDate.h.
+  std::mt19937 rng{0xC0FFEEu};
+  std::uniform_int_distribution<int32_t> dist{
+      fast_date::kRataDieMin, fast_date::kRataDieMax};
+  for (int i = 0; i < 2'000'000; ++i) {
+    const int32_t d = dist(rng);
+    const auto got = daysToYmd(d);
+    const auto want = hinnantYmd(d);
+    ASSERT_EQ(got.year, want.year) << "day=" << d;
+    ASSERT_EQ(got.month, want.month) << "day=" << d;
+    ASSERT_EQ(got.day, want.day) << "day=" << d;
+  }
+}
+
+TEST(FastDateTest, boundaries) {
+  // Days at every century and 400-year boundary across the algorithm's
+  // exact range. Boundaries are where Gregorian rules diverge most.
+  for (int32_t centuryYear = fast_date::kYearMin + 100;
+       centuryYear <= fast_date::kYearMax - 100;
+       centuryYear += 100) {
+    const auto sd = date::sys_days{
+        date::year{centuryYear} / date::month{3} / date::day{1}};
+    const int32_t d = sd.time_since_epoch().count();
+    const auto got = daysToYmd(d);
+    const auto want = hinnantYmd(d);
+    expectEq(d, got, want);
+  }
+}
+
+// --- Public-API random-input cross-checks (fuzzer-style) -----------------
+// These verify the patched Velox functions (Timestamp::epochToCalendarUtc and
+// util::daysSinceEpochFromDate), not just the inner FastDate.h primitives.
+// Three distributions per direction:
+//   tight:     ~+/- 70 years from epoch (the realistic-data case).
+//   wide:      across the full fast_date::kRataDie range (algorithm domain).
+//   fallback:  way outside the algorithm range, exercising the legacy loop.
+//
+// Each distribution gets 2M random samples, cross-checked against
+// date::year_month_day from velox/external/date/date.h.
+
+namespace {
+constexpr int64_t kSecondsPerDay = 86'400;
+
+// Floor-division: seconds -> days, treating negative remainders correctly.
+int64_t epochToDays(int64_t epoch) {
+  int64_t d = epoch / kSecondsPerDay;
+  int64_t r = epoch % kSecondsPerDay;
+  if (r < 0) {
+    --d;
+  }
+  return d;
+}
+
+// Reference y/m/d for any int64 day count (Hinnant supports the full range).
+struct ReferenceYmd {
+  int64_t year;
+  uint32_t month;
+  uint32_t day;
+};
+ReferenceYmd hinnantRef(int64_t days) {
+  const date::sys_days sd{date::days{days}};
+  const date::year_month_day ymd{sd};
+  return {
+      static_cast<int64_t>(ymd.year()),
+      static_cast<unsigned>(ymd.month()),
+      static_cast<unsigned>(ymd.day()),
+  };
+}
+} // namespace
+
+TEST(FastDateTest, fuzzEpochToCalendarUtcMatchesHinnant) {
+  std::mt19937_64 rng{0xFAB1Eull};
+  // Tight: realistic Velox data (~1900-2040).
+  std::uniform_int_distribution<int64_t> tight{
+      -25'567 * kSecondsPerDay, 25'567 * kSecondsPerDay};
+  // Wide: full algorithmic range (~3M years).
+  std::uniform_int_distribution<int64_t> wide{
+      static_cast<int64_t>(fast_date::kRataDieMin) * kSecondsPerDay,
+      static_cast<int64_t>(fast_date::kRataDieMax) * kSecondsPerDay};
+  // Fallback: outside the algorithm range, exercising the legacy loop.
+  // Limit to int64 / 86400 so seconds * 86400 doesn't overflow on the way in.
+  std::uniform_int_distribution<int64_t> fallback{
+      -(static_cast<int64_t>(fast_date::kYearMax) + 100'000) * 365 *
+          kSecondsPerDay,
+      -static_cast<int64_t>(fast_date::kRataDieMin - 1) * kSecondsPerDay};
+
+  auto check = [](int64_t epoch) {
+    std::tm tm;
+    if (!Timestamp::epochToCalendarUtc(epoch, tm)) {
+      // Out-of-range outputs are an acceptable "false" return; just skip.
+      return;
+    }
+    const int64_t days = epochToDays(epoch);
+    const auto want = hinnantRef(days);
+    ASSERT_EQ(tm.tm_year + 1900, want.year) << "epoch=" << epoch;
+    ASSERT_EQ(tm.tm_mon + 1, want.month) << "epoch=" << epoch;
+    ASSERT_EQ(static_cast<unsigned>(tm.tm_mday), want.day) << "epoch=" << epoch;
+  };
+
+  for (int i = 0; i < 2'000'000; ++i) {
+    check(tight(rng));
+  }
+  for (int i = 0; i < 2'000'000; ++i) {
+    check(wide(rng));
+  }
+  // Fewer fallback samples: per-call cost is much higher (legacy loop).
+  for (int i = 0; i < 500'000; ++i) {
+    check(fallback(rng));
+  }
+}
+
+TEST(FastDateTest, fuzzDaysSinceEpochFromDateMatchesHinnant) {
+  std::mt19937_64 rng{0xCAFEull};
+
+  auto check = [](int32_t year, uint32_t month, uint32_t day) {
+    auto got = util::daysSinceEpochFromDate(year, month, day);
+    if (got.hasError()) {
+      return;
+    }
+    const date::sys_days sd{
+        date::year{year} / date::month{month} / date::day{day}};
+    const int64_t want = sd.time_since_epoch().count();
+    ASSERT_EQ(got.value(), want)
+        << "y=" << year << " m=" << month << " d=" << day;
+  };
+
+  // Tight: realistic Velox years.
+  std::uniform_int_distribution<int32_t> tightYear{1900, 2040};
+  // Wide: algorithm domain.
+  std::uniform_int_distribution<int32_t> wideYear{
+      fast_date::kYearMin, fast_date::kYearMax};
+  // Fallback: outside the algorithm range, exercising the legacy 400-year
+  // step loop (year still within isValidDate's accepted range).
+  std::uniform_int_distribution<int32_t> fallbackYear{
+      fast_date::kYearMax + 1, fast_date::kYearMax + 1'000'000};
+
+  // Pick a valid day for the (year, month) pair so we don't trip
+  // isValidDate's "31 Feb"-style rejections.
+  auto sample = [&rng](int32_t year) {
+    const uint32_t month = std::uniform_int_distribution<uint32_t>{1, 12}(rng);
+    const date::year_month_day_last lastOfMonth{
+        date::year{year} / date::month{month} / date::last};
+    const uint32_t maxDay =
+        static_cast<unsigned>(static_cast<date::day>(lastOfMonth.day()));
+    const uint32_t day =
+        std::uniform_int_distribution<uint32_t>{1, maxDay}(rng);
+    return std::make_tuple(year, month, day);
+  };
+
+  for (int i = 0; i < 2'000'000; ++i) {
+    auto [y, m, d] = sample(tightYear(rng));
+    check(y, m, d);
+  }
+  for (int i = 0; i < 2'000'000; ++i) {
+    auto [y, m, d] = sample(wideYear(rng));
+    check(y, m, d);
+  }
+  for (int i = 0; i < 500'000; ++i) {
+    auto [y, m, d] = sample(fallbackYear(rng));
+    check(y, m, d);
+  }
+}
+
+} // namespace
+} // namespace facebook::velox::test


### PR DESCRIPTION
## Summary

Replaces the per-call work in `Timestamp::epochToCalendarUtc` and `util::daysSinceEpochFromDate` (multiple `daysBetweenYears` invocations with `y/4 - y/100 + y/400`, `std::upper_bound` over the month-offset table, branchy leap-year and overflow checks, plus a small convergence loop) with the Neri-Schneider 2022 constant-time algorithm via a new header `velox/type/FastDate.h`. The existing slow paths are kept as fallbacks for inputs outside the algorithm's exact range so observable behavior is preserved.

The replacement is a fixed sequence of multiplies and shifts. It's faster on every input that goes through it, including the tight-range data that Velox's existing path already handles with 0-1 loop iterations.

Closes #17364.

## Numbers

WIth i7-1260P, GCC 11.4 release flags `-O3 -mavx2 -mfma -DNDEBUG`:

**API-vs-API microbench** (1M random inputs, `velox_date_conversion_benchmark`):

| direction | workload | legacy_loop (pre-patch) | NS via patched API (post-patch) | speedup |
|---|---|---|---|---|
| epoch-days → y/m/d | tight (~1900-2040) | 53.0 ns | 18.0 ns | **2.95×** |
| epoch-days → y/m/d | wide (~3M-yr span) | 68.1 ns | 17.9 ns | **3.81×** |
| y/m/d → epoch-days | tight | 15.6 ns | 13.5 ns | **1.16×** |
| y/m/d → epoch-days | wide | 336.0 ns | 13.4 ns | **25.1×** |

**End-to-end on Presto/Spark expressions** (`velox_date_extract_benchmark`, 1024-row vectors fuzzed via `VectorFuzzer::randDate` ≈ ±67 years from epoch, 5-run averages):

| expression | base avg | base [min, max] | NS avg | NS [min, max] | speedup |
|---|---|---|---|---|---|
| `year(timestamp)` | 10.59 ms | [9.87, 10.86] | 5.66 ms | [5.55, 5.71] | **1.87×** |
| `day(date)` | 9.91 ms | [9.83, 10.01] | 5.57 ms | [5.41, 5.69] | **1.78×** |
| `month(timestamp)` | 11.11 ms | [11.00, 11.24] | 6.68 ms | [6.58, 6.81] | **1.66×** |
| `month(date)` | 10.89 ms | [10.77, 11.01] | 6.59 ms | [6.45, 6.70] | **1.65×** |
| `day_of_year(date)` | 10.73 ms | [10.60, 10.91] | 6.77 ms | [6.62, 6.88] | **1.58×** |
| `quarter(date)` | 11.32 ms | [11.16, 11.40] | 7.23 ms | [7.09, 7.37] | **1.57×** |
| `last_day_of_month(date)` | 17.02 ms | [16.83, 17.31] | 12.03 ms | [11.74, 12.25] | **1.41×** |
| `make_date(y,m,d)` (Spark) | 7.00 ms | [6.84, 7.14] | 5.43 ms | [5.32, 5.52] | **1.29×** |
| `year(date)` | 2.44 ms | [2.34, 2.53] | 2.40 ms | [2.16, 2.55] | 1.02× *(noise; ranges overlap)* |
| `day(timestamp)` | 2.90 ms | [2.75, 2.97] | 2.87 ms | [2.69, 2.96] | 1.01× *(noise; ranges overlap)* |

The fuzzer's date range is the default ±67 years from epoch - Velox's best case for the existing path. Wider ranges would show a larger end-to-end speedup but aren't realistic production data.

## Correctness

- 9M random samples per direction (2M tight + 2M algorithm-domain wide + 500k out-of-range fallback) cross-checked against Howard Hinnant's `date::year_month_day` from `velox/external/date/date.h`. Verifies the patched public API (`Timestamp::epochToCalendarUtc` and `util::daysSinceEpochFromDate`), including the legacy-loop fallback paths.
- Boundary-day coverage at every century boundary across the algorithm's exact range.
- Slow loops retained for inputs outside the algorithm's exact range, so behavior across the full `kMinYear` / `kMaxYear` validation range in `TimestampConversion.h` is unchanged.

## Test

- `make unittest` on a release build: `velox_type_test` (covers `FastDateTest`, `TimestampTest`, `TimestampConversionTest`), `velox_function_prestosql_datetime_test`, `velox_functions_spark_datetime_test`, `velox_expression_test`.
- `make benchmarks-basic-build`: confirm `velox_date_extract_benchmark` and `velox_format_datetime_benchmark` build and run.
- `velox_date_conversion_benchmark` to validate the API-vs-API ratios on the reviewer's hardware.