### PR TITLE
fix(parquet): Fix subfield case-sensitive naming for Iceberg tables

### DIFF
--- a/velox/connectors/hive/FileSplitReader.cpp
+++ b/velox/connectors/hive/FileSplitReader.cpp
@@ -178,6 +178,10 @@ void FileSplitReader::configureReaderOptions(
   baseReaderOpts_.setRandomSkip(std::move(randomSkip));
   baseReaderOpts_.setScanSpec(scanSpec_);
   baseReaderOpts_.setFileFormat(fileSplit_->fileFormat);
+  if (!nameToFieldId_.empty()) {
+    baseReaderOpts_.setUseColumnNamesForColumnMapping(true);
+    baseReaderOpts_.setNameToFieldId(nameToFieldId_);
+  }
 }
 
 void FileSplitReader::configureBaseReaderOptions() {

--- a/velox/connectors/hive/FileSplitReader.h
+++ b/velox/connectors/hive/FileSplitReader.h
@@ -135,6 +135,10 @@ class FileSplitReader {
     return readerOutputType_;
   }
 
+  void setNameToFieldId(std::unordered_map<std::string, int32_t> mapping) {
+    nameToFieldId_ = std::move(mapping);
+  }
+
   std::string toString() const;
 
  protected:
@@ -242,6 +246,7 @@ class FileSplitReader {
   std::unique_ptr<dwio::common::RowReader> baseRowReader_;
   dwio::common::ReaderOptions baseReaderOpts_;
   dwio::common::RowReaderOptions baseRowReaderOpts_;
+  std::unordered_map<std::string, int32_t> nameToFieldId_;
   bool emptySplit_;
 };
 

--- a/velox/connectors/hive/iceberg/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/CMakeLists.txt
@@ -22,6 +22,7 @@ set(
   IcebergDataFileStatistics.cpp
   IcebergDataSink.cpp
   IcebergDataSource.cpp
+  IcebergFieldIdUtils.cpp
   IcebergDeletionVectorSink.cpp
   IcebergDwrfStatsCollector.cpp
   IcebergMergeProcessor.cpp
@@ -54,6 +55,7 @@ velox_add_library(
   IcebergDataFileStatistics.h
   IcebergDataSink.h
   IcebergDataSource.h
+  IcebergFieldIdUtils.h
   IcebergDeleteFile.h
   IcebergDeletionVectorSink.h
   IcebergDwrfStatsCollector.h

--- a/velox/connectors/hive/iceberg/IcebergDataSource.cpp
+++ b/velox/connectors/hive/iceberg/IcebergDataSource.cpp
@@ -16,8 +16,13 @@
 
 #include "velox/connectors/hive/iceberg/IcebergDataSource.h"
 
+#include <folly/String.h>
+
+#include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
+#include "velox/connectors/hive/iceberg/IcebergFieldIdUtils.h"
 #include "velox/connectors/hive/iceberg/IcebergSplit.h"
 #include "velox/connectors/hive/iceberg/IcebergSplitReader.h"
+#include "velox/type/Type.h"
 
 namespace facebook::velox::connector::hive::iceberg {
 
@@ -37,7 +42,36 @@ IcebergDataSource::IcebergDataSource(
           ioExecutor,
           connectorQueryCtx,
           hiveConfig),
-      columnHandles_(std::make_shared<ColumnHandleMap>(assignments)) {}
+      columnHandles_(std::make_shared<ColumnHandleMap>(assignments)) {
+  for (const auto& [name, columnHandle] : assignments) {
+    if (!columnHandle) {
+      continue;
+    }
+
+    auto icebergHandle =
+        std::dynamic_pointer_cast<const IcebergColumnHandle>(columnHandle);
+    if (!icebergHandle) {
+      continue;
+    }
+
+    std::string lowerName = icebergHandle->name();
+    folly::toLowerAscii(lowerName);
+    const auto& field = icebergHandle->field();
+    nameToFieldId_[lowerName] = field.fieldId;
+
+    const auto dataType = icebergHandle->dataType();
+    if (!dataType || field.children.empty()) {
+      continue;
+    }
+
+    auto rowType = asRowType(dataType);
+    if (!rowType) {
+      continue;
+    }
+
+    extractNestedFieldIds(field, rowType, nameToFieldId_);
+  }
+}
 
 std::unique_ptr<FileSplitReader> IcebergDataSource::createSplitReader() {
   prepareSplit();
@@ -57,6 +91,10 @@ std::unique_ptr<FileSplitReader> IcebergDataSource::createSplitReader() {
       ioExecutor_,
       scanSpec_,
       columnHandles_);
+
+  if (!nameToFieldId_.empty()) {
+    reader->setNameToFieldId(nameToFieldId_);
+  }
 
   return reader;
 }

--- a/velox/connectors/hive/iceberg/IcebergDataSource.h
+++ b/velox/connectors/hive/iceberg/IcebergDataSource.h
@@ -17,6 +17,8 @@
 
 #include "velox/connectors/hive/HiveDataSource.h"
 
+#include <unordered_map>
+
 namespace facebook::velox::connector::hive::iceberg {
 
 /// Iceberg-specific data source that extends HiveDataSource.
@@ -48,6 +50,7 @@ class IcebergDataSource : public HiveDataSource {
  private:
   /// Column handles map for accessing column metadata.
   std::shared_ptr<ColumnHandleMap> columnHandles_;
+  std::unordered_map<std::string, int32_t> nameToFieldId_;
 };
 
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergFieldIdUtils.cpp
+++ b/velox/connectors/hive/iceberg/IcebergFieldIdUtils.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/IcebergFieldIdUtils.h"
+
+#include <folly/String.h>
+
+namespace facebook::velox::connector::hive::iceberg {
+
+// NOTE: The flat name->fieldId map used here does not handle schemas where the
+// same field name appears at multiple nesting levels (e.g.
+// struct<a: struct<id: int>, b: struct<id: int>>). In that case both inner
+// `id` fields collide to the same map key. This is acceptable for the common
+// case (Iceberg tables with distinct field names across levels) but is a known
+// limitation. A future improvement could scope the map by parent field ID.
+void extractNestedFieldIds(
+    const parquet::ParquetFieldId& field,
+    const RowTypePtr& rowType,
+    std::unordered_map<std::string, int32_t>& mapping) {
+  if (!rowType || field.children.empty()) {
+    return;
+  }
+
+  const auto numChildren =
+      std::min<size_t>(field.children.size(), rowType->size());
+  for (size_t i = 0; i < numChildren; ++i) {
+    const auto& child = field.children[i];
+    std::string lowerName = rowType->nameOf(i);
+    folly::toLowerAscii(lowerName);
+    mapping[lowerName] = child.fieldId;
+
+    if (!child.children.empty()) {
+      auto childRowType = asRowType(rowType->childAt(i));
+      if (childRowType) {
+        extractNestedFieldIds(child, childRowType, mapping);
+      }
+    }
+  }
+}
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergFieldIdUtils.h
+++ b/velox/connectors/hive/iceberg/IcebergFieldIdUtils.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+#include "velox/dwio/common/ParquetFieldId.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+/// Recursively extracts Iceberg field IDs from a ParquetFieldId tree into
+/// a lowercase name -> fieldId mapping. Used during IcebergDataSource
+/// construction to build the map passed to the Parquet reader for field-ID-
+/// based column matching.
+void extractNestedFieldIds(
+    const parquet::ParquetFieldId& field,
+    const RowTypePtr& rowType,
+    std::unordered_map<std::string, int32_t>& mapping);
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/dwio/common/Options.cpp
+++ b/velox/dwio/common/Options.cpp
@@ -74,6 +74,9 @@ std::string formatConfigPrefix(FileFormat fmt, std::string_view separator) {
 ColumnReaderOptions makeColumnReaderOptions(const ReaderOptions& options) {
   ColumnReaderOptions columnReaderOptions;
   columnReaderOptions.columnMappingMode_ = options.columnMappingMode();
+  columnReaderOptions.useColumnNamesForColumnMapping_ =
+      options.useColumnNamesForColumnMapping();
+  columnReaderOptions.nameToFieldId_ = options.nameToFieldId();
   return columnReaderOptions;
 }
 

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -738,8 +738,19 @@ class ReaderOptions : public io::ReaderOptions {
     return *this;
   }
 
+  ReaderOptions& setUseColumnNamesForColumnMapping(bool flag) {
+    useColumnNamesForColumnMapping_ = flag;
+    return *this;
+  }
+
   ReaderOptions& setColumnMappingMode(ColumnMappingMode mode) {
     columnMappingMode_ = mode;
+    return *this;
+  }
+
+  ReaderOptions& setNameToFieldId(
+      std::unordered_map<std::string, int32_t> mapping) {
+    nameToFieldId_ = std::move(mapping);
     return *this;
   }
 
@@ -842,8 +853,16 @@ class ReaderOptions : public io::ReaderOptions {
     return fileColumnNamesReadAsLowerCase_;
   }
 
+  bool useColumnNamesForColumnMapping() const {
+    return useColumnNamesForColumnMapping_;
+  }
+
   ColumnMappingMode columnMappingMode() const {
     return columnMappingMode_;
+  }
+
+  const std::unordered_map<std::string, int32_t>& nameToFieldId() const {
+    return nameToFieldId_;
   }
 
   const std::shared_ptr<random::RandomSkipTracker>& randomSkip() const {
@@ -1014,7 +1033,9 @@ class ReaderOptions : public io::ReaderOptions {
   uint64_t footerSpeculativeIoSize_{kDefaultFooterSpeculativeIoSize};
   uint64_t filePreloadThreshold_{kDefaultFilePreloadThreshold};
   bool fileColumnNamesReadAsLowerCase_{false};
+  bool useColumnNamesForColumnMapping_{false};
   ColumnMappingMode columnMappingMode_{ColumnMappingMode::kPosition};
+  std::unordered_map<std::string, int32_t> nameToFieldId_;
   std::shared_ptr<random::RandomSkipTracker> randomSkip_;
   std::shared_ptr<velox::common::ScanSpec> scanSpec_;
   const tz::TimeZone* sessionTimezone_{nullptr};
@@ -1070,6 +1091,8 @@ struct WriterOptions {
 struct ColumnReaderOptions {
   /// How to map table fields to file fields.
   ColumnMappingMode columnMappingMode_{ColumnMappingMode::kPosition};
+  bool useColumnNamesForColumnMapping_{false};
+  std::unordered_map<std::string, int32_t> nameToFieldId_;
 };
 
 ColumnReaderOptions makeColumnReaderOptions(const ReaderOptions& options);

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -491,6 +491,7 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
   auto& schema = *fileMetaData_->schema();
   uint32_t curSchemaIdx = schemaIdx;
   auto& schemaElement = schema[curSchemaIdx];
+  std::optional<int32_t> fieldId = schemaElement.field_id().to_optional();
   bool isRepeated = false;
   bool isOptional = false;
 
@@ -516,7 +517,7 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
   }
 
   if (parquetReaderOptions_.columnMappingMode != ColumnMappingMode::kName &&
-      options_.fileSchema()) {
+      !options_.useColumnNamesForColumnMapping() && options_.fileSchema()) {
     if (isParquetReservedKeyword(name, parentSchemaIdx, curSchemaIdx)) {
       columnNames.push_back(name);
     }
@@ -563,10 +564,35 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
 
         if (requestedRowType) {
           if (parquetReaderOptions_.columnMappingMode ==
-              ColumnMappingMode::kName) {
-            auto fileTypeIdx = requestedRowType->getChildIdxIfExists(childName);
-            if (fileTypeIdx.has_value()) {
-              childRequestedType = requestedRowType->childAt(*fileTypeIdx);
+                  ColumnMappingMode::kName ||
+              options_.useColumnNamesForColumnMapping()) {
+            std::optional<uint32_t> requestedChildIndex;
+            if (auto childFieldId =
+                    schema[schemaIdx].field_id().to_optional()) {
+              const auto& nameToFieldId = options_.nameToFieldId();
+              if (!nameToFieldId.empty()) {
+                for (uint32_t j = 0; j < requestedRowType->size(); ++j) {
+                  std::string lookup = requestedRowType->nameOf(j);
+                  folly::toLowerAscii(lookup);
+                  auto it = nameToFieldId.find(lookup);
+                  if (it != nameToFieldId.end() &&
+                      it->second == *childFieldId) {
+                    requestedChildIndex = j;
+                    break;
+                  }
+                }
+                if (!requestedChildIndex.has_value()) {
+                  followChild = false;
+                }
+              }
+            }
+            if (!requestedChildIndex.has_value()) {
+              requestedChildIndex =
+                  requestedRowType->getChildIdxIfExists(childName);
+            }
+            if (requestedChildIndex.has_value()) {
+              childRequestedType =
+                  requestedRowType->childAt(*requestedChildIndex);
             }
           } else {
             // Handle schema evolution.
@@ -636,7 +662,11 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
                 maxRepeat + 1,
                 maxDefine,
                 isOptional,
-                isRepeated);
+                isRepeated,
+                0,
+                0,
+                0,
+                fieldId);
           }
           // Only special case list of map and list of list is handled here,
           // other generic case is handled with case MAP
@@ -673,7 +703,11 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
                 maxRepeat,
                 maxDefine,
                 isOptional,
-                isRepeated);
+                isRepeated,
+                0,
+                0,
+                0,
+                fieldId);
           }
 
           // For backward-compatibility, a group annotated with MAP_KEY_VALUE
@@ -704,7 +738,11 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
               maxRepeat + 1,
               maxDefine,
               isOptional,
-              isRepeated);
+              isRepeated,
+              0,
+              0,
+              0,
+              fieldId);
         }
 
         default:
@@ -742,7 +780,11 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
                 maxRepeat,
                 maxDefine,
                 isOptional,
-                isRepeated);
+                isRepeated,
+                0,
+                0,
+                0,
+                fieldId);
           } else {
             // According to the spec of list backward compatibility
             // https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#lists
@@ -774,7 +816,11 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
                     maxRepeat,
                     maxDefine,
                     isOptional,
-                    isRepeated));
+                    isRepeated,
+                    0,
+                    0,
+                    0,
+                    std::nullopt));
             auto res = std::make_unique<ParquetTypeWithId>(
                 TypeFactory<TypeKind::ARRAY>::create(childrenRowType),
                 std::move(rowChildren),
@@ -788,7 +834,11 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
                 maxRepeat,
                 maxDefine,
                 isOptional,
-                isRepeated);
+                isRepeated,
+                0,
+                0,
+                0,
+                fieldId);
             return res;
           }
         } else if (
@@ -812,7 +862,11 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
               maxRepeat,
               maxDefine,
               isOptional,
-              isRepeated);
+              isRepeated,
+              0,
+              0,
+              0,
+              fieldId);
         } else {
           // Row type
           // To support list backward compatibility, need create a new row type
@@ -838,7 +892,11 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
                   maxRepeat,
                   maxDefine,
                   isOptional,
-                  isRepeated));
+                  isRepeated,
+                  0,
+                  0,
+                  0,
+                  std::nullopt));
           return std::make_unique<ParquetTypeWithId>(
               TypeFactory<TypeKind::ARRAY>::create(childrenRowType),
               std::move(rowChildren),
@@ -852,7 +910,11 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
               maxRepeat,
               maxDefine,
               isOptional,
-              isRepeated);
+              isRepeated,
+              0,
+              0,
+              0,
+              fieldId);
         }
       } else {
         // Row type
@@ -870,7 +932,11 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
             maxRepeat,
             maxDefine,
             isOptional,
-            isRepeated);
+            isRepeated,
+            0,
+            0,
+            0,
+            fieldId);
       }
     }
   } else { // leaf node
@@ -901,7 +967,8 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
         isRepeated,
         precision,
         scale,
-        typeLength);
+        typeLength,
+        fieldId);
 
     if (apache::thrift::can_throw(*schemaElement.repetition_type()) ==
         thrift::FieldRepetitionType::REPEATED) {
@@ -922,7 +989,11 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
           maxRepeat,
           maxDefine - 1,
           isOptional,
-          isRepeated);
+          isRepeated,
+          0,
+          0,
+          0,
+          fieldId);
     }
     return leafTypePtr;
   }
