### PR TITLE
build: Centralize cmake flag profiles and fix latent ubuntu-debug build issues (#17531)

### DIFF
--- a/.github/scripts/cmake-flags.sh
+++ b/.github/scripts/cmake-flags.sh
@@ -1,0 +1,117 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# shellcheck shell=bash
+# shellcheck disable=SC2034 # CMAKE_FLAGS is consumed by callers that source this file.
+
+# Source this file (do not exec it) from a workflow `run:` step to
+# populate the CMAKE_FLAGS array for one of the supported build
+# profiles. The caller must set BUILD_PROFILE in env before sourcing;
+# USE_CLANG (default false) gates compiler-conditional flags.
+#
+# Supported profiles:
+#   * adapters             — Linux release with adapters (linux-build-base.yml).
+#   * ubuntu-debug         — Ubuntu debug with system dependencies.
+#   * ubuntu-bundled-deps  — Ubuntu debug with velox's BUNDLED dependency
+#                            resolution; mirrors ubuntu-debug minus
+#                            REMOTE_FUNCTIONS (velox doesn't bundle the FB_OS
+#                            suite — fbthrift / fizz / wangle / mvfst — so
+#                            that flag has no business in BUNDLED-deps mode).
+#   * fedora-debug         — Fedora debug.
+#   * macos                — macOS debug/release.
+#
+# Truly job-local extras stay at the call site (e.g. the macOS job
+# appends `-DCMAKE_BUILD_TYPE=$BUILD_TYPE` per matrix entry). Anything
+# that's a property of the profile itself belongs here.
+#
+# Usage:
+#   BUILD_PROFILE=adapters [USE_CLANG=true] source .github/scripts/cmake-flags.sh
+#   EXTRA_CMAKE_FLAGS=("${CMAKE_FLAGS[@]}" -DVELOX_ENABLE_X=ON)
+
+case "${BUILD_PROFILE:?BUILD_PROFILE must be set before sourcing cmake-flags.sh}" in
+adapters)
+  CMAKE_FLAGS=(
+    -DVELOX_MONO_LIBRARY=ON
+    -DVELOX_ENABLE_BENCHMARKS=ON
+    -DVELOX_ENABLE_EXAMPLES=ON
+    -DVELOX_ENABLE_ARROW=ON
+    -DVELOX_ENABLE_GEO=ON
+    -DVELOX_ENABLE_PARQUET=ON
+    -DVELOX_ENABLE_HDFS=ON
+    -DVELOX_ENABLE_S3=ON
+    -DVELOX_ENABLE_GCS=ON
+    -DVELOX_ENABLE_ABFS=ON
+    -DVELOX_ENABLE_WAVE=ON
+  )
+  if [[ ${USE_CLANG:-false} != "true" ]]; then
+    # Faiss has a link issue under Clang; the remote function service
+    # has open issues under Clang too (#13897). cuDF is GCC-only.
+    CMAKE_FLAGS+=(
+      -DVELOX_ENABLE_FAISS=ON
+      -DVELOX_ENABLE_REMOTE_FUNCTIONS=ON
+      -DVELOX_ENABLE_CUDF=ON
+    )
+  fi
+  ;;
+
+ubuntu-debug | ubuntu-bundled-deps)
+  CMAKE_FLAGS=(
+    -DCMAKE_LINK_LIBRARIES_STRATEGY=REORDER_FREELY
+    -DVELOX_BUILD_SHARED=ON
+    -DVELOX_ENABLE_BENCHMARKS=ON
+    -DVELOX_ENABLE_EXAMPLES=ON
+    -DVELOX_ENABLE_ARROW=ON
+    -DVELOX_ENABLE_GEO=ON
+    -DVELOX_ENABLE_PARQUET=ON
+    -DVELOX_MONO_LIBRARY=ON
+  )
+  if [[ ${USE_CLANG:-false} != "true" ]]; then
+    CMAKE_FLAGS+=(-DVELOX_ENABLE_FAISS=ON)
+  fi
+  if [[ $BUILD_PROFILE == "ubuntu-debug" && ${USE_CLANG:-false} != "true" ]]; then
+    # REMOTE_FUNCTIONS pulls in fbthrift / fizz / wangle / mvfst, which
+    # velox doesn't bundle. ubuntu-debug runs in the velox-dev container
+    # which has them pre-installed; ubuntu-bundled-deps runs on a bare
+    # runner where they don't exist, so it must omit this flag.
+    CMAKE_FLAGS+=(-DVELOX_ENABLE_REMOTE_FUNCTIONS=ON)
+  fi
+  ;;
+
+fedora-debug)
+  # fedora-debug is always GCC; no USE_CLANG branch needed.
+  CMAKE_FLAGS=(
+    -DVELOX_ENABLE_PARQUET=ON
+    -DARROW_THRIFT_USE_SHARED=ON
+    -DVELOX_ENABLE_EXAMPLES=ON
+    -DVELOX_ENABLE_FAISS=ON
+  )
+  ;;
+
+macos)
+  # macOS is always Clang; no USE_CLANG branch needed.
+  CMAKE_FLAGS=(
+    -DTREAT_WARNINGS_AS_ERRORS=1
+    -DENABLE_ALL_WARNINGS=1
+    -DVELOX_ENABLE_PARQUET=ON
+    -DVELOX_MONO_LIBRARY=ON
+    -DVELOX_BUILD_SHARED=ON
+    -DVELOX_ENABLE_FAISS=ON
+  )
+  ;;
+
+*)
+  echo "::error::unknown BUILD_PROFILE: ${BUILD_PROFILE}" >&2
+  return 1
+  ;;
+esac

