### PR TITLE
fix: Use singleton instance for opaque type when parsing types (#17403)

### DIFF
--- a/velox/type/fbhive/HiveTypeParser.cpp
+++ b/velox/type/fbhive/HiveTypeParser.cpp
@@ -146,7 +146,13 @@ Result HiveTypeParser::parseType() {
 
     // TODO: `getTypeIdForOpaqueTypeAlias()` should take a std::string_view so
     // we don't need to needlessly construct a std::string.
-    auto typeIndex = getTypeIdForOpaqueTypeAlias(std::string(innerTypeName));
+    std::string aliasName(innerTypeName);
+    // If the alias is registered as a custom type (via
+    // OpaqueCustomTypeRegister), return it to respect the singleton semantics.
+    if (auto customType = getCustomType(aliasName, /*parameters=*/{})) {
+      return Result{customType};
+    }
+    auto typeIndex = getTypeIdForOpaqueTypeAlias(aliasName);
     auto instance = std::make_shared<const OpaqueType>(typeIndex);
     return Result{instance};
   } else {

--- a/velox/type/fbhive/tests/HiveTypeParserTests.cpp
+++ b/velox/type/fbhive/tests/HiveTypeParserTests.cpp
@@ -21,6 +21,7 @@
 #include "gtest/gtest-test-part.h"
 #include "gtest/gtest.h"
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/type/OpaqueCustomTypes.h"
 #include "velox/type/fbhive/HiveTypeParser.h"
 
 using facebook::velox::TypeKind;
@@ -183,6 +184,8 @@ TEST(FbHive, parseOpaque) {
   HiveTypeParser parser;
   auto t = parser.parse("opaque<bar>");
   ASSERT_EQ(t->toString(), "OPAQUE<facebook::velox::type::fbhive::Foo>");
+  EXPECT_EQ(t->kind(), TypeKind::OPAQUE);
+  EXPECT_FALSE(customTypeExists("bar"));
   unregisterOpaqueType<Foo>("bar");
 }
 
@@ -194,5 +197,20 @@ TEST(FbHive, parseUnregisteredOpaque) {
       parser.parse("opaque<Foo>"),
       "Could not find type 'Foo'. Did you call registerOpaqueType?");
   unregisterOpaqueType<Foo>("bar");
+}
+
+struct CustomFoo {};
+constexpr char kCustomFooName[] = "CustomFoo";
+using CustomFooRegistrar = OpaqueCustomTypeRegister<CustomFoo, kCustomFooName>;
+
+TEST(FbHive, parseOpaqueCustomTypeReturnsSingleton) {
+  CustomFooRegistrar::registerType();
+  HiveTypeParser parser;
+  auto parsed = parser.parse("opaque<CustomFoo>");
+  // The parser must return the registered custom-type singleton so that
+  // pointer equality with the type produced by CustomType<TypeT> in UDF
+  // signatures holds.
+  EXPECT_EQ(parsed.get(), CustomFooRegistrar::singletonTypePtr().get());
+  CustomFooRegistrar::unregisterType();
 }
 } // namespace facebook::velox::type::fbhive


### PR DESCRIPTION
Summary:

When handling UDFs with opaque types in Axiom, this happens:

* We have a custom sink, AOS, which has opaque types on its schema
* UDF registry CSV signatures get parsed using HiveTypeParser.cpp, one of them has opaque type as output.
* `PlanBuilder::tableWrite` in Axiom enforces strict type equality between the producer's output schema and the sink's declared schema, which is pointer based, so two instances of the same type fail equality. Axiom thinks these types are different and reports schema mismatch.

Fix:

When parsing opaque types in `HiveTypeParser` verify whether an instance of that opaque type has already been registered. This is consistent with the singleton semantics.

Reviewed By: kagamiori

Differential Revision: D103703826


