### PR TITLE
fix(cudf): Fix UCX output buffer lifetime after async cuDF concat

### DIFF
--- a/velox/experimental/cudf/exec/Utilities.cpp
+++ b/velox/experimental/cudf/exec/Utilities.cpp
@@ -172,7 +172,7 @@ std::vector<std::unique_ptr<cudf::table>> getConcatenatedTableBatched(
 
 void streamsWaitForStream(
     CudaEvent& event,
-    const std::vector<rmm::cuda_stream_view>& streams,
+    std::span<const rmm::cuda_stream_view> streams,
     rmm::cuda_stream_view stream) {
   event.recordFrom(stream);
   for (const auto& strm : streams) {
@@ -208,8 +208,8 @@ const CudaEvent& CudaEvent::waitOn(rmm::cuda_stream_view stream) const {
 }
 
 void orderCudfVectorDeallocationsAfterStream(
-    const std::vector<CudfVectorPtr>& vectors,
-    const std::vector<rmm::cuda_stream_view>& inputStreams,
+    std::span<const CudfVectorPtr> vectors,
+    std::span<const rmm::cuda_stream_view> inputStreams,
     rmm::cuda_stream_view stream) {
   bool allRebound = true;
   for (const auto& vector : vectors) {

--- a/velox/experimental/cudf/exec/Utilities.cpp
+++ b/velox/experimental/cudf/exec/Utilities.cpp
@@ -24,9 +24,42 @@
 #include <cudf/detail/utilities/stream_pool.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
+#include <cuda_runtime_api.h>
+
 #include <limits>
+#include <vector>
 
 namespace facebook::velox::cudf_velox {
+namespace {
+
+int getNumCudaDevices() {
+  int numDevices{};
+  CUDF_CUDA_TRY(cudaGetDeviceCount(&numDevices));
+  return numDevices;
+}
+
+int getCurrentCudaDevice() {
+  int device{};
+  CUDF_CUDA_TRY(cudaGetDevice(&device));
+  return device;
+}
+
+CudaEvent& eventForThread() {
+  // Intentionally leak per-thread, per-device events to avoid CUDA calls from
+  // thread-local destructors after CUDA context teardown.
+  thread_local static std::vector<CudaEvent*> events(getNumCudaDevices());
+  auto const device = getCurrentCudaDevice();
+  VELOX_CHECK_GE(device, 0);
+  auto const deviceIndex = static_cast<size_t>(device);
+  VELOX_CHECK_LT(deviceIndex, events.size());
+
+  if (events[deviceIndex] == nullptr) {
+    events[deviceIndex] = new CudaEvent(cudaEventDisableTiming);
+  }
+  return *events[deviceIndex];
+}
+
+} // namespace
 
 std::unique_ptr<cudf::table> concatenateTables(
     std::vector<std::unique_ptr<cudf::table>> tables,
@@ -218,8 +251,7 @@ void orderCudfVectorDeallocationsAfterStream(
   }
 
   if (!allRebound) {
-    CudaEvent event(cudaEventDisableTiming);
-    streamsWaitForStream(event, inputStreams, stream);
+    streamsWaitForStream(eventForThread(), inputStreams, stream);
   }
 }
 

--- a/velox/experimental/cudf/exec/Utilities.cpp
+++ b/velox/experimental/cudf/exec/Utilities.cpp
@@ -101,11 +101,7 @@ std::unique_ptr<cudf::table> getConcatenatedTable(
   // the wrong stream.
   auto output = cudf::concatenate(tableViews, stream, mr);
 
-  // Order input deallocations after the concatenate read.
-  // Since memory resources are stream-ordered, deallocations
-  // on inputStreams will be ordered after the concatenate completes.
-  CudaEvent event(cudaEventDisableTiming);
-  streamsWaitForStream(event, inputStreams, stream);
+  orderCudfVectorDeallocationsAfterStream(tables, inputStreams, stream);
   // Input tables are deallocated here when 'tables' goes out of scope.
   return output;
 }
@@ -168,12 +164,7 @@ std::vector<std::unique_ptr<cudf::table>> getConcatenatedTableBatched(
             stream,
             mr));
   }
-  // Order input deallocations after the concatenate reads by making all input
-  // streams wait for the output stream.
-  // Since memory resources are stream-ordered, deallocations
-  // on inputStreams will be ordered after the concatenate completes.
-  CudaEvent event(cudaEventDisableTiming);
-  streamsWaitForStream(event, inputStreams, stream);
+  orderCudfVectorDeallocationsAfterStream(tables, inputStreams, stream);
 
   // Input tables are deallocated here when 'tables' goes out of scope.
   return outputTables;
@@ -214,6 +205,22 @@ const CudaEvent& CudaEvent::recordFrom(rmm::cuda_stream_view stream) const {
 const CudaEvent& CudaEvent::waitOn(rmm::cuda_stream_view stream) const {
   CUDF_CUDA_TRY(cudaStreamWaitEvent(stream.value(), event_, 0));
   return *this;
+}
+
+void orderCudfVectorDeallocationsAfterStream(
+    const std::vector<CudfVectorPtr>& vectors,
+    const std::vector<rmm::cuda_stream_view>& inputStreams,
+    rmm::cuda_stream_view stream) {
+  bool allRebound = true;
+  for (const auto& vector : vectors) {
+    VELOX_CHECK_NOT_NULL(vector);
+    allRebound &= vector->rebindStream(stream);
+  }
+
+  if (!allRebound) {
+    CudaEvent event(cudaEventDisableTiming);
+    streamsWaitForStream(event, inputStreams, stream);
+  }
 }
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/Utilities.h
+++ b/velox/experimental/cudf/exec/Utilities.h
@@ -23,6 +23,7 @@
 #include <rmm/cuda_stream_view.hpp>
 
 #include <memory>
+#include <span>
 
 namespace facebook::velox::cudf_velox {
 
@@ -178,7 +179,7 @@ class CudaEvent {
  */
 void streamsWaitForStream(
     CudaEvent& event,
-    const std::vector<rmm::cuda_stream_view>& streams,
+    std::span<const rmm::cuda_stream_view> streams,
     rmm::cuda_stream_view stream);
 
 /**
@@ -190,7 +191,7 @@ void streamsWaitForStream(
  * materializing, e.g. packed-table inputs or older cuDF builds.
  */
 void orderCudfVectorDeallocationsAfterStream(
-    const std::vector<CudfVectorPtr>& vectors,
-    const std::vector<rmm::cuda_stream_view>& inputStreams,
+    std::span<const CudfVectorPtr> vectors,
+    std::span<const rmm::cuda_stream_view> inputStreams,
     rmm::cuda_stream_view stream);
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/Utilities.h
+++ b/velox/experimental/cudf/exec/Utilities.h
@@ -180,4 +180,17 @@ void streamsWaitForStream(
     CudaEvent& event,
     const std::vector<rmm::cuda_stream_view>& streams,
     rmm::cuda_stream_view stream);
+
+/**
+ * @brief Orders CudfVector deallocations after work on a target stream.
+ *
+ * Prefer rebinding owned table buffers to @p stream so stream-ordered memory
+ * resources free the inputs after prior work on that stream. Falls back to an
+ * event wait on @p inputStreams when an input cannot be rebound without
+ * materializing, e.g. packed-table inputs or older cuDF builds.
+ */
+void orderCudfVectorDeallocationsAfterStream(
+    const std::vector<CudfVectorPtr>& vectors,
+    const std::vector<rmm::cuda_stream_view>& inputStreams,
+    rmm::cuda_stream_view stream);
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/tests/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/CMakeLists.txt
@@ -108,6 +108,12 @@ velox_add_cudf_test(
 )
 
 velox_add_cudf_test(
+  NAME velox_cudf_vector_test
+  SOURCES Main.cpp CudfVectorTest.cpp
+  LIBS velox_cudf_vector velox_vector_test_lib cudf::cudf
+)
+
+velox_add_cudf_test(
   NAME velox_cudf_decimal_expression_test
   SOURCES Main.cpp DecimalExpressionTest.cpp
   LIBS ${CUDF_TEST_DEFAULT_LIBS} velox_functions_test_lib

--- a/velox/experimental/cudf/tests/CudfVectorTest.cpp
+++ b/velox/experimental/cudf/tests/CudfVectorTest.cpp
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/cudf/vector/CudfVector.h"
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+#include <cudf/contiguous_split.hpp>
+#include <cudf/utilities/error.hpp>
+
+#include <rmm/device_buffer.hpp>
+#include <rmm/mr/cuda_memory_resource.hpp>
+#include <rmm/resource_ref.hpp>
+
+#include <cuda/memory_resource>
+#include <cuda/stream_ref>
+#include <cuda_runtime_api.h>
+
+#include <array>
+#include <memory>
+#include <vector>
+
+using namespace facebook::velox;
+using namespace facebook::velox::cudf_velox;
+using namespace facebook::velox::test;
+
+namespace {
+
+class TestCudaStream {
+ public:
+  TestCudaStream() {
+    VELOX_CHECK_EQ(
+        cudaStreamCreateWithFlags(&stream_, cudaStreamNonBlocking),
+        cudaSuccess);
+  }
+
+  ~TestCudaStream() {
+    if (stream_ != nullptr) {
+      cudaStreamDestroy(stream_);
+    }
+  }
+
+  rmm::cuda_stream_view view() const {
+    return rmm::cuda_stream_view{stream_};
+  }
+
+  cudaStream_t value() const {
+    return stream_;
+  }
+
+ private:
+  cudaStream_t stream_{nullptr};
+};
+
+struct RecordingState {
+  cudaStream_t lastDeallocationStream{nullptr};
+  int deallocationCount{0};
+};
+
+class RecordingDeviceResource {
+ public:
+  void* allocate(
+      cuda::stream_ref stream,
+      std::size_t bytes,
+      std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) {
+    return upstream_.allocate(stream, bytes, alignment);
+  }
+
+  void deallocate(
+      cuda::stream_ref stream,
+      void* ptr,
+      std::size_t bytes,
+      std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept {
+    state_->lastDeallocationStream = stream.get();
+    ++state_->deallocationCount;
+    upstream_.deallocate(stream, ptr, bytes, alignment);
+  }
+
+  void* allocate_sync(
+      std::size_t bytes,
+      std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) {
+    return upstream_.allocate_sync(bytes, alignment);
+  }
+
+  void deallocate_sync(
+      void* ptr,
+      std::size_t bytes,
+      std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept {
+    upstream_.deallocate_sync(ptr, bytes, alignment);
+  }
+
+  void reset() {
+    state_->lastDeallocationStream = nullptr;
+    state_->deallocationCount = 0;
+  }
+
+  int deallocationCount() const {
+    return state_->deallocationCount;
+  }
+
+  cudaStream_t lastDeallocationStream() const {
+    return state_->lastDeallocationStream;
+  }
+
+  bool operator==(const RecordingDeviceResource& other) const noexcept {
+    return state_ == other.state_;
+  }
+
+ private:
+  std::shared_ptr<RecordingState> state_{std::make_shared<RecordingState>()};
+  rmm::mr::cuda_memory_resource upstream_;
+};
+
+void get_property(
+    const RecordingDeviceResource&,
+    cuda::mr::device_accessible) noexcept {}
+
+std::unique_ptr<cudf::table> makeTable(
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  std::array<int32_t, 4> values{{1, 2, 3, 4}};
+  rmm::device_buffer data(values.size() * sizeof(int32_t), stream, mr);
+  CUDF_CUDA_TRY(cudaMemcpyAsync(
+      data.data(),
+      values.data(),
+      values.size() * sizeof(int32_t),
+      cudaMemcpyHostToDevice,
+      stream.value()));
+
+  std::vector<std::unique_ptr<cudf::column>> columns;
+  columns.push_back(std::make_unique<cudf::column>(
+      cudf::data_type{cudf::type_id::INT32},
+      static_cast<cudf::size_type>(values.size()),
+      std::move(data),
+      rmm::device_buffer{},
+      0));
+  return std::make_unique<cudf::table>(std::move(columns));
+}
+
+class CudfVectorTest : public ::testing::Test, public VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+};
+
+TEST_F(CudfVectorTest, rebindOwnedTableDeallocationStream) {
+  TestCudaStream allocationStream;
+  TestCudaStream targetStream;
+  RecordingDeviceResource resource;
+
+  auto table = makeTable(
+      allocationStream.view(),
+      rmm::to_device_async_resource_ref_checked(&resource));
+  allocationStream.view().synchronize();
+
+  auto vector = std::make_shared<CudfVector>(
+      pool_.get(),
+      ROW({"c0"}, {INTEGER()}),
+      table->num_rows(),
+      std::move(table),
+      allocationStream.view());
+  resource.reset();
+
+  ASSERT_TRUE(vector->rebindStream(targetStream.view()));
+  vector.reset();
+
+  EXPECT_GT(resource.deallocationCount(), 0);
+  EXPECT_EQ(resource.lastDeallocationStream(), targetStream.value());
+}
+
+TEST_F(CudfVectorTest, rebindPackedTableDeallocationStream) {
+  TestCudaStream allocationStream;
+  TestCudaStream targetStream;
+  RecordingDeviceResource resource;
+
+  auto table = makeTable(
+      allocationStream.view(), cudf::get_current_device_resource_ref());
+  auto packedColumns = cudf::pack(
+      table->view(),
+      allocationStream.view(),
+      rmm::to_device_async_resource_ref_checked(&resource));
+  allocationStream.view().synchronize();
+  auto tableView = cudf::unpack(packedColumns);
+  auto packedTable = std::make_unique<cudf::packed_table>(
+      cudf::packed_table{tableView, std::move(packedColumns)});
+
+  // Model the intra-node UCX path: the packed buffer was allocated on
+  // allocationStream, but downstream work is associated with targetStream.
+  // The CudfVector logical stream is already targetStream, but the packed
+  // buffer's deallocation stream is still allocationStream. rebindStream must
+  // update the packed buffer even when stream_ already matches targetStream.
+  auto vector = std::make_shared<CudfVector>(
+      pool_.get(),
+      ROW({"c0"}, {INTEGER()}),
+      packedTable->table.num_rows(),
+      std::move(packedTable),
+      targetStream.view());
+  resource.reset();
+
+  ASSERT_TRUE(vector->rebindStream(targetStream.view()));
+  vector.reset();
+
+  EXPECT_GT(resource.deallocationCount(), 0);
+  EXPECT_EQ(resource.lastDeallocationStream(), targetStream.value());
+}
+
+} // namespace

--- a/velox/experimental/cudf/tests/CudfVectorTest.cpp
+++ b/velox/experimental/cudf/tests/CudfVectorTest.cpp
@@ -23,7 +23,7 @@
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/device_buffer.hpp>
-#include <rmm/mr/cuda_memory_resource.hpp>
+#include <rmm/mr/cuda_async_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
 #include <cuda/memory_resource>
@@ -66,18 +66,18 @@ class TestCudaStream {
   cudaStream_t stream_{nullptr};
 };
 
-struct RecordingState {
+struct RecordingAsyncResourceState {
   cudaStream_t lastDeallocationStream{nullptr};
   std::size_t deallocationCount{0};
 };
 
-class RecordingDeviceResource {
+class RecordingAsyncDeviceResource {
  public:
   void* allocate(
       cuda::stream_ref stream,
       std::size_t bytes,
       std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) {
-    return upstream_.allocate(stream, bytes, alignment);
+    return asyncUpstream_.allocate(stream, bytes, alignment);
   }
 
   void deallocate(
@@ -87,20 +87,20 @@ class RecordingDeviceResource {
       std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept {
     state_->lastDeallocationStream = stream.get();
     ++state_->deallocationCount;
-    upstream_.deallocate(stream, ptr, bytes, alignment);
+    asyncUpstream_.deallocate(stream, ptr, bytes, alignment);
   }
 
   void* allocate_sync(
       std::size_t bytes,
       std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) {
-    return upstream_.allocate_sync(bytes, alignment);
+    return asyncUpstream_.allocate_sync(bytes, alignment);
   }
 
   void deallocate_sync(
       void* ptr,
       std::size_t bytes,
       std::size_t alignment = rmm::CUDA_ALLOCATION_ALIGNMENT) noexcept {
-    upstream_.deallocate_sync(ptr, bytes, alignment);
+    asyncUpstream_.deallocate_sync(ptr, bytes, alignment);
   }
 
   void reset() {
@@ -108,7 +108,7 @@ class RecordingDeviceResource {
     state_->deallocationCount = 0;
   }
 
-  int deallocationCount() const {
+  std::size_t deallocationCount() const {
     return state_->deallocationCount;
   }
 
@@ -116,17 +116,18 @@ class RecordingDeviceResource {
     return state_->lastDeallocationStream;
   }
 
-  bool operator==(const RecordingDeviceResource& other) const noexcept {
+  bool operator==(const RecordingAsyncDeviceResource& other) const noexcept {
     return state_ == other.state_;
   }
 
  private:
-  std::shared_ptr<RecordingState> state_{std::make_shared<RecordingState>()};
-  rmm::mr::cuda_memory_resource upstream_;
+  std::shared_ptr<RecordingAsyncResourceState> state_{
+      std::make_shared<RecordingAsyncResourceState>()};
+  rmm::mr::cuda_async_memory_resource asyncUpstream_;
 };
 
 void get_property(
-    const RecordingDeviceResource&,
+    const RecordingAsyncDeviceResource&,
     cuda::mr::device_accessible) noexcept {}
 
 std::unique_ptr<cudf::table> makeTable(
@@ -161,7 +162,7 @@ class CudfVectorTest : public ::testing::Test, public VectorTestBase {
 TEST_F(CudfVectorTest, rebindOwnedTableDeallocationStream) {
   TestCudaStream allocationStream;
   TestCudaStream targetStream;
-  RecordingDeviceResource resource;
+  RecordingAsyncDeviceResource resource;
 
   auto table = makeTable(
       allocationStream.view(),
@@ -186,7 +187,7 @@ TEST_F(CudfVectorTest, rebindOwnedTableDeallocationStream) {
 TEST_F(CudfVectorTest, rebindPackedTableDeallocationStream) {
   TestCudaStream allocationStream;
   TestCudaStream targetStream;
-  RecordingDeviceResource resource;
+  RecordingAsyncDeviceResource resource;
 
   auto table = makeTable(
       allocationStream.view(), cudf::get_current_device_resource_ref());

--- a/velox/experimental/cudf/tests/CudfVectorTest.cpp
+++ b/velox/experimental/cudf/tests/CudfVectorTest.cpp
@@ -43,9 +43,12 @@ namespace {
 class TestCudaStream {
  public:
   TestCudaStream() {
-    VELOX_CHECK_EQ(
-        cudaStreamCreateWithFlags(&stream_, cudaStreamNonBlocking),
-        cudaSuccess);
+    auto status = cudaStreamCreateWithFlags(&stream_, cudaStreamNonBlocking);
+    VELOX_CHECK(
+        status == cudaSuccess,
+        "cudaStreamCreateWithFlags failed: {} ({})",
+        cudaGetErrorString(status),
+        static_cast<int>(status));
   }
 
   ~TestCudaStream() {
@@ -143,12 +146,13 @@ std::unique_ptr<cudf::table> makeTable(
       stream.value()));
 
   std::vector<std::unique_ptr<cudf::column>> columns;
-  columns.push_back(std::make_unique<cudf::column>(
-      cudf::data_type{cudf::type_id::INT32},
-      static_cast<cudf::size_type>(values.size()),
-      std::move(data),
-      rmm::device_buffer{},
-      0));
+  columns.push_back(
+      std::make_unique<cudf::column>(
+          cudf::data_type{cudf::type_id::INT32},
+          static_cast<cudf::size_type>(values.size()),
+          std::move(data),
+          rmm::device_buffer{},
+          0));
   return std::make_unique<cudf::table>(std::move(columns));
 }
 

--- a/velox/experimental/cudf/tests/CudfVectorTest.cpp
+++ b/velox/experimental/cudf/tests/CudfVectorTest.cpp
@@ -68,7 +68,7 @@ class TestCudaStream {
 
 struct RecordingState {
   cudaStream_t lastDeallocationStream{nullptr};
-  int deallocationCount{0};
+  std::size_t deallocationCount{0};
 };
 
 class RecordingDeviceResource {

--- a/velox/experimental/cudf/vector/CudfVector.cpp
+++ b/velox/experimental/cudf/vector/CudfVector.cpp
@@ -23,14 +23,8 @@
 #include "velox/vector/TypeAliases.h"
 
 #include <cudf/column/column.hpp>
-#include <cudf/table/table.hpp>
-
-#if __has_include(<cudf/column/column_stream.hpp>)
 #include <cudf/column/column_stream.hpp>
-#define VELOX_CUDF_HAS_COLUMN_REBIND_STREAM 1
-#else
-#define VELOX_CUDF_HAS_COLUMN_REBIND_STREAM 0
-#endif
+#include <cudf/table/table.hpp>
 
 namespace facebook::velox::cudf_velox {
 namespace {
@@ -183,15 +177,14 @@ std::unique_ptr<cudf::table> CudfVector::release() {
 }
 
 bool CudfVector::rebindStream(rmm::cuda_stream_view stream) {
-  if (stream_.value() == stream.value()) {
-    return true;
-  }
-
-#if VELOX_CUDF_HAS_COLUMN_REBIND_STREAM
   if (auto* tablePtr =
           std::get_if<std::unique_ptr<cudf::table>>(&tableStorage_)) {
     if (!*tablePtr) {
       return false;
+    }
+
+    if (stream_.value() == stream.value()) {
+      return true;
     }
 
     auto columns = (*tablePtr)->release();
@@ -204,7 +197,18 @@ bool CudfVector::rebindStream(rmm::cuda_stream_view stream) {
     stream_ = stream;
     return true;
   }
-#endif
+
+  if (auto* packedPtr =
+          std::get_if<std::unique_ptr<cudf::packed_table>>(&tableStorage_)) {
+    if (!*packedPtr) {
+      return false;
+    }
+
+    (*packedPtr)->data.gpu_data->set_stream(stream);
+    stream_ = stream;
+    return true;
+  }
+
   return false;
 }
 

--- a/velox/experimental/cudf/vector/CudfVector.cpp
+++ b/velox/experimental/cudf/vector/CudfVector.cpp
@@ -25,6 +25,13 @@
 #include <cudf/column/column.hpp>
 #include <cudf/table/table.hpp>
 
+#if __has_include(<cudf/column/column_stream.hpp>)
+#include <cudf/column/column_stream.hpp>
+#define VELOX_CUDF_HAS_COLUMN_REBIND_STREAM 1
+#else
+#define VELOX_CUDF_HAS_COLUMN_REBIND_STREAM 0
+#endif
+
 namespace facebook::velox::cudf_velox {
 namespace {
 
@@ -173,6 +180,32 @@ std::unique_ptr<cudf::table> CudfVector::release() {
   // Clear the packed table since we've materialized
   packedPtr.reset();
   return materializedTable;
+}
+
+bool CudfVector::rebindStream(rmm::cuda_stream_view stream) {
+  if (stream_.value() == stream.value()) {
+    return true;
+  }
+
+#if VELOX_CUDF_HAS_COLUMN_REBIND_STREAM
+  if (auto* tablePtr =
+          std::get_if<std::unique_ptr<cudf::table>>(&tableStorage_)) {
+    if (!*tablePtr) {
+      return false;
+    }
+
+    auto columns = (*tablePtr)->release();
+    for (auto& column : columns) {
+      column = cudf::rebind_stream(std::move(*column), stream);
+    }
+
+    *tablePtr = std::make_unique<cudf::table>(std::move(columns));
+    tabView_ = (*tablePtr)->view();
+    stream_ = stream;
+    return true;
+  }
+#endif
+  return false;
 }
 
 uint64_t CudfVector::estimateFlatSize() const {

--- a/velox/experimental/cudf/vector/CudfVector.h
+++ b/velox/experimental/cudf/vector/CudfVector.h
@@ -68,6 +68,11 @@ class CudfVector : public RowVector {
   /// first (which copies the data).
   std::unique_ptr<cudf::table> release();
 
+  /// Rebinds owned table buffers to use 'stream' for future deallocation.
+  /// Returns false when the storage cannot be rebound without materializing or
+  /// when the cuDF rebind API is unavailable.
+  bool rebindStream(rmm::cuda_stream_view stream);
+
   uint64_t estimateFlatSize() const override;
 
  private:

--- a/velox/experimental/cudf/vector/CudfVector.h
+++ b/velox/experimental/cudf/vector/CudfVector.h
@@ -69,8 +69,7 @@ class CudfVector : public RowVector {
   std::unique_ptr<cudf::table> release();
 
   /// Rebinds owned table buffers to use 'stream' for future deallocation.
-  /// Returns false when the storage cannot be rebound without materializing or
-  /// when the cuDF rebind API is unavailable.
+  /// Returns false when the storage cannot be rebound without materializing.
   bool rebindStream(rmm::cuda_stream_view stream);
 
   uint64_t estimateFlatSize() const override;

--- a/velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp
+++ b/velox/experimental/ucx-exchange/UcxPartitionedOutput.cpp
@@ -19,11 +19,13 @@
 #include "velox/core/QueryConfig.h"
 #include "velox/exec/Driver.h"
 #include "velox/exec/Operator.h"
+#include "velox/experimental/cudf/exec/Utilities.h"
 #include "velox/experimental/cudf/vector/CudfVector.h"
 
 #include <cudf/concatenate.hpp>
 #include <cudf/contiguous_split.hpp>
 #include <cudf/copying.hpp>
+#include <cudf/detail/utilities/stream_pool.hpp>
 #include <cudf/partitioning.hpp>
 
 using namespace facebook::velox::cudf_velox;
@@ -128,23 +130,25 @@ void UcxPartitionedOutput::flushPending() {
           ? cv->getTableView()
           : cv->getTableView().select(remap_.begin(), remap_.end());
     } else {
-      // Sync all input streams so their GPU data is ready to read.
-      for (auto& v : pendingInputs_) {
-        v->stream().synchronize();
-      }
-
       // Collect (remapped) table views.
       std::vector<cudf::table_view> views;
+      std::vector<rmm::cuda_stream_view> inputStreams;
       views.reserve(pendingInputs_.size());
+      inputStreams.reserve(pendingInputs_.size());
       for (auto& v : pendingInputs_) {
+        inputStreams.push_back(v->stream());
         views.push_back(
             remap_.empty()
                 ? v->getTableView()
                 : v->getTableView().select(remap_.begin(), remap_.end()));
       }
 
+      cudf::detail::join_streams(inputStreams, stream);
       mergedTable = cudf::concatenate(
           views, stream, cudf::get_current_device_resource_ref());
+
+      orderCudfVectorDeallocationsAfterStream(
+          pendingInputs_, inputStreams, stream);
 
       // Free input GPU memory before partitioning (peak = 2x -> 1x).
       pendingInputs_.clear();


### PR DESCRIPTION
UcxPartitionedOutput::flushPending() synchronizes input streams before launching cudf::concatenate(), but concatenate itself is asynchronous on the output stream. When multiple pending inputs were flushed, the operator could clear pendingInputs_ immediately after launching concat, allowing the input CudfVector buffers to be deallocated before the concat kernels finished reading them.

This caused nondeterministic GPU result corruption. A TPC-H Q18 correctness loop against a DuckDB reference reproduced the issue regularly, and compute-sanitizer reported a use-after-free with this stack:

  cudf::concatenate
  UcxPartitionedOutput::flushPending

Fix the lifetime ordering without a CPU-blocking synchronize:

* make the concat/output stream wait for all input streams before reading input table views;
* prefer rebinding owned cuDF input buffers to the output stream so their stream-ordered deallocation happens after concat work on that stream;
* fall back to a single event recorded on the output stream and waited by all input streams when inputs cannot be rebound.

This keeps the existing memory behavior of releasing pending input buffers before partitioning, while making their async lifetime ordering explicit.

Validated by:
* TPC-H Q18 GPU correctness loop against stored DuckDB reference
* compute-sanitizer with stream-ordered race tracking, confirming the original concat use-after-free is no longer reported