### PR TITLE
fix(spark): Fix regexp_replace with backslash-letter replacements

### DIFF
--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -2456,4 +2456,35 @@ regexpReplaceWithLambdaSignatures() {
               .argumentType("function(array(varchar), varchar)")
               .build()};
 }
+
+std::string unescapeReplacement(const std::string& replacement) {
+  std::string result;
+  result.reserve(replacement.size());
+  for (size_t i = 0; i < replacement.size();) {
+    const char current = replacement[i];
+    const bool hasNext = i + 1 < replacement.size();
+    if (current == '\\' && hasNext) {
+      const char following = replacement[i + 1];
+      if (following == '\\' || (following >= '0' && following <= '9')) {
+        // '\\\\' and '\\<digit>' have the same meaning in RE2 and in
+        // java.util.regex; keep them as a two-byte unit.
+        result.push_back(current);
+        result.push_back(following);
+        i += 2;
+      } else {
+        // '\\<other>' in java.util.regex is just <other>; emit the trailing
+        // byte and skip the backslash.
+        result.push_back(following);
+        i += 2;
+      }
+    } else {
+      // Plain byte, or a trailing lone '\\'. The latter is invalid in both
+      // engines; we keep the byte so RE2 surfaces the error later instead of
+      // silently dropping input here.
+      result.push_back(current);
+      ++i;
+    }
+  }
+  return result;
+}
 } // namespace facebook::velox::functions

--- a/velox/functions/lib/Re2Functions.h
+++ b/velox/functions/lib/Re2Functions.h
@@ -409,25 +409,70 @@ FOLLY_ALWAYS_INLINE std::string prepareRegexpReplacePattern(
   return newPattern;
 }
 
-/// This function preprocesses an input replacement string to follow RE2 syntax
-/// for java.util.regex used by Presto and Spark. These are the replacements
-/// that are required.
-/// 1. RE2 replacement only supports group index capture, so we need to convert
-/// group name captures to group index captures.
-/// 2. Group index capture in java.util.regex replacement is '$N', while in RE2
-/// replacement it is '\N'. We need to convert it.
-/// 3. Replacement in RE2 only supports '\' followed by a digit or another '\',
-/// while java.util.regex will ignore '\' in replacements, so we need to
-/// unescape it.
+/// Translate a java.util.regex-style replacement string into the equivalent
+/// RE2 replacement.
 ///
