### PR TITLE
refactor: Introduce PrestoQueryConfig with array_agg key (#17591)

### DIFF
--- a/velox/core/QueryConfig.cpp
+++ b/velox/core/QueryConfig.cpp
@@ -142,9 +142,6 @@ const std::vector<config::ConfigProperty>& QueryConfig::registeredProperties() {
     // Writer.
     VELOX_REGISTER_QUERY_CONFIG(kWriterFlushThresholdBytes);
 
-    // Presto-specific.
-    VELOX_REGISTER_QUERY_CONFIG(kPrestoArrayAggIgnoreNulls);
-
     // Task writer.
     VELOX_REGISTER_QUERY_CONFIG(kTaskWriterCount);
 

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -838,14 +838,17 @@ class QueryConfig {
       96L << 20,
       "Minimum memory footprint to reclaim from a file writer by flushing.")
 
-  /// If true, array_agg() aggregation function will ignore nulls in the input.
-  VELOX_QUERY_CONFIG(
-      kPrestoArrayAggIgnoreNulls,
-      prestoArrayAggIgnoreNulls,
-      "presto.array_agg.ignore_nulls",
-      bool,
-      false,
-      "If true, array_agg() ignores nulls in the input.")
+  /// Back-compat shim for out-of-tree callers; use PrestoQueryConfig instead.
+  [[deprecated("Use PrestoQueryConfig::kArrayAggIgnoreNulls.")]]
+  static constexpr const char* kPrestoArrayAggIgnoreNulls =
+      "presto.array_agg.ignore_nulls";
+
+  [[deprecated("Use PrestoQueryConfig{config}.arrayAggIgnoreNulls().")]]
+  bool prestoArrayAggIgnoreNulls() const {
+    // Storage key is hardcoded (rather than referencing the deprecated
+    // constant above) so the shim does not self-trigger the warning.
+    return get<bool>("presto.array_agg.ignore_nulls", /*defaultValue=*/false);
+  }
 
   /// The number of local parallel table writer operators per task.
   VELOX_QUERY_CONFIG(

--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -11,6 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+velox_add_library(
+  velox_presto_query_config
+  OBJECT
+  PrestoConfigProvider.cpp
+  PrestoQueryConfig.cpp
+  HEADERS
+  PrestoConfigProvider.h
+  PrestoQueryConfig.h
+)
+velox_link_libraries(velox_presto_query_config velox_config_property velox_core)
+
 add_subdirectory(coercion)
 add_subdirectory(json)
 add_subdirectory(types)
@@ -141,6 +152,7 @@ velox_link_libraries(
   velox_functions_lib
   velox_expression
   velox_external_md5
+  velox_presto_query_config
   velox_type_tz
   velox_presto_types
   velox_functions_util

--- a/velox/functions/prestosql/PrestoConfigProvider.cpp
+++ b/velox/functions/prestosql/PrestoConfigProvider.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/prestosql/PrestoConfigProvider.h"
+
+#include "velox/functions/prestosql/PrestoQueryConfig.h"
+
+namespace facebook::velox::functions::prestosql {
+
+std::vector<config::ConfigProperty> PrestoConfigProvider::properties() const {
+  return PrestoQueryConfig::registeredProperties();
+}
+
+std::string PrestoConfigProvider::normalize(
+    std::string_view /*name*/,
+    std::string_view value) const {
+  return std::string{value};
+}
+
+} // namespace facebook::velox::functions::prestosql

--- a/velox/functions/prestosql/PrestoConfigProvider.h
+++ b/velox/functions/prestosql/PrestoConfigProvider.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/common/config/ConfigProvider.h"
+
+namespace facebook::velox::functions::prestosql {
+
+/// Exposes Presto function-package session-overridable properties.
+class PrestoConfigProvider : public config::ConfigProvider {
+ public:
+  /// Returns all session-overridable Presto function properties.
+  std::vector<config::ConfigProperty> properties() const override;
+
+  /// Validates and normalizes a property value.
+  std::string normalize(std::string_view name, std::string_view value)
+      const override;
+};
+
+} // namespace facebook::velox::functions::prestosql

--- a/velox/functions/prestosql/PrestoQueryConfig.cpp
+++ b/velox/functions/prestosql/PrestoQueryConfig.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/prestosql/PrestoQueryConfig.h"
+
+namespace facebook::velox::functions::prestosql {
+
+const std::vector<config::ConfigProperty>&
+PrestoQueryConfig::registeredProperties() {
+  static const std::vector<config::ConfigProperty> kProperties = [] {
+    std::vector<config::ConfigProperty> properties;
+#define VELOX_REGISTER_PRESTO_CONFIG(constName)                           \
+  config::registerConfigProperty<PrestoQueryConfig::constName##Property>( \
+      properties)
+
+    VELOX_REGISTER_PRESTO_CONFIG(kArrayAggIgnoreNulls);
+
+#undef VELOX_REGISTER_PRESTO_CONFIG
+
+    return properties;
+  }();
+  return kProperties;
+}
+
+} // namespace facebook::velox::functions::prestosql

--- a/velox/functions/prestosql/PrestoQueryConfig.h
+++ b/velox/functions/prestosql/PrestoQueryConfig.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/common/config/ConfigProperty.h"
+#include "velox/core/QueryConfig.h"
+
+namespace facebook::velox::functions::prestosql {
+
+// Defines a traits struct (constName##Property), a key constant, and a typed
+// accessor that reads the qualified key (kPrefix + key) from the wrapped
+// QueryConfig. Mirrors SparkQueryConfig's macro pattern.
+#define VELOX_PRESTO_CONFIG(                                     \
+    constName, accessorName, keyStr, CppType, defaultVal, desc)  \
+  struct constName##Property {                                   \
+    using type = CppType;                                        \
+    static constexpr const char* key = keyStr;                   \
+    static constexpr auto defaultValue = defaultVal;             \
+    static constexpr const char* description = desc;             \
+  };                                                             \
+  static constexpr const char* constName = keyStr;               \
+  CppType accessorName() const {                                 \
+    return config_.get<CppType>(qualify(constName), defaultVal); \
+  }
+
+/// Typed view over Presto-specific session properties stored in the shared
+/// QueryConfig. Construct on demand: PrestoQueryConfig{queryConfig}.
+/// Holds a reference to the QueryConfig and must not outlive it.
+///
+/// Property names are declared unqualified (e.g., "array_agg.ignore_nulls").
+/// The shared QueryConfig storage namespace is disambiguated by kPrefix.
+/// Read accessors prepend kPrefix when looking up values; writers populating
+/// the QueryConfig map must do the same via qualify().
+class PrestoQueryConfig {
+ public:
+  explicit PrestoQueryConfig(const core::QueryConfig& config)
+      : config_{config} {}
+
+  /// Storage-key prefix applied to all Presto properties in the shared
+  /// QueryConfig map. Does not include the trailing dot; qualify() inserts
+  /// the dot when building the qualified key.
+  ///
+  /// Hardcoded for the same reason as SparkQueryConfig::kPrefix: simple
+  /// functions receive only const QueryConfig& in initialize() and have no
+  /// channel for per-package config, so the process can host only one Presto
+  /// mount and that mount must use this prefix.
+  static constexpr std::string_view kPrefix = "presto";
+
+  /// Returns the qualified storage key for the given unqualified property
+  /// name. Use when populating a QueryConfig map with Presto properties.
+  static std::string qualify(std::string_view name) {
+    return std::string{kPrefix} + "." + std::string{name};
+  }
+
+  /// If true, array_agg() aggregation function ignores nulls in the input.
+  VELOX_PRESTO_CONFIG(
+      kArrayAggIgnoreNulls,
+      arrayAggIgnoreNulls,
+      "array_agg.ignore_nulls",
+      bool,
+      false,
+      "If true, array_agg() ignores nulls in the input.")
+
+  /// Returns all registered Presto config properties. Property names are
+  /// unqualified (no "presto." prefix).
+  static const std::vector<config::ConfigProperty>& registeredProperties();
+
+ private:
+  const core::QueryConfig& config_;
+};
+
+#undef VELOX_PRESTO_CONFIG
+
+} // namespace facebook::velox::functions::prestosql

--- a/velox/functions/prestosql/aggregates/ArrayAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArrayAggAggregate.cpp
@@ -18,8 +18,12 @@
 #include "velox/exec/ContainerRowSerde.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/functions/lib/aggregates/ValueList.h"
+#include "velox/functions/prestosql/PrestoQueryConfig.h"
 
 namespace facebook::velox::aggregate::prestosql {
+
+using functions::prestosql::PrestoQueryConfig;
+
 namespace {
 
 struct ArrayAccumulator {
@@ -455,7 +459,7 @@ void registerArrayAggAggregate(
         VELOX_CHECK_EQ(
             argTypes.size(), 1, "{} takes at most one argument", names.front());
         return std::make_unique<ArrayAggAggregate>(
-            resultType, config.prestoArrayAggIgnoreNulls());
+            resultType, PrestoQueryConfig{config}.arrayAggIgnoreNulls());
       },
       withCompanionFunctions,
       overwrite);

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -111,6 +111,7 @@ add_executable(
   MultimapFromEntriesTest.cpp
   NotTest.cpp
   ParsePrestoDataSizeTest.cpp
+  PrestoQueryConfigTest.cpp
   ProbabilityTest.cpp
   RandTest.cpp
   ReduceTest.cpp

--- a/velox/functions/prestosql/tests/PrestoQueryConfigTest.cpp
+++ b/velox/functions/prestosql/tests/PrestoQueryConfigTest.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/prestosql/PrestoQueryConfig.h"
+
+#include <gtest/gtest.h>
+
+namespace facebook::velox::functions::prestosql::test {
+namespace {
+
+// Verifies the write/read loop: values set via qualify(key) in the underlying
+// QueryConfig map are returned by the corresponding typed accessor.
+TEST(PrestoQueryConfigTest, roundTrip) {
+  {
+    core::QueryConfig queryConfig({
+        {PrestoQueryConfig::qualify(PrestoQueryConfig::kArrayAggIgnoreNulls),
+         "true"},
+    });
+    EXPECT_TRUE(PrestoQueryConfig{queryConfig}.arrayAggIgnoreNulls());
+  }
+
+  {
+    core::QueryConfig queryConfig({
+        {PrestoQueryConfig::qualify(PrestoQueryConfig::kArrayAggIgnoreNulls),
+         "false"},
+    });
+    EXPECT_FALSE(PrestoQueryConfig{queryConfig}.arrayAggIgnoreNulls());
+  }
+}
+
+} // namespace
+} // namespace facebook::velox::functions::prestosql::test


### PR DESCRIPTION
Summary:

Introduces `PrestoQueryConfig` and `PrestoConfigProvider` under `velox/functions/prestosql/`, mirroring `SparkQueryConfig`. Migrates the first Presto-specific property — `presto.array_agg.ignore_nulls` — out of `core::QueryConfig` into the new class. The session property name is unchanged. The only in-Velox call site (`functions/prestosql/aggregates/ArrayAggAggregate.cpp`) now reads it via `PrestoQueryConfig{config}.arrayAggIgnoreNulls()`.

`PrestoQueryConfig` is a thin view that wraps a `const QueryConfig&`. Storage stays in the shared `QueryConfig` `IConfig` map. Simple functions receive only `const QueryConfig&` in `initialize()` and have no other channel for per-package config. Read accessors prepend `kPrefix` ("presto.") via `qualify()` when looking up values. Writers populating a `QueryConfig` map call `qualify()` the same way.

`QueryConfig` keeps `kPrestoArrayAggIgnoreNulls` and `prestoArrayAggIgnoreNulls()` as `[[deprecated]]` shims that hardcode the storage key. Out-of-tree callers (the mirrored Presto coordinator, Axiom, Axel) continue to compile while they migrate. The shims will be removed once external callers have switched.

Differential Revision: D106052190


