### PR TITLE
misc: Remove dead file-metadata-cache-enabled config

### DIFF
--- a/velox/connectors/hive/FileConfig.cpp
+++ b/velox/connectors/hive/FileConfig.cpp
@@ -43,7 +43,6 @@ const std::vector<config::ConfigProperty>& FileConfig::registeredProperties() {
     VELOX_HIVE_CONFIG_REGISTER(kLoadQuantumSession);
     VELOX_HIVE_CONFIG_REGISTER(kReadStatsBasedFilterReorderDisabledSession);
     VELOX_HIVE_CONFIG_REGISTER(kIndexEnabledSession);
-    VELOX_HIVE_CONFIG_REGISTER(kFileMetadataCacheEnabledSession);
     VELOX_HIVE_CONFIG_REGISTER(kPinFileMetadataSession);
     VELOX_HIVE_CONFIG_REGISTER(kSelectiveNimbleReaderEnabledSession);
     VELOX_HIVE_CONFIG_REGISTER(kMaxCoalescedDistanceSession);

--- a/velox/connectors/hive/FileConfig.h
+++ b/velox/connectors/hive/FileConfig.h
@@ -205,16 +205,6 @@ class FileConfig {
   static constexpr const char* kIndexEnabled = "index-enabled";
 
   VELOX_HIVE_CONFIG(
-      kFileMetadataCacheEnabledSession,
-      fileMetadataCacheEnabled,
-      "file_metadata_cache_enabled",
-      bool,
-      false,
-      "Cache file metadata in AsyncDataCache.")
-  static constexpr const char* kFileMetadataCacheEnabled =
-      "file-metadata-cache-enabled";
-
-  VELOX_HIVE_CONFIG(
       kPinFileMetadataSession,
       pinFileMetadata,
       "pin_file_metadata",

--- a/velox/connectors/hive/FileConnectorUtil.cpp
+++ b/velox/connectors/hive/FileConnectorUtil.cpp
@@ -97,8 +97,6 @@ void configureReaderOptions(
     readerOptions.setSelectiveNimbleReaderEnabled(
         connectorQueryCtx->selectiveNimbleReaderEnabled());
   }
-  readerOptions.setFileMetadataCacheEnabled(
-      fileConfig->fileMetadataCacheEnabled(sessionProperties));
   readerOptions.setPinFileMetadata(
       fileConfig->pinFileMetadata(sessionProperties));
 

--- a/velox/connectors/hive/tests/FileConfigTest.cpp
+++ b/velox/connectors/hive/tests/FileConfigTest.cpp
@@ -46,7 +46,6 @@ TEST(FileConfigTest, defaultConfig) {
   EXPECT_FALSE(config.preserveFlatMapsInMemory(emptySession.get()));
   EXPECT_FALSE(config.indexEnabled(emptySession.get()));
   EXPECT_FALSE(config.readerCollectColumnCpuMetrics(emptySession.get()));
-  EXPECT_FALSE(config.fileMetadataCacheEnabled(emptySession.get()));
   EXPECT_FALSE(config.pinFileMetadata(emptySession.get()));
   EXPECT_EQ(config.orcFooterSpeculativeIoSize(emptySession.get()), 256UL << 10);
   EXPECT_EQ(
@@ -71,7 +70,6 @@ TEST(FileConfigTest, overrideConfig) {
       {FileConfig::kPreserveFlatMapsInMemory, "true"},
       {FileConfig::kIndexEnabled, "true"},
       {FileConfig::kReaderCollectColumnCpuMetrics, "true"},
-      {FileConfig::kFileMetadataCacheEnabled, "true"},
       {FileConfig::kPinFileMetadata, "true"},
       {FileConfig::kOrcFooterSpeculativeIoSize, std::to_string(512UL << 10)},
       {FileConfig::kParquetFooterSpeculativeIoSize, std::to_string(1UL << 20)},
@@ -96,7 +94,6 @@ TEST(FileConfigTest, overrideConfig) {
   EXPECT_TRUE(config.preserveFlatMapsInMemory(emptySession.get()));
   EXPECT_TRUE(config.indexEnabled(emptySession.get()));
   EXPECT_TRUE(config.readerCollectColumnCpuMetrics(emptySession.get()));
-  EXPECT_TRUE(config.fileMetadataCacheEnabled(emptySession.get()));
   EXPECT_TRUE(config.pinFileMetadata(emptySession.get()));
   EXPECT_EQ(config.orcFooterSpeculativeIoSize(emptySession.get()), 512UL << 10);
   EXPECT_EQ(
@@ -122,7 +119,6 @@ TEST(FileConfigTest, overrideSession) {
       {FileConfig::kPreserveFlatMapsInMemorySession, "true"},
       {FileConfig::kIndexEnabledSession, "true"},
       {FileConfig::kReaderCollectColumnCpuMetricsSession, "true"},
-      {FileConfig::kFileMetadataCacheEnabledSession, "true"},
       {FileConfig::kPinFileMetadataSession, "true"},
       {FileConfig::kOrcFooterSpeculativeIoSizeSession,
        std::to_string(128UL << 10)},
@@ -146,7 +142,6 @@ TEST(FileConfigTest, overrideSession) {
   EXPECT_TRUE(config.preserveFlatMapsInMemory(session.get()));
   EXPECT_TRUE(config.indexEnabled(session.get()));
   EXPECT_TRUE(config.readerCollectColumnCpuMetrics(session.get()));
-  EXPECT_TRUE(config.fileMetadataCacheEnabled(session.get()));
   EXPECT_TRUE(config.pinFileMetadata(session.get()));
   EXPECT_EQ(config.orcFooterSpeculativeIoSize(session.get()), 128UL << 10);
   EXPECT_EQ(config.parquetFooterSpeculativeIoSize(session.get()), 512UL << 10);

--- a/velox/connectors/hive/tests/HiveConfigTest.cpp
+++ b/velox/connectors/hive/tests/HiveConfigTest.cpp
@@ -56,7 +56,6 @@ TEST(HiveConfigTest, defaultConfig) {
   ASSERT_EQ(hiveConfig.loadQuantum(emptySession.get()), 8 << 20);
   ASSERT_FALSE(hiveConfig.preserveFlatMapsInMemory(emptySession.get()));
   ASSERT_FALSE(hiveConfig.indexEnabled(emptySession.get()));
-  ASSERT_FALSE(hiveConfig.fileMetadataCacheEnabled(emptySession.get()));
   ASSERT_EQ(
       hiveConfig.orcFooterSpeculativeIoSize(emptySession.get()), 256UL << 10);
   ASSERT_EQ(
@@ -91,7 +90,6 @@ TEST(HiveConfigTest, overrideConfig) {
       {HiveConfig::kMaxBucketCount, std::to_string(100'000)},
       {HiveConfig::kPreserveFlatMapsInMemory, "true"},
       {HiveConfig::kIndexEnabled, "true"},
-      {HiveConfig::kFileMetadataCacheEnabled, "true"},
       {HiveConfig::kOrcFooterSpeculativeIoSize, std::to_string(512UL << 10)},
       {HiveConfig::kParquetFooterSpeculativeIoSize, std::to_string(1UL << 20)},
       {HiveConfig::kNimbleFooterSpeculativeIoSize, std::to_string(4UL << 20)},
@@ -130,7 +128,6 @@ TEST(HiveConfigTest, overrideConfig) {
   ASSERT_EQ(hiveConfig.maxBucketCount(emptySession.get()), 100'000);
   ASSERT_TRUE(hiveConfig.preserveFlatMapsInMemory(emptySession.get()));
   ASSERT_TRUE(hiveConfig.indexEnabled(emptySession.get()));
-  ASSERT_TRUE(hiveConfig.fileMetadataCacheEnabled(emptySession.get()));
   ASSERT_EQ(
       hiveConfig.orcFooterSpeculativeIoSize(emptySession.get()), 512UL << 10);
   ASSERT_EQ(
@@ -160,7 +157,6 @@ TEST(HiveConfigTest, overrideSession) {
       {HiveConfig::kLoadQuantumSession, std::to_string(4 << 20)},
       {HiveConfig::kPreserveFlatMapsInMemorySession, "true"},
       {HiveConfig::kIndexEnabledSession, "true"},
-      {HiveConfig::kFileMetadataCacheEnabledSession, "true"},
       {HiveConfig::kOrcFooterSpeculativeIoSizeSession,
        std::to_string(128UL << 10)},
       {HiveConfig::kParquetFooterSpeculativeIoSizeSession,
@@ -197,7 +193,6 @@ TEST(HiveConfigTest, overrideSession) {
   ASSERT_EQ(hiveConfig.loadQuantum(session.get()), 4 << 20);
   ASSERT_TRUE(hiveConfig.preserveFlatMapsInMemory(session.get()));
   ASSERT_TRUE(hiveConfig.indexEnabled(session.get()));
-  ASSERT_TRUE(hiveConfig.fileMetadataCacheEnabled(session.get()));
   ASSERT_EQ(hiveConfig.orcFooterSpeculativeIoSize(session.get()), 128UL << 10);
   ASSERT_EQ(
       hiveConfig.parquetFooterSpeculativeIoSize(session.get()), 512UL << 10);

--- a/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
@@ -184,10 +184,6 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
   EXPECT_EQ(
       readerOptions.filePreloadThreshold(), hiveConfig->filePreloadThreshold());
   EXPECT_EQ(readerOptions.prefetchRowGroups(), hiveConfig->prefetchRowGroups());
-  EXPECT_EQ(
-      readerOptions.fileMetadataCacheEnabled(),
-      hiveConfig->fileMetadataCacheEnabled(&sessionProperties));
-
   // Modify field delimiter and change the file format.
   clearDynamicParameters(FileFormat::TEXT);
   serdeParameters[SerDeOptions::kFieldDelim] = '\t';
@@ -276,7 +272,6 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
   customHiveConfigProps[hive::HiveConfig::kOrcUseColumnNames] = "true";
   customHiveConfigProps[hive::HiveConfig::kFilePreloadThreshold] = "9999";
   customHiveConfigProps[hive::HiveConfig::kPrefetchRowGroups] = "10";
-  customHiveConfigProps[hive::HiveConfig::kFileMetadataCacheEnabled] = "true";
   customHiveConfigProps[hive::HiveConfig::kOrcFooterSpeculativeIoSize] = "1111";
   hiveConfig = std::make_shared<hive::HiveConfig>(
       std::make_shared<config::ConfigBase>(std::move(customHiveConfigProps)));
@@ -298,7 +293,6 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
   EXPECT_EQ(
       readerOptions.filePreloadThreshold(), hiveConfig->filePreloadThreshold());
   EXPECT_EQ(readerOptions.prefetchRowGroups(), hiveConfig->prefetchRowGroups());
-  EXPECT_TRUE(readerOptions.fileMetadataCacheEnabled());
   clearDynamicParameters(FileFormat::ORC);
   performConfigure();
   checkUseColumnNamesForColumnMapping();
@@ -441,61 +435,6 @@ TEST_F(HiveConnectorUtilTest, footerSpeculativeIoSizeByFormat) {
         readerOptions.footerSpeculativeIoSize(),
         hiveConfig->nimbleFooterSpeculativeIoSize(&sessionProperties));
     EXPECT_EQ(readerOptions.footerSpeculativeIoSize(), 3333);
-  }
-}
-
-TEST_F(HiveConnectorUtilTest, fileMetadataCacheEnabledSessionOverride) {
-  // Verify default is off.
-  dwio::common::ReaderOptions defaultOptions(pool_.get());
-  defaultOptions.setDataIoStats(dataIoStats_.get());
-  defaultOptions.setMetadataIoStats(metadataIoStats_.get());
-  ASSERT_FALSE(defaultOptions.fileMetadataCacheEnabled());
-
-  for (bool enabled : {true, false}) {
-    SCOPED_TRACE(fmt::format("fileMetadataCacheEnabled={}", enabled));
-
-    config::ConfigBase sessionProperties(
-        std::unordered_map<std::string, std::string>{
-            {hive::HiveConfig::kFileMetadataCacheEnabledSession,
-             enabled ? "true" : "false"}});
-    auto connectorQueryCtx = std::make_unique<connector::ConnectorQueryCtx>(
-        pool_.get(),
-        pool_.get(),
-        &sessionProperties,
-        nullptr,
-        common::PrefixSortConfig(),
-        nullptr,
-        nullptr,
-        "query.HiveConnectorUtilTest",
-        "task.HiveConnectorUtilTest",
-        "planNodeId.HiveConnectorUtilTest",
-        0,
-        "");
-    auto hiveConfig =
-        std::make_shared<hive::HiveConfig>(std::make_shared<config::ConfigBase>(
-            std::unordered_map<std::string, std::string>()));
-    dwio::common::ReaderOptions readerOptions(pool_.get());
-    readerOptions.setDataIoStats(dataIoStats_.get());
-    readerOptions.setMetadataIoStats(metadataIoStats_.get());
-
-    auto tableHandle = std::make_shared<hive::HiveTableHandle>(
-        "testConnectorId",
-        "testTable",
-        common::SubfieldFilters{},
-        nullptr,
-        nullptr,
-        std::vector<std::string>{},
-        std::unordered_map<std::string, std::string>{});
-    auto split = std::make_shared<hive::HiveConnectorSplit>(
-        "testConnectorId", "/tmp/", FileFormat::DWRF);
-    configureReaderOptions(
-        hiveConfig,
-        connectorQueryCtx.get(),
-        tableHandle,
-        split,
-        split->serdeParameters,
-        readerOptions);
-    ASSERT_EQ(readerOptions.fileMetadataCacheEnabled(), enabled);
   }
 }
 

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -858,21 +858,13 @@ must be specified as raw byte counts.
      - 0
      - Maximum number of output rows to return per index lookup request. The limit is applied to the actual output rows
        after filtering. 0 means no limit (default).
-   * - file-metadata-cache-enabled
-     - file_metadata_cache_enabled
-     - bool
-     - false
-     - Whether to cache file metadata (footer, stripes, index) in the process-wide AsyncDataCache. When enabled,
-       the first reader performs a speculative tail read and populates the cache; subsequent readers on the same file
-       serve metadata from cache with zero file IO. Currently only supported by Nimble format.
    * - pin-file-metadata
      - pin_file_metadata
      - bool
      - false
      - Whether to pin parsed metadata objects (e.g., StripeGroup, IndexGroup) in the reader's metadata cache with
        strong references so they are never evicted. This avoids re-reading and re-parsing metadata on every stripe
-       access when weak-pointer cache entries would otherwise expire. Can be used independently of
-       file-metadata-cache-enabled. Currently only supported by Nimble format.
+       access when weak-pointer cache entries would otherwise expire. Currently only supported by Nimble format.
    * - reader.collect-column-cpu-metrics
      - reader.collect_column_cpu_metrics
      - bool

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -746,18 +746,6 @@ class ReaderOptions : public io::ReaderOptions {
     selectiveNimbleReaderEnabled_ = value;
   }
 
-  /// Whether to cache file metadata (footer, stripes, index) in the
-  /// process-wide AsyncDataCache. When enabled, the first reader performs a
-  /// speculative tail read and populates the cache; subsequent readers on the
-  /// same file initialize from the cache with zero additional IO.
-  bool fileMetadataCacheEnabled() const {
-    return fileMetadataCacheEnabled_;
-  }
-
-  void setFileMetadataCacheEnabled(bool value) {
-    fileMetadataCacheEnabled_ = value;
-  }
-
   /// If true, pins parsed metadata objects (e.g., StripeGroup, IndexGroup) in
   /// the reader's metadata cache with strong references so they are never
   /// evicted. This avoids re-reading and re-parsing metadata on every stripe
@@ -830,7 +818,6 @@ class ReaderOptions : public io::ReaderOptions {
   const tz::TimeZone* sessionTimezone_{nullptr};
   bool adjustTimestampToTimezone_{false};
   bool selectiveNimbleReaderEnabled_{false};
-  bool fileMetadataCacheEnabled_{false};
   bool pinFileMetadata_{false};
   bool loadClusterIndex_{true};
   bool loadChunkIndex_{true};


### PR DESCRIPTION
Summary: The `file-metadata-cache-enabled` config was set on `ReaderOptions` but never read by any production code. After the `MetadataInput` refactor (D104349994), metadata caching is determined automatically by whether `FileHandle + AsyncDataCache` are provided to `TabletReader` — the boolean flag is not consulted.

Differential Revision: D105284797


