### PR TITLE
perf: Reuse vector in DistinctAggregations (#17480)

### DIFF
--- a/velox/exec/DistinctAggregations.cpp
+++ b/velox/exec/DistinctAggregations.cpp
@@ -247,12 +247,18 @@ class TypedDistinctAggregations : public DistinctAggregations {
       const auto& aggregate = *aggregates_[i];
 
       // For each group, add distinct inputs to aggregate.
+      VectorPtr data;
       for (auto* group : groups) {
         auto* accumulator = reinterpret_cast<AccumulatorType*>(group + offset_);
 
         // TODO Process group rows in batches to avoid creating very large input
         // vectors.
-        auto data = BaseVector::create(inputType_, accumulator->size(), pool_);
+        if (!data) {
+          data = BaseVector::create(inputType_, accumulator->size(), pool_);
+        } else {
+          BaseVector::prepareForReuse(data, accumulator->size());
+        }
+
         if constexpr (std::is_same_v<T, ComplexType>) {
           accumulator->extractValues(*data, 0);
         } else {


### PR DESCRIPTION
Summary:

TypedDistinctAggregations::extractValues() loops over every group to extract distinct rows from the accumulator and add them to the aggregation function. It currently create a new vector to hold the distinct rows every time. This can cause a large number of memory allocation when the grouping keys have high cardinality. This diff make it reuse the vector across groups.

Reviewed By: Yuhta

Differential Revision: D104498389


