### PR TITLE
perf(functions): Speed up date_trunc/trunc on DATE and TIMESTAMP via Neri-Schneider

### DIFF
--- a/velox/benchmarks/basic/DateExtractBenchmark.cpp
+++ b/velox/benchmarks/basic/DateExtractBenchmark.cpp
@@ -78,6 +78,75 @@ int main(int argc, char** argv) {
       .addExpression("last_day_of_month", "last_day_of_month(c0)")
       .disableTesting();
 
+  // date_trunc on DATE inputs. Each unit hits a different code path
+  // in truncateDate (kWeek is pure int math, kMonth/kQuarter/kYear
+  // round-trip through the Neri-Schneider primitives in FastDate.h).
+  // Use a bounded year range (1970..~2100) so the benchmark measures
+  // the realistic in-range work rather than the rate of out-of-range
+  // throws that an unbounded fuzz of int32 days would produce.
+  auto dateTruncInput = vectorMaker.flatVector<int32_t>(
+      1024,
+      [](auto i) { return static_cast<int32_t>(i * 47); },
+      nullptr,
+      DATE());
+  benchmarkBuilder
+      .addBenchmarkSet(
+          "date_trunc_year_date", vectorMaker.rowVector({dateTruncInput}))
+      .addExpression("date_trunc_year", "date_trunc('year', c0)")
+      .disableTesting();
+
+  benchmarkBuilder
+      .addBenchmarkSet(
+          "date_trunc_quarter_date", vectorMaker.rowVector({dateTruncInput}))
+      .addExpression("date_trunc_quarter", "date_trunc('quarter', c0)")
+      .disableTesting();
+
+  benchmarkBuilder
+      .addBenchmarkSet(
+          "date_trunc_month_date", vectorMaker.rowVector({dateTruncInput}))
+      .addExpression("date_trunc_month", "date_trunc('month', c0)")
+      .disableTesting();
+
+  benchmarkBuilder
+      .addBenchmarkSet(
+          "date_trunc_week_date", vectorMaker.rowVector({dateTruncInput}))
+      .addExpression("date_trunc_week", "date_trunc('week', c0)")
+      .disableTesting();
+
+  // date_trunc on TIMESTAMP inputs for the date-level units. Same
+  // recipe as the DATE benches with a bounded range (~130 years from
+  // epoch) so the measurement reflects the in-range path rather than
+  // the rate of out-of-range throws an unbounded fuzz would produce.
+  auto timestampTruncInput = vectorMaker.flatVector<Timestamp>(
+      1024, [](auto i) { return Timestamp(i * 86400 * 47, 0); });
+  benchmarkBuilder
+      .addBenchmarkSet(
+          "date_trunc_year_timestamp",
+          vectorMaker.rowVector({timestampTruncInput}))
+      .addExpression("date_trunc_year", "date_trunc('year', c0)")
+      .disableTesting();
+
+  benchmarkBuilder
+      .addBenchmarkSet(
+          "date_trunc_quarter_timestamp",
+          vectorMaker.rowVector({timestampTruncInput}))
+      .addExpression("date_trunc_quarter", "date_trunc('quarter', c0)")
+      .disableTesting();
+
+  benchmarkBuilder
+      .addBenchmarkSet(
+          "date_trunc_month_timestamp",
+          vectorMaker.rowVector({timestampTruncInput}))
+      .addExpression("date_trunc_month", "date_trunc('month', c0)")
+      .disableTesting();
+
+  benchmarkBuilder
+      .addBenchmarkSet(
+          "date_trunc_week_timestamp",
+          vectorMaker.rowVector({timestampTruncInput}))
+      .addExpression("date_trunc_week", "date_trunc('week', c0)")
+      .disableTesting();
+
   // TIMESTAMP inputs (seconds + nanos).
   benchmarkBuilder
       .addBenchmarkSet(

--- a/velox/functions/lib/TimeUtils.cpp
+++ b/velox/functions/lib/TimeUtils.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/functions/lib/TimeUtils.h"
+#include "velox/type/FastDate.h"
 
 namespace facebook::velox::functions {
 
@@ -188,16 +189,96 @@ Timestamp truncateTimestamp(
       result = adjustEpoch(getSeconds(timestamp, timeZone), 24 * 60 * 60);
       break;
 
-    default:
-      auto dateTime = getDateTime(timestamp, timeZone);
-      adjustDateTime(dateTime, unit);
-      result = Timestamp(Timestamp::calendarUtcToEpoch(dateTime), 0);
+    default: {
+      // Week, month, quarter, and year truncation are date-unit
+      // operations: convert to local days, truncate via the
+      // Date-domain helper (which avoids the std::tm round trip and
+      // goes directly through Neri-Schneider for in-range years),
+      // then materialize a local Timestamp at the start of the
+      // truncated unit. The toGMT below converts it back. Falls back
+      // to the std::tm path for the unreachable extreme inputs whose
+      // local day count overflows int32_t.
+      const int64_t localSeconds = getSeconds(timestamp, timeZone);
+      int64_t localDays = localSeconds / kSecondsInDay;
+      if (localSeconds < 0 && localSeconds % kSecondsInDay) {
+        --localDays;
+      }
+      if (FOLLY_LIKELY(
+              localDays >= std::numeric_limits<int32_t>::min() &&
+              localDays <= std::numeric_limits<int32_t>::max())) {
+        const int32_t truncatedDays =
+            truncateDate(static_cast<int32_t>(localDays), unit);
+        result =
+            Timestamp(static_cast<int64_t>(truncatedDays) * kSecondsInDay, 0);
+      } else {
+        auto dateTime = getDateTime(timestamp, timeZone);
+        adjustDateTime(dateTime, unit);
+        result = Timestamp(Timestamp::calendarUtcToEpoch(dateTime), 0);
+      }
       break;
+    }
   }
 
   if (timeZone != nullptr) {
     result.toGMT(*timeZone);
   }
   return result;
+}
+
+int32_t truncateDate(int32_t days, DateTimeUnit unit) {
+  if (unit == DateTimeUnit::kDay) {
+    return days;
+  }
+
+  if (unit == DateTimeUnit::kWeek) {
+    // 1970-01-01 was a Thursday, so for any day d the ISO weekday
+    // (0 = Sun, 1 = Mon, ..., 6 = Sat) is `(4 + d) mod 7`. To shift
+    // back to Monday: Sun -> 6 days back, Mon -> 0, otherwise
+    // weekday - 1.
+    int32_t weekday = (4 + days) % 7;
+    if (weekday < 0) {
+      weekday += 7;
+    }
+    const int32_t offsetBack = weekday == 0 ? 6 : weekday - 1;
+    return days - offsetBack;
+  }
+
+  // Month/quarter/year — pull (y, m, d) via the fast Neri-Schneider,
+  // adjust the month, push back. Only safe when both daysToYmd and
+  // ymdToDays land strictly inside their exact domains; the few years
+  // at each end of the int32 day range fall through to the existing
+  // std::tm path.
+  if (FOLLY_LIKELY(
+          days >= fast_date::kRataDieMin && days <= fast_date::kRataDieMax)) {
+    const auto ymd = daysToYmd(days);
+    if (FOLLY_LIKELY(
+            ymd.year > fast_date::kYearMin && ymd.year < fast_date::kYearMax)) {
+      uint32_t month;
+      switch (unit) {
+        case DateTimeUnit::kYear:
+          month = 1u;
+          break;
+        case DateTimeUnit::kQuarter:
+          month = ((ymd.month - 1u) / 3u) * 3u + 1u;
+          break;
+        case DateTimeUnit::kMonth:
+          month = ymd.month;
+          break;
+        default:
+          VELOX_UNREACHABLE();
+      }
+      return ymdToDays(ymd.year, month, 1u);
+    }
+  }
+
+  // Fallback for rare boundary inputs.
+  std::tm dateTime;
+  const int64_t seconds = static_cast<int64_t>(days) * kSecondsInDay;
+  VELOX_USER_CHECK(
+      Timestamp::epochToCalendarUtc(seconds, dateTime),
+      "Date is too large: {} days",
+      days);
+  adjustDateTime(dateTime, unit);
+  return Timestamp::calendarUtcToEpoch(dateTime) / kSecondsInDay;
 }
 } // namespace facebook::velox::functions

--- a/velox/functions/lib/TimeUtils.cpp
+++ b/velox/functions/lib/TimeUtils.cpp
@@ -235,12 +235,21 @@ int32_t truncateDate(int32_t days, DateTimeUnit unit) {
     // (0 = Sun, 1 = Mon, ..., 6 = Sat) is `(4 + d) mod 7`. To shift
     // back to Monday: Sun -> 6 days back, Mon -> 0, otherwise
     // weekday - 1.
-    int32_t weekday = (4 + days) % 7;
+    int32_t weekday = static_cast<int32_t>((4LL + days) % 7);
     if (weekday < 0) {
       weekday += 7;
     }
     const int32_t offsetBack = weekday == 0 ? 6 : weekday - 1;
-    return days - offsetBack;
+    // Subtract in 64-bit to avoid signed overflow when days == INT32_MIN, then
+    // reject the rare inputs whose Monday falls before the representable range
+    // rather than returning a wrapped value.
+    const int64_t weekStart = static_cast<int64_t>(days) - offsetBack;
+    VELOX_USER_CHECK_GE(
+        weekStart,
+        std::numeric_limits<int32_t>::min(),
+        "Date is out of range for truncation: {} days",
+        days);
+    return static_cast<int32_t>(weekStart);
   }
 
   // Month/quarter/year — pull (y, m, d) via the fast Neri-Schneider,
@@ -279,6 +288,15 @@ int32_t truncateDate(int32_t days, DateTimeUnit unit) {
       "Date is too large: {} days",
       days);
   adjustDateTime(dateTime, unit);
-  return Timestamp::calendarUtcToEpoch(dateTime) / kSecondsInDay;
+  // The truncated unit start can fall before the representable range for inputs
+  // near INT32_MIN; reject those rather than returning a wrapped value.
+  const int64_t truncatedDays =
+      Timestamp::calendarUtcToEpoch(dateTime) / kSecondsInDay;
+  VELOX_USER_CHECK_GE(
+      truncatedDays,
+      std::numeric_limits<int32_t>::min(),
+      "Date is out of range for truncation: {} days",
+      days);
+  return static_cast<int32_t>(truncatedDays);
 }
 } // namespace facebook::velox::functions

