### PR TITLE
perf: Use absl::FindLongestCommonPrefix in longest_common_prefix Presto function

### DIFF
--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -145,6 +145,7 @@ velox_link_libraries(
   velox_functions_util
   Folly::folly
   FastFloat::fast_float
+  absl::strings
   stemmer::stemmer
 )
 

--- a/velox/functions/prestosql/StringFunctions.h
+++ b/velox/functions/prestosql/StringFunctions.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <absl/strings/match.h>
+
 #include "velox/common/base/XxHashInline.h"
 
 #include "velox/functions/Udf.h"
@@ -725,21 +727,17 @@ struct LongestCommonPrefixFunction {
     stringImpl::stringToCodePoints(right);
 
     if constexpr (isAscii) {
-      // Fast path for ASCII: simple byte comparison.
-      const char* leftData = left.data();
-      const char* rightData = right.data();
-      const size_t minLength = std::min(left.size(), right.size());
+      // Fast path for ASCII: byte-level prefix using Abseil. The result
+      // refers to bytes inside `left`, which is allowed because the function
+      // declares `reuse_strings_from_arg = 0`.
+      const absl::string_view prefix = absl::FindLongestCommonPrefix(
+          absl::string_view(left.data(), left.size()),
+          absl::string_view(right.data(), right.size()));
 
-      size_t commonLength = 0;
-      while (commonLength < minLength &&
-             leftData[commonLength] == rightData[commonLength]) {
-        commonLength++;
-      }
-
-      if (commonLength == 0) {
+      if (prefix.empty()) {
         result.setEmpty();
       } else {
-        result.setNoCopy(StringView(leftData, commonLength));
+        result.setNoCopy(StringView(prefix.data(), prefix.size()));
       }
     } else {
       // Unicode path: lazy codepoint iteration.


### PR DESCRIPTION
Fixes #15467.

### Change

Replace the manual byte-by-byte loop in the ASCII fast path of `LongestCommonPrefixFunction` (in `velox/functions/prestosql/StringFunctions.h`) with `absl::FindLongestCommonPrefix` from `absl/strings/match.h`, as suggested in the issue. The Unicode codepoint path is unchanged.

### Build / link

`velox_functions_prestosql_impl` now links `absl::strings` directly. `absl` is already a transitive dependency via re2 and s2geometry, so this only adds an explicit link target — no new external dependency.

### Tests

All existing cases in `StringFunctionsTest::longestCommonPrefix` still pass (empty inputs, identical strings, partial common prefix, Unicode, NULL inputs). The change is behavior-preserving for the ASCII path.