### PR TITLE
fix(writer): Wire WriterOptions::memoryBudget into WriterContext::getMemoryBudget() (#17444)

### DIFF
--- a/velox/dwio/dwrf/test/WriterContextTest.cpp
+++ b/velox/dwio/dwrf/test/WriterContextTest.cpp
@@ -219,6 +219,44 @@ TEST_F(WriterContextTest, memory) {
   ASSERT_EQ(context.availableMemoryReservation(), 786368);
 }
 
+TEST_F(WriterContextTest, memoryBudgetDefault) {
+  auto pool = memory::memoryManager()->addRootPool("memoryBudgetDefault");
+  WriterContext context{std::make_shared<Config>(), pool};
+  ASSERT_EQ(context.getMemoryBudget(), pool->maxCapacity());
+}
+
+TEST_F(WriterContextTest, memoryBudgetLessThanPoolCapacity) {
+  const int64_t poolCapacity = 1L << 30;
+  const int64_t budget = 256L << 20;
+  auto pool = memory::memoryManager()->addRootPool(
+      "memoryBudgetLessThanPoolCapacity", poolCapacity);
+  WriterContext context{
+      std::make_shared<Config>(),
+      pool,
+      dwio::common::MetricsLog::voidLog(),
+      nullptr,
+      false,
+      nullptr,
+      budget};
+  ASSERT_EQ(context.getMemoryBudget(), budget);
+}
+
+TEST_F(WriterContextTest, memoryBudgetGreaterThanPoolCapacity) {
+  const int64_t poolCapacity = 256L << 20;
+  const int64_t budget = 1L << 30;
+  auto pool = memory::memoryManager()->addRootPool(
+      "memoryBudgetGreaterThanPoolCapacity", poolCapacity);
+  WriterContext context{
+      std::make_shared<Config>(),
+      pool,
+      dwio::common::MetricsLog::voidLog(),
+      nullptr,
+      false,
+      nullptr,
+      budget};
+  ASSERT_EQ(context.getMemoryBudget(), poolCapacity);
+}
+
 TEST_F(WriterContextTest, abort) {
   auto writerRoot = memory::memoryManager()->addRootPool(
       "abort", 1L << 30, exec::MemoryReclaimer::create());

--- a/velox/dwio/dwrf/writer/Writer.cpp
+++ b/velox/dwio/dwrf/writer/Writer.cpp
@@ -175,7 +175,8 @@ Writer::Writer(
       pool,
       options.sessionTimezone,
       options.adjustTimestampToTimezone,
-      std::move(handler));
+      std::move(handler),
+      options.memoryBudget);
   auto& context = writerBase_->getContext();
   VELOX_CHECK_EQ(
       context.getTotalMemoryUsage(),

--- a/velox/dwio/dwrf/writer/WriterBase.h
+++ b/velox/dwio/dwrf/writer/WriterBase.h
@@ -80,14 +80,16 @@ class WriterBase {
       std::shared_ptr<velox::memory::MemoryPool> pool,
       const tz::TimeZone* sessionTimezone = nullptr,
       const bool adjustTimestampToTimezone = false,
-      std::unique_ptr<encryption::EncryptionHandler> handler = nullptr) {
+      std::unique_ptr<encryption::EncryptionHandler> handler = nullptr,
+      int64_t memoryBudget = std::numeric_limits<int64_t>::max()) {
     context_ = std::make_unique<WriterContext>(
         config,
         std::move(pool),
         sink_->metricsLog(),
         sessionTimezone,
         adjustTimestampToTimezone,
-        std::move(handler));
+        std::move(handler),
+        memoryBudget);
     writerSink_ = std::make_unique<WriterSink>(
         *sink_,
         context_->getMemoryPool(MemoryUsageCategory::OUTPUT_STREAM),

--- a/velox/dwio/dwrf/writer/WriterContext.cpp
+++ b/velox/dwio/dwrf/writer/WriterContext.cpp
@@ -29,9 +29,11 @@ WriterContext::WriterContext(
     const dwio::common::MetricsLogPtr& metricLogger,
     const tz::TimeZone* sessionTimezone,
     const bool adjustTimestampToTimezone,
-    std::unique_ptr<encryption::EncryptionHandler> handler)
+    std::unique_ptr<encryption::EncryptionHandler> handler,
+    int64_t memoryBudget)
     : config_{config},
       pool_{std::move(pool)},
+      memoryBudget_{memoryBudget},
       dictionaryPool_{
           pool_->addLeafChild(fmt::format("{}.dictionary", pool_->name()))},
       outputStreamPool_{
@@ -69,7 +71,17 @@ WriterContext::WriterContext(
   }
   validateConfigs();
   VLOG(2) << fmt::format(
-      "Compression config: {}", common::compressionKindToString(compression_));
+      "DWRF WriterContext initialized: pool='{}', maxCapacity={}MB, "
+      "memoryBudget={}MB, effectiveBudget={}MB, "
+      "stripeSizeFlushThreshold={}MB, dictionarySizeFlushThreshold={}MB, "
+      "compression={}",
+      pool_->name(),
+      pool_->maxCapacity() / (1024 * 1024),
+      memoryBudget_ / (1024 * 1024),
+      getMemoryBudget() / (1024 * 1024),
+      stripeSizeFlushThreshold_ / (1024 * 1024),
+      dictionarySizeFlushThreshold_ / (1024 * 1024),
+      common::compressionKindToString(compression_));
 }
 
 WriterContext::~WriterContext() {

--- a/velox/dwio/dwrf/writer/WriterContext.h
+++ b/velox/dwio/dwrf/writer/WriterContext.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <limits>
 #include "velox/common/base/GTestMacros.h"
 #include "velox/common/time/CpuWallTimer.h"
@@ -46,7 +47,8 @@ class WriterContext : public CompressionBufferPool {
           dwio::common::MetricsLog::voidLog(),
       const tz::TimeZone* sessionTimezone = nullptr,
       const bool adjustTimestampToTimezone = false,
-      std::unique_ptr<encryption::EncryptionHandler> handler = nullptr);
+      std::unique_ptr<encryption::EncryptionHandler> handler = nullptr,
+      int64_t memoryBudget = std::numeric_limits<int64_t>::max());
 
   ~WriterContext() override;
 
@@ -190,7 +192,7 @@ class WriterContext : public CompressionBufferPool {
   int64_t getTotalMemoryUsage() const;
 
   int64_t getMemoryBudget() const {
-    return pool_->maxCapacity();
+    return std::min(memoryBudget_, pool_->maxCapacity());
   }
 
   /// Returns the available memory reservations from all the memory pools.
@@ -622,6 +624,7 @@ class WriterContext : public CompressionBufferPool {
 
   const std::shared_ptr<const Config> config_;
   const std::shared_ptr<memory::MemoryPool> pool_;
+  const int64_t memoryBudget_;
   const std::shared_ptr<memory::MemoryPool> dictionaryPool_;
   const std::shared_ptr<memory::MemoryPool> outputStreamPool_;
   const std::shared_ptr<memory::MemoryPool> generalPool_;


### PR DESCRIPTION
Summary:

## Context/Motivation

Wire WriterOptions::memoryBudget into WriterContext::getMemoryBudget()

Reviewed By: kevinwilfong

Differential Revision: D104239162
