### PR TITLE
fix(build): Add folly header dependency to velox_future

### DIFF
--- a/velox/common/future/CMakeLists.txt
+++ b/velox/common/future/CMakeLists.txt
@@ -13,4 +13,6 @@
 # limitations under the License.
 velox_add_library(velox_future INTERFACE HEADERS VeloxPromise.h)
 
+velox_link_libraries(velox_future INTERFACE Folly::folly)
+
 velox_install_library_headers()


### PR DESCRIPTION
The velox_future interface library includes folly headers but doesn’t declare this dependency. This can lead to missing headers such as event.h that may not be found in the system include path on platforms such as macOS where libevent is installed in homebrew.

Addresses: https://github.com/prestodb/presto/issues/27856