### PR TITLE
feat: Add PaimonDataSink for writing to Paimon tables (#17404)

### DIFF
--- a/velox/connectors/hive/paimon/CMakeLists.txt
+++ b/velox/connectors/hive/paimon/CMakeLists.txt
@@ -30,16 +30,24 @@ velox_link_libraries(velox_hive_paimon_split velox_connector velox_hive_connecto
 velox_add_library(
   velox_hive_paimon_connector
   PaimonConnector.cpp
+  PaimonDataSink.cpp
   PaimonDataSource.cpp
   PaimonSplitReader.cpp
   HEADERS
   PaimonConfig.h
   PaimonConnector.h
+  PaimonDataSink.h
   PaimonDataSource.h
   PaimonSplitReader.h
 )
 
-velox_link_libraries(velox_hive_paimon_connector velox_hive_paimon_split velox_hive_connector)
+velox_link_libraries(
+  velox_hive_paimon_connector
+  velox_hive_paimon_split
+  velox_hive_connector
+  velox_hive_partition_function
+  Folly::folly
+)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/connectors/hive/paimon/PaimonConnector.cpp
+++ b/velox/connectors/hive/paimon/PaimonConnector.cpp
@@ -15,6 +15,8 @@
  */
 #include "velox/connectors/hive/paimon/PaimonConnector.h"
 
+#include "velox/common/Casts.h"
+#include "velox/connectors/hive/paimon/PaimonDataSink.h"
 #include "velox/connectors/hive/paimon/PaimonDataSource.h"
 
 namespace facebook::velox::connector::hive::paimon {
@@ -38,6 +40,21 @@ std::unique_ptr<DataSource> PaimonConnector::createDataSource(
       &fileHandleFactory_,
       ioExecutor_,
       connectorQueryCtx,
+      paimonConfig_);
+}
+
+std::unique_ptr<DataSink> PaimonConnector::createDataSink(
+    RowTypePtr inputType,
+    ConnectorInsertTableHandlePtr connectorInsertTableHandle,
+    ConnectorQueryCtx* connectorQueryCtx,
+    CommitStrategy commitStrategy) {
+  auto paimonInsertHandle = checkedPointerCast<const HiveInsertTableHandle>(
+      connectorInsertTableHandle);
+  return std::make_unique<PaimonDataSink>(
+      inputType,
+      paimonInsertHandle,
+      connectorQueryCtx,
+      commitStrategy,
       paimonConfig_);
 }
 

--- a/velox/connectors/hive/paimon/PaimonConnector.h
+++ b/velox/connectors/hive/paimon/PaimonConnector.h
@@ -39,6 +39,13 @@ class PaimonConnector final : public HiveConnector {
       const ColumnHandleMap& columnHandles,
       ConnectorQueryCtx* connectorQueryCtx) override;
 
+  /// Creates PaimonDataSink for writing to Paimon tables.
+  std::unique_ptr<DataSink> createDataSink(
+      RowTypePtr inputType,
+      ConnectorInsertTableHandlePtr connectorInsertTableHandle,
+      ConnectorQueryCtx* connectorQueryCtx,
+      CommitStrategy commitStrategy) override;
+
  private:
   const std::shared_ptr<PaimonConfig> paimonConfig_;
 };

--- a/velox/connectors/hive/paimon/PaimonDataSink.cpp
+++ b/velox/connectors/hive/paimon/PaimonDataSink.cpp
@@ -1,0 +1,363 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/paimon/PaimonDataSink.h"
+
+#include "velox/common/base/Fs.h"
+#include "velox/connectors/hive/HivePartitionFunction.h"
+#include "velox/connectors/hive/HivePartitionName.h"
+
+#include <boost/lexical_cast.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+
+namespace facebook::velox::connector::hive::paimon {
+namespace {
+
+std::string makeUuid() {
+  return boost::lexical_cast<std::string>(boost::uuids::random_generator()());
+}
+
+// Appends a sequence number to a filename for file rotation.
+// "data-xxx.orc" with seq 0 -> "data-xxx.orc"
+// "data-xxx.orc" with seq 2 -> "data-xxx_2.orc"
+std::string makeSequencedFileName(
+    const std::string& filename,
+    uint32_t sequenceNumber) {
+  // The first file uses the base name without a suffix.
+  if (sequenceNumber == 0) {
+    return filename;
+  }
+  // Insert the sequence number before the file extension.
+  const auto dotPos = filename.rfind('.');
+  if (dotPos == std::string::npos) {
+    return fmt::format("{}_{}", filename, sequenceNumber);
+  }
+  return fmt::format(
+      "{}_{}{}",
+      filename.substr(0, dotPos),
+      sequenceNumber,
+      filename.substr(dotPos));
+}
+
+int32_t getBucketCount(const HiveBucketProperty* bucketProperty) {
+  return bucketProperty == nullptr ? 0 : bucketProperty->bucketCount();
+}
+
+std::unique_ptr<core::PartitionFunction> createBucketFunction(
+    const HiveBucketProperty& bucketProperty,
+    const RowTypePtr& inputType) {
+  const auto& bucketedBy = bucketProperty.bucketedBy();
+  const auto& bucketedTypes = bucketProperty.bucketedTypes();
+  VELOX_CHECK_EQ(
+      bucketedBy.size(),
+      bucketedTypes.size(),
+      "bucketedBy and bucketedTypes must have the same size");
+  std::vector<column_index_t> bucketedByChannels;
+  bucketedByChannels.reserve(bucketedBy.size());
+  for (int32_t i = 0; i < bucketedBy.size(); ++i) {
+    const auto& bucketColumn = bucketedBy[i];
+    const auto& bucketType = bucketedTypes[i];
+    const auto inputChannel = inputType->getChildIdx(bucketColumn);
+    if (FOLLY_UNLIKELY(
+            !inputType->childAt(inputChannel)->equivalent(*bucketType))) {
+      VELOX_USER_FAIL(
+          "Input column {} type {} doesn't match bucket type {}",
+          inputType->nameOf(inputChannel),
+          inputType->childAt(inputChannel)->toString(),
+          bucketType->toString());
+    }
+    bucketedByChannels.push_back(inputChannel);
+  }
+  return std::make_unique<HivePartitionFunction>(
+      bucketProperty.bucketCount(), bucketedByChannels);
+}
+
+std::unique_ptr<PartitionIdGenerator> createPartitionIdGenerator(
+    const RowTypePtr& inputType,
+    const std::shared_ptr<const HiveInsertTableHandle>& insertTableHandle,
+    uint32_t maxPartitions,
+    memory::MemoryPool* pool) {
+  const auto& partitionChannels = insertTableHandle->partitionChannels();
+  if (partitionChannels.empty()) {
+    return nullptr;
+  }
+  return std::make_unique<PartitionIdGenerator>(
+      inputType, partitionChannels, maxPartitions, pool);
+}
+
+std::string makeBucketDirectory(std::optional<uint32_t> bucketId) {
+  return fmt::format("bucket-{}", bucketId.value_or(0));
+}
+
+// Builds a directory path: {base}/{partition}/{bucket-N}.
+std::string makePaimonDirectory(
+    const std::string& baseDir,
+    const std::optional<std::string>& partition,
+    const std::string& bucketDir) {
+  fs::path path(baseDir);
+  if (partition.has_value()) {
+    path /= partition.value();
+  }
+  path /= bucketDir;
+  return path.string();
+}
+
+// Returns storage format file extension.
+std::string formatExtension(dwio::common::FileFormat format) {
+  switch (format) {
+    case dwio::common::FileFormat::PARQUET:
+      return ".parquet";
+    case dwio::common::FileFormat::DWRF:
+      [[fallthrough]];
+    case dwio::common::FileFormat::ORC:
+      return ".orc";
+    default:
+      VELOX_UNSUPPORTED(
+          "Unsupported file format: {}", dwio::common::toString(format));
+  }
+}
+
+// Default max open writers for Paimon (matches Hive's default of 128).
+constexpr uint32_t kDefaultMaxOpenWriters = 128;
+
+} // namespace
+
+PaimonDataSink::PaimonDataSink(
+    RowTypePtr inputType,
+    std::shared_ptr<const HiveInsertTableHandle> insertTableHandle,
+    const ConnectorQueryCtx* connectorQueryCtx,
+    CommitStrategy commitStrategy,
+    const std::shared_ptr<const PaimonConfig>& paimonConfig)
+    : FileDataSink(
+          inputType,
+          connectorQueryCtx,
+          commitStrategy,
+          insertTableHandle->storageFormat(),
+          kDefaultMaxOpenWriters,
+          insertTableHandle->partitionChannels(),
+          insertTableHandle->nonPartitionChannels(),
+          getBucketCount(insertTableHandle->bucketProperty()),
+          getBucketCount(insertTableHandle->bucketProperty()) > 0
+              ? createBucketFunction(
+                    *insertTableHandle->bucketProperty(),
+                    inputType)
+              : nullptr,
+          createPartitionIdGenerator(
+              inputType,
+              insertTableHandle,
+              kDefaultMaxOpenWriters,
+              connectorQueryCtx->memoryPool()),
+          dwio::common::getWriterFactory(insertTableHandle->storageFormat()),
+          /*maxTargetFileBytes=*/0,
+          /*partitionKeyAsLowerCase=*/true,
+          connectorQueryCtx->spillConfig(),
+          /*sortWriterFinishTimeSliceLimitMs=*/0),
+      insertTableHandle_(std::move(insertTableHandle)),
+      paimonConfig_(paimonConfig) {
+  VELOX_USER_CHECK(
+      (commitStrategy_ == CommitStrategy::kNoCommit) ||
+          (commitStrategy_ == CommitStrategy::kTaskCommit),
+      "Unsupported commit strategy: {}",
+      CommitStrategyName::toName(commitStrategy_));
+}
+
+std::vector<std::string> PaimonDataSink::commitMessage() const {
+  std::vector<std::string> messages;
+  messages.reserve(writerInfo_.size());
+
+  for (int i = 0; i < writerInfo_.size(); ++i) {
+    const auto& info = writerInfo_.at(i);
+    VELOX_CHECK_NOT_NULL(info);
+
+    // Build per-file write info array.
+    folly::dynamic fileWriteInfos = folly::dynamic::array;
+    for (const auto& fileInfo : info->writtenFiles) {
+      fileWriteInfos.push_back(
+          folly::dynamic::object(
+              CommitMessage::kWriteFileName, fileInfo.writeFileName)(
+              CommitMessage::kTargetFileName, fileInfo.targetFileName)(
+              CommitMessage::kFileSize, fileInfo.fileSize)(
+              CommitMessage::kFileRowCount, fileInfo.numRows));
+    }
+
+    // Extract partition values from the partition name (key=value format).
+    // The partition name is stored in writerParameters.
+    folly::dynamic partitionValues = folly::dynamic::object;
+    // Note: partition values are not directly available from the writer
+    // parameters as a map. The coordinator tracks partition values separately.
+    // For now, we pass the partition name string.
+
+    // Extract bucket number from writer ID. We reconstruct it by looking at
+    // the writer index map.
+    int32_t bucketNumber = -1;
+    for (const auto& [writerId, index] : writerIndexMap_) {
+      if (index == i) {
+        bucketNumber = writerId.bucketId.value_or(-1);
+        break;
+      }
+    }
+
+    auto commitJson = folly::toJson(
+        folly::dynamic::object(
+            CommitMessage::kPartitionValues, std::move(partitionValues))(
+            CommitMessage::kBucketNumber, bucketNumber)(
+            CommitMessage::kWritePath, info->writerParameters.writeDirectory())(
+            CommitMessage::kTargetPath,
+            info->writerParameters.targetDirectory())(
+            CommitMessage::kFileWriteInfos, std::move(fileWriteInfos))(
+            CommitMessage::kTotalRowCount, info->numWrittenRows)(
+            CommitMessage::kInMemoryDataSizeInBytes, info->inputSizeInBytes)(
+            CommitMessage::kOnDiskDataSizeInBytes,
+            ioStats_.at(i)->rawBytesWritten()));
+
+    messages.push_back(std::move(commitJson));
+  }
+  return messages;
+}
+
+void PaimonDataSink::computePartitionAndBucketIds(const RowVectorPtr& input) {
+  VELOX_CHECK(isPartitioned() || isBucketed());
+
+  if (isPartitioned()) {
+    partitionIdGenerator_->run(input, partitionIds_);
+  }
+
+  if (isBucketed()) {
+    bucketFunction_->partition(*input, bucketIds_);
+  }
+}
+
+std::unique_ptr<dwio::common::Writer> PaimonDataSink::createWriterForIndex(
+    size_t writerIndex) {
+  VELOX_CHECK_LT(writerIndex, writerInfo_.size());
+  VELOX_CHECK_LT(writerIndex, ioStats_.size());
+
+  auto& info = writerInfo_[writerIndex];
+  const auto& params = info->writerParameters;
+
+  // Compute and store the new file names (handles file rotation).
+  info->currentWriteFileName =
+      makeSequencedFileName(params.writeFileName(), info->fileSequenceNumber);
+  info->currentTargetFileName =
+      makeSequencedFileName(params.targetFileName(), info->fileSequenceNumber);
+
+  const auto writePath =
+      (fs::path(params.writeDirectory()) / info->currentWriteFileName).string();
+
+  auto options = createWriterOptions(writerIndex);
+
+  auto writer = writerFactory_->createWriter(
+      dwio::common::FileSink::create(
+          writePath,
+          {
+              .bufferWrite = false,
+              .connectorProperties = paimonConfig_->config(),
+              .pool = info->sinkPool.get(),
+              .metricLogger = dwio::common::MetricsLog::voidLog(),
+              .stats = ioStats_[writerIndex].get(),
+              .fileSystemStats = fileSystemStats_.get(),
+          }),
+      options);
+  return writer;
+}
+
+std::shared_ptr<dwio::common::WriterOptions>
+PaimonDataSink::createWriterOptions() const {
+  return createWriterOptions(writerInfo_.size() - 1);
+}
+
+std::shared_ptr<dwio::common::WriterOptions>
+PaimonDataSink::createWriterOptions(size_t writerIndex) const {
+  VELOX_CHECK_LT(writerIndex, writerInfo_.size());
+
+  auto options = insertTableHandle_->writerOptions();
+  if (!options) {
+    options = writerFactory_->createWriterOptions();
+  }
+
+  if (options->schema == nullptr) {
+    options->schema = getNonPartitionTypes(dataChannels_, inputType_);
+  }
+
+  if (options->memoryPool == nullptr) {
+    options->memoryPool = writerInfo_[writerIndex]->writerPool.get();
+  }
+
+  if (!options->compressionKind) {
+    options->compressionKind = insertTableHandle_->compressionKind();
+  }
+
+  options->nonReclaimableSection =
+      writerInfo_[writerIndex]->nonReclaimableSectionHolder.get();
+
+  if (options->memoryReclaimerFactory == nullptr ||
+      options->memoryReclaimerFactory() == nullptr) {
+    options->memoryReclaimerFactory = []() {
+      return exec::MemoryReclaimer::create();
+    };
+  }
+
+  if (options->serdeParameters.empty()) {
+    options->serdeParameters = std::map<std::string, std::string>(
+        insertTableHandle_->serdeParameters().begin(),
+        insertTableHandle_->serdeParameters().end());
+  }
+
+  options->sessionTimezoneName = connectorQueryCtx_->sessionTimezone();
+  options->adjustTimestampToTimezone =
+      connectorQueryCtx_->adjustTimestampToTimezone();
+  return options;
+}
+
+std::string PaimonDataSink::getPartitionName(uint32_t partitionId) const {
+  VELOX_CHECK_NOT_NULL(partitionIdGenerator_);
+  return HivePartitionName::partitionName(
+      partitionId,
+      partitionIdGenerator_->partitionValues(),
+      partitionKeyAsLowerCase_);
+}
+
+WriterParameters PaimonDataSink::getWriterParameters(
+    const std::optional<std::string>& partition,
+    std::optional<uint32_t> bucketId) const {
+  // Paimon file naming: data-{uuid}.{format}
+  auto uuid = makeUuid();
+  auto targetFileName =
+      fmt::format("data-{}{}", uuid, formatExtension(storageFormat_));
+  auto writeFileName = isCommitRequired()
+      ? fmt::format(".tmp.paimon.{}", targetFileName)
+      : targetFileName;
+
+  // Paimon directory layout: {root}/{partition=value}/bucket-{N}/
+  auto bucketDir = makeBucketDirectory(bucketId);
+
+  return WriterParameters{
+      WriterParameters::UpdateMode::kNew,
+      partition,
+      targetFileName,
+      makePaimonDirectory(
+          insertTableHandle_->locationHandle()->targetPath(),
+          partition,
+          bucketDir),
+      writeFileName,
+      makePaimonDirectory(
+          insertTableHandle_->locationHandle()->writePath(),
+          partition,
+          bucketDir)};
+}
+
+} // namespace facebook::velox::connector::hive::paimon

--- a/velox/connectors/hive/paimon/PaimonDataSink.h
+++ b/velox/connectors/hive/paimon/PaimonDataSink.h
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/connectors/hive/FileDataSink.h"
+#include "velox/connectors/hive/HiveDataSink.h"
+#include "velox/connectors/hive/paimon/PaimonConfig.h"
+
+namespace facebook::velox::connector::hive::paimon {
+
+/// JSON field names for the commit message produced by PaimonDataSink.
+///
+/// Each writer (one per partition × bucket) produces a JSON object consumed by
+/// the Paimon coordinator to create manifest entries and a new snapshot.
+///
+/// JSON structure:
+/// {
+///   "partitionValues":           {"dt": "2024-01-01", "hour": "10"},
+///   "bucketNumber":              0,
+///   "writePath":                 "<staging directory>",
+///   "targetPath":                "<final directory>",
+///   "fileWriteInfos": [
+///     {
+///       "writeFileName":         "<temp filename in writePath>",
+///       "targetFileName":        "<final filename in targetPath>",
+///       "fileSize":              <bytes>,
+///       "rowCount":              <rows in this file>
+///     }
+///   ],
+///   "totalRowCount":             <total rows across all files>,
+///   "inMemoryDataSizeInBytes":   <uncompressed bytes>,
+///   "onDiskDataSizeInBytes":     <compressed bytes on disk>
+/// }
+struct CommitMessage {
+  /// Partition key-value pairs. Empty object for unpartitioned tables.
+  static constexpr const char* kPartitionValues = "partitionValues";
+  /// Bucket number within the partition. -1 for unbucketed tables.
+  static constexpr const char* kBucketNumber = "bucketNumber";
+  /// Staging directory where files were written.
+  static constexpr const char* kWritePath = "writePath";
+  /// Final directory after commit.
+  static constexpr const char* kTargetPath = "targetPath";
+  /// Per-file metadata array.
+  static constexpr const char* kFileWriteInfos = "fileWriteInfos";
+  /// Temporary filename in the staging directory.
+  static constexpr const char* kWriteFileName = "writeFileName";
+  /// Final filename after commit.
+  static constexpr const char* kTargetFileName = "targetFileName";
+  /// Size of individual file in bytes.
+  static constexpr const char* kFileSize = "fileSize";
+  /// Number of rows in individual file.
+  static constexpr const char* kFileRowCount = "rowCount";
+  /// Total rows written across all files for this partition/bucket.
+  static constexpr const char* kTotalRowCount = "totalRowCount";
+  /// Uncompressed input data size in bytes.
+  static constexpr const char* kInMemoryDataSizeInBytes =
+      "inMemoryDataSizeInBytes";
+  /// Compressed bytes written to disk.
+  static constexpr const char* kOnDiskDataSizeInBytes = "onDiskDataSizeInBytes";
+};
+
+/// Paimon-specific data sink for writing data files to Paimon tables.
+///
+/// Extends FileDataSink with Paimon's directory layout (bucket-N/ directories),
+/// file naming (data-{uuid}.{format}), and commit message format.
+///
+/// Supports append-only writes for unpartitioned, partitioned, and bucketed
+/// tables. Primary-key table writes, sorted writes, and memory reclamation
+/// are not yet supported.
+///
+/// Directory layout:
+///   {tableRoot}/{partition=value}/bucket-{N}/data-{uuid}.orc
+///
+/// All Paimon tables have a bucket directory — unbucketed tables use bucket-0.
+class PaimonDataSink : public FileDataSink {
+ public:
+  PaimonDataSink(
+      RowTypePtr inputType,
+      std::shared_ptr<const HiveInsertTableHandle> insertTableHandle,
+      const ConnectorQueryCtx* connectorQueryCtx,
+      CommitStrategy commitStrategy,
+      const std::shared_ptr<const PaimonConfig>& paimonConfig);
+
+ protected:
+  /// Generates Paimon-specific commit messages for the coordinator.
+  std::vector<std::string> commitMessage() const override;
+
+  /// Computes partition and bucket IDs for each row.
+  void computePartitionAndBucketIds(const RowVectorPtr& input) override;
+
+  /// Creates a file writer for the given writer index.
+  std::unique_ptr<facebook::velox::dwio::common::Writer> createWriterForIndex(
+      size_t writerIndex) override;
+
+  /// Creates writer options with Paimon-specific settings.
+  std::shared_ptr<dwio::common::WriterOptions> createWriterOptions()
+      const override;
+
+  std::shared_ptr<dwio::common::WriterOptions> createWriterOptions(
+      size_t writerIndex) const override;
+
+  /// Returns Hive-style partition directory name (key=value).
+  std::string getPartitionName(uint32_t partitionId) const override;
+
+  /// Returns writer parameters with Paimon directory layout (bucket-N/).
+  WriterParameters getWriterParameters(
+      const std::optional<std::string>& partition,
+      std::optional<uint32_t> bucketId) const override;
+
+ private:
+  const std::shared_ptr<const HiveInsertTableHandle> insertTableHandle_;
+  const std::shared_ptr<const PaimonConfig> paimonConfig_;
+};
+
+} // namespace facebook::velox::connector::hive::paimon

--- a/velox/connectors/hive/paimon/tests/CMakeLists.txt
+++ b/velox/connectors/hive/paimon/tests/CMakeLists.txt
@@ -57,4 +57,16 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
     GTest::gtest_main
     fmt::fmt
   )
