### PR TITLE
docs: Add PR review scripts and style guide

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,9 +2,42 @@
 
 Guidance for Claude Code when working in the Velox repository.
 
+## Branch Hygiene
+
+Before creating a new feature branch, always:
+
+1. `git checkout main`
+2. `git fetch upstream && git rebase upstream/main`
+3. Delete stale feature branches.
+4. Push main to origin if behind upstream.
+5. `git checkout -b <new-branch>`
+
 ## PR Review
 
 When asked to review a PR (via `/pr-review`), always use the /pr-review skill.
+
+### Review scripts
+
+Use `scripts/review/fetch.py` and `scripts/review/post.py` for PR reviews
+instead of raw `gh api` calls.
+
+```bash
+# Fetch PR metadata, diff, comments, and reviews in one shot.
+python3 scripts/review/fetch.py <owner/repo> <pr-number>
+python3 scripts/review/fetch.py <github-pr-url>
+
+# Post a review from a file.
+python3 scripts/review/post.py <owner/repo> <pr-number> <event> <body-file>
+python3 scripts/review/post.py <github-pr-url> <event> <body-file>
+# Events: APPROVE, REQUEST_CHANGES, COMMENT
+```
+
+Always draft the review body in `/tmp/` and get approval before calling
+`post.py`.
+
+### Review style
+
+See [scripts/review/REVIEW_GUIDE.md](../scripts/review/REVIEW_GUIDE.md).
 
 ## Queries
 

