### PR TITLE
feat(operator): Make spill IoStats key suffix configurable

### DIFF
--- a/velox/core/QueryConfig.cpp
+++ b/velox/core/QueryConfig.cpp
@@ -134,6 +134,7 @@ const std::vector<config::ConfigProperty>& QueryConfig::registeredProperties() {
     VELOX_REGISTER_QUERY_CONFIG(kAggregationSpillFileCreateConfig);
     VELOX_REGISTER_QUERY_CONFIG(kHashJoinSpillFileCreateConfig);
     VELOX_REGISTER_QUERY_CONFIG(kRowNumberSpillFileCreateConfig);
+    VELOX_REGISTER_QUERY_CONFIG(kSpillIoStatsKeySuffix);
     VELOX_REGISTER_QUERY_CONFIG(kSpillStartPartitionBit);
     VELOX_REGISTER_QUERY_CONFIG(kSpillNumPartitionBits);
     VELOX_REGISTER_QUERY_CONFIG(kMinSpillableReservationPct);

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -792,6 +792,19 @@ class QueryConfig {
       "",
       "Config for creating row number spill files.")
 
+  /// Suffix appended to filesystem IoStats keys harvested from the spill
+  /// FileSystem when folded into an operator's runtimeStats. Empty by
+  /// default. Set to a non-empty value (e.g. ".spill") to disambiguate
+  /// spill IoStats keys from connector IoStats keys that may be folded into
+  /// the same OperatorStats by other code paths.
+  VELOX_QUERY_CONFIG(
+      kSpillIoStatsKeySuffix,
+      spillIoStatsKeySuffix,
+      "spill_io_stats_key_suffix",
+      std::string,
+      "",
+      "Suffix appended to spill filesystem IoStats keys in runtimeStats.")
+
   /// Default offset spill start partition bit.
   VELOX_QUERY_CONFIG(
       kSpillStartPartitionBit,

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -482,10 +482,13 @@ void Operator::recordSpillStats() {
   }
 
   // Collect filesystem I/O stats for spilling.
+  const auto& spillIoStatsKeySuffix =
+      operatorCtx_->task()->queryCtx()->queryConfig().spillIoStatsKeySuffix();
   const auto ioStatsMap = spillStats_->ioStats.stats();
   for (const auto& [statName, statValue] : ioStatsMap) {
     lockedStats->addRuntimeStat(
-        statName, RuntimeCounter(statValue.sum, statValue.unit));
+        statName + spillIoStatsKeySuffix,
+        RuntimeCounter(statValue.sum, statValue.unit));
   }
 
   spillStats_->reset();


### PR DESCRIPTION
Summary:
Add a new `QueryConfig` setting `spill_io_stats_key_suffix` (default empty) that `Operator::recordSpillStats()` appends to every FileSystem IoStats key it folds into `OperatorStats::runtimeStats`. With the empty default, behavior is unchanged. Deployments whose connector and spill backend share a `velox::FileSystem` implementation can set the suffix (e.g. `.spill`) so spill IO surfaces under a distinct key instead of colliding with the connector's key.

On `TableWriter`, `Operator::close()` adds spill IoStats via `addRuntimeStat` (sum), and the next `TableWriter::stats()` overwrites every shared key with the connector's `dataSink_->runtimeStats()` via straight assignment. When both backends use the same FileSystem and emit IoStats from one global key namespace, the spill contribution for any shared key is silently dropped from the snapshot. The suffix puts spill keys in a distinct namespace so both values survive.

The `kSpill*` constants in `Operator.h` are unchanged -- those are the spill subsystem's own counters and have always been spill-specific. Only the dynamic FileSystem-supplied IoStats keys carry the suffix. Note the Warm Storage FileSystem keys are region-scoped (`wsWriteBytes.<region>`), so the suffix lands after the region segment, e.g. `wsWriteBytes.<region>.spill`.

Differential Revision: D103299645
