### PR TITLE
feat: Add PUFFIN to dwio::common::FileFormat

### DIFF
--- a/velox/dwio/common/Options.cpp
+++ b/velox/dwio/common/Options.cpp
@@ -43,6 +43,8 @@ FileFormat toFileFormat(std::string_view s) {
     return FileFormat::FLUX;
   } else if (s == "avro") {
     return FileFormat::AVRO;
+  } else if (s == "puffin") {
+    return FileFormat::PUFFIN;
   }
   return FileFormat::UNKNOWN;
 }
@@ -73,6 +75,8 @@ std::string_view toString(FileFormat fmt) {
       return "flux";
     case FileFormat::AVRO:
       return "avro";
+    case FileFormat::PUFFIN:
+      return "puffin";
     default:
       return "unknown";
   }

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -54,6 +54,10 @@ enum class FileFormat {
   SST = 10, // rocksdb sst format
   FLUX = 11,
   AVRO = 12,
+  PUFFIN =
+      13, // Iceberg V3 Puffin blob container (e.g. deletion vectors).
+          // Not consumed by dwio::ReaderFactory; read directly by the
+          // Iceberg connector via FileSystem::pread of the blob byte-range.
 };
 
 FileFormat toFileFormat(std::string_view s);


### PR DESCRIPTION
Summary:
Adds a PUFFIN entry to the FileFormat enum for Iceberg V3 Puffin blob
containers (used for deletion vectors). Like SST, FLUX, and AVRO, PUFFIN
is a recognized format identifier but is not consumed by the
dwio::ReaderFactory registry — Puffin files are read directly by the
Iceberg connector via FileSystem::pread of the blob byte-range
(see velox/connectors/hive/iceberg/DeletionVectorReader.cpp), and
dispatched by IcebergDeleteFile::content == FileContent::kDeletionVector
in IcebergSplitReader, not by FileFormat.

Also adds the matching toString / toFileFormat string mappings.

Reviewed By: zzhao0

Differential Revision: D105654940


