### PR TITLE
feat: Add flux as valid index source (#17542)

### DIFF
--- a/velox/connectors/hive/HiveIndexSource.cpp
+++ b/velox/connectors/hive/HiveIndexSource.cpp
@@ -1069,6 +1069,7 @@ void HiveIndexSource::addSplits(
     } else {
       VELOX_CHECK(
           hiveSplit->fileFormat == dwio::common::FileFormat::NIMBLE ||
+              hiveSplit->fileFormat == dwio::common::FileFormat::FLUX ||
               hiveSplit->fileFormat == dwio::common::FileFormat::SST,
           "No IndexReaderFactory registered for format: {}",
           dwio::common::toString(hiveSplit->fileFormat));

--- a/velox/dwio/common/Options.cpp
+++ b/velox/dwio/common/Options.cpp
@@ -39,6 +39,8 @@ FileFormat toFileFormat(std::string_view s) {
     return FileFormat::ORC;
   } else if (s == "sst") {
     return FileFormat::SST;
+  } else if (s == "flux") {
+    return FileFormat::FLUX;
   } else if (s == "avro") {
     return FileFormat::AVRO;
   }
@@ -67,6 +69,8 @@ std::string_view toString(FileFormat fmt) {
       return "orc";
     case FileFormat::SST:
       return "sst";
+    case FileFormat::FLUX:
+      return "flux";
     case FileFormat::AVRO:
       return "avro";
     default:

--- a/velox/dwio/common/tests/OptionsTests.cpp
+++ b/velox/dwio/common/tests/OptionsTests.cpp
@@ -25,6 +25,11 @@ TEST(OptionsTests, defaultRowNumberColumnInfoTest) {
   ASSERT_EQ(std::nullopt, rowReaderOptions.rowNumberColumnInfo());
 }
 
+TEST(OptionsTests, fluxFileFormatRoundTrip) {
+  ASSERT_EQ(FileFormat::FLUX, toFileFormat("flux"));
+  ASSERT_EQ("flux", toString(FileFormat::FLUX));
+}
+
 TEST(OptionsTests, setRowNumberColumnInfoTest) {
   RowReaderOptions rowReaderOptions;
   RowNumberColumnInfo rowNumberColumnInfo;


### PR DESCRIPTION
Summary:

This diff adds FLUX as a valid index source into Velox and adds roundtrip serializatino.

Reviewed By: xiaoxmeng

Differential Revision: D105505038


