### PR TITLE
feat(dwio): Expose row selection from projectColumns (#17379)

### DIFF
--- a/velox/dwio/common/Reader.cpp
+++ b/velox/dwio/common/Reader.cpp
@@ -20,7 +20,7 @@ namespace facebook::velox::dwio::common {
 
 using namespace velox::common;
 
-VectorPtr RowReader::projectColumns(
+RowReader::ProjectColumnsResult RowReader::projectColumnsWithSelection(
     const VectorPtr& input,
     const ScanSpec& spec,
     const Mutation* mutation) {
@@ -75,15 +75,23 @@ VectorPtr RowReader::projectColumns(
   auto rowType = ROW(std::move(names), std::move(types));
   auto size = bits::countBits(passed.data(), 0, input->size());
   if (size == 0) {
-    return RowVector::createEmpty(rowType, input->pool());
+    // Empty output. Return null selectedRows when the input was already
+    // empty (no rows were dropped — identity mapping holds trivially).
+    // Otherwise return a zero-length selection buffer so callers can
+    // distinguish "all rows filtered out" from "identity mapping" by
+    // checking selectedRows == nullptr.
+    return {
+        RowVector::createEmpty(rowType, input->pool()),
+        input->size() == 0 ? nullptr : allocateIndices(0, input->pool())};
   }
 
   // Preserve input nulls buffer
   BufferPtr outputNulls = input->nulls();
 
+  BufferPtr selectedRows;
   if (size < input->size()) {
-    auto indices = allocateIndices(size, input->pool());
-    auto* rawIndices = indices->asMutable<vector_size_t>();
+    selectedRows = allocateIndices(size, input->pool());
+    auto* rawIndices = selectedRows->asMutable<vector_size_t>();
     vector_size_t j = 0;
     bits::forEachSetBit(
         passed.data(), 0, input->size(), [&](auto i) { rawIndices[j++] = i; });
@@ -93,7 +101,7 @@ VectorPtr RowReader::projectColumns(
       }
       child->disableMemo();
       child = BaseVector::wrapInDictionary(
-          nullptr, indices, size, std::move(child));
+          nullptr, selectedRows, size, std::move(child));
     }
 
     // Filter the nulls buffer to match the filtered rows
@@ -146,8 +154,16 @@ VectorPtr RowReader::projectColumns(
             std::move(rowTypes));
   }
 
-  return std::make_shared<RowVector>(
+  auto output = std::make_shared<RowVector>(
       input->pool(), rowType, outputNulls, size, std::move(children));
+  return {std::move(output), std::move(selectedRows)};
+}
+
+VectorPtr RowReader::projectColumns(
+    const VectorPtr& input,
+    const ScanSpec& spec,
+    const Mutation* mutation) {
+  return projectColumnsWithSelection(input, spec, mutation).output;
 }
 
 namespace {

--- a/velox/dwio/common/Reader.h
+++ b/velox/dwio/common/Reader.h
@@ -152,6 +152,34 @@ class RowReader {
   }
 
   /**
+   * Result of projectColumnsWithSelection. 'output' is the projected
+   * RowVector. 'selectedRows' maps each output row back to its input row
+   * index: selectedRows[i] is the input row that produced output row i.
+   * 'selectedRows' is null when no rows were dropped — output rows are
+   * identity-aligned with the input. This includes the empty-input case
+   * (input->size() == 0), where the identity mapping holds trivially.
+   * When all rows are filtered out from a non-empty input, 'output' is
+   * empty and 'selectedRows' is a non-null zero-length buffer so callers
+   * can distinguish "filtered to empty" from "identity mapping".
+   */
+  struct ProjectColumnsResult {
+    VectorPtr output;
+    BufferPtr selectedRows;
+  };
+
+  /**
+   * Like projectColumns, but also returns the input-row selection used to
+   * build the output. Callers that need to keep an external per-input-row
+   * structure (for example, an index reader's inputHits buffer) aligned
+   * with the filtered output can use 'selectedRows' to compact that
+   * structure without re-running filters.
+   */
+  static ProjectColumnsResult projectColumnsWithSelection(
+      const VectorPtr& input,
+      const velox::common::ScanSpec& spec,
+      const Mutation* mutation);
+
+  /**
    * Helper function used by non-selective reader to project top level columns
    * according to the scan spec and mutations.
    */

--- a/velox/dwio/common/tests/ReaderTest.cpp
+++ b/velox/dwio/common/tests/ReaderTest.cpp
@@ -18,6 +18,7 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 namespace facebook::velox::dwio::common {
@@ -465,6 +466,78 @@ TEST_F(ReaderTest, projectColumnsFiltersRowNullsWithMutation) {
   EXPECT_FALSE(actual->isNullAt(5)); // was row 7
   EXPECT_TRUE(actual->isNullAt(6)); // was row 8
   EXPECT_FALSE(actual->isNullAt(7)); // was row 9
+}
+
+TEST_F(ReaderTest, projectColumnsWithSelectionIdentity) {
+  // No filter: every input row passes, selectedRows is null to signal
+  // identity mapping with input.
+  constexpr int kSize = 5;
+  auto input =
+      makeRowVector({"c0"}, {makeFlatVector<int64_t>(kSize, folly::identity)});
+
+  common::ScanSpec spec("<root>");
+  spec.addAllChildFields(*input->type());
+
+  auto result = RowReader::projectColumnsWithSelection(input, spec, nullptr);
+  EXPECT_EQ(result.output->size(), kSize);
+  EXPECT_EQ(result.selectedRows, nullptr);
+}
+
+TEST_F(ReaderTest, projectColumnsWithSelectionFiltered) {
+  // Filter keeps a subset; selectedRows must list the surviving input
+  // indices in order.
+  constexpr int kSize = 6;
+  auto input =
+      makeRowVector({"c0"}, {makeFlatVector<int64_t>(kSize, folly::identity)});
+
+  common::ScanSpec spec("<root>");
+  spec.addAllChildFields(*input->type());
+  spec.childByName("c0")->setFilter(
+      common::createBigintValues({1, 3, 5}, false));
+
+  auto result = RowReader::projectColumnsWithSelection(input, spec, nullptr);
+  ASSERT_NE(result.selectedRows, nullptr);
+  ASSERT_EQ(result.output->size(), 3);
+  ASSERT_EQ(
+      result.selectedRows->size() / sizeof(vector_size_t),
+      result.output->size());
+  const auto* indices = result.selectedRows->as<vector_size_t>();
+  EXPECT_THAT(
+      std::vector<vector_size_t>(indices, indices + 3),
+      testing::ElementsAre(1, 3, 5));
+}
+
+TEST_F(ReaderTest, projectColumnsWithSelectionAllFiltered) {
+  // Filter rejects every row; output is empty and selectedRows is a
+  // zero-length buffer (non-null) so callers can distinguish "empty after
+  // filtering" from "identity mapping".
+  constexpr int kSize = 4;
+  auto input =
+      makeRowVector({"c0"}, {makeFlatVector<int64_t>(kSize, folly::identity)});
+
+  common::ScanSpec spec("<root>");
+  spec.addAllChildFields(*input->type());
+  spec.childByName("c0")->setFilter(common::createBigintValues({99}, false));
+
+  auto result = RowReader::projectColumnsWithSelection(input, spec, nullptr);
+  EXPECT_EQ(result.output->size(), 0);
+  ASSERT_NE(result.selectedRows, nullptr);
+  EXPECT_EQ(result.selectedRows->size(), 0);
+}
+
+TEST_F(ReaderTest, projectColumnsWithSelectionEmptyInput) {
+  // Empty input: no rows were dropped, so the identity contract holds and
+  // selectedRows must be null. Distinguishes "empty identity" from "all
+  // rows filtered out", which returns a non-null zero-length buffer.
+  auto input =
+      makeRowVector({"c0"}, {makeFlatVector<int64_t>(0, folly::identity)});
+
+  common::ScanSpec spec("<root>");
+  spec.addAllChildFields(*input->type());
+
+  auto result = RowReader::projectColumnsWithSelection(input, spec, nullptr);
+  EXPECT_EQ(result.output->size(), 0);
+  EXPECT_EQ(result.selectedRows, nullptr);
 }
 
 } // namespace


### PR DESCRIPTION
Summary:

Adds `RowReader::projectColumnsWithSelection`, a richer variant of
`projectColumns` that also returns the kept-row mapping (i.e. the input
row index that produced each output row). Existing `projectColumns`
becomes a thin wrapper that forwards to the new helper and discards the
selection.

Motivation: SST index reader currently runs a separate pre-filter pass
purely to recover the kept-row mapping so it can keep `inputHits` aligned
with the filtered output, then calls `projectColumns` which re-applies
the same filters. Exposing the mapping from `projectColumns` lets
SST do the work in one pass; that follow-up lives in a separate diff.

Semantics:
- `selectedRows[i]` is the input row index that produced output row `i`.
- `selectedRows == nullptr` means no rows were dropped — output rows are
  identity-aligned with input.
- When all rows are filtered out, `output` is empty and `selectedRows`
  is a non-null zero-length buffer so callers can distinguish "filtered
  to empty" from "identity".

All existing `projectColumns` semantics (mutations, filters, constants,
top-level projection, null-buffer compaction, transforms, output row
type construction) are preserved.

Reviewed By: Yuhta

Differential Revision: D102699815


