### PR TITLE
fix: Update row lineage handling for Iceberg V3 spec compliance

### DIFF
--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -565,11 +565,8 @@ uint64_t IcebergSplitReader::next(uint64_t size, VectorPtr& output) {
     VELOX_DCHECK_NOT_NULL(
         rowOutput, "Expected RowVector output from table scan");
 
-    // If lastUpdatedSeqNumOutputIndex_ is present but dataSequenceNumber_ is
-    // not, the output is a constant NULL value vector already populated by the
-    // reader via adaptColumns.
-    if (lastUpdatedSeqNumOutputIndex_.has_value() &&
-        dataSequenceNumber_.has_value()) {
+    if (lastUpdatedSeqNumOutputIndex_.has_value()) {
+      VELOX_DCHECK(dataSequenceNumber_.has_value());
       auto& seqNumChild = rowOutput->childAt(*lastUpdatedSeqNumOutputIndex_);
       const int64_t seqNum = static_cast<int64_t>(*dataSequenceNumber_);
       fillNullsWithInt64(
@@ -709,6 +706,16 @@ std::vector<TypePtr> IcebergSplitReader::adaptColumns(
           // try to bind this output channel to a file read.
           continue;
         }
+        if (!firstRowId_.has_value() &&
+            (fieldName == IcebergMetadataColumn::kRowIdColumnName ||
+             fieldName ==
+                 IcebergMetadataColumn::kLastUpdatedSequenceNumberColumnName)) {
+          // Null first_row_id: spec requires null for both lineage columns.
+          childSpec->setConstantValue(
+              BaseVector::createNullConstant(
+                  BIGINT(), 1, connectorQueryCtx_->memoryPool()));
+          continue;
+        }
         childSpec->setConstantValue(nullptr);
         auto& outputType = readerOutputType_->childAt(*outputTypeIdx);
         columnTypes[*fileTypeIdx] = outputType;
@@ -734,9 +741,8 @@ std::vector<TypePtr> IcebergSplitReader::adaptColumns(
         //    partition value as a constant, so this branch leaves it alone.
         if (fieldName ==
             IcebergMetadataColumn::kLastUpdatedSequenceNumberColumnName) {
-          // Column is absent from the data file. Per the Iceberg V3 spec, when
-          // a data file has a null first_row_id, readers must produce null for
-          // both _row_id and _last_updated_sequence_number.
+          // Column absent from file. Use data_sequence_number constant when
+          // first_row_id is present; null otherwise (spec requirement).
           if (dataSequenceNumber_.has_value() && firstRowId_.has_value()) {
             childSpec->setConstantValue(
                 std::make_shared<ConstantVector<int64_t>>(
@@ -751,12 +757,14 @@ std::vector<TypePtr> IcebergSplitReader::adaptColumns(
                     BIGINT(), 1, connectorQueryCtx_->memoryPool()));
           }
         } else if (fieldName == IcebergMetadataColumn::kRowIdColumnName) {
+          // Column absent from file. next() fills nulls with first_row_id +
+          // _pos when first_row_id is present.
           childSpec->setConstantValue(
               BaseVector::createNullConstant(
                   BIGINT(), 1, connectorQueryCtx_->memoryPool()));
         } else if (childSpec->isConstant()) {
-          // Constant already set (case 6, or set on a previous prepareSplit
-          // call for the same scanSpec). Nothing to do.
+          // Constant already set (equality-delete partition column, or set on
+          // a previous prepareSplit call for the same scanSpec). Nothing to do.
           continue;
         } else if (auto partitionIt = fileSplit_->partitionKeys.find(fieldName);
                    partitionIt != fileSplit_->partitionKeys.end()) {

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -209,7 +209,7 @@ void IcebergSplitReader::prepareSplit(
   auto rowType = getAdaptedRowType();
 
   lastUpdatedSeqNumOutputIndex_ = std::nullopt;
-  if (dataSequenceNumber_.has_value()) {
+  if (dataSequenceNumber_.has_value() && firstRowId_.has_value()) {
     auto* seqNumSpec = scanSpec_->childByName(
         IcebergMetadataColumn::kLastUpdatedSequenceNumberColumnName);
     if (seqNumSpec && !seqNumSpec->isConstant()) {
@@ -734,11 +734,10 @@ std::vector<TypePtr> IcebergSplitReader::adaptColumns(
         //    partition value as a constant, so this branch leaves it alone.
         if (fieldName ==
             IcebergMetadataColumn::kLastUpdatedSequenceNumberColumnName) {
-          // Column is absent from the data file. If a data sequence number is
-          // available (V3 snapshot), set a constant so every row inherits it.
-          // Otherwise (pre-V3 snapshot where the sequence number chain is
-          // unassigned), return null — analogous to the _row_id null path.
-          if (dataSequenceNumber_.has_value()) {
+          // Column is absent from the data file. Per the Iceberg V3 spec, when
+          // a data file has a null first_row_id, readers must produce null for
+          // both _row_id and _last_updated_sequence_number.
+          if (dataSequenceNumber_.has_value() && firstRowId_.has_value()) {
             childSpec->setConstantValue(
                 std::make_shared<ConstantVector<int64_t>>(
                     connectorQueryCtx_->memoryPool(),

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.h
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.h
@@ -97,17 +97,21 @@ class IcebergSplitReader : public FileSplitReader {
   ///       written. Set as NULL constant since the old file doesn't contain
   ///       this column.
   ///    c) Row lineage (_last_updated_sequence_number):
-  ///       Per the Iceberg V3 spec, when a data file has a null first_row_id,
-  ///       readers must produce null for both _row_id and
-  ///       _last_updated_sequence_number. If the column is not in the file and
-  ///       $first_row_id is present, inherit the data sequence number from the
-  ///       manifest entry ($data_sequence_number info column).
+  ///       Per the Iceberg V3 spec, when first_row_id is absent, readers must
+  ///       produce null for both _row_id and _last_updated_sequence_number.
+  ///       This applies whether or not the columns are physically present in
+  ///       the file. When first_row_id is present and the column is absent
+  ///       from the file, inherit the data sequence number from the manifest
+  ///       entry ($data_sequence_number info column). When the column is
+  ///       physically present and first_row_id is present, use the stored
+  ///       value (null slots are filled from $data_sequence_number in next()).
   ///    d) Row lineage (_row_id):
-  ///       Per the spec, null _row_id values are assigned as
-  ///       first_row_id + file position. When first_row_id is available from
-  ///       the split info column $first_row_id, the value is computed
-  ///       in next(). When first_row_id is not available (e.g.,
-  ///       pre-V3 tables), NULL is returned.
+  ///       Per the spec, when first_row_id is absent, produce null regardless
+  ///       of physical storage. When first_row_id is present and the column
+  ///       is absent from the file, null is installed here and next() replaces
+  ///       it with first_row_id + file position. When the column is physically
+  ///       present, null slots are filled from first_row_id + file position in
+  ///       next(); non-null slots are preserved.
   std::vector<TypePtr> adaptColumns(
       const RowTypePtr& fileType,
       const RowTypePtr& tableSchema) const override;

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.h
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.h
@@ -97,10 +97,11 @@ class IcebergSplitReader : public FileSplitReader {
   ///       written. Set as NULL constant since the old file doesn't contain
   ///       this column.
   ///    c) Row lineage (_last_updated_sequence_number):
-  ///       For Iceberg V3 row lineage, if the column is not in the file,
-  ///       inherit the data sequence number from the file's manifest entry
-  ///       (provided via $data_sequence_number info column). Per the spec,
-  ///       null values indicate the value should be inherited.
+  ///       Per the Iceberg V3 spec, when a data file has a null first_row_id,
+  ///       readers must produce null for both _row_id and
+  ///       _last_updated_sequence_number. If the column is not in the file and
+  ///       $first_row_id is present, inherit the data sequence number from the
+  ///       manifest entry ($data_sequence_number info column).
   ///    d) Row lineage (_row_id):
   ///       Per the spec, null _row_id values are assigned as
   ///       first_row_id + file position. When first_row_id is available from

--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -1539,6 +1539,9 @@ TEST_F(HiveIcebergTest, skipDeleteFileByPositionUpperBound) {
 //   indices.
 //   9. data_sequence_number without first_row_id: both _row_id and
 //      _last_updated_sequence_number are null.
+//  10. Physical lineage columns present with data_sequence_number but no
+//      first_row_id: both columns are null (spec requires null when
+//      first_row_id is absent, regardless of physical storage).
 TEST_F(HiveIcebergTest, rowLineage) {
   folly::SingletonVault::singleton()->registrationComplete();
 
@@ -1680,6 +1683,26 @@ TEST_F(HiveIcebergTest, rowLineage) {
           kOutputNames,
           {
               makeFlatVector<int64_t>({1, 2, 3}),
+              makeNullableFlatVector<int64_t>(
+                  {std::nullopt, std::nullopt, std::nullopt}),
+              makeNullableFlatVector<int64_t>(
+                  {std::nullopt, std::nullopt, std::nullopt}),
+          })},
+  });
+
+  // 10. Physical lineage columns present, data_sequence_number set,
+  // first_row_id absent. Per spec, first_row_id absent means null for both
+  // _row_id and _last_updated_sequence_number regardless of what is
+  // physically stored in the file.
+  assertRowLineage({
+      .values = {10, 20, 30},
+      .storedRowIds = {{500, 501, 502}},
+      .storedSequenceNumbers = {{3, 5, 3}},
+      .dataSequenceNumber = 7,
+      .expectedVectors = {makeRowVector(
+          kOutputNames,
+          {
+              makeFlatVector<int64_t>({10, 20, 30}),
               makeNullableFlatVector<int64_t>(
                   {std::nullopt, std::nullopt, std::nullopt}),
               makeNullableFlatVector<int64_t>(

--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -1537,6 +1537,8 @@ TEST_F(HiveIcebergTest, skipDeleteFileByPositionUpperBound) {
 //   7. Positional deletes: _row_id uses file-absolute positions.
 //   8. Subfield filter: _row_id uses file-absolute positions, not output
 //   indices.
+//   9. data_sequence_number without first_row_id: both _row_id and
+//      _last_updated_sequence_number are null.
 TEST_F(HiveIcebergTest, rowLineage) {
   folly::SingletonVault::singleton()->registrationComplete();
 
@@ -1666,6 +1668,22 @@ TEST_F(HiveIcebergTest, rowLineage) {
               makeFlatVector<int64_t>({30, 40, 50}),
               makeFlatVector<int64_t>({102, 103, 104}),
               makeFlatVector<int64_t>({15, 15, 15}),
+          })},
+  });
+
+  // 9. data_sequence_number without first_row_id: _last_updated_sequence_number
+  // must be null because _row_id is null (no first_row_id to anchor it).
+  assertRowLineage({
+      .values = {1, 2, 3},
+      .dataSequenceNumber = 7,
+      .expectedVectors = {makeRowVector(
+          kOutputNames,
+          {
+              makeFlatVector<int64_t>({1, 2, 3}),
+              makeNullableFlatVector<int64_t>(
+                  {std::nullopt, std::nullopt, std::nullopt}),
+              makeNullableFlatVector<int64_t>(
+                  {std::nullopt, std::nullopt, std::nullopt}),
           })},
   });
 }


### PR DESCRIPTION
The last sequence number was being populated in Iceberg V2 tables in violation of the iceberg specification. This was discovered during end-to-end tests in https://github.com/prestodb/presto/pull/27743.