### PR TITLE
fix(build): Cmake formatting for iceberg tests

### DIFF
--- a/velox/connectors/hive/iceberg/tests/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/tests/CMakeLists.txt
@@ -160,13 +160,8 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
     GTest::gtest_main
   )
 
-  add_executable(
-    velox_hive_writer_options_adapter_test WriterOptionsAdapterTest.cpp
-  )
-  add_test(
-    velox_hive_writer_options_adapter_test
-    velox_hive_writer_options_adapter_test
-  )
+  add_executable(velox_hive_writer_options_adapter_test WriterOptionsAdapterTest.cpp)
+  add_test(velox_hive_writer_options_adapter_test velox_hive_writer_options_adapter_test)
 
   target_link_libraries(
     velox_hive_writer_options_adapter_test


### PR DESCRIPTION
PR https://github.com/facebookincubator/velox/pull/17493 introduced some changes that run afoul of the formatting.

Though the actions show it did pass. Not clear how that passed but it now appears in all PRs bringing in this code.