### PR TITLE
build: Bump Presto Java image to 0.297

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ services:
     image: ghcr.io/facebookincubator/velox-dev:presto-java
     build:
       args:
-        - PRESTO_VERSION=0.295
+        - PRESTO_VERSION=0.297
       dockerfile: scripts/docker/java.dockerfile
 
   spark-server:

--- a/scripts/docker/java.dockerfile
+++ b/scripts/docker/java.dockerfile
@@ -15,7 +15,7 @@
 
 # Global arg default to share across stages
 ARG SPARK_VERSION=3.5.1
-ARG PRESTO_VERSION=0.295
+ARG PRESTO_VERSION=0.297
 
 #########################
 # Stage: Spark Download #


### PR DESCRIPTION
Summary:
- Bump Presto version for the Java Docker image from 0.295 to 0.297.
- Keep docker-compose build args in sync.

Tests:
- Not run (version-only Docker image config change).