### PR TITLE
fix(type): Move inline serialize/deserialize methods from Type.h to Type.cpp (#17373)

### DIFF
--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -258,6 +258,80 @@ TypePtr Type::create(const folly::dynamic& obj) {
   }
 }
 
+template <TypeKind KIND>
+folly::dynamic ScalarType<KIND>::serialize() const {
+  folly::dynamic obj = folly::dynamic::object;
+  obj["name"] = "Type";
+  obj["type"] = TypeTraits<KIND>::name;
+  return obj;
+}
+
+template folly::dynamic ScalarType<TypeKind::BOOLEAN>::serialize() const;
+template folly::dynamic ScalarType<TypeKind::TINYINT>::serialize() const;
+template folly::dynamic ScalarType<TypeKind::SMALLINT>::serialize() const;
+template folly::dynamic ScalarType<TypeKind::INTEGER>::serialize() const;
+template folly::dynamic ScalarType<TypeKind::BIGINT>::serialize() const;
+template folly::dynamic ScalarType<TypeKind::REAL>::serialize() const;
+template folly::dynamic ScalarType<TypeKind::DOUBLE>::serialize() const;
+template folly::dynamic ScalarType<TypeKind::VARCHAR>::serialize() const;
+template folly::dynamic ScalarType<TypeKind::VARBINARY>::serialize() const;
+template folly::dynamic ScalarType<TypeKind::TIMESTAMP>::serialize() const;
+template folly::dynamic ScalarType<TypeKind::HUGEINT>::serialize() const;
+template folly::dynamic ScalarType<TypeKind::UNKNOWN>::serialize() const;
+template folly::dynamic ScalarType<TypeKind::OPAQUE>::serialize() const;
+
+template <TypeKind KIND>
+folly::dynamic DecimalType<KIND>::serialize() const {
+  auto obj = ScalarType<KIND>::serialize();
+  obj["type"] = name();
+  obj["precision"] = precision();
+  obj["scale"] = scale();
+  return obj;
+}
+
+template folly::dynamic DecimalType<TypeKind::BIGINT>::serialize() const;
+template folly::dynamic DecimalType<TypeKind::HUGEINT>::serialize() const;
+
+folly::dynamic UnknownType::serialize() const {
+  folly::dynamic obj = folly::dynamic::object;
+  obj["name"] = "Type";
+  obj["type"] = TypeTraits<TypeKind::UNKNOWN>::name;
+  return obj;
+}
+
+folly::dynamic IntervalDayTimeType::serialize() const {
+  folly::dynamic obj = folly::dynamic::object;
+  obj["name"] = "IntervalDayTimeType";
+  obj["type"] = name();
+  return obj;
+}
+
+TypePtr IntervalDayTimeType::deserialize(const folly::dynamic& /*obj*/) {
+  return IntervalDayTimeType::get();
+}
+
+folly::dynamic IntervalYearMonthType::serialize() const {
+  folly::dynamic obj = folly::dynamic::object;
+  obj["name"] = "IntervalYearMonthType";
+  obj["type"] = name();
+  return obj;
+}
+
+TypePtr IntervalYearMonthType::deserialize(const folly::dynamic& /*obj*/) {
+  return IntervalYearMonthType::get();
+}
+
+folly::dynamic DateType::serialize() const {
+  folly::dynamic obj = folly::dynamic::object;
+  obj["name"] = "DateType";
+  obj["type"] = name();
+  return obj;
+}
+
+TypePtr DateType::deserialize(const folly::dynamic& /*obj*/) {
+  return DateType::get();
+}
+
 // static
 void Type::registerSerDe() {
   auto& registry = velox::DeserializationRegistryForSharedPtr();

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -823,13 +823,7 @@ class ScalarType : public CanProvideCustomComparisonType<KIND> {
     return Type::hasSameTypeId(other);
   }
 
-  // TODO: velox implementation is in cpp
-  folly::dynamic serialize() const override {
-    folly::dynamic obj = folly::dynamic::object;
-    obj["name"] = "Type";
-    obj["type"] = TypeTraits<KIND>::name;
-    return obj;
-  }
+  folly::dynamic serialize() const override;
 };
 
 /// This class represents the fixed-point numbers.
