### PR TITLE
fix(spark): Crash in get_json_object Spark function

### DIFF
--- a/velox/functions/sparksql/GetJsonObject.h
+++ b/velox/functions/sparksql/GetJsonObject.h
@@ -220,7 +220,7 @@ struct GetJsonObjectFunction {
         return false;
       }
 
-      if (!extractStringResult(rawResult, result)) {
+      if (!extractStringResult(rawResult, paddedJson, result)) {
         return false;
       }
     } catch (simdjson::simdjson_error&) {
@@ -246,6 +246,7 @@ struct GetJsonObjectFunction {
   // Returns true if the conversion is successful. Otherwise, returns false.
   bool extractStringResult(
       simdjson::simdjson_result<simdjson::ondemand::value> rawResult,
+      const simdjson::padded_string& paddedJson,
       out_type<Varchar>& result) {
     std::stringstream ss;
     switch (rawResult.type()) {
@@ -288,6 +289,12 @@ struct GetJsonObjectFunction {
         return false;
       }
       case simdjson::ondemand::json_type::string: {
+        std::string_view rawToken;
+        if (rawResult.raw_json_token().get(rawToken) ||
+            !hasClosedJsonString(rawToken, paddedJson)) {
+          return false;
+        }
+
         std::string_view stringResult;
         if (!rawResult.get_string().get(stringResult)) {
           result.append(stringResult);
@@ -306,6 +313,59 @@ struct GetJsonObjectFunction {
       default:
         return false;
     }
+  }
+
+  bool hasClosedJsonString(
+      std::string_view rawToken,
+      const simdjson::padded_string& paddedJson) {
+    const auto* begin = paddedJson.data();
+    const auto* stringStart = rawToken.data();
+    if (begin == nullptr || stringStart == nullptr) {
+      return false;
+    }
+
+    if (!isStringViewInPaddedJson(rawToken, paddedJson)) {
+      return false;
+    }
+
+    const auto* end = begin + paddedJson.size();
+    if (stringStart < begin || stringStart >= end || *stringStart != '"') {
+      return false;
+    }
+
+    bool escaped = false;
+    for (auto* current = stringStart + 1; current < end; ++current) {
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (*current == '\\') {
+        escaped = true;
+        continue;
+      }
+      if (*current == '"') {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool isStringViewInPaddedJson(
+      std::string_view value,
+      const simdjson::padded_string& paddedJson) {
+    const auto* begin = paddedJson.data();
+    const auto* data = value.data();
+    if (begin == nullptr || data == nullptr) {
+      return value.empty();
+    }
+
+    const auto size = paddedJson.size();
+    const auto* end = begin + size;
+    if (data < begin || data > end) {
+      return false;
+    }
+
+    return value.size() <= static_cast<size_t>(end - data);
   }
 
   // Checks whether the obtained result is followed by valid char. Because

--- a/velox/functions/sparksql/tests/GetJsonObjectTest.cpp
+++ b/velox/functions/sparksql/tests/GetJsonObjectTest.cpp
@@ -235,5 +235,9 @@ TEST_F(GetJsonObjectTest, number) {
       "-1234567890123456789012345678901234567890");
 }
 
+TEST_F(GetJsonObjectTest, incompleteJsonStringValue) {
+  EXPECT_EQ(getJsonObject(R"({"key":")", "$.key"), std::nullopt);
+}
+
 } // namespace
 } // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
## Summary

This change fixes a crash in Spark SQL `get_json_object` when the requested JSON path points to an incomplete string value.

Example input:

```json
{"key":"
```

For:

```sql
get_json_object(json, '$.key')
```

the function should return null instead of crashing.

## Problem

`get_json_object` uses simdjson's incomplete JSON parsing mode:

```cpp
parser.iterate_allow_incomplete_json(json)
```

This allows Velox to extract valid fields from JSON strings that contain trailing invalid or incomplete content.

However, when the requested value itself is an unterminated JSON string, simdjson may still classify the value as a string. Calling `get_string()` on that value can enter simdjson's unescape path with an invalid raw string token, which can lead to memory corruption and a later crash during `simdjson::padded_string` destruction.

## Fix

Before calling `get_string()` for string results, the code now checks the raw JSON token:

1. The raw token must point into the current `paddedJson` buffer.
2. The token must start with `"`.
3. The token must contain an unescaped closing quote within the original JSON length.

If the target string value is incomplete, `get_json_object` returns null instead of calling `get_string()`.

This keeps the existing behavior for incomplete JSON with valid target fields, while safely rejecting incomplete target string values.

## Test

Added a regression test:

```cpp
TEST_F(GetJsonObjectTest, incompleteJsonStringValue) {
  EXPECT_EQ(getJsonObject(R"({"key":")", "$.key"), std::nullopt);
}
```

## Was this patch authored or co-authored using generative AI tooling?

Yes, AI tool generates this patch.