--- a/.github/scripts/gh-api-retry.sh
+++ b/.github/scripts/gh-api-retry.sh
@@ -1,0 +1,58 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# shellcheck shell=bash
+
+# Source this file from a workflow `run:` step to define a `gh_api`
+# function that wraps `gh api` with retry-with-exponential-backoff.
+# Use it in place of bare `gh api` for any GitHub API call from CI:
+# transient network blips, rate-limit hiccups (especially on the
+# stricter /search/issues path), and 5xx upstream failures all become
+# survivable instead of single-shot workflow failures.
+#
+# Args: same as `gh api`. Stdout is preserved on the successful
+# attempt so jq pipelines still work. On a final failure, the function
+# returns gh's exit code so the caller's `set -e` semantics are
+# unchanged.
+#
+# Env knobs (sensible defaults; tweak only if a caller has a reason):
+#   GH_API_RETRY_MAX     — max attempts, default 3
+#   GH_API_RETRY_BACKOFF — base sleep seconds, default 2 (exponential:
+#                          2, 4, 8 between attempts when base=2)
+#
+# Usage:
+#   source .github/scripts/gh-api-retry.sh
+#   gh_api "/repos/$OWNER/$REPO/pulls/$PR"
+#   gh_api --paginate "/repos/$OWNER/$REPO/issues/$N/comments"
+#   gh_api -X POST "/repos/$OWNER/$REPO/actions/runs/$RUN/rerun"
+gh_api() {
+  local max_attempts="${GH_API_RETRY_MAX:-3}"
+  local sleep_base="${GH_API_RETRY_BACKOFF:-2}"
+  local attempt=1
+  local exit_code=0
+  while [ "$attempt" -le "$max_attempts" ]; do
+    if gh api "$@"; then
+      return 0
+    fi
+    exit_code=$?
+    if [ "$attempt" -lt "$max_attempts" ]; then
+      local wait_secs=$((sleep_base ** attempt))
+      echo "::warning::gh api attempt ${attempt}/${max_attempts} failed (exit ${exit_code}); retrying in ${wait_secs}s" >&2
+      sleep "$wait_secs"
+    fi
+    attempt=$((attempt + 1))
+  done
+  echo "::error::gh api failed after ${max_attempts} attempts (final exit ${exit_code}): gh api $*" >&2
+  return "$exit_code"
+}

