### PR TITLE
feat: Add Spark CAST(varchar as timestamp_utc)

### DIFF
--- a/velox/docs/functions/spark/conversion.rst
+++ b/velox/docs/functions/spark/conversion.rst
@@ -530,3 +530,23 @@ Valid examples
   -- 2020-01-01 00:00:00 UTC in America/Los_Angeles is local 2019-12-31 16:00:00.
   -- TIMESTAMP_UTC stores that local time as epoch 1577808000.
   SELECT cast(timestamp '2020-01-01 00:00:00' as timestamp_ntz); -- 2019-12-31 16:00:00
+
+From VARCHAR
+^^^^^^^^^^^^
+
+Casting a string to timestamp_utc parses the input as a local timestamp,
+not subject to session timezone adjustment.
+Any timezone suffix in the string is accepted but ignored — only the
+parsed timestamp is stored.
+Leading and trailing whitespace is stripped before parsing.
+
+Valid examples
+
+::
+
+  SELECT cast('1970-01-01' as timestamp_ntz); -- 1970-01-01 00:00:00
+  SELECT cast('2000-01-01 12:21:56' as timestamp_ntz); -- 2000-01-01 12:21:56
+  SELECT cast('2015-03-18T12:03:17' as timestamp_ntz); -- 2015-03-18 12:03:17
+  SELECT cast('2015-03-18 12:03:17.123' as timestamp_ntz); -- 2015-03-18 12:03:17.123
+  SELECT cast('1970-01-01 00:00:00-08:00' as timestamp_ntz); -- 1970-01-01 00:00:00
+  SELECT cast('2015-03-18T12:03:17Z' as timestamp_ntz); -- 2015-03-18 12:03:17

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -222,7 +222,10 @@ void CastExpr::applyCastKernel(
         }
       }
       if constexpr (ToKind == TypeKind::TIMESTAMP) {
-        const auto castResult = hooks_->castStringToTimestamp(inputRowValue);
+        const bool adjustTimezone =
+            !result->type()->equivalent(*TIMESTAMP_UTC());
+        const auto castResult =
+            hooks_->castStringToTimestamp(inputRowValue, adjustTimezone);
         setResultOrStatus(castResult, row);
         return;
       }
