### PR TITLE
fix(build): Build cudf test utils with VELOX_BUILD_TEST_UTILS

### DIFF
--- a/velox/experimental/cudf/CMakeLists.txt
+++ b/velox/experimental/cudf/CMakeLists.txt
@@ -19,6 +19,8 @@ add_subdirectory(expression)
 
 if(VELOX_BUILD_TESTING)
   add_subdirectory(tests)
+elseif(VELOX_BUILD_TEST_UTILS)
+  add_subdirectory(tests/utils)
 endif()
 
 if(VELOX_ENABLE_BENCHMARKS)


### PR DESCRIPTION
If a user builds the cudf benchmarks without VELOX_BUILD_TESTING it fails because the test utils used are not built. Benchmarks build with VELOX_BUILD_TEST_UTILS enabled.