### PR TITLE
fix: Mark EnforceSingleRowNode as requiring single-thread execution (#17543)

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -4873,6 +4873,14 @@ class EnforceSingleRowNode : public PlanNode {
     return sources_;
   }
 
+  /// Validates that input produces exactly one row, so the pipeline must
+  /// observe all rows sequentially on a single driver. Multiple drivers
+  /// would each independently produce a row (or NULL on empty input),
+  /// breaking the single-row contract.
+  bool requiresSingleThread() const override {
+    return true;
+  }
+
   void accept(const PlanNodeVisitor& visitor, PlanNodeVisitorContext& context)
       const override;
 


### PR DESCRIPTION
Summary:

`EnforceSingleRowNode` validates that its input produces exactly one row. With multiple drivers, each driver independently sees a slice of the input and may emit its own row (or NULL on empty input), violating the single-row contract. Mark it `requiresSingleThread() = true` so the runtime collapses the pipeline to one driver, matching the existing treatment of `LimitNode`, `OrderByNode`, and other operators with the same constraint.

Differential Revision: D105507323