@@ -717,7 +720,7 @@ void CastExpr::applyCastPrimitivesDispatch(
   }
 
   if constexpr (ToKind == TypeKind::TIMESTAMP) {
-    VELOX_DCHECK(toType->equivalent(*TIMESTAMP()));
+    verifyToTimestampCast(fromType, toType);
   }
 
   if (isSupportedFastUpcast(fromType, toType)) {

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -769,6 +769,23 @@ VectorPtr CastExpr::applyDecimal(
   return castResult;
 }
 
+bool CastExpr::verifyToTimestampCast(
+    const TypePtr& fromType,
+    const TypePtr& toType) {
+  bool isSupported = fromType->kind() == TypeKind::VARCHAR &&
+      toType->equivalent(*TIMESTAMP_UTC());
+  if (isSupported) {
+    VELOX_USER_CHECK(
+        hooks_->supportsTimestampUtc(),
+        "Cast from {} to {} is not supported",
+        fromType->toString(),
+        toType->toString());
+  } else {
+    VELOX_DCHECK(toType->equivalent(*TIMESTAMP()));
+  }
+  return isSupported;
+}
+
 void CastExpr::applyPeeled(
     const SelectivityVector& rows,
     const BaseVector& input,
@@ -876,6 +893,9 @@ void CastExpr::applyPeeled(
           fromType->toString(),
           toType->toString());
       result = applyTimestampTimestampUtcCast<true>(rows, context, input);
+    } else if (fromType->kind() == TypeKind::VARCHAR) {
+      applyCastPrimitivesDispatch<TypeKind::TIMESTAMP>(
+          fromType, toType, rows, context, input, result);
     } else {
       VELOX_UNSUPPORTED(
           "Cast from {} to {} is not supported",

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -295,6 +295,8 @@ class CastExpr : public SpecialForm {
       const BaseVector& input,
       VectorPtr& result);
 
+  bool verifyToTimestampCast(const TypePtr& fromType, const TypePtr& toType);
+
   VectorPtr applyTimestampToVarcharCast(
       const TypePtr& toType,
       const SelectivityVector& rows,

--- a/velox/expression/CastHooks.h
+++ b/velox/expression/CastHooks.h
@@ -44,8 +44,13 @@ class CastHooks {
  public:
   virtual ~CastHooks() = default;
 
+  /// Parses a string to a timestamp. When 'adjustTimezone' is true, applies
+  /// the session timezone to the parsed result. When false, the parsed
+  /// timestamp fields are stored as-is, not subject to session timezone
+  /// adjustment (used for TIMESTAMP UTC casts).
   virtual Expected<Timestamp> castStringToTimestamp(
-      const StringView& view) const = 0;
+      const StringView& view,
+      bool adjustTimezone) const = 0;
 
   virtual Expected<Timestamp> castIntToTimestamp(int64_t seconds) const = 0;
 

--- a/velox/expression/PrestoCastHooks.cpp
+++ b/velox/expression/PrestoCastHooks.cpp
@@ -39,7 +39,8 @@ PrestoCastHooks::PrestoCastHooks(const core::QueryConfig& config)
 }
 
 Expected<Timestamp> PrestoCastHooks::castStringToTimestamp(
-    const StringView& view) const {
+    const StringView& view,
+    bool /*adjustTimezone*/) const {
   const auto conversionResult = util::fromTimestampWithTimezoneString(
       view.data(),
       view.size(),

--- a/velox/expression/PrestoCastHooks.h
+++ b/velox/expression/PrestoCastHooks.h
@@ -28,7 +28,8 @@ class PrestoCastHooks : public CastHooks {
 
   // Uses the default implementation of 'castFromDateString'.
   Expected<Timestamp> castStringToTimestamp(
-      const StringView& view) const override;
+      const StringView& view,
+      bool adjustTimezone) const override;
 
   Expected<Timestamp> castIntToTimestamp(int64_t seconds) const override;
 

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
@@ -39,13 +39,18 @@ TimestampToStringOptions SparkCastHooks::timestampUtcToStringOptions() const {
 }
 
 Expected<Timestamp> SparkCastHooks::castStringToTimestamp(
-    const StringView& view) const {
+    const StringView& view,
+    bool adjustTimezone) const {
   auto conversionResult = util::fromTimestampWithTimezoneString(
       view.data(), view.size(), util::TimestampParseMode::kSparkCast);
   if (conversionResult.hasError()) {
     return folly::makeUnexpected(conversionResult.error());
   }
-
+  if (!adjustTimezone) {
+    // For TIMESTAMP UTC, ignore any timezone suffix and store the parsed
+    // timestamp fields as-is, not subject to session timezone adjustment.
+    return conversionResult.value().timestamp;
+  }
   auto sessionTimezone = config_.sessionTimezone().empty()
       ? nullptr
       : tz::locateZone(config_.sessionTimezone());

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.h
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.h
@@ -30,7 +30,8 @@ class SparkCastHooks : public exec::CastHooks {
 
   // TODO: Spark hook allows more string patterns than Presto.
   Expected<Timestamp> castStringToTimestamp(
-      const StringView& view) const override;
+      const StringView& view,
+      bool adjustTimezone) const override;
 
   /// When casting integral value as timestamp, the input is treated as the
   /// number of seconds since the epoch (1970-01-01 00:00:00 UTC).

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -695,6 +695,60 @@ class SparkCastExprTest : public functions::test::CastBaseTest {
          Timestamp(-8 * 3600, 0)});
   }
 
+  void testStringToTimestampUtc() {
+    // Basic cases: stored as-is, not subject to session timezone adjustment.
+    testCast(
+        makeNullableFlatVector<std::string>(
+            {"1970-01-01",
+             "1970-01-01 00:00:00",
+             "2000-01-01",
+             "2000-01-01 12:21:56",
+             "2015-03-18T12:03:17",
+             "2015-03-18 12:03:17.123"},
+            VARCHAR()),
+        makeNullableFlatVector<Timestamp>(
+            {Timestamp(0, 0),
+             Timestamp(0, 0),
+             Timestamp(946'684'800, 0),
+             Timestamp(946'729'316, 0),
+             Timestamp(1'426'680'197, 0),
+             Timestamp(1'426'680'197, 123'000'000)},
+            TIMESTAMP_UTC()));
+
+    // Timezone suffix is accepted but ignored.
+    testCast(
+        makeNullableFlatVector<std::string>(
+            {"1970-01-01 00:00:00-02:00",
+             "1970-01-01 00:00:00 +02:00",
+             "2015-03-18T12:03:17Z",
+             "2015-03-18 12:03:17 America/Los_Angeles"},
+            VARCHAR()),
+        makeNullableFlatVector<Timestamp>(
+            {Timestamp(0, 0),
+             Timestamp(0, 0),
+             Timestamp(1'426'680'197, 0),
+             Timestamp(1'426'680'197, 0)},
+            TIMESTAMP_UTC()));
+
+    // Session timezone does not affect TIMESTAMP_UTC.
+    SCOPE_EXIT {
+      setTimezone("");
+    };
+    setTimezone("Asia/Shanghai");
+    testCast(
+        makeNullableFlatVector<std::string>(
+            {"1970-01-01 00:00:00", "1970-01-01 08:00:00"}, VARCHAR()),
+        makeNullableFlatVector<Timestamp>(
+            {Timestamp(0, 0), Timestamp(28'800, 0)}, TIMESTAMP_UTC()));
+
+    // Leading and trailing whitespace is stripped before parsing.
+    testCast(
+        makeNullableFlatVector<std::string>(
+            {"\n\f\r\t\n\x1f 2000-01-01 12:21:56\v\x1c\x1d\x1e"}, VARCHAR()),
+        makeNullableFlatVector<Timestamp>(
+            {Timestamp(946'729'316, 0)}, TIMESTAMP_UTC()));
+  }
+
   void testStringToDate() {
     testCast<std::string, int32_t>(
         "date",
@@ -1458,6 +1512,10 @@ TEST_F(SparkCastExprTestAnsiOn, stringToTimestampInvalidThrows) {
   testInvalidTimestamp("2012-Oct-01");
 }
 
+TEST_F(SparkCastExprTestAnsiOn, stringToTimestampUtc) {
+  testStringToTimestampUtc();
+}
+
 TEST_F(SparkCastExprTestAnsiOn, stringToDate) {
   testStringToDate();
   auto testInvalidDate = [this](const std::string& value) {
@@ -1740,6 +1798,14 @@ TEST_F(SparkCastExprTestAnsiOff, stringToTimestamp) {
   testStringToTimestamp();
   testCast<std::string, Timestamp>(
       "timestamp", {"INVALID", "2012-Oct-01"}, {std::nullopt, std::nullopt});
+}
+
+TEST_F(SparkCastExprTestAnsiOff, stringToTimestampUtc) {
+  testStringToTimestampUtc();
+  // Invalid string produces null in non-ANSI mode.
+  testCast(
+      makeNullableFlatVector<std::string>({"INVALID"}, VARCHAR()),
+      makeNullableFlatVector<Timestamp>({std::nullopt}, TIMESTAMP_UTC()));
 }
 
 TEST_F(SparkCastExprTestAnsiOff, stringToDate) {


### PR DESCRIPTION
This PR adds support for casting VARCHAR to TIMESTAMP_UTC inside CastExpr.
TimestampUtcType (Velox's representation of Spark's TIMESTAMP_NTZ) stores timestamps without timezone information. The value is taken as-is with no session timezone adjustment applied. Accordingly, the cast parses the input string and stores only the timestamp, ignoring any timezone suffix in the input.

Related type PR: https://github.com/facebookincubator/velox/pull/17091
Related issue: https://github.com/facebookincubator/velox/issues/17087
Spark reference: [TimestampNTZType.scala](https://github.com/apache/spark/blob/master/sql/api/src/main/scala/org/apache/spark/sql/types/TimestampNTZType.scala)
Related cast PR ( TIMESTAMP UTC -> VARCHAR): https://github.com/facebookincubator/velox/pull/17514