### PR TITLE
fix: Pass request type to SelectiveDecimalColumnReader

### DIFF
--- a/velox/dwio/dwrf/reader/SelectiveDecimalColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveDecimalColumnReader.cpp
@@ -24,22 +24,19 @@ SelectiveDecimalColumnReader<DataT>::SelectiveDecimalColumnReader(
     const std::shared_ptr<const TypeWithId>& fileType,
     DwrfParams& params,
     common::ScanSpec& scanSpec)
-    // Use requestedType (table schema) when it is a decimal of the same
-    // TypeKind as the file type.  This allows the reader to rescale values
-    // from the ORC file's precision/scale to the metastore-declared
-    // precision/scale, so that NativeScan output matches the vanilla Spark
-    // scan path and decimal join-key comparisons succeed.
+    // When the read schema (requestedType) differs from the file schema,
+    // prefer using requestedType for decoding as long as the conversion is
+    // supported (e.g. reading decimal with different scale). This allows the
+    // reader to interpret values according to the table schema, so that
+    // NativeScan matches the vanilla Spark scan behavior.
     //
     // When the TypeKinds differ (e.g. file is HUGEINT but table declares
     // BIGINT) we fall back to the file type to avoid buffer-size mismatches
     // in getIntValues(); in that case the Gluten fallback-tag logic will
     // ensure symmetric scan behaviour at the join level.
     : SelectiveColumnReader(
-          (requestedType && requestedType->isDecimal() &&
-           requestedType->kind() == fileType->type()->kind())
-              ? requestedType
-              : fileType->type(),
-          fileType,
+          requestedType,
+          std::move(fileType),
           params,
           scanSpec) {
   EncodingKey encodingKey{fileType_->id(), params.flatMapContext().sequence};

--- a/velox/dwio/dwrf/reader/SelectiveDecimalColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveDecimalColumnReader.cpp
@@ -24,12 +24,15 @@ SelectiveDecimalColumnReader<DataT>::SelectiveDecimalColumnReader(
     const std::shared_ptr<const TypeWithId>& fileType,
     DwrfParams& params,
     common::ScanSpec& scanSpec)
-    // When the read schema (requestedType) differs from the file schema,
-    // prefer using requestedType for decoding as long as the conversion is
-    // supported (e.g. reading decimal with different scale). This allows the
-    // reader to interpret values according to the table schema, so that
-    // NativeScan matches the vanilla Spark scan behavior.
+    // Read using requestedType so that values are materialized at the
+    // table-schema scale rather than the file-footer scale. See the header
+    // comment for the Hive ORC DECIMAL(38, 18) footer behavior this works
+    // around.
     : SelectiveColumnReader(requestedType, fileType, params, scanSpec) {
+  VELOX_CHECK(
+      requestedType_->isDecimal(),
+      "SelectiveDecimalColumnReader requires a decimal requestedType, got {}",
+      requestedType_->toString());
   EncodingKey encodingKey{fileType_->id(), params.flatMapContext().sequence};
   auto& stripe = params.stripeStreams();
   if constexpr (std::is_same_v<DataT, std::int64_t>) {

--- a/velox/dwio/dwrf/reader/SelectiveDecimalColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveDecimalColumnReader.cpp
@@ -29,11 +29,6 @@ SelectiveDecimalColumnReader<DataT>::SelectiveDecimalColumnReader(
     // supported (e.g. reading decimal with different scale). This allows the
     // reader to interpret values according to the table schema, so that
     // NativeScan matches the vanilla Spark scan behavior.
-    //
-    // When the TypeKinds differ (e.g. file is HUGEINT but table declares
-    // BIGINT) we fall back to the file type to avoid buffer-size mismatches
-    // in getIntValues(); in that case the Gluten fallback-tag logic will
-    // ensure symmetric scan behaviour at the join level.
     : SelectiveColumnReader(requestedType, fileType, params, scanSpec) {
   EncodingKey encodingKey{fileType_->id(), params.flatMapContext().sequence};
   auto& stripe = params.stripeStreams();

--- a/velox/dwio/dwrf/reader/SelectiveDecimalColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveDecimalColumnReader.cpp
@@ -20,10 +20,28 @@ namespace facebook::velox::dwrf {
 
 template <typename DataT>
 SelectiveDecimalColumnReader<DataT>::SelectiveDecimalColumnReader(
+    const TypePtr& requestedType,
     const std::shared_ptr<const TypeWithId>& fileType,
     DwrfParams& params,
     common::ScanSpec& scanSpec)
-    : SelectiveColumnReader(fileType->type(), fileType, params, scanSpec) {
+    // Use requestedType (table schema) when it is a decimal of the same
+    // TypeKind as the file type.  This allows the reader to rescale values
+    // from the ORC file's precision/scale to the metastore-declared
+    // precision/scale, so that NativeScan output matches the vanilla Spark
+    // scan path and decimal join-key comparisons succeed.
+    //
+    // When the TypeKinds differ (e.g. file is HUGEINT but table declares
+    // BIGINT) we fall back to the file type to avoid buffer-size mismatches
+    // in getIntValues(); in that case the Gluten fallback-tag logic will
+    // ensure symmetric scan behaviour at the join level.
+    : SelectiveColumnReader(
+          (requestedType && requestedType->isDecimal() &&
+           requestedType->kind() == fileType->type()->kind())
+              ? requestedType
+              : fileType->type(),
+          fileType,
+          params,
+          scanSpec) {
   EncodingKey encodingKey{fileType_->id(), params.flatMapContext().sequence};
   auto& stripe = params.stripeStreams();
   if constexpr (std::is_same_v<DataT, std::int64_t>) {

--- a/velox/dwio/dwrf/reader/SelectiveDecimalColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveDecimalColumnReader.cpp
@@ -34,11 +34,7 @@ SelectiveDecimalColumnReader<DataT>::SelectiveDecimalColumnReader(
     // BIGINT) we fall back to the file type to avoid buffer-size mismatches
     // in getIntValues(); in that case the Gluten fallback-tag logic will
     // ensure symmetric scan behaviour at the join level.
-    : SelectiveColumnReader(
-          requestedType,
-          std::move(fileType),
-          params,
-          scanSpec) {
+    : SelectiveColumnReader(requestedType, fileType, params, scanSpec) {
   EncodingKey encodingKey{fileType_->id(), params.flatMapContext().sequence};
   auto& stripe = params.stripeStreams();
   if constexpr (std::is_same_v<DataT, std::int64_t>) {

--- a/velox/dwio/dwrf/reader/SelectiveDecimalColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveDecimalColumnReader.h
@@ -28,6 +28,14 @@ using namespace dwio::common;
 template <typename DataT>
 class SelectiveDecimalColumnReader : public SelectiveColumnReader {
  public:
+  // requestedType is the DECIMAL type to materialize values as. It must be a
+  // decimal type. Hive's ORC writer always records DECIMAL(38, 18) in the
+  // file footer regardless of the metastore-declared precision/scale; the
+  // per-row scale at which each value was actually written lives in the
+  // SECONDARY (a.k.a. NANO_DATA) stream. The reader uses
+  // requestedType.scale() (the table-schema scale) as the target scale and
+  // rescales each value from its per-row scale, so the output matches what
+  // table consumers expect even when the file footer scale differs.
   SelectiveDecimalColumnReader(
       const TypePtr& requestedType,
       const std::shared_ptr<const TypeWithId>& fileType,

--- a/velox/dwio/dwrf/reader/SelectiveDecimalColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveDecimalColumnReader.h
@@ -29,6 +29,7 @@ template <typename DataT>
 class SelectiveDecimalColumnReader : public SelectiveColumnReader {
  public:
   SelectiveDecimalColumnReader(
+      const TypePtr& requestedType,
       const std::shared_ptr<const TypeWithId>& fileType,
       DwrfParams& params,
       common::ScanSpec& scanSpec);

--- a/velox/dwio/dwrf/reader/SelectiveDwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveDwrfReader.cpp
@@ -81,7 +81,7 @@ std::unique_ptr<SelectiveColumnReader> SelectiveDwrfReader::build(
     case TypeKind::BIGINT:
       if (fileType->type()->isDecimal()) {
         return std::make_unique<SelectiveDecimalColumnReader<int64_t>>(
-            fileType, params, scanSpec);
+            requestedType, fileType, params, scanSpec);
       } else {
         return buildIntegerReader(
             requestedType, fileType, params, LONG_BYTE_SIZE, scanSpec);
@@ -150,7 +150,7 @@ std::unique_ptr<SelectiveColumnReader> SelectiveDwrfReader::build(
     case TypeKind::HUGEINT:
       if (fileType->type()->isDecimal()) {
         return std::make_unique<SelectiveDecimalColumnReader<int128_t>>(
-            fileType, params, scanSpec);
+            requestedType, fileType, params, scanSpec);
       }
       [[fallthrough]];
     default:

--- a/velox/dwio/dwrf/test/TestColumnReader.cpp
+++ b/velox/dwio/dwrf/test/TestColumnReader.cpp
@@ -4077,6 +4077,235 @@ TEST_P(TestColumnReader, testDecimal128WithSkip) {
       DecimalUtil::toString(intBatch->valueAt(4), decimalType));
 }
 
+// The following three tests verify that SelectiveDecimalColumnReader uses
+// requestedType (the metastore/table schema) to determine the target scale,
+// rather than the file-footer type.
+//
+// Background: Hive's ORC writer always stores DECIMAL(38, 18) in the file
+// footer regardless of the metastore-declared precision.  The per-row
+// SECONDARY (NANO_DATA) stream carries the actual scale at which each value
+// was written.  Without the fix, the selective reader derives scale_ from the
+// file-footer type (scale=18) and incorrectly rescales integer values
+// (DECIMAL(p,0)) by multiplying them by 10^18, causing join-key mismatches
+// when one side uses NativeScan and the other falls back to vanilla Spark.
+
+// Scenario: integer column (per-row scale=0) stored in an ORC file whose
+// footer declares DECIMAL(38, 18), but the metastore says DECIMAL(20, 0).
+// The reader must produce the original integer values without rescaling.
+TEST_P(TestColumnReader, testDecimal128RequestedTypeScaleZero) {
+  // set getEncoding
+  proto::ColumnEncoding directEncoding;
+  directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
+  EXPECT_CALL(streams_, getEncodingProxy(_))
+      .WillRepeatedly(Return(&directEncoding));
+
+  // set getStream
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
+      .WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
+      .WillRepeatedly(Return(nullptr));
+
+  // col_0's DATA stream: values 1, 2, 3, 4 as zigzag-encoded varints (2,4,6,8)
+  const unsigned char numBuffer[] = {0x02, 0x04, 0x06, 0x08};
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+      .WillRepeatedly(Return(
+          new SeekableArrayInputStream(numBuffer, std::size(numBuffer))));
+
+  // col_0's SECONDARY (NANO_DATA) stream: 4 rows all with scale=0.
+  // RLEv1 run encoding: ctrl=0x01 (run of 4), delta=0x00, base=0x00
+  // (zigzag(0) = 0).
+  const unsigned char scaleBuffer[] = {0x01, 0x00, 0x00};
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_NANO_DATA, true))
+      .WillRepeatedly(Return(
+          new SeekableArrayInputStream(scaleBuffer, std::size(scaleBuffer))));
+
+  // File footer type: DECIMAL(38, 18) — Hive always writes this.
+  auto fileType = HiveTypeParser().parse("struct<col_0:decimal(38, 18)>");
+  // Metastore / requested type: DECIMAL(20, 0).
+  auto requestedType = HiveTypeParser().parse("struct<col_0:decimal(20, 0)>");
+
+  auto scanSpec = std::make_unique<common::ScanSpec>("root");
+  buildReader(requestedType, fileType, {}, scanSpec.get());
+  VectorPtr batch = newBatch(requestedType);
+  skipAndRead(batch, /* read */ 4);
+
+  auto intBatch = getOnlyChild<FlatVector<int128_t>>(batch);
+  ASSERT_EQ(4, batch->size());
+  ASSERT_EQ(4, intBatch->size());
+  ASSERT_EQ(0, getNullCount(batch));
+  ASSERT_EQ(0, getNullCount(intBatch));
+  // Values must be the original integers, not multiplied by 10^18.
+  EXPECT_EQ(1, (long long)intBatch->valueAt(0));
+  EXPECT_EQ(2, (long long)intBatch->valueAt(1));
+  EXPECT_EQ(3, (long long)intBatch->valueAt(2));
+  EXPECT_EQ(4, (long long)intBatch->valueAt(3));
+}
+
+// Scenario: non-zero scale column where the per-row scale already matches the
+// requestedType scale.  The reader must not apply any rescaling.
+TEST_P(TestColumnReader, testDecimal128RequestedTypeScaleMatchesData) {
+  // set getEncoding
+  proto::ColumnEncoding directEncoding;
+  directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
+  EXPECT_CALL(streams_, getEncodingProxy(_))
+      .WillRepeatedly(Return(&directEncoding));
+
+  // set getStream
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
+      .WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
+      .WillRepeatedly(Return(nullptr));
+
+  // col_0's DATA stream: values 1, 2, 3, 4 (zigzag: 2, 4, 6, 8)
+  const unsigned char numBuffer[] = {0x02, 0x04, 0x06, 0x08};
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+      .WillRepeatedly(Return(
+          new SeekableArrayInputStream(numBuffer, std::size(numBuffer))));
+
+  // col_0's SECONDARY (NANO_DATA) stream: 4 rows all with scale=5.
+  // RLEv1: ctrl=0x01 (run of 4), delta=0x00, base=0x0A (zigzag(5) = 10).
+  const unsigned char scaleBuffer[] = {0x01, 0x00, 0x0A};
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_NANO_DATA, true))
+      .WillRepeatedly(Return(
+          new SeekableArrayInputStream(scaleBuffer, std::size(scaleBuffer))));
+
+  // File footer: DECIMAL(38, 18) — Hive default.
+  auto fileType = HiveTypeParser().parse("struct<col_0:decimal(38, 18)>");
+  // Requested type: DECIMAL(25, 5) — per-row scale equals target scale.
+  auto requestedType = HiveTypeParser().parse("struct<col_0:decimal(25, 5)>");
+
+  auto scanSpec = std::make_unique<common::ScanSpec>("root");
+  buildReader(requestedType, fileType, {}, scanSpec.get());
+  VectorPtr batch = newBatch(requestedType);
+  skipAndRead(batch, /* read */ 4);
+
+  auto intBatch = getOnlyChild<FlatVector<int128_t>>(batch);
+  ASSERT_EQ(4, batch->size());
+  ASSERT_EQ(4, intBatch->size());
+  ASSERT_EQ(0, getNullCount(batch));
+  ASSERT_EQ(0, getNullCount(intBatch));
+  // currentScale(5) == targetScale(5): no rescaling expected.
+  EXPECT_EQ(1, (long long)intBatch->valueAt(0));
+  EXPECT_EQ(2, (long long)intBatch->valueAt(1));
+  EXPECT_EQ(3, (long long)intBatch->valueAt(2));
+  EXPECT_EQ(4, (long long)intBatch->valueAt(3));
+}
+
+// Scenario: per-row scale (3) is lower than the requestedType scale (5).
+// The reader must upscale by multiplying by 10^(5-3) = 100.
+TEST_P(TestColumnReader, testDecimal128RequestedTypeUpscale) {
+  // set getEncoding
+  proto::ColumnEncoding directEncoding;
+  directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
+  EXPECT_CALL(streams_, getEncodingProxy(_))
+      .WillRepeatedly(Return(&directEncoding));
+
+  // set getStream
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
+      .WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
+      .WillRepeatedly(Return(nullptr));
+
+  // col_0's DATA stream: values 1, 2, 3, 4 (zigzag: 2, 4, 6, 8)
+  const unsigned char numBuffer[] = {0x02, 0x04, 0x06, 0x08};
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+      .WillRepeatedly(Return(
+          new SeekableArrayInputStream(numBuffer, std::size(numBuffer))));
+
+  // col_0's SECONDARY (NANO_DATA) stream: 4 rows all with scale=3.
+  // RLEv1: ctrl=0x01 (run of 4), delta=0x00, base=0x06 (zigzag(3) = 6).
+  const unsigned char scaleBuffer[] = {0x01, 0x00, 0x06};
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_NANO_DATA, true))
+      .WillRepeatedly(Return(
+          new SeekableArrayInputStream(scaleBuffer, std::size(scaleBuffer))));
+
+  // File footer: DECIMAL(38, 18) — Hive default.
+  auto fileType = HiveTypeParser().parse("struct<col_0:decimal(38, 18)>");
+  // Requested type: DECIMAL(25, 5) — target scale=5, needs upscaling.
+  auto requestedType = HiveTypeParser().parse("struct<col_0:decimal(25, 5)>");
+
+  auto scanSpec = std::make_unique<common::ScanSpec>("root");
+  buildReader(requestedType, fileType, {}, scanSpec.get());
+  VectorPtr batch = newBatch(requestedType);
+  skipAndRead(batch, /* read */ 4);
+
+  auto intBatch = getOnlyChild<FlatVector<int128_t>>(batch);
+  ASSERT_EQ(4, batch->size());
+  ASSERT_EQ(4, intBatch->size());
+  ASSERT_EQ(0, getNullCount(batch));
+  ASSERT_EQ(0, getNullCount(intBatch));
+  // currentScale(3) → targetScale(5): multiply by 10^2 = 100.
+  EXPECT_EQ(100, (long long)intBatch->valueAt(0));
+  EXPECT_EQ(200, (long long)intBatch->valueAt(1));
+  EXPECT_EQ(300, (long long)intBatch->valueAt(2));
+  EXPECT_EQ(400, (long long)intBatch->valueAt(3));
+}
+
+// Scenario: short decimal (BIGINT, precision<=18).  File declares
+// DECIMAL(12, 5), metastore says DECIMAL(10, 2).  The reader must downscale
+// by dividing by 10^(5-2) = 1000.
+TEST_P(TestColumnReader, testDecimal64RequestedTypeDownscale) {
+  // set getEncoding
+  proto::ColumnEncoding directEncoding;
+  directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
+  EXPECT_CALL(streams_, getEncodingProxy(_))
+      .WillRepeatedly(Return(&directEncoding));
+
+  // set getStream
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
+      .WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
+      .WillRepeatedly(Return(nullptr));
+
+  // col_0's DATA stream: values 1000, 2000, 3000, 4000 as zigzag varints.
+  // Zigzag(n) = 2n for positive n.  Varint encoding splits into 7-bit groups.
+  // Zigzag(1000)=2000: 2000 mod 128=80=0x50, cont=0xD0; 2000>>7=15=0x0F.
+  // Zigzag(2000)=4000: 4000 mod 128=32=0x20, cont=0xA0; 4000>>7=31=0x1F.
+  // Zigzag(3000)=6000: 6000 mod 128=112=0x70, cont=0xF0; 6000>>7=46=0x2E.
+  // Zigzag(4000)=8000: 8000 mod 128=64=0x40, cont=0xC0; 8000>>7=62=0x3E.
+  const unsigned char numBuffer[] = {
+      0xD0,
+      0x0F, // 1000
+      0xA0,
+      0x1F, // 2000
+      0xF0,
+      0x2E, // 3000
+      0xC0,
+      0x3E, // 4000
+  };
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+      .WillRepeatedly(Return(
+          new SeekableArrayInputStream(numBuffer, std::size(numBuffer))));
+
+  // col_0's SECONDARY (NANO_DATA) stream: 4 rows all with scale=5.
+  // RLEv1: ctrl=0x01 (run of 4), delta=0x00, base=0x0A (zigzag(5)=10).
+  const unsigned char scaleBuffer[] = {0x01, 0x00, 0x0A};
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_NANO_DATA, true))
+      .WillRepeatedly(Return(
+          new SeekableArrayInputStream(scaleBuffer, std::size(scaleBuffer))));
+
+  // File footer: DECIMAL(12, 5) (BIGINT).
+  auto fileType = HiveTypeParser().parse("struct<col_0:decimal(12, 5)>");
+  // Requested type: DECIMAL(10, 2) (BIGINT) — target scale=2.
+  auto requestedType = HiveTypeParser().parse("struct<col_0:decimal(10, 2)>");
+
+  auto scanSpec = std::make_unique<common::ScanSpec>("root");
+  buildReader(requestedType, fileType, {}, scanSpec.get());
+  VectorPtr batch = newBatch(requestedType);
+  skipAndRead(batch, /* read */ 4);
+
+  auto intBatch = getOnlyChild<FlatVector<int64_t>>(batch);
+  ASSERT_EQ(4, batch->size());
+  ASSERT_EQ(4, intBatch->size());
+  ASSERT_EQ(0, getNullCount(batch));
+  ASSERT_EQ(0, getNullCount(intBatch));
+  // currentScale(5) → targetScale(2): divide by 10^3 = 1000.
+  EXPECT_EQ(1, intBatch->valueAt(0));
+  EXPECT_EQ(2, intBatch->valueAt(1));
+  EXPECT_EQ(3, intBatch->valueAt(2));
+  EXPECT_EQ(4, intBatch->valueAt(3));
+}
+
 TEST_P(TestColumnReader, testLargeSkip) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;

--- a/velox/dwio/dwrf/test/TestColumnReader.cpp
+++ b/velox/dwio/dwrf/test/TestColumnReader.cpp
@@ -395,7 +395,7 @@ class TestColumnReader : public testing::TestWithParam<ReaderTestParams>,
     auto scanSpec = std::make_unique<common::ScanSpec>("root");
     buildReader(requestedRowType, fileRowType, {}, scanSpec.get());
     VectorPtr batch = newBatch(requestedRowType);
-    skipAndRead(batch, /*read=*/expectedValues.size());
+    skipAndRead(batch, /*readSize=*/expectedValues.size());
 
     auto actual = getOnlyChild<FlatVector<DataT>>(batch);
     ASSERT_EQ(expectedValues.size(), batch->size());
@@ -4183,17 +4183,13 @@ TEST_P(TestColumnReader, decimalRequestedTypeNonDecimalRejected) {
       .WillRepeatedly(Return(nullptr));
 
   auto fileType = ROW("col_0", DECIMAL(38, 18));
-  for (const auto& [nonDecimalType, expectedToKind] :
-       std::vector<std::pair<TypePtr, std::string>>{
-           {BIGINT(), "BIGINT"}, {DOUBLE(), "DOUBLE"}}) {
-    SCOPED_TRACE(nonDecimalType->toString());
-    auto requestedType = ROW("col_0", nonDecimalType);
-    auto scanSpec = std::make_unique<common::ScanSpec>("root");
-    VELOX_ASSERT_THROW(
-        buildReader(requestedType, fileType, {}, scanSpec.get()),
-        std::string("Schema mismatch, From Kind: HUGEINT, To Kind: ") +
-            expectedToKind);
-  }
+  auto scanSpec = std::make_unique<common::ScanSpec>("root");
+  VELOX_ASSERT_THROW(
+      buildReader(ROW("col_0", BIGINT()), fileType, {}, scanSpec.get()),
+      "Schema mismatch, From Kind: HUGEINT, To Kind: BIGINT");
+  VELOX_ASSERT_THROW(
+      buildReader(ROW("col_0", DOUBLE()), fileType, {}, scanSpec.get()),
+      "Schema mismatch, From Kind: HUGEINT, To Kind: DOUBLE");
 }
 
 TEST_P(TestColumnReader, testLargeSkip) {

--- a/velox/dwio/dwrf/test/TestColumnReader.cpp
+++ b/velox/dwio/dwrf/test/TestColumnReader.cpp
@@ -365,13 +365,15 @@ class TestColumnReader : public testing::TestWithParam<ReaderTestParams>,
   // Helper for SelectiveDecimalColumnReader tests that exercise schema
   // mismatch between the file footer (e.g. Hive ORC's DECIMAL(38, 18))
   // and the requested table-schema type.
-  template <typename DataT>
+  template <typename DataT, size_t kDataSize, size_t kScaleSize>
   void verifyDecimalRequestedType(
-      folly::Range<const unsigned char*> dataBuffer,
-      folly::Range<const unsigned char*> scaleBuffer,
-      const RowTypePtr& fileType,
-      const RowTypePtr& requestedType,
+      const unsigned char (&dataBuffer)[kDataSize],
+      const unsigned char (&scaleBuffer)[kScaleSize],
+      const TypePtr& fileType,
+      const TypePtr& requestedType,
       const std::vector<DataT>& expectedValues) {
+    auto fileRowType = ROW("col_0", fileType);
+    auto requestedRowType = ROW("col_0", requestedType);
     proto::ColumnEncoding directEncoding;
     directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
     EXPECT_CALL(streams_, getEncodingProxy(_))
@@ -384,15 +386,15 @@ class TestColumnReader : public testing::TestWithParam<ReaderTestParams>,
         .WillRepeatedly(Return(nullptr));
 
     EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
-        .WillRepeatedly(Return(new SeekableArrayInputStream(
-            dataBuffer.data(), dataBuffer.size())));
+        .WillRepeatedly(
+            Return(new SeekableArrayInputStream(dataBuffer, kDataSize)));
     EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_NANO_DATA, true))
-        .WillRepeatedly(Return(new SeekableArrayInputStream(
-            scaleBuffer.data(), scaleBuffer.size())));
+        .WillRepeatedly(
+            Return(new SeekableArrayInputStream(scaleBuffer, kScaleSize)));
 
     auto scanSpec = std::make_unique<common::ScanSpec>("root");
-    buildReader(requestedType, fileType, {}, scanSpec.get());
-    VectorPtr batch = newBatch(requestedType);
+    buildReader(requestedRowType, fileRowType, {}, scanSpec.get());
+    VectorPtr batch = newBatch(requestedRowType);
     skipAndRead(batch, /*read=*/expectedValues.size());
 
     auto actual = getOnlyChild<FlatVector<DataT>>(batch);
@@ -402,7 +404,7 @@ class TestColumnReader : public testing::TestWithParam<ReaderTestParams>,
 
     auto* pool = &streams_.getMemoryPool();
     auto expected = BaseVector::create<FlatVector<DataT>>(
-        requestedType->childAt(0), expectedValues.size(), pool);
+        requestedType, expectedValues.size(), pool);
     for (vector_size_t i = 0; i < expectedValues.size(); ++i) {
       expected->set(i, expectedValues[i]);
     }
@@ -4125,90 +4127,52 @@ TEST_P(TestColumnReader, testDecimal128WithSkip) {
       DecimalUtil::toString(intBatch->valueAt(4), decimalType));
 }
 
-// The following tests verify that SelectiveDecimalColumnReader uses
-// requestedType (the metastore/table schema) to determine the target scale,
-// rather than the file-footer scale. See the comment on
-// SelectiveDecimalColumnReader's constructor for the underlying Hive ORC
-// DECIMAL(38, 18) footer behavior these tests cover.
+// Verify that when the file type doesn't match the metastore type,
+// the metastore type wins and data is rescaled accordingly.
 
 // Integer column (per-row scale=0) stored in an ORC file whose footer
 // declares DECIMAL(38, 18), but the metastore says DECIMAL(20, 0). The
 // reader must produce the original integer values without rescaling.
-TEST_P(TestColumnReader, testDecimal128RequestedTypeScaleZero) {
-  // DATA: values 1, 2, 3, 4 as zigzag-encoded varints.
+TEST_P(TestColumnReader, longDecimalRequestedTypeScaleZero) {
   const unsigned char dataBuffer[] = {0x02, 0x04, 0x06, 0x08};
-  // SECONDARY (NANO_DATA): 4 rows with scale=0.
-  // RLEv1 run: ctrl=0x01 (run of 4), delta=0x00, base=zigzag(0)=0x00.
   const unsigned char scaleBuffer[] = {0x01, 0x00, 0x00};
   verifyDecimalRequestedType<int128_t>(
-      folly::Range(dataBuffer, std::size(dataBuffer)),
-      folly::Range(scaleBuffer, std::size(scaleBuffer)),
-      ROW({"col_0"}, {DECIMAL(38, 18)}),
-      ROW({"col_0"}, {DECIMAL(20, 0)}),
-      // Expected: original integers, not multiplied by 10^18.
-      {int128_t{1}, int128_t{2}, int128_t{3}, int128_t{4}});
+      dataBuffer, scaleBuffer, DECIMAL(38, 18), DECIMAL(20, 0), {1, 2, 3, 4});
 }
 
 // Per-row scale (5) already matches the requestedType scale (5); no
 // rescaling expected.
-TEST_P(TestColumnReader, testDecimal128RequestedTypeScaleMatchesData) {
-  // DATA: values 1, 2, 3, 4.
+TEST_P(TestColumnReader, longDecimalRequestedTypeScaleMatchesData) {
   const unsigned char dataBuffer[] = {0x02, 0x04, 0x06, 0x08};
-  // SECONDARY: 4 rows with scale=5. RLEv1 base=zigzag(5)=0x0A.
   const unsigned char scaleBuffer[] = {0x01, 0x00, 0x0A};
   verifyDecimalRequestedType<int128_t>(
-      folly::Range(dataBuffer, std::size(dataBuffer)),
-      folly::Range(scaleBuffer, std::size(scaleBuffer)),
-      ROW({"col_0"}, {DECIMAL(38, 18)}),
-      ROW({"col_0"}, {DECIMAL(25, 5)}),
-      {int128_t{1}, int128_t{2}, int128_t{3}, int128_t{4}});
+      dataBuffer, scaleBuffer, DECIMAL(38, 18), DECIMAL(25, 5), {1, 2, 3, 4});
 }
 
 // Per-row scale (3) is lower than the requestedType scale (5). The reader
 // must upscale by multiplying by 10^(5-3) = 100.
-TEST_P(TestColumnReader, testDecimal128RequestedTypeUpscale) {
+TEST_P(TestColumnReader, longDecimalRequestedTypeUpscale) {
   const unsigned char dataBuffer[] = {0x02, 0x04, 0x06, 0x08};
-  // SECONDARY: scale=3, base=zigzag(3)=0x06.
   const unsigned char scaleBuffer[] = {0x01, 0x00, 0x06};
   verifyDecimalRequestedType<int128_t>(
-      folly::Range(dataBuffer, std::size(dataBuffer)),
-      folly::Range(scaleBuffer, std::size(scaleBuffer)),
-      ROW({"col_0"}, {DECIMAL(38, 18)}),
-      ROW({"col_0"}, {DECIMAL(25, 5)}),
-      {int128_t{100}, int128_t{200}, int128_t{300}, int128_t{400}});
+      dataBuffer,
+      scaleBuffer,
+      DECIMAL(38, 18),
+      DECIMAL(25, 5),
+      {100, 200, 300, 400});
 }
 
 // Short decimal (BIGINT, precision<=18). File declares DECIMAL(12, 5),
 // metastore says DECIMAL(10, 2). Reader must downscale by 10^(5-2)=1000.
-TEST_P(TestColumnReader, testDecimal64RequestedTypeDownscale) {
-  // DATA: values 1000, 2000, 3000, 4000 as zigzag varints.
+TEST_P(TestColumnReader, shortDecimalRequestedTypeDownscale) {
   const unsigned char dataBuffer[] = {
-      0xD0,
-      0x0F, // 1000
-      0xA0,
-      0x1F, // 2000
-      0xF0,
-      0x2E, // 3000
-      0xC0,
-      0x3E, // 4000
-  };
-  // SECONDARY: scale=5, base=zigzag(5)=0x0A.
+      0xD0, 0x0F, 0xA0, 0x1F, 0xF0, 0x2E, 0xC0, 0x3E};
   const unsigned char scaleBuffer[] = {0x01, 0x00, 0x0A};
   verifyDecimalRequestedType<int64_t>(
-      folly::Range(dataBuffer, std::size(dataBuffer)),
-      folly::Range(scaleBuffer, std::size(scaleBuffer)),
-      ROW({"col_0"}, {DECIMAL(12, 5)}),
-      ROW({"col_0"}, {DECIMAL(10, 2)}),
-      {int64_t{1}, int64_t{2}, int64_t{3}, int64_t{4}});
+      dataBuffer, scaleBuffer, DECIMAL(12, 5), DECIMAL(10, 2), {1, 2, 3, 4});
 }
 
-// A non-decimal requestedType against a decimal file column is unsupported
-// and must be rejected when the reader is constructed.
-//
-// SelectiveDwrfReader::build runs the type-compatibility check first, so the
-// schema-mismatch error is raised before the SelectiveDecimalColumnReader
-// constructor's own VELOX_CHECK runs.
-TEST_P(TestColumnReader, testDecimalRequestedTypeBigintRejected) {
+TEST_P(TestColumnReader, decimalRequestedTypeNonDecimalRejected) {
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
   EXPECT_CALL(streams_, getEncodingProxy(_))
@@ -4218,30 +4182,18 @@ TEST_P(TestColumnReader, testDecimalRequestedTypeBigintRejected) {
   EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
-  auto fileType = ROW({"col_0"}, {DECIMAL(38, 18)});
-  auto requestedType = ROW({"col_0"}, {BIGINT()});
-  auto scanSpec = std::make_unique<common::ScanSpec>("root");
-  VELOX_ASSERT_THROW(
-      buildReader(requestedType, fileType, {}, scanSpec.get()),
-      "Schema mismatch");
-}
-
-TEST_P(TestColumnReader, testDecimalRequestedTypeDoubleRejected) {
-  proto::ColumnEncoding directEncoding;
-  directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams_, getEncodingProxy(_))
-      .WillRepeatedly(Return(&directEncoding));
-  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
-      .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
-      .WillRepeatedly(Return(nullptr));
-
-  auto fileType = ROW({"col_0"}, {DECIMAL(38, 18)});
-  auto requestedType = ROW({"col_0"}, {DOUBLE()});
-  auto scanSpec = std::make_unique<common::ScanSpec>("root");
-  VELOX_ASSERT_THROW(
-      buildReader(requestedType, fileType, {}, scanSpec.get()),
-      "Schema mismatch");
+  auto fileType = ROW("col_0", DECIMAL(38, 18));
+  for (const auto& [nonDecimalType, expectedToKind] :
+       std::vector<std::pair<TypePtr, std::string>>{
+           {BIGINT(), "BIGINT"}, {DOUBLE(), "DOUBLE"}}) {
+    SCOPED_TRACE(nonDecimalType->toString());
+    auto requestedType = ROW("col_0", nonDecimalType);
+    auto scanSpec = std::make_unique<common::ScanSpec>("root");
+    VELOX_ASSERT_THROW(
+        buildReader(requestedType, fileType, {}, scanSpec.get()),
+        std::string("Schema mismatch, From Kind: HUGEINT, To Kind: ") +
+            expectedToKind);
+  }
 }
 
 TEST_P(TestColumnReader, testLargeSkip) {

--- a/velox/dwio/dwrf/test/TestColumnReader.cpp
+++ b/velox/dwio/dwrf/test/TestColumnReader.cpp
@@ -27,6 +27,7 @@
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/DictionaryVector.h"
 #include "velox/vector/FlatVector.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
 
 #include <folly/Random.h>
 #include <folly/String.h>
@@ -359,6 +360,53 @@ class TestColumnReader : public testing::TestWithParam<ReaderTestParams>,
 
   bool parallelDecoding() const override {
     return parallelDecoding_;
+  }
+
+  // Helper for SelectiveDecimalColumnReader tests that exercise schema
+  // mismatch between the file footer (e.g. Hive ORC's DECIMAL(38, 18))
+  // and the requested table-schema type.
+  template <typename DataT>
+  void verifyDecimalRequestedType(
+      folly::Range<const unsigned char*> dataBuffer,
+      folly::Range<const unsigned char*> scaleBuffer,
+      const RowTypePtr& fileType,
+      const RowTypePtr& requestedType,
+      const std::vector<DataT>& expectedValues) {
+    proto::ColumnEncoding directEncoding;
+    directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
+    EXPECT_CALL(streams_, getEncodingProxy(_))
+        .WillRepeatedly(Return(&directEncoding));
+
+    EXPECT_CALL(
+        streams_, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
+        .WillRepeatedly(Return(nullptr));
+    EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
+        .WillRepeatedly(Return(nullptr));
+
+    EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+        .WillRepeatedly(Return(new SeekableArrayInputStream(
+            dataBuffer.data(), dataBuffer.size())));
+    EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_NANO_DATA, true))
+        .WillRepeatedly(Return(new SeekableArrayInputStream(
+            scaleBuffer.data(), scaleBuffer.size())));
+
+    auto scanSpec = std::make_unique<common::ScanSpec>("root");
+    buildReader(requestedType, fileType, {}, scanSpec.get());
+    VectorPtr batch = newBatch(requestedType);
+    skipAndRead(batch, /*read=*/expectedValues.size());
+
+    auto actual = getOnlyChild<FlatVector<DataT>>(batch);
+    ASSERT_EQ(expectedValues.size(), batch->size());
+    ASSERT_EQ(0, getNullCount(batch));
+    ASSERT_EQ(0, getNullCount(actual));
+
+    auto* pool = &streams_.getMemoryPool();
+    auto expected = BaseVector::create<FlatVector<DataT>>(
+        requestedType->childAt(0), expectedValues.size(), pool);
+    for (vector_size_t i = 0; i < expectedValues.size(); ++i) {
+      expected->set(i, expectedValues[i]);
+    }
+    facebook::velox::test::assertEqualVectors(expected, actual);
   }
 };
 
@@ -4077,193 +4125,64 @@ TEST_P(TestColumnReader, testDecimal128WithSkip) {
       DecimalUtil::toString(intBatch->valueAt(4), decimalType));
 }
 
-// The following three tests verify that SelectiveDecimalColumnReader uses
+// The following tests verify that SelectiveDecimalColumnReader uses
 // requestedType (the metastore/table schema) to determine the target scale,
-// rather than the file-footer type.
-//
-// Background: Hive's ORC writer always stores DECIMAL(38, 18) in the file
-// footer regardless of the metastore-declared precision.  The per-row
-// SECONDARY (NANO_DATA) stream carries the actual scale at which each value
-// was written.  Without the fix, the selective reader derives scale_ from the
-// file-footer type (scale=18) and incorrectly rescales integer values
-// (DECIMAL(p,0)) by multiplying them by 10^18, causing join-key mismatches
-// when one side uses NativeScan and the other falls back to vanilla Spark.
+// rather than the file-footer scale. See the comment on
+// SelectiveDecimalColumnReader's constructor for the underlying Hive ORC
+// DECIMAL(38, 18) footer behavior these tests cover.
 
-// Scenario: integer column (per-row scale=0) stored in an ORC file whose
-// footer declares DECIMAL(38, 18), but the metastore says DECIMAL(20, 0).
-// The reader must produce the original integer values without rescaling.
+// Integer column (per-row scale=0) stored in an ORC file whose footer
+// declares DECIMAL(38, 18), but the metastore says DECIMAL(20, 0). The
+// reader must produce the original integer values without rescaling.
 TEST_P(TestColumnReader, testDecimal128RequestedTypeScaleZero) {
-  // set getEncoding
-  proto::ColumnEncoding directEncoding;
-  directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams_, getEncodingProxy(_))
-      .WillRepeatedly(Return(&directEncoding));
-
-  // set getStream
-  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
-      .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
-      .WillRepeatedly(Return(nullptr));
-
-  // col_0's DATA stream: values 1, 2, 3, 4 as zigzag-encoded varints (2,4,6,8)
-  const unsigned char numBuffer[] = {0x02, 0x04, 0x06, 0x08};
-  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
-      .WillRepeatedly(Return(
-          new SeekableArrayInputStream(numBuffer, std::size(numBuffer))));
-
-  // col_0's SECONDARY (NANO_DATA) stream: 4 rows all with scale=0.
-  // RLEv1 run encoding: ctrl=0x01 (run of 4), delta=0x00, base=0x00
-  // (zigzag(0) = 0).
+  // DATA: values 1, 2, 3, 4 as zigzag-encoded varints.
+  const unsigned char dataBuffer[] = {0x02, 0x04, 0x06, 0x08};
+  // SECONDARY (NANO_DATA): 4 rows with scale=0.
+  // RLEv1 run: ctrl=0x01 (run of 4), delta=0x00, base=zigzag(0)=0x00.
   const unsigned char scaleBuffer[] = {0x01, 0x00, 0x00};
-  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_NANO_DATA, true))
-      .WillRepeatedly(Return(
-          new SeekableArrayInputStream(scaleBuffer, std::size(scaleBuffer))));
-
-  // File footer type: DECIMAL(38, 18) — Hive always writes this.
-  auto fileType = HiveTypeParser().parse("struct<col_0:decimal(38, 18)>");
-  // Metastore / requested type: DECIMAL(20, 0).
-  auto requestedType = HiveTypeParser().parse("struct<col_0:decimal(20, 0)>");
-
-  auto scanSpec = std::make_unique<common::ScanSpec>("root");
-  buildReader(requestedType, fileType, {}, scanSpec.get());
-  VectorPtr batch = newBatch(requestedType);
-  skipAndRead(batch, /* read */ 4);
-
-  auto intBatch = getOnlyChild<FlatVector<int128_t>>(batch);
-  ASSERT_EQ(4, batch->size());
-  ASSERT_EQ(4, intBatch->size());
-  ASSERT_EQ(0, getNullCount(batch));
-  ASSERT_EQ(0, getNullCount(intBatch));
-  // Values must be the original integers, not multiplied by 10^18.
-  EXPECT_EQ(1, (long long)intBatch->valueAt(0));
-  EXPECT_EQ(2, (long long)intBatch->valueAt(1));
-  EXPECT_EQ(3, (long long)intBatch->valueAt(2));
-  EXPECT_EQ(4, (long long)intBatch->valueAt(3));
+  verifyDecimalRequestedType<int128_t>(
+      folly::Range(dataBuffer, std::size(dataBuffer)),
+      folly::Range(scaleBuffer, std::size(scaleBuffer)),
+      ROW({"col_0"}, {DECIMAL(38, 18)}),
+      ROW({"col_0"}, {DECIMAL(20, 0)}),
+      // Expected: original integers, not multiplied by 10^18.
+      {int128_t{1}, int128_t{2}, int128_t{3}, int128_t{4}});
 }
 
-// Scenario: non-zero scale column where the per-row scale already matches the
-// requestedType scale.  The reader must not apply any rescaling.
+// Per-row scale (5) already matches the requestedType scale (5); no
+// rescaling expected.
 TEST_P(TestColumnReader, testDecimal128RequestedTypeScaleMatchesData) {
-  // set getEncoding
-  proto::ColumnEncoding directEncoding;
-  directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams_, getEncodingProxy(_))
-      .WillRepeatedly(Return(&directEncoding));
-
-  // set getStream
-  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
-      .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
-      .WillRepeatedly(Return(nullptr));
-
-  // col_0's DATA stream: values 1, 2, 3, 4 (zigzag: 2, 4, 6, 8)
-  const unsigned char numBuffer[] = {0x02, 0x04, 0x06, 0x08};
-  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
-      .WillRepeatedly(Return(
-          new SeekableArrayInputStream(numBuffer, std::size(numBuffer))));
-
-  // col_0's SECONDARY (NANO_DATA) stream: 4 rows all with scale=5.
-  // RLEv1: ctrl=0x01 (run of 4), delta=0x00, base=0x0A (zigzag(5) = 10).
+  // DATA: values 1, 2, 3, 4.
+  const unsigned char dataBuffer[] = {0x02, 0x04, 0x06, 0x08};
+  // SECONDARY: 4 rows with scale=5. RLEv1 base=zigzag(5)=0x0A.
   const unsigned char scaleBuffer[] = {0x01, 0x00, 0x0A};
-  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_NANO_DATA, true))
-      .WillRepeatedly(Return(
-          new SeekableArrayInputStream(scaleBuffer, std::size(scaleBuffer))));
-
-  // File footer: DECIMAL(38, 18) — Hive default.
-  auto fileType = HiveTypeParser().parse("struct<col_0:decimal(38, 18)>");
-  // Requested type: DECIMAL(25, 5) — per-row scale equals target scale.
-  auto requestedType = HiveTypeParser().parse("struct<col_0:decimal(25, 5)>");
-
-  auto scanSpec = std::make_unique<common::ScanSpec>("root");
-  buildReader(requestedType, fileType, {}, scanSpec.get());
-  VectorPtr batch = newBatch(requestedType);
-  skipAndRead(batch, /* read */ 4);
-
-  auto intBatch = getOnlyChild<FlatVector<int128_t>>(batch);
-  ASSERT_EQ(4, batch->size());
-  ASSERT_EQ(4, intBatch->size());
-  ASSERT_EQ(0, getNullCount(batch));
-  ASSERT_EQ(0, getNullCount(intBatch));
-  // currentScale(5) == targetScale(5): no rescaling expected.
-  EXPECT_EQ(1, (long long)intBatch->valueAt(0));
-  EXPECT_EQ(2, (long long)intBatch->valueAt(1));
-  EXPECT_EQ(3, (long long)intBatch->valueAt(2));
-  EXPECT_EQ(4, (long long)intBatch->valueAt(3));
+  verifyDecimalRequestedType<int128_t>(
+      folly::Range(dataBuffer, std::size(dataBuffer)),
+      folly::Range(scaleBuffer, std::size(scaleBuffer)),
+      ROW({"col_0"}, {DECIMAL(38, 18)}),
+      ROW({"col_0"}, {DECIMAL(25, 5)}),
+      {int128_t{1}, int128_t{2}, int128_t{3}, int128_t{4}});
 }
 
