### PR TITLE
test: Handle empty SelectivityVector in reduceToSelectedRows

### DIFF
--- a/velox/expression/tests/ExpressionVerifier.cpp
+++ b/velox/expression/tests/ExpressionVerifier.cpp
@@ -114,6 +114,14 @@ RowVectorPtr reduceToSelectedRows(
   if (rows.isAllSelected()) {
     return rowVector;
   }
+  if (!rows.hasSelections()) {
+    // No rows are selected; return an empty RowVector matching the input
+    // schema rather than asserting on cnt > 0 below. The fuzzer can produce
+    // SelectivityVectors with no bits set when verifying expressions
+    // whose result is fully filtered out.
+    return std::dynamic_pointer_cast<RowVector>(
+        BaseVector::create(rowVector->type(), 0, rowVector->pool()));
+  }
   BufferPtr indices = allocateIndices(rows.end(), rowVector->pool());
   auto rawIndices = indices->asMutable<vector_size_t>();
   vector_size_t cnt = 0;


### PR DESCRIPTION
Fixes #17446.

### Problem

`reduceToSelectedRows` in `velox/expression/tests/ExpressionVerifier.cpp` asserts that at least one row was selected:

```cpp
rows.applyToSelected([&](vector_size_t row) { rawIndices[cnt++] = row; });
VELOX_CHECK_GT(cnt, 0);
```

The Presto Bias Fuzzer can hand the function a `SelectivityVector` with no bits set — for example when an expression's result is fully filtered out by an upstream operator. The assertion then SIGABRTs, killing the fuzzer mid-run with:

```
Expression: cnt > 0 (0 vs. 0)
```

### Fix

Short-circuit before the assertion: if `rows.hasSelections()` is false, return an empty `RowVector` of the input schema. The two callers (`makeProjectionPlan` for the reference-DB path, `assertEqualResults` for the comparison path) handle empty results correctly — both branches end up comparing empty-vs-empty, which is the intended semantics for a fully filtered-out batch.

### Note on testing

`reduceToSelectedRows` lives in an anonymous namespace and is only reached when `referenceQueryRunner_ != nullptr`. The existing unit tests in `ExpressionVerifierUnitTest.cpp` pass `nullptr` for the reference runner, so they don't exercise this code path. Happy to either move `reduceToSelectedRows` to a named utility namespace and add a direct unit test, or wire up a stub `ReferenceQueryRunner` — let me know which you prefer.