### PR TITLE
build: Surface and fix MONO=OFF link gaps

### DIFF
--- a/velox/benchmarks/CMakeLists.txt
+++ b/velox/benchmarks/CMakeLists.txt
@@ -32,7 +32,7 @@ if(${VELOX_BUILD_TEST_UTILS})
 
   add_library(velox_benchmark_builder ExpressionBenchmarkBuilder.cpp)
   velox_add_test_headers(velox_benchmark_builder ExpressionBenchmarkBuilder.h)
-  target_link_libraries(velox_benchmark_builder ${velox_benchmark_deps})
+  target_link_libraries(velox_benchmark_builder ${velox_benchmark_deps} velox_vector_test_lib)
 
   # This is a workaround for the use of VectorTestBase.h which includes gtest.h
   target_link_libraries(velox_benchmark_builder GTest::gtest)

--- a/velox/connectors/CMakeLists.txt
+++ b/velox/connectors/CMakeLists.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 velox_add_library(velox_connector Connector.cpp HEADERS Connector.h ConnectorRegistryInternal.h)
 
-velox_link_libraries(velox_connector velox_common_config velox_vector)
+velox_link_libraries(velox_connector velox_common_config velox_exec_spill_stats velox_vector)
 
 velox_add_library(velox_connector_registry ConnectorRegistry.cpp HEADERS ConnectorRegistry.h)
 

--- a/velox/connectors/hive/CMakeLists.txt
+++ b/velox/connectors/hive/CMakeLists.txt
@@ -81,6 +81,7 @@ velox_link_libraries(
     velox_common_io
     velox_connector
     velox_dwio_catalog_fbhive
+    velox_exec
     velox_hive_partition_function
     velox_key_encoder
 )

--- a/velox/connectors/hive/iceberg/tests/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ if(VELOX_ENABLE_BENCHMARKS)
     velox_exec_test_lib
     velox_exec
     velox_hive_connector
+    velox_hive_iceberg_splitreader
     Folly::folly
     Folly::follybenchmark
     ${TEST_LINK_LIBS}
@@ -153,6 +154,8 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
     velox_dwio_common_test_utils
     velox_dwio_dwrf_reader
     velox_dwio_dwrf_writer
+    velox_dwio_parquet_reader
+    velox_dwio_parquet_writer
     GTest::gtest
     GTest::gtest_main
   )