-// Scenario: per-row scale (3) is lower than the requestedType scale (5).
-// The reader must upscale by multiplying by 10^(5-3) = 100.
+// Per-row scale (3) is lower than the requestedType scale (5). The reader
+// must upscale by multiplying by 10^(5-3) = 100.
 TEST_P(TestColumnReader, testDecimal128RequestedTypeUpscale) {
-  // set getEncoding
-  proto::ColumnEncoding directEncoding;
-  directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams_, getEncodingProxy(_))
-      .WillRepeatedly(Return(&directEncoding));
-
-  // set getStream
-  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
-      .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
-      .WillRepeatedly(Return(nullptr));
-
-  // col_0's DATA stream: values 1, 2, 3, 4 (zigzag: 2, 4, 6, 8)
-  const unsigned char numBuffer[] = {0x02, 0x04, 0x06, 0x08};
-  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
-      .WillRepeatedly(Return(
-          new SeekableArrayInputStream(numBuffer, std::size(numBuffer))));
-
-  // col_0's SECONDARY (NANO_DATA) stream: 4 rows all with scale=3.
-  // RLEv1: ctrl=0x01 (run of 4), delta=0x00, base=0x06 (zigzag(3) = 6).
+  const unsigned char dataBuffer[] = {0x02, 0x04, 0x06, 0x08};
+  // SECONDARY: scale=3, base=zigzag(3)=0x06.
   const unsigned char scaleBuffer[] = {0x01, 0x00, 0x06};
