### PR TITLE
feat: Add per-batch scan stats callback to TableScan (#17494)

### DIFF
--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -36,6 +36,16 @@ class TraceCtx;
 
 namespace facebook::velox::core {
 
+/// Per-batch scan statistics event fired by TableScan after each batch.
+struct ScanBatchEvent {
+  /// Post-pushdown, pre-remaining-filter row count.
+  uint64_t numRows;
+  /// Wall time spent producing this batch in microseconds.
+  uint64_t wallTimeMicros;
+  /// Table name from the connector table handle.
+  std::string_view tableName;
+};
+
 struct PlanFragment;
 
 /// Query execution context that manages resources and configuration for a
@@ -321,6 +331,17 @@ class QueryCtx : public std::enable_shared_from_this<QueryCtx> {
     traceCtxProvider_ = std::move(provider);
   }
 
+  using ScanBatchCallback = std::function<void(const ScanBatchEvent&)>;
+
+  /// Sets an optional callback fired by TableScan after each non-empty batch.
+  void setScanBatchCallback(ScanBatchCallback callback) {
+    scanBatchCallback_ = std::move(callback);
+  }
+
+  const ScanBatchCallback& scanBatchCallback() const {
+    return scanBatchCallback_;
+  }
+
   /// Store a per-query registry override. Each subsystem defines its own key
   /// (e.g., "connectors", "vectorFunctions"). The registry is stored as a
   /// type-erased shared_ptr; callers must use the same type T for setRegistry
@@ -476,6 +497,9 @@ class QueryCtx : public std::enable_shared_from_this<QueryCtx> {
 
   // A function that constructs a custom trace ctx object.
   TraceCtxProvider traceCtxProvider_;
+
+  // Optional per-batch scan stats callback.
+  ScanBatchCallback scanBatchCallback_;
 
   // Type-erased registry entry for per-query overrides.
   struct RegistryEntry {

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -195,6 +195,8 @@ RowVectorPtr TableScan::getOutput() {
     const auto estimatedRowSize = dataSource_->estimatedRowSize();
     const int32_t readBatchSize = calculateBatchSize(estimatedRowSize);
 
+    const auto prevCompletedRows = dataSource_->getCompletedRows();
+
     uint64_t ioTimeUs{0};
     std::optional<RowVectorPtr> dataOptional;
     {
@@ -229,6 +231,18 @@ RowVectorPtr TableScan::getOutput() {
             flatSize = data->estimateFlatSize();
           }
           lockedStats->addInputVector(flatSize, data->size());
+          const auto completedRowsDelta =
+              dataSource_->getCompletedRows() - prevCompletedRows;
+          if (completedRowsDelta > 0) {
+            if (const auto& callback = operatorCtx_->driverCtx()
+                                           ->task->queryCtx()
+                                           ->scanBatchCallback()) {
+              callback(
+                  {.numRows = completedRowsDelta,
+                   .wallTimeMicros = ioTimeUs,
+                   .tableName = tableHandle_->name()});
+            }
+          }
           maxFilteringRatio_ = std::max(
               {maxFilteringRatio_,
                1.0 * data->size() / readBatchSize,

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -6781,5 +6781,43 @@ TEST_F(TableScanTest, fileFormatRuntimeStats) {
   ASSERT_EQ(stats.at("fileFormat.dwrf").sum, 3);
 }
 
+TEST_F(TableScanTest, scanBatchCallback) {
+  auto vectors = makeVectors(3, 1'000);
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->getPath(), vectors);
+
+  uint64_t totalRows{0};
+  uint64_t callbackCount{0};
+  std::string receivedTableName;
+  auto queryCtx = core::QueryCtx::create(executor_.get());
+  queryCtx->setScanBatchCallback([&](const core::ScanBatchEvent& event) {
+    totalRows += event.numRows;
+    receivedTableName = std::string(event.tableName);
+    ++callbackCount;
+  });
+
+  auto plan = tableScanNode();
+  auto task = AssertQueryBuilder(plan)
+                  .splits(makeHiveConnectorSplits({filePath}))
+                  .queryCtx(queryCtx)
+                  .copyResults(pool_.get());
+
+  EXPECT_GT(totalRows, 0);
+  EXPECT_GT(callbackCount, 0);
+  EXPECT_FALSE(receivedTableName.empty());
+}
+
+TEST_F(TableScanTest, scanBatchCallbackNotSetIsNoOp) {
+  auto vectors = makeVectors(3, 1'000);
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->getPath(), vectors);
+
+  auto plan = tableScanNode();
+  auto result = AssertQueryBuilder(plan)
+                    .splits(makeHiveConnectorSplits({filePath}))
+                    .copyResults(pool_.get());
+  EXPECT_GT(result->size(), 0);
+}
+
 } // namespace
 } // namespace facebook::velox::exec


### PR DESCRIPTION
Summary:

Add an optional per-batch scan statistics callback to Velox's TableScan
operator via QueryCtx. The callback fires after each non-empty batch with
the completed row count delta, wall time, and table name.

This enables accurate per-batch scan statistics reporting without polling,
matching the push-model semantics of existing scan callbacks in the
execution stack.

Changes:
- Add ScanBatchEvent struct and ScanBatchCb callback to QueryCtx
- Fire callback in TableScan::getOutput() with completed rows delta
  (from getCompletedRows()), wall time (microseconds from existing
  MicrosecondTimer), and table name (from tableHandle_->name())
- Wire callback adapter in VeloxBatchCursor for HiveConnector path with
  mutex for kParallel thread safety

Follows existing Velox callback patterns (CallbackSink::Consumer,
UpdateAndCheckTraceLimitCB, HiveColumnHandle::postProcessor).

Reviewed By: Yuhta

Differential Revision: D104889992