--- a/.github/workflows/ci-failure-comment.yml
+++ b/.github/workflows/ci-failure-comment.yml
@@ -55,6 +55,17 @@ jobs:
         github.event.workflow_run.conclusion == 'failure'))
     runs-on: ubuntu-latest
     steps:
+      # workflow_run-triggered jobs start with an empty workspace; check
+      # out just the helper-scripts dir so the sourced gh-api-retry.sh
+      # is on disk for the gh_api callers below. Sparse-checkout keeps
+      # this fast; the later "Checkout for Claude context and prompt"
+      # step swaps to a different sparse set (CLAUDE.md + skill files)
+      # but only after gh_api usage is done.
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/scripts
+
       - name: Get PR number
         id: pr
         env:
@@ -70,7 +81,8 @@ jobs:
             exit 0
           fi
 
-          pr_number=$(gh api \
+          source .github/scripts/gh-api-retry.sh
+          pr_number=$(gh_api \
             "/repos/${REPO}/pulls?head=${HEAD_OWNER}:${HEAD_BRANCH}&state=open" \
             -q '.[0].number // empty')
 
@@ -118,7 +130,8 @@ jobs:
             # No failure artifacts — build metadata from failed jobs in the run.
             # This handles workflows (e.g., Fuzzer Jobs) that don't upload
             # ci-failure-* artifacts.
-            METADATA=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs" \
+            source .github/scripts/gh-api-retry.sh
+            METADATA=$(gh_api "repos/${REPO}/actions/runs/${RUN_ID}/jobs" \
               --paginate --jq '[.jobs[] | select(.conclusion == "failure") | {job: .name, type: "unknown"}]')
             if [ "$METADATA" = "[]" ] || [ -z "$METADATA" ]; then
               echo "No failure artifacts or failed jobs found."

--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -50,7 +50,8 @@ jobs:
         run: |
           echo "JOB_TRIGGER: $JOB_TRIGGER"
           if [[ "$JOB_TRIGGER" == "pull_request" ]]; then
-            merge_base_commit=$(gh api -q '.merge_base_commit.sha' \
+            source .github/scripts/gh-api-retry.sh
+            merge_base_commit=$(gh_api -q '.merge_base_commit.sha' \
               /repos/facebookincubator/velox/compare/facebookincubator:$BASE_REF...$PR_OWNER:$HEAD_REF \
             )
 

--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -155,28 +155,14 @@ jobs:
           # Set compiler to GCC 14
           CUDA_FLAGS: -ccbin /opt/rh/gcc-toolset-14/root/usr/bin
         run: |
-          EXTRA_CMAKE_FLAGS=(
-            "-DVELOX_ENABLE_BENCHMARKS=ON"
-            "-DVELOX_ENABLE_EXAMPLES=ON"
-            "-DVELOX_ENABLE_ARROW=ON"
-            "-DVELOX_ENABLE_GEO=ON"
-            "-DVELOX_ENABLE_PARQUET=ON"
-            "-DVELOX_ENABLE_HDFS=ON"
-            "-DVELOX_ENABLE_S3=ON"
-            "-DVELOX_ENABLE_GCS=ON"
-            "-DVELOX_ENABLE_ABFS=ON"
-            "-DVELOX_ENABLE_WAVE=ON"
-            "-DVELOX_MONO_LIBRARY=ON"
-          )
+          # All adapters cmake flags (including compiler-conditional
+          # ones — Faiss, REMOTE_FUNCTIONS, and CUDF — are only added
+          # when USE_CLANG != true) live in .github/scripts/cmake-flags.sh.
+          # Edit the script, not this list.
+          BUILD_PROFILE=adapters USE_CLANG="${USE_CLANG}" source .github/scripts/cmake-flags.sh
+          EXTRA_CMAKE_FLAGS=("${CMAKE_FLAGS[@]}")
           if [[ "${USE_CLANG}" = "true" ]]; then
              scripts/setup-centos9.sh install_clang15; export CC=/usr/bin/clang-15; export CXX=/usr/bin/clang++-15; CUDA_FLAGS="-ccbin /usr/lib64/llvm15/bin/clang++-15";
-          else
-            # cuDF (unsupported for Clang) and Faiss (link issue when using Clang)
-            # are excluded for Clang compilation and need to be added back when using GCC.
-            EXTRA_CMAKE_FLAGS+=("-DVELOX_ENABLE_CUDF=ON")
-            EXTRA_CMAKE_FLAGS+=("-DVELOX_ENABLE_FAISS=ON")
-            # Investigate issues with remote function service: Issue #13897
-            EXTRA_CMAKE_FLAGS+=("-DVELOX_ENABLE_REMOTE_FUNCTIONS=ON")
           fi
           source /opt/rh/gcc-toolset-14/enable
           g++ --version
@@ -519,6 +505,14 @@ jobs:
         env:
           VELOX_DEPENDENCY_SOURCE: SYSTEM
           ICU_SOURCE: SYSTEM
+          # Mirror the adapters and fedora-debug jobs: build FAISS from
+          # source instead of resolving the system-installed package.
+          # The system FAISS config (/usr/local/share/faiss/faiss-config.cmake)
+          # sets the link interface of the imported `faiss` target to
+          # include OpenMP::OpenMP_CXX without ever calling
+          # find_package(OpenMP) to define it, so a SYSTEM resolution
+          # fails the configure.
+          faiss_SOURCE: BUNDLED
           # Use BUNDLED gflags to provide PIC static gflags for .so plugins.
           # The container's folly is built with -DGFLAGS_SHARED=FALSE so its
           # exported config references gflags_static which BUNDLED gflags provides.
@@ -529,23 +523,20 @@ jobs:
           glog_SOURCE: SYSTEM
           MAKEFLAGS: NUM_THREADS=32 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=6
         run: |
-          EXTRA_CMAKE_FLAGS=(
-            "-DCMAKE_LINK_LIBRARIES_STRATEGY=REORDER_FREELY"
-            "-DVELOX_BUILD_SHARED=ON"
-            "-DVELOX_ENABLE_BENCHMARKS=ON"
-            "-DVELOX_ENABLE_EXAMPLES=ON"
-            "-DVELOX_ENABLE_ARROW=ON"
-            "-DVELOX_ENABLE_GEO=ON"
-            "-DVELOX_ENABLE_PARQUET=ON"
-            "-DVELOX_MONO_LIBRARY=ON"
-          )
+          # The container ships CMake 3.30.4. Bump to 3.31.1 so
+          # CMAKE_LINK_LIBRARIES_STRATEGY=REORDER_FREELY (added in 3.31)
+          # actually takes effect — without it ld --as-needed drops
+          # libxxhash.so before libthriftmetadata.a needs XXH3_64bits,
+          # breaking the velox_functions_remote_client_test link.
+          uv tool install --force cmake@3.31.1
+          # Shared per-profile flag lists live in
+          # .github/scripts/cmake-flags.sh — script handles
+          # Clang-conditional flags internally via USE_CLANG.
+          BUILD_PROFILE=ubuntu-debug USE_CLANG="${USE_CLANG}" source .github/scripts/cmake-flags.sh
           if [[ "${USE_CLANG}" = "true" ]]; then
              export CC=/usr/bin/clang-15; export CXX=/usr/bin/clang++-15;
-          else
-            EXTRA_CMAKE_FLAGS+=("-DVELOX_ENABLE_FAISS=ON")
-            EXTRA_CMAKE_FLAGS+=("-DVELOX_ENABLE_REMOTE_FUNCTIONS=ON")
           fi
-          export EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS[*]}"
+          export EXTRA_CMAKE_FLAGS="${CMAKE_FLAGS[*]}"
           make debug 2>&1 | tee /tmp/build-output.log
 
       - name: Extract build errors
@@ -725,14 +716,13 @@ jobs:
           simdjson_SOURCE: BUNDLED
           gRPC_SOURCE: SYSTEM
           MAKEFLAGS: NUM_THREADS=32 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=6
-          EXTRA_CMAKE_FLAGS: >-
-            -DVELOX_ENABLE_PARQUET=ON
-            -DARROW_THRIFT_USE_SHARED=ON
-            -DVELOX_ENABLE_EXAMPLES=ON
         run: |
           uv tool install --force cmake@3.31.1
           dnf install -y -q --setopt=install_weak_deps=False grpc-devel grpc-plugins
-          export EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS} -DVELOX_ENABLE_FAISS=ON"
+          # Shared per-profile flag lists live in
+          # .github/scripts/cmake-flags.sh.
+          BUILD_PROFILE=fedora-debug source .github/scripts/cmake-flags.sh
+          export EXTRA_CMAKE_FLAGS="${CMAKE_FLAGS[*]}"
           make debug
 
       - name: CCache after

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -102,16 +102,12 @@ jobs:
           CMAKE_POLICY_VERSION_MINIMUM: '3.5'
         run: |
           ccache -sz -M 5Gi
