### PR TITLE
fix(parquet): Report estimated footer thrift memory to the pool

### DIFF
--- a/velox/connectors/hive/FileConfig.cpp
+++ b/velox/connectors/hive/FileConfig.cpp
@@ -92,6 +92,12 @@ uint64_t FileConfig::filePreloadThreshold() const {
   return config_->get<uint64_t>(kFilePreloadThreshold, 8UL << 20);
 }
 
+uint64_t FileConfig::parquetFooterTrackThriftMemoryThreshold() const {
+  return config_->get<uint64_t>(
+      kParquetFooterTrackThriftMemoryThreshold,
+      std::numeric_limits<uint64_t>::max());
+}
+
 uint8_t FileConfig::readTimestampUnit(const config::ConfigBase* session) const {
   const auto unit = sessionValue<uint8_t>(
       session, kReadTimestampUnitSession, kReadTimestampUnit, 3 /*milli*/);

--- a/velox/connectors/hive/FileConfig.cpp
+++ b/velox/connectors/hive/FileConfig.cpp
@@ -37,6 +37,7 @@ const std::vector<config::ConfigProperty>& FileConfig::registeredProperties() {
     VELOX_HIVE_CONFIG_REGISTER(kNimbleFooterSpeculativeIoSizeSession);
     VELOX_HIVE_CONFIG_REGISTER(kNimbleStringDecoderZeroCopySession);
     VELOX_HIVE_CONFIG_REGISTER(kNimblePreserveDictionaryEncodingSession);
+    VELOX_HIVE_CONFIG_REGISTER(kParquetFooterMemoryTrackingThresholdSession);
     VELOX_HIVE_CONFIG_REGISTER(kFileColumnNamesReadAsLowerCaseSession);
     VELOX_HIVE_CONFIG_REGISTER(kIgnoreMissingFilesSession);
     VELOX_HIVE_CONFIG_REGISTER(kMaxCoalescedBytesSession);
@@ -90,12 +91,6 @@ size_t FileConfig::parallelUnitLoadCount(
 
 uint64_t FileConfig::filePreloadThreshold() const {
   return config_->get<uint64_t>(kFilePreloadThreshold, 8UL << 20);
-}
-
-uint64_t FileConfig::parquetFooterTrackThriftMemoryThreshold() const {
-  return config_->get<uint64_t>(
-      kParquetFooterTrackThriftMemoryThreshold,
-      std::numeric_limits<uint64_t>::max());
 }
 
 uint8_t FileConfig::readTimestampUnit(const config::ConfigBase* session) const {

--- a/velox/connectors/hive/FileConfig.h
+++ b/velox/connectors/hive/FileConfig.h
@@ -144,18 +144,6 @@ class FileConfig {
       false,
       "Preserve dictionary encoding for Nimble string column reads.")
 
-  VELOX_HIVE_CONFIG(
-      kParquetFooterMemoryTrackingThresholdSession,
-      parquetFooterMemoryTrackingThreshold,
-      "parquet_footer_memory_tracking_threshold",
-      uint64_t,
-      std::numeric_limits<uint64_t>::max(),
-      "Footer byte size beyond which the Parquet reader estimates and "
-      "reports the deserialized footer's heap footprint to the memory "
-      "pool. Defaults to disabled (max uint64).")
-  static constexpr const char* kParquetFooterMemoryTrackingThreshold =
-      "parquet-footer-memory-tracking-threshold";
-
   // --- VELOX_HIVE_CONFIG properties ---
 
   VELOX_HIVE_CONFIG(
@@ -260,6 +248,16 @@ class FileConfig {
       bool,
       true,
       "Enable selective Nimble reader.")
+
+  VELOX_HIVE_CONFIG(
+      kParquetFooterMemoryTrackingThresholdSession,
+      parquetFooterMemoryTrackingThreshold,
+      "parquet_footer_memory_tracking_threshold",
+      uint64_t,
+      std::numeric_limits<uint64_t>::max(),
+      "Serialized footer size in bytes beyond which the Parquet reader "
+      "estimates and reports the deserialized footer's heap footprint to "
+      "the memory pool. Defaults to disabled (max uint64).")
 
   // --- VELOX_HIVE_CONFIG_PROPERTY properties ---
 

--- a/velox/connectors/hive/FileConfig.h
+++ b/velox/connectors/hive/FileConfig.h
@@ -144,17 +144,17 @@ class FileConfig {
       false,
       "Preserve dictionary encoding for Nimble string column reads.")
 
-  VELOX_HIVE_CONFIG_LEGACY(
+  VELOX_HIVE_CONFIG(
       kParquetFooterMemoryTrackingThresholdSession,
-      kParquetFooterMemoryTrackingThreshold,
       parquetFooterMemoryTrackingThreshold,
       "parquet_footer_memory_tracking_threshold",
-      "parquet.footer-memory-tracking-threshold",
       uint64_t,
       std::numeric_limits<uint64_t>::max(),
       "Footer byte size beyond which the Parquet reader estimates and "
       "reports the deserialized footer's heap footprint to the memory "
       "pool. Defaults to disabled (max uint64).")
+  static constexpr const char* kParquetFooterMemoryTrackingThreshold =
+      "parquet-footer-memory-tracking-threshold";
 
   // --- VELOX_HIVE_CONFIG properties ---
 

--- a/velox/connectors/hive/FileConfig.h
+++ b/velox/connectors/hive/FileConfig.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <limits>
 #include <string>
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/config/Config.h"
@@ -142,6 +143,18 @@ class FileConfig {
       bool,
       false,
       "Preserve dictionary encoding for Nimble string column reads.")
+
+  VELOX_HIVE_CONFIG_LEGACY(
+      kParquetFooterMemoryTrackingThresholdSession,
+      kParquetFooterMemoryTrackingThreshold,
+      parquetFooterMemoryTrackingThreshold,
+      "parquet_footer_memory_tracking_threshold",
+      "parquet.footer-memory-tracking-threshold",
+      uint64_t,
+      std::numeric_limits<uint64_t>::max(),
+      "Footer byte size beyond which the Parquet reader estimates and "
+      "reports the deserialized footer's heap footprint to the memory "
+      "pool. Defaults to disabled (max uint64).")
 
   // --- VELOX_HIVE_CONFIG properties ---
 
@@ -284,12 +297,6 @@ class FileConfig {
   /// meta data together. Optimization to decrease the small IO requests.
   static constexpr const char* kFilePreloadThreshold = "file-preload-threshold";
 
-  /// The byte size threshold beyond which the Parquet reader estimates and
-  /// reports the memory usage of deserialized Thrift objects to the memory
-  /// pool. Defaults to disabled (max uint64).
-  static constexpr const char* kParquetFooterTrackThriftMemoryThreshold =
-      "parquet.track-footer-thrift-memory-threshold";
-
   explicit FileConfig(std::shared_ptr<const config::ConfigBase> config) {
     VELOX_CHECK_NOT_NULL(
         config, "Config is null for FileConfig initialization");
@@ -305,11 +312,6 @@ class FileConfig {
   size_t parallelUnitLoadCount(const config::ConfigBase* session) const;
 
   uint64_t filePreloadThreshold() const;
-
-  /// Returns the byte size threshold beyond which the Parquet reader reports
-  /// the deserialized Thrift footer's memory consumption to the memory pool.
-  /// Defaults to disabled (max uint64).
-  uint64_t parquetFooterTrackThriftMemoryThreshold() const;
 
   // Returns the timestamp unit used when reading timestamps from files.
   uint8_t readTimestampUnit(const config::ConfigBase* session) const;

--- a/velox/connectors/hive/FileConfig.h
+++ b/velox/connectors/hive/FileConfig.h
@@ -284,6 +284,12 @@ class FileConfig {
   /// meta data together. Optimization to decrease the small IO requests.
   static constexpr const char* kFilePreloadThreshold = "file-preload-threshold";
 
+  /// The byte size threshold beyond which the Parquet reader estimates and
+  /// reports the memory usage of deserialized Thrift objects to the memory
+  /// pool. Defaults to disabled (max uint64).
+  static constexpr const char* kParquetFooterTrackThriftMemoryThreshold =
+      "parquet.track-footer-thrift-memory-threshold";
+
   explicit FileConfig(std::shared_ptr<const config::ConfigBase> config) {
     VELOX_CHECK_NOT_NULL(
         config, "Config is null for FileConfig initialization");
@@ -299,6 +305,11 @@ class FileConfig {
   size_t parallelUnitLoadCount(const config::ConfigBase* session) const;
 
   uint64_t filePreloadThreshold() const;
+
+  /// Returns the byte size threshold beyond which the Parquet reader reports
+  /// the deserialized Thrift footer's memory consumption to the memory pool.
+  /// Defaults to disabled (max uint64).
+  uint64_t parquetFooterTrackThriftMemoryThreshold() const;
 
   // Returns the timestamp unit used when reading timestamps from files.
   uint8_t readTimestampUnit(const config::ConfigBase* session) const;

--- a/velox/connectors/hive/FileConnectorUtil.cpp
+++ b/velox/connectors/hive/FileConnectorUtil.cpp
@@ -77,6 +77,8 @@ void configureReaderOptions(
       useColumnNamesForColumnMapping);
   readerOptions.setFileSchema(fileSchema);
   readerOptions.setFilePreloadThreshold(fileConfig->filePreloadThreshold());
+  readerOptions.setParquetFooterTrackThriftMemoryThreshold(
+      fileConfig->parquetFooterTrackThriftMemoryThreshold());
   readerOptions.setPrefetchRowGroups(fileConfig->prefetchRowGroups());
   readerOptions.setCacheable(fileSplit->cacheable);
   const auto& sessionTzName = connectorQueryCtx->sessionTimezone();

--- a/velox/connectors/hive/FileConnectorUtil.cpp
+++ b/velox/connectors/hive/FileConnectorUtil.cpp
@@ -77,8 +77,8 @@ void configureReaderOptions(
       useColumnNamesForColumnMapping);
   readerOptions.setFileSchema(fileSchema);
   readerOptions.setFilePreloadThreshold(fileConfig->filePreloadThreshold());
-  readerOptions.setParquetFooterTrackThriftMemoryThreshold(
-      fileConfig->parquetFooterTrackThriftMemoryThreshold());
+  readerOptions.setParquetFooterMemoryTrackingThreshold(
+      fileConfig->parquetFooterMemoryTrackingThreshold(sessionProperties));
   readerOptions.setPrefetchRowGroups(fileConfig->prefetchRowGroups());
   readerOptions.setCacheable(fileSplit->cacheable);
   const auto& sessionTzName = connectorQueryCtx->sessionTimezone();

--- a/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
@@ -274,8 +274,6 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
   customHiveConfigProps[hive::HiveConfig::kFileColumnNamesReadAsLowerCase] =
       "true";
   customHiveConfigProps[hive::HiveConfig::kOrcUseColumnNames] = "true";
-  customHiveConfigProps
-      [hive::HiveConfig::kParquetFooterMemoryTrackingThreshold] = "1111";
   customHiveConfigProps[hive::HiveConfig::kFilePreloadThreshold] = "9999";
   customHiveConfigProps[hive::HiveConfig::kPrefetchRowGroups] = "10";
   customHiveConfigProps[hive::HiveConfig::kCacheMetadata] = "true";
@@ -297,9 +295,6 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
   EXPECT_EQ(
       readerOptions.footerSpeculativeIoSize(),
       hiveConfig->orcFooterSpeculativeIoSize(&sessionProperties));
-  EXPECT_EQ(
-      readerOptions.parquetFooterMemoryTrackingThreshold(),
-      hiveConfig->parquetFooterMemoryTrackingThreshold(&sessionProperties));
   EXPECT_EQ(
       readerOptions.filePreloadThreshold(), hiveConfig->filePreloadThreshold());
   EXPECT_EQ(readerOptions.prefetchRowGroups(), hiveConfig->prefetchRowGroups());

--- a/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
@@ -275,7 +275,7 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
       "true";
   customHiveConfigProps[hive::HiveConfig::kOrcUseColumnNames] = "true";
   customHiveConfigProps
-      [hive::HiveConfig::kParquetFooterTrackThriftMemoryThreshold] = "1111";
+      [hive::HiveConfig::kParquetFooterMemoryTrackingThreshold] = "1111";
   customHiveConfigProps[hive::HiveConfig::kFilePreloadThreshold] = "9999";
   customHiveConfigProps[hive::HiveConfig::kPrefetchRowGroups] = "10";
   customHiveConfigProps[hive::HiveConfig::kCacheMetadata] = "true";
@@ -298,8 +298,8 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
       readerOptions.footerSpeculativeIoSize(),
       hiveConfig->orcFooterSpeculativeIoSize(&sessionProperties));
   EXPECT_EQ(
-      readerOptions.parquetFooterTrackThriftMemoryThreshold(),
-      hiveConfig->parquetFooterTrackThriftMemoryThreshold());
+      readerOptions.parquetFooterMemoryTrackingThreshold(),
+      hiveConfig->parquetFooterMemoryTrackingThreshold(&sessionProperties));
   EXPECT_EQ(
       readerOptions.filePreloadThreshold(), hiveConfig->filePreloadThreshold());
   EXPECT_EQ(readerOptions.prefetchRowGroups(), hiveConfig->prefetchRowGroups());

--- a/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
@@ -274,6 +274,8 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
   customHiveConfigProps[hive::HiveConfig::kFileColumnNamesReadAsLowerCase] =
       "true";
   customHiveConfigProps[hive::HiveConfig::kOrcUseColumnNames] = "true";
+  customHiveConfigProps
+      [hive::HiveConfig::kParquetFooterTrackThriftMemoryThreshold] = "1111";
   customHiveConfigProps[hive::HiveConfig::kFilePreloadThreshold] = "9999";
   customHiveConfigProps[hive::HiveConfig::kPrefetchRowGroups] = "10";
   customHiveConfigProps[hive::HiveConfig::kCacheMetadata] = "true";
@@ -295,6 +297,9 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
   EXPECT_EQ(
       readerOptions.footerSpeculativeIoSize(),
       hiveConfig->orcFooterSpeculativeIoSize(&sessionProperties));
+  EXPECT_EQ(
+      readerOptions.parquetFooterTrackThriftMemoryThreshold(),
+      hiveConfig->parquetFooterTrackThriftMemoryThreshold());
   EXPECT_EQ(
       readerOptions.filePreloadThreshold(), hiveConfig->filePreloadThreshold());
   EXPECT_EQ(readerOptions.prefetchRowGroups(), hiveConfig->prefetchRowGroups());

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -936,8 +936,8 @@ must be specified as raw byte counts.
        silently over-consuming. The reservation shrinks as row groups are
        skipped by filterRowGroups and is released in full when the reader
        is destroyed. When tracking engages, the estimate is also surfaced
-       per scan via the runtime stat ``footerEstimatedBytes`` so operators
-       can compare it against actual pool usage.
+       per scan via the runtime stat ``parquetFooterEstimatedBytes`` so
+       operators can compare it against actual pool usage.
    * - nimble.footer-speculative-io-size
      - nimble_footer_speculative_io_size
      - integer

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -529,15 +529,15 @@ Spilling
      - bool
      - false
      - Enable the prefix sort or fallback to timsort in spill. The prefix sort is faster than std::sort but requires the
-       memory to build normalized prefix keys,
-           which might have potential risk of running out of server memory.*
-               -spiller_start_partition_bit -
-           integer - 29 -
-           The start partition bit which is used
-                   with `spiller_num_partition_bits` together to calculate the
-                       spilling partition number.*
-               -spiller_num_partition_bits -
-           integer - 3 - The number of bits(N) used to calculate the spilling partition number for hash join and RowNumber: 2 ^ N. At the moment the maximum
+       memory to build normalized prefix keys, which might have potential risk of running out of server memory.
+   * - spiller_start_partition_bit
+     - integer
+     - 29
+     - The start partition bit which is used with `spiller_num_partition_bits` together to calculate the spilling partition number.
+   * - spiller_num_partition_bits
+     - integer
+     - 3
+     - The number of bits (N) used to calculate the spilling partition number for hash join and RowNumber: 2 ^ N. At the moment the maximum
        value is 3, meaning we only support up to 8-way spill partitioning.ing.
    * - testing.spill_pct
      - integer

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -1011,6 +1011,11 @@ must be specified as raw byte counts.
      - string
      - parquet-cpp-velox version 0.0.0
      - Created-by value used when writing to Parquet.
+   * - hive.parquet.track-footer-thrift-memory-threshold
+     -
+     - string
+     - disabled (max uint64)
+     - Threshold for tracking thrift memory usage in Parquet file footers. When the footer size exceeds this threshold, memory usage is tracked and reported. By default, tracking is disabled.
 
 ``Amazon S3 Configuration``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -1011,9 +1011,9 @@ must be specified as raw byte counts.
      - string
      - parquet-cpp-velox version 0.0.0
      - Created-by value used when writing to Parquet.
-   * - hive.parquet.track-footer-thrift-memory-threshold
+   * - parquet.track-footer-thrift-memory-threshold
      -
-     - string
+     - integer
      - disabled (max uint64)
      - Threshold for tracking thrift memory usage in Parquet file footers. When the footer size exceeds this threshold, memory usage is tracked and reported. By default, tracking is disabled.
 

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -529,15 +529,15 @@ Spilling
      - bool
      - false
      - Enable the prefix sort or fallback to timsort in spill. The prefix sort is faster than std::sort but requires the
-       memory to build normalized prefix keys, which might have potential risk of running out of server memory.
-   * - spiller_start_partition_bit
-     - integer
-     - 29
-     - The start partition bit which is used with `spiller_num_partition_bits` together to calculate the spilling partition number.
-   * - spiller_num_partition_bits
-     - integer
-     - 3
-     - The number of bits (N) used to calculate the spilling partition number for hash join and RowNumber: 2 ^ N. At the moment the maximum
+       memory to build normalized prefix keys,
+           which might have potential risk of running out of server memory.*
+               -spiller_start_partition_bit -
+           integer - 29 -
+           The start partition bit which is used
+                   with `spiller_num_partition_bits` together to calculate the
+                       spilling partition number.*
+               -spiller_num_partition_bits -
+           integer - 3 - The number of bits(N) used to calculate the spilling partition number for hash join and RowNumber: 2 ^ N. At the moment the maximum
        value is 3, meaning we only support up to 8-way spill partitioning.ing.
    * - testing.spill_pct
      - integer
@@ -908,6 +908,14 @@ must be specified as raw byte counts.
      - Speculative tail-read size in bytes when opening Parquet files. Controls how many bytes are read from the end
        of the file to load the footer and nearby metadata in a single IO operation.
        Set to 0 for adaptive mode.
+   * - parquet.footer-memory-tracking-threshold
+     - parquet_footer_memory_tracking_threshold
+     - integer
+     - disabled (max uint64)
+     - Footer byte size beyond which the Parquet reader estimates and reports the deserialized footer's heap
+       footprint to the memory pool, so footers large enough to dominate query memory are accounted for instead
+       of being invisible. Footers smaller than the threshold are not reported (default behavior). When set, the
+       memory is released as row groups are skipped or when the reader is destroyed.
    * - nimble.footer-speculative-io-size
      - nimble_footer_speculative_io_size
      - integer
@@ -1011,11 +1019,6 @@ must be specified as raw byte counts.
      - string
      - parquet-cpp-velox version 0.0.0
      - Created-by value used when writing to Parquet.
-   * - parquet.track-footer-thrift-memory-threshold
-     -
-     - integer
-     - disabled (max uint64)
-     - Threshold for tracking thrift memory usage in Parquet file footers. When the footer size exceeds this threshold, memory usage is tracked and reported. By default, tracking is disabled.
 
 ``Amazon S3 Configuration``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -908,14 +908,36 @@ must be specified as raw byte counts.
      - Speculative tail-read size in bytes when opening Parquet files. Controls how many bytes are read from the end
        of the file to load the footer and nearby metadata in a single IO operation.
        Set to 0 for adaptive mode.
-   * - parquet.footer-memory-tracking-threshold
+   * - parquet-footer-memory-tracking-threshold
      - parquet_footer_memory_tracking_threshold
      - integer
      - disabled (max uint64)
-     - Footer byte size above which the Parquet reader estimates the deserialized footer's heap footprint
-       and reports it to the memory pool. Large footers that would otherwise dominate query memory are
-       tracked instead of remaining invisible. Footers below the threshold are not reported. When tracking
-       is enabled, the reported memory is released as row groups are skipped and when the reader is destroyed.
+     - Serialized footer byte size above which the Parquet reader engages
+       memory tracking for the deserialized footer. Disabled by default
+       because the tracking path adds per-file CPU (walking the inline
+       struct tree to estimate heap usage) and the estimate is approximate;
+       enable it on workloads where large Parquet footers (millions of
+       columns or row groups) can dominate worker memory and cause silent
+       OOMs.
+
+       The threshold is compared against the serialized footer length
+       reported in the file trailer. The reported reservation is the
+       estimated heap footprint of the deserialized footer, which can be
+       several times the serialized length (in observed cases ~7-8x for
+       wide schemas). Pick the threshold based on the serialized size you
+       are willing to silently absorb; e.g. setting it to 16MB will start
+       tracking once the deserialized estimate is likely to exceed ~100MB.
+
+       Tracking is approximate: the estimate walks the thrift struct tree
+       at file-open time and is never re-measured against the allocator.
+       It cannot prevent the initial deserialization allocation — that
+       memory is already on the heap — but it makes the footprint visible
+       to the pool so the next allocation check fails fast instead of
+       silently over-consuming. The reservation shrinks as row groups are
+       skipped by filterRowGroups and is released in full when the reader
+       is destroyed. When tracking engages, the estimate is also surfaced
+       per scan via the runtime stat ``footerEstimatedBytes`` so operators
+       can compare it against actual pool usage.
    * - nimble.footer-speculative-io-size
      - nimble_footer_speculative_io_size
      - integer

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -538,7 +538,7 @@ Spilling
      - integer
      - 3
      - The number of bits (N) used to calculate the spilling partition number for hash join and RowNumber: 2 ^ N. At the moment the maximum
-       value is 3, meaning we only support up to 8-way spill partitioning.ing.
+       value is 3, meaning we only support up to 8-way spill partitioning.
    * - testing.spill_pct
      - integer
      - 0

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -912,10 +912,10 @@ must be specified as raw byte counts.
      - parquet_footer_memory_tracking_threshold
      - integer
      - disabled (max uint64)
-     - Footer byte size beyond which the Parquet reader estimates and reports the deserialized footer's heap
-       footprint to the memory pool, so footers large enough to dominate query memory are accounted for instead
-       of being invisible. Footers smaller than the threshold are not reported (default behavior). When set, the
-       memory is released as row groups are skipped or when the reader is destroyed.
+     - Footer byte size above which the Parquet reader estimates the deserialized footer's heap footprint
+       and reports it to the memory pool. Large footers that would otherwise dominate query memory are
+       tracked instead of remaining invisible. Footers below the threshold are not reported. When tracking
+       is enabled, the reported memory is released as row groups are skipped and when the reader is destroyed.
    * - nimble.footer-speculative-io-size
      - nimble_footer_speculative_io_size
      - integer

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -579,6 +579,8 @@ class ReaderOptions : public io::ReaderOptions {
       1024 * 1024; // 1MB
   static constexpr uint64_t kDefaultFilePreloadThreshold =
       1024 * 1024 * 8; // 8MB
+  static constexpr uint64_t kDefaultParquetFooterTrackThriftMemoryThreshold =
+      std::numeric_limits<uint64_t>::max(); // Disabled by default.
 
   explicit ReaderOptions(velox::memory::MemoryPool* pool)
       : io::ReaderOptions(pool) {}
@@ -627,6 +629,10 @@ class ReaderOptions : public io::ReaderOptions {
 
   ReaderOptions& setFooterSpeculativeIoSize(uint64_t size) {
     footerSpeculativeIoSize_ = size;
+    return *this;
+  }
+  ReaderOptions& setParquetFooterTrackThriftMemoryThreshold(uint64_t size) {
+    parquetFooterTrackThriftMemoryThreshold_ = size;
     return *this;
   }
 
@@ -689,6 +695,10 @@ class ReaderOptions : public io::ReaderOptions {
 
   uint64_t footerSpeculativeIoSize() const {
     return footerSpeculativeIoSize_;
+  }
+
+  uint64_t parquetFooterTrackThriftMemoryThreshold() const {
+    return parquetFooterTrackThriftMemoryThreshold_;
   }
 
   uint64_t filePreloadThreshold() const {
@@ -881,6 +891,8 @@ class ReaderOptions : public io::ReaderOptions {
   bool loadChunkIndex_{true};
   bool allowEmptyFile_{false};
   bool allowInt32Narrowing_{false};
+  uint64_t parquetFooterTrackThriftMemoryThreshold_{
+      kDefaultParquetFooterTrackThriftMemoryThreshold};
 };
 
 struct WriterOptions {

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -579,7 +579,7 @@ class ReaderOptions : public io::ReaderOptions {
       1024 * 1024; // 1MB
   static constexpr uint64_t kDefaultFilePreloadThreshold =
       1024 * 1024 * 8; // 8MB
-  static constexpr uint64_t kDefaultParquetFooterTrackThriftMemoryThreshold =
+  static constexpr uint64_t kDefaultParquetFooterMemoryTrackingThreshold =
       std::numeric_limits<uint64_t>::max(); // Disabled by default.
 
   explicit ReaderOptions(velox::memory::MemoryPool* pool)
@@ -631,8 +631,8 @@ class ReaderOptions : public io::ReaderOptions {
     footerSpeculativeIoSize_ = size;
     return *this;
   }
-  ReaderOptions& setParquetFooterTrackThriftMemoryThreshold(uint64_t size) {
-    parquetFooterTrackThriftMemoryThreshold_ = size;
+  ReaderOptions& setParquetFooterMemoryTrackingThreshold(uint64_t size) {
+    parquetFooterMemoryTrackingThreshold_ = size;
     return *this;
   }
 
@@ -697,8 +697,8 @@ class ReaderOptions : public io::ReaderOptions {
     return footerSpeculativeIoSize_;
   }
 
-  uint64_t parquetFooterTrackThriftMemoryThreshold() const {
-    return parquetFooterTrackThriftMemoryThreshold_;
+  uint64_t parquetFooterMemoryTrackingThreshold() const {
+    return parquetFooterMemoryTrackingThreshold_;
   }
 
   uint64_t filePreloadThreshold() const {
@@ -891,8 +891,8 @@ class ReaderOptions : public io::ReaderOptions {
   bool loadChunkIndex_{true};
   bool allowEmptyFile_{false};
   bool allowInt32Narrowing_{false};
-  uint64_t parquetFooterTrackThriftMemoryThreshold_{
-      kDefaultParquetFooterTrackThriftMemoryThreshold};
+  uint64_t parquetFooterMemoryTrackingThreshold_{
+      kDefaultParquetFooterMemoryTrackingThreshold};
 };
 
 struct WriterOptions {

--- a/velox/dwio/common/Statistics.h
+++ b/velox/dwio/common/Statistics.h
@@ -795,10 +795,11 @@ struct RuntimeStatistics {
     if (numStripes > 0) {
       result.emplace("numStripes", RuntimeMetric(numStripes));
     }
-    if (footerEstimatedBytes > 0) {
+    if (parquetFooterEstimatedBytes > 0) {
       result.emplace(
-          "footerEstimatedBytes",
-          RuntimeMetric(footerEstimatedBytes, RuntimeCounter::Unit::kBytes));
+          "parquetFooterEstimatedBytes",
+          RuntimeMetric(
+              parquetFooterEstimatedBytes, RuntimeCounter::Unit::kBytes));
     }
     columnReaderStats.toRuntimeMetrics(result);
     return result;

--- a/velox/dwio/common/Statistics.h
+++ b/velox/dwio/common/Statistics.h
@@ -756,11 +756,12 @@ struct RuntimeStatistics {
 
   int64_t numStripes{0};
 
-  // Estimated bytes reported to the memory pool for the deserialized file
-  // footer, when the reader's footer-memory tracking path is engaged. Lets
-  // operators compare the estimate against actual pool usage. 0 when the
-  // reader did not engage tracking (e.g. footer below threshold).
-  int64_t footerEstimatedBytes{0};
+  // Estimated bytes reported to the memory pool for the deserialized
+  // Parquet file footer, when the parquet reader's footer-memory
+  // tracking path is engaged. Lets operators compare the estimate
+  // against actual pool usage. 0 when the reader did not engage
+  // tracking (e.g. footer below threshold or non-parquet format).
+  int64_t parquetFooterEstimatedBytes{0};
 
   UnitLoaderStats unitLoaderStats;
   ColumnReaderStatistics columnReaderStats;

--- a/velox/dwio/common/Statistics.h
+++ b/velox/dwio/common/Statistics.h
@@ -756,6 +756,12 @@ struct RuntimeStatistics {
 
   int64_t numStripes{0};
 
+  // Estimated bytes reported to the memory pool for the deserialized file
+  // footer, when the reader's footer-memory tracking path is engaged. Lets
+  // operators compare the estimate against actual pool usage. 0 when the
+  // reader did not engage tracking (e.g. footer below threshold).
+  int64_t footerEstimatedBytes{0};
+
   UnitLoaderStats unitLoaderStats;
   ColumnReaderStatistics columnReaderStats;
 
@@ -788,6 +794,11 @@ struct RuntimeStatistics {
     }
     if (numStripes > 0) {
       result.emplace("numStripes", RuntimeMetric(numStripes));
+    }
+    if (footerEstimatedBytes > 0) {
+      result.emplace(
+          "footerEstimatedBytes",
+          RuntimeMetric(footerEstimatedBytes, RuntimeCounter::Unit::kBytes));
     }
     columnReaderStats.toRuntimeMetrics(result);
     return result;

--- a/velox/dwio/parquet/reader/Metadata.cpp
+++ b/velox/dwio/parquet/reader/Metadata.cpp
@@ -33,6 +33,71 @@ size_t keyValueMetadataSize(const std::vector<thrift::KeyValue>& keyValues) {
   return size;
 }
 
+// Returns the dynamically-allocated bytes reachable from `column` BEYOND the
+// inline thrift::ColumnChunk struct. The caller is expected to account for
+// sizeof(thrift::ColumnChunk) when including this column in a vector. Inline
+// sub-structs (thrift::ColumnMetaData, thrift::Statistics) live inside
+// sizeof(ColumnChunk) and are NOT counted again here; only their dynamically
+// allocated payloads (vectors and string buffers) are added.
+size_t columnMetadataSize(const thrift::ColumnChunk& column) {
+  size_t size = 0;
+  // Heap-backed vectors and the strings they contain.
+  size += column.meta_data.encodings.size() * sizeof(thrift::Encoding::type);
+  size += column.meta_data.path_in_schema.size() * sizeof(std::string);
+  for (const auto& path : column.meta_data.path_in_schema) {
+    size += path.capacity();
+  }
+  size += keyValueMetadataSize(column.meta_data.key_value_metadata);
+
+  // thrift::Statistics is an inline member of thrift::ColumnMetaData. Its POD
+  // fields (null_count, distinct_count) are already in sizeof(ColumnChunk).
+  // Only the heap-backed string payloads need to be added here.
+  if (column.meta_data.__isset.statistics) {
+    const auto& stats = column.meta_data.statistics;
+    if (stats.__isset.min) {
+      size += stats.min.capacity();
+    }
+    if (stats.__isset.max) {
+      size += stats.max.capacity();
+    }
+    if (stats.__isset.min_value) {
+      size += stats.min_value.capacity();
+    }
+    if (stats.__isset.max_value) {
+      size += stats.max_value.capacity();
+    }
+  }
+  return size;
+}
+
+// Estimates the heap memory held by `metadata` after thrift deserialization.
+// Returns sizeof(thrift::FileMetaData) plus the bytes of every dynamically
+// allocated vector and string reachable through it. Inline POD members and
+// inline thrift sub-structs (e.g. thrift::EncryptionAlgorithm,
+// thrift::SchemaElement::logicalType) are part of the parent sizeof and are
+// not double-counted here.
+size_t fileMetadataSize(const thrift::FileMetaData& metadata) {
+  size_t totalSize = sizeof(thrift::FileMetaData);
+  // Schema vector heap allocation plus per-element name strings.
+  totalSize += metadata.schema.size() * sizeof(thrift::SchemaElement);
+  for (const auto& schema : metadata.schema) {
+    totalSize += schema.name.capacity();
+  }
+  // Row groups vector heap allocation plus the columns vectors it owns.
+  totalSize += metadata.row_groups.size() * sizeof(thrift::RowGroup);
+  for (const auto& rowGroup : metadata.row_groups) {
+    totalSize += rowGroup.columns.size() * sizeof(thrift::ColumnChunk);
+    for (const auto& column : rowGroup.columns) {
+      totalSize += columnMetadataSize(column);
+    }
+  }
+  totalSize += keyValueMetadataSize(metadata.key_value_metadata);
+  totalSize += metadata.created_by.capacity();
+  totalSize += metadata.column_orders.size() * sizeof(thrift::ColumnOrder);
+  totalSize += metadata.footer_signing_key_metadata.capacity();
+  return totalSize;
+}
+
 } // namespace
 
 template <typename T>
@@ -406,69 +471,12 @@ std::string FileMetaDataPtr::createdBy() const {
   return thriftFileMetaDataPtr(ptr_)->created_by;
 }
 
-// Returns the dynamically-allocated bytes reachable from `column` BEYOND the
-// inline thrift::ColumnChunk struct. The caller is expected to account for
-// sizeof(thrift::ColumnChunk) when including this column in a vector. Inline
-// sub-structs (thrift::ColumnMetaData, thrift::Statistics) live inside
-// sizeof(ColumnChunk) and are NOT counted again here; only their dynamically
-// allocated payloads (vectors and string buffers) are added.
-size_t calculateColumnMetadataSize(const thrift::ColumnChunk& column) {
-  size_t size = 0;
-  // Heap-backed vectors and the strings they contain.
-  size += column.meta_data.encodings.size() * sizeof(thrift::Encoding::type);
-  size += column.meta_data.path_in_schema.size() * sizeof(std::string);
-  for (const auto& path : column.meta_data.path_in_schema) {
-    size += path.capacity();
-  }
-  size += keyValueMetadataSize(column.meta_data.key_value_metadata);
-
-  // thrift::Statistics is an inline member of thrift::ColumnMetaData. Its POD
-  // fields (null_count, distinct_count) are already in sizeof(ColumnChunk).
-  // Only the heap-backed string payloads need to be added here.
-  if (column.meta_data.__isset.statistics) {
-    const auto& stats = column.meta_data.statistics;
-    if (stats.__isset.min) {
-      size += stats.min.capacity();
-    }
-    if (stats.__isset.max) {
-      size += stats.max.capacity();
-    }
-    if (stats.__isset.min_value) {
-      size += stats.min_value.capacity();
-    }
-    if (stats.__isset.max_value) {
-      size += stats.max_value.capacity();
-    }
-  }
-  return size;
+size_t ColumnChunkMetaDataPtr::calculateColumnMetadataSize() const {
+  return columnMetadataSize(*thriftColumnChunkPtr(ptr_));
 }
 
-// Estimates the heap memory held by `metadata` after thrift deserialization.
-// Returns sizeof(thrift::FileMetaData) plus the bytes of every dynamically
-// allocated vector and string reachable through it. Inline POD members and
-// inline thrift sub-structs (e.g. thrift::EncryptionAlgorithm,
-// thrift::SchemaElement::logicalType) are part of the parent sizeof and are
-// not double-counted here.
-size_t calculateFileMetadataSize(const thrift::FileMetaData& metadata) {
-  size_t totalSize = sizeof(thrift::FileMetaData);
-  // Schema vector heap allocation plus per-element name strings.
-  totalSize += metadata.schema.size() * sizeof(thrift::SchemaElement);
-  for (const auto& schema : metadata.schema) {
-    totalSize += schema.name.capacity();
-  }
-  // Row groups vector heap allocation plus the columns vectors it owns.
-  totalSize += metadata.row_groups.size() * sizeof(thrift::RowGroup);
-  for (const auto& rowGroup : metadata.row_groups) {
-    totalSize += rowGroup.columns.size() * sizeof(thrift::ColumnChunk);
-    for (const auto& column : rowGroup.columns) {
-      totalSize += calculateColumnMetadataSize(column);
-    }
-  }
-  totalSize += keyValueMetadataSize(metadata.key_value_metadata);
-  totalSize += metadata.created_by.capacity();
-  totalSize += metadata.column_orders.size() * sizeof(thrift::ColumnOrder);
-  totalSize += metadata.footer_signing_key_metadata.capacity();
-  return totalSize;
+size_t FileMetaDataPtr::calculateFileMetadataSize() const {
+  return fileMetadataSize(*thriftFileMetaDataPtr(ptr_));
 }
 
 } // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/reader/Metadata.cpp
+++ b/velox/dwio/parquet/reader/Metadata.cpp
@@ -49,18 +49,42 @@ size_t keyValueMetadataSize(const std::vector<thrift::KeyValue>& keyValues) {
 // Returns the estimated total bytes held by `column`:
 // sizeof(thrift::ColumnChunk) plus every dynamically allocated vector and
 // string reachable through it. Inline sub-structs (thrift::ColumnMetaData,
-// thrift::Statistics) live inside sizeof(ColumnChunk) and are NOT counted again
-// here; only their dynamically allocated payloads (vectors and string buffers)
-// are added.
+// thrift::Statistics, thrift::ColumnCryptoMetaData) live inside
+// sizeof(ColumnChunk) and are NOT counted again here; only their dynamically
+// allocated payloads (vectors and string buffers) are added.
 size_t columnMetadataSize(const thrift::ColumnChunk& column) {
   size_t size = sizeof(thrift::ColumnChunk);
-  // Heap-backed vectors and the strings they contain.
+  // Optional heap-backed strings on ColumnChunk itself.
+  if (column.__isset.file_path) {
+    size += heapStringSize(column.file_path);
+  }
+  if (column.__isset.encrypted_column_metadata) {
+    size += heapStringSize(column.encrypted_column_metadata);
+  }
+  // Optional crypto metadata. The union's inner structs are inline within
+  // ColumnChunk via __isset, so only their heap-backed payloads are added.
+  if (column.__isset.crypto_metadata &&
+      column.crypto_metadata.__isset.ENCRYPTION_WITH_COLUMN_KEY) {
+    const auto& key = column.crypto_metadata.ENCRYPTION_WITH_COLUMN_KEY;
+    size += key.path_in_schema.size() * sizeof(std::string);
+    for (const auto& path : key.path_in_schema) {
+      size += heapStringSize(path);
+    }
+    if (key.__isset.key_metadata) {
+      size += heapStringSize(key.key_metadata);
+    }
+  }
+  // Heap-backed vectors and the strings they contain inside ColumnMetaData.
   size += column.meta_data.encodings.size() * sizeof(thrift::Encoding::type);
   size += column.meta_data.path_in_schema.size() * sizeof(std::string);
   for (const auto& path : column.meta_data.path_in_schema) {
     size += heapStringSize(path);
   }
   size += keyValueMetadataSize(column.meta_data.key_value_metadata);
+  if (column.meta_data.__isset.encoding_stats) {
+    size += column.meta_data.encoding_stats.size() *
+        sizeof(thrift::PageEncodingStats);
+  }
 
   // thrift::Statistics is an inline member of thrift::ColumnMetaData. Its POD
   // fields (null_count, distinct_count) are already in sizeof(ColumnChunk).

--- a/velox/dwio/parquet/reader/Metadata.cpp
+++ b/velox/dwio/parquet/reader/Metadata.cpp
@@ -19,6 +19,22 @@
 
 namespace facebook::velox::parquet {
 
+namespace {
+
+// Returns the dynamically-allocated byte size held by a thrift key/value
+// metadata vector — the inline thrift::KeyValue array bytes plus the heap
+// storage backing each key and value string.
+size_t keyValueMetadataSize(const std::vector<thrift::KeyValue>& keyValues) {
+  size_t size = keyValues.size() * sizeof(thrift::KeyValue);
+  for (const auto& kv : keyValues) {
+    size += kv.key.capacity();
+    size += kv.value.capacity();
+  }
+  return size;
+}
+
+} // namespace
+
 template <typename T>
 inline const T load(const char* ptr) {
   T ret;
@@ -388,6 +404,70 @@ std::string FileMetaDataPtr::keyValueMetadataValue(
 
 std::string FileMetaDataPtr::createdBy() const {
   return thriftFileMetaDataPtr(ptr_)->created_by;
+}
+
+size_t calculateColumnMetadataSize(const thrift::ColumnChunk& column) {
+  size_t size = 0;
+  size += sizeof(thrift::ColumnChunk);
+  size += sizeof(thrift::ColumnMetaData);
+  size += column.meta_data.encodings.size() * sizeof(thrift::Encoding::type);
+  size += column.meta_data.path_in_schema.size() * sizeof(std::string);
+  for (const auto& path : column.meta_data.path_in_schema) {
+    size += path.capacity();
+  }
+  size += keyValueMetadataSize(column.meta_data.key_value_metadata);
+
+  if (column.meta_data.__isset.statistics) {
+    const auto& stats = column.meta_data.statistics;
+    size += sizeof(thrift::Statistics);
+    if (stats.__isset.min) {
+      size += stats.min.capacity();
+    }
+    if (stats.__isset.max) {
+      size += stats.max.capacity();
+    }
+    if (stats.__isset.min_value) {
+      size += stats.min_value.capacity();
+    }
+    if (stats.__isset.max_value) {
+      size += stats.max_value.capacity();
+    }
+    if (stats.__isset.null_count) {
+      size += sizeof(int64_t);
+    }
+    if (stats.__isset.distinct_count) {
+      size += sizeof(int64_t);
+    }
+  }
+  return size;
+}
+
+size_t calculateFileMetadataSize(const thrift::FileMetaData& metadata) {
+  size_t totalSize = sizeof(thrift::FileMetaData);
+  for (const auto& schema : metadata.schema) {
+    size_t elementSize = sizeof(schema) + schema.name.capacity() +
+        sizeof(schema.type) + sizeof(schema.type_length) +
+        sizeof(schema.repetition_type) + sizeof(schema.num_children) +
+        sizeof(schema.converted_type) + sizeof(schema.scale) +
+        sizeof(schema.precision) + sizeof(schema.field_id);
+    if (schema.__isset.logicalType) {
+      elementSize += sizeof(schema.logicalType);
+    }
+    totalSize += elementSize;
+  }
+  totalSize += metadata.row_groups.size() * sizeof(thrift::RowGroup);
+  for (const auto& rowGroup : metadata.row_groups) {
+    totalSize += rowGroup.columns.size() * sizeof(thrift::ColumnChunk);
+    for (const auto& column : rowGroup.columns) {
+      totalSize += calculateColumnMetadataSize(column);
+    }
+  }
+  totalSize += keyValueMetadataSize(metadata.key_value_metadata);
+  totalSize += metadata.created_by.capacity();
+  totalSize += metadata.column_orders.size() * sizeof(thrift::ColumnOrder);
+  totalSize += sizeof(thrift::EncryptionAlgorithm);
+  totalSize += metadata.footer_signing_key_metadata.capacity();
+  return totalSize;
 }
 
 } // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/reader/Metadata.cpp
+++ b/velox/dwio/parquet/reader/Metadata.cpp
@@ -21,14 +21,27 @@ namespace facebook::velox::parquet {
 
 namespace {
 
+// Returns the heap bytes held by `s`, skipping SSO strings whose buffer is
+// inline within the std::string object and already counted by the containing
+// struct's sizeof. Detects SSO by checking whether s.data() points inside the
+// std::string itself, which is portable across libc++, libstdc++, and MSVC.
+size_t heapStringSize(const std::string& s) {
+  const auto* data = reinterpret_cast<const char*>(s.data());
+  const auto* begin = reinterpret_cast<const char*>(&s);
+  if (data >= begin && data < begin + sizeof(std::string)) {
+    return 0;
+  }
+  return s.capacity();
+}
+
 // Returns the dynamically-allocated byte size held by a thrift key/value
 // metadata vector — the inline thrift::KeyValue array bytes plus the heap
 // storage backing each key and value string.
 size_t keyValueMetadataSize(const std::vector<thrift::KeyValue>& keyValues) {
   size_t size = keyValues.size() * sizeof(thrift::KeyValue);
   for (const auto& kv : keyValues) {
-    size += kv.key.capacity();
-    size += kv.value.capacity();
+    size += heapStringSize(kv.key);
+    size += heapStringSize(kv.value);
   }
   return size;
 }
@@ -45,7 +58,7 @@ size_t columnMetadataSize(const thrift::ColumnChunk& column) {
   size += column.meta_data.encodings.size() * sizeof(thrift::Encoding::type);
   size += column.meta_data.path_in_schema.size() * sizeof(std::string);
   for (const auto& path : column.meta_data.path_in_schema) {
-    size += path.capacity();
+    size += heapStringSize(path);
   }
   size += keyValueMetadataSize(column.meta_data.key_value_metadata);
 
@@ -55,16 +68,16 @@ size_t columnMetadataSize(const thrift::ColumnChunk& column) {
   if (column.meta_data.__isset.statistics) {
     const auto& stats = column.meta_data.statistics;
     if (stats.__isset.min) {
-      size += stats.min.capacity();
+      size += heapStringSize(stats.min);
     }
     if (stats.__isset.max) {
-      size += stats.max.capacity();
+      size += heapStringSize(stats.max);
     }
     if (stats.__isset.min_value) {
-      size += stats.min_value.capacity();
+      size += heapStringSize(stats.min_value);
     }
     if (stats.__isset.max_value) {
-      size += stats.max_value.capacity();
+      size += heapStringSize(stats.max_value);
     }
   }
   return size;
@@ -81,7 +94,7 @@ size_t fileMetadataSize(const thrift::FileMetaData& metadata) {
   // Schema vector heap allocation plus per-element name strings.
   totalSize += metadata.schema.size() * sizeof(thrift::SchemaElement);
   for (const auto& schema : metadata.schema) {
-    totalSize += schema.name.capacity();
+    totalSize += heapStringSize(schema.name);
   }
   // Row groups vector heap allocation plus the columns vectors it owns.
   totalSize += metadata.row_groups.size() * sizeof(thrift::RowGroup);
@@ -91,9 +104,9 @@ size_t fileMetadataSize(const thrift::FileMetaData& metadata) {
     }
   }
   totalSize += keyValueMetadataSize(metadata.key_value_metadata);
-  totalSize += metadata.created_by.capacity();
+  totalSize += heapStringSize(metadata.created_by);
   totalSize += metadata.column_orders.size() * sizeof(thrift::ColumnOrder);
-  totalSize += metadata.footer_signing_key_metadata.capacity();
+  totalSize += heapStringSize(metadata.footer_signing_key_metadata);
   return totalSize;
 }
 

--- a/velox/dwio/parquet/reader/Metadata.cpp
+++ b/velox/dwio/parquet/reader/Metadata.cpp
@@ -33,14 +33,14 @@ size_t keyValueMetadataSize(const std::vector<thrift::KeyValue>& keyValues) {
   return size;
 }
 
-// Returns the dynamically-allocated bytes reachable from `column` BEYOND the
-// inline thrift::ColumnChunk struct. The caller is expected to account for
-// sizeof(thrift::ColumnChunk) when including this column in a vector. Inline
-// sub-structs (thrift::ColumnMetaData, thrift::Statistics) live inside
-// sizeof(ColumnChunk) and are NOT counted again here; only their dynamically
-// allocated payloads (vectors and string buffers) are added.
+// Returns the estimated total bytes held by `column`:
+// sizeof(thrift::ColumnChunk) plus every dynamically allocated vector and
+// string reachable through it. Inline sub-structs (thrift::ColumnMetaData,
+// thrift::Statistics) live inside sizeof(ColumnChunk) and are NOT counted again
+// here; only their dynamically allocated payloads (vectors and string buffers)
+// are added.
 size_t columnMetadataSize(const thrift::ColumnChunk& column) {
-  size_t size = 0;
+  size_t size = sizeof(thrift::ColumnChunk);
   // Heap-backed vectors and the strings they contain.
   size += column.meta_data.encodings.size() * sizeof(thrift::Encoding::type);
   size += column.meta_data.path_in_schema.size() * sizeof(std::string);
@@ -86,7 +86,6 @@ size_t fileMetadataSize(const thrift::FileMetaData& metadata) {
   // Row groups vector heap allocation plus the columns vectors it owns.
   totalSize += metadata.row_groups.size() * sizeof(thrift::RowGroup);
   for (const auto& rowGroup : metadata.row_groups) {
-    totalSize += rowGroup.columns.size() * sizeof(thrift::ColumnChunk);
     for (const auto& column : rowGroup.columns) {
       totalSize += columnMetadataSize(column);
     }

--- a/velox/dwio/parquet/reader/Metadata.cpp
+++ b/velox/dwio/parquet/reader/Metadata.cpp
@@ -406,10 +406,15 @@ std::string FileMetaDataPtr::createdBy() const {
   return thriftFileMetaDataPtr(ptr_)->created_by;
 }
 
+// Returns the dynamically-allocated bytes reachable from `column` BEYOND the
+// inline thrift::ColumnChunk struct. The caller is expected to account for
+// sizeof(thrift::ColumnChunk) when including this column in a vector. Inline
+// sub-structs (thrift::ColumnMetaData, thrift::Statistics) live inside
+// sizeof(ColumnChunk) and are NOT counted again here; only their dynamically
+// allocated payloads (vectors and string buffers) are added.
 size_t calculateColumnMetadataSize(const thrift::ColumnChunk& column) {
   size_t size = 0;
-  size += sizeof(thrift::ColumnChunk);
-  size += sizeof(thrift::ColumnMetaData);
+  // Heap-backed vectors and the strings they contain.
   size += column.meta_data.encodings.size() * sizeof(thrift::Encoding::type);
   size += column.meta_data.path_in_schema.size() * sizeof(std::string);
   for (const auto& path : column.meta_data.path_in_schema) {
@@ -417,9 +422,11 @@ size_t calculateColumnMetadataSize(const thrift::ColumnChunk& column) {
   }
   size += keyValueMetadataSize(column.meta_data.key_value_metadata);
 
+  // thrift::Statistics is an inline member of thrift::ColumnMetaData. Its POD
+  // fields (null_count, distinct_count) are already in sizeof(ColumnChunk).
+  // Only the heap-backed string payloads need to be added here.
   if (column.meta_data.__isset.statistics) {
     const auto& stats = column.meta_data.statistics;
-    size += sizeof(thrift::Statistics);
     if (stats.__isset.min) {
       size += stats.min.capacity();
     }
@@ -432,29 +439,24 @@ size_t calculateColumnMetadataSize(const thrift::ColumnChunk& column) {
     if (stats.__isset.max_value) {
       size += stats.max_value.capacity();
     }
-    if (stats.__isset.null_count) {
-      size += sizeof(int64_t);
-    }
-    if (stats.__isset.distinct_count) {
-      size += sizeof(int64_t);
-    }
   }
   return size;
 }
 
+// Estimates the heap memory held by `metadata` after thrift deserialization.
+// Returns sizeof(thrift::FileMetaData) plus the bytes of every dynamically
+// allocated vector and string reachable through it. Inline POD members and
+// inline thrift sub-structs (e.g. thrift::EncryptionAlgorithm,
+// thrift::SchemaElement::logicalType) are part of the parent sizeof and are
+// not double-counted here.
 size_t calculateFileMetadataSize(const thrift::FileMetaData& metadata) {
   size_t totalSize = sizeof(thrift::FileMetaData);
+  // Schema vector heap allocation plus per-element name strings.
+  totalSize += metadata.schema.size() * sizeof(thrift::SchemaElement);
   for (const auto& schema : metadata.schema) {
-    size_t elementSize = sizeof(schema) + schema.name.capacity() +
-        sizeof(schema.type) + sizeof(schema.type_length) +
-        sizeof(schema.repetition_type) + sizeof(schema.num_children) +
-        sizeof(schema.converted_type) + sizeof(schema.scale) +
-        sizeof(schema.precision) + sizeof(schema.field_id);
-    if (schema.__isset.logicalType) {
-      elementSize += sizeof(schema.logicalType);
-    }
-    totalSize += elementSize;
+    totalSize += schema.name.capacity();
   }
+  // Row groups vector heap allocation plus the columns vectors it owns.
   totalSize += metadata.row_groups.size() * sizeof(thrift::RowGroup);
   for (const auto& rowGroup : metadata.row_groups) {
     totalSize += rowGroup.columns.size() * sizeof(thrift::ColumnChunk);
@@ -465,7 +467,6 @@ size_t calculateFileMetadataSize(const thrift::FileMetaData& metadata) {
   totalSize += keyValueMetadataSize(metadata.key_value_metadata);
   totalSize += metadata.created_by.capacity();
   totalSize += metadata.column_orders.size() * sizeof(thrift::ColumnOrder);
-  totalSize += sizeof(thrift::EncryptionAlgorithm);
   totalSize += metadata.footer_signing_key_metadata.capacity();
   return totalSize;
 }

--- a/velox/dwio/parquet/reader/Metadata.cpp
+++ b/velox/dwio/parquet/reader/Metadata.cpp
@@ -24,7 +24,12 @@ namespace {
 // Returns the heap bytes held by `s`, skipping SSO strings whose buffer is
 // inline within the std::string object and already counted by the containing
 // struct's sizeof. Detects SSO by checking whether s.data() points inside the
-// std::string itself, which is portable across libc++, libstdc++, and MSVC.
+// std::string itself. This relies on the standard library placing the SSO
+// buffer inside the object, which is true on libc++, libstdc++, and MSVC —
+// the implementations Velox supports — but is not guaranteed by the C++
+// standard. On a hypothetical implementation that stored SSO data outside
+// the object, the check would simply treat short strings as heap-allocated
+// and slightly over-report, never under-report.
 size_t heapStringSize(const std::string& s) {
   const auto* data = reinterpret_cast<const char*>(s.data());
   const auto* begin = reinterpret_cast<const char*>(&s);
@@ -507,11 +512,11 @@ std::string FileMetaDataPtr::createdBy() const {
   return thriftFileMetaDataPtr(ptr_)->created_by;
 }
 
-size_t ColumnChunkMetaDataPtr::calculateColumnMetadataSize() const {
+size_t ColumnChunkMetaDataPtr::estimateColumnMetadataSize() const {
   return columnMetadataSize(*thriftColumnChunkPtr(ptr_));
 }
 
-size_t FileMetaDataPtr::calculateFileMetadataSize() const {
+size_t FileMetaDataPtr::estimateFileMetadataSize() const {
   return fileMetadataSize(*thriftFileMetaDataPtr(ptr_));
 }
 

--- a/velox/dwio/parquet/reader/Metadata.h
+++ b/velox/dwio/parquet/reader/Metadata.h
@@ -18,6 +18,7 @@
 
 #include "velox/dwio/common/Statistics.h"
 #include "velox/dwio/common/compression/Compression.h"
+#include "velox/dwio/parquet/thrift/ParquetThriftTypes.h"
 
 namespace facebook::velox::parquet {
 
@@ -159,5 +160,9 @@ class FileMetaDataPtr {
  private:
   const void* ptr_;
 };
+
+size_t calculateColumnMetadataSize(const thrift::ColumnChunk& column);
+
+size_t calculateFileMetadataSize(const thrift::FileMetaData& metadata);
 
 } // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/reader/Metadata.h
+++ b/velox/dwio/parquet/reader/Metadata.h
@@ -75,6 +75,12 @@ class ColumnChunkMetaDataPtr {
   /// This information is optional and may be 0 if omitted.
   int64_t totalUncompressedSize() const;
 
+  /// Returns the estimated dynamically-allocated heap memory reachable from
+  /// this column chunk's thrift representation. Excludes the inline
+  /// thrift::ColumnChunk struct itself; callers that account for the
+  /// containing vector must add sizeof(thrift::ColumnChunk) separately.
+  size_t calculateColumnMetadataSize() const;
+
  private:
   const void* ptr_;
 };
@@ -157,12 +163,13 @@ class FileMetaDataPtr {
   /// Return the Parquet writer created_by string.
   std::string createdBy() const;
 
+  /// Returns the estimated total heap memory held by this file's thrift
+  /// representation: sizeof(thrift::FileMetaData) plus every dynamically
+  /// allocated vector and string reachable through it.
+  size_t calculateFileMetadataSize() const;
+
  private:
   const void* ptr_;
 };
-
-size_t calculateColumnMetadataSize(const thrift::ColumnChunk& column);
-
-size_t calculateFileMetadataSize(const thrift::FileMetaData& metadata);
 
 } // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/reader/Metadata.h
+++ b/velox/dwio/parquet/reader/Metadata.h
@@ -18,7 +18,6 @@
 
 #include "velox/dwio/common/Statistics.h"
 #include "velox/dwio/common/compression/Compression.h"
-#include "velox/dwio/parquet/thrift/ParquetThriftTypes.h"
 
 namespace facebook::velox::parquet {
 
@@ -75,10 +74,9 @@ class ColumnChunkMetaDataPtr {
   /// This information is optional and may be 0 if omitted.
   int64_t totalUncompressedSize() const;
 
-  /// Returns the estimated dynamically-allocated heap memory reachable from
-  /// this column chunk's thrift representation. Excludes the inline
-  /// thrift::ColumnChunk struct itself; callers that account for the
-  /// containing vector must add sizeof(thrift::ColumnChunk) separately.
+  /// Returns the estimated total bytes held by this column's thrift
+  /// representation: sizeof(thrift::ColumnChunk) plus every dynamically
+  /// allocated vector and string reachable through it.
   size_t calculateColumnMetadataSize() const;
 
  private:

--- a/velox/dwio/parquet/reader/Metadata.h
+++ b/velox/dwio/parquet/reader/Metadata.h
@@ -76,8 +76,11 @@ class ColumnChunkMetaDataPtr {
 
   /// Returns the estimated total bytes held by this column's thrift
   /// representation: sizeof(thrift::ColumnChunk) plus every dynamically
-  /// allocated vector and string reachable through it.
-  size_t calculateColumnMetadataSize() const;
+  /// allocated vector and string reachable through it. The estimate
+  /// walks the inline struct tree and approximates the heap footprint;
+  /// it is not measured from the allocator and may over- or
+  /// under-report by a small fraction.
+  size_t estimateColumnMetadataSize() const;
 
  private:
   const void* ptr_;
@@ -163,8 +166,11 @@ class FileMetaDataPtr {
 
   /// Returns the estimated total heap memory held by this file's thrift
   /// representation: sizeof(thrift::FileMetaData) plus every dynamically
-  /// allocated vector and string reachable through it.
-  size_t calculateFileMetadataSize() const;
+  /// allocated vector and string reachable through it. The estimate
+  /// walks the inline struct tree and approximates the heap footprint;
+  /// it is not measured from the allocator and may over- or
+  /// under-report by a small fraction.
+  size_t estimateFileMetadataSize() const;
 
  private:
   const void* ptr_;

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -141,11 +141,7 @@ class ReaderBase {
       std::unique_ptr<dwio::common::BufferedInput>,
       const dwio::common::ReaderOptions& options);
 
-  virtual ~ReaderBase() {
-    if (thriftMemoryReported_ && thriftSize_ > 0) {
-      pool_.reportExternalFree(thriftSize_);
-    }
-  }
+  virtual ~ReaderBase();
 
   memory::MemoryPool& getMemoryPool() const {
     return pool_;
@@ -219,11 +215,7 @@ class ReaderBase {
   /// back to the pool and reduces the remaining tracked size accordingly.
   /// Called when parts of the footer (e.g. cleared row group columns) are
   /// released early, before ~ReaderBase frees the rest.
-  void releaseThriftBytes(size_t bytes) {
-    VELOX_CHECK_GE(thriftSize_, bytes);
-    pool_.reportExternalFree(bytes);
-    thriftSize_ -= bytes;
-  }
+  void releaseThriftBytes(size_t bytes);
 
  private:
   // Reads and parses file footer.
@@ -308,6 +300,18 @@ ReaderBase::ReaderBase(
     pool_.reportExternalAllocation(thriftSize_);
     thriftMemoryReported_ = true;
   }
+}
+
+ReaderBase::~ReaderBase() {
+  if (thriftMemoryReported_ && thriftSize_ > 0) {
+    pool_.reportExternalFree(thriftSize_);
+  }
+}
+
+void ReaderBase::releaseThriftBytes(size_t bytes) {
+  VELOX_CHECK_GE(thriftSize_, bytes);
+  pool_.reportExternalFree(bytes);
+  thriftSize_ -= bytes;
 }
 
 void ReaderBase::loadFileMetaData() {
@@ -1418,8 +1422,6 @@ class ParquetRowReader::Impl {
           // Measure the columns BEFORE clearing so we can release the matching
           // amount from the pool reservation that ReaderBase reported.
           if (readerBase_->isThriftMemoryReported()) {
-            freedThriftSize +=
-                rowGroups_[i].columns.size() * sizeof(thrift::ColumnChunk);
             for (const auto& column : rowGroups_[i].columns) {
               freedThriftSize +=
                   ColumnChunkMetaDataPtr(&column).calculateColumnMetadataSize();

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -360,7 +360,7 @@ void ReaderBase::loadFileMetaData() {
   fileMetaData_ = std::make_unique<thrift::FileMetaData>();
   fileMetaData_->read(thriftProtocol.get());
   if (footerLength > options().parquetFooterMemoryTrackingThreshold()) {
-    thriftSize_ = calculateFileMetadataSize(*fileMetaData_);
+    thriftSize_ = fileMetaData().calculateFileMetadataSize();
   }
 }
 
@@ -1421,7 +1421,8 @@ class ParquetRowReader::Impl {
             freedThriftSize +=
                 rowGroups_[i].columns.size() * sizeof(thrift::ColumnChunk);
             for (const auto& column : rowGroups_[i].columns) {
-              freedThriftSize += calculateColumnMetadataSize(column);
+              freedThriftSize +=
+                  ColumnChunkMetaDataPtr(&column).calculateColumnMetadataSize();
             }
           }
           rowGroups_[i].columns.clear();

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -141,7 +141,13 @@ class ReaderBase {
       std::unique_ptr<dwio::common::BufferedInput>,
       const dwio::common::ReaderOptions& options);
 
-  virtual ~ReaderBase() = default;
+  virtual ~ReaderBase() {
+    if (thriftSize_ > 0) {
+      if (thriftMemoryReported_) {
+        pool_.reportExternalFree(thriftSize_);
+      }
+    }
+  }
 
   memory::MemoryPool& getMemoryPool() const {
     return pool_;
@@ -203,6 +209,9 @@ class ReaderBase {
   /// Checks whether the specific row group has been loaded and
   /// the data still exists in the buffered inputs.
   bool isRowGroupBuffered(int32_t rowGroupIndex) const;
+  bool thriftMemoryReported_ = false;
+
+  size_t thriftSize_ = 0;
 
  private:
   // Reads and parses file footer.
@@ -316,6 +325,9 @@ void ReaderBase::loadFileMetaData() {
       thriftTransport);
   fileMetaData_ = std::make_unique<thrift::FileMetaData>();
   fileMetaData_->read(thriftProtocol.get());
+  if (footerLength > options().parquetFooterTrackThriftMemoryThreshold()) {
+    thriftSize_ = calculateFileMetadataSize(*fileMetaData_);
+  }
 }
 
 void ReaderBase::initializeSchema() {
@@ -1342,6 +1354,8 @@ class ParquetRowReader::Impl {
     }
 
     uint64_t rowNumber = 0;
+    size_t totalColumnsSize = 0;
+    size_t totalClearedColumns = 0;
     for (auto i = 0; i < rowGroups_.size(); i++) {
       VELOX_CHECK_GT(rowGroups_[i].columns.size(), 0);
       auto fileOffset =
@@ -1369,6 +1383,12 @@ class ParquetRowReader::Impl {
           // reduce the memory consumption. ColumnChunks consume the most
           // memory. Skip the 0th RowGroup as it is used by estimatedRowSize().
           rowGroups_[i].columns.clear();
+          if (readerBase_->thriftSize_ > 0) {
+            for (const auto& column : rowGroups_[i].columns) {
+              totalColumnsSize += calculateColumnMetadataSize(column);
+              totalClearedColumns++;
+            }
+          }
         }
         if (rowGroupInRange) {
           skippedStrides_++;
@@ -1376,6 +1396,14 @@ class ParquetRowReader::Impl {
       }
 
       rowNumber += rowGroups_[i].num_rows;
+    }
+
+    if (totalClearedColumns > 0 && readerBase_->thriftSize_ > 0) {
+      readerBase_->thriftSize_ -= totalColumnsSize;
+    }
+    if (readerBase_->thriftSize_ > 0) {
+      pool_.reportExternalAllocation(readerBase_->thriftSize_);
+      readerBase_->thriftMemoryReported_ = true;
     }
   }
 

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -142,10 +142,8 @@ class ReaderBase {
       const dwio::common::ReaderOptions& options);
 
   virtual ~ReaderBase() {
-    if (thriftSize_ > 0) {
-      if (thriftMemoryReported_) {
-        pool_.reportExternalFree(thriftSize_);
-      }
+    if (thriftMemoryReported_ && thriftSize_ > 0) {
+      pool_.reportExternalFree(thriftSize_);
     }
   }
 
@@ -209,9 +207,23 @@ class ReaderBase {
   /// Checks whether the specific row group has been loaded and
   /// the data still exists in the buffered inputs.
   bool isRowGroupBuffered(int32_t rowGroupIndex) const;
-  bool thriftMemoryReported_ = false;
 
-  size_t thriftSize_ = 0;
+  /// Returns true if the deserialized Thrift footer's memory has been
+  /// reported to the memory pool. False when the footer was smaller than
+  /// the tracking threshold, so no allocation was reported.
+  bool isThriftMemoryReported() const {
+    return thriftMemoryReported_;
+  }
+
+  /// Releases 'bytes' from the previously reported Thrift footer memory
+  /// back to the pool and reduces the remaining tracked size accordingly.
+  /// Called when parts of the footer (e.g. cleared row group columns) are
+  /// released early, before ~ReaderBase frees the rest.
+  void releaseThriftBytes(size_t bytes) {
+    VELOX_CHECK_GE(thriftSize_, bytes);
+    pool_.reportExternalFree(bytes);
+    thriftSize_ -= bytes;
+  }
 
  private:
   // Reads and parses file footer.
@@ -257,6 +269,18 @@ class ReaderBase {
   // Map from row group index to pre-created loading BufferedInput.
   std::unordered_map<uint32_t, std::shared_ptr<dwio::common::BufferedInput>>
       inputs_;
+
+  // Whether the deserialized Thrift footer's heap footprint has been
+  // reported to 'pool_'. Set once in the constructor after a successful
+  // reportExternalAllocation, and consulted by ~ReaderBase and
+  // releaseThriftBytes to decide whether the pool needs to be notified on
+  // release.
+  bool thriftMemoryReported_{false};
+
+  // Estimated bytes of heap memory held by 'fileMetaData_' that have been
+  // reported to 'pool_' and not yet released. Decreases as row group
+  // columns are cleared early; the remainder is released by ~ReaderBase.
+  size_t thriftSize_{0};
 };
 
 ReaderBase::ReaderBase(
@@ -335,7 +359,7 @@ void ReaderBase::loadFileMetaData() {
       thriftTransport);
   fileMetaData_ = std::make_unique<thrift::FileMetaData>();
   fileMetaData_->read(thriftProtocol.get());
-  if (footerLength > options().parquetFooterTrackThriftMemoryThreshold()) {
+  if (footerLength > options().parquetFooterMemoryTrackingThreshold()) {
     thriftSize_ = calculateFileMetadataSize(*fileMetaData_);
   }
 }
@@ -1393,7 +1417,7 @@ class ParquetRowReader::Impl {
           // memory. Skip the 0th RowGroup as it is used by estimatedRowSize().
           // Measure the columns BEFORE clearing so we can release the matching
           // amount from the pool reservation that ReaderBase reported.
-          if (readerBase_->thriftMemoryReported_) {
+          if (readerBase_->isThriftMemoryReported()) {
             freedThriftSize +=
                 rowGroups_[i].columns.size() * sizeof(thrift::ColumnChunk);
             for (const auto& column : rowGroups_[i].columns) {
@@ -1412,11 +1436,9 @@ class ParquetRowReader::Impl {
 
     if (freedThriftSize > 0) {
       // ReaderBase reported the full thrift footprint at construction. Release
-      // the portion we just freed by clearing skipped row groups, and shrink
-      // the recorded size so ~ReaderBase frees only the remaining bytes.
-      VELOX_CHECK_GE(readerBase_->thriftSize_, freedThriftSize);
-      pool_.reportExternalFree(freedThriftSize);
-      readerBase_->thriftSize_ -= freedThriftSize;
+      // the portion we just freed by clearing skipped row groups; the
+      // remainder is released by ~ReaderBase.
+      readerBase_->releaseThriftBytes(freedThriftSize);
     }
   }
 

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -1425,7 +1425,10 @@ class ParquetRowReader::Impl {
                   ColumnChunkMetaDataPtr(&column).calculateColumnMetadataSize();
             }
           }
-          rowGroups_[i].columns.clear();
+          // Swap-with-empty to actually release the vector's buffer; clear()
+          // would only destroy elements while retaining capacity, so the
+          // reported freed bytes would not match the memory actually returned.
+          rowGroups_[i].columns = {};
         }
         if (rowGroupInRange) {
           skippedStrides_++;

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -274,6 +274,16 @@ ReaderBase::ReaderBase(
   loadFileMetaData();
   initializeSchema();
   initializeVersion();
+
+  // Report the thrift footer reservation only after all other initialization
+  // succeeds. If a step before this throws, ~ReaderBase will not run, so a
+  // reportExternalAllocation made earlier in the constructor would leak.
+  // Doing it last keeps reportExternalAllocation/reportExternalFree paired
+  // through ~ReaderBase.
+  if (thriftSize_ > 0) {
+    pool_.reportExternalAllocation(thriftSize_);
+    thriftMemoryReported_ = true;
+  }
 }
 
 void ReaderBase::loadFileMetaData() {
@@ -1354,8 +1364,7 @@ class ParquetRowReader::Impl {
     }
 
     uint64_t rowNumber = 0;
-    size_t totalColumnsSize = 0;
-    size_t totalClearedColumns = 0;
+    size_t freedThriftSize = 0;
     for (auto i = 0; i < rowGroups_.size(); i++) {
       VELOX_CHECK_GT(rowGroups_[i].columns.size(), 0);
       auto fileOffset =
@@ -1382,13 +1391,16 @@ class ParquetRowReader::Impl {
           // Clear the metadata of row groups that are not read. This helps
           // reduce the memory consumption. ColumnChunks consume the most
           // memory. Skip the 0th RowGroup as it is used by estimatedRowSize().
-          rowGroups_[i].columns.clear();
-          if (readerBase_->thriftSize_ > 0) {
+          // Measure the columns BEFORE clearing so we can release the matching
+          // amount from the pool reservation that ReaderBase reported.
+          if (readerBase_->thriftMemoryReported_) {
+            freedThriftSize +=
+                rowGroups_[i].columns.size() * sizeof(thrift::ColumnChunk);
             for (const auto& column : rowGroups_[i].columns) {
-              totalColumnsSize += calculateColumnMetadataSize(column);
-              totalClearedColumns++;
+              freedThriftSize += calculateColumnMetadataSize(column);
             }
           }
+          rowGroups_[i].columns.clear();
         }
         if (rowGroupInRange) {
           skippedStrides_++;
@@ -1398,12 +1410,13 @@ class ParquetRowReader::Impl {
       rowNumber += rowGroups_[i].num_rows;
     }
 
-    if (totalClearedColumns > 0 && readerBase_->thriftSize_ > 0) {
-      readerBase_->thriftSize_ -= totalColumnsSize;
-    }
-    if (readerBase_->thriftSize_ > 0) {
-      pool_.reportExternalAllocation(readerBase_->thriftSize_);
-      readerBase_->thriftMemoryReported_ = true;
+    if (freedThriftSize > 0) {
+      // ReaderBase reported the full thrift footprint at construction. Release
+      // the portion we just freed by clearing skipped row groups, and shrink
+      // the recorded size so ~ReaderBase frees only the remaining bytes.
+      VELOX_CHECK_GE(readerBase_->thriftSize_, freedThriftSize);
+      pool_.reportExternalFree(freedThriftSize);
+      readerBase_->thriftSize_ -= freedThriftSize;
     }
   }
 

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -1521,7 +1521,7 @@ class ParquetRowReader::Impl {
   void updateRuntimeStats(dwio::common::RuntimeStatistics& stats) const {
     stats.skippedStrides += skippedStrides_;
     stats.processedStrides += rowGroupIds_.size();
-    stats.footerEstimatedBytes += readerBase_->initialThriftSize();
+    stats.parquetFooterEstimatedBytes += readerBase_->initialThriftSize();
     stats.columnReaderStats.pageLoadTimeNs.merge(
         columnReaderStats_.pageLoadTimeNs);
   }

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -211,6 +211,14 @@ class ReaderBase {
     return thriftMemoryReported_;
   }
 
+  /// Returns the estimated footer size reported to the pool at
+  /// construction. Unchanged by later releaseThriftBytes() calls, so it
+  /// reflects the initial estimate rather than the remaining reservation.
+  /// Zero when tracking was not engaged.
+  size_t initialThriftSize() const {
+    return initialThriftSize_;
+  }
+
   /// Releases 'bytes' from the previously reported Thrift footer memory
   /// back to the pool and reduces the remaining tracked size accordingly.
   /// Called when parts of the footer (e.g. cleared row group columns) are
@@ -273,6 +281,11 @@ class ReaderBase {
   // reported to 'pool_' and not yet released. Decreases as row group
   // columns are cleared early; the remainder is released by ~ReaderBase.
   size_t thriftSize_{0};
+
+  // The value of 'thriftSize_' at construction time, captured before any
+  // releaseThriftBytes() calls shrink it. Surfaced as a runtime stat so
+  // operators can compare the estimate against actual pool usage.
+  size_t initialThriftSize_{0};
 };
 
 ReaderBase::ReaderBase(
@@ -299,6 +312,7 @@ ReaderBase::ReaderBase(
   if (thriftSize_ > 0) {
     pool_.reportExternalAllocation(thriftSize_);
     thriftMemoryReported_ = true;
+    initialThriftSize_ = thriftSize_;
   }
 }
 
@@ -364,7 +378,7 @@ void ReaderBase::loadFileMetaData() {
   fileMetaData_ = std::make_unique<thrift::FileMetaData>();
   fileMetaData_->read(thriftProtocol.get());
   if (footerLength > options().parquetFooterMemoryTrackingThreshold()) {
-    thriftSize_ = fileMetaData().calculateFileMetadataSize();
+    thriftSize_ = fileMetaData().estimateFileMetadataSize();
   }
 }
 
@@ -1424,7 +1438,7 @@ class ParquetRowReader::Impl {
           if (readerBase_->isThriftMemoryReported()) {
             for (const auto& column : rowGroups_[i].columns) {
               freedThriftSize +=
-                  ColumnChunkMetaDataPtr(&column).calculateColumnMetadataSize();
+                  ColumnChunkMetaDataPtr(&column).estimateColumnMetadataSize();
             }
           }
           // Swap with a fresh empty vector to actually release the buffer.
@@ -1507,6 +1521,7 @@ class ParquetRowReader::Impl {
   void updateRuntimeStats(dwio::common::RuntimeStatistics& stats) const {
     stats.skippedStrides += skippedStrides_;
     stats.processedStrides += rowGroupIds_.size();
+    stats.footerEstimatedBytes += readerBase_->initialThriftSize();
     stats.columnReaderStats.pageLoadTimeNs.merge(
         columnReaderStats_.pageLoadTimeNs);
   }

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -1427,10 +1427,11 @@ class ParquetRowReader::Impl {
                   ColumnChunkMetaDataPtr(&column).calculateColumnMetadataSize();
             }
           }
-          // Swap-with-empty to actually release the vector's buffer; clear()
-          // would only destroy elements while retaining capacity, so the
-          // reported freed bytes would not match the memory actually returned.
-          rowGroups_[i].columns = {};
+          // Swap with a fresh empty vector to actually release the buffer.
+          // operator=({}) and clear() preserve capacity, so the bytes
+          // reported as freed would still be resident; only the
+          // swap-with-empty idiom guarantees the allocation is released.
+          std::vector<thrift::ColumnChunk>().swap(rowGroups_[i].columns);
         }
         if (rowGroupInRange) {
           skippedStrides_++;

--- a/velox/dwio/parquet/tests/reader/CMakeLists.txt
+++ b/velox/dwio/parquet/tests/reader/CMakeLists.txt
@@ -55,6 +55,14 @@ target_link_libraries(
 if(VELOX_ENABLE_BENCHMARKS)
   add_executable(velox_dwio_parquet_reader_benchmark ParquetReaderBenchmarkMain.cpp)
   target_link_libraries(velox_dwio_parquet_reader_benchmark velox_dwio_parquet_reader_benchmark_lib)
+
+  add_executable(velox_dwio_parquet_metadata_benchmark MetadataBenchmark.cpp)
+  target_link_libraries(
+    velox_dwio_parquet_metadata_benchmark
+    velox_dwio_native_parquet_reader
+    Folly::follybenchmark
+    Folly::folly
+  )
 endif()
 
 add_executable(

--- a/velox/dwio/parquet/tests/reader/CMakeLists.txt
+++ b/velox/dwio/parquet/tests/reader/CMakeLists.txt
@@ -63,6 +63,7 @@ add_executable(
   ParquetReaderWideningTest.cpp
   ParquetReaderBenchmarkTest.cpp
   BloomFilterTest.cpp
+  MetadataTest.cpp
 )
 add_test(
   NAME velox_dwio_parquet_reader_test

--- a/velox/dwio/parquet/tests/reader/CMakeLists.txt
+++ b/velox/dwio/parquet/tests/reader/CMakeLists.txt
@@ -57,12 +57,7 @@ if(VELOX_ENABLE_BENCHMARKS)
   target_link_libraries(velox_dwio_parquet_reader_benchmark velox_dwio_parquet_reader_benchmark_lib)
 
   add_executable(velox_dwio_parquet_metadata_benchmark MetadataBenchmark.cpp)
-  target_link_libraries(
-    velox_dwio_parquet_metadata_benchmark
-    velox_dwio_native_parquet_reader
-    Folly::follybenchmark
-    Folly::folly
-  )
+  target_link_libraries(velox_dwio_parquet_metadata_benchmark velox_dwio_native_parquet_reader)
 endif()
 
 add_executable(

--- a/velox/dwio/parquet/tests/reader/MetadataBenchmark.cpp
+++ b/velox/dwio/parquet/tests/reader/MetadataBenchmark.cpp
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-#include <folly/Benchmark.h>
-#include <folly/init/Init.h>
+#include <chrono>
+#include <cstdio>
+#include <string>
+#include <vector>
 
 #include "velox/dwio/parquet/reader/Metadata.h"
 #include "velox/dwio/parquet/thrift/ParquetThriftTypes.h"
@@ -74,38 +76,48 @@ thrift::FileMetaData makeFooter(size_t numColumns, size_t numRowGroups) {
   return metadata;
 }
 
-void runEstimate(size_t numColumns, size_t numRowGroups) {
-  folly::BenchmarkSuspender suspender;
+void run(const char* label, size_t numColumns, size_t numRowGroups, int iters) {
   auto footer = makeFooter(numColumns, numRowGroups);
   FileMetaDataPtr ptr(&footer);
-  suspender.dismiss();
-  auto bytes = ptr.estimateFileMetadataSize();
-  folly::doNotOptimizeAway(bytes);
+  // Warm caches.
+  for (int i = 0; i < std::max(1, iters / 10); ++i) {
+    auto bytes = ptr.estimateFileMetadataSize();
+    asm volatile("" : : "g"(bytes) : "memory");
+  }
+  auto start = std::chrono::steady_clock::now();
+  size_t total = 0;
+  for (int i = 0; i < iters; ++i) {
+    total += ptr.estimateFileMetadataSize();
+  }
+  auto end = std::chrono::steady_clock::now();
+  asm volatile("" : : "g"(total) : "memory");
+  auto totalNanos =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
+  double perCallNs = static_cast<double>(totalNanos) / iters;
+  // Reported MB matches what would be passed to reportExternalAllocation.
+  double estMb = ptr.estimateFileMetadataSize() / (1024.0 * 1024.0);
+  std::printf(
+      "%-10s columns=%-5zu row_groups=%-5zu chunks=%-9zu  per_call=%9.2f us  "
+      "estimate=%6.1f MB\n",
+      label,
+      numColumns,
+      numRowGroups,
+      numColumns * numRowGroups,
+      perCallNs / 1000.0,
+      estMb);
 }
 
 } // namespace
 
-// Mirrors the per-call cost of estimateFileMetadataSize() across
-// realistic footer shapes:
-//   small  - 10 columns x  4 row groups (typical narrow file)
-//   medium - 100 columns x 50 row groups
-//   wide   - 6879 columns x 147 row groups (the OOM pathology)
-BENCHMARK(estimateSmall) {
-  runEstimate(10, 4);
-}
-
-BENCHMARK(estimateMedium) {
-  runEstimate(100, 50);
-}
-
-BENCHMARK(estimateWide) {
-  runEstimate(6879, 147);
-}
-
 } // namespace facebook::velox::parquet
 
-int main(int argc, char** argv) {
-  folly::Init init{&argc, &argv};
-  folly::runBenchmarks();
+int main() {
+  using namespace facebook::velox::parquet;
+  std::printf(
+      "Per-call cost of estimateFileMetadataSize() across footer shapes.\n"
+      "Heap-payload sizes chosen to defeat SSO so heap dereferences are paid.\n\n");
+  run("small", 10, 4, 100'000);
+  run("medium", 100, 50, 5'000);
+  run("wide", 6879, 147, 20);
   return 0;
 }

--- a/velox/dwio/parquet/tests/reader/MetadataBenchmark.cpp
+++ b/velox/dwio/parquet/tests/reader/MetadataBenchmark.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "velox/dwio/parquet/reader/Metadata.h"
+#include "velox/dwio/parquet/thrift/ParquetThriftTypes.h"
+
+namespace facebook::velox::parquet {
+
+namespace {
+
+// Heap-allocated payload sizes representative of real footers: long
+// enough to defeat SSO so the walk pays for the heap dereferences,
+// short enough to keep the working set bounded.
+constexpr size_t kPathSegmentLen = 24;
+constexpr size_t kStatsValueLen = 32;
+
+thrift::ColumnChunk makeColumn(size_t pathDepth) {
+  thrift::ColumnChunk column;
+  std::vector<std::string> path;
+  path.reserve(pathDepth);
+  for (size_t i = 0; i < pathDepth; ++i) {
+    path.emplace_back(kPathSegmentLen, 'p');
+  }
+  column.meta_data.path_in_schema = std::move(path);
+  column.meta_data.encodings = {
+      thrift::Encoding::PLAIN,
+      thrift::Encoding::RLE,
+      thrift::Encoding::RLE_DICTIONARY,
+  };
+  column.meta_data.__isset.statistics = true;
+  column.meta_data.statistics.__set_min(std::string(kStatsValueLen, 'm'));
+  column.meta_data.statistics.__set_max(std::string(kStatsValueLen, 'M'));
+  column.meta_data.statistics.__set_min_value(std::string(kStatsValueLen, 'a'));
+  column.meta_data.statistics.__set_max_value(std::string(kStatsValueLen, 'z'));
+  column.meta_data.num_values = 1'000'000;
+  column.meta_data.total_compressed_size = 1 << 20;
+  column.meta_data.total_uncompressed_size = 2 << 20;
+  return column;
+}
+
+thrift::FileMetaData makeFooter(size_t numColumns, size_t numRowGroups) {
+  thrift::FileMetaData metadata;
+  metadata.created_by = "velox-benchmark";
+  metadata.num_rows = static_cast<int64_t>(numColumns) * numRowGroups;
+  metadata.schema.resize(numColumns + 1);
+  metadata.schema[0].name = "root";
+  metadata.schema[0].num_children = static_cast<int32_t>(numColumns);
+  for (size_t i = 0; i < numColumns; ++i) {
+    metadata.schema[i + 1].name = "col_" + std::to_string(i);
+  }
+  metadata.row_groups.resize(numRowGroups);
+  for (auto& rowGroup : metadata.row_groups) {
+    rowGroup.columns.reserve(numColumns);
+    for (size_t i = 0; i < numColumns; ++i) {
+      rowGroup.columns.push_back(makeColumn(/*pathDepth=*/2));
+    }
+  }
+  return metadata;
+}
+
+void runEstimate(size_t numColumns, size_t numRowGroups) {
+  folly::BenchmarkSuspender suspender;
+  auto footer = makeFooter(numColumns, numRowGroups);
+  FileMetaDataPtr ptr(&footer);
+  suspender.dismiss();
+  auto bytes = ptr.estimateFileMetadataSize();
+  folly::doNotOptimizeAway(bytes);
+}
+
+} // namespace
+
+// Mirrors the per-call cost of estimateFileMetadataSize() across
+// realistic footer shapes:
+//   small  - 10 columns x  4 row groups (typical narrow file)
+//   medium - 100 columns x 50 row groups
+//   wide   - 6879 columns x 147 row groups (the OOM pathology)
+BENCHMARK(estimateSmall) {
+  runEstimate(10, 4);
+}
+
+BENCHMARK(estimateMedium) {
+  runEstimate(100, 50);
+}
+
+BENCHMARK(estimateWide) {
+  runEstimate(6879, 147);
+}
+
+} // namespace facebook::velox::parquet
+
+int main(int argc, char** argv) {
+  folly::Init init{&argc, &argv};
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/dwio/parquet/tests/reader/MetadataTest.cpp
+++ b/velox/dwio/parquet/tests/reader/MetadataTest.cpp
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/parquet/reader/Metadata.h"
+
+#include <gtest/gtest.h>
+#include "velox/dwio/parquet/thrift/ParquetThriftTypes.h"
+
+namespace facebook::velox::parquet {
+
+namespace {
+
+// Long enough to defeat the small-string optimization on libstdc++,
+// libc++, and MSVC, so heap accounting is exercised.
+const std::string kLongString(64, 'x');
+
+size_t estimateColumnSize(const thrift::ColumnChunk& column) {
+  return ColumnChunkMetaDataPtr(&column).estimateColumnMetadataSize();
+}
+
+size_t estimateFileSize(const thrift::FileMetaData& metadata) {
+  return FileMetaDataPtr(&metadata).estimateFileMetadataSize();
+}
+
+} // namespace
+
+// An empty ColumnChunk has no heap-backed payloads; the estimate must
+// equal sizeof(thrift::ColumnChunk) and never double-count inline
+// sub-structs like ColumnMetaData or ColumnCryptoMetaData.
+TEST(MetadataTest, emptyColumnChunkIsSizeofOnly) {
+  thrift::ColumnChunk column;
+  EXPECT_EQ(estimateColumnSize(column), sizeof(thrift::ColumnChunk));
+}
+
+// file_path is a heap-allocated string on ColumnChunk; setting it must
+// add exactly the string capacity.
+TEST(MetadataTest, columnChunkAccountsFilePath) {
+  thrift::ColumnChunk column;
+  column.__set_file_path(kLongString);
+  EXPECT_EQ(
+      estimateColumnSize(column),
+      sizeof(thrift::ColumnChunk) + column.file_path.capacity());
+}
+
+// SSO strings live inline in the std::string object, which is already
+// covered by sizeof(ColumnChunk). The estimator must not add their
+// capacity on top.
+TEST(MetadataTest, columnChunkSkipsSsoFilePath) {
+  thrift::ColumnChunk column;
+  // Short string fits in SSO buffer on all supported standard libraries.
+  column.__set_file_path("short");
+  EXPECT_EQ(estimateColumnSize(column), sizeof(thrift::ColumnChunk));
+}
+
+// encrypted_column_metadata is a heap-allocated string on ColumnChunk.
+TEST(MetadataTest, columnChunkAccountsEncryptedColumnMetadata) {
+  thrift::ColumnChunk column;
+  column.__set_encrypted_column_metadata(kLongString);
+  EXPECT_EQ(
+      estimateColumnSize(column),
+      sizeof(thrift::ColumnChunk) +
+          column.encrypted_column_metadata.capacity());
+}
+
+// meta_data.encodings is a heap-allocated vector; each element is a
+// fixed-size enum.
+TEST(MetadataTest, columnChunkAccountsEncodings) {
+  thrift::ColumnChunk column;
+  column.meta_data.encodings.push_back(thrift::Encoding::PLAIN);
+  column.meta_data.encodings.push_back(thrift::Encoding::RLE);
+  EXPECT_EQ(
+      estimateColumnSize(column),
+      sizeof(thrift::ColumnChunk) + 2 * sizeof(thrift::Encoding::type));
+}
+
+// meta_data.path_in_schema is a heap-allocated vector of strings; the
+// vector buffer plus the heap part of each string must be counted.
+TEST(MetadataTest, columnChunkAccountsPathInSchema) {
+  thrift::ColumnChunk column;
+  column.meta_data.path_in_schema.push_back(kLongString);
+  column.meta_data.path_in_schema.push_back(kLongString);
+  size_t expected = sizeof(thrift::ColumnChunk) +
+      column.meta_data.path_in_schema.size() * sizeof(std::string);
+  for (const auto& path : column.meta_data.path_in_schema) {
+    expected += path.capacity();
+  }
+  EXPECT_EQ(estimateColumnSize(column), expected);
+}
+
+// meta_data.key_value_metadata: each KeyValue holds two heap strings.
+TEST(MetadataTest, columnChunkAccountsKeyValueMetadata) {
+  thrift::ColumnChunk column;
+  thrift::KeyValue kv;
+  kv.key = kLongString;
+  kv.value = kLongString;
+  column.meta_data.key_value_metadata.push_back(kv);
+  size_t expected = sizeof(thrift::ColumnChunk) +
+      column.meta_data.key_value_metadata.size() * sizeof(thrift::KeyValue) +
+      column.meta_data.key_value_metadata[0].key.capacity() +
+      column.meta_data.key_value_metadata[0].value.capacity();
+  EXPECT_EQ(estimateColumnSize(column), expected);
+}
+
+// Statistics is an inline member of ColumnMetaData; only its heap-backed
+// min/max strings should be added. The struct itself must not be
+// double-counted on top of sizeof(ColumnChunk).
+TEST(MetadataTest, columnChunkAccountsStatisticsHeapOnly) {
+  thrift::ColumnChunk column;
+  column.meta_data.__isset.statistics = true;
+  column.meta_data.statistics.__set_min(kLongString);
+  column.meta_data.statistics.__set_max(kLongString);
+  column.meta_data.statistics.__set_min_value(kLongString);
+  column.meta_data.statistics.__set_max_value(kLongString);
+  const auto& stats = column.meta_data.statistics;
+  size_t expected = sizeof(thrift::ColumnChunk) + stats.min.capacity() +
+      stats.max.capacity() + stats.min_value.capacity() +
+      stats.max_value.capacity();
+  EXPECT_EQ(estimateColumnSize(column), expected);
+}
+
+// Statistics with no isset must contribute nothing beyond sizeof(CC).
+TEST(MetadataTest, columnChunkSkipsStatisticsWhenNotSet) {
+  thrift::ColumnChunk column;
+  column.meta_data.__isset.statistics = false;
+  EXPECT_EQ(estimateColumnSize(column), sizeof(thrift::ColumnChunk));
+}
+
+// An empty FileMetaData estimate must equal sizeof(thrift::FileMetaData)
+// and never double-count inline sub-structs.
+TEST(MetadataTest, emptyFileMetaDataIsSizeofOnly) {
+  thrift::FileMetaData metadata;
+  EXPECT_EQ(estimateFileSize(metadata), sizeof(thrift::FileMetaData));
+}
+
+// Schema is a heap vector of SchemaElement; each element's name string
+// must be counted on top of the inline element bytes.
+TEST(MetadataTest, fileMetaDataAccountsSchema) {
+  thrift::FileMetaData metadata;
+  thrift::SchemaElement element;
+  element.name = kLongString;
+  metadata.schema.push_back(element);
+  metadata.schema.push_back(element);
+  size_t expected = sizeof(thrift::FileMetaData) +
+      metadata.schema.size() * sizeof(thrift::SchemaElement) +
+      metadata.schema[0].name.capacity() + metadata.schema[1].name.capacity();
+  EXPECT_EQ(estimateFileSize(metadata), expected);
+}
+
+// Each RowGroup's columns vector and its element heap payloads must
+// flow into the file-level estimate.
+TEST(MetadataTest, fileMetaDataAccountsRowGroupColumns) {
+  thrift::FileMetaData metadata;
+  thrift::RowGroup rowGroup;
+  thrift::ColumnChunk column;
+  column.__set_file_path(kLongString);
+  rowGroup.columns.push_back(column);
+  rowGroup.columns.push_back(column);
+  metadata.row_groups.push_back(rowGroup);
+  size_t expected = sizeof(thrift::FileMetaData) +
+      metadata.row_groups.size() * sizeof(thrift::RowGroup);
+  for (const auto& group : metadata.row_groups) {
+    for (const auto& col : group.columns) {
+      expected += estimateColumnSize(col);
+    }
+  }
+  EXPECT_EQ(estimateFileSize(metadata), expected);
+}
+
+// created_by is a heap string on FileMetaData.
+TEST(MetadataTest, fileMetaDataAccountsCreatedBy) {
+  thrift::FileMetaData metadata;
+  metadata.created_by = kLongString;
+  EXPECT_EQ(
+      estimateFileSize(metadata),
+      sizeof(thrift::FileMetaData) + metadata.created_by.capacity());
+}
+
+// key_value_metadata uses the same per-element accounting as on
+// ColumnChunk.
+TEST(MetadataTest, fileMetaDataAccountsKeyValueMetadata) {
+  thrift::FileMetaData metadata;
+  thrift::KeyValue kv;
+  kv.key = kLongString;
+  kv.value = kLongString;
+  metadata.key_value_metadata.push_back(kv);
+  size_t expected = sizeof(thrift::FileMetaData) +
+      metadata.key_value_metadata.size() * sizeof(thrift::KeyValue) +
+      metadata.key_value_metadata[0].key.capacity() +
+      metadata.key_value_metadata[0].value.capacity();
+  EXPECT_EQ(estimateFileSize(metadata), expected);
+}
+
+// column_orders is a fixed-size element vector; no string payloads.
+TEST(MetadataTest, fileMetaDataAccountsColumnOrders) {
+  thrift::FileMetaData metadata;
+  metadata.column_orders.emplace_back();
+  metadata.column_orders.emplace_back();
+  EXPECT_EQ(
+      estimateFileSize(metadata),
+      sizeof(thrift::FileMetaData) +
+          metadata.column_orders.size() * sizeof(thrift::ColumnOrder));
+}
+
+// footer_signing_key_metadata is a heap string on FileMetaData.
+TEST(MetadataTest, fileMetaDataAccountsFooterSigningKey) {
+  thrift::FileMetaData metadata;
+  metadata.footer_signing_key_metadata = kLongString;
+  EXPECT_EQ(
+      estimateFileSize(metadata),
+      sizeof(thrift::FileMetaData) +
+          metadata.footer_signing_key_metadata.capacity());
+}
+
+} // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -2187,24 +2187,28 @@ TEST_F(ParquetReaderTest, thriftMemoryTracking) {
 }
 
 TEST_F(ParquetReaderTest, thriftMemoryNotTrackedByDefault) {
-  // Verifies that the production default (no threshold set) leaves the
-  // pool untouched: no allocation is reported and ~ReaderBase has nothing
-  // to release.
+  // Verifies that the production default (no threshold set) does not engage
+  // the external allocation tracking path: no reportExternalAllocation is
+  // made, and ~ReaderBase has nothing to release.
   const std::string sample(getExampleFilePath("sample.parquet"));
 
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
   readerOptions.setDataIoStats(dataIoStats_);
   readerOptions.setMetadataIoStats(metadataIoStats_);
   // Default threshold (uint64::max) leaves tracking disabled.
-  const auto initialUsage = leafPool_->usedBytes();
+  const auto initialExternalAllocs = leafPool_->stats().numExternalAllocs;
   {
     auto reader = createReader(sample, readerOptions);
     auto rowReaderOpts = getReaderOpts(sampleSchema());
     rowReaderOpts.setScanSpec(makeScanSpec(sampleSchema()));
     auto rowReader = reader->createRowReader(rowReaderOpts);
-    EXPECT_EQ(leafPool_->usedBytes(), initialUsage);
+    // No external allocation was reported by the Thrift footer path even
+    // though the reader and row reader were fully constructed.
+    EXPECT_EQ(leafPool_->stats().numExternalAllocs, initialExternalAllocs);
   }
-  EXPECT_EQ(leafPool_->usedBytes(), initialUsage);
+  // And no external free either, since none was reported.
+  EXPECT_EQ(leafPool_->stats().numExternalAllocs, initialExternalAllocs);
+  EXPECT_EQ(leafPool_->stats().numExternalFrees, 0);
 }
 
 TEST_F(ParquetReaderTest, thriftMemoryReleasedForSkippedRowGroups) {

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -1902,7 +1902,6 @@ TEST_F(ParquetReaderTest, readerWithSchema) {
   auto buffer = std::make_unique<dwio::common::BufferedInput>(
       file, readerOptions.memoryPool());
   ParquetReader reader(std::move(buffer), readerOptions);
-
   EXPECT_EQ(reader.rowType()->toString(), schema->toString());
 }
 
@@ -2137,4 +2136,38 @@ TEST_F(ParquetReaderTest, readTimeWithMultipleColumns) {
   auto rowReader = reader->createRowReader(rowReaderOpts);
 
   assertReadWithReaderAndExpected(rowType, *rowReader, data, *leafPool_);
+}
+
+TEST_F(ParquetReaderTest, thriftMemoryTracking) {
+  // Verifies that when the footer size exceeds the configured threshold,
+  // memory for the deserialized Thrift footer is reported to the pool when
+  // the row reader is created and released when the reader is destroyed.
+  const std::string sample(getExampleFilePath("sample.parquet"));
+
+  dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  // 1-byte threshold forces memory tracking to engage for any footer.
+  readerOptions.setParquetFooterTrackThriftMemoryThreshold(1);
+  const auto initialUsage = leafPool_->usedBytes();
+  {
+    auto reader = createReader(sample, readerOptions);
+    EXPECT_EQ(reader->numberOfRows(), 20ULL);
+    auto rowReaderOpts = getReaderOpts(sampleSchema());
+    rowReaderOpts.setScanSpec(makeScanSpec(sampleSchema()));
+    auto rowReader = reader->createRowReader(rowReaderOpts);
+
+    // After row reader creation, the Thrift footer memory has been reported.
+    const auto memoryAfterRowReader = leafPool_->usedBytes();
+    EXPECT_GT(memoryAfterRowReader, initialUsage);
+
+    auto result = BaseVector::create(sampleSchema(), 0, leafPool_.get());
+    rowReader->next(10, result);
+    EXPECT_EQ(result->size(), 10);
+
+    // Memory remains reported throughout reading.
+    EXPECT_GE(leafPool_->usedBytes(), memoryAfterRowReader);
+  }
+
+  // ~ReaderBase() releases the reported memory, returning to baseline.
+  EXPECT_EQ(leafPool_->usedBytes(), initialUsage);
 }

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -2139,10 +2139,10 @@ TEST_F(ParquetReaderTest, readTimeWithMultipleColumns) {
   assertReadWithReaderAndExpected(rowType, *rowReader, data, *leafPool_);
 }
 
+// Verifies that when the footer size exceeds the configured threshold, memory
+// for the deserialized Thrift footer is reported to the pool when the row
+// reader is created and released when the reader is destroyed.
 TEST_F(ParquetReaderTest, thriftMemoryTracking) {
-  // Verifies that when the footer size exceeds the configured threshold,
-  // memory for the deserialized Thrift footer is reported to the pool when
-  // the row reader is created and released when the reader is destroyed.
   const std::string sample(getExampleFilePath("sample.parquet"));
 
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
@@ -2158,13 +2158,10 @@ TEST_F(ParquetReaderTest, thriftMemoryTracking) {
     rowReaderOpts.setScanSpec(makeScanSpec(sampleSchema()));
     auto rowReader = reader->createRowReader(rowReaderOpts);
 
-    // After row reader creation, the Thrift footer memory has been reported.
-    const auto memoryAfterRowReader = leafPool_->usedBytes();
-    EXPECT_GT(memoryAfterRowReader, initialUsage);
-
     // The reported footprint must at least cover the FileMetaData struct
     // itself plus one ColumnChunk per (row group * column) — anything smaller
     // means the estimator is not accounting for the per-row-group payload.
+    const auto memoryAfterRowReader = leafPool_->usedBytes();
     const auto reportedBytes = memoryAfterRowReader - initialUsage;
     const auto numRowGroups = reader->fileMetaData().numRowGroups();
     EXPECT_GT(numRowGroups, 0);
@@ -2186,10 +2183,50 @@ TEST_F(ParquetReaderTest, thriftMemoryTracking) {
   EXPECT_EQ(leafPool_->usedBytes(), initialUsage);
 }
 
+// Verifies that the ParquetReader, not the RowReader, owns the tracked
+// footer memory: destroying a RowReader leaves the pool reservation
+// intact, and creating additional RowReaders does not double-report.
+TEST_F(ParquetReaderTest, thriftMemoryOwnedByReader) {
+  const std::string sample(getExampleFilePath("sample.parquet"));
+
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
+  readerOptions.setParquetFooterMemoryTrackingThreshold(1);
+  const auto initialAllocs = leafPool_->stats().numExternalAllocs;
+  const auto initialFrees = leafPool_->stats().numExternalFrees;
+  {
+    auto reader = createReader(sample, readerOptions);
+    // The reader's constructor makes exactly one external allocation.
+    EXPECT_EQ(leafPool_->stats().numExternalAllocs, initialAllocs + 1);
+    EXPECT_EQ(leafPool_->stats().numExternalFrees, initialFrees);
+
+    {
+      auto rowReaderOpts = getReaderOpts(sampleSchema());
+      rowReaderOpts.setScanSpec(makeScanSpec(sampleSchema()));
+      auto rowReader = reader->createRowReader(rowReaderOpts);
+    }
+    // Creating and destroying a row reader must not touch the external
+    // allocation accounting — the reader owns it.
+    EXPECT_EQ(leafPool_->stats().numExternalAllocs, initialAllocs + 1);
+    EXPECT_EQ(leafPool_->stats().numExternalFrees, initialFrees);
+
+    // A second row reader on the same reader must not re-report the footer.
+    auto rowReaderOpts = getReaderOpts(sampleSchema());
+    rowReaderOpts.setScanSpec(makeScanSpec(sampleSchema()));
+    auto rowReader2 = reader->createRowReader(rowReaderOpts);
+    EXPECT_EQ(leafPool_->stats().numExternalAllocs, initialAllocs + 1);
+    EXPECT_EQ(leafPool_->stats().numExternalFrees, initialFrees);
+  }
+  // The reader's destruction releases the reservation with one external free.
+  EXPECT_EQ(leafPool_->stats().numExternalAllocs, initialAllocs + 1);
+  EXPECT_EQ(leafPool_->stats().numExternalFrees, initialFrees + 1);
+}
+
+// Verifies that the production default (no threshold set) does not engage
+// the external allocation tracking path: no reportExternalAllocation is
+// made, and ~ReaderBase has nothing to release.
 TEST_F(ParquetReaderTest, thriftMemoryNotTrackedByDefault) {
-  // Verifies that the production default (no threshold set) does not engage
-  // the external allocation tracking path: no reportExternalAllocation is
-  // made, and ~ReaderBase has nothing to release.
   const std::string sample(getExampleFilePath("sample.parquet"));
 
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
@@ -2211,10 +2248,10 @@ TEST_F(ParquetReaderTest, thriftMemoryNotTrackedByDefault) {
   EXPECT_EQ(leafPool_->stats().numExternalFrees, 0);
 }
 
+// Verifies that when row groups are skipped via the scan range, the portion
+// of the Thrift footer memory belonging to those row groups is released back
+// to the pool when the row reader runs filterRowGroups.
 TEST_F(ParquetReaderTest, thriftMemoryReleasedForSkippedRowGroups) {
-  // Verifies that when row groups are skipped via the scan range, the
-  // portion of the Thrift footer memory belonging to those row groups is
-  // released back to the pool when the row reader runs filterRowGroups.
   const auto rowType = ROW({"id"}, {BIGINT()});
   const std::string sample(getExampleFilePath("multiple_row_groups.parquet"));
 

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -2232,6 +2232,52 @@ TEST_F(ParquetReaderTest, thriftMemoryOwnedByReader) {
   EXPECT_GE(leafPool_->stats().numExternalFrees, initialFrees + 1);
 }
 
+// Verifies that the estimated footer size is surfaced via the per-scan
+// runtime stat, and appears in the runtime-metric map for operator
+// stats consumers.
+TEST_F(ParquetReaderTest, thriftMemoryRuntimeStat) {
+  const std::string sample(getExampleFilePath("sample.parquet"));
+  auto readerOptions = makeThriftTrackingReaderOptions();
+  auto reader = createReader(sample, readerOptions);
+  auto rowReaderOpts = getReaderOpts(sampleSchema());
+  rowReaderOpts.setScanSpec(makeScanSpec(sampleSchema()));
+  auto rowReader = reader->createRowReader(rowReaderOpts);
+
+  dwio::common::RuntimeStatistics stats;
+  rowReader->updateRuntimeStats(stats);
+  EXPECT_GT(stats.parquetFooterEstimatedBytes, 0);
+
+  auto metrics = stats.toRuntimeMetricMap();
+  ASSERT_TRUE(metrics.count("parquetFooterEstimatedBytes"));
+  EXPECT_EQ(
+      metrics["parquetFooterEstimatedBytes"].sum,
+      stats.parquetFooterEstimatedBytes);
+  EXPECT_EQ(
+      metrics["parquetFooterEstimatedBytes"].unit,
+      RuntimeCounter::Unit::kBytes);
+}
+
+// Verifies that without tracking the runtime stat stays at zero and
+// the metric is not emitted in the metric map (kept off the operator
+// stats panel for non-tracking scans).
+TEST_F(ParquetReaderTest, thriftMemoryRuntimeStatAbsentWithoutTracking) {
+  const std::string sample(getExampleFilePath("sample.parquet"));
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
+  auto reader = createReader(sample, readerOptions);
+  auto rowReaderOpts = getReaderOpts(sampleSchema());
+  rowReaderOpts.setScanSpec(makeScanSpec(sampleSchema()));
+  auto rowReader = reader->createRowReader(rowReaderOpts);
+
+  dwio::common::RuntimeStatistics stats;
+  rowReader->updateRuntimeStats(stats);
+  EXPECT_EQ(stats.parquetFooterEstimatedBytes, 0);
+
+  auto metrics = stats.toRuntimeMetricMap();
+  EXPECT_EQ(metrics.count("parquetFooterEstimatedBytes"), 0);
+}
+
 // Verifies that without setting the threshold the tracking path is
 // disabled: no external allocation is reported, and ~ReaderBase has
 // nothing to release.

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -2147,7 +2147,7 @@ TEST_F(ParquetReaderTest, thriftMemoryTracking) {
   dwio::common::ReaderOptions readerOptions{
       leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
   // 1-byte threshold forces memory tracking to engage for any footer.
-  readerOptions.setParquetFooterTrackThriftMemoryThreshold(1);
+  readerOptions.setParquetFooterMemoryTrackingThreshold(1);
   const auto initialUsage = leafPool_->usedBytes();
   {
     auto reader = createReader(sample, readerOptions);
@@ -2160,6 +2160,17 @@ TEST_F(ParquetReaderTest, thriftMemoryTracking) {
     const auto memoryAfterRowReader = leafPool_->usedBytes();
     EXPECT_GT(memoryAfterRowReader, initialUsage);
 
+    // The reported footprint must at least cover the FileMetaData struct
+    // itself plus one ColumnChunk per row group * column — anything smaller
+    // means the estimator is not accounting for the per-row-group payload.
+    const auto reportedBytes = memoryAfterRowReader - initialUsage;
+    const auto numRowGroups = reader->fileMetaData().numRowGroups();
+    EXPECT_GT(numRowGroups, 0);
+    EXPECT_GE(
+        reportedBytes,
+        sizeof(thrift::FileMetaData) +
+            numRowGroups * sizeof(thrift::ColumnChunk));
+
     auto result = BaseVector::create(sampleSchema(), 0, leafPool_.get());
     rowReader->next(10, result);
     EXPECT_EQ(result->size(), 10);
@@ -2169,5 +2180,47 @@ TEST_F(ParquetReaderTest, thriftMemoryTracking) {
   }
 
   // ~ReaderBase() releases the reported memory, returning to baseline.
+  EXPECT_EQ(leafPool_->usedBytes(), initialUsage);
+}
+
+TEST_F(ParquetReaderTest, thriftMemoryReleasedForSkippedRowGroups) {
+  // Verifies that when row groups are skipped via the scan range, the
+  // portion of the Thrift footer memory belonging to those row groups is
+  // released back to the pool when the row reader runs filterRowGroups.
+  const auto rowType = ROW({"id"}, {BIGINT()});
+  const std::string sample(getExampleFilePath("multiple_row_groups.parquet"));
+
+  dwio::common::ReaderOptions readerOptions{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  // 1-byte threshold forces memory tracking to engage for any footer.
+  readerOptions.setParquetFooterMemoryTrackingThreshold(1);
+  const auto initialUsage = leafPool_->usedBytes();
+  {
+    auto reader = createReader(sample, readerOptions);
+    const auto numRowGroups = reader->fileMetaData().numRowGroups();
+    ASSERT_GT(numRowGroups, 1);
+
+    // After reader construction, the full footer footprint is reported.
+    const auto memoryAfterReader = leafPool_->usedBytes();
+    EXPECT_GT(memoryAfterReader, initialUsage);
+
+    // Limit the scan range to keep only row group 0; row groups 1+ fall
+    // outside the range and get cleared by filterRowGroups().
+    const auto secondRowGroupOffset =
+        reader->fileMetaData().rowGroup(1).fileOffset();
+    ASSERT_GT(secondRowGroupOffset, 0);
+
+    RowReaderOptions rowReaderOpts;
+    rowReaderOpts.setScanSpec(makeScanSpec(rowType));
+    rowReaderOpts.range(0, secondRowGroupOffset);
+    auto rowReader = reader->createRowReader(rowReaderOpts);
+
+    // The cleared row groups' bytes must have been released to the pool.
+    EXPECT_LT(leafPool_->usedBytes(), memoryAfterReader);
+    // Row group 0 is preserved, so some memory remains reported.
+    EXPECT_GT(leafPool_->usedBytes(), initialUsage);
+  }
+
+  // ~ReaderBase() releases the remaining reported memory.
   EXPECT_EQ(leafPool_->usedBytes(), initialUsage);
 }

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -2184,8 +2184,9 @@ TEST_F(ParquetReaderTest, thriftMemoryTracking) {
 }
 
 // Verifies that the ParquetReader, not the RowReader, owns the tracked
-// footer memory: destroying a RowReader leaves the pool reservation
-// intact, and creating additional RowReaders does not double-report.
+// footer memory: creating and destroying RowReaders does not touch the
+// external allocation accounting, and creating additional RowReaders
+// does not re-report the footer.
 TEST_F(ParquetReaderTest, thriftMemoryOwnedByReader) {
   const std::string sample(getExampleFilePath("sample.parquet"));
 
@@ -2205,15 +2206,21 @@ TEST_F(ParquetReaderTest, thriftMemoryOwnedByReader) {
       auto rowReaderOpts = getReaderOpts(sampleSchema());
       rowReaderOpts.setScanSpec(makeScanSpec(sampleSchema()));
       auto rowReader = reader->createRowReader(rowReaderOpts);
+      // Creating a row reader must not touch the external allocation
+      // accounting — the reader owns it.
+      EXPECT_EQ(leafPool_->stats().numExternalAllocs, initialAllocs + 1);
+      EXPECT_EQ(leafPool_->stats().numExternalFrees, initialFrees);
     }
-    // Creating and destroying a row reader must not touch the external
-    // allocation accounting — the reader owns it.
+    // Destroying the row reader must not release the reservation either.
     EXPECT_EQ(leafPool_->stats().numExternalAllocs, initialAllocs + 1);
     EXPECT_EQ(leafPool_->stats().numExternalFrees, initialFrees);
 
-    // A second row reader on the same reader must not re-report the footer.
+    // A second row reader configured with an out-of-file scan range matches
+    // no row groups, so it does not attempt to prefetch. It must not
+    // re-report the footer or release the reservation.
     auto rowReaderOpts = getReaderOpts(sampleSchema());
     rowReaderOpts.setScanSpec(makeScanSpec(sampleSchema()));
+    rowReaderOpts.range(0, 1);
     auto rowReader2 = reader->createRowReader(rowReaderOpts);
     EXPECT_EQ(leafPool_->stats().numExternalAllocs, initialAllocs + 1);
     EXPECT_EQ(leafPool_->stats().numExternalFrees, initialFrees);

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -2163,15 +2163,16 @@ TEST_F(ParquetReaderTest, thriftMemoryTracking) {
     EXPECT_GT(memoryAfterRowReader, initialUsage);
 
     // The reported footprint must at least cover the FileMetaData struct
-    // itself plus one ColumnChunk per row group * column — anything smaller
+    // itself plus one ColumnChunk per (row group * column) — anything smaller
     // means the estimator is not accounting for the per-row-group payload.
     const auto reportedBytes = memoryAfterRowReader - initialUsage;
     const auto numRowGroups = reader->fileMetaData().numRowGroups();
     EXPECT_GT(numRowGroups, 0);
+    const auto numColumns = sampleSchema()->size();
     EXPECT_GE(
         reportedBytes,
         sizeof(thrift::FileMetaData) +
-            numRowGroups * sizeof(thrift::ColumnChunk));
+            numRowGroups * numColumns * sizeof(thrift::ColumnChunk));
 
     auto result = BaseVector::create(sampleSchema(), 0, leafPool_.get());
     rowReader->next(10, result);
@@ -2182,6 +2183,27 @@ TEST_F(ParquetReaderTest, thriftMemoryTracking) {
   }
 
   // ~ReaderBase() releases the reported memory, returning to baseline.
+  EXPECT_EQ(leafPool_->usedBytes(), initialUsage);
+}
+
+TEST_F(ParquetReaderTest, thriftMemoryNotTrackedByDefault) {
+  // Verifies that the production default (no threshold set) leaves the
+  // pool untouched: no allocation is reported and ~ReaderBase has nothing
+  // to release.
+  const std::string sample(getExampleFilePath("sample.parquet"));
+
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
+  // Default threshold (uint64::max) leaves tracking disabled.
+  const auto initialUsage = leafPool_->usedBytes();
+  {
+    auto reader = createReader(sample, readerOptions);
+    auto rowReaderOpts = getReaderOpts(sampleSchema());
+    rowReaderOpts.setScanSpec(makeScanSpec(sampleSchema()));
+    auto rowReader = reader->createRowReader(rowReaderOpts);
+    EXPECT_EQ(leafPool_->usedBytes(), initialUsage);
+  }
   EXPECT_EQ(leafPool_->usedBytes(), initialUsage);
 }
 

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -70,6 +70,16 @@ class ParquetReaderTest : public ParquetTestBase {
     assertReadWithReaderAndFilters(
         std::move(reader), fileName, fileSchema, std::move(filters), expected);
   }
+
+  // Builds ReaderOptions with the Parquet thrift footer-memory tracking
+  // path enabled by a 1-byte threshold so any footer engages tracking.
+  dwio::common::ReaderOptions makeThriftTrackingReaderOptions() {
+    dwio::common::ReaderOptions readerOptions(leafPool_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
+    readerOptions.setParquetFooterMemoryTrackingThreshold(1);
+    return readerOptions;
+  }
 };
 
 TEST_F(ParquetReaderTest, parseSample) {
@@ -2144,12 +2154,7 @@ TEST_F(ParquetReaderTest, readTimeWithMultipleColumns) {
 // reader is created and released when the reader is destroyed.
 TEST_F(ParquetReaderTest, thriftMemoryTracking) {
   const std::string sample(getExampleFilePath("sample.parquet"));
-
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
-  // 1-byte threshold forces memory tracking to engage for any footer.
-  readerOptions.setParquetFooterMemoryTrackingThreshold(1);
+  auto readerOptions = makeThriftTrackingReaderOptions();
   const auto initialUsage = leafPool_->usedBytes();
   {
     auto reader = createReader(sample, readerOptions);
@@ -2158,9 +2163,9 @@ TEST_F(ParquetReaderTest, thriftMemoryTracking) {
     rowReaderOpts.setScanSpec(makeScanSpec(sampleSchema()));
     auto rowReader = reader->createRowReader(rowReaderOpts);
 
-    // The reported footprint must at least cover the FileMetaData struct
-    // itself plus one ColumnChunk per (row group * column) — anything smaller
-    // means the estimator is not accounting for the per-row-group payload.
+    // Reported bytes must at least cover FileMetaData plus one ColumnChunk
+    // per (row group * column); anything smaller would mean per-row-group
+    // payload is not accounted for.
     const auto memoryAfterRowReader = leafPool_->usedBytes();
     const auto reportedBytes = memoryAfterRowReader - initialUsage;
     const auto numRowGroups = reader->fileMetaData().numRowGroups();
@@ -2175,39 +2180,32 @@ TEST_F(ParquetReaderTest, thriftMemoryTracking) {
     rowReader->next(10, result);
     EXPECT_EQ(result->size(), 10);
 
-    // Memory remains reported throughout reading.
+    // Reading does not release any of the reported memory.
     EXPECT_GE(leafPool_->usedBytes(), memoryAfterRowReader);
   }
 
-  // ~ReaderBase() releases the reported memory, returning to baseline.
+  // Destroying the reader returns memory to the pre-tracking baseline.
   EXPECT_EQ(leafPool_->usedBytes(), initialUsage);
 }
 
 // Verifies that the ParquetReader, not the RowReader, owns the tracked
-// footer memory: the reader makes the only reportExternalAllocation,
-// row readers add no further external allocations across their entire
-// lifecycle (including a second row reader on the same ParquetReader),
-// and the reservation is released through ~ReaderBase (with possible
-// earlier releaseThriftBytes calls for skipped row groups).
+// footer memory: a single external allocation is made when the reader
+// is constructed, no further external allocations are made when row
+// readers are created or destroyed (including a second row reader on
+// the same ParquetReader), and the reservation is balanced by frees
+// after the reader is destroyed.
 TEST_F(ParquetReaderTest, thriftMemoryOwnedByReader) {
   const std::string sample(getExampleFilePath("sample.parquet"));
-
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
-  readerOptions.setParquetFooterMemoryTrackingThreshold(1);
+  auto readerOptions = makeThriftTrackingReaderOptions();
   const auto initialAllocs = leafPool_->stats().numExternalAllocs;
   const auto initialFrees = leafPool_->stats().numExternalFrees;
   {
     auto reader = createReader(sample, readerOptions);
-    // The reader's constructor makes exactly one external allocation.
     EXPECT_EQ(leafPool_->stats().numExternalAllocs, initialAllocs + 1);
     EXPECT_EQ(leafPool_->stats().numExternalFrees, initialFrees);
 
     {
-      // Full scan range keeps every row group, so filterRowGroups does not
-      // call releaseThriftBytes — neither row reader creation nor
-      // destruction must touch the accounting.
+      // Full-range row reader: no row groups skipped, no accounting change.
       auto rowReaderOpts = getReaderOpts(sampleSchema());
       rowReaderOpts.setScanSpec(makeScanSpec(sampleSchema()));
       auto rowReader = reader->createRowReader(rowReaderOpts);
@@ -2217,33 +2215,26 @@ TEST_F(ParquetReaderTest, thriftMemoryOwnedByReader) {
     EXPECT_EQ(leafPool_->stats().numExternalAllocs, initialAllocs + 1);
     EXPECT_EQ(leafPool_->stats().numExternalFrees, initialFrees);
 
-    // Create a second row reader on the *same* ParquetReader. The
-    // out-of-file scan range (0, 1) matches no row groups, so the
-    // constructor skips advanceToNextRowGroup and avoids a pre-existing
-    // multi-row-reader limitation in ParquetData::seekToRowGroup (the
-    // shared ReaderBase::inputs_ cache leaves the new column reader with
-    // no enqueued streams). filterRowGroups may release the memory of
-    // any skipped row groups through the reader's releaseThriftBytes API
-    // — that is the reader's reservation shrinking, not a row-reader-
-    // owned allocation. The key invariant under test is that no new
-    // external allocation appears: the reader, not the row reader,
-    // remains the sole owner of the reservation.
+    // A second row reader on the same ParquetReader does not allocate.
+    // Range (0, 1) is out-of-file, so no row groups match — this also
+    // sidesteps a pre-existing multi-row-reader prefetch limitation in
+    // ParquetData::seekToRowGroup unrelated to footer accounting.
     auto emptyRangeRowReaderOpts = getReaderOpts(sampleSchema());
     emptyRangeRowReaderOpts.setScanSpec(makeScanSpec(sampleSchema()));
     emptyRangeRowReaderOpts.range(0, 1);
     auto emptyRangeRowReader = reader->createRowReader(emptyRangeRowReaderOpts);
     EXPECT_EQ(leafPool_->stats().numExternalAllocs, initialAllocs + 1);
   }
-  // After the reader is destroyed, every external allocation has a
-  // matching external free: one initial alloc, balanced by one or more
-  // frees from ~ReaderBase plus any earlier releaseThriftBytes calls.
+  // Every external alloc is paired with at least one free across the
+  // reader's lifetime (frees may include early releases from skipped
+  // row groups in addition to the final release in ~ReaderBase).
   EXPECT_EQ(leafPool_->stats().numExternalAllocs, initialAllocs + 1);
   EXPECT_GE(leafPool_->stats().numExternalFrees, initialFrees + 1);
 }
 
-// Verifies that the production default (no threshold set) does not engage
-// the external allocation tracking path: no reportExternalAllocation is
-// made, and ~ReaderBase has nothing to release.
+// Verifies that without setting the threshold the tracking path is
+// disabled: no external allocation is reported, and ~ReaderBase has
+// nothing to release.
 TEST_F(ParquetReaderTest, thriftMemoryNotTrackedByDefault) {
   const std::string sample(getExampleFilePath("sample.parquet"));
 
@@ -2257,11 +2248,8 @@ TEST_F(ParquetReaderTest, thriftMemoryNotTrackedByDefault) {
     auto rowReaderOpts = getReaderOpts(sampleSchema());
     rowReaderOpts.setScanSpec(makeScanSpec(sampleSchema()));
     auto rowReader = reader->createRowReader(rowReaderOpts);
-    // No external allocation was reported by the Thrift footer path even
-    // though the reader and row reader were fully constructed.
     EXPECT_EQ(leafPool_->stats().numExternalAllocs, initialExternalAllocs);
   }
-  // And no external free either, since none was reported.
   EXPECT_EQ(leafPool_->stats().numExternalAllocs, initialExternalAllocs);
   EXPECT_EQ(leafPool_->stats().numExternalFrees, 0);
 }
@@ -2272,24 +2260,18 @@ TEST_F(ParquetReaderTest, thriftMemoryNotTrackedByDefault) {
 TEST_F(ParquetReaderTest, thriftMemoryReleasedForSkippedRowGroups) {
   const auto rowType = ROW({"id"}, {BIGINT()});
   const std::string sample(getExampleFilePath("multiple_row_groups.parquet"));
-
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
-  // 1-byte threshold forces memory tracking to engage for any footer.
-  readerOptions.setParquetFooterMemoryTrackingThreshold(1);
+  auto readerOptions = makeThriftTrackingReaderOptions();
   const auto initialUsage = leafPool_->usedBytes();
   {
     auto reader = createReader(sample, readerOptions);
     const auto numRowGroups = reader->fileMetaData().numRowGroups();
     ASSERT_GT(numRowGroups, 1);
 
-    // After reader construction, the full footer footprint is reported.
+    // Full footer footprint is reported at reader construction.
     const auto memoryAfterReader = leafPool_->usedBytes();
     EXPECT_GT(memoryAfterReader, initialUsage);
 
-    // Limit the scan range to keep only row group 0; row groups 1+ fall
-    // outside the range and get cleared by filterRowGroups().
+    // Scan range covers only row group 0; later groups are cleared.
     const auto secondRowGroupOffset =
         reader->fileMetaData().rowGroup(1).fileOffset();
     ASSERT_GT(secondRowGroupOffset, 0);
@@ -2299,12 +2281,10 @@ TEST_F(ParquetReaderTest, thriftMemoryReleasedForSkippedRowGroups) {
     rowReaderOpts.range(0, secondRowGroupOffset);
     auto rowReader = reader->createRowReader(rowReaderOpts);
 
-    // The cleared row groups' bytes must have been released to the pool.
+    // Cleared row groups' bytes are released; row group 0 still tracked.
     EXPECT_LT(leafPool_->usedBytes(), memoryAfterReader);
-    // Row group 0 is preserved, so some memory remains reported.
     EXPECT_GT(leafPool_->usedBytes(), initialUsage);
   }
 
-  // ~ReaderBase() releases the remaining reported memory.
   EXPECT_EQ(leafPool_->usedBytes(), initialUsage);
 }

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -2184,9 +2184,11 @@ TEST_F(ParquetReaderTest, thriftMemoryTracking) {
 }
 
 // Verifies that the ParquetReader, not the RowReader, owns the tracked
-// footer memory: creating a row reader does not call
-// reportExternalAllocation, and destroying it does not call
-// reportExternalFree.
+// footer memory: the reader makes the only reportExternalAllocation,
+// row readers add no further external allocations across their entire
+// lifecycle (including a second row reader on the same ParquetReader),
+// and the reservation is released through ~ReaderBase (with possible
+// earlier releaseThriftBytes calls for skipped row groups).
 TEST_F(ParquetReaderTest, thriftMemoryOwnedByReader) {
   const std::string sample(getExampleFilePath("sample.parquet"));
 
@@ -2204,22 +2206,39 @@ TEST_F(ParquetReaderTest, thriftMemoryOwnedByReader) {
 
     {
       // Full scan range keeps every row group, so filterRowGroups does not
-      // call releaseThriftBytes — any change in numExternalFrees would mean
-      // the row reader's lifecycle (not just row-group skipping) is
-      // touching the accounting.
+      // call releaseThriftBytes — neither row reader creation nor
+      // destruction must touch the accounting.
       auto rowReaderOpts = getReaderOpts(sampleSchema());
       rowReaderOpts.setScanSpec(makeScanSpec(sampleSchema()));
       auto rowReader = reader->createRowReader(rowReaderOpts);
       EXPECT_EQ(leafPool_->stats().numExternalAllocs, initialAllocs + 1);
       EXPECT_EQ(leafPool_->stats().numExternalFrees, initialFrees);
     }
-    // Destroying the row reader must not release the reservation either.
     EXPECT_EQ(leafPool_->stats().numExternalAllocs, initialAllocs + 1);
     EXPECT_EQ(leafPool_->stats().numExternalFrees, initialFrees);
+
+    // Create a second row reader on the *same* ParquetReader. The
+    // out-of-file scan range (0, 1) matches no row groups, so the
+    // constructor skips advanceToNextRowGroup and avoids a pre-existing
+    // multi-row-reader limitation in ParquetData::seekToRowGroup (the
+    // shared ReaderBase::inputs_ cache leaves the new column reader with
+    // no enqueued streams). filterRowGroups may release the memory of
+    // any skipped row groups through the reader's releaseThriftBytes API
+    // — that is the reader's reservation shrinking, not a row-reader-
+    // owned allocation. The key invariant under test is that no new
+    // external allocation appears: the reader, not the row reader,
+    // remains the sole owner of the reservation.
+    auto rowReaderOpts2 = getReaderOpts(sampleSchema());
+    rowReaderOpts2.setScanSpec(makeScanSpec(sampleSchema()));
+    rowReaderOpts2.range(0, 1);
+    auto rowReader2 = reader->createRowReader(rowReaderOpts2);
+    EXPECT_EQ(leafPool_->stats().numExternalAllocs, initialAllocs + 1);
   }
-  // The reader's destruction releases the reservation with one external free.
+  // After the reader is destroyed, every external allocation has a
+  // matching external free: one initial alloc, balanced by one or more
+  // frees from ~ReaderBase plus any earlier releaseThriftBytes calls.
   EXPECT_EQ(leafPool_->stats().numExternalAllocs, initialAllocs + 1);
-  EXPECT_EQ(leafPool_->stats().numExternalFrees, initialFrees + 1);
+  EXPECT_GE(leafPool_->stats().numExternalFrees, initialFrees + 1);
 }
 
 // Verifies that the production default (no threshold set) does not engage

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -2184,9 +2184,9 @@ TEST_F(ParquetReaderTest, thriftMemoryTracking) {
 }
 
 // Verifies that the ParquetReader, not the RowReader, owns the tracked
-// footer memory: creating and destroying RowReaders does not touch the
-// external allocation accounting, and creating additional RowReaders
-// does not re-report the footer.
+// footer memory: creating a row reader does not call
+// reportExternalAllocation, and destroying it does not call
+// reportExternalFree.
 TEST_F(ParquetReaderTest, thriftMemoryOwnedByReader) {
   const std::string sample(getExampleFilePath("sample.parquet"));
 
@@ -2203,25 +2203,17 @@ TEST_F(ParquetReaderTest, thriftMemoryOwnedByReader) {
     EXPECT_EQ(leafPool_->stats().numExternalFrees, initialFrees);
 
     {
+      // Full scan range keeps every row group, so filterRowGroups does not
+      // call releaseThriftBytes — any change in numExternalFrees would mean
+      // the row reader's lifecycle (not just row-group skipping) is
+      // touching the accounting.
       auto rowReaderOpts = getReaderOpts(sampleSchema());
       rowReaderOpts.setScanSpec(makeScanSpec(sampleSchema()));
       auto rowReader = reader->createRowReader(rowReaderOpts);
-      // Creating a row reader must not touch the external allocation
-      // accounting — the reader owns it.
       EXPECT_EQ(leafPool_->stats().numExternalAllocs, initialAllocs + 1);
       EXPECT_EQ(leafPool_->stats().numExternalFrees, initialFrees);
     }
     // Destroying the row reader must not release the reservation either.
-    EXPECT_EQ(leafPool_->stats().numExternalAllocs, initialAllocs + 1);
-    EXPECT_EQ(leafPool_->stats().numExternalFrees, initialFrees);
-
-    // A second row reader configured with an out-of-file scan range matches
-    // no row groups, so it does not attempt to prefetch. It must not
-    // re-report the footer or release the reservation.
-    auto rowReaderOpts = getReaderOpts(sampleSchema());
-    rowReaderOpts.setScanSpec(makeScanSpec(sampleSchema()));
-    rowReaderOpts.range(0, 1);
-    auto rowReader2 = reader->createRowReader(rowReaderOpts);
     EXPECT_EQ(leafPool_->stats().numExternalAllocs, initialAllocs + 1);
     EXPECT_EQ(leafPool_->stats().numExternalFrees, initialFrees);
   }

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -2228,10 +2228,10 @@ TEST_F(ParquetReaderTest, thriftMemoryOwnedByReader) {
     // owned allocation. The key invariant under test is that no new
     // external allocation appears: the reader, not the row reader,
     // remains the sole owner of the reservation.
-    auto rowReaderOpts2 = getReaderOpts(sampleSchema());
-    rowReaderOpts2.setScanSpec(makeScanSpec(sampleSchema()));
-    rowReaderOpts2.range(0, 1);
-    auto rowReader2 = reader->createRowReader(rowReaderOpts2);
+    auto emptyRangeRowReaderOpts = getReaderOpts(sampleSchema());
+    emptyRangeRowReaderOpts.setScanSpec(makeScanSpec(sampleSchema()));
+    emptyRangeRowReaderOpts.range(0, 1);
+    auto emptyRangeRowReader = reader->createRowReader(emptyRangeRowReaderOpts);
     EXPECT_EQ(leafPool_->stats().numExternalAllocs, initialAllocs + 1);
   }
   // After the reader is destroyed, every external allocation has a

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -1902,6 +1902,7 @@ TEST_F(ParquetReaderTest, readerWithSchema) {
   auto buffer = std::make_unique<dwio::common::BufferedInput>(
       file, readerOptions.memoryPool());
   ParquetReader reader(std::move(buffer), readerOptions);
+
   EXPECT_EQ(reader.rowType()->toString(), schema->toString());
 }
 
@@ -2144,8 +2145,9 @@ TEST_F(ParquetReaderTest, thriftMemoryTracking) {
   // the row reader is created and released when the reader is destroyed.
   const std::string sample(getExampleFilePath("sample.parquet"));
 
-  dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   // 1-byte threshold forces memory tracking to engage for any footer.
   readerOptions.setParquetFooterMemoryTrackingThreshold(1);
   const auto initialUsage = leafPool_->usedBytes();
@@ -2190,8 +2192,9 @@ TEST_F(ParquetReaderTest, thriftMemoryReleasedForSkippedRowGroups) {
   const auto rowType = ROW({"id"}, {BIGINT()});
   const std::string sample(getExampleFilePath("multiple_row_groups.parquet"));
 
-  dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   // 1-byte threshold forces memory tracking to engage for any footer.
   readerOptions.setParquetFooterMemoryTrackingThreshold(1);
   const auto initialUsage = leafPool_->usedBytes();


### PR DESCRIPTION
## Summary

Co-authored-by: @jaystarshot

Fix #12252. Large Parquet footers (e.g. ~130MB serialized resulting in
~960MB of `FileMetaData`) consume significant heap memory through Thrift
deserialization without being reported to the memory pool, so queries
silently over-consume worker memory instead of failing fast.

This PR adds an opt-in config (`parquet-footer-memory-tracking-threshold`)
that makes the reader walk the deserialized footer once via
`estimateFileMetadataSize()` and report the heap footprint to the pool
through `reportExternalAllocation()`. The reservation is visible in
pool stats so the next allocation check fails the query cleanly:

```
Top 10 leaf memory pool usages:
    op.4.0.6.Aggregation usage 23.74GB reserved 23.74GB peak 23.74GB
    op.0.0.6.TableScan usage 1.58GB reserved 1.59GB peak 2.81GB
    ...
```

## Scope: visibility, not prevention

This PR is the visibility layer — it does **not** reduce the actual
heap footprint. The full `thrift::FileMetaData` is still deserialized
eagerly because Thrift's generated `read()` materializes every nested
field, and Parquet's footer is one Thrift blob with nested
`row_groups[].columns[]`.

The root-cause fix would be selective deserialization: a partial
Thrift reader that keeps the raw footer bytes alive and uses
`TProtocol::skip(T_STRUCT)` on unprojected column chunks within each
`RowGroup.columns` LIST. For the 6879-column × 147-row-group case
with a 10-column projection: ~1M chunks → ~1.5K, ~99.85% memory drop.
That's a multi-week refactor (lifetime threading for per-row-reader
projection, proxy class changes in `Metadata.h`, hand-rolled wire
format) — being evaluated as a follow-up, no implementation yet.
This PR is the short-term mitigation. The two efforts won't compete
once selective deserialization lands — the projected-column residual
still benefits from being accounted in the pool.

## Status at Uber

This PR's tracking path is enabled internally so we can identify
which workloads hit large Parquet footers. Selective deserialization
is under evaluation as a follow-up but has no implementation yet.
Default remains `off` upstream so out-of-the-box behavior is
unchanged.

## CPU overhead

Measured via `MetadataBenchmark` (built with
`-DVELOX_ENABLE_BENCHMARKS=ON`). Apple M1, `-O2`, single-threaded:

| Footer shape          | Chunks    | Per-call cost | Estimate |
| --------------------- | --------- | ------------- | -------- |
| Small (10 × 4)        | 40        | ~0.3 µs       | ~20 KB   |
| Medium (100 × 50)     | 5,000     | ~22 µs        | ~2 MB    |
| Wide (6879 × 147)     | 1,011,213 | ~5 ms         | ~490 MB  |

Per-chunk cost is ~5 ns — pointer chasing + integer arithmetic, no
allocations. For typical footers it's submicrosecond; even the
pathology case is single-digit ms. The walk is strictly cheaper per
field than the eager Thrift deserialization that already runs on
every reader open. The opt-in flag is kept for rollout safety (the
estimate is approximate; could trigger false memory pressure on
workloads sized to fit at today's untracked footprint); plan is to
flip the default to always-on after a release cycle of internal
measurement.

## Design properties

- **Tracking is approximate.** The size is estimated by walking the
  inline Thrift struct tree, not measured from the allocator.
  Over-estimates cause false memory pressure; under-estimates provide
  partial protection.
- **Cannot prevent the initial allocation.** The full footer is
  deserialized before the estimate is computed — that memory is
  already on the heap. Tracking only makes the footprint visible so
  the *next* allocation check fails fast rather than silently
  over-consuming.
- **Threshold compares serialized footer length; the reservation is
  the deserialized estimate.** The two can diverge by several times
  (in the observed case above, ~7-8x). Pick the threshold against the
  serialized size you are willing to absorb silently.
- **Surfaced as a runtime stat.** When tracking engages, the estimate
  is reported per scan as `parquetFooterEstimatedBytes` so operators
  can compare it against actual pool usage.

## Limitations

- **Tracking ≠ prevention** (see Scope above). Selective
  deserialization is the real fix; see the Status section.
- **Small String Optimization (SSO) detection is non-portable.**
  `heapStringSize` decides whether a `std::string`'s buffer is inline
  by checking if `data()` points inside the string object. This works
  on libstdc++, libc++, and MSVC but is not guaranteed by the C++
  standard. On a hypothetical standard library that stored SSO data
  outside the object, short strings would be over-reported as
  heap-allocated rather than under-reported — the failure direction
  is safe.

## Test plan

- `MetadataTest` — direct unit tests over `thrift::ColumnChunk` /
  `thrift::FileMetaData` covering each heap-backed field, SSO
  exclusion, and the no-double-count invariant on inline sub-structs.
- `ParquetReaderTest.thriftMemoryTracking` /
  `thriftMemoryOwnedByReader` / `thriftMemoryNotTrackedByDefault` /
  `thriftMemoryReleasedForSkippedRowGroups` — end-to-end coverage of
  report/release accounting.
- `ParquetReaderTest.thriftMemoryRuntimeStat` /
  `thriftMemoryRuntimeStatAbsentWithoutTracking` — verifies the
  `parquetFooterEstimatedBytes` runtime stat is emitted only when
  tracking engages.
- `MetadataBenchmark` — microbenchmark for the per-call cost of
  `estimateFileMetadataSize` (numbers above).
