### PR TITLE
fix(build): Apple toolchain breaking dependencies

### DIFF
--- a/CMake/resolve_dependency_modules/arrow/CMakeLists.txt
+++ b/CMake/resolve_dependency_modules/arrow/CMakeLists.txt
@@ -58,6 +58,11 @@ if(VELOX_ENABLE_ARROW)
     -DCMAKE_POLICY_VERSION_MINIMUM=3.5
     # Remove with Arrow upgrade to Arrow 20.
     -DARROW_CXXFLAGS=-Wno-documentation
+    # Arrow inherits the CMake build type from Velox. So a Debug build turns
+    # on additional warnings that can cause the build to fail
+    # (e.g. deprecated-literal-operator in Apple Clang 21).
+    # The SYSTEM version of Arrow is always a Release build.
+    -DBUILD_WARNING_LEVEL=PRODUCTION
   )
   set(ARROW_LIBDIR ${ARROW_PREFIX}/install/lib)
 

--- a/CMake/resolve_dependency_modules/arrow/cmake-compatibility.patch
+++ b/CMake/resolve_dependency_modules/arrow/cmake-compatibility.patch
@@ -32,3 +32,14 @@
    if(MSVC)
      string(REPLACE "/WX" "" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
      string(REPLACE "/WX" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+--- a/cpp/cmake_modules/BuildUtils.cmake
++++ b/cpp/cmake_modules/BuildUtils.cmake
+@@ -112,7 +112,7 @@
+     execute_process(COMMAND ${LIBTOOL_MACOS} -V
+                     OUTPUT_VARIABLE LIBTOOL_V_OUTPUT
+                     OUTPUT_STRIP_TRAILING_WHITESPACE)
+-    if(NOT "${LIBTOOL_V_OUTPUT}" MATCHES ".*cctools-([0-9.]+).*")
++    if(NOT "${LIBTOOL_V_OUTPUT}" MATCHES ".*cctools.+([0-9.]+).*")
+       message(FATAL_ERROR "libtool found appears to be the incompatible GNU libtool: ${LIBTOOL_MACOS}"
+       )
+     endif()

--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -80,7 +80,16 @@ function install_mvfst {
 
 function install_fbthrift {
   wget_and_untar https://github.com/facebook/fbthrift/archive/refs/tags/"${FB_OS_VERSION}".tar.gz fbthrift
-  cmake_install_dir fbthrift -Denable_tests=OFF -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS=OFF
+  # Apple Clang's libc++ no longer defines _LIBCPP_HAS_NO_ASAN (renamed to
+  # _LIBCPP_INSTRUMENTED_WITH_ASAN), so folly's UninitializedMemoryHacks.h
+  # causing undefined symbol. This is fixed in the latest FBOS versions and
+  # can be removed on FBOS upgrade.
+  local FBTHRIFT_EXTRA_CXXFLAGS=""
+  if [[ "$(uname)" == "Darwin" ]]; then
+    FBTHRIFT_EXTRA_CXXFLAGS=" -D_LIBCPP_HAS_NO_ASAN"
+  fi
+  EXTRA_PKG_CXXFLAGS="$FBTHRIFT_EXTRA_CXXFLAGS" \
+    cmake_install_dir fbthrift -Denable_tests=OFF -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS=OFF
 }
 
 function install_duckdb {

--- a/velox/exec/tests/utils/ExpressionBuilder.h
+++ b/velox/exec/tests/utils/ExpressionBuilder.h
@@ -296,7 +296,7 @@ inline detail::ExprWrapper col(std::string name) {
 
 /// Enable users to use a custom C++ literal to add a column reference.
 /// For example: "col"_c
-inline detail::ExprWrapper operator"" _c(const char* str, size_t len) {
+inline detail::ExprWrapper operator""_c(const char* str, size_t len) {
   return col(std::string(str, len));
 }
 


### PR DESCRIPTION
1. The toolchain changed the flag to detect the sanitizer. The current folly version has the old solution. This is fixed in the latest folly. It affects the fbthrift build only.
2. Arrow regex parsing lib tool version does not handle change from - to _ in the toolchain.
3. Arrow emitting warnings as errors in Debug build when bundled.
4. Fix Clang 21 (also on Linux) compile error.


Addresses: https://github.com/facebookincubator/velox/issues/17537