### PR TITLE
fix: Fix BufferPool::release to take BufferPtr&& with uniqueness check (#17469)

### DIFF
--- a/velox/buffer/BufferPool.cpp
+++ b/velox/buffer/BufferPool.cpp
@@ -39,10 +39,11 @@ BufferPtr BufferPool::get() {
   return result;
 }
 
-void BufferPool::release(BufferPtr buffer) {
-  if (buffer != nullptr && buffers_.size() < kMaxCached) {
-    buffers_.push_back(std::move(buffer));
+void BufferPool::release(BufferPtr&& buffer) {
+  if (buffer == nullptr || !buffer->unique() || buffers_.size() >= kMaxCached) {
+    return;
   }
+  buffers_.push_back(std::move(buffer));
 }
 
 size_t BufferPool::size() const {

--- a/velox/buffer/BufferPool.h
+++ b/velox/buffer/BufferPool.h
@@ -39,8 +39,9 @@ class BufferPool {
   BufferPtr get();
 
   /// Returns a buffer to the pool for future reuse. Drops the buffer if the
-  /// pool is full or if 'buffer' is null.
-  void release(BufferPtr buffer);
+  /// pool is full or if 'buffer' is null. The buffer must have a unique
+  /// reference (refcount == 1) to ensure safe reuse.
+  void release(BufferPtr&& buffer);
 
   /// Returns the number of cached buffers currently in the pool.
   size_t size() const;

--- a/velox/buffer/tests/BufferPoolTest.cpp
+++ b/velox/buffer/tests/BufferPoolTest.cpp
@@ -91,8 +91,31 @@ TEST_F(BufferPoolTest, getWithMinBytesNoMatch) {
 
 TEST_F(BufferPoolTest, recycleNullptr) {
   BufferPool bufferPool;
-  bufferPool.release(nullptr);
+  BufferPtr nullBuffer;
+  bufferPool.release(std::move(nullBuffer));
   EXPECT_EQ(bufferPool.size(), 0);
+}
+
+TEST_F(BufferPoolTest, releaseNonUniqueBuffer) {
+  BufferPool bufferPool;
+  auto buffer = AlignedBuffer::allocate<char>(1'024, pool_.get());
+  auto copy = buffer;
+  EXPECT_FALSE(buffer->unique());
+  bufferPool.release(std::move(buffer));
+  EXPECT_EQ(bufferPool.size(), 0);
+}
+
+TEST_F(BufferPoolTest, releaseMoveSemantics) {
+  BufferPool bufferPool;
+  auto buffer = AlignedBuffer::allocate<char>(1'024, pool_.get());
+  auto* rawPtr = buffer.get();
+  EXPECT_TRUE(buffer->unique());
+  // NOLINTNEXTLINE(bugprone-use-after-move)
+  bufferPool.release(std::move(buffer));
+  EXPECT_EQ(buffer, nullptr);
+  EXPECT_EQ(bufferPool.size(), 1);
+  auto retrieved = bufferPool.get();
+  EXPECT_EQ(retrieved.get(), rawPtr);
 }
 
 TEST_F(BufferPoolTest, maxCachedLimit) {


### PR DESCRIPTION
Summary:

Change BufferPool::release() to take BufferPtr&& (move semantics) to make ownership transfer explicit and prevent use-after-release. Add a debug-only uniqueness check (VELOX_DCHECK on refcount == 1) to catch double-release bugs during development.

Also add temporary hit/miss counters with LOG_EVERY_N for benchmarking buffer reuse effectiveness.

Reviewed By: tanjialiang

Differential Revision: D104505378


