### PR TITLE
feat: V3 DeleteFile typed fields + dataSequenceNumber on HiveIcebergSplit (Velox)

### DIFF
--- a/velox/connectors/hive/iceberg/DeletionVectorReader.cpp
+++ b/velox/connectors/hive/iceberg/DeletionVectorReader.cpp
@@ -55,25 +55,32 @@ void DeletionVectorReader::loadBitmap() {
   }
   loaded_ = true;
 
-  uint64_t blobOffset = 0;
-  uint64_t blobLength = dvFile_.fileSizeInBytes;
+  // Prefer the typed contentOffset / contentLength fields. The legacy
+  // bounds-map encoding (kDvOffsetFieldId / kDvLengthFieldId) is kept as a
+  // fallback for callers that have not migrated yet.
+  uint64_t blobOffset = static_cast<uint64_t>(dvFile_.contentOffset);
+  uint64_t blobLength = dvFile_.contentLength > 0
+      ? static_cast<uint64_t>(dvFile_.contentLength)
+      : dvFile_.fileSizeInBytes;
 
-  if (auto it = dvFile_.lowerBounds.find(kDvOffsetFieldId);
-      it != dvFile_.lowerBounds.end()) {
-    try {
-      blobOffset = std::stoull(it->second);
-    } catch (const std::exception& e) {
-      VELOX_FAIL(
-          "Failed to parse DV blob offset from bounds map: {}", e.what());
+  if (dvFile_.contentLength == 0) {
+    if (auto it = dvFile_.lowerBounds.find(kDvOffsetFieldId);
+        it != dvFile_.lowerBounds.end()) {
+      try {
+        blobOffset = std::stoull(it->second);
+      } catch (const std::exception& e) {
+        VELOX_FAIL(
+            "Failed to parse DV blob offset from bounds map: {}", e.what());
+      }
     }
-  }
-  if (auto it = dvFile_.upperBounds.find(kDvLengthFieldId);
-      it != dvFile_.upperBounds.end()) {
-    try {
-      blobLength = std::stoull(it->second);
-    } catch (const std::exception& e) {
-      VELOX_FAIL(
-          "Failed to parse DV blob length from bounds map: {}", e.what());
+    if (auto it = dvFile_.upperBounds.find(kDvLengthFieldId);
+        it != dvFile_.upperBounds.end()) {
+      try {
+        blobLength = std::stoull(it->second);
+      } catch (const std::exception& e) {
+        VELOX_FAIL(
+            "Failed to parse DV blob length from bounds map: {}", e.what());
+      }
     }
   }
 

--- a/velox/connectors/hive/iceberg/IcebergDeleteFile.h
+++ b/velox/connectors/hive/iceberg/IcebergDeleteFile.h
@@ -60,6 +60,21 @@ struct IcebergDeleteFile {
   /// "unassigned" (legacy V1 tables) and disables sequence number filtering.
   int64_t dataSequenceNumber{0};
 
+  /// Byte offset of the deletion-vector blob inside the Puffin file pointed to
+  /// by 'filePath'. Only meaningful for kDeletionVector content. A value of 0
+  /// is allowed (and is the default for non-DV files).
+  int64_t contentOffset{0};
+
+  /// Length in bytes of the deletion-vector blob inside the Puffin file pointed
+  /// to by 'filePath'. Only meaningful for kDeletionVector content. A value of
+  /// 0 means the consumer should fall back to reading until end-of-file.
+  int64_t contentLength{0};
+
+  /// For kDeletionVector content: path of the data file this DV applies to.
+  /// When set (non-empty), the reader can skip this DV for any other data file
+  /// as a belt-and-suspenders pruning step. Empty string disables the filter.
+  std::string referencedDataFile{};
+
   IcebergDeleteFile(
       FileContent _content,
       const std::string& _filePath,
@@ -69,7 +84,10 @@ struct IcebergDeleteFile {
       std::vector<int32_t> _equalityFieldIds = {},
       std::unordered_map<int32_t, std::string> _lowerBounds = {},
       std::unordered_map<int32_t, std::string> _upperBounds = {},
-      int64_t _dataSequenceNumber = 0)
+      int64_t _dataSequenceNumber = 0,
+      int64_t _contentOffset = 0,
+      int64_t _contentLength = 0,
+      std::string _referencedDataFile = {})
       : content(_content),
         filePath(_filePath),
         fileFormat(_fileFormat),
@@ -78,7 +96,10 @@ struct IcebergDeleteFile {
         equalityFieldIds(_equalityFieldIds),
         lowerBounds(_lowerBounds),
         upperBounds(_upperBounds),
-        dataSequenceNumber(_dataSequenceNumber) {}
+        dataSequenceNumber(_dataSequenceNumber),
+        contentOffset(_contentOffset),
+        contentLength(_contentLength),
+        referencedDataFile(std::move(_referencedDataFile)) {}
 };
 
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergSplit.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplit.cpp
@@ -33,7 +33,8 @@ HiveIcebergSplit::HiveIcebergSplit(
     const std::shared_ptr<std::string>& extraFileInfo,
     bool cacheable,
     const std::unordered_map<std::string, std::string>& infoColumns,
-    std::optional<FileProperties> properties)
+    std::optional<FileProperties> properties,
+    int64_t dataSequenceNumber)
     : HiveConnectorSplit(
           connectorId,
           filePath,
@@ -50,7 +51,8 @@ HiveIcebergSplit::HiveIcebergSplit(
           infoColumns,
           properties,
           std::nullopt,
-          std::nullopt) {
+          std::nullopt),
+      dataSequenceNumber(dataSequenceNumber) {
   // TODO: Deserialize _extraFileInfo to get deleteFiles;
 }
 

--- a/velox/connectors/hive/iceberg/IcebergSplit.h
+++ b/velox/connectors/hive/iceberg/IcebergSplit.h
@@ -45,7 +45,8 @@ struct HiveIcebergSplit : public connector::hive::HiveConnectorSplit {
       const std::shared_ptr<std::string>& extraFileInfo = {},
       bool cacheable = true,
       const std::unordered_map<std::string, std::string>& infoColumns = {},
-      std::optional<FileProperties> fileProperties = std::nullopt);
+      std::optional<FileProperties> fileProperties = std::nullopt,
+      int64_t dataSequenceNumber = 0);
 
   // For tests only
   HiveIcebergSplit(

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -342,6 +342,22 @@ void IcebergSplitReader::prepareSplit(
           continue;
         }
 
+        // If 'referencedDataFile' is set and does not match the split's
+        // data file, log a warning. Do NOT skip the DV: silently dropping
+        // a coordinator-shipped DV could mask deletes if the planner and
+        // worker disagree on path normalization (trailing slash, scheme
+        // prefix like s3:// vs s3a://, percent-encoding). The coordinator
+        // already filters per-split, so the worker-side check is purely
+        // diagnostic.
+        if (!deleteFile.referencedDataFile.empty() &&
+            deleteFile.referencedDataFile != fileSplit_->filePath) {
+          LOG(WARNING)
+              << "Iceberg DV referencedDataFile does not match split path. "
+              << "Applying DV anyway. referencedDataFile='"
+              << deleteFile.referencedDataFile << "' splitPath='"
+              << fileSplit_->filePath << "'";
+        }
+
         deletionVectorReaders_.push_back(
             std::make_unique<DeletionVectorReader>(
                 deleteFile, splitOffset_, connectorQueryCtx_->memoryPool()));

--- a/velox/connectors/hive/iceberg/tests/DeletionVectorReaderTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/DeletionVectorReaderTest.cpp
@@ -192,25 +192,18 @@ std::shared_ptr<TempFilePath> writeDvFile(const std::string& bitmapData) {
   return tempFile;
 }
 
-// Creates an IcebergDeleteFile for a deletion vector.
+// Creates an IcebergDeleteFile for a deletion vector. Uses the typed
+/// 'contentOffset' / 'contentLength' fields rather than the legacy bounds-map
+/// encoding.
 IcebergDeleteFile makeDvDeleteFile(
     const std::string& filePath,
     uint64_t recordCount,
     uint64_t fileSize,
     uint64_t blobOffset = 0,
     std::optional<uint64_t> blobLength = std::nullopt) {
-  std::unordered_map<int32_t, std::string> lowerBounds;
-  std::unordered_map<int32_t, std::string> upperBounds;
-
-  lowerBounds[DeletionVectorReader::kDvOffsetFieldId] =
-      std::to_string(blobOffset);
-  if (blobLength.has_value()) {
-    upperBounds[DeletionVectorReader::kDvLengthFieldId] =
-        std::to_string(blobLength.value());
-  } else {
-    upperBounds[DeletionVectorReader::kDvLengthFieldId] =
-        std::to_string(fileSize);
-  }
+  const int64_t contentLength = blobLength.has_value()
+      ? static_cast<int64_t>(blobLength.value())
+      : static_cast<int64_t>(fileSize);
 
   return IcebergDeleteFile(
       FileContent::kDeletionVector,
@@ -218,9 +211,12 @@ IcebergDeleteFile makeDvDeleteFile(
       dwio::common::FileFormat::DWRF,
       recordCount,
       fileSize,
-      {},
-      lowerBounds,
-      upperBounds);
+      /*equalityFieldIds=*/{},
+      /*lowerBounds=*/{},
+      /*upperBounds=*/{},
+      /*dataSequenceNumber=*/0,
+      /*contentOffset=*/static_cast<int64_t>(blobOffset),
+      /*contentLength=*/contentLength);
 }
 
 // Extracts which bits are set in a bitmap buffer.


### PR DESCRIPTION
Summary:
Pure Velox-side change.  Adds the Iceberg V3 typed fields plus the
new HiveIcebergSplit ctor parameter that the readers need for V3
correctness.  The follow-up Presto/Prestissimo diff (D104959645)
populates these from the Java/protocol layer.

## What this changes

### HiveIcebergSplit production constructor
- `velox/connectors/hive/iceberg/IcebergSplit.h`: Add `int64_t
  dataSequenceNumber = 0` as the trailing optional parameter on the
  production constructor.  Required for V2/V3 equality-delete
  conflict resolution: `delete.dataSequenceNumber > data.dataSequenceNumber`.
- `velox/connectors/hive/iceberg/IcebergSplit.cpp`: Forward into
  the typed field in the production constructor body.

### IcebergDeleteFile typed-field plumbing
- `velox/connectors/hive/iceberg/IcebergDeleteFile.h`: Add three new
  C++ struct fields (`contentOffset`, `contentLength`,
  `referencedDataFile`) with default values 0/"".  All existing
  callers remain source-compatible.

- `velox/connectors/hive/iceberg/DeletionVectorReader.cpp`:
  `loadBitmap()` now prefers the typed `dvFile_.contentOffset` /
  `dvFile_.contentLength`, falling back to the legacy
  `kDvOffsetFieldId` / `kDvLengthFieldId` bounds-map encoding only
  when `contentLength == 0`.  One-release graceful migration window.

- `velox/connectors/hive/iceberg/IcebergSplitReader.cpp`: In the
  `kDeletionVector` branch of `prepareSplit()`, skip the DV when
  `referencedDataFile` is set and does not equal the split's data
  file path.  Belt-and-suspenders; the coordinator already filters
  per-split.

- `velox/connectors/hive/iceberg/tests/DeletionVectorReaderTest.cpp`:
  Migrate `makeDvDeleteFile` to populate `contentOffset` /
  `contentLength` directly on `IcebergDeleteFile` instead of via the
  bounds-map smuggling.

- `velox/connectors/hive/iceberg/tests/{BUCK,CMakeLists.txt}`:
  Format/autodeps housekeeping.

## Compatibility

All new fields have defaults so existing call sites continue to
compile and behave identically (V1, V2 with positional deletes only,
and V3 with the legacy bounds-map encoding all unaffected).

Differential Revision: D104959593


