### PR TITLE
feat: Support Spark hour(timestamp_utc) function

### DIFF
--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -173,9 +173,27 @@ These functions support TIMESTAMP and DATE input types.
 
 .. spark:function:: hour(timestamp) -> integer
 
-    Returns the hour of ``timestamp``.::
+    Returns the hour of ``timestamp``, subject to the session timezone.
 
-        SELECT hour('2009-07-30 12:58:59'); -- 12
+    Under session timezone UTC: ::
+
+        SELECT hour('2009-07-30 19:58:59'); -- 19
+
+    Under session timezone ``America/Los_Angeles`` (UTC-7): ::
+
+        SELECT hour('2009-07-30 19:58:59 UTC'); -- 12
+
+.. spark:function:: hour(timestamp_utc) -> integer
+
+    Returns the hour of ``timestamp_utc``, not subject to the session timezone. ::
+
+    Under session timezone UTC: ::
+
+        SELECT hour(TIMESTAMP_NTZ '2009-07-30 19:58:59'); -- 19
+
+    Under session timezone ``America/Los_Angeles`` (UTC-7): ::
+
+        SELECT hour(TIMESTAMP_NTZ '2009-07-30 19:58:59 UTC'); -- 19
 
 .. spark:function:: last_day(date) -> date
 

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -885,13 +885,26 @@ struct NextDayFunction {
   bool invalidFormat_{false};
 };
 
-template <typename T>
+template <typename T, typename TTimestamp>
 struct HourFunction : public InitSessionTimezone<T> {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& inputTypes,
+      const core::QueryConfig& config,
+      const arg_type<TTimestamp>* timestamp) {
+    if constexpr (std::is_same_v<TTimestamp, TimestampUtc>) {
+      // TIMESTAMP UTC represents a timestamp in UTC, not subject to session
+      // timezone adjustment.
+      this->timeZone_ = nullptr;
+    } else {
+      InitSessionTimezone<T>::initialize(inputTypes, config, timestamp);
+    }
+  }
+
   FOLLY_ALWAYS_INLINE void call(
       int32_t& result,
-      const arg_type<Timestamp>& timestamp) {
+      const arg_type<TTimestamp>& timestamp) {
     result = getDateTime(timestamp, this->timeZone_).tm_hour;
   }
 };

--- a/velox/functions/sparksql/registration/RegisterDatetime.cpp
+++ b/velox/functions/sparksql/registration/RegisterDatetime.cpp
@@ -75,7 +75,14 @@ void registerDatetimeFunctions(const std::string& prefix) {
   registerFunction<NextDayFunction, Date, Date, Varchar>({prefix + "next_day"});
   registerFunction<GetTimestampFunction, Timestamp, Varchar, Varchar>(
       {prefix + "get_timestamp"});
-  registerFunction<HourFunction, int32_t, Timestamp>({prefix + "hour"});
+  registerFunction<
+      ParameterBinder<HourFunction, Timestamp>,
+      int32_t,
+      Timestamp>({prefix + "hour"});
+  registerFunction<
+      ParameterBinder<HourFunction, TimestampUtc>,
+      int32_t,
+      TimestampUtc>({prefix + "hour"});
   registerFunction<MinuteFunction, int32_t, Timestamp>({prefix + "minute"});
   registerFunction<SecondFunction, int32_t, Timestamp>({prefix + "second"});
   registerFunction<MakeYMIntervalFunction, IntervalYearMonth>(

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -944,6 +944,24 @@ TEST_F(DateTimeFunctionsTest, hour) {
   EXPECT_EQ(2, hour("1969-01-01 13:23:00.001"));
 }
 
+TEST_F(DateTimeFunctionsTest, hourTimestampUtc) {
+  const auto hourUtc = [&](StringView timestampStr) {
+    auto ts = std::make_optional(parseTimestamp(timestampStr));
+    return evaluateOnce<int32_t>("hour(c0)", TIMESTAMP_UTC(), ts);
+  };
+
+  EXPECT_EQ(0, hourUtc("2024-01-08 00:23:00.001"));
+  EXPECT_EQ(1, hourUtc("2024-01-08 01:23:00.001"));
+  EXPECT_EQ(13, hourUtc("2024-01-20 13:23:00.001"));
+
+  // TIMESTAMP UTC must not be affected by session timezone.
+  setQueryTimeZone("Pacific/Apia");
+
+  EXPECT_EQ(0, hourUtc("2024-01-08 00:23:00.001"));
+  EXPECT_EQ(1, hourUtc("2024-01-08 01:23:00.001"));
+  EXPECT_EQ(13, hourUtc("2024-01-20 13:23:00.001"));
+}
+
 TEST_F(DateTimeFunctionsTest, minute) {
   const auto minute = [&](const StringView& timestampStr) {
     const auto timeStamp = std::make_optional(parseTimestamp(timestampStr));


### PR DESCRIPTION
This PR adds support for hour(timestamp_utc) in Spark functions.

TimestampUtcType (Velox's representation of Spark's TIMESTAMP_NTZ) stores timestamps without timezone information — the value is taken as-is with no session timezone adjustment applied. Accordingly, hour(timestamp_utc) returns the stored hour directly without adjusting for the session timezone.

Related type PR: #17091
Related issue: #17087
Spark reference: [datetimeExpressions.scala](https://github.com/apache/spark/blob/v4.0.0/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala#L403-L412)