### PR TITLE
docs: Add self-review checklists for contributors

### DIFF
--- a/CODING_STYLE.md
+++ b/CODING_STYLE.md
@@ -5,6 +5,10 @@ promoting consistency within the codebase, and encouraging common practices
 which will make the codebase easier to read, edit, maintain and debug in the
 future.
 
+Before submitting a PR, run through the
+[Self-Review Checklist](scripts/review/SELF_REVIEW.md). For function PRs,
+also check the [Function PR Guide](scripts/review/FUNCTION_PR_GUIDE.md).
+
 ## Code Formatting, Headers, and Licenses
 
 We use [pre-commit](https://pre-commit.com) to manage the installation and
@@ -117,6 +121,9 @@ line width, indentation and ordering (for includes, using directives and etc). 
   | `sel` | `selectivity` |
   | `rowCount` | `numRows` |
 
+  * Do not use numbered or lettered variables (`bitmap1`, `bitmapA`, `rows2`).
+    Use descriptive names that convey meaning, or inline the value to avoid
+    naming altogether.
   * Well-established abbreviations in the domain are acceptable (e.g., `id`,
     `url`, `sql`, `expr`).
   * Loop indices like `i`, `j`, `k` are acceptable for simple loops.
@@ -225,6 +232,10 @@ return result;
 buffer.reserve(1024);
 ```
 
+* **Do not reference other implementations** in comments ("like Java Presto",
+  "similar to Spark's X"). Logic should stand on its own. The exception is
+  function implementations that deliberately match another engine's semantics
+  — there, a reference to the canonical spec helps verify correctness.
 * **Do not duplicate comments between `.h` and `.cpp`.** Document the function
   in the header; the implementation should not repeat the same comment.
   Duplicated comments diverge over time.
@@ -259,6 +270,9 @@ buffer.reserve(1024);
       i)`
     * Note that the values of v1 and v2 are already included in the exception
       message by default.
+* **Error messages must match the check.** `VELOX_CHECK_GE(x, 0)` checks
+  `x >= 0`, so the message should say "non-negative" or "greater than or
+  equal to 0", not "greater than 0".
 * Put runtime information (names, values, types) at the **end** of error
   messages, after the static description.
 
@@ -325,6 +339,8 @@ buffer.reserve(1024);
   | `100` | `100` (no separator needed) |
 * For floating point literals, never omit the initial 0 before the decimal
   point (always `0.5`, not `.5`).
+* Constants shared across files belong in a common header, not duplicated
+  in each file.
 * File level variables and constants should be defined in an anonymous
   namespace.
 * Always prefer const variables and enum to using preprocessor (#define) to
@@ -531,6 +547,9 @@ using ContinuePromise = VeloxPromise<bool>;
   at the top or bottom of the file.
 * **Keep method implementations in .cpp.** Except for trivial one-liners,
   define methods in the .cpp file to keep headers small and reduce build times.
+* **Prefer constructor parameters over setter injection.** If a dependency
+  is required for the object to function, pass it in the constructor rather
+  than adding a setter method.
 * **Avoid default arguments** when all callers can pass values explicitly.
 * **Never use `friend`, `FRIEND_TEST`, or any friend declarations.** If a test
   needs access to private members, redesign the API or test through public
@@ -538,6 +557,12 @@ using ContinuePromise = VeloxPromise<bool>;
 
 ## Tests
 
+* **Each test file should have one test suite with a matching name.** E.g.,
+  `FooTest.cpp` contains the `FooTest` suite.
+* **Use `TEST()` for empty fixtures, `TEST_F()` only when the fixture is
+  used.**
+* **No copy-pasted test blocks.** If two tests differ only in one parameter,
+  use a loop or a local lambda.
 * **Place new tests next to related existing tests**, not at the end of the
   file. Group tests by topic (e.g., place `tryCast` next to `types`,
   `notBetween` next to `ifClause` which uses `between`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -313,7 +313,7 @@ Adding Presto and Spark functions are a good way to get yourself familiar with
 Velox and the code review process. In addition to the general contribution
 guidelines presented above, review the
 [Function PR Guide](scripts/review/FUNCTION_PR_GUIDE.md) for a detailed
-checklist covering documentation, registration, implementation, and testing.
+checklist covering documentation, registration, and implementation.
 Here are specific guidelines for contributing functions:
 
 1. Read [How to add a scalar function?](https://facebookincubator.github.io/velox/develop/scalar-functions.html) guide. When implementing a function, simple function is preferred unless the implementation of vector function provides a significant performance gain which can be demonstrated

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,8 +100,12 @@ The contribution process is outlined below:
    reviewers. For PRs that add or modify functions, also check the
    [Function PR Guide](scripts/review/FUNCTION_PR_GUIDE.md). If you use
    Claude or a similar AI tool, paste these checklists as context and ask
-   it to review your diff. Catching common issues before review saves
-   everyone time.
+   it to review your diff.
+   * We want to provide timely, thorough reviews on every PR. When
+   reviewers spend rounds on naming, style, and conventions, it delays
+   feedback on design and correctness — for your PR and for others
+   waiting in the queue. PRs that repeatedly miss these basics may be
+   sent back for self-review before a detailed review can begin.
 
 6. Review is performed by one or more reviewers.
    * This normally happens within a few days, but may take longer if the change

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -319,7 +319,9 @@ Here are specific guidelines for contributing functions:
 1. Read [How to add a scalar function?](https://facebookincubator.github.io/velox/develop/scalar-functions.html) guide. When implementing a function, simple function is preferred unless the implementation of vector function provides a significant performance gain which can be demonstrated
 with a benchmark.
 
-2. Use the following template for the PR title: Add xxx [Presto|Spark] function (replace xxx with the function name).
+2. Follow the PR title convention from the
+   [Function PR Guide](scripts/review/FUNCTION_PR_GUIDE.md), e.g.
+   `feat(presto): Add abs scalar function`.
    * Ensure the PR description contains a link to the function documentation
    from Presto or Spark docs.
    * Describe the function semantics and edge cases clearly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,12 +95,20 @@ The contribution process is outlined below:
      tagging the appropriate maintainers for that component.
    * Once all CI signals are green, tag the reviewers identified in Step 3.
 
-5. Review is performed by one or more reviewers.
+5. **Self-review before requesting review.** Run through the
+   [Self-Review Checklist](scripts/review/SELF_REVIEW.md) before tagging
+   reviewers. For PRs that add or modify functions, also check the
+   [Function PR Guide](scripts/review/FUNCTION_PR_GUIDE.md). If you use
+   Claude or a similar AI tool, paste these checklists as context and ask
+   it to review your diff. Catching common issues before review saves
+   everyone time.
+
+6. Review is performed by one or more reviewers.
    * This normally happens within a few days, but may take longer if the change
    is large, complex, or if a critical reviewer is unavailable (feel free to
    ping them in the PR or on Slack).
 
-6. Address feedback and update the PR.
+7. Address feedback and update the PR.
    * After pushing changes, add a comment to the PR mentioning the
    reviewer(s) by name, stating the comments have been addressed. This is the best
    way to ensure that the reviewer is notified that the code is ready to be reviewed
@@ -108,8 +116,13 @@ The contribution process is outlined below:
    * As a PR author, please do not "Resolve Conversation" when review comments are
    addressed. Instead, wait for the reviewer to verify the comment has been
    addressed and resolve the conversation.
+   * Before requesting re-review, re-read every review comment and confirm
+   each is addressed or discussed. Do not silently skip items. If a
+   requested change is too large for this PR, say so and propose a plan
+   (e.g., separate PR). See the re-review section in the
+   [Self-Review Checklist](scripts/review/SELF_REVIEW.md).
 
-7. Iterate on this process until your changes are reviewed and accepted by a
+8. Iterate on this process until your changes are reviewed and accepted by a
    maintainer. At this point, a Meta employee will be notified to merge your PR,
    due to tooling limitations.
 
@@ -295,8 +308,10 @@ following best practices:
 
 Adding Presto and Spark functions are a good way to get yourself familiar with
 Velox and the code review process. In addition to the general contribution
-guidelines presented above, here are specific guidelines for contributing
-functions:
+guidelines presented above, review the
+[Function PR Guide](scripts/review/FUNCTION_PR_GUIDE.md) for a detailed
+checklist covering documentation, registration, implementation, and testing.
+Here are specific guidelines for contributing functions:
 
 1. Read [How to add a scalar function?](https://facebookincubator.github.io/velox/develop/scalar-functions.html) guide. When implementing a function, simple function is preferred unless the implementation of vector function provides a significant performance gain which can be demonstrated
 with a benchmark.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,11 +120,10 @@ The contribution process is outlined below:
    * As a PR author, please do not "Resolve Conversation" when review comments are
    addressed. Instead, wait for the reviewer to verify the comment has been
    addressed and resolve the conversation.
-   * Before requesting re-review, re-read every review comment and confirm
-   each is addressed or discussed. Do not silently skip items. If a
-   requested change is too large for this PR, say so and propose a plan
-   (e.g., separate PR). See the re-review section in the
-   [Self-Review Checklist](scripts/review/SELF_REVIEW.md).
+   * Before requesting re-review, confirm every review comment is either
+   addressed in code or discussed in a reply. Do not silently skip items.
+   If a requested change is too large for this PR, say so and propose a
+   plan (e.g., separate PR).
 
 8. Iterate on this process until your changes are reviewed and accepted by a
    maintainer. At this point, a Meta employee will be notified to merge your PR,

--- a/scripts/review/FUNCTION_PR_GUIDE.md
+++ b/scripts/review/FUNCTION_PR_GUIDE.md
@@ -5,10 +5,10 @@ functions, or special forms. Use alongside `SELF_REVIEW.md`.
 
 ## PR title
 
-When adding a new function, follow this pattern:
-
-- `feat(presto): Add abs scalar function`
-- `feat(spark): Add bitmap_or_agg aggregate function`
+- Adding: `feat(presto): Add abs scalar function`
+- Adding: `feat(spark): Add bitmap_or_agg aggregate function`
+- Fixing: `fix(presto): Fix abs function for negative zero`
+- Fixing: `fix(spark): Fix bitmap_or_agg for all-null inputs`
 
 ## Documentation
 

--- a/scripts/review/FUNCTION_PR_GUIDE.md
+++ b/scripts/review/FUNCTION_PR_GUIDE.md
@@ -3,6 +3,11 @@
 Additional checklist for PRs that add or modify scalar functions, aggregate
 functions, or special forms. Use alongside `SELF_REVIEW.md`.
 
+## PR title
+
+When adding a new function, use:
+`feat(presto|spark): Add xxx scalar|aggregate function`
+
 ## Documentation
 
 - [ ] Doc entry exists in the correct `.rst` file under `docs/functions/`

--- a/scripts/review/FUNCTION_PR_GUIDE.md
+++ b/scripts/review/FUNCTION_PR_GUIDE.md
@@ -19,12 +19,8 @@ functions, or special forms. Use alongside `SELF_REVIEW.md`.
 
 ## Registration
 
-- [ ] Function is registered in the correct `Register.cpp`.
 - [ ] Registration name matches the engine's canonical name.
 - [ ] Prefix handling is correct (`prefix + "function_name"`).
-- [ ] `withCompanionFunctions` and `overwrite` parameters are plumbed
-      through.
-- [ ] Function signature uses the right types (not overly broad).
 
 ## Implementation
 

--- a/scripts/review/FUNCTION_PR_GUIDE.md
+++ b/scripts/review/FUNCTION_PR_GUIDE.md
@@ -31,7 +31,7 @@ functions, or special forms. Use alongside `SELF_REVIEW.md`.
 - [ ] Use `SimpleFunction` API for scalar functions when possible.
 - [ ] Use `SimpleAggregateAdapter` for aggregate functions when possible.
       Before concluding it doesn't support your use case, check the actual
-      header — it supports HSA, custom `destroy()`, variable-size
+      header — it supports `HashStringAllocator`, custom `destroy()`, variable-size
       accumulators, and external memory.
 - [ ] `default_null_behavior_` is set correctly. Functions that produce
       non-null output for null inputs (e.g., `IS NULL`, aggregate functions

--- a/scripts/review/FUNCTION_PR_GUIDE.md
+++ b/scripts/review/FUNCTION_PR_GUIDE.md
@@ -35,9 +35,10 @@ functions, or special forms. Use alongside `SELF_REVIEW.md`.
 - [ ] Input validation uses the [non-throwing error path](https://velox-lib.io/blog/optimize-try-more#non-throwing-simple-functions)
       (`Status` / `setError`) so functions work correctly inside `TRY`.
       Use `VELOX_CHECK_*` only for internal invariants that indicate bugs.
-- [ ] `EvalCtx::moveOrCopyResult` is used when a function may be called
-      with a pre-existing result vector (e.g., inside `SwitchExpr` /
-      `IF` / `CASE WHEN`). Do not unconditionally replace `result`.
+- [ ] For vector functions and special forms: `EvalCtx::moveOrCopyResult`
+      is used when the function may be called with a pre-existing result
+      vector (e.g., inside `IF` / `CASE WHEN`). Do not unconditionally
+      replace `result`.
 
 ## Aggregate functions
 

--- a/scripts/review/FUNCTION_PR_GUIDE.md
+++ b/scripts/review/FUNCTION_PR_GUIDE.md
@@ -40,11 +40,3 @@ functions, or special forms. Use alongside `SELF_REVIEW.md`.
       vector (e.g., inside `IF` / `CASE WHEN`). Do not unconditionally
       replace `result`.
 
-## Naming
-
-- [ ] File names match: `FunctionName.cpp`, `FunctionName.h`,
-      `FunctionNameTest.cpp`.
-- [ ] Class name matches the function: `FunctionNameFunction` or
-      `FunctionNameAggregate`.
-- [ ] Test fixture name matches: `FunctionNameTest`.
-- [ ] Enum values for function variants use `kPascalCase`.

--- a/scripts/review/FUNCTION_PR_GUIDE.md
+++ b/scripts/review/FUNCTION_PR_GUIDE.md
@@ -32,11 +32,9 @@ functions, or special forms. Use alongside `SELF_REVIEW.md`.
 - [ ] `default_null_behavior_` is set correctly. Functions that produce
       non-null output for null inputs (e.g., `IS NULL`, aggregate functions
       returning default values) must set this to `false`.
-- [ ] Input validation uses `VELOX_USER_CHECK_*` (user-facing errors), not
-      `VELOX_CHECK_*` (internal invariants). Intermediate/internal
-      validation uses `VELOX_CHECK_*`.
-- [ ] Error messages are user-friendly and include the actual values that
-      caused the error.
+- [ ] Input validation uses the [non-throwing error path](https://velox-lib.io/blog/optimize-try-more#non-throwing-simple-functions)
+      (`Status` / `setError`) so functions work correctly inside `TRY`.
+      Use `VELOX_CHECK_*` only for internal invariants that indicate bugs.
 - [ ] `EvalCtx::moveOrCopyResult` is used when a function may be called
       with a pre-existing result vector (e.g., inside `SwitchExpr` /
       `IF` / `CASE WHEN`). Do not unconditionally replace `result`.

--- a/scripts/review/FUNCTION_PR_GUIDE.md
+++ b/scripts/review/FUNCTION_PR_GUIDE.md
@@ -5,8 +5,10 @@ functions, or special forms. Use alongside `SELF_REVIEW.md`.
 
 ## PR title
 
-When adding a new function, use:
-`feat(presto|spark): Add xxx scalar|aggregate function`
+When adding a new function, follow this pattern:
+
+- `feat(presto): Add abs scalar function`
+- `feat(spark): Add bitmap_or_agg aggregate function`
 
 ## Documentation
 

--- a/scripts/review/FUNCTION_PR_GUIDE.md
+++ b/scripts/review/FUNCTION_PR_GUIDE.md
@@ -38,8 +38,10 @@ functions, or special forms. Use alongside `SELF_REVIEW.md`.
       header — it supports `HashStringAllocator`, custom `destroy()`, variable-size
       accumulators, and external memory.
 - [ ] Input validation uses the [non-throwing error path](https://velox-lib.io/blog/optimize-try-more#non-throwing-simple-functions)
-      (`Status` / `setError`) so functions work correctly inside `TRY`.
-      Use `VELOX_CHECK_*` only for internal invariants that indicate bugs.
+      (`Status` / `setError`) so functions work correctly and efficiently
+      inside `TRY` — throwing exceptions in C++ is extremely expensive due
+      to stack trace capture. Use `VELOX_CHECK_*` only for internal
+      invariants that indicate bugs.
 - [ ] For vector functions and special forms: `EvalCtx::moveOrCopyResult`
       is used when the function may be called with a pre-existing result
       vector (e.g., inside `IF` / `CASE WHEN`). Do not unconditionally

--- a/scripts/review/FUNCTION_PR_GUIDE.md
+++ b/scripts/review/FUNCTION_PR_GUIDE.md
@@ -1,0 +1,88 @@
+# Function PR Review Guide
+
+Additional checklist for PRs that add or modify scalar functions, aggregate
+functions, or special forms. Use alongside `SELF_REVIEW.md`.
+
+## Documentation
+
+- [ ] Doc entry exists in the correct `.rst` file under `docs/functions/`
+      (e.g., `docs/functions/spark/aggregate.rst`,
+      `docs/functions/presto/math.rst`).
+- [ ] Doc entry uses the correct directive (e.g., `.. spark:function::`,
+      `.. function::`).
+- [ ] Signature matches the implementation: argument types, return type,
+      nullability.
+- [ ] Behavior is described precisely: edge cases, null handling, error
+      conditions, valid input ranges.
+- [ ] If the function mirrors a function in another engine (Spark, Presto),
+      link to the canonical spec rather than copying its description.
+
+## Registration
+
+- [ ] Function is registered in the correct `Register.cpp`.
+- [ ] Registration name matches the engine's canonical name.
+- [ ] Prefix handling is correct (`prefix + "function_name"`).
+- [ ] `withCompanionFunctions` and `overwrite` parameters are plumbed
+      through.
+- [ ] Function signature uses the right types (not overly broad).
+
+## Implementation
+
+- [ ] Use `SimpleFunction` API for scalar functions when possible.
+- [ ] Use `SimpleAggregateAdapter` for aggregate functions when possible.
+      If you claim it doesn't support your use case, verify against the
+      actual header — it supports HSA, custom `destroy()`,
+      variable-size accumulators, and external memory.
+- [ ] `default_null_behavior_` is set correctly. Functions that produce
+      non-null output for null inputs (e.g., `IS NULL`, aggregate functions
+      returning default values) must set this to `false`.
+- [ ] Input validation uses `VELOX_USER_CHECK_*` (user-facing errors), not
+      `VELOX_CHECK_*` (internal invariants). Intermediate/internal
+      validation uses `VELOX_CHECK_*`.
+- [ ] Error messages are user-friendly and include the actual values that
+      caused the error.
+- [ ] `EvalCtx::moveOrCopyResult` is used when a function may be called
+      with a pre-existing result vector (e.g., inside `SwitchExpr` /
+      `IF` / `CASE WHEN`). Do not unconditionally replace `result`.
+
+## Aggregate functions
+
+- [ ] All aggregation steps work correctly: partial, intermediate, final,
+      and single.
+- [ ] `combine` (merge) handles null intermediate states.
+- [ ] Memory allocated through `HashStringAllocator` is freed in
+      `destroy()`.
+- [ ] `use_external_memory_` is set to `true` if the accumulator allocates
+      through `HashStringAllocator`.
+- [ ] `is_fixed_size_` is set correctly.
+
+## Tests
+
+- [ ] Test file exists in the `tests/` subdirectory alongside the source.
+- [ ] Test file is added to `CMakeLists.txt`.
+- [ ] Tests cover: basic operation, null inputs, empty input, edge cases,
+      error cases (invalid input with `VELOX_ASSERT_THROW`).
+- [ ] For aggregate functions: tests cover `testAggregations` (exercises
+      all aggregation modes), group-by, global aggregation, and an
+      end-to-end test with upstream functions if applicable.
+- [ ] For bug fixes: an integration test with the actual expression context
+      (e.g., `SWITCH`, `IF`, `TRY`) that triggered the bug, not just
+      direct function calls.
+- [ ] Expected values are derived from the Spark/Presto spec or reference
+      implementation, not hand-computed from the code being tested.
+
+## Special forms
+
+- [ ] Type resolution works through the standard `resolveType` path.
+- [ ] If type resolution requires constant argument values, discuss the
+      approach with the reviewer before modifying the framework.
+- [ ] `constructSpecialForm` is implemented correctly.
+
+## Naming
+
+- [ ] File names match: `FunctionName.cpp`, `FunctionName.h`,
+      `FunctionNameTest.cpp`.
+- [ ] Class name matches the function: `FunctionNameFunction` or
+      `FunctionNameAggregate`.
+- [ ] Test fixture name matches: `FunctionNameTest`.
+- [ ] Enum values for function variants use `kPascalCase`.

--- a/scripts/review/FUNCTION_PR_GUIDE.md
+++ b/scripts/review/FUNCTION_PR_GUIDE.md
@@ -44,7 +44,7 @@ functions, or special forms. Use alongside `SELF_REVIEW.md`.
       invariants that indicate bugs.
 - [ ] Watch for unnecessary string copies and allocations. Functions that
       process strings are called per-row and small inefficiencies add up
-      quickly. Prefer `StringView` and in-place operations over
+      quickly. Prefer `std::string_view` and in-place operations over
       `std::string` temporaries.
 - [ ] For vector functions and special forms: `EvalCtx::moveOrCopyResult`
       is used when the function may be called with a pre-existing result

--- a/scripts/review/FUNCTION_PR_GUIDE.md
+++ b/scripts/review/FUNCTION_PR_GUIDE.md
@@ -12,7 +12,8 @@ When adding a new function, use:
 
 - [ ] Doc entry exists in the correct `.rst` file under `docs/functions/`
       (e.g., `docs/functions/spark/aggregate.rst`,
-      `docs/functions/presto/math.rst`).
+      `docs/functions/presto/math.rst`). Functions must appear in
+      alphabetical order.
 - [ ] Doc entry uses the correct directive (e.g., `.. spark:function::`,
       `.. function::`).
 - [ ] Signature matches the implementation: argument types, return type,

--- a/scripts/review/FUNCTION_PR_GUIDE.md
+++ b/scripts/review/FUNCTION_PR_GUIDE.md
@@ -50,4 +50,3 @@ functions, or special forms. Use alongside `SELF_REVIEW.md`.
       is used when the function may be called with a pre-existing result
       vector (e.g., inside `IF` / `CASE WHEN`). Do not unconditionally
       replace `result`.
-

--- a/scripts/review/FUNCTION_PR_GUIDE.md
+++ b/scripts/review/FUNCTION_PR_GUIDE.md
@@ -40,28 +40,6 @@ functions, or special forms. Use alongside `SELF_REVIEW.md`.
       vector (e.g., inside `IF` / `CASE WHEN`). Do not unconditionally
       replace `result`.
 
-## Tests
-
-- [ ] Test file exists in the `tests/` subdirectory alongside the source.
-- [ ] Test file is added to `CMakeLists.txt`.
-- [ ] Tests cover: basic operation, null inputs, empty input, edge cases,
-      error cases (invalid input with `VELOX_ASSERT_THROW`).
-- [ ] For aggregate functions: tests cover `testAggregations` (exercises
-      all aggregation modes), group-by, global aggregation, and an
-      end-to-end test with upstream functions if applicable.
-- [ ] For bug fixes: an integration test with the actual expression context
-      (e.g., `SWITCH`, `IF`, `TRY`) that triggered the bug, not just
-      direct function calls.
-- [ ] Expected values are derived from the Spark/Presto spec or reference
-      implementation, not hand-computed from the code being tested.
-
-## Special forms
-
-- [ ] Type resolution works through the standard `resolveType` path.
-- [ ] If type resolution requires constant argument values, discuss the
-      approach with the reviewer before modifying the framework.
-- [ ] `constructSpecialForm` is implemented correctly.
-
 ## Naming
 
 - [ ] File names match: `FunctionName.cpp`, `FunctionName.h`,

--- a/scripts/review/FUNCTION_PR_GUIDE.md
+++ b/scripts/review/FUNCTION_PR_GUIDE.md
@@ -30,9 +30,9 @@ functions, or special forms. Use alongside `SELF_REVIEW.md`.
 
 - [ ] Use `SimpleFunction` API for scalar functions when possible.
 - [ ] Use `SimpleAggregateAdapter` for aggregate functions when possible.
-      If you claim it doesn't support your use case, verify against the
-      actual header — it supports HSA, custom `destroy()`,
-      variable-size accumulators, and external memory.
+      Before concluding it doesn't support your use case, check the actual
+      header — it supports HSA, custom `destroy()`, variable-size
+      accumulators, and external memory.
 - [ ] `default_null_behavior_` is set correctly. Functions that produce
       non-null output for null inputs (e.g., `IS NULL`, aggregate functions
       returning default values) must set this to `false`.

--- a/scripts/review/FUNCTION_PR_GUIDE.md
+++ b/scripts/review/FUNCTION_PR_GUIDE.md
@@ -37,9 +37,6 @@ When adding a new function, follow this pattern:
       Before concluding it doesn't support your use case, check the actual
       header — it supports `HashStringAllocator`, custom `destroy()`, variable-size
       accumulators, and external memory.
-- [ ] `default_null_behavior_` is set correctly. Functions that produce
-      non-null output for null inputs (e.g., `IS NULL`, aggregate functions
-      returning default values) must set this to `false`.
 - [ ] Input validation uses the [non-throwing error path](https://velox-lib.io/blog/optimize-try-more#non-throwing-simple-functions)
       (`Status` / `setError`) so functions work correctly inside `TRY`.
       Use `VELOX_CHECK_*` only for internal invariants that indicate bugs.

--- a/scripts/review/FUNCTION_PR_GUIDE.md
+++ b/scripts/review/FUNCTION_PR_GUIDE.md
@@ -42,6 +42,10 @@ functions, or special forms. Use alongside `SELF_REVIEW.md`.
       inside `TRY` — throwing exceptions in C++ is extremely expensive due
       to stack trace capture. Use `VELOX_CHECK_*` only for internal
       invariants that indicate bugs.
+- [ ] Watch for unnecessary string copies and allocations. Functions that
+      process strings are called per-row and small inefficiencies add up
+      quickly. Prefer `StringView` and in-place operations over
+      `std::string` temporaries.
 - [ ] For vector functions and special forms: `EvalCtx::moveOrCopyResult`
       is used when the function may be called with a pre-existing result
       vector (e.g., inside `IF` / `CASE WHEN`). Do not unconditionally

--- a/scripts/review/FUNCTION_PR_GUIDE.md
+++ b/scripts/review/FUNCTION_PR_GUIDE.md
@@ -40,17 +40,6 @@ functions, or special forms. Use alongside `SELF_REVIEW.md`.
       vector (e.g., inside `IF` / `CASE WHEN`). Do not unconditionally
       replace `result`.
 
-## Aggregate functions
-
-- [ ] All aggregation steps work correctly: partial, intermediate, final,
-      and single.
-- [ ] `combine` (merge) handles null intermediate states.
-- [ ] Memory allocated through `HashStringAllocator` is freed in
-      `destroy()`.
-- [ ] `use_external_memory_` is set to `true` if the accumulator allocates
-      through `HashStringAllocator`.
-- [ ] `is_fixed_size_` is set correctly.
-
 ## Tests
 
 - [ ] Test file exists in the `tests/` subdirectory alongside the source.

--- a/scripts/review/REVIEW_GUIDE.md
+++ b/scripts/review/REVIEW_GUIDE.md
@@ -111,6 +111,9 @@ and refer back.
   duplication? Do test names follow conventions?
 - **Test files.** Each test file should have one test suite with a matching
   name. Empty test fixtures should use `TEST()` instead of `TEST_F()`.
+- **Error message tests.** When tests verify error messages, ensure they
+  match the full descriptive text, not just internal formatting from CHECK
+  macros (e.g., `"(0 vs. 0)"` is not a useful assertion).
 
 ### Documentation
 
@@ -123,7 +126,4 @@ and refer back.
   existing subsystem, check that stats and `toString()` distinguish the new
   operations from existing ones. Shared counters hide information needed
   for troubleshooting.
-- **Error message tests.** When tests verify error messages, ensure they
-  match the full descriptive text, not just internal formatting from CHECK
-  macros (e.g., `"(0 vs. 0)"` is not a useful assertion).
 - **When unsure about conventions**, CC the maintainer rather than guessing.

--- a/scripts/review/REVIEW_GUIDE.md
+++ b/scripts/review/REVIEW_GUIDE.md
@@ -56,6 +56,22 @@ When the author says "addressed comments", re-review the full diff — don't
 just check the boxes from the previous round. Docs, naming, design choices,
 and new code added while addressing feedback all need fresh eyes.
 
+### Re-review rejected
+
+When the author requests re-review but clearly hasn't fully addressed prior
+feedback (e.g., explicitly flagged bugs still present, items silently
+skipped, sloppy fixes), lead with a process comment before the technical
+points:
+
+> @author, please review your changes more carefully before requesting
+> re-review. [Specific example: "The UB bug was explicitly flagged with a
+> fix, yet it's still present."]. Each re-review round costs reviewer
+> time — please make sure feedback is fully addressed.
+
+Then list the remaining issues. Don't re-explain items that were already
+explained with code snippets in the previous round — just say "not fixed"
+and refer back.
+
 ## What to check
 
 ### Correctness
@@ -103,4 +119,11 @@ and new code added while addressing feedback all need fresh eyes.
 - Check if **existing** doc pages need updating — e.g., a change to plan output
   may require updating the print-plan-with-stats page, a dependency version
   bump may require updating the dependency table.
+- **Debuggability of new APIs.** When a PR adds new operations to an
+  existing subsystem, check that stats and `toString()` distinguish the new
+  operations from existing ones. Shared counters hide information needed
+  for troubleshooting.
+- **Error message tests.** When tests verify error messages, ensure they
+  match the full descriptive text, not just internal formatting from CHECK
+  macros (e.g., `"(0 vs. 0)"` is not a useful assertion).
 - **When unsure about conventions**, CC the maintainer rather than guessing.

--- a/scripts/review/REVIEW_GUIDE.md
+++ b/scripts/review/REVIEW_GUIDE.md
@@ -112,8 +112,8 @@ and refer back.
 - **Test files.** Each test file should have one test suite with a matching
   name. Empty test fixtures should use `TEST()` instead of `TEST_F()`.
 - **Error message tests.** When tests verify error messages, ensure they
-  match the full descriptive text, not just internal formatting from CHECK
-  macros (e.g., `"(0 vs. 0)"` is not a useful assertion).
+  match the full descriptive text, not just the auto-generated comparison
+  output from `VELOX_CHECK_*` macros.
 
 ### Documentation
 

--- a/scripts/review/REVIEW_GUIDE.md
+++ b/scripts/review/REVIEW_GUIDE.md
@@ -98,7 +98,8 @@ and refer back.
   [.claude/CLAUDE.md](../../.claude/CLAUDE.md).
 - **Comments.** Flag verbose code comments that restate the code, duplicate
   docs elsewhere, or explain obvious behavior. Remove references to other
-  implementations ("like Java Presto") — logic should stand on its own.
+  implementations ("like Java Presto") unless the goal is to match that
+  engine's semantics — logic should stand on its own.
 - **Naming.** Check variable names, file names, class names against coding
   style conventions. Do not abbreviate parameter names.
 - **Enums.** `kPascalCase` enumerators, trailing commas, `VELOX_DEFINE_ENUM_NAME`.

--- a/scripts/review/SELF_REVIEW.md
+++ b/scripts/review/SELF_REVIEW.md
@@ -5,12 +5,6 @@ AI tool, paste this file as context and ask it to review your diff against
 these rules. Most items come from recurring review feedback — fixing them
 before review saves everyone time.
 
-We want to provide timely, thorough reviews on every PR. When reviewers
-spend rounds on naming, style, and conventions, it delays feedback on
-design and correctness — for your PR and for others waiting in the queue.
-PRs that repeatedly miss these basics may be sent back for self-review
-before a detailed review can begin.
-
 ## Before requesting review
 
 - [ ] CI is green.

--- a/scripts/review/SELF_REVIEW.md
+++ b/scripts/review/SELF_REVIEW.md
@@ -10,7 +10,8 @@ before review saves everyone time.
 - [ ] CI is green.
 - [ ] PR title describes what changed (not the symptom or the ticket).
 - [ ] PR description matches what the code actually does. If the scope grew
-      beyond the original description, update it.
+      beyond the original description, update it. Do not include test
+      results or pass/fail status — CI reports that.
 
 ## Naming
 

--- a/scripts/review/SELF_REVIEW.md
+++ b/scripts/review/SELF_REVIEW.md
@@ -65,7 +65,7 @@ before review saves everyone time.
 - [ ] No duplicated test helpers across files. Extract to a shared header.
 - [ ] `TEST()` for empty fixtures, `TEST_F()` only when the fixture is used.
 - [ ] Error message assertions match the full descriptive text, not just
-      internal formatting like `"(0 vs. 0)"`.
+      the auto-generated comparison output from `VELOX_CHECK_*` macros.
 - [ ] Each test file has one test suite with a matching name.
 
 ## Documentation
@@ -93,7 +93,8 @@ Before requesting re-review after addressing feedback:
       reply. Do not silently skip items.
 - [ ] Run the full diff review again — don't just fix the flagged lines.
       Addressing feedback often introduces new issues.
-- [ ] Check that behavioral changes (e.g., dropping IO stats, changing
-      exception to nullptr) are intentional and mentioned.
+- [ ] Check that behavioral changes (e.g., removing configuration that
+      existing code relied on, changing error handling from throwing to
+      returning null) are intentional and mentioned.
 - [ ] If a requested change is too large for this PR, say so and propose
       a plan (e.g., separate PR). Do not silently skip it.

--- a/scripts/review/SELF_REVIEW.md
+++ b/scripts/review/SELF_REVIEW.md
@@ -1,0 +1,98 @@
+# Self-Review Checklist for Contributors
+
+Run this checklist before requesting review. If you use Claude or a similar
+AI tool, paste this file as context and ask it to review your diff against
+these rules. Most items come from recurring review feedback — fixing them
+before review saves everyone time.
+
+## Before requesting review
+
+- [ ] CI is green.
+- [ ] PR title describes what changed (not the symptom or the ticket).
+- [ ] PR description matches what the code actually does. If the scope grew
+      beyond the original description, update it.
+- [ ] Every review comment from the previous round is either addressed in
+      code or discussed in a reply. Do not silently skip items.
+
+## Naming
+
+- [ ] No abbreviated variable names. Use `array`, not `arr`. Use `value`,
+      not `val`. Use `count`, not `cnt`. Use `byteIndex`, not `idx`.
+      Only loop indices (`i`, `j`) are acceptable.
+- [ ] No numbered or lettered variables (`bitmap1`, `bitmapA`, `rows2`).
+      Use descriptive names that convey meaning, or inline the value to
+      avoid naming altogether.
+- [ ] Parameter names are consistent within a function and across related
+      functions. Don't use `arg` in one place and `input` in another for
+      the same concept.
+
+## Code
+
+- [ ] No non-trivial implementations in headers. If a method body has more
+      than one statement, it belongs in the `.cpp` file.
+- [ ] No setter injection when the value could be a constructor parameter.
+- [ ] No comments referencing other implementations ("like Java Presto",
+      "similar to Spark's X"). Logic should stand on its own.
+- [ ] No unnecessary type aliases (`using ConnectorConfig = ...` when used once).
+- [ ] No unnecessary `static_cast` when the type already matches.
+- [ ] No undefined behavior in evaluation order. Watch for
+      `{std::move(x), x->method()}` — evaluation order of arguments is
+      unspecified.
+- [ ] Existing utility methods are used instead of inline boilerplate.
+      Search for existing helpers before writing your own.
+- [ ] Constants shared across files are in a common header, not duplicated.
+
+## Error handling
+
+- [ ] `VELOX_CHECK_*` for internal invariants, `VELOX_USER_CHECK_*` for
+      user-facing input validation. Don't mix them up.
+- [ ] Error messages match the check. `VELOX_CHECK_GE(x, 0)` should not say
+      "greater than 0" — it checks `>= 0`.
+- [ ] Error messages are descriptive. `VELOX_CHECK_*` macros already append
+      compared values — don't repeat them in the custom message.
+- [ ] Validation is consistent: if a function requires exactly N bytes,
+      don't silently skip invalid inputs before the check.
+
+## Tests
+
+- [ ] Bug fixes: write the test first, confirm it fails without the fix,
+      then apply the fix. A test that passes with and without the fix proves
+      nothing.
+- [ ] No copy-pasted test blocks. If two tests differ only in one parameter,
+      use a loop or a local lambda.
+- [ ] Use existing test helpers (`makeArrayFromJson`, `makeBitmapVector`,
+      etc.) instead of verbose manual construction.
+- [ ] No duplicated test helpers across files. Extract to a shared header.
+- [ ] `TEST()` for empty fixtures, `TEST_F()` only when the fixture is used.
+- [ ] Error message assertions match the full descriptive text, not just
+      internal formatting like `"(0 vs. 0)"`.
+- [ ] Each test file has one test suite with a matching name.
+
+## Documentation
+
+- [ ] New functions and features have doc entries (e.g., in
+      `docs/functions/spark/aggregate.rst`).
+- [ ] No unexplained jargon. Define acronyms and domain terms.
+- [ ] Check if existing doc pages need updating when behavior changes.
+
+## API changes
+
+- [ ] New API surface is documented in the header.
+- [ ] No redundant parameters (can types be derived from richer inputs?).
+- [ ] Method names are consistent with stat/counter names they update.
+- [ ] Consider debuggability: can you tell what's happening from
+      stats/toString output?
+- [ ] If the PR touches public APIs beyond the original scope, discuss
+      with the reviewer first. Do not silently expand scope.
+
+## Re-review checklist
+
+Before requesting re-review after addressing feedback:
+
+- [ ] Re-read every review comment. Confirm each is addressed or discussed.
+- [ ] Run the full diff review again — don't just fix the flagged lines.
+      Addressing feedback often introduces new issues.
+- [ ] Check that behavioral changes (e.g., dropping IO stats, changing
+      exception to nullptr) are intentional and mentioned.
+- [ ] If a requested change is too large for this PR, say so and propose
+      a plan (e.g., separate PR). Do not silently skip it.

--- a/scripts/review/SELF_REVIEW.md
+++ b/scripts/review/SELF_REVIEW.md
@@ -31,7 +31,8 @@ before review saves everyone time.
       than one statement, it belongs in the `.cpp` file.
 - [ ] No setter injection when the value could be a constructor parameter.
 - [ ] No comments referencing other implementations ("like Java Presto",
-      "similar to Spark's X"). Logic should stand on its own.
+      "similar to Spark's X") unless the goal is to match that engine's
+      semantics. Logic should stand on its own.
 - [ ] No unnecessary type aliases (`using ConnectorConfig = ...` when used once).
 - [ ] No unnecessary `static_cast` when the type already matches.
 - [ ] No undefined behavior in evaluation order. Watch for

--- a/scripts/review/SELF_REVIEW.md
+++ b/scripts/review/SELF_REVIEW.md
@@ -11,8 +11,6 @@ before review saves everyone time.
 - [ ] PR title describes what changed (not the symptom or the ticket).
 - [ ] PR description matches what the code actually does. If the scope grew
       beyond the original description, update it.
-- [ ] Every review comment from the previous round is either addressed in
-      code or discussed in a reply. Do not silently skip items.
 
 ## Naming
 
@@ -89,7 +87,8 @@ before review saves everyone time.
 
 Before requesting re-review after addressing feedback:
 
-- [ ] Re-read every review comment. Confirm each is addressed or discussed.
+- [ ] Every review comment is either addressed in code or discussed in a
+      reply. Do not silently skip items.
 - [ ] Run the full diff review again — don't just fix the flagged lines.
       Addressing feedback often introduces new issues.
 - [ ] Check that behavioral changes (e.g., dropping IO stats, changing

--- a/scripts/review/SELF_REVIEW.md
+++ b/scripts/review/SELF_REVIEW.md
@@ -5,6 +5,12 @@ AI tool, paste this file as context and ask it to review your diff against
 these rules. Most items come from recurring review feedback — fixing them
 before review saves everyone time.
 
+We want to provide timely, thorough reviews on every PR. When reviewers
+spend rounds on naming, style, and conventions, it delays feedback on
+design and correctness — for your PR and for others waiting in the queue.
+PRs that repeatedly miss these basics may be sent back for self-review
+before a detailed review can begin.
+
 ## Before requesting review
 
 - [ ] CI is green.

--- a/scripts/review/SELF_REVIEW.md
+++ b/scripts/review/SELF_REVIEW.md
@@ -45,7 +45,9 @@ before review saves everyone time.
 ## Error handling
 
 - [ ] `VELOX_CHECK_*` for internal invariants, `VELOX_USER_CHECK_*` for
-      user-facing input validation. Don't mix them up.
+      user-facing input validation. Don't mix them up. For functions,
+      prefer the [non-throwing error path](https://velox-lib.io/blog/optimize-try-more#non-throwing-simple-functions)
+      instead — see the [Function PR Guide](FUNCTION_PR_GUIDE.md).
 - [ ] Error messages match the check. `VELOX_CHECK_GE(x, 0)` should not say
       "greater than 0" — it checks `>= 0`.
 - [ ] Error messages are descriptive. `VELOX_CHECK_*` macros already append


### PR DESCRIPTION
## Summary
- Add `scripts/review/SELF_REVIEW.md` — general self-review checklist covering naming, code quality, error handling, tests, documentation, API changes, and re-review process.
- Add `scripts/review/FUNCTION_PR_GUIDE.md` — function-specific checklist covering PR title conventions, documentation (.rst), registration, and implementation.
- Update `scripts/review/REVIEW_GUIDE.md` — add "re-review rejected" template, error message test and debuggability checks.
- Update `CONTRIBUTING.md` — add self-review step to the contribution process, link to both checklists, add re-review guidance, align function PR title convention.
- Update `CODING_STYLE.md` — add rules for numbered variables, referencing other implementations, error message accuracy, shared constants, constructor parameters over setters, test structure. Link to new checklists.

All checklist items are derived from recurring PR review feedback.

## Test plan
- Documentation-only change, no code modifications.