-  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_NANO_DATA, true))
-      .WillRepeatedly(Return(
-          new SeekableArrayInputStream(scaleBuffer, std::size(scaleBuffer))));
-
-  // File footer: DECIMAL(38, 18) — Hive default.
-  auto fileType = HiveTypeParser().parse("struct<col_0:decimal(38, 18)>");
-  // Requested type: DECIMAL(25, 5) — target scale=5, needs upscaling.
-  auto requestedType = HiveTypeParser().parse("struct<col_0:decimal(25, 5)>");
-
-  auto scanSpec = std::make_unique<common::ScanSpec>("root");
-  buildReader(requestedType, fileType, {}, scanSpec.get());
-  VectorPtr batch = newBatch(requestedType);
-  skipAndRead(batch, /* read */ 4);
-
-  auto intBatch = getOnlyChild<FlatVector<int128_t>>(batch);
-  ASSERT_EQ(4, batch->size());
-  ASSERT_EQ(4, intBatch->size());
-  ASSERT_EQ(0, getNullCount(batch));
-  ASSERT_EQ(0, getNullCount(intBatch));
-  // currentScale(3) → targetScale(5): multiply by 10^2 = 100.
-  EXPECT_EQ(100, (long long)intBatch->valueAt(0));
-  EXPECT_EQ(200, (long long)intBatch->valueAt(1));
-  EXPECT_EQ(300, (long long)intBatch->valueAt(2));
-  EXPECT_EQ(400, (long long)intBatch->valueAt(3));
+  verifyDecimalRequestedType<int128_t>(
+      folly::Range(dataBuffer, std::size(dataBuffer)),
+      folly::Range(scaleBuffer, std::size(scaleBuffer)),
+      ROW({"col_0"}, {DECIMAL(38, 18)}),
+      ROW({"col_0"}, {DECIMAL(25, 5)}),
+      {int128_t{100}, int128_t{200}, int128_t{300}, int128_t{400}});
 }
 
