### PR TITLE
fix(parquet): LIST/MAP reader: null buffer size() stale after ensureCapacity

### DIFF
--- a/velox/dwio/parquet/reader/ParquetData.h
+++ b/velox/dwio/parquet/reader/ParquetData.h
@@ -113,6 +113,9 @@ class ParquetData : public dwio::common::FormatData {
     presetNulls_ = nulls;
     presetNullsSize_ = numValues;
     presetNullsConsumed_ = 0;
+    if (nulls) {
+      nulls->setSize(bits::nbytes(numValues));
+    }
   }
 
   int32_t presetNullsLeft() const {
@@ -140,6 +143,7 @@ class ParquetData : public dwio::common::FormatData {
             bits,
             0,
             numValues);
+        nulls->setSize(bits::nbytes(numValues));
         presetNullsConsumed_ += numValues;
       }
       return;

--- a/velox/dwio/parquet/tests/ParquetTestBase.cpp
+++ b/velox/dwio/parquet/tests/ParquetTestBase.cpp
@@ -250,6 +250,30 @@ dwio::common::MemorySink* ParquetTestBase::write(
 }
 
 dwio::common::MemorySink* ParquetTestBase::write(
+    const std::vector<RowVectorPtr>& batches,
+    const WriterOptions& writerOptions,
+    const RowTypePtr& rowType) {
+  VELOX_CHECK(!batches.empty());
+  auto sink = std::make_unique<dwio::common::MemorySink>(
+      200 * 1024 * 1024,
+      dwio::common::FileSink::Options{.pool = leafPool_.get()});
+  auto* sinkPtr = sink.get();
+  const auto& resolvedRowType =
+      rowType != nullptr ? rowType : batches[0]->rowType();
+  auto writer =
+      std::make_unique<Writer>(std::move(sink), writerOptions, resolvedRowType);
+  for (size_t i = 0; i < batches.size(); ++i) {
+    writer->write(batches[i]);
+    if (i + 1 < batches.size()) {
+      writer->flush();
+    }
+  }
+  writer->close();
+  writers_.push_back(std::move(writer));
+  return sinkPtr;
+}
+
+dwio::common::MemorySink* ParquetTestBase::write(
     const RowVectorPtr& data,
     std::unordered_map<std::string, std::string> configFromFile,
     std::unordered_map<std::string, std::string> sessionProperties) {

--- a/velox/dwio/parquet/tests/ParquetTestBase.cpp
+++ b/velox/dwio/parquet/tests/ParquetTestBase.cpp
@@ -251,17 +251,14 @@ dwio::common::MemorySink* ParquetTestBase::write(
 
 dwio::common::MemorySink* ParquetTestBase::write(
     const std::vector<RowVectorPtr>& batches,
-    const WriterOptions& writerOptions,
-    const RowTypePtr& rowType) {
+    const WriterOptions& writerOptions) {
   VELOX_CHECK(!batches.empty());
   auto sink = std::make_unique<dwio::common::MemorySink>(
       200 * 1024 * 1024,
       dwio::common::FileSink::Options{.pool = leafPool_.get()});
   auto* sinkPtr = sink.get();
-  const auto& resolvedRowType =
-      rowType != nullptr ? rowType : batches[0]->rowType();
-  auto writer =
-      std::make_unique<Writer>(std::move(sink), writerOptions, resolvedRowType);
+  auto writer = std::make_unique<Writer>(
+      std::move(sink), writerOptions, batches[0]->rowType());
   for (size_t i = 0; i < batches.size(); ++i) {
     writer->write(batches[i]);
     if (i + 1 < batches.size()) {

--- a/velox/dwio/parquet/tests/ParquetTestBase.h
+++ b/velox/dwio/parquet/tests/ParquetTestBase.h
@@ -212,6 +212,11 @@ class ParquetTestBase : public testing::Test,
       const RowTypePtr& rowType = nullptr);
 
   dwio::common::MemorySink* write(
+      const std::vector<RowVectorPtr>& batches,
+      const WriterOptions& writerOptions,
+      const RowTypePtr& rowType = nullptr);
+
+  dwio::common::MemorySink* write(
       const RowVectorPtr& data,
       std::unordered_map<std::string, std::string> configFromFile = {},
       std::unordered_map<std::string, std::string> sessionProperties = {});

--- a/velox/dwio/parquet/tests/ParquetTestBase.h
+++ b/velox/dwio/parquet/tests/ParquetTestBase.h
@@ -211,10 +211,13 @@ class ParquetTestBase : public testing::Test,
       const WriterOptions& writerOptions,
       const RowTypePtr& rowType = nullptr);
 
+  /// Writes each batch as a separate Parquet row group by flushing between
+  /// batches. Uses batches[0]->rowType() as the file schema. Configure
+  /// WriterOptions (e.g. flushPolicyFactory) so batch sizes are not split
+  /// further by the writer.
   dwio::common::MemorySink* write(
       const std::vector<RowVectorPtr>& batches,
-      const WriterOptions& writerOptions,
-      const RowTypePtr& rowType = nullptr);
+      const WriterOptions& writerOptions);
 
   dwio::common::MemorySink* write(
       const RowVectorPtr& data,

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -2022,38 +2022,42 @@ TEST_F(ParquetReaderTest, thriftMemoryReleasedForSkippedRowGroups) {
 // bits::nbytes(numLists). ensureCapacity only guarantees capacity; without an
 // explicit setSize, logical size can stay stale for the current batch.
 //
-// This test exercises both LIST and MAP with two row groups:
-// RG1: 3336 rows.
-// RG2: 4096 rows.
+// This test exercises both LIST and MAP with two row groups. RG1 must be
+// smaller than RG2 so the null buffer's logical size is insufficient for RG2,
+// but the allocation must round up to a capacity large enough for reuse.
 TEST_F(ParquetReaderTest, nullBufferSizeAcrossRowGroups) {
   constexpr vector_size_t kFirstRowGroupRows = 3336;
   constexpr vector_size_t kSecondRowGroupRows = 4096;
   constexpr vector_size_t kNumRows = kFirstRowGroupRows + kSecondRowGroupRows;
-  // Observed nulls buffer capacity after ensureCapacity + memory pool rounding.
-  constexpr int64_t kExpectedNullsCapacity = 672;
 
   auto assertNullBufferSizeAcrossBatches =
       [&](const RowTypePtr& rowType, dwio::common::RowReader& rowReader) {
-        auto readBatch = [&](vector_size_t batchSize)
-            -> std::pair<VectorPtr, vector_size_t> {
-          VectorPtr result = BaseVector::create(rowType, 0, leafPool_.get());
-          const auto numRead = rowReader.next(batchSize, result);
-          const auto& column = BaseVector::loadedVectorShared(
-              result->asUnchecked<RowVector>()->childAt(0));
-          return {column, numRead};
-        };
+        VectorPtr result = BaseVector::create(rowType, 0, leafPool_.get());
+        const auto numRead = rowReader.next(kFirstRowGroupRows, result);
+        ASSERT_EQ(numRead, kFirstRowGroupRows);
+        const auto& column = BaseVector::loadedVectorShared(
+            result->asUnchecked<RowVector>()->childAt(0));
+        ASSERT_TRUE(column->nulls()) << "Test data must contain nulls";
 
-        auto assertBatch = [&](vector_size_t batchSize) {
-          SCOPED_TRACE(fmt::format("batchSize={}", batchSize));
-          auto [column, numRead] = readBatch(batchSize);
-          ASSERT_EQ(numRead, batchSize);
-          ASSERT_TRUE(column->nulls()) << "Test data must contain nulls";
-          EXPECT_EQ(column->nulls()->capacity(), kExpectedNullsCapacity);
-          EXPECT_NO_THROW(column->validate({}));
-        };
+        auto nulls = column->nulls();
+        // Without the fix, this stale size would persist into RG2 and cause a
+        // crash.
+        ASSERT_LT(nulls->size(), bits::nbytes(kSecondRowGroupRows))
+            << "RG1 null buffer must be smaller than what RG2 needs";
+        // Buffer must have enough physical capacity to be reused for RG2,
+        // otherwise the pool reallocates and the bug doesn't trigger.
+        ASSERT_GE(nulls->capacity(), bits::nbytes(kSecondRowGroupRows))
+            << "RG1 null buffer capacity must be large enough for RG2 reuse";
+        EXPECT_NO_THROW(column->validate({}));
 
-        assertBatch(kFirstRowGroupRows);
-        assertBatch(kSecondRowGroupRows);
+        SCOPED_TRACE(fmt::format("batchSize={}", kSecondRowGroupRows));
+        result = BaseVector::create(rowType, 0, leafPool_.get());
+        const auto numRead2 = rowReader.next(kSecondRowGroupRows, result);
+        ASSERT_EQ(numRead2, kSecondRowGroupRows);
+        const auto& column2 = BaseVector::loadedVectorShared(
+            result->asUnchecked<RowVector>()->childAt(0));
+        ASSERT_TRUE(column2->nulls()) << "Test data must contain nulls";
+        EXPECT_NO_THROW(column2->validate({}));
       };
 
   auto runCase = [&](std::string_view traceName,
@@ -2068,20 +2072,14 @@ TEST_F(ParquetReaderTest, nullBufferSizeAcrossRowGroups) {
       return std::make_unique<DefaultFlushPolicy>(
           kSecondRowGroupRows, kBytesInRowGroup);
     };
-    auto sink = std::make_unique<MemorySink>(
-        200 * 1024 * 1024, FileSink::Options{.pool = leafPool_.get()});
-    auto* sinkPtr = sink.get();
-    auto writer = std::make_unique<parquet::Writer>(
-        std::move(sink), writerOptions, rowType);
-    writer->write(
-        makeRowVector({"a"}, {columnData->slice(0, kFirstRowGroupRows)}));
-    writer->flush();
-    writer->write(makeRowVector(
-        {"a"}, {columnData->slice(kFirstRowGroupRows, kSecondRowGroupRows)}));
-    writer->close();
-    writers_.push_back(std::move(writer));
-
-    auto [reader, rowReader] = readerBuilder(*sinkPtr, rowType).build();
+    auto* sink = write(
+        {makeRowVector({"a"}, {columnData->slice(0, kFirstRowGroupRows)}),
+         makeRowVector(
+             {"a"},
+             {columnData->slice(kFirstRowGroupRows, kSecondRowGroupRows)})},
+        writerOptions,
+        rowType);
+    auto [reader, rowReader] = readerBuilder(*sink, rowType).build();
     ASSERT_EQ(reader->fileMetaData().numRowGroups(), 2);
     ASSERT_EQ(reader->fileMetaData().rowGroup(0).numRows(), kFirstRowGroupRows);
     ASSERT_EQ(
@@ -2089,30 +2087,22 @@ TEST_F(ParquetReaderTest, nullBufferSizeAcrossRowGroups) {
     assertNullBufferSizeAcrossBatches(rowType, *rowReader);
   };
 
-  runCase(
-      "list",
-      ROW("a", ARRAY(INTEGER())),
-      makeArrayVector<int32_t>(
-          kNumRows,
-          [](vector_size_t /*rowIndex*/) { return 1; },
-          [](vector_size_t rowIndex, vector_size_t elementIndex) {
-            return rowIndex * 2 + elementIndex;
-          },
-          [&](vector_size_t rowIndex) {
-            return rowIndex == 100 || rowIndex == kFirstRowGroupRows + 100 ||
-                rowIndex == kFirstRowGroupRows + 200;
-          }));
+  // kNumRows 1-element arrays, 3 of which are null — one in RG1, two in RG2.
+  auto arrays = makeArrayVector<int32_t>(
+      kNumRows, [](auto) { return 1; }, [](auto i) { return i; });
+  arrays->setNull(100, true);
+  arrays->setNull(kFirstRowGroupRows + 100, true);
+  arrays->setNull(kFirstRowGroupRows + 200, true);
+  runCase("list", ROW("a", ARRAY(INTEGER())), arrays);
 
-  runCase(
-      "map",
-      ROW("a", MAP(INTEGER(), INTEGER())),
-      makeMapVector<int32_t, int32_t>(
-          kNumRows,
-          [](vector_size_t /*rowIndex*/) { return 1; },
-          [](vector_size_t elementIndex) { return elementIndex; },
-          [](vector_size_t elementIndex) { return elementIndex + 1000; },
-          [&](vector_size_t rowIndex) {
-            return rowIndex == 100 || rowIndex == kFirstRowGroupRows + 100 ||
-                rowIndex == kFirstRowGroupRows + 200;
-          }));
+  // kNumRows 1-element maps, 3 of which are null — one in RG1, two in RG2.
+  auto maps = makeMapVector<int32_t, int32_t>(
+      kNumRows,
+      [](auto) { return 1; },
+      [](auto i) { return i; },
+      [](auto i) { return i; });
+  maps->setNull(100, true);
+  maps->setNull(kFirstRowGroupRows + 100, true);
+  maps->setNull(kFirstRowGroupRows + 200, true);
+  runCase("map", ROW("a", MAP(INTEGER(), INTEGER())), maps);
 }

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -2017,3 +2017,93 @@ TEST_F(ParquetReaderTest, thriftMemoryReleasedForSkippedRowGroups) {
 
   EXPECT_EQ(leafPool_->usedBytes(), initialUsage);
 }
+
+// ParquetData::setNulls must keep nullsInReadRange_->size() in sync with
+// bits::nbytes(numLists). ensureCapacity only guarantees capacity; without an
+// explicit setSize, logical size can stay stale for the current batch.
+//
+// This test exercises both LIST and MAP with two row groups:
+// RG1: 4096 rows.
+// RG2: 3336 rows.
+TEST_F(ParquetReaderTest, nullBufferSizeAcrossRowGroups) {
+  constexpr vector_size_t kFirstRowGroupRows = 4096;
+  constexpr vector_size_t kSecondRowGroupRows = 3336;
+  constexpr vector_size_t kNumRows = kFirstRowGroupRows + kSecondRowGroupRows;
+
+  auto assertNullBufferSizeAcrossBatches =
+      [&](const RowTypePtr& rowType, dwio::common::RowReader& rowReader) {
+        auto readBatch = [&](vector_size_t batchSize)
+            -> std::pair<VectorPtr, vector_size_t> {
+          VectorPtr result = BaseVector::create(rowType, 0, leafPool_.get());
+          const auto numRead = rowReader.next(batchSize, result);
+          const auto& column = BaseVector::loadedVectorShared(
+              result->asUnchecked<RowVector>()->childAt(0));
+          return {column, numRead};
+        };
+
+        auto assertBatch = [&](vector_size_t batchSize, bool exactNullSize) {
+          SCOPED_TRACE(fmt::format("batchSize={}", batchSize));
+          auto [column, numRead] = readBatch(batchSize);
+          ASSERT_EQ(numRead, batchSize);
+          ASSERT_TRUE(column->nulls()) << "Test data must contain nulls";
+          if (exactNullSize) {
+            EXPECT_EQ(column->nulls()->size(), bits::nbytes(numRead));
+          } else {
+            EXPECT_GE(column->nulls()->size(), bits::nbytes(numRead));
+          }
+          EXPECT_NO_THROW(column->validate({}));
+        };
+
+        assertBatch(kFirstRowGroupRows, false);
+        assertBatch(kSecondRowGroupRows, true);
+      };
+
+  auto runCase = [&](std::string_view traceName,
+                     const RowTypePtr& rowType,
+                     const VectorPtr& columnData) {
+    SCOPED_TRACE(traceName);
+    parquet::WriterOptions writerOptions;
+    writerOptions.memoryPool = rootPool_.get();
+    writerOptions.flushPolicyFactory = [kFirstRowGroupRows]() {
+      return std::make_unique<parquet::LambdaFlushPolicy>(
+          kFirstRowGroupRows, kBytesInRowGroup, []() { return false; });
+    };
+    auto data = makeRowVector({"a"}, {columnData});
+    auto* sink = write(data, writerOptions);
+    auto [reader, rowReader] = readerBuilder(*sink, rowType).build();
+    ASSERT_EQ(reader->fileMetaData().numRowGroups(), 2);
+    ASSERT_EQ(reader->fileMetaData().rowGroup(0).numRows(), kFirstRowGroupRows);
+    ASSERT_EQ(
+        reader->fileMetaData().rowGroup(1).numRows(), kSecondRowGroupRows);
+    assertNullBufferSizeAcrossBatches(rowType, *rowReader);
+  };
+
+  runCase(
+      "list",
+      ROW("a", ARRAY(INTEGER())),
+      makeArrayVector<int32_t>(
+          kNumRows,
+          [&](vector_size_t rowIndex) {
+            return rowIndex < kFirstRowGroupRows ? 1 : 2;
+          },
+          [](vector_size_t rowIndex, vector_size_t elementIndex) {
+            return rowIndex * 2 + elementIndex;
+          },
+          [&](vector_size_t rowIndex) {
+            return rowIndex == 100 || rowIndex == kFirstRowGroupRows + 100;
+          }));
+
+  runCase(
+      "map",
+      ROW("a", MAP(INTEGER(), INTEGER())),
+      makeMapVector<int32_t, int32_t>(
+          kNumRows,
+          [&](vector_size_t rowIndex) {
+            return rowIndex < kFirstRowGroupRows ? 1 : 2;
+          },
+          [](vector_size_t elementIndex) { return elementIndex; },
+          [](vector_size_t elementIndex) { return elementIndex + 1000; },
+          [&](vector_size_t rowIndex) {
+            return rowIndex == 100 || rowIndex == kFirstRowGroupRows + 100;
+          }));
+}

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -2023,12 +2023,14 @@ TEST_F(ParquetReaderTest, thriftMemoryReleasedForSkippedRowGroups) {
 // explicit setSize, logical size can stay stale for the current batch.
 //
 // This test exercises both LIST and MAP with two row groups:
-// RG1: 4096 rows.
-// RG2: 3336 rows.
+// RG1: 3336 rows.
+// RG2: 4096 rows.
 TEST_F(ParquetReaderTest, nullBufferSizeAcrossRowGroups) {
-  constexpr vector_size_t kFirstRowGroupRows = 4096;
-  constexpr vector_size_t kSecondRowGroupRows = 3336;
+  constexpr vector_size_t kFirstRowGroupRows = 3336;
+  constexpr vector_size_t kSecondRowGroupRows = 4096;
   constexpr vector_size_t kNumRows = kFirstRowGroupRows + kSecondRowGroupRows;
+  // Observed nulls buffer capacity after ensureCapacity + memory pool rounding.
+  constexpr int64_t kExpectedNullsCapacity = 672;
 
   auto assertNullBufferSizeAcrossBatches =
       [&](const RowTypePtr& rowType, dwio::common::RowReader& rowReader) {
@@ -2041,21 +2043,17 @@ TEST_F(ParquetReaderTest, nullBufferSizeAcrossRowGroups) {
           return {column, numRead};
         };
 
-        auto assertBatch = [&](vector_size_t batchSize, bool exactNullSize) {
+        auto assertBatch = [&](vector_size_t batchSize) {
           SCOPED_TRACE(fmt::format("batchSize={}", batchSize));
           auto [column, numRead] = readBatch(batchSize);
           ASSERT_EQ(numRead, batchSize);
           ASSERT_TRUE(column->nulls()) << "Test data must contain nulls";
-          if (exactNullSize) {
-            EXPECT_EQ(column->nulls()->size(), bits::nbytes(numRead));
-          } else {
-            EXPECT_GE(column->nulls()->size(), bits::nbytes(numRead));
-          }
+          EXPECT_EQ(column->nulls()->capacity(), kExpectedNullsCapacity);
           EXPECT_NO_THROW(column->validate({}));
         };
 
-        assertBatch(kFirstRowGroupRows, false);
-        assertBatch(kSecondRowGroupRows, true);
+        assertBatch(kFirstRowGroupRows);
+        assertBatch(kSecondRowGroupRows);
       };
 
   auto runCase = [&](std::string_view traceName,
@@ -2064,13 +2062,26 @@ TEST_F(ParquetReaderTest, nullBufferSizeAcrossRowGroups) {
     SCOPED_TRACE(traceName);
     parquet::WriterOptions writerOptions;
     writerOptions.memoryPool = rootPool_.get();
-    writerOptions.flushPolicyFactory = [kFirstRowGroupRows]() {
-      return std::make_unique<parquet::LambdaFlushPolicy>(
-          kFirstRowGroupRows, kBytesInRowGroup, []() { return false; });
+    // Use the second row group size as writeTable max row group length so the
+    // 4096-row batch is not split again by Arrow.
+    writerOptions.flushPolicyFactory = [kSecondRowGroupRows]() {
+      return std::make_unique<DefaultFlushPolicy>(
+          kSecondRowGroupRows, kBytesInRowGroup);
     };
-    auto data = makeRowVector({"a"}, {columnData});
-    auto* sink = write(data, writerOptions);
-    auto [reader, rowReader] = readerBuilder(*sink, rowType).build();
+    auto sink = std::make_unique<MemorySink>(
+        200 * 1024 * 1024, FileSink::Options{.pool = leafPool_.get()});
+    auto* sinkPtr = sink.get();
+    auto writer = std::make_unique<parquet::Writer>(
+        std::move(sink), writerOptions, rowType);
+    writer->write(
+        makeRowVector({"a"}, {columnData->slice(0, kFirstRowGroupRows)}));
+    writer->flush();
+    writer->write(makeRowVector(
+        {"a"}, {columnData->slice(kFirstRowGroupRows, kSecondRowGroupRows)}));
+    writer->close();
+    writers_.push_back(std::move(writer));
+
+    auto [reader, rowReader] = readerBuilder(*sinkPtr, rowType).build();
     ASSERT_EQ(reader->fileMetaData().numRowGroups(), 2);
     ASSERT_EQ(reader->fileMetaData().rowGroup(0).numRows(), kFirstRowGroupRows);
     ASSERT_EQ(
@@ -2083,14 +2094,13 @@ TEST_F(ParquetReaderTest, nullBufferSizeAcrossRowGroups) {
       ROW("a", ARRAY(INTEGER())),
       makeArrayVector<int32_t>(
           kNumRows,
-          [&](vector_size_t rowIndex) {
-            return rowIndex < kFirstRowGroupRows ? 1 : 2;
-          },
+          [](vector_size_t /*rowIndex*/) { return 1; },
           [](vector_size_t rowIndex, vector_size_t elementIndex) {
             return rowIndex * 2 + elementIndex;
           },
           [&](vector_size_t rowIndex) {
-            return rowIndex == 100 || rowIndex == kFirstRowGroupRows + 100;
+            return rowIndex == 100 || rowIndex == kFirstRowGroupRows + 100 ||
+                rowIndex == kFirstRowGroupRows + 200;
           }));
 
   runCase(
@@ -2098,12 +2108,11 @@ TEST_F(ParquetReaderTest, nullBufferSizeAcrossRowGroups) {
       ROW("a", MAP(INTEGER(), INTEGER())),
       makeMapVector<int32_t, int32_t>(
           kNumRows,
-          [&](vector_size_t rowIndex) {
-            return rowIndex < kFirstRowGroupRows ? 1 : 2;
-          },
+          [](vector_size_t /*rowIndex*/) { return 1; },
           [](vector_size_t elementIndex) { return elementIndex; },
           [](vector_size_t elementIndex) { return elementIndex + 1000; },
           [&](vector_size_t rowIndex) {
-            return rowIndex == 100 || rowIndex == kFirstRowGroupRows + 100;
+            return rowIndex == 100 || rowIndex == kFirstRowGroupRows + 100 ||
+                rowIndex == kFirstRowGroupRows + 200;
           }));
 }

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -2030,40 +2030,42 @@ TEST_F(ParquetReaderTest, nullBufferSizeAcrossRowGroups) {
   constexpr vector_size_t kSecondRowGroupRows = 4096;
   constexpr vector_size_t kNumRows = kFirstRowGroupRows + kSecondRowGroupRows;
 
-  auto assertNullBufferSizeAcrossBatches =
-      [&](const RowTypePtr& rowType, dwio::common::RowReader& rowReader) {
-        VectorPtr result = BaseVector::create(rowType, 0, leafPool_.get());
-        const auto numRead = rowReader.next(kFirstRowGroupRows, result);
-        ASSERT_EQ(numRead, kFirstRowGroupRows);
-        const auto& column = BaseVector::loadedVectorShared(
-            result->asUnchecked<RowVector>()->childAt(0));
-        ASSERT_TRUE(column->nulls()) << "Test data must contain nulls";
+  auto assertNullBufferSize = [&](const RowTypePtr& rowType,
+                                  dwio::common::RowReader& rowReader) {
+    {
+      SCOPED_TRACE(fmt::format("batchSize={}", kFirstRowGroupRows));
+      VectorPtr result = BaseVector::create(rowType, 0, leafPool_.get());
+      const auto numRead = rowReader.next(kFirstRowGroupRows, result);
+      ASSERT_EQ(numRead, kFirstRowGroupRows);
+      const auto& column = BaseVector::loadedVectorShared(
+          result->asUnchecked<RowVector>()->childAt(0));
+      ASSERT_TRUE(column->nulls()) << "Test data must contain nulls";
 
-        auto nulls = column->nulls();
-        // Without the fix, this stale size would persist into RG2 and cause a
-        // crash.
-        ASSERT_LT(nulls->size(), bits::nbytes(kSecondRowGroupRows))
-            << "RG1 null buffer must be smaller than what RG2 needs";
-        // Buffer must have enough physical capacity to be reused for RG2,
-        // otherwise the pool reallocates and the bug doesn't trigger.
-        ASSERT_GE(nulls->capacity(), bits::nbytes(kSecondRowGroupRows))
-            << "RG1 null buffer capacity must be large enough for RG2 reuse";
-        EXPECT_NO_THROW(column->validate({}));
+      auto nulls = column->nulls();
+      // Without the fix, this stale size would persist into RG2 and cause a
+      // crash.
+      ASSERT_LT(nulls->size(), bits::nbytes(kSecondRowGroupRows))
+          << "RG1 null buffer must be smaller than what RG2 needs";
+      // Buffer must have enough physical capacity to be reused for RG2,
+      // otherwise the pool reallocates and the bug doesn't trigger.
+      ASSERT_GE(nulls->capacity(), bits::nbytes(kSecondRowGroupRows))
+          << "RG1 null buffer capacity must be large enough for RG2 reuse";
+      EXPECT_NO_THROW(column->validate({}));
+    }
+    {
+      SCOPED_TRACE(fmt::format("batchSize={}", kSecondRowGroupRows));
+      VectorPtr result = BaseVector::create(rowType, 0, leafPool_.get());
+      const auto numRead = rowReader.next(kSecondRowGroupRows, result);
+      ASSERT_EQ(numRead, kSecondRowGroupRows);
+      const auto& column = BaseVector::loadedVectorShared(
+          result->asUnchecked<RowVector>()->childAt(0));
+      ASSERT_TRUE(column->nulls()) << "Test data must contain nulls";
+      EXPECT_NO_THROW(column->validate({}));
+    }
+  };
 
-        SCOPED_TRACE(fmt::format("batchSize={}", kSecondRowGroupRows));
-        result = BaseVector::create(rowType, 0, leafPool_.get());
-        const auto numRead2 = rowReader.next(kSecondRowGroupRows, result);
-        ASSERT_EQ(numRead2, kSecondRowGroupRows);
-        const auto& column2 = BaseVector::loadedVectorShared(
-            result->asUnchecked<RowVector>()->childAt(0));
-        ASSERT_TRUE(column2->nulls()) << "Test data must contain nulls";
-        EXPECT_NO_THROW(column2->validate({}));
-      };
-
-  auto runCase = [&](std::string_view traceName,
-                     const RowTypePtr& rowType,
-                     const VectorPtr& columnData) {
-    SCOPED_TRACE(traceName);
+  auto verifyType = [&](const RowTypePtr& rowType,
+                        const VectorPtr& columnData) {
     parquet::WriterOptions writerOptions;
     writerOptions.memoryPool = rootPool_.get();
     // Use the second row group size as writeTable max row group length so the
@@ -2077,32 +2079,40 @@ TEST_F(ParquetReaderTest, nullBufferSizeAcrossRowGroups) {
          makeRowVector(
              {"a"},
              {columnData->slice(kFirstRowGroupRows, kSecondRowGroupRows)})},
-        writerOptions,
-        rowType);
+        writerOptions);
     auto [reader, rowReader] = readerBuilder(*sink, rowType).build();
     ASSERT_EQ(reader->fileMetaData().numRowGroups(), 2);
     ASSERT_EQ(reader->fileMetaData().rowGroup(0).numRows(), kFirstRowGroupRows);
     ASSERT_EQ(
         reader->fileMetaData().rowGroup(1).numRows(), kSecondRowGroupRows);
-    assertNullBufferSizeAcrossBatches(rowType, *rowReader);
+    assertNullBufferSize(rowType, *rowReader);
+  };
+
+  const auto isNullRow = [](vector_size_t row) {
+    return row == 100 || row == kFirstRowGroupRows + 100 ||
+        row == kFirstRowGroupRows + 200;
   };
 
   // kNumRows 1-element arrays, 3 of which are null — one in RG1, two in RG2.
   auto arrays = makeArrayVector<int32_t>(
-      kNumRows, [](auto) { return 1; }, [](auto i) { return i; });
-  arrays->setNull(100, true);
-  arrays->setNull(kFirstRowGroupRows + 100, true);
-  arrays->setNull(kFirstRowGroupRows + 200, true);
-  runCase("list", ROW("a", ARRAY(INTEGER())), arrays);
+      kNumRows,
+      [&](auto row) { return isNullRow(row) ? 0 : 1; },
+      [](auto i) { return i; },
+      isNullRow);
+  {
+    SCOPED_TRACE("list");
+    verifyType(ROW("a", ARRAY(INTEGER())), arrays);
+  }
 
   // kNumRows 1-element maps, 3 of which are null — one in RG1, two in RG2.
   auto maps = makeMapVector<int32_t, int32_t>(
       kNumRows,
-      [](auto) { return 1; },
+      [&](auto row) { return isNullRow(row) ? 0 : 1; },
       [](auto i) { return i; },
-      [](auto i) { return i; });
-  maps->setNull(100, true);
-  maps->setNull(kFirstRowGroupRows + 100, true);
-  maps->setNull(kFirstRowGroupRows + 200, true);
-  runCase("map", ROW("a", MAP(INTEGER(), INTEGER())), maps);
+      [](auto i) { return i; },
+      isNullRow);
+  {
+    SCOPED_TRACE("map");
+    verifyType(ROW("a", MAP(INTEGER(), INTEGER())), maps);
+  }
 }


### PR DESCRIPTION
### Summary
Use velox from gluten:
Error Code: INVALID_STATE
Reason: (512 vs. 424) Length must be less than or equal to 424.
Retriable: False
Expression: bytesLength <= buffer->size() - bytesOffset
Function: sliceBufferZeroCopy
File: /home/lifulong/incubator-gluten/ep/build-velox/build/velox_ep/velox/buffer/Buffer.cpp

When reading Parquet LIST/MAP columns, nullsInReadRange_ may carry a stale Buffer::size() across batches.
ensureCapacity() guarantees capacity but may not synchronize logical size for the current numLists.
ParquetData::setNulls(...) stores null-buffer pointer but does not call setSize(bits::nbytes(numLists)).
As a result, a later full batch (e.g., 4096 rows, needs 512 bytes) may see nulls->size() still at a smaller stale value (e.g., 424), triggering failures in downstream paths that rely on null bitmap size bounds (e.g., Buffer::slice<bool>).

### Root cause
In ListColumnReader::setLengthsFromRepDefs (and similarly Map):
```
dwio::common::ensureCapacity<uint64_t>(
    nullsInReadRange_, bits::nwords(numRepDefs + 1), memoryPool_);
// capacity is ensured, logical size may remain stale
auto numLists = pageReader.getLengthsAndNulls(...);
formatData_->as<ParquetData>().setNulls(nullsInReadRange(), numLists);
// pointer is set, but buffer size is not synchronized to numLists
size() therefore reflects prior allocation history, not current batch logical row count.
```

### Observed Diagnostic Sequence
From instrumented logs (same field, same reader lifecycle):

End of one row group has a short final batch:
numLists=3336, nullsInReadRange.size=424, cap=672
Next row group starts with a full batch:
numLists=4096, needNullBytes=512
nullsInReadRange.size remains 424 (cap still 672)
Downstream check fails:
NULLS_UNDERSIZE ... needNullBytes=512 nullsInReadRange.size=424
eventually fails in Buffer::slice<bool> / ArrayVector::slice

For the short batch (numLists=3336), execution hit a null-buffer reallocation path: the newly produced buffer had a logical size of 424 bytes (53 * 8), while alignment caused the physical allocation capacity to be 672 bytes.

