### PR TITLE
fix: Back out  Bump Presto Java image to 0.297 (#17455)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ services:
     image: ghcr.io/facebookincubator/velox-dev:presto-java
     build:
       args:
-        - PRESTO_VERSION=0.297
+        - PRESTO_VERSION=0.295
       dockerfile: scripts/docker/java.dockerfile
 
   spark-server:

--- a/scripts/docker/java.dockerfile
+++ b/scripts/docker/java.dockerfile
@@ -15,7 +15,7 @@
 
 # Global arg default to share across stages
 ARG SPARK_VERSION=3.5.1
-ARG PRESTO_VERSION=0.297
+ARG PRESTO_VERSION=0.295
 
 #########################
 # Stage: Spark Download #


### PR DESCRIPTION
Summary:

Backs out D104265464 (commit 03891890b42c), which bumped the Presto Java Docker image from 0.295 to 0.297.

Reverts the version bump in:
- fbcode/velox/public_tld/docker-compose.yml
- fbcode/velox/public_tld/scripts/docker/java.dockerfile

Reviewed By: mbasmanova, pratikpugalia

Differential Revision: D104320457