-// Scenario: short decimal (BIGINT, precision<=18).  File declares
-// DECIMAL(12, 5), metastore says DECIMAL(10, 2).  The reader must downscale
-// by dividing by 10^(5-2) = 1000.
+// Short decimal (BIGINT, precision<=18). File declares DECIMAL(12, 5),
+// metastore says DECIMAL(10, 2). Reader must downscale by 10^(5-2)=1000.
 TEST_P(TestColumnReader, testDecimal64RequestedTypeDownscale) {
-  // set getEncoding
-  proto::ColumnEncoding directEncoding;
-  directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams_, getEncodingProxy(_))
-      .WillRepeatedly(Return(&directEncoding));
-
-  // set getStream
-  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
-      .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
-      .WillRepeatedly(Return(nullptr));
-
-  // col_0's DATA stream: values 1000, 2000, 3000, 4000 as zigzag varints.
-  // Zigzag(n) = 2n for positive n.  Varint encoding splits into 7-bit groups.
-  // Zigzag(1000)=2000: 2000 mod 128=80=0x50, cont=0xD0; 2000>>7=15=0x0F.
-  // Zigzag(2000)=4000: 4000 mod 128=32=0x20, cont=0xA0; 4000>>7=31=0x1F.
-  // Zigzag(3000)=6000: 6000 mod 128=112=0x70, cont=0xF0; 6000>>7=46=0x2E.
-  // Zigzag(4000)=8000: 8000 mod 128=64=0x40, cont=0xC0; 8000>>7=62=0x3E.
-  const unsigned char numBuffer[] = {
+  // DATA: values 1000, 2000, 3000, 4000 as zigzag varints.
+  const unsigned char dataBuffer[] = {
       0xD0,
       0x0F, // 1000
       0xA0,
@@ -4273,37 +4192,56 @@ TEST_P(TestColumnReader, testDecimal64RequestedTypeDownscale) {
       0xC0,
       0x3E, // 4000
   };
-  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
-      .WillRepeatedly(Return(
-          new SeekableArrayInputStream(numBuffer, std::size(numBuffer))));
-
-  // col_0's SECONDARY (NANO_DATA) stream: 4 rows all with scale=5.
-  // RLEv1: ctrl=0x01 (run of 4), delta=0x00, base=0x0A (zigzag(5)=10).
+  // SECONDARY: scale=5, base=zigzag(5)=0x0A.
   const unsigned char scaleBuffer[] = {0x01, 0x00, 0x0A};
-  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_NANO_DATA, true))
-      .WillRepeatedly(Return(
-          new SeekableArrayInputStream(scaleBuffer, std::size(scaleBuffer))));
+  verifyDecimalRequestedType<int64_t>(
+      folly::Range(dataBuffer, std::size(dataBuffer)),
+      folly::Range(scaleBuffer, std::size(scaleBuffer)),
+      ROW({"col_0"}, {DECIMAL(12, 5)}),
+      ROW({"col_0"}, {DECIMAL(10, 2)}),
+      {int64_t{1}, int64_t{2}, int64_t{3}, int64_t{4}});
+}
 
