### PR TITLE
refactor: Extract RowLayout from RowContainer constructor

### DIFF
--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -83,6 +83,7 @@ velox_add_library(
   ProbeOperatorState.cpp
   SubPartitionedSortWindowBuild.cpp
   RowContainer.cpp
+  RowLayout.cpp
   RowNumber.cpp
   RowsStreamingWindowBuild.cpp
   ScaleWriterLocalPartition.cpp
@@ -188,6 +189,7 @@ velox_add_library(
   ProbeOperatorState.h
   RoundRobinPartitionFunction.h
   RowContainer.h
+  RowLayout.h
   RowNumber.h
   RowsStreamingWindowBuild.h
   ScaleWriterLocalPartition.h

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -20,22 +20,11 @@
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/ContainerRowSerde.h"
 #include "velox/exec/Operator.h"
+#include "velox/exec/RowLayout.h"
 #include "velox/type/FloatingPointUtil.h"
 
 namespace facebook::velox::exec {
 namespace {
-template <TypeKind Kind>
-static int32_t kindSize() {
-  return sizeof(typename KindToFlatVector<Kind>::HashRowType);
-}
-
-static int32_t typeKindSize(TypeKind kind) {
-  if (kind == TypeKind::UNKNOWN) {
-    return sizeof(UnknownValue);
-  }
-
-  return VELOX_DYNAMIC_TYPE_DISPATCH(kindSize, kind);
-}
 
 #if defined(__has_feature)
 #if __has_feature(thread_sanitizer)
@@ -148,123 +137,47 @@ RowContainer::RowContainer(
       accumulators_(accumulators),
       rows_(pool),
       rowPointers_(StlAllocator<char*>(stringAllocator_.get())) {
-  // Compute the layout of the payload row.  The row has keys, null flags,
-  // accumulators, dependent fields. All fields are fixed width. If variable
-  // width data is referenced, this is done with StringView(for VARCHAR) and
-  // std::string_view(for ARRAY, MAP and ROW) pointing to the data (StringView
-  // might inline the data if it's sufficiently small). The number of bytes used
-  // by each key is determined by keyTypes[i]. Null flags are one bit per field.
-  // If nullableKeys is true there is a null flag for each key. If there are
-  // accumulators, the remaining bits in the current byte are ignored and the
-  // flags for the accumulators begin aligned on the next byte. A null bit and
-  // an initialized bit, alternating, for each accumulator follow. A null bit
-  // for each dependent field follows that.  If hasProbedFlag is true, there is
-  // an extra bit to track if the row has been selected by a hash join probe.
-  // This is followed by a free bit which is set if the row is in a free list.
-  // The accumulators come next, with size given by
-  // Aggregate::accumulatorFixedWidthSize(). Dependent fields follow. These are
-  // non-key columns for hash join or order by. If there are variable length
-  // columns or accumulators, i.e. ones that allocate extra space, this space is
-  // tracked by a uint32_t after the dependent columns. If this is a hash join
-  // build side, the pointer to the next row with the same key is after the
-  // optional row size.
-  //
-  // In most cases, rows are prefixed with a normalized_key_t at index
-  // -1, 8 bytes below the pointer. This space is reserved for a 64
-  // bit unique digest of the keys for speeding up comparison. This
-  // space is reserved for the rows that are inserted before the
-  // cardinality grows too large for packing all in 64
-  // bits. 'numRowsWithNormalizedKey_' gives the number of rows with
-  // the extra field.
-  int32_t offset = 0;
-  int32_t flagOffset = 0;
-  bool isVariableWidth = false;
-  for (auto& type : keyTypes_) {
-    typeKinds_.push_back(type->kind());
-    types_.push_back(type);
-    offsets_.push_back(offset);
-    offset += typeKindSize(type->kind());
-    nullOffsets_.push_back(flagOffset);
-    isVariableWidth |= !type->isFixedWidth();
-    if (nullableKeys_) {
-      ++flagOffset;
-    }
-  }
-  // Make offset at least sizeof pointer so that there is space for a
-  // free list next pointer below the bit at 'freeFlagOffset_'.
-  offset = std::max<int32_t>(offset, sizeof(void*));
-  const int32_t firstAggregateOffset = offset;
-  if (!accumulators.empty()) {
-    // This moves flagOffset to the start of the next byte.
-    // This is to guarantee the null and initialized bits for an aggregate
-    // always appear in the same byte.
-    flagOffset = (flagOffset + 7) & -8;
-  }
-  for (const auto& accumulator : accumulators) {
-    // Null bit.
-    nullOffsets_.push_back(flagOffset);
-    // Increment for two bits: null bit and following initialized bit.
-    flagOffset += kNumAccumulatorFlags;
-    isVariableWidth |= !accumulator.isFixedSize();
-    usesExternalMemory_ |= accumulator.usesExternalMemory();
-    alignment_ = combineAlignments(accumulator.alignment(), alignment_);
-  }
-  for (auto& type : dependentTypes) {
+  // The row layout (byte offsets, null bit positions, flag region size and
+  // alignment) is computed by RowLayout::compute(); see RowLayout.h for the
+  // overall row shape. 'numRowsWithNormalizedKey_' is incremented as rows are
+  // allocated with the optional 64-bit normalized-key prefix.
+  types_.reserve(keyTypes.size() + dependentTypes.size());
+  typeKinds_.reserve(keyTypes.size() + dependentTypes.size());
+  for (const auto& type : keyTypes_) {
     types_.push_back(type);
     typeKinds_.push_back(type->kind());
-    nullOffsets_.push_back(flagOffset);
-    ++flagOffset;
-    isVariableWidth |= !type->isFixedWidth();
   }
-  if (hasProbedFlag) {
-    probedFlagOffset_ = flagOffset + firstAggregateOffset * 8;
-    ++flagOffset;
+  for (const auto& type : dependentTypes) {
+    types_.push_back(type);
+    typeKinds_.push_back(type->kind());
   }
-  // Free flag.
-  freeFlagOffset_ = flagOffset + firstAggregateOffset * 8;
-  ++flagOffset;
-  // Add 1 to the last null offset to get the number of bits.
-  flagBytes_ = bits::nbytes(flagOffset);
-  // Fixup 'nullOffsets_' to be the bit number from the start of the row.
-  for (int32_t i = 0; i < nullOffsets_.size(); ++i) {
-    nullOffsets_[i] += firstAggregateOffset * 8;
-  }
-  offset += flagBytes_;
-  for (const auto& accumulator : accumulators) {
-    // Accumulator offset must be aligned by their alignment size.
-    offset = bits::roundUp(offset, accumulator.alignment());
-    offsets_.push_back(offset);
-    offset += accumulator.fixedWidthSize();
-  }
-  for (auto& type : dependentTypes) {
-    offsets_.push_back(offset);
-    offset += typeKindSize(type->kind());
-  }
-  if (isVariableWidth) {
-    rowSizeOffset_ = offset;
-    offset += sizeof(uint32_t);
-  }
-  if (hasNext) {
-    nextOffset_ = offset;
-    offset += sizeof(void*);
-  }
-  if (hasCountFlag) {
-    countOffset_ = offset;
-    offset += sizeof(int32_t);
-  }
-  fixedRowSize_ = bits::roundUp(offset, alignment_);
-  originalNormalizedKeySize_ = hasNormalizedKeys_
-      ? bits::roundUp(sizeof(normalized_key_t), alignment_)
-      : 0;
+
+  auto layout = RowLayout::compute(
+      keyTypes,
+      accumulators,
+      dependentTypes,
+      RowLayoutOptions{
+          .nullableKeys = nullableKeys,
+          .hasNext = hasNext,
+          .hasProbedFlag = hasProbedFlag,
+          .hasCountFlag = hasCountFlag,
+          .hasNormalizedKeys = hasNormalizedKeys,
+      });
+  offsets_ = std::move(layout.offsets);
+  nullOffsets_ = std::move(layout.nullOffsets);
+  rowColumns_ = std::move(layout.rowColumns);
+  probedFlagOffset_ = layout.probedFlagOffset;
+  freeFlagOffset_ = layout.freeFlagOffset;
+  countOffset_ = layout.countOffset;
+  nextOffset_ = layout.nextOffset;
+  rowSizeOffset_ = layout.rowSizeOffset;
+  flagBytes_ = layout.flagBytes;
+  fixedRowSize_ = layout.fixedRowSize;
+  originalNormalizedKeySize_ = layout.originalNormalizedKeySize;
   normalizedKeySize_ = originalNormalizedKeySize_;
-  size_t nullOffsetsPos = 0;
-  for (auto i = 0; i < offsets_.size(); ++i) {
-    rowColumns_.emplace_back(
-        offsets_[i],
-        (nullableKeys_ || i >= keyTypes_.size()) ? nullOffsets_[nullOffsetsPos]
-                                                 : RowColumn::kNotNullOffset);
-    ++nullOffsetsPos;
-  }
+  alignment_ = layout.alignment;
+  usesExternalMemory_ = layout.usesExternalMemory;
+
   rowColumnsStats_.resize(types_.size());
 }
 
@@ -611,7 +524,7 @@ int32_t RowContainer::variableSizeAt(const char* row, column_index_t column)
 }
 
 int32_t RowContainer::fixedSizeAt(column_index_t column) const {
-  return typeKindSize(typeKinds_[column]);
+  return RowLayout::typeKindSize(typeKinds_[column]);
 }
 
 int32_t RowContainer::extractVariableSizeAt(
@@ -693,8 +606,8 @@ void RowContainer::extractSerializedRows(
     const VectorPtr& result) const {
   // The format of the extracted row is: null bytes followed by keys and
   // dependent columns. Fixed-width columns are serialized into fixed number of
-  // bytes (see typeKindSize). Variable-width columns are serialized as 4 bytes
-  // of size followed by that many bytes.
+  // bytes (see RowLayout::typeKindSize). Variable-width columns are serialized
+  // as 4 bytes of size followed by that many bytes.
 
   // First, calculate total number of bytes needed to serialize all rows.
 
@@ -703,7 +616,7 @@ void RowContainer::extractSerializedRows(
   for (auto i = 0; i < types_.size(); ++i) {
     const auto& type = types_[i];
     if (type->isFixedWidth()) {
-      fixedWidthRowSize += typeKindSize(type->kind());
+      fixedWidthRowSize += RowLayout::typeKindSize(type->kind());
     } else {
       hasVariableWidth = true;
     }
@@ -742,7 +655,7 @@ void RowContainer::extractSerializedRows(
     for (auto j = 0; j < types_.size(); ++j) {
       const auto& type = types_[j];
       if (type->isFixedWidth()) {
-        const auto size = typeKindSize(type->kind());
+        const auto size = RowLayout::typeKindSize(type->kind());
         ::memcpy(rawBuffer + offset, row + rowColumns_[j].offset(), size);
         offset += size;
       } else {
@@ -774,7 +687,7 @@ void RowContainer::storeSerializedRow(
   for (auto i = 0; i < types_.size(); ++i) {
     const auto& type = types_[i];
     if (type->isFixedWidth()) {
-      const auto size = typeKindSize(type->kind());
+      const auto size = RowLayout::typeKindSize(type->kind());
       ::memcpy(row + rowColumns_[i].offset(), serialized.data() + offset, size);
       offset += size;
     } else {

--- a/velox/exec/RowLayout.cpp
+++ b/velox/exec/RowLayout.cpp
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/RowLayout.h"
+
+#include "velox/common/base/BitUtil.h"
+
+namespace facebook::velox::exec {
+namespace {
+
+template <TypeKind Kind>
+int32_t kindSize() {
+  return sizeof(typename KindToFlatVector<Kind>::HashRowType);
+}
+
+} // namespace
+
+// static
+int32_t RowLayout::typeKindSize(TypeKind kind) {
+  if (kind == TypeKind::UNKNOWN) {
+    return sizeof(UnknownValue);
+  }
+  return VELOX_DYNAMIC_TYPE_DISPATCH(kindSize, kind);
+}
+
+// static
+RowLayout RowLayout::compute(
+    const std::vector<TypePtr>& keyTypes,
+    const std::vector<Accumulator>& accumulators,
+    const std::vector<TypePtr>& dependentTypes,
+    const RowLayoutOptions& options) {
+  RowLayout layout;
+
+  int32_t offset = 0;
+  int32_t flagOffset = 0;
+  bool isVariableWidth = false;
+  for (const auto& type : keyTypes) {
+    layout.offsets.push_back(offset);
+    offset += typeKindSize(type->kind());
+    layout.nullOffsets.push_back(flagOffset);
+    isVariableWidth |= !type->isFixedWidth();
+    if (options.nullableKeys) {
+      ++flagOffset;
+    }
+  }
+  // Make offset at least sizeof pointer so that there is space for a free
+  // list next pointer below the bit at 'freeFlagOffset'.
+  offset = std::max<int32_t>(offset, sizeof(void*));
+  const int32_t firstAggregateOffset = offset;
+  if (!accumulators.empty()) {
+    // Move flagOffset to the start of the next byte. This guarantees the
+    // null and initialized bits for an aggregate always appear in the same
+    // byte.
+    flagOffset = (flagOffset + 7) & -8;
+  }
+  for (const auto& accumulator : accumulators) {
+    // Null bit.
+    layout.nullOffsets.push_back(flagOffset);
+    // Increment for two bits: null bit and following initialized bit.
+    flagOffset += RowContainer::kNumAccumulatorFlags;
+    isVariableWidth |= !accumulator.isFixedSize();
+    layout.usesExternalMemory |= accumulator.usesExternalMemory();
+    layout.alignment = RowContainer::combineAlignments(
+        accumulator.alignment(), layout.alignment);
+  }
+  for (const auto& type : dependentTypes) {
+    layout.nullOffsets.push_back(flagOffset);
+    ++flagOffset;
+    isVariableWidth |= !type->isFixedWidth();
+  }
+  if (options.hasProbedFlag) {
+    layout.probedFlagOffset = flagOffset + firstAggregateOffset * 8;
+    ++flagOffset;
+  }
+  // Free flag.
+  layout.freeFlagOffset = flagOffset + firstAggregateOffset * 8;
+  ++flagOffset;
+  // 'flagOffset' is now the total number of flag bits; convert to bytes.
+  layout.flagBytes = bits::nbytes(flagOffset);
+  // Until this point each entry in 'nullOffsets' is a bit offset relative to
+  // the start of the flag region. Shift them to be bit offsets from the row
+  // start so RowColumn callers can read them directly.
+  for (int32_t i = 0; i < layout.nullOffsets.size(); ++i) {
+    layout.nullOffsets[i] += firstAggregateOffset * 8;
+  }
+  offset += layout.flagBytes;
+  for (const auto& accumulator : accumulators) {
+    // Each accumulator's payload is aligned to its declared alignment.
+    offset = bits::roundUp(offset, accumulator.alignment());
+    layout.offsets.push_back(offset);
+    offset += accumulator.fixedWidthSize();
+  }
+  for (const auto& type : dependentTypes) {
+    layout.offsets.push_back(offset);
+    offset += typeKindSize(type->kind());
+  }
+  if (isVariableWidth) {
+    layout.rowSizeOffset = offset;
+    offset += sizeof(uint32_t);
+  }
+  if (options.hasNext) {
+    layout.nextOffset = offset;
+    offset += sizeof(void*);
+  }
+  if (options.hasCountFlag) {
+    layout.countOffset = offset;
+    offset += sizeof(int32_t);
+  }
+  layout.fixedRowSize = bits::roundUp(offset, layout.alignment);
+  layout.originalNormalizedKeySize = options.hasNormalizedKeys
+      ? bits::roundUp(sizeof(normalized_key_t), layout.alignment)
+      : 0;
+
+  size_t nullOffsetsPos = 0;
+  for (size_t i = 0; i < layout.offsets.size(); ++i) {
+    layout.rowColumns.emplace_back(
+        layout.offsets[i],
+        (options.nullableKeys || i >= keyTypes.size())
+            ? layout.nullOffsets[nullOffsetsPos]
+            : RowColumn::kNotNullOffset);
+    ++nullOffsetsPos;
+  }
+  return layout;
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/RowLayout.h
+++ b/velox/exec/RowLayout.h
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <vector>
+
+#include "velox/exec/RowContainer.h"
+
+namespace facebook::velox::exec {
+
+/// Optional flags that control how RowLayout::compute() lays out a row.
+///
+/// Defaults match a RowContainer constructed with only key types and a
+/// memory pool: keys are nullable; no next-row pointer, probed flag,
+/// counting-join counter, or normalized-key prefix.
+struct RowLayoutOptions {
+  /// True if each key column has a null flag bit.
+  bool nullableKeys{true};
+
+  /// True if the row carries an inline next-row pointer used to thread
+  /// duplicate keys in a hash-join build side.
+  bool hasNext{false};
+
+  /// True if the row carries a probed-state bit for full or right outer
+  /// join.
+  bool hasProbedFlag{false};
+
+  /// True if the row carries a per-row int32_t count, used by counting
+  /// joins.
+  bool hasCountFlag{false};
+
+  /// True if the row reserves space for a normalized 64-bit key digest in
+  /// the slot immediately below the row pointer.
+  bool hasNormalizedKeys{false};
+};
+
+/// Computed memory layout of a single row inside a RowContainer.
+///
+/// A row carries its keys, then null flags for keys, accumulators and
+/// dependents, then an optional probed bit, then the free bit, then the
+/// accumulator payloads, then the dependent fields, then optional uint32_t
+/// row size and next-row pointer and counting-join counter slots. Variable
+/// width key, dependent and accumulator data is stored out of line through
+/// HashStringAllocator and referenced from the row by StringView (for
+/// VARCHAR/VARBINARY) or std::string_view (for ARRAY/MAP/ROW). When
+/// 'hasNormalizedKeys' is true the row is additionally prefixed with a
+/// 64-bit normalized key digest in the slot immediately below the row
+/// pointer.
+///
+/// All fields describe positions within a single row:
+///  - Byte offsets are relative to the start of the row (the row pointer
+///    returned by RowContainer::newRow()).
+///  - Bit offsets ('nullOffsets', 'probedFlagOffset', 'freeFlagOffset') are
+///    relative to the start of the row, in bits.
+///
+/// This is a pure value object. It carries no allocator or runtime state.
+/// Use RowLayout::compute() to derive a layout from container parameters
+/// without instantiating a RowContainer.
+struct RowLayout {
+  /// Byte offset of each non-aggregate field. Order is keys, accumulators,
+  /// dependents. Size equals the total column count
+  /// (keyTypes.size() + accumulators.size() + dependentTypes.size()).
+  std::vector<int32_t> offsets;
+
+  /// Bit offset of the null flag for each non-aggregate field. Same order and
+  /// size as 'offsets'. When 'options.nullableKeys' is false the entries for
+  /// keys are populated for indexing convenience but the bits are unused;
+  /// the corresponding RowColumn in 'rowColumns' carries kNotNullOffset.
+  std::vector<int32_t> nullOffsets;
+
+  /// Packed (offset, nullByte, nullMask) view per column. Same order and size
+  /// as 'offsets'.
+  std::vector<RowColumn> rowColumns;
+
+  /// Bit offset of the probed flag for full or right outer join. 0 when not
+  /// applicable.
+  int32_t probedFlagOffset{0};
+
+  /// Bit offset of the free-row flag.
+  int32_t freeFlagOffset{0};
+
+  /// Byte offset of the per-row count for counting joins. 0 when not
+  /// applicable.
+  int32_t countOffset{0};
+
+  /// Byte offset of the next-row pointer for hash join chains. 0 when keys
+  /// are guaranteed unique.
+  int32_t nextOffset{0};
+
+  /// Byte offset of the uint32_t variable-row-size counter. 0 when the row
+  /// has no variable-width fields and no accumulators.
+  int32_t rowSizeOffset{0};
+
+  /// Number of bytes occupied by the flag region (per-column null bits, the
+  /// optional probed bit, and the free bit).
+  int32_t flagBytes{0};
+
+  /// Total fixed row size in bytes, rounded up to 'alignment'.
+  int32_t fixedRowSize{0};
+
+  /// Bytes reserved before each row for the optional normalized key. 0 when
+  /// normalized keys are not requested.
+  int32_t originalNormalizedKeySize{0};
+
+  /// Row alignment in bytes. Combined from accumulator alignments. Always a
+  /// power of two.
+  int32_t alignment{1};
+
+  /// True if any accumulator reports usesExternalMemory.
+  bool usesExternalMemory{false};
+
+  /// Computes the row layout from container parameters. Pure function: makes
+  /// no allocations beyond the returned vectors and reads no global state.
+  /// 'keyTypes', 'accumulators' and 'dependentTypes' must outlive the call.
+  /// Each accumulator's alignment must be a power of two.
+  static RowLayout compute(
+      const std::vector<TypePtr>& keyTypes,
+      const std::vector<Accumulator>& accumulators,
+      const std::vector<TypePtr>& dependentTypes,
+      const RowLayoutOptions& options = {});
+
+  /// Returns the in-row byte size of a fixed-width value of the given type
+  /// kind.
+  static int32_t typeKindSize(TypeKind kind);
+};
+
+} // namespace facebook::velox::exec

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -120,6 +120,7 @@ set(
   StreamingAggregationTest.cpp
   ContainerRowSerdeTest.cpp
   RowContainerTest.cpp
+  RowLayoutTest.cpp
   TopNTest.cpp
   WriterFuzzerUtilTest.cpp
   PlanNodeStatsTest.cpp

--- a/velox/exec/tests/RowLayoutTest.cpp
+++ b/velox/exec/tests/RowLayoutTest.cpp
@@ -1,0 +1,321 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/RowLayout.h"
+
+#include <gtest/gtest.h>
+
+#include "velox/exec/RowContainer.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+
+namespace facebook::velox::exec::test {
+namespace {
+
+// Tests for RowLayout. Two flavors:
+//
+//  1. 'verifyLayoutMatches' cases build a real RowContainer with a parameter
+//     set, call RowLayout::compute() with the equivalent options, and assert
+//     the publicly observable layout (fixedRowSize, nextOffset, rowSizeOffset,
+//     probedFlagOffset, countOffset and per-column RowColumn) is identical.
+//     RowContainer's constructor consumes RowLayout, so these assertions
+//     guard the public layout accessors against regressions.
+//
+//  2. 'goldenXxx' cases compare RowLayout::compute() against hand-traced
+//     expected values. They lock in absolute correctness independent of
+//     RowContainer.
+class RowLayoutTest : public testing::Test, public velox::test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  void verifyLayoutMatches(
+      const std::vector<TypePtr>& keyTypes,
+      const std::vector<Accumulator>& accumulators,
+      const std::vector<TypePtr>& dependentTypes,
+      const RowLayoutOptions& options) {
+    RowContainer container(
+        keyTypes,
+        options.nullableKeys,
+        accumulators,
+        dependentTypes,
+        options.hasNext,
+        /*isJoinBuild=*/false,
+        options.hasProbedFlag,
+        options.hasCountFlag,
+        options.hasNormalizedKeys,
+        /*useListRowIndex=*/false,
+        pool_.get());
+
+    auto layout =
+        RowLayout::compute(keyTypes, accumulators, dependentTypes, options);
+
+    EXPECT_EQ(layout.fixedRowSize, container.fixedRowSize());
+    EXPECT_EQ(layout.nextOffset, container.nextOffset());
+    EXPECT_EQ(layout.rowSizeOffset, container.rowSizeOffset());
+    EXPECT_EQ(layout.probedFlagOffset, container.probedFlagOffset());
+    EXPECT_EQ(layout.countOffset, container.countOffset());
+
+    const size_t expectedColumns =
+        keyTypes.size() + accumulators.size() + dependentTypes.size();
+    ASSERT_EQ(layout.rowColumns.size(), expectedColumns);
+    ASSERT_EQ(layout.offsets.size(), expectedColumns);
+    ASSERT_EQ(layout.nullOffsets.size(), expectedColumns);
+
+    for (size_t i = 0; i < expectedColumns; ++i) {
+      const auto fromContainer = container.columnAt(i);
+      const auto fromLayout = layout.rowColumns[i];
+      EXPECT_EQ(fromLayout.offset(), fromContainer.offset()) << "column " << i;
+      EXPECT_EQ(fromLayout.nullByte(), fromContainer.nullByte())
+          << "column " << i;
+      EXPECT_EQ(fromLayout.nullMask(), fromContainer.nullMask())
+          << "column " << i;
+    }
+  }
+
+  // Returns a fixed-size accumulator with the given byte size and alignment.
+  // The destroy and spill-extract callbacks are inert; the layout computation
+  // does not invoke them.
+  static Accumulator makeAccumulator(int32_t size, int32_t alignment) {
+    return Accumulator(
+        /*isFixedSize=*/true,
+        size,
+        /*usesExternalMemory=*/false,
+        alignment,
+        /*spillType=*/nullptr,
+        [](folly::Range<char**>, VectorPtr&) { VELOX_UNREACHABLE(); },
+        [](folly::Range<char**>) {});
+  }
+
+  // Returns a variable-size accumulator. Layout treats it as variable-width,
+  // forcing a row-size counter.
+  static Accumulator makeVariableAccumulator(int32_t alignment) {
+    return Accumulator(
+        /*isFixedSize=*/false,
+        /*fixedSize=*/16,
+        /*usesExternalMemory=*/false,
+        alignment,
+        /*spillType=*/nullptr,
+        [](folly::Range<char**>, VectorPtr&) { VELOX_UNREACHABLE(); },
+        [](folly::Range<char**>) {});
+  }
+};
+
+TEST_F(RowLayoutTest, keysOnlyNullable) {
+  verifyLayoutMatches({BIGINT(), INTEGER(), SMALLINT()}, {}, {}, {});
+}
+
+TEST_F(RowLayoutTest, keysOnlyNotNullable) {
+  verifyLayoutMatches({BIGINT(), INTEGER()}, {}, {}, {.nullableKeys = false});
+}
+
+TEST_F(RowLayoutTest, keysWithDependents) {
+  verifyLayoutMatches({BIGINT()}, {}, {VARCHAR(), DOUBLE(), BOOLEAN()}, {});
+}
+
+TEST_F(RowLayoutTest, withProbedFlag) {
+  verifyLayoutMatches(
+      {BIGINT(), VARCHAR()},
+      {},
+      {INTEGER()},
+      {.hasNext = true, .hasProbedFlag = true});
+}
+
+TEST_F(RowLayoutTest, withCountFlag) {
+  verifyLayoutMatches(
+      {BIGINT()}, {}, {}, {.nullableKeys = false, .hasCountFlag = true});
+}
+
+TEST_F(RowLayoutTest, withNextPointer) {
+  verifyLayoutMatches({BIGINT()}, {}, {DOUBLE()}, {.hasNext = true});
+}
+
+TEST_F(RowLayoutTest, withFixedAccumulator) {
+  verifyLayoutMatches(
+      {BIGINT()}, {makeAccumulator(/*size=*/8, /*alignment=*/8)}, {}, {});
+}
+
+TEST_F(RowLayoutTest, withAlignedAccumulator) {
+  // Mirrors the alignment exercise inside RowContainerTest.alignment.
+  verifyLayoutMatches(
+      {SMALLINT()},
+      {makeAccumulator(/*size=*/42, /*alignment=*/64)},
+      {},
+      {.hasNormalizedKeys = true});
+}
+
+TEST_F(RowLayoutTest, withVariableWidthAccumulator) {
+  verifyLayoutMatches(
+      {BIGINT()}, {makeVariableAccumulator(/*alignment=*/8)}, {}, {});
+}
+
+TEST_F(RowLayoutTest, withNormalizedKey) {
+  verifyLayoutMatches(
+      {BIGINT(), INTEGER()}, {}, {}, {.hasNormalizedKeys = true});
+}
+
+TEST_F(RowLayoutTest, variableWidthKey) {
+  verifyLayoutMatches({VARCHAR()}, {}, {}, {});
+}
+
+TEST_F(RowLayoutTest, complexTypes) {
+  verifyLayoutMatches(
+      {BIGINT()},
+      {},
+      {ARRAY(INTEGER()), MAP(BIGINT(), VARCHAR()), ROW({BIGINT(), VARCHAR()})},
+      {});
+}
+
+TEST_F(RowLayoutTest, allFlagsOn) {
+  verifyLayoutMatches(
+      {BIGINT(), VARCHAR()},
+      {makeAccumulator(/*size=*/16, /*alignment=*/8),
+       makeAccumulator(/*size=*/24, /*alignment=*/16)},
+      {DOUBLE(), ARRAY(INTEGER())},
+      {.hasNext = true,
+       .hasProbedFlag = true,
+       .hasCountFlag = true,
+       .hasNormalizedKeys = true});
+}
+
+TEST_F(RowLayoutTest, manyKeysForceFlagOverflow) {
+  // With many nullable keys plus an accumulator, the flag region is forced to
+  // straddle the next byte boundary at the start of the accumulator flags.
+  // This exercises the flagOffset = (flagOffset + 7) & -8 alignment step.
+  verifyLayoutMatches(
+      {BIGINT(),
+       INTEGER(),
+       SMALLINT(),
+       TINYINT(),
+       BIGINT(),
+       INTEGER(),
+       SMALLINT(),
+       TINYINT(),
+       BIGINT(),
+       INTEGER(),
+       SMALLINT(),
+       TINYINT()},
+      {makeAccumulator(/*size=*/8, /*alignment=*/8)},
+      {},
+      {});
+}
+
+// Hand-traced layout for a minimal nullable-keys case.
+// Layout:
+//   bytes  0..7  : key 0 (BIGINT)
+//   bytes  8..11 : key 1 (INTEGER)
+//   bytes 12     : flag byte (bit 0 = key0 null, bit 1 = key1 null,
+//                              bit 2 = free flag)
+TEST_F(RowLayoutTest, goldenSimpleKeys) {
+  auto layout = RowLayout::compute(
+      {BIGINT(), INTEGER()}, /*accumulators=*/{}, /*dependentTypes=*/{}, {});
+
+  EXPECT_EQ(layout.fixedRowSize, 13);
+  EXPECT_EQ(layout.flagBytes, 1);
+  EXPECT_EQ(layout.alignment, 1);
+  EXPECT_EQ(layout.freeFlagOffset, 12 * 8 + 2);
+  EXPECT_EQ(layout.probedFlagOffset, 0);
+  EXPECT_EQ(layout.nextOffset, 0);
+  EXPECT_EQ(layout.countOffset, 0);
+  EXPECT_EQ(layout.rowSizeOffset, 0);
+  EXPECT_EQ(layout.originalNormalizedKeySize, 0);
+  EXPECT_FALSE(layout.usesExternalMemory);
+
+  ASSERT_EQ(layout.offsets.size(), 2);
+  EXPECT_EQ(layout.offsets[0], 0);
+  EXPECT_EQ(layout.offsets[1], 8);
+
+  ASSERT_EQ(layout.nullOffsets.size(), 2);
+  EXPECT_EQ(layout.nullOffsets[0], 12 * 8 + 0);
+  EXPECT_EQ(layout.nullOffsets[1], 12 * 8 + 1);
+
+  ASSERT_EQ(layout.rowColumns.size(), 2);
+  EXPECT_EQ(layout.rowColumns[0].offset(), 0);
+  EXPECT_EQ(layout.rowColumns[0].nullByte(), 12);
+  EXPECT_EQ(layout.rowColumns[0].nullMask(), 0x1);
+  EXPECT_EQ(layout.rowColumns[1].offset(), 8);
+  EXPECT_EQ(layout.rowColumns[1].nullByte(), 12);
+  EXPECT_EQ(layout.rowColumns[1].nullMask(), 0x2);
+}
+
+// Hand-traced layout for a hash-join build side with a fixed-size accumulator,
+// a probed flag, a count slot, a next pointer and a normalized-key prefix.
+// Layout:
+//   bytes  0..7  : key 0 (BIGINT)
+//   bytes  8..9  : flag bytes
+//                  byte 8: bits 0..6 unused (flag region starts at byte 8 so
+//                          flag bit numbering restarts here),
+//                  bit 64        = key 0 null
+//                  bits 65..71   = unused (forced to next byte boundary
+//                                  because there is an accumulator),
+//                  bits 72,73    = accumulator null + initialized,
+//                  bit 74        = dependent (DOUBLE) null,
+//                  bit 75        = probed,
+//                  bit 76        = free
+//   bytes 10..15 : padding to align accumulator to 8
+//   bytes 16..23 : accumulator payload (size 8, alignment 8)
+//   bytes 24..31 : dependent (DOUBLE)
+//   bytes 32..39 : next-row pointer
+//   bytes 40..43 : count int32_t
+//   bytes 44..47 : padding to align row size to 8
+//   plus 8 bytes reserved before the row pointer for the normalized key
+TEST_F(RowLayoutTest, goldenHashJoinWithAccumulator) {
+  auto layout = RowLayout::compute(
+      {BIGINT()},
+      {makeAccumulator(/*size=*/8, /*alignment=*/8)},
+      {DOUBLE()},
+      {.hasNext = true,
+       .hasProbedFlag = true,
+       .hasCountFlag = true,
+       .hasNormalizedKeys = true});
+
+  EXPECT_EQ(layout.fixedRowSize, 48);
+  EXPECT_EQ(layout.flagBytes, 2);
+  EXPECT_EQ(layout.alignment, 8);
+  EXPECT_EQ(layout.probedFlagOffset, 8 * 8 + 11);
+  EXPECT_EQ(layout.freeFlagOffset, 8 * 8 + 12);
+  EXPECT_EQ(layout.nextOffset, 32);
+  EXPECT_EQ(layout.countOffset, 40);
+  EXPECT_EQ(layout.rowSizeOffset, 0);
+  EXPECT_EQ(layout.originalNormalizedKeySize, 8);
+  EXPECT_FALSE(layout.usesExternalMemory);
+
+  ASSERT_EQ(layout.offsets.size(), 3);
+  EXPECT_EQ(layout.offsets[0], 0);
+  EXPECT_EQ(layout.offsets[1], 16);
+  EXPECT_EQ(layout.offsets[2], 24);
+
+  ASSERT_EQ(layout.nullOffsets.size(), 3);
+  EXPECT_EQ(layout.nullOffsets[0], 8 * 8 + 0);
+  EXPECT_EQ(layout.nullOffsets[1], 8 * 8 + 8);
+  EXPECT_EQ(layout.nullOffsets[2], 8 * 8 + 10);
+
+  ASSERT_EQ(layout.rowColumns.size(), 3);
+  EXPECT_EQ(layout.rowColumns[0].offset(), 0);
+  EXPECT_EQ(layout.rowColumns[0].nullByte(), 8);
+  EXPECT_EQ(layout.rowColumns[0].nullMask(), 0x1);
+  EXPECT_EQ(layout.rowColumns[1].offset(), 16);
+  EXPECT_EQ(layout.rowColumns[1].nullByte(), 9);
+  EXPECT_EQ(layout.rowColumns[1].nullMask(), 0x1);
+  EXPECT_EQ(layout.rowColumns[2].offset(), 24);
+  EXPECT_EQ(layout.rowColumns[2].nullByte(), 9);
+  EXPECT_EQ(layout.rowColumns[2].nullMask(), 0x4);
+}
+
+} // namespace
+} // namespace facebook::velox::exec::test


### PR DESCRIPTION
### Motivation

`RowContainer`'s constructor performed ~100 lines of byte-offset and null-bit accounting inline, mixing schema setup with raw layout math. This PR lifts the layout computation into a small, independently testable function so that the algorithm has a single owner and a dedicated unit test, and so future refactors that need the layout (e.g. a separate storage layer) can reuse it without re-deriving offsets.

### What changed

- New `velox/exec/RowLayout.{h,cpp}` declaring:
  - A `RowLayoutOptions` struct carrying the five layout-affecting flags (`nullableKeys`, `hasNext`, `hasProbedFlag`, `hasCountFlag`, `hasNormalizedKeys`) so callers use designated initializers instead of a positional bool list.
  - A `RowLayout` struct holding the computed offsets, flag bit positions, fixed row size, alignment, flag-region byte count, and `usesExternalMemory` flag.
  - `RowLayout::compute(keyTypes, accumulators, dependentTypes, options)` ported from the constructor body.
  - `RowLayout::typeKindSize(TypeKind)` as the single home for the in-row fixed-width size helper.
- `RowContainer.cpp` constructor now calls `RowLayout::compute(...)` with a `RowLayoutOptions` and assigns the result into its existing private fields. `types_` and `typeKinds_` are still populated in the constructor since they are schema, not layout. The constructor's giant layout doc comment is replaced by a short pointer to `RowLayout.h`. The duplicate `typeKindSize` previously living in `RowContainer.cpp`'s anonymous namespace is removed; all five call sites (`fixedSizeAt`, `extractSerializedRows` size accounting, `extractSerializedRows` value copy, `storeSerializedRow`) now call `RowLayout::typeKindSize`.
- New `velox/exec/tests/RowLayoutTest.cpp` with 16 cases:
  - 14 `verifyLayoutMatches(...)` cases (keys-only nullable/not, dependents, probed/count/next flags independently, fixed-size accumulator, 64-byte aligned accumulator, variable-width accumulator, normalized-key prefix, variable-width key, complex dependent types, all flags on, and a 12-key case forcing flag-region byte alignment) that build a real `RowContainer` and assert `RowLayout::compute()` produces the same `fixedRowSize`, `nextOffset`, `rowSizeOffset`, `probedFlagOffset`, `countOffset`, and per-column `(offset, nullByte, nullMask)` the container exposes through its public accessors.
  - 2 hand-traced golden-value cases (`goldenSimpleKeys`, `goldenHashJoinWithAccumulator`) that hard-code expected `fixedRowSize`, `flagBytes`, `alignment`, `freeFlagOffset`, `probedFlagOffset`, `nextOffset`, `countOffset`, `originalNormalizedKeySize`, every entry of `offsets` and `nullOffsets`, and every `RowColumn` triple. These lock in absolute correctness independent of the constructor and cover private layout fields the public-accessor tests cannot reach (`flagBytes`, `freeFlagOffset`, `alignment`, `originalNormalizedKeySize`, `usesExternalMemory`, the raw `offsets` / `nullOffsets` vectors).
- `velox/exec/CMakeLists.txt` and `velox/exec/tests/CMakeLists.txt` register the new files. `RowLayoutTest.cpp` joins the `velox_exec_test` grouped suite alongside `RowContainerTest.cpp`.