### PR TITLE
refactor(parquet): Refactor parquet reader test

### DIFF
--- a/velox/dwio/parquet/tests/CMakeLists.txt
+++ b/velox/dwio/parquet/tests/CMakeLists.txt
@@ -19,12 +19,26 @@ set(
   velox_exec_test_lib
   velox_dwio_parquet_reader
   velox_dwio_parquet_writer
+  velox_dwio_parquet_test_base
   velox_test_util
   GTest::gtest
   GTest::gtest_main
   GTest::gmock
   gflags::gflags
   glog::glog
+)
+
+add_library(velox_dwio_parquet_test_base ParquetTestBase.cpp)
+velox_add_test_headers(velox_dwio_parquet_test_base ParquetTestBase.h)
+target_link_libraries(
+  velox_dwio_parquet_test_base
+  velox_dwio_parquet_reader
+  velox_dwio_parquet_writer
+  velox_vector_fuzzer
+  velox_vector_test_lib
+  velox_dwio_common_test_utils
+  GTest::gtest
+  GTest::gmock
 )
 
 add_subdirectory(common)
@@ -47,5 +61,3 @@ target_link_libraries(
 )
 
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/examples DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-
-velox_add_library(velox_dwio_parquet_test_base INTERFACE HEADERS ParquetTestBase.h)

