### PR TITLE
feat: Extend MarkDistinct to allow multiple input masks (#17565)

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -2461,12 +2461,13 @@ PlanNodePtr WindowNode::create(const folly::dynamic& obj, void* context) {
 
 RowTypePtr getMarkDistinctOutputType(
     const RowTypePtr& inputType,
-    const std::string& markerName) {
+    const std::vector<std::string>& markerNames) {
   std::vector<std::string> names = inputType->names();
   std::vector<TypePtr> types = inputType->children();
-
-  names.emplace_back(markerName);
-  types.emplace_back(BOOLEAN());
+  for (const auto& name : markerNames) {
+    names.emplace_back(name);
+    types.emplace_back(BOOLEAN());
+  }
   return ROW(std::move(names), std::move(types));
 }
 
@@ -2475,20 +2476,48 @@ MarkDistinctNode::MarkDistinctNode(
     std::string markerName,
     std::vector<FieldAccessTypedExprPtr> distinctKeys,
     PlanNodePtr source)
+    : MarkDistinctNode(
+          std::move(id),
+          std::vector<std::string>{std::move(markerName)},
+          std::move(distinctKeys),
+          /*masks=*/{},
+          std::move(source)) {}
+
+MarkDistinctNode::MarkDistinctNode(
+    PlanNodeId id,
+    std::vector<std::string> markerNames,
+    std::vector<FieldAccessTypedExprPtr> distinctKeys,
+    std::vector<FieldAccessTypedExprPtr> masks,
+    PlanNodePtr source)
     : PlanNode(std::move(id)),
-      markerName_(std::move(markerName)),
+      markerNames_(std::move(markerNames)),
+      masks_(std::move(masks)),
       distinctKeys_(std::move(distinctKeys)),
       sources_{std::move(source)},
       outputType_(
-          getMarkDistinctOutputType(sources_[0]->outputType(), markerName_)) {
-  VELOX_USER_CHECK_GT(markerName_.size(), 0);
+          getMarkDistinctOutputType(sources_[0]->outputType(), markerNames_)) {
+  VELOX_USER_CHECK_EQ(
+      markerNames_.size(),
+      masks_.size() + 1,
+      "markerNames must have exactly one more entry than masks");
   VELOX_USER_CHECK_GT(distinctKeys_.size(), 0);
+  for (const auto& name : markerNames_) {
+    VELOX_USER_CHECK(!name.empty(), "MarkDistinct marker name cannot be empty");
+  }
+  for (const auto& mask : masks_) {
+    VELOX_USER_CHECK_EQ(
+        mask->type()->kind(),
+        TypeKind::BOOLEAN,
+        "MarkDistinct mask must be BOOLEAN: {}",
+        mask->name());
+  }
 }
 
 folly::dynamic MarkDistinctNode::serialize() const {
   auto obj = PlanNode::serialize();
-  obj["distinctKeys"] = ISerializable::serialize(this->distinctKeys_);
-  obj["markerName"] = this->markerName_;
+  obj["distinctKeys"] = ISerializable::serialize(distinctKeys_);
+  obj["markerNames"] = ISerializable::serialize(markerNames_);
+  obj["masks"] = ISerializable::serialize(masks_);
   return obj;
 }
 
@@ -2502,10 +2531,14 @@ void MarkDistinctNode::accept(
 PlanNodePtr MarkDistinctNode::create(const folly::dynamic& obj, void* context) {
   auto source = deserializeSingleSource(obj, context);
   auto distinctKeys = deserializeFields(obj["distinctKeys"], context);
-  auto markerName = obj["markerName"].asString();
-
+  auto markerNames = deserializeStrings(obj["markerNames"]);
+  auto masks = deserializeFields(obj["masks"], context);
   return std::make_shared<MarkDistinctNode>(
-      deserializePlanNodeId(obj), markerName, distinctKeys, source);
+      deserializePlanNodeId(obj),
+      std::move(markerNames),
+      std::move(distinctKeys),
+      std::move(masks),
+      source);
 }
 
 EnforceDistinctNode::EnforceDistinctNode(
@@ -3761,6 +3794,11 @@ PlanNodePtr OrderByNode::create(const folly::dynamic& obj, void* context) {
 
 void MarkDistinctNode::addDetails(std::stringstream& stream) const {
   addFields(stream, distinctKeys_);
+  if (!masks_.empty()) {
+    stream << ", masks: [";
+    addFields(stream, masks_);
+    stream << "]";
+  }
 }
 
 void EnforceDistinctNode::addDetails(std::stringstream& stream) const {

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -5431,17 +5431,39 @@ class RowNumberNode : public PlanNode {
 
 using RowNumberNodePtr = std::shared_ptr<const RowNumberNode>;
 
-/// The MarkDistinct operator marks unique rows based on distinctKeys.
-/// The result is put in a new markerName column alongside the original input.
-/// @param markerName Name of the output mask channel.
-/// @param distinctKeys Names of grouping keys.
-/// column.
+/// Marks unique rows based on a set of distinct keys. Always produces
+/// masks.size() + 1 boolean marker columns:
+///
+/// markers[0]: no-mask marker — true for the first occurrence of each distinct
+/// key combination, regardless of any mask.
+///
+/// markers[i+1]: per-mask marker — true for the first occurrence of each
+/// distinct key combination where masks[i] is true.
+///
+/// When masks is empty (single-marker mode), only the no-mask marker is
+/// produced.
 class MarkDistinctNode : public PlanNode {
  public:
+  /// Constructs a single-marker MarkDistinct node.
+  /// @param markerName Name of the output boolean marker column.
+  /// @param distinctKeys Columns to check for distinct values.
   MarkDistinctNode(
       PlanNodeId id,
       std::string markerName,
       std::vector<FieldAccessTypedExprPtr> distinctKeys,
+      PlanNodePtr source);
+
+  /// Constructs a MarkDistinct node that produces one no-mask marker followed
+  /// by one marker per mask column.
+  /// @param markerNames Names of output boolean marker columns. Must have
+  ///   exactly masks.size() + 1 entries.
+  /// @param distinctKeys Columns to check for distinct values.
+  /// @param masks Boolean input columns used as masks. Can be empty.
+  MarkDistinctNode(
+      PlanNodeId id,
+      std::vector<std::string> markerNames,
+      std::vector<FieldAccessTypedExprPtr> distinctKeys,
+      std::vector<FieldAccessTypedExprPtr> masks,
       PlanNodePtr source);
 
   class Builder {
@@ -5450,7 +5472,8 @@ class MarkDistinctNode : public PlanNode {
 
     explicit Builder(const MarkDistinctNode& other) {
       id_ = other.id();
-      markerName_ = other.markerName();
+      markerNames_ = other.markerNames();
+      masks_ = other.masks();
       distinctKeys_ = other.distinctKeys();
       VELOX_CHECK_EQ(other.sources().size(), 1);
       source_ = other.sources()[0];
@@ -5461,8 +5484,13 @@ class MarkDistinctNode : public PlanNode {
       return *this;
     }
 
-    Builder& markerName(std::string markerName) {
-      markerName_ = std::move(markerName);
+    Builder& markerNames(std::vector<std::string> markerNames) {
+      markerNames_ = std::move(markerNames);
+      return *this;
+    }
+
+    Builder& masks(std::vector<FieldAccessTypedExprPtr> masks) {
+      masks_ = std::move(masks);
       return *this;
     }
 
@@ -5479,7 +5507,7 @@ class MarkDistinctNode : public PlanNode {
     std::shared_ptr<MarkDistinctNode> build() const {
       VELOX_USER_CHECK(id_.has_value(), "MarkDistinctNode id is not set");
       VELOX_USER_CHECK(
-          markerName_.has_value(), "MarkDistinctNode markerName is not set");
+          markerNames_.has_value(), "MarkDistinctNode markerNames is not set");
       VELOX_USER_CHECK(
           distinctKeys_.has_value(),
           "MarkDistinctNode distinctKeys is not set");
@@ -5488,14 +5516,16 @@ class MarkDistinctNode : public PlanNode {
 
       return std::make_shared<MarkDistinctNode>(
           id_.value(),
-          markerName_.value(),
+          markerNames_.value(),
           distinctKeys_.value(),
+          masks_.value_or(std::vector<FieldAccessTypedExprPtr>{}),
           source_.value());
     }
 
    private:
     std::optional<PlanNodeId> id_;
-    std::optional<std::string> markerName_;
+    std::optional<std::vector<std::string>> markerNames_;
+    std::optional<std::vector<FieldAccessTypedExprPtr>> masks_;
     std::optional<std::vector<FieldAccessTypedExprPtr>> distinctKeys_;
     std::optional<PlanNodePtr> source_;
   };
@@ -5521,8 +5551,22 @@ class MarkDistinctNode : public PlanNode {
     return queryConfig.markDistinctSpillEnabled();
   }
 
-  const std::string& markerName() const {
-    return markerName_;
+  /// Returns the no-mask marker name (markerNames[0]). Retained for callers
+  /// not yet migrated to markerNames(); to be removed in a follow-up.
+  [[deprecated("Use markerNames()[0]")]] const std::string& markerName() const {
+    return markerNames_[0];
+  }
+
+  /// Returns all marker names: [0] is the no-mask marker, [1..N] correspond
+  /// to masks[0..N-1]. The constructor invariant markerNames_.size() ==
+  /// masks_.size() + 1 guarantees this is always non-empty.
+  const std::vector<std::string>& markerNames() const {
+    return markerNames_;
+  }
+
+  /// Returns mask column references. Empty for single-marker mode.
+  const std::vector<FieldAccessTypedExprPtr>& masks() const {
+    return masks_;
   }
 
   const std::vector<FieldAccessTypedExprPtr>& distinctKeys() const {
@@ -5536,7 +5580,12 @@ class MarkDistinctNode : public PlanNode {
  private:
   void addDetails(std::stringstream& stream) const override;
 
-  const std::string markerName_;
+  // markerNames_[0] is the no-mask marker; markerNames_[i+1] corresponds to
+  // masks_[i]. Always has masks_.size() + 1 entries.
+  const std::vector<std::string> markerNames_;
+
+  // Mask channel references. Empty in single-marker mode.
+  const std::vector<FieldAccessTypedExprPtr> masks_;
 
   const std::vector<FieldAccessTypedExprPtr> distinctKeys_;
 

--- a/velox/core/tests/PlanNodeBuilderTest.cpp
+++ b/velox/core/tests/PlanNodeBuilderTest.cpp
@@ -15,6 +15,7 @@
  */
 #include <gtest/gtest.h>
 
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/core/PlanNode.h"
 #include "velox/core/TableWriteTraits.h"
@@ -1183,28 +1184,113 @@ TEST_F(PlanNodeBuilderTest, rowNumberNode) {
 
 TEST_F(PlanNodeBuilderTest, markDistinctNode) {
   const PlanNodeId id = "mark_distinct_node_id";
-  const std::string markerName = "is_distinct";
   const std::vector<FieldAccessTypedExprPtr> distinctKeys{
       std::make_shared<FieldAccessTypedExpr>(BIGINT(), "c0")};
 
-  const auto verify = [&](const std::shared_ptr<const MarkDistinctNode>& node) {
-    EXPECT_EQ(node->id(), id);
-    EXPECT_EQ(node->markerName(), markerName);
-    EXPECT_EQ(node->distinctKeys(), distinctKeys);
-    EXPECT_EQ(node->sources().size(), 1);
-    EXPECT_EQ(node->sources()[0], source_);
-  };
+  {
+    SCOPED_TRACE("single-marker");
+    const std::vector<std::string> markerNames{"is_distinct"};
+    const auto verify =
+        [&](const std::shared_ptr<const MarkDistinctNode>& node) {
+          EXPECT_EQ(node->id(), id);
+          EXPECT_EQ(node->markerNames(), markerNames);
+          EXPECT_TRUE(node->masks().empty());
+          EXPECT_EQ(node->distinctKeys(), distinctKeys);
+          EXPECT_EQ(node->sources().size(), 1);
+          EXPECT_EQ(node->sources()[0], source_);
+        };
 
-  const auto node = MarkDistinctNode::Builder()
-                        .id(id)
-                        .markerName(markerName)
-                        .distinctKeys(distinctKeys)
-                        .source(source_)
-                        .build();
-  verify(node);
+    const auto node = MarkDistinctNode::Builder()
+                          .id(id)
+                          .markerNames(markerNames)
+                          .distinctKeys(distinctKeys)
+                          .source(source_)
+                          .build();
+    verify(node);
 
-  const auto node2 = MarkDistinctNode::Builder(*node).build();
-  verify(node2);
+    const auto node2 = MarkDistinctNode::Builder(*node).build();
+    verify(node2);
+  }
+  {
+    SCOPED_TRACE("multi-mask");
+    const std::vector<std::string> markerNames{"nomask", "m0", "m1"};
+    const std::vector<FieldAccessTypedExprPtr> masks{
+        std::make_shared<FieldAccessTypedExpr>(BOOLEAN(), "c1"),
+        std::make_shared<FieldAccessTypedExpr>(BOOLEAN(), "c2")};
+
+    const auto verify =
+        [&](const std::shared_ptr<const MarkDistinctNode>& node) {
+          EXPECT_EQ(node->id(), id);
+          EXPECT_EQ(node->markerNames(), markerNames);
+          EXPECT_EQ(node->masks(), masks);
+          EXPECT_EQ(node->distinctKeys(), distinctKeys);
+          EXPECT_EQ(node->sources().size(), 1);
+          EXPECT_EQ(node->sources()[0], source_);
+        };
+
+    const auto node = MarkDistinctNode::Builder()
+                          .id(id)
+                          .markerNames(markerNames)
+                          .masks(masks)
+                          .distinctKeys(distinctKeys)
+                          .source(source_)
+                          .build();
+    verify(node);
+
+    const auto node2 = MarkDistinctNode::Builder(*node).build();
+    verify(node2);
+  }
+}
+
+TEST_F(PlanNodeBuilderTest, markDistinctNodeMarkerCountMismatch) {
+  const std::vector<FieldAccessTypedExprPtr> distinctKeys{
+      std::make_shared<FieldAccessTypedExpr>(BIGINT(), "c0")};
+  const std::vector<FieldAccessTypedExprPtr> masks{
+      std::make_shared<FieldAccessTypedExpr>(BOOLEAN(), "c1")};
+
+  VELOX_ASSERT_THROW(
+      MarkDistinctNode::Builder()
+          .id("test_id")
+          .markerNames({"m0", "m1", "m2"})
+          .distinctKeys(distinctKeys)
+          .masks(masks)
+          .source(source_)
+          .build(),
+      "markerNames must have exactly one more entry than masks");
+}
+
+TEST_F(PlanNodeBuilderTest, markDistinctNodeNonBooleanMask) {
+  const std::vector<FieldAccessTypedExprPtr> distinctKeys{
+      std::make_shared<FieldAccessTypedExpr>(BIGINT(), "c0")};
+  const std::vector<FieldAccessTypedExprPtr> intMasks{
+      std::make_shared<FieldAccessTypedExpr>(INTEGER(), "c1")};
+
+  VELOX_ASSERT_THROW(
+      MarkDistinctNode::Builder()
+          .id("test_id")
+          .markerNames({"nomask", "m0"})
+          .distinctKeys(distinctKeys)
+          .masks(intMasks)
+          .source(source_)
+          .build(),
+      "MarkDistinct mask must be BOOLEAN");
+}
+
+TEST_F(PlanNodeBuilderTest, markDistinctNodeEmptyMarkerName) {
+  const std::vector<FieldAccessTypedExprPtr> distinctKeys{
+      std::make_shared<FieldAccessTypedExpr>(BIGINT(), "c0")};
+  const std::vector<FieldAccessTypedExprPtr> masks{
+      std::make_shared<FieldAccessTypedExpr>(BOOLEAN(), "c1")};
+
+  VELOX_ASSERT_THROW(
+      MarkDistinctNode::Builder()
+          .id("test_id")
+          .markerNames({"nomask", ""})
+          .distinctKeys(distinctKeys)
+          .masks(masks)
+          .source(source_)
+          .build(),
+      "MarkDistinct marker name cannot be empty");
 }
 
 TEST_F(PlanNodeBuilderTest, topNRowNumberNode) {

--- a/velox/docs/develop/operators.rst
+++ b/velox/docs/develop/operators.rst
@@ -1017,13 +1017,17 @@ FilterNode(rank/row_number <= limit), but it uses less memory and CPU.
 MarkDistinctNode
 ~~~~~~~~~~~~~~~~
 
-The MarkDistinct operator is used to produce aggregate mask columns for aggregations over distinct values, e.g. agg(DISTINCT a).
-Mask is a boolean column set to true for a subset of input rows that collectively represent a set of unique values of 'distinctKeys'.
+The MarkDistinct operator produces boolean marker columns identifying the first occurrence of each distinct
+combination of 'distinctKeys'. It emits one no-mask marker (true on the first occurrence of each distinct key
+combination), followed by one marker per entry in 'masks' (true on the first occurrence of each distinct key
+combination for which the corresponding mask column is true). This allows MarkDistinct to produce aggregate
+mask columns for aggregation over distinct values, with and without filters.
 
 This operator supports spilling. The spill mechanism follows the same pattern as RowNumber: when memory pressure
 triggers spilling, the hash table contents and future input are partitioned and written to disk. During restore,
 each partition's hash table is rebuilt from the spilled data, preserving knowledge of which keys were already seen.
-Disabled by default; enable with `mark_distinct_spill_enabled` configuration property.
+When masks are present, the per-key bitmask tracking which masks have already fired is spilled alongside the hash
+table and restored together. Disabled by default; enable with `mark_distinct_spill_enabled` configuration property.
 
 .. list-table::
   :widths: 10 30
@@ -1032,10 +1036,12 @@ Disabled by default; enable with `mark_distinct_spill_enabled` configuration pro
 
   * - Property
     - Description
-  * - markerName
-    - Name of the output mask column.
+  * - markerNames
+    - Names of the output marker columns. The first name is the no-mask marker; the remaining names correspond positionally to entries in 'masks'. Must have exactly one more entry than 'masks'.
   * - distinctKeys
     - Names of grouping keys.
+  * - masks
+    - List of boolean mask column references. Empty when only the no-mask marker is needed.
 
 MixedUnionNode
 ~~~~~~~~~~~~~~

--- a/velox/exec/EnforceDistinct.cpp
+++ b/velox/exec/EnforceDistinct.cpp
@@ -45,6 +45,7 @@ EnforceDistinct::EnforceDistinct(
           std::vector<core::TypedExprPtr>{
               planNode->preGroupedKeys().begin(),
               planNode->preGroupedKeys().end()}),
+      /*extraAccumulators=*/{},
       operatorCtx_.get(),
       &nonReclaimableSection_);
 }

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/exec/GroupingSet.h"
+#include "velox/common/base/BitUtil.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/exec/OperatorUtils.h"
 #include "velox/exec/Task.h"
@@ -140,9 +141,10 @@ std::unique_ptr<GroupingSet> GroupingSet::createForDistinct(
     const RowTypePtr& inputType,
     std::vector<std::unique_ptr<VectorHasher>>&& hashers,
     std::vector<column_index_t>&& preGroupedKeys,
+    std::vector<Accumulator> extraAccumulators,
     OperatorCtx* operatorCtx,
     tsan_atomic<bool>* nonReclaimableSection) {
-  return std::make_unique<GroupingSet>(
+  auto groupingSet = std::make_unique<GroupingSet>(
       inputType,
       std::move(hashers),
       std::move(preGroupedKeys),
@@ -158,7 +160,15 @@ std::unique_ptr<GroupingSet> GroupingSet::createForDistinct(
       &operatorCtx->driverCtx()->queryConfig(),
       operatorCtx->pool(),
       /*spillStats=*/nullptr);
-};
+
+  if (extraAccumulators.empty()) {
+    return groupingSet;
+  }
+
+  groupingSet->extraAccumulators_ = std::move(extraAccumulators);
+  groupingSet->createHashTable();
+  return groupingSet;
+}
 
 namespace {
 bool equalKeys(
@@ -410,7 +420,7 @@ void initializeAggregates(
 
 std::vector<Accumulator> GroupingSet::accumulators(bool excludeToIntermediate) {
   std::vector<Accumulator> accumulators;
-  accumulators.reserve(aggregates_.size());
+  accumulators.reserve(aggregates_.size() + extraAccumulators_.size());
   for (auto& aggregate : aggregates_) {
     if (!excludeToIntermediate ||
         !aggregate.function->supportsToIntermediate()) {
@@ -427,6 +437,10 @@ std::vector<Accumulator> GroupingSet::accumulators(bool excludeToIntermediate) {
     if (aggregation != nullptr) {
       accumulators.push_back(aggregation->accumulator());
     }
+  }
+
+  for (const auto& extra : extraAccumulators_) {
+    accumulators.push_back(extra);
   }
   return accumulators;
 }

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -50,14 +50,20 @@ class GroupingSet {
 
   ~GroupingSet();
 
-  /// Used by MarkDistinct and EnforceDistinct operators to identify rows with
-  /// unique values for a set of keys.
+  /// Creates a GroupingSet for MarkDistinct and EnforceDistinct operators to
+  /// identify rows with unique values for a set of keys. When
+  /// 'extraAccumulators' is non-empty, appends them to the row layout and
+  /// eagerly creates the hash table so callers can read column offsets via
+  /// table().
   /// @param preGroupedKeys Subset of grouping keys that input is already
   /// clustered on.
+  /// @param extraAccumulators Caller-provided accumulators appended to the
+  ///   row layout (e.g. MarkDistinct's per-group bitmask). Can be empty.
   static std::unique_ptr<GroupingSet> createForDistinct(
       const RowTypePtr& inputType,
       std::vector<std::unique_ptr<VectorHasher>>&& hashers,
       std::vector<column_index_t>&& preGroupedKeys,
+      std::vector<Accumulator> extraAccumulators,
       OperatorCtx* operatorCtx,
       tsan_atomic<bool>* nonReclaimableSection);
 
@@ -357,6 +363,10 @@ class GroupingSet {
   AggregationMasks masks_;
   std::unique_ptr<SortedAggregations> sortedAggregations_;
   std::vector<std::unique_ptr<DistinctAggregations>> distinctAggregations_;
+
+  // Caller-provided accumulators appended to the row layout by
+  // createForDistinct(). Used by MarkDistinct for per-group bitmask storage.
+  std::vector<Accumulator> extraAccumulators_;
 
   // Boolean indicating whether any aggregate supports compact().
   bool hasCompactableAggregates_{false};

--- a/velox/exec/MarkDistinct.cpp
+++ b/velox/exec/MarkDistinct.cpp
@@ -41,27 +41,59 @@ MarkDistinct::MarkDistinct(
               ? driverCtx->makeSpillConfig(operatorId, planNode->name())
               : std::nullopt) {
   inputType_ = planNode->sources()[0]->outputType();
+  for (const auto& mask : planNode->masks()) {
+    maskChannels_.push_back(inputType_->getChildIdx(mask->name()));
+  }
 
   // Set all input columns as identity projection.
   for (auto i = 0; i < inputType_->size(); ++i) {
     identityProjections_.emplace_back(i, i);
   }
 
-  // Use result[0] for distinct mask output.
-  resultProjections_.emplace_back(0, inputType_->size());
+  // Result projections: one per marker output column. The first marker is the
+  // no-mask marker; additional markers correspond to each mask.
+  const auto numMarkers = numMasks() + 1;
+  for (int32_t i = 0; i < numMarkers; ++i) {
+    resultProjections_.emplace_back(i, inputType_->size() + i);
+  }
 
   for (const auto& key : planNode->distinctKeys()) {
     distinctKeyChannels_.push_back(inputType_->getChildIdx(key->name()));
   }
 
+  auto hashers = createVectorHashers(inputType_, planNode->distinctKeys());
+  std::vector<Accumulator> extraAccumulators;
+  if (numMasks() > 0) {
+    const auto numBytes = static_cast<int32_t>(bits::nbytes(numMasks()));
+    extraAccumulators.emplace_back(
+        /*isFixedSize=*/true,
+        /*fixedSize=*/numBytes,
+        /*usesExternalMemory=*/false,
+        /*alignment=*/1,
+        /*spillType=*/VARBINARY(),
+        [this, numBytes](folly::Range<char**> groups, VectorPtr& result) {
+          auto* flatResult = result->as<FlatVector<StringView>>();
+          for (auto i = 0; i < groups.size(); ++i) {
+            flatResult->set(
+                i, StringView(groups[i] + bitmaskOffset_, numBytes));
+          }
+        },
+        /*destroyFunction=*/nullptr);
+  }
+
   groupingSet_ = GroupingSet::createForDistinct(
       inputType_,
-      createVectorHashers(inputType_, planNode->distinctKeys()),
+      std::move(hashers),
       /*preGroupedKeys=*/{},
+      std::move(extraAccumulators),
       operatorCtx_.get(),
       &nonReclaimableSection_);
-
-  results_.resize(1);
+  if (numMasks() > 0) {
+    bitmaskOffset_ =
+        groupingSet_->table()->rows()->accumulatorColumnAt(0).offset();
+  }
+  results_.resize(numMarkers);
+  decodedMasks_.resize(numMasks());
 
   if (spillEnabled()) {
     setSpillPartitionBits();
@@ -136,6 +168,21 @@ void MarkDistinct::restoreNextSpillPartition() {
           *lookup, input, rows, spillConfig_->startPartitionBit);
       table->groupProbe(*lookup, spillConfig_->startPartitionBit);
 
+      // Restore bitmask bytes from spilled accumulator column. Spill layout
+      // is [keys..., bitmask]: rows()->columnTypes() followed by each
+      // accumulator's spillType(). The single extra accumulator (bitmask)
+      // sits at index hashers.size().
+      if (numMasks() > 0) {
+        auto* bitmaskVector =
+            data->childAt(hashers.size())->as<FlatVector<StringView>>();
+        const auto numBytes = bits::nbytes(numMasks());
+        for (auto i = 0; i < data->size(); ++i) {
+          auto bitmask = bitmaskVector->valueAt(i);
+          VELOX_CHECK_EQ(bitmask.size(), numBytes);
+          memcpy(lookup->hits[i] + bitmaskOffset_, bitmask.data(), numBytes);
+        }
+      }
+
       columns.assign(inputType_->size(), nullptr);
     }
   }
@@ -191,18 +238,75 @@ RowVectorPtr MarkDistinct::getOutput() {
 
   const auto outputSize = input_->size();
 
-  VectorPtr& result = results_[0];
-  if (result && result.use_count() == 1) {
-    BaseVector::prepareForReuse(result, outputSize);
-  } else {
-    result = BaseVector::create(BOOLEAN(), outputSize, operatorCtx_->pool());
+  const auto numMarkers = numMasks() + 1;
+  const auto& lookup = groupingSet_->hashLookup();
+
+  // Allocate and zero-init all marker vectors.
+  for (int32_t i = 0; i < numMarkers; ++i) {
+    VectorPtr& result = results_[i];
+    if (result) {
+      BaseVector::prepareForReuse(result, outputSize);
+    } else {
+      result = BaseVector::create(BOOLEAN(), outputSize, operatorCtx_->pool());
+    }
+    auto* resultBits =
+        result->as<FlatVector<bool>>()->mutableRawValues<uint64_t>();
+    bits::fillBits(resultBits, 0, outputSize, false);
   }
 
-  auto* resultBits =
+  // Result[0] is the no-mask marker — true for first-seen key combinations.
+  auto* nomaskBits =
       results_[0]->as<FlatVector<bool>>()->mutableRawValues<uint64_t>();
-  bits::fillBits(resultBits, 0, outputSize, false);
-  for (const auto i : groupingSet_->hashLookup().newGroups) {
-    bits::setBit(resultBits, i, true);
+  for (const auto index : lookup.newGroups) {
+    bits::setBit(nomaskBits, index, true);
+  }
+
+  if (numMasks() > 0) {
+    const auto numBytes = bits::nbytes(numMasks());
+
+    // Zero bitmask bytes for newly created groups.
+    for (const auto index : lookup.newGroups) {
+      memset(lookup.hits[index] + bitmaskOffset_, 0, numBytes);
+    }
+
+    for (int32_t i = 0; i < numMasks(); ++i) {
+      decodedMasks_[i].decode(*input_->childAt(maskChannels_[i]));
+    }
+
+    // Results[1..N]: per-mask markers. For each (row, mask) where the mask
+    // is active, check the per-group bitmask. If bit i is unset this is the
+    // first row where mask i is true for this key — set the bit and emit
+    // true.
+    for (int32_t i = 0; i < numMasks(); ++i) {
+      auto& decoded = decodedMasks_[i];
+      auto* resultBits =
+          results_[i + 1]->as<FlatVector<bool>>()->mutableRawValues<uint64_t>();
+
+      auto markIfFirst = [&](vector_size_t row) {
+        auto* bitmask =
+            reinterpret_cast<uint8_t*>(lookup.hits[row] + bitmaskOffset_);
+        if (!bits::isBitSet(bitmask, i)) {
+          bits::setBit(bitmask, i);
+          bits::setBit(resultBits, row);
+        }
+      };
+
+      if (decoded.isConstantMapping()) {
+        if (decoded.isNullAt(0) || !decoded.valueAt<bool>(0)) {
+          continue;
+        }
+        for (auto row = 0; row < outputSize; ++row) {
+          markIfFirst(row);
+        }
+      } else {
+        for (auto row = 0; row < outputSize; ++row) {
+          if (decoded.isNullAt(row) || !decoded.valueAt<bool>(row)) {
+            continue;
+          }
+          markIfFirst(row);
+        }
+      }
+    }
   }
 
   auto output = fillOutput(outputSize, nullptr);
@@ -327,6 +431,9 @@ SpillPartitionIdSet MarkDistinct::spillHashTable() {
 
   auto* table = groupingSet_->table();
   auto columnTypes = table->rows()->columnTypes();
+  for (const auto& accumulator : table->rows()->accumulators()) {
+    columnTypes.push_back(accumulator.spillType());
+  }
   auto tableType = ROW(std::move(columnTypes));
 
   auto hashTableSpiller = std::make_unique<MarkDistinctHashTableSpiller>(
@@ -374,7 +481,7 @@ void MarkDistinct::spill() {
     input_ = nullptr;
   }
   results_.clear();
-  results_.resize(1);
+  results_.resize(numMasks() + 1);
 }
 
 void MarkDistinct::spillInput(

--- a/velox/exec/MarkDistinct.h
+++ b/velox/exec/MarkDistinct.h
@@ -20,6 +20,7 @@
 #include "velox/exec/HashPartitionFunction.h"
 #include "velox/exec/Operator.h"
 #include "velox/exec/Spiller.h"
+#include "velox/vector/DecodedVector.h"
 
 namespace facebook::velox::exec {
 
@@ -117,6 +118,18 @@ class MarkDistinct : public Operator {
   bool yield_{false};
 
   std::vector<column_index_t> distinctKeyChannels_;
+
+  // Input channels for mask booleans. Empty for single-marker mode.
+  std::vector<column_index_t> maskChannels_;
+
+  // Cached byte offset of the per-group bitmask within a RowContainer row.
+  int32_t bitmaskOffset_{0};
+
+  int32_t numMasks() const {
+    return static_cast<int32_t>(maskChannels_.size());
+  }
+
+  std::vector<DecodedVector> decodedMasks_;
 };
 
 /// Spills the hash table contents (distinct keys) from MarkDistinct's

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -901,6 +901,12 @@ class RowContainer {
     return accumulators_;
   }
 
+  /// Returns the RowColumn for the i-th accumulator. Accumulators are laid
+  /// out in row storage after the keys.
+  RowColumn accumulatorColumnAt(int32_t i) const {
+    return columnAt(keyTypes_.size() + i);
+  }
+
   const HashStringAllocator& stringAllocator() const {
     return *stringAllocator_;
   }

--- a/velox/exec/tests/MarkDistinctTest.cpp
+++ b/velox/exec/tests/MarkDistinctTest.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <gmock/gmock.h>
+
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/FileSystems.h"
 #include "velox/exec/PlanNodeStats.h"
@@ -28,6 +30,20 @@ using namespace facebook::velox::test;
 using facebook::velox::exec::Operator;
 using facebook::velox::exec::TestScopedSpillInjection;
 using facebook::velox::memory::testingRunArbitration;
+
+namespace {
+// Returns the id of the first MarkDistinctNode in 'plan', or std::nullopt if
+// none exists in the subtree.
+std::optional<core::PlanNodeId> findMarkDistinctId(
+    const core::PlanNodePtr& plan) {
+  if (auto* node = core::PlanNode::findFirstNode(plan.get(), [](const auto* n) {
+        return dynamic_cast<const core::MarkDistinctNode*>(n) != nullptr;
+      })) {
+    return node->id();
+  }
+  return std::nullopt;
+}
+} // namespace
 
 class MarkDistinctTest : public OperatorTestBase {
  public:
@@ -50,12 +66,97 @@ class MarkDistinctTest : public OperatorTestBase {
     assertEqualVectors(expectedResults, results);
   }
 
+  // Expects a 3-column input (distinct key + 2 boolean masks) and a 3-column
+  // 'expectedMarkers' (no-mask marker + 2 per-mask markers). Runs MarkDistinct
+  // and asserts the output matches input columns followed by the expected
+  // markers.
+  void assertMarkers(
+      const RowVectorPtr& input,
+      const std::vector<VectorPtr>& expectedMarkers) {
+    VELOX_CHECK_EQ(expectedMarkers.size(), 3);
+    auto expectedColumns = input->children();
+    expectedColumns.insert(
+        expectedColumns.end(), expectedMarkers.begin(), expectedMarkers.end());
+    auto expected = makeRowVector(expectedColumns);
+
+    auto plan = PlanBuilder()
+                    .values({input})
+                    .markDistinct({"nomask", "m0", "m1"}, {"c0"}, {"c1", "c2"})
+                    .planNode();
+
+    AssertQueryBuilder(plan).assertResults(expected);
+  }
+
+  // End-to-end multi-mask query shape for aggregation and spill tests:
+  // 2 keys + 2 boolean masks → 3 markers (nomask + 2 per-mask). Returns {plan,
+  // duckDbSql}.
+  std::pair<core::PlanNodePtr, std::string> makeMultiMaskCase(
+      const std::vector<RowVectorPtr>& vectors) {
+    auto plan =
+        PlanBuilder()
+            .values(vectors)
+            .markDistinct({"nomask", "m0", "m1"}, {"c0", "c1"}, {"c2", "c3"})
+            .singleAggregation(
+                {"c0"},
+                {"count(c1)", "count(c1)", "count(c1)"},
+                {"nomask", "m0", "m1"})
+            .planNode();
+    return {
+        std::move(plan),
+        "SELECT c0, "
+        "count(DISTINCT c1), "
+        "count(DISTINCT c1) FILTER (WHERE c2), "
+        "count(DISTINCT c1) FILTER (WHERE c3) "
+        "FROM tmp GROUP BY 1"};
+  }
+
+  // Runs 'plan' that contains a MarkDistinct node with spilling enabled
+  // and validates the result against DuckDB. Asserts that the MarkDistinct
+  // node actually spilled. 'configure' lets callers add per-test config
+  // overrides on the AssertQueryBuilder.
+  void runSpillTest(
+      const core::PlanNodePtr& plan,
+      const std::string& duckDbSql,
+      uint32_t numSpills = 1,
+      std::function<void(AssertQueryBuilder&)> configure = nullptr) {
+    const auto markDistinctId = findMarkDistinctId(plan);
+    VELOX_CHECK(markDistinctId.has_value(), "No MarkDistinct node in plan");
+
+    const auto spillDirectory = exec::test::TempDirectoryPath::create();
+    auto queryCtx = core::QueryCtx::create(executor_.get());
+    TestScopedSpillInjection scopedSpillInjection(100, ".*", numSpills);
+
+    AssertQueryBuilder builder(duckDbQueryRunner_);
+    builder.spillDirectory(spillDirectory->getPath())
+        .config(core::QueryConfig::kSpillEnabled, true)
+        .config(core::QueryConfig::kMarkDistinctSpillEnabled, true)
+        .config(core::QueryConfig::kAggregationSpillEnabled, false)
+        .queryCtx(queryCtx)
+        .plan(plan);
+    if (configure) {
+      configure(builder);
+    }
+    auto task = builder.assertResults(duckDbSql);
+
+    auto taskStats = exec::toPlanStats(task->taskStats());
+    auto& planStats = taskStats.at(*markDistinctId);
+    ASSERT_GT(planStats.spilledBytes, 0);
+    ASSERT_GT(planStats.spilledRows, 0);
+    ASSERT_GT(planStats.spilledFiles, 0);
+    ASSERT_GT(planStats.spilledPartitions, 0);
+
+    task.reset();
+    waitForAllTasksToBeDeleted();
+  }
+
  protected:
   MarkDistinctTest() {
     filesystems::registerLocalFileSystem();
   }
 
-  RowTypePtr rowType_{ROW({"c0", "c1"}, {BIGINT(), BIGINT()})};
+  RowTypePtr rowType_{
+      ROW({"c0", "c1", "c2", "c3"},
+          {BIGINT(), BIGINT(), BOOLEAN(), BOOLEAN()})};
 
   VectorFuzzer::Options fuzzerOpts_{
       .vectorSize = 1024,
@@ -162,9 +263,6 @@ TEST_F(MarkDistinctTest, aggregation) {
 }
 
 TEST_F(MarkDistinctTest, spill) {
-  auto vectors = createVectors(8, rowType_, fuzzerOpts_);
-  createDuckDbTable(vectors);
-
   struct {
     uint32_t spillPartitionBits;
     uint32_t numSpills;
@@ -181,50 +279,42 @@ TEST_F(MarkDistinctTest, spill) {
 
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
-    const auto spillDirectory = exec::test::TempDirectoryPath::create();
-    auto queryCtx = core::QueryCtx::create(executor_.get());
-    TestScopedSpillInjection scopedSpillInjection(
-        100, ".*", testData.numSpills);
+    auto configure = [&](AssertQueryBuilder& builder) {
+      builder
+          .config(
+              core::QueryConfig::kSpillNumPartitionBits,
+              testData.spillPartitionBits)
+          .config(
+              core::QueryConfig::kDriverCpuTimeSliceLimitMs,
+              testData.cpuTimeSliceLimitMs);
+    };
 
-    core::PlanNodeId markDistinctId;
-    auto task =
-        AssertQueryBuilder(duckDbQueryRunner_)
-            .spillDirectory(spillDirectory->getPath())
-            .config(core::QueryConfig::kSpillEnabled, true)
-            .config(core::QueryConfig::kMarkDistinctSpillEnabled, true)
-            .config(
-                core::QueryConfig::kSpillNumPartitionBits,
-                testData.spillPartitionBits)
-            .config(
-                core::QueryConfig::kDriverCpuTimeSliceLimitMs,
-                testData.cpuTimeSliceLimitMs)
-            .config(core::QueryConfig::kAggregationSpillEnabled, false)
-            .queryCtx(queryCtx)
-            .plan(
-                PlanBuilder()
-                    .values(vectors)
-                    .markDistinct("c1_distinct", {"c0", "c1"})
-                    .capturePlanNodeId(markDistinctId)
-                    .singleAggregation({"c0"}, {"count(c1)"}, {"c1_distinct"})
-                    .planNode())
-            .assertResults("SELECT c0, count(distinct c1) FROM tmp GROUP BY 1");
-
-    auto taskStats = exec::toPlanStats(task->taskStats());
-    auto& planStats = taskStats.at(markDistinctId);
-    ASSERT_GT(planStats.spilledBytes, 0);
-    ASSERT_GT(planStats.spilledFiles, 0);
-    ASSERT_GT(planStats.spilledRows, 0);
-    ASSERT_GT(planStats.spilledPartitions, 0);
-
-    task.reset();
-    waitForAllTasksToBeDeleted();
+    {
+      SCOPED_TRACE("single-marker");
+      auto vectors = createVectors(8, rowType_, fuzzerOpts_);
+      createDuckDbTable(vectors);
+      auto plan = PlanBuilder()
+                      .values(vectors)
+                      .markDistinct("c1_distinct", {"c0", "c1"})
+                      .singleAggregation({"c0"}, {"count(c1)"}, {"c1_distinct"})
+                      .planNode();
+      runSpillTest(
+          plan,
+          "SELECT c0, count(distinct c1) FROM tmp GROUP BY 1",
+          testData.numSpills,
+          configure);
+    }
+    {
+      SCOPED_TRACE("multi-mask");
+      auto vectors = createVectors(8, rowType_, fuzzerOpts_);
+      createDuckDbTable(vectors);
+      auto [plan, sql] = makeMultiMaskCase(vectors);
+      runSpillTest(plan, sql, testData.numSpills, configure);
+    }
   }
 }
 
 DEBUG_ONLY_TEST_F(MarkDistinctTest, reclaimDuringInputOrOutput) {
-  auto vectors = createVectors(8, rowType_, fuzzerOpts_);
-  createDuckDbTable(vectors);
-
   struct {
     std::string spillInjectionPoint;
     uint32_t spillPartitionBits;
@@ -241,15 +331,18 @@ DEBUG_ONLY_TEST_F(MarkDistinctTest, reclaimDuringInputOrOutput) {
       {"facebook::velox::exec::Driver::runInternal::addInput", 3},
       {"facebook::velox::exec::Driver::runInternal::getOutput", 3}};
 
-  for (const auto& testData : testSettings) {
-    SCOPED_TRACE(testData.debugString());
+  auto runShape = [&](const std::vector<RowVectorPtr>& vectors,
+                      const core::PlanNodePtr& plan,
+                      const std::string& duckDbSql,
+                      const std::string& spillInjectionPoint,
+                      uint32_t spillPartitionBits) {
+    createDuckDbTable(vectors);
     const auto spillDirectory = exec::test::TempDirectoryPath::create();
     auto queryCtx = core::QueryCtx::create(executor_.get());
 
     std::atomic_int numRound{0};
     SCOPED_TESTVALUE_SET(
-        testData.spillInjectionPoint,
-        std::function<void(Operator*)>(([&](Operator* op) {
+        spillInjectionPoint, std::function<void(Operator*)>(([&](Operator* op) {
           if (op->operatorType() != "MarkDistinct") {
             return;
           }
@@ -259,28 +352,22 @@ DEBUG_ONLY_TEST_F(MarkDistinctTest, reclaimDuringInputOrOutput) {
           testingRunArbitration(op->pool(), 0);
         })));
 
-    core::PlanNodeId markDistinctId;
+    const auto markDistinctId = findMarkDistinctId(plan);
+    VELOX_CHECK(markDistinctId.has_value(), "No MarkDistinct node in plan");
     auto task =
         AssertQueryBuilder(duckDbQueryRunner_)
             .spillDirectory(spillDirectory->getPath())
             .config(core::QueryConfig::kSpillEnabled, true)
             .config(core::QueryConfig::kMarkDistinctSpillEnabled, true)
             .config(
-                core::QueryConfig::kSpillNumPartitionBits,
-                testData.spillPartitionBits)
+                core::QueryConfig::kSpillNumPartitionBits, spillPartitionBits)
             .config(core::QueryConfig::kAggregationSpillEnabled, false)
             .queryCtx(queryCtx)
-            .plan(
-                PlanBuilder()
-                    .values(vectors)
-                    .markDistinct("c1_distinct", {"c0", "c1"})
-                    .capturePlanNodeId(markDistinctId)
-                    .singleAggregation({"c0"}, {"count(c1)"}, {"c1_distinct"})
-                    .planNode())
-            .assertResults("SELECT c0, count(distinct c1) FROM tmp GROUP BY 1");
+            .plan(plan)
+            .assertResults(duckDbSql);
 
     auto taskStats = exec::toPlanStats(task->taskStats());
-    auto& planStats = taskStats.at(markDistinctId);
+    auto& planStats = taskStats.at(*markDistinctId);
     ASSERT_GT(planStats.spilledBytes, 0);
     ASSERT_GT(planStats.spilledFiles, 0);
     ASSERT_GT(planStats.spilledRows, 0);
@@ -288,13 +375,40 @@ DEBUG_ONLY_TEST_F(MarkDistinctTest, reclaimDuringInputOrOutput) {
 
     task.reset();
     waitForAllTasksToBeDeleted();
+  };
+
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+    {
+      SCOPED_TRACE("single-marker");
+      auto vectors = createVectors(8, rowType_, fuzzerOpts_);
+      auto plan = PlanBuilder()
+                      .values(vectors)
+                      .markDistinct("c1_distinct", {"c0", "c1"})
+                      .singleAggregation({"c0"}, {"count(c1)"}, {"c1_distinct"})
+                      .planNode();
+      runShape(
+          vectors,
+          plan,
+          "SELECT c0, count(distinct c1) FROM tmp GROUP BY 1",
+          testData.spillInjectionPoint,
+          testData.spillPartitionBits);
+    }
+    {
+      SCOPED_TRACE("multi-mask");
+      auto vectors = createVectors(8, rowType_, fuzzerOpts_);
+      auto [plan, sql] = makeMultiMaskCase(vectors);
+      runShape(
+          vectors,
+          plan,
+          sql,
+          testData.spillInjectionPoint,
+          testData.spillPartitionBits);
+    }
   }
 }
 
 DEBUG_ONLY_TEST_F(MarkDistinctTest, recursiveSpill) {
-  auto vectors = createVectors(32, rowType_, fuzzerOpts_);
-  createDuckDbTable(vectors);
-
   struct {
     int32_t numSpills;
     int32_t maxSpillLevel;
@@ -305,8 +419,12 @@ DEBUG_ONLY_TEST_F(MarkDistinctTest, recursiveSpill) {
     }
   } testSettings[] = {{2, 3}, {8, 4}};
 
-  for (const auto& testData : testSettings) {
-    SCOPED_TRACE(testData.debugString());
+  auto runShape = [&](const std::vector<RowVectorPtr>& vectors,
+                      const core::PlanNodePtr& plan,
+                      const std::string& duckDbSql,
+                      int32_t targetNumSpills,
+                      int32_t maxSpillLevel) {
+    createDuckDbTable(vectors);
     const auto spillDirectory = exec::test::TempDirectoryPath::create();
     auto queryCtx = core::QueryCtx::create(executor_.get());
 
@@ -334,40 +452,35 @@ DEBUG_ONLY_TEST_F(MarkDistinctTest, recursiveSpill) {
           if (!op->testingNoMoreInput()) {
             return;
           }
-          if (numSpills++ >= testData.numSpills) {
+          if (numSpills++ >= targetNumSpills) {
             return;
           }
           testingRunArbitration(op->pool(), 0);
         })));
 
-    core::PlanNodeId markDistinctId;
+    const auto markDistinctId = findMarkDistinctId(plan);
+    VELOX_CHECK(markDistinctId.has_value(), "No MarkDistinct node in plan");
     auto task =
         AssertQueryBuilder(duckDbQueryRunner_)
             .spillDirectory(spillDirectory->getPath())
             .config(core::QueryConfig::kSpillEnabled, true)
             .config(core::QueryConfig::kMarkDistinctSpillEnabled, true)
-            .config(
-                core::QueryConfig::kMaxSpillLevel, testData.maxSpillLevel - 1)
+            .config(core::QueryConfig::kMaxSpillLevel, maxSpillLevel - 1)
             .config(core::QueryConfig::kAggregationSpillEnabled, false)
             .queryCtx(queryCtx)
-            .plan(
-                PlanBuilder()
-                    .values(vectors)
-                    .markDistinct("c1_distinct", {"c0", "c1"})
-                    .capturePlanNodeId(markDistinctId)
-                    .singleAggregation({"c0"}, {"count(c1)"}, {"c1_distinct"})
-                    .planNode())
-            .assertResults("SELECT c0, count(distinct c1) FROM tmp GROUP BY 1");
+            .plan(plan)
+            .assertResults(duckDbSql);
 
     auto taskStats = exec::toPlanStats(task->taskStats());
-    auto& planStats = taskStats.at(markDistinctId);
+    auto& planStats = taskStats.at(*markDistinctId);
     ASSERT_GT(planStats.spilledBytes, 0);
     ASSERT_GT(planStats.spilledFiles, 0);
     ASSERT_GT(planStats.spilledRows, 0);
+    ASSERT_GT(planStats.spilledPartitions, 0);
 
     auto runTimeStats =
         task->taskStats().pipelineStats.back().operatorStats.at(1).runtimeStats;
-    if (testData.numSpills > testData.maxSpillLevel) {
+    if (targetNumSpills > maxSpillLevel) {
       ASSERT_GT(runTimeStats["exceededMaxSpillLevel"].sum, 0);
     } else {
       ASSERT_EQ(runTimeStats.count("exceededMaxSpillLevel"), 0);
@@ -375,6 +488,31 @@ DEBUG_ONLY_TEST_F(MarkDistinctTest, recursiveSpill) {
 
     task.reset();
     waitForAllTasksToBeDeleted();
+  };
+
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+    {
+      SCOPED_TRACE("single-marker");
+      auto vectors = createVectors(32, rowType_, fuzzerOpts_);
+      auto plan = PlanBuilder()
+                      .values(vectors)
+                      .markDistinct("c1_distinct", {"c0", "c1"})
+                      .singleAggregation({"c0"}, {"count(c1)"}, {"c1_distinct"})
+                      .planNode();
+      runShape(
+          vectors,
+          plan,
+          "SELECT c0, count(distinct c1) FROM tmp GROUP BY 1",
+          testData.numSpills,
+          testData.maxSpillLevel);
+    }
+    {
+      SCOPED_TRACE("multi-mask");
+      auto vectors = createVectors(32, rowType_, fuzzerOpts_);
+      auto [plan, sql] = makeMultiMaskCase(vectors);
+      runShape(vectors, plan, sql, testData.numSpills, testData.maxSpillLevel);
+    }
   }
 }
 
@@ -401,38 +539,14 @@ TEST_F(MarkDistinctTest, spillWithDuplicateKeys) {
           makeFlatVector<int64_t>({10, 20, 30, 90, 100}),
       }),
   };
+
   createDuckDbTable(vectors);
-
-  const auto spillDirectory = exec::test::TempDirectoryPath::create();
-  auto queryCtx = core::QueryCtx::create(executor_.get());
-  // Trigger spill after the second batch so pre-spill output includes keys
-  // that also appear in post-spill batches.
-  TestScopedSpillInjection scopedSpillInjection(100, ".*", 1);
-
-  core::PlanNodeId markDistinctId;
-  auto task =
-      AssertQueryBuilder(duckDbQueryRunner_)
-          .spillDirectory(spillDirectory->getPath())
-          .config(core::QueryConfig::kSpillEnabled, true)
-          .config(core::QueryConfig::kMarkDistinctSpillEnabled, true)
-          .config(core::QueryConfig::kAggregationSpillEnabled, false)
-          .queryCtx(queryCtx)
-          .plan(
-              PlanBuilder()
+  auto plan = PlanBuilder()
                   .values(vectors)
                   .markDistinct("c1_distinct", {"c0", "c1"})
-                  .capturePlanNodeId(markDistinctId)
                   .singleAggregation({"c0"}, {"count(c1)"}, {"c1_distinct"})
-                  .planNode())
-          .assertResults("SELECT c0, count(distinct c1) FROM tmp GROUP BY 1");
-
-  auto taskStats = exec::toPlanStats(task->taskStats());
-  auto& planStats = taskStats.at(markDistinctId);
-  ASSERT_GT(planStats.spilledBytes, 0);
-  ASSERT_GT(planStats.spilledRows, 0);
-
-  task.reset();
-  waitForAllTasksToBeDeleted();
+                  .planNode();
+  runSpillTest(plan, "SELECT c0, count(distinct c1) FROM tmp GROUP BY 1");
 }
 
 TEST_F(MarkDistinctTest, memoryUsage) {
@@ -540,5 +654,263 @@ TEST_F(MarkDistinctTest, maxSpillBytes) {
       ASSERT_EQ(
           e.errorCode(), facebook::velox::error_code::kSpillLimitExceeded);
     }
+  }
+}
+
+TEST_F(MarkDistinctTest, multiMaskWithNulls) {
+  // Null keys are treated as valid distinct values (ignoreNullKeys = false).
+  // Mask values are chosen so each per-mask marker diverges from the no-mask
+  // marker and from the other per-mask marker.
+  auto data = makeRowVector({
+      makeNullableFlatVector<int32_t>(
+          {1, std::nullopt, 1, std::nullopt, std::nullopt}),
+      makeFlatVector<bool>({true, false, true, true, false}),
+      makeFlatVector<bool>({false, true, true, false, true}),
+  });
+
+  assertMarkers(
+      data,
+      {
+          makeFlatVector<bool>({true, true, false, false, false}),
+          makeFlatVector<bool>({true, false, false, true, false}),
+          makeFlatVector<bool>({false, true, true, false, false}),
+      });
+}
+
+TEST_F(MarkDistinctTest, multiMaskNullMasks) {
+  // Null mask values are treated as false. Specifically test the case where
+  // the first row of a key has a null mask: the per-mask marker must NOT
+  // fire on that row, even though no other row has set the bit yet.
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({1, 1, 1, 1}),
+      makeNullableFlatVector<bool>({std::nullopt, true, false, true}),
+      makeNullableFlatVector<bool>({true, std::nullopt, std::nullopt, false}),
+  });
+
+  assertMarkers(
+      data,
+      {
+          makeFlatVector<bool>({true, false, false, false}),
+          makeFlatVector<bool>({false, true, false, false}),
+          makeFlatVector<bool>({true, false, false, false}),
+      });
+}
+
+TEST_F(MarkDistinctTest, multiMaskAllMasksFalse) {
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({1, 2, 3}),
+      makeFlatVector<bool>({false, false, false}),
+      makeFlatVector<bool>({false, false, false}),
+  });
+
+  assertMarkers(
+      data,
+      {
+          makeFlatVector<bool>({true, true, true}),
+          makeFlatVector<bool>({false, false, false}),
+          makeFlatVector<bool>({false, false, false}),
+      });
+}
+
+TEST_F(MarkDistinctTest, multiMaskEncodedMasks) {
+  // Dictionary-encoded mask0 with non-trivial indices (reversed) and
+  // constant-encoded mask1 exercise the DecodedVector decode path.
+  // Base: [F, T, T, F, T]. Reversed indices [4,3,2,1,0] → logical [T,F,T,T,F].
+  auto baseMask = makeFlatVector<bool>({false, true, true, false, true});
+  auto indices = makeIndices(5, [](auto row) { return 4 - row; });
+  auto dictMask = wrapInDictionary(indices, 5, baseMask);
+  auto constMask =
+      BaseVector::wrapInConstant(5, 0, makeFlatVector<bool>({true}));
+
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({1, 1, 1, 2, 2}),
+      dictMask,
+      constMask,
+  });
+
+  // Per-row expected markers:
+  //   nomask:  key=1 first at row 0, key=2 first at row 3 → [T,F,F,T,F].
+  //   result0: dict mask logical [T,F,T,T,F]; key=1 mask=T at row 0 fires,
+  //            row 2 mask=T but key already seen → F; key=2 mask=T at row 3
+  //            fires; row 4 mask=F → F.
+  //   result1: const mask always true; mirrors no-mask marker.
+  assertMarkers(
+      data,
+      {
+          makeFlatVector<bool>({true, false, false, true, false}),
+          makeFlatVector<bool>({true, false, false, true, false}),
+          makeFlatVector<bool>({true, false, false, true, false}),
+      });
+}
+
+TEST_F(MarkDistinctTest, multiMaskAggregation) {
+  // End-to-end with downstream aggregation, validated against DuckDB.
+  std::vector<RowVectorPtr> vectors = {
+      makeRowVector({
+          makeFlatVector<int32_t>({1, 1, 2, 2}),
+          makeFlatVector<int32_t>({10, 20, 30, 40}),
+          makeFlatVector<bool>({true, true, true, false}),
+          makeFlatVector<bool>({true, false, true, true}),
+      }),
+      makeRowVector({
+          makeFlatVector<int32_t>({1, 2, 1}),
+          makeFlatVector<int32_t>({10, 30, 30}),
+          makeFlatVector<bool>({true, true, true}),
+          makeFlatVector<bool>({true, true, false}),
+      }),
+  };
+
+  createDuckDbTable(vectors);
+  auto [plan, sql] = makeMultiMaskCase(vectors);
+  AssertQueryBuilder(plan, duckDbQueryRunner_).assertResults(sql);
+}
+
+TEST_F(MarkDistinctTest, chainedMarkDistinctSharedMask) {
+  // Two chained MarkDistinct nodes that both reference the same mask column.
+  // Verifies the mask column flows through the first MarkDistinct unchanged
+  // and remains addressable by the second.
+  std::vector<RowVectorPtr> vectors = {
+      makeRowVector({
+          makeFlatVector<int32_t>({1, 1, 2}),
+          makeFlatVector<int32_t>({10, 20, 10}),
+          makeFlatVector<int32_t>({100, 100, 200}),
+          makeFlatVector<bool>({true, false, true}),
+      }),
+      makeRowVector({
+          makeFlatVector<int32_t>({2, 1}),
+          makeFlatVector<int32_t>({20, 10}),
+          makeFlatVector<int32_t>({200, 100}),
+          makeFlatVector<bool>({true, false}),
+      }),
+  };
+  createDuckDbTable(vectors);
+
+  auto plan =
+      PlanBuilder()
+          .values(vectors)
+          .markDistinct({"c1_nomask", "c1_filtered"}, {"c0", "c1"}, {"c3"})
+          .markDistinct({"c2_nomask", "c2_filtered"}, {"c0", "c2"}, {"c3"})
+          .singleAggregation(
+              {"c0"}, {"sum(c1)", "sum(c2)"}, {"c1_filtered", "c2_filtered"})
+          .planNode();
+
+  AssertQueryBuilder(plan, duckDbQueryRunner_)
+      .assertResults(
+          "SELECT c0, "
+          "sum(DISTINCT c1) FILTER (WHERE c3), "
+          "sum(DISTINCT c2) FILTER (WHERE c3) "
+          "FROM tmp GROUP BY 1");
+}
+
+TEST_F(MarkDistinctTest, multiMaskNonContiguousMaskChannels) {
+  // Mask channels at non-contiguous positions in the input.
+  // Input schema: (g:int, mask0:bool, x:int, mask1:bool).
+  // Use distinct x values so the two masks produce different results —
+  // a swap of mask channel indices would be detected.
+  auto data = makeRowVector(
+      {"g", "mask0", "x", "mask1"},
+      {
+          makeFlatVector<int32_t>({1, 1, 2}),
+          makeFlatVector<bool>({true, true, true}),
+          makeFlatVector<int32_t>({10, 20, 30}),
+          makeFlatVector<bool>({true, false, true}),
+      });
+
+  auto expected = makeRowVector(
+      {"g", "mask0", "x", "mask1", "nomask", "m0", "m1"},
+      {
+          makeFlatVector<int32_t>({1, 1, 2}),
+          makeFlatVector<bool>({true, true, true}),
+          makeFlatVector<int32_t>({10, 20, 30}),
+          makeFlatVector<bool>({true, false, true}),
+          // Markers below.
+          makeFlatVector<bool>({true, true, true}),
+          makeFlatVector<bool>({true, true, true}),
+          makeFlatVector<bool>({true, false, true}),
+      });
+
+  auto plan =
+      PlanBuilder()
+          .values({data})
+          .markDistinct({"nomask", "m0", "m1"}, {"g", "x"}, {"mask0", "mask1"})
+          .planNode();
+
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+TEST_F(MarkDistinctTest, multiMaskSpillWithOverlappingKeys) {
+  // Same keys appear before and after spill with different masks active.
+  // Pre-spill: mask0=T, mask1=F. Post-spill: mask0=F, mask1=T.
+  // After restore, bitmask must preserve pre-spill state.
+  const int32_t batchSize = 100;
+  std::vector<RowVectorPtr> vectors;
+  for (int32_t batch = 0; batch < 4; ++batch) {
+    vectors.push_back(makeRowVector({
+        makeFlatVector<int64_t>(batchSize, [](auto row) { return row + 1; }),
+        makeFlatVector<int64_t>(batchSize, [](auto row) { return row + 1; }),
+        makeFlatVector<bool>(batchSize, [](auto /*row*/) { return true; }),
+        makeFlatVector<bool>(batchSize, [](auto /*row*/) { return false; }),
+    }));
+  }
+  for (int32_t batch = 0; batch < 4; ++batch) {
+    vectors.push_back(makeRowVector({
+        makeFlatVector<int64_t>(batchSize, [](auto row) { return row + 1; }),
+        makeFlatVector<int64_t>(batchSize, [](auto row) { return row + 1; }),
+        makeFlatVector<bool>(batchSize, [](auto /*row*/) { return false; }),
+        makeFlatVector<bool>(batchSize, [](auto /*row*/) { return true; }),
+    }));
+  }
+
+  createDuckDbTable(vectors);
+  auto [plan, sql] = makeMultiMaskCase(vectors);
+  runSpillTest(plan, sql);
+}
+
+TEST_F(MarkDistinctTest, multiMaskLargeN) {
+  // Exercise multi-byte bitmask handling. N=9 crosses the first byte boundary
+  // (bits::nbytes(9) == 2). N=64 is exactly 8 bytes. N=100 spans 13 bytes.
+  // Mask values vary per channel so a bit-position bug produces wrong values
+  // for at least one mask.
+  // mask_i[row 0] = bit 0 of i, mask_i[row 1] = bit 1 of i, row 2 = true.
+  // This gives each mask a unique per-mask result and ensures every bit
+  // position in the per-group bitmask is set by at least one mask.
+  auto maskBits = [](int32_t i) {
+    return std::pair<bool, bool>{(i & 1) != 0, (i & 2) != 0};
+  };
+
+  for (int32_t numMasks : {9, 64, 100}) {
+    SCOPED_TRACE(fmt::format("numMasks: {}", numMasks));
+    std::vector<VectorPtr> inputColumns;
+    inputColumns.push_back(makeFlatVector<int32_t>({1, 1, 2}));
+
+    std::vector<std::string> markerNames;
+    markerNames.push_back("nomask");
+    std::vector<std::string> maskNames;
+    for (int32_t i = 0; i < numMasks; ++i) {
+      auto [firstRow, secondRow] = maskBits(i);
+      inputColumns.push_back(makeFlatVector<bool>({firstRow, secondRow, true}));
+      markerNames.push_back(fmt::format("m{}", i));
+      maskNames.push_back(fmt::format("c{}", i + 1));
+    }
+    auto data = makeRowVector(inputColumns);
+
+    // Expected: nomask = [T, F, T] (first occurrence of each key).
+    // For mask_i: result[0] = mask_i[0]; result[1] fires only if mask_i[0]
+    // was false and mask_i[1] is true; result[2] = mask_i[2] = true.
+    std::vector<VectorPtr> expectedColumns = inputColumns;
+    expectedColumns.push_back(makeFlatVector<bool>({true, false, true}));
+    for (int32_t i = 0; i < numMasks; ++i) {
+      auto [firstRow, secondRow] = maskBits(i);
+      expectedColumns.push_back(
+          makeFlatVector<bool>({firstRow, !firstRow && secondRow, true}));
+    }
+    auto expected = makeRowVector(expectedColumns);
+
+    auto plan = PlanBuilder()
+                    .values({data})
+                    .markDistinct(markerNames, {"c0"}, maskNames)
+                    .planNode();
+
+    AssertQueryBuilder(plan).assertResults(expected);
   }
 }

--- a/velox/exec/tests/PlanNodeSerdeTest.cpp
+++ b/velox/exec/tests/PlanNodeSerdeTest.cpp
@@ -56,6 +56,7 @@ class PlanNodeSerdeTest : public testing::Test,
             {3, 4, 5},
             {},
         }),
+        makeFlatVector<bool>({false, true, true}),
     })};
   }
 
@@ -171,11 +172,22 @@ TEST_F(PlanNodeSerdeTest, assignUniqueId) {
 }
 
 TEST_F(PlanNodeSerdeTest, markDistinct) {
-  auto plan = PlanBuilder()
-                  .values({data_})
-                  .markDistinct("marker", {"c0", "c1", "c2"})
-                  .planNode();
-  testSerde(plan);
+  {
+    SCOPED_TRACE("single-marker");
+    auto plan = PlanBuilder()
+                    .values({data_})
+                    .markDistinct("marker", {"c0", "c1", "c2"})
+                    .planNode();
+    testSerde(plan);
+  }
+  {
+    SCOPED_TRACE("multi-mask");
+    auto plan = PlanBuilder()
+                    .values({data_})
+                    .markDistinct({"m0", "m1", "m2"}, {"c0"}, {"c2", "c4"})
+                    .planNode();
+    testSerde(plan);
+  }
 }
 
 TEST_F(PlanNodeSerdeTest, enforceDistinct) {

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -23,6 +23,7 @@
 #include "velox/parse/TypeResolver.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 using facebook::velox::exec::test::PlanBuilder;
@@ -1000,15 +1001,33 @@ TEST_F(PlanNodeToStringTest, topNDenseRank) {
 }
 
 TEST_F(PlanNodeToStringTest, markDistinct) {
-  auto op =
-      PlanBuilder()
-          .tableScan(ROW({"a", "b", "c"}, {VARCHAR(), BIGINT(), BIGINT()}))
-          .markDistinct("marker", {"a", "b"})
-          .planNode();
-  ASSERT_EQ("-- MarkDistinct[1]\n", op->toString());
-  ASSERT_EQ(
-      "-- MarkDistinct[1][a, b] -> a:VARCHAR, b:BIGINT, c:BIGINT, marker:BOOLEAN\n",
-      op->toString(true, false));
+  {
+    SCOPED_TRACE("single-marker");
+    auto op =
+        PlanBuilder()
+            .tableScan(ROW({"a", "b", "c"}, {VARCHAR(), BIGINT(), BIGINT()}))
+            .markDistinct("marker", {"a", "b"})
+            .planNode();
+    ASSERT_EQ("-- MarkDistinct[1]\n", op->toString());
+    ASSERT_EQ(
+        "-- MarkDistinct[1][a, b] -> a:VARCHAR, b:BIGINT, c:BIGINT, marker:BOOLEAN\n",
+        op->toString(true, false));
+  }
+  {
+    SCOPED_TRACE("multi-mask");
+    auto op =
+        PlanBuilder()
+            .tableScan(
+                ROW({"a", "b", "m0", "m1"},
+                    {VARCHAR(), BIGINT(), BOOLEAN(), BOOLEAN()}))
+            .markDistinct({"nomask", "r0", "r1"}, {"a", "b"}, {"m0", "m1"})
+            .planNode();
+    ASSERT_EQ("-- MarkDistinct[1]\n", op->toString());
+    ASSERT_EQ(
+        "-- MarkDistinct[1][a, b, masks: [m0, m1]] -> a:VARCHAR, b:BIGINT, "
+        "m0:BOOLEAN, m1:BOOLEAN, nomask:BOOLEAN, r0:BOOLEAN, r1:BOOLEAN\n",
+        op->toString(true, false));
+  }
 }
 
 TEST_F(PlanNodeToStringTest, tableWrite) {

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -2528,13 +2528,33 @@ PlanBuilder& PlanBuilder::topNRowNumber(
 }
 
 PlanBuilder& PlanBuilder::markDistinct(
-    std::string markerKey,
+    std::string markerName,
     const std::vector<std::string>& distinctKeys) {
   VELOX_CHECK_NOT_NULL(planNode_, "MarkDistinct cannot be the source node");
   planNode_ = std::make_shared<core::MarkDistinctNode>(
       nextPlanNodeId(),
-      std::move(markerKey),
+      std::move(markerName),
       fields(planNode_->outputType(), distinctKeys),
+      planNode_);
+  VELOX_CHECK(!planNode_->supportsBarrier());
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::markDistinct(
+    std::vector<std::string> markerNames,
+    const std::vector<std::string>& distinctKeys,
+    const std::vector<std::string>& maskNames) {
+  VELOX_CHECK_NOT_NULL(planNode_, "MarkDistinct cannot be the source node");
+  VELOX_CHECK_EQ(
+      markerNames.size(),
+      maskNames.size() + 1,
+      "Number of marker names must be one more than mask names");
+  auto inputType = planNode_->outputType();
+  planNode_ = std::make_shared<core::MarkDistinctNode>(
+      nextPlanNodeId(),
+      std::move(markerNames),
+      fields(inputType, distinctKeys),
+      fields(inputType, maskNames),
       planNode_);
   VELOX_CHECK(!planNode_->supportsBarrier());
   return *this;

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -1503,11 +1503,22 @@ class PlanBuilder {
       bool generateRowNumber);
 
   /// Add a MarkDistinctNode to compute aggregate mask channel
-  /// @param markerKey Name of output mask channel
+  /// @param markerName Name of output mask channel
   /// @param distinctKeys List of columns to be marked distinct.
   PlanBuilder& markDistinct(
-      std::string markerKey,
+      std::string markerName,
       const std::vector<std::string>& distinctKeys);
+
+  /// Add a multi-mask MarkDistinctNode. Produces maskNames.size() + 1 marker
+  /// columns: one no-mask marker, followed by one marker for each mask.
+  /// @param markerNames Names of output boolean marker columns. Must have
+  ///   exactly maskNames.size() + 1 entries.
+  /// @param distinctKeys List of columns to check for distinct values.
+  /// @param maskNames Column names of the input boolean mask columns.
+  PlanBuilder& markDistinct(
+      std::vector<std::string> markerNames,
+      const std::vector<std::string>& distinctKeys,
+      const std::vector<std::string>& maskNames);
 
   /// Add an EnforceDistinctNode to ensure input has unique values for the
   /// specified keys at runtime. Throws with the specified error message if


### PR DESCRIPTION
Summary:

Extends MarkDistinctNode to emit multiple boolean markers from a single 
operator instance: one "no-mask" marker (true on first occurrence of each 
distinct key) followed by one marker per mask (true on first occurrence of 
each distinct key where the mask column is true). This allows aggregations 
on DISTINCT inputs with FILTER to execute via MarkDistinct followed by 
non-DISTINCT aggregation.

Reviewed By: mbasmanova

Differential Revision: D104913168


