### PR TITLE
fix: Validate reduce_agg initial state

### DIFF
--- a/velox/functions/prestosql/aggregates/ReduceAgg.cpp
+++ b/velox/functions/prestosql/aggregates/ReduceAgg.cpp
@@ -570,6 +570,12 @@ class ReduceAgg : public exec::Aggregate {
       }
     });
 
+    if (rawInput && numNotNull > 0) {
+      // Validate the initial value on the original input rows before group-by
+      // aggregation reorders values for lambda evaluation.
+      verifyInitialValueArg(args[1], rows);
+    }
+
     const auto numGroups = uniqueGroups.size();
 
     std::vector<vector_size_t> groupCounts(numGroups, 0);

--- a/velox/functions/prestosql/aggregates/tests/ReduceAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ReduceAggTest.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
@@ -249,6 +250,29 @@ TEST_F(ReduceAggTest, arraysGroupBy) {
        "(a, b) -> slice(reverse(array_sort(array_distinct(concat(a, b)))), 1, 3)) "
        "FILTER (WHERE m)"},
       {expected});
+}
+
+TEST_F(ReduceAggTest, nonConstantInitialValueGroupBy) {
+  auto data = makeRowVector(
+      {"k", "c0", "c1"},
+      {
+          makeFlatVector<int32_t>({1, 1, 2}),
+          makeFlatVector<int64_t>({2, 3, 20}),
+          makeArrayVector<int64_t>({{1, 2}, {1, 3}, {2, 20}}),
+      });
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .singleAggregation(
+                      {"k"},
+                      {"reduce_agg(c0, c1, "
+                       "(s, x) -> concat(s, array[x]), "
+                       "(s, s2) -> concat(s, s2))"})
+                  .planNode();
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()),
+      "Initial value in reduce_agg must be constant");
 }
 
 TEST_F(ReduceAggTest, differentInputAndCombine) {

--- a/velox/functions/prestosql/aggregates/tests/ReduceAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ReduceAggTest.cpp
@@ -275,6 +275,29 @@ TEST_F(ReduceAggTest, nonConstantInitialValueGroupBy) {
       "Initial value in reduce_agg must be constant");
 }
 
+TEST_F(ReduceAggTest, allNullInputSkipsInitialValueCheck) {
+  auto data = makeRowVector(
+      {"k", "c0", "c1"},
+      {
+          makeFlatVector<int32_t>({1, 1, 2, 2}),
+          makeConstant<int64_t>(std::nullopt, 4),
+          makeArrayVector<int64_t>({{1, 2}, {1, 2}, {2, 20}, {2, 20}}),
+      });
+
+  auto expected = makeRowVector({
+      makeFlatVector<int32_t>({1, 2}),
+      makeNullableArrayVector<int64_t>({std::nullopt, std::nullopt}),
+  });
+
+  testAggregations(
+      {data},
+      {"k"},
+      {"reduce_agg(c0, c1, "
+       "(s, x) -> concat(s, array[x]), "
+       "(s, s2) -> concat(s, s2))"},
+      {expected});
+}
+
 TEST_F(ReduceAggTest, differentInputAndCombine) {
   auto data = makeRowVector(
       {"k", "c0", "c1", "m"},


### PR DESCRIPTION
## Summary

Fixes prestodb/presto#27710.

`reduce_agg` in Velox accepted a non-constant initial state in grouped raw-input aggregation, which diverged from Presto Java semantics.

## Bug

Presto requires the `reduce_agg` initial state to be a non-null literal. Native execution already validated this in some `ReduceAgg` paths, but the grouped raw-input path converted input rows to states without validating that the initial state was constant.

That allowed queries such as:

```sql
SELECT
    id,
    reduce_agg(value, array[id, value],
        (a, b) -> a || b,
        (a, b) -> a || b)
FROM (
    VALUES
        (1, 2), (1, 3), (1, 4),
        (2, 20), (2, 30), (2, 40)
) AS t(id, value)
GROUP BY id
```

to succeed and use the per-row `array[id, value]` expression as the initial state.

## Fix

`ReduceAgg::toStates` now validates the dictionary-wrapped initial state before creating lambda inputs for grouped raw input. Non-constant initial states now fail consistently with the existing native validation:

```text
Initial value in reduce_agg must be constant
```

The patch also adds a grouped regression test covering non-constant array initial state.

## Validation

The focused native repro now fails during grouped `reduce_agg` state initialization instead of producing duplicated state values. The Velox unit coverage was added with the patch in:

```text
velox/functions/prestosql/aggregates/tests/ReduceAggTest.cpp
```
