### PR TITLE
fix: Fix aliased column name lookup in HiveIndexSource init

### DIFF
--- a/velox/connectors/hive/FileDataSource.cpp
+++ b/velox/connectors/hive/FileDataSource.cpp
@@ -192,7 +192,7 @@ FileDataSource::FileDataSource(
   tableHandle_ = checkedPointerCast<const FileTableHandle>(tableHandle);
 
   folly::F14FastMap<std::string_view, const FileColumnHandle*> columnHandles;
-  // Column handled keyed on the column alias, the name used in the query.
+  // Column handles keyed on the table column name.
   for (const auto& [_, columnHandle] : assignments) {
     auto handle = checkedPointerCast<const FileColumnHandle>(columnHandle);
     const auto [it, unique] =

--- a/velox/connectors/hive/HiveIndexSource.cpp
+++ b/velox/connectors/hive/HiveIndexSource.cpp
@@ -818,7 +818,7 @@ void HiveIndexSource::init(
   VELOX_CHECK_NOT_NULL(tableHandle_);
 
   folly::F14FastMap<std::string_view, const HiveColumnHandle*> columnHandles;
-  // Column handled keyed on the column alias, the name used in the query.
+  // Column handles keyed on the table column name.
   for (const auto& [_, columnHandle] : assignments) {
     auto handle = checkedPointerCast<const HiveColumnHandle>(columnHandle);
     const auto [it, unique] =
@@ -840,13 +840,13 @@ void HiveIndexSource::init(
   std::vector<std::string> readColumnNames;
   auto readColumnTypes = outputType_->children();
   for (const auto& outputName : outputType_->names()) {
-    auto it = columnHandles.find(outputName);
+    auto it = assignments.find(outputName);
     VELOX_CHECK(
-        it != columnHandles.end(),
+        it != assignments.end(),
         "ColumnHandle is missing for output column: {}",
         outputName);
 
-    auto* handle = it->second;
+    auto handle = checkedPointerCast<const HiveColumnHandle>(it->second);
     readColumnNames.push_back(handle->name());
     for (auto& subfield : handle->requiredSubfields()) {
       VELOX_USER_CHECK_EQ(


### PR DESCRIPTION
Summary: Fix column handle lookup in init() to use the assignments map keyed by output alias name instead of the columnHandles map keyed by table column name. Presto generates aliased output column names (e.g., "u0_15") to avoid collisions between probe and index sides; the old lookup by table column name ("u0") would fail to find these.

Differential Revision: D104770882


