### PR TITLE
feat: Add VectorFunctionListener registry for observing VectorFunction::apply calls (#17508)

### DIFF
--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -32,7 +32,7 @@
 
 namespace facebook::velox::exec::trace {
 class TraceCtx;
-}
+} // namespace facebook::velox::exec::trace
 
 namespace facebook::velox::core {
 

--- a/velox/docs/develop/scalar-functions.rst
+++ b/velox/docs/develop/scalar-functions.rst
@@ -1203,6 +1203,72 @@ Benchmarks are a great way to check if an optimization is working, evaluate
 how much benefit it brings and decide whether it is worth the additional
 complexity.
 
+Listening to Function Calls
+--------------------------
+
+Velox supports observing VectorFunction::apply calls via a global listener
+registry. This is useful for monitoring, access control, auditing, or any
+cross-cutting concern that needs to observe function execution without modifying
+function implementations.
+
+Listener factories are registered globally via
+``registerVectorFunctionListenerFactory()``. During expression compilation,
+ExprCompiler calls each factory's ``create()`` method once per resolved scalar
+function. The factory receives the function name, ``VectorFunctionMetadata``,
+and ``QueryConfig``, and returns a ``VectorFunctionListeners`` struct containing
+optional pre and/or post listeners, or ``std::nullopt`` to skip that function.
+
+.. code-block:: c++
+
+  #include "velox/expression/VectorFunctionListener.h"
+
+  class MyListenerFactory : public VectorFunctionListenerFactory {
+   public:
+    std::optional<VectorFunctionListeners> create(
+        std::string_view functionName,
+        const VectorFunctionMetadata& metadata,
+        const core::QueryConfig& queryConfig) override {
+      if (functionName != "target_fn") {
+        return std::nullopt;
+      }
+      return VectorFunctionListeners{
+          std::make_shared<PreApplyListener>(
+              [](std::string_view functionName,
+                 const SelectivityVector& rows,
+                 const std::vector<VectorPtr>& args,
+                 const TypePtr& outputType,
+                 const EvalCtx& context) {
+                // Called before VectorFunction::apply.
+              }),
+          std::make_shared<PostApplyListener>(
+              [](std::string_view functionName,
+                 const SelectivityVector& rows,
+                 const std::vector<VectorPtr>& args,
+                 const TypePtr& outputType,
+                 const EvalCtx& context,
+                 const VectorPtr& result,
+                 std::exception_ptr error) {
+                // Called after VectorFunction::apply, even if apply threw.
+                // 'error' is non-null when apply threw; the framework
+                // rethrows it after all post-listeners have executed.
+              }),
+      };
+    }
+  };
+
+  // Register globally (typically at startup).
+  auto factory = std::make_shared<MyListenerFactory>();
+  registerVectorFunctionListenerFactory(factory);
+
+Key properties:
+
+- **Multiple factories** can be registered independently, each observing
+  different concerns without coordination.
+- **Pre-listener** exceptions propagate immediately and abort the function call.
+- **Post-listener** exceptions are caught and logged (rate-limited); they do not
+  mask the original apply error or prevent other post-listeners from running.
+- **Special forms** (AND, OR, CAST, etc.) are not subject to listening.
+
 Documenting
 -----------
 

--- a/velox/expression/CMakeLists.txt
+++ b/velox/expression/CMakeLists.txt
@@ -19,13 +19,15 @@ velox_link_libraries(velox_type_signature velox_common_base)
 velox_add_library(
   velox_expression_functions
   FunctionSignature.cpp
-  SignatureBinder.cpp
   ReverseSignatureBinder.cpp
+  SignatureBinder.cpp
+  VectorFunctionListener.cpp
   HEADERS
   FunctionMetadata.h
   FunctionSignature.h
   ReverseSignatureBinder.h
   SignatureBinder.h
+  VectorFunctionListener.h
 )
 
 velox_link_libraries(

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -18,6 +18,8 @@
 #include <boost/uuid/uuid_io.hpp>
 #include <cmath>
 
+#include <folly/GLog.h>
+
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/Fs.h"
 #include "velox/common/base/SuccinctPrinter.h"
@@ -139,7 +141,8 @@ Expr::Expr(
     std::shared_ptr<VectorFunction> vectorFunction,
     VectorFunctionMetadata metadata,
     std::string name,
-    bool trackCpuUsage)
+    bool trackCpuUsage,
+    std::vector<VectorFunctionListeners> listeners)
     : type_(std::move(type)),
       inputs_(std::move(inputs)),
       name_(std::move(name)),
@@ -150,7 +153,8 @@ Expr::Expr(
           vectorFunction_->supportsFlatNoNullsFastPath() &&
           type_->isPrimitiveType() && type_->isFixedWidth() &&
           allSupportFlatNoNullsFastPath(inputs_)},
-      trackCpuUsage_{trackCpuUsage} {
+      trackCpuUsage_{trackCpuUsage},
+      listeners_(std::move(listeners)) {
   constantInputs_.reserve(inputs_.size());
   inputIsConstant_.reserve(inputs_.size());
   inputValues_.reserve(inputs_.size());
@@ -538,14 +542,7 @@ void Expr::evalSimplifiedImpl(
   }
 
   // Apply the actual function.
-  try {
-    vectorFunction_->apply(
-        remainingRows.rows(), inputValues_, type(), context, result);
-  } catch (const VeloxException&) {
-    throw;
-  } catch (const std::exception& e) {
-    VELOX_USER_FAIL(e.what());
-  }
+  invokeApplyWithListeners(remainingRows.rows(), context, result);
 
   // Make sure the returned vector has its null bitmap properly set.
   addNulls(rows, remainingRows.rows().asRange().bits(), context, result);
@@ -1696,6 +1693,59 @@ void Expr::finalizeAdaptiveCalibration(
   }
 }
 
+void Expr::invokeApplyWithListeners(
+    const SelectivityVector& rows,
+    EvalCtx& context,
+    VectorPtr& result) {
+  bool hasPostListeners = false;
+  for (const auto& listener : listeners_) {
+    if (listener.pre) {
+      (*listener.pre)(name_, rows, inputValues_, type(), context);
+    }
+    hasPostListeners |= (listener.post != nullptr);
+  }
+
+  if (!hasPostListeners) {
+    try {
+      vectorFunction_->apply(rows, inputValues_, type(), context, result);
+    } catch (const VeloxException&) {
+      throw;
+    } catch (const std::exception& e) {
+      VELOX_USER_FAIL(e.what());
+    }
+    return;
+  }
+
+  std::exception_ptr applyError;
+  try {
+    vectorFunction_->apply(rows, inputValues_, type(), context, result);
+  } catch (const VeloxException&) {
+    applyError = std::current_exception();
+  } catch (const std::exception& e) {
+    try {
+      VELOX_USER_FAIL(e.what());
+    } catch (...) {
+      applyError = std::current_exception();
+    }
+  }
+
+  for (const auto& listener : listeners_) {
+    if (listener.post) {
+      try {
+        (*listener.post)(
+            name_, rows, inputValues_, type(), context, result, applyError);
+      } catch (const std::exception& e) {
+        FB_LOG_EVERY_MS(ERROR, 5000)
+            << "Post-apply listener threw for function '" << name_
+            << "': " << e.what();
+      }
+    }
+  }
+  if (applyError) {
+    std::rethrow_exception(applyError);
+  }
+}
+
 void Expr::applyFunction(
     const SelectivityVector& rows,
     EvalCtx& context,
@@ -1709,13 +1759,7 @@ void Expr::applyFunction(
       ? computeIsAsciiForResult(vectorFunction_.get(), inputValues_, rows)
       : std::nullopt;
 
-  try {
-    vectorFunction_->apply(rows, inputValues_, type(), context, result);
-  } catch (const VeloxException&) {
-    throw;
-  } catch (const std::exception& e) {
-    VELOX_USER_FAIL(e.what());
-  }
+  invokeApplyWithListeners(rows, context, result);
 
   if (!result) {
     MutableRemainingRows remainingRows(rows, context);

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -26,6 +26,7 @@
 #include "velox/expression/EvalCtx.h"
 #include "velox/expression/ExprStats.h"
 #include "velox/expression/VectorFunction.h"
+#include "velox/expression/VectorFunctionListener.h"
 #include "velox/type/Subfield.h"
 #include "velox/vector/SimpleVector.h"
 
@@ -145,7 +146,8 @@ class Expr {
       std::shared_ptr<VectorFunction> vectorFunction,
       VectorFunctionMetadata metadata,
       std::string name,
-      bool trackCpuUsage);
+      bool trackCpuUsage,
+      std::vector<VectorFunctionListeners> listeners = {});
 
   virtual ~Expr() = default;
 
@@ -518,6 +520,13 @@ class Expr {
       EvalCtx& context,
       VectorPtr& result);
 
+  // Invokes vectorFunction_->apply() with registered listeners and exception
+  // wrapping. Post-listeners always run (even if apply throws).
+  void invokeApplyWithListeners(
+      const SelectivityVector& rows,
+      EvalCtx& context,
+      VectorPtr& result);
+
   // Returns true if values in 'distinctFields_' have nulls that are
   // worth skipping. If so, the rows in 'rows' with at least one sure
   // null are deselected in 'nullHolder->get()'.
@@ -639,6 +648,10 @@ class Expr {
   const std::optional<SpecialFormKind> specialFormKind_;
   const bool supportsFlatNoNullsFastPath_;
   const bool trackCpuUsage_;
+  // Listeners invoked around vectorFunction_->apply() in both applyFunction()
+  // and evalSimplifiedImpl(). Collected from the global listener factory
+  // registry during expression compilation.
+  const std::vector<VectorFunctionListeners> listeners_;
 
   std::vector<VectorPtr> constantInputs_;
   std::vector<bool> inputIsConstant_;

--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -293,21 +293,18 @@ ExprPtr compileCall(
         ctx.queryCtx->queryConfig());
   }
 
+  std::shared_ptr<VectorFunction> vectorFunction;
+  VectorFunctionMetadata metadata;
+
   if (auto functionWithMetadata = getVectorFunctionWithMetadata(
           call->name(),
           inputTypes,
           getConstantInputs(inputs),
           ctx.queryCtx->queryConfig())) {
-    return std::make_shared<Expr>(
-        resultType,
-        std::move(inputs),
-        functionWithMetadata->first,
-        functionWithMetadata->second,
-        call->name(),
-        trackCpuUsage);
-  }
-
-  if (auto simpleFunctionEntry =
+    vectorFunction = functionWithMetadata->first;
+    metadata = functionWithMetadata->second;
+  } else if (
+      auto simpleFunctionEntry =
           simpleFunctions().resolveFunction(call->name(), inputTypes)) {
     VELOX_USER_CHECK(
         resultType->equivalent(*simpleFunctionEntry->type().get()),
@@ -318,49 +315,56 @@ ExprPtr compileCall(
         resultType,
         folly::join(", ", inputTypes));
 
-    auto func = simpleFunctionEntry->createFunction()->createVectorFunction(
-        inputTypes,
-        getConstantInputs(inputs),
-        ctx.queryCtx->queryConfig(),
-        ctx.pool);
-    return std::make_shared<Expr>(
-        resultType,
-        std::move(inputs),
-        std::move(func),
-        simpleFunctionEntry->metadata(),
-        call->name(),
-        trackCpuUsage);
-  }
+    vectorFunction =
+        simpleFunctionEntry->createFunction()->createVectorFunction(
+            inputTypes,
+            getConstantInputs(inputs),
+            ctx.queryCtx->queryConfig(),
+            ctx.pool);
+    metadata = simpleFunctionEntry->metadata();
+  } else {
+    const auto& functionName = call->name();
+    auto vectorFunctionSignatures = getVectorFunctionSignatures(functionName);
+    auto simpleFunctionSignatures =
+        simpleFunctions().getFunctionSignatures(functionName);
+    std::vector<std::string> signatures;
 
-  const auto& functionName = call->name();
-  auto vectorFunctionSignatures = getVectorFunctionSignatures(functionName);
-  auto simpleFunctionSignatures =
-      simpleFunctions().getFunctionSignatures(functionName);
-  std::vector<std::string> signatures;
+    if (vectorFunctionSignatures.has_value()) {
+      for (const auto& signature : vectorFunctionSignatures.value()) {
+        signatures.push_back(fmt::format("({})", signature->toString()));
+      }
+    }
 
-  if (vectorFunctionSignatures.has_value()) {
-    for (const auto& signature : vectorFunctionSignatures.value()) {
+    for (const auto& signature : simpleFunctionSignatures) {
       signatures.push_back(fmt::format("({})", signature->toString()));
+    }
+
+    if (signatures.empty()) {
+      VELOX_USER_FAIL(
+          "Scalar function name not registered: {}, called with arguments: ({}).",
+          call->name(),
+          folly::join(", ", inputTypes));
+    } else {
+      VELOX_USER_FAIL(
+          "Scalar function {} not registered with arguments: ({}). "
+          "Found function registered with the following signatures:\n{}",
+          call->name(),
+          folly::join(", ", inputTypes),
+          folly::join("\n", signatures));
     }
   }
 
-  for (const auto& signature : simpleFunctionSignatures) {
-    signatures.push_back(fmt::format("({})", signature->toString()));
-  }
+  auto listeners = createVectorFunctionListeners(
+      call->name(), metadata, ctx.queryCtx->queryConfig());
 
-  if (signatures.empty()) {
-    VELOX_USER_FAIL(
-        "Scalar function name not registered: {}, called with arguments: ({}).",
-        call->name(),
-        folly::join(", ", inputTypes));
-  } else {
-    VELOX_USER_FAIL(
-        "Scalar function {} not registered with arguments: ({}). "
-        "Found function registered with the following signatures:\n{}",
-        call->name(),
-        folly::join(", ", inputTypes),
-        folly::join("\n", signatures));
-  }
+  return std::make_shared<Expr>(
+      resultType,
+      std::move(inputs),
+      std::move(vectorFunction),
+      metadata,
+      call->name(),
+      trackCpuUsage,
+      std::move(listeners));
 }
 
 ExprPtr compileCast(

--- a/velox/expression/VectorFunctionListener.cpp
+++ b/velox/expression/VectorFunctionListener.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/expression/VectorFunctionListener.h"
+
+#include <folly/Synchronized.h>
+
+namespace facebook::velox::exec {
+
+namespace {
+
+folly::Synchronized<
+    std::vector<std::shared_ptr<VectorFunctionListenerFactory>>>&
+listenerFactories() {
+  static folly::Synchronized<
+      std::vector<std::shared_ptr<VectorFunctionListenerFactory>>>
+      kFactories;
+  return kFactories;
+}
+
+} // namespace
+
+bool registerVectorFunctionListenerFactory(
+    std::shared_ptr<VectorFunctionListenerFactory> factory) {
+  return listenerFactories().withWLock([&](auto& factories) {
+    for (const auto& existing : factories) {
+      if (existing == factory) {
+        return false;
+      }
+    }
+    factories.emplace_back(std::move(factory));
+    return true;
+  });
+}
+
+bool unregisterVectorFunctionListenerFactory(
+    const std::shared_ptr<VectorFunctionListenerFactory>& factory) {
+  return listenerFactories().withWLock([&](auto& factories) {
+    for (auto it = factories.begin(); it != factories.end(); ++it) {
+      if (*it == factory) {
+        factories.erase(it);
+        return true;
+      }
+    }
+    return false;
+  });
+}
+
+std::vector<VectorFunctionListeners> createVectorFunctionListeners(
+    std::string_view name,
+    const VectorFunctionMetadata& metadata,
+    const core::QueryConfig& queryConfig) {
+  std::vector<VectorFunctionListeners> listeners;
+  listenerFactories().withRLock([&](const auto& factories) {
+    for (const auto& factory : factories) {
+      if (auto result = factory->create(name, metadata, queryConfig)) {
+        listeners.push_back(std::move(*result));
+      }
+    }
+  });
+  return listeners;
+}
+
+} // namespace facebook::velox::exec

--- a/velox/expression/VectorFunctionListener.h
+++ b/velox/expression/VectorFunctionListener.h
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <exception>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string_view>
+#include <vector>
+
+#include "velox/expression/FunctionMetadata.h"
+
+namespace facebook::velox {
+class BaseVector;
+class Type;
+class SelectivityVector;
+} // namespace facebook::velox
+
+namespace facebook::velox::core {
+class QueryConfig;
+} // namespace facebook::velox::core
+
+/// Listener infrastructure for observing VectorFunction::apply calls during
+/// expression evaluation.
+///
+/// Listeners are registered globally via registerVectorFunctionListenerFactory.
+/// During expression compilation, ExprCompiler iterates all registered
+/// factories, calling create() once per resolved scalar function with the
+/// function name, metadata, and QueryConfig. Each factory may return a
+/// VectorFunctionListeners struct containing pre and/or post listeners, or
+/// std::nullopt to skip that function. Returned listeners are stored on the
+/// Expr node and invoked around every VectorFunction::apply call in both the
+/// standard (applyFunction) and simplified (evalSimplifiedImpl) evaluation
+/// paths. Special forms (AND, OR, CAST, etc.) are not subject to listening.
+///
+/// Multiple factories can be registered independently, each observing
+/// different concerns (monitoring, access control, auditing, etc.) without
+/// coordination.
+
+namespace facebook::velox::exec {
+
+class EvalCtx;
+
+/// Callback invoked before VectorFunction::apply.
+using PreApplyListener = std::function<void(
+    std::string_view functionName,
+    const SelectivityVector& rows,
+    const std::vector<std::shared_ptr<BaseVector>>& args,
+    const std::shared_ptr<const Type>& outputType,
+    const EvalCtx& context)>;
+
+/// Callback invoked after VectorFunction::apply, regardless of whether apply
+/// succeeded or threw. When apply throws, 'error' holds the exception;
+/// otherwise it is nullptr. The 'error' exception is always rethrown by the
+/// framework after all post-listeners have executed. If a post-listener itself
+/// throws, the exception is caught, logged periodically, and remaining
+/// post-listeners still execute.
+using PostApplyListener = std::function<void(
+    std::string_view functionName,
+    const SelectivityVector& rows,
+    const std::vector<std::shared_ptr<BaseVector>>& args,
+    const std::shared_ptr<const Type>& outputType,
+    const EvalCtx& context,
+    const std::shared_ptr<BaseVector>& result,
+    std::exception_ptr error)>;
+
+/// Pre/post listeners returned by VectorFunctionListenerFactory. Stored as
+/// shared_ptrs so multiple Expr instances can reference the same listener
+/// without copying.
+struct VectorFunctionListeners {
+  /// Called before vectorFunction_->apply(); may be null.
+  std::shared_ptr<const PreApplyListener> pre;
+  /// Called after vectorFunction_->apply() regardless of outcome; may be null.
+  std::shared_ptr<const PostApplyListener> post;
+};
+
+/// Factory that optionally creates pre/post listeners for a given function.
+/// Called once per function during expression compilation. Returns
+/// std::nullopt to skip listening for that function.
+class VectorFunctionListenerFactory {
+ public:
+  virtual ~VectorFunctionListenerFactory() = default;
+
+  virtual std::optional<VectorFunctionListeners> create(
+      std::string_view name,
+      const VectorFunctionMetadata& metadata,
+      const core::QueryConfig& queryConfig) = 0;
+};
+
+/// Registers a listener factory globally. Returns true if the factory was
+/// newly added, false if it was already registered.
+bool registerVectorFunctionListenerFactory(
+    std::shared_ptr<VectorFunctionListenerFactory> factory);
+
+/// Unregisters a previously registered listener factory. Returns true if the
+/// factory was found and removed.
+bool unregisterVectorFunctionListenerFactory(
+    const std::shared_ptr<VectorFunctionListenerFactory>& factory);
+
+/// Iterates all registered factories and collects listeners for the given
+/// function. Called by ExprCompiler during expression compilation.
+std::vector<VectorFunctionListeners> createVectorFunctionListeners(
+    std::string_view name,
+    const VectorFunctionMetadata& metadata,
+    const core::QueryConfig& queryConfig);
+
+} // namespace facebook::velox::exec

--- a/velox/expression/tests/ExprCompilerTest.cpp
+++ b/velox/expression/tests/ExprCompilerTest.cpp
@@ -18,6 +18,7 @@
 #include "velox/core/Expressions.h"
 #include "velox/expression/Expr.h"
 #include "velox/expression/FieldReference.h"
+#include "velox/expression/VectorFunctionListener.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/functions/prestosql/types/JsonType.h"
 #include "velox/parse/ExpressionsParser.h"
@@ -441,6 +442,364 @@ TEST_F(ExprCompilerTest, simpleFunctionMemoryPool) {
 
   auto stringView = decoded.valueAt<StringView>(0);
   ASSERT_GT(stringView.size(), 0) << "HLL sketch is empty";
+}
+
+class TrackingListenerFactory : public VectorFunctionListenerFactory {
+ public:
+  std::optional<VectorFunctionListeners> create(
+      std::string_view name,
+      const VectorFunctionMetadata& /*metadata*/,
+      const core::QueryConfig& /*queryConfig*/) override {
+    trackedNames.emplace_back(name);
+    return std::nullopt;
+  }
+
+  std::vector<std::string> trackedNames;
+};
+
+class CountingListenerFactory : public VectorFunctionListenerFactory {
+ public:
+  CountingListenerFactory()
+      : preCount(std::make_shared<std::atomic<int>>(0)),
+        postCount(std::make_shared<std::atomic<int>>(0)) {}
+
+  std::optional<VectorFunctionListeners> create(
+      std::string_view /*functionName*/,
+      const VectorFunctionMetadata& /*metadata*/,
+      const core::QueryConfig& /*queryConfig*/) override {
+    return VectorFunctionListeners{
+        std::make_shared<PreApplyListener>(
+            [counter = preCount](
+                std::string_view /*functionName*/,
+                const SelectivityVector& /*rows*/,
+                const std::vector<VectorPtr>& /*args*/,
+                const TypePtr& /*outputType*/,
+                const EvalCtx& /*context*/) { ++(*counter); }),
+        std::make_shared<PostApplyListener>(
+            [counter = postCount](
+                std::string_view /*functionName*/,
+                const SelectivityVector& /*rows*/,
+                const std::vector<VectorPtr>& /*args*/,
+                const TypePtr& /*outputType*/,
+                const EvalCtx& /*context*/,
+                const VectorPtr& /*result*/,
+                std::exception_ptr /*error*/) { ++(*counter); }),
+    };
+  }
+
+  std::shared_ptr<std::atomic<int>> preCount;
+  std::shared_ptr<std::atomic<int>> postCount;
+};
+
+class SelectiveListenerFactory : public VectorFunctionListenerFactory {
+ public:
+  explicit SelectiveListenerFactory(
+      std::string targetName,
+      std::shared_ptr<std::atomic<int>> counter)
+      : targetName_(std::move(targetName)), counter_(std::move(counter)) {}
+
+  std::optional<VectorFunctionListeners> create(
+      std::string_view name,
+      const VectorFunctionMetadata& /*metadata*/,
+      const core::QueryConfig& /*queryConfig*/) override {
+    if (name != targetName_) {
+      return std::nullopt;
+    }
+    return VectorFunctionListeners{
+        std::make_shared<PreApplyListener>(
+            [counter = counter_](
+                std::string_view /*functionName*/,
+                const SelectivityVector& /*rows*/,
+                const std::vector<VectorPtr>& /*args*/,
+                const TypePtr& /*outputType*/,
+                const EvalCtx& /*context*/) { ++(*counter); }),
+        nullptr,
+    };
+  }
+
+ private:
+  std::string targetName_;
+  std::shared_ptr<std::atomic<int>> counter_;
+};
+
+TEST_F(ExprCompilerTest, listenerFactory) {
+  auto factory = std::make_shared<TrackingListenerFactory>();
+  registerVectorFunctionListenerFactory(factory);
+
+  auto rowType = ROW({"a"}, {BIGINT()});
+  auto field = makeField(rowType);
+  auto expression = call("plus", {field("a"), bigint(1)});
+  auto exprSet = compile(expression);
+  ASSERT_EQ(factory->trackedNames.size(), 1);
+  EXPECT_EQ(factory->trackedNames[0], "plus");
+
+  auto input = makeRowVector({"a"}, {makeFlatVector<int64_t>({1, 2, 3})});
+  SelectivityVector rows(3);
+  EvalCtx evalCtx(execCtx_.get(), exprSet.get(), input.get());
+  std::vector<VectorPtr> results(1);
+  exprSet->eval(rows, evalCtx, results);
+
+  auto expected = makeFlatVector<int64_t>({2, 3, 4});
+  velox::test::assertEqualVectors(expected, results[0]);
+  unregisterVectorFunctionListenerFactory(factory);
+}
+
+TEST_F(ExprCompilerTest, listenerNotCalledForSpecialForms) {
+  auto factory = std::make_shared<TrackingListenerFactory>();
+  registerVectorFunctionListenerFactory(factory);
+
+  auto rowType = ROW({"a", "b"}, {BOOLEAN(), BOOLEAN()});
+  auto field = makeField(rowType);
+  auto expression = andCall(field("a"), field("b"));
+  compile(expression);
+
+  EXPECT_TRUE(factory->trackedNames.empty());
+  unregisterVectorFunctionListenerFactory(factory);
+}
+
+TEST_F(ExprCompilerTest, listenerPrePostCallbacks) {
+  auto factory = std::make_shared<CountingListenerFactory>();
+  registerVectorFunctionListenerFactory(factory);
+
+  auto rowType = ROW({"a"}, {BIGINT()});
+  auto field = makeField(rowType);
+  auto expression = call("plus", {field("a"), bigint(1)});
+  auto exprSet = compile(expression);
+
+  auto input = makeRowVector({"a"}, {makeFlatVector<int64_t>({1, 2, 3})});
+  SelectivityVector rows(3);
+  EvalCtx evalCtx(execCtx_.get(), exprSet.get(), input.get());
+  std::vector<VectorPtr> results(1);
+  exprSet->eval(rows, evalCtx, results);
+
+  EXPECT_EQ(factory->preCount->load(), 1);
+  EXPECT_EQ(factory->postCount->load(), 1);
+  auto expected = makeFlatVector<int64_t>({2, 3, 4});
+  velox::test::assertEqualVectors(expected, results[0]);
+  unregisterVectorFunctionListenerFactory(factory);
+}
+
+TEST_F(ExprCompilerTest, listenerSelectiveHooking) {
+  auto hookCount = std::make_shared<std::atomic<int>>(0);
+  auto factory = std::make_shared<SelectiveListenerFactory>("plus", hookCount);
+  registerVectorFunctionListenerFactory(factory);
+
+  auto rowType = ROW({"a"}, {BIGINT()});
+  auto field = makeField(rowType);
+  auto expression =
+      call("plus", {call("multiply", {field("a"), bigint(2)}), bigint(1)});
+  auto exprSet = compile(expression);
+
+  auto input = makeRowVector({"a"}, {makeFlatVector<int64_t>({1, 2, 3})});
+  SelectivityVector rows(3);
+  EvalCtx evalCtx(execCtx_.get(), exprSet.get(), input.get());
+  std::vector<VectorPtr> results(1);
+  exprSet->eval(rows, evalCtx, results);
+
+  EXPECT_EQ(hookCount->load(), 1);
+  auto expected = makeFlatVector<int64_t>({3, 5, 7});
+  velox::test::assertEqualVectors(expected, results[0]);
+  unregisterVectorFunctionListenerFactory(factory);
+}
+
+TEST_F(ExprCompilerTest, listenerPreThrows) {
+  class ThrowingPreFactory : public VectorFunctionListenerFactory {
+   public:
+    std::optional<VectorFunctionListeners> create(
+        std::string_view /*functionName*/,
+        const VectorFunctionMetadata& /*metadata*/,
+        const core::QueryConfig& /*queryConfig*/) override {
+      return VectorFunctionListeners{
+          std::make_shared<PreApplyListener>(
+              [](std::string_view /*functionName*/,
+                 const SelectivityVector& /*rows*/,
+                 const std::vector<VectorPtr>& /*args*/,
+                 const TypePtr& /*outputType*/,
+                 const EvalCtx& /*context*/) {
+                VELOX_USER_FAIL("pre-listener error");
+              }),
+          nullptr,
+      };
+    }
+  };
+
+  auto factory = std::make_shared<ThrowingPreFactory>();
+  registerVectorFunctionListenerFactory(factory);
+
+  auto rowType = ROW({"a"}, {BIGINT()});
+  auto field = makeField(rowType);
+  auto expression = call("plus", {field("a"), bigint(1)});
+  auto exprSet = compile(expression);
+
+  auto input = makeRowVector({"a"}, {makeFlatVector<int64_t>({1, 2, 3})});
+  SelectivityVector rows(3);
+  EvalCtx evalCtx(execCtx_.get(), exprSet.get(), input.get());
+  std::vector<VectorPtr> results(1);
+  VELOX_ASSERT_THROW(
+      exprSet->eval(rows, evalCtx, results), "pre-listener error");
+  unregisterVectorFunctionListenerFactory(factory);
+}
+
+TEST_F(ExprCompilerTest, listenerPostThrowsIsSwallowed) {
+  auto secondPostCalled = std::make_shared<bool>(false);
+
+  class ThrowingPostFactory : public VectorFunctionListenerFactory {
+   public:
+    std::optional<VectorFunctionListeners> create(
+        std::string_view /*functionName*/,
+        const VectorFunctionMetadata& /*metadata*/,
+        const core::QueryConfig& /*queryConfig*/) override {
+      return VectorFunctionListeners{
+          nullptr,
+          std::make_shared<PostApplyListener>(
+              [](std::string_view /*functionName*/,
+                 const SelectivityVector& /*rows*/,
+                 const std::vector<VectorPtr>& /*args*/,
+                 const TypePtr& /*outputType*/,
+                 const EvalCtx& /*context*/,
+                 const VectorPtr& /*result*/,
+                 std::exception_ptr /*error*/) {
+                VELOX_USER_FAIL("post-listener error");
+              }),
+      };
+    }
+  };
+
+  class CheckingPostFactory : public VectorFunctionListenerFactory {
+   public:
+    explicit CheckingPostFactory(std::shared_ptr<bool> called)
+        : called_(std::move(called)) {}
+
+    std::optional<VectorFunctionListeners> create(
+        std::string_view /*functionName*/,
+        const VectorFunctionMetadata& /*metadata*/,
+        const core::QueryConfig& /*queryConfig*/) override {
+      return VectorFunctionListeners{
+          nullptr,
+          std::make_shared<PostApplyListener>(
+              [called = called_](
+                  std::string_view /*functionName*/,
+                  const SelectivityVector& /*rows*/,
+                  const std::vector<VectorPtr>& /*args*/,
+                  const TypePtr& /*outputType*/,
+                  const EvalCtx& /*context*/,
+                  const VectorPtr& /*result*/,
+                  std::exception_ptr /*error*/) { *called = true; }),
+      };
+    }
+
+   private:
+    std::shared_ptr<bool> called_;
+  };
+
+  auto throwingFactory = std::make_shared<ThrowingPostFactory>();
+  auto checkingFactory =
+      std::make_shared<CheckingPostFactory>(secondPostCalled);
+  registerVectorFunctionListenerFactory(throwingFactory);
+  registerVectorFunctionListenerFactory(checkingFactory);
+
+  auto rowType = ROW({"a"}, {BIGINT()});
+  auto field = makeField(rowType);
+  auto expression = call("plus", {field("a"), bigint(1)});
+  auto exprSet = compile(expression);
+
+  auto input = makeRowVector({"a"}, {makeFlatVector<int64_t>({1, 2, 3})});
+  SelectivityVector rows(3);
+  EvalCtx evalCtx(execCtx_.get(), exprSet.get(), input.get());
+  std::vector<VectorPtr> results(1);
+  exprSet->eval(rows, evalCtx, results);
+
+  auto expected = makeFlatVector<int64_t>({2, 3, 4});
+  velox::test::assertEqualVectors(expected, results[0]);
+  EXPECT_TRUE(*secondPostCalled);
+  unregisterVectorFunctionListenerFactory(throwingFactory);
+  unregisterVectorFunctionListenerFactory(checkingFactory);
+}
+
+TEST_F(ExprCompilerTest, listenerPostReceivesApplyError) {
+  auto postCalled = std::make_shared<std::atomic<bool>>(false);
+  auto receivedError = std::make_shared<std::atomic<bool>>(false);
+
+  class ErrorCapturingFactory : public VectorFunctionListenerFactory {
+   public:
+    ErrorCapturingFactory(
+        std::shared_ptr<std::atomic<bool>> postCalled,
+        std::shared_ptr<std::atomic<bool>> receivedError)
+        : postCalled_(std::move(postCalled)),
+          receivedError_(std::move(receivedError)) {}
+
+    std::optional<VectorFunctionListeners> create(
+        std::string_view /*functionName*/,
+        const VectorFunctionMetadata& /*metadata*/,
+        const core::QueryConfig& /*queryConfig*/) override {
+      return VectorFunctionListeners{
+          nullptr,
+          std::make_shared<PostApplyListener>(
+              [postCalled = postCalled_, receivedError = receivedError_](
+                  std::string_view /*functionName*/,
+                  const SelectivityVector& /*rows*/,
+                  const std::vector<VectorPtr>& /*args*/,
+                  const TypePtr& /*outputType*/,
+                  const EvalCtx& /*context*/,
+                  const VectorPtr& /*result*/,
+                  std::exception_ptr error) {
+                postCalled->store(true);
+                receivedError->store(error != nullptr);
+              }),
+      };
+    }
+
+   private:
+    std::shared_ptr<std::atomic<bool>> postCalled_;
+    std::shared_ptr<std::atomic<bool>> receivedError_;
+  };
+
+  auto factory =
+      std::make_shared<ErrorCapturingFactory>(postCalled, receivedError);
+  registerVectorFunctionListenerFactory(factory);
+
+  auto rowType = ROW({"a"}, {BIGINT()});
+  auto field = makeField(rowType);
+  auto expression = call("divide", {field("a"), bigint(0)});
+  auto exprSet = compile(expression);
+
+  auto input = makeRowVector({"a"}, {makeFlatVector<int64_t>({1, 2, 3})});
+  SelectivityVector rows(3);
+  EvalCtx evalCtx(execCtx_.get(), exprSet.get(), input.get());
+  std::vector<VectorPtr> results(1);
+  EXPECT_THROW(exprSet->eval(rows, evalCtx, results), VeloxException);
+
+  EXPECT_TRUE(postCalled->load());
+  EXPECT_TRUE(receivedError->load());
+  unregisterVectorFunctionListenerFactory(factory);
+}
+
+TEST_F(ExprCompilerTest, multipleListenerFactories) {
+  auto factoryA = std::make_shared<CountingListenerFactory>();
+  auto factoryB = std::make_shared<CountingListenerFactory>();
+  registerVectorFunctionListenerFactory(factoryA);
+  registerVectorFunctionListenerFactory(factoryB);
+
+  auto rowType = ROW({"a"}, {BIGINT()});
+  auto field = makeField(rowType);
+  auto expression = call("plus", {field("a"), bigint(1)});
+  auto exprSet = compile(expression);
+
+  auto input = makeRowVector({"a"}, {makeFlatVector<int64_t>({1, 2, 3})});
+  SelectivityVector rows(3);
+  EvalCtx evalCtx(execCtx_.get(), exprSet.get(), input.get());
+  std::vector<VectorPtr> results(1);
+  exprSet->eval(rows, evalCtx, results);
+
+  EXPECT_EQ(factoryA->preCount->load(), 1);
+  EXPECT_EQ(factoryA->postCount->load(), 1);
+  EXPECT_EQ(factoryB->preCount->load(), 1);
+  EXPECT_EQ(factoryB->postCount->load(), 1);
+
+  auto expected = makeFlatVector<int64_t>({2, 3, 4});
+  velox::test::assertEqualVectors(expected, results[0]);
+  unregisterVectorFunctionListenerFactory(factoryA);
+  unregisterVectorFunctionListenerFactory(factoryB);
 }
 
 } // namespace facebook::velox::exec::test


### PR DESCRIPTION
Summary:

Introduces a global listener registry for observing VectorFunction::apply calls during expression evaluation, following the SplitListeners pattern (velox/exec/Task.h).

Listener factories are registered globally via registerVectorFunctionListenerFactory(). During expression compilation, ExprCompiler iterates all registered factories, calling create() once per resolved scalar function with the function name, VectorFunctionMetadata, and QueryConfig. Each factory independently decides whether to observe that function by returning a VectorFunctionListeners struct (containing pre and/or post listeners) or std::nullopt to skip. Returned listeners are stored on the Expr node and invoked via invokeApplyWithListeners() in both applyFunction() and evalSimplifiedImpl(). Special forms (AND, OR, CAST, etc.) are not subject to listening.

Key design decisions:
- Global static registry (not per-query): multiple factories can be registered independently without coordination, each observing different concerns (monitoring, access control, auditing).
- Factory receives QueryConfig: per-query behavior control without per-query factory instances. A factory can return std::nullopt based on config flags.
- Listeners are shared_ptrs so a single listener instance can be shared across multiple Expr nodes.
- Post-listener has finally semantics: always runs after apply, even if apply throws. Receives std::exception_ptr (nullptr on success) enabling RAII-like cleanup.
- Listener exceptions propagate as-is (not wrapped as user errors). Only VectorFunction::apply non-Velox exceptions are wrapped via VELOX_USER_FAIL.
- Both listeners receive the expression name as the first argument for attribution.

Reviewed By: kevinwilfong

Differential Revision: D104325777


