### PR TITLE
docs(review): Expand self-review checklist

### DIFF
--- a/scripts/review/REVIEW_GUIDE.md
+++ b/scripts/review/REVIEW_GUIDE.md
@@ -72,6 +72,21 @@ Then list the remaining issues. Don't re-explain items that were already
 explained with code snippets in the previous round — just say "not fixed"
 and refer back.
 
+### Refactoring PRs
+
+Refactoring PRs require extra scrutiny beyond "does the code compile and
+tests pass":
+
+- **Re-read the PR description as a cold reader.** If you can't explain
+  the before/after component responsibilities from the description alone,
+  send it back.
+- **Read new files end-to-end.** Verify that class names match file names,
+  APIs are minimal (no private methods promoted to public), and
+  abstractions are clean. Don't trust "I renamed X and extracted Y" —
+  verify the result is well-designed, not just mechanically reorganized.
+- **Check that the refactoring is pure.** No behavioral changes, no new
+  tests (unless closing a pre-existing coverage gap in a separate PR).
+
 ## What to check
 
 ### Correctness

--- a/scripts/review/SELF_REVIEW.md
+++ b/scripts/review/SELF_REVIEW.md
@@ -17,6 +17,17 @@ before review saves everyone time.
 - [ ] PR description matches what the code actually does. If the scope grew
       beyond the original description, update it. Do not include test
       results or pass/fail status — CI reports that.
+- [ ] For refactoring PRs, the description explains the before/after
+      component responsibilities — what existed before, what exists after,
+      and how they assemble. A diff that "extracts X" without explaining
+      the resulting design is not ready for review.
+- [ ] Bug fixes are not mixed with refactoring. If you find a bug while
+      refactoring, fix it in a separate PR.
+- [ ] When fixing a regression, CC the original author and reviewers of
+      the PR that introduced it.
+- [ ] When fixing a bug caused by a pattern (e.g., using regex to parse
+      escapes), audit other usages of the same pattern and note in the PR
+      whether they are safe.
 
 ## Naming
 
@@ -38,6 +49,17 @@ before review saves everyone time.
 - [ ] No comments referencing other implementations ("like Java Presto",
       "similar to Spark's X") unless the goal is to match that engine's
       semantics. Logic should stand on its own.
+- [ ] No scaffolding-style comments in committed code: don't name sibling
+      functions ("X handles Y; we handle Z"), don't describe rejected
+      alternative paths ("without requiring a dynamic_cast"), don't
+      contrast with what the code isn't doing. These belong in the PR
+      description or a diff reply.
+- [ ] When changing behavior or layout, update neighboring doc comments to
+      match. Don't leave stale descriptions that describe an earlier
+      version of the code.
+- [ ] No default arguments when all callers can pass values explicitly.
+      `= {}` / `= nullptr` on parameters that every caller supplies is
+      noise; pass the value or split into two helpers.
 - [ ] No unnecessary type aliases (`using ConnectorConfig = ...` when used once).
 - [ ] No unnecessary `static_cast` when the type already matches.
 - [ ] No undefined behavior in evaluation order. Watch for
@@ -65,15 +87,36 @@ before review saves everyone time.
 - [ ] Bug fixes: write the test first, confirm it fails without the fix,
       then apply the fix. A test that passes with and without the fix proves
       nothing.
+- [ ] New tests are placed next to related existing tests, grouped by
+      topic — not appended at the end of the file.
+- [ ] New tests follow the file's existing assertion style. Don't switch to
+      `EXPECT_THAT(..., HasSubstr(...))` when neighboring tests pin the
+      full string with `ASSERT_EQ`, or to individual `EXPECT_EQ`s when
+      neighbors use gtest container matchers.
+- [ ] New shape or variant cases fold into an existing `TEST_F` as
+      additional assertions (use `{ SCOPED_TRACE("…") … }` scope blocks
+      to disambiguate). Don't introduce `xMulti` / `xVariant` /
+      `xExtended` `TEST_F`s for what should be cases inside the existing
+      test.
+- [ ] No new test case duplicates coverage already in an adjacent test in
+      the same file. Fold overlapping cases into the existing test rather
+      than adding a separate one.
 - [ ] No copy-pasted test blocks. If two tests differ only in one parameter,
       use a loop or a local lambda.
 - [ ] Use existing test helpers (`makeArrayFromJson`, `makeBitmapVector`,
       etc.) instead of verbose manual construction.
 - [ ] No duplicated test helpers across files. Extract to a shared header.
+- [ ] Test helpers are designed building blocks, not mechanical extractions
+      of duplication. Name after what they assert (`assertMarkers`,
+      `runSpillTest`); take the natural input, not whatever happened to
+      vary across the first few callers.
 - [ ] `TEST()` for empty fixtures, `TEST_F()` only when the fixture is used.
 - [ ] Error message assertions match the full descriptive text, not just
       the auto-generated comparison output from `VELOX_CHECK_*` macros.
 - [ ] Each test file has one test suite with a matching name.
+- [ ] Test comments describe what behavior the test verifies, not the bug
+      history or implementation details that led to writing the test. The
+      bug story belongs in the commit message and PR description.
 
 ## Documentation
 


### PR DESCRIPTION
Summary:
Recent reviews kept flagging the same patterns:

- tests appended at the end of the file instead of next to related ones
- new `TEST_F`s for shape variants that belong inside an existing test
- helpers named after incidental shape rather than what they assert
- scaffolding comments naming sibling functions or rejected alternatives
- doc comments left stale after a refactor
- default arguments every caller supplies

None were caught by the existing self-review checklist. Adds five items to the Tests section and three to the Code section.

Differential Revision: D106081257


