### PR TITLE
refactor: Enforce not-null IoStatistics in ReaderOptions (#17399)

### DIFF
--- a/velox/common/io/Options.h
+++ b/velox/common/io/Options.h
@@ -18,6 +18,7 @@
 
 #include <folly/Executor.h>
 
+#include "velox/common/base/Exceptions.h"
 #include "velox/common/io/IoStatistics.h"
 #include "velox/common/memory/Memory.h"
 
@@ -72,7 +73,10 @@ class ReaderOptions {
       IoStatistics* metadataIoStats)
       : pool_{pool},
         dataIoStats_{dataIoStats},
-        metadataIoStats_{metadataIoStats} {}
+        metadataIoStats_{metadataIoStats} {
+    VELOX_CHECK_NOT_NULL(dataIoStats);
+    VELOX_CHECK_NOT_NULL(metadataIoStats);
+  }
 
   /// Modifies the autoPreloadLength
   ReaderOptions& setAutoPreloadLength(uint64_t len) {

--- a/velox/connectors/hive/FileIndexReader.cpp
+++ b/velox/connectors/hive/FileIndexReader.cpp
@@ -245,7 +245,10 @@ void FileIndexReader::parseIndexLookupConditions() {
 std::unique_ptr<dwio::common::Reader> FileIndexReader::createFileReader() {
   VELOX_CHECK_NOT_NULL(hiveSplit_);
 
-  dwio::common::ReaderOptions readerOpts(connectorQueryCtx_->memoryPool());
+  dwio::common::ReaderOptions readerOpts(
+      connectorQueryCtx_->memoryPool(),
+      ioStatistics_.get(),
+      ioStatistics_.get());
   hive::configureReaderOptions(
       fileConfig_,
       connectorQueryCtx_,

--- a/velox/connectors/hive/iceberg/EqualityDeleteFileReader.cpp
+++ b/velox/connectors/hive/iceberg/EqualityDeleteFileReader.cpp
@@ -182,7 +182,8 @@ EqualityDeleteFileReader::EqualityDeleteFileReader(
       0,
       deleteFile.fileSizeInBytes);
 
-  dwio::common::ReaderOptions deleteReaderOpts(pool_);
+  dwio::common::ReaderOptions deleteReaderOpts(
+      pool_, ioStatistics.get(), ioStatistics.get());
   configureReaderOptions(
       fileConfig,
       connectorQueryCtx,

--- a/velox/connectors/hive/iceberg/PositionalDeleteFileReader.cpp
+++ b/velox/connectors/hive/iceberg/PositionalDeleteFileReader.cpp
@@ -81,7 +81,8 @@ PositionalDeleteFileReader::PositionalDeleteFileReader(
 
   // Create the Reader and RowReader
 
-  dwio::common::ReaderOptions deleteReaderOpts(pool_);
+  dwio::common::ReaderOptions deleteReaderOpts(
+      pool_, ioStatistics_.get(), ioStatistics_.get());
   configureReaderOptions(
       fileConfig_,
       connectorQueryCtx,

--- a/velox/connectors/hive/iceberg/tests/IcebergSplitReaderBenchmark.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergSplitReaderBenchmark.cpp
@@ -294,6 +294,8 @@ void IcebergSplitReaderBenchmark::readSingleColumn(
   const RowTypePtr readerOutputType;
   const std::shared_ptr<io::IoStatistics> ioStatistics =
       std::make_shared<io::IoStatistics>();
+  const std::shared_ptr<io::IoStatistics> metadataIoStatistics =
+      std::make_shared<io::IoStatistics>();
   const std::shared_ptr<IoStats> ioStats = std::make_shared<IoStats>();
 
   std::shared_ptr<memory::MemoryPool> root =
@@ -341,7 +343,7 @@ void IcebergSplitReaderBenchmark::readSingleColumn(
             hiveConfig,
             rowType,
             ioStatistics,
-            nullptr,
+            metadataIoStatistics,
             ioStats,
             &fileHandleFactory,
             nullptr,

--- a/velox/connectors/hive/tests/FileConnectorUtilTest.cpp
+++ b/velox/connectors/hive/tests/FileConnectorUtilTest.cpp
@@ -19,6 +19,7 @@
 #include <gtest/gtest.h>
 
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/io/IoStatistics.h"
 #include "velox/connectors/hive/FileConfig.h"
 #include "velox/connectors/hive/FileConnectorSplit.h"
 #include "velox/connectors/hive/TableHandle.h"
@@ -78,13 +79,19 @@ class FileConnectorUtilTest : public exec::test::HiveConnectorTestBase {
   }
 
   std::unique_ptr<dwio::common::Reader> makeReader(const std::string& path) {
-    dwio::common::ReaderOptions readerOpts{pool_.get()};
+    dwio::common::ReaderOptions readerOpts{
+        pool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
     readerOpts.setFileFormat(dwio::common::FileFormat::DWRF);
     auto readFile = std::make_shared<LocalReadFile>(path);
     auto input = std::make_unique<dwio::common::BufferedInput>(
         std::move(readFile), readerOpts.memoryPool());
     return dwrf::DwrfReader::create(std::move(input), readerOpts);
   }
+
+  std::shared_ptr<velox::io::IoStatistics> dataIoStats_ =
+      std::make_shared<velox::io::IoStatistics>();
+  std::shared_ptr<velox::io::IoStatistics> metadataIoStats_ =
+      std::make_shared<velox::io::IoStatistics>();
 
  private:
   std::vector<std::shared_ptr<exec::test::TempFilePath>> tempPaths_;
@@ -97,7 +104,8 @@ TEST_F(FileConnectorUtilTest, configureReaderOptions) {
   {
     auto holder = makeConnectorQueryCtx();
     auto split = makeSplit(dwio::common::FileFormat::DWRF);
-    dwio::common::ReaderOptions readerOptions(pool_.get());
+    dwio::common::ReaderOptions readerOptions(
+        pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
     hive::configureReaderOptions(
         fileConfig,
         holder.ctx.get(),
@@ -116,7 +124,8 @@ TEST_F(FileConnectorUtilTest, configureReaderOptions) {
     auto holder = makeConnectorQueryCtx(
         {{hive::FileConfig::kOrcUseColumnNamesSession, "true"}});
     auto split = makeSplit(dwio::common::FileFormat::ORC);
-    dwio::common::ReaderOptions readerOptions(pool_.get());
+    dwio::common::ReaderOptions readerOptions(
+        pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
     hive::configureReaderOptions(
         fileConfig,
         holder.ctx.get(),
@@ -134,7 +143,8 @@ TEST_F(FileConnectorUtilTest, configureReaderOptions) {
     auto holder = makeConnectorQueryCtx(
         {{hive::FileConfig::kParquetUseColumnNamesSession, "true"}});
     auto split = makeSplit(dwio::common::FileFormat::PARQUET);
-    dwio::common::ReaderOptions readerOptions(pool_.get());
+    dwio::common::ReaderOptions readerOptions(
+        pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
     hive::configureReaderOptions(
         fileConfig,
         holder.ctx.get(),
@@ -151,7 +161,8 @@ TEST_F(FileConnectorUtilTest, configureReaderOptions) {
   {
     auto holder = makeConnectorQueryCtx();
     auto split = makeSplit(dwio::common::FileFormat::DWRF);
-    dwio::common::ReaderOptions readerOptions(pool_.get());
+    dwio::common::ReaderOptions readerOptions(
+        pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
     readerOptions.setFileFormat(dwio::common::FileFormat::PARQUET);
     VELOX_ASSERT_THROW(
         hive::configureReaderOptions(

--- a/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
@@ -17,6 +17,7 @@
 #include "velox/connectors/hive/HiveConnectorUtil.h"
 #include <gtest/gtest.h>
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/io/IoStatistics.h"
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/connectors/hive/TableHandle.h"
@@ -68,6 +69,10 @@ class HiveConnectorUtilTest : public exec::test::HiveConnectorTestBase {
 
   std::shared_ptr<memory::MemoryPool> pool_ =
       memory::memoryManager()->addLeafPool();
+  std::shared_ptr<velox::io::IoStatistics> dataIoStats_ =
+      std::make_shared<velox::io::IoStatistics>();
+  std::shared_ptr<velox::io::IoStatistics> metadataIoStats_ =
+      std::make_shared<velox::io::IoStatistics>();
 };
 
 TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
@@ -93,7 +98,8 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
   const std::unordered_map<std::string, std::string> customSplitInfo;
 
   // Dynamic parameters.
-  dwio::common::ReaderOptions readerOptions(pool_.get());
+  dwio::common::ReaderOptions readerOptions(
+      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
   FileFormat fileFormat{FileFormat::DWRF};
   std::unordered_map<std::string, std::string> tableParameters;
   std::unordered_map<std::string, std::string> serdeParameters;
@@ -137,7 +143,8 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
   };
 
   auto clearDynamicParameters = [&](FileFormat newFileFormat) {
-    readerOptions = dwio::common::ReaderOptions(pool_.get());
+    readerOptions = dwio::common::ReaderOptions(
+        pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
     fileFormat = newFileFormat;
     tableParameters.clear();
     serdeParameters.clear();
@@ -356,7 +363,8 @@ TEST_F(HiveConnectorUtilTest, footerSpeculativeIoSizeByFormat) {
 
   // Test ORC format.
   {
-    dwio::common::ReaderOptions readerOptions(pool_.get());
+    dwio::common::ReaderOptions readerOptions(
+        pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
     auto tableHandle = createTableHandle();
     auto split = createSplit(FileFormat::ORC);
     configureReaderOptions(
@@ -374,7 +382,8 @@ TEST_F(HiveConnectorUtilTest, footerSpeculativeIoSizeByFormat) {
 
   // Test DWRF format (uses ORC config).
   {
-    dwio::common::ReaderOptions readerOptions(pool_.get());
+    dwio::common::ReaderOptions readerOptions(
+        pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
     auto tableHandle = createTableHandle();
     auto split = createSplit(FileFormat::DWRF);
     configureReaderOptions(
@@ -392,7 +401,8 @@ TEST_F(HiveConnectorUtilTest, footerSpeculativeIoSizeByFormat) {
 
   // Test Parquet format.
   {
-    dwio::common::ReaderOptions readerOptions(pool_.get());
+    dwio::common::ReaderOptions readerOptions(
+        pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
     auto tableHandle = createTableHandle();
     auto split = createSplit(FileFormat::PARQUET);
     configureReaderOptions(
@@ -410,7 +420,8 @@ TEST_F(HiveConnectorUtilTest, footerSpeculativeIoSizeByFormat) {
 
   // Test Nimble format.
   {
-    dwio::common::ReaderOptions readerOptions(pool_.get());
+    dwio::common::ReaderOptions readerOptions(
+        pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
     auto tableHandle = createTableHandle();
     auto split = createSplit(FileFormat::NIMBLE);
     configureReaderOptions(
@@ -429,7 +440,8 @@ TEST_F(HiveConnectorUtilTest, footerSpeculativeIoSizeByFormat) {
 
 TEST_F(HiveConnectorUtilTest, fileMetadataCacheEnabledSessionOverride) {
   // Verify default is off.
-  dwio::common::ReaderOptions defaultOptions(pool_.get());
+  dwio::common::ReaderOptions defaultOptions(
+      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
   ASSERT_FALSE(defaultOptions.fileMetadataCacheEnabled());
 
   for (bool enabled : {true, false}) {
@@ -455,7 +467,8 @@ TEST_F(HiveConnectorUtilTest, fileMetadataCacheEnabledSessionOverride) {
     auto hiveConfig =
         std::make_shared<hive::HiveConfig>(std::make_shared<config::ConfigBase>(
             std::unordered_map<std::string, std::string>()));
-    dwio::common::ReaderOptions readerOptions(pool_.get());
+    dwio::common::ReaderOptions readerOptions(
+        pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
 
     auto tableHandle = std::make_shared<hive::HiveTableHandle>(
         "testConnectorId",
@@ -513,7 +526,8 @@ TEST_F(HiveConnectorUtilTest, cacheRetention) {
         0,
         "");
 
-    dwio::common::ReaderOptions readerOptions(pool_.get());
+    dwio::common::ReaderOptions readerOptions(
+        pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
 
     auto tableHandle = std::make_shared<hive::HiveTableHandle>(
         "testConnectorId",

--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 #include "velox/common/caching/AsyncDataCache.h"
+#include "velox/common/io/IoStatistics.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 
 #include <folly/init/Init.h>
@@ -243,6 +244,10 @@ class HiveDataSinkTest : public exec::test::HiveConnectorTestBase {
       std::make_shared<HiveConfig>(std::make_shared<config::ConfigBase>(
           std::unordered_map<std::string, std::string>()));
   std::unique_ptr<folly::IOThreadPoolExecutor> spillExecutor_;
+  std::shared_ptr<velox::io::IoStatistics> dataIoStats_ =
+      std::make_shared<velox::io::IoStatistics>();
+  std::shared_ptr<velox::io::IoStatistics> metadataIoStats_ =
+      std::make_shared<velox::io::IoStatistics>();
 };
 
 TEST_F(HiveDataSinkTest, hiveSortingColumn) {
@@ -1171,7 +1176,8 @@ TEST_F(HiveDataSinkTest, flushPolicyWithParquet) {
   ASSERT_TRUE(dataSink->finish());
   dataSink->close();
 
-  dwio::common::ReaderOptions readerOpts{pool_.get()};
+  dwio::common::ReaderOptions readerOpts{
+      pool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   const std::vector<std::string> filePaths =
       listFiles(outputDirectory->getPath());
   auto bufferedInput = std::make_unique<dwio::common::BufferedInput>(
@@ -1209,7 +1215,8 @@ TEST_F(HiveDataSinkTest, flushPolicyWithDWRF) {
   ASSERT_TRUE(dataSink->finish());
   dataSink->close();
 
-  dwio::common::ReaderOptions readerOpts{pool_.get()};
+  dwio::common::ReaderOptions readerOpts{
+      pool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   const std::vector<std::string> filePaths =
       listFiles(outputDirectory->getPath());
   auto bufferedInput = std::make_unique<dwio::common::BufferedInput>(

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -567,8 +567,8 @@ class ReaderOptions : public io::ReaderOptions {
 
   ReaderOptions(
       velox::memory::MemoryPool* pool,
-      velox::io::IoStatistics* dataIoStats = nullptr,
-      velox::io::IoStatistics* metadataIoStats = nullptr)
+      velox::io::IoStatistics* dataIoStats,
+      velox::io::IoStatistics* metadataIoStats)
       : io::ReaderOptions(pool, dataIoStats, metadataIoStats) {}
 
   /// Sets the format of the file, such as "rc" or "dwrf". The default is

--- a/velox/dwio/common/tests/BufferedInputTest.cpp
+++ b/velox/dwio/common/tests/BufferedInputTest.cpp
@@ -773,13 +773,16 @@ class CustomBufferedInputTest : public testing::Test {
   }
 
   const std::shared_ptr<MemoryPool> pool_ = memoryManager()->addLeafPool();
+  facebook::velox::io::IoStatistics dataIoStats_;
+  facebook::velox::io::IoStatistics metadataIoStats_;
 };
 
 } // namespace
 
 TEST_F(CustomBufferedInputTest, basic) {
   facebook::velox::FileHandle fileHandle;
-  facebook::velox::dwio::common::ReaderOptions readerOpts(pool_.get());
+  facebook::velox::dwio::common::ReaderOptions readerOpts(
+      pool_.get(), &dataIoStats_, &metadataIoStats_);
   auto ioStatistics = std::make_shared<facebook::velox::io::IoStatistics>();
   auto ioStats = std::make_shared<facebook::velox::IoStats>();
   auto executor = std::make_unique<folly::IOThreadPoolExecutor>(10, 10);

--- a/velox/dwio/common/tests/utils/E2EFilterTestBase.cpp
+++ b/velox/dwio/common/tests/utils/E2EFilterTestBase.cpp
@@ -433,7 +433,8 @@ void E2EFilterTestBase::readWithoutFilter(
     const std::vector<RowVectorPtr>& batches,
     uint64_t& time) {
   SCOPED_TRACE("Read without filter");
-  dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  dwio::common::ReaderOptions readerOpts{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   dwio::common::RowReaderOptions rowReaderOpts;
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
@@ -487,7 +488,8 @@ void E2EFilterTestBase::readWithFilter(
     bool useValueHook,
     bool skipCheck) {
   SCOPED_TRACE("Read with filter");
-  dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  dwio::common::ReaderOptions readerOpts{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   dwio::common::RowReaderOptions rowReaderOpts;
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
@@ -875,7 +877,8 @@ void E2EFilterTestBase::testMetadataFilterImpl(
   specB->setChannel(1);
   specC->setProjectOut(true);
   specC->setChannel(0);
-  ReaderOptions readerOpts{leafPool_.get()};
+  ReaderOptions readerOpts{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   RowReaderOptions rowReaderOpts;
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
@@ -1138,7 +1141,8 @@ void E2EFilterTestBase::testSubfieldsPruning() {
   auto specF = spec->addFieldRecursively("f", *ARRAY(BIGINT()), 5);
   specF->childByName(common::ScanSpec::kArrayElementsFieldName)
       ->setFilter(common::createBigintValues({0, 2, 4}, false));
-  ReaderOptions readerOpts{leafPool_.get()};
+  ReaderOptions readerOpts{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   RowReaderOptions rowReaderOpts;
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
@@ -1228,7 +1232,8 @@ void E2EFilterTestBase::testMutationCornerCases() {
   }
   auto& rowType = batches[0]->type();
   writeToMemory(rowType, batches, false);
-  ReaderOptions readerOpts{leafPool_.get()};
+  ReaderOptions readerOpts{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
   auto reader = makeReader(readerOpts, std::move(input));

--- a/velox/dwio/common/tests/utils/E2EFilterTestBase.h
+++ b/velox/dwio/common/tests/utils/E2EFilterTestBase.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "velox/common/io/IoStatistics.h"
 #include "velox/common/testutil/RandomSeed.h"
 #include "velox/common/time/Timer.h"
 #include "velox/dwio/common/BufferedInput.h"
@@ -420,6 +421,10 @@ class E2EFilterTestBase : public testing::Test {
   std::unique_ptr<common::FilterGenerator> filterGenerator_;
   std::shared_ptr<memory::MemoryPool> rootPool_;
   std::shared_ptr<memory::MemoryPool> leafPool_;
+  std::shared_ptr<velox::io::IoStatistics> dataIoStats_ =
+      std::make_shared<velox::io::IoStatistics>();
+  std::shared_ptr<velox::io::IoStatistics> metadataIoStats_ =
+      std::make_shared<velox::io::IoStatistics>();
   std::shared_ptr<const RowType> rowType_;
   std::string sinkData_;
   bool useVInts_ = true;

--- a/velox/dwio/dwrf/reader/ReaderBase.cpp
+++ b/velox/dwio/dwrf/reader/ReaderBase.cpp
@@ -82,8 +82,12 @@ FooterStatisticsImpl::FooterStatisticsImpl(
 ReaderBase::ReaderBase(
     MemoryPool& pool,
     std::unique_ptr<dwio::common::BufferedInput> input,
-    FileFormat fileFormat)
-    : ReaderBase(createReaderOptions(pool, fileFormat), std::move(input)) {}
+    FileFormat fileFormat,
+    io::IoStatistics* dataIoStats,
+    io::IoStatistics* metadataIoStats)
+    : ReaderBase(
+          createReaderOptions(pool, fileFormat, dataIoStats, metadataIoStats),
+          std::move(input)) {}
 
 namespace {
 

--- a/velox/dwio/dwrf/reader/ReaderBase.h
+++ b/velox/dwio/dwrf/reader/ReaderBase.h
@@ -70,7 +70,9 @@ class ReaderBase {
   ReaderBase(
       memory::MemoryPool& pool,
       std::unique_ptr<dwio::common::BufferedInput> input,
-      dwio::common::FileFormat fileFormat = dwio::common::FileFormat::DWRF);
+      dwio::common::FileFormat fileFormat,
+      io::IoStatistics* dataIoStats,
+      io::IoStatistics* metadataIoStats);
 
   /// Creates reader base from metadata.
   ReaderBase(
@@ -79,8 +81,13 @@ class ReaderBase {
       std::unique_ptr<PostScript> ps,
       const proto::Footer* footer,
       std::unique_ptr<StripeMetadataCache> cache,
-      std::unique_ptr<encryption::DecryptionHandler> handler = nullptr)
-      : options_{dwio::common::ReaderOptions(&pool)},
+      std::unique_ptr<encryption::DecryptionHandler> handler,
+      io::IoStatistics* dataIoStats,
+      io::IoStatistics* metadataIoStats)
+      : options_{dwio::common::ReaderOptions(
+            &pool,
+            dataIoStats,
+            metadataIoStats)},
         input_{std::move(input)},
         fileLength_{0},
         postScript_{std::move(ps)},
@@ -262,8 +269,10 @@ class ReaderBase {
 
   static dwio::common::ReaderOptions createReaderOptions(
       memory::MemoryPool& pool,
-      dwio::common::FileFormat fileFormat) {
-    dwio::common::ReaderOptions options(&pool);
+      dwio::common::FileFormat fileFormat,
+      io::IoStatistics* dataIoStats,
+      io::IoStatistics* metadataIoStats) {
+    dwio::common::ReaderOptions options(&pool, dataIoStats, metadataIoStats);
     options.setFileFormat(fileFormat);
     return options;
   }

--- a/velox/dwio/dwrf/test/ColumnWriterStatsTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterStatsTests.cpp
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 
 #include "velox/common/base/Nulls.h"
+#include "velox/common/io/IoStatistics.h"
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
 #include "velox/dwio/dwrf/reader/DwrfReader.h"
 #include "velox/dwio/dwrf/writer/FlushPolicy.h"
@@ -194,7 +195,8 @@ class ColumnWriterStatsTest : public ::testing::Test {
         std::make_shared<facebook::velox::InMemoryReadFile>(std::move(data));
     auto input = std::make_unique<BufferedInput>(readFile, *leafPool_);
 
-    dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+    dwio::common::ReaderOptions readerOpts{
+        leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
     RowReaderOptions rowReaderOpts;
     auto reader = std::make_unique<DwrfReader>(readerOpts, std::move(input));
     return reader->createRowReader(rowReaderOpts);
@@ -228,6 +230,10 @@ class ColumnWriterStatsTest : public ::testing::Test {
 
   std::shared_ptr<MemoryPool> rootPool_;
   std::shared_ptr<MemoryPool> leafPool_;
+  std::shared_ptr<io::IoStatistics> dataIoStats_ =
+      std::make_shared<io::IoStatistics>();
+  std::shared_ptr<io::IoStatistics> metadataIoStats_ =
+      std::make_shared<io::IoStatistics>();
 };
 
 template <typename T>

--- a/velox/dwio/dwrf/test/ColumnWriterTest.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTest.cpp
@@ -1937,7 +1937,9 @@ std::unique_ptr<DwrfReader> getDwrfReader(
     MemoryPool& leafPool,
     const std::shared_ptr<const RowType> type,
     const VectorPtr& batch,
-    bool useFlatMap) {
+    bool useFlatMap,
+    io::IoStatistics& dataIoStats,
+    io::IoStatistics& metadataIoStats) {
   auto config = std::make_shared<Config>();
   if (useFlatMap) {
     config->set(Config::FLATTEN_MAP, true);
@@ -1962,7 +1964,8 @@ std::unique_ptr<DwrfReader> getDwrfReader(
   writer.close();
 
   std::string data(sinkPtr->data(), sinkPtr->size());
-  dwio::common::ReaderOptions readerOpts{&leafPool};
+  dwio::common::ReaderOptions readerOpts{
+      &leafPool, &dataIoStats, &metadataIoStats};
   return std::make_unique<DwrfReader>(
       readerOpts,
       std::make_unique<BufferedInput>(
@@ -1985,8 +1988,12 @@ void testMapWriterStats(const std::shared_ptr<const RowType> type) {
   auto rootPool = memory::memoryManager()->addRootPool();
   auto leafPool = memory::memoryManager()->addLeafPool();
   auto batch = BatchMaker::createBatch(type, 10, *leafPool);
-  auto mapReader = getDwrfReader(*rootPool, *leafPool, type, batch, false);
-  auto flatMapReader = getDwrfReader(*rootPool, *leafPool, type, batch, true);
+  io::IoStatistics dataIoStats;
+  io::IoStatistics metadataIoStats;
+  auto mapReader = getDwrfReader(
+      *rootPool, *leafPool, type, batch, false, dataIoStats, metadataIoStats);
+  auto flatMapReader = getDwrfReader(
+      *rootPool, *leafPool, type, batch, true, dataIoStats, metadataIoStats);
   ASSERT_EQ(
       mapReader->getFooter().statisticsSize(),
       flatMapReader->getFooter().statisticsSize());

--- a/velox/dwio/dwrf/test/DirectBufferedInputTest.cpp
+++ b/velox/dwio/dwrf/test/DirectBufferedInputTest.cpp
@@ -53,11 +53,13 @@ class DirectBufferedInputTest : public testing::Test {
   void SetUp() override {
     executor_ = std::make_unique<folly::IOThreadPoolExecutor>(10, 10);
     ioStatistics_ = std::make_shared<IoStatistics>();
+    metadataIoStats_ = std::make_shared<IoStatistics>();
     fileIoStats_ = std::make_shared<IoStatistics>();
     ioStats_ = std::make_shared<facebook::velox::IoStats>();
     tracker_ = std::make_shared<cache::ScanTracker>("", nullptr, kLoadQuantum);
     file_ = std::make_shared<TestReadFile>(11, 100 << 20, ioStats_);
-    opts_ = std::make_unique<dwio::common::ReaderOptions>(pool_.get());
+    opts_ = std::make_unique<dwio::common::ReaderOptions>(
+        pool_.get(), ioStatistics_.get(), metadataIoStats_.get());
     opts_->setLoadQuantum(kLoadQuantum);
   }
 
@@ -134,6 +136,7 @@ class DirectBufferedInputTest : public testing::Test {
   std::shared_ptr<TestReadFile> file_;
   std::shared_ptr<cache::ScanTracker> tracker_;
   std::shared_ptr<IoStatistics> ioStatistics_;
+  std::shared_ptr<IoStatistics> metadataIoStats_;
   std::shared_ptr<IoStatistics> fileIoStats_;
   std::shared_ptr<facebook::velox::IoStats> ioStats_;
   std::unique_ptr<folly::IOThreadPoolExecutor> executor_;

--- a/velox/dwio/dwrf/test/E2EReaderTest.cpp
+++ b/velox/dwio/dwrf/test/E2EReaderTest.cpp
@@ -20,6 +20,7 @@
 #include "folly/Random.h"
 #include "folly/String.h"
 #include "velox/common/file/File.h"
+#include "velox/common/io/IoStatistics.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/common/FileSink.h"
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
@@ -103,6 +104,9 @@ class E2EReaderTest : public testing::TestWithParam<ValueTypes> {
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
   }
+
+  io::IoStatistics dataIoStats_;
+  io::IoStatistics metadataIoStats_;
 };
 } // namespace
 
@@ -174,7 +178,8 @@ TEST_P(E2EReaderTest, SharedDictionaryFlatmapReadAsStruct) {
   writer->close();
   writer.reset();
 
-  dwio::common::ReaderOptions readerOpts{pool.get()};
+  dwio::common::ReaderOptions readerOpts{
+      pool.get(), &dataIoStats_, &metadataIoStats_};
   auto bufferedInput = std::make_unique<BufferedInput>(
       std::make_shared<LocalReadFile>(path), *pool);
   auto reader = DwrfReader::create(std::move(bufferedInput), readerOpts);

--- a/velox/dwio/dwrf/test/E2EWriterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EWriterTest.cpp
@@ -18,6 +18,7 @@
 #include <random>
 #include "velox/common/base/SpillConfig.h"
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/io/IoStatistics.h"
 #include "velox/common/memory/tests/SharedArbitratorTestUtil.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/dwio/common/Options.h"
@@ -62,6 +63,11 @@ class E2EWriterTest : public testing::Test {
     leafPool_ = rootPool_->addLeafChild("leaf");
   }
 
+  std::shared_ptr<io::IoStatistics> dataIoStats_ =
+      std::make_shared<io::IoStatistics>();
+  std::shared_ptr<io::IoStatistics> metadataIoStats_ =
+      std::make_shared<io::IoStatistics>();
+
   static std::unique_ptr<dwrf::DwrfReader> createReader(
       const MemorySink& sink,
       const dwio::common::ReaderOptions& opts) {
@@ -104,7 +110,8 @@ class E2EWriterTest : public testing::Test {
 
     writer.close();
 
-    dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+    dwio::common::ReaderOptions readerOpts{
+        leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
     RowReaderOptions rowReaderOpts;
     auto reader = createReader(*sinkPtr, readerOpts);
     auto rowReader = reader->createRowReader(rowReaderOpts);
@@ -166,7 +173,8 @@ class E2EWriterTest : public testing::Test {
 
     writer.close();
 
-    dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+    dwio::common::ReaderOptions readerOpts{
+        leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
     RowReaderOptions rowReaderOpts;
     auto reader = createReader(*sinkPtr, readerOpts);
     auto rowReader = reader->createRowReader(rowReaderOpts);
@@ -568,7 +576,8 @@ TEST_F(E2EWriterTest, PresentStreamIsSuppressedOnFlatMap) {
       config,
       dwrf::E2EWriterTestUtil::simpleFlushPolicyFactory(true));
 
-  dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  dwio::common::ReaderOptions readerOpts{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   RowReaderOptions rowReaderOpts;
   auto reader = createReader(*sinkPtr, readerOpts);
   auto rowReader = reader->createRowReader(rowReaderOpts);
@@ -940,7 +949,8 @@ TEST_F(E2EWriterTest, PartialStride) {
   writer.write(batch);
   writer.close();
 
-  dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  dwio::common::ReaderOptions readerOpts{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   RowReaderOptions rowReaderOpts;
   auto reader = createReader(*sinkPtr, readerOpts);
   ASSERT_EQ(
@@ -1140,7 +1150,8 @@ class E2EEncryptionTest : public E2EWriterTest {
     writer_->close();
 
     // read it back for compare
-    dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+    dwio::common::ReaderOptions readerOpts{
+        leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
     readerOpts.setDecrypterFactory(decrypterFactory);
     return createReader(*sink_, readerOpts);
   }

--- a/velox/dwio/dwrf/test/ReaderBaseTests.cpp
+++ b/velox/dwio/dwrf/test/ReaderBaseTests.cpp
@@ -18,6 +18,7 @@
 #include <cstring>
 
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/io/IoStatistics.h"
 #include "velox/dwio/common/Arena.h"
 #include "velox/dwio/common/InputStream.h"
 #include "velox/dwio/common/encryption/TestProvider.h"
@@ -111,7 +112,9 @@ class EncryptedStatsTest : public Test {
         std::make_unique<PostScript>(std::move(ps)),
         footerWrapper.getDwrfPtr(),
         nullptr,
-        std::move(handler));
+        std::move(handler),
+        dataIoStats_.get(),
+        metadataIoStats_.get());
   }
 
   void clearKey(uint32_t groupIdx) {
@@ -127,6 +130,10 @@ class EncryptedStatsTest : public Test {
   std::shared_ptr<MemoryPool> pool_;
   std::shared_ptr<MemoryPool> sinkPool_;
   std::shared_ptr<MemoryPool> readerPool_;
+  std::shared_ptr<facebook::velox::io::IoStatistics> dataIoStats_ =
+      std::make_shared<facebook::velox::io::IoStatistics>();
+  std::shared_ptr<facebook::velox::io::IoStatistics> metadataIoStats_ =
+      std::make_shared<facebook::velox::io::IoStatistics>();
 };
 
 TEST_F(EncryptedStatsTest, statistics) {
@@ -179,7 +186,9 @@ TEST_F(EncryptedStatsTest, getColumnStatisticsKeyNotLoaded) {
 
 std::unique_ptr<ReaderBase> createCorruptedFileReader(
     uint64_t footerLen,
-    uint32_t cacheLen) {
+    uint32_t cacheLen,
+    facebook::velox::io::IoStatistics& dataIoStats,
+    facebook::velox::io::IoStatistics& metadataIoStats) {
   auto pool = facebook::velox::memory::memoryManager()->addLeafPool();
   MemorySink sink{1024, {.pool = pool.get()}};
   DataBufferHolder holder{*pool, 1024, 0, DEFAULT_PAGE_GROW_RATIO, &sink};
@@ -214,7 +223,8 @@ std::unique_ptr<ReaderBase> createCorruptedFileReader(
   sink.write(std::move(buf));
   auto readFile = std::make_shared<facebook::velox::InMemoryReadFile>(
       std::string(sink.data(), sink.size()));
-  facebook::velox::dwio::common::ReaderOptions readerOpts{pool.get()};
+  facebook::velox::dwio::common::ReaderOptions readerOpts{
+      pool.get(), &dataIoStats, &metadataIoStats};
   return std::make_unique<ReaderBase>(
       readerOpts, std::make_unique<BufferedInput>(readFile, *pool));
 }
@@ -224,13 +234,16 @@ class ReaderBaseTest : public Test {
   static void SetUpTestCase() {
     MemoryManager::testingSetInstance(MemoryManager::Options{});
   }
+
+  facebook::velox::io::IoStatistics dataIoStats_;
+  facebook::velox::io::IoStatistics metadataIoStats_;
 };
 
 TEST_F(ReaderBaseTest, InvalidPostScriptThrows) {
   VELOX_ASSERT_THROW(
-      createCorruptedFileReader(1'000'000, 0),
+      createCorruptedFileReader(1'000'000, 0, dataIoStats_, metadataIoStats_),
       "Corrupted file, footer size is invalid");
   VELOX_ASSERT_THROW(
-      createCorruptedFileReader(0, 1'000'000),
+      createCorruptedFileReader(0, 1'000'000, dataIoStats_, metadataIoStats_),
       "Corrupted file, cache size is invalid");
 }

--- a/velox/dwio/dwrf/test/ReaderTest.cpp
+++ b/velox/dwio/dwrf/test/ReaderTest.cpp
@@ -43,6 +43,8 @@
 #include <memory>
 #include <numeric>
 
+#include "velox/common/io/IoStatistics.h"
+
 namespace facebook::velox::dwrf {
 namespace {
 
@@ -124,6 +126,10 @@ class TestReaderP
 
  private:
   std::unique_ptr<folly::Executor> executor_;
+
+ protected:
+  io::IoStatistics dataIoStats_;
+  io::IoStatistics metadataIoStats_;
 };
 
 class TestReader : public testing::Test, public VectorTestBase {
@@ -143,6 +149,9 @@ class TestReader : public testing::Test, public VectorTestBase {
     }
     return batches;
   }
+
+  io::IoStatistics dataIoStats_;
+  io::IoStatistics metadataIoStats_;
 };
 
 TEST_F(TestReader, testWriterVersions) {
@@ -265,9 +274,11 @@ void verifyFlatMapReading(
     const int32_t expectedBatchSize[],
     const int32_t numBatches,
     bool returnFlatVector,
+    io::IoStatistics& dataIoStats,
+    io::IoStatistics& metadataIoStats,
     const std::vector<uint32_t>& expectedPrefetchRowSizes = {},
     const std::vector<bool>& shouldTryPrefetch = {}) {
-  dwio::common::ReaderOptions readerOpts{pool};
+  dwio::common::ReaderOptions readerOpts{pool, &dataIoStats, &metadataIoStats};
 
   /* If an extra sanity check is desired you can uncomment the 2 below lines and
    * re-run */
@@ -381,13 +392,17 @@ class TestFlatMapReader : public TestWithParam<bool>, public VectorTestBase {
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
   }
+
+  io::IoStatistics dataIoStats_;
+  io::IoStatistics metadataIoStats_;
 };
 
 TEST_P(TestFlatMapReader, testReadFlatMapEmptyMap) {
   const std::string emptyFile(getExampleFilePath("empty_flatmap.orc"));
   auto returnFlatVector = GetParam();
 
-  dwio::common::ReaderOptions readerOpts{pool()};
+  dwio::common::ReaderOptions readerOpts{
+      pool(), &dataIoStats_, &metadataIoStats_};
   RowReaderOptions rowReaderOpts;
   rowReaderOpts.setReturnFlatVector(returnFlatVector);
   std::shared_ptr<const RowType> emptyFileType =
@@ -417,7 +432,8 @@ TEST_P(TestFlatMapReader, testStringKeyLifeCycle) {
   auto returnFlatVector = GetParam();
 
   VectorPtr batch;
-  dwio::common::ReaderOptions readerOptions{pool()};
+  dwio::common::ReaderOptions readerOptions{
+      pool(), &dataIoStats_, &metadataIoStats_};
 
   {
     RowReaderOptions rowReaderOptions;
@@ -481,7 +497,9 @@ TEST_P(TestFlatMapReader, testReadFlatMapSampleSmallSkips) {
       seeks.data(),
       expectedBatchSize.data(),
       expectedBatchSize.size(),
-      returnFlatVector);
+      returnFlatVector,
+      dataIoStats_,
+      metadataIoStats_);
 }
 
 TEST_P(TestFlatMapReader, testReadFlatMapSampleSmall) {
@@ -496,7 +514,9 @@ TEST_P(TestFlatMapReader, testReadFlatMapSampleSmall) {
       seeks.data(),
       expectedBatchSize.data(),
       expectedBatchSize.size(),
-      returnFlatVector);
+      returnFlatVector,
+      dataIoStats_,
+      metadataIoStats_);
 }
 
 TEST_P(TestFlatMapReader, testReadFlatMapSampleLarge) {
@@ -514,7 +534,9 @@ TEST_P(TestFlatMapReader, testReadFlatMapSampleLarge) {
       seeks.data(),
       expectedBatchSize.data(),
       expectedBatchSize.size(),
-      returnFlatVector);
+      returnFlatVector,
+      dataIoStats_,
+      metadataIoStats_);
 }
 
 VELOX_INSTANTIATE_TEST_SUITE_P(
@@ -529,10 +551,14 @@ class TestFlatMapReaderFlatLayout
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
   }
+
+  io::IoStatistics dataIoStats_;
+  io::IoStatistics metadataIoStats_;
 };
 
 TEST_P(TestFlatMapReaderFlatLayout, testCompare) {
-  dwio::common::ReaderOptions readerOptions{pool()};
+  dwio::common::ReaderOptions readerOptions{
+      pool(), &dataIoStats_, &metadataIoStats_};
   auto reader = DwrfReader::create(
       createFileBufferedInput(getFMSmallFile(), readerOptions.memoryPool()),
       readerOptions);
@@ -565,7 +591,8 @@ VELOX_INSTANTIATE_TEST_SUITE_P(
 TEST_F(TestReader, testReadFlatMapWithKeyFilters) {
   // batch size is set as 1000 in reading
   // file has schema: a int, b struct<a:int, b:float, c:string>, c float
-  dwio::common::ReaderOptions readerOpts{pool()};
+  dwio::common::ReaderOptions readerOpts{
+      pool(), &dataIoStats_, &metadataIoStats_};
   RowReaderOptions rowReaderOpts;
   // set map key filter for map1 we only need key=1, and map2 only key-1
   auto cs = std::make_shared<ColumnSelector>(
@@ -618,7 +645,8 @@ TEST_F(TestReader, testReadFlatMapWithKeyFilters) {
 TEST_F(TestReader, testReadFlatMapWithKeyRejectList) {
   // batch size is set as 1000 in reading
   // file has schema: a int, b struct<a:int, b:float, c:string>, c float
-  dwio::common::ReaderOptions readerOpts{pool()};
+  dwio::common::ReaderOptions readerOpts{
+      pool(), &dataIoStats_, &metadataIoStats_};
   RowReaderOptions rowReaderOpts;
   auto cs = std::make_shared<ColumnSelector>(
       getFlatmapSchema(), std::vector<std::string>{"map1#[\"!2\",\"!3\"]"});
@@ -673,7 +701,8 @@ TEST_F(TestReader, testStatsCallbackFiredWithFiltering) {
         selectedKeyStreamsAggregate += keySelectionStats.selectedKeys;
       });
 
-  dwio::common::ReaderOptions readerOpts{pool()};
+  dwio::common::ReaderOptions readerOpts{
+      pool(), &dataIoStats_, &metadataIoStats_};
 
   auto reader = DwrfReader::create(
       createFileBufferedInput(getFMSmallFile(), readerOpts.memoryPool()),
@@ -711,7 +740,8 @@ TEST_F(TestReader, testBlockedIoCallbackFiredBlocking) {
       });
   rowReaderOpts.setEagerFirstStripeLoad(false);
 
-  dwio::common::ReaderOptions readerOpts{pool()};
+  dwio::common::ReaderOptions readerOpts{
+      pool(), &dataIoStats_, &metadataIoStats_};
 
   auto reader = DwrfReader::create(
       createFileBufferedInput(getFMLargeFile(), readerOpts.memoryPool()),
@@ -755,7 +785,8 @@ TEST_F(TestReader, DISABLED_testBlockedIoCallbackFiredNonBlocking) {
       });
   rowReaderOpts.setEagerFirstStripeLoad(false);
 
-  dwio::common::ReaderOptions readerOpts{pool()};
+  dwio::common::ReaderOptions readerOpts{
+      pool(), &dataIoStats_, &metadataIoStats_};
 
   auto reader = DwrfReader::create(
       createFileBufferedInput(getFMLargeFile(), readerOpts.memoryPool()),
@@ -804,7 +835,8 @@ TEST_F(TestReader, DISABLED_testBlockedIoCallbackFiredWithFirstStripeLoad) {
 
   rowReaderOpts.setEagerFirstStripeLoad(true);
 
-  dwio::common::ReaderOptions readerOpts{pool()};
+  dwio::common::ReaderOptions readerOpts{
+      pool(), &dataIoStats_, &metadataIoStats_};
 
   auto reader = DwrfReader::create(
       createFileBufferedInput(getFMLargeFile(), readerOpts.memoryPool()),
@@ -839,7 +871,8 @@ TEST_F(TestReader, DISABLED_testBlockedIoCallbackFiredWithFirstStripeLoad) {
 }
 
 TEST_F(TestReader, testEstimatedSize) {
-  dwio::common::ReaderOptions readerOpts{pool()};
+  dwio::common::ReaderOptions readerOpts{
+      pool(), &dataIoStats_, &metadataIoStats_};
   {
     auto reader = DwrfReader::create(
         createFileBufferedInput(getFMSmallFile(), readerOpts.memoryPool()),
@@ -867,7 +900,8 @@ TEST_F(TestReader, testEstimatedSize) {
 }
 
 TEST_F(TestReader, testSubfieldEstimatedSize) {
-  dwio::common::ReaderOptions readerOpts{pool()};
+  dwio::common::ReaderOptions readerOpts{
+      pool(), &dataIoStats_, &metadataIoStats_};
   std::shared_ptr<const RowType> schema =
       std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse("struct<\
               a:int,\
@@ -902,7 +936,8 @@ TEST_F(TestReader, testSubfieldEstimatedSize) {
   ASSERT_EQ(rowReader->estimatedRowSize(), 8);
 
   // estimation with full struct field selection
-  dwio::common::ReaderOptions readerOpts2{pool()};
+  dwio::common::ReaderOptions readerOpts2{
+      pool(), &dataIoStats_, &metadataIoStats_};
   auto subfields2 = makeSubfields({"a", "b"});
   folly::F14FastMap<std::string, std::vector<const common::Subfield*>>
       subfields2ByName = groupSubfields(subfields2);
@@ -938,7 +973,8 @@ TEST_F(TestReader, testStatsCallbackFiredWithoutFiltering) {
         selectedKeyStreamsAggregate += keySelectionStats.selectedKeys;
       });
 
-  dwio::common::ReaderOptions readerOpts{pool()};
+  dwio::common::ReaderOptions readerOpts{
+      pool(), &dataIoStats_, &metadataIoStats_};
 
   auto reader = DwrfReader::create(
       createFileBufferedInput(getFMSmallFile(), readerOpts.memoryPool()),
@@ -1022,8 +1058,10 @@ void verifyFlatmapStructEncoding(
     const std::string& filename,
     const std::vector<int32_t>& keysAsFields,
     const std::vector<int32_t>& keysToSelect,
+    io::IoStatistics& dataIoStats,
+    io::IoStatistics& metadataIoStats,
     size_t batchSize = 1000) {
-  dwio::common::ReaderOptions readerOpts{pool};
+  dwio::common::ReaderOptions readerOpts{pool, &dataIoStats, &metadataIoStats};
   auto reader = DwrfReader::create(
       createFileBufferedInput(filename, readerOpts.memoryPool()), readerOpts);
 
@@ -1090,7 +1128,9 @@ TEST_F(TestReader, testFlatmapAsStructSmall) {
       pool(),
       getFMSmallFile(),
       {1, 2, 3, 4, 5, -99999999 /* does not exist */},
-      {} /* no key filtering */);
+      {} /* no key filtering */,
+      dataIoStats_,
+      metadataIoStats_);
 }
 
 TEST_F(TestReader, testFlatmapAsStructSmallEmptyInmap) {
@@ -1099,6 +1139,8 @@ TEST_F(TestReader, testFlatmapAsStructSmallEmptyInmap) {
       getFMSmallFile(),
       {1, 2, 3, 4, 5, -99999999 /* does not exist */},
       {} /* no key filtering */,
+      dataIoStats_,
+      metadataIoStats_,
       2);
 }
 
@@ -1107,7 +1149,9 @@ TEST_F(TestReader, testFlatmapAsStructLarge) {
       pool(),
       getFMSmallFile(),
       {1, 2, 3, 4, 5, -99999999 /* does not exist */},
-      {} /* no key filtering */);
+      {} /* no key filtering */,
+      dataIoStats_,
+      metadataIoStats_);
 }
 
 TEST_F(TestReader, testFlatmapAsStructWithKeyProjection) {
@@ -1115,7 +1159,9 @@ TEST_F(TestReader, testFlatmapAsStructWithKeyProjection) {
       pool(),
       getFMSmallFile(),
       {1, 2, 3, 4, 5, -99999999 /* does not exist */},
-      {3, 5} /* select only these to read */);
+      {3, 5} /* select only these to read */,
+      dataIoStats_,
+      metadataIoStats_);
 }
 
 TEST_F(TestReader, testFlatmapAsStructRequiringKeyList) {
@@ -1129,7 +1175,8 @@ TEST_F(TestReader, testFlatmapAsStructRequiringKeyList) {
 // TODO: replace with mock
 TEST_F(TestReader, testMismatchSchemaMoreFields) {
   // file has schema: a int, b struct<a:int, b:float, c:string>, c float
-  dwio::common::ReaderOptions readerOpts{pool()};
+  dwio::common::ReaderOptions readerOpts{
+      pool(), &dataIoStats_, &metadataIoStats_};
   RowReaderOptions rowReaderOpts;
   std::shared_ptr<const RowType> requestedType =
       std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse(
@@ -1175,7 +1222,8 @@ TEST_F(TestReader, testMismatchSchemaMoreFields) {
 
 TEST_F(TestReader, testMismatchSchemaFewerFields) {
   // file has schema: a int, b struct<a:int, b:float, c:string>, c float
-  dwio::common::ReaderOptions readerOpts{pool()};
+  dwio::common::ReaderOptions readerOpts{
+      pool(), &dataIoStats_, &metadataIoStats_};
   RowReaderOptions rowReaderOpts;
   std::shared_ptr<const RowType> requestedType =
       std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse(
@@ -1217,7 +1265,8 @@ TEST_F(TestReader, testMismatchSchemaFewerFields) {
 
 TEST_F(TestReader, testMismatchSchemaNestedMoreFields) {
   // file has schema: a int, b struct<a:int, b:float>, c float
-  dwio::common::ReaderOptions readerOpts{pool()};
+  dwio::common::ReaderOptions readerOpts{
+      pool(), &dataIoStats_, &metadataIoStats_};
   RowReaderOptions rowReaderOpts;
   std::shared_ptr<const RowType> requestedType =
       std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse(
@@ -1284,7 +1333,8 @@ TEST_F(TestReader, testMismatchSchemaNestedMoreFields) {
 
 TEST_F(TestReader, testMismatchSchemaNestedFewerFields) {
   // file has schema: a int, b struct<a:int, b:float>, c float
-  dwio::common::ReaderOptions readerOpts{pool()};
+  dwio::common::ReaderOptions readerOpts{
+      pool(), &dataIoStats_, &metadataIoStats_};
   RowReaderOptions rowReaderOpts;
   std::shared_ptr<const RowType> requestedType =
       std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse(
@@ -1342,7 +1392,8 @@ TEST_F(TestReader, testMismatchSchemaNestedFewerFields) {
 
 TEST_F(TestReader, testMismatchSchemaIncompatibleNotSelected) {
   // file has schema: a int, b struct<a:int, b:float>, c float
-  dwio::common::ReaderOptions readerOpts{pool()};
+  dwio::common::ReaderOptions readerOpts{
+      pool(), &dataIoStats_, &metadataIoStats_};
   RowReaderOptions rowReaderOpts;
   std::shared_ptr<const RowType> requestedType =
       std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse(
@@ -1424,7 +1475,8 @@ TEST_F(TestReader, testMismatchSchemaIncompatible) {
 
 TEST_F(TestReader, fileColumnNamesReadAsLowerCase) {
   // upper.orc holds one columns (Bool_Val: BOOLEAN, b: BIGINT)
-  dwio::common::ReaderOptions readerOpts{pool()};
+  dwio::common::ReaderOptions readerOpts{
+      pool(), &dataIoStats_, &metadataIoStats_};
   readerOpts.setFileColumnNamesReadAsLowerCase(true);
   auto reader = DwrfReader::create(
       createFileBufferedInput(
@@ -1438,7 +1490,8 @@ TEST_F(TestReader, fileColumnNamesReadAsLowerCase) {
 TEST_F(TestReader, fileColumnNamesReadAsLowerCaseComplexStruct) {
   // upper_complex.orc holds type
   // Cc:struct<CcLong0:bigint,CcMap1:map<string,struct<CcArray2:array<struct<CcInt3:int>>>>>
-  dwio::common::ReaderOptions readerOpts{pool()};
+  dwio::common::ReaderOptions readerOpts{
+      pool(), &dataIoStats_, &metadataIoStats_};
   readerOpts.setFileColumnNamesReadAsLowerCase(true);
   auto reader = DwrfReader::create(
       createFileBufferedInput(
@@ -1476,7 +1529,8 @@ TEST_F(TestReader, fileColumnNamesReadAsLowerCaseComplexStruct) {
 }
 
 TEST_F(TestReader, TestStripeSizeCallback) {
-  dwio::common::ReaderOptions readerOpts{pool()};
+  dwio::common::ReaderOptions readerOpts{
+      pool(), &dataIoStats_, &metadataIoStats_};
   readerOpts.setFilePreloadThreshold(0);
   readerOpts.setFooterSpeculativeIoSize(17);
   RowReaderOptions rowReaderOpts;
@@ -1504,7 +1558,8 @@ TEST_F(TestReader, TestStripeSizeCallback) {
 }
 
 TEST_F(TestReader, TestStripeSizeCallbackLimitsOneStripe) {
-  dwio::common::ReaderOptions readerOpts{pool()};
+  dwio::common::ReaderOptions readerOpts{
+      pool(), &dataIoStats_, &metadataIoStats_};
   readerOpts.setFilePreloadThreshold(0);
   readerOpts.setFooterSpeculativeIoSize(17);
   RowReaderOptions rowReaderOpts;
@@ -1533,7 +1588,8 @@ TEST_F(TestReader, TestStripeSizeCallbackLimitsOneStripe) {
 }
 
 TEST_F(TestReader, TestStripeSizeCallbackLimitsTwoStripe) {
-  dwio::common::ReaderOptions readerOpts{pool()};
+  dwio::common::ReaderOptions readerOpts{
+      pool(), &dataIoStats_, &metadataIoStats_};
   readerOpts.setFilePreloadThreshold(0);
   readerOpts.setFooterSpeculativeIoSize(17);
   RowReaderOptions rowReaderOpts;
@@ -1825,7 +1881,8 @@ TEST_F(TestReader, testEmptyFile) {
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<InMemoryReadFile>(std::move(data)), *pool());
 
-  dwio::common::ReaderOptions readerOpts{pool()};
+  dwio::common::ReaderOptions readerOpts{
+      pool(), &dataIoStats_, &metadataIoStats_};
   RowReaderOptions rowReaderOpts;
 
   auto rowReader = DwrfReader::create(std::move(input), readerOpts)
@@ -1908,7 +1965,9 @@ void testBufferLifeCycle(
     const std::shared_ptr<dwrf::Config>& config,
     std::mt19937& rng,
     size_t batchSize,
-    bool hasNull) {
+    bool hasNull,
+    io::IoStatistics& dataIoStats,
+    io::IoStatistics& metadataIoStats) {
   std::vector<VectorPtr> batches;
   std::function<bool(vector_size_t)> isNullAt = nullptr;
   if (hasNull) {
@@ -1928,7 +1987,7 @@ void testBufferLifeCycle(
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<InMemoryReadFile>(std::move(data)), *pool);
 
-  dwio::common::ReaderOptions readerOpts{pool};
+  dwio::common::ReaderOptions readerOpts{pool, &dataIoStats, &metadataIoStats};
   RowReaderOptions rowReaderOpts;
   rowReaderOpts.setReturnFlatVector(true);
   auto reader = std::make_unique<DwrfReader>(readerOpts, std::move(input));
@@ -1966,7 +2025,9 @@ void testFlatmapAsMapFieldLifeCycle(
     const std::shared_ptr<dwrf::Config>& config,
     std::mt19937& rng,
     size_t batchSize,
-    bool hasNull) {
+    bool hasNull,
+    io::IoStatistics& dataIoStats,
+    io::IoStatistics& metadataIoStats) {
   std::vector<VectorPtr> batches;
   std::function<bool(vector_size_t)> isNullAt = nullptr;
   if (hasNull) {
@@ -1986,7 +2047,7 @@ void testFlatmapAsMapFieldLifeCycle(
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<InMemoryReadFile>(std::move(data)), *pool);
 
-  dwio::common::ReaderOptions readerOpts{pool};
+  dwio::common::ReaderOptions readerOpts{pool, &dataIoStats, &metadataIoStats};
   RowReaderOptions rowReaderOpts;
   rowReaderOpts.setReturnFlatVector(true);
   auto reader = std::make_unique<DwrfReader>(readerOpts, std::move(input));
@@ -2083,8 +2144,24 @@ TEST_F(TestReader, testBufferLifeCycle) {
   std::mt19937 rng{seed};
 
   for (auto i = 0; i < 10; ++i) {
-    testBufferLifeCycle(pool(), schema, config, rng, batchSize, false);
-    testBufferLifeCycle(pool(), schema, config, rng, batchSize, true);
+    testBufferLifeCycle(
+        pool(),
+        schema,
+        config,
+        rng,
+        batchSize,
+        false,
+        dataIoStats_,
+        metadataIoStats_);
+    testBufferLifeCycle(
+        pool(),
+        schema,
+        config,
+        rng,
+        batchSize,
+        true,
+        dataIoStats_,
+        metadataIoStats_);
   }
 }
 
@@ -2102,8 +2179,24 @@ TEST_F(TestReader, testFlatmapAsMapFieldLifeCycle) {
   LOG(INFO) << "seed: " << seed;
   std::mt19937 rng{seed};
 
-  testFlatmapAsMapFieldLifeCycle(pool(), schema, config, rng, batchSize, false);
-  testFlatmapAsMapFieldLifeCycle(pool(), schema, config, rng, batchSize, true);
+  testFlatmapAsMapFieldLifeCycle(
+      pool(),
+      schema,
+      config,
+      rng,
+      batchSize,
+      false,
+      dataIoStats_,
+      metadataIoStats_);
+  testFlatmapAsMapFieldLifeCycle(
+      pool(),
+      schema,
+      config,
+      rng,
+      batchSize,
+      true,
+      dataIoStats_,
+      metadataIoStats_);
 }
 
 TEST_F(TestReader, testFooterWrapper) {
@@ -2167,6 +2260,8 @@ std::pair<std::unique_ptr<dwrf::Writer>, std::unique_ptr<DwrfReader>>
 createWriterReader(
     const std::vector<VectorPtr>& batches,
     memory::MemoryPool* pool,
+    io::IoStatistics& dataIoStats,
+    io::IoStatistics& metadataIoStats,
     const std::shared_ptr<dwrf::Config>& config =
         std::make_shared<dwrf::Config>(),
     std::function<std::unique_ptr<DWRFFlushPolicy>()> flushPolicy =
@@ -2183,7 +2278,7 @@ createWriterReader(
   std::string data(sinkPtr->data(), sinkPtr->size());
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<InMemoryReadFile>(std::move(data)), *pool);
-  dwio::common::ReaderOptions readerOpts(pool);
+  dwio::common::ReaderOptions readerOpts(pool, &dataIoStats, &metadataIoStats);
   readerOpts.setFileFormat(FileFormat::DWRF);
   auto reader = DwrfReader::create(std::move(input), readerOpts);
   return std::make_pair(std::move(writer), std::move(reader));
@@ -2201,7 +2296,8 @@ TEST_F(TestReader, setRowNumberColumnInfo) {
   };
   auto batches = createBatches(integerValues);
   auto schema = asRowType(batches[0]->type());
-  auto [writer, reader] = createWriterReader(batches, pool());
+  auto [writer, reader] =
+      createWriterReader(batches, pool(), dataIoStats_, metadataIoStats_);
 
   auto spec = std::make_shared<common::ScanSpec>("<root>");
   spec->addAllChildFields(*schema);
@@ -2230,7 +2326,8 @@ TEST_F(TestReader, reuseRowNumberColumn) {
   std::vector<std::vector<int32_t>> integerValues{{0, 1, 2, 3, 4}};
   auto batches = createBatches(integerValues);
   auto schema = asRowType(batches[0]->type());
-  auto [writer, reader] = createWriterReader(batches, pool());
+  auto [writer, reader] =
+      createWriterReader(batches, pool(), dataIoStats_, metadataIoStats_);
 
   auto spec = std::make_shared<common::ScanSpec>("<root>");
   spec->addAllChildFields(*schema);
@@ -2296,7 +2393,8 @@ TEST_F(TestReader, explicitRowNumberColumn) {
       {9, 10, 11, 12, 13, 14, 15},
   };
   auto batches = createBatches(integerValues);
-  auto [writer, reader] = createWriterReader(batches, pool());
+  auto [writer, reader] =
+      createWriterReader(batches, pool(), dataIoStats_, metadataIoStats_);
   auto spec = std::make_shared<common::ScanSpec>("<root>");
   spec->addField("c0", 0);
   spec->addField("$row_number", 1)
@@ -2333,7 +2431,8 @@ TEST_F(TestReader, failToReuseReaderNulls) {
       makeRowVector({"c"}, {makeFlatVector<int64_t>(11, folly::identity)}),
   });
   auto schema = asRowType(data->type());
-  auto [writer, reader] = createWriterReader({data}, pool());
+  auto [writer, reader] =
+      createWriterReader({data}, pool(), dataIoStats_, metadataIoStats_);
   auto spec = std::make_shared<common::ScanSpec>("<root>");
   spec->addAllChildFields(*schema);
   spec->childByName("c0")->childByName("a")->setFilter(
@@ -2384,7 +2483,8 @@ TEST_F(TestReader, readFlatMapsSomeEmpty) {
   config->set(dwrf::Config::FLATTEN_MAP, true);
   config->set(dwrf::Config::MAP_FLAT_COLS, {0});
 
-  auto [writer, reader] = createWriterReader({row}, pool(), config);
+  auto [writer, reader] =
+      createWriterReader({row}, pool(), dataIoStats_, metadataIoStats_, config);
 
   auto schema = asRowType(row->type());
   auto spec = std::make_shared<common::ScanSpec>("<root>");
@@ -2450,7 +2550,8 @@ TEST_F(TestReader, readFlatMapsWithNullMaps) {
   config->set(dwrf::Config::FLATTEN_MAP, true);
   config->set(dwrf::Config::MAP_FLAT_COLS, {0});
 
-  auto [writer, reader] = createWriterReader({row}, pool(), config);
+  auto [writer, reader] =
+      createWriterReader({row}, pool(), dataIoStats_, metadataIoStats_, config);
 
   auto schema = asRowType(row->type());
   auto spec = std::make_shared<common::ScanSpec>("<root>");
@@ -2507,7 +2608,8 @@ TEST_F(TestReader, readFlatMapsAsFlatMaps) {
     config->set(dwrf::Config::FLATTEN_MAP, true);
     config->set(dwrf::Config::MAP_FLAT_COLS, {0});
 
-    auto [writer, reader] = createWriterReader({input}, pool(), config);
+    auto [writer, reader] = createWriterReader(
+        {input}, pool(), dataIoStats_, metadataIoStats_, config);
 
     auto schema = asRowType(input->type());
     auto spec = std::make_shared<common::ScanSpec>("<root>");
@@ -2580,8 +2682,8 @@ TEST_F(TestReader, readFlatMapMultiStripeDifferentKeys) {
   config->set(dwrf::Config::MAP_FLAT_COLS, {0});
 
   // simpleFlushPolicyFactory(true) produces one stripe per batch.
-  auto [writer, reader] =
-      createWriterReader({stripe1, stripe2}, pool(), config);
+  auto [writer, reader] = createWriterReader(
+      {stripe1, stripe2}, pool(), dataIoStats_, metadataIoStats_, config);
   ASSERT_EQ(reader->getNumberOfStripes(), 2);
 
   auto schema = asRowType(stripe1->type());
@@ -2632,7 +2734,8 @@ TEST_F(TestReader, readStructWithWholeBatchFiltered) {
       std::make_shared<RowVector>(pool(), rowType, nulls, vectorSize, children);
   auto row = makeRowVector({"c0"}, {c0});
 
-  auto [writer, reader] = createWriterReader({row}, pool());
+  auto [writer, reader] =
+      createWriterReader({row}, pool(), dataIoStats_, metadataIoStats_);
 
   auto schema = asRowType(row->type());
   auto spec = std::make_shared<common::ScanSpec>("<root>");
@@ -2687,6 +2790,8 @@ TEST_F(TestReader, readStringDictionaryAsFlat) {
   auto [writer, reader] = createWriterReader(
       {batch},
       pool(),
+      dataIoStats_,
+      metadataIoStats_,
       std::make_shared<dwrf::Config>(),
       // The always true flush policy would disable dictionary encoding at least
       // for first batch.
@@ -2728,7 +2833,8 @@ TEST_F(TestReader, missingSubfieldsNoResultReusing) {
           makeFlatVector<int64_t>(kSize, folly::identity),
       }),
   });
-  auto [writer, reader] = createWriterReader({batch}, pool());
+  auto [writer, reader] =
+      createWriterReader({batch}, pool(), dataIoStats_, metadataIoStats_);
   auto schema = ROW({{"c0", ROW({{"c0", BIGINT()}, {"c1", VARCHAR()}})}});
   auto spec = std::make_shared<common::ScanSpec>("<root>");
   spec->addAllChildFields(*schema);
@@ -2757,7 +2863,8 @@ TEST_F(TestReader, selectiveStringDirectFastPath) {
       makeFlatVector<int64_t>(17, [](auto i) { return i != 8; }),
       makeFlatVector<StringView>(17, genStr),
   });
-  auto [writer, reader] = createWriterReader({batch}, pool());
+  auto [writer, reader] =
+      createWriterReader({batch}, pool(), dataIoStats_, metadataIoStats_);
   auto schema = asRowType(batch->type());
   auto spec = std::make_shared<common::ScanSpec>("<root>");
   spec->addAllChildFields(*schema);
@@ -2783,7 +2890,8 @@ TEST_F(TestReader, selectiveStringDirect) {
       makeFlatVector<int64_t>(17, [](auto i) { return i != 15; }),
       makeFlatVector<StringView>(17, genStr),
   });
-  auto [writer, reader] = createWriterReader({batch}, pool());
+  auto [writer, reader] =
+      createWriterReader({batch}, pool(), dataIoStats_, metadataIoStats_);
   auto schema = asRowType(batch->type());
   auto spec = std::make_shared<common::ScanSpec>("<root>");
   spec->addAllChildFields(*schema);
@@ -2807,7 +2915,8 @@ TEST_F(TestReader, selectiveFlatMapFastPathAllInlinedStringKeys) {
   auto config = std::make_shared<dwrf::Config>();
   config->set(dwrf::Config::FLATTEN_MAP, true);
   config->set(dwrf::Config::MAP_FLAT_COLS, {0});
-  auto [writer, reader] = createWriterReader({row}, pool(), config);
+  auto [writer, reader] =
+      createWriterReader({row}, pool(), dataIoStats_, metadataIoStats_, config);
   auto schema = asRowType(row->type());
   auto spec = std::make_shared<common::ScanSpec>("<root>");
   spec->addAllChildFields(*schema);
@@ -2825,7 +2934,8 @@ TEST_F(TestReader, skipLongString) {
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<LocalReadFile>(getExampleFilePath("long_string.dwrf")),
       *pool());
-  dwio::common::ReaderOptions readerOpts(pool());
+  dwio::common::ReaderOptions readerOpts(
+      pool(), &dataIoStats_, &metadataIoStats_);
   readerOpts.setFileFormat(FileFormat::DWRF);
   auto reader = DwrfReader::create(std::move(input), readerOpts);
   auto spec = std::make_shared<common::ScanSpec>("<root>");
@@ -2867,7 +2977,8 @@ TEST_F(TestReader, mapAsStruct) {
   auto row = makeRowVector({
       makeMapVector<int32_t, int64_t>({{{1, 4}, {2, 5}}, {{1, 6}, {3, 7}}}),
   });
-  auto [writer, reader] = createWriterReader({row}, pool());
+  auto [writer, reader] =
+      createWriterReader({row}, pool(), dataIoStats_, metadataIoStats_);
   auto outType = ROW({"c0"}, {ROW({"3", "1"}, BIGINT())});
   auto spec = std::make_shared<common::ScanSpec>("<root>");
   spec->addAllChildFields(*outType);
@@ -2894,7 +3005,8 @@ TEST_F(TestReader, mapAsStructFilterAfterRead) {
       makeRowVector(
           {makeConstant<int64_t>(0, 3)}, [](auto i) { return i == 0; }),
   });
-  auto [writer, reader] = createWriterReader({row}, pool());
+  auto [writer, reader] =
+      createWriterReader({row}, pool(), dataIoStats_, metadataIoStats_);
   auto outType =
       ROW({"c0", "c1"}, {ROW({"3", "1"}, BIGINT()), ROW({"c0"}, BIGINT())});
   auto spec = std::make_shared<common::ScanSpec>("<root>");
@@ -2922,7 +3034,8 @@ TEST_F(TestReader, mapAsStructFilterAfterRead) {
 
 TEST_F(TestReader, mapAsStructAllEmpty) {
   auto row = makeRowVector({makeMapVector<int32_t, int64_t>({{}, {}})});
-  auto [writer, reader] = createWriterReader({row}, pool());
+  auto [writer, reader] =
+      createWriterReader({row}, pool(), dataIoStats_, metadataIoStats_);
   auto outType = ROW({"c0"}, {ROW({"1"}, BIGINT())});
   auto spec = std::make_shared<common::ScanSpec>("<root>");
   spec->addAllChildFields(*outType);
@@ -3001,7 +3114,8 @@ DEBUG_ONLY_TEST_F(TestReader, asyncLoadSurvivesReaderDestruction) {
 
   // Make sure ReaderOptions and DwrfRowReader are freed after {} scope
   {
-    dwio::common::ReaderOptions readerOpts(pool());
+    dwio::common::ReaderOptions readerOpts(
+        pool(), &dataIoStats_, &metadataIoStats_);
     readerOpts.setFileFormat(FileFormat::DWRF);
     auto reader = DwrfReader::create(std::move(input), readerOpts);
 

--- a/velox/dwio/dwrf/test/StripeReaderBaseTests.cpp
+++ b/velox/dwio/dwrf/test/StripeReaderBaseTests.cpp
@@ -17,6 +17,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "velox/common/io/IoStatistics.h"
 #include "velox/dwio/common/encryption/TestProvider.h"
 #include "velox/dwio/dwrf/reader/StripeReaderBase.h"
 #include "velox/dwio/dwrf/utils/ProtoUtils.h"
@@ -73,7 +74,9 @@ class StripeLoadKeysTest : public Test {
         nullptr,
         footer_.get(),
         nullptr,
-        std::move(handler));
+        std::move(handler),
+        dataIoStats_.get(),
+        metadataIoStats_.get());
 
     stripeReader_ = std::make_unique<StripeReaderBase>(reader_);
   }
@@ -104,6 +107,10 @@ class StripeLoadKeysTest : public Test {
   std::unique_ptr<StripeReaderBase> stripeReader_;
   TestEncryption* enc_;
   std::shared_ptr<MemoryPool> pool_;
+  std::shared_ptr<io::IoStatistics> dataIoStats_ =
+      std::make_shared<io::IoStatistics>();
+  std::shared_ptr<io::IoStatistics> metadataIoStats_ =
+      std::make_shared<io::IoStatistics>();
   std::unique_ptr<const proto::StripeFooter> stripeFooter_;
   std::unique_ptr<const encryption::DecryptionHandler> handler_;
   std::unique_ptr<const StripeInformationWrapper> stripeInfo_;

--- a/velox/dwio/dwrf/test/StripeStreamTest.cpp
+++ b/velox/dwio/dwrf/test/StripeStreamTest.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/dwio/dwrf/reader/StripeStream.h"
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/io/IoStatistics.h"
 #include "velox/dwio/common/Arena.h"
 #include "velox/dwio/common/encryption/TestProvider.h"
 #include "velox/dwio/dwrf/test/OrcTest.h"
@@ -138,6 +139,10 @@ class StripeStreamTest : public testing::TestWithParam<DwrfFormat> {
     MemoryManager::testingSetInstance(MemoryManager::Options{});
   }
   std::shared_ptr<MemoryPool> pool_{memoryManager()->addLeafPool()};
+  std::shared_ptr<facebook::velox::io::IoStatistics> dataIoStats_ =
+      std::make_shared<facebook::velox::io::IoStatistics>();
+  std::shared_ptr<facebook::velox::io::IoStatistics> metadataIoStats_ =
+      std::make_shared<facebook::velox::io::IoStatistics>();
 };
 
 class StripeStreamFormatTypeTest : public testing::TestWithParam<DwrfFormat> {
@@ -146,6 +151,10 @@ class StripeStreamFormatTypeTest : public testing::TestWithParam<DwrfFormat> {
     MemoryManager::testingSetInstance(MemoryManager::Options{});
   }
   std::shared_ptr<MemoryPool> pool_{memoryManager()->addLeafPool()};
+  std::shared_ptr<facebook::velox::io::IoStatistics> dataIoStats_ =
+      std::make_shared<facebook::velox::io::IoStatistics>();
+  std::shared_ptr<facebook::velox::io::IoStatistics> metadataIoStats_ =
+      std::make_shared<facebook::velox::io::IoStatistics>();
   DwrfFormat testParamDwrfFormat_ = GetParam();
 };
 
@@ -177,7 +186,10 @@ TEST_P(StripeStreamFormatTypeTest, planReads) {
           true),
       std::make_unique<PostScript>(proto::PostScript{}),
       footer,
-      nullptr);
+      nullptr,
+      nullptr,
+      dataIoStats_.get(),
+      metadataIoStats_.get());
   ColumnSelector cs{readerBase->schema(), std::vector<uint64_t>{2}, true};
 
   TestDecrypterFactory factory;
@@ -260,7 +272,10 @@ TEST_F(StripeStreamTest, filterSequences) {
       std::make_unique<BufferedInput>(std::move(is), *pool_),
       std::make_unique<PostScript>(proto::PostScript{}),
       footer,
-      nullptr);
+      nullptr,
+      nullptr,
+      dataIoStats_.get(),
+      metadataIoStats_.get());
 
   // mock a filter that we only need one node and one sequence
   ColumnSelector cs{readerBase->schema(), std::vector<std::string>{"a#[1]"}};
@@ -328,7 +343,10 @@ TEST_P(StripeStreamFormatTypeTest, zeroLength) {
       std::make_unique<BufferedInput>(std::move(is), *pool_),
       std::make_unique<PostScript>(std::move(ps)),
       footer,
-      nullptr);
+      nullptr,
+      nullptr,
+      dataIoStats_.get(),
+      metadataIoStats_.get());
 
   TestDecrypterFactory factory;
   auto handler = DecryptionHandler::create(FooterWrapper(footer), &factory);
@@ -462,7 +480,10 @@ TEST_P(StripeStreamFormatTypeTest, planReadsIndex) {
       std::make_unique<BufferedInput>(std::move(is), *pool_),
       std::make_unique<PostScript>(std::move(ps)),
       footer,
-      std::move(cache));
+      std::move(cache),
+      nullptr,
+      dataIoStats_.get(),
+      metadataIoStats_.get());
 
   TestDecrypterFactory factory;
   auto handler = DecryptionHandler::create(FooterWrapper(footer), &factory);
@@ -648,7 +669,9 @@ TEST_F(StripeStreamTest, readEncryptedStreams) {
       std::make_unique<PostScript>(std::move(ps)),
       footer,
       nullptr,
-      std::move(handler));
+      std::move(handler),
+      dataIoStats_.get(),
+      metadataIoStats_.get());
   auto stripeMetadata = std::make_unique<const StripeMetadata>(
       &readerBase->bufferedInput(),
       std::move(stripeFooter),
@@ -732,7 +755,9 @@ TEST_F(StripeStreamTest, schemaMismatch) {
       std::make_unique<PostScript>(std::move(ps)),
       footer,
       nullptr,
-      std::move(handler));
+      std::move(handler),
+      dataIoStats_.get(),
+      metadataIoStats_.get());
   auto stripeMetadata = std::make_unique<const StripeMetadata>(
       &readerBase->bufferedInput(),
       std::move(stripeFooter),

--- a/velox/dwio/dwrf/test/WriterTest.cpp
+++ b/velox/dwio/dwrf/test/WriterTest.cpp
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 #include <stdexcept>
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/io/IoStatistics.h"
 #include "velox/dwio/dwrf/reader/ReaderBase.h"
 #include "velox/dwio/dwrf/writer/WriterBase.h"
 #include "velox/type/fbhive/HiveTypeParser.h"
@@ -61,7 +62,8 @@ class WriterTest : public Test {
     std::string data(sinkPtr_->data(), sinkPtr_->size());
     auto readFile = std::make_shared<InMemoryReadFile>(std::move(data));
     auto input = std::make_unique<BufferedInput>(std::move(readFile), *pool_);
-    dwio::common::ReaderOptions readerOpts{pool_.get()};
+    dwio::common::ReaderOptions readerOpts{
+        pool_.get(), &dataIoStats_, &metadataIoStats_};
     auto reader = std::make_unique<ReaderBase>(readerOpts, std::move(input));
     reader->loadCache();
     return reader;
@@ -91,6 +93,8 @@ class WriterTest : public Test {
   std::shared_ptr<MemoryPool> pool_;
   MemorySink* sinkPtr_;
   std::unique_ptr<WriterBase> writer_;
+  io::IoStatistics dataIoStats_;
+  io::IoStatistics metadataIoStats_;
 };
 
 class SupportedCompressionTest

--- a/velox/dwio/dwrf/test/utils/E2EWriterTestUtil.cpp
+++ b/velox/dwio/dwrf/test/utils/E2EWriterTestUtil.cpp
@@ -17,6 +17,7 @@
 #include "velox/dwio/dwrf/test/utils/E2EWriterTestUtil.h"
 
 #include <gtest/gtest.h>
+#include "velox/common/io/IoStatistics.h"
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
 #include "velox/dwio/dwrf/reader/DwrfReader.h"
 #include "velox/dwio/dwrf/writer/FlushPolicy.h"
@@ -114,7 +115,9 @@ namespace facebook::velox::dwrf {
       std::string(sinkPtr->data(), sinkPtr->size()));
   auto input = std::make_unique<BufferedInput>(readFile, pool);
 
-  dwio::common::ReaderOptions readerOpts{&pool};
+  io::IoStatistics dataIoStats;
+  io::IoStatistics metadataIoStats;
+  dwio::common::ReaderOptions readerOpts{&pool, &dataIoStats, &metadataIoStats};
   RowReaderOptions rowReaderOpts;
   auto reader = std::make_unique<DwrfReader>(readerOpts, std::move(input));
   EXPECT_GE(numStripesUpper, reader->getNumberOfStripes());

--- a/velox/dwio/orc/test/ReaderFilterTest.cpp
+++ b/velox/dwio/orc/test/ReaderFilterTest.cpp
@@ -47,6 +47,9 @@ class OrcReaderFilterTestP
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
   }
+
+  io::IoStatistics dataIoStats_;
+  io::IoStatistics metadataIoStats_;
 };
 
 INSTANTIATE_TEST_SUITE_P(
@@ -217,7 +220,8 @@ TEST_P(OrcReaderFilterTestP, tests) {
 
   std::string fileName = "orc_all_type.orc";
 
-  dwio::common::ReaderOptions readerOpts{pool()};
+  dwio::common::ReaderOptions readerOpts{
+      pool(), &dataIoStats_, &metadataIoStats_};
 
   // To make DwrfReader reads ORC file, setFileFormat to FileFormat::ORC
   readerOpts.setFileFormat(dwio::common::FileFormat::ORC);

--- a/velox/dwio/orc/test/ReaderTest.cpp
+++ b/velox/dwio/orc/test/ReaderTest.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include "velox/common/io/IoStatistics.h"
 #include "velox/dwio/dwrf/common/Common.h"
 #include "velox/dwio/dwrf/reader/DwrfReader.h"
 #include "velox/dwio/dwrf/test/OrcTest.h"
@@ -35,6 +36,11 @@ class OrcReaderTest : public testing::Test, public VectorTestBase {
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
   }
+
+  std::shared_ptr<io::IoStatistics> dataIoStats_ =
+      std::make_shared<io::IoStatistics>();
+  std::shared_ptr<io::IoStatistics> metadataIoStats_ =
+      std::make_shared<io::IoStatistics>();
 };
 
 inline std::string getExamplesFilePath(const std::string& fileName) {
@@ -46,7 +52,8 @@ inline std::string getExamplesFilePath(const std::string& fileName) {
 TEST_F(OrcReaderTest, testOrcReaderSimple) {
   const std::string simpleTest(
       getExamplesFilePath("TestStringDictionary.testRowIndex.orc"));
-  dwio::common::ReaderOptions readerOpts{pool()};
+  dwio::common::ReaderOptions readerOpts{
+      pool(), dataIoStats_.get(), metadataIoStats_.get()};
   // To make DwrfReader reads ORC file, setFileFormat to FileFormat::ORC
   readerOpts.setFileFormat(dwio::common::FileFormat::ORC);
   auto reader = DwrfReader::create(
@@ -83,7 +90,8 @@ TEST_F(OrcReaderTest, testOrcReaderComplexTypes) {
          g:map<string,struct<\
            h:struct<\
              i:array<double>>>>>>"));
-  dwio::common::ReaderOptions readerOpts{pool()};
+  dwio::common::ReaderOptions readerOpts{
+      pool(), dataIoStats_.get(), metadataIoStats_.get()};
   readerOpts.setFileFormat(dwio::common::FileFormat::ORC);
   auto reader = DwrfReader::create(
       createFileBufferedInput(icebergOrc, readerOpts.memoryPool()), readerOpts);
@@ -102,7 +110,8 @@ TEST_F(OrcReaderTest, testOrcReaderComplexTypes) {
 
 TEST_F(OrcReaderTest, testOrcReaderVarchar) {
   const std::string varcharOrc(getExamplesFilePath("orc_index_int_string.orc"));
-  dwio::common::ReaderOptions readerOpts{pool()};
+  dwio::common::ReaderOptions readerOpts{
+      pool(), dataIoStats_.get(), metadataIoStats_.get()};
   readerOpts.setFileFormat(dwio::common::FileFormat::ORC);
   auto reader = DwrfReader::create(
       createFileBufferedInput(varcharOrc, readerOpts.memoryPool()), readerOpts);
@@ -133,7 +142,8 @@ TEST_F(OrcReaderTest, testOrcReaderVarchar) {
 TEST_F(OrcReaderTest, testOrcReaderDate) {
   const std::string dateOrc(
       getExamplesFilePath("TestOrcFile.testDate1900.orc"));
-  dwio::common::ReaderOptions readerOpts{pool()};
+  dwio::common::ReaderOptions readerOpts{
+      pool(), dataIoStats_.get(), metadataIoStats_.get()};
   readerOpts.setFileFormat(dwio::common::FileFormat::ORC);
   auto reader = DwrfReader::create(
       createFileBufferedInput(dateOrc, readerOpts.memoryPool()), readerOpts);
@@ -178,7 +188,8 @@ TEST_F(OrcReaderTest, testOrcReaderDate) {
 // ) with (format = 'ORC');
 TEST_F(OrcReaderTest, testOrcReadAllType) {
   const std::string dateOrc(getExamplesFilePath("orc_all_type.orc"));
-  dwio::common::ReaderOptions readerOpts{pool()};
+  dwio::common::ReaderOptions readerOpts{
+      pool(), dataIoStats_.get(), metadataIoStats_.get()};
   readerOpts.setFileFormat(dwio::common::FileFormat::ORC);
   auto reader = DwrfReader::create(
       createFileBufferedInput(dateOrc, readerOpts.memoryPool()), readerOpts);
@@ -255,7 +266,8 @@ TEST_F(OrcReaderTest, testOrcRlev2) {
   auto spec = std::make_shared<common::ScanSpec>("<root>");
   spec->addAllChildFields(*schema);
 
-  dwio::common::ReaderOptions readerOpts{pool()};
+  dwio::common::ReaderOptions readerOpts{
+      pool(), dataIoStats_.get(), metadataIoStats_.get()};
   readerOpts.setScanSpec(spec);
   readerOpts.setFileFormat(dwio::common::FileFormat::ORC);
 
@@ -361,13 +373,19 @@ class OrcReaderTestP : public testing::TestWithParam<OrcFileDescription>,
     return test::getDataFilePath(
         "velox/dwio/orc/test", "examples/expected/" + GetParam().json);
   }
+
+  std::shared_ptr<io::IoStatistics> dataIoStats_ =
+      std::make_shared<io::IoStatistics>();
+  std::shared_ptr<io::IoStatistics> metadataIoStats_ =
+      std::make_shared<io::IoStatistics>();
 };
 
 TEST_P(
     OrcReaderTestP,
     DwrfReader_FetchesOrcMetadata_ExpectCorrectFooterAndMetadata) {
   const std::string dateOrc(getFilename());
-  dwio::common::ReaderOptions readerOpts{pool()};
+  dwio::common::ReaderOptions readerOpts{
+      pool(), dataIoStats_.get(), metadataIoStats_.get()};
   readerOpts.setFileFormat(dwio::common::FileFormat::ORC);
   auto reader = DwrfReader::create(
       createFileBufferedInput(dateOrc, readerOpts.memoryPool()), readerOpts);
@@ -408,7 +426,8 @@ TEST_P(OrcReaderTestP, DwrfRowReader_ReadAllColumnTypes_ExpectedRowDataRead) {
   scanSpec->addAllChildFields(*schema);
 
   const std::string dateOrc(getFilename());
-  dwio::common::ReaderOptions readerOpts{pool()};
+  dwio::common::ReaderOptions readerOpts{
+      pool(), dataIoStats_.get(), metadataIoStats_.get()};
   readerOpts.setFileFormat(dwio::common::FileFormat::ORC);
   readerOpts.setScanSpec(scanSpec);
 

--- a/velox/dwio/parquet/tests/ParquetTestBase.h
+++ b/velox/dwio/parquet/tests/ParquetTestBase.h
@@ -20,6 +20,7 @@
 #include <string>
 #include "velox/common/base/Fs.h"
 #include "velox/common/file/File.h"
+#include "velox/common/io/IoStatistics.h"
 #include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/dwio/common/FileSink.h"
 #include "velox/dwio/common/Reader.h"
@@ -236,6 +237,10 @@ class ParquetTestBase : public testing::Test,
   static constexpr uint64_t kBytesInRowGroup = 128 * 1'024 * 1'024;
   std::shared_ptr<memory::MemoryPool> rootPool_;
   std::shared_ptr<memory::MemoryPool> leafPool_;
+  std::shared_ptr<velox::io::IoStatistics> dataIoStats_ =
+      std::make_shared<velox::io::IoStatistics>();
+  std::shared_ptr<velox::io::IoStatistics> metadataIoStats_ =
+      std::make_shared<velox::io::IoStatistics>();
   std::shared_ptr<TempDirectoryPath> tempPath_;
   // Stores writers created by write() helper to keep sinks alive for reading.
   std::vector<std::unique_ptr<Writer>> writers_;

--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/common/io/IoStatistics.h"
 #include "velox/dwio/common/tests/utils/E2EFilterTestBase.h"
 #include "velox/dwio/parquet/reader/ParquetReader.h"
 #include "velox/dwio/parquet/reader/ParquetTypeWithId.h"
@@ -91,6 +92,10 @@ class E2EFilterTest : public E2EFilterTestBase,
     return std::make_unique<ParquetReader>(std::move(input), opts);
   }
 
+  std::shared_ptr<velox::io::IoStatistics> dataIoStats_ =
+      std::make_shared<velox::io::IoStatistics>();
+  std::shared_ptr<velox::io::IoStatistics> metadataIoStats_ =
+      std::make_shared<velox::io::IoStatistics>();
   std::unique_ptr<facebook::velox::parquet::Writer> writer_;
   facebook::velox::parquet::WriterOptions options_;
   uint64_t rowsInRowGroup_ = 10'000;
@@ -663,7 +668,8 @@ TEST_F(E2EFilterTest, largeMetadata) {
       std::static_pointer_cast<RowVector>(test::BatchMaker::createBatch(
           rowType_, 1000, *leafPool_, nullptr, 0)));
   writeToMemory(rowType_, batches, false);
-  dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  dwio::common::ReaderOptions readerOpts{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   readerOpts.setFooterSpeculativeIoSize(1024);
   readerOpts.setFilePreloadThreshold(1024 * 8);
   dwio::common::RowReaderOptions rowReaderOpts;
@@ -748,7 +754,8 @@ TEST_F(E2EFilterTest, combineRowGroup) {
             rowType_, 1, *leafPool_, nullptr, 0)));
   }
   writeToMemory(rowType_, batches, false);
-  dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  dwio::common::ReaderOptions readerOpts{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
   auto reader = makeReader(readerOpts, std::move(input));
@@ -805,7 +812,8 @@ TEST_F(E2EFilterTest, parquetMRVersionStringStatsRowGroupFiltering) {
             {kSanXing, kVivo, kSanXing, kVivo, kSanXing})}));
     writer->close();
 
-    dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+    dwio::common::ReaderOptions readerOptions{
+        leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
     auto input = std::make_unique<BufferedInput>(
         std::make_shared<InMemoryReadFile>(
             std::string(sinkPtr->data(), sinkPtr->size())),
@@ -861,7 +869,8 @@ TEST_F(E2EFilterTest, writeDecimalAsInteger) {
        makeFlatVector<int64_t>({1, 2}, DECIMAL(10, 2)),
        makeFlatVector<int128_t>({1, 2}, DECIMAL(19, 2))});
   writeToMemory(rowVector->type(), {rowVector}, false);
-  dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  dwio::common::ReaderOptions readerOpts{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
   auto reader = makeReader(readerOpts, std::move(input));
@@ -886,7 +895,8 @@ TEST_F(E2EFilterTest, configurableWriteSchema) {
     }
 
     writeToMemory(newType, batches, false);
-    dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+    dwio::common::ReaderOptions readerOpts{
+        leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
     auto input = std::make_unique<BufferedInput>(
         std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
     auto reader = makeReader(readerOpts, std::move(input));

--- a/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
@@ -96,7 +96,8 @@ std::shared_ptr<ScanSpec> ParquetReaderBenchmark::createScanSpec(
 std::unique_ptr<RowReader> ParquetReaderBenchmark::createReader(
     std::shared_ptr<ScanSpec> scanSpec,
     const RowTypePtr& rowType) {
-  dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  dwio::common::ReaderOptions readerOpts{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<LocalReadFile>(fileFolder_->getPath() + "/" + fileName_),
       readerOpts.memoryPool());

--- a/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.h
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "velox/common/io/IoStatistics.h"
 #include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/dwio/common/FileSink.h"
 #include "velox/dwio/common/Options.h"
@@ -113,6 +114,10 @@ class ParquetReaderBenchmark {
   std::unique_ptr<facebook::velox::test::DataSetBuilder> dataSetBuilder_;
   std::shared_ptr<facebook::velox::memory::MemoryPool> rootPool_;
   std::shared_ptr<facebook::velox::memory::MemoryPool> leafPool_;
+  std::shared_ptr<facebook::velox::io::IoStatistics> dataIoStats_ =
+      std::make_shared<facebook::velox::io::IoStatistics>();
+  std::shared_ptr<facebook::velox::io::IoStatistics> metadataIoStats_ =
+      std::make_shared<facebook::velox::io::IoStatistics>();
   std::unique_ptr<facebook::velox::parquet::Writer> writer_;
   facebook::velox::dwio::common::RuntimeStatistics runtimeStats_;
 };

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -35,7 +35,8 @@ class ParquetReaderTest : public ParquetTestBase {
       const RowTypePtr& rowType) {
     const std::string sample(getExampleFilePath(fileName));
 
-    dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+    dwio::common::ReaderOptions readerOptions{
+        leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
     auto reader = createReader(sample, readerOptions);
 
     RowReaderOptions rowReaderOpts;
@@ -61,7 +62,8 @@ class ParquetReaderTest : public ParquetTestBase {
       FilterMap filters,
       const RowVectorPtr& expected) {
     const auto filePath(getExampleFilePath(fileName));
-    dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+    dwio::common::ReaderOptions readerOpts{
+        leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
     auto reader = createReader(filePath, readerOpts);
     assertReadWithReaderAndFilters(
         std::move(reader), fileName, fileSchema, std::move(filters), expected);
@@ -76,7 +78,8 @@ TEST_F(ParquetReaderTest, parseSample) {
   //   b: [1.0..20.0]
   const std::string sample(getExampleFilePath("sample.parquet"));
 
-  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 20ULL);
 
@@ -125,7 +128,8 @@ TEST_F(ParquetReaderTest, parseEmptyNestedList) {
   const std::string sample(
       getExampleFilePath("parse_empty_nested_list.parquet"));
 
-  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 1000ULL);
 
@@ -183,7 +187,8 @@ TEST_F(ParquetReaderTest, parseUnannotatedList) {
   // }
   const std::string sample(getExampleFilePath("unannotated_list.parquet"));
 
-  dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  dwio::common::ReaderOptions readerOpts{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto reader = createReader(sample, readerOpts);
 
   EXPECT_EQ(reader->numberOfRows(), 22ULL);
@@ -238,7 +243,8 @@ TEST_F(ParquetReaderTest, parseUnannotatedMap) {
   const std::string filename("unnotated_map.parquet");
   const std::string sample(getExampleFilePath(filename));
 
-  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto reader = createReader(sample, readerOptions);
 
   auto type = reader->typeWithId();
@@ -277,7 +283,8 @@ TEST_F(ParquetReaderTest, parseLegacyListWithMultipleChildren) {
   const std::string filename("listmultiplechildren.parquet");
   const std::string sample(getExampleFilePath(filename));
 
-  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto reader = createReader(sample, readerOptions);
 
   auto type = reader->typeWithId();
@@ -336,7 +343,8 @@ TEST_F(ParquetReaderTest, parseArrayOfRowHiveReservedKeywords) {
   const std::string sample(
       getExampleFilePath("array_of_row_hive_reserved_keywords.parquet"));
 
-  dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  dwio::common::ReaderOptions readerOpts{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto reader = createReader(sample, readerOpts);
   EXPECT_EQ(reader->rowType()->toString(), expectedVeloxType);
   EXPECT_EQ(reader->numberOfRows(), 6ULL);
@@ -387,7 +395,8 @@ TEST_F(ParquetReaderTest, parseArrayOfRowHiveReservedKeywords) {
 TEST_F(ParquetReaderTest, parseSampleRange1) {
   const std::string sample(getExampleFilePath("sample.parquet"));
 
-  dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  dwio::common::ReaderOptions readerOpts{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto reader = createReader(sample, readerOpts);
 
   auto rowReaderOpts = getReaderOpts(sampleSchema());
@@ -406,7 +415,8 @@ TEST_F(ParquetReaderTest, parseSampleRange1) {
 TEST_F(ParquetReaderTest, parseSampleRange2) {
   const std::string sample(getExampleFilePath("sample.parquet"));
 
-  dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  dwio::common::ReaderOptions readerOpts{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto reader = createReader(sample, readerOpts);
 
   auto rowReaderOpts = getReaderOpts(sampleSchema());
@@ -425,7 +435,8 @@ TEST_F(ParquetReaderTest, parseSampleRange2) {
 TEST_F(ParquetReaderTest, parseSampleEmptyRange) {
   const std::string sample(getExampleFilePath("sample.parquet"));
 
-  dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  dwio::common::ReaderOptions readerOpts{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto reader = createReader(sample, readerOpts);
 
   auto rowReaderOpts = getReaderOpts(sampleSchema());
@@ -443,7 +454,8 @@ TEST_F(ParquetReaderTest, parseReadAsLowerCase) {
   // 2 rows.
   const std::string upper(getExampleFilePath("upper.parquet"));
 
-  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto outputRowType = ROW({"a", "b"}, {BIGINT(), BIGINT()});
   readerOptions.setFileSchema(outputRowType);
   readerOptions.setFileColumnNamesReadAsLowerCase(true);
@@ -479,7 +491,8 @@ TEST_F(ParquetReaderTest, parseRowMapArrayReadAsLowerCase) {
   // +-----------------------+
   const std::string upper(getExampleFilePath("upper_complex.parquet"));
 
-  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   readerOptions.setFileColumnNamesReadAsLowerCase(true);
   auto reader = createReader(upper, readerOptions);
 
@@ -522,7 +535,8 @@ TEST_F(ParquetReaderTest, parseEmpty) {
   // 0 rows.
   const std::string empty(getExampleFilePath("empty.parquet"));
 
-  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto reader = createReader(empty, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 0ULL);
 
@@ -544,7 +558,8 @@ TEST_F(ParquetReaderTest, parseInt) {
   //   bigint: [1000 .. 1009]
   const std::string sample(getExampleFilePath("int.parquet"));
 
-  dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  dwio::common::ReaderOptions readerOpts{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto reader = createReader(sample, readerOpts);
 
   EXPECT_EQ(reader->numberOfRows(), 10ULL);
@@ -579,7 +594,8 @@ TEST_F(ParquetReaderTest, parseUnsignedInt1) {
   //   uint64: [18446744073709551615, 2000000000000000000, 3000000000000000000]
   const std::string sample(getExampleFilePath("uint.parquet"));
 
-  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto reader = createReader(sample, readerOptions);
 
   EXPECT_EQ(reader->numberOfRows(), 3ULL);
@@ -683,7 +699,8 @@ TEST_F(ParquetReaderTest, parseDate) {
   //   date: [1969-12-27 .. 1970-01-20]
   const std::string sample(getExampleFilePath("date.parquet"));
 
-  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto reader = createReader(sample, readerOptions);
 
   EXPECT_EQ(reader->numberOfRows(), 25ULL);
@@ -710,7 +727,8 @@ TEST_F(ParquetReaderTest, parseRowMapArray) {
   // ARRAY(INTEGER)) c1) c)
   const std::string sample(getExampleFilePath("row_map_array.parquet"));
 
-  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto reader = createReader(sample, readerOptions);
 
   EXPECT_EQ(reader->numberOfRows(), 1ULL);
@@ -743,7 +761,8 @@ TEST_F(ParquetReaderTest, parseRowMapArray) {
 TEST_F(ParquetReaderTest, projectNoColumns) {
   // This is the case for count(*).
   auto rowType = ROW({}, {});
-  dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  dwio::common::ReaderOptions readerOpts{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto reader = createReader(getExampleFilePath("sample.parquet"), readerOpts);
   RowReaderOptions rowReaderOpts;
   rowReaderOpts.setScanSpec(makeScanSpec(rowType));
@@ -767,7 +786,8 @@ TEST_F(ParquetReaderTest, parseIntDecimal) {
   //   a: [11.11, 11.11, 22.22, 22.22, 33.33, 33.33]
   //   b: [11.11, 11.11, 22.22, 22.22, 33.33, 33.33]
   auto rowType = ROW({"a", "b"}, {DECIMAL(7, 2), DECIMAL(14, 2)});
-  dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  dwio::common::ReaderOptions readerOpts{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   const std::string decimal_dict(getExampleFilePath("decimal_dict.parquet"));
 
   auto reader = createReader(decimal_dict, readerOpts);
@@ -821,7 +841,8 @@ TEST_F(ParquetReaderTest, parseMapKeyValueAsMap) {
 
   const std::string sample(getExampleFilePath("map_key_value.parquet"));
 
-  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 1ULL);
 
@@ -869,7 +890,8 @@ TEST_F(ParquetReaderTest, parseRowArrayTest) {
   const std::string sample(
       getExampleFilePath("proto-struct-with-array.parquet"));
 
-  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 1ULL);
   auto type = reader->typeWithId();
@@ -1154,7 +1176,8 @@ TEST_F(ParquetReaderTest, filterRowGroups) {
   // decimal_no_ColumnMetadata.parquet has one columns a: DECIMAL(9,1). It
   // doesn't have ColumnMetaData, and rowGroups_[0].columns[0].file_offset is 0.
   auto rowType = ROW({"_c0"}, {DECIMAL(9, 1)});
-  dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  dwio::common::ReaderOptions readerOpts{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   const std::string decimal_dict(
       getExampleFilePath("decimal_no_ColumnMetadata.parquet"));
 
@@ -1181,7 +1204,8 @@ TEST_F(ParquetReaderTest, shouldIgnoreStatsForParquetMRVersions) {
 // This test is to verify filterRowGroups() doesn't fail if offset is 0
 TEST_F(ParquetReaderTest, filterRowGroupsWithZeroOffset) {
   auto rowType = ROW({"IDX"}, {INTEGER()});
-  const dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  const dwio::common::ReaderOptions readerOpts{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   const std::string zeroOffsetPath(
       getExampleFilePath("zero_offset_row_group.parquet"));
 
@@ -1197,7 +1221,8 @@ TEST_F(ParquetReaderTest, parseLongTagged) {
   // This is a case for long with annonation read
   const std::string sample(getExampleFilePath("tagged_long.parquet"));
 
-  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto reader = createReader(sample, readerOptions);
 
   EXPECT_EQ(reader->numberOfRows(), 4ULL);
@@ -1215,7 +1240,8 @@ TEST_F(ParquetReaderTest, preloadSmallFile) {
   auto file = std::make_shared<LocalReadFile>(sample);
   auto input = std::make_unique<BufferedInput>(file, *leafPool_);
 
-  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto reader =
       std::make_unique<ParquetReader>(std::move(input), readerOptions);
 
@@ -1249,7 +1275,8 @@ TEST_F(ParquetReaderTest, prefetchRowGroups) {
   const std::string sample(getExampleFilePath("multiple_row_groups.parquet"));
   const int numRowGroups = 4;
 
-  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   // Disable preload of file.
   readerOptions.setFilePreloadThreshold(0);
 
@@ -1302,7 +1329,8 @@ TEST_F(ParquetReaderTest, testEmptyRowGroups) {
   // empty_row_groups.parquet contains empty row groups
   const std::string sample(getExampleFilePath("empty_row_groups.parquet"));
 
-  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 5ULL);
 
@@ -1328,7 +1356,8 @@ TEST_F(ParquetReaderTest, testEnumType) {
   // enum_type.parquet contains 1 column (ENUM) with 3 rows.
   const std::string sample(getExampleFilePath("enum_type.parquet"));
 
-  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 3ULL);
 
@@ -1353,7 +1382,8 @@ TEST_F(ParquetReaderTest, readVarbinaryFromFLBA) {
   const std::string filename("varbinary_flba.parquet");
   const std::string sample(getExampleFilePath(filename));
 
-  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto reader = createReader(sample, readerOptions);
 
   auto type = reader->typeWithId();
@@ -1384,7 +1414,8 @@ TEST_F(ParquetReaderTest, readBinaryAsStringFromNation) {
   const std::string filename("nation.parquet");
   const std::string sample(getExampleFilePath(filename));
 
-  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto outputRowType =
       ROW({"nationkey", "name", "regionkey", "comment"},
           {BIGINT(), VARCHAR(), BIGINT(), VARCHAR()});
@@ -1415,7 +1446,8 @@ TEST_F(ParquetReaderTest, readComplexType) {
   const std::string filename("complex_with_varchar_varbinary.parquet");
   const std::string sample(getExampleFilePath(filename));
 
-  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto outputRowType =
       ROW({"a", "b", "c", "d"},
           {ARRAY(VARCHAR()),
@@ -1462,7 +1494,8 @@ TEST_F(ParquetReaderTest, readFixedLenBinaryAsStringFromUuid) {
   const std::string filename("uuid.parquet");
   const std::string sample(getExampleFilePath(filename));
 
-  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto outputRowType = ROW({"uuid_field"}, {VARCHAR()});
 
   readerOptions.setFileSchema(outputRowType);
@@ -1490,7 +1523,8 @@ TEST_F(ParquetReaderTest, readFixedLenBinaryAsStringFromUuid) {
 TEST_F(ParquetReaderTest, testV2PageWithZeroMaxDefRep) {
   const std::string sample(getExampleFilePath("v2_page.parquet"));
 
-  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 5ULL);
 
@@ -1514,7 +1548,8 @@ TEST_F(ParquetReaderTest, testV2PageWithZeroMaxDefRep) {
 TEST_F(ParquetReaderTest, readComplexTypeWithV2Page) {
   const std::string sample(getExampleFilePath("complex_type_v2_page.parquet"));
 
-  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 1ULL);
 
@@ -1554,7 +1589,8 @@ TEST_F(ParquetReaderTest, arrayOfMapOfIntKeyArrayValue) {
       "ROW<test:ARRAY<MAP<VARCHAR,ARRAY<INTEGER>>>>";
   const std::string sample(
       getExampleFilePath("array_of_map_of_int_key_array_value.parquet"));
-  facebook::velox::dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  facebook::velox::dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->rowType()->toString(), expectedVeloxType);
   auto type = reader->typeWithId();
@@ -1587,7 +1623,8 @@ TEST_F(ParquetReaderTest, arrayOfMapOfIntKeyStructValue) {
       "ROW<test:ARRAY<MAP<INTEGER,ROW<stringfield:VARCHAR,longfield:BIGINT>>>>";
   const std::string sample(
       getExampleFilePath("array_of_map_of_int_key_struct_value.parquet"));
-  facebook::velox::dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  facebook::velox::dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->rowType()->toString(), expectedVeloxType);
   auto type = reader->typeWithId();
@@ -1621,7 +1658,8 @@ TEST_F(ParquetReaderTest, struct_of_array_of_array) {
       "ROW<test:ROW<stringarrayfield:ARRAY<ARRAY<VARCHAR>>,intarrayfield:ARRAY<ARRAY<INTEGER>>>>";
   const std::string sample(
       getExampleFilePath("struct_of_array_of_array.parquet"));
-  facebook::velox::dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  facebook::velox::dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto reader = createReader(sample, readerOptions);
   auto type = reader->typeWithId();
   EXPECT_EQ(type->size(), 1ULL);
@@ -1685,7 +1723,8 @@ TEST_F(ParquetReaderTest, struct_of_array_of_array) {
 TEST_F(ParquetReaderTest, testLzoDataPage) {
   const std::string sample(getExampleFilePath("lzo.parquet"));
 
-  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 23'547ULL);
 
@@ -1720,7 +1759,8 @@ TEST_F(ParquetReaderTest, testLzoDataPage) {
 TEST_F(ParquetReaderTest, testEmptyV2DataPage) {
   const std::string sample(getExampleFilePath("empty_v2datapage.parquet"));
 
-  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 30001ULL);
 
@@ -1752,7 +1792,8 @@ TEST_F(ParquetReaderTest, parquet251) {
 TEST_F(ParquetReaderTest, fileColumnVarcharToMetadataColumnMismatchTest) {
   const std::string sample(getExampleFilePath("nation.parquet"));
 
-  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
 
   auto runVarcharColTest = [&](const TypePtr& requestedType) {
     // The type in the file is a BYTE_ARRAY resolving to VARCHAR.
@@ -1811,7 +1852,8 @@ TEST_F(ParquetReaderTest, readerWithSchema) {
   writer->close();
 
   // Create the reader.
-  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   readerOptions.setFileSchema(schema);
   std::string dataBuf(sinkPtr->data(), sinkPtr->size());
   auto file = std::make_shared<InMemoryReadFile>(std::move(dataBuf));
@@ -1832,7 +1874,8 @@ TEST_F(ParquetReaderTest, columnStatistics) {
       });
 
   auto* sink = write(data);
-  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto reader = createReaderInMemory(*sink, readerOptions);
   const auto& schema = reader->typeWithId();
 
@@ -1891,7 +1934,8 @@ TEST_F(ParquetReaderTest, columnStatisticsWithNulls) {
       });
 
   auto* sink = write(data);
-  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto reader = createReaderInMemory(*sink, readerOptions);
   const auto& schema = reader->typeWithId();
 
@@ -1924,7 +1968,8 @@ TEST_F(ParquetReaderTest, columnStatisticsMultipleRowGroups) {
       });
 
   auto* sink = write(data, writerOptions);
-  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto reader = createReaderInMemory(*sink, readerOptions);
 
   // Verify we have multiple row groups.
@@ -1956,7 +2001,8 @@ TEST_F(ParquetReaderTest, readTimeMillis) {
           TIME())});
   auto sink = write(data);
 
-  dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  dwio::common::ReaderOptions readerOpts{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto reader = createReaderInMemory(*sink, readerOpts);
 
   EXPECT_EQ(reader->numberOfRows(), 6ULL);
@@ -1988,7 +2034,8 @@ TEST_F(ParquetReaderTest, readTimeWithMultipleColumns) {
 
   auto sink = write(data);
 
-  dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  dwio::common::ReaderOptions readerOpts{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto reader = createReaderInMemory(*sink, readerOpts);
 
   EXPECT_EQ(reader->numberOfRows(), 5ULL);

--- a/velox/dwio/parquet/tests/reader/ParquetReaderWideningTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderWideningTest.cpp
@@ -32,7 +32,8 @@ class ParquetReaderWideningTest : public ParquetTestBase {
       const RowTypePtr& readSchema,
       bool allowInt32Narrowing = false) {
     auto* sink = write(writeData);
-    dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+    dwio::common::ReaderOptions readerOptions{
+        leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
     readerOptions.setFileSchema(readSchema);
     readerOptions.setAllowInt32Narrowing(allowInt32Narrowing);
     auto reader = createReaderInMemory(*sink, readerOptions);
@@ -72,7 +73,8 @@ class ParquetReaderWideningTest : public ParquetTestBase {
       const RowVectorPtr& expected,
       bool allowInt32Narrowing = false) {
     auto* sink = write(writeData);
-    dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+    dwio::common::ReaderOptions readerOptions{
+        leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
     readerOptions.setFileSchema(readSchema);
     readerOptions.setAllowInt32Narrowing(allowInt32Narrowing);
     auto reader = createReaderInMemory(*sink, readerOptions);
@@ -94,7 +96,8 @@ class ParquetReaderWideningTest : public ParquetTestBase {
       const RowTypePtr& readSchema,
       const std::string& sourceTypeName) {
     auto* sink = write(writeData);
-    dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+    dwio::common::ReaderOptions readerOptions{
+        leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
     readerOptions.setFileSchema(readSchema);
     VELOX_ASSERT_THROW(
         createReaderInMemory(*sink, readerOptions),
@@ -227,7 +230,8 @@ void FloatToDoubleEvolutionTest::runFloatToDoubleScenario(
 
   RowTypePtr readSchema = ROW({"float_col", "id"}, {DOUBLE(), BIGINT()});
 
-  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   readerOptions.setFileSchema(readSchema);
 
   std::string dataBuf(sinkPtr->data(), sinkPtr->size());
@@ -1060,7 +1064,8 @@ TEST_F(ParquetReaderWideningTest, allowInt32Narrowing) {
   auto* sink = write(data);
 
   // Default: flag is false.
-  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   ASSERT_FALSE(readerOptions.allowInt32Narrowing());
 
   // INT32->TINYINT narrowing rejected by default.

--- a/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -17,6 +17,7 @@
 #include <folly/init/Init.h>
 
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/io/IoStatistics.h"
 #include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/dwio/common/tests/utils/DataFiles.h" // @manual
 #include "velox/dwio/parquet/RegisterParquetReader.h" // @manual
@@ -168,7 +169,8 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
 
   void loadDataWithRowType(const std::string& filePath, RowVectorPtr data) {
     auto pool = facebook::velox::memory::memoryManager()->addLeafPool();
-    dwio::common::ReaderOptions readerOpts{pool.get()};
+    dwio::common::ReaderOptions readerOpts{
+        pool.get(), dataIoStats_.get(), metadataIoStats_.get()};
     auto reader = std::make_unique<ParquetReader>(
         std::make_unique<facebook::velox::dwio::common::BufferedInput>(
             std::make_shared<LocalReadFile>(filePath), readerOpts.memoryPool()),
@@ -314,6 +316,10 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
 
   RowTypePtr rowType_;
   TimestampPrecision timestampPrecision_ = TimestampPrecision::kMicroseconds;
+  std::shared_ptr<io::IoStatistics> dataIoStats_ =
+      std::make_shared<io::IoStatistics>();
+  std::shared_ptr<io::IoStatistics> metadataIoStats_ =
+      std::make_shared<io::IoStatistics>();
 };
 
 TEST_F(ParquetTableScanTest, basic) {

--- a/velox/dwio/parquet/tests/writer/ParquetWriterFieldIdTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterFieldIdTest.cpp
@@ -68,7 +68,8 @@ TEST_P(ParquetWriterFieldIdTest, fieldIds) {
 
   auto* sinkPtr = write(data, writerOptions);
 
-  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto parquetReader = createReaderInMemory(*sinkPtr, readerOptions);
   EXPECT_EQ(parquetReader->numberOfRows(), kRows);
   auto veloxRowType = parquetReader->rowType();

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -88,7 +88,8 @@ class ParquetWriterTest : public ParquetTestBase {
   thrift::PageHeader readPageHeader(
       MemorySink* sinkPtr,
       int64_t offsetFromDataPage) {
-    dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+    dwio::common::ReaderOptions readerOptions{
+        leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
     auto reader = createReaderInMemory(*sinkPtr, readerOptions);
 
     auto colChunkPtr = reader->fileMetaData().rowGroup(0).columnChunk(0);
@@ -408,7 +409,8 @@ TEST_F(ParquetWriterTest, compression) {
 
   auto* sinkPtr = write(data, writerOptions);
 
-  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto reader = createReaderInMemory(*sinkPtr, readerOptions);
 
   ASSERT_EQ(reader->numberOfRows(), kRows);
@@ -800,7 +802,8 @@ TEST_F(ParquetWriterTest, allNulls) {
 
   auto* sinkPtr = write(data);
 
-  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   auto reader = createReaderInMemory(*sinkPtr, readerOptions);
 
   ASSERT_EQ(reader->numberOfRows(), kRows);

--- a/velox/dwio/parquet/writer/arrow/tests/FileDeserializeTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/FileDeserializeTest.cpp
@@ -19,6 +19,7 @@
 #include <gmock/gmock.h>
 
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/io/IoStatistics.h"
 #include "velox/common/testutil/TempFilePath.h"
 #include "velox/dwio/parquet/reader/ParquetReader.h"
 #include "velox/dwio/parquet/writer/arrow/Exception.h"
@@ -971,7 +972,10 @@ class TestParquetFileReader : public ::testing::Test {
         memory::memoryManager()->addRootPool("MetadataTest");
     std::shared_ptr<facebook::velox::memory::MemoryPool> leafPool =
         rootPool->addLeafChild("MetadataTest");
-    dwio::common::ReaderOptions readerOptions{leafPool.get()};
+    auto dataIoStats = std::make_shared<velox::io::IoStatistics>();
+    auto metadataIoStats = std::make_shared<velox::io::IoStatistics>();
+    dwio::common::ReaderOptions readerOptions{
+        leafPool.get(), dataIoStats.get(), metadataIoStats.get()};
     auto input = std::make_unique<dwio::common::BufferedInput>(
         std::make_shared<LocalReadFile>(filePath->getPath()),
         readerOptions.memoryPool());
@@ -1027,7 +1031,10 @@ TEST_F(TestParquetFileReader, IncompleteMetadata) {
       memory::memoryManager()->addRootPool("MetadataTest");
   std::shared_ptr<facebook::velox::memory::MemoryPool> leafPool =
       rootPool->addLeafChild("MetadataTest");
-  dwio::common::ReaderOptions readerOptions{leafPool.get()};
+  auto dataIoStats = std::make_shared<velox::io::IoStatistics>();
+  auto metadataIoStats = std::make_shared<velox::io::IoStatistics>();
+  dwio::common::ReaderOptions readerOptions{
+      leafPool.get(), dataIoStats.get(), metadataIoStats.get()};
   auto input = std::make_unique<dwio::common::BufferedInput>(
       std::make_shared<LocalReadFile>(filePath->getPath()),
       readerOptions.memoryPool());

--- a/velox/dwio/parquet/writer/arrow/tests/MetadataTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/MetadataTest.cpp
@@ -21,6 +21,7 @@
 #include <gtest/gtest.h>
 
 #include "arrow/util/key_value_metadata.h"
+#include "velox/common/io/IoStatistics.h"
 #include "velox/common/testutil/TempFilePath.h"
 #include "velox/dwio/parquet/reader/ParquetReader.h"
 #include "velox/dwio/parquet/writer/arrow/FileWriter.h"
@@ -414,7 +415,10 @@ TEST(Metadata, TestAddKeyValueMetadata) {
       memory::memoryManager()->addRootPool("MetadataTest");
   std::shared_ptr<facebook::velox::memory::MemoryPool> leafPool =
       rootPool->addLeafChild("MetadataTest");
-  dwio::common::ReaderOptions readerOptions{leafPool.get()};
+  auto dataIoStats = std::make_shared<velox::io::IoStatistics>();
+  auto metadataIoStats = std::make_shared<velox::io::IoStatistics>();
+  dwio::common::ReaderOptions readerOptions{
+      leafPool.get(), dataIoStats.get(), metadataIoStats.get()};
   auto input = std::make_unique<dwio::common::BufferedInput>(
       std::make_shared<LocalReadFile>(filePath->getPath()),
       readerOptions.memoryPool());
@@ -533,7 +537,10 @@ TEST(Metadata, TestSortingColumns) {
       memory::memoryManager()->addRootPool("MetadataTest");
   std::shared_ptr<facebook::velox::memory::MemoryPool> leafPool =
       rootPool->addLeafChild("MetadataTest");
-  dwio::common::ReaderOptions readerOptions{leafPool.get()};
+  auto dataIoStats = std::make_shared<velox::io::IoStatistics>();
+  auto metadataIoStats = std::make_shared<velox::io::IoStatistics>();
+  dwio::common::ReaderOptions readerOptions{
+      leafPool.get(), dataIoStats.get(), metadataIoStats.get()};
   auto input = std::make_unique<dwio::common::BufferedInput>(
       std::make_shared<LocalReadFile>(filePath->getPath()),
       readerOptions.memoryPool());

--- a/velox/dwio/parquet/writer/arrow/tests/StatisticsTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/StatisticsTest.cpp
@@ -20,6 +20,7 @@
 
 #include "arrow/testing/builder.h"
 
+#include "velox/common/io/IoStatistics.h"
 #include "velox/common/testutil/TempFilePath.h"
 #include "velox/dwio/parquet/reader/ParquetReader.h"
 #include "velox/dwio/parquet/writer/arrow/FileWriter.h"
@@ -485,7 +486,10 @@ class TestStatistics : public PrimitiveTypedTest<TestType> {
         memory::memoryManager()->addRootPool("StatisticsTest");
     std::shared_ptr<facebook::velox::memory::MemoryPool> leafPool =
         rootPool->addLeafChild("StatisticsTest");
-    dwio::common::ReaderOptions readerOptions{leafPool.get()};
+    auto dataIoStats = std::make_shared<velox::io::IoStatistics>();
+    auto metadataIoStats = std::make_shared<velox::io::IoStatistics>();
+    dwio::common::ReaderOptions readerOptions{
+        leafPool.get(), dataIoStats.get(), metadataIoStats.get()};
     auto input = std::make_unique<dwio::common::BufferedInput>(
         std::make_shared<LocalReadFile>(filePath->getPath()),
         readerOptions.memoryPool());
@@ -1030,7 +1034,10 @@ class TestStatisticsSortOrder : public ::testing::Test {
         memory::memoryManager()->addRootPool("StatisticsTest");
     std::shared_ptr<facebook::velox::memory::MemoryPool> leafPool =
         rootPool->addLeafChild("StatisticsTest");
-    dwio::common::ReaderOptions readerOptions{leafPool.get()};
+    auto dataIoStats = std::make_shared<velox::io::IoStatistics>();
+    auto metadataIoStats = std::make_shared<velox::io::IoStatistics>();
+    dwio::common::ReaderOptions readerOptions{
+        leafPool.get(), dataIoStats.get(), metadataIoStats.get()};
     auto input = std::make_unique<dwio::common::BufferedInput>(
         std::make_shared<LocalReadFile>(filePath->getPath()),
         readerOptions.memoryPool());
@@ -1325,7 +1332,10 @@ TEST_F(TestStatisticsSortOrderFLBA, decimalSortOrder) {
       memory::memoryManager()->addRootPool("StatisticsTest");
   std::shared_ptr<facebook::velox::memory::MemoryPool> leafPool =
       rootPool->addLeafChild("StatisticsTest");
-  dwio::common::ReaderOptions readerOptions{leafPool.get()};
+  auto dataIoStats = std::make_shared<velox::io::IoStatistics>();
+  auto metadataIoStats = std::make_shared<velox::io::IoStatistics>();
+  dwio::common::ReaderOptions readerOptions{
+      leafPool.get(), dataIoStats.get(), metadataIoStats.get()};
   auto input = std::make_unique<dwio::common::BufferedInput>(
       std::make_shared<LocalReadFile>(filePath->getPath()),
       readerOptions.memoryPool());

--- a/velox/dwio/text/tests/reader/TextReaderTest.cpp
+++ b/velox/dwio/text/tests/reader/TextReaderTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/common/io/IoStatistics.h"
 #include "velox/dwio/common/tests/utils/DataFiles.h"
 #include "velox/dwio/text/RegisterTextReader.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
@@ -56,6 +57,11 @@ class TextReaderTest : public testing::Test,
     spec->addAllChildFields(type);
     options.setScanSpec(spec);
   }
+
+  std::shared_ptr<velox::io::IoStatistics> dataIoStats_ =
+      std::make_shared<velox::io::IoStatistics>();
+  std::shared_ptr<velox::io::IoStatistics> metadataIoStats_ =
+      std::make_shared<velox::io::IoStatistics>();
 
  private:
   std::shared_ptr<LocalReadFile> readFile_;
@@ -126,7 +132,8 @@ TEST_F(TextReaderTest, basic) {
       "examples/simple_types_compressed_file.gz");
   auto readFile = std::make_shared<LocalReadFile>(path);
 
-  auto readerOptions = dwio::common::ReaderOptions(pool());
+  auto readerOptions = dwio::common::ReaderOptions(
+      pool(), dataIoStats_.get(), metadataIoStats_.get());
   readerOptions.setFileSchema(type);
 
   auto input =
@@ -236,7 +243,8 @@ TEST_F(TextReaderTest, headerAndCustomNullString) {
       "velox/dwio/text/tests/reader/", "examples/simple_types_with_header");
   auto readFile = std::make_shared<LocalReadFile>(path);
 
-  auto readerOptions = dwio::common::ReaderOptions(pool());
+  auto readerOptions = dwio::common::ReaderOptions(
+      pool(), dataIoStats_.get(), metadataIoStats_.get());
   readerOptions.setFileSchema(type);
   auto rowReaderOptions = dwio::common::RowReaderOptions();
   setScanSpec(*type, rowReaderOptions);
@@ -410,7 +418,8 @@ TEST_F(TextReaderTest, complexTypesWithCustomDelimiters) {
   auto readFile = std::make_shared<LocalReadFile>(path);
 
   auto serDeOptions = dwio::common::SerDeOptions('\t', '|', '#', '\\', true);
-  auto readerOptions = dwio::common::ReaderOptions(pool());
+  auto readerOptions = dwio::common::ReaderOptions(
+      pool(), dataIoStats_.get(), metadataIoStats_.get());
   readerOptions.setFileSchema(type);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -475,7 +484,8 @@ TEST_F(TextReaderTest, projectComplexTypesWithCustomDelimiters) {
   auto readFile = std::make_shared<LocalReadFile>(path);
 
   auto serDeOptions = dwio::common::SerDeOptions('\t', '|', '#', '\\', true);
-  auto readerOptions = dwio::common::ReaderOptions(pool());
+  auto readerOptions = dwio::common::ReaderOptions(
+      pool(), dataIoStats_.get(), metadataIoStats_.get());
   readerOptions.setFileSchema(type);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -578,7 +588,8 @@ TEST_F(TextReaderTest, projectPrimitiveTypes) {
   auto path = velox::test::getDataFilePath(
       "velox/dwio/text/tests/reader/", "examples/simple_types");
   auto readFile = std::make_shared<LocalReadFile>(path);
-  auto readerOptions = dwio::common::ReaderOptions(pool());
+  auto readerOptions = dwio::common::ReaderOptions(
+      pool(), dataIoStats_.get(), metadataIoStats_.get());
   readerOptions.setFileSchema(type);
   auto input =
       std::make_unique<dwio::common::BufferedInput>(readFile, poolRef());
@@ -646,7 +657,8 @@ TEST_F(TextReaderTest, projectColumns) {
       "velox/dwio/text/tests/reader/",
       "examples/simple_types_compressed_file.gz");
   auto readFile = std::make_shared<LocalReadFile>(path);
-  auto readerOptions = dwio::common::ReaderOptions(pool());
+  auto readerOptions = dwio::common::ReaderOptions(
+      pool(), dataIoStats_.get(), metadataIoStats_.get());
   readerOptions.setFileSchema(type);
   auto input =
       std::make_unique<dwio::common::BufferedInput>(readFile, poolRef());
@@ -701,7 +713,8 @@ TEST_F(TextReaderTest, projectNone) {
       "velox/dwio/text/tests/reader/", "examples/simple_types");
   auto readFile = std::make_shared<LocalReadFile>(path);
 
-  auto readerOptions = dwio::common::ReaderOptions(pool());
+  auto readerOptions = dwio::common::ReaderOptions(
+      pool(), dataIoStats_.get(), metadataIoStats_.get());
   readerOptions.setFileSchema(type);
 
   dwio::common::RowReaderOptions rowReaderOptions;
@@ -736,7 +749,8 @@ TEST_F(TextReaderTest, compressedProjectNone) {
       "examples/simple_types_compressed_file.gz");
   auto readFile = std::make_shared<LocalReadFile>(path);
 
-  auto readerOptions = dwio::common::ReaderOptions(pool());
+  auto readerOptions = dwio::common::ReaderOptions(
+      pool(), dataIoStats_.get(), metadataIoStats_.get());
   readerOptions.setFileSchema(type);
 
   dwio::common::RowReaderOptions rowReaderOptions;
@@ -767,7 +781,8 @@ TEST_F(TextReaderTest, compressedFilter) {
       "velox/dwio/text/tests/reader/",
       "examples/simple_types_compressed_file.gz");
   auto readFile = std::make_shared<LocalReadFile>(path);
-  auto readerOptions = dwio::common::ReaderOptions(pool());
+  auto readerOptions = dwio::common::ReaderOptions(
+      pool(), dataIoStats_.get(), metadataIoStats_.get());
   readerOptions.setFileSchema(type);
   auto input =
       std::make_unique<dwio::common::BufferedInput>(readFile, poolRef());
@@ -811,7 +826,8 @@ TEST_F(TextReaderTest, filter) {
       "velox/dwio/text/tests/reader/", "examples/more_simple_types");
   auto readFile = std::make_shared<LocalReadFile>(path);
 
-  auto readerOptions = dwio::common::ReaderOptions(pool());
+  auto readerOptions = dwio::common::ReaderOptions(
+      pool(), dataIoStats_.get(), metadataIoStats_.get());
   readerOptions.setFileSchema(type);
 
   auto input =
@@ -869,7 +885,8 @@ TEST_F(TextReaderTest, shrinkBatch) {
   auto path = velox::test::getDataFilePath(
       "velox/dwio/text/tests/reader/", "examples/simple_types");
   auto readFile = std::make_shared<LocalReadFile>(path);
-  auto readerOptions = dwio::common::ReaderOptions(pool());
+  auto readerOptions = dwio::common::ReaderOptions(
+      pool(), dataIoStats_.get(), metadataIoStats_.get());
   readerOptions.setFileSchema(type);
   auto input =
       std::make_unique<dwio::common::BufferedInput>(readFile, poolRef());
@@ -902,7 +919,8 @@ TEST_F(TextReaderTest, compressedShrinkBatch) {
       "velox/dwio/text/tests/reader/",
       "examples/simple_types_compressed_file.gz");
   auto readFile = std::make_shared<LocalReadFile>(path);
-  auto readerOptions = dwio::common::ReaderOptions(pool());
+  auto readerOptions = dwio::common::ReaderOptions(
+      pool(), dataIoStats_.get(), metadataIoStats_.get());
   readerOptions.setFileSchema(type);
   auto input =
       std::make_unique<dwio::common::BufferedInput>(readFile, poolRef());
@@ -932,7 +950,8 @@ TEST_F(TextReaderTest, emptyFile) {
   auto path = velox::test::getDataFilePath(
       "velox/dwio/text/tests/reader/", "examples/empty.gz");
   auto readFile = std::make_shared<LocalReadFile>(path);
-  auto readerOptions = dwio::common::ReaderOptions(pool());
+  auto readerOptions = dwio::common::ReaderOptions(
+      pool(), dataIoStats_.get(), metadataIoStats_.get());
   readerOptions.setFileSchema(type);
   auto rowReaderOptions = dwio::common::RowReaderOptions();
   setScanSpec(*type, rowReaderOptions);
@@ -979,7 +998,8 @@ TEST_F(TextReaderTest, readRanges) {
       "examples/simple_types_10_bytes_per_row");
   auto readFile = std::make_shared<LocalReadFile>(path);
 
-  auto readerOptions = dwio::common::ReaderOptions(pool());
+  auto readerOptions = dwio::common::ReaderOptions(
+      pool(), dataIoStats_.get(), metadataIoStats_.get());
   readerOptions.setFileSchema(type);
 
   auto input =
@@ -1076,7 +1096,8 @@ TEST_F(TextReaderTest, readFloatAsInt) {
       "velox/dwio/text/tests/reader/", "examples/simple_types");
   auto readFile = std::make_shared<LocalReadFile>(path);
 
-  auto readerOptions = dwio::common::ReaderOptions(pool());
+  auto readerOptions = dwio::common::ReaderOptions(
+      pool(), dataIoStats_.get(), metadataIoStats_.get());
   readerOptions.setFileSchema(type);
 
   auto input =
@@ -1175,7 +1196,8 @@ TEST_F(TextReaderTest, simpleTypes) {
       "velox/dwio/text/tests/reader/", "examples/more_simple_types");
   auto readFile = std::make_shared<LocalReadFile>(path);
 
-  auto readerOptions = dwio::common::ReaderOptions(pool());
+  auto readerOptions = dwio::common::ReaderOptions(
+      pool(), dataIoStats_.get(), metadataIoStats_.get());
   readerOptions.setFileSchema(type);
 
   auto input =
@@ -1235,7 +1257,8 @@ TEST_F(TextReaderTest, primitiveLimitsStressTest) {
       "velox/dwio/text/tests/reader/", "examples/primitive_limits");
   auto readFile = std::make_shared<LocalReadFile>(path);
 
-  auto readerOptions = dwio::common::ReaderOptions(pool());
+  auto readerOptions = dwio::common::ReaderOptions(
+      pool(), dataIoStats_.get(), metadataIoStats_.get());
   auto serDeOptions = dwio::common::SerDeOptions('\t', '=', '|', '\\', true);
   readerOptions.setFileSchema(type);
   readerOptions.setSerDeOptions(serDeOptions);
@@ -1393,7 +1416,8 @@ TEST_F(TextReaderTest, DISABLED_nestedComplexTypesWithCustomDelimiters) {
   auto serDeOptions = dwio::common::SerDeOptions('\t', '=', '|', '\\', true);
   serDeOptions.separators[3] = ',';
   serDeOptions.separators[4] = ':';
-  auto readerOptions = dwio::common::ReaderOptions(pool());
+  auto readerOptions = dwio::common::ReaderOptions(
+      pool(), dataIoStats_.get(), metadataIoStats_.get());
   readerOptions.setFileSchema(type);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -1464,7 +1488,8 @@ TEST_F(TextReaderTest, nestedArraysWithCustomDelimiters) {
   // - Pipe ('|') for outer array element separation (depth 1)
   // - Comma (',') for inner array element separation (depth 2)
   auto serDeOptions = dwio::common::SerDeOptions('\t', '|', ',', '\\', true);
-  auto readerOptions = dwio::common::ReaderOptions(pool());
+  auto readerOptions = dwio::common::ReaderOptions(
+      pool(), dataIoStats_.get(), metadataIoStats_.get());
   readerOptions.setFileSchema(type);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -1555,7 +1580,8 @@ TEST_F(TextReaderTest, tripleNestedArraysWithCustomDelimiters) {
   // - Hash ('#') for innermost array element separation (depth 3)
   auto serDeOptions = dwio::common::SerDeOptions('\t', '|', ',', '\\', true);
   serDeOptions.separators[3] = '#';
-  auto readerOptions = dwio::common::ReaderOptions(pool());
+  auto readerOptions = dwio::common::ReaderOptions(
+      pool(), dataIoStats_.get(), metadataIoStats_.get());
   readerOptions.setFileSchema(type);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -1589,7 +1615,8 @@ TEST_F(TextReaderTest, varbinarySuccessfulDecoding) {
 
   auto readFile = std::make_shared<LocalReadFile>(path);
 
-  auto readerOptions = dwio::common::ReaderOptions(pool());
+  auto readerOptions = dwio::common::ReaderOptions(
+      pool(), dataIoStats_.get(), metadataIoStats_.get());
   readerOptions.setFileSchema(type);
 
   auto input =
@@ -1624,7 +1651,8 @@ TEST_F(TextReaderTest, varbinaryUnsuccessfulDecoding) {
 
   auto readFile = std::make_shared<LocalReadFile>(path);
 
-  auto readerOptions = dwio::common::ReaderOptions(pool());
+  auto readerOptions = dwio::common::ReaderOptions(
+      pool(), dataIoStats_.get(), metadataIoStats_.get());
   readerOptions.setFileSchema(type);
 
   auto input =
@@ -1716,7 +1744,8 @@ TEST_F(TextReaderTest, logicalTypes) {
       "velox/dwio/text/tests/reader/", "examples/logical_types.gz");
 
   auto readFile = std::make_shared<LocalReadFile>(path);
-  auto readerOptions = dwio::common::ReaderOptions(pool());
+  auto readerOptions = dwio::common::ReaderOptions(
+      pool(), dataIoStats_.get(), metadataIoStats_.get());
   readerOptions.setFileSchema(type);
 
   auto input =
@@ -1773,7 +1802,8 @@ TEST_F(TextReaderTest, nestedRows) {
   auto readFile = std::make_shared<LocalReadFile>(path);
   auto serDeOptions = dwio::common::SerDeOptions('&', ',', '#', '\\', true);
 
-  auto readerOptions = dwio::common::ReaderOptions(pool());
+  auto readerOptions = dwio::common::ReaderOptions(
+      pool(), dataIoStats_.get(), metadataIoStats_.get());
   readerOptions.setFileSchema(type);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -1852,7 +1882,8 @@ TEST_P(TextReaderDecompressionTest, tests) {
       velox::test::getDataFilePath("velox/dwio/text/tests/reader/", filepath);
   auto readFile = std::make_shared<LocalReadFile>(path);
 
-  auto readerOptions = dwio::common::ReaderOptions(pool());
+  auto readerOptions = dwio::common::ReaderOptions(
+      pool(), dataIoStats_.get(), metadataIoStats_.get());
   readerOptions.setFileSchema(type);
 
   auto input =
@@ -1925,7 +1956,8 @@ TEST_F(TextReaderTest, unsupportedCompressedKind) {
           kBaseDir, "examples/simple_types_compressed_file.snappy")};
   for (const auto& path : paths) {
     auto readFile = std::make_shared<LocalReadFile>(path);
-    auto readerOptions = dwio::common::ReaderOptions(pool());
+    auto readerOptions = dwio::common::ReaderOptions(
+        pool(), dataIoStats_.get(), metadataIoStats_.get());
     readerOptions.setFileSchema(type);
     auto input =
         std::make_unique<dwio::common::BufferedInput>(readFile, poolRef());

--- a/velox/dwio/text/tests/writer/TextWriterTest.cpp
+++ b/velox/dwio/text/tests/writer/TextWriterTest.cpp
@@ -17,6 +17,7 @@
 #include "velox/dwio/text/writer/TextWriter.h"
 #include "velox/buffer/Buffer.h"
 #include "velox/common/file/FileSystems.h"
+#include "velox/common/io/IoStatistics.h"
 #include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/dwio/text/RegisterTextReader.h"
 #include "velox/dwio/text/RegisterTextWriter.h"
@@ -64,6 +65,10 @@ class TextWriterTest : public testing::Test,
 
   constexpr static float kInf = std::numeric_limits<float>::infinity();
   constexpr static double kNaN = std::numeric_limits<double>::quiet_NaN();
+  std::shared_ptr<velox::io::IoStatistics> dataIoStats_ =
+      std::make_shared<velox::io::IoStatistics>();
+  std::shared_ptr<velox::io::IoStatistics> metadataIoStats_ =
+      std::make_shared<velox::io::IoStatistics>();
   std::shared_ptr<memory::MemoryPool> rootPool_;
   std::shared_ptr<memory::MemoryPool> leafPool_;
   std::shared_ptr<TempDirectoryPath> tempPath_;
@@ -227,7 +232,8 @@ TEST_F(TextWriterTest, verifyWriteWithTextReader) {
   auto readerFactory =
       dwio::common::getReaderFactory(dwio::common::FileFormat::TEXT);
   auto readFile = std::make_shared<LocalReadFile>(filePath.string());
-  auto readerOptions = dwio::common::ReaderOptions(pool());
+  auto readerOptions = dwio::common::ReaderOptions(
+      pool(), dataIoStats_.get(), metadataIoStats_.get());
   readerOptions.setFileSchema(schema);
   auto input =
       std::make_unique<dwio::common::BufferedInput>(readFile, poolRef());
@@ -495,7 +501,8 @@ TEST_F(TextWriterTest, verifyMapAndArrayComplexTypesWithTextReader) {
   auto readerFactory =
       dwio::common::getReaderFactory(dwio::common::FileFormat::TEXT);
   auto readFile = std::make_shared<LocalReadFile>(filePath.string());
-  auto readerOptions = dwio::common::ReaderOptions(pool());
+  auto readerOptions = dwio::common::ReaderOptions(
+      pool(), dataIoStats_.get(), metadataIoStats_.get());
   readerOptions.setFileSchema(schema);
   readerOptions.setSerDeOptions(serDeOptions);
   auto input =
@@ -686,7 +693,8 @@ TEST_F(TextWriterTest, verifyArrayTypesWithTextReader) {
   auto readerFactory =
       dwio::common::getReaderFactory(dwio::common::FileFormat::TEXT);
   auto readFile = std::make_shared<LocalReadFile>(filePath.string());
-  auto readerOptions = dwio::common::ReaderOptions(pool());
+  auto readerOptions = dwio::common::ReaderOptions(
+      pool(), dataIoStats_.get(), metadataIoStats_.get());
   readerOptions.setFileSchema(schema);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -924,7 +932,8 @@ TEST_F(TextWriterTest, verifyMapTypesWithTextReader) {
   auto readerFactory =
       dwio::common::getReaderFactory(dwio::common::FileFormat::TEXT);
   auto readFile = std::make_shared<LocalReadFile>(filePath.string());
-  auto readerOptions = dwio::common::ReaderOptions(pool());
+  auto readerOptions = dwio::common::ReaderOptions(
+      pool(), dataIoStats_.get(), metadataIoStats_.get());
   readerOptions.setFileSchema(schema);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -1079,7 +1088,8 @@ TEST_F(TextWriterTest, verifyNestedRowTypesWithTextReader) {
   auto readerFactory =
       dwio::common::getReaderFactory(dwio::common::FileFormat::TEXT);
   auto readFile = std::make_shared<LocalReadFile>(filePath.string());
-  auto readerOptions = dwio::common::ReaderOptions(pool());
+  auto readerOptions = dwio::common::ReaderOptions(
+      pool(), dataIoStats_.get(), metadataIoStats_.get());
   readerOptions.setFileSchema(schema);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -1467,7 +1477,8 @@ TEST_F(
   auto readerFactory =
       dwio::common::getReaderFactory(dwio::common::FileFormat::TEXT);
   auto readFile = std::make_shared<LocalReadFile>(filePath.string());
-  auto readerOptions = dwio::common::ReaderOptions(pool());
+  auto readerOptions = dwio::common::ReaderOptions(
+      pool(), dataIoStats_.get(), metadataIoStats_.get());
   readerOptions.setFileSchema(schema);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -1596,7 +1607,8 @@ TEST_F(TextWriterTest, verifySimpleEscapeCharTestWithTextReader) {
   auto readerFactory =
       dwio::common::getReaderFactory(dwio::common::FileFormat::TEXT);
   auto readFile = std::make_shared<LocalReadFile>(filePath.string());
-  auto readerOptions = dwio::common::ReaderOptions(pool());
+  auto readerOptions = dwio::common::ReaderOptions(
+      pool(), dataIoStats_.get(), metadataIoStats_.get());
   readerOptions.setFileSchema(schema);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -1728,7 +1740,8 @@ TEST_F(TextWriterTest, verifyCustomEscapeCharTestWithTextReader) {
   auto readerFactory =
       dwio::common::getReaderFactory(dwio::common::FileFormat::TEXT);
   auto readFile = std::make_shared<LocalReadFile>(filePath.string());
-  auto readerOptions = dwio::common::ReaderOptions(pool());
+  auto readerOptions = dwio::common::ReaderOptions(
+      pool(), dataIoStats_.get(), metadataIoStats_.get());
   readerOptions.setFileSchema(schema);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -1850,7 +1863,8 @@ TEST_F(TextWriterTest, verifyHeaderTestWithTextReader) {
   auto readerFactory =
       dwio::common::getReaderFactory(dwio::common::FileFormat::TEXT);
   auto readFile = std::make_shared<LocalReadFile>(filePath.string());
-  auto readerOptions = dwio::common::ReaderOptions(pool());
+  auto readerOptions = dwio::common::ReaderOptions(
+      pool(), dataIoStats_.get(), metadataIoStats_.get());
   readerOptions.setFileSchema(schema);
   readerOptions.setSerDeOptions(serDeOptions);
 

--- a/velox/examples/ScanOrc.cpp
+++ b/velox/examples/ScanOrc.cpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 
 #include "velox/common/file/FileSystems.h"
+#include "velox/common/io/IoStatistics.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/dwio/common/Reader.h"
@@ -49,7 +50,10 @@ int main(int argc, char** argv) {
   auto pool = facebook::velox::memory::memoryManager()->addLeafPool();
 
   std::string filePath{argv[1]};
-  dwio::common::ReaderOptions readerOpts{pool.get()};
+  io::IoStatistics dataIoStats;
+  io::IoStatistics metadataIoStats;
+  dwio::common::ReaderOptions readerOpts{
+      pool.get(), &dataIoStats, &metadataIoStats};
   // To make DwrfReader reads ORC file, setFileFormat to FileFormat::ORC
   readerOpts.setFileFormat(FileFormat::ORC);
   auto reader = dwio::common::getReaderFactory(FileFormat::ORC)

--- a/velox/exec/benchmarks/RowContainerSortBenchmark.cpp
+++ b/velox/exec/benchmarks/RowContainerSortBenchmark.cpp
@@ -17,6 +17,7 @@
 #include <folly/Benchmark.h>
 #include <folly/init/Init.h>
 
+#include "velox/common/io/IoStatistics.h"
 #include "velox/dwio/common/tests/utils/DataFiles.h"
 #include "velox/dwio/parquet/reader/ParquetReader.h"
 #include "velox/exec/RowContainer.h"
@@ -64,7 +65,10 @@ std::vector<std::optional<StringView>> getDataFromFile() {
   const std::string sample(getExampleFilePath("str_sort.parquet"));
   auto rowType = ROW({"query_sig", "result_sig"}, {VARCHAR(), VARCHAR()});
   auto pool = memory::memoryManager()->addLeafPool();
-  facebook::velox::dwio::common::ReaderOptions readerOptions{pool.get()};
+  velox::io::IoStatistics dataIoStats;
+  velox::io::IoStatistics metadataIoStats;
+  facebook::velox::dwio::common::ReaderOptions readerOptions{
+      pool.get(), &dataIoStats, &metadataIoStats};
   facebook::velox::parquet::ParquetReader reader =
       createReader(sample, readerOptions);
   auto rowReaderOpts = getReaderOpts(rowType);

--- a/velox/exec/tests/utils/TpchQueryBuilder.cpp
+++ b/velox/exec/tests/utils/TpchQueryBuilder.cpp
@@ -70,7 +70,8 @@ void TpchQueryBuilder::readFileSchema(
     const std::string& tableName,
     const std::string& filePath,
     const std::vector<std::string>& columns) {
-  dwio::common::ReaderOptions readerOptions{pool_.get()};
+  dwio::common::ReaderOptions readerOptions{
+      pool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   readerOptions.setFileFormat(format_);
   auto uniqueReadFile =
       filesystems::getFileSystem(filePath, nullptr)->openFileForRead(filePath);

--- a/velox/exec/tests/utils/TpchQueryBuilder.h
+++ b/velox/exec/tests/utils/TpchQueryBuilder.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "velox/common/io/IoStatistics.h"
 #include "velox/dwio/common/Options.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/exec/tests/utils/VeloxPlanLoader.h"
@@ -144,6 +145,10 @@ class TpchQueryBuilder {
   static constexpr const char* kPartsupp = "partsupp";
   std::shared_ptr<memory::MemoryPool> pool_ =
       memory::memoryManager()->addLeafPool();
+  std::shared_ptr<io::IoStatistics> dataIoStats_ =
+      std::make_shared<io::IoStatistics>();
+  std::shared_ptr<io::IoStatistics> metadataIoStats_ =
+      std::make_shared<io::IoStatistics>();
   const bool filtersAsNode_;
 };
 

--- a/velox/experimental/cudf/connectors/hive/CudfSplitReader.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfSplitReader.cpp
@@ -74,7 +74,8 @@ CudfSplitReader::CudfSplitReader(
       cudfHiveConfig_(cudfHiveConfig),
       pool_(connectorQueryCtx->memoryPool()),
       useExperimentalCudfReader_(useExperimentalCudfReader),
-      baseReaderOpts_(pool_),
+      baseReaderOpts_(pool_, ioStatistics_.get(), ioStatistics_.get()),
+
       subfieldFilterExpr_(subfieldFilterExpr) {}
 
 void CudfSplitReader::prepareSplit(

--- a/velox/python/file/PyFile.cpp
+++ b/velox/python/file/PyFile.cpp
@@ -17,6 +17,7 @@
 #include "velox/python/file/PyFile.h"
 #include <fmt/format.h>
 #include <folly/String.h>
+#include "velox/common/io/IoStatistics.h"
 #include "velox/dwio/common/ReaderFactory.h"
 
 namespace facebook::velox::py {
@@ -55,10 +56,13 @@ PyType PyFile::getSchema() {
                         ->openFileForRead(filePath_);
     auto input = std::make_unique<dwio::common::BufferedInput>(
         std::shared_ptr<ReadFile>(std::move(readFile)), *leafPool);
-    auto reader =
-        dwio::common::getReaderFactory(fileFormat_)
-            ->createReader(
-                std::move(input), dwio::common::ReaderOptions{leafPool.get()});
+    io::IoStatistics dataIoStats;
+    io::IoStatistics metadataIoStats;
+    auto reader = dwio::common::getReaderFactory(fileFormat_)
+                      ->createReader(
+                          std::move(input),
+                          dwio::common::ReaderOptions{
+                              leafPool.get(), &dataIoStats, &metadataIoStats});
     fileSchema_ = reader->rowType();
   }
   return PyType{fileSchema_};


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/nimble/pull/690


Add VELOX_CHECK_NOT_NULL for both dataIoStats and metadataIoStats in the base io::ReaderOptions constructor, and remove the = nullptr defaults from the derived dwio::common::ReaderOptions constructor. This ensures all readers explicitly provide IoStatistics for tracking storage reads, SSD reads, RAM cache hits, and overread bytes separately for data and metadata IO.

Updated the DWRF ReaderBase backward-compat and metadata constructors to require IoStatistics parameters. Fixed all callers across the codebase to explicitly create and pass separate dataIoStats and metadataIoStats. For test fixtures, IoStatistics are class members. For free functions where the reader does not outlive the function, local IoStatistics are used. For classes that own readers (DwrfCopier, DwrfToNimbleConverter, ParallelReader), IoStatistics are class members declared before the reader for correct lifetime.

bypass-github-export-checks

Reviewed By: duxiao1212, tanjialiang

Differential Revision: D103639664
