### PR TITLE
fix(exec): Preserve connector runtime stats on early termination (#17392)

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -301,6 +301,8 @@ class DataSource {
   /// connector-specific fields, and call scanBatchCallback_.
   virtual void fireScanBatchCallback(core::ScanBatchEvent /*event*/) {}
 
+  /// Returns cumulative runtime stats for work completed so far by this data
+  /// source.
   virtual std::unordered_map<std::string, RuntimeMetric> getRuntimeStats() {
     return {};
   }

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -67,6 +67,24 @@ std::unique_ptr<connector::DataSource> createDataSource(
   return dataSource;
 }
 
+// Snapshots cumulative 'dataSource' runtime stats into 'stats'. Must be called
+// with the operator stats lock held and from the Driver thread (the only thread
+// that mutates 'dataSource'). No-op if 'dataSource' is null.
+void copyConnectorRuntimeStatsLocked(
+    connector::DataSource* dataSource,
+    OperatorStats& stats) {
+  if (dataSource == nullptr) {
+    return;
+  }
+  for (const auto& [name, metric] : dataSource->getRuntimeStats()) {
+    if (auto it = stats.runtimeStats.find(name);
+        it != stats.runtimeStats.end()) {
+      VELOX_CHECK_EQ(it->second.unit, metric.unit);
+    }
+    stats.runtimeStats[name] = metric;
+  }
+}
+
 } // namespace
 
 TableScan::TableScan(
@@ -274,6 +292,7 @@ RowVectorPtr TableScan::getOutput() {
             RuntimeCounter(numReadyPreloadedSplits_));
         numReadyPreloadedSplits_ = 0;
       }
+      copyConnectorRuntimeStatsLocked(dataSource_.get(), *lockedStats);
       currNumRawInputRows = lockedStats->rawInputPositions;
     }
     VELOX_CHECK_LE(rawInputRowsSinceLastSplit_, currNumRawInputRows);
@@ -319,18 +338,6 @@ bool TableScan::getSplit() {
 
   if (!split.hasConnectorSplit()) {
     noMoreSplits_ = true;
-    if (dataSource_) {
-      const auto connectorStats = dataSource_->getRuntimeStats();
-      auto lockedStats = stats_.wlock();
-      for (const auto& [name, metric] : connectorStats) {
-        if (FOLLY_UNLIKELY(lockedStats->runtimeStats.count(name) == 0)) {
-          lockedStats->runtimeStats.emplace(name, RuntimeMetric(metric.unit));
-        } else {
-          VELOX_CHECK_EQ(lockedStats->runtimeStats.at(name).unit, metric.unit);
-        }
-        lockedStats->runtimeStats.at(name).merge(metric);
-      }
-    }
     return false;
   }
 
@@ -571,6 +578,7 @@ void TableScan::close() {
   Operator::close();
 
   if (dataSource_ != nullptr) {
+    copyConnectorRuntimeStatsLocked(dataSource_.get(), *stats_.wlock());
     dataSource_->cancel();
   }
 


### PR DESCRIPTION
Summary:

## Problem

TableScan currently harvests `dataSource_->getRuntimeStats()` only inside the noMoreSplits-sentinel branch of `getOutput`. That branch is only reached when the operator polls a split with `!hasConnectorSplit()` — i.e., when the coordinator's "no more splits" sentinel is processed via `getOutput`.

Anything that tears the operator down before it polls that sentinel drops the connector-side runtime stats on the floor (e.g. `LocalLimit` being satisfied, which does not set "no more splits" for upstream operators on the driver)

## Solution

Move the harvest into a `getOutput` and `close` override, ensuring that the stats are (almost) always included

## Alternative Implementations Considered

a) Harvest stats in `stats` method.

This pattern is used in other operators like `TableWriter`.

Problem: `dataSource_` is initialized lazily in the driver thread, while `stats` is called by a different thread. Therefore, the naive implementation has a TSAN violation.

This is solvable with synchronization, and arguably the "proper" solution, but it increases the scope/number of line changes. I decided it wasn't worth it.

b) Only harvest in `close`, not `getOutput`

Problem: there's no guarantee `close` runs prior to the final stats being collected.

In particular, in Prestissimo, if the coordinator deletes tasks prior to their completion (e.g. due to `FinalLimit` condition being met), then the on-thread drivers may not call `close` prior to final stats collection. This results in the IO stats completely missing.

Note that the general race condition (operator may still be running and updating the stats while we harvest the stats the final time) still exists in my solution. Instead, my solution gives us best-effort, most recently collected IO stats, instead of completely omitting the IO stats.

Reviewed By: Yuhta

Differential Revision: D103114178


