### PR TITLE
feat: Add expression input tracing support (#17428)

### DIFF
--- a/velox/exec/FilterProject.cpp
+++ b/velox/exec/FilterProject.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/exec/FilterProject.h"
 #include "velox/core/Expressions.h"
+#include "velox/exec/Driver.h"
 #include "velox/exec/OperatorType.h"
 #include "velox/expression/Expr.h"
 #include "velox/expression/FieldReference.h"
@@ -208,6 +209,11 @@ void FilterProject::initialize() {
   }
   filter_.reset();
   project_.reset();
+
+  if (const auto* traceCtx = operatorCtx_->driverCtx()->traceCtx();
+      traceCtx && traceCtx->shouldTrace(*this)) {
+    exprs_->maybeSetupTracers(*this, *traceCtx);
+  }
 }
 
 void FilterProject::addInput(RowVectorPtr input) {

--- a/velox/exec/FilterProject.h
+++ b/velox/exec/FilterProject.h
@@ -59,6 +59,7 @@ class FilterProject : public Operator {
   void close() override {
     Operator::close();
     if (exprs_ != nullptr) {
+      exprs_->finishTracers();
       exprs_->clear();
     } else {
       VELOX_CHECK(!initialized_);

--- a/velox/exec/tests/CustomTraceTest.cpp
+++ b/velox/exec/tests/CustomTraceTest.cpp
@@ -88,16 +88,22 @@ class TestTraceCtx : public TraceCtx {
 // Captures expression output vectors keyed by function name.
 using TExprCapturedVectors = std::unordered_map<std::string, VectorPtr>;
 
+// Captures expression input vectors keyed by function name.
+using TExprCapturedInputs =
+    std::unordered_map<std::string, std::vector<VectorPtr>>;
+
 // A test trace implementation for expression-level tracing. Traces output
 // batches from named expression functions listed in tracedExprs.
 class ExprTestTraceCtx : public TraceCtx {
  public:
   ExprTestTraceCtx(
       const std::vector<std::string>& tracedExprs,
-      TExprCapturedVectors& capturedVectors)
+      TExprCapturedVectors& capturedVectors,
+      TExprCapturedInputs* capturedInputs = nullptr)
       : TraceCtx(false),
         tracedExprs_(tracedExprs.begin(), tracedExprs.end()),
-        capturedVectors_(capturedVectors) {}
+        capturedVectors_(capturedVectors),
+        capturedInputs_(capturedInputs) {}
 
   bool shouldTrace(const Operator& /*op*/) const override {
     return true;
@@ -113,6 +119,18 @@ class ExprTestTraceCtx : public TraceCtx {
       int instanceIndex) const override {
     auto key = fmt::format("{}_{}", functionName, instanceIndex);
     return std::make_unique<TestExprWriter>(std::move(key), capturedVectors_);
+  }
+
+  std::unique_ptr<TraceExprInputWriter> createExprInputTracer(
+      const Operator& /*op*/,
+      std::string_view functionName,
+      int instanceIndex) const override {
+    if (!capturedInputs_) {
+      return nullptr;
+    }
+    auto key = fmt::format("{}_{}", functionName, instanceIndex);
+    return std::make_unique<TestExprInputWriterImpl>(
+        std::move(key), *capturedInputs_);
   }
 
  private:
@@ -135,8 +153,28 @@ class ExprTestTraceCtx : public TraceCtx {
     TExprCapturedVectors& capturedVectors_;
   };
 
+  class TestExprInputWriterImpl : public TraceExprInputWriter {
+   public:
+    TestExprInputWriterImpl(
+        std::string functionName,
+        TExprCapturedInputs& capturedInputs)
+        : functionName_(std::move(functionName)),
+          capturedInputs_(capturedInputs) {}
+
+    void write(const std::vector<VectorPtr>& inputs) override {
+      capturedInputs_[functionName_] = inputs;
+    }
+
+    void finish() override {}
+
+   private:
+    const std::string functionName_;
+    TExprCapturedInputs& capturedInputs_;
+  };
+
   std::unordered_set<std::string> tracedExprs_;
   TExprCapturedVectors& capturedVectors_;
+  TExprCapturedInputs* capturedInputs_;
 };
 
 class CustomTraceTest : public exec::test::HiveConnectorTestBase {};
@@ -225,6 +263,59 @@ TEST_F(CustomTraceTest, exprOutputTrace) {
   assertEqualVectors(iterator->second, expected);
 
   capturedVectors.clear();
+}
+
+TEST_F(CustomTraceTest, exprInputTrace) {
+  auto vector = makeRowVector(
+      {"a", "b"},
+      {makeFlatVector<int64_t>(10, [](auto row) { return row; }),
+       makeFlatVector<int64_t>(10, [](auto row) { return row + 100; })});
+
+  auto plan = PlanBuilder().values({vector}).project({"a + b as c"}).planNode();
+
+  TExprCapturedVectors capturedOutputs;
+  TExprCapturedInputs capturedInputs;
+  auto queryCtx =
+      core::QueryCtx::Builder()
+          .executor(executor_.get())
+          .traceCtxProvider([&](core::QueryCtx&, const core::PlanFragment&) {
+            return std::make_unique<ExprTestTraceCtx>(
+                std::vector<std::string>{"plus"},
+                capturedOutputs,
+                &capturedInputs);
+          })
+          .build();
+
+  std::shared_ptr<Task> task;
+  AssertQueryBuilder(plan)
+      .config(core::QueryConfig::kQueryTraceEnabled, true)
+      .queryCtx(queryCtx)
+      .countResults(task);
+
+  // Verify input vectors were captured.
+  auto inputIterator = capturedInputs.find("plus_0");
+  ASSERT_TRUE(inputIterator != capturedInputs.end());
+
+  const auto& capturedInput = inputIterator->second;
+  ASSERT_EQ(capturedInput.size(), 2);
+
+  auto expectedInputA =
+      makeFlatVector<int64_t>(10, [](auto row) { return row; });
+  auto expectedInputB =
+      makeFlatVector<int64_t>(10, [](auto row) { return row + 100; });
+  assertEqualVectors(capturedInput[0], expectedInputA);
+  assertEqualVectors(capturedInput[1], expectedInputB);
+
+  // Verify output was also captured.
+  auto outputIterator = capturedOutputs.find("plus_0");
+  ASSERT_TRUE(outputIterator != capturedOutputs.end());
+
+  auto expectedOutput =
+      makeFlatVector<int64_t>(10, [](auto row) { return row + row + 100; });
+  assertEqualVectors(outputIterator->second, expectedOutput);
+
+  capturedOutputs.clear();
+  capturedInputs.clear();
 }
 
 TEST_F(CustomTraceTest, exprTraceOnlyMatchingFunctions) {

--- a/velox/exec/tests/CustomTraceTest.cpp
+++ b/velox/exec/tests/CustomTraceTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <fmt/format.h>
 #include <gtest/gtest.h>
 #include <unordered_map>
 #include <utility>
@@ -82,6 +83,60 @@ class TestTraceCtx : public TraceCtx {
   TCapturedVectors& tracedVectors_;
 };
 
+// Captures expression output vectors keyed by function name.
+using TExprCapturedVectors = std::unordered_map<std::string, VectorPtr>;
+
+// A test trace implementation for expression-level tracing. Traces output
+// batches from named expression functions listed in tracedExprs.
+class ExprTestTraceCtx : public TraceCtx {
+ public:
+  ExprTestTraceCtx(
+      const std::vector<std::string>& tracedExprs,
+      TExprCapturedVectors& capturedVectors)
+      : TraceCtx(false),
+        tracedExprs_(tracedExprs.begin(), tracedExprs.end()),
+        capturedVectors_(capturedVectors) {}
+
+  bool shouldTrace(const Operator& /*op*/) const override {
+    return true;
+  }
+
+  bool shouldTraceExpr(std::string_view functionName) const override {
+    return tracedExprs_.contains(std::string(functionName));
+  }
+
+  std::unique_ptr<TraceExprWriter> createExprOutputTracer(
+      const Operator& /*op*/,
+      std::string_view functionName,
+      int instanceIndex) const override {
+    auto key = fmt::format("{}_{}", functionName, instanceIndex);
+    return std::make_unique<TestExprWriter>(std::move(key), capturedVectors_);
+  }
+
+ private:
+  class TestExprWriter : public TraceExprWriter {
+   public:
+    TestExprWriter(
+        std::string functionName,
+        TExprCapturedVectors& capturedVectors)
+        : functionName_(std::move(functionName)),
+          capturedVectors_(capturedVectors) {}
+
+    void write(const VectorPtr& vector) override {
+      capturedVectors_[functionName_] = vector;
+    }
+
+    void finish() override {}
+
+   private:
+    const std::string functionName_;
+    TExprCapturedVectors& capturedVectors_;
+  };
+
+  std::unordered_set<std::string> tracedExprs_;
+  TExprCapturedVectors& capturedVectors_;
+};
+
 class CustomTraceTest : public exec::test::HiveConnectorTestBase {};
 
 TEST_F(CustomTraceTest, customTrace) {
@@ -135,6 +190,181 @@ TEST_F(CustomTraceTest, customTrace) {
 
   // Vectors need to be destructed before the pool in the task dies.
   tracedVectors.clear();
+}
+
+TEST_F(CustomTraceTest, exprOutputTrace) {
+  auto vector = makeRowVector(
+      {"a"}, {makeFlatVector<int64_t>(10, [](auto row) { return row; })});
+
+  auto plan =
+      PlanBuilder().values({vector}).project({"a * 10 as a"}).planNode();
+
+  TExprCapturedVectors capturedVectors;
+  auto queryCtx =
+      core::QueryCtx::Builder()
+          .executor(executor_.get())
+          .traceCtxProvider([&](core::QueryCtx&, const core::PlanFragment&) {
+            return std::make_unique<ExprTestTraceCtx>(
+                std::vector<std::string>{"multiply"}, capturedVectors);
+          })
+          .build();
+
+  std::shared_ptr<Task> task;
+  AssertQueryBuilder(plan)
+      .config(core::QueryConfig::kQueryTraceEnabled, true)
+      .queryCtx(queryCtx)
+      .countResults(task);
+
+  auto iterator = capturedVectors.find("multiply_0");
+  ASSERT_TRUE(iterator != capturedVectors.end());
+
+  auto expected =
+      makeFlatVector<int64_t>(10, [](auto row) { return row * 10; });
+  assertEqualVectors(iterator->second, expected);
+
+  capturedVectors.clear();
+}
+
+TEST_F(CustomTraceTest, exprTraceOnlyMatchingFunctions) {
+  auto vector = makeRowVector(
+      {"a"}, {makeFlatVector<int64_t>(10, [](auto row) { return row; })});
+
+  // Two projections: multiply then plus. Only trace "plus".
+  auto plan = PlanBuilder()
+                  .values({vector})
+                  .project({"a * 10 as b", "a + 5 as c"})
+                  .planNode();
+
+  TExprCapturedVectors capturedVectors;
+  auto queryCtx =
+      core::QueryCtx::Builder()
+          .executor(executor_.get())
+          .traceCtxProvider([&](core::QueryCtx&, const core::PlanFragment&) {
+            return std::make_unique<ExprTestTraceCtx>(
+                std::vector<std::string>{"plus"}, capturedVectors);
+          })
+          .build();
+
+  std::shared_ptr<Task> task;
+  AssertQueryBuilder(plan)
+      .config(core::QueryConfig::kQueryTraceEnabled, true)
+      .queryCtx(queryCtx)
+      .countResults(task);
+
+  // "plus" should be captured.
+  EXPECT_TRUE(capturedVectors.contains("plus_0"));
+
+  // "multiply" should not be captured.
+  EXPECT_FALSE(capturedVectors.contains("multiply_0"));
+
+  capturedVectors.clear();
+}
+
+TEST_F(CustomTraceTest, exprTraceMultipleInstances) {
+  auto vector = makeRowVector(
+      {"a", "b"},
+      {makeFlatVector<int64_t>(10, [](auto row) { return row; }),
+       makeFlatVector<int64_t>(10, [](auto row) { return row + 100; })});
+
+  auto plan = PlanBuilder()
+                  .values({vector})
+                  .project({"a * 10 as c", "b * 20 as d"})
+                  .planNode();
+
+  TExprCapturedVectors capturedVectors;
+  auto queryCtx =
+      core::QueryCtx::Builder()
+          .executor(executor_.get())
+          .traceCtxProvider([&](core::QueryCtx&, const core::PlanFragment&) {
+            return std::make_unique<ExprTestTraceCtx>(
+                std::vector<std::string>{"multiply"}, capturedVectors);
+          })
+          .build();
+
+  std::shared_ptr<Task> task;
+  AssertQueryBuilder(plan)
+      .config(core::QueryConfig::kQueryTraceEnabled, true)
+      .queryCtx(queryCtx)
+      .countResults(task);
+
+  ASSERT_TRUE(capturedVectors.contains("multiply_0"));
+  ASSERT_TRUE(capturedVectors.contains("multiply_1"));
+
+  auto expected0 =
+      makeFlatVector<int64_t>(10, [](auto row) { return row * 10; });
+  auto expected1 =
+      makeFlatVector<int64_t>(10, [](auto row) { return (row + 100) * 20; });
+
+  assertEqualVectors(capturedVectors.at("multiply_0"), expected0);
+  assertEqualVectors(capturedVectors.at("multiply_1"), expected1);
+
+  capturedVectors.clear();
+}
+
+TEST_F(CustomTraceTest, exprTraceCseSharedNode) {
+  auto vector = makeRowVector(
+      {"a"}, {makeFlatVector<int64_t>(10, [](auto row) { return row; })});
+
+  // Both projections share the "a * 10" subexpression (CSE). The visited set
+  // should ensure the shared multiply node is only traced once.
+  auto plan = PlanBuilder()
+                  .values({vector})
+                  .project({"a * 10 + 1 as b", "a * 10 + 2 as c"})
+                  .planNode();
+
+  TExprCapturedVectors capturedVectors;
+  auto queryCtx =
+      core::QueryCtx::Builder()
+          .executor(executor_.get())
+          .traceCtxProvider([&](core::QueryCtx&, const core::PlanFragment&) {
+            return std::make_unique<ExprTestTraceCtx>(
+                std::vector<std::string>{"multiply"}, capturedVectors);
+          })
+          .build();
+
+  std::shared_ptr<Task> task;
+  AssertQueryBuilder(plan)
+      .config(core::QueryConfig::kQueryTraceEnabled, true)
+      .queryCtx(queryCtx)
+      .countResults(task);
+
+  // The shared CSE node should produce exactly one multiply instance.
+  EXPECT_TRUE(capturedVectors.contains("multiply_0"));
+  EXPECT_FALSE(capturedVectors.contains("multiply_1"));
+
+  capturedVectors.clear();
+}
+
+TEST_F(CustomTraceTest, exprTraceNullResult) {
+  auto vector = makeRowVector(
+      {"a"},
+      {makeNullableFlatVector<int64_t>({1, std::nullopt, 3, std::nullopt, 5})});
+
+  // try(a / 0) produces all nulls without throwing.
+  auto plan =
+      PlanBuilder().values({vector}).project({"try(a / 0) as b"}).planNode();
+
+  TExprCapturedVectors capturedVectors;
+  auto queryCtx =
+      core::QueryCtx::Builder()
+          .executor(executor_.get())
+          .traceCtxProvider([&](core::QueryCtx&, const core::PlanFragment&) {
+            return std::make_unique<ExprTestTraceCtx>(
+                std::vector<std::string>{"divide"}, capturedVectors);
+          })
+          .build();
+
+  std::shared_ptr<Task> task;
+  AssertQueryBuilder(plan)
+      .config(core::QueryConfig::kQueryTraceEnabled, true)
+      .queryCtx(queryCtx)
+      .countResults(task);
+
+  // divide is inside try() which catches the error and produces nulls.
+  // The tracer should still capture output (the null vector).
+  EXPECT_TRUE(capturedVectors.contains("divide_0"));
+
+  capturedVectors.clear();
 }
 
 // Helper to convert a vector of plan node IDs to a breakpoints map with null

--- a/velox/exec/tests/CustomTraceTest.cpp
+++ b/velox/exec/tests/CustomTraceTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <fmt/format.h>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <unordered_map>
 #include <utility>
@@ -24,6 +25,7 @@
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/exec/trace/TraceCtx.h"
+#include "velox/expression/VectorFunction.h"
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
@@ -1086,6 +1088,147 @@ TEST_F(CustomTraceTest, parallelMoveStepWithPlanId) {
   // batch.
   EXPECT_EQ(numProject2Hits, kNumDrivers * kNumBatches);
   EXPECT_EQ(numFinalOutputs, kNumDrivers * kNumBatches);
+}
+
+// TraceCtx that tracks maybeActivateIntraExprTracing calls.
+class IntraExprTraceCtx : public TraceCtx {
+ public:
+  IntraExprTraceCtx(
+      const std::vector<std::string>& tracedExprs,
+      std::vector<std::string>& activatedFunctions)
+      : TraceCtx(false),
+        tracedExprs_(tracedExprs.begin(), tracedExprs.end()),
+        activatedFunctions_(activatedFunctions) {}
+
+  bool shouldTrace(const Operator&) const override {
+    return true;
+  }
+
+  bool shouldTraceExpr(std::string_view functionName) const override {
+    return tracedExprs_.contains(std::string(functionName));
+  }
+
+  std::unique_ptr<TraceExprWriter> createExprOutputTracer(
+      const Operator&,
+      std::string_view,
+      int) const override {
+    return nullptr;
+  }
+
+  void maybeActivateIntraExprTracing(
+      const Operator&,
+      std::string_view functionName,
+      VectorFunction&) const override {
+    activatedFunctions_.emplace_back(functionName);
+  }
+
+ private:
+  std::unordered_set<std::string> tracedExprs_;
+  std::vector<std::string>& activatedFunctions_;
+};
+
+TEST_F(CustomTraceTest, intraExprTracingCalledForTracedFunctions) {
+  auto vector = makeRowVector(
+      {"a"}, {makeFlatVector<int64_t>(10, [](auto row) { return row; })});
+
+  auto plan =
+      PlanBuilder().values({vector}).project({"a * 10 as a"}).planNode();
+
+  std::vector<std::string> activatedFunctions;
+  auto queryCtx =
+      core::QueryCtx::Builder()
+          .executor(executor_.get())
+          .traceCtxProvider([&](core::QueryCtx&, const core::PlanFragment&) {
+            return std::make_unique<IntraExprTraceCtx>(
+                std::vector<std::string>{"multiply"}, activatedFunctions);
+          })
+          .build();
+
+  std::shared_ptr<Task> task;
+  AssertQueryBuilder(plan)
+      .config(core::QueryConfig::kQueryTraceEnabled, true)
+      .queryCtx(queryCtx)
+      .countResults(task);
+
+  EXPECT_THAT(activatedFunctions, testing::ElementsAre("multiply"));
+}
+
+TEST_F(CustomTraceTest, intraExprTracingNotCalledForUntracedFunctions) {
+  auto vector = makeRowVector(
+      {"a"}, {makeFlatVector<int64_t>(10, [](auto row) { return row; })});
+
+  auto plan = PlanBuilder()
+                  .values({vector})
+                  .project({"a * 10 as b", "a + 5 as c"})
+                  .planNode();
+
+  std::vector<std::string> activatedFunctions;
+  auto queryCtx =
+      core::QueryCtx::Builder()
+          .executor(executor_.get())
+          .traceCtxProvider([&](core::QueryCtx&, const core::PlanFragment&) {
+            return std::make_unique<IntraExprTraceCtx>(
+                std::vector<std::string>{"plus"}, activatedFunctions);
+          })
+          .build();
+
+  std::shared_ptr<Task> task;
+  AssertQueryBuilder(plan)
+      .config(core::QueryConfig::kQueryTraceEnabled, true)
+      .queryCtx(queryCtx)
+      .countResults(task);
+
+  EXPECT_THAT(activatedFunctions, testing::ElementsAre("plus"));
+}
+
+TEST_F(CustomTraceTest, intraExprTracingNotCalledWhenOperatorNotTraced) {
+  auto vector = makeRowVector(
+      {"a"}, {makeFlatVector<int64_t>(10, [](auto row) { return row; })});
+
+  // TraceCtx where shouldTrace returns false for all operators.
+  class NoOpTraceCtx : public TraceCtx {
+   public:
+    explicit NoOpTraceCtx(std::vector<std::string>& activatedFunctions)
+        : TraceCtx(false), activatedFunctions_(activatedFunctions) {}
+
+    bool shouldTrace(const Operator&) const override {
+      return false;
+    }
+
+    bool shouldTraceExpr(std::string_view) const override {
+      return true;
+    }
+
+    void maybeActivateIntraExprTracing(
+        const Operator&,
+        std::string_view functionName,
+        VectorFunction&) const override {
+      activatedFunctions_.emplace_back(functionName);
+    }
+
+   private:
+    std::vector<std::string>& activatedFunctions_;
+  };
+
+  auto plan =
+      PlanBuilder().values({vector}).project({"a * 10 as a"}).planNode();
+
+  std::vector<std::string> activatedFunctions;
+  auto queryCtx =
+      core::QueryCtx::Builder()
+          .executor(executor_.get())
+          .traceCtxProvider([&](core::QueryCtx&, const core::PlanFragment&) {
+            return std::make_unique<NoOpTraceCtx>(activatedFunctions);
+          })
+          .build();
+
+  std::shared_ptr<Task> task;
+  AssertQueryBuilder(plan)
+      .config(core::QueryConfig::kQueryTraceEnabled, true)
+      .queryCtx(queryCtx)
+      .countResults(task);
+
+  EXPECT_THAT(activatedFunctions, testing::IsEmpty());
 }
 
 } // namespace

--- a/velox/exec/trace/TraceCtx.h
+++ b/velox/exec/trace/TraceCtx.h
@@ -19,6 +19,7 @@
 #include <cstdint>
 #include <functional>
 #include <string>
+#include <string_view>
 #include "velox/exec/trace/TraceWriter.h"
 
 namespace facebook::velox::exec {
@@ -50,10 +51,27 @@ class TraceCtx {
     return nullptr;
   }
 
-  /// Whether a particular operator should be traced. Called before the task
-  /// starts execution, when operators are instantiated.
+  /// Returns whether a particular operator should be traced. Called before the
+  /// task starts execution, when operators are instantiated.
   virtual bool shouldTrace(const Operator&) const {
     return false;
+  }
+
+  /// Returns whether a particular expression function should be traced. Called
+  /// during operator initialization in Expr::maybeSetupTracer().
+  virtual bool shouldTraceExpr(std::string_view /*functionName*/) const {
+    return false;
+  }
+
+  /// Creates a writer for capturing output batches from a traced expression.
+  /// The instanceIndex distinguishes multiple Expr nodes with the same
+  /// function name within a single operator. Ownership is transferred to the
+  /// caller.
+  virtual std::unique_ptr<trace::TraceExprWriter> createExprOutputTracer(
+      const Operator& /*op*/,
+      std::string_view /*functionName*/,
+      int /*instanceIndex*/) const {
+    return nullptr;
   }
 
   bool dryRun() const {

--- a/velox/exec/trace/TraceCtx.h
+++ b/velox/exec/trace/TraceCtx.h
@@ -75,6 +75,14 @@ class TraceCtx {
     return nullptr;
   }
 
+  /// Creates a writer for capturing input batches to a traced expression.
+  virtual std::unique_ptr<trace::TraceExprInputWriter> createExprInputTracer(
+      const Operator& /*op*/,
+      std::string_view /*functionName*/,
+      int /*instanceIndex*/) const {
+    return nullptr;
+  }
+
   /// Activates intra-expression tracing on a vector function whose owning
   /// operator and expression have both passed the tracing gates
   /// (shouldTrace() and shouldTraceExpr() respectively).

--- a/velox/exec/trace/TraceCtx.h
+++ b/velox/exec/trace/TraceCtx.h
@@ -24,7 +24,8 @@
 
 namespace facebook::velox::exec {
 class Operator;
-}
+class VectorFunction;
+} // namespace facebook::velox::exec
 
 namespace facebook::velox::exec::trace {
 
@@ -73,6 +74,14 @@ class TraceCtx {
       int /*instanceIndex*/) const {
     return nullptr;
   }
+
+  /// Activates intra-expression tracing on a vector function whose owning
+  /// operator and expression have both passed the tracing gates
+  /// (shouldTrace() and shouldTraceExpr() respectively).
+  virtual void maybeActivateIntraExprTracing(
+      const Operator& /*op*/,
+      std::string_view /*functionName*/,
+      VectorFunction& /*function*/) const {}
 
   bool dryRun() const {
     return dryRun_;

--- a/velox/exec/trace/TraceWriter.h
+++ b/velox/exec/trace/TraceWriter.h
@@ -60,6 +60,21 @@ class TraceExprWriter {
   virtual void finish() = 0;
 };
 
+/// Abstract interface for capturing traced expression input. Implementations
+/// receive the raw input vectors (which may include null entries) and are
+/// responsible for filtering, wrapping, and serializing them.
+class TraceExprInputWriter {
+ public:
+  virtual ~TraceExprInputWriter() = default;
+
+  /// Writes expression input vectors. The inputs vector may contain null
+  /// entries which implementations should skip.
+  virtual void write(const std::vector<VectorPtr>& inputs) = 0;
+
+  /// Closes the data file and writes out the data summary.
+  virtual void finish() = 0;
+};
+
 /// Abstract interface for capturing traced split information. Implementations
 /// are responsible for processing and/or recording the splits found during
 /// query execution tracing, enabling replay and analysis of query input

--- a/velox/exec/trace/TraceWriter.h
+++ b/velox/exec/trace/TraceWriter.h
@@ -45,6 +45,21 @@ class TraceInputWriter {
   virtual void finish() = 0;
 };
 
+/// Abstract interface for capturing traced expression output. Implementations
+/// are responsible for processing individual expression result vectors during
+/// query execution tracing.
+class TraceExprWriter {
+ public:
+  virtual ~TraceExprWriter() = default;
+
+  /// Writes a single expression output vector. Expression tracing runs inside
+  /// Expr::apply(), which has no mechanism to block the driver pipeline.
+  virtual void write(const VectorPtr& result) = 0;
+
+  /// Closes the data file and writes out the data summary.
+  virtual void finish() = 0;
+};
+
 /// Abstract interface for capturing traced split information. Implementations
 /// are responsible for processing and/or recording the splits found during
 /// query execution tracing, enabling replay and analysis of query input

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1710,6 +1710,10 @@ void Expr::applyFunction(
       ? computeIsAsciiForResult(vectorFunction_.get(), inputValues_, rows)
       : std::nullopt;
 
+  if (FOLLY_UNLIKELY(inputTracer_ != nullptr)) {
+    inputTracer_->write(inputValues_);
+  }
+
   try {
     vectorFunction_->apply(rows, inputValues_, type(), context, result);
   } catch (const VeloxException&) {
@@ -2043,6 +2047,7 @@ void Expr::maybeSetupTracer(
   if (traceCtx.shouldTraceExpr(name_)) {
     const int index = instanceCounts[name_]++;
     outputTracer_ = traceCtx.createExprOutputTracer(op, name_, index);
+    inputTracer_ = traceCtx.createExprInputTracer(op, name_, index);
     if (vectorFunction_) {
       traceCtx.maybeActivateIntraExprTracing(op, name_, *vectorFunction_);
     }
@@ -2065,6 +2070,9 @@ void Expr::finishTracer(std::unordered_set<Expr*>& visited) {
   }
   if (outputTracer_) {
     outputTracer_->finish();
+  }
+  if (inputTracer_) {
+    inputTracer_->finish();
   }
   for (auto& input : inputs_) {
     input->finishTracer(visited);

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -23,6 +23,7 @@
 #include "velox/common/base/SuccinctPrinter.h"
 #include "velox/common/process/ThreadDebugInfo.h"
 #include "velox/common/testutil/TestValue.h"
+#include "velox/exec/trace/TraceCtx.h"
 #include "velox/expression/CastExpr.h"
 
 #include "velox/common/EnumDefine.h"
@@ -1717,6 +1718,10 @@ void Expr::applyFunction(
     VELOX_USER_FAIL(e.what());
   }
 
+  if (FOLLY_UNLIKELY(outputTracer_ != nullptr) && result) {
+    outputTracer_->write(result);
+  }
+
   if (!result) {
     MutableRemainingRows remainingRows(rows, context);
 
@@ -2014,6 +2019,52 @@ ExprSet::ExprSet(
   for (auto& expr : exprs_) {
     Expr::mergeFields(
         distinctFields_, multiplyReferencedFields_, expr->distinctFields());
+  }
+}
+
+void ExprSet::maybeSetupTracers(
+    const Operator& op,
+    const trace::TraceCtx& traceCtx) {
+  std::unordered_set<Expr*> visited;
+  std::unordered_map<std::string, int> instanceCounts;
+  for (auto& expr : exprs_) {
+    expr->maybeSetupTracer(op, traceCtx, visited, instanceCounts);
+  }
+}
+
+void Expr::maybeSetupTracer(
+    const Operator& op,
+    const trace::TraceCtx& traceCtx,
+    std::unordered_set<Expr*>& visited,
+    std::unordered_map<std::string, int>& instanceCounts) {
+  if (!visited.insert(this).second) {
+    return;
+  }
+  if (traceCtx.shouldTraceExpr(name_)) {
+    const int index = instanceCounts[name_]++;
+    outputTracer_ = traceCtx.createExprOutputTracer(op, name_, index);
+  }
+  for (auto& input : inputs_) {
+    input->maybeSetupTracer(op, traceCtx, visited, instanceCounts);
+  }
+}
+
+void ExprSet::finishTracers() {
+  std::unordered_set<Expr*> visited;
+  for (auto& expr : exprs_) {
+    expr->finishTracer(visited);
+  }
+}
+
+void Expr::finishTracer(std::unordered_set<Expr*>& visited) {
+  if (!visited.insert(this).second) {
+    return;
+  }
+  if (outputTracer_) {
+    outputTracer_->finish();
+  }
+  for (auto& input : inputs_) {
+    input->finishTracer(visited);
   }
 }
 

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -2043,6 +2043,9 @@ void Expr::maybeSetupTracer(
   if (traceCtx.shouldTraceExpr(name_)) {
     const int index = instanceCounts[name_]++;
     outputTracer_ = traceCtx.createExprOutputTracer(op, name_, index);
+    if (vectorFunction_) {
+      traceCtx.maybeActivateIntraExprTracing(op, name_, *vectorFunction_);
+    }
   }
   for (auto& input : inputs_) {
     input->maybeSetupTracer(op, traceCtx, visited, instanceCounts);

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -796,6 +796,9 @@ class Expr {
 
   // Cached output tracer set up during expression initialization.
   std::unique_ptr<trace::TraceExprWriter> outputTracer_;
+
+  // Cached input tracer set up during expression initialization.
+  std::unique_ptr<trace::TraceExprInputWriter> inputTracer_;
 };
 
 /// Generate a selectivity vector of a single row.

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -23,16 +23,22 @@
 
 #include "velox/common/time/CpuWallTimer.h"
 #include "velox/core/ExpressionEvaluator.h"
+#include "velox/exec/trace/TraceWriter.h"
 #include "velox/expression/EvalCtx.h"
 #include "velox/expression/ExprStats.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/type/Subfield.h"
 #include "velox/vector/SimpleVector.h"
 
+namespace facebook::velox::exec::trace {
+class TraceCtx;
+} // namespace facebook::velox::exec::trace
+
 namespace facebook::velox::exec {
 
 class ExprSet;
 class FieldReference;
+class Operator;
 class VectorFunction;
 
 /// Maintains a set of rows for evaluation and removes rows with
@@ -436,6 +442,21 @@ class Expr {
     return inputValues_;
   }
 
+  /// Sets up expression-level output tracer if the given TraceCtx indicates
+  /// this expression should be traced. Called once during operator
+  /// initialization. Uses a visited set to avoid redundant traversal of
+  /// shared CSE nodes.
+  void maybeSetupTracer(
+      const Operator& op,
+      const trace::TraceCtx& traceCtx,
+      std::unordered_set<Expr*>& visited,
+      std::unordered_map<std::string, int>& instanceCounts);
+
+  /// Finishes expression-level output tracing by calling finish() on the
+  /// cached tracer. Uses a visited set to avoid redundant traversal of
+  /// shared CSE nodes.
+  void finishTracer(std::unordered_set<Expr*>& visited);
+
   void setAllNulls(
       const SelectivityVector& rows,
       EvalCtx& context,
@@ -772,6 +793,9 @@ class Expr {
   // True if distinctFields_ are identical to at least one of the parent
   // expression's distinct fields.
   bool sameAsParentDistinctFields_ = false;
+
+  // Cached output tracer set up during expression initialization.
+  std::unique_ptr<trace::TraceExprWriter> outputTracer_;
 };
 
 /// Generate a selectivity vector of a single row.
@@ -857,6 +881,13 @@ class ExprSet {
   void addToMemo(Expr* expr) {
     memoizingExprs_.insert(expr);
   }
+
+  /// Sets up expression-level tracers on all expressions in this set.
+  void maybeSetupTracers(const Operator& op, const trace::TraceCtx& traceCtx);
+
+  /// Finishes expression-level tracers on all expressions in this set.
+  /// Called during operator close.
+  void finishTracers();
 
   /// Returns text representation of the expression set.
   /// @param compact If true, uses one-line representation for each expression.


### PR DESCRIPTION
Summary:

Adds expression input tracing, complementing the existing output tracing. When expression tracing is configured for a function, the tracer now captures both the input arguments (before the function executes) and the output result (after execution).

Changes:
- `TraceCtx`: Added `createExprInputTracer(op, functionName, instanceIndex)` virtual method returning a `TraceInputWriter` for capturing expression inputs as a `RowVector`
- `Expr::maybeSetupTracer()`: Creates and caches the input tracer alongside the output tracer
- `Expr::apply()`: Writes input vectors to the tracer before calling `vectorFunction_->apply()`
- `Expr::finishTracer()`: Calls `finish()` on the input tracer during operator close

Differential Revision: D103463116


