### PR TITLE
fix(type): Remove folly/dynamic.h from Type.h by extracting TypeSerdeCache (#17374)

### DIFF
--- a/velox/exec/tests/PlanNodeSerdeTest.cpp
+++ b/velox/exec/tests/PlanNodeSerdeTest.cpp
@@ -21,6 +21,7 @@
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/parse/TypeResolver.h"
+#include "velox/type/TypeSerde.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
 #include <gtest/gtest.h>

--- a/velox/type/CMakeLists.txt
+++ b/velox/type/CMakeLists.txt
@@ -60,6 +60,7 @@ velox_add_library(
   Type.h
   TypeCoercer.h
   TypeEncodingUtil.h
+  TypeSerde.h
   TypeUtil.h
   Variant.h
   WideRangeDateConversion.h

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -16,7 +16,10 @@
 
 #include <velox/type/Type.h>
 
+#include <folly/dynamic.h>
+
 #include "velox/common/EnumDefine.h"
+#include "velox/type/TypeSerde.h"
 
 #include <boost/algorithm/string.hpp>
 #include <fmt/format.h>

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -18,7 +18,6 @@
 #include <folly/CPortability.h>
 #include <folly/Random.h>
 #include <folly/container/F14Set.h>
-#include <folly/dynamic.h>
 
 #include <cstdint>
 #include <cstring>
@@ -44,6 +43,10 @@
 #include "velox/type/Timestamp.h"
 #include "velox/type/Tree.h"
 #include "velox/type/tz/TimeZoneMap.h"
+
+namespace folly {
+struct dynamic;
+}
 
 namespace facebook::velox {
 
@@ -2567,95 +2570,6 @@ void toAppend(
 
 /// Appends type's SQL string to 'out'. Uses DuckDB SQL.
 void toTypeSql(const TypePtr& type, std::ostream& out);
-
-/// Cache of serialized RowType instances. Useful to reduce the size of
-/// serialized expressions and plans. Disabled by default. Not thread safe.
-///
-/// To enable, call 'serializedTypeCache().enable()'. This enables the cache for
-/// the current thread. To disable, call 'serializedTypeCache().disable()'.
-/// While enables, type serialization will use the cache and serialize the types
-/// using IDs stored in the cache. The caller is responsible for saving
-/// serialized types from the cache and using these to hidrate
-/// 'deserializedTypeCache()' before deserializing the types.
-class SerializedTypeCache {
- public:
-  struct Options {
-    // Caching applies to RowType's with at least this many fields.
-    size_t minRowTypeSize = 10;
-  };
-
-  bool isEnabled() const {
-    return enabled_;
-  }
-
-  const Options& options() const {
-    return options_;
-  }
-
-  void enable(const Options& options = {.minRowTypeSize = 10}) {
-    enabled_ = true;
-    options_ = options;
-  }
-
-  void disable() {
-    enabled_ = false;
-  }
-
-  size_t size() const {
-    return cache_.size();
-  }
-
-  void clear() {
-    cache_.clear();
-  }
-
-  /// Returns the ID of the type if it is in the cache. Returns std::nullopt if
-  /// type is not found in the cache. Cache key is type instance pointer. Hence,
-  /// equal but different instances are stored separately.
-  std::optional<int32_t> get(const Type& type) const;
-
-  /// Stores the type in the cache. Returns the ID of the type. Reports an error
-  /// if type is already present in the cache. IDs are monotonically increasing.
-  /// Serialized type may refer to types stored previously in the cache. When
-  /// deserializing type cache, make sure to deserialize types in the order of
-  /// cache IDs.
-  int32_t put(const Type& type, folly::dynamic serialized);
-
-  /// Serialized the types stored in the cache. Use
-  /// DeserializedTypeCache::deserialize to deserialize.
-  folly::dynamic serialize();
-
- private:
-  bool enabled_{false};
-  Options options_;
-  folly::F14FastMap<const Type*, std::pair<int32_t, folly::dynamic>> cache_;
-};
-
-/// Thread local cache of serialized RowType instances. Used by
-/// RowType::serialize.
-SerializedTypeCache& serializedTypeCache();
-
-/// Thread local cache of deserialized RowType instances. Used when
-/// deserializing Type objects.
-class DeserializedTypeCache {
- public:
-  void deserialize(const folly::dynamic& obj);
-
-  size_t size() const {
-    return cache_.size();
-  }
-
-  const TypePtr& get(int32_t id) const;
-
-  void clear() {
-    cache_.clear();
-  }
-
- private:
-  folly::F14FastMap<int32_t, TypePtr> cache_;
-};
-
-DeserializedTypeCache& deserializedTypeCache();
 
 template <typename T>
 std::string Type::valueToString(T value) const {

--- a/velox/type/TypeSerde.h
+++ b/velox/type/TypeSerde.h
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <folly/container/F14Map.h>
+#include <folly/dynamic.h>
+
+#include "velox/type/Type.h"
+
+namespace facebook::velox {
+
+/// Cache of serialized RowType instances. Useful to reduce the size of
+/// serialized expressions and plans. Disabled by default. Not thread safe.
+///
+/// To enable, call 'serializedTypeCache().enable()'. This enables the cache for
+/// the current thread. To disable, call 'serializedTypeCache().disable()'.
+/// While enables, type serialization will use the cache and serialize the types
+/// using IDs stored in the cache. The caller is responsible for saving
+/// serialized types from the cache and using these to hidrate
+/// 'deserializedTypeCache()' before deserializing the types.
+class SerializedTypeCache {
+ public:
+  struct Options {
+    // Caching applies to RowType's with at least this many fields.
+    size_t minRowTypeSize = 10;
+  };
+
+  bool isEnabled() const {
+    return enabled_;
+  }
+
+  const Options& options() const {
+    return options_;
+  }
+
+  void enable(const Options& options = {.minRowTypeSize = 10}) {
+    enabled_ = true;
+    options_ = options;
+  }
+
+  void disable() {
+    enabled_ = false;
+  }
+
+  size_t size() const {
+    return cache_.size();
+  }
+
+  void clear() {
+    cache_.clear();
+  }
+
+  /// Returns the ID of the type if it is in the cache. Returns std::nullopt if
+  /// type is not found in the cache. Cache key is type instance pointer. Hence,
+  /// equal but different instances are stored separately.
+  std::optional<int32_t> get(const Type& type) const;
+
+  /// Stores the type in the cache. Returns the ID of the type. Reports an error
+  /// if type is already present in the cache. IDs are monotonically increasing.
+  /// Serialized type may refer to types stored previously in the cache. When
+  /// deserializing type cache, make sure to deserialize types in the order of
+  /// cache IDs.
+  int32_t put(const Type& type, folly::dynamic serialized);
+
+  /// Serialized the types stored in the cache. Use
+  /// DeserializedTypeCache::deserialize to deserialize.
+  folly::dynamic serialize();
+
+ private:
+  bool enabled_{false};
+  Options options_;
+  folly::F14FastMap<const Type*, std::pair<int32_t, folly::dynamic>> cache_;
+};
+
+/// Thread local cache of serialized RowType instances. Used by
+/// RowType::serialize.
+SerializedTypeCache& serializedTypeCache();
+
+/// Thread local cache of deserialized RowType instances. Used when
+/// deserializing Type objects.
+class DeserializedTypeCache {
+ public:
+  void deserialize(const folly::dynamic& obj);
+
+  size_t size() const {
+    return cache_.size();
+  }
+
+  const TypePtr& get(int32_t id) const;
+
+  void clear() {
+    cache_.clear();
+  }
+
+ private:
+  folly::F14FastMap<int32_t, TypePtr> cache_;
+};
+
+DeserializedTypeCache& deserializedTypeCache();
+
+} // namespace facebook::velox

--- a/velox/type/tests/TypeTest.cpp
+++ b/velox/type/tests/TypeTest.cpp
@@ -20,6 +20,7 @@
 #include "velox/type/SimpleFunctionApi.h"
 #include "velox/type/TimestampConversion.h"
 #include "velox/type/TypeEncodingUtil.h"
+#include "velox/type/TypeSerde.h"
 #include "velox/type/tests/utils/CustomTypesForTesting.h"
 
 using namespace facebook;


### PR DESCRIPTION
Summary:

Extract SerializedTypeCache and DeserializedTypeCache from Type.h into a new TypeSerde.h header. This allows removing #include <folly/dynamic.h> from Type.h, which is included by 228+ files. The folly/dynamic.h header is ~3-4M preprocessed, so removing it from this critical include chain significantly reduces compile times across the codebase.

Changes:
- Type.h: Remove #include <folly/dynamic.h>, add forward declaration for folly::dynamic, extract SerializedTypeCache and DeserializedTypeCache to TypeSerde.h
- TypeSerde.h: New header containing the extracted cache classes
- Type.cpp: Add #include <folly/dynamic.h> and #include "TypeSerde.h"
- TypeTest.cpp, PlanNodeSerdeTest.cpp: Add #include "TypeSerde.h"
- BUCK: Add TypeSerde.h to headers list

Reviewed By: kgpai

Differential Revision: D102442468
