### PR TITLE
refactor: Add IO stats setters to ReaderOptions and use pool-only constructor

### DIFF
--- a/velox/common/io/Options.h
+++ b/velox/common/io/Options.h
@@ -67,6 +67,11 @@ class ReaderOptions {
   static constexpr int32_t kDefaultCoalesceBytes = 128 << 20; // 128M
   static constexpr int32_t kDefaultPrefetchRowGroups = 1;
 
+  explicit ReaderOptions(velox::memory::MemoryPool* pool) : pool_{pool} {
+    VELOX_CHECK_NOT_NULL(pool_);
+  }
+
+  // Deprecated: use pool-only constructor + setDataIoStats/setMetadataIoStats.
   ReaderOptions(
       velox::memory::MemoryPool* pool,
       IoStatistics* dataIoStats,
@@ -74,8 +79,25 @@ class ReaderOptions {
       : pool_{pool},
         dataIoStats_{dataIoStats},
         metadataIoStats_{metadataIoStats} {
-    VELOX_CHECK_NOT_NULL(dataIoStats);
-    VELOX_CHECK_NOT_NULL(metadataIoStats);
+    VELOX_CHECK_NOT_NULL(pool_);
+  }
+
+  ReaderOptions& setDataIoStats(IoStatistics* stats) {
+    VELOX_CHECK_NULL(dataIoStats_, "dataIoStats already set");
+    dataIoStats_ = stats;
+    return *this;
+  }
+
+  ReaderOptions& setMetadataIoStats(IoStatistics* stats) {
+    VELOX_CHECK_NULL(metadataIoStats_, "metadataIoStats already set");
+    metadataIoStats_ = stats;
+    return *this;
+  }
+
+  ReaderOptions& setIndexIoStats(IoStatistics* stats) {
+    VELOX_CHECK_NULL(indexIoStats_, "indexIoStats already set");
+    indexIoStats_ = stats;
+    return *this;
   }
 
   /// Modifies the autoPreloadLength
@@ -171,10 +193,15 @@ class ReaderOptions {
     return metadataIoStats_;
   }
 
+  IoStatistics* indexIoStats() const {
+    return indexIoStats_;
+  }
+
  protected:
   velox::memory::MemoryPool* pool_;
-  IoStatistics* dataIoStats_;
-  IoStatistics* metadataIoStats_;
+  IoStatistics* dataIoStats_{nullptr};
+  IoStatistics* metadataIoStats_{nullptr};
+  IoStatistics* indexIoStats_{nullptr};
 
   std::shared_ptr<folly::Executor> ioExecutor_;
 

--- a/velox/common/io/tests/ReaderOptionsTest.cpp
+++ b/velox/common/io/tests/ReaderOptionsTest.cpp
@@ -19,6 +19,8 @@
 #include <folly/executors/CPUThreadPoolExecutor.h>
 #include <gtest/gtest.h>
 
+#include "velox/common/base/tests/GTestUtils.h"
+
 namespace facebook::velox::io {
 
 class ReaderOptionsTest : public ::testing::Test {
@@ -31,14 +33,16 @@ class ReaderOptionsTest : public ::testing::Test {
       memory::memoryManager()->addLeafPool("ReaderOptionsTest")};
   IoStatistics dataIoStats_;
   IoStatistics metadataIoStats_;
+  IoStatistics indexIoStats_;
 };
 
 TEST_F(ReaderOptionsTest, constructor) {
-  ReaderOptions options(pool_.get(), &dataIoStats_, &metadataIoStats_);
+  ReaderOptions options(pool_.get());
 
   EXPECT_EQ(&options.memoryPool(), pool_.get());
-  EXPECT_EQ(options.dataIoStats(), &dataIoStats_);
-  EXPECT_EQ(options.metadataIoStats(), &metadataIoStats_);
+  EXPECT_EQ(options.dataIoStats(), nullptr);
+  EXPECT_EQ(options.metadataIoStats(), nullptr);
+  EXPECT_EQ(options.indexIoStats(), nullptr);
   EXPECT_EQ(options.ioExecutor(), nullptr);
   EXPECT_EQ(options.autoPreloadLength(), DEFAULT_AUTO_PRELOAD_SIZE);
   EXPECT_EQ(options.prefetchMode(), PrefetchMode::PREFETCH);
@@ -52,7 +56,7 @@ TEST_F(ReaderOptionsTest, constructor) {
 }
 
 TEST_F(ReaderOptionsTest, setters) {
-  ReaderOptions options(pool_.get(), &dataIoStats_, &metadataIoStats_);
+  ReaderOptions options(pool_.get());
 
   options.setAutoPreloadLength(1'024);
   EXPECT_EQ(options.autoPreloadLength(), 1'024);
@@ -77,7 +81,7 @@ TEST_F(ReaderOptionsTest, setters) {
 }
 
 TEST_F(ReaderOptionsTest, ioExecutor) {
-  ReaderOptions options(pool_.get(), &dataIoStats_, &metadataIoStats_);
+  ReaderOptions options(pool_.get());
   EXPECT_EQ(options.ioExecutor(), nullptr);
 
   auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(2);
@@ -89,10 +93,14 @@ TEST_F(ReaderOptionsTest, ioExecutor) {
 }
 
 TEST_F(ReaderOptionsTest, ioStats) {
-  ReaderOptions options(pool_.get(), &dataIoStats_, &metadataIoStats_);
+  ReaderOptions options(pool_.get());
+  options.setDataIoStats(&dataIoStats_);
+  options.setMetadataIoStats(&metadataIoStats_);
+  options.setIndexIoStats(&indexIoStats_);
 
   EXPECT_EQ(options.dataIoStats(), &dataIoStats_);
   EXPECT_EQ(options.metadataIoStats(), &metadataIoStats_);
+  EXPECT_EQ(options.indexIoStats(), &indexIoStats_);
 
   options.dataIoStats()->read().increment(100);
   EXPECT_EQ(dataIoStats_.read().count(), 1);
@@ -101,11 +109,18 @@ TEST_F(ReaderOptionsTest, ioStats) {
   options.metadataIoStats()->read().increment(50);
   EXPECT_EQ(metadataIoStats_.read().count(), 1);
   EXPECT_EQ(metadataIoStats_.read().sum(), 50);
+
+  options.indexIoStats()->read().increment(25);
+  EXPECT_EQ(indexIoStats_.read().count(), 1);
+  EXPECT_EQ(indexIoStats_.read().sum(), 25);
 }
 
 TEST_F(ReaderOptionsTest, chainingSetters) {
-  ReaderOptions options(pool_.get(), &dataIoStats_, &metadataIoStats_);
-  auto& result = options.setAutoPreloadLength(1'024)
+  ReaderOptions options(pool_.get());
+  auto& result = options.setDataIoStats(&dataIoStats_)
+                     .setMetadataIoStats(&metadataIoStats_)
+                     .setIndexIoStats(&indexIoStats_)
+                     .setAutoPreloadLength(1'024)
                      .setPrefetchMode(PrefetchMode::PRELOAD)
                      .setLoadQuantum(4 << 20)
                      .setMaxCoalesceDistance(1 << 20)
@@ -113,12 +128,47 @@ TEST_F(ReaderOptionsTest, chainingSetters) {
                      .setPrefetchRowGroups(4);
 
   EXPECT_EQ(&result, &options);
+  EXPECT_EQ(options.dataIoStats(), &dataIoStats_);
+  EXPECT_EQ(options.metadataIoStats(), &metadataIoStats_);
+  EXPECT_EQ(options.indexIoStats(), &indexIoStats_);
   EXPECT_EQ(options.autoPreloadLength(), 1'024);
   EXPECT_EQ(options.prefetchMode(), PrefetchMode::PRELOAD);
   EXPECT_EQ(options.loadQuantum(), 4 << 20);
   EXPECT_EQ(options.maxCoalesceDistance(), 1 << 20);
   EXPECT_EQ(options.maxCoalesceBytes(), 64 << 20);
   EXPECT_EQ(options.prefetchRowGroups(), 4);
+}
+
+TEST_F(ReaderOptionsTest, doubleSetIoStatsThrows) {
+  ReaderOptions options(pool_.get());
+  options.setDataIoStats(&dataIoStats_);
+  VELOX_ASSERT_THROW(
+      options.setDataIoStats(&dataIoStats_), "dataIoStats already set");
+
+  ReaderOptions options2(pool_.get());
+  options2.setMetadataIoStats(&metadataIoStats_);
+  VELOX_ASSERT_THROW(
+      options2.setMetadataIoStats(&metadataIoStats_),
+      "metadataIoStats already set");
+
+  ReaderOptions options3(pool_.get());
+  options3.setIndexIoStats(&indexIoStats_);
+  VELOX_ASSERT_THROW(
+      options3.setIndexIoStats(&indexIoStats_), "indexIoStats already set");
+}
+
+TEST_F(ReaderOptionsTest, copyConstruct) {
+  ReaderOptions options(pool_.get());
+  options.setDataIoStats(&dataIoStats_);
+  options.setMetadataIoStats(&metadataIoStats_);
+  options.setLoadQuantum(4 << 20);
+
+  ReaderOptions copy(options);
+  EXPECT_EQ(&copy.memoryPool(), pool_.get());
+  EXPECT_EQ(copy.dataIoStats(), &dataIoStats_);
+  EXPECT_EQ(copy.metadataIoStats(), &metadataIoStats_);
+  EXPECT_EQ(copy.indexIoStats(), nullptr);
+  EXPECT_EQ(copy.loadQuantum(), 4 << 20);
 }
 
 } // namespace facebook::velox::io

--- a/velox/connectors/hive/FileIndexReader.cpp
+++ b/velox/connectors/hive/FileIndexReader.cpp
@@ -245,10 +245,9 @@ void FileIndexReader::parseIndexLookupConditions() {
 std::unique_ptr<dwio::common::Reader> FileIndexReader::createFileReader() {
   VELOX_CHECK_NOT_NULL(hiveSplit_);
 
-  dwio::common::ReaderOptions readerOpts(
-      connectorQueryCtx_->memoryPool(),
-      ioStatistics_.get(),
-      ioStatistics_.get());
+  dwio::common::ReaderOptions readerOpts(connectorQueryCtx_->memoryPool());
+  readerOpts.setDataIoStats(ioStatistics_.get());
+  readerOpts.setMetadataIoStats(ioStatistics_.get());
   hive::configureReaderOptions(
       fileConfig_,
       connectorQueryCtx_,

--- a/velox/connectors/hive/FileSplitReader.cpp
+++ b/velox/connectors/hive/FileSplitReader.cpp
@@ -158,11 +158,11 @@ FileSplitReader::FileSplitReader(
       fileSplit_(fileSplit),
       connectorQueryCtx_(connectorQueryCtx),
       readerOutputType_(readerOutputType),
-      baseReaderOpts_(
-          connectorQueryCtx->memoryPool(),
-          dataIoStats_.get(),
-          metadataIoStats_.get()),
-      emptySplit_(false) {}
+      baseReaderOpts_(connectorQueryCtx->memoryPool()),
+      emptySplit_(false) {
+  baseReaderOpts_.setDataIoStats(dataIoStats_.get());
+  baseReaderOpts_.setMetadataIoStats(metadataIoStats_.get());
+}
 
 void FileSplitReader::configureReaderOptions(
     std::shared_ptr<velox::random::RandomSkipTracker> randomSkip) {

--- a/velox/connectors/hive/iceberg/EqualityDeleteFileReader.cpp
+++ b/velox/connectors/hive/iceberg/EqualityDeleteFileReader.cpp
@@ -182,8 +182,9 @@ EqualityDeleteFileReader::EqualityDeleteFileReader(
       0,
       deleteFile.fileSizeInBytes);
 
-  dwio::common::ReaderOptions deleteReaderOpts(
-      pool_, ioStatistics.get(), ioStatistics.get());
+  dwio::common::ReaderOptions deleteReaderOpts(pool_);
+  deleteReaderOpts.setDataIoStats(ioStatistics.get());
+  deleteReaderOpts.setMetadataIoStats(ioStatistics.get());
   configureReaderOptions(
       fileConfig,
       connectorQueryCtx,

--- a/velox/connectors/hive/iceberg/PositionalDeleteFileReader.cpp
+++ b/velox/connectors/hive/iceberg/PositionalDeleteFileReader.cpp
@@ -81,8 +81,9 @@ PositionalDeleteFileReader::PositionalDeleteFileReader(
 
   // Create the Reader and RowReader
 
-  dwio::common::ReaderOptions deleteReaderOpts(
-      pool_, ioStatistics_.get(), ioStatistics_.get());
+  dwio::common::ReaderOptions deleteReaderOpts(pool_);
+  deleteReaderOpts.setDataIoStats(ioStatistics_.get());
+  deleteReaderOpts.setMetadataIoStats(ioStatistics_.get());
   configureReaderOptions(
       fileConfig_,
       connectorQueryCtx,

--- a/velox/connectors/hive/tests/FileConnectorUtilTest.cpp
+++ b/velox/connectors/hive/tests/FileConnectorUtilTest.cpp
@@ -79,8 +79,9 @@ class FileConnectorUtilTest : public exec::test::HiveConnectorTestBase {
   }
 
   std::unique_ptr<dwio::common::Reader> makeReader(const std::string& path) {
-    dwio::common::ReaderOptions readerOpts{
-        pool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+    dwio::common::ReaderOptions readerOpts(pool_.get());
+    readerOpts.setDataIoStats(dataIoStats_.get());
+    readerOpts.setMetadataIoStats(metadataIoStats_.get());
     readerOpts.setFileFormat(dwio::common::FileFormat::DWRF);
     auto readFile = std::make_shared<LocalReadFile>(path);
     auto input = std::make_unique<dwio::common::BufferedInput>(
@@ -104,8 +105,9 @@ TEST_F(FileConnectorUtilTest, configureReaderOptions) {
   {
     auto holder = makeConnectorQueryCtx();
     auto split = makeSplit(dwio::common::FileFormat::DWRF);
-    dwio::common::ReaderOptions readerOptions(
-        pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+    dwio::common::ReaderOptions readerOptions(pool_.get());
+    readerOptions.setDataIoStats(dataIoStats_.get());
+    readerOptions.setMetadataIoStats(metadataIoStats_.get());
     hive::configureReaderOptions(
         fileConfig,
         holder.ctx.get(),
@@ -124,8 +126,9 @@ TEST_F(FileConnectorUtilTest, configureReaderOptions) {
     auto holder = makeConnectorQueryCtx(
         {{hive::FileConfig::kOrcUseColumnNamesSession, "true"}});
     auto split = makeSplit(dwio::common::FileFormat::ORC);
-    dwio::common::ReaderOptions readerOptions(
-        pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+    dwio::common::ReaderOptions readerOptions(pool_.get());
+    readerOptions.setDataIoStats(dataIoStats_.get());
+    readerOptions.setMetadataIoStats(metadataIoStats_.get());
     hive::configureReaderOptions(
         fileConfig,
         holder.ctx.get(),
@@ -143,8 +146,9 @@ TEST_F(FileConnectorUtilTest, configureReaderOptions) {
     auto holder = makeConnectorQueryCtx(
         {{hive::FileConfig::kParquetUseColumnNamesSession, "true"}});
     auto split = makeSplit(dwio::common::FileFormat::PARQUET);
-    dwio::common::ReaderOptions readerOptions(
-        pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+    dwio::common::ReaderOptions readerOptions(pool_.get());
+    readerOptions.setDataIoStats(dataIoStats_.get());
+    readerOptions.setMetadataIoStats(metadataIoStats_.get());
     hive::configureReaderOptions(
         fileConfig,
         holder.ctx.get(),
@@ -161,8 +165,9 @@ TEST_F(FileConnectorUtilTest, configureReaderOptions) {
   {
     auto holder = makeConnectorQueryCtx();
     auto split = makeSplit(dwio::common::FileFormat::DWRF);
-    dwio::common::ReaderOptions readerOptions(
-        pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+    dwio::common::ReaderOptions readerOptions(pool_.get());
+    readerOptions.setDataIoStats(dataIoStats_.get());
+    readerOptions.setMetadataIoStats(metadataIoStats_.get());
     readerOptions.setFileFormat(dwio::common::FileFormat::PARQUET);
     VELOX_ASSERT_THROW(
         hive::configureReaderOptions(

--- a/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
@@ -98,8 +98,9 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
   const std::unordered_map<std::string, std::string> customSplitInfo;
 
   // Dynamic parameters.
-  dwio::common::ReaderOptions readerOptions(
-      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   FileFormat fileFormat{FileFormat::DWRF};
   std::unordered_map<std::string, std::string> tableParameters;
   std::unordered_map<std::string, std::string> serdeParameters;
@@ -143,8 +144,9 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
   };
 
   auto clearDynamicParameters = [&](FileFormat newFileFormat) {
-    readerOptions = dwio::common::ReaderOptions(
-        pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+    readerOptions = dwio::common::ReaderOptions(pool_.get());
+    readerOptions.setDataIoStats(dataIoStats_.get());
+    readerOptions.setMetadataIoStats(metadataIoStats_.get());
     fileFormat = newFileFormat;
     tableParameters.clear();
     serdeParameters.clear();
@@ -363,8 +365,9 @@ TEST_F(HiveConnectorUtilTest, footerSpeculativeIoSizeByFormat) {
 
   // Test ORC format.
   {
-    dwio::common::ReaderOptions readerOptions(
-        pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+    dwio::common::ReaderOptions readerOptions(pool_.get());
+    readerOptions.setDataIoStats(dataIoStats_.get());
+    readerOptions.setMetadataIoStats(metadataIoStats_.get());
     auto tableHandle = createTableHandle();
     auto split = createSplit(FileFormat::ORC);
     configureReaderOptions(
@@ -382,8 +385,9 @@ TEST_F(HiveConnectorUtilTest, footerSpeculativeIoSizeByFormat) {
 
   // Test DWRF format (uses ORC config).
   {
-    dwio::common::ReaderOptions readerOptions(
-        pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+    dwio::common::ReaderOptions readerOptions(pool_.get());
+    readerOptions.setDataIoStats(dataIoStats_.get());
+    readerOptions.setMetadataIoStats(metadataIoStats_.get());
     auto tableHandle = createTableHandle();
     auto split = createSplit(FileFormat::DWRF);
     configureReaderOptions(
@@ -401,8 +405,9 @@ TEST_F(HiveConnectorUtilTest, footerSpeculativeIoSizeByFormat) {
 
   // Test Parquet format.
   {
-    dwio::common::ReaderOptions readerOptions(
-        pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+    dwio::common::ReaderOptions readerOptions(pool_.get());
+    readerOptions.setDataIoStats(dataIoStats_.get());
+    readerOptions.setMetadataIoStats(metadataIoStats_.get());
     auto tableHandle = createTableHandle();
     auto split = createSplit(FileFormat::PARQUET);
     configureReaderOptions(
@@ -420,8 +425,9 @@ TEST_F(HiveConnectorUtilTest, footerSpeculativeIoSizeByFormat) {
 
   // Test Nimble format.
   {
-    dwio::common::ReaderOptions readerOptions(
-        pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+    dwio::common::ReaderOptions readerOptions(pool_.get());
+    readerOptions.setDataIoStats(dataIoStats_.get());
+    readerOptions.setMetadataIoStats(metadataIoStats_.get());
     auto tableHandle = createTableHandle();
     auto split = createSplit(FileFormat::NIMBLE);
     configureReaderOptions(
@@ -440,8 +446,9 @@ TEST_F(HiveConnectorUtilTest, footerSpeculativeIoSizeByFormat) {
 
 TEST_F(HiveConnectorUtilTest, fileMetadataCacheEnabledSessionOverride) {
   // Verify default is off.
-  dwio::common::ReaderOptions defaultOptions(
-      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions defaultOptions(pool_.get());
+  defaultOptions.setDataIoStats(dataIoStats_.get());
+  defaultOptions.setMetadataIoStats(metadataIoStats_.get());
   ASSERT_FALSE(defaultOptions.fileMetadataCacheEnabled());
 
   for (bool enabled : {true, false}) {
@@ -467,8 +474,9 @@ TEST_F(HiveConnectorUtilTest, fileMetadataCacheEnabledSessionOverride) {
     auto hiveConfig =
         std::make_shared<hive::HiveConfig>(std::make_shared<config::ConfigBase>(
             std::unordered_map<std::string, std::string>()));
-    dwio::common::ReaderOptions readerOptions(
-        pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+    dwio::common::ReaderOptions readerOptions(pool_.get());
+    readerOptions.setDataIoStats(dataIoStats_.get());
+    readerOptions.setMetadataIoStats(metadataIoStats_.get());
 
     auto tableHandle = std::make_shared<hive::HiveTableHandle>(
         "testConnectorId",
@@ -526,8 +534,9 @@ TEST_F(HiveConnectorUtilTest, cacheRetention) {
         0,
         "");
 
-    dwio::common::ReaderOptions readerOptions(
-        pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+    dwio::common::ReaderOptions readerOptions(pool_.get());
+    readerOptions.setDataIoStats(dataIoStats_.get());
+    readerOptions.setMetadataIoStats(metadataIoStats_.get());
 
     auto tableHandle = std::make_shared<hive::HiveTableHandle>(
         "testConnectorId",

--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -1176,8 +1176,9 @@ TEST_F(HiveDataSinkTest, flushPolicyWithParquet) {
   ASSERT_TRUE(dataSink->finish());
   dataSink->close();
 
-  dwio::common::ReaderOptions readerOpts{
-      pool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOpts(pool_.get());
+  readerOpts.setDataIoStats(dataIoStats_.get());
+  readerOpts.setMetadataIoStats(metadataIoStats_.get());
   const std::vector<std::string> filePaths =
       listFiles(outputDirectory->getPath());
   auto bufferedInput = std::make_unique<dwio::common::BufferedInput>(
@@ -1215,8 +1216,9 @@ TEST_F(HiveDataSinkTest, flushPolicyWithDWRF) {
   ASSERT_TRUE(dataSink->finish());
   dataSink->close();
 
-  dwio::common::ReaderOptions readerOpts{
-      pool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOpts(pool_.get());
+  readerOpts.setDataIoStats(dataIoStats_.get());
+  readerOpts.setMetadataIoStats(metadataIoStats_.get());
   const std::vector<std::string> filePaths =
       listFiles(outputDirectory->getPath());
   auto bufferedInput = std::make_unique<dwio::common::BufferedInput>(

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -565,6 +565,10 @@ class ReaderOptions : public io::ReaderOptions {
   static constexpr uint64_t kDefaultFilePreloadThreshold =
       1024 * 1024 * 8; // 8MB
 
+  explicit ReaderOptions(velox::memory::MemoryPool* pool)
+      : io::ReaderOptions(pool) {}
+
+  // Deprecated: use pool-only constructor + setDataIoStats/setMetadataIoStats.
   ReaderOptions(
       velox::memory::MemoryPool* pool,
       velox::io::IoStatistics* dataIoStats,

--- a/velox/dwio/common/tests/BufferedInputTest.cpp
+++ b/velox/dwio/common/tests/BufferedInputTest.cpp
@@ -781,8 +781,9 @@ class CustomBufferedInputTest : public testing::Test {
 
 TEST_F(CustomBufferedInputTest, basic) {
   facebook::velox::FileHandle fileHandle;
-  facebook::velox::dwio::common::ReaderOptions readerOpts(
-      pool_.get(), &dataIoStats_, &metadataIoStats_);
+  facebook::velox::dwio::common::ReaderOptions readerOpts(pool_.get());
+  readerOpts.setDataIoStats(&dataIoStats_);
+  readerOpts.setMetadataIoStats(&metadataIoStats_);
   auto ioStatistics = std::make_shared<facebook::velox::io::IoStatistics>();
   auto ioStats = std::make_shared<facebook::velox::IoStats>();
   auto executor = std::make_unique<folly::IOThreadPoolExecutor>(10, 10);

--- a/velox/dwio/common/tests/CachedBufferedInputTest.cpp
+++ b/velox/dwio/common/tests/CachedBufferedInputTest.cpp
@@ -149,8 +149,9 @@ TEST_F(CachedBufferedInputTest, reset) {
   }
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
-  io::ReaderOptions readerOptions(
-      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setLoadQuantum(1 << 20);
 
   auto& ids = fileIds();
@@ -287,8 +288,9 @@ TEST_F(CachedBufferedInputTest, readAfterReset) {
   }
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
-  io::ReaderOptions readerOptions(
-      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setLoadQuantum(1 << 20);
 
   auto& ids = fileIds();
@@ -355,8 +357,9 @@ DEBUG_ONLY_TEST_F(CachedBufferedInputTest, resetInputWithBeforeLoading) {
   }
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
-  io::ReaderOptions readerOptions(
-      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setLoadQuantum(1 << 20);
 
   auto& ids = fileIds();
@@ -452,8 +455,9 @@ DEBUG_ONLY_TEST_F(CachedBufferedInputTest, resetInputWithAfterLoading) {
   }
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
-  io::ReaderOptions readerOptions(
-      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setLoadQuantum(1 << 20);
 
   auto& ids = fileIds();
@@ -549,8 +553,9 @@ TEST_F(CachedBufferedInputTest, hasCache) {
   content.resize(kContentSize);
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
-  io::ReaderOptions readerOptions(
-      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto& ids = fileIds();
   StringIdLease fileId(ids, "testFile");
   StringIdLease groupId(ids, "testGroup");
@@ -581,8 +586,9 @@ TEST_P(CacheRegionTest, cacheAndFind) {
   }
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
-  io::ReaderOptions readerOptions(
-      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto& ids = fileIds();
   StringIdLease fileId(ids, "testFile_cacheAndFind");
   StringIdLease groupId(ids, "testGroup_cacheAndFind");
@@ -649,8 +655,9 @@ TEST_P(CacheRegionTest, smallEntry) {
   }
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
-  io::ReaderOptions readerOptions(
-      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto& ids = fileIds();
   StringIdLease fileId(ids, "testFile_smallEntry");
   StringIdLease groupId(ids, "testGroup_smallEntry");
@@ -719,8 +726,9 @@ TEST_P(CacheRegionTest, largeEntry) {
   }
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
-  io::ReaderOptions readerOptions(
-      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto& ids = fileIds();
   StringIdLease fileId(ids, "testFile_largeEntry");
   StringIdLease groupId(ids, "testGroup_largeEntry");
@@ -783,8 +791,9 @@ TEST_P(CacheRegionTest, miss) {
   std::string content(kContentSize, 'x');
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
-  io::ReaderOptions readerOptions(
-      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto& ids = fileIds();
   StringIdLease fileId(ids, "testFile_miss");
   StringIdLease groupId(ids, "testGroup_miss");
@@ -815,8 +824,9 @@ TEST_P(CacheRegionTest, pinKeepsDataAlive) {
   }
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
-  io::ReaderOptions readerOptions(
-      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto& ids = fileIds();
   StringIdLease fileId(ids, "testFile_pinAlive");
   StringIdLease groupId(ids, "testGroup_pinAlive");
@@ -883,8 +893,9 @@ TEST_F(CachedBufferedInputTest, findCachedRegionExclusiveWithWait) {
   }
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
-  io::ReaderOptions readerOptions(
-      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto& ids = fileIds();
   const std::string fileName = "testFile_findWait";
   StringIdLease fileId(ids, fileName);
@@ -966,8 +977,9 @@ TEST_F(CachedBufferedInputTest, cacheRegionSkipsOngoingInsert) {
   }
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
-  io::ReaderOptions readerOptions(
-      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto& ids = fileIds();
   const std::string fileName = "testFile_skipInsert";
   StringIdLease fileId(ids, fileName);
@@ -1031,8 +1043,9 @@ TEST_F(CachedBufferedInputTest, preloadCalledTwice) {
   std::string content(1024, 'x');
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
-  io::ReaderOptions readerOptions(
-      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto& ids = fileIds();
   StringIdLease fileId(ids, "preloadTwice");
   StringIdLease groupId(ids, "preloadTwiceGroup");
@@ -1058,8 +1071,9 @@ TEST_F(CachedBufferedInputTest, isBufferedWithPreload) {
   std::string content(1024, 'x');
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
-  io::ReaderOptions readerOptions(
-      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto& ids = fileIds();
   StringIdLease fileId(ids, "isBufferedPreload");
   StringIdLease groupId(ids, "isBufferedPreloadGroup");
@@ -1091,8 +1105,9 @@ TEST_F(CachedBufferedInputTest, enqueueSkipsRequestsWhenPreloaded) {
   std::string content(1024, 'x');
   auto readFile = std::make_shared<tests::utils::CountingReadFile>(content);
 
-  io::ReaderOptions readerOptions(
-      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto& ids = fileIds();
   StringIdLease fileId(ids, "enqueueSkipsRequests");
   StringIdLease groupId(ids, "enqueueSkipsRequestsGroup");
@@ -1142,8 +1157,9 @@ TEST_F(CachedBufferedInputTest, readSetsPreloadedPinWhenPreloaded) {
   }
   auto readFile = std::make_shared<tests::utils::CountingReadFile>(content);
 
-  io::ReaderOptions readerOptions(
-      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setLoadQuantum(1 << 20);
 
   auto& ids = fileIds();
@@ -1185,8 +1201,9 @@ TEST_F(CachedBufferedInputTest, preloadAfterEnqueue) {
   std::string content(1024, 'x');
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
-  io::ReaderOptions readerOptions(
-      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto& ids = fileIds();
   StringIdLease fileId(ids, "preloadAfterEnqueue");
   StringIdLease groupId(ids, "preloadAfterEnqueueGroup");
@@ -1221,8 +1238,9 @@ TEST_F(CachedBufferedInputTest, preloadedStreamSkipsEviction) {
   }
   auto readFile = std::make_shared<tests::utils::CountingReadFile>(content);
 
-  io::ReaderOptions readerOptions(
-      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setCacheable(false);
   readerOptions.setLoadQuantum(1 << 20);
 
@@ -1285,8 +1303,9 @@ TEST_F(CachedBufferedInputTest, preloadRespectsNotCacheable) {
   }
   auto readFile = std::make_shared<tests::utils::CountingReadFile>(content);
 
-  io::ReaderOptions readerOptions(
-      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setCacheable(false);
   readerOptions.setLoadQuantum(1 << 20);
 
@@ -1332,8 +1351,9 @@ TEST_F(CachedBufferedInputTest, preloadRespectsCacheable) {
   }
   auto readFile = std::make_shared<tests::utils::CountingReadFile>(content);
 
-  io::ReaderOptions readerOptions(
-      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setCacheable(true);
   readerOptions.setLoadQuantum(1 << 20);
 
@@ -1391,8 +1411,9 @@ TEST_F(CachedBufferedInputTest, preload) {
     }
     auto readFile = std::make_shared<tests::utils::CountingReadFile>(content);
 
-    io::ReaderOptions readerOptions(
-        pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+    io::ReaderOptions readerOptions(pool_.get());
+    readerOptions.setDataIoStats(dataIoStats_.get());
+    readerOptions.setMetadataIoStats(metadataIoStats_.get());
     readerOptions.setLoadQuantum(1 << 20);
 
     auto& ids = fileIds();
@@ -1473,8 +1494,9 @@ TEST_F(CachedBufferedInputTest, preloadCacheSharing) {
   }
   auto readFile = std::make_shared<tests::utils::CountingReadFile>(content);
 
-  io::ReaderOptions readerOptions(
-      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setLoadQuantum(1 << 20);
 
   auto& ids = fileIds();
@@ -1557,8 +1579,9 @@ TEST_F(CachedBufferedInputTest, prefetchScope) {
   }
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
-  io::ReaderOptions readerOptions(
-      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
 
   auto& ids = fileIds();
   StringIdLease fileId(ids, "testFile");
@@ -1620,8 +1643,9 @@ TEST_F(CachedBufferedInputTest, cloneNonCacheable) {
   std::string content(kContentSize, 'x');
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
-  io::ReaderOptions readerOptions(
-      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setLoadQuantum(1 << 20);
 
   auto& ids = fileIds();

--- a/velox/dwio/common/tests/DirectBufferedInputTest.cpp
+++ b/velox/dwio/common/tests/DirectBufferedInputTest.cpp
@@ -96,8 +96,9 @@ TEST_F(DirectBufferedInputTest, reset) {
 
     auto readFile = std::make_shared<InMemoryReadFile>(content);
 
-    io::ReaderOptions readerOptions(
-        pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+    io::ReaderOptions readerOptions(pool_.get());
+    readerOptions.setDataIoStats(dataIoStats_.get());
+    readerOptions.setMetadataIoStats(metadataIoStats_.get());
     readerOptions.setLoadQuantum(1 << 20);
 
     auto& ids = fileIds();
@@ -222,8 +223,9 @@ TEST_F(DirectBufferedInputTest, readAfterReset) {
 
     auto readFile = std::make_shared<InMemoryReadFile>(content);
 
-    io::ReaderOptions readerOptions(
-        pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+    io::ReaderOptions readerOptions(pool_.get());
+    readerOptions.setDataIoStats(dataIoStats_.get());
+    readerOptions.setMetadataIoStats(metadataIoStats_.get());
     readerOptions.setLoadQuantum(1 << 20);
 
     auto& ids = fileIds();
@@ -301,8 +303,9 @@ DEBUG_ONLY_TEST_F(DirectBufferedInputTest, resetInputWithBeforeLoading) {
 
     auto readFile = std::make_shared<InMemoryReadFile>(content);
 
-    io::ReaderOptions readerOptions(
-        pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+    io::ReaderOptions readerOptions(pool_.get());
+    readerOptions.setDataIoStats(dataIoStats_.get());
+    readerOptions.setMetadataIoStats(metadataIoStats_.get());
     readerOptions.setLoadQuantum(1 << 20);
 
     auto& ids = fileIds();
@@ -407,8 +410,9 @@ DEBUG_ONLY_TEST_F(DirectBufferedInputTest, resetInputWithAfterLoading) {
 
     auto readFile = std::make_shared<InMemoryReadFile>(content);
 
-    io::ReaderOptions readerOptions(
-        pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+    io::ReaderOptions readerOptions(pool_.get());
+    readerOptions.setDataIoStats(dataIoStats_.get());
+    readerOptions.setMetadataIoStats(metadataIoStats_.get());
     readerOptions.setLoadQuantum(1 << 20);
 
     auto& ids = fileIds();
@@ -499,8 +503,9 @@ TEST_F(DirectBufferedInputTest, preloadCalledTwice) {
   std::string content(1024, 'x');
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
-  io::ReaderOptions readerOptions(
-      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto& ids = fileIds();
   StringIdLease fileId(ids, "preloadTwice");
   StringIdLease groupId(ids, "preloadTwiceGroup");
@@ -525,8 +530,9 @@ TEST_F(DirectBufferedInputTest, isBufferedWithPreload) {
   std::string content(1024, 'x');
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
-  io::ReaderOptions readerOptions(
-      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto& ids = fileIds();
   StringIdLease fileId(ids, "isBufferedPreload");
   StringIdLease groupId(ids, "isBufferedPreloadGroup");
@@ -557,8 +563,9 @@ TEST_F(DirectBufferedInputTest, enqueueSkipsRequestsWhenPreloaded) {
   std::string content(1024, 'x');
   auto readFile = std::make_shared<tests::utils::CountingReadFile>(content);
 
-  io::ReaderOptions readerOptions(
-      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto& ids = fileIds();
   StringIdLease fileId(ids, "enqueueSkipsRequests");
   StringIdLease groupId(ids, "enqueueSkipsRequestsGroup");
@@ -602,8 +609,9 @@ TEST_F(DirectBufferedInputTest, preloadAfterEnqueue) {
   std::string content(1024, 'x');
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
-  io::ReaderOptions readerOptions(
-      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto& ids = fileIds();
   StringIdLease fileId(ids, "preloadAfterEnqueue");
   StringIdLease groupId(ids, "preloadAfterEnqueueGroup");
@@ -628,8 +636,9 @@ TEST_F(DirectBufferedInputTest, preloadedDataWithoutPreload) {
   std::string content(1024, 'x');
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
-  io::ReaderOptions readerOptions(
-      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto& ids = fileIds();
   StringIdLease fileId(ids, "preloadedDataNoPreload");
   StringIdLease groupId(ids, "preloadedDataNoPreloadGroup");
@@ -653,8 +662,9 @@ TEST_F(DirectBufferedInputTest, preloadedDataOffsetOutOfRange) {
   std::string content(1024, 'x');
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
-  io::ReaderOptions readerOptions(
-      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto& ids = fileIds();
   StringIdLease fileId(ids, "preloadedDataOOR");
   StringIdLease groupId(ids, "preloadedDataOORGroup");
@@ -701,8 +711,9 @@ TEST_F(DirectBufferedInputTest, preload) {
     }
     auto readFile = std::make_shared<tests::utils::CountingReadFile>(content);
 
-    io::ReaderOptions readerOptions(
-        pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+    io::ReaderOptions readerOptions(pool_.get());
+    readerOptions.setDataIoStats(dataIoStats_.get());
+    readerOptions.setMetadataIoStats(metadataIoStats_.get());
     readerOptions.setLoadQuantum(1 << 20);
 
     auto& ids = fileIds();
@@ -811,8 +822,9 @@ TEST_F(DirectBufferedInputTest, preloadedData) {
     }
     auto readFile = std::make_shared<tests::utils::CountingReadFile>(content);
 
-    io::ReaderOptions readerOptions(
-        pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+    io::ReaderOptions readerOptions(pool_.get());
+    readerOptions.setDataIoStats(dataIoStats_.get());
+    readerOptions.setMetadataIoStats(metadataIoStats_.get());
     auto& ids = fileIds();
     StringIdLease fileId(
         ids,
@@ -876,8 +888,9 @@ TEST_F(DirectBufferedInputTest, hasCache) {
   std::string content(1024, 'x');
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
-  io::ReaderOptions readerOptions(
-      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
 
   auto& ids = fileIds();
   StringIdLease fileId(ids, "testFile");

--- a/velox/dwio/common/tests/utils/E2EFilterTestBase.cpp
+++ b/velox/dwio/common/tests/utils/E2EFilterTestBase.cpp
@@ -433,8 +433,9 @@ void E2EFilterTestBase::readWithoutFilter(
     const std::vector<RowVectorPtr>& batches,
     uint64_t& time) {
   SCOPED_TRACE("Read without filter");
-  dwio::common::ReaderOptions readerOpts{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  readerOpts.setDataIoStats(dataIoStats_.get());
+  readerOpts.setMetadataIoStats(metadataIoStats_.get());
   dwio::common::RowReaderOptions rowReaderOpts;
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
@@ -488,8 +489,9 @@ void E2EFilterTestBase::readWithFilter(
     bool useValueHook,
     bool skipCheck) {
   SCOPED_TRACE("Read with filter");
-  dwio::common::ReaderOptions readerOpts{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  readerOpts.setDataIoStats(dataIoStats_.get());
+  readerOpts.setMetadataIoStats(metadataIoStats_.get());
   dwio::common::RowReaderOptions rowReaderOpts;
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
@@ -877,8 +879,9 @@ void E2EFilterTestBase::testMetadataFilterImpl(
   specB->setChannel(1);
   specC->setProjectOut(true);
   specC->setChannel(0);
-  ReaderOptions readerOpts{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  ReaderOptions readerOpts{leafPool_.get()};
+  readerOpts.setDataIoStats(dataIoStats_.get());
+  readerOpts.setMetadataIoStats(metadataIoStats_.get());
   RowReaderOptions rowReaderOpts;
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
@@ -1141,8 +1144,9 @@ void E2EFilterTestBase::testSubfieldsPruning() {
   auto specF = spec->addFieldRecursively("f", *ARRAY(BIGINT()), 5);
   specF->childByName(common::ScanSpec::kArrayElementsFieldName)
       ->setFilter(common::createBigintValues({0, 2, 4}, false));
-  ReaderOptions readerOpts{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  ReaderOptions readerOpts{leafPool_.get()};
+  readerOpts.setDataIoStats(dataIoStats_.get());
+  readerOpts.setMetadataIoStats(metadataIoStats_.get());
   RowReaderOptions rowReaderOpts;
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
@@ -1232,8 +1236,9 @@ void E2EFilterTestBase::testMutationCornerCases() {
   }
   auto& rowType = batches[0]->type();
   writeToMemory(rowType, batches, false);
-  ReaderOptions readerOpts{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  ReaderOptions readerOpts{leafPool_.get()};
+  readerOpts.setDataIoStats(dataIoStats_.get());
+  readerOpts.setMetadataIoStats(metadataIoStats_.get());
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
   auto reader = makeReader(readerOpts, std::move(input));

--- a/velox/dwio/dwrf/reader/ReaderBase.h
+++ b/velox/dwio/dwrf/reader/ReaderBase.h
@@ -84,10 +84,12 @@ class ReaderBase {
       std::unique_ptr<encryption::DecryptionHandler> handler,
       io::IoStatistics* dataIoStats,
       io::IoStatistics* metadataIoStats)
-      : options_{dwio::common::ReaderOptions(
-            &pool,
-            dataIoStats,
-            metadataIoStats)},
+      : options_{[&] {
+          dwio::common::ReaderOptions opts(&pool);
+          opts.setDataIoStats(dataIoStats);
+          opts.setMetadataIoStats(metadataIoStats);
+          return opts;
+        }()},
         input_{std::move(input)},
         fileLength_{0},
         postScript_{std::move(ps)},
@@ -272,7 +274,9 @@ class ReaderBase {
       dwio::common::FileFormat fileFormat,
       io::IoStatistics* dataIoStats,
       io::IoStatistics* metadataIoStats) {
-    dwio::common::ReaderOptions options(&pool, dataIoStats, metadataIoStats);
+    dwio::common::ReaderOptions options(&pool);
+    options.setDataIoStats(dataIoStats);
+    options.setMetadataIoStats(metadataIoStats);
     options.setFileFormat(fileFormat);
     return options;
   }

--- a/velox/dwio/dwrf/test/CacheInputTest.cpp
+++ b/velox/dwio/dwrf/test/CacheInputTest.cpp
@@ -222,8 +222,9 @@ class CacheTest : public ::testing::Test {
       const IoStatisticsPtr& ioStatistics,
       const std::shared_ptr<facebook::velox::IoStats>& ioStats) {
     auto data = std::make_unique<StripeData>();
-    auto readOptions = io::ReaderOptions(
-        pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+    auto readOptions = io::ReaderOptions(pool_.get());
+    readOptions.setDataIoStats(dataIoStats_.get());
+    readOptions.setMetadataIoStats(metadataIoStats_.get());
     readOptions.setCacheable(cacheable);
     data->input = std::make_unique<CachedBufferedInput>(
         readFile,
@@ -491,8 +492,12 @@ TEST_F(CacheTest, window) {
       dataIoStats_,
       ioStats_,
       executor_.get(),
-      io::ReaderOptions(
-          pool_.get(), dataIoStats_.get(), metadataIoStats_.get()));
+      [&] {
+        io::ReaderOptions opts(pool_.get());
+        opts.setDataIoStats(dataIoStats_.get());
+        opts.setMetadataIoStats(metadataIoStats_.get());
+        return opts;
+      }());
   auto begin = 4 * kMB;
   auto end = 17 * kMB;
   auto stream = input->read(begin, end - begin, LogType::TEST);
@@ -739,7 +744,9 @@ class FileWithReadAhead {
       std::shared_ptr<facebook::velox::IoStats> ioStats,
       memory::MemoryPool& pool,
       folly::Executor* executor)
-      : options_(&pool, &dataIoStats_, &metadataIoStats_) {
+      : options_(&pool) {
+    options_.setDataIoStats(&dataIoStats_);
+    options_.setMetadataIoStats(&metadataIoStats_);
     fileId_ = std::make_unique<StringIdLease>(fileIds(), name);
     file_ = std::make_shared<TestReadFile>(fileId_->id(), kFileSize, ioStats);
     options_.setCacheable(false);
@@ -960,8 +967,9 @@ TEST_F(CacheTest, loadQuotumTooLarge) {
   StringIdLease fileId{fileIds(), "foo"};
   auto readFile =
       std::make_shared<TestReadFile>(fileId.id(), 10 << 20, nullptr);
-  auto readOptions = io::ReaderOptions(
-      pool_.get(), dataIoStats_.get(), metadataIoStats_.get());
+  auto readOptions = io::ReaderOptions(pool_.get());
+  readOptions.setDataIoStats(dataIoStats_.get());
+  readOptions.setMetadataIoStats(metadataIoStats_.get());
   readOptions.setLoadQuantum(9 << 20 /*9MB*/);
   VELOX_ASSERT_THROW(
       std::make_unique<CachedBufferedInput>(
@@ -999,8 +1007,12 @@ TEST_F(CacheTest, ssdReadVerification) {
       dataIoStats_,
       ioStats_,
       executor_.get(),
-      io::ReaderOptions(
-          pool_.get(), dataIoStats_.get(), metadataIoStats_.get()));
+      [&] {
+        io::ReaderOptions opts(pool_.get());
+        opts.setDataIoStats(dataIoStats_.get());
+        opts.setMetadataIoStats(metadataIoStats_.get());
+        return opts;
+      }());
 
   const auto readData = [&](uint32_t numBytesRead) {
     const uint64_t kNumBytesPerRead = 4 << 20;

--- a/velox/dwio/dwrf/test/ColumnWriterStatsTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterStatsTests.cpp
@@ -195,8 +195,9 @@ class ColumnWriterStatsTest : public ::testing::Test {
         std::make_shared<facebook::velox::InMemoryReadFile>(std::move(data));
     auto input = std::make_unique<BufferedInput>(readFile, *leafPool_);
 
-    dwio::common::ReaderOptions readerOpts{
-        leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+    dwio::common::ReaderOptions readerOpts(leafPool_.get());
+    readerOpts.setDataIoStats(dataIoStats_.get());
+    readerOpts.setMetadataIoStats(metadataIoStats_.get());
     RowReaderOptions rowReaderOpts;
     auto reader = std::make_unique<DwrfReader>(readerOpts, std::move(input));
     return reader->createRowReader(rowReaderOpts);

--- a/velox/dwio/dwrf/test/DirectBufferedInputTest.cpp
+++ b/velox/dwio/dwrf/test/DirectBufferedInputTest.cpp
@@ -58,8 +58,9 @@ class DirectBufferedInputTest : public testing::Test {
     ioStats_ = std::make_shared<facebook::velox::IoStats>();
     tracker_ = std::make_shared<cache::ScanTracker>("", nullptr, kLoadQuantum);
     file_ = std::make_shared<TestReadFile>(11, 100 << 20, ioStats_);
-    opts_ = std::make_unique<dwio::common::ReaderOptions>(
-        pool_.get(), ioStatistics_.get(), metadataIoStats_.get());
+    opts_ = std::make_unique<dwio::common::ReaderOptions>(pool_.get());
+    opts_->setDataIoStats(ioStatistics_.get());
+    opts_->setMetadataIoStats(metadataIoStats_.get());
     opts_->setLoadQuantum(kLoadQuantum);
   }
 

--- a/velox/dwio/dwrf/test/E2EReaderTest.cpp
+++ b/velox/dwio/dwrf/test/E2EReaderTest.cpp
@@ -178,8 +178,9 @@ TEST_P(E2EReaderTest, SharedDictionaryFlatmapReadAsStruct) {
   writer->close();
   writer.reset();
 
-  dwio::common::ReaderOptions readerOpts{
-      pool.get(), &dataIoStats_, &metadataIoStats_};
+  dwio::common::ReaderOptions readerOpts(pool.get());
+  readerOpts.setDataIoStats(&dataIoStats_);
+  readerOpts.setMetadataIoStats(&metadataIoStats_);
   auto bufferedInput = std::make_unique<BufferedInput>(
       std::make_shared<LocalReadFile>(path), *pool);
   auto reader = DwrfReader::create(std::move(bufferedInput), readerOpts);

--- a/velox/dwio/dwrf/test/E2EWriterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EWriterTest.cpp
@@ -110,8 +110,9 @@ class E2EWriterTest : public testing::Test {
 
     writer.close();
 
-    dwio::common::ReaderOptions readerOpts{
-        leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+    dwio::common::ReaderOptions readerOpts(leafPool_.get());
+    readerOpts.setDataIoStats(dataIoStats_.get());
+    readerOpts.setMetadataIoStats(metadataIoStats_.get());
     RowReaderOptions rowReaderOpts;
     auto reader = createReader(*sinkPtr, readerOpts);
     auto rowReader = reader->createRowReader(rowReaderOpts);
@@ -173,8 +174,9 @@ class E2EWriterTest : public testing::Test {
 
     writer.close();
 
-    dwio::common::ReaderOptions readerOpts{
-        leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+    dwio::common::ReaderOptions readerOpts(leafPool_.get());
+    readerOpts.setDataIoStats(dataIoStats_.get());
+    readerOpts.setMetadataIoStats(metadataIoStats_.get());
     RowReaderOptions rowReaderOpts;
     auto reader = createReader(*sinkPtr, readerOpts);
     auto rowReader = reader->createRowReader(rowReaderOpts);
@@ -576,8 +578,9 @@ TEST_F(E2EWriterTest, PresentStreamIsSuppressedOnFlatMap) {
       config,
       dwrf::E2EWriterTestUtil::simpleFlushPolicyFactory(true));
 
-  dwio::common::ReaderOptions readerOpts{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOpts(leafPool_.get());
+  readerOpts.setDataIoStats(dataIoStats_.get());
+  readerOpts.setMetadataIoStats(metadataIoStats_.get());
   RowReaderOptions rowReaderOpts;
   auto reader = createReader(*sinkPtr, readerOpts);
   auto rowReader = reader->createRowReader(rowReaderOpts);
@@ -949,8 +952,9 @@ TEST_F(E2EWriterTest, PartialStride) {
   writer.write(batch);
   writer.close();
 
-  dwio::common::ReaderOptions readerOpts{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOpts(leafPool_.get());
+  readerOpts.setDataIoStats(dataIoStats_.get());
+  readerOpts.setMetadataIoStats(metadataIoStats_.get());
   RowReaderOptions rowReaderOpts;
   auto reader = createReader(*sinkPtr, readerOpts);
   ASSERT_EQ(
@@ -1150,8 +1154,9 @@ class E2EEncryptionTest : public E2EWriterTest {
     writer_->close();
 
     // read it back for compare
-    dwio::common::ReaderOptions readerOpts{
-        leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+    dwio::common::ReaderOptions readerOpts(leafPool_.get());
+    readerOpts.setDataIoStats(dataIoStats_.get());
+    readerOpts.setMetadataIoStats(metadataIoStats_.get());
     readerOpts.setDecrypterFactory(decrypterFactory);
     return createReader(*sink_, readerOpts);
   }

--- a/velox/dwio/dwrf/test/ReaderTest.cpp
+++ b/velox/dwio/dwrf/test/ReaderTest.cpp
@@ -278,7 +278,9 @@ void verifyFlatMapReading(
     io::IoStatistics& metadataIoStats,
     const std::vector<uint32_t>& expectedPrefetchRowSizes = {},
     const std::vector<bool>& shouldTryPrefetch = {}) {
-  dwio::common::ReaderOptions readerOpts{pool, &dataIoStats, &metadataIoStats};
+  dwio::common::ReaderOptions readerOpts{pool};
+  readerOpts.setDataIoStats(&dataIoStats);
+  readerOpts.setMetadataIoStats(&metadataIoStats);
 
   /* If an extra sanity check is desired you can uncomment the 2 below lines and
    * re-run */
@@ -401,8 +403,9 @@ TEST_P(TestFlatMapReader, testReadFlatMapEmptyMap) {
   const std::string emptyFile(getExampleFilePath("empty_flatmap.orc"));
   auto returnFlatVector = GetParam();
 
-  dwio::common::ReaderOptions readerOpts{
-      pool(), &dataIoStats_, &metadataIoStats_};
+  dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setDataIoStats(&dataIoStats_);
+  readerOpts.setMetadataIoStats(&metadataIoStats_);
   RowReaderOptions rowReaderOpts;
   rowReaderOpts.setReturnFlatVector(returnFlatVector);
   std::shared_ptr<const RowType> emptyFileType =
@@ -432,8 +435,9 @@ TEST_P(TestFlatMapReader, testStringKeyLifeCycle) {
   auto returnFlatVector = GetParam();
 
   VectorPtr batch;
-  dwio::common::ReaderOptions readerOptions{
-      pool(), &dataIoStats_, &metadataIoStats_};
+  dwio::common::ReaderOptions readerOptions{pool()};
+  readerOptions.setDataIoStats(&dataIoStats_);
+  readerOptions.setMetadataIoStats(&metadataIoStats_);
 
   {
     RowReaderOptions rowReaderOptions;
@@ -557,8 +561,9 @@ class TestFlatMapReaderFlatLayout
 };
 
 TEST_P(TestFlatMapReaderFlatLayout, testCompare) {
-  dwio::common::ReaderOptions readerOptions{
-      pool(), &dataIoStats_, &metadataIoStats_};
+  dwio::common::ReaderOptions readerOptions{pool()};
+  readerOptions.setDataIoStats(&dataIoStats_);
+  readerOptions.setMetadataIoStats(&metadataIoStats_);
   auto reader = DwrfReader::create(
       createFileBufferedInput(getFMSmallFile(), readerOptions.memoryPool()),
       readerOptions);
@@ -591,8 +596,9 @@ VELOX_INSTANTIATE_TEST_SUITE_P(
 TEST_F(TestReader, testReadFlatMapWithKeyFilters) {
   // batch size is set as 1000 in reading
   // file has schema: a int, b struct<a:int, b:float, c:string>, c float
-  dwio::common::ReaderOptions readerOpts{
-      pool(), &dataIoStats_, &metadataIoStats_};
+  dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setDataIoStats(&dataIoStats_);
+  readerOpts.setMetadataIoStats(&metadataIoStats_);
   RowReaderOptions rowReaderOpts;
   // set map key filter for map1 we only need key=1, and map2 only key-1
   auto cs = std::make_shared<ColumnSelector>(
@@ -645,8 +651,9 @@ TEST_F(TestReader, testReadFlatMapWithKeyFilters) {
 TEST_F(TestReader, testReadFlatMapWithKeyRejectList) {
   // batch size is set as 1000 in reading
   // file has schema: a int, b struct<a:int, b:float, c:string>, c float
-  dwio::common::ReaderOptions readerOpts{
-      pool(), &dataIoStats_, &metadataIoStats_};
+  dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setDataIoStats(&dataIoStats_);
+  readerOpts.setMetadataIoStats(&metadataIoStats_);
   RowReaderOptions rowReaderOpts;
   auto cs = std::make_shared<ColumnSelector>(
       getFlatmapSchema(), std::vector<std::string>{"map1#[\"!2\",\"!3\"]"});
@@ -701,8 +708,9 @@ TEST_F(TestReader, testStatsCallbackFiredWithFiltering) {
         selectedKeyStreamsAggregate += keySelectionStats.selectedKeys;
       });
 
-  dwio::common::ReaderOptions readerOpts{
-      pool(), &dataIoStats_, &metadataIoStats_};
+  dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setDataIoStats(&dataIoStats_);
+  readerOpts.setMetadataIoStats(&metadataIoStats_);
 
   auto reader = DwrfReader::create(
       createFileBufferedInput(getFMSmallFile(), readerOpts.memoryPool()),
@@ -740,8 +748,9 @@ TEST_F(TestReader, testBlockedIoCallbackFiredBlocking) {
       });
   rowReaderOpts.setEagerFirstStripeLoad(false);
 
-  dwio::common::ReaderOptions readerOpts{
-      pool(), &dataIoStats_, &metadataIoStats_};
+  dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setDataIoStats(&dataIoStats_);
+  readerOpts.setMetadataIoStats(&metadataIoStats_);
 
   auto reader = DwrfReader::create(
       createFileBufferedInput(getFMLargeFile(), readerOpts.memoryPool()),
@@ -785,8 +794,9 @@ TEST_F(TestReader, DISABLED_testBlockedIoCallbackFiredNonBlocking) {
       });
   rowReaderOpts.setEagerFirstStripeLoad(false);
 
-  dwio::common::ReaderOptions readerOpts{
-      pool(), &dataIoStats_, &metadataIoStats_};
+  dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setDataIoStats(&dataIoStats_);
+  readerOpts.setMetadataIoStats(&metadataIoStats_);
 
   auto reader = DwrfReader::create(
       createFileBufferedInput(getFMLargeFile(), readerOpts.memoryPool()),
@@ -835,8 +845,9 @@ TEST_F(TestReader, DISABLED_testBlockedIoCallbackFiredWithFirstStripeLoad) {
 
   rowReaderOpts.setEagerFirstStripeLoad(true);
 
-  dwio::common::ReaderOptions readerOpts{
-      pool(), &dataIoStats_, &metadataIoStats_};
+  dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setDataIoStats(&dataIoStats_);
+  readerOpts.setMetadataIoStats(&metadataIoStats_);
 
   auto reader = DwrfReader::create(
       createFileBufferedInput(getFMLargeFile(), readerOpts.memoryPool()),
@@ -871,8 +882,9 @@ TEST_F(TestReader, DISABLED_testBlockedIoCallbackFiredWithFirstStripeLoad) {
 }
 
 TEST_F(TestReader, testEstimatedSize) {
-  dwio::common::ReaderOptions readerOpts{
-      pool(), &dataIoStats_, &metadataIoStats_};
+  dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setDataIoStats(&dataIoStats_);
+  readerOpts.setMetadataIoStats(&metadataIoStats_);
   {
     auto reader = DwrfReader::create(
         createFileBufferedInput(getFMSmallFile(), readerOpts.memoryPool()),
@@ -900,8 +912,9 @@ TEST_F(TestReader, testEstimatedSize) {
 }
 
 TEST_F(TestReader, testSubfieldEstimatedSize) {
-  dwio::common::ReaderOptions readerOpts{
-      pool(), &dataIoStats_, &metadataIoStats_};
+  dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setDataIoStats(&dataIoStats_);
+  readerOpts.setMetadataIoStats(&metadataIoStats_);
   std::shared_ptr<const RowType> schema =
       std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse("struct<\
               a:int,\
@@ -936,8 +949,9 @@ TEST_F(TestReader, testSubfieldEstimatedSize) {
   ASSERT_EQ(rowReader->estimatedRowSize(), 8);
 
   // estimation with full struct field selection
-  dwio::common::ReaderOptions readerOpts2{
-      pool(), &dataIoStats_, &metadataIoStats_};
+  dwio::common::ReaderOptions readerOpts2{pool()};
+  readerOpts2.setDataIoStats(&dataIoStats_);
+  readerOpts2.setMetadataIoStats(&metadataIoStats_);
   auto subfields2 = makeSubfields({"a", "b"});
   folly::F14FastMap<std::string, std::vector<const common::Subfield*>>
       subfields2ByName = groupSubfields(subfields2);
@@ -973,8 +987,9 @@ TEST_F(TestReader, testStatsCallbackFiredWithoutFiltering) {
         selectedKeyStreamsAggregate += keySelectionStats.selectedKeys;
       });
 
-  dwio::common::ReaderOptions readerOpts{
-      pool(), &dataIoStats_, &metadataIoStats_};
+  dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setDataIoStats(&dataIoStats_);
+  readerOpts.setMetadataIoStats(&metadataIoStats_);
 
   auto reader = DwrfReader::create(
       createFileBufferedInput(getFMSmallFile(), readerOpts.memoryPool()),
@@ -1061,7 +1076,9 @@ void verifyFlatmapStructEncoding(
     io::IoStatistics& dataIoStats,
     io::IoStatistics& metadataIoStats,
     size_t batchSize = 1000) {
-  dwio::common::ReaderOptions readerOpts{pool, &dataIoStats, &metadataIoStats};
+  dwio::common::ReaderOptions readerOpts{pool};
+  readerOpts.setDataIoStats(&dataIoStats);
+  readerOpts.setMetadataIoStats(&metadataIoStats);
   auto reader = DwrfReader::create(
       createFileBufferedInput(filename, readerOpts.memoryPool()), readerOpts);
 
@@ -1175,8 +1192,9 @@ TEST_F(TestReader, testFlatmapAsStructRequiringKeyList) {
 // TODO: replace with mock
 TEST_F(TestReader, testMismatchSchemaMoreFields) {
   // file has schema: a int, b struct<a:int, b:float, c:string>, c float
-  dwio::common::ReaderOptions readerOpts{
-      pool(), &dataIoStats_, &metadataIoStats_};
+  dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setDataIoStats(&dataIoStats_);
+  readerOpts.setMetadataIoStats(&metadataIoStats_);
   RowReaderOptions rowReaderOpts;
   std::shared_ptr<const RowType> requestedType =
       std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse(
@@ -1222,8 +1240,9 @@ TEST_F(TestReader, testMismatchSchemaMoreFields) {
 
 TEST_F(TestReader, testMismatchSchemaFewerFields) {
   // file has schema: a int, b struct<a:int, b:float, c:string>, c float
-  dwio::common::ReaderOptions readerOpts{
-      pool(), &dataIoStats_, &metadataIoStats_};
+  dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setDataIoStats(&dataIoStats_);
+  readerOpts.setMetadataIoStats(&metadataIoStats_);
   RowReaderOptions rowReaderOpts;
   std::shared_ptr<const RowType> requestedType =
       std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse(
@@ -1265,8 +1284,9 @@ TEST_F(TestReader, testMismatchSchemaFewerFields) {
 
 TEST_F(TestReader, testMismatchSchemaNestedMoreFields) {
   // file has schema: a int, b struct<a:int, b:float>, c float
-  dwio::common::ReaderOptions readerOpts{
-      pool(), &dataIoStats_, &metadataIoStats_};
+  dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setDataIoStats(&dataIoStats_);
+  readerOpts.setMetadataIoStats(&metadataIoStats_);
   RowReaderOptions rowReaderOpts;
   std::shared_ptr<const RowType> requestedType =
       std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse(
@@ -1333,8 +1353,9 @@ TEST_F(TestReader, testMismatchSchemaNestedMoreFields) {
 
 TEST_F(TestReader, testMismatchSchemaNestedFewerFields) {
   // file has schema: a int, b struct<a:int, b:float>, c float
-  dwio::common::ReaderOptions readerOpts{
-      pool(), &dataIoStats_, &metadataIoStats_};
+  dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setDataIoStats(&dataIoStats_);
+  readerOpts.setMetadataIoStats(&metadataIoStats_);
   RowReaderOptions rowReaderOpts;
   std::shared_ptr<const RowType> requestedType =
       std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse(
@@ -1392,8 +1413,9 @@ TEST_F(TestReader, testMismatchSchemaNestedFewerFields) {
 
 TEST_F(TestReader, testMismatchSchemaIncompatibleNotSelected) {
   // file has schema: a int, b struct<a:int, b:float>, c float
-  dwio::common::ReaderOptions readerOpts{
-      pool(), &dataIoStats_, &metadataIoStats_};
+  dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setDataIoStats(&dataIoStats_);
+  readerOpts.setMetadataIoStats(&metadataIoStats_);
   RowReaderOptions rowReaderOpts;
   std::shared_ptr<const RowType> requestedType =
       std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse(
@@ -1475,8 +1497,9 @@ TEST_F(TestReader, testMismatchSchemaIncompatible) {
 
 TEST_F(TestReader, fileColumnNamesReadAsLowerCase) {
   // upper.orc holds one columns (Bool_Val: BOOLEAN, b: BIGINT)
-  dwio::common::ReaderOptions readerOpts{
-      pool(), &dataIoStats_, &metadataIoStats_};
+  dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setDataIoStats(&dataIoStats_);
+  readerOpts.setMetadataIoStats(&metadataIoStats_);
   readerOpts.setFileColumnNamesReadAsLowerCase(true);
   auto reader = DwrfReader::create(
       createFileBufferedInput(
@@ -1490,8 +1513,9 @@ TEST_F(TestReader, fileColumnNamesReadAsLowerCase) {
 TEST_F(TestReader, fileColumnNamesReadAsLowerCaseComplexStruct) {
   // upper_complex.orc holds type
   // Cc:struct<CcLong0:bigint,CcMap1:map<string,struct<CcArray2:array<struct<CcInt3:int>>>>>
-  dwio::common::ReaderOptions readerOpts{
-      pool(), &dataIoStats_, &metadataIoStats_};
+  dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setDataIoStats(&dataIoStats_);
+  readerOpts.setMetadataIoStats(&metadataIoStats_);
   readerOpts.setFileColumnNamesReadAsLowerCase(true);
   auto reader = DwrfReader::create(
       createFileBufferedInput(
@@ -1529,8 +1553,9 @@ TEST_F(TestReader, fileColumnNamesReadAsLowerCaseComplexStruct) {
 }
 
 TEST_F(TestReader, TestStripeSizeCallback) {
-  dwio::common::ReaderOptions readerOpts{
-      pool(), &dataIoStats_, &metadataIoStats_};
+  dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setDataIoStats(&dataIoStats_);
+  readerOpts.setMetadataIoStats(&metadataIoStats_);
   readerOpts.setFilePreloadThreshold(0);
   readerOpts.setFooterSpeculativeIoSize(17);
   RowReaderOptions rowReaderOpts;
@@ -1558,8 +1583,9 @@ TEST_F(TestReader, TestStripeSizeCallback) {
 }
 
 TEST_F(TestReader, TestStripeSizeCallbackLimitsOneStripe) {
-  dwio::common::ReaderOptions readerOpts{
-      pool(), &dataIoStats_, &metadataIoStats_};
+  dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setDataIoStats(&dataIoStats_);
+  readerOpts.setMetadataIoStats(&metadataIoStats_);
   readerOpts.setFilePreloadThreshold(0);
   readerOpts.setFooterSpeculativeIoSize(17);
   RowReaderOptions rowReaderOpts;
@@ -1588,8 +1614,9 @@ TEST_F(TestReader, TestStripeSizeCallbackLimitsOneStripe) {
 }
 
 TEST_F(TestReader, TestStripeSizeCallbackLimitsTwoStripe) {
-  dwio::common::ReaderOptions readerOpts{
-      pool(), &dataIoStats_, &metadataIoStats_};
+  dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setDataIoStats(&dataIoStats_);
+  readerOpts.setMetadataIoStats(&metadataIoStats_);
   readerOpts.setFilePreloadThreshold(0);
   readerOpts.setFooterSpeculativeIoSize(17);
   RowReaderOptions rowReaderOpts;
@@ -1881,8 +1908,9 @@ TEST_F(TestReader, testEmptyFile) {
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<InMemoryReadFile>(std::move(data)), *pool());
 
-  dwio::common::ReaderOptions readerOpts{
-      pool(), &dataIoStats_, &metadataIoStats_};
+  dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setDataIoStats(&dataIoStats_);
+  readerOpts.setMetadataIoStats(&metadataIoStats_);
   RowReaderOptions rowReaderOpts;
 
   auto rowReader = DwrfReader::create(std::move(input), readerOpts)
@@ -1987,7 +2015,9 @@ void testBufferLifeCycle(
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<InMemoryReadFile>(std::move(data)), *pool);
 
-  dwio::common::ReaderOptions readerOpts{pool, &dataIoStats, &metadataIoStats};
+  dwio::common::ReaderOptions readerOpts{pool};
+  readerOpts.setDataIoStats(&dataIoStats);
+  readerOpts.setMetadataIoStats(&metadataIoStats);
   RowReaderOptions rowReaderOpts;
   rowReaderOpts.setReturnFlatVector(true);
   auto reader = std::make_unique<DwrfReader>(readerOpts, std::move(input));
@@ -2047,7 +2077,9 @@ void testFlatmapAsMapFieldLifeCycle(
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<InMemoryReadFile>(std::move(data)), *pool);
 
-  dwio::common::ReaderOptions readerOpts{pool, &dataIoStats, &metadataIoStats};
+  dwio::common::ReaderOptions readerOpts{pool};
+  readerOpts.setDataIoStats(&dataIoStats);
+  readerOpts.setMetadataIoStats(&metadataIoStats);
   RowReaderOptions rowReaderOpts;
   rowReaderOpts.setReturnFlatVector(true);
   auto reader = std::make_unique<DwrfReader>(readerOpts, std::move(input));
@@ -2278,7 +2310,9 @@ createWriterReader(
   std::string data(sinkPtr->data(), sinkPtr->size());
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<InMemoryReadFile>(std::move(data)), *pool);
-  dwio::common::ReaderOptions readerOpts(pool, &dataIoStats, &metadataIoStats);
+  dwio::common::ReaderOptions readerOpts(pool);
+  readerOpts.setDataIoStats(&dataIoStats);
+  readerOpts.setMetadataIoStats(&metadataIoStats);
   readerOpts.setFileFormat(FileFormat::DWRF);
   auto reader = DwrfReader::create(std::move(input), readerOpts);
   return std::make_pair(std::move(writer), std::move(reader));
@@ -2934,8 +2968,9 @@ TEST_F(TestReader, skipLongString) {
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<LocalReadFile>(getExampleFilePath("long_string.dwrf")),
       *pool());
-  dwio::common::ReaderOptions readerOpts(
-      pool(), &dataIoStats_, &metadataIoStats_);
+  dwio::common::ReaderOptions readerOpts(pool());
+  readerOpts.setDataIoStats(&dataIoStats_);
+  readerOpts.setMetadataIoStats(&metadataIoStats_);
   readerOpts.setFileFormat(FileFormat::DWRF);
   auto reader = DwrfReader::create(std::move(input), readerOpts);
   auto spec = std::make_shared<common::ScanSpec>("<root>");
@@ -3114,8 +3149,9 @@ DEBUG_ONLY_TEST_F(TestReader, asyncLoadSurvivesReaderDestruction) {
 
   // Make sure ReaderOptions and DwrfRowReader are freed after {} scope
   {
-    dwio::common::ReaderOptions readerOpts(
-        pool(), &dataIoStats_, &metadataIoStats_);
+    dwio::common::ReaderOptions readerOpts(pool());
+    readerOpts.setDataIoStats(&dataIoStats_);
+    readerOpts.setMetadataIoStats(&metadataIoStats_);
     readerOpts.setFileFormat(FileFormat::DWRF);
     auto reader = DwrfReader::create(std::move(input), readerOpts);
 

--- a/velox/dwio/dwrf/test/WriterTest.cpp
+++ b/velox/dwio/dwrf/test/WriterTest.cpp
@@ -62,8 +62,9 @@ class WriterTest : public Test {
     std::string data(sinkPtr_->data(), sinkPtr_->size());
     auto readFile = std::make_shared<InMemoryReadFile>(std::move(data));
     auto input = std::make_unique<BufferedInput>(std::move(readFile), *pool_);
-    dwio::common::ReaderOptions readerOpts{
-        pool_.get(), &dataIoStats_, &metadataIoStats_};
+    dwio::common::ReaderOptions readerOpts(pool_.get());
+    readerOpts.setDataIoStats(&dataIoStats_);
+    readerOpts.setMetadataIoStats(&metadataIoStats_);
     auto reader = std::make_unique<ReaderBase>(readerOpts, std::move(input));
     reader->loadCache();
     return reader;

--- a/velox/dwio/dwrf/test/utils/E2EWriterTestUtil.cpp
+++ b/velox/dwio/dwrf/test/utils/E2EWriterTestUtil.cpp
@@ -117,7 +117,9 @@ namespace facebook::velox::dwrf {
 
   io::IoStatistics dataIoStats;
   io::IoStatistics metadataIoStats;
-  dwio::common::ReaderOptions readerOpts{&pool, &dataIoStats, &metadataIoStats};
+  dwio::common::ReaderOptions readerOpts(&pool);
+  readerOpts.setDataIoStats(&dataIoStats);
+  readerOpts.setMetadataIoStats(&metadataIoStats);
   RowReaderOptions rowReaderOpts;
   auto reader = std::make_unique<DwrfReader>(readerOpts, std::move(input));
   EXPECT_GE(numStripesUpper, reader->getNumberOfStripes());

--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -668,8 +668,9 @@ TEST_F(E2EFilterTest, largeMetadata) {
       std::static_pointer_cast<RowVector>(test::BatchMaker::createBatch(
           rowType_, 1000, *leafPool_, nullptr, 0)));
   writeToMemory(rowType_, batches, false);
-  dwio::common::ReaderOptions readerOpts{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOpts(leafPool_.get());
+  readerOpts.setDataIoStats(dataIoStats_.get());
+  readerOpts.setMetadataIoStats(metadataIoStats_.get());
   readerOpts.setFooterSpeculativeIoSize(1024);
   readerOpts.setFilePreloadThreshold(1024 * 8);
   dwio::common::RowReaderOptions rowReaderOpts;
@@ -754,8 +755,9 @@ TEST_F(E2EFilterTest, combineRowGroup) {
             rowType_, 1, *leafPool_, nullptr, 0)));
   }
   writeToMemory(rowType_, batches, false);
-  dwio::common::ReaderOptions readerOpts{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOpts(leafPool_.get());
+  readerOpts.setDataIoStats(dataIoStats_.get());
+  readerOpts.setMetadataIoStats(metadataIoStats_.get());
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
   auto reader = makeReader(readerOpts, std::move(input));
@@ -812,8 +814,9 @@ TEST_F(E2EFilterTest, parquetMRVersionStringStatsRowGroupFiltering) {
             {kSanXing, kVivo, kSanXing, kVivo, kSanXing})}));
     writer->close();
 
-    dwio::common::ReaderOptions readerOptions{
-        leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+    dwio::common::ReaderOptions readerOptions(leafPool_.get());
+    readerOptions.setDataIoStats(dataIoStats_.get());
+    readerOptions.setMetadataIoStats(metadataIoStats_.get());
     auto input = std::make_unique<BufferedInput>(
         std::make_shared<InMemoryReadFile>(
             std::string(sinkPtr->data(), sinkPtr->size())),
@@ -869,8 +872,9 @@ TEST_F(E2EFilterTest, writeDecimalAsInteger) {
        makeFlatVector<int64_t>({1, 2}, DECIMAL(10, 2)),
        makeFlatVector<int128_t>({1, 2}, DECIMAL(19, 2))});
   writeToMemory(rowVector->type(), {rowVector}, false);
-  dwio::common::ReaderOptions readerOpts{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOpts(leafPool_.get());
+  readerOpts.setDataIoStats(dataIoStats_.get());
+  readerOpts.setMetadataIoStats(metadataIoStats_.get());
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
   auto reader = makeReader(readerOpts, std::move(input));
@@ -895,8 +899,9 @@ TEST_F(E2EFilterTest, configurableWriteSchema) {
     }
 
     writeToMemory(newType, batches, false);
-    dwio::common::ReaderOptions readerOpts{
-        leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+    dwio::common::ReaderOptions readerOpts(leafPool_.get());
+    readerOpts.setDataIoStats(dataIoStats_.get());
+    readerOpts.setMetadataIoStats(metadataIoStats_.get());
     auto input = std::make_unique<BufferedInput>(
         std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
     auto reader = makeReader(readerOpts, std::move(input));

--- a/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
@@ -96,8 +96,9 @@ std::shared_ptr<ScanSpec> ParquetReaderBenchmark::createScanSpec(
 std::unique_ptr<RowReader> ParquetReaderBenchmark::createReader(
     std::shared_ptr<ScanSpec> scanSpec,
     const RowTypePtr& rowType) {
-  dwio::common::ReaderOptions readerOpts{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOpts(leafPool_.get());
+  readerOpts.setDataIoStats(dataIoStats_.get());
+  readerOpts.setMetadataIoStats(metadataIoStats_.get());
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<LocalReadFile>(fileFolder_->getPath() + "/" + fileName_),
       readerOpts.memoryPool());

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -35,8 +35,9 @@ class ParquetReaderTest : public ParquetTestBase {
       const RowTypePtr& rowType) {
     const std::string sample(getExampleFilePath(fileName));
 
-    dwio::common::ReaderOptions readerOptions{
-        leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+    dwio::common::ReaderOptions readerOptions(leafPool_.get());
+    readerOptions.setDataIoStats(dataIoStats_.get());
+    readerOptions.setMetadataIoStats(metadataIoStats_.get());
     auto reader = createReader(sample, readerOptions);
 
     RowReaderOptions rowReaderOpts;
@@ -62,8 +63,9 @@ class ParquetReaderTest : public ParquetTestBase {
       FilterMap filters,
       const RowVectorPtr& expected) {
     const auto filePath(getExampleFilePath(fileName));
-    dwio::common::ReaderOptions readerOpts{
-        leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+    dwio::common::ReaderOptions readerOpts(leafPool_.get());
+    readerOpts.setDataIoStats(dataIoStats_.get());
+    readerOpts.setMetadataIoStats(metadataIoStats_.get());
     auto reader = createReader(filePath, readerOpts);
     assertReadWithReaderAndFilters(
         std::move(reader), fileName, fileSchema, std::move(filters), expected);
@@ -78,8 +80,9 @@ TEST_F(ParquetReaderTest, parseSample) {
   //   b: [1.0..20.0]
   const std::string sample(getExampleFilePath("sample.parquet"));
 
-  dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 20ULL);
 
@@ -128,8 +131,9 @@ TEST_F(ParquetReaderTest, parseEmptyNestedList) {
   const std::string sample(
       getExampleFilePath("parse_empty_nested_list.parquet"));
 
-  dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 1000ULL);
 
@@ -187,8 +191,9 @@ TEST_F(ParquetReaderTest, parseUnannotatedList) {
   // }
   const std::string sample(getExampleFilePath("unannotated_list.parquet"));
 
-  dwio::common::ReaderOptions readerOpts{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOpts(leafPool_.get());
+  readerOpts.setDataIoStats(dataIoStats_.get());
+  readerOpts.setMetadataIoStats(metadataIoStats_.get());
   auto reader = createReader(sample, readerOpts);
 
   EXPECT_EQ(reader->numberOfRows(), 22ULL);
@@ -243,8 +248,9 @@ TEST_F(ParquetReaderTest, parseUnannotatedMap) {
   const std::string filename("unnotated_map.parquet");
   const std::string sample(getExampleFilePath(filename));
 
-  dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto reader = createReader(sample, readerOptions);
 
   auto type = reader->typeWithId();
@@ -283,8 +289,9 @@ TEST_F(ParquetReaderTest, parseLegacyListWithMultipleChildren) {
   const std::string filename("listmultiplechildren.parquet");
   const std::string sample(getExampleFilePath(filename));
 
-  dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto reader = createReader(sample, readerOptions);
 
   auto type = reader->typeWithId();
@@ -343,8 +350,9 @@ TEST_F(ParquetReaderTest, parseArrayOfRowHiveReservedKeywords) {
   const std::string sample(
       getExampleFilePath("array_of_row_hive_reserved_keywords.parquet"));
 
-  dwio::common::ReaderOptions readerOpts{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOpts(leafPool_.get());
+  readerOpts.setDataIoStats(dataIoStats_.get());
+  readerOpts.setMetadataIoStats(metadataIoStats_.get());
   auto reader = createReader(sample, readerOpts);
   EXPECT_EQ(reader->rowType()->toString(), expectedVeloxType);
   EXPECT_EQ(reader->numberOfRows(), 6ULL);
@@ -395,8 +403,9 @@ TEST_F(ParquetReaderTest, parseArrayOfRowHiveReservedKeywords) {
 TEST_F(ParquetReaderTest, parseSampleRange1) {
   const std::string sample(getExampleFilePath("sample.parquet"));
 
-  dwio::common::ReaderOptions readerOpts{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOpts(leafPool_.get());
+  readerOpts.setDataIoStats(dataIoStats_.get());
+  readerOpts.setMetadataIoStats(metadataIoStats_.get());
   auto reader = createReader(sample, readerOpts);
 
   auto rowReaderOpts = getReaderOpts(sampleSchema());
@@ -415,8 +424,9 @@ TEST_F(ParquetReaderTest, parseSampleRange1) {
 TEST_F(ParquetReaderTest, parseSampleRange2) {
   const std::string sample(getExampleFilePath("sample.parquet"));
 
-  dwio::common::ReaderOptions readerOpts{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOpts(leafPool_.get());
+  readerOpts.setDataIoStats(dataIoStats_.get());
+  readerOpts.setMetadataIoStats(metadataIoStats_.get());
   auto reader = createReader(sample, readerOpts);
 
   auto rowReaderOpts = getReaderOpts(sampleSchema());
@@ -435,8 +445,9 @@ TEST_F(ParquetReaderTest, parseSampleRange2) {
 TEST_F(ParquetReaderTest, parseSampleEmptyRange) {
   const std::string sample(getExampleFilePath("sample.parquet"));
 
-  dwio::common::ReaderOptions readerOpts{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOpts(leafPool_.get());
+  readerOpts.setDataIoStats(dataIoStats_.get());
+  readerOpts.setMetadataIoStats(metadataIoStats_.get());
   auto reader = createReader(sample, readerOpts);
 
   auto rowReaderOpts = getReaderOpts(sampleSchema());
@@ -454,8 +465,9 @@ TEST_F(ParquetReaderTest, parseReadAsLowerCase) {
   // 2 rows.
   const std::string upper(getExampleFilePath("upper.parquet"));
 
-  dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto outputRowType = ROW({"a", "b"}, {BIGINT(), BIGINT()});
   readerOptions.setFileSchema(outputRowType);
   readerOptions.setFileColumnNamesReadAsLowerCase(true);
@@ -491,8 +503,9 @@ TEST_F(ParquetReaderTest, parseRowMapArrayReadAsLowerCase) {
   // +-----------------------+
   const std::string upper(getExampleFilePath("upper_complex.parquet"));
 
-  dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileColumnNamesReadAsLowerCase(true);
   auto reader = createReader(upper, readerOptions);
 
@@ -535,8 +548,9 @@ TEST_F(ParquetReaderTest, parseEmpty) {
   // 0 rows.
   const std::string empty(getExampleFilePath("empty.parquet"));
 
-  dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto reader = createReader(empty, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 0ULL);
 
@@ -558,8 +572,9 @@ TEST_F(ParquetReaderTest, parseInt) {
   //   bigint: [1000 .. 1009]
   const std::string sample(getExampleFilePath("int.parquet"));
 
-  dwio::common::ReaderOptions readerOpts{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOpts(leafPool_.get());
+  readerOpts.setDataIoStats(dataIoStats_.get());
+  readerOpts.setMetadataIoStats(metadataIoStats_.get());
   auto reader = createReader(sample, readerOpts);
 
   EXPECT_EQ(reader->numberOfRows(), 10ULL);
@@ -594,8 +609,9 @@ TEST_F(ParquetReaderTest, parseUnsignedInt1) {
   //   uint64: [18446744073709551615, 2000000000000000000, 3000000000000000000]
   const std::string sample(getExampleFilePath("uint.parquet"));
 
-  dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto reader = createReader(sample, readerOptions);
 
   EXPECT_EQ(reader->numberOfRows(), 3ULL);
@@ -699,8 +715,9 @@ TEST_F(ParquetReaderTest, parseDate) {
   //   date: [1969-12-27 .. 1970-01-20]
   const std::string sample(getExampleFilePath("date.parquet"));
 
-  dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto reader = createReader(sample, readerOptions);
 
   EXPECT_EQ(reader->numberOfRows(), 25ULL);
@@ -727,8 +744,9 @@ TEST_F(ParquetReaderTest, parseRowMapArray) {
   // ARRAY(INTEGER)) c1) c)
   const std::string sample(getExampleFilePath("row_map_array.parquet"));
 
-  dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto reader = createReader(sample, readerOptions);
 
   EXPECT_EQ(reader->numberOfRows(), 1ULL);
@@ -761,8 +779,9 @@ TEST_F(ParquetReaderTest, parseRowMapArray) {
 TEST_F(ParquetReaderTest, projectNoColumns) {
   // This is the case for count(*).
   auto rowType = ROW({}, {});
-  dwio::common::ReaderOptions readerOpts{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOpts(leafPool_.get());
+  readerOpts.setDataIoStats(dataIoStats_.get());
+  readerOpts.setMetadataIoStats(metadataIoStats_.get());
   auto reader = createReader(getExampleFilePath("sample.parquet"), readerOpts);
   RowReaderOptions rowReaderOpts;
   rowReaderOpts.setScanSpec(makeScanSpec(rowType));
@@ -786,8 +805,9 @@ TEST_F(ParquetReaderTest, parseIntDecimal) {
   //   a: [11.11, 11.11, 22.22, 22.22, 33.33, 33.33]
   //   b: [11.11, 11.11, 22.22, 22.22, 33.33, 33.33]
   auto rowType = ROW({"a", "b"}, {DECIMAL(7, 2), DECIMAL(14, 2)});
-  dwio::common::ReaderOptions readerOpts{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOpts(leafPool_.get());
+  readerOpts.setDataIoStats(dataIoStats_.get());
+  readerOpts.setMetadataIoStats(metadataIoStats_.get());
   const std::string decimal_dict(getExampleFilePath("decimal_dict.parquet"));
 
   auto reader = createReader(decimal_dict, readerOpts);
@@ -841,8 +861,9 @@ TEST_F(ParquetReaderTest, parseMapKeyValueAsMap) {
 
   const std::string sample(getExampleFilePath("map_key_value.parquet"));
 
-  dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 1ULL);
 
@@ -890,8 +911,9 @@ TEST_F(ParquetReaderTest, parseRowArrayTest) {
   const std::string sample(
       getExampleFilePath("proto-struct-with-array.parquet"));
 
-  dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 1ULL);
   auto type = reader->typeWithId();
@@ -1176,8 +1198,9 @@ TEST_F(ParquetReaderTest, filterRowGroups) {
   // decimal_no_ColumnMetadata.parquet has one columns a: DECIMAL(9,1). It
   // doesn't have ColumnMetaData, and rowGroups_[0].columns[0].file_offset is 0.
   auto rowType = ROW({"_c0"}, {DECIMAL(9, 1)});
-  dwio::common::ReaderOptions readerOpts{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOpts(leafPool_.get());
+  readerOpts.setDataIoStats(dataIoStats_.get());
+  readerOpts.setMetadataIoStats(metadataIoStats_.get());
   const std::string decimal_dict(
       getExampleFilePath("decimal_no_ColumnMetadata.parquet"));
 
@@ -1204,8 +1227,9 @@ TEST_F(ParquetReaderTest, shouldIgnoreStatsForParquetMRVersions) {
 // This test is to verify filterRowGroups() doesn't fail if offset is 0
 TEST_F(ParquetReaderTest, filterRowGroupsWithZeroOffset) {
   auto rowType = ROW({"IDX"}, {INTEGER()});
-  const dwio::common::ReaderOptions readerOpts{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOpts(leafPool_.get());
+  readerOpts.setDataIoStats(dataIoStats_.get());
+  readerOpts.setMetadataIoStats(metadataIoStats_.get());
   const std::string zeroOffsetPath(
       getExampleFilePath("zero_offset_row_group.parquet"));
 
@@ -1221,8 +1245,9 @@ TEST_F(ParquetReaderTest, parseLongTagged) {
   // This is a case for long with annonation read
   const std::string sample(getExampleFilePath("tagged_long.parquet"));
 
-  dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto reader = createReader(sample, readerOptions);
 
   EXPECT_EQ(reader->numberOfRows(), 4ULL);
@@ -1240,8 +1265,9 @@ TEST_F(ParquetReaderTest, preloadSmallFile) {
   auto file = std::make_shared<LocalReadFile>(sample);
   auto input = std::make_unique<BufferedInput>(file, *leafPool_);
 
-  dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto reader =
       std::make_unique<ParquetReader>(std::move(input), readerOptions);
 
@@ -1275,8 +1301,9 @@ TEST_F(ParquetReaderTest, prefetchRowGroups) {
   const std::string sample(getExampleFilePath("multiple_row_groups.parquet"));
   const int numRowGroups = 4;
 
-  dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   // Disable preload of file.
   readerOptions.setFilePreloadThreshold(0);
 
@@ -1329,8 +1356,9 @@ TEST_F(ParquetReaderTest, testEmptyRowGroups) {
   // empty_row_groups.parquet contains empty row groups
   const std::string sample(getExampleFilePath("empty_row_groups.parquet"));
 
-  dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 5ULL);
 
@@ -1356,8 +1384,9 @@ TEST_F(ParquetReaderTest, testEnumType) {
   // enum_type.parquet contains 1 column (ENUM) with 3 rows.
   const std::string sample(getExampleFilePath("enum_type.parquet"));
 
-  dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 3ULL);
 
@@ -1382,8 +1411,9 @@ TEST_F(ParquetReaderTest, readVarbinaryFromFLBA) {
   const std::string filename("varbinary_flba.parquet");
   const std::string sample(getExampleFilePath(filename));
 
-  dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto reader = createReader(sample, readerOptions);
 
   auto type = reader->typeWithId();
@@ -1414,8 +1444,9 @@ TEST_F(ParquetReaderTest, readBinaryAsStringFromNation) {
   const std::string filename("nation.parquet");
   const std::string sample(getExampleFilePath(filename));
 
-  dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto outputRowType =
       ROW({"nationkey", "name", "regionkey", "comment"},
           {BIGINT(), VARCHAR(), BIGINT(), VARCHAR()});
@@ -1446,8 +1477,9 @@ TEST_F(ParquetReaderTest, readComplexType) {
   const std::string filename("complex_with_varchar_varbinary.parquet");
   const std::string sample(getExampleFilePath(filename));
 
-  dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto outputRowType =
       ROW({"a", "b", "c", "d"},
           {ARRAY(VARCHAR()),
@@ -1494,8 +1526,9 @@ TEST_F(ParquetReaderTest, readFixedLenBinaryAsStringFromUuid) {
   const std::string filename("uuid.parquet");
   const std::string sample(getExampleFilePath(filename));
 
-  dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto outputRowType = ROW({"uuid_field"}, {VARCHAR()});
 
   readerOptions.setFileSchema(outputRowType);
@@ -1523,8 +1556,9 @@ TEST_F(ParquetReaderTest, readFixedLenBinaryAsStringFromUuid) {
 TEST_F(ParquetReaderTest, testV2PageWithZeroMaxDefRep) {
   const std::string sample(getExampleFilePath("v2_page.parquet"));
 
-  dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 5ULL);
 
@@ -1548,8 +1582,9 @@ TEST_F(ParquetReaderTest, testV2PageWithZeroMaxDefRep) {
 TEST_F(ParquetReaderTest, readComplexTypeWithV2Page) {
   const std::string sample(getExampleFilePath("complex_type_v2_page.parquet"));
 
-  dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 1ULL);
 
@@ -1589,8 +1624,9 @@ TEST_F(ParquetReaderTest, arrayOfMapOfIntKeyArrayValue) {
       "ROW<test:ARRAY<MAP<VARCHAR,ARRAY<INTEGER>>>>";
   const std::string sample(
       getExampleFilePath("array_of_map_of_int_key_array_value.parquet"));
-  facebook::velox::dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  facebook::velox::dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->rowType()->toString(), expectedVeloxType);
   auto type = reader->typeWithId();
@@ -1623,8 +1659,9 @@ TEST_F(ParquetReaderTest, arrayOfMapOfIntKeyStructValue) {
       "ROW<test:ARRAY<MAP<INTEGER,ROW<stringfield:VARCHAR,longfield:BIGINT>>>>";
   const std::string sample(
       getExampleFilePath("array_of_map_of_int_key_struct_value.parquet"));
-  facebook::velox::dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  facebook::velox::dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->rowType()->toString(), expectedVeloxType);
   auto type = reader->typeWithId();
@@ -1658,8 +1695,9 @@ TEST_F(ParquetReaderTest, struct_of_array_of_array) {
       "ROW<test:ROW<stringarrayfield:ARRAY<ARRAY<VARCHAR>>,intarrayfield:ARRAY<ARRAY<INTEGER>>>>";
   const std::string sample(
       getExampleFilePath("struct_of_array_of_array.parquet"));
-  facebook::velox::dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  facebook::velox::dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto reader = createReader(sample, readerOptions);
   auto type = reader->typeWithId();
   EXPECT_EQ(type->size(), 1ULL);
@@ -1723,8 +1761,9 @@ TEST_F(ParquetReaderTest, struct_of_array_of_array) {
 TEST_F(ParquetReaderTest, testLzoDataPage) {
   const std::string sample(getExampleFilePath("lzo.parquet"));
 
-  dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 23'547ULL);
 
@@ -1759,8 +1798,9 @@ TEST_F(ParquetReaderTest, testLzoDataPage) {
 TEST_F(ParquetReaderTest, testEmptyV2DataPage) {
   const std::string sample(getExampleFilePath("empty_v2datapage.parquet"));
 
-  dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 30001ULL);
 
@@ -1792,8 +1832,9 @@ TEST_F(ParquetReaderTest, parquet251) {
 TEST_F(ParquetReaderTest, fileColumnVarcharToMetadataColumnMismatchTest) {
   const std::string sample(getExampleFilePath("nation.parquet"));
 
-  dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
 
   auto runVarcharColTest = [&](const TypePtr& requestedType) {
     // The type in the file is a BYTE_ARRAY resolving to VARCHAR.
@@ -1852,8 +1893,9 @@ TEST_F(ParquetReaderTest, readerWithSchema) {
   writer->close();
 
   // Create the reader.
-  dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(schema);
   std::string dataBuf(sinkPtr->data(), sinkPtr->size());
   auto file = std::make_shared<InMemoryReadFile>(std::move(dataBuf));
@@ -1874,8 +1916,9 @@ TEST_F(ParquetReaderTest, columnStatistics) {
       });
 
   auto* sink = write(data);
-  dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto reader = createReaderInMemory(*sink, readerOptions);
   const auto& schema = reader->typeWithId();
 
@@ -1934,8 +1977,9 @@ TEST_F(ParquetReaderTest, columnStatisticsWithNulls) {
       });
 
   auto* sink = write(data);
-  dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto reader = createReaderInMemory(*sink, readerOptions);
   const auto& schema = reader->typeWithId();
 
@@ -1968,8 +2012,9 @@ TEST_F(ParquetReaderTest, columnStatisticsMultipleRowGroups) {
       });
 
   auto* sink = write(data, writerOptions);
-  dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto reader = createReaderInMemory(*sink, readerOptions);
 
   // Verify we have multiple row groups.
@@ -2001,8 +2046,9 @@ TEST_F(ParquetReaderTest, readTimeMillis) {
           TIME())});
   auto sink = write(data);
 
-  dwio::common::ReaderOptions readerOpts{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOpts(leafPool_.get());
+  readerOpts.setDataIoStats(dataIoStats_.get());
+  readerOpts.setMetadataIoStats(metadataIoStats_.get());
   auto reader = createReaderInMemory(*sink, readerOpts);
 
   EXPECT_EQ(reader->numberOfRows(), 6ULL);
@@ -2034,8 +2080,9 @@ TEST_F(ParquetReaderTest, readTimeWithMultipleColumns) {
 
   auto sink = write(data);
 
-  dwio::common::ReaderOptions readerOpts{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOpts(leafPool_.get());
+  readerOpts.setDataIoStats(dataIoStats_.get());
+  readerOpts.setMetadataIoStats(metadataIoStats_.get());
   auto reader = createReaderInMemory(*sink, readerOpts);
 
   EXPECT_EQ(reader->numberOfRows(), 5ULL);

--- a/velox/dwio/parquet/tests/reader/ParquetReaderWideningTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderWideningTest.cpp
@@ -32,8 +32,9 @@ class ParquetReaderWideningTest : public ParquetTestBase {
       const RowTypePtr& readSchema,
       bool allowInt32Narrowing = false) {
     auto* sink = write(writeData);
-    dwio::common::ReaderOptions readerOptions{
-        leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+    dwio::common::ReaderOptions readerOptions(leafPool_.get());
+    readerOptions.setDataIoStats(dataIoStats_.get());
+    readerOptions.setMetadataIoStats(metadataIoStats_.get());
     readerOptions.setFileSchema(readSchema);
     readerOptions.setAllowInt32Narrowing(allowInt32Narrowing);
     auto reader = createReaderInMemory(*sink, readerOptions);
@@ -73,8 +74,9 @@ class ParquetReaderWideningTest : public ParquetTestBase {
       const RowVectorPtr& expected,
       bool allowInt32Narrowing = false) {
     auto* sink = write(writeData);
-    dwio::common::ReaderOptions readerOptions{
-        leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+    dwio::common::ReaderOptions readerOptions(leafPool_.get());
+    readerOptions.setDataIoStats(dataIoStats_.get());
+    readerOptions.setMetadataIoStats(metadataIoStats_.get());
     readerOptions.setFileSchema(readSchema);
     readerOptions.setAllowInt32Narrowing(allowInt32Narrowing);
     auto reader = createReaderInMemory(*sink, readerOptions);
@@ -96,8 +98,9 @@ class ParquetReaderWideningTest : public ParquetTestBase {
       const RowTypePtr& readSchema,
       const std::string& sourceTypeName) {
     auto* sink = write(writeData);
-    dwio::common::ReaderOptions readerOptions{
-        leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+    dwio::common::ReaderOptions readerOptions(leafPool_.get());
+    readerOptions.setDataIoStats(dataIoStats_.get());
+    readerOptions.setMetadataIoStats(metadataIoStats_.get());
     readerOptions.setFileSchema(readSchema);
     VELOX_ASSERT_THROW(
         createReaderInMemory(*sink, readerOptions),
@@ -230,8 +233,9 @@ void FloatToDoubleEvolutionTest::runFloatToDoubleScenario(
 
   RowTypePtr readSchema = ROW({"float_col", "id"}, {DOUBLE(), BIGINT()});
 
-  dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(readSchema);
 
   std::string dataBuf(sinkPtr->data(), sinkPtr->size());
@@ -1064,8 +1068,9 @@ TEST_F(ParquetReaderWideningTest, allowInt32Narrowing) {
   auto* sink = write(data);
 
   // Default: flag is false.
-  dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   ASSERT_FALSE(readerOptions.allowInt32Narrowing());
 
   // INT32->TINYINT narrowing rejected by default.

--- a/velox/dwio/parquet/tests/writer/ParquetWriterFieldIdTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterFieldIdTest.cpp
@@ -68,8 +68,9 @@ TEST_P(ParquetWriterFieldIdTest, fieldIds) {
 
   auto* sinkPtr = write(data, writerOptions);
 
-  dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto parquetReader = createReaderInMemory(*sinkPtr, readerOptions);
   EXPECT_EQ(parquetReader->numberOfRows(), kRows);
   auto veloxRowType = parquetReader->rowType();

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -88,8 +88,9 @@ class ParquetWriterTest : public ParquetTestBase {
   thrift::PageHeader readPageHeader(
       MemorySink* sinkPtr,
       int64_t offsetFromDataPage) {
-    dwio::common::ReaderOptions readerOptions{
-        leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+    dwio::common::ReaderOptions readerOptions(leafPool_.get());
+    readerOptions.setDataIoStats(dataIoStats_.get());
+    readerOptions.setMetadataIoStats(metadataIoStats_.get());
     auto reader = createReaderInMemory(*sinkPtr, readerOptions);
 
     auto colChunkPtr = reader->fileMetaData().rowGroup(0).columnChunk(0);
@@ -409,8 +410,9 @@ TEST_F(ParquetWriterTest, compression) {
 
   auto* sinkPtr = write(data, writerOptions);
 
-  dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto reader = createReaderInMemory(*sinkPtr, readerOptions);
 
   ASSERT_EQ(reader->numberOfRows(), kRows);
@@ -802,8 +804,9 @@ TEST_F(ParquetWriterTest, allNulls) {
 
   auto* sinkPtr = write(data);
 
-  dwio::common::ReaderOptions readerOptions{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto reader = createReaderInMemory(*sinkPtr, readerOptions);
 
   ASSERT_EQ(reader->numberOfRows(), kRows);

--- a/velox/dwio/parquet/writer/arrow/tests/FileDeserializeTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/FileDeserializeTest.cpp
@@ -974,8 +974,9 @@ class TestParquetFileReader : public ::testing::Test {
         rootPool->addLeafChild("MetadataTest");
     auto dataIoStats = std::make_shared<velox::io::IoStatistics>();
     auto metadataIoStats = std::make_shared<velox::io::IoStatistics>();
-    dwio::common::ReaderOptions readerOptions{
-        leafPool.get(), dataIoStats.get(), metadataIoStats.get()};
+    dwio::common::ReaderOptions readerOptions(leafPool.get());
+    readerOptions.setDataIoStats(dataIoStats.get());
+    readerOptions.setMetadataIoStats(metadataIoStats.get());
     auto input = std::make_unique<dwio::common::BufferedInput>(
         std::make_shared<LocalReadFile>(filePath->getPath()),
         readerOptions.memoryPool());
@@ -1033,8 +1034,9 @@ TEST_F(TestParquetFileReader, IncompleteMetadata) {
       rootPool->addLeafChild("MetadataTest");
   auto dataIoStats = std::make_shared<velox::io::IoStatistics>();
   auto metadataIoStats = std::make_shared<velox::io::IoStatistics>();
-  dwio::common::ReaderOptions readerOptions{
-      leafPool.get(), dataIoStats.get(), metadataIoStats.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool.get());
+  readerOptions.setDataIoStats(dataIoStats.get());
+  readerOptions.setMetadataIoStats(metadataIoStats.get());
   auto input = std::make_unique<dwio::common::BufferedInput>(
       std::make_shared<LocalReadFile>(filePath->getPath()),
       readerOptions.memoryPool());

--- a/velox/dwio/parquet/writer/arrow/tests/MetadataTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/MetadataTest.cpp
@@ -417,8 +417,9 @@ TEST(Metadata, TestAddKeyValueMetadata) {
       rootPool->addLeafChild("MetadataTest");
   auto dataIoStats = std::make_shared<velox::io::IoStatistics>();
   auto metadataIoStats = std::make_shared<velox::io::IoStatistics>();
-  dwio::common::ReaderOptions readerOptions{
-      leafPool.get(), dataIoStats.get(), metadataIoStats.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool.get());
+  readerOptions.setDataIoStats(dataIoStats.get());
+  readerOptions.setMetadataIoStats(metadataIoStats.get());
   auto input = std::make_unique<dwio::common::BufferedInput>(
       std::make_shared<LocalReadFile>(filePath->getPath()),
       readerOptions.memoryPool());
@@ -539,8 +540,9 @@ TEST(Metadata, TestSortingColumns) {
       rootPool->addLeafChild("MetadataTest");
   auto dataIoStats = std::make_shared<velox::io::IoStatistics>();
   auto metadataIoStats = std::make_shared<velox::io::IoStatistics>();
-  dwio::common::ReaderOptions readerOptions{
-      leafPool.get(), dataIoStats.get(), metadataIoStats.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool.get());
+  readerOptions.setDataIoStats(dataIoStats.get());
+  readerOptions.setMetadataIoStats(metadataIoStats.get());
   auto input = std::make_unique<dwio::common::BufferedInput>(
       std::make_shared<LocalReadFile>(filePath->getPath()),
       readerOptions.memoryPool());

--- a/velox/dwio/parquet/writer/arrow/tests/StatisticsTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/StatisticsTest.cpp
@@ -488,8 +488,9 @@ class TestStatistics : public PrimitiveTypedTest<TestType> {
         rootPool->addLeafChild("StatisticsTest");
     auto dataIoStats = std::make_shared<velox::io::IoStatistics>();
     auto metadataIoStats = std::make_shared<velox::io::IoStatistics>();
-    dwio::common::ReaderOptions readerOptions{
-        leafPool.get(), dataIoStats.get(), metadataIoStats.get()};
+    dwio::common::ReaderOptions readerOptions(leafPool.get());
+    readerOptions.setDataIoStats(dataIoStats.get());
+    readerOptions.setMetadataIoStats(metadataIoStats.get());
     auto input = std::make_unique<dwio::common::BufferedInput>(
         std::make_shared<LocalReadFile>(filePath->getPath()),
         readerOptions.memoryPool());
@@ -1036,8 +1037,9 @@ class TestStatisticsSortOrder : public ::testing::Test {
         rootPool->addLeafChild("StatisticsTest");
     auto dataIoStats = std::make_shared<velox::io::IoStatistics>();
     auto metadataIoStats = std::make_shared<velox::io::IoStatistics>();
-    dwio::common::ReaderOptions readerOptions{
-        leafPool.get(), dataIoStats.get(), metadataIoStats.get()};
+    dwio::common::ReaderOptions readerOptions(leafPool.get());
+    readerOptions.setDataIoStats(dataIoStats.get());
+    readerOptions.setMetadataIoStats(metadataIoStats.get());
     auto input = std::make_unique<dwio::common::BufferedInput>(
         std::make_shared<LocalReadFile>(filePath->getPath()),
         readerOptions.memoryPool());
@@ -1334,8 +1336,9 @@ TEST_F(TestStatisticsSortOrderFLBA, decimalSortOrder) {
       rootPool->addLeafChild("StatisticsTest");
   auto dataIoStats = std::make_shared<velox::io::IoStatistics>();
   auto metadataIoStats = std::make_shared<velox::io::IoStatistics>();
-  dwio::common::ReaderOptions readerOptions{
-      leafPool.get(), dataIoStats.get(), metadataIoStats.get()};
+  dwio::common::ReaderOptions readerOptions(leafPool.get());
+  readerOptions.setDataIoStats(dataIoStats.get());
+  readerOptions.setMetadataIoStats(metadataIoStats.get());
   auto input = std::make_unique<dwio::common::BufferedInput>(
       std::make_shared<LocalReadFile>(filePath->getPath()),
       readerOptions.memoryPool());

--- a/velox/dwio/text/tests/reader/TextReaderTest.cpp
+++ b/velox/dwio/text/tests/reader/TextReaderTest.cpp
@@ -136,8 +136,9 @@ TEST_F(TextReaderTest, basic) {
       "examples/simple_types_compressed_file.gz");
   auto readFile = std::make_shared<LocalReadFile>(path);
 
-  auto readerOptions = dwio::common::ReaderOptions(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(type);
 
   auto input =
@@ -247,8 +248,9 @@ TEST_F(TextReaderTest, headerAndCustomNullString) {
       "velox/dwio/text/tests/reader/", "examples/simple_types_with_header");
   auto readFile = std::make_shared<LocalReadFile>(path);
 
-  auto readerOptions = dwio::common::ReaderOptions(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(type);
   auto rowReaderOptions = dwio::common::RowReaderOptions();
   setScanSpec(*type, rowReaderOptions);
@@ -422,8 +424,9 @@ TEST_F(TextReaderTest, complexTypesWithCustomDelimiters) {
   auto readFile = std::make_shared<LocalReadFile>(path);
 
   auto serDeOptions = dwio::common::SerDeOptions('\t', '|', '#', '\\', true);
-  auto readerOptions = dwio::common::ReaderOptions(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(type);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -488,8 +491,9 @@ TEST_F(TextReaderTest, projectComplexTypesWithCustomDelimiters) {
   auto readFile = std::make_shared<LocalReadFile>(path);
 
   auto serDeOptions = dwio::common::SerDeOptions('\t', '|', '#', '\\', true);
-  auto readerOptions = dwio::common::ReaderOptions(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(type);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -592,8 +596,9 @@ TEST_F(TextReaderTest, projectPrimitiveTypes) {
   auto path = velox::test::getDataFilePath(
       "velox/dwio/text/tests/reader/", "examples/simple_types");
   auto readFile = std::make_shared<LocalReadFile>(path);
-  auto readerOptions = dwio::common::ReaderOptions(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(type);
   auto input =
       std::make_unique<dwio::common::BufferedInput>(readFile, poolRef());
@@ -661,8 +666,9 @@ TEST_F(TextReaderTest, projectColumns) {
       "velox/dwio/text/tests/reader/",
       "examples/simple_types_compressed_file.gz");
   auto readFile = std::make_shared<LocalReadFile>(path);
-  auto readerOptions = dwio::common::ReaderOptions(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(type);
   auto input =
       std::make_unique<dwio::common::BufferedInput>(readFile, poolRef());
@@ -717,8 +723,9 @@ TEST_F(TextReaderTest, projectNone) {
       "velox/dwio/text/tests/reader/", "examples/simple_types");
   auto readFile = std::make_shared<LocalReadFile>(path);
 
-  auto readerOptions = dwio::common::ReaderOptions(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(type);
 
   dwio::common::RowReaderOptions rowReaderOptions;
@@ -753,8 +760,9 @@ TEST_F(TextReaderTest, compressedProjectNone) {
       "examples/simple_types_compressed_file.gz");
   auto readFile = std::make_shared<LocalReadFile>(path);
 
-  auto readerOptions = dwio::common::ReaderOptions(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(type);
 
   dwio::common::RowReaderOptions rowReaderOptions;
@@ -785,8 +793,9 @@ TEST_F(TextReaderTest, compressedFilter) {
       "velox/dwio/text/tests/reader/",
       "examples/simple_types_compressed_file.gz");
   auto readFile = std::make_shared<LocalReadFile>(path);
-  auto readerOptions = dwio::common::ReaderOptions(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(type);
   auto input =
       std::make_unique<dwio::common::BufferedInput>(readFile, poolRef());
@@ -830,8 +839,9 @@ TEST_F(TextReaderTest, filter) {
       "velox/dwio/text/tests/reader/", "examples/more_simple_types");
   auto readFile = std::make_shared<LocalReadFile>(path);
 
-  auto readerOptions = dwio::common::ReaderOptions(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(type);
 
   auto input =
@@ -889,8 +899,9 @@ TEST_F(TextReaderTest, shrinkBatch) {
   auto path = velox::test::getDataFilePath(
       "velox/dwio/text/tests/reader/", "examples/simple_types");
   auto readFile = std::make_shared<LocalReadFile>(path);
-  auto readerOptions = dwio::common::ReaderOptions(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(type);
   auto input =
       std::make_unique<dwio::common::BufferedInput>(readFile, poolRef());
@@ -923,8 +934,9 @@ TEST_F(TextReaderTest, compressedShrinkBatch) {
       "velox/dwio/text/tests/reader/",
       "examples/simple_types_compressed_file.gz");
   auto readFile = std::make_shared<LocalReadFile>(path);
-  auto readerOptions = dwio::common::ReaderOptions(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(type);
   auto input =
       std::make_unique<dwio::common::BufferedInput>(readFile, poolRef());
@@ -954,8 +966,9 @@ TEST_F(TextReaderTest, emptyFile) {
   auto path = velox::test::getDataFilePath(
       "velox/dwio/text/tests/reader/", "examples/empty.gz");
   auto readFile = std::make_shared<LocalReadFile>(path);
-  auto readerOptions = dwio::common::ReaderOptions(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(type);
   auto rowReaderOptions = dwio::common::RowReaderOptions();
   setScanSpec(*type, rowReaderOptions);
@@ -1002,8 +1015,9 @@ TEST_F(TextReaderTest, readRanges) {
       "examples/simple_types_10_bytes_per_row");
   auto readFile = std::make_shared<LocalReadFile>(path);
 
-  auto readerOptions = dwio::common::ReaderOptions(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(type);
 
   auto input =
@@ -1100,8 +1114,9 @@ TEST_F(TextReaderTest, readFloatAsInt) {
       "velox/dwio/text/tests/reader/", "examples/simple_types");
   auto readFile = std::make_shared<LocalReadFile>(path);
 
-  auto readerOptions = dwio::common::ReaderOptions(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(type);
 
   auto input =
@@ -1200,8 +1215,9 @@ TEST_F(TextReaderTest, simpleTypes) {
       "velox/dwio/text/tests/reader/", "examples/more_simple_types");
   auto readFile = std::make_shared<LocalReadFile>(path);
 
-  auto readerOptions = dwio::common::ReaderOptions(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(type);
 
   auto input =
@@ -1261,8 +1277,9 @@ TEST_F(TextReaderTest, primitiveLimitsStressTest) {
       "velox/dwio/text/tests/reader/", "examples/primitive_limits");
   auto readFile = std::make_shared<LocalReadFile>(path);
 
-  auto readerOptions = dwio::common::ReaderOptions(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   auto serDeOptions = dwio::common::SerDeOptions('\t', '=', '|', '\\', true);
   readerOptions.setFileSchema(type);
   readerOptions.setSerDeOptions(serDeOptions);
@@ -1420,8 +1437,9 @@ TEST_F(TextReaderTest, DISABLED_nestedComplexTypesWithCustomDelimiters) {
   auto serDeOptions = dwio::common::SerDeOptions('\t', '=', '|', '\\', true);
   serDeOptions.separators[3] = ',';
   serDeOptions.separators[4] = ':';
-  auto readerOptions = dwio::common::ReaderOptions(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(type);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -1492,8 +1510,9 @@ TEST_F(TextReaderTest, nestedArraysWithCustomDelimiters) {
   // - Pipe ('|') for outer array element separation (depth 1)
   // - Comma (',') for inner array element separation (depth 2)
   auto serDeOptions = dwio::common::SerDeOptions('\t', '|', ',', '\\', true);
-  auto readerOptions = dwio::common::ReaderOptions(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(type);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -1584,8 +1603,9 @@ TEST_F(TextReaderTest, tripleNestedArraysWithCustomDelimiters) {
   // - Hash ('#') for innermost array element separation (depth 3)
   auto serDeOptions = dwio::common::SerDeOptions('\t', '|', ',', '\\', true);
   serDeOptions.separators[3] = '#';
-  auto readerOptions = dwio::common::ReaderOptions(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(type);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -1619,8 +1639,9 @@ TEST_F(TextReaderTest, varbinarySuccessfulDecoding) {
 
   auto readFile = std::make_shared<LocalReadFile>(path);
 
-  auto readerOptions = dwio::common::ReaderOptions(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(type);
 
   auto input =
@@ -1655,8 +1676,9 @@ TEST_F(TextReaderTest, varbinaryUnsuccessfulDecoding) {
 
   auto readFile = std::make_shared<LocalReadFile>(path);
 
-  auto readerOptions = dwio::common::ReaderOptions(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(type);
 
   auto input =
@@ -1748,8 +1770,9 @@ TEST_F(TextReaderTest, logicalTypes) {
       "velox/dwio/text/tests/reader/", "examples/logical_types.gz");
 
   auto readFile = std::make_shared<LocalReadFile>(path);
-  auto readerOptions = dwio::common::ReaderOptions(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(type);
 
   auto input =
@@ -1806,8 +1829,9 @@ TEST_F(TextReaderTest, nestedRows) {
   auto readFile = std::make_shared<LocalReadFile>(path);
   auto serDeOptions = dwio::common::SerDeOptions('&', ',', '#', '\\', true);
 
-  auto readerOptions = dwio::common::ReaderOptions(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(type);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -1886,8 +1910,9 @@ TEST_P(TextReaderDecompressionTest, tests) {
       velox::test::getDataFilePath("velox/dwio/text/tests/reader/", filepath);
   auto readFile = std::make_shared<LocalReadFile>(path);
 
-  auto readerOptions = dwio::common::ReaderOptions(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(type);
 
   auto input =
@@ -1960,8 +1985,9 @@ TEST_F(TextReaderTest, unsupportedCompressedKind) {
           kBaseDir, "examples/simple_types_compressed_file.snappy")};
   for (const auto& path : paths) {
     auto readFile = std::make_shared<LocalReadFile>(path);
-    auto readerOptions = dwio::common::ReaderOptions(
-        pool(), dataIoStats_.get(), metadataIoStats_.get());
+    dwio::common::ReaderOptions readerOptions(pool());
+    readerOptions.setDataIoStats(dataIoStats_.get());
+    readerOptions.setMetadataIoStats(metadataIoStats_.get());
     readerOptions.setFileSchema(type);
     auto input =
         std::make_unique<dwio::common::BufferedInput>(readFile, poolRef());
@@ -1987,8 +2013,9 @@ TEST_F(TextReaderTest, extractionMapKeys) {
   auto readFile = std::make_shared<LocalReadFile>(path);
 
   auto serDeOptions = dwio::common::SerDeOptions('\t', '|', '#', '\\', true);
-  auto readerOptions = dwio::common::ReaderOptions(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(type);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -2054,8 +2081,9 @@ TEST_F(TextReaderTest, extractionMapValues) {
   auto readFile = std::make_shared<LocalReadFile>(path);
 
   auto serDeOptions = dwio::common::SerDeOptions('\t', '|', '#', '\\', true);
-  auto readerOptions = dwio::common::ReaderOptions(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(type);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -2133,8 +2161,9 @@ TEST_F(TextReaderTest, extractionMapKeyFilter) {
   auto factory = dwio::common::getReaderFactory(dwio::common::FileFormat::TEXT);
 
   auto readFile = std::make_shared<LocalReadFile>(textFile->getPath());
-  auto readerOptions = dwio::common::ReaderOptions(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(type);
 
   auto input =
@@ -2198,8 +2227,9 @@ TEST_F(TextReaderTest, extractionTransformOnMapColumn) {
   auto readFile = std::make_shared<LocalReadFile>(path);
 
   auto serDeOptions = dwio::common::SerDeOptions('\t', '|', '#', '\\', true);
-  auto readerOptions = dwio::common::ReaderOptions(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(type);
   readerOptions.setSerDeOptions(serDeOptions);
 

--- a/velox/dwio/text/tests/writer/TextWriterTest.cpp
+++ b/velox/dwio/text/tests/writer/TextWriterTest.cpp
@@ -232,8 +232,9 @@ TEST_F(TextWriterTest, verifyWriteWithTextReader) {
   auto readerFactory =
       dwio::common::getReaderFactory(dwio::common::FileFormat::TEXT);
   auto readFile = std::make_shared<LocalReadFile>(filePath.string());
-  auto readerOptions = dwio::common::ReaderOptions(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(schema);
   auto input =
       std::make_unique<dwio::common::BufferedInput>(readFile, poolRef());
@@ -501,8 +502,9 @@ TEST_F(TextWriterTest, verifyMapAndArrayComplexTypesWithTextReader) {
   auto readerFactory =
       dwio::common::getReaderFactory(dwio::common::FileFormat::TEXT);
   auto readFile = std::make_shared<LocalReadFile>(filePath.string());
-  auto readerOptions = dwio::common::ReaderOptions(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(schema);
   readerOptions.setSerDeOptions(serDeOptions);
   auto input =
@@ -693,8 +695,9 @@ TEST_F(TextWriterTest, verifyArrayTypesWithTextReader) {
   auto readerFactory =
       dwio::common::getReaderFactory(dwio::common::FileFormat::TEXT);
   auto readFile = std::make_shared<LocalReadFile>(filePath.string());
-  auto readerOptions = dwio::common::ReaderOptions(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(schema);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -932,8 +935,9 @@ TEST_F(TextWriterTest, verifyMapTypesWithTextReader) {
   auto readerFactory =
       dwio::common::getReaderFactory(dwio::common::FileFormat::TEXT);
   auto readFile = std::make_shared<LocalReadFile>(filePath.string());
-  auto readerOptions = dwio::common::ReaderOptions(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(schema);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -1088,8 +1092,9 @@ TEST_F(TextWriterTest, verifyNestedRowTypesWithTextReader) {
   auto readerFactory =
       dwio::common::getReaderFactory(dwio::common::FileFormat::TEXT);
   auto readFile = std::make_shared<LocalReadFile>(filePath.string());
-  auto readerOptions = dwio::common::ReaderOptions(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(schema);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -1477,8 +1482,9 @@ TEST_F(
   auto readerFactory =
       dwio::common::getReaderFactory(dwio::common::FileFormat::TEXT);
   auto readFile = std::make_shared<LocalReadFile>(filePath.string());
-  auto readerOptions = dwio::common::ReaderOptions(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(schema);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -1607,8 +1613,9 @@ TEST_F(TextWriterTest, verifySimpleEscapeCharTestWithTextReader) {
   auto readerFactory =
       dwio::common::getReaderFactory(dwio::common::FileFormat::TEXT);
   auto readFile = std::make_shared<LocalReadFile>(filePath.string());
-  auto readerOptions = dwio::common::ReaderOptions(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(schema);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -1740,8 +1747,9 @@ TEST_F(TextWriterTest, verifyCustomEscapeCharTestWithTextReader) {
   auto readerFactory =
       dwio::common::getReaderFactory(dwio::common::FileFormat::TEXT);
   auto readFile = std::make_shared<LocalReadFile>(filePath.string());
-  auto readerOptions = dwio::common::ReaderOptions(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(schema);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -1863,8 +1871,9 @@ TEST_F(TextWriterTest, verifyHeaderTestWithTextReader) {
   auto readerFactory =
       dwio::common::getReaderFactory(dwio::common::FileFormat::TEXT);
   auto readFile = std::make_shared<LocalReadFile>(filePath.string());
-  auto readerOptions = dwio::common::ReaderOptions(
-      pool(), dataIoStats_.get(), metadataIoStats_.get());
+  dwio::common::ReaderOptions readerOptions(pool());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileSchema(schema);
   readerOptions.setSerDeOptions(serDeOptions);
 

--- a/velox/examples/ScanOrc.cpp
+++ b/velox/examples/ScanOrc.cpp
@@ -52,8 +52,9 @@ int main(int argc, char** argv) {
   std::string filePath{argv[1]};
   io::IoStatistics dataIoStats;
   io::IoStatistics metadataIoStats;
-  dwio::common::ReaderOptions readerOpts{
-      pool.get(), &dataIoStats, &metadataIoStats};
+  dwio::common::ReaderOptions readerOpts(pool.get());
+  readerOpts.setDataIoStats(&dataIoStats);
+  readerOpts.setMetadataIoStats(&metadataIoStats);
   // To make DwrfReader reads ORC file, setFileFormat to FileFormat::ORC
   readerOpts.setFileFormat(FileFormat::ORC);
   auto reader = dwio::common::getReaderFactory(FileFormat::ORC)

--- a/velox/exec/benchmarks/RowContainerSortBenchmark.cpp
+++ b/velox/exec/benchmarks/RowContainerSortBenchmark.cpp
@@ -67,8 +67,9 @@ std::vector<std::optional<StringView>> getDataFromFile() {
   auto pool = memory::memoryManager()->addLeafPool();
   velox::io::IoStatistics dataIoStats;
   velox::io::IoStatistics metadataIoStats;
-  facebook::velox::dwio::common::ReaderOptions readerOptions{
-      pool.get(), &dataIoStats, &metadataIoStats};
+  facebook::velox::dwio::common::ReaderOptions readerOptions(pool.get());
+  readerOptions.setDataIoStats(&dataIoStats);
+  readerOptions.setMetadataIoStats(&metadataIoStats);
   facebook::velox::parquet::ParquetReader reader =
       createReader(sample, readerOptions);
   auto rowReaderOpts = getReaderOpts(rowType);

--- a/velox/exec/fuzzer/CacheFuzzer.cpp
+++ b/velox/exec/fuzzer/CacheFuzzer.cpp
@@ -375,8 +375,9 @@ void CacheFuzzer::initializeCache(bool restartCache) {
 }
 
 void CacheFuzzer::initializeInputs() {
-  const auto readOptions =
-      io::ReaderOptions(pool_.get(), &dataIoStats_, &metadataIoStats_);
+  io::ReaderOptions readOptions(pool_.get());
+  readOptions.setDataIoStats(&dataIoStats_);
+  readOptions.setMetadataIoStats(&metadataIoStats_);
   auto tracker = std::make_shared<ScanTracker>(
       "testTracker", nullptr, 256 << 10 /*256KB*/);
   auto ioStatistics = std::make_shared<IoStatistics>();

--- a/velox/exec/tests/utils/TpchQueryBuilder.cpp
+++ b/velox/exec/tests/utils/TpchQueryBuilder.cpp
@@ -70,8 +70,9 @@ void TpchQueryBuilder::readFileSchema(
     const std::string& tableName,
     const std::string& filePath,
     const std::vector<std::string>& columns) {
-  dwio::common::ReaderOptions readerOptions{
-      pool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_.get());
+  readerOptions.setMetadataIoStats(metadataIoStats_.get());
   readerOptions.setFileFormat(format_);
   auto uniqueReadFile =
       filesystems::getFileSystem(filePath, nullptr)->openFileForRead(filePath);

--- a/velox/python/file/PyFile.cpp
+++ b/velox/python/file/PyFile.cpp
@@ -58,11 +58,11 @@ PyType PyFile::getSchema() {
         std::shared_ptr<ReadFile>(std::move(readFile)), *leafPool);
     io::IoStatistics dataIoStats;
     io::IoStatistics metadataIoStats;
+    dwio::common::ReaderOptions readerOptions(leafPool.get());
+    readerOptions.setDataIoStats(&dataIoStats);
+    readerOptions.setMetadataIoStats(&metadataIoStats);
     auto reader = dwio::common::getReaderFactory(fileFormat_)
-                      ->createReader(
-                          std::move(input),
-                          dwio::common::ReaderOptions{
-                              leafPool.get(), &dataIoStats, &metadataIoStats});
+                      ->createReader(std::move(input), readerOptions);
     fileSchema_ = reader->rowType();
   }
   return PyType{fileSchema_};


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/nimble/pull/712

CONTEXT: The ReaderOptions constructor required all three parameters (pool, dataIoStats, metadataIoStats) with VELOX_CHECK_NOT_NULL enforcement (D103639664). This caused friction for callers that do not need IO stats tracking (D104286501), and prevented MetadataInput from cleanly constructing ReaderOptions with only a pool.

WHAT: Change ReaderOptions to a pool-only constructor with setter methods for IO stats. Add a new indexIoStats member for tracking index read IO separately from data and metadata IO.

API changes in io::ReaderOptions (base class):
- Constructor: ReaderOptions(pool) — pool-only, no IO stats args
- New setters: setDataIoStats(), setMetadataIoStats(), setIndexIoStats()
- New member: indexIoStats_ with getter indexIoStats()
- All IO stats members default to nullptr

Same changes propagated to dwio::common::ReaderOptions (derived class).

All ~160 callers across velox/ and dwio/ updated to use pool-only constructor followed by setter calls.

Reviewed By: duxiao1212

Differential Revision: D104504414
