### PR TITLE
feat(memory): Add reportAllocation/reportFree for external allocations

### DIFF
--- a/velox/common/base/tests/StatsReporterTest.cpp
+++ b/velox/common/base/tests/StatsReporterTest.cpp
@@ -251,7 +251,7 @@ class TestMemoryPool : public memory::MemoryPool {
     return nullptr;
   }
 
-  void reportAllocation(int64_t /* unused */) override {}
+  void reportExternalAllocation(int64_t /* unused */) override {}
 
   void* allocateZeroFilled(int64_t /* unused */, int64_t /* unused */)
       override {
@@ -267,7 +267,7 @@ class TestMemoryPool : public memory::MemoryPool {
 
   void free(void* /* unused */, int64_t /* unused */) override {}
 
-  void reportFree(int64_t /* unused */) override {}
+  void reportExternalFree(int64_t /* unused */) override {}
 
   void allocateNonContiguous(
       memory::MachinePageCount /* unused */,

--- a/velox/common/base/tests/StatsReporterTest.cpp
+++ b/velox/common/base/tests/StatsReporterTest.cpp
@@ -251,6 +251,8 @@ class TestMemoryPool : public memory::MemoryPool {
     return nullptr;
   }
 
+  void reportAllocation(int64_t /* unused */) override {}
+
   void* allocateZeroFilled(int64_t /* unused */, int64_t /* unused */)
       override {
     return nullptr;
@@ -264,6 +266,8 @@ class TestMemoryPool : public memory::MemoryPool {
   }
 
   void free(void* /* unused */, int64_t /* unused */) override {}
+
+  void reportFree(int64_t /* unused */) override {}
 
   void allocateNonContiguous(
       memory::MachinePageCount /* unused */,

--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -540,6 +540,12 @@ void* MemoryPoolImpl::allocate(
   return buffer;
 }
 
+void MemoryPoolImpl::reportAllocation(int64_t size) {
+  CHECK_AND_INC_MEM_OP_STATS(this, Allocs);
+  const auto alignedSize = sizeAlign(size);
+  reserve(alignedSize);
+}
+
 void* MemoryPoolImpl::allocateZeroFilled(int64_t numEntries, int64_t sizeEach) {
   CHECK_AND_INC_MEM_OP_STATS(this, Allocs);
   const auto size = sizeEach * numEntries;
@@ -614,6 +620,12 @@ bool MemoryPoolImpl::transferTo(MemoryPool* dest, void* buffer, uint64_t size) {
   release(alignedSize);
 
   return true;
+}
+
+void MemoryPoolImpl::reportFree(int64_t size) {
+  CHECK_AND_INC_MEM_OP_STATS(this, Frees);
+  const auto alignedSize = sizeAlign(size);
+  release(alignedSize);
 }
 
 void MemoryPoolImpl::allocateNonContiguous(

--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -170,7 +170,7 @@ std::string capacityToString(int64_t capacity) {
 
 std::string MemoryPool::Stats::toString() const {
   return fmt::format(
-      "usedBytes:{} reservedBytes:{} peakBytes:{} cumulativeBytes:{} numAllocs:{} numFrees:{} numReserves:{} numReleases:{} numShrinks:{} numReclaims:{} numCollisions:{} numCapacityGrowths:{}",
+      "usedBytes:{} reservedBytes:{} peakBytes:{} cumulativeBytes:{} numAllocs:{} numFrees:{} numReserves:{} numReleases:{} numShrinks:{} numReclaims:{} numCollisions:{} numCapacityGrowths:{} numExternalAllocs:{} numExternalFrees:{} cumulativeExternalBytes:{}",
       succinctBytes(usedBytes),
       succinctBytes(reservedBytes),
       succinctBytes(peakBytes),
@@ -182,7 +182,10 @@ std::string MemoryPool::Stats::toString() const {
       numShrinks,
       numReclaims,
       numCollisions,
-      numCapacityGrowths);
+      numCapacityGrowths,
+      numExternalAllocs,
+      numExternalFrees,
+      succinctBytes(cumulativeExternalBytes));
 }
 
 bool MemoryPool::Stats::operator==(const MemoryPool::Stats& other) const {
@@ -196,7 +199,10 @@ bool MemoryPool::Stats::operator==(const MemoryPool::Stats& other) const {
              numReserves,
              numReleases,
              numCollisions,
-             numCapacityGrowths) ==
+             numCapacityGrowths,
+             numExternalAllocs,
+             numExternalFrees,
+             cumulativeExternalBytes) ==
       std::tie(
              other.usedBytes,
              other.reservedBytes,
@@ -207,7 +213,10 @@ bool MemoryPool::Stats::operator==(const MemoryPool::Stats& other) const {
              other.numReserves,
              other.numReleases,
              other.numCollisions,
-             other.numCapacityGrowths);
+             other.numCapacityGrowths,
+             other.numExternalAllocs,
+             other.numExternalFrees,
+             other.cumulativeExternalBytes);
 }
 
 std::ostream& operator<<(std::ostream& os, const MemoryPool::Stats& stats) {
@@ -502,6 +511,9 @@ MemoryPool::Stats MemoryPoolImpl::statsLocked() const {
   stats.numReleases = numReleases_;
   stats.numCollisions = numCollisions_;
   stats.numCapacityGrowths = numCapacityGrowths_;
+  stats.numExternalAllocs = numExternalAllocs_;
+  stats.numExternalFrees = numExternalFrees_;
+  stats.cumulativeExternalBytes = cumulativeExternalBytes_;
   return stats;
 }
 
@@ -540,11 +552,15 @@ void* MemoryPoolImpl::allocate(
   return buffer;
 }
 
-void MemoryPoolImpl::reportAllocation(int64_t size) {
+void MemoryPoolImpl::reportExternalAllocation(int64_t size) {
   VELOX_CHECK_GT(size, 0);
-  CHECK_AND_INC_MEM_OP_STATS(this, Allocs);
-  const auto alignedSize = sizeAlign(size);
-  reserve(alignedSize);
+  if (FOLLY_UNLIKELY(kind_ != Kind::kLeaf)) {
+    VELOX_FAIL(
+        "Memory operation is only allowed on leaf memory pool: {}", toString());
+  }
+  ++numExternalAllocs_;
+  cumulativeExternalBytes_ += size;
+  reserve(size);
 }
 
 void* MemoryPoolImpl::allocateZeroFilled(int64_t numEntries, int64_t sizeEach) {
@@ -623,11 +639,14 @@ bool MemoryPoolImpl::transferTo(MemoryPool* dest, void* buffer, uint64_t size) {
   return true;
 }
 
-void MemoryPoolImpl::reportFree(int64_t size) {
+void MemoryPoolImpl::reportExternalFree(int64_t size) {
   VELOX_CHECK_GT(size, 0);
-  CHECK_AND_INC_MEM_OP_STATS(this, Frees);
-  const auto alignedSize = sizeAlign(size);
-  release(alignedSize);
+  if (FOLLY_UNLIKELY(kind_ != Kind::kLeaf)) {
+    VELOX_FAIL(
+        "Memory operation is only allowed on leaf memory pool: {}", toString());
+  }
+  ++numExternalFrees_;
+  release(size);
 }
 
 void MemoryPoolImpl::allocateNonContiguous(

--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -553,7 +553,7 @@ void* MemoryPoolImpl::allocate(
 }
 
 void MemoryPoolImpl::reportExternalAllocation(int64_t size) {
-  VELOX_CHECK_GT(size, 0);
+  VELOX_CHECK_GT(size, 0, "reportExternalAllocation requires positive size");
   if (FOLLY_UNLIKELY(kind_ != Kind::kLeaf)) {
     VELOX_FAIL(
         "Memory operation is only allowed on leaf memory pool: {}", toString());
@@ -640,7 +640,7 @@ bool MemoryPoolImpl::transferTo(MemoryPool* dest, void* buffer, uint64_t size) {
 }
 
 void MemoryPoolImpl::reportExternalFree(int64_t size) {
-  VELOX_CHECK_GT(size, 0);
+  VELOX_CHECK_GT(size, 0, "reportExternalFree requires positive size");
   if (FOLLY_UNLIKELY(kind_ != Kind::kLeaf)) {
     VELOX_FAIL(
         "Memory operation is only allowed on leaf memory pool: {}", toString());

--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -541,6 +541,7 @@ void* MemoryPoolImpl::allocate(
 }
 
 void MemoryPoolImpl::reportAllocation(int64_t size) {
+  VELOX_CHECK_GT(size, 0);
   CHECK_AND_INC_MEM_OP_STATS(this, Allocs);
   const auto alignedSize = sizeAlign(size);
   reserve(alignedSize);
@@ -623,6 +624,7 @@ bool MemoryPoolImpl::transferTo(MemoryPool* dest, void* buffer, uint64_t size) {
 }
 
 void MemoryPoolImpl::reportFree(int64_t size) {
+  VELOX_CHECK_GT(size, 0);
   CHECK_AND_INC_MEM_OP_STATS(this, Frees);
   const auto alignedSize = sizeAlign(size);
   release(alignedSize);

--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -241,10 +241,10 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
       std::optional<uint32_t> alignment = std::nullopt) = 0;
 
   /// Reports an external allocation of 'size' bytes to the memory pool without
-  /// actually allocating memory through the pool. Used to track memory owned by
-  /// objects allocated outside of the pool (for example, Thrift-deserialized
-  /// structures). Each call must be paired with a matching reportFree() of the
-  /// same 'size' when the external memory is released.
+  /// allocating any memory. Used to track memory owned by objects that were
+  /// allocated outside of the pool (e.g., Thrift-deserialized structures).
+  /// Each call must be paired with a matching reportFree() of the same 'size'
+  /// when the external memory is released. 'size' must be positive.
   virtual void reportAllocation(int64_t size) = 0;
 
   /// Allocates a zero-filled buffer with capacity that can store 'numEntries'
@@ -265,9 +265,9 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
     return false;
   }
 
-  /// Releases a previously reported external allocation of 'size' bytes from
-  /// the memory pool without freeing any memory. Pair every call with a
-  /// matching reportAllocation() of the same 'size'.
+  /// Reports the release of 'size' bytes of externally tracked memory. Must
+  /// be paired with a prior reportAllocation() of the same 'size'. 'size'
+  /// must be positive.
   virtual void reportFree(int64_t size) = 0;
 
   /// Allocates one or more runs that add up to at least 'numPages', with the

--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -243,9 +243,12 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
   /// Reports an external allocation of 'size' bytes to the memory pool without
   /// allocating any memory. Used to track memory owned by objects that were
   /// allocated outside of the pool (e.g., Thrift-deserialized structures).
-  /// Each call must be paired with a matching reportFree() of the same 'size'
-  /// when the external memory is released. 'size' must be positive.
-  virtual void reportAllocation(int64_t size) = 0;
+  /// Each call must be paired with a matching reportExternalFree() of the
+  /// same 'size' when the external memory is released. 'size' must be
+  /// positive. External allocations are counted separately from regular pool
+  /// allocations and surfaced through Stats::numExternalAllocs and
+  /// Stats::cumulativeExternalBytes.
+  virtual void reportExternalAllocation(int64_t size) = 0;
 
   /// Allocates a zero-filled buffer with capacity that can store 'numEntries'
   /// entries with each size of 'sizeEach'.
@@ -266,9 +269,9 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
   }
 
   /// Reports the release of 'size' bytes of externally tracked memory. Must
-  /// be paired with a prior reportAllocation() of the same 'size'. 'size'
-  /// must be positive.
-  virtual void reportFree(int64_t size) = 0;
+  /// be paired with a prior reportExternalAllocation() of the same 'size'.
+  /// 'size' must be positive.
+  virtual void reportExternalFree(int64_t size) = 0;
 
   /// Allocates one or more runs that add up to at least 'numPages', with the
   /// smallest run being at least 'minSizeClass' pages. 'minSizeClass' must be
@@ -467,6 +470,14 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
     ///
     /// NOTE: this only applies for the root memory pool.
     uint64_t numCapacityGrowths{0};
+    /// The number of external allocations reported via
+    /// reportExternalAllocation().
+    uint64_t numExternalAllocs{0};
+    /// The number of external frees reported via reportExternalFree().
+    uint64_t numExternalFrees{0};
+    /// The cumulative sum of bytes reported via reportExternalAllocation()
+    /// since the pool was created.
+    uint64_t cumulativeExternalBytes{0};
 
     bool operator==(const Stats& rhs) const;
 
@@ -628,7 +639,7 @@ class MemoryPoolImpl : public MemoryPool {
   void* allocate(int64_t size, std::optional<uint32_t> alignment = std::nullopt)
       override;
 
-  void reportAllocation(int64_t size) override;
+  void reportExternalAllocation(int64_t size) override;
 
   void* allocateZeroFilled(int64_t numEntries, int64_t sizeEach) override;
 
@@ -638,7 +649,7 @@ class MemoryPoolImpl : public MemoryPool {
 
   bool transferTo(MemoryPool* dest, void* buffer, uint64_t size) override;
 
-  void reportFree(int64_t size) override;
+  void reportExternalFree(int64_t size) override;
 
   void allocateNonContiguous(
       MachinePageCount numPages,
@@ -975,7 +986,10 @@ class MemoryPoolImpl : public MemoryPool {
         << succinctBytes(minReservationBytes_);
     out << "] counters [allocs " << numAllocs_ << ", frees " << numFrees_
         << ", reserves " << numReserves_ << ", releases " << numReleases_
-        << ", collisions " << numCollisions_ << "])";
+        << ", collisions " << numCollisions_ << ", external-allocs "
+        << numExternalAllocs_ << ", external-frees " << numExternalFrees_
+        << ", cumulative-external " << succinctBytes(cumulativeExternalBytes_)
+        << "])";
     out << ">";
     return out.str();
   }
@@ -1110,6 +1124,17 @@ class MemoryPoolImpl : public MemoryPool {
   //
   // NOTE: this only applies for root memory pool.
   std::atomic_uint64_t numCapacityGrowths_{0};
+
+  // The number of external allocations reported via
+  // reportExternalAllocation().
+  std::atomic_uint64_t numExternalAllocs_{0};
+
+  // The number of external frees reported via reportExternalFree().
+  std::atomic_uint64_t numExternalFrees_{0};
+
+  // The cumulative sum of bytes reported via reportExternalAllocation() since
+  // the pool was created.
+  std::atomic_uint64_t cumulativeExternalBytes_{0};
 
   // Mutex for 'debugAllocRecords_'.
   mutable std::mutex debugAllocMutex_;

--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -240,6 +240,13 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
       int64_t size,
       std::optional<uint32_t> alignment = std::nullopt) = 0;
 
+  /// Reports an external allocation of 'size' bytes to the memory pool without
+  /// actually allocating memory through the pool. Used to track memory owned by
+  /// objects allocated outside of the pool (for example, Thrift-deserialized
+  /// structures). Each call must be paired with a matching reportFree() of the
+  /// same 'size' when the external memory is released.
+  virtual void reportAllocation(int64_t size) = 0;
+
   /// Allocates a zero-filled buffer with capacity that can store 'numEntries'
   /// entries with each size of 'sizeEach'.
   virtual void* allocateZeroFilled(int64_t numEntries, int64_t sizeEach) = 0;
@@ -257,6 +264,11 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
   transferTo(MemoryPool* /*dest*/, void* /*buffer*/, uint64_t /*size*/) {
     return false;
   }
+
+  /// Releases a previously reported external allocation of 'size' bytes from
+  /// the memory pool without freeing any memory. Pair every call with a
+  /// matching reportAllocation() of the same 'size'.
+  virtual void reportFree(int64_t size) = 0;
 
   /// Allocates one or more runs that add up to at least 'numPages', with the
   /// smallest run being at least 'minSizeClass' pages. 'minSizeClass' must be
@@ -616,6 +628,8 @@ class MemoryPoolImpl : public MemoryPool {
   void* allocate(int64_t size, std::optional<uint32_t> alignment = std::nullopt)
       override;
 
+  void reportAllocation(int64_t size) override;
+
   void* allocateZeroFilled(int64_t numEntries, int64_t sizeEach) override;
 
   void* reallocate(void* p, int64_t size, int64_t newSize) override;
@@ -623,6 +637,8 @@ class MemoryPoolImpl : public MemoryPool {
   void free(void* p, int64_t size) override;
 
   bool transferTo(MemoryPool* dest, void* buffer, uint64_t size) override;
+
+  void reportFree(int64_t size) override;
 
   void allocateNonContiguous(
       MachinePageCount numPages,

--- a/velox/common/memory/tests/MemoryCapExceededTest.cpp
+++ b/velox/common/memory/tests/MemoryCapExceededTest.cpp
@@ -87,7 +87,8 @@ TEST_P(MemoryCapExceededTest, singleDriver) {
       "] parent[null] MALLOC track-usage thread-safe]<max capacity 5.00MB "
       "capacity 5.00MB used 3.75MB available 0B reservation [used 0B, reserved "
       "5.00MB, min 0B] counters [allocs 0, frees 0, reserves 0, releases 0, "
-      "collisions 0])>"};
+      "collisions 0, external-allocs 0, external-frees 0, cumulative-external "
+      "0B])>"};
   std::vector<std::string> expectedDetailedTexts = {
       "node.1 usage 12.00KB reserved 1.00MB peak 1.00MB",
       "op.1.0.0.FilterProject usage 12.00KB reserved 1.00MB peak 12.00KB",

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -510,10 +510,18 @@ TEST_P(MemoryPoolTest, reportExternalAllocationRejectsNonPositiveSize) {
   auto child =
       root->addLeafChild("reportExternalNonPositive", isLeafThreadSafe_);
 
-  VELOX_ASSERT_THROW(child->reportExternalAllocation(0), "(0 vs. 0)");
-  VELOX_ASSERT_THROW(child->reportExternalAllocation(-1), "(-1 vs. 0)");
-  VELOX_ASSERT_THROW(child->reportExternalFree(0), "(0 vs. 0)");
-  VELOX_ASSERT_THROW(child->reportExternalFree(-1), "(-1 vs. 0)");
+  VELOX_ASSERT_THROW(
+      child->reportExternalAllocation(0),
+      "(0 vs. 0) reportExternalAllocation requires positive size");
+  VELOX_ASSERT_THROW(
+      child->reportExternalAllocation(-1),
+      "(-1 vs. 0) reportExternalAllocation requires positive size");
+  VELOX_ASSERT_THROW(
+      child->reportExternalFree(0),
+      "(0 vs. 0) reportExternalFree requires positive size");
+  VELOX_ASSERT_THROW(
+      child->reportExternalFree(-1),
+      "(-1 vs. 0) reportExternalFree requires positive size");
   ASSERT_EQ(child->usedBytes(), 0);
   ASSERT_EQ(child->reservedBytes(), 0);
 }
@@ -839,7 +847,9 @@ TEST_P(MemoryPoolTest, memoryCapExceptions) {
                     "parent[MemoryCapExceptions] MMAP track-usage {}]<max "
                     "capacity 256.00MB capacity 256.00MB used 0B available 0B "
                     "reservation [used 0B, reserved 0B, min 0B] counters [allocs "
-                    "1, frees 0, reserves 0, releases 0, collisions 0])> Failed to"
+                    "1, frees 0, reserves 0, releases 0, collisions 0, "
+                    "external-allocs 0, external-frees 0, cumulative-external "
+                    "0B])> Failed to"
                     " evict from cache state: AsyncDataCache:\nCache size: 0B "
                     "tinySize: 0B large size: 0B\nCache entries: 0 read pins: "
                     "0 write pins: 0 pinned shared: 0B pinned exclusive: 0B\n "
@@ -857,7 +867,9 @@ TEST_P(MemoryPoolTest, memoryCapExceptions) {
                     "parent[MemoryCapExceptions] MMAP track-usage {}]<max "
                     "capacity 256.00MB capacity 256.00MB used 0B available 0B "
                     "reservation [used 0B, reserved 0B, min 0B] counters [allocs "
-                    "1, frees 0, reserves 0, releases 0, collisions 0])> "
+                    "1, frees 0, reserves 0, releases 0, collisions 0, "
+                    "external-allocs 0, external-frees 0, cumulative-external "
+                    "0B])> "
                     "Exceeded memory allocator limit when allocating 32769 "
                     "new pages for total allocation of 32769 pages, the memory"
                     " allocator capacity is 32768 pages, the allocated pages is 32769",
@@ -873,7 +885,9 @@ TEST_P(MemoryPoolTest, memoryCapExceptions) {
                     "parent[MemoryCapExceptions] MALLOC track-usage {}]"
                     "<max capacity 256.00MB capacity 256.00MB used 0B available "
                     "0B reservation [used 0B, reserved 0B, min 0B] counters "
-                    "[allocs 1, frees 0, reserves 0, releases 0, collisions 0])>"
+                    "[allocs 1, frees 0, reserves 0, releases 0, collisions 0, "
+                    "external-allocs 0, external-frees 0, cumulative-external "
+                    "0B])>"
                     " Failed to evict from cache state: AsyncDataCache:\nCache "
                     "size: 0B tinySize: 0B large size: 0B\nCache entries: 0 "
                     "read pins: 0 write pins: 0 pinned shared: 0B pinned "
@@ -891,7 +905,9 @@ TEST_P(MemoryPoolTest, memoryCapExceptions) {
                     "parent[MemoryCapExceptions] MALLOC track-usage {}]"
                     "<max capacity 256.00MB capacity 256.00MB used 0B available "
                     "0B reservation [used 0B, reserved 0B, min 0B] counters "
-                    "[allocs 1, frees 0, reserves 0, releases 0, collisions 0])>"
+                    "[allocs 1, frees 0, reserves 0, releases 0, collisions 0, "
+                    "external-allocs 0, external-frees 0, cumulative-external "
+                    "0B])>"
                     " Failed to allocateBytes 128.00MB: Exceeded memory "
                     "allocator limit of 128.00MB",
                     isLeafThreadSafe_ ? "thread-safe" : "non-thread-safe"),
@@ -3320,13 +3336,13 @@ TEST_P(MemoryPoolTest, usageTrackerOptionTest) {
   ASSERT_EQ(
       child->toString(),
       fmt::format(
-          "Memory Pool[usageTrackerOptionTest LEAF root[usageTrackerOptionTest] parent[usageTrackerOptionTest] {} track-usage {}]<unlimited max capacity unlimited capacity used 0B available 0B reservation [used 0B, reserved 0B, min 0B] counters [allocs 0, frees 0, reserves 0, releases 0, collisions 0])>",
+          "Memory Pool[usageTrackerOptionTest LEAF root[usageTrackerOptionTest] parent[usageTrackerOptionTest] {} track-usage {}]<unlimited max capacity unlimited capacity used 0B available 0B reservation [used 0B, reserved 0B, min 0B] counters [allocs 0, frees 0, reserves 0, releases 0, collisions 0, external-allocs 0, external-frees 0, cumulative-external 0B])>",
           useMmap_ ? "MMAP" : "MALLOC",
           isLeafThreadSafe_ ? "thread-safe" : "non-thread-safe"));
   ASSERT_EQ(
       root->toString(),
       fmt::format(
-          "Memory Pool[usageTrackerOptionTest AGGREGATE root[usageTrackerOptionTest] parent[null] {} track-usage thread-safe]<unlimited max capacity unlimited capacity used 0B available 0B reservation [used 0B, reserved 0B, min 0B] counters [allocs 0, frees 0, reserves 0, releases 0, collisions 0])>",
+          "Memory Pool[usageTrackerOptionTest AGGREGATE root[usageTrackerOptionTest] parent[null] {} track-usage thread-safe]<unlimited max capacity unlimited capacity used 0B available 0B reservation [used 0B, reserved 0B, min 0B] counters [allocs 0, frees 0, reserves 0, releases 0, collisions 0, external-allocs 0, external-frees 0, cumulative-external 0B])>",
           useMmap_ ? "MMAP" : "MALLOC"));
 }
 
@@ -3343,54 +3359,54 @@ TEST_P(MemoryPoolTest, statsAndToString) {
   void* buf1 = leafChild1->allocate(bufferSize);
   ASSERT_EQ(
       leafChild1->stats().toString(),
-      "usedBytes:1.00KB reservedBytes:1.00MB peakBytes:1.00KB cumulativeBytes:1.00KB numAllocs:1 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0");
+      "usedBytes:1.00KB reservedBytes:1.00MB peakBytes:1.00KB cumulativeBytes:1.00KB numAllocs:1 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0 numExternalAllocs:0 numExternalFrees:0 cumulativeExternalBytes:0B");
   ASSERT_EQ(
       leafChild1->toString(),
       fmt::format(
-          "Memory Pool[leaf-child1 LEAF root[stats] parent[stats] {} track-usage {}]<max capacity 4.00GB capacity 4.00GB used 1.00KB available 1023.00KB reservation [used 1.00KB, reserved 1.00MB, min 0B] counters [allocs 1, frees 0, reserves 0, releases 0, collisions 0])>",
+          "Memory Pool[leaf-child1 LEAF root[stats] parent[stats] {} track-usage {}]<max capacity 4.00GB capacity 4.00GB used 1.00KB available 1023.00KB reservation [used 1.00KB, reserved 1.00MB, min 0B] counters [allocs 1, frees 0, reserves 0, releases 0, collisions 0, external-allocs 0, external-frees 0, cumulative-external 0B])>",
           useMmap_ ? "MMAP" : "MALLOC",
           isLeafThreadSafe_ ? "thread-safe" : "non-thread-safe"));
   ASSERT_EQ(
       leafChild2->stats().toString(),
-      "usedBytes:0B reservedBytes:0B peakBytes:0B cumulativeBytes:0B numAllocs:0 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0");
+      "usedBytes:0B reservedBytes:0B peakBytes:0B cumulativeBytes:0B numAllocs:0 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0 numExternalAllocs:0 numExternalFrees:0 cumulativeExternalBytes:0B");
   ASSERT_EQ(
       leafChild1->toString(),
       fmt::format(
-          "Memory Pool[leaf-child1 LEAF root[stats] parent[stats] {} track-usage {}]<max capacity 4.00GB capacity 4.00GB used 1.00KB available 1023.00KB reservation [used 1.00KB, reserved 1.00MB, min 0B] counters [allocs 1, frees 0, reserves 0, releases 0, collisions 0])>",
+          "Memory Pool[leaf-child1 LEAF root[stats] parent[stats] {} track-usage {}]<max capacity 4.00GB capacity 4.00GB used 1.00KB available 1023.00KB reservation [used 1.00KB, reserved 1.00MB, min 0B] counters [allocs 1, frees 0, reserves 0, releases 0, collisions 0, external-allocs 0, external-frees 0, cumulative-external 0B])>",
           useMmap_ ? "MMAP" : "MALLOC",
           isLeafThreadSafe_ ? "thread-safe" : "non-thread-safe"));
   ASSERT_EQ(
       aggregateChild->stats().toString(),
-      "usedBytes:0B reservedBytes:0B peakBytes:0B cumulativeBytes:0B numAllocs:0 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0");
+      "usedBytes:0B reservedBytes:0B peakBytes:0B cumulativeBytes:0B numAllocs:0 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0 numExternalAllocs:0 numExternalFrees:0 cumulativeExternalBytes:0B");
   ASSERT_EQ(
       root->stats().toString(),
-      "usedBytes:1.00KB reservedBytes:1.00MB peakBytes:1.00MB cumulativeBytes:1.00MB numAllocs:0 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0");
+      "usedBytes:1.00KB reservedBytes:1.00MB peakBytes:1.00MB cumulativeBytes:1.00MB numAllocs:0 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0 numExternalAllocs:0 numExternalFrees:0 cumulativeExternalBytes:0B");
   void* buf2 = leafChild2->allocate(bufferSize);
   ASSERT_EQ(
       leafChild1->stats().toString(),
-      "usedBytes:1.00KB reservedBytes:1.00MB peakBytes:1.00KB cumulativeBytes:1.00KB numAllocs:1 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0");
+      "usedBytes:1.00KB reservedBytes:1.00MB peakBytes:1.00KB cumulativeBytes:1.00KB numAllocs:1 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0 numExternalAllocs:0 numExternalFrees:0 cumulativeExternalBytes:0B");
   ASSERT_EQ(
       leafChild2->stats().toString(),
-      "usedBytes:1.00KB reservedBytes:1.00MB peakBytes:1.00KB cumulativeBytes:1.00KB numAllocs:1 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0");
+      "usedBytes:1.00KB reservedBytes:1.00MB peakBytes:1.00KB cumulativeBytes:1.00KB numAllocs:1 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0 numExternalAllocs:0 numExternalFrees:0 cumulativeExternalBytes:0B");
   ASSERT_EQ(
       aggregateChild->stats().toString(),
-      "usedBytes:1.00KB reservedBytes:1.00MB peakBytes:1.00MB cumulativeBytes:1.00MB numAllocs:0 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0");
+      "usedBytes:1.00KB reservedBytes:1.00MB peakBytes:1.00MB cumulativeBytes:1.00MB numAllocs:0 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0 numExternalAllocs:0 numExternalFrees:0 cumulativeExternalBytes:0B");
   ASSERT_EQ(
       root->stats().toString(),
-      "usedBytes:2.00KB reservedBytes:2.00MB peakBytes:2.00MB cumulativeBytes:2.00MB numAllocs:0 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0");
+      "usedBytes:2.00KB reservedBytes:2.00MB peakBytes:2.00MB cumulativeBytes:2.00MB numAllocs:0 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0 numExternalAllocs:0 numExternalFrees:0 cumulativeExternalBytes:0B");
   leafChild1->free(buf1, bufferSize);
   ASSERT_EQ(
       leafChild1->stats().toString(),
-      "usedBytes:0B reservedBytes:0B peakBytes:1.00KB cumulativeBytes:1.00KB numAllocs:1 numFrees:1 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0");
+      "usedBytes:0B reservedBytes:0B peakBytes:1.00KB cumulativeBytes:1.00KB numAllocs:1 numFrees:1 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0 numExternalAllocs:0 numExternalFrees:0 cumulativeExternalBytes:0B");
   ASSERT_EQ(
       leafChild2->stats().toString(),
-      "usedBytes:1.00KB reservedBytes:1.00MB peakBytes:1.00KB cumulativeBytes:1.00KB numAllocs:1 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0");
+      "usedBytes:1.00KB reservedBytes:1.00MB peakBytes:1.00KB cumulativeBytes:1.00KB numAllocs:1 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0 numExternalAllocs:0 numExternalFrees:0 cumulativeExternalBytes:0B");
   ASSERT_EQ(
       aggregateChild->stats().toString(),
-      "usedBytes:1.00KB reservedBytes:1.00MB peakBytes:1.00MB cumulativeBytes:1.00MB numAllocs:0 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0");
+      "usedBytes:1.00KB reservedBytes:1.00MB peakBytes:1.00MB cumulativeBytes:1.00MB numAllocs:0 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0 numExternalAllocs:0 numExternalFrees:0 cumulativeExternalBytes:0B");
   ASSERT_EQ(
       root->stats().toString(),
-      "usedBytes:1.00KB reservedBytes:1.00MB peakBytes:2.00MB cumulativeBytes:2.00MB numAllocs:0 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0");
+      "usedBytes:1.00KB reservedBytes:1.00MB peakBytes:2.00MB cumulativeBytes:2.00MB numAllocs:0 numFrees:0 numReserves:0 numReleases:0 numShrinks:0 numReclaims:0 numCollisions:0 numCapacityGrowths:0 numExternalAllocs:0 numExternalFrees:0 cumulativeExternalBytes:0B");
   leafChild2->free(buf2, bufferSize);
   std::vector<void*> bufs;
   for (int i = 0; i < 10; ++i) {

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -452,22 +452,34 @@ TEST_P(MemoryPoolTest, reportExternalAllocation) {
   const int64_t kReportSize{1L * MB};
   const auto initialStats = child->stats();
   ASSERT_EQ(child->usedBytes(), 0);
+  ASSERT_EQ(initialStats.numExternalAllocs, 0);
+  ASSERT_EQ(initialStats.numExternalFrees, 0);
+  ASSERT_EQ(initialStats.cumulativeExternalBytes, 0);
 
-  // reportAllocation does not allocate memory but should account for it in
-  // usedBytes/reservedBytes and bump the Allocs stat.
-  child->reportAllocation(kReportSize);
+  // reportExternalAllocation does not allocate memory but should account for
+  // it in usedBytes/reservedBytes and bump the external-allocation stats.
+  // It must not increment numAllocs (reserved for real pool allocations).
+  child->reportExternalAllocation(kReportSize);
   ASSERT_EQ(child->usedBytes(), kReportSize);
   ASSERT_GE(child->reservedBytes(), kReportSize);
-  ASSERT_EQ(child->stats().numAllocs, initialStats.numAllocs + 1);
-  ASSERT_EQ(child->stats().peakBytes, kReportSize);
+  auto stats = child->stats();
+  ASSERT_EQ(stats.numAllocs, initialStats.numAllocs);
+  ASSERT_EQ(stats.numExternalAllocs, 1);
+  ASSERT_EQ(stats.cumulativeExternalBytes, kReportSize);
+  ASSERT_EQ(stats.peakBytes, kReportSize);
 
-  // A paired reportFree of the same size returns the pool to its original
-  // bookkeeping state and bumps the Frees stat. peak stays at its max.
-  child->reportFree(kReportSize);
+  // A paired reportExternalFree of the same size returns the pool to its
+  // original bookkeeping state and bumps the external-free stat without
+  // touching numFrees. peak stays at its max. cumulativeExternalBytes is a
+  // running total of all external allocations and never decreases.
+  child->reportExternalFree(kReportSize);
   ASSERT_EQ(child->usedBytes(), 0);
   ASSERT_EQ(child->reservedBytes(), 0);
-  ASSERT_EQ(child->stats().numFrees, initialStats.numFrees + 1);
-  ASSERT_EQ(child->stats().peakBytes, kReportSize);
+  stats = child->stats();
+  ASSERT_EQ(stats.numFrees, initialStats.numFrees);
+  ASSERT_EQ(stats.numExternalFrees, 1);
+  ASSERT_EQ(stats.cumulativeExternalBytes, kReportSize);
+  ASSERT_EQ(stats.peakBytes, kReportSize);
 }
 
 TEST_P(MemoryPoolTest, reportExternalAllocationCapacityExceeded) {
@@ -486,7 +498,7 @@ TEST_P(MemoryPoolTest, reportExternalAllocationCapacityExceeded) {
   // Reporting more than the pool's capacity must trip the same memory-cap
   // path that allocate() does, leaving usage at zero.
   VELOX_ASSERT_THROW(
-      pool->reportAllocation(static_cast<int64_t>(kMaxCap) + 1L * MB),
+      pool->reportExternalAllocation(static_cast<int64_t>(kMaxCap) + 1L * MB),
       "Exceeded memory pool capacity");
   ASSERT_EQ(pool->usedBytes(), 0);
   ASSERT_EQ(pool->reservedBytes(), 0);
@@ -498,10 +510,10 @@ TEST_P(MemoryPoolTest, reportExternalAllocationRejectsNonPositiveSize) {
   auto child =
       root->addLeafChild("reportExternalNonPositive", isLeafThreadSafe_);
 
-  VELOX_ASSERT_THROW(child->reportAllocation(0), "(0 vs. 0)");
-  VELOX_ASSERT_THROW(child->reportAllocation(-1), "(-1 vs. 0)");
-  VELOX_ASSERT_THROW(child->reportFree(0), "(0 vs. 0)");
-  VELOX_ASSERT_THROW(child->reportFree(-1), "(-1 vs. 0)");
+  VELOX_ASSERT_THROW(child->reportExternalAllocation(0), "(0 vs. 0)");
+  VELOX_ASSERT_THROW(child->reportExternalAllocation(-1), "(-1 vs. 0)");
+  VELOX_ASSERT_THROW(child->reportExternalFree(0), "(0 vs. 0)");
+  VELOX_ASSERT_THROW(child->reportExternalFree(-1), "(-1 vs. 0)");
   ASSERT_EQ(child->usedBytes(), 0);
   ASSERT_EQ(child->reservedBytes(), 0);
 }

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -443,6 +443,69 @@ TEST_P(MemoryPoolTest, usedBytes) {
   ASSERT_EQ(root->usedBytes(), 0);
 }
 
+TEST_P(MemoryPoolTest, reportExternalAllocation) {
+  auto manager = getMemoryManager();
+  auto root = manager->addRootPool();
+  auto child =
+      root->addLeafChild("reportExternalAllocation", isLeafThreadSafe_);
+
+  const int64_t kReportSize{1L * MB};
+  const auto initialStats = child->stats();
+  ASSERT_EQ(child->usedBytes(), 0);
+
+  // reportAllocation does not allocate memory but should account for it in
+  // usedBytes/reservedBytes and bump the Allocs stat.
+  child->reportAllocation(kReportSize);
+  ASSERT_EQ(child->usedBytes(), kReportSize);
+  ASSERT_GE(child->reservedBytes(), kReportSize);
+  ASSERT_EQ(child->stats().numAllocs, initialStats.numAllocs + 1);
+  ASSERT_EQ(child->stats().peakBytes, kReportSize);
+
+  // A paired reportFree of the same size returns the pool to its original
+  // bookkeeping state and bumps the Frees stat. peak stays at its max.
+  child->reportFree(kReportSize);
+  ASSERT_EQ(child->usedBytes(), 0);
+  ASSERT_EQ(child->reservedBytes(), 0);
+  ASSERT_EQ(child->stats().numFrees, initialStats.numFrees + 1);
+  ASSERT_EQ(child->stats().peakBytes, kReportSize);
+}
+
+TEST_P(MemoryPoolTest, reportExternalAllocationCapacityExceeded) {
+  const uint64_t kMaxCap = 128L * MB;
+  MemoryManager::Options options;
+  options.allocatorCapacity = kMaxCap;
+  options.arbitratorCapacity = kMaxCap;
+  options.extraArbitratorConfigs = {
+      {std::string(SharedArbitrator::ExtraConfig::kReservedCapacity),
+       folly::to<std::string>(kMaxCap / 2) + "B"}};
+  setupMemory(options);
+  auto manager = getMemoryManager();
+  auto root = manager->addRootPool("reportExternalCap", kMaxCap);
+  auto pool = root->addLeafChild("reportExternalCap", isLeafThreadSafe_);
+
+  // Reporting more than the pool's capacity must trip the same memory-cap
+  // path that allocate() does, leaving usage at zero.
+  VELOX_ASSERT_THROW(
+      pool->reportAllocation(static_cast<int64_t>(kMaxCap) + 1L * MB),
+      "Exceeded memory pool capacity");
+  ASSERT_EQ(pool->usedBytes(), 0);
+  ASSERT_EQ(pool->reservedBytes(), 0);
+}
+
+TEST_P(MemoryPoolTest, reportExternalAllocationRejectsNonPositiveSize) {
+  auto manager = getMemoryManager();
+  auto root = manager->addRootPool();
+  auto child =
+      root->addLeafChild("reportExternalNonPositive", isLeafThreadSafe_);
+
+  VELOX_ASSERT_THROW(child->reportAllocation(0), "(0 vs. 0)");
+  VELOX_ASSERT_THROW(child->reportAllocation(-1), "(-1 vs. 0)");
+  VELOX_ASSERT_THROW(child->reportFree(0), "(0 vs. 0)");
+  VELOX_ASSERT_THROW(child->reportFree(-1), "(-1 vs. 0)");
+  ASSERT_EQ(child->usedBytes(), 0);
+  ASSERT_EQ(child->reservedBytes(), 0);
+}
+
 TEST_P(MemoryPoolTest, DISABLED_memoryLeakCheck) {
   gflags::FlagSaver flagSaver;
   testing::FLAGS_gtest_death_test_style = "fast";

--- a/velox/dwio/dwrf/test/WriterFlushTest.cpp
+++ b/velox/dwio/dwrf/test/WriterFlushTest.cpp
@@ -40,7 +40,12 @@ class MockMemoryPool : public velox::memory::MemoryPool {
       MemoryPool::Kind kind,
       std::shared_ptr<MemoryPool> parent,
       int64_t cap = std::numeric_limits<int64_t>::max())
-      : MemoryPool{name, kind, parent, {.alignment = velox::memory::MemoryAllocator::kMinAlignment, .maxCapacity = cap}},
+      : MemoryPool{
+            name,
+            kind,
+            parent,
+            {.alignment = velox::memory::MemoryAllocator::kMinAlignment,
+             .maxCapacity = cap}},
         capacity_(cap) {}
 
   ~MockMemoryPool() override {
@@ -100,6 +105,10 @@ class MockMemoryPool : public velox::memory::MemoryPool {
     return allocator_->allocateBytes(size);
   }
 
+  void reportAllocation(int64_t size) override {
+    updateLocalMemoryUsage(size);
+  }
+
   void* allocateZeroFilled(int64_t numEntries, int64_t sizeEach) override {
     updateLocalMemoryUsage(numEntries * sizeEach);
     return allocator_->allocateZeroFilled(numEntries * sizeEach);
@@ -116,6 +125,10 @@ class MockMemoryPool : public velox::memory::MemoryPool {
 
   void free(void* p, int64_t size) override {
     allocator_->freeBytes(p, size);
+    updateLocalMemoryUsage(-size);
+  }
+
+  void reportFree(int64_t size) override {
     updateLocalMemoryUsage(-size);
   }
 

--- a/velox/dwio/dwrf/test/WriterFlushTest.cpp
+++ b/velox/dwio/dwrf/test/WriterFlushTest.cpp
@@ -40,12 +40,7 @@ class MockMemoryPool : public velox::memory::MemoryPool {
       MemoryPool::Kind kind,
       std::shared_ptr<MemoryPool> parent,
       int64_t cap = std::numeric_limits<int64_t>::max())
-      : MemoryPool{
-            name,
-            kind,
-            parent,
-            {.alignment = velox::memory::MemoryAllocator::kMinAlignment,
-             .maxCapacity = cap}},
+      : MemoryPool{name, kind, parent, {.alignment = velox::memory::MemoryAllocator::kMinAlignment, .maxCapacity = cap}},
         capacity_(cap) {}
 
   ~MockMemoryPool() override {
@@ -105,7 +100,7 @@ class MockMemoryPool : public velox::memory::MemoryPool {
     return allocator_->allocateBytes(size);
   }
 
-  void reportAllocation(int64_t size) override {
+  void reportExternalAllocation(int64_t size) override {
     updateLocalMemoryUsage(size);
   }
 
@@ -128,7 +123,7 @@ class MockMemoryPool : public velox::memory::MemoryPool {
     updateLocalMemoryUsage(-size);
   }
 
-  void reportFree(int64_t size) override {
+  void reportExternalFree(int64_t size) override {
     updateLocalMemoryUsage(-size);
   }
 


### PR DESCRIPTION
## Summary

Split out from #17467 at reviewer request, so the `MemoryPool` API addition
can be reviewed independently from its first consumer (Parquet Thrift footer
memory tracking).

## Problem

Some objects in Velox hold heap memory that was allocated outside the pool —
the most prominent example is the deserialized Thrift `FileMetaData` in the
Parquet reader, which can grow to hundreds of MBs for files with very wide
schemas or many row groups. Today there is no way to account for that
memory against the owning pool, so the bytes are invisible to the memory
arbitrator and queries can OOM the worker without ever crossing the pool's
reservation limit.

## Changes

- `MemoryPool::reportAllocation(int64_t)` and `MemoryPool::reportFree(int64_t)`
  pure virtuals. Callers report external bytes when they take ownership and
  release them in the matching destructor. Every `reportAllocation` must be
  paired with a `reportFree` of the same size.
- `MemoryPoolImpl` implements both as thin wrappers around `reserve()` /
  `release()`, aligning the size the same way `allocate()` / `free()` does and
  reusing `CHECK_AND_INC_MEM_OP_STATS` so external allocations show up in the
  Allocs/Frees op stats.
- `TestMemoryPool` (StatsReporterTest) gets no-op overrides; `MockMemoryPool`
  (WriterFlushTest) updates its local usage counter so existing tests keep
  working.

## Consumer

#17467 is the first consumer — once that PR rebases on top of this one, only
the Parquet-specific bits remain in it.

## Test plan

- [ ] Existing `velox/common/memory/tests` and `velox/dwio/dwrf/test/WriterFlushTest` continue to pass.
- [ ] CI green on Linux and macOS.