### PR TITLE
fix: Signal `noMoreData` before cancelling task in `ExchangeClientTest.lazyFetching`

### DIFF
--- a/velox/exec/tests/ExchangeClientTest.cpp
+++ b/velox/exec/tests/ExchangeClientTest.cpp
@@ -1108,6 +1108,7 @@ TEST_P(ExchangeClientTest, lazyFetching) {
     auto pages = fetchPages(1, *client, 1);
     ASSERT_EQ(1, pages.size());
 
+    bufferManager_->noMoreData(taskId);
     task->requestCancel();
     bufferManager_->removeTask(taskId);
     task.reset();
@@ -1143,6 +1144,7 @@ TEST_P(ExchangeClientTest, lazyFetching) {
     auto pages = fetchPages(1, *client, 1);
     ASSERT_EQ(1, pages.size());
 
+    bufferManager_->noMoreData(taskId);
     task->requestCancel();
     bufferManager_->removeTask(taskId);
     task.reset();


### PR DESCRIPTION
Summary: The `lazyFetching` test intermittently times out because `requestCancel()` is called without first signaling `noMoreData()` on the buffer manager. This creates a race where the exchange client may block indefinitely waiting for data that will never arrive. Call `bufferManager_->noMoreData(taskId)` before `requestCancel()` in both the lazy and non-lazy test blocks to ensure the client can drain cleanly.

Differential Revision: D106030902


