### PR TITLE
feat: Add IndexSource lookupTiming and per-phase index lookup stats

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -26,6 +26,7 @@
 #include "velox/common/config/ConfigProvider.h"
 #include "velox/common/file/TokenProvider.h"
 #include "velox/common/future/VeloxPromise.h"
+#include "velox/common/time/CpuWallTimer.h"
 #include "velox/core/ExpressionEvaluator.h"
 #include "velox/core/QueryConfig.h"
 #include "velox/exec/SpillStats.h"
@@ -414,6 +415,25 @@ class IndexSource {
   virtual std::shared_ptr<ResultIterator> lookup(const Request& request) = 0;
 
   virtual std::unordered_map<std::string, RuntimeMetric> runtimeStats() = 0;
+
+  /// Returns cumulative timing for lookup operations performed by this
+  /// IndexSource. Used by IndexLookupJoin to attribute time to the
+  /// IndexSource node in the operator stats tree.
+  ///
+  /// - count: number of completed lookup iterations.
+  /// - wallNanos: total wall time across all lookup phases.
+  /// - cpuNanos: total CPU time consumed by the IndexSource (excludes
+  ///   probe-side work attributed to the join).
+  ///
+  /// NOTE: CPU time may undercount actual CPU consumption: CpuWallTimer
+  /// measures CPU on the calling thread only, so any work performed on prefetch
+  /// worker threads or async I/O completion handlers is not included.
+  ///
+  /// Default returns zero timing for IndexSource implementations that don't
+  /// track per-lookup timing.
+  virtual CpuWallTiming lookupTiming() const {
+    return CpuWallTiming{};
+  }
 };
 
 /// Collection of context data for use in a DataSource, IndexSource or DataSink.