-/// The unescape step in (3) is performed as a single left-to-right byte scan
-/// so that an escaped backslash '\\' is always consumed as one unit and the
-/// byte that follows it is preserved verbatim. This invariant is required by
-/// inputs such as '\\n' (a literal backslash followed by 'n'): the leading
-/// '\\' must be kept as-is, and the trailing 'n' must not be revisited as
-/// the target of another backslash-unescape, otherwise the replacement
-/// collapses to '\n' which RE2 then rejects, silently dropping the matched
-/// bytes from the input string.
+/// Both java.util.regex and RE2 treat '\\' as an escape introducer in the
+/// replacement, but they differ on what may follow:
+///   - '\\\\'      -> a single literal backslash (same in both).
+///   - '\\<digit>' -> back-reference (same in both, though Spark/Java also
+///                    accept the '$<digit>' form which the caller converts
+///                    separately).
+///   - '\\<other>' -> java.util.regex silently drops the backslash and keeps
+///                    the trailing character as a literal; RE2 rejects this
+///                    form. To bridge the two, we strip the backslash here.
+///
+/// The translation must consume the input in two-byte escape units. A regex
+/// pass cannot do this: given '\\\\X' (literal backslash followed by 'X'),
+/// the leftmost search for '\\<not-digit-not-backslash>' starts at offset 1,
+/// matches '\\X' and produces 'X', dropping the leading backslash that
+/// should have been kept. This byte-level loop walks the string left to
+/// right and always advances past a recognized escape unit as a whole.
+FOLLY_ALWAYS_INLINE std::string unescapeReplacement(
+    const std::string& replacement) {
+  std::string result;
+  result.reserve(replacement.size());
+  for (size_t i = 0; i < replacement.size();) {
+    const char current = replacement[i];
+    const bool hasNext = i + 1 < replacement.size();
+    if (current == '\\' && hasNext) {
+      const char following = replacement[i + 1];
+      if (following == '\\' || (following >= '0' && following <= '9')) {
+        // '\\\\' and '\\<digit>' have the same meaning in RE2 and in
+        // java.util.regex; keep them as a two-byte unit.
+        result.push_back(current);
+        result.push_back(following);
+        i += 2;
+      } else {
+        // '\\<other>' in java.util.regex is just <other>; emit the trailing
+        // byte and skip the backslash.
+        result.push_back(following);
+        i += 2;
+      }
+    } else {
+      // Plain byte, or a trailing lone '\\'. The latter is invalid in both
+      // engines; we keep the byte so RE2 surfaces the error later instead of
+      // silently dropping input here.
+      result.push_back(current);
+      ++i;
+    }
+  }
+  return result;
+}
+
+/// This function preprocesses an input replacement string to follow RE2
+/// syntax for java.util.regex used by Presto and Spark. The required
+/// transformations are:
+/// 1. RE2 replacement only supports group index capture, so named capturing
+/// group references are converted to numbered captures.
+/// 2. Group index capture in java.util.regex replacement is '$N', while in
+/// RE2 replacement it is '\N'. We convert it.
+/// 3. java.util.regex silently drops a backslash that is followed by any
+/// character other than another backslash or a digit; RE2 instead rejects
+/// such sequences. To match Spark/Presto semantics we strip the leading
+/// backslash before passing the replacement to RE2. The transformation is
+/// done by unescapeReplacement(); see that function for why it cannot be
+/// expressed as another regex pass.
 FOLLY_ALWAYS_INLINE std::string prepareRegexpReplaceReplacement(
     const RE2& re,
     const StringView& replacement) {
@@ -476,42 +521,7 @@ FOLLY_ALWAYS_INLINE std::string prepareRegexpReplaceReplacement(
       kConvertRegex.error());
   RE2::GlobalReplace(&newReplacement, kConvertRegex, R"(\\\1)");
 
-  // Un-escape character except digit or '\\'.
-  // We scan byte by byte so that an escaped backslash '\\' is always consumed
-  // as a single unit; the following byte is then preserved verbatim and is
-  // never mistaken for the start of another '\X' escape sequence. This avoids
-  // a regression where input like '\\n' (literal backslash + 'n') was being
-  // turned into '\n' by RE2::GlobalReplace, which subsequently failed in
-  // RE2::Rewrite and silently dropped matched bytes from the input string.
-  std::string unescaped;
-  unescaped.reserve(newReplacement.size());
-  for (size_t i = 0; i < newReplacement.size();) {
-    const char c = newReplacement[i];
-    if (c == '\\' && i + 1 < newReplacement.size()) {
-      const char next = newReplacement[i + 1];
-      if (next == '\\' || (next >= '0' && next <= '9')) {
-        // Preserve '\\' (literal backslash in RE2) and '\<digit>'
-        // (RE2 numbered backreference) as a two-byte unit.
-        unescaped.push_back(c);
-        unescaped.push_back(next);
-        i += 2;
-      } else {
-        // '\X' where X is neither a digit nor '\' -> emit literal X, matching
-        // java.util.regex semantics that silently ignores the backslash.
-        unescaped.push_back(next);
-        i += 2;
-      }
-    } else {
-      // Plain byte (or trailing lone '\\' which RE2::Rewrite will reject; we
-      // keep prior behavior of letting RE2 surface the error rather than
-      // silently dropping the byte here).
-      unescaped.push_back(c);
-      ++i;
-    }
-  }
-  newReplacement = std::move(unescaped);
-
-  return newReplacement;
+  return unescapeReplacement(newReplacement);
 }
 
 } // namespace facebook::velox::functions

