### PR TITLE
build: Upgrade CUDA to 13.2

### DIFF
--- a/.github/workflows/breeze.yml
+++ b/.github/workflows/breeze.yml
@@ -88,7 +88,7 @@ jobs:
     if: ${{ github.repository == 'facebookincubator/velox' }}
     name: Ubuntu GPU debug
     env:
-      CUDA_VERSION: '12.9'
+      CUDA_VERSION: '13.2'
     defaults:
       run:
         shell: bash

--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -150,7 +150,7 @@ jobs:
         id: build
         env:
           MAKEFLAGS: NUM_THREADS=32 MAX_HIGH_MEM_JOBS=12 MAX_LINK_JOBS=12
-          CUDA_ARCHITECTURES: 70
+          CUDA_ARCHITECTURES: 75
           CUDA_COMPILER: /usr/local/cuda-${CUDA_VERSION}/bin/nvcc
           # Set compiler to GCC 14
           CUDA_FLAGS: -ccbin /opt/rh/gcc-toolset-14/root/usr/bin

--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -90,7 +90,7 @@ jobs:
       CCACHE_DIR: ${{ github.workspace }}/ccache
       VELOX_DEPENDENCY_SOURCE: SYSTEM
       cudf_SOURCE: BUNDLED
-      CUDA_VERSION: '12.9'
+      CUDA_VERSION: '13.2'
       faiss_SOURCE: BUNDLED
       USE_CLANG: "${{ inputs.use-clang && 'true' || 'false' }}"
     outputs:
@@ -384,7 +384,7 @@ jobs:
     steps:
       - name: Install Packages
         run: |
-          sudo apt-get update && sudo apt-get install -y cmake patchelf cuda-toolkit-12-9
+          sudo apt-get update && sudo apt-get install -y cmake patchelf cuda-toolkit-13-2
           export MINIO_VERSION="2022-05-26T05-48-41Z"
           export MINIO_BINARY_NAME="minio-2022-05-26"
           wget https://dl.min.io/server/minio/release/linux-amd64/archive/minio.RELEASE."${MINIO_VERSION}" -O "${MINIO_BINARY_NAME}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -491,10 +491,10 @@ if(VELOX_ENABLE_WAVE OR VELOX_ENABLE_CUDF)
   endif()
   if(VELOX_ENABLE_CUDF)
     foreach(arch ${CMAKE_CUDA_ARCHITECTURES})
-      if(arch LESS 70)
+      if(arch LESS 75)
         message(
           FATAL_ERROR
-          "CUDA architecture ${arch} is below 70. CUDF requires Volta (SM 70) or newer GPUs."
+          "CUDA architecture ${arch} is below 75. CUDF requires Turing (SM 75) or newer GPUs."
         )
       endif()
     endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -491,10 +491,15 @@ if(VELOX_ENABLE_WAVE OR VELOX_ENABLE_CUDF)
   endif()
   if(VELOX_ENABLE_CUDF)
     foreach(arch ${CMAKE_CUDA_ARCHITECTURES})
-      if(arch LESS 75)
+      if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 13.0.0 AND arch LESS 70)
         message(
           FATAL_ERROR
-          "CUDA architecture ${arch} is below 75. CUDF requires Turing (SM 75) or newer GPUs."
+          "CUDA architecture ${arch} is below 70. CUDF requires Volta (SM 70) or newer GPUs."
+        )
+      elseif(arch LESS 75)
+        message(
+          FATAL_ERROR
+          "CUDA architecture ${arch} is below 75. CUDA 13 requires Turing (SM 75) or newer GPUs."
         )
       endif()
     endforeach()

--- a/scripts/docker/centos-multi.dockerfile
+++ b/scripts/docker/centos-multi.dockerfile
@@ -169,7 +169,7 @@ FROM centos9 AS adapters
 COPY scripts/setup-centos-adapters.sh /
 
 ARG CUDA_VERSION
-ENV CUDA_VERSION=${CUDA_VERSION:-12.9}
+ENV CUDA_VERSION=${CUDA_VERSION:-13.2}
 
 RUN bash /setup-centos-adapters.sh install_cuda && \
       dnf clean all

--- a/scripts/setup-centos-adapters.sh
+++ b/scripts/setup-centos-adapters.sh
@@ -23,14 +23,14 @@
 # * INSTALL_PREREQUISITES="N": Skip installation of packages for build.
 # * PROMPT_ALWAYS_RESPOND="n": Automatically respond to interactive prompts.
 #     Use "n" to never wipe directories.
-# * VELOX_CUDA_VERSION="12.9": Which version of CUDA to install, will pick up
+# * VELOX_CUDA_VERSION="13.2": Which version of CUDA to install, will pick up
 #   CUDA_VERSION from the env
 # * VELOX_UCX_VERSION="1.19.0": Which version of ucx to install, will pick up
 #   UCX_VERSION from the env
 
 set -efx -o pipefail
 
-VELOX_CUDA_VERSION=${CUDA_VERSION:-"12.9"}
+VELOX_CUDA_VERSION=${CUDA_VERSION:-"13.2"}
 VELOX_UCX_VERSION=${UCX_VERSION:-"1.19.0"}
 SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 source "$SCRIPT_DIR"/setup-centos9.sh

--- a/velox/experimental/wave/common/Cuda.cu
+++ b/velox/experimental/wave/common/Cuda.cu
@@ -231,8 +231,17 @@ void Stream::wait() {
 }
 
 void Stream::prefetch(Device* device, void* ptr, size_t size) {
-  CUDA_CHECK(cudaMemPrefetchAsync(
-      ptr, size, device ? device->deviceId : cudaCpuDeviceId, stream_->stream));
+  const auto deviceId = device ? device->deviceId : cudaCpuDeviceId;
+#if defined(CUDART_VERSION) && CUDART_VERSION >= 13000
+  cudaMemLocation location{
+      deviceId == cudaCpuDeviceId ? cudaMemLocationTypeHost
+                                  : cudaMemLocationTypeDevice,
+      deviceId};
+  constexpr int flags = 0;
+  CUDA_CHECK(cudaMemPrefetchAsync(ptr, size, location, flags, stream_->stream));
+#else
+  CUDA_CHECK(cudaMemPrefetchAsync(ptr, size, deviceId, stream_->stream));
+#endif
 }
 
 void Stream::memset(void* ptr, int32_t value, size_t size) {


### PR DESCRIPTION
Upgrade CUDA build defaults to 13.2.

xref: https://github.com/prestodb/presto/pull/27853

The minimum CUDA architecture is changed from 70 to 75, corresponding to the minimum support in CUDA 13.

Image builds can override the default by passing a different `CUDA_VERSION` as a build argument.