### PR TITLE
feat: Support dialect-specific type coercion (#17519)

### DIFF
--- a/velox/docs/develop/types.rst
+++ b/velox/docs/develop/types.rst
@@ -337,3 +337,233 @@ key differences are listed below.
   also not orderable, but it is comparable if both key and value types are
   comparable. The implication is that MAP type cannot be used as a join, group
   by or order by key in Spark.
+
+Type Coercion
+~~~~~~~~~~~~~
+Type coercion is the implicit conversion of a value from one type to
+another during query planning. It resolves function overloads and
+special-form result types when arguments don't match a signature exactly.
+
+Coercion is a planning-time concern: by the time a Velox ``Task`` is
+constructed, every implicit conversion is already a materialized ``Cast``
+node in the typed expression tree, and runtime evaluators do not consult
+the coercer.
+
+Coercion rules live in ``TypeCoercer`` (``velox/type/TypeCoercer.h``).
+``TypeCoercer`` is value-typed and immutable after construction. Velox ships
+a default instance (``TypeCoercer::defaults()``) holding a conservative
+built-in rule set used when no dialect coercer is provided. SQL dialects
+ship their own complete instances -- for example,
+``velox::functions::prestosql::typeCoercer()`` for the Presto dialect -- that
+match the dialect's overload-resolution semantics.
+
+``TypeCoercer`` itself is frontend-agnostic: it's a plain value type that
+the resolver APIs (``SignatureBinder``,
+``resolveFunction*WithCoercions``, the special-form ``resolveTypeInt``
+helpers) accept as a defaulted tail parameter so existing callers
+compile unchanged and use ``TypeCoercer::defaults()``. How a coercer
+reaches the resolver APIs is the frontend's choice. Axiom, for example,
+threads the dialect coercer through ``logical_plan::PlanBuilder``'s
+``Context.coercer`` field, which the SQL parser sets when constructing
+the plan builder; other frontends may pass a coercer directly into the
+resolver APIs or wire it through their own planning context.
+
+Customization scope
+^^^^^^^^^^^^^^^^^^^
+
+What a dialect's ``TypeCoercer`` rule set controls:
+
+* **Primitives** (TINYINT, SMALLINT, INTEGER, BIGINT, REAL, DOUBLE, BOOLEAN,
+  VARCHAR, VARBINARY, DATE, TIMESTAMP, UNKNOWN): full control over which
+  source/target pairs are allowed and at what cost. Lower cost is preferred
+  during overload resolution.
+* **DECIMAL**: customizable for source and target separately; DECIMAL ->
+  DECIMAL is not customizable. See the DECIMAL section below.
+* **Container types** (ARRAY, MAP, ROW) and FUNCTION/OPAQUE: not
+  customizable directly. Coercibility is structural -- names and arities
+  must match, and children are recursed element-wise. A dialect controls
+  container behavior only indirectly via element-type rules.
+* **Custom types** (e.g. JSON, TIMESTAMP WITH TIME ZONE, BINGTILE): not
+  customizable through a dialect's ``TypeCoercer`` rule set. Custom-type
+  coercions are registered via ``registerCastRules`` alongside
+  ``registerCustomType`` and live in the global ``CastRulesRegistry``,
+  which is shared across dialects. To keep callers from having to query
+  both registries, ``TypeCoercer::coerceTypeBase`` consults
+  ``CastRulesRegistry`` as a fallback after its own rule lookup -- so
+  custom-type coercions remain reachable through any ``TypeCoercer``
+  instance even though the dialect can't override them.
+
+Cost magnitudes
+^^^^^^^^^^^^^^^
+
+Overload resolution sums per-argument coercion costs
+(``Coercion::overallCost``) to compare candidate signatures. For sums to
+be meaningful, every ``CoercionEntry.cost`` in a single ``TypeCoercer``
+instance must be in the same small magnitude -- today's defaults use
+costs 1-9, one per source-type series. There is no hardcoded surcharge
+added at lookup time: the dialect's rule cost is returned verbatim.
+
+DECIMAL
+^^^^^^^
+
+DECIMAL handling depends on which side is DECIMAL. Rule keys collapse on
+the name ``DECIMAL`` regardless of (p, s) -- one rule per
+``(sourceName, targetName)`` pair on each side.
+
+**Source DECIMAL** (e.g. ``DECIMAL(p, s) -> DOUBLE``). A dialect
+registers one rule per ``(DECIMAL, target)`` where ``target`` is a
+non-DECIMAL type (DECIMAL -> DECIMAL is not customizable; see below).
+The source must be the canonical placeholder ``DECIMAL(1, 0)``; the rule
+fires for any actual ``DECIMAL(p, s)`` source because the source's
+precision/scale is not part of the lookup key. The rule resolves
+directly to the target type at the rule's cost.
+
+**Target DECIMAL** (e.g. ``INTEGER -> DECIMAL(p, s)``). A dialect
+registers one rule per ``(source, DECIMAL)``. The rule's stored target
+is the minimum-width decimal that holds every value of the source
+(e.g. ``INTEGER -> DECIMAL(10, 0)``). At lookup, the type system extends
+the rule's fixed target to the caller's requested ``DECIMAL(p, s)`` via
+``ShortDecimalType::isCoercibleTo`` / ``LongDecimalType::isCoercibleTo``
+(see widening rule below). Returns ``nullopt`` if the caller's target is
+too narrow.
+
+Widening itself contributes 0 to the cost; the rule's stored cost is
+returned verbatim. ``INT -> DECIMAL(10, 0)`` and ``INT -> DECIMAL(38,
+18)`` both cost whatever the rule says (e.g. cost 2 in INTEGER's series).
+This is a simple choice that works for current overload-resolution
+cases; it may need to be revisited if a function is registered with
+multiple concrete DECIMAL-target signatures, since they would all coerce
+at the same cost and produce ambiguous resolution.
+
+**DECIMAL -> DECIMAL** (e.g. ``DECIMAL(10, 2) -> DECIMAL(20, 4)``) is
+**not customizable** by dialects. ``TypeCoercer`` rejects rule entries
+with both source and target DECIMAL at construction time, so attempting
+to register one fails fast. Dialects that need non-standard
+DECIMAL -> DECIMAL semantics must extend the type system, not
+``TypeCoercer``.
+
+At lookup time, ``coerceTypeBase`` short-circuits for any two DECIMALs
+regardless of (p, s) and returns ``Coercion{type: from, cost: 0}``.
+Precision/scale reconciliation is therefore not done by
+``coerceTypeBase`` itself; instead it happens via DECIMAL-specific paths
+in two places:
+
+* ``LongDecimalType::commonSuperType`` inside ``leastCommonSuperType``
+  computes the common ``(p, s)`` for plan-level operations (UNION, CASE
+  result type, etc.).
+* ``SignatureBinder``'s integer-parameter binding handles function
+  signatures of the form ``DECIMAL(P, S)`` by binding ``P`` and ``S`` as
+  integer variables from the actual argument types.
+
+*DECIMAL widening rule.* ``DECIMAL(p1, s1)`` is coercible to
+``DECIMAL(p2, s2)`` iff:
+
+* ``p1 - s1 <= p2 - s2`` -- the target has at least as many integer
+  digits as the source, and
+* ``s1 <= s2`` -- the target has at least as much scale.
+
+Both conditions must hold; otherwise the widening fails. This rule is
+used by Target DECIMAL above (extending a fixed-width target to a wider
+caller-requested DECIMAL) and by ``LongDecimalType::commonSuperType``
+for DECIMAL -> DECIMAL reconciliation.
+
+``coerceTypeBase`` vs ``coercible``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``coerceTypeBase(from, to)`` is a single-rule lookup. It does NOT recurse
+into container children -- ``coerceTypeBase(ARRAY<INT>, ARRAY<BIGINT>)``
+returns ``nullopt`` because no flat rule keys on
+``("ARRAY", "ARRAY")``. ``coercible(from, to)`` is the structural
+predicate: for primitives it delegates to ``coerceTypeBase``; for
+containers it requires matching names and arities, then sums child
+coercion costs.
+
+Default coercion rules
+^^^^^^^^^^^^^^^^^^^^^^
+
+``TypeCoercer::defaults()`` ships the rules below. In this and the
+Presto-specific table that follows, allowed targets are listed in cost
+order (cheapest first), and for DECIMAL targets the listed type is the
+minimum-width decimal that holds every value of the source (lookup
+widens to a wider DECIMAL when compatible -- see the DECIMAL section
+above).
+
+==============   ==========================================================
+Source           Allowed targets (in cost order, cheapest first)
+==============   ==========================================================
+TINYINT          SMALLINT, INTEGER, BIGINT, DECIMAL(3, 0), REAL, DOUBLE
+SMALLINT         INTEGER, BIGINT, DECIMAL(5, 0), REAL, DOUBLE
+INTEGER          BIGINT, DECIMAL(10, 0), REAL, DOUBLE
+BIGINT           DECIMAL(19, 0), DOUBLE
+REAL             DOUBLE
+DECIMAL          REAL, DOUBLE
+DATE             TIMESTAMP
+UNKNOWN          TINYINT, BOOLEAN, SMALLINT, INTEGER, BIGINT, REAL, DOUBLE,
+                 VARCHAR, VARBINARY
+==============   ==========================================================
+
+Notable absences:
+
+* ``BIGINT -> REAL`` is not in the defaults (BIGINT has 64-bit integer
+  precision; REAL holds only ~7 decimal digits). Presto allows it; the
+  Presto dialect coercer adds it (see below).
+* No reverse conversions (e.g. ``DOUBLE -> REAL``, ``BIGINT -> INTEGER``).
+* No string conversions (e.g. ``INTEGER -> VARCHAR``).
+* No conversions between unrelated families (e.g. ``BOOLEAN -> INTEGER``,
+  ``DATE -> BIGINT``).
+
+Presto-specific coercion rules
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``velox::functions::prestosql::typeCoercer()`` (in
+``velox/functions/prestosql/coercion/PrestoCoercions.{h,cpp}``) ships a
+complete rule set independent from ``TypeCoercer::defaults()`` so that
+dialect-specific changes don't silently shift when Velox defaults change.
+Same table conventions as above.
+
+==============   ==========================================================
+Source           Allowed targets (in cost order, cheapest first)
+==============   ==========================================================
+TINYINT          SMALLINT, INTEGER, BIGINT, DECIMAL(3, 0), REAL, DOUBLE
+SMALLINT         INTEGER, BIGINT, DECIMAL(5, 0), REAL, DOUBLE
+INTEGER          BIGINT, DECIMAL(10, 0), REAL, DOUBLE
+BIGINT           DECIMAL(19, 0), REAL, DOUBLE
+REAL             DOUBLE
+DECIMAL          REAL, DOUBLE
+DATE             TIMESTAMP
+UNKNOWN          TINYINT, BOOLEAN, SMALLINT, INTEGER, BIGINT, REAL, DOUBLE,
+                 VARCHAR, VARBINARY
+==============   ==========================================================
+
+Differences from Velox's defaults:
+
+* ``BIGINT -> REAL`` is added. The BIGINT row becomes
+  ``DECIMAL(19, 0), REAL, DOUBLE``, mirroring the INTEGER row's
+  ordering. This makes ``divide(real, bigint)`` resolve to
+  ``divide(real, real)`` via ``BIGINT -> REAL`` (cost 2) instead of
+  ``divide(double, double)`` via ``REAL -> DOUBLE + BIGINT -> DOUBLE``
+  (cost 1 + 3 = 4), matching Presto's overload resolution.
+
+Presto also allows the following implicit coercions:
+
+==============================   ==========================================
+Source                           Target
+==============================   ==========================================
+TIMESTAMP                        TIMESTAMP WITH TIME ZONE
+DATE                             TIMESTAMP WITH TIME ZONE
+TIME                             TIME WITH TIME ZONE
+==============================   ==========================================
+
+These are not part of ``presto::typeCoercer()``'s rule set. From
+Velox's perspective the targets above are *custom* types
+(``TIMESTAMP WITH TIME ZONE``, ``TIME WITH TIME ZONE``) registered via
+``registerCustomType``, so their coercion rules live in the global
+``CastRulesRegistry`` (registered with ``implicitAllowed = true``
+alongside the type) rather than in the dialect's ``TypeCoercer``.
+Lookup still finds them because ``coerceTypeBase`` consults
+``CastRulesRegistry`` as a fallback.
+
+Casts to other Presto types backed by Velox custom types (JSON,
+BINGTILE, IPADDRESS, IPPREFIX, UUID, BIGINT_ENUM, VARCHAR_ENUM,
+P4HYPERLOGLOG) are explicit-only -- see
+:doc:`/functions/presto/conversion`.

--- a/velox/exec/AggregateFunctionRegistry.cpp
+++ b/velox/exec/AggregateFunctionRegistry.cpp
@@ -40,7 +40,7 @@ TypePtr resolveResultType(
     const std::vector<TypePtr>& argTypes) {
   if (auto signatures = getAggregateFunctionSignatures(name)) {
     for (const auto& signature : signatures.value()) {
-      SignatureBinder binder(*signature, argTypes);
+      SignatureBinder binder(*signature, argTypes, TypeCoercer::defaults());
       if (binder.tryBind()) {
         return binder.tryResolveReturnType();
       }
@@ -56,14 +56,15 @@ TypePtr resolveResultType(
 TypePtr resolveResultTypeWithCoercions(
     const std::string& name,
     const std::vector<TypePtr>& argTypes,
-    std::vector<TypePtr>& coercions) {
+    std::vector<TypePtr>& coercions,
+    const TypeCoercer& coercer) {
   coercions.clear();
 
   if (auto signatures = getAggregateFunctionSignatures(name)) {
     std::vector<FunctionSignaturePtr> baseSignatures(
         signatures.value().begin(), signatures.value().end());
     if (auto type = tryResolveReturnTypeWithCoercions(
-            baseSignatures, argTypes, coercions)) {
+            baseSignatures, argTypes, coercions, coercer)) {
       return type;
     }
 
@@ -79,7 +80,7 @@ TypePtr resolveIntermediateType(
     const std::vector<TypePtr>& argTypes) {
   if (auto signatures = getAggregateFunctionSignatures(name)) {
     for (const auto& signature : signatures.value()) {
-      SignatureBinder binder(*signature, argTypes);
+      SignatureBinder binder(*signature, argTypes, TypeCoercer::defaults());
       if (binder.tryBind()) {
         return binder.tryResolveType(signature->intermediateType());
       }

--- a/velox/exec/AggregateFunctionRegistry.h
+++ b/velox/exec/AggregateFunctionRegistry.h
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "velox/type/Type.h"
+#include "velox/type/TypeCoercer.h"
 
 namespace facebook::velox::exec {
 
@@ -44,10 +45,12 @@ TypePtr resolveResultType(
 /// resolve a function successfully. Contains one entry per argument. The entry
 /// is null if no coercion is required for that argument. The entry is not null
 /// if coercion is necessary.
+/// @param coercer Coercion rule set to use when resolving type coercions.
 TypePtr resolveResultTypeWithCoercions(
     const std::string& name,
     const std::vector<TypePtr>& argTypes,
-    std::vector<TypePtr>& coercions);
+    std::vector<TypePtr>& coercions,
+    const TypeCoercer& coercer);
 
 /// Given a name of aggregate function and argument types, returns the
 /// intermediate type if the function exists. Throws if function doesn't exist

--- a/velox/exec/WindowFunction.cpp
+++ b/velox/exec/WindowFunction.cpp
@@ -75,7 +75,7 @@ TypePtr resolveWindowResultType(
 
   if (auto signatures = getWindowFunctionSignatures(sanitizedName)) {
     for (const auto& signature : signatures.value()) {
-      SignatureBinder binder(*signature, argTypes);
+      SignatureBinder binder(*signature, argTypes, TypeCoercer::defaults());
       if (binder.tryBind()) {
         return binder.tryResolveReturnType();
       }
@@ -93,14 +93,15 @@ TypePtr resolveWindowResultType(
 TypePtr resolveWindowResultTypeWithCoercions(
     const std::string& name,
     const std::vector<TypePtr>& argTypes,
-    std::vector<TypePtr>& coercions) {
+    std::vector<TypePtr>& coercions,
+    const TypeCoercer& coercer) {
   coercions.clear();
 
   auto sanitizedName = sanitizeName(name);
 
   if (auto signatures = getWindowFunctionSignatures(sanitizedName)) {
     if (auto type = tryResolveReturnTypeWithCoercions(
-            signatures.value(), argTypes, coercions)) {
+            signatures.value(), argTypes, coercions, coercer)) {
       return type;
     }
 
@@ -131,7 +132,7 @@ std::unique_ptr<WindowFunction> WindowFunction::create(
 
     const auto& signatures = func.value()->signatures;
     for (auto& signature : signatures) {
-      SignatureBinder binder(*signature, argTypes);
+      SignatureBinder binder(*signature, argTypes, TypeCoercer::defaults());
       if (binder.tryBind()) {
         auto type = binder.tryResolveType(signature->returnType());
         VELOX_USER_CHECK(

--- a/velox/exec/WindowFunction.h
+++ b/velox/exec/WindowFunction.h
@@ -18,6 +18,7 @@
 #include "velox/core/QueryConfig.h"
 #include "velox/exec/WindowPartition.h"
 #include "velox/expression/FunctionSignature.h"
+#include "velox/type/TypeCoercer.h"
 #include "velox/vector/BaseVector.h"
 
 namespace facebook::velox::exec {
@@ -191,10 +192,12 @@ TypePtr resolveWindowResultType(
 /// @param coercions A list of optional type coercions applied to resolve the
 /// function. Contains one entry per argument. The entry is null if no coercion
 /// is required for that argument.
+/// @param coercer Coercion rule set to use when resolving type coercions.
 TypePtr resolveWindowResultTypeWithCoercions(
     const std::string& name,
     const std::vector<TypePtr>& argTypes,
-    std::vector<TypePtr>& coercions);
+    std::vector<TypePtr>& coercions,
+    const TypeCoercer& coercer);
 
 struct WindowFunctionEntry {
   std::vector<FunctionSignaturePtr> signatures;

--- a/velox/exec/tests/AggregateFunctionRegistryTest.cpp
+++ b/velox/exec/tests/AggregateFunctionRegistryTest.cpp
@@ -49,8 +49,8 @@ class AggregateFunctionRegistryTest : public testing::Test {
 
     {
       std::vector<TypePtr> coercions;
-      auto finalType =
-          resolveResultTypeWithCoercions(name, argTypes, coercions);
+      auto finalType = resolveResultTypeWithCoercions(
+          name, argTypes, coercions, TypeCoercer::defaults());
       VELOX_EXPECT_EQ_TYPES(finalType, expectedFinalType);
 
       EXPECT_EQ(coercions.size(), argTypes.size());
@@ -70,7 +70,8 @@ class AggregateFunctionRegistryTest : public testing::Test {
         "Aggregate function signature is not supported");
 
     std::vector<TypePtr> coercions;
-    auto finalType = resolveResultTypeWithCoercions(name, argTypes, coercions);
+    auto finalType = resolveResultTypeWithCoercions(
+        name, argTypes, coercions, TypeCoercer::defaults());
     VELOX_EXPECT_EQ_TYPES(finalType, expectedFinalType);
 
     EXPECT_EQ(coercions.size(), argTypes.size());

--- a/velox/exec/tests/WindowFunctionRegistryTest.cpp
+++ b/velox/exec/tests/WindowFunctionRegistryTest.cpp
@@ -64,7 +64,7 @@ class WindowFunctionRegistryTest : public testing::Test {
       const std::vector<TypePtr>& argTypes) {
     if (auto windowFunctionSignatures = getWindowFunctionSignatures(name)) {
       for (const auto& signature : windowFunctionSignatures.value()) {
-        SignatureBinder binder(*signature, argTypes);
+        SignatureBinder binder(*signature, argTypes, TypeCoercer::defaults());
         if (binder.tryBind()) {
           return binder.tryResolveReturnType();
         }
@@ -94,7 +94,8 @@ class WindowFunctionRegistryTest : public testing::Test {
         resolveWindowResultType(name, argTypes), expectedReturnType);
 
     std::vector<TypePtr> coercions;
-    auto type = resolveWindowResultTypeWithCoercions(name, argTypes, coercions);
+    auto type = resolveWindowResultTypeWithCoercions(
+        name, argTypes, coercions, TypeCoercer::defaults());
     VELOX_EXPECT_EQ_TYPES(type, expectedReturnType);
     EXPECT_EQ(coercions, nullTypes(argTypes.size()));
   }
@@ -105,7 +106,8 @@ class WindowFunctionRegistryTest : public testing::Test {
       const TypePtr& expectedReturnType,
       const std::vector<TypePtr>& expectedCoercions) {
     std::vector<TypePtr> coercions;
-    auto type = resolveWindowResultTypeWithCoercions(name, argTypes, coercions);
+    auto type = resolveWindowResultTypeWithCoercions(
+        name, argTypes, coercions, TypeCoercer::defaults());
     VELOX_EXPECT_EQ_TYPES(type, expectedReturnType);
     EXPECT_EQ(coercions.size(), expectedCoercions.size());
     for (auto i = 0; i < coercions.size(); ++i) {
@@ -194,7 +196,10 @@ TEST_F(WindowFunctionRegistryTest, resolveResultTypeErrors) {
     std::vector<TypePtr> coercions;
     VELOX_ASSERT_THROW(
         resolveWindowResultTypeWithCoercions(
-            "nonexistent_func", {BIGINT(), DOUBLE()}, coercions),
+            "nonexistent_func",
+            {BIGINT(), DOUBLE()},
+            coercions,
+            TypeCoercer::defaults()),
         "Window function not registered");
   }
 
@@ -203,7 +208,7 @@ TEST_F(WindowFunctionRegistryTest, resolveResultTypeErrors) {
     std::vector<TypePtr> coercions;
     VELOX_ASSERT_THROW(
         resolveWindowResultTypeWithCoercions(
-            "window_func", {VARCHAR()}, coercions),
+            "window_func", {VARCHAR()}, coercions, TypeCoercer::defaults()),
         "Window function signature is not supported");
   }
 
@@ -213,7 +218,10 @@ TEST_F(WindowFunctionRegistryTest, resolveResultTypeErrors) {
     std::vector<TypePtr> coercions;
     VELOX_ASSERT_THROW(
         resolveWindowResultTypeWithCoercions(
-            "window_func", {VARCHAR(), BIGINT()}, coercions),
+            "window_func",
+            {VARCHAR(), BIGINT()},
+            coercions,
+            TypeCoercer::defaults()),
         "Window function signature is not supported");
   }
 }

--- a/velox/exec/tests/utils/AggregationResolver.cpp
+++ b/velox/exec/tests/utils/AggregationResolver.cpp
@@ -50,7 +50,8 @@ TypePtr resolveAggregateType(
     bool nullOnFailure) {
   if (auto signatures = exec::getAggregateFunctionSignatures(aggregateName)) {
     for (const auto& signature : signatures.value()) {
-      exec::SignatureBinder binder(*signature, rawInputTypes);
+      exec::SignatureBinder binder(
+          *signature, rawInputTypes, TypeCoercer::defaults());
       if (binder.tryBind()) {
         return binder.tryResolveType(
             exec::isPartialOutput(step) ? signature->intermediateType()

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -2206,7 +2206,8 @@ TypePtr resolveWindowType(
     bool nullOnFailure) {
   if (auto signatures = exec::getWindowFunctionSignatures(windowFunctionName)) {
     for (const auto& signature : signatures.value()) {
-      exec::SignatureBinder binder(*signature, inputTypes);
+      exec::SignatureBinder binder(
+          *signature, inputTypes, TypeCoercer::defaults());
       if (binder.tryBind()) {
         return binder.tryResolveType(signature->returnType());
       }

--- a/velox/experimental/cudf/exec/CudfAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfAggregation.cpp
@@ -268,7 +268,7 @@ bool matchTypedCallAgainstSignatures(
   }
   for (const auto& sig : sigs) {
     std::vector<Coercion> coercions(n);
-    exec::SignatureBinder binder(*sig, argTypes);
+    exec::SignatureBinder binder(*sig, argTypes, TypeCoercer::defaults());
     if (!binder.tryBindWithCoercions(coercions)) {
       continue;
     }

--- a/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
@@ -248,7 +248,7 @@ static bool matchCallAgainstSignatures(
     argTypes.push_back(in->type());
   }
   for (const auto& sig : sigs) {
-    exec::SignatureBinder binder(*sig, argTypes);
+    exec::SignatureBinder binder(*sig, argTypes, TypeCoercer::defaults());
     if (!binder.tryBind()) {
       continue;
     }

--- a/velox/expression/CoalesceExpr.cpp
+++ b/velox/expression/CoalesceExpr.cpp
@@ -24,7 +24,8 @@ namespace {
 TypePtr resolveTypeInt(
     const std::vector<TypePtr>& argTypes,
     bool allowedCoercions,
-    std::vector<TypePtr>& coercions) {
+    std::vector<TypePtr>& coercions,
+    const TypeCoercer& coercer) {
   VELOX_CHECK_GT(
       argTypes.size(),
       0,
@@ -44,12 +45,12 @@ TypePtr resolveTypeInt(
       continue;
     }
 
-    if (allowedCoercions && TypeCoercer::coercible(argTypes[i], resultType)) {
+    if (allowedCoercions && coercer.coercible(argTypes[i], resultType)) {
       coercions[i] = resultType;
       continue;
     }
 
-    if (allowedCoercions && TypeCoercer::coercible(resultType, argTypes[i])) {
+    if (allowedCoercions && coercer.coercible(resultType, argTypes[i])) {
       resultType = argTypes[i];
       for (auto j = 0; j < i; j++) {
         coercions[j] = resultType;
@@ -69,7 +70,7 @@ TypePtr resolveTypeInt(
 
 TypePtr resolveTypeInt(const std::vector<TypePtr>& argTypes) {
   std::vector<TypePtr> coercions;
-  return resolveTypeInt(argTypes, false, coercions);
+  return resolveTypeInt(argTypes, false, coercions, TypeCoercer::defaults());
 }
 } // namespace
 
@@ -147,10 +148,11 @@ TypePtr CoalesceCallToSpecialForm::resolveType(
   return resolveTypeInt(argTypes);
 }
 
-TypePtr CoalesceCallToSpecialForm::resolveTypeWithCorsions(
+TypePtr CoalesceCallToSpecialForm::resolveTypeWithCoercions(
     const std::vector<TypePtr>& argTypes,
-    std::vector<TypePtr>& coercions) {
-  return resolveTypeInt(argTypes, true, coercions);
+    std::vector<TypePtr>& coercions,
+    const TypeCoercer& coercer) {
+  return resolveTypeInt(argTypes, true, coercions, coercer);
 }
 
 ExprPtr CoalesceCallToSpecialForm::constructSpecialForm(

--- a/velox/expression/CoalesceExpr.h
+++ b/velox/expression/CoalesceExpr.h
@@ -46,9 +46,10 @@ class CoalesceCallToSpecialForm : public FunctionCallToSpecialForm {
   /// argument types are the same.
   TypePtr resolveType(const std::vector<TypePtr>& argTypes) override;
 
-  TypePtr resolveTypeWithCorsions(
+  TypePtr resolveTypeWithCoercions(
       const std::vector<TypePtr>& argTypes,
-      std::vector<TypePtr>& coercions) override;
+      std::vector<TypePtr>& coercions,
+      const TypeCoercer& coercer) override;
 
   ExprPtr constructSpecialForm(
       const TypePtr& type,

--- a/velox/expression/FunctionCallToSpecialForm.cpp
+++ b/velox/expression/FunctionCallToSpecialForm.cpp
@@ -34,13 +34,14 @@ TypePtr resolveTypeForSpecialForm(
 TypePtr resolveTypeForSpecialFormWithCoercions(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes,
-    std::vector<TypePtr>& coercions) {
+    std::vector<TypePtr>& coercions,
+    const TypeCoercer& coercer) {
   auto specialForm = specialFormRegistry().getSpecialForm(functionName);
   if (specialForm == nullptr) {
     return nullptr;
   }
 
-  return specialForm->resolveTypeWithCorsions(argTypes, coercions);
+  return specialForm->resolveTypeWithCoercions(argTypes, coercions, coercer);
 }
 
 ExprPtr constructSpecialForm(

--- a/velox/expression/FunctionCallToSpecialForm.h
+++ b/velox/expression/FunctionCallToSpecialForm.h
@@ -18,6 +18,7 @@
 
 #include "velox/expression/Expr.h"
 #include "velox/type/Type.h"
+#include "velox/type/TypeCoercer.h"
 
 namespace facebook::velox::exec {
 class FunctionCallToSpecialForm {
@@ -33,9 +34,10 @@ class FunctionCallToSpecialForm {
   /// Like 'resolveType', but with support for applying type conversions if a
   /// special form signature doesn't match 'argTypes' exactly. Support varies
   /// from special form to special form. By default, no coersions are attempted.
-  virtual TypePtr resolveTypeWithCorsions(
+  virtual TypePtr resolveTypeWithCoercions(
       const std::vector<TypePtr>& argTypes,
-      [[maybe_unused]] std::vector<TypePtr>& coercions) {
+      [[maybe_unused]] std::vector<TypePtr>& coercions,
+      [[maybe_unused]] const TypeCoercer& coercer) {
     coercions.clear();
     coercions.resize(argTypes.size());
     return resolveType(argTypes);
@@ -61,7 +63,8 @@ TypePtr resolveTypeForSpecialForm(
 TypePtr resolveTypeForSpecialFormWithCoercions(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes,
-    std::vector<TypePtr>& coercions);
+    std::vector<TypePtr>& coercions,
+    const TypeCoercer& coercer);
 
 /// Returns the SpeicalForm associated with the functionName.  If functionName
 /// is not the name of a known SpecialForm, returns nulltpr.

--- a/velox/expression/ReverseSignatureBinder.h
+++ b/velox/expression/ReverseSignatureBinder.h
@@ -30,7 +30,8 @@ class ReverseSignatureBinder : private SignatureBinderBase {
   ReverseSignatureBinder(
       const exec::FunctionSignature& signature,
       const TypePtr& returnType)
-      : SignatureBinderBase{signature}, returnType_{returnType} {}
+      : SignatureBinderBase{signature, TypeCoercer::defaults()},
+        returnType_{returnType} {}
 
   /// Try bind returnType_ to the return type of the function signature. Return
   /// true if the binding succeeds, or false otherwise.

--- a/velox/expression/SignatureBinder.cpp
+++ b/velox/expression/SignatureBinder.cpp
@@ -189,8 +189,7 @@ bool SignatureBinder::tryBind(
           }
 
           for (auto i = numFormalArgs; i < numActualTypes; i++) {
-            if (auto cost =
-                    TypeCoercer::coercible(actualTypes_[i], firstType)) {
+            if (auto cost = coercer_.coercible(actualTypes_[i], firstType)) {
               if (cost.value() > 0) {
                 coercions[i] = Coercion{firstType, cost.value()};
               }
@@ -288,7 +287,7 @@ std::optional<bool> SignatureBinderBase::checkSetTypeVariable(
     VELOX_CHECK(bindingIt != typeVariablesBindings_.end());
 
     const auto& boundType = bindingIt->second;
-    const auto cost = TypeCoercer::coercible(actualType, boundType);
+    const auto cost = coercer_.coercible(actualType, boundType);
     VELOX_CHECK(cost.has_value());
 
     if (cost.value() > 0) {
@@ -361,7 +360,7 @@ bool SignatureBinder::tryBindVariablesWithCoercion(
     }
 
     if (auto superType =
-            TypeCoercer::leastCommonSuperType(actualType, bindingIt->second)) {
+            coercer_.leastCommonSuperType(actualType, bindingIt->second)) {
       typeVariablesBindings_[baseName] = superType;
       return true;
     }
@@ -412,7 +411,7 @@ bool SignatureBinderBase::tryBind(
   if (!boost::algorithm::iequals(typeName, actualType->name())) {
     if (allowCoercion && typeSignature.parameters().empty()) {
       if (auto availableCoercion =
-              TypeCoercer::coerceTypeBase(actualType, typeName)) {
+              coercer_.coerceTypeBase(actualType, typeName)) {
         coercion = availableCoercion.value();
         return true;
       }
@@ -615,10 +614,11 @@ TypePtr SignatureBinder::tryResolveType(
 TypePtr tryResolveReturnTypeWithCoercions(
     const std::vector<FunctionSignaturePtr>& signatures,
     const std::vector<TypePtr>& argTypes,
-    std::vector<TypePtr>& coercions) {
+    std::vector<TypePtr>& coercions,
+    const TypeCoercer& coercer) {
   std::vector<std::pair<std::vector<Coercion>, TypePtr>> candidates;
   for (const auto& signature : signatures) {
-    SignatureBinder binder(*signature, argTypes);
+    SignatureBinder binder(*signature, argTypes, coercer);
     std::vector<Coercion> requiredCoercions;
     if (binder.tryBindWithCoercions(requiredCoercions)) {
       auto type = binder.tryResolveReturnType();

--- a/velox/expression/SignatureBinder.h
+++ b/velox/expression/SignatureBinder.h
@@ -23,22 +23,24 @@ namespace facebook::velox::exec {
 
 class SignatureBinderBase {
  protected:
-  explicit SignatureBinderBase(const exec::FunctionSignature& signature)
-      : signature_{signature} {}
+  SignatureBinderBase(
+      const exec::FunctionSignature& signature,
+      const TypeCoercer& coercer)
+      : signature_{signature}, coercer_{coercer} {}
 
-  /// Return true if actualType can bind to typeSignature and update bindings_
-  /// accordingly. The number of parameters in typeSignature and actualType
-  /// must match. Return false otherwise.
+  // Return true if actualType can bind to typeSignature and update bindings_
+  // accordingly. The number of parameters in typeSignature and actualType
+  // must match. Return false otherwise.
   bool tryBind(
       const exec::TypeSignature& typeSignature,
       const TypePtr& actualType);
 
-  /// Like 'tryBind', but allows implicit type conversion if actualType
-  /// doesn't match typeSignature exactly.
-  ///
-  /// @param coercion Type coercion necessary to bind actualType to
-  /// typeSignature if there is no exact match. 'coercion.type' is null if
-  /// there is exact match.
+  // Like 'tryBind', but allows implicit type conversion if actualType
+  // doesn't match typeSignature exactly.
+  //
+  // @param coercion Type coercion necessary to bind actualType to
+  // typeSignature if there is no exact match. 'coercion.type' is null if
+  // there is exact match.
   bool tryBindWithCoercion(
       const exec::TypeSignature& typeSignature,
       const TypePtr& actualType,
@@ -49,33 +51,37 @@ class SignatureBinderBase {
     return signature_.variables();
   }
 
-  /// The function signature we are trying to bind.
+  // The function signature we are trying to bind.
   const exec::FunctionSignature& signature_;
 
-  /// Record concrete types that are bound to type variables.
+  // Coercion rules used for implicit type conversion. Defaults to
+  // TypeCoercer::defaults() when no dialect-specific coercer is supplied.
+  const TypeCoercer& coercer_;
+
+  // Record concrete types that are bound to type variables.
   std::unordered_map<std::string, TypePtr> typeVariablesBindings_;
 
-  /// Record concrete values that are bound to integer variables.
+  // Record concrete values that are bound to integer variables.
   std::unordered_map<std::string, int> integerVariablesBindings_;
 
-  /// Record concrete values that are bound to LongEnumParameter variables.
+  // Record concrete values that are bound to LongEnumParameter variables.
   std::unordered_map<std::string, LongEnumParameter> longEnumVariablesBindings_;
 
-  /// Record concrete values that are bound to VarcharEnumParameter variables.
+  // Record concrete values that are bound to VarcharEnumParameter variables.
   std::unordered_map<std::string, VarcharEnumParameter>
       varcharEnumVariablesBindings_;
 
  private:
-  /// If the integer parameter is set, then it must match with value.
-  /// Returns false if values do not match or the parameter does not exist.
+  // If the integer parameter is set, then it must match with value.
+  // Returns false if values do not match or the parameter does not exist.
   bool checkOrSetIntegerParameter(const std::string& parameterName, int value);
 
-  /// Try to bind the LongEnumParameter from the actualType.
+  // Try to bind the LongEnumParameter from the actualType.
   bool checkOrSetLongEnumParameter(
       const std::string& parameterName,
       const LongEnumParameter& params);
 
-  /// Try to bind the VarcharEnumParameter from the actualType.
+  // Try to bind the VarcharEnumParameter from the actualType.
   bool checkOrSetVarcharEnumParameter(
       const std::string& parameterName,
       const VarcharEnumParameter& params);
@@ -86,7 +92,7 @@ class SignatureBinderBase {
       bool allowCoercion,
       Coercion& coercion);
 
-  /// Try to bind the integer parameter from the actualType.
+  // Try to bind the integer parameter from the actualType.
   bool tryBindIntegerParameters(
       const std::vector<exec::TypeSignature>& parameters,
       const TypePtr& actualType);
@@ -108,11 +114,12 @@ class SignatureBinderBase {
 /// corresponding to lambda inputs).
 class SignatureBinder : private SignatureBinderBase {
  public:
-  // Requires that signature and actualTypes are not r-values.
+  /// Requires that signature and actualTypes are not r-values.
   SignatureBinder(
       const exec::FunctionSignature& signature,
-      const std::vector<TypePtr>& actualTypes)
-      : SignatureBinderBase{signature}, actualTypes_{actualTypes} {}
+      const std::vector<TypePtr>& actualTypes,
+      const TypeCoercer& coercer)
+      : SignatureBinderBase{signature, coercer}, actualTypes_{actualTypes} {}
 
   /// Returns true if successfully resolved all generic type names.
   bool tryBind();
@@ -129,8 +136,8 @@ class SignatureBinder : private SignatureBinderBase {
     return tryResolveType(signature_.returnType());
   }
 
-  // Try resolve type for the specified signature. Return nullptr if cannot
-  // resolve.
+  /// Try resolve type for the specified signature. Return nullptr if cannot
+  /// resolve.
   TypePtr tryResolveType(const exec::TypeSignature& typeSignature) {
     return tryResolveType(
         typeSignature,
@@ -141,8 +148,8 @@ class SignatureBinder : private SignatureBinderBase {
         varcharEnumVariablesBindings_);
   }
 
-  // Try resolve types for all specified signatures. Return empty list if some
-  // signatures cannot be resolved.
+  /// Try resolve types for all specified signatures. Return empty list if some
+  /// signatures cannot be resolved.
   std::vector<TypePtr> tryResolveTypes(
       const folly::Range<const TypeSignature*>& typeSignatures) {
     std::vector<TypePtr> types;
@@ -158,8 +165,8 @@ class SignatureBinder : private SignatureBinderBase {
     return types;
   }
 
-  // Given a pre-computed binding for type variables resolve typeSignature if
-  // possible.
+  /// Given a pre-computed binding for type variables resolve typeSignature if
+  /// possible.
   static TypePtr tryResolveType(
       const exec::TypeSignature& typeSignature,
       const std::unordered_map<std::string, SignatureVariable>& variables,
@@ -176,9 +183,9 @@ class SignatureBinder : private SignatureBinderBase {
         dummyEmpty3);
   }
 
-  // Given a pre-computed binding for type variables and integer variables,
-  // resolve typeSignature if possible. integerVariablesBindings might will be
-  // updated with the bound value.
+  /// Given a pre-computed binding for type variables and integer variables,
+  /// resolve typeSignature if possible. integerVariablesBindings might will be
+  /// updated with the bound value.
   static TypePtr tryResolveType(
       const exec::TypeSignature& typeSignature,
       const std::unordered_map<std::string, SignatureVariable>& variables,
@@ -192,12 +199,12 @@ class SignatureBinder : private SignatureBinderBase {
  private:
   bool tryBind(bool allowCoercions, std::vector<Coercion>& coercions);
 
-  /// Pre-binds type variables to their least common super type across all
-  /// arguments. Runs before the main binding loop. Only binds type variables,
-  /// not integer variables (e.g. decimal precision/scale) — those are bound
-  /// later by tryBind. Does not check base type name match since coercion may
-  /// change the base type. Returns false if a type variable conflict is found
-  /// that would prevent binding; true otherwise.
+  // Pre-binds type variables to their least common super type across all
+  // arguments. Runs before the main binding loop. Only binds type variables,
+  // not integer variables (e.g. decimal precision/scale) -- those are bound
+  // later by tryBind. Does not check base type name match since coercion may
+  // change the base type. Returns false if a type variable conflict is found
+  // that would prevent binding; true otherwise.
   bool tryBindVariablesWithCoercion(
       const exec::TypeSignature& typeSignature,
       const TypePtr& actualType);
@@ -213,6 +220,7 @@ class SignatureBinder : private SignatureBinderBase {
 TypePtr tryResolveReturnTypeWithCoercions(
     const std::vector<FunctionSignaturePtr>& signatures,
     const std::vector<TypePtr>& argTypes,
-    std::vector<TypePtr>& coercions);
+    std::vector<TypePtr>& coercions,
+    const TypeCoercer& coercer);
 
 } // namespace facebook::velox::exec

--- a/velox/expression/SimpleFunctionRegistry.cpp
+++ b/velox/expression/SimpleFunctionRegistry.cpp
@@ -176,7 +176,8 @@ SimpleFunctionRegistry::resolveFunction(
     const std::string& name,
     const std::vector<TypePtr>& argTypes,
     bool allowCoercion,
-    std::vector<TypePtr>& coercions) const {
+    std::vector<TypePtr>& coercions,
+    const TypeCoercer& coercer) const {
   using Candidate = std::pair<const FunctionEntry*, TypePtr>;
 
   std::optional<Candidate> selectedCandidate;
@@ -186,7 +187,7 @@ SimpleFunctionRegistry::resolveFunction(
       std::optional<uint32_t> priority;
 
       for (const auto& [candidateSignature, functionEntry] : *signatureMap) {
-        SignatureBinder binder(candidateSignature, argTypes);
+        SignatureBinder binder(candidateSignature, argTypes, coercer);
 
         std::vector<Coercion> requiredCoercions;
 

--- a/velox/expression/SimpleFunctionRegistry.h
+++ b/velox/expression/SimpleFunctionRegistry.h
@@ -159,14 +159,16 @@ class SimpleFunctionRegistry {
       const std::string& name,
       const std::vector<TypePtr>& argTypes) const {
     std::vector<TypePtr> coercions;
-    return resolveFunction(name, argTypes, false, coercions);
+    return resolveFunction(
+        name, argTypes, false, coercions, TypeCoercer::defaults());
   }
 
   std::optional<ResolvedSimpleFunction> resolveFunctionWithCoercions(
       const std::string& name,
       const std::vector<TypePtr>& argTypes,
-      std::vector<TypePtr>& coercions) const {
-    return resolveFunction(name, argTypes, true, coercions);
+      std::vector<TypePtr>& coercions,
+      const TypeCoercer& coercer) const {
+    return resolveFunction(name, argTypes, true, coercions, coercer);
   }
 
  private:
@@ -174,7 +176,8 @@ class SimpleFunctionRegistry {
       const std::string& name,
       const std::vector<TypePtr>& argTypes,
       bool allowCoercion,
-      std::vector<TypePtr>& coercions) const;
+      std::vector<TypePtr>& coercions,
+      const TypeCoercer& coercer) const;
 
   /// Registers a function with the given name and metadata. If an entry with
   /// the name already exists and 'overwrite' is true, the existing entry is

--- a/velox/expression/SwitchExpr.cpp
+++ b/velox/expression/SwitchExpr.cpp
@@ -29,11 +29,12 @@ bool hasElseClause(const std::vector<ExprPtr>& inputs) {
 TypePtr resolveTypeInt(
     const std::vector<TypePtr>& argTypes,
     bool allowedCoercions,
-    std::vector<TypePtr>& coercions);
+    std::vector<TypePtr>& coercions,
+    const TypeCoercer& coercer);
 
 TypePtr resolveTypeInt(const std::vector<TypePtr>& argTypes) {
   std::vector<TypePtr> coercions;
-  return resolveTypeInt(argTypes, false, coercions);
+  return resolveTypeInt(argTypes, false, coercions, TypeCoercer::defaults());
 };
 } // namespace
 
@@ -233,7 +234,8 @@ namespace {
 TypePtr resolveTypeInt(
     const std::vector<TypePtr>& argTypes,
     bool allowedCoercions,
-    std::vector<TypePtr>& coercions) {
+    std::vector<TypePtr>& coercions,
+    const TypeCoercer& coercer) {
   VELOX_CHECK_GT(
       argTypes.size(),
       1,
@@ -266,10 +268,9 @@ TypePtr resolveTypeInt(
         "Condition of  SWITCH statement is not bool");
 
     if (*thenType != *resultType) {
-      if (allowedCoercions && TypeCoercer::coercible(thenType, resultType)) {
+      if (allowedCoercions && coercer.coercible(thenType, resultType)) {
         coercions[i * 2 + 1] = resultType;
-      } else if (
-          allowedCoercions && TypeCoercer::coercible(resultType, thenType)) {
+      } else if (allowedCoercions && coercer.coercible(resultType, thenType)) {
         resultType = thenType;
         setCoercionsUpTo(i * 2 - 1, resultType);
       } else {
@@ -287,10 +288,9 @@ TypePtr resolveTypeInt(
     const auto& elseType = argTypes.back();
 
     if (*elseType != *resultType) {
-      if (allowedCoercions && TypeCoercer::coercible(elseType, resultType)) {
+      if (allowedCoercions && coercer.coercible(elseType, resultType)) {
         coercions.back() = resultType;
-      } else if (
-          allowedCoercions && TypeCoercer::coercible(resultType, elseType)) {
+      } else if (allowedCoercions && coercer.coercible(resultType, elseType)) {
         resultType = elseType;
         setCoercionsUpTo(numArgs - 2, resultType);
       } else {
@@ -312,10 +312,11 @@ TypePtr SwitchCallToSpecialForm::resolveType(
   return resolveTypeInt(argTypes);
 }
 
-TypePtr SwitchCallToSpecialForm::resolveTypeWithCorsions(
+TypePtr SwitchCallToSpecialForm::resolveTypeWithCoercions(
     const std::vector<TypePtr>& argTypes,
-    std::vector<TypePtr>& coercions) {
-  return resolveTypeInt(argTypes, true, coercions);
+    std::vector<TypePtr>& coercions,
+    const TypeCoercer& coercer) {
+  return resolveTypeInt(argTypes, true, coercions, coercer);
 }
 
 ExprPtr SwitchCallToSpecialForm::constructSpecialForm(
@@ -337,14 +338,15 @@ TypePtr IfCallToSpecialForm::resolveType(const std::vector<TypePtr>& argTypes) {
   return resolveTypeInt(argTypes);
 }
 
-TypePtr IfCallToSpecialForm::resolveTypeWithCorsions(
+TypePtr IfCallToSpecialForm::resolveTypeWithCoercions(
     const std::vector<TypePtr>& argTypes,
-    std::vector<TypePtr>& coercions) {
+    std::vector<TypePtr>& coercions,
+    const TypeCoercer& coercer) {
   VELOX_CHECK_EQ(
       argTypes.size(),
       3,
       "An IF statement must have 3 clauses: 'if', 'then', and 'else'.");
 
-  return resolveTypeInt(argTypes, true, coercions);
+  return resolveTypeInt(argTypes, true, coercions, coercer);
 }
 } // namespace facebook::velox::exec

--- a/velox/expression/SwitchExpr.h
+++ b/velox/expression/SwitchExpr.h
@@ -73,9 +73,10 @@ class SwitchCallToSpecialForm : public FunctionCallToSpecialForm {
   TypePtr resolveType(const std::vector<TypePtr>& argTypes) override;
 
   /// Supports coercions for odd arguments (then and else branches).
-  TypePtr resolveTypeWithCorsions(
+  TypePtr resolveTypeWithCoercions(
       const std::vector<TypePtr>& argTypes,
-      std::vector<TypePtr>& coercions) override;
+      std::vector<TypePtr>& coercions,
+      const TypeCoercer& coercer) override;
 
   ExprPtr constructSpecialForm(
       const TypePtr& type,
@@ -92,9 +93,10 @@ class IfCallToSpecialForm : public SwitchCallToSpecialForm {
   TypePtr resolveType(const std::vector<TypePtr>& argTypes) override;
 
   /// Supports coercions for 2nd and 3rd arguments (then and else branches).
-  TypePtr resolveTypeWithCorsions(
+  TypePtr resolveTypeWithCoercions(
       const std::vector<TypePtr>& argTypes,
-      std::vector<TypePtr>& coercions) override;
+      std::vector<TypePtr>& coercions,
+      const TypeCoercer& coercer) override;
 };
 
 } // namespace facebook::velox::exec

--- a/velox/expression/VectorFunction.cpp
+++ b/velox/expression/VectorFunction.cpp
@@ -101,9 +101,10 @@ bool hasCoercion(const std::vector<Coercion>& coercions) {
 TypePtr resolveVectorFunctionWithCoercions(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes,
-    std::vector<TypePtr>& coercions) {
+    std::vector<TypePtr>& coercions,
+    const TypeCoercer& coercer) {
   if (auto result = resolveVectorFunctionWithMetadataWithCoercions(
-          functionName, argTypes, coercions)) {
+          functionName, argTypes, coercions, coercer)) {
     return result->first;
   }
 
@@ -119,7 +120,8 @@ resolveVectorFunctionWithMetadata(
       [&](const auto& /*name*/, const auto& entry)
           -> std::optional<std::pair<TypePtr, VectorFunctionMetadata>> {
         for (const auto& signature : entry.signatures) {
-          exec::SignatureBinder binder(*signature, argTypes);
+          exec::SignatureBinder binder(
+              *signature, argTypes, TypeCoercer::defaults());
           if (binder.tryBind()) {
             return {{binder.tryResolveReturnType(), entry.metadata}};
           }
@@ -132,7 +134,8 @@ std::optional<std::pair<TypePtr, VectorFunctionMetadata>>
 resolveVectorFunctionWithMetadataWithCoercions(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes,
-    std::vector<TypePtr>& coercions) {
+    std::vector<TypePtr>& coercions,
+    const TypeCoercer& coercer) {
   coercions.clear();
 
   return applyToVectorFunctionEntry<std::pair<TypePtr, VectorFunctionMetadata>>(
@@ -141,7 +144,7 @@ resolveVectorFunctionWithMetadataWithCoercions(
           -> std::optional<std::pair<TypePtr, VectorFunctionMetadata>> {
         std::vector<std::pair<std::vector<Coercion>, TypePtr>> candidates;
         for (const auto& signature : entry.signatures) {
-          exec::SignatureBinder binder(*signature, argTypes);
+          exec::SignatureBinder binder(*signature, argTypes, coercer);
           std::vector<Coercion> requiredCoercions;
           if (binder.tryBindWithCoercions(requiredCoercions)) {
             auto type = binder.tryResolveReturnType();
@@ -200,7 +203,8 @@ getVectorFunctionWithMetadata(
               std::shared_ptr<VectorFunction>,
               VectorFunctionMetadata>> {
         for (const auto& signature : entry.signatures) {
-          exec::SignatureBinder binder(*signature, inputTypes);
+          exec::SignatureBinder binder(
+              *signature, inputTypes, TypeCoercer::defaults());
           if (binder.tryBind()) {
             auto inputArgs = toVectorFunctionArgs(inputTypes, constantInputs);
 

--- a/velox/expression/VectorFunction.h
+++ b/velox/expression/VectorFunction.h
@@ -22,6 +22,7 @@
 #include "velox/expression/EvalCtx.h"
 #include "velox/expression/FunctionMetadata.h"
 #include "velox/expression/FunctionSignature.h"
+#include "velox/type/TypeCoercer.h"
 #include "velox/vector/SelectivityVector.h"
 #include "velox/vector/SimpleVector.h"
 
@@ -192,7 +193,8 @@ TypePtr resolveVectorFunction(
 TypePtr resolveVectorFunctionWithCoercions(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes,
-    std::vector<TypePtr>& coercions);
+    std::vector<TypePtr>& coercions,
+    const TypeCoercer& coercer);
 
 std::optional<std::pair<TypePtr, VectorFunctionMetadata>>
 resolveVectorFunctionWithMetadata(
@@ -210,7 +212,8 @@ std::optional<std::pair<TypePtr, VectorFunctionMetadata>>
 resolveVectorFunctionWithMetadataWithCoercions(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes,
-    std::vector<TypePtr>& coercions);
+    std::vector<TypePtr>& coercions,
+    const TypeCoercer& coercer);
 
 /// Returns an instance of VectorFunction for the given name, input types and
 /// optionally constant input values.

--- a/velox/expression/fuzzer/ExpressionFuzzer.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzer.cpp
@@ -46,7 +46,7 @@ class FullSignatureBinder : public SignatureBinderBase {
       const exec::FunctionSignature& signature,
       const std::vector<TypePtr>& argTypes,
       const TypePtr& returnType)
-      : SignatureBinderBase(signature) {
+      : SignatureBinderBase(signature, TypeCoercer::defaults()) {
     if (signature_.argumentTypes().size() != argTypes.size()) {
       return;
     }

--- a/velox/expression/fuzzer/tests/ArgTypesGeneratorTestUtils.cpp
+++ b/velox/expression/fuzzer/tests/ArgTypesGeneratorTestUtils.cpp
@@ -28,7 +28,7 @@ void assertReturnType(
   const auto argTypes = generator->generateArgs(signature, returnType, seed);
 
   // Resolve return type from argument types for the given signature.
-  exec::SignatureBinder binder(signature, argTypes);
+  exec::SignatureBinder binder(signature, argTypes, TypeCoercer::defaults());
   VELOX_CHECK(
       binder.tryBind(),
       "Failed to resolve {} from argument types.",

--- a/velox/expression/tests/SignatureBinderTest.cpp
+++ b/velox/expression/tests/SignatureBinderTest.cpp
@@ -62,11 +62,13 @@ void testSignatureBinder(
   SCOPED_TRACE(fmt::format("Actual types: {}", toString(actualTypes)));
 
   {
-    exec::SignatureBinder binder(*signature, actualTypes);
+    exec::SignatureBinder binder(
+        *signature, actualTypes, TypeCoercer::defaults());
     ASSERT_TRUE(binder.tryBind());
   }
 
-  exec::SignatureBinder binder(*signature, actualTypes);
+  exec::SignatureBinder binder(
+      *signature, actualTypes, TypeCoercer::defaults());
   std::vector<Coercion> coercions;
   ASSERT_TRUE(binder.tryBindWithCoercions(coercions));
 
@@ -85,12 +87,14 @@ void assertCannotBind(
   SCOPED_TRACE(fmt::format("Actual types: {}", toString(actualTypes)));
 
   {
-    exec::SignatureBinder binder(*signature, actualTypes);
+    exec::SignatureBinder binder(
+        *signature, actualTypes, TypeCoercer::defaults());
     ASSERT_FALSE(binder.tryBind());
   }
 
   if (allowCoercion) {
-    exec::SignatureBinder binder(*signature, actualTypes);
+    exec::SignatureBinder binder(
+        *signature, actualTypes, TypeCoercer::defaults());
     std::vector<Coercion> coercions;
     ASSERT_FALSE(binder.tryBindWithCoercions(coercions));
   }
@@ -103,11 +107,13 @@ void assertCannotResolve(
   SCOPED_TRACE(fmt::format("Actual types: {}", toString(actualTypes)));
 
   {
-    exec::SignatureBinder binder(*signature, actualTypes);
+    exec::SignatureBinder binder(
+        *signature, actualTypes, TypeCoercer::defaults());
     ASSERT_TRUE(binder.tryBind());
   }
 
-  exec::SignatureBinder binder(*signature, actualTypes);
+  exec::SignatureBinder binder(
+      *signature, actualTypes, TypeCoercer::defaults());
   std::vector<Coercion> coercions;
   ASSERT_TRUE(binder.tryBindWithCoercions(coercions));
 
@@ -245,7 +251,8 @@ TEST(SignatureBinderTest, decimals) {
                          .build();
 
     const std::vector<TypePtr> actualTypes{DECIMAL(10, 4)};
-    exec::SignatureBinder binder(*signature, actualTypes);
+    exec::SignatureBinder binder(
+        *signature, actualTypes, TypeCoercer::defaults());
     ASSERT_TRUE(binder.tryBind());
 
     auto intermediateType =
@@ -270,7 +277,7 @@ TEST(SignatureBinderTest, decimals) {
                          .argumentType("DECIMAL(b_precision, b_scale)")
                          .build();
     const std::vector<TypePtr> argTypes{DECIMAL(11, 5), DECIMAL(10, 6)};
-    exec::SignatureBinder binder(*signature, argTypes);
+    exec::SignatureBinder binder(*signature, argTypes, TypeCoercer::defaults());
     ASSERT_TRUE(binder.tryBind());
     ASSERT_TRUE(binder.tryResolveReturnType() == nullptr);
   }
@@ -285,7 +292,8 @@ TEST(SignatureBinderTest, decimals) {
                          .build();
     {
       const std::vector<TypePtr> argTypes{DECIMAL(11, 5), DECIMAL(11, 5)};
-      exec::SignatureBinder binder(*signature, argTypes);
+      exec::SignatureBinder binder(
+          *signature, argTypes, TypeCoercer::defaults());
       ASSERT_TRUE(binder.tryBind());
       auto returnType = binder.tryResolveReturnType();
       ASSERT_TRUE(returnType != nullptr);
@@ -294,7 +302,8 @@ TEST(SignatureBinderTest, decimals) {
 
     {
       const std::vector<TypePtr> argTypes{DECIMAL(28, 5), DECIMAL(28, 5)};
-      exec::SignatureBinder binder(*signature, argTypes);
+      exec::SignatureBinder binder(
+          *signature, argTypes, TypeCoercer::defaults());
       ASSERT_TRUE(binder.tryBind());
       auto returnType = binder.tryResolveReturnType();
       ASSERT_TRUE(returnType != nullptr);
@@ -304,11 +313,13 @@ TEST(SignatureBinderTest, decimals) {
     // Decimal scalar function signature with precision/scale mismatch.
     {
       const std::vector<TypePtr> argTypes{DECIMAL(28, 5), DECIMAL(29, 5)};
-      exec::SignatureBinder binder(*signature, argTypes);
+      exec::SignatureBinder binder(
+          *signature, argTypes, TypeCoercer::defaults());
       ASSERT_FALSE(binder.tryBind());
 
       const std::vector<TypePtr> argTypes1{DECIMAL(28, 7), DECIMAL(28, 5)};
-      exec::SignatureBinder binder1(*signature, argTypes1);
+      exec::SignatureBinder binder1(
+          *signature, argTypes1, TypeCoercer::defaults());
 
       ASSERT_FALSE(binder1.tryBind());
     }
@@ -318,7 +329,8 @@ TEST(SignatureBinderTest, decimals) {
     {
       const std::vector<TypePtr> argTypes{
           MAP(VARCHAR(), BIGINT()), MAP(VARCHAR(), BIGINT())};
-      exec::SignatureBinder binder(*signature, argTypes);
+      exec::SignatureBinder binder(
+          *signature, argTypes, TypeCoercer::defaults());
       std::vector<Coercion> coercions;
       ASSERT_FALSE(binder.tryBindWithCoercions(coercions));
     }
@@ -520,13 +532,15 @@ TEST(SignatureBinderTest, knownOnly) {
                        .build();
   {
     auto actualTypes = std::vector<TypePtr>{MAP(UNKNOWN(), UNKNOWN())};
-    exec::SignatureBinder binder(*signature, actualTypes);
+    exec::SignatureBinder binder(
+        *signature, actualTypes, TypeCoercer::defaults());
     ASSERT_FALSE(binder.tryBind());
   }
 
   {
     auto actualTypes = std::vector<TypePtr>{MAP(INTEGER(), UNKNOWN())};
-    exec::SignatureBinder binder(*signature, actualTypes);
+    exec::SignatureBinder binder(
+        *signature, actualTypes, TypeCoercer::defaults());
     ASSERT_TRUE(binder.tryBind());
   }
 }
@@ -539,13 +553,15 @@ TEST(SignatureBinderTest, orderableComparable) {
                        .build();
   {
     auto actualTypes = std::vector<TypePtr>{ARRAY(BIGINT())};
-    exec::SignatureBinder binder(*signature, actualTypes);
+    exec::SignatureBinder binder(
+        *signature, actualTypes, TypeCoercer::defaults());
     ASSERT_TRUE(binder.tryBind());
   }
 
   {
     auto actualTypes = std::vector<TypePtr>{ARRAY(MAP(BIGINT(), BIGINT()))};
-    exec::SignatureBinder binder(*signature, actualTypes);
+    exec::SignatureBinder binder(
+        *signature, actualTypes, TypeCoercer::defaults());
     ASSERT_FALSE(binder.tryBind());
   }
 
@@ -557,21 +573,24 @@ TEST(SignatureBinderTest, orderableComparable) {
                   .build();
   {
     auto actualTypes = std::vector<TypePtr>{ROW({BIGINT(), ARRAY(DOUBLE())})};
-    exec::SignatureBinder binder(*signature, actualTypes);
+    exec::SignatureBinder binder(
+        *signature, actualTypes, TypeCoercer::defaults());
     ASSERT_TRUE(binder.tryBind());
   }
 
   {
     auto actualTypes =
         std::vector<TypePtr>{ROW({MAP(VARCHAR(), BIGINT()), ARRAY(DOUBLE())})};
-    exec::SignatureBinder binder(*signature, actualTypes);
+    exec::SignatureBinder binder(
+        *signature, actualTypes, TypeCoercer::defaults());
     ASSERT_TRUE(binder.tryBind());
   }
 
   {
     auto actualTypes =
         std::vector<TypePtr>{ROW({BIGINT(), MAP(VARCHAR(), BIGINT())})};
-    exec::SignatureBinder binder(*signature, actualTypes);
+    exec::SignatureBinder binder(
+        *signature, actualTypes, TypeCoercer::defaults());
     ASSERT_FALSE(binder.tryBind());
   }
 }
@@ -585,7 +604,8 @@ TEST(SignatureBinderTest, orderableComparableAggregate) {
                        .build();
   {
     auto actualTypes = std::vector<TypePtr>{ARRAY(MAP(BIGINT(), BIGINT()))};
-    exec::SignatureBinder binder(*signature, actualTypes);
+    exec::SignatureBinder binder(
+        *signature, actualTypes, TypeCoercer::defaults());
     ASSERT_TRUE(binder.tryBind());
   }
 
@@ -598,7 +618,8 @@ TEST(SignatureBinderTest, orderableComparableAggregate) {
   {
     auto actualTypes =
         std::vector<TypePtr>{ROW({MAP(VARCHAR(), BIGINT()), ARRAY(DOUBLE())})};
-    exec::SignatureBinder binder(*signature, actualTypes);
+    exec::SignatureBinder binder(
+        *signature, actualTypes, TypeCoercer::defaults());
     ASSERT_TRUE(binder.tryBind());
   }
 
@@ -611,13 +632,15 @@ TEST(SignatureBinderTest, orderableComparableAggregate) {
   {
     auto actualTypes =
         std::vector<TypePtr>{ROW({MAP(VARCHAR(), BIGINT()), ARRAY(DOUBLE())})};
-    exec::SignatureBinder binder(*signature, actualTypes);
+    exec::SignatureBinder binder(
+        *signature, actualTypes, TypeCoercer::defaults());
     ASSERT_FALSE(binder.tryBind());
   }
 
   {
     auto actualTypes = std::vector<TypePtr>{ROW({BIGINT(), ARRAY(DOUBLE())})};
-    exec::SignatureBinder binder(*signature, actualTypes);
+    exec::SignatureBinder binder(
+        *signature, actualTypes, TypeCoercer::defaults());
     ASSERT_TRUE(binder.tryBind());
   }
 
@@ -632,14 +655,16 @@ TEST(SignatureBinderTest, orderableComparableAggregate) {
   {
     auto actualTypes =
         std::vector<TypePtr>{MAP(VARCHAR(), BIGINT()), ARRAY(DOUBLE())};
-    exec::SignatureBinder binder(*signature, actualTypes);
+    exec::SignatureBinder binder(
+        *signature, actualTypes, TypeCoercer::defaults());
     ASSERT_TRUE(binder.tryBind());
   }
 
   {
     auto actualTypes =
         std::vector<TypePtr>{ARRAY(DOUBLE()), MAP(VARCHAR(), BIGINT())};
-    exec::SignatureBinder binder(*signature, actualTypes);
+    exec::SignatureBinder binder(
+        *signature, actualTypes, TypeCoercer::defaults());
     ASSERT_FALSE(binder.tryBind());
   }
 }
@@ -872,7 +897,7 @@ TEST(SignatureBinderTest, lambda) {
                        .build();
 
   std::vector<TypePtr> inputTypes{ARRAY(BIGINT()), DOUBLE(), nullptr, nullptr};
-  exec::SignatureBinder binder(*signature, inputTypes);
+  exec::SignatureBinder binder(*signature, inputTypes, TypeCoercer::defaults());
   ASSERT_FALSE(binder.tryBind());
 
   // Resolve inputs for function(S,T,S). We resolve first 2 arguments, since
@@ -1130,11 +1155,13 @@ void testCoercions(
   SCOPED_TRACE(fmt::format("Actual types: {}", toString(actualTypes)));
 
   {
-    exec::SignatureBinder binder(*signature, actualTypes);
+    exec::SignatureBinder binder(
+        *signature, actualTypes, TypeCoercer::defaults());
     ASSERT_FALSE(binder.tryBind());
   }
 
-  exec::SignatureBinder binder(*signature, actualTypes);
+  exec::SignatureBinder binder(
+      *signature, actualTypes, TypeCoercer::defaults());
 
   std::vector<Coercion> coercions;
   ASSERT_TRUE(binder.tryBindWithCoercions(coercions));
@@ -1156,7 +1183,8 @@ void testNoCoercions(
   SCOPED_TRACE(fmt::format("Actual types: {}", toString(actualTypes)));
 
   {
-    exec::SignatureBinder binder(*signature, actualTypes);
+    exec::SignatureBinder binder(
+        *signature, actualTypes, TypeCoercer::defaults());
     ASSERT_TRUE(binder.tryBind());
 
     auto returnType = binder.tryResolveReturnType();
@@ -1165,7 +1193,8 @@ void testNoCoercions(
   }
 
   {
-    exec::SignatureBinder binder(*signature, actualTypes);
+    exec::SignatureBinder binder(
+        *signature, actualTypes, TypeCoercer::defaults());
 
     std::vector<Coercion> coercions;
     ASSERT_TRUE(binder.tryBindWithCoercions(coercions));
@@ -1665,8 +1694,8 @@ TEST(SignatureBinderTest, tryResolveReturnTypeWithCoercions) {
   // No signatures returns nullptr.
   {
     std::vector<TypePtr> coercions;
-    auto type =
-        exec::tryResolveReturnTypeWithCoercions({}, {BIGINT()}, coercions);
+    auto type = exec::tryResolveReturnTypeWithCoercions(
+        {}, {BIGINT()}, coercions, TypeCoercer::defaults());
     ASSERT_EQ(type, nullptr);
   }
 
@@ -1677,7 +1706,7 @@ TEST(SignatureBinderTest, tryResolveReturnTypeWithCoercions) {
     };
     std::vector<TypePtr> coercions;
     auto type = exec::tryResolveReturnTypeWithCoercions(
-        signatures, {BIGINT(), BIGINT()}, coercions);
+        signatures, {BIGINT(), BIGINT()}, coercions, TypeCoercer::defaults());
     VELOX_ASSERT_EQ_TYPES(type, BIGINT());
     ASSERT_EQ(coercions.size(), 2);
     ASSERT_EQ(coercions[0], nullptr);
@@ -1691,7 +1720,7 @@ TEST(SignatureBinderTest, tryResolveReturnTypeWithCoercions) {
     };
     std::vector<TypePtr> coercions;
     auto type = exec::tryResolveReturnTypeWithCoercions(
-        signatures, {VARCHAR(), BIGINT()}, coercions);
+        signatures, {VARCHAR(), BIGINT()}, coercions, TypeCoercer::defaults());
     ASSERT_EQ(type, nullptr);
   }
 
@@ -1703,7 +1732,7 @@ TEST(SignatureBinderTest, tryResolveReturnTypeWithCoercions) {
     };
     std::vector<TypePtr> coercions;
     auto type = exec::tryResolveReturnTypeWithCoercions(
-        signatures, {BIGINT(), BIGINT()}, coercions);
+        signatures, {BIGINT(), BIGINT()}, coercions, TypeCoercer::defaults());
     VELOX_ASSERT_EQ_TYPES(type, BIGINT());
     ASSERT_EQ(coercions.size(), 2);
     ASSERT_EQ(coercions[0], nullptr);
@@ -1718,7 +1747,7 @@ TEST(SignatureBinderTest, tryResolveReturnTypeWithCoercions) {
     };
     std::vector<TypePtr> coercions;
     auto type = exec::tryResolveReturnTypeWithCoercions(
-        signatures, {TINYINT(), TINYINT()}, coercions);
+        signatures, {TINYINT(), TINYINT()}, coercions, TypeCoercer::defaults());
     // integer(integer, integer) is lower cost than bigint(bigint, bigint).
     VELOX_ASSERT_EQ_TYPES(type, INTEGER());
     ASSERT_EQ(coercions.size(), 2);
@@ -1733,7 +1762,7 @@ TEST(SignatureBinderTest, tryResolveReturnTypeWithCoercions) {
     };
     std::vector<TypePtr> coercions;
     auto type = exec::tryResolveReturnTypeWithCoercions(
-        signatures, {TINYINT(), BIGINT()}, coercions);
+        signatures, {TINYINT(), BIGINT()}, coercions, TypeCoercer::defaults());
     VELOX_ASSERT_EQ_TYPES(type, BIGINT());
     ASSERT_EQ(coercions.size(), 2);
     VELOX_ASSERT_EQ_TYPES(coercions[0], BIGINT());

--- a/velox/functions/FunctionRegistry.cpp
+++ b/velox/functions/FunctionRegistry.cpp
@@ -152,17 +152,18 @@ bool hasCoercions(const std::vector<TypePtr>& coercions) {
 TypePtr resolveFunctionWithCoercions(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes,
-    std::vector<TypePtr>& coercions) {
+    std::vector<TypePtr>& coercions,
+    const TypeCoercer& coercer) {
   // Check if this is a simple function.
   if (auto resolvedFunction =
           exec::simpleFunctions().resolveFunctionWithCoercions(
-              functionName, argTypes, coercions)) {
+              functionName, argTypes, coercions, coercer)) {
     if (hasCoercions(coercions)) {
       // Check if there is a vector function that can be invoked without
       // coercions.
       std::vector<TypePtr> alternativeCoersions;
       auto otherType = exec::resolveVectorFunctionWithCoercions(
-          functionName, argTypes, alternativeCoersions);
+          functionName, argTypes, alternativeCoersions, coercer);
       if (otherType != nullptr && !hasCoercions(alternativeCoersions)) {
         coercions.clear();
         return otherType;
@@ -174,7 +175,7 @@ TypePtr resolveFunctionWithCoercions(
 
   // Check if VectorFunctions has this function name + signature.
   return exec::resolveVectorFunctionWithCoercions(
-      functionName, argTypes, coercions);
+      functionName, argTypes, coercions, coercer);
 }
 
 std::optional<std::pair<TypePtr, exec::VectorFunctionMetadata>>
@@ -203,13 +204,15 @@ TypePtr resolveFunctionOrCallableSpecialForm(
 TypePtr resolveFunctionOrCallableSpecialFormWithCoercions(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes,
-    std::vector<TypePtr>& coercions) {
+    std::vector<TypePtr>& coercions,
+    const TypeCoercer& coercer) {
   if (auto returnType = resolveCallableSpecialFormWithCoercions(
-          functionName, argTypes, coercions)) {
+          functionName, argTypes, coercions, coercer)) {
     return returnType;
   }
 
-  return resolveFunctionWithCoercions(functionName, argTypes, coercions);
+  return resolveFunctionWithCoercions(
+      functionName, argTypes, coercions, coercer);
 }
 
 TypePtr resolveCallableSpecialForm(
@@ -221,9 +224,10 @@ TypePtr resolveCallableSpecialForm(
 TypePtr resolveCallableSpecialFormWithCoercions(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes,
-    std::vector<TypePtr>& coercions) {
+    std::vector<TypePtr>& coercions,
+    const TypeCoercer& coercer) {
   return exec::resolveTypeForSpecialFormWithCoercions(
-      functionName, argTypes, coercions);
+      functionName, argTypes, coercions, coercer);
 }
 
 TypePtr resolveSimpleFunction(
@@ -254,9 +258,10 @@ std::optional<std::pair<TypePtr, exec::VectorFunctionMetadata>>
 resolveVectorFunctionWithMetadataWithCoercions(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes,
-    std::vector<TypePtr>& coercions) {
+    std::vector<TypePtr>& coercions,
+    const TypeCoercer& coercer) {
   return exec::resolveVectorFunctionWithMetadataWithCoercions(
-      functionName, argTypes, coercions);
+      functionName, argTypes, coercions, coercer);
 }
 
 void removeFunction(const std::string& functionName) {

--- a/velox/functions/FunctionRegistry.h
+++ b/velox/functions/FunctionRegistry.h
@@ -21,6 +21,7 @@
 #include "velox/expression/FunctionMetadata.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/type/Type.h"
+#include "velox/type/TypeCoercer.h"
 
 namespace facebook::velox {
 
@@ -77,7 +78,8 @@ TypePtr resolveFunction(
 TypePtr resolveFunctionWithCoercions(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes,
-    std::vector<TypePtr>& coercions);
+    std::vector<TypePtr>& coercions,
+    const TypeCoercer& coercer);
 
 /// Given a function name and argument types, returns a pair of return
 /// type and metadata if function exists. Otherwise, returns std::nullopt.
@@ -104,7 +106,8 @@ TypePtr resolveFunctionOrCallableSpecialForm(
 TypePtr resolveFunctionOrCallableSpecialFormWithCoercions(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes,
-    std::vector<TypePtr>& coercions);
+    std::vector<TypePtr>& coercions,
+    const TypeCoercer& coercer);
 
 /// Given the name of a special form and argument types, returns
 /// the return type if the special form exists and is supported, otherwise
@@ -129,7 +132,8 @@ TypePtr resolveCallableSpecialForm(
 TypePtr resolveCallableSpecialFormWithCoercions(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes,
-    std::vector<TypePtr>& coercions);
+    std::vector<TypePtr>& coercions,
+    const TypeCoercer& coercer);
 
 /// Given name of simple function and argument types, returns
 /// the return type if function exists otherwise returns nullptr
@@ -161,7 +165,8 @@ std::optional<std::pair<TypePtr, exec::VectorFunctionMetadata>>
 resolveVectorFunctionWithMetadataWithCoercions(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes,
-    std::vector<TypePtr>& coercions);
+    std::vector<TypePtr>& coercions,
+    const TypeCoercer& coercer);
 
 /// Given name of a function, removes it from both the simple and vector
 /// function registries (including all signatures).

--- a/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
+++ b/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
@@ -222,7 +222,7 @@ std::string getMergeExtractFunctionNameWithSuffix(
   VELOX_CHECK(signatures.has_value());
 
   for (const auto& signature : signatures.value()) {
-    exec::SignatureBinder binder{*signature, argTypes};
+    exec::SignatureBinder binder{*signature, argTypes, TypeCoercer::defaults()};
     if (binder.tryBind()) {
       if (auto resolvedType = binder.tryResolveReturnType()) {
         return exec::CompanionSignatures::mergeExtractFunctionNameWithSuffix(
@@ -245,7 +245,7 @@ std::string getExtractFunctionNameWithSuffix(
   VELOX_CHECK(signatures.has_value());
 
   for (const auto& signature : signatures.value()) {
-    exec::SignatureBinder binder{*signature, argTypes};
+    exec::SignatureBinder binder{*signature, argTypes, TypeCoercer::defaults()};
     if (binder.tryBind()) {
       if (auto resultType = binder.tryResolveReturnType()) {
         return exec::CompanionSignatures::extractFunctionNameWithSuffix(

--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+add_subdirectory(coercion)
 add_subdirectory(json)
 add_subdirectory(types)
 add_subdirectory(window)

--- a/velox/functions/prestosql/coercion/CMakeLists.txt
+++ b/velox/functions/prestosql/coercion/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+velox_add_library(velox_presto_coercions PrestoCoercions.cpp HEADERS PrestoCoercions.h)
+
+velox_link_libraries(velox_presto_coercions velox_type)
+
+if(${VELOX_BUILD_TESTING})
+  add_subdirectory(tests)
+endif()

--- a/velox/functions/prestosql/coercion/PrestoCoercions.cpp
+++ b/velox/functions/prestosql/coercion/PrestoCoercions.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/prestosql/coercion/PrestoCoercions.h"
+
+namespace facebook::velox::functions::prestosql {
+
+namespace {
+
+// Complete Presto coercion rule set. Self-contained; intentionally does not
+// reference TypeCoercer::defaults() so changes to Velox defaults cannot
+// silently shift Presto semantics. Lower cost = preferred during overload
+// resolution.
+//
+// TODO: transcribe the full Presto Java `TypeCoercion` table. Today's set
+// matches Velox's defaults plus BIGINT -> REAL (Presto allows this lossy
+// conversion; Velox defaults do not).
+std::vector<CoercionEntry> prestoRules() {
+  std::vector<CoercionEntry> rules;
+
+  auto add = [&](const TypePtr& from, const std::vector<TypePtr>& to) {
+    int32_t cost = 0;
+    for (const auto& toType : to) {
+      rules.push_back({from, toType, ++cost});
+    }
+  };
+
+  add(TINYINT(),
+      {SMALLINT(), INTEGER(), BIGINT(), DECIMAL(3, 0), REAL(), DOUBLE()});
+  add(SMALLINT(), {INTEGER(), BIGINT(), DECIMAL(5, 0), REAL(), DOUBLE()});
+  add(INTEGER(), {BIGINT(), DECIMAL(10, 0), REAL(), DOUBLE()});
+  // Presto-specific: BIGINT -> REAL is added between DECIMAL and DOUBLE,
+  // mirroring the INTEGER row's ordering. This makes divide(real, bigint)
+  // resolve to divide(real, real) via BIGINT -> REAL (cost 2) instead of
+  // divide(double, double) via REAL -> DOUBLE + BIGINT -> DOUBLE (cost 1 +
+  // 3 = 4), matching Presto's overload resolution.
+  add(BIGINT(), {DECIMAL(19, 0), REAL(), DOUBLE()});
+  add(REAL(), {DOUBLE()});
+  add(DECIMAL(1, 0), {REAL(), DOUBLE()});
+  add(DATE(), {TIMESTAMP()});
+  add(UNKNOWN(),
+      {TINYINT(),
+       BOOLEAN(),
+       SMALLINT(),
+       INTEGER(),
+       BIGINT(),
+       REAL(),
+       DOUBLE(),
+       VARCHAR(),
+       VARBINARY()});
+
+  return rules;
+}
+
+} // namespace
+
+const TypeCoercer& typeCoercer() {
+  static const TypeCoercer instance{prestoRules()};
+  return instance;
+}
+
+} // namespace facebook::velox::functions::prestosql

--- a/velox/functions/prestosql/coercion/PrestoCoercions.h
+++ b/velox/functions/prestosql/coercion/PrestoCoercions.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/type/TypeCoercer.h"
+
+namespace facebook::velox::functions::prestosql {
+
+/// Coercion rule set for the Presto SQL dialect. Returned coercer is a
+/// singleton.
+const TypeCoercer& typeCoercer();
+
+} // namespace facebook::velox::functions::prestosql

--- a/velox/functions/prestosql/coercion/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/coercion/tests/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_executable(velox_presto_coercions_test PrestoCoercionsTest.cpp)
+
+add_test(velox_presto_coercions_test velox_presto_coercions_test)
+
+target_link_libraries(
+  velox_presto_coercions_test
+  velox_presto_coercions
+  GTest::gtest
+  GTest::gtest_main
+)

--- a/velox/functions/prestosql/coercion/tests/PrestoCoercionsTest.cpp
+++ b/velox/functions/prestosql/coercion/tests/PrestoCoercionsTest.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/prestosql/coercion/PrestoCoercions.h"
+
+#include <gtest/gtest.h>
+
+namespace facebook::velox::functions::prestosql {
+namespace {
+
+// Verifies the BIGINT row of the Presto coercion table. The relative
+// ordering DECIMAL < REAL < DOUBLE is load-bearing for overload resolution:
+// for `divide(real, bigint)`, BIGINT -> REAL (cost 2) must beat
+// REAL -> DOUBLE + BIGINT -> DOUBLE (cost 1 + 3 = 4) so the resolver picks
+// divide(real, real) and the result type is REAL -- matching Presto's
+// behavior.
+TEST(PrestoCoercionsTest, bigintRow) {
+  const auto& tc = typeCoercer();
+
+  auto toDecimal = tc.coerceTypeBase(BIGINT(), DECIMAL(19, 0));
+  auto toReal = tc.coerceTypeBase(BIGINT(), REAL());
+  auto toDouble = tc.coerceTypeBase(BIGINT(), DOUBLE());
+
+  ASSERT_TRUE(toDecimal.has_value());
+  ASSERT_TRUE(toReal.has_value());
+  ASSERT_TRUE(toDouble.has_value());
+
+  EXPECT_LT(toDecimal->cost, toReal->cost);
+  EXPECT_LT(toReal->cost, toDouble->cost);
+}
+
+// Sanity check on a representative subset of the Presto rule set.
+TEST(PrestoCoercionsTest, sanity) {
+  const auto& tc = typeCoercer();
+
+  EXPECT_TRUE(tc.coercible(INTEGER(), BIGINT()).has_value());
+  EXPECT_TRUE(tc.coercible(BIGINT(), DOUBLE()).has_value());
+  EXPECT_TRUE(tc.coercible(DATE(), TIMESTAMP()).has_value());
+  EXPECT_TRUE(tc.coercible(REAL(), DOUBLE()).has_value());
+  EXPECT_TRUE(tc.coercible(UNKNOWN(), VARCHAR()).has_value());
+}
+
+} // namespace
+} // namespace facebook::velox::functions::prestosql

--- a/velox/functions/prestosql/types/tests/CustomTypeCoercionTest.cpp
+++ b/velox/functions/prestosql/types/tests/CustomTypeCoercionTest.cpp
@@ -41,44 +41,51 @@ class CustomTypeCoercionTest : public testing::Test {
 };
 
 TEST_F(CustomTypeCoercionTest, timestampWithTimeZone) {
-  auto coercion = TypeCoercer::coerceTypeBase(
+  auto coercion = TypeCoercer::defaults().coerceTypeBase(
       TIMESTAMP(), TIMESTAMP_WITH_TIME_ZONE()->name());
   ASSERT_TRUE(coercion.has_value());
   VELOX_EXPECT_EQ_TYPES(coercion->type, TIMESTAMP_WITH_TIME_ZONE());
   EXPECT_EQ(coercion->cost, 1);
 
-  coercion =
-      TypeCoercer::coerceTypeBase(DATE(), TIMESTAMP_WITH_TIME_ZONE()->name());
+  coercion = TypeCoercer::defaults().coerceTypeBase(
+      DATE(), TIMESTAMP_WITH_TIME_ZONE()->name());
   ASSERT_TRUE(coercion.has_value());
   VELOX_EXPECT_EQ_TYPES(coercion->type, TIMESTAMP_WITH_TIME_ZONE());
   EXPECT_EQ(coercion->cost, 2);
 
   // Reverse directions are explicit-only, not coercible.
   ASSERT_FALSE(
-      TypeCoercer::coerceTypeBase(
+      TypeCoercer::defaults().coerceTypeBase(
           TIMESTAMP_WITH_TIME_ZONE(), TIMESTAMP()->name()));
   ASSERT_FALSE(
-      TypeCoercer::coerceTypeBase(TIMESTAMP_WITH_TIME_ZONE(), DATE()->name()));
+      TypeCoercer::defaults().coerceTypeBase(
+          TIMESTAMP_WITH_TIME_ZONE(), DATE()->name()));
 }
 
 TEST_F(CustomTypeCoercionTest, timeWithTimeZone) {
-  auto coercion =
-      TypeCoercer::coerceTypeBase(TIME(), TIME_WITH_TIME_ZONE()->name());
+  auto coercion = TypeCoercer::defaults().coerceTypeBase(
+      TIME(), TIME_WITH_TIME_ZONE()->name());
   ASSERT_TRUE(coercion.has_value());
   VELOX_EXPECT_EQ_TYPES(coercion->type, TIME_WITH_TIME_ZONE());
 
   // Reverse directions are explicit-only, not coercible.
   ASSERT_FALSE(
-      TypeCoercer::coerceTypeBase(TIME_WITH_TIME_ZONE(), TIME()->name()));
+      TypeCoercer::defaults().coerceTypeBase(
+          TIME_WITH_TIME_ZONE(), TIME()->name()));
   ASSERT_FALSE(
-      TypeCoercer::coerceTypeBase(TIME_WITH_TIME_ZONE(), DATE()->name()));
+      TypeCoercer::defaults().coerceTypeBase(
+          TIME_WITH_TIME_ZONE(), DATE()->name()));
 }
 
 TEST_F(CustomTypeCoercionTest, digests) {
   EXPECT_FALSE(
-      TypeCoercer::coerceTypeBase(TDIGEST(DOUBLE()), "QDIGEST").has_value());
+      TypeCoercer::defaults()
+          .coerceTypeBase(TDIGEST(DOUBLE()), "QDIGEST")
+          .has_value());
   EXPECT_FALSE(
-      TypeCoercer::coerceTypeBase(QDIGEST(DOUBLE()), "TDIGEST").has_value());
+      TypeCoercer::defaults()
+          .coerceTypeBase(QDIGEST(DOUBLE()), "TDIGEST")
+          .has_value());
 }
 
 } // namespace

--- a/velox/functions/tests/FunctionRegistryTest.cpp
+++ b/velox/functions/tests/FunctionRegistryTest.cpp
@@ -104,7 +104,8 @@ class FunctionRegistryTest : public testing::Test {
     VELOX_EXPECT_EQ_TYPES(type, expected);
 
     std::vector<TypePtr> coercions;
-    type = resolveFunctionWithCoercions(functionName, types, coercions);
+    type = resolveFunctionWithCoercions(
+        functionName, types, coercions, TypeCoercer::defaults());
     VELOX_EXPECT_EQ_TYPES(type, expected);
 
     if (expected != nullptr) {
@@ -128,7 +129,12 @@ class FunctionRegistryTest : public testing::Test {
     static ResolveFuncs function() {
       return {
           .resolveFunc = resolveFunction,
-          .resolveWithCoercionsFunc = resolveFunctionWithCoercions,
+          .resolveWithCoercionsFunc = [](const auto& name,
+                                         const auto& argTypes,
+                                         auto& coercions) -> TypePtr {
+            return resolveFunctionWithCoercions(
+                name, argTypes, coercions, TypeCoercer::defaults());
+          },
       };
     }
 
@@ -146,7 +152,7 @@ class FunctionRegistryTest : public testing::Test {
                                          auto& coercions) -> TypePtr {
             try {
               return resolveCallableSpecialFormWithCoercions(
-                  name, argTypes, coercions);
+                  name, argTypes, coercions, TypeCoercer::defaults());
             } catch (const VeloxException&) {
               return nullptr;
             }
@@ -291,7 +297,7 @@ class FunctionRegistryTest : public testing::Test {
       bool expectedDeterministic) {
     std::vector<TypePtr> coercions;
     auto result = resolveVectorFunctionWithMetadataWithCoercions(
-        name, argTypes, coercions);
+        name, argTypes, coercions, TypeCoercer::defaults());
     ASSERT_TRUE(result.has_value());
     VELOX_EXPECT_EQ_TYPES(result->first, expectedReturnType);
     EXPECT_EQ(result->second.deterministic, expectedDeterministic);
@@ -317,7 +323,7 @@ class FunctionRegistryTest : public testing::Test {
       bool expectedDeterministic) {
     std::vector<TypePtr> coercions;
     auto result = resolveVectorFunctionWithMetadataWithCoercions(
-        name, argTypes, coercions);
+        name, argTypes, coercions, TypeCoercer::defaults());
     ASSERT_TRUE(result.has_value());
     VELOX_EXPECT_EQ_TYPES(result->first, expectedReturnType);
     EXPECT_EQ(result->second.deterministic, expectedDeterministic);
@@ -333,7 +339,7 @@ class FunctionRegistryTest : public testing::Test {
       const std::vector<TypePtr>& argTypes) {
     std::vector<TypePtr> coercions;
     auto result = resolveVectorFunctionWithMetadataWithCoercions(
-        name, argTypes, coercions);
+        name, argTypes, coercions, TypeCoercer::defaults());
     EXPECT_FALSE(result.has_value());
   }
 };

--- a/velox/parse/TypeResolver.cpp
+++ b/velox/parse/TypeResolver.cpp
@@ -498,7 +498,7 @@ TypedExprPtr Expressions::tryResolveCallWithLambdas(
   }
 
   // Resolve lambda arguments.
-  exec::SignatureBinder binder(*signature, childTypes);
+  exec::SignatureBinder binder(*signature, childTypes, TypeCoercer::defaults());
   binder.tryBind();
   for (auto i = 0; i < numArgs; ++i) {
     if (signature->isLambdaArgumentAt(i)) {

--- a/velox/type/TypeCoercer.cpp
+++ b/velox/type/TypeCoercer.cpp
@@ -32,17 +32,13 @@ int64_t Coercion::overallCost(const std::vector<Coercion>& coercions) {
 
 namespace {
 
-std::unordered_map<std::pair<std::string, std::string>, Coercion>
-allowedCoercions() {
-  std::unordered_map<std::pair<std::string, std::string>, Coercion> coercions;
+std::vector<CoercionEntry> defaultRules() {
+  std::vector<CoercionEntry> rules;
 
   auto add = [&](const TypePtr& from, const std::vector<TypePtr>& to) {
     int32_t cost = 0;
     for (const auto& toType : to) {
-      coercions.emplace(
-          std::make_pair<std::string, std::string>(
-              from->name(), toType->name()),
-          Coercion{.type = toType, .cost = ++cost});
+      rules.push_back({from, toType, ++cost});
     }
   };
 
@@ -65,22 +61,106 @@ allowedCoercions() {
        VARCHAR(),
        VARBINARY()});
 
-  return coercions;
+  return rules;
 }
+
 } // namespace
 
+TypeCoercer::TypeCoercer(const std::vector<CoercionEntry>& rules) {
+  // Tracks costs already used for a given source type to enforce uniqueness.
+  std::unordered_map<std::string, std::unordered_set<int32_t>> costsByFrom;
+
+  for (const auto& entry : rules) {
+    VELOX_CHECK_NOT_NULL(entry.from, "CoercionEntry.from must not be null");
+    VELOX_CHECK_NOT_NULL(entry.to, "CoercionEntry.to must not be null");
+
+    // Built-in -> built-in only. Custom-type coercions go through
+    // CastRulesRegistry and must not appear in a TypeCoercer rule set.
+    //
+    // Timing note: customTypeExists() checks the global custom-type
+    // registry at construction time. Today's TypeCoercer instances are
+    // lazy Meyers singletons (TypeCoercer::defaults(),
+    // presto::typeCoercer()) initialized on first use, so by then all
+    // relevant custom types are registered. If a future caller
+    // constructs a TypeCoercer eagerly (e.g., during static
+    // initialization), a rule with a name not yet registered as custom
+    // could pass this check but later collide with that type. Keep
+    // TypeCoercer construction lazy.
+    VELOX_CHECK(
+        !customTypeExists(entry.from->name()),
+        "CoercionEntry.from must be a built-in type, got custom type {}",
+        entry.from->name());
+    VELOX_CHECK(
+        !customTypeExists(entry.to->name()),
+        "CoercionEntry.to must be a built-in type, got custom type {}",
+        entry.to->name());
+
+    if (entry.from->isDecimal()) {
+      // DECIMAL -> DECIMAL is not honored: the same-name short-circuit at
+      // the top of coerceTypeBase returns cost 0 before the rule lookup
+      // runs. Reject these entries so users don't silently believe a
+      // rule is in effect.
+      VELOX_CHECK(
+          !entry.to->isDecimal(),
+          "DECIMAL -> DECIMAL coercion is not customizable via TypeCoercer. "
+          "DECIMAL -> DECIMAL reconciliation is handled by the type system "
+          "(LongDecimalType::commonSuperType). Rejecting rule {} -> {}.",
+          entry.from->toString(),
+          entry.to->toString());
+
+      // Source DECIMAL must be the canonical placeholder DECIMAL(1, 0).
+      // Source (p, s) is irrelevant at lookup -- the rule fires for any
+      // DECIMAL(p, s) -- so allowing other values here would create a
+      // false impression that callers can scope a rule to a particular
+      // precision or scale.
+      VELOX_CHECK(
+          entry.from->equivalent(*DECIMAL(1, 0)),
+          "Source DECIMAL in CoercionEntry must be DECIMAL(1, 0); got {}. "
+          "TypeCoercer does not distinguish source decimals by (p, s).",
+          entry.from->toString());
+    }
+
+    // Cost must be unique per source type so overload resolution has a
+    // deterministic preference order.
+    auto& seen = costsByFrom[entry.from->name()];
+    VELOX_CHECK(
+        seen.insert(entry.cost).second,
+        "Duplicate cost {} for source type {} in TypeCoercer rule set",
+        entry.cost,
+        entry.from->name());
+
+    // Reject duplicate (fromName, toName) pairs. This guards in particular
+    // against the common DECIMAL footgun: all decimals share the same name,
+    // so multiple {SOURCE, DECIMAL(p, s), cost} entries with different
+    // (p, s) collide on the same map key. Only one DECIMAL rule per source
+    // is supported (the minimum-width decimal -- see CoercionEntry doc).
+    auto [it, inserted] = rules_.emplace(
+        std::make_pair(entry.from->name(), entry.to->name()),
+        Coercion{.type = entry.to, .cost = entry.cost});
+    VELOX_CHECK(
+        inserted,
+        "Duplicate coercion rule {} -> {} in TypeCoercer rule set",
+        entry.from->name(),
+        entry.to->name());
+  }
+}
+
 // static
+const TypeCoercer& TypeCoercer::defaults() {
+  static const TypeCoercer instance{defaultRules()};
+  return instance;
+}
+
 std::optional<Coercion> TypeCoercer::coerceTypeBase(
     const TypePtr& fromType,
-    const TypePtr& toType) {
+    const TypePtr& toType) const {
   if (fromType->name() == toType->name()) {
     return Coercion{.type = fromType, .cost = 0};
   }
 
-  // Check built-in coercions first.
-  static const auto kAllowedCoercions = allowedCoercions();
-  auto it = kAllowedCoercions.find({fromType->name(), toType->name()});
-  if (it != kAllowedCoercions.end()) {
+  // Check this coercer's rule set first.
+  auto it = rules_.find({fromType->name(), toType->name()});
+  if (it != rules_.end()) {
     if (toType->isDecimal() && it->second.type->isDecimal()) {
       if (it->second.type->isShortDecimal()) {
         if (!it->second.type->asShortDecimal().isCoercibleTo(*toType)) {
@@ -96,7 +176,9 @@ std::optional<Coercion> TypeCoercer::coerceTypeBase(
     return it->second;
   }
 
-  // Check CastRulesRegistry directly — no type reconstruction needed.
+  // Fall back to CastRulesRegistry for custom-type coercions. Custom-type
+  // names are dialect-distinct in practice, so the global registry doesn't
+  // cross-contaminate dialects.
   if (auto cost = CastRulesRegistry::instance().canCoerce(fromType, toType)) {
     return Coercion{.type = toType, .cost = *cost};
   }
@@ -104,23 +186,21 @@ std::optional<Coercion> TypeCoercer::coerceTypeBase(
   return std::nullopt;
 }
 
-// static
 std::optional<Coercion> TypeCoercer::coerceTypeBase(
     const TypePtr& fromType,
-    const std::string& toTypeName) {
-  static const auto kAllowedCoercions = allowedCoercions();
+    const std::string& toTypeName) const {
   if (fromType->name() == toTypeName) {
     return Coercion{.type = fromType, .cost = 0};
   }
 
-  // Check built-in coercions first.
-  auto it = kAllowedCoercions.find({fromType->name(), toTypeName});
-  if (it != kAllowedCoercions.end()) {
+  // Check this coercer's rule set first.
+  auto it = rules_.find({fromType->name(), toTypeName});
+  if (it != rules_.end()) {
     return it->second;
   }
 
   // Fall back to CastRulesRegistry for custom type coercions. Skip
-  // parameterized types — we cannot construct the target type without knowing
+  // parameterized types -- we cannot construct the target type without knowing
   // its type parameters.
   // getCustomType() returns nullptr for built-in types. Callers must not
   // pass parametric custom type names (e.g., "BIGINT_ENUM") because their
@@ -138,10 +218,9 @@ std::optional<Coercion> TypeCoercer::coerceTypeBase(
   return std::nullopt;
 }
 
-// static
 std::optional<int32_t> TypeCoercer::coercible(
     const TypePtr& fromType,
-    const TypePtr& toType) {
+    const TypePtr& toType) const {
   if (fromType->isUnknown()) {
     if (toType->isUnknown()) {
       return 0;
@@ -150,7 +229,7 @@ std::optional<int32_t> TypeCoercer::coercible(
   }
 
   if (fromType->size() == 0) {
-    if (auto coercion = TypeCoercer::coerceTypeBase(fromType, toType)) {
+    if (auto coercion = coerceTypeBase(fromType, toType)) {
       return coercion->cost;
     }
 
@@ -176,7 +255,10 @@ std::optional<int32_t> TypeCoercer::coercible(
 
 namespace {
 
-TypePtr leastCommonSuperRowType(const RowType& a, const RowType& b) {
+TypePtr leastCommonSuperRowType(
+    const TypeCoercer& coercer,
+    const RowType& a,
+    const RowType& b) {
   std::vector<std::string> childNames;
   childNames.reserve(a.size());
 
@@ -195,7 +277,7 @@ TypePtr leastCommonSuperRowType(const RowType& a, const RowType& b) {
   childTypes.reserve(a.size());
   for (auto i = 0; i < a.size(); i++) {
     if (auto childType =
-            TypeCoercer::leastCommonSuperType(a.childAt(i), b.childAt(i))) {
+            coercer.leastCommonSuperType(a.childAt(i), b.childAt(i))) {
       childTypes.push_back(childType);
     } else {
       return nullptr;
@@ -204,10 +286,11 @@ TypePtr leastCommonSuperRowType(const RowType& a, const RowType& b) {
 
   return ROW(std::move(childNames), std::move(childTypes));
 }
+
 } // namespace
 
-// static
-TypePtr TypeCoercer::leastCommonSuperType(const TypePtr& a, const TypePtr& b) {
+TypePtr TypeCoercer::leastCommonSuperType(const TypePtr& a, const TypePtr& b)
+    const {
   if (a->isUnknown()) {
     return b;
   }
@@ -227,11 +310,11 @@ TypePtr TypeCoercer::leastCommonSuperType(const TypePtr& a, const TypePtr& b) {
       }
     }
 
-    if (TypeCoercer::coerceTypeBase(a, b)) {
+    if (coerceTypeBase(a, b)) {
       return b;
     }
 
-    if (TypeCoercer::coerceTypeBase(b, a)) {
+    if (coerceTypeBase(b, a)) {
       return a;
     }
 
@@ -243,7 +326,7 @@ TypePtr TypeCoercer::leastCommonSuperType(const TypePtr& a, const TypePtr& b) {
   }
 
   if (a->name() == TypeKindName::toName(TypeKind::ROW)) {
-    return leastCommonSuperRowType(a->asRow(), b->asRow());
+    return leastCommonSuperRowType(*this, a->asRow(), b->asRow());
   }
 
   std::vector<TypeParameter> childTypes;

--- a/velox/type/TypeCoercer.h
+++ b/velox/type/TypeCoercer.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <folly/hash/Hash.h>
 #include "velox/type/Type.h"
 
 namespace facebook::velox {
@@ -71,33 +72,137 @@ struct Coercion {
   }
 };
 
+/// One entry in a TypeCoercer's rule set.
+///
+/// DECIMAL handling: rules are keyed by (from->name(), to->name()), and all
+/// decimal types share name "DECIMAL". A coercer therefore holds at most one
+/// DECIMAL rule per source type. The 'to' field on that rule must be the
+/// minimum-width decimal that fits every value of the source type (e.g.,
+/// TINYINT -> DECIMAL(3, 0)). Lookup at coerceTypeBase(from, target) widens
+/// the stored minimum-width decimal to the caller's requested target if
+/// isCoercibleTo allows; the rule's cost is preserved.
+struct CoercionEntry {
+  TypePtr from;
+  TypePtr to;
+  int32_t cost;
+};
+
+/// Type coercion rules. Each instance owns a complete rule set and
+/// is immutable after construction. Velox ships a default instance
+/// (TypeCoercer::defaults()) holding today's conservative built-in rules;
+/// each SQL dialect can ship its own complete instance with rules that match
+/// the dialect's semantics.
+///
+/// Coercion is a planning-time concern: by the time a Velox Task is
+/// constructed, every type mismatch is already an explicit Cast node. Runtime
+/// expression evaluators do not consult TypeCoercer.
+///
+/// Customization scope. The rule set determines coercion between primitive
+/// types (TINYINT, SMALLINT, INTEGER, BIGINT, REAL, DOUBLE, BOOLEAN,
+/// VARCHAR, VARBINARY, DATE, TIMESTAMP, UNKNOWN); a dialect has full
+/// control over which pairs are allowed and at what cost.
+///
+/// Cost magnitudes. Overload resolution sums per-argument coercion costs
+/// (Coercion::overallCost) to compare candidate signatures. For sums to
+/// be meaningful, every CoercionEntry.cost in a single TypeCoercer
+/// instance must be in the same small magnitude -- today's defaults use
+/// costs 1-9, one per source-type series. A dialect that mixes costs of
+/// vastly different magnitudes (e.g., 1-10 for some entries, 100-1000
+/// for others) will produce surprising tie-breaking. There is no
+/// hardcoded surcharge added at lookup time: the dialect's rule cost is
+/// returned verbatim, including for INT -> DECIMAL widening -- the rule's
+/// stored cost applies to every compatible target (p, s).
+///
+/// DECIMAL handling is two-step: the dialect's rule resolves a
+/// fixed-(p, s) decimal, then the type system's generic DECIMAL->DECIMAL
+/// compatibility widens it to the caller's request. Rule keys collapse on
+/// the name "DECIMAL" regardless of (p, s) -- one rule per
+/// (sourceName, targetName) pair on each side.
+///
+/// Source DECIMAL: a dialect registers one rule per (DECIMAL, target).
+/// The source must be DECIMAL(1, 0) (the canonical placeholder -- see
+/// CoercionEntry doc); the rule fires for any actual DECIMAL(p, s) source
+/// because the source's precision/scale is not part of the lookup key.
+///
+/// Target DECIMAL: a dialect registers one rule per (source, DECIMAL),
+/// with the rule's stored target serving as the minimum-width decimal
+/// that holds every value of the source (e.g., INTEGER -> DECIMAL(10, 0)).
+/// At lookup, the type system extends this fixed target to the caller's
+/// requested (p, s) via ShortDecimalType / LongDecimalType isCoercibleTo
+/// -- the dialect does not control widening; it picks only the
+/// minimum-width target.
+///
+/// DECIMAL -> DECIMAL is **not customizable** by dialects. Rule entries
+/// with both source and target DECIMAL are not honored: the same-name
+/// short-circuit at the top of coerceTypeBase returns cost 0 for any two
+/// DECIMALs regardless of (p, s) before the rule lookup runs.
+/// Precision/scale reconciliation between two DECIMALs is hardcoded in
+/// the type system -- LongDecimalType::commonSuperType inside
+/// leastCommonSuperType for plan-level operations (UNION, CASE result
+/// type, etc.), and SignatureBinder's integer-parameter binding for
+/// function signatures of the form DECIMAL(P, S). Dialects that need
+/// non-standard DECIMAL->DECIMAL semantics must extend the type system,
+/// not TypeCoercer.
+///
+/// Container types (ARRAY, MAP, ROW) and FUNCTION/OPAQUE are not
+/// customizable directly -- coercibility for those is structural (names and
+/// arities must match, children are recursed element-wise, see
+/// coercible()), so a dialect controls their behavior only indirectly via
+/// element-type rules.
+///
+/// Custom types (e.g. JSON, TIMESTAMP WITH TIME ZONE) are out of scope for
+/// TypeCoercer; they're coerced via the global CastRulesRegistry registered
+/// alongside registerCustomType().
 class TypeCoercer {
  public:
-  /// Checks if 'fromType' can be implicitly converted to 'toType'.
+  /// Construct from a complete rule set. Rules are frozen on construction.
+  /// Dialect-specific factories (e.g. presto::typeCoercer()) build a
+  /// TypeCoercer and expose it as a singleton rather than mutating an
+  /// existing instance.
+  explicit TypeCoercer(const std::vector<CoercionEntry>& rules);
+
+  /// Velox's default coercer holding today's conservative built-in rules.
+  /// Used by callers that have not selected a dialect-specific coercer.
+  static const TypeCoercer& defaults();
+
+  /// Checks if 'fromType' can be implicitly converted to 'toType' via a
+  /// single rule lookup. Does NOT recurse into container children -- for
+  /// container coercibility (e.g., ARRAY<INT> vs ARRAY<BIGINT>), use
+  /// coercible() instead.
   ///
   /// Prefer this over the string overload when the target type is available,
   /// as it avoids reconstructing the type from a name (which can throw for
   /// parametric custom types like BigintEnum).
   ///
+  /// For DECIMAL targets, the rule's stored type is the minimum-width
+  /// decimal for the source. If 'toType' is a wider DECIMAL that the
+  /// minimum can be coerced to (per ShortDecimalType / LongDecimalType
+  /// isCoercibleTo), the returned Coercion carries 'toType' and the rule's
+  /// cost. If 'toType' is too narrow, returns nullopt.
+  ///
   /// @return "to" type and cost if conversion is possible.
-  static std::optional<Coercion> coerceTypeBase(
+  std::optional<Coercion> coerceTypeBase(
       const TypePtr& fromType,
-      const TypePtr& toType);
+      const TypePtr& toType) const;
 
   /// Checks if the base of 'fromType' can be implicitly converted to a type
   /// with the given name. Used by SignatureBinder which only has a type name.
   ///
   /// @return "to" type and cost if conversion is possible.
-  static std::optional<Coercion> coerceTypeBase(
+  std::optional<Coercion> coerceTypeBase(
       const TypePtr& fromType,
-      const std::string& toTypeName);
+      const std::string& toTypeName) const;
 
-  /// Checks if 'fromType' can be implicitly converted to 'toType'.
+  /// Checks if 'fromType' can be implicitly converted to 'toType', recursing
+  /// into container children. For primitives this delegates to
+  /// coerceTypeBase(); for containers (ARRAY, MAP, ROW, FUNCTION) the names
+  /// and arities must match, then each child must be element-wise coercible.
   ///
-  /// @return Cost of conversion if possible. std::nullopt otherwise.
-  static std::optional<int32_t> coercible(
+  /// @return Total cost (sum of child costs for containers) if possible.
+  /// std::nullopt otherwise.
+  std::optional<int32_t> coercible(
       const TypePtr& fromType,
-      const TypePtr& toType);
+      const TypePtr& toType) const;
 
   /// Returns least common type for 'a' and 'b', i.e. a type that both 'a' and
   /// 'b' are coercible to. Returns nullptr if no such type exists.
@@ -105,7 +210,20 @@ class TypeCoercer {
   /// When `a` and `b` are ROW types with different field names, the resulting
   /// ROW has empty field names for any positions where the corresponding field
   /// names do not match.
-  static TypePtr leastCommonSuperType(const TypePtr& a, const TypePtr& b);
+  TypePtr leastCommonSuperType(const TypePtr& a, const TypePtr& b) const;
+
+ private:
+  struct PairHash {
+    size_t operator()(const std::pair<std::string, std::string>& p) const {
+      return folly::hash::hash_combine(
+          std::hash<std::string>{}(p.first),
+          std::hash<std::string>{}(p.second));
+    }
+  };
+
+  // Flat map: (fromName, toName) -> Coercion{type, cost}.
+  std::unordered_map<std::pair<std::string, std::string>, Coercion, PairHash>
+      rules_;
 };
 
 } // namespace facebook::velox

--- a/velox/type/tests/TypeCoercerTest.cpp
+++ b/velox/type/tests/TypeCoercerTest.cpp
@@ -23,19 +23,22 @@ namespace facebook::velox {
 namespace {
 
 void testCoercion(const TypePtr& fromType, const TypePtr& toType) {
-  auto coercion = TypeCoercer::coerceTypeBase(fromType, toType->name());
+  auto coercion =
+      TypeCoercer::defaults().coerceTypeBase(fromType, toType->name());
   ASSERT_TRUE(coercion.has_value());
   VELOX_EXPECT_EQ_TYPES(coercion->type, toType);
 }
 
 void testBaseCoercion(const TypePtr& fromType) {
-  auto coercion = TypeCoercer::coerceTypeBase(fromType, fromType->kindName());
+  auto coercion =
+      TypeCoercer::defaults().coerceTypeBase(fromType, fromType->kindName());
   ASSERT_TRUE(coercion.has_value());
   VELOX_EXPECT_EQ_TYPES(coercion->type, fromType);
 }
 
 void testNoCoercion(const TypePtr& fromType, const TypePtr& toType) {
-  auto coercion = TypeCoercer::coerceTypeBase(fromType, toType->name());
+  auto coercion =
+      TypeCoercer::defaults().coerceTypeBase(fromType, toType->name());
   ASSERT_FALSE(coercion.has_value());
 }
 
@@ -60,9 +63,9 @@ TEST(TypeCoercerTest, decimal) {
   testNoCoercion(DECIMAL(10, 2), VARCHAR());
   testNoCoercion(DECIMAL(10, 2), BIGINT());
 
-  ASSERT_TRUE(TypeCoercer::coercible(DECIMAL(10, 2), DOUBLE()));
-  ASSERT_TRUE(TypeCoercer::coercible(DECIMAL(10, 2), REAL()));
-  ASSERT_FALSE(TypeCoercer::coercible(DOUBLE(), DECIMAL(10, 2)));
+  ASSERT_TRUE(TypeCoercer::defaults().coercible(DECIMAL(10, 2), DOUBLE()));
+  ASSERT_TRUE(TypeCoercer::defaults().coercible(DECIMAL(10, 2), REAL()));
+  ASSERT_FALSE(TypeCoercer::defaults().coercible(DOUBLE(), DECIMAL(10, 2)));
 }
 
 TEST(TypeCoercerTest, integerToDecimal) {
@@ -71,81 +74,90 @@ TEST(TypeCoercerTest, integerToDecimal) {
   testCoercion(INTEGER(), DECIMAL(10, 0));
   testCoercion(BIGINT(), DECIMAL(19, 0));
 
-  ASSERT_TRUE(TypeCoercer::coercible(TINYINT(), DECIMAL(10, 2)));
-  ASSERT_TRUE(TypeCoercer::coercible(SMALLINT(), DECIMAL(10, 2)));
-  ASSERT_TRUE(TypeCoercer::coercible(INTEGER(), DECIMAL(38, 4)));
-  ASSERT_TRUE(TypeCoercer::coercible(BIGINT(), DECIMAL(38, 4)));
+  ASSERT_TRUE(TypeCoercer::defaults().coercible(TINYINT(), DECIMAL(10, 2)));
+  ASSERT_TRUE(TypeCoercer::defaults().coercible(SMALLINT(), DECIMAL(10, 2)));
+  ASSERT_TRUE(TypeCoercer::defaults().coercible(INTEGER(), DECIMAL(38, 4)));
+  ASSERT_TRUE(TypeCoercer::defaults().coercible(BIGINT(), DECIMAL(38, 4)));
 
-  ASSERT_TRUE(TypeCoercer::coercible(TINYINT(), DECIMAL(3, 0)));
-  ASSERT_TRUE(TypeCoercer::coercible(SMALLINT(), DECIMAL(5, 0)));
-  ASSERT_TRUE(TypeCoercer::coercible(INTEGER(), DECIMAL(10, 0)));
-  ASSERT_TRUE(TypeCoercer::coercible(BIGINT(), DECIMAL(19, 0)));
+  ASSERT_TRUE(TypeCoercer::defaults().coercible(TINYINT(), DECIMAL(3, 0)));
+  ASSERT_TRUE(TypeCoercer::defaults().coercible(SMALLINT(), DECIMAL(5, 0)));
+  ASSERT_TRUE(TypeCoercer::defaults().coercible(INTEGER(), DECIMAL(10, 0)));
+  ASSERT_TRUE(TypeCoercer::defaults().coercible(BIGINT(), DECIMAL(19, 0)));
 
-  ASSERT_FALSE(TypeCoercer::coercible(TINYINT(), DECIMAL(2, 0)));
-  ASSERT_FALSE(TypeCoercer::coercible(SMALLINT(), DECIMAL(4, 0)));
-  ASSERT_FALSE(TypeCoercer::coercible(INTEGER(), DECIMAL(9, 0)));
-  ASSERT_FALSE(TypeCoercer::coercible(BIGINT(), DECIMAL(18, 0)));
-  ASSERT_FALSE(TypeCoercer::coercible(INTEGER(), DECIMAL(4, 2)));
-  ASSERT_FALSE(TypeCoercer::coercible(BIGINT(), DECIMAL(10, 2)));
+  ASSERT_FALSE(TypeCoercer::defaults().coercible(TINYINT(), DECIMAL(2, 0)));
+  ASSERT_FALSE(TypeCoercer::defaults().coercible(SMALLINT(), DECIMAL(4, 0)));
+  ASSERT_FALSE(TypeCoercer::defaults().coercible(INTEGER(), DECIMAL(9, 0)));
+  ASSERT_FALSE(TypeCoercer::defaults().coercible(BIGINT(), DECIMAL(18, 0)));
+  ASSERT_FALSE(TypeCoercer::defaults().coercible(INTEGER(), DECIMAL(4, 2)));
+  ASSERT_FALSE(TypeCoercer::defaults().coercible(BIGINT(), DECIMAL(10, 2)));
 
-  ASSERT_FALSE(TypeCoercer::coercible(DECIMAL(10, 2), INTEGER()));
-  ASSERT_FALSE(TypeCoercer::coercible(DECIMAL(10, 2), BIGINT()));
+  ASSERT_FALSE(TypeCoercer::defaults().coercible(DECIMAL(10, 2), INTEGER()));
+  ASSERT_FALSE(TypeCoercer::defaults().coercible(DECIMAL(10, 2), BIGINT()));
 }
 
 TEST(TypeCoercerTest, integerToDecimalLeastCommonSuperType) {
   VELOX_ASSERT_EQ_TYPES(
-      TypeCoercer::leastCommonSuperType(INTEGER(), DECIMAL(38, 4)),
+      TypeCoercer::defaults().leastCommonSuperType(INTEGER(), DECIMAL(38, 4)),
       DECIMAL(38, 4));
   VELOX_ASSERT_EQ_TYPES(
-      TypeCoercer::leastCommonSuperType(DECIMAL(38, 4), INTEGER()),
+      TypeCoercer::defaults().leastCommonSuperType(DECIMAL(38, 4), INTEGER()),
       DECIMAL(38, 4));
   VELOX_ASSERT_EQ_TYPES(
-      TypeCoercer::leastCommonSuperType(BIGINT(), DECIMAL(10, 2)),
+      TypeCoercer::defaults().leastCommonSuperType(BIGINT(), DECIMAL(10, 2)),
       DECIMAL(21, 2));
   VELOX_ASSERT_EQ_TYPES(
-      TypeCoercer::leastCommonSuperType(DECIMAL(10, 2), BIGINT()),
+      TypeCoercer::defaults().leastCommonSuperType(DECIMAL(10, 2), BIGINT()),
       DECIMAL(21, 2));
   VELOX_ASSERT_EQ_TYPES(
-      TypeCoercer::leastCommonSuperType(INTEGER(), DECIMAL(4, 2)),
+      TypeCoercer::defaults().leastCommonSuperType(INTEGER(), DECIMAL(4, 2)),
       DECIMAL(12, 2));
   VELOX_ASSERT_EQ_TYPES(
-      TypeCoercer::leastCommonSuperType(SMALLINT(), DECIMAL(4, 2)),
+      TypeCoercer::defaults().leastCommonSuperType(SMALLINT(), DECIMAL(4, 2)),
       DECIMAL(7, 2));
   VELOX_ASSERT_EQ_TYPES(
-      TypeCoercer::leastCommonSuperType(TINYINT(), DECIMAL(10, 4)),
+      TypeCoercer::defaults().leastCommonSuperType(TINYINT(), DECIMAL(10, 4)),
       DECIMAL(10, 4));
   VELOX_ASSERT_EQ_TYPES(
-      TypeCoercer::leastCommonSuperType(BIGINT(), DECIMAL(19, 0)),
+      TypeCoercer::defaults().leastCommonSuperType(BIGINT(), DECIMAL(19, 0)),
       DECIMAL(19, 0));
 
   ASSERT_EQ(
-      TypeCoercer::leastCommonSuperType(BIGINT(), DECIMAL(38, 20)), nullptr);
+      TypeCoercer::defaults().leastCommonSuperType(BIGINT(), DECIMAL(38, 20)),
+      nullptr);
 }
 
 TEST(TypeCoercerTest, decimalDecimalLeastCommonSuperType) {
   VELOX_ASSERT_EQ_TYPES(
-      TypeCoercer::leastCommonSuperType(DECIMAL(10, 2), DECIMAL(20, 4)),
+      TypeCoercer::defaults().leastCommonSuperType(
+          DECIMAL(10, 2), DECIMAL(20, 4)),
       DECIMAL(20, 4));
   VELOX_ASSERT_EQ_TYPES(
-      TypeCoercer::leastCommonSuperType(DECIMAL(20, 2), DECIMAL(10, 4)),
+      TypeCoercer::defaults().leastCommonSuperType(
+          DECIMAL(20, 2), DECIMAL(10, 4)),
       DECIMAL(22, 4));
   VELOX_ASSERT_EQ_TYPES(
-      TypeCoercer::leastCommonSuperType(DECIMAL(38, 4), DECIMAL(38, 4)),
+      TypeCoercer::defaults().leastCommonSuperType(
+          DECIMAL(38, 4), DECIMAL(38, 4)),
       DECIMAL(38, 4));
   VELOX_ASSERT_EQ_TYPES(
-      TypeCoercer::leastCommonSuperType(DECIMAL(10, 2), DECIMAL(10, 2)),
+      TypeCoercer::defaults().leastCommonSuperType(
+          DECIMAL(10, 2), DECIMAL(10, 2)),
       DECIMAL(10, 2));
 }
 
 TEST(TypeCoercerTest, decimalLeastCommonSuperType) {
   VELOX_ASSERT_EQ_TYPES(
-      TypeCoercer::leastCommonSuperType(DECIMAL(10, 2), DOUBLE()), DOUBLE());
+      TypeCoercer::defaults().leastCommonSuperType(DECIMAL(10, 2), DOUBLE()),
+      DOUBLE());
   VELOX_ASSERT_EQ_TYPES(
-      TypeCoercer::leastCommonSuperType(DOUBLE(), DECIMAL(10, 2)), DOUBLE());
+      TypeCoercer::defaults().leastCommonSuperType(DOUBLE(), DECIMAL(10, 2)),
+      DOUBLE());
   VELOX_ASSERT_EQ_TYPES(
-      TypeCoercer::leastCommonSuperType(DECIMAL(10, 2), REAL()), REAL());
+      TypeCoercer::defaults().leastCommonSuperType(DECIMAL(10, 2), REAL()),
+      REAL());
   VELOX_ASSERT_EQ_TYPES(
-      TypeCoercer::leastCommonSuperType(REAL(), DECIMAL(10, 2)), REAL());
+      TypeCoercer::defaults().leastCommonSuperType(REAL(), DECIMAL(10, 2)),
+      REAL());
 }
 
 TEST(TypeCoercerTest, date) {
@@ -156,10 +168,10 @@ TEST(TypeCoercerTest, date) {
 }
 
 TEST(TypeCoercerTest, unknown) {
-  ASSERT_TRUE(TypeCoercer::coercible(UNKNOWN(), BOOLEAN()));
-  ASSERT_TRUE(TypeCoercer::coercible(UNKNOWN(), BIGINT()));
-  ASSERT_TRUE(TypeCoercer::coercible(UNKNOWN(), VARCHAR()));
-  ASSERT_TRUE(TypeCoercer::coercible(UNKNOWN(), ARRAY(INTEGER())));
+  ASSERT_TRUE(TypeCoercer::defaults().coercible(UNKNOWN(), BOOLEAN()));
+  ASSERT_TRUE(TypeCoercer::defaults().coercible(UNKNOWN(), BIGINT()));
+  ASSERT_TRUE(TypeCoercer::defaults().coercible(UNKNOWN(), VARCHAR()));
+  ASSERT_TRUE(TypeCoercer::defaults().coercible(UNKNOWN(), ARRAY(INTEGER())));
 }
 
 TEST(TypeCoercerTest, coerceTypeBaseFromUnknown) {
@@ -178,7 +190,7 @@ TEST(TypeCoercerTest, coerceTypeBaseFromUnknown) {
 TEST(TypeCoercerTest, noCost) {
   auto assertNoCost = [](const TypePtr& type) {
     SCOPED_TRACE(type->toString());
-    auto cost = TypeCoercer::coercible(type, type);
+    auto cost = TypeCoercer::defaults().coercible(type, type);
     ASSERT_TRUE(cost.has_value());
     EXPECT_EQ(cost.value(), 0);
   };
@@ -205,121 +217,181 @@ TEST(TypeCoercerTest, noCost) {
 }
 
 TEST(TypeCoercerTest, array) {
-  ASSERT_TRUE(TypeCoercer::coercible(ARRAY(UNKNOWN()), ARRAY(INTEGER())));
   ASSERT_TRUE(
-      TypeCoercer::coercible(ARRAY(UNKNOWN()), ARRAY(ARRAY(VARCHAR()))));
+      TypeCoercer::defaults().coercible(ARRAY(UNKNOWN()), ARRAY(INTEGER())));
+  ASSERT_TRUE(
+      TypeCoercer::defaults().coercible(
+          ARRAY(UNKNOWN()), ARRAY(ARRAY(VARCHAR()))));
 
-  ASSERT_FALSE(TypeCoercer::coercible(ARRAY(BIGINT()), ARRAY(REAL())));
   ASSERT_FALSE(
-      TypeCoercer::coercible(ARRAY(UNKNOWN()), MAP(INTEGER(), REAL())));
-  ASSERT_FALSE(TypeCoercer::coercible(ARRAY(UNKNOWN()), ROW({UNKNOWN()})));
-  ASSERT_FALSE(TypeCoercer::coercible(ARRAY(VARCHAR()), VARCHAR()));
+      TypeCoercer::defaults().coercible(ARRAY(BIGINT()), ARRAY(REAL())));
+  ASSERT_FALSE(
+      TypeCoercer::defaults().coercible(
+          ARRAY(UNKNOWN()), MAP(INTEGER(), REAL())));
+  ASSERT_FALSE(
+      TypeCoercer::defaults().coercible(ARRAY(UNKNOWN()), ROW({UNKNOWN()})));
+  ASSERT_FALSE(TypeCoercer::defaults().coercible(ARRAY(VARCHAR()), VARCHAR()));
 }
 
 TEST(TypeCoercerTest, map) {
   ASSERT_TRUE(
-      TypeCoercer::coercible(
+      TypeCoercer::defaults().coercible(
           MAP(UNKNOWN(), UNKNOWN()), MAP(INTEGER(), REAL())));
   ASSERT_TRUE(
-      TypeCoercer::coercible(MAP(VARCHAR(), REAL()), MAP(VARCHAR(), DOUBLE())));
+      TypeCoercer::defaults().coercible(
+          MAP(VARCHAR(), REAL()), MAP(VARCHAR(), DOUBLE())));
   ASSERT_TRUE(
-      TypeCoercer::coercible(MAP(INTEGER(), REAL()), MAP(BIGINT(), DOUBLE())));
+      TypeCoercer::defaults().coercible(
+          MAP(INTEGER(), REAL()), MAP(BIGINT(), DOUBLE())));
 
   ASSERT_FALSE(
-      TypeCoercer::coercible(MAP(INTEGER(), REAL()), MAP(BIGINT(), INTEGER())));
+      TypeCoercer::defaults().coercible(
+          MAP(INTEGER(), REAL()), MAP(BIGINT(), INTEGER())));
   ASSERT_FALSE(
-      TypeCoercer::coercible(MAP(UNKNOWN(), UNKNOWN()), ARRAY(BIGINT())));
+      TypeCoercer::defaults().coercible(
+          MAP(UNKNOWN(), UNKNOWN()), ARRAY(BIGINT())));
   ASSERT_FALSE(
-      TypeCoercer::coercible(
+      TypeCoercer::defaults().coercible(
           MAP(UNKNOWN(), UNKNOWN()), ROW({INTEGER(), BIGINT()})));
 }
 
 TEST(TypeCoercerTest, row) {
   ASSERT_TRUE(
-      TypeCoercer::coercible(
+      TypeCoercer::defaults().coercible(
           ROW({UNKNOWN(), INTEGER(), REAL()}),
           ROW({SMALLINT(), BIGINT(), DOUBLE()})));
 
   ASSERT_FALSE(
-      TypeCoercer::coercible(
+      TypeCoercer::defaults().coercible(
           ROW({UNKNOWN(), INTEGER(), REAL()}),
           ROW({SMALLINT(), VARCHAR(), DOUBLE()})));
 
   ASSERT_FALSE(
-      TypeCoercer::coercible(
+      TypeCoercer::defaults().coercible(
           ROW({UNKNOWN(), INTEGER(), REAL()}), ARRAY(INTEGER())));
   ASSERT_FALSE(
-      TypeCoercer::coercible(
+      TypeCoercer::defaults().coercible(
           ROW({UNKNOWN(), INTEGER(), REAL()}), MAP(INTEGER(), REAL())));
   ASSERT_FALSE(
-      TypeCoercer::coercible(
+      TypeCoercer::defaults().coercible(
           ROW({UNKNOWN(), INTEGER(), REAL()}), ROW({UNKNOWN(), INTEGER()})));
   ASSERT_FALSE(
-      TypeCoercer::coercible(ROW({UNKNOWN(), INTEGER(), REAL()}), BIGINT()));
+      TypeCoercer::defaults().coercible(
+          ROW({UNKNOWN(), INTEGER(), REAL()}), BIGINT()));
 }
 
 TEST(TypeCoercerTest, leastCommonSuperType) {
   VELOX_ASSERT_EQ_TYPES(
-      TypeCoercer::leastCommonSuperType(INTEGER(), BIGINT()), BIGINT());
+      TypeCoercer::defaults().leastCommonSuperType(INTEGER(), BIGINT()),
+      BIGINT());
 
   VELOX_ASSERT_EQ_TYPES(
-      TypeCoercer::leastCommonSuperType(ARRAY(INTEGER()), ARRAY(TINYINT())),
+      TypeCoercer::defaults().leastCommonSuperType(
+          ARRAY(INTEGER()), ARRAY(TINYINT())),
       ARRAY(INTEGER()));
 
   VELOX_ASSERT_EQ_TYPES(
-      TypeCoercer::leastCommonSuperType(
+      TypeCoercer::defaults().leastCommonSuperType(
           MAP(TINYINT(), DOUBLE()), MAP(INTEGER(), REAL())),
       MAP(INTEGER(), DOUBLE()));
 
   VELOX_ASSERT_EQ_TYPES(
-      TypeCoercer::leastCommonSuperType(
+      TypeCoercer::defaults().leastCommonSuperType(
           ROW({TINYINT(), DOUBLE()}), ROW({INTEGER(), REAL()})),
       ROW({INTEGER(), DOUBLE()}));
 
   VELOX_ASSERT_EQ_TYPES(
-      TypeCoercer::leastCommonSuperType(
+      TypeCoercer::defaults().leastCommonSuperType(
           ROW({"", "", ""}, INTEGER()), ROW({"", "", ""}, SMALLINT())),
       ROW({"", "", ""}, INTEGER()));
 
   VELOX_ASSERT_EQ_TYPES(
-      TypeCoercer::leastCommonSuperType(
+      TypeCoercer::defaults().leastCommonSuperType(
           ROW({"a", "b", "c"}, INTEGER()), ROW({"a", "b", "c"}, SMALLINT())),
       ROW({"a", "b", "c"}, INTEGER()));
 
   VELOX_ASSERT_EQ_TYPES(
-      TypeCoercer::leastCommonSuperType(
+      TypeCoercer::defaults().leastCommonSuperType(
           ROW({"", "", ""}, INTEGER()), ROW({"a", "b", "c"}, SMALLINT())),
       ROW({"", "", ""}, INTEGER()));
 
   VELOX_ASSERT_EQ_TYPES(
-      TypeCoercer::leastCommonSuperType(
+      TypeCoercer::defaults().leastCommonSuperType(
           ROW({"a", "bb", ""}, INTEGER()), ROW({"a", "b", "c"}, SMALLINT())),
       ROW({"a", "", ""}, INTEGER()));
 
   ASSERT_TRUE(
-      TypeCoercer::leastCommonSuperType(VARCHAR(), TINYINT()) == nullptr);
-
-  ASSERT_TRUE(
-      TypeCoercer::leastCommonSuperType(ARRAY(TINYINT()), TINYINT()) ==
+      TypeCoercer::defaults().leastCommonSuperType(VARCHAR(), TINYINT()) ==
       nullptr);
 
   ASSERT_TRUE(
-      TypeCoercer::leastCommonSuperType(ARRAY(TINYINT()), ARRAY(VARCHAR())) ==
-      nullptr);
+      TypeCoercer::defaults().leastCommonSuperType(
+          ARRAY(TINYINT()), TINYINT()) == nullptr);
 
   ASSERT_TRUE(
-      TypeCoercer::leastCommonSuperType(
+      TypeCoercer::defaults().leastCommonSuperType(
+          ARRAY(TINYINT()), ARRAY(VARCHAR())) == nullptr);
+
+  ASSERT_TRUE(
+      TypeCoercer::defaults().leastCommonSuperType(
           ROW({""}, TINYINT()), ROW({"", ""}, TINYINT())) == nullptr);
 
   ASSERT_TRUE(
-      TypeCoercer::leastCommonSuperType(
+      TypeCoercer::defaults().leastCommonSuperType(
           MAP(INTEGER(), REAL()), ROW({INTEGER(), REAL()})) == nullptr);
 }
 
 TEST(TypeCoercerTest, parametricBuiltinTargetDoesNotThrow) {
   // Parametric built-in factories throw on empty params. Verify graceful
   // handling.
-  EXPECT_EQ(TypeCoercer::coerceTypeBase(BIGINT(), "ARRAY"), std::nullopt);
+  EXPECT_EQ(
+      TypeCoercer::defaults().coerceTypeBase(BIGINT(), "ARRAY"), std::nullopt);
+}
+
+TEST(TypeCoercerTest, ctorRejectsDuplicateCostForSameSource) {
+  VELOX_ASSERT_THROW(
+      TypeCoercer({{INTEGER(), BIGINT(), 1}, {INTEGER(), DOUBLE(), 1}}),
+      "Duplicate cost 1 for source type INTEGER");
+}
+
+TEST(TypeCoercerTest, ctorRejectsNullEntries) {
+  VELOX_ASSERT_THROW(
+      TypeCoercer({{nullptr, BIGINT(), 1}}),
+      "CoercionEntry.from must not be null");
+  VELOX_ASSERT_THROW(
+      TypeCoercer({{INTEGER(), nullptr, 1}}),
+      "CoercionEntry.to must not be null");
+}
+
+TEST(TypeCoercerTest, ctorRejectsDecimalToDecimal) {
+  // DECIMAL -> DECIMAL is hardcoded in the type system; rule entries
+  // wouldn't be honored, so reject them at construction.
+  VELOX_ASSERT_THROW(
+      TypeCoercer({{DECIMAL(1, 0), DECIMAL(20, 4), 1}}),
+      "DECIMAL -> DECIMAL coercion is not customizable");
+}
+
+TEST(TypeCoercerTest, ctorRejectsNonCanonicalSourceDecimal) {
+  // Source DECIMAL must be the canonical placeholder DECIMAL(1, 0).
+  VELOX_ASSERT_THROW(
+      TypeCoercer({{DECIMAL(10, 2), DOUBLE(), 1}}),
+      "Source DECIMAL in CoercionEntry must be DECIMAL(1, 0)");
+
+  // The canonical placeholder is accepted.
+  EXPECT_NO_THROW(TypeCoercer({{DECIMAL(1, 0), DOUBLE(), 1}}));
+}
+
+TEST(TypeCoercerTest, ctorRejectsDuplicateRule) {
+  // Plain duplicate (same source -> same target name).
+  VELOX_ASSERT_THROW(
+      TypeCoercer({{INTEGER(), BIGINT(), 1}, {INTEGER(), BIGINT(), 2}}),
+      "Duplicate coercion rule INTEGER -> BIGINT");
+
+  // DECIMAL footgun: both rules collide on map key (TINYINT, DECIMAL).
+  VELOX_ASSERT_THROW(
+      TypeCoercer(
+          {{TINYINT(), DECIMAL(3, 0), 1}, {TINYINT(), DECIMAL(10, 2), 2}}),
+      "Duplicate coercion rule TINYINT -> DECIMAL");
 }
 
 } // namespace


### PR DESCRIPTION
Summary:

Velox's coercion rules don't match Presto. Presto allows `BIGINT -> REAL`, Velox doesn't. So `select typeof(real '1' / bigint '2')` returns `real` in Presto but `double` in Axiom (which uses Velox's coercion). The same root cause affects all REAL/BIGINT arithmetic, comparisons, `IN`, `CASE`, `COALESCE`, set operations, and `JOIN USING`.

Before this change, Velox's `TypeCoercer` had a single hard-coded rule set with no per-dialect customization. This change makes coercion rules customizable: a SQL dialect can ship its own complete rule set that matches its semantics, without modifying Velox's defaults and without colliding with other dialects in the same process.

`TypeCoercer` is now an instance class that owns a complete `CoercionEntry` rule set. Velox ships `TypeCoercer::defaults()` holding today's lossless built-in rules. Each SQL dialect ships its own complete instance. This change adds Presto's: `velox::functions::prestosql::typeCoercer()`, the Velox defaults plus `BIGINT -> REAL`. Rule sets are flat per-dialect (no live mixing, no layering): cost numbers are only meaningful inside a single rule set.

Constructor validates that:

- entries are non-null;
- both source and target are built-in types (custom-type coercions remain in `CastRulesRegistry`);
- source DECIMAL is the canonical placeholder `DECIMAL(1, 0)`;
- no `DECIMAL -> DECIMAL` entries (handled by the type system);
- cost is unique per source type;
- no duplicate `(fromName, toName)` keys.

The Velox-side resolution API (`SignatureBinder`, `resolveFunction*WithCoercions`, `SwitchExpr`/`CoalesceExpr` planning helpers) gains `const TypeCoercer& coercer = TypeCoercer::defaults()` as a tail parameter so Velox-internal callers compile unchanged. The downstream Axiom integration -- threading the dialect coercer through `PlanBuilder::Context` and wiring `presto::typeCoercer()` in `PrestoParser` -- lands as a follow-up.

Coercion is a planning-time concern. Runtime expression evaluators (`Expr` ctors, `ExprCompiler`) do not consult `TypeCoercer` and are unchanged.

`velox/docs/develop/types.rst` adds a new "Type Coercion" section covering the `TypeCoercer` mechanism, customization scope, `coerceTypeBase` vs `coercible`, the default-rules table, the Presto-specific additions, and the 2-step DECIMAL handling per case.

# Breaking Changes

There are no static back-compat wrappers. Consumers that called the old static methods (`velox::TypeCoercer::coercible(...)`, `velox::TypeCoercer::leastCommonSuperType(...)`, etc.) will fail to compile until they are updated to invoke the instance API on a `TypeCoercer&` -- typically `TypeCoercer::defaults().coercible(...)` for callers that don't have a dialect coercer.

bypass-github-export-checks

Reviewed By: xiaoxmeng

Differential Revision: D105206605
