### PR TITLE
feat(velox): Support implicit integer-to-decimal type coercion

### DIFF
--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -833,6 +833,9 @@ class ScalarType : public CanProvideCustomComparisonType<KIND> {
 };
 
 /// This class represents the fixed-point numbers.
+std::pair<uint8_t, uint8_t> getDecimalPrecisionScale(const Type& type);
+TypePtr DECIMAL(uint8_t precision, uint8_t scale);
+
 /// The parameter "precision" represents the number of digits the
 /// Decimal Type can support and "scale" represents the number of digits to
 /// the right of the decimal point.
@@ -884,6 +887,74 @@ class DecimalType : public ScalarType<KIND> {
 
   std::span<const TypeParameter> parameters() const override {
     return parameters_;
+  }
+
+  /// Returns the minimum DECIMAL precision needed to represent all values
+  /// of 'kind' without loss. E.g. SMALLINT needs precision 5 since max
+  /// value is 32767 (5 digits). Returns std::nullopt for non-integer types.
+  static std::optional<uint8_t> minPrecisionForInteger(TypeKind kind) {
+    switch (kind) {
+      case TypeKind::TINYINT:
+        return 3;
+      case TypeKind::SMALLINT:
+        return 5;
+      case TypeKind::INTEGER:
+        return 10;
+      case TypeKind::BIGINT:
+        return 19;
+      default:
+        return std::nullopt;
+    }
+  }
+
+  /// Returns true if this DECIMAL can be coerced to the target DECIMAL
+  /// without precision loss. For integers, first map to the natural DECIMAL
+  /// via minPrecisionForInteger (e.g. INTEGER → DECIMAL(10,0)), then call
+  /// this method. The rule is: (p1 - s1) <= (p2 - s2) && s1 <= s2.
+  bool isCoercibleTo(const Type& target) const {
+    auto [targetPrecision, targetScale] = getDecimalPrecisionScale(target);
+    return precision() - scale() <= targetPrecision - targetScale &&
+        scale() <= targetScale;
+  }
+
+  /// Returns the narrowest DECIMAL that can represent values from both
+  /// 'lhs' and 'rhs' (each may be integer or decimal). Returns nullptr
+  /// if the result would exceed DECIMAL(38, s).
+  static TypePtr commonSuperType(const TypePtr& lhs, const TypePtr& rhs) {
+    auto extractComponents = [](const TypePtr& type,
+                                int32_t& integerDigits,
+                                uint8_t& scale) -> bool {
+      if (type->isDecimal()) {
+        auto [precision, s] = getDecimalPrecisionScale(*type);
+        integerDigits = precision - s;
+        scale = s;
+        return true;
+      }
+      if (auto precision = minPrecisionForInteger(type->kind())) {
+        integerDigits = *precision;
+        scale = 0;
+        return true;
+      }
+      return false;
+    };
+
+    int32_t lhsDigits = 0;
+    int32_t rhsDigits = 0;
+    uint8_t lhsScale = 0;
+    uint8_t rhsScale = 0;
+
+    if (!extractComponents(lhs, lhsDigits, lhsScale) ||
+        !extractComponents(rhs, rhsDigits, rhsScale)) {
+      return nullptr;
+    }
+
+    auto scale = std::max(lhsScale, rhsScale);
+    auto integerDigits = std::max(lhsDigits, rhsDigits);
+    auto precision = std::min(38, integerDigits + scale);
+    if (precision - scale < integerDigits) {
+      return nullptr;
+    }
+    return DECIMAL(precision, scale);
   }
 
  protected:
@@ -951,8 +1022,6 @@ FOLLY_ALWAYS_INLINE bool Type::isDecimal() const {
 FOLLY_ALWAYS_INLINE bool isDecimalName(const std::string& name) {
   return (name == "DECIMAL");
 }
-
-std::pair<uint8_t, uint8_t> getDecimalPrecisionScale(const Type& type);
 
 class UnknownType : public CanProvideCustomComparisonType<TypeKind::UNKNOWN> {
  public:

--- a/velox/type/TypeCoercer.cpp
+++ b/velox/type/TypeCoercer.cpp
@@ -46,10 +46,11 @@ allowedCoercions() {
     }
   };
 
-  add(TINYINT(), {SMALLINT(), INTEGER(), BIGINT(), REAL(), DOUBLE()});
-  add(SMALLINT(), {INTEGER(), BIGINT(), REAL(), DOUBLE()});
-  add(INTEGER(), {BIGINT(), REAL(), DOUBLE()});
-  add(BIGINT(), {DOUBLE()});
+  add(TINYINT(),
+      {SMALLINT(), INTEGER(), BIGINT(), DECIMAL(3, 0), REAL(), DOUBLE()});
+  add(SMALLINT(), {INTEGER(), BIGINT(), DECIMAL(5, 0), REAL(), DOUBLE()});
+  add(INTEGER(), {BIGINT(), DECIMAL(10, 0), REAL(), DOUBLE()});
+  add(BIGINT(), {DECIMAL(19, 0), DOUBLE()});
   add(REAL(), {DOUBLE()});
   add(DECIMAL(1, 0), {REAL(), DOUBLE()});
   add(DATE(), {TIMESTAMP()});
@@ -80,6 +81,18 @@ std::optional<Coercion> TypeCoercer::coerceTypeBase(
   static const auto kAllowedCoercions = allowedCoercions();
   auto it = kAllowedCoercions.find({fromType->name(), toType->name()});
   if (it != kAllowedCoercions.end()) {
+    if (toType->isDecimal() && it->second.type->isDecimal()) {
+      if (it->second.type->isShortDecimal()) {
+        if (!it->second.type->asShortDecimal().isCoercibleTo(*toType)) {
+          return std::nullopt;
+        }
+      } else {
+        if (!it->second.type->asLongDecimal().isCoercibleTo(*toType)) {
+          return std::nullopt;
+        }
+      }
+      return Coercion{.type = toType, .cost = it->second.cost};
+    }
     return it->second;
   }
 
@@ -208,6 +221,12 @@ TypePtr TypeCoercer::leastCommonSuperType(const TypePtr& a, const TypePtr& b) {
   }
 
   if (a->size() == 0) {
+    if (a->isDecimal() || b->isDecimal()) {
+      if (auto result = LongDecimalType::commonSuperType(a, b)) {
+        return result;
+      }
+    }
+
     if (TypeCoercer::coerceTypeBase(a, b)) {
       return b;
     }

--- a/velox/type/tests/TypeCoercerTest.cpp
+++ b/velox/type/tests/TypeCoercerTest.cpp
@@ -65,6 +65,78 @@ TEST(TypeCoercerTest, decimal) {
   ASSERT_FALSE(TypeCoercer::coercible(DOUBLE(), DECIMAL(10, 2)));
 }
 
+TEST(TypeCoercerTest, integerToDecimal) {
+  testCoercion(TINYINT(), DECIMAL(3, 0));
+  testCoercion(SMALLINT(), DECIMAL(5, 0));
+  testCoercion(INTEGER(), DECIMAL(10, 0));
+  testCoercion(BIGINT(), DECIMAL(19, 0));
+
+  ASSERT_TRUE(TypeCoercer::coercible(TINYINT(), DECIMAL(10, 2)));
+  ASSERT_TRUE(TypeCoercer::coercible(SMALLINT(), DECIMAL(10, 2)));
+  ASSERT_TRUE(TypeCoercer::coercible(INTEGER(), DECIMAL(38, 4)));
+  ASSERT_TRUE(TypeCoercer::coercible(BIGINT(), DECIMAL(38, 4)));
+
+  ASSERT_TRUE(TypeCoercer::coercible(TINYINT(), DECIMAL(3, 0)));
+  ASSERT_TRUE(TypeCoercer::coercible(SMALLINT(), DECIMAL(5, 0)));
+  ASSERT_TRUE(TypeCoercer::coercible(INTEGER(), DECIMAL(10, 0)));
+  ASSERT_TRUE(TypeCoercer::coercible(BIGINT(), DECIMAL(19, 0)));
+
+  ASSERT_FALSE(TypeCoercer::coercible(TINYINT(), DECIMAL(2, 0)));
+  ASSERT_FALSE(TypeCoercer::coercible(SMALLINT(), DECIMAL(4, 0)));
+  ASSERT_FALSE(TypeCoercer::coercible(INTEGER(), DECIMAL(9, 0)));
+  ASSERT_FALSE(TypeCoercer::coercible(BIGINT(), DECIMAL(18, 0)));
+  ASSERT_FALSE(TypeCoercer::coercible(INTEGER(), DECIMAL(4, 2)));
+  ASSERT_FALSE(TypeCoercer::coercible(BIGINT(), DECIMAL(10, 2)));
+
+  ASSERT_FALSE(TypeCoercer::coercible(DECIMAL(10, 2), INTEGER()));
+  ASSERT_FALSE(TypeCoercer::coercible(DECIMAL(10, 2), BIGINT()));
+}
+
+TEST(TypeCoercerTest, integerToDecimalLeastCommonSuperType) {
+  VELOX_ASSERT_EQ_TYPES(
+      TypeCoercer::leastCommonSuperType(INTEGER(), DECIMAL(38, 4)),
+      DECIMAL(38, 4));
+  VELOX_ASSERT_EQ_TYPES(
+      TypeCoercer::leastCommonSuperType(DECIMAL(38, 4), INTEGER()),
+      DECIMAL(38, 4));
+  VELOX_ASSERT_EQ_TYPES(
+      TypeCoercer::leastCommonSuperType(BIGINT(), DECIMAL(10, 2)),
+      DECIMAL(21, 2));
+  VELOX_ASSERT_EQ_TYPES(
+      TypeCoercer::leastCommonSuperType(DECIMAL(10, 2), BIGINT()),
+      DECIMAL(21, 2));
+  VELOX_ASSERT_EQ_TYPES(
+      TypeCoercer::leastCommonSuperType(INTEGER(), DECIMAL(4, 2)),
+      DECIMAL(12, 2));
+  VELOX_ASSERT_EQ_TYPES(
+      TypeCoercer::leastCommonSuperType(SMALLINT(), DECIMAL(4, 2)),
+      DECIMAL(7, 2));
+  VELOX_ASSERT_EQ_TYPES(
+      TypeCoercer::leastCommonSuperType(TINYINT(), DECIMAL(10, 4)),
+      DECIMAL(10, 4));
+  VELOX_ASSERT_EQ_TYPES(
+      TypeCoercer::leastCommonSuperType(BIGINT(), DECIMAL(19, 0)),
+      DECIMAL(19, 0));
+
+  ASSERT_EQ(
+      TypeCoercer::leastCommonSuperType(BIGINT(), DECIMAL(38, 20)), nullptr);
+}
+
+TEST(TypeCoercerTest, decimalDecimalLeastCommonSuperType) {
+  VELOX_ASSERT_EQ_TYPES(
+      TypeCoercer::leastCommonSuperType(DECIMAL(10, 2), DECIMAL(20, 4)),
+      DECIMAL(20, 4));
+  VELOX_ASSERT_EQ_TYPES(
+      TypeCoercer::leastCommonSuperType(DECIMAL(20, 2), DECIMAL(10, 4)),
+      DECIMAL(22, 4));
+  VELOX_ASSERT_EQ_TYPES(
+      TypeCoercer::leastCommonSuperType(DECIMAL(38, 4), DECIMAL(38, 4)),
+      DECIMAL(38, 4));
+  VELOX_ASSERT_EQ_TYPES(
+      TypeCoercer::leastCommonSuperType(DECIMAL(10, 2), DECIMAL(10, 2)),
+      DECIMAL(10, 2));
+}
+
 TEST(TypeCoercerTest, decimalLeastCommonSuperType) {
   VELOX_ASSERT_EQ_TYPES(
       TypeCoercer::leastCommonSuperType(DECIMAL(10, 2), DOUBLE()), DOUBLE());


### PR DESCRIPTION
Summary:
Add implicit integer types to DECIMAL.

**Context**

Previously, queries like the following would fail:
```
SUM(IF(ds = '2025-03-24', sum_delta_pct, 0))
```
with error messages like:
```
Else clause of a SWITCH statement must have the same type as then clauses. 
Expected DECIMAL(38, 4), but got INTEGER.
```

**Rules**

In order to support this type of coercion, rules would need to be implemented to not match integers with the wrong decimal precision.

**DECIMAL coercion:** (p1, s1) -> (p2, s2) is valid iff (p1 - s1) <= (p2 - s2) && s1 <= s2.                                                                                                          

**Integer-to-DECIMAL coercion (2-step):**
1.  First map to minimum integer digits

| Source Type | Default DECIMAL | Min integer digits |
|-------------|----------------|--------------------|
| TINYINT | DECIMAL(3, 0) | 3 |
| SMALLINT | DECIMAL(5, 0) | 5 |
| INTEGER | DECIMAL(10, 0) | 10 |
| BIGINT | DECIMAL(19, 0) | 19 |
2. Apply the DECIMAL coercion rule above.

*The one intentional difference from Presto Java is that Velox does not allow BIGINT -> REAL (since 32-bit float loses precision for 64-bit integers).*

Coercion examples: INTEGER -> (38, 4) valid; INTEGER -> (10, 2) invalid because 10 > 8; (10, 4) -> (10, 2) invalid because 4 > 2; BIGINT -> (38, 20) invalid because 19 > 18.

**Super-type:** superType((p1, s1), (p2, s2)) = (d + s, s) where d = max(p1 - s1, p2 - s2) and s = max(s1, s2). Returns null if d + s > 38. Same 2-step mapping for integers.

Super-type examples: superType(INTEGER, (38, 4)) = (38, 4); superType(BIGINT, (10, 2)) = (21, 2); superType(BIGINT, (38, 20)) = null because 19 + 20 > 38.              
                                                                  
**Changes**

DecimalType::minPrecisionForInteger() — static method returning the minimum DECIMAL precision needed to represent all values of a given integer TypeKind. This is step 1 of the integer-to-DECIMAL coercion.

DecimalType::isCoercibleTo() — instance method implementing the DECIMAL-to-DECIMAL coercion rule. This is step 2 of the integer-to-DECIMAL coercion. The allowedCoercions() table maps each integer type to its natural DECIMAL, and coerceTypeBase calls isCoercibleTo on that natural DECIMAL against the actual target.

decimalSuperType() — static function computing the narrowest DECIMAL that can represent values from both inputs, whether integer or decimal. Returns nullptr when the result would exceed DECIMAL(38, s).

Differential Revision: D104275505


