### PR TITLE
fix(type): Remove folly/dynamic.h from StringView.h, Timestamp.h, and HugeInt.h (#17372)

### DIFF
--- a/velox/type/HugeInt.h
+++ b/velox/type/HugeInt.h
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <folly/dynamic.h>
-#include <sstream>
 #include <string>
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/base/Exceptions.h"

--- a/velox/type/StringView.cpp
+++ b/velox/type/StringView.cpp
@@ -15,6 +15,9 @@
  */
 
 #include "velox/type/StringView.h"
+
+#include <folly/dynamic.h>
+
 #include "velox/common/base/SimdUtil.h"
 
 namespace facebook::velox {
@@ -134,4 +137,9 @@ int32_t StringView::linearSearch(
   return linearSearchSimple(key, strings, indices, numStrings);
 #endif
 }
+
+StringView::operator folly::dynamic() const {
+  return folly::dynamic(folly::StringPiece(data(), size()));
+}
+
 } // namespace facebook::velox

--- a/velox/type/StringView.h
+++ b/velox/type/StringView.h
@@ -23,12 +23,15 @@
 #include <folly/FBString.h>
 #include <folly/Format.h>
 #include <folly/Range.h>
-#include <folly/dynamic.h>
 
 #include <fmt/format.h>
 
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/base/Exceptions.h"
+
+namespace folly {
+struct dynamic;
+}
 
 namespace facebook::velox {
 
@@ -269,9 +272,7 @@ struct StringView {
   /// folly::dynamic.
   ///
   /// > folly::dynamic str(StringView()); // ok
-  /* implicit */ operator folly::dynamic() const {
-    return folly::dynamic(folly::StringPiece(data(), size()));
-  }
+  /* implicit */ operator folly::dynamic() const;
 
   const char* begin() const&& = delete;
   const char* begin() const& {

--- a/velox/type/Timestamp.cpp
+++ b/velox/type/Timestamp.cpp
@@ -14,8 +14,12 @@
  * limitations under the License.
  */
 #include "velox/type/Timestamp.h"
+
 #include <charconv>
 #include <chrono>
+
+#include <folly/dynamic.h>
+
 #include "velox/common/base/CountBits.h"
 #include "velox/external/tzdb/exception.h"
 #include "velox/type/FastDate.h"
@@ -23,6 +27,23 @@
 #include "velox/type/tz/TimeZoneMap.h"
 
 namespace facebook::velox {
+
+Timestamp Timestamp::create(const folly::dynamic& obj) {
+  auto seconds = obj["seconds"].asInt();
+  auto nanos = obj["nanos"].asInt();
+  return Timestamp(seconds, nanos);
+}
+
+Timestamp::operator folly::dynamic() const {
+  return folly::dynamic(seconds_);
+}
+
+folly::dynamic Timestamp::serialize() const {
+  folly::dynamic obj = folly::dynamic::object;
+  obj["seconds"] = seconds_;
+  obj["nanos"] = nanos_;
+  return obj;
+}
 
 // static
 Timestamp Timestamp::fromDaysAndNanos(int32_t days, int64_t nanos) {

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -15,14 +15,15 @@
  */
 #pragma once
 
-#include <iomanip>
-#include <sstream>
+#include <ostream>
 #include <string>
-
-#include <folly/dynamic.h>
 
 #include "velox/common/base/CheckedArithmetic.h"
 #include "velox/type/StringView.h"
+
+namespace folly {
+struct dynamic;
+}
 
 namespace facebook::velox {
 
@@ -125,11 +126,7 @@ struct Timestamp {
   // Returns the current unix timestamp (ms precision).
   static Timestamp now();
 
-  static Timestamp create(const folly::dynamic& obj) {
-    auto seconds = obj["seconds"].asInt();
-    auto nanos = obj["nanos"].asInt();
-    return Timestamp(seconds, nanos);
-  }
+  static Timestamp create(const folly::dynamic& obj);
 
   int64_t getSeconds() const {
     return seconds_;
@@ -428,16 +425,9 @@ struct Timestamp {
     return toString();
   }
 
-  operator folly::dynamic() const {
-    return folly::dynamic(seconds_);
-  }
+  operator folly::dynamic() const;
 
-  folly::dynamic serialize() const {
-    folly::dynamic obj = folly::dynamic::object;
-    obj["seconds"] = seconds_;
-    obj["nanos"] = nanos_;
-    return obj;
-  }
+  folly::dynamic serialize() const;
 
   // Pretty printer for gtest.
   friend void PrintTo(const Timestamp& timestamp, std::ostream* os) {

--- a/velox/type/tests/TimestampTest.cpp
+++ b/velox/type/tests/TimestampTest.cpp
@@ -15,7 +15,9 @@
  */
 
 #include <gtest/gtest.h>
+#include <iomanip>
 #include <random>
+#include <sstream>
 
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/testutil/RandomSeed.h"


### PR DESCRIPTION
Summary:

Move folly::dynamic serialization methods from headers to .cpp files, keeping folly/dynamic.h as a private (non-exported) dependency. This removes ~3-4M of preprocessed includes from every consumer of these headers.

Changes:
- StringView.h: Move operator folly::dynamic() to StringView.cpp
- Timestamp.h: Move create(), operator folly::dynamic(), serialize() to Timestamp.cpp; remove unused <sstream> and <iomanip> includes
- HugeInt.h: Remove unused folly/dynamic.h and <sstream> includes
- BUCK: Move //folly:dynamic from exported_deps to deps for both velox_string_view and velox_timestamp targets
- TimestampTest.cpp: Add direct <iomanip> and <sstream> includes

Reviewed By: kevinwilfong

Differential Revision: D102442507


