### PR TITLE
perf(parquet): Direct decompress for snappy/zstd bypassing intermediate copy

### DIFF
--- a/velox/dwio/parquet/reader/PageReader.cpp
+++ b/velox/dwio/parquet/reader/PageReader.cpp
@@ -16,6 +16,9 @@
 
 #include "velox/dwio/parquet/reader/PageReader.h"
 
+#include <snappy.h>
+#include <zstd.h>
+
 #include "velox/common/testutil/TestValue.h"
 #include "velox/common/time/Timer.h"
 #include "velox/dwio/common/BufferUtil.h"
@@ -143,27 +146,59 @@ const char* PageReader::decompressData(
     const char* pageData,
     uint32_t compressedSize,
     uint32_t uncompressedSize) {
-  std::unique_ptr<dwio::common::SeekableInputStream> inputStream =
-      std::make_unique<dwio::common::SeekableArrayInputStream>(
-          pageData, compressedSize, 0);
-  auto streamDebugInfo =
-      fmt::format("Page Reader: Stream {}", inputStream_->getName());
-  std::unique_ptr<dwio::common::SeekableInputStream> decompressedStream =
-      dwio::common::compression::createDecompressor(
-          codec_,
-          std::move(inputStream),
-          uncompressedSize,
-          pool_,
-          getParquetDecompressionOptions(codec_),
-          streamDebugInfo,
-          nullptr,
-          true,
-          compressedSize);
-
   dwio::common::ensureCapacity<char>(
       decompressedData_, uncompressedSize, &pool_);
-  decompressedStream->readFully(
-      decompressedData_->asMutable<char>(), uncompressedSize);
+  auto* dest = decompressedData_->asMutable<char>();
+
+  switch (codec_) {
+    case common::CompressionKind::CompressionKind_SNAPPY: {
+      size_t actualUncompressedSize;
+      VELOX_CHECK(
+          snappy::GetUncompressedLength(
+              pageData, compressedSize, &actualUncompressedSize),
+          "Snappy: failed to get uncompressed length from corrupt data");
+      VELOX_CHECK_EQ(actualUncompressedSize, uncompressedSize);
+      VELOX_CHECK(
+          snappy::RawUncompress(pageData, compressedSize, dest),
+          "Snappy decompression failed");
+      break;
+    }
+    case common::CompressionKind::CompressionKind_ZSTD: {
+      thread_local std::unique_ptr<ZSTD_DCtx, size_t (*)(ZSTD_DCtx*)> zstdCtx{
+          ZSTD_createDCtx(), ZSTD_freeDCtx};
+      VELOX_CHECK_NOT_NULL(zstdCtx);
+      const auto actualUncompressedSize = ZSTD_decompressDCtx(
+          zstdCtx.get(), dest, uncompressedSize, pageData, compressedSize);
+      VELOX_CHECK(
+          !ZSTD_isError(actualUncompressedSize),
+          "ZSTD decompression failed: {}",
+          ZSTD_getErrorName(actualUncompressedSize));
+      VELOX_CHECK_EQ(actualUncompressedSize, uncompressedSize);
+      break;
+    }
+    default: {
+      // Fallback to stream-based decompression for other codecs (gzip, lz4,
+      // lzo).
+      std::unique_ptr<dwio::common::SeekableInputStream> inputStream =
+          std::make_unique<dwio::common::SeekableArrayInputStream>(
+              pageData, compressedSize, 0);
+      auto streamDebugInfo =
+          fmt::format("Page Reader: Stream {}", inputStream_->getName());
+      std::unique_ptr<dwio::common::SeekableInputStream> decompressedStream =
+          dwio::common::compression::createDecompressor(
+              codec_,
+              std::move(inputStream),
+              uncompressedSize,
+              pool_,
+              getParquetDecompressionOptions(codec_),
+              streamDebugInfo,
+              nullptr,
+              true,
+              compressedSize);
+      decompressedStream->readFully(dest, uncompressedSize);
+      break;
+    }
+  }
 
   return decompressedData_->as<char>();
 }


### PR DESCRIPTION
For snappy and zstd compressed Parquet pages, decompress directly into the target buffer instead of going through the stream-based PagedInputStream path.

## Problem

The current path creates a `SeekableArrayInputStream`, wraps it in a `PagedInputStream` (which allocates an internal `outputBuffer_`), decompresses into that buffer, then copies to the final destination via `readFully()` (`std::copy`). The intermediate buffer allocation and copy add unnecessary overhead for codecs where the full compressed page is already available in memory. Profiling on TPC-H SF100 with snappy-compressed Parquet showed `memmove` (from `std::copy` in `readFully`) as a visible cost in the decompression path.

## Fix

Call `snappy::RawUncompress` / `ZSTD_decompress` directly into the destination buffer, eliminating the intermediate allocation and copy. Other codecs (gzip, lz4, lzo) fall back to the original stream-based path.

Both `Snappy::snappy` and `zstd::zstd` are already linked in the parquet reader CMakeLists.