@@ -1428,6 +1499,8 @@ class ParquetRowReader::Impl {
         options_.timestampPrecision());
     requestedType_ = options_.requestedType() ? options_.requestedType()
                                               : readerBase_->schema();
+    columnReaderOptions_ =
+        dwio::common::makeColumnReaderOptions(readerBase_->options());
     columnReader_ = ParquetColumnReader::build(
         columnReaderOptions_,
         requestedType_,
@@ -1443,9 +1516,6 @@ class ParquetRowReader::Impl {
       // table scan.
       advanceToNextRowGroup();
     }
-
-    columnReaderOptions_ =
-        dwio::common::makeColumnReaderOptions(readerBase_->options());
   }
 
   void filterRowGroups() {

--- a/velox/dwio/parquet/reader/ParquetTypeWithId.h
+++ b/velox/dwio/parquet/reader/ParquetTypeWithId.h
@@ -50,7 +50,8 @@ class ParquetTypeWithId : public dwio::common::TypeWithId {
       bool isRepeated,
       int32_t precision = 0,
       int32_t scale = 0,
-      int32_t typeLength = 0)
+      int32_t typeLength = 0,
+      std::optional<int32_t> fieldId = std::nullopt)
       : TypeWithId(type, std::move(children), id, maxId, column),
         name_(name),
         parquetType_(parquetType),
