### PR TITLE
Add reallocateBytes to MemoryAllocator to avoid unnecessary memcpy (#17525)

### DIFF
--- a/velox/common/memory/MallocAllocator.cpp
+++ b/velox/common/memory/MallocAllocator.cpp
@@ -335,6 +335,61 @@ void* MallocAllocator::allocateZeroFilledWithoutRetry(uint64_t bytes) {
   return result;
 }
 
+void* MallocAllocator::reallocateBytesWithoutRetry(
+    void* p,
+    uint64_t oldSize,
+    uint64_t newSize,
+    uint16_t alignment) {
+  if (p == nullptr || alignment > kMinAlignment ||
+      (reinterpret_cast<uintptr_t>(p) % alignment) != 0) {
+    return nullptr;
+  }
+  if (!isAlignmentValid(newSize, alignment)) {
+    VELOX_FAIL(
+        "Alignment check failed, reallocateBytes {}, alignmentBytes {}",
+        newSize,
+        alignment);
+  }
+  const auto delta =
+      static_cast<int64_t>(newSize) - static_cast<int64_t>(oldSize);
+  if (delta > 0 && !incrementUsage(delta)) {
+    auto errorMsg = fmt::format(
+        "Failed to reallocate: exceeded memory allocator limit of {}. "
+        "Old size: {}, new size: {}",
+        succinctBytes(capacity_),
+        succinctBytes(oldSize),
+        succinctBytes(newSize));
+    VELOX_MEM_LOG_EVERY_MS(WARNING, 1000) << errorMsg;
+    setAllocatorFailureMessage(errorMsg);
+    return nullptr;
+  }
+  void* result = ::realloc(p, newSize); // NOLINT
+  if (result == nullptr) {
+    // realloc failed. The original pointer is still valid.
+    if (delta > 0) {
+      decrementUsage(delta);
+    }
+    VELOX_MEM_LOG(ERROR) << "Failed to reallocateBytes from "
+                         << succinctBytes(oldSize) << " to "
+                         << succinctBytes(newSize);
+    return nullptr;
+  }
+  // ::realloc() must return a pointer aligned to the requested alignment.
+  // The C standard guarantees alignof(max_align_t), and we already enforced
+  // alignment <= kMinAlignment above, so this should always hold for a
+  // conformant allocator. Fail loudly if it doesn't (e.g., a non-conformant
+  // LD_PRELOAD interposer).
+  VELOX_CHECK_EQ(
+      reinterpret_cast<uintptr_t>(result) % alignment,
+      0,
+      "::realloc returned a pointer not aligned to requested alignment: {}",
+      alignment);
+  if (delta < 0) {
+    decrementUsage(-delta);
+  }
+  return result;
+}
+
 void MallocAllocator::freeBytes(void* p, uint64_t bytes) noexcept {
   ::free(p); // NOLINT
   decrementUsage(bytes);

--- a/velox/common/memory/MallocAllocator.h
+++ b/velox/common/memory/MallocAllocator.h
@@ -117,6 +117,25 @@ class MallocAllocator : public MemoryAllocator {
 
   void* allocateZeroFilledWithoutRetry(uint64_t bytes) override;
 
+  /// Attempts in-place reallocation via ::realloc(). Returns nullptr when
+  /// ::realloc() cannot satisfy the request, in which case the caller falls
+  /// back to allocate + memcpy + free. Preconditions for using ::realloc():
+  /// 1. p must be non-null. ::realloc(nullptr, n) would behave like malloc,
+  ///    but we route nullptr through allocateBytes so the caller picks up
+  ///    cache eviction on the fallback.
+  /// 2. The requested alignment must be at most kMinAlignment. ::realloc()
+  ///    guarantees only kMinAlignment on the returned pointer (and may move
+  ///    the data to a new address), so larger alignments cannot be honored.
+  /// 3. p must already be aligned to the requested alignment. MemoryAllocator
+  ///    is a standalone module that may be used outside MemoryPool, so we
+  ///    cannot rely on the caller to pass an alignment matching the original
+  ///    allocation.
+  void* reallocateBytesWithoutRetry(
+      void* p,
+      uint64_t oldSize,
+      uint64_t newSize,
+      uint16_t alignment) override;
+
   // Increments current usage and check current 'allocatedBytes_' counter to
   // make sure current usage does not go above 'capacity_'. If it goes above
   // 'capacity_', the increment will not be applied. Returns true if within

--- a/velox/common/memory/MemoryAllocator.cpp
+++ b/velox/common/memory/MemoryAllocator.cpp
@@ -18,6 +18,8 @@
 
 #include <sys/mman.h>
 #include <sys/resource.h>
+#include <algorithm>
+#include <cstring>
 #include <iostream>
 #include <numeric>
 
@@ -373,6 +375,40 @@ void* MemoryAllocator::allocateZeroFilledWithoutRetry(uint64_t bytes) {
     ::memset(result, 0, bytes);
   }
   return result;
+}
+
+void* MemoryAllocator::reallocateBytes(
+    void* p,
+    uint64_t oldSize,
+    uint64_t newSize,
+    uint16_t alignment) {
+  // Try in-place reallocation first (supported by MallocAllocator via
+  // ::realloc(), which jemalloc can often service without moving data).
+  void* result = reallocateBytesWithoutRetry(p, oldSize, newSize, alignment);
+  if (result != nullptr) {
+    return result;
+  }
+  // Fallback: allocate new + memcpy + free old. This path also handles
+  // cache eviction via allocateBytes.
+  void* newP = allocateBytes(newSize, alignment);
+  if (newP == nullptr) {
+    return nullptr;
+  }
+  if (p != nullptr) {
+    ::memcpy(newP, p, std::min(oldSize, newSize));
+    freeBytes(p, oldSize);
+  }
+  return newP;
+}
+
+void* MemoryAllocator::reallocateBytesWithoutRetry(
+    void* /*p*/,
+    uint64_t /*oldSize*/,
+    uint64_t /*newSize*/,
+    uint16_t /*alignment*/) {
+  // Default: in-place reallocation not supported. Caller will fall back to
+  // allocateBytes + memcpy + freeBytes.
+  return nullptr;
 }
 
 Stats Stats::operator-(const Stats& other) const {

--- a/velox/common/memory/MemoryAllocator.h
+++ b/velox/common/memory/MemoryAllocator.h
@@ -371,6 +371,20 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
   /// 'cache()' if registered. But sufficient space is not guaranteed.
   void* allocateZeroFilled(uint64_t bytes);
 
+  /// Reallocates contiguous memory. Tries in-place reallocation first (via the
+  /// allocator-specific reallocateBytesWithoutRetry), falling back to
+  /// allocateBytes + memcpy + freeBytes if the allocator does not support
+  /// in-place reallocation. Returns nullptr on failure.
+  ///
+  /// When the underlying allocator is MallocAllocator (backed by jemalloc),
+  /// this uses ::realloc() which can often expand the allocation in-place,
+  /// avoiding the expensive memcpy.
+  void* reallocateBytes(
+      void* p,
+      uint64_t oldSize,
+      uint64_t newSize,
+      uint16_t alignment = kMinAlignment);
+
   /// Frees contiguous memory allocated by allocateBytes, allocateZeroFilled,
   /// reallocateBytes.
   virtual void freeBytes(void* p, uint64_t size) noexcept = 0;
@@ -510,6 +524,16 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
       uint16_t alignment) = 0;
 
   virtual void* allocateZeroFilledWithoutRetry(uint64_t bytes);
+
+  // Attempts to reallocate 'p' from 'oldSize' to 'newSize' bytes without
+  // retry through cache eviction. Returns nullptr if in-place reallocation
+  // is not supported or fails. The default implementation always returns
+  // nullptr; MallocAllocator overrides this to use ::realloc().
+  virtual void* reallocateBytesWithoutRetry(
+      void* p,
+      uint64_t oldSize,
+      uint64_t newSize,
+      uint16_t alignment);
 
   virtual bool growContiguousWithoutRetry(
       MachinePageCount increment,

--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -32,6 +32,13 @@ DEFINE_bool(
     false,
     "Whether allow to memory capacity transfer between memory pools from different tasks, which might happen in use case like Spark-Gluten");
 
+DEFINE_bool(
+    velox_enable_inplace_realloc,
+    true,
+    "If true, MemoryPool::reallocate uses MemoryAllocator::reallocateBytes "
+    "which tries in-place reallocation via ::realloc() (jemalloc can often "
+    "expand without memcpy). If false, uses the legacy alloc+memcpy+free path.");
+
 DECLARE_bool(velox_suppress_memory_capacity_exceeding_error_message);
 
 using facebook::velox::common::testutil::TestValue;
@@ -564,9 +571,39 @@ void* MemoryPoolImpl::allocateZeroFilled(int64_t numEntries, int64_t sizeEach) {
 void* MemoryPoolImpl::reallocate(void* p, int64_t size, int64_t newSize) {
   CHECK_AND_INC_MEM_OP_STATS(this, Allocs);
   const auto alignedNewSize = sizeAlign(newSize);
+  const auto alignedOldSize = sizeAlign(size);
   reserve(alignedNewSize);
 
-  void* newP = allocator_->allocateBytes(alignedNewSize, alignment_);
+  // Two fully separate branches are kept here intentionally so the legacy
+  // path can be deleted as a single block once the in-place path is rolled
+  // out and FLAGS_velox_enable_inplace_realloc is removed.
+  if (FLAGS_velox_enable_inplace_realloc) {
+    // In-place path: try ::realloc() via reallocateBytes, which jemalloc can
+    // often service without moving data (avoiding the expensive memcpy).
+    void* const newP = allocator_->reallocateBytes(
+        p, alignedOldSize, alignedNewSize, alignment_);
+    if (newP == nullptr) {
+      release(alignedNewSize);
+      handleAllocationFailure(
+          fmt::format(
+              "{} failed with new {} and old {} from {} {}",
+              __FUNCTION__,
+              succinctBytes(newSize),
+              succinctBytes(size),
+              toString(),
+              allocator_->getAndClearFailureMessage()));
+    }
+    if (p != nullptr) {
+      INC_MEM_OP_STATS(Frees);
+      DEBUG_RECORD_FREE(p, size);
+      release(alignedOldSize);
+    }
+    DEBUG_RECORD_ALLOC(this, newP, newSize);
+    return newP;
+  }
+
+  // Legacy path: allocate new + memcpy + free old.
+  void* const newP = allocator_->allocateBytes(alignedNewSize, alignment_);
   if (FOLLY_UNLIKELY(newP == nullptr)) {
     release(alignedNewSize);
     handleAllocationFailure(

--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -30,6 +30,7 @@
 
 DECLARE_bool(velox_memory_leak_check_enabled);
 DECLARE_bool(velox_memory_pool_capacity_transfer_across_tasks);
+DECLARE_bool(velox_enable_inplace_realloc);
 
 namespace facebook::velox::exec {
 class ParallelMemoryReclaimer;

--- a/velox/common/memory/tests/MemoryAllocatorTest.cpp
+++ b/velox/common/memory/tests/MemoryAllocatorTest.cpp
@@ -1251,6 +1251,109 @@ TEST_P(MemoryAllocatorTest, allocateBytes) {
   ASSERT_TRUE(instance_->checkConsistency());
 }
 
+TEST_P(MemoryAllocatorTest, reallocateBytes) {
+  // Test grow: allocate, fill, reallocate larger, verify data preserved.
+  {
+    const uint64_t kInitialSize = 1024;
+    const uint64_t kNewSize = 4096;
+    void* p = instance_->allocateBytes(kInitialSize);
+    ASSERT_NE(nullptr, p);
+    ::memset(p, 0xAB, kInitialSize);
+
+    auto usedBefore = instance_->totalUsedBytes();
+    void* newP = instance_->reallocateBytes(p, kInitialSize, kNewSize);
+    ASSERT_NE(nullptr, newP);
+    // Verify original data is preserved.
+    for (uint64_t i = 0; i < kInitialSize; ++i) {
+      ASSERT_EQ(static_cast<uint8_t>(0xAB), static_cast<uint8_t*>(newP)[i])
+          << "at byte " << i;
+    }
+    // Verify memory accounting: usage should have increased by the delta.
+    if (!useMmap_) {
+      ASSERT_EQ(
+          usedBefore + (kNewSize - kInitialSize), instance_->totalUsedBytes());
+    }
+    instance_->freeBytes(newP, kNewSize);
+  }
+
+  // Test shrink: allocate, fill, reallocate smaller, verify data preserved.
+  {
+    const uint64_t kInitialSize = 4096;
+    const uint64_t kNewSize = 1024;
+    void* p = instance_->allocateBytes(kInitialSize);
+    ASSERT_NE(nullptr, p);
+    ::memset(p, 0xCD, kInitialSize);
+
+    void* newP = instance_->reallocateBytes(p, kInitialSize, kNewSize);
+    ASSERT_NE(nullptr, newP);
+    for (uint64_t i = 0; i < kNewSize; ++i) {
+      ASSERT_EQ(static_cast<uint8_t>(0xCD), static_cast<uint8_t*>(newP)[i])
+          << "at byte " << i;
+    }
+    instance_->freeBytes(newP, kNewSize);
+  }
+
+  // Test with nullptr input: should behave like allocateBytes.
+  {
+    const uint64_t kSize = 2048;
+    void* newP = instance_->reallocateBytes(nullptr, 0, kSize);
+    ASSERT_NE(nullptr, newP);
+    ::memset(newP, 0xEF, kSize);
+    instance_->freeBytes(newP, kSize);
+  }
+
+  // Test memory accounting after full cycle.
+  if (!useMmap_) {
+    ASSERT_EQ(0, instance_->totalUsedBytes());
+  }
+  ASSERT_TRUE(instance_->checkConsistency());
+}
+
+TEST_P(MemoryAllocatorTest, reallocateBytesWithAlignment) {
+  // Non-default alignment should fall back to allocate+memcpy+free
+  // (MallocAllocator's reallocateBytesWithoutRetry returns nullptr for
+  // non-default alignment since ::realloc() cannot guarantee it).
+  const uint64_t kInitialSize = 1024;
+  const uint64_t kNewSize = 4096;
+  const uint16_t kAlignment = MemoryAllocator::kMaxAlignment;
+  void* p = instance_->allocateBytes(kInitialSize, kAlignment);
+  ASSERT_NE(nullptr, p);
+  ASSERT_EQ(0, reinterpret_cast<uintptr_t>(p) % kAlignment);
+  ::memset(p, 0x42, kInitialSize);
+
+  void* newP =
+      instance_->reallocateBytes(p, kInitialSize, kNewSize, kAlignment);
+  ASSERT_NE(nullptr, newP);
+  ASSERT_EQ(0, reinterpret_cast<uintptr_t>(newP) % kAlignment);
+  for (uint64_t i = 0; i < kInitialSize; ++i) {
+    ASSERT_EQ(static_cast<uint8_t>(0x42), static_cast<uint8_t*>(newP)[i])
+        << "at byte " << i;
+  }
+  instance_->freeBytes(newP, kNewSize);
+  ASSERT_TRUE(instance_->checkConsistency());
+}
+
+TEST_P(MemoryAllocatorTest, reallocateBytesCapacityExceeded) {
+  if (useMmap_) {
+    // MmapAllocator has different capacity semantics; skip.
+    return;
+  }
+  // Allocate most of capacity, then try to reallocate beyond it.
+  const uint64_t kInitialSize = 1024;
+  const uint64_t kOverCapacity = kCapacityBytes + 1;
+  void* p = instance_->allocateBytes(kInitialSize);
+  ASSERT_NE(nullptr, p);
+
+  void* newP = instance_->reallocateBytes(p, kInitialSize, kOverCapacity);
+  ASSERT_EQ(nullptr, newP);
+  // Original pointer should still be valid after failed reallocation.
+  // Memory accounting should be unchanged.
+  ASSERT_EQ(kInitialSize, instance_->totalUsedBytes());
+  instance_->freeBytes(p, kInitialSize);
+  ASSERT_EQ(0, instance_->totalUsedBytes());
+  ASSERT_TRUE(instance_->checkConsistency());
+}
+
 TEST_P(MemoryAllocatorTest, allocateBytesWithAlignment) {
   struct {
     uint64_t allocateBytes;


### PR DESCRIPTION
Summary:

Strobelight profiling (https://fburl.com/scuba/strobelight_services/oeoxrdzz) shows that `__folly_memcpy` via `AlignedBuffer::reallocate` is the top CPU consumer in dai_data/waas, costing $3.6M/yr (16.12% of all memcpy CPU). The root cause is that `MemoryPoolImpl::reallocate` always does alloc + memcpy + free, even when jemalloc could expand the allocation in-place via `::realloc()`.

This diff adds a `reallocateBytes` method to `MemoryAllocator` that tries in-place reallocation first. `MallocAllocator` overrides `reallocateBytesWithoutRetry` to use `::realloc()`, which jemalloc can often service without moving data (avoiding the expensive memcpy). Other allocators (e.g., MmapAllocator) fall back to the existing alloc + memcpy + free path via the default implementation.

The new path is gated by `--velox_enable_inplace_realloc`, which **defaults to true** so all Velox-using services get the win out of the box. The legacy alloc + memcpy + free path is kept behind the gflag in `MemoryPoolImpl::reallocate` as a per-service safety knob — any service that needs to opt out can override the gflag locally. Once the in-place path has baked across the fleet, the gflag and the legacy branch can be deleted in a follow-up.

The change is backward-compatible at the API level: when `::realloc()` cannot expand in-place, the implementation falls back to allocating new memory + memcpy + free (same behavior as today).

Reviewed By: tanjialiang

Differential Revision: D101689101