-          cmake \
-              -B _build/$BUILD_TYPE \
-              -GNinja \
-              -DTREAT_WARNINGS_AS_ERRORS=1 \
-              -DENABLE_ALL_WARNINGS=1 \
-              -DVELOX_ENABLE_PARQUET=ON \
-              -DVELOX_MONO_LIBRARY=ON \
-              -DVELOX_BUILD_SHARED=ON \
-              -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
-              -DVELOX_ENABLE_FAISS=ON
+          # Shared per-profile flag lists live in
+          # .github/scripts/cmake-flags.sh.
+          BUILD_PROFILE=macos source .github/scripts/cmake-flags.sh
+          cmake -B _build/$BUILD_TYPE -GNinja \
+              "${CMAKE_FLAGS[@]}" \
+              -DCMAKE_BUILD_TYPE=$BUILD_TYPE
 
       - name: Build
         run: |

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -121,6 +121,17 @@ jobs:
 
     steps:
 
+      # Sparse-checkout just the helper scripts dir up front so the
+      # sourced gh-api-retry.sh is on disk for the merge-base step
+      # below. Lands at $GITHUB_WORKSPACE/.github/scripts; the later
+      # "Checkout Contender" / "Checkout Main" steps put their full
+      # clones in different subdirectories (velox/, velox_main/) and
+      # don't conflict.
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/scripts
+
       - name: Get merge base with main
         if: ${{ github.event_name != 'schedule' }}
         working-directory: ${{ github.workspace }}
