### PR TITLE
feat: Add valueAt() and containsKey() to EnumTypeBase

### DIFF
--- a/velox/functions/prestosql/types/EnumTypeBase.h
+++ b/velox/functions/prestosql/types/EnumTypeBase.h
@@ -61,6 +61,22 @@ class EnumTypeBase : public TPhysical {
     return std::nullopt;
   }
 
+  /// Returns the value for a key name. If the key does not exist,
+  /// return std::nullopt.
+  std::optional<TValue> valueAt(const std::string& key) const {
+    const auto& map = forwardMap();
+    auto it = map.find(key);
+    if (it != map.end()) {
+      return it->second;
+    }
+    return std::nullopt;
+  }
+
+  /// Returns true if the enum has an entry for 'key'.
+  bool containsKey(const std::string& key) const {
+    return valueAt(key).has_value();
+  }
+
   const std::string& enumName() const {
     return name_;
   }
@@ -76,6 +92,14 @@ class EnumTypeBase : public TPhysical {
   /// parameters.
   template <typename EnumType>
   static std::shared_ptr<const EnumType> getCached(const TParameter& parameter);
+
+  const std::unordered_map<std::string, TValue>& forwardMap() const {
+    if constexpr (std::is_same_v<TParameter, LongEnumParameter>) {
+      return parameters_[0].longEnumLiteral->valuesMap;
+    } else {
+      return parameters_[0].varcharEnumLiteral->valuesMap;
+    }
+  }
 
   const std::vector<TypeParameter> parameters_;
   const std::string name_;

--- a/velox/functions/prestosql/types/tests/BigintEnumTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/BigintEnumTypeTest.cpp
@@ -84,5 +84,19 @@ TEST_F(BigintEnumTypeTest, keyAt) {
   // Test non-existent value
   ASSERT_EQ(moodEnum_->keyAt(999), std::nullopt);
 }
+
+TEST_F(BigintEnumTypeTest, valueAt) {
+  EXPECT_EQ(moodEnum_->valueAt("CURIOUS"), -2);
+  EXPECT_EQ(moodEnum_->valueAt("HAPPY"), 0);
+  EXPECT_EQ(moodEnum_->valueAt("unknown"), std::nullopt);
+}
+
+TEST_F(BigintEnumTypeTest, containsKey) {
+  EXPECT_TRUE(moodEnum_->containsKey("CURIOUS"));
+  EXPECT_TRUE(moodEnum_->containsKey("HAPPY"));
+  EXPECT_FALSE(moodEnum_->containsKey("curious"));
+  EXPECT_FALSE(moodEnum_->containsKey("unknown"));
+}
+
 } // namespace
 } // namespace facebook::velox

--- a/velox/functions/prestosql/types/tests/VarcharEnumTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/VarcharEnumTypeTest.cpp
@@ -79,5 +79,18 @@ TEST_F(VarcharEnumTypeTest, basic) {
 TEST_F(VarcharEnumTypeTest, serde) {
   testTypeSerde(colorEnum_);
 }
+
+TEST_F(VarcharEnumTypeTest, valueAt) {
+  EXPECT_EQ(colorEnum_->valueAt("RED"), "red");
+  EXPECT_EQ(colorEnum_->valueAt("BLUE"), "blue");
+  EXPECT_EQ(colorEnum_->valueAt("unknown"), std::nullopt);
+}
+
+TEST_F(VarcharEnumTypeTest, containsKey) {
+  EXPECT_TRUE(colorEnum_->containsKey("RED"));
+  EXPECT_FALSE(colorEnum_->containsKey("red"));
+  EXPECT_FALSE(colorEnum_->containsKey("unknown"));
+}
+
 } // namespace
 } // namespace facebook::velox


### PR DESCRIPTION
Summary:
Adds forward-map lookup methods to EnumTypeBase for looking up enum values by key name directly from the TypePtr.

- `valueAt(const std::string& key)` — Returns the value for a key name, or nullopt. Mirrors the existing `keyAt(value)` convention.
- `containsKey(const std::string& key)` — Returns true if the enum has an entry for the key. Delegates to `valueAt(key).has_value()`.

These complement the existing reverse-map methods (`containsValue`, `keyAt`) and are needed by Axiom's enum type resolution to look up enum literal values without reaching into TypeParameter internals.

Reviewed By: mbasmanova

Differential Revision: D104496173


