### PR TITLE
fix(cudf): Fix CudfSplitReader ReaderOptions init

### DIFF
--- a/velox/experimental/cudf/connectors/hive/CudfSplitReader.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfSplitReader.cpp
@@ -75,8 +75,10 @@ CudfSplitReader::CudfSplitReader(
       pool_(connectorQueryCtx->memoryPool()),
       useExperimentalCudfReader_(useExperimentalCudfReader),
       baseReaderOpts_(pool_),
-
-      subfieldFilterExpr_(subfieldFilterExpr) {}
+      subfieldFilterExpr_(subfieldFilterExpr) {
+  baseReaderOpts_.setDataIoStats(ioStatistics_);
+  baseReaderOpts_.setMetadataIoStats(ioStatistics_);
+}
 
 void CudfSplitReader::prepareSplit(
     dwio::common::RuntimeStatistics& runtimeStats) {

--- a/velox/experimental/cudf/connectors/hive/CudfSplitReader.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfSplitReader.cpp
@@ -74,7 +74,7 @@ CudfSplitReader::CudfSplitReader(
       cudfHiveConfig_(cudfHiveConfig),
       pool_(connectorQueryCtx->memoryPool()),
       useExperimentalCudfReader_(useExperimentalCudfReader),
-      baseReaderOpts_(pool_, ioStatistics_.get(), ioStatistics_.get()),
+      baseReaderOpts_(pool_),
 
       subfieldFilterExpr_(subfieldFilterExpr) {}
 


### PR DESCRIPTION
Fix
```
/__w/velox/velox/velox/experimental/cudf/connectors/hive/CudfSplitReader.cpp: In constructor 'facebook::velox::cudf_velox::connector::hive::CudfSplitReader::CudfSplitReader(std::shared_ptr<facebook::velox::cudf_velox::connector::hive::CudfHiveConnectorSplit>, std::shared_ptr<const facebook::velox::connector::hive::HiveTableHandle>, const facebook::velox::RowTypePtr&, const std::vector<std::__cxx11::basic_string<char> >&, facebook::velox::FileHandleFactory*, folly::Executor*, const facebook::velox::connector::ConnectorQueryCtx*, const std::shared_ptr<facebook::velox::cudf_velox::connector::hive::CudfHiveConfig>&, const std::shared_ptr<facebook::velox::io::IoStatistics>&, const std::shared_ptr<facebook::velox::IoStats>&, bool, const cudf::ast::expression*)':
/__w/velox/velox/velox/experimental/cudf/connectors/hive/CudfSplitReader.cpp:77:7: error: no matching function for call to 'facebook::velox::dwio::common::ReaderOptions::ReaderOptions(facebook::velox::memory::MemoryPool*&, std::__shared_ptr<facebook::velox::io::IoStatistics, __gnu_cxx::_S_atomic>::element_type*, std::__shared_ptr<facebook::velox::io::IoStatistics, __gnu_cxx::_S_atomic>::element_type*)'
   77 |       baseReaderOpts_(pool_, ioStatistics_.get(), ioStatistics_.get()),
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /__w/velox/velox/./velox/experimental/cudf/connectors/hive/CudfHiveConnectorSplit.h:20,
                 from /__w/velox/velox/./velox/experimental/cudf/connectors/hive/CudfSplitReader.h:20,
                 from /__w/velox/velox/velox/experimental/cudf/connectors/hive/CudfSplitReader.cpp:18:
/__w/velox/velox/./velox/dwio/common/Options.h:579:12: note: candidate: 'facebook::velox::dwio::common::ReaderOptions::ReaderOptions(facebook::velox::memory::MemoryPool*)'
  579 |   explicit ReaderOptions(velox::memory::MemoryPool* pool)
      |            ^~~~~~~~~~~~~
/__w/velox/velox/./velox/dwio/common/Options.h:579:12: note:   candidate expects 1 argument, 3 provided
/__w/velox/velox/./velox/dwio/common/Options.h:572:7: note: candidate: 'facebook::velox::dwio::common::ReaderOptions::ReaderOptions(const facebook::velox::dwio::common::ReaderOptions&)'
  572 | class ReaderOptions : public io::ReaderOptions {
```
Refs: https://github.com/facebookincubator/velox/actions/runs/25913198690/job/76163332652?pr=17500