--- a/velox/functions/lib/Re2Functions.h
+++ b/velox/functions/lib/Re2Functions.h
@@ -426,39 +426,12 @@ FOLLY_ALWAYS_INLINE std::string prepareRegexpReplacePattern(
 /// pass cannot do this: given '\\\\X' (literal backslash followed by 'X'),
 /// the leftmost search for '\\<not-digit-not-backslash>' starts at offset 1,
 /// matches '\\X' and produces 'X', dropping the leading backslash that
-/// should have been kept. This byte-level loop walks the string left to
-/// right and always advances past a recognized escape unit as a whole.
-FOLLY_ALWAYS_INLINE std::string unescapeReplacement(
-    const std::string& replacement) {
-  std::string result;
-  result.reserve(replacement.size());
-  for (size_t i = 0; i < replacement.size();) {
-    const char current = replacement[i];
-    const bool hasNext = i + 1 < replacement.size();
-    if (current == '\\' && hasNext) {
-      const char following = replacement[i + 1];
-      if (following == '\\' || (following >= '0' && following <= '9')) {
-        // '\\\\' and '\\<digit>' have the same meaning in RE2 and in
-        // java.util.regex; keep them as a two-byte unit.
-        result.push_back(current);
-        result.push_back(following);
-        i += 2;
-      } else {
-        // '\\<other>' in java.util.regex is just <other>; emit the trailing
-        // byte and skip the backslash.
-        result.push_back(following);
-        i += 2;
-      }
-    } else {
-      // Plain byte, or a trailing lone '\\'. The latter is invalid in both
-      // engines; we keep the byte so RE2 surfaces the error later instead of
-      // silently dropping input here.
-      result.push_back(current);
-      ++i;
-    }
-  }
-  return result;
-}
+/// should have been kept. The implementation walks the string left to right
+/// and always advances past a recognized escape unit as a whole.
+///
+/// Defined in Re2Functions.cpp; called once per query during replacement
+/// preprocessing, not per row.
+std::string unescapeReplacement(const std::string& replacement);
 
 /// This function preprocesses an input replacement string to follow RE2
 /// syntax for java.util.regex used by Presto and Spark. The required

--- a/velox/functions/lib/Re2Functions.h
+++ b/velox/functions/lib/Re2Functions.h
@@ -419,6 +419,15 @@ FOLLY_ALWAYS_INLINE std::string prepareRegexpReplacePattern(
 /// 3. Replacement in RE2 only supports '\' followed by a digit or another '\',
 /// while java.util.regex will ignore '\' in replacements, so we need to
 /// unescape it.
+///
+/// The unescape step in (3) is performed as a single left-to-right byte scan
+/// so that an escaped backslash '\\' is always consumed as one unit and the
+/// byte that follows it is preserved verbatim. This invariant is required by
+/// inputs such as '\\n' (a literal backslash followed by 'n'): the leading
+/// '\\' must be kept as-is, and the trailing 'n' must not be revisited as
+/// the target of another backslash-unescape, otherwise the replacement
+/// collapses to '\n' which RE2 then rejects, silently dropping the matched
+/// bytes from the input string.
 FOLLY_ALWAYS_INLINE std::string prepareRegexpReplaceReplacement(
     const RE2& re,
     const StringView& replacement) {
@@ -467,14 +476,40 @@ FOLLY_ALWAYS_INLINE std::string prepareRegexpReplaceReplacement(
       kConvertRegex.error());
   RE2::GlobalReplace(&newReplacement, kConvertRegex, R"(\\\1)");
 
-  // Un-escape character except digit or '\\'
-  static const RE2 kUnescapeRegex(R"(\\([^0-9\\]))");
-  VELOX_DCHECK(
-      kUnescapeRegex.ok(),
-      "Invalid regular expression {}: {}.",
-      R"(\\([^0-9\\]))",
-      kUnescapeRegex.error());
-  RE2::GlobalReplace(&newReplacement, kUnescapeRegex, R"(\1)");
+  // Un-escape character except digit or '\\'.
+  // We scan byte by byte so that an escaped backslash '\\' is always consumed
+  // as a single unit; the following byte is then preserved verbatim and is
+  // never mistaken for the start of another '\X' escape sequence. This avoids
+  // a regression where input like '\\n' (literal backslash + 'n') was being
+  // turned into '\n' by RE2::GlobalReplace, which subsequently failed in
+  // RE2::Rewrite and silently dropped matched bytes from the input string.
+  std::string unescaped;
+  unescaped.reserve(newReplacement.size());
+  for (size_t i = 0; i < newReplacement.size();) {
+    const char c = newReplacement[i];
+    if (c == '\\' && i + 1 < newReplacement.size()) {
+      const char next = newReplacement[i + 1];
+      if (next == '\\' || (next >= '0' && next <= '9')) {
+        // Preserve '\\' (literal backslash in RE2) and '\<digit>'
+        // (RE2 numbered backreference) as a two-byte unit.
+        unescaped.push_back(c);
+        unescaped.push_back(next);
+        i += 2;
+      } else {
+        // '\X' where X is neither a digit nor '\' -> emit literal X, matching
+        // java.util.regex semantics that silently ignores the backslash.
+        unescaped.push_back(next);
+        i += 2;
+      }
+    } else {
+      // Plain byte (or trailing lone '\\' which RE2::Rewrite will reject; we
+      // keep prior behavior of letting RE2 surface the error rather than
+      // silently dropping the byte here).
+      unescaped.push_back(c);
+      ++i;
+    }
+  }
+  newReplacement = std::move(unescaped);
 
   return newReplacement;
 }

--- a/velox/functions/sparksql/tests/RegexFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/RegexFunctionsTest.cpp
@@ -325,39 +325,52 @@ TEST_F(RegexFunctionsTest, regexpReplaceWithEmptyString) {
   EXPECT_EQ(result, output);
 }
 
-// Verifies that the SQL replacement '\\n' (three bytes: '\\', '\\', 'n')
-// produces the two-byte literal '\\n' (one backslash followed by 'n') when
-// the matched byte is LF (0x0A). Inputs include a multibyte UTF-8 character
-// to confirm that surrounding bytes do not affect the replacement.
-TEST_F(RegexFunctionsTest, regexpReplaceLiteralBackslashLetterReplacement) {
+// Verifies the handling of backslash escapes in regexp_replace's replacement
+// argument. Three families are covered in a single table:
+//   1. Two-byte literal '\\X' (e.g. '\\n', '\\b', '\\f', '\\r', '\\t') is
+//      preserved verbatim, so a matched control byte is rewritten to a
+//      literal backslash plus letter. Inputs include a multibyte UTF-8
+//      character to confirm surrounding bytes do not affect the result.
+//   2. Replacement of the form '\\X' where X is neither a digit nor '\\'
+//      drops the leading backslash and produces literal X, matching
+//      java.util.regex semantics (e.g. '\\{' -> '{', '\\$' -> '$').
+//
+// Patterns use the explicit hex form '\\x08' for backspace because RE2
+// interprets '\\b' in patterns as a word boundary anchor; the other letter
+// escapes ('\\f', '\\r', '\\t') match the corresponding control bytes
+// directly.
+TEST_F(RegexFunctionsTest, regexpReplaceBackslashEscapes) {
   auto result = testingRegexpReplaceRows(
-      {"A\nB", "A\nB\nC", "\xE5\x9B\xBD\nA"},
-      {"\\n", "\\n", "\\n"},
-      {"\\\\n", "\\\\n", "\\\\n"});
-  auto expected = convertOutput({"A\\nB", "A\\nB\\nC", "\xE5\x9B\xBD\\nA"}, 1);
-  assertEqualVectors(result, expected);
-}
-
-// Verifies that '\\' + letter replacements covering the control characters
-// that JSON escaping commonly substitutes -- '\\b' (0x08), '\\f' (0x0C),
-// '\\r' (0x0D), '\\t' (0x09) -- each produce the corresponding two-byte
-// literal '\\X' sequence.
-TEST_F(RegexFunctionsTest, regexpReplaceControlCharsReplacement) {
-  auto result = testingRegexpReplaceRows(
-      {"A\bB", "A\fB", "A\rB", "A\tB"},
-      {"\\x08", "\\x0c", "\\r", "\\t"},
-      {"\\\\b", "\\\\f", "\\\\r", "\\\\t"});
-  auto expected = convertOutput({"A\\bB", "A\\fB", "A\\rB", "A\\tB"}, 1);
-  assertEqualVectors(result, expected);
-}
-
-// Verifies that a replacement of the form '\\X', where X is neither a digit
-// nor another '\\', drops the leading backslash and produces a literal 'X',
-// matching java.util.regex semantics (e.g. '\\{' -> '{', '\\$' -> '$').
-TEST_F(RegexFunctionsTest, regexpReplaceUnescapesNonDigitNonBackslash) {
-  auto result = testingRegexpReplaceRows(
-      {"[{}]", "a$b"}, {"\\[\\{", "\\$"}, {"\\{", "#"});
-  auto expected = convertOutput({"{}]", "a#b"}, 1);
+      {"A\nB",
+       "A\nB\nC",
+       "\xE5\x9B\xBD\nA",
+       "A\bB",
+       "A\fB",
+       "A\rB",
+       "A\tB",
+       "[{}]",
+       "a$b"},
+      {"\\n", "\\n", "\\n", "\\x08", "\\f", "\\r", "\\t", "\\[\\{", "\\$"},
+      {"\\\\n",
+       "\\\\n",
+       "\\\\n",
+       "\\\\b",
+       "\\\\f",
+       "\\\\r",
+       "\\\\t",
+       "\\{",
+       "#"});
+  auto expected = convertOutput(
+      {"A\\nB",
+       "A\\nB\\nC",
+       "\xE5\x9B\xBD\\nA",
+       "A\\bB",
+       "A\\fB",
+       "A\\rB",
+       "A\\tB",
+       "{}]",
+       "a#b"},
+      1);
   assertEqualVectors(result, expected);
 }
 

--- a/velox/functions/sparksql/tests/RegexFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/RegexFunctionsTest.cpp
@@ -325,6 +325,61 @@ TEST_F(RegexFunctionsTest, regexpReplaceWithEmptyString) {
   EXPECT_EQ(result, output);
 }
 
+// 'regexp_replace' must replace LF (0x0A) with the two-byte literal
+// sequence '\' + 'n' when the user-supplied SQL replacement is the 3-byte
+// sequence '\', '\', 'n' (equivalent to Spark/Java `\\n`). Inputs that
+// contain multibyte UTF-8 characters are included to ensure the replacement
+// path treats the LF as a plain byte regardless of surrounding bytes.
+TEST_F(RegexFunctionsTest, regexpReplaceLiteralBackslashLetterReplacement) {
+  // Pattern column matches LF byte; replacement column is the 3-byte string
+  // '\\n' (a literal backslash followed by another backslash followed by 'n').
+  auto result = testingRegexpReplaceRows(
+      {std::string("A\nB"),
+       std::string("A\nB\nC"),
+       std::string("\xE5\x9B\xBD\nA")},
+      {std::string("\\n"), std::string("\\n"), std::string("\\n")},
+      {std::string("\\\\n"), std::string("\\\\n"), std::string("\\\\n")});
+  auto expected = convertOutput({"A\\nB", "A\\nB\\nC", "\xE5\x9B\xBD\\nA"}, 1);
+  assertEqualVectors(result, expected);
+}
+
+// The same '\\' + letter replacement form must work for the control
+// characters that JSON escaping commonly substitutes: '\b' (0x08),
+// '\f' (0x0C), '\r' (0x0D) and '\t' (0x09). Each match must be replaced by
+// the two-byte literal '\X' sequence rather than being dropped.
+TEST_F(RegexFunctionsTest, regexpReplaceControlCharsReplacement) {
+  auto result = testingRegexpReplaceRows(
+      {std::string("A\bB"),
+       std::string("A\fB"),
+       std::string("A\rB"),
+       std::string("A\tB")},
+      {std::string("\\x08"),
+       std::string("\\x0c"),
+       std::string("\\r"),
+       std::string("\\t")},
+      {std::string("\\\\b"),
+       std::string("\\\\f"),
+       std::string("\\\\r"),
+       std::string("\\\\t")});
+  auto expected = convertOutput({"A\\bB", "A\\fB", "A\\rB", "A\\tB"}, 1);
+  assertEqualVectors(result, expected);
+}
+
+// A replacement of the form '\X' where X is neither a digit nor another '\'
+// must drop the leading backslash and produce a literal 'X', matching
+// java.util.regex semantics. This covers cases such as '\{' -> '{' and
+// '\$' -> '$'.
+TEST_F(RegexFunctionsTest, regexpReplaceUnescapesNonDigitNonBackslash) {
+  // Replacement column is C++ literal "\\{" = 2 bytes (backslash + '{').
+  // Java regex semantics drop the leading backslash, leaving literal '{'.
+  auto result = testingRegexpReplaceRows(
+      {std::string("[{}]"), std::string("a$b")},
+      {std::string("\\[\\{"), std::string("\\$")},
+      {std::string("\\{"), std::string("#")});
+  auto expected = convertOutput({"{}]", "a#b"}, 1);
+  assertEqualVectors(result, expected);
+}
+
 TEST_F(RegexFunctionsTest, regexpReplacePosition) {
   std::string output1 = "abc";
   std::string output2 = "bc";

--- a/velox/functions/sparksql/tests/RegexFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/RegexFunctionsTest.cpp
@@ -325,57 +325,38 @@ TEST_F(RegexFunctionsTest, regexpReplaceWithEmptyString) {
   EXPECT_EQ(result, output);
 }
 
-// 'regexp_replace' must replace LF (0x0A) with the two-byte literal
-// sequence '\' + 'n' when the user-supplied SQL replacement is the 3-byte
-// sequence '\', '\', 'n' (equivalent to Spark/Java `\\n`). Inputs that
-// contain multibyte UTF-8 characters are included to ensure the replacement
-// path treats the LF as a plain byte regardless of surrounding bytes.
+// Verifies that the SQL replacement '\\n' (three bytes: '\\', '\\', 'n')
+// produces the two-byte literal '\\n' (one backslash followed by 'n') when
+// the matched byte is LF (0x0A). Inputs include a multibyte UTF-8 character
+// to confirm that surrounding bytes do not affect the replacement.
 TEST_F(RegexFunctionsTest, regexpReplaceLiteralBackslashLetterReplacement) {
-  // Pattern column matches LF byte; replacement column is the 3-byte string
-  // '\\n' (a literal backslash followed by another backslash followed by 'n').
   auto result = testingRegexpReplaceRows(
-      {std::string("A\nB"),
-       std::string("A\nB\nC"),
-       std::string("\xE5\x9B\xBD\nA")},
-      {std::string("\\n"), std::string("\\n"), std::string("\\n")},
-      {std::string("\\\\n"), std::string("\\\\n"), std::string("\\\\n")});
+      {"A\nB", "A\nB\nC", "\xE5\x9B\xBD\nA"},
+      {"\\n", "\\n", "\\n"},
+      {"\\\\n", "\\\\n", "\\\\n"});
   auto expected = convertOutput({"A\\nB", "A\\nB\\nC", "\xE5\x9B\xBD\\nA"}, 1);
   assertEqualVectors(result, expected);
 }
 
-// The same '\\' + letter replacement form must work for the control
-// characters that JSON escaping commonly substitutes: '\b' (0x08),
-// '\f' (0x0C), '\r' (0x0D) and '\t' (0x09). Each match must be replaced by
-// the two-byte literal '\X' sequence rather than being dropped.
+// Verifies that '\\' + letter replacements covering the control characters
+// that JSON escaping commonly substitutes -- '\\b' (0x08), '\\f' (0x0C),
+// '\\r' (0x0D), '\\t' (0x09) -- each produce the corresponding two-byte
+// literal '\\X' sequence.
 TEST_F(RegexFunctionsTest, regexpReplaceControlCharsReplacement) {
   auto result = testingRegexpReplaceRows(
-      {std::string("A\bB"),
-       std::string("A\fB"),
-       std::string("A\rB"),
-       std::string("A\tB")},
-      {std::string("\\x08"),
-       std::string("\\x0c"),
-       std::string("\\r"),
-       std::string("\\t")},
-      {std::string("\\\\b"),
-       std::string("\\\\f"),
-       std::string("\\\\r"),
-       std::string("\\\\t")});
+      {"A\bB", "A\fB", "A\rB", "A\tB"},
+      {"\\x08", "\\x0c", "\\r", "\\t"},
+      {"\\\\b", "\\\\f", "\\\\r", "\\\\t"});
   auto expected = convertOutput({"A\\bB", "A\\fB", "A\\rB", "A\\tB"}, 1);
   assertEqualVectors(result, expected);
 }
 
-// A replacement of the form '\X' where X is neither a digit nor another '\'
-// must drop the leading backslash and produce a literal 'X', matching
-// java.util.regex semantics. This covers cases such as '\{' -> '{' and
-// '\$' -> '$'.
+// Verifies that a replacement of the form '\\X', where X is neither a digit
+// nor another '\\', drops the leading backslash and produces a literal 'X',
+// matching java.util.regex semantics (e.g. '\\{' -> '{', '\\$' -> '$').
 TEST_F(RegexFunctionsTest, regexpReplaceUnescapesNonDigitNonBackslash) {
-  // Replacement column is C++ literal "\\{" = 2 bytes (backslash + '{').
-  // Java regex semantics drop the leading backslash, leaving literal '{'.
   auto result = testingRegexpReplaceRows(
-      {std::string("[{}]"), std::string("a$b")},
-      {std::string("\\[\\{"), std::string("\\$")},
-      {std::string("\\{"), std::string("#")});
+      {"[{}]", "a$b"}, {"\\[\\{", "\\$"}, {"\\{", "#"});
   auto expected = convertOutput({"{}]", "a#b"}, 1);
   assertEqualVectors(result, expected);
 }


