### PR TITLE
build: Add gh_api retry helper and adopt across workflows

### DIFF
--- a/.github/scripts/gh-api-retry.sh
+++ b/.github/scripts/gh-api-retry.sh
@@ -1,0 +1,58 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# shellcheck shell=bash
+
+# Source this file from a workflow `run:` step to define a `gh_api`
+# function that wraps `gh api` with retry-with-exponential-backoff.
+# Use it in place of bare `gh api` for any GitHub API call from CI:
+# transient network blips, rate-limit hiccups (especially on the
+# stricter /search/issues path), and 5xx upstream failures all become
+# survivable instead of single-shot workflow failures.
+#
+# Args: same as `gh api`. Stdout is preserved on the successful
+# attempt so jq pipelines still work. On a final failure, the function
+# returns gh's exit code so the caller's `set -e` semantics are
+# unchanged.
+#
+# Env knobs (sensible defaults; tweak only if a caller has a reason):
+#   GH_API_RETRY_MAX     — max attempts, default 3
+#   GH_API_RETRY_BACKOFF — base sleep seconds, default 2 (exponential:
+#                          2, 4, 8 between attempts when base=2)
+#
+# Usage:
+#   source .github/scripts/gh-api-retry.sh
+#   gh_api "/repos/$OWNER/$REPO/pulls/$PR"
+#   gh_api --paginate "/repos/$OWNER/$REPO/issues/$N/comments"
+#   gh_api -X POST "/repos/$OWNER/$REPO/actions/runs/$RUN/rerun"
+gh_api() {
+  local max_attempts="${GH_API_RETRY_MAX:-3}"
+  local sleep_base="${GH_API_RETRY_BACKOFF:-2}"
+  local attempt=1
+  local exit_code=0
+  while [ "$attempt" -le "$max_attempts" ]; do
+    if gh api "$@"; then
+      return 0
+    fi
+    exit_code=$?
+    if [ "$attempt" -lt "$max_attempts" ]; then
+      local wait_secs=$((sleep_base ** attempt))
+      echo "::warning::gh api attempt ${attempt}/${max_attempts} failed (exit ${exit_code}); retrying in ${wait_secs}s" >&2
+      sleep "$wait_secs"
+    fi
+    attempt=$((attempt + 1))
+  done
+  echo "::error::gh api failed after ${max_attempts} attempts (final exit ${exit_code}): gh api $*" >&2
+  return "$exit_code"
+}

--- a/.github/workflows/ci-failure-comment.yml
+++ b/.github/workflows/ci-failure-comment.yml
@@ -55,6 +55,17 @@ jobs:
         github.event.workflow_run.conclusion == 'failure'))
     runs-on: ubuntu-latest
     steps:
+      # workflow_run-triggered jobs start with an empty workspace; check
+      # out just the helper-scripts dir so the sourced gh-api-retry.sh
+      # is on disk for the gh_api callers below. Sparse-checkout keeps
+      # this fast; the later "Checkout for Claude context and prompt"
+      # step swaps to a different sparse set (CLAUDE.md + skill files)
+      # but only after gh_api usage is done.
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/scripts
+
       - name: Get PR number
         id: pr
         env:
@@ -70,7 +81,8 @@ jobs:
             exit 0
           fi
 
