### PR TITLE
perf: skip lazy vector loading in FilterProject when output has no unloaded lazies to reduce loadReusedLazyVectors CPU cost (#17458)

### DIFF
--- a/velox/exec/FilterProject.cpp
+++ b/velox/exec/FilterProject.cpp
@@ -108,7 +108,7 @@ const void* lazyIdentityPtr(const VectorPtr& vec) {
 // hook during pushdown. Accessing a loaded vector in this case can lead to
 // incorrect results or even a crash.
 void loadReusedLazyVectors(const RowVectorPtr& output) {
-  if (!output) {
+  if (!output || !output->containsLazyNotLoaded()) {
     return;
   }
 


### PR DESCRIPTION
Summary:

`loadReusedLazyVectors` in filterProject is unconditionally invoked but has non-negligible CPU cost — up to 7% in some workloads. 

It does two full passes over all output columns per batch: the first calls lazyIdentityPtr() on each column, which recursively peels dictionary/constant/sequence layers via unwrapToLazy(); the second calls lazyIdentityPtr() again on duplicates, then loadedVector(). This diff adds an early containsLazyNotLoaded() check to skip both passes when there are no lazy vectors in the output.

This PR skips the cpu heavy call when output doesn't have unloaded lazies.

Differential Revision: D101933314


