### PR TITLE
fix(filter): Avoid int64 overflow in combineRangesAndNegatedValues

### DIFF
--- a/velox/type/Filter.cpp
+++ b/velox/type/Filter.cpp
@@ -1670,29 +1670,27 @@ std::unique_ptr<Filter> combineRangesAndNegatedValues(
   std::vector<std::unique_ptr<BigintRange>> outRanges;
 
   for (int i = 0; i < ranges.size(); ++i) {
-    auto it =
-        std::lower_bound(rejects.begin(), rejects.end(), ranges[i]->lower());
-    int64_t start = ranges[i]->lower();
-    int64_t end;
+    const int64_t rangeLower{ranges[i]->lower()};
+    const int64_t rangeUpper{ranges[i]->upper()};
+    auto begin = std::lower_bound(rejects.begin(), rejects.end(), rangeLower);
+    auto end = std::upper_bound(begin, rejects.end(), rangeUpper);
 
-    while (it != rejects.end()) {
-      end = *it - 1;
-      if (start >= ranges[i]->lower() && end < ranges[i]->upper()) {
-        if (start <= end) {
-          outRanges.emplace_back(
-              std::make_unique<common::BigintRange>(start, end, false));
-        }
-        start = *it + 1;
-        ++it;
-      } else {
+    int64_t start{rangeLower};
+    bool finished{false};
+    for (auto it = begin; it != end; ++it) {
+      if (*it > start) {
+        outRanges.emplace_back(
+            std::make_unique<common::BigintRange>(start, *it - 1, false));
+      }
+      if (*it == std::numeric_limits<int64_t>::max()) {
+        finished = true;
         break;
       }
+      start = *it + 1;
     }
-    end = ranges[i]->upper();
-    if (start <= end && start >= ranges[i]->lower() &&
-        end <= ranges[i]->upper()) {
+    if (!finished && start <= rangeUpper) {
       outRanges.emplace_back(
-          std::make_unique<common::BigintRange>(start, end, false));
+          std::make_unique<common::BigintRange>(start, rangeUpper, false));
     }
   }
 

--- a/velox/type/tests/FilterTest.cpp
+++ b/velox/type/tests/FilterTest.cpp
@@ -1773,6 +1773,16 @@ TEST(FilterTest, mergeWithBigint) {
   filters.push_back(notIn({empty - 5, empty, empty + 5}, true));
   filters.push_back(notIn({5, 498, 499, 500}, false));
 
+  const int64_t kInt64Min = std::numeric_limits<int64_t>::min();
+  const int64_t kInt64Max = std::numeric_limits<int64_t>::max();
+  filters.push_back(notIn({kInt64Min, -1}));
+  filters.push_back(notIn({kInt64Min, -1}, true));
+  filters.push_back(notIn({1, kInt64Max}));
+  filters.push_back(notIn({1, kInt64Max}, true));
+  filters.push_back(notIn({kInt64Min, kInt64Max}));
+  filters.push_back(between(kInt64Min, 0));
+  filters.push_back(between(0, kInt64Max));
+
   for (const auto& left : filters) {
     for (const auto& right : filters) {
       testMergeWithBigint(left.get(), right.get());


### PR DESCRIPTION
Summary:
`combineRangesAndNegatedValues` in `velox/type/Filter.cpp` computed `*it - 1` and `*it + 1` on rejected values without bounds checks, triggering UBSan signed-integer-overflow when the rejected list contained `INT64_MIN` (or symmetrically `INT64_MAX`) merged with a `BigintRange` whose bound included that value.

Skip the subtraction when `*it == INT64_MIN` (no value exists below it). Set an `exhausted` flag and skip the trailing emit when `*it == INT64_MAX`. Hoisted the out-of-range early-exit so the loop body never runs on rejects past `upper`

Differential Revision: D102705379


