### PR TITLE
feat: Add MetadataInput for IO-coalesced metadata loading with optional caching (#17438)

### DIFF
--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -486,9 +486,9 @@ void CacheShard::acquireEvictedData(
     const uint64_t bytes = entry->size_;
     if (bytesToAcquire > 0) {
       bytesToAcquire = bytes > bytesToAcquire ? 0 : bytesToAcquire - bytes;
-      acquired.contiguous.emplace_back(entry->contiguousData_, bytes);
+      acquired.byteAllocations.emplace_back(entry->contiguousData_, bytes);
     } else {
-      toFree.contiguous.emplace_back(entry->contiguousData_, bytes);
+      toFree.byteAllocations.emplace_back(entry->contiguousData_, bytes);
     }
     entry->contiguousData_ = nullptr;
     largeEvicted += memory::AllocationTraits::pageBytes(
@@ -498,9 +498,9 @@ void CacheShard::acquireEvictedData(
     const auto bytes = entry->nonContiguousData_.byteSize();
     if (bytesToAcquire > 0) {
       bytesToAcquire = bytes > bytesToAcquire ? 0 : bytesToAcquire - bytes;
-      acquired.nonContiguous.appendMove(entry->nonContiguousData());
+      acquired.nonContiguousAllocs.appendMove(entry->nonContiguousData());
     } else {
-      toFree.nonContiguous.appendMove(entry->nonContiguousData());
+      toFree.nonContiguousAllocs.appendMove(entry->nonContiguousData());
     }
     VELOX_DCHECK(entry->nonContiguousData().empty());
     largeEvicted += bytes;
@@ -746,16 +746,16 @@ bool CacheShard::removeFileEntries(
         continue;
       }
 
-      numAgedOut_++;
+      ++numAgedOut_;
       ++numRemoved;
       if (cacheEntry->contiguousData_ != nullptr) {
         pagesRemoved += memory::AllocationTraits::numPages(cacheEntry->size_);
-        toFree.contiguous.emplace_back(
+        toFree.byteAllocations.emplace_back(
             cacheEntry->contiguousData_, cacheEntry->size_);
         cacheEntry->contiguousData_ = nullptr;
       } else {
         pagesRemoved += cacheEntry->nonContiguousData().numPages();
-        toFree.nonContiguous.appendMove(cacheEntry->nonContiguousData());
+        toFree.nonContiguousAllocs.appendMove(cacheEntry->nonContiguousData());
       }
       removeEntryLocked(cacheEntry.get());
       emptySlots_.push_back(entryIndex);

--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -342,8 +342,8 @@ class AsyncDataCacheEntry {
   // The data being cached (non-contiguous page runs).
   memory::Allocation nonContiguousData_;
 
-  // Contiguous bytes allocated via allocateBytes (jemalloc). Populated when
-  // the entry is created with contiguous=true and size >= kTinyDataSize.
+  // Contiguous bytes allocated via allocateBytes. Populated when the entry is
+  // created with contiguous=true and size >= kTinyDataSize.
   void* contiguousData_{nullptr};
 
   // Contains the cached data if this is much smaller than a MemoryAllocator

--- a/velox/common/caching/SsdFile.cpp
+++ b/velox/common/caching/SsdFile.cpp
@@ -232,6 +232,9 @@ CoalesceIoStats SsdFile::load(
         read(offset, buffers);
       });
 
+  common::testutil::TestValue::adjust(
+      "facebook::velox::cache::SsdFile::load", this);
+
   for (auto i = 0; i < ssdPins.size(); ++i) {
     pins[i].checkedEntry()->setSsdFile(this, ssdPins[i].run().offset());
     auto* entry = pins[i].checkedEntry();

--- a/velox/common/caching/SsdFile.h
+++ b/velox/common/caching/SsdFile.h
@@ -336,6 +336,7 @@ class SsdFile {
 
   /// Erases 'key'
   bool erase(RawFileCacheKey key);
+
   /// Copies the data in 'ssdPins' into 'pins'. Coalesces IO for nearby
   /// entries if they are in ascending order and near enough.
   CoalesceIoStats load(

--- a/velox/common/caching/tests/AsyncDataCacheTest.cpp
+++ b/velox/common/caching/tests/AsyncDataCacheTest.cpp
@@ -2173,7 +2173,7 @@ TEST_P(AsyncDataCacheTest, acquiredMemory) {
     memory::Allocation allocation;
     ASSERT_TRUE(allocator->allocateNonContiguous(10, allocation));
     const auto expectedBytes = allocation.byteSize();
-    acquired.nonContiguous.appendMove(allocation);
+    acquired.nonContiguousAllocs.appendMove(allocation);
 
     ASSERT_FALSE(acquired.empty());
     ASSERT_EQ(acquired.totalBytes(), expectedBytes);
@@ -2183,15 +2183,15 @@ TEST_P(AsyncDataCacheTest, acquiredMemory) {
     ASSERT_EQ(acquired.totalBytes(), 0);
   }
 
-  // Contiguous only.
+  // Byte allocations only.
   {
     AcquiredMemory acquired;
     auto* ptr1 = allocator->allocateBytes(1'024);
     auto* ptr2 = allocator->allocateBytes(2'048);
     ASSERT_NE(ptr1, nullptr);
     ASSERT_NE(ptr2, nullptr);
-    acquired.contiguous.emplace_back(ptr1, 1'024);
-    acquired.contiguous.emplace_back(ptr2, 2'048);
+    acquired.byteAllocations.emplace_back(ptr1, 1'024);
+    acquired.byteAllocations.emplace_back(ptr2, 2'048);
 
     ASSERT_FALSE(acquired.empty());
     ASSERT_EQ(acquired.totalBytes(), 3'072);
@@ -2201,21 +2201,21 @@ TEST_P(AsyncDataCacheTest, acquiredMemory) {
     ASSERT_EQ(acquired.totalBytes(), 0);
   }
 
-  // Mixed non-contiguous and contiguous.
+  // Mixed non-contiguous and byte allocations.
   {
     AcquiredMemory acquired;
     memory::Allocation allocation;
     ASSERT_TRUE(allocator->allocateNonContiguous(10, allocation));
     const auto nonContiguousBytes = allocation.byteSize();
-    acquired.nonContiguous.appendMove(allocation);
+    acquired.nonContiguousAllocs.appendMove(allocation);
 
-    constexpr uint64_t kContiguousSize = 4'096;
-    auto* ptr = allocator->allocateBytes(kContiguousSize);
+    constexpr uint64_t kByteAllocSize = 4'096;
+    auto* ptr = allocator->allocateBytes(kByteAllocSize);
     ASSERT_NE(ptr, nullptr);
-    acquired.contiguous.emplace_back(ptr, kContiguousSize);
+    acquired.byteAllocations.emplace_back(ptr, kByteAllocSize);
 
     ASSERT_FALSE(acquired.empty());
-    ASSERT_EQ(acquired.totalBytes(), nonContiguousBytes + kContiguousSize);
+    ASSERT_EQ(acquired.totalBytes(), nonContiguousBytes + kByteAllocSize);
 
     acquired.free(allocator);
     ASSERT_TRUE(acquired.empty());

--- a/velox/common/memory/MemoryAllocator.cpp
+++ b/velox/common/memory/MemoryAllocator.cpp
@@ -29,11 +29,11 @@ DECLARE_bool(velox_memory_use_hugepages);
 namespace facebook::velox::memory {
 
 void AcquiredMemory::free(MemoryAllocator* allocator) {
-  allocator->freeNonContiguous(nonContiguous);
-  for (auto& [ptr, size] : contiguous) {
+  allocator->freeNonContiguous(nonContiguousAllocs);
+  for (auto& [ptr, size] : byteAllocations) {
     allocator->freeBytes(ptr, size);
   }
-  contiguous.clear();
+  byteAllocations.clear();
 }
 
 // static

--- a/velox/common/memory/MemoryAllocator.h
+++ b/velox/common/memory/MemoryAllocator.h
@@ -141,15 +141,17 @@ struct Stats {
 class MemoryAllocator;
 
 /// Memory collected from evicted cache entries. Non-contiguous page
-/// allocations and contiguous byte allocations are tracked separately so they
-/// can be freed back to the allocator before retrying allocation.
+/// allocations and byte allocations (from allocateBytes()) are tracked
+/// separately so they can be freed back to the allocator before retrying
+/// allocation.
 struct AcquiredMemory {
-  Allocation nonContiguous;
-  std::vector<std::pair<void*, uint64_t>> contiguous;
+  Allocation nonContiguousAllocs;
+  // Byte allocations from allocateBytes().
+  std::vector<std::pair<void*, uint64_t>> byteAllocations;
 
   uint64_t totalBytes() const {
-    uint64_t bytes = nonContiguous.byteSize();
-    for (const auto& [_, size] : contiguous) {
+    uint64_t bytes = nonContiguousAllocs.byteSize();
+    for (const auto& [_, size] : byteAllocations) {
       bytes += size;
     }
     return bytes;
@@ -158,7 +160,7 @@ struct AcquiredMemory {
   void free(MemoryAllocator* allocator);
 
   bool empty() const {
-    return nonContiguous.empty() && contiguous.empty();
+    return nonContiguousAllocs.empty() && byteAllocations.empty();
   }
 };
 


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookincubator/nimble/pull/705

CONTEXT: Nimble metadata (stripes, stripe groups, cluster index) is stored compressed on disk and decompressed on every read. There is no process-wide caching of the decompressed metadata — each reader decompresses independently, wasting CPU. Metadata sections are also read individually without IO coalescing.

WHAT:

**FlatBuffers schema:**
- Add `uncompressed_size` field to MetadataSection table, enabling efficient pre-allocation of decompression buffers. Old files read 0 (default) for backward compatibility. The MetadataSection C++ class stores this as `std::optional<uint32_t>` — nullopt for old files, present for new files.

**ZstdCompression:**
- Add uncompress(source, destination, destinationSize) overload for decompressing directly into a caller-provided buffer (zero copy into cache pins).

**MetadataBuffer:**
- Add CachePin storage path alongside the existing BufferPtr path. content() dispatches between the two, enabling zero-copy access to cached metadata.
- Add static decompress() factory methods for BufferPtr and IOBuf inputs.

**MetadataInput:**
- Two-phase IO: enqueue() registers sections and returns a MetadataHandle, load() executes coalesced preadv for all enqueued sections, handle.read() returns the decompressed MetadataBuffer.
- DirectMetadataInput: IO coalescing via velox::coalesceIo, no caching.
- CachedMetadataInput: IO coalescing + AsyncDataCache (memory + SSD tiers). Checks memory cache → SSD cache → file IO. Caches decompressed metadata in contiguous cache entries. For uncompressed sections, reads directly into cache pin buffers (zero copy). For compressed sections, decompresses directly into cache pin buffers.
- QueryIoLatencyGuard RAII class for measuring IO latency.
- Records coalesced IO stats (payload bytes, overread bytes).

**TabletReader integration:**
- Uses MetadataInput for loading stripe group and optional section metadata with IO coalescing.

Reviewed By: Yuhta, tanjialiang

Differential Revision: D102478682


