### PR TITLE
feat: Add runtime stat measuring number of passthrough rows for abandoned partial aggregation

### DIFF
--- a/velox/docs/develop/aggregations.rst
+++ b/velox/docs/develop/aggregations.rst
@@ -364,5 +364,6 @@ accumulators.
 Many aggregate functions implement toIntermediate() fast path. Some examples include:
 :func:`min`, :func:`max`, :func:`array_agg`, :func:`set_agg`, :func:`map_agg`, :func:`map_union`.
 
-One can use runtime statistic `abandonedPartialAggregation` to tell whether
-partial aggregation was abandoned.
+Runtime statistic `abandonedPartialAggregationRows` counts rows that bypassed
+partial aggregation after it was abandoned. A value greater than 0 indicates
+that partial aggregation was abandoned.

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -302,9 +302,6 @@ void HashAggregation::maybeIncreasePartialAggregationMemoryUsage(
            maxExtendedPartialAggregationMemoryUsage_)) {
     groupingSet_->abandonPartialAggregation();
     pool()->release();
-    addRuntimeStat(
-        std::string(HashAggregation::kAbandonedPartialAggregation),
-        RuntimeCounter(1));
     abandonedPartialAggregation_ = true;
     return;
   }
@@ -344,8 +341,7 @@ RowVectorPtr HashAggregation::getOutput() {
     prepareOutput(input_->size());
     groupingSet_->toIntermediate(input_, output_);
     addRuntimeStat(
-        std::string(
-            HashAggregation::kAbandonedPartialAggregationPassthroughRowCount),
+        std::string(HashAggregation::kAbandonedPartialAggregationRows),
         RuntimeCounter(input_->size()));
     numOutputRows_ += input_->size();
     input_ = nullptr;

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -343,6 +343,10 @@ RowVectorPtr HashAggregation::getOutput() {
     }
     prepareOutput(input_->size());
     groupingSet_->toIntermediate(input_, output_);
+    addRuntimeStat(
+        std::string(
+            HashAggregation::kAbandonedPartialAggregationPassthroughRowCount),
+        RuntimeCounter(input_->size()));
     numOutputRows_ += input_->size();
     input_ = nullptr;
     return output_;

--- a/velox/exec/HashAggregation.h
+++ b/velox/exec/HashAggregation.h
@@ -35,6 +35,10 @@ class HashAggregation : public Operator {
   /// Whether partial aggregation was abandoned due to insufficient reduction.
   static constexpr std::string_view kAbandonedPartialAggregation =
       "abandonedPartialAggregation";
+  /// Number of rows emitted after partial aggregation was abandoned.
+  static constexpr std::string_view
+      kAbandonedPartialAggregationPassthroughRowCount =
+          "abandonedPartialAggregationPassthroughRowCount";
 
   HashAggregation(
       int32_t operatorId,

--- a/velox/exec/HashAggregation.h
+++ b/velox/exec/HashAggregation.h
@@ -32,13 +32,9 @@ class HashAggregation : public Operator {
   /// Ratio of output to input rows in partial aggregation as a percentage.
   static constexpr std::string_view kPartialAggregationPct =
       "partialAggregationPct";
-  /// Whether partial aggregation was abandoned due to insufficient reduction.
-  static constexpr std::string_view kAbandonedPartialAggregation =
-      "abandonedPartialAggregation";
   /// Number of rows emitted after partial aggregation was abandoned.
-  static constexpr std::string_view
-      kAbandonedPartialAggregationPassthroughRowCount =
-          "abandonedPartialAggregationPassthroughRowCount";
+  static constexpr std::string_view kAbandonedPartialAggregationRows =
+      "abandonedPartialAggregationRows";
 
   HashAggregation(
       int32_t operatorId,

--- a/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
+++ b/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
@@ -1039,16 +1039,10 @@ void AggregationTestBase::testAggregationsImpl(
     auto partialStats = taskStats.at(partialNodeId).customStats;
     auto intermediateStats = taskStats.at(intermediateNodeId).customStats;
     if (inputVectors > 1) {
-      EXPECT_LT(0, partialStats.at("abandonedPartialAggregation").count);
       EXPECT_LT(
-          0,
-          partialStats.at("abandonedPartialAggregationPassthroughRowCount")
-              .sum);
-      EXPECT_LT(0, intermediateStats.at("abandonedPartialAggregation").count);
+          0, partialStats.at("abandonedPartialAggregationRows").sum);
       EXPECT_LT(
-          0,
-          intermediateStats.at("abandonedPartialAggregationPassthroughRowCount")
-              .sum);
+          0, intermediateStats.at("abandonedPartialAggregationRows").sum);
     }
   }
 

--- a/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
+++ b/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
@@ -1039,10 +1039,8 @@ void AggregationTestBase::testAggregationsImpl(
     auto partialStats = taskStats.at(partialNodeId).customStats;
     auto intermediateStats = taskStats.at(intermediateNodeId).customStats;
     if (inputVectors > 1) {
-      EXPECT_LT(
-          0, partialStats.at("abandonedPartialAggregationRows").sum);
-      EXPECT_LT(
-          0, intermediateStats.at("abandonedPartialAggregationRows").sum);
+      EXPECT_LT(0, partialStats.at("abandonedPartialAggregationRows").sum);
+      EXPECT_LT(0, intermediateStats.at("abandonedPartialAggregationRows").sum);
     }
   }
 

--- a/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
+++ b/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
@@ -1040,7 +1040,15 @@ void AggregationTestBase::testAggregationsImpl(
     auto intermediateStats = taskStats.at(intermediateNodeId).customStats;
     if (inputVectors > 1) {
       EXPECT_LT(0, partialStats.at("abandonedPartialAggregation").count);
+      EXPECT_LT(
+          0,
+          partialStats.at("abandonedPartialAggregationPassthroughRowCount")
+              .sum);
       EXPECT_LT(0, intermediateStats.at("abandonedPartialAggregation").count);
+      EXPECT_LT(
+          0,
+          intermediateStats.at("abandonedPartialAggregationPassthroughRowCount")
+              .sum);
     }
   }
 

--- a/velox/functions/prestosql/aggregates/tests/CountAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/CountAggregationTest.cpp
@@ -150,9 +150,7 @@ TEST_F(CountAggregationTest, mask) {
               "SELECT k, count(c) FILTER (where m) FROM tmp GROUP BY k");
   auto taskStats = toPlanStats(task->taskStats());
   auto partialStats = taskStats.at(partialNodeId).customStats;
-  EXPECT_LT(0, partialStats.at("abandonedPartialAggregation").count);
-  EXPECT_LT(
-      0, partialStats.at("abandonedPartialAggregationPassthroughRowCount").sum);
+  EXPECT_LT(0, partialStats.at("abandonedPartialAggregationRows").sum);
 }
 
 TEST_F(CountAggregationTest, distinct) {

--- a/velox/functions/prestosql/aggregates/tests/CountAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/CountAggregationTest.cpp
@@ -151,6 +151,8 @@ TEST_F(CountAggregationTest, mask) {
   auto taskStats = toPlanStats(task->taskStats());
   auto partialStats = taskStats.at(partialNodeId).customStats;
   EXPECT_LT(0, partialStats.at("abandonedPartialAggregation").count);
+  EXPECT_LT(
+      0, partialStats.at("abandonedPartialAggregationPassthroughRowCount").sum);
 }
 
 TEST_F(CountAggregationTest, distinct) {


### PR DESCRIPTION
The patch replaces the existing boolean stat `kAbandonedPartialAggregation` with a new integer stat `kAbandonedPartialAggregationRows`, in the HashAggregation operator so users can measure how many rows passed through after partial aggregation was abandoned. This makes performance analysis of partial hash aggregation easier.