### PR TITLE
feat: Add partition column support to HiveIndexSource

### DIFF
--- a/velox/connectors/hive/FileSplitReader.cpp
+++ b/velox/connectors/hive/FileSplitReader.cpp
@@ -447,13 +447,13 @@ void FileSplitReader::setPartitionValue(
     common::ScanSpec* spec,
     const std::string& partitionKey,
     const std::optional<std::string>& value) const {
-  auto it = partitionKeys_->find(partitionKey);
+  const auto it = partitionKeys_->find(partitionKey);
   VELOX_CHECK(
       it != partitionKeys_->end(),
       "ColumnHandle is missing for partition key {}",
       partitionKey);
-  auto type = it->second->dataType();
-  auto constant = newConstantFromString(
+  const auto type = it->second->dataType();
+  const auto constant = newConstantFromString(
       type,
       value,
       connectorQueryCtx_->memoryPool(),

--- a/velox/connectors/hive/HiveIndexSource.cpp
+++ b/velox/connectors/hive/HiveIndexSource.cpp
@@ -21,6 +21,7 @@
 #include "velox/common/time/Timer.h"
 #include "velox/connectors/hive/FileDataSource.h"
 #include "velox/connectors/hive/FileIndexReader.h"
+#include "velox/connectors/hive/FileSplitReader.h"
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/HiveConnectorUtil.h"
 #include "velox/exec/OperatorUtils.h"
@@ -169,7 +170,7 @@ std::string getTableColumnName(
   auto it = assignments.find(inputColumnName);
   VELOX_USER_CHECK(
       it != assignments.end(),
-      "Column '{}' not found in assignments",
+      "Column not found in assignments: {}",
       inputColumnName);
   const auto* handle =
       checkedPointerCast<const HiveColumnHandle>(it->second.get());
@@ -824,8 +825,17 @@ void HiveIndexSource::init(
     const auto [it, unique] =
         columnHandles.emplace(handle->name(), handle.get());
     VELOX_CHECK(unique, "Duplicate column handle for {}", handle->name());
-    // NOTE: we only support regular column handle for hive index source.
-    checkColumnHandleIsRegular(*handle);
+    // Allow regular and partition key columns. Partition keys are not read
+    // from files — their values are synthesized from split metadata.
+    VELOX_CHECK(
+        handle->columnType() == HiveColumnHandle::ColumnType::kRegular ||
+            handle->columnType() == HiveColumnHandle::ColumnType::kPartitionKey,
+        "Unsupported column type {} for column {}",
+        HiveColumnHandle::columnTypeName(handle->columnType()),
+        handle->name());
+    if (handle->columnType() == HiveColumnHandle::ColumnType::kPartitionKey) {
+      partitionKeyHandles_.emplace(handle->name(), handle);
+    }
   }
 
   for (const auto& handle : tableHandle_->filterColumnHandles()) {
@@ -848,6 +858,12 @@ void HiveIndexSource::init(
 
     auto handle = checkedPointerCast<const HiveColumnHandle>(it->second);
     readColumnNames.push_back(handle->name());
+    if (handle->columnType() == HiveColumnHandle::ColumnType::kPartitionKey) {
+      // Subfield projection / postProcessor checks below don't apply to
+      // partition columns; their values come from split metadata.
+      continue;
+    }
+
     for (auto& subfield : handle->requiredSubfields()) {
       VELOX_USER_CHECK_EQ(
           getColumnName(subfield),
@@ -881,7 +897,7 @@ void HiveIndexSource::init(
       filters_,
       /*indexColumns=*/{},
       tableHandle_->dataColumns(),
-      /*partitionKeys=*/{},
+      partitionKeyHandles_,
       /*infoColumns=*/{},
       /*specialColumns=*/{},
       hiveConfig_->readStatsBasedFilterReorderDisabled(
@@ -889,11 +905,68 @@ void HiveIndexSource::init(
       pool_);
 }
 
+void HiveIndexSource::setPartitionValues(
+    const std::vector<std::shared_ptr<ConnectorSplit>>& splits) {
+  if (partitionKeyHandles_.empty() || splits.empty()) {
+    return;
+  }
+  const auto firstSplit =
+      checkedPointerCast<const HiveConnectorSplit>(splits[0]);
+  const auto& partitionValues = firstSplit->partitionKeys;
+
+  // Sanity check all splits share the same partition values.
+  for (size_t i = 1; i < splits.size(); ++i) {
+    const auto& split = checkedPointerCast<const HiveConnectorSplit>(splits[i]);
+    VELOX_CHECK(
+        split->partitionKeys == partitionValues,
+        "Split {} partition values differ from split 0: split[0].path={}, split[{}].path={}",
+        i,
+        firstSplit->filePath,
+        i,
+        split->filePath);
+  }
+
+  // Iterate scan spec children and set constant values for partition columns
+  // found in the split metadata.
+  auto& childrenSpecs = scanSpec_->children();
+  for (size_t i = 0; i < childrenSpecs.size(); ++i) {
+    auto* childSpec = childrenSpecs[i].get();
+    const auto& fieldName = childSpec->fieldName();
+
+    if (auto partitionIt = partitionValues.find(fieldName);
+        partitionIt != partitionValues.end()) {
+      setPartitionValue(childSpec, fieldName, partitionIt->second);
+    }
+  }
+}
+
+void HiveIndexSource::setPartitionValue(
+    common::ScanSpec* spec,
+    const std::string& partitionKey,
+    const std::optional<std::string>& value) const {
+  const auto it = partitionKeyHandles_.find(partitionKey);
+  VELOX_CHECK(
+      it != partitionKeyHandles_.end(),
+      "ColumnHandle is missing for partition key {}",
+      partitionKey);
+  const auto type = it->second->dataType();
+  const auto constant = newConstantFromString(
+      type,
+      value,
+      pool_,
+      hiveConfig_->readTimestampPartitionValueAsLocalTime(
+          connectorQueryCtx_->sessionProperties()),
+      it->second->isPartitionDateValueDaysSinceEpoch());
+  spec->setConstantValue(constant);
+}
+
 void HiveIndexSource::addSplits(
     std::vector<std::shared_ptr<ConnectorSplit>> splits) {
   VELOX_CHECK(
       readers_.empty(),
       "addSplits can only be called once for HiveIndexSource");
+
+  setPartitionValues(splits);
 
   auto* registry = IndexReaderFactoryRegistry::getInstance();
   for (auto& split : splits) {

--- a/velox/connectors/hive/HiveIndexSource.h
+++ b/velox/connectors/hive/HiveIndexSource.h
@@ -35,10 +35,12 @@ class HiveConfig;
 
 /// Provides index lookup for Hive-metastore-backed tables.
 ///
-/// Owns format-agnostic orchestration: remaining filter evaluation, output
-/// projection, and (in future) partition routing. Delegates format-specific
-/// reads to either the built-in FileIndexReader (for Nimble) or external
-/// SplitIndexReader implementations registered via IndexReaderFactoryRegistry.
+/// Owns format-agnostic orchestration: remaining filter evaluation and output
+/// projection. Delegates format-specific reads to either the built-in
+/// FileIndexReader (for Nimble) or external SplitIndexReader implementations
+/// registered via IndexReaderFactoryRegistry. Supports partitioned tables by
+/// synthesizing partition column values from split metadata via scan-spec
+/// constants.
 class HiveIndexSource : public IndexSource,
                         public std::enable_shared_from_this<HiveIndexSource> {
  public:
@@ -86,11 +88,24 @@ class HiveIndexSource : public IndexSource,
   vector_size_t evaluateRemainingFilter(RowVectorPtr& rowVector);
 
   // Projects output from reader output to the final output type. Wraps child
-  // vectors with remaining filter indices if provided.
+  // vectors with remaining filter indices if provided. Partition
+  // columns are emitted by the reader directly via setConstantValue() on
+  // the scan spec, so they are projected like any other column here.
   RowVectorPtr projectOutput(
       vector_size_t numRows,
       const BufferPtr& remainingIndices,
       const RowVectorPtr& rowVector);
+
+  // Sets partition column constants on scanSpec_ from the first split's
+  // partition values. No-op if there are no partition columns or no splits.
+  void setPartitionValues(
+      const std::vector<std::shared_ptr<ConnectorSplit>>& splits);
+
+  // Sets a constant partition value on the scanSpec for a partition column.
+  void setPartitionValue(
+      common::ScanSpec* spec,
+      const std::string& partitionKey,
+      const std::optional<std::string>& value) const;
 
   void init(
       const ColumnHandleMap& assignments,
@@ -175,6 +190,12 @@ class HiveIndexSource : public IndexSource,
   // This is passed to FileIndexReader.
   std::vector<core::IndexLookupConditionPtr> indexLookupConditions_;
 
+  // Partition column handles, keyed by table column name (handle->name()).
+  // Populated from kPartitionKey assignments in init(). Used to feed
+  // partition handles into makeScanSpec() and to look up dataType() when
+  // parsing partition value strings into typed constants.
+  std::unordered_map<std::string, FileColumnHandlePtr> partitionKeyHandles_;
+
   // Filters for pushdown. Includes subfield filters from table handle and
   // filters converted from constant index lookup conditions.
   common::SubfieldFilters filters_;
@@ -204,11 +225,13 @@ class HiveIndexSource : public IndexSource,
 
   // Scan spec for the index reader.
   std::shared_ptr<common::ScanSpec> scanSpec_;
-  // Output type for the index reader.
+  // Output type for the index reader. Includes partition columns when they
+  // appear in outputType_; the per-split reader emits their values as
+  // constants via the scan spec's setConstantValue().
   RowTypePtr readerOutputType_;
-  /// All index readers (both built-in and external). FileIndexReader
-  /// (Nimble) and external readers both implement SplitIndexReader.
-  /// Created by addSplits().
+  // All index readers (both built-in and external). FileIndexReader
+  // (Nimble) and external readers both implement SplitIndexReader.
+  // Created by addSplits().
   std::vector<std::unique_ptr<SplitIndexReader>> readers_;
 
   // Cached empty output vector.


### PR DESCRIPTION
Summary:
Accept kPartitionKey column handles in HiveIndexSource init() (previously crashed on any non-regular handle). Track partition column handles in partitionKeyHandles_, include partition columns in readerOutputType_, and synthesize partition column values from split metadata via scan-spec setConstantValue().

Key changes:
- init(): Accept kPartitionKey handles alongside kRegular. Populate partitionKeyHandles_. Skip subfield/postProcessor checks for partition columns.
- setPartitionValues(): New method that sets partition constants on scanSpec_ children from the first split's partition keys. Iterates scan spec children (same pattern as FileSplitReader::adaptColumns) and delegates to setPartitionValue() for each partition column. Validates all splits share the same partition values.
- setPartitionValue(): Extracted helper matching FileSplitReader::setPartitionValue signature.
- addSplits(): Calls setPartitionValues() before creating readers.
- Pass partitionKeyHandles_ to makeScanSpec() so partition column children are included in the spec.

Reviewed By: xiaoxmeng

Differential Revision: D104739908


