### PR TITLE
fix(exec): Avoid lock contention on OutputBuffer read path

### DIFF
--- a/velox/exec/OutputBuffer.cpp
+++ b/velox/exec/OutputBuffer.cpp
@@ -783,12 +783,10 @@ std::string OutputBuffer::toStringLocked() const {
 }
 
 double OutputBuffer::getUtilization() const {
-  std::lock_guard<std::mutex> l(mutex_);
   return bufferedBytes_ / static_cast<double>(maxSize_);
 }
 
 bool OutputBuffer::isOverutilized() const {
-  std::lock_guard<std::mutex> l(mutex_);
   return (bufferedBytes_ > (0.5 * maxSize_)) || atEnd_;
 }
 

--- a/velox/exec/OutputBuffer.h
+++ b/velox/exec/OutputBuffer.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "velox/common/base/Portability.h"
 #include "velox/core/PlanNode.h"
 #include "velox/exec/ExchangeQueue.h"
 
@@ -403,9 +404,9 @@ class OutputBuffer {
   // after receiving no-more-broadcast-buffers signal.
   std::vector<std::shared_ptr<SerializedPageBase>> dataToBroadcast_;
 
-  mutable std::mutex mutex_;
+  std::mutex mutex_;
   // Actual data size in 'buffers_'.
-  int64_t bufferedBytes_{0};
+  tsan_atomic<int64_t> bufferedBytes_{0};
   // The number of buffered pages which corresponds to 'bufferedBytes_'.
   int64_t bufferedPages_{0};
   // The total number of output bytes, rows and pages.
@@ -425,7 +426,7 @@ class OutputBuffer {
   uint32_t numFinished_{0};
   // When this reaches buffers_.size(), 'this' can be freed.
   int numFinalAcknowledges_ = 0;
-  bool atEnd_ = false;
+  tsan_atomic<bool> atEnd_{false};
 
   // Time since last change in bufferedBytes_. Used to compute total time data
   // is buffered. Ignored if bufferedBytes_ is zero.


### PR DESCRIPTION
Summary:
D99238897 added `mutex_` to `OutputBuffer::getUtilization()` / `isOverutilized()` to fix a TSAN race. These are called from `Task::taskStats()` (~1Hz/task) and the same mutex is held by `enqueue` / `getData` / `acknowledge`, so on busy clusters stats polling serializes against the producer hot path. We've been seeing chronic baseline UER `Failed to fetch data%Exhausted after%retries%` (proxygen 60s ingress timeout) since the version carrying D99238897 rolled out; off-CPU strobelight showed producer threads queued behind stats readers on `OutputBuffer::mutex_`.

Drop the locks in the two stat accessors and promote `bufferedBytes_` / `atEnd_` to `tsan_atomic<T>` — `std::atomic<T>` in TSAN, plain `T` in production. TSAN sees synchronized access (race report stays closed); production has zero overhead.

Safe because:
- Canonical Velox idiom for stat counters per `Portability.h:54-58`; same pattern at `LocalPartition.h:52`.
- Producer back-pressure (`bufferedBytes_ >= maxSize_` at `OutputBuffer.cpp:477`, `< continueSize_` at 671) STILL runs under `mutex_`.
- Only consumer is `ScaledWriterScheduler` via `taskStats`, which is averaged / hysteretic / polled and tolerates stale values.

Differential Revision: D103726335


