### PR TITLE
feat: Add per-phase index lookup stats (#17416)

### DIFF
--- a/velox/docs/monitoring/stats.rst
+++ b/velox/docs/monitoring/stats.rst
@@ -426,8 +426,9 @@ These stats are reported only by connector data or index sources.
    * - numIndexLookupStripes
      -
      - The total number of stripes that need to be read for all index lookup
-       requests. Multiple requests may share the same stripe, and each shared
-       stripe is counted once per request that needs it.
+       requests. Within a single startLookup() call, a stripe shared by
+       multiple requests is counted once; across different startLookup() calls,
+       the same stripe is counted separately for each call.
    * - numIndexMatchedRows
      -
      - The total number of rows matched by the cluster index across all stripes.
@@ -445,6 +446,27 @@ These stats are reported only by connector data or index sources.
      - The number of times a stripe has been loaded during index lookup. This
        metric helps track the I/O efficiency of index-based reads, where lower
        values indicate better stripe reuse across lookups.
+   * - numIndexDistinctStripesLoaded
+     -
+     - The number of distinct stripes loaded across the lifetime of the index
+       reader. Comparing with numStripeLoads (which counts every load call)
+       reveals redundant loads of the same stripe.
+   * - indexStripeLoadWallNanos
+     - nanos
+     - Wall time spent loading stripes (or equivalent format-specific load
+       unit) during index lookup, summed across all stripe loads.
+   * - indexStripeLoadCpuNanos
+     - nanos
+     - CPU time spent loading stripes during index lookup. May undercount on
+       async/prefetch paths.
+   * - indexDataDecodeWallNanos
+     - nanos
+     - Wall time spent decoding column data from loaded stripes during index
+       lookup, summed across all read segments.
+   * - indexDataDecodeCpuNanos
+     - nanos
+     - CPU time spent decoding column data from loaded stripes during index
+       lookup. Same prefetch undercounting caveat as indexStripeLoadCpuNanos.
 
 FileBasedDataSource
 -------------------

--- a/velox/dwio/common/Reader.h
+++ b/velox/dwio/common/Reader.h
@@ -244,8 +244,9 @@ class IndexReader {
       "numIndexLookupRequests";
 
   /// Tracks the total number of stripes that need to be read for all requests.
-  /// Multiple requests may share the same stripe, and each shared stripe is
-  /// counted once per request that needs it.
+  /// Within a single startLookup() call, a stripe shared by multiple requests
+  /// is counted once; across different startLookup() calls, the same stripe is
+  /// counted separately for each call.
   static constexpr std::string_view kNumIndexLookupStripes =
       "numIndexLookupStripes";
 
@@ -270,6 +271,32 @@ class IndexReader {
   /// overlapping ranges are merged to minimize I/O.
   static constexpr std::string_view kNumIndexLookupReadSegments =
       "numIndexLookupReadSegments";
+
+  /// Wall time spent loading stripes (or equivalent format-specific load unit)
+  /// during index lookup, summed across all stripe loads.
+  static constexpr std::string_view kIndexStripeLoadWallNanos =
+      "indexStripeLoadWallNanos";
+
+  /// CPU time spent loading stripes during index lookup. May undercount on
+  /// async/prefetch paths; see IndexSource::lookupTiming() for details.
+  static constexpr std::string_view kIndexStripeLoadCpuNanos =
+      "indexStripeLoadCpuNanos";
+
+  /// Wall time spent decoding column data from loaded stripes during index
+  /// lookup, summed across all read segments.
+  static constexpr std::string_view kIndexDataDecodeWallNanos =
+      "indexDataDecodeWallNanos";
+
+  /// CPU time spent decoding column data from loaded stripes during index
+  /// lookup. Same prefetch caveat as kIndexStripeLoadCpuNanos.
+  static constexpr std::string_view kIndexDataDecodeCpuNanos =
+      "indexDataDecodeCpuNanos";
+
+  /// Number of distinct stripes loaded across the lifetime of this index
+  /// reader. Useful for spotting redundant loads when comparing against
+  /// numStripeLoads (which counts every load call).
+  static constexpr std::string_view kNumIndexDistinctStripesLoaded =
+      "numIndexDistinctStripesLoaded";
 
   virtual ~IndexReader() = default;
 

--- a/velox/exec/IndexLookupJoin.cpp
+++ b/velox/exec/IndexLookupJoin.cpp
@@ -1676,8 +1676,9 @@ void IndexLookupJoin::recordConnectorStats() {
         RuntimeCounter(
             static_cast<int64_t>(lookupWallTime.sum),
             RuntimeCounter::Unit::kNanos));
-    // NOTE: this might not be accurate as it doesn't include the time
-    // spent inside the index storage client.
+    // NOTE: lookupCpuNanos may undercount CPU consumed on prefetch worker
+    // threads or async I/O completion handlers, since CpuWallTimer measures
+    // CPU on the calling thread only.
     indexStatWriter_->addRuntimeStat(
         "lookupCpuNanos",
         RuntimeCounter(

--- a/velox/exec/tests/utils/TestIndexStorageConnector.h
+++ b/velox/exec/tests/utils/TestIndexStorageConnector.h
@@ -355,7 +355,7 @@ class TestIndexSource : public connector::IndexSource,
   const std::shared_ptr<memory::MemoryPool> pool_;
   folly::Executor* const executor_;
 
-  mutable std::mutex mutex_;
+  std::mutex mutex_;
 
   // Join condition filter input type.
   RowTypePtr conditionInputType_;


### PR DESCRIPTION
Summary:

Adds runtime stats for the per-phase timing of an index lookup. The new constants live on dwio::common::IndexReader so any index reader implementation can adopt them:

- indexStripeLoadWallNanos / indexStripeLoadCpuNanos: time loading stripes during index lookup.
- indexDataDecodeWallNanos / indexDataDecodeCpuNanos: time decoding column data from loaded stripes.
- numIndexDistinctStripesLoaded: unique stripes loaded across the reader's lifetime; comparing against numStripeLoads spots redundant loads.

HiveIndexSource accumulates per-iteration timing (setup, read, output, filter wall+cpu) into IterationStats and reports the breakdown via runtime stats. IndexLookupJoin still synthesizes lookupCount/lookupWallNanos/lookupCpuNanos for the IndexSource node's addInputTiming from the existing stat names, with a comment noting that lookupCpuNanos may undercount CPU consumed on prefetch worker threads or async I/O completion handlers (CpuWallTimer measures the calling thread only).

Documentation updates: new entries in stats.rst, clarified numIndexLookupStripes semantics (sum of unique stripes per startLookup() call; deduplicated within a call, accumulated across calls).

Reviewed By: xiaoxmeng

Differential Revision: D103968606


