### PR TITLE
feat: Support json type when parsing Hive types (#17573)

### DIFF
--- a/velox/type/fbhive/HiveTypeParser.cpp
+++ b/velox/type/fbhive/HiveTypeParser.cpp
@@ -99,6 +99,13 @@ Result HiveTypeParser::parseType() {
   VELOX_CHECK(!nt.isEOS(), "Unexpected end of stream parsing type!!!");
 
   if (!nt.isValidType()) {
+    // An identifier that is not a builtin keyword may name a registered custom
+    // type (e.g. Presto's JSON). Resolve it generically through the custom-type
+    // registry before failing.
+    if (auto customType =
+            getCustomType(std::string(nt.value), /*parameters=*/{})) {
+      return Result{customType};
+    }
     VELOX_FAIL(
         "Unexpected token {} at {}. typeKind = {}",
         nt.value,

--- a/velox/type/fbhive/tests/HiveTypeParserTests.cpp
+++ b/velox/type/fbhive/tests/HiveTypeParserTests.cpp
@@ -128,6 +128,7 @@ TEST(FbHive, badParse) {
       parser.parse("uniontype< bigint , int, float"),
       "Unexpected token uniontype at < bigint , int, float");
   VELOX_ASSERT_THROW(parser.parse("badid"), "Unexpected token badid at ");
+  VELOX_ASSERT_THROW(parser.parse("not_a_real_type"), "Unexpected token");
   VELOX_ASSERT_THROW(
       parser.parse("struct<int, bigint>"), "Unexpected token ' bigint>'");
   VELOX_ASSERT_THROW(parser.parse("list<>"), "Unexpected token list at <>");
@@ -212,5 +213,51 @@ TEST(FbHive, parseOpaqueCustomTypeReturnsSingleton) {
   // signatures holds.
   EXPECT_EQ(parsed.get(), CustomFooRegistrar::singletonTypePtr().get());
   CustomFooRegistrar::unregisterType();
+}
+
+namespace {
+
+// A generic VARCHAR-backed custom type used solely to exercise the parser's
+// custom-type lookup. It is unrelated to any real type.
+class TestCustomType final : public VarcharType {
+  TestCustomType() = default;
+
+ public:
+  static std::shared_ptr<const TestCustomType> get() {
+    static const TestCustomType kInstance;
+    return {std::shared_ptr<const TestCustomType>{}, &kInstance};
+  }
+};
+
+class TestCustomTypeFactory : public CustomTypeFactory {
+ public:
+  TypePtr getType(const std::vector<TypeParameter>& parameters) const override {
+    VELOX_CHECK(parameters.empty());
+    return TestCustomType::get();
+  }
+
+  exec::CastOperatorPtr getCastOperator() const override {
+    return nullptr;
+  }
+
+  AbstractInputGeneratorPtr getInputGenerator(
+      const InputGeneratorConfig& /*config*/) const override {
+    return nullptr;
+  }
+};
+
+} // namespace
+
+TEST(FbHive, parseCustomTypeReturnsSingleton) {
+  // An identifier that names a registered custom type must resolve to that
+  // registered singleton (not fail as an unknown token) so downstream
+  // type-equality with UDF signatures holds.
+  registerCustomType(
+      "test_custom_type", std::make_unique<const TestCustomTypeFactory>());
+  HiveTypeParser parser;
+  auto parsed = parser.parse("test_custom_type");
+  EXPECT_EQ(parsed.get(), TestCustomType::get().get());
+  EXPECT_EQ(parsed->kind(), TypeKind::VARCHAR);
+  unregisterCustomType("test_custom_type");
 }
 } // namespace facebook::velox::type::fbhive


### PR DESCRIPTION
Summary:

In XStream we encode UDF signatures as Hive types. Custom types such as `json` will appear as such instead of `opaque<json>`. This needs to be handled in the Hive deserializer.

The problem is that for a type to be considered valid in Hive deserializer, it has to be registered in as a token in `HiveTypeParser` - this couples the hive parser with specific engines. Do avoid that we add a fallback for "invalid types" in case it happens to be a custom type.

Reviewed By: kagamiori

Differential Revision: D105874755


