### PR TITLE
feat: Add dedicated CaseExpr special form to evaluate simple CASE subject exactly once per row (#17445)

### DIFF
--- a/velox/duckdb/conversion/DuckParser.cpp
+++ b/velox/duckdb/conversion/DuckParser.cpp
@@ -620,6 +620,68 @@ core::ExprPtr parseCaseExpr(
     return callExpr("if", std::move(params), getAlias(expr), options);
   }
 
+  // Detect simple CASE: DuckDB rewrites `CASE subject WHEN val THEN res` into
+  // a searched CASE where each when_expr is `COMPARE_EQUAL(subject_copy, val)`.
+  // The original form is lost in the AST (DuckDB's CaseExpression has no field
+  // to distinguish the two). We reverse-engineer it by checking whether all
+  // when_exprs are equality comparisons with a structurally identical left-hand
+  // side (the subject), and if so emit "case" instead of "switch". CaseExpr
+  // evaluates the subject exactly once and reuses the cached vector for each
+  // WHEN comparison, avoiding re-evaluation of non-deterministic subjects
+  // (e.g. rand()).
+  //
+  // Note: this detection can also match a user-written searched CASE whose
+  // conditions happen to be `x = v1`, `x = v2`, ... with the same LHS. This
+  // is semantically equivalent to `CASE x WHEN v1 ... WHEN v2 ...` for
+  // deterministic subjects. For non-deterministic subjects the evaluation
+  // count changes from per-branch to once, but writing a searched CASE with
+  // repeated non-deterministic equality checks against the same expression
+  // is unlikely in practice.
+  {
+    bool allEqWithSameSubject = true;
+    const ComparisonExpression* firstComp =
+        dynamic_cast<const ComparisonExpression*>(checks[0].when_expr.get());
+    const std::string subjectStr =
+        (firstComp && firstComp->type == ExpressionType::COMPARE_EQUAL)
+        ? firstComp->left->ToString()
+        : "";
+
+    if (!subjectStr.empty()) {
+      for (size_t i = 1; i < checks.size(); i++) {
+        const auto* comp = dynamic_cast<const ComparisonExpression*>(
+            checks[i].when_expr.get());
+        if (!comp || comp->type != ExpressionType::COMPARE_EQUAL ||
+            comp->left->ToString() != subjectStr) {
+          allEqWithSameSubject = false;
+          break;
+        }
+      }
+    } else {
+      allEqWithSameSubject = false;
+    }
+
+    if (allEqWithSameSubject) {
+      // Emit: case(subject, when_val_0, then_0, when_val_1, then_1,
+      //                       ..., [else])
+      std::vector<core::ExprPtr> inputs;
+      inputs.reserve(checks.size() * 2 + 2);
+      // Subject — parse from the left side of the first condition.
+      inputs.emplace_back(parseExpr(*firstComp->left, options));
+      for (const auto& check : checks) {
+        const auto& comp =
+            dynamic_cast<const ComparisonExpression&>(*check.when_expr);
+        inputs.emplace_back(parseExpr(*comp.right, options)); // WHEN value
+        inputs.emplace_back(parseExpr(*check.then_expr, options)); // THEN
+      }
+      auto elseExpr = parseExpr(*caseExpr.else_expr, options);
+      if (!isNullConstant(elseExpr)) {
+        inputs.emplace_back(elseExpr);
+      }
+      return callExpr("case", std::move(inputs), getAlias(expr), options);
+    }
+  }
+
+  // Searched CASE (or simple CASE that could not be detected): emit "switch".
   std::vector<core::ExprPtr> inputs;
   inputs.reserve(checks.size() * 2 + 1);
   for (auto& check : checks) {

--- a/velox/duckdb/conversion/tests/DuckParserTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckParserTest.cpp
@@ -454,8 +454,9 @@ TEST(DuckParserTest, switchCase) {
       "switch(gt(\"a\",0),1,lt(\"a\",0),-1)",
       parseExpr("case when a > 0 then 1 when a < 0 then -1end")->toString());
 
+  // Simple CASE emits "case" (subject evaluated once).
   EXPECT_EQ(
-      "switch(eq(\"a\",1),x,eq(\"a\",5),y,z)",
+      "case(\"a\",1,x,5,y,z)",
       parseExpr("case a when 1 then 'x' when 5 then 'y' else 'z' end")
           ->toString());
 }

--- a/velox/expression/CMakeLists.txt
+++ b/velox/expression/CMakeLists.txt
@@ -41,6 +41,7 @@ velox_link_libraries(
 velox_add_library(
   velox_expression
   BooleanMix.cpp
+  CaseExpr.cpp
   CastExpr.cpp
   CastHooks.cpp
   CoalesceExpr.cpp
@@ -72,6 +73,7 @@ velox_add_library(
   VectorFunction.cpp
   HEADERS
   BooleanMix.h
+  CaseExpr.h
   CastExpr-inl.h
   CastExpr.h
   CastHooks.h

--- a/velox/expression/CaseExpr.cpp
+++ b/velox/expression/CaseExpr.cpp
@@ -1,0 +1,587 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/expression/CaseExpr.h"
+#include "velox/expression/BooleanMix.h"
+#include "velox/expression/CastExpr.h"
+#include "velox/expression/ExprConstants.h"
+#include "velox/expression/FieldReference.h"
+#include "velox/expression/SimpleFunctionRegistry.h"
+#include "velox/expression/VectorFunction.h"
+#include "velox/type/TypeCoercer.h"
+#include "velox/vector/ComplexVector.h"
+
+namespace facebook::velox::exec {
+
+namespace {
+
+// Returns true when the total number of inputs is consistent with the
+// case layout: 1 (subject) + 2*N (when/then pairs) + 0 or 1 (else).
+// Equivalently the count after removing the subject must be even (no else) or
+// odd (with else).
+bool hasElseClause(const std::vector<ExprPtr>& inputs) {
+  // total = 1 + 2*N         → (total - 1) is even  → no else
+  // total = 1 + 2*N + 1 = 2*(N+1)  → (total - 1) is odd → has else
+  return (inputs.size() - 1) % 2 == 1;
+}
+
+size_t numCasesFromInputs(const std::vector<ExprPtr>& inputs) {
+  bool hasElse = hasElseClause(inputs);
+  return (inputs.size() - 1 - (hasElse ? 1 : 0)) / 2;
+}
+
+} // namespace
+
+CaseExpr::CaseExpr(
+    TypePtr type,
+    const std::vector<ExprPtr>& inputs,
+    ExprPtr eqExpr,
+    RowTypePtr eqInputType,
+    bool inputsSupportFlatNoNullsFastPath)
+    : SpecialForm(
+          SpecialFormKind::kCase,
+          std::move(type),
+          inputs,
+          expression::kCase,
+          hasElseClause(inputs) && inputsSupportFlatNoNullsFastPath,
+          false /* trackCpuUsage */),
+      numCases_{numCasesFromInputs(inputs)},
+      hasElseClause_{hasElseClause(inputs)},
+      eqExpr_{std::move(eqExpr)},
+      eqInputType_{std::move(eqInputType)} {
+  VELOX_CHECK_NOT_NULL(eqExpr_, "CaseExpr requires a non-null eq Expr");
+  VELOX_CHECK_NOT_NULL(eqInputType_);
+  VELOX_CHECK_GE(
+      inputs_.size(),
+      3,
+      "CaseExpr requires at least 3 inputs: subject, when_value, then_result");
+
+  const auto& subjectType = inputs_[0]->type();
+  for (size_t i = 0; i < numCases_; i++) {
+    VELOX_CHECK(
+        *inputs_[2 * i + 1]->type() == *subjectType,
+        "All WHEN values must have the same type as the subject. "
+        "Expected {}, got {}.",
+        subjectType->toString(),
+        inputs_[2 * i + 1]->type()->toString());
+  }
+}
+
+// static
+ExprPtr CaseExpr::create(
+    TypePtr type,
+    std::vector<ExprPtr> inputs,
+    const TypePtr& comparisonType,
+    bool /* trackCpuUsage */,
+    const core::QueryConfig& config) {
+  VELOX_CHECK_GE(
+      inputs.size(),
+      3,
+      "CASE requires at least 3 compiled children: subject, when, then");
+
+  const size_t numCases = numCasesFromInputs(inputs);
+
+  // Cast the subject and each WHEN value to the comparison super-type so the
+  // single 'eq' Expr can be applied with a single uniform type.
+  CastCallToSpecialForm castForm;
+  if (*inputs[0]->type() != *comparisonType) {
+    inputs[0] = castForm.constructSpecialForm(
+        comparisonType, {inputs[0]}, false, config);
+  }
+  for (size_t i = 0; i < numCases; ++i) {
+    if (*inputs[2 * i + 1]->type() != *comparisonType) {
+      inputs[2 * i + 1] = castForm.constructSpecialForm(
+          comparisonType, {inputs[2 * i + 1]}, false, config);
+    }
+  }
+
+  // Build a reusable 'eq' Expr over a two-column synthetic row. At evaluation
+  // time evalSpecialForm wraps the cached subject and each WHEN vector into a
+  // RowVector matching this type, then calls eqExpr_->eval. The pattern
+  // mirrors how LambdaExpr's body Expr is evaluated against a synthetic row
+  // of (lambda args + captures): only public Expr APIs are needed and we
+  // still get peeling, the registered eq variant's null semantics, and
+  // per-row error reporting.
+  auto eqInputType = ROW({"c0", "c1"}, {comparisonType, comparisonType});
+
+  std::vector<ExprPtr> eqChildren;
+  eqChildren.reserve(2);
+  eqChildren.push_back(
+      std::make_shared<FieldReference>(
+          comparisonType, std::vector<ExprPtr>{}, "c0"));
+  eqChildren.push_back(
+      std::make_shared<FieldReference>(
+          comparisonType, std::vector<ExprPtr>{}, "c1"));
+
+  // Resolve 'eq' for the comparison type, mirroring compileCall: try the
+  // VectorFunction registry first (covers the SIMD eq for numeric, date,
+  // interval, and decimal types), then fall back to the SimpleFunction
+  // registry (which has a Generic<T1>, Generic<T1> eq registration that
+  // covers everything else — varchar, varbinary, timestamp, boolean, JSON,
+  // IPAddress, complex types, etc.).
+  std::shared_ptr<VectorFunction> eqFunction;
+  VectorFunctionMetadata eqMetadata;
+  const std::vector<TypePtr> eqInputTypes{comparisonType, comparisonType};
+  if (auto vectorEq = getVectorFunctionWithMetadata(
+          "eq", eqInputTypes, /*constantInputs=*/{}, config)) {
+    eqFunction = std::move(vectorEq->first);
+    eqMetadata = std::move(vectorEq->second);
+  } else if (
+      auto simpleEq = simpleFunctions().resolveFunction("eq", eqInputTypes)) {
+    eqFunction = simpleEq->createFunction()->createVectorFunction(
+        eqInputTypes, /*constantInputs=*/{}, config, /*memoryPool=*/nullptr);
+    eqMetadata = simpleEq->metadata();
+  } else {
+    VELOX_USER_FAIL(
+        "case: no 'eq' function registered for type '{}'.",
+        comparisonType->toString());
+  }
+  auto eqExpr = std::make_shared<Expr>(
+      BOOLEAN(),
+      std::move(eqChildren),
+      std::move(eqFunction),
+      std::move(eqMetadata),
+      "eq",
+      /*trackCpuUsage=*/false);
+  eqExpr->computeMetadata();
+
+  const bool inputsSupportFlatNoNullsFastPath =
+      Expr::allSupportFlatNoNullsFastPath(inputs);
+
+  return std::make_shared<CaseExpr>(
+      std::move(type),
+      std::move(inputs),
+      std::move(eqExpr),
+      std::move(eqInputType),
+      inputsSupportFlatNoNullsFastPath);
+}
+
+void CaseExpr::evalSpecialForm(
+    const SelectivityVector& rows,
+    EvalCtx& context,
+    VectorPtr& finalResult) {
+  VectorPtr localResult;
+  LocalSelectivityVector remainingRows(context, rows);
+  LocalSelectivityVector thenRows(context);
+
+  // Fix finalSelection at 'rows' unless already fixed by an outer expression.
+  ScopedFinalSelectionSetter scopedFinalSelectionSetter(context, &rows);
+
+  // Null-propagation pre-pass: if all THEN/ELSE branches propagate nulls from
+  // the same input fields, and the subject/WHEN values use a subset of those
+  // fields, pre-null and deselect rows where those fields are null.  This
+  // avoids evaluating the subject and eq function on rows that are guaranteed
+  // to produce null, and prevents errors on null inputs for strict functions.
+  if (propagatesNulls_) {
+    auto& remaining = *remainingRows.get();
+    for (auto* field : distinctFields_) {
+      context.ensureFieldLoaded(field->index(context), remaining);
+      const auto& vector = context.getField(field->index(context));
+      if (vector->mayHaveNulls()) {
+        LocalDecodedVector decoded(context, *vector, remaining);
+        addNulls(remaining, decoded->nulls(&remaining), context, localResult);
+        remaining.deselectNulls(
+            decoded->nulls(&remaining), remaining.begin(), remaining.end());
+      }
+    }
+  }
+
+  // Step 1: Evaluate the subject expression exactly once.
+  VectorPtr subjectVector;
+  inputs_[0]->eval(rows, context, subjectVector);
+
+  // Rows where subject evaluation itself errored out are deselected so that
+  // subsequent WHEN checks do not observe stale data at those positions.
+  if (context.errors()) {
+    context.deselectErrors(*remainingRows);
+  }
+
+  // Step 2: Build a reusable two-column RowVector for invoking eqExpr_.
+  // The RowVector is shared across WHEN iterations (only children()[1]
+  // changes); a fresh EvalCtx is created per iteration so no internal
+  // state (peeled fields, encodings, errors) leaks between clauses.
+  auto eqRow = std::make_shared<RowVector>(
+      context.pool(),
+      eqInputType_,
+      /*nulls=*/nullptr,
+      rows.end(),
+      std::vector<VectorPtr>{subjectVector, subjectVector});
+
+  VectorPtr condition;
+  const uint64_t* values;
+
+  for (size_t i = 0; i < numCases_; i++) {
+    context.releaseVector(condition);
+
+    if (!remainingRows->hasSelections()) {
+      break;
+    }
+
+    // Evaluate the WHEN value for the remaining (unmatched) rows.
+    VectorPtr whenVector;
+    inputs_[2 * i + 1]->eval(*remainingRows.get(), context, whenVector);
+
+    if (context.errors()) {
+      context.deselectErrors(*remainingRows);
+      if (!remainingRows->hasSelections()) {
+        break;
+      }
+    }
+
+    eqRow->children()[1] = whenVector;
+    eqRow->unsafeResize(remainingRows->end());
+    EvalCtx eqCtx{context.execCtx(), context.exprSet(), eqRow.get()};
+    *eqCtx.mutableThrowOnError() = context.throwOnError();
+
+    eqExpr_->clearCache();
+    eqExpr_->eval(*remainingRows.get(), eqCtx, condition);
+
+    // Surface eq errors through the parent context so the existing CASE
+    // error-handling deselects them and they fall through to the
+    // error-null-fill at the end.
+    if (eqCtx.errors()) {
+      eqCtx.moveAppendErrors(*context.errorsPtr());
+      context.deselectErrors(*remainingRows);
+      if (!remainingRows->hasSelections()) {
+        break;
+      }
+    }
+
+    // Interpret the boolean condition result.  Nulls are merged to false
+    // (mergeNullsToValues = true), matching SQL semantics: eq(x, null) is
+    // UNKNOWN and therefore does not select the THEN branch.
+    const auto booleanMix = getFlatBool(
+        condition.get(),
+        *remainingRows.get(),
+        context,
+        &tempValues_,
+        nullptr,
+        true /* mergeNullsToValues */,
+        &values,
+        nullptr);
+
+    switch (booleanMix) {
+      case BooleanMix::kAllTrue:
+        // Every remaining row matched — evaluate THEN for all of them and stop.
+        inputs_[2 * i + 2]->eval(*remainingRows.get(), context, localResult);
+        remainingRows->clearAll();
+        continue;
+      case BooleanMix::kAllNull:
+      case BooleanMix::kAllFalse:
+        // No rows matched this WHEN — move to the next case.
+        continue;
+      default: {
+        // Mixed: compute the subset of remainingRows where condition is true.
+        thenRows.get(remainingRows->end(), false);
+        bits::andBits(
+            thenRows.get()->asMutableRange().bits(),
+            remainingRows->asRange().bits(),
+            values,
+            0,
+            remainingRows->end());
+        thenRows.get()->updateBounds();
+
+        if (thenRows.get()->hasSelections()) {
+          inputs_[2 * i + 2]->eval(*thenRows.get(), context, localResult);
+          remainingRows->deselect(*thenRows.get());
+        }
+      }
+    }
+  }
+
+  // Step 4: Handle rows that matched no WHEN branch.
+  if (remainingRows->hasSelections()) {
+    if (hasElseClause_) {
+      inputs_.back()->eval(*remainingRows.get(), context, localResult);
+    } else {
+      // No ELSE: write NULL for every unmatched row.
+      context.ensureWritable(*remainingRows.get(), type(), localResult);
+      remainingRows->applyToSelected(
+          [&](auto row) { localResult->setNull(row, true); });
+    }
+  }
+
+  // Step 5: Null-fill rows that produced errors during evaluation.
+  // Some rows may have been deselected due to errors in subject, WHEN-value,
+  // or eq evaluation.  Ensure those positions are addressable in localResult.
+  if (context.errors()) {
+    // TODO: Fix decoding function vector issue #6269.
+    if (type()->kind() != TypeKind::FUNCTION) {
+      LocalSelectivityVector nonErrorRows(context, rows);
+      context.deselectErrors(*nonErrorRows);
+      addNulls(rows, nonErrorRows->asRange().bits(), context, localResult);
+    }
+  }
+
+  // TODO: Fix evaluate lambda expression return vector of size 0 issue #6270.
+  if (type()->kind() != TypeKind::FUNCTION) {
+    VELOX_CHECK_NOT_NULL(localResult);
+    VELOX_CHECK_GE(localResult->size(), rows.end());
+  }
+
+  context.moveOrCopyResult(localResult, rows, finalResult);
+}
+
+std::string CaseExpr::toSql(std::vector<VectorPtr>* complexConstants) const {
+  // Generate standard SQL simple-CASE syntax so that the expression can be
+  // faithfully round-tripped through parseCaseExpr → CaseExpr without
+  // structural divergence.
+  std::stringstream sql;
+  sql << "CASE " << inputs_[0]->toSql(complexConstants);
+  for (size_t i = 0; i < numCases_; i++) {
+    sql << " WHEN " << inputs_[2 * i + 1]->toSql(complexConstants);
+    sql << " THEN " << inputs_[2 * i + 2]->toSql(complexConstants);
+  }
+  if (hasElseClause_) {
+    sql << " ELSE " << inputs_.back()->toSql(complexConstants);
+  }
+  sql << " END";
+  return sql.str();
+}
+
+void CaseExpr::computePropagatesNulls() {
+  // CaseExpr propagates nulls when:
+  //   1. Every THEN clause (and the optional ELSE) propagates nulls.
+  //   2. Every THEN/ELSE clause references the same set of input fields.
+  //   3. The subject and every WHEN value reference only a subset of those
+  //      fields.
+  //
+  // Under these conditions a null in any of the shared fields causes the
+  // subject to be null, which in turn causes no WHEN branch to match (since
+  // eq(null, x) is always null/false).  With no ELSE the row returns null,
+  // and with an ELSE its THEN/ELSE expression also returns null (condition 1).
+  // Pre-nulling and deselecting those rows avoids unnecessary work and
+  // prevents errors on strict functions.
+
+  // Condition 1 & 2: all THEN clauses propagate nulls and share the same
+  // distinct fields.
+  for (size_t i = 0; i < numCases_; i++) {
+    if (!inputs_[2 * i + 2]->propagatesNulls()) {
+      propagatesNulls_ = false;
+      return;
+    }
+  }
+  if (hasElseClause_ && !inputs_.back()->propagatesNulls()) {
+    propagatesNulls_ = false;
+    return;
+  }
+
+  const auto& firstThenFields = inputs_[2]->distinctFields();
+  for (size_t i = 0; i < numCases_; i++) {
+    if (!Expr::isSameFields(
+            firstThenFields, inputs_[2 * i + 2]->distinctFields())) {
+      propagatesNulls_ = false;
+      return;
+    }
+  }
+  if (hasElseClause_) {
+    if (!Expr::isSameFields(
+            firstThenFields, inputs_.back()->distinctFields())) {
+      propagatesNulls_ = false;
+      return;
+    }
+  }
+
+  // Condition 3: subject and all WHEN values use only a subset of the
+  // THEN/ELSE fields.
+  if (!Expr::isSubsetOfFields(inputs_[0]->distinctFields(), firstThenFields)) {
+    propagatesNulls_ = false;
+    return;
+  }
+  for (size_t i = 0; i < numCases_; i++) {
+    if (!Expr::isSubsetOfFields(
+            inputs_[2 * i + 1]->distinctFields(), firstThenFields)) {
+      propagatesNulls_ = false;
+      return;
+    }
+  }
+
+  propagatesNulls_ = true;
+}
+
+// CaseCallToSpecialForm
+
+TypePtr CaseCallToSpecialForm::resolveType(
+    const std::vector<TypePtr>& argTypes) {
+  // Layout: subject, (when_val, then_result)+, [else]
+  VELOX_CHECK_GE(
+      argTypes.size(),
+      3,
+      "case requires at least 3 arguments: subject, when_value, then_result");
+
+  const bool hasElse = (argTypes.size() % 2 == 0);
+  const size_t numCases = (argTypes.size() - 1 - (hasElse ? 1 : 0)) / 2;
+
+  // The result type is the type of the first THEN clause (index 2).
+  const TypePtr& resultType = argTypes[2];
+
+  for (size_t i = 0; i < numCases; i++) {
+    const auto& thenType = argTypes[2 * i + 2];
+    VELOX_CHECK(
+        *thenType == *resultType,
+        "All THEN clauses in case must have the same type. "
+        "Expected {}, got {}.",
+        resultType->toString(),
+        thenType->toString());
+  }
+
+  if (hasElse) {
+    VELOX_CHECK(
+        *argTypes.back() == *resultType,
+        "ELSE clause in case must match THEN clause type. "
+        "Expected {}, got {}.",
+        resultType->toString(),
+        argTypes.back()->toString());
+  }
+
+  return resultType;
+}
+
+TypePtr CaseCallToSpecialForm::resolveTypeWithCoercions(
+    const std::vector<TypePtr>& argTypes,
+    std::vector<TypePtr>& coercions,
+    const TypeCoercer& coercer) {
+  coercions.clear();
+  coercions.resize(argTypes.size());
+
+  const bool hasElse = (argTypes.size() % 2 == 0);
+  const size_t numCases = (argTypes.size() - 1 - (hasElse ? 1 : 0)) / 2;
+
+  // Determine the comparison type: the least-common super-type of the subject
+  // and all WHEN values.  The ExprCompiler will insert CastExprs for any
+  // argument whose type doesn't already match the comparison type.
+  TypePtr comparisonType = argTypes[0]; // start with the subject type
+  for (size_t i = 0; i < numCases; i++) {
+    const auto& whenType = argTypes[2 * i + 1];
+    if (*whenType != *comparisonType) {
+      auto common = coercer.leastCommonSuperType(comparisonType, whenType);
+      VELOX_CHECK_NOT_NULL(
+          common,
+          "case: subject type '{}' and WHEN value type '{}' have "
+          "no common super-type.",
+          comparisonType->toString(),
+          whenType->toString());
+      comparisonType = common;
+    }
+  }
+
+  // Emit coercions for subject and WHEN values that differ from comparisonType.
+  if (*argTypes[0] != *comparisonType) {
+    coercions[0] = comparisonType;
+  }
+  for (size_t i = 0; i < numCases; i++) {
+    if (*argTypes[2 * i + 1] != *comparisonType) {
+      coercions[2 * i + 1] = comparisonType;
+    }
+  }
+
+  // Resolve the result type from THEN (and optional ELSE) clauses with
+  // widening coercions, mirroring the logic in SwitchCallToSpecialForm.
+  TypePtr resultType = argTypes[2];
+  for (size_t i = 0; i < numCases; i++) {
+    const auto& thenType = argTypes[2 * i + 2];
+    if (*thenType != *resultType) {
+      if (coercer.coercible(thenType, resultType)) {
+        coercions[2 * i + 2] = resultType;
+      } else if (coercer.coercible(resultType, thenType)) {
+        resultType = thenType;
+        for (size_t j = 0; j < i; j++) {
+          coercions[2 * j + 2] = resultType;
+        }
+      } else {
+        VELOX_FAIL(
+            "All THEN clauses in case must have the same type. "
+            "Expected {}, but got {}.",
+            resultType->toString(),
+            thenType->toString());
+      }
+    }
+  }
+
+  if (hasElse) {
+    const auto& elseType = argTypes.back();
+    if (*elseType != *resultType) {
+      if (coercer.coercible(elseType, resultType)) {
+        coercions.back() = resultType;
+      } else if (coercer.coercible(resultType, elseType)) {
+        resultType = elseType;
+        for (size_t i = 0; i < numCases; i++) {
+          coercions[2 * i + 2] = resultType;
+        }
+      } else {
+        VELOX_FAIL(
+            "ELSE clause in case must match THEN clause type. "
+            "Expected {}, but got {}.",
+            resultType->toString(),
+            elseType->toString());
+      }
+    }
+  }
+
+  return resultType;
+}
+
+ExprPtr CaseCallToSpecialForm::constructSpecialForm(
+    const TypePtr& type,
+    std::vector<ExprPtr>&& compiledChildren,
+    bool /* trackCpuUsage */,
+    const core::QueryConfig& config) {
+  VELOX_CHECK_GE(
+      compiledChildren.size(), 3, "case requires at least 3 compiled children");
+
+  const size_t numCases = numCasesFromInputs(compiledChildren);
+
+  // Align the subject and WHEN value types by inserting CastExprs where
+  // needed so the 'eq' VectorFunction can be looked up with a single
+  // uniform type.
+  //
+  // Although resolveTypeWithCorsions already computes these coercions, the
+  // Velox type resolver (parse::TypeResolver) never calls it. It only calls
+  // resolveType, which validates THEN/ELSE types but not subject/WHEN types.
+  // The resolver handles mismatches via brute-force implicit casts that
+  // permute each argument independently — but that does not guarantee a
+  // group of arguments (subject + all WHEN values) converge to a common
+  // type. SwitchExpr avoids this because its inputs are already fully-typed
+  // boolean conditions (e.g. eq(c0, 7) is resolved before SwitchExpr sees
+  // it). CaseExpr receives the raw subject and WHEN values as separate
+  // inputs, so it must reconcile their types here.
+  TypePtr comparisonType = compiledChildren[0]->type();
+  for (size_t i = 0; i < numCases; i++) {
+    const auto& whenType = compiledChildren[2 * i + 1]->type();
+    if (*whenType != *comparisonType) {
+      auto common = TypeCoercer::defaults().leastCommonSuperType(
+          comparisonType, whenType);
+      VELOX_CHECK_NOT_NULL(
+          common,
+          "case: subject type '{}' and WHEN value type '{}' have "
+          "no common super-type.",
+          comparisonType->toString(),
+          whenType->toString());
+      comparisonType = common;
+    }
+  }
+
+  // Delegate to CaseExpr::create so that the cast insertion + eq Expr
+  // construction logic lives in one place — shared with the kCase ExprKind
+  // path in ExprCompiler.
+  return CaseExpr::create(
+      type,
+      std::move(compiledChildren),
+      comparisonType,
+      /*trackCpuUsage=*/false,
+      config);
+}
+
+} // namespace facebook::velox::exec

--- a/velox/expression/CaseExpr.h
+++ b/velox/expression/CaseExpr.h
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/expression/FunctionCallToSpecialForm.h"
+#include "velox/expression/SpecialForm.h"
+#include "velox/expression/VectorFunction.h"
+
+namespace facebook::velox::exec {
+
+/// Simple CASE expression — evaluates the subject exactly once per row.
+///
+///   CASE subject
+///     WHEN val  THEN result
+///     [WHEN val THEN result ...]
+///     [ELSE result]
+///   END
+///
+/// Inputs layout:
+///   inputs_[0]         = subject expression
+///   inputs_[2*i + 1]   = WHEN value for case i  (i = 0..numCases_-1)
+///   inputs_[2*i + 2]   = THEN result for case i
+///   inputs_.back()     = ELSE result (present only when hasElseClause_)
+///
+/// Unlike SwitchExpr, which duplicates the subject into each eq() condition
+/// (causing non-deterministic subjects like rand() to be re-evaluated per WHEN
+/// branch), CaseExpr evaluates the subject once and applies a pre-built 'eq'
+/// Expr to the cached subject vector and each WHEN value vector. Routing the
+/// comparison through the Expr layer (rather than calling the VectorFunction
+/// directly) preserves dictionary peeling, the registered eq variant's
+/// semantic differences (e.g. Spark vs Presto null-handling), and per-row
+/// error reporting via TRY.
+class CaseExpr : public SpecialForm {
+ public:
+  /// @param eqExpr Pre-built 'eq' Expr whose children are FieldReferences
+  /// over a synthetic two-column row (subject, when). Invoked at evaluation
+  /// time against a RowVector populated with the cached subject and each
+  /// per-iteration WHEN vector. Must not be null.
+  /// @param eqInputType Two-column row type matching eqExpr's FieldReferences.
+  CaseExpr(
+      TypePtr type,
+      const std::vector<ExprPtr>& inputs,
+      ExprPtr eqExpr,
+      RowTypePtr eqInputType,
+      bool inputsSupportFlatNoNullsFastPath);
+
+  /// Builds the eq Expr (eq(field("c0"), field("c1")) over a synthetic row of
+  /// type ROW(comparisonType, comparisonType)) and constructs a CaseExpr.
+  /// Mirrors NullIfExpr::create, which builds a CastExpr and stores it on
+  /// the special form for use during evalSpecialForm.
+  static ExprPtr create(
+      TypePtr type,
+      std::vector<ExprPtr> inputs,
+      const TypePtr& comparisonType,
+      bool trackCpuUsage,
+      const core::QueryConfig& config);
+
+  void evalSpecialForm(
+      const SelectivityVector& rows,
+      EvalCtx& context,
+      VectorPtr& result) override;
+
+  bool isConditional() const override {
+    return true;
+  }
+
+  void clearCache() override {
+    Expr::clearCache();
+    tempValues_.reset();
+  }
+
+  /// Generates standard SQL CASE syntax so that the round-trip in testToSql
+  /// produces an identical expression tree.  The base Expr::toSql() would emit
+  /// "case"(...) which DuckDB cannot re-parse as a CASE expression.
+  std::string toSql(
+      std::vector<VectorPtr>* complexConstants = nullptr) const override;
+
+ private:
+  void computePropagatesNulls() override;
+
+  const size_t numCases_;
+  const bool hasElseClause_;
+
+  // Pre-built 'eq' Expr used to compare the cached subject vector against
+  // each WHEN value vector. Holds two FieldReferences over eqInputType_.
+  const ExprPtr eqExpr_;
+
+  // Synthetic row type backing eqExpr_'s FieldReferences. Two columns of
+  // comparisonType, named "c0" (subject) and "c1" (when).
+  const RowTypePtr eqInputType_;
+
+  // Scratch buffer reused across calls by getFlatBool.
+  BufferPtr tempValues_;
+};
+
+class CaseCallToSpecialForm : public FunctionCallToSpecialForm {
+ public:
+  /// Returns the type of the first THEN clause.  Throws if:
+  ///   - fewer than 3 arguments are provided,
+  ///   - THEN (and optional ELSE) clause types are inconsistent, or
+  ///   - no 'eq' function is registered for the subject / WHEN-value types.
+  TypePtr resolveType(const std::vector<TypePtr>& argTypes) override;
+
+  /// Like resolveType but also fills in type coercions for the subject and WHEN
+  /// values when their types differ.  The subject and all WHEN values are
+  /// coerced to their least-common super-type so that the 'eq' VectorFunction
+  /// can be looked up with a single uniform type.  THEN/ELSE coercions follow
+  /// the same widening logic as SwitchCallToSpecialForm.
+  TypePtr resolveTypeWithCoercions(
+      const std::vector<TypePtr>& argTypes,
+      std::vector<TypePtr>& coercions,
+      const TypeCoercer& coercer) override;
+
+  ExprPtr constructSpecialForm(
+      const TypePtr& type,
+      std::vector<ExprPtr>&& compiledChildren,
+      bool trackCpuUsage,
+      const core::QueryConfig& config) override;
+};
+
+} // namespace facebook::velox::exec

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -60,6 +60,7 @@ const auto& specialFormNames() {
       {SpecialFormKind::kTry, "TRY"},
       {SpecialFormKind::kAnd, "AND"},
       {SpecialFormKind::kOr, "OR"},
+      {SpecialFormKind::kCase, "CASE"},
       {SpecialFormKind::kCustom, "CUSTOM"},
   };
   return kNames;

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -123,6 +123,7 @@ enum class SpecialFormKind : int32_t {
   kAnd = 7,
   kOr = 8,
   kNullIf = 9,
+  kCase = 10,
   kCustom = 999,
 };
 
@@ -312,6 +313,10 @@ class Expr {
 
   bool isOr() const {
     return specialFormKind_ == SpecialFormKind::kOr;
+  }
+
+  bool isCase() const {
+    return specialFormKind_ == SpecialFormKind::kCase;
   }
 
   bool isCustom() const {

--- a/velox/expression/ExprConstants.h
+++ b/velox/expression/ExprConstants.h
@@ -27,5 +27,6 @@ inline constexpr const char* kTryCast = "try_cast";
 inline constexpr const char* kTry = "try";
 inline constexpr const char* kRowConstructor = "row_constructor";
 inline constexpr const char* kNullIf = "nullif";
+inline constexpr const char* kCase = "case";
 
 } // namespace facebook::velox::expression

--- a/velox/expression/RegisterSpecialForm.cpp
+++ b/velox/expression/RegisterSpecialForm.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/expression/RegisterSpecialForm.h"
 
+#include "velox/expression/CaseExpr.h"
 #include "velox/expression/CastExpr.h"
 #include "velox/expression/CoalesceExpr.h"
 #include "velox/expression/CoalesceRewrite.h"
@@ -46,6 +47,8 @@ void registerFunctionCallToSpecialForms() {
       std::make_unique<ConjunctCallToSpecialForm>(false /* isAnd */));
   registerFunctionCallToSpecialForm(
       expression::kSwitch, std::make_unique<SwitchCallToSpecialForm>());
+  registerFunctionCallToSpecialForm(
+      expression::kCase, std::make_unique<CaseCallToSpecialForm>());
   registerFunctionCallToSpecialForm(
       expression::kTry, std::make_unique<TryCallToSpecialForm>());
   registerFunctionCallToSpecialForm(

--- a/velox/expression/fuzzer/ExpressionFuzzer.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzer.cpp
@@ -729,6 +729,30 @@ std::vector<core::TypedExprPtr> ExpressionFuzzer::generateSwitchArgs(
   return inputExpressions;
 }
 
+std::vector<core::TypedExprPtr> ExpressionFuzzer::generateCaseArgs(
+    const CallableSignature& input) {
+  VELOX_CHECK_EQ(
+      input.args.size(),
+      3,
+      "Three inputs are expected from the template signature.");
+  size_t cases = rand32(1, 5);
+  bool useFinalElse = vectorFuzzer_->coinToss(0.5);
+
+  auto subjectType = input.args[0];
+  auto thenClauseType = input.args[2];
+  std::vector<core::TypedExprPtr> inputExpressions;
+  // Subject expression.
+  inputExpressions.push_back(generateArg(subjectType));
+  for (int case_idx = 0; case_idx < cases; case_idx++) {
+    inputExpressions.push_back(generateArg(subjectType)); // WHEN value
+    inputExpressions.push_back(generateArg(thenClauseType)); // THEN result
+  }
+  if (useFinalElse) {
+    inputExpressions.push_back(generateArg(thenClauseType));
+  }
+  return inputExpressions;
+}
+
 ExpressionFuzzer::FuzzedExpressionData ExpressionFuzzer::fuzzExpressions(
     const RowTypePtr& outType) {
   state_.reset();
@@ -854,6 +878,9 @@ std::vector<core::TypedExprPtr> ExpressionFuzzer::getArgsForCallable(
   // specified through argValuesGenerators_.
   if (callable.name == "switch") {
     return generateSwitchArgs(callable);
+  }
+  if (callable.name == "case") {
+    return generateCaseArgs(callable);
   }
 
   auto funcIt = argValuesGenerators_.find(callable.name);

--- a/velox/expression/fuzzer/ExpressionFuzzer.h
+++ b/velox/expression/fuzzer/ExpressionFuzzer.h
@@ -91,7 +91,7 @@ class ExpressionFuzzer {
 
     // Comma-separated list of special forms to use in generated expression.
     // Supported special forms: and, or, coalesce, if, switch, cast.")
-    std::string specialForms = "and,or,cast,coalesce,if,switch";
+    std::string specialForms = "and,or,cast,coalesce,if,switch,case";
 
     // This list can include a mix of function names and function signatures.
     // Use function name to exclude all signatures of a given function from
@@ -220,6 +220,13 @@ class ExpressionFuzzer {
   /// else clause. Finally, uses the type specified in the signature to
   /// generate inputs with that return type.
   std::vector<core::TypedExprPtr> generateSwitchArgs(
+      const CallableSignature& input);
+
+  /// Generates arguments for the 'case' special form. The signature's type
+  /// variable is bounded to randomly selected types for the subject/WHEN
+  /// values and THEN/ELSE results. It randomly decides the number of cases
+  /// (up to a max of 5) and whether to include the else clause.
+  std::vector<core::TypedExprPtr> generateCaseArgs(
       const CallableSignature& input);
 
   core::TypedExprPtr getCallExprFromCallable(

--- a/velox/expression/fuzzer/FuzzerRunner.cpp
+++ b/velox/expression/fuzzer/FuzzerRunner.cpp
@@ -92,9 +92,9 @@ DEFINE_string(
 
 DEFINE_string(
     special_forms,
-    "and,or,cast,coalesce,if,switch",
+    "and,or,cast,coalesce,if,switch,case",
     "Comma-separated list of special forms to use in generated expression. "
-    "Supported special forms: and, or, coalesce, if, switch, cast.");
+    "Supported special forms: and, or, coalesce, if, switch, case, cast.");
 
 DEFINE_int32(
     velox_fuzzer_max_level_of_nesting,

--- a/velox/expression/fuzzer/SpecialFormSignatureGenerator.cpp
+++ b/velox/expression/fuzzer/SpecialFormSignatureGenerator.cpp
@@ -93,6 +93,7 @@ SpecialFormSignatureGenerator::getSignatures() const {
               {"coalesce", getSignaturesForCoalesce()},
               {"if", getSignaturesForIf()},
               {"switch", getSignaturesForSwitch()},
+              {"case", getSignaturesForCase()},
               {"cast", getSignaturesForCast()}};
   return kSpecialForms;
 }
@@ -166,6 +167,26 @@ SpecialFormSignatureGenerator::getSignaturesForSwitch() const {
               .argumentType("boolean")
               .argumentType("T")
               .returnType("T")
+              .build()};
+}
+
+std::vector<exec::FunctionSignaturePtr>
+SpecialFormSignatureGenerator::getSignaturesForCase() const {
+  // Signature: case (subject, when, then) -> output:
+  // S, S, R -> R
+  // CaseExpr::create resolves 'eq' for the subject type S via the
+  // VectorFunction registry, falling back to the SimpleFunction registry —
+  // the latter has a Generic<T1>, Generic<T1> eq registration so any
+  // comparable type is accepted. The fuzzer binds S to a randomly selected
+  // type and generates the variable number of WHEN/THEN pairs (and optional
+  // ELSE) via an override; this single signature defines the slot types.
+  return {exec::FunctionSignatureBuilder()
+              .typeVariable("S")
+              .typeVariable("R")
+              .argumentType("S")
+              .argumentType("S")
+              .argumentType("R")
+              .returnType("R")
               .build()};
 }
 

--- a/velox/expression/fuzzer/SpecialFormSignatureGenerator.h
+++ b/velox/expression/fuzzer/SpecialFormSignatureGenerator.h
@@ -97,6 +97,9 @@ class SpecialFormSignatureGenerator {
   virtual std::vector<exec::FunctionSignaturePtr> getSignaturesForSwitch()
       const;
 
+  // Returns the signatures for the 'case' special form.
+  virtual std::vector<exec::FunctionSignaturePtr> getSignaturesForCase() const;
+
   // Returns the common signatures for the 'cast' special form.
   std::vector<exec::FunctionSignaturePtr> getCommonSignaturesForCast() const;
 

--- a/velox/expression/tests/ExprStatsTest.cpp
+++ b/velox/expression/tests/ExprStatsTest.cpp
@@ -348,14 +348,14 @@ TEST_F(ExprStatsTest, specialForms) {
   ASSERT_EQ(1, stats.at("coalesce").numProcessedVectors);
   ASSERT_EQ(1024, stats.at("coalesce").numProcessedRows);
 
-  // SWITCH.
+  // CASE (simple CASE — subject evaluated once).
   events.clear();
   evaluate("case c0 when 7 then 1 when 11 then 2 else 0 end", data);
   ASSERT_EQ(1, events.size());
   stats = events.back().stats;
 
-  ASSERT_EQ(1, stats.at("switch").numProcessedVectors);
-  ASSERT_EQ(1024, stats.at("switch").numProcessedRows);
+  ASSERT_EQ(1, stats.at("case").numProcessedVectors);
+  ASSERT_EQ(1024, stats.at("case").numProcessedRows);
 
   ASSERT_TRUE(exec::unregisterExprSetListener(listener));
 }

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -1741,35 +1741,357 @@ TEST_P(ParameterizedExprTest, switchExpr) {
   assertEqualVectors(expected, result);
 }
 
-TEST_P(ParameterizedExprTest, swithExprSanityChecks) {
+// Simple CASE expressions with an explicit subject are now routed through
+// CaseExpr (emitted as "case" by parseCaseExpr).  CaseExpr evaluates
+// the subject exactly once per row and reuses the cached vector for each WHEN
+// comparison via the pre-resolved 'eq' VectorFunction.
+
+TEST_P(ParameterizedExprTest, caseExprBasic) {
+  // Verify correct value matching and null propagation for a simple CASE with
+  // a deterministic column subject.
+  vector_size_t size = 1'000;
+  auto vector = makeRowVector(
+      {makeFlatVector<int32_t>(size, [](auto row) { return row % 3; }),
+       makeFlatVector<int32_t>(
+           size, [](auto row) { return row % 3; }, nullEvery(5)),
+       makeConstant<int32_t>(0, size)});
+
+  // Basic matching.
+  auto result =
+      evaluate("case c0 when 0 then 0 when 1 then 1 when 2 then 2 end", vector);
+  auto expected =
+      makeFlatVector<int64_t>(size, [](auto row) { return row % 3; });
+  assertEqualVectors(expected, result);
+
+  // ELSE clause.
+  result = evaluate("case c0 when 7 then 1 when 11 then 2 else 0 end", vector);
+  expected = makeFlatVector<int64_t>(size, [](auto /*row*/) { return 0; });
+  assertEqualVectors(expected, result);
+
+  // No ELSE, unmatched rows produce null.
+  result = evaluate("case c0 when 7 then 1 when 11 then 2 end", vector);
+  expected = makeAllNullFlatVector<int64_t>(size);
+  assertEqualVectors(expected, result);
+
+  // Nullable subject column (c1, nulls at every 5th row).
+  // Null subject: eq(null, k) is always null/false, so null rows fall through.
+  // With no ELSE the result for null-subject rows is null.
+  result =
+      evaluate("case c1 when 0 then 0 when 1 then 1 when 2 then 2 end", vector);
+  expected = makeFlatVector<int64_t>(
+      size,
+      [](auto row) { return row % 3; },
+      nullEvery(5) /* null-subject rows produce null */);
+  assertEqualVectors(expected, result);
+
+  // Nullable subject with ELSE: null subject falls through to ELSE.
+  result = evaluate(
+      "case c1 when 0 then 0 when 1 then 1 when 2 then 2 else -1 end", vector);
+  expected = makeFlatVector<int64_t>(size, [](auto row) {
+    // Null rows (row % 5 == 0) hit the ELSE clause → -1.
+    return (row % 5 == 0) ? -1 : row % 3;
+  });
+  assertEqualVectors(expected, result);
+
+  // Constant subject with no match produces all null.
+  result = evaluate("case c2 when 100 then 1 when 200 then 2 end", vector);
+  expected = makeAllNullFlatVector<int64_t>(size);
+  assertEqualVectors(expected, result);
+}
+
+TEST_P(ParameterizedExprTest, caseExprNonConstantThen) {
+  // THEN clauses that reference input columns (not constants).
+  vector_size_t size = 1'000;
+  auto vector = makeRowVector(
+      {makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+       makeFlatVector<int32_t>(
+           size, [](auto row) { return row; }, nullEvery(5))});
+
+  auto result = evaluate(
+      "case when c0 < 7 then c0 + 5 when c0 < 11 then c0 - 11 "
+      "else c0::BIGINT end",
+      vector);
+  auto expected = makeFlatVector<int64_t>(size, [](auto row) -> int64_t {
+    if (row < 7) {
+      return row + 5;
+    }
+    if (row < 11) {
+      return row - 11;
+    }
+    return row;
+  });
+  assertEqualVectors(expected, result);
+}
+
+TEST_P(ParameterizedExprTest, caseExprRandSubjectEvaluatedOnce) {
+  // With CaseExpr the subject (RAND()) is evaluated exactly once per row.
+  // The cached result is compared against each WHEN value, so every row is
+  // guaranteed to match exactly one branch (0, 1, or 2).  Nulls cannot appear
+  // because FLOOR(RAND()*3) is always in {0,1,2} and all three are covered.
+  vector_size_t size = 1'000;
+  auto vector = makeRowVector(
+      {makeFlatVector<int64_t>(size, [](auto row) { return row; })});
+
+  auto result = evaluate(
+      "case cast(floor(rand() * 3.0) as integer)"
+      " when 0 then 0"
+      " when 1 then 1"
+      " when 2 then 2"
+      " end",
+      vector);
+
+  ASSERT_EQ(size, result->size());
+  auto* flat = result->asFlatVector<int64_t>();
+  ASSERT_NE(flat, nullptr);
+  for (vector_size_t i = 0; i < size; ++i) {
+    // Subject is evaluated once → always matches one of the three branches →
+    // no row should be null.
+    ASSERT_FALSE(result->isNullAt(i)) << "Unexpected null at row " << i;
+    auto val = flat->valueAt(i);
+    ASSERT_GE(val, 0) << "Value out of range at row " << i;
+    ASSERT_LE(val, 2) << "Value out of range at row " << i;
+  }
+}
+
+TEST_P(ParameterizedExprTest, caseExprWhenNullNeverMatches) {
+  // WHEN NULL uses equality semantics: eq(x, null) is always null/false,
+  // so WHEN NULL never matches any row — including rows where the subject
+  // itself is null.  The value 3 (THEN result of WHEN NULL) must never appear.
+  vector_size_t size = 1'000;
+  auto vector = makeRowVector({makeFlatVector<int32_t>(
+      size, [](auto row) { return row % 3; }, nullEvery(5))});
+
+  auto result = evaluate(
+      "case c0"
+      " when 0 then 0"
+      " when 1 then 1"
+      " when 2 then 2"
+      " when null then 3"
+      " end",
+      vector);
+
+  ASSERT_EQ(size, result->size());
+  auto* flat = result->asFlatVector<int64_t>();
+  ASSERT_NE(flat, nullptr);
+  for (vector_size_t i = 0; i < size; ++i) {
+    if (i % 5 == 0) {
+      // Null subject: eq(null, k) is always null/false for any k.
+      // WHEN NULL also never fires.  No ELSE → null output.
+      ASSERT_TRUE(result->isNullAt(i)) << "Expected null at row " << i;
+    } else {
+      ASSERT_FALSE(result->isNullAt(i)) << "Unexpected null at row " << i;
+      auto val = flat->valueAt(i);
+      // 3 (from WHEN NULL) must never appear.
+      ASSERT_NE(val, 3) << "WHEN NULL fired unexpectedly at row " << i;
+      ASSERT_EQ(val, i % 3) << "Wrong value at row " << i;
+    }
+  }
+}
+
+TEST_P(ParameterizedExprTest, caseExprSanityChecks) {
   auto vector = makeRowVector({makeFlatVector<int32_t>({1, 2, 3})});
 
   // Then clauses have different types.
   VELOX_ASSERT_THROW(
       evaluate(
           "case c0 when 7 then 1 when 11 then 'welcome' else 0 end", vector),
-      "All then clauses of a SWITCH statement must have the same type. "
-      "Expected BIGINT, but got VARCHAR.");
+      "All THEN clauses in case must have the same type. "
+      "Expected BIGINT, got VARCHAR.");
 
   // Else clause has different type.
   VELOX_ASSERT_THROW(
       evaluate("case c0 when 7 then 1 when 11 then 2 else 'hello' end", vector),
-      "Else clause of a SWITCH statement must have the same type as 'then' clauses. "
-      "Expected BIGINT, but got VARCHAR.");
+      "ELSE clause in case must match THEN clause type. "
+      "Expected BIGINT, got VARCHAR.");
 
   // Unknown is not implicitly casted.
   VELOX_ASSERT_THROW(
       evaluate("case c0 when 7 then 1 when 11 then null else 3 end", vector),
-      "All then clauses of a SWITCH statement must have the same type. "
-      "Expected BIGINT, but got UNKNOWN.");
+      "All THEN clauses in case must have the same type. "
+      "Expected BIGINT, got UNKNOWN.");
 
   // Unknown is not implicitly casted.
   VELOX_ASSERT_THROW(
       evaluate(
           "case c0 when 7 then  row_constructor(null, 1) when 11 then  row_constructor(1, null) end",
           vector),
+      "All THEN clauses in case must have the same type. "
+      "Expected ROW<c1:UNKNOWN,c2:BIGINT>, got ROW<c1:BIGINT,c2:UNKNOWN>.");
+}
+
+TEST_P(ParameterizedExprTest, swithExprSanityChecks) {
+  // Use conditions that cannot be detected as a simple CASE (different
+  // subjects per branch) so that the parser emits "switch" not "case".
+  auto vector = makeRowVector(
+      {makeFlatVector<int32_t>({1, 2, 3}), makeFlatVector<int32_t>({4, 5, 6})});
+
+  // Then clauses have different types.
+  VELOX_ASSERT_THROW(
+      evaluate(
+          "case when c0 > 7 then 1 when c1 > 11 then 'welcome' else 0 end",
+          vector),
+      "All then clauses of a SWITCH statement must have the same type. "
+      "Expected BIGINT, but got VARCHAR.");
+
+  // Else clause has different type.
+  VELOX_ASSERT_THROW(
+      evaluate(
+          "case when c0 > 7 then 1 when c1 > 11 then 2 else 'hello' end",
+          vector),
+      "Else clause of a SWITCH statement must have the same type as 'then' "
+      "clauses. Expected BIGINT, but got VARCHAR.");
+
+  // Unknown is not implicitly casted.
+  VELOX_ASSERT_THROW(
+      evaluate(
+          "case when c0 > 7 then 1 when c1 > 11 then null else 3 end", vector),
+      "All then clauses of a SWITCH statement must have the same type. "
+      "Expected BIGINT, but got UNKNOWN.");
+
+  // Unknown is not implicitly casted.
+  VELOX_ASSERT_THROW(
+      evaluate(
+          "case when c0 > 7 then row_constructor(null, 1) when c1 > 11 then row_constructor(1, null) end",
+          vector),
       "All then clauses of a SWITCH statement must have the same type. "
       "Expected ROW<c1:UNKNOWN,c2:BIGINT>, but got ROW<c1:BIGINT,c2:UNKNOWN>.");
+}
+
+TEST_P(ParameterizedExprTest, caseExprExceptionHandling) {
+  registerFunction<TestingAlwaysThrowsFunction, int64_t, int64_t>(
+      {"always_throws_bigint"});
+
+  // THEN clause exception.
+  {
+    auto input = makeRowVector({makeFlatVector<int64_t>({1, 2})});
+
+    // Without try: throws.
+    VELOX_ASSERT_THROW(
+        evaluate(
+            "case c0 when 1 then always_throws_bigint(c0) else 0 end", input),
+        "");
+
+    // With try: row 0 matches → THEN errors → null; row 1 → ELSE 0.
+    auto result = evaluate(
+        "try(case c0 when 1 then always_throws_bigint(c0) else 0 end)", input);
+    EXPECT_TRUE(result->isNullAt(0));
+    EXPECT_FALSE(result->isNullAt(1));
+    EXPECT_EQ(result->as<SimpleVector<int64_t>>()->valueAt(1), 0);
+  }
+
+  // ELSE clause exception.
+  {
+    auto input = makeRowVector({makeFlatVector<int64_t>({1, 2})});
+
+    // Without try: throws.
+    VELOX_ASSERT_THROW(
+        evaluate(
+            "case c0 when 1 then 10 else always_throws_bigint(c0) end", input),
+        "");
+
+    // With try: row 0 matches → THEN 10; row 1 → ELSE errors → null.
+    auto result = evaluate(
+        "try(case c0 when 1 then 10 else always_throws_bigint(c0) end)", input);
+    EXPECT_FALSE(result->isNullAt(0));
+    EXPECT_EQ(result->as<SimpleVector<int64_t>>()->valueAt(0), 10);
+    EXPECT_TRUE(result->isNullAt(1));
+  }
+
+  // Subject exception.
+  {
+    auto input = makeRowVector({makeFlatVector<int64_t>({1, 2, 3})});
+
+    // Without try: throws.
+    VELOX_ASSERT_THROW(
+        evaluate(
+            "case always_throws_bigint(c0) when 1 then 10 else 0 end", input),
+        "");
+
+    // With try: subject errors for every row → all null.
+    auto result = evaluate(
+        "try(case always_throws_bigint(c0) when 1 then 10 else 0 end)", input);
+    for (auto i = 0; i < input->size(); i++) {
+      EXPECT_TRUE(result->isNullAt(i)) << "at row " << i;
+    }
+  }
+
+  // Null propagation masks THEN/ELSE exceptions.
+  // propagatesNulls_ is true when every THEN/ELSE references the same field
+  // used by the subject.  Rows where that field is null are pre-deselected
+  // before the subject, eq, and THEN/ELSE are ever evaluated, so the throwing
+  // expression is never reached for null rows.
+  //
+  // c0 = {0, null, 4}. THEN and ELSE are both c0 / 0.
+  // Non-null rows hit division by zero; null row is masked by propagation.
+  {
+    auto input = makeRowVector({makeFlatVector<int64_t>(
+        3,
+        [](auto row) { return row * 2; },
+        [](auto row) { return row == 1; })});
+
+    // Without try: non-null rows hit c0/0 → throws.
+    VELOX_ASSERT_THROW(
+        evaluate("case c0 when 1 then c0 / 0 else c0 / 0 end", input), "");
+
+    // With try: non-null rows → error → null; null row → propagation → null.
+    auto result =
+        evaluate("try(case c0 when 1 then c0 / 0 else c0 / 0 end)", input);
+    EXPECT_TRUE(result->isNullAt(0));
+    EXPECT_TRUE(result->isNullAt(1));
+    EXPECT_TRUE(result->isNullAt(2));
+  }
+
+  // Null propagation masks WHEN-value exceptions.
+  // All THEN/ELSE reference c0, subject is c0, WHEN value uses c0 → subset
+  // of THEN/ELSE fields → propagatesNulls_ is true.
+  // Rows where c0 is null are pre-deselected so always_throws_bigint is never
+  // called for them, and they return null cleanly.
+  //
+  // c0 = {0, null, 2}.
+  {
+    auto input = makeRowVector({makeFlatVector<int64_t>(
+        3, [](auto row) { return row; }, [](auto row) { return row == 1; })});
+
+    // Without try: non-null rows call always_throws_bigint → throws.
+    VELOX_ASSERT_THROW(
+        evaluate(
+            "case c0 when always_throws_bigint(c0) then c0 else c0 end", input),
+        "");
+
+    // With try: non-null rows → error → null; null row → propagation → null.
+    auto result = evaluate(
+        "try(case c0 when always_throws_bigint(c0) then c0 else c0 end)",
+        input);
+    EXPECT_TRUE(result->isNullAt(0));
+    EXPECT_TRUE(result->isNullAt(1));
+    EXPECT_TRUE(result->isNullAt(2));
+  }
+
+  // THEN/ELSE exception with null subject, without null propagation.
+  // THEN/ELSE reference c1 (not c0), so propagatesNulls_ is false. The null
+  // in c0 causes the row to fall to ELSE, which throws on c1.
+  //
+  // c0 = {1, null}, c1 = {10, 20}.
+  {
+    auto input = makeRowVector(
+        {makeNullableFlatVector<int64_t>({1, std::nullopt}),
+         makeFlatVector<int64_t>({10, 20})});
+
+    // Without try: row 0 matches → THEN always_throws_bigint(c1) → throws.
+    VELOX_ASSERT_THROW(
+        evaluate(
+            "case c0 when 1 then always_throws_bigint(c1) else always_throws_bigint(c1) end",
+            input),
+        "");
+
+    // With try: row 0 → THEN errors → null; row 1 → c0 null, no match →
+    // ELSE always_throws_bigint(c1) → error → null.
+    auto result = evaluate(
+        "try(case c0 when 1 then always_throws_bigint(c1) else always_throws_bigint(c1) end)",
+        input);
+    EXPECT_TRUE(result->isNullAt(0));
+    EXPECT_TRUE(result->isNullAt(1));
+  }
 }
 
 TEST_P(ParameterizedExprTest, switchExprWithNull) {
@@ -3079,8 +3401,12 @@ TEST_P(ParameterizedExprTest, toSql) {
   testToSql("if(a = 10, true, false)", rowType);
   testToSql("case a when 7 then 1 when 11 then 2 else 0 end", rowType);
   testToSql("case a when 7 then 1 when 11 then 2 when 17 then 3 end", rowType);
+  // Use a::bigint explicitly so the subject and the THEN-clause expression
+  // both go through the same ExprCompiler cast path, avoiding a CSE
+  // divergence between the original and re-compiled expression trees.
   testToSql(
-      "case a when b + 3 then 1 when b * 11 then 2 when b - 17 then a + b end",
+      "case a::bigint when b + 3 then 1 when b * 11 then 2"
+      " when b - 17 then a::bigint + b end",
       rowType);
 
   // AND / OR.


### PR DESCRIPTION
Summary:

Why a dedicated CaseExpr
------------------------
`CASE a WHEN v1 THEN r1 ... END` can produce wrong results when `a` is non-deterministic. For example:

  SELECT CASE cast(rand() * 3 as integer)
    WHEN 0 THEN 'zero' WHEN 1 THEN 'one' WHEN 2 THEN 'two'
    ELSE 'other' END
  FROM unnest(sequence(1, 10000));

`cast(rand() * 3 as integer)` only produces 0/1/2, so `'other'` should never appear — yet ~37% of rows return it.

This happens because `PrestoToVeloxExpr::convertSwitchExpr` rewrites simple CASE into the searched form `SWITCH(eq(a, v1), r1, eq(a, v2), r2, ...)`, duplicating `a` in every `eq()`. Velox evaluates each occurrence independently as CSE cannot deduplicate because `a` is non-deterministic, so `rand()` re-rolls per WHEN.

More details: https://github.com/facebookincubator/velox/issues/17115

Implementation
--------------
`CaseExpr` evaluates the subject `a` exactly once and pipes the cached result vector into a pre-built `eq` Expr to evaluate each WHEN clause — the same pattern `LambdaExpr` uses to invoke its body Expr against a synthetic row of (lambda args + captures).

Fuzzer coverage and testing
---------------------------
Added fuzzer support for the new CASE implementation and ran the fuzzer for 12 hours to flush out bugs.

One bug found and fixed: `EvalCtx::inputFlatNoNulls_` is cached at construction, so the synthetic eq row's WHEN slot is seeded with a constant-null vector to force the flag false and prevent the `evalFlatNoNulls` fast path from skipping null propagation.

Reviewed By: kgpai

Differential Revision: D101667510


