### PR TITLE
feat: Support reading Iceberg TIME (TIME_MICROS) columns (#17478)

### DIFF
--- a/velox/dwio/common/tests/utils/BatchMaker.cpp
+++ b/velox/dwio/common/tests/utils/BatchMaker.cpp
@@ -142,13 +142,13 @@ VectorPtr BatchMaker::createVector<TypeKind::BIGINT>(
     std::mt19937& gen,
     std::function<bool(vector_size_t /*index*/)> isNullAt) {
   if (type->isTime()) {
+    const bool isMicros = type->equivalent(*TIME_MICRO_UTC());
+    // TIME is milliseconds since midnight; TIME_MICRO_UTC is microseconds.
+    const int64_t maxValue = isMicros ? 86'400'000'000LL : 86'400'000LL;
     return createScalar<int64_t>(
         size,
         gen,
-        [&gen]() {
-          // TIME is milliseconds since midnight.
-          return Random::rand64(0, 86400000, gen);
-        },
+        [&gen, maxValue]() { return Random::rand64(0, maxValue, gen); },
         pool,
         isNullAt,
         type);

--- a/velox/dwio/parquet/reader/ParquetColumnReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetColumnReader.cpp
@@ -43,7 +43,9 @@ std::unique_ptr<dwio::common::SelectiveColumnReader> ParquetColumnReader::build(
   auto colName = scanSpec.fieldName();
 
   if (fileType->type()->isTime()) {
-    VELOX_CHECK(fileType->type()->equivalent(*TIME()));
+    VELOX_CHECK(
+        fileType->type()->equivalent(*TIME()) ||
+        fileType->type()->equivalent(*TIME_MICRO_UTC()));
     return std::make_unique<TimeColumnReader>(
         requestedType, fileType, params, scanSpec);
   }

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -1047,10 +1047,26 @@ TypePtr ReaderBase::convertType(
             requestedType->toString());
         return TIME();
 
+      case thrift::ConvertedType::TIME_MICROS: {
+        VELOX_CHECK_EQ(
+            schemaElement.type,
+            thrift::Type::INT64,
+            "TIME_MICROS converted type can only be set for value of thrift::Type::INT64");
+        const bool isCompatibleRequestedType = !requestedType ||
+            isCompatible(requestedType, isRepeated, [](const TypePtr& type) {
+              return type->equivalent(*TIME_MICRO_UTC());
+            });
+        VELOX_CHECK(
+            isCompatibleRequestedType,
+            kTypeMappingErrorFmtStr,
+            "TIME MICRO UTC",
+            requestedType->toString());
+        return TIME_MICRO_UTC();
+      }
+
       case thrift::ConvertedType::MAP:
       case thrift::ConvertedType::MAP_KEY_VALUE:
       case thrift::ConvertedType::LIST:
-      case thrift::ConvertedType::TIME_MICROS:
       case thrift::ConvertedType::JSON:
       case thrift::ConvertedType::BSON:
       case thrift::ConvertedType::INTERVAL:

--- a/velox/dwio/parquet/reader/TimeColumnReader.h
+++ b/velox/dwio/parquet/reader/TimeColumnReader.h
@@ -23,8 +23,11 @@
 namespace facebook::velox::parquet {
 
 /// Column reader for Parquet TIME type.
-/// Handles conversion from Parquet TIME_MILLIS (INT32, milliseconds) to
-/// Velox TIME type (BIGINT, milliseconds).
+/// Handles conversion from:
+/// - Parquet TIME_MILLIS (INT32, milliseconds) to Velox TIME (BIGINT,
+///   milliseconds).
+/// - Parquet TIME_MICROS (INT64, microseconds) to Velox TIME MICRO UTC
+///   (BIGINT, microseconds).
 class TimeColumnReader : public IntegerColumnReader {
  public:
   TimeColumnReader(
@@ -39,12 +42,15 @@ class TimeColumnReader : public IntegerColumnReader {
       VELOX_CHECK(logicalType->__isset.TIME);
       const auto unit = logicalType->TIME.unit;
       VELOX_CHECK(
-          unit.__isset.MILLIS,
-          "TIME precision other than milliseconds is not supported");
+          unit.__isset.MILLIS || unit.__isset.MICROS,
+          "TIME precision other than milliseconds or microseconds is not supported");
+      isMicros_ = unit.__isset.MICROS;
     } else if (auto convertedType = typeWithId->convertedType_) {
       VELOX_CHECK(
-          convertedType == thrift::ConvertedType::type::TIME_MILLIS,
-          "TIME converted type other than TIME_MILLIS is not supported");
+          convertedType == thrift::ConvertedType::type::TIME_MILLIS ||
+              convertedType == thrift::ConvertedType::type::TIME_MICROS,
+          "TIME converted type other than TIME_MILLIS or TIME_MICROS is not supported");
+      isMicros_ = convertedType == thrift::ConvertedType::type::TIME_MICROS;
     } else {
       VELOX_NYI("Logical type and converted type are not provided for TIME.");
     }
@@ -54,13 +60,18 @@ class TimeColumnReader : public IntegerColumnReader {
       int64_t offset,
       const RowSet& rows,
       const uint64_t* /*incomingNulls*/) override {
-    // Parquet stores TIME as INT32 (TIME_MILLIS).
-    // Velox represents TIME as BIGINT (8-byte).
-    // Use the physical width: TIME_MILLIS is INT32 (4 bytes).
-    VELOX_WIDTH_DISPATCH(4, prepareRead, offset, rows, nullptr);
+    // Velox represents TIME as BIGINT (8 bytes) for both precisions.
+    // Parquet stores TIME_MILLIS as INT32 (4 bytes) and TIME_MICROS as
+    // INT64 (8 bytes). Dispatch on the physical width.
+    const int32_t physicalWidth = isMicros_ ? 8 : 4;
+    VELOX_WIDTH_DISPATCH(physicalWidth, prepareRead, offset, rows, nullptr);
     readCommon<IntegerColumnReader, true>(rows);
     readOffset_ += rows.back() + 1;
   }
+
+ private:
+  // True for TIME_MICROS (INT64), false for TIME_MILLIS (INT32).
+  bool isMicros_{false};
 };
 
 } // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -745,6 +745,54 @@ TEST_F(E2EFilterTest, time) {
   }
 }
 
+TEST_F(E2EFilterTest, timeMicros) {
+  struct {
+    parquet::arrow::Encoding::type encoding;
+    bool enableDictionary;
+    bool keepNulls;
+  } testCases[] = {
+      {parquet::arrow::Encoding::kPlain, false, true},
+      {parquet::arrow::Encoding::kPlain, true, true},
+      {parquet::arrow::Encoding::kDeltaBinaryPacked, false, false},
+      {parquet::arrow::Encoding::kDeltaBinaryPacked, false, true},
+  };
+
+  for (const auto& testCase : testCases) {
+    options_.encoding = testCase.encoding;
+    bool enableDictionary = testCase.enableDictionary;
+    bool keepNulls = testCase.keepNulls;
+    SCOPED_TRACE(
+        fmt::format(
+            "Encoding: {}, Dictionary: {}, KeepNulls: {}",
+            static_cast<int>(options_.encoding),
+            enableDictionary,
+            keepNulls));
+
+    options_.enableDictionary = enableDictionary;
+    options_.dataPageSize = 4 * 1024;
+    // Microseconds since midnight up to 86,399,999,999 (one second short of
+    // 24 h). Use a smaller cap when forcing a dictionary so values are dense.
+    const int64_t valMax = enableDictionary ? 1'000 : 86'399'999'999LL;
+
+    testWithTypes(
+        "time_val:time_micro_utc",
+        [&]() {
+          makeIntDistribution<int64_t>(
+              "time_val",
+              0, // min
+              valMax, // max
+              22, // repeats
+              19, // rareFrequency
+              0, // rareMin
+              valMax, // rareMax
+              keepNulls); // keepNulls
+        },
+        false,
+        {"time_val"},
+        20);
+  }
+}
+
 TEST_F(E2EFilterTest, combineRowGroup) {
   rowsInRowGroup_ = 5;
   rowType_ = ROW({"c0"}, {INTEGER()});

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -2065,6 +2065,44 @@ TEST_F(ParquetReaderTest, readTimeMillis) {
   assertReadWithReaderAndExpected(rowType, *rowReader, data, *leafPool_);
 }
 
+TEST_F(ParquetReaderTest, readTimeMicros) {
+  // Write TIME MICRO UTC data using the parquet writer.
+  // The writer exports Velox TIME MICRO UTC as Arrow time64 with microseconds
+  // unit, which maps to Parquet TIME_MICROS (INT64).
+  const auto rowType = ROW({"time_col"}, {TIME_MICRO_UTC()});
+
+  auto data = makeRowVector(
+      rowType->names(),
+      {makeNullableFlatVector<int64_t>(
+          {0,
+           1,
+           1'000,
+           3'600'000'000,
+           std::nullopt,
+           43'200'000'000,
+           86'399'999'999},
+          TIME_MICRO_UTC())});
+  auto sink = write(data);
+
+  const dwio::common::ReaderOptions readerOpts{
+      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  auto reader = createReaderInMemory(*sink, readerOpts);
+
+  EXPECT_EQ(reader->numberOfRows(), 7ULL);
+
+  auto type = reader->typeWithId();
+  EXPECT_EQ(type->size(), 1ULL);
+  auto col0 = type->childAt(0);
+  EXPECT_TRUE(col0->type()->isTime());
+  EXPECT_TRUE(col0->type()->equivalent(*TIME_MICRO_UTC()));
+
+  auto rowReaderOpts = getReaderOpts(rowType);
+  rowReaderOpts.setScanSpec(makeScanSpec(rowType));
+  auto rowReader = reader->createRowReader(rowReaderOpts);
+
+  assertReadWithReaderAndExpected(rowType, *rowReader, data, *leafPool_);
+}
+
 TEST_F(ParquetReaderTest, readTimeWithMultipleColumns) {
   const auto rowType =
       ROW({"id", "time_col", "name"}, {INTEGER(), TIME(), VARCHAR()});

--- a/velox/type/fbhive/HiveTypeParser.cpp
+++ b/velox/type/fbhive/HiveTypeParser.cpp
@@ -59,6 +59,7 @@ HiveTypeParser::HiveTypeParser() {
   setupMetadata<TokenType::Long, TypeKind::BIGINT>("bigint");
   setupMetadata<TokenType::Date, TypeKind::INTEGER>("date");
   setupMetadata<TokenType::Time, TypeKind::BIGINT>("time");
+  setupMetadata<TokenType::TimeMicroUtc, TypeKind::BIGINT>("time_micro_utc");
   setupMetadata<TokenType::Float, TypeKind::REAL>({"float", "real"});
   setupMetadata<TokenType::Double, TypeKind::DOUBLE>("double");
   setupMetadata<TokenType::Decimal, TypeKind::BIGINT>("decimal");
@@ -124,6 +125,8 @@ Result HiveTypeParser::parseType() {
       return Result{DATE()};
     } else if (nt.metadata->tokenString[0] == "time") {
       return Result{TIME()};
+    } else if (nt.metadata->tokenString[0] == "time_micro_utc") {
+      return Result{TIME_MICRO_UTC()};
     }
     auto scalarType = createScalarType(nt.typeKind());
     VELOX_CHECK_NOT_NULL(

--- a/velox/type/fbhive/HiveTypeParser.h
+++ b/velox/type/fbhive/HiveTypeParser.h
@@ -52,6 +52,10 @@ enum class TokenType {
   Identifier,
   EndOfStream,
   Decimal,
+  // TimeMicroUtc must precede Time so the longer keyword is matched first
+  // by the prefix-iteration tokenizer (the same trick used for Timestamp
+  // vs Time).
+  TimeMicroUtc,
   Time,
   LeftRoundBracket,
   RightRoundBracket,

--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -294,10 +294,15 @@ const char* exportArrowFormatStr(
       return "i"; // int32
     case TypeKind::BIGINT:
       if (type->isTime()) {
-        VELOX_DCHECK(type->equivalent(*TIME()));
-        // TIME is stored as milliseconds since midnight in Velox.
-        // Export as Arrow time32 with milliseconds unit.
-        return "ttm";
+        if (type->equivalent(*TIME())) {
+          // TIME is stored as milliseconds since midnight in Velox.
+          // Export as Arrow time32 with milliseconds unit.
+          return "ttm";
+        }
+        VELOX_DCHECK(type->equivalent(*TIME_MICRO_UTC()));
+        // TIME MICRO UTC is stored as microseconds since midnight in Velox.
+        // Export as Arrow time64 with microseconds unit.
+        return "ttu";
       }
       return "l"; // int64
     case TypeKind::REAL:
@@ -735,17 +740,17 @@ void exportValidityBitmap(
 bool isFlatScalarZeroCopy(const TypePtr& type, const ArrowOptions& options) {
   // - Velox's Timestamp representation (2x 64bit values) does not have an
   // equivalent in Arrow.
-  // - Velox's TIME is in milliseconds, Arrow time64 is in microseconds.
-  bool isTime = type->isTime();
-  if (isTime) {
-    VELOX_DCHECK(type->equivalent(*TIME()));
-  }
+  // - Velox's TIME (millisecond precision) is exported as Arrow time32, which
+  // is narrower than the underlying BIGINT and therefore requires conversion.
+  // TIME_MICRO_UTC matches Arrow time64 in width and is zero-copy.
+  const bool needsTimeConversion = type->isTime() && type->equivalent(*TIME());
   if (options.useDecimalTypeWidth) {
     // Short decimal is zero-copy.
-    return !type->isTimestamp() && !isTime;
+    return !type->isTimestamp() && !needsTimeConversion;
   }
   // Short decimal requires conversion.
-  return !type->isShortDecimal() && !type->isTimestamp() && !isTime;
+  return !type->isShortDecimal() && !type->isTimestamp() &&
+      !needsTimeConversion;
 }
 
 // Returns the size of a single element of a given `type` in the target arrow
@@ -756,9 +761,13 @@ size_t getArrowElementSize(const TypePtr& type, const ArrowOptions& options) {
   } else if (type->isTimestamp()) {
     return sizeof(int64_t);
   } else if (type->isTime()) {
-    VELOX_DCHECK(type->equivalent(*TIME()));
-    // TIME is exported as Arrow time32 (int32_t).
-    return sizeof(int32_t);
+    if (type->equivalent(*TIME())) {
+      // TIME is exported as Arrow time32 (int32_t).
+      return sizeof(int32_t);
+    }
+    VELOX_DCHECK(type->equivalent(*TIME_MICRO_UTC()));
+    // TIME MICRO UTC is exported as Arrow time64 (int64_t).
+    return sizeof(int64_t);
   }
   return type->cppSizeInBytes();
 }
@@ -790,8 +799,9 @@ void exportValues(
             checkedMultiply<size_t>(out.length, size), pool);
   if (type->kind() == TypeKind::TIMESTAMP) {
     gatherFromTimestampBuffer(vec, rows, options.timestampUnit, *values);
-  } else if (type->kind() == TypeKind::BIGINT && type->isTime()) {
-    VELOX_DCHECK(type->equivalent(*TIME()));
+  } else if (
+      type->kind() == TypeKind::BIGINT && type->isTime() &&
+      type->equivalent(*TIME())) {
     gatherFromTimeBuffer(vec, rows, *values);
   } else {
     gatherFromBuffer(*type, *vec.values(), rows, options, *values);


### PR DESCRIPTION
Summary:
OSS issue: https://github.com/facebookincubator/velox/issues/17477

The Iceberg TIME type is represented in Parquet with microsecond precision
(TIME_MICROS, INT64). The Velox Parquet reader previously rejected this type
with:

  Unsupported Parquet SchemaElement converted type: TIME_MICROS

This diff wires TIME_MICROS through to the existing Velox `TIME_MICRO_UTC()`
type (BIGINT, microseconds since midnight, UTC). Concretely:

- `ParquetReader::convertType` now maps the `TIME_MICROS` converted type to
  `TIME_MICRO_UTC()` after checking that the physical storage is INT64 and
  the requested type is compatible.
- `TimeColumnReader` accepts both `TIME_MILLIS` (INT32, 4 bytes) and
  `TIME_MICROS` (INT64, 8 bytes), dispatching `prepareRead` with the right
  physical width.
- `ParquetColumnReader::build` allows either `TIME()` or `TIME_MICRO_UTC()`
  as the file column type when constructing a `TimeColumnReader`.
- `vector/arrow/Bridge.cpp` extends the Velox->Arrow export path to handle
  `TIME_MICRO_UTC` (Arrow time64 microseconds, format string "ttu"). This is
  needed so the existing Velox parquet writer (which goes through the Arrow
  bridge) can produce TIME_MICROS files for round-trip tests.

Differential Revision: D104719277


