### PR TITLE
build: Surface per-instance fuzzer state on cancel/timeout (#17414)

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -509,7 +509,7 @@ jobs:
                 --repro_persist_path=__REPRO_DIR__
 
       - name: Archive production artifacts
-        if: ${{ !cancelled() }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: presto-fuzzer-failure-artifacts
@@ -587,7 +587,7 @@ jobs:
                 --table_name_prefix=i__INSTANCE_ID__
 
       - name: Archive expression production artifacts
-        if: ${{ !cancelled() }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: presto-sot-fuzzer-failure-artifacts
@@ -654,7 +654,7 @@ jobs:
             && echo -e "\n\nPresto Fuzzer run finished successfully."
 
       - name: Archive Presto Bias expression production artifacts
-        if: ${{ !cancelled() }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: presto-bias-fuzzer-failure-artifacts
@@ -703,7 +703,7 @@ jobs:
                 --table_name_prefix=i__INSTANCE_ID__
 
       - name: Archive Spark aggregate production artifacts
-        if: ${{ !cancelled() }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: spark-agg-fuzzer-failure-artifacts
@@ -761,7 +761,7 @@ jobs:
             && echo -e "\n\nSpark Fuzzer run finished successfully."
 
       - name: Archive Spark expression production artifacts
-        if: ${{ !cancelled() }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: spark-fuzzer-failure-artifacts
@@ -814,7 +814,7 @@ jobs:
                 --repro_persist_path=__REPRO_DIR__
 
       - name: Archive Spark expression production artifacts
-        if: ${{ !cancelled() }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: spark-fuzzer-failure-artifacts
@@ -882,7 +882,7 @@ jobs:
                 --table_name_prefix=i__INSTANCE_ID__
 
       - name: Archive join production artifacts
-        if: ${{ !cancelled() }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: presto-sot-join-fuzzer-failure-artifacts
@@ -929,7 +929,7 @@ jobs:
                 --repro_path=__REPRO_DIR__
 
       - name: Archive Exchange production artifacts
-        if: ${{ !cancelled() }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: exchange-fuzzer-failure-artifacts
@@ -998,7 +998,7 @@ jobs:
                 --table_name_prefix=i__INSTANCE_ID__
 
       - name: Archive row number production artifacts
-        if: ${{ !cancelled() }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: row-fuzzer-failure-artifacts
@@ -1067,7 +1067,7 @@ jobs:
                 --table_name_prefix=i__INSTANCE_ID__
 
       - name: Archive topn row number production artifacts
-        if: ${{ !cancelled() }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: topn-row-fuzzer-failure-artifacts
@@ -1111,7 +1111,7 @@ jobs:
                 --log_dir=__LOG_DIR__
 
       - name: Archive Cache production artifacts
-        if: ${{ !cancelled() }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: cache-fuzzer-logs
@@ -1153,7 +1153,7 @@ jobs:
                 --log_dir=__LOG_DIR__
 
       - name: Archive table evolution production artifacts
-        if: ${{ !cancelled() }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: table-evolution-fuzzer-test-logs
@@ -1195,12 +1195,12 @@ jobs:
                 --log_dir=__LOG_DIR__
 
       - name: Archive memory arbitration production artifacts
-        if: ${{ !cancelled() }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: memory-arbitration-fuzzer-test-logs
           path: |
-            /tmp/memory_arbitration_fuzzer_test
+            /tmp/memory_arbitration_fuzzer
 
   presto-java-aggregation-fuzzer-run:
     name: Aggregation Fuzzer with Presto as source of truth
@@ -1265,7 +1265,7 @@ jobs:
                 --table_name_prefix=i__INSTANCE_ID__
 
       - name: Archive aggregate production artifacts
-        if: ${{ !cancelled() }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: presto-sot-aggregate-fuzzer-failure-artifacts
@@ -1365,7 +1365,7 @@ jobs:
                 --repro_persist_path=/tmp/presto_only_bias_function_fuzzer_repro \
           && echo -e "\n\nPresto Fuzzer run finished successfully."
       - name: Archive Presto only-bias-function expression fuzzer production artifacts
-        if: ${{ !cancelled() }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: presto-only-bias-function-fuzzer-failure-artifacts
@@ -1449,7 +1449,7 @@ jobs:
           && echo -e "\n\nAggregation fuzzer run finished successfully."
 
       - name: Archive bias aggregate production artifacts
-        if: ${{ !cancelled() }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: presto-bias-sot-aggregate-fuzzer-failure-artifacts
@@ -1545,7 +1545,7 @@ jobs:
                 --table_name_prefix=i__INSTANCE_ID__
 
       - name: Archive window production artifacts
-        if: ${{ !cancelled() }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: presto-sot-window-fuzzer-failure-artifacts
@@ -1618,7 +1618,7 @@ jobs:
                 --table_name_prefix=i__INSTANCE_ID__
 
       - name: Archive writer production artifacts
-        if: ${{ !cancelled() }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: presto-sot-writer-fuzzer-failure-artifacts
@@ -1662,7 +1662,7 @@ jobs:
                 --log_dir=__LOG_DIR__
 
       - name: Archive spatial join fuzzer production artifacts
-        if: ${{ !cancelled() }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: spatial-join-fuzzer-failure-artifacts

--- a/scripts/ci/run-fuzzer-parallel.sh
+++ b/scripts/ci/run-fuzzer-parallel.sh
@@ -31,7 +31,44 @@ BINARY=$3
 shift 3
 
 PIDS=()
+SEEDS=()
 FAILED=0
+
+dump_instance() {
+  local idx=$1
+  echo "=== Instance ${idx} stdout (last 200 lines) ==="
+  tail -200 "${REPRO_BASE}/instance_${idx}/stdout.log" 2>/dev/null ||
+    echo "(no stdout.log)"
+  echo "=== End instance ${idx} ==="
+}
+
+# When the GH Actions step timeout fires it sends SIGTERM. Without this trap
+# `wait` blocks indefinitely, the per-instance stdout is never surfaced, and
+# the only signal in the job log is "context canceled" with no diagnostics.
+on_signal() {
+  local sig=$1
+  echo "::warning::run-fuzzer-parallel.sh received ${sig}; dumping per-instance state"
+  for i in "${!PIDS[@]}"; do
+    local idx=$((i + 1))
+    local pid=${PIDS[$i]}
+    if kill -0 "$pid" 2>/dev/null; then
+      echo "::error::Instance ${idx} (PID ${pid}, seed=${SEEDS[$i]}) still running at ${sig}; sending SIGTERM"
+      kill -TERM "$pid" 2>/dev/null || true
+    fi
+  done
+  sleep 5
+  for i in "${!PIDS[@]}"; do
+    local idx=$((i + 1))
+    local pid=${PIDS[$i]}
+    if kill -0 "$pid" 2>/dev/null; then
+      kill -KILL "$pid" 2>/dev/null || true
+    fi
+    dump_instance "$idx"
+  done
+  exit 124
+}
+trap 'on_signal SIGTERM' TERM
+trap 'on_signal SIGINT' INT
 
 for i in $(seq 1 "$NUM_INSTANCES"); do
   REPRO_DIR="${REPRO_BASE}/instance_${i}"
@@ -52,6 +89,7 @@ for i in $(seq 1 "$NUM_INSTANCES"); do
   echo "Starting instance ${i}: seed=${SEED}, repro=${REPRO_DIR}"
   "$BINARY" "${INSTANCE_ARGS[@]}" >"${REPRO_DIR}/stdout.log" 2>&1 &
   PIDS+=($!)
+  SEEDS+=("$SEED")
 done
 
 echo "Waiting for ${NUM_INSTANCES} instances to complete..."
@@ -59,13 +97,11 @@ echo "Waiting for ${NUM_INSTANCES} instances to complete..."
 for i in "${!PIDS[@]}"; do
   IDX=$((i + 1))
   if ! wait "${PIDS[$i]}"; then
-    echo "::error::Fuzzer instance ${IDX} FAILED (PID ${PIDS[$i]})"
-    echo "=== Instance ${IDX} stdout (last 100 lines) ==="
-    tail -100 "${REPRO_BASE}/instance_${IDX}/stdout.log" || true
-    echo "=== End instance ${IDX} ==="
+    echo "::error::Fuzzer instance ${IDX} FAILED (PID ${PIDS[$i]}, seed=${SEEDS[$i]})"
+    dump_instance "$IDX"
     FAILED=$((FAILED + 1))
   else
-    echo "Instance ${IDX} passed"
+    echo "Instance ${IDX} passed (seed=${SEEDS[$i]})"
   fi
 done
 


### PR DESCRIPTION
Summary:

Two recent `Fuzzer Jobs` runs (Spark Fuzzer 2026-05-05, Memory Arbitration Fuzzer 2026-05-01) hung on a single instance and were killed by the workflow `timeout-minutes: 30`, leaving only "context canceled" in the logs. The same workflow succeeded on most other 4-core-ubuntu runners in the same run, so the hangs look like per-runner-instance flakiness rather than workload oversubscription.

We can't diagnose the hangs because per-instance `stdout.log` files are written under `${REPRO_DIR}/instance_${i}/` and the archive steps used `if: ${{ !cancelled() }}`, which deliberately skips upload on the exact failure mode we care about. The bash script also had no signal handler, so on SIGTERM it died inside `wait` without dumping anything.

This change is logging-only — no behavior change to fuzzer execution.

`scripts/ci/run-fuzzer-parallel.sh`:
- Track per-instance seeds in `SEEDS` array; include them in pass/fail messages.
- Add `dump_instance` helper and a SIGTERM/SIGINT trap that warns about still-running children, SIGTERMs them, sleeps 5s, SIGKILLs survivors, dumps each instance's `stdout.log` tail (last 200 lines), and exits 124.

`.github/workflows/scheduled.yml`:
- Replace all 19 `if: ${{ !cancelled() }}` on archive steps with `if: ${{ always() }}` so per-instance artifacts upload on cancel.
- Fix Memory Arbitration archive path: `/tmp/memory_arbitration_fuzzer_test` → `/tmp/memory_arbitration_fuzzer` (the binary writes to the latter; the suffixed path was always empty).

Reviewed By: kgpai

Differential Revision: D103932791


