### PR TITLE
feat: Add intra-expression tracing activation hook to TraceCtx

### DIFF
--- a/velox/exec/tests/CustomTraceTest.cpp
+++ b/velox/exec/tests/CustomTraceTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <fmt/format.h>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <unordered_map>
 #include <utility>
@@ -24,6 +25,7 @@
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/exec/trace/TraceCtx.h"
+#include "velox/expression/VectorFunction.h"
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
@@ -453,6 +455,147 @@ TEST_F(CustomTraceTest, exprTraceThrowingWriter) {
                       .config(core::QueryConfig::kQueryTraceEnabled, true)
                       .queryCtx(queryCtx)
                       .countResults(task));
+}
+
+// TraceCtx that tracks maybeActivateIntraExprTracing calls.
+class IntraExprTraceCtx : public TraceCtx {
+ public:
+  IntraExprTraceCtx(
+      const std::vector<std::string>& tracedExprs,
+      std::vector<std::string>& activatedFunctions)
+      : TraceCtx(false),
+        tracedExprs_(tracedExprs.begin(), tracedExprs.end()),
+        activatedFunctions_(activatedFunctions) {}
+
+  bool shouldTrace(const Operator&) const override {
+    return true;
+  }
+
+  bool shouldTraceExpr(std::string_view functionName) const override {
+    return tracedExprs_.contains(std::string(functionName));
+  }
+
+  std::unique_ptr<TraceExprWriter> createExprOutputTracer(
+      const Operator&,
+      std::string_view,
+      int) const override {
+    return nullptr;
+  }
+
+  void maybeActivateIntraExprTracing(
+      const Operator&,
+      std::string_view functionName,
+      VectorFunction&) const override {
+    activatedFunctions_.emplace_back(functionName);
+  }
+
+ private:
+  std::unordered_set<std::string> tracedExprs_;
+  std::vector<std::string>& activatedFunctions_;
+};
+
+TEST_F(CustomTraceTest, intraExprTracingCalledForTracedFunctions) {
+  auto vector = makeRowVector(
+      {"a"}, {makeFlatVector<int64_t>(10, [](auto row) { return row; })});
+
+  auto plan =
+      PlanBuilder().values({vector}).project({"a * 10 as a"}).planNode();
+
+  std::vector<std::string> activatedFunctions;
+  auto queryCtx =
+      core::QueryCtx::Builder()
+          .executor(executor_.get())
+          .traceCtxProvider([&](core::QueryCtx&, const core::PlanFragment&) {
+            return std::make_unique<IntraExprTraceCtx>(
+                std::vector<std::string>{"multiply"}, activatedFunctions);
+          })
+          .build();
+
+  std::shared_ptr<Task> task;
+  AssertQueryBuilder(plan)
+      .config(core::QueryConfig::kQueryTraceEnabled, true)
+      .queryCtx(queryCtx)
+      .countResults(task);
+
+  EXPECT_THAT(activatedFunctions, testing::ElementsAre("multiply"));
+}
+
+TEST_F(CustomTraceTest, intraExprTracingNotCalledForUntracedFunctions) {
+  auto vector = makeRowVector(
+      {"a"}, {makeFlatVector<int64_t>(10, [](auto row) { return row; })});
+
+  auto plan = PlanBuilder()
+                  .values({vector})
+                  .project({"a * 10 as b", "a + 5 as c"})
+                  .planNode();
+
+  std::vector<std::string> activatedFunctions;
+  auto queryCtx =
+      core::QueryCtx::Builder()
+          .executor(executor_.get())
+          .traceCtxProvider([&](core::QueryCtx&, const core::PlanFragment&) {
+            return std::make_unique<IntraExprTraceCtx>(
+                std::vector<std::string>{"plus"}, activatedFunctions);
+          })
+          .build();
+
+  std::shared_ptr<Task> task;
+  AssertQueryBuilder(plan)
+      .config(core::QueryConfig::kQueryTraceEnabled, true)
+      .queryCtx(queryCtx)
+      .countResults(task);
+
+  EXPECT_THAT(activatedFunctions, testing::ElementsAre("plus"));
+}
+
+TEST_F(CustomTraceTest, intraExprTracingNotCalledWhenOperatorNotTraced) {
+  auto vector = makeRowVector(
+      {"a"}, {makeFlatVector<int64_t>(10, [](auto row) { return row; })});
+
+  // TraceCtx where shouldTrace returns false for all operators.
+  class NoOpTraceCtx : public TraceCtx {
+   public:
+    explicit NoOpTraceCtx(std::vector<std::string>& activatedFunctions)
+        : TraceCtx(false), activatedFunctions_(activatedFunctions) {}
+
+    bool shouldTrace(const Operator&) const override {
+      return false;
+    }
+
+    bool shouldTraceExpr(std::string_view) const override {
+      return true;
+    }
+
+    void maybeActivateIntraExprTracing(
+        const Operator&,
+        std::string_view functionName,
+        VectorFunction&) const override {
+      activatedFunctions_.emplace_back(functionName);
+    }
+
+   private:
+    std::vector<std::string>& activatedFunctions_;
+  };
+
+  auto plan =
+      PlanBuilder().values({vector}).project({"a * 10 as a"}).planNode();
+
+  std::vector<std::string> activatedFunctions;
+  auto queryCtx =
+      core::QueryCtx::Builder()
+          .executor(executor_.get())
+          .traceCtxProvider([&](core::QueryCtx&, const core::PlanFragment&) {
+            return std::make_unique<NoOpTraceCtx>(activatedFunctions);
+          })
+          .build();
+
+  std::shared_ptr<Task> task;
+  AssertQueryBuilder(plan)
+      .config(core::QueryConfig::kQueryTraceEnabled, true)
+      .queryCtx(queryCtx)
+      .countResults(task);
+
+  EXPECT_THAT(activatedFunctions, testing::IsEmpty());
 }
 
 // Helper to convert a vector of plan node IDs to a breakpoints map with null

