### PR TITLE
feat(iceberg): Support customize file name generator for IcebergInsertTableHandle

### DIFF
--- a/velox/connectors/hive/iceberg/IcebergConnector.cpp
+++ b/velox/connectors/hive/iceberg/IcebergConnector.cpp
@@ -131,4 +131,8 @@ std::unique_ptr<DataSink> IcebergConnector::createDataSink(
       static_cast<int32_t>(icebergInsertHandle->writeKind()));
 }
 
+void IcebergConnector::registerSerDe() {
+  IcebergFileNameGenerator::registerSerDe();
+}
+
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergConnector.h
+++ b/velox/connectors/hive/iceberg/IcebergConnector.h
@@ -62,6 +62,8 @@ class IcebergConnector final : public HiveConnector {
       ConnectorQueryCtx* connectorQueryCtx,
       CommitStrategy commitStrategy) override;
 
+  static void registerSerDe();
+
  private:
   const std::shared_ptr<IcebergConfig> icebergConfig_;
 };

--- a/velox/connectors/hive/iceberg/IcebergDataSink.cpp
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.cpp
@@ -84,23 +84,11 @@ folly::dynamic extractPartitionValue<TypeKind::TIMESTAMP>(
   return child->asChecked<SimpleVector<Timestamp>>()->valueAt(row).toMicros();
 }
 
-class IcebergFileNameGenerator : public FileNameGenerator {
- public:
-  std::pair<std::string, std::string> gen(
-      std::optional<uint32_t> bucketId,
-      const std::shared_ptr<const HiveInsertTableHandle> insertTableHandle,
-      const ConnectorQueryCtx& connectorQueryCtx,
-      uint32_t maxNumBuckets,
-      bool commitRequired) const override;
-
-  folly::dynamic serialize() const override;
-
-  std::string toString() const override;
-};
-
 std::string makeUuid() {
   return boost::lexical_cast<std::string>(boost::uuids::random_generator()());
 }
+
+} // namespace
 
 std::pair<std::string, std::string> IcebergFileNameGenerator::gen(
     std::optional<uint32_t> bucketId,
@@ -128,7 +116,17 @@ std::string IcebergFileNameGenerator::toString() const {
   return "IcebergFileNameGenerator";
 }
 
-} // namespace
+std::shared_ptr<IcebergFileNameGenerator> IcebergFileNameGenerator::deserialize(
+    const folly::dynamic& /* obj */,
+    void* /* context */) {
+  return std::make_shared<IcebergFileNameGenerator>();
+}
+
+void IcebergFileNameGenerator::registerSerDe() {
+  auto& registry = DeserializationWithContextRegistryForSharedPtr();
+  registry.Register(
+      "IcebergFileNameGenerator", IcebergFileNameGenerator::deserialize);
+}
 
 IcebergInsertTableHandle::IcebergInsertTableHandle(
     std::vector<IcebergColumnHandlePtr> inputColumns,
@@ -137,7 +135,8 @@ IcebergInsertTableHandle::IcebergInsertTableHandle(
     IcebergPartitionSpecPtr partitionSpec,
     std::optional<common::CompressionKind> compressionKind,
     const std::unordered_map<std::string, std::string>& serdeParameters,
-    WriteKind writeKind)
+    WriteKind writeKind,
+    std::shared_ptr<const FileNameGenerator> fileNameGenerator)
     : HiveInsertTableHandle(
           std::vector<HiveColumnHandlePtr>(
               inputColumns.begin(),
@@ -149,7 +148,7 @@ IcebergInsertTableHandle::IcebergInsertTableHandle(
           serdeParameters,
           nullptr,
           false,
-          std::make_shared<const HiveInsertFileNameGenerator>()),
+          std::move(fileNameGenerator)),
       partitionSpec_(partitionSpec),
       writeKind_(writeKind) {
   // Data-file writes and merge writes both require the input row type to

--- a/velox/connectors/hive/iceberg/IcebergDataSink.h
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.h
@@ -35,6 +35,28 @@
 
 namespace facebook::velox::connector::hive::iceberg {
 
+class IcebergFileNameGenerator : public FileNameGenerator {
+ public:
+  IcebergFileNameGenerator() {}
+
+  std::pair<std::string, std::string> gen(
+      std::optional<uint32_t> bucketId,
+      const std::shared_ptr<const HiveInsertTableHandle> insertTableHandle,
+      const ConnectorQueryCtx& connectorQueryCtx,
+      uint32_t maxNumBuckets,
+      bool commitRequired) const override;
+
+  static void registerSerDe();
+
+  folly::dynamic serialize() const override;
+
+  std::string toString() const override;
+
+  static std::shared_ptr<IcebergFileNameGenerator> deserialize(
+      const folly::dynamic& obj,
+      void* context);
+};
+
 /// Represents a request for Iceberg write.
 class IcebergInsertTableHandle final : public HiveInsertTableHandle {
  public:
@@ -80,6 +102,8 @@ class IcebergInsertTableHandle final : public HiveInsertTableHandle {
   /// @param writeKind Selects between data-file emission (default) and V3
   /// deletion-vector emission. The default preserves existing INSERT
   /// semantics.
+  /// @param fileNameGenerator File name generator for generating unique file
+  /// names for data files. Defaults to IcebergFileNameGenerator.
   IcebergInsertTableHandle(
       std::vector<IcebergColumnHandlePtr> inputColumns,
       LocationHandlePtr locationHandle,
@@ -87,7 +111,9 @@ class IcebergInsertTableHandle final : public HiveInsertTableHandle {
       IcebergPartitionSpecPtr partitionSpec,
       std::optional<common::CompressionKind> compressionKind = {},
       const std::unordered_map<std::string, std::string>& serdeParameters = {},
-      WriteKind writeKind = WriteKind::kData);
+      WriteKind writeKind = WriteKind::kData,
+      std::shared_ptr<const FileNameGenerator> fileNameGenerator =
+          std::make_shared<const IcebergFileNameGenerator>());
 
   /// Returns the Iceberg partition specification that defines how the table
   /// is partitioned.


### PR DESCRIPTION
Expose fileNameGenerator in IcebergInsertTableHandle so that users can provide a custom fileNameGenerator when creating it—for example, to include partition ID, task ID, or other information in Gluten.

Original commit: https://github.com/IBM/velox/pull/1571