@@ -62,7 +63,8 @@ class ParquetTypeWithId : public dwio::common::TypeWithId {
         isRepeated_(isRepeated),
         precision_(precision),
         scale_(scale),
-        typeLength_(typeLength) {}
+        typeLength_(typeLength),
+        fieldId_(fieldId) {}
 
   bool isLeaf() const {
     // Negative column ordinal means non-leaf column.
@@ -75,6 +77,10 @@ class ParquetTypeWithId : public dwio::common::TypeWithId {
 
   const ParquetTypeWithId* parquetParent() const {
     return reinterpret_cast<const ParquetTypeWithId*>(parent());
+  }
+
+  std::optional<int32_t> fieldId() const {
+    return fieldId_;
   }
 
   /// Fills 'info' and returns the mode for interpreting levels.
@@ -94,6 +100,7 @@ class ParquetTypeWithId : public dwio::common::TypeWithId {
   const int32_t precision_;
   const int32_t scale_;
   const int32_t typeLength_;
+  const std::optional<int32_t> fieldId_;
 
   // True if this is or has a non-repeated leaf.
   bool hasNonRepeatedLeaf() const;

--- a/velox/dwio/parquet/reader/StructColumnReader.cpp
+++ b/velox/dwio/parquet/reader/StructColumnReader.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/dwio/parquet/reader/StructColumnReader.h"
 
+#include <folly/String.h>
+
 #include "velox/dwio/common/BufferedInput.h"
 #include "velox/dwio/parquet/reader/ParquetColumnReader.h"
 #include "velox/dwio/parquet/reader/RepeatedColumnReader.h"
@@ -48,9 +50,46 @@ StructColumnReader::StructColumnReader(
     if (!childSpecs[i]->readFromFile()) {
       continue;
     }
-    auto childFileType = fileType_->childByName(childSpec->fieldName());
-    auto childRequestedType =
-        requestedType_->asRow().findChild(childSpec->fieldName());
+    std::shared_ptr<const dwio::common::TypeWithId> childFileType;
+    TypePtr childRequestedType;
+    if (columnReaderOptions.useColumnNamesForColumnMapping_ &&
+        !columnReaderOptions.nameToFieldId_.empty()) {
+      std::string lookup = childSpec->fieldName();
+      folly::toLowerAscii(lookup);
+      auto it = columnReaderOptions.nameToFieldId_.find(lookup);
+      if (it != columnReaderOptions.nameToFieldId_.end()) {
+        for (const auto& child :
+             reinterpret_cast<const ParquetTypeWithId*>(fileType_.get())
+                 ->getChildren()) {
+          auto parquetChild =
+              reinterpret_cast<const ParquetTypeWithId*>(child.get());
+          if (parquetChild->fieldId().has_value() &&
+              parquetChild->fieldId().value() == it->second) {
+            childFileType = child;
+            break;
+          }
+        }
+        // Find the corresponding requested type using case-insensitive name
+        // matching, since the ScanSpec field name may differ in case from the
+        // requested schema's field names.
+        const auto& rowType = requestedType_->asRow();
+        for (uint32_t j = 0; j < rowType.size(); ++j) {
+          std::string rowFieldLower = rowType.nameOf(j);
+          folly::toLowerAscii(rowFieldLower);
+          if (rowFieldLower == lookup) {
+            childRequestedType = rowType.childAt(j);
+            break;
+          }
+        }
+      }
+    }
+    if (!childFileType) {
+      childFileType = fileType_->childByName(childSpec->fieldName());
+    }
+    if (!childRequestedType) {
+      childRequestedType =
+          requestedType_->asRow().findChild(childSpec->fieldName());
+    }
     addChild(
         ParquetColumnReader::build(
             columnReaderOptions,

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -2035,3 +2035,303 @@ TEST_F(ParquetReaderTest, thriftMemoryReleasedForSkippedRowGroups) {
 
   EXPECT_EQ(leafPool_->usedBytes(), initialUsage);
 }
+
+// ============================================================
+// Field ID Matching Tests for Iceberg support
+// ============================================================
+
+// Verifies that ReaderOptions stores and returns the nameToFieldId map.
+TEST_F(ParquetReaderTest, fieldIdMatchingStorage) {
+  std::unordered_map<std::string, int32_t> nameToFieldId;
+  nameToFieldId["currencycode"] = 1;
+  nameToFieldId["j"] = 2;
+
+  dwio::common::ReaderOptions opts(leafPool_.get());
+  opts.setNameToFieldId(nameToFieldId);
+
+  EXPECT_EQ(opts.nameToFieldId().size(), 2);
+  EXPECT_EQ(opts.nameToFieldId().at("currencycode"), 1);
+  EXPECT_EQ(opts.nameToFieldId().at("j"), 2);
+}
+
+// Verifies that lowercase keys are stored and found correctly.
+TEST_F(ParquetReaderTest, fieldIdMatchingCaseInsensitive) {
+  std::unordered_map<std::string, int32_t> nameToFieldId;
+  nameToFieldId["currencycode"] = 1;
+  nameToFieldId["firstname"] = 2;
+
+  dwio::common::ReaderOptions opts(leafPool_.get());
+  opts.setNameToFieldId(nameToFieldId);
+
+  auto it1 = opts.nameToFieldId().find("currencycode");
+  EXPECT_NE(it1, opts.nameToFieldId().end());
+  EXPECT_EQ(it1->second, 1);
+
+  auto it2 = opts.nameToFieldId().find("firstname");
+  EXPECT_NE(it2, opts.nameToFieldId().end());
+  EXPECT_EQ(it2->second, 2);
+}
+
+// Verifies that the default mapping is empty and setting an empty map works.
+TEST_F(ParquetReaderTest, fieldIdMatchingEmptyMapping) {
+  dwio::common::ReaderOptions opts(leafPool_.get());
+  EXPECT_TRUE(opts.nameToFieldId().empty());
+
+  std::unordered_map<std::string, int32_t> emptyMap;
+  opts.setNameToFieldId(emptyMap);
+  EXPECT_TRUE(opts.nameToFieldId().empty());
+}
+
+// Verifies that missing keys are not found and existing keys are.
+TEST_F(ParquetReaderTest, fieldIdMatchingLookupBehavior) {
+  std::unordered_map<std::string, int32_t> nameToFieldId;
+  nameToFieldId["existingfield"] = 100;
+
+  dwio::common::ReaderOptions opts(leafPool_.get());
+  opts.setNameToFieldId(nameToFieldId);
+
+  auto it1 = opts.nameToFieldId().find("existingfield");
+  EXPECT_NE(it1, opts.nameToFieldId().end());
+  EXPECT_EQ(it1->second, 100);
+
+  auto it2 = opts.nameToFieldId().find("nonexistingfield");
+  EXPECT_EQ(it2, opts.nameToFieldId().end());
+}
+
+// Verifies that ParquetReader resolves columns by field ID when the requested
+// schema differs from the file schema only by case.
+TEST_F(ParquetReaderTest, fieldIdMatchingWithCaseMismatch) {
+  constexpr int32_t kRows = 10;
+  auto data = makeRowVector(
+      {"currencyCode", "amount"},
+      {makeFlatVector<int32_t>(kRows, [](auto row) { return row + 100; }),
+       makeFlatVector<int64_t>(kRows, [](auto row) { return row * 1000; })});
+
+  dwio::common::WriterOptions baseOptions;
+  baseOptions.memoryPool = rootPool_.get();
+  ParquetWriterOptions writerOptions;
+  writerOptions.parquetFieldIds = {
+      ParquetFieldId{1, {}},
+      ParquetFieldId{2, {}},
+  };
+
+  auto* sinkPtr = write(data, baseOptions, writerOptions);
+  auto requestedSchema = ROW({"CURRENCYCODE", "AMOUNT"}, {INTEGER(), BIGINT()});
+
+  // With field ID mapping: read succeeds.
+  {
+    std::unordered_map<std::string, int32_t> nameToFieldId;
+    nameToFieldId["currencycode"] = 1;
+    nameToFieldId["amount"] = 2;
+
+    dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+    readerOptions.setUseColumnNamesForColumnMapping(true);
+    readerOptions.setNameToFieldId(nameToFieldId);
+
+    auto parquetReader = createReaderInMemory(*sinkPtr, readerOptions);
+    EXPECT_EQ(parquetReader->numberOfRows(), kRows);
+
+    dwio::common::RowReaderOptions rowReaderOpts;
+    rowReaderOpts.setScanSpec(makeScanSpec(requestedSchema));
+    auto rowReader = parquetReader->createRowReader(rowReaderOpts);
+
+    auto expected = makeRowVector(
+        {"CURRENCYCODE", "AMOUNT"},
+        {makeFlatVector<int32_t>(kRows, [](auto row) { return row + 100; }),
+         makeFlatVector<int64_t>(kRows, [](auto row) { return row * 1000; })});
+
+    assertReadWithReaderAndExpected(
+        requestedSchema, *rowReader, expected, *leafPool_);
+  }
+
+  // Without field ID mapping: schema mismatch causes an error.
+  {
+    dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+    auto parquetReader = createReaderInMemory(*sinkPtr, readerOptions);
+    dwio::common::RowReaderOptions rowReaderOpts;
+    rowReaderOpts.setScanSpec(makeScanSpec(requestedSchema));
+    VELOX_ASSERT_THROW(
+        parquetReader->createRowReader(rowReaderOpts), "not found");
+  }
+}
+
+// Verifies that nested struct fields are resolved by field ID when the
+// requested schema differs from the file schema by case.
+TEST_F(ParquetReaderTest, fieldIdMatchingNestedStruct) {
+  constexpr int32_t kRows = 10;
+
+  auto innerStruct = makeRowVector(
+      {"inner"},
+      {makeFlatVector<int32_t>(kRows, [](auto row) { return row + 100; })});
+  auto data = makeRowVector(
+      {"id", "outer"},
+      {makeFlatVector<int64_t>(kRows, [](auto row) { return row; }),
+       innerStruct});
+
+  dwio::common::WriterOptions baseOptions;
+  baseOptions.memoryPool = rootPool_.get();
+  ParquetWriterOptions writerOptions;
+  writerOptions.parquetFieldIds = {
+      ParquetFieldId{1, {}},
+      ParquetFieldId{2, {ParquetFieldId{3, {}}}},
+  };
+
+  auto* sinkPtr = write(data, baseOptions, writerOptions);
+  auto requestedSchema =
+      ROW({"ID", "OUTER"}, {BIGINT(), ROW({"INNER"}, {INTEGER()})});
+
+  // With field ID mapping: read succeeds.
+  {
+    std::unordered_map<std::string, int32_t> nameToFieldId;
+    nameToFieldId["id"] = 1;
+    nameToFieldId["outer"] = 2;
+    nameToFieldId["inner"] = 3;
+
+    dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+    readerOptions.setUseColumnNamesForColumnMapping(true);
+    readerOptions.setNameToFieldId(nameToFieldId);
+
+    auto parquetReader = createReaderInMemory(*sinkPtr, readerOptions);
+    EXPECT_EQ(parquetReader->numberOfRows(), kRows);
+
+    dwio::common::RowReaderOptions rowReaderOpts;
+    rowReaderOpts.setScanSpec(makeScanSpec(requestedSchema));
+    auto rowReader = parquetReader->createRowReader(rowReaderOpts);
+
+    auto expectedInner = makeRowVector(
+        {"INNER"},
+        {makeFlatVector<int32_t>(kRows, [](auto row) { return row + 100; })});
+    auto expected = makeRowVector(
+        {"ID", "OUTER"},
+        {makeFlatVector<int64_t>(kRows, [](auto row) { return row; }),
+         expectedInner});
+
+    assertReadWithReaderAndExpected(
+        requestedSchema, *rowReader, expected, *leafPool_);
+  }
+
+  // Without field ID mapping: schema mismatch causes an error.
+  {
+    dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+    auto parquetReader = createReaderInMemory(*sinkPtr, readerOptions);
+    dwio::common::RowReaderOptions rowReaderOpts;
+    rowReaderOpts.setScanSpec(makeScanSpec(requestedSchema));
+    VELOX_ASSERT_THROW(
+        parquetReader->createRowReader(rowReaderOpts), "not found");
+  }
+}
+
+// Verifies that field ID matching resolves columns regardless of their
+// positional order in the requested schema.
+TEST_F(ParquetReaderTest, fieldIdMatchingReorderedFields) {
+  constexpr int32_t kRows = 10;
+
+  // File schema: a(id=1), b(id=2), c(id=3).
+  auto data = makeRowVector(
+      {"a", "b", "c"},
+      {makeFlatVector<int32_t>(kRows, [](auto row) { return row + 100; }),
+       makeFlatVector<int64_t>(kRows, [](auto row) { return row + 200; }),
+       makeFlatVector<int32_t>(kRows, [](auto row) { return row + 300; })});
+
+  dwio::common::WriterOptions baseOptions;
+  baseOptions.memoryPool = rootPool_.get();
+  ParquetWriterOptions writerOptions;
+  writerOptions.parquetFieldIds = {
+      ParquetFieldId{1, {}},
+      ParquetFieldId{2, {}},
+      ParquetFieldId{3, {}},
+  };
+
+  auto* sinkPtr = write(data, baseOptions, writerOptions);
+
+  // Request in order C, A, B with case mismatch.
+  auto requestedSchema = ROW({"C", "A", "B"}, {INTEGER(), INTEGER(), BIGINT()});
+
+  std::unordered_map<std::string, int32_t> nameToFieldId;
+  nameToFieldId["a"] = 1;
+  nameToFieldId["b"] = 2;
+  nameToFieldId["c"] = 3;
+
+  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  readerOptions.setUseColumnNamesForColumnMapping(true);
+  readerOptions.setNameToFieldId(nameToFieldId);
+
+  auto parquetReader = createReaderInMemory(*sinkPtr, readerOptions);
+  EXPECT_EQ(parquetReader->numberOfRows(), kRows);
+
+  dwio::common::RowReaderOptions rowReaderOpts;
+  rowReaderOpts.setScanSpec(makeScanSpec(requestedSchema));
+  auto rowReader = parquetReader->createRowReader(rowReaderOpts);
+
+  // Expected order: C(id=3), A(id=1), B(id=2).
+  auto expected = makeRowVector(
+      {"C", "A", "B"},
+      {makeFlatVector<int32_t>(kRows, [](auto row) { return row + 300; }),
+       makeFlatVector<int32_t>(kRows, [](auto row) { return row + 100; }),
+       makeFlatVector<int64_t>(kRows, [](auto row) { return row + 200; })});
+
+  assertReadWithReaderAndExpected(
+      requestedSchema, *rowReader, expected, *leafPool_);
+}
+
+// Verifies the behavior when nameToFieldId maps a column to a field ID that
+// does not exist in the file (e.g. mapping currencycode->99, but the file has
+// currencyCode with fieldId=1).
+//
+// Design decision: the nameToFieldId mapping is treated as authoritative.  If
+// the supplied field ID cannot be found in the file, the reader must not fall
+// back to a name-based match, because that could bind the requested column to
+// a different logical field.  The expected behavior is to report the field as
+// missing.  The cause of the mismatch is intentionally unspecified — it could
+// be stale metadata, schema evolution, or a bug — only the contract matters.
+//
+// Concretely: createRowReader throws because StructColumnReader cannot locate
+// the child file type for the unresolved column.  This test documents that
+// contract so any future change that alters the fallback behavior — e.g.
+// returning null instead of throwing — is caught as a deliberate regression.
+TEST_F(ParquetReaderTest, fieldIdMatchingUnknownFieldIdDoesNotFallBackToName) {
+  constexpr int32_t kRows = 5;
+  auto data = makeRowVector(
+      {"currencyCode", "amount"},
+      {makeFlatVector<int32_t>(kRows, [](auto row) { return row + 100; }),
+       makeFlatVector<int64_t>(kRows, [](auto row) { return row * 1000; })});
+
+  dwio::common::WriterOptions baseOptions;
+  baseOptions.memoryPool = rootPool_.get();
+  ParquetWriterOptions writerOptions;
+  // File embeds fieldId=1 on currencyCode, fieldId=2 on amount.
+  writerOptions.parquetFieldIds = {
+      ParquetFieldId{1, {}},
+      ParquetFieldId{2, {}},
+  };
+
+  auto* sinkPtr = write(data, baseOptions, writerOptions);
+
+  // Requested schema uses uppercase names (as Iceberg typically delivers them).
+  auto requestedSchema = ROW({"CURRENCYCODE", "AMOUNT"}, {INTEGER(), BIGINT()});
+
+  // The mapping points currencycode to fieldId=99, which does not exist in the
+  // file (file has fieldId=1).  amount is correctly mapped to 2.
+  std::unordered_map<std::string, int32_t> nameToFieldId;
+  nameToFieldId["currencycode"] = 99; // wrong ID — no file column has this
+  nameToFieldId["amount"] = 2;
+
+  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  readerOptions.setUseColumnNamesForColumnMapping(true);
+  readerOptions.setNameToFieldId(nameToFieldId);
+
+  auto parquetReader = createReaderInMemory(*sinkPtr, readerOptions);
+
+  dwio::common::RowReaderOptions rowReaderOpts;
+  rowReaderOpts.setScanSpec(makeScanSpec(requestedSchema));
+
+  // When no physical Parquet field matches the supplied field ID, field-ID
+  // matching yields no result and the implementation falls back to
+  // childByName(childSpec->fieldName()). That lookup is case-sensitive
+  // against the physical Parquet schema. If the requested name differs
+  // only by case from the physical name, the fallback also fails and
+  // createRowReader() throws "not found" rather than silently binding the
+  // requested column to a different field.
+  VELOX_ASSERT_THROW(
+      parquetReader->createRowReader(rowReaderOpts), "not found");
+}


### PR DESCRIPTION
### Summary
This PR fixes the subfield case-sensitive naming issue for Iceberg
tables in the Parquet reader by implementing field ID-based column
matching in Presto C++.
### Problem
Presto C++ was using name-based matching for Iceberg columns, which
caused failures when field names had case mismatches between the schema
and Parquet file.

Example:

```
CREATE TABLE test_struct1(x) AS
SELECT CAST(ROW(1, 2) AS ROW("currencyCode" int, "j" int)) AS x;

SELECT * FROM test_struct1;

This failed in Presto C++ with:

Field not found: currencyCode

while the same query worked in Presto Java.
```

### Solution

This change implements field ID-based matching similar to Presto Java by:

- extracting field IDs from Iceberg column handles
- propagating field ID mappings through the reader pipeline
- matching columns using field IDs in the Parquet reader
- supporting nested field ID extraction
- preserving backward compatibility when field IDs are absent

### Testing

- parquet reader test target builds successfully
- existing parquet reader tests pass locally
- added 5 field ID matching tests in ParquetReaderTest.cpp
- manually verified the original failing query along with a few more cases

### Related

- Internal lakehouse-presto [issue](https://github.ibm.com/lakehouse/presto/issues/4804)
- Related internal tracking/workaround [issue](https://github.ibm.com/lakehouse/tracker/issues/59268)