### PR TITLE
feat(dwio): Add public fileIoContext() accessor to ReadFileInputStream

### DIFF
--- a/velox/dwio/common/InputStream.h
+++ b/velox/dwio/common/InputStream.h
@@ -181,6 +181,10 @@ class ReadFileInputStream final : public InputStream {
     return readFile_;
   }
 
+  const FileIoContext& fileIoContext() const {
+    return fileIoContext_;
+  }
+
  private:
   FileIoContext fileIoContext_;
   std::shared_ptr<velox::ReadFile> readFile_;


### PR DESCRIPTION
Summary:
`ReadFileInputStream` constructs a `FileIoContext` from its constructor parameters and uses it as the third argument to every `readFile_->pread*` call it makes (see `read`, `readAsync`, `vread` in `velox/dwio/common/InputStream.cpp`). The context carries the operator's `IoStats*` and `cacheable` hint, threading per-call instrumentation context to whatever `velox::ReadFile` implementation backs the stream.

Today the `FileIoContext` is private. Callers that hold a `BufferedInput` (and therefore the `ReadFileInputStream` returned by `getInputStream()`) but want to issue *direct* `ReadFile::pread*` calls themselves — for example, format readers like Nimble's `TabletReader` that hold a raw `velox::ReadFile*` and bypass the BufferedInput for some reads — have no way to recover the same `FileIoContext` the input stream uses internally. They end up calling `pread*` with a default-constructed `FileIoContext{}`, dropping the per-call instrumentation context and producing inconsistent stats accounting between reads issued through the input stream and reads issued directly.

Add a public const accessor `fileIoContext()` returning a const reference to the stored `FileIoContext`, placed right next to the existing `getReadFile()` accessor. Pure addition — no behavior change for any existing caller.

Compatibility:
- Source-compatible: pure addition of a new const inline method.
- Binary-compatible: no member added, no virtual table change.
- Behavior-compatible: no existing code path modified.

Reviewed By: xiaoxmeng

Differential Revision: D103114177


