### PR TITLE
fix: Guard overflow access on LongDecimalType::kMaxPrecision

### DIFF
--- a/velox/type/DecimalUtil.h
+++ b/velox/type/DecimalUtil.h
@@ -169,12 +169,14 @@ class DecimalUtil {
     auto scaleDifference = toScale - fromScale;
     bool isOverflow = false;
     if (scaleDifference >= 0) {
+      VELOX_DCHECK_LT(scaleDifference, std::size(DecimalUtil::kPowersOfTen));
       isOverflow = __builtin_mul_overflow(
           rescaledValue,
           DecimalUtil::kPowersOfTen[scaleDifference],
           &rescaledValue);
     } else {
       scaleDifference = -scaleDifference;
+      VELOX_DCHECK_LT(scaleDifference, std::size(DecimalUtil::kPowersOfTen));
       const auto scalingFactor = DecimalUtil::kPowersOfTen[scaleDifference];
       rescaledValue /= scalingFactor;
       int128_t remainder = inputValue % scalingFactor;
@@ -583,6 +585,9 @@ class DecimalUtil {
     int128_t out = 0;
     VELOX_RETURN_NOT_OK(parseStringToDecimalComponents(
         s, toScale, parsedPrecision, parsedScale, out));
+    if (parsedScale - toScale > LongDecimalType::kMaxPrecision) {
+      return Status::UserError("Decimal scale difference is too large.");
+    }
 
     const auto status = rescaleWithRoundUp<int128_t, T>(
         out,

--- a/velox/type/DecimalUtil.h
+++ b/velox/type/DecimalUtil.h
@@ -585,9 +585,12 @@ class DecimalUtil {
     int128_t out = 0;
     VELOX_RETURN_NOT_OK(parseStringToDecimalComponents(
         s, toScale, parsedPrecision, parsedScale, out));
-    if (parsedScale - toScale > LongDecimalType::kMaxPrecision) {
-      return Status::UserError("Decimal scale difference is too large.");
-    }
+    VELOX_RETURN_IF(
+        parsedScale - toScale > LongDecimalType::kMaxPrecision,
+        Status::UserError(
+            "Decimal scale difference is too large: {} vs max {}.",
+            parsedScale - toScale,
+            LongDecimalType::kMaxPrecision));
 
     const auto status = rescaleWithRoundUp<int128_t, T>(
         out,

--- a/velox/type/DecimalUtil.h
+++ b/velox/type/DecimalUtil.h
@@ -169,14 +169,24 @@ class DecimalUtil {
     auto scaleDifference = toScale - fromScale;
     bool isOverflow = false;
     if (scaleDifference >= 0) {
-      VELOX_DCHECK_LT(scaleDifference, std::size(DecimalUtil::kPowersOfTen));
+      VELOX_RETURN_IF(
+          scaleDifference > LongDecimalType::kMaxPrecision,
+          Status::UserError(
+              "Decimal scale difference is too large: {} vs max {}.",
+              scaleDifference,
+              LongDecimalType::kMaxPrecision));
       isOverflow = __builtin_mul_overflow(
           rescaledValue,
           DecimalUtil::kPowersOfTen[scaleDifference],
           &rescaledValue);
     } else {
       scaleDifference = -scaleDifference;
-      VELOX_DCHECK_LT(scaleDifference, std::size(DecimalUtil::kPowersOfTen));
+      VELOX_RETURN_IF(
+          scaleDifference > LongDecimalType::kMaxPrecision,
+          Status::UserError(
+              "Decimal scale difference is too large: {} vs max {}.",
+              scaleDifference,
+              LongDecimalType::kMaxPrecision));
       const auto scalingFactor = DecimalUtil::kPowersOfTen[scaleDifference];
       rescaledValue /= scalingFactor;
       int128_t remainder = inputValue % scalingFactor;
@@ -585,12 +595,6 @@ class DecimalUtil {
     int128_t out = 0;
     VELOX_RETURN_NOT_OK(parseStringToDecimalComponents(
         s, toScale, parsedPrecision, parsedScale, out));
-    VELOX_RETURN_IF(
-        parsedScale - toScale > LongDecimalType::kMaxPrecision,
-        Status::UserError(
-            "Decimal scale difference is too large: {} vs max {}.",
-            parsedScale - toScale,
-            LongDecimalType::kMaxPrecision));
 
     const auto status = rescaleWithRoundUp<int128_t, T>(
         out,

--- a/velox/type/tests/DecimalTest.cpp
+++ b/velox/type/tests/DecimalTest.cpp
@@ -794,7 +794,7 @@ TEST(DecimalTest, castFromStringError) {
   testCastFromString<int64_t>(
       "9e", 12, 2, "Value is not a number. The exponent part is empty.");
   testCastFromString<int64_t>(
-  "09{xi+yD", 12, 2, "Value is not a number. Chars are invalid.");
+      "09{xi+yD", 12, 2, "Value is not a number. Chars are invalid.");
 
   // Large negative exponent string.
   testCastFromString<int128_t>(

--- a/velox/type/tests/DecimalTest.cpp
+++ b/velox/type/tests/DecimalTest.cpp
@@ -794,7 +794,11 @@ TEST(DecimalTest, castFromStringError) {
   testCastFromString<int64_t>(
       "9e", 12, 2, "Value is not a number. The exponent part is empty.");
   testCastFromString<int64_t>(
-      "09{xi+yD", 12, 2, "Value is not a number. Chars are invalid.");
+  "09{xi+yD", 12, 2, "Value is not a number. Chars are invalid.");
+
+  // Large negative exponent string.
+  testCastFromString<int128_t>(
+      "6E-120", 38, 0, "Decimal scale difference is too large.");
 }
 } // namespace
 } // namespace facebook::velox

--- a/velox/type/tests/DecimalTest.cpp
+++ b/velox/type/tests/DecimalTest.cpp
@@ -797,8 +797,7 @@ TEST(DecimalTest, castFromStringError) {
       "09{xi+yD", 12, 2, "Value is not a number. Chars are invalid.");
 
   // Large negative exponent string.
-  testCastFromString<int128_t>(
-      "6E-120", 38, 0, "Decimal scale difference is too large: 120 vs max 38.");
+  testCastFromString<int128_t>("6E-120", 38, 0, "Value too large.");
 }
 } // namespace
 } // namespace facebook::velox

--- a/velox/type/tests/DecimalTest.cpp
+++ b/velox/type/tests/DecimalTest.cpp
@@ -798,7 +798,7 @@ TEST(DecimalTest, castFromStringError) {
 
   // Large negative exponent string.
   testCastFromString<int128_t>(
-      "6E-120", 38, 0, "Decimal scale difference is too large.");
+      "6E-120", 38, 0, "Decimal scale difference is too large: 120 vs max 38.");
 }
 } // namespace
 } // namespace facebook::velox


### PR DESCRIPTION
The patch adds essential guards in code to protect against overflow access on `LongDecimalType::kMaxPrecision` when casting a large negative-exponent string to decimal, like `CAST('6E-120' AS DECIMAL(38, 0))`. Otherwise UB will be led.

This is the step 1 for fixing https://github.com/facebookincubator/velox/issues/17593