### PR TITLE
feat(cudf): Add accurate GPU runtime statistics for cudf operators

### DIFF
--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -1360,6 +1360,10 @@ Note: These configurations are experimental and subject to change.
      - bool
      - true
      - If true, allow falling back to Velox CPU execution when an operation is not supported in cuDF execution. If false, an error will be thrown if an operation is not supported in cuDF execution.
+   * - cudf.gpu_timing_enabled
+     - bool
+     - false
+     - If true, report per-operator GPU wall time via the ``gpuWallTimeNanos`` runtime stat, measured using CUDA events. In benchmarks, use ``-include_custom_stats`` to display.
    * - cudf.debug_enabled
      - bool
      - false

--- a/velox/experimental/cudf/CudfConfig.h
+++ b/velox/experimental/cudf/CudfConfig.h
@@ -50,6 +50,7 @@ struct CudfConfig {
   static constexpr const char* kCudfConcatOptimizationEnabled{
       "cudf.concat_optimization_enabled"};
   static constexpr const char* kCudfTimestampUnit{"cudf.timestamp_unit"};
+  static constexpr const char* kCudfGpuTimingEnabled{"cudf.gpu_timing_enabled"};
   /// Query session configs for the cuDF Operators.
   static constexpr const char* kCudfTopNBatchSize{"cudf.topk_batch_size"};
 
@@ -131,6 +132,9 @@ struct CudfConfig {
   /// "s" (seconds), "ms" (milliseconds), "us" (microseconds), "ns"
   /// (nanoseconds).
   cudf::type_id timestampUnit = cudf::type_id::TIMESTAMP_NANOSECONDS;
+
+  /// For profiling only; adds per-operator CUDA event overhead.
+  bool gpuTimingEnabled{false};
 };
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/CMakeLists.txt
+++ b/velox/experimental/cudf/exec/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(
   CudfAssignUniqueId.cpp
   CudfBatchConcat.cpp
   CudfConversion.cpp
+  CudfOperator.cpp
   CudfDistinct.cpp
   CudfEnforceSingleRow.cpp
   CudfFilterProject.cpp

--- a/velox/experimental/cudf/exec/CudfOperator.cpp
+++ b/velox/experimental/cudf/exec/CudfOperator.cpp
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/experimental/cudf/exec/CudfOperator.h"
+
+namespace facebook::velox::cudf_velox {
+
+CudfOperatorBase::CudfOperatorBase(
+    int32_t operatorId,
+    exec::DriverCtx* driverCtx,
+    RowTypePtr outputType,
+    const core::PlanNodeId& planNodeId,
+    const std::string& operatorName,
+    std::optional<nvtx3::color> color,
+    NvtxMethodFlag nvtxMethods,
+    std::optional<common::SpillConfig> spillConfig,
+    std::optional<std::shared_ptr<const core::PlanNode>> planNode)
+    : Operator(
+          driverCtx,
+          outputType,
+          operatorId,
+          planNodeId,
+          operatorName,
+          spillConfig),
+      NvtxHelper(color, operatorId, fmt::format("[{}]", planNodeId)),
+      className_(operatorName),
+      nvtxMethods_(nvtxMethods),
+      gpuTimingEnabled_(CudfConfig::getInstance().gpuTimingEnabled) {
+  if (gpuTimingEnabled_) {
+    initEvents();
+  }
+}
+
+CudfOperatorBase::~CudfOperatorBase() {
+  if (gpuTimingEnabled_) {
+    if (readIdx_ < writeIdx_) {
+      cudaDeviceSynchronize();
+    }
+    destroyEvents();
+  }
+}
+
+void CudfOperatorBase::addInput(RowVectorPtr input) {
+  VELOX_NVTX_OPERATOR_FUNC_RANGE_IF(
+      nvtxMethods_ & NvtxMethodFlag::kAddInput, className_);
+  if (gpuTimingEnabled_) {
+    auto stream = cudf::get_default_stream(cudf::allow_default_stream);
+    recordTimingStart(stream);
+    doAddInput(std::move(input));
+    recordTimingStopAndEnqueue(stream);
+  } else {
+    doAddInput(std::move(input));
+  }
+  checkCudaErrorInDebug();
+}
+
+RowVectorPtr CudfOperatorBase::getOutput() {
+  VELOX_NVTX_OPERATOR_FUNC_RANGE_IF(
+      nvtxMethods_ & NvtxMethodFlag::kGetOutput, className_);
+  RowVectorPtr result;
+  if (gpuTimingEnabled_) {
+    auto stream = cudf::get_default_stream(cudf::allow_default_stream);
+    recordTimingStart(stream);
+    result = doGetOutput();
+    recordTimingStopAndEnqueue(stream);
+    resolveCompletedSlots();
+  } else {
+    result = doGetOutput();
+  }
+  checkCudaErrorInDebug();
+  return result;
+}
+
+void CudfOperatorBase::noMoreInput() {
+  VELOX_NVTX_OPERATOR_FUNC_RANGE_IF(
+      nvtxMethods_ & NvtxMethodFlag::kNoMoreInput, className_);
+  doNoMoreInput();
+  checkCudaErrorInDebug();
+}
+
+void CudfOperatorBase::close() {
+  VELOX_NVTX_OPERATOR_FUNC_RANGE_IF(
+      nvtxMethods_ & NvtxMethodFlag::kClose, className_);
+  if (gpuTimingEnabled_) {
+    cudaDeviceSynchronize();
+    resolveCompletedSlots();
+  }
+  doClose();
+  checkCudaErrorInDebug();
+}
+
+void CudfOperatorBase::doNoMoreInput() {
+  Operator::noMoreInput();
+}
+
+void CudfOperatorBase::doClose() {
+  Operator::close();
+}
+
+void CudfOperatorBase::initEvents() {
+  for (uint32_t i = 0; i < kTimingSlots; i++) {
+    VELOX_CHECK_EQ(
+        static_cast<int>(cudaEventCreate(&timingSlots_[i].start)),
+        static_cast<int>(cudaSuccess),
+        "Failed to create CUDA start event for timing slot {}",
+        i);
+    VELOX_CHECK_EQ(
+        static_cast<int>(cudaEventCreate(&timingSlots_[i].stop)),
+        static_cast<int>(cudaSuccess),
+        "Failed to create CUDA stop event for timing slot {}",
+        i);
+  }
+}
+
+void CudfOperatorBase::destroyEvents() {
+  for (uint32_t i = 0; i < kTimingSlots; i++) {
+    cudaEventDestroy(timingSlots_[i].start);
+    cudaEventDestroy(timingSlots_[i].stop);
+  }
+}
+
+void CudfOperatorBase::gpuTimingCallback(void* userData) {
+  auto* slot = static_cast<TimingSlot*>(userData);
+  slot->ready.store(true, std::memory_order_release);
+}
+
+void CudfOperatorBase::recordTimingStart(rmm::cuda_stream_view stream) {
+  if (writeIdx_ - readIdx_ >= kTimingSlots) {
+    LOG(WARNING) << className_
+                 << ": GPU timing ring buffer overflow, forcing sync";
+    auto& oldest = timingSlots_[readIdx_ & (kTimingSlots - 1)];
+    cudaEventSynchronize(oldest.stop);
+    float ms = 0;
+    if (cudaEventElapsedTime(&ms, oldest.start, oldest.stop) == cudaSuccess) {
+      addRuntimeStat(
+          kGpuWallTime,
+          RuntimeCounter(
+              static_cast<int64_t>(ms * 1e6), RuntimeCounter::Unit::kNanos));
+    }
+    ++readIdx_;
+  }
+  auto& slot = timingSlots_[writeIdx_ & (kTimingSlots - 1)];
+  slot.ready.store(false, std::memory_order_relaxed);
+  VELOX_CHECK_EQ(
+      static_cast<int>(cudaEventRecord(slot.start, stream.value())),
+      static_cast<int>(cudaSuccess),
+      "Failed to record CUDA start event for timing slot {}",
+      writeIdx_);
+}
+
+void CudfOperatorBase::recordTimingStopAndEnqueue(
+    rmm::cuda_stream_view stream) {
+  auto& slot = timingSlots_[writeIdx_ & (kTimingSlots - 1)];
+  VELOX_CHECK_EQ(
+      static_cast<int>(cudaEventRecord(slot.stop, stream.value())),
+      static_cast<int>(cudaSuccess),
+      "Failed to record CUDA stop event for timing slot {}",
+      writeIdx_);
+  VELOX_CHECK_EQ(
+      static_cast<int>(
+          cudaLaunchHostFunc(stream.value(), gpuTimingCallback, &slot)),
+      static_cast<int>(cudaSuccess),
+      "Failed to launch host callback for timing slot {}",
+      writeIdx_);
+  ++writeIdx_;
+}
+
+void CudfOperatorBase::resolveCompletedSlots() {
+  while (readIdx_ < writeIdx_) {
+    auto& slot = timingSlots_[readIdx_ & (kTimingSlots - 1)];
+    if (!slot.ready.load(std::memory_order_acquire)) {
+      break;
+    }
+    float ms = 0;
+    if (cudaEventElapsedTime(&ms, slot.start, slot.stop) != cudaSuccess) {
+      LOG(WARNING) << className_
+                   << ": cudaEventElapsedTime failed for timing slot "
+                   << readIdx_ << ", skipping";
+      ++readIdx_;
+      continue;
+    }
+    addRuntimeStat(
+        kGpuWallTime,
+        RuntimeCounter(
+            static_cast<int64_t>(ms * 1e6), RuntimeCounter::Unit::kNanos));
+    ++readIdx_;
+  }
+}
+
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/CudfOperator.h
+++ b/velox/experimental/cudf/exec/CudfOperator.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "velox/experimental/cudf/CudfConfig.h"
+#include "velox/experimental/cudf/CudfDefaultStreamOverload.h"
 #include "velox/experimental/cudf/exec/DebugUtil.h"
 #include "velox/experimental/cudf/exec/NvtxHelper.h"
 
@@ -23,8 +24,11 @@
 #include "velox/core/PlanNode.h"
 #include "velox/exec/Operator.h"
 
+#include <cuda_runtime.h>
+
 #include <glog/logging.h>
 
+#include <atomic>
 #include <type_traits>
 
 namespace facebook::velox::cudf_velox {
@@ -101,8 +105,15 @@ class CudfOperator : public NvtxHelper {
 ///     void doAddInput(RowVectorPtr input) override { /* process input */ }
 ///     RowVectorPtr doGetOutput() override { /* return output or nullptr */ }
 ///   };
+///
+/// GPU Timing (cudf.gpu_timing_enabled):
+/// Records CUDA events around doAddInput/doGetOutput, resolves elapsed time
+/// via host callbacks, and reports as "gpuWallTimeNanos" runtime stat. No sync
+/// on the submission path unless the 64-slot ring buffer overflows.
 class CudfOperatorBase : public exec::Operator, public NvtxHelper {
  public:
+  static constexpr std::string_view kGpuWallTime{"gpuWallTimeNanos"};
+
   CudfOperatorBase(
       int32_t operatorId,
       exec::DriverCtx* driverCtx,
@@ -113,63 +124,44 @@ class CudfOperatorBase : public exec::Operator, public NvtxHelper {
       NvtxMethodFlag nvtxMethods = NvtxMethodFlag::kAll,
       std::optional<common::SpillConfig> spillConfig = std::nullopt,
       std::optional<std::shared_ptr<const core::PlanNode>> planNode =
-          std::nullopt)
-      : Operator(
-            driverCtx,
-            outputType,
-            operatorId,
-            planNodeId,
-            operatorName,
-            spillConfig),
-        NvtxHelper(color, operatorId, fmt::format("[{}]", planNodeId)),
-        className_(operatorName),
-        nvtxMethods_(nvtxMethods) {}
+          std::nullopt);
 
-  void addInput(RowVectorPtr input) final {
-    VELOX_NVTX_OPERATOR_FUNC_RANGE_IF(
-        nvtxMethods_ & NvtxMethodFlag::kAddInput, className_);
-    doAddInput(std::move(input));
-    checkCudaErrorInDebug();
-  }
+  ~CudfOperatorBase() override;
 
-  RowVectorPtr getOutput() final {
-    VELOX_NVTX_OPERATOR_FUNC_RANGE_IF(
-        nvtxMethods_ & NvtxMethodFlag::kGetOutput, className_);
-    auto result = doGetOutput();
-    checkCudaErrorInDebug();
-    return result;
-  }
-
-  void noMoreInput() final {
-    VELOX_NVTX_OPERATOR_FUNC_RANGE_IF(
-        nvtxMethods_ & NvtxMethodFlag::kNoMoreInput, className_);
-    doNoMoreInput();
-    checkCudaErrorInDebug();
-  }
-
-  void close() final {
-    VELOX_NVTX_OPERATOR_FUNC_RANGE_IF(
-        nvtxMethods_ & NvtxMethodFlag::kClose, className_);
-    doClose();
-    checkCudaErrorInDebug();
-  }
+  void addInput(RowVectorPtr input) final;
+  RowVectorPtr getOutput() final;
+  void noMoreInput() final;
+  void close() final;
 
  protected:
   virtual void doAddInput(RowVectorPtr input) = 0;
-
   virtual RowVectorPtr doGetOutput() = 0;
-
-  virtual void doNoMoreInput() {
-    Operator::noMoreInput();
-  }
-
-  virtual void doClose() {
-    Operator::close();
-  }
+  virtual void doNoMoreInput();
+  virtual void doClose();
 
  private:
+  struct TimingSlot {
+    cudaEvent_t start{};
+    cudaEvent_t stop{};
+    std::atomic<bool> ready{false};
+  };
+
+  static constexpr uint32_t kTimingSlots = 64;
+
+  void initEvents();
+  void destroyEvents();
+  static void gpuTimingCallback(void* userData);
+  void recordTimingStart(rmm::cuda_stream_view stream);
+  void recordTimingStopAndEnqueue(rmm::cuda_stream_view stream);
+  void resolveCompletedSlots();
+
   const std::string className_;
   const NvtxMethodFlag nvtxMethods_;
+  const bool gpuTimingEnabled_;
+
+  TimingSlot timingSlots_[kTimingSlots]{};
+  uint32_t writeIdx_{0};
+  uint32_t readIdx_{0};
 };
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -419,6 +419,9 @@ void CudfConfig::initialize(
   if (config.find(kCudfTopNBatchSize) != config.end()) {
     topNBatchSize = folly::to<int32_t>(config[kCudfTopNBatchSize]);
   }
+  if (config.find(kCudfGpuTimingEnabled) != config.end()) {
+    gpuTimingEnabled = folly::to<bool>(config[kCudfGpuTimingEnabled]);
+  }
   if (config.find(kCudfTimestampUnit) != config.end()) {
     const auto& unit = config[kCudfTimestampUnit];
     if (unit == "s") {

--- a/velox/experimental/cudf/tests/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/CMakeLists.txt
@@ -228,6 +228,12 @@ velox_add_cudf_test(
   LIBS ${CUDF_TEST_DEFAULT_LIBS} fmt::fmt
 )
 
+velox_add_cudf_test(
+  NAME velox_cudf_gpu_timing_test
+  SOURCES Main.cpp GpuTimingTest.cpp
+  LIBS ${CUDF_TEST_DEFAULT_LIBS}
+)
+
 add_subdirectory(utils)
 
 if(${VELOX_ENABLE_SPARK_FUNCTIONS})

--- a/velox/experimental/cudf/tests/GpuTimingTest.cpp
+++ b/velox/experimental/cudf/tests/GpuTimingTest.cpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/experimental/cudf/CudfConfig.h"
+#include "velox/experimental/cudf/exec/CudfOperator.h"
+#include "velox/experimental/cudf/exec/ToCudf.h"
+#include "velox/experimental/cudf/tests/CudfFunctionBaseTest.h"
+
+#include "velox/exec/PlanNodeStats.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+
+class GpuTimingTest : public OperatorTestBase {
+ protected:
+  void SetUp() override {
+    OperatorTestBase::SetUp();
+    cudf_velox::CudfConfig::getInstance().allowCpuFallback = false;
+    cudf_velox::CudfConfig::getInstance().gpuTimingEnabled = true;
+    cudf_velox::registerCudf();
+  }
+
+  void TearDown() override {
+    cudf_velox::CudfConfig::getInstance().gpuTimingEnabled = false;
+    cudf_velox::unregisterCudf();
+    OperatorTestBase::TearDown();
+  }
+};
+
+TEST_F(GpuTimingTest, projectReportsGpuWallTime) {
+  auto input = makeRowVector(
+      {"c0"}, {makeFlatVector<int32_t>(10000, [](auto row) { return row; })});
+
+  core::PlanNodeId projNodeId;
+  auto plan = PlanBuilder()
+                  .values({input})
+                  .project({"c0 * c0 as x"})
+                  .capturePlanNodeId(projNodeId)
+                  .planNode();
+
+  std::shared_ptr<exec::Task> task;
+  AssertQueryBuilder(plan).copyResults(pool(), task);
+
+  auto stats = toPlanStats(task->taskStats());
+  auto& opStats = stats.at(projNodeId);
+
+  ASSERT_TRUE(opStats.customStats.count("gpuWallTimeNanos"));
+  auto& gpuStat = opStats.customStats.at("gpuWallTimeNanos");
+  EXPECT_GT(gpuStat.count, 0);
+  EXPECT_GT(gpuStat.sum, 1000L);
+  EXPECT_LT(gpuStat.sum, 10'000'000'000L);
+}
+
+TEST_F(GpuTimingTest, disabledNoGpuWallTime) {
+  cudf_velox::CudfConfig::getInstance().gpuTimingEnabled = false;
+
+  auto input = makeRowVector(
+      {"c0"}, {makeFlatVector<int32_t>(100, [](auto row) { return row; })});
+
+  core::PlanNodeId projNodeId;
+  auto plan = PlanBuilder()
+                  .values({input})
+                  .project({"c0 + 1 as x"})
+                  .capturePlanNodeId(projNodeId)
+                  .planNode();
+
+  std::shared_ptr<exec::Task> task;
+  AssertQueryBuilder(plan).copyResults(pool(), task);
+
+  auto stats = toPlanStats(task->taskStats());
+  auto& opStats = stats.at(projNodeId);
+
+  EXPECT_EQ(opStats.customStats.count("gpuWallTimeNanos"), 0);
+}
+
+TEST_F(GpuTimingTest, multipleBatchesAccumulate) {
+  std::vector<RowVectorPtr> batches;
+  for (int i = 0; i < 10; i++) {
+    batches.push_back(makeRowVector(
+        {"c0"}, {makeFlatVector<int32_t>(100, [](auto row) { return row; })}));
+  }
+
+  core::PlanNodeId projNodeId;
+  auto plan = PlanBuilder()
+                  .values(batches)
+                  .project({"c0 * 2 as x"})
+                  .capturePlanNodeId(projNodeId)
+                  .planNode();
+
+  std::shared_ptr<exec::Task> task;
+  AssertQueryBuilder(plan).copyResults(pool(), task);
+
+  auto stats = toPlanStats(task->taskStats());
+  auto& opStats = stats.at(projNodeId);
+
+  ASSERT_TRUE(opStats.customStats.count("gpuWallTimeNanos"));
+  auto& gpuStat = opStats.customStats.at("gpuWallTimeNanos");
+  EXPECT_GT(gpuStat.count, 1);
+  EXPECT_GT(gpuStat.sum, 0);
+}


### PR DESCRIPTION
## Summary

Adds per-operator GPU wall time measurement to the cuDF adapter using CUDA events, addressing #16722.

When `cudf.gpu_timing_enabled=true`, each cuDF operator reports a `gpuWallTimeNanos` runtime stat showing the actual GPU execution time (kernel launch to completion), measured at hardware precision via `cudaEventElapsedTime`.

## Design

* **CUDA Event ring buffer** (64 slots) in `CudfOperatorBase` records start/stop events around each `addInput`/`getOutput` call
* **Asynchronous resolution**: a host-function callback (`cudaLaunchHostFunc`) marks slots as ready; `resolveCompletedSlots()` harvests completed slots without blocking the driver thread
* **Zero sync overhead** on the critical path — `cudaDeviceSynchronize` only happens in `close()` to flush remaining slots
* **Robust error handling**: `cudaEventCreate`, `cudaEventRecord`, and `cudaLaunchHostFunc` use `VELOX_CHECK_EQ` (failures here indicate an unrecoverable CUDA context error). `cudaEventElapsedTime` uses LOG(WARNING) + skip for recoverable sampling loss.
* **Graceful overflow**: if all 64 slots are in-flight, falls back to synchronous resolve with a LOG(WARNING)

## Output

`gpuWallTimeNanos` appears in operator custom stats (visible with `-include_custom_stats` In benchmarks):

```
Execution time: 573ms
Splits total: 1, finished: 1
-- OrderBy[5][l_returnflag ASC NULLS LAST, l_linestatus ASC NULLS LAST] -> l_returnflag:VARCHAR, l_linestatus:VARCHAR, a0:DOUBLE, a1:DOUBLE, a2:DOUBLE, a3:DOUBLE, a4:DOUBLE, a5:DOUBLE, a6:DOUBLE, a7:BIGINT
   Output: 8 rows (752B, 2 batches), Cpu time: 8.52ms, Wall time: 8.61ms, Blocked wall time: 0ns, Peak memory: 384B, Memory allocations: 2, CPU breakdown: B/I/O/F (36.44us/19.02us/668.60us/7.80ms)
   CudfToVelox: Input: 4 rows (304B, 1 batches), Output: 4 rows (448B, 1 batches), Cpu time: 613.68us, Wall time: 677.75us, Blocked wall time: 0ns, Peak memory: 384B, Memory allocations: 2, Threads: 1, CPU breakdown: B/I/O/F (19.91us/8.84us/577.50us/7.43us)
      driverCpuTimeNanos           sum: 613.68us, count: 1, min: 613.68us, max: 613.68us, avg: 613.68us
      gpuWallTimeNanos             sum: 286.65us, count: 8, min: 2.02us, max: 243.74us, avg: 35.83us
      queuedWallNanos              sum: 342.00us, count: 1, min: 342.00us, max: 342.00us, avg: 342.00us
      runningAddInputWallNanos     sum: 9.83us, count: 1, min: 9.83us, max: 9.83us, avg: 9.83us
      runningFinishWallNanos       sum: 13.57us, count: 1, min: 13.57us, max: 13.57us, avg: 13.57us
      runningGetOutputWallNanos    sum: 617.84us, count: 1, min: 617.84us, max: 617.84us, avg: 617.84us
      runningIsBlockedWallNanos    sum: 36.51us, count: 1, min: 36.51us, max: 36.51us, avg: 36.51us
   CudfOrderBy: Input: 4 rows (432B, 1 batches), Output: 4 rows (304B, 1 batches), Cpu time: 7.91ms, Wall time: 7.93ms, Blocked wall time: 0ns, Peak memory: 0B, Memory allocations: 0, Threads: 1, CPU breakdown: B/I/O/F (16.53us/10.18us/91.10us/7.79ms)
      driverCpuTimeNanos           sum: 7.91ms, count: 1, min: 7.91ms, max: 7.91ms, avg: 7.91ms
      gpuWallTimeNanos             sum: 13.30us, count: 7, min: 1.02us, max: 2.05us, avg: 1.90us
      runningAddInputWallNanos     sum: 11.22us, count: 1, min: 11.22us, max: 11.22us, avg: 11.22us
      runningFinishWallNanos       sum: 7.80ms, count: 1, min: 7.80ms, max: 7.80ms, avg: 7.80ms
      runningGetOutputWallNanos    sum: 97.00us, count: 1, min: 97.00us, max: 97.00us, avg: 97.00us
      runningIsBlockedWallNanos    sum: 30.52us, count: 1, min: 30.52us, max: 30.52us, avg: 30.52us
```

## Validation

* 3 unit tests (enabled reports stat, disabled does not, multiple batches accumulate)
* TPC-H Q1 SF10: gpuWallTime sum = 231ms