--- a/velox/functions/lib/TimeUtils.cpp
+++ b/velox/functions/lib/TimeUtils.cpp
@@ -190,14 +190,7 @@ Timestamp truncateTimestamp(
       break;
 
     default: {
-      // Week, month, quarter, and year truncation are date-unit
-      // operations: convert to local days, truncate via the
-      // Date-domain helper (which avoids the std::tm round trip and
-      // goes directly through Neri-Schneider for in-range years),
-      // then materialize a local Timestamp at the start of the
-      // truncated unit. The toGMT below converts it back. Falls back
-      // to the std::tm path for the unreachable extreme inputs whose
-      // local day count overflows int32_t.
+      // Convert to local days, truncate, convert back to local midnight.
       const int64_t localSeconds = getSeconds(timestamp, timeZone);
       int64_t localDays = localSeconds / kSecondsInDay;
       if (localSeconds < 0 && localSeconds % kSecondsInDay) {

--- a/velox/functions/lib/TimeUtils.h
+++ b/velox/functions/lib/TimeUtils.h
@@ -165,4 +165,14 @@ Timestamp truncateTimestamp(
     Timestamp timestamp,
     DateTimeUnit unit,
     const tz::TimeZone* timeZone);
+
+/// Truncates a date (days since 1970-01-01) to the start of the
+/// specified unit. Supported units are kDay, kWeek, kMonth, kQuarter,
+/// and kYear; any other value is undefined behavior. Avoids the
+/// std::tm round trip used by adjustDateTime + calendarUtcToEpoch:
+/// kWeek is pure int math on the day count, and kMonth/kQuarter/kYear
+/// go directly through the Neri-Schneider primitives in FastDate.h.
+/// Falls back to the std::tm path for the rare boundary years where
+/// the inverse Neri-Schneider isn't safe.
+int32_t truncateDate(int32_t days, DateTimeUnit unit);
 } // namespace facebook::velox::functions

--- a/velox/functions/lib/tests/TimeUtilsTest.cpp
+++ b/velox/functions/lib/tests/TimeUtilsTest.cpp
@@ -15,8 +15,11 @@
  */
 #include <gtest/gtest.h>
 
+#include <limits>
+
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/lib/TimeUtils.h"
+#include "velox/type/FastDate.h"
 
 namespace facebook::velox::functions {
 namespace {
@@ -101,6 +104,71 @@ TEST(TimeUtilsTest, adjustEpoch) {
   EXPECT_EQ(Timestamp(998474400, 0), adjustEpoch(998474645, 60 * 60));
   EXPECT_EQ(Timestamp(998438400, 0), adjustEpoch(998474645, 24 * 60 * 60));
   EXPECT_EQ(Timestamp(-120, 0), adjustEpoch(-61, 60));
+}
+
+TEST(TimeUtilsTest, truncateDate) {
+  // Epoch day 0 is 1970-01-01, a Thursday.
+  EXPECT_EQ(0, truncateDate(0, DateTimeUnit::kDay));
+  EXPECT_EQ(-3, truncateDate(0, DateTimeUnit::kWeek)); // Monday 1969-12-29.
+  EXPECT_EQ(0, truncateDate(0, DateTimeUnit::kMonth));
+  EXPECT_EQ(0, truncateDate(0, DateTimeUnit::kQuarter));
+  EXPECT_EQ(0, truncateDate(0, DateTimeUnit::kYear));
+
+  // Day 4 is Monday 1970-01-05; day 3 is Sunday 1970-01-04.
+  EXPECT_EQ(4, truncateDate(4, DateTimeUnit::kWeek));
+  EXPECT_EQ(-3, truncateDate(3, DateTimeUnit::kWeek)); // Back to 1969-12-29.
+
+  // Negative / pre-epoch days.
+  EXPECT_EQ(-1, truncateDate(-1, DateTimeUnit::kDay)); // 1969-12-31.
+  EXPECT_EQ(-3, truncateDate(-1, DateTimeUnit::kWeek)); // Monday 1969-12-29.
+  EXPECT_EQ(-31, truncateDate(-1, DateTimeUnit::kMonth)); // 1969-12-01.
+  EXPECT_EQ(-365, truncateDate(-1, DateTimeUnit::kYear)); // 1969-01-01.
+  EXPECT_EQ(-10, truncateDate(-7, DateTimeUnit::kWeek)); // 1969-12-25 Thu.
+
+  // INT32 boundaries for kWeek exercise the signed-overflow paths that must
+  // stay defined under sanitizers.
+  EXPECT_EQ(
+      2147483643,
+      truncateDate(std::numeric_limits<int32_t>::max(), DateTimeUnit::kWeek));
+  // Near INT32_MIN the truncated unit start is unrepresentable as an int32 day,
+  // so every unit rejects it rather than returning a wrapped value.
+  for (auto unit :
+       {DateTimeUnit::kWeek,
+        DateTimeUnit::kMonth,
+        DateTimeUnit::kQuarter,
+        DateTimeUnit::kYear}) {
+    VELOX_ASSERT_THROW(
+        truncateDate(std::numeric_limits<int32_t>::min(), unit),
+        "Date is out of range for truncation");
+  }
+
+  // Fast-path boundaries near the FastDate year limits.
+  EXPECT_EQ(
+      ymdToDays(fast_date::kYearMax - 1, 1, 1),
+      truncateDate(
+          ymdToDays(fast_date::kYearMax - 1, 6, 15), DateTimeUnit::kYear));
+  EXPECT_EQ(
+      ymdToDays(fast_date::kYearMin + 1, 6, 1),
+      truncateDate(
+          ymdToDays(fast_date::kYearMin + 1, 6, 15), DateTimeUnit::kMonth));
+
+  // Inputs just outside the FastDate day range fall through to the std::tm
+  // path; results must stay consistent with the fast path. Expected day
+  // numbers were computed independently via proleptic Gregorian.
+  EXPECT_EQ(
+      1061042246,
+      truncateDate(fast_date::kRataDieMax + 1, DateTimeUnit::kYear));
+  EXPECT_EQ(
+      1061042397,
+      truncateDate(fast_date::kRataDieMax + 1, DateTimeUnit::kMonth));
+  EXPECT_EQ(
+      -12699482, truncateDate(fast_date::kRataDieMin - 1, DateTimeUnit::kYear));
+  EXPECT_EQ(
+      -12699451,
+      truncateDate(fast_date::kRataDieMin - 1, DateTimeUnit::kMonth));
+  EXPECT_EQ(
+      2147483455,
+      truncateDate(std::numeric_limits<int32_t>::max(), DateTimeUnit::kYear));
 }
 
 TEST(TimeUtilsTest, truncateTimestamp) {
@@ -230,6 +298,50 @@ TEST(TimeUtilsTest, truncateTimestamp) {
       Timestamp(978336000, 0),
       truncateTimestamp(
           Timestamp(998'474'645, 321'001'234), DateTimeUnit::kYear, timezone1));
+}
+
+TEST(TimeUtilsTest, truncateTimestampTimeZone) {
+  auto* la = tz::locateZone("America/Los_Angeles");
+
+  // 2026-03-15 17:00 UTC = 2026-03-15 10:00 PDT (Sunday, post DST switch).
+  // Week truncation -> Monday 2026-03-09 00:00 PDT = 2026-03-09 07:00 UTC.
+  EXPECT_EQ(
+      Timestamp(1773039600, 0),
+      truncateTimestamp(Timestamp(1773594000, 0), DateTimeUnit::kWeek, la));
+
+  // 2026-02-15 18:00 UTC = 2026-02-15 10:00 PST.
+  // Month truncation -> 2026-02-01 00:00 PST = 2026-02-01 08:00 UTC.
+  EXPECT_EQ(
+      Timestamp(1769932800, 0),
+      truncateTimestamp(Timestamp(1771178400, 0), DateTimeUnit::kMonth, la));
+
+  // Pre-epoch with a negative UTC offset exercises floor division end-to-end.
+  // 1969-12-31 23:30 UTC = 1969-12-31 15:30 PST (Wednesday).
+  // Week truncation -> Monday 1969-12-29 00:00 PST = 1969-12-29 08:00 UTC.
+  EXPECT_EQ(
+      Timestamp(-230400, 0),
+      truncateTimestamp(Timestamp(-1800, 0), DateTimeUnit::kWeek, la));
+
+  // Non-integer-hour offsets. 2026-06-15 12:00 UTC is a Monday in both zones.
+  auto* kolkata = tz::locateZone("Asia/Kolkata"); // +05:30.
+  EXPECT_EQ(
+      Timestamp(1781461800, 0),
+      truncateTimestamp(
+          Timestamp(1781524800, 0), DateTimeUnit::kWeek, kolkata));
+  EXPECT_EQ(
+      Timestamp(1780252200, 0),
+      truncateTimestamp(
+          Timestamp(1781524800, 0), DateTimeUnit::kMonth, kolkata));
+
+  auto* kathmandu = tz::locateZone("Asia/Kathmandu"); // +05:45.
+  EXPECT_EQ(
+      Timestamp(1781460900, 0),
+      truncateTimestamp(
+          Timestamp(1781524800, 0), DateTimeUnit::kWeek, kathmandu));
+  EXPECT_EQ(
+      Timestamp(1780251300, 0),
+      truncateTimestamp(
+          Timestamp(1781524800, 0), DateTimeUnit::kMonth, kathmandu));
 }
 } // namespace
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -1190,16 +1190,7 @@ struct DateTruncFunction : public TimestampWithTimezoneSupport<T> {
     DateTimeUnit unit = unit_.has_value()
         ? unit_.value()
         : getDateUnit(unitString, true).value();
-
-    if (unit == DateTimeUnit::kDay) {
-      result = date;
-      return;
-    }
-
-    auto dateTime = getDateTime(date);
-    adjustDateTime(dateTime, unit);
-
-    result = Timestamp::calendarUtcToEpoch(dateTime) / kSecondsInDay;
+    result = truncateDate(date, unit);
   }
 
   FOLLY_ALWAYS_INLINE void call(

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -619,10 +619,7 @@ struct TruncFunction {
     if (!unitOption.has_value() || unitOption.value() < DateTimeUnit::kWeek) {
       return false;
     }
-    auto dateTime = getDateTime(date);
-    adjustDateTime(dateTime, unitOption.value());
-
-    result = Timestamp::calendarUtcToEpoch(dateTime) / kSecondsInDay;
+    result = truncateDate(date, unitOption.value());
     return true;
   }
 


### PR DESCRIPTION
## Summary
Adds a `truncateDate(days, unit)` helper in `velox/functions/lib/TimeUtils` that bypasses the `std::tm` round trip used by `getDateTime + adjustDateTime + calendarUtcToEpoch`:

- `kDay` returns `days` unchanged.
- `kWeek` shifts back to the most recent Monday with pure integer math on `(4 + days) mod 7` (1970-01-01 was a Thursday).
- `kMonth/kQuarter/kYear` go directly through Neri-Schneider - `daysToYmd` → adjust month → `ymdToDays`.
- Falls back to the existing `std::tm` path only at the rare boundary years where `ymdToDays` is unsafe.

Wires it into three call sites:
- Presto `DateTruncFunction::call(Date, ...)`
- Spark `TruncFunction::call(Date, ...)`
- The `default` branch of `truncateTimestamp` (week/month/quarter/year on TIMESTAMP), which floors local seconds to days, calls `truncateDate`, then re-materializes a local `Timestamp` at midnight; the existing `toGMT` round trip below preserves timezone semantics. Falls back to the prior `std::tm` path only when `localDays` overflows int32 (essentially unreachable for any practical Velox `Timestamp`).

Sub-day truncation units (kMicrosecond/kMillisecond/kSecond/kMinute/kHour) and the already-fast kDay branch are unchanged.

Closes #17420. Follow-up to #17371 / #17364.

## Numbers

`velox_date_extract_benchmark --bm_regex=date_trunc_` (1024-row vectors, bounded ranges so the measurement reflects in-range work, 3-run median, GCC 11 release):

DATE input:
| unit | baseline | patched | speedup |
|------|---------:|--------:|--------:|
| year    | 11.68 ms | 4.00 ms | **2.92×** |
| quarter | 12.90 ms | 5.58 ms | **2.31×** |
| month   | 12.05 ms | 4.87 ms | **2.47×** |
| week    | 12.30 ms | 3.04 ms | **4.05×** |

TIMESTAMP input:
| unit | baseline | patched | speedup |
|------|---------:|--------:|--------:|
| year    | 22.09 ms | 13.83 ms | **1.60×** |
| quarter | 24.09 ms | 14.67 ms | **1.64×** |
| month   | 22.46 ms | 14.48 ms | **1.55×** |
| week    | 23.78 ms | 11.73 ms | **2.03×** |

The `kWeek` path is purest int math (no `daysToYmd`/`ymdToDays`), which is why it wins biggest. The TIMESTAMP speedups are smaller because the per-row constant overhead (timezone bookkeeping, Timestamp construction, optional `toGMT`) is unchanged - only the std::tm round trip is replaced.

## Correctness

- All Presto `DateTimeFunctionsTest.dateTrunc*` tests pass (13 tests, including timestamp-with-timezone variants like `dateTruncTimeStampForWeek`, `dateTruncTimeStampWithTimezoneForWeek`, `dateTruncTimeStampWithTimezoneStringForWeek`).
- All Spark `DateTimeFunctionsTest.dateTrunc / trunc / truncate*` tests pass (4 tests).
- The boundary-year fallback path retains the `getDateTime + adjustDateTime + calendarUtcToEpoch` flow, so any observable behavior change for inputs outside the Neri-Schneider domain would also surface a regression in the existing test suite - none observed.

## Test

- `make unittest` on a release build: `velox_functions_test` (Presto DateTimeFunctionsTest), `velox_functions_spark_test` (Spark DateTimeFunctionsTest).
- `velox_date_extract_benchmark --bm_regex=date_trunc_` to validate per-unit speedups on the reviewer's hardware.