--- a/velox/exec/trace/TraceCtx.h
+++ b/velox/exec/trace/TraceCtx.h
@@ -24,7 +24,8 @@
 
 namespace facebook::velox::exec {
 class Operator;
-}
+class VectorFunction;
+} // namespace facebook::velox::exec
 
 namespace facebook::velox::exec::trace {
 
@@ -73,6 +74,14 @@ class TraceCtx {
       int /*instanceIndex*/) const {
     return nullptr;
   }
+
+  /// Activates intra-expression tracing on a vector function whose owning
+  /// operator and expression have both passed the tracing gates
+  /// (shouldTrace() and shouldTraceExpr() respectively).
+  virtual void maybeActivateIntraExprTracing(
+      const Operator& /*op*/,
+      std::string_view /*functionName*/,
+      VectorFunction& /*function*/) const {}
 
   bool dryRun() const {
     return dryRun_;

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -2089,8 +2089,11 @@ void Expr::maybeSetupTracer(
     const int index = instanceCounts[name_]++;
     try {
       outputTracer_ = traceCtx.createExprOutputTracer(op, name_, index);
+      if (vectorFunction_) {
+        traceCtx.maybeActivateIntraExprTracing(op, name_, *vectorFunction_);
+      }
     } catch (const std::exception& e) {
-      LOG(ERROR) << "Failed to create expression output tracer: " << e.what();
+      LOG(ERROR) << "Failed to set up expression tracer: " << e.what();
     }
   }
   for (auto& input : inputs_) {


### PR DESCRIPTION
Summary:
Adds a `maybeActivateIntraExprTracing()` virtual method to `TraceCtx`, allowing implementations to activate internal tracing on a `VectorFunction` when expression-level tracing is configured for it. This complements the inter-expression tracing added in D102552818, which captures batches flowing between expressions. Some vector functions run internal pipelines that benefit from their own tracing — this hook lets `TraceCtx` implementations activate that when both the operator gate (`shouldTrace()`) and the expression gate (`shouldTraceExpr()`) pass.

Changes:
- `TraceCtx`: Added virtual method `maybeActivateIntraExprTracing(op, functionName, function)` with a no-op default
- `Expr::maybeSetupTracer()`: Calls `maybeActivateIntraExprTracing()` when `shouldTraceExpr()` matches and the expression has a `vectorFunction_`

Differential Revision: D102883025