@@ -132,12 +143,13 @@ jobs:
           PR_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
         id: get-merge-base
         run: |
+          source .github/scripts/gh-api-retry.sh
           if [ '${{ github.event_name == 'push' }}' == "true" ]; then
             # get the parent commit of the current one to get the relevant function signatures
-            head_main=$(gh api -q '.parents.[0].sha' '/repos/facebookincubator/velox/commits/${{ github.sha }}')
+            head_main=$(gh_api -q '.parents.[0].sha' '/repos/facebookincubator/velox/commits/${{ github.sha }}')
           elif [ '${{ github.event_name == 'pull_request' }}' == "true" ]; then
             # Get the merge base from the api
-            head_main=$(gh api -q '.merge_base_commit.sha' \
+            head_main=$(gh_api -q '.merge_base_commit.sha' \
               /repos/facebookincubator/velox/compare/facebookincubator:$BASE_REF...$PR_OWNER:$HEAD_REF \
             )
           else

--- a/.github/workflows/ubuntu-bundled-deps.yml
+++ b/.github/workflows/ubuntu-bundled-deps.yml
@@ -82,18 +82,8 @@ jobs:
           ICU_SOURCE: SYSTEM
           MAKEFLAGS: NUM_THREADS=16 MAX_HIGH_MEM_JOBS=4 MAX_LINK_JOBS=2
         run: |
-          EXTRA_CMAKE_FLAGS=(
-            "-DCMAKE_LINK_LIBRARIES_STRATEGY=REORDER_FREELY"
-            "-DVELOX_ENABLE_BENCHMARKS=ON"
-            "-DVELOX_ENABLE_EXAMPLES=ON"
-            "-DVELOX_ENABLE_ARROW=ON"
-            "-DVELOX_ENABLE_GEO=ON"
-            "-DVELOX_ENABLE_PARQUET=ON"
-            "-DVELOX_MONO_LIBRARY=ON"
-            "-DVELOX_BUILD_SHARED=ON"
-            "-DVELOX_ENABLE_FAISS=ON"
-            "-DVELOX_ENABLE_REMOTE_FUNCTIONS=ON"
-          )
+          BUILD_PROFILE=ubuntu-bundled-deps source .github/scripts/cmake-flags.sh
+          export EXTRA_CMAKE_FLAGS="${CMAKE_FLAGS[*]}"
           make debug
 
       - name: CCache after

--- a/CMake/FindArrow.cmake
+++ b/CMake/FindArrow.cmake
@@ -43,5 +43,36 @@ if(Arrow_FOUND AND NOT TARGET arrow)
     arrow
     PROPERTIES IMPORTED_LOCATION ${ARROW_LIB} INTERFACE_LINK_LIBRARIES thrift
   )
