### PR TITLE
feat: Add KeyDecoder for Velox serializer keys (#17510)

### DIFF
--- a/velox/serializers/CMakeLists.txt
+++ b/velox/serializers/CMakeLists.txt
@@ -11,7 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-velox_add_library(velox_key_encoder KeyEncoder.cpp HEADERS KeyEncoder.h)
+velox_add_library(
+  velox_key_encoder
+  KeyDecoder.cpp
+  KeyEncoder.cpp
+  HEADERS
+  KeyDecoder.h
+  KeyEncoder.h
+)
 
 velox_link_libraries(
   velox_key_encoder

--- a/velox/serializers/KeyDecoder.cpp
+++ b/velox/serializers/KeyDecoder.cpp
@@ -1,0 +1,379 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/serializers/KeyDecoder.h"
+
+#include <cstring>
+#include <limits>
+#include <type_traits>
+
+#include <folly/lang/Bits.h>
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/type/Timestamp.h"
+#include "velox/vector/BaseVector.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::velox::serializer {
+namespace {
+
+// Validates if a type is a valid index column type.
+// Only primitive scalar types are supported except UNKNOWN and HUGEINT.
+bool isValidIndexColumnType(const TypePtr& type) {
+  return type->isPrimitiveType() && type->kind() != TypeKind::UNKNOWN &&
+      type->kind() != TypeKind::HUGEINT;
+}
+
+std::vector<vector_size_t> getKeyChannels(
+    const RowTypePtr& inputType,
+    const std::vector<std::string>& keyColumns) {
+  std::vector<vector_size_t> keyChannels;
+  keyChannels.reserve(keyColumns.size());
+  for (const auto& keyColumn : keyColumns) {
+    keyChannels.emplace_back(inputType->getChildIdx(keyColumn));
+  }
+  return keyChannels;
+}
+
+RowTypePtr makeOutputType(
+    const RowTypePtr& inputType,
+    const std::vector<std::string>& keyColumns) {
+  const auto keyChannels = getKeyChannels(inputType, keyColumns);
+  std::vector<TypePtr> childTypes;
+  childTypes.reserve(keyChannels.size());
+  for (const auto channel : keyChannels) {
+    childTypes.push_back(inputType->childAt(channel));
+  }
+  return ROW(keyColumns, std::move(childTypes));
+}
+
+vector_size_t checkedVectorSize(size_t size) {
+  VELOX_CHECK_LE(
+      size,
+      static_cast<size_t>(std::numeric_limits<vector_size_t>::max()),
+      "Row count exceeds vector_size_t maximum: {}",
+      size);
+  return static_cast<vector_size_t>(size);
+}
+
+column_index_t checkedColumnIndex(size_t index) {
+  VELOX_CHECK_LE(
+      index,
+      static_cast<size_t>(std::numeric_limits<column_index_t>::max()),
+      "Column index exceeds column_index_t maximum: {}",
+      index);
+  return static_cast<column_index_t>(index);
+}
+
+StringView makeStringView(std::string_view value) {
+  VELOX_CHECK_LE(
+      value.size(),
+      static_cast<size_t>(std::numeric_limits<int32_t>::max()),
+      "Decoded string exceeds StringView maximum length: {}",
+      value.size());
+  return StringView(value.data(), static_cast<int32_t>(value.size()));
+}
+
+struct Cursor {
+  const std::string_view encodedKey;
+  size_t offset_{0};
+
+  explicit Cursor(std::string_view encodedKey) : encodedKey{encodedKey} {}
+
+  uint8_t readRawByte() {
+    VELOX_CHECK_LT(
+        offset_,
+        encodedKey.size(),
+        "Malformed encoded key: unexpected end of key at offset {}",
+        offset());
+    return static_cast<uint8_t>(encodedKey.at(offset_++));
+  }
+
+  template <typename T>
+  T readRawBytes() {
+    VELOX_CHECK_GE(
+        remaining(),
+        sizeof(T),
+        "Malformed encoded key: need {} byte(s) at offset {}, only {} byte(s) remain",
+        sizeof(T),
+        offset(),
+        remaining());
+
+    T value;
+    auto* bytes = reinterpret_cast<uint8_t*>(&value);
+    for (size_t i = 0; i < sizeof(T); ++i) {
+      bytes[i] = readRawByte();
+    }
+    return value;
+  }
+
+  size_t offset() const {
+    return offset_;
+  }
+
+  size_t remaining() const {
+    return encodedKey.size() - offset_;
+  }
+};
+
+// Reverses KeyEncoder's bytewise inversion for descending sort order.
+FOLLY_ALWAYS_INLINE uint8_t decodeByte(uint8_t value, bool descending) {
+  return descending ? static_cast<uint8_t>(0xff ^ value) : value;
+}
+
+bool decodeNullMarker(Cursor& cursor, bool nullLast) {
+  const auto marker = cursor.readRawByte();
+  const auto nullByte = static_cast<uint8_t>(nullLast);
+  const auto nonNullByte = static_cast<uint8_t>(!nullLast);
+  VELOX_CHECK(
+      marker == nullByte || marker == nonNullByte,
+      "Malformed encoded key: invalid null marker {} at offset {}",
+      static_cast<uint32_t>(marker),
+      cursor.offset() - 1);
+  return marker == nullByte;
+}
+
+template <typename T>
+T decodeFixedWidth(Cursor& cursor, bool descending) {
+  using UnsignedT = std::make_unsigned_t<T>;
+
+  UnsignedT value = cursor.readRawBytes<UnsignedT>();
+  if (descending) {
+    value = ~value;
+  }
+  value = folly::Endian::big(value);
+
+  if constexpr (std::is_signed_v<T>) {
+    constexpr int kSignBitShift = sizeof(T) * 8 - 1;
+    value ^= (UnsignedT{1} << kSignBitShift);
+  }
+
+  return static_cast<T>(value);
+}
+
+bool decodeBoolean(Cursor& cursor, bool descending) {
+  const auto decoded = decodeByte(cursor.readRawByte(), descending);
+  VELOX_CHECK(
+      decoded == 1 || decoded == 2,
+      "Malformed encoded key: invalid boolean byte {} at offset {}",
+      static_cast<uint32_t>(decoded),
+      cursor.offset() - 1);
+  return decoded == 2;
+}
+
+std::string decodeString(Cursor& cursor, bool descending) {
+  std::string result;
+
+  while (true) {
+    const auto decoded = decodeByte(cursor.readRawByte(), descending);
+    if (decoded == 0) {
+      return result;
+    }
+
+    if (decoded == 1) {
+      const auto decodedEscaped = decodeByte(cursor.readRawByte(), descending);
+      VELOX_CHECK(
+          decodedEscaped == 0 || decodedEscaped == 1,
+          "Malformed encoded key: invalid escaped string byte {} at offset {}",
+          static_cast<uint32_t>(decodedEscaped),
+          cursor.offset() - 1);
+      result.push_back(static_cast<char>(decodedEscaped));
+      continue;
+    }
+
+    result.push_back(static_cast<char>(decoded));
+  }
+}
+
+double decodeDouble(Cursor& cursor, bool descending) {
+  constexpr uint64_t kSignBit = 1ULL << 63;
+
+  const uint64_t orderedValue = decodeFixedWidth<uint64_t>(cursor, descending);
+  const uint64_t bits = (orderedValue & kSignBit) != 0
+      ? (orderedValue ^ kSignBit)
+      : ~orderedValue;
+
+  double result;
+  std::memcpy(&result, &bits, sizeof(result));
+  return result;
+}
+
+float decodeReal(Cursor& cursor, bool descending) {
+  constexpr uint32_t kSignBit = 1U << 31;
+
+  const uint32_t orderedValue = decodeFixedWidth<uint32_t>(cursor, descending);
+  const uint32_t bits = (orderedValue & kSignBit) != 0
+      ? (orderedValue ^ kSignBit)
+      : ~orderedValue;
+
+  float result;
+  std::memcpy(&result, &bits, sizeof(result));
+  return result;
+}
+
+void decodeValue(
+    Cursor& cursor,
+    const TypePtr& type,
+    const core::SortOrder& sortOrder,
+    vector_size_t row,
+    VectorPtr& output) {
+  const bool nullLast = !sortOrder.isNullsFirst();
+  const bool descending = !sortOrder.isAscending();
+
+  if (decodeNullMarker(cursor, nullLast)) {
+    output->setNull(row, true);
+    return;
+  }
+
+  if (type->isDate()) {
+    output->asFlatVector<int32_t>()->set(
+        row, decodeFixedWidth<int32_t>(cursor, descending));
+    return;
+  }
+
+  switch (type->kind()) {
+    case TypeKind::BIGINT:
+      output->asFlatVector<int64_t>()->set(
+          row, decodeFixedWidth<int64_t>(cursor, descending));
+      return;
+    case TypeKind::INTEGER:
+      output->asFlatVector<int32_t>()->set(
+          row, decodeFixedWidth<int32_t>(cursor, descending));
+      return;
+    case TypeKind::SMALLINT:
+      output->asFlatVector<int16_t>()->set(
+          row, decodeFixedWidth<int16_t>(cursor, descending));
+      return;
+    case TypeKind::TINYINT:
+      output->asFlatVector<int8_t>()->set(
+          row, decodeFixedWidth<int8_t>(cursor, descending));
+      return;
+    case TypeKind::DOUBLE:
+      output->asFlatVector<double>()->set(
+          row, decodeDouble(cursor, descending));
+      return;
+    case TypeKind::REAL:
+      output->asFlatVector<float>()->set(row, decodeReal(cursor, descending));
+      return;
+    case TypeKind::BOOLEAN:
+      output->asFlatVector<bool>()->set(row, decodeBoolean(cursor, descending));
+      return;
+    case TypeKind::VARCHAR:
+    case TypeKind::VARBINARY: {
+      const auto value = decodeString(cursor, descending);
+      output->asFlatVector<StringView>()->set(row, makeStringView(value));
+      return;
+    }
+    case TypeKind::TIMESTAMP: {
+      const auto seconds = decodeFixedWidth<int64_t>(cursor, descending);
+      const auto nanos = decodeFixedWidth<uint64_t>(cursor, descending);
+      output->asFlatVector<Timestamp>()->set(row, Timestamp(seconds, nanos));
+      return;
+    }
+    case TypeKind::HUGEINT:
+    case TypeKind::ARRAY:
+    case TypeKind::MAP:
+    case TypeKind::ROW:
+    case TypeKind::UNKNOWN:
+    case TypeKind::FUNCTION:
+    case TypeKind::OPAQUE:
+    case TypeKind::INVALID:
+      VELOX_UNSUPPORTED("Unsupported type: {}", type->kind());
+  }
+}
+
+} // namespace
+
+// static.
+std::unique_ptr<KeyDecoder> KeyDecoder::create(
+    const std::vector<std::string>& keyColumns,
+    RowTypePtr inputType,
+    std::vector<core::SortOrder> sortOrders,
+    memory::MemoryPool* pool) {
+  return std::unique_ptr<KeyDecoder>(new KeyDecoder(
+      keyColumns, std::move(inputType), std::move(sortOrders), pool));
+}
+
+KeyDecoder::KeyDecoder(
+    const std::vector<std::string>& keyColumns,
+    RowTypePtr inputType,
+    std::vector<core::SortOrder> sortOrders,
+    memory::MemoryPool* pool)
+    : outputType_{makeOutputType(inputType, keyColumns)},
+      sortOrders_{std::move(sortOrders)},
+      pool_{pool} {
+  VELOX_CHECK_GT(outputType_->size(), 0);
+  VELOX_CHECK_EQ(
+      outputType_->size(),
+      sortOrders_.size(),
+      "Size mismatch between key columns and sort orders");
+
+  for (size_t i = 0; i < outputType_->size(); ++i) {
+    const auto column = checkedColumnIndex(i);
+    const auto& columnType = outputType_->childAt(column);
+    VELOX_CHECK(
+        isValidIndexColumnType(columnType),
+        "Unsupported type for index column '{}': {}",
+        outputType_->nameOf(column),
+        columnType->toString());
+  }
+}
+
+RowVectorPtr KeyDecoder::decode(
+    std::span<const std::string_view> encodedKeys) const {
+  const auto numRows = checkedVectorSize(encodedKeys.size());
+  std::vector<VectorPtr> children;
+  children.reserve(outputType_->size());
+  for (size_t i = 0; i < outputType_->size(); ++i) {
+    const auto column = checkedColumnIndex(i);
+    children.push_back(
+        BaseVector::create(outputType_->childAt(column), numRows, pool_));
+  }
+
+  for (vector_size_t row = 0; row < numRows; ++row) {
+    Cursor cursor(encodedKeys[static_cast<size_t>(row)]);
+    for (size_t column = 0; column < outputType_->size(); ++column) {
+      const auto columnIndex = checkedColumnIndex(column);
+      decodeValue(
+          cursor,
+          outputType_->childAt(columnIndex),
+          sortOrders_[column],
+          row,
+          children.at(column));
+    }
+
+    VELOX_CHECK_EQ(
+        cursor.remaining(),
+        0,
+        "Malformed encoded key: {} trailing byte(s) remain after decoding row {}",
+        cursor.remaining(),
+        row);
+  }
+
+  return std::make_shared<RowVector>(
+      pool_, outputType_, nullptr, numRows, std::move(children));
+}
+
+RowVectorPtr KeyDecoder::decode(
+    std::span<const std::string> encodedKeys) const {
+  std::vector<std::string_view> views;
+  views.reserve(encodedKeys.size());
+  for (const auto& key : encodedKeys) {
+    views.emplace_back(key);
+  }
+  return decode(std::span<const std::string_view>(views));
+}
+
+} // namespace facebook::velox::serializer

--- a/velox/serializers/KeyDecoder.h
+++ b/velox/serializers/KeyDecoder.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <memory>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "velox/common/memory/Memory.h"
+#include "velox/core/PlanNode.h"
+#include "velox/type/Type.h"
+#include "velox/vector/ComplexVector.h"
+
+namespace facebook::velox::serializer {
+
+/// KeyDecoder decodes byte-comparable keys produced by KeyEncoder back into
+/// Velox vectors. The decoded RowVector contains only the key columns, in the
+/// same order passed to create().
+///
+/// Floating point values round-trip through KeyEncoder's canonicalized
+/// representation. In particular, all NaNs decode as canonical quiet NaNs and
+/// -0.0 decodes as +0.0.
+class KeyDecoder {
+ public:
+  /// Factory method to create a KeyDecoder instance.
+  ///
+  /// @param keyColumns Names of columns included in the encoded key, in order
+  /// @param inputType Row type used to look up column types by name
+  /// @param sortOrders Sort order for each key column (ascending/descending,
+  ///                   nulls first/last)
+  /// @param pool Memory pool for allocations
+  /// @return Unique pointer to a new KeyDecoder instance
+  static std::unique_ptr<KeyDecoder> create(
+      const std::vector<std::string>& keyColumns,
+      RowTypePtr inputType,
+      std::vector<core::SortOrder> sortOrders,
+      memory::MemoryPool* pool);
+
+  /// Decodes byte-comparable keys back into a RowVector of key columns.
+  RowVectorPtr decode(std::span<const std::string_view> encodedKeys) const;
+
+  /// Convenience overload for string-backed encoded keys.
+  RowVectorPtr decode(std::span<const std::string> encodedKeys) const;
+
+  /// Returns the decoded output type. This contains only the key columns in
+  /// the order passed to create().
+  const RowTypePtr& outputType() const {
+    return outputType_;
+  }
+
+  /// Returns the sort orders for each key column.
+  const std::vector<core::SortOrder>& sortOrders() const {
+    return sortOrders_;
+  }
+
+ private:
+  KeyDecoder(
+      const std::vector<std::string>& keyColumns,
+      RowTypePtr inputType,
+      std::vector<core::SortOrder> sortOrders,
+      memory::MemoryPool* pool);
+
+  const RowTypePtr outputType_;
+  const std::vector<core::SortOrder> sortOrders_;
+  memory::MemoryPool* const pool_;
+};
+
+} // namespace facebook::velox::serializer

--- a/velox/serializers/tests/CMakeLists.txt
+++ b/velox/serializers/tests/CMakeLists.txt
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_executable(velox_key_encoder_test KeyEncoderTest.cpp)
+add_executable(velox_key_encoder_test KeyDecoderTest.cpp KeyEncoderTest.cpp)
 
 add_test(
   NAME velox_key_encoder_test
@@ -32,7 +32,8 @@ target_link_libraries(
   GTest::gmock
 )
 
-# Split velox_serializer_test into individual test binaries for parallel execution.
+# Split velox_serializer_test into individual test binaries for parallel
+# execution.
 set(
   VELOX_SERIALIZER_TEST_SOURCES
   CompactRowSerializerTest.cpp

--- a/velox/serializers/tests/KeyDecoderTest.cpp
+++ b/velox/serializers/tests/KeyDecoderTest.cpp
@@ -1,0 +1,396 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/serializers/KeyDecoder.h"
+
+#include <cstring>
+#include <limits>
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/serializers/KeyEncoder.h"
+#include "velox/type/Timestamp.h"
+#include "velox/type/Type.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+namespace facebook::velox::serializer::test {
+namespace {
+
+class KeyDecoderTest : public velox::exec::test::OperatorTestBase {
+ protected:
+  template <typename T>
+  static T& checkedReference(const std::unique_ptr<T>& pointer) {
+    VELOX_CHECK_NOT_NULL(pointer.get());
+    // @lint-ignore NULLSAFECLANG nullable-dereference
+    return *pointer;
+  }
+
+  RowVectorPtr encodeAndDecode(
+      const RowVectorPtr& input,
+      const std::vector<std::string>& keyColumns,
+      const std::vector<velox::core::SortOrder>& sortOrders) {
+    auto encoder = KeyEncoder::create(
+        keyColumns, asRowType(input->type()), sortOrders, pool_.get());
+    auto decoder = KeyDecoder::create(
+        keyColumns, asRowType(input->type()), sortOrders, pool_.get());
+    auto& keyEncoder = checkedReference(encoder);
+    auto& keyDecoder = checkedReference(decoder);
+
+    std::vector<char> buffer;
+    std::vector<std::string_view> encodedKeys;
+    keyEncoder.encode(input, encodedKeys, [&buffer](size_t size) -> void* {
+      buffer.resize(size);
+      return buffer.data();
+    });
+
+    return keyDecoder.decode(std::span<const std::string_view>(encodedKeys));
+  }
+
+  std::vector<std::string> encodeToStrings(
+      const RowVectorPtr& input,
+      const std::vector<std::string>& keyColumns,
+      const std::vector<velox::core::SortOrder>& sortOrders) {
+    auto encoder = KeyEncoder::create(
+        keyColumns, asRowType(input->type()), sortOrders, pool_.get());
+    auto& keyEncoder = checkedReference(encoder);
+
+    std::vector<char> buffer;
+    std::vector<std::string_view> encodedViews;
+    keyEncoder.encode(input, encodedViews, [&buffer](size_t size) -> void* {
+      buffer.resize(size);
+      return buffer.data();
+    });
+
+    std::vector<std::string> encodedKeys;
+    encodedKeys.reserve(encodedViews.size());
+    for (const auto encodedView : encodedViews) {
+      encodedKeys.emplace_back(encodedView.data(), encodedView.size());
+    }
+    return encodedKeys;
+  }
+
+  RowVectorPtr projectKeyColumns(
+      const RowVectorPtr& input,
+      const std::vector<std::string>& keyColumns) {
+    const auto inputType = asRowType(input->type());
+
+    std::vector<TypePtr> childTypes;
+    std::vector<VectorPtr> children;
+    childTypes.reserve(keyColumns.size());
+    children.reserve(keyColumns.size());
+
+    for (const auto& keyColumn : keyColumns) {
+      const auto channel = inputType->getChildIdx(keyColumn);
+      childTypes.push_back(inputType->childAt(channel));
+      children.push_back(input->childAt(channel));
+    }
+
+    return std::make_shared<RowVector>(
+        pool_.get(),
+        ROW(keyColumns, childTypes),
+        nullptr,
+        input->size(),
+        children);
+  }
+
+  std::vector<velox::core::SortOrder> repeatedSortOrders(
+      size_t count,
+      const velox::core::SortOrder& sortOrder) {
+    return std::vector<velox::core::SortOrder>(count, sortOrder);
+  }
+
+  static StringView stringView(std::string_view value) {
+    VELOX_CHECK_LE(
+        value.size(),
+        static_cast<size_t>(std::numeric_limits<int32_t>::max()),
+        "Test string exceeds StringView maximum length: {}",
+        value.size());
+    return StringView(value.data(), static_cast<int32_t>(value.size()));
+  }
+
+  static double bitsToDouble(uint64_t bits) {
+    double value;
+    std::memcpy(&value, &bits, sizeof(value));
+    return value;
+  }
+
+  static float bitsToFloat(uint32_t bits) {
+    float value;
+    std::memcpy(&value, &bits, sizeof(value));
+    return value;
+  }
+
+  static uint64_t doubleToBits(double value) {
+    uint64_t bits;
+    std::memcpy(&bits, &value, sizeof(bits));
+    return bits;
+  }
+
+  static uint32_t floatToBits(float value) {
+    uint32_t bits;
+    std::memcpy(&bits, &value, sizeof(bits));
+    return bits;
+  }
+};
+
+TEST_F(KeyDecoderTest, roundTripAllSupportedTypesWithoutNulls) {
+  const std::string varchar0("alpha");
+  const std::string varchar1({char(0), char(1), 'b', 'e', 't', 'a'});
+  const std::string varchar2("omega");
+
+  const std::string binary0({char(0), char(1), char(2)});
+  const std::string binary1({char(0xff), char(0), char(1)});
+  const std::string binary2("bin");
+
+  auto input = makeRowVector(
+      {makeFlatVector<int64_t>({-9, 0, 99}),
+       makeFlatVector<int32_t>({-1234, 0, 5678}),
+       makeFlatVector<int16_t>({-12, 0, 12}),
+       makeFlatVector<int8_t>({-5, 0, 5}),
+       makeFlatVector<double>({-12.5, 0.5, 42.25}),
+       makeFlatVector<float>({-3.5f, 0.25f, 7.75f}),
+       makeFlatVector<bool>({true, false, true}),
+       makeFlatVector<StringView>(
+           {stringView(varchar0), stringView(varchar1), stringView(varchar2)},
+           VARCHAR()),
+       makeFlatVector<StringView>(
+           {stringView(binary0), stringView(binary1), stringView(binary2)},
+           VARBINARY()),
+       makeFlatVector<Timestamp>(
+           {Timestamp(-100, 1), Timestamp(0, 0), Timestamp(123, 999'999'999)}),
+       makeFlatVector<int32_t>({-1, 0, 365}, DATE())});
+
+  const std::vector<std::string> keyColumns = {
+      "c8", "c0", "c10", "c7", "c3", "c9", "c1", "c6", "c2", "c4", "c5"};
+
+  const auto expected = projectKeyColumns(input, keyColumns);
+  for (const auto& sortOrder :
+       {velox::core::kAscNullsFirst,
+        velox::core::kAscNullsLast,
+        velox::core::kDescNullsFirst,
+        velox::core::kDescNullsLast}) {
+    SCOPED_TRACE(
+        fmt::format(
+            "sortOrder={}{}",
+            sortOrder.isAscending() ? "ASC" : "DESC",
+            sortOrder.isNullsFirst() ? "_NULLS_FIRST" : "_NULLS_LAST"));
+    const auto decoded = encodeAndDecode(
+        input, keyColumns, repeatedSortOrders(keyColumns.size(), sortOrder));
+    velox::test::assertEqualVectors(expected, decoded);
+  }
+}
+
+TEST_F(KeyDecoderTest, roundTripAllSupportedTypesWithNulls) {
+  const std::string varchar0("alpha");
+  const std::string varchar2({char(0), char(1), 't', 'a', 'i', 'l'});
+
+  const std::string binary0({char(0), char(1)});
+  const std::string binary2({char(0xfe), char(0xff)});
+
+  auto input = makeRowVector(
+      {makeNullableFlatVector<int64_t>({-9, std::nullopt, 99}),
+       makeNullableFlatVector<int32_t>({-1234, std::nullopt, 5678}),
+       makeNullableFlatVector<int16_t>({-12, std::nullopt, 12}),
+       makeNullableFlatVector<int8_t>({-5, std::nullopt, 5}),
+       makeNullableFlatVector<double>({-12.5, std::nullopt, 42.25}),
+       makeNullableFlatVector<float>({-3.5f, std::nullopt, 7.75f}),
+       makeNullableFlatVector<bool>({true, std::nullopt, false}),
+       makeNullableFlatVector<StringView>(
+           {stringView(varchar0), std::nullopt, stringView(varchar2)},
+           VARCHAR()),
+       makeNullableFlatVector<StringView>(
+           {stringView(binary0), std::nullopt, stringView(binary2)},
+           VARBINARY()),
+       makeNullableFlatVector<Timestamp>(
+           {Timestamp(-100, 1), std::nullopt, Timestamp(123, 999'999'999)}),
+       makeNullableFlatVector<int32_t>({-1, std::nullopt, 365}, DATE())});
+
+  const std::vector<std::string> keyColumns = {
+      "c9", "c7", "c1", "c10", "c3", "c8", "c0", "c6", "c2", "c4", "c5"};
+
+  const auto expected = projectKeyColumns(input, keyColumns);
+  for (const auto& sortOrder :
+       {velox::core::kAscNullsFirst,
+        velox::core::kAscNullsLast,
+        velox::core::kDescNullsFirst,
+        velox::core::kDescNullsLast}) {
+    SCOPED_TRACE(
+        fmt::format(
+            "sortOrder={}{}",
+            sortOrder.isAscending() ? "ASC" : "DESC",
+            sortOrder.isNullsFirst() ? "_NULLS_FIRST" : "_NULLS_LAST"));
+    const auto decoded = encodeAndDecode(
+        input, keyColumns, repeatedSortOrders(keyColumns.size(), sortOrder));
+    velox::test::assertEqualVectors(expected, decoded);
+  }
+}
+
+TEST_F(KeyDecoderTest, roundTripWithMixedSortOrders) {
+  auto input = makeRowVector(
+      {makeNullableFlatVector<int64_t>({7, 3, std::nullopt}),
+       makeNullableFlatVector<StringView>(
+           {stringView("a"), stringView("b"), std::nullopt}, VARCHAR()),
+       makeNullableFlatVector<Timestamp>(
+           {Timestamp(1, 10), Timestamp(2, 20), std::nullopt}),
+       makeNullableFlatVector<float>({1.5f, std::nullopt, -2.5f}),
+       makeNullableFlatVector<int32_t>({10, std::nullopt, -10}, DATE())});
+
+  const std::vector<std::string> keyColumns = {"c4", "c1", "c0", "c3", "c2"};
+  const std::vector<velox::core::SortOrder> sortOrders = {
+      velox::core::kDescNullsLast,
+      velox::core::kAscNullsFirst,
+      velox::core::kDescNullsFirst,
+      velox::core::kAscNullsLast,
+      velox::core::kDescNullsLast,
+  };
+
+  const auto decoded = encodeAndDecode(input, keyColumns, sortOrders);
+  const auto expected = projectKeyColumns(input, keyColumns);
+  velox::test::assertEqualVectors(expected, decoded);
+}
+
+TEST_F(KeyDecoderTest, fuzzRoundTripSupportedKeyTypes) {
+  const auto rowType =
+      ROW({"c0", "c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9", "c10"},
+          {BIGINT(),
+           INTEGER(),
+           SMALLINT(),
+           TINYINT(),
+           DOUBLE(),
+           REAL(),
+           BOOLEAN(),
+           VARCHAR(),
+           VARBINARY(),
+           TIMESTAMP(),
+           DATE()});
+
+  const std::vector<std::string> keyColumns = {
+      "c8", "c0", "c10", "c7", "c3", "c9", "c1", "c6", "c2", "c4", "c5"};
+  const std::vector<std::vector<velox::core::SortOrder>> sortOrderSets = {
+      repeatedSortOrders(keyColumns.size(), velox::core::kAscNullsFirst),
+      repeatedSortOrders(keyColumns.size(), velox::core::kAscNullsLast),
+      repeatedSortOrders(keyColumns.size(), velox::core::kDescNullsFirst),
+      repeatedSortOrders(keyColumns.size(), velox::core::kDescNullsLast),
+      {velox::core::kDescNullsLast,
+       velox::core::kAscNullsFirst,
+       velox::core::kDescNullsFirst,
+       velox::core::kAscNullsLast,
+       velox::core::kDescNullsLast,
+       velox::core::kAscNullsFirst,
+       velox::core::kDescNullsFirst,
+       velox::core::kAscNullsLast,
+       velox::core::kDescNullsLast,
+       velox::core::kAscNullsFirst,
+       velox::core::kDescNullsFirst},
+  };
+
+  VectorFuzzer::Options options;
+  options.vectorSize = 64;
+  options.nullRatio = 0.2;
+  options.stringLength = 32;
+  options.stringVariableLength = true;
+  options.timestampPrecision =
+      VectorFuzzer::Options::TimestampPrecision::kNanoSeconds;
+  VectorFuzzer fuzzer(options, pool_.get());
+
+  constexpr int32_t kNumIterations = 20;
+  for (int32_t iteration = 0; iteration < kNumIterations; ++iteration) {
+    SCOPED_TRACE(fmt::format("iteration={}", iteration));
+    const auto input = fuzzer.fuzzInputFlatRow(rowType);
+    const auto expected = projectKeyColumns(input, keyColumns);
+
+    for (size_t sortOrderIndex = 0; sortOrderIndex < sortOrderSets.size();
+         ++sortOrderIndex) {
+      SCOPED_TRACE(fmt::format("sortOrderIndex={}", sortOrderIndex));
+      const auto& sortOrders = sortOrderSets.at(sortOrderIndex);
+      const auto encodedKeys = encodeToStrings(input, keyColumns, sortOrders);
+      auto decoder =
+          KeyDecoder::create(keyColumns, rowType, sortOrders, pool_.get());
+      auto& keyDecoder = checkedReference(decoder);
+
+      const auto decoded =
+          keyDecoder.decode(std::span<const std::string>(encodedKeys));
+      velox::test::assertEqualVectors(expected, decoded);
+      EXPECT_EQ(encodedKeys, encodeToStrings(decoded, keyColumns, sortOrders));
+    }
+  }
+}
+
+TEST_F(KeyDecoderTest, floatingPointValuesAreCanonicalized) {
+  auto input = makeRowVector(
+      {makeFlatVector<double>(
+           {bitsToDouble(0x8000000000000000ULL),
+            bitsToDouble(0x7ff0000000000001ULL),
+            1.5}),
+       makeFlatVector<float>(
+           {bitsToFloat(0x80000000U), bitsToFloat(0x7f800001U), -2.5f})});
+
+  const auto decoded = encodeAndDecode(
+      input,
+      {"c0", "c1"},
+      {velox::core::kAscNullsFirst, velox::core::kAscNullsFirst});
+
+  const auto* doubleValues = decoded->childAt(0)->asFlatVector<double>();
+  const auto* floatValues = decoded->childAt(1)->asFlatVector<float>();
+
+  EXPECT_EQ(doubleToBits(doubleValues->valueAt(0)), 0);
+  EXPECT_EQ(floatToBits(floatValues->valueAt(0)), 0);
+
+  EXPECT_EQ(doubleToBits(doubleValues->valueAt(1)), 0x7ff8000000000000ULL);
+  EXPECT_EQ(floatToBits(floatValues->valueAt(1)), 0x7fc00000U);
+
+  EXPECT_EQ(doubleValues->valueAt(2), 1.5);
+  EXPECT_EQ(floatValues->valueAt(2), -2.5f);
+}
+
+TEST_F(KeyDecoderTest, malformedEncodedKeysThrow) {
+  auto decoder = KeyDecoder::create(
+      {"c0", "c1"},
+      ROW({"c0", "c1"}, {BIGINT(), VARCHAR()}),
+      {velox::core::kAscNullsFirst, velox::core::kAscNullsFirst},
+      pool_.get());
+  auto& keyDecoder = checkedReference(decoder);
+
+  {
+    const std::vector<std::string_view> encodedKeys = {
+        std::string_view("\x01\x80", 2)};
+    VELOX_ASSERT_THROW(
+        keyDecoder.decode(std::span<const std::string_view>(encodedKeys)),
+        "Malformed");
+  }
+
+  {
+    const std::vector<std::string_view> encodedKeys = {
+        std::string_view("\x01\x80\x00", 3)};
+    VELOX_ASSERT_THROW(
+        keyDecoder.decode(std::span<const std::string_view>(encodedKeys)),
+        "Malformed");
+  }
+
+  {
+    const std::vector<std::string_view> encodedKeys = {std::string_view(
+        "\x01\x80\x00\x00\x00\x00\x00\x00\x00\x01\x01\x02\x00", 13)};
+    VELOX_ASSERT_THROW(
+        keyDecoder.decode(std::span<const std::string_view>(encodedKeys)),
+        "invalid escaped string byte");
+  }
+}
+
+} // namespace
+} // namespace facebook::velox::serializer::test


### PR DESCRIPTION
Summary:

Add velox::serializer::KeyDecoder to decode KeyEncoder-compatible composite keys for all supported scalar key column types. Wire the decoder into Buck/CMake and add round-trip plus malformed-input coverage.

Reviewed By: xiaoxmeng

Differential Revision: D101708729


