### PR TITLE
fix(cudf): Show stats for adapter operators not in plan tree

### DIFF
--- a/velox/docs/develop/debugging/print-plan-with-stats.rst
+++ b/velox/docs/develop/debugging/print-plan-with-stats.rst
@@ -283,3 +283,22 @@ TableScan operator shows how many rows were processed by pushing down aggregatio
 .. code-block::
 
     loadedToValueHook          sum: 50000, count: 5, min: 10000, max: 10000
+
+GPU Operator Stats
+~~~~~~~~~~~~~~~~~~
+
+When cuDF GPU operators are enabled, the stats output includes GPU-specific
+operators. Adapter operators (``CudfToVelox``, ``CudfFromVelox``) appear as
+operator-type breakdown lines under their parent plan node:
+
+.. code-block::
+
+    -- Aggregation[4][FINAL] -> a0:DOUBLE
+       Output: 2 rows, Cpu time: 546us, Wall time: 601us
+       CudfToVelox: Input: 1 rows, Cpu time: 193us, Wall time: 224us
+       CudfReduceFINAL: Input: 1 rows, Cpu time: 352us, Wall time: 377us
+
+Here, ``Aggregation[4]`` has two operators: ``CudfReduceFINAL`` (the GPU
+aggregation) and ``CudfToVelox`` (GPU-to-CPU format conversion). The summary
+line shows their combined stats. This is the same multi-operator mechanism
+used by ``HashBuild``/``HashProbe`` under join nodes.

--- a/velox/docs/develop/operators.rst
+++ b/velox/docs/develop/operators.rst
@@ -1128,3 +1128,41 @@ ALL.
 .. image:: images/local-exchange.png
     :width: 400
     :align: center
+
+GPU Operators (cuDF)
+--------------------
+
+When cuDF is enabled, CPU operators are replaced with GPU equivalents at
+pipeline construction time via the ``OperatorAdapterRegistry``. For example,
+``FilterProject`` becomes ``CudfFilterProject``, ``Aggregation`` becomes
+``CudfGroupby`` or ``CudfReduce``, and ``HashJoin`` becomes
+``CudfHashJoinBuild``/``CudfHashJoinProbe``.
+
+Adapter operators are automatically inserted at GPU/CPU boundaries:
+
+* ``CudfFromVelox`` — inserted before a GPU operator when the preceding
+  operator produces CPU data (host-to-device conversion).
+* ``CudfToVelox`` — inserted after a GPU operator when the next operator
+  or the pipeline output requires CPU data (device-to-host conversion).
+
+Adapter operators use synthetic planNodeIds (e.g. ``4-to-velox``) at runtime,
+but redirect their stats to the parent plan node via ``setStatSplitter``.
+This means they appear in ``printPlanWithStats`` output as operator-type
+breakdown lines under their parent node (the same mechanism used by
+``HashBuild``/``HashProbe`` under ``HashJoinNode``).
+
+All cuDF operators extend ``CudfOperatorBase``, which provides:
+
+* Template method pattern (``doAddInput``/``doGetOutput``/``doClose``)
+* NVTX profiling ranges
+
+GPU operators are identified by their ``Cudf`` prefix in operator type names
+(e.g. ``CudfFilterProject``, ``CudfLocalPartition``, ``CudfReduceFINAL``).
+Operators without this prefix (e.g. ``LocalExchange``) run on CPU.
+``TableScan`` uses the cuDF GPU parquet reader via the connector layer but
+is not itself a ``CudfOperatorBase`` subclass.
+
+In stats output, "Cpu time" and "Wall time" for GPU operators reflect the
+host-side duration of ``addInput``/``getOutput`` calls, which includes
+enqueuing GPU work and synchronizing. These are not GPU hardware execution
+times.

