### PR TITLE
fix: Call base initialize method in Expand operator

### DIFF
--- a/velox/exec/Expand.cpp
+++ b/velox/exec/Expand.cpp
@@ -62,6 +62,7 @@ Expand::Expand(
 }
 
 void Expand::initialize() {
+  Operator::initialize();
   if (constantProjections_.empty()) {
     return;
   }

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -219,7 +219,7 @@ class Operator : public BaseRuntimeStatWriter {
   /// allocation from memory pool that can't be done under operator constructor.
   ///
   /// NOTE: the default implementation set 'initialized_' to true to ensure we
-  /// never call this more than once. The overload initialize() implementation
+  /// never call this more than once. The overriding initialize() implementation
   /// must call this base implementation first.
   virtual void initialize();
 


### PR DESCRIPTION
This fix adds a call to the base Operator::initialize method, which sets up the reclaimer, tracer, and initialization state. This is consistent with how other operators implement their initialize method.