### PR TITLE
fix: Deletion vector offsets must comply with spec

### DIFF
--- a/velox/connectors/hive/iceberg/DeletionVectorReader.cpp
+++ b/velox/connectors/hive/iceberg/DeletionVectorReader.cpp
@@ -27,6 +27,7 @@ namespace facebook::velox::connector::hive::iceberg {
 namespace {
 static constexpr uint32_t kSerialCookieNoRun = 12'346;
 static constexpr uint32_t kSerialCookie = 12'347;
+static constexpr uint32_t kRunContainersNoOffsetThreshold = 4;
 } // namespace
 
 DeletionVectorReader::DeletionVectorReader(
@@ -226,7 +227,8 @@ void DeletionVectorReader::deserializeRoaring64Bitmap(const std::string& data) {
     }
 
     // Skip offset section
-    const bool hasOffsetSection = !hasRunContainers || numContainers >= 4;
+    const bool hasOffsetSection =
+        !hasRunContainers || numContainers >= kRunContainersNoOffsetThreshold;
     if (hasOffsetSection) {
       ptr += numContainers * sizeof(uint32_t);
     }
@@ -317,7 +319,8 @@ void DeletionVectorReader::deserialize32BitRoaringBitmap(
   }
 
   // Skip offset section
-  const bool hasOffsetSection = !hasRunContainers || numContainers >= 4;
+  const bool hasOffsetSection =
+      !hasRunContainers || numContainers >= kRunContainersNoOffsetThreshold;
   if (hasOffsetSection) {
     VELOX_CHECK_GE(
         static_cast<size_t>(end - ptr),

--- a/velox/connectors/hive/iceberg/DeletionVectorReader.cpp
+++ b/velox/connectors/hive/iceberg/DeletionVectorReader.cpp
@@ -225,8 +225,9 @@ void DeletionVectorReader::deserializeRoaring64Bitmap(const std::string& data) {
       containers[i] = {key, static_cast<uint32_t>(cardMinus1) + 1, isRun};
     }
 
-    // Skip offset section.
-    if (numContainers >= 4) {
+    // Skip offset section
+    const bool hasOffsetSection = !hasRunContainers || numContainers >= 4;
+    if (hasOffsetSection) {
       ptr += numContainers * sizeof(uint32_t);
     }
 
@@ -315,8 +316,9 @@ void DeletionVectorReader::deserialize32BitRoaringBitmap(
     containers[i] = {key, static_cast<uint32_t>(cardMinus1) + 1};
   }
 
-  // Skip offset section.
-  if (numContainers >= 4) {
+  // Skip offset section
+  const bool hasOffsetSection = !hasRunContainers || numContainers >= 4;
+  if (hasOffsetSection) {
     VELOX_CHECK_GE(
         static_cast<size_t>(end - ptr),
         numContainers * 4,

--- a/velox/connectors/hive/iceberg/DeletionVectorWriter.cpp
+++ b/velox/connectors/hive/iceberg/DeletionVectorWriter.cpp
@@ -30,7 +30,6 @@ namespace {
 
 // Roaring Bitmap portable format constants.
 constexpr uint32_t kSerialCookieNoRun = 12'346;
-constexpr uint32_t kNoOffsetThreshold = 4;
 constexpr uint32_t kMaxArrayContainerCardinality = 4'096;
 // Full bitmap container: 2^16 bits = 1024 uint64 words = 8192 bytes.
 constexpr size_t kBitmapContainerBytes = 8'192;
@@ -159,9 +158,7 @@ std::string DeletionVectorWriter::serialize32(
   writeLittleEndian(data, kSerialCookieNoRun);
   writeLittleEndian(data, numContainers);
   serializeKeyCardinality(data, containers);
-  if (numContainers >= kNoOffsetThreshold) {
-    serializeOffsets(data, containers);
-  }
+  serializeOffsets(data, containers);
   serializeContainerData(data, containers);
   return data;
 }

--- a/velox/connectors/hive/iceberg/tests/DeletionVectorReaderTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/DeletionVectorReaderTest.cpp
@@ -32,9 +32,9 @@ using namespace facebook::velox::common::testutil;
 
 namespace {
 
-/// Serializes a roaring bitmap in the portable format (no-run variant,
-/// cookie = 12346). Supports only array containers (cardinality <= 4096).
-/// This is the simplest format the DeletionVectorReader needs to parse.
+// Serializes a roaring bitmap in the portable format (no-run variant,
+// cookie = 12346). Supports only array containers (cardinality <= 4096).
+// This is the simplest format the DeletionVectorReader needs to parse.
 std::string serializeRoaringBitmapNoRun(const std::vector<int64_t>& positions) {
   if (positions.empty()) {
     // Empty bitmap: cookie + 0 containers.
@@ -93,8 +93,8 @@ std::string serializeRoaringBitmapNoRun(const std::vector<int64_t>& positions) {
   return data;
 }
 
-/// Serializes a roaring bitmap in the portable format with run containers
-/// (cookie = 12347). All containers are run-encoded.
+// Serializes a roaring bitmap in the portable format with run containers
+// (cookie = 12347). All containers are run-encoded.
 std::string serializeRoaringBitmapWithRuns(
     const std::vector<
         std::pair<uint16_t, std::vector<std::pair<uint16_t, uint16_t>>>>&
@@ -161,9 +161,9 @@ std::string serializeRoaringBitmapWithRuns(
   return data;
 }
 
-/// Expands a list of run-encoded containers into the full set of positions
-/// they represent. Each container is keyed by its high 16 bits and contains
-/// runs of (start, lengthMinus1)
+// Expands a list of run-encoded containers into the full set of positions
+// they represent. Each container is keyed by its high 16 bits and contains
+// runs of (start, lengthMinus1)
 std::vector<uint64_t> expandRuns(
     const std::vector<
         std::pair<uint16_t, std::vector<std::pair<uint16_t, uint16_t>>>>&
@@ -180,7 +180,7 @@ std::vector<uint64_t> expandRuns(
   return result;
 }
 
-/// Writes binary data to a temp file and returns the path.
+// Writes binary data to a temp file and returns the path.
 std::shared_ptr<TempFilePath> writeDvFile(const std::string& bitmapData) {
   auto tempFile = TempFilePath::create();
   // Write directly via C++ streams since TempFilePath already creates the
@@ -192,7 +192,7 @@ std::shared_ptr<TempFilePath> writeDvFile(const std::string& bitmapData) {
   return tempFile;
 }
 
-/// Creates an IcebergDeleteFile for a deletion vector.
+// Creates an IcebergDeleteFile for a deletion vector.
 IcebergDeleteFile makeDvDeleteFile(
     const std::string& filePath,
     uint64_t recordCount,
@@ -223,7 +223,7 @@ IcebergDeleteFile makeDvDeleteFile(
       upperBounds);
 }
 
-/// Extracts which bits are set in a bitmap buffer.
+// Extracts which bits are set in a bitmap buffer.
 std::vector<uint64_t> getSetBits(const BufferPtr& bitmap, uint64_t size) {
   auto* raw = bitmap->as<uint8_t>();
   std::vector<uint64_t> result;

--- a/velox/connectors/hive/iceberg/tests/DeletionVectorReaderTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/DeletionVectorReaderTest.cpp
@@ -132,9 +132,9 @@ std::string serializeRoaringBitmapWithRuns(
     data.append(reinterpret_cast<const char*>(&cardMinus1), 2);
   }
 
-  // Offset section (required for >= 4 containers)
-  constexpr uint32_t kRunContainerNoOffsetThreshold = 4;
-  if (numContainers >= kRunContainerNoOffsetThreshold) {
+  // Offset section (required for >= 4)
+  constexpr uint32_t kRunContainersNoOffsetThreshold = 4;
+  if (numContainers >= kRunContainersNoOffsetThreshold) {
     // First container offset = cookie (4) + runBitmap (runBitmapBytes)
     // + descriptive header (4 * numContainers) + offset header
     // (4 * numContainers).

--- a/velox/connectors/hive/iceberg/tests/DeletionVectorReaderTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/DeletionVectorReaderTest.cpp
@@ -161,6 +161,25 @@ std::string serializeRoaringBitmapWithRuns(
   return data;
 }
 
+/// Expands a list of run-encoded containers into the full set of positions
+/// they represent. Each container is keyed by its high 16 bits and contains
+/// runs of (start, lengthMinus1)
+std::vector<uint64_t> expandRuns(
+    const std::vector<
+        std::pair<uint16_t, std::vector<std::pair<uint16_t, uint16_t>>>>&
+        containerRuns) {
+  std::vector<uint64_t> result;
+  for (const auto& [key, runs] : containerRuns) {
+    const uint64_t base = static_cast<uint64_t>(key) * 65536;
+    for (const auto& [start, lengthMinus1] : runs) {
+      for (uint64_t i = 0; i <= lengthMinus1; ++i) {
+        result.push_back(base + start + i);
+      }
+    }
+  }
+  return result;
+}
+
 /// Writes binary data to a temp file and returns the path.
 std::shared_ptr<TempFilePath> writeDvFile(const std::string& bitmapData) {
   auto tempFile = TempFilePath::create();
@@ -370,7 +389,9 @@ TEST_F(DeletionVectorReaderTest, runContainers) {
   auto tempFile = writeDvFile(bitmapData);
   auto fileSize = static_cast<uint64_t>(bitmapData.size());
 
-  auto dvFile = makeDvDeleteFile(tempFile->getPath(), 20, fileSize);
+  auto expected = expandRuns(containerRuns);
+  auto dvFile =
+      makeDvDeleteFile(tempFile->getPath(), expected.size(), fileSize);
 
   DeletionVectorReader reader(dvFile, 0, pool_.get());
 
@@ -378,14 +399,6 @@ TEST_F(DeletionVectorReaderTest, runContainers) {
   reader.readDeletePositions(0, 100, bitmap);
 
   auto setBits = getSetBits(bitmap, 100);
-  // Expect positions 10-19 and 50-59.
-  std::vector<uint64_t> expected;
-  for (uint64_t i = 10; i <= 19; ++i) {
-    expected.push_back(i);
-  }
-  for (uint64_t i = 50; i <= 59; ++i) {
-    expected.push_back(i);
-  }
   EXPECT_EQ(setBits, expected);
   EXPECT_TRUE(reader.noMoreData());
 }
@@ -402,7 +415,9 @@ TEST_F(DeletionVectorReaderTest, runContainersWithOffsetHeader) {
   auto tempFile = writeDvFile(bitmapData);
   auto fileSize = static_cast<uint64_t>(bitmapData.size());
 
-  auto dvFile = makeDvDeleteFile(tempFile->getPath(), 20, fileSize);
+  auto expected = expandRuns(containerRuns);
+  auto dvFile =
+      makeDvDeleteFile(tempFile->getPath(), expected.size(), fileSize);
 
   DeletionVectorReader reader(dvFile, 0, pool_.get());
 
@@ -411,19 +426,6 @@ TEST_F(DeletionVectorReaderTest, runContainersWithOffsetHeader) {
   reader.readDeletePositions(0, numRows, bitmap);
 
   auto setBits = getSetBits(bitmap, numRows);
-  std::vector<uint64_t> expected;
-  for (uint64_t i = 10; i <= 14; ++i) {
-    expected.push_back(i);
-  }
-  for (uint64_t i = 65536; i <= 65538; ++i) {
-    expected.push_back(i);
-  }
-  expected.push_back(65636);
-  expected.push_back(65637);
-  expected.push_back(131072 + 500);
-  for (uint64_t i = 0; i <= 9; ++i) {
-    expected.push_back(196608 + 1000 + i);
-  }
   EXPECT_EQ(setBits, expected);
   EXPECT_TRUE(reader.noMoreData());
 }

--- a/velox/connectors/hive/iceberg/tests/DeletionVectorReaderTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/DeletionVectorReaderTest.cpp
@@ -133,8 +133,8 @@ std::string serializeRoaringBitmapWithRuns(
   }
 
   // Offset section (required for >= 4 containers)
-  constexpr uint32_t kNoOffsetThreshold = 4;
-  if (numContainers >= kNoOffsetThreshold) {
+  constexpr uint32_t kRunContainerNoOffsetThreshold = 4;
+  if (numContainers >= kRunContainerNoOffsetThreshold) {
     // First container offset = cookie (4) + runBitmap (runBitmapBytes)
     // + descriptive header (4 * numContainers) + offset header
     // (4 * numContainers).

--- a/velox/connectors/hive/iceberg/tests/DeletionVectorReaderTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/DeletionVectorReaderTest.cpp
@@ -62,7 +62,7 @@ std::string serializeRoaringBitmapNoRun(const std::vector<int64_t>& positions) {
 
   std::string data;
   // Cookie.
-  uint32_t cookie = 12346;
+  constexpr uint32_t cookie = 12346;
   data.append(reinterpret_cast<const char*>(&cookie), 4);
   // Container count.
   data.append(reinterpret_cast<const char*>(&numContainers), 4);
@@ -74,8 +74,8 @@ std::string serializeRoaringBitmapNoRun(const std::vector<int64_t>& positions) {
     data.append(reinterpret_cast<const char*>(&cardMinus1), 2);
   }
 
-  // Offset section (required for >= 4 containers).
-  if (numContainers >= 4) {
+  // Offset section (required for > 0 containers)
+  if (numContainers > 0) {
     uint32_t offset = 4 + 4 + numContainers * 4 + numContainers * 4;
     for (auto& [key, vals] : containers) {
       data.append(reinterpret_cast<const char*>(&offset), 4);
@@ -130,6 +130,21 @@ std::string serializeRoaringBitmapWithRuns(
     uint16_t cardMinus1 = static_cast<uint16_t>(cardinalities[i] - 1);
     data.append(reinterpret_cast<const char*>(&key), 2);
     data.append(reinterpret_cast<const char*>(&cardMinus1), 2);
+  }
+
+  // Offset section (required for >= 4 containers)
+  constexpr uint32_t kNoOffsetThreshold = 4;
+  if (numContainers >= kNoOffsetThreshold) {
+    // First container offset = cookie (4) + runBitmap (runBitmapBytes)
+    // + descriptive header (4 * numContainers) + offset header
+    // (4 * numContainers).
+    uint32_t offset =
+        4 + runBitmapBytes + 4 * numContainers + 4 * numContainers;
+    for (auto& [key, runs] : containerRuns) {
+      data.append(reinterpret_cast<const char*>(&offset), 4);
+      // Each run container occupies 2 + 4 * numRuns bytes.
+      offset += 2 + 4 * static_cast<uint32_t>(runs.size());
+    }
   }
 
   // Container data: each run container has numRuns (uint16) followed by
@@ -370,6 +385,44 @@ TEST_F(DeletionVectorReaderTest, runContainers) {
   }
   for (uint64_t i = 50; i <= 59; ++i) {
     expected.push_back(i);
+  }
+  EXPECT_EQ(setBits, expected);
+  EXPECT_TRUE(reader.noMoreData());
+}
+
+TEST_F(DeletionVectorReaderTest, runContainersWithOffsetHeader) {
+  std::vector<std::pair<uint16_t, std::vector<std::pair<uint16_t, uint16_t>>>>
+      containerRuns = {
+          {0, {{10, 4}}}, // positions 10-14
+          {1, {{0, 2}, {100, 1}}}, // positions 65536-65538, 65636-65637
+          {2, {{500, 0}}}, // position 131072+500 = 131572
+          {3, {{1000, 9}}}, // positions 196608+1000..196608+1009
+      };
+  auto bitmapData = serializeRoaringBitmapWithRuns(containerRuns);
+  auto tempFile = writeDvFile(bitmapData);
+  auto fileSize = static_cast<uint64_t>(bitmapData.size());
+
+  auto dvFile = makeDvDeleteFile(tempFile->getPath(), 20, fileSize);
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get());
+
+  const uint64_t numRows = 200'000;
+  auto bitmap = allocateBitmap(numRows);
+  reader.readDeletePositions(0, numRows, bitmap);
+
+  auto setBits = getSetBits(bitmap, numRows);
+  std::vector<uint64_t> expected;
+  for (uint64_t i = 10; i <= 14; ++i) {
+    expected.push_back(i);
+  }
+  for (uint64_t i = 65536; i <= 65538; ++i) {
+    expected.push_back(i);
+  }
+  expected.push_back(65636);
+  expected.push_back(65637);
+  expected.push_back(131072 + 500);
+  for (uint64_t i = 0; i <= 9; ++i) {
+    expected.push_back(196608 + 1000 + i);
   }
   EXPECT_EQ(setBits, expected);
   EXPECT_TRUE(reader.noMoreData());


### PR DESCRIPTION
Fix the deletion vector writer and reader to always (not when numContainers >=4) write/read offsets in case of non-run bitmaps consistent with the [roaring bitmap spec](https://github.com/RoaringBitmap/RoaringFormatSpec#3-offset-header).