### PR TITLE
perf(type): Speed up date/timestamp string casts via Neri-Schneider

### DIFF
--- a/velox/benchmarks/basic/CastBenchmark.cpp
+++ b/velox/benchmarks/basic/CastBenchmark.cpp
@@ -92,6 +92,13 @@ int main(int argc, char** argv) {
       [](auto row) { return fmt::format("2024-05-{:02d}", 1 + row % 30); });
   auto invalidDateStrings = vectorMaker.flatVector<std::string>(
       vectorSize, [](auto row) { return fmt::format("2024-05...{}", row); });
+  // Spread inputs across ~150 years (1970..~2120) so the formatter
+  // exercises a realistic mix of years/months/days, not a single date.
+  auto dateInput = vectorMaker.flatVector<int32_t>(
+      vectorSize,
+      [](auto row) { return static_cast<int32_t>(row * 53); },
+      nullptr,
+      DATE());
 
   benchmarkBuilder
       .addBenchmarkSet(
@@ -107,6 +114,11 @@ int main(int argc, char** argv) {
       .addExpression(
           "tryexpr_cast_invalid_input", "try(cast (invalid_date as date))")
       .addExpression("cast_valid", "cast(valid_date as date)");
+
+  benchmarkBuilder
+      .addBenchmarkSet(
+          "cast_date_as_varchar", vectorMaker.rowVector({"d"}, {dateInput}))
+      .addExpression("cast_valid", "cast(d as varchar)");
 
   benchmarkBuilder
       .addBenchmarkSet(

--- a/velox/type/CMakeLists.txt
+++ b/velox/type/CMakeLists.txt
@@ -57,6 +57,7 @@ velox_add_library(
   TimestampConversion.h
   Tokenizer.h
   Tree.h
+  TwoDigitChars.h
   Type.h
   TypeCoercer.h
   TypeEncodingUtil.h

--- a/velox/type/Timestamp.cpp
+++ b/velox/type/Timestamp.cpp
@@ -19,6 +19,7 @@
 #include "velox/common/base/CountBits.h"
 #include "velox/external/tzdb/exception.h"
 #include "velox/type/FastDate.h"
+#include "velox/type/TwoDigitChars.h"
 #include "velox/type/WideRangeDateConversion.h"
 #include "velox/type/tz/TimeZoneMap.h"
 
@@ -133,6 +134,53 @@ const int16_t daysBeforeFirstDayOfMonth[][12] = {
     {0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334},
     {0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335},
 };
+
+// Writes the optional fractional part of a timestamp (".fff..." or
+// nothing if skipped). Returns the new write position.
+char* appendFractionalNanos(
+    char* writePosition,
+    uint64_t nanos,
+    const TimestampToStringOptions& options) {
+  if (options.precision == TimestampToStringOptions::Precision::kMilliseconds) {
+    nanos /= 1'000'000;
+  } else if (
+      options.precision == TimestampToStringOptions::Precision::kMicroseconds) {
+    nanos /= 1'000;
+  }
+  if (options.skipTrailingZeros && nanos == 0) {
+    return writePosition;
+  }
+  *writePosition++ = '.';
+  const auto numDigits = countDigits(nanos);
+  const auto precisionWidth = static_cast<int8_t>(options.precision);
+  std::memset(writePosition, '0', precisionWidth - numDigits);
+  writePosition += precisionWidth - numDigits;
+  if (options.skipTrailingZeros) {
+    std::optional<uint32_t> nonZeroOffset = std::nullopt;
+    int32_t offset = numDigits - 1;
+    while (nanos > 0) {
+      if (nonZeroOffset.has_value() || nanos % 10 != 0) {
+        *(writePosition + offset) = '0' + nanos % 10;
+        if (!nonZeroOffset.has_value()) {
+          nonZeroOffset = offset;
+        }
+      }
+      --offset;
+      nanos /= 10;
+    }
+    writePosition += nonZeroOffset.value() + 1;
+  } else {
+    const auto [position, errorCode] =
+        std::to_chars(writePosition, writePosition + numDigits, nanos);
+    VELOX_DCHECK_EQ(
+        errorCode,
+        std::errc(),
+        "Failed to convert fractional part to chars: {}.",
+        std::make_error_code(errorCode).message());
+    writePosition = position;
+  }
+  return writePosition;
+}
 
 } // namespace
 
@@ -271,50 +319,7 @@ StringView Timestamp::tmToStringView(
   *writePosition++ = ':';
   writePosition += appendDigits(tmValue.tm_sec, 2, writePosition);
 
-  if (options.precision == TimestampToStringOptions::Precision::kMilliseconds) {
-    nanos /= 1'000'000;
-  } else if (
-      options.precision == TimestampToStringOptions::Precision::kMicroseconds) {
-    nanos /= 1'000;
-  }
-  if (options.skipTrailingZeros && nanos == 0) {
-    return StringView(startPosition, writePosition - startPosition);
-  }
-
-  // Fractional part.
-  *writePosition++ = '.';
-  // Append leading zeros.
-  const auto numDigits = countDigits(nanos);
-  const auto precisionWidth = static_cast<int8_t>(options.precision);
-  std::memset(writePosition, '0', precisionWidth - numDigits);
-  writePosition += precisionWidth - numDigits;
-
-  // Append the remaining numeric digits.
-  if (options.skipTrailingZeros) {
-    std::optional<uint32_t> nonZeroOffset = std::nullopt;
-    int32_t offset = numDigits - 1;
-    // Write non-zero digits from end to start.
-    while (nanos > 0) {
-      if (nonZeroOffset.has_value() || nanos % 10 != 0) {
-        *(writePosition + offset) = '0' + nanos % 10;
-        if (!nonZeroOffset.has_value()) {
-          nonZeroOffset = offset;
-        }
-      }
-      --offset;
-      nanos /= 10;
-    }
-    writePosition += nonZeroOffset.value() + 1;
-  } else {
-    const auto [position, errorCode] =
-        std::to_chars(writePosition, writePosition + numDigits, nanos);
-    VELOX_DCHECK_EQ(
-        errorCode,
-        std::errc(),
-        "Failed to convert fractional part to chars: {}.",
-        std::make_error_code(errorCode).message());
-    writePosition = position;
-  }
+  writePosition = appendFractionalNanos(writePosition, nanos, options);
   return StringView(startPosition, writePosition - startPosition);
 }
 
@@ -322,6 +327,65 @@ StringView Timestamp::tsToStringView(
     const Timestamp& ts,
     const TimestampToStringOptions& options,
     char* const startPosition) {
+  // Fast path: the dominant production case — no leading positive
+  // sign, year ∈ [0, 9999], days inside the Neri-Schneider domain.
+  // Skips the std::tm fill in epochToCalendarUtc and the
+  // appendDigits / std::to_chars machinery in tmToStringView, going
+  // directly from (days, rem) to digits via two-byte memcpy lookups.
+  if (FOLLY_LIKELY(
+          options.mode != TimestampToStringOptions::Mode::kTimeOnly &&
+          !options.leadingPositiveSign)) {
+    const int64_t seconds = ts.getSeconds();
+    int64_t days = seconds / kSecondsPerDay;
+    int64_t rem = seconds % kSecondsPerDay;
+    if (rem < 0) {
+      rem += kSecondsPerDay;
+      --days;
+    }
+    if (FOLLY_LIKELY(
+            days >= fast_date::kRataDieMin && days <= fast_date::kRataDieMax)) {
+      const auto ymd = daysToYmd(static_cast<int32_t>(days));
+      // Fast path emits the year as exactly four digits, so it requires
+      // either `zeroPaddingYear` or `year >= 1000`. For the rare
+      // unpadded < 1000 case, fall through to the slow path which
+      // omits leading zeros via appendDigits' nullopt-min-width branch.
+      if (FOLLY_LIKELY(
+              ymd.year >= 0 && ymd.year <= 9999 &&
+              (options.zeroPaddingYear || ymd.year >= 1000))) {
+        char* writePosition = startPosition;
+        const uint32_t year = static_cast<uint32_t>(ymd.year);
+        const uint32_t yearHigh = year / 100u;
+        const uint32_t yearLow = year - yearHigh * 100u;
+        writeTwoDigit(writePosition + 0, yearHigh);
+        writeTwoDigit(writePosition + 2, yearLow);
+        writePosition[4] = '-';
+        writeTwoDigit(writePosition + 5, ymd.month);
+        writePosition[7] = '-';
+        writeTwoDigit(writePosition + 8, ymd.day);
+        writePosition += 10;
+        if (options.mode == TimestampToStringOptions::Mode::kDateOnly) {
+          return StringView(startPosition, writePosition - startPosition);
+        }
+        *writePosition++ = options.dateTimeSeparator;
+        const uint32_t hour =
+            static_cast<uint32_t>(rem) / static_cast<uint32_t>(kSecondsPerHour);
+        const uint32_t remainingSeconds = static_cast<uint32_t>(rem) -
+            hour * static_cast<uint32_t>(kSecondsPerHour);
+        const uint32_t minute = remainingSeconds / 60u;
+        const uint32_t second = remainingSeconds - minute * 60u;
+        writeTwoDigit(writePosition, hour);
+        writePosition[2] = ':';
+        writeTwoDigit(writePosition + 3, minute);
+        writePosition[5] = ':';
+        writeTwoDigit(writePosition + 6, second);
+        writePosition += 8;
+        writePosition =
+            appendFractionalNanos(writePosition, ts.getNanos(), options);
+        return StringView(startPosition, writePosition - startPosition);
+      }
+    }
+  }
+  // Fallback: existing slow path through std::tm + tmToStringView.
   std::tm tmValue;
   VELOX_USER_CHECK(
       epochToCalendarUtc(ts.getSeconds(), tmValue),

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -803,7 +803,66 @@ Expected<int64_t> daysSinceEpochFromDayOfYear(int32_t year, int32_t dayOfYear) {
       });
 }
 
+namespace {
+
+// Fast path for the dominant production shape: a strict 10-character
+// `YYYY-MM-DD` ASCII date with dash separators and zero-padded fields.
+// Produces the same answer as the general parser for every ParseMode
+// (no leading sign, no trailing whitespace/T, exactly one canonical
+// representation per logical date), so it can short-circuit before the
+// general parser's mode-specific branches and per-digit checked
+// arithmetic.
+//
+// Returns true and sets `daysSinceEpoch` on a successful match.
+// Returns false on any shape mismatch or invalid date — the caller
+// must then dispatch to the general parser so that the right error
+// message is produced.
+bool tryFastParseStrictIsoDate(
+    const char* str,
+    size_t len,
+    int32_t& daysSinceEpoch) {
+  if (len != 10 || str[4] != '-' || str[7] != '-') {
+    return false;
+  }
+  // Reject any non-digit byte by checking that all eight digits land
+  // in [0, 9] — fold the bound check into a single comparison via
+  // bitwise OR, so a non-digit byte (which underflows to a huge
+  // unsigned value) trips the same branch as an out-of-range digit.
+  const uint32_t yearThousands = static_cast<uint8_t>(str[0]) - '0';
+  const uint32_t yearHundreds = static_cast<uint8_t>(str[1]) - '0';
+  const uint32_t yearTens = static_cast<uint8_t>(str[2]) - '0';
+  const uint32_t yearOnes = static_cast<uint8_t>(str[3]) - '0';
+  const uint32_t monthTens = static_cast<uint8_t>(str[5]) - '0';
+  const uint32_t monthOnes = static_cast<uint8_t>(str[6]) - '0';
+  const uint32_t dayTens = static_cast<uint8_t>(str[8]) - '0';
+  const uint32_t dayOnes = static_cast<uint8_t>(str[9]) - '0';
+  if ((yearThousands | yearHundreds | yearTens | yearOnes | monthTens |
+       monthOnes | dayTens | dayOnes) > 9u) {
+    return false;
+  }
+  const int32_t year = static_cast<int32_t>(
+      yearThousands * 1000u + yearHundreds * 100u + yearTens * 10u + yearOnes);
+  const int32_t month = static_cast<int32_t>(monthTens * 10u + monthOnes);
+  const int32_t day = static_cast<int32_t>(dayTens * 10u + dayOnes);
+  // Year is always in [0, 9999], well inside the fast inverse domain
+  // (kYearMin, kYearMax), so daysSinceEpochFromDate takes its inline
+  // fast branch and the result fits in int32 with room to spare.
+  auto result = daysSinceEpochFromDate(year, month, day);
+  if (result.hasError()) {
+    return false;
+  }
+  daysSinceEpoch = static_cast<int32_t>(result.value());
+  return true;
+}
+
+} // namespace
+
 Expected<int32_t> fromDateString(const char* str, size_t len, ParseMode mode) {
+  int32_t fastDays;
+  if (tryFastParseStrictIsoDate(str, len, fastDays)) {
+    return fastDays;
+  }
+
   int64_t daysSinceEpoch;
   size_t pos = 0;
 

--- a/velox/type/TwoDigitChars.h
+++ b/velox/type/TwoDigitChars.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+
+namespace facebook::velox {
+
+/// Lookup table of two-digit decimal strings packed contiguously, so
+/// that `kTwoDigitChars + 2 * n` points at the two ASCII bytes of `n`
+/// for any n in [0, 99]. Storing as char[] lets callers emit a fixed-
+/// width two-digit field with a single 16-bit memcpy per pair, faster
+/// than std::to_chars + std::memset for zero-padding or per-byte
+/// stores via division/modulo. Used by the date / timestamp formatters
+/// in DateType::toIso8601 and Timestamp::tsToStringView.
+inline constexpr char kTwoDigitChars[] =
+    "00010203040506070809"
+    "10111213141516171819"
+    "20212223242526272829"
+    "30313233343536373839"
+    "40414243444546474849"
+    "50515253545556575859"
+    "60616263646566676869"
+    "70717273747576777879"
+    "80818283848586878889"
+    "90919293949596979899";
+
+/// Writes the two ASCII bytes of `value` (which must be in [0, 99])
+/// to the two bytes starting at `out` via a single 16-bit memcpy.
+inline void writeTwoDigit(char* out, uint32_t value) {
+  std::memcpy(out, kTwoDigitChars + 2u * value, 2);
+}
+
+} // namespace facebook::velox

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -30,8 +30,10 @@
 #include "velox/external/tzdb/exception.h"
 #include "velox/type/CastRegistry.h"
 #include "velox/type/DecimalUtil.h"
+#include "velox/type/FastDate.h"
 #include "velox/type/Time.h"
 #include "velox/type/TimestampConversion.h"
+#include "velox/type/TwoDigitChars.h"
 
 namespace std {
 template <>
@@ -1312,13 +1314,52 @@ std::string IntervalYearMonthType::valueToString(int32_t value) const {
   return oss.str();
 }
 
+namespace {
+
+// Writes a positive 4-digit ISO date `YYYY-MM-DD` (exactly 10 bytes)
+// into `out`. Caller guarantees year is in [0, 9999], month in [1, 12],
+// day in [1, 31], and that `out` has at least 10 bytes available.
+inline void
+writeIsoDate4DigitYear(char* out, uint32_t year, uint32_t month, uint32_t day) {
+  const uint32_t yearHigh = year / 100u;
+  const uint32_t yearLow = year - yearHigh * 100u;
+  writeTwoDigit(out + 0, yearHigh);
+  writeTwoDigit(out + 2, yearLow);
+  out[4] = '-';
+  writeTwoDigit(out + 5, month);
+  out[7] = '-';
+  writeTwoDigit(out + 8, day);
+}
+
+} // namespace
+
 std::string DateType::toString(int32_t days) const {
   return DateType::toIso8601(days);
 }
 
 std::string DateType::toIso8601(int32_t days) {
-  // Find the number of seconds for the days_;
-  // Casting 86400 to int64 to handle overflows gracefully.
+  // Fast path: positive 4-digit year, no sign. Covers all dates in the
+  // proleptic Gregorian range [0001-01-01, 9999-12-31] and their
+  // immediate neighborhood — the dominant production case. Skips the
+  // std::tm round trip and the std::to_chars/memset machinery in
+  // tmToStringView, going directly from days → y/m/d via the
+  // Neri-Schneider primitive and emitting digits with two-byte memcpy
+  // table lookups.
+  if (FOLLY_LIKELY(
+          days >= fast_date::kRataDieMin && days <= fast_date::kRataDieMax)) {
+    const auto ymd = daysToYmd(days);
+    if (FOLLY_LIKELY(ymd.year >= 0 && ymd.year <= 9999)) {
+      std::string result(10, '\0');
+      writeIsoDate4DigitYear(
+          result.data(), static_cast<uint32_t>(ymd.year), ymd.month, ymd.day);
+      return result;
+    }
+  }
+
+  // General path: negative years, years above 9999, or rare dates
+  // outside the Neri-Schneider domain. Goes through tmToStringView so
+  // the leading sign and variable-width year are formatted exactly as
+  // before.
   int64_t daySeconds = days * (int64_t)(86400);
   std::tm tmValue;
   VELOX_CHECK(

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -295,6 +295,48 @@ TEST(DateTimeUtilTest, fromDateStringInvalid) {
   testCastFromDateStringInvalid("1970-01-01T01:00:47.000", ParseMode::kIso8601);
 }
 
+// Locks in the strict 10-char `YYYY-MM-DD` fast path in fromDateString: its
+// eligibility edges, the shape mismatches that must fall through to the general
+// parser, and the invalid dates the fast path must reject with the canonical
+// error.
+TEST(DateTimeUtilTest, fromDateStringStrictIsoFastPath) {
+  // Fast-path-eligible boundaries: epoch, the year-zero edge, and the
+  // year-9999 edge all land in the fast inverse domain.
+  EXPECT_EQ(20581, parseDate("2026-05-08", ParseMode::kPrestoCast));
+  EXPECT_EQ(-719528, parseDate("0000-01-01", ParseMode::kPrestoCast));
+  EXPECT_EQ(2932896, parseDate("9999-12-31", ParseMode::kPrestoCast));
+
+  // Shape mismatches must fall through to the general parser and produce the
+  // same answer: unpadded fields, a leading sign, and surrounding whitespace.
+  EXPECT_EQ(20581, parseDate("2026-5-8", ParseMode::kPrestoCast));
+  EXPECT_EQ(20581, parseDate("+2026-05-08", ParseMode::kPrestoCast));
+  EXPECT_EQ(20581, parseDate(" 2026-05-08 ", ParseMode::kPrestoCast));
+
+  // The fast path computes an invalid date — it must reject and let the general
+  // parser produce the canonical error rather than returning a bogus day count.
+  auto expectInvalid = [](const StringView& str) {
+    VELOX_ASSERT_THROW(
+        parseDate(str, ParseMode::kPrestoCast),
+        fmt::format(
+            "Unable to parse date value: \"{}\". "
+            "Valid date string pattern is (YYYY-MM-DD), "
+            "and can be prefixed with [+-]",
+            std::string(str.data(), str.size())));
+  };
+  expectInvalid("2026-02-29"); // Not a leap year.
+  expectInvalid("2026-13-08"); // Month out of range.
+  expectInvalid("2026-00-08"); // Month zero.
+  expectInvalid("2026-05-32"); // Day out of range.
+
+  // A non-digit byte at any digit position underflows the unsigned digit
+  // subtraction and trips the same bounds branch as an out-of-range digit, so
+  // the fast path falls through; a wrong separator byte fails the shape check.
+  expectInvalid("X026-05-08");
+  expectInvalid("2026-X5-08");
+  expectInvalid("2026-05-0X");
+  expectInvalid("2026:05-08");
+}
+
 // bash command to verify:
 // $ date -d "2000-01-01 12:21:56Z" +%s
 // ('Z' at the end means UTC).

--- a/velox/type/tests/TimestampTest.cpp
+++ b/velox/type/tests/TimestampTest.cpp
@@ -260,6 +260,80 @@ TEST(TimestampTest, toStringPrestoCastBehavior) {
       "-0001-11-29 19:33:20.000", Timestamp(-62170000000, 0).toString(options));
 }
 
+// Locks in the fast/slow seam of tsToStringView around the year-padding edge,
+// the predicates that disable the fast path, and the pre-epoch floor-division
+// branch.
+TEST(TimestampTest, toStringFastPathBoundary) {
+  TimestampToStringOptions options = {
+      .precision = TimestampToStringOptions::Precision::kMilliseconds,
+  };
+
+  // year == 999: the fast path emits exactly four year digits, so it only
+  // applies when zeroPaddingYear is set; otherwise the unpadded year falls
+  // through to the slow path.
+  const Timestamp year999 = Timestamp(-30627466200, 0);
+  options.zeroPaddingYear = true;
+  EXPECT_EQ("0999-06-15T10:30:00.000", year999.toString(options));
+  options.zeroPaddingYear = false;
+  EXPECT_EQ("999-06-15T10:30:00.000", year999.toString(options));
+
+  // year > 9999 with a leading positive sign disables the fast path.
+  const Timestamp year10000 = Timestamp(253402300800, 0);
+  options.leadingPositiveSign = true;
+  EXPECT_EQ("+10000-01-01T00:00:00.000", year10000.toString(options));
+  // year == 10000 is just outside the fast domain even without the sign.
+  options.leadingPositiveSign = false;
+  EXPECT_EQ("10000-01-01T00:00:00.000", year10000.toString(options));
+
+  // kTimeOnly always takes the slow path.
+  options.mode = TimestampToStringOptions::Mode::kTimeOnly;
+  EXPECT_EQ("10:30:00.000", Timestamp(37800, 0).toString(options));
+
+  // Pre-epoch seconds exercise the fast path's floor-division branch (rem < 0
+  // borrows a day).
+  EXPECT_EQ("1969-12-31T23:59:59.000000000", Timestamp(-1, 0).toString());
+}
+
+// Locks in appendFractionalNanos, now shared by the fast and slow paths, across
+// every (precision, skipTrailingZeros) combination plus the nanos == 0 case.
+TEST(TimestampTest, toStringFractionalNanos) {
+  using Precision = TimestampToStringOptions::Precision;
+  // 2024-01-02T03:04:05, a fast-path-eligible year, with a fraction that has
+  // trailing zeros at each precision.
+  const int64_t seconds = 1704164645;
+  const std::string base = "2024-01-02T03:04:05";
+
+  auto format = [&](uint64_t nanos,
+                    Precision precision,
+                    bool skipTrailingZeros) {
+    return Timestamp(seconds, nanos)
+        .toString(
+            {.precision = precision, .skipTrailingZeros = skipTrailingZeros});
+  };
+
+  const uint64_t nanos = 123'000'000;
+  EXPECT_EQ(base + ".123", format(nanos, Precision::kMilliseconds, false));
+  EXPECT_EQ(base + ".123", format(nanos, Precision::kMilliseconds, true));
+  EXPECT_EQ(base + ".123000", format(nanos, Precision::kMicroseconds, false));
+  EXPECT_EQ(base + ".123", format(nanos, Precision::kMicroseconds, true));
+  EXPECT_EQ(base + ".123000000", format(nanos, Precision::kNanoseconds, false));
+  EXPECT_EQ(base + ".123", format(nanos, Precision::kNanoseconds, true));
+
+  // skipTrailingZeros must also drop zeros within the millisecond field.
+  EXPECT_EQ(
+      base + ".100", format(100'000'000, Precision::kMilliseconds, false));
+  EXPECT_EQ(base + ".1", format(100'000'000, Precision::kMilliseconds, true));
+
+  // nanos == 0: keep the zero-filled fraction unless trailing zeros are
+  // skipped, in which case the fraction is omitted entirely.
+  EXPECT_EQ(base + ".000", format(0, Precision::kMilliseconds, false));
+  EXPECT_EQ(base + ".000000", format(0, Precision::kMicroseconds, false));
+  EXPECT_EQ(base + ".000000000", format(0, Precision::kNanoseconds, false));
+  EXPECT_EQ(base, format(0, Precision::kMilliseconds, true));
+  EXPECT_EQ(base, format(0, Precision::kMicroseconds, true));
+  EXPECT_EQ(base, format(0, Precision::kNanoseconds, true));
+}
+
 namespace {
 
 std::string toStringAlt(

--- a/velox/type/tests/TypeTest.cpp
+++ b/velox/type/tests/TypeTest.cpp
@@ -336,6 +336,23 @@ TEST(TypeTest, dateToString) {
   EXPECT_EQ(DATE()->toString(-1855961014), "-5079479-05-03");
 }
 
+// Locks in the fast/slow boundary of DateType::toIso8601: the four-digit-year
+// fast path and the fallbacks for years outside [0, 9999].
+TEST(TypeTest, dateToStringFastPathBoundary) {
+  // Fast path: positive four-digit years, including the year-zero and
+  // year-9999 edges.
+  EXPECT_EQ(DateType::toIso8601(0), "1970-01-01");
+  EXPECT_EQ(DateType::toIso8601(-719528), "0000-01-01");
+  EXPECT_EQ(DateType::toIso8601(2932896), "9999-12-31");
+
+  // One day past 9999-12-31 needs five year digits, so it falls through to the
+  // general path.
+  EXPECT_EQ(DateType::toIso8601(2932897), "10000-01-01");
+
+  // Negative years take the general path with its leading sign.
+  EXPECT_EQ(DateType::toIso8601(-1855961014), "-5079479-05-03");
+}
+
 // Tests the generic Type::valueToString<T> template which routes to
 // type-specific formatting based on the type. Tests are grouped by physical
 // type and use the same raw values to illustrate the difference in output.


### PR DESCRIPTION
## Summary
Three follow-up speedups on top of  #17371 / #17364's Neri-Schneider primitives, each in its own commit:

1. `CAST(varchar AS DATE)`: strict 10-char `YYYY-MM-DD` fast path in `util::fromDateString`, skipping the general parser's per-digit checked arithmetic and ParseMode dispatch.
2. `CAST(DATE AS varchar)`: `DateType::toIso8601` skips the `std::tm` round trip and emits digits via 16-bit memcpy from a shared two-digit-pair lookup table.
3. `CAST(TIMESTAMP AS varchar)`: same recipe in `Timestamp::tsToStringView`; fractional-nanos handling is factored into a shared helper used by both fast and slow paths.

The general paths are preserved as fallbacks — negative years, years > 9999, unpadded < 1000 years (`zeroPaddingYear = false`), `leadingPositiveSign`, partial Spark/ISO forms, signed-year inputs, `kTimeOnly` mode, and inputs outside the Neri-Schneider domain all continue through the existing slow path so observable behavior is preserved.

Closes #17418.

## Numbers

`velox_cast_benchmark` (1024-row vectors, 3-run median, GCC 11 release):

| direction | benchmark | baseline | patched | speedup |
|-----------|-----------|---------:|--------:|--------:|
| varchar → DATE | `cast_varhar_as_date##cast_valid` | 33.33 ms | 23.42 ms | **1.42×** |
| DATE → varchar | `cast_date_as_varchar##cast_valid` | 107.70 ms | 47.91 ms | **2.25×** |
| TIMESTAMP → varchar | `cast_timestamp_as_varchar##cast` | 56.11 ms | 29.94 ms | **1.87×** |

Other entries in `cast_varhar_as_date` (try_cast on invalid/empty inputs) are unchanged because they don't match the strict-shape fast path.

## Correctness

- Existing parser/formatter coverage (`DateTimeUtilTest.fromDateString`, `fromDateStringInvalid`, `TypeTest.dateToString`, `TimestampTest.*`) exercises the targeted code paths; the fast paths fall through on any shape mismatch so general-path error messages and partial-form handling are byte-for-byte preserved.
- Boundary cases that exercise the slow path stay green: `DATE()->toString(-1855961014)` → `"-5079479-05-03"`, `CastExprTest.timestampToString` with the unpadded `384-01-01T08:00:00.000` case (zeroPaddingYear = false, year < 1000), and the existing `12345-12-18` / `-1-1-1` parse cases.
- Cast layer cross-checks: `CastExprTest.*` (Presto, 56 tests) and `SparkCastExprTestAnsi{On,Off}.*` (46 tests).

## Test

- `velox_cast_benchmark --bm_regex=cast_(varhar_as_date|date_as_varchar|timestamp_as_varchar)` to validate the per-direction speedups on the reviewer's hardware.