### PR TITLE
feat(cudf): Support aggregations on constants

### DIFF
--- a/velox/experimental/cudf/exec/CudfAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfAggregation.cpp
@@ -98,17 +98,29 @@ bool isCompanionAggregateName(std::string const& kind) {
       kind.find("_merge_extract") != std::string::npos;
 }
 
+bool isSupportedConstantAggregationName(std::string const& kind) {
+  const auto prefix = CudfConfig::getInstance().functionNamePrefix;
+  const auto originalName = getOriginalName(kind);
+  return originalName == prefix + "sum" || originalName == prefix + "avg" ||
+      originalName == prefix + "min" || originalName == prefix + "max" ||
+      originalName == prefix + "count";
+}
+
 bool isSupportedZeroColumnAggregation(
     const core::AggregationNode& aggregationNode) {
-  // Zero-column input: only global prefixed `count` aggregates (same as
-  // createAggregator). No GROUP BY keys.
+  // Zero-column input: global count(*) or aggregates over constants. No GROUP
+  // BY keys.
   return aggregationNode.groupingKeys().empty() &&
       !aggregationNode.aggregates().empty() &&
       std::all_of(
              aggregationNode.aggregates().begin(),
              aggregationNode.aggregates().end(),
              [](const auto& aggregate) {
-               return isCountFunctionName(aggregate.call->name());
+               return (isCountFunctionName(aggregate.call->name()) &&
+                       aggregate.call->inputs().empty()) ||
+                   (isSupportedConstantAggregationName(
+                        aggregate.call->name()) &&
+                    hasOnlyConstantArguments(*aggregate.call));
              });
 }
 } // namespace
@@ -180,7 +192,7 @@ AggregationInputChannels buildAggregationInputChannels(
         result.constants[i] = constant->toConstantVector(operatorCtx.pool());
         aggInputs.push_back(fallbackChannel);
       } else {
-        VELOX_NYI("Constants and lambdas not yet supported");
+        VELOX_NYI("Aggregation arguments must be columns or constants");
       }
     }
 
@@ -304,7 +316,8 @@ bool canAggregationBeEvaluatedByRegistry(
     return true;
   }
 
