### PR TITLE
feat: Separate metadata and index caching/pinning into independent controls (#17544)

### DIFF
--- a/velox/connectors/hive/FileConfig.cpp
+++ b/velox/connectors/hive/FileConfig.cpp
@@ -43,8 +43,10 @@ const std::vector<config::ConfigProperty>& FileConfig::registeredProperties() {
     VELOX_HIVE_CONFIG_REGISTER(kLoadQuantumSession);
     VELOX_HIVE_CONFIG_REGISTER(kReadStatsBasedFilterReorderDisabledSession);
     VELOX_HIVE_CONFIG_REGISTER(kIndexEnabledSession);
-    VELOX_HIVE_CONFIG_REGISTER(kFileMetadataCacheEnabledSession);
-    VELOX_HIVE_CONFIG_REGISTER(kPinFileMetadataSession);
+    VELOX_HIVE_CONFIG_REGISTER(kCacheMetadataSession);
+    VELOX_HIVE_CONFIG_REGISTER(kPinMetadataSession);
+    VELOX_HIVE_CONFIG_REGISTER(kCacheIndexSession);
+    VELOX_HIVE_CONFIG_REGISTER(kPinIndexSession);
     VELOX_HIVE_CONFIG_REGISTER(kSelectiveNimbleReaderEnabledSession);
     VELOX_HIVE_CONFIG_REGISTER(kMaxCoalescedDistanceSession);
     VELOX_HIVE_CONFIG_REGISTER(kParallelUnitLoadCountSession);

--- a/velox/connectors/hive/FileConfig.h
+++ b/velox/connectors/hive/FileConfig.h
@@ -205,23 +205,40 @@ class FileConfig {
   static constexpr const char* kIndexEnabled = "index-enabled";
 
   VELOX_HIVE_CONFIG(
-      kFileMetadataCacheEnabledSession,
-      fileMetadataCacheEnabled,
-      "file_metadata_cache_enabled",
+      kCacheMetadataSession,
+      cacheMetadata,
+      "cache_metadata",
       bool,
       false,
       "Cache file metadata in AsyncDataCache.")
-  static constexpr const char* kFileMetadataCacheEnabled =
-      "file-metadata-cache-enabled";
+  static constexpr const char* kCacheMetadata = "cache-metadata";
 
   VELOX_HIVE_CONFIG(
-      kPinFileMetadataSession,
-      pinFileMetadata,
-      "pin_file_metadata",
+      kPinMetadataSession,
+      pinMetadata,
+      "pin_metadata",
       bool,
       false,
       "Pin parsed metadata objects in reader cache.")
-  static constexpr const char* kPinFileMetadata = "pin-file-metadata";
+  static constexpr const char* kPinMetadata = "pin-metadata";
+
+  VELOX_HIVE_CONFIG(
+      kCacheIndexSession,
+      cacheIndex,
+      "cache_index",
+      bool,
+      false,
+      "Cache index data in AsyncDataCache.")
+  static constexpr const char* kCacheIndex = "cache-index";
+
+  VELOX_HIVE_CONFIG(
+      kPinIndexSession,
+      pinIndex,
+      "pin_index",
+      bool,
+      false,
+      "Pin parsed index objects in reader cache.")
+  static constexpr const char* kPinIndex = "pin-index";
 
   VELOX_HIVE_CONFIG(
       kSelectiveNimbleReaderEnabledSession,

--- a/velox/connectors/hive/FileConnectorUtil.cpp
+++ b/velox/connectors/hive/FileConnectorUtil.cpp
@@ -97,10 +97,10 @@ void configureReaderOptions(
     readerOptions.setSelectiveNimbleReaderEnabled(
         connectorQueryCtx->selectiveNimbleReaderEnabled());
   }
-  readerOptions.setFileMetadataCacheEnabled(
-      fileConfig->fileMetadataCacheEnabled(sessionProperties));
-  readerOptions.setPinFileMetadata(
-      fileConfig->pinFileMetadata(sessionProperties));
+  readerOptions.setCacheMetadata(fileConfig->cacheMetadata(sessionProperties));
+  readerOptions.setPinMetadata(fileConfig->pinMetadata(sessionProperties));
+  readerOptions.setCacheIndex(fileConfig->cacheIndex(sessionProperties));
+  readerOptions.setPinIndex(fileConfig->pinIndex(sessionProperties));
 
   // Set footer speculative IO size based on file format.
   switch (fileSplit->fileFormat) {

--- a/velox/connectors/hive/FileIndexReader.cpp
+++ b/velox/connectors/hive/FileIndexReader.cpp
@@ -249,6 +249,7 @@ std::unique_ptr<dwio::common::Reader> FileIndexReader::createFileReader() {
   // TODO: Use separate IoStatistics for data and metadata.
   readerOpts.setDataIoStats(ioStatistics_);
   readerOpts.setMetadataIoStats(ioStatistics_);
+  readerOpts.setIndexIoStats(ioStatistics_);
   hive::configureReaderOptions(
       fileConfig_,
       connectorQueryCtx_,
@@ -256,6 +257,7 @@ std::unique_ptr<dwio::common::Reader> FileIndexReader::createFileReader() {
       hiveSplit_,
       hiveSplit_->serdeParameters,
       readerOpts);
+  readerOpts.setLoadClusterIndex(true);
   readerOpts.setScanSpec(scanSpec_);
   readerOpts.setFileFormat(hiveSplit_->fileFormat);
   VELOX_CHECK_NULL(readerOpts.randomSkip());

--- a/velox/connectors/hive/tests/FileConfigTest.cpp
+++ b/velox/connectors/hive/tests/FileConfigTest.cpp
@@ -46,8 +46,10 @@ TEST(FileConfigTest, defaultConfig) {
   EXPECT_FALSE(config.preserveFlatMapsInMemory(emptySession.get()));
   EXPECT_FALSE(config.indexEnabled(emptySession.get()));
   EXPECT_FALSE(config.readerCollectColumnCpuMetrics(emptySession.get()));
-  EXPECT_FALSE(config.fileMetadataCacheEnabled(emptySession.get()));
-  EXPECT_FALSE(config.pinFileMetadata(emptySession.get()));
+  EXPECT_FALSE(config.cacheMetadata(emptySession.get()));
+  EXPECT_FALSE(config.pinMetadata(emptySession.get()));
+  EXPECT_FALSE(config.cacheIndex(emptySession.get()));
+  EXPECT_FALSE(config.pinIndex(emptySession.get()));
   EXPECT_EQ(config.orcFooterSpeculativeIoSize(emptySession.get()), 256UL << 10);
   EXPECT_EQ(
       config.parquetFooterSpeculativeIoSize(emptySession.get()), 256UL << 10);
@@ -71,8 +73,10 @@ TEST(FileConfigTest, overrideConfig) {
       {FileConfig::kPreserveFlatMapsInMemory, "true"},
       {FileConfig::kIndexEnabled, "true"},
       {FileConfig::kReaderCollectColumnCpuMetrics, "true"},
-      {FileConfig::kFileMetadataCacheEnabled, "true"},
-      {FileConfig::kPinFileMetadata, "true"},
+      {FileConfig::kCacheMetadata, "true"},
+      {FileConfig::kPinMetadata, "true"},
+      {FileConfig::kCacheIndex, "true"},
+      {FileConfig::kPinIndex, "true"},
       {FileConfig::kOrcFooterSpeculativeIoSize, std::to_string(512UL << 10)},
       {FileConfig::kParquetFooterSpeculativeIoSize, std::to_string(1UL << 20)},
       {FileConfig::kNimbleFooterSpeculativeIoSize, std::to_string(4UL << 20)},
@@ -96,8 +100,10 @@ TEST(FileConfigTest, overrideConfig) {
   EXPECT_TRUE(config.preserveFlatMapsInMemory(emptySession.get()));
   EXPECT_TRUE(config.indexEnabled(emptySession.get()));
   EXPECT_TRUE(config.readerCollectColumnCpuMetrics(emptySession.get()));
-  EXPECT_TRUE(config.fileMetadataCacheEnabled(emptySession.get()));
-  EXPECT_TRUE(config.pinFileMetadata(emptySession.get()));
+  EXPECT_TRUE(config.cacheMetadata(emptySession.get()));
+  EXPECT_TRUE(config.pinMetadata(emptySession.get()));
+  EXPECT_TRUE(config.cacheIndex(emptySession.get()));
+  EXPECT_TRUE(config.pinIndex(emptySession.get()));
   EXPECT_EQ(config.orcFooterSpeculativeIoSize(emptySession.get()), 512UL << 10);
   EXPECT_EQ(
       config.parquetFooterSpeculativeIoSize(emptySession.get()), 1UL << 20);
@@ -122,8 +128,10 @@ TEST(FileConfigTest, overrideSession) {
       {FileConfig::kPreserveFlatMapsInMemorySession, "true"},
       {FileConfig::kIndexEnabledSession, "true"},
       {FileConfig::kReaderCollectColumnCpuMetricsSession, "true"},
-      {FileConfig::kFileMetadataCacheEnabledSession, "true"},
-      {FileConfig::kPinFileMetadataSession, "true"},
+      {FileConfig::kCacheMetadataSession, "true"},
+      {FileConfig::kPinMetadataSession, "true"},
+      {FileConfig::kCacheIndexSession, "true"},
+      {FileConfig::kPinIndexSession, "true"},
       {FileConfig::kOrcFooterSpeculativeIoSizeSession,
        std::to_string(128UL << 10)},
       {FileConfig::kParquetFooterSpeculativeIoSizeSession,
@@ -146,8 +154,10 @@ TEST(FileConfigTest, overrideSession) {
   EXPECT_TRUE(config.preserveFlatMapsInMemory(session.get()));
   EXPECT_TRUE(config.indexEnabled(session.get()));
   EXPECT_TRUE(config.readerCollectColumnCpuMetrics(session.get()));
-  EXPECT_TRUE(config.fileMetadataCacheEnabled(session.get()));
-  EXPECT_TRUE(config.pinFileMetadata(session.get()));
+  EXPECT_TRUE(config.cacheMetadata(session.get()));
+  EXPECT_TRUE(config.pinMetadata(session.get()));
+  EXPECT_TRUE(config.cacheIndex(session.get()));
+  EXPECT_TRUE(config.pinIndex(session.get()));
   EXPECT_EQ(config.orcFooterSpeculativeIoSize(session.get()), 128UL << 10);
   EXPECT_EQ(config.parquetFooterSpeculativeIoSize(session.get()), 512UL << 10);
   EXPECT_EQ(config.nimbleFooterSpeculativeIoSize(session.get()), 2UL << 20);

--- a/velox/connectors/hive/tests/HiveConfigTest.cpp
+++ b/velox/connectors/hive/tests/HiveConfigTest.cpp
@@ -56,7 +56,8 @@ TEST(HiveConfigTest, defaultConfig) {
   ASSERT_EQ(hiveConfig.loadQuantum(emptySession.get()), 8 << 20);
   ASSERT_FALSE(hiveConfig.preserveFlatMapsInMemory(emptySession.get()));
   ASSERT_FALSE(hiveConfig.indexEnabled(emptySession.get()));
-  ASSERT_FALSE(hiveConfig.fileMetadataCacheEnabled(emptySession.get()));
+  ASSERT_FALSE(hiveConfig.cacheMetadata(emptySession.get()));
+  ASSERT_FALSE(hiveConfig.cacheIndex(emptySession.get()));
   ASSERT_EQ(
       hiveConfig.orcFooterSpeculativeIoSize(emptySession.get()), 256UL << 10);
   ASSERT_EQ(
@@ -91,7 +92,8 @@ TEST(HiveConfigTest, overrideConfig) {
       {HiveConfig::kMaxBucketCount, std::to_string(100'000)},
       {HiveConfig::kPreserveFlatMapsInMemory, "true"},
       {HiveConfig::kIndexEnabled, "true"},
-      {HiveConfig::kFileMetadataCacheEnabled, "true"},
+      {HiveConfig::kCacheMetadata, "true"},
+      {HiveConfig::kCacheIndex, "true"},
       {HiveConfig::kOrcFooterSpeculativeIoSize, std::to_string(512UL << 10)},
       {HiveConfig::kParquetFooterSpeculativeIoSize, std::to_string(1UL << 20)},
       {HiveConfig::kNimbleFooterSpeculativeIoSize, std::to_string(4UL << 20)},
@@ -130,7 +132,8 @@ TEST(HiveConfigTest, overrideConfig) {
   ASSERT_EQ(hiveConfig.maxBucketCount(emptySession.get()), 100'000);
   ASSERT_TRUE(hiveConfig.preserveFlatMapsInMemory(emptySession.get()));
   ASSERT_TRUE(hiveConfig.indexEnabled(emptySession.get()));
-  ASSERT_TRUE(hiveConfig.fileMetadataCacheEnabled(emptySession.get()));
+  ASSERT_TRUE(hiveConfig.cacheMetadata(emptySession.get()));
+  ASSERT_TRUE(hiveConfig.cacheIndex(emptySession.get()));
   ASSERT_EQ(
       hiveConfig.orcFooterSpeculativeIoSize(emptySession.get()), 512UL << 10);
   ASSERT_EQ(
@@ -160,7 +163,8 @@ TEST(HiveConfigTest, overrideSession) {
       {HiveConfig::kLoadQuantumSession, std::to_string(4 << 20)},
       {HiveConfig::kPreserveFlatMapsInMemorySession, "true"},
       {HiveConfig::kIndexEnabledSession, "true"},
-      {HiveConfig::kFileMetadataCacheEnabledSession, "true"},
+      {HiveConfig::kCacheMetadataSession, "true"},
+      {HiveConfig::kCacheIndexSession, "true"},
       {HiveConfig::kOrcFooterSpeculativeIoSizeSession,
        std::to_string(128UL << 10)},
       {HiveConfig::kParquetFooterSpeculativeIoSizeSession,
@@ -197,7 +201,8 @@ TEST(HiveConfigTest, overrideSession) {
   ASSERT_EQ(hiveConfig.loadQuantum(session.get()), 4 << 20);
   ASSERT_TRUE(hiveConfig.preserveFlatMapsInMemory(session.get()));
   ASSERT_TRUE(hiveConfig.indexEnabled(session.get()));
-  ASSERT_TRUE(hiveConfig.fileMetadataCacheEnabled(session.get()));
+  ASSERT_TRUE(hiveConfig.cacheMetadata(session.get()));
+  ASSERT_TRUE(hiveConfig.cacheIndex(session.get()));
   ASSERT_EQ(hiveConfig.orcFooterSpeculativeIoSize(session.get()), 128UL << 10);
   ASSERT_EQ(
       hiveConfig.parquetFooterSpeculativeIoSize(session.get()), 512UL << 10);

--- a/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
@@ -185,8 +185,8 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
       readerOptions.filePreloadThreshold(), hiveConfig->filePreloadThreshold());
   EXPECT_EQ(readerOptions.prefetchRowGroups(), hiveConfig->prefetchRowGroups());
   EXPECT_EQ(
-      readerOptions.fileMetadataCacheEnabled(),
-      hiveConfig->fileMetadataCacheEnabled(&sessionProperties));
+      readerOptions.cacheMetadata(),
+      hiveConfig->cacheMetadata(&sessionProperties));
 
   // Modify field delimiter and change the file format.
   clearDynamicParameters(FileFormat::TEXT);
@@ -276,7 +276,7 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
   customHiveConfigProps[hive::HiveConfig::kOrcUseColumnNames] = "true";
   customHiveConfigProps[hive::HiveConfig::kFilePreloadThreshold] = "9999";
   customHiveConfigProps[hive::HiveConfig::kPrefetchRowGroups] = "10";
-  customHiveConfigProps[hive::HiveConfig::kFileMetadataCacheEnabled] = "true";
+  customHiveConfigProps[hive::HiveConfig::kCacheMetadata] = "true";
   customHiveConfigProps[hive::HiveConfig::kOrcFooterSpeculativeIoSize] = "1111";
   hiveConfig = std::make_shared<hive::HiveConfig>(
       std::make_shared<config::ConfigBase>(std::move(customHiveConfigProps)));
@@ -298,7 +298,7 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
   EXPECT_EQ(
       readerOptions.filePreloadThreshold(), hiveConfig->filePreloadThreshold());
   EXPECT_EQ(readerOptions.prefetchRowGroups(), hiveConfig->prefetchRowGroups());
-  EXPECT_TRUE(readerOptions.fileMetadataCacheEnabled());
+  EXPECT_TRUE(readerOptions.cacheMetadata());
   clearDynamicParameters(FileFormat::ORC);
   performConfigure();
   checkUseColumnNamesForColumnMapping();
@@ -444,19 +444,19 @@ TEST_F(HiveConnectorUtilTest, footerSpeculativeIoSizeByFormat) {
   }
 }
 
-TEST_F(HiveConnectorUtilTest, fileMetadataCacheEnabledSessionOverride) {
+TEST_F(HiveConnectorUtilTest, cacheMetadataSessionOverride) {
   // Verify default is off.
   dwio::common::ReaderOptions defaultOptions(pool_.get());
   defaultOptions.setDataIoStats(dataIoStats_);
   defaultOptions.setMetadataIoStats(metadataIoStats_);
-  ASSERT_FALSE(defaultOptions.fileMetadataCacheEnabled());
+  ASSERT_FALSE(defaultOptions.cacheMetadata());
 
   for (bool enabled : {true, false}) {
-    SCOPED_TRACE(fmt::format("fileMetadataCacheEnabled={}", enabled));
+    SCOPED_TRACE(fmt::format("cacheMetadata={}", enabled));
 
     config::ConfigBase sessionProperties(
         std::unordered_map<std::string, std::string>{
-            {hive::HiveConfig::kFileMetadataCacheEnabledSession,
+            {hive::HiveConfig::kCacheMetadataSession,
              enabled ? "true" : "false"}});
     auto connectorQueryCtx = std::make_unique<connector::ConnectorQueryCtx>(
         pool_.get(),
@@ -495,7 +495,62 @@ TEST_F(HiveConnectorUtilTest, fileMetadataCacheEnabledSessionOverride) {
         split,
         split->serdeParameters,
         readerOptions);
-    ASSERT_EQ(readerOptions.fileMetadataCacheEnabled(), enabled);
+    ASSERT_EQ(readerOptions.cacheMetadata(), enabled);
+  }
+}
+
+TEST_F(HiveConnectorUtilTest, cacheIndexSessionOverride) {
+  dwio::common::ReaderOptions defaultOptions(pool_.get());
+  defaultOptions.setDataIoStats(dataIoStats_);
+  defaultOptions.setMetadataIoStats(metadataIoStats_);
+  ASSERT_FALSE(defaultOptions.cacheIndex());
+
+  for (bool enabled : {true, false}) {
+    SCOPED_TRACE(fmt::format("cacheIndex={}", enabled));
+
+    config::ConfigBase sessionProperties(
+        std::unordered_map<std::string, std::string>{
+            {hive::HiveConfig::kCacheIndexSession,
+             enabled ? "true" : "false"}});
+    auto connectorQueryCtx = std::make_unique<connector::ConnectorQueryCtx>(
+        pool_.get(),
+        pool_.get(),
+        &sessionProperties,
+        nullptr,
+        common::PrefixSortConfig(),
+        nullptr,
+        nullptr,
+        "query.HiveConnectorUtilTest",
+        "task.HiveConnectorUtilTest",
+        "planNodeId.HiveConnectorUtilTest",
+        0,
+        "");
+    auto hiveConfig =
+        std::make_shared<hive::HiveConfig>(std::make_shared<config::ConfigBase>(
+            std::unordered_map<std::string, std::string>()));
+    dwio::common::ReaderOptions readerOptions(pool_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
+
+    auto tableHandle = std::make_shared<hive::HiveTableHandle>(
+        "testConnectorId",
+        "testTable",
+        common::SubfieldFilters{},
+        nullptr,
+        nullptr,
+        std::vector<std::string>{},
+        std::unordered_map<std::string, std::string>{});
+    auto split = std::make_shared<hive::HiveConnectorSplit>(
+        "testConnectorId", "/tmp/", FileFormat::DWRF);
+    configureReaderOptions(
+        hiveConfig,
+        connectorQueryCtx.get(),
+        tableHandle,
+        split,
+        split->serdeParameters,
+        readerOptions);
+    ASSERT_EQ(readerOptions.cacheIndex(), enabled);
+    ASSERT_EQ(readerOptions.pinIndex(), false);
   }
 }
 

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -858,21 +858,34 @@ must be specified as raw byte counts.
      - 0
      - Maximum number of output rows to return per index lookup request. The limit is applied to the actual output rows
        after filtering. 0 means no limit (default).
-   * - file-metadata-cache-enabled
-     - file_metadata_cache_enabled
+   * - cache-metadata
+     - cache_metadata
      - bool
      - false
      - Whether to cache file metadata (footer, stripes, index) in the process-wide AsyncDataCache. When enabled,
        the first reader performs a speculative tail read and populates the cache; subsequent readers on the same file
        serve metadata from cache with zero file IO. Currently only supported by Nimble format.
-   * - pin-file-metadata
-     - pin_file_metadata
+   * - pin-metadata
+     - pin_metadata
      - bool
      - false
      - Whether to pin parsed metadata objects (e.g., StripeGroup, IndexGroup) in the reader's metadata cache with
        strong references so they are never evicted. This avoids re-reading and re-parsing metadata on every stripe
        access when weak-pointer cache entries would otherwise expire. Can be used independently of
-       file-metadata-cache-enabled. Currently only supported by Nimble format.
+       cache-metadata. Currently only supported by Nimble format.
+   * - cache-index
+     - cache_index
+     - bool
+     - false
+     - Whether to cache index data (e.g., cluster index key stream) in the async data cache.
+       Currently only supported by Nimble format.
+   * - pin-index
+     - pin_index
+     - bool
+     - false
+     - Whether to pin parsed index objects (e.g., HashIndex, SortedIndex) in the reader's index cache with
+       strong references so they are never evicted. Can be used independently of
+       cache-index. Currently only supported by Nimble format.
    * - reader.collect-column-cpu-metrics
      - reader.collect_column_cpu_metrics
      - bool

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -743,29 +743,51 @@ class ReaderOptions : public io::ReaderOptions {
   /// process-wide AsyncDataCache. When enabled, the first reader performs a
   /// speculative tail read and populates the cache; subsequent readers on the
   /// same file initialize from the cache with zero additional IO.
-  bool fileMetadataCacheEnabled() const {
-    return fileMetadataCacheEnabled_;
+  bool cacheMetadata() const {
+    return cacheMetadata_;
   }
 
-  void setFileMetadataCacheEnabled(bool value) {
-    fileMetadataCacheEnabled_ = value;
+  void setCacheMetadata(bool value) {
+    cacheMetadata_ = value;
   }
 
   /// If true, pins parsed metadata objects (e.g., StripeGroup, IndexGroup) in
   /// the reader's metadata cache with strong references so they are never
   /// evicted. This avoids re-reading and re-parsing metadata on every stripe
-  /// access when weak-pointer cache entries would otherwise expire.
-  bool pinFileMetadata() const {
-    return pinFileMetadata_;
+  /// access when weak-pointer cache entries would otherwise expire. Works
+  /// independently of cacheMetadata.
+  bool pinMetadata() const {
+    return pinMetadata_;
   }
 
-  void setPinFileMetadata(bool value) {
-    pinFileMetadata_ = value;
+  void setPinMetadata(bool value) {
+    pinMetadata_ = value;
+  }
+
+  /// If true, caches index data (e.g., cluster index key stream) in the
+  /// async data cache.
+  bool cacheIndex() const {
+    return cacheIndex_;
+  }
+
+  void setCacheIndex(bool value) {
+    cacheIndex_ = value;
+  }
+
+  /// If true, pins parsed index objects in the reader's index cache with
+  /// strong references so they are never evicted. Works independently of
+  /// cacheIndex.
+  bool pinIndex() const {
+    return pinIndex_;
+  }
+
+  void setPinIndex(bool value) {
+    pinIndex_ = value;
   }
 
   /// Whether to load and initialize the cluster index during file open.
   /// When true, the cluster index section is preloaded and the structured
-  /// ClusterIndex object is created. Default true.
+  /// ClusterIndex object is created. Default false.
   bool loadClusterIndex() const {
     return loadClusterIndex_;
   }
@@ -823,9 +845,11 @@ class ReaderOptions : public io::ReaderOptions {
   const tz::TimeZone* sessionTimezone_{nullptr};
   bool adjustTimestampToTimezone_{false};
   bool selectiveNimbleReaderEnabled_{false};
-  bool fileMetadataCacheEnabled_{false};
-  bool pinFileMetadata_{false};
-  bool loadClusterIndex_{true};
+  bool cacheMetadata_{false};
+  bool pinMetadata_{false};
+  bool cacheIndex_{false};
+  bool pinIndex_{false};
+  bool loadClusterIndex_{false};
   bool loadChunkIndex_{true};
   bool allowEmptyFile_{false};
   bool allowInt32Narrowing_{false};


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookincubator/nimble/pull/745

Rename `TabletReader::Options::pinFileMetadata` to `pinMetadata` and separate file metadata vs index caching/pinning into four independent controls:

- `pinMetadata`: pins parsed file metadata objects (StripeGroup, ChunkIndexGroup) in the in-memory weak-pointer cache with strong references so they are never evicted within the same TabletReader.
- `cacheMetadata`: caches raw file metadata (footer, stripe groups) in the process-wide `AsyncDataCache`. Takes effect only when `fileHandle` and `cache` are provided; silently falls back to direct IO otherwise.
- `pinIndex`: pins parsed index objects (HashIndex, SortedIndex) in the `DenseIndexRegistry` cache with strong references. Previously hardcoded to `true`; now controllable via this flag (defaults to `false`).
- `cacheIndex`: caches index data (partition metadata, key streams) in `AsyncDataCache` via `IndexLookup::Options`. Takes effect only when `fileHandle` and `cache` are provided.

Also changes `loadClusterIndex` and `loadDenseIndexes` defaults from `true` to `false` in both `TabletReader::Options` and `ReaderOptions`. Callers that need these indexes now explicitly opt in. Updated all production callsites (`NimbleDumpLib::emitIndex`, `FileLayout::create`, rexdb cluster index dump) and test utilities (`makeTestTabletOptions`, `TabletWithIndexTest`).

Also cleans up `IndexLookup`:
- `createIndexDataInput`/`createIndexMetadataInput` now return `shared_ptr` (avoids casts at call sites)
- Removed unused `pool` parameter from `createIndexDataInput`
- `IndexLookup::Options::validate()` now requires `indexIoStats` to be set
- `ClusterIndex` holds `shared_ptr<BufferedInput>` instead of `unique_ptr`

Test cleanup:
- Added `indexIoStats_` class member to `VeloxReaderTest` and `SelectiveNimbleReaderTest` (consistent with existing `dataIoStats_`/`metadataIoStats_` pattern)
- `metadataReuseWithSameReader` tests now use class io stats members instead of creating locals

Unit tests:
- `VeloxReaderTest::metadataReuseWithSameReader`: 6 combinations of `{pinMetadata, cacheMetadata, provideCache}`, all expect within-reader metadata reuse with `expectRamHit` validation
- `VeloxReaderTest::metadataReuseCrossReaders`: 5 combinations with `expectCrossReaderReuse` and `expectRamHit`; only `cacheMetadata=true` with cache provided enables cross-reader reuse
- `SelectiveNimbleReaderTest::metadataReuseWithSameReader` and `metadataReuseCrossReaders`: matching tests for the selective reader path
- `NimbleIndexProjectorTest::metadataReuseWithSameReader`: matching test for the index projector path
- `DenseIndexRegistryTest::pinIndexEnabled`/`pinIndexDisabled`: verifies `pinIndex` flag wires through to `MetadataCache`
- `IndexLookupTest::optionsValidateIndexIoStats`: verifies `indexIoStats` null check

Reviewed By: HuamengJiang, tanjialiang

Differential Revision: D105465252


