### PR TITLE
fix(tracer): Fix TableWrite trace replayer to register connector and preserve serde parameters

### DIFF
--- a/velox/tool/trace/TableWriterReplayer.cpp
+++ b/velox/tool/trace/TableWriterReplayer.cpp
@@ -41,6 +41,18 @@ makeHiveInsertTableHandle(
   const auto storageFormat = tracedHandle->storageFormat();
   const auto serdeParameters = tracedHandle->serdeParameters();
   const auto writerOptions = tracedHandle->writerOptions();
+  LOG(INFO) << "Traced serde parameters:";
+  for (const auto& [key, value] : serdeParameters) {
+    LOG(INFO) << fmt::format("\t{}: {}", key, value);
+  }
+  LOG(INFO) << fmt::format(
+      "Traced writer options: {}", writerOptions ? "present" : "null");
+  LOG(INFO) << "Traced storage parameters:";
+  for (const auto& [key, value] : tracedHandle->storageParameters()) {
+    LOG(INFO) << fmt::format("\t{}: {}", key, value);
+  }
+  LOG(INFO) << fmt::format(
+      "Storage format: {}", dwio::common::toString(storageFormat));
   return std::make_shared<connector::hive::HiveInsertTableHandle>(
       inputColumns,
       std::make_shared<connector::hive::LocationHandle>(
@@ -53,7 +65,7 @@ makeHiveInsertTableHandle(
           : std::make_shared<connector::hive::HiveBucketProperty>(
                 *tracedHandle->bucketProperty()),
       compressionKind,
-      std::unordered_map<std::string, std::string>{}, // serdeParameters
+      serdeParameters,
       writerOptions,
       tracedHandle->ensureFiles(),
       tracedHandle->fileNameGenerator(),

--- a/velox/tool/trace/TraceReplayRunner.cpp
+++ b/velox/tool/trace/TraceReplayRunner.cpp
@@ -344,6 +344,17 @@ TraceReplayRunner::createReplayer() const {
     VELOX_USER_CHECK(
         !FLAGS_table_writer_output_dir.empty(),
         "--table_writer_output_dir is required");
+    const std::string writerConnectorId = "test-hive";
+    if (!connector::ConnectorRegistry::tryGet(writerConnectorId)) {
+      connector::hive::HiveConnectorFactory factory;
+      const auto hiveConnector = factory.newConnector(
+          writerConnectorId,
+          std::make_shared<config::ConfigBase>(
+              std::unordered_map<std::string, std::string>()),
+          ioExecutor_.get());
+      connector::ConnectorRegistry::global().insert(
+          hiveConnector->connectorId(), hiveConnector);
+    }
     replayer = std::make_unique<tool::trace::TableWriterReplayer>(
         FLAGS_root_dir,
         FLAGS_query_id,

--- a/velox/tool/trace/tests/TableWriterReplayerTest.cpp
+++ b/velox/tool/trace/tests/TableWriterReplayerTest.cpp
@@ -394,6 +394,100 @@ TEST_F(TableWriterReplayerTest, basic) {
   assertEqualResults({data}, {copy});
 }
 
+TEST_F(TableWriterReplayerTest, serdeParametersPreserved) {
+  vector_size_t size = 1'000;
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+      makeFlatVector<int32_t>(
+          size, [](auto row) { return row * 2; }, nullEvery(7)),
+  });
+  auto sourceFilePath = TempFilePath::create();
+  writeToFile(sourceFilePath->getPath(), data);
+
+  const std::unordered_map<std::string, std::string> serdeParams = {
+      {"test.param.one", "value1"},
+      {"test.param.two", "42"},
+  };
+
+  auto rowType = asRowType(data->type());
+  auto targetDirectoryPath = TempDirectoryPath::create();
+  auto insertHandle = std::make_shared<core::InsertTableHandle>(
+      kHiveConnectorId,
+      makeHiveInsertTableHandle(
+          rowType->names(),
+          rowType->children(),
+          {},
+          nullptr,
+          makeLocationHandle(
+              targetDirectoryPath->getPath(),
+              std::nullopt,
+              connector::hive::LocationHandle::TableType::kNew),
+          fileFormat_,
+          std::nullopt,
+          serdeParams));
+
+  std::string traceNodeId;
+  auto plan =
+      PlanBuilder()
+          .tableScan(rowType)
+          .addNode(addTableWriter(
+              rowType, rowType->names(), std::nullopt, insertHandle, false))
+          .capturePlanNodeId(traceNodeId)
+          .project({TableWriteTraits::rowCountColumnName()})
+          .singleAggregation(
+              {},
+              {fmt::format("sum({})", TableWriteTraits::rowCountColumnName())})
+          .planNode();
+
+  const auto testDir = TempDirectoryPath::create();
+  const auto traceRoot = fmt::format("{}/{}", testDir->getPath(), "traceRoot");
+  std::shared_ptr<Task> task;
+  AssertQueryBuilder(plan)
+      .config(core::QueryConfig::kQueryTraceEnabled, true)
+      .config(core::QueryConfig::kQueryTraceDir, traceRoot)
+      .config(core::QueryConfig::kQueryTraceMaxBytes, 100UL << 30)
+      .config(core::QueryConfig::kQueryTraceTaskRegExp, ".*")
+      .config(core::QueryConfig::kQueryTraceNodeId, traceNodeId)
+      .split(makeHiveConnectorSplit(sourceFilePath->getPath()))
+      .copyResults(pool(), task);
+
+  const auto traceOutputDir = TempDirectoryPath::create();
+  const auto result = TableWriterReplayer(
+                          traceRoot,
+                          task->queryCtx()->queryId(),
+                          task->taskId(),
+                          "1",
+                          "TableWriter",
+                          "",
+                          0,
+                          executor_.get(),
+                          traceOutputDir->getPath())
+                          .run();
+
+  const auto taskTraceDir = exec::trace::getTaskTraceDirectory(
+      traceRoot, task->queryCtx()->queryId(), task->taskId());
+  const auto taskMetaReader =
+      exec::trace::TaskTraceMetadataReader(taskTraceDir, pool());
+  const auto queryPlan = taskMetaReader.queryPlan();
+  const auto* replayNode = core::PlanNode::findFirstNode(
+      queryPlan.get(),
+      [&](const auto* node) { return node->id() == traceNodeId; });
+  ASSERT_NE(replayNode, nullptr);
+  const auto* tableWriteNode =
+      dynamic_cast<const core::TableWriteNode*>(replayNode);
+  ASSERT_NE(tableWriteNode, nullptr);
+  const auto tracedHandle =
+      std::dynamic_pointer_cast<const connector::hive::HiveInsertTableHandle>(
+          tableWriteNode->insertTableHandle()->connectorInsertTableHandle());
+  ASSERT_NE(tracedHandle, nullptr);
+  const auto& tracedSerdeParams = tracedHandle->serdeParameters();
+  ASSERT_EQ(tracedSerdeParams.size(), serdeParams.size());
+  for (const auto& [key, value] : serdeParams) {
+    ASSERT_EQ(tracedSerdeParams.count(key), 1);
+    ASSERT_EQ(tracedSerdeParams.at(key), value);
+  }
+}
+
 TEST_F(TableWriterReplayerTest, partitionWrite) {
   const int32_t numPartitions = 4;
   const int32_t numBatches = 2;


### PR DESCRIPTION
Summary:
The Velox trace replayer had two bugs that prevented faithful replay of `TableWrite` operations:

1. **Missing HiveConnector registration**: `TraceReplayRunner::createReplayer()` did not register a `HiveConnector` for the `"test-hive"` connector ID used by `TableWriterReplayer`. This caused a segfault in `TableWriter::createDataSink()` when replaying TableWrite traces via the CLI tool. The `TableScan` path already had this registration (lines 379-402), but it was missing for `TableWrite`. The existing unit tests passed because `HiveConnectorTestBase::SetUp()` registers the connector implicitly.

2. **Dropped serde parameters**: `makeHiveInsertTableHandle()` in `TableWriterReplayer.cpp` read `serdeParameters` from the traced handle but passed an empty map to the reconstructed `HiveInsertTableHandle`. This silently dropped all table-level writer configuration — including chunking thresholds (`nimble.chunking.*`), flat map settings, and encoding selection parameters — causing the replayed write to use default settings instead of the production configuration.

Also adds diagnostic logging of traced serde parameters, writer options, storage parameters, and storage format during replay.

Differential Revision: D105281263


