### PR TITLE
fix(ci): Drop unsupported -v flag from Presto launcher

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -559,7 +559,7 @@ jobs:
           cd velox
           cp ./scripts/ci/presto/etc/hive.properties $PRESTO_HOME/etc/catalog
           ls -lR $PRESTO_HOME/etc
-          $PRESTO_HOME/bin/launcher run -v > /tmp/server.log 2>&1 &
+          $PRESTO_HOME/bin/launcher run > /tmp/server.log 2>&1 &
           # Sleep for 60 seconds to allow Presto server to start.
           sleep 60
           /opt/presto-cli --server 127.0.0.1:8080 --execute 'CREATE SCHEMA IF NOT EXISTS hive.tpch;'
@@ -863,7 +863,7 @@ jobs:
           cd  velox
           cp ./scripts/ci/presto/etc/hive.properties $PRESTO_HOME/etc/catalog
           ls -lR $PRESTO_HOME/etc
-          $PRESTO_HOME/bin/launcher run -v > /tmp/server.log 2>&1 &
+          $PRESTO_HOME/bin/launcher run > /tmp/server.log 2>&1 &
           # Sleep for 60 seconds to allow Presto server to start.
           sleep 60
           /opt/presto-cli --server 127.0.0.1:8080 --execute 'CREATE SCHEMA IF NOT EXISTS hive.tpch;'
@@ -979,7 +979,7 @@ jobs:
           cd velox
           cp ./scripts/ci/presto/etc/hive.properties $PRESTO_HOME/etc/catalog
           ls -lR $PRESTO_HOME/etc
-          $PRESTO_HOME/bin/launcher run -v > /tmp/server.log 2>&1 &
+          $PRESTO_HOME/bin/launcher run > /tmp/server.log 2>&1 &
           # Sleep for 60 seconds to allow Presto server to start.
           sleep 60
           /opt/presto-cli --server 127.0.0.1:8080 --execute 'CREATE SCHEMA IF NOT EXISTS hive.tpch;'
@@ -1048,7 +1048,7 @@ jobs:
           cd velox
           cp ./scripts/ci/presto/etc/hive.properties $PRESTO_HOME/etc/catalog
           ls -lR $PRESTO_HOME/etc
-          $PRESTO_HOME/bin/launcher run -v > /tmp/server.log 2>&1 &
+          $PRESTO_HOME/bin/launcher run > /tmp/server.log 2>&1 &
           # Sleep for 60 seconds to allow Presto server to start.
           sleep 60
           /opt/presto-cli --server 127.0.0.1:8080 --execute 'CREATE SCHEMA IF NOT EXISTS hive.tpch;'
@@ -1244,7 +1244,7 @@ jobs:
           cd  velox
           cp ./scripts/ci/presto/etc/hive.properties $PRESTO_HOME/etc/catalog
           ls -lR $PRESTO_HOME/etc
-          $PRESTO_HOME/bin/launcher run -v > /tmp/server.log 2>&1 &
+          $PRESTO_HOME/bin/launcher run > /tmp/server.log 2>&1 &
           # Sleep for 60 seconds to allow Presto server to start.
           sleep 60
           /opt/presto-cli --server 127.0.0.1:8080 --execute 'CREATE SCHEMA IF NOT EXISTS hive.tpch;'
@@ -1322,7 +1322,7 @@ jobs:
           cd  velox
           cp ./scripts/ci/presto/etc/hive.properties $PRESTO_HOME/etc/catalog
           ls -lR $PRESTO_HOME/etc
-          $PRESTO_HOME/bin/launcher run -v > /tmp/server.log 2>&1 &
+          $PRESTO_HOME/bin/launcher run > /tmp/server.log 2>&1 &
           # Sleep for 60 seconds to allow Presto server to start.
           sleep 60
           /opt/presto-cli --server 127.0.0.1:8080 --execute 'CREATE SCHEMA IF NOT EXISTS hive.tpch;'
@@ -1421,7 +1421,7 @@ jobs:
           cd  velox
           cp ./scripts/ci/presto/etc/hive.properties $PRESTO_HOME/etc/catalog
           ls -lR $PRESTO_HOME/etc
-          $PRESTO_HOME/bin/launcher run -v > /tmp/server.log 2>&1 &
+          $PRESTO_HOME/bin/launcher run > /tmp/server.log 2>&1 &
           # Sleep for 60 seconds to allow Presto server to start.
           sleep 60
           /opt/presto-cli --server 127.0.0.1:8080 --execute 'CREATE SCHEMA IF NOT EXISTS hive.tpch;'
@@ -1523,7 +1523,7 @@ jobs:
           cd  velox
           cp ./scripts/ci/presto/etc/hive.properties $PRESTO_HOME/etc/catalog
           ls -lR $PRESTO_HOME/etc
-          $PRESTO_HOME/bin/launcher run -v > /tmp/server.log 2>&1 &
+          $PRESTO_HOME/bin/launcher run > /tmp/server.log 2>&1 &
           # Sleep for 60 seconds to allow Presto server to start.
           sleep 60
           /opt/presto-cli --server 127.0.0.1:8080 --execute 'CREATE SCHEMA IF NOT EXISTS hive.tpch;'
@@ -1597,7 +1597,7 @@ jobs:
           ls -lR $PRESTO_HOME/etc
           echo "jvm config content:"
           cat $PRESTO_HOME/etc/jvm.config
-          $PRESTO_HOME/bin/launcher run -v > /tmp/server.log 2>&1 &
+          $PRESTO_HOME/bin/launcher run > /tmp/server.log 2>&1 &
           ls -lR /var/log
           # Sleep for 60 seconds to allow Presto server to start.
           sleep 60


### PR DESCRIPTION
## Summary

- #17430 bumped the Presto Java image from 0.295 to 0.297, which removed the `-v` flag from `bin/launcher`. Every \"Presto as source of truth\" fuzzer job now fails before the Presto coordinator can come up:

  ```
  usage: launcher [options] command
  launcher: error: unrecognized arguments: -v
  ```

  (visible in `tmp/server.log` inside the artifacts uploaded by the failed jobs, e.g. https://github.com/facebookincubator/velox/actions/runs/25520600307/artifacts/6866639117)

- After the 60s sleep, the workflow tries to connect to `127.0.0.1:8080` and gets `java.net.ConnectException: Failed to connect`, which is the visible failure in jobs like `Writer Fuzzer with Presto as source of truth`, `Aggregation Fuzzer with Presto as source of truth`, `Window Fuzzer …`, `Join Fuzzer`, and `Expression Fuzzer with Presto SOT` in https://github.com/facebookincubator/velox/actions/runs/25520600307.

- Server output is already redirected to `/tmp/server.log`, so dropping `-v` loses nothing. This patch removes it from all 9 invocations in `.github/workflows/scheduled.yml`.

## Test plan

- [ ] Re-run the Fuzzer Jobs workflow on `main` after merge and confirm the Presto-SOT jobs (Writer / Aggregation / Window / Join / Expression) start the Presto server and proceed past the connect step.