@@ -877,13 +871,7 @@ class DecimalType : public ScalarType<KIND> {
     return fmt::format("DECIMAL({}, {})", precision(), scale());
   }
 
-  folly::dynamic serialize() const override {
-    auto obj = ScalarType<KIND>::serialize();
-    obj["type"] = name();
-    obj["precision"] = precision();
-    obj["scale"] = scale();
-    return obj;
-  }
+  folly::dynamic serialize() const override;
 
   std::span<const TypeParameter> parameters() const override {
     return parameters_;
@@ -1056,12 +1044,7 @@ class UnknownType : public CanProvideCustomComparisonType<TypeKind::UNKNOWN> {
     return Type::hasSameTypeId(other);
   }
 
-  folly::dynamic serialize() const override {
-    folly::dynamic obj = folly::dynamic::object;
-    obj["name"] = "Type";
-    obj["type"] = TypeTraits<TypeKind::UNKNOWN>::name;
-    return obj;
-  }
+  folly::dynamic serialize() const override;
 };
 
 class ArrayType : public TypeBase<TypeKind::ARRAY> {
@@ -1527,16 +1510,9 @@ class IntervalDayTimeType final : public BigintType {
   /// Perhaps, Type::valueToString(variant)?
   std::string valueToString(int64_t value) const;
 
-  folly::dynamic serialize() const override {
-    folly::dynamic obj = folly::dynamic::object;
-    obj["name"] = "IntervalDayTimeType";
-    obj["type"] = name();
-    return obj;
-  }
+  folly::dynamic serialize() const override;
 
-  static TypePtr deserialize(const folly::dynamic& /*obj*/) {
-    return IntervalDayTimeType::get();
-  }
+  static TypePtr deserialize(const folly::dynamic& obj);
 };
 
 FOLLY_ALWAYS_INLINE std::shared_ptr<const IntervalDayTimeType>
@@ -1578,16 +1554,9 @@ class IntervalYearMonthType final : public IntegerType {
   /// represented as 1-2; -14 months would be represents as -1-2.
   std::string valueToString(int32_t value) const;
 
-  folly::dynamic serialize() const override {
-    folly::dynamic obj = folly::dynamic::object;
-    obj["name"] = "IntervalYearMonthType";
-    obj["type"] = name();
-    return obj;
-  }
+  folly::dynamic serialize() const override;
 
-  static TypePtr deserialize(const folly::dynamic& /*obj*/) {
-    return IntervalYearMonthType::get();
-  }
+  static TypePtr deserialize(const folly::dynamic& obj);
 };
 
 FOLLY_ALWAYS_INLINE std::shared_ptr<const IntervalYearMonthType>
@@ -1632,16 +1601,9 @@ class DateType final : public IntegerType {
 
   int32_t toDays(const char* in, size_t len) const;
 
-  folly::dynamic serialize() const override {
-    folly::dynamic obj = folly::dynamic::object;
-    obj["name"] = "DateType";
-    obj["type"] = name();
-    return obj;
-  }
+  folly::dynamic serialize() const override;
 
-  static TypePtr deserialize(const folly::dynamic& /*obj*/) {
-    return DateType::get();
-  }
+  static TypePtr deserialize(const folly::dynamic& obj);
 };
 
 FOLLY_ALWAYS_INLINE std::shared_ptr<const DateType> DATE() {


### PR DESCRIPTION
Summary:

Move all inline folly::dynamic serialize() and deserialize() implementations
from Type.h to Type.cpp. This reduces header bloat and sets up for future
folly/dynamic.h removal from Type.h once TypeSerdeCache is refactored.

Moved methods:
- ScalarType<KIND>::serialize() (with explicit template instantiations)
- DecimalType<KIND>::serialize() (with explicit template instantiations)
- UnknownType::serialize()
- IntervalDayTimeType::serialize() and deserialize()
- IntervalYearMonthType::serialize() and deserialize()
- DateType::serialize() and deserialize()

Reviewed By: kevinwilfong

Differential Revision: D102442531