-  set_target_properties(arrow_testing PROPERTIES IMPORTED_LOCATION ${ARROW_TESTING_LIB})
+  # arrow_testing's gtest_util.cc.o references arrow::ipc::internal::json::*
+  # and arrow::Initialize symbols defined in libarrow.a. We need libarrow.a
+  # to appear AFTER libarrow_testing.a in the link line so ld --as-needed
+  # has the unresolved refs in its set when it sees libarrow.a.
+  #
+  # WORKAROUND for an ODR violation: the velox-dev:adapters image installs
+  # both Apache Thrift (at /usr/local/include/thrift/transport/) and FBThrift
+  # (at /usr/local/include/thrift/lib/cpp/transport/). Both inject
+  # apache::thrift::transport::TMemoryBuffer into the same C++ namespace
+  # with different inline bodies (different `write_virt` overflow logic,
+  # null-pointer guards, etc.). When MONO=ON + static linking, the linker
+  # dedupes weak template instantiations across libvelox.a's translation
+  # units and picks ONE definition. Apache's wins → vendored arrow-parquet
+  # code is happy. FBThrift's wins → vendored code calls FBThrift's
+  # TMemoryBuffer::write_virt at runtime and tests fail with "Insufficient
+  # space in external MemoryBuffer".
+  #
+  # Declaring the dep via the literal ${ARROW_LIB} path (instead of the
+  # `arrow` target name) appends libarrow.a to consumers' link lines as a
+  # terminal node, without going through CMake's transitive-dep graph. This
+  # preserves the established link order under which Apache's TMemoryBuffer
+  # definition wins. Using the `arrow` target here would reorder CMake's
+  # dep graph (because `arrow` carries INTERFACE_LINK_LIBRARIES thrift) and
+  # flip the winner to FBThrift — breaking velox_dwio_arrow_parquet_writer_test.
+  #
+  # Proper fix is upstream: FBThrift should not share the apache::thrift::*
+  # namespace, or velox should split libvelox so FBThrift-using code and
+  # vendored arrow-parquet code never land in the same link line.
+  set_target_properties(
+    arrow_testing
+    PROPERTIES IMPORTED_LOCATION ${ARROW_TESTING_LIB} INTERFACE_LINK_LIBRARIES ${ARROW_LIB}
+  )
 endif()

--- a/CMake/resolve_dependency_modules/arrow/CMakeLists.txt
+++ b/CMake/resolve_dependency_modules/arrow/CMakeLists.txt
@@ -110,8 +110,14 @@ if(VELOX_ENABLE_ARROW)
   )
   set_target_properties(arrow PROPERTIES IMPORTED_LOCATION ${ARROW_LIBDIR}/libarrow.a)
   set_property(TARGET arrow PROPERTY INTERFACE_LINK_LIBRARIES ${RE2} thrift)
