### PR TITLE
build: Drop unnecessary velox_core_expressions dep

### DIFF
--- a/velox/expression/CMakeLists.txt
+++ b/velox/expression/CMakeLists.txt
@@ -121,7 +121,6 @@ velox_link_libraries(
   velox_core
   velox_vector
   velox_common_base
-  velox_core_expressions
   velox_expression_functions
   velox_functions_util
   velox_type_tz

--- a/velox/expression/tests/ConjunctTest.cpp
+++ b/velox/expression/tests/ConjunctTest.cpp
@@ -19,7 +19,6 @@
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
-#include "velox/parse/Expressions.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::exec;

--- a/velox/expression/tests/ExprEncodingsTest.cpp
+++ b/velox/expression/tests/ExprEncodingsTest.cpp
@@ -19,7 +19,6 @@
 #include "velox/common/base/Exceptions.h"
 #include "velox/expression/ConstantExpr.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
-#include "velox/parse/Expressions.h"
 #include "velox/parse/ExpressionsParser.h"
 #include "velox/parse/TypeResolver.h"
 #include "velox/vector/VectorEncoding.h"

--- a/velox/expression/tests/ExprStatsTest.cpp
+++ b/velox/expression/tests/ExprStatsTest.cpp
@@ -21,7 +21,6 @@
 #include "velox/functions/Registerer.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
-#include "velox/parse/Expressions.h"
 #include "velox/parse/ExpressionsParser.h"
 #include "velox/parse/TypeResolver.h"
 

--- a/velox/expression/tests/ExpressionRunner.cpp
+++ b/velox/expression/tests/ExpressionRunner.cpp
@@ -24,7 +24,6 @@
 #include "velox/expression/fuzzer/FuzzerToolkit.h"
 #include "velox/expression/tests/ExpressionRunner.h"
 #include "velox/expression/tests/ExpressionVerifier.h"
-#include "velox/parse/Expressions.h"
 #include "velox/parse/ExpressionsParser.h"
 #include "velox/parse/QueryPlanner.h"
 #include "velox/parse/TypeResolver.h"

--- a/velox/expression/tests/ExpressionRunner.h
+++ b/velox/expression/tests/ExpressionRunner.h
@@ -16,7 +16,6 @@
 
 #include <string>
 #include "velox/exec/fuzzer/ReferenceQueryRunner.h"
-#include "velox/parse/Expressions.h"
 #include "velox/vector/TypeAliases.h"
 
 namespace facebook::velox::test {

--- a/velox/expression/tests/ExpressionVerifierUnitTest.cpp
+++ b/velox/expression/tests/ExpressionVerifierUnitTest.cpp
@@ -23,7 +23,6 @@
 #include "velox/common/file/FileSystems.h"
 #include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/functions/Registerer.h"
-#include "velox/parse/Expressions.h"
 #include "velox/parse/ExpressionsParser.h"
 #include "velox/parse/TypeResolver.h"
 #include "velox/type/Type.h"

--- a/velox/parse/CMakeLists.txt
+++ b/velox/parse/CMakeLists.txt
@@ -11,33 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# Leaf library that owns the out-of-line definitions for the
-# `velox::core` expression class hierarchy declared in Expressions.h
-# (CallExpr, CastExpr, FieldAccessExpr, ConstantExpr, LambdaExpr,
-# WindowCallExpr, ...). Lifted out of velox_parse_expression so that
-# velox_expression — which uses dynamic_cast on these classes — can
-# pick up the typeinfo without taking a dependency on
-# velox_parse_expression itself, which would close a cycle
-# (velox_parse_expression already depends on velox_expression).
-velox_add_library(velox_core_expressions Expressions.cpp HEADERS Expressions.h IExpr.h)
-velox_link_libraries(velox_core_expressions velox_common_base velox_type Folly::folly)
-
 velox_add_library(
   velox_parse_expression
   ExprRewriter.cpp
+  Expressions.cpp
   SqlExpressionsParser.cpp
   HEADERS
   ExprRewriter.h
+  Expressions.h
+  IExpr.h
   SqlExpressionsParser.h
   TypeResolver.h
 )
-velox_link_libraries(
-  velox_parse_expression
-  velox_core_expressions
-  velox_type
-  velox_parse_utils
-  velox_expression
-)
+velox_link_libraries(velox_parse_expression velox_type velox_parse_utils velox_expression)
 
 velox_add_library(
   velox_parse_parser


### PR DESCRIPTION
Summary:
The MONO=OFF adapters job was failing pre https://github.com/facebookincubator/velox/pull/17387 with link errors that traced back to dead `#include "velox/parse/Expressions.h"` lines in velox/expression/tests/ pulling in the IExpr hierarchy that no test code actually used. https://github.com/facebookincubator/velox/pull/17387 worked around this by extracting velox_core_expressions as a leaf and linking it from velox_expression.

The over-broad dep now dangles when VELOX_ENABLE_PARSE=OFF (Prestissimo prod), causing https://github.com/facebookincubator/velox/issues/17448: ld fails with `library 'velox_core_expressions' not found` when linking velox_functions_remote_server_main.

Drop the dep, fold Expressions.cpp back into velox_parse_expression, delete the leaf, and remove the dead includes (the actual root cause). Real consumers of core::CallExpr typeinfo (PlanBuilder, fuzzer transforms, DuckParser) still reach it via velox_parse_expression transitively. Other D102198782 fixes stay landed.

Differential Revision: D104304862


