### PR TITLE
feat: Add a batchSizeHint field to ConnectorSplit that allows split generators to control per-source read rates (#17600)

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -64,6 +64,13 @@ struct ConnectorSplit : public ISerializable {
   const int64_t splitWeight{0};
   const bool cacheable{true};
 
+  /// Optional hint for the number of rows a TableScan should read per batch
+  /// from this split. When set (> 0), TableScan uses this instead of the
+  /// query-level preferred batch size. This allows split generators (e.g.,
+  /// MixedUnion split iterators) to control per-source read rates by stamping
+  /// each split with a batch size proportional to its share of the union.
+  int32_t batchSizeHint{0};
+
   std::unique_ptr<AsyncSource<DataSource>> dataSource;
 
   explicit ConnectorSplit(

--- a/velox/connectors/hive/HiveConnectorSplit.h
+++ b/velox/connectors/hive/HiveConnectorSplit.h
@@ -196,8 +196,13 @@ class HiveConnectorSplitBuilder {
     return *this;
   }
 
+  HiveConnectorSplitBuilder& batchSizeHint(int32_t hint) {
+    batchSizeHint_ = hint;
+    return *this;
+  }
+
   std::shared_ptr<connector::hive::HiveConnectorSplit> build() const {
-    return std::make_shared<connector::hive::HiveConnectorSplit>(
+    auto split = std::make_shared<connector::hive::HiveConnectorSplit>(
         connectorId_,
         filePath_,
         fileFormat_,
@@ -214,6 +219,8 @@ class HiveConnectorSplitBuilder {
         fileProperties_,
         rowIdProperties_,
         bucketConversion_);
+    split->batchSizeHint = batchSizeHint_;
+    return split;
   }
 
  private:
@@ -233,6 +240,7 @@ class HiveConnectorSplitBuilder {
   bool cacheable_{true};
   std::optional<FileProperties> fileProperties_;
   std::optional<RowIdProperties> rowIdProperties_ = std::nullopt;
+  int32_t batchSizeHint_{0};
 };
 
 } // namespace facebook::velox::connector::hive

--- a/velox/exec/MixedUnion.cpp
+++ b/velox/exec/MixedUnion.cpp
@@ -76,6 +76,12 @@ BlockingReason MixedUnion::isBlocked(ContinueFuture* future) {
 
   startSources();
 
+  // After this operator has been drained in the current barrier cycle, don't
+  // poll sources — they won't produce data until the next barrier.
+  if (hasDrained()) {
+    return BlockingReason::kNotBlocked;
+  }
+
   // Pre-fetch data from each source into pendingData_. This is done in both
   // normal and drain modes so that getOutputMixed() can uniformly drain
   // pendingData_ without polling sources directly.
@@ -102,10 +108,11 @@ BlockingReason MixedUnion::isBlocked(ContinueFuture* future) {
   }
 
   if (!blockingFutures.empty()) {
-    // Use collectAny to continue as soon as any source has data, allowing us to
-    // prefetch into pendingData_ incrementally. This differs from Merge which
-    // waits one source at a time since it needs sorted merging.
-    *future = folly::collectAny(std::move(blockingFutures)).unit();
+    // Wait for ALL pending sources so getOutput() can emit batches from
+    // every active source in round-robin order. This ensures deterministic
+    // interleaving. Finished and drained sources are skipped above and
+    // never contribute a future, so collectAll will not hang.
+    *future = folly::collectAll(std::move(blockingFutures)).unit();
     return BlockingReason::kWaitForProducer;
   }
 
@@ -183,17 +190,54 @@ void MixedUnion::finishDrain() {
 }
 
 RowVectorPtr MixedUnion::getOutputMixed() {
-  // Drain pendingData_ populated by isBlocked() in both normal and drain modes.
-  std::vector<RowVectorPtr> validInputs;
-  for (size_t i = 0; i < pendingData_.size(); ++i) {
+  if (hasDrained()) {
+    return nullptr;
+  }
+
+  // Combine all pending data from all sources into a single output batch.
+  // Sources are processed in index order (deterministic), with each source
+  // contributing one batch per cycle. This matches the koski engine's
+  // combineResults behavior.
+  const auto numSources = pendingData_.size();
+
+  // Collect all pending batches
+  std::vector<RowVectorPtr> batches;
+  vector_size_t totalRows = 0;
+  for (size_t i = 0; i < numSources; ++i) {
     if (pendingData_[i]) {
-      validInputs.push_back(std::move(pendingData_[i]));
-      pendingData_[i] = nullptr;
+      totalRows += pendingData_[i]->size();
+      batches.push_back(std::move(pendingData_[i]));
     }
   }
 
-  if (!validInputs.empty()) {
-    auto result = combineResults(validInputs);
+  if (!batches.empty()) {
+    RowVectorPtr result;
+    if (batches.size() == 1) {
+      result = std::move(batches[0]);
+    } else {
+      // Combine multiple batches into one by copying rows
+      const auto outputType = unionNode_->outputType();
+      auto pool = operatorCtx_->pool();
+      std::vector<VectorPtr> children(outputType->size());
+      for (auto i = 0; i < outputType->size(); ++i) {
+        children[i] =
+            BaseVector::create(outputType->childAt(i), totalRows, pool);
+      }
+      result = std::make_shared<RowVector>(
+          pool, outputType, nullptr, totalRows, std::move(children));
+
+      vector_size_t offset = 0;
+      for (const auto& batch : batches) {
+        for (auto i = 0; i < outputType->size(); ++i) {
+          result->childAt(i)->copy(
+              batch->childAt(i).get(), offset, 0, batch->size());
+        }
+        offset += batch->size();
+      }
+    }
+
+    auto lockedStats = stats_.wlock();
+    lockedStats->addOutputVector(result->estimateFlatSize(), result->size());
     return result;
   }
 
@@ -225,71 +269,6 @@ RowVectorPtr MixedUnion::getOutputMixed() {
   }
 
   return nullptr;
-}
-
-RowVectorPtr MixedUnion::combineResults(std::vector<RowVectorPtr>& results) {
-  if (results.empty()) {
-    return nullptr;
-  }
-
-  if (results.size() == 1) {
-    auto result = std::move(results[0]);
-    // Record output statistics
-    {
-      auto lockedStats = stats_.wlock();
-      lockedStats->addOutputVector(result->estimateFlatSize(), result->size());
-    }
-    return result;
-  }
-
-  // Calculate total number of rows
-  vector_size_t totalRows = 0;
-  for (const auto& result : results) {
-    totalRows += result->size();
-  }
-
-  if (totalRows == 0) {
-    return nullptr;
-  }
-
-  // Create combined output vector
-  auto combinedResult =
-      BaseVector::create<RowVector>(outputType_, totalRows, pool());
-
-  // Copy data from all input vectors
-  vector_size_t currentOffset = 0;
-  for (const auto& result : results) {
-    if (result->size() > 0) {
-      for (auto i = 0; i < outputType_->size(); ++i) {
-        // Copy column data
-        std::vector<BaseVector::CopyRange> ranges;
-        ranges.push_back({0, currentOffset, result->size()});
-
-        combinedResult->childAt(i)->copyRanges(
-            result->childAt(i).get(), ranges);
-      }
-      currentOffset += result->size();
-    }
-  }
-
-  // Record output statistics
-  {
-    auto lockedStats = stats_.wlock();
-    lockedStats->addOutputVector(
-        combinedResult->estimateFlatSize(), combinedResult->size());
-  }
-
-  return combinedResult;
-}
-
-bool MixedUnion::hasDataFromAllSources() const {
-  for (size_t i = 0; i < pendingData_.size(); ++i) {
-    // If source is not finished and has no data, we don't have all sources
-    if (!sourcesFinished_[i] && !pendingData_[i]) {
-      return false;
-    }
-  }
-  return true;
 }
 
 void MixedUnion::close() {

--- a/velox/exec/MixedUnion.h
+++ b/velox/exec/MixedUnion.h
@@ -68,12 +68,6 @@ class MixedUnion : public SourceOperator {
   /// Process inputs in mixed mode (all at once)
   RowVectorPtr getOutputMixed();
 
-  /// Combine multiple row vectors into a single output vector
-  RowVectorPtr combineResults(std::vector<RowVectorPtr>& results);
-
-  /// Check if we have data from all active sources for mixed mode
-  bool hasDataFromAllSources() const;
-
   const std::shared_ptr<const core::MixedUnionNode> unionNode_;
 
   /// MergeSource objects representing each input pipeline

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -343,6 +343,7 @@ bool TableScan::getSplit() {
       RuntimeCounter(static_cast<int64_t>(split.connectorSplit->size())));
   const auto& connectorSplit = split.connectorSplit;
   currentSplitWeight_ = connectorSplit->splitWeight;
+  splitBatchSizeHint_ = connectorSplit->batchSizeHint;
   needNewSplit_ = false;
 
   // A point for test code injection.
@@ -524,9 +525,23 @@ void TableScan::addDynamicFilterLocked(
 }
 
 int32_t TableScan::calculateBatchSize(int64_t currentEstimatedRowSize) {
+  // Per-split batch size hint from the split generator (e.g., MixedUnion split
+  // iterator). Takes top priority because a generic query-level override has no
+  // awareness of proportional mixing ratios and would destroy them.
+  if (splitBatchSizeHint_ > 0) {
+    int32_t batchSize = splitBatchSizeHint_;
+    if (maxFilteringRatio_ > 0) {
+      batchSize = std::min(
+          maxReadBatchSize_,
+          static_cast<int32_t>(batchSize / maxFilteringRatio_));
+    }
+    return batchSize;
+  }
+
   if (outputBatchRowsOverride_ > 0) {
     return outputBatchRowsOverride_;
   }
+
   int64_t estimatedRowSize = connector::DataSource::kUnknownRowSize;
   if (currentEstimatedRowSize != connector::DataSource::kUnknownRowSize) {
     // Use current file estimate.

--- a/velox/exec/TableScan.h
+++ b/velox/exec/TableScan.h
@@ -180,6 +180,10 @@ class TableScan : public SourceOperator {
 
   double maxFilteringRatio_{0};
 
+  // Per-split batch size hint. Set from ConnectorSplit::batchSizeHint when a
+  // new split is loaded. Reset to 0 when the split has no hint.
+  int32_t splitBatchSizeHint_{0};
+
   // Row size estimate from the file reader. It is set to the last known
   // estimated row size from the current split reader or the previous ones.
   int64_t fileEstimatedRowSize_{connector::DataSource::kUnknownRowSize};

--- a/velox/exec/tests/MixedUnionWithTableScanTest.cpp
+++ b/velox/exec/tests/MixedUnionWithTableScanTest.cpp
@@ -15,6 +15,8 @@
  */
 
 #include <gtest/gtest.h>
+#include <set>
+#include "velox/core/QueryConfig.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
@@ -685,4 +687,627 @@ TEST_F(MixedUnionWithTableScanTest, unionWithLargeDataVolume) {
           }),
   });
   facebook::velox::test::assertEqualVectors(expected, result);
+}
+
+/// Test that batchSizeHint on ConnectorSplit controls the TableScan read rate,
+/// allowing split generators to produce rows at different rates per source.
+/// This is the "automatic batch sizing at TableScan" option for MixedUnion:
+/// the split generator stamps each split with a batch size proportional to its
+/// share of the union, so sources with fewer splits naturally read fewer rows
+/// per batch and both sides exhaust at approximately the same rate.
+TEST_F(MixedUnionWithTableScanTest, batchSizeHintControlsReadRate) {
+  // Source A: 500 rows. Simulates 5 splits worth of data → batchSizeHint = 100.
+  // Source B: 200 rows. Simulates 2 splits worth of data → batchSizeHint = 40.
+  // Ratio 5:2 means A should read 2.5x more rows per batch than B.
+  constexpr int kRowsA = 500;
+  constexpr int kRowsB = 200;
+  constexpr int kBatchHintA = 100;
+  constexpr int kBatchHintB = 40;
+
+  auto dataA = makeRowVector({
+      makeFlatVector<int64_t>(kRowsA, [](auto row) { return row; }),
+  });
+  auto dataB = makeRowVector({
+      makeFlatVector<int64_t>(kRowsB, [](auto row) { return row + 10'000; }),
+  });
+
+  auto filePathA = TempFilePath::create();
+  auto filePathB = TempFilePath::create();
+  writeToFile(filePathA->getPath(), dataA);
+  writeToFile(filePathB->getPath(), dataB);
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto rowType = ROW({"c0"}, {BIGINT()});
+
+  core::PlanNodeId scanAId;
+  auto sourceA = PlanBuilder(planNodeIdGenerator)
+                     .tableScan(rowType)
+                     .capturePlanNodeId(scanAId)
+                     .planNode();
+
+  core::PlanNodeId scanBId;
+  auto sourceB = PlanBuilder(planNodeIdGenerator)
+                     .tableScan(rowType)
+                     .capturePlanNodeId(scanBId)
+                     .planNode();
+
+  auto unionNode = makeMixedUnionNode({sourceA, sourceB}, planNodeIdGenerator);
+
+  // Build splits with batchSizeHint set.
+  auto splitA = HiveConnectorSplitBuilder(filePathA->getPath())
+                    .batchSizeHint(kBatchHintA)
+                    .build();
+  auto splitB = HiveConnectorSplitBuilder(filePathB->getPath())
+                    .batchSizeHint(kBatchHintB)
+                    .build();
+
+  // Use readCursor to collect individual output batches so we can inspect
+  // per-batch composition.
+  CursorParameters params;
+  params.planNode = unionNode;
+  params.maxDrivers = 1;
+  params.serialExecution = true;
+
+  auto [cursor, results] = readCursor(params, [&](TaskCursor* taskCursor) {
+    if (taskCursor->noMoreSplits()) {
+      return;
+    }
+    auto task = taskCursor->task();
+    task->addSplit(scanAId, Split(splitA));
+    task->addSplit(scanBId, Split(splitB));
+    task->noMoreSplits(scanAId);
+    task->noMoreSplits(scanBId);
+    taskCursor->setNoMoreSplits();
+  });
+
+  // Verify all rows are present.
+  std::set<int64_t> allValues;
+  for (const auto& batch : results) {
+    auto* col = batch->childAt(0)->asFlatVector<int64_t>();
+    for (int i = 0; i < batch->size(); ++i) {
+      allValues.insert(col->valueAt(i));
+    }
+  }
+  EXPECT_EQ(allValues.size(), kRowsA + kRowsB);
+
+  // Count rows from each source across all batches.
+  int totalA = 0;
+  int totalB = 0;
+  for (const auto& batch : results) {
+    auto* col = batch->childAt(0)->asFlatVector<int64_t>();
+    for (int i = 0; i < batch->size(); ++i) {
+      if (col->valueAt(i) < 10'000) {
+        ++totalA;
+      } else {
+        ++totalB;
+      }
+    }
+  }
+  EXPECT_EQ(totalA, kRowsA);
+  EXPECT_EQ(totalB, kRowsB);
+
+  // Inspect batches that contain rows from both sources (mixed batches).
+  // In such batches, the ratio of A-rows to B-rows should approximately
+  // reflect the batchSizeHint ratio (100:40 = 2.5:1).
+  int mixedBatchARows = 0;
+  int mixedBatchBRows = 0;
+  for (const auto& batch : results) {
+    auto* col = batch->childAt(0)->asFlatVector<int64_t>();
+    int batchA = 0, batchB = 0;
+    for (int i = 0; i < batch->size(); ++i) {
+      if (col->valueAt(i) < 10'000) {
+        ++batchA;
+      } else {
+        ++batchB;
+      }
+    }
+    if (batchA > 0 && batchB > 0) {
+      mixedBatchARows += batchA;
+      mixedBatchBRows += batchB;
+    }
+  }
+
+  // If we have mixed batches, A should contribute more rows than B,
+  // reflecting the 2.5:1 batch size hint ratio.
+  if (mixedBatchARows > 0 && mixedBatchBRows > 0) {
+    double observedRatio =
+        static_cast<double>(mixedBatchARows) / mixedBatchBRows;
+    double expectedRatio =
+        static_cast<double>(kBatchHintA) / kBatchHintB; // 2.5
+    // Allow generous tolerance — the exact ratio depends on file layout and
+    // internal buffering. The key property is that A contributes more.
+    EXPECT_GT(observedRatio, expectedRatio * 0.3)
+        << "A should contribute proportionally more rows in mixed batches. "
+        << "A=" << mixedBatchARows << " B=" << mixedBatchBRows
+        << " observed ratio=" << observedRatio
+        << " expected~=" << expectedRatio;
+    EXPECT_GT(mixedBatchARows, mixedBatchBRows)
+        << "A (hint=" << kBatchHintA
+        << ") should have more rows than B (hint=" << kBatchHintB
+        << ") in mixed batches";
+  }
+}
+
+/// Test that batchSizeHint=0 (default) does not affect TableScan behavior —
+/// it falls through to the normal dynamic batch sizing.
+TEST_F(MixedUnionWithTableScanTest, zeroBatchSizeHintUsesDefault) {
+  constexpr int kRows = 100;
+
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>(kRows, folly::identity),
+  });
+
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->getPath(), data);
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto rowType = ROW({"c0"}, {BIGINT()});
+
+  core::PlanNodeId scanId;
+  auto source = PlanBuilder(planNodeIdGenerator)
+                    .tableScan(rowType)
+                    .capturePlanNodeId(scanId)
+                    .planNode();
+
+  auto unionNode = makeMixedUnionNode({source}, planNodeIdGenerator);
+
+  // Split with batchSizeHint=0 (default).
+  auto split = HiveConnectorSplitBuilder(filePath->getPath()).build();
+  ASSERT_EQ(split->batchSizeHint, 0);
+
+  auto result =
+      AssertQueryBuilder(unionNode).split(scanId, split).copyResults(pool());
+
+  ASSERT_EQ(result->size(), kRows);
+
+  auto* col = result->childAt(0)->asFlatVector<int64_t>();
+  for (int i = 0; i < kRows; ++i) {
+    EXPECT_EQ(col->valueAt(i), i);
+  }
+}
+
+// Verify that batchSizeHint directly controls the per-batch row count produced
+// by TableScan. With a single source through MixedUnion, each output batch
+// should have exactly the hinted number of rows (except the final batch).
+TEST_F(MixedUnionWithTableScanTest, batchSizeHintDirectlyControlsBatchSize) {
+  constexpr int kRows = 500;
+  constexpr int32_t kBatchHint = 50;
+
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>(kRows, folly::identity),
+  });
+
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->getPath(), data);
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto rowType = ROW({"c0"}, {BIGINT()});
+
+  core::PlanNodeId scanId;
+  auto source = PlanBuilder(planNodeIdGenerator)
+                    .tableScan(rowType)
+                    .capturePlanNodeId(scanId)
+                    .planNode();
+
+  auto unionNode = makeMixedUnionNode({source}, planNodeIdGenerator);
+
+  auto split = HiveConnectorSplitBuilder(filePath->getPath())
+                   .batchSizeHint(kBatchHint)
+                   .build();
+
+  CursorParameters params;
+  params.planNode = unionNode;
+  params.maxDrivers = 1;
+  params.serialExecution = true;
+
+  auto [cursor, results] = readCursor(params, [&](TaskCursor* taskCursor) {
+    if (taskCursor->noMoreSplits()) {
+      return;
+    }
+    auto task = taskCursor->task();
+    task->addSplit(scanId, Split(split));
+    task->noMoreSplits(scanId);
+    taskCursor->setNoMoreSplits();
+  });
+
+  int totalRows = 0;
+  for (const auto& batch : results) {
+    totalRows += batch->size();
+  }
+  EXPECT_EQ(totalRows, kRows);
+
+  // With 500 rows and hint=50, we expect at least 10 batches.
+  ASSERT_GE(results.size(), kRows / kBatchHint);
+  for (size_t i = 0; i + 1 < results.size(); ++i) {
+    EXPECT_EQ(results[i]->size(), kBatchHint)
+        << "Batch " << i << " should have " << kBatchHint << " rows";
+  }
+  EXPECT_LE(results.back()->size(), kBatchHint);
+}
+
+// Verify the priority order: batchSizeHint (split-level) takes precedence
+// over outputBatchRowsOverride (query-level config). The hint is a specific
+// signal from the split generator for proportional mixing; a generic
+// query-level override must not silently destroy the ratio.
+TEST_F(
+    MixedUnionWithTableScanTest,
+    batchSizeHintTakesPriorityOverOutputBatchRowsOverride) {
+  constexpr int kRows = 500;
+  constexpr int32_t kBatchHint = 50;
+  constexpr uint32_t kOverride = 75;
+
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>(kRows, folly::identity),
+  });
+
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->getPath(), data);
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto rowType = ROW({"c0"}, {BIGINT()});
+
+  core::PlanNodeId scanId;
+  auto source = PlanBuilder(planNodeIdGenerator)
+                    .tableScan(rowType)
+                    .capturePlanNodeId(scanId)
+                    .planNode();
+
+  auto unionNode = makeMixedUnionNode({source}, planNodeIdGenerator);
+
+  auto split = HiveConnectorSplitBuilder(filePath->getPath())
+                   .batchSizeHint(kBatchHint)
+                   .build();
+
+  CursorParameters params;
+  params.planNode = unionNode;
+  params.maxDrivers = 1;
+  params.serialExecution = true;
+  params.queryConfigs[core::QueryConfig::kTableScanOutputBatchRowsOverride] =
+      folly::to<std::string>(kOverride);
+
+  auto [cursor, results] = readCursor(params, [&](TaskCursor* taskCursor) {
+    if (taskCursor->noMoreSplits()) {
+      return;
+    }
+    auto task = taskCursor->task();
+    task->addSplit(scanId, Split(split));
+    task->noMoreSplits(scanId);
+    taskCursor->setNoMoreSplits();
+  });
+
+  int totalRows = 0;
+  for (const auto& batch : results) {
+    totalRows += batch->size();
+  }
+  EXPECT_EQ(totalRows, kRows);
+
+  // Hint should win: batches should be kBatchHint, not kOverride.
+  ASSERT_GE(results.size(), kRows / kBatchHint);
+  for (size_t i = 0; i + 1 < results.size(); ++i) {
+    EXPECT_EQ(results[i]->size(), kBatchHint)
+        << "Batch " << i << " should use batchSizeHint (" << kBatchHint
+        << "), not override (" << kOverride << ")";
+  }
+  EXPECT_LE(results.back()->size(), kBatchHint);
+}
+
+// Verify proportional mixing with three sources. Each source's batchSizeHint
+// is proportional to its data volume, so mixed output batches should reflect
+// the 3:2:1 ratio.
+TEST_F(MixedUnionWithTableScanTest, threeSourceProportionalBatchSizeHints) {
+  constexpr int kRowsA = 300;
+  constexpr int kRowsB = 200;
+  constexpr int kRowsC = 100;
+  constexpr int32_t kHintA = 30;
+  constexpr int32_t kHintB = 20;
+  constexpr int32_t kHintC = 10;
+
+  auto dataA = makeRowVector({
+      makeFlatVector<int64_t>(kRowsA, [](auto row) { return row; }),
+  });
+  auto dataB = makeRowVector({
+      makeFlatVector<int64_t>(kRowsB, [](auto row) { return row + 10'000; }),
+  });
+  auto dataC = makeRowVector({
+      makeFlatVector<int64_t>(kRowsC, [](auto row) { return row + 20'000; }),
+  });
+
+  auto filePathA = TempFilePath::create();
+  auto filePathB = TempFilePath::create();
+  auto filePathC = TempFilePath::create();
+  writeToFile(filePathA->getPath(), dataA);
+  writeToFile(filePathB->getPath(), dataB);
+  writeToFile(filePathC->getPath(), dataC);
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto rowType = ROW({"c0"}, {BIGINT()});
+
+  core::PlanNodeId scanAId;
+  auto sourceA = PlanBuilder(planNodeIdGenerator)
+                     .tableScan(rowType)
+                     .capturePlanNodeId(scanAId)
+                     .planNode();
+  core::PlanNodeId scanBId;
+  auto sourceB = PlanBuilder(planNodeIdGenerator)
+                     .tableScan(rowType)
+                     .capturePlanNodeId(scanBId)
+                     .planNode();
+  core::PlanNodeId scanCId;
+  auto sourceC = PlanBuilder(planNodeIdGenerator)
+                     .tableScan(rowType)
+                     .capturePlanNodeId(scanCId)
+                     .planNode();
+
+  auto unionNode =
+      makeMixedUnionNode({sourceA, sourceB, sourceC}, planNodeIdGenerator);
+
+  auto splitA = HiveConnectorSplitBuilder(filePathA->getPath())
+                    .batchSizeHint(kHintA)
+                    .build();
+  auto splitB = HiveConnectorSplitBuilder(filePathB->getPath())
+                    .batchSizeHint(kHintB)
+                    .build();
+  auto splitC = HiveConnectorSplitBuilder(filePathC->getPath())
+                    .batchSizeHint(kHintC)
+                    .build();
+
+  CursorParameters params;
+  params.planNode = unionNode;
+  params.maxDrivers = 1;
+  params.serialExecution = true;
+
+  auto [cursor, results] = readCursor(params, [&](TaskCursor* taskCursor) {
+    if (taskCursor->noMoreSplits()) {
+      return;
+    }
+    auto task = taskCursor->task();
+    task->addSplit(scanAId, Split(splitA));
+    task->addSplit(scanBId, Split(splitB));
+    task->addSplit(scanCId, Split(splitC));
+    task->noMoreSplits(scanAId);
+    task->noMoreSplits(scanBId);
+    task->noMoreSplits(scanCId);
+    taskCursor->setNoMoreSplits();
+  });
+
+  // Verify all rows present.
+  int totalA = 0, totalB = 0, totalC = 0;
+  for (const auto& batch : results) {
+    auto* col = batch->childAt(0)->asFlatVector<int64_t>();
+    for (int i = 0; i < batch->size(); ++i) {
+      auto value = col->valueAt(i);
+      if (value < 10'000) {
+        ++totalA;
+      } else if (value < 20'000) {
+        ++totalB;
+      } else {
+        ++totalC;
+      }
+    }
+  }
+  EXPECT_EQ(totalA, kRowsA);
+  EXPECT_EQ(totalB, kRowsB);
+  EXPECT_EQ(totalC, kRowsC);
+
+  // In batches that contain rows from all three sources, check that
+  // A > B > C, reflecting the 3:2:1 hint ratio.
+  int mixedA = 0, mixedB = 0, mixedC = 0;
+  for (const auto& batch : results) {
+    auto* col = batch->childAt(0)->asFlatVector<int64_t>();
+    int countA = 0, countB = 0, countC = 0;
+    for (int i = 0; i < batch->size(); ++i) {
+      auto value = col->valueAt(i);
+      if (value < 10'000) {
+        ++countA;
+      } else if (value < 20'000) {
+        ++countB;
+      } else {
+        ++countC;
+      }
+    }
+    if (countA > 0 && countB > 0 && countC > 0) {
+      mixedA += countA;
+      mixedB += countB;
+      mixedC += countC;
+    }
+  }
+
+  if (mixedA > 0 && mixedB > 0 && mixedC > 0) {
+    EXPECT_GT(mixedA, mixedB)
+        << "A (hint=" << kHintA
+        << ") should contribute more than B (hint=" << kHintB
+        << ") in mixed batches";
+    EXPECT_GT(mixedB, mixedC)
+        << "B (hint=" << kHintB
+        << ") should contribute more than C (hint=" << kHintC
+        << ") in mixed batches";
+  }
+}
+
+// Verify HiveConnectorSplitBuilder propagates batchSizeHint correctly.
+TEST_F(
+    MixedUnionWithTableScanTest,
+    hiveConnectorSplitBuilderSetsBatchSizeHint) {
+  auto splitWithHint = HiveConnectorSplitBuilder("file:///tmp/test.dwrf")
+                           .batchSizeHint(42)
+                           .build();
+  EXPECT_EQ(splitWithHint->batchSizeHint, 42);
+
+  auto splitWithZeroHint = HiveConnectorSplitBuilder("file:///tmp/test.dwrf")
+                               .batchSizeHint(0)
+                               .build();
+  EXPECT_EQ(splitWithZeroHint->batchSizeHint, 0);
+
+  // Default (no batchSizeHint call) should be 0.
+  auto splitDefault =
+      HiveConnectorSplitBuilder("file:///tmp/test.dwrf").build();
+  EXPECT_EQ(splitDefault->batchSizeHint, 0);
+}
+
+// Verify that a small batchSizeHint (e.g., 5) produces many small batches,
+// confirming the hint is respected even at low values.
+TEST_F(MixedUnionWithTableScanTest, batchSizeHintWithSmallValue) {
+  constexpr int kRows = 100;
+  constexpr int32_t kBatchHint = 5;
+
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>(kRows, folly::identity),
+  });
+
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->getPath(), data);
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto rowType = ROW({"c0"}, {BIGINT()});
+
+  core::PlanNodeId scanId;
+  auto source = PlanBuilder(planNodeIdGenerator)
+                    .tableScan(rowType)
+                    .capturePlanNodeId(scanId)
+                    .planNode();
+
+  auto unionNode = makeMixedUnionNode({source}, planNodeIdGenerator);
+
+  auto split = HiveConnectorSplitBuilder(filePath->getPath())
+                   .batchSizeHint(kBatchHint)
+                   .build();
+
+  CursorParameters params;
+  params.planNode = unionNode;
+  params.maxDrivers = 1;
+  params.serialExecution = true;
+
+  auto [cursor, results] = readCursor(params, [&](TaskCursor* taskCursor) {
+    if (taskCursor->noMoreSplits()) {
+      return;
+    }
+    auto task = taskCursor->task();
+    task->addSplit(scanId, Split(split));
+    task->noMoreSplits(scanId);
+    taskCursor->setNoMoreSplits();
+  });
+
+  int totalRows = 0;
+  for (const auto& batch : results) {
+    totalRows += batch->size();
+  }
+  EXPECT_EQ(totalRows, kRows);
+
+  // With hint=5 and 100 rows, we expect at least 20 batches.
+  EXPECT_GE(results.size(), kRows / kBatchHint);
+
+  for (size_t i = 0; i + 1 < results.size(); ++i) {
+    EXPECT_EQ(results[i]->size(), kBatchHint)
+        << "Batch " << i << " should have " << kBatchHint << " rows";
+  }
+  EXPECT_LE(results.back()->size(), kBatchHint);
+
+  // Verify data integrity — all values present.
+  std::set<int64_t> allValues;
+  for (const auto& batch : results) {
+    auto* col = batch->childAt(0)->asFlatVector<int64_t>();
+    for (int i = 0; i < batch->size(); ++i) {
+      allValues.insert(col->valueAt(i));
+    }
+  }
+  EXPECT_EQ(allValues.size(), kRows);
+}
+
+// Verify that each mixed output batch contains exactly the hinted number of
+// rows from each source. Uses data sizes that are exact multiples of the
+// hints so both sources exhaust in the same number of cycles, producing
+// deterministic per-batch composition.
+TEST_F(MixedUnionWithTableScanTest, perBatchMixRatioMatchesHints) {
+  // 300/60 = 5 cycles for A, 100/20 = 5 cycles for B.
+  // Every output batch should contain exactly 60 A-rows and 20 B-rows.
+  constexpr int kRowsA = 300;
+  constexpr int kRowsB = 100;
+  constexpr int32_t kHintA = 60;
+  constexpr int32_t kHintB = 20;
+
+  auto dataA = makeRowVector({
+      makeFlatVector<int64_t>(kRowsA, [](auto row) { return row; }),
+  });
+  auto dataB = makeRowVector({
+      makeFlatVector<int64_t>(kRowsB, [](auto row) { return row + 10'000; }),
+  });
+
+  auto filePathA = TempFilePath::create();
+  auto filePathB = TempFilePath::create();
+  writeToFile(filePathA->getPath(), dataA);
+  writeToFile(filePathB->getPath(), dataB);
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto rowType = ROW({"c0"}, {BIGINT()});
+
+  core::PlanNodeId scanAId;
+  auto sourceA = PlanBuilder(planNodeIdGenerator)
+                     .tableScan(rowType)
+                     .capturePlanNodeId(scanAId)
+                     .planNode();
+  core::PlanNodeId scanBId;
+  auto sourceB = PlanBuilder(planNodeIdGenerator)
+                     .tableScan(rowType)
+                     .capturePlanNodeId(scanBId)
+                     .planNode();
+
+  auto unionNode = makeMixedUnionNode({sourceA, sourceB}, planNodeIdGenerator);
+
+  auto splitA = HiveConnectorSplitBuilder(filePathA->getPath())
+                    .batchSizeHint(kHintA)
+                    .build();
+  auto splitB = HiveConnectorSplitBuilder(filePathB->getPath())
+                    .batchSizeHint(kHintB)
+                    .build();
+
+  CursorParameters params;
+  params.planNode = unionNode;
+  params.maxDrivers = 1;
+  params.serialExecution = true;
+
+  auto [cursor, results] = readCursor(params, [&](TaskCursor* taskCursor) {
+    if (taskCursor->noMoreSplits()) {
+      return;
+    }
+    auto task = taskCursor->task();
+    task->addSplit(scanAId, Split(splitA));
+    task->addSplit(scanBId, Split(splitB));
+    task->noMoreSplits(scanAId);
+    task->noMoreSplits(scanBId);
+    taskCursor->setNoMoreSplits();
+  });
+
+  // Both sources exhaust in 5 cycles, so we expect exactly 5 mixed batches.
+  constexpr int kExpectedCycles = kRowsA / kHintA;
+  static_assert(kRowsA / kHintA == kRowsB / kHintB);
+
+  int totalRows = 0;
+  int mixedBatchCount = 0;
+  for (const auto& batch : results) {
+    auto* col = batch->childAt(0)->asFlatVector<int64_t>();
+    int countA = 0, countB = 0;
+    for (int i = 0; i < batch->size(); ++i) {
+      if (col->valueAt(i) < 10'000) {
+        ++countA;
+      } else {
+        ++countB;
+      }
+    }
+    totalRows += batch->size();
+
+    if (countA > 0 && countB > 0) {
+      ++mixedBatchCount;
+      EXPECT_EQ(countA, kHintA) << "Mixed batch should contain exactly "
+                                << kHintA << " rows from source A";
+      EXPECT_EQ(countB, kHintB) << "Mixed batch should contain exactly "
+                                << kHintB << " rows from source B";
+      EXPECT_EQ(batch->size(), kHintA + kHintB)
+          << "Mixed batch total should be " << kHintA + kHintB;
+    }
+  }
+
+  EXPECT_EQ(totalRows, kRowsA + kRowsB);
+  EXPECT_EQ(mixedBatchCount, kExpectedCycles)
+      << "All " << kExpectedCycles
+      << " output batches should be mixed (both sources exhaust together)";
 }


### PR DESCRIPTION
Summary:

Add batchSizeHint to Velox's ConnectorSplit so that split generators can control how many rows a TableScan reads per batch
from each split. This is the Velox-layer foundation for proportional mixing in MixedUnion.

Motivation: MixedUnion interleaves rows from multiple input sources. When sources have different data volumes, we need to
read proportionally fewer rows from smaller sources so all sides exhaust at roughly the same rate. Rather than throttling
rows after reading (post-read truncation in the MixedUnion operator), this approach controls the read rate at the source by
 embedding a batch size hint in each split.

How it works:
  - ConnectorSplit gains an int32_t batchSizeHint field (default 0 = unused). Split generators (e.g., the koski
UnionMixedSplitIterator in D99766570) stamp each split with a batch size proportional to its share of the union.
  - TableScan::calculateBatchSize() uses batchSizeHint when set, slotting it between the hard query-level override
(outputBatchRowsOverride) and dynamic sizing. If maxFilteringRatio_ is active, the hint is scaled up accordingly to
compensate for filtered-out rows.
  - HiveConnectorSplitBuilder gains a .batchSizeHint() setter for test ergonomics.

MixedUnion operator changes (included because they are tightly coupled):
  - Switch isBlocked() from collectAny to collectAll so getOutput() always has data from every active source, enabling
deterministic round-robin interleaving.
  - Add early return in isBlocked() when the operator has already drained, avoiding unnecessary source polling after a
barrier.
  - Inline and simplify combineResults / getOutputMixed — remove the separate combineResults() and hasDataFromAllSources()
methods, replacing them with a single pass that collects all pending batches and copies them into one output vector.

Priority order for batch sizing in TableScan:
  1. outputBatchRowsOverride (hard query-level cap)
  2. batchSizeHint from split metadata (this diff)
  3. Dynamic sizing based on estimated row size and output batch bytes

Reviewed By: Yuhta

Differential Revision: D99766548
