### PR TITLE
feat: Add partition key propagation to ScanBatchEvent callback (#17513)

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -28,6 +28,7 @@
 #include "velox/common/future/VeloxPromise.h"
 #include "velox/core/ExpressionEvaluator.h"
 #include "velox/core/QueryConfig.h"
+#include "velox/core/ScanBatchEvent.h"
 #include "velox/exec/SpillStats.h"
 #include "velox/type/Filter.h"
 #include "velox/vector/ComplexVector.h"
@@ -282,6 +283,17 @@ class DataSource {
   /// Returns the number of input rows processed so far.
   virtual uint64_t getCompletedRows() = 0;
 
+  /// Stores a callback to fire after each scan batch.
+  void setScanBatchCallback(core::ScanBatchCallback callback) {
+    scanBatchCallback_ = std::move(callback);
+  }
+
+  /// Called by TableScan after each non-empty batch with generic scan stats.
+  /// Default is a no-op. Subclasses should override to create a
+  /// connector-specific event (e.g., FileScanBatchEvent), enrich it with
+  /// connector-specific fields, and call scanBatchCallback_.
+  virtual void fireScanBatchCallback(core::ScanBatchEvent /*event*/) {}
+
   virtual std::unordered_map<std::string, RuntimeMetric> getRuntimeStats() {
     return {};
   }
@@ -326,6 +338,9 @@ class DataSource {
   /// connector implementation decides how to support the cancellation if
   /// needed.
   virtual void cancel() {}
+
+ protected:
+  core::ScanBatchCallback scanBatchCallback_;
 };
 
 class IndexSource {

--- a/velox/connectors/hive/FileDataSource.cpp
+++ b/velox/connectors/hive/FileDataSource.cpp
@@ -616,6 +616,25 @@ void FileDataSource::addDynamicFilter(
   }
 }
 
+void FileDataSource::fireScanBatchCallback(core::ScanBatchEvent event) {
+  if (!scanBatchCallback_) {
+    return;
+  }
+  FileScanBatchEvent fileEvent;
+  fileEvent.numRows = event.numRows;
+  fileEvent.wallTimeMicros = event.wallTimeMicros;
+  if (tableHandle_) {
+    fileEvent.tableName = tableHandle_->name();
+  }
+  if (split_) {
+    fileEvent.filePath = split_->filePath;
+    if (!split_->partitionKeys.empty()) {
+      fileEvent.partitionKeys = &split_->partitionKeys;
+    }
+  }
+  scanBatchCallback_(fileEvent);
+}
+
 std::unordered_map<std::string, RuntimeMetric>
 FileDataSource::getRuntimeStats() {
   auto res = runtimeStats_.toRuntimeMetricMap();

--- a/velox/connectors/hive/FileDataSource.h
+++ b/velox/connectors/hive/FileDataSource.h
@@ -30,6 +30,18 @@
 
 namespace facebook::velox::connector::hive {
 
+/// File-specific scan batch event with split metadata.
+struct FileScanBatchEvent : public core::ScanBatchEvent {
+  /// Table name from the connector table handle.
+  std::string_view tableName;
+  /// File path of the current split.
+  std::string_view filePath;
+  /// Non-owning pointer to the current split's partition keys.
+  /// Null when partition keys are not available.
+  const std::unordered_map<std::string, std::optional<std::string>>*
+      partitionKeys{nullptr};
+};
+
 class FileConfig;
 
 /// Base class for file-based data sources that read from columnar file formats
@@ -81,6 +93,8 @@ class FileDataSource : public DataSource {
   uint64_t getCompletedRows() override {
     return completedRows_;
   }
+
+  void fireScanBatchCallback(core::ScanBatchEvent event) override;
 
   std::unordered_map<std::string, RuntimeMetric> getRuntimeStats() override;
 

--- a/velox/core/CMakeLists.txt
+++ b/velox/core/CMakeLists.txt
@@ -35,6 +35,7 @@ velox_add_library(
   PlanNode.h
   QueryConfig.h
   QueryCtx.h
+  ScanBatchEvent.h
   SimpleFunctionMetadata.h
   TableWriteTraits.h
 )

--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -27,6 +27,7 @@
 #include "velox/common/caching/AsyncDataCache.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/core/QueryConfig.h"
+#include "velox/core/ScanBatchEvent.h"
 #include "velox/vector/DecodedVector.h"
 #include "velox/vector/VectorPool.h"
 
@@ -35,16 +36,6 @@ class TraceCtx;
 } // namespace facebook::velox::exec::trace
 
 namespace facebook::velox::core {
-
-/// Per-batch scan statistics event fired by TableScan after each batch.
-struct ScanBatchEvent {
-  /// Post-pushdown, pre-remaining-filter row count.
-  uint64_t numRows;
-  /// Wall time spent producing this batch in microseconds.
-  uint64_t wallTimeMicros;
-  /// Table name from the connector table handle.
-  std::string_view tableName;
-};
 
 struct PlanFragment;
 
@@ -330,8 +321,6 @@ class QueryCtx : public std::enable_shared_from_this<QueryCtx> {
   void setTraceCtxProvider(TraceCtxProvider provider) {
     traceCtxProvider_ = std::move(provider);
   }
-
-  using ScanBatchCallback = std::function<void(const ScanBatchEvent&)>;
 
   /// Sets an optional callback fired by TableScan after each non-empty batch.
   void setScanBatchCallback(ScanBatchCallback callback) {

--- a/velox/core/ScanBatchEvent.h
+++ b/velox/core/ScanBatchEvent.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+#include <functional>
+
+namespace facebook::velox::core {
+
+/// Per-batch scan statistics event fired by TableScan after each batch.
+struct ScanBatchEvent {
+  virtual ~ScanBatchEvent() = default;
+
+  /// Post-pushdown, pre-remaining-filter row count.
+  uint64_t numRows{0};
+  /// Wall time spent producing this batch in microseconds.
+  uint64_t wallTimeMicros{0};
+};
+
+using ScanBatchCallback = std::function<void(const ScanBatchEvent&)>;
+
+} // namespace facebook::velox::core

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -234,14 +234,10 @@ RowVectorPtr TableScan::getOutput() {
           const auto completedRowsDelta =
               dataSource_->getCompletedRows() - prevCompletedRows;
           if (completedRowsDelta > 0) {
-            if (const auto& callback = operatorCtx_->driverCtx()
-                                           ->task->queryCtx()
-                                           ->scanBatchCallback()) {
-              callback(
-                  {.numRows = completedRowsDelta,
-                   .wallTimeMicros = ioTimeUs,
-                   .tableName = tableHandle_->name()});
-            }
+            core::ScanBatchEvent event;
+            event.numRows = completedRowsDelta;
+            event.wallTimeMicros = ioTimeUs;
+            dataSource_->fireScanBatchCallback(event);
           }
           maxFilteringRatio_ = std::max(
               {maxFilteringRatio_,
@@ -368,6 +364,10 @@ bool TableScan::getSplit() {
         tableHandle_,
         columnHandles_,
         connectorQueryCtx_.get());
+    if (const auto& callback =
+            operatorCtx_->driverCtx()->task->queryCtx()->scanBatchCallback()) {
+      dataSource_->setScanBatchCallback(callback);
+    }
   }
 
   debugString_ = fmt::format(

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -6793,7 +6793,10 @@ TEST_F(TableScanTest, scanBatchCallback) {
   auto queryCtx = core::QueryCtx::create(executor_.get());
   queryCtx->setScanBatchCallback([&](const core::ScanBatchEvent& event) {
     totalRows += event.numRows;
-    receivedTableName = std::string(event.tableName);
+    if (const auto* fileEvent =
+            dynamic_cast<const connector::hive::FileScanBatchEvent*>(&event)) {
+      receivedTableName = std::string(fileEvent->tableName);
+    }
     ++callbackCount;
   });
 
@@ -6806,6 +6809,51 @@ TEST_F(TableScanTest, scanBatchCallback) {
   EXPECT_GT(totalRows, 0);
   EXPECT_GT(callbackCount, 0);
   EXPECT_FALSE(receivedTableName.empty());
+}
+
+TEST_F(TableScanTest, scanBatchCallbackPartitionKeys) {
+  auto vectors = makeVectors(1, 1'000);
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->getPath(), vectors);
+
+  std::unordered_map<std::string, std::optional<std::string>>
+      receivedPartitionKeys;
+  bool callbackFired{false};
+  auto queryCtx = core::QueryCtx::create(executor_.get());
+  queryCtx->setScanBatchCallback([&](const core::ScanBatchEvent& event) {
+    if (const auto* fileEvent =
+            dynamic_cast<const connector::hive::FileScanBatchEvent*>(&event)) {
+      if (fileEvent->partitionKeys) {
+        receivedPartitionKeys = *fileEvent->partitionKeys;
+      }
+    }
+    callbackFired = true;
+  });
+
+  connector::ColumnHandleMap assignments = {
+      {"c0", regularColumn("c0", BIGINT())},
+      {"ds", partitionKey("ds", VARCHAR())},
+  };
+
+  auto outputType = ROW({"c0", "ds"}, {BIGINT(), VARCHAR()});
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .outputType(outputType)
+                  .assignments(assignments)
+                  .endTableScan()
+                  .planNode();
+
+  auto split = exec::test::HiveConnectorSplitBuilder(filePath->getPath())
+                   .partitionKey("ds", "2026-05-12")
+                   .build();
+
+  AssertQueryBuilder(plan).queryCtx(queryCtx).split(split).copyResults(
+      pool_.get());
+
+  ASSERT_TRUE(callbackFired);
+  const std::unordered_map<std::string, std::optional<std::string>> expected{
+      {"ds", "2026-05-12"}};
+  ASSERT_EQ(receivedPartitionKeys, expected);
 }
 
 TEST_F(TableScanTest, scanBatchCallbackNotSetIsNoOp) {


### PR DESCRIPTION
Summary:

Add partition key information to the per-batch scan stats callback.

Changes:
- Add `getPartitionKeys()` virtual method to `DataSource` interface with default empty implementation. `FileDataSource` overrides to return the current split's partition keys.
- Add `partitionKeys` pointer field to `ScanBatchEvent`, populated from `dataSource_->getPartitionKeys()` in `TableScan::getOutput()`.
- New test `scanBatchCallbackPartitionKeys` verifying partition keys propagate through the callback.

Reviewed By: Yuhta

Differential Revision: D105112445


