### PR TITLE
refactor: Enforce callers to provide metadataIoStats to TabletReader (#17534)

### DIFF
--- a/velox/experimental/wave/dwio/nimble/tests/NimbleReaderTestUtil.cpp
+++ b/velox/experimental/wave/dwio/nimble/tests/NimbleReaderTestUtil.cpp
@@ -19,6 +19,7 @@
 #include "dwio/nimble/common/tests/NimbleFileWriter.h"
 #include "dwio/nimble/encodings/EncodingSelectionPolicy.h"
 #include "dwio/nimble/tablet/TabletReader.h"
+#include "dwio/nimble/tablet/tests/TabletTestUtils.h"
 #include "dwio/nimble/velox/VeloxWriterOptions.h"
 #include "velox/common/file/File.h"
 #include "velox/exec/fuzzer/ReferenceQueryRunner.h"
@@ -365,7 +366,10 @@ std::vector<std::unique_ptr<StreamLoader>> writeToNimbleAndGetStreamLoaders(
     auto numChildren = chunkVectors[0]->as<RowVector>()->childrenSize();
 
     auto readFile = std::make_unique<InMemoryReadFile>(file);
-    auto tablet = TabletReader::create(std::move(readFile), pool, {});
+    auto tablet = TabletReader::create(
+        std::move(readFile),
+        pool,
+        facebook::nimble::test::makeTestTabletOptions(pool));
     auto stripeIdentifier = tablet->stripeIdentifier(0);
     // VELOX_CHECK_EQ(numChildren + 1, tablet.streamCount(stripeIdentifier));
 


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookincubator/nimble/pull/731

Remove the `defaultIoStats_` fallback in `TabletReader` and instead enforce that callers always supply `ioOptions` with a non-null `metadataIoStats()`. The constructor now does an early `NIMBLE_CHECK` / `NIMBLE_CHECK_NOT_NULL` in its init list, so any caller that forgets to set the field fails fast at construction with a clear message.

Reviewed By: xiaoxmeng

Differential Revision: D105338687


