### PR TITLE
feat: Add NimbleWriterOptionsAdapter for Iceberg writes (#17493)

### DIFF
--- a/velox/connectors/hive/iceberg/WriterOptionsAdapter.cpp
+++ b/velox/connectors/hive/iceberg/WriterOptionsAdapter.cpp
@@ -23,6 +23,13 @@ namespace facebook::velox::connector::hive::iceberg {
 
 namespace {
 
+// Manifest format string emitted in Iceberg commit messages for files that
+// share the ORC on-disk family. Iceberg's manifest vocabulary has no DWRF or
+// NIMBLE enum, so DWRF and NIMBLE files are reported as "ORC" per the
+// cross-engine convention shared with the Java planner (see
+// FileFormat.{DWRF,NIMBLE}.toIceberg() in presto-facebook-iceberg).
+constexpr std::string_view kOrcManifestFormat{"ORC"};
+
 class ParquetWriterOptionsAdapter : public WriterOptionsAdapter {
  public:
   std::string manifestFormatString() const override {
@@ -48,7 +55,7 @@ class ParquetWriterOptionsAdapter : public WriterOptionsAdapter {
 class DwrfWriterOptionsAdapter : public WriterOptionsAdapter {
  public:
   std::string manifestFormatString() const override {
-    return "ORC";
+    return std::string{kOrcManifestFormat};
   }
 
   void applyPostConfigs(dwio::common::WriterOptions& options) const override {
@@ -66,6 +73,17 @@ class DwrfWriterOptionsAdapter : public WriterOptionsAdapter {
   }
 };
 
+class NimbleWriterOptionsAdapter : public WriterOptionsAdapter {
+ public:
+  // Reports NIMBLE files as ORC in the manifest so cross-engine readers
+  // (Presto coordinator, catalog) can interpret the commit message. The
+  // actual on-disk format is identified at read time via the file
+  // extension and on-disk magic bytes, not via this string.
+  std::string manifestFormatString() const override {
+    return std::string{kOrcManifestFormat};
+  }
+};
+
 } // namespace
 
 std::unique_ptr<WriterOptionsAdapter> createWriterOptionsAdapter(
@@ -78,6 +96,8 @@ std::unique_ptr<WriterOptionsAdapter> createWriterOptionsAdapter(
       return std::make_unique<ParquetWriterOptionsAdapter>();
     case dwio::common::FileFormat::DWRF:
       return std::make_unique<DwrfWriterOptionsAdapter>();
+    case dwio::common::FileFormat::NIMBLE:
+      return std::make_unique<NimbleWriterOptionsAdapter>();
     default:
       return nullptr;
   }

--- a/velox/connectors/hive/iceberg/tests/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/tests/CMakeLists.txt
@@ -159,4 +159,21 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
     GTest::gtest
     GTest::gtest_main
   )
+
+  add_executable(
+    velox_hive_writer_options_adapter_test WriterOptionsAdapterTest.cpp
+  )
+  add_test(
+    velox_hive_writer_options_adapter_test
+    velox_hive_writer_options_adapter_test
+  )
+
+  target_link_libraries(
+    velox_hive_writer_options_adapter_test
+    velox_hive_connector
+    velox_hive_iceberg_splitreader
+    velox_dwio_common_exception
+    GTest::gtest
+    GTest::gtest_main
+  )
 endif()

--- a/velox/connectors/hive/iceberg/tests/WriterOptionsAdapterTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/WriterOptionsAdapterTest.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/WriterOptionsAdapter.h"
+
+#include <gtest/gtest.h>
+#include "velox/common/base/tests/GTestUtils.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+namespace {
+
+// Verifies the dispatch table in createWriterOptionsAdapter():
+// PARQUET, DWRF, NIMBLE return non-null adapters; everything else returns
+// null. This is the single source of truth for which file formats the
+// Iceberg DataSink supports on the write path.
+TEST(WriterOptionsAdapterTest, createWriterOptionsAdapterDispatch) {
+  EXPECT_NE(
+      createWriterOptionsAdapter(dwio::common::FileFormat::PARQUET), nullptr);
+  EXPECT_NE(
+      createWriterOptionsAdapter(dwio::common::FileFormat::DWRF), nullptr);
+  EXPECT_NE(
+      createWriterOptionsAdapter(dwio::common::FileFormat::NIMBLE), nullptr);
+
+  // ORC, TEXT, JSON, ALPHA, etc. are intentionally unsupported on the
+  // write path until each gets its own end-to-end coverage.
+  EXPECT_EQ(createWriterOptionsAdapter(dwio::common::FileFormat::ORC), nullptr);
+  EXPECT_EQ(
+      createWriterOptionsAdapter(dwio::common::FileFormat::TEXT), nullptr);
+  EXPECT_EQ(
+      createWriterOptionsAdapter(dwio::common::FileFormat::JSON), nullptr);
+}
+
+// Verifies isSupportedFileFormat() agrees with createWriterOptionsAdapter().
+TEST(WriterOptionsAdapterTest, isSupportedFileFormatMatchesDispatch) {
+  EXPECT_TRUE(isSupportedFileFormat(dwio::common::FileFormat::PARQUET));
+  EXPECT_TRUE(isSupportedFileFormat(dwio::common::FileFormat::DWRF));
+  EXPECT_TRUE(isSupportedFileFormat(dwio::common::FileFormat::NIMBLE));
+
+  EXPECT_FALSE(isSupportedFileFormat(dwio::common::FileFormat::ORC));
+  EXPECT_FALSE(isSupportedFileFormat(dwio::common::FileFormat::TEXT));
+  EXPECT_FALSE(isSupportedFileFormat(dwio::common::FileFormat::JSON));
+}
+
+// Verifies the manifest format string written into Iceberg commit messages
+// matches the cross-engine convention. Iceberg's manifest vocabulary has no
+// DWRF/NIMBLE enum, so both report "ORC" (matching the Java planner's
+// FileFormat.{DWRF,NIMBLE}.toIceberg()) so downstream Iceberg consumers can
+// interpret the message. Parquet reports "PARQUET" because Iceberg has a
+// native enum for it. The on-disk format is identified at read time via
+// the file extension and on-disk magic bytes, so writing "ORC" for NIMBLE
+// is safe.
+TEST(WriterOptionsAdapterTest, toManifestFormatString) {
+  EXPECT_EQ(
+      toManifestFormatString(dwio::common::FileFormat::PARQUET), "PARQUET");
+  EXPECT_EQ(toManifestFormatString(dwio::common::FileFormat::DWRF), "ORC");
+  EXPECT_EQ(toManifestFormatString(dwio::common::FileFormat::NIMBLE), "ORC");
+}
+
+// Verifies toManifestFormatString() throws for unsupported formats rather
+// than silently returning an incorrect string.
+TEST(WriterOptionsAdapterTest, toManifestFormatStringThrowsForUnsupported) {
+  VELOX_ASSERT_THROW(
+      toManifestFormatString(dwio::common::FileFormat::ORC),
+      "Unsupported file format for Iceberg manifest");
+  VELOX_ASSERT_THROW(
+      toManifestFormatString(dwio::common::FileFormat::TEXT),
+      "Unsupported file format for Iceberg manifest");
+}
+
+} // namespace
+} // namespace facebook::velox::connector::hive::iceberg


### PR DESCRIPTION
Summary:

Adds support for writing Iceberg tables in NIMBLE format via a new
`NimbleWriterOptionsAdapter` mirroring the existing
`DwrfWriterOptionsAdapter` in the anonymous namespace of
`WriterOptionsAdapter.cpp`, plus a `case dwio::common::FileFormat::NIMBLE`
arm in `createWriterOptionsAdapter()`.

## Why

Before this diff, `isSupportedFileFormat(NIMBLE)` returned `false` because
`createWriterOptionsAdapter()` only handled `PARQUET` and `DWRF`. Any
INSERT into a NIMBLE-formatted Iceberg table failed at the
`IcebergDataSink` ctor with:

```
isSupportedFileFormat(tableStorageFormat)
Unsupported file format for writing Iceberg tables: nimble
```

NIMBLE is otherwise fully supported in Velox's dwio layer (reader,
writer, vector serde) -- only the Iceberg connector's
`WriterOptionsAdapter` dispatch was missing.

## Manifest format string choice

The new adapter reports `manifestFormatString() == "ORC"`, matching the
convention already used by `DwrfWriterOptionsAdapter`. Iceberg's manifest
file-format vocabulary has no NIMBLE enum, and the cross-engine
convention established by Java
`com.facebook.presto.iceberg.FileFormat.NIMBLE.toIceberg()` (in
presto-facebook-iceberg) reports NIMBLE as `"ORC"` so downstream
consumers (coordinator, catalog, snapshot tooling) can interpret the
commit message without a NIMBLE-aware enum extension.

The actual on-disk format is identified at read time via the file
extension and the Nimble magic bytes (`0xa1fa` little-endian footer),
not via the manifest string. Writing `"ORC"` here is therefore safe and
preserves cross-engine round-trip compatibility with Java planners.

## What this does NOT do

- Does not register a `NimbleWriterFactory` with the dwio writer
  registry -- that registration happens at the Prestissimo server
  bootstrap (covered in the stacked `presto_cpp` diff).
- Does not change DWRF or Parquet adapter behavior.
- Does not touch the read path.

Reviewed By: srsuryadev

Differential Revision: D104838011


