### PR TITLE
fix: FloatingPointRange::mergeWith for MultiRange and singleton ranges (#17523)

### DIFF
--- a/velox/type/Filter.h
+++ b/velox/type/Filter.h
@@ -1696,6 +1696,7 @@ class FloatingPointRange final : public AbstractRange {
       case FilterKind::kAlwaysTrue:
       case FilterKind::kAlwaysFalse:
       case FilterKind::kIsNull:
+      case FilterKind::kMultiRange:
         return other->mergeWith(this);
       case FilterKind::kIsNotNull:
         return std::make_unique<FloatingPointRange<T>>(
@@ -1725,7 +1726,8 @@ class FloatingPointRange final : public AbstractRange {
         auto upperExclusive = !bothUpperUnbounded &&
             (!testDouble(upper) || !other->testDouble(upper));
 
-        if (lower > upper || (lower == upper && lowerExclusive_)) {
+        if (lower > upper ||
+            (lower == upper && (lowerExclusive || upperExclusive))) {
           if (bothNullAllowed) {
             return std::make_unique<IsNull>();
           }

--- a/velox/type/tests/FilterTest.cpp
+++ b/velox/type/tests/FilterTest.cpp
@@ -1514,6 +1514,19 @@ void testMergeWithFloat(Filter* left, Filter* right) {
     float f = i * 0.1;
     ASSERT_EQ(merged->testFloat(f), left->testFloat(f) && right->testFloat(f));
   }
+  for (float f : {
+           -3.4f,
+           -1.2f,
+           -0.5f,
+           0.5f,
+           1.2f,
+           2.0f,
+           2.5f,
+           3.4f,
+           std::numeric_limits<float>::quiet_NaN(),
+       }) {
+    ASSERT_EQ(merged->testFloat(f), left->testFloat(f) && right->testFloat(f));
+  }
 }
 
 void testMergeWithBytes(Filter* left, Filter* right) {
@@ -1940,6 +1953,10 @@ TEST(FilterTest, mergeMultiRange) {
       orFilter(lessThanOrEqualFloat(1.2), greaterThanOrEqualFloat(3.4)));
   filters.push_back(
       orFilter(lessThanOrEqualFloat(1.2), greaterThanOrEqualFloat(3.4), true));
+
+  filters.push_back(lessThanFloat(2.0));
+  filters.push_back(greaterThanOrEqualFloat(0.5));
+  filters.push_back(betweenFloat(-0.5, 2.5));
 
   for (const auto& left : filters) {
     for (const auto& right : filters) {


### PR DESCRIPTION
Summary:

`FloatingPointRange<T>::mergeWith` had two correctness bugs:

1. Falls through to `VELOX_UNREACHABLE` against `MultiRange`, the canonical encoding of OR-composed predicates and `<>` on floating-point columns. The reverse direction at `Filter.cpp:1494` is implemented, so the crash depended on conjunct ordering during filter distribution. Delegate `kMultiRange` to `other->mergeWith(this)`, mirroring `kAlwaysTrue` / `kAlwaysFalse` / `kIsNull`. `BigintRange::mergeWith` already does this for `kBigintMultiRange`.

2. Singleton-point intersections like `(-inf, 1.2] ∩ [1.2, +inf)` collapsed to `AlwaysFalse`. The early-return at `Filter.h:1729` checked `this->lowerExclusive_` (set to `true` by convention when lower is unbounded) instead of the locally-computed merged exclusivity, and ignored upper exclusivity. Switch to `(lowerExclusive || upperExclusive)` using the local values.

Reviewed By: Yuhta

Differential Revision: D104925281


