### PR TITLE
feat(parse): Add FieldAccessExpr::tryAsRootColumn helper

### DIFF
--- a/velox/parse/Expressions.cpp
+++ b/velox/parse/Expressions.cpp
@@ -64,6 +64,15 @@ VELOX_DEFINE_EMBEDDED_ENUM_NAME(IExpr, Kind, kindNames)
 VELOX_DEFINE_EMBEDDED_ENUM_NAME(WindowCallExpr, WindowType, windowTypeNames);
 VELOX_DEFINE_EMBEDDED_ENUM_NAME(WindowCallExpr, BoundType, boundTypeNames);
 
+// static
+const FieldAccessExpr* FieldAccessExpr::tryAsRootColumn(const ExprPtr& expr) {
+  const auto* field = dynamic_cast<const FieldAccessExpr*>(expr.get());
+  if (field == nullptr || !field->isRootColumn()) {
+    return nullptr;
+  }
+  return field;
+}
+
 bool FieldAccessExpr::operator==(const IExpr& other) const {
   if (!other.is(Kind::kFieldAccess)) {
     return false;

--- a/velox/parse/Expressions.h
+++ b/velox/parse/Expressions.h
@@ -72,6 +72,10 @@ class FieldAccessExpr : public IExpr {
     return input()->is(Kind::kInput);
   }
 
+  /// Returns 'expr' as a FieldAccessExpr if it refers directly to a
+  /// top-level input column; otherwise returns nullptr.
+  static const FieldAccessExpr* tryAsRootColumn(const ExprPtr& expr);
+
   std::string toString() const override;
 
   ExprPtr replaceInputs(std::vector<ExprPtr> newInputs) const override {

--- a/velox/parse/tests/ExprTest.cpp
+++ b/velox/parse/tests/ExprTest.cpp
@@ -16,6 +16,7 @@
 #include <folly/container/F14Map.h>
 #include <gtest/gtest.h>
 #include "velox/duckdb/conversion/DuckParser.h"
+#include "velox/parse/Expressions.h"
 #include "velox/parse/IExpr.h"
 
 namespace facebook::velox::core {
@@ -63,6 +64,30 @@ TEST_F(ExprTest, hashMap) {
     EXPECT_EQ(exprs.at(expr1), 5);
     EXPECT_EQ(exprs.at(expr2), 6);
     EXPECT_EQ(exprs.at(expr3), 5);
+  }
+}
+
+TEST_F(ExprTest, tryAsRootColumn) {
+  // Top-level field access on an input column.
+  {
+    auto expr = parse("a");
+    const auto* field = FieldAccessExpr::tryAsRootColumn(expr);
+    ASSERT_NE(field, nullptr);
+    EXPECT_EQ(field->name(), "a");
+  }
+
+  // Dereference (a.b) is a FieldAccess whose input is not an InputExpr.
+  {
+    auto expr = parse("a.b");
+    EXPECT_EQ(FieldAccessExpr::tryAsRootColumn(expr), nullptr);
+  }
+
+  // Non-FieldAccess expressions are not root columns.
+  {
+    EXPECT_EQ(FieldAccessExpr::tryAsRootColumn(parse("a + 1")), nullptr);
+    EXPECT_EQ(FieldAccessExpr::tryAsRootColumn(parse("42")), nullptr);
+    EXPECT_EQ(
+        FieldAccessExpr::tryAsRootColumn(parse("cast(a as bigint)")), nullptr);
   }
 }
 


### PR DESCRIPTION
Summary:
The pattern "is this Expr a top-level FieldAccessExpr referring to an input column" — `dynamic_cast<FieldAccessExpr*>(expr.get())` followed by `field->isRootColumn()` — is hand-rolled across multiple call sites (Axiom's optimizer, parser, planner; Velox's own ExprResolver). Each site reimplements the boilerplate; some need just the name, others also need `alias()`.

Add a static helper on `FieldAccessExpr` that returns the `FieldAccessExpr*` when the expression is a root-column FieldAccess and nullptr otherwise. Returning the pointer keeps callers flexible — `name()`, `alias()`, etc. are all reachable from the same handle.

Differential Revision: D105833371


