### PR TITLE
feat(spark): Add bitmap_construct_agg aggregate function

### DIFF
--- a/velox/docs/functions/spark/aggregate.rst
+++ b/velox/docs/functions/spark/aggregate.rst
@@ -22,6 +22,13 @@ General Aggregate Functions
 
     Returns the bitwise XOR of all non-null input values, or null if none.
 
+.. spark:function:: bitmap_construct_agg(position) -> varbinary
+
+    Builds a fixed-size 4096-byte (32768-bit) bitmap by setting bits at the
+    specified positions. Input positions must be BIGINT values in [0, 32767].
+    Null inputs are ignored. Returns an all-zeros bitmap for empty or all-null
+    input (this is a non-nullable aggregate).
+
 .. spark:function:: bloom_filter_agg(hash, estimatedNumItems, numBits) -> varbinary
 
     Creates bloom filter from input hashes and returns it serialized into VARBINARY.

--- a/velox/functions/sparksql/aggregates/BitmapConstructAggAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/BitmapConstructAggAggregate.cpp
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/sparksql/aggregates/BitmapConstructAggAggregate.h"
+
+#include <cstring>
+
+#include "velox/common/base/BitUtil.h"
+#include "velox/exec/SimpleAggregateAdapter.h"
+#include "velox/expression/FunctionSignature.h"
+
+namespace facebook::velox::functions::aggregate::sparksql {
+
+namespace {
+
+// Spark bitmap_construct_agg uses a fixed-size bitmap of 4096 bytes (32768
+// bits). Each input value in [0, 32767] maps to a single bit in the bitmap.
+// See org.apache.spark.sql.catalyst.expressions.BitmapConstructAgg.
+constexpr int32_t kBitmapNumBytes = 4096;
+constexpr int64_t kBitmapNumBits = static_cast<int64_t>(kBitmapNumBytes) * 8;
+
+// Validates that a bitmap position is within [0, kBitmapNumBits).
+void validateBitmapPosition(int64_t position) {
+  VELOX_USER_CHECK_GE(position, 0, "Bitmap position out of bounds");
+  VELOX_USER_CHECK_LT(
+      position, kBitmapNumBits, "Bitmap position out of bounds");
+}
+
+class BitmapConstructAggAggregate {
+ public:
+  using InputType = Row<int64_t>;
+
+  using IntermediateType = Varbinary;
+
+  using OutputType = Varbinary;
+
+  // Non-default null behavior: the aggregate always produces a non-null result
+  // (an all-zeros bitmap) even when all inputs are null or the group is empty.
+  static constexpr bool default_null_behavior_ = false;
+
+  struct AccumulatorType {
+    // Pointer to the 4096-byte bitmap stored in external memory.
+    uint8_t* data_{nullptr};
+    // Header for the HashStringAllocator-managed allocation.
+    HashStringAllocator::Header* header_{nullptr};
+
+    static constexpr bool is_fixed_size_ = false;
+    static constexpr bool use_external_memory_ = true;
+
+    explicit AccumulatorType(
+        HashStringAllocator* /*allocator*/,
+        BitmapConstructAggAggregate* /*fn*/) {}
+
+    bool addInput(
+        HashStringAllocator* allocator,
+        exec::optional_arg_type<int64_t> position) {
+      if (!position.has_value()) {
+        return false;
+      }
+      validateBitmapPosition(position.value());
+      init(allocator);
+      bits::setBit(data_, static_cast<uint64_t>(position.value()));
+      return true;
+    }
+
+    bool combine(
+        HashStringAllocator* allocator,
+        exec::optional_arg_type<IntermediateType> other) {
+      if (!other.has_value()) {
+        return false;
+      }
+      auto serialized = other.value();
+      VELOX_CHECK_EQ(
+          serialized.size(),
+          kBitmapNumBytes,
+          "Unexpected intermediate bitmap size");
+      init(allocator);
+      bits::orBits(
+          reinterpret_cast<uint64_t*>(data_),
+          reinterpret_cast<const uint64_t*>(serialized.data()),
+          0,
+          kBitmapNumBits);
+      return true;
+    }
+
+    // Always produce a non-null result (all-zeros bitmap for empty groups)
+    // to match Spark's bitmap_construct_agg semantics.
+    bool writeIntermediateResult(
+        bool /*nonNullGroup*/,
+        exec::out_type<IntermediateType>& out) {
+      return writeResult(out);
+    }
+
+    bool writeFinalResult(
+        bool /*nonNullGroup*/,
+        exec::out_type<OutputType>& out) {
+      return writeResult(out);
+    }
+
+    void destroy(HashStringAllocator* allocator) {
+      if (header_) {
+        allocator->free(header_);
+        header_ = nullptr;
+        data_ = nullptr;
+      }
+    }
+
+   private:
+    bool writeResult(exec::out_type<Varbinary>& out) {
+      out.resize(kBitmapNumBytes);
+      if (data_) {
+        std::memcpy(out.data(), data_, kBitmapNumBytes);
+      } else {
+        std::memset(out.data(), 0, kBitmapNumBytes);
+      }
+      return true;
+    }
+
+    void init(HashStringAllocator* allocator) {
+      if (!data_) {
+        header_ = allocator->allocate(kBitmapNumBytes);
+        data_ = reinterpret_cast<uint8_t*>(header_->begin());
+        std::memset(data_, 0, kBitmapNumBytes);
+      }
+    }
+  };
+};
+
+} // namespace
+
+exec::AggregateRegistrationResult registerBitmapConstructAggAggregate(
+    const std::string& name,
+    bool withCompanionFunctions,
+    bool overwrite) {
+  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
+      exec::AggregateFunctionSignatureBuilder()
+          .argumentType("bigint")
+          .intermediateType("varbinary")
+          .returnType("varbinary")
+          .build()};
+
+  return exec::registerAggregateFunction(
+      name,
+      std::move(signatures),
+      [name](
+          core::AggregationNode::Step step,
+          const std::vector<TypePtr>& argTypes,
+          const TypePtr& resultType,
+          const core::QueryConfig& config) -> std::unique_ptr<exec::Aggregate> {
+        VELOX_CHECK_EQ(
+            argTypes.size(), 1, "{} takes exactly one argument", name);
+        return std::make_unique<
+            exec::SimpleAggregateAdapter<BitmapConstructAggAggregate>>(
+            step, argTypes, resultType, &config);
+      },
+      withCompanionFunctions,
+      overwrite);
+}
+
+} // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/BitmapConstructAggAggregate.h
+++ b/velox/functions/sparksql/aggregates/BitmapConstructAggAggregate.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+
+#include "velox/exec/AggregateUtil.h"
+
+namespace facebook::velox::functions::aggregate::sparksql {
+
+exec::AggregateRegistrationResult registerBitmapConstructAggAggregate(
+    const std::string& name,
+    bool withCompanionFunctions,
+    bool overwrite);
+
+} // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/CMakeLists.txt
+++ b/velox/functions/sparksql/aggregates/CMakeLists.txt
@@ -15,6 +15,7 @@ velox_add_library(
   velox_functions_spark_aggregates
   ApproxPercentileAggregate.cpp
   AverageAggregate.cpp
+  BitmapConstructAggAggregate.cpp
   BitwiseXorAggregate.cpp
   BloomFilterAggAggregate.cpp
   CentralMomentsAggregate.cpp
@@ -32,6 +33,7 @@ velox_add_library(
   HEADERS
   ApproxPercentileAggregate.h
   AverageAggregate.h
+  BitmapConstructAggAggregate.h
   BitwiseXorAggregate.h
   BloomFilterAggAggregate.h
   CentralMomentsAggregate.h

--- a/velox/functions/sparksql/aggregates/Register.cpp
+++ b/velox/functions/sparksql/aggregates/Register.cpp
@@ -18,6 +18,7 @@
 
 #include "velox/functions/sparksql/aggregates/ApproxPercentileAggregate.h"
 #include "velox/functions/sparksql/aggregates/AverageAggregate.h"
+#include "velox/functions/sparksql/aggregates/BitmapConstructAggAggregate.h"
 #include "velox/functions/sparksql/aggregates/BitwiseXorAggregate.h"
 #include "velox/functions/sparksql/aggregates/BloomFilterAggAggregate.h"
 #include "velox/functions/sparksql/aggregates/CentralMomentsAggregate.h"
@@ -57,6 +58,8 @@ void registerAggregateFunctions(
   registerFirstLastAggregates(prefix, withCompanionFunctions, overwrite);
   registerMinMaxAggregates(prefix, withCompanionFunctions, overwrite);
   registerMinMaxByAggregates(prefix, withCompanionFunctions, overwrite);
+  registerBitmapConstructAggAggregate(
+      prefix + "bitmap_construct_agg", withCompanionFunctions, overwrite);
   registerBitwiseXorAggregate(prefix, withCompanionFunctions, overwrite);
   registerBloomFilterAggAggregate(
       prefix + "bloom_filter_agg", withCompanionFunctions, overwrite);

--- a/velox/functions/sparksql/aggregates/tests/BitmapConstructAggAggregateTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/BitmapConstructAggAggregateTest.cpp
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/BitUtil.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
+#include "velox/functions/sparksql/aggregates/Register.h"
+
+namespace facebook::velox::functions::aggregate::sparksql::test {
+namespace {
+
+constexpr int32_t kBitmapNumBytes = 4096;
+
+class BitmapConstructAggAggregateTest
+    : public aggregate::test::AggregationTestBase {
+ public:
+  void SetUp() override {
+    AggregationTestBase::SetUp();
+    registerAggregateFunctions("");
+  }
+
+  // Returns a 4096-byte bitmap string with the specified bits set.
+  std::string makeBitmapString(const std::vector<int64_t>& positions) {
+    std::string bitmap(kBitmapNumBytes, '\0');
+    auto* data = reinterpret_cast<uint8_t*>(bitmap.data());
+    for (auto position : positions) {
+      bits::setBit(data, position);
+    }
+    return bitmap;
+  }
+
+  // Returns a single-row VARBINARY vector containing the bitmap.
+  VectorPtr makeBitmapWithBits(const std::vector<int64_t>& positions) {
+    return makeFlatVector({makeBitmapString(positions)}, VARBINARY());
+  }
+};
+
+TEST_F(BitmapConstructAggAggregateTest, basic) {
+  // Single group, several bit positions.
+  auto input = makeRowVector({makeFlatVector<int64_t>({0, 1, 7, 8, 100})});
+  auto expected = makeBitmapWithBits({0, 1, 7, 8, 100});
+
+  testAggregations(
+      {input}, {}, {"bitmap_construct_agg(c0)"}, {makeRowVector({expected})});
+}
+
+TEST_F(BitmapConstructAggAggregateTest, allNullInputReturnsZeroBitmap) {
+  // Spark contract: nullable = false, so all-null input produces all-zeros.
+  auto input = makeRowVector({makeNullableFlatVector<int64_t>(
+      {std::nullopt, std::nullopt, std::nullopt})});
+  auto expected = makeBitmapWithBits({});
+
+  testAggregations(
+      {input}, {}, {"bitmap_construct_agg(c0)"}, {makeRowVector({expected})});
+}
+
+TEST_F(BitmapConstructAggAggregateTest, emptyInputReturnsZeroBitmap) {
+  auto input = makeRowVector({makeFlatVector<int64_t>({})});
+  auto expected = makeBitmapWithBits({});
+
+  testAggregations(
+      {input}, {}, {"bitmap_construct_agg(c0)"}, {makeRowVector({expected})});
+}
+
+TEST_F(BitmapConstructAggAggregateTest, mixedNullAndValid) {
+  // Mix of null and valid values.
+  auto input = makeRowVector({makeNullableFlatVector<int64_t>(
+      {std::nullopt, 5, std::nullopt, 10, std::nullopt})});
+  auto expected = makeBitmapWithBits({5, 10});
+
+  testAggregations(
+      {input}, {}, {"bitmap_construct_agg(c0)"}, {makeRowVector({expected})});
+}
+
+TEST_F(BitmapConstructAggAggregateTest, groupBy) {
+  // Test with group-by: two groups, including one all-null group.
+  auto input = makeRowVector({
+      makeFlatVector<int32_t>({1, 1, 2, 2, 2}),
+      makeNullableFlatVector<int64_t>(
+          {0, 100, std::nullopt, std::nullopt, std::nullopt}),
+  });
+
+  // Group 1: bits 0 and 100 set. Group 2: all-zeros (all-null input).
+  auto bitmap1 = makeBitmapString({0, 100});
+  auto bitmap2 = makeBitmapString({});
+  auto expected = makeRowVector({
+      makeFlatVector<int32_t>({1, 2}),
+      makeFlatVector<StringView>(
+          {StringView(bitmap1), StringView(bitmap2)}, VARBINARY()),
+  });
+
+  testAggregations(
+      {input}, {"c0"}, {"bitmap_construct_agg(c1)"}, {}, {expected});
+}
+
+TEST_F(BitmapConstructAggAggregateTest, boundaryPositions) {
+  // Test min and max valid positions.
+  auto input = makeRowVector({makeFlatVector<int64_t>({0, 32767})});
+  auto expected = makeBitmapWithBits({0, 32767});
+
+  testAggregations(
+      {input}, {}, {"bitmap_construct_agg(c0)"}, {makeRowVector({expected})});
+}
+
+TEST_F(BitmapConstructAggAggregateTest, invalidPositionNegative) {
+  auto input = makeRowVector({makeFlatVector<int64_t>({-1})});
+  VELOX_ASSERT_THROW(
+      testAggregations(
+          {input},
+          {},
+          {"bitmap_construct_agg(c0)"},
+          std::vector<RowVectorPtr>{}),
+      "Bitmap position out of bounds");
+}
+
+TEST_F(BitmapConstructAggAggregateTest, invalidPositionTooLarge) {
+  auto input = makeRowVector({makeFlatVector<int64_t>({32768})});
+  VELOX_ASSERT_THROW(
+      testAggregations(
+          {input},
+          {},
+          {"bitmap_construct_agg(c0)"},
+          std::vector<RowVectorPtr>{}),
+      "Bitmap position out of bounds");
+}
+
+TEST_F(BitmapConstructAggAggregateTest, duplicatePositions) {
+  // Duplicate positions should result in same bitmap as unique.
+  auto input = makeRowVector({makeFlatVector<int64_t>({5, 5, 5, 10, 10})});
+  auto expected = makeBitmapWithBits({5, 10});
+
+  testAggregations(
+      {input}, {}, {"bitmap_construct_agg(c0)"}, {makeRowVector({expected})});
+}
+
+TEST_F(BitmapConstructAggAggregateTest, partialAndFinalAggregation) {
+  // Test that partial -> final merge works correctly.
+  // Split data across multiple batches to exercise intermediate merge.
+  auto batch1 = makeRowVector({makeFlatVector<int64_t>({0, 1, 2})});
+  auto batch2 = makeRowVector({makeFlatVector<int64_t>({3, 4, 5})});
+  auto expected = makeBitmapWithBits({0, 1, 2, 3, 4, 5});
+
+  testAggregations(
+      {batch1, batch2},
+      {},
+      {"bitmap_construct_agg(c0)"},
+      {makeRowVector({expected})});
+}
+
+TEST_F(BitmapConstructAggAggregateTest, invalidIntermediateSizeTooSmall) {
+  std::string tinyBitmap(1, '\xFF');
+  auto input = makeRowVector(
+      {makeFlatVector<StringView>({StringView(tinyBitmap)}, VARBINARY())});
+
+  auto plan =
+      exec::test::PlanBuilder()
+          .values({input})
+          .finalAggregation({}, {"bitmap_construct_agg(c0)"}, {{BIGINT()}})
+          .planNode();
+
+  VELOX_ASSERT_THROW(
+      exec::test::AssertQueryBuilder(plan).copyResults(pool()),
+      "Unexpected intermediate bitmap size");
+}
+
+TEST_F(BitmapConstructAggAggregateTest, invalidIntermediateSizeTooLarge) {
+  std::string bigBitmap(8192, '\x00');
+  auto input = makeRowVector(
+      {makeFlatVector<StringView>({StringView(bigBitmap)}, VARBINARY())});
+
+  auto plan =
+      exec::test::PlanBuilder()
+          .values({input})
+          .finalAggregation({}, {"bitmap_construct_agg(c0)"}, {{BIGINT()}})
+          .planNode();
+
+  VELOX_ASSERT_THROW(
+      exec::test::AssertQueryBuilder(plan).copyResults(pool()),
+      "Unexpected intermediate bitmap size");
+}
+
+TEST_F(BitmapConstructAggAggregateTest, nullIntermediateInFinalAggregation) {
+  // A null intermediate should be skipped; the result should still be a valid
+  // all-zeros bitmap (non-null output).
+  auto input = makeRowVector(
+      {makeNullableFlatVector<StringView>({std::nullopt}, VARBINARY())});
+
+  auto plan =
+      exec::test::PlanBuilder()
+          .values({input})
+          .finalAggregation({}, {"bitmap_construct_agg(c0)"}, {{BIGINT()}})
+          .planNode();
+
+  auto expected = makeRowVector({makeBitmapWithBits({})});
+  exec::test::AssertQueryBuilder(plan).assertResults(expected);
+}
+
+TEST_F(BitmapConstructAggAggregateTest, mergeMultipleIntermediates) {
+  // Two batches with disjoint positions exercise the 64-bit OR combine logic.
+  auto batch1 = makeRowVector({makeFlatVector<int64_t>({0})});
+  auto batch2 = makeRowVector({makeFlatVector<int64_t>({15})});
+  auto expected = makeBitmapWithBits({0, 15});
+
+  testAggregations(
+      {batch1, batch2},
+      {},
+      {"bitmap_construct_agg(c0)"},
+      {makeRowVector({expected})});
+}
+
+TEST_F(BitmapConstructAggAggregateTest, mergeOverlappingIntermediates) {
+  // Two batches with overlapping positions — OR produces union.
+  auto batch1 = makeRowVector({makeFlatVector<int64_t>({0})});
+  auto batch2 = makeRowVector({makeFlatVector<int64_t>({0, 1})});
+  auto expected = makeBitmapWithBits({0, 1});
+
+  testAggregations(
+      {batch1, batch2},
+      {},
+      {"bitmap_construct_agg(c0)"},
+      {makeRowVector({expected})});
+}
+
+} // namespace
+} // namespace facebook::velox::functions::aggregate::sparksql::test

--- a/velox/functions/sparksql/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/aggregates/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(
   velox_functions_spark_aggregates_test
   ApproxPercentileAggregateTest.cpp
   AverageAggregationTest.cpp
+  BitmapConstructAggAggregateTest.cpp
   BitwiseXorAggregationTest.cpp
   BloomFilterAggAggregateTest.cpp
   CentralMomentsAggregationTest.cpp


### PR DESCRIPTION
CONTEXT: Spark 3.4+ introduced bitmap aggregate functions (`bitmap_construct_agg`, `bitmap_or_agg`, `bitmap_bucket_number`, `bitmap_bit_position`, `bitmap_count`) for efficient count-distinct approximation using sub-bitmap splitting. `bitmap_construct_agg` is the core aggregation primitive — it builds a fixed-size 4096-byte bitmap (32768 bits) from input bit positions computed by `bitmap_bit_position`.

WHAT: Add the `bitmap_construct_agg` aggregate function for Spark. The function takes BIGINT input positions in [0, 32767] and produces a VARBINARY bitmap with the corresponding bits set.

Key design points:
- Uses `SimpleAggregateAdapter` with `default_null_behavior_ = false` for non-nullable output
- Fixed 4096-byte bitmap allocated lazily via `HashStringAllocator` (zero cost for empty groups)
- Out-of-range positions raise a descriptive error with plain English message
- NULL inputs are skipped; the aggregate is non-nullable (returns all-zeros bitmap for empty/all-null input)
- Partial aggregation supported: intermediate bitmaps serialized as VARBINARY, merged via 64-bit OR
- Uses `bits::setBit` for bitmap manipulation

Tests cover: basic, null handling, group-by, boundaries, invalid positions, partial+final merge, invalid intermediates, overlapping merges.

Ref: `org.apache.spark.sql.catalyst.expressions.BitmapConstructAgg`