--- a/velox/dwio/parquet/tests/ParquetTestBase.cpp
+++ b/velox/dwio/parquet/tests/ParquetTestBase.cpp
@@ -1,0 +1,254 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/parquet/tests/ParquetTestBase.h"
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::parquet {
+
+ParquetTestReaderBuilder::ParquetTestReaderBuilder(ParquetTestBase* testBase)
+    : testBase_(testBase) {}
+
+ParquetTestReaderBuilder& ParquetTestReaderBuilder::file(
+    const std::string& fileName) {
+  fileName_ = fileName;
+  sink_ = nullptr;
+  return *this;
+}
+
+ParquetTestReaderBuilder& ParquetTestReaderBuilder::sink(
+    const dwio::common::MemorySink& sink) {
+  sink_ = &sink;
+  fileName_.reset();
+  return *this;
+}
+
+ParquetTestReaderBuilder& ParquetTestReaderBuilder::schema(
+    const RowTypePtr& rowType) {
+  schema_ = rowType;
+  return *this;
+}
+
+ParquetTestReaderBuilder& ParquetTestReaderBuilder::range(
+    uint64_t offset,
+    uint64_t length) {
+  range_ = {offset, length};
+  return *this;
+}
+
+ParquetTestReaderBuilder& ParquetTestReaderBuilder::noColumnSelector() {
+  noColumnSelector_ = true;
+  return *this;
+}
+
+ParquetTestReaderBuilder& ParquetTestReaderBuilder::readerOptions(
+    const dwio::common::ReaderOptions& readerOptions) {
+  readerOptions_ = readerOptions;
+  return *this;
+}
+
+std::pair<
+    std::unique_ptr<ParquetReader>,
+    std::unique_ptr<dwio::common::RowReader>>
+ParquetTestReaderBuilder::build() {
+  VELOX_CHECK(schema_ != nullptr, "schema is required");
+  VELOX_CHECK(
+      fileName_.has_value() ^ (sink_ != nullptr),
+      "either file or sink must be set");
+
+  auto readerOpts =
+      readerOptions_.value_or(testBase_->makeDefaultReaderOptions());
+  std::unique_ptr<ParquetReader> reader;
+  if (sink_ != nullptr) {
+    reader = testBase_->createReaderInMemory(*sink_, readerOpts);
+  } else {
+    reader = testBase_->createReader(*fileName_, readerOpts);
+  }
+
+  dwio::common::RowReaderOptions rowReaderOpts;
+  if (!noColumnSelector_) {
+    rowReaderOpts = testBase_->makeRowReaderOpts(schema_);
+  }
+  rowReaderOpts.setScanSpec(testBase_->makeScanSpec(schema_));
+  if (range_.has_value()) {
+    rowReaderOpts.range(range_->first, range_->second);
+  }
+  auto rowReader = reader->createRowReader(rowReaderOpts);
+  return {std::move(reader), std::move(rowReader)};
+}
+
+std::unique_ptr<facebook::velox::parquet::ParquetReader>
+ParquetTestBase::createReader(
+    const std::string& fileName,
+    const dwio::common::ReaderOptions& opts) {
+  const auto path = getExampleFilePath(fileName);
+  auto input = std::make_unique<dwio::common::BufferedInput>(
+      std::make_shared<LocalReadFile>(path), opts.memoryPool());
+  return std::make_unique<facebook::velox::parquet::ParquetReader>(
+      std::move(input), opts);
+}
+
+void ParquetTestBase::assertEqualVectorPart(
+    const VectorPtr& expected,
+    const VectorPtr& actual,
+    vector_size_t offset) {
+  ASSERT_GE(expected->size(), actual->size() + offset);
+  ASSERT_EQ(expected->typeKind(), actual->typeKind());
+  for (vector_size_t i = 0; i < actual->size(); i++) {
+    ASSERT_TRUE(expected->equalValueAt(actual.get(), i + offset, i))
+        << "at " << (i + offset) << ": expected "
+        << expected->toString(i + offset) << ", but got "
+        << actual->toString(i);
+  }
+}
+
+void ParquetTestBase::assertReadWithReaderAndExpected(
+    std::shared_ptr<const RowType> outputType,
+    dwio::common::RowReader& reader,
+    RowVectorPtr expected,
+    memory::MemoryPool& memoryPool) {
+  uint64_t total = 0;
+  VectorPtr result = BaseVector::create(outputType, 0, &memoryPool);
+  while (total < expected->size()) {
+    auto part = reader.next(1000, result);
+    if (part > 0) {
+      assertEqualVectorPart(expected, result, total);
+      total += result->size();
+    } else {
+      break;
+    }
+  }
+  EXPECT_EQ(total, expected->size());
+  EXPECT_EQ(reader.next(1000, result), 0);
+}
+
+void ParquetTestBase::assertReadWithReaderAndFilters(
+    dwio::common::Reader& reader,
+    const RowTypePtr& fileSchema,
+    FilterMap filters,
+    const RowVectorPtr& expected) {
+  auto scanSpec = makeScanSpec(fileSchema);
+  for (auto&& [column, filter] : filters) {
+    scanSpec->getOrCreateChild(velox::common::Subfield(column))
+        ->setFilter(std::move(filter));
+  }
+
+  auto rowReaderOpts = makeRowReaderOpts(fileSchema);
+  rowReaderOpts.setScanSpec(scanSpec);
+  auto rowReader = reader.createRowReader(rowReaderOpts);
+  assertReadWithReaderAndExpected(fileSchema, *rowReader, expected, *leafPool_);
+}
+
+std::unique_ptr<dwio::common::FileSink> ParquetTestBase::createSink(
+    const std::string& filePath) {
+  auto sink = dwio::common::FileSink::create(
+      fmt::format("file:{}", filePath), {.pool = rootPool_.get()});
+  EXPECT_TRUE(sink->isBuffered());
+  EXPECT_TRUE(fs::exists(filePath));
+  EXPECT_FALSE(sink->isClosed());
+  return sink;
+}
+
+std::unique_ptr<facebook::velox::parquet::Writer> ParquetTestBase::createWriter(
+    std::unique_ptr<dwio::common::FileSink> sink,
+    std::function<
+        std::unique_ptr<facebook::velox::parquet::DefaultFlushPolicy>()>
+        flushPolicy,
+    const RowTypePtr& rowType,
+    facebook::velox::common::CompressionKind compressionKind) {
+  facebook::velox::parquet::WriterOptions options;
+  options.memoryPool = rootPool_.get();
+  options.flushPolicyFactory = flushPolicy;
+  options.compressionKind = compressionKind;
+  return std::make_unique<facebook::velox::parquet::Writer>(
+      std::move(sink), options, rowType);
+}
+
+std::vector<RowVectorPtr> ParquetTestBase::createBatches(
+    const RowTypePtr& rowType,
+    uint64_t numBatches,
+    uint64_t vectorSize) {
+  std::vector<RowVectorPtr> batches;
+  batches.reserve(numBatches);
+  VectorFuzzer fuzzer({.vectorSize = vectorSize}, leafPool_.get());
+  for (auto i = 0; i < numBatches; ++i) {
+    batches.emplace_back(fuzzer.fuzzInputFlatRow(rowType));
+  }
+  return batches;
+}
+
+dwio::common::MemorySink* ParquetTestBase::write(
+    const RowVectorPtr& data,
+    const WriterOptions& writerOptions,
+    const RowTypePtr& rowType) {
+  auto sink = std::make_unique<dwio::common::MemorySink>(
+      200 * 1024 * 1024,
+      dwio::common::FileSink::Options{.pool = leafPool_.get()});
+  auto* sinkPtr = sink.get();
+  auto writer = std::make_unique<Writer>(
+      std::move(sink),
+      writerOptions,
+      rowType != nullptr ? rowType : data->rowType());
+  writer->write(data);
+  writer->close();
+  writers_.push_back(std::move(writer));
+  return sinkPtr;
+}
+
+dwio::common::MemorySink* ParquetTestBase::write(
+    const RowVectorPtr& data,
+    std::unordered_map<std::string, std::string> configFromFile,
+    std::unordered_map<std::string, std::string> sessionProperties) {
+  parquet::WriterOptions writerOptions;
+  writerOptions.memoryPool = rootPool_.get();
+  auto connectorConfig = config::ConfigBase(std::move(configFromFile));
+  auto connectorSessionProperties =
+      config::ConfigBase(std::move(sessionProperties));
+  writerOptions.processConfigs(connectorConfig, connectorSessionProperties);
+  return write(data, writerOptions);
+}
+
+std::unique_ptr<ParquetReader> ParquetTestBase::createReaderInMemory(
+    const dwio::common::MemorySink& sink,
+    const dwio::common::ReaderOptions& opts) {
+  std::string data(sink.data(), sink.size());
+  return std::make_unique<ParquetReader>(
+      std::make_unique<dwio::common::BufferedInput>(
+          std::make_shared<InMemoryReadFile>(std::move(data)),
+          opts.memoryPool()),
+      opts);
+}
+
+std::unique_ptr<dwio::common::RowReader>
+ParquetTestBase::createRowReaderFromReader(
+    dwio::common::Reader& reader,
+    const RowTypePtr& rowType) {
+  auto rowReaderOpts = makeRowReaderOpts(rowType);
+  rowReaderOpts.setScanSpec(makeScanSpec(rowType));
+  return reader.createRowReader(rowReaderOpts);
+}
+
+std::unique_ptr<dwio::common::RowReader>
+ParquetTestBase::createRowReaderFromReaderNoSelect(
+    dwio::common::Reader& reader,
+    const RowTypePtr& rowType) {
+  dwio::common::RowReaderOptions rowReaderOpts;
+  rowReaderOpts.setScanSpec(makeScanSpec(rowType));
+  return reader.createRowReader(rowReaderOpts);
+}
+
+} // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/tests/ParquetTestBase.cpp
+++ b/velox/dwio/parquet/tests/ParquetTestBase.cpp
@@ -19,43 +19,73 @@
 #include "velox/common/base/Exceptions.h"
 
 namespace facebook::velox::parquet {
+namespace {
 
-ParquetTestReaderBuilder::ParquetTestReaderBuilder(ParquetTestBase* testBase)
-    : testBase_(testBase) {}
-
-ParquetTestReaderBuilder& ParquetTestReaderBuilder::file(
-    const std::string& fileName) {
-  fileName_ = fileName;
-  sink_ = nullptr;
-  return *this;
+dwio::common::ReaderOptions makeReaderOptions(
+    memory::MemoryPool* pool,
+    const std::shared_ptr<velox::io::IoStatistics>& dataIoStats,
+    const std::shared_ptr<velox::io::IoStatistics>& metadataIoStats) {
+  dwio::common::ReaderOptions opts(pool);
+  opts.setDataIoStats(dataIoStats);
+  opts.setMetadataIoStats(metadataIoStats);
+  return opts;
 }
 
-ParquetTestReaderBuilder& ParquetTestReaderBuilder::sink(
-    const dwio::common::MemorySink& sink) {
-  sink_ = &sink;
-  fileName_.reset();
-  return *this;
-}
-
-ParquetTestReaderBuilder& ParquetTestReaderBuilder::schema(
+dwio::common::RowReaderOptions makeRowReaderOptsWithSelector(
     const RowTypePtr& rowType) {
-  schema_ = rowType;
-  return *this;
+  dwio::common::RowReaderOptions rowReaderOpts;
+  rowReaderOpts.select(
+      std::make_shared<dwio::common::ColumnSelector>(
+          rowType, rowType->names(), nullptr, false));
+  return rowReaderOpts;
 }
 
-ParquetTestReaderBuilder& ParquetTestReaderBuilder::range(
+std::shared_ptr<velox::common::ScanSpec> makeScanSpec(
+    const RowTypePtr& rowType) {
+  auto scanSpec = std::make_shared<velox::common::ScanSpec>("");
+  scanSpec->addAllChildFields(*rowType);
+  return scanSpec;
+}
+
+} // namespace
+
+ParquetReaderBuilder::ParquetReaderBuilder(
+    memory::MemoryPool* pool,
+    const std::shared_ptr<velox::io::IoStatistics>& dataIoStats,
+    const std::shared_ptr<velox::io::IoStatistics>& metadataIoStats,
+    const std::string& filePath,
+    const RowTypePtr& outputType)
+    : pool_(pool),
+      dataIoStats_(dataIoStats),
+      metadataIoStats_(metadataIoStats),
+      filePath_(filePath),
+      outputType_(outputType) {}
+
+ParquetReaderBuilder::ParquetReaderBuilder(
+    memory::MemoryPool* pool,
+    const std::shared_ptr<velox::io::IoStatistics>& dataIoStats,
+    const std::shared_ptr<velox::io::IoStatistics>& metadataIoStats,
+    const dwio::common::MemorySink& buffer,
+    const RowTypePtr& outputType)
+    : pool_(pool),
+      dataIoStats_(dataIoStats),
+      metadataIoStats_(metadataIoStats),
+      buffer_(&buffer),
+      outputType_(outputType) {}
+
+ParquetReaderBuilder& ParquetReaderBuilder::byteRange(
     uint64_t offset,
     uint64_t length) {
-  range_ = {offset, length};
+  byteRange_ = {offset, length};
   return *this;
 }
 
-ParquetTestReaderBuilder& ParquetTestReaderBuilder::noColumnSelector() {
-  noColumnSelector_ = true;
+ParquetReaderBuilder& ParquetReaderBuilder::withScanSpecOnly() {
+  withScanSpecOnly_ = true;
   return *this;
 }
 
-ParquetTestReaderBuilder& ParquetTestReaderBuilder::readerOptions(
+ParquetReaderBuilder& ParquetReaderBuilder::options(
     const dwio::common::ReaderOptions& readerOptions) {
   readerOptions_ = readerOptions;
   return *this;
@@ -64,31 +94,41 @@ ParquetTestReaderBuilder& ParquetTestReaderBuilder::readerOptions(
 std::pair<
     std::unique_ptr<ParquetReader>,
     std::unique_ptr<dwio::common::RowReader>>
-ParquetTestReaderBuilder::build() {
-  VELOX_CHECK(schema_ != nullptr, "schema is required");
+ParquetReaderBuilder::build() {
   VELOX_CHECK(
-      fileName_.has_value() ^ (sink_ != nullptr),
-      "either file or sink must be set");
+      filePath_.has_value() ^ (buffer_ != nullptr),
+      "file path or in-memory buffer must be set");
 
-  auto readerOpts =
-      readerOptions_.value_or(testBase_->makeDefaultReaderOptions());
+  auto readerOpts = readerOptions_.value_or(
+      makeReaderOptions(pool_, dataIoStats_, metadataIoStats_));
   std::unique_ptr<ParquetReader> reader;
-  if (sink_ != nullptr) {
-    reader = testBase_->createReaderInMemory(*sink_, readerOpts);
+  if (buffer_ != nullptr) {
+    std::string data(buffer_->data(), buffer_->size());
+    reader = std::make_unique<ParquetReader>(
+        std::make_unique<dwio::common::BufferedInput>(
+            std::make_shared<InMemoryReadFile>(std::move(data)),
+            readerOpts.memoryPool()),
+        readerOpts);
   } else {
-    reader = testBase_->createReader(*fileName_, readerOpts);
+    auto input = std::make_unique<dwio::common::BufferedInput>(
+        std::make_shared<LocalReadFile>(*filePath_), readerOpts.memoryPool());
+    reader = std::make_unique<ParquetReader>(std::move(input), readerOpts);
   }
 
   dwio::common::RowReaderOptions rowReaderOpts;
-  if (!noColumnSelector_) {
-    rowReaderOpts = testBase_->makeRowReaderOpts(schema_);
+  if (!withScanSpecOnly_) {
+    rowReaderOpts = makeRowReaderOptsWithSelector(outputType_);
   }
-  rowReaderOpts.setScanSpec(testBase_->makeScanSpec(schema_));
-  if (range_.has_value()) {
-    rowReaderOpts.range(range_->first, range_->second);
+  rowReaderOpts.setScanSpec(makeScanSpec(outputType_));
+  if (byteRange_.has_value()) {
+    rowReaderOpts.range(byteRange_->first, byteRange_->second);
   }
   auto rowReader = reader->createRowReader(rowReaderOpts);
   return {std::move(reader), std::move(rowReader)};
+}
+
+dwio::common::ReaderOptions ParquetTestBase::makeDefaultReaderOptions() const {
+  return makeReaderOptions(leafPool_.get(), dataIoStats_, metadataIoStats_);
 }
 
 std::unique_ptr<facebook::velox::parquet::ParquetReader>
@@ -236,17 +276,12 @@ std::unique_ptr<ParquetReader> ParquetTestBase::createReaderInMemory(
 std::unique_ptr<dwio::common::RowReader>
 ParquetTestBase::createRowReaderFromReader(
     dwio::common::Reader& reader,
-    const RowTypePtr& rowType) {
-  auto rowReaderOpts = makeRowReaderOpts(rowType);
-  rowReaderOpts.setScanSpec(makeScanSpec(rowType));
-  return reader.createRowReader(rowReaderOpts);
-}
-
-std::unique_ptr<dwio::common::RowReader>
-ParquetTestBase::createRowReaderFromReaderNoSelect(
-    dwio::common::Reader& reader,
-    const RowTypePtr& rowType) {
+    const RowTypePtr& rowType,
+    bool useColumnSelector) {
   dwio::common::RowReaderOptions rowReaderOpts;
+  if (useColumnSelector) {
+    rowReaderOpts = makeRowReaderOpts(rowType);
+  }
   rowReaderOpts.setScanSpec(makeScanSpec(rowType));
   return reader.createRowReader(rowReaderOpts);
 }

--- a/velox/dwio/parquet/tests/ParquetTestBase.h
+++ b/velox/dwio/parquet/tests/ParquetTestBase.h
@@ -17,7 +17,9 @@
 #pragma once
 
 #include <gtest/gtest.h>
+#include <optional>
 #include <string>
+#include <utility>
 #include "velox/common/base/Fs.h"
 #include "velox/common/file/File.h"
 #include "velox/common/io/IoStatistics.h"
@@ -34,8 +36,46 @@
 namespace facebook::velox::parquet {
 using TempDirectoryPath = common::testutil::TempDirectoryPath;
 
+class ParquetTestBase;
+
+/// Fluent builder for creating ParquetReader + RowReader pairs in tests.
+class ParquetTestReaderBuilder {
+ public:
+  ParquetTestReaderBuilder& file(const std::string& fileName);
+
+  ParquetTestReaderBuilder& sink(const dwio::common::MemorySink& sink);
+
+  ParquetTestReaderBuilder& schema(const RowTypePtr& rowType);
+
+  ParquetTestReaderBuilder& range(uint64_t offset, uint64_t length);
+
+  ParquetTestReaderBuilder& noColumnSelector();
+
+  ParquetTestReaderBuilder& readerOptions(
+      const dwio::common::ReaderOptions& readerOptions);
+
+  std::pair<
+      std::unique_ptr<ParquetReader>,
+      std::unique_ptr<dwio::common::RowReader>>
+  build();
+
+ private:
+  friend class ParquetTestBase;
+  explicit ParquetTestReaderBuilder(ParquetTestBase* testBase);
+
+  ParquetTestBase* testBase_;
+  std::optional<std::string> fileName_;
+  const dwio::common::MemorySink* sink_{nullptr};
+  RowTypePtr schema_;
+  std::optional<std::pair<uint64_t, uint64_t>> range_;
+  bool noColumnSelector_{false};
+  std::optional<dwio::common::ReaderOptions> readerOptions_;
+};
+
 class ParquetTestBase : public testing::Test,
                         public velox::test::VectorTestBase {
+  friend class ParquetTestReaderBuilder;
+
  protected:
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
@@ -46,6 +86,7 @@ class ParquetTestBase : public testing::Test,
     rootPool_ = memory::memoryManager()->addRootPool("ParquetTests");
     leafPool_ = rootPool_->addLeafChild("ParquetTests");
     tempPath_ = TempDirectoryPath::create();
+    readerStore_.clear();
   }
 
   static RowTypePtr sampleSchema() {
@@ -53,7 +94,7 @@ class ParquetTestBase : public testing::Test,
   }
 
   static RowTypePtr dateSchema() {
-    return ROW({"date"}, {DATE()});
+    return ROW("date", DATE());
   }
 
   static RowTypePtr intSchema() {
@@ -65,15 +106,27 @@ class ParquetTestBase : public testing::Test,
   }
 
   std::unique_ptr<facebook::velox::parquet::ParquetReader> createReader(
-      const std::string& path,
-      const dwio::common::ReaderOptions& opts) {
-    auto input = std::make_unique<dwio::common::BufferedInput>(
-        std::make_shared<LocalReadFile>(path), opts.memoryPool());
-    return std::make_unique<facebook::velox::parquet::ParquetReader>(
-        std::move(input), opts);
+      const std::string& fileName,
+      const dwio::common::ReaderOptions& opts);
+
+  std::unique_ptr<facebook::velox::parquet::ParquetReader> createReader(
+      const std::string& fileName) {
+    return createReader(fileName, makeDefaultReaderOptions());
   }
 
-  dwio::common::RowReaderOptions getReaderOpts(
+  // Creates a ReaderOptions pre-populated with the test's shared IoStatistics
+  // and the leaf memory pool. Callers needing extra settings (e.g.
+  // setFileSchema, setAllowInt32Narrowing) should obtain a copy via this
+  // method and then apply their overrides.
+  dwio::common::ReaderOptions makeDefaultReaderOptions() const {
+    dwio::common::ReaderOptions opts(leafPool_.get());
+    opts.setDataIoStats(dataIoStats_);
+    opts.setMetadataIoStats(metadataIoStats_);
+    return opts;
+  }
+
+  // Returns RowReaderOptions with a ColumnSelector for the given schema.
+  dwio::common::RowReaderOptions makeRowReaderOpts(
       const RowTypePtr& rowType,
       bool fileColumnNamesReadAsLowerCase = false) {
     dwio::common::RowReaderOptions rowReaderOpts;
@@ -83,7 +136,6 @@ class ParquetTestBase : public testing::Test,
             rowType->names(),
             nullptr,
             fileColumnNamesReadAsLowerCase));
-
     return rowReaderOpts;
   }
 
@@ -100,65 +152,22 @@ class ParquetTestBase : public testing::Test,
   void assertEqualVectorPart(
       const VectorPtr& expected,
       const VectorPtr& actual,
-      vector_size_t offset) {
-    ASSERT_GE(expected->size(), actual->size() + offset);
-    ASSERT_EQ(expected->typeKind(), actual->typeKind());
-    for (vector_size_t i = 0; i < actual->size(); i++) {
-      ASSERT_TRUE(expected->equalValueAt(actual.get(), i + offset, i))
-          << "at " << (i + offset) << ": expected "
-          << expected->toString(i + offset) << ", but got "
-          << actual->toString(i);
-    }
-  }
+      vector_size_t offset);
 
   void assertReadWithReaderAndExpected(
       std::shared_ptr<const RowType> outputType,
       dwio::common::RowReader& reader,
       RowVectorPtr expected,
-      memory::MemoryPool& memoryPool) {
-    uint64_t total = 0;
-    VectorPtr result = BaseVector::create(outputType, 0, &memoryPool);
-    while (total < expected->size()) {
-      auto part = reader.next(1000, result);
-      if (part > 0) {
-        assertEqualVectorPart(expected, result, total);
-        total += result->size();
-      } else {
-        break;
-      }
-    }
-    EXPECT_EQ(total, expected->size());
-    EXPECT_EQ(reader.next(1000, result), 0);
-  }
+      memory::MemoryPool& memoryPool);
 
   void assertReadWithReaderAndFilters(
-      const std::unique_ptr<dwio::common::Reader> reader,
-      const std::string& /* fileName */,
+      dwio::common::Reader& reader,
       const RowTypePtr& fileSchema,
       FilterMap filters,
-      const RowVectorPtr& expected) {
-    auto scanSpec = makeScanSpec(fileSchema);
-    for (auto&& [column, filter] : filters) {
-      scanSpec->getOrCreateChild(velox::common::Subfield(column))
-          ->setFilter(std::move(filter));
-    }
-
-    auto rowReaderOpts = getReaderOpts(fileSchema);
-    rowReaderOpts.setScanSpec(scanSpec);
-    auto rowReader = reader->createRowReader(rowReaderOpts);
-    assertReadWithReaderAndExpected(
-        fileSchema, *rowReader, expected, *leafPool_);
-  }
+      const RowVectorPtr& expected);
 
   std::unique_ptr<dwio::common::FileSink> createSink(
-      const std::string& filePath) {
-    auto sink = dwio::common::FileSink::create(
-        fmt::format("file:{}", filePath), {.pool = rootPool_.get()});
-    EXPECT_TRUE(sink->isBuffered());
-    EXPECT_TRUE(fs::exists(filePath));
-    EXPECT_FALSE(sink->isClosed());
-    return sink;
-  }
+      const std::string& filePath);
 
   std::unique_ptr<facebook::velox::parquet::Writer> createWriter(
       std::unique_ptr<dwio::common::FileSink> sink,
@@ -167,27 +176,12 @@ class ParquetTestBase : public testing::Test,
           flushPolicy,
       const RowTypePtr& rowType,
       facebook::velox::common::CompressionKind compressionKind =
-          facebook::velox::common::CompressionKind_NONE) {
-    facebook::velox::parquet::WriterOptions options;
-    options.memoryPool = rootPool_.get();
-    options.flushPolicyFactory = flushPolicy;
-    options.compressionKind = compressionKind;
-    return std::make_unique<facebook::velox::parquet::Writer>(
-        std::move(sink), options, rowType);
-  }
+          facebook::velox::common::CompressionKind_NONE);
 
   std::vector<RowVectorPtr> createBatches(
       const RowTypePtr& rowType,
       uint64_t numBatches,
-      uint64_t vectorSize) {
-    std::vector<RowVectorPtr> batches;
-    batches.reserve(numBatches);
-    VectorFuzzer fuzzer({.vectorSize = vectorSize}, leafPool_.get());
-    for (auto i = 0; i < numBatches; ++i) {
-      batches.emplace_back(fuzzer.fuzzInputFlatRow(rowType));
-    }
-    return batches;
-  }
+      uint64_t vectorSize);
 
   std::string getExampleFilePath(const std::string& fileName) {
     return test::getDataFilePath(
@@ -197,43 +191,32 @@ class ParquetTestBase : public testing::Test,
   dwio::common::MemorySink* write(
       const RowVectorPtr& data,
       const WriterOptions& writerOptions,
-      const RowTypePtr& rowType = nullptr) {
-    auto sink = std::make_unique<dwio::common::MemorySink>(
-        200 * 1024 * 1024,
-        dwio::common::FileSink::Options{.pool = leafPool_.get()});
-    auto* sinkPtr = sink.get();
-    auto writer = std::make_unique<Writer>(
-        std::move(sink),
-        writerOptions,
-        rowType != nullptr ? rowType : data->rowType());
-    writer->write(data);
-    writer->close();
-    writers_.push_back(std::move(writer));
-    return sinkPtr;
-  }
+      const RowTypePtr& rowType = nullptr);
 
   dwio::common::MemorySink* write(
       const RowVectorPtr& data,
       std::unordered_map<std::string, std::string> configFromFile = {},
-      std::unordered_map<std::string, std::string> sessionProperties = {}) {
-    parquet::WriterOptions writerOptions;
-    writerOptions.memoryPool = rootPool_.get();
-    auto connectorConfig = config::ConfigBase(std::move(configFromFile));
-    auto connectorSessionProperties =
-        config::ConfigBase(std::move(sessionProperties));
-    writerOptions.processConfigs(connectorConfig, connectorSessionProperties);
-    return write(data, writerOptions);
-  }
+      std::unordered_map<std::string, std::string> sessionProperties = {});
 
   std::unique_ptr<ParquetReader> createReaderInMemory(
       const dwio::common::MemorySink& sink,
-      const dwio::common::ReaderOptions& opts) {
-    std::string data(sink.data(), sink.size());
-    return std::make_unique<ParquetReader>(
-        std::make_unique<dwio::common::BufferedInput>(
-            std::make_shared<InMemoryReadFile>(std::move(data)),
-            opts.memoryPool()),
-        opts);
+      const dwio::common::ReaderOptions& opts);
+
+  std::unique_ptr<ParquetReader> createReaderInMemory(
+      const dwio::common::MemorySink& sink) {
+    return createReaderInMemory(sink, makeDefaultReaderOptions());
+  }
+
+  std::unique_ptr<dwio::common::RowReader> createRowReaderFromReader(
+      dwio::common::Reader& reader,
+      const RowTypePtr& rowType);
+
+  std::unique_ptr<dwio::common::RowReader> createRowReaderFromReaderNoSelect(
+      dwio::common::Reader& reader,
+      const RowTypePtr& rowType);
+
+  ParquetTestReaderBuilder readerBuilder() {
+    return ParquetTestReaderBuilder(this);
   }
 
   static constexpr uint64_t kRowsInRowGroup = 10'000;
@@ -247,5 +230,7 @@ class ParquetTestBase : public testing::Test,
   std::shared_ptr<TempDirectoryPath> tempPath_;
   // Stores writers created by write() helper to keep sinks alive for reading.
   std::vector<std::unique_ptr<Writer>> writers_;
+  // Stores readers whose lifetime must extend beyond the current call frame.
+  std::vector<std::unique_ptr<dwio::common::Reader>> readerStore_;
 };
 } // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/tests/ParquetTestBase.h
+++ b/velox/dwio/parquet/tests/ParquetTestBase.h
@@ -38,44 +38,67 @@ using TempDirectoryPath = common::testutil::TempDirectoryPath;
 
 class ParquetTestBase;
 
-/// Fluent builder for creating ParquetReader + RowReader pairs in tests.
-class ParquetTestReaderBuilder {
+/// Builder for creating ParquetReader + RowReader pairs in unit tests.
+///
+/// Construct via ParquetTestBase::readerBuilder with a data source (example
+/// file or in-memory buffer) and output projection, then apply optional
+/// overrides.
+class ParquetReaderBuilder {
  public:
-  ParquetTestReaderBuilder& file(const std::string& fileName);
+  /// Reads Parquet from an on-disk file at filePath (a resolved path, e.g. from
+  /// getExampleFilePath()) and projects outputType.
+  ParquetReaderBuilder(
+      memory::MemoryPool* pool,
+      const std::shared_ptr<velox::io::IoStatistics>& dataIoStats,
+      const std::shared_ptr<velox::io::IoStatistics>& metadataIoStats,
+      const std::string& filePath,
+      const RowTypePtr& outputType);
 
-  ParquetTestReaderBuilder& sink(const dwio::common::MemorySink& sink);
+  /// Reads Parquet from bytes held in buffer (e.g. a MemorySink from write())
+  /// and projects outputType.
+  ParquetReaderBuilder(
+      memory::MemoryPool* pool,
+      const std::shared_ptr<velox::io::IoStatistics>& dataIoStats,
+      const std::shared_ptr<velox::io::IoStatistics>& metadataIoStats,
+      const dwio::common::MemorySink& buffer,
+      const RowTypePtr& outputType);
 
-  ParquetTestReaderBuilder& schema(const RowTypePtr& rowType);
+  /// Limits the read to byte range [offset, offset + length) in the file.
+  /// Use for split-level / slice read tests.
+  ParquetReaderBuilder& byteRange(uint64_t offset, uint64_t length);
 
-  ParquetTestReaderBuilder& range(uint64_t offset, uint64_t length);
+  /// Configures RowReaderOptions with only a ScanSpec and no ColumnSelector.
+  /// By default, build() adds a ColumnSelector derived from the output type
+  /// passed to readerBuilder(). Use
+  /// this when tests should not select output columns explicitly—for example
+  /// empty projection (count(*)), metadata-only reads, or reading via
+  /// ParquetReader::rowType() without a predetermined projection.
+  ParquetReaderBuilder& withScanSpecOnly();
 
-  ParquetTestReaderBuilder& noColumnSelector();
-
-  ParquetTestReaderBuilder& readerOptions(
+  /// Supplies ReaderOptions instead of the default (leaf pool + IoStatistics).
+  ParquetReaderBuilder& options(
       const dwio::common::ReaderOptions& readerOptions);
 
+  /// Creates a ParquetReader and RowReader from the configured inputs.
   std::pair<
       std::unique_ptr<ParquetReader>,
       std::unique_ptr<dwio::common::RowReader>>
   build();
 
  private:
-  friend class ParquetTestBase;
-  explicit ParquetTestReaderBuilder(ParquetTestBase* testBase);
-
-  ParquetTestBase* testBase_;
-  std::optional<std::string> fileName_;
-  const dwio::common::MemorySink* sink_{nullptr};
-  RowTypePtr schema_;
-  std::optional<std::pair<uint64_t, uint64_t>> range_;
-  bool noColumnSelector_{false};
+  memory::MemoryPool* pool_;
+  std::shared_ptr<velox::io::IoStatistics> dataIoStats_;
+  std::shared_ptr<velox::io::IoStatistics> metadataIoStats_;
+  std::optional<std::string> filePath_;
+  const dwio::common::MemorySink* buffer_{nullptr};
+  RowTypePtr outputType_;
+  std::optional<std::pair<uint64_t, uint64_t>> byteRange_;
+  bool withScanSpecOnly_{false};
   std::optional<dwio::common::ReaderOptions> readerOptions_;
 };
 
 class ParquetTestBase : public testing::Test,
                         public velox::test::VectorTestBase {
-  friend class ParquetTestReaderBuilder;
-
  protected:
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
@@ -118,12 +141,7 @@ class ParquetTestBase : public testing::Test,
   // and the leaf memory pool. Callers needing extra settings (e.g.
   // setFileSchema, setAllowInt32Narrowing) should obtain a copy via this
   // method and then apply their overrides.
-  dwio::common::ReaderOptions makeDefaultReaderOptions() const {
-    dwio::common::ReaderOptions opts(leafPool_.get());
-    opts.setDataIoStats(dataIoStats_);
-    opts.setMetadataIoStats(metadataIoStats_);
-    return opts;
-  }
+  dwio::common::ReaderOptions makeDefaultReaderOptions() const;
 
   // Returns RowReaderOptions with a ColumnSelector for the given schema.
   dwio::common::RowReaderOptions makeRowReaderOpts(
@@ -207,16 +225,32 @@ class ParquetTestBase : public testing::Test,
     return createReaderInMemory(sink, makeDefaultReaderOptions());
   }
 
+  /// Creates a RowReader for reader. When useColumnSelector is true (default),
+  /// RowReaderOptions include a ColumnSelector for rowType;
+  /// otherwise only a ScanSpec is set (see
+  /// ParquetReaderBuilder::withScanSpecOnly).
   std::unique_ptr<dwio::common::RowReader> createRowReaderFromReader(
       dwio::common::Reader& reader,
-      const RowTypePtr& rowType);
+      const RowTypePtr& rowType,
+      bool useColumnSelector = true);
 
-  std::unique_ptr<dwio::common::RowReader> createRowReaderFromReaderNoSelect(
-      dwio::common::Reader& reader,
-      const RowTypePtr& rowType);
+  /// exampleFileName is a file under the parquet reader examples directory.
+  ParquetReaderBuilder readerBuilder(
+      const std::string& exampleFileName,
+      const RowTypePtr& outputType) {
+    return ParquetReaderBuilder(
+        leafPool_.get(),
+        dataIoStats_,
+        metadataIoStats_,
+        getExampleFilePath(exampleFileName),
+        outputType);
+  }
 
-  ParquetTestReaderBuilder readerBuilder() {
-    return ParquetTestReaderBuilder(this);
+  ParquetReaderBuilder readerBuilder(
+      const dwio::common::MemorySink& buffer,
+      const RowTypePtr& outputType) {
+    return ParquetReaderBuilder(
+        leafPool_.get(), dataIoStats_, metadataIoStats_, buffer, outputType);
   }
 
   static constexpr uint64_t kRowsInRowGroup = 10'000;

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -30,23 +30,16 @@ using namespace facebook::velox::parquet;
 
 class ParquetReaderTest : public ParquetTestBase {
  public:
+  /// Returns only the RowReader for callers that do not need the Reader
+  /// directly. The Reader is kept alive in readerStore_ for the duration of
+  /// the test, preventing use-after-free when the RowReader reads lazily.
   std::unique_ptr<dwio::common::RowReader> createRowReader(
       const std::string& fileName,
       const RowTypePtr& rowType) {
-    const std::string sample(getExampleFilePath(fileName));
-
-    dwio::common::ReaderOptions readerOptions(leafPool_.get());
-    readerOptions.setDataIoStats(dataIoStats_);
-    readerOptions.setMetadataIoStats(metadataIoStats_);
-    auto reader = createReader(sample, readerOptions);
-
-    RowReaderOptions rowReaderOpts;
-    rowReaderOpts.select(
-        std::make_shared<facebook::velox::dwio::common::ColumnSelector>(
-            rowType, rowType->names()));
-    rowReaderOpts.setScanSpec(makeScanSpec(rowType));
-    auto rowReader = reader->createRowReader(rowReaderOpts);
-    return rowReader;
+    auto [reader, rowReader] =
+        readerBuilder().file(fileName).schema(rowType).build();
+    readerStore_.push_back(std::move(reader));
+    return std::move(rowReader);
   }
 
   void assertReadWithExpected(
@@ -62,21 +55,15 @@ class ParquetReaderTest : public ParquetTestBase {
       const RowTypePtr& fileSchema,
       FilterMap filters,
       const RowVectorPtr& expected) {
-    const auto filePath(getExampleFilePath(fileName));
-    dwio::common::ReaderOptions readerOpts(leafPool_.get());
-    readerOpts.setDataIoStats(dataIoStats_);
-    readerOpts.setMetadataIoStats(metadataIoStats_);
-    auto reader = createReader(filePath, readerOpts);
+    auto reader = createReader(fileName);
     assertReadWithReaderAndFilters(
-        std::move(reader), fileName, fileSchema, std::move(filters), expected);
+        *reader, fileSchema, std::move(filters), expected);
   }
 
   // Builds ReaderOptions with the Parquet thrift footer-memory tracking
   // path enabled by a 1-byte threshold so any footer engages tracking.
   dwio::common::ReaderOptions makeThriftTrackingReaderOptions() {
-    dwio::common::ReaderOptions readerOptions(leafPool_.get());
-    readerOptions.setDataIoStats(dataIoStats_);
-    readerOptions.setMetadataIoStats(metadataIoStats_);
+    auto readerOptions = makeDefaultReaderOptions();
     readerOptions.setParquetFooterMemoryTrackingThreshold(1);
     return readerOptions;
   }
@@ -88,12 +75,8 @@ TEST_F(ParquetReaderTest, parseSample) {
   // Data is in plain uncompressed format:
   //   a: [1..20]
   //   b: [1.0..20.0]
-  const std::string sample(getExampleFilePath("sample.parquet"));
-
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReader(sample, readerOptions);
+  auto [reader, rowReader] =
+      readerBuilder().file("sample.parquet").schema(sampleSchema()).build();
   EXPECT_EQ(reader->numberOfRows(), 20ULL);
 
   auto type = reader->typeWithId();
@@ -105,10 +88,6 @@ TEST_F(ParquetReaderTest, parseSample) {
   EXPECT_EQ(type->childByName("a"), col0);
   EXPECT_EQ(type->childByName("b"), col1);
 
-  auto rowReaderOpts = getReaderOpts(sampleSchema());
-  auto scanSpec = makeScanSpec(sampleSchema());
-  rowReaderOpts.setScanSpec(scanSpec);
-  auto rowReader = reader->createRowReader(rowReaderOpts);
   auto expected = makeRowVector({
       makeFlatVector<int64_t>(20, [](auto row) { return row + 1; }),
       makeFlatVector<double>(20, [](auto row) { return row + 1; }),
@@ -119,15 +98,11 @@ TEST_F(ParquetReaderTest, parseSample) {
 }
 
 TEST_F(ParquetReaderTest, parquetFieldIdColumnMappingNotImplemented) {
-  const std::string sample(getExampleFilePath("sample.parquet"));
-
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
+  auto readerOptions = makeDefaultReaderOptions();
   readerOptions.setColumnMappingMode(ColumnMappingMode::kParquetFieldId);
 
   VELOX_ASSERT_THROW(
-      createReader(sample, readerOptions),
+      createReader("sample.parquet", readerOptions),
       "Parquet field ID column mapping is not implemented yet.");
 }
 
@@ -151,13 +126,11 @@ TEST_F(ParquetReaderTest, parseEmptyNestedList) {
   //
   // All 1000 rows in one row group.
   // Data is in RLE_DICTIONARY Snappy format.
-  const std::string sample(
-      getExampleFilePath("parse_empty_nested_list.parquet"));
-
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReader(sample, readerOptions);
+  auto schema = ROW("msg", ROW("a", ROW("b", ARRAY(INTEGER()))));
+  auto [reader, rowReader] = readerBuilder()
+                                 .file("parse_empty_nested_list.parquet")
+                                 .schema(schema)
+                                 .build();
   EXPECT_EQ(reader->numberOfRows(), 1000ULL);
 
   // Ensure the intact data structure
@@ -183,11 +156,6 @@ TEST_F(ParquetReaderTest, parseEmptyNestedList) {
   EXPECT_EQ(childMsgA->childByName("b"), childMsgAB);
 
   // Ensure actual data can be read
-  auto schema = ROW({"msg"}, {ROW({"a"}, {ROW({"b"}, {ARRAY(INTEGER())})})});
-  auto rowReaderOpts = getReaderOpts(schema);
-  auto scanSpec = makeScanSpec(schema);
-  rowReaderOpts.setScanSpec(scanSpec);
-  auto rowReader = reader->createRowReader(rowReaderOpts);
 
   auto expected =
       makeRowVector({makeRowVector({makeRowVector({makeArrayVector<int32_t>(
@@ -212,12 +180,7 @@ TEST_F(ParquetReaderTest, parseUnannotatedList) {
   //     }
   //   }
   // }
-  const std::string sample(getExampleFilePath("unannotated_list.parquet"));
-
-  dwio::common::ReaderOptions readerOpts(leafPool_.get());
-  readerOpts.setDataIoStats(dataIoStats_);
-  readerOpts.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReader(sample, readerOpts);
+  auto reader = createReader("unannotated_list.parquet");
 
   EXPECT_EQ(reader->numberOfRows(), 22ULL);
 
@@ -269,12 +232,8 @@ TEST_F(ParquetReaderTest, parseUnannotatedMap) {
   //  }
   //}
   const std::string filename("unnotated_map.parquet");
-  const std::string sample(getExampleFilePath(filename));
 
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReader(sample, readerOptions);
+  auto reader = createReader(filename);
 
   auto type = reader->typeWithId();
   EXPECT_EQ(type->size(), 1ULL);
@@ -310,12 +269,8 @@ TEST_F(ParquetReaderTest, parseLegacyListWithMultipleChildren) {
   // }
   // Namely, node 'array' has >1 child
   const std::string filename("listmultiplechildren.parquet");
-  const std::string sample(getExampleFilePath(filename));
 
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReader(sample, readerOptions);
+  auto reader = createReader(filename);
 
   auto type = reader->typeWithId();
   EXPECT_EQ(type->size(), 1ULL);
@@ -370,13 +325,7 @@ TEST_F(ParquetReaderTest, parseArrayOfRowHiveReservedKeywords) {
   //  }
   const std::string expectedVeloxType =
       "ROW<id:INTEGER,items:ARRAY<ROW<name:VARCHAR,quantity:INTEGER,price:DOUBLE>>>";
-  const std::string sample(
-      getExampleFilePath("array_of_row_hive_reserved_keywords.parquet"));
-
-  dwio::common::ReaderOptions readerOpts(leafPool_.get());
-  readerOpts.setDataIoStats(dataIoStats_);
-  readerOpts.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReader(sample, readerOpts);
+  auto reader = createReader("array_of_row_hive_reserved_keywords.parquet");
   EXPECT_EQ(reader->rowType()->toString(), expectedVeloxType);
   EXPECT_EQ(reader->numberOfRows(), 6ULL);
 
@@ -424,18 +373,11 @@ TEST_F(ParquetReaderTest, parseArrayOfRowHiveReservedKeywords) {
 }
 
 TEST_F(ParquetReaderTest, parseSampleRange1) {
-  const std::string sample(getExampleFilePath("sample.parquet"));
-
-  dwio::common::ReaderOptions readerOpts(leafPool_.get());
-  readerOpts.setDataIoStats(dataIoStats_);
-  readerOpts.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReader(sample, readerOpts);
-
-  auto rowReaderOpts = getReaderOpts(sampleSchema());
-  auto scanSpec = makeScanSpec(sampleSchema());
-  rowReaderOpts.setScanSpec(scanSpec);
-  rowReaderOpts.range(0, 200);
-  auto rowReader = reader->createRowReader(rowReaderOpts);
+  auto [reader, rowReader] = readerBuilder()
+                                 .file("sample.parquet")
+                                 .schema(sampleSchema())
+                                 .range(0, 200)
+                                 .build();
   auto expected = makeRowVector({
       makeFlatVector<int64_t>(10, [](auto row) { return row + 1; }),
       makeFlatVector<double>(10, [](auto row) { return row + 1; }),
@@ -445,18 +387,11 @@ TEST_F(ParquetReaderTest, parseSampleRange1) {
 }
 
 TEST_F(ParquetReaderTest, parseSampleRange2) {
-  const std::string sample(getExampleFilePath("sample.parquet"));
-
-  dwio::common::ReaderOptions readerOpts(leafPool_.get());
-  readerOpts.setDataIoStats(dataIoStats_);
-  readerOpts.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReader(sample, readerOpts);
-
-  auto rowReaderOpts = getReaderOpts(sampleSchema());
-  auto scanSpec = makeScanSpec(sampleSchema());
-  rowReaderOpts.setScanSpec(scanSpec);
-  rowReaderOpts.range(200, 500);
-  auto rowReader = reader->createRowReader(rowReaderOpts);
+  auto [reader, rowReader] = readerBuilder()
+                                 .file("sample.parquet")
+                                 .schema(sampleSchema())
+                                 .range(200, 500)
+                                 .build();
   auto expected = makeRowVector({
       makeFlatVector<int64_t>(10, [](auto row) { return row + 11; }),
       makeFlatVector<double>(10, [](auto row) { return row + 11; }),
@@ -466,18 +401,11 @@ TEST_F(ParquetReaderTest, parseSampleRange2) {
 }
 
 TEST_F(ParquetReaderTest, parseSampleEmptyRange) {
-  const std::string sample(getExampleFilePath("sample.parquet"));
-
-  dwio::common::ReaderOptions readerOpts(leafPool_.get());
-  readerOpts.setDataIoStats(dataIoStats_);
-  readerOpts.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReader(sample, readerOpts);
-
-  auto rowReaderOpts = getReaderOpts(sampleSchema());
-  auto scanSpec = makeScanSpec(sampleSchema());
-  rowReaderOpts.setScanSpec(scanSpec);
-  rowReaderOpts.range(300, 10);
-  auto rowReader = reader->createRowReader(rowReaderOpts);
+  auto [reader, rowReader] = readerBuilder()
+                                 .file("sample.parquet")
+                                 .schema(sampleSchema())
+                                 .range(300, 10)
+                                 .build();
 
   VectorPtr result;
   EXPECT_EQ(rowReader->next(1000, result), 0);
@@ -486,15 +414,11 @@ TEST_F(ParquetReaderTest, parseSampleEmptyRange) {
 TEST_F(ParquetReaderTest, parseReadAsLowerCase) {
   // upper.parquet holds two columns (A: BIGINT, b: BIGINT) and
   // 2 rows.
-  const std::string upper(getExampleFilePath("upper.parquet"));
-
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
+  auto readerOptions = makeDefaultReaderOptions();
   auto outputRowType = ROW({"a", "b"}, {BIGINT(), BIGINT()});
   readerOptions.setFileSchema(outputRowType);
   readerOptions.setFileColumnNamesReadAsLowerCase(true);
-  auto reader = createReader(upper, readerOptions);
+  auto reader = createReader("upper.parquet", readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 2ULL);
 
   auto type = reader->typeWithId();
@@ -524,13 +448,9 @@ TEST_F(ParquetReaderTest, parseRowMapArrayReadAsLowerCase) {
   // +-----------------------+
   // |{120, {key -> {[{1}]}}}|
   // +-----------------------+
-  const std::string upper(getExampleFilePath("upper_complex.parquet"));
-
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
+  auto readerOptions = makeDefaultReaderOptions();
   readerOptions.setFileColumnNamesReadAsLowerCase(true);
-  auto reader = createReader(upper, readerOptions);
+  auto reader = createReader("upper_complex.parquet", readerOptions);
 
   EXPECT_EQ(reader->numberOfRows(), 1ULL);
 
@@ -569,12 +489,7 @@ TEST_F(ParquetReaderTest, parseRowMapArrayReadAsLowerCase) {
 TEST_F(ParquetReaderTest, parseEmpty) {
   // empty.parquet holds two columns (a: BIGINT, b: DOUBLE) and
   // 0 rows.
-  const std::string empty(getExampleFilePath("empty.parquet"));
-
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReader(empty, readerOptions);
+  auto reader = createReader("empty.parquet");
   EXPECT_EQ(reader->numberOfRows(), 0ULL);
 
   auto type = reader->typeWithId();
@@ -593,12 +508,8 @@ TEST_F(ParquetReaderTest, parseInt) {
   // Data is in plain uncompressed format:
   //   int: [100 .. 109]
   //   bigint: [1000 .. 1009]
-  const std::string sample(getExampleFilePath("int.parquet"));
-
-  dwio::common::ReaderOptions readerOpts(leafPool_.get());
-  readerOpts.setDataIoStats(dataIoStats_);
-  readerOpts.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReader(sample, readerOpts);
+  auto [reader, rowReader] =
+      readerBuilder().file("int.parquet").schema(intSchema()).build();
 
   EXPECT_EQ(reader->numberOfRows(), 10ULL);
 
@@ -608,11 +519,6 @@ TEST_F(ParquetReaderTest, parseInt) {
   EXPECT_EQ(col0->type()->kind(), TypeKind::INTEGER);
   auto col1 = type->childAt(1);
   EXPECT_EQ(col1->type()->kind(), TypeKind::BIGINT);
-
-  auto rowReaderOpts = getReaderOpts(intSchema());
-  auto scanSpec = makeScanSpec(intSchema());
-  rowReaderOpts.setScanSpec(scanSpec);
-  auto rowReader = reader->createRowReader(rowReaderOpts);
 
   auto expected = makeRowVector({
       makeFlatVector<int32_t>(10, [](auto row) { return row + 100; }),
@@ -630,13 +536,11 @@ TEST_F(ParquetReaderTest, parseUnsignedInt1) {
   //   uint16: [65535, 2000, 3000]
   //   uint32: [4294967295, 2000000000, 3000000000]
   //   uint64: [18446744073709551615, 2000000000000000000, 3000000000000000000]
-  const std::string sample(getExampleFilePath("uint.parquet"));
-
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReader(sample, readerOptions);
-
+  auto rowType =
+      ROW({"uint8", "uint16", "uint32", "uint64"},
+          {TINYINT(), SMALLINT(), INTEGER(), BIGINT()});
+  auto [reader, rowReader] =
+      readerBuilder().file("uint.parquet").schema(rowType).build();
   EXPECT_EQ(reader->numberOfRows(), 3ULL);
   auto type = reader->typeWithId();
   EXPECT_EQ(type->size(), 4ULL);
@@ -648,17 +552,6 @@ TEST_F(ParquetReaderTest, parseUnsignedInt1) {
   EXPECT_EQ(col2->type()->kind(), TypeKind::INTEGER);
   auto col3 = type->childAt(3);
   EXPECT_EQ(col3->type()->kind(), TypeKind::BIGINT);
-
-  auto rowType =
-      ROW({"uint8", "uint16", "uint32", "uint64"},
-          {TINYINT(), SMALLINT(), INTEGER(), BIGINT()});
-
-  RowReaderOptions rowReaderOpts;
-  rowReaderOpts.select(
-      std::make_shared<dwio::common::ColumnSelector>(
-          rowType, rowType->names()));
-  rowReaderOpts.setScanSpec(makeScanSpec(rowType));
-  auto rowReader = reader->createRowReader(rowReaderOpts);
 
   auto expected = makeRowVector(
       {makeFlatVector<uint8_t>({255, 2, 3}),
@@ -736,12 +629,8 @@ TEST_F(ParquetReaderTest, parseDate) {
   // 25 rows.
   // Data is in plain uncompressed format:
   //   date: [1969-12-27 .. 1970-01-20]
-  const std::string sample(getExampleFilePath("date.parquet"));
-
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReader(sample, readerOptions);
+  auto [reader, rowReader] =
+      readerBuilder().file("date.parquet").schema(dateSchema()).build();
 
   EXPECT_EQ(reader->numberOfRows(), 25ULL);
 
@@ -751,10 +640,6 @@ TEST_F(ParquetReaderTest, parseDate) {
   EXPECT_EQ(col0->type(), DATE());
   EXPECT_EQ(type->childByName("date"), col0);
 
-  auto rowReaderOpts = getReaderOpts(dateSchema());
-  auto scanSpec = makeScanSpec(dateSchema());
-  rowReaderOpts.setScanSpec(scanSpec);
-  auto rowReader = reader->createRowReader(rowReaderOpts);
   auto expected = makeRowVector({
       makeFlatVector<int32_t>(25, [](auto row) { return row - 5; }),
   });
@@ -765,12 +650,7 @@ TEST_F(ParquetReaderTest, parseDate) {
 TEST_F(ParquetReaderTest, parseRowMapArray) {
   // sample.parquet holds one row of type (ROW(BIGINT c0, MAP(VARCHAR,
   // ARRAY(INTEGER)) c1) c)
-  const std::string sample(getExampleFilePath("row_map_array.parquet"));
-
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReader(sample, readerOptions);
+  auto reader = createReader("row_map_array.parquet");
 
   EXPECT_EQ(reader->numberOfRows(), 1ULL);
 
@@ -802,13 +682,11 @@ TEST_F(ParquetReaderTest, parseRowMapArray) {
 TEST_F(ParquetReaderTest, projectNoColumns) {
   // This is the case for count(*).
   auto rowType = ROW({}, {});
-  dwio::common::ReaderOptions readerOpts(leafPool_.get());
-  readerOpts.setDataIoStats(dataIoStats_);
-  readerOpts.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReader(getExampleFilePath("sample.parquet"), readerOpts);
-  RowReaderOptions rowReaderOpts;
-  rowReaderOpts.setScanSpec(makeScanSpec(rowType));
-  auto rowReader = reader->createRowReader(rowReaderOpts);
+  auto [reader, rowReader] = readerBuilder()
+                                 .file("sample.parquet")
+                                 .schema(rowType)
+                                 .noColumnSelector()
+                                 .build();
   auto result = BaseVector::create(rowType, 1, leafPool_.get());
   constexpr int kBatchSize = 100;
   ASSERT_TRUE(rowReader->next(kBatchSize, result));
@@ -828,15 +706,11 @@ TEST_F(ParquetReaderTest, parseIntDecimal) {
   //   a: [11.11, 11.11, 22.22, 22.22, 33.33, 33.33]
   //   b: [11.11, 11.11, 22.22, 22.22, 33.33, 33.33]
   auto rowType = ROW({"a", "b"}, {DECIMAL(7, 2), DECIMAL(14, 2)});
-  dwio::common::ReaderOptions readerOpts(leafPool_.get());
-  readerOpts.setDataIoStats(dataIoStats_);
-  readerOpts.setMetadataIoStats(metadataIoStats_);
-  const std::string decimal_dict(getExampleFilePath("decimal_dict.parquet"));
-
-  auto reader = createReader(decimal_dict, readerOpts);
-  RowReaderOptions rowReaderOpts;
-  rowReaderOpts.setScanSpec(makeScanSpec(rowType));
-  auto rowReader = reader->createRowReader(rowReaderOpts);
+  auto [reader, rowReader] = readerBuilder()
+                                 .file("decimal_dict.parquet")
+                                 .schema(rowType)
+                                 .noColumnSelector()
+                                 .build();
 
   EXPECT_EQ(reader->numberOfRows(), 6ULL);
 
@@ -882,12 +756,10 @@ TEST_F(ParquetReaderTest, parseMapKeyValueAsMap) {
   // 3:       REQUIRED BYTE_ARRAY key (UTF8)
   // 4:       OPTIONAL INT64 value (UTF8)
 
-  const std::string sample(getExampleFilePath("map_key_value.parquet"));
-
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReader(sample, readerOptions);
+  auto fileSchema =
+      ROW("test", createType<TypeKind::MAP>({VARCHAR(), BIGINT()}));
+  auto [reader, rowReader] =
+      readerBuilder().file("map_key_value.parquet").schema(fileSchema).build();
   EXPECT_EQ(reader->numberOfRows(), 1ULL);
 
   auto rowType = reader->typeWithId();
@@ -902,13 +774,6 @@ TEST_F(ParquetReaderTest, parseMapKeyValueAsMap) {
 
   auto mapValueType = mapColumnType->childAt(1);
   EXPECT_EQ(mapValueType->type()->kind(), TypeKind::BIGINT);
-
-  auto fileSchema =
-      ROW({"test"}, {createType<TypeKind::MAP>({VARCHAR(), BIGINT()})});
-  auto rowReaderOpts = getReaderOpts(fileSchema);
-  auto scanSpec = makeScanSpec(fileSchema);
-  rowReaderOpts.setScanSpec(scanSpec);
-  auto rowReader = reader->createRowReader(rowReaderOpts);
 
   auto expected = makeRowVector({vectorMaker_.mapVector<std::string, int64_t>(
       {{{"0", 0},
@@ -931,21 +796,6 @@ TEST_F(ParquetReaderTest, parseRowArrayTest) {
   //   optionalMessage:struct<someId:int>
   //   requiredMessage:struct<someId:int>
   //   repeatedMessage:array<struct<someId:int>>
-  const std::string sample(
-      getExampleFilePath("proto-struct-with-array.parquet"));
-
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReader(sample, readerOptions);
-  EXPECT_EQ(reader->numberOfRows(), 1ULL);
-  auto type = reader->typeWithId();
-  EXPECT_EQ(type->size(), 6ULL);
-  auto col6_type = type->childAt(5);
-  EXPECT_EQ(col6_type->type()->kind(), TypeKind::ARRAY);
-  auto col6_1_type = col6_type->childAt(0);
-  EXPECT_EQ(col6_1_type->type()->kind(), TypeKind::ROW);
-
   auto outputRowType =
       ROW({"optionalPrimitive",
            "requiredPrimitive",
@@ -956,12 +806,21 @@ TEST_F(ParquetReaderTest, parseRowArrayTest) {
           {INTEGER(),
            INTEGER(),
            ARRAY(INTEGER()),
-           ROW({"someId"}, {INTEGER()}),
-           ROW({"someId"}, {INTEGER()}),
-           ARRAY(ROW({"someId"}, {INTEGER()}))});
-  auto rowReaderOpts = getReaderOpts(outputRowType);
-  rowReaderOpts.setScanSpec(makeScanSpec(outputRowType));
-  auto rowReader = reader->createRowReader(rowReaderOpts);
+           ROW("someId", INTEGER()),
+           ROW("someId", INTEGER()),
+           ARRAY(ROW("someId", INTEGER()))});
+  auto [reader, rowReader] = readerBuilder()
+                                 .file("proto-struct-with-array.parquet")
+                                 .schema(outputRowType)
+                                 .build();
+  EXPECT_EQ(reader->numberOfRows(), 1ULL);
+  auto type = reader->typeWithId();
+  EXPECT_EQ(type->size(), 6ULL);
+  auto col6Type = type->childAt(5);
+  EXPECT_EQ(col6Type->type()->kind(), TypeKind::ARRAY);
+  auto col61Type = col6Type->childAt(0);
+  EXPECT_EQ(col61Type->type()->kind(), TypeKind::ROW);
+
   VectorPtr result = BaseVector::create(outputRowType, 0, &*leafPool_);
 
   ASSERT_TRUE(rowReader->next(1, result));
@@ -1220,17 +1079,12 @@ TEST_F(ParquetReaderTest, readDifferentEncodingsWithFilter) {
 TEST_F(ParquetReaderTest, filterRowGroups) {
   // decimal_no_ColumnMetadata.parquet has one columns a: DECIMAL(9,1). It
   // doesn't have ColumnMetaData, and rowGroups_[0].columns[0].file_offset is 0.
-  auto rowType = ROW({"_c0"}, {DECIMAL(9, 1)});
-  dwio::common::ReaderOptions readerOpts(leafPool_.get());
-  readerOpts.setDataIoStats(dataIoStats_);
-  readerOpts.setMetadataIoStats(metadataIoStats_);
-  const std::string decimal_dict(
-      getExampleFilePath("decimal_no_ColumnMetadata.parquet"));
-
-  auto reader = createReader(decimal_dict, readerOpts);
-  RowReaderOptions rowReaderOpts;
-  rowReaderOpts.setScanSpec(makeScanSpec(rowType));
-  auto rowReader = reader->createRowReader(rowReaderOpts);
+  auto rowType = ROW("_c0", DECIMAL(9, 1));
+  auto [reader, rowReader] = readerBuilder()
+                                 .file("decimal_no_ColumnMetadata.parquet")
+                                 .schema(rowType)
+                                 .noColumnSelector()
+                                 .build();
 
   EXPECT_EQ(reader->numberOfRows(), 10ULL);
 }
@@ -1249,29 +1103,19 @@ TEST_F(ParquetReaderTest, shouldIgnoreStatsForParquetMRVersions) {
 
 // This test is to verify filterRowGroups() doesn't fail if offset is 0
 TEST_F(ParquetReaderTest, filterRowGroupsWithZeroOffset) {
-  auto rowType = ROW({"IDX"}, {INTEGER()});
-  dwio::common::ReaderOptions readerOpts(leafPool_.get());
-  readerOpts.setDataIoStats(dataIoStats_);
-  readerOpts.setMetadataIoStats(metadataIoStats_);
-  const std::string zeroOffsetPath(
-      getExampleFilePath("zero_offset_row_group.parquet"));
-
-  auto reader = createReader(zeroOffsetPath, readerOpts);
-  RowReaderOptions rowReaderOpts;
-  rowReaderOpts.setScanSpec(makeScanSpec(rowType));
-  auto rowReader = reader->createRowReader(rowReaderOpts);
+  auto rowType = ROW("IDX", INTEGER());
+  auto [reader, rowReader] = readerBuilder()
+                                 .file("zero_offset_row_group.parquet")
+                                 .schema(rowType)
+                                 .noColumnSelector()
+                                 .build();
 
   EXPECT_EQ(reader->numberOfRows(), 1L);
 }
 
 TEST_F(ParquetReaderTest, parseLongTagged) {
   // This is a case for long with annonation read
-  const std::string sample(getExampleFilePath("tagged_long.parquet"));
-
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReader(sample, readerOptions);
+  auto reader = createReader("tagged_long.parquet");
 
   EXPECT_EQ(reader->numberOfRows(), 4ULL);
 
@@ -1288,16 +1132,10 @@ TEST_F(ParquetReaderTest, preloadSmallFile) {
   auto file = std::make_shared<LocalReadFile>(sample);
   auto input = std::make_unique<BufferedInput>(file, *leafPool_);
 
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
-  auto reader =
-      std::make_unique<ParquetReader>(std::move(input), readerOptions);
+  auto reader = std::make_unique<ParquetReader>(
+      std::move(input), makeDefaultReaderOptions());
 
-  auto rowReaderOpts = getReaderOpts(sampleSchema());
-  auto scanSpec = makeScanSpec(sampleSchema());
-  rowReaderOpts.setScanSpec(scanSpec);
-  auto rowReader = reader->createRowReader(rowReaderOpts);
+  auto rowReader = createRowReaderFromReader(*reader, sampleSchema());
 
   // Ensure the input is small parquet file.
   const auto fileSize = file->size();
@@ -1320,13 +1158,10 @@ TEST_F(ParquetReaderTest, preloadSmallFile) {
 }
 
 TEST_F(ParquetReaderTest, prefetchRowGroups) {
-  auto rowType = ROW({"id"}, {BIGINT()});
-  const std::string sample(getExampleFilePath("multiple_row_groups.parquet"));
+  auto rowType = ROW("id", BIGINT());
   const int numRowGroups = 4;
 
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
+  auto readerOptions = makeDefaultReaderOptions();
   // Disable preload of file.
   readerOptions.setFilePreloadThreshold(0);
 
@@ -1339,12 +1174,10 @@ TEST_F(ParquetReaderTest, prefetchRowGroups) {
   for (auto numPrefetch : numPrefetchRowGroups) {
     readerOptions.setPrefetchRowGroups(numPrefetch);
 
-    auto reader = createReader(sample, readerOptions);
+    auto reader = createReader("multiple_row_groups.parquet", readerOptions);
     EXPECT_EQ(reader->fileMetaData().numRowGroups(), numRowGroups);
 
-    RowReaderOptions rowReaderOpts;
-    rowReaderOpts.setScanSpec(makeScanSpec(rowType));
-    auto rowReader = reader->createRowReader(rowReaderOpts);
+    auto rowReader = createRowReaderFromReaderNoSelect(*reader, rowType);
     auto parquetRowReader = dynamic_cast<ParquetRowReader*>(rowReader.get());
 
     constexpr int kBatchSize = 1000;
@@ -1377,12 +1210,11 @@ TEST_F(ParquetReaderTest, prefetchRowGroups) {
 
 TEST_F(ParquetReaderTest, testEmptyRowGroups) {
   // empty_row_groups.parquet contains empty row groups
-  const std::string sample(getExampleFilePath("empty_row_groups.parquet"));
-
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReader(sample, readerOptions);
+  auto fileSchema = ROW("a", INTEGER());
+  auto [reader, rowReader] = readerBuilder()
+                                 .file("empty_row_groups.parquet")
+                                 .schema(fileSchema)
+                                 .build();
   EXPECT_EQ(reader->numberOfRows(), 5ULL);
 
   auto rowType = reader->typeWithId();
@@ -1392,12 +1224,6 @@ TEST_F(ParquetReaderTest, testEmptyRowGroups) {
   auto integerType = rowType->childAt(0);
   EXPECT_EQ(integerType->type()->kind(), TypeKind::INTEGER);
 
-  auto fileSchema = ROW({"a"}, {INTEGER()});
-  auto rowReaderOpts = getReaderOpts(fileSchema);
-  auto scanSpec = makeScanSpec(fileSchema);
-  rowReaderOpts.setScanSpec(scanSpec);
-  auto rowReader = reader->createRowReader(rowReaderOpts);
-
   auto expected = makeRowVector({makeFlatVector<int32_t>({0, 3, 3, 3, 3})});
 
   assertReadWithReaderAndExpected(fileSchema, *rowReader, expected, *leafPool_);
@@ -1405,12 +1231,9 @@ TEST_F(ParquetReaderTest, testEmptyRowGroups) {
 
 TEST_F(ParquetReaderTest, testEnumType) {
   // enum_type.parquet contains 1 column (ENUM) with 3 rows.
-  const std::string sample(getExampleFilePath("enum_type.parquet"));
-
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReader(sample, readerOptions);
+  auto fileSchema = ROW("test", VARCHAR());
+  auto [reader, rowReader] =
+      readerBuilder().file("enum_type.parquet").schema(fileSchema).build();
   EXPECT_EQ(reader->numberOfRows(), 3ULL);
 
   auto rowType = reader->typeWithId();
@@ -1418,11 +1241,6 @@ TEST_F(ParquetReaderTest, testEnumType) {
   EXPECT_EQ(rowType->size(), 1ULL);
 
   EXPECT_EQ(rowType->childAt(0)->type()->kind(), TypeKind::VARCHAR);
-
-  auto fileSchema = ROW({"test"}, {VARCHAR()});
-  auto rowReaderOpts = getReaderOpts(fileSchema);
-  rowReaderOpts.setScanSpec(makeScanSpec(fileSchema));
-  auto rowReader = reader->createRowReader(rowReaderOpts);
 
   auto expected =
       makeRowVector({makeFlatVector<StringView>({"FOO", "BAR", "FOO"})});
@@ -1432,12 +1250,9 @@ TEST_F(ParquetReaderTest, testEnumType) {
 
 TEST_F(ParquetReaderTest, readVarbinaryFromFLBA) {
   const std::string filename("varbinary_flba.parquet");
-  const std::string sample(getExampleFilePath(filename));
-
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReader(sample, readerOptions);
+  auto selectedType = ROW("flba_field", VARBINARY());
+  auto [reader, rowReader] =
+      readerBuilder().file(filename).schema(selectedType).build();
 
   auto type = reader->typeWithId();
   EXPECT_EQ(type->size(), 8ULL);
@@ -1445,11 +1260,6 @@ TEST_F(ParquetReaderTest, readVarbinaryFromFLBA) {
       std::static_pointer_cast<const ParquetTypeWithId>(type->childAt(6));
   EXPECT_EQ(flbaCol->name_, "flba_field");
   EXPECT_EQ(flbaCol->parquetType_, thrift::Type::FIXED_LEN_BYTE_ARRAY);
-
-  auto selectedType = ROW({"flba_field"}, {VARBINARY()});
-  auto rowReaderOpts = getReaderOpts(selectedType);
-  rowReaderOpts.setScanSpec(makeScanSpec(selectedType));
-  auto rowReader = reader->createRowReader(rowReaderOpts);
 
   auto expected = std::string(1024, '*');
   VectorPtr result = BaseVector::create(selectedType, 0, &(*leafPool_));
@@ -1465,26 +1275,21 @@ TEST_F(ParquetReaderTest, readVarbinaryFromFLBA) {
 
 TEST_F(ParquetReaderTest, readBinaryAsStringFromNation) {
   const std::string filename("nation.parquet");
-  const std::string sample(getExampleFilePath(filename));
 
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
+  auto readerOptions = makeDefaultReaderOptions();
   auto outputRowType =
       ROW({"nationkey", "name", "regionkey", "comment"},
           {BIGINT(), VARCHAR(), BIGINT(), VARCHAR()});
 
   readerOptions.setFileSchema(outputRowType);
-  auto reader = createReader(sample, readerOptions);
+  auto reader = createReader(filename, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 25ULL);
   auto rowType = reader->typeWithId();
   EXPECT_EQ(rowType->type()->kind(), TypeKind::ROW);
   EXPECT_EQ(rowType->size(), 4ULL);
   EXPECT_EQ(rowType->childAt(1)->type()->kind(), TypeKind::VARCHAR);
 
-  auto rowReaderOpts = getReaderOpts(outputRowType);
-  rowReaderOpts.setScanSpec(makeScanSpec(outputRowType));
-  auto rowReader = reader->createRowReader(rowReaderOpts);
+  auto rowReader = createRowReaderFromReader(*reader, outputRowType);
 
   auto expected = std::string("ALGERIA");
   VectorPtr result = BaseVector::create(outputRowType, 0, &(*leafPool_));
@@ -1498,11 +1303,8 @@ TEST_F(ParquetReaderTest, readBinaryAsStringFromNation) {
 
 TEST_F(ParquetReaderTest, readComplexType) {
   const std::string filename("complex_with_varchar_varbinary.parquet");
-  const std::string sample(getExampleFilePath(filename));
 
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
+  auto readerOptions = makeDefaultReaderOptions();
   auto outputRowType =
       ROW({"a", "b", "c", "d"},
           {ARRAY(VARCHAR()),
@@ -1511,16 +1313,14 @@ TEST_F(ParquetReaderTest, readComplexType) {
            MAP(VARBINARY(), BIGINT())});
 
   readerOptions.setFileSchema(outputRowType);
-  auto reader = createReader(sample, readerOptions);
+  auto reader = createReader(filename, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 1);
   auto rowType = reader->rowType();
   EXPECT_EQ(rowType->kind(), TypeKind::ROW);
   EXPECT_EQ(rowType->size(), 4);
   EXPECT_EQ(*rowType, *outputRowType);
 
-  auto rowReaderOpts = getReaderOpts(outputRowType);
-  rowReaderOpts.setScanSpec(makeScanSpec(outputRowType));
-  auto rowReader = reader->createRowReader(rowReaderOpts);
+  auto rowReader = createRowReaderFromReader(*reader, outputRowType);
 
   VectorPtr result = BaseVector::create(outputRowType, 0, &(*leafPool_));
   rowReader->next(1, result);
@@ -1547,24 +1347,19 @@ TEST_F(ParquetReaderTest, readComplexType) {
 
 TEST_F(ParquetReaderTest, readFixedLenBinaryAsStringFromUuid) {
   const std::string filename("uuid.parquet");
-  const std::string sample(getExampleFilePath(filename));
 
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
-  auto outputRowType = ROW({"uuid_field"}, {VARCHAR()});
+  auto readerOptions = makeDefaultReaderOptions();
+  auto outputRowType = ROW("uuid_field", VARCHAR());
 
   readerOptions.setFileSchema(outputRowType);
-  auto reader = createReader(sample, readerOptions);
+  auto reader = createReader(filename, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 3ULL);
   auto rowType = reader->typeWithId();
   EXPECT_EQ(rowType->type()->kind(), TypeKind::ROW);
   EXPECT_EQ(rowType->size(), 1ULL);
   EXPECT_EQ(rowType->childAt(0)->type()->kind(), TypeKind::VARCHAR);
 
-  auto rowReaderOpts = getReaderOpts(outputRowType);
-  rowReaderOpts.setScanSpec(makeScanSpec(outputRowType));
-  auto rowReader = reader->createRowReader(rowReaderOpts);
+  auto rowReader = createRowReaderFromReader(*reader, outputRowType);
 
   auto expected = std::string("5468454a-363f-ccc8-7d0b-76072a75dfaa");
   VectorPtr result = BaseVector::create(outputRowType, 0, &(*leafPool_));
@@ -1577,12 +1372,9 @@ TEST_F(ParquetReaderTest, readFixedLenBinaryAsStringFromUuid) {
 }
 
 TEST_F(ParquetReaderTest, testV2PageWithZeroMaxDefRep) {
-  const std::string sample(getExampleFilePath("v2_page.parquet"));
-
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReader(sample, readerOptions);
+  auto outputRowType = ROW("regionkey", BIGINT());
+  auto [reader, rowReader] =
+      readerBuilder().file("v2_page.parquet").schema(outputRowType).build();
   EXPECT_EQ(reader->numberOfRows(), 5ULL);
 
   auto rowType = reader->typeWithId();
@@ -1591,11 +1383,6 @@ TEST_F(ParquetReaderTest, testV2PageWithZeroMaxDefRep) {
 
   EXPECT_EQ(rowType->childAt(0)->type()->kind(), TypeKind::BIGINT);
 
-  auto outputRowType = ROW({"regionkey"}, {BIGINT()});
-  auto rowReaderOpts = getReaderOpts(outputRowType);
-  rowReaderOpts.setScanSpec(makeScanSpec(outputRowType));
-  auto rowReader = reader->createRowReader(rowReaderOpts);
-
   auto expected = makeRowVector({makeFlatVector<int64_t>({0, 1, 2, 3, 4})});
 
   assertReadWithReaderAndExpected(
@@ -1603,23 +1390,17 @@ TEST_F(ParquetReaderTest, testV2PageWithZeroMaxDefRep) {
 }
 
 TEST_F(ParquetReaderTest, readComplexTypeWithV2Page) {
-  const std::string sample(getExampleFilePath("complex_type_v2_page.parquet"));
-
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReader(sample, readerOptions);
+  auto outputRowType =
+      ROW({"nums", "props"}, {ARRAY(INTEGER()), MAP(VARCHAR(), INTEGER())});
+  auto [reader, rowReader] = readerBuilder()
+                                 .file("complex_type_v2_page.parquet")
+                                 .schema(outputRowType)
+                                 .build();
   EXPECT_EQ(reader->numberOfRows(), 1ULL);
 
   auto rowType = reader->typeWithId();
   EXPECT_EQ(rowType->type()->kind(), TypeKind::ROW);
   EXPECT_EQ(rowType->size(), 2ULL);
-
-  auto outputRowType =
-      ROW({"nums", "props"}, {ARRAY(INTEGER()), MAP(VARCHAR(), INTEGER())});
-  auto rowReaderOpts = getReaderOpts(outputRowType);
-  rowReaderOpts.setScanSpec(makeScanSpec(outputRowType));
-  auto rowReader = reader->createRowReader(rowReaderOpts);
 
   auto expected = makeRowVector(
       {makeArrayVectorFromJson<int32_t>({"[4 ,5]"}),
@@ -1645,18 +1426,15 @@ TEST_F(ParquetReaderTest, arrayOfMapOfIntKeyArrayValue) {
   //  }
   const std::string expectedVeloxType =
       "ROW<test:ARRAY<MAP<VARCHAR,ARRAY<INTEGER>>>>";
-  const std::string sample(
-      getExampleFilePath("array_of_map_of_int_key_array_value.parquet"));
-  facebook::velox::dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReader(sample, readerOptions);
+  auto rowType = ROW("test", ARRAY(MAP(VARCHAR(), ARRAY(INTEGER()))));
+  auto [reader, rowReader] =
+      readerBuilder()
+          .file("array_of_map_of_int_key_array_value.parquet")
+          .schema(rowType)
+          .noColumnSelector()
+          .build();
   EXPECT_EQ(reader->rowType()->toString(), expectedVeloxType);
   auto type = reader->typeWithId();
-  RowReaderOptions rowReaderOpts;
-  auto rowType = ROW({"test"}, {ARRAY(MAP(VARCHAR(), ARRAY(INTEGER())))});
-  rowReaderOpts.setScanSpec(makeScanSpec(rowType));
-  auto rowReader = reader->createRowReader(rowReaderOpts);
   auto result = BaseVector::create(rowType, 10, leafPool_.get());
   constexpr int kBatchSize = 1000;
   while (rowReader->next(kBatchSize, result)) {
@@ -1680,18 +1458,11 @@ TEST_F(ParquetReaderTest, arrayOfMapOfIntKeyStructValue) {
   //  }
   const std::string expectedVeloxType =
       "ROW<test:ARRAY<MAP<INTEGER,ROW<stringfield:VARCHAR,longfield:BIGINT>>>>";
-  const std::string sample(
-      getExampleFilePath("array_of_map_of_int_key_struct_value.parquet"));
-  facebook::velox::dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReader(sample, readerOptions);
+  auto reader = createReader("array_of_map_of_int_key_struct_value.parquet");
   EXPECT_EQ(reader->rowType()->toString(), expectedVeloxType);
   auto type = reader->typeWithId();
-  RowReaderOptions rowReaderOpts;
   auto rowType = reader->rowType();
-  rowReaderOpts.setScanSpec(makeScanSpec(rowType));
-  auto rowReader = reader->createRowReader(rowReaderOpts);
+  auto rowReader = createRowReaderFromReaderNoSelect(*reader, rowType);
   auto result = BaseVector::create(rowType, 10, leafPool_.get());
   constexpr int kBatchSize = 1000;
   while (rowReader->next(kBatchSize, result)) {
@@ -1716,12 +1487,15 @@ TEST_F(ParquetReaderTest, struct_of_array_of_array) {
   //  }
   const std::string expectedVeloxType =
       "ROW<test:ROW<stringarrayfield:ARRAY<ARRAY<VARCHAR>>,intarrayfield:ARRAY<ARRAY<INTEGER>>>>";
-  const std::string sample(
-      getExampleFilePath("struct_of_array_of_array.parquet"));
-  facebook::velox::dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReader(sample, readerOptions);
+  auto rowType =
+      ROW("test",
+          ROW({"stringarrayfield", "intarrayfield"},
+              {ARRAY(ARRAY(VARCHAR())), ARRAY(ARRAY(INTEGER()))}));
+  auto [reader, rowReader] = readerBuilder()
+                                 .file("struct_of_array_of_array.parquet")
+                                 .schema(rowType)
+                                 .noColumnSelector()
+                                 .build();
   auto type = reader->typeWithId();
   EXPECT_EQ(type->size(), 1ULL);
   EXPECT_EQ(reader->rowType()->toString(), expectedVeloxType);
@@ -1767,14 +1541,6 @@ TEST_F(ParquetReaderTest, struct_of_array_of_array) {
   EXPECT_EQ(
       array_leaf_column_for_intarrayfield->type()->kind(), TypeKind::INTEGER);
 
-  RowReaderOptions rowReaderOpts;
-  auto rowType =
-      ROW({"test"},
-          {ROW(
-              {"stringarrayfield", "intarrayfield"},
-              {ARRAY(ARRAY(VARCHAR())), ARRAY(ARRAY(INTEGER()))})});
-  rowReaderOpts.setScanSpec(makeScanSpec(rowType));
-  auto rowReader = reader->createRowReader(rowReaderOpts);
   auto result = BaseVector::create(rowType, 10, leafPool_.get());
   constexpr int kBatchSize = 1000;
   while (rowReader->next(kBatchSize, result)) {
@@ -1782,20 +1548,12 @@ TEST_F(ParquetReaderTest, struct_of_array_of_array) {
 }
 
 TEST_F(ParquetReaderTest, testLzoDataPage) {
-  const std::string sample(getExampleFilePath("lzo.parquet"));
-
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReader(sample, readerOptions);
-  EXPECT_EQ(reader->numberOfRows(), 23'547ULL);
-
   auto outputRowType = ROW(
       {"test"},
       {ROW({"intfield", "stringarrayfield"}, {INTEGER(), ARRAY(VARCHAR())})});
-  auto rowReaderOpts = getReaderOpts(outputRowType);
-  rowReaderOpts.setScanSpec(makeScanSpec(outputRowType));
-  auto rowReader = reader->createRowReader(rowReaderOpts);
+  auto [reader, rowReader] =
+      readerBuilder().file("lzo.parquet").schema(outputRowType).build();
+  EXPECT_EQ(reader->numberOfRows(), 23'547ULL);
 
   VectorPtr result = BaseVector::create(outputRowType, 0, &*leafPool_);
   rowReader->next(23'547ULL, result);
@@ -1819,20 +1577,13 @@ TEST_F(ParquetReaderTest, testLzoDataPage) {
 }
 
 TEST_F(ParquetReaderTest, testEmptyV2DataPage) {
-  const std::string sample(getExampleFilePath("empty_v2datapage.parquet"));
-
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReader(sample, readerOptions);
+  auto outputRowType = ROW("test", REAL());
+  auto [reader, rowReader] = readerBuilder()
+                                 .file("empty_v2datapage.parquet")
+                                 .schema(outputRowType)
+                                 .build();
   EXPECT_EQ(reader->numberOfRows(), 30001ULL);
-
-  auto outputRowType = ROW({"test"}, {REAL()});
   EXPECT_EQ(*(reader->typeWithId()->type()), *outputRowType);
-
-  auto rowReaderOpts = getReaderOpts(outputRowType);
-  rowReaderOpts.setScanSpec(makeScanSpec(outputRowType));
-  auto rowReader = reader->createRowReader(rowReaderOpts);
 
   auto expected = makeRowVector({makeFlatVector<float>(
       30001, [](auto /*row*/) { return 1; }, nullEvery(1))});
@@ -1847,17 +1598,13 @@ TEST_F(ParquetReaderTest, parquet251) {
   auto expected = makeRowVector({
       makeFlatVector<std::string>({"2"}),
   });
-  auto rowType = ROW({"str"}, {VARCHAR()});
+  auto rowType = ROW("str", VARCHAR());
   assertReadWithFilters(
       "parquet-251.parquet", rowType, std::move(filters), expected);
 }
 
 TEST_F(ParquetReaderTest, fileColumnVarcharToMetadataColumnMismatchTest) {
-  const std::string sample(getExampleFilePath("nation.parquet"));
-
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
+  auto readerOptions = makeDefaultReaderOptions();
 
   auto runVarcharColTest = [&](const TypePtr& requestedType) {
     // The type in the file is a BYTE_ARRAY resolving to VARCHAR.
@@ -1873,7 +1620,7 @@ TEST_F(ParquetReaderTest, fileColumnVarcharToMetadataColumnMismatchTest) {
     // schema from the file.
     readerOptions.setFileSchema(outputRowType);
     VELOX_ASSERT_THROW(
-        createReader(sample, readerOptions),
+        createReader("nation.parquet", readerOptions),
         fmt::format(
             "Converted type VARCHAR is not allowed for requested type {} for file column 'name'",
             requestedType->toString()));
@@ -1916,9 +1663,7 @@ TEST_F(ParquetReaderTest, readerWithSchema) {
   writer->close();
 
   // Create the reader.
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
+  auto readerOptions = makeDefaultReaderOptions();
   readerOptions.setFileSchema(schema);
   std::string dataBuf(sinkPtr->data(), sinkPtr->size());
   auto file = std::make_shared<InMemoryReadFile>(std::move(dataBuf));
@@ -1939,10 +1684,7 @@ TEST_F(ParquetReaderTest, columnStatistics) {
       });
 
   auto* sink = write(data);
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReaderInMemory(*sink, readerOptions);
+  auto reader = createReaderInMemory(*sink);
   const auto& schema = reader->typeWithId();
 
   // Root ROW type — no stats for non-leaf.
@@ -2000,10 +1742,7 @@ TEST_F(ParquetReaderTest, columnStatisticsWithNulls) {
       });
 
   auto* sink = write(data);
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReaderInMemory(*sink, readerOptions);
+  auto reader = createReaderInMemory(*sink);
   const auto& schema = reader->typeWithId();
 
   auto stats = reader->columnStatistics(schema->childByName("a")->id());
@@ -2035,10 +1774,7 @@ TEST_F(ParquetReaderTest, columnStatisticsMultipleRowGroups) {
       });
 
   auto* sink = write(data, writerOptions);
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReaderInMemory(*sink, readerOptions);
+  auto reader = createReaderInMemory(*sink);
 
   // Verify we have multiple row groups.
   ASSERT_GT(reader->fileMetaData().numRowGroups(), 1);
@@ -2060,7 +1796,7 @@ TEST_F(ParquetReaderTest, readTimeMillis) {
   // Write TIME data using the parquet writer.
   // The writer exports Velox TIME as Arrow time32 with milliseconds unit,
   // which maps to Parquet TIME_MILLIS (INT32).
-  const auto rowType = ROW({"time_col"}, {TIME()});
+  const auto rowType = ROW("time_col", TIME());
 
   auto data = makeRowVector(
       rowType->names(),
@@ -2069,10 +1805,8 @@ TEST_F(ParquetReaderTest, readTimeMillis) {
           TIME())});
   auto sink = write(data);
 
-  dwio::common::ReaderOptions readerOpts(leafPool_.get());
-  readerOpts.setDataIoStats(dataIoStats_);
-  readerOpts.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReaderInMemory(*sink, readerOpts);
+  auto [reader, rowReader] =
+      readerBuilder().sink(*sink).schema(rowType).build();
 
   EXPECT_EQ(reader->numberOfRows(), 6ULL);
 
@@ -2081,10 +1815,6 @@ TEST_F(ParquetReaderTest, readTimeMillis) {
   auto col0 = type->childAt(0);
   EXPECT_TRUE(col0->type()->isTime());
 
-  auto rowReaderOpts = getReaderOpts(rowType);
-  rowReaderOpts.setScanSpec(makeScanSpec(rowType));
-  auto rowReader = reader->createRowReader(rowReaderOpts);
-
   assertReadWithReaderAndExpected(rowType, *rowReader, data, *leafPool_);
 }
 
@@ -2092,7 +1822,7 @@ TEST_F(ParquetReaderTest, readTimeMicros) {
   // Write TIME MICRO UTC data using the parquet writer.
   // The writer exports Velox TIME MICRO UTC as Arrow time64 with microseconds
   // unit, which maps to Parquet TIME_MICROS (INT64).
-  const auto rowType = ROW({"time_col"}, {TIME_MICRO_UTC()});
+  const auto rowType = ROW("time_col", TIME_MICRO_UTC());
 
   auto data = makeRowVector(
       rowType->names(),
@@ -2107,10 +1837,8 @@ TEST_F(ParquetReaderTest, readTimeMicros) {
           TIME_MICRO_UTC())});
   auto sink = write(data);
 
-  dwio::common::ReaderOptions readerOpts{leafPool_.get()};
-  readerOpts.setDataIoStats(dataIoStats_);
-  readerOpts.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReaderInMemory(*sink, readerOpts);
+  auto [reader, rowReader] =
+      readerBuilder().sink(*sink).schema(rowType).build();
 
   EXPECT_EQ(reader->numberOfRows(), 7ULL);
 
@@ -2119,10 +1847,6 @@ TEST_F(ParquetReaderTest, readTimeMicros) {
   auto col0 = type->childAt(0);
   EXPECT_TRUE(col0->type()->isTime());
   EXPECT_TRUE(col0->type()->equivalent(*TIME_MICRO_UTC()));
-
-  auto rowReaderOpts = getReaderOpts(rowType);
-  rowReaderOpts.setScanSpec(makeScanSpec(rowType));
-  auto rowReader = reader->createRowReader(rowReaderOpts);
 
   assertReadWithReaderAndExpected(rowType, *rowReader, data, *leafPool_);
 }
@@ -2142,10 +1866,8 @@ TEST_F(ParquetReaderTest, readTimeWithMultipleColumns) {
 
   auto sink = write(data);
 
-  dwio::common::ReaderOptions readerOpts(leafPool_.get());
-  readerOpts.setDataIoStats(dataIoStats_);
-  readerOpts.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReaderInMemory(*sink, readerOpts);
+  auto [reader, rowReader] =
+      readerBuilder().sink(*sink).schema(rowType).build();
 
   EXPECT_EQ(reader->numberOfRows(), 5ULL);
 
@@ -2155,10 +1877,6 @@ TEST_F(ParquetReaderTest, readTimeWithMultipleColumns) {
   EXPECT_TRUE(type->childAt(1)->type()->isTime());
   EXPECT_EQ(type->childAt(2)->type()->kind(), TypeKind::VARCHAR);
 
-  auto rowReaderOpts = getReaderOpts(rowType);
-  rowReaderOpts.setScanSpec(makeScanSpec(rowType));
-  auto rowReader = reader->createRowReader(rowReaderOpts);
-
   assertReadWithReaderAndExpected(rowType, *rowReader, data, *leafPool_);
 }
 
@@ -2166,13 +1884,12 @@ TEST_F(ParquetReaderTest, readTimeWithMultipleColumns) {
 // for the deserialized Thrift footer is reported to the pool when the row
 // reader is created and released when the reader is destroyed.
 TEST_F(ParquetReaderTest, thriftMemoryTracking) {
-  const std::string sample(getExampleFilePath("sample.parquet"));
   auto readerOptions = makeThriftTrackingReaderOptions();
   const auto initialUsage = leafPool_->usedBytes();
   {
-    auto reader = createReader(sample, readerOptions);
+    auto reader = createReader("sample.parquet", readerOptions);
     EXPECT_EQ(reader->numberOfRows(), 20ULL);
-    auto rowReaderOpts = getReaderOpts(sampleSchema());
+    auto rowReaderOpts = makeRowReaderOpts(sampleSchema());
     rowReaderOpts.setScanSpec(makeScanSpec(sampleSchema()));
     auto rowReader = reader->createRowReader(rowReaderOpts);
 
@@ -2208,18 +1925,17 @@ TEST_F(ParquetReaderTest, thriftMemoryTracking) {
 // the same ParquetReader), and the reservation is balanced by frees
 // after the reader is destroyed.
 TEST_F(ParquetReaderTest, thriftMemoryOwnedByReader) {
-  const std::string sample(getExampleFilePath("sample.parquet"));
   auto readerOptions = makeThriftTrackingReaderOptions();
   const auto initialAllocs = leafPool_->stats().numExternalAllocs;
   const auto initialFrees = leafPool_->stats().numExternalFrees;
   {
-    auto reader = createReader(sample, readerOptions);
+    auto reader = createReader("sample.parquet", readerOptions);
     EXPECT_EQ(leafPool_->stats().numExternalAllocs, initialAllocs + 1);
     EXPECT_EQ(leafPool_->stats().numExternalFrees, initialFrees);
 
     {
       // Full-range row reader: no row groups skipped, no accounting change.
-      auto rowReaderOpts = getReaderOpts(sampleSchema());
+      auto rowReaderOpts = makeRowReaderOpts(sampleSchema());
       rowReaderOpts.setScanSpec(makeScanSpec(sampleSchema()));
       auto rowReader = reader->createRowReader(rowReaderOpts);
       EXPECT_EQ(leafPool_->stats().numExternalAllocs, initialAllocs + 1);
@@ -2232,7 +1948,7 @@ TEST_F(ParquetReaderTest, thriftMemoryOwnedByReader) {
     // Range (0, 1) is out-of-file, so no row groups match — this also
     // sidesteps a pre-existing multi-row-reader prefetch limitation in
     // ParquetData::seekToRowGroup unrelated to footer accounting.
-    auto emptyRangeRowReaderOpts = getReaderOpts(sampleSchema());
+    auto emptyRangeRowReaderOpts = makeRowReaderOpts(sampleSchema());
     emptyRangeRowReaderOpts.setScanSpec(makeScanSpec(sampleSchema()));
     emptyRangeRowReaderOpts.range(0, 1);
     auto emptyRangeRowReader = reader->createRowReader(emptyRangeRowReaderOpts);
@@ -2249,10 +1965,9 @@ TEST_F(ParquetReaderTest, thriftMemoryOwnedByReader) {
 // runtime stat, and appears in the runtime-metric map for operator
 // stats consumers.
 TEST_F(ParquetReaderTest, thriftMemoryRuntimeStat) {
-  const std::string sample(getExampleFilePath("sample.parquet"));
   auto readerOptions = makeThriftTrackingReaderOptions();
-  auto reader = createReader(sample, readerOptions);
-  auto rowReaderOpts = getReaderOpts(sampleSchema());
+  auto reader = createReader("sample.parquet", readerOptions);
+  auto rowReaderOpts = makeRowReaderOpts(sampleSchema());
   rowReaderOpts.setScanSpec(makeScanSpec(sampleSchema()));
   auto rowReader = reader->createRowReader(rowReaderOpts);
 
@@ -2274,12 +1989,8 @@ TEST_F(ParquetReaderTest, thriftMemoryRuntimeStat) {
 // the metric is not emitted in the metric map (kept off the operator
 // stats panel for non-tracking scans).
 TEST_F(ParquetReaderTest, thriftMemoryRuntimeStatAbsentWithoutTracking) {
-  const std::string sample(getExampleFilePath("sample.parquet"));
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReader(sample, readerOptions);
-  auto rowReaderOpts = getReaderOpts(sampleSchema());
+  auto reader = createReader("sample.parquet");
+  auto rowReaderOpts = makeRowReaderOpts(sampleSchema());
   rowReaderOpts.setScanSpec(makeScanSpec(sampleSchema()));
   auto rowReader = reader->createRowReader(rowReaderOpts);
 
@@ -2295,16 +2006,11 @@ TEST_F(ParquetReaderTest, thriftMemoryRuntimeStatAbsentWithoutTracking) {
 // disabled: no external allocation is reported, and ~ReaderBase has
 // nothing to release.
 TEST_F(ParquetReaderTest, thriftMemoryNotTrackedByDefault) {
-  const std::string sample(getExampleFilePath("sample.parquet"));
-
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
   // Default threshold (uint64::max) leaves tracking disabled.
   const auto initialExternalAllocs = leafPool_->stats().numExternalAllocs;
   {
-    auto reader = createReader(sample, readerOptions);
-    auto rowReaderOpts = getReaderOpts(sampleSchema());
+    auto reader = createReader("sample.parquet");
+    auto rowReaderOpts = makeRowReaderOpts(sampleSchema());
     rowReaderOpts.setScanSpec(makeScanSpec(sampleSchema()));
     auto rowReader = reader->createRowReader(rowReaderOpts);
     EXPECT_EQ(leafPool_->stats().numExternalAllocs, initialExternalAllocs);
@@ -2318,11 +2024,10 @@ TEST_F(ParquetReaderTest, thriftMemoryNotTrackedByDefault) {
 // to the pool when the row reader runs filterRowGroups.
 TEST_F(ParquetReaderTest, thriftMemoryReleasedForSkippedRowGroups) {
   const auto rowType = ROW({"id"}, {BIGINT()});
-  const std::string sample(getExampleFilePath("multiple_row_groups.parquet"));
   auto readerOptions = makeThriftTrackingReaderOptions();
   const auto initialUsage = leafPool_->usedBytes();
   {
-    auto reader = createReader(sample, readerOptions);
+    auto reader = createReader("multiple_row_groups.parquet", readerOptions);
     const auto numRowGroups = reader->fileMetaData().numRowGroups();
     ASSERT_GT(numRowGroups, 1);
 

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -36,8 +36,7 @@ class ParquetReaderTest : public ParquetTestBase {
   std::unique_ptr<dwio::common::RowReader> createRowReader(
       const std::string& fileName,
       const RowTypePtr& rowType) {
-    auto [reader, rowReader] =
-        readerBuilder().file(fileName).schema(rowType).build();
+    auto [reader, rowReader] = readerBuilder(fileName, rowType).build();
     readerStore_.push_back(std::move(reader));
     return std::move(rowReader);
   }
@@ -76,7 +75,7 @@ TEST_F(ParquetReaderTest, parseSample) {
   //   a: [1..20]
   //   b: [1.0..20.0]
   auto [reader, rowReader] =
-      readerBuilder().file("sample.parquet").schema(sampleSchema()).build();
+      readerBuilder("sample.parquet", sampleSchema()).build();
   EXPECT_EQ(reader->numberOfRows(), 20ULL);
 
   auto type = reader->typeWithId();
@@ -127,10 +126,8 @@ TEST_F(ParquetReaderTest, parseEmptyNestedList) {
   // All 1000 rows in one row group.
   // Data is in RLE_DICTIONARY Snappy format.
   auto schema = ROW("msg", ROW("a", ROW("b", ARRAY(INTEGER()))));
-  auto [reader, rowReader] = readerBuilder()
-                                 .file("parse_empty_nested_list.parquet")
-                                 .schema(schema)
-                                 .build();
+  auto [reader, rowReader] =
+      readerBuilder("parse_empty_nested_list.parquet", schema).build();
   EXPECT_EQ(reader->numberOfRows(), 1000ULL);
 
   // Ensure the intact data structure
@@ -373,11 +370,8 @@ TEST_F(ParquetReaderTest, parseArrayOfRowHiveReservedKeywords) {
 }
 
 TEST_F(ParquetReaderTest, parseSampleRange1) {
-  auto [reader, rowReader] = readerBuilder()
-                                 .file("sample.parquet")
-                                 .schema(sampleSchema())
-                                 .range(0, 200)
-                                 .build();
+  auto [reader, rowReader] =
+      readerBuilder("sample.parquet", sampleSchema()).byteRange(0, 200).build();
   auto expected = makeRowVector({
       makeFlatVector<int64_t>(10, [](auto row) { return row + 1; }),
       makeFlatVector<double>(10, [](auto row) { return row + 1; }),
@@ -387,10 +381,8 @@ TEST_F(ParquetReaderTest, parseSampleRange1) {
 }
 
 TEST_F(ParquetReaderTest, parseSampleRange2) {
-  auto [reader, rowReader] = readerBuilder()
-                                 .file("sample.parquet")
-                                 .schema(sampleSchema())
-                                 .range(200, 500)
+  auto [reader, rowReader] = readerBuilder("sample.parquet", sampleSchema())
+                                 .byteRange(200, 500)
                                  .build();
   auto expected = makeRowVector({
       makeFlatVector<int64_t>(10, [](auto row) { return row + 11; }),
@@ -401,10 +393,8 @@ TEST_F(ParquetReaderTest, parseSampleRange2) {
 }
 
 TEST_F(ParquetReaderTest, parseSampleEmptyRange) {
-  auto [reader, rowReader] = readerBuilder()
-                                 .file("sample.parquet")
-                                 .schema(sampleSchema())
-                                 .range(300, 10)
+  auto [reader, rowReader] = readerBuilder("sample.parquet", sampleSchema())
+                                 .byteRange(300, 10)
                                  .build();
 
   VectorPtr result;
@@ -508,8 +498,7 @@ TEST_F(ParquetReaderTest, parseInt) {
   // Data is in plain uncompressed format:
   //   int: [100 .. 109]
   //   bigint: [1000 .. 1009]
-  auto [reader, rowReader] =
-      readerBuilder().file("int.parquet").schema(intSchema()).build();
+  auto [reader, rowReader] = readerBuilder("int.parquet", intSchema()).build();
 
   EXPECT_EQ(reader->numberOfRows(), 10ULL);
 
@@ -539,8 +528,7 @@ TEST_F(ParquetReaderTest, parseUnsignedInt1) {
   auto rowType =
       ROW({"uint8", "uint16", "uint32", "uint64"},
           {TINYINT(), SMALLINT(), INTEGER(), BIGINT()});
-  auto [reader, rowReader] =
-      readerBuilder().file("uint.parquet").schema(rowType).build();
+  auto [reader, rowReader] = readerBuilder("uint.parquet", rowType).build();
   EXPECT_EQ(reader->numberOfRows(), 3ULL);
   auto type = reader->typeWithId();
   EXPECT_EQ(type->size(), 4ULL);
@@ -630,7 +618,7 @@ TEST_F(ParquetReaderTest, parseDate) {
   // Data is in plain uncompressed format:
   //   date: [1969-12-27 .. 1970-01-20]
   auto [reader, rowReader] =
-      readerBuilder().file("date.parquet").schema(dateSchema()).build();
+      readerBuilder("date.parquet", dateSchema()).build();
 
   EXPECT_EQ(reader->numberOfRows(), 25ULL);
 
@@ -682,11 +670,8 @@ TEST_F(ParquetReaderTest, parseRowMapArray) {
 TEST_F(ParquetReaderTest, projectNoColumns) {
   // This is the case for count(*).
   auto rowType = ROW({}, {});
-  auto [reader, rowReader] = readerBuilder()
-                                 .file("sample.parquet")
-                                 .schema(rowType)
-                                 .noColumnSelector()
-                                 .build();
+  auto [reader, rowReader] =
+      readerBuilder("sample.parquet", rowType).withScanSpecOnly().build();
   auto result = BaseVector::create(rowType, 1, leafPool_.get());
   constexpr int kBatchSize = 100;
   ASSERT_TRUE(rowReader->next(kBatchSize, result));
@@ -706,11 +691,8 @@ TEST_F(ParquetReaderTest, parseIntDecimal) {
   //   a: [11.11, 11.11, 22.22, 22.22, 33.33, 33.33]
   //   b: [11.11, 11.11, 22.22, 22.22, 33.33, 33.33]
   auto rowType = ROW({"a", "b"}, {DECIMAL(7, 2), DECIMAL(14, 2)});
-  auto [reader, rowReader] = readerBuilder()
-                                 .file("decimal_dict.parquet")
-                                 .schema(rowType)
-                                 .noColumnSelector()
-                                 .build();
+  auto [reader, rowReader] =
+      readerBuilder("decimal_dict.parquet", rowType).withScanSpecOnly().build();
 
   EXPECT_EQ(reader->numberOfRows(), 6ULL);
 
@@ -759,7 +741,7 @@ TEST_F(ParquetReaderTest, parseMapKeyValueAsMap) {
   auto fileSchema =
       ROW("test", createType<TypeKind::MAP>({VARCHAR(), BIGINT()}));
   auto [reader, rowReader] =
-      readerBuilder().file("map_key_value.parquet").schema(fileSchema).build();
+      readerBuilder("map_key_value.parquet", fileSchema).build();
   EXPECT_EQ(reader->numberOfRows(), 1ULL);
 
   auto rowType = reader->typeWithId();
@@ -809,10 +791,8 @@ TEST_F(ParquetReaderTest, parseRowArrayTest) {
            ROW("someId", INTEGER()),
            ROW("someId", INTEGER()),
            ARRAY(ROW("someId", INTEGER()))});
-  auto [reader, rowReader] = readerBuilder()
-                                 .file("proto-struct-with-array.parquet")
-                                 .schema(outputRowType)
-                                 .build();
+  auto [reader, rowReader] =
+      readerBuilder("proto-struct-with-array.parquet", outputRowType).build();
   EXPECT_EQ(reader->numberOfRows(), 1ULL);
   auto type = reader->typeWithId();
   EXPECT_EQ(type->size(), 6ULL);
@@ -1080,11 +1060,10 @@ TEST_F(ParquetReaderTest, filterRowGroups) {
   // decimal_no_ColumnMetadata.parquet has one columns a: DECIMAL(9,1). It
   // doesn't have ColumnMetaData, and rowGroups_[0].columns[0].file_offset is 0.
   auto rowType = ROW("_c0", DECIMAL(9, 1));
-  auto [reader, rowReader] = readerBuilder()
-                                 .file("decimal_no_ColumnMetadata.parquet")
-                                 .schema(rowType)
-                                 .noColumnSelector()
-                                 .build();
+  auto [reader, rowReader] =
+      readerBuilder("decimal_no_ColumnMetadata.parquet", rowType)
+          .withScanSpecOnly()
+          .build();
 
   EXPECT_EQ(reader->numberOfRows(), 10ULL);
 }
@@ -1104,11 +1083,10 @@ TEST_F(ParquetReaderTest, shouldIgnoreStatsForParquetMRVersions) {
 // This test is to verify filterRowGroups() doesn't fail if offset is 0
 TEST_F(ParquetReaderTest, filterRowGroupsWithZeroOffset) {
   auto rowType = ROW("IDX", INTEGER());
-  auto [reader, rowReader] = readerBuilder()
-                                 .file("zero_offset_row_group.parquet")
-                                 .schema(rowType)
-                                 .noColumnSelector()
-                                 .build();
+  auto [reader, rowReader] =
+      readerBuilder("zero_offset_row_group.parquet", rowType)
+          .withScanSpecOnly()
+          .build();
 
   EXPECT_EQ(reader->numberOfRows(), 1L);
 }
@@ -1177,7 +1155,7 @@ TEST_F(ParquetReaderTest, prefetchRowGroups) {
     auto reader = createReader("multiple_row_groups.parquet", readerOptions);
     EXPECT_EQ(reader->fileMetaData().numRowGroups(), numRowGroups);
 
-    auto rowReader = createRowReaderFromReaderNoSelect(*reader, rowType);
+    auto rowReader = createRowReaderFromReader(*reader, rowType, false);
     auto parquetRowReader = dynamic_cast<ParquetRowReader*>(rowReader.get());
 
     constexpr int kBatchSize = 1000;
@@ -1211,10 +1189,8 @@ TEST_F(ParquetReaderTest, prefetchRowGroups) {
 TEST_F(ParquetReaderTest, testEmptyRowGroups) {
   // empty_row_groups.parquet contains empty row groups
   auto fileSchema = ROW("a", INTEGER());
-  auto [reader, rowReader] = readerBuilder()
-                                 .file("empty_row_groups.parquet")
-                                 .schema(fileSchema)
-                                 .build();
+  auto [reader, rowReader] =
+      readerBuilder("empty_row_groups.parquet", fileSchema).build();
   EXPECT_EQ(reader->numberOfRows(), 5ULL);
 
   auto rowType = reader->typeWithId();
@@ -1233,7 +1209,7 @@ TEST_F(ParquetReaderTest, testEnumType) {
   // enum_type.parquet contains 1 column (ENUM) with 3 rows.
   auto fileSchema = ROW("test", VARCHAR());
   auto [reader, rowReader] =
-      readerBuilder().file("enum_type.parquet").schema(fileSchema).build();
+      readerBuilder("enum_type.parquet", fileSchema).build();
   EXPECT_EQ(reader->numberOfRows(), 3ULL);
 
   auto rowType = reader->typeWithId();
@@ -1251,8 +1227,7 @@ TEST_F(ParquetReaderTest, testEnumType) {
 TEST_F(ParquetReaderTest, readVarbinaryFromFLBA) {
   const std::string filename("varbinary_flba.parquet");
   auto selectedType = ROW("flba_field", VARBINARY());
-  auto [reader, rowReader] =
-      readerBuilder().file(filename).schema(selectedType).build();
+  auto [reader, rowReader] = readerBuilder(filename, selectedType).build();
 
   auto type = reader->typeWithId();
   EXPECT_EQ(type->size(), 8ULL);
@@ -1374,7 +1349,7 @@ TEST_F(ParquetReaderTest, readFixedLenBinaryAsStringFromUuid) {
 TEST_F(ParquetReaderTest, testV2PageWithZeroMaxDefRep) {
   auto outputRowType = ROW("regionkey", BIGINT());
   auto [reader, rowReader] =
-      readerBuilder().file("v2_page.parquet").schema(outputRowType).build();
+      readerBuilder("v2_page.parquet", outputRowType).build();
   EXPECT_EQ(reader->numberOfRows(), 5ULL);
 
   auto rowType = reader->typeWithId();
@@ -1392,10 +1367,8 @@ TEST_F(ParquetReaderTest, testV2PageWithZeroMaxDefRep) {
 TEST_F(ParquetReaderTest, readComplexTypeWithV2Page) {
   auto outputRowType =
       ROW({"nums", "props"}, {ARRAY(INTEGER()), MAP(VARCHAR(), INTEGER())});
-  auto [reader, rowReader] = readerBuilder()
-                                 .file("complex_type_v2_page.parquet")
-                                 .schema(outputRowType)
-                                 .build();
+  auto [reader, rowReader] =
+      readerBuilder("complex_type_v2_page.parquet", outputRowType).build();
   EXPECT_EQ(reader->numberOfRows(), 1ULL);
 
   auto rowType = reader->typeWithId();
@@ -1428,10 +1401,8 @@ TEST_F(ParquetReaderTest, arrayOfMapOfIntKeyArrayValue) {
       "ROW<test:ARRAY<MAP<VARCHAR,ARRAY<INTEGER>>>>";
   auto rowType = ROW("test", ARRAY(MAP(VARCHAR(), ARRAY(INTEGER()))));
   auto [reader, rowReader] =
-      readerBuilder()
-          .file("array_of_map_of_int_key_array_value.parquet")
-          .schema(rowType)
-          .noColumnSelector()
+      readerBuilder("array_of_map_of_int_key_array_value.parquet", rowType)
+          .withScanSpecOnly()
           .build();
   EXPECT_EQ(reader->rowType()->toString(), expectedVeloxType);
   auto type = reader->typeWithId();
@@ -1462,7 +1433,7 @@ TEST_F(ParquetReaderTest, arrayOfMapOfIntKeyStructValue) {
   EXPECT_EQ(reader->rowType()->toString(), expectedVeloxType);
   auto type = reader->typeWithId();
   auto rowType = reader->rowType();
-  auto rowReader = createRowReaderFromReaderNoSelect(*reader, rowType);
+  auto rowReader = createRowReaderFromReader(*reader, rowType, false);
   auto result = BaseVector::create(rowType, 10, leafPool_.get());
   constexpr int kBatchSize = 1000;
   while (rowReader->next(kBatchSize, result)) {
@@ -1491,11 +1462,10 @@ TEST_F(ParquetReaderTest, struct_of_array_of_array) {
       ROW("test",
           ROW({"stringarrayfield", "intarrayfield"},
               {ARRAY(ARRAY(VARCHAR())), ARRAY(ARRAY(INTEGER()))}));
-  auto [reader, rowReader] = readerBuilder()
-                                 .file("struct_of_array_of_array.parquet")
-                                 .schema(rowType)
-                                 .noColumnSelector()
-                                 .build();
+  auto [reader, rowReader] =
+      readerBuilder("struct_of_array_of_array.parquet", rowType)
+          .withScanSpecOnly()
+          .build();
   auto type = reader->typeWithId();
   EXPECT_EQ(type->size(), 1ULL);
   EXPECT_EQ(reader->rowType()->toString(), expectedVeloxType);
@@ -1552,7 +1522,7 @@ TEST_F(ParquetReaderTest, testLzoDataPage) {
       {"test"},
       {ROW({"intfield", "stringarrayfield"}, {INTEGER(), ARRAY(VARCHAR())})});
   auto [reader, rowReader] =
-      readerBuilder().file("lzo.parquet").schema(outputRowType).build();
+      readerBuilder("lzo.parquet", outputRowType).build();
   EXPECT_EQ(reader->numberOfRows(), 23'547ULL);
 
   VectorPtr result = BaseVector::create(outputRowType, 0, &*leafPool_);
@@ -1578,10 +1548,8 @@ TEST_F(ParquetReaderTest, testLzoDataPage) {
 
 TEST_F(ParquetReaderTest, testEmptyV2DataPage) {
   auto outputRowType = ROW("test", REAL());
-  auto [reader, rowReader] = readerBuilder()
-                                 .file("empty_v2datapage.parquet")
-                                 .schema(outputRowType)
-                                 .build();
+  auto [reader, rowReader] =
+      readerBuilder("empty_v2datapage.parquet", outputRowType).build();
   EXPECT_EQ(reader->numberOfRows(), 30001ULL);
   EXPECT_EQ(*(reader->typeWithId()->type()), *outputRowType);
 
@@ -1805,8 +1773,7 @@ TEST_F(ParquetReaderTest, readTimeMillis) {
           TIME())});
   auto sink = write(data);
 
-  auto [reader, rowReader] =
-      readerBuilder().sink(*sink).schema(rowType).build();
+  auto [reader, rowReader] = readerBuilder(*sink, rowType).build();
 
   EXPECT_EQ(reader->numberOfRows(), 6ULL);
 
@@ -1837,8 +1804,7 @@ TEST_F(ParquetReaderTest, readTimeMicros) {
           TIME_MICRO_UTC())});
   auto sink = write(data);
 
-  auto [reader, rowReader] =
-      readerBuilder().sink(*sink).schema(rowType).build();
+  auto [reader, rowReader] = readerBuilder(*sink, rowType).build();
 
   EXPECT_EQ(reader->numberOfRows(), 7ULL);
 
@@ -1866,8 +1832,7 @@ TEST_F(ParquetReaderTest, readTimeWithMultipleColumns) {
 
   auto sink = write(data);
 
-  auto [reader, rowReader] =
-      readerBuilder().sink(*sink).schema(rowType).build();
+  auto [reader, rowReader] = readerBuilder(*sink, rowType).build();
 
   EXPECT_EQ(reader->numberOfRows(), 5ULL);
 

--- a/velox/dwio/parquet/tests/reader/ParquetReaderWideningTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderWideningTest.cpp
@@ -27,20 +27,32 @@ using namespace facebook::velox::parquet;
 
 class ParquetReaderWideningTest : public ParquetTestBase {
  public:
+  /// Builds widening/narrowing ReaderOptions from the default options.
+  dwio::common::ReaderOptions makeWideningReaderOptions(
+      const RowTypePtr& readSchema,
+      bool allowInt32Narrowing = false) const {
+    auto opts = makeDefaultReaderOptions();
+    opts.setFileSchema(readSchema);
+    opts.setAllowInt32Narrowing(allowInt32Narrowing);
+    return opts;
+  }
+
+  /// Writes data, reads it back with a wider (or narrower) schema and returns
+  /// only the RowReader. The underlying ParquetReader is stored in readerStore_
+  /// so it stays alive for the duration of the test.
   std::unique_ptr<dwio::common::RowReader> createWideningRowReader(
       const RowVectorPtr& writeData,
       const RowTypePtr& readSchema,
       bool allowInt32Narrowing = false) {
     auto* sink = write(writeData);
-    dwio::common::ReaderOptions readerOptions(leafPool_.get());
-    readerOptions.setDataIoStats(dataIoStats_);
-    readerOptions.setMetadataIoStats(metadataIoStats_);
-    readerOptions.setFileSchema(readSchema);
-    readerOptions.setAllowInt32Narrowing(allowInt32Narrowing);
-    auto reader = createReaderInMemory(*sink, readerOptions);
-    auto rowReaderOpts = getReaderOpts(readSchema);
-    rowReaderOpts.setScanSpec(makeScanSpec(readSchema));
-    return reader->createRowReader(rowReaderOpts);
+    auto [reader, rowReader] = readerBuilder()
+                                   .sink(*sink)
+                                   .schema(readSchema)
+                                   .readerOptions(makeWideningReaderOptions(
+                                       readSchema, allowInt32Narrowing))
+                                   .build();
+    readerStore_.push_back(std::move(reader));
+    return std::move(rowReader);
   }
 
   /// Writes Parquet data with one schema and reads it back with a wider schema,
@@ -74,13 +86,9 @@ class ParquetReaderWideningTest : public ParquetTestBase {
       const RowVectorPtr& expected,
       bool allowInt32Narrowing = false) {
     auto* sink = write(writeData);
-    dwio::common::ReaderOptions readerOptions(leafPool_.get());
-    readerOptions.setDataIoStats(dataIoStats_);
-    readerOptions.setMetadataIoStats(metadataIoStats_);
-    readerOptions.setFileSchema(readSchema);
-    readerOptions.setAllowInt32Narrowing(allowInt32Narrowing);
-    auto reader = createReaderInMemory(*sink, readerOptions);
-    auto rowReaderOpts = getReaderOpts(readSchema);
+    auto reader = createReaderInMemory(
+        *sink, makeWideningReaderOptions(readSchema, allowInt32Narrowing));
+    auto rowReaderOpts = makeRowReaderOpts(readSchema);
     auto scanSpec = makeScanSpec(readSchema);
     auto* child = scanSpec->getOrCreateChild(common::Subfield("col"));
     child->setFilter(std::move(filter));
@@ -98,12 +106,8 @@ class ParquetReaderWideningTest : public ParquetTestBase {
       const RowTypePtr& readSchema,
       const std::string& sourceTypeName) {
     auto* sink = write(writeData);
-    dwio::common::ReaderOptions readerOptions(leafPool_.get());
-    readerOptions.setDataIoStats(dataIoStats_);
-    readerOptions.setMetadataIoStats(metadataIoStats_);
-    readerOptions.setFileSchema(readSchema);
     VELOX_ASSERT_THROW(
-        createReaderInMemory(*sink, readerOptions),
+        createReaderInMemory(*sink, makeWideningReaderOptions(readSchema)),
         "Converted type " + sourceTypeName +
             " is not allowed for requested type");
   }
@@ -233,10 +237,7 @@ void FloatToDoubleEvolutionTest::runFloatToDoubleScenario(
 
   RowTypePtr readSchema = ROW({"float_col", "id"}, {DOUBLE(), BIGINT()});
 
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
-  readerOptions.setFileSchema(readSchema);
+  auto readerOptions = makeWideningReaderOptions(readSchema);
 
   std::string dataBuf(sinkPtr->data(), sinkPtr->size());
   auto file = std::make_shared<InMemoryReadFile>(std::move(dataBuf));
@@ -440,7 +441,7 @@ TEST_F(ParquetReaderWideningTest, intToShortDecimalWidening) {
   auto expected = makeRowVector({makeFlatVector<int64_t>(
       {0, 100, -100, 10'000, -10'000, 214'748'364'700LL, -214'748'364'800LL},
       DECIMAL(12, 2))});
-  assertWideningReads(writeData, ROW({"col"}, {DECIMAL(12, 2)}), expected);
+  assertWideningReads(writeData, ROW("col", DECIMAL(12, 2)), expected);
 }
 
 TEST_F(ParquetReaderWideningTest, smallintToShortDecimalWidening) {
@@ -448,7 +449,7 @@ TEST_F(ParquetReaderWideningTest, smallintToShortDecimalWidening) {
       {makeFlatVector<int16_t>({0, 1, -1, 100, 32'767, -32'768})});
   auto expected = makeRowVector({makeFlatVector<int64_t>(
       {0, 100, -100, 10'000, 3'276'700, -3'276'800}, DECIMAL(12, 2))});
-  assertWideningReads(writeData, ROW({"col"}, {DECIMAL(12, 2)}), expected);
+  assertWideningReads(writeData, ROW("col", DECIMAL(12, 2)), expected);
 }
 
 TEST_F(ParquetReaderWideningTest, tinyintToShortDecimalWidening) {
@@ -456,7 +457,7 @@ TEST_F(ParquetReaderWideningTest, tinyintToShortDecimalWidening) {
       makeRowVector({makeFlatVector<int8_t>({0, 1, -1, 100, 127, -128})});
   auto expected = makeRowVector({makeFlatVector<int64_t>(
       {0, 100, -100, 10'000, 12'700, -12'800}, DECIMAL(12, 2))});
-  assertWideningReads(writeData, ROW({"col"}, {DECIMAL(12, 2)}), expected);
+  assertWideningReads(writeData, ROW("col", DECIMAL(12, 2)), expected);
 }
 
 // Parquet stores TINYINT as INT32, so the minimum precision for decimal
@@ -466,7 +467,7 @@ TEST_F(ParquetReaderWideningTest, tinyintToDecimalMinPrecisionWidening) {
       makeRowVector({makeFlatVector<int8_t>({0, 1, -1, 127, -128})});
   auto expected = makeRowVector(
       {makeFlatVector<int64_t>({0, 1, -1, 127, -128}, DECIMAL(10, 0))});
-  assertWideningReads(writeData, ROW({"col"}, {DECIMAL(10, 0)}), expected);
+  assertWideningReads(writeData, ROW("col", DECIMAL(10, 0)), expected);
 }
 
 // Parquet stores SMALLINT as INT32, so decimal widening requires
@@ -476,7 +477,7 @@ TEST_F(ParquetReaderWideningTest, smallintToDecimalMinPrecisionWidening) {
       makeRowVector({makeFlatVector<int16_t>({0, 1, -1, 32'767, -32'768})});
   auto expected = makeRowVector(
       {makeFlatVector<int64_t>({0, 1, -1, 32'767, -32'768}, DECIMAL(10, 0))});
-  assertWideningReads(writeData, ROW({"col"}, {DECIMAL(10, 0)}), expected);
+  assertWideningReads(writeData, ROW("col", DECIMAL(10, 0)), expected);
 }
 
 // Byte -> Long Decimal. Parquet stores TINYINT as INT32.
@@ -485,7 +486,7 @@ TEST_F(ParquetReaderWideningTest, tinyintToLongDecimalWidening) {
       makeRowVector({makeFlatVector<int8_t>({0, 1, -1, 127, -128})});
   auto expected = makeRowVector(
       {makeFlatVector<int128_t>({0, 1, -1, 127, -128}, DECIMAL(20, 0))});
-  assertWideningReads(writeData, ROW({"col"}, {DECIMAL(20, 0)}), expected);
+  assertWideningReads(writeData, ROW("col", DECIMAL(20, 0)), expected);
 }
 
 // Short -> Long Decimal. Parquet stores SMALLINT as INT32.
@@ -494,7 +495,7 @@ TEST_F(ParquetReaderWideningTest, smallintToLongDecimalWidening) {
       makeRowVector({makeFlatVector<int16_t>({0, 1, -1, 32'767, -32'768})});
   auto expected = makeRowVector(
       {makeFlatVector<int128_t>({0, 1, -1, 32'767, -32'768}, DECIMAL(20, 0))});
-  assertWideningReads(writeData, ROW({"col"}, {DECIMAL(20, 0)}), expected);
+  assertWideningReads(writeData, ROW("col", DECIMAL(20, 0)), expected);
 }
 
 TEST_F(ParquetReaderWideningTest, bigintToLongDecimalWidening) {
@@ -507,7 +508,7 @@ TEST_F(ParquetReaderWideningTest, bigintToLongDecimalWidening) {
        static_cast<int128_t>(1'000'000'000'000LL) * 100'000,
        static_cast<int128_t>(-1'000'000'000'000LL) * 100'000},
       DECIMAL(25, 5))});
-  assertWideningReads(writeData, ROW({"col"}, {DECIMAL(25, 5)}), expected);
+  assertWideningReads(writeData, ROW("col", DECIMAL(25, 5)), expected);
 }
 
 TEST_F(ParquetReaderWideningTest, decimalToDecimalWidening) {
@@ -516,7 +517,7 @@ TEST_F(ParquetReaderWideningTest, decimalToDecimalWidening) {
   // Each value v becomes v * 10^(4-2) = v * 100.
   auto expected = makeRowVector({makeFlatVector<int64_t>(
       {111'100, 222'200, 333'300, -444'400, 0}, DECIMAL(10, 4))});
-  assertWideningReads(writeData, ROW({"col"}, {DECIMAL(10, 4)}), expected);
+  assertWideningReads(writeData, ROW("col", DECIMAL(10, 4)), expected);
 }
 
 TEST_F(ParquetReaderWideningTest, decimalToDecimalPrecisionOnlyWidening) {
@@ -524,7 +525,7 @@ TEST_F(ParquetReaderWideningTest, decimalToDecimalPrecisionOnlyWidening) {
       {makeFlatVector<int64_t>({1111, 2222, 3333, -4444, 0}, DECIMAL(7, 2))});
   auto expected = makeRowVector(
       {makeFlatVector<int64_t>({1111, 2222, 3333, -4444, 0}, DECIMAL(10, 2))});
-  assertWideningReads(writeData, ROW({"col"}, {DECIMAL(10, 2)}), expected);
+  assertWideningReads(writeData, ROW("col", DECIMAL(10, 2)), expected);
 }
 
 // Decimal long -> long, precision-only widening (scale stays the same).
@@ -533,7 +534,7 @@ TEST_F(ParquetReaderWideningTest, decimalLongToLongPrecisionOnlyWidening) {
       {makeFlatVector<int128_t>({1111, -2222, 0}, DECIMAL(20, 2))});
   auto expected = makeRowVector(
       {makeFlatVector<int128_t>({1111, -2222, 0}, DECIMAL(22, 2))});
-  assertWideningReads(writeData, ROW({"col"}, {DECIMAL(22, 2)}), expected);
+  assertWideningReads(writeData, ROW("col", DECIMAL(22, 2)), expected);
 }
 
 TEST_F(ParquetReaderWideningTest, decimalToDecimalWideningWithNulls) {
@@ -544,7 +545,7 @@ TEST_F(ParquetReaderWideningTest, decimalToDecimalWideningWithNulls) {
   auto expected = makeRowVector({makeNullableFlatVector<int64_t>(
       {std::nullopt, 111'100, std::nullopt, -444'400, 0, std::nullopt},
       DECIMAL(10, 4))});
-  assertWideningReads(writeData, ROW({"col"}, {DECIMAL(10, 4)}), expected);
+  assertWideningReads(writeData, ROW("col", DECIMAL(10, 4)), expected);
 }
 
 TEST_F(ParquetReaderWideningTest, intToDecimalWideningWithNulls) {
@@ -553,7 +554,7 @@ TEST_F(ParquetReaderWideningTest, intToDecimalWideningWithNulls) {
   auto expected = makeRowVector({makeNullableFlatVector<int64_t>(
       {std::nullopt, 4200, std::nullopt, -700, 0, std::nullopt},
       DECIMAL(12, 2))});
-  assertWideningReads(writeData, ROW({"col"}, {DECIMAL(12, 2)}), expected);
+  assertWideningReads(writeData, ROW("col", DECIMAL(12, 2)), expected);
 }
 
 // All-null column: getDecimalValues must handle ConstantVector (all nulls)
@@ -563,7 +564,7 @@ TEST_F(ParquetReaderWideningTest, intToDecimalWideningAllNull) {
       {std::nullopt, std::nullopt, std::nullopt})});
   auto expected = makeRowVector({makeNullableFlatVector<int64_t>(
       {std::nullopt, std::nullopt, std::nullopt}, DECIMAL(12, 2))});
-  assertWideningReads(writeData, ROW({"col"}, {DECIMAL(12, 2)}), expected);
+  assertWideningReads(writeData, ROW("col", DECIMAL(12, 2)), expected);
 }
 
 TEST_F(ParquetReaderWideningTest, decimalToDecimalWideningAllNull) {
@@ -571,7 +572,7 @@ TEST_F(ParquetReaderWideningTest, decimalToDecimalWideningAllNull) {
       {std::nullopt, std::nullopt, std::nullopt}, DECIMAL(7, 2))});
   auto expected = makeRowVector({makeNullableFlatVector<int64_t>(
       {std::nullopt, std::nullopt, std::nullopt}, DECIMAL(10, 4))});
-  assertWideningReads(writeData, ROW({"col"}, {DECIMAL(10, 4)}), expected);
+  assertWideningReads(writeData, ROW("col", DECIMAL(10, 4)), expected);
 }
 
 // INT32 -> SMALLINT narrowing. Parquet stores both as INT32; reading with
@@ -581,14 +582,14 @@ TEST_F(ParquetReaderWideningTest, intToSmallintNarrowing) {
       makeRowVector({makeFlatVector<int32_t>({0, 1, -1, 100, -100})});
   auto expected =
       makeRowVector({makeFlatVector<int16_t>({0, 1, -1, 100, -100})});
-  assertNarrowingReads(writeData, ROW({"col"}, {SMALLINT()}), expected);
+  assertNarrowingReads(writeData, ROW("col", SMALLINT()), expected);
 }
 
 TEST_F(ParquetReaderWideningTest, smallintToTinyintNarrowing) {
   auto writeData =
       makeRowVector({makeFlatVector<int16_t>({0, 1, -1, 42, -42})});
   auto expected = makeRowVector({makeFlatVector<int8_t>({0, 1, -1, 42, -42})});
-  assertNarrowingReads(writeData, ROW({"col"}, {TINYINT()}), expected);
+  assertNarrowingReads(writeData, ROW("col", TINYINT()), expected);
 }
 
 TEST_F(ParquetReaderWideningTest, shortToIntegerWidening) {
@@ -596,7 +597,7 @@ TEST_F(ParquetReaderWideningTest, shortToIntegerWidening) {
       makeRowVector({makeFlatVector<int16_t>({0, 1, -1, 32'767, -32'768})});
   auto expected =
       makeRowVector({makeFlatVector<int32_t>({0, 1, -1, 32'767, -32'768})});
-  assertWideningReads(writeData, ROW({"col"}, {INTEGER()}), expected);
+  assertWideningReads(writeData, ROW("col", INTEGER()), expected);
 }
 
 TEST_F(ParquetReaderWideningTest, intToBigintWidening) {
@@ -604,21 +605,21 @@ TEST_F(ParquetReaderWideningTest, intToBigintWidening) {
       {makeFlatVector<int32_t>({0, 1, -1, 2'147'483'647, -2'147'483'648})});
   auto expected = makeRowVector(
       {makeFlatVector<int64_t>({0, 1, -1, 2'147'483'647, -2'147'483'648})});
-  assertWideningReads(writeData, ROW({"col"}, {BIGINT()}), expected);
+  assertWideningReads(writeData, ROW("col", BIGINT()), expected);
 }
 
 // INT32 -> SMALLINT overflow: 32768 truncates to -32768.
 TEST_F(ParquetReaderWideningTest, intToSmallintOverflow) {
   auto writeData = makeRowVector({makeFlatVector<int32_t>({32'768})});
   auto expected = makeRowVector({makeFlatVector<int16_t>({-32'768})});
-  assertNarrowingReads(writeData, ROW({"col"}, {SMALLINT()}), expected);
+  assertNarrowingReads(writeData, ROW("col", SMALLINT()), expected);
 }
 
 // INT16 -> TINYINT overflow: 128 truncates to -128.
 TEST_F(ParquetReaderWideningTest, smallintToTinyintOverflow) {
   auto writeData = makeRowVector({makeFlatVector<int16_t>({128})});
   auto expected = makeRowVector({makeFlatVector<int8_t>({-128})});
-  assertNarrowingReads(writeData, ROW({"col"}, {TINYINT()}), expected);
+  assertNarrowingReads(writeData, ROW("col", TINYINT()), expected);
 }
 
 // INT32 -> DOUBLE works because sizeof(int32_t)=4 != sizeof(double)=8,
@@ -628,7 +629,7 @@ TEST_F(ParquetReaderWideningTest, intToDoubleWidening) {
       {0, 1, -1, 100, -100, 2'147'483'647, -2'147'483'648})});
   auto expected = makeRowVector({makeFlatVector<double>(
       {0.0, 1.0, -1.0, 100.0, -100.0, 2'147'483'647.0, -2'147'483'648.0})});
-  assertWideningReads(writeData, ROW({"col"}, {DOUBLE()}), expected);
+  assertWideningReads(writeData, ROW("col", DOUBLE()), expected);
 }
 
 TEST_F(ParquetReaderWideningTest, intToDoubleWideningWithNulls) {
@@ -636,7 +637,7 @@ TEST_F(ParquetReaderWideningTest, intToDoubleWideningWithNulls) {
       {std::nullopt, 42, std::nullopt, -7, 0, std::nullopt})});
   auto expected = makeRowVector({makeNullableFlatVector<double>(
       {std::nullopt, 42.0, std::nullopt, -7.0, 0.0, std::nullopt})});
-  assertWideningReads(writeData, ROW({"col"}, {DOUBLE()}), expected);
+  assertWideningReads(writeData, ROW("col", DOUBLE()), expected);
 }
 
 // Byte/Short -> Double widening. Parquet stores both as INT32.
@@ -645,7 +646,7 @@ TEST_F(ParquetReaderWideningTest, tinyintToDoubleWidening) {
       makeRowVector({makeFlatVector<int8_t>({0, 1, -1, 127, -128})});
   auto expected =
       makeRowVector({makeFlatVector<double>({0.0, 1.0, -1.0, 127.0, -128.0})});
-  assertWideningReads(writeData, ROW({"col"}, {DOUBLE()}), expected);
+  assertWideningReads(writeData, ROW("col", DOUBLE()), expected);
 }
 
 TEST_F(ParquetReaderWideningTest, smallintToDoubleWidening) {
@@ -653,7 +654,7 @@ TEST_F(ParquetReaderWideningTest, smallintToDoubleWidening) {
       makeRowVector({makeFlatVector<int16_t>({0, 1, -1, 32'767, -32'768})});
   auto expected = makeRowVector(
       {makeFlatVector<double>({0.0, 1.0, -1.0, 32'767.0, -32'768.0})});
-  assertWideningReads(writeData, ROW({"col"}, {DOUBLE()}), expected);
+  assertWideningReads(writeData, ROW("col", DOUBLE()), expected);
 }
 
 // INT -> Decimal with scale=0 (exact boundary: p-s=10 for INT32).
@@ -662,7 +663,7 @@ TEST_F(ParquetReaderWideningTest, intToDecimalScale0Widening) {
       makeRowVector({makeFlatVector<int32_t>({0, 42, -42, 2'147'483'647})});
   auto expected = makeRowVector(
       {makeFlatVector<int64_t>({0, 42, -42, 2'147'483'647}, DECIMAL(10, 0))});
-  assertWideningReads(writeData, ROW({"col"}, {DECIMAL(10, 0)}), expected);
+  assertWideningReads(writeData, ROW("col", DECIMAL(10, 0)), expected);
 }
 
 // INT -> Decimal with scale=1 (p-s=10, minimum boundary with nonzero scale).
@@ -670,7 +671,7 @@ TEST_F(ParquetReaderWideningTest, intToDecimalScale1Widening) {
   auto writeData = makeRowVector({makeFlatVector<int32_t>({0, 5, -5, 100})});
   auto expected = makeRowVector(
       {makeFlatVector<int64_t>({0, 50, -50, 1000}, DECIMAL(11, 1))});
-  assertWideningReads(writeData, ROW({"col"}, {DECIMAL(11, 1)}), expected);
+  assertWideningReads(writeData, ROW("col", DECIMAL(11, 1)), expected);
 }
 
 // Byte -> Decimal with nonzero scale. Values multiplied by 10^scale.
@@ -679,7 +680,7 @@ TEST_F(ParquetReaderWideningTest, tinyintToDecimalWithScaleWidening) {
       makeRowVector({makeFlatVector<int8_t>({0, 1, -1, 127, -128})});
   auto expected = makeRowVector(
       {makeFlatVector<int64_t>({0, 10, -10, 1'270, -1'280}, DECIMAL(11, 1))});
-  assertWideningReads(writeData, ROW({"col"}, {DECIMAL(11, 1)}), expected);
+  assertWideningReads(writeData, ROW("col", DECIMAL(11, 1)), expected);
 }
 
 // Short -> Decimal with nonzero scale. Values multiplied by 10^scale.
@@ -688,7 +689,7 @@ TEST_F(ParquetReaderWideningTest, smallintToDecimalWithScaleWidening) {
       makeRowVector({makeFlatVector<int16_t>({0, 1, -1, 32'767, -32'768})});
   auto expected = makeRowVector({makeFlatVector<int64_t>(
       {0, 10, -10, 327'670, -327'680}, DECIMAL(11, 1))});
-  assertWideningReads(writeData, ROW({"col"}, {DECIMAL(11, 1)}), expected);
+  assertWideningReads(writeData, ROW("col", DECIMAL(11, 1)), expected);
 }
 
 // INT32 -> Long Decimal (crossing short/long boundary).
@@ -697,7 +698,7 @@ TEST_F(ParquetReaderWideningTest, intToLongDecimalWidening) {
       {makeFlatVector<int32_t>({0, 1, -1, 2'147'483'647, -2'147'483'648})});
   auto expected = makeRowVector({makeFlatVector<int128_t>(
       {0, 1, -1, 2'147'483'647, -2'147'483'648}, DECIMAL(20, 0))});
-  assertWideningReads(writeData, ROW({"col"}, {DECIMAL(20, 0)}), expected);
+  assertWideningReads(writeData, ROW("col", DECIMAL(20, 0)), expected);
 }
 
 // BIGINT -> Decimal(38,0), maximum precision long decimal.
@@ -707,7 +708,7 @@ TEST_F(ParquetReaderWideningTest, bigintToMaxPrecisionDecimalWidening) {
   auto expected = makeRowVector({makeFlatVector<int128_t>(
       {0, 1, -1, static_cast<int128_t>(9'223'372'036'854'775'807LL)},
       DECIMAL(38, 0))});
-  assertWideningReads(writeData, ROW({"col"}, {DECIMAL(38, 0)}), expected);
+  assertWideningReads(writeData, ROW("col", DECIMAL(38, 0)), expected);
 }
 
 // BIGINT -> Decimal(21,1), INT64 with nonzero scale.
@@ -716,7 +717,7 @@ TEST_F(ParquetReaderWideningTest, bigintToDecimalWithScaleWidening) {
       makeRowVector({makeFlatVector<int64_t>({0, 1, -1, 999'999})});
   auto expected = makeRowVector(
       {makeFlatVector<int128_t>({0, 10, -10, 9'999'990}, DECIMAL(21, 1))});
-  assertWideningReads(writeData, ROW({"col"}, {DECIMAL(21, 1)}), expected);
+  assertWideningReads(writeData, ROW("col", DECIMAL(21, 1)), expected);
 }
 
 // Decimal short -> long decimal crossing: file stores int64 (short decimal),
@@ -726,7 +727,7 @@ TEST_F(ParquetReaderWideningTest, decimalShortToLongWidening) {
       {makeFlatVector<int64_t>({1111, -2222, 0, 99999}, DECIMAL(5, 2))});
   auto expected = makeRowVector(
       {makeFlatVector<int128_t>({1111, -2222, 0, 99999}, DECIMAL(20, 2))});
-  assertWideningReads(writeData, ROW({"col"}, {DECIMAL(20, 2)}), expected);
+  assertWideningReads(writeData, ROW("col", DECIMAL(20, 2)), expected);
 }
 
 TEST_F(ParquetReaderWideningTest, decimalShortToLongWithScaleWidening) {
@@ -735,7 +736,7 @@ TEST_F(ParquetReaderWideningTest, decimalShortToLongWithScaleWidening) {
   // v * 10^(4-2) = v * 100
   auto expected = makeRowVector(
       {makeFlatVector<int128_t>({111'100, -222'200, 0}, DECIMAL(20, 4))});
-  assertWideningReads(writeData, ROW({"col"}, {DECIMAL(20, 4)}), expected);
+  assertWideningReads(writeData, ROW("col", DECIMAL(20, 4)), expected);
 }
 
 // INT -> Decimal(38,0) max precision.
@@ -743,7 +744,7 @@ TEST_F(ParquetReaderWideningTest, smallintToMaxPrecisionDecimalWidening) {
   auto writeData = makeRowVector({makeFlatVector<int16_t>({0, 1, -1, 32'767})});
   auto expected = makeRowVector(
       {makeFlatVector<int128_t>({0, 1, -1, 32'767}, DECIMAL(38, 0))});
-  assertWideningReads(writeData, ROW({"col"}, {DECIMAL(38, 0)}), expected);
+  assertWideningReads(writeData, ROW("col", DECIMAL(38, 0)), expected);
 }
 
 TEST_F(ParquetReaderWideningTest, intToMaxPrecisionDecimalWidening) {
@@ -751,7 +752,7 @@ TEST_F(ParquetReaderWideningTest, intToMaxPrecisionDecimalWidening) {
       makeRowVector({makeFlatVector<int32_t>({0, 1, -1, 2'147'483'647})});
   auto expected = makeRowVector(
       {makeFlatVector<int128_t>({0, 1, -1, 2'147'483'647}, DECIMAL(38, 0))});
-  assertWideningReads(writeData, ROW({"col"}, {DECIMAL(38, 0)}), expected);
+  assertWideningReads(writeData, ROW("col", DECIMAL(38, 0)), expected);
 }
 
 // Decimal(5,2) -> (10,7) -- short to short with large scale increase.
@@ -761,7 +762,7 @@ TEST_F(ParquetReaderWideningTest, decimalWideningLargeScaleIncrease) {
   // v * 10^(7-2) = v * 100000
   auto expected = makeRowVector({makeFlatVector<int64_t>(
       {111'100'000, -222'200'000, 0}, DECIMAL(10, 7))});
-  assertWideningReads(writeData, ROW({"col"}, {DECIMAL(10, 7)}), expected);
+  assertWideningReads(writeData, ROW("col", DECIMAL(10, 7)), expected);
 }
 
 // Decimal(5,2) -> (20,17) -- short to long with large scale increase.
@@ -774,7 +775,7 @@ TEST_F(ParquetReaderWideningTest, decimalShortToLongLargeScaleWidening) {
        static_cast<int128_t>(-2222) * 1'000'000'000'000'000LL,
        0},
       DECIMAL(20, 17))});
-  assertWideningReads(writeData, ROW({"col"}, {DECIMAL(20, 17)}), expected);
+  assertWideningReads(writeData, ROW("col", DECIMAL(20, 17)), expected);
 }
 
 // Decimal(10,2) -> (12,4) -- short to short with precision and scale increase.
@@ -784,7 +785,7 @@ TEST_F(ParquetReaderWideningTest, decimalShortWideningPrecisionAndScale) {
   // v * 10^(4-2) = v * 100
   auto expected = makeRowVector(
       {makeFlatVector<int64_t>({1'234'500, -6'789'000, 0}, DECIMAL(12, 4))});
-  assertWideningReads(writeData, ROW({"col"}, {DECIMAL(12, 4)}), expected);
+  assertWideningReads(writeData, ROW("col", DECIMAL(12, 4)), expected);
 }
 
 // Decimal(10,2) -> (20,12) -- short to long with large scale increase.
@@ -799,7 +800,7 @@ TEST_F(
        static_cast<int128_t>(-67890) * 10'000'000'000LL,
        0},
       DECIMAL(20, 12))});
-  assertWideningReads(writeData, ROW({"col"}, {DECIMAL(20, 12)}), expected);
+  assertWideningReads(writeData, ROW("col", DECIMAL(20, 12)), expected);
 }
 
 // Decimal(20,2) -> (22,4) -- long to long with scale increase.
@@ -809,7 +810,7 @@ TEST_F(ParquetReaderWideningTest, decimalLongToLongWithScaleWidening) {
   // v * 10^(4-2) = v * 100
   auto expected = makeRowVector(
       {makeFlatVector<int128_t>({1'234'500, -6'789'000, 0}, DECIMAL(22, 4))});
-  assertWideningReads(writeData, ROW({"col"}, {DECIMAL(22, 4)}), expected);
+  assertWideningReads(writeData, ROW("col", DECIMAL(22, 4)), expected);
 }
 
 TEST_F(ParquetReaderWideningTest, typeWideningRejectionIncompatibleTypes) {
@@ -817,53 +818,53 @@ TEST_F(ParquetReaderWideningTest, typeWideningRejectionIncompatibleTypes) {
   // vs INT32's 10, which would cause silent precision loss.
   assertWideningThrows(
       makeRowVector({makeFlatVector<int32_t>({1, 2, 3})}),
-      ROW({"col"}, {REAL()}),
+      ROW("col", REAL()),
       "INTEGER");
 
   // BIGINT -> DOUBLE is not supported.
   assertWideningThrows(
       makeRowVector({makeFlatVector<int64_t>({1, 2, 3})}),
-      ROW({"col"}, {DOUBLE()}),
+      ROW("col", DOUBLE()),
       "BIGINT");
 
   // BIGINT -> INTEGER/SMALLINT/TINYINT narrowing is not supported.
   assertWideningThrows(
       makeRowVector({makeFlatVector<int64_t>({1, 2, 3})}),
-      ROW({"col"}, {INTEGER()}),
+      ROW("col", INTEGER()),
       "BIGINT");
   assertWideningThrows(
       makeRowVector({makeFlatVector<int64_t>({1, 2, 3})}),
-      ROW({"col"}, {SMALLINT()}),
+      ROW("col", SMALLINT()),
       "BIGINT");
   assertWideningThrows(
       makeRowVector({makeFlatVector<int64_t>({1, 2, 3})}),
-      ROW({"col"}, {TINYINT()}),
+      ROW("col", TINYINT()),
       "BIGINT");
 
   // DOUBLE -> FLOAT/INTEGER is not supported.
   assertWideningThrows(
       makeRowVector({makeFlatVector<double>({1.0, 2.0, 3.0})}),
-      ROW({"col"}, {REAL()}),
+      ROW("col", REAL()),
       "DOUBLE");
   assertWideningThrows(
       makeRowVector({makeFlatVector<double>({1.0, 2.0, 3.0})}),
-      ROW({"col"}, {INTEGER()}),
+      ROW("col", INTEGER()),
       "DOUBLE");
 
   // FLOAT -> INTEGER/BIGINT is not supported.
   assertWideningThrows(
       makeRowVector({makeFlatVector<float>({1.0f, 2.0f, 3.0f})}),
-      ROW({"col"}, {INTEGER()}),
+      ROW("col", INTEGER()),
       "REAL");
   assertWideningThrows(
       makeRowVector({makeFlatVector<float>({1.0f, 2.0f})}),
-      ROW({"col"}, {BIGINT()}),
+      ROW("col", BIGINT()),
       "REAL");
 
   // BIGINT -> FLOAT is not supported (precision loss).
   assertWideningThrows(
       makeRowVector({makeFlatVector<int64_t>({1, 2})}),
-      ROW({"col"}, {REAL()}),
+      ROW("col", REAL()),
       "BIGINT");
 }
 
@@ -871,57 +872,57 @@ TEST_F(ParquetReaderWideningTest, typeWideningRejectionIntDecimalPrecision) {
   // INT32 -> DECIMAL(8,0). p-s=8 < 10, insufficient for INT32.
   assertWideningThrows(
       makeRowVector({makeFlatVector<int32_t>({1, 2, 3})}),
-      ROW({"col"}, {DECIMAL(8, 0)}),
+      ROW("col", DECIMAL(8, 0)),
       "INTEGER");
 
   // TINYINT -> DECIMAL(9,0). Parquet stores TINYINT as INT32, so the
   // minimum precision is p-s >= 10. p-s=9 < 10.
   assertWideningThrows(
       makeRowVector({makeFlatVector<int8_t>({1, 2, 3})}),
-      ROW({"col"}, {DECIMAL(9, 0)}),
+      ROW("col", DECIMAL(9, 0)),
       "TINYINT");
 
   // SMALLINT -> DECIMAL(9,0). Same as TINYINT: stored as INT32, p-s=9 < 10.
   assertWideningThrows(
       makeRowVector({makeFlatVector<int16_t>({1, 2, 3})}),
-      ROW({"col"}, {DECIMAL(9, 0)}),
+      ROW("col", DECIMAL(9, 0)),
       "SMALLINT");
 
   // BIGINT -> DECIMAL(18,0). p-s=18 < 20, insufficient for INT64.
   assertWideningThrows(
       makeRowVector({makeFlatVector<int64_t>({1, 2, 3})}),
-      ROW({"col"}, {DECIMAL(18, 0)}),
+      ROW("col", DECIMAL(18, 0)),
       "BIGINT");
 
   // Exact boundary: INT32 -> DECIMAL(9,0), p-s=9 < 10.
   assertWideningThrows(
       makeRowVector({makeFlatVector<int32_t>({1, 2, 3})}),
-      ROW({"col"}, {DECIMAL(9, 0)}),
+      ROW("col", DECIMAL(9, 0)),
       "INTEGER");
 
   // Exact boundary: BIGINT -> DECIMAL(19,0), p-s=19 < 20.
   assertWideningThrows(
       makeRowVector({makeFlatVector<int64_t>({1, 2, 3})}),
-      ROW({"col"}, {DECIMAL(19, 0)}),
+      ROW("col", DECIMAL(19, 0)),
       "BIGINT");
 
   // Rejection with nonzero scale: p-s must still meet the threshold.
   // TINYINT -> DECIMAL(3,1). p-s=2 < 10.
   assertWideningThrows(
       makeRowVector({makeFlatVector<int8_t>({1, 2})}),
-      ROW({"col"}, {DECIMAL(3, 1)}),
+      ROW("col", DECIMAL(3, 1)),
       "TINYINT");
 
   // INT32 -> DECIMAL(10,1). p-s=9 < 10.
   assertWideningThrows(
       makeRowVector({makeFlatVector<int32_t>({1, 2})}),
-      ROW({"col"}, {DECIMAL(10, 1)}),
+      ROW("col", DECIMAL(10, 1)),
       "INTEGER");
 
   // BIGINT -> DECIMAL(20,1). p-s=19 < 20.
   assertWideningThrows(
       makeRowVector({makeFlatVector<int64_t>({1, 2})}),
-      ROW({"col"}, {DECIMAL(20, 1)}),
+      ROW("col", DECIMAL(20, 1)),
       "BIGINT");
 
   // INT->Decimal with insufficient precision (various small precisions).
@@ -929,19 +930,19 @@ TEST_F(ParquetReaderWideningTest, typeWideningRejectionIntDecimalPrecision) {
   auto smallintData = makeRowVector({makeFlatVector<int16_t>({1})});
   auto intData = makeRowVector({makeFlatVector<int32_t>({1})});
   auto bigintData = makeRowVector({makeFlatVector<int64_t>({1})});
-  assertWideningThrows(tinyintData, ROW({"col"}, {DECIMAL(1, 0)}), "TINYINT");
-  assertWideningThrows(tinyintData, ROW({"col"}, {DECIMAL(2, 0)}), "TINYINT");
-  assertWideningThrows(tinyintData, ROW({"col"}, {DECIMAL(3, 0)}), "TINYINT");
-  assertWideningThrows(smallintData, ROW({"col"}, {DECIMAL(3, 0)}), "SMALLINT");
-  assertWideningThrows(smallintData, ROW({"col"}, {DECIMAL(4, 0)}), "SMALLINT");
-  assertWideningThrows(smallintData, ROW({"col"}, {DECIMAL(5, 0)}), "SMALLINT");
-  assertWideningThrows(intData, ROW({"col"}, {DECIMAL(5, 0)}), "INTEGER");
-  assertWideningThrows(bigintData, ROW({"col"}, {DECIMAL(10, 0)}), "BIGINT");
+  assertWideningThrows(tinyintData, ROW("col", DECIMAL(1, 0)), "TINYINT");
+  assertWideningThrows(tinyintData, ROW("col", DECIMAL(2, 0)), "TINYINT");
+  assertWideningThrows(tinyintData, ROW("col", DECIMAL(3, 0)), "TINYINT");
+  assertWideningThrows(smallintData, ROW("col", DECIMAL(3, 0)), "SMALLINT");
+  assertWideningThrows(smallintData, ROW("col", DECIMAL(4, 0)), "SMALLINT");
+  assertWideningThrows(smallintData, ROW("col", DECIMAL(5, 0)), "SMALLINT");
+  assertWideningThrows(intData, ROW("col", DECIMAL(5, 0)), "INTEGER");
+  assertWideningThrows(bigintData, ROW("col", DECIMAL(10, 0)), "BIGINT");
 
   // INT->Decimal with nonzero scale, insufficient precision.
-  assertWideningThrows(tinyintData, ROW({"col"}, {DECIMAL(4, 1)}), "TINYINT");
-  assertWideningThrows(smallintData, ROW({"col"}, {DECIMAL(6, 1)}), "SMALLINT");
-  assertWideningThrows(smallintData, ROW({"col"}, {DECIMAL(5, 1)}), "SMALLINT");
+  assertWideningThrows(tinyintData, ROW("col", DECIMAL(4, 1)), "TINYINT");
+  assertWideningThrows(smallintData, ROW("col", DECIMAL(6, 1)), "SMALLINT");
+  assertWideningThrows(smallintData, ROW("col", DECIMAL(5, 1)), "SMALLINT");
 }
 
 TEST_F(
@@ -950,45 +951,45 @@ TEST_F(
   // Decimal precision decrease.
   assertWideningThrows(
       makeRowVector({makeFlatVector<int64_t>({1111}, DECIMAL(10, 2))}),
-      ROW({"col"}, {DECIMAL(5, 2)}),
+      ROW("col", DECIMAL(5, 2)),
       "DECIMAL(10, 2)");
   assertWideningThrows(
       makeRowVector({makeFlatVector<int128_t>({1111}, DECIMAL(20, 2))}),
-      ROW({"col"}, {DECIMAL(5, 2)}),
+      ROW("col", DECIMAL(5, 2)),
       "DECIMAL(20, 2)");
   assertWideningThrows(
       makeRowVector({makeFlatVector<int64_t>({1111}, DECIMAL(12, 2))}),
-      ROW({"col"}, {DECIMAL(10, 2)}),
+      ROW("col", DECIMAL(10, 2)),
       "DECIMAL(12, 2)");
   assertWideningThrows(
       makeRowVector({makeFlatVector<int128_t>({1111}, DECIMAL(20, 2))}),
-      ROW({"col"}, {DECIMAL(10, 2)}),
+      ROW("col", DECIMAL(10, 2)),
       "DECIMAL(20, 2)");
   assertWideningThrows(
       makeRowVector({makeFlatVector<int128_t>({1111}, DECIMAL(22, 2))}),
-      ROW({"col"}, {DECIMAL(20, 2)}),
+      ROW("col", DECIMAL(20, 2)),
       "DECIMAL(22, 2)");
 
   // Decimal precision+scale decrease (precInc < 0).
   assertWideningThrows(
       makeRowVector({makeFlatVector<int64_t>({1111}, DECIMAL(10, 7))}),
-      ROW({"col"}, {DECIMAL(5, 2)}),
+      ROW("col", DECIMAL(5, 2)),
       "DECIMAL(10, 7)");
   assertWideningThrows(
       makeRowVector({makeFlatVector<int128_t>({1111}, DECIMAL(20, 17))}),
-      ROW({"col"}, {DECIMAL(5, 2)}),
+      ROW("col", DECIMAL(5, 2)),
       "DECIMAL(20, 17)");
   assertWideningThrows(
       makeRowVector({makeFlatVector<int64_t>({1111}, DECIMAL(12, 4))}),
-      ROW({"col"}, {DECIMAL(10, 2)}),
+      ROW("col", DECIMAL(10, 2)),
       "DECIMAL(12, 4)");
   assertWideningThrows(
       makeRowVector({makeFlatVector<int128_t>({1111}, DECIMAL(20, 17))}),
-      ROW({"col"}, {DECIMAL(10, 2)}),
+      ROW("col", DECIMAL(10, 2)),
       "DECIMAL(20, 17)");
   assertWideningThrows(
       makeRowVector({makeFlatVector<int128_t>({1111}, DECIMAL(22, 4))}),
-      ROW({"col"}, {DECIMAL(20, 2)}),
+      ROW("col", DECIMAL(20, 2)),
       "DECIMAL(22, 4)");
 }
 
@@ -996,53 +997,53 @@ TEST_F(ParquetReaderWideningTest, typeWideningRejectionDecimalScaleViolation) {
   // DECIMAL(7,2) -> DECIMAL(8,5). scaleInc=3 > precInc=1.
   assertWideningThrows(
       makeRowVector({makeFlatVector<int64_t>({1111, 2222}, DECIMAL(7, 2))}),
-      ROW({"col"}, {DECIMAL(8, 5)}),
+      ROW("col", DECIMAL(8, 5)),
       "DECIMAL(7, 2)");
 
   // DECIMAL(7,2) -> DECIMAL(6,2). Precision decrease is not allowed.
   assertWideningThrows(
       makeRowVector({makeFlatVector<int64_t>({1111, 2222}, DECIMAL(7, 2))}),
-      ROW({"col"}, {DECIMAL(6, 2)}),
+      ROW("col", DECIMAL(6, 2)),
       "DECIMAL(7, 2)");
 
   // DECIMAL(7,4) -> DECIMAL(8,2). Scale narrowing (scaleInc < 0) is rejected.
   assertWideningThrows(
       makeRowVector({makeFlatVector<int64_t>({1111, 2222}, DECIMAL(7, 4))}),
-      ROW({"col"}, {DECIMAL(8, 2)}),
+      ROW("col", DECIMAL(8, 2)),
       "DECIMAL(7, 4)");
 
   // Scale decrease with precision increase (scaleInc < 0).
   assertWideningThrows(
       makeRowVector({makeFlatVector<int64_t>({1111}, DECIMAL(10, 6))}),
-      ROW({"col"}, {DECIMAL(12, 4)}),
+      ROW("col", DECIMAL(12, 4)),
       "DECIMAL(10, 6)");
   assertWideningThrows(
       makeRowVector({makeFlatVector<int128_t>({1111}, DECIMAL(20, 7))}),
-      ROW({"col"}, {DECIMAL(22, 5)}),
+      ROW("col", DECIMAL(22, 5)),
       "DECIMAL(20, 7)");
 
   // Precision decrease with scale increase.
   assertWideningThrows(
       makeRowVector({makeFlatVector<int64_t>({1111}, DECIMAL(12, 4))}),
-      ROW({"col"}, {DECIMAL(10, 6)}),
+      ROW("col", DECIMAL(10, 6)),
       "DECIMAL(12, 4)");
   assertWideningThrows(
       makeRowVector({makeFlatVector<int128_t>({1111}, DECIMAL(22, 5))}),
-      ROW({"col"}, {DECIMAL(20, 7)}),
+      ROW("col", DECIMAL(20, 7)),
       "DECIMAL(22, 5)");
 
   // scaleInc > precInc (not enough precision for the scale increase).
   assertWideningThrows(
       makeRowVector({makeFlatVector<int64_t>({1111}, DECIMAL(5, 2))}),
-      ROW({"col"}, {DECIMAL(6, 4)}),
+      ROW("col", DECIMAL(6, 4)),
       "DECIMAL(5, 2)");
   assertWideningThrows(
       makeRowVector({makeFlatVector<int64_t>({1111}, DECIMAL(10, 4))}),
-      ROW({"col"}, {DECIMAL(12, 7)}),
+      ROW("col", DECIMAL(12, 7)),
       "DECIMAL(10, 4)");
   assertWideningThrows(
       makeRowVector({makeFlatVector<int128_t>({1111}, DECIMAL(20, 5))}),
-      ROW({"col"}, {DECIMAL(22, 8)}),
+      ROW("col", DECIMAL(22, 8)),
       "DECIMAL(20, 5)");
 }
 
@@ -1068,19 +1069,17 @@ TEST_F(ParquetReaderWideningTest, allowInt32Narrowing) {
   auto* sink = write(data);
 
   // Default: flag is false.
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
+  auto readerOptions = makeDefaultReaderOptions();
   ASSERT_FALSE(readerOptions.allowInt32Narrowing());
 
   // INT32->TINYINT narrowing rejected by default.
-  readerOptions.setFileSchema(ROW({"c1"}, {TINYINT()}));
+  readerOptions.setFileSchema(ROW("c1", TINYINT()));
   VELOX_ASSERT_THROW(
       createReaderInMemory(*sink, readerOptions),
       "is not allowed for requested type");
 
   // INT32->SMALLINT narrowing rejected by default.
-  readerOptions.setFileSchema(ROW({"c1"}, {SMALLINT()}));
+  readerOptions.setFileSchema(ROW("c1", SMALLINT()));
   VELOX_ASSERT_THROW(
       createReaderInMemory(*sink, readerOptions),
       "is not allowed for requested type");
@@ -1088,15 +1087,16 @@ TEST_F(ParquetReaderWideningTest, allowInt32Narrowing) {
   // Annotated type-matching always works without the flag.
   // INT_8 -> TINYINT: write as TINYINT (produces INT_8 annotation), read back.
   {
-    auto readSchema = ROW({"c1"}, {TINYINT()});
+    auto readSchema = ROW("c1", TINYINT());
     auto tinyData =
         makeRowVector({"c1"}, {makeFlatVector<int8_t>({-128, -1, 0, 1, 127})});
     auto* tinySink = write(tinyData);
     readerOptions.setFileSchema(readSchema);
-    auto reader = createReaderInMemory(*tinySink, readerOptions);
-    auto rowReaderOpts = getReaderOpts(readSchema);
-    rowReaderOpts.setScanSpec(makeScanSpec(readSchema));
-    auto rowReader = reader->createRowReader(rowReaderOpts);
+    auto [reader, rowReader] = readerBuilder()
+                                   .sink(*tinySink)
+                                   .schema(readSchema)
+                                   .readerOptions(readerOptions)
+                                   .build();
     assertReadWithReaderAndExpected(
         readSchema, *rowReader, tinyData, *leafPool_);
   }
@@ -1104,15 +1104,16 @@ TEST_F(ParquetReaderWideningTest, allowInt32Narrowing) {
   // INT_16 -> SMALLINT: write as SMALLINT (produces INT_16 annotation), read
   // back.
   {
-    auto readSchema = ROW({"c1"}, {SMALLINT()});
+    auto readSchema = ROW("c1", SMALLINT());
     auto smallData = makeRowVector(
         {"c1"}, {makeFlatVector<int16_t>({-32768, -1, 0, 1, 32767})});
     auto* smallSink = write(smallData);
     readerOptions.setFileSchema(readSchema);
-    auto reader = createReaderInMemory(*smallSink, readerOptions);
-    auto rowReaderOpts = getReaderOpts(readSchema);
-    rowReaderOpts.setScanSpec(makeScanSpec(readSchema));
-    auto rowReader = reader->createRowReader(rowReaderOpts);
+    auto [reader, rowReader] = readerBuilder()
+                                   .sink(*smallSink)
+                                   .schema(readSchema)
+                                   .readerOptions(readerOptions)
+                                   .build();
     assertReadWithReaderAndExpected(
         readSchema, *rowReader, smallData, *leafPool_);
   }
@@ -1122,13 +1123,13 @@ TEST_F(ParquetReaderWideningTest, allowInt32Narrowing) {
 
   // INT32->TINYINT: values are truncated via static_cast<int8_t>.
   {
-    auto readSchema = ROW({"c1"}, {TINYINT()});
+    auto readSchema = ROW("c1", TINYINT());
     readerOptions.setFileSchema(readSchema);
-    auto reader = createReaderInMemory(*sink, readerOptions);
-
-    auto rowReaderOpts = getReaderOpts(readSchema);
-    rowReaderOpts.setScanSpec(makeScanSpec(readSchema));
-    auto rowReader = reader->createRowReader(rowReaderOpts);
+    auto [reader, rowReader] = readerBuilder()
+                                   .sink(*sink)
+                                   .schema(readSchema)
+                                   .readerOptions(readerOptions)
+                                   .build();
 
     auto expected = makeRowVector(
         {"c1"},
@@ -1152,13 +1153,13 @@ TEST_F(ParquetReaderWideningTest, allowInt32Narrowing) {
 
   // INT32->SMALLINT: values are truncated via static_cast<int16_t>.
   {
-    auto readSchema = ROW({"c1"}, {SMALLINT()});
+    auto readSchema = ROW("c1", SMALLINT());
     readerOptions.setFileSchema(readSchema);
-    auto reader = createReaderInMemory(*sink, readerOptions);
-
-    auto rowReaderOpts = getReaderOpts(readSchema);
-    rowReaderOpts.setScanSpec(makeScanSpec(readSchema));
-    auto rowReader = reader->createRowReader(rowReaderOpts);
+    auto [reader, rowReader] = readerBuilder()
+                                   .sink(*sink)
+                                   .schema(readSchema)
+                                   .readerOptions(readerOptions)
+                                   .build();
 
     auto expected = makeRowVector(
         {"c1"},
@@ -1188,10 +1189,7 @@ TEST_F(ParquetReaderWideningTest, tinyintToSmallintWideningWithFilter) {
   auto expected =
       makeRowVector({"col"}, {makeFlatVector<int16_t>({0, 10, 50, 127})});
   assertWideningWithFilter(
-      writeData,
-      ROW({"col"}, {SMALLINT()}),
-      exec::greaterThanOrEqual(0),
-      expected);
+      writeData, ROW("col", SMALLINT()), exec::greaterThanOrEqual(0), expected);
 }
 
 TEST_F(ParquetReaderWideningTest, tinyintToIntegerWideningWithFilter) {
@@ -1200,10 +1198,7 @@ TEST_F(ParquetReaderWideningTest, tinyintToIntegerWideningWithFilter) {
   auto expected =
       makeRowVector({"col"}, {makeFlatVector<int32_t>({0, 10, 50, 127})});
   assertWideningWithFilter(
-      writeData,
-      ROW({"col"}, {INTEGER()}),
-      exec::greaterThanOrEqual(0),
-      expected);
+      writeData, ROW("col", INTEGER()), exec::greaterThanOrEqual(0), expected);
 }
 
 TEST_F(ParquetReaderWideningTest, shortToIntegerWideningWithFilter) {
@@ -1212,10 +1207,7 @@ TEST_F(ParquetReaderWideningTest, shortToIntegerWideningWithFilter) {
   auto expected =
       makeRowVector({"col"}, {makeFlatVector<int32_t>({50, 100, 32'767})});
   assertWideningWithFilter(
-      writeData,
-      ROW({"col"}, {INTEGER()}),
-      exec::greaterThanOrEqual(50),
-      expected);
+      writeData, ROW("col", INTEGER()), exec::greaterThanOrEqual(50), expected);
 }
 
 TEST_F(ParquetReaderWideningTest, intToBigintWideningWithFilter) {
@@ -1224,10 +1216,7 @@ TEST_F(ParquetReaderWideningTest, intToBigintWideningWithFilter) {
   auto expected =
       makeRowVector({"col"}, {makeFlatVector<int64_t>({50, 100, 2'000'000})});
   assertWideningWithFilter(
-      writeData,
-      ROW({"col"}, {BIGINT()}),
-      exec::greaterThanOrEqual(50),
-      expected);
+      writeData, ROW("col", BIGINT()), exec::greaterThanOrEqual(50), expected);
 }
 
 // INT -> DOUBLE widening + filter.
@@ -1238,10 +1227,7 @@ TEST_F(ParquetReaderWideningTest, intToDoubleWideningWithFilter) {
       makeRowVector({"col"}, {makeFlatVector<double>({50.0, 100.0})});
   // BigintRange filter.
   assertWideningWithFilter(
-      writeData,
-      ROW({"col"}, {DOUBLE()}),
-      exec::greaterThanOrEqual(50),
-      expected);
+      writeData, ROW("col", DOUBLE()), exec::greaterThanOrEqual(50), expected);
 }
 
 TEST_F(ParquetReaderWideningTest, tinyintToDoubleWideningWithFilter) {
@@ -1250,10 +1236,7 @@ TEST_F(ParquetReaderWideningTest, tinyintToDoubleWideningWithFilter) {
   auto expected =
       makeRowVector({"col"}, {makeFlatVector<double>({0.0, 10.0, 50.0})});
   assertWideningWithFilter(
-      writeData,
-      ROW({"col"}, {DOUBLE()}),
-      exec::greaterThanOrEqual(0),
-      expected);
+      writeData, ROW("col", DOUBLE()), exec::greaterThanOrEqual(0), expected);
 }
 
 // DoubleRange filter not yet supported for widened columns. See #16895.
@@ -1264,7 +1247,7 @@ TEST_F(
       makeRowVector({"col"}, {makeFlatVector<int32_t>({-100, 0, 50, 100})});
   assertWideningWithFilter(
       writeData,
-      ROW({"col"}, {DOUBLE()}),
+      ROW("col", DOUBLE()),
       exec::greaterThanOrEqualDouble(50.0),
       makeRowVector({"col"}, {makeFlatVector<double>({50.0, 100.0})}));
 }
@@ -1276,7 +1259,7 @@ TEST_F(ParquetReaderWideningTest, intToDecimalWideningWithFilter) {
   // Scale 0.
   assertWideningWithFilter(
       writeData,
-      ROW({"col"}, {DECIMAL(10, 0)}),
+      ROW("col", DECIMAL(10, 0)),
       exec::greaterThanOrEqual(50),
       makeRowVector(
           {"col"}, {makeFlatVector<int64_t>({50, 100}, DECIMAL(10, 0))}));
@@ -1290,7 +1273,7 @@ TEST_F(
       makeRowVector({"col"}, {makeFlatVector<int32_t>({-100, 0, 50, 100})});
   assertWideningWithFilter(
       writeData,
-      ROW({"col"}, {DECIMAL(12, 2)}),
+      ROW("col", DECIMAL(12, 2)),
       exec::greaterThanOrEqual(5'000),
       makeRowVector(
           {"col"}, {makeFlatVector<int64_t>({5'000, 10'000}, DECIMAL(12, 2))}));
@@ -1303,7 +1286,7 @@ TEST_F(ParquetReaderWideningTest, DISABLED_bigintToDecimalWideningWithFilter) {
   // BIGINT -> Decimal(25, 5).
   assertWideningWithFilter(
       writeData,
-      ROW({"col"}, {DECIMAL(25, 5)}),
+      ROW("col", DECIMAL(25, 5)),
       exec::greaterThanOrEqualHugeint(int128_t(50) * 100'000),
       makeRowVector(
           {"col"},
@@ -1313,14 +1296,14 @@ TEST_F(ParquetReaderWideningTest, DISABLED_bigintToDecimalWideningWithFilter) {
   // BIGINT -> Decimal(38, 0).
   assertWideningWithFilter(
       writeData,
-      ROW({"col"}, {DECIMAL(38, 0)}),
+      ROW("col", DECIMAL(38, 0)),
       exec::greaterThanOrEqualHugeint(int128_t(50)),
       makeRowVector(
           {"col"}, {makeFlatVector<int128_t>({50, 100}, DECIMAL(38, 0))}));
   // BIGINT -> Decimal(21, 1).
   assertWideningWithFilter(
       writeData,
-      ROW({"col"}, {DECIMAL(21, 1)}),
+      ROW("col", DECIMAL(21, 1)),
       exec::greaterThanOrEqualHugeint(int128_t(50) * 10),
       makeRowVector(
           {"col"},
@@ -1336,7 +1319,7 @@ TEST_F(ParquetReaderWideningTest, decimalShortToShortWideningWithFilter) {
   // Scale unchanged: DECIMAL(7,2) -> DECIMAL(10,2).
   assertWideningWithFilter(
       writeData,
-      ROW({"col"}, {DECIMAL(10, 2)}),
+      ROW("col", DECIMAL(10, 2)),
       exec::greaterThanOrEqual(5'000),
       makeRowVector(
           {"col"}, {makeFlatVector<int64_t>({5'000, 10'000}, DECIMAL(10, 2))}));
@@ -1351,7 +1334,7 @@ TEST_F(
       {makeFlatVector<int64_t>({-1'000, 0, 5'000, 10'000}, DECIMAL(7, 2))});
   assertWideningWithFilter(
       writeData,
-      ROW({"col"}, {DECIMAL(10, 4)}),
+      ROW("col", DECIMAL(10, 4)),
       exec::greaterThanOrEqual(500'000),
       makeRowVector(
           {"col"},
@@ -1369,7 +1352,7 @@ TEST_F(
   // Scale unchanged: DECIMAL(5,2) -> DECIMAL(20,2).
   assertWideningWithFilter(
       writeData,
-      ROW({"col"}, {DECIMAL(20, 2)}),
+      ROW("col", DECIMAL(20, 2)),
       exec::greaterThanOrEqualHugeint(int128_t(5'000)),
       makeRowVector(
           {"col"},
@@ -1377,7 +1360,7 @@ TEST_F(
   // Scale changed: DECIMAL(5,2) -> DECIMAL(20,4).
   assertWideningWithFilter(
       writeData,
-      ROW({"col"}, {DECIMAL(20, 4)}),
+      ROW("col", DECIMAL(20, 4)),
       exec::greaterThanOrEqualHugeint(int128_t(500'000)),
       makeRowVector(
           {"col"},
@@ -1385,7 +1368,7 @@ TEST_F(
   // Large scale increase: DECIMAL(5,2) -> DECIMAL(10,7).
   assertWideningWithFilter(
       writeData,
-      ROW({"col"}, {DECIMAL(10, 7)}),
+      ROW("col", DECIMAL(10, 7)),
       exec::greaterThanOrEqual(500'000'000),
       makeRowVector(
           {"col"},
@@ -1394,7 +1377,7 @@ TEST_F(
   // Precision and scale increase: DECIMAL(5,2) -> DECIMAL(12,4).
   assertWideningWithFilter(
       writeData,
-      ROW({"col"}, {DECIMAL(12, 4)}),
+      ROW("col", DECIMAL(12, 4)),
       exec::greaterThanOrEqual(500'000),
       makeRowVector(
           {"col"},
@@ -1410,7 +1393,7 @@ TEST_F(
       {makeFlatVector<int128_t>({-1'000, 0, 5'000, 10'000}, DECIMAL(20, 2))});
   assertWideningWithFilter(
       writeData,
-      ROW({"col"}, {DECIMAL(22, 4)}),
+      ROW("col", DECIMAL(22, 4)),
       exec::greaterThanOrEqualHugeint(int128_t(500'000)),
       makeRowVector(
           {"col"},
@@ -1427,7 +1410,7 @@ TEST_F(ParquetReaderWideningTest, intNarrowingFilterBehavior) {
       makeRowVector({"col"}, {makeFlatVector<int8_t>({0, 50, 127})});
   assertWideningWithFilter(
       writeData,
-      ROW({"col"}, {TINYINT()}),
+      ROW("col", TINYINT()),
       std::make_unique<common::BigintRange>(0, 127, /*nullAllowed=*/false),
       expected,
       /*allowInt32Narrowing=*/true);
@@ -1440,14 +1423,14 @@ TEST_F(ParquetReaderWideningTest, intToBigintWideningNullFilter) {
       {makeNullableFlatVector<int32_t>({0, std::nullopt, 50, std::nullopt})});
   assertWideningWithFilter(
       writeData,
-      ROW({"col"}, {BIGINT()}),
+      ROW("col", BIGINT()),
       exec::isNull(),
       makeRowVector(
           {"col"},
           {makeNullableFlatVector<int64_t>({std::nullopt, std::nullopt})}));
   assertWideningWithFilter(
       writeData,
-      ROW({"col"}, {BIGINT()}),
+      ROW("col", BIGINT()),
       exec::isNotNull(),
       makeRowVector({"col"}, {makeFlatVector<int64_t>({0, 50})}));
 }
@@ -1458,14 +1441,14 @@ TEST_F(ParquetReaderWideningTest, intToDoubleWideningNullFilter) {
       {makeNullableFlatVector<int32_t>({0, std::nullopt, 50, std::nullopt})});
   assertWideningWithFilter(
       writeData,
-      ROW({"col"}, {DOUBLE()}),
+      ROW("col", DOUBLE()),
       exec::isNull(),
       makeRowVector(
           {"col"},
           {makeNullableFlatVector<double>({std::nullopt, std::nullopt})}));
   assertWideningWithFilter(
       writeData,
-      ROW({"col"}, {DOUBLE()}),
+      ROW("col", DOUBLE()),
       exec::isNotNull(),
       makeRowVector({"col"}, {makeFlatVector<double>({0.0, 50.0})}));
 }
@@ -1476,7 +1459,7 @@ TEST_F(ParquetReaderWideningTest, intToDecimalScale0NullFilter) {
       {makeNullableFlatVector<int32_t>({0, std::nullopt, 50, std::nullopt})});
   assertWideningWithFilter(
       writeData,
-      ROW({"col"}, {DECIMAL(10, 0)}),
+      ROW("col", DECIMAL(10, 0)),
       exec::isNull(),
       makeRowVector(
           {"col"},
@@ -1484,7 +1467,7 @@ TEST_F(ParquetReaderWideningTest, intToDecimalScale0NullFilter) {
               {std::nullopt, std::nullopt}, DECIMAL(10, 0))}));
   assertWideningWithFilter(
       writeData,
-      ROW({"col"}, {DECIMAL(10, 0)}),
+      ROW("col", DECIMAL(10, 0)),
       exec::isNotNull(),
       makeRowVector(
           {"col"}, {makeFlatVector<int64_t>({0, 50}, DECIMAL(10, 0))}));
@@ -1497,7 +1480,7 @@ TEST_F(ParquetReaderWideningTest, decimalPrecisionOnlyNullFilter) {
           {1'000, std::nullopt, 5'000, std::nullopt}, DECIMAL(7, 2))});
   assertWideningWithFilter(
       writeData,
-      ROW({"col"}, {DECIMAL(10, 2)}),
+      ROW("col", DECIMAL(10, 2)),
       exec::isNull(),
       makeRowVector(
           {"col"},
@@ -1505,7 +1488,7 @@ TEST_F(ParquetReaderWideningTest, decimalPrecisionOnlyNullFilter) {
               {std::nullopt, std::nullopt}, DECIMAL(10, 2))}));
   assertWideningWithFilter(
       writeData,
-      ROW({"col"}, {DECIMAL(10, 2)}),
+      ROW("col", DECIMAL(10, 2)),
       exec::isNotNull(),
       makeRowVector(
           {"col"}, {makeFlatVector<int64_t>({1'000, 5'000}, DECIMAL(10, 2))}));

--- a/velox/dwio/parquet/tests/reader/ParquetReaderWideningTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderWideningTest.cpp
@@ -45,12 +45,10 @@ class ParquetReaderWideningTest : public ParquetTestBase {
       const RowTypePtr& readSchema,
       bool allowInt32Narrowing = false) {
     auto* sink = write(writeData);
-    auto [reader, rowReader] = readerBuilder()
-                                   .sink(*sink)
-                                   .schema(readSchema)
-                                   .readerOptions(makeWideningReaderOptions(
-                                       readSchema, allowInt32Narrowing))
-                                   .build();
+    auto [reader, rowReader] =
+        readerBuilder(*sink, readSchema)
+            .options(makeWideningReaderOptions(readSchema, allowInt32Narrowing))
+            .build();
     readerStore_.push_back(std::move(reader));
     return std::move(rowReader);
   }
@@ -1092,11 +1090,8 @@ TEST_F(ParquetReaderWideningTest, allowInt32Narrowing) {
         makeRowVector({"c1"}, {makeFlatVector<int8_t>({-128, -1, 0, 1, 127})});
     auto* tinySink = write(tinyData);
     readerOptions.setFileSchema(readSchema);
-    auto [reader, rowReader] = readerBuilder()
-                                   .sink(*tinySink)
-                                   .schema(readSchema)
-                                   .readerOptions(readerOptions)
-                                   .build();
+    auto [reader, rowReader] =
+        readerBuilder(*tinySink, readSchema).options(readerOptions).build();
     assertReadWithReaderAndExpected(
         readSchema, *rowReader, tinyData, *leafPool_);
   }
@@ -1109,11 +1104,8 @@ TEST_F(ParquetReaderWideningTest, allowInt32Narrowing) {
         {"c1"}, {makeFlatVector<int16_t>({-32768, -1, 0, 1, 32767})});
     auto* smallSink = write(smallData);
     readerOptions.setFileSchema(readSchema);
-    auto [reader, rowReader] = readerBuilder()
-                                   .sink(*smallSink)
-                                   .schema(readSchema)
-                                   .readerOptions(readerOptions)
-                                   .build();
+    auto [reader, rowReader] =
+        readerBuilder(*smallSink, readSchema).options(readerOptions).build();
     assertReadWithReaderAndExpected(
         readSchema, *rowReader, smallData, *leafPool_);
   }
@@ -1125,11 +1117,8 @@ TEST_F(ParquetReaderWideningTest, allowInt32Narrowing) {
   {
     auto readSchema = ROW("c1", TINYINT());
     readerOptions.setFileSchema(readSchema);
-    auto [reader, rowReader] = readerBuilder()
-                                   .sink(*sink)
-                                   .schema(readSchema)
-                                   .readerOptions(readerOptions)
-                                   .build();
+    auto [reader, rowReader] =
+        readerBuilder(*sink, readSchema).options(readerOptions).build();
 
     auto expected = makeRowVector(
         {"c1"},
@@ -1155,11 +1144,8 @@ TEST_F(ParquetReaderWideningTest, allowInt32Narrowing) {
   {
     auto readSchema = ROW("c1", SMALLINT());
     readerOptions.setFileSchema(readSchema);
-    auto [reader, rowReader] = readerBuilder()
-                                   .sink(*sink)
-                                   .schema(readSchema)
-                                   .readerOptions(readerOptions)
-                                   .build();
+    auto [reader, rowReader] =
+        readerBuilder(*sink, readSchema).options(readerOptions).build();
 
     auto expected = makeRowVector(
         {"c1"},

--- a/velox/dwio/parquet/tests/writer/ParquetWriterFieldIdTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterFieldIdTest.cpp
@@ -68,10 +68,7 @@ TEST_P(ParquetWriterFieldIdTest, fieldIds) {
 
   auto* sinkPtr = write(data, writerOptions);
 
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
-  auto parquetReader = createReaderInMemory(*sinkPtr, readerOptions);
+  auto parquetReader = createReaderInMemory(*sinkPtr);
   EXPECT_EQ(parquetReader->numberOfRows(), kRows);
   auto veloxRowType = parquetReader->rowType();
   EXPECT_EQ(*veloxRowType, *schema);

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -68,16 +68,6 @@ class ParquetWriterTest : public ParquetTestBase {
     writers_.clear();
   }
 
-  std::unique_ptr<RowReader> createRowReaderWithSchema(
-      const std::unique_ptr<Reader> reader,
-      const RowTypePtr& rowType) {
-    auto rowReaderOpts = getReaderOpts(rowType);
-    auto scanSpec = makeScanSpec(rowType);
-    rowReaderOpts.setScanSpec(scanSpec);
-    auto rowReader = reader->createRowReader(rowReaderOpts);
-    return rowReader;
-  }
-
   RowVectorPtr makeSmallintTestData(int64_t rows) {
     auto data = makeRowVector({
         makeFlatVector<int16_t>(rows, [](auto row) { return row + 1; }),
@@ -94,10 +84,7 @@ class ParquetWriterTest : public ParquetTestBase {
   thrift::PageHeader readPageHeader(
       MemorySink* sinkPtr,
       int64_t offsetFromDataPage) {
-    dwio::common::ReaderOptions readerOptions(leafPool_.get());
-    readerOptions.setDataIoStats(dataIoStats_);
-    readerOptions.setMetadataIoStats(metadataIoStats_);
-    auto reader = createReaderInMemory(*sinkPtr, readerOptions);
+    auto reader = createReaderInMemory(*sinkPtr);
 
     auto colChunkPtr = reader->fileMetaData().rowGroup(0).columnChunk(0);
     std::string_view sinkData(sinkPtr->data(), sinkPtr->size());
@@ -416,10 +403,7 @@ TEST_F(ParquetWriterTest, compression) {
 
   auto* sinkPtr = write(data, writerOptions);
 
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReaderInMemory(*sinkPtr, readerOptions);
+  auto reader = createReaderInMemory(*sinkPtr);
 
   ASSERT_EQ(reader->numberOfRows(), kRows);
   ASSERT_EQ(*reader->rowType(), *schema);
@@ -431,7 +415,7 @@ TEST_F(ParquetWriterTest, compression) {
                             : CompressionKind::CompressionKind_SNAPPY);
   }
 
-  auto rowReader = createRowReaderWithSchema(std::move(reader), schema);
+  auto rowReader = createRowReaderFromReader(*reader, schema);
   assertReadWithReaderAndExpected(schema, *rowReader, data, *leafPool_);
 }
 
@@ -697,15 +681,12 @@ TEST_F(ParquetWriterTest, preEpochInt96Timestamp) {
 
   auto* sinkPtr = write(data, writerOptions);
 
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReaderInMemory(*sinkPtr, readerOptions);
+  auto reader = createReaderInMemory(*sinkPtr);
 
   ASSERT_EQ(reader->numberOfRows(), data->size());
   ASSERT_EQ(*reader->rowType(), *schema);
 
-  auto rowReader = createRowReaderWithSchema(std::move(reader), schema);
+  auto rowReader = createRowReaderFromReader(*reader, schema);
   assertReadWithReaderAndExpected(schema, *rowReader, data, *leafPool_);
 
   // Read the Int96 values directly to verify the correctness of the conversion
@@ -775,9 +756,7 @@ TEST_F(ParquetWriterTest, largeMetadata) {
 
   const auto* sinkPtr = write(data, writerOptions);
 
-  dwio::common::ReaderOptions readerOpts(leafPool_.get());
-  readerOpts.setDataIoStats(dataIoStats_);
-  readerOpts.setMetadataIoStats(metadataIoStats_);
+  auto readerOpts = makeDefaultReaderOptions();
   readerOpts.setFooterSpeculativeIoSize(1024);
   readerOpts.setFilePreloadThreshold(1024 * 8);
 
@@ -797,10 +776,7 @@ TEST_F(ParquetWriterTest, writeDecimalAsInteger) {
 
   const auto* sinkPtr = write(rowVector, writerOptions);
 
-  dwio::common::ReaderOptions readerOpts(leafPool_.get());
-  readerOpts.setDataIoStats(dataIoStats_);
-  readerOpts.setMetadataIoStats(metadataIoStats_);
-  const auto reader = createReaderInMemory(*sinkPtr, readerOpts);
+  const auto reader = createReaderInMemory(*sinkPtr);
 
   const auto types = reader->typeWithId()->getChildren();
   ASSERT_GE(types.size(), 3);
@@ -836,15 +812,12 @@ TEST_F(ParquetWriterTest, configurableWriteSchema) {
     parquet::WriterOptions writerOptions;
     writerOptions.memoryPool = rootPool_.get();
     const auto* sinkPtr = write(data, writerOptions, newType);
-    dwio::common::ReaderOptions readerOpts(leafPool_.get());
-    readerOpts.setDataIoStats(dataIoStats_);
-    readerOpts.setMetadataIoStats(metadataIoStats_);
-    auto reader = createReaderInMemory(*sinkPtr, readerOpts);
+    auto reader = createReaderInMemory(*sinkPtr);
 
     ASSERT_EQ(reader->numberOfRows(), kNumRows);
     EXPECT_EQ(reader->rowType()->toString(), newType->toString());
 
-    auto rowReader = createRowReaderWithSchema(std::move(reader), newType);
+    auto rowReader = createRowReaderFromReader(*reader, newType);
     assertReadWithReaderAndExpected(newType, *rowReader, expected, *leafPool_);
   };
 
@@ -882,17 +855,13 @@ TEST_F(ParquetWriterTest, updateWriterOptionsFromHiveConfig) {
 
   const auto* sinkPtr = write(data, std::move(configFromFile), {});
 
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReaderInMemory(*sinkPtr, readerOptions);
+  auto reader = createReaderInMemory(*sinkPtr);
 
   ASSERT_EQ(reader->numberOfRows(), data->size());
   ASSERT_EQ(*reader->rowType(), *data->rowType());
 
-  auto rowReaderOpts = getReaderOpts(data->rowType());
-  auto scanSpec = makeScanSpec(data->rowType());
-  rowReaderOpts.setScanSpec(scanSpec);
+  auto rowReaderOpts = makeRowReaderOpts(data->rowType());
+  rowReaderOpts.setScanSpec(makeScanSpec(data->rowType()));
   rowReaderOpts.setTimestampPrecision(TimestampPrecision::kNanoseconds);
   auto rowReader = reader->createRowReader(rowReaderOpts);
   assertReadWithReaderAndExpected(
@@ -950,17 +919,14 @@ TEST_F(ParquetWriterTest, enableStoreDecimalAsInteger) {
         auto* sinkPtr = write(
             data, std::move(configFromFile), std::move(sessionProperties));
 
-        dwio::common::ReaderOptions readerOptions(leafPool_.get());
-        readerOptions.setDataIoStats(dataIoStats_);
-        readerOptions.setMetadataIoStats(metadataIoStats_);
-        auto reader = createReaderInMemory(*sinkPtr, readerOptions);
+        auto reader = createReaderInMemory(*sinkPtr);
         auto& parquetReader = dynamic_cast<ParquetReader&>(*reader);
 
         const auto& types = parquetReader.typeWithId()->getChildren();
         ASSERT_EQ(types.size(), 3);
         verifyPhysicalTypes(types);
 
-        auto rowReader = createRowReaderWithSchema(std::move(reader), rowType);
+        auto rowReader = createRowReaderFromReader(*reader, rowType);
         assertReadWithReaderAndExpected(rowType, *rowReader, data, *leafPool_);
       };
 
@@ -1104,15 +1070,12 @@ TEST_F(ParquetWriterTest, allNulls) {
 
   auto* sinkPtr = write(data);
 
-  dwio::common::ReaderOptions readerOptions(leafPool_.get());
-  readerOptions.setDataIoStats(dataIoStats_);
-  readerOptions.setMetadataIoStats(metadataIoStats_);
-  auto reader = createReaderInMemory(*sinkPtr, readerOptions);
+  auto reader = createReaderInMemory(*sinkPtr);
 
   ASSERT_EQ(reader->numberOfRows(), kRows);
   ASSERT_EQ(*reader->rowType(), *schema);
 
-  auto rowReader = createRowReaderWithSchema(std::move(reader), schema);
+  auto rowReader = createRowReaderFromReader(*reader, schema);
   assertReadWithReaderAndExpected(schema, *rowReader, data, *leafPool_);
 }
 


### PR DESCRIPTION
Refactors Parquet reader/writer unit test infrastructure to remove repeated boilerplate for creating `ParquetReader` + `RowReader` (previously copy-pasted `ReaderOptions`, `ColumnSelector`, `ScanSpec`, and `createRowReader` setup across `ParquetReaderTest` and `ParquetReaderWideningTest`).

- Extract `ParquetTestBase` implementation into a linkable `velox_dwio_parquet_test_base` library (`ParquetTestBase.cpp`).
- Add `ParquetReaderBuilder` (builder pattern) on `ParquetTestBase`:
  - **Constructor** — required input: example file (`readerBuilder("foo.parquet")`, path resolved via `getExampleFilePath()`) or in-memory buffer (`readerBuilder(*sink)`); plus pool and IoStatistics.
  - **Required setter** — `outputType()` sets the RowReader output projection.
  - **Optional setters** — `byteRange()` for split-level byte-range tests; `withScanSpecOnly()` to skip `ColumnSelector`; `options()` to override `ReaderOptions`.
  - **`build()`** — returns `{ParquetReader, RowReader}`. Method-level docs describe each step for test readability.
- Migrate `ParquetReaderTest` and `ParquetReaderWideningTest` to the builder; simplify single-column `ROW(...)` usage in widening tests; minor call-site updates in writer tests.