### PR TITLE
fix(fuzzer): Skip functions missing in Presto 0.297 in expression SOT fuzzer

### DIFF
--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -510,6 +510,15 @@ std::unordered_set<std::string> skipFunctionsSOT = {
     "s2_cell_to_token",
     "ip_version", // New function, pending Presto Java implementation
     "ip_prefix_masklen", // New function, pending Presto Java implementation
+    // Documented in Presto 0.295 (functions/{array,map}.html) but missing from
+    // the 0.297 docs and not registered in the 0.297 server image used for SOT
+    // fuzzing — fuzzer aborts with "Function ... not registered". Whether
+    // this is a removal or a plugin/namespace move in 0.297 is TBD; skip
+    // until that is sorted out (see #17449 / #17450).
+    "any_keys_match",
+    "no_keys_match",
+    "remove_nulls",
+    "array_max_by",
 };
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
## Summary

After #17430 bumped the Presto Java image from 0.295 to 0.297, the **Expression Fuzzer with Presto as source of truth** aborts within ~45s of starting. All 4 fuzzer instances trip the same `ExpressionVerifier` "Only reference path threw exception" assertion because Presto rejects the generated query with `Function ... not registered` for one of these names: `any_keys_match`, `no_keys_match`, `remove_nulls`, `array_max_by`. Failure log: https://github.com/facebookincubator/velox/actions/runs/25523606885/job/74915186515.

This patch adds those four names to ` skipFunctionsSOT` so the fuzzer stops picking them when Presto is the source of truth. The launcher startup fix in #17449 already gets 3 of 4 Presto-SOT jobs back to green; with this change the Expression Fuzzer SOT job should join them.

## Validation against official Presto docs

I checked each function against the published 0.295 and 0.297 docs and against the running 0.297 server:

| Function | Presto 0.295 docs | Presto 0.297 docs | Runtime in 0.297 server |
|---|---|---|---|
| `any_keys_match` | Present | Not on map page | "not registered" |
| `no_keys_match` | Present | Not on map page | "not registered" |
| `remove_nulls` | Present | Not on array page | "not registered" |
| `array_max_by` | Present | Not on array page | "not registered" |

Sources:
- 0.295: https://prestodb.io/docs/0.295/functions/array.html, https://prestodb.io/docs/0.295/functions/map.html
- 0.297: https://prestodb.io/docs/0.297/functions/array.html, https://prestodb.io/docs/0.297/functions/map.html
- 0.296 release notes do not call out a removal: https://prestodb.io/docs/0.297/release/release-0.296.html

So these are **not Velox-only functions** — they were available in 0.295 and disappeared in 0.297. Whether that is a removal, a plugin/namespace move (Presto 0.296 added "Add support for custom schemas in native sidecar function registry"), or a packaging change in the server tarball is still TBD. The skips here are a stop-gap to keep the SOT fuzzer running; they should be removed once we identify the cause and either reload the missing functions in our CI Presto config or wait for them to come back upstream.

`array_sort_desc` was originally in this list but removed after verifying that Presto 0.297 still ships its 2-arg lambda overload — only the 1-arg form Velox additionally registers is missing, and the precision cost of a bare-name skip there isn't worth it.

## Test plan

- [ ] After landing, watch the next Fuzzer Jobs run on `main` and confirm `Expression Fuzzer with Presto SOT` reaches the full fuzzer duration without aborting on any of the four function names.