--- a/scripts/review/REVIEW_GUIDE.md
+++ b/scripts/review/REVIEW_GUIDE.md
@@ -1,0 +1,106 @@
+# PR Review Style Guide
+
+## Procedure
+
+1. Fetch PR using `scripts/review/fetch.py`. This is the only fetch needed —
+   work from its output for all subsequent analysis. Do not make additional
+   `gh api` or `gh pr diff` calls.
+2. Draft review to `~/.claude/review-drafts/pr-XXXXX-r1-v1.md`.
+3. Show draft and get approval before posting.
+4. Post using `scripts/review/post.py`.
+
+## First rule
+
+Before writing anything, ask: "Do I understand what this PR does end-to-end,
+and have I verified the claims?" If the answer is no, dig deeper before
+drafting. The most common mistake is focusing on code details before
+understanding the change.
+
+## Tone
+
+- **Opening:** "Thank you for the fix/contribution!" — then straight to the
+  points. Don't elaborate on what the PR does or praise specific design choices.
+- **Don't restate the PR description.** The author knows what they wrote.
+- **Skip "Thank you" when the PR needs fundamental clarification.** Lead with
+  the question instead.
+- **Be extra respectful when asking contributors to engage upstream.** They're
+  volunteering their time. Suggest filing an issue first — it shows respect for
+  upstream maintainers' expertise.
+- **Be encouraging with new contributors.** Acknowledge the value of the
+  capability they're adding.
+
+## Structure
+
+- Reviews should be concise and actionable. The author wants to get their work
+  done — don't waste their time with fluff.
+- **Order: big picture first.** Documentation, design questions, then code,
+  then tests. The most impactful feedback should come first.
+- **Every point must be actionable.** No observations without asks. If it
+  doesn't require the author to change something, don't include it.
+- **Drop qualifiers when the fix is obvious.** Don't explain why something is
+  wrong if the fix is self-evident.
+
+## Rigor
+
+- **Verify before claiming.** Don't assert facts about the codebase, other
+  projects, or behavior without checking. When in doubt, read the code.
+- **Verify author claims.** When an author says an API doesn't support
+  something, or references another PR/diff/external behavior, check the source.
+  Don't accept at face value.
+- **Check terminology.** Use precise terms. Don't conflate catalog/connector,
+  function/method, etc.
+
+## Re-reviews
+
+When the author says "addressed comments", re-review the full diff — don't
+just check the boxes from the previous round. Docs, naming, design choices,
+and new code added while addressing feedback all need fresh eyes.
+
+## What to check
+
+### Correctness
+
+- **PR title and description.** Are they clear, succinct, accurate? Does the
+  title describe what changed (not the symptom)? Does the description match
+  what the code actually does?
+- **CI status.** Is CI green? If red, is it related to the PR or pre-existing?
+- **Design.** Question design choices, don't just document them. Flag
+  surprising behavior (e.g., auto-selection), unnecessary complexity, or
+  features that could be simpler.
+- **API design.** Flag anti-patterns: setter injection when constructor params
+  would work, bypassing existing methods with inline boilerplate, unnecessary
+  type aliases. When a PR adds API surface for an external consumer, question
+  the consumer's architecture — "why does the caller need this?" matters more
+  than "what's the cleanest way to expose it?"
+- **Registries.** New registries should follow existing patterns (e.g.,
+  query-scoped registries design in #16993).
+
+### Code quality
+
+- **Velox coding conventions.** Ensure code follows
+  [CODING_STYLE.md](../../CODING_STYLE.md) and the rules in
+  [.claude/CLAUDE.md](../../.claude/CLAUDE.md).
+- **Comments.** Flag verbose code comments that restate the code, duplicate
+  docs elsewhere, or explain obvious behavior. Remove references to other
+  implementations ("like Java Presto") — logic should stand on its own.
+- **Naming.** Check variable names, file names, class names against coding
+  style conventions. Do not abbreviate parameter names.
+- **Enums.** `kPascalCase` enumerators, trailing commas, `VELOX_DEFINE_ENUM_NAME`.
+
+### Testing
+
+- **Tests.** Are they sufficient? Do they reproduce the bug? Is there an
+  integration test, not just a unit test? Are expected values hand-computed
+  (fragile) or derived from the test input? Are test helpers used to reduce
+  duplication? Do test names follow conventions?
+- **Test files.** Each test file should have one test suite with a matching
+  name. Empty test fixtures should use `TEST()` instead of `TEST_F()`.
+
+### Documentation
+
+- Are new functions/features documented? Are docs updated for changed behavior?
+  Are README changes accurate (not removing still-valid content)?
+- Check if **existing** doc pages need updating — e.g., a change to plan output
+  may require updating the print-plan-with-stats page, a dependency version
+  bump may require updating the dependency table.
+- **When unsure about conventions**, CC the maintainer rather than guessing.

--- a/scripts/review/fetch.py
+++ b/scripts/review/fetch.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fetch all review-relevant information for a GitHub PR in one shot.
+
+Usage: fetch.py <owner/repo> <pr-number>
+       fetch.py <github-pr-url>
+
+Examples:
+    fetch.py facebookincubator/velox 17495
+    fetch.py https://github.com/facebookincubator/velox/pull/17495
+"""
+
+import json
+import re
+import subprocess
+import sys
+
+
+def run_gh(*args):
+    result = subprocess.run(["gh"] + list(args), capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"Error: {result.stderr.strip()}", file=sys.stderr)
+        return None
+    return result.stdout.strip()
+
+
+def parse_args():
+    if len(sys.argv) == 2:
+        match = re.match(r"https?://github\.com/([^/]+/[^/]+)/pull/(\d+)", sys.argv[1])
+        if match:
+            return match.group(1), match.group(2)
+        print(f"Invalid URL: {sys.argv[1]}", file=sys.stderr)
+        sys.exit(1)
+    elif len(sys.argv) == 3:
+        return sys.argv[1], sys.argv[2]
+    else:
+        print(__doc__.strip(), file=sys.stderr)
+        sys.exit(1)
+
+
+def fetch_pr_metadata(repo, pr):
+    raw = run_gh(
+        "pr",
+        "view",
+        pr,
+        "--repo",
+        repo,
+        "--json",
+        "title,body,author,state,files,additions,deletions,baseRefName,headRefName",
+    )
+    if not raw:
+        return None
+    return json.loads(raw)
+
+
+def fetch_diff(repo, pr):
+    return run_gh("pr", "diff", pr, "--repo", repo)
+
+
+def fetch_issue_comments(repo, pr):
+    raw = run_gh(
+        "api",
+        f"repos/{repo}/issues/{pr}/comments",
+        "--paginate",
+    )
+    if not raw:
+        return []
+    return json.loads(raw)
+
+
+def fetch_review_comments(repo, pr):
+    raw = run_gh(
+        "api",
+        f"repos/{repo}/pulls/{pr}/comments",
+        "--paginate",
+    )
+    if not raw:
+        return []
+    return json.loads(raw)
+
+
+def fetch_reviews(repo, pr):
+    raw = run_gh(
+        "api",
+        f"repos/{repo}/pulls/{pr}/reviews",
+    )
+    if not raw:
+        return []
+    return json.loads(raw)
+
+
+def print_section(title, content):
+    print(f"\n{'=' * 60}")
+    print(f" {title}")
+    print(f"{'=' * 60}\n")
+    print(content)
+
+
+def main():
+    repo, pr = parse_args()
+
+    metadata = fetch_pr_metadata(repo, pr)
+    if not metadata:
+        sys.exit(1)
+
+    print_section(
+        f"PR #{pr}: {metadata['title']}",
+        f"Author: {metadata['author']['login']}\n"
+        f"State: {metadata['state']}\n"
+        f"Branch: {metadata['headRefName']} -> {metadata['baseRefName']}\n"
+        f"+{metadata['additions']} -{metadata['deletions']}\n"
+        f"Files: {', '.join(f['path'] for f in metadata['files'])}\n"
+        f"\n{metadata['body']}",
+    )
+
+    diff = fetch_diff(repo, pr)
+    if diff:
+        print_section("Diff", diff)
+
+    skip = {"netlify[bot]", "github-actions[bot]"}
+
+    comments = fetch_issue_comments(repo, pr)
+    visible = [c for c in comments if c["user"]["login"] not in skip]
+    if visible:
+        lines = []
+        for c in visible:
+            lines.append(f"--- {c['user']['login']} ({c['created_at']}) ---")
+            lines.append(c["body"])
+            lines.append("")
+        print_section("Comments", "\n".join(lines))
+
+    reviews = fetch_reviews(repo, pr)
+    visible_reviews = [r for r in reviews if r.get("body")]
+    if visible_reviews:
+        lines = []
+        for r in visible_reviews:
+            lines.append(
+                f"--- {r['user']['login']} ({r['state']}, {r['submitted_at']}) ---"
+            )
+            lines.append(r["body"])
+            lines.append("")
+        print_section("Reviews", "\n".join(lines))
+
+    inline = fetch_review_comments(repo, pr)
+    if inline:
+        lines = []
+        for c in inline:
+            loc = f"{c['path']}:{c.get('line', c.get('original_line', '?'))}"
+            lines.append(f"--- {c['user']['login']} on {loc} ({c['created_at']}) ---")
+            lines.append(c["body"])
+            lines.append("")
+        print_section("Inline Comments", "\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/review/post.py
+++ b/scripts/review/post.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Post a GitHub PR review from a file.
+
+Usage: post.py <owner/repo> <pr-number> <event> <body-file>
+       post.py <github-pr-url> <event> <body-file>
+
+Events: APPROVE, REQUEST_CHANGES, COMMENT
+
+Examples:
+    post.py facebookincubator/velox 17495 REQUEST_CHANGES /tmp/review.md
+    post.py https://github.com/facebookincubator/velox/pull/17495 APPROVE /tmp/review.md
+"""
+
+import json
+import re
+import subprocess
+import sys
+
+VALID_EVENTS = {"APPROVE", "REQUEST_CHANGES", "COMMENT"}
+
+
+def run_gh(*args, stdin=None):
+    result = subprocess.run(
+        ["gh"] + list(args),
+        input=stdin,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(f"Error: {result.stderr.strip()}", file=sys.stderr)
+        sys.exit(1)
+    return result.stdout.strip()
+
+
+def parse_args():
+    if len(sys.argv) == 4:
+        match = re.match(r"https?://github\.com/([^/]+/[^/]+)/pull/(\d+)", sys.argv[1])
+        if match:
+            return match.group(1), match.group(2), sys.argv[2], sys.argv[3]
+        print(f"Invalid URL: {sys.argv[1]}", file=sys.stderr)
+        sys.exit(1)
+    elif len(sys.argv) == 5:
+        return sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+    else:
+        print(__doc__.strip(), file=sys.stderr)
+        sys.exit(1)
+
+
+def main():
+    repo, pr, event, body_file = parse_args()
+
+    event = event.upper()
+    if event not in VALID_EVENTS:
+        print(
+            f"Invalid event: {event}. Must be one of: {', '.join(sorted(VALID_EVENTS))}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    with open(body_file) as f:
+        body = f.read()
+
+    if not body.strip():
+        print("Error: review body is empty", file=sys.stderr)
+        sys.exit(1)
+
+    payload = json.dumps({"event": event, "body": body, "comments": []})
+
+    result = run_gh(
+        "api",
+        f"repos/{repo}/pulls/{pr}/reviews",
+        "--method",
+        "POST",
+        "--input",
+        "-",
+        stdin=payload,
+    )
+
+    data = json.loads(result)
+    print(data.get("html_url", "Review submitted"))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Streamline the PR review workflow by reducing the number of manual commands and permission prompts needed to fetch PR data and post reviews. The style guide captures review conventions developed over many review iterations.

Add scripts and a style guide for PR reviews:

- `scripts/review/fetch.py` — fetches PR metadata, diff, comments, and reviews in one shot
- `scripts/review/post.py` — posts a review from a file (handles multiline bodies cleanly)
- `scripts/review/REVIEW_GUIDE.md` — review style guide covering tone, structure, and what to check

