### PR TITLE
misc: Simplify loadReusedLazyVectors to use identityProjections

### DIFF
--- a/velox/exec/FilterProject.cpp
+++ b/velox/exec/FilterProject.cpp
@@ -74,61 +74,22 @@ std::vector<OperatorStats> splitStats(
   return {std::move(projectStats), std::move(filterStats)};
 }
 
-// Unwraps dictionary/constant/sequence encodings to get to the underlying
-// Lazy vector if it exists. Otherwise, returns nullptr.
-const BaseVector* unwrapToLazy(const VectorPtr& vector) {
-  switch (vector->encoding()) {
-    case VectorEncoding::Simple::CONSTANT:
-    case VectorEncoding::Simple::DICTIONARY:
-    case VectorEncoding::Simple::SEQUENCE: {
-      return vector->valueVector() ? unwrapToLazy(vector->valueVector())
-                                   : nullptr;
-    }
-    case VectorEncoding::Simple::LAZY:
-      return vector.get();
-    default:
-      return nullptr;
-  }
-}
-
-// Returns a unique identity pointer for Lazy vectors. For other vectors,
-// returns nullptr.
-const void* lazyIdentityPtr(const VectorPtr& vec) {
-  if (!vec) {
-    return nullptr;
-  }
-  const BaseVector* lazyVec = unwrapToLazy(vec);
-  if (!lazyVec) {
-    return nullptr;
-  }
-  return static_cast<const void*>(lazyVec);
-}
-
-// Load the reused lazy vectors in the output. A lazy vector cannot be reused
-// across different output fields because its contents may be loaded via a
-// hook during pushdown. Accessing a loaded vector in this case can lead to
-// incorrect results or even a crash.
-void loadReusedLazyVectors(const RowVectorPtr& output) {
-  if (!output || !output->containsLazyNotLoaded()) {
+// Load lazy vectors for input channels that are referenced by more than one
+// identity projection. A lazy vector cannot be reused across different output
+// fields because its contents may be loaded via a hook during pushdown.
+// Accessing a loaded vector in this case can lead to incorrect results or
+// even a crash.
+void loadReusedLazyVectors(
+    const RowVectorPtr& input,
+    const std::vector<column_index_t>& reusedInputChannels) {
+  if (!input || reusedInputChannels.empty()) {
     return;
   }
 
-  const auto& vectors = output->children();
-
-  // Build a map of lazy identity pointers to their occurrence count.
-  std::unordered_map<const void*, size_t> lazyIdentityCounts;
-  for (const auto& vector : vectors) {
-    const void* id = lazyIdentityPtr(vector);
-    if (id) {
-      lazyIdentityCounts[id]++;
-    }
-  }
-
-  // Load only the vectors whose lazy identity appears more than once.
-  for (auto& vector : vectors) {
-    const void* id = lazyIdentityPtr(vector);
-    if (id && lazyIdentityCounts[id] > 1) {
-      vector->loadedVector();
+  auto& children = input->children();
+  for (const auto inputChannel : reusedInputChannels) {
+    if (isLazyNotLoaded(*children[inputChannel])) {
+      children[inputChannel]->loadedVector();
     }
   }
 }
@@ -188,6 +149,18 @@ void FilterProject::initialize() {
     }
     isIdentityProjection_ = true;
   }
+  {
+    std::unordered_map<column_index_t, size_t> inputChannelCounts;
+    for (const auto& projection : identityProjections_) {
+      inputChannelCounts[projection.inputChannel]++;
+    }
+    for (const auto& [inputChannel, count] : inputChannelCounts) {
+      if (count > 1) {
+        reusedInputChannels_.push_back(inputChannel);
+      }
+    }
+  }
+
   numExprs_ = allExprs.size();
   exprs_ = makeExprSetFromFlag(
       std::move(allExprs), operatorCtx_->execCtx(), lazyDereference_);
@@ -251,8 +224,10 @@ RowVectorPtr FilterProject::getOutput() {
   if (!hasFilter_) {
     VELOX_CHECK(!isIdentityProjection_);
     auto results = project(*rows, evalCtx);
+    if (!lazyDereference_) {
+      loadReusedLazyVectors(input_, reusedInputChannels_);
+    }
     auto output = fillOutput(size, nullptr, results);
-    loadReusedLazyVectors(output);
     return output;
   }
 
@@ -273,11 +248,13 @@ RowVectorPtr FilterProject::getOutput() {
     results = project(*rows, evalCtx);
   }
 
+  if (!lazyDereference_) {
+    loadReusedLazyVectors(input_, reusedInputChannels_);
+  }
   auto output = fillOutput(
       numOut,
       allRowsSelected ? nullptr : filterEvalCtx_.selectedIndices,
       results);
-  loadReusedLazyVectors(output);
   return output;
 }
 

--- a/velox/exec/FilterProject.h
+++ b/velox/exec/FilterProject.h
@@ -128,5 +128,13 @@ class FilterProject : public Operator {
   // will load c1 only for rows where f(c0) is true. However, c1 identity
   // projection needs all rows.
   std::vector<column_index_t> multiplyReferencedFieldIndices_;
+
+  // Input channels that map to more than one output channel via identity
+  // projections. Their lazy vectors must be loaded before fillOutput to avoid
+  // sharing unloaded lazy vectors across multiple output fields. Skipped when
+  // `lazyDereference_` is true because LazyDereferenceNode guarantees no filter
+  // (no partial-row loading through pushdown hooks) and expects lazy vectors to
+  // remain unloaded for downstream parallel processing.
+  std::vector<column_index_t> reusedInputChannels_;
 };
 } // namespace facebook::velox::exec


### PR DESCRIPTION
Summary:
Refactor `loadReusedLazyVectors` in FilterProject to use `identityProjections` instead of scanning all output children for duplicate lazy vector pointers. The new implementation finds input channels that appear in more than one identity projection and loads them directly on the input vector before `fillOutput` is called, ensuring the output contains already-loaded vectors.

This removes the need for the `unwrapToLazy` and `lazyIdentityPtr` helper functions.

Loading is skipped when `lazyDereference_` is true because `LazyDereferenceNode` guarantees no filter (no partial-row loading through pushdown hooks) and expects lazy vectors to remain unloaded for downstream parallel processing.

Reviewed By: Yuhta

Differential Revision: D102241800


