### PR TITLE
feat(wave): Add durable kernel caching infrastructure to wave/common (#17474)

### DIFF
--- a/scripts/checks/run-clang-tidy.py
+++ b/scripts/checks/run-clang-tidy.py
@@ -45,12 +45,16 @@ def git_changed_lines(commit):
         match = re.match(r"^\+\+\+ b/(.*(\.cpp|\.h|\.hpp))$", line)
         if match:
             matched_file = match.group(1)
-            # Exclude all files in cudf directories
-            # Exclude *-inl.h files: they are designed to be included from
-            # their corresponding header (e.g., SimdUtil-inl.h is included by
-            # SimdUtil.h) and cannot be compiled as standalone translation
-            # units.
-            if "cudf/" not in matched_file and not matched_file.endswith("-inl.h"):
+            # Exclude files in cudf, wave, and torchwave directories
+            # as clang-tidy doesn't support CUDA compiler flags and CUDA
+            # headers. Exclude *-inl.h files: they are designed to be
+            # included from their corresponding header and cannot be
+            # compiled as standalone translation units.
+            if (
+                "cudf/" not in matched_file
+                and "wave/" not in matched_file
+                and not matched_file.endswith("-inl.h")
+            ):
                 file = matched_file
 
         match = re.match(r"^@@", line)
@@ -77,9 +81,9 @@ def tidy(args):
     files = util.input_files(args.files)
     files = [file for file in files if re.match(r".*(\.cpp|\.h|\.hpp)$", file)]
 
-    # Exclude all files in cudf directories
+    # Exclude files in cudf, wave, and torchwave directories
     # as clang-tidy doesn't support CUDA compiler flags and CUDA headers
-    files = [file for file in files if "cudf/" not in file]
+    files = [file for file in files if "cudf/" not in file and "wave/" not in file]
 
     # Exclude *-inl.h files: they are designed to be included from their
     # corresponding header and cannot be compiled as standalone translation

--- a/velox/experimental/wave/common/CMakeLists.txt
+++ b/velox/experimental/wave/common/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(
   Cuda.cu
   Exception.cpp
   KernelCache.cpp
+  KernelFsCache.cpp
   Type.cpp
   ResultStaging.cpp
 )

--- a/velox/experimental/wave/common/Compile.cu
+++ b/velox/experimental/wave/common/Compile.cu
@@ -17,6 +17,7 @@
 #include <fmt/format.h>
 #include <gflags/gflags.h>
 #include <nvrtc.h>
+#include <chrono>
 #include "velox/experimental/wave/common/Cuda.h"
 #include "velox/experimental/wave/common/CudaUtil.cuh"
 #include "velox/experimental/wave/common/Exception.h"
@@ -54,8 +55,11 @@ void nvrtcCheck(nvrtcResult result) {
 
 class CompiledModuleImpl : public CompiledModule {
  public:
-  CompiledModuleImpl(CUmodule module, std::vector<CUfunction> kernels)
-      : module_(module), kernels_(std::move(kernels)) {}
+  CompiledModuleImpl(
+      CUmodule module,
+      std::vector<CUfunction> kernels,
+      int64_t compileMs)
+      : module_(module), kernels_(std::move(kernels)), compileMs_(compileMs) {}
 
   ~CompiledModuleImpl() {
     auto result = cuModuleUnload(module_);
@@ -72,11 +76,20 @@ class CompiledModuleImpl : public CompiledModule {
       Stream* stream,
       void** args) override;
 
+  void launchCooperative(
+      int32_t kernelIdx,
+      int32_t numBlocks,
+      int32_t numThreads,
+      int32_t shared,
+      Stream* stream,
+      void** args) override;
+
   KernelInfo info(int32_t kernelIdx) override;
 
  private:
   CUmodule module_;
   std::vector<CUfunction> kernels_;
+  int64_t compileMs_;
 };
 
 namespace {
@@ -291,7 +304,7 @@ void CompiledModule::initialize() {
   ensureInit();
 }
 
-std::shared_ptr<CompiledModule> CompiledModule::create(const KernelSpec& spec) {
+std::shared_ptr<CompiledModule> CompiledModule::create(KernelSpec& spec) {
   ensureInit();
   const char** headers = waveHeaderTextString.data();
   const char** headerNames = waveHeaderNameString.data();
@@ -311,6 +324,14 @@ std::shared_ptr<CompiledModule> CompiledModule::create(const KernelSpec& spec) {
     numHeaders += spec.numHeaders;
   }
   nvrtcProgram prog;
+  std::string entryNames;
+  for (auto& name : spec.entryPoints) {
+    if (!entryNames.empty()) {
+      entryNames += ", ";
+    }
+    entryNames += name;
+  }
+  auto nvrtcStart = std::chrono::steady_clock::now();
   nvrtcCreateProgram(
       &prog,
       spec.code.c_str(), // buffer
@@ -336,9 +357,15 @@ std::shared_ptr<CompiledModule> CompiledModule::create(const KernelSpec& spec) {
 
   if (compileResult != NVRTC_SUCCESS) {
     nvrtcDestroyProgram(&prog);
-    waveError(std::string("Cuda compilation error: ") + log);
+    auto errorMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                       std::chrono::steady_clock::now() - nvrtcStart)
+                       .count();
+    waveError(fmt::format("Cuda compilation error ({}ms): {}", errorMs, log));
   }
-  // Obtain PTX from the program.
+  auto elapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                       std::chrono::steady_clock::now() - nvrtcStart)
+                       .count();
+  // Obtain PTX or CUBIN from the program.
   size_t codeSize;
   std::string code;
   if (FLAGS_cuda_ptx) {
@@ -355,6 +382,25 @@ std::shared_ptr<CompiledModule> CompiledModule::create(const KernelSpec& spec) {
     const char* temp;
     nvrtcCheck(nvrtcGetLoweredName(prog, entry.c_str(), &temp));
     loweredNames.push_back(std::string(temp));
+  }
+  spec.loweredNames = loweredNames;
+  if (!spec.cubinPath.empty()) {
+    std::string cubin;
+    if (FLAGS_cuda_ptx) {
+      size_t cubinSize;
+      nvrtcCheck(nvrtcGetCUBINSize(prog, &cubinSize));
+      cubin.resize(cubinSize);
+      nvrtcCheck(nvrtcGetCUBIN(prog, cubin.data()));
+    } else {
+      cubin = code;
+    }
+    std::ofstream out(spec.cubinPath, std::ios::binary);
+    out.write(cubin.data(), cubin.size());
+    // Write lowered names so fromCubin can resolve entry points.
+    std::ofstream namesOut(spec.cubinPath + ".names");
+    for (auto& name : loweredNames) {
+      namesOut << name << "\n";
+    }
   }
 
   nvrtcDestroyProgram(&prog);
@@ -381,7 +427,33 @@ std::shared_ptr<CompiledModule> CompiledModule::create(const KernelSpec& spec) {
     funcs.emplace_back();
     CU_CHECK(cuModuleGetFunction(&funcs.back(), module, name.c_str()));
   }
-  return std::make_shared<CompiledModuleImpl>(module, std::move(funcs));
+  return std::make_shared<CompiledModuleImpl>(
+      module, std::move(funcs), elapsedMs);
+}
+
+// static
+std::shared_ptr<CompiledModule> CompiledModule::fromCubin(
+    const std::string& cubinPath,
+    const KernelSpec& spec) {
+  auto loadStart = std::chrono::steady_clock::now();
+  CUmodule module;
+  auto loadResult = cuModuleLoad(&module, cubinPath.c_str());
+  if (loadResult != CUDA_SUCCESS) {
+    const char* errStr;
+    cuGetErrorString(loadResult, &errStr);
+    waveError(
+        fmt::format("Error loading CUBIN from {}: {}", cubinPath, errStr));
+  }
+  std::vector<CUfunction> funcs;
+  for (auto& name : spec.loweredNames) {
+    funcs.emplace_back();
+    CU_CHECK(cuModuleGetFunction(&funcs.back(), module, name.c_str()));
+  }
+  auto elapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                       std::chrono::steady_clock::now() - loadStart)
+                       .count();
+  return std::make_shared<CompiledModuleImpl>(
+      module, std::move(funcs), elapsedMs);
 }
 
 void CompiledModuleImpl::launch(
@@ -406,6 +478,27 @@ void CompiledModuleImpl::launch(
   CU_CHECK(result);
 };
 
+void CompiledModuleImpl::launchCooperative(
+    int32_t kernelIdx,
+    int32_t numBlocks,
+    int32_t numThreads,
+    int32_t shared,
+    Stream* stream,
+    void** args) {
+  auto result = cuLaunchCooperativeKernel(
+      kernels_[kernelIdx],
+      numBlocks,
+      1,
+      1, // grid dim
+      numThreads,
+      1,
+      1, // block dim
+      shared,
+      reinterpret_cast<CUstream>(stream->stream()->stream),
+      args);
+  CU_CHECK(result);
+};
+
 KernelInfo CompiledModuleImpl::info(int32_t kernelIdx) {
   KernelInfo info;
   auto f = kernels_[kernelIdx];
@@ -420,6 +513,7 @@ KernelInfo CompiledModuleImpl::info(int32_t kernelIdx) {
   info.maxOccupancy0 = max;
   cuOccupancyMaxActiveBlocksPerMultiprocessor(&max, f, 256, 256 * 32);
   info.maxOccupancy32 = max;
+  info.compileMs = compileMs_;
   return info;
 }
 

--- a/velox/experimental/wave/common/Cuda.cu
+++ b/velox/experimental/wave/common/Cuda.cu
@@ -23,6 +23,7 @@
 #include "velox/experimental/wave/common/HashTable.h"
 
 #include <assert.h>
+#include <atomic>
 #include <mutex>
 #include <sstream>
 
@@ -69,7 +70,7 @@ std::string Device::toString() const {
 
 namespace {
 std::mutex ctxMutex;
-bool driverInited = false;
+std::atomic<bool> driverInited{false};
 
 // A context for each device. Each is initialized on first use and made the
 // primary context for the device.
@@ -78,8 +79,8 @@ std::vector<CUcontext> contexts;
 std::vector<std::unique_ptr<Device>> devices;
 
 Device* setDriverDevice(int32_t deviceId) {
+  std::lock_guard<std::mutex> l(ctxMutex);
   if (!driverInited) {
-    std::lock_guard<std::mutex> l(ctxMutex);
     CU_CHECK(cuInit(0));
     int32_t cnt;
     CU_CHECK(cuDeviceGetCount(&cnt));
@@ -97,24 +98,21 @@ Device* setDriverDevice(int32_t deviceId) {
     cuCtxSetCurrent(contexts[deviceId]);
     return devices[deviceId].get();
   }
-  {
-    std::lock_guard<std::mutex> l(ctxMutex);
-    CUdevice dev;
-    CU_CHECK(cuDeviceGet(&dev, deviceId));
-    CU_CHECK(cuDevicePrimaryCtxRetain(&contexts[deviceId], dev));
-    devices[deviceId] = std::make_unique<Device>(deviceId);
-    cudaDeviceProp prop;
-    CUDA_CHECK(cudaGetDeviceProperties(&prop, deviceId));
-    auto& device = devices[deviceId];
-    device->model = prop.name;
-    device->major = prop.major;
-    device->minor = prop.minor;
-    device->globalMB = prop.totalGlobalMem >> 20;
-    device->numSM = prop.multiProcessorCount;
-    device->sharedMemPerSM = prop.sharedMemPerMultiprocessor;
-    device->L2Size = prop.l2CacheSize;
-    device->persistingL2MaxSize = prop.persistingL2CacheMaxSize;
-  }
+  CUdevice dev;
+  CU_CHECK(cuDeviceGet(&dev, deviceId));
+  CU_CHECK(cuDevicePrimaryCtxRetain(&contexts[deviceId], dev));
+  devices[deviceId] = std::make_unique<Device>(deviceId);
+  cudaDeviceProp prop;
+  CUDA_CHECK(cudaGetDeviceProperties(&prop, deviceId));
+  auto& device = devices[deviceId];
+  device->model = prop.name;
+  device->major = prop.major;
+  device->minor = prop.minor;
+  device->globalMB = prop.totalGlobalMem >> 20;
+  device->numSM = prop.multiProcessorCount;
+  device->sharedMemPerSM = prop.sharedMemPerMultiprocessor;
+  device->L2Size = prop.l2CacheSize;
+  device->persistingL2MaxSize = prop.persistingL2CacheMaxSize;
   CU_CHECK(cuCtxSetCurrent(contexts[deviceId]));
   return devices[deviceId].get();
 }
@@ -123,16 +121,15 @@ Device* setDriverDevice(int32_t deviceId) {
 
 Device* currentDevice() {
   CUcontext ctx;
-  CU_CHECK(cuCtxGetCurrent(&ctx));
-  if (!ctx) {
+  if (CUDA_SUCCESS != cuCtxGetCurrent(&ctx) || ctx == nullptr) {
     return nullptr;
   }
+  std::lock_guard<std::mutex> l(ctxMutex);
   for (auto i = 0; i < contexts.size(); ++i) {
     if (contexts[i] == ctx) {
       return devices[i].get();
     }
   }
-  waveError("Device context not found. Inconsistent state.");
   return nullptr;
 }
 
@@ -441,7 +438,7 @@ std::string KernelInfo::toString() const {
   out << "NumRegs=" << numRegs << " maxThreadsPerBlock= " << maxThreadsPerBlock
       << " sharedMemory=" << sharedMemory << " localMemory=" << localMemory
       << " occupancy 256,  0=" << maxOccupancy0
-      << " occupancy 256,32=" << maxOccupancy32;
+      << " occupancy 256,32=" << maxOccupancy32 << " compileMs=" << compileMs;
   return out.str();
 }
 

--- a/velox/experimental/wave/common/Cuda.h
+++ b/velox/experimental/wave/common/Cuda.h
@@ -240,6 +240,8 @@ struct KernelInfo {
   int32_t localMemory{0};
   int32_t maxOccupancy0{0};
   int32_t maxOccupancy32{0};
+  /// NVRTC compilation time in milliseconds.
+  int64_t compileMs{0};
 
   std::string toString() const;
 };
@@ -250,8 +252,20 @@ struct KernelSpec {
   std::vector<std::string> entryPoints;
   std::string filePath;
   int32_t numHeaders{0};
-  const char** headers;
+  const char** headers{nullptr};
   const char** headerNames{nullptr};
+  /// If non-empty, the compiled CUBIN is written to this path.
+  std::string cubinPath;
+  /// Mangled entry point names. Populated by create() after compilation.
+  /// Must be set when using fromCubinPath.
+  std::vector<std::string> loweredNames;
+  /// If non-empty, loads a pre-compiled CUBIN from this path instead of
+  /// compiling. loweredNames must be populated.
+  std::string fromCubinPath;
+  /// Called after compilation (or failure), before the kernel is added to the
+  /// cache. On success, error is nullptr and loweredNames is populated. On
+  /// failure, error holds the exception.
+  std::function<void(KernelSpec& spec, std::exception_ptr error)> postCompile;
 };
 
 /// Represents the result of compilation. Wrapped accessed through
@@ -261,10 +275,26 @@ struct CompiledModule {
 
   static void initialize();
 
-  /// Compiles 'spec' and returns the result.
-  static std::shared_ptr<CompiledModule> create(const KernelSpec& spec);
+  /// Compiles 'spec' and returns the result. Populates spec.loweredNames.
+  static std::shared_ptr<CompiledModule> create(KernelSpec& spec);
+
+  /// Loads a pre-compiled CUBIN from 'cubinPath' using the mangled entry point
+  /// names in 'spec.loweredNames'.
+  static std::shared_ptr<CompiledModule> fromCubin(
+      const std::string& cubinPath,
+      const KernelSpec& spec);
 
   virtual void launch(
+      int32_t kernelIdx,
+      int32_t numBlocks,
+      int32_t numThreads,
+      int32_t shared,
+      Stream* stream,
+      void** args) = 0;
+
+  /// Launches the kernel as a cooperative grid. All blocks are guaranteed
+  /// to be resident simultaneously.
+  virtual void launchCooperative(
       int32_t kernelIdx,
       int32_t numBlocks,
       int32_t numThreads,
@@ -297,7 +327,18 @@ class CompiledKernel {
       const std::string& key,
       KernelGenFunc func);
 
+  /// Clears all entries from the kernel cache.
+  static void clearCache();
+
   virtual void launch(
+      int32_t idx,
+      int32_t numBlocks,
+      int32_t numThreads,
+      int32_t shared,
+      Stream* stream,
+      void** args) = 0;
+
+  virtual void launchCooperative(
       int32_t idx,
       int32_t numBlocks,
       int32_t numThreads,

--- a/velox/experimental/wave/common/KernelCache.cpp
+++ b/velox/experimental/wave/common/KernelCache.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/common/caching/CachedFactory.h"
 #include "velox/experimental/wave/common/Cuda.h"
+#include "velox/experimental/wave/common/Exception.h"
 
 #include <folly/executors/CPUThreadPoolExecutor.h>
 #include <folly/futures/Future.h>
@@ -45,6 +46,18 @@ class FutureCompiledModule : public CompiledModule {
       void** args) override {
     ensureReady();
     module_->launch(kernelIdx, numBlocks, numThreads, shared, stream, args);
+  }
+
+  void launchCooperative(
+      int32_t kernelIdx,
+      int32_t numBlocks,
+      int32_t numThreads,
+      int32_t shared,
+      Stream* stream,
+      void** args) override {
+    ensureReady();
+    module_->launchCooperative(
+        kernelIdx, numBlocks, numThreads, shared, stream, args);
   }
 
   KernelInfo info(int32_t kernelIdx) override {
@@ -84,6 +97,17 @@ class AsyncCompiledKernel : public CompiledKernel {
     (*ptr_)->launch(kernelIdx, numBlocks, numThreads, shared, stream, args);
   }
 
+  void launchCooperative(
+      int32_t kernelIdx,
+      int32_t numBlocks,
+      int32_t numThreads,
+      int32_t shared,
+      Stream* stream,
+      void** args) override {
+    (*ptr_)->launchCooperative(
+        kernelIdx, numBlocks, numThreads, shared, stream, args);
+  }
+
   KernelInfo info(int32_t kernelIdx) override {
     return (*ptr_)->info(kernelIdx);
   }
@@ -107,7 +131,25 @@ class KernelGenerator {
     compilerExecutor()->add([genCopy = *gen, holder, device]() {
       setDevice(device);
       auto spec = genCopy();
-      auto module = CompiledModule::create(spec);
+      ModulePtr module;
+      try {
+        if (!spec.fromCubinPath.empty()) {
+          if (spec.loweredNames.empty()) {
+            waveError("loweredNames must be set when using fromCubinPath");
+          }
+          module = CompiledModule::fromCubin(spec.fromCubinPath, spec);
+        } else {
+          module = CompiledModule::create(spec);
+        }
+        if (spec.postCompile) {
+          spec.postCompile(spec, nullptr);
+        }
+      } catch (...) {
+        if (spec.postCompile) {
+          spec.postCompile(spec, std::current_exception());
+        }
+        throw;
+      }
       holder->promise.setValue(module);
     });
     ModulePtr result =
@@ -143,6 +185,11 @@ std::unique_ptr<CompiledKernel> CompiledKernel::getKernel(
     KernelGenFunc gen) {
   auto ptr = kernelCache().generate(key, &gen);
   return std::make_unique<AsyncCompiledKernel>(std::move(ptr));
+}
+
+// static
+void CompiledKernel::clearCache() {
+  kernelCache().clearCache();
 }
 
 } // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/KernelFsCache.cpp
+++ b/velox/experimental/wave/common/KernelFsCache.cpp
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/wave/common/KernelFsCache.h"
+
+#include <fmt/format.h>
+#include <unistd.h>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+
+namespace fs = std::filesystem;
+
+namespace facebook::velox::wave {
+
+namespace {
+
+std::string readFile(const std::string& path) {
+  std::ifstream in(path);
+  if (!in.good()) {
+    return {};
+  }
+  return {std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>()};
+}
+
+std::vector<std::string> readNames(const std::string& path) {
+  std::vector<std::string> result;
+  std::ifstream in(path);
+  std::string line;
+  while (std::getline(in, line)) {
+    if (!line.empty()) {
+      result.push_back(line);
+    }
+  }
+  return result;
+}
+
+} // namespace
+
+KernelFsCache::KernelFsCache(const std::string& cacheDir)
+    : cacheDir_(cacheDir) {}
+
+std::string KernelFsCache::cuPath(int32_t ordinal) const {
+  return fmt::format("{}/{}.cu", cacheDir_, ordinal);
+}
+
+std::string KernelFsCache::cubinPath(int32_t ordinal) const {
+  return fmt::format("{}/{}.cubin", cacheDir_, ordinal);
+}
+
+std::string KernelFsCache::namesPath(int32_t ordinal) const {
+  return fmt::format("{}/{}.cubin.names", cacheDir_, ordinal);
+}
+
+void KernelFsCache::init() {
+  if (initialized_) {
+    return;
+  }
+  initialized_ = true;
+
+  if (!fs::exists(cacheDir_)) {
+    fs::create_directories(cacheDir_);
+    return;
+  }
+
+  for (auto& entry : fs::directory_iterator(cacheDir_)) {
+    if (entry.path().extension() != ".cu") {
+      continue;
+    }
+    auto stem = entry.path().stem().string();
+    int32_t ordinal;
+    try {
+      ordinal = std::stoi(stem);
+    } catch (...) {
+      continue;
+    }
+    auto cubinFile = cubinPath(ordinal);
+    auto namesFile = namesPath(ordinal);
+    if (!fs::exists(cubinFile) || fs::file_size(cubinFile) == 0 ||
+        !fs::exists(namesFile)) {
+      continue;
+    }
+    auto text = readFile(entry.path().string());
+    if (text.empty()) {
+      continue;
+    }
+    auto hash = std::hash<std::string>{}(text);
+    hashToEntries_[hash].push_back({ordinal});
+    ++numEntries_;
+    if (ordinal >= nextOrdinal_) {
+      nextOrdinal_ = ordinal + 1;
+    }
+  }
+}
+
+std::unique_ptr<CompiledKernel> KernelFsCache::getKernel(
+    const std::string& key,
+    KernelGenFunc genFunc) {
+  auto hash = std::hash<std::string>{}(key);
+  auto assignedOrdinal = std::make_shared<std::atomic<int32_t>>(-1);
+
+  auto wrappedGen = [this,
+                     keyCopy = key,
+                     hash,
+                     genFuncCopy = std::move(genFunc),
+                     assignedOrdinal]() -> KernelSpec {
+    std::unique_lock lock(mutex_);
+    init();
+
+    auto it = hashToEntries_.find(hash);
+    if (it != hashToEntries_.end()) {
+      for (auto& entry : it->second) {
+        auto text = readFile(cuPath(entry.ordinal));
+        if (text != keyCopy) {
+          continue;
+        }
+        auto cubinFilePath = cubinPath(entry.ordinal);
+        auto namesFilePath = namesPath(entry.ordinal);
+        if (!fs::exists(cubinFilePath) || fs::file_size(cubinFilePath) == 0 ||
+            !fs::exists(namesFilePath)) {
+          continue;
+        }
+        auto lowered = readNames(namesFilePath);
+        lock.unlock();
+        ++hits_;
+
+        KernelSpec loadSpec;
+        loadSpec.loweredNames = std::move(lowered);
+        loadSpec.fromCubinPath = std::move(cubinFilePath);
+        return loadSpec;
+      }
+    }
+
+    lock.unlock();
+    auto spec = genFuncCopy();
+    lock.lock();
+
+    auto ordinal = nextOrdinal_++;
+    assignedOrdinal->store(ordinal);
+    spec.cubinPath = cubinPath(ordinal);
+
+    spec.postCompile = [this, ordinal, hash, keyCopy](
+                           KernelSpec& /*compiled*/, std::exception_ptr error) {
+      std::unique_lock lock(mutex_);
+      if (error) {
+        std::error_code removeError;
+        fs::remove(cubinPath(ordinal), removeError);
+        fs::remove(cubinPath(ordinal) + ".names", removeError);
+        return;
+      }
+      {
+        std::ofstream out(cuPath(ordinal));
+        out << keyCopy;
+      }
+      hashToEntries_[hash].push_back({ordinal});
+      ++numEntries_;
+    };
+
+    ++misses_;
+    lock.unlock();
+
+    return spec;
+  };
+
+  try {
+    return CompiledKernel::getKernel(key, std::move(wrappedGen));
+  } catch (...) {
+    std::unique_lock lock(mutex_);
+    auto ordinal = assignedOrdinal->load();
+    if (ordinal >= 0) {
+      std::error_code removeError;
+      fs::remove(cuPath(ordinal), removeError);
+      fs::remove(cubinPath(ordinal), removeError);
+      fs::remove(namesPath(ordinal), removeError);
+      auto it = hashToEntries_.find(hash);
+      if (it != hashToEntries_.end()) {
+        auto& entries = it->second;
+        entries.erase(
+            std::remove_if(
+                entries.begin(),
+                entries.end(),
+                [&](const CacheEntry& entry) {
+                  return entry.ordinal == ordinal;
+                }),
+            entries.end());
+        if (entries.empty()) {
+          hashToEntries_.erase(it);
+        }
+      }
+    }
+    throw;
+  }
+}
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/KernelFsCache.h
+++ b/velox/experimental/wave/common/KernelFsCache.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
+#include "velox/experimental/wave/common/Cuda.h"
+
+namespace facebook::velox::wave {
+
+/// Caches compiled CUDA kernels on the filesystem, keyed by source hash.
+/// Stores .cu source, .cubin binaries, and .names (mangled entry points)
+/// in a directory. On lookup, hashes the source text and compares against
+/// cached entries to avoid recompilation across runs.
+class KernelFsCache {
+ public:
+  explicit KernelFsCache(const std::string& cacheDir);
+
+  /// Returns a compiled kernel for the given key. If a matching source is
+  /// found in the cache directory, loads the pre-compiled CUBIN. Otherwise
+  /// compiles via wave and stores the result for future runs.
+  std::unique_ptr<CompiledKernel> getKernel(
+      const std::string& key,
+      KernelGenFunc genFunc);
+
+  /// Returns the number of cache hits since construction.
+  int64_t hits() const {
+    return hits_;
+  }
+
+  /// Returns the number of cache misses since construction.
+  int64_t misses() const {
+    return misses_;
+  }
+
+  /// Returns the number of distinct successfully cached entries.
+  int32_t size() const {
+    return numEntries_.load();
+  }
+
+ private:
+  struct CacheEntry {
+    int32_t ordinal;
+  };
+
+  /// Scans the cache directory and populates hashToEntries_ on first call.
+  void init();
+
+  /// Returns the path for the .cu source file at the given cache ordinal.
+  std::string cuPath(int32_t ordinal) const;
+  /// Returns the path for the .cubin binary at the given cache ordinal.
+  std::string cubinPath(int32_t ordinal) const;
+  /// Returns the path for the .cubin.names sidecar at the given cache ordinal.
+  std::string namesPath(int32_t ordinal) const;
+
+  // Directory holding the cached .cu, .cubin, and .cubin.names files.
+  std::string cacheDir_;
+  // True after the first call to init().
+  bool initialized_{false};
+  // Protects hashToEntries_, nextOrdinal_, and initialized_.
+  std::mutex mutex_;
+  // Maps source-text hash to cache entries sharing that hash.
+  // Using unordered_map because adding folly::F14FastMap as a dependency
+  // causes dependency count regressions across all downstream wave targets.
+  std::unordered_map<size_t, std::vector<CacheEntry>> hashToEntries_;
+  // Next ordinal for new cache files.
+  std::atomic<int32_t> nextOrdinal_{0};
+  // Serial number for compile operations.
+  std::atomic<int32_t> compileSerial_{0};
+  // Number of distinct cached entries.
+  std::atomic<int32_t> numEntries_{0};
+  std::atomic<int64_t> hits_{0};
+  std::atomic<int64_t> misses_{0};
+};
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/tests/CompileTest.cu
+++ b/velox/experimental/wave/common/tests/CompileTest.cu
@@ -17,13 +17,18 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 
+#include <folly/ScopeGuard.h>
 #include <gtest/gtest.h>
 #include "velox/experimental/wave/common/Buffer.h"
 #include "velox/experimental/wave/common/CudaUtil.cuh"
 #include "velox/experimental/wave/common/Exception.h"
 #include "velox/experimental/wave/common/GpuArena.h"
+#include "velox/experimental/wave/common/KernelFsCache.h"
 #include "velox/experimental/wave/common/tests/BlockTest.h"
 
+#include <unistd.h>
+#include <filesystem>
+#include <fstream>
 #include <iostream>
 
 namespace facebook::velox::wave {
@@ -227,6 +232,181 @@ TEST_F(CompileTest, reduce) {
     sum += i;
   }
   EXPECT_EQ(sum, ptr2[0]);
+}
+
+TEST_F(CompileTest, cubinCache) {
+  const char* text =
+      "#include \"velox/experimental/wave/common/Scan.cuh\"\n"
+      "namespace facebook::velox::wave {\n"
+      "__global__ void scanKernel32(int32_t* ints) {\n"
+      "  using Scan = WarpScan<uint32_t>;\n"
+      "uint32_t out;\n"
+      " Scan().exclusiveSum(ints[threadIdx.x], out);\n"
+      "ints[threadIdx.x] = out;\n"
+      "__syncthreads();\n"
+      "}\n"
+      "}\n";
+
+  std::string cubinPath =
+      "/tmp/compile_test_scan_" + std::to_string(getpid()) + ".cubin";
+
+  // Phase 1: compile via getKernel with cubinPath and postCompile set.
+  bool postCompileCalled = false;
+  std::vector<std::string> savedLoweredNames;
+
+  auto kernel = CompiledKernel::getKernel("scanCubinTest", [&]() -> KernelSpec {
+    KernelSpec spec;
+    spec.code = text;
+    spec.entryPoints = {"facebook::velox::wave::scanKernel32"};
+    spec.filePath = "scan_cubin.cu";
+    spec.cubinPath = cubinPath;
+    spec.postCompile = [&](KernelSpec& compiled, std::exception_ptr error) {
+      EXPECT_EQ(error, nullptr);
+      postCompileCalled = true;
+      savedLoweredNames = compiled.loweredNames;
+    };
+    return spec;
+  });
+
+  // Verify postCompile was called and loweredNames were populated.
+  auto info = kernel->info(0);
+  EXPECT_GT(info.numRegs, 0);
+  EXPECT_TRUE(postCompileCalled);
+  ASSERT_EQ(savedLoweredNames.size(), 1);
+
+  // Launch and verify result.
+  auto runAndCheck = [&](CompiledKernel& kernel) {
+    WaveBufferPtr ints = arena_->allocate<uint32_t>(32);
+    for (auto i = 0; i < 32; ++i) {
+      ints->as<uint32_t>()[i] = i;
+    }
+    auto rawInts = ints->as<int32_t>();
+    void* params = &rawInts;
+    auto stream = std::make_unique<Stream>();
+    kernel.launch(0, 1, 32, 0, stream.get(), &params);
+    stream->wait();
+    int32_t sum = 0;
+    for (auto i = 0; i < 32; ++i) {
+      EXPECT_EQ(rawInts[i], sum);
+      sum += i;
+    }
+  };
+  runAndCheck(*kernel);
+
+  // Phase 2: clear cache and load from CUBIN via getKernel with
+  // fromCubinPath.
+  CompiledKernel::clearCache();
+  auto kernel2 =
+      CompiledKernel::getKernel("scanCubinTest2", [&]() -> KernelSpec {
+        KernelSpec spec;
+        spec.entryPoints = {"facebook::velox::wave::scanKernel32"};
+        spec.fromCubinPath = cubinPath;
+        spec.loweredNames = savedLoweredNames;
+        return spec;
+      });
+  runAndCheck(*kernel2);
+}
+
+TEST_F(CompileTest, fsCache) {
+  const char* scanText =
+      "#include \"velox/experimental/wave/common/Scan.cuh\"\n"
+      "namespace facebook::velox::wave {\n"
+      "__global__ void scanKernel32(int32_t* ints) {\n"
+      "  using Scan = WarpScan<uint32_t>;\n"
+      "uint32_t out;\n"
+      " Scan().exclusiveSum(ints[threadIdx.x], out);\n"
+      "ints[threadIdx.x] = out;\n"
+      "__syncthreads();\n"
+      "}\n"
+      "}\n";
+
+  auto cachePath = "/tmp/compile_test_fscache_" + std::to_string(getpid());
+  std::error_code ec;
+  std::filesystem::remove_all(cachePath, ec);
+  SCOPE_EXIT {
+    std::filesystem::remove_all(cachePath, ec);
+  };
+
+  auto runAndCheck = [&](CompiledKernel& kernel) {
+    WaveBufferPtr ints = arena_->allocate<uint32_t>(32);
+    for (auto i = 0; i < 32; ++i) {
+      ints->as<uint32_t>()[i] = i;
+    }
+    auto rawInts = ints->as<int32_t>();
+    void* params = &rawInts;
+    auto stream = std::make_unique<Stream>();
+    kernel.launch(0, 1, 32, 0, stream.get(), &params);
+    stream->wait();
+    int32_t sum = 0;
+    for (auto i = 0; i < 32; ++i) {
+      EXPECT_EQ(rawInts[i], sum);
+      sum += i;
+    }
+  };
+
+  auto makeGenFunc = [&]() -> KernelGenFunc {
+    return [&]() -> KernelSpec {
+      KernelSpec spec;
+      spec.code = scanText;
+      spec.entryPoints = {"facebook::velox::wave::scanKernel32"};
+      spec.filePath = "scan_fs.cu";
+      return spec;
+    };
+  };
+
+  {
+    KernelFsCache cache(cachePath);
+
+    // First call: expect miss.
+    {
+      auto kernel = cache.getKernel(scanText, makeGenFunc());
+      runAndCheck(*kernel);
+    }
+    EXPECT_EQ(cache.misses(), 1);
+    EXPECT_EQ(cache.hits(), 0);
+    EXPECT_EQ(cache.size(), 1);
+
+    // Second call after clearing RAM cache: expect fs cache hit.
+    CompiledKernel::clearCache();
+    {
+      auto kernel2 = cache.getKernel(scanText, makeGenFunc());
+      runAndCheck(*kernel2);
+    }
+    EXPECT_EQ(cache.hits(), 1);
+    EXPECT_EQ(cache.misses(), 1);
+    EXPECT_EQ(cache.size(), 1);
+  }
+
+  // Destroy the fs cache and RAM cache, then recreate from the same path.
+  CompiledKernel::clearCache();
+  {
+    KernelFsCache cache2(cachePath);
+    auto kernel3 = cache2.getKernel(scanText, makeGenFunc());
+    runAndCheck(*kernel3);
+    EXPECT_EQ(cache2.hits(), 1);
+    EXPECT_EQ(cache2.misses(), 0);
+    EXPECT_EQ(cache2.size(), 1);
+
+    // Make a broken kernel text that will fail to compile.
+    auto badText = std::string(scanText) + "#error intentional\n";
+    auto sizeBefore = cache2.size();
+    bool threw = false;
+    try {
+      auto badKernel = cache2.getKernel(badText, [&]() -> KernelSpec {
+        KernelSpec spec;
+        spec.code = badText;
+        spec.entryPoints = {"facebook::velox::wave::scanKernel32"};
+        spec.filePath = "scan_bad.cu";
+        return spec;
+      });
+      // Access info to force the deferred compilation to complete.
+      badKernel->info(0);
+    } catch (...) {
+      threw = true;
+    }
+    EXPECT_TRUE(threw);
+    EXPECT_EQ(cache2.size(), sizeBefore);
+  }
 }
 
 } // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/tests/HashTableTest.cpp
+++ b/velox/experimental/wave/common/tests/HashTableTest.cpp
@@ -232,13 +232,10 @@ class HashTableTest : public testing::Test {
 
   void updateJitMtxCoa(TestingRow* rows, HashRun& run, TestingRow* reference) {
     std::cout << "updateJitMtxCoa" << std::endl;
-    KernelSpec spec = {
-        jitMtxCoa,
-        {"facebook::velox::wave::jitSumMtxCoalesce"},
-        "sum1Jit.cu",
-        0,
-        nullptr,
-        nullptr};
+    KernelSpec spec;
+    spec.code = jitMtxCoa;
+    spec.entryPoints = {"facebook::velox::wave::jitSumMtxCoalesce"};
+    spec.filePath = "sum1Jit.cu";
     auto kernel = CompiledModule::create(spec);
     uint64_t micros = 0;
     {


### PR DESCRIPTION
Summary:

Adds filesystem-based CUBIN caching and kernel compilation lifecycle hooks to wave/common. This allows compiled CUDA kernels to be persisted to disk and reloaded across runs, avoiding expensive NVRTC recompilation. A 35K-line kernel that takes 18s to compile loads from cache in ~150ms.

KernelSpec extensions (Cuda.h):
- fromCubinPath: loads a pre-compiled CUBIN instead of compiling
- loweredNames: mangled entry point names, populated by create() after compilation
- postCompile: callback invoked after compilation (or failure) with an exception_ptr; loweredNames is populated at this point
- cubinPath: writes the compiled CUBIN to disk when set

KernelInfo (Cuda.h, Cuda.cu):
- Added compileMs field recording NVRTC compilation time

CompiledModule (Compile.cu):
- create() now populates spec.loweredNames after resolving mangled names
- create() writes a .names sidecar file alongside the CUBIN when cubinPath is set

KernelCache (KernelCache.cpp):
- KernelGenerator now handles fromCubinPath: loads from CUBIN instead of compiling
- Calls postCompile with nullptr on success, current_exception() on failure
- Added clearCache() static method on CompiledKernel

KernelFsCache (new files):
- Filesystem-based kernel cache keyed by source text hash
- On init, reads .cu files from the cache directory and builds an in-memory hash table
- On lookup hit, loads the matching .cubin via fromCubinPath
- On miss, compiles via wave, writes .cu/.cubin/.names to the cache directory
- Thread-safe: mutex protects init, lookup, and entry creation; compilation runs outside the mutex
- Tracks hits/misses/size counters
- Error handling: postCompile cleans up files on failure; outer try/catch removes partial entries

Tests (CompileTest.cu):
- cubinCache: compiles via getKernel with cubinPath + postCompile, verifies postCompile is called with nullptr, clears RAM cache, reloads from CUBIN via fromCubinPath, verifies correctness
- fsCache: exercises miss path, hit-after-clear path, hit-after-reconstruct (new KernelFsCache instance), and compilation error path (verifies size doesn't grow on failure)

Reviewed By: Yuhta

Differential Revision: D104613803


