### PR TITLE
fix: Filter on constant ScanSpec fields

### DIFF
--- a/velox/dwio/common/ScanSpec.cpp
+++ b/velox/dwio/common/ScanSpec.cpp
@@ -157,7 +157,7 @@ bool ScanSpec::hasFilter() const {
   if (hasFilter_.has_value()) {
     return hasFilter_.value();
   }
-  if (!isConstant() && filter()) {
+  if (filter()) {
     hasFilter_ = true;
     return true;
   }

--- a/velox/dwio/common/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/common/SelectiveStructColumnReader.cpp
@@ -21,16 +21,6 @@
 namespace facebook::velox::dwio::common {
 namespace {
 
-bool testFilterOnConstant(const velox::common::ScanSpec& spec) {
-  if (spec.isConstant() && !spec.constantValue()->isNullAt(0)) {
-    // Non-null constant is known value during split scheduling and filters on
-    // them should not be handled at execution level.
-    return true;
-  }
-  // Check filter on missing field.
-  return !spec.hasFilter() || spec.testNull();
-}
-
 // Recursively makes empty RowVectors for positions in 'children' where the
 // corresponding child type in 'rowType' is a row. The reader expects RowVector
 // outputs to be initialized so that the content corresponds to the query schema
@@ -690,6 +680,18 @@ void SelectiveStructColumnReaderBase::getValues(
   }
 
   resultRow->invalidateContainsLazyNotLoaded();
+}
+
+// static
+bool SelectiveStructColumnReaderBase::testFilterOnConstant(
+    const velox::common::ScanSpec& spec) {
+  if (spec.isConstant() && !spec.constantValue()->isNullAt(0)) {
+    // Non-null constant is known value during split scheduling and filters on
+    // them should not be handled at execution level.
+    return true;
+  }
+  // Check filter on missing field.
+  return !spec.hasFilter() || spec.testNull();
 }
 
 namespace detail {

--- a/velox/dwio/common/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/common/SelectiveStructColumnReader.cpp
@@ -21,16 +21,6 @@
 namespace facebook::velox::dwio::common {
 namespace {
 
-bool testFilterOnConstant(const velox::common::ScanSpec& spec) {
-  if (spec.isConstant() && !spec.constantValue()->isNullAt(0)) {
-    // Non-null constant is known value during split scheduling and filters on
-    // them should not be handled at execution level.
-    return true;
-  }
-  // Check filter on missing field.
-  return !spec.hasFilter() || spec.testNull();
-}
-
 // Recursively makes empty RowVectors for positions in 'children' where the
 // corresponding child type in 'rowType' is a row. The reader expects RowVector
 // outputs to be initialized so that the content corresponds to the query schema
@@ -729,6 +719,18 @@ void SelectiveStructColumnReaderBase::getValues(
   }
 
   resultRow->invalidateContainsLazyNotLoaded();
+}
+
+// static
+bool SelectiveStructColumnReaderBase::testFilterOnConstant(
+    const velox::common::ScanSpec& spec) {
+  if (spec.isConstant() && !spec.constantValue()->isNullAt(0)) {
+    // Non-null constant is known value during split scheduling and filters on
+    // them should not be handled at execution level.
+    return true;
+  }
+  // Check filter on missing field.
+  return !spec.hasFilter() || spec.testNull();
 }
 
 namespace detail {

--- a/velox/dwio/common/SelectiveStructColumnReader.h
+++ b/velox/dwio/common/SelectiveStructColumnReader.h
@@ -105,6 +105,11 @@ class SelectiveStructColumnReaderBase : public SelectiveColumnReader {
     currentRowNumber_ = value;
   }
 
+  /// Evaluates split-time filtering for a constant field.
+  /// Returns true for non-null constants, or when no filter is present, or when
+  /// the filter allows null values.
+  static bool testFilterOnConstant(const velox::common::ScanSpec& spec);
+
  protected:
   template <typename T, typename KeyNode, typename FormatData>
   friend class SelectiveFlatMapColumnReaderHelper;

--- a/velox/dwio/common/tests/ScanSpecTest.cpp
+++ b/velox/dwio/common/tests/ScanSpecTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/dwio/common/ScanSpec.h"
+#include "velox/dwio/common/SelectiveStructColumnReader.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
 #include <gtest/gtest.h>
@@ -103,6 +104,63 @@ TEST_F(ScanSpecTest, setFilterResetsHasFilter) {
   ASSERT_TRUE(scanSpec.childByName("c1")->hasFilter());
   ASSERT_FALSE(scanSpec.childByName("c0")->hasFilter());
   ASSERT_TRUE(scanSpec.hasFilter());
+}
+
+TEST_F(ScanSpecTest, testFilterOnConstant) {
+  auto test = [&](auto&& setup, bool expected) {
+    ScanSpec scanSpec("<root>");
+    auto* child = scanSpec.addField("c0", 0);
+    setup(scanSpec, *child);
+    ASSERT_EQ(
+        dwio::common::SelectiveStructColumnReaderBase::testFilterOnConstant(
+            *child),
+        expected);
+  };
+
+  // Non-null constants are accepted regardless of filter kind.
+  test(
+      [&](ScanSpec&, ScanSpec& child) {
+        child.setConstantValue(
+            BaseVector::createConstant(BIGINT(), 1LL, 1, pool()));
+        child.setFilter(std::make_shared<IsNull>());
+      },
+      true);
+  test(
+      [&](ScanSpec&, ScanSpec& child) {
+        child.setConstantValue(
+            BaseVector::createConstant(BIGINT(), 1LL, 1, pool()));
+        child.setFilter(std::make_shared<IsNotNull>());
+      },
+      true);
+
+  // Null constants are accepted only when the filter can match nulls.
+  test(
+      [&](ScanSpec&, ScanSpec& child) {
+        child.setConstantValue(
+            BaseVector::createNullConstant(BIGINT(), 1, pool()));
+        child.setFilter(std::make_shared<IsNull>());
+      },
+      true);
+  test(
+      [&](ScanSpec& scanSpec, ScanSpec& child) {
+        child.setConstantValue(
+            BaseVector::createNullConstant(BIGINT(), 1, pool()));
+        child.setFilter(std::make_shared<IsNotNull>());
+      },
+      false);
+
+  // For non-constant specs, there is no filter or the filter accepts nulls.
+  test([](ScanSpec&, ScanSpec&) {}, true);
+  test(
+      [](ScanSpec&, ScanSpec& child) {
+        child.setFilter(std::make_shared<IsNull>());
+      },
+      true);
+  test(
+      [](ScanSpec&, ScanSpec& child) {
+        child.setFilter(std::make_shared<IsNotNull>());
+      },
+      false);
 }
 
 class TypedScanSpecTest : public testing::TestWithParam<TypePtr>,


### PR DESCRIPTION
This PR fixes filter handling for constant scan spec nodes by making
`ScanSpec::hasFilter()` return true whenever a filter is present, including for
constant fields such as schema-evolution null constants. This ensures that
`testFilterOnConstant` in `velox/dwio/common/SelectiveStructColumnReader.cpp`, 
which relies on `hasFilter()`, correctly preserves constant-filter semantics 
instead of treating those nodes as unfiltered.

Part of: https://github.com/facebookincubator/velox/pull/17555.