### PR TITLE
build(docker): Pin tzdata across all velox-dev images

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -68,6 +68,13 @@ target "pyvelox" {
   args = {
     image              = "quay.io/pypa/manylinux_2_28:latest"
     VELOX_BUILD_SHARED = "OFF"
+    # pyvelox uses a manylinux base which is el8, not el9. The
+    # dockerfile's CENTOS_TZDATA_VERSION default is el9 (correct for
+    # the centos9/adapters targets); override here to the el8 build of
+    # the same upstream tzdata release. Keep the upstream version
+    # (2026a) in sync with CENTOS_TZDATA_VERSION at the top of
+    # scripts/docker/centos-multi.dockerfile.
+    CENTOS_TZDATA_VERSION = "2026a-1.el8"
   }
   matrix = {
     arch = ["amd64", "arm64"]

--- a/scripts/docker/centos-multi.dockerfile
+++ b/scripts/docker/centos-multi.dockerfile
@@ -17,12 +17,26 @@
 #   - centos9: Our base CI build
 #   - adapters: Based on centos9 with all optional dependencies installed
 #   - pyvelox: Image used by cibuildwheel to build pyvelox
+#
+# tzdata is pinned to a known-good version across every stage. Without
+# the pin, each docker rebuild silently picks up the latest tzdata from
+# the CentOS repos — tzdata 2026b's encoding of British Columbia's
+# permanent-PDT change broke Velox's bundled libc++ chrono::tzdb parser
+# (issue #17522). To bump intentionally: change the default below and
+# re-run the Presto-SOT fuzzers locally to confirm before merging.
+ARG CENTOS_TZDATA_VERSION=2026a-1.el9
 
 ########################
 # Stage 1: Base Build  #
 ########################
 ARG image=quay.io/centos/centos:stream9
 FROM $image AS base-build
+
+ARG CENTOS_TZDATA_VERSION
+# Pin tzdata. `dnf install` is a no-op if already at the pinned version,
+# and falls through to `downgrade` when the base image ships a newer one.
+RUN dnf -y install "tzdata-${CENTOS_TZDATA_VERSION}.noarch" || \
+      dnf -y downgrade "tzdata-${CENTOS_TZDATA_VERSION}.noarch"
 
 COPY scripts/setup-helper-functions.sh /
 COPY scripts/setup-versions.sh /
@@ -64,6 +78,12 @@ RUN bash /setup-centos9.sh && \
 # Stage 2: Base Image  #
 ########################
 FROM $image AS base-image
+
+ARG CENTOS_TZDATA_VERSION
+# Pin tzdata — see top of file for rationale. Inherited by centos9,
+# pyvelox, and (transitively, via the centos9 tag) the java images.
+RUN dnf -y install "tzdata-${CENTOS_TZDATA_VERSION}.noarch" || \
+      dnf -y downgrade "tzdata-${CENTOS_TZDATA_VERSION}.noarch"
 
 COPY scripts/setup-helper-functions.sh /
 COPY scripts/setup-versions.sh /
@@ -115,6 +135,11 @@ RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/velox_deps.conf \
 ########################
 FROM $image AS adapters-build
 
+ARG CENTOS_TZDATA_VERSION
+# Pin tzdata — see top of file for rationale.
+RUN dnf -y install "tzdata-${CENTOS_TZDATA_VERSION}.noarch" || \
+      dnf -y downgrade "tzdata-${CENTOS_TZDATA_VERSION}.noarch"
+
 COPY scripts/setup-helper-functions.sh /
 COPY scripts/setup-versions.sh /
 COPY scripts/setup-common.sh /
@@ -151,6 +176,13 @@ RUN bash /setup-centos-adapters.sh install_cuda && \
 
 RUN bash /setup-centos-adapters.sh install_adapters_deps_from_dnf && \
       dnf clean all
+
+ARG CENTOS_TZDATA_VERSION
+# tzdata-java is pulled in by the Java install above. Pin it to match
+# the OS tzdata pinned in centos9 so the JDK and Velox C++ see the
+# same timezone rules — issue #17522 was caused by this drift.
+RUN dnf -y install "tzdata-java-${CENTOS_TZDATA_VERSION}.noarch" || \
+      dnf -y downgrade "tzdata-java-${CENTOS_TZDATA_VERSION}.noarch"
 
 # put CUDA binaries on the PATH
 ENV PATH=/usr/local/cuda/bin:${PATH}

--- a/scripts/docker/fedora.dockerfile
+++ b/scripts/docker/fedora.dockerfile
@@ -12,11 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# tzdata is pinned to a known-good version so docker rebuilds (any time
+# scripts/docker/*.dockerfile or scripts/setup-*.sh changes) don't
+# silently bump tzdata in the image. See issue #17522 for the bug class
+# this prevents — version mismatch between OS tzdata and consumers'
+# bundled tzdb code can produce silent 1-hour offsets in TIMESTAMP
+# WITH TIME ZONE values. To bump intentionally: change the default and
+# rebuild locally to confirm before merging.
+ARG FEDORA_TZDATA_VERSION=2025c-1.fc42
+
 ########################
 # Stage 1: Base Build  #
 ########################
 ARG base=quay.io/fedora/fedora:42-x86_64
 FROM $base AS base-build
+
+ARG FEDORA_TZDATA_VERSION
+RUN dnf -y install "tzdata-${FEDORA_TZDATA_VERSION}.noarch" || \
+      dnf -y downgrade "tzdata-${FEDORA_TZDATA_VERSION}.noarch"
 
 COPY scripts/setup-helper-functions.sh /
 COPY scripts/setup-versions.sh /
@@ -50,6 +63,10 @@ RUN bash /setup-fedora.sh && \
 # Stage 2: Base Image  #
 ########################
 FROM $base AS fedora
+
+ARG FEDORA_TZDATA_VERSION
+RUN dnf -y install "tzdata-${FEDORA_TZDATA_VERSION}.noarch" || \
+      dnf -y downgrade "tzdata-${FEDORA_TZDATA_VERSION}.noarch"
 
 COPY scripts/setup-helper-functions.sh /
 COPY scripts/setup-versions.sh /

--- a/scripts/docker/java.dockerfile
+++ b/scripts/docker/java.dockerfile
@@ -16,6 +16,10 @@
 # Global arg default to share across stages
 ARG SPARK_VERSION=3.5.1
 ARG PRESTO_VERSION=0.295
+# tzdata version pin — see scripts/docker/centos-multi.dockerfile for the
+# rationale. Keep this string in sync with CENTOS_TZDATA_VERSION there so
+# the OS tzdata and JDK tzdata-java agree on timezone rules. Issue #17522.
+ARG CENTOS_TZDATA_VERSION=2026a-1.el9
 
 #########################
 # Stage: Spark Download #
@@ -49,7 +53,17 @@ RUN tar -xzf presto-server.tar.gz
 #########################
 FROM ghcr.io/facebookincubator/velox-dev:centos9 AS java-base
 
-RUN dnf install -y -q --setopt=install_weak_deps=False java-17-openjdk less procps tzdata
+ARG CENTOS_TZDATA_VERSION
+# Pin tzdata-java to the same version as the OS tzdata pinned in the
+# centos9 base. The base image already has tzdata pinned; we re-pin
+# here as a defensive `install || downgrade` so this stage builds
+# correctly even before the centos9 image has been rebuilt with the pin.
+RUN dnf install -y -q --setopt=install_weak_deps=False \
+      java-17-openjdk less procps tzdata && \
+    (dnf -y install "tzdata-java-${CENTOS_TZDATA_VERSION}.noarch" || \
+     dnf -y downgrade "tzdata-java-${CENTOS_TZDATA_VERSION}.noarch") && \
+    (dnf -y install "tzdata-${CENTOS_TZDATA_VERSION}.noarch" || \
+     dnf -y downgrade "tzdata-${CENTOS_TZDATA_VERSION}.noarch")
 
 # We set the timezone to America/Los_Angeles due to issue
 # detailed here : https://github.com/facebookincubator/velox/issues/8127

--- a/scripts/docker/ubuntu-22.04-cpp.dockerfile
+++ b/scripts/docker/ubuntu-22.04-cpp.dockerfile
@@ -11,8 +11,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# tzdata is pinned to a known-good version so docker rebuilds (any time
+# scripts/docker/*.dockerfile or scripts/setup-*.sh changes) don't
+# silently bump tzdata in the image. See issue #17522 for the bug class
+# this prevents — version mismatch between OS tzdata and consumers'
+# bundled tzdb code can produce silent 1-hour offsets in TIMESTAMP
+# WITH TIME ZONE values. To bump intentionally: change the default and
+# rebuild locally to confirm before merging.
+ARG UBUNTU_TZDATA_VERSION=2026a-0ubuntu0.22.04.1n
+
 ARG base=ubuntu:22.04
 FROM ${base}
+
+ARG UBUNTU_TZDATA_VERSION
+ARG DEBIAN_FRONTEND="noninteractive"
+RUN apt-get update && \
+      apt-get install -y --allow-downgrades "tzdata=${UBUNTU_TZDATA_VERSION}"
 
 RUN apt update && \
       apt install -y sudo \

--- a/scripts/docker/ubuntu-22.04-cpp.dockerfile
+++ b/scripts/docker/ubuntu-22.04-cpp.dockerfile
@@ -18,7 +18,7 @@
 # bundled tzdb code can produce silent 1-hour offsets in TIMESTAMP
 # WITH TIME ZONE values. To bump intentionally: change the default and
 # rebuild locally to confirm before merging.
-ARG UBUNTU_TZDATA_VERSION=2026a-0ubuntu0.22.04.1n
+ARG UBUNTU_TZDATA_VERSION=2026a-0ubuntu0.22.04.1
 
 ARG base=ubuntu:22.04
 FROM ${base}


### PR DESCRIPTION
## Summary

Pin `tzdata` (and `tzdata-java` where applicable) in all four velox-dev dockerfiles. Closes / mitigates #17522.

Without an explicit pin, every docker rebuild — triggered by any change to `scripts/docker/*.dockerfile` or `scripts/setup-*.sh` — silently picks up the latest `tzdata` from the distro repos. tzdata `2026b`'s encoding of British Columbia's permanent-PDT change broke Velox's bundled libc++ chrono::tzdb parser and caused the Presto-SOT fuzzer regression in #17522:

- 4 fuzzers (Expression / Window / Aggregation / Join, all "with Presto as source of truth") fail on any plan touching `TIMESTAMP WITH TIME ZONE`.
- The mismatch shape is exactly `(3,600,000 ms) << 12 = 14,745,600,000` — i.e., 1-hour offset, same `tz_id`. Velox's tzdb returns the wrong offset for the affected timezones; Presto Java (reading `tzdata-java`) is correct.

The trigger was a routine docker rebuild on 2026-05-14 that bumped `tzdata` from `2026a-1.el9` → `2026b-1.el9`. With this PR the version is explicit and reproducible.

## Per-image pin

| Image | Pinned to | Notes |
|---|---|---|
| `centos9`, `pyvelox` | `tzdata-2026a-1.el9` | pinned in `base-image` stage |
| `adapters` | `tzdata-2026a-1.el9` + `tzdata-java-2026a-1.el9` | inherits from `centos9`; `tzdata-java` re-pinned after Java install |
| `presto-java`, `spark-server` | `tzdata-2026a-1.el9` + `tzdata-java-2026a-1.el9` | defensive re-pin in `java-base` so it builds even before `centos9` is rebuilt with the pin |
| `fedora` | `tzdata-2025c-1.fc42` (current) | pinned in `base-build` and `fedora` stages |
| `ubuntu` (22.04) | `tzdata=2026a-0ubuntu0.22.04.1n` (current) | `apt-get install --allow-downgrades` |

## Mechanism

Pin uses an install-or-downgrade pattern that works whether the base image ships an older, equal, or newer tzdata than the pinned version:

```dockerfile
ARG CENTOS_TZDATA_VERSION=2026a-1.el9
RUN dnf -y install "tzdata-${CENTOS_TZDATA_VERSION}.noarch" || \
      dnf -y downgrade "tzdata-${CENTOS_TZDATA_VERSION}.noarch"
```

Verified manually on a fresh `quay.io/centos/centos:stream9` (currently shipping `2026b`): `dnf install tzdata-2026a-1.el9.noarch` performs the downgrade as expected, so the `|| dnf downgrade` fallback is defensive.

## Bumping intentionally

Change the `{CENTOS,FEDORA,UBUNTU}_TZDATA_VERSION` ARG default at the top of each dockerfile, rebuild the docker images, and re-run the Presto-SOT fuzzers locally to confirm no regression before merging.

## Test plan

- [ ] Docker images rebuild successfully (workflow `docker.yml` will fire automatically on this PR since it touches `scripts/docker/*.dockerfile`).
- [ ] After the rebuilt images land on `:presto-java`, the four Presto-SOT fuzzer jobs (Expression, Window, Aggregation, Join) go green again on `main`.
- [ ] `rpm -q tzdata` inside the rebuilt `velox-dev:presto-java` shows `tzdata-2026a-1.el9.noarch` (and `tzdata-java` matches).