### PR TITLE
fix(window): Use batch index for NaN frame bounds

### DIFF
--- a/velox/exec/WindowPartition.cpp
+++ b/velox/exec/WindowPartition.cpp
@@ -381,7 +381,7 @@ void WindowPartition::updateKRangeFrameBounds(
     if constexpr (std::is_floating_point_v<T>) {
       if (data_->isNanAt<T>(partitionRow, mappedFrameRowColumn) &&
           !data_->isNanAt<T>(partitionRow, orderByRowColumn)) {
-        validFrames.setValid(currentRow, false);
+        validFrames.setValid(i, false);
         continue;
       }
     }

--- a/velox/exec/tests/WindowTest.cpp
+++ b/velox/exec/tests/WindowTest.cpp
@@ -983,6 +983,32 @@ TEST_F(WindowTest, NaNFrameBound) {
   }
 }
 
+TEST_F(WindowTest, nanFrameBoundAcrossOutputBatches) {
+  const auto kNan = std::numeric_limits<double>::quiet_NaN();
+  auto data = makeRowVector(
+      {"value", "sort_key", "frame_offset"},
+      {
+          makeFlatVector<int64_t>({1, 2, 3, 4}),
+          makeFlatVector<double>({1.0, 2.0, 3.0, 4.0}),
+          makeFlatVector<double>({0.0, 0.0, kNan, 0.0}),
+      });
+
+  auto plan =
+      PlanBuilder()
+          .values({data})
+          .window(
+              {"sum(value) over (order by sort_key range between frame_offset preceding and current row)"})
+          .project({"w0"})
+          .planNode();
+
+  auto expected = makeRowVector(
+      {makeNullableFlatVector<int64_t>({1, 3, std::nullopt, 10})});
+  AssertQueryBuilder(plan)
+      .config(core::QueryConfig::kPreferredOutputBatchRows, "2")
+      .config(core::QueryConfig::kMaxOutputBatchRows, "2")
+      .assertResults(expected);
+}
+
 DEBUG_ONLY_TEST_F(WindowTest, releaseWindowBuildInTime) {
   const vector_size_t size = 1'000;
   auto data = makeRowVector(


### PR DESCRIPTION
Window RANGE frame evaluation marks rows invalid when a frame bound is NaN and the ORDER BY value is not. For output batches after the first one, this used the partition-absolute row number to update a batch-sized SelectivityVector, so the current batch row stayed selected.

Use the batch-local row index when clearing validFrames. WindowTest covers NaN frame bounds across output batches.