### PR TITLE
fix(filter): Collapse all-duplicate IN list to BigintRange in createBigintValuesFilter (#17377)

### DIFF
--- a/velox/type/Filter.cpp
+++ b/velox/type/Filter.cpp
@@ -1076,6 +1076,12 @@ std::unique_ptr<Filter> createBigintValuesFilter(
       min = values[i];
     }
   }
+  if (min == max) {
+    if (negated) {
+      return std::make_unique<NegatedBigintRange>(min, max, nullAllowed);
+    }
+    return std::make_unique<BigintRange>(min, max, nullAllowed);
+  }
   // If bitmap would have more than 4 words per set bit, we prefer a
   // hash table. If bitmap fits in under 32 words, we use bitmap anyhow.
   int64_t range;

--- a/velox/type/tests/FilterTest.cpp
+++ b/velox/type/tests/FilterTest.cpp
@@ -546,6 +546,29 @@ TEST(FilterTest, bigintValuesUsingBitmask) {
   EXPECT_FALSE(filter->testInt64Range(1234, 2000, false));
 }
 
+TEST(FilterTest, bigintValuesAllDuplicates) {
+  auto filter = createBigintValues({7, 7}, false);
+  ASSERT_TRUE(dynamic_cast<BigintRange*>(filter.get()));
+  EXPECT_TRUE(filter->testInt64(7));
+  EXPECT_FALSE(filter->testInt64(6));
+  EXPECT_FALSE(filter->testInt64(8));
+  EXPECT_FALSE(filter->testNull());
+
+  filter = createBigintValues({42, 42, 42, 42, 42}, true);
+  ASSERT_TRUE(dynamic_cast<BigintRange*>(filter.get()));
+  EXPECT_TRUE(filter->testInt64(42));
+  EXPECT_FALSE(filter->testInt64(41));
+  EXPECT_FALSE(filter->testInt64(43));
+  EXPECT_TRUE(filter->testNull());
+
+  auto negated = createNegatedBigintValues({7, 7}, false);
+  ASSERT_TRUE(dynamic_cast<NegatedBigintRange*>(negated.get()));
+  EXPECT_FALSE(negated->testInt64(7));
+  EXPECT_TRUE(negated->testInt64(6));
+  EXPECT_TRUE(negated->testInt64(8));
+  EXPECT_FALSE(negated->testNull());
+}
+
 TEST(FilterTest, negatedBigintValuesUsingBitmask) {
   auto filter = createNegatedBigintValues({1, 6, 1000, 8, 9, 100, 10}, false);
   auto castedFilter =


### PR DESCRIPTION
Summary:

`createBigintValuesFilter` crashes when called with multiple values that all collapse to a single point (`min == max`). The existing `values.size() == 1` early return covers the trivial single-element case but not inputs like `[5, 5]` or `[42, 42, 42, 42, 42]` where the vector has size > 1 but every element is identical. The function falls through to the bitmap path, which constructs a `BigintValuesUsingBitmask`; that constructor enforces `VELOX_CHECK_LT(min, max)` and aborts.

Fix: after computing `min` and `max`, early-return a `BigintRange` (or `NegatedBigintRange` for NOT IN) when `min == max`, mirroring the existing `values.size() == 1` handling.

This makes the API safe for callers that do not deduplicate upstream — most notably `ExprToSubfieldFilter::makeInFilter` -> `toInt64In` -> `in()` -> `createBigintValues`. Callers that already deduplicate (`InPredicate.cpp::toValues`, `HiveConnectorUtil.cpp::deduplicate`) pay only a single extra comparison that never fires.

Differential Revision: D103035415