--- a/velox/experimental/cudf/exec/CudfConversion.cpp
+++ b/velox/experimental/cudf/exec/CudfConversion.cpp
@@ -86,7 +86,17 @@ CudfFromVelox::CudfFromVelox(
           std::nullopt,
           std::nullopt),
       timestampTimeZone_(driverCtx->queryConfig().get<std::string>(
-          facebook::velox::core::QueryConfig::kSessionTimezone)) {}
+          facebook::velox::core::QueryConfig::kSessionTimezone)) {
+  auto parentId = planNodeId.substr(0, planNodeId.find("-from-velox"));
+  stats_.withWLock([&](auto& stats) {
+    stats.setStatSplitter(
+        [parentId = std::move(parentId)](const auto& combinedStats) {
+          auto result = combinedStats;
+          result.planNodeId = parentId;
+          return std::vector<exec::OperatorStats>{std::move(result)};
+        });
+  });
+}
 
 void CudfFromVelox::doAddInput(RowVectorPtr input) {
   if (input->size() > 0) {
@@ -179,7 +189,17 @@ CudfToVelox::CudfToVelox(
           nvtx3::rgb{148, 0, 211}, // Purple
           NvtxMethodFlag::kAll,
           std::nullopt,
-          std::nullopt) {}
+          std::nullopt) {
+  auto parentId = planNodeId.substr(0, planNodeId.find("-to-velox"));
+  stats_.withWLock([&](auto& stats) {
+    stats.setStatSplitter(
+        [parentId = std::move(parentId)](const auto& combinedStats) {
+          auto result = combinedStats;
+          result.planNodeId = parentId;
+          return std::vector<exec::OperatorStats>{std::move(result)};
+        });
+  });
+}
 
 bool CudfToVelox::isPassthroughMode() const {
   return operatorCtx_->driverCtx()->queryConfig().get<bool>(

--- a/velox/experimental/cudf/tests/AdapterOperatorTest.cpp
+++ b/velox/experimental/cudf/tests/AdapterOperatorTest.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/experimental/cudf/CudfConfig.h"
+#include "velox/experimental/cudf/exec/ToCudf.h"
+#include "velox/experimental/cudf/tests/CudfFunctionBaseTest.h"
+
+#include "velox/exec/PlanNodeStats.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+
+class AdapterOperatorTest : public OperatorTestBase {
+ protected:
+  void SetUp() override {
+    OperatorTestBase::SetUp();
+    cudf_velox::CudfConfig::getInstance().allowCpuFallback = false;
+    cudf_velox::registerCudf();
+  }
+
+  void TearDown() override {
+    cudf_velox::unregisterCudf();
+    OperatorTestBase::TearDown();
+  }
+};
+
+TEST_F(AdapterOperatorTest, adapterStatsMergedIntoPlanNode) {
+  auto data = makeRowVector({"c0"}, {makeFlatVector<int32_t>({1, 2, 3, 4, 5})});
+
+  core::PlanNodeId projNodeId;
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .project({"c0 * 2 as x"})
+                  .capturePlanNodeId(projNodeId)
+                  .planNode();
+
+  std::shared_ptr<exec::Task> task;
+  AssertQueryBuilder(plan).copyResults(pool(), task);
+
+  auto stats = toPlanStats(task->taskStats());
+  auto& projStats = stats.at(projNodeId);
+
+  EXPECT_TRUE(projStats.isMultiOperatorTypeNode());
+  EXPECT_TRUE(projStats.operatorStats.count("CudfToVelox"));
+}

--- a/velox/experimental/cudf/tests/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/CMakeLists.txt
@@ -93,6 +93,12 @@ velox_add_cudf_test(
 )
 
 velox_add_cudf_test(
+  NAME velox_cudf_adapter_operator_test
+  SOURCES Main.cpp AdapterOperatorTest.cpp
+  LIBS ${CUDF_TEST_DEFAULT_LIBS} velox_functions_test_lib
+)
+
+velox_add_cudf_test(
   NAME velox_cudf_filter_project_test
   SOURCES Main.cpp FilterProjectTest.cpp
   LIBS ${CUDF_TEST_DEFAULT_LIBS} velox_functions_test_lib

--- a/velox/experimental/cudf/tests/OrderByTest.cpp
+++ b/velox/experimental/cudf/tests/OrderByTest.cpp
@@ -383,8 +383,9 @@ TEST_F(OrderByTest, outputBatchRows) {
     EXPECT_EQ(
         testData.expectedOutputVectors,
         toPlanStats(task->taskStats())
-            .at(orderById + "-to-velox")
-            .outputVectors);
+            .at(orderById)
+            .operatorStats.at("CudfToVelox")
+            ->outputVectors);
   }
 }
 


### PR DESCRIPTION
## Summary

`CudfToVelox` and `CudfFromVelox` adapter operators use synthetic planNodeIds (e.g. 4-to-velox) and are not part of the plan tree. Their stats were previously invisible in `printPlanWithStats` output, making it difficult to observe adapter operator performance (e.g. GPU-CPU conversion overhead). Using `setStatSplitter` to remap their stats to the parent plan node at collection time, they now appear as operator-type breakdown lines under their parent node — the same mechanism used by `HashBuild/HashProbe` under `HashJoinNode`.



## Changes

- `CudfConversion.cpp`: `setStatSplitter` in CudfFromVelox/CudfToVelox constructors remaps stats planNodeId to parent.
- `AdapterOperatorTest.cpp`: Verifies stats merge into parent plan node.
- `operators.rst`: GPU Operators (cuDF) section — plan rewriting, adapter operators, naming convention.
- `print-plan-with-stats.rst`: GPU Operator Stats section — example output with multi-operator breakdown.


## Example output
### GPU mode output (TPC-H Q6 SF10)
```
Execution time: 346ms
Splits total: 1, finished: 1
-- Aggregation[4][FINAL a0 := sum("a0")] -> a0:DOUBLE
   Output: 2 rows (16B, 2 batches), Cpu time: 576.15us, Wall time: 632.42us, Blocked wall time: 0ns, Peak memory: 0B, Memory allocations: 0, CPU breakdown: B/I/O/F (32.88us/4.81us/524.85us/13.61us)
   CudfToVelox: Input: 1 rows (8B, 1 batches), Output: 1 rows (8B, 1 batches), Cpu time: 223.65us, Wall time: 254.26us, Blocked wall time: 0ns, Peak memory: 0B, Memory allocations: 0, Threads: 1, CPU breakdown: B/I/O/F (18.46us/2.35us/195.12us/7.72us)
   CudfReduceFINAL: Input: 1 rows (8B, 1 batches), Output: 1 rows (8B, 1 batches), Cpu time: 352.50us, Wall time: 378.16us, Blocked wall time: 0ns, Peak memory: 0B, Memory allocations: 0, Threads: 1, CPU breakdown: B/I/O/F (14.42us/2.46us/329.73us/5.89us)
  -- LocalPartition[3][GATHER] -> a0:DOUBLE
     Output: 2 rows (16B, 2 batches), Cpu time: 107.75us, Wall time: 139.80us, Blocked wall time: 343.93ms, Peak memory: 0B, Memory allocations: 0, CPU breakdown: B/I/O/F (18.36us/46.05us/23.23us/20.11us)
     CudfLocalPartition: Input: 1 rows (8B, 1 batches), Output: 1 rows (8B, 1 batches), Cpu time: 88.15us, Wall time: 109.59us, Blocked wall time: 0ns, Peak memory: 0B, Memory allocations: 0, Threads: 1, CPU breakdown: B/I/O/F (11.34us/46.05us/11.59us/19.17us)
     LocalExchange: Input: 1 rows (8B, 1 batches), Output: 1 rows (8B, 1 batches), Cpu time: 19.60us, Wall time: 30.21us, Blocked wall time: 343.93ms, Peak memory: 0B, Memory allocations: 0, Threads: 1, CPU breakdown: B/I/O/F (7.02us/0ns/11.64us/940ns)
    -- Aggregation[2][PARTIAL a0 := sum(ROW["p0"])] -> a0:DOUBLE
       Output: 1 rows (8B, 1 batches), Cpu time: 10.82ms, Wall time: 10.84ms, Blocked wall time: 0ns, Peak memory: 0B, Memory allocations: 0, Threads: 1, CPU breakdown: B/I/O/F (13.44us/4.65us/10.80ms/5.03us)
      -- Project[1][expressions: (p0:DOUBLE, multiply(ROW["l_extendedprice"],ROW["l_discount"]))] -> p0:DOUBLE
         Output: 1139264 rows (8.83MB, 1 batches), Cpu time: 44.62ms, Wall time: 44.64ms, Blocked wall time: 0ns, Peak memory: 0B, Memory allocations: 0, Threads: 1, CPU breakdown: B/I/O/F (8.92us/6.32us/44.60ms/5.13us)
        -- TableScan[0][table: lineitem, range filters: [(l_discount, DoubleRange: [0.050000, 0.070000] no nulls), (l_quantity, DoubleRange: (-inf, 24.000000) no nulls), (l_shipdate, BigintRange: [8766, 9130] no nulls)]] -> l_shipdate:DATE, l_extendedprice:DOUBLE, l_quantity:DOUBLE, l_discount:DOUBLE
           Input: 1139264 rows (30.97MB, 1 batches), Output: 1139264 rows (30.97MB, 1 batches), Cpu time: 147.16ms, Wall time: 288.43ms, Blocked wall time: 0ns, Peak memory: 1.72MB, Memory allocations: 1957, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (4.16us/0ns/147.15ms/1.03us)
```