-  // File footer: DECIMAL(12, 5) (BIGINT).
-  auto fileType = HiveTypeParser().parse("struct<col_0:decimal(12, 5)>");
-  // Requested type: DECIMAL(10, 2) (BIGINT) — target scale=2.
-  auto requestedType = HiveTypeParser().parse("struct<col_0:decimal(10, 2)>");
+// A non-decimal requestedType against a decimal file column is unsupported
+// and must be rejected when the reader is constructed.
+//
+// SelectiveDwrfReader::build runs the type-compatibility check first, so the
+// schema-mismatch error is raised before the SelectiveDecimalColumnReader
+// constructor's own VELOX_CHECK runs.
+TEST_P(TestColumnReader, testDecimalRequestedTypeBigintRejected) {
+  proto::ColumnEncoding directEncoding;
+  directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
+  EXPECT_CALL(streams_, getEncodingProxy(_))
+      .WillRepeatedly(Return(&directEncoding));
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
+      .WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
+      .WillRepeatedly(Return(nullptr));
 
+  auto fileType = ROW({"col_0"}, {DECIMAL(38, 18)});
+  auto requestedType = ROW({"col_0"}, {BIGINT()});
   auto scanSpec = std::make_unique<common::ScanSpec>("root");
-  buildReader(requestedType, fileType, {}, scanSpec.get());
-  VectorPtr batch = newBatch(requestedType);
-  skipAndRead(batch, /* read */ 4);
+  VELOX_ASSERT_THROW(
+      buildReader(requestedType, fileType, {}, scanSpec.get()),
+      "Schema mismatch");
+}
 
