### PR TITLE
Fix HashTableCache poisoned executor: drop cache entry on builder failure

### DIFF
--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -217,7 +217,9 @@ bool HashBuild::receivedCachedHashTable() {
   // Ensure that table is ready.
   VELOX_CHECK(
       cacheEntry_->buildComplete,
-      "Signalled that cache table is ready but it is not built yet.");
+      "Hash table cache build failed for key '{}'. "
+      "The builder task may have encountered an error (e.g., OOM).",
+      cacheKey_);
   // Proceed through normal noMoreInput flow which will use the cache.
   setRunning();
   noMoreInput();
@@ -1423,6 +1425,11 @@ bool HashBuild::nonReclaimableState() const {
 
 void HashBuild::close() {
   Operator::close();
+
+  if (useHashTableCache() && cacheEntry_ != nullptr &&
+      !cacheEntry_->buildComplete && hashTableCacheBuilderTask()) {
+    HashTableCache::instance()->drop(cacheKey_);
+  }
 
   {
     // Free up major memory usage. Gate access to them as they can be accessed

--- a/velox/exec/HashTableCache.cpp
+++ b/velox/exec/HashTableCache.cpp
@@ -118,6 +118,7 @@ void HashTableCache::put(
 
 void HashTableCache::drop(const std::string& key) {
   std::shared_ptr<HashTableCacheEntry> entry;
+  std::vector<ContinuePromise> promises;
   {
     std::lock_guard<std::mutex> guard(lock_);
     auto it = tables_.find(key);
@@ -131,7 +132,14 @@ void HashTableCache::drop(const std::string& key) {
   // is destroyed. This ensures the tablePool's memory is released
   // before any parent pools are destroyed.
   if (entry) {
+    promises = std::move(entry->buildPromises);
     entry->table.reset();
+  }
+
+  // Fulfill any pending build promises so waiting tasks are unblocked
+  // rather than hanging forever (e.g., after builder OOM).
+  for (auto& promise : promises) {
+    promise.setValue();
   }
 }
 

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -129,6 +129,7 @@ set(
   TableScanTest.cpp
   AggregationTest.cpp
   OrderByTest.cpp
+  HashTableCacheTest.cpp
   HashTableTest.cpp
   RowNumberTest.cpp
   UnnestTest.cpp

--- a/velox/exec/tests/HashTableCacheTest.cpp
+++ b/velox/exec/tests/HashTableCacheTest.cpp
@@ -222,4 +222,55 @@ TEST_F(HashTableCacheTest, builderTaskDriversDoNotWait) {
   EXPECT_FALSE(future2.valid());
 }
 
+// Verifies that when the builder task fails (e.g., OOM in finishHashBuild()),
+// dropping the cache entry unblocks all waiting tasks and allows new tasks
+// to become builders.
+TEST_F(HashTableCacheTest, builderFailureUnblocksWaiters) {
+  auto* cache = HashTableCache::instance();
+  const std::string key = "query_oom:node1";
+
+  // Builder task gets the entry.
+  ContinueFuture builderFuture = ContinueFuture::makeEmpty();
+  auto builderEntry =
+      cache->get(key, "builder_task", queryCtx_.get(), &builderFuture);
+  ASSERT_FALSE(builderFuture.valid());
+
+  // Two waiter tasks arrive while builder is working.
+  ContinueFuture waiterFuture1 = ContinueFuture::makeEmpty();
+  cache->get(key, "waiter_task_1", queryCtx_.get(), &waiterFuture1);
+  ASSERT_TRUE(waiterFuture1.valid());
+
+  ContinueFuture waiterFuture2 = ContinueFuture::makeEmpty();
+  cache->get(key, "waiter_task_2", queryCtx_.get(), &waiterFuture2);
+  ASSERT_TRUE(waiterFuture2.valid());
+
+  // Simulate builder task failure: close() now calls drop() when the builder
+  // fails without completing the build.
+  cache->drop(key);
+  builderEntry.reset();
+
+  // Both waiters should be unblocked.
+  EXPECT_TRUE(waiterFuture1.isReady())
+      << "Pre-existing waiter should be unblocked after builder failure";
+  EXPECT_TRUE(waiterFuture2.isReady())
+      << "Second waiter should also be unblocked after builder failure";
+
+  // A new task arriving after drop should become a fresh builder.
+  auto pool2 = memory::memoryManager()->addRootPool("HashTableCacheTest_retry");
+  auto queryCtx2 = core::QueryCtx::create(
+      nullptr,
+      core::QueryConfig{{}},
+      {},
+      cache::AsyncDataCache::getInstance(),
+      pool2);
+  ContinueFuture newFuture = ContinueFuture::makeEmpty();
+  auto newEntry = cache->get(key, "new_builder", queryCtx2.get(), &newFuture);
+  EXPECT_FALSE(newFuture.valid())
+      << "New task after drop should become builder, not waiter";
+  EXPECT_EQ(newEntry->builderTaskId, "new_builder");
+  EXPECT_FALSE(newEntry->buildComplete);
+
+  cache->drop(key);
+}
+
 } // namespace facebook::velox::exec::test


### PR DESCRIPTION
Summary:
When a HashBuild builder task fails (e.g., OOM in finishHashBuild()) before calling HashTableCache::put(), the cache entry persists with buildComplete=false and unfulfilled ContinuePromises. This causes all subsequent tasks landing on the same executor to hang forever in kWaitForBuild state with 0B allocated memory, until the driver times out (exit_code=254). This was observed in spark3_full_shadow verifier jobs where entire jobs got stuck for 9+ hours.

The fix has two parts:

1. HashBuild::close(): When the builder task closes without completing the build, call HashTableCache::drop() to remove the poisoned cache entry. This is gated on: caching is enabled, this is the builder task, and buildComplete is still false.

2. HashTableCache::drop(): Fulfill any pending buildPromises before erasing the entry, so waiting tasks are unblocked instead of hanging forever. Waiters wake up and fail with a clear error via the existing VELOX_CHECK in receivedCachedHashTable().

Also updates the error message in receivedCachedHashTable() to include the cache key and mention possible OOM cause, and converts the builderFailureLeavesWaitersStuck test to verify the fix instead of documenting the bug.

Differential Revision: D105165613