--- a/velox/connectors/hive/paimon/tests/CMakeLists.txt
+++ b/velox/connectors/hive/paimon/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
   target_link_libraries(
     velox_hive_paimon_split_test
     velox_hive_paimon_split
+    velox_dwio_common
     GTest::gtest
     GTest::gtest_main
     GTest::gmock

--- a/velox/core/tests/CMakeLists.txt
+++ b/velox/core/tests/CMakeLists.txt
@@ -53,5 +53,5 @@ add_test(velox_core_plan_consistency_checker_test velox_core_plan_consistency_ch
 
 target_link_libraries(
   velox_core_plan_consistency_checker_test
-  PRIVATE velox_core GTest::gtest GTest::gtest_main
+  PRIVATE velox_core velox_exec GTest::gtest GTest::gtest_main
 )

--- a/velox/dwio/dwrf/test/CMakeLists.txt
+++ b/velox/dwio/dwrf/test/CMakeLists.txt
@@ -428,6 +428,7 @@ target_link_libraries(
   velox_dwio_dwrf_reader_test
   velox_dwrf_test_utils
   velox_vector_test_lib
+  velox_hive_connector
   velox_link_libs
   Folly::folly
   fmt::fmt

--- a/velox/dwio/parquet/writer/CMakeLists.txt
+++ b/velox/dwio/parquet/writer/CMakeLists.txt
@@ -22,6 +22,7 @@ velox_link_libraries(
   velox_dwio_arrow_parquet_writer_util_lib
   velox_dwio_common
   velox_arrow_bridge
+  velox_exec
   arrow
   fmt::fmt
 )

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -94,7 +94,6 @@ velox_add_library(
   SpatialJoinProbe.cpp
   Spill.cpp
   SpillFile.cpp
-  SpillStats.cpp
   Spiller.cpp
   StreamingAggregation.cpp
   StreamingEnforceDistinct.cpp
@@ -204,7 +203,6 @@ velox_add_library(
   SpatialJoinProbe.h
   Spill.h
   SpillFile.h
-  SpillStats.h
   Spiller.h
   Split.h
   StreamingAggregation.h
@@ -233,6 +231,9 @@ velox_add_library(
   WindowPartition.h
 )
 
+velox_add_library(velox_exec_spill_stats SpillStats.cpp HEADERS SpillStats.h)
+velox_link_libraries(velox_exec_spill_stats velox_common_base velox_file Folly::folly)
+
 velox_link_libraries(
   velox_exec
   velox_arrow_bridge
@@ -241,6 +242,7 @@ velox_link_libraries(
   velox_core
   velox_connector
   velox_connector_registry
+  velox_exec_spill_stats
   velox_expression
   velox_file
   velox_presto_serializer
@@ -249,6 +251,11 @@ velox_link_libraries(
   velox_test_util
   velox_vector
 )
+
+if(VELOX_ENABLE_GEO)
+  velox_compile_definitions(velox_exec PRIVATE VELOX_ENABLE_GEO)
+  velox_link_libraries(velox_exec velox_common_geospatial_serde)
+endif()
 
 velox_add_library(velox_cursor Cursor.cpp HEADERS Cursor.h)
 

--- a/velox/exec/rpc/tests/CMakeLists.txt
+++ b/velox/exec/rpc/tests/CMakeLists.txt
@@ -75,6 +75,7 @@ target_link_libraries(
   velox_rpc_rate_limiter
   GTest::gtest
   GTest::gtest_main
+  Folly::folly
 )
 
 add_test(NAME velox_rpc_rate_limiter_test COMMAND velox_rpc_rate_limiter_test)

--- a/velox/experimental/cudf/connectors/hive/CMakeLists.txt
+++ b/velox/experimental/cudf/connectors/hive/CMakeLists.txt
@@ -28,6 +28,6 @@ set_target_properties(velox_cudf_hive_connector PROPERTIES CUDA_ARCHITECTURES na
 
 target_link_libraries(
   velox_cudf_hive_connector
-  PRIVATE velox_hive_connector
+  PRIVATE velox_hive_connector velox_dwio_common
   PUBLIC cudf::cudf velox_cudf_expression
 )

--- a/velox/experimental/cudf/tests/utils/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/utils/CMakeLists.txt
@@ -37,5 +37,6 @@ target_link_libraries(
   velox_duckdb_conversion
   velox_file_test_utils
   velox_cudf_hive_connector
+  velox_s3fs
   velox_aggregates
 )

--- a/velox/expression/CMakeLists.txt
+++ b/velox/expression/CMakeLists.txt
@@ -121,6 +121,7 @@ velox_link_libraries(
   velox_core
   velox_vector
   velox_common_base
+  velox_core_expressions
   velox_expression_functions
   velox_functions_util
   velox_type_tz

--- a/velox/functions/prestosql/aggregates/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/CMakeLists.txt
@@ -134,9 +134,10 @@ velox_link_libraries(
   Folly::folly
 )
 
-if(${VELOX_ENABLE_GEO})
+if(VELOX_ENABLE_GEO)
   velox_sources(velox_aggregates PRIVATE GeometryAggregate.cpp)
   velox_link_libraries(velox_aggregates velox_functions_geo)
+  velox_compile_definitions(velox_aggregates PRIVATE VELOX_ENABLE_GEO)
 endif()
 
 if(${VELOX_BUILD_TESTING})

--- a/velox/functions/sparksql/types/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/types/tests/CMakeLists.txt
@@ -18,5 +18,8 @@ target_link_libraries(
   velox_spark_types_test
   velox_spark_types
   velox_vector_test_lib
+  velox_functions_spark
+  velox_parse_parser
+  velox_common_fuzzer_util
   GTest::gtest_main
 )

--- a/velox/functions/sparksql/window/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/window/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ set(
   velox_core
   velox_exec
   velox_exec_test_lib
+  velox_functions_spark_aggregates
   velox_functions_spark_window
   velox_functions_window_test_lib
   velox_vector_fuzzer

--- a/velox/parse/CMakeLists.txt
+++ b/velox/parse/CMakeLists.txt
@@ -11,19 +11,33 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# Leaf library that owns the out-of-line definitions for the
+# `velox::core` expression class hierarchy declared in Expressions.h
+# (CallExpr, CastExpr, FieldAccessExpr, ConstantExpr, LambdaExpr,
+# WindowCallExpr, ...). Lifted out of velox_parse_expression so that
+# velox_expression — which uses dynamic_cast on these classes — can
+# pick up the typeinfo without taking a dependency on
+# velox_parse_expression itself, which would close a cycle
+# (velox_parse_expression already depends on velox_expression).
+velox_add_library(velox_core_expressions Expressions.cpp HEADERS Expressions.h IExpr.h)
+velox_link_libraries(velox_core_expressions velox_common_base velox_type Folly::folly)
+
 velox_add_library(
   velox_parse_expression
   ExprRewriter.cpp
-  Expressions.cpp
   SqlExpressionsParser.cpp
   HEADERS
   ExprRewriter.h
-  Expressions.h
-  IExpr.h
   SqlExpressionsParser.h
   TypeResolver.h
 )
-velox_link_libraries(velox_parse_expression velox_type velox_parse_utils velox_expression)
+velox_link_libraries(
+  velox_parse_expression
+  velox_core_expressions
+  velox_type
+  velox_parse_utils
+  velox_expression
+)
 
 velox_add_library(
   velox_parse_parser

--- a/velox/type/tests/CMakeLists.txt
+++ b/velox/type/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ target_link_libraries(
   velox_type
   velox_type_test_lib
   velox_common_base
+  velox_expression
   Folly::folly
   GTest::gtest
   GTest::gtest_main


### PR DESCRIPTION
Summary:
The selective-build planner (D101717176, stacked above) needs `MONO=OFF` to produce a non-degenerate per-target dep graph; under `MONO=ON` every velox source maps to the same `libvelox.so` and the planner degenerates to a full build.

`MONO=OFF` surfaces dep-hygiene debt that `MONO=ON` hides. This diff fixes:

- **Missing direct deps** on a handful of test/benchmark/library targets (paimon, dwrf, iceberg, sparksql, cudf, parquet writer, hive connector) — one-line `target_link_libraries` adds.
- **Wrong link order** for typeinfo/symbol references — fixed at the library level (e.g. `velox_benchmark_builder` → `velox_vector_test_lib`) so CMake propagates correct order to all consumers.
- **`velox_connector` ↔ `velox_exec` cycle** via `exec::SpillStats`, and **`velox_expression` ↔ `velox_parse_expression` cycle** via `core::CallExpr` typeinfo — broken by extracting the shared symbols into leaf libraries (`velox_exec_spill_stats`, `velox_core_expressions`) that both sides depend on.
- **Per-target compile-define propagation** — `velox_compile_definitions(... VELOX_ENABLE_GEO)` only reached the mono target under `MONO=ON`; added it explicitly to `velox_aggregates` and `velox_exec` so geometry aggregates register and `SpatialJoinBuild`'s geo path compiles.
- **SYSTEM-include propagation** — `velox_exec`'s newly-active geo path pulled in `<geos/geom/Geometry.h>` whose `#warning` became a fatal `-Werror=cpp`; added `velox_link_libraries(velox_exec velox_common_geospatial_serde)` so geos's SYSTEM include path propagates.

`MONO=ON` builds unchanged — wrappers fold the new leaf libs into the mono target.

Differential Revision: D102198782


