### PR TITLE
perf: Batch HashStringAllocator write sessions in ValueList::appendValues

### DIFF
--- a/velox/functions/lib/aggregates/ValueList.cpp
+++ b/velox/functions/lib/aggregates/ValueList.cpp
@@ -17,7 +17,20 @@
 #include "velox/exec/ContainerRowSerde.h"
 
 namespace facebook::velox::aggregate {
+namespace {
+// Set isKey to false to avoid unnecessary sorting.
+const exec::ContainerRowSerdeOptions& valueSerdeOptions() {
+  static const exec::ContainerRowSerdeOptions kOptions{/*isKey=*/false};
+  return kOptions;
+}
+} // namespace
+
 void ValueList::prepareAppend(HashStringAllocator* allocator) {
+  ensureAllocations(allocator);
+  maybeFlushNullsAtBoundary(allocator);
+}
+
+void ValueList::ensureAllocations(HashStringAllocator* allocator) {
   if (!nullsBegin_) {
     nullsBegin_ = allocator->allocate(HashStringAllocator::kMinAlloc);
     nullsCurrent_ = {nullsBegin_, nullsBegin_->begin()};
@@ -27,7 +40,9 @@ void ValueList::prepareAppend(HashStringAllocator* allocator) {
     dataBegin_ = allocator->allocate(kInitialSize);
     dataCurrent_ = {dataBegin_, dataBegin_->begin()};
   }
+}
 
+void ValueList::maybeFlushNullsAtBoundary(HashStringAllocator* allocator) {
   if (size_ && size_ % 64 == 0) {
     writeLastNulls(allocator);
     lastNulls_ = 0;
@@ -65,9 +80,8 @@ void ValueList::appendNonNull(
   allocator->extendWrite(dataCurrent_, stream);
   // The stream may have a tail of a previous write.
   const auto initialSize = stream.size();
-  // Set isKey to false to avoid unnecessary sorting.
-  static const exec::ContainerRowSerdeOptions kOptions{/*isKey=*/false};
-  exec::ContainerRowSerde::serialize(values, index, stream, kOptions);
+  exec::ContainerRowSerde::serialize(
+      values, index, stream, valueSerdeOptions());
   ++size_;
   bytes_ += stream.size() - initialSize;
 
@@ -87,6 +101,55 @@ void ValueList::appendValue(
   } else {
     appendNonNull(base, decoded.index(index), allocator);
   }
+}
+
+void ValueList::appendValues(
+    const DecodedVector& decoded,
+    const SelectivityVector& rows,
+    HashStringAllocator* allocator) {
+  if (!rows.hasSelections()) {
+    return;
+  }
+  ensureAllocations(allocator);
+
+  auto& base = *decoded.base();
+  const bool mayHaveNulls = decoded.mayHaveNulls();
+
+  // We cannot hold a single data-stream write session open across the entire
+  // loop because maybeFlushNullsAtBoundary -> writeLastNulls opens its own
+  // extendWrite/finishWrite on the same allocator, which resets the
+  // allocator's internal write state.  Instead we close and reopen the data
+  // stream around each null-word boundary flush.
+  ByteOutputStream stream(allocator);
+  allocator->extendWrite(dataCurrent_, stream);
+  auto segmentStart = stream.size();
+
+  rows.applyToSelected([&](vector_size_t row) {
+    if (size_ && size_ % 64 == 0) {
+      bytes_ += stream.size() - segmentStart;
+      dataCurrent_ =
+          allocator->finishWrite(stream, std::clamp(bytes_ / 2, 24, 1024))
+              .second;
+      writeLastNulls(allocator);
+      lastNulls_ = 0;
+      allocator->ensureAvailable(sizeof(int64_t), nullsCurrent_);
+
+      allocator->extendWrite(dataCurrent_, stream);
+      segmentStart = stream.size();
+    }
+
+    if (mayHaveNulls && decoded.isNullAt(row)) {
+      lastNulls_ |= 1UL << (size_ % 64);
+    } else {
+      exec::ContainerRowSerde::serialize(
+          base, decoded.index(row), stream, valueSerdeOptions());
+    }
+    ++size_;
+  });
+
+  bytes_ += stream.size() - segmentStart;
+  dataCurrent_ =
+      allocator->finishWrite(stream, std::clamp(bytes_ / 2, 24, 1024)).second;
 }
 
 void ValueList::appendRange(

--- a/velox/functions/lib/aggregates/ValueList.h
+++ b/velox/functions/lib/aggregates/ValueList.h
@@ -47,6 +47,14 @@ class ValueList {
     }
   }
 
+  /// Appends all rows selected by 'rows' from 'decoded' in a single
+  /// HashStringAllocator write session. Avoids the per-value
+  /// extendWrite/finishWrite round-trip of appendValue.
+  void appendValues(
+      const DecodedVector& decoded,
+      const SelectivityVector& rows,
+      HashStringAllocator* allocator);
+
   void appendRange(
       const VectorPtr& vector,
       vector_size_t offset,
@@ -94,6 +102,13 @@ class ValueList {
       HashStringAllocator* allocator);
 
   void prepareAppend(HashStringAllocator* allocator);
+
+  // Lazily allocates the 'nulls' and 'data' blocks on first append.
+  void ensureAllocations(HashStringAllocator* allocator);
+
+  // Flushes 'lastNulls_' and resets it if we are about to start a new
+  // 64-element null word.
+  void maybeFlushNullsAtBoundary(HashStringAllocator* allocator);
 
   // Writes lastNulls_ word to the 'nulls' block.
   void writeLastNulls(HashStringAllocator* allocator);

--- a/velox/functions/prestosql/aggregates/ArrayAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArrayAggAggregate.cpp
@@ -348,12 +348,16 @@ class ArrayAggAggregate : public exec::Aggregate {
 
     decodedElements_.decode(*args[0], rows);
     auto tracker = trackRowSize(group);
-    rows.applyToSelected([&](vector_size_t row) {
-      if (ignoreNulls_ && decodedElements_.isNullAt(row)) {
+    if (ignoreNulls_ && decodedElements_.mayHaveNulls()) {
+      const auto* nulls = decodedElements_.nulls(&rows);
+      if (nulls != nullptr) {
+        SelectivityVector nonNullRows = rows;
+        nonNullRows.deselectNulls(nulls, rows.begin(), rows.end());
+        values.appendValues(decodedElements_, nonNullRows, allocator_);
         return;
       }
-      values.appendValue(decodedElements_, row, allocator_);
-    });
+    }
+    values.appendValues(decodedElements_, rows, allocator_);
   }
 
   void addSingleGroupIntermediateResults(

--- a/velox/functions/prestosql/aggregates/benchmarks/ArrayAgg.cpp
+++ b/velox/functions/prestosql/aggregates/benchmarks/ArrayAgg.cpp
@@ -1,0 +1,309 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "velox/exec/Cursor.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/lib/aggregates/ValueList.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+DEFINE_int64(fuzzer_seed, 99887766, "Seed for random input dataset generator");
+
+using namespace facebook::velox;
+using namespace facebook::velox::aggregate;
+using namespace facebook::velox::exec::test;
+
+namespace {
+
+// End-to-end benchmark: SELECT array_agg(x) FROM t (global, single group)
+// exercises Aggregate::addSingleGroupRawInput, which is the path the
+// ValueList::appendValues optimization targets.
+class ArrayAggBenchmark
+    : public facebook::velox::exec::test::HiveConnectorTestBase {
+ public:
+  ArrayAggBenchmark() {
+    HiveConnectorTestBase::SetUp();
+
+    inputType_ = ROW({
+        {"i32", INTEGER()},
+        {"i64", BIGINT()},
+        {"f64", DOUBLE()},
+        {"i64_halfnull", BIGINT()},
+        {"str_short", VARCHAR()},
+        {"str_long", VARCHAR()},
+        {"str_halfnull", VARCHAR()},
+    });
+
+    VectorFuzzer::Options opts;
+    opts.vectorSize = kRowsPerVector;
+    opts.nullRatio = 0;
+    VectorFuzzer fuzzer(opts, pool(), FLAGS_fuzzer_seed);
+
+    std::vector<RowVectorPtr> vectors;
+    for (auto i = 0; i < kNumVectors; ++i) {
+      std::vector<VectorPtr> children;
+      children.emplace_back(fuzzer.fuzzFlat(INTEGER()));
+      children.emplace_back(fuzzer.fuzzFlat(BIGINT()));
+      children.emplace_back(fuzzer.fuzzFlat(DOUBLE()));
+      opts.nullRatio = 0.5;
+      fuzzer.setOptions(opts);
+      children.emplace_back(fuzzer.fuzzFlat(BIGINT()));
+      opts.nullRatio = 0;
+      fuzzer.setOptions(opts);
+      opts.stringLength = 10;
+      fuzzer.setOptions(opts);
+      children.emplace_back(fuzzer.fuzzFlat(VARCHAR()));
+      opts.stringLength = 200;
+      fuzzer.setOptions(opts);
+      children.emplace_back(fuzzer.fuzzFlat(VARCHAR()));
+      opts.nullRatio = 0.5;
+      opts.stringLength = 50;
+      fuzzer.setOptions(opts);
+      children.emplace_back(fuzzer.fuzzFlat(VARCHAR()));
+      opts.nullRatio = 0;
+      opts.stringLength = 0;
+      fuzzer.setOptions(opts);
+      vectors.emplace_back(makeRowVector(inputType_->names(), children));
+    }
+
+    filePath_ = TempFilePath::create();
+    writeToFile(filePath_->getPath(), vectors);
+  }
+
+  ~ArrayAggBenchmark() override {
+    HiveConnectorTestBase::TearDown();
+  }
+
+  void TestBody() override {}
+
+  // Global (single-group) array_agg. Exercises addSingleGroupRawInput.
+  void runGlobal(const std::string& aggregate) {
+    folly::BenchmarkSuspender suspender;
+    auto plan = PlanBuilder()
+                    .tableScan(inputType_)
+                    .singleAggregation({}, {aggregate})
+                    .planFragment();
+
+    auto task = makeTask(plan);
+    task->addSplit(
+        "0",
+        facebook::velox::exec::Split(
+            makeHiveConnectorSplit(filePath_->getPath())));
+    task->noMoreSplits("0");
+    suspender.dismiss();
+
+    vector_size_t numResultRows = 0;
+    while (auto result = task->next()) {
+      numResultRows += result->size();
+    }
+    folly::doNotOptimizeAway(numResultRows);
+  }
+
+  std::shared_ptr<facebook::velox::exec::Task> makeTask(
+      core::PlanFragment plan) {
+    return facebook::velox::exec::Task::create(
+        "t",
+        std::move(plan),
+        0,
+        core::QueryCtx::create(executor_.get()),
+        facebook::velox::exec::Task::ExecutionMode::kSerial,
+        facebook::velox::exec::Consumer{});
+  }
+
+ public:
+  static constexpr int32_t kNumVectors = 200;
+  static constexpr int32_t kRowsPerVector = 10'000;
+
+ private:
+  RowTypePtr inputType_;
+  std::shared_ptr<TempFilePath> filePath_;
+};
+
+std::unique_ptr<ArrayAggBenchmark> benchmark;
+
+void doRunGlobal(uint32_t, const std::string& aggregate) {
+  benchmark->runGlobal(aggregate);
+}
+
+BENCHMARK_NAMED_PARAM(doRunGlobal, global_i32, "array_agg(i32)");
+BENCHMARK_NAMED_PARAM(doRunGlobal, global_i64, "array_agg(i64)");
+BENCHMARK_NAMED_PARAM(doRunGlobal, global_f64, "array_agg(f64)");
+BENCHMARK_NAMED_PARAM(
+    doRunGlobal,
+    global_i64_halfnull,
+    "array_agg(i64_halfnull)");
+BENCHMARK_NAMED_PARAM(doRunGlobal, global_str_short, "array_agg(str_short)");
+BENCHMARK_NAMED_PARAM(doRunGlobal, global_str_long, "array_agg(str_long)");
+BENCHMARK_NAMED_PARAM(
+    doRunGlobal,
+    global_str_halfnull,
+    "array_agg(str_halfnull)");
+BENCHMARK_DRAW_LINE();
+
+// Direct ValueList microbenchmark: compares appendValue (per-row stream
+// extendWrite/finishWrite) against appendValues (single batched session).
+class ValueListMicroBenchmark : public test::VectorTestBase {
+ public:
+  ValueListMicroBenchmark() {
+    constexpr int32_t kSize = 100'000;
+    inputInt_ = makeFlatVector<int64_t>(kSize, [](auto i) { return i * 31; });
+
+    VectorFuzzer::Options opts;
+    opts.vectorSize = kSize;
+    opts.nullRatio = 0;
+    opts.stringLength = 10;
+    VectorFuzzer fuzzer(opts, pool(), 42);
+    inputStrShort_ = fuzzer.fuzzFlat(VARCHAR());
+    opts.stringLength = 200;
+    fuzzer.setOptions(opts);
+    inputStr200_ = fuzzer.fuzzFlat(VARCHAR());
+    opts.stringLength = 1'000;
+    fuzzer.setOptions(opts);
+    inputStr1K_ = fuzzer.fuzzFlat(VARCHAR());
+    opts.stringLength = 10'000;
+    fuzzer.setOptions(opts);
+    inputStr10K_ = fuzzer.fuzzFlat(VARCHAR());
+    opts.vectorSize = 10'000;
+    opts.stringLength = 100'000;
+    fuzzer.setOptions(opts);
+    inputStr100K_ = fuzzer.fuzzFlat(VARCHAR());
+    rows10K_ = SelectivityVector(10'000);
+    opts.vectorSize = 1'000;
+    opts.stringLength = 500'000;
+    fuzzer.setOptions(opts);
+    inputStr500K_ = fuzzer.fuzzFlat(VARCHAR());
+    rows1K_ = SelectivityVector(1'000);
+
+    rows_ = SelectivityVector(kSize);
+  }
+
+  void appendOneByOne(const VectorPtr& input, const SelectivityVector& rows) {
+    HashStringAllocator allocator{pool()};
+    DecodedVector decoded(*input, rows);
+    ValueList values;
+    rows.applyToSelected([&](vector_size_t row) {
+      values.appendValue(decoded, row, &allocator);
+    });
+    folly::doNotOptimizeAway(values.size());
+    values.free(&allocator);
+  }
+
+  void appendBatch(const VectorPtr& input, const SelectivityVector& rows) {
+    HashStringAllocator allocator{pool()};
+    DecodedVector decoded(*input, rows);
+    ValueList values;
+    values.appendValues(decoded, rows, &allocator);
+    folly::doNotOptimizeAway(values.size());
+    values.free(&allocator);
+  }
+
+  VectorPtr inputInt_;
+  VectorPtr inputStrShort_;
+  VectorPtr inputStr200_;
+  VectorPtr inputStr1K_;
+  VectorPtr inputStr10K_;
+  VectorPtr inputStr100K_;
+  VectorPtr inputStr500K_;
+  SelectivityVector rows_;
+  SelectivityVector rows10K_;
+  SelectivityVector rows1K_;
+};
+
+std::unique_ptr<ValueListMicroBenchmark> micro;
+
+BENCHMARK(valueList_int64_perRow) {
+  micro->appendOneByOne(micro->inputInt_, micro->rows_);
+}
+
+BENCHMARK_RELATIVE(valueList_int64_batch) {
+  micro->appendBatch(micro->inputInt_, micro->rows_);
+}
+
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK(valueList_str10_perRow) {
+  micro->appendOneByOne(micro->inputStrShort_, micro->rows_);
+}
+
+BENCHMARK_RELATIVE(valueList_str10_batch) {
+  micro->appendBatch(micro->inputStrShort_, micro->rows_);
+}
+
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK(valueList_str200_perRow) {
+  micro->appendOneByOne(micro->inputStr200_, micro->rows_);
+}
+
+BENCHMARK_RELATIVE(valueList_str200_batch) {
+  micro->appendBatch(micro->inputStr200_, micro->rows_);
+}
+
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK(valueList_str1K_perRow) {
+  micro->appendOneByOne(micro->inputStr1K_, micro->rows_);
+}
+
+BENCHMARK_RELATIVE(valueList_str1K_batch) {
+  micro->appendBatch(micro->inputStr1K_, micro->rows_);
+}
+
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK(valueList_str10K_perRow) {
+  micro->appendOneByOne(micro->inputStr10K_, micro->rows_);
+}
+
+BENCHMARK_RELATIVE(valueList_str10K_batch) {
+  micro->appendBatch(micro->inputStr10K_, micro->rows_);
+}
+
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK(valueList_str100K_perRow) {
+  micro->appendOneByOne(micro->inputStr100K_, micro->rows10K_);
+}
+
+BENCHMARK_RELATIVE(valueList_str100K_batch) {
+  micro->appendBatch(micro->inputStr100K_, micro->rows10K_);
+}
+
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK(valueList_str500K_perRow) {
+  micro->appendOneByOne(micro->inputStr500K_, micro->rows1K_);
+}
+
+BENCHMARK_RELATIVE(valueList_str500K_batch) {
+  micro->appendBatch(micro->inputStr500K_, micro->rows1K_);
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  folly::Init init{&argc, &argv};
+  facebook::velox::exec::test::OperatorTestBase::SetUpTestCase();
+  benchmark = std::make_unique<ArrayAggBenchmark>();
+  micro = std::make_unique<ValueListMicroBenchmark>();
+  folly::runBenchmarks();
+  benchmark.reset();
+  micro.reset();
+  facebook::velox::exec::test::OperatorTestBase::TearDownTestCase();
+  return 0;
+}

--- a/velox/functions/prestosql/aggregates/benchmarks/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/benchmarks/CMakeLists.txt
@@ -61,3 +61,20 @@ target_link_libraries(
   Folly::follybenchmark
   gflags::gflags
 )
+
+add_executable(velox_aggregates_array_agg_bm ArrayAgg.cpp)
+
+target_link_libraries(
+  velox_aggregates_array_agg_bm
+  velox_aggregates
+  velox_hive_connector
+  velox_functions_lib
+  velox_exec_test_lib
+  velox_functions_prestosql
+  velox_dwio_common_exception
+  velox_vector_fuzzer
+  velox_vector_test_lib
+  Folly::folly
+  Folly::follybenchmark
+  gflags::gflags
+)


### PR DESCRIPTION
## Summary

Batches `HashStringAllocator` `extendWrite`/`finishWrite` calls in a new
`ValueList::appendValues` method, replacing the per-row round-trip in
single-group aggregation paths (`addSingleGroupRawInput`).

- **`ValueList::appendValues(decoded, rows, allocator)`** — opens the data
  stream once and serializes all selected non-null values in bulk.  Closes
  and reopens only at 64-element null-word boundaries where `writeLastNulls`
  needs its own allocator session.
- **`ArrayAggAggregate::addSingleGroupRawInput`** — wired to use the new
  bulk path.  For `ignoreNulls`, uses `SelectivityVector::deselectNulls`
  instead of per-row branching.
- **Refactored `prepareAppend`** into `ensureAllocations` + `maybeFlushNullsAtBoundary`
  so both singleton and batch paths share them.
- **Benchmark** (`ArrayAgg.cpp`) — end-to-end global `array_agg` and direct
  `ValueList` microbenchmark across int64, short/long varchar, with
  `BENCHMARK_RELATIVE`.

## Benchmark results

ValueList microbenchmark (Apple M1, release build):

```
============================================================================
valueList_int64_perRow                                      3.02ms    331.67
valueList_int64_batch                           550.16%   548.04us     1.82K
----------------------------------------------------------------------------
valueList_str10_perRow                                      3.29ms    304.20
valueList_str10_batch                           394.49%   833.29us     1.20K
----------------------------------------------------------------------------
valueList_str200_perRow                                     6.84ms    146.10
valueList_str200_batch                          313.16%     2.19ms    457.54
----------------------------------------------------------------------------
valueList_str1K_perRow                                     19.55ms     51.16
valueList_str1K_batch                           217.48%     8.99ms    111.26
----------------------------------------------------------------------------
valueList_str10K_perRow                                   115.17ms      8.68
valueList_str10K_batch                          120.19%    95.82ms     10.44
----------------------------------------------------------------------------
valueList_str100K_perRow                                     2.83s   353.14m
valueList_str100K_batch                         2925.5%    96.80ms     10.33
----------------------------------------------------------------------------
valueList_str500K_perRow                                     2.68s   373.32m
valueList_str500K_batch                         5726.7%    46.78ms     21.38
```

| Type | Rows | Per-row | Batch | Speedup |
|---|---|---|---|---|
| int64 | 100K | 3.0ms | 548µs | **5.5x** |
| varchar(10) | 100K | 3.3ms | 833µs | **3.9x** |
| varchar(200) | 100K | 6.8ms | 2.2ms | **3.1x** |
| varchar(1K) | 100K | 19.6ms | 9.0ms | **2.2x** |
| varchar(10K) | 100K | 115ms | 95.8ms | **1.2x** |
| varchar(100K) | 10K | 2.83s | 96.8ms | **29x** |
| varchar(500K) | 1K | 2.68s | 46.8ms | **57x** |

## Not yet wired (deferred)

- `addRawInput` (per-row, multi-group) — harder to batch since rows fan out
  to different groups.
- `addSingleGroupIntermediateResults` — same structure; trivial to extend.
- `appendRange` in `ValueList` — currently per-element loop.

## Test plan

- [x] All 10 `ArrayAggTest` unit tests pass
- [x] Benchmark runs clean across int/varchar types
- [ ] CI