### PR TITLE
fix(cudf): Return null for decimal division by zero

### DIFF
--- a/velox/experimental/cudf/expression/AstExpressionUtils.h
+++ b/velox/experimental/cudf/expression/AstExpressionUtils.h
@@ -671,38 +671,17 @@ cudf::ast::expression const& AstContext::pushExprToTree(
     return *result;
   } else if (name == "cast" || name == "try_cast") {
     VELOX_CHECK_EQ(len, 1);
-    // Only INTEGER, BIGINT, DOUBLE casts are supported in pure AST
-    // Other casts (including DECIMAL) need to go through precompute path
-    if (expr->type()->kind() == TypeKind::INTEGER ||
-        expr->type()->kind() == TypeKind::BIGINT ||
-        expr->type()->kind() == TypeKind::DOUBLE) {
-      auto const& op1 = pushExprToTree(expr->inputs()[0]);
-      if (expr->type()->kind() == TypeKind::INTEGER) {
-        // No int32 cast in cudf ast
-        return tree.push(Operation{Op::CAST_TO_INT64, op1});
-      } else if (expr->type()->kind() == TypeKind::BIGINT) {
-        return tree.push(Operation{Op::CAST_TO_INT64, op1});
-      } else if (expr->type()->kind() == TypeKind::DOUBLE) {
-        return tree.push(Operation{Op::CAST_TO_FLOAT64, op1});
-      }
+    auto const& op1 = pushExprToTree(expr->inputs()[0]);
+    if (expr->type()->kind() == TypeKind::INTEGER) {
+      // No int32 cast in cudf ast
+      return tree.push(Operation{Op::CAST_TO_INT64, op1});
+    } else if (expr->type()->kind() == TypeKind::BIGINT) {
+      return tree.push(Operation{Op::CAST_TO_INT64, op1});
+    } else if (expr->type()->kind() == TypeKind::DOUBLE) {
+      return tree.push(Operation{Op::CAST_TO_FLOAT64, op1});
+    } else {
+      VELOX_FAIL("Unsupported type for cast operation");
     }
-    // For unsupported cast types (including DECIMAL), fall through to
-    // precompute path below
-    if (!allowPureAstOnly && canBeEvaluatedByCudf(expr, /*deep=*/false)) {
-      int sideIdx = findExpressionSide(expr);
-      if (sideIdx == -2) {
-        VELOX_FAIL(
-            "Expression spans both join sides and cannot be precomputed: " +
-            name);
-      }
-      if (sideIdx < 0) {
-        sideIdx = 0;
-      }
-      auto node =
-          createCudfExpression(expr, inputRowSchema[sideIdx]);
-      return addPrecomputeInstructionOnSide(sideIdx, 0, name, "", node);
-    }
-    VELOX_FAIL("Unsupported type for cast operation");
   } else if (auto fieldExpr = std::dynamic_pointer_cast<FieldReference>(expr)) {
     // Refer to the appropriate side
     const auto fieldName =

--- a/velox/experimental/cudf/expression/AstExpressionUtils.h
+++ b/velox/experimental/cudf/expression/AstExpressionUtils.h
@@ -671,17 +671,38 @@ cudf::ast::expression const& AstContext::pushExprToTree(
     return *result;
   } else if (name == "cast" || name == "try_cast") {
     VELOX_CHECK_EQ(len, 1);
-    auto const& op1 = pushExprToTree(expr->inputs()[0]);
-    if (expr->type()->kind() == TypeKind::INTEGER) {
-      // No int32 cast in cudf ast
-      return tree.push(Operation{Op::CAST_TO_INT64, op1});
-    } else if (expr->type()->kind() == TypeKind::BIGINT) {
-      return tree.push(Operation{Op::CAST_TO_INT64, op1});
-    } else if (expr->type()->kind() == TypeKind::DOUBLE) {
-      return tree.push(Operation{Op::CAST_TO_FLOAT64, op1});
-    } else {
-      VELOX_FAIL("Unsupported type for cast operation");
+    // Only INTEGER, BIGINT, DOUBLE casts are supported in pure AST
+    // Other casts (including DECIMAL) need to go through precompute path
+    if (expr->type()->kind() == TypeKind::INTEGER ||
+        expr->type()->kind() == TypeKind::BIGINT ||
+        expr->type()->kind() == TypeKind::DOUBLE) {
+      auto const& op1 = pushExprToTree(expr->inputs()[0]);
+      if (expr->type()->kind() == TypeKind::INTEGER) {
+        // No int32 cast in cudf ast
+        return tree.push(Operation{Op::CAST_TO_INT64, op1});
+      } else if (expr->type()->kind() == TypeKind::BIGINT) {
+        return tree.push(Operation{Op::CAST_TO_INT64, op1});
+      } else if (expr->type()->kind() == TypeKind::DOUBLE) {
+        return tree.push(Operation{Op::CAST_TO_FLOAT64, op1});
+      }
     }
+    // For unsupported cast types (including DECIMAL), fall through to
+    // precompute path below
+    if (!allowPureAstOnly && canBeEvaluatedByCudf(expr, /*deep=*/false)) {
+      int sideIdx = findExpressionSide(expr);
+      if (sideIdx == -2) {
+        VELOX_FAIL(
+            "Expression spans both join sides and cannot be precomputed: " +
+            name);
+      }
+      if (sideIdx < 0) {
+        sideIdx = 0;
+      }
+      auto node =
+          createCudfExpression(expr, inputRowSchema[sideIdx]);
+      return addPrecomputeInstructionOnSide(sideIdx, 0, name, "", node);
+    }
+    VELOX_FAIL("Unsupported type for cast operation");
   } else if (auto fieldExpr = std::dynamic_pointer_cast<FieldReference>(expr)) {
     // Refer to the appropriate side
     const auto fieldName =

--- a/velox/experimental/cudf/expression/CMakeLists.txt
+++ b/velox/experimental/cudf/expression/CMakeLists.txt
@@ -15,6 +15,7 @@
 add_library(
   velox_cudf_expression
   AstExpression.cpp
+  DecimalExpressionKernels.cpp
   DecimalExpressionKernels.cu
   ExpressionEvaluator.cpp
   JitExpression.cpp

--- a/velox/experimental/cudf/expression/DecimalExpressionKernels.cpp
+++ b/velox/experimental/cudf/expression/DecimalExpressionKernels.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/experimental/cudf/expression/DecimalExpressionKernels.h"
+
+#include <cudf/binaryop.hpp>
+#include <cudf/copying.hpp>
+#include <cudf/scalar/scalar_factories.hpp>
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/experimental/cudf/expression/AstPrinter.h"
+
+namespace facebook::velox::cudf_velox {
+
+// Scatters null values to positions where the divisor is zero.
+// Returns a new column with nulls at zero-divisor positions.
+std::unique_ptr<cudf::column> scatterNullsAtZeroDivisor(
+    std::unique_ptr<cudf::column> result,
+    const cudf::column_view& divisor,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  // Create zero scalar for comparison and null scalar for scattering.
+  std::unique_ptr<cudf::scalar> zeroScalar;
+  std::unique_ptr<cudf::scalar> nullScalar;
+  auto divisorScale = numeric::scale_type{divisor.type().scale()};
+  auto outputScale = numeric::scale_type{result->type().scale()};
+  
+  if (divisor.type().id() == cudf::type_id::DECIMAL64) {
+    zeroScalar = cudf::make_fixed_point_scalar<numeric::decimal64>(
+        0, divisorScale, stream, mr);
+    nullScalar = cudf::make_fixed_point_scalar<numeric::decimal64>(
+        0, outputScale, stream, mr);
+  } else if (divisor.type().id() == cudf::type_id::DECIMAL128) {
+    zeroScalar = cudf::make_fixed_point_scalar<numeric::decimal128>(
+        0, divisorScale, stream, mr);
+    nullScalar = cudf::make_fixed_point_scalar<numeric::decimal128>(
+        0, outputScale, stream, mr);
+  } else {
+    VELOX_FAIL(
+        "Unsupported decimal type {} for division",
+        cudf::ast::type_id_to_string(divisor.type().id()));
+  }
+  nullScalar->set_valid_async(false, stream);
+
+  // Create boolean column: TRUE where divisor == 0, FALSE otherwise.
+  auto divisorIsZero = cudf::binary_operation(
+      divisor,
+      *zeroScalar,
+      cudf::binary_operator::EQUAL,
+      cudf::data_type{cudf::type_id::BOOL8},
+      stream,
+      mr);
+
+  // Scatter nulls where divisor is zero.
+  return cudf::copy_if_else(
+      *nullScalar, *result, divisorIsZero->view(), stream, mr);
+}
+
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/expression/DecimalExpressionKernels.cu
+++ b/velox/experimental/cudf/expression/DecimalExpressionKernels.cu
@@ -35,62 +35,6 @@
 namespace facebook::velox::cudf_velox {
 namespace {
 
-// Creates a boolean column indicating where the divisor is zero.
-// Returns a column of BOOL8 where true means divisor == 0.
-std::unique_ptr<cudf::column> createDivisorZeroMask(
-    const cudf::column_view& divisor,
-    rmm::cuda_stream_view stream,
-    rmm::device_async_resource_ref mr) {
-  // Create a scalar with value 0 matching the divisor's type and scale.
-  std::unique_ptr<cudf::scalar> zero;
-  auto scale = numeric::scale_type{divisor.type().scale()};
-  if (divisor.type().id() == cudf::type_id::DECIMAL64) {
-    zero =
-        cudf::make_fixed_point_scalar<numeric::decimal64>(0, scale, stream, mr);
-  } else if (divisor.type().id() == cudf::type_id::DECIMAL128) {
-    zero = cudf::make_fixed_point_scalar<numeric::decimal128>(
-        0, scale, stream, mr);
-  } else {
-    CUDF_FAIL("Unsupported decimal type for division");
-  }
-
-  // Create boolean column: TRUE where divisor == 0, FALSE otherwise.
-  return cudf::binary_operation(
-      divisor,
-      *zero,
-      cudf::binary_operator::EQUAL,
-      cudf::data_type{cudf::type_id::BOOL8},
-      stream,
-      mr);
-}
-
-// Scatters null values to positions where the divisor is zero.
-// Returns a new column with nulls at zero-divisor positions.
-std::unique_ptr<cudf::column> scatterNullsAtZeroDivisor(
-    std::unique_ptr<cudf::column> result,
-    const cudf::column_view& divisor,
-    rmm::cuda_stream_view stream,
-    rmm::device_async_resource_ref mr) {
-  // Create boolean mask: true where divisor == 0, false otherwise.
-  auto divisorIsZero = createDivisorZeroMask(divisor, stream, mr);
-
-  // Create a null scalar matching the result type.
-  std::unique_ptr<cudf::scalar> nullScalar;
-  auto outputType = result->type();
-  if (outputType.id() == cudf::type_id::DECIMAL64) {
-    nullScalar = cudf::make_fixed_point_scalar<numeric::decimal64>(
-        0, numeric::scale_type{outputType.scale()}, stream, mr);
-  } else {
-    nullScalar = cudf::make_fixed_point_scalar<numeric::decimal128>(
-        0, numeric::scale_type{outputType.scale()}, stream, mr);
-  }
-  nullScalar->set_valid_async(false, stream);
-
-  // Scatter nulls where divisor is zero.
-  return cudf::copy_if_else(
-      *nullScalar, *result, divisorIsZero->view(), stream, mr);
-}
-
 template <typename OutT>
 __device__ OutT
 decimalDivideImpl(__int128_t numerator, __int128_t denom, __int128_t scale) {

--- a/velox/experimental/cudf/expression/DecimalExpressionKernels.cu
+++ b/velox/experimental/cudf/expression/DecimalExpressionKernels.cu
@@ -15,10 +15,14 @@
  */
 #include "velox/experimental/cudf/expression/DecimalExpressionKernels.h"
 
+#include <cudf/binaryop.hpp>
 #include <cudf/column/column_factories.hpp>
+#include <cudf/fixed_point/fixed_point.hpp>
 #include <cudf/null_mask.hpp>
 #include <cudf/scalar/scalar.hpp>
+#include <cudf/scalar/scalar_factories.hpp>
 #include <cudf/table/table_view.hpp>
+#include <cudf/transform.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/memory_resource.hpp>
@@ -30,6 +34,34 @@
 
 namespace facebook::velox::cudf_velox {
 namespace {
+
+// Creates a null mask that marks zeros in the divisor column as null.
+// Returns the combined mask (existing nulls AND non-zero divisor) and null count.
+std::pair<std::unique_ptr<rmm::device_buffer>, cudf::size_type> createDivisorNullMask(
+    const cudf::column_view& divisor,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  // Create a scalar with value 0 matching the divisor's type and scale.
+  std::unique_ptr<cudf::scalar> zero;
+  auto scale = numeric::scale_type{divisor.type().scale()};
+  if (divisor.type().id() == cudf::type_id::DECIMAL64) {
+    zero = cudf::make_fixed_point_scalar<numeric::decimal64>(0, scale, stream, mr);
+  } else {
+    zero = cudf::make_fixed_point_scalar<numeric::decimal128>(0, scale, stream, mr);
+  }
+
+  // Create boolean column: TRUE where divisor != 0 (valid), FALSE where divisor == 0 (null).
+  auto nonZero = cudf::binary_operation(
+      divisor,
+      *zero,
+      cudf::binary_operator::NOT_EQUAL,
+      cudf::data_type{cudf::type_id::BOOL8},
+      stream,
+      mr);
+
+  // Convert boolean column to bitmask: TRUE -> valid bit, FALSE -> null bit.
+  return cudf::bools_to_mask(nonZero->view(), stream, mr);
+}
 
 template <typename OutT>
 __device__ OutT
@@ -196,10 +228,35 @@ std::unique_ptr<cudf::column> decimalDivide(
   CUDF_EXPECTS(
       aRescale >= 0, "Decimal divide requires non-negative rescale factor");
 
-  auto [nullMask, nullCount] =
+  // Combine input null masks with a mask that marks zero divisors as null.
+  auto [inputNullMask, inputNullCount] =
       cudf::bitmask_and(cudf::table_view({lhs, rhs}), stream, mr);
+  auto [zeroMaskPtr, zeroNullCount] = createDivisorNullMask(rhs, stream, mr);
+
+  // AND the masks together: null if either input is null OR divisor is zero.
+  rmm::device_buffer finalMask;
+  cudf::size_type finalNullCount;
+  if (inputNullMask.size() > 0 && zeroMaskPtr && zeroMaskPtr->size() > 0) {
+    auto [combined, count] = cudf::bitmask_and(
+        std::vector<cudf::bitmask_type const*>{
+            static_cast<cudf::bitmask_type const*>(inputNullMask.data()),
+            static_cast<cudf::bitmask_type const*>(zeroMaskPtr->data())},
+        std::vector<cudf::size_type>{0, 0},
+        lhs.size(),
+        stream,
+        mr);
+    finalMask = std::move(combined);
+    finalNullCount = count;
+  } else if (zeroMaskPtr && zeroMaskPtr->size() > 0) {
+    finalMask = std::move(*zeroMaskPtr);
+    finalNullCount = zeroNullCount;
+  } else {
+    finalMask = std::move(inputNullMask);
+    finalNullCount = inputNullCount;
+  }
+
   auto out = cudf::make_fixed_width_column(
-      outputType, lhs.size(), std::move(nullMask), nullCount, stream, mr);
+      outputType, lhs.size(), std::move(finalMask), finalNullCount, stream, mr);
 
   if (lhs.type().id() == cudf::type_id::DECIMAL64) {
     if (outputType.id() == cudf::type_id::DECIMAL64) {
@@ -286,10 +343,35 @@ std::unique_ptr<cudf::column> decimalDivide(
     return makeAllNullDecimalColumn(outputType, rhs.size(), stream, mr);
   }
 
-  auto nullMask = cudf::copy_bitmask(rhs, stream, mr);
-  auto nullCount = rhs.null_count();
+  // Combine rhs null mask with a mask that marks zero divisors as null.
+  auto inputNullMask = cudf::copy_bitmask(rhs, stream, mr);
+  auto inputNullCount = rhs.null_count();
+  auto [zeroMaskPtr, zeroNullCount] = createDivisorNullMask(rhs, stream, mr);
+
+  // AND the masks together: null if rhs is null OR divisor is zero.
+  rmm::device_buffer finalMask;
+  cudf::size_type finalNullCount;
+  if (inputNullMask.size() > 0 && zeroMaskPtr && zeroMaskPtr->size() > 0) {
+    auto [combined, count] = cudf::bitmask_and(
+        std::vector<cudf::bitmask_type const*>{
+            static_cast<cudf::bitmask_type const*>(inputNullMask.data()),
+            static_cast<cudf::bitmask_type const*>(zeroMaskPtr->data())},
+        std::vector<cudf::size_type>{0, 0},
+        rhs.size(),
+        stream,
+        mr);
+    finalMask = std::move(combined);
+    finalNullCount = count;
+  } else if (zeroMaskPtr && zeroMaskPtr->size() > 0) {
+    finalMask = std::move(*zeroMaskPtr);
+    finalNullCount = zeroNullCount;
+  } else {
+    finalMask = std::move(inputNullMask);
+    finalNullCount = inputNullCount;
+  }
+
   auto out = cudf::make_fixed_width_column(
-      outputType, rhs.size(), std::move(nullMask), nullCount, stream, mr);
+      outputType, rhs.size(), std::move(finalMask), finalNullCount, stream, mr);
 
   auto lhsValue = getDecimalScalarValue(lhs, stream);
 

--- a/velox/experimental/cudf/expression/DecimalExpressionKernels.cu
+++ b/velox/experimental/cudf/expression/DecimalExpressionKernels.cu
@@ -36,8 +36,10 @@ namespace facebook::velox::cudf_velox {
 namespace {
 
 // Creates a null mask that marks zeros in the divisor column as null.
-// Returns the combined mask (existing nulls AND non-zero divisor) and null count.
-std::pair<std::unique_ptr<rmm::device_buffer>, cudf::size_type> createDivisorNullMask(
+// Returns the combined mask (existing nulls AND non-zero divisor) and null
+// count.
+std::pair<std::unique_ptr<rmm::device_buffer>, cudf::size_type>
+createDivisorNullMask(
     const cudf::column_view& divisor,
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr) {
@@ -45,12 +47,15 @@ std::pair<std::unique_ptr<rmm::device_buffer>, cudf::size_type> createDivisorNul
   std::unique_ptr<cudf::scalar> zero;
   auto scale = numeric::scale_type{divisor.type().scale()};
   if (divisor.type().id() == cudf::type_id::DECIMAL64) {
-    zero = cudf::make_fixed_point_scalar<numeric::decimal64>(0, scale, stream, mr);
+    zero =
+        cudf::make_fixed_point_scalar<numeric::decimal64>(0, scale, stream, mr);
   } else {
-    zero = cudf::make_fixed_point_scalar<numeric::decimal128>(0, scale, stream, mr);
+    zero = cudf::make_fixed_point_scalar<numeric::decimal128>(
+        0, scale, stream, mr);
   }
 
-  // Create boolean column: TRUE where divisor != 0 (valid), FALSE where divisor == 0 (null).
+  // Create boolean column: TRUE where divisor != 0 (valid), FALSE where divisor
+  // == 0 (null).
   auto nonZero = cudf::binary_operation(
       divisor,
       *zero,

--- a/velox/experimental/cudf/expression/DecimalExpressionKernels.cu
+++ b/velox/experimental/cudf/expression/DecimalExpressionKernels.cu
@@ -17,12 +17,12 @@
 
 #include <cudf/binaryop.hpp>
 #include <cudf/column/column_factories.hpp>
+#include <cudf/copying.hpp>
 #include <cudf/fixed_point/fixed_point.hpp>
 #include <cudf/null_mask.hpp>
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/scalar/scalar_factories.hpp>
 #include <cudf/table/table_view.hpp>
-#include <cudf/transform.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/memory_resource.hpp>
@@ -35,11 +35,9 @@
 namespace facebook::velox::cudf_velox {
 namespace {
 
-// Creates a null mask that marks zeros in the divisor column as null.
-// Returns the combined mask (existing nulls AND non-zero divisor) and null
-// count.
-std::pair<std::unique_ptr<rmm::device_buffer>, cudf::size_type>
-createDivisorNullMask(
+// Creates a boolean column indicating where the divisor is zero.
+// Returns a column of BOOL8 where true means divisor == 0.
+std::unique_ptr<cudf::column> createDivisorZeroMask(
     const cudf::column_view& divisor,
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr) {
@@ -49,23 +47,48 @@ createDivisorNullMask(
   if (divisor.type().id() == cudf::type_id::DECIMAL64) {
     zero =
         cudf::make_fixed_point_scalar<numeric::decimal64>(0, scale, stream, mr);
-  } else {
+  } else if (divisor.type().id() == cudf::type_id::DECIMAL128) {
     zero = cudf::make_fixed_point_scalar<numeric::decimal128>(
         0, scale, stream, mr);
+  } else {
+    CUDF_FAIL("Unsupported decimal type for division");
   }
 
-  // Create boolean column: TRUE where divisor != 0 (valid), FALSE where divisor
-  // == 0 (null).
-  auto nonZero = cudf::binary_operation(
+  // Create boolean column: TRUE where divisor == 0, FALSE otherwise.
+  return cudf::binary_operation(
       divisor,
       *zero,
-      cudf::binary_operator::NOT_EQUAL,
+      cudf::binary_operator::EQUAL,
       cudf::data_type{cudf::type_id::BOOL8},
       stream,
       mr);
+}
 
-  // Convert boolean column to bitmask: TRUE -> valid bit, FALSE -> null bit.
-  return cudf::bools_to_mask(nonZero->view(), stream, mr);
+// Scatters null values to positions where the divisor is zero.
+// Returns a new column with nulls at zero-divisor positions.
+std::unique_ptr<cudf::column> scatterNullsAtZeroDivisor(
+    std::unique_ptr<cudf::column> result,
+    const cudf::column_view& divisor,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  // Create boolean mask: true where divisor == 0, false otherwise.
+  auto divisorIsZero = createDivisorZeroMask(divisor, stream, mr);
+
+  // Create a null scalar matching the result type.
+  std::unique_ptr<cudf::scalar> nullScalar;
+  auto outputType = result->type();
+  if (outputType.id() == cudf::type_id::DECIMAL64) {
+    nullScalar = cudf::make_fixed_point_scalar<numeric::decimal64>(
+        0, numeric::scale_type{outputType.scale()}, stream, mr);
+  } else {
+    nullScalar = cudf::make_fixed_point_scalar<numeric::decimal128>(
+        0, numeric::scale_type{outputType.scale()}, stream, mr);
+  }
+  nullScalar->set_valid_async(false, stream);
+
+  // Scatter nulls where divisor is zero.
+  return cudf::copy_if_else(
+      *nullScalar, *result, divisorIsZero->view(), stream, mr);
 }
 
 template <typename OutT>
@@ -233,35 +256,13 @@ std::unique_ptr<cudf::column> decimalDivide(
   CUDF_EXPECTS(
       aRescale >= 0, "Decimal divide requires non-negative rescale factor");
 
-  // Combine input null masks with a mask that marks zero divisors as null.
-  auto [inputNullMask, inputNullCount] =
+  // Combine input null masks (lhs and rhs nulls).
+  auto [nullMask, nullCount] =
       cudf::bitmask_and(cudf::table_view({lhs, rhs}), stream, mr);
-  auto [zeroMaskPtr, zeroNullCount] = createDivisorNullMask(rhs, stream, mr);
 
-  // AND the masks together: null if either input is null OR divisor is zero.
-  rmm::device_buffer finalMask;
-  cudf::size_type finalNullCount;
-  if (inputNullMask.size() > 0 && zeroMaskPtr && zeroMaskPtr->size() > 0) {
-    auto [combined, count] = cudf::bitmask_and(
-        std::vector<cudf::bitmask_type const*>{
-            static_cast<cudf::bitmask_type const*>(inputNullMask.data()),
-            static_cast<cudf::bitmask_type const*>(zeroMaskPtr->data())},
-        std::vector<cudf::size_type>{0, 0},
-        lhs.size(),
-        stream,
-        mr);
-    finalMask = std::move(combined);
-    finalNullCount = count;
-  } else if (zeroMaskPtr && zeroMaskPtr->size() > 0) {
-    finalMask = std::move(*zeroMaskPtr);
-    finalNullCount = zeroNullCount;
-  } else {
-    finalMask = std::move(inputNullMask);
-    finalNullCount = inputNullCount;
-  }
-
+  // Create output column with input null mask and perform division.
   auto out = cudf::make_fixed_width_column(
-      outputType, lhs.size(), std::move(finalMask), finalNullCount, stream, mr);
+      outputType, lhs.size(), std::move(nullMask), nullCount, stream, mr);
 
   if (lhs.type().id() == cudf::type_id::DECIMAL64) {
     if (outputType.id() == cudf::type_id::DECIMAL64) {
@@ -285,7 +286,8 @@ std::unique_ptr<cudf::column> decimalDivide(
         lhs, rhs, out->mutable_view(), aRescale, stream);
   }
 
-  return out;
+  // Scatter nulls where divisor is zero.
+  return scatterNullsAtZeroDivisor(std::move(out), rhs, stream, mr);
 }
 
 std::unique_ptr<cudf::column> decimalDivide(
@@ -348,35 +350,13 @@ std::unique_ptr<cudf::column> decimalDivide(
     return makeAllNullDecimalColumn(outputType, rhs.size(), stream, mr);
   }
 
-  // Combine rhs null mask with a mask that marks zero divisors as null.
-  auto inputNullMask = cudf::copy_bitmask(rhs, stream, mr);
-  auto inputNullCount = rhs.null_count();
-  auto [zeroMaskPtr, zeroNullCount] = createDivisorNullMask(rhs, stream, mr);
+  // Copy rhs null mask.
+  auto nullMask = cudf::copy_bitmask(rhs, stream, mr);
+  auto nullCount = rhs.null_count();
 
-  // AND the masks together: null if rhs is null OR divisor is zero.
-  rmm::device_buffer finalMask;
-  cudf::size_type finalNullCount;
-  if (inputNullMask.size() > 0 && zeroMaskPtr && zeroMaskPtr->size() > 0) {
-    auto [combined, count] = cudf::bitmask_and(
-        std::vector<cudf::bitmask_type const*>{
-            static_cast<cudf::bitmask_type const*>(inputNullMask.data()),
-            static_cast<cudf::bitmask_type const*>(zeroMaskPtr->data())},
-        std::vector<cudf::size_type>{0, 0},
-        rhs.size(),
-        stream,
-        mr);
-    finalMask = std::move(combined);
-    finalNullCount = count;
-  } else if (zeroMaskPtr && zeroMaskPtr->size() > 0) {
-    finalMask = std::move(*zeroMaskPtr);
-    finalNullCount = zeroNullCount;
-  } else {
-    finalMask = std::move(inputNullMask);
-    finalNullCount = inputNullCount;
-  }
-
+  // Create output column and perform division.
   auto out = cudf::make_fixed_width_column(
-      outputType, rhs.size(), std::move(finalMask), finalNullCount, stream, mr);
+      outputType, rhs.size(), std::move(nullMask), nullCount, stream, mr);
 
   auto lhsValue = getDecimalScalarValue(lhs, stream);
 
@@ -402,7 +382,8 @@ std::unique_ptr<cudf::column> decimalDivide(
         lhsValue, rhs, out->mutable_view(), aRescale, stream);
   }
 
-  return out;
+  // Scatter nulls where divisor is zero.
+  return scatterNullsAtZeroDivisor(std::move(out), rhs, stream, mr);
 }
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/expression/DecimalExpressionKernels.h
+++ b/velox/experimental/cudf/expression/DecimalExpressionKernels.h
@@ -50,4 +50,12 @@ std::unique_ptr<cudf::column> decimalDivide(
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr);
 
+// Helper function to scatter nulls at zero-divisor positions.
+// Moved to .cpp file to allow use of VELOX_FAIL (incompatible with nvcc).
+std::unique_ptr<cudf::column> scatterNullsAtZeroDivisor(
+    std::unique_ptr<cudf::column> result,
+    const cudf::column_view& divisor,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr);
+
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
@@ -479,9 +479,6 @@ class BinaryFunction : public CudfFunction {
             rhsView = rhsCast->view();
           }
         }
-        if (hasDecimalZero(rhsView, stream, mr)) {
-          VELOX_USER_FAIL("Division by zero");
-        }
         auto lhsScale = -lhsView.type().scale();
         auto rhsScale = -rhsView.type().scale();
         auto outScale = -type_.scale();
@@ -639,9 +636,6 @@ class BinaryFunction : public CudfFunction {
     }
     if (op_ == cudf::binary_operator::DIV && cudf::is_fixed_point(type_)) {
       auto rhsView = asView(inputColumns[0]);
-      if (hasDecimalZero(rhsView, stream, mr)) {
-        VELOX_USER_FAIL("Division by zero");
-      }
       auto lhsScale = -left_->type().scale();
       auto rhsScale = -rhsView.type().scale();
       auto outScale = -type_.scale();

--- a/velox/experimental/cudf/tests/DecimalExpressionTest.cpp
+++ b/velox/experimental/cudf/tests/DecimalExpressionTest.cpp
@@ -1057,8 +1057,8 @@ TEST_F(CudfDecimalTest, decimalDivideByZero) {
   auto input = makeRowVector(
       {"a", "b"},
       {
-          makeFlatVector<int64_t>({100}, DECIMAL(10, 2)),
-          makeFlatVector<int64_t>({0}, DECIMAL(10, 2)),
+          makeFlatVector<int64_t>({100, 200, 300}, DECIMAL(10, 2)),
+          makeFlatVector<int64_t>({0, 50, 0}, DECIMAL(10, 2)),
       });
 
   std::vector<RowVectorPtr> vectors = {input};
@@ -1068,9 +1068,21 @@ TEST_F(CudfDecimalTest, decimalDivideByZero) {
                   .project({"a / b AS div"})
                   .planNode();
 
-  VELOX_ASSERT_USER_THROW(
-      facebook::velox::exec::test::AssertQueryBuilder(plan).copyResults(pool()),
-      "Division by zero");
+  auto result =
+      facebook::velox::exec::test::AssertQueryBuilder(plan).copyResults(pool());
+
+  // Expect null for rows where b = 0, and the division result otherwise.
+  // Input values are stored as fixed-point: 100 = 1.00, 200 = 2.00, etc.
+  // Row 0: 1.00 / 0 = null
+  // Row 1: 2.00 / 0.50 = 4.00 (stored as 400 in DECIMAL(12,2))
+  // Row 2: 3.00 / 0 = null
+  auto expectedType = DECIMAL(12, 2);
+  auto expected = makeRowVector({
+      makeNullableFlatVector<int64_t>(
+          {std::nullopt, 400, std::nullopt}, expectedType),
+  });
+
+  facebook::velox::test::assertEqualVectors(expected, result);
 }
 
 TEST_F(CudfDecimalTest, decimalModulo) {


### PR DESCRIPTION
### Summary

- Decimal column division by zero now returns null instead of throwing an exception. DecimalExpressionKernels.cu creates a GPU bitmask (createDivisorNullMask) marking zero divisors as null and ANDs it with input null masks. The corresponding hasDecimalZero checks in ExpressionEvaluator are removed since the kernel handles it. The scalar-constant divisor check is preserved.