+  # Mirror the path-based interface dep from CMake/FindArrow.cmake — see
+  # the SYSTEM-arrow comment there for the ODR-violation rationale that
+  # forces us to use ${ARROW_LIBDIR}/libarrow.a (path) instead of the
+  # `arrow` target name.
   set_target_properties(
     arrow_testing
-    PROPERTIES IMPORTED_LOCATION ${ARROW_LIBDIR}/libarrow_testing.a
+    PROPERTIES
+      IMPORTED_LOCATION ${ARROW_LIBDIR}/libarrow_testing.a
+      INTERFACE_LINK_LIBRARIES ${ARROW_LIBDIR}/libarrow.a
   )
 endif()

--- a/CMake/resolve_dependency_modules/gflags.cmake
+++ b/CMake/resolve_dependency_modules/gflags.cmake
@@ -42,7 +42,15 @@ FetchContent_Declare(
 set(GFLAGS_NAMESPACE "google;gflags")
 
 set(GFLAGS_BUILD_SHARED_LIBS ${VELOX_BUILD_SHARED})
-set(GFLAGS_BUILD_STATIC_LIBS ${VELOX_BUILD_STATIC})
+# Always build the static target. The pre-installed folly in the
+# velox-dev:ubuntu-22.04 image was linked against gflags_static and its
+# exported config (folly-targets.cmake) keeps `gflags_static` in
+# INTERFACE_LINK_LIBRARIES. When VELOX_BUILD_SHARED=ON,
+# cmake_dependent_option forces VELOX_BUILD_STATIC=OFF, so without this
+# override BUNDLED gflags would only emit the shared variants and CMake
+# would fall back to a literal `-lgflags_static` that the linker can't
+# resolve. Cost is one extra small static archive.
+set(GFLAGS_BUILD_STATIC_LIBS ON)
 
 set(GFLAGS_BUILD_gflags_LIB ON)
 set(GFLAGS_BUILD_gflags_nothreads_LIB ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -659,6 +659,32 @@ if(VELOX_ENABLE_REMOTE_FUNCTIONS)
   find_package(fizz CONFIG REQUIRED)
   find_package(wangle CONFIG REQUIRED)
   find_package(FBThrift CONFIG REQUIRED)
+
+  # Workaround for a missing edge in the system-installed FBThrift's
+  # exported CMake graph. At the pinned FB_OS_VERSION, fbthrift's own
+  # `target_link_libraries(thriftmetadata PUBLIC ...)` block does not
+  # declare an xxhash dep on `thriftmetadata` — the conditional
+  # `if(Xxhash_FOUND) target_link_libraries(thriftmetadata PUBLIC
+  # ${Xxhash_LIBRARY})` block was added later in fbthrift mainline.
+  # Meanwhile `libthriftmetadata.a` itself does call XXH3_64bits(),
+  # so the binary needs xxhash but the exported FBThriftTargets.cmake
+  # doesn't declare it. Symptom (only with VELOX_BUILD_SHARED=ON +
+  # VELOX_MONO_LIBRARY=ON, where libvelox.so doesn't drag xxhash in
+  # incidentally): `undefined reference to symbol 'XXH3_64bits'` on
+  # any test executable that links FBThrift through velox.
+  # Tracking: https://github.com/facebook/fbthrift/issues/651,
+  # https://github.com/facebookincubator/velox/issues/13153.
+  # Remove once FB_OS_VERSION is bumped past the commit that adds the
+  # `if(Xxhash_FOUND)` block AND the velox-dev container is rebuilt
+  # against that fixed fbthrift release.
+  if(TARGET FBThrift::thriftmetadata)
+    find_library(VELOX_XXHASH_LIB xxhash REQUIRED)
+    set_property(
+      TARGET FBThrift::thriftmetadata
+      APPEND
+      PROPERTY INTERFACE_LINK_LIBRARIES "${VELOX_XXHASH_LIB}"
+    )
+  endif()
 endif()
 
 if(VELOX_ENABLE_GCS)


### PR DESCRIPTION
Summary:

### Summary

- Introduces `.github/scripts/cmake-flags.sh`, a bash helper that sets a `CMAKE_FLAGS` array per `BUILD_PROFILE` (adapters, ubuntu-debug, ubuntu-bundled-deps, fedora-debug, macos).
- Replaces scattered inline `EXTRA_CMAKE_FLAGS=(...)` arrays, enabling one-line per-profile flag changes and fixing a long-standing bash export bug.
- Pure refactor for adapters / fedora-debug / macos (flag sets preserved byte-for-byte from main). ubuntu-bundled-deps drops `VELOX_ENABLE_REMOTE_FUNCTIONS=ON` from its declared set (see Workflow Adoption); previously declared but never reached cmake due to the bash bug. The bash-export fix is what unmasks the latent ubuntu-debug issues addressed below.

### Bash Export Bug Fix

- Previously, exporting an array as a scalar with the same name failed silently, causing `make` to receive empty flags and cmake to use defaults.
- The new script uses distinct names for the array (`CMAKE_FLAGS`) and export (`EXTRA_CMAKE_FLAGS`), ensuring flags are properly passed.

### Workflow Adoption

| File | Change |
|---|---|
| `.github/workflows/linux-build-base.yml` | "Make Build" steps for adapters, ubuntu-debug, fedora-debug now source the script. Ubuntu-debug installs cmake@3.31.1 for `CMAKE_LINK_LIBRARIES_STRATEGY=REORDER_FREELY`. Ubuntu-debug env adds `faiss_SOURCE: BUNDLED`. |
| `.github/workflows/macos.yml` | Configure Build step sources the script. |
| `.github/workflows/ubuntu-bundled-deps.yml` | Make Debug Build step sources the script, fixing the silent-export bug. Flags now reach cmake. Profile drops `VELOX_ENABLE_REMOTE_FUNCTIONS=ON` — velox doesn't bundle the FB_OS suite (fbthrift / fizz / wangle / mvfst), so REMOTE_FUNCTIONS has no business in BUNDLED-deps mode (matches de facto behavior since the flag never reached cmake before). |

### Latent Ubuntu-Debug Build Fixes

With correct flags applied, three CMake config bugs surfaced and were fixed:

1. **`CMake/resolve_dependency_modules/gflags.cmake`**: Forces `GFLAGS_BUILD_STATIC_LIBS=ON` to resolve linking issues with folly and gflags_static.
2. **`CMake/FindArrow.cmake`** (and `CMake/resolve_dependency_modules/arrow/CMakeLists.txt` for BUNDLED arrow): Appends `${ARROW_LIB}` (path, not target) to `arrow_testing`'s `INTERFACE_LINK_LIBRARIES`. The path-based form ensures libarrow.a appears after libarrow_testing.a in the link line — required so `ld --as-needed` resolves `arrow::ipc::internal::json::*` and `arrow::Initialize` referenced from `gtest_util.cc.o`. **Workaround for an ODR violation**: the velox-dev:adapters image installs both Apache Thrift (at `/usr/local/include/thrift/transport/`) and FBThrift (at `/usr/local/include/thrift/lib/cpp/transport/`); both inject `apache::thrift::transport::TMemoryBuffer` into the same namespace with different inline bodies, and using the `arrow` target name here (instead of `${ARROW_LIB}`) reorders CMake's dep graph to drag FBThrift's definition ahead of Apache's, breaking `velox_dwio_arrow_parquet_writer_test` with "Insufficient space in external MemoryBuffer". Proper upstream fix would be FBThrift moving its types out of `apache::thrift::*`.
3. **`CMakeLists.txt`**: Appends xxhash to `FBThrift::thriftmetadata`'s `INTERFACE_LINK_LIBRARIES`. Required due to missing xxhash dependency in the pinned FBThrift version. See [fbthrift#651](https://github.com/facebook/fbthrift/issues/651), [velox#13153](https://github.com/facebookincubator/velox/issues/13153).

> These fixes, along with `REORDER_FREELY`, allow CMake to correctly position static archives for the linker.

Differential Revision: D105292587


