### PR TITLE
perf: Avoid unnecessary object copy (#17601)

### DIFF
--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -546,7 +546,8 @@ class SelectiveColumnReader {
     }
     formatData_->readNulls(
         numRows, incomingNulls, nullsInReadRange_, readsNullsOnly);
-    if (isFlatMapValue_ && nullsInReadRange_) {
+    if (isFlatMapValue_ && nullsInReadRange_ &&
+        flatMapValueNullsInReadRange_.get() != nullsInReadRange_.get()) {
       flatMapValueNullsInReadRange_ = nullsInReadRange_;
     }
   }


### PR DESCRIPTION
Summary:

Optimized `SelectiveColumnReader::readNulls` by adding a pointer equality check (`flatMapValueNullsInReadRange_.get() != nullsInReadRange_.get()`) before the `boost::intrusive_ptr` copy assignment at line 550. This avoids redundant atomic reference count increment/decrement operations when both pointers already refer to the same object, which occurs when `nullsInReadRange_` was non-null at function entry and `formatData_->readNulls` reused the existing buffer without reallocating.

Reviewed By: IosifSpulber

Differential Revision: D105338601