### PR DESCRIPTION
  **Summary**
  
  Fixes a silent data-correctness regression in regexp_replace (Spark variant) where matched bytes are dropped instead of being replaced when the user-supplied replacement is a Spark/Java-style \\X literal (e.g. \\n, \\b, \\t, \\r, \\f).

Fixes: https://github.com/facebookincubator/velox/issues/17577

  **Root cause**

  Introduced by #10981 (https://github.com/facebookincubator/velox/pull/10981). The Spark replacement preprocessing in `prepareRegexpReplaceReplacement` runs:

```
  static const RE2 kUnescapeRegex(R"(\\([^0-9\\]))");
  RE2::GlobalReplace(&newReplacement, kUnescapeRegex, R"(\1)");
```

  `RE2::GlobalReplace` does a leftmost search and does not honor the higher-priority \\ escape unit when scanning — given the 3-byte input `\\n`, the engine first tries a match at offset 0 (`\` followed by `\`, rejected because of `[^0-9\\]`), then at offset 1 (`\` followed by `n`, matches) and rewrites the trailing two bytes to `n`. The leading `\` survives, so the full replacement string becomes the 2-byte sequence `\n`.
  
  That 2-byte string is then handed to RE2::Rewrite. RE2 only accepts \<digit> (backreference) or \\ (literal backslash) in rewrite strings. `\n` falls into the third branch in re2.cc:

```
  } else {
    if (options_.log_errors())
      LOG(ERROR) << "invalid rewrite pattern: " << rewrite.data();
    return false;
  }
```

  Rewrite returns false without pushing any bytes, and RE2::GlobalReplace ignores that return value (re2.cc:484), so each match is rewritten to the empty string. Net effect: every LF byte matched by the regex is silently deleted.

  The same defect applies to \\b, \\f, \\r, \\t, and any other \\<non-digit-non-backslash> replacement. It does not surface in fully-constant minimal repros because Spark Catalyst's `ConstantFolding` evaluates the call in the JVM and never reaches Velox; column-input plans (regexp_replace(<column>, '\\n', '\\\\n')) are required to trigger it. In production the bug corrupted 100% of rows in a 266k-row JSON-escaping query against an Iceberg column containing CJK characters interleaved with LF bytes.
  
  **Minimal repro**

We can running the following SQL to reproduce the bug.
`SELECT hex(regexp_replace(c0, '\\n', '\\\\n')) FROM (VALUES (unhex('410A41'))) t(c0);`
 The output of Spark (correct):  "A\nA"  (4 bytes: 41 5C 6E 41)
 The output of Velox (buggy):    "AA"    (2 bytes: 41 41 — LF deleted)


  (The repro must use a column input; replacing c0 with unhex('410A41') directly hides the bug because it gets constant-folded.)