### PR TITLE
Refactor ReaderOptions IoStatistics from raw pointers to shared_ptr (#17518)

### DIFF
--- a/velox/common/io/Options.h
+++ b/velox/common/io/Options.h
@@ -71,32 +71,21 @@ class ReaderOptions {
     VELOX_CHECK_NOT_NULL(pool_);
   }
 
-  // Deprecated: use pool-only constructor + setDataIoStats/setMetadataIoStats.
-  ReaderOptions(
-      velox::memory::MemoryPool* pool,
-      IoStatistics* dataIoStats,
-      IoStatistics* metadataIoStats)
-      : pool_{pool},
-        dataIoStats_{dataIoStats},
-        metadataIoStats_{metadataIoStats} {
-    VELOX_CHECK_NOT_NULL(pool_);
-  }
-
-  ReaderOptions& setDataIoStats(IoStatistics* stats) {
+  ReaderOptions& setDataIoStats(std::shared_ptr<IoStatistics> stats) {
     VELOX_CHECK_NULL(dataIoStats_, "dataIoStats already set");
-    dataIoStats_ = stats;
+    dataIoStats_ = std::move(stats);
     return *this;
   }
 
-  ReaderOptions& setMetadataIoStats(IoStatistics* stats) {
+  ReaderOptions& setMetadataIoStats(std::shared_ptr<IoStatistics> stats) {
     VELOX_CHECK_NULL(metadataIoStats_, "metadataIoStats already set");
-    metadataIoStats_ = stats;
+    metadataIoStats_ = std::move(stats);
     return *this;
   }
 
-  ReaderOptions& setIndexIoStats(IoStatistics* stats) {
+  ReaderOptions& setIndexIoStats(std::shared_ptr<IoStatistics> stats) {
     VELOX_CHECK_NULL(indexIoStats_, "indexIoStats already set");
-    indexIoStats_ = stats;
+    indexIoStats_ = std::move(stats);
     return *this;
   }
 
@@ -183,25 +172,25 @@ class ReaderOptions {
 
   /// IO statistics for tracking storage reads, SSD reads, RAM cache hits,
   /// and overread bytes for data stream IO.
-  IoStatistics* dataIoStats() const {
+  const std::shared_ptr<IoStatistics>& dataIoStats() const {
     return dataIoStats_;
   }
 
   /// IO statistics for tracking storage reads, SSD reads, RAM cache hits,
   /// and overread bytes for metadata IO (footer, stripe groups, index).
-  IoStatistics* metadataIoStats() const {
+  const std::shared_ptr<IoStatistics>& metadataIoStats() const {
     return metadataIoStats_;
   }
 
-  IoStatistics* indexIoStats() const {
+  const std::shared_ptr<IoStatistics>& indexIoStats() const {
     return indexIoStats_;
   }
 
  protected:
   velox::memory::MemoryPool* pool_;
-  IoStatistics* dataIoStats_{nullptr};
-  IoStatistics* metadataIoStats_{nullptr};
-  IoStatistics* indexIoStats_{nullptr};
+  std::shared_ptr<IoStatistics> dataIoStats_;
+  std::shared_ptr<IoStatistics> metadataIoStats_;
+  std::shared_ptr<IoStatistics> indexIoStats_;
 
   std::shared_ptr<folly::Executor> ioExecutor_;
 

--- a/velox/common/io/tests/ReaderOptionsTest.cpp
+++ b/velox/common/io/tests/ReaderOptionsTest.cpp
@@ -31,9 +31,10 @@ class ReaderOptionsTest : public ::testing::Test {
 
   const std::shared_ptr<memory::MemoryPool> pool_{
       memory::memoryManager()->addLeafPool("ReaderOptionsTest")};
-  IoStatistics dataIoStats_;
-  IoStatistics metadataIoStats_;
-  IoStatistics indexIoStats_;
+  std::shared_ptr<IoStatistics> dataIoStats_{std::make_shared<IoStatistics>()};
+  std::shared_ptr<IoStatistics> metadataIoStats_{
+      std::make_shared<IoStatistics>()};
+  std::shared_ptr<IoStatistics> indexIoStats_{std::make_shared<IoStatistics>()};
 };
 
 TEST_F(ReaderOptionsTest, constructor) {
@@ -94,32 +95,32 @@ TEST_F(ReaderOptionsTest, ioExecutor) {
 
 TEST_F(ReaderOptionsTest, ioStats) {
   ReaderOptions options(pool_.get());
-  options.setDataIoStats(&dataIoStats_);
-  options.setMetadataIoStats(&metadataIoStats_);
-  options.setIndexIoStats(&indexIoStats_);
+  options.setDataIoStats(dataIoStats_);
+  options.setMetadataIoStats(metadataIoStats_);
+  options.setIndexIoStats(indexIoStats_);
 
-  EXPECT_EQ(options.dataIoStats(), &dataIoStats_);
-  EXPECT_EQ(options.metadataIoStats(), &metadataIoStats_);
-  EXPECT_EQ(options.indexIoStats(), &indexIoStats_);
+  EXPECT_EQ(options.dataIoStats(), dataIoStats_);
+  EXPECT_EQ(options.metadataIoStats(), metadataIoStats_);
+  EXPECT_EQ(options.indexIoStats(), indexIoStats_);
 
   options.dataIoStats()->read().increment(100);
-  EXPECT_EQ(dataIoStats_.read().count(), 1);
-  EXPECT_EQ(dataIoStats_.read().sum(), 100);
+  EXPECT_EQ(dataIoStats_->read().count(), 1);
+  EXPECT_EQ(dataIoStats_->read().sum(), 100);
 
   options.metadataIoStats()->read().increment(50);
-  EXPECT_EQ(metadataIoStats_.read().count(), 1);
-  EXPECT_EQ(metadataIoStats_.read().sum(), 50);
+  EXPECT_EQ(metadataIoStats_->read().count(), 1);
+  EXPECT_EQ(metadataIoStats_->read().sum(), 50);
 
   options.indexIoStats()->read().increment(25);
-  EXPECT_EQ(indexIoStats_.read().count(), 1);
-  EXPECT_EQ(indexIoStats_.read().sum(), 25);
+  EXPECT_EQ(indexIoStats_->read().count(), 1);
+  EXPECT_EQ(indexIoStats_->read().sum(), 25);
 }
 
 TEST_F(ReaderOptionsTest, chainingSetters) {
   ReaderOptions options(pool_.get());
-  auto& result = options.setDataIoStats(&dataIoStats_)
-                     .setMetadataIoStats(&metadataIoStats_)
-                     .setIndexIoStats(&indexIoStats_)
+  auto& result = options.setDataIoStats(dataIoStats_)
+                     .setMetadataIoStats(metadataIoStats_)
+                     .setIndexIoStats(indexIoStats_)
                      .setAutoPreloadLength(1'024)
                      .setPrefetchMode(PrefetchMode::PRELOAD)
                      .setLoadQuantum(4 << 20)
@@ -128,9 +129,9 @@ TEST_F(ReaderOptionsTest, chainingSetters) {
                      .setPrefetchRowGroups(4);
 
   EXPECT_EQ(&result, &options);
-  EXPECT_EQ(options.dataIoStats(), &dataIoStats_);
-  EXPECT_EQ(options.metadataIoStats(), &metadataIoStats_);
-  EXPECT_EQ(options.indexIoStats(), &indexIoStats_);
+  EXPECT_EQ(options.dataIoStats(), dataIoStats_);
+  EXPECT_EQ(options.metadataIoStats(), metadataIoStats_);
+  EXPECT_EQ(options.indexIoStats(), indexIoStats_);
   EXPECT_EQ(options.autoPreloadLength(), 1'024);
   EXPECT_EQ(options.prefetchMode(), PrefetchMode::PRELOAD);
   EXPECT_EQ(options.loadQuantum(), 4 << 20);
@@ -141,32 +142,32 @@ TEST_F(ReaderOptionsTest, chainingSetters) {
 
 TEST_F(ReaderOptionsTest, doubleSetIoStatsThrows) {
   ReaderOptions options(pool_.get());
-  options.setDataIoStats(&dataIoStats_);
+  options.setDataIoStats(dataIoStats_);
   VELOX_ASSERT_THROW(
-      options.setDataIoStats(&dataIoStats_), "dataIoStats already set");
+      options.setDataIoStats(dataIoStats_), "dataIoStats already set");
 
   ReaderOptions options2(pool_.get());
-  options2.setMetadataIoStats(&metadataIoStats_);
+  options2.setMetadataIoStats(metadataIoStats_);
   VELOX_ASSERT_THROW(
-      options2.setMetadataIoStats(&metadataIoStats_),
+      options2.setMetadataIoStats(metadataIoStats_),
       "metadataIoStats already set");
 
   ReaderOptions options3(pool_.get());
-  options3.setIndexIoStats(&indexIoStats_);
+  options3.setIndexIoStats(indexIoStats_);
   VELOX_ASSERT_THROW(
-      options3.setIndexIoStats(&indexIoStats_), "indexIoStats already set");
+      options3.setIndexIoStats(indexIoStats_), "indexIoStats already set");
 }
 
 TEST_F(ReaderOptionsTest, copyConstruct) {
   ReaderOptions options(pool_.get());
-  options.setDataIoStats(&dataIoStats_);
-  options.setMetadataIoStats(&metadataIoStats_);
+  options.setDataIoStats(dataIoStats_);
+  options.setMetadataIoStats(metadataIoStats_);
   options.setLoadQuantum(4 << 20);
 
   ReaderOptions copy(options);
   EXPECT_EQ(&copy.memoryPool(), pool_.get());
-  EXPECT_EQ(copy.dataIoStats(), &dataIoStats_);
-  EXPECT_EQ(copy.metadataIoStats(), &metadataIoStats_);
+  EXPECT_EQ(copy.dataIoStats(), dataIoStats_);
+  EXPECT_EQ(copy.metadataIoStats(), metadataIoStats_);
   EXPECT_EQ(copy.indexIoStats(), nullptr);
   EXPECT_EQ(copy.loadQuantum(), 4 << 20);
 }

--- a/velox/connectors/hive/FileIndexReader.cpp
+++ b/velox/connectors/hive/FileIndexReader.cpp
@@ -246,8 +246,9 @@ std::unique_ptr<dwio::common::Reader> FileIndexReader::createFileReader() {
   VELOX_CHECK_NOT_NULL(hiveSplit_);
 
   dwio::common::ReaderOptions readerOpts(connectorQueryCtx_->memoryPool());
-  readerOpts.setDataIoStats(ioStatistics_.get());
-  readerOpts.setMetadataIoStats(ioStatistics_.get());
+  // TODO: Use separate IoStatistics for data and metadata.
+  readerOpts.setDataIoStats(ioStatistics_);
+  readerOpts.setMetadataIoStats(ioStatistics_);
   hive::configureReaderOptions(
       fileConfig_,
       connectorQueryCtx_,

--- a/velox/connectors/hive/FileSplitReader.cpp
+++ b/velox/connectors/hive/FileSplitReader.cpp
@@ -160,8 +160,8 @@ FileSplitReader::FileSplitReader(
       readerOutputType_(readerOutputType),
       baseReaderOpts_(connectorQueryCtx->memoryPool()),
       emptySplit_(false) {
-  baseReaderOpts_.setDataIoStats(dataIoStats_.get());
-  baseReaderOpts_.setMetadataIoStats(metadataIoStats_.get());
+  baseReaderOpts_.setDataIoStats(dataIoStats_);
+  baseReaderOpts_.setMetadataIoStats(metadataIoStats_);
 }
 
 void FileSplitReader::configureReaderOptions(

--- a/velox/connectors/hive/iceberg/EqualityDeleteFileReader.cpp
+++ b/velox/connectors/hive/iceberg/EqualityDeleteFileReader.cpp
@@ -183,8 +183,9 @@ EqualityDeleteFileReader::EqualityDeleteFileReader(
       deleteFile.fileSizeInBytes);
 
   dwio::common::ReaderOptions deleteReaderOpts(pool_);
-  deleteReaderOpts.setDataIoStats(ioStatistics.get());
-  deleteReaderOpts.setMetadataIoStats(ioStatistics.get());
+  // TODO: Use separate IoStatistics for data and metadata.
+  deleteReaderOpts.setDataIoStats(ioStatistics);
+  deleteReaderOpts.setMetadataIoStats(ioStatistics);
   configureReaderOptions(
       fileConfig,
       connectorQueryCtx,

--- a/velox/connectors/hive/iceberg/PositionalDeleteFileReader.cpp
+++ b/velox/connectors/hive/iceberg/PositionalDeleteFileReader.cpp
@@ -82,8 +82,9 @@ PositionalDeleteFileReader::PositionalDeleteFileReader(
   // Create the Reader and RowReader
 
   dwio::common::ReaderOptions deleteReaderOpts(pool_);
-  deleteReaderOpts.setDataIoStats(ioStatistics_.get());
-  deleteReaderOpts.setMetadataIoStats(ioStatistics_.get());
+  // TODO: Use separate IoStatistics for data and metadata.
+  deleteReaderOpts.setDataIoStats(ioStatistics_);
+  deleteReaderOpts.setMetadataIoStats(ioStatistics_);
   configureReaderOptions(
       fileConfig_,
       connectorQueryCtx,

--- a/velox/connectors/hive/tests/FileConnectorUtilTest.cpp
+++ b/velox/connectors/hive/tests/FileConnectorUtilTest.cpp
@@ -80,8 +80,8 @@ class FileConnectorUtilTest : public exec::test::HiveConnectorTestBase {
 
   std::unique_ptr<dwio::common::Reader> makeReader(const std::string& path) {
     dwio::common::ReaderOptions readerOpts(pool_.get());
-    readerOpts.setDataIoStats(dataIoStats_.get());
-    readerOpts.setMetadataIoStats(metadataIoStats_.get());
+    readerOpts.setDataIoStats(dataIoStats_);
+    readerOpts.setMetadataIoStats(metadataIoStats_);
     readerOpts.setFileFormat(dwio::common::FileFormat::DWRF);
     auto readFile = std::make_shared<LocalReadFile>(path);
     auto input = std::make_unique<dwio::common::BufferedInput>(
@@ -106,8 +106,8 @@ TEST_F(FileConnectorUtilTest, configureReaderOptions) {
     auto holder = makeConnectorQueryCtx();
     auto split = makeSplit(dwio::common::FileFormat::DWRF);
     dwio::common::ReaderOptions readerOptions(pool_.get());
-    readerOptions.setDataIoStats(dataIoStats_.get());
-    readerOptions.setMetadataIoStats(metadataIoStats_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
     hive::configureReaderOptions(
         fileConfig,
         holder.ctx.get(),
@@ -127,8 +127,8 @@ TEST_F(FileConnectorUtilTest, configureReaderOptions) {
         {{hive::FileConfig::kOrcUseColumnNamesSession, "true"}});
     auto split = makeSplit(dwio::common::FileFormat::ORC);
     dwio::common::ReaderOptions readerOptions(pool_.get());
-    readerOptions.setDataIoStats(dataIoStats_.get());
-    readerOptions.setMetadataIoStats(metadataIoStats_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
     hive::configureReaderOptions(
         fileConfig,
         holder.ctx.get(),
@@ -147,8 +147,8 @@ TEST_F(FileConnectorUtilTest, configureReaderOptions) {
         {{hive::FileConfig::kParquetUseColumnNamesSession, "true"}});
     auto split = makeSplit(dwio::common::FileFormat::PARQUET);
     dwio::common::ReaderOptions readerOptions(pool_.get());
-    readerOptions.setDataIoStats(dataIoStats_.get());
-    readerOptions.setMetadataIoStats(metadataIoStats_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
     hive::configureReaderOptions(
         fileConfig,
         holder.ctx.get(),
@@ -166,8 +166,8 @@ TEST_F(FileConnectorUtilTest, configureReaderOptions) {
     auto holder = makeConnectorQueryCtx();
     auto split = makeSplit(dwio::common::FileFormat::DWRF);
     dwio::common::ReaderOptions readerOptions(pool_.get());
-    readerOptions.setDataIoStats(dataIoStats_.get());
-    readerOptions.setMetadataIoStats(metadataIoStats_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
     readerOptions.setFileFormat(dwio::common::FileFormat::PARQUET);
     VELOX_ASSERT_THROW(
         hive::configureReaderOptions(

--- a/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
@@ -99,8 +99,8 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
 
   // Dynamic parameters.
   dwio::common::ReaderOptions readerOptions(pool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   FileFormat fileFormat{FileFormat::DWRF};
   std::unordered_map<std::string, std::string> tableParameters;
   std::unordered_map<std::string, std::string> serdeParameters;
@@ -145,8 +145,8 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
 
   auto clearDynamicParameters = [&](FileFormat newFileFormat) {
     readerOptions = dwio::common::ReaderOptions(pool_.get());
-    readerOptions.setDataIoStats(dataIoStats_.get());
-    readerOptions.setMetadataIoStats(metadataIoStats_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
     fileFormat = newFileFormat;
     tableParameters.clear();
     serdeParameters.clear();
@@ -366,8 +366,8 @@ TEST_F(HiveConnectorUtilTest, footerSpeculativeIoSizeByFormat) {
   // Test ORC format.
   {
     dwio::common::ReaderOptions readerOptions(pool_.get());
-    readerOptions.setDataIoStats(dataIoStats_.get());
-    readerOptions.setMetadataIoStats(metadataIoStats_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
     auto tableHandle = createTableHandle();
     auto split = createSplit(FileFormat::ORC);
     configureReaderOptions(
@@ -386,8 +386,8 @@ TEST_F(HiveConnectorUtilTest, footerSpeculativeIoSizeByFormat) {
   // Test DWRF format (uses ORC config).
   {
     dwio::common::ReaderOptions readerOptions(pool_.get());
-    readerOptions.setDataIoStats(dataIoStats_.get());
-    readerOptions.setMetadataIoStats(metadataIoStats_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
     auto tableHandle = createTableHandle();
     auto split = createSplit(FileFormat::DWRF);
     configureReaderOptions(
@@ -406,8 +406,8 @@ TEST_F(HiveConnectorUtilTest, footerSpeculativeIoSizeByFormat) {
   // Test Parquet format.
   {
     dwio::common::ReaderOptions readerOptions(pool_.get());
-    readerOptions.setDataIoStats(dataIoStats_.get());
-    readerOptions.setMetadataIoStats(metadataIoStats_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
     auto tableHandle = createTableHandle();
     auto split = createSplit(FileFormat::PARQUET);
     configureReaderOptions(
@@ -426,8 +426,8 @@ TEST_F(HiveConnectorUtilTest, footerSpeculativeIoSizeByFormat) {
   // Test Nimble format.
   {
     dwio::common::ReaderOptions readerOptions(pool_.get());
-    readerOptions.setDataIoStats(dataIoStats_.get());
-    readerOptions.setMetadataIoStats(metadataIoStats_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
     auto tableHandle = createTableHandle();
     auto split = createSplit(FileFormat::NIMBLE);
     configureReaderOptions(
@@ -447,8 +447,8 @@ TEST_F(HiveConnectorUtilTest, footerSpeculativeIoSizeByFormat) {
 TEST_F(HiveConnectorUtilTest, fileMetadataCacheEnabledSessionOverride) {
   // Verify default is off.
   dwio::common::ReaderOptions defaultOptions(pool_.get());
-  defaultOptions.setDataIoStats(dataIoStats_.get());
-  defaultOptions.setMetadataIoStats(metadataIoStats_.get());
+  defaultOptions.setDataIoStats(dataIoStats_);
+  defaultOptions.setMetadataIoStats(metadataIoStats_);
   ASSERT_FALSE(defaultOptions.fileMetadataCacheEnabled());
 
   for (bool enabled : {true, false}) {
@@ -475,8 +475,8 @@ TEST_F(HiveConnectorUtilTest, fileMetadataCacheEnabledSessionOverride) {
         std::make_shared<hive::HiveConfig>(std::make_shared<config::ConfigBase>(
             std::unordered_map<std::string, std::string>()));
     dwio::common::ReaderOptions readerOptions(pool_.get());
-    readerOptions.setDataIoStats(dataIoStats_.get());
-    readerOptions.setMetadataIoStats(metadataIoStats_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
 
     auto tableHandle = std::make_shared<hive::HiveTableHandle>(
         "testConnectorId",
@@ -535,8 +535,8 @@ TEST_F(HiveConnectorUtilTest, cacheRetention) {
         "");
 
     dwio::common::ReaderOptions readerOptions(pool_.get());
-    readerOptions.setDataIoStats(dataIoStats_.get());
-    readerOptions.setMetadataIoStats(metadataIoStats_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
 
     auto tableHandle = std::make_shared<hive::HiveTableHandle>(
         "testConnectorId",

--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -1177,8 +1177,8 @@ TEST_F(HiveDataSinkTest, flushPolicyWithParquet) {
   dataSink->close();
 
   dwio::common::ReaderOptions readerOpts(pool_.get());
-  readerOpts.setDataIoStats(dataIoStats_.get());
-  readerOpts.setMetadataIoStats(metadataIoStats_.get());
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   const std::vector<std::string> filePaths =
       listFiles(outputDirectory->getPath());
   auto bufferedInput = std::make_unique<dwio::common::BufferedInput>(
@@ -1217,8 +1217,8 @@ TEST_F(HiveDataSinkTest, flushPolicyWithDWRF) {
   dataSink->close();
 
   dwio::common::ReaderOptions readerOpts(pool_.get());
-  readerOpts.setDataIoStats(dataIoStats_.get());
-  readerOpts.setMetadataIoStats(metadataIoStats_.get());
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   const std::vector<std::string> filePaths =
       listFiles(outputDirectory->getPath());
   auto bufferedInput = std::make_unique<dwio::common::BufferedInput>(

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -579,13 +579,6 @@ class ReaderOptions : public io::ReaderOptions {
   explicit ReaderOptions(velox::memory::MemoryPool* pool)
       : io::ReaderOptions(pool) {}
 
-  // Deprecated: use pool-only constructor + setDataIoStats/setMetadataIoStats.
-  ReaderOptions(
-      velox::memory::MemoryPool* pool,
-      velox::io::IoStatistics* dataIoStats,
-      velox::io::IoStatistics* metadataIoStats)
-      : io::ReaderOptions(pool, dataIoStats, metadataIoStats) {}
-
   /// Sets the format of the file, such as "rc" or "dwrf". The default is
   /// "dwrf".
   ReaderOptions& setFileFormat(FileFormat format) {

--- a/velox/dwio/common/tests/BufferedInputTest.cpp
+++ b/velox/dwio/common/tests/BufferedInputTest.cpp
@@ -773,8 +773,10 @@ class CustomBufferedInputTest : public testing::Test {
   }
 
   const std::shared_ptr<MemoryPool> pool_ = memoryManager()->addLeafPool();
-  facebook::velox::io::IoStatistics dataIoStats_;
-  facebook::velox::io::IoStatistics metadataIoStats_;
+  std::shared_ptr<facebook::velox::io::IoStatistics> dataIoStats_{
+      std::make_shared<facebook::velox::io::IoStatistics>()};
+  std::shared_ptr<facebook::velox::io::IoStatistics> metadataIoStats_{
+      std::make_shared<facebook::velox::io::IoStatistics>()};
 };
 
 } // namespace
@@ -782,8 +784,8 @@ class CustomBufferedInputTest : public testing::Test {
 TEST_F(CustomBufferedInputTest, basic) {
   facebook::velox::FileHandle fileHandle;
   facebook::velox::dwio::common::ReaderOptions readerOpts(pool_.get());
-  readerOpts.setDataIoStats(&dataIoStats_);
-  readerOpts.setMetadataIoStats(&metadataIoStats_);
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   auto ioStatistics = std::make_shared<facebook::velox::io::IoStatistics>();
   auto ioStats = std::make_shared<facebook::velox::IoStats>();
   auto executor = std::make_unique<folly::IOThreadPoolExecutor>(10, 10);

--- a/velox/dwio/common/tests/CachedBufferedInputTest.cpp
+++ b/velox/dwio/common/tests/CachedBufferedInputTest.cpp
@@ -150,8 +150,8 @@ TEST_F(CachedBufferedInputTest, reset) {
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
   io::ReaderOptions readerOptions(pool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setLoadQuantum(1 << 20);
 
   auto& ids = fileIds();
@@ -289,8 +289,8 @@ TEST_F(CachedBufferedInputTest, readAfterReset) {
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
   io::ReaderOptions readerOptions(pool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setLoadQuantum(1 << 20);
 
   auto& ids = fileIds();
@@ -358,8 +358,8 @@ DEBUG_ONLY_TEST_F(CachedBufferedInputTest, resetInputWithBeforeLoading) {
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
   io::ReaderOptions readerOptions(pool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setLoadQuantum(1 << 20);
 
   auto& ids = fileIds();
@@ -456,8 +456,8 @@ DEBUG_ONLY_TEST_F(CachedBufferedInputTest, resetInputWithAfterLoading) {
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
   io::ReaderOptions readerOptions(pool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setLoadQuantum(1 << 20);
 
   auto& ids = fileIds();
@@ -554,8 +554,8 @@ TEST_F(CachedBufferedInputTest, hasCache) {
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
   io::ReaderOptions readerOptions(pool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto& ids = fileIds();
   StringIdLease fileId(ids, "testFile");
   StringIdLease groupId(ids, "testGroup");
@@ -587,8 +587,8 @@ TEST_P(CacheRegionTest, cacheAndFind) {
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
   io::ReaderOptions readerOptions(pool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto& ids = fileIds();
   StringIdLease fileId(ids, "testFile_cacheAndFind");
   StringIdLease groupId(ids, "testGroup_cacheAndFind");
@@ -656,8 +656,8 @@ TEST_P(CacheRegionTest, smallEntry) {
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
   io::ReaderOptions readerOptions(pool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto& ids = fileIds();
   StringIdLease fileId(ids, "testFile_smallEntry");
   StringIdLease groupId(ids, "testGroup_smallEntry");
@@ -727,8 +727,8 @@ TEST_P(CacheRegionTest, largeEntry) {
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
   io::ReaderOptions readerOptions(pool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto& ids = fileIds();
   StringIdLease fileId(ids, "testFile_largeEntry");
   StringIdLease groupId(ids, "testGroup_largeEntry");
@@ -792,8 +792,8 @@ TEST_P(CacheRegionTest, miss) {
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
   io::ReaderOptions readerOptions(pool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto& ids = fileIds();
   StringIdLease fileId(ids, "testFile_miss");
   StringIdLease groupId(ids, "testGroup_miss");
@@ -825,8 +825,8 @@ TEST_P(CacheRegionTest, pinKeepsDataAlive) {
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
   io::ReaderOptions readerOptions(pool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto& ids = fileIds();
   StringIdLease fileId(ids, "testFile_pinAlive");
   StringIdLease groupId(ids, "testGroup_pinAlive");
@@ -894,8 +894,8 @@ TEST_F(CachedBufferedInputTest, findCachedRegionExclusiveWithWait) {
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
   io::ReaderOptions readerOptions(pool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto& ids = fileIds();
   const std::string fileName = "testFile_findWait";
   StringIdLease fileId(ids, fileName);
@@ -978,8 +978,8 @@ TEST_F(CachedBufferedInputTest, cacheRegionSkipsOngoingInsert) {
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
   io::ReaderOptions readerOptions(pool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto& ids = fileIds();
   const std::string fileName = "testFile_skipInsert";
   StringIdLease fileId(ids, fileName);
@@ -1044,8 +1044,8 @@ TEST_F(CachedBufferedInputTest, preloadCalledTwice) {
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
   io::ReaderOptions readerOptions(pool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto& ids = fileIds();
   StringIdLease fileId(ids, "preloadTwice");
   StringIdLease groupId(ids, "preloadTwiceGroup");
@@ -1072,8 +1072,8 @@ TEST_F(CachedBufferedInputTest, isBufferedWithPreload) {
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
   io::ReaderOptions readerOptions(pool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto& ids = fileIds();
   StringIdLease fileId(ids, "isBufferedPreload");
   StringIdLease groupId(ids, "isBufferedPreloadGroup");
@@ -1106,8 +1106,8 @@ TEST_F(CachedBufferedInputTest, enqueueSkipsRequestsWhenPreloaded) {
   auto readFile = std::make_shared<tests::utils::CountingReadFile>(content);
 
   io::ReaderOptions readerOptions(pool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto& ids = fileIds();
   StringIdLease fileId(ids, "enqueueSkipsRequests");
   StringIdLease groupId(ids, "enqueueSkipsRequestsGroup");
@@ -1158,8 +1158,8 @@ TEST_F(CachedBufferedInputTest, readSetsPreloadedPinWhenPreloaded) {
   auto readFile = std::make_shared<tests::utils::CountingReadFile>(content);
 
   io::ReaderOptions readerOptions(pool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setLoadQuantum(1 << 20);
 
   auto& ids = fileIds();
@@ -1202,8 +1202,8 @@ TEST_F(CachedBufferedInputTest, preloadAfterEnqueue) {
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
   io::ReaderOptions readerOptions(pool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto& ids = fileIds();
   StringIdLease fileId(ids, "preloadAfterEnqueue");
   StringIdLease groupId(ids, "preloadAfterEnqueueGroup");
@@ -1239,8 +1239,8 @@ TEST_F(CachedBufferedInputTest, preloadedStreamSkipsEviction) {
   auto readFile = std::make_shared<tests::utils::CountingReadFile>(content);
 
   io::ReaderOptions readerOptions(pool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setCacheable(false);
   readerOptions.setLoadQuantum(1 << 20);
 
@@ -1304,8 +1304,8 @@ TEST_F(CachedBufferedInputTest, preloadRespectsNotCacheable) {
   auto readFile = std::make_shared<tests::utils::CountingReadFile>(content);
 
   io::ReaderOptions readerOptions(pool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setCacheable(false);
   readerOptions.setLoadQuantum(1 << 20);
 
@@ -1352,8 +1352,8 @@ TEST_F(CachedBufferedInputTest, preloadRespectsCacheable) {
   auto readFile = std::make_shared<tests::utils::CountingReadFile>(content);
 
   io::ReaderOptions readerOptions(pool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setCacheable(true);
   readerOptions.setLoadQuantum(1 << 20);
 
@@ -1412,8 +1412,8 @@ TEST_F(CachedBufferedInputTest, preload) {
     auto readFile = std::make_shared<tests::utils::CountingReadFile>(content);
 
     io::ReaderOptions readerOptions(pool_.get());
-    readerOptions.setDataIoStats(dataIoStats_.get());
-    readerOptions.setMetadataIoStats(metadataIoStats_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
     readerOptions.setLoadQuantum(1 << 20);
 
     auto& ids = fileIds();
@@ -1495,8 +1495,8 @@ TEST_F(CachedBufferedInputTest, preloadCacheSharing) {
   auto readFile = std::make_shared<tests::utils::CountingReadFile>(content);
 
   io::ReaderOptions readerOptions(pool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setLoadQuantum(1 << 20);
 
   auto& ids = fileIds();
@@ -1580,8 +1580,8 @@ TEST_F(CachedBufferedInputTest, prefetchScope) {
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
   io::ReaderOptions readerOptions(pool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
 
   auto& ids = fileIds();
   StringIdLease fileId(ids, "testFile");
@@ -1644,8 +1644,8 @@ TEST_F(CachedBufferedInputTest, cloneNonCacheable) {
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
   io::ReaderOptions readerOptions(pool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setLoadQuantum(1 << 20);
 
   auto& ids = fileIds();

--- a/velox/dwio/common/tests/DirectBufferedInputTest.cpp
+++ b/velox/dwio/common/tests/DirectBufferedInputTest.cpp
@@ -97,8 +97,8 @@ TEST_F(DirectBufferedInputTest, reset) {
     auto readFile = std::make_shared<InMemoryReadFile>(content);
 
     io::ReaderOptions readerOptions(pool_.get());
-    readerOptions.setDataIoStats(dataIoStats_.get());
-    readerOptions.setMetadataIoStats(metadataIoStats_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
     readerOptions.setLoadQuantum(1 << 20);
 
     auto& ids = fileIds();
@@ -224,8 +224,8 @@ TEST_F(DirectBufferedInputTest, readAfterReset) {
     auto readFile = std::make_shared<InMemoryReadFile>(content);
 
     io::ReaderOptions readerOptions(pool_.get());
-    readerOptions.setDataIoStats(dataIoStats_.get());
-    readerOptions.setMetadataIoStats(metadataIoStats_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
     readerOptions.setLoadQuantum(1 << 20);
 
     auto& ids = fileIds();
@@ -304,8 +304,8 @@ DEBUG_ONLY_TEST_F(DirectBufferedInputTest, resetInputWithBeforeLoading) {
     auto readFile = std::make_shared<InMemoryReadFile>(content);
 
     io::ReaderOptions readerOptions(pool_.get());
-    readerOptions.setDataIoStats(dataIoStats_.get());
-    readerOptions.setMetadataIoStats(metadataIoStats_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
     readerOptions.setLoadQuantum(1 << 20);
 
     auto& ids = fileIds();
@@ -411,8 +411,8 @@ DEBUG_ONLY_TEST_F(DirectBufferedInputTest, resetInputWithAfterLoading) {
     auto readFile = std::make_shared<InMemoryReadFile>(content);
 
     io::ReaderOptions readerOptions(pool_.get());
-    readerOptions.setDataIoStats(dataIoStats_.get());
-    readerOptions.setMetadataIoStats(metadataIoStats_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
     readerOptions.setLoadQuantum(1 << 20);
 
     auto& ids = fileIds();
@@ -504,8 +504,8 @@ TEST_F(DirectBufferedInputTest, preloadCalledTwice) {
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
   io::ReaderOptions readerOptions(pool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto& ids = fileIds();
   StringIdLease fileId(ids, "preloadTwice");
   StringIdLease groupId(ids, "preloadTwiceGroup");
@@ -531,8 +531,8 @@ TEST_F(DirectBufferedInputTest, isBufferedWithPreload) {
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
   io::ReaderOptions readerOptions(pool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto& ids = fileIds();
   StringIdLease fileId(ids, "isBufferedPreload");
   StringIdLease groupId(ids, "isBufferedPreloadGroup");
@@ -564,8 +564,8 @@ TEST_F(DirectBufferedInputTest, enqueueSkipsRequestsWhenPreloaded) {
   auto readFile = std::make_shared<tests::utils::CountingReadFile>(content);
 
   io::ReaderOptions readerOptions(pool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto& ids = fileIds();
   StringIdLease fileId(ids, "enqueueSkipsRequests");
   StringIdLease groupId(ids, "enqueueSkipsRequestsGroup");
@@ -610,8 +610,8 @@ TEST_F(DirectBufferedInputTest, preloadAfterEnqueue) {
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
   io::ReaderOptions readerOptions(pool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto& ids = fileIds();
   StringIdLease fileId(ids, "preloadAfterEnqueue");
   StringIdLease groupId(ids, "preloadAfterEnqueueGroup");
@@ -637,8 +637,8 @@ TEST_F(DirectBufferedInputTest, preloadedDataWithoutPreload) {
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
   io::ReaderOptions readerOptions(pool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto& ids = fileIds();
   StringIdLease fileId(ids, "preloadedDataNoPreload");
   StringIdLease groupId(ids, "preloadedDataNoPreloadGroup");
@@ -663,8 +663,8 @@ TEST_F(DirectBufferedInputTest, preloadedDataOffsetOutOfRange) {
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
   io::ReaderOptions readerOptions(pool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto& ids = fileIds();
   StringIdLease fileId(ids, "preloadedDataOOR");
   StringIdLease groupId(ids, "preloadedDataOORGroup");
@@ -712,8 +712,8 @@ TEST_F(DirectBufferedInputTest, preload) {
     auto readFile = std::make_shared<tests::utils::CountingReadFile>(content);
 
     io::ReaderOptions readerOptions(pool_.get());
-    readerOptions.setDataIoStats(dataIoStats_.get());
-    readerOptions.setMetadataIoStats(metadataIoStats_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
     readerOptions.setLoadQuantum(1 << 20);
 
     auto& ids = fileIds();
@@ -823,8 +823,8 @@ TEST_F(DirectBufferedInputTest, preloadedData) {
     auto readFile = std::make_shared<tests::utils::CountingReadFile>(content);
 
     io::ReaderOptions readerOptions(pool_.get());
-    readerOptions.setDataIoStats(dataIoStats_.get());
-    readerOptions.setMetadataIoStats(metadataIoStats_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
     auto& ids = fileIds();
     StringIdLease fileId(
         ids,
@@ -889,8 +889,8 @@ TEST_F(DirectBufferedInputTest, hasCache) {
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
   io::ReaderOptions readerOptions(pool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
 
   auto& ids = fileIds();
   StringIdLease fileId(ids, "testFile");

--- a/velox/dwio/common/tests/utils/E2EFilterTestBase.cpp
+++ b/velox/dwio/common/tests/utils/E2EFilterTestBase.cpp
@@ -434,8 +434,8 @@ void E2EFilterTestBase::readWithoutFilter(
     uint64_t& time) {
   SCOPED_TRACE("Read without filter");
   dwio::common::ReaderOptions readerOpts{leafPool_.get()};
-  readerOpts.setDataIoStats(dataIoStats_.get());
-  readerOpts.setMetadataIoStats(metadataIoStats_.get());
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   dwio::common::RowReaderOptions rowReaderOpts;
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
@@ -490,8 +490,8 @@ void E2EFilterTestBase::readWithFilter(
     bool skipCheck) {
   SCOPED_TRACE("Read with filter");
   dwio::common::ReaderOptions readerOpts{leafPool_.get()};
-  readerOpts.setDataIoStats(dataIoStats_.get());
-  readerOpts.setMetadataIoStats(metadataIoStats_.get());
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   dwio::common::RowReaderOptions rowReaderOpts;
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
@@ -880,8 +880,8 @@ void E2EFilterTestBase::testMetadataFilterImpl(
   specC->setProjectOut(true);
   specC->setChannel(0);
   ReaderOptions readerOpts{leafPool_.get()};
-  readerOpts.setDataIoStats(dataIoStats_.get());
-  readerOpts.setMetadataIoStats(metadataIoStats_.get());
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   RowReaderOptions rowReaderOpts;
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
@@ -1145,8 +1145,8 @@ void E2EFilterTestBase::testSubfieldsPruning() {
   specF->childByName(common::ScanSpec::kArrayElementsFieldName)
       ->setFilter(common::createBigintValues({0, 2, 4}, false));
   ReaderOptions readerOpts{leafPool_.get()};
-  readerOpts.setDataIoStats(dataIoStats_.get());
-  readerOpts.setMetadataIoStats(metadataIoStats_.get());
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   RowReaderOptions rowReaderOpts;
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
@@ -1237,8 +1237,8 @@ void E2EFilterTestBase::testMutationCornerCases() {
   auto& rowType = batches[0]->type();
   writeToMemory(rowType, batches, false);
   ReaderOptions readerOpts{leafPool_.get()};
-  readerOpts.setDataIoStats(dataIoStats_.get());
-  readerOpts.setMetadataIoStats(metadataIoStats_.get());
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
   auto reader = makeReader(readerOpts, std::move(input));

--- a/velox/dwio/dwrf/reader/ReaderBase.cpp
+++ b/velox/dwio/dwrf/reader/ReaderBase.cpp
@@ -79,16 +79,6 @@ FooterStatisticsImpl::FooterStatisticsImpl(
   }
 }
 
-ReaderBase::ReaderBase(
-    MemoryPool& pool,
-    std::unique_ptr<dwio::common::BufferedInput> input,
-    FileFormat fileFormat,
-    io::IoStatistics* dataIoStats,
-    io::IoStatistics* metadataIoStats)
-    : ReaderBase(
-          createReaderOptions(pool, fileFormat, dataIoStats, metadataIoStats),
-          std::move(input)) {}
-
 namespace {
 
 template <typename T>

--- a/velox/dwio/dwrf/reader/ReaderBase.h
+++ b/velox/dwio/dwrf/reader/ReaderBase.h
@@ -65,16 +65,7 @@ class ReaderBase {
       const dwio::common::ReaderOptions& options,
       std::unique_ptr<dwio::common::BufferedInput> input);
 
-  /// Creates reader base from buffered input.
-  /// It is kept here for backward compatibility with Meta's internal usage.
-  ReaderBase(
-      memory::MemoryPool& pool,
-      std::unique_ptr<dwio::common::BufferedInput> input,
-      dwio::common::FileFormat fileFormat,
-      io::IoStatistics* dataIoStats,
-      io::IoStatistics* metadataIoStats);
-
-  /// Creates reader base from metadata.
+  /// Creates reader base from metadata (for testing).
   ReaderBase(
       memory::MemoryPool& pool,
       std::unique_ptr<dwio::common::BufferedInput> input,
@@ -82,12 +73,12 @@ class ReaderBase {
       const proto::Footer* footer,
       std::unique_ptr<StripeMetadataCache> cache,
       std::unique_ptr<encryption::DecryptionHandler> handler,
-      io::IoStatistics* dataIoStats,
-      io::IoStatistics* metadataIoStats)
+      std::shared_ptr<io::IoStatistics> dataIoStats = nullptr,
+      std::shared_ptr<io::IoStatistics> metadataIoStats = nullptr)
       : options_{[&] {
           dwio::common::ReaderOptions opts(&pool);
-          opts.setDataIoStats(dataIoStats);
-          opts.setMetadataIoStats(metadataIoStats);
+          opts.setDataIoStats(std::move(dataIoStats));
+          opts.setMetadataIoStats(std::move(metadataIoStats));
           return opts;
         }()},
         input_{std::move(input)},
@@ -268,18 +259,6 @@ class ReaderBase {
       const FooterWrapper& footer,
       uint32_t index = 0,
       bool fileColumnNamesReadAsLowerCase = false);
-
-  static dwio::common::ReaderOptions createReaderOptions(
-      memory::MemoryPool& pool,
-      dwio::common::FileFormat fileFormat,
-      io::IoStatistics* dataIoStats,
-      io::IoStatistics* metadataIoStats) {
-    dwio::common::ReaderOptions options(&pool);
-    options.setDataIoStats(dataIoStats);
-    options.setMetadataIoStats(metadataIoStats);
-    options.setFileFormat(fileFormat);
-    return options;
-  }
 
   const dwio::common::ReaderOptions options_;
   const std::unique_ptr<dwio::common::BufferedInput> input_;

--- a/velox/dwio/dwrf/test/CacheInputTest.cpp
+++ b/velox/dwio/dwrf/test/CacheInputTest.cpp
@@ -223,8 +223,8 @@ class CacheTest : public ::testing::Test {
       const std::shared_ptr<facebook::velox::IoStats>& ioStats) {
     auto data = std::make_unique<StripeData>();
     auto readOptions = io::ReaderOptions(pool_.get());
-    readOptions.setDataIoStats(dataIoStats_.get());
-    readOptions.setMetadataIoStats(metadataIoStats_.get());
+    readOptions.setDataIoStats(dataIoStats_);
+    readOptions.setMetadataIoStats(metadataIoStats_);
     readOptions.setCacheable(cacheable);
     data->input = std::make_unique<CachedBufferedInput>(
         readFile,
@@ -494,8 +494,8 @@ TEST_F(CacheTest, window) {
       executor_.get(),
       [&] {
         io::ReaderOptions opts(pool_.get());
-        opts.setDataIoStats(dataIoStats_.get());
-        opts.setMetadataIoStats(metadataIoStats_.get());
+        opts.setDataIoStats(dataIoStats_);
+        opts.setMetadataIoStats(metadataIoStats_);
         return opts;
       }());
   auto begin = 4 * kMB;
@@ -745,8 +745,8 @@ class FileWithReadAhead {
       memory::MemoryPool& pool,
       folly::Executor* executor)
       : options_(&pool) {
-    options_.setDataIoStats(&dataIoStats_);
-    options_.setMetadataIoStats(&metadataIoStats_);
+    options_.setDataIoStats(dataIoStats_);
+    options_.setMetadataIoStats(metadataIoStats_);
     fileId_ = std::make_unique<StringIdLease>(fileIds(), name);
     file_ = std::make_shared<TestReadFile>(fileId_->id(), kFileSize, ioStats);
     options_.setCacheable(false);
@@ -776,8 +776,10 @@ class FileWithReadAhead {
   }
 
  private:
-  io::IoStatistics dataIoStats_;
-  io::IoStatistics metadataIoStats_;
+  std::shared_ptr<io::IoStatistics> dataIoStats_{
+      std::make_shared<io::IoStatistics>()};
+  std::shared_ptr<io::IoStatistics> metadataIoStats_{
+      std::make_shared<io::IoStatistics>()};
 
   std::unique_ptr<StringIdLease> fileId_;
   std::unique_ptr<CachedBufferedInput> bufferedInput_;
@@ -968,8 +970,8 @@ TEST_F(CacheTest, loadQuotumTooLarge) {
   auto readFile =
       std::make_shared<TestReadFile>(fileId.id(), 10 << 20, nullptr);
   auto readOptions = io::ReaderOptions(pool_.get());
-  readOptions.setDataIoStats(dataIoStats_.get());
-  readOptions.setMetadataIoStats(metadataIoStats_.get());
+  readOptions.setDataIoStats(dataIoStats_);
+  readOptions.setMetadataIoStats(metadataIoStats_);
   readOptions.setLoadQuantum(9 << 20 /*9MB*/);
   VELOX_ASSERT_THROW(
       std::make_unique<CachedBufferedInput>(
@@ -1009,8 +1011,8 @@ TEST_F(CacheTest, ssdReadVerification) {
       executor_.get(),
       [&] {
         io::ReaderOptions opts(pool_.get());
-        opts.setDataIoStats(dataIoStats_.get());
-        opts.setMetadataIoStats(metadataIoStats_.get());
+        opts.setDataIoStats(dataIoStats_);
+        opts.setMetadataIoStats(metadataIoStats_);
         return opts;
       }());
 

--- a/velox/dwio/dwrf/test/ColumnWriterStatsTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterStatsTests.cpp
@@ -196,8 +196,8 @@ class ColumnWriterStatsTest : public ::testing::Test {
     auto input = std::make_unique<BufferedInput>(readFile, *leafPool_);
 
     dwio::common::ReaderOptions readerOpts(leafPool_.get());
-    readerOpts.setDataIoStats(dataIoStats_.get());
-    readerOpts.setMetadataIoStats(metadataIoStats_.get());
+    readerOpts.setDataIoStats(dataIoStats_);
+    readerOpts.setMetadataIoStats(metadataIoStats_);
     RowReaderOptions rowReaderOpts;
     auto reader = std::make_unique<DwrfReader>(readerOpts, std::move(input));
     return reader->createRowReader(rowReaderOpts);

--- a/velox/dwio/dwrf/test/ColumnWriterTest.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTest.cpp
@@ -1938,8 +1938,8 @@ std::unique_ptr<DwrfReader> getDwrfReader(
     const std::shared_ptr<const RowType> type,
     const VectorPtr& batch,
     bool useFlatMap,
-    io::IoStatistics& dataIoStats,
-    io::IoStatistics& metadataIoStats) {
+    std::shared_ptr<io::IoStatistics> dataIoStats,
+    std::shared_ptr<io::IoStatistics> metadataIoStats) {
   auto config = std::make_shared<Config>();
   if (useFlatMap) {
     config->set(Config::FLATTEN_MAP, true);
@@ -1964,8 +1964,9 @@ std::unique_ptr<DwrfReader> getDwrfReader(
   writer.close();
 
   std::string data(sinkPtr->data(), sinkPtr->size());
-  dwio::common::ReaderOptions readerOpts{
-      &leafPool, &dataIoStats, &metadataIoStats};
+  dwio::common::ReaderOptions readerOpts{&leafPool};
+  readerOpts.setDataIoStats(std::move(dataIoStats));
+  readerOpts.setMetadataIoStats(std::move(metadataIoStats));
   return std::make_unique<DwrfReader>(
       readerOpts,
       std::make_unique<BufferedInput>(
@@ -1988,8 +1989,8 @@ void testMapWriterStats(const std::shared_ptr<const RowType> type) {
   auto rootPool = memory::memoryManager()->addRootPool();
   auto leafPool = memory::memoryManager()->addLeafPool();
   auto batch = BatchMaker::createBatch(type, 10, *leafPool);
-  io::IoStatistics dataIoStats;
-  io::IoStatistics metadataIoStats;
+  auto dataIoStats = std::make_shared<io::IoStatistics>();
+  auto metadataIoStats = std::make_shared<io::IoStatistics>();
   auto mapReader = getDwrfReader(
       *rootPool, *leafPool, type, batch, false, dataIoStats, metadataIoStats);
   auto flatMapReader = getDwrfReader(

--- a/velox/dwio/dwrf/test/DirectBufferedInputTest.cpp
+++ b/velox/dwio/dwrf/test/DirectBufferedInputTest.cpp
@@ -59,8 +59,8 @@ class DirectBufferedInputTest : public testing::Test {
     tracker_ = std::make_shared<cache::ScanTracker>("", nullptr, kLoadQuantum);
     file_ = std::make_shared<TestReadFile>(11, 100 << 20, ioStats_);
     opts_ = std::make_unique<dwio::common::ReaderOptions>(pool_.get());
-    opts_->setDataIoStats(ioStatistics_.get());
-    opts_->setMetadataIoStats(metadataIoStats_.get());
+    opts_->setDataIoStats(ioStatistics_);
+    opts_->setMetadataIoStats(metadataIoStats_);
     opts_->setLoadQuantum(kLoadQuantum);
   }
 

--- a/velox/dwio/dwrf/test/E2EReaderTest.cpp
+++ b/velox/dwio/dwrf/test/E2EReaderTest.cpp
@@ -105,8 +105,10 @@ class E2EReaderTest : public testing::TestWithParam<ValueTypes> {
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
   }
 
-  io::IoStatistics dataIoStats_;
-  io::IoStatistics metadataIoStats_;
+  std::shared_ptr<io::IoStatistics> dataIoStats_{
+      std::make_shared<io::IoStatistics>()};
+  std::shared_ptr<io::IoStatistics> metadataIoStats_{
+      std::make_shared<io::IoStatistics>()};
 };
 } // namespace
 
@@ -179,8 +181,8 @@ TEST_P(E2EReaderTest, SharedDictionaryFlatmapReadAsStruct) {
   writer.reset();
 
   dwio::common::ReaderOptions readerOpts(pool.get());
-  readerOpts.setDataIoStats(&dataIoStats_);
-  readerOpts.setMetadataIoStats(&metadataIoStats_);
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   auto bufferedInput = std::make_unique<BufferedInput>(
       std::make_shared<LocalReadFile>(path), *pool);
   auto reader = DwrfReader::create(std::move(bufferedInput), readerOpts);

--- a/velox/dwio/dwrf/test/E2EWriterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EWriterTest.cpp
@@ -111,8 +111,8 @@ class E2EWriterTest : public testing::Test {
     writer.close();
 
     dwio::common::ReaderOptions readerOpts(leafPool_.get());
-    readerOpts.setDataIoStats(dataIoStats_.get());
-    readerOpts.setMetadataIoStats(metadataIoStats_.get());
+    readerOpts.setDataIoStats(dataIoStats_);
+    readerOpts.setMetadataIoStats(metadataIoStats_);
     RowReaderOptions rowReaderOpts;
     auto reader = createReader(*sinkPtr, readerOpts);
     auto rowReader = reader->createRowReader(rowReaderOpts);
@@ -175,8 +175,8 @@ class E2EWriterTest : public testing::Test {
     writer.close();
 
     dwio::common::ReaderOptions readerOpts(leafPool_.get());
-    readerOpts.setDataIoStats(dataIoStats_.get());
-    readerOpts.setMetadataIoStats(metadataIoStats_.get());
+    readerOpts.setDataIoStats(dataIoStats_);
+    readerOpts.setMetadataIoStats(metadataIoStats_);
     RowReaderOptions rowReaderOpts;
     auto reader = createReader(*sinkPtr, readerOpts);
     auto rowReader = reader->createRowReader(rowReaderOpts);
@@ -579,8 +579,8 @@ TEST_F(E2EWriterTest, PresentStreamIsSuppressedOnFlatMap) {
       dwrf::E2EWriterTestUtil::simpleFlushPolicyFactory(true));
 
   dwio::common::ReaderOptions readerOpts(leafPool_.get());
-  readerOpts.setDataIoStats(dataIoStats_.get());
-  readerOpts.setMetadataIoStats(metadataIoStats_.get());
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   RowReaderOptions rowReaderOpts;
   auto reader = createReader(*sinkPtr, readerOpts);
   auto rowReader = reader->createRowReader(rowReaderOpts);
@@ -953,8 +953,8 @@ TEST_F(E2EWriterTest, PartialStride) {
   writer.close();
 
   dwio::common::ReaderOptions readerOpts(leafPool_.get());
-  readerOpts.setDataIoStats(dataIoStats_.get());
-  readerOpts.setMetadataIoStats(metadataIoStats_.get());
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   RowReaderOptions rowReaderOpts;
   auto reader = createReader(*sinkPtr, readerOpts);
   ASSERT_EQ(
@@ -1155,8 +1155,8 @@ class E2EEncryptionTest : public E2EWriterTest {
 
     // read it back for compare
     dwio::common::ReaderOptions readerOpts(leafPool_.get());
-    readerOpts.setDataIoStats(dataIoStats_.get());
-    readerOpts.setMetadataIoStats(metadataIoStats_.get());
+    readerOpts.setDataIoStats(dataIoStats_);
+    readerOpts.setMetadataIoStats(metadataIoStats_);
     readerOpts.setDecrypterFactory(decrypterFactory);
     return createReader(*sink_, readerOpts);
   }

--- a/velox/dwio/dwrf/test/ReaderBaseTests.cpp
+++ b/velox/dwio/dwrf/test/ReaderBaseTests.cpp
@@ -113,8 +113,8 @@ class EncryptedStatsTest : public Test {
         footerWrapper.getDwrfPtr(),
         nullptr,
         std::move(handler),
-        dataIoStats_.get(),
-        metadataIoStats_.get());
+        dataIoStats_,
+        metadataIoStats_);
   }
 
   void clearKey(uint32_t groupIdx) {
@@ -186,9 +186,7 @@ TEST_F(EncryptedStatsTest, getColumnStatisticsKeyNotLoaded) {
 
 std::unique_ptr<ReaderBase> createCorruptedFileReader(
     uint64_t footerLen,
-    uint32_t cacheLen,
-    facebook::velox::io::IoStatistics& dataIoStats,
-    facebook::velox::io::IoStatistics& metadataIoStats) {
+    uint32_t cacheLen) {
   auto pool = facebook::velox::memory::memoryManager()->addLeafPool();
   MemorySink sink{1024, {.pool = pool.get()}};
   DataBufferHolder holder{*pool, 1024, 0, DEFAULT_PAGE_GROW_RATIO, &sink};
@@ -223,8 +221,11 @@ std::unique_ptr<ReaderBase> createCorruptedFileReader(
   sink.write(std::move(buf));
   auto readFile = std::make_shared<facebook::velox::InMemoryReadFile>(
       std::string(sink.data(), sink.size()));
-  facebook::velox::dwio::common::ReaderOptions readerOpts{
-      pool.get(), &dataIoStats, &metadataIoStats};
+  facebook::velox::dwio::common::ReaderOptions readerOpts{pool.get()};
+  readerOpts.setDataIoStats(
+      std::make_shared<facebook::velox::io::IoStatistics>());
+  readerOpts.setMetadataIoStats(
+      std::make_shared<facebook::velox::io::IoStatistics>());
   return std::make_unique<ReaderBase>(
       readerOpts, std::make_unique<BufferedInput>(readFile, *pool));
 }
@@ -234,16 +235,13 @@ class ReaderBaseTest : public Test {
   static void SetUpTestCase() {
     MemoryManager::testingSetInstance(MemoryManager::Options{});
   }
-
-  facebook::velox::io::IoStatistics dataIoStats_;
-  facebook::velox::io::IoStatistics metadataIoStats_;
 };
 
 TEST_F(ReaderBaseTest, InvalidPostScriptThrows) {
   VELOX_ASSERT_THROW(
-      createCorruptedFileReader(1'000'000, 0, dataIoStats_, metadataIoStats_),
+      createCorruptedFileReader(1'000'000, 0),
       "Corrupted file, footer size is invalid");
   VELOX_ASSERT_THROW(
-      createCorruptedFileReader(0, 1'000'000, dataIoStats_, metadataIoStats_),
+      createCorruptedFileReader(0, 1'000'000),
       "Corrupted file, cache size is invalid");
 }

--- a/velox/dwio/dwrf/test/ReaderTest.cpp
+++ b/velox/dwio/dwrf/test/ReaderTest.cpp
@@ -129,8 +129,10 @@ class TestReaderP
   std::unique_ptr<folly::Executor> executor_;
 
  protected:
-  io::IoStatistics dataIoStats_;
-  io::IoStatistics metadataIoStats_;
+  std::shared_ptr<io::IoStatistics> dataIoStats_{
+      std::make_shared<io::IoStatistics>()};
+  std::shared_ptr<io::IoStatistics> metadataIoStats_{
+      std::make_shared<io::IoStatistics>()};
 };
 
 class TestReader : public testing::Test, public VectorTestBase {
@@ -151,8 +153,10 @@ class TestReader : public testing::Test, public VectorTestBase {
     return batches;
   }
 
-  io::IoStatistics dataIoStats_;
-  io::IoStatistics metadataIoStats_;
+  std::shared_ptr<io::IoStatistics> dataIoStats_{
+      std::make_shared<io::IoStatistics>()};
+  std::shared_ptr<io::IoStatistics> metadataIoStats_{
+      std::make_shared<io::IoStatistics>()};
 };
 
 TEST_F(TestReader, testWriterVersions) {
@@ -275,13 +279,13 @@ void verifyFlatMapReading(
     const int32_t expectedBatchSize[],
     const int32_t numBatches,
     bool returnFlatVector,
-    io::IoStatistics& dataIoStats,
-    io::IoStatistics& metadataIoStats,
+    const std::shared_ptr<io::IoStatistics>& dataIoStats,
+    const std::shared_ptr<io::IoStatistics>& metadataIoStats,
     const std::vector<uint32_t>& expectedPrefetchRowSizes = {},
     const std::vector<bool>& shouldTryPrefetch = {}) {
   dwio::common::ReaderOptions readerOpts{pool};
-  readerOpts.setDataIoStats(&dataIoStats);
-  readerOpts.setMetadataIoStats(&metadataIoStats);
+  readerOpts.setDataIoStats(dataIoStats);
+  readerOpts.setMetadataIoStats(metadataIoStats);
 
   /* If an extra sanity check is desired you can uncomment the 2 below lines and
    * re-run */
@@ -396,8 +400,10 @@ class TestFlatMapReader : public TestWithParam<bool>, public VectorTestBase {
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
   }
 
-  io::IoStatistics dataIoStats_;
-  io::IoStatistics metadataIoStats_;
+  std::shared_ptr<io::IoStatistics> dataIoStats_{
+      std::make_shared<io::IoStatistics>()};
+  std::shared_ptr<io::IoStatistics> metadataIoStats_{
+      std::make_shared<io::IoStatistics>()};
 };
 
 TEST_P(TestFlatMapReader, testReadFlatMapEmptyMap) {
@@ -405,8 +411,8 @@ TEST_P(TestFlatMapReader, testReadFlatMapEmptyMap) {
   auto returnFlatVector = GetParam();
 
   dwio::common::ReaderOptions readerOpts{pool()};
-  readerOpts.setDataIoStats(&dataIoStats_);
-  readerOpts.setMetadataIoStats(&metadataIoStats_);
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   RowReaderOptions rowReaderOpts;
   rowReaderOpts.setReturnFlatVector(returnFlatVector);
   std::shared_ptr<const RowType> emptyFileType =
@@ -437,8 +443,8 @@ TEST_P(TestFlatMapReader, testStringKeyLifeCycle) {
 
   VectorPtr batch;
   dwio::common::ReaderOptions readerOptions{pool()};
-  readerOptions.setDataIoStats(&dataIoStats_);
-  readerOptions.setMetadataIoStats(&metadataIoStats_);
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
 
   {
     RowReaderOptions rowReaderOptions;
@@ -557,14 +563,16 @@ class TestFlatMapReaderFlatLayout
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
   }
 
-  io::IoStatistics dataIoStats_;
-  io::IoStatistics metadataIoStats_;
+  std::shared_ptr<io::IoStatistics> dataIoStats_{
+      std::make_shared<io::IoStatistics>()};
+  std::shared_ptr<io::IoStatistics> metadataIoStats_{
+      std::make_shared<io::IoStatistics>()};
 };
 
 TEST_P(TestFlatMapReaderFlatLayout, testCompare) {
   dwio::common::ReaderOptions readerOptions{pool()};
-  readerOptions.setDataIoStats(&dataIoStats_);
-  readerOptions.setMetadataIoStats(&metadataIoStats_);
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto reader = DwrfReader::create(
       createFileBufferedInput(getFMSmallFile(), readerOptions.memoryPool()),
       readerOptions);
@@ -598,8 +606,8 @@ TEST_F(TestReader, testReadFlatMapWithKeyFilters) {
   // batch size is set as 1000 in reading
   // file has schema: a int, b struct<a:int, b:float, c:string>, c float
   dwio::common::ReaderOptions readerOpts{pool()};
-  readerOpts.setDataIoStats(&dataIoStats_);
-  readerOpts.setMetadataIoStats(&metadataIoStats_);
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   RowReaderOptions rowReaderOpts;
   // set map key filter for map1 we only need key=1, and map2 only key-1
   auto cs = std::make_shared<ColumnSelector>(
@@ -653,8 +661,8 @@ TEST_F(TestReader, testReadFlatMapWithKeyRejectList) {
   // batch size is set as 1000 in reading
   // file has schema: a int, b struct<a:int, b:float, c:string>, c float
   dwio::common::ReaderOptions readerOpts{pool()};
-  readerOpts.setDataIoStats(&dataIoStats_);
-  readerOpts.setMetadataIoStats(&metadataIoStats_);
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   RowReaderOptions rowReaderOpts;
   auto cs = std::make_shared<ColumnSelector>(
       getFlatmapSchema(), std::vector<std::string>{"map1#[\"!2\",\"!3\"]"});
@@ -710,8 +718,8 @@ TEST_F(TestReader, testStatsCallbackFiredWithFiltering) {
       });
 
   dwio::common::ReaderOptions readerOpts{pool()};
-  readerOpts.setDataIoStats(&dataIoStats_);
-  readerOpts.setMetadataIoStats(&metadataIoStats_);
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
 
   auto reader = DwrfReader::create(
       createFileBufferedInput(getFMSmallFile(), readerOpts.memoryPool()),
@@ -750,8 +758,8 @@ TEST_F(TestReader, testBlockedIoCallbackFiredBlocking) {
   rowReaderOpts.setEagerFirstStripeLoad(false);
 
   dwio::common::ReaderOptions readerOpts{pool()};
-  readerOpts.setDataIoStats(&dataIoStats_);
-  readerOpts.setMetadataIoStats(&metadataIoStats_);
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
 
   auto reader = DwrfReader::create(
       createFileBufferedInput(getFMLargeFile(), readerOpts.memoryPool()),
@@ -796,8 +804,8 @@ TEST_F(TestReader, DISABLED_testBlockedIoCallbackFiredNonBlocking) {
   rowReaderOpts.setEagerFirstStripeLoad(false);
 
   dwio::common::ReaderOptions readerOpts{pool()};
-  readerOpts.setDataIoStats(&dataIoStats_);
-  readerOpts.setMetadataIoStats(&metadataIoStats_);
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
 
   auto reader = DwrfReader::create(
       createFileBufferedInput(getFMLargeFile(), readerOpts.memoryPool()),
@@ -847,8 +855,8 @@ TEST_F(TestReader, DISABLED_testBlockedIoCallbackFiredWithFirstStripeLoad) {
   rowReaderOpts.setEagerFirstStripeLoad(true);
 
   dwio::common::ReaderOptions readerOpts{pool()};
-  readerOpts.setDataIoStats(&dataIoStats_);
-  readerOpts.setMetadataIoStats(&metadataIoStats_);
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
 
   auto reader = DwrfReader::create(
       createFileBufferedInput(getFMLargeFile(), readerOpts.memoryPool()),
@@ -884,8 +892,8 @@ TEST_F(TestReader, DISABLED_testBlockedIoCallbackFiredWithFirstStripeLoad) {
 
 TEST_F(TestReader, testEstimatedSize) {
   dwio::common::ReaderOptions readerOpts{pool()};
-  readerOpts.setDataIoStats(&dataIoStats_);
-  readerOpts.setMetadataIoStats(&metadataIoStats_);
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   {
     auto reader = DwrfReader::create(
         createFileBufferedInput(getFMSmallFile(), readerOpts.memoryPool()),
@@ -914,8 +922,8 @@ TEST_F(TestReader, testEstimatedSize) {
 
 TEST_F(TestReader, testSubfieldEstimatedSize) {
   dwio::common::ReaderOptions readerOpts{pool()};
-  readerOpts.setDataIoStats(&dataIoStats_);
-  readerOpts.setMetadataIoStats(&metadataIoStats_);
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   std::shared_ptr<const RowType> schema =
       std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse("struct<\
               a:int,\
@@ -951,8 +959,8 @@ TEST_F(TestReader, testSubfieldEstimatedSize) {
 
   // estimation with full struct field selection
   dwio::common::ReaderOptions readerOpts2{pool()};
-  readerOpts2.setDataIoStats(&dataIoStats_);
-  readerOpts2.setMetadataIoStats(&metadataIoStats_);
+  readerOpts2.setDataIoStats(dataIoStats_);
+  readerOpts2.setMetadataIoStats(metadataIoStats_);
   auto subfields2 = makeSubfields({"a", "b"});
   folly::F14FastMap<std::string, std::vector<const common::Subfield*>>
       subfields2ByName = groupSubfields(subfields2);
@@ -989,8 +997,8 @@ TEST_F(TestReader, testStatsCallbackFiredWithoutFiltering) {
       });
 
   dwio::common::ReaderOptions readerOpts{pool()};
-  readerOpts.setDataIoStats(&dataIoStats_);
-  readerOpts.setMetadataIoStats(&metadataIoStats_);
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
 
   auto reader = DwrfReader::create(
       createFileBufferedInput(getFMSmallFile(), readerOpts.memoryPool()),
@@ -1074,12 +1082,12 @@ void verifyFlatmapStructEncoding(
     const std::string& filename,
     const std::vector<int32_t>& keysAsFields,
     const std::vector<int32_t>& keysToSelect,
-    io::IoStatistics& dataIoStats,
-    io::IoStatistics& metadataIoStats,
+    const std::shared_ptr<io::IoStatistics>& dataIoStats,
+    const std::shared_ptr<io::IoStatistics>& metadataIoStats,
     size_t batchSize = 1000) {
   dwio::common::ReaderOptions readerOpts{pool};
-  readerOpts.setDataIoStats(&dataIoStats);
-  readerOpts.setMetadataIoStats(&metadataIoStats);
+  readerOpts.setDataIoStats(dataIoStats);
+  readerOpts.setMetadataIoStats(metadataIoStats);
   auto reader = DwrfReader::create(
       createFileBufferedInput(filename, readerOpts.memoryPool()), readerOpts);
 
@@ -1194,8 +1202,8 @@ TEST_F(TestReader, testFlatmapAsStructRequiringKeyList) {
 TEST_F(TestReader, testMismatchSchemaMoreFields) {
   // file has schema: a int, b struct<a:int, b:float, c:string>, c float
   dwio::common::ReaderOptions readerOpts{pool()};
-  readerOpts.setDataIoStats(&dataIoStats_);
-  readerOpts.setMetadataIoStats(&metadataIoStats_);
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   RowReaderOptions rowReaderOpts;
   std::shared_ptr<const RowType> requestedType =
       std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse(
@@ -1242,8 +1250,8 @@ TEST_F(TestReader, testMismatchSchemaMoreFields) {
 TEST_F(TestReader, testMismatchSchemaFewerFields) {
   // file has schema: a int, b struct<a:int, b:float, c:string>, c float
   dwio::common::ReaderOptions readerOpts{pool()};
-  readerOpts.setDataIoStats(&dataIoStats_);
-  readerOpts.setMetadataIoStats(&metadataIoStats_);
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   RowReaderOptions rowReaderOpts;
   std::shared_ptr<const RowType> requestedType =
       std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse(
@@ -1286,8 +1294,8 @@ TEST_F(TestReader, testMismatchSchemaFewerFields) {
 TEST_F(TestReader, testMismatchSchemaNestedMoreFields) {
   // file has schema: a int, b struct<a:int, b:float>, c float
   dwio::common::ReaderOptions readerOpts{pool()};
-  readerOpts.setDataIoStats(&dataIoStats_);
-  readerOpts.setMetadataIoStats(&metadataIoStats_);
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   RowReaderOptions rowReaderOpts;
   std::shared_ptr<const RowType> requestedType =
       std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse(
@@ -1355,8 +1363,8 @@ TEST_F(TestReader, testMismatchSchemaNestedMoreFields) {
 TEST_F(TestReader, testMismatchSchemaNestedFewerFields) {
   // file has schema: a int, b struct<a:int, b:float>, c float
   dwio::common::ReaderOptions readerOpts{pool()};
-  readerOpts.setDataIoStats(&dataIoStats_);
-  readerOpts.setMetadataIoStats(&metadataIoStats_);
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   RowReaderOptions rowReaderOpts;
   std::shared_ptr<const RowType> requestedType =
       std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse(
@@ -1415,8 +1423,8 @@ TEST_F(TestReader, testMismatchSchemaNestedFewerFields) {
 TEST_F(TestReader, testMismatchSchemaIncompatibleNotSelected) {
   // file has schema: a int, b struct<a:int, b:float>, c float
   dwio::common::ReaderOptions readerOpts{pool()};
-  readerOpts.setDataIoStats(&dataIoStats_);
-  readerOpts.setMetadataIoStats(&metadataIoStats_);
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   RowReaderOptions rowReaderOpts;
   std::shared_ptr<const RowType> requestedType =
       std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse(
@@ -1499,8 +1507,8 @@ TEST_F(TestReader, testMismatchSchemaIncompatible) {
 TEST_F(TestReader, fileColumnNamesReadAsLowerCase) {
   // upper.orc holds one columns (Bool_Val: BOOLEAN, b: BIGINT)
   dwio::common::ReaderOptions readerOpts{pool()};
-  readerOpts.setDataIoStats(&dataIoStats_);
-  readerOpts.setMetadataIoStats(&metadataIoStats_);
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   readerOpts.setFileColumnNamesReadAsLowerCase(true);
   auto reader = DwrfReader::create(
       createFileBufferedInput(
@@ -1515,8 +1523,8 @@ TEST_F(TestReader, fileColumnNamesReadAsLowerCaseComplexStruct) {
   // upper_complex.orc holds type
   // Cc:struct<CcLong0:bigint,CcMap1:map<string,struct<CcArray2:array<struct<CcInt3:int>>>>>
   dwio::common::ReaderOptions readerOpts{pool()};
-  readerOpts.setDataIoStats(&dataIoStats_);
-  readerOpts.setMetadataIoStats(&metadataIoStats_);
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   readerOpts.setFileColumnNamesReadAsLowerCase(true);
   auto reader = DwrfReader::create(
       createFileBufferedInput(
@@ -1555,8 +1563,8 @@ TEST_F(TestReader, fileColumnNamesReadAsLowerCaseComplexStruct) {
 
 TEST_F(TestReader, TestStripeSizeCallback) {
   dwio::common::ReaderOptions readerOpts{pool()};
-  readerOpts.setDataIoStats(&dataIoStats_);
-  readerOpts.setMetadataIoStats(&metadataIoStats_);
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   readerOpts.setFilePreloadThreshold(0);
   readerOpts.setFooterSpeculativeIoSize(17);
   RowReaderOptions rowReaderOpts;
@@ -1585,8 +1593,8 @@ TEST_F(TestReader, TestStripeSizeCallback) {
 
 TEST_F(TestReader, TestStripeSizeCallbackLimitsOneStripe) {
   dwio::common::ReaderOptions readerOpts{pool()};
-  readerOpts.setDataIoStats(&dataIoStats_);
-  readerOpts.setMetadataIoStats(&metadataIoStats_);
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   readerOpts.setFilePreloadThreshold(0);
   readerOpts.setFooterSpeculativeIoSize(17);
   RowReaderOptions rowReaderOpts;
@@ -1616,8 +1624,8 @@ TEST_F(TestReader, TestStripeSizeCallbackLimitsOneStripe) {
 
 TEST_F(TestReader, TestStripeSizeCallbackLimitsTwoStripe) {
   dwio::common::ReaderOptions readerOpts{pool()};
-  readerOpts.setDataIoStats(&dataIoStats_);
-  readerOpts.setMetadataIoStats(&metadataIoStats_);
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   readerOpts.setFilePreloadThreshold(0);
   readerOpts.setFooterSpeculativeIoSize(17);
   RowReaderOptions rowReaderOpts;
@@ -1910,8 +1918,8 @@ TEST_F(TestReader, testEmptyFile) {
       std::make_shared<InMemoryReadFile>(std::move(data)), *pool());
 
   dwio::common::ReaderOptions readerOpts{pool()};
-  readerOpts.setDataIoStats(&dataIoStats_);
-  readerOpts.setMetadataIoStats(&metadataIoStats_);
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   RowReaderOptions rowReaderOpts;
 
   auto rowReader = DwrfReader::create(std::move(input), readerOpts)
@@ -1995,8 +2003,8 @@ void testBufferLifeCycle(
     std::mt19937& rng,
     size_t batchSize,
     bool hasNull,
-    io::IoStatistics& dataIoStats,
-    io::IoStatistics& metadataIoStats) {
+    const std::shared_ptr<io::IoStatistics>& dataIoStats,
+    const std::shared_ptr<io::IoStatistics>& metadataIoStats) {
   std::vector<VectorPtr> batches;
   std::function<bool(vector_size_t)> isNullAt = nullptr;
   if (hasNull) {
@@ -2017,8 +2025,8 @@ void testBufferLifeCycle(
       std::make_shared<InMemoryReadFile>(std::move(data)), *pool);
 
   dwio::common::ReaderOptions readerOpts{pool};
-  readerOpts.setDataIoStats(&dataIoStats);
-  readerOpts.setMetadataIoStats(&metadataIoStats);
+  readerOpts.setDataIoStats(dataIoStats);
+  readerOpts.setMetadataIoStats(metadataIoStats);
   RowReaderOptions rowReaderOpts;
   rowReaderOpts.setReturnFlatVector(true);
   auto reader = std::make_unique<DwrfReader>(readerOpts, std::move(input));
@@ -2057,8 +2065,8 @@ void testFlatmapAsMapFieldLifeCycle(
     std::mt19937& rng,
     size_t batchSize,
     bool hasNull,
-    io::IoStatistics& dataIoStats,
-    io::IoStatistics& metadataIoStats) {
+    const std::shared_ptr<io::IoStatistics>& dataIoStats,
+    const std::shared_ptr<io::IoStatistics>& metadataIoStats) {
   std::vector<VectorPtr> batches;
   std::function<bool(vector_size_t)> isNullAt = nullptr;
   if (hasNull) {
@@ -2079,8 +2087,8 @@ void testFlatmapAsMapFieldLifeCycle(
       std::make_shared<InMemoryReadFile>(std::move(data)), *pool);
 
   dwio::common::ReaderOptions readerOpts{pool};
-  readerOpts.setDataIoStats(&dataIoStats);
-  readerOpts.setMetadataIoStats(&metadataIoStats);
+  readerOpts.setDataIoStats(dataIoStats);
+  readerOpts.setMetadataIoStats(metadataIoStats);
   RowReaderOptions rowReaderOpts;
   rowReaderOpts.setReturnFlatVector(true);
   auto reader = std::make_unique<DwrfReader>(readerOpts, std::move(input));
@@ -2293,8 +2301,8 @@ std::pair<std::unique_ptr<dwrf::Writer>, std::unique_ptr<DwrfReader>>
 createWriterReader(
     const std::vector<VectorPtr>& batches,
     memory::MemoryPool* pool,
-    io::IoStatistics& dataIoStats,
-    io::IoStatistics& metadataIoStats,
+    const std::shared_ptr<io::IoStatistics>& dataIoStats,
+    const std::shared_ptr<io::IoStatistics>& metadataIoStats,
     const std::shared_ptr<dwrf::Config>& config =
         std::make_shared<dwrf::Config>(),
     std::function<std::unique_ptr<DWRFFlushPolicy>()> flushPolicy =
@@ -2312,8 +2320,8 @@ createWriterReader(
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<InMemoryReadFile>(std::move(data)), *pool);
   dwio::common::ReaderOptions readerOpts(pool);
-  readerOpts.setDataIoStats(&dataIoStats);
-  readerOpts.setMetadataIoStats(&metadataIoStats);
+  readerOpts.setDataIoStats(dataIoStats);
+  readerOpts.setMetadataIoStats(metadataIoStats);
   readerOpts.setFileFormat(FileFormat::DWRF);
   auto reader = DwrfReader::create(std::move(input), readerOpts);
   return std::make_pair(std::move(writer), std::move(reader));
@@ -2970,8 +2978,8 @@ TEST_F(TestReader, skipLongString) {
       std::make_shared<LocalReadFile>(getExampleFilePath("long_string.dwrf")),
       *pool());
   dwio::common::ReaderOptions readerOpts(pool());
-  readerOpts.setDataIoStats(&dataIoStats_);
-  readerOpts.setMetadataIoStats(&metadataIoStats_);
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   readerOpts.setFileFormat(FileFormat::DWRF);
   auto reader = DwrfReader::create(std::move(input), readerOpts);
   auto spec = std::make_shared<common::ScanSpec>("<root>");
@@ -3151,8 +3159,8 @@ DEBUG_ONLY_TEST_F(TestReader, asyncLoadSurvivesReaderDestruction) {
   // Make sure ReaderOptions and DwrfRowReader are freed after {} scope
   {
     dwio::common::ReaderOptions readerOpts(pool());
-    readerOpts.setDataIoStats(&dataIoStats_);
-    readerOpts.setMetadataIoStats(&metadataIoStats_);
+    readerOpts.setDataIoStats(dataIoStats_);
+    readerOpts.setMetadataIoStats(metadataIoStats_);
     readerOpts.setFileFormat(FileFormat::DWRF);
     auto reader = DwrfReader::create(std::move(input), readerOpts);
 
@@ -3532,7 +3540,7 @@ TEST_F(TestReader, extractionMapKeysIoReduction) {
 
   auto runWithSpec =
       [&](const std::shared_ptr<common::ScanSpec>& scanSpec) -> uint64_t {
-    io::IoStatistics ioStats;
+    auto ioStats = std::make_shared<io::IoStatistics>();
     // Disable coalescing (maxMergeDistance=0) so each stream is read
     // separately and rawBytesRead reflects actual stream-level I/O.
     // Disable file preloading so small files don't bypass per-stream IO.
@@ -3540,10 +3548,12 @@ TEST_F(TestReader, extractionMapKeysIoReduction) {
         std::make_shared<InMemoryReadFile>(fileData),
         *pool(),
         MetricsLog::voidLog(),
-        &ioStats,
+        ioStats.get(),
         /*ioStats=*/nullptr,
         /*maxMergeDistance=*/0);
-    dwio::common::ReaderOptions readerOpts(pool(), &ioStats, &ioStats);
+    dwio::common::ReaderOptions readerOpts(pool());
+    readerOpts.setDataIoStats(ioStats);
+    readerOpts.setMetadataIoStats(ioStats);
     readerOpts.setFileFormat(FileFormat::DWRF);
     readerOpts.setFilePreloadThreshold(0);
     auto rdr = DwrfReader::create(std::move(input), readerOpts);
@@ -3553,7 +3563,7 @@ TEST_F(TestReader, extractionMapKeysIoReduction) {
     auto res = BaseVector::create(schema, 0, pool());
     while (rr->next(kNumRows, res) > 0) {
     }
-    return ioStats.rawBytesRead();
+    return ioStats->rawBytesRead();
   };
 
   auto fullSpec = std::make_shared<common::ScanSpec>("<root>");
@@ -3778,17 +3788,19 @@ TEST_F(TestReader, extractionNestedChainScanSpec) {
 
   auto runLargeWithSpec =
       [&](const std::shared_ptr<common::ScanSpec>& scanSpec) -> uint64_t {
-    io::IoStatistics ioStats;
+    auto ioStats = std::make_shared<io::IoStatistics>();
     // Disable coalescing so each stream is read separately.
     // Disable file preloading so small files don't bypass per-stream IO.
     auto input = std::make_unique<BufferedInput>(
         std::make_shared<InMemoryReadFile>(largeFileData),
         *pool(),
         MetricsLog::voidLog(),
-        &ioStats,
+        ioStats.get(),
         /*ioStats=*/nullptr,
         /*maxMergeDistance=*/0);
-    dwio::common::ReaderOptions readerOpts(pool(), &ioStats, &ioStats);
+    dwio::common::ReaderOptions readerOpts(pool());
+    readerOpts.setDataIoStats(ioStats);
+    readerOpts.setMetadataIoStats(ioStats);
     readerOpts.setFileFormat(FileFormat::DWRF);
     readerOpts.setFilePreloadThreshold(0);
     auto rdr = DwrfReader::create(std::move(input), readerOpts);
@@ -3798,7 +3810,7 @@ TEST_F(TestReader, extractionNestedChainScanSpec) {
     auto res = BaseVector::create(schema, 0, pool());
     while (rr->next(kLargeNumRows, res) > 0) {
     }
-    return ioStats.rawBytesRead();
+    return ioStats->rawBytesRead();
   };
 
   // Full scan: read all columns.

--- a/velox/dwio/dwrf/test/StripeReaderBaseTests.cpp
+++ b/velox/dwio/dwrf/test/StripeReaderBaseTests.cpp
@@ -75,8 +75,8 @@ class StripeLoadKeysTest : public Test {
         footer_.get(),
         nullptr,
         std::move(handler),
-        dataIoStats_.get(),
-        metadataIoStats_.get());
+        dataIoStats_,
+        metadataIoStats_);
 
     stripeReader_ = std::make_unique<StripeReaderBase>(reader_);
   }

--- a/velox/dwio/dwrf/test/StripeStreamTest.cpp
+++ b/velox/dwio/dwrf/test/StripeStreamTest.cpp
@@ -188,8 +188,8 @@ TEST_P(StripeStreamFormatTypeTest, planReads) {
       footer,
       nullptr,
       nullptr,
-      dataIoStats_.get(),
-      metadataIoStats_.get());
+      dataIoStats_,
+      metadataIoStats_);
   ColumnSelector cs{readerBase->schema(), std::vector<uint64_t>{2}, true};
 
   TestDecrypterFactory factory;
@@ -274,8 +274,8 @@ TEST_F(StripeStreamTest, filterSequences) {
       footer,
       nullptr,
       nullptr,
-      dataIoStats_.get(),
-      metadataIoStats_.get());
+      dataIoStats_,
+      metadataIoStats_);
 
   // mock a filter that we only need one node and one sequence
   ColumnSelector cs{readerBase->schema(), std::vector<std::string>{"a#[1]"}};
@@ -345,8 +345,8 @@ TEST_P(StripeStreamFormatTypeTest, zeroLength) {
       footer,
       nullptr,
       nullptr,
-      dataIoStats_.get(),
-      metadataIoStats_.get());
+      dataIoStats_,
+      metadataIoStats_);
 
   TestDecrypterFactory factory;
   auto handler = DecryptionHandler::create(FooterWrapper(footer), &factory);
@@ -482,8 +482,8 @@ TEST_P(StripeStreamFormatTypeTest, planReadsIndex) {
       footer,
       std::move(cache),
       nullptr,
-      dataIoStats_.get(),
-      metadataIoStats_.get());
+      dataIoStats_,
+      metadataIoStats_);
 
   TestDecrypterFactory factory;
   auto handler = DecryptionHandler::create(FooterWrapper(footer), &factory);
@@ -670,8 +670,8 @@ TEST_F(StripeStreamTest, readEncryptedStreams) {
       footer,
       nullptr,
       std::move(handler),
-      dataIoStats_.get(),
-      metadataIoStats_.get());
+      dataIoStats_,
+      metadataIoStats_);
   auto stripeMetadata = std::make_unique<const StripeMetadata>(
       &readerBase->bufferedInput(),
       std::move(stripeFooter),
@@ -756,8 +756,8 @@ TEST_F(StripeStreamTest, schemaMismatch) {
       footer,
       nullptr,
       std::move(handler),
-      dataIoStats_.get(),
-      metadataIoStats_.get());
+      dataIoStats_,
+      metadataIoStats_);
   auto stripeMetadata = std::make_unique<const StripeMetadata>(
       &readerBase->bufferedInput(),
       std::move(stripeFooter),

--- a/velox/dwio/dwrf/test/WriterTest.cpp
+++ b/velox/dwio/dwrf/test/WriterTest.cpp
@@ -63,8 +63,8 @@ class WriterTest : public Test {
     auto readFile = std::make_shared<InMemoryReadFile>(std::move(data));
     auto input = std::make_unique<BufferedInput>(std::move(readFile), *pool_);
     dwio::common::ReaderOptions readerOpts(pool_.get());
-    readerOpts.setDataIoStats(&dataIoStats_);
-    readerOpts.setMetadataIoStats(&metadataIoStats_);
+    readerOpts.setDataIoStats(dataIoStats_);
+    readerOpts.setMetadataIoStats(metadataIoStats_);
     auto reader = std::make_unique<ReaderBase>(readerOpts, std::move(input));
     reader->loadCache();
     return reader;
@@ -94,8 +94,10 @@ class WriterTest : public Test {
   std::shared_ptr<MemoryPool> pool_;
   MemorySink* sinkPtr_;
   std::unique_ptr<WriterBase> writer_;
-  io::IoStatistics dataIoStats_;
-  io::IoStatistics metadataIoStats_;
+  std::shared_ptr<io::IoStatistics> dataIoStats_{
+      std::make_shared<io::IoStatistics>()};
+  std::shared_ptr<io::IoStatistics> metadataIoStats_{
+      std::make_shared<io::IoStatistics>()};
 };
 
 class SupportedCompressionTest

--- a/velox/dwio/dwrf/test/utils/E2EWriterTestUtil.cpp
+++ b/velox/dwio/dwrf/test/utils/E2EWriterTestUtil.cpp
@@ -115,11 +115,11 @@ namespace facebook::velox::dwrf {
       std::string(sinkPtr->data(), sinkPtr->size()));
   auto input = std::make_unique<BufferedInput>(readFile, pool);
 
-  io::IoStatistics dataIoStats;
-  io::IoStatistics metadataIoStats;
+  auto dataIoStats = std::make_shared<io::IoStatistics>();
+  auto metadataIoStats = std::make_shared<io::IoStatistics>();
   dwio::common::ReaderOptions readerOpts(&pool);
-  readerOpts.setDataIoStats(&dataIoStats);
-  readerOpts.setMetadataIoStats(&metadataIoStats);
+  readerOpts.setDataIoStats(dataIoStats);
+  readerOpts.setMetadataIoStats(metadataIoStats);
   RowReaderOptions rowReaderOpts;
   auto reader = std::make_unique<DwrfReader>(readerOpts, std::move(input));
   EXPECT_GE(numStripesUpper, reader->getNumberOfStripes());

--- a/velox/dwio/orc/test/ReaderFilterTest.cpp
+++ b/velox/dwio/orc/test/ReaderFilterTest.cpp
@@ -48,8 +48,10 @@ class OrcReaderFilterTestP
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
   }
 
-  io::IoStatistics dataIoStats_;
-  io::IoStatistics metadataIoStats_;
+  std::shared_ptr<io::IoStatistics> dataIoStats_{
+      std::make_shared<io::IoStatistics>()};
+  std::shared_ptr<io::IoStatistics> metadataIoStats_{
+      std::make_shared<io::IoStatistics>()};
 };
 
 INSTANTIATE_TEST_SUITE_P(
@@ -220,8 +222,9 @@ TEST_P(OrcReaderFilterTestP, tests) {
 
   std::string fileName = "orc_all_type.orc";
 
-  dwio::common::ReaderOptions readerOpts{
-      pool(), &dataIoStats_, &metadataIoStats_};
+  dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
 
   // To make DwrfReader reads ORC file, setFileFormat to FileFormat::ORC
   readerOpts.setFileFormat(dwio::common::FileFormat::ORC);

--- a/velox/dwio/orc/test/ReaderTest.cpp
+++ b/velox/dwio/orc/test/ReaderTest.cpp
@@ -52,8 +52,9 @@ inline std::string getExamplesFilePath(const std::string& fileName) {
 TEST_F(OrcReaderTest, testOrcReaderSimple) {
   const std::string simpleTest(
       getExamplesFilePath("TestStringDictionary.testRowIndex.orc"));
-  dwio::common::ReaderOptions readerOpts{
-      pool(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   // To make DwrfReader reads ORC file, setFileFormat to FileFormat::ORC
   readerOpts.setFileFormat(dwio::common::FileFormat::ORC);
   auto reader = DwrfReader::create(
@@ -90,8 +91,9 @@ TEST_F(OrcReaderTest, testOrcReaderComplexTypes) {
          g:map<string,struct<\
            h:struct<\
              i:array<double>>>>>>"));
-  dwio::common::ReaderOptions readerOpts{
-      pool(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   readerOpts.setFileFormat(dwio::common::FileFormat::ORC);
   auto reader = DwrfReader::create(
       createFileBufferedInput(icebergOrc, readerOpts.memoryPool()), readerOpts);
@@ -110,8 +112,9 @@ TEST_F(OrcReaderTest, testOrcReaderComplexTypes) {
 
 TEST_F(OrcReaderTest, testOrcReaderVarchar) {
   const std::string varcharOrc(getExamplesFilePath("orc_index_int_string.orc"));
-  dwio::common::ReaderOptions readerOpts{
-      pool(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   readerOpts.setFileFormat(dwio::common::FileFormat::ORC);
   auto reader = DwrfReader::create(
       createFileBufferedInput(varcharOrc, readerOpts.memoryPool()), readerOpts);
@@ -142,8 +145,9 @@ TEST_F(OrcReaderTest, testOrcReaderVarchar) {
 TEST_F(OrcReaderTest, testOrcReaderDate) {
   const std::string dateOrc(
       getExamplesFilePath("TestOrcFile.testDate1900.orc"));
-  dwio::common::ReaderOptions readerOpts{
-      pool(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   readerOpts.setFileFormat(dwio::common::FileFormat::ORC);
   auto reader = DwrfReader::create(
       createFileBufferedInput(dateOrc, readerOpts.memoryPool()), readerOpts);
@@ -188,8 +192,9 @@ TEST_F(OrcReaderTest, testOrcReaderDate) {
 // ) with (format = 'ORC');
 TEST_F(OrcReaderTest, testOrcReadAllType) {
   const std::string dateOrc(getExamplesFilePath("orc_all_type.orc"));
-  dwio::common::ReaderOptions readerOpts{
-      pool(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   readerOpts.setFileFormat(dwio::common::FileFormat::ORC);
   auto reader = DwrfReader::create(
       createFileBufferedInput(dateOrc, readerOpts.memoryPool()), readerOpts);
@@ -266,8 +271,9 @@ TEST_F(OrcReaderTest, testOrcRlev2) {
   auto spec = std::make_shared<common::ScanSpec>("<root>");
   spec->addAllChildFields(*schema);
 
-  dwio::common::ReaderOptions readerOpts{
-      pool(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   readerOpts.setScanSpec(spec);
   readerOpts.setFileFormat(dwio::common::FileFormat::ORC);
 
@@ -384,8 +390,9 @@ TEST_P(
     OrcReaderTestP,
     DwrfReader_FetchesOrcMetadata_ExpectCorrectFooterAndMetadata) {
   const std::string dateOrc(getFilename());
-  dwio::common::ReaderOptions readerOpts{
-      pool(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   readerOpts.setFileFormat(dwio::common::FileFormat::ORC);
   auto reader = DwrfReader::create(
       createFileBufferedInput(dateOrc, readerOpts.memoryPool()), readerOpts);
@@ -426,8 +433,9 @@ TEST_P(OrcReaderTestP, DwrfRowReader_ReadAllColumnTypes_ExpectedRowDataRead) {
   scanSpec->addAllChildFields(*schema);
 
   const std::string dateOrc(getFilename());
-  dwio::common::ReaderOptions readerOpts{
-      pool(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOpts{pool()};
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   readerOpts.setFileFormat(dwio::common::FileFormat::ORC);
   readerOpts.setScanSpec(scanSpec);
 

--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -686,8 +686,8 @@ TEST_F(E2EFilterTest, largeMetadata) {
           rowType_, 1000, *leafPool_, nullptr, 0)));
   writeToMemory(rowType_, batches, false);
   dwio::common::ReaderOptions readerOpts(leafPool_.get());
-  readerOpts.setDataIoStats(dataIoStats_.get());
-  readerOpts.setMetadataIoStats(metadataIoStats_.get());
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   readerOpts.setFooterSpeculativeIoSize(1024);
   readerOpts.setFilePreloadThreshold(1024 * 8);
   dwio::common::RowReaderOptions rowReaderOpts;
@@ -821,8 +821,8 @@ TEST_F(E2EFilterTest, combineRowGroup) {
   }
   writeToMemory(rowType_, batches, false);
   dwio::common::ReaderOptions readerOpts(leafPool_.get());
-  readerOpts.setDataIoStats(dataIoStats_.get());
-  readerOpts.setMetadataIoStats(metadataIoStats_.get());
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
   auto reader = makeReader(readerOpts, std::move(input));
@@ -880,8 +880,8 @@ TEST_F(E2EFilterTest, parquetMRVersionStringStatsRowGroupFiltering) {
     writer->close();
 
     dwio::common::ReaderOptions readerOptions(leafPool_.get());
-    readerOptions.setDataIoStats(dataIoStats_.get());
-    readerOptions.setMetadataIoStats(metadataIoStats_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
     auto input = std::make_unique<BufferedInput>(
         std::make_shared<InMemoryReadFile>(
             std::string(sinkPtr->data(), sinkPtr->size())),
@@ -938,8 +938,8 @@ TEST_F(E2EFilterTest, writeDecimalAsInteger) {
        makeFlatVector<int128_t>({1, 2}, DECIMAL(19, 2))});
   writeToMemory(rowVector->type(), {rowVector}, false);
   dwio::common::ReaderOptions readerOpts(leafPool_.get());
-  readerOpts.setDataIoStats(dataIoStats_.get());
-  readerOpts.setMetadataIoStats(metadataIoStats_.get());
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
   auto reader = makeReader(readerOpts, std::move(input));
@@ -965,8 +965,8 @@ TEST_F(E2EFilterTest, configurableWriteSchema) {
 
     writeToMemory(newType, batches, false);
     dwio::common::ReaderOptions readerOpts(leafPool_.get());
-    readerOpts.setDataIoStats(dataIoStats_.get());
-    readerOpts.setMetadataIoStats(metadataIoStats_.get());
+    readerOpts.setDataIoStats(dataIoStats_);
+    readerOpts.setMetadataIoStats(metadataIoStats_);
     auto input = std::make_unique<BufferedInput>(
         std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
     auto reader = makeReader(readerOpts, std::move(input));

--- a/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
@@ -97,8 +97,8 @@ std::unique_ptr<RowReader> ParquetReaderBenchmark::createReader(
     std::shared_ptr<ScanSpec> scanSpec,
     const RowTypePtr& rowType) {
   dwio::common::ReaderOptions readerOpts(leafPool_.get());
-  readerOpts.setDataIoStats(dataIoStats_.get());
-  readerOpts.setMetadataIoStats(metadataIoStats_.get());
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   auto input = std::make_unique<BufferedInput>(
       std::make_shared<LocalReadFile>(fileFolder_->getPath() + "/" + fileName_),
       readerOpts.memoryPool());

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -36,8 +36,8 @@ class ParquetReaderTest : public ParquetTestBase {
     const std::string sample(getExampleFilePath(fileName));
 
     dwio::common::ReaderOptions readerOptions(leafPool_.get());
-    readerOptions.setDataIoStats(dataIoStats_.get());
-    readerOptions.setMetadataIoStats(metadataIoStats_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
     auto reader = createReader(sample, readerOptions);
 
     RowReaderOptions rowReaderOpts;
@@ -64,8 +64,8 @@ class ParquetReaderTest : public ParquetTestBase {
       const RowVectorPtr& expected) {
     const auto filePath(getExampleFilePath(fileName));
     dwio::common::ReaderOptions readerOpts(leafPool_.get());
-    readerOpts.setDataIoStats(dataIoStats_.get());
-    readerOpts.setMetadataIoStats(metadataIoStats_.get());
+    readerOpts.setDataIoStats(dataIoStats_);
+    readerOpts.setMetadataIoStats(metadataIoStats_);
     auto reader = createReader(filePath, readerOpts);
     assertReadWithReaderAndFilters(
         std::move(reader), fileName, fileSchema, std::move(filters), expected);
@@ -81,8 +81,8 @@ TEST_F(ParquetReaderTest, parseSample) {
   const std::string sample(getExampleFilePath("sample.parquet"));
 
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 20ULL);
 
@@ -132,8 +132,8 @@ TEST_F(ParquetReaderTest, parseEmptyNestedList) {
       getExampleFilePath("parse_empty_nested_list.parquet"));
 
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 1000ULL);
 
@@ -192,8 +192,8 @@ TEST_F(ParquetReaderTest, parseUnannotatedList) {
   const std::string sample(getExampleFilePath("unannotated_list.parquet"));
 
   dwio::common::ReaderOptions readerOpts(leafPool_.get());
-  readerOpts.setDataIoStats(dataIoStats_.get());
-  readerOpts.setMetadataIoStats(metadataIoStats_.get());
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   auto reader = createReader(sample, readerOpts);
 
   EXPECT_EQ(reader->numberOfRows(), 22ULL);
@@ -249,8 +249,8 @@ TEST_F(ParquetReaderTest, parseUnannotatedMap) {
   const std::string sample(getExampleFilePath(filename));
 
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto reader = createReader(sample, readerOptions);
 
   auto type = reader->typeWithId();
@@ -290,8 +290,8 @@ TEST_F(ParquetReaderTest, parseLegacyListWithMultipleChildren) {
   const std::string sample(getExampleFilePath(filename));
 
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto reader = createReader(sample, readerOptions);
 
   auto type = reader->typeWithId();
@@ -351,8 +351,8 @@ TEST_F(ParquetReaderTest, parseArrayOfRowHiveReservedKeywords) {
       getExampleFilePath("array_of_row_hive_reserved_keywords.parquet"));
 
   dwio::common::ReaderOptions readerOpts(leafPool_.get());
-  readerOpts.setDataIoStats(dataIoStats_.get());
-  readerOpts.setMetadataIoStats(metadataIoStats_.get());
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   auto reader = createReader(sample, readerOpts);
   EXPECT_EQ(reader->rowType()->toString(), expectedVeloxType);
   EXPECT_EQ(reader->numberOfRows(), 6ULL);
@@ -404,8 +404,8 @@ TEST_F(ParquetReaderTest, parseSampleRange1) {
   const std::string sample(getExampleFilePath("sample.parquet"));
 
   dwio::common::ReaderOptions readerOpts(leafPool_.get());
-  readerOpts.setDataIoStats(dataIoStats_.get());
-  readerOpts.setMetadataIoStats(metadataIoStats_.get());
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   auto reader = createReader(sample, readerOpts);
 
   auto rowReaderOpts = getReaderOpts(sampleSchema());
@@ -425,8 +425,8 @@ TEST_F(ParquetReaderTest, parseSampleRange2) {
   const std::string sample(getExampleFilePath("sample.parquet"));
 
   dwio::common::ReaderOptions readerOpts(leafPool_.get());
-  readerOpts.setDataIoStats(dataIoStats_.get());
-  readerOpts.setMetadataIoStats(metadataIoStats_.get());
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   auto reader = createReader(sample, readerOpts);
 
   auto rowReaderOpts = getReaderOpts(sampleSchema());
@@ -446,8 +446,8 @@ TEST_F(ParquetReaderTest, parseSampleEmptyRange) {
   const std::string sample(getExampleFilePath("sample.parquet"));
 
   dwio::common::ReaderOptions readerOpts(leafPool_.get());
-  readerOpts.setDataIoStats(dataIoStats_.get());
-  readerOpts.setMetadataIoStats(metadataIoStats_.get());
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   auto reader = createReader(sample, readerOpts);
 
   auto rowReaderOpts = getReaderOpts(sampleSchema());
@@ -466,8 +466,8 @@ TEST_F(ParquetReaderTest, parseReadAsLowerCase) {
   const std::string upper(getExampleFilePath("upper.parquet"));
 
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto outputRowType = ROW({"a", "b"}, {BIGINT(), BIGINT()});
   readerOptions.setFileSchema(outputRowType);
   readerOptions.setFileColumnNamesReadAsLowerCase(true);
@@ -504,8 +504,8 @@ TEST_F(ParquetReaderTest, parseRowMapArrayReadAsLowerCase) {
   const std::string upper(getExampleFilePath("upper_complex.parquet"));
 
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileColumnNamesReadAsLowerCase(true);
   auto reader = createReader(upper, readerOptions);
 
@@ -549,8 +549,8 @@ TEST_F(ParquetReaderTest, parseEmpty) {
   const std::string empty(getExampleFilePath("empty.parquet"));
 
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto reader = createReader(empty, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 0ULL);
 
@@ -573,8 +573,8 @@ TEST_F(ParquetReaderTest, parseInt) {
   const std::string sample(getExampleFilePath("int.parquet"));
 
   dwio::common::ReaderOptions readerOpts(leafPool_.get());
-  readerOpts.setDataIoStats(dataIoStats_.get());
-  readerOpts.setMetadataIoStats(metadataIoStats_.get());
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   auto reader = createReader(sample, readerOpts);
 
   EXPECT_EQ(reader->numberOfRows(), 10ULL);
@@ -610,8 +610,8 @@ TEST_F(ParquetReaderTest, parseUnsignedInt1) {
   const std::string sample(getExampleFilePath("uint.parquet"));
 
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto reader = createReader(sample, readerOptions);
 
   EXPECT_EQ(reader->numberOfRows(), 3ULL);
@@ -716,8 +716,8 @@ TEST_F(ParquetReaderTest, parseDate) {
   const std::string sample(getExampleFilePath("date.parquet"));
 
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto reader = createReader(sample, readerOptions);
 
   EXPECT_EQ(reader->numberOfRows(), 25ULL);
@@ -745,8 +745,8 @@ TEST_F(ParquetReaderTest, parseRowMapArray) {
   const std::string sample(getExampleFilePath("row_map_array.parquet"));
 
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto reader = createReader(sample, readerOptions);
 
   EXPECT_EQ(reader->numberOfRows(), 1ULL);
@@ -780,8 +780,8 @@ TEST_F(ParquetReaderTest, projectNoColumns) {
   // This is the case for count(*).
   auto rowType = ROW({}, {});
   dwio::common::ReaderOptions readerOpts(leafPool_.get());
-  readerOpts.setDataIoStats(dataIoStats_.get());
-  readerOpts.setMetadataIoStats(metadataIoStats_.get());
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   auto reader = createReader(getExampleFilePath("sample.parquet"), readerOpts);
   RowReaderOptions rowReaderOpts;
   rowReaderOpts.setScanSpec(makeScanSpec(rowType));
@@ -806,8 +806,8 @@ TEST_F(ParquetReaderTest, parseIntDecimal) {
   //   b: [11.11, 11.11, 22.22, 22.22, 33.33, 33.33]
   auto rowType = ROW({"a", "b"}, {DECIMAL(7, 2), DECIMAL(14, 2)});
   dwio::common::ReaderOptions readerOpts(leafPool_.get());
-  readerOpts.setDataIoStats(dataIoStats_.get());
-  readerOpts.setMetadataIoStats(metadataIoStats_.get());
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   const std::string decimal_dict(getExampleFilePath("decimal_dict.parquet"));
 
   auto reader = createReader(decimal_dict, readerOpts);
@@ -862,8 +862,8 @@ TEST_F(ParquetReaderTest, parseMapKeyValueAsMap) {
   const std::string sample(getExampleFilePath("map_key_value.parquet"));
 
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 1ULL);
 
@@ -912,8 +912,8 @@ TEST_F(ParquetReaderTest, parseRowArrayTest) {
       getExampleFilePath("proto-struct-with-array.parquet"));
 
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 1ULL);
   auto type = reader->typeWithId();
@@ -1199,8 +1199,8 @@ TEST_F(ParquetReaderTest, filterRowGroups) {
   // doesn't have ColumnMetaData, and rowGroups_[0].columns[0].file_offset is 0.
   auto rowType = ROW({"_c0"}, {DECIMAL(9, 1)});
   dwio::common::ReaderOptions readerOpts(leafPool_.get());
-  readerOpts.setDataIoStats(dataIoStats_.get());
-  readerOpts.setMetadataIoStats(metadataIoStats_.get());
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   const std::string decimal_dict(
       getExampleFilePath("decimal_no_ColumnMetadata.parquet"));
 
@@ -1228,8 +1228,8 @@ TEST_F(ParquetReaderTest, shouldIgnoreStatsForParquetMRVersions) {
 TEST_F(ParquetReaderTest, filterRowGroupsWithZeroOffset) {
   auto rowType = ROW({"IDX"}, {INTEGER()});
   dwio::common::ReaderOptions readerOpts(leafPool_.get());
-  readerOpts.setDataIoStats(dataIoStats_.get());
-  readerOpts.setMetadataIoStats(metadataIoStats_.get());
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   const std::string zeroOffsetPath(
       getExampleFilePath("zero_offset_row_group.parquet"));
 
@@ -1246,8 +1246,8 @@ TEST_F(ParquetReaderTest, parseLongTagged) {
   const std::string sample(getExampleFilePath("tagged_long.parquet"));
 
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto reader = createReader(sample, readerOptions);
 
   EXPECT_EQ(reader->numberOfRows(), 4ULL);
@@ -1266,8 +1266,8 @@ TEST_F(ParquetReaderTest, preloadSmallFile) {
   auto input = std::make_unique<BufferedInput>(file, *leafPool_);
 
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto reader =
       std::make_unique<ParquetReader>(std::move(input), readerOptions);
 
@@ -1302,8 +1302,8 @@ TEST_F(ParquetReaderTest, prefetchRowGroups) {
   const int numRowGroups = 4;
 
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   // Disable preload of file.
   readerOptions.setFilePreloadThreshold(0);
 
@@ -1357,8 +1357,8 @@ TEST_F(ParquetReaderTest, testEmptyRowGroups) {
   const std::string sample(getExampleFilePath("empty_row_groups.parquet"));
 
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 5ULL);
 
@@ -1385,8 +1385,8 @@ TEST_F(ParquetReaderTest, testEnumType) {
   const std::string sample(getExampleFilePath("enum_type.parquet"));
 
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 3ULL);
 
@@ -1412,8 +1412,8 @@ TEST_F(ParquetReaderTest, readVarbinaryFromFLBA) {
   const std::string sample(getExampleFilePath(filename));
 
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto reader = createReader(sample, readerOptions);
 
   auto type = reader->typeWithId();
@@ -1445,8 +1445,8 @@ TEST_F(ParquetReaderTest, readBinaryAsStringFromNation) {
   const std::string sample(getExampleFilePath(filename));
 
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto outputRowType =
       ROW({"nationkey", "name", "regionkey", "comment"},
           {BIGINT(), VARCHAR(), BIGINT(), VARCHAR()});
@@ -1478,8 +1478,8 @@ TEST_F(ParquetReaderTest, readComplexType) {
   const std::string sample(getExampleFilePath(filename));
 
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto outputRowType =
       ROW({"a", "b", "c", "d"},
           {ARRAY(VARCHAR()),
@@ -1527,8 +1527,8 @@ TEST_F(ParquetReaderTest, readFixedLenBinaryAsStringFromUuid) {
   const std::string sample(getExampleFilePath(filename));
 
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto outputRowType = ROW({"uuid_field"}, {VARCHAR()});
 
   readerOptions.setFileSchema(outputRowType);
@@ -1557,8 +1557,8 @@ TEST_F(ParquetReaderTest, testV2PageWithZeroMaxDefRep) {
   const std::string sample(getExampleFilePath("v2_page.parquet"));
 
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 5ULL);
 
@@ -1583,8 +1583,8 @@ TEST_F(ParquetReaderTest, readComplexTypeWithV2Page) {
   const std::string sample(getExampleFilePath("complex_type_v2_page.parquet"));
 
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 1ULL);
 
@@ -1625,8 +1625,8 @@ TEST_F(ParquetReaderTest, arrayOfMapOfIntKeyArrayValue) {
   const std::string sample(
       getExampleFilePath("array_of_map_of_int_key_array_value.parquet"));
   facebook::velox::dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->rowType()->toString(), expectedVeloxType);
   auto type = reader->typeWithId();
@@ -1660,8 +1660,8 @@ TEST_F(ParquetReaderTest, arrayOfMapOfIntKeyStructValue) {
   const std::string sample(
       getExampleFilePath("array_of_map_of_int_key_struct_value.parquet"));
   facebook::velox::dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->rowType()->toString(), expectedVeloxType);
   auto type = reader->typeWithId();
@@ -1696,8 +1696,8 @@ TEST_F(ParquetReaderTest, struct_of_array_of_array) {
   const std::string sample(
       getExampleFilePath("struct_of_array_of_array.parquet"));
   facebook::velox::dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto reader = createReader(sample, readerOptions);
   auto type = reader->typeWithId();
   EXPECT_EQ(type->size(), 1ULL);
@@ -1762,8 +1762,8 @@ TEST_F(ParquetReaderTest, testLzoDataPage) {
   const std::string sample(getExampleFilePath("lzo.parquet"));
 
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 23'547ULL);
 
@@ -1799,8 +1799,8 @@ TEST_F(ParquetReaderTest, testEmptyV2DataPage) {
   const std::string sample(getExampleFilePath("empty_v2datapage.parquet"));
 
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 30001ULL);
 
@@ -1833,8 +1833,8 @@ TEST_F(ParquetReaderTest, fileColumnVarcharToMetadataColumnMismatchTest) {
   const std::string sample(getExampleFilePath("nation.parquet"));
 
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
 
   auto runVarcharColTest = [&](const TypePtr& requestedType) {
     // The type in the file is a BYTE_ARRAY resolving to VARCHAR.
@@ -1894,8 +1894,8 @@ TEST_F(ParquetReaderTest, readerWithSchema) {
 
   // Create the reader.
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(schema);
   std::string dataBuf(sinkPtr->data(), sinkPtr->size());
   auto file = std::make_shared<InMemoryReadFile>(std::move(dataBuf));
@@ -1917,8 +1917,8 @@ TEST_F(ParquetReaderTest, columnStatistics) {
 
   auto* sink = write(data);
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto reader = createReaderInMemory(*sink, readerOptions);
   const auto& schema = reader->typeWithId();
 
@@ -1978,8 +1978,8 @@ TEST_F(ParquetReaderTest, columnStatisticsWithNulls) {
 
   auto* sink = write(data);
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto reader = createReaderInMemory(*sink, readerOptions);
   const auto& schema = reader->typeWithId();
 
@@ -2013,8 +2013,8 @@ TEST_F(ParquetReaderTest, columnStatisticsMultipleRowGroups) {
 
   auto* sink = write(data, writerOptions);
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto reader = createReaderInMemory(*sink, readerOptions);
 
   // Verify we have multiple row groups.
@@ -2047,8 +2047,8 @@ TEST_F(ParquetReaderTest, readTimeMillis) {
   auto sink = write(data);
 
   dwio::common::ReaderOptions readerOpts(leafPool_.get());
-  readerOpts.setDataIoStats(dataIoStats_.get());
-  readerOpts.setMetadataIoStats(metadataIoStats_.get());
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   auto reader = createReaderInMemory(*sink, readerOpts);
 
   EXPECT_EQ(reader->numberOfRows(), 6ULL);
@@ -2084,8 +2084,9 @@ TEST_F(ParquetReaderTest, readTimeMicros) {
           TIME_MICRO_UTC())});
   auto sink = write(data);
 
-  const dwio::common::ReaderOptions readerOpts{
-      leafPool_.get(), dataIoStats_.get(), metadataIoStats_.get()};
+  dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   auto reader = createReaderInMemory(*sink, readerOpts);
 
   EXPECT_EQ(reader->numberOfRows(), 7ULL);
@@ -2119,8 +2120,8 @@ TEST_F(ParquetReaderTest, readTimeWithMultipleColumns) {
   auto sink = write(data);
 
   dwio::common::ReaderOptions readerOpts(leafPool_.get());
-  readerOpts.setDataIoStats(dataIoStats_.get());
-  readerOpts.setMetadataIoStats(metadataIoStats_.get());
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
   auto reader = createReaderInMemory(*sink, readerOpts);
 
   EXPECT_EQ(reader->numberOfRows(), 5ULL);

--- a/velox/dwio/parquet/tests/reader/ParquetReaderWideningTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderWideningTest.cpp
@@ -33,8 +33,8 @@ class ParquetReaderWideningTest : public ParquetTestBase {
       bool allowInt32Narrowing = false) {
     auto* sink = write(writeData);
     dwio::common::ReaderOptions readerOptions(leafPool_.get());
-    readerOptions.setDataIoStats(dataIoStats_.get());
-    readerOptions.setMetadataIoStats(metadataIoStats_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
     readerOptions.setFileSchema(readSchema);
     readerOptions.setAllowInt32Narrowing(allowInt32Narrowing);
     auto reader = createReaderInMemory(*sink, readerOptions);
@@ -75,8 +75,8 @@ class ParquetReaderWideningTest : public ParquetTestBase {
       bool allowInt32Narrowing = false) {
     auto* sink = write(writeData);
     dwio::common::ReaderOptions readerOptions(leafPool_.get());
-    readerOptions.setDataIoStats(dataIoStats_.get());
-    readerOptions.setMetadataIoStats(metadataIoStats_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
     readerOptions.setFileSchema(readSchema);
     readerOptions.setAllowInt32Narrowing(allowInt32Narrowing);
     auto reader = createReaderInMemory(*sink, readerOptions);
@@ -99,8 +99,8 @@ class ParquetReaderWideningTest : public ParquetTestBase {
       const std::string& sourceTypeName) {
     auto* sink = write(writeData);
     dwio::common::ReaderOptions readerOptions(leafPool_.get());
-    readerOptions.setDataIoStats(dataIoStats_.get());
-    readerOptions.setMetadataIoStats(metadataIoStats_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
     readerOptions.setFileSchema(readSchema);
     VELOX_ASSERT_THROW(
         createReaderInMemory(*sink, readerOptions),
@@ -234,8 +234,8 @@ void FloatToDoubleEvolutionTest::runFloatToDoubleScenario(
   RowTypePtr readSchema = ROW({"float_col", "id"}, {DOUBLE(), BIGINT()});
 
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(readSchema);
 
   std::string dataBuf(sinkPtr->data(), sinkPtr->size());
@@ -1069,8 +1069,8 @@ TEST_F(ParquetReaderWideningTest, allowInt32Narrowing) {
 
   // Default: flag is false.
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   ASSERT_FALSE(readerOptions.allowInt32Narrowing());
 
   // INT32->TINYINT narrowing rejected by default.

--- a/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -169,8 +169,9 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
 
   void loadDataWithRowType(const std::string& filePath, RowVectorPtr data) {
     auto pool = facebook::velox::memory::memoryManager()->addLeafPool();
-    dwio::common::ReaderOptions readerOpts{
-        pool.get(), dataIoStats_.get(), metadataIoStats_.get()};
+    dwio::common::ReaderOptions readerOpts{pool.get()};
+    readerOpts.setDataIoStats(dataIoStats_);
+    readerOpts.setMetadataIoStats(metadataIoStats_);
     auto reader = std::make_unique<ParquetReader>(
         std::make_unique<facebook::velox::dwio::common::BufferedInput>(
             std::make_shared<LocalReadFile>(filePath), readerOpts.memoryPool()),

--- a/velox/dwio/parquet/tests/writer/ParquetWriterFieldIdTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterFieldIdTest.cpp
@@ -69,8 +69,8 @@ TEST_P(ParquetWriterFieldIdTest, fieldIds) {
   auto* sinkPtr = write(data, writerOptions);
 
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto parquetReader = createReaderInMemory(*sinkPtr, readerOptions);
   EXPECT_EQ(parquetReader->numberOfRows(), kRows);
   auto veloxRowType = parquetReader->rowType();

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -90,8 +90,8 @@ class ParquetWriterTest : public ParquetTestBase {
       MemorySink* sinkPtr,
       int64_t offsetFromDataPage) {
     dwio::common::ReaderOptions readerOptions(leafPool_.get());
-    readerOptions.setDataIoStats(dataIoStats_.get());
-    readerOptions.setMetadataIoStats(metadataIoStats_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
     auto reader = createReaderInMemory(*sinkPtr, readerOptions);
 
     auto colChunkPtr = reader->fileMetaData().rowGroup(0).columnChunk(0);
@@ -412,8 +412,8 @@ TEST_F(ParquetWriterTest, compression) {
   auto* sinkPtr = write(data, writerOptions);
 
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto reader = createReaderInMemory(*sinkPtr, readerOptions);
 
   ASSERT_EQ(reader->numberOfRows(), kRows);
@@ -809,8 +809,8 @@ TEST_F(ParquetWriterTest, allNulls) {
   auto* sinkPtr = write(data);
 
   dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto reader = createReaderInMemory(*sinkPtr, readerOptions);
 
   ASSERT_EQ(reader->numberOfRows(), kRows);

--- a/velox/dwio/parquet/writer/arrow/tests/FileDeserializeTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/FileDeserializeTest.cpp
@@ -975,8 +975,8 @@ class TestParquetFileReader : public ::testing::Test {
     auto dataIoStats = std::make_shared<velox::io::IoStatistics>();
     auto metadataIoStats = std::make_shared<velox::io::IoStatistics>();
     dwio::common::ReaderOptions readerOptions(leafPool.get());
-    readerOptions.setDataIoStats(dataIoStats.get());
-    readerOptions.setMetadataIoStats(metadataIoStats.get());
+    readerOptions.setDataIoStats(dataIoStats);
+    readerOptions.setMetadataIoStats(metadataIoStats);
     auto input = std::make_unique<dwio::common::BufferedInput>(
         std::make_shared<LocalReadFile>(filePath->getPath()),
         readerOptions.memoryPool());
@@ -1035,8 +1035,8 @@ TEST_F(TestParquetFileReader, IncompleteMetadata) {
   auto dataIoStats = std::make_shared<velox::io::IoStatistics>();
   auto metadataIoStats = std::make_shared<velox::io::IoStatistics>();
   dwio::common::ReaderOptions readerOptions(leafPool.get());
-  readerOptions.setDataIoStats(dataIoStats.get());
-  readerOptions.setMetadataIoStats(metadataIoStats.get());
+  readerOptions.setDataIoStats(dataIoStats);
+  readerOptions.setMetadataIoStats(metadataIoStats);
   auto input = std::make_unique<dwio::common::BufferedInput>(
       std::make_shared<LocalReadFile>(filePath->getPath()),
       readerOptions.memoryPool());

--- a/velox/dwio/parquet/writer/arrow/tests/MetadataTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/MetadataTest.cpp
@@ -418,8 +418,8 @@ TEST(Metadata, TestAddKeyValueMetadata) {
   auto dataIoStats = std::make_shared<velox::io::IoStatistics>();
   auto metadataIoStats = std::make_shared<velox::io::IoStatistics>();
   dwio::common::ReaderOptions readerOptions(leafPool.get());
-  readerOptions.setDataIoStats(dataIoStats.get());
-  readerOptions.setMetadataIoStats(metadataIoStats.get());
+  readerOptions.setDataIoStats(dataIoStats);
+  readerOptions.setMetadataIoStats(metadataIoStats);
   auto input = std::make_unique<dwio::common::BufferedInput>(
       std::make_shared<LocalReadFile>(filePath->getPath()),
       readerOptions.memoryPool());
@@ -541,8 +541,8 @@ TEST(Metadata, TestSortingColumns) {
   auto dataIoStats = std::make_shared<velox::io::IoStatistics>();
   auto metadataIoStats = std::make_shared<velox::io::IoStatistics>();
   dwio::common::ReaderOptions readerOptions(leafPool.get());
-  readerOptions.setDataIoStats(dataIoStats.get());
-  readerOptions.setMetadataIoStats(metadataIoStats.get());
+  readerOptions.setDataIoStats(dataIoStats);
+  readerOptions.setMetadataIoStats(metadataIoStats);
   auto input = std::make_unique<dwio::common::BufferedInput>(
       std::make_shared<LocalReadFile>(filePath->getPath()),
       readerOptions.memoryPool());

--- a/velox/dwio/parquet/writer/arrow/tests/StatisticsTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/StatisticsTest.cpp
@@ -489,8 +489,8 @@ class TestStatistics : public PrimitiveTypedTest<TestType> {
     auto dataIoStats = std::make_shared<velox::io::IoStatistics>();
     auto metadataIoStats = std::make_shared<velox::io::IoStatistics>();
     dwio::common::ReaderOptions readerOptions(leafPool.get());
-    readerOptions.setDataIoStats(dataIoStats.get());
-    readerOptions.setMetadataIoStats(metadataIoStats.get());
+    readerOptions.setDataIoStats(dataIoStats);
+    readerOptions.setMetadataIoStats(metadataIoStats);
     auto input = std::make_unique<dwio::common::BufferedInput>(
         std::make_shared<LocalReadFile>(filePath->getPath()),
         readerOptions.memoryPool());
@@ -1038,8 +1038,8 @@ class TestStatisticsSortOrder : public ::testing::Test {
     auto dataIoStats = std::make_shared<velox::io::IoStatistics>();
     auto metadataIoStats = std::make_shared<velox::io::IoStatistics>();
     dwio::common::ReaderOptions readerOptions(leafPool.get());
-    readerOptions.setDataIoStats(dataIoStats.get());
-    readerOptions.setMetadataIoStats(metadataIoStats.get());
+    readerOptions.setDataIoStats(dataIoStats);
+    readerOptions.setMetadataIoStats(metadataIoStats);
     auto input = std::make_unique<dwio::common::BufferedInput>(
         std::make_shared<LocalReadFile>(filePath->getPath()),
         readerOptions.memoryPool());
@@ -1337,8 +1337,8 @@ TEST_F(TestStatisticsSortOrderFLBA, decimalSortOrder) {
   auto dataIoStats = std::make_shared<velox::io::IoStatistics>();
   auto metadataIoStats = std::make_shared<velox::io::IoStatistics>();
   dwio::common::ReaderOptions readerOptions(leafPool.get());
-  readerOptions.setDataIoStats(dataIoStats.get());
-  readerOptions.setMetadataIoStats(metadataIoStats.get());
+  readerOptions.setDataIoStats(dataIoStats);
+  readerOptions.setMetadataIoStats(metadataIoStats);
   auto input = std::make_unique<dwio::common::BufferedInput>(
       std::make_shared<LocalReadFile>(filePath->getPath()),
       readerOptions.memoryPool());

--- a/velox/dwio/text/tests/reader/TextReaderTest.cpp
+++ b/velox/dwio/text/tests/reader/TextReaderTest.cpp
@@ -137,8 +137,8 @@ TEST_F(TextReaderTest, basic) {
   auto readFile = std::make_shared<LocalReadFile>(path);
 
   dwio::common::ReaderOptions readerOptions(pool());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(type);
 
   auto input =
@@ -249,8 +249,8 @@ TEST_F(TextReaderTest, headerAndCustomNullString) {
   auto readFile = std::make_shared<LocalReadFile>(path);
 
   dwio::common::ReaderOptions readerOptions(pool());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(type);
   auto rowReaderOptions = dwio::common::RowReaderOptions();
   setScanSpec(*type, rowReaderOptions);
@@ -425,8 +425,8 @@ TEST_F(TextReaderTest, complexTypesWithCustomDelimiters) {
 
   auto serDeOptions = dwio::common::SerDeOptions('\t', '|', '#', '\\', true);
   dwio::common::ReaderOptions readerOptions(pool());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(type);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -492,8 +492,8 @@ TEST_F(TextReaderTest, projectComplexTypesWithCustomDelimiters) {
 
   auto serDeOptions = dwio::common::SerDeOptions('\t', '|', '#', '\\', true);
   dwio::common::ReaderOptions readerOptions(pool());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(type);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -597,8 +597,8 @@ TEST_F(TextReaderTest, projectPrimitiveTypes) {
       "velox/dwio/text/tests/reader/", "examples/simple_types");
   auto readFile = std::make_shared<LocalReadFile>(path);
   dwio::common::ReaderOptions readerOptions(pool());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(type);
   auto input =
       std::make_unique<dwio::common::BufferedInput>(readFile, poolRef());
@@ -667,8 +667,8 @@ TEST_F(TextReaderTest, projectColumns) {
       "examples/simple_types_compressed_file.gz");
   auto readFile = std::make_shared<LocalReadFile>(path);
   dwio::common::ReaderOptions readerOptions(pool());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(type);
   auto input =
       std::make_unique<dwio::common::BufferedInput>(readFile, poolRef());
@@ -724,8 +724,8 @@ TEST_F(TextReaderTest, projectNone) {
   auto readFile = std::make_shared<LocalReadFile>(path);
 
   dwio::common::ReaderOptions readerOptions(pool());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(type);
 
   dwio::common::RowReaderOptions rowReaderOptions;
@@ -761,8 +761,8 @@ TEST_F(TextReaderTest, compressedProjectNone) {
   auto readFile = std::make_shared<LocalReadFile>(path);
 
   dwio::common::ReaderOptions readerOptions(pool());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(type);
 
   dwio::common::RowReaderOptions rowReaderOptions;
@@ -794,8 +794,8 @@ TEST_F(TextReaderTest, compressedFilter) {
       "examples/simple_types_compressed_file.gz");
   auto readFile = std::make_shared<LocalReadFile>(path);
   dwio::common::ReaderOptions readerOptions(pool());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(type);
   auto input =
       std::make_unique<dwio::common::BufferedInput>(readFile, poolRef());
@@ -840,8 +840,8 @@ TEST_F(TextReaderTest, filter) {
   auto readFile = std::make_shared<LocalReadFile>(path);
 
   dwio::common::ReaderOptions readerOptions(pool());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(type);
 
   auto input =
@@ -900,8 +900,8 @@ TEST_F(TextReaderTest, shrinkBatch) {
       "velox/dwio/text/tests/reader/", "examples/simple_types");
   auto readFile = std::make_shared<LocalReadFile>(path);
   dwio::common::ReaderOptions readerOptions(pool());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(type);
   auto input =
       std::make_unique<dwio::common::BufferedInput>(readFile, poolRef());
@@ -935,8 +935,8 @@ TEST_F(TextReaderTest, compressedShrinkBatch) {
       "examples/simple_types_compressed_file.gz");
   auto readFile = std::make_shared<LocalReadFile>(path);
   dwio::common::ReaderOptions readerOptions(pool());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(type);
   auto input =
       std::make_unique<dwio::common::BufferedInput>(readFile, poolRef());
@@ -967,8 +967,8 @@ TEST_F(TextReaderTest, emptyFile) {
       "velox/dwio/text/tests/reader/", "examples/empty.gz");
   auto readFile = std::make_shared<LocalReadFile>(path);
   dwio::common::ReaderOptions readerOptions(pool());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(type);
   auto rowReaderOptions = dwio::common::RowReaderOptions();
   setScanSpec(*type, rowReaderOptions);
@@ -1016,8 +1016,8 @@ TEST_F(TextReaderTest, readRanges) {
   auto readFile = std::make_shared<LocalReadFile>(path);
 
   dwio::common::ReaderOptions readerOptions(pool());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(type);
 
   auto input =
@@ -1115,8 +1115,8 @@ TEST_F(TextReaderTest, readFloatAsInt) {
   auto readFile = std::make_shared<LocalReadFile>(path);
 
   dwio::common::ReaderOptions readerOptions(pool());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(type);
 
   auto input =
@@ -1216,8 +1216,8 @@ TEST_F(TextReaderTest, simpleTypes) {
   auto readFile = std::make_shared<LocalReadFile>(path);
 
   dwio::common::ReaderOptions readerOptions(pool());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(type);
 
   auto input =
@@ -1278,8 +1278,8 @@ TEST_F(TextReaderTest, primitiveLimitsStressTest) {
   auto readFile = std::make_shared<LocalReadFile>(path);
 
   dwio::common::ReaderOptions readerOptions(pool());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   auto serDeOptions = dwio::common::SerDeOptions('\t', '=', '|', '\\', true);
   readerOptions.setFileSchema(type);
   readerOptions.setSerDeOptions(serDeOptions);
@@ -1438,8 +1438,8 @@ TEST_F(TextReaderTest, DISABLED_nestedComplexTypesWithCustomDelimiters) {
   serDeOptions.separators[3] = ',';
   serDeOptions.separators[4] = ':';
   dwio::common::ReaderOptions readerOptions(pool());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(type);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -1511,8 +1511,8 @@ TEST_F(TextReaderTest, nestedArraysWithCustomDelimiters) {
   // - Comma (',') for inner array element separation (depth 2)
   auto serDeOptions = dwio::common::SerDeOptions('\t', '|', ',', '\\', true);
   dwio::common::ReaderOptions readerOptions(pool());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(type);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -1604,8 +1604,8 @@ TEST_F(TextReaderTest, tripleNestedArraysWithCustomDelimiters) {
   auto serDeOptions = dwio::common::SerDeOptions('\t', '|', ',', '\\', true);
   serDeOptions.separators[3] = '#';
   dwio::common::ReaderOptions readerOptions(pool());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(type);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -1640,8 +1640,8 @@ TEST_F(TextReaderTest, varbinarySuccessfulDecoding) {
   auto readFile = std::make_shared<LocalReadFile>(path);
 
   dwio::common::ReaderOptions readerOptions(pool());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(type);
 
   auto input =
@@ -1677,8 +1677,8 @@ TEST_F(TextReaderTest, varbinaryUnsuccessfulDecoding) {
   auto readFile = std::make_shared<LocalReadFile>(path);
 
   dwio::common::ReaderOptions readerOptions(pool());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(type);
 
   auto input =
@@ -1771,8 +1771,8 @@ TEST_F(TextReaderTest, logicalTypes) {
 
   auto readFile = std::make_shared<LocalReadFile>(path);
   dwio::common::ReaderOptions readerOptions(pool());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(type);
 
   auto input =
@@ -1830,8 +1830,8 @@ TEST_F(TextReaderTest, nestedRows) {
   auto serDeOptions = dwio::common::SerDeOptions('&', ',', '#', '\\', true);
 
   dwio::common::ReaderOptions readerOptions(pool());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(type);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -1911,8 +1911,8 @@ TEST_P(TextReaderDecompressionTest, tests) {
   auto readFile = std::make_shared<LocalReadFile>(path);
 
   dwio::common::ReaderOptions readerOptions(pool());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(type);
 
   auto input =
@@ -1986,8 +1986,8 @@ TEST_F(TextReaderTest, unsupportedCompressedKind) {
   for (const auto& path : paths) {
     auto readFile = std::make_shared<LocalReadFile>(path);
     dwio::common::ReaderOptions readerOptions(pool());
-    readerOptions.setDataIoStats(dataIoStats_.get());
-    readerOptions.setMetadataIoStats(metadataIoStats_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
     readerOptions.setFileSchema(type);
     auto input =
         std::make_unique<dwio::common::BufferedInput>(readFile, poolRef());
@@ -2014,8 +2014,8 @@ TEST_F(TextReaderTest, extractionMapKeys) {
 
   auto serDeOptions = dwio::common::SerDeOptions('\t', '|', '#', '\\', true);
   dwio::common::ReaderOptions readerOptions(pool());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(type);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -2082,8 +2082,8 @@ TEST_F(TextReaderTest, extractionMapValues) {
 
   auto serDeOptions = dwio::common::SerDeOptions('\t', '|', '#', '\\', true);
   dwio::common::ReaderOptions readerOptions(pool());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(type);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -2162,8 +2162,8 @@ TEST_F(TextReaderTest, extractionMapKeyFilter) {
 
   auto readFile = std::make_shared<LocalReadFile>(textFile->getPath());
   dwio::common::ReaderOptions readerOptions(pool());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(type);
 
   auto input =
@@ -2228,8 +2228,8 @@ TEST_F(TextReaderTest, extractionTransformOnMapColumn) {
 
   auto serDeOptions = dwio::common::SerDeOptions('\t', '|', '#', '\\', true);
   dwio::common::ReaderOptions readerOptions(pool());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(type);
   readerOptions.setSerDeOptions(serDeOptions);
 

--- a/velox/dwio/text/tests/writer/TextWriterTest.cpp
+++ b/velox/dwio/text/tests/writer/TextWriterTest.cpp
@@ -233,8 +233,8 @@ TEST_F(TextWriterTest, verifyWriteWithTextReader) {
       dwio::common::getReaderFactory(dwio::common::FileFormat::TEXT);
   auto readFile = std::make_shared<LocalReadFile>(filePath.string());
   dwio::common::ReaderOptions readerOptions(pool());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(schema);
   auto input =
       std::make_unique<dwio::common::BufferedInput>(readFile, poolRef());
@@ -503,8 +503,8 @@ TEST_F(TextWriterTest, verifyMapAndArrayComplexTypesWithTextReader) {
       dwio::common::getReaderFactory(dwio::common::FileFormat::TEXT);
   auto readFile = std::make_shared<LocalReadFile>(filePath.string());
   dwio::common::ReaderOptions readerOptions(pool());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(schema);
   readerOptions.setSerDeOptions(serDeOptions);
   auto input =
@@ -696,8 +696,8 @@ TEST_F(TextWriterTest, verifyArrayTypesWithTextReader) {
       dwio::common::getReaderFactory(dwio::common::FileFormat::TEXT);
   auto readFile = std::make_shared<LocalReadFile>(filePath.string());
   dwio::common::ReaderOptions readerOptions(pool());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(schema);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -936,8 +936,8 @@ TEST_F(TextWriterTest, verifyMapTypesWithTextReader) {
       dwio::common::getReaderFactory(dwio::common::FileFormat::TEXT);
   auto readFile = std::make_shared<LocalReadFile>(filePath.string());
   dwio::common::ReaderOptions readerOptions(pool());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(schema);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -1093,8 +1093,8 @@ TEST_F(TextWriterTest, verifyNestedRowTypesWithTextReader) {
       dwio::common::getReaderFactory(dwio::common::FileFormat::TEXT);
   auto readFile = std::make_shared<LocalReadFile>(filePath.string());
   dwio::common::ReaderOptions readerOptions(pool());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(schema);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -1483,8 +1483,8 @@ TEST_F(
       dwio::common::getReaderFactory(dwio::common::FileFormat::TEXT);
   auto readFile = std::make_shared<LocalReadFile>(filePath.string());
   dwio::common::ReaderOptions readerOptions(pool());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(schema);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -1614,8 +1614,8 @@ TEST_F(TextWriterTest, verifySimpleEscapeCharTestWithTextReader) {
       dwio::common::getReaderFactory(dwio::common::FileFormat::TEXT);
   auto readFile = std::make_shared<LocalReadFile>(filePath.string());
   dwio::common::ReaderOptions readerOptions(pool());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(schema);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -1748,8 +1748,8 @@ TEST_F(TextWriterTest, verifyCustomEscapeCharTestWithTextReader) {
       dwio::common::getReaderFactory(dwio::common::FileFormat::TEXT);
   auto readFile = std::make_shared<LocalReadFile>(filePath.string());
   dwio::common::ReaderOptions readerOptions(pool());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(schema);
   readerOptions.setSerDeOptions(serDeOptions);
 
@@ -1872,8 +1872,8 @@ TEST_F(TextWriterTest, verifyHeaderTestWithTextReader) {
       dwio::common::getReaderFactory(dwio::common::FileFormat::TEXT);
   auto readFile = std::make_shared<LocalReadFile>(filePath.string());
   dwio::common::ReaderOptions readerOptions(pool());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileSchema(schema);
   readerOptions.setSerDeOptions(serDeOptions);
 

--- a/velox/examples/ScanOrc.cpp
+++ b/velox/examples/ScanOrc.cpp
@@ -50,11 +50,11 @@ int main(int argc, char** argv) {
   auto pool = facebook::velox::memory::memoryManager()->addLeafPool();
 
   std::string filePath{argv[1]};
-  io::IoStatistics dataIoStats;
-  io::IoStatistics metadataIoStats;
+  auto dataIoStats = std::make_shared<io::IoStatistics>();
+  auto metadataIoStats = std::make_shared<io::IoStatistics>();
   dwio::common::ReaderOptions readerOpts(pool.get());
-  readerOpts.setDataIoStats(&dataIoStats);
-  readerOpts.setMetadataIoStats(&metadataIoStats);
+  readerOpts.setDataIoStats(dataIoStats);
+  readerOpts.setMetadataIoStats(metadataIoStats);
   // To make DwrfReader reads ORC file, setFileFormat to FileFormat::ORC
   readerOpts.setFileFormat(FileFormat::ORC);
   auto reader = dwio::common::getReaderFactory(FileFormat::ORC)

--- a/velox/exec/benchmarks/RowContainerSortBenchmark.cpp
+++ b/velox/exec/benchmarks/RowContainerSortBenchmark.cpp
@@ -65,11 +65,11 @@ std::vector<std::optional<StringView>> getDataFromFile() {
   const std::string sample(getExampleFilePath("str_sort.parquet"));
   auto rowType = ROW({"query_sig", "result_sig"}, {VARCHAR(), VARCHAR()});
   auto pool = memory::memoryManager()->addLeafPool();
-  velox::io::IoStatistics dataIoStats;
-  velox::io::IoStatistics metadataIoStats;
+  auto dataIoStats = std::make_shared<velox::io::IoStatistics>();
+  auto metadataIoStats = std::make_shared<velox::io::IoStatistics>();
   facebook::velox::dwio::common::ReaderOptions readerOptions(pool.get());
-  readerOptions.setDataIoStats(&dataIoStats);
-  readerOptions.setMetadataIoStats(&metadataIoStats);
+  readerOptions.setDataIoStats(dataIoStats);
+  readerOptions.setMetadataIoStats(metadataIoStats);
   facebook::velox::parquet::ParquetReader reader =
       createReader(sample, readerOptions);
   auto rowReaderOpts = getReaderOpts(rowType);

--- a/velox/exec/fuzzer/CacheFuzzer.cpp
+++ b/velox/exec/fuzzer/CacheFuzzer.cpp
@@ -165,8 +165,10 @@ class CacheFuzzer {
   std::unique_ptr<folly::IOThreadPoolExecutor> executor_;
   std::shared_ptr<AsyncDataCache> cache_;
 
-  io::IoStatistics dataIoStats_;
-  io::IoStatistics metadataIoStats_;
+  std::shared_ptr<io::IoStatistics> dataIoStats_{
+      std::make_shared<io::IoStatistics>()};
+  std::shared_ptr<io::IoStatistics> metadataIoStats_{
+      std::make_shared<io::IoStatistics>()};
 
   // Save the config for the last iteration so they can be potentially reused
   // after restart.
@@ -376,8 +378,8 @@ void CacheFuzzer::initializeCache(bool restartCache) {
 
 void CacheFuzzer::initializeInputs() {
   io::ReaderOptions readOptions(pool_.get());
-  readOptions.setDataIoStats(&dataIoStats_);
-  readOptions.setMetadataIoStats(&metadataIoStats_);
+  readOptions.setDataIoStats(dataIoStats_);
+  readOptions.setMetadataIoStats(metadataIoStats_);
   auto tracker = std::make_shared<ScanTracker>(
       "testTracker", nullptr, 256 << 10 /*256KB*/);
   auto ioStatistics = std::make_shared<IoStatistics>();

--- a/velox/exec/tests/utils/TpchQueryBuilder.cpp
+++ b/velox/exec/tests/utils/TpchQueryBuilder.cpp
@@ -71,8 +71,8 @@ void TpchQueryBuilder::readFileSchema(
     const std::string& filePath,
     const std::vector<std::string>& columns) {
   dwio::common::ReaderOptions readerOptions(pool_.get());
-  readerOptions.setDataIoStats(dataIoStats_.get());
-  readerOptions.setMetadataIoStats(metadataIoStats_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
   readerOptions.setFileFormat(format_);
   auto uniqueReadFile =
       filesystems::getFileSystem(filePath, nullptr)->openFileForRead(filePath);

--- a/velox/python/file/PyFile.cpp
+++ b/velox/python/file/PyFile.cpp
@@ -56,11 +56,11 @@ PyType PyFile::getSchema() {
                         ->openFileForRead(filePath_);
     auto input = std::make_unique<dwio::common::BufferedInput>(
         std::shared_ptr<ReadFile>(std::move(readFile)), *leafPool);
-    io::IoStatistics dataIoStats;
-    io::IoStatistics metadataIoStats;
+    auto dataIoStats = std::make_shared<io::IoStatistics>();
+    auto metadataIoStats = std::make_shared<io::IoStatistics>();
     dwio::common::ReaderOptions readerOptions(leafPool.get());
-    readerOptions.setDataIoStats(&dataIoStats);
-    readerOptions.setMetadataIoStats(&metadataIoStats);
+    readerOptions.setDataIoStats(dataIoStats);
+    readerOptions.setMetadataIoStats(metadataIoStats);
     auto reader = dwio::common::getReaderFactory(fileFormat_)
                       ->createReader(std::move(input), readerOptions);
     fileSchema_ = reader->rowType();


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookincubator/nimble/pull/723

Change `io::ReaderOptions` to hold `std::shared_ptr<IoStatistics>` instead of raw `IoStatistics*` pointers for `dataIoStats_`, `metadataIoStats_`, and `indexIoStats_` members. This simplifies lifetime management at call sites — most callers already owned `shared_ptr<IoStatistics>` and were passing `.get()` to the setters.

Setters now take `std::shared_ptr<IoStatistics>`, getters return `const std::shared_ptr<IoStatistics>&`. The deprecated constructor is updated to match.

Call site changes:
- Callers that already held `shared_ptr` (majority): removed `.get()` calls
- Callers with stack-allocated `IoStatistics`: converted to `make_shared`
- `SplitReader.cpp`: uses non-owning `shared_ptr` with no-op deleter for `PerfMetrics`-owned `FbIoStatistics`
- `MetadataInput` (Nimble): `ioStats_` member changed from raw to `shared_ptr`
- `ReaderBase` (DWRF): constructors and static helper updated

Reviewed By: zacw7

Differential Revision: D105191880