+
+  add_executable(velox_hive_paimon_data_sink_test PaimonDataSinkTest.cpp)
+  add_test(velox_hive_paimon_data_sink_test velox_hive_paimon_data_sink_test)
+
+  target_link_libraries(
+    velox_hive_paimon_data_sink_test
+    velox_hive_paimon_connector
+    velox_hive_paimon_split
+    velox_exec_test_util
+    GTest::gtest
+    GTest::gtest_main
+  )
 endif()

--- a/velox/connectors/hive/paimon/tests/PaimonDataSinkTest.cpp
+++ b/velox/connectors/hive/paimon/tests/PaimonDataSinkTest.cpp
@@ -1,0 +1,308 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/connectors/hive/paimon/PaimonDataSink.h"
+
+#include <gtest/gtest.h>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/connectors/ConnectorRegistry.h"
+#include "velox/connectors/hive/HiveConfig.h"
+#include "velox/connectors/hive/paimon/PaimonConnector.h"
+#include "velox/connectors/hive/paimon/PaimonConnectorSplit.h"
+#include "velox/core/TableWriteTraits.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/exec/tests/utils/TempDirectoryPath.h"
+
+#include <folly/json.h>
+
+namespace facebook::velox::connector::hive::paimon {
+namespace {
+
+static const std::string kPaimonConnectorId = "test-paimon-write";
+
+class PaimonDataSinkTest : public exec::test::HiveConnectorTestBase {
+ protected:
+  void SetUp() override {
+    HiveConnectorTestBase::SetUp();
+    auto config = std::make_shared<config::ConfigBase>(
+        std::unordered_map<std::string, std::string>{});
+    auto connector =
+        PaimonConnectorFactory().newConnector(kPaimonConnectorId, config);
+    ConnectorRegistry::global().insert(connector->connectorId(), connector);
+  }
+
+  void TearDown() override {
+    ConnectorRegistry::global().erase(kPaimonConnectorId);
+    HiveConnectorTestBase::TearDown();
+  }
+
+  /// Creates an InsertTableHandle for writing through the Paimon connector.
+  std::shared_ptr<core::InsertTableHandle> makePaimonInsertTableHandle(
+      const RowTypePtr& rowType,
+      const std::string& targetDirectory,
+      const std::vector<std::string>& partitionedBy = {},
+      dwio::common::FileFormat format = dwio::common::FileFormat::DWRF) {
+    auto hiveInsertHandle = makeHiveInsertTableHandle(
+        rowType->names(),
+        rowType->children(),
+        partitionedBy,
+        makeLocationHandle(targetDirectory));
+    return std::make_shared<core::InsertTableHandle>(
+        kPaimonConnectorId, hiveInsertHandle);
+  }
+
+  /// Creates a table handle for reading with the Paimon connector.
+  static std::shared_ptr<HiveTableHandle> makePaimonTableHandle(
+      const RowTypePtr& dataColumns = nullptr) {
+    return std::make_shared<HiveTableHandle>(
+        kPaimonConnectorId,
+        "paimon_table",
+        common::SubfieldFilters{},
+        nullptr,
+        dataColumns);
+  }
+
+  /// Creates column assignments for reading with the Paimon connector.
+  static connector::ColumnHandleMap makePaimonColumnHandles(
+      const RowTypePtr& rowType) {
+    connector::ColumnHandleMap assignments;
+    assignments.reserve(rowType->size());
+    for (uint32_t i = 0; i < rowType->size(); ++i) {
+      const auto& name = rowType->nameOf(i);
+      assignments[name] = std::make_shared<HiveColumnHandle>(
+          name,
+          HiveColumnHandle::ColumnType::kRegular,
+          rowType->childAt(i),
+          rowType->childAt(i));
+    }
+    return assignments;
+  }
+
+  /// Builds a write plan: values() → tableWrite() using Paimon connector.
+  core::PlanNodePtr makePaimonWritePlan(
+      const std::vector<RowVectorPtr>& data,
+      const std::string& targetDirectory,
+      const std::vector<std::string>& partitionedBy = {},
+      dwio::common::FileFormat format = dwio::common::FileFormat::DWRF) {
+    auto rowType = asRowType(data[0]->type());
+    auto insertHandle =
+        makePaimonInsertTableHandle(rowType, targetDirectory, partitionedBy);
+    return exec::test::PlanBuilder()
+        .values(data)
+        .tableWrite(
+            targetDirectory,
+            /*partitionBy=*/{},
+            /*bucketCount=*/0,
+            /*bucketedBy=*/{},
+            /*sortBy=*/{},
+            format,
+            /*aggregates=*/{},
+            kPaimonConnectorId,
+            /*serdeParameters=*/{},
+            /*options=*/nullptr,
+            /*outputFileName=*/"",
+            common::CompressionKind_NONE,
+            /*schema=*/nullptr,
+            /*ensureFiles=*/false,
+            connector::CommitStrategy::kNoCommit,
+            insertHandle)
+        .planNode();
+  }
+
+  /// Builds a read plan using the Paimon connector.
+  core::PlanNodePtr makePaimonScanPlan(const RowTypePtr& outputType) {
+    auto tableHandle = makePaimonTableHandle(outputType);
+    auto assignments = makePaimonColumnHandles(outputType);
+    return exec::test::PlanBuilder()
+        .startTableScan()
+        .connectorId(kPaimonConnectorId)
+        .outputType(outputType)
+        .tableHandle(tableHandle)
+        .assignments(assignments)
+        .endTableScan()
+        .planNode();
+  }
+
+  /// Creates a PaimonConnectorSplit from a file path.
+  std::shared_ptr<PaimonConnectorSplit> makePaimonSplit(
+      const std::string& filePath) {
+    PaimonConnectorSplitBuilder builder(
+        kPaimonConnectorId,
+        /*snapshotId=*/1,
+        PaimonTableType::kAppendOnly,
+        dwio::common::FileFormat::DWRF);
+    builder.addFile(filePath, /*fileSize=*/0);
+    return builder.build();
+  }
+
+  /// Extracts the commit message JSON strings from the write result.
+  std::vector<std::string> extractCommitMessages(
+      const RowVectorPtr& result) const {
+    std::vector<std::string> messages;
+    auto fragments = result->childAt(core::TableWriteTraits::kFragmentChannel)
+                         ->as<FlatVector<StringView>>();
+    for (auto i = 0; i < result->size(); ++i) {
+      if (!fragments->isNullAt(i)) {
+        messages.push_back(fragments->valueAt(i).str());
+      }
+    }
+    return messages;
+  }
+};
+
+// E2E test: write data to an unpartitioned Paimon table.
+TEST_F(PaimonDataSinkTest, unpartitionedWrite) {
+  auto rowType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
+  auto data = makeVectors(rowType, 1, 100);
+
+  auto outputDirectory = exec::test::TempDirectoryPath::create();
+
+  auto plan = makePaimonWritePlan(data, outputDirectory->getPath());
+  auto result = exec::test::AssertQueryBuilder(plan).copyResults(pool());
+
+  // Verify the write produced output rows.
+  ASSERT_GT(result->size(), 0);
+
+  // Extract and validate commit messages.
+  auto messages = extractCommitMessages(result);
+  ASSERT_EQ(messages.size(), 1);
+
+  auto commitJson = folly::parseJson(messages[0]);
+  EXPECT_EQ(commitJson[CommitMessage::kBucketNumber].asInt(), -1);
+  EXPECT_GT(commitJson[CommitMessage::kTotalRowCount].asInt(), 0);
+  EXPECT_GT(commitJson[CommitMessage::kOnDiskDataSizeInBytes].asInt(), 0);
+
+  // Verify file write infos.
+  auto fileInfos = commitJson[CommitMessage::kFileWriteInfos];
+  ASSERT_EQ(fileInfos.size(), 1);
+  EXPECT_GT(fileInfos[0][CommitMessage::kFileSize].asInt(), 0);
+
+  // Verify the target path includes bucket-0 directory.
+  auto targetPath = commitJson[CommitMessage::kTargetPath].asString();
+  EXPECT_TRUE(targetPath.find("bucket-0") != std::string::npos)
+      << "Target path should contain bucket-0: " << targetPath;
+}
+
+// E2E test: write then read back data through the Paimon connector.
+TEST_F(PaimonDataSinkTest, writeAndReadBack) {
+  auto rowType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
+  auto data = makeVectors(rowType, 1, 100);
+
+  auto outputDirectory = exec::test::TempDirectoryPath::create();
+
+  // Write data.
+  auto writePlan = makePaimonWritePlan(data, outputDirectory->getPath());
+  auto writeResult =
+      exec::test::AssertQueryBuilder(writePlan).copyResults(pool());
+
+  // Parse the commit message to find the written file.
+  auto messages = extractCommitMessages(writeResult);
+  ASSERT_EQ(messages.size(), 1);
+
+  auto commitJson = folly::parseJson(messages[0]);
+  auto writePath = commitJson[CommitMessage::kWritePath].asString();
+  auto fileInfos = commitJson[CommitMessage::kFileWriteInfos];
+  ASSERT_EQ(fileInfos.size(), 1);
+  auto writeFileName = fileInfos[0][CommitMessage::kWriteFileName].asString();
+
+  // Read back the written file using a Paimon scan.
+  auto filePath = fmt::format("{}/{}", writePath, writeFileName);
+  auto split = makePaimonSplit(filePath);
+  auto readPlan = makePaimonScanPlan(rowType);
+
+  exec::test::AssertQueryBuilder(readPlan).split(split).assertResults(data);
+}
+
+// E2E test: write multiple batches to verify accumulation.
+TEST_F(PaimonDataSinkTest, multipleBatches) {
+  auto rowType = ROW({"c0"}, {BIGINT()});
+  auto batch1 = makeVectors(rowType, 1, 50);
+  auto batch2 = makeVectors(rowType, 1, 30);
+
+  std::vector<RowVectorPtr> allData;
+  allData.insert(allData.end(), batch1.begin(), batch1.end());
+  allData.insert(allData.end(), batch2.begin(), batch2.end());
+
+  auto outputDirectory = exec::test::TempDirectoryPath::create();
+
+  auto writePlan = makePaimonWritePlan(allData, outputDirectory->getPath());
+  auto writeResult =
+      exec::test::AssertQueryBuilder(writePlan).copyResults(pool());
+
+  // Parse commit message and verify total row count.
+  auto messages = extractCommitMessages(writeResult);
+  ASSERT_EQ(messages.size(), 1);
+
+  auto commitJson = folly::parseJson(messages[0]);
+  EXPECT_EQ(commitJson[CommitMessage::kTotalRowCount].asInt(), 80);
+
+  // Read back and verify.
+  auto writePath = commitJson[CommitMessage::kWritePath].asString();
+  auto writeFileName = commitJson[CommitMessage::kFileWriteInfos][0]
+                                 [CommitMessage::kWriteFileName]
+                                     .asString();
+
+  auto filePath = fmt::format("{}/{}", writePath, writeFileName);
+  auto split = makePaimonSplit(filePath);
+  auto readPlan = makePaimonScanPlan(rowType);
+
+  exec::test::AssertQueryBuilder(readPlan).split(split).assertResults(allData);
+}
+
+// Verify commit message JSON structure.
+TEST_F(PaimonDataSinkTest, commitMessageFormat) {
+  auto rowType = ROW({"c0"}, {BIGINT()});
+  auto data = makeVectors(rowType, 1, 10);
+
+  auto outputDirectory = exec::test::TempDirectoryPath::create();
+
+  auto writePlan = makePaimonWritePlan(data, outputDirectory->getPath());
+  auto writeResult =
+      exec::test::AssertQueryBuilder(writePlan).copyResults(pool());
+
+  auto messages = extractCommitMessages(writeResult);
+  ASSERT_EQ(messages.size(), 1);
+
+  auto commitJson = folly::parseJson(messages[0]);
+
+  // Verify all expected fields are present.
+  EXPECT_TRUE(commitJson.count(CommitMessage::kPartitionValues));
+  EXPECT_TRUE(commitJson.count(CommitMessage::kBucketNumber));
+  EXPECT_TRUE(commitJson.count(CommitMessage::kWritePath));
+  EXPECT_TRUE(commitJson.count(CommitMessage::kTargetPath));
+  EXPECT_TRUE(commitJson.count(CommitMessage::kFileWriteInfos));
+  EXPECT_TRUE(commitJson.count(CommitMessage::kTotalRowCount));
+  EXPECT_TRUE(commitJson.count(CommitMessage::kInMemoryDataSizeInBytes));
+  EXPECT_TRUE(commitJson.count(CommitMessage::kOnDiskDataSizeInBytes));
+
+  // Verify file write info fields.
+  auto fileInfos = commitJson[CommitMessage::kFileWriteInfos];
+  ASSERT_GE(fileInfos.size(), 1);
+  EXPECT_TRUE(fileInfos[0].count(CommitMessage::kWriteFileName));
+  EXPECT_TRUE(fileInfos[0].count(CommitMessage::kTargetFileName));
+  EXPECT_TRUE(fileInfos[0].count(CommitMessage::kFileSize));
+  EXPECT_TRUE(fileInfos[0].count(CommitMessage::kFileRowCount));
+
+  // Verify file naming convention.
+  auto targetFileName = fileInfos[0][CommitMessage::kTargetFileName].asString();
+  EXPECT_TRUE(targetFileName.find("data-") == 0)
+      << "Target file should start with 'data-': " << targetFileName;
+}
+
+} // namespace
+} // namespace facebook::velox::connector::hive::paimon