-          pr_number=$(gh api \
+          source .github/scripts/gh-api-retry.sh
+          pr_number=$(gh_api \
             "/repos/${REPO}/pulls?head=${HEAD_OWNER}:${HEAD_BRANCH}&state=open" \
             -q '.[0].number // empty')
 
@@ -118,7 +130,8 @@ jobs:
             # No failure artifacts — build metadata from failed jobs in the run.
             # This handles workflows (e.g., Fuzzer Jobs) that don't upload
             # ci-failure-* artifacts.
-            METADATA=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs" \
+            source .github/scripts/gh-api-retry.sh
+            METADATA=$(gh_api "repos/${REPO}/actions/runs/${RUN_ID}/jobs" \
               --paginate --jq '[.jobs[] | select(.conclusion == "failure") | {job: .name, type: "unknown"}]')
             if [ "$METADATA" = "[]" ] || [ -z "$METADATA" ]; then
               echo "No failure artifacts or failed jobs found."

--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -50,7 +50,8 @@ jobs:
         run: |
           echo "JOB_TRIGGER: $JOB_TRIGGER"
           if [[ "$JOB_TRIGGER" == "pull_request" ]]; then
-            merge_base_commit=$(gh api -q '.merge_base_commit.sha' \
+            source .github/scripts/gh-api-retry.sh
+            merge_base_commit=$(gh_api -q '.merge_base_commit.sha' \
               /repos/facebookincubator/velox/compare/facebookincubator:$BASE_REF...$PR_OWNER:$HEAD_REF \
             )
 

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -121,6 +121,17 @@ jobs:
 
     steps:
 
+      # Sparse-checkout just the helper scripts dir up front so the
+      # sourced gh-api-retry.sh is on disk for the merge-base step
+      # below. Lands at $GITHUB_WORKSPACE/.github/scripts; the later
+      # "Checkout Contender" / "Checkout Main" steps put their full
+      # clones in different subdirectories (velox/, velox_main/) and
+      # don't conflict.
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/scripts
+
       - name: Get merge base with main
         if: ${{ github.event_name != 'schedule' }}
         working-directory: ${{ github.workspace }}
@@ -132,12 +143,13 @@ jobs:
           PR_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
         id: get-merge-base
         run: |
+          source .github/scripts/gh-api-retry.sh
           if [ '${{ github.event_name == 'push' }}' == "true" ]; then
             # get the parent commit of the current one to get the relevant function signatures
-            head_main=$(gh api -q '.parents.[0].sha' '/repos/facebookincubator/velox/commits/${{ github.sha }}')
+            head_main=$(gh_api -q '.parents.[0].sha' '/repos/facebookincubator/velox/commits/${{ github.sha }}')
           elif [ '${{ github.event_name == 'pull_request' }}' == "true" ]; then
             # Get the merge base from the api
-            head_main=$(gh api -q '.merge_base_commit.sha' \
+            head_main=$(gh_api -q '.merge_base_commit.sha' \
               /repos/facebookincubator/velox/compare/facebookincubator:$BASE_REF...$PR_OWNER:$HEAD_REF \
             )
           else


### PR DESCRIPTION
Summary:
Adds `.github/scripts/gh-api-retry.sh`, a sourced bash helper that defines a `gh_api()` wrapper around `gh api` with 3-attempt exponential backoff. Use it in place of bare `gh api` for any GitHub API call from CI: transient network blips, rate-limit hiccups (especially on `/search/issues`), and 5xx upstream failures all become survivable instead of single-shot workflow failures.

## Adoption in this diff

- `linux-build-base.yml` get-changes step (`/repos/.../compare/...`)
- `ci-failure-comment.yml` Get-PR-number + Collect-failure-metadata steps (`/repos/.../pulls?head=...`, `/repos/.../actions/runs/.../jobs`). Adds an upfront sparse-checkout of `.github/scripts` so the helper is on disk for the workflow_run-triggered job (which starts with an empty workspace).
- `scheduled.yml` Get-merge-base step (2 GETs to `/repos/.../commits/...` and `/repos/.../compare/...`). Adds the same sparse-checkout pattern.

Behaviour for the migrated calls is otherwise unchanged — same payload, same endpoints, same `set -e` semantics. Stdout is preserved on the successful attempt so existing `jq` pipelines keep working.

## Env knobs

- `GH_API_RETRY_MAX` — max attempts, default 3
- `GH_API_RETRY_BACKOFF` — base sleep seconds, default 2 (exponential: 2, 4, 8 between attempts when base=2)

Differential Revision: D105292586


