### PR TITLE
build(cudf): Add install_cuda_runtime for runtime images

### DIFF
--- a/scripts/setup-centos-adapters.sh
+++ b/scripts/setup-centos-adapters.sh
@@ -68,12 +68,11 @@ function install_ucx {
   )
 }
 
-function install_cuda {
+function setup_cuda_repo {
   # See https://developer.nvidia.com/cuda-downloads
   local arch
   arch="$(uname -m)"
   local repo_url
-  version="${1:-$VELOX_CUDA_VERSION}"
 
   if [[ $arch == "x86_64" ]]; then
     repo_url="https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo"
@@ -86,8 +85,13 @@ function install_cuda {
   fi
 
   dnf config-manager --add-repo "$repo_url"
+}
+
+function install_cuda {
+  local version="${1:-$VELOX_CUDA_VERSION}"
   local dashed
   dashed="$(echo "$version" | tr '.' '-')"
+  setup_cuda_repo || return 1
   dnf_install \
     cuda-compat-"$dashed" \
     cuda-driver-devel-"$dashed" \
@@ -97,6 +101,22 @@ function install_cuda {
     libnvjitlink-devel-"$dashed" \
     cuda-nvml-devel-"$dashed" \
     numactl-devel
+}
+
+function install_cuda_runtime {
+  # Installs only CUDA runtime libraries (no -devel packages).
+  # For use in runtime containers that don't need headers/static libs.
+  local version="${1:-$VELOX_CUDA_VERSION}"
+  local dashed
+  dashed="$(echo "$version" | tr '.' '-')"
+  setup_cuda_repo || return 1
+  dnf_install \
+    cuda-cudart-"$dashed" \
+    cuda-compat-"$dashed" \
+    cuda-nvrtc-"$dashed" \
+    libcufile-"$dashed" \
+    libnvjitlink-"$dashed" \
+    numactl-libs
 }
 
 function install_adapters_deps_from_dnf {


### PR DESCRIPTION
Introduce install_cuda_runtime alongside install_cuda. The new function installs only the CUDA runtime shared libraries (cuda-cudart, cuda-compat, cuda-nvrtc, libcufile, libnvjitlink) plus numactl-libs, which UCX links against at runtime.

Extract the arch -> CUDA repo URL setup into a setup_cuda_repo helper used by both install_cuda and install_cuda_runtime, and add the missing local keyword to the version assignment so it no longer leaks into the global scope.