### PR TITLE
fix(spark): Spark struct field access producing wrong results inside CASE WHEN

### DIFF
--- a/velox/functions/sparksql/specialforms/GetArrayStructFields.cpp
+++ b/velox/functions/sparksql/specialforms/GetArrayStructFields.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/functions/sparksql/specialforms/GetArrayStructFields.h"
 #include "velox/expression/ConstantExpr.h"
+#include "velox/expression/EvalCtx.h"
 #include "velox/vector/ComplexVector.h"
 
 namespace facebook::velox::functions::sparksql {
@@ -69,11 +70,13 @@ class GetArrayStructFieldsFunction : public exec::VectorFunction {
         arrayVec->sizes(),
         fieldResult);
 
+    VectorPtr localResult;
     if (decoded->isIdentityMapping()) {
-      result = arrayResult;
+      localResult = std::move(arrayResult);
     } else {
-      result = decoded->wrap(arrayResult, *args[0], decoded->size());
+      localResult = decoded->wrap(arrayResult, *args[0], decoded->size());
     }
+    context.moveOrCopyResult(localResult, rows, result);
   }
 
  private:
@@ -121,7 +124,7 @@ exec::ExprPtr GetArrayStructFieldsCallToSpecialForm::constructSpecialForm(
 
   auto ordinal = constantVector->valueAt(0);
 
-  VELOX_USER_CHECK_GE(
+  VELOX_CHECK_GE(
       ordinal, 0, "Invalid ordinal. Should be greater than or equal to 0.");
   auto numFields = args[0]->type()->asArray().elementType()->asRow().size();
   VELOX_USER_CHECK_LT(

--- a/velox/functions/sparksql/specialforms/GetStructField.cpp
+++ b/velox/functions/sparksql/specialforms/GetStructField.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/functions/sparksql/specialforms/GetStructField.h"
 #include "velox/expression/ConstantExpr.h"
+#include "velox/expression/EvalCtx.h"
 #include "velox/vector/ComplexVector.h"
 
 namespace facebook::velox::functions::sparksql {
@@ -42,12 +43,16 @@ class GetStructFieldFunction : public exec::VectorFunction {
         ordinal_,
         rowData->childrenSize(),
         "Invalid ordinal. Should be smaller than the children size of input row vector.");
+    const VectorPtr& child = rowData->childAt(ordinal_);
+
+    VectorPtr fieldResult;
     if (decoded->isIdentityMapping()) {
-      result = rowData->childAt(ordinal_);
+      fieldResult = child;
     } else {
-      result =
-          decoded->wrap(rowData->childAt(ordinal_), *args[0], decoded->size());
+      fieldResult = decoded->wrap(child, *args[0], decoded->size());
     }
+
+    context.moveOrCopyResult(fieldResult, rows, result);
   }
 
  private:
@@ -95,7 +100,8 @@ exec::ExprPtr GetStructFieldCallToSpecialForm::constructSpecialForm(
 
   auto ordinal = constantVector->valueAt(0);
 
-  VELOX_USER_CHECK_GE(ordinal, 0, "Invalid ordinal. Should be greater than 0.");
+  VELOX_CHECK_GE(
+      ordinal, 0, "Invalid ordinal. Should be greater than or equal to 0.");
   auto getStructFieldFunction =
       std::make_shared<GetStructFieldFunction>(ordinal);
 

--- a/velox/functions/sparksql/tests/GetArrayStructFieldsTest.cpp
+++ b/velox/functions/sparksql/tests/GetArrayStructFieldsTest.cpp
@@ -26,15 +26,25 @@ namespace {
 
 class GetArrayStructFieldsTest : public SparkFunctionBaseTest {
  protected:
+  core::TypedExprPtr makeGetArrayStructFieldsExpr(
+      const TypePtr& inputType,
+      const TypePtr& resultType,
+      const std::string& inputName,
+      int32_t ordinal) {
+    return std::make_shared<const core::CallTypedExpr>(
+        resultType,
+        GetArrayStructFieldsCallToSpecialForm::kGetArrayStructFields,
+        std::make_shared<const core::FieldAccessTypedExpr>(
+            inputType, inputName),
+        std::make_shared<core::ConstantTypedExpr>(INTEGER(), variant(ordinal)));
+  }
+
   void testGetArrayStructFields(
       const VectorPtr& input,
       int ordinal,
       const VectorPtr& expected) {
-    auto expr = std::make_shared<const core::CallTypedExpr>(
-        expected->type(),
-        GetArrayStructFieldsCallToSpecialForm::kGetArrayStructFields,
-        std::make_shared<const core::FieldAccessTypedExpr>(input->type(), "c0"),
-        std::make_shared<core::ConstantTypedExpr>(INTEGER(), variant(ordinal)));
+    auto expr = makeGetArrayStructFieldsExpr(
+        input->type(), expected->type(), "c0", ordinal);
 
     // Input is flat.
     auto result = evaluate(expr, makeRowVector({input}));
@@ -148,13 +158,44 @@ TEST_F(GetArrayStructFieldsTest, invalidOrdinal) {
           elementVector, -1, makeArrayVector(offsets, colInt)),
       "The first argument of get_array_struct_fields should be of array(row) type.");
 
-  VELOX_ASSERT_USER_THROW(
+  VELOX_ASSERT_RUNTIME_THROW(
       testGetArrayStructFields(data, -1, makeArrayVector(offsets, colInt)),
       "Invalid ordinal. Should be greater than or equal to 0.");
 
   VELOX_ASSERT_USER_THROW(
       testGetArrayStructFields(data, 2, makeArrayVector(offsets, colInt)),
       fmt::format("(2 vs. 1) Invalid ordinal 2 for struct with 1 fields."));
+}
+
+TEST_F(GetArrayStructFieldsTest, switchWithGetArrayStructFieldsInBranches) {
+  const auto rowType = ROW({"c0"}, {INTEGER()});
+  auto data = makeRowVector({
+      makeFlatVector<bool>({true, false, true, false}),
+      makeArrayOfRowVector<std::tuple<int32_t>>(
+          {{{std::tuple{1}}},
+           {{std::tuple{2}}},
+           {{std::tuple{3}}},
+           {{std::tuple{4}}}},
+          rowType),
+      makeArrayOfRowVector<std::tuple<int32_t>>(
+          {{{std::tuple{10}}},
+           {{std::tuple{20}}},
+           {{std::tuple{30}}},
+           {{std::tuple{40}}}},
+          rowType),
+  });
+
+  auto switchExpr = std::make_shared<const core::CallTypedExpr>(
+      ARRAY(INTEGER()),
+      "switch",
+      std::make_shared<const core::FieldAccessTypedExpr>(BOOLEAN(), "c0"),
+      makeGetArrayStructFieldsExpr(
+          data->childAt(1)->type(), ARRAY(INTEGER()), "c1", 0),
+      makeGetArrayStructFieldsExpr(
+          data->childAt(2)->type(), ARRAY(INTEGER()), "c2", 0));
+  auto result = evaluate(switchExpr, data);
+  assertEqualVectors(
+      makeArrayVectorFromJson<int32_t>({"[1]", "[20]", "[3]", "[40]"}), result);
 }
 
 } // namespace

--- a/velox/functions/sparksql/tests/GetStructFieldTest.cpp
+++ b/velox/functions/sparksql/tests/GetStructFieldTest.cpp
@@ -18,6 +18,7 @@
 
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/core/Expressions.h"
+#include "velox/functions/sparksql/specialforms/GetStructField.h"
 #include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
@@ -28,15 +29,25 @@ namespace {
 
 class GetStructFieldTest : public SparkFunctionBaseTest {
  protected:
+  core::TypedExprPtr makeGetStructFieldExpr(
+      const TypePtr& inputType,
+      const TypePtr& resultType,
+      const std::string& inputName,
+      int32_t ordinal) {
+    return std::make_shared<const core::CallTypedExpr>(
+        resultType,
+        GetStructFieldCallToSpecialForm::kGetStructField,
+        std::make_shared<const core::FieldAccessTypedExpr>(
+            inputType, inputName),
+        std::make_shared<core::ConstantTypedExpr>(INTEGER(), variant(ordinal)));
+  }
+
   void testGetStructField(
       const VectorPtr& input,
       int ordinal,
       const VectorPtr& expected) {
-    auto expr = std::make_shared<const core::CallTypedExpr>(
-        expected->type(),
-        "get_struct_field",
-        std::make_shared<const core::FieldAccessTypedExpr>(input->type(), "c0"),
-        std::make_shared<core::ConstantTypedExpr>(INTEGER(), variant(ordinal)));
+    auto expr =
+        makeGetStructFieldExpr(input->type(), expected->type(), "c0", ordinal);
 
     // Input is flat.
     auto result = evaluate(expr, makeRowVector({input}));
@@ -104,15 +115,32 @@ TEST_F(GetStructFieldTest, invalidOrdinal) {
   auto data = makeRowVector({colInt, colString, colIntWithNull});
 
   // Get int field.
-  VELOX_ASSERT_THROW(
+  VELOX_ASSERT_RUNTIME_THROW(
       testGetStructField(data, -1, colInt),
-      "Invalid ordinal. Should be greater than 0.");
+      "Invalid ordinal. Should be greater than or equal to 0.");
 
   // Get string field.
   VELOX_ASSERT_THROW(
       testGetStructField(data, 4, colString),
       fmt::format(
           "(4 vs. 3) Invalid ordinal. Should be smaller than the children size of input row vector."));
+}
+
+TEST_F(GetStructFieldTest, switchWithGetStructFieldInBranches) {
+  auto data = makeRowVector({
+      makeFlatVector<bool>({true, false, true, false}),
+      makeRowVector({makeFlatVector<int32_t>({1, 2, 3, 4})}),
+      makeRowVector({makeFlatVector<int32_t>({10, 20, 30, 40})}),
+  });
+
+  auto switchExpr = std::make_shared<const core::CallTypedExpr>(
+      INTEGER(),
+      "switch",
+      std::make_shared<const core::FieldAccessTypedExpr>(BOOLEAN(), "c0"),
+      makeGetStructFieldExpr(data->childAt(1)->type(), INTEGER(), "c1", 0),
+      makeGetStructFieldExpr(data->childAt(2)->type(), INTEGER(), "c2", 0));
+  auto result = evaluate(switchExpr, data);
+  assertEqualVectors(makeFlatVector<int32_t>({1, 20, 3, 40}), result);
 }
 
 } // namespace


### PR DESCRIPTION
GetStructField::apply unconditionally replaces result with the struct's child vector. When used inside CASE WHEN (SwitchExpr), this drops data written by prior branches and can shrink the vector, causing a crash.

Fix: Use EvalCtx::moveOrCopyResult to merge into the existing result when one is already present.