### PR TITLE
feat: Add preloadIndex option to ClusterIndex for eager metadata + key-stream loading

### DIFF
--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -800,6 +800,18 @@ class ReaderOptions : public io::ReaderOptions {
     loadClusterIndex_ = value;
   }
 
+  /// Whether to eagerly preload all per-partition metadata and decode all
+  /// per-partition key streams during file open. Only effective when
+  /// loadClusterIndex() is also true. Implies pinning so preloaded chunks
+  /// are not evicted on first lookup. Default false.
+  bool preloadIndex() const {
+    return preloadIndex_;
+  }
+
+  void setPreloadIndex(bool value) {
+    preloadIndex_ = value;
+  }
+
   /// Whether to load and initialize the chunk index during file open.
   /// When true, the chunk index section is preloaded and the structured
   /// ChunkIndex object is created. Default true.
@@ -854,6 +866,7 @@ class ReaderOptions : public io::ReaderOptions {
   bool cacheIndex_{false};
   bool pinIndex_{false};
   bool loadClusterIndex_{false};
+  bool preloadIndex_{false};
   bool loadChunkIndex_{true};
   bool allowEmptyFile_{false};
   bool allowInt32Narrowing_{false};


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookincubator/nimble/pull/756

Add a new `preloadIndex` option to `velox::dwio::common::ReaderOptions` that, when set together with `loadClusterIndex`, eagerly loads all per-partition metadata and decodes all per-partition key streams at file-open time. After preload, every subsequent `lookup()` / `keyAtRow()` call hits only in-memory state — no further IO on the index.

Today the cluster index is fully lazy: the first lookup against each partition triggers a small metadata IO, and the first lookup against each chunk triggers another IO + decode. This produces irregular tail-latency spikes and prevents the index from being fully memory-resident even when `pinIndex=true` is set (`pinIndex` only retains chunks *after* they've been lazy-touched).

Implementation:
- `ReaderOptions::setPreloadIndex(bool)` → `TabletReader::Options::preloadIndex` → `IndexLookup::Options::preloadIndex` → consumed by `ClusterIndex` ctor.
- `ClusterIndex::preloadIndex()` does two batched IOs: (1) `metadataInput_->load(std::span<MetadataSection>)` for all partition metadata in one coalesced call, then (2) loops `dataInput_->enqueue(region)` for every chunk across all partitions followed by a single `dataInput_->load(LogType::GROUP_INDEX)` for coalesced IO, then decodes each chunk into the existing `IndexPartition::decodedChunks` map. No new data structures.
- Auto-promotes `pinIndex=true` when `preloadIndex=true` so the caller only needs to flip one knob. `IndexLookup::Options::validate()` rejects `preloadIndex=true && pinIndex=false` to guard against direct misuse.

No new public data structure is introduced — `IndexPartition::decodedChunks` already stores decoded chunks, and `DecodedKeyChunk::encoding->get(rowInChunk, &valueView)` gives O(1) random access.

This is the core API. Wiring `setPreloadIndex(true)` into `FileIndexReader.cpp` and `NimbleIndexBenchmarkReader.cpp` is a follow-up.

Reviewed By: xiaoxmeng

Differential Revision: D105779932


