### PR TITLE
fix(cache): Drop stale checkpoint when checkpointing is disabled

### DIFF
--- a/velox/common/caching/SsdFile.cpp
+++ b/velox/common/caching/SsdFile.cpp
@@ -138,6 +138,8 @@ SsdFile::SsdFile(const Config& config)
   regionPins_.resize(maxRegions_, 0);
   if (checkpointEnabled()) {
     initializeCheckpoint();
+  } else {
+    removeStaleRecoveryFiles();
   }
 
   if (disableFileCow_) {
@@ -710,6 +712,28 @@ void SsdFile::deleteFile(std::unique_ptr<WriteFile> file) {
     ++stats_.deleteMetaFileErrors;
     VELOX_SSD_CACHE_LOG(ERROR)
         << fmt::format("Error in deleting file {}: {}", filePath, e.what());
+  }
+}
+
+void SsdFile::removeStaleRecoveryFiles() {
+  const auto checkpointPath = checkpointFilePath();
+  if (fs_->exists(checkpointPath)) {
+    try {
+      fs_->remove(checkpointPath);
+    } catch (const std::exception& e) {
+      VELOX_SSD_CACHE_LOG(WARNING) << "Failed to remove stale checkpoint file "
+                                   << checkpointPath << ": " << e.what();
+    }
+  }
+  const auto logPath = evictLogFilePath();
+  if (fs_->exists(logPath)) {
+    try {
+      fs_->remove(logPath);
+    } catch (const std::exception& e) {
+      VELOX_SSD_CACHE_LOG(WARNING)
+          << "Failed to remove stale eviction log file " << logPath << ": "
+          << e.what();
+    }
   }
 }
 

--- a/velox/common/caching/SsdFile.h
+++ b/velox/common/caching/SsdFile.h
@@ -531,6 +531,22 @@ class SsdFile {
   // Deletes the given file if it exists.
   void deleteFile(std::unique_ptr<WriteFile> file);
 
+  // Removes the checkpoint and eviction-log files left behind by a previous
+  // SsdFile instance using this same data file. Called from the constructor
+  // when this instance has checkpointing disabled.
+  //
+  // The checkpoint and log together describe which logical keys live at
+  // which offsets in the data file; recovery on startup reads them to
+  // rebuild 'entries_'. They are trustworthy only while every write to the
+  // data file also keeps them up to date. With checkpointing off this
+  // instance writes into the existing data file but never touches the
+  // meta files, so a later instance with checkpointing re-enabled would
+  // recover from a stale checkpoint pointing at overwritten regions and
+  // silently return wrong bytes. Removing them here keeps the on-disk
+  // state to either {data + matching checkpoint} or {data alone}; the
+  // {data + stale checkpoint} state becomes unreachable.
+  void removeStaleRecoveryFiles();
+
   // Allocates 'kCheckpointBufferSize' buffer from cache memory pool for
   // checkpointing.
   void allocateCheckpointBuffer();


### PR DESCRIPTION
Summary:
When `SsdFile` is constructed with checkpointing disabled, any existing
`*.cpt` and `*.log` files from a previous instance are now removed.

The previous behavior allowed a stale checkpoint to outlive the data
file content it described:

  1. Instance A runs with checkpoint enabled, writes data and persists
     `cache0`, `cache0.cpt`, `cache0.log`.
  2. Instance B runs with checkpoint disabled, opens the existing
     `cache0` data file, marks all existing regions as writable, and
     overwrites them with new content. `cache0.cpt` is left untouched.
  3. Instance C runs with checkpoint enabled. `SsdFile::readCheckpoint`
     succeeds against `cache0.cpt` and populates `entries_` with
     mappings whose offsets point at regions whose disk content was
     overwritten by Instance B. With checksum read verification also
     disabled (a common surrounding configuration), the wrong bytes
     are returned to the reader without any error.

This sequence shows up reliably in `velox_cache_fuzzer`, which cycles
through several `SsdCache` instances per iteration with randomized
shard counts, capacities, and checkpoint/checksum settings, all reusing
the same cache directory.

Part of the issue #17158

Differential Revision: D104303438