-  auto intBatch = getOnlyChild<FlatVector<int64_t>>(batch);
-  ASSERT_EQ(4, batch->size());
-  ASSERT_EQ(4, intBatch->size());
-  ASSERT_EQ(0, getNullCount(batch));
-  ASSERT_EQ(0, getNullCount(intBatch));
-  // currentScale(5) → targetScale(2): divide by 10^3 = 1000.
-  EXPECT_EQ(1, intBatch->valueAt(0));
-  EXPECT_EQ(2, intBatch->valueAt(1));
-  EXPECT_EQ(3, intBatch->valueAt(2));
-  EXPECT_EQ(4, intBatch->valueAt(3));
+TEST_P(TestColumnReader, testDecimalRequestedTypeDoubleRejected) {
+  proto::ColumnEncoding directEncoding;
+  directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
+  EXPECT_CALL(streams_, getEncodingProxy(_))
+      .WillRepeatedly(Return(&directEncoding));
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
+      .WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
+      .WillRepeatedly(Return(nullptr));
+
+  auto fileType = ROW({"col_0"}, {DECIMAL(38, 18)});
+  auto requestedType = ROW({"col_0"}, {DOUBLE()});
+  auto scanSpec = std::make_unique<common::ScanSpec>("root");
+  VELOX_ASSERT_THROW(
+      buildReader(requestedType, fileType, {}, scanSpec.get()),
+      "Schema mismatch");
 }
 
 TEST_P(TestColumnReader, testLargeSkip) {


### PR DESCRIPTION
**Summary**: when the leaf node (Scan operator) in one child of the Join operator is rolled back to Vanilla Spark, while the leaf node (Scan operator) in the other child still uses NativeScan, and the join key used by Join contains the decimal type, Spark ORC reader will prioritize using the decimal type in the table schema (e.g. DECIMAL (20,0)) over the decimal type in the ORC file (e.g. DECIMAL (38,18)) but Native ORC reader only using the decimal type in the ORC file, which ultimately leads to incorrect matching of the join key, resulting in the output of 0 rows after join.

**Root cause**:
Hive ORC fixed the DECIMAL (38,18) in footer, and the true scale of each row is written in the SECONDRY stream. The original ORC reader used footer's
The use of scale instead of the scale of the meta store (table schema) results in inconsistency between the output of NativeScan and Vanilla Spark.

Fixes: https://github.com/facebookincubator/velox/issues/17462

This PR proposes to pass the request type into `SelectiveColumnReader`.

This PR could help to fix https://github.com/apache/gluten/issues/11980