-  if (hasOnlyConstantArguments(call)) {
+  if (hasOnlyConstantArguments(call) &&
+      !isSupportedConstantAggregationName(call.name())) {
     return false;
   }
 

--- a/velox/experimental/cudf/exec/CudfGroupby.cpp
+++ b/velox/experimental/cudf/exec/CudfGroupby.cpp
@@ -34,6 +34,8 @@
 #include <cudf/detail/utilities/stream_pool.hpp>
 #include <cudf/unary.hpp>
 
+#include <limits>
+
 namespace {
 
 using namespace facebook::velox;
@@ -43,42 +45,80 @@ using cudf_velox::get_temp_mr;
 using cudf_velox::GroupbyAggregator;
 using cudf_velox::ResolvedAggregateInfo;
 
-#define DEFINE_SIMPLE_GROUPBY_AGGREGATOR(Name, name, KIND)                    \
-  struct Groupby##Name##Aggregator : GroupbyAggregator {                      \
-    Groupby##Name##Aggregator(                                                \
-        core::AggregationNode::Step step,                                     \
-        uint32_t inputIndex,                                                  \
-        VectorPtr constant,                                                   \
-        const TypePtr& resultType)                                            \
-        : GroupbyAggregator(step, inputIndex, constant, resultType) {}        \
-                                                                              \
-    void addGroupbyRequest(                                                   \
-        cudf::table_view const& tbl,                                          \
-        std::vector<cudf::groupby::aggregation_request>& requests) override { \
-      VELOX_CHECK(                                                            \
-          constant == nullptr,                                                \
-          #Name "Aggregator does not yet support constant input");            \
-      auto& request = requests.emplace_back();                                \
-      output_idx = requests.size() - 1;                                       \
-      request.values = tbl.column(inputIndex);                                \
-      request.aggregations.push_back(                                         \
-          cudf::make_##name##_aggregation<cudf::groupby_aggregation>());      \
-    }                                                                         \
-                                                                              \
-    std::unique_ptr<cudf::column> makeOutputColumn(                           \
-        std::vector<cudf::groupby::aggregation_result>& results,              \
-        rmm::cuda_stream_view stream) override {                              \
-      auto col = std::move(results[output_idx].results[0]);                   \
-      const auto cudfType =                                                   \
-          cudf::data_type(cudf_velox::veloxToCudfTypeId(resultType));         \
-      if (col->type() != cudfType) {                                          \
-        col = cudf::cast(*col, cudfType, stream, get_output_mr());            \
-      }                                                                       \
-      return col;                                                             \
-    }                                                                         \
-                                                                              \
-   private:                                                                   \
-    uint32_t output_idx;                                                      \
+std::unique_ptr<cudf::column> makeConstantInputColumn(
+    const VectorPtr& constant,
+    cudf::size_type rowCount,
+    rmm::cuda_stream_view stream) {
+  VELOX_CHECK_NOT_NULL(constant);
+  VELOX_CHECK_GE(rowCount, 0);
+  VELOX_CHECK_LE(rowCount, std::numeric_limits<vector_size_t>::max());
+
+  const auto size = static_cast<vector_size_t>(rowCount);
+  auto repeatedConstant = BaseVector::wrapInConstant(size, 0, constant);
+  auto row = std::make_shared<RowVector>(
+      constant->pool(),
+      ROW({"constant"}, {constant->type()}),
+      nullptr,
+      size,
+      std::vector<VectorPtr>{std::move(repeatedConstant)});
+
+  auto table = cudf_velox::with_arrow::toCudfTable(
+      row, constant->pool(), stream, get_temp_mr());
+  auto columns = table->release();
+  VELOX_CHECK_EQ(columns.size(), 1);
+  return std::move(columns[0]);
+}
+
+cudf::column_view aggregationInputColumn(
+    cudf::table_view const& tbl,
+    uint32_t inputIndex,
+    const VectorPtr& constant,
+    rmm::cuda_stream_view stream,
+    std::unique_ptr<cudf::column>& constantColumn) {
+  if (constant == nullptr) {
+    return tbl.column(inputIndex);
+  }
+
+  constantColumn = makeConstantInputColumn(constant, tbl.num_rows(), stream);
+  return constantColumn->view();
+}
+
+#define DEFINE_SIMPLE_GROUPBY_AGGREGATOR(Name, name, KIND)               \
+  struct Groupby##Name##Aggregator : GroupbyAggregator {                 \
+    Groupby##Name##Aggregator(                                           \
+        core::AggregationNode::Step step,                                \
+        uint32_t inputIndex,                                             \
+        VectorPtr constant,                                              \
+        const TypePtr& resultType)                                       \
+        : GroupbyAggregator(step, inputIndex, constant, resultType) {}   \
+                                                                         \
+    void addGroupbyRequest(                                              \
+        cudf::table_view const& tbl,                                     \
+        std::vector<cudf::groupby::aggregation_request>& requests,       \
+        rmm::cuda_stream_view stream) override {                         \
+      auto& request = requests.emplace_back();                           \
+      output_idx = requests.size() - 1;                                  \
+      request.values = aggregationInputColumn(                           \
+          tbl, inputIndex, constant, stream, constantColumn_);           \
+      request.aggregations.push_back(                                    \
+          cudf::make_##name##_aggregation<cudf::groupby_aggregation>()); \
+    }                                                                    \
+                                                                         \
+    std::unique_ptr<cudf::column> makeOutputColumn(                      \
+        std::vector<cudf::groupby::aggregation_result>& results,         \
+        rmm::cuda_stream_view stream) override {                         \
+      auto col = std::move(results[output_idx].results[0]);              \
+      const auto cudfType =                                              \
+          cudf::data_type(cudf_velox::veloxToCudfTypeId(resultType));    \
+      if (col->type() != cudfType) {                                     \
+        col = cudf::cast(*col, cudfType, stream, get_output_mr());       \
+      }                                                                  \
+      return col;                                                        \
+    }                                                                    \
+                                                                         \
+   private:                                                              \
+    uint32_t output_idx;                                                 \
+    std::unique_ptr<cudf::column> constantColumn_;                       \
   };
 
 DEFINE_SIMPLE_GROUPBY_AGGREGATOR(Sum, sum, SUM)
@@ -96,7 +136,8 @@ struct GroupbyCountAggregator : GroupbyAggregator {
 
   void addGroupbyRequest(
       cudf::table_view const& tbl,
-      std::vector<cudf::groupby::aggregation_request>& requests) override {
+      std::vector<cudf::groupby::aggregation_request>& requests,
+      rmm::cuda_stream_view /*stream*/) override {
     auto& request = requests.emplace_back();
     outputIndex_ = requests.size() - 1;
     // kCountAll and kNullConstant both submit a count-all-rows request;
@@ -150,12 +191,14 @@ struct GroupbyMeanAggregator : GroupbyAggregator {
 
   void addGroupbyRequest(
       cudf::table_view const& tbl,
-      std::vector<cudf::groupby::aggregation_request>& requests) override {
+      std::vector<cudf::groupby::aggregation_request>& requests,
+      rmm::cuda_stream_view stream) override {
     switch (step) {
       case core::AggregationNode::Step::kSingle: {
         auto& request = requests.emplace_back();
         meanIdx_ = requests.size() - 1;
-        request.values = tbl.column(inputIndex);
+        request.values = aggregationInputColumn(
+            tbl, inputIndex, constant, stream, constantColumn_);
         request.aggregations.push_back(
             cudf::make_mean_aggregation<cudf::groupby_aggregation>());
         break;
@@ -163,7 +206,8 @@ struct GroupbyMeanAggregator : GroupbyAggregator {
       case core::AggregationNode::Step::kPartial: {
         auto& request = requests.emplace_back();
         sumIdx_ = requests.size() - 1;
-        request.values = tbl.column(inputIndex);
+        request.values = aggregationInputColumn(
+            tbl, inputIndex, constant, stream, constantColumn_);
         request.aggregations.push_back(
             cudf::make_sum_aggregation<cudf::groupby_aggregation>());
         request.aggregations.push_back(
@@ -293,6 +337,7 @@ struct GroupbyMeanAggregator : GroupbyAggregator {
   uint32_t meanIdx_;
   uint32_t sumIdx_;
   uint32_t countIdx_;
+  std::unique_ptr<cudf::column> constantColumn_;
 };
 
 std::unique_ptr<GroupbyAggregator> createGroupbyAggregator(
@@ -659,7 +704,7 @@ CudfVectorPtr CudfGroupby::doGroupByAggregation(
 
   std::vector<cudf::groupby::aggregation_request> requests;
   for (auto& aggregator : aggregators) {
-    aggregator->addGroupbyRequest(tableView, requests);
+    aggregator->addGroupbyRequest(tableView, requests, stream);
   }
 
   auto [groupKeys, results] =

--- a/velox/experimental/cudf/exec/CudfGroupby.h
+++ b/velox/experimental/cudf/exec/CudfGroupby.h
@@ -30,7 +30,8 @@ struct GroupbyAggregator {
 
   virtual void addGroupbyRequest(
       cudf::table_view const& tbl,
-      std::vector<cudf::groupby::aggregation_request>& requests) = 0;
+      std::vector<cudf::groupby::aggregation_request>& requests,
+      rmm::cuda_stream_view stream) = 0;
 
   virtual std::unique_ptr<cudf::column> makeOutputColumn(
       std::vector<cudf::groupby::aggregation_result>& results,

--- a/velox/experimental/cudf/exec/CudfReduce.cpp
+++ b/velox/experimental/cudf/exec/CudfReduce.cpp
@@ -36,6 +36,8 @@
 #include <cudf/unary.hpp>
 #include <cudf/utilities/error.hpp>
 
+#include <limits>
+
 namespace {
 
 using namespace facebook::velox;
@@ -45,33 +47,76 @@ using facebook::velox::cudf_velox::get_temp_mr;
 using facebook::velox::cudf_velox::ReduceAggregator;
 using facebook::velox::cudf_velox::ResolvedAggregateInfo;
 
-#define DEFINE_SIMPLE_REDUCE_AGGREGATOR(Name, name)                    \
-  struct Reduce##Name##Aggregator : ReduceAggregator {                 \
-    Reduce##Name##Aggregator(                                          \
-        core::AggregationNode::Step step,                              \
-        uint32_t inputIndex,                                           \
-        VectorPtr constant,                                            \
-        const TypePtr& resultType)                                     \
-        : ReduceAggregator(step, inputIndex, constant, resultType) {}  \
-                                                                       \
-    std::unique_ptr<cudf::column> doReduce(                            \
-        cudf::table_view const& input,                                 \
-        TypePtr const& outputType,                                     \
-        rmm::cuda_stream_view stream,                                  \
-        vector_size_t /*inputRowCount*/) override {                    \
-      auto const aggRequest =                                          \
-          cudf::make_##name##_aggregation<cudf::reduce_aggregation>(); \
-      auto const cudfOutputType =                                      \
-          cudf::data_type(cudf_velox::veloxToCudfTypeId(outputType));  \
-      auto const resultScalar = cudf::reduce(                          \
-          input.column(inputIndex),                                    \
-          *aggRequest,                                                 \
-          cudfOutputType,                                              \
-          stream,                                                      \
-          get_temp_mr());                                              \
-      return cudf::make_column_from_scalar(                            \
-          *resultScalar, 1, stream, get_output_mr());                  \
-    }                                                                  \
+std::unique_ptr<cudf::column> makeConstantInputColumn(
+    const VectorPtr& constant,
+    cudf::size_type rowCount,
+    rmm::cuda_stream_view stream) {
+  VELOX_CHECK_NOT_NULL(constant);
+  VELOX_CHECK_GE(rowCount, 0);
+  VELOX_CHECK_LE(rowCount, std::numeric_limits<vector_size_t>::max());
+
+  const auto size = static_cast<vector_size_t>(rowCount);
+  auto repeatedConstant = BaseVector::wrapInConstant(size, 0, constant);
+  auto row = std::make_shared<RowVector>(
+      constant->pool(),
+      ROW({"constant"}, {constant->type()}),
+      nullptr,
+      size,
+      std::vector<VectorPtr>{std::move(repeatedConstant)});
+
+  auto table = cudf_velox::with_arrow::toCudfTable(
+      row, constant->pool(), stream, get_temp_mr());
+  auto columns = table->release();
+  VELOX_CHECK_EQ(columns.size(), 1);
+  return std::move(columns[0]);
+}
+
+cudf::column_view aggregationInputColumn(
+    cudf::table_view const& input,
+    uint32_t inputIndex,
+    const VectorPtr& constant,
+    vector_size_t inputRowCount,
+    rmm::cuda_stream_view stream,
+    std::unique_ptr<cudf::column>& constantColumn) {
+  if (constant == nullptr) {
+    return input.column(inputIndex);
+  }
+
+  VELOX_CHECK_GE(inputRowCount, 0);
+  VELOX_CHECK_LE(inputRowCount, std::numeric_limits<cudf::size_type>::max());
+  const auto rowCount = input.num_columns() == 0
+      ? static_cast<cudf::size_type>(inputRowCount)
+      : input.num_rows();
+  constantColumn = makeConstantInputColumn(constant, rowCount, stream);
+  return constantColumn->view();
+}
+
+#define DEFINE_SIMPLE_REDUCE_AGGREGATOR(Name, name)                            \
+  struct Reduce##Name##Aggregator : ReduceAggregator {                         \
+    Reduce##Name##Aggregator(                                                  \
+        core::AggregationNode::Step step,                                      \
+        uint32_t inputIndex,                                                   \
+        VectorPtr constant,                                                    \
+        const TypePtr& resultType)                                             \
+        : ReduceAggregator(step, inputIndex, constant, resultType) {}          \
+                                                                               \
+    std::unique_ptr<cudf::column> doReduce(                                    \
+        cudf::table_view const& input,                                         \
+        TypePtr const& outputType,                                             \
+        rmm::cuda_stream_view stream,                                          \
+        vector_size_t inputRowCount) override {                                \
+      std::unique_ptr<cudf::column> constantColumn;                            \
+      const auto inputColumn = aggregationInputColumn(                         \
+          input, inputIndex, constant, inputRowCount, stream, constantColumn); \
+      auto const aggRequest =                                                  \
+          cudf::make_##name##_aggregation<cudf::reduce_aggregation>();         \
+      auto const cudfOutputType =                                              \
+          cudf::data_type(cudf_velox::veloxToCudfTypeId(outputType));          \
+      auto const resultScalar = cudf::reduce(                                  \
+          inputColumn, *aggRequest, cudfOutputType, stream, get_temp_mr());    \
+      return cudf::make_column_from_scalar(                                    \
+          *resultScalar, 1, stream, get_output_mr());                          \
+    }                                                                          \
   };
 
 DEFINE_SIMPLE_REDUCE_AGGREGATOR(Sum, sum)
@@ -152,19 +197,18 @@ struct ReduceMeanAggregator : ReduceAggregator {
       cudf::table_view const& input,
       TypePtr const& outputType,
       rmm::cuda_stream_view stream,
-      vector_size_t /*inputRowCount*/) override {
+      vector_size_t inputRowCount) override {
     switch (step) {
       case core::AggregationNode::Step::kSingle: {
+        std::unique_ptr<cudf::column> constantColumn;
+        const auto inputColumn = aggregationInputColumn(
+            input, inputIndex, constant, inputRowCount, stream, constantColumn);
         auto const aggRequest =
             cudf::make_mean_aggregation<cudf::reduce_aggregation>();
         auto const cudfOutputType =
             cudf::data_type(cudf_velox::veloxToCudfTypeId(outputType));
         auto const resultScalar = cudf::reduce(
-            input.column(inputIndex),
-            *aggRequest,
-            cudfOutputType,
-            stream,
-            get_temp_mr());
+            inputColumn, *aggRequest, cudfOutputType, stream, get_temp_mr());
         return cudf::make_column_from_scalar(
             *resultScalar, 1, stream, get_output_mr());
       }
@@ -177,16 +221,15 @@ struct ReduceMeanAggregator : ReduceAggregator {
             cudf::data_type(cudf_velox::veloxToCudfTypeId(sumType));
         auto const cudfCountType =
             cudf::data_type(cudf_velox::veloxToCudfTypeId(countType));
+        std::unique_ptr<cudf::column> constantColumn;
+        const auto inputColumn = aggregationInputColumn(
+            input, inputIndex, constant, inputRowCount, stream, constantColumn);
 
         // sum
         auto const aggRequest =
             cudf::make_sum_aggregation<cudf::reduce_aggregation>();
         auto const sumResultScalar = cudf::reduce(
-            input.column(inputIndex),
-            *aggRequest,
-            cudfSumType,
-            stream,
-            get_temp_mr());
+            inputColumn, *aggRequest, cudfSumType, stream, get_temp_mr());
         auto sumCol = cudf::make_column_from_scalar(
             *sumResultScalar, 1, stream, get_output_mr());
 
@@ -194,8 +237,7 @@ struct ReduceMeanAggregator : ReduceAggregator {
         // count the number of valid rows.
         auto countCol = cudf::make_column_from_scalar(
             cudf::numeric_scalar<int64_t>(
-                input.column(inputIndex).size() -
-                    input.column(inputIndex).null_count(),
+                inputColumn.size() - inputColumn.null_count(),
                 true,
                 stream,
                 get_temp_mr()),
@@ -207,6 +249,45 @@ struct ReduceMeanAggregator : ReduceAggregator {
         auto children = std::vector<std::unique_ptr<cudf::column>>();
         children.push_back(std::move(sumCol));
         children.push_back(std::move(countCol));
+        return std::make_unique<cudf::column>(
+            cudf::data_type(cudf::type_id::STRUCT),
+            1,
+            rmm::device_buffer{},
+            rmm::device_buffer{},
+            0,
+            std::move(children));
+      }
+      case core::AggregationNode::Step::kIntermediate: {
+        VELOX_CHECK(outputType->isRow());
+        auto const& rowType = outputType->asRow();
+        auto const sumType = rowType.childAt(0);
+        auto const countType = rowType.childAt(1);
+        auto const cudfSumType =
+            cudf::data_type(cudf_velox::veloxToCudfTypeId(sumType));
+        auto const cudfCountType =
+            cudf::data_type(cudf_velox::veloxToCudfTypeId(countType));
+
+        auto const inputColumn = input.column(inputIndex);
+        auto const sumCol = inputColumn.child(0);
+        auto const countCol = inputColumn.child(1);
+
+        auto const sumAggRequest =
+            cudf::make_sum_aggregation<cudf::reduce_aggregation>();
+        auto const sumResultScalar = cudf::reduce(
+            sumCol, *sumAggRequest, cudfSumType, stream, get_temp_mr());
+        auto sumResultCol = cudf::make_column_from_scalar(
+            *sumResultScalar, 1, stream, get_output_mr());
+
+        auto const countAggRequest =
+            cudf::make_sum_aggregation<cudf::reduce_aggregation>();
+        auto const countResultScalar = cudf::reduce(
+            countCol, *countAggRequest, cudfCountType, stream, get_temp_mr());
+        auto countResultCol = cudf::make_column_from_scalar(
+            *countResultScalar, 1, stream, get_output_mr());
+
+        auto children = std::vector<std::unique_ptr<cudf::column>>();
+        children.push_back(std::move(sumResultCol));
+        children.push_back(std::move(countResultCol));
         return std::make_unique<cudf::column>(
             cudf::data_type(cudf::type_id::STRUCT),
             1,

--- a/velox/experimental/cudf/tests/AggregationSelectionTest.cpp
+++ b/velox/experimental/cudf/tests/AggregationSelectionTest.cpp
@@ -138,6 +138,16 @@ TEST_F(CudfAggregationSelectionTest, supportedAggregationFunctions) {
   ASSERT_TRUE(canBeEvaluatedByCudf(*aggregationNode, queryCtx_.get()));
 }
 
+TEST_F(CudfAggregationSelectionTest, supportedConstantAggregationFunctions) {
+  auto globalAggregationNode =
+      createAggregationNode({}, {"sum(1)", "avg(1)", "min(1)", "max(1)"});
+  ASSERT_TRUE(canBeEvaluatedByCudf(*globalAggregationNode, queryCtx_.get()));
+
+  auto groupedAggregationNode =
+      createAggregationNode({"c0"}, {"sum(1)", "avg(1)", "min(1)", "max(1)"});
+  ASSERT_TRUE(canBeEvaluatedByCudf(*groupedAggregationNode, queryCtx_.get()));
+}
+
 // Test unsupported aggregation functions
 TEST_F(CudfAggregationSelectionTest, unsupportedAggregationFunctions) {
   auto aggregationNode =

--- a/velox/experimental/cudf/tests/AggregationTest.cpp
+++ b/velox/experimental/cudf/tests/AggregationTest.cpp
@@ -75,8 +75,6 @@ class AggregationTest : public OperatorTestBase {
       bool distinct) {
     std::vector<std::string> aggregates;
     if (!distinct) {
-      // TODO (dm): "sum(15)", "sum(0.1)",  "min(15)",  "min(0.1)", "max(15)",
-      // "max(0.1)",
       aggregates = {
           "sum(c1)",
           "sum(c2)",
@@ -111,8 +109,6 @@ class AggregationTest : public OperatorTestBase {
     if (distinct) {
       assertQuery(op, "SELECT distinct " + keyName + " " + fromClause);
     } else {
-      // TODO (dm): sum(15), sum(cast(0.1 as double)), min(15), min(0.1),
-      // max(15), max(0.1),
       assertQuery(
           op,
           "SELECT " + keyName +
@@ -126,8 +122,6 @@ class AggregationTest : public OperatorTestBase {
       bool ignoreNullKeys,
       bool distinct) {
     std::vector<std::string> aggregates;
-    // TODO (dm): "sum(15)", "sum(0.1)",  "min(15)",  "min(0.1)", "max(15)",
-    // "max(0.1)"
     if (!distinct) {
       aggregates = {
           "sum(c4)",
@@ -157,8 +151,6 @@ class AggregationTest : public OperatorTestBase {
     if (distinct) {
       assertQuery(op, "SELECT distinct c0, c1, c6 " + fromClause);
     } else {
-      // TODO (dm): sum(15), sum(cast(0.1 as double)), min(15), min(0.1),
-      // max(15), max(0.1),, sum(1)
       assertQuery(
           op,
           "SELECT c0, c1, c6, sum(c4), sum(c5), min(c3), min(c4), min(c5),  max(c3), max(c4), max(c5) " +
@@ -227,7 +219,6 @@ TEST_F(AggregationTest, global) {
   auto vectors = makeVectors(rowType_, 10, 100);
   createDuckDbTable(vectors);
 
-  // DM: removed "sum(15)","min(15)","max(15)",
   auto op = PlanBuilder()
                 .values(vectors)
                 .aggregation(
@@ -253,7 +244,6 @@ TEST_F(AggregationTest, global) {
                     false)
                 .planNode();
 
-  // DM: removed sum(15), min(15), max(15),
   assertQuery(
       op,
       "SELECT sum(c1), sum(c2), sum(c4), sum(c5), "
@@ -370,6 +360,44 @@ TEST_F(AggregationTest, varcharMinMax) {
   assertQuery(op, "SELECT min(c6), max(c6) FROM tmp");
 }
 
+TEST_F(AggregationTest, constantAggregationsGlobal) {
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>({1, 2, 3, 4}),
+  });
+  createDuckDbTable({data});
+
+  for (const auto steps :
+       {AggSteps::kSingle,
+        AggSteps::kPartialFinal,
+        AggSteps::kPartialIntermediateFinal}) {
+    testAggregation(
+        {data},
+        {},
+        {"sum(1)", "avg(1)", "min(1)", "max(1)", "min('x')", "max('x')"},
+        "SELECT sum(1), avg(1), min(1), max(1), min('x'), max('x') FROM tmp",
+        steps);
+  }
+}
+
+TEST_F(AggregationTest, constantAggregationsGroupBy) {
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>({1, 1, 2, 2, 2}),
+  });
+  createDuckDbTable({data});
+
+  for (const auto steps :
+       {AggSteps::kSingle,
+        AggSteps::kPartialFinal,
+        AggSteps::kPartialIntermediateFinal}) {
+    testAggregation(
+        {data},
+        {"c0"},
+        {"sum(1)", "avg(1)", "min(1)", "max(1)"},
+        "SELECT c0, sum(1), avg(1), min(1), max(1) FROM tmp GROUP BY c0",
+        steps);
+  }
+}
+
 TEST_F(AggregationTest, allKeyTypes) {
   // Covers different key types. Unlike the integer/string tests, the
   // hash table begins life in the generic mode, not array or
@@ -388,13 +416,12 @@ TEST_F(AggregationTest, allKeyTypes) {
   auto op =
       PlanBuilder()
           .values(batches)
-          .singleAggregation({"c0", "c1", "c2", "c3", "c4", "c5"}, {"sum(c6)"})
+          .singleAggregation({"c0", "c1", "c2", "c3", "c4", "c5"}, {"sum(1)"})
           .planNode();
 
-  // DM: Instead of sum(c6), this was sum(1) but we don't yet support constants
   assertQuery(
       op,
-      "SELECT c0, c1, c2, c3, c4, c5, sum(c6) FROM tmp "
+      "SELECT c0, c1, c2, c3, c4, c5, sum(1) FROM tmp "
       " GROUP BY c0, c1, c2, c3, c4, c5");
 }
 

--- a/velox/experimental/cudf/tests/ToCudfSelectionTest.cpp
+++ b/velox/experimental/cudf/tests/ToCudfSelectionTest.cpp
@@ -364,8 +364,8 @@ TEST_F(ToCudfSelectionTest, unsupportedAggregationInputExpressionsFallsBack) {
   ASSERT_TRUE(wasDefaultHashAggregationUsed(task));
 }
 
-// Non-count constant aggregates are not supported by cuDF aggregation.
-TEST_F(ToCudfSelectionTest, nonCountConstantAggregationFallsBack) {
+// Non-count constant aggregates should use cuDF aggregation.
+TEST_F(ToCudfSelectionTest, nonCountConstantAggregationUsesCudf) {
   auto vectors = makeVectors(rowType_, 10, 100);
   createDuckDbTable(vectors);
 
@@ -381,8 +381,8 @@ TEST_F(ToCudfSelectionTest, nonCountConstantAggregationFallsBack) {
                   .plan(plan)
                   .assertResults("SELECT sum(1) FROM tmp");
 
-  ASSERT_FALSE(wasCudfAggregationUsed(task));
-  ASSERT_TRUE(wasDefaultHashAggregationUsed(task));
+  ASSERT_TRUE(wasCudfAggregationUsed(task));
+  ASSERT_FALSE(wasDefaultHashAggregationUsed(task));
 }
 
 // Test zero-column count(*) should stay on GPU.
@@ -430,6 +430,35 @@ TEST_F(ToCudfSelectionTest, zeroColumnCountConstantUsesGpu) {
                   .config("cudf.enabled", true)
                   .plan(plan)
                   .assertResults("SELECT count(1) FROM tmp WHERE c0 > 0");
+
+  ASSERT_TRUE(wasCudfAggregationUsed(task));
+  ASSERT_FALSE(wasDefaultHashAggregationUsed(task));
+}
+
+TEST_F(ToCudfSelectionTest, zeroColumnConstantAggregationsUseGpu) {
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>({1, 2, 3, 4}),
+  });
+  createDuckDbTable({data});
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .filter("c0 > 0")
+                  .project({})
+                  .aggregation(
+                      {},
+                      {"sum(1)", "avg(1)", "min(1)", "max(1)"},
+                      {},
+                      core::AggregationNode::Step::kSingle,
+                      false)
+                  .planNode();
+
+  auto task =
+      AssertQueryBuilder(duckDbQueryRunner_)
+          .config("cudf.enabled", true)
+          .plan(plan)
+          .assertResults(
+              "SELECT sum(1), avg(1), min(1), max(1) FROM tmp WHERE c0 > 0");
 
   ASSERT_TRUE(wasCudfAggregationUsed(task));
   ASSERT_FALSE(wasDefaultHashAggregationUsed(task));


### PR DESCRIPTION
Summary:

Add cuDF support for aggregations whose inputs are constants. This allows
SUM(1), AVG(1), MIN(1), MAX(1), COUNT(1), and zero-column constant aggregate
plans to stay on the cuDF aggregation path instead of falling back to CPU.

The implementation materializes constant aggregate inputs as cuDF columns for
reduce and group-by aggregation, keeps the temporary columns alive through the
cuDF request, and updates selection logic to accept supported constant
aggregates while still rejecting unsupported constant-only aggregate calls.

Tests:

- clang-format -i on modified files
- git diff --check upstream/main...HEAD
- Built these targeted Docker targets using
  cmake --build _build/release-source-cudf-split:
  velox_cudf_aggregation_test, velox_cudf_tocudf_selection_test, and
  velox_cudf_aggregation_selection_test



Fixes #16537