### PR TITLE
feat: Add Spark CAST(timestamp_utc as varchar)

### DIFF
--- a/velox/docs/functions/spark/conversion.rst
+++ b/velox/docs/functions/spark/conversion.rst
@@ -244,6 +244,26 @@ Valid examples
   SELECT cast(cast('0384-01-01 08:00:00.000' as timestamp) as string); -- '0384-01-01 08:00:00'
   SELECT cast(cast('-0010-02-01 10:00:00.000' as timestamp) as string); -- '-0010-02-01 10:00:00'
 
+From TIMESTAMP_UTC
+^^^^^^^^^^^^^^^^^^
+
+Casting a timestamp_utc to a string uses the same ISO 8601 format as TIMESTAMP,
+but is not subject to session timezone adjustment.
+The conversion precision is microsecond, and trailing zeros are not appended.
+When the year exceeds 9999, a positive sign is added.
+
+Valid examples
+
+::
+
+  SELECT cast(TIMESTAMP_NTZ '1970-01-01 00:00:00' as string); -- '1970-01-01 00:00:00'
+  SELECT cast(TIMESTAMP_NTZ '2000-01-01 12:21:56.129' as string); -- '2000-01-01 12:21:56.129'
+  SELECT cast(TIMESTAMP_NTZ '2000-01-01 12:21:56.100000' as string); -- '2000-01-01 12:21:56.1'
+  SELECT cast(TIMESTAMP_NTZ '2000-01-01 12:21:56.129900' as string); -- '2000-01-01 12:21:56.1299'
+  SELECT cast(TIMESTAMP_NTZ '10000-02-01 16:00:00.000' as string); -- '+10000-02-01 16:00:00'
+  SELECT cast(TIMESTAMP_NTZ '0384-01-01 08:00:00.000' as string); -- '0384-01-01 08:00:00'
+  SELECT cast(TIMESTAMP_NTZ '-0010-02-01 10:00:00.000' as string); -- '-0010-02-01 10:00:00'
+
 Cast to Date
 ------------
 

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -872,8 +872,18 @@ void CastExpr::applyPeeled(
       fromType->kind() == TypeKind::TIMESTAMP &&
       (toType->kind() == TypeKind::VARCHAR ||
        toType->kind() == TypeKind::VARBINARY)) {
-    VELOX_DCHECK(fromType->equivalent(*TIMESTAMP()));
-    result = applyTimestampToVarcharCast(toType, rows, context, input);
+    if (fromType->equivalent(*TIMESTAMP_UTC())) {
+      VELOX_USER_CHECK(
+          hooks_->supportsTimestampUtc(),
+          "Cast from {} to {} is not supported",
+          fromType->toString(),
+          toType->toString());
+      result = applyTimestampToVarcharCast(
+          toType, rows, context, input, hooks_->timestampUtcToStringOptions());
+    } else {
+      result = applyTimestampToVarcharCast(
+          toType, rows, context, input, hooks_->timestampToStringOptions());
+    }
   } else if (toType->kind() == TypeKind::VARBINARY) {
     switch (fromType->kind()) {
       case TypeKind::TINYINT:
@@ -940,14 +950,14 @@ VectorPtr CastExpr::applyTimestampToVarcharCast(
     const TypePtr& toType,
     const SelectivityVector& rows,
     exec::EvalCtx& context,
-    const BaseVector& input) {
+    const BaseVector& input,
+    const TimestampToStringOptions& options) {
   VectorPtr result;
   context.ensureWritable(rows, toType, result);
   (*result).clearNulls(rows);
   auto flatResult = result->asFlatVector<StringView>();
   const auto simpleInput = input.as<SimpleVector<Timestamp>>();
 
-  const auto& options = hooks_->timestampToStringOptions();
   const uint32_t rowSize = getMaxStringLength(options);
 
   Buffer* buffer = flatResult->getBufferWithSpace(
@@ -955,7 +965,7 @@ VectorPtr CastExpr::applyTimestampToVarcharCast(
   char* rawBuffer = buffer->asMutable<char>() + buffer->size();
 
   applyToSelectedNoThrowLocal(context, rows, result, [&](vector_size_t row) {
-    // Adjust input timestamp according the session timezone.
+    // Adjust input timestamp according the session timezone when required.
     Timestamp inputValue(simpleInput->valueAt(row));
     if (options.timeZone) {
       inputValue.toTimezone(*(options.timeZone));

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -299,7 +299,8 @@ class CastExpr : public SpecialForm {
       const TypePtr& toType,
       const SelectivityVector& rows,
       exec::EvalCtx& context,
-      const BaseVector& input);
+      const BaseVector& input,
+      const TimestampToStringOptions& options);
 
   // Casts basic numeric types to wider types.
   template <TypeKind ToKind, TypeKind FromKind>

--- a/velox/expression/CastHooks.h
+++ b/velox/expression/CastHooks.h
@@ -65,6 +65,11 @@ class CastHooks {
   /// Returns the options to cast from timestamp to string.
   virtual const TimestampToStringOptions& timestampToStringOptions() const = 0;
 
+  /// Returns the options to cast from TIMESTAMP_UTC to string, with
+  /// timeZone = nullptr since TIMESTAMP_UTC is not subject to session
+  /// timezone adjustment.
+  virtual TimestampToStringOptions timestampUtcToStringOptions() const = 0;
+
   /// Returns whether to cast to int by truncate.
   virtual bool truncate() const = 0;
 
@@ -74,6 +79,10 @@ class CastHooks {
   virtual bool applyTryCastRecursively() const = 0;
 
   virtual PolicyType getPolicy() const = 0;
+
+  /// Returns true if TIMESTAMP_UTC casts are supported.
+  /// Spark supports them; Presto does not.
+  virtual bool supportsTimestampUtc() const = 0;
 
   /// Converts boolean to timestamp type.
   virtual Expected<Timestamp> castBooleanToTimestamp(bool seconds) const = 0;

--- a/velox/expression/PrestoCastHooks.h
+++ b/velox/expression/PrestoCastHooks.h
@@ -57,6 +57,11 @@ class PrestoCastHooks : public CastHooks {
   // Returns cast options following 'isLegacyCast' and session timezone.
   const TimestampToStringOptions& timestampToStringOptions() const override;
 
+  // Presto does not support TIMESTAMP_UTC casts.
+  TimestampToStringOptions timestampUtcToStringOptions() const override {
+    VELOX_UNSUPPORTED("Cast from TIMESTAMP_UTC to VARCHAR is not supported");
+  }
+
   bool truncate() const override {
     return false;
   }
@@ -66,6 +71,11 @@ class PrestoCastHooks : public CastHooks {
   }
 
   PolicyType getPolicy() const override;
+
+  // Presto does not support TIMESTAMP_UTC casts.
+  bool supportsTimestampUtc() const override {
+    return false;
+  }
 
   bool isScientific() const override {
     return false;

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
@@ -32,6 +32,12 @@ SparkCastHooks::SparkCastHooks(
   }
 }
 
+TimestampToStringOptions SparkCastHooks::timestampUtcToStringOptions() const {
+  auto options = timestampToStringOptions_;
+  options.timeZone = nullptr;
+  return options;
+}
+
 Expected<Timestamp> SparkCastHooks::castStringToTimestamp(
     const StringView& view) const {
   auto conversionResult = util::fromTimestampWithTimezoneString(

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.h
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.h
@@ -68,6 +68,8 @@ class SparkCastHooks : public exec::CastHooks {
     return timestampToStringOptions_;
   }
 
+  TimestampToStringOptions timestampUtcToStringOptions() const override;
+
   bool truncate() const override {
     return allowOverflow_;
   }
@@ -77,6 +79,11 @@ class SparkCastHooks : public exec::CastHooks {
   }
 
   exec::PolicyType getPolicy() const override;
+
+  // Spark supports TIMESTAMP_UTC casts.
+  bool supportsTimestampUtc() const override {
+    return true;
+  }
 
   void castDateTimestampToGMT(
       Timestamp& timestamp,

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -539,6 +539,35 @@ class SparkCastExprTest : public functions::test::CastBaseTest {
         });
   }
 
+  void testTimestampUtcToString() {
+    // Basic formatting: output reflects the stored UTC time directly.
+    testCast(
+        makeNullableFlatVector<Timestamp>(
+            {Timestamp(0, 0),
+             Timestamp(946'684'800, 0),
+             Timestamp(946'729'316, 0),
+             Timestamp(1'426'680'197, 0),
+             Timestamp(1'426'680'197, 123'000'000),
+             Timestamp(1'426'680'197, 123'456'000)},
+            TIMESTAMP_UTC()),
+        makeNullableFlatVector<std::string>(
+            {"1970-01-01 00:00:00",
+             "2000-01-01 00:00:00",
+             "2000-01-01 12:21:56",
+             "2015-03-18 12:03:17",
+             "2015-03-18 12:03:17.123",
+             "2015-03-18 12:03:17.123456"},
+            VARCHAR()));
+
+    // Session timezone does not affect TIMESTAMP_UTC output.
+    setTimezone("Asia/Shanghai");
+    testCast(
+        makeNullableFlatVector<Timestamp>(
+            {Timestamp(0, 0), Timestamp(946'729'316, 0)}, TIMESTAMP_UTC()),
+        makeNullableFlatVector<std::string>(
+            {"1970-01-01 00:00:00", "2000-01-01 12:21:56"}, VARCHAR()));
+  }
+
   void testInvalidDate() {
     testInvalidCast<int8_t>(
         "date", {12}, "Cast from TINYINT to DATE is not supported", TINYINT());
@@ -1095,6 +1124,10 @@ TEST_F(SparkCastExprTestAnsiOn, timestampToString) {
   testTimestampToString();
 }
 
+TEST_F(SparkCastExprTestAnsiOn, timestampUtcToString) {
+  testTimestampUtcToString();
+}
+
 TEST_F(SparkCastExprTestAnsiOn, testInvalidDate) {
   auto expected = [](const std::string& v) {
     return fmt::format(
@@ -1374,6 +1407,10 @@ TEST_F(SparkCastExprTestAnsiOff, timestampToInt) {
 
 TEST_F(SparkCastExprTestAnsiOff, timestampToString) {
   testTimestampToString();
+}
+
+TEST_F(SparkCastExprTestAnsiOff, timestampUtcToString) {
+  testTimestampUtcToString();
 }
 
 TEST_F(SparkCastExprTestAnsiOff, testInvalidDate) {


### PR DESCRIPTION
This PR adds support for Spark casting `TIMESTAMP UTC` to `VARCHAR`.

The output is formatted using `kTimestampUtcToStringOptions` with
`timeZone = nullptr`, so no session timezone adjustment is applied — the
`Timestamp` is written as-is.

Spark reference: [ToStringBase.scala](https://github.com/apache/spark/blob/v3.5.1/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ToStringBase.scala#L63-L64).