### PR TITLE
feat(iceberg): Added iceberg clustered writer

### DIFF
--- a/velox/connectors/hive/FileDataSink.cpp
+++ b/velox/connectors/hive/FileDataSink.cpp
@@ -232,6 +232,24 @@ void FileDataSink::finalizeWriterFile(size_t index) {
   info->cumulativeWrittenBytes = ioStats_[index]->rawBytesWritten();
 }
 
+void FileDataSink::closeWriterAndFinalize(size_t index) {
+  VELOX_CHECK_LT(index, writers_.size());
+  VELOX_CHECK_LT(index, writerInfo_.size());
+
+  if (writers_[index] == nullptr) {
+    return;
+  }
+
+  WRITER_NON_RECLAIMABLE_SECTION_GUARD(index);
+
+  VELOX_USER_CHECK(
+      !sortWrite(), "Clustered Iceberg writer does not support sorted writes");
+
+  writers_[index]->close();
+  finalizeWriterFile(index);
+  writers_[index].reset();
+}
+
 void FileDataSink::rotateWriter(size_t index) {
   VELOX_CHECK_LT(index, writers_.size());
   VELOX_CHECK_LT(index, writerInfo_.size());

--- a/velox/connectors/hive/FileDataSink.cpp
+++ b/velox/connectors/hive/FileDataSink.cpp
@@ -244,6 +244,58 @@ void FileDataSink::finalizeWriterFile(size_t index) {
   info->cumulativeWrittenBytes = ioStats_[index]->rawBytesWritten();
 }
 
+void FileDataSink::closeWriterAndFinalize(size_t index) {
+  VELOX_CHECK_LT(index, writers_.size());
+  VELOX_CHECK_LT(index, writerInfo_.size());
+
+  if (writers_[index] == nullptr) {
+    return;
+  }
+
+  WRITER_NON_RECLAIMABLE_SECTION_GUARD(index);
+
+  writers_[index]->close();
+  finalizeWriterFile(index);
+  mergeWriterStats(closedWriterStats_, writers_[index]->runtimeStats());
+  writers_[index].reset();
+}
+
+std::shared_ptr<WriterInfo> FileDataSink::releaseWriter(
+    size_t index,
+    const WriterId& id) {
+  VELOX_CHECK_EQ(index + 1, writers_.size());
+  VELOX_CHECK_EQ(writers_.size(), writerInfo_.size());
+  VELOX_CHECK_EQ(writerInfo_.size(), ioStats_.size());
+  VELOX_CHECK_EQ(ioStats_.size(), partitionSizes_.size());
+  VELOX_CHECK_EQ(partitionSizes_.size(), partitionRows_.size());
+  VELOX_CHECK_EQ(partitionRows_.size(), rawPartitionRows_.size());
+  VELOX_CHECK_NULL(writers_[index]);
+
+  const auto mapIt = writerIndexMap_.find(id);
+  VELOX_CHECK(mapIt != writerIndexMap_.end());
+  VELOX_CHECK_EQ(mapIt->second, index);
+
+  auto info = std::move(writerInfo_[index]);
+  VELOX_CHECK_NOT_NULL(info);
+
+  releasedWriterStats_.numWrittenBytes += ioStats_[index]->rawBytesWritten();
+  releasedWriterStats_.writeIOTimeUs += ioStats_[index]->writeIOTimeUs();
+  releasedWriterStats_.numWrittenFiles += info->writtenFiles.size();
+  if (!info->spillStats->empty()) {
+    releasedWriterStats_.spillStats += *info->spillStats;
+  }
+
+  writerIndexMap_.erase(mapIt);
+  writers_.pop_back();
+  writerInfo_.pop_back();
+  ioStats_.pop_back();
+  partitionSizes_.pop_back();
+  partitionRows_.pop_back();
+  rawPartitionRows_.pop_back();
+
+  return info;
+}
+
 void FileDataSink::rotateWriter(size_t index) {
   VELOX_CHECK_LT(index, writers_.size());
   VELOX_CHECK_LT(index, writerInfo_.size());
@@ -286,6 +338,8 @@ DataSink::Stats FileDataSink::stats() const {
     return stats;
   }
 
+  stats.numWrittenBytes = releasedWriterStats_.numWrittenBytes;
+  stats.writeIOTimeUs = releasedWriterStats_.writeIOTimeUs;
   for (const auto& ioStats : ioStats_) {
     stats.numWrittenBytes += ioStats->rawBytesWritten();
     stats.writeIOTimeUs += ioStats->writeIOTimeUs();
@@ -304,10 +358,10 @@ DataSink::Stats FileDataSink::stats() const {
     }
   }
 
-  // Count total files written, including rotated files.
-  stats.numWrittenFiles = 0;
-  for (size_t i = 0; i < writerInfo_.size(); ++i) {
-    const auto& info = writerInfo_.at(i);
+  // Count total files written, including rotated and released files.
+  stats.numWrittenFiles = releasedWriterStats_.numWrittenFiles;
+  stats.spillStats += releasedWriterStats_.spillStats;
+  for (const auto& info : writerInfo_) {
     VELOX_CHECK_NOT_NULL(info);
     stats.numWrittenFiles += info->writtenFiles.size();
     if (!info->spillStats->empty()) {
@@ -465,12 +519,11 @@ uint32_t FileDataSink::appendWriter(const WriterId& id) {
   if (sortWrite()) {
     sortPool = createSortPool(writerPool);
   }
-  writerInfo_.emplace_back(
-      std::make_shared<WriterInfo>(
-          std::move(writerParameters),
-          std::move(writerPool),
-          std::move(sinkPool),
-          std::move(sortPool)));
+  writerInfo_.emplace_back(std::make_shared<WriterInfo>(
+      std::move(writerParameters),
+      std::move(writerPool),
+      std::move(sinkPool),
+      std::move(sortPool)));
   ioStats_.emplace_back(std::make_unique<io::IoStatistics>());
 
   setMemoryReclaimers(writerInfo_.back().get(), ioStats_.back().get());

--- a/velox/connectors/hive/FileDataSink.h
+++ b/velox/connectors/hive/FileDataSink.h
@@ -373,6 +373,10 @@ class FileDataSink : public DataSink {
   // Finalizes the current file for the writer at the given index.
   void finalizeWriterFile(size_t index);
 
+  // Closes the physical writer at 'index', finalizes its current file metadata,
+  // and releases the writer object.
+  void closeWriterAndFinalize(size_t index);
+
   virtual void closeInternal();
 
   // IMPORTANT NOTE: these are passed to writers as raw pointers. FileDataSink

--- a/velox/connectors/hive/FileDataSink.h
+++ b/velox/connectors/hive/FileDataSink.h
@@ -373,6 +373,16 @@ class FileDataSink : public DataSink {
   // Finalizes the current file for the writer at the given index.
   void finalizeWriterFile(size_t index);
 
+  // Closes the physical writer at 'index', finalizes its current file metadata,
+  // and releases the writer object.
+  void closeWriterAndFinalize(size_t index);
+
+  // Removes a closed writer and its heavy resources from the last writer slot.
+  // Returns lightweight writer metadata so a subclass can retain its commit
+  // result. Statistics from the released writer remain available through
+  // stats().
+  std::shared_ptr<WriterInfo> releaseWriter(size_t index, const WriterId& id);
+
   virtual void closeInternal();
 
   // IMPORTANT NOTE: these are passed to writers as raw pointers. FileDataSink
@@ -426,6 +436,10 @@ class FileDataSink : public DataSink {
 
   // Reusable buffers for bucket id calculations.
   std::vector<uint32_t> bucketIds_;
+
+  // Statistics accumulated from writers whose heavy state has been released
+  // before the sink itself is closed.
+  Stats releasedWriterStats_;
 };
 
 FOLLY_ALWAYS_INLINE std::ostream& operator<<(

--- a/velox/connectors/hive/PartitionIdGenerator.cpp
+++ b/velox/connectors/hive/PartitionIdGenerator.cpp
@@ -16,16 +16,21 @@
 
 #include "velox/connectors/hive/PartitionIdGenerator.h"
 
+#include <algorithm>
+#include <limits>
+
 namespace facebook::velox::connector::hive {
 
 PartitionIdGenerator::PartitionIdGenerator(
     const RowTypePtr& inputType,
     std::vector<column_index_t> partitionChannels,
     uint32_t maxPartitions,
-    memory::MemoryPool* pool)
+    memory::MemoryPool* pool,
+    bool enforceMaxPartitions)
     : pool_(pool),
       partitionChannels_(std::move(partitionChannels)),
-      maxPartitions_(maxPartitions) {
+      maxPartitions_(maxPartitions),
+      enforceMaxPartitions_(enforceMaxPartitions) {
   VELOX_USER_CHECK(
       !partitionChannels_.empty(), "There must be at least one partition key.");
   for (auto channel : partitionChannels_) {
@@ -75,18 +80,42 @@ void PartitionIdGenerator::run(
       result[i] = it->second;
     } else {
       uint64_t nextPartitionId = partitionIds_.size();
-      VELOX_USER_CHECK_LT(
-          nextPartitionId,
-          maxPartitions_,
-          "Exceeded limit of {} distinct partitions.",
-          maxPartitions_);
+      if (enforceMaxPartitions_) {
+        VELOX_USER_CHECK_LT(
+            nextPartitionId,
+            maxPartitions_,
+            "Exceeded limit of {} distinct partitions.",
+            maxPartitions_);
+      }
 
       partitionIds_.emplace(valueId, nextPartitionId);
+      ensurePartitionValueCapacity(nextPartitionId);
       savePartitionValues(nextPartitionId, input, i);
 
       result[i] = nextPartitionId;
     }
   }
+}
+
+void PartitionIdGenerator::ensurePartitionValueCapacity(uint64_t partitionId) {
+  if (partitionId < partitionValues_->size()) {
+    return;
+  }
+
+  VELOX_USER_CHECK_LT(
+      partitionId,
+      static_cast<uint64_t>(std::numeric_limits<vector_size_t>::max()),
+      "Exceeded maximum supported number of distinct partitions");
+
+  const auto requiredSize = static_cast<vector_size_t>(partitionId + 1);
+  const auto currentSize = partitionValues_->size();
+  const auto maxSize = std::numeric_limits<vector_size_t>::max();
+  const auto doubledSize = currentSize > maxSize / 2
+      ? maxSize
+      : static_cast<vector_size_t>(currentSize * 2);
+  const auto newSize =
+      std::max<vector_size_t>(requiredSize, currentSize == 0 ? 1 : doubledSize);
+  partitionValues_->resize(newSize);
 }
 
 void PartitionIdGenerator::computeValueIds(

--- a/velox/connectors/hive/PartitionIdGenerator.h
+++ b/velox/connectors/hive/PartitionIdGenerator.h
@@ -29,11 +29,15 @@ class PartitionIdGenerator {
   /// @param maxPartitions The max number of distinct partitions.
   /// @param pool Memory pool. Used to allocate memory for storing unique
   /// partition key values.
+  /// @param enforceMaxPartitions Whether to reject inputs with more than
+  /// maxPartitions distinct partitions. If false, storage for partition values
+  /// grows as needed.
   PartitionIdGenerator(
       const RowTypePtr& inputType,
       std::vector<column_index_t> partitionChannels,
       uint32_t maxPartitions,
-      memory::MemoryPool* pool);
+      memory::MemoryPool* pool,
+      bool enforceMaxPartitions = true);
 
   /// Generate sequential partition IDs for input vector.
   /// @param input Input RowVector.
@@ -77,11 +81,18 @@ class PartitionIdGenerator {
       const RowVectorPtr& input,
       vector_size_t row);
 
+  // Grows partitionValues_ to include 'partitionId'. This is used when the
+  // number of historical partitions is not limited by the number of writers
+  // that may be open simultaneously.
+  void ensurePartitionValueCapacity(uint64_t partitionId);
+
   memory::MemoryPool* const pool_;
 
   const std::vector<column_index_t> partitionChannels_;
 
   const uint32_t maxPartitions_;
+
+  const bool enforceMaxPartitions_;
 
   std::vector<std::unique_ptr<exec::VectorHasher>> hashers_;
   bool hasMultiplierSet_ = false;

--- a/velox/connectors/hive/iceberg/IcebergConfig.cpp
+++ b/velox/connectors/hive/iceberg/IcebergConfig.cpp
@@ -32,4 +32,9 @@ std::string IcebergConfig::functionPrefix() const {
       kFunctionPrefixConfig, kDefaultFunctionPrefix);
 }
 
+bool IcebergConfig::fanoutEnabled(const config::ConfigBase* session) const {
+  return session->get<bool>(
+      kFanoutEnabledSession, config_->get<bool>(kFanoutEnabled, true));
+}
+
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergConfig.h
+++ b/velox/connectors/hive/iceberg/IcebergConfig.h
@@ -35,6 +35,12 @@ class IcebergConfig {
   /// connector config override is provided.
   static constexpr const char* kDefaultFunctionPrefix = "$internal$.iceberg.";
 
+  /// Controls the writer mode, whether the fanout mode writer is enabled,
+  /// default value is true, setting to false means clustered mode.
+  /// Currently applies only to the Iceberg writer.
+  static constexpr const char* kFanoutEnabled = "fanout-enabled";
+  static constexpr const char* kFanoutEnabledSession = "fanout_enabled";
+
   explicit IcebergConfig(
       const std::shared_ptr<const config::ConfigBase>& config);
 
@@ -43,6 +49,9 @@ class IcebergConfig {
   }
 
   std::string functionPrefix() const;
+
+  /// Return if fanout writer mode is enabled.
+  bool fanoutEnabled(const config::ConfigBase* session) const;
 
  private:
   const std::shared_ptr<const config::ConfigBase> config_;

--- a/velox/connectors/hive/iceberg/IcebergDataSink.cpp
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.cpp
@@ -303,8 +303,103 @@ IcebergDataSink::IcebergDataSink(
           partitionSpec_ != nullptr
               ? std::make_unique<IcebergPartitionName>(partitionSpec_)
               : nullptr),
-      partitionRowType_(std::move(partitionRowType)) {
-  commitPartitionValue_.resize(maxOpenWriters_);
+      partitionRowType_(std::move(partitionRowType)),
+      clusteredWrite_(!icebergConfig->fanoutEnabled(
+          connectorQueryCtx_->sessionProperties())) {
+  commitPartitionValue_.resize(writerInfo_.size());
+}
+
+void IcebergDataSink::appendData(RowVectorPtr input) {
+  if (!clusteredWrite_) {
+    HiveDataSink::appendData(std::move(input));
+    return;
+  }
+
+  clusteredAppendData(std::move(input));
+}
+
+void IcebergDataSink::clusteredAppendData(RowVectorPtr input) {
+  checkRunning();
+
+  input->loadedVector();
+
+  // Unpartitioned Iceberg doesn't need clustered routing.
+  if (!isPartitioned()) {
+    const auto index = ensureWriter(WriterId::unpartitionedId());
+    write(index, input);
+    return;
+  }
+
+  VELOX_USER_CHECK(
+      !sortWrite(), "Clustered Iceberg writer does not support sorted writes");
+
+  computePartitionAndBucketIds(input);
+
+  std::fill(partitionSizes_.begin(), partitionSizes_.end(), 0);
+
+  const auto numRows = input->size();
+
+  for (vector_size_t row = 0; row < numRows; ++row) {
+    const auto id = getWriterId(row);
+
+    if (!currentClusteredWriterId_.has_value()) {
+      checkClusteredWriterNotClosed(id);
+      currentClusteredWriterId_ = id;
+      currentClusteredWriterIndex_ = ensureWriter(id);
+    } else if (*currentClusteredWriterId_ != id) {
+      writeRowsToClusteredWriter(input, *currentClusteredWriterIndex_);
+      closeCurrentClusteredWriter();
+
+      checkClusteredWriterNotClosed(id);
+      currentClusteredWriterId_ = id;
+      currentClusteredWriterIndex_ = ensureWriter(id);
+    }
+
+    updatePartitionRows(*currentClusteredWriterIndex_, numRows, row);
+  }
+
+  if (currentClusteredWriterIndex_.has_value()) {
+    writeRowsToClusteredWriter(input, *currentClusteredWriterIndex_);
+  }
+}
+
+void IcebergDataSink::writeRowsToClusteredWriter(
+    const RowVectorPtr& input,
+    uint32_t writerIndex) {
+  const auto partitionSize = partitionSizes_[writerIndex];
+  if (partitionSize == 0) {
+    return;
+  }
+
+  VELOX_CHECK_NOT_NULL(partitionRows_[writerIndex]);
+  partitionRows_[writerIndex]->setSize(partitionSize * sizeof(vector_size_t));
+
+  RowVectorPtr writerInput = partitionSize == input->size()
+      ? input
+      : exec::wrap(partitionSize, partitionRows_[writerIndex], input);
+
+  write(writerIndex, writerInput);
+
+  partitionSizes_[writerIndex] = 0;
+}
+
+void IcebergDataSink::closeCurrentClusteredWriter() {
+  VELOX_CHECK(currentClusteredWriterId_.has_value());
+  VELOX_CHECK(currentClusteredWriterIndex_.has_value());
+
+  closedClusteredWriterIds_.insert(*currentClusteredWriterId_);
+
+  closeWriterAndFinalize(*currentClusteredWriterIndex_);
+
+  currentClusteredWriterId_.reset();
+  currentClusteredWriterIndex_.reset();
+}
+
+void IcebergDataSink::checkClusteredWriterNotClosed(const WriterId& id) const {
+  VELOX_USER_CHECK_EQ(
+      closedClusteredWriterIds_.count(id),
+      0,
+      "Iceberg clustered writer requires input rows to be clustered by partition");
 }
 
 std::vector<std::string> IcebergDataSink::commitMessage() const {
@@ -378,10 +473,16 @@ std::string IcebergDataSink::getPartitionName(uint32_t partitionId) const {
 }
 
 uint32_t IcebergDataSink::ensureWriter(const WriterId& id) {
-  auto writerId = HiveDataSink::ensureWriter(id);
+  const auto writerId = HiveDataSink::ensureWriter(id);
+
+  if (commitPartitionValue_.size() <= writerId) {
+    commitPartitionValue_.resize(writerId + 1);
+  }
+
   if (isPartitioned() && commitPartitionValue_[writerId].isNull()) {
     commitPartitionValue_[writerId] = makeCommitPartitionValue(writerId);
   }
+
   return writerId;
 }
 

--- a/velox/connectors/hive/iceberg/IcebergDataSink.cpp
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.cpp
@@ -288,6 +288,18 @@ folly::dynamic buildIcebergCommitData(
   return commitData;
 }
 
+void mergeWriterStats(
+    folly::F14FastMap<std::string, RuntimeMetric>& mergedStats,
+    const folly::F14FastMap<std::string, RuntimeMetric>& stats) {
+  for (const auto& [name, metric] : stats) {
+    auto [it, inserted] = mergedStats.emplace(name, metric);
+    if (!inserted) {
+      VELOX_CHECK_EQ(it->second.unit, metric.unit);
+      it->second.merge(metric);
+    }
+  }
+}
+
 } // namespace
 
 IcebergDataSink::IcebergDataSink(
@@ -344,7 +356,9 @@ IcebergDataSink::IcebergDataSink(
                     }(),
                     hiveConfig->maxPartitionsPerWriters(
                         connectorQueryCtx->sessionProperties()),
-                    connectorQueryCtx->memoryPool())
+                    connectorQueryCtx->memoryPool(),
+                    icebergConfig->fanoutEnabled(
+                        connectorQueryCtx->sessionProperties()))
               : nullptr),
       partitionSpec_(insertTableHandle->partitionSpec()),
       transformEvaluator_(
@@ -361,8 +375,10 @@ IcebergDataSink::IcebergDataSink(
               ? std::make_unique<IcebergPartitionName>(partitionSpec_)
               : nullptr),
       partitionRowType_(std::move(partitionRowType)),
-      icebergInsertTableHandle_(insertTableHandle) {
-  commitPartitionValue_.resize(maxOpenWriters_);
+      icebergInsertTableHandle_(insertTableHandle),
+      clusteredWrite_(!icebergConfig->fanoutEnabled(
+          connectorQueryCtx_->sessionProperties())) {
+  commitPartitionValue_.resize(writerInfo_.size());
 
   // Build the column handle list once for whichever format-specific stats
   // collector applies.
@@ -379,42 +395,185 @@ IcebergDataSink::IcebergDataSink(
       insertTableHandle->storageFormat(), columnHandles, inputType_);
 }
 
+void IcebergDataSink::appendData(RowVectorPtr input) {
+  if (!clusteredWrite_) {
+    HiveDataSink::appendData(std::move(input));
+    return;
+  }
+
+  clusteredAppendData(std::move(input));
+}
+
+void IcebergDataSink::clusteredAppendData(RowVectorPtr input) {
+  checkRunning();
+
+  input->loadedVector();
+
+  // Unpartitioned Iceberg doesn't need clustered routing.
+  if (!isPartitioned()) {
+    const auto index = ensureWriter(WriterId::unpartitionedId());
+    write(index, input);
+    return;
+  }
+
+  VELOX_USER_CHECK(
+      !sortWrite(), "Clustered Iceberg writer does not support sorted writes");
+  VELOX_DCHECK(!isBucketed());
+
+  computePartitionAndBucketIds(input);
+
+  const auto numRows = input->size();
+  for (vector_size_t runStart = 0; runStart < numRows;) {
+    const auto id = getWriterId(runStart);
+    auto runEnd = runStart + 1;
+    while (runEnd < numRows &&
+           partitionIds_[runEnd] == partitionIds_[runStart]) {
+      ++runEnd;
+    }
+
+    ensureClusteredWriter(id);
+
+    const auto runSize = runEnd - runStart;
+    RowVectorPtr writerInput = input;
+    if (runSize != numRows) {
+      writerInput =
+          std::dynamic_pointer_cast<RowVector>(input->slice(runStart, runSize));
+      VELOX_CHECK_NOT_NULL(writerInput);
+    }
+    write(*currentClusteredWriterIndex_, std::move(writerInput));
+
+    runStart = runEnd;
+  }
+}
+
+void IcebergDataSink::ensureClusteredWriter(const WriterId& id) {
+  if (currentClusteredWriterId_ == id) {
+    return;
+  }
+
+  validateNewClusteredWriter(id);
+  if (currentClusteredWriterId_.has_value()) {
+    closeCurrentClusteredWriter();
+  }
+
+  currentClusteredWriterId_ = id;
+  currentClusteredWriterIndex_ = ensureWriter(id);
+  lastClusteredPartitionId_ = id.partitionId;
+}
+
+void IcebergDataSink::validateNewClusteredWriter(const WriterId& id) const {
+  VELOX_CHECK(id.partitionId.has_value());
+
+  const uint64_t expectedPartitionId = lastClusteredPartitionId_.has_value()
+      ? static_cast<uint64_t>(*lastClusteredPartitionId_) + 1
+      : 0;
+  VELOX_USER_CHECK_EQ(
+      id.partitionId.value(),
+      expectedPartitionId,
+      "Iceberg clustered writer requires input rows to be clustered by partition");
+}
+
+void IcebergDataSink::closeCurrentClusteredWriter() {
+  VELOX_CHECK(currentClusteredWriterId_.has_value());
+  VELOX_CHECK(currentClusteredWriterIndex_.has_value());
+
+  const auto id = *currentClusteredWriterId_;
+  const auto index = *currentClusteredWriterIndex_;
+
+  if (dataFileStats_.size() <= index) {
+    dataFileStats_.resize(index + 1);
+  }
+  {
+    const memory::NonReclaimableSectionGuard nonReclaimableGuard(
+        writerInfo_[index]->nonReclaimableSectionHolder.get());
+    closeWriterAndCollectStats(index);
+  }
+
+  VELOX_CHECK_EQ(commitPartitionValue_.size(), index + 1);
+  auto partitionValue = std::move(commitPartitionValue_[index]);
+  auto dataFileStats = std::move(dataFileStats_[index]);
+  auto writerInfo = releaseWriter(index, id);
+  commitPartitionValue_.pop_back();
+  dataFileStats_.pop_back();
+  if (reportedRowsPerWriter_.size() == index + 1) {
+    reportedRowsPerWriter_.pop_back();
+  }
+  saveCompletedClusteredWriter(
+      writerInfo, std::move(dataFileStats), std::move(partitionValue));
+
+  currentClusteredWriterId_.reset();
+  currentClusteredWriterIndex_.reset();
+}
+
+void IcebergDataSink::saveCompletedClusteredWriter(
+    const std::shared_ptr<WriterInfo>& writerInfo,
+    std::vector<IcebergDataFileStatisticsPtr> dataFileStats,
+    folly::dynamic partitionValue) {
+  VELOX_CHECK_NOT_NULL(writerInfo);
+  if (writerInfo->writtenFiles.empty()) {
+    return;
+  }
+
+  completedClusteredWriters_.push_back(CompletedClusteredWriter{
+      writerInfo->writerParameters.targetDirectory(),
+      std::move(writerInfo->writtenFiles),
+      std::move(dataFileStats),
+      std::move(partitionValue)});
+}
+
 std::vector<std::string> IcebergDataSink::commitMessage() const {
   std::vector<std::string> commitTasks;
-  commitTasks.reserve(writerInfo_.size());
+  commitTasks.reserve(completedClusteredWriters_.size() + writerInfo_.size());
+
+  const auto appendCommitTasks =
+      [&commitTasks, this](
+          const std::string& targetDirectory,
+          const std::vector<FileInfo>& writtenFiles,
+          const std::vector<IcebergDataFileStatisticsPtr>& dataFileStats,
+          const folly::dynamic& partitionValue) {
+        // Following metadata (json format) is consumed by Presto
+        // CommitTaskData. It contains the minimal subset of metadata.
+        VELOX_CHECK_EQ(writtenFiles.size(), dataFileStats.size());
+        for (auto fileIdx = 0; fileIdx < writtenFiles.size(); ++fileIdx) {
+          const auto& fileInfo = writtenFiles[fileIdx];
+          folly::dynamic commitData = buildIcebergCommitData(
+              (fs::path(targetDirectory) / fileInfo.targetFileName).string(),
+              fileInfo.fileSize,
+              dataFileStats[fileIdx]->toJson(),
+              icebergInsertTableHandle_->partitionSpec()
+                  ? icebergInsertTableHandle_->partitionSpec()->specId
+                  : 0,
+              toManifestFormatString(
+                  icebergInsertTableHandle_->storageFormat()),
+              icebergInsertTableHandle_->writeKind() ==
+                  IcebergInsertTableHandle::WriteKind::kDeletionVector);
+          if (!partitionValue.isNull()) {
+            commitData["partitionDataJson"] = folly::toJson(
+                folly::dynamic::object("partitionValues", partitionValue));
+          }
+          commitTasks.push_back(folly::toJson(commitData));
+        }
+      };
+
+  for (const auto& completedWriter : completedClusteredWriters_) {
+    appendCommitTasks(
+        completedWriter.targetDirectory,
+        completedWriter.writtenFiles,
+        completedWriter.dataFileStats,
+        completedWriter.partitionValue);
+  }
 
   for (auto i = 0; i < writerInfo_.size(); ++i) {
-    const auto& writerInfo = writerInfo_.at(i);
+    const auto& writerInfo = writerInfo_[i];
     VELOX_CHECK_NOT_NULL(writerInfo);
-
-    // Following metadata (json format) is consumed by Presto CommitTaskData.
-    // It contains the minimal subset of metadata.
-    VELOX_CHECK_EQ(writerInfo->writtenFiles.size(), dataFileStats_[i].size());
-    for (auto fileIdx = 0; fileIdx < writerInfo->writtenFiles.size();
-         ++fileIdx) {
-      const auto& fileInfo = writerInfo->writtenFiles[fileIdx];
-      folly::dynamic commitData = buildIcebergCommitData(
-          (fs::path(writerInfo->writerParameters.targetDirectory()) /
-           fileInfo.targetFileName)
-              .string(),
-          fileInfo.fileSize,
-          dataFileStats_[i][fileIdx]->toJson(),
-          icebergInsertTableHandle_->partitionSpec()
-              ? icebergInsertTableHandle_->partitionSpec()->specId
-              : 0,
-          toManifestFormatString(icebergInsertTableHandle_->storageFormat()),
-          icebergInsertTableHandle_->writeKind() ==
-              IcebergInsertTableHandle::WriteKind::kDeletionVector);
-      if (!commitPartitionValue_.empty() &&
-          !commitPartitionValue_[i].isNull()) {
-        commitData["partitionDataJson"] = folly::toJson(
-            folly::dynamic::object(
-                "partitionValues", commitPartitionValue_[i]));
-      }
-      auto commitDataJson = folly::toJson(commitData);
-      commitTasks.push_back(commitDataJson);
-    }
+    appendCommitTasks(
+        writerInfo->writerParameters.targetDirectory(),
+        writerInfo->writtenFiles,
+        dataFileStats_[i],
+        i < commitPartitionValue_.size() ? commitPartitionValue_[i]
+                                         : folly::dynamic());
   }
+
   return commitTasks;
 }
 
@@ -445,10 +604,18 @@ std::string IcebergDataSink::getPartitionName(uint32_t partitionId) const {
 }
 
 uint32_t IcebergDataSink::ensureWriter(const WriterId& id) {
-  auto writerId = HiveDataSink::ensureWriter(id);
-  if (isPartitioned() && commitPartitionValue_[writerId].isNull()) {
-    commitPartitionValue_[writerId] = makeCommitPartitionValue(writerId);
+  const auto writerId = HiveDataSink::ensureWriter(id);
+
+  if (commitPartitionValue_.size() <= writerId) {
+    commitPartitionValue_.resize(writerId + 1);
   }
+
+  if (isPartitioned() && commitPartitionValue_[writerId].isNull()) {
+    VELOX_CHECK(id.partitionId.has_value());
+    commitPartitionValue_[writerId] =
+        makeCommitPartitionValue(id.partitionId.value());
+  }
+
   return writerId;
 }
 
@@ -516,16 +683,16 @@ IcebergDataSink::createWriterOptions(size_t writerIndex) const {
 }
 
 folly::dynamic IcebergDataSink::makeCommitPartitionValue(
-    uint32_t writerIndex) const {
+    uint32_t partitionId) const {
   folly::dynamic partitionValues = folly::dynamic::array();
   const auto& transformedValues = partitionIdGenerator_->partitionValues();
   for (auto i = 0; i < partitionChannels_.size(); ++i) {
     const auto& child = transformedValues->childAt(i);
-    if (child->isNullAt(writerIndex)) {
+    if (child->isNullAt(partitionId)) {
       partitionValues.push_back(nullptr);
     } else {
       partitionValues.push_back(VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
-          extractPartitionValue, child->typeKind(), child, writerIndex));
+          extractPartitionValue, child->typeKind(), child, partitionId));
     }
   }
   return partitionValues;
@@ -535,10 +702,16 @@ void IcebergDataSink::closeWriterAndCollectStats(size_t index) {
   auto metadata = writers_[index]->close();
   const bool fileAdded = getCurrentFileBytes(index) > 0;
 
+  const auto releasePhysicalWriter = [&]() {
+    mergeWriterStats(closedWriterStats_, writers_[index]->runtimeStats());
+    writers_[index].reset();
+  };
+
   // Finalize file info (capture file size, add to writtenFiles).
   finalizeWriterFile(index);
 
   if (!fileAdded) {
+    releasePhysicalWriter();
     return;
   }
   // Collect format-specific per-file statistics: DWRF/ORC read the live
@@ -547,6 +720,7 @@ void IcebergDataSink::closeWriterAndCollectStats(size_t index) {
   if (statsCollector_ != nullptr) {
     if (auto stats = statsCollector_->collect(*writers_[index], metadata)) {
       dataFileStats_[index].emplace_back(std::move(stats));
+      releasePhysicalWriter();
       return;
     }
   }
@@ -574,6 +748,7 @@ void IcebergDataSink::closeWriterAndCollectStats(size_t index) {
   // That only degrades predicate pruning (a perf optimization), not
   // correctness.
   dataFileStats_[index].emplace_back(std::move(stats));
+  releasePhysicalWriter();
 }
 
 void IcebergDataSink::rotateWriter(size_t index) {
@@ -595,10 +770,6 @@ void IcebergDataSink::rotateWriter(size_t index) {
         writerInfo_[index]->nonReclaimableSectionHolder.get());
     closeWriterAndCollectStats(index);
   }
-
-  // Release old writer. The new writer will be created lazily on the next
-  // write call.
-  writers_[index].reset();
 
   ++writerInfo_[index]->fileSequenceNumber;
 }

--- a/velox/connectors/hive/iceberg/IcebergDataSink.h
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.h
@@ -106,6 +106,8 @@ class IcebergDataSink : public HiveDataSink {
   /// Presto and Spark Iceberg commit protocol.
   std::vector<std::string> commitMessage() const override;
 
+  void appendData(RowVectorPtr input) override;
+
  private:
   IcebergDataSink(
       RowTypePtr inputType,
@@ -151,6 +153,16 @@ class IcebergDataSink : public HiveDataSink {
   // the writer in commitPartitionValue_ if not already set, which will be
   // included in the commit message as "partitionDataJson".
   uint32_t ensureWriter(const WriterId& id) override;
+
+  void clusteredAppendData(RowVectorPtr input);
+
+  void writeRowsToClusteredWriter(
+      const RowVectorPtr& input,
+      uint32_t writerIndex);
+
+  void closeCurrentClusteredWriter();
+
+  void checkClusteredWriterNotClosed(const WriterId& id) const;
 
   // Creates writer options configured for Iceberg table writes. Extends the
   // base HiveDataSink writer options with Iceberg-specific settings:
@@ -213,6 +225,20 @@ class IcebergDataSink : public HiveDataSink {
   // folly::dynamic array of values across all partition fields), ready for JSON
   // serialization.
   std::vector<folly::dynamic> commitPartitionValue_;
+
+  // Enable this initially by hardcoding true, or wire it to a config/session
+  // property if your engine exposes one.
+  const bool clusteredWrite_;
+
+  // Current logical Iceberg partition writer. Kept open across input batches so
+  // clustered data split across batches remains valid.
+  std::optional<WriterId> currentClusteredWriterId_;
+  std::optional<uint32_t> currentClusteredWriterIndex_;
+
+  // Logical writer IDs that have already been closed. If one appears again, the
+  // input is not clustered.
+  folly::F14FastSet<WriterId, WriterIdHasher, WriterIdEq>
+      closedClusteredWriterIds_;
 };
 
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergDataSink.h
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.h
@@ -209,6 +209,8 @@ class IcebergDataSink : public HiveDataSink {
   /// Presto and Spark Iceberg commit protocol.
   std::vector<std::string> commitMessage() const override;
 
+  void appendData(RowVectorPtr input) override;
+
  private:
   IcebergDataSink(
       RowTypePtr inputType,
@@ -255,6 +257,24 @@ class IcebergDataSink : public HiveDataSink {
   // included in the commit message as "partitionDataJson".
   uint32_t ensureWriter(const WriterId& id) override;
 
+  void clusteredAppendData(RowVectorPtr input);
+
+  // Makes 'id' the active clustered writer, closing and releasing the previous
+  // writer when the partition changes.
+  void ensureClusteredWriter(const WriterId& id);
+
+  // Validates that a newly observed partition has not already been closed.
+  void validateNewClusteredWriter(const WriterId& id) const;
+
+  void closeCurrentClusteredWriter();
+
+  // Retains commit metadata while allowing the active writer pools and I/O
+  // state to be destroyed.
+  void saveCompletedClusteredWriter(
+      const std::shared_ptr<WriterInfo>& writerInfo,
+      std::vector<IcebergDataFileStatisticsPtr> dataFileStats,
+      folly::dynamic partitionValue);
+
   // Creates writer options configured for Iceberg table writes. Extends the
   // base HiveDataSink writer options with Iceberg-specific settings:
   // - Sets timestamp timezone to nullopt (UTC) for Iceberg compliance.
@@ -262,13 +282,16 @@ class IcebergDataSink : public HiveDataSink {
   std::shared_ptr<dwio::common::WriterOptions> createWriterOptions(
       size_t writerIndex) const override;
 
-  // Extracts partition values for a specific writer to be included in the
-  // commit message. Converts the transformed partition values from columnar
-  // storage (partitionIdGenerator_->partitionValues() where each partition
-  // field is a separate column) to row storage (a folly::dynamic array of
-  // values for the given writer index) for JSON serialization.
-  // Returns nullptr for null partition values.
-  folly::dynamic makeCommitPartitionValue(uint32_t writerIndex) const;
+  // Extracts transformed values for 'partitionId' into the row-oriented JSON
+  // representation required by the commit protocol.
+  folly::dynamic makeCommitPartitionValue(uint32_t partitionId) const;
+
+  struct CompletedClusteredWriter {
+    std::string targetDirectory;
+    std::vector<FileInfo> writtenFiles;
+    std::vector<IcebergDataFileStatisticsPtr> dataFileStats;
+    folly::dynamic partitionValue;
+  };
 
   // Closes the active writer at 'index' to flush its file footer, captures
   // the file metadata for Iceberg stats aggregation (via
@@ -366,6 +389,15 @@ class IcebergDataSink : public HiveDataSink {
   // via IcebergStatsCollector::create() and reused across all writers. Null
   // when the format has no Iceberg statistics support compiled in.
   std::shared_ptr<IcebergStatsCollector> statsCollector_;
+
+  const bool clusteredWrite_;
+
+  // The clustered path keeps at most one physical writer alive. Completed
+  // writers retain only the metadata needed for commit messages.
+  std::optional<WriterId> currentClusteredWriterId_;
+  std::optional<uint32_t> currentClusteredWriterIndex_;
+  std::optional<uint32_t> lastClusteredPartitionId_;
+  std::vector<CompletedClusteredWriter> completedClusteredWriters_;
 };
 
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/tests/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/tests/CMakeLists.txt
@@ -63,6 +63,7 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
     IcebergConnectorTest.cpp
     IcebergInsertTest.cpp
     IcebergTestBase.cpp
+    IcebergWriteModeTest.cpp
     Main.cpp
     PartitionNameTest.cpp
     PartitionSpecTest.cpp

--- a/velox/connectors/hive/iceberg/tests/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/tests/CMakeLists.txt
@@ -73,6 +73,7 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
     IcebergParquetStatsTest.cpp
     IcebergSessionCredentialsE2ETest.cpp
     IcebergTestBase.cpp
+    IcebergWriteModeTest.cpp
     Main.cpp
     PartitionNameTest.cpp
     PartitionSpecTest.cpp

--- a/velox/connectors/hive/iceberg/tests/IcebergWriteModeTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergWriteModeTest.cpp
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/connectors/hive/iceberg/tests/IcebergTestBase.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/exec/tests/utils/TempDirectoryPath.h"
+
+using namespace facebook::velox::exec::test;
+
+namespace facebook::velox::connector::hive::iceberg::test {
+
+class IcebergWriterModeTest : public IcebergTestBase,
+                              public ::testing::WithParamInterface<bool> {
+ protected:
+  void SetUp() override {
+    IcebergTestBase::SetUp();
+
+    setConnectorSessionProperty(
+        IcebergConfig::kFanoutEnabledSession, GetParam() ? "true" : "false");
+  }
+
+  RowTypePtr rowType_;
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    FanoutModes,
+    IcebergWriterModeTest,
+    ::testing::Values(true, false),
+    [](const testing::TestParamInfo<bool>& info) {
+      return info.param ? "FanoutEnabled" : "FanoutDisabled";
+    });
+
+TEST_P(IcebergWriterModeTest, identityPartitioning) {
+  constexpr auto size = 10;
+  std::vector<std::string> names = {"c_int"};
+  std::vector<TypePtr> types = {INTEGER()};
+  rowType_ = ROW(names, types);
+
+  auto outputDirectory = TempDirectoryPath::create();
+  auto dataSink = createDataSink(
+      rowType_,
+      outputDirectory->getPath(),
+      {{0, TransformType::kIdentity, std::nullopt}});
+
+  auto intVector1 =
+      makeFlatVector<int32_t>(size, [](vector_size_t row) { return row; });
+  auto vector1 = makeRowVector(names, {intVector1});
+  auto intVector2 =
+      makeFlatVector<int32_t>(size, [](vector_size_t row) { return row + 10; });
+  auto vector2 = makeRowVector(names, {intVector2});
+  dataSink->appendData(vector1);
+  dataSink->appendData(vector2);
+  ASSERT_TRUE(dataSink->finish());
+  dataSink->close();
+  createDuckDbTable({vector1, vector2});
+  auto splits = createSplitsForDirectory(outputDirectory->getPath());
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(test::kIcebergConnectorId)
+                  .outputType(rowType_)
+                  .endTableScan()
+                  .planNode();
+  assertQuery(plan, splits, fmt::format("SELECT * FROM tmp"));
+}
+
+TEST_P(IcebergWriterModeTest, clusteredInput) {
+  constexpr auto size = 100;
+  std::vector<std::string> names = {"c_int"};
+  std::vector<TypePtr> types = {INTEGER()};
+  rowType_ = ROW(names, types);
+
+  auto outputDirectory = TempDirectoryPath::create();
+  auto dataSink = createDataSink(
+      rowType_,
+      outputDirectory->getPath(),
+      {{0, TransformType::kIdentity, std::nullopt}});
+
+  auto intVector1 = makeConstant(100, size, INTEGER());
+  auto vector1 = makeRowVector(names, {intVector1});
+  auto intVector2 = makeConstant(100, size, INTEGER());
+  auto vector2 = makeRowVector(names, {intVector2});
+  dataSink->appendData(vector1);
+  dataSink->appendData(vector2);
+  ASSERT_TRUE(dataSink->finish());
+  dataSink->close();
+  createDuckDbTable({vector1, vector2});
+  auto splits = createSplitsForDirectory(outputDirectory->getPath());
+  ASSERT_EQ(splits.size(), 1);
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(test::kIcebergConnectorId)
+                  .outputType(rowType_)
+                  .endTableScan()
+                  .planNode();
+  assertQuery(plan, splits, fmt::format("SELECT * FROM tmp"));
+}
+
+TEST_P(IcebergWriterModeTest, clusteredNullInput) {
+  constexpr auto size = 100;
+  std::vector<std::string> names = {"c_int"};
+  std::vector<TypePtr> types = {INTEGER()};
+  rowType_ = ROW(names, types);
+
+  auto outputDirectory = TempDirectoryPath::create();
+  auto dataSink = createDataSink(
+      rowType_,
+      outputDirectory->getPath(),
+      {{0, TransformType::kIdentity, std::nullopt}});
+
+  auto intVector1 = makeNullConstant(TypeKind::INTEGER, size);
+  auto vector1 = makeRowVector(names, {intVector1});
+  auto intVector2 = makeNullConstant(TypeKind::INTEGER, size);
+  auto vector2 = makeRowVector(names, {intVector2});
+  dataSink->appendData(vector1);
+  dataSink->appendData(vector2);
+  ASSERT_TRUE(dataSink->finish());
+  dataSink->close();
+  // auto stats = dataSink->dataFileStats();
+  // ASSERT_TRUE(stats.at(0)->upperBounds.empty());
+  // ASSERT_EQ(stats.at(0)->nullValueCounts.at(1), size * 2);
+  createDuckDbTable({vector1, vector2});
+  auto splits = createSplitsForDirectory(outputDirectory->getPath());
+  ASSERT_EQ(splits.size(), 1);
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(test::kIcebergConnectorId)
+                  .outputType(rowType_)
+                  .endTableScan()
+                  .planNode();
+  assertQuery(plan, splits, fmt::format("SELECT * FROM tmp"));
+}
+
+TEST_P(IcebergWriterModeTest, sortedByAndIdentityPartittioning) {
+  constexpr auto size = 10;
+  std::vector<std::string> names = {"c_int"};
+  std::vector<TypePtr> types = {INTEGER()};
+  rowType_ = ROW(names, types);
+
+  auto outputDirectory = TempDirectoryPath::create();
+  auto dataSink = createDataSink(
+      rowType_,
+      outputDirectory->getPath(),
+      {{0, TransformType::kIdentity, std::nullopt}});
+
+  auto intVector1 =
+      makeFlatVector<int32_t>(size, [](vector_size_t row) { return row; });
+  auto vector1 = makeRowVector(names, {intVector1});
+  auto intVector2 =
+      makeFlatVector<int32_t>(size, [](vector_size_t row) { return row + 10; });
+  auto vector2 = makeRowVector(names, {intVector2});
+  dataSink->appendData(vector1);
+  dataSink->appendData(vector2);
+  ASSERT_TRUE(dataSink->finish());
+  dataSink->close();
+  createDuckDbTable({vector1, vector2});
+  auto splits = createSplitsForDirectory(outputDirectory->getPath());
+  ASSERT_EQ(splits.size(), size * 2);
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(test::kIcebergConnectorId)
+                  .outputType(rowType_)
+                  .endTableScan()
+                  .planNode();
+  assertQuery(plan, splits, fmt::format("SELECT * FROM tmp"));
+}
+TEST_P(IcebergWriterModeTest, reappearingPartitionFailsOnlyInClusteredMode) {
+  constexpr auto size = 10;
+  std::vector<std::string> names = {"c_int"};
+  std::vector<TypePtr> types = {INTEGER()};
+  rowType_ = ROW(names, types);
+
+  auto outputDirectory = TempDirectoryPath::create();
+  auto dataSink = createDataSink(
+      rowType_,
+      outputDirectory->getPath(),
+      {{0, TransformType::kIdentity, std::nullopt}});
+
+  auto intVector1 =
+      makeFlatVector<int32_t>(size, [](vector_size_t row) { return row / 5; });
+  auto vector1 = makeRowVector(names, {intVector1});
+
+  auto intVector2 = makeFlatVector<int32_t>(
+      size, [](vector_size_t row) { return row < 5 ? 0 : 2; });
+  auto vector2 = makeRowVector(names, {intVector2});
+
+  dataSink->appendData(vector1);
+
+  if (!GetParam()) {
+    VELOX_ASSERT_THROW(
+        dataSink->appendData(vector2),
+        "Iceberg clustered writer requires input rows to be clustered by partition");
+    dataSink->abort();
+    return;
+  }
+
+  dataSink->appendData(vector2);
+  ASSERT_TRUE(dataSink->finish());
+  dataSink->close();
+
+  createDuckDbTable({vector1, vector2});
+
+  auto splits = createSplitsForDirectory(outputDirectory->getPath());
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(test::kIcebergConnectorId)
+                  .outputType(rowType_)
+                  .endTableScan()
+                  .planNode();
+
+  assertQuery(plan, splits, "SELECT * FROM tmp");
+}
+} // namespace facebook::velox::connector::hive::iceberg::test

--- a/velox/connectors/hive/iceberg/tests/IcebergWriteModeTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergWriteModeTest.cpp
@@ -1,0 +1,281 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/json.h>
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/connectors/hive/iceberg/tests/IcebergTestBase.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/exec/tests/utils/TempDirectoryPath.h"
+
+using namespace facebook::velox::exec::test;
+
+namespace facebook::velox::connector::hive::iceberg::test {
+
+class IcebergWriterModeTest : public IcebergTestBase,
+                              public ::testing::WithParamInterface<bool> {
+ protected:
+  void SetUp() override {
+    IcebergTestBase::SetUp();
+
+    setConnectorSessionProperty(
+        IcebergConfig::kFanoutEnabledSession, GetParam() ? "true" : "false");
+  }
+
+  RowTypePtr rowType_;
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    FanoutModes,
+    IcebergWriterModeTest,
+    ::testing::Values(true, false),
+    [](const testing::TestParamInfo<bool>& info) {
+      return info.param ? "FanoutEnabled" : "FanoutDisabled";
+    });
+
+TEST_P(IcebergWriterModeTest, identityPartitioning) {
+  constexpr auto size = 10;
+  std::vector<std::string> names = {"c_int"};
+  std::vector<TypePtr> types = {INTEGER()};
+  rowType_ = ROW(names, types);
+
+  auto outputDirectory = TempDirectoryPath::create();
+  auto dataSink = createDataSink(
+      rowType_,
+      outputDirectory->getPath(),
+      {{0, TransformType::kIdentity, std::nullopt}});
+
+  auto intVector1 =
+      makeFlatVector<int32_t>(size, [](vector_size_t row) { return row; });
+  auto vector1 = makeRowVector(names, {intVector1});
+  auto intVector2 =
+      makeFlatVector<int32_t>(size, [](vector_size_t row) { return row + 10; });
+  auto vector2 = makeRowVector(names, {intVector2});
+  dataSink->appendData(vector1);
+  dataSink->appendData(vector2);
+  ASSERT_TRUE(dataSink->finish());
+  dataSink->close();
+  createDuckDbTable({vector1, vector2});
+  auto splits = createSplitsForDirectory(outputDirectory->getPath());
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(test::kIcebergConnectorId)
+                  .outputType(rowType_)
+                  .endTableScan()
+                  .planNode();
+  assertQuery(plan, splits, fmt::format("SELECT * FROM tmp"));
+}
+
+TEST_P(IcebergWriterModeTest, clusteredInput) {
+  constexpr auto size = 100;
+  std::vector<std::string> names = {"c_int"};
+  std::vector<TypePtr> types = {INTEGER()};
+  rowType_ = ROW(names, types);
+
+  auto outputDirectory = TempDirectoryPath::create();
+  auto dataSink = createDataSink(
+      rowType_,
+      outputDirectory->getPath(),
+      {{0, TransformType::kIdentity, std::nullopt}});
+
+  auto intVector1 = makeConstant(100, size, INTEGER());
+  auto vector1 = makeRowVector(names, {intVector1});
+  auto intVector2 = makeConstant(100, size, INTEGER());
+  auto vector2 = makeRowVector(names, {intVector2});
+  dataSink->appendData(vector1);
+  dataSink->appendData(vector2);
+  ASSERT_TRUE(dataSink->finish());
+  dataSink->close();
+  createDuckDbTable({vector1, vector2});
+  auto splits = createSplitsForDirectory(outputDirectory->getPath());
+  ASSERT_EQ(splits.size(), 1);
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(test::kIcebergConnectorId)
+                  .outputType(rowType_)
+                  .endTableScan()
+                  .planNode();
+  assertQuery(plan, splits, fmt::format("SELECT * FROM tmp"));
+}
+
+TEST_P(IcebergWriterModeTest, clusteredNullInput) {
+  constexpr auto size = 100;
+  std::vector<std::string> names = {"c_int"};
+  std::vector<TypePtr> types = {INTEGER()};
+  rowType_ = ROW(names, types);
+
+  auto outputDirectory = TempDirectoryPath::create();
+  auto dataSink = createDataSink(
+      rowType_,
+      outputDirectory->getPath(),
+      {{0, TransformType::kIdentity, std::nullopt}});
+
+  auto intVector1 = makeNullConstant(TypeKind::INTEGER, size);
+  auto vector1 = makeRowVector(names, {intVector1});
+  auto intVector2 = makeNullConstant(TypeKind::INTEGER, size);
+  auto vector2 = makeRowVector(names, {intVector2});
+  dataSink->appendData(vector1);
+  dataSink->appendData(vector2);
+  ASSERT_TRUE(dataSink->finish());
+  dataSink->close();
+  // auto stats = dataSink->dataFileStats();
+  // ASSERT_TRUE(stats.at(0)->upperBounds.empty());
+  // ASSERT_EQ(stats.at(0)->nullValueCounts.at(1), size * 2);
+  createDuckDbTable({vector1, vector2});
+  auto splits = createSplitsForDirectory(outputDirectory->getPath());
+  ASSERT_EQ(splits.size(), 1);
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(test::kIcebergConnectorId)
+                  .outputType(rowType_)
+                  .endTableScan()
+                  .planNode();
+  assertQuery(plan, splits, fmt::format("SELECT * FROM tmp"));
+}
+
+TEST_P(IcebergWriterModeTest, sortedByAndIdentityPartittioning) {
+  constexpr auto size = 10;
+  std::vector<std::string> names = {"c_int"};
+  std::vector<TypePtr> types = {INTEGER()};
+  rowType_ = ROW(names, types);
+
+  auto outputDirectory = TempDirectoryPath::create();
+  auto dataSink = createDataSink(
+      rowType_,
+      outputDirectory->getPath(),
+      {{0, TransformType::kIdentity, std::nullopt}});
+
+  auto intVector1 =
+      makeFlatVector<int32_t>(size, [](vector_size_t row) { return row; });
+  auto vector1 = makeRowVector(names, {intVector1});
+  auto intVector2 =
+      makeFlatVector<int32_t>(size, [](vector_size_t row) { return row + 10; });
+  auto vector2 = makeRowVector(names, {intVector2});
+  dataSink->appendData(vector1);
+  dataSink->appendData(vector2);
+  ASSERT_TRUE(dataSink->finish());
+  dataSink->close();
+  createDuckDbTable({vector1, vector2});
+  auto splits = createSplitsForDirectory(outputDirectory->getPath());
+  ASSERT_EQ(splits.size(), size * 2);
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(test::kIcebergConnectorId)
+                  .outputType(rowType_)
+                  .endTableScan()
+                  .planNode();
+  assertQuery(plan, splits, fmt::format("SELECT * FROM tmp"));
+}
+TEST_P(IcebergWriterModeTest, totalPartitionsCanExceedOpenWriterLimit) {
+  setConnectorSessionProperty(HiveConfig::kMaxPartitionsPerWritersSession, "2");
+
+  std::vector<std::string> names = {"c_int"};
+  std::vector<TypePtr> types = {INTEGER()};
+  rowType_ = ROW(names, types);
+
+  auto outputDirectory = TempDirectoryPath::create();
+  auto dataSink = createDataSink(
+      rowType_,
+      outputDirectory->getPath(),
+      {{0, TransformType::kIdentity, std::nullopt}});
+
+  auto intVector =
+      makeFlatVector<int32_t>(3, [](vector_size_t row) { return row; });
+  auto input = makeRowVector(names, {intVector});
+
+  if (GetParam()) {
+    VELOX_ASSERT_THROW(
+        dataSink->appendData(input), "Exceeded limit of 2 distinct partitions");
+    dataSink->abort();
+    return;
+  }
+
+  dataSink->appendData(input);
+  ASSERT_TRUE(dataSink->finish());
+  const auto commitTasks = dataSink->close();
+
+  ASSERT_EQ(commitTasks.size(), 3);
+  for (auto i = 0; i < commitTasks.size(); ++i) {
+    const auto commitData = folly::parseJson(commitTasks[i]);
+    const auto partitionData =
+        folly::parseJson(commitData["partitionDataJson"].asString());
+    ASSERT_EQ(partitionData["partitionValues"].size(), 1);
+    EXPECT_EQ(partitionData["partitionValues"][0].asInt(), i);
+  }
+
+  const auto stats = dataSink->stats();
+  EXPECT_EQ(stats.numWrittenFiles, 3);
+  EXPECT_GT(stats.numWrittenBytes, 0);
+
+  createDuckDbTable({input});
+  const auto splits = createSplitsForDirectory(outputDirectory->getPath());
+  ASSERT_EQ(splits.size(), 3);
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(test::kIcebergConnectorId)
+                  .outputType(rowType_)
+                  .endTableScan()
+                  .planNode();
+  assertQuery(plan, splits, "SELECT * FROM tmp");
+}
+
+TEST_P(IcebergWriterModeTest, reappearingPartitionFailsOnlyInClusteredMode) {
+  constexpr auto size = 10;
+  std::vector<std::string> names = {"c_int"};
+  std::vector<TypePtr> types = {INTEGER()};
+  rowType_ = ROW(names, types);
+
+  auto outputDirectory = TempDirectoryPath::create();
+  auto dataSink = createDataSink(
+      rowType_,
+      outputDirectory->getPath(),
+      {{0, TransformType::kIdentity, std::nullopt}});
+
+  auto intVector1 =
+      makeFlatVector<int32_t>(size, [](vector_size_t row) { return row / 5; });
+  auto vector1 = makeRowVector(names, {intVector1});
+
+  auto intVector2 = makeFlatVector<int32_t>(
+      size, [](vector_size_t row) { return row < 5 ? 0 : 2; });
+  auto vector2 = makeRowVector(names, {intVector2});
+
+  dataSink->appendData(vector1);
+
+  if (!GetParam()) {
+    VELOX_ASSERT_THROW(
+        dataSink->appendData(vector2),
+        "Iceberg clustered writer requires input rows to be clustered by partition");
+    dataSink->abort();
+    return;
+  }
+
+  dataSink->appendData(vector2);
+  ASSERT_TRUE(dataSink->finish());
+  dataSink->close();
+
+  createDuckDbTable({vector1, vector2});
+
+  auto splits = createSplitsForDirectory(outputDirectory->getPath());
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(test::kIcebergConnectorId)
+                  .outputType(rowType_)
+                  .endTableScan()
+                  .planNode();
+
+  assertQuery(plan, splits, "SELECT * FROM tmp");
+}
+} // namespace facebook::velox::connector::hive::iceberg::test


### PR DESCRIPTION
This PR introduces two new configs `fanout-enabled` and `fanout_enabled`. These control the clustered writer option on a connector and session basis.