### PR TITLE
feat: Log selected flat map feature names in keySelectionCallback

### DIFF
--- a/velox/dwio/common/FlatMapHelper.h
+++ b/velox/dwio/common/FlatMapHelper.h
@@ -52,10 +52,18 @@ enum class FlatMapOutput : uint8_t {
 };
 
 // Struct for keeping track flatmap key stream metrics.
-// Used by keySelectionCallback_ in FlatMapColumnReader
+// Used by keySelectionCallback_ in FlatMapColumnReader.
+//
+// 'columnName' and 'selectedFeatureNames' are optional and may be populated
+// by readers that have access to the flat map's column name and the names of
+// the features it actually projected (in the caller-specified order). They
+// can be consumed by logging infrastructure to inform write-time feature
+// reordering configurations.
 struct FlatMapKeySelectionStats {
   uint64_t totalKeys = 0;
   uint64_t selectedKeys = 0;
+  std::string columnName;
+  std::vector<std::string> selectedFeatureNames;
 };
 
 // Initialize flat vector


### PR DESCRIPTION
Summary:
Extends `FlatMapKeySelectionStats` with two optional fields
(`columnName` and `selectedFeatureNames`) and populates them from the
Nimble `FieldReaderFactory::create()` path when invoking the existing
`keySelectionCallback`. This gives callback consumers (e.g. Scuba/ODS
loggers) the information needed to inform write-time flat map feature
reordering configurations (`VeloxWriterOptions::featureReordering` /
`FeatureReorderingLayoutPlanner`).

Existing callers that only read `totalKeys`/`selectedKeys` are
unaffected — the new fields default-initialize and existing designated
initializers continue to compile.

Differential Revision: D105609449


