### PR TITLE
feat: Allow subfield rename and deletion for ORC format

### DIFF
--- a/velox/connectors/hive/HiveSplitReader.cpp
+++ b/velox/connectors/hive/HiveSplitReader.cpp
@@ -143,12 +143,26 @@ std::vector<TypePtr> HiveSplitReader::adaptColumns(
         childSpec->columnType() == common::ScanSpec::ColumnType::kRegular) {
       auto fileTypeIdx = fileType->getChildIdxIfExists(fieldName);
       if (!fileTypeIdx.has_value()) {
-        VELOX_CHECK(tableSchema, "Unable to resolve column '{}'", fieldName);
+        auto outputTypeIdx = readerOutputType_->getChildIdxIfExists(fieldName);
+        TypePtr fieldType;
+        if (outputTypeIdx.has_value()) {
+          // Field name exists in the user-specified output type.
+          fieldType = readerOutputType_->childAt(outputTypeIdx.value());
+        } else {
+          VELOX_CHECK_NOT_NULL(
+              tableSchema,
+              "Unable to resolve column '{}': table schema is null.",
+              fieldName);
+          auto fieldTypeIdx = tableSchema->getChildIdxIfExists(fieldName);
+          VELOX_CHECK(
+              fieldTypeIdx.has_value(),
+              "Unable to resolve column '{}': column not found in table schema.",
+              fieldName);
+          fieldType = tableSchema->childAt(fieldTypeIdx.value());
+        }
         childSpec->setConstantValue(
             BaseVector::createNullConstant(
-                tableSchema->findChild(fieldName),
-                1,
-                connectorQueryCtx_->memoryPool()));
+                fieldType, 1, connectorQueryCtx_->memoryPool()));
       } else {
         childSpec->setConstantValue(nullptr);
         auto outputTypeIdx = readerOutputType_->getChildIdxIfExists(fieldName);

--- a/velox/dwio/common/SelectiveFlatMapColumnReader.h
+++ b/velox/dwio/common/SelectiveFlatMapColumnReader.h
@@ -24,11 +24,13 @@ namespace facebook::velox::dwio::common {
 class SelectiveFlatMapColumnReader : public SelectiveStructColumnReaderBase {
  protected:
   SelectiveFlatMapColumnReader(
+      const dwio::common::ColumnReaderOptions& columnReaderOptions,
       const TypePtr& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       FormatParams& params,
       velox::common::ScanSpec& scanSpec)
       : SelectiveStructColumnReaderBase(
+            columnReaderOptions,
             requestedType,
             fileType,
             params,

--- a/velox/dwio/common/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/common/SelectiveStructColumnReader.cpp
@@ -425,7 +425,11 @@ void SelectiveStructColumnReaderBase::read(
   }
 
   const auto& childSpecs = scanSpec_->children();
-  VELOX_CHECK(!childSpecs.empty());
+  // When using name-based mapping, empty child specs are valid
+  // (e.g., when all struct fields are renamed/deleted).
+  if (columnReaderOptions_.columnMappingMode_ != ColumnMappingMode::kName) {
+    VELOX_CHECK(!childSpecs.empty());
+  }
   for (size_t i = 0; i < childSpecs.size(); ++i) {
     const auto& childSpec = childSpecs[i];
 
@@ -524,9 +528,15 @@ bool SelectiveStructColumnReaderBase::isChildMissing(
                                                   // row type that doesn't exist
                                                   // in the output.
        fileType_->type()->kind() !=
-           TypeKind::MAP && // If this is the case it means this is a flat map,
-                            // so it can't have "missing" fields.
-       childSpec.channel() >= fileType_->size());
+           TypeKind::MAP // If this is the case it means this is a flat map,
+                         // so it can't have "missing" fields.
+       ) &&
+      // Name-based missing-field check applies only to row types, not flat
+      // maps.
+      ((fileType_->type()->isRow() &&
+        columnReaderOptions_.columnMappingMode_ == ColumnMappingMode::kName)
+           ? !asRowType(fileType_->type())->containsChild(childSpec.fieldName())
+           : childSpec.channel() >= fileType_->size());
 }
 
 std::unique_ptr<velox::dwio::common::ColumnLoader>
@@ -548,7 +558,10 @@ SelectiveStructColumnReaderBase::makeColumnLoader(vector_size_t index) {
 void SelectiveStructColumnReaderBase::getValues(
     const RowSet& rows,
     VectorPtr* result) {
-  VELOX_CHECK(!scanSpec_->children().empty());
+  // See comment in read().
+  if (columnReaderOptions_.columnMappingMode_ != ColumnMappingMode::kName) {
+    VELOX_CHECK(!scanSpec_->children().empty());
+  }
   VELOX_CHECK_NOT_NULL(
       *result, "SelectiveStructColumnReaderBase expects a non-null result");
 

--- a/velox/dwio/common/SelectiveStructColumnReader.h
+++ b/velox/dwio/common/SelectiveStructColumnReader.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "velox/dwio/common/Options.h"
 #include "velox/dwio/common/SelectiveColumnReaderInternal.h"
 
 namespace facebook::velox::dwio::common {
@@ -113,6 +114,7 @@ class SelectiveStructColumnReaderBase : public SelectiveColumnReader {
   static constexpr int32_t kConstantChildSpecSubscript{-1};
 
   SelectiveStructColumnReaderBase(
+      const dwio::common::ColumnReaderOptions& columnReaderOptions,
       const TypePtr& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       FormatParams& params,
@@ -120,6 +122,7 @@ class SelectiveStructColumnReaderBase : public SelectiveColumnReader {
       bool isRoot = false,
       bool generateLazyChildren = true)
       : SelectiveColumnReader(requestedType, fileType, params, scanSpec),
+        columnReaderOptions_(columnReaderOptions),
         debugString_(
             getExceptionContext().message(VeloxException::Type::kSystem)),
         isRoot_(isRoot),
@@ -179,6 +182,8 @@ class SelectiveStructColumnReaderBase : public SelectiveColumnReader {
       setOutputRows(rows);
     }
   }
+
+  dwio::common::ColumnReaderOptions columnReaderOptions_;
 
   // Context information obtained from ExceptionContext. Stored here
   // so that LazyVector readers under this can add this to their

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -331,13 +331,15 @@ DwrfRowReader::DwrfRowReader(
     makeProjectedNodes(*getReader().schemaWithId(), *projectedNodes_);
   }
 
+  // Configure reader options before calling 'getUnitLoader()'.
+  // Construction is single-threaded, and the unit loader is created only
+  // after 'columnReaderOptions_' has been initialized.
+  columnReaderOptions_ = dwio::common::makeColumnReaderOptions(
+      readerBaseShared()->readerOptions());
   unitLoader_ = getUnitLoader();
   if (!emptyFile()) {
     getReader().loadCache();
   }
-
-  columnReaderOptions_ = dwio::common::makeColumnReaderOptions(
-      readerBaseShared()->readerOptions());
 }
 
 std::unique_ptr<ColumnReader>& DwrfRowReader::getColumnReader() {

--- a/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
@@ -202,6 +202,7 @@ class SelectiveFlatMapAsStructReader : public SelectiveStructColumnReaderBase {
       DwrfParams& params,
       common::ScanSpec& scanSpec)
       : SelectiveStructColumnReaderBase(
+            columnReaderOptions,
             requestedType,
             fileType,
             params,
@@ -241,6 +242,7 @@ class SelectiveFlatMapAsMapReader : public SelectiveStructColumnReaderBase {
       DwrfParams& params,
       common::ScanSpec& scanSpec)
       : SelectiveStructColumnReaderBase(
+            columnReaderOptions,
             requestedType,
             fileType,
             params,
@@ -285,6 +287,7 @@ class SelectiveFlatMapReader
       DwrfParams& params,
       common::ScanSpec& scanSpec)
       : dwio::common::SelectiveFlatMapColumnReader(
+            columnReaderOptions,
             requestedType,
             fileType,
             params,

--- a/velox/dwio/dwrf/reader/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStructColumnReader.cpp
@@ -31,6 +31,7 @@ SelectiveStructColumnReader::SelectiveStructColumnReader(
     common::ScanSpec& scanSpec,
     bool isRoot)
     : SelectiveStructColumnReaderBase(
+          columnReaderOptions,
           requestedType,
           fileType,
           params,

--- a/velox/dwio/dwrf/reader/SelectiveStructColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveStructColumnReader.h
@@ -25,6 +25,7 @@ class SelectiveStructColumnReaderBase
     : public dwio::common::SelectiveStructColumnReaderBase {
  public:
   SelectiveStructColumnReaderBase(
+      const dwio::common::ColumnReaderOptions& columnReaderOptions,
       const TypePtr& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       DwrfParams& params,
@@ -32,6 +33,7 @@ class SelectiveStructColumnReaderBase
       bool isRoot = false,
       bool generateLazyChildren = true)
       : dwio::common::SelectiveStructColumnReaderBase(
+            columnReaderOptions,
             requestedType,
             fileType,
             params,

--- a/velox/dwio/parquet/reader/StructColumnReader.cpp
+++ b/velox/dwio/parquet/reader/StructColumnReader.cpp
@@ -32,7 +32,12 @@ StructColumnReader::StructColumnReader(
     const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
     ParquetParams& params,
     common::ScanSpec& scanSpec)
-    : SelectiveStructColumnReader(requestedType, fileType, params, scanSpec) {
+    : SelectiveStructColumnReader(
+          columnReaderOptions,
+          requestedType,
+          fileType,
+          params,
+          scanSpec) {
   auto& childSpecs = scanSpec_->stableChildren();
   for (auto i = 0; i < childSpecs.size(); ++i) {
     auto childSpec = childSpecs[i];

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -1233,6 +1233,200 @@ TEST_F(TableScanTest, missingColumnsInRepeatedColumns) {
       .assertResults(expected);
 }
 
+// Verifies struct field resolution by name, including missing, renamed,
+// case-variant, and nested fields, plus filter pushdown on unresolved paths.
+TEST_F(TableScanTest, structMatchByName) {
+  const auto assertSelectUseColumnNames =
+      [this](
+          const RowTypePtr& outputType,
+          const std::string& sql,
+          const std::string& filePath,
+          const std::string& remainingFilter = "") {
+        const auto plan =
+            PlanBuilder().tableScan(outputType, {}, remainingFilter).planNode();
+        AssertQueryBuilder(plan, duckDbQueryRunner_)
+            .connectorSessionProperty(
+                kHiveConnectorId,
+                connector::hive::HiveConfig::kOrcUseColumnNamesSession,
+                "true")
+            .split(makeHiveConnectorSplit(filePath))
+            .assertResults(sql);
+      };
+  const auto id = makeFlatVector<int64_t>({2, 4, 6, 8, 10});
+  const std::vector<VectorPtr> names = {
+      makeFlatVector<std::string>({
+          "Janet",
+          "Bob",
+          "Alice",
+          "Carol",
+          "David",
+      }),
+      makeFlatVector<std::string>({
+          "Jones",
+          "Brown",
+          "White",
+          "Green",
+          "Black",
+      }),
+  };
+  const auto address = makeFlatVector<std::string>({
+      "567 Maple Drive",
+      "1 Oak St",
+      "9 Pine Rd",
+      "22 Cedar Ave",
+      "77 Birch Blvd",
+  });
+
+  {
+    const auto name = makeRowVector({"first", "last"}, names);
+    const auto vector =
+        makeRowVector({"id", "name", "address"}, {id, name, address});
+
+    const auto file = TempFilePath::create();
+    writeToFile(file->getPath(), {vector});
+    createDuckDbTable({vector});
+
+    assertSelectUseColumnNames(
+        asRowType(vector->type()),
+        "SELECT id, name, address from tmp",
+        file->getPath());
+
+    const auto assertMissingFieldFilter =
+        [&](const RowTypePtr& outputType,
+            const std::string& projectionSql,
+            const std::string& missingFieldFilter) {
+          assertSelectUseColumnNames(
+              outputType, projectionSql, file->getPath());
+          assertSelectUseColumnNames(
+              outputType,
+              "SELECT * from tmp where false",
+              file->getPath(),
+              missingFieldFilter);
+        };
+
+    // Add one non-existing subfield 'middle' to the 'name' field and rename
+    // field 'address'.
+    {
+      const auto rowType = ROW(
+          {"id", "name", "email"},
+          {BIGINT(),
+           ROW({"first", "middle", "last"}, {VARCHAR(), VARCHAR(), VARCHAR()}),
+           VARCHAR()});
+      assertMissingFieldFilter(
+          rowType,
+          "SELECT id, row(name.first, null, name.last), null FROM tmp",
+          "not(is_null(name.middle))");
+    }
+
+    // Rename subfields of the 'name' field.
+    {
+      const auto rowType =
+          ROW({"id", "name", "address"},
+              {BIGINT(), ROW({"a", "b"}, {VARCHAR(), VARCHAR()}), VARCHAR()});
+      assertMissingFieldFilter(
+          rowType,
+          "SELECT id, row(null, null), address FROM tmp",
+          "not(is_null(name.a))");
+    }
+
+    // Deletion of one subfield from the 'name' field.
+    {
+      const auto rowType =
+          ROW({"id", "name", "address"},
+              {BIGINT(), ROW({"full"}, {VARCHAR()}), VARCHAR()});
+      assertMissingFieldFilter(
+          rowType,
+          "SELECT id, row(null), address FROM tmp",
+          "not(is_null(name.full))");
+    }
+
+    // No subfield in the 'name' field.
+    {
+      const auto rowType =
+          ROW({"id", "name", "address"}, {BIGINT(), ROW({}, {}), VARCHAR()});
+      const auto op = PlanBuilder()
+                          .startTableScan()
+                          .outputType(rowType)
+                          .dataColumns(rowType)
+                          .endTableScan()
+                          .planNode();
+      const auto split = makeHiveConnectorSplit(file->getPath());
+      const auto result =
+          AssertQueryBuilder(op)
+              .connectorSessionProperty(
+                  kHiveConnectorId,
+                  connector::hive::HiveConfig::kOrcUseColumnNamesSession,
+                  "true")
+              .split(split)
+              .copyResults(pool());
+      const auto rows = result->as<RowVector>();
+      const auto expected = makeRowVector(ROW({}, {}), 5);
+      facebook::velox::test::assertEqualVectors(expected, rows->childAt(1));
+    }
+  }
+
+  // Case sensitivity and lower-case conversion when matching by name.
+  {
+    const auto name = makeRowVector({"FIRST", "LAST"}, names);
+    const auto vector =
+        makeRowVector({"id", "name", "address"}, {id, name, address});
+
+    const auto file = TempFilePath::create();
+    writeToFile(file->getPath(), {vector});
+    createDuckDbTable({vector});
+
+    const auto rowType = ROW(
+        {"id", "name", "address"},
+        {BIGINT(), ROW({"first", "last"}, {VARCHAR(), VARCHAR()}), VARCHAR()});
+    assertSelectUseColumnNames(
+        rowType,
+        "SELECT id, row(null, null), address FROM tmp",
+        file->getPath());
+
+    // Case insensitivity when matching by name and reading as lower case.
+    const auto op =
+        PlanBuilder().tableScan(rowType, {}, "", rowType).planNode();
+    AssertQueryBuilder(op, duckDbQueryRunner_)
+        .connectorSessionProperty(
+            kHiveConnectorId,
+            connector::hive::HiveConfig::kOrcUseColumnNamesSession,
+            "true")
+        .connectorSessionProperty(
+            kHiveConnectorId,
+            connector::hive::HiveConfig::kFileColumnNamesReadAsLowerCaseSession,
+            "true")
+        .split(makeHiveConnectorSplit(file->getPath()))
+        .assertResults("SELECT id, name, address FROM tmp");
+  }
+
+  // Nested struct: rename inner fields to verify recursive name-based matching.
+  {
+    const auto nested = makeRowVector(
+        {"a"},
+        {makeRowVector(
+            {"b", "c"},
+            {
+                makeFlatVector<int32_t>({1, 2, 3, 4, 5}),
+                makeFlatVector<std::string>({"x", "y", "z", "u", "v"}),
+            })});
+    const auto file = TempFilePath::create();
+    writeToFile(file->getPath(), {nested});
+    createDuckDbTable({nested});
+
+    const auto nestedRowType =
+        ROW({"a"}, {ROW({"c", "b_renamed"}, {VARCHAR(), INTEGER()})});
+    assertSelectUseColumnNames(
+        nestedRowType, "SELECT row(a.c, null) FROM tmp", file->getPath());
+
+    // Filter pushdown on renamed (missing) inner field.
+    assertSelectUseColumnNames(
+        nestedRowType,
+        "SELECT * FROM tmp WHERE false",
+        file->getPath(),
+        "not(is_null(a.b_renamed))");
+  }
+}
+
 // Tests queries that use Lazy vectors with multiple layers of wrapping.
 TEST_F(TableScanTest, constDictLazy) {
   vector_size_t size = 1'000;


### PR DESCRIPTION
The default behavior of the schema evolution for row type is matching by index. 
This PR supports subfield rename and deletion for ORC file format, controlled by
configuration `useColumnNamesForColumnMapping`.
Missing subfields are identified by matching the file type and requested type on
the names of subfields, and NULL occupies the position of the missing subfields. 
Below table summarizes the results for difference cases.

| Column schema | Requested output schema | ORC result |
| ------------- | ------------- |  ------------- |
| row({"a", "c"}) | row({"a", "b", "c"})  |  row(a_val, NULL, c_val) |
| row({"a", "c"}) | row({"b"})  | row(NULL) |
| row({"a", "c"}) | row({"b", "d"})  | row(NULL, NULL) |
| row({"a", "c"}) | row({})  | row() |

This PR also fixes a pre-existing bug where `columnReaderOptions_` wasn't initialized
before `getUnitLoader()` built the column readers.

Replaces: https://github.com/facebookincubator/velox/pull/15848.
Part of: https://github.com/facebookincubator/velox/pull/17555.