--- a/velox/connectors/hive/HiveIndexSource.cpp
+++ b/velox/connectors/hive/HiveIndexSource.cpp
@@ -1041,6 +1041,12 @@ void HiveIndexSource::recordIterationStats(
   const auto totalWallNs = iterationStats.setupWallNs +
       iterationStats.readWallNs + iterationStats.outputWallNs +
       iterationStats.filterWallNs;
+  const auto totalCpuNs = iterationStats.setupCpuNs + iterationStats.readCpuNs +
+      iterationStats.outputCpuNs + iterationStats.filterCpuNs;
+  ++lookupTiming_.count;
+  lookupTiming_.wallNanos += totalWallNs;
+  lookupTiming_.cpuNanos += totalCpuNs;
+
   if (totalWallNs != 0) {
     exec::addOperatorRuntimeStats(
         IterationStats::kConnectorLookupWallNanos,

--- a/velox/connectors/hive/HiveIndexSource.h
+++ b/velox/connectors/hive/HiveIndexSource.h
@@ -61,6 +61,10 @@ class HiveIndexSource : public IndexSource,
 
   std::unordered_map<std::string, RuntimeMetric> runtimeStats() override;
 
+  CpuWallTiming lookupTiming() const override {
+    return lookupTiming_;
+  }
+
  private:
   friend class HiveLookupIterator;
 
@@ -219,6 +223,10 @@ class HiveIndexSource : public IndexSource,
 
   // Per-call timing stats accumulated via addOperatorRuntimeStats().
   std::unordered_map<std::string, RuntimeMetric> runtimeStats_;
+
+  // Cumulative end-to-end lookup timing. Updated once per iteration in
+  // recordIterationStats(). Returned by lookupTiming().
+  CpuWallTiming lookupTiming_;
 };
 
 } // namespace facebook::velox::connector::hive

--- a/velox/docs/monitoring/stats.rst
+++ b/velox/docs/monitoring/stats.rst
@@ -426,8 +426,9 @@ These stats are reported only by connector data or index sources.
    * - numIndexLookupStripes
      -
      - The total number of stripes that need to be read for all index lookup
-       requests. Multiple requests may share the same stripe, and each shared
-       stripe is counted once per request that needs it.
+       requests. Within a single startLookup() call, a stripe shared by
+       multiple requests is counted once; across different startLookup() calls,
+       the same stripe is counted separately for each call.
    * - numIndexMatchedRows
      -
      - The total number of rows matched by the cluster index across all stripes.
@@ -445,6 +446,27 @@ These stats are reported only by connector data or index sources.
      - The number of times a stripe has been loaded during index lookup. This
        metric helps track the I/O efficiency of index-based reads, where lower
        values indicate better stripe reuse across lookups.
+   * - numIndexDistinctStripesLoaded
+     -
+     - The number of distinct stripes loaded across the lifetime of the index
+       reader. Comparing with numStripeLoads (which counts every load call)
+       reveals redundant loads of the same stripe.
+   * - indexStripeLoadWallNanos
+     - nanos
+     - Wall time spent loading stripes (or equivalent format-specific load
+       unit) during index lookup, summed across all stripe loads.
+   * - indexStripeLoadCpuNanos
+     - nanos
+     - CPU time spent loading stripes during index lookup. May undercount on
+       async/prefetch paths.
+   * - indexDataReadWallNanos
+     - nanos
+     - Wall time spent reading column data from loaded stripes during index
+       lookup, summed across all read segments.
+   * - indexDataReadCpuNanos
+     - nanos
+     - CPU time spent reading column data from loaded stripes during index
+       lookup. Same prefetch undercounting caveat as indexStripeLoadCpuNanos.
 
 FileBasedDataSource
 -------------------

--- a/velox/dwio/common/Reader.h
+++ b/velox/dwio/common/Reader.h
@@ -244,8 +244,9 @@ class IndexReader {
       "numIndexLookupRequests";
 
   /// Tracks the total number of stripes that need to be read for all requests.
-  /// Multiple requests may share the same stripe, and each shared stripe is
-  /// counted once per request that needs it.
+  /// Within a single startLookup() call, a stripe shared by multiple requests
+  /// is counted once; across different startLookup() calls, the same stripe is
+  /// counted separately for each call.
   static constexpr std::string_view kNumIndexLookupStripes =
       "numIndexLookupStripes";
 
@@ -270,6 +271,32 @@ class IndexReader {
   /// overlapping ranges are merged to minimize I/O.
   static constexpr std::string_view kNumIndexLookupReadSegments =
       "numIndexLookupReadSegments";
+
+  /// Wall time spent loading stripes (or equivalent format-specific load unit)
+  /// during index lookup, summed across all stripe loads.
+  static constexpr std::string_view kIndexStripeLoadWallNanos =
+      "indexStripeLoadWallNanos";
+
+  /// CPU time spent loading stripes during index lookup. May undercount on
+  /// async/prefetch paths; see IndexSource::lookupTiming() for details.
+  static constexpr std::string_view kIndexStripeLoadCpuNanos =
+      "indexStripeLoadCpuNanos";
+
+  /// Wall time spent reading column data from loaded stripes during index
+  /// lookup, summed across all read segments.
+  static constexpr std::string_view kIndexDataReadWallNanos =
+      "indexDataReadWallNanos";
+
+  /// CPU time spent reading column data from loaded stripes during index
+  /// lookup. Same prefetch caveat as kIndexStripeLoadCpuNanos.
+  static constexpr std::string_view kIndexDataReadCpuNanos =
+      "indexDataReadCpuNanos";
+
+  /// Number of distinct stripes loaded across the lifetime of this index
+  /// reader. Useful for spotting redundant loads when comparing against
+  /// numStripeLoads (which counts every load call).
+  static constexpr std::string_view kNumIndexDistinctStripesLoaded =
+      "numIndexDistinctStripesLoaded";
 
   virtual ~IndexReader() = default;
 

--- a/velox/exec/IndexLookupJoin.cpp
+++ b/velox/exec/IndexLookupJoin.cpp
@@ -1663,28 +1663,24 @@ void IndexLookupJoin::recordConnectorStats() {
 
   // Record lookup timing into the index stat writer. splitStats extracts these
   // to populate the IndexSource node's addInputTiming.
-  if (connectorStats.count(std::string(kConnectorLookupWallTime)) != 0) {
-    const auto& lookupWallTime =
-        connectorStats[std::string(kConnectorLookupWallTime)];
+  const auto lookupTiming = indexSource_->lookupTiming();
+  if (lookupTiming.count > 0) {
     indexStatWriter_->addRuntimeStat(
         "lookupCount",
         RuntimeCounter(
-            static_cast<int64_t>(lookupWallTime.count),
+            static_cast<int64_t>(lookupTiming.count),
             RuntimeCounter::Unit::kNone));
     indexStatWriter_->addRuntimeStat(
         "lookupWallNanos",
         RuntimeCounter(
-            static_cast<int64_t>(lookupWallTime.sum),
+            static_cast<int64_t>(lookupTiming.wallNanos),
             RuntimeCounter::Unit::kNanos));
-    // NOTE: this might not be accurate as it doesn't include the time
-    // spent inside the index storage client.
+    // NOTE: lookupCpuNanos may undercount CPU consumed on prefetch worker
+    // threads or async I/O completion handlers.
     indexStatWriter_->addRuntimeStat(
         "lookupCpuNanos",
         RuntimeCounter(
-            static_cast<int64_t>(
-                connectorStats[std::string(kConnectorResultPrepareTime)].sum +
-                connectorStats[std::string(kClientRequestProcessTime)].sum +
-                connectorStats[std::string(kClientResultProcessTime)].sum),
+            static_cast<int64_t>(lookupTiming.cpuNanos),
             RuntimeCounter::Unit::kNanos));
   }
   // Copy index source stats into the operator's own runtimeStats so they are

--- a/velox/exec/tests/utils/TestIndexStorageConnector.cpp
+++ b/velox/exec/tests/utils/TestIndexStorageConnector.cpp
@@ -345,6 +345,7 @@ void TestIndexSource::initOutputProjections(
 void TestIndexSource::recordCpuTiming(const CpuWallTiming& timing) {
   VELOX_CHECK_EQ(timing.count, 1);
   std::lock_guard<std::mutex> l(mutex_);
+  lookupTiming_.add(timing);
   if (timing.wallNanos != 0) {
     addOperatorRuntimeStats(
         std::string(IndexLookupJoin::kConnectorLookupWallTime),

--- a/velox/exec/tests/utils/TestIndexStorageConnector.h
+++ b/velox/exec/tests/utils/TestIndexStorageConnector.h
@@ -228,6 +228,11 @@ class TestIndexSource : public connector::IndexSource,
 
   std::unordered_map<std::string, RuntimeMetric> runtimeStats() override;
 
+  CpuWallTiming lookupTiming() const override {
+    std::lock_guard<std::mutex> l(mutex_);
+    return lookupTiming_;
+  }
+
   memory::MemoryPool* pool() const {
     return pool_.get();
   }
@@ -372,6 +377,7 @@ class TestIndexSource : public connector::IndexSource,
   std::vector<IdentityProjection> conditionTableProjections_;
   std::vector<IdentityProjection> lookupOutputProjections_;
   std::unordered_map<std::string, RuntimeMetric> runtimeStats_;
+  CpuWallTiming lookupTiming_;
 
   // Collected splits for the index source (if tableHandle_->needsIndexSplit()
   // returns true). This is only used for testing the split interface but not


### PR DESCRIPTION
Summary:
Adds infrastructure for reporting per-phase timing and counts during index lookup operations:

- IndexSource::lookupTiming() virtual on the connector base class returns cumulative CpuWallTiming for the lookup phase. IndexLookupJoin uses it to populate addInputTiming on the IndexSource node, replacing the previous synthesis from raw stat names. HiveIndexSource, SequenceStorageIndexSource, and TestIndexSource all implement it. The docstring notes that CPU time may undercount work performed on prefetch worker threads or async I/O completion handlers.

- New stat name constants on dwio::common::IndexReader for format-agnostic per-phase metrics: indexStripeLoadWallNanos, indexStripeLoadCpuNanos, indexDataReadWallNanos, indexDataReadCpuNanos, and numIndexDistinctStripesLoaded.

- HiveIndexSource accumulates per-iteration timing (setup, read, output, filter wall+cpu) into IterationStats and reports it through both lookupTiming() and runtime stats.

- Documentation updates with new stat entries and clarified numIndexLookupStripes semantics (sum of unique stripes per startLookup() call; deduplicated within a call, accumulated across calls).

Differential Revision: D103968606