### PR DESCRIPTION
Summary:

Add write support for Paimon tables by implementing `PaimonDataSink`, which extends `FileDataSink` (extracted in D99814921) with Paimon-specific behavior.

**PaimonDataSink** provides:
- Paimon directory layout: `{tableRoot}/{partition=value}/bucket-{N}/data-{uuid}.{format}`
- Paimon file naming: `data-{uuid}.orc` with sequenced rotation (`data-{uuid}_2.orc`)
- Commit message JSON with per-file metadata (`fileWriteInfos`), partition values, bucket number, row counts, and data sizes for the Paimon coordinator to create manifest entries
- Partition and bucket ID computation reusing Hive infrastructure (`HivePartitionFunction`, `PartitionIdGenerator`)
- Writer creation with `PaimonConfig`-backed connector properties

**PaimonConnector** is extended with a `createDataSink()` override that creates `PaimonDataSink` instances, completing the read+write connector interface.

Supports append-only writes for unpartitioned, partitioned, and bucketed tables. Primary-key table writes, sorted writes, and memory reclamation are not yet supported.

Also fixes a bug in `HiveDataSink` where `sortWrite_` was set inside the `if (sortColumnIndices)` block but also needed to be set unconditionally after it (the existing code used `connectorQueryCtx` instead of `connectorQueryCtx_`).

Reviewed By: xiaoxmeng

Differential Revision: D103289827


