### PR TITLE
refactor: Minor normalize gtest names to start with lowerCase

### DIFF
--- a/.github/workflows/breeze.yml
+++ b/.github/workflows/breeze.yml
@@ -57,6 +57,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           path: velox
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Install uv
@@ -67,6 +68,7 @@ jobs:
           source scripts/setup-ubuntu.sh && install_apt_deps
 
       - name: Make Debug Build
+        id: build
         env:
           VELOX_DEPENDENCY_SOURCE: BUNDLED
         # OpenMP build with asan+ubsan enabled
@@ -74,9 +76,29 @@ jobs:
           cmake -S velox/experimental/breeze -B _build-breeze/debug \
                 -DCMAKE_BUILD_TYPE=Asan \
                 -DCMAKE_CXX_FLAGS="-fsanitize=undefined" \
+                -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
                 -DBUILD_GENERATE_TEST_FIXTURES=OFF \
                 -DBUILD_OPENMP=ON
           cmake --build _build-breeze/debug -j 8
+
+      - name: Install and run clang-tidy
+        if: ${{ steps.build.outcome == 'success' && github.event_name == 'pull_request' }}
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          uv tool install clang-tidy==18.1.8
+          RANGE="${BASE_SHA}..HEAD"
+          FILES=$(git diff --name-only "$RANGE" -- velox/experimental/breeze/ | grep -E '\.(cpp|h|hpp)$' || true)
+          # The usage of GCC14 adds compiler warnings not understood by Clang/Clang-tidy.
+          # We replace them for now but eventually move Clang-tidy to the Clang based build.
+          BUILD_PATH=$(realpath _build-breeze/debug)
+          sed -i 's/-Wno-maybe-uninitialized//g' "$BUILD_PATH/compile_commands.json"
+
+          if [[ -n "$FILES" ]]; then
+            python ./scripts/checks/run-clang-tidy.py -p "$BUILD_PATH" --commit "$RANGE" $FILES
+          else
+            echo "No changed Breeze C++ files to run clang-tidy."
+          fi
 
       - name: Run Tests
         run: |

--- a/.github/workflows/breeze.yml
+++ b/.github/workflows/breeze.yml
@@ -79,12 +79,17 @@ jobs:
                 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
                 -DBUILD_GENERATE_TEST_FIXTURES=OFF \
                 -DBUILD_OPENMP=ON
+          compiler_file=$(find _build-breeze/debug/CMakeFiles -name CMakeCXXCompiler.cmake -print -quit)
+          compiler_id=$(sed -n 's/^set(CMAKE_CXX_COMPILER_ID "\(.*\)")$/\1/p' "$compiler_file")
+          echo "compiler_file=${compiler_file}" >> "$GITHUB_OUTPUT"
+          echo "compiler_id=${compiler_id}" >> "$GITHUB_OUTPUT"
           cmake --build _build-breeze/debug -j 8
 
       - name: Install and run clang-tidy
-        if: ${{ steps.build.outcome == 'success' && github.event_name == 'pull_request' }}
+        if: ${{ steps.build.outcome == 'success' && github.event_name == 'pull_request' && steps.build.outputs.compiler_id == 'GNU' }}
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          COMPILER_FILE: ${{ steps.build.outputs.compiler_file }}
         run: |
           uv tool install clang-tidy==18.1.8
           RANGE="${BASE_SHA}..HEAD"
@@ -92,7 +97,10 @@ jobs:
           # The usage of GCC14 adds compiler warnings not understood by Clang/Clang-tidy.
           # We replace them for now but eventually move Clang-tidy to the Clang based build.
           BUILD_PATH=$(realpath _build-breeze/debug)
+          CXX_COMPILER=$(sed -n 's/^set(CMAKE_CXX_COMPILER "\(.*\)")$/\1/p' "$COMPILER_FILE")
+          GCC_INCLUDE=$("$CXX_COMPILER" -print-file-name=include)
           sed -i 's/-Wno-maybe-uninitialized//g' "$BUILD_PATH/compile_commands.json"
+          sed -i "s# -fopenmp -DPLATFORM_OPENMP# -isystem ${GCC_INCLUDE} -fopenmp -DPLATFORM_OPENMP#g" "$BUILD_PATH/compile_commands.json"
 
           if [[ -n "$FILES" ]]; then
             python ./scripts/checks/run-clang-tidy.py -p "$BUILD_PATH" --commit "$RANGE" $FILES

--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -250,7 +250,9 @@ jobs:
           sed -i 's/-Wno-class-memaccess//g' $BUILD_PATH/compile_commands.json
           sed -i 's/-Wno-maybe-uninitialized//g' $BUILD_PATH/compile_commands.json
           sed -i 's/-fcoroutines//g' $BUILD_PATH/compile_commands.json
-          python ./scripts/checks/run-clang-tidy.py -p $BUILD_PATH --commit $RANGE $FILES
+          # Breeze is a separate CMake project. Its files need the Breeze
+          # compile database, not the adapters build compile database.
+          python ./scripts/checks/run-clang-tidy.py -p $BUILD_PATH --commit $RANGE --exclude-dir breeze/ $FILES
 
       - name: Check cuDF Changes
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2

--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -255,14 +255,14 @@ jobs:
           python ./scripts/checks/run-clang-tidy.py -p $BUILD_PATH --commit $RANGE --exclude-dir breeze/ $FILES
 
       - name: Check cuDF Changes
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: changes
         if: ${{ ! inputs.use-clang && always() }}
-        with:
-          filters: |
-            cudf:
-              - 'velox/experimental/cudf/**'
-              - 'CMake/resolve_dependency_modules/cudf.cmake'
+        env:
+          FILES: ${{ needs.get-changes.outputs.changed-files }}
+        run: |
+          if grep -qE '^(velox/experimental/cudf/|CMake/resolve_dependency_modules/cudf\.cmake$)' <<< "$FILES"; then
+            echo "cudf=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Copy Shared Libraries for cuDF Test Binaries
         if: ${{ ! inputs.use-clang && steps.changes.outputs.cudf && always() }}

--- a/scripts/checks/run-clang-tidy.py
+++ b/scripts/checks/run-clang-tidy.py
@@ -22,6 +22,10 @@ import os
 import util
 
 
+# clang-tidy doesn't support CUDA compiler flags and CUDA headers.
+DEFAULT_EXCLUDE_DIRS = ["cudf/", "wave/"]
+
+
 class Multimap(dict):
     def __setitem__(self, key, value):
         if key not in self:
@@ -30,7 +34,26 @@ class Multimap(dict):
             self[key].append(value)
 
 
-def git_changed_lines(commit):
+def should_exclude(file, exclude_dirs):
+    return any(exclude_dir in file for exclude_dir in exclude_dirs)
+
+
+def get_exclude_dirs(exclude_dirs):
+    return list(dict.fromkeys(DEFAULT_EXCLUDE_DIRS + (exclude_dirs or [])))
+
+
+def is_supported_file(file, exclude_dirs):
+    # Exclude files in exclude_dirs.
+    # Exclude *-inl.h files: they are designed to be included from their corresponding header
+    # and cannot be compiled as standalone translation units.
+    return (
+        re.match(r".*(\.cpp|\.h|\.hpp)$", file)
+        and not should_exclude(file, exclude_dirs)
+        and not file.endswith("-inl.h")
+    )
+
+
+def git_changed_lines(commit, exclude_dirs):
     file = ""
     changed_lines = Multimap()
 
@@ -45,16 +68,7 @@ def git_changed_lines(commit):
         match = re.match(r"^\+\+\+ b/(.*(\.cpp|\.h|\.hpp))$", line)
         if match:
             matched_file = match.group(1)
-            # Exclude files in cudf, wave, and torchwave directories
-            # as clang-tidy doesn't support CUDA compiler flags and CUDA
-            # headers. Exclude *-inl.h files: they are designed to be
-            # included from their corresponding header and cannot be
-            # compiled as standalone translation units.
-            if (
-                "cudf/" not in matched_file
-                and "wave/" not in matched_file
-                and not matched_file.endswith("-inl.h")
-            ):
+            if is_supported_file(matched_file, exclude_dirs):
                 file = matched_file
 
         match = re.match(r"^@@", line)
@@ -78,30 +92,22 @@ def check_output(output):
 
 
 def tidy(args):
+    exclude_dirs = get_exclude_dirs(args.exclude_dirs)
     files = util.input_files(args.files)
-    files = [file for file in files if re.match(r".*(\.cpp|\.h|\.hpp)$", file)]
-
-    # Exclude files in cudf, wave, and torchwave directories
-    # as clang-tidy doesn't support CUDA compiler flags and CUDA headers
-    files = [file for file in files if "cudf/" not in file and "wave/" not in file]
-
-    # Exclude *-inl.h files: they are designed to be included from their
-    # corresponding header and cannot be compiled as standalone translation
-    # units (see git_changed_lines for rationale).
-    files = [file for file in files if not file.endswith("-inl.h")]
+    files = [file for file in files if is_supported_file(file, exclude_dirs)]
 
     in_gha = os.environ.get("GITHUB_ACTIONS") is not None
-    changed_lines = git_changed_lines(args.commit)
-
+    changed_lines = git_changed_lines(args.commit, exclude_dirs)
+    filtered_files = [file for file in files if file in changed_lines]
     line_filter = json.dumps(
-        [{"name": key, "lines": value} for key, value in changed_lines.items()]
+        [{"name": file, "lines": changed_lines[file]} for file in filtered_files]
     )
-    filtered_files = [*changed_lines.keys()]
+    lines = f"'--line-filter={line_filter}'"
+
     if len(filtered_files) == 0:
         return 0
 
     fix = "--fix" if args.fix == "fix" else ""
-    lines = f"'--line-filter={line_filter}'" if args.commit is not None else ""
 
     ok = True
     build_path = args.p or os.getenv("BUILD_PATH")
@@ -142,9 +148,16 @@ def tidy(args):
 def parse_args():
     global parser
     parser = argparse.ArgumentParser(description="Clang Tidy Utility")
-    parser.add_argument("--commit")
+    parser.add_argument("--commit", required=True)
     parser.add_argument("--fix")
     parser.add_argument("-p", help="Path containing 'compile_commands.json'")
+    parser.add_argument(
+        "--exclude-dir",
+        action="append",
+        default=[],
+        dest="exclude_dirs",
+        help="Additional path substring to exclude from clang-tidy.",
+    )
 
     parser.add_argument("files", metavar="FILES", nargs="+", help="files to process")
 

--- a/velox/common/base/tests/SimdUtilTest.cpp
+++ b/velox/common/base/tests/SimdUtilTest.cpp
@@ -393,7 +393,7 @@ TEST_F(SimdUtilTest, crc32) {
   EXPECT_EQ(checksum, 121285919);
 }
 
-TEST_F(SimdUtilTest, Batch64_assign) {
+TEST_F(SimdUtilTest, batch64_assign) {
   auto b = simd::Batch64<int32_t>::from({0, 1});
   EXPECT_EQ(b.data[0], 0);
   EXPECT_EQ(b.data[1], 1);
@@ -402,7 +402,7 @@ TEST_F(SimdUtilTest, Batch64_assign) {
   EXPECT_EQ(b.data[1], 1);
 }
 
-TEST_F(SimdUtilTest, Batch64_arithmetics) {
+TEST_F(SimdUtilTest, batch64_arithmetics) {
   auto b = simd::Batch64<int32_t>::from({0, 1});
   auto bb = b + 42;
   EXPECT_EQ(bb.data[0], 42);
@@ -412,7 +412,7 @@ TEST_F(SimdUtilTest, Batch64_arithmetics) {
   EXPECT_EQ(bb.data[1], 0);
 }
 
-TEST_F(SimdUtilTest, Batch64_memory) {
+TEST_F(SimdUtilTest, batch64_memory) {
   int32_t data[] = {0, 1};
   auto b = simd::Batch64<int32_t>::load_unaligned(data);
   EXPECT_EQ(b.data[0], 0);

--- a/velox/common/base/tests/StatsReporterTest.cpp
+++ b/velox/common/base/tests/StatsReporterTest.cpp
@@ -787,7 +787,7 @@ class DynamicQuantilePatternTest
     : public StatsReporterTest,
       public testing::WithParamInterface<DynamicQuantilePatternTestCase> {};
 
-TEST_P(DynamicQuantilePatternTest, PatternScenarios) {
+TEST_P(DynamicQuantilePatternTest, patternScenarios) {
   const auto& testCase = GetParam();
   testCase.testFunc(this);
 }

--- a/velox/common/file/tests/FileUtilsTest.cpp
+++ b/velox/common/file/tests/FileUtilsTest.cpp
@@ -116,7 +116,7 @@ auto getReader(
 
 } // namespace
 
-TEST(CoalesceSegmentsTest, EmptyCase) {
+TEST(CoalesceSegmentsTest, emptyCase) {
   const Regions r = {};
 
   MockShouldCoalesce shouldCoalesce;
@@ -129,7 +129,7 @@ TEST(CoalesceSegmentsTest, EmptyCase) {
   EXPECT_EQ(resultRegions, expected);
 }
 
-TEST(CoalesceSegmentsTest, MergeAll) {
+TEST(CoalesceSegmentsTest, mergeAll) {
   const Regions r = {{0, 4}, {4, 4}, {8, 1}, {9, 2}, {11, 3}};
 
   MockShouldCoalesce shouldCoalesce;
@@ -146,7 +146,7 @@ TEST(CoalesceSegmentsTest, MergeAll) {
   EXPECT_EQ(resultRegions, expected);
 }
 
-TEST(CoalesceSegmentsTest, MergeNone) {
+TEST(CoalesceSegmentsTest, mergeNone) {
   const Regions r = {{0, 4}, {4, 4}, {8, 1}, {9, 2}, {11, 3}};
 
   MockShouldCoalesce shouldCoalesce;
@@ -164,7 +164,7 @@ TEST(CoalesceSegmentsTest, MergeNone) {
   EXPECT_EQ(resultRegions, expected);
 }
 
-TEST(CoalesceSegmentsTest, MergeOdd) {
+TEST(CoalesceSegmentsTest, mergeOdd) {
   const Regions r = {{0, 4}, {4, 4}, {8, 1}, {9, 2}, {11, 3}};
 
   auto isOdd = [](size_t i) { return i % 2 == 1; };
@@ -184,7 +184,7 @@ TEST(CoalesceSegmentsTest, MergeOdd) {
   EXPECT_EQ(resultRegions, expected);
 }
 
-TEST(CoalesceSegmentsTest, MergeEven) {
+TEST(CoalesceSegmentsTest, mergeEven) {
   const Regions r = {{{0, 4}, {4, 4}, {8, 1}, {9, 2}, {11, 3}}};
   auto isEven = [](size_t i) { return i % 2 == 0; };
 
@@ -203,7 +203,7 @@ TEST(CoalesceSegmentsTest, MergeEven) {
   EXPECT_EQ(resultRegions, expected);
 }
 
-TEST(CoalesceIfDistanceLETest, MultipleCases) {
+TEST(CoalesceIfDistanceLETest, multipleCases) {
   EXPECT_TRUE(willCoalesceIfDistanceLE(0, {0, 1}, {1, 1}, 0));
   EXPECT_FALSE(willCoalesceIfDistanceLE(0, {0, 1}, {2, 1}, 0));
 
@@ -218,7 +218,7 @@ TEST(CoalesceIfDistanceLETest, MultipleCases) {
   EXPECT_TRUE(willCoalesceIfDistanceLE(0, {0, 0}, {0, 1}, 0));
 }
 
-TEST(CoalesceIfDistanceLETest, MultipleSegments) {
+TEST(CoalesceIfDistanceLETest, multipleSegments) {
   uint64_t coalescedBytes = 0;
   auto willCoalesce = CoalesceIfDistanceLE(10, &coalescedBytes);
   EXPECT_TRUE(willCoalesce({0, 1}, {1, 1})); // 0
@@ -229,11 +229,11 @@ TEST(CoalesceIfDistanceLETest, MultipleSegments) {
   EXPECT_EQ(coalescedBytes, 19);
 }
 
-TEST(CoalesceIfDistanceLETest, SupportsNullArgument) {
+TEST(CoalesceIfDistanceLETest, supportsNullArgument) {
   EXPECT_NO_THROW(CoalesceIfDistanceLE(10, nullptr)({0, 10}, {20, 5})); // 10
 }
 
-TEST(CoalesceIfDistanceLETest, SegmentsMustBeSorted) {
+TEST(CoalesceIfDistanceLETest, segmentsMustBeSorted) {
   EXPECT_THROW(
       willCoalesceIfDistanceLE(0, {1, 1}, {0, 1}, 0),
       ::facebook::velox::VeloxRuntimeError);
@@ -248,7 +248,7 @@ TEST(CoalesceIfDistanceLETest, SegmentsMustBeSorted) {
       ::facebook::velox::VeloxRuntimeError);
 }
 
-TEST(CoalesceIfDistanceLETest, SegmentsCantOverlap) {
+TEST(CoalesceIfDistanceLETest, segmentsCantOverlap) {
   EXPECT_THROW(
       willCoalesceIfDistanceLE(0, {0, 1}, {0, 1}, 0),
       ::facebook::velox::VeloxRuntimeError);
@@ -271,7 +271,7 @@ TEST(CoalesceIfDistanceLETest, SegmentsCantOverlap) {
 
 class ReadToIOBufsTest : public testing::TestWithParam<bool> {};
 
-TEST_P(ReadToIOBufsTest, CanRead) {
+TEST_P(ReadToIOBufsTest, canRead) {
   Regions r = {{0, 1}, {5, 1}, {10, 6}, {16, 5}};
   std::vector<folly::IOBuf> iobufs;
   iobufs.reserve(r.size());

--- a/velox/common/memory/tests/MemoryAllocatorTest.cpp
+++ b/velox/common/memory/tests/MemoryAllocatorTest.cpp
@@ -1470,7 +1470,7 @@ TEST_P(MemoryAllocatorTest, allocateZeroFilled) {
   ASSERT_TRUE(instance_->checkConsistency());
 }
 
-TEST_P(MemoryAllocatorTest, StlMemoryAllocator) {
+TEST_P(MemoryAllocatorTest, stlMemoryAllocator) {
   {
     std::vector<double, StlAllocator<double>> data(
         0, StlAllocator<double>(*pool_));

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -677,7 +677,7 @@ TEST_P(MemoryPoolTest, releasableMemory) {
   }
 }
 
-TEST_P(MemoryPoolTest, ReallocTestSameSize) {
+TEST_P(MemoryPoolTest, reallocTestSameSize) {
   auto manager = getMemoryManager();
   auto root = manager->addRootPool();
 
@@ -699,7 +699,7 @@ TEST_P(MemoryPoolTest, ReallocTestSameSize) {
   ASSERT_EQ(2 * kChunkSize, pool->stats().peakBytes);
 }
 
-TEST_P(MemoryPoolTest, ReallocTestHigher) {
+TEST_P(MemoryPoolTest, reallocTestHigher) {
   auto manager = getMemoryManager();
   auto root = manager->addRootPool();
 
@@ -720,7 +720,7 @@ TEST_P(MemoryPoolTest, ReallocTestHigher) {
   EXPECT_EQ(4 * kChunkSize, pool->stats().peakBytes);
 }
 
-TEST_P(MemoryPoolTest, ReallocTestLower) {
+TEST_P(MemoryPoolTest, reallocTestLower) {
   auto manager = getMemoryManager();
   auto root = manager->addRootPool();
   auto pool = root->addLeafChild("elastic_quota", isLeafThreadSafe_);
@@ -919,7 +919,7 @@ TEST_P(MemoryPoolTest, memoryCapExceptions) {
   }
 }
 
-TEST(MemoryPoolTest, GetAlignment) {
+TEST(MemoryPoolTest, getAlignment) {
   {
     MemoryManager::Options options;
     options.allocatorCapacity = kMaxMemory;
@@ -936,7 +936,7 @@ TEST(MemoryPoolTest, GetAlignment) {
   }
 }
 
-TEST_P(MemoryPoolTest, MemoryManagerGlobalCap) {
+TEST_P(MemoryPoolTest, memoryManagerGlobalCap) {
   MemoryManager::Options options;
   options.allocatorCapacity = 32L * MB;
   options.arbitratorCapacity = 32L * MB;

--- a/velox/common/serialization/tests/TestRegistry.cpp
+++ b/velox/common/serialization/tests/TestRegistry.cpp
@@ -21,7 +21,7 @@
 using namespace ::facebook::velox;
 
 namespace {
-TEST(Registry, SmartPointerFactoryWithNoArgument) {
+TEST(Registry, smartPointerFactoryWithNoArgument) {
   Registry<size_t, std::unique_ptr<size_t>()> registry;
 
   const size_t key = 0;
@@ -38,7 +38,7 @@ TEST(Registry, SmartPointerFactoryWithNoArgument) {
   EXPECT_EQ(*registry.Create(key), value);
 }
 
-TEST(Registry, ValueFactoryWithArguments) {
+TEST(Registry, valueFactoryWithArguments) {
   Registry<size_t, size_t(size_t, size_t)> registry;
 
   const size_t key = 0;

--- a/velox/connectors/hive/iceberg/tests/IcebergParquetStatsTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergParquetStatsTest.cpp
@@ -560,7 +560,7 @@ TEST_F(IcebergParquetStatsTest, mixedDoubleFloat) {
   EXPECT_FLOAT_EQ(maxFloatVal, -std::numeric_limits<float>::infinity());
 }
 
-TEST_F(IcebergParquetStatsTest, NaN) {
+TEST_F(IcebergParquetStatsTest, nan) {
   constexpr vector_size_t size = 1'000;
   constexpr int32_t expectedNulls = 500;
   constexpr int32_t doubleColId = 1;

--- a/velox/core/tests/StringTest.cpp
+++ b/velox/core/tests/StringTest.cpp
@@ -27,7 +27,7 @@ StringWriter createStringWriter(const std::string& str) {
 }
 } // namespace
 
-TEST(String, StringWriter) {
+TEST(String, stringWriter) {
   // Default constructor & empty string copy.
   {
     const std::string emptyString;

--- a/velox/dwio/common/Range.h
+++ b/velox/dwio/common/Range.h
@@ -116,8 +116,8 @@ class Ranges {
   std::vector<std::tuple<size_t, size_t>> ranges_;
   size_t size_{0};
 
-  VELOX_FRIEND_TEST(RangeTests, Add);
-  VELOX_FRIEND_TEST(RangeTests, Filter);
+  VELOX_FRIEND_TEST(RangeTests, add);
+  VELOX_FRIEND_TEST(RangeTests, filter);
 };
 
 } // namespace facebook::velox::common

--- a/velox/dwio/common/tests/BufferedInputTest.cpp
+++ b/velox/dwio/common/tests/BufferedInputTest.cpp
@@ -444,7 +444,7 @@ TEST_F(BufferedInputTest, readSorting) {
   }
 }
 
-TEST_F(BufferedInputTest, VreadSorting) {
+TEST_F(BufferedInputTest, vreadSorting) {
   std::string content = "aaabbbcccdddeeefffggghhhiiijjjkkklllmmmnnnooopppqqq";
   std::vector<Region> regions = {{6, 3}, {24, 3}, {3, 3}, {0, 3}, {29, 3}};
 
@@ -482,7 +482,7 @@ TEST_F(BufferedInputTest, VreadSorting) {
   }
 }
 
-TEST_F(BufferedInputTest, VreadSortingWithLabels) {
+TEST_F(BufferedInputTest, vreadSortingWithLabels) {
   std::string content = "aaabbbcccdddeeefffggghhhiiijjjkkklllmmmnnnooopppqqq";
   std::vector<std::string> l = {"a", "b", "c", "d", "e"};
   std::vector<Region> regions = {

--- a/velox/dwio/common/tests/ColumnReaderStatisticsTests.cpp
+++ b/velox/dwio/common/tests/ColumnReaderStatisticsTests.cpp
@@ -24,7 +24,7 @@ using namespace facebook::velox::dwio::common;
 using facebook::velox::RuntimeMetric;
 using facebook::velox::TypeKind;
 
-TEST(IoCounterTest, BasicOperations) {
+TEST(IoCounterTest, basicOperations) {
   facebook::velox::io::IoCounter counter;
 
   EXPECT_EQ(counter.sum(), 0);
@@ -39,7 +39,7 @@ TEST(IoCounterTest, BasicOperations) {
   EXPECT_EQ(counter.max(), 5'000);
 }
 
-TEST(IoCounterTest, ConcurrentAccess) {
+TEST(IoCounterTest, concurrentAccess) {
   facebook::velox::io::IoCounter counter;
   constexpr int kNumThreads = 4;
   constexpr int kIterationsPerThread = 1'000;
@@ -61,7 +61,7 @@ TEST(IoCounterTest, ConcurrentAccess) {
   EXPECT_EQ(counter.count(), kNumThreads * kIterationsPerThread);
 }
 
-TEST(ColumnMetricsSetTest, GetOrCreate) {
+TEST(ColumnMetricsSetTest, getOrCreate) {
   ColumnMetricsSet metricsSet;
 
   auto* result = metricsSet.getOrCreate(1);
@@ -75,7 +75,7 @@ TEST(ColumnMetricsSetTest, GetOrCreate) {
   EXPECT_NE(result2, result);
 }
 
-TEST(ColumnMetricsSetTest, GetOrCreateWithTypeKind) {
+TEST(ColumnMetricsSetTest, getOrCreateWithTypeKind) {
   ColumnMetricsSet metricsSet;
 
   // Pass type when calling getOrCreate.
@@ -99,7 +99,7 @@ TEST(ColumnMetricsSetTest, GetOrCreateWithTypeKind) {
   EXPECT_EQ(metrics["column_2.VARCHAR.decompressCPUTimeNanos"].sum, 2'000);
 }
 
-TEST(ColumnMetricsSetTest, ToRuntimeMetrics) {
+TEST(ColumnMetricsSetTest, toRuntimeMetrics) {
   ColumnMetricsSet metricsSet;
 
   // Empty stats produces empty result.
@@ -136,7 +136,7 @@ TEST(ColumnMetricsSetTest, ToRuntimeMetrics) {
   EXPECT_EQ(result.count("column_99.DOUBLE.decompressCPUTimeNanos"), 0);
 }
 
-TEST(ColumnMetricsSetTest, ToRuntimeMetricsWithInvalidType) {
+TEST(ColumnMetricsSetTest, toRuntimeMetricsWithInvalidType) {
   ColumnMetricsSet metricsSet;
 
   // Add timing data without type information (INVALID type).
@@ -150,7 +150,7 @@ TEST(ColumnMetricsSetTest, ToRuntimeMetricsWithInvalidType) {
   EXPECT_EQ(result["column_1.INVALID.decompressCPUTimeNanos"].sum, 5'000);
 }
 
-TEST(ColumnMetricsSetTest, ToRuntimeMetricsWithDecodeTime) {
+TEST(ColumnMetricsSetTest, toRuntimeMetricsWithDecodeTime) {
   ColumnMetricsSet metricsSet;
 
   // Add both decompress and decode timing data.
@@ -178,7 +178,7 @@ TEST(ColumnMetricsSetTest, ToRuntimeMetricsWithDecodeTime) {
   EXPECT_EQ(result["column_2.VARCHAR.decodeCPUTimeNanos"].count, 1);
 }
 
-TEST(RuntimeStatisticsTest, ToRuntimeMetricMap) {
+TEST(RuntimeStatisticsTest, toRuntimeMetricMap) {
   RuntimeStatistics stats;
 
   // Empty stats produces empty result.
@@ -213,7 +213,7 @@ TEST(RuntimeStatisticsTest, ToRuntimeMetricMap) {
   EXPECT_EQ(result["column_1.BIGINT.decodeCPUTimeNanos"].count, 1);
 }
 
-TEST(ColumnMetricsSetConcurrencyTest, ConcurrentGetOrCreate) {
+TEST(ColumnMetricsSetConcurrencyTest, concurrentGetOrCreate) {
   ColumnMetricsSet metricsSet;
   constexpr int kNumThreads = 4;
   constexpr int kNumColumns = 10;
@@ -247,7 +247,7 @@ TEST(ColumnMetricsSetConcurrencyTest, ConcurrentGetOrCreate) {
   }
 }
 
-TEST(IoCounterTest, MergeStats) {
+TEST(IoCounterTest, mergeStats) {
   facebook::velox::io::IoCounter counter1;
   counter1.increment(5'000);
   counter1.increment(3'000);
@@ -261,7 +261,7 @@ TEST(IoCounterTest, MergeStats) {
   EXPECT_EQ(counter1.count(), 3);
 }
 
-TEST(ColumnMetricsSetTest, MergeFromWithOverlappingNodeIds) {
+TEST(ColumnMetricsSetTest, mergeFromWithOverlappingNodeIds) {
   ColumnMetricsSet src;
   auto* srcCol1 = src.getOrCreate(1, TypeKind::BIGINT);
   srcCol1->decompressCPUTimeNanos.increment(5'000);
@@ -292,7 +292,7 @@ TEST(ColumnMetricsSetTest, MergeFromWithOverlappingNodeIds) {
   EXPECT_EQ(result["column_2.VARCHAR.decodeCPUTimeNanos"].count, 1);
 }
 
-TEST(ColumnMetricsSetTest, MergeFromWithDisjointNodeIds) {
+TEST(ColumnMetricsSetTest, mergeFromWithDisjointNodeIds) {
   ColumnMetricsSet src;
   auto* srcCol3 = src.getOrCreate(3, TypeKind::DOUBLE);
   srcCol3->decompressCPUTimeNanos.increment(3'000);
@@ -318,7 +318,7 @@ TEST(ColumnMetricsSetTest, MergeFromWithDisjointNodeIds) {
   EXPECT_EQ(result["column_4.BOOLEAN.decompressCPUTimeNanos"].sum, 4'000);
 }
 
-TEST(ColumnMetricsSetTest, MergeFromEmpty) {
+TEST(ColumnMetricsSetTest, mergeFromEmpty) {
   ColumnMetricsSet nonEmpty;
   auto* col = nonEmpty.getOrCreate(1, TypeKind::BIGINT);
   col->decompressCPUTimeNanos.increment(5'000);
@@ -339,7 +339,7 @@ TEST(ColumnMetricsSetTest, MergeFromEmpty) {
   EXPECT_EQ(result["column_1.BIGINT.decompressCPUTimeNanos"].sum, 5'000);
 }
 
-TEST(ColumnReaderStatisticsTest, MergeFromWithColumnMetrics) {
+TEST(ColumnReaderStatisticsTest, mergeFromWithColumnMetrics) {
   ColumnReaderStatistics src;
   src.flattenStringDictionaryValues = 100;
   src.columnMetricsSet.emplace();
@@ -359,7 +359,7 @@ TEST(ColumnReaderStatisticsTest, MergeFromWithColumnMetrics) {
   EXPECT_EQ(result["column_1.BIGINT.decompressCPUTimeNanos"].sum, 1'000);
 }
 
-TEST(ColumnReaderStatisticsTest, MergeFromBothWithColumnMetrics) {
+TEST(ColumnReaderStatisticsTest, mergeFromBothWithColumnMetrics) {
   ColumnReaderStatistics src;
   src.flattenStringDictionaryValues = 100;
   src.columnMetricsSet.emplace();
@@ -382,7 +382,7 @@ TEST(ColumnReaderStatisticsTest, MergeFromBothWithColumnMetrics) {
   EXPECT_EQ(result["column_1.BIGINT.decompressCPUTimeNanos"].sum, 3'000);
 }
 
-TEST(ColumnReaderStatisticsTest, MergeFromWithoutColumnMetrics) {
+TEST(ColumnReaderStatisticsTest, mergeFromWithoutColumnMetrics) {
   ColumnReaderStatistics src;
   src.flattenStringDictionaryValues = 100;
 

--- a/velox/dwio/common/tests/DataBufferTests.cpp
+++ b/velox/dwio/common/tests/DataBufferTests.cpp
@@ -36,7 +36,7 @@ class DataBufferTest : public testing::Test {
   const std::shared_ptr<MemoryPool> pool_ = memoryManager()->addLeafPool();
 };
 
-TEST_F(DataBufferTest, ZeroOut) {
+TEST_F(DataBufferTest, zeroOut) {
   const uint8_t VALUE = 13;
   DataBuffer<uint8_t> buffer(*pool_, 16);
   for (auto i = 0; i < buffer.size(); i++) {
@@ -64,7 +64,7 @@ TEST_F(DataBufferTest, ZeroOut) {
   }
 }
 
-TEST_F(DataBufferTest, At) {
+TEST_F(DataBufferTest, at) {
   DataBuffer<uint8_t> buffer{*pool_};
   for (auto i = 0; i != 15; ++i) {
     buffer.append(i);
@@ -84,7 +84,7 @@ TEST_F(DataBufferTest, At) {
   }
 }
 
-TEST_F(DataBufferTest, Reset) {
+TEST_F(DataBufferTest, reset) {
   DataBuffer<uint8_t> buffer{*pool_};
   buffer.reserve(16);
   for (auto i = 0; i != 15; ++i) {
@@ -138,7 +138,7 @@ TEST_F(DataBufferTest, Reset) {
   }
 }
 
-TEST_F(DataBufferTest, Wrap) {
+TEST_F(DataBufferTest, wrap) {
   auto size = 26;
   auto buffer = velox::AlignedBuffer::allocate<char>(size, pool_.get());
   auto raw = buffer->asMutable<char>();
@@ -154,7 +154,7 @@ TEST_F(DataBufferTest, Wrap) {
   }
 }
 
-TEST_F(DataBufferTest, Move) {
+TEST_F(DataBufferTest, move) {
   {
     DataBuffer<uint8_t> buffer{*pool_};
     buffer.reserve(16);

--- a/velox/dwio/common/tests/ExecutorBarrierTest.cpp
+++ b/velox/dwio/common/tests/ExecutorBarrierTest.cpp
@@ -22,7 +22,7 @@
 using namespace ::testing;
 using namespace ::facebook::velox::dwio::common;
 
-TEST(ExecutorBarrierTest, GetNumPriorities) {
+TEST(ExecutorBarrierTest, getNumPriorities) {
   const uint8_t kNumPriorities = 5;
   auto executor =
       std::make_shared<folly::CPUThreadPoolExecutor>(10, kNumPriorities);
@@ -30,7 +30,7 @@ TEST(ExecutorBarrierTest, GetNumPriorities) {
   EXPECT_EQ(barrier->getNumPriorities(), kNumPriorities);
 }
 
-TEST(ExecutorBarrierTest, CanOwn) {
+TEST(ExecutorBarrierTest, canOwn) {
   auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
   {
     auto barrier = std::make_shared<ExecutorBarrier>(executor);
@@ -39,7 +39,7 @@ TEST(ExecutorBarrierTest, CanOwn) {
   EXPECT_EQ(executor.use_count(), 1);
 }
 
-TEST(ExecutorBarrierTest, CanAwaitMultipleTimes) {
+TEST(ExecutorBarrierTest, canAwaitMultipleTimes) {
   auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
   auto barrier = std::make_shared<ExecutorBarrier>(executor);
   for (int time = 0, multipleTimes = 10; time < multipleTimes; ++time) {
@@ -47,7 +47,7 @@ TEST(ExecutorBarrierTest, CanAwaitMultipleTimes) {
   }
 }
 
-TEST(ExecutorBarrierTest, AddCanBeReused) {
+TEST(ExecutorBarrierTest, addCanBeReused) {
   auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
   auto barrier = std::make_shared<ExecutorBarrier>(executor);
 
@@ -66,7 +66,7 @@ TEST(ExecutorBarrierTest, AddCanBeReused) {
   EXPECT_EQ(count, (2 * kCalls));
 }
 
-TEST(ExecutorBarrierTest, AddWithPriorityCanBeReused) {
+TEST(ExecutorBarrierTest, addWithPriorityCanBeReused) {
   auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
   auto barrier = std::make_shared<ExecutorBarrier>(executor);
 
@@ -86,7 +86,7 @@ TEST(ExecutorBarrierTest, AddWithPriorityCanBeReused) {
   EXPECT_EQ(count, (2 * kCalls));
 }
 
-TEST(ExecutorBarrierTest, AddCanBeReusedAfterException) {
+TEST(ExecutorBarrierTest, addCanBeReusedAfterException) {
   auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
   auto barrier = std::make_shared<ExecutorBarrier>(executor);
 
@@ -108,7 +108,7 @@ TEST(ExecutorBarrierTest, AddCanBeReusedAfterException) {
   EXPECT_EQ(count, (2 * kCalls));
 }
 
-TEST(ExecutorBarrierTest, AddWithPriorityCanBeReusedAfterException) {
+TEST(ExecutorBarrierTest, addWithPriorityCanBeReusedAfterException) {
   auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
   auto barrier = std::make_shared<ExecutorBarrier>(executor);
 
@@ -133,7 +133,7 @@ TEST(ExecutorBarrierTest, AddWithPriorityCanBeReusedAfterException) {
   EXPECT_EQ(count, (2 * kCalls));
 }
 
-TEST(ExecutorBarrierTest, Add) {
+TEST(ExecutorBarrierTest, add) {
   auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
   auto barrier = std::make_shared<ExecutorBarrier>(executor);
 
@@ -146,7 +146,7 @@ TEST(ExecutorBarrierTest, Add) {
   EXPECT_EQ(count, kCalls);
 }
 
-TEST(ExecutorBarrierTest, AddWithPriority) {
+TEST(ExecutorBarrierTest, addWithPriority) {
   auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
   auto barrier = std::make_shared<ExecutorBarrier>(executor);
 
@@ -160,7 +160,7 @@ TEST(ExecutorBarrierTest, AddWithPriority) {
   EXPECT_EQ(count, kCalls);
 }
 
-TEST(ExecutorBarrierTest, AddCanIgnore) {
+TEST(ExecutorBarrierTest, addCanIgnore) {
   auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
   auto barrier = std::make_shared<ExecutorBarrier>(executor);
 
@@ -171,7 +171,7 @@ TEST(ExecutorBarrierTest, AddCanIgnore) {
   // Discard: barrier->waitAll();
 }
 
-TEST(ExecutorBarrierTest, AddWithPriorityCanIgnore) {
+TEST(ExecutorBarrierTest, addWithPriorityCanIgnore) {
   auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
   auto barrier = std::make_shared<ExecutorBarrier>(executor);
 
@@ -182,7 +182,7 @@ TEST(ExecutorBarrierTest, AddWithPriorityCanIgnore) {
   // Discard: barrier->waitAll();
 }
 
-TEST(ExecutorBarrierTest, DestructorDoesntThrow) {
+TEST(ExecutorBarrierTest, destructorDoesntThrow) {
   const int kCalls = 30;
   std::atomic<int> count{0};
   {
@@ -201,7 +201,7 @@ TEST(ExecutorBarrierTest, DestructorDoesntThrow) {
   EXPECT_EQ(count, kCalls);
 }
 
-TEST(ExecutorBarrierTest, AddException) {
+TEST(ExecutorBarrierTest, addException) {
   auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
   auto barrier = std::make_shared<ExecutorBarrier>(executor);
 
@@ -219,7 +219,7 @@ TEST(ExecutorBarrierTest, AddException) {
   EXPECT_EQ(count, kCalls);
 }
 
-TEST(ExecutorBarrierTest, AddWithPriorityException) {
+TEST(ExecutorBarrierTest, addWithPriorityException) {
   auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
   auto barrier = std::make_shared<ExecutorBarrier>(executor);
 
@@ -240,7 +240,7 @@ TEST(ExecutorBarrierTest, AddWithPriorityException) {
   EXPECT_EQ(count, kCalls);
 }
 
-TEST(ExecutorBarrierTest, AddNonStdException) {
+TEST(ExecutorBarrierTest, addNonStdException) {
   auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
   auto barrier = std::make_shared<ExecutorBarrier>(executor);
 
@@ -259,7 +259,7 @@ TEST(ExecutorBarrierTest, AddNonStdException) {
   EXPECT_EQ(count, kCalls);
 }
 
-TEST(ExecutorBarrierTest, AddWithPriorityNonStdException) {
+TEST(ExecutorBarrierTest, addWithPriorityNonStdException) {
   auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
   auto barrier = std::make_shared<ExecutorBarrier>(executor);
 
@@ -281,7 +281,7 @@ TEST(ExecutorBarrierTest, AddWithPriorityNonStdException) {
   EXPECT_EQ(count, kCalls);
 }
 
-TEST(ExecutorBarrierTest, AddExceptions) {
+TEST(ExecutorBarrierTest, addExceptions) {
   auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
   auto barrier = std::make_shared<ExecutorBarrier>(executor);
 
@@ -297,7 +297,7 @@ TEST(ExecutorBarrierTest, AddExceptions) {
   EXPECT_EQ(count, kCalls);
 }
 
-TEST(ExecutorBarrierTest, AddWithPriorityExceptions) {
+TEST(ExecutorBarrierTest, addWithPriorityExceptions) {
   auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
   auto barrier = std::make_shared<ExecutorBarrier>(executor);
 

--- a/velox/dwio/common/tests/MeasureTimeTests.cpp
+++ b/velox/dwio/common/tests/MeasureTimeTests.cpp
@@ -21,18 +21,18 @@
 using namespace ::testing;
 using namespace ::facebook::velox::dwio::common;
 
-TEST(MeasureTimeTests, DoesntCreateMeasureIfNoCallback) {
+TEST(MeasureTimeTests, doesntCreateMeasureIfNoCallback) {
   EXPECT_FALSE(measureTimeIfCallback(nullptr).has_value());
 }
 
-TEST(MeasureTimeTests, CreatesMeasureIfCallback) {
+TEST(MeasureTimeTests, createsMeasureIfCallback) {
   auto callback =
       std::function<void(std::chrono::high_resolution_clock::duration)>(
           [](const auto&) {});
   EXPECT_TRUE(measureTimeIfCallback(callback).has_value());
 }
 
-TEST(MeasureTimeTests, MeasuresTime) {
+TEST(MeasureTimeTests, measuresTime) {
   bool measured{false};
   {
     auto callback =

--- a/velox/dwio/common/tests/OnDemandUnitLoaderTests.cpp
+++ b/velox/dwio/common/tests/OnDemandUnitLoaderTests.cpp
@@ -38,31 +38,31 @@ class OnDemandUnitLoaderCommonTests
   }
 };
 
-TEST_F(OnDemandUnitLoaderCommonTests, NoUnitButSkip) {
+TEST_F(OnDemandUnitLoaderCommonTests, noUnitButSkip) {
   testNoUnitButSkip();
 }
 
-TEST_F(OnDemandUnitLoaderCommonTests, InitialSkip) {
+TEST_F(OnDemandUnitLoaderCommonTests, initialSkip) {
   testInitialSkip();
 }
 
-TEST_F(OnDemandUnitLoaderCommonTests, CanRequestUnitMultipleTimes) {
+TEST_F(OnDemandUnitLoaderCommonTests, canRequestUnitMultipleTimes) {
   testCanRequestUnitMultipleTimes();
 }
 
-TEST_F(OnDemandUnitLoaderCommonTests, UnitOutOfRange) {
+TEST_F(OnDemandUnitLoaderCommonTests, unitOutOfRange) {
   testUnitOutOfRange();
 }
 
-TEST_F(OnDemandUnitLoaderCommonTests, SeekOutOfRange) {
+TEST_F(OnDemandUnitLoaderCommonTests, seekOutOfRange) {
   testSeekOutOfRange();
 }
 
-TEST_F(OnDemandUnitLoaderCommonTests, SeekOutOfRangeReaderError) {
+TEST_F(OnDemandUnitLoaderCommonTests, seekOutOfRangeReaderError) {
   testSeekOutOfRangeReaderError();
 }
 
-TEST(OnDemandUnitLoaderTests, LoadsCorrectlyWithReader) {
+TEST(OnDemandUnitLoaderTests, loadsCorrectlyWithReader) {
   size_t blockedOnIoCount = 0;
   OnDemandUnitLoaderFactory factory([&](auto) { ++blockedOnIoCount; });
   ReaderMock readerMock{{10, 20, 30}, {0, 0, 0}, factory, 0};
@@ -99,7 +99,7 @@ TEST(OnDemandUnitLoaderTests, LoadsCorrectlyWithReader) {
   EXPECT_EQ(blockedOnIoCount, 3);
 }
 
-TEST(OnDemandUnitLoaderTests, LoadsCorrectlyWithNoCallback) {
+TEST(OnDemandUnitLoaderTests, loadsCorrectlyWithNoCallback) {
   OnDemandUnitLoaderFactory factory(nullptr);
   ReaderMock readerMock{{10, 20, 30}, {0, 0, 0}, factory, 0};
   EXPECT_EQ(readerMock.unitsLoaded(), std::vector<bool>({false, false, false}));
@@ -127,7 +127,7 @@ TEST(OnDemandUnitLoaderTests, LoadsCorrectlyWithNoCallback) {
   EXPECT_EQ(readerMock.unitsLoaded(), std::vector<bool>({false, false, true}));
 }
 
-TEST(OnDemandUnitLoaderTests, CanSeek) {
+TEST(OnDemandUnitLoaderTests, canSeek) {
   size_t blockedOnIoCount = 0;
   OnDemandUnitLoaderFactory factory([&](auto) { ++blockedOnIoCount; });
   ReaderMock readerMock{{10, 20, 30}, {0, 0, 0}, factory, 0};

--- a/velox/dwio/common/tests/ParallelForTest.cpp
+++ b/velox/dwio/common/tests/ParallelForTest.cpp
@@ -99,7 +99,7 @@ void testParallelFor(
 
 } // namespace
 
-TEST(ParallelForTest, E2E) {
+TEST(ParallelForTest, e2e) {
   auto inlineExecutor = folly::InlineExecutor::instance();
   for (size_t parallelism = 0; parallelism < 25; ++parallelism) {
     for (size_t begin = 0; begin < 25; ++begin) {
@@ -116,7 +116,7 @@ TEST(ParallelForTest, E2E) {
   }
 }
 
-TEST(ParallelForTest, E2EParallel) {
+TEST(ParallelForTest, e2eParallel) {
   for (size_t parallelism = 1; parallelism < 2; ++parallelism) {
     folly::CPUThreadPoolExecutor executor(parallelism);
     for (size_t begin = 0; begin < 25; ++begin) {
@@ -133,7 +133,7 @@ TEST(ParallelForTest, E2EParallel) {
   }
 }
 
-TEST(ParallelForTest, CanOwnExecutor) {
+TEST(ParallelForTest, canOwnExecutor) {
   auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(2);
   const size_t indexInvokedSize = 100;
   std::unordered_map<size_t, std::atomic<size_t>> indexInvoked;

--- a/velox/dwio/common/tests/ParallelUnitLoaderTest.cpp
+++ b/velox/dwio/common/tests/ParallelUnitLoaderTest.cpp
@@ -37,31 +37,31 @@ class ParallelUnitLoaderTest
       std::make_unique<folly::CPUThreadPoolExecutor>(10);
 };
 
-TEST_F(ParallelUnitLoaderTest, NoUnitButSkip) {
+TEST_F(ParallelUnitLoaderTest, noUnitButSkip) {
   testNoUnitButSkip();
 }
 
-TEST_F(ParallelUnitLoaderTest, InitialSkip) {
+TEST_F(ParallelUnitLoaderTest, initialSkip) {
   testInitialSkip();
 }
 
-TEST_F(ParallelUnitLoaderTest, CanRequestUnitMultipleTimes) {
+TEST_F(ParallelUnitLoaderTest, canRequestUnitMultipleTimes) {
   testCanRequestUnitMultipleTimes();
 }
 
-TEST_F(ParallelUnitLoaderTest, UnitOutOfRange) {
+TEST_F(ParallelUnitLoaderTest, unitOutOfRange) {
   testUnitOutOfRange();
 }
 
-TEST_F(ParallelUnitLoaderTest, SeekOutOfRange) {
+TEST_F(ParallelUnitLoaderTest, seekOutOfRange) {
   testSeekOutOfRange();
 }
 
-TEST_F(ParallelUnitLoaderTest, SeekOutOfRangeReaderError) {
+TEST_F(ParallelUnitLoaderTest, seekOutOfRangeReaderError) {
   testSeekOutOfRangeReaderError();
 }
 
-TEST_F(ParallelUnitLoaderTest, LoadsCorrectlyWithReader) {
+TEST_F(ParallelUnitLoaderTest, loadsCorrectlyWithReader) {
   auto factory = createFactory();
   ReaderMock readerMock{{10, 20, 30}, {0, 0, 0}, factory, 0};
 
@@ -92,7 +92,7 @@ TEST_F(ParallelUnitLoaderTest, LoadsCorrectlyWithReader) {
 }
 
 // Performance comparison test
-TEST_F(ParallelUnitLoaderTest, PerformanceComparison) {
+TEST_F(ParallelUnitLoaderTest, performanceComparison) {
   std::vector<uint64_t> rowsPerUnit = {100, 100, 100, 100, 100, 100, 100, 100};
   std::vector<uint64_t> ioSizes = {
       1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024};

--- a/velox/dwio/common/tests/RangeTests.cpp
+++ b/velox/dwio/common/tests/RangeTests.cpp
@@ -23,7 +23,7 @@ using namespace ::testing;
 
 namespace facebook::velox::common {
 
-TEST(RangeTests, Add) {
+TEST(RangeTests, add) {
   Ranges ranges;
   VELOX_ASSERT_THROW(ranges.add(2, 1), "");
   ranges.add(2, 2);
@@ -50,7 +50,7 @@ TEST(RangeTests, Add) {
   ASSERT_EQ(ranges.size(), 0);
 }
 
-TEST(RangeTests, ForEach) {
+TEST(RangeTests, forEach) {
   Ranges ranges;
   ranges.add(1, 3);
   ranges.add(6, 9);
@@ -62,7 +62,7 @@ TEST(RangeTests, ForEach) {
   ASSERT_EQ(total, 24);
 }
 
-TEST(RangeTests, Filter) {
+TEST(RangeTests, filter) {
   auto r = Ranges::of(1, 10);
   auto r2 = r.filter([](auto /* unused */) { return true; });
   ASSERT_EQ(r2.size(), 9);

--- a/velox/dwio/common/tests/ReadFileInputStreamTests.cpp
+++ b/velox/dwio/common/tests/ReadFileInputStreamTests.cpp
@@ -35,7 +35,7 @@ class ReadFileInputStreamTest : public testing::Test {
   }
 };
 
-TEST_F(ReadFileInputStreamTest, LocalReadFile) {
+TEST_F(ReadFileInputStreamTest, localReadFile) {
   auto tempFile = TempFilePath::create();
   const auto& filename = tempFile->getPath();
   remove(filename.c_str());
@@ -66,7 +66,7 @@ TEST_F(ReadFileInputStreamTest, LocalReadFile) {
   remove(filename.c_str());
 }
 
-TEST(ReadFileInputStream, SimpleUsage) {
+TEST(ReadFileInputStream, simpleUsage) {
   std::string fileData;
   {
     InMemoryWriteFile writeFile(&fileData);
@@ -88,7 +88,7 @@ TEST(ReadFileInputStream, SimpleUsage) {
   ASSERT_EQ(read_value, "aaaaabbbbbccccc");
 }
 
-TEST(ReadFileInputStream, VReadIOBufs) {
+TEST(ReadFileInputStream, vReadIOBufs) {
   std::string fileData;
   {
     InMemoryWriteFile writeFile(&fileData);

--- a/velox/dwio/common/tests/UnitLoaderToolsTests.cpp
+++ b/velox/dwio/common/tests/UnitLoaderToolsTests.cpp
@@ -24,7 +24,7 @@ using namespace ::testing;
 using namespace ::facebook::velox::dwio::common;
 using namespace ::facebook::velox::dwio::common::unit_loader_tools;
 
-TEST(UnitLoaderToolsTests, NoCallbacksCreated) {
+TEST(UnitLoaderToolsTests, noCallbacksCreated) {
   std::atomic_size_t callCount = 0;
   {
     CallbackOnLastSignal callback([&callCount]() { ++callCount; });
@@ -33,13 +33,13 @@ TEST(UnitLoaderToolsTests, NoCallbacksCreated) {
   EXPECT_EQ(callCount, 1);
 }
 
-TEST(UnitLoaderToolsTests, SupportsNullCallbacks) {
+TEST(UnitLoaderToolsTests, supportsNullCallbacks) {
   CallbackOnLastSignal callback(nullptr);
   auto cb = callback.getCallback();
   EXPECT_TRUE(cb == nullptr);
 }
 
-TEST(UnitLoaderToolsTests, NoExplicitCalls) {
+TEST(UnitLoaderToolsTests, noExplicitCalls) {
   std::atomic_size_t callCount = 0;
   {
     CallbackOnLastSignal callback([&callCount]() { ++callCount; });
@@ -62,7 +62,7 @@ TEST(UnitLoaderToolsTests, NoExplicitCalls) {
   EXPECT_EQ(callCount, 1);
 }
 
-TEST(UnitLoaderToolsTests, NoExplicitCallsFactoryDeletedFirst) {
+TEST(UnitLoaderToolsTests, noExplicitCallsFactoryDeletedFirst) {
   std::atomic_size_t callCount = 0;
   {
     std::function<void()> c1, c2;
@@ -79,7 +79,7 @@ TEST(UnitLoaderToolsTests, NoExplicitCallsFactoryDeletedFirst) {
   EXPECT_EQ(callCount, 1);
 }
 
-TEST(UnitLoaderToolsTests, ExplicitCalls) {
+TEST(UnitLoaderToolsTests, explicitCalls) {
   std::atomic_size_t callCount = 0;
   {
     CallbackOnLastSignal callback([&callCount]() { ++callCount; });
@@ -109,7 +109,7 @@ TEST(UnitLoaderToolsTests, ExplicitCalls) {
   EXPECT_EQ(callCount, 1);
 }
 
-TEST(UnitLoaderToolsTests, WillOnlyCallbackOnce) {
+TEST(UnitLoaderToolsTests, willOnlyCallbackOnce) {
   std::atomic_size_t callCount = 0;
   {
     CallbackOnLastSignal callback([&callCount]() { ++callCount; });
@@ -144,7 +144,7 @@ TEST(UnitLoaderToolsTests, WillOnlyCallbackOnce) {
   EXPECT_EQ(callCount, 1);
 }
 
-TEST(UnitLoaderToolsTests, HowMuchToSkip) {
+TEST(UnitLoaderToolsTests, howMuchToSkip) {
   // Helpers
   auto testSkip = [](uint64_t rowsToSkip, std::vector<uint64_t> rowCount) {
     return howMuchToSkip(rowsToSkip, rowCount.cbegin(), rowCount.cend());

--- a/velox/dwio/dwrf/common/IntEncoder.h
+++ b/velox/dwio/dwrf/common/IntEncoder.h
@@ -233,7 +233,7 @@ class IntEncoder {
   FOLLY_ALWAYS_INLINE int32_t writeVslong(int64_t value, char* buffer);
   FOLLY_ALWAYS_INLINE int32_t writeLongLE(int64_t value, char* buffer);
 
-  VELOX_FRIEND_TEST(TestIntEncoder, TestVarIntEncoder);
+  VELOX_FRIEND_TEST(TestIntEncoder, testVarIntEncoder);
 };
 
 #define WRITE_INTS(FUNC)                                       \

--- a/velox/dwio/dwrf/reader/StripeDictionaryCache.h
+++ b/velox/dwio/dwrf/reader/StripeDictionaryCache.h
@@ -59,7 +59,7 @@ class StripeDictionaryCache {
       EncodingKeyHash>
       intDictionaryFactories_;
 
-  VELOX_FRIEND_TEST(StripeDictionaryCacheTest, RegisterDictionary);
+  VELOX_FRIEND_TEST(StripeDictionaryCacheTest, registerDictionary);
 };
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/test/ChecksumTests.cpp
+++ b/velox/dwio/dwrf/test/ChecksumTests.cpp
@@ -46,7 +46,7 @@ class ChecksumTests : public Test {
   std::array<char, 4096> data;
 };
 
-TEST_F(ChecksumTests, Null) {
+TEST_F(ChecksumTests, null) {
   auto checksum = ChecksumFactory::create(proto::ChecksumAlgorithm::NULL_);
   ASSERT_EQ(checksum, nullptr);
 }
@@ -58,6 +58,6 @@ TEST_F(ChecksumTests, xxHash) {
       2625948533963027735);
 }
 
-TEST_F(ChecksumTests, Crc32) {
+TEST_F(ChecksumTests, crc32) {
   runTest(proto::ChecksumAlgorithm::CRC32, 4133052486, 3074245904);
 }

--- a/velox/dwio/dwrf/test/ColumnWriterIndexTest.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterIndexTest.cpp
@@ -436,7 +436,7 @@ class TimestampWriterIndexTest : public testing::Test,
   // is sufficient
 };
 
-TEST_F(TimestampWriterIndexTest, TestIndex) {
+TEST_F(TimestampWriterIndexTest, testIndex) {
   // Present Stream has 4. seconds and nanos are Ints with 3 each.
   // 4+3+3 = 10. There is no backfill.
   runTest(2, 10, 0, 0);
@@ -476,7 +476,7 @@ VELOX_TYPED_TEST_SUITE(
     IntegerColumnWriterDictionaryEncodingIndexTest,
     DictionaryTypes);
 
-TYPED_TEST(IntegerColumnWriterDictionaryEncodingIndexTest, WriteAllStreams) {
+TYPED_TEST(IntegerColumnWriterDictionaryEncodingIndexTest, writeAllStreams) {
   // Present stream uses 4 positions.
   // compressed size, uncompressed size, ByteRLE numLiterals,
   // Boolean 8-bitsRemaining
@@ -492,7 +492,7 @@ TYPED_TEST(IntegerColumnWriterDictionaryEncodingIndexTest, WriteAllStreams) {
   this->runTest(1, RECORD_POSITION_COUNT, BACKFILL_POSITION_COUNT, 100);
 }
 
-TYPED_TEST(IntegerColumnWriterDictionaryEncodingIndexTest, OmitInDictStream) {
+TYPED_TEST(IntegerColumnWriterDictionaryEncodingIndexTest, omitInDictStream) {
   // Present stream uses 4 positions.
   // compressed size, uncompressed size, ByteRLE numLiterals,
   // Boolean 8-bitsRemaining
@@ -533,7 +533,7 @@ class BoolColumnWriterEncodingIndexTest : public testing::Test,
   }
 };
 
-TEST_F(BoolColumnWriterEncodingIndexTest, TestIndex) {
+TEST_F(BoolColumnWriterEncodingIndexTest, testIndex) {
   // Boolean Stream uses one Stream for Presence and Other Stream for data
   // Each Stream has compressed size, uncompressed size, ByteRLE numLiterals,
   // Boolean 8-bitsRemaining , so 4+4 =8. It has no back fill streams.
@@ -569,7 +569,7 @@ class ByteColumnWriterEncodingIndexTest : public testing::Test,
   }
 };
 
-TEST_F(ByteColumnWriterEncodingIndexTest, TestIndex) {
+TEST_F(ByteColumnWriterEncodingIndexTest, testIndex) {
   // Byte Stream has presence Stream and data stream.
   // Present Stream has compressed size, uncompressed size, ByteRLE numLiterals,
   // Boolean 8-bitsRemaining (4)
@@ -630,7 +630,7 @@ class BinaryColumnWriterEncodingIndexTest : public testing::Test,
   }
 };
 
-TEST_F(BinaryColumnWriterEncodingIndexTest, TestIndex) {
+TEST_F(BinaryColumnWriterEncodingIndexTest, testIndex) {
   // Binary Stream has present, data and length.
   // Present Stream has compressed size, uncompressed size, ByteRLE numLiterals,
   // Boolean 8-bitsRemaining (4)
@@ -674,7 +674,7 @@ class FloatColumnWriterEncodingIndexTest : public testing::Test,
 using FloatTypes = ::testing::Types<float, double>;
 VELOX_TYPED_TEST_SUITE(FloatColumnWriterEncodingIndexTest, FloatTypes);
 
-TYPED_TEST(FloatColumnWriterEncodingIndexTest, TestIndex) {
+TYPED_TEST(FloatColumnWriterEncodingIndexTest, testIndex) {
   // Float Stream has present and data.
   // Present Stream has compressed size, uncompressed size, ByteRLE numLiterals,
   // Boolean 8-bitsRemaining (4)
@@ -868,7 +868,7 @@ class IntegerColumnWriterDirectEncodingIndexTest : public testing::Test {
   bool abandonDict_;
 };
 
-TEST_F(IntegerColumnWriterDirectEncodingIndexTest, ConvertFromDictionary) {
+TEST_F(IntegerColumnWriterDirectEncodingIndexTest, convertFromDictionary) {
   testForAllTypes(1, 6, 0);
   testForAllTypes(10, 6, 0);
   // 6 positions: {PRESENT, 4}, {DATA, 2}
@@ -876,7 +876,7 @@ TEST_F(IntegerColumnWriterDirectEncodingIndexTest, ConvertFromDictionary) {
   testForAllTypes(10, 6, 1);
 }
 
-TEST_F(IntegerColumnWriterDirectEncodingIndexTest, DirectWrites) {
+TEST_F(IntegerColumnWriterDirectEncodingIndexTest, directWrites) {
   // Same 6 positions but recorded at different points in time.
   testForAllTypes(1, 6, 2);
   testForAllTypes(10, 6, 100);
@@ -889,7 +889,7 @@ class IntegerColumnWriterAbandonDictionaryIndexTest
       : IntegerColumnWriterDirectEncodingIndexTest{true} {}
 };
 
-TEST_F(IntegerColumnWriterAbandonDictionaryIndexTest, AbandonDictionary) {
+TEST_F(IntegerColumnWriterAbandonDictionaryIndexTest, abandonDictionary) {
   testForAllTypes(1, 6, 0, abandonEveryWrite);
   testForAllTypes(10, 6, 0, abandonEveryWrite);
   // 6 positions: {PRESENT, 4}, {DATA, 2}
@@ -993,7 +993,7 @@ class StringColumnWriterDictionaryEncodingIndexTest : public testing::Test {
   std::shared_ptr<Config> config_;
 };
 
-TEST_F(StringColumnWriterDictionaryEncodingIndexTest, WriteAllStreams) {
+TEST_F(StringColumnWriterDictionaryEncodingIndexTest, writeAllStreams) {
   runTest(1, 17, 0);
   // 17 positions: {PRESENT, 4}, {STRIDE_DICT_DATA, 2}, {STRIDE_DICT_LENGTH, 3},
   // {stride dict size, 1}, {IN_DICTIONARY, 4}, {DATA, 3}
@@ -1001,7 +1001,7 @@ TEST_F(StringColumnWriterDictionaryEncodingIndexTest, WriteAllStreams) {
   runTest(1, 17, 100);
 }
 
-TEST_F(StringColumnWriterDictionaryEncodingIndexTest, OmitInDictStream) {
+TEST_F(StringColumnWriterDictionaryEncodingIndexTest, omitInDictStream) {
   runTest(2, 7, 0);
   // Writing the batch twice so that all values are in dictionary.
   // 7 positions: {PRESENT, 4}, {DATA, 3}
@@ -1179,7 +1179,7 @@ class StringColumnWriterDirectEncodingIndexTest : public testing::Test {
   bool abandonDict_;
 };
 
-TEST_F(StringColumnWriterDirectEncodingIndexTest, ConvertFromDictionary) {
+TEST_F(StringColumnWriterDirectEncodingIndexTest, convertFromDictionary) {
   runTest(1, 9, 0);
   runTest(10, 9, 0);
   // 9 positions: {PRESENT, 4}, {DATA, 2}, {DATA_LENGTH, 3}
@@ -1187,7 +1187,7 @@ TEST_F(StringColumnWriterDirectEncodingIndexTest, ConvertFromDictionary) {
   runTest(10, 9, 1);
 }
 
-TEST_F(StringColumnWriterDirectEncodingIndexTest, DirectWrites) {
+TEST_F(StringColumnWriterDirectEncodingIndexTest, directWrites) {
   // Same 9 positions but recorded at different points in time.
   runTest(1, 9, 2);
   runTest(10, 9, 100);
@@ -1200,7 +1200,7 @@ class StringColumnWriterAbandonDictionaryIndexTest
       : StringColumnWriterDirectEncodingIndexTest{true} {}
 };
 
-TEST_F(StringColumnWriterAbandonDictionaryIndexTest, AbandonDictionary) {
+TEST_F(StringColumnWriterAbandonDictionaryIndexTest, abandonDictionary) {
   runTest(1, 9, 0, abandonEveryWrite);
   runTest(10, 9, 0, abandonEveryWrite);
   // 9 positions: {PRESENT, 4}, {DATA, 2}, {DATA_LENGTH, 3}
@@ -1268,7 +1268,7 @@ class ListColumnWriterEncodingIndexTest : public testing::Test,
   }
 };
 
-TEST_F(ListColumnWriterEncodingIndexTest, TestIndex) {
+TEST_F(ListColumnWriterEncodingIndexTest, testIndex) {
   // List Stream has present and length.
   // Present Stream has compressed size, uncompressed size, ByteRLE numLiterals,
   // Boolean 8-bitsRemaining (4)
@@ -1343,7 +1343,7 @@ class MapColumnWriterEncodingIndexTest : public testing::Test,
   }
 };
 
-TEST_F(MapColumnWriterEncodingIndexTest, TestIndex) {
+TEST_F(MapColumnWriterEncodingIndexTest, testIndex) {
   // Map Stream has present and length.
   // Present Stream has compressed size, uncompressed size, ByteRLE numLiterals,
   // Boolean 8-bitsRemaining (4)
@@ -1433,7 +1433,7 @@ class FlatMapColumnWriterEncodingIndexTest : public testing::Test,
   }
 };
 
-TEST_F(FlatMapColumnWriterEncodingIndexTest, TestIndex) {
+TEST_F(FlatMapColumnWriterEncodingIndexTest, testIndex) {
   config_->set(Config::FLATTEN_MAP, true);
   config_->set(Config::MAP_FLAT_COLS, {0});
 
@@ -1495,7 +1495,7 @@ class StructColumnWriterEncodingIndexTest : public testing::Test,
   }
 };
 
-TEST_F(StructColumnWriterEncodingIndexTest, TestIndex) {
+TEST_F(StructColumnWriterEncodingIndexTest, testIndex) {
   // Struct Stream has present stream
   // Present Stream has compressed size, uncompressed size, ByteRLE numLiterals,
   // Boolean 8-bitsRemaining (4)

--- a/velox/dwio/dwrf/test/ColumnWriterStatsTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterStatsTests.cpp
@@ -255,7 +255,7 @@ VectorPtr makeFlatVector(
   return flatVector;
 }
 
-TEST_F(ColumnWriterStatsTest, Bool) {
+TEST_F(ColumnWriterStatsTest, bool) {
   auto populateBoolBatch =
       [](MemoryPool& pool, VectorPtr* vector, size_t size) {
         BufferPtr nulls = allocateNulls(size, &pool);
@@ -281,7 +281,7 @@ TEST_F(ColumnWriterStatsTest, Bool) {
   verifyTypeStats("struct<bool_val:boolean>", populateBoolBatch);
 }
 
-TEST_F(ColumnWriterStatsTest, TinyInt) {
+TEST_F(ColumnWriterStatsTest, tinyInt) {
   auto populateTinyIntBatch =
       [](MemoryPool& pool, VectorPtr* vector, size_t size) {
         BufferPtr nulls = allocateNulls(size, &pool);
@@ -307,7 +307,7 @@ TEST_F(ColumnWriterStatsTest, TinyInt) {
   verifyTypeStats("struct<byte_val:tinyint>", populateTinyIntBatch);
 }
 
-TEST_F(ColumnWriterStatsTest, SmallInt) {
+TEST_F(ColumnWriterStatsTest, smallInt) {
   auto populateSmallIntBatch =
       [](MemoryPool& pool, VectorPtr* vector, size_t size) {
         BufferPtr nulls = allocateNulls(size, &pool);
@@ -335,7 +335,7 @@ TEST_F(ColumnWriterStatsTest, SmallInt) {
   verifyTypeStats("struct<small_val:smallint>", populateSmallIntBatch);
 }
 
-TEST_F(ColumnWriterStatsTest, Int) {
+TEST_F(ColumnWriterStatsTest, int) {
   auto populateIntBatch = [](MemoryPool& pool, VectorPtr* vector, size_t size) {
     BufferPtr nulls = allocateNulls(size, &pool);
     auto* nullsPtr = nulls->asMutable<uint64_t>();
@@ -362,7 +362,7 @@ TEST_F(ColumnWriterStatsTest, Int) {
   verifyTypeStats("struct<int_val:int>", populateIntBatch);
 }
 
-TEST_F(ColumnWriterStatsTest, Long) {
+TEST_F(ColumnWriterStatsTest, long) {
   auto populateLongBatch =
       [](MemoryPool& pool, VectorPtr* vector, size_t size) {
         BufferPtr nulls = allocateNulls(size, &pool);
@@ -413,11 +413,11 @@ auto populateFloatBatch = [](MemoryPool& pool, VectorPtr* vector, size_t size) {
   return std::vector<size_t>{totalSize, totalSize};
 };
 
-TEST_F(ColumnWriterStatsTest, Float) {
+TEST_F(ColumnWriterStatsTest, float) {
   verifyTypeStats("struct<float_val:float>", populateFloatBatch);
 }
 
-TEST_F(ColumnWriterStatsTest, Double) {
+TEST_F(ColumnWriterStatsTest, double) {
   auto populateDoubleBatch =
       [](MemoryPool& pool, VectorPtr* vector, size_t size) {
         BufferPtr nulls = allocateNulls(size, &pool);
@@ -445,7 +445,7 @@ TEST_F(ColumnWriterStatsTest, Double) {
   verifyTypeStats("struct<long_val:double>", populateDoubleBatch);
 }
 
-TEST_F(ColumnWriterStatsTest, String) {
+TEST_F(ColumnWriterStatsTest, string) {
   auto populateStringBatch =
       [](MemoryPool& pool, VectorPtr* vector, size_t size) {
         std::mt19937 gen{};
@@ -465,7 +465,7 @@ TEST_F(ColumnWriterStatsTest, String) {
   verifyTypeStats("struct<string_val:string>", populateStringBatch);
 }
 
-TEST_F(ColumnWriterStatsTest, Binary) {
+TEST_F(ColumnWriterStatsTest, binary) {
   auto populateBinaryBatch =
       [](MemoryPool& pool, VectorPtr* vector, size_t size) {
         std::mt19937 gen{};
@@ -485,7 +485,7 @@ TEST_F(ColumnWriterStatsTest, Binary) {
   verifyTypeStats("struct<binary_val:binary>", populateBinaryBatch);
 }
 
-TEST_F(ColumnWriterStatsTest, Timestamp) {
+TEST_F(ColumnWriterStatsTest, timestamp) {
   auto populateTimestampBatch = [](MemoryPool& pool,
                                    VectorPtr* vector,
                                    size_t size) {
@@ -514,7 +514,7 @@ TEST_F(ColumnWriterStatsTest, Timestamp) {
   verifyTypeStats("struct<timestamp_val:timestamp>", populateTimestampBatch);
 }
 
-TEST_F(ColumnWriterStatsTest, List) {
+TEST_F(ColumnWriterStatsTest, list) {
   auto populateListBatch = [](MemoryPool& pool,
                               VectorPtr* vector,
                               size_t size) {
@@ -560,7 +560,7 @@ TEST_F(ColumnWriterStatsTest, List) {
   verifyTypeStats("struct<array_val:array<float>>", populateListBatch);
 }
 
-TEST_F(ColumnWriterStatsTest, Map) {
+TEST_F(ColumnWriterStatsTest, map) {
   auto populateMapBatch = [](MemoryPool& pool, VectorPtr* vector, size_t size) {
     BufferPtr nulls = allocateNulls(size, &pool);
     auto* nullsPtr = nulls->asMutable<uint64_t>();
@@ -615,7 +615,7 @@ TEST_F(ColumnWriterStatsTest, Map) {
       "struct<map_val:map<int,float>>", populateMapBatch, FLAT_MAP_COL_ID);
 }
 
-TEST_F(ColumnWriterStatsTest, Struct) {
+TEST_F(ColumnWriterStatsTest, struct) {
   auto populateStructBatch =
       [](MemoryPool& pool, VectorPtr* vector, size_t size) {
         BufferPtr nulls = allocateNulls(size, &pool);

--- a/velox/dwio/dwrf/test/ColumnWriterTest.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTest.cpp
@@ -406,7 +406,7 @@ class ColumnWriterTest : public Test {
   std::shared_ptr<MemoryPool> pool_ = memoryManager()->addLeafPool();
 };
 
-TEST_F(ColumnWriterTest, LowMemoryModeConfig) {
+TEST_F(ColumnWriterTest, lowMemoryModeConfig) {
   auto dataTypeWithId = TypeWithId::create(std::make_shared<VarcharType>(), 1);
   auto config = std::make_shared<Config>();
   WriterContext context{config, memory::memoryManager()->addRootPool()};
@@ -415,7 +415,7 @@ TEST_F(ColumnWriterTest, LowMemoryModeConfig) {
   EXPECT_TRUE(writer->useDictionaryEncoding());
 }
 
-TEST_F(ColumnWriterTest, IntegerDictionaryEncodingEnabledConfig) {
+TEST_F(ColumnWriterTest, integerDictionaryEncodingEnabledConfig) {
   auto dataTypeWithId = TypeWithId::create(INTEGER(), 1);
   auto config = std::make_shared<Config>();
   config->set(Config::INTEGER_DICTIONARY_ENCODING_ENABLED, true);
@@ -430,7 +430,7 @@ TEST_F(ColumnWriterTest, IntegerDictionaryEncodingEnabledConfig) {
   EXPECT_FALSE(writer->useDictionaryEncoding());
 }
 
-TEST_F(ColumnWriterTest, StringDictionaryEncodingEnabledConfig) {
+TEST_F(ColumnWriterTest, stringDictionaryEncodingEnabledConfig) {
   auto dataTypeWithId = TypeWithId::create(VARCHAR(), 1);
   auto config = std::make_shared<Config>();
   config->set(Config::STRING_DICTIONARY_ENCODING_ENABLED, true);
@@ -445,7 +445,7 @@ TEST_F(ColumnWriterTest, StringDictionaryEncodingEnabledConfig) {
   EXPECT_FALSE(writer->useDictionaryEncoding());
 }
 
-TEST_F(ColumnWriterTest, TestBooleanWriter) {
+TEST_F(ColumnWriterTest, testBooleanWriter) {
   std::vector<std::optional<bool>> data;
   for (auto i = 0; i < ITERATIONS; ++i) {
     bool value = (bool)(Random::rand32() & 1);
@@ -457,7 +457,7 @@ TEST_F(ColumnWriterTest, TestBooleanWriter) {
   testDataTypeWriter(BOOLEAN(), data, 3);
 }
 
-TEST_F(ColumnWriterTest, TestNullBooleanWriter) {
+TEST_F(ColumnWriterTest, testNullBooleanWriter) {
   std::vector<std::optional<bool>> data;
   for (auto i = 0; i < ITERATIONS; ++i) {
     data.emplace_back();
@@ -502,7 +502,7 @@ TEST_F(ColumnWriterTest, testDecimalWriter) {
   testDataTypeWriter(DECIMAL(38, 4), longValues, /*sequence=*/0, format);
 }
 
-TEST_F(ColumnWriterTest, TestTimestampEpochWriter) {
+TEST_F(ColumnWriterTest, testTimestampEpochWriter) {
   std::vector<std::optional<Timestamp>> data;
   // This value will be corrupted. verified in verifyValue method.
   data.emplace_back(Timestamp(-1, 1));
@@ -516,7 +516,7 @@ TEST_F(ColumnWriterTest, TestTimestampEpochWriter) {
   testDataTypeWriter(TIMESTAMP(), data);
 }
 
-TEST_F(ColumnWriterTest, TestTimestampWriter) {
+TEST_F(ColumnWriterTest, testTimestampWriter) {
   std::vector<std::optional<Timestamp>> data;
   for (int64_t i = 0; i < ITERATIONS; ++i) {
     Timestamp ts(i, i);
@@ -528,7 +528,7 @@ TEST_F(ColumnWriterTest, TestTimestampWriter) {
   testDataTypeWriter(TIMESTAMP(), data, 6);
 }
 
-TEST_F(ColumnWriterTest, TestTimestampBoundaryValuesWriter) {
+TEST_F(ColumnWriterTest, testTimestampBoundaryValuesWriter) {
   std::vector<std::optional<Timestamp>> data;
   for (int64_t i = 0; i < ITERATIONS; ++i) {
     if (i & 1) {
@@ -543,7 +543,7 @@ TEST_F(ColumnWriterTest, TestTimestampBoundaryValuesWriter) {
   testDataTypeWriter(TIMESTAMP(), data);
 }
 
-TEST_F(ColumnWriterTest, TestTimestampMixedWriter) {
+TEST_F(ColumnWriterTest, testTimestampMixedWriter) {
   std::vector<std::optional<Timestamp>> data;
   for (int64_t i = 0; i < ITERATIONS; ++i) {
     int64_t seconds = Random::rand64(Timestamp::kMaxSeconds);
@@ -568,7 +568,7 @@ void verifyInvalidTimestamp(int64_t seconds, int64_t nanos) {
       testDataTypeWriter(TIMESTAMP(), data), exception::LoggedException);
 }
 
-TEST_F(ColumnWriterTest, TestTimestampNullWriter) {
+TEST_F(ColumnWriterTest, testTimestampNullWriter) {
   std::vector<std::optional<Timestamp>> data;
   for (int64_t i = 0; i < ITERATIONS; ++i) {
     data.emplace_back();
@@ -576,7 +576,7 @@ TEST_F(ColumnWriterTest, TestTimestampNullWriter) {
   testDataTypeWriter(TIMESTAMP(), data);
 }
 
-TEST_F(ColumnWriterTest, TestBooleanMixedWriter) {
+TEST_F(ColumnWriterTest, testBooleanMixedWriter) {
   std::vector<std::optional<bool>> data;
   for (auto i = 0; i < ITERATIONS; ++i) {
     bool value = (bool)(Random::rand32() & 1);
@@ -586,7 +586,7 @@ TEST_F(ColumnWriterTest, TestBooleanMixedWriter) {
   testDataTypeWriter(BOOLEAN(), data);
 }
 
-TEST_F(ColumnWriterTest, TestAllBytesWriter) {
+TEST_F(ColumnWriterTest, testAllBytesWriter) {
   std::vector<std::optional<int8_t>> data;
   for (int16_t i = INT8_MIN; i <= INT8_MAX; ++i) {
     data.emplace_back(i);
@@ -597,7 +597,7 @@ TEST_F(ColumnWriterTest, TestAllBytesWriter) {
   testDataTypeWriter(TINYINT(), data);
 }
 
-TEST_F(ColumnWriterTest, TestRepeatedValuesByteWriter) {
+TEST_F(ColumnWriterTest, testRepeatedValuesByteWriter) {
   std::vector<std::optional<int8_t>> data;
   for (auto i = 0; i < ITERATIONS; ++i) {
     data.emplace_back(INT8_MIN);
@@ -605,7 +605,7 @@ TEST_F(ColumnWriterTest, TestRepeatedValuesByteWriter) {
   testDataTypeWriter(TINYINT(), data);
 }
 
-TEST_F(ColumnWriterTest, TestOnlyNullByteWriter) {
+TEST_F(ColumnWriterTest, testOnlyNullByteWriter) {
   std::vector<std::optional<int8_t>> data;
   for (auto i = 0; i <= ITERATIONS; ++i) {
     data.emplace_back();
@@ -613,7 +613,7 @@ TEST_F(ColumnWriterTest, TestOnlyNullByteWriter) {
   testDataTypeWriter(TINYINT(), data);
 }
 
-TEST_F(ColumnWriterTest, TestByteNullAndExtremeValueMixed) {
+TEST_F(ColumnWriterTest, testByteNullAndExtremeValueMixed) {
   std::vector<std::optional<int8_t>> data;
   for (auto i = 0; i < ITERATIONS; ++i) {
     data.emplace_back(INT8_MIN);
@@ -636,7 +636,7 @@ void generateSampleData(std::vector<std::optional<T>>& data) {
   }
 }
 
-TEST_F(ColumnWriterTest, TestByteWriter) {
+TEST_F(ColumnWriterTest, testByteWriter) {
   std::vector<std::optional<int8_t>> data;
   generateSampleData(data);
   testDataTypeWriter(TINYINT(), data);
@@ -645,7 +645,7 @@ TEST_F(ColumnWriterTest, TestByteWriter) {
   testDataTypeWriter(TINYINT(), data, 5);
 }
 
-TEST_F(ColumnWriterTest, TestShortWriter) {
+TEST_F(ColumnWriterTest, testShortWriter) {
   std::vector<std::optional<int16_t>> data;
   generateSampleData(data);
   testDataTypeWriter(SMALLINT(), data);
@@ -654,7 +654,7 @@ TEST_F(ColumnWriterTest, TestShortWriter) {
   testDataTypeWriter(SMALLINT(), data, 23);
 }
 
-TEST_F(ColumnWriterTest, TestIntWriter) {
+TEST_F(ColumnWriterTest, testIntWriter) {
   std::vector<std::optional<int32_t>> data;
   generateSampleData(data);
   testDataTypeWriter(INTEGER(), data);
@@ -663,7 +663,7 @@ TEST_F(ColumnWriterTest, TestIntWriter) {
   testDataTypeWriter(INTEGER(), data, 1);
 }
 
-TEST_F(ColumnWriterTest, TestLongWriter) {
+TEST_F(ColumnWriterTest, testLongWriter) {
   std::vector<std::optional<int64_t>> data;
   generateSampleData(data);
   testDataTypeWriter(BIGINT(), data);
@@ -672,7 +672,7 @@ TEST_F(ColumnWriterTest, TestLongWriter) {
   testDataTypeWriter(BIGINT(), data, 42);
 }
 
-TEST_F(ColumnWriterTest, TestBinaryWriter) {
+TEST_F(ColumnWriterTest, testBinaryWriter) {
   std::vector<std::optional<StringView>> data;
   const size_t size = 100;
   for (size_t i = 0; i < size; ++i) {
@@ -689,7 +689,7 @@ TEST_F(ColumnWriterTest, TestBinaryWriter) {
   testDataTypeWriter(VARBINARY(), data, 42);
 }
 
-TEST_F(ColumnWriterTest, TestBinaryWriterAllNulls) {
+TEST_F(ColumnWriterTest, testBinaryWriterAllNulls) {
   std::vector<std::optional<StringView>> data{100};
   testDataTypeWriter(VARBINARY(), data);
 }
@@ -1291,7 +1291,7 @@ void testMapWriterRowImpl() {
   testMapWriterRow<TVALUE>(*pool, batches, true, true);
 }
 
-TEST_F(ColumnWriterTest, TestMapWriterNestedRow) {
+TEST_F(ColumnWriterTest, testMapWriterNestedRow) {
   testMapWriterRowImpl<bool>();
   testMapWriterRowImpl<Array<int32_t>>();
   testMapWriterRowImpl<Array<bool>>();
@@ -1365,7 +1365,7 @@ void testMapWriterNumericKeyUseFlatMap(bool useFlatMap) {
   testMapWriterNumericKey<T>(useFlatMap, MapWriterInputType::kFlatMap);
 }
 
-TEST_F(ColumnWriterTest, TestMapWriterFloatKey) {
+TEST_F(ColumnWriterTest, testMapWriterFloatKey) {
   testMapWriterNumericKey<float>(/* useFlatMap */ false);
 
   EXPECT_THROW(
@@ -1387,14 +1387,14 @@ TEST_F(ColumnWriterTest, TestMapWriterFloatKey) {
       exception::LoggedException);
 }
 
-TEST_F(ColumnWriterTest, TestMapWriterInt64Key) {
+TEST_F(ColumnWriterTest, testMapWriterInt64Key) {
   testMapWriterNumericKey<int64_t>(/* useFlatMap */ false);
   testMapWriterNumericKey<int64_t>(/* useFlatMap */ true);
   testMapWriterNumericKeyUseStruct<int64_t>(/* useFlatMap */ true);
   testMapWriterNumericKeyUseFlatMap<int64_t>(/* useFlatMap */ true);
 }
 
-TEST_F(ColumnWriterTest, TestMapWriterDuplicatedInt64Key) {
+TEST_F(ColumnWriterTest, testMapWriterDuplicatedInt64Key) {
   using T = int64_t;
   using b = MapBuilder<T, T>;
 
@@ -1407,28 +1407,28 @@ TEST_F(ColumnWriterTest, TestMapWriterDuplicatedInt64Key) {
       "Duplicated key in map: 5");
 }
 
-TEST_F(ColumnWriterTest, TestMapWriterInt32Key) {
+TEST_F(ColumnWriterTest, testMapWriterInt32Key) {
   testMapWriterNumericKey<int32_t>(/* useFlatMap */ false);
   testMapWriterNumericKey<int32_t>(/* useFlatMap */ true);
   testMapWriterNumericKeyUseStruct<int32_t>(/* useFlatMap */ true);
   testMapWriterNumericKeyUseFlatMap<int32_t>(/* useFlatMap */ true);
 }
 
-TEST_F(ColumnWriterTest, TestMapWriterInt16Key) {
+TEST_F(ColumnWriterTest, testMapWriterInt16Key) {
   testMapWriterNumericKey<int16_t>(/* useFlatMap */ false);
   testMapWriterNumericKey<int16_t>(/* useFlatMap */ true);
   testMapWriterNumericKeyUseStruct<int16_t>(/* useFlatMap */ true);
   testMapWriterNumericKeyUseFlatMap<int16_t>(/* useFlatMap */ true);
 }
 
-TEST_F(ColumnWriterTest, TestMapWriterInt8Key) {
+TEST_F(ColumnWriterTest, testMapWriterInt8Key) {
   testMapWriterNumericKey<int8_t>(/* useFlatMap */ false);
   testMapWriterNumericKey<int8_t>(/* useFlatMap */ true);
   testMapWriterNumericKeyUseStruct<int8_t>(/* useFlatMap */ true);
   testMapWriterNumericKeyUseFlatMap<int8_t>(/* useFlatMap */ true);
 }
 
-TEST_F(ColumnWriterTest, TestMapWriterStringKey) {
+TEST_F(ColumnWriterTest, testMapWriterStringKey) {
   using keyType = StringView;
   using valueType = StringView;
   using b = MapBuilder<keyType, valueType>;
@@ -1523,7 +1523,7 @@ void testFlatMapWriter(
 //
 // With the bug: crashes with SIGABRT in F14Table::rehashImpl.
 // With the fix: passes (keys are properly owned).
-TEST_F(ColumnWriterTest, TestFlatMapDanglingStringViewKeyOnRehash) {
+TEST_F(ColumnWriterTest, testFlatMapDanglingStringViewKeyOnRehash) {
   const auto rowType = CppToType<Row<Map<StringView, int32_t>>>::create();
   const auto writerSchema = TypeWithId::create(rowType);
   const auto writerDataTypeWithId = writerSchema->childAt(0);
@@ -1594,7 +1594,7 @@ TEST_F(ColumnWriterTest, TestFlatMapDanglingStringViewKeyOnRehash) {
   writer->createIndexEntry();
 }
 
-TEST_F(ColumnWriterTest, TestFlatMapKeyNotInAllBatches) {
+TEST_F(ColumnWriterTest, testFlatMapKeyNotInAllBatches) {
   VectorMaker maker(pool_.get());
   // Test the case where not all keys appear in all batches.
   const std::vector<RowVectorPtr> batches{
@@ -1608,7 +1608,7 @@ TEST_F(ColumnWriterTest, TestFlatMapKeyNotInAllBatches) {
   testFlatMapWriter(batches, pool_.get());
 }
 
-TEST_F(ColumnWriterTest, TesFlatMapDuplicatedKey) {
+TEST_F(ColumnWriterTest, tesFlatMapDuplicatedKey) {
   const size_t size = 3;
   const BufferPtr inMaps = AlignedBuffer::allocate<bool>(size, pool_.get());
   bits::fillBits(inMaps->asMutable<uint64_t>(), 1, size, pool_.get());
@@ -1628,7 +1628,7 @@ TEST_F(ColumnWriterTest, TesFlatMapDuplicatedKey) {
       testFlatMapWriter({batch}, pool_.get()), "Duplicated key in map: 2");
 }
 
-TEST_F(ColumnWriterTest, TestMapWriterDuplicatedStringKey) {
+TEST_F(ColumnWriterTest, testMapWriterDuplicatedStringKey) {
   using keyType = StringView;
   using valueType = StringView;
   using b = MapBuilder<keyType, valueType>;
@@ -1643,7 +1643,7 @@ TEST_F(ColumnWriterTest, TestMapWriterDuplicatedStringKey) {
       "Duplicated key in map: 2");
 }
 
-TEST_F(ColumnWriterTest, TestMapWriterDifferentNumericKeyValue) {
+TEST_F(ColumnWriterTest, testMapWriterDifferentNumericKeyValue) {
   using keyType = float;
   using valueType = int32_t;
   using b = MapBuilder<keyType, valueType>;
@@ -1657,7 +1657,7 @@ TEST_F(ColumnWriterTest, TestMapWriterDifferentNumericKeyValue) {
   testMapWriter<keyType, valueType>(*pool_, batch, /* useFlatMap */ false);
 }
 
-TEST_F(ColumnWriterTest, TestMapWriterDifferentKeyValue) {
+TEST_F(ColumnWriterTest, testMapWriterDifferentKeyValue) {
   using keyType = float;
   using valueType = StringView;
   using b = MapBuilder<keyType, valueType>;
@@ -1671,7 +1671,7 @@ TEST_F(ColumnWriterTest, TestMapWriterDifferentKeyValue) {
   testMapWriter<keyType, valueType>(*pool_, batch, /* useFlatMap */ false);
 }
 
-TEST_F(ColumnWriterTest, TestMapWriterMixedBatchTypeHandling) {
+TEST_F(ColumnWriterTest, testMapWriterMixedBatchTypeHandling) {
   using keyType = int32_t;
   using valueType = int32_t;
   using b = MapBuilder<keyType, valueType>;
@@ -1704,7 +1704,7 @@ TEST_F(ColumnWriterTest, TestMapWriterMixedBatchTypeHandling) {
       "");
 }
 
-TEST_F(ColumnWriterTest, TestMapWriterBinaryKey) {
+TEST_F(ColumnWriterTest, testMapWriterBinaryKey) {
   using keyType = StringView;
   using valueType = int32_t;
   using b = MapBuilder<keyType, valueType>;
@@ -1742,7 +1742,7 @@ void testMapWriterImpl() {
   testMapWriter<keyType, valueType>(*pool, batch, /* useFlatMap */ true);
 }
 
-TEST_F(ColumnWriterTest, TestMapWriterNestedMap) {
+TEST_F(ColumnWriterTest, testMapWriterNestedMap) {
   testMapWriterImpl<int32_t, bool>();
   testMapWriterImpl<int32_t, Array<int32_t>>();
   testMapWriterImpl<int32_t, Array<bool>>();
@@ -1756,7 +1756,7 @@ TEST_F(ColumnWriterTest, TestMapWriterNestedMap) {
   testMapWriterImpl<int32_t, Row<int32_t, bool, StringView>>();
 }
 
-TEST_F(ColumnWriterTest, TestMapWriterDifferentStripeBatches) {
+TEST_F(ColumnWriterTest, testMapWriterDifferentStripeBatches) {
   using keyType = int32_t;
   using valueType = int32_t;
   using b = MapBuilder<keyType, valueType>;
@@ -1790,7 +1790,7 @@ TEST_F(ColumnWriterTest, TestMapWriterDifferentStripeBatches) {
       false);
 }
 
-TEST_F(ColumnWriterTest, TestMapWriterNullValues) {
+TEST_F(ColumnWriterTest, testMapWriterNullValues) {
   using keyType = int32_t;
   using valueType = int32_t;
   using b = MapBuilder<keyType, valueType>;
@@ -1805,7 +1805,7 @@ TEST_F(ColumnWriterTest, TestMapWriterNullValues) {
   testMapWriter<keyType, valueType>(*pool_, batch, /* useFlatMap */ true);
 }
 
-TEST_F(ColumnWriterTest, TestMapWriterNullRows) {
+TEST_F(ColumnWriterTest, testMapWriterNullRows) {
   using keyType = int32_t;
   using valueType = int32_t;
   using b = MapBuilder<keyType, valueType>;
@@ -1823,7 +1823,7 @@ TEST_F(ColumnWriterTest, TestMapWriterNullRows) {
   testMapWriter<keyType, valueType>(*pool_, batch, /* useFlatMap */ true);
 }
 
-TEST_F(ColumnWriterTest, TestMapWriterDuplicateKeys) {
+TEST_F(ColumnWriterTest, testMapWriterDuplicateKeys) {
   using keyType = int32_t;
   using valueType = int32_t;
   using b = MapBuilder<keyType, valueType>;
@@ -1843,7 +1843,7 @@ TEST_F(ColumnWriterTest, TestMapWriterDuplicateKeys) {
       exception::LoggedException);
 }
 
-TEST_F(ColumnWriterTest, TestMapWriterBigBatch) {
+TEST_F(ColumnWriterTest, testMapWriterBigBatch) {
   using keyType = int32_t;
   using valueType = float;
   using b = MapBuilder<keyType, valueType>;
@@ -1879,7 +1879,7 @@ TEST_F(ColumnWriterTest, TestMapWriterBigBatch) {
       /* useFlatMap */ true);
 }
 
-TEST_F(ColumnWriterTest, TestMapWriterUnalignedKeyValueCount) {
+TEST_F(ColumnWriterTest, testMapWriterUnalignedKeyValueCount) {
   VectorMaker maker(pool_.get());
   auto keys = maker.flatVector<int64_t>(11, folly::identity);
   auto values = maker.flatVector<int64_t>(12, folly::identity);
@@ -1921,7 +1921,7 @@ TEST_F(ColumnWriterTest, TestMapWriterUnalignedKeyValueCount) {
       (testMapWriter<int64_t, int64_t>(*pool_, batch, true)), "");
 }
 
-TEST_F(ColumnWriterTest, TestStructKeysConfigSerializationDeserialization) {
+TEST_F(ColumnWriterTest, testStructKeysConfigSerializationDeserialization) {
   const std::vector<std::vector<std::string>> columns{
       {"1.45", "hi, you;", "29102819", "1e-4"},
       {"291", "world"},
@@ -2014,7 +2014,7 @@ void testMapWriterStats(const std::shared_ptr<const RowType> type) {
   }
 }
 
-TEST_F(ColumnWriterTest, TestMapWriterCompareStatsBinaryKey) {
+TEST_F(ColumnWriterTest, testMapWriterCompareStatsBinaryKey) {
   using keyType = Varbinary;
   // We create a complex map with complex value structure to test that value
   // aggregation work well in flat maps
@@ -2024,7 +2024,7 @@ TEST_F(ColumnWriterTest, TestMapWriterCompareStatsBinaryKey) {
   testMapWriterStats(type);
 }
 
-TEST_F(ColumnWriterTest, TestMapWriterCompareStatsStringKey) {
+TEST_F(ColumnWriterTest, testMapWriterCompareStatsStringKey) {
   using keyType = std::string;
   // We create a complex map with complex value structure to test that value
   // aggregation work well in flat maps
@@ -2034,7 +2034,7 @@ TEST_F(ColumnWriterTest, TestMapWriterCompareStatsStringKey) {
   testMapWriterStats(type);
 }
 
-TEST_F(ColumnWriterTest, TestMapWriterCompareStatsInt8Key) {
+TEST_F(ColumnWriterTest, testMapWriterCompareStatsInt8Key) {
   using keyType = int8_t;
 
   // We create a complex map with complex value structure to test that value
@@ -2045,7 +2045,7 @@ TEST_F(ColumnWriterTest, TestMapWriterCompareStatsInt8Key) {
   testMapWriterStats(type);
 }
 
-TEST_F(ColumnWriterTest, TestMapWriterCompareStatsInt16Key) {
+TEST_F(ColumnWriterTest, testMapWriterCompareStatsInt16Key) {
   using keyType = int16_t;
 
   // We create a complex map with complex value structure to test that value
@@ -2056,7 +2056,7 @@ TEST_F(ColumnWriterTest, TestMapWriterCompareStatsInt16Key) {
   testMapWriterStats(type);
 }
 
-TEST_F(ColumnWriterTest, TestMapWriterCompareStatsInt32Key) {
+TEST_F(ColumnWriterTest, testMapWriterCompareStatsInt32Key) {
   using keyType = int32_t;
 
   // We create a complex map with complex value structure to test that value
@@ -2067,7 +2067,7 @@ TEST_F(ColumnWriterTest, TestMapWriterCompareStatsInt32Key) {
   testMapWriterStats(type);
 }
 
-TEST_F(ColumnWriterTest, TestMapWriterCompareStatsInt64Key) {
+TEST_F(ColumnWriterTest, testMapWriterCompareStatsInt64Key) {
   using keyType = int64_t;
 
   // We create a complex map with complex value structure to test that value
@@ -2085,11 +2085,11 @@ void testFractionalWrite(const TypePtr& t) {
   testDataTypeWriter(t, data);
 }
 
-TEST_F(ColumnWriterTest, TestFloatWriter) {
+TEST_F(ColumnWriterTest, testFloatWriter) {
   testFractionalWrite<float>(REAL());
 }
 
-TEST_F(ColumnWriterTest, TestDoubleWriter) {
+TEST_F(ColumnWriterTest, testDoubleWriter) {
   testFractionalWrite<double>(DOUBLE());
 }
 
@@ -2103,11 +2103,11 @@ void testFractionalInfinityWrite(const TypePtr& t) {
   testDataTypeWriter(t, data);
 }
 
-TEST_F(ColumnWriterTest, TestFloatInfinityWriter) {
+TEST_F(ColumnWriterTest, testFloatInfinityWriter) {
   testFractionalInfinityWrite<float>(REAL());
 }
 
-TEST_F(ColumnWriterTest, TestDoubleInfinityWriter) {
+TEST_F(ColumnWriterTest, testDoubleInfinityWriter) {
   testFractionalInfinityWrite<double>(DOUBLE());
 }
 
@@ -2121,11 +2121,11 @@ void testFractionalNegativeInfinityWrite(const TypePtr& t) {
   testDataTypeWriter(t, data);
 }
 
-TEST_F(ColumnWriterTest, TestFloatNegativeInfinityWriter) {
+TEST_F(ColumnWriterTest, testFloatNegativeInfinityWriter) {
   testFractionalNegativeInfinityWrite<float>(REAL());
 }
 
-TEST_F(ColumnWriterTest, TestDoubleNegativeInfinityWriter) {
+TEST_F(ColumnWriterTest, testDoubleNegativeInfinityWriter) {
   testFractionalNegativeInfinityWrite<double>(DOUBLE());
 }
 
@@ -2139,11 +2139,11 @@ void testFractionalNaNWrite(const TypePtr& t) {
   testDataTypeWriter(t, data);
 }
 
-TEST_F(ColumnWriterTest, TestFloatNanWriter) {
+TEST_F(ColumnWriterTest, testFloatNanWriter) {
   testFractionalNaNWrite<float>(REAL());
 }
 
-TEST_F(ColumnWriterTest, TestDoubleNanWriter) {
+TEST_F(ColumnWriterTest, testDoubleNanWriter) {
   testFractionalNaNWrite<double>(DOUBLE());
 }
 
@@ -2156,11 +2156,11 @@ void testFractionalNullWrite(const TypePtr& t) {
   testDataTypeWriter(t, data);
 }
 
-TEST_F(ColumnWriterTest, TestFloatAllNullWriter) {
+TEST_F(ColumnWriterTest, testFloatAllNullWriter) {
   testFractionalNullWrite<float>(REAL());
 }
 
-TEST_F(ColumnWriterTest, TestDoubleAllNullWriter) {
+TEST_F(ColumnWriterTest, testDoubleAllNullWriter) {
   testFractionalNullWrite<double>(DOUBLE());
 }
 
@@ -2184,11 +2184,11 @@ void testFractionalMixedWrite(const TypePtr& t) {
   testDataTypeWriter(t, data);
 }
 
-TEST_F(ColumnWriterTest, TestFloatMixedWriter) {
+TEST_F(ColumnWriterTest, testFloatMixedWriter) {
   testFractionalMixedWrite<float>(REAL());
 }
 
-TEST_F(ColumnWriterTest, TestDoubleMixedWriter) {
+TEST_F(ColumnWriterTest, testDoubleMixedWriter) {
   testFractionalMixedWrite<double>(DOUBLE());
 }
 
@@ -2689,7 +2689,7 @@ struct IntegerColumnWriterDirectEncodingUniversalTestCase
             flushCount} {}
 };
 
-TEST_F(ColumnWriterTest, IntegerTypeDictionaryEncodingWrites) {
+TEST_F(ColumnWriterTest, integerTypeDictionaryEncodingWrites) {
   struct TestCase
       : public IntegerColumnWriterDictionaryEncodingUniversalTestCase {
     TestCase(
@@ -2729,7 +2729,7 @@ TEST_F(ColumnWriterTest, IntegerTypeDictionaryEncodingWrites) {
   }
 }
 
-TEST_F(ColumnWriterTest, IntegerTypeDictionaryEncodingWritesWithNulls) {
+TEST_F(ColumnWriterTest, integerTypeDictionaryEncodingWritesWithNulls) {
   struct DictionaryEncodingTestCase
       : public IntegerColumnWriterDictionaryEncodingUniversalTestCase {
     DictionaryEncodingTestCase(
@@ -2798,7 +2798,7 @@ TEST_F(ColumnWriterTest, IntegerTypeDictionaryEncodingWritesWithNulls) {
   }
 }
 
-TEST_F(ColumnWriterTest, IntegerTypeDictionaryEncodingHugeWrites) {
+TEST_F(ColumnWriterTest, integerTypeDictionaryEncodingHugeWrites) {
   struct TestCase
       : public IntegerColumnWriterDictionaryEncodingUniversalTestCase {
     TestCase(
@@ -2842,7 +2842,7 @@ TEST_F(ColumnWriterTest, IntegerTypeDictionaryEncodingHugeWrites) {
 }
 
 // Split test to avoid sandcastle timeouts.
-TEST_F(ColumnWriterTest, IntegerTypeDictionaryEncodingHugeRepeatedWrites) {
+TEST_F(ColumnWriterTest, integerTypeDictionaryEncodingHugeRepeatedWrites) {
   struct TestCase
       : public IntegerColumnWriterDictionaryEncodingUniversalTestCase {
     TestCase(
@@ -2879,7 +2879,7 @@ TEST_F(ColumnWriterTest, IntegerTypeDictionaryEncodingHugeRepeatedWrites) {
   }
 }
 
-TEST_F(ColumnWriterTest, IntegerTypeDirectEncodingWrites) {
+TEST_F(ColumnWriterTest, integerTypeDirectEncodingWrites) {
   struct TestCase : public IntegerColumnWriterDirectEncodingUniversalTestCase {
     TestCase(
         size_t size,
@@ -2913,7 +2913,7 @@ TEST_F(ColumnWriterTest, IntegerTypeDirectEncodingWrites) {
   }
 }
 
-TEST_F(ColumnWriterTest, IntegerTypeDirectEncodingWritesWithNulls) {
+TEST_F(ColumnWriterTest, integerTypeDirectEncodingWritesWithNulls) {
   struct TestCase : public IntegerColumnWriterDirectEncodingUniversalTestCase {
     TestCase(
         size_t size,
@@ -2949,7 +2949,7 @@ TEST_F(ColumnWriterTest, IntegerTypeDirectEncodingWritesWithNulls) {
   }
 }
 
-TEST_F(ColumnWriterTest, IntegerTypeDirectEncodingHugeWrites) {
+TEST_F(ColumnWriterTest, integerTypeDirectEncodingHugeWrites) {
   struct TestCase : public IntegerColumnWriterDirectEncodingUniversalTestCase {
     TestCase(
         size_t size,
@@ -2979,7 +2979,7 @@ TEST_F(ColumnWriterTest, IntegerTypeDirectEncodingHugeWrites) {
 }
 
 // Split test to avoid sandcastle timeouts.
-TEST_F(ColumnWriterTest, IntegerTypeDirectEncodingHugeRepeatedWrites) {
+TEST_F(ColumnWriterTest, integerTypeDirectEncodingHugeRepeatedWrites) {
   struct TestCase : public IntegerColumnWriterDirectEncodingUniversalTestCase {
     TestCase(
         size_t size,
@@ -3012,7 +3012,7 @@ TEST_F(ColumnWriterTest, IntegerTypeDirectEncodingHugeRepeatedWrites) {
   }
 }
 
-TEST_F(ColumnWriterTest, IntegerTypeDictionaryWriteThreshold) {
+TEST_F(ColumnWriterTest, integerTypeDictionaryWriteThreshold) {
   struct DictionaryEncodingTestCase
       : public IntegerColumnWriterDictionaryEncodingUniversalTestCase {
     DictionaryEncodingTestCase(
@@ -3103,7 +3103,7 @@ TEST_F(ColumnWriterTest, IntegerTypeDictionaryWriteThreshold) {
   }
 }
 
-TEST_F(ColumnWriterTest, IntegerColumnWriterAbandonDictionaries) {
+TEST_F(ColumnWriterTest, integerColumnWriterAbandonDictionaries) {
   struct TestCase : public IntegerColumnWriterUniversalTestCase {
     TestCase(
         size_t size,
@@ -3235,7 +3235,7 @@ TEST_F(ColumnWriterTest, IntegerColumnWriterAbandonDictionaries) {
   }
 }
 
-TEST_F(ColumnWriterTest, IntegerColumnWriterAbandonDictionariesWithNulls) {
+TEST_F(ColumnWriterTest, integerColumnWriterAbandonDictionariesWithNulls) {
   struct TestCase : public IntegerColumnWriterUniversalTestCase {
     TestCase(
         size_t size,
@@ -3367,7 +3367,7 @@ TEST_F(ColumnWriterTest, IntegerColumnWriterAbandonDictionariesWithNulls) {
   }
 }
 
-TEST_F(ColumnWriterTest, IntegerColumnWriterAbandonLowValueDictionaries) {
+TEST_F(ColumnWriterTest, integerColumnWriterAbandonLowValueDictionaries) {
   struct TestCase : public IntegerColumnWriterUniversalTestCase {
     TestCase(
         size_t size,
@@ -3572,7 +3572,7 @@ void testIntegerDictionaryEncodableWriterConstructor() {
   }
 }
 
-TEST_F(ColumnWriterTest, IntegerDictionaryDictionaryEncodableWriterCtor) {
+TEST_F(ColumnWriterTest, integerDictionaryDictionaryEncodableWriterCtor) {
   testIntegerDictionaryEncodableWriterConstructor<int16_t>();
   testIntegerDictionaryEncodableWriterConstructor<int32_t>();
   testIntegerDictionaryEncodableWriterConstructor<int64_t>();
@@ -3821,7 +3821,7 @@ struct StringDirectEncodingTestCase : public StringColumnWriterTestCase {
             flushCount} {}
 };
 
-TEST_F(ColumnWriterTest, StringDictionaryEncodingWrite) {
+TEST_F(ColumnWriterTest, stringDictionaryEncodingWrite) {
   struct TestCase : public StringDictionaryEncodingTestCase {
     explicit TestCase(
         size_t size,
@@ -3895,7 +3895,7 @@ bool genNulls_ForStride2(
   return strideIndex == 2;
 }
 
-TEST_F(ColumnWriterTest, StrideStringWithSomeDataNotInDictionary) {
+TEST_F(ColumnWriterTest, strideStringWithSomeDataNotInDictionary) {
   struct TestCase : public StringDictionaryEncodingTestCase {
     explicit TestCase(
         size_t size,
@@ -3927,7 +3927,7 @@ TEST_F(ColumnWriterTest, StrideStringWithSomeDataNotInDictionary) {
   }
 }
 
-TEST_F(ColumnWriterTest, StringDictionaryEncodingWritesWithNulls) {
+TEST_F(ColumnWriterTest, stringDictionaryEncodingWritesWithNulls) {
   struct DictionaryEncodingTestCase : public StringDictionaryEncodingTestCase {
     DictionaryEncodingTestCase(
         size_t size,
@@ -4001,7 +4001,7 @@ TEST_F(ColumnWriterTest, StringDictionaryEncodingWritesWithNulls) {
   }
 }
 
-TEST_F(ColumnWriterTest, StringDirectEncodingWrites) {
+TEST_F(ColumnWriterTest, stringDirectEncodingWrites) {
   struct TestCase : public StringDirectEncodingTestCase {
     TestCase(
         size_t size,
@@ -4033,7 +4033,7 @@ TEST_F(ColumnWriterTest, StringDirectEncodingWrites) {
   }
 }
 
-TEST_F(ColumnWriterTest, StringDirectEncodingWritesWithNulls) {
+TEST_F(ColumnWriterTest, stringDirectEncodingWritesWithNulls) {
   struct TestCase : public StringDirectEncodingTestCase {
     TestCase(
         size_t size,
@@ -4069,7 +4069,7 @@ TEST_F(ColumnWriterTest, StringDirectEncodingWritesWithNulls) {
   }
 }
 
-TEST_F(ColumnWriterTest, StringColumnWriterAbandonDictionaries) {
+TEST_F(ColumnWriterTest, stringColumnWriterAbandonDictionaries) {
   struct TestCase : public StringColumnWriterTestCase {
     TestCase(
         size_t size,
@@ -4203,7 +4203,7 @@ TEST_F(ColumnWriterTest, StringColumnWriterAbandonDictionaries) {
 }
 
 // TODO: how about all nulls?
-TEST_F(ColumnWriterTest, StringColumnWriterAbandonDictionariesWithNulls) {
+TEST_F(ColumnWriterTest, stringColumnWriterAbandonDictionariesWithNulls) {
   struct TestCase : public StringColumnWriterTestCase {
     TestCase(
         size_t size,
@@ -4336,7 +4336,7 @@ TEST_F(ColumnWriterTest, StringColumnWriterAbandonDictionariesWithNulls) {
   }
 }
 
-TEST_F(ColumnWriterTest, StringColumnWriterAbandonLowValueDictionaries) {
+TEST_F(ColumnWriterTest, stringColumnWriterAbandonLowValueDictionaries) {
   struct TestCase : public StringColumnWriterTestCase {
     TestCase(
         size_t size,
@@ -4518,7 +4518,7 @@ TEST_F(ColumnWriterTest, StringColumnWriterAbandonLowValueDictionaries) {
   }
 }
 
-TEST_F(ColumnWriterTest, IntDictWriterDirectValueOverflow) {
+TEST_F(ColumnWriterTest, intDictWriterDirectValueOverflow) {
   auto config = std::make_shared<Config>();
   WriterContext context{
       config,
@@ -4561,7 +4561,7 @@ TEST_F(ColumnWriterTest, IntDictWriterDirectValueOverflow) {
   }
 }
 
-TEST_F(ColumnWriterTest, ShortDictWriterDictValueOverflow) {
+TEST_F(ColumnWriterTest, shortDictWriterDictValueOverflow) {
   auto config = std::make_shared<Config>();
   WriterContext context{config, memory::memoryManager()->addRootPool()};
   context.initBuffer();
@@ -4607,7 +4607,7 @@ TEST_F(ColumnWriterTest, ShortDictWriterDictValueOverflow) {
   }
 }
 
-TEST_F(ColumnWriterTest, RemovePresentStream) {
+TEST_F(ColumnWriterTest, removePresentStream) {
   auto config = std::make_shared<Config>();
 
   std::vector<std::optional<int32_t>> data;
@@ -4638,7 +4638,7 @@ TEST_F(ColumnWriterTest, RemovePresentStream) {
   ASSERT_EQ(streams.getStream(si, {}, false), nullptr);
 }
 
-TEST_F(ColumnWriterTest, ColumnIdInStream) {
+TEST_F(ColumnWriterTest, columnIdInStream) {
   auto config = std::make_shared<Config>();
 
   std::vector<std::optional<int32_t>> data;
@@ -4857,7 +4857,7 @@ void testDictionary(
       .runTest(valueAt, [](int) { return false; });
 }
 
-TEST_F(ColumnWriterTest, ColumnWriterDictionarySimple) {
+TEST_F(ColumnWriterTest, columnWriterDictionarySimple) {
   testDictionary<Timestamp>(TIMESTAMP(), randomNulls(11), [](vector_size_t i) {
     return Timestamp(i * 5, i * 2);
   });

--- a/velox/dwio/dwrf/test/CommonTests.cpp
+++ b/velox/dwio/dwrf/test/CommonTests.cpp
@@ -49,7 +49,7 @@ class CommonTest : public ::testing::Test {
 
 TEST_F(
     CommonTest,
-    DwrfStreamIdentifierGetFormat_WithStreamTypes_GetCorrectFormat) {
+    dwrfStreamIdentifierGetFormat_WithStreamTypes_GetCorrectFormat) {
   EXPECT_EQ(
       DwrfStreamIdentifier(createDwrfStream({}, {}, {}, {})).format(),
       DwrfFormat::kDwrf);
@@ -58,7 +58,7 @@ TEST_F(
       DwrfStreamIdentifier(createOrcStream({}, {})).format(), DwrfFormat::kOrc);
 }
 
-TEST_F(CommonTest, DwrfStreamIdentifier_WithDwrfStream_GetCorrectInfo) {
+TEST_F(CommonTest, dwrfStreamIdentifier_WithDwrfStream_GetCorrectInfo) {
   auto streamId = DwrfStreamIdentifier(
       createDwrfStream(proto::Stream::Kind::Stream_Kind_DATA, 1, 2, 3));
 
@@ -69,7 +69,7 @@ TEST_F(CommonTest, DwrfStreamIdentifier_WithDwrfStream_GetCorrectInfo) {
   EXPECT_EQ(streamId.column(), 3);
 }
 
-TEST_F(CommonTest, DwrfStreamIdentifier_WithOrcStream_GetCorrectInfo) {
+TEST_F(CommonTest, dwrfStreamIdentifier_WithOrcStream_GetCorrectInfo) {
   auto streamId = DwrfStreamIdentifier(
       createOrcStream(proto::orc::Stream::Kind::Stream_Kind_DATA, 1));
 
@@ -83,7 +83,7 @@ TEST_F(CommonTest, DwrfStreamIdentifier_WithOrcStream_GetCorrectInfo) {
 
 TEST_F(
     CommonTest,
-    DwrfStreamIdentifierGetKind_WithAllStreamKinds_GetCorrectConversion) {
+    dwrfStreamIdentifierGetKind_WithAllStreamKinds_GetCorrectConversion) {
   // DWRF
   for (auto [dwrfStreamKind, veloxStreamKind] :
        std::vector<std::tuple<proto::Stream_Kind, StreamKind>>{
@@ -133,7 +133,7 @@ TEST_F(
 
 TEST_F(
     CommonTest,
-    EncodingKeyGetKindFor_WithAllStreamKinds_GetCorrectConversion) {
+    encodingKeyGetKindFor_WithAllStreamKinds_GetCorrectConversion) {
   // DWRF
   for (auto [dwrfStreamKind, veloxStreamKind] :
        std::vector<std::tuple<proto::Stream_Kind, StreamKind>>{

--- a/velox/dwio/dwrf/test/ConfigTests.cpp
+++ b/velox/dwio/dwrf/test/ConfigTests.cpp
@@ -31,7 +31,7 @@ T getConfig(
   return config->get(entry);
 }
 
-TEST(ConfigTests, Set) {
+TEST(ConfigTests, set) {
   Config config;
   // set
   auto val = folly::Random::rand32();
@@ -48,7 +48,7 @@ TEST(ConfigTests, Set) {
   EXPECT_TRUE(config.get(Config::CREATE_INDEX));
 }
 
-TEST(ConfigTests, EnumConfig) {
+TEST(ConfigTests, enumConfig) {
   Config config;
   config.set(Config::COMPRESSION, CompressionKind::CompressionKind_ZLIB);
   EXPECT_EQ(
@@ -58,14 +58,14 @@ TEST(ConfigTests, EnumConfig) {
       config.get(Config::COMPRESSION), CompressionKind::CompressionKind_NONE);
 }
 
-TEST(ConfigTests, UInt32Config) {
+TEST(ConfigTests, uint32Config) {
   Config config;
   auto val = folly::Random::rand32();
   config.set(Config::ROW_INDEX_STRIDE, val);
   EXPECT_EQ(config.get(Config::ROW_INDEX_STRIDE), val);
 }
 
-TEST(ConfigTests, BoolConfig) {
+TEST(ConfigTests, boolConfig) {
   Config config;
   config.set(Config::CREATE_INDEX, false);
   EXPECT_FALSE(config.get(Config::CREATE_INDEX));
@@ -156,7 +156,7 @@ TEST(ConfigTests, writerOptionsOverrideSession) {
 }
 
 class ConfigTests : public ::testing::TestWithParam<ConfigTestParams> {};
-TEST_P(ConfigTests, FlatMapCols) {
+TEST_P(ConfigTests, flatMapCols) {
   const auto& params = GetParam();
   std::map<std::string, std::string> inputConfigMap{
       {"orc.map.flat.cols", params.inputCols}};

--- a/velox/dwio/dwrf/test/DataBufferHolderTests.cpp
+++ b/velox/dwio/dwrf/test/DataBufferHolderTests.cpp
@@ -31,7 +31,7 @@ class DataBufferHolderTest : public testing::Test {
   std::shared_ptr<MemoryPool> pool_{memoryManager()->addLeafPool()};
 };
 
-TEST_F(DataBufferHolderTest, InputCheck) {
+TEST_F(DataBufferHolderTest, inputCheck) {
   VELOX_ASSERT_THROW((DataBufferHolder{*pool_, 0}), "");
   VELOX_ASSERT_THROW((DataBufferHolder{*pool_, 1024, 2048}), "");
   VELOX_ASSERT_THROW((DataBufferHolder{*pool_, 1024, 1024, 1.1f}), "");
@@ -47,7 +47,7 @@ TEST_F(DataBufferHolderTest, InputCheck) {
   }
 }
 
-TEST_F(DataBufferHolderTest, TakeAndGetBuffer) {
+TEST_F(DataBufferHolderTest, takeAndGetBuffer) {
   MemorySink sink{1024, {.pool = pool_.get()}};
   DataBufferHolder holder{*pool_, 1024, 0, 2.0f, &sink};
   DataBuffer<char> buffer{*pool_, 512};
@@ -69,7 +69,7 @@ TEST_F(DataBufferHolderTest, TakeAndGetBuffer) {
   ASSERT_EQ(holder.getBuffers().size(), 0);
 }
 
-TEST_F(DataBufferHolderTest, TruncateBufferHolder) {
+TEST_F(DataBufferHolderTest, truncateBufferHolder) {
   DataBufferHolder holder{*pool_, 1024};
   constexpr size_t BUF_SIZE = 10;
   DataBuffer<char> buffer{*pool_, BUF_SIZE};
@@ -93,7 +93,7 @@ TEST_F(DataBufferHolderTest, TruncateBufferHolder) {
   }
 }
 
-TEST_F(DataBufferHolderTest, TakeAndGetBufferNoOutput) {
+TEST_F(DataBufferHolderTest, takeAndGetBufferNoOutput) {
   DataBufferHolder holder{*pool_, 1024};
   DataBuffer<char> buffer{*pool_, 512};
   std::memset(buffer.data(), 'a', 512);
@@ -122,7 +122,7 @@ TEST_F(DataBufferHolderTest, TakeAndGetBufferNoOutput) {
   }
 }
 
-TEST_F(DataBufferHolderTest, Reset) {
+TEST_F(DataBufferHolderTest, reset) {
   DataBufferHolder holder{*pool_, 1024};
   DataBuffer<char> buffer{*pool_, 512};
   std::memset(buffer.data(), 'a', 512);
@@ -135,7 +135,7 @@ TEST_F(DataBufferHolderTest, Reset) {
   ASSERT_FALSE(holder.isSuppressed());
 }
 
-TEST_F(DataBufferHolderTest, TryResize) {
+TEST_F(DataBufferHolderTest, tryResize) {
   DataBufferHolder holder{*pool_, 1024, 128};
 
   auto runTest = [&](uint64_t size,
@@ -248,7 +248,7 @@ TEST_F(DataBufferHolderTest, TryResize) {
       1024 + headerSize);
 }
 
-TEST_F(DataBufferHolderTest, TestGrowRatio) {
+TEST_F(DataBufferHolderTest, testGrowRatio) {
   DataBufferHolder holder{*pool_, 1024, 16, 4.0f};
   DataBuffer<char> buffer{*pool_, 16};
   ASSERT_TRUE(holder.tryResize(buffer, 0, 1));

--- a/velox/dwio/dwrf/test/DecompressionTest.cpp
+++ b/velox/dwio/dwrf/test/DecompressionTest.cpp
@@ -953,18 +953,18 @@ class TestSeek : public ::testing::Test {
   std::shared_ptr<MemoryPool> pool_ = memory::memoryManager()->addLeafPool();
 };
 
-TEST_F(TestSeek, Zlib) {
+TEST_F(TestSeek, zlib) {
   auto codec = zlib::getCodec(
       zlib::Options(zlib::Options::Format::RAW), COMPRESSION_LEVEL_DEFAULT);
   runTest(*codec, CompressionKind_ZLIB);
 }
 
-TEST_F(TestSeek, Zstd) {
+TEST_F(TestSeek, zstd) {
   auto codec = getCodec(CodecType::ZSTD);
   runTest(*codec, CompressionKind_ZSTD);
 }
 
-TEST_F(TestSeek, Snappy) {
+TEST_F(TestSeek, snappy) {
   auto codec = getCodec(CodecType::SNAPPY);
   runTest(*codec, CompressionKind_SNAPPY);
 }

--- a/velox/dwio/dwrf/test/DecryptionTests.cpp
+++ b/velox/dwio/dwrf/test/DecryptionTests.cpp
@@ -28,7 +28,7 @@ using namespace facebook::velox::dwrf;
 using namespace facebook::velox::dwrf::encryption;
 using namespace facebook::velox::type::fbhive;
 
-TEST(Decryption, NotEncrypted) {
+TEST(Decryption, notEncrypted) {
   HiveTypeParser parser;
   auto type = parser.parse("struct<a:int>");
   proto::Footer footer;
@@ -39,7 +39,7 @@ TEST(Decryption, NotEncrypted) {
   ASSERT_FALSE(handler->isEncrypted());
 }
 
-TEST(Decryption, NoKeyProvider) {
+TEST(Decryption, noKeyProvider) {
   HiveTypeParser parser;
   auto type = parser.parse("struct<a:int>");
   proto::Footer footer;
@@ -51,7 +51,7 @@ TEST(Decryption, NoKeyProvider) {
       DecryptionHandler::create(footer, &factory), exception::LoggedException);
 }
 
-TEST(Decryption, EmptyGroup) {
+TEST(Decryption, emptyGroup) {
   HiveTypeParser parser;
   auto type = parser.parse("struct<a:int>");
   proto::Footer footer;
@@ -64,7 +64,7 @@ TEST(Decryption, EmptyGroup) {
       DecryptionHandler::create(footer, &factory), exception::LoggedException);
 }
 
-TEST(Decryption, EmptyNodes) {
+TEST(Decryption, emptyNodes) {
   HiveTypeParser parser;
   auto type = parser.parse("struct<a:int>");
   proto::Footer footer;
@@ -79,7 +79,7 @@ TEST(Decryption, EmptyNodes) {
       DecryptionHandler::create(footer, &factory), exception::LoggedException);
 }
 
-TEST(Decryption, StatsMismatch) {
+TEST(Decryption, statsMismatch) {
   HiveTypeParser parser;
   auto type = parser.parse("struct<a:int>");
   proto::Footer footer;
@@ -97,7 +97,7 @@ TEST(Decryption, StatsMismatch) {
       DecryptionHandler::create(footer, &factory), exception::LoggedException);
 }
 
-TEST(Decryption, KeyExistenceMismatch) {
+TEST(Decryption, keyExistenceMismatch) {
   HiveTypeParser parser;
   auto type = parser.parse("struct<a:int>");
   proto::Footer footer;
@@ -118,7 +118,7 @@ TEST(Decryption, KeyExistenceMismatch) {
       DecryptionHandler::create(footer, &factory), exception::LoggedException);
 }
 
-TEST(Decryption, ReuseStripeKey) {
+TEST(Decryption, reuseStripeKey) {
   HiveTypeParser parser;
   auto type = parser.parse("struct<a:int>");
   proto::Footer footer;
@@ -138,7 +138,7 @@ TEST(Decryption, ReuseStripeKey) {
   ASSERT_EQ(td.getKey(), "foobar");
 }
 
-TEST(Decryption, StripeKeyMismatch) {
+TEST(Decryption, stripeKeyMismatch) {
   HiveTypeParser parser;
   auto type = parser.parse("struct<a:int>");
   proto::Footer footer;
@@ -157,7 +157,7 @@ TEST(Decryption, StripeKeyMismatch) {
       DecryptionHandler::create(footer, &factory), exception::LoggedException);
 }
 
-TEST(Decryption, Basic) {
+TEST(Decryption, basic) {
   HiveTypeParser parser;
   auto type = parser.parse("struct<a:int,b:float,c:string,d:double>");
   proto::Footer footer;
@@ -187,7 +187,7 @@ TEST(Decryption, Basic) {
   }
 }
 
-TEST(Decryption, NestedType) {
+TEST(Decryption, nestedType) {
   HiveTypeParser parser;
   auto type = parser.parse(
       "struct<a:int,b:map<float,map<int,double>>,c:struct<a:string,b:int>,d:array<double>>");
@@ -228,7 +228,7 @@ TEST(Decryption, NestedType) {
   }
 }
 
-TEST(Decryption, RootNode) {
+TEST(Decryption, rootNode) {
   HiveTypeParser parser;
   auto type = parser.parse("struct<a:int,b:int>");
   proto::Footer footer;
@@ -245,7 +245,7 @@ TEST(Decryption, RootNode) {
   ASSERT_EQ(handler->getEncryptionGroupCount(), 1);
 }
 
-TEST(Decryption, GroupOverlap) {
+TEST(Decryption, groupOverlap) {
   HiveTypeParser parser;
   auto type = parser.parse("struct<a:struct<a:float,b:double>>");
   proto::Footer footer;

--- a/velox/dwio/dwrf/test/E2EReaderTest.cpp
+++ b/velox/dwio/dwrf/test/E2EReaderTest.cpp
@@ -112,7 +112,7 @@ class E2EReaderTest : public testing::TestWithParam<ValueTypes> {
 };
 } // namespace
 
-TEST_P(E2EReaderTest, SharedDictionaryFlatmapReadAsStruct) {
+TEST_P(E2EReaderTest, sharedDictionaryFlatmapReadAsStruct) {
   const size_t batchCount = 10;
   size_t size = 1;
   auto pool = memory::memoryManager()->addLeafPool();

--- a/velox/dwio/dwrf/test/E2EWriterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EWriterTest.cpp
@@ -346,7 +346,7 @@ VectorPtr createRowVector(
       /*nullCount=*/0);
 }
 
-TEST_F(E2EWriterTest, E2E) {
+TEST_F(E2EWriterTest, e2e) {
   const size_t batchCount = 4;
   // Start with a size larger than stride to cover splitting into
   // strides. Continue with smaller size for faster test.
@@ -478,7 +478,7 @@ TEST_F(E2EWriterTest, DISABLED_DisableLinearHeuristicsLargeAnalytics) {
   dwrf::E2EWriterTestUtil::testWriter(*leafPool_, type, batches, 8, 8, config);
 }
 
-TEST_F(E2EWriterTest, FlatMapDictionaryEncoding) {
+TEST_F(E2EWriterTest, flatMapDictionaryEncoding) {
   const size_t batchCount = 4;
   // Start with a size larger than stride to cover splitting into
   // strides. Continue with smaller size for faster test.
@@ -515,7 +515,7 @@ TEST_F(E2EWriterTest, FlatMapDictionaryEncoding) {
   dwrf::E2EWriterTestUtil::testWriter(*pool, type, batches, 1, 1, config);
 }
 
-TEST_F(E2EWriterTest, MaxFlatMapKeys) {
+TEST_F(E2EWriterTest, maxFlatMapKeys) {
   using keyType = int32_t;
   using valueType = int32_t;
   using b = MapBuilder<keyType, valueType>;
@@ -547,7 +547,7 @@ TEST_F(E2EWriterTest, MaxFlatMapKeys) {
       config);
 }
 
-TEST_F(E2EWriterTest, PresentStreamIsSuppressedOnFlatMap) {
+TEST_F(E2EWriterTest, presentStreamIsSuppressedOnFlatMap) {
   using keyType = int32_t;
   using valueType = int64_t;
   using b = MapBuilder<keyType, valueType>;
@@ -597,7 +597,7 @@ TEST_F(E2EWriterTest, PresentStreamIsSuppressedOnFlatMap) {
   }
 }
 
-TEST_F(E2EWriterTest, TooManyFlatMapKeys) {
+TEST_F(E2EWriterTest, tooManyFlatMapKeys) {
   using keyType = int32_t;
   using valueType = int32_t;
   using b = MapBuilder<keyType, valueType>;
@@ -631,7 +631,7 @@ TEST_F(E2EWriterTest, TooManyFlatMapKeys) {
       "");
 }
 
-TEST_F(E2EWriterTest, FlatMapBackfill) {
+TEST_F(E2EWriterTest, flatMapBackfill) {
   auto pool = memory::memoryManager()->addLeafPool();
 
   using keyType = int32_t;
@@ -740,7 +740,7 @@ void testFlatMapWithNulls(
       dwrf::E2EWriterTestUtil::simpleFlushPolicyFactory(false));
 }
 
-TEST_F(E2EWriterTest, FlatMapWithNulls) {
+TEST_F(E2EWriterTest, flatMapWithNulls) {
   testFlatMapWithNulls(
       /*firstRowNotNull=*/false, /*enableFlatmapDictionaryEncoding=*/false);
   testFlatMapWithNulls(
@@ -751,7 +751,7 @@ TEST_F(E2EWriterTest, FlatMapWithNulls) {
       /*firstRowNotNull=*/true, /*enableFlatmapDictionaryEncoding=*/true);
 }
 
-TEST_F(E2EWriterTest, FlatMapWithNullsSharedDict) {
+TEST_F(E2EWriterTest, flatMapWithNullsSharedDict) {
   testFlatMapWithNulls(
       /*firstRowNotNull=*/false,
       /*enableFlatmapDictionaryEncoding=*/true,
@@ -762,7 +762,7 @@ TEST_F(E2EWriterTest, FlatMapWithNullsSharedDict) {
       /*shareDictionary=*/true);
 }
 
-TEST_F(E2EWriterTest, FlatMapEmpty) {
+TEST_F(E2EWriterTest, flatMapEmpty) {
   auto pool = memory::memoryManager()->addLeafPool();
 
   using keyType = int32_t;
@@ -803,7 +803,7 @@ TEST_F(E2EWriterTest, FlatMapEmpty) {
       dwrf::E2EWriterTestUtil::simpleFlushPolicyFactory(false));
 }
 
-TEST_F(E2EWriterTest, FlatMapConfigSingleColumn) {
+TEST_F(E2EWriterTest, flatMapConfigSingleColumn) {
   HiveTypeParser parser;
   auto type = parser.parse(
       "struct<"
@@ -814,7 +814,7 @@ TEST_F(E2EWriterTest, FlatMapConfigSingleColumn) {
   testFlatMapConfig(type, {}, {});
 }
 
-TEST_F(E2EWriterTest, FlatMapConfigMixedTypes) {
+TEST_F(E2EWriterTest, flatMapConfigMixedTypes) {
   HiveTypeParser parser;
   auto type = parser.parse(
       "struct<"
@@ -826,7 +826,7 @@ TEST_F(E2EWriterTest, FlatMapConfigMixedTypes) {
   testFlatMapConfig(type, {}, {});
 }
 
-TEST_F(E2EWriterTest, FlatMapConfigNestedMap) {
+TEST_F(E2EWriterTest, flatMapConfigNestedMap) {
   HiveTypeParser parser;
   auto type = parser.parse(
       "struct<"
@@ -838,7 +838,7 @@ TEST_F(E2EWriterTest, FlatMapConfigNestedMap) {
   testFlatMapConfig(type, {}, {});
 }
 
-TEST_F(E2EWriterTest, FlatMapConfigMixedMaps) {
+TEST_F(E2EWriterTest, flatMapConfigMixedMaps) {
   HiveTypeParser parser;
   auto type = parser.parse(
       "struct<"
@@ -852,7 +852,7 @@ TEST_F(E2EWriterTest, FlatMapConfigMixedMaps) {
   testFlatMapConfig(type, {}, {});
 }
 
-TEST_F(E2EWriterTest, FlatMapConfigNotMapColumn) {
+TEST_F(E2EWriterTest, flatMapConfigNotMapColumn) {
   HiveTypeParser parser;
   auto type = parser.parse(
       "struct<"
@@ -903,7 +903,7 @@ TEST_F(E2EWriterTest, mapStatsMultiStrides) {
   testFlatMapFileStats(type, {0, 1, 2, 3, 4, 5}, /*strideSize=*/1000);
 }
 
-TEST_F(E2EWriterTest, PartialStride) {
+TEST_F(E2EWriterTest, partialStride) {
   auto type = ROW({"bool_val"}, {INTEGER()});
 
   size_t batchSize = 1'000;
@@ -963,7 +963,7 @@ TEST_F(E2EWriterTest, PartialStride) {
   ASSERT_EQ(true, reader->columnStatistics(1)->hasNull().value());
 }
 
-TEST_F(E2EWriterTest, OversizeRows) {
+TEST_F(E2EWriterTest, oversizeRows) {
   auto pool = facebook::velox::memory::memoryManager()->addLeafPool();
 
   HiveTypeParser parser;
@@ -1001,7 +1001,7 @@ TEST_F(E2EWriterTest, OversizeRows) {
       false);
 }
 
-TEST_F(E2EWriterTest, OversizeBatches) {
+TEST_F(E2EWriterTest, oversizeBatches) {
   auto pool = facebook::velox::memory::memoryManager()->addLeafPool();
 
   HiveTypeParser parser;
@@ -1049,7 +1049,7 @@ TEST_F(E2EWriterTest, OversizeBatches) {
       false);
 }
 
-TEST_F(E2EWriterTest, OverflowLengthIncrements) {
+TEST_F(E2EWriterTest, overflowLengthIncrements) {
   auto pool = facebook::velox::memory::memoryManager()->addLeafPool();
 
   HiveTypeParser parser;
@@ -1203,7 +1203,7 @@ class E2EEncryptionTest : public E2EWriterTest {
   std::vector<VectorPtr> batches_;
 };
 
-TEST_F(E2EEncryptionTest, EncryptRoot) {
+TEST_F(E2EEncryptionTest, encryptRoot) {
   auto spec =
       std::make_shared<EncryptionSpecification>(EncryptionProvider::Unknown);
   spec->withRootEncryptionProperties(
@@ -1254,7 +1254,7 @@ TEST_F(E2EEncryptionTest, EncryptRoot) {
   validateFileContent(*reader);
 }
 
-TEST_F(E2EEncryptionTest, EncryptSelectedFields) {
+TEST_F(E2EEncryptionTest, encryptSelectedFields) {
   auto spec =
       std::make_shared<EncryptionSpecification>(EncryptionProvider::Unknown);
   spec->withEncryptedField(
@@ -1338,7 +1338,7 @@ TEST_F(E2EEncryptionTest, EncryptSelectedFields) {
   validateFileContent(*reader);
 }
 
-TEST_F(E2EEncryptionTest, EncryptEmptyFile) {
+TEST_F(E2EEncryptionTest, encryptEmptyFile) {
   auto spec =
       std::make_shared<EncryptionSpecification>(EncryptionProvider::Unknown);
   spec->withEncryptedField(
@@ -1353,7 +1353,7 @@ TEST_F(E2EEncryptionTest, EncryptEmptyFile) {
   ASSERT_FALSE(handler.isEncrypted());
 }
 
-TEST_F(E2EEncryptionTest, ReadWithoutKey) {
+TEST_F(E2EEncryptionTest, readWithoutKey) {
   auto spec =
       std::make_shared<EncryptionSpecification>(EncryptionProvider::Unknown);
   spec->withEncryptedField(

--- a/velox/dwio/dwrf/test/EncodingManagerTests.cpp
+++ b/velox/dwio/dwrf/test/EncodingManagerTests.cpp
@@ -24,7 +24,7 @@
 using namespace ::testing;
 
 namespace facebook::velox::dwrf {
-TEST(TestEncodingIter, Ctor) {
+TEST(TestEncodingIter, ctor) {
   proto::StripeFooter footer;
   std::vector<proto::StripeEncryptionGroup> encryptionGroups;
   // footer []
@@ -212,7 +212,7 @@ TEST(TestEncodingIter, Ctor) {
 
 // The Ctor test has covered most iterator adjustments. Suffices
 // to then just sanity test pass-in values.
-TEST(TestEncodingIter, EncodingIterBeginAndEnd) {
+TEST(TestEncodingIter, encodingIterBeginAndEnd) {
   proto::StripeFooter footer;
   footer.add_encoding();
   std::vector<proto::StripeEncryptionGroup> encryptionGroups;
@@ -279,7 +279,7 @@ void testEncodingIter(
 }
 } // namespace
 
-TEST(TestEncodingManager, EncodingIter) {
+TEST(TestEncodingManager, encodingIter) {
   testEncodingIter({{1, 0}}, {});
   testEncodingIter({}, {{{1, 0}}});
   testEncodingIter({{1, 0}}, {{{2, 1}, {2, 3}}});

--- a/velox/dwio/dwrf/test/EncryptionTests.cpp
+++ b/velox/dwio/dwrf/test/EncryptionTests.cpp
@@ -27,7 +27,7 @@ using namespace facebook::velox::dwio::common::encryption::test;
 using namespace facebook::velox::dwrf::encryption;
 using namespace facebook::velox::type::fbhive;
 
-TEST(Encryption, NotEncrypted) {
+TEST(Encryption, notEncrypted) {
   HiveTypeParser parser;
   auto type = parser.parse("struct<a:int>");
   EncryptionSpecification spec{EncryptionProvider::Unknown};
@@ -36,7 +36,7 @@ TEST(Encryption, NotEncrypted) {
   ASSERT_FALSE(handler->isEncrypted());
 }
 
-TEST(Encryption, RootThenField) {
+TEST(Encryption, rootThenField) {
   HiveTypeParser parser;
   auto type = parser.parse("struct<a:int>");
   EncryptionSpecification spec{EncryptionProvider::Unknown};
@@ -49,7 +49,7 @@ TEST(Encryption, RootThenField) {
       exception::LoggedException);
 }
 
-TEST(Encryption, FieldThenRoot) {
+TEST(Encryption, fieldThenRoot) {
   HiveTypeParser parser;
   auto type = parser.parse("struct<a:int>");
   EncryptionSpecification spec{EncryptionProvider::Unknown};
@@ -62,7 +62,7 @@ TEST(Encryption, FieldThenRoot) {
       exception::LoggedException);
 }
 
-TEST(Encryption, Root) {
+TEST(Encryption, root) {
   HiveTypeParser parser;
   auto type = parser.parse("struct<a:int, b:int>");
   EncryptionSpecification spec{EncryptionProvider::Unknown};
@@ -77,7 +77,7 @@ TEST(Encryption, Root) {
   }
 }
 
-TEST(Encryption, InvalidField) {
+TEST(Encryption, invalidField) {
   HiveTypeParser parser;
   auto type = parser.parse("struct<a:int>");
   EncryptionSpecification spec{EncryptionProvider::Unknown};
@@ -90,7 +90,7 @@ TEST(Encryption, InvalidField) {
       exception::LoggedException);
 }
 
-TEST(Encryption, InvalidProperties) {
+TEST(Encryption, invalidProperties) {
   HiveTypeParser parser;
   auto type = parser.parse("struct<a:int>");
   EncryptionSpecification spec{EncryptionProvider::Unknown};
@@ -101,7 +101,7 @@ TEST(Encryption, InvalidProperties) {
       exception::LoggedException);
 }
 
-TEST(Encryption, DifferentEncrypter) {
+TEST(Encryption, differentEncrypter) {
   HiveTypeParser parser;
   auto type = parser.parse("struct<a:int,b:int>");
   EncryptionSpecification spec{EncryptionProvider::Unknown};
@@ -116,7 +116,7 @@ TEST(Encryption, DifferentEncrypter) {
   ASSERT_EQ(handler->getEncryptionGroupCount(), 2);
 }
 
-TEST(Encryption, SameEncrypter) {
+TEST(Encryption, sameEncrypter) {
   HiveTypeParser parser;
   auto type = parser.parse("struct<a:int,b:int>");
   EncryptionSpecification spec{EncryptionProvider::Unknown};
@@ -132,7 +132,7 @@ TEST(Encryption, SameEncrypter) {
   ASSERT_EQ(handler->getEncryptionGroupCount(), 1);
 }
 
-TEST(Encryption, SameEncrypter2) {
+TEST(Encryption, sameEncrypter2) {
   HiveTypeParser parser;
   auto type = parser.parse("struct<a:int,b:int>");
   EncryptionSpecification spec{EncryptionProvider::Unknown};
@@ -147,7 +147,7 @@ TEST(Encryption, SameEncrypter2) {
   ASSERT_EQ(handler->getEncryptionGroupCount(), 1);
 }
 
-TEST(Encryption, DupeField) {
+TEST(Encryption, dupeField) {
   HiveTypeParser parser;
   auto type = parser.parse("struct<a:int,b:int>");
   EncryptionSpecification spec{EncryptionProvider::Unknown};
@@ -164,7 +164,7 @@ TEST(Encryption, DupeField) {
       exception::LoggedException);
 }
 
-TEST(Encryption, Basic) {
+TEST(Encryption, basic) {
   HiveTypeParser parser;
   auto type = parser.parse("struct<a:int,b:float,c:string,d:double>");
   EncryptionSpecification spec{EncryptionProvider::Unknown};
@@ -191,7 +191,7 @@ TEST(Encryption, Basic) {
   }
 }
 
-TEST(Encryption, NestedType) {
+TEST(Encryption, nestedType) {
   HiveTypeParser parser;
   auto type = parser.parse(
       "struct<a:int,b:map<float,map<int,double>>,c:struct<a:string,b:int>,d:array<double>>");

--- a/velox/dwio/dwrf/test/FileMetadataTest.cpp
+++ b/velox/dwio/dwrf/test/FileMetadataTest.cpp
@@ -37,14 +37,14 @@ class FileMetadataTest : public ::testing::Test {
       StripeFooterWrapper(orcStripeFooter_);
 };
 
-TEST_F(FileMetadataTest, StripeFooterWrapper_GetFormat_CorrectFormat) {
+TEST_F(FileMetadataTest, stripeFooterWrapper_GetFormat_CorrectFormat) {
   EXPECT_EQ(dwrfStripeFooterWrapper_.format(), DwrfFormat::kDwrf);
   EXPECT_EQ(orcStripeFooterWrapper_.format(), DwrfFormat::kOrc);
 }
 
 TEST_F(
     FileMetadataTest,
-    StripeFooterWrapper_GetStripeFooter_ReturnsProtoTypes) {
+    stripeFooterWrapper_GetStripeFooter_ReturnsProtoTypes) {
   EXPECT_EQ(
       &dwrfStripeFooterWrapper_.getStripeFooterDwrf(), dwrfStripeFooter_.get());
   EXPECT_ANY_THROW(dwrfStripeFooterWrapper_.getStripeFooterOrc());
@@ -56,7 +56,7 @@ TEST_F(
 
 TEST_F(
     FileMetadataTest,
-    StripeFooterWrapper_GetStreamData_ReturnsCorrispondingProtoInfo) {
+    stripeFooterWrapper_GetStreamData_ReturnsCorrispondingProtoInfo) {
   // 2 streams with incrementing length for validation
   dwrfStripeFooter_->add_streams()->set_length(1);
   dwrfStripeFooter_->add_streams()->set_length(2);
@@ -92,7 +92,7 @@ TEST_F(
 
 TEST_F(
     FileMetadataTest,
-    StripeFooterWrapper_GetEncodings_ReturnsCorrispondingProtoInfo) {
+    stripeFooterWrapper_GetEncodings_ReturnsCorrispondingProtoInfo) {
   // 2 encoding with incrementing node for validation
   dwrfStripeFooter_->add_encoding()->set_kind(
       proto::ColumnEncoding_Kind::ColumnEncoding_Kind_DICTIONARY);
@@ -143,7 +143,7 @@ TEST_F(
 
 TEST_F(
     FileMetadataTest,
-    StripeFooterWrapper_GetEncryptionGroups_ReturnsCorrispondingProtoInfo) {
+    stripeFooterWrapper_GetEncryptionGroups_ReturnsCorrispondingProtoInfo) {
   // 2 encryption groups with incrementing group for validation
   dwrfStripeFooter_->add_encryptiongroups()->append("test_encryption_group_1");
   dwrfStripeFooter_->add_encryptiongroups()->append("test_encryption_group_2");

--- a/velox/dwio/dwrf/test/FlushPolicyTest.cpp
+++ b/velox/dwio/dwrf/test/FlushPolicyTest.cpp
@@ -32,7 +32,7 @@ class DefaultFlushPolicyTest : public testing::Test {
   }
 };
 
-TEST_F(DefaultFlushPolicyTest, StripeProgressTest) {
+TEST_F(DefaultFlushPolicyTest, stripeProgressTest) {
   struct TestCase {
     const uint64_t stripeSizeThreshold;
     const int64_t stripeSize;
@@ -57,7 +57,7 @@ TEST_F(DefaultFlushPolicyTest, StripeProgressTest) {
   }
 }
 
-TEST_F(DefaultFlushPolicyTest, AdditionalCriteriaTest) {
+TEST_F(DefaultFlushPolicyTest, additionalCriteriaTest) {
   struct TestCase {
     const bool flushStripe;
     const bool overMemoryBudget;
@@ -134,7 +134,7 @@ TEST_F(DefaultFlushPolicyTest, AdditionalCriteriaTest) {
   }
 }
 
-TEST_F(DefaultFlushPolicyTest, EarlyDictionaryEvaluation) {
+TEST_F(DefaultFlushPolicyTest, earlyDictionaryEvaluation) {
   // Test the precedence of decisions.
   struct TestCase {
     dwio::common::StripeProgress stripeProgress;
@@ -237,7 +237,7 @@ TEST_F(DefaultFlushPolicyTest, EarlyDictionaryEvaluation) {
       FlushDecision::SKIP);
 }
 
-TEST_F(DefaultFlushPolicyTest, EmptyFile) {
+TEST_F(DefaultFlushPolicyTest, emptyFile) {
   // Empty vector creation succeeds.
   RowsPerStripeFlushPolicy policy({});
 
@@ -246,7 +246,7 @@ TEST_F(DefaultFlushPolicyTest, EmptyFile) {
       exception::LoggedException);
 }
 
-TEST_F(DefaultFlushPolicyTest, InvalidCases) {
+TEST_F(DefaultFlushPolicyTest, invalidCases) {
   // Vector with 0 rows, throws
   ASSERT_THROW(
       RowsPerStripeFlushPolicy policy({5, 7, 0, 10}),
@@ -254,7 +254,7 @@ TEST_F(DefaultFlushPolicyTest, InvalidCases) {
 }
 
 // RowsPerStripeFlushPolicy has no dictionary flush criteria.
-TEST_F(DefaultFlushPolicyTest, DictionaryCriteriaTest) {
+TEST_F(DefaultFlushPolicyTest, dictionaryCriteriaTest) {
   auto config = std::make_shared<Config>();
   WriterContext context{
       config, memory::memoryManager()->addRootPool("DictionaryCriteriaTest")};
@@ -294,7 +294,7 @@ TEST_F(DefaultFlushPolicyTest, DictionaryCriteriaTest) {
           context));
 }
 
-TEST_F(DefaultFlushPolicyTest, FlushTest) {
+TEST_F(DefaultFlushPolicyTest, flushTest) {
   RowsPerStripeFlushPolicy policy({5, 7, 12});
 
   ASSERT_FALSE(policy.shouldFlush(

--- a/velox/dwio/dwrf/test/IndexBuilderTests.cpp
+++ b/velox/dwio/dwrf/test/IndexBuilderTests.cpp
@@ -41,14 +41,14 @@ class IndexBuilderTest : public testing::Test {
   StatisticsBuilderOptions options_{16};
 };
 
-TEST_F(IndexBuilderTest, Constructor) {
+TEST_F(IndexBuilderTest, constructor) {
   IndexBuilder builder{nullptr};
   EXPECT_EQ(1, builder.getEntrySize());
   // Ensure a clean start.
   EXPECT_EQ(0, getEntry(builder, 0).positionsSize());
 }
 
-TEST_F(IndexBuilderTest, AddEntry) {
+TEST_F(IndexBuilderTest, addEntry) {
   IndexBuilder builder{nullptr};
   ASSERT_EQ(1, builder.getEntrySize());
   builder.add(0uL);
@@ -70,7 +70,7 @@ TEST_F(IndexBuilderTest, AddEntry) {
   }
 }
 
-TEST_F(IndexBuilderTest, Add) {
+TEST_F(IndexBuilderTest, add) {
   IndexBuilder builder{nullptr};
   builder.add(0uL);
   EXPECT_THAT(getPositions(builder, 0), ElementsAreArray({0uL}));
@@ -90,7 +90,7 @@ TEST_F(IndexBuilderTest, Add) {
   EXPECT_THAT(getPositions(builder, 2), ElementsAreArray({144uL}));
 }
 
-TEST_F(IndexBuilderTest, Backfill) {
+TEST_F(IndexBuilderTest, backfill) {
   IndexBuilder builder{nullptr};
   StatisticsBuilder sb{options_};
   builder.addEntry(sb);
@@ -124,7 +124,7 @@ TEST_F(IndexBuilderTest, Backfill) {
   ASSERT_EQ(0, getEntry(builder, 6).positionsSize());
 }
 
-TEST_F(IndexBuilderTest, RemovePresentStreamPositions) {
+TEST_F(IndexBuilderTest, removePresentStreamPositions) {
   IndexBuilder builder{nullptr};
   auto indexCount = 3;
   StatisticsBuilder sb{options_};

--- a/velox/dwio/dwrf/test/LayoutPlannerTests.cpp
+++ b/velox/dwio/dwrf/test/LayoutPlannerTests.cpp
@@ -44,7 +44,7 @@ class LayoutPlannerTest : public testing::Test {
 };
 } // namespace
 
-TEST_F(LayoutPlannerTest, CreateNodeToColumnIdMapping) {
+TEST_F(LayoutPlannerTest, createNodeToColumnIdMapping) {
   testCreateNodeToColumnIdMapping(ROW({BOOLEAN()}), {{0, 0}, {1, 0}});
   testCreateNodeToColumnIdMapping(
       ROW(
@@ -96,7 +96,7 @@ TEST_F(LayoutPlannerTest, CreateNodeToColumnIdMapping) {
        {17, 5}});
 }
 
-TEST_F(LayoutPlannerTest, Basic) {
+TEST_F(LayoutPlannerTest, basic) {
   auto config = std::make_shared<Config>();
   config->set(
       Config::COMPRESSION, common::CompressionKind::CompressionKind_NONE);

--- a/velox/dwio/dwrf/test/PhysicalSizeAggregatorTest.cpp
+++ b/velox/dwio/dwrf/test/PhysicalSizeAggregatorTest.cpp
@@ -21,7 +21,7 @@
 using namespace ::testing;
 
 namespace facebook::velox::dwrf {
-TEST(PhysicalSizeAggregatorTest, UpdateLeaf) {
+TEST(PhysicalSizeAggregatorTest, updateLeaf) {
   auto leafOne = std::make_unique<PhysicalSizeAggregator>(nullptr);
   auto leafTwo = std::make_unique<PhysicalSizeAggregator>(nullptr);
   ASSERT_EQ(0, leafOne->getResult());
@@ -43,7 +43,7 @@ TEST(PhysicalSizeAggregatorTest, UpdateLeaf) {
   EXPECT_EQ(2, leafTwo->getResult());
 }
 
-TEST(PhysicalSizeAggregatorTest, UpdateParent) {
+TEST(PhysicalSizeAggregatorTest, updateParent) {
   auto parent = std::make_unique<PhysicalSizeAggregator>(nullptr);
   auto childOne = std::make_unique<PhysicalSizeAggregator>(parent.get());
   auto childTwo = std::make_unique<PhysicalSizeAggregator>(parent.get());

--- a/velox/dwio/dwrf/test/RatioTrackerTest.cpp
+++ b/velox/dwio/dwrf/test/RatioTrackerTest.cpp
@@ -23,7 +23,7 @@ using namespace ::testing;
 
 namespace facebook::velox::dwrf {
 
-TEST(RatioTrackerTest, BasicTests) {
+TEST(RatioTrackerTest, basicTests) {
   struct TestCase {
     explicit TestCase(
         std::shared_ptr<RatioTracker> tracker,
@@ -70,7 +70,7 @@ TEST(RatioTrackerTest, BasicTests) {
   }
 }
 
-TEST(RatioTrackerTest, EmptyInputTests) {
+TEST(RatioTrackerTest, emptyInputTests) {
   struct TestCase {
     explicit TestCase(
         std::shared_ptr<RatioTracker> tracker,

--- a/velox/dwio/dwrf/test/ReaderBaseTests.cpp
+++ b/velox/dwio/dwrf/test/ReaderBaseTests.cpp
@@ -237,7 +237,7 @@ class ReaderBaseTest : public Test {
   }
 };
 
-TEST_F(ReaderBaseTest, InvalidPostScriptThrows) {
+TEST_F(ReaderBaseTest, invalidPostScriptThrows) {
   VELOX_ASSERT_THROW(
       createCorruptedFileReader(1'000'000, 0),
       "Corrupted file, footer size is invalid");

--- a/velox/dwio/dwrf/test/ReaderTest.cpp
+++ b/velox/dwio/dwrf/test/ReaderTest.cpp
@@ -1561,7 +1561,7 @@ TEST_F(TestReader, fileColumnNamesReadAsLowerCaseComplexStruct) {
   EXPECT_EQ(col0_1_1_0_0->childByName("ccint3"), col0_1_1_0_0_0);
 }
 
-TEST_F(TestReader, TestStripeSizeCallback) {
+TEST_F(TestReader, testStripeSizeCallback) {
   dwio::common::ReaderOptions readerOpts{pool()};
   readerOpts.setDataIoStats(dataIoStats_);
   readerOpts.setMetadataIoStats(metadataIoStats_);
@@ -1591,7 +1591,7 @@ TEST_F(TestReader, TestStripeSizeCallback) {
   EXPECT_EQ(numCalls, 1);
 }
 
-TEST_F(TestReader, TestStripeSizeCallbackLimitsOneStripe) {
+TEST_F(TestReader, testStripeSizeCallbackLimitsOneStripe) {
   dwio::common::ReaderOptions readerOpts{pool()};
   readerOpts.setDataIoStats(dataIoStats_);
   readerOpts.setMetadataIoStats(metadataIoStats_);
@@ -1622,7 +1622,7 @@ TEST_F(TestReader, TestStripeSizeCallbackLimitsOneStripe) {
   EXPECT_EQ(numCalls, 1);
 }
 
-TEST_F(TestReader, TestStripeSizeCallbackLimitsTwoStripe) {
+TEST_F(TestReader, testStripeSizeCallbackLimitsTwoStripe) {
   dwio::common::ReaderOptions readerOpts{pool()};
   readerOpts.setDataIoStats(dataIoStats_);
   readerOpts.setMetadataIoStats(metadataIoStats_);

--- a/velox/dwio/dwrf/test/StreamLabelsTests.cpp
+++ b/velox/dwio/dwrf/test/StreamLabelsTests.cpp
@@ -30,7 +30,7 @@ class StreamLabelsTest : public testing::Test {
   }
 };
 
-TEST_F(StreamLabelsTest, E2E) {
+TEST_F(StreamLabelsTest, e2e) {
   auto pool = facebook::velox::memory::memoryManager()->addLeafPool();
   AllocationPool allocationPool(pool.get());
   StreamLabels root(allocationPool);

--- a/velox/dwio/dwrf/test/StripeReaderBaseTests.cpp
+++ b/velox/dwio/dwrf/test/StripeReaderBaseTests.cpp
@@ -118,22 +118,22 @@ class StripeLoadKeysTest : public Test {
 
 } // namespace facebook::velox::dwrf
 
-TEST_F(StripeLoadKeysTest, FirstStripeHasKey) {
+TEST_F(StripeLoadKeysTest, firstStripeHasKey) {
   runTest(0);
   ASSERT_EQ(enc_->getKey(), "stripe0");
 }
 
-TEST_F(StripeLoadKeysTest, SecondStripeNoKey) {
+TEST_F(StripeLoadKeysTest, secondStripeNoKey) {
   runTest(1);
   ASSERT_EQ(enc_->getKey(), "stripe0");
 }
 
-TEST_F(StripeLoadKeysTest, ThirdStripeHasKey) {
+TEST_F(StripeLoadKeysTest, thirdStripeHasKey) {
   runTest(2);
   ASSERT_EQ(enc_->getKey(), "stripe2");
 }
 
-TEST_F(StripeLoadKeysTest, KeyMismatch) {
+TEST_F(StripeLoadKeysTest, keyMismatch) {
   try {
     static_cast<void>(runTest(3));
     FAIL() << "Expected an exception";

--- a/velox/dwio/dwrf/test/TestBufferedOutputStream.cpp
+++ b/velox/dwio/dwrf/test/TestBufferedOutputStream.cpp
@@ -246,7 +246,7 @@ class AppendOnlyBufferedStreamTest : public testing::Test {
   std::shared_ptr<MemoryPool> pool_ = memoryManager()->addLeafPool();
 };
 
-TEST_F(AppendOnlyBufferedStreamTest, Basic) {
+TEST_F(AppendOnlyBufferedStreamTest, basic) {
   MemorySink memSink(1024, {.pool = pool_.get()});
   uint64_t block = 10;
   DataBufferHolder holder{*pool_, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};

--- a/velox/dwio/dwrf/test/TestDictionaryEncodingUtils.cpp
+++ b/velox/dwio/dwrf/test/TestDictionaryEncodingUtils.cpp
@@ -32,7 +32,7 @@ class DictionaryEncodingUtilsTest : public testing::Test {
   }
 };
 
-TEST_F(DictionaryEncodingUtilsTest, StringGetSortedIndexLookupTable) {
+TEST_F(DictionaryEncodingUtilsTest, stringGetSortedIndexLookupTable) {
   struct TestCase {
     explicit TestCase(
         bool sort,
@@ -146,7 +146,7 @@ TEST_F(DictionaryEncodingUtilsTest, StringGetSortedIndexLookupTable) {
   }
 }
 
-TEST_F(DictionaryEncodingUtilsTest, StringStrideDictOptimization) {
+TEST_F(DictionaryEncodingUtilsTest, stringStrideDictOptimization) {
   constexpr size_t kStrideSize{10};
   struct TestCase {
     explicit TestCase(

--- a/velox/dwio/dwrf/test/TestEncodingSelector.cpp
+++ b/velox/dwio/dwrf/test/TestEncodingSelector.cpp
@@ -28,7 +28,7 @@ class EntropyEncodingSelectorTests : public testing::Test {
   }
 };
 
-TEST_F(EntropyEncodingSelectorTests, Ctor) {
+TEST_F(EntropyEncodingSelectorTests, ctor) {
   auto pool = memoryManager()->addLeafPool();
   float slightlyOver = 1.0f + std::numeric_limits<float>::epsilon() * 2;
   float slightlyUnder = -std::numeric_limits<float>::epsilon();
@@ -94,7 +94,7 @@ class EntropyEncodingSelectorTest {
   }
 };
 
-TEST_F(EntropyEncodingSelectorTests, NoHeuristic) {
+TEST_F(EntropyEncodingSelectorTests, noHeuristic) {
   class TestCase : public EntropyEncodingSelectorTest {
    public:
     explicit TestCase(
@@ -137,7 +137,7 @@ TEST_F(EntropyEncodingSelectorTests, NoHeuristic) {
   }
 }
 
-TEST_F(EntropyEncodingSelectorTests, NoSampling) {
+TEST_F(EntropyEncodingSelectorTests, noSampling) {
   class TestCase : public EntropyEncodingSelectorTest {
    public:
     explicit TestCase(
@@ -187,7 +187,7 @@ std::string alphabeticRoundRobin(size_t index, size_t size) {
   return std::string(size % (index + 1), element);
 }
 
-TEST_F(EntropyEncodingSelectorTests, Sampling) {
+TEST_F(EntropyEncodingSelectorTests, sampling) {
   class TestCase : public EntropyEncodingSelectorTest {
    public:
     explicit TestCase(

--- a/velox/dwio/dwrf/test/TestIntEncoder.cpp
+++ b/velox/dwio/dwrf/test/TestIntEncoder.cpp
@@ -32,7 +32,7 @@ class VarintPairs {
       : value{value}, varInt{varInt} {}
 };
 
-TEST(TestIntEncoder, TestVarIntEncoder) {
+TEST(TestIntEncoder, testVarIntEncoder) {
   auto values = std::vector<VarintPairs>{
       {0, {0x0}},
       {(1ul << 7) - 1, {0x7F}},

--- a/velox/dwio/dwrf/test/TestIntegerDictionaryEncoder.cpp
+++ b/velox/dwio/dwrf/test/TestIntegerDictionaryEncoder.cpp
@@ -33,7 +33,7 @@ class TestIntegerDictionaryEncoder : public ::testing::Test {
   }
 };
 
-TEST_F(TestIntegerDictionaryEncoder, AddKey) {
+TEST_F(TestIntegerDictionaryEncoder, addKey) {
   struct TestCase {
     explicit TestCase(
         const std::vector<int64_t>& addKeySequence,
@@ -61,7 +61,7 @@ TEST_F(TestIntegerDictionaryEncoder, AddKey) {
   }
 }
 
-TEST_F(TestIntegerDictionaryEncoder, GetCount) {
+TEST_F(TestIntegerDictionaryEncoder, getCount) {
   struct TestCase {
     explicit TestCase(
         const std::vector<int64_t>& addKeySequence,
@@ -99,7 +99,7 @@ TEST_F(TestIntegerDictionaryEncoder, GetCount) {
   }
 }
 
-TEST_F(TestIntegerDictionaryEncoder, GetTotalCount) {
+TEST_F(TestIntegerDictionaryEncoder, getTotalCount) {
   struct TestCase {
     explicit TestCase(
         const std::vector<int64_t>& addKeySequence,
@@ -126,7 +126,7 @@ TEST_F(TestIntegerDictionaryEncoder, GetTotalCount) {
   }
 }
 
-TEST_F(TestIntegerDictionaryEncoder, Clear) {
+TEST_F(TestIntegerDictionaryEncoder, clear) {
   auto pool = memoryManager()->addLeafPool();
   {
     IntegerDictionaryEncoder<int64_t> intDictEncoder{*pool, *pool};
@@ -207,7 +207,7 @@ TEST_F(TestIntegerDictionaryEncoder, Clear) {
   }
 }
 
-TEST_F(TestIntegerDictionaryEncoder, RepeatedFlush) {
+TEST_F(TestIntegerDictionaryEncoder, repeatedFlush) {
   auto pool = memoryManager()->addLeafPool();
   IntegerDictionaryEncoder<int64_t> intDictEncoder{*pool, *pool};
   std::vector<int> keys{0, 1, 4, 9, 16, 25, 9, 1};
@@ -233,7 +233,7 @@ TEST_F(TestIntegerDictionaryEncoder, RepeatedFlush) {
   EXPECT_ANY_THROW(intDictEncoder.getLookupTable());
 }
 
-TEST_F(TestIntegerDictionaryEncoder, Limit) {
+TEST_F(TestIntegerDictionaryEncoder, limit) {
   auto pool = memoryManager()->addLeafPool();
   IntegerDictionaryEncoder<int16_t> intDictEncoder{*pool, *pool};
   for (size_t iter = 0; iter < 2; ++iter) {
@@ -310,13 +310,13 @@ void testGetSortedIndexLookupTable() {
   }
 }
 
-TEST_F(TestIntegerDictionaryEncoder, GetSortedIndexLookupTable) {
+TEST_F(TestIntegerDictionaryEncoder, getSortedIndexLookupTable) {
   testGetSortedIndexLookupTable<int16_t>();
   testGetSortedIndexLookupTable<int32_t>();
   testGetSortedIndexLookupTable<int64_t>();
 }
 
-TEST_F(TestIntegerDictionaryEncoder, ShortIntegerDictionary) {
+TEST_F(TestIntegerDictionaryEncoder, shortIntegerDictionary) {
   // DictionaryEncoding lookupTable can contain the index into dictionary
   // or the actual value. For short integer, index can be  [0,2^16-1]
   // and the values can be from [-2^15, 2^15-1]. Integer writers always
@@ -494,7 +494,7 @@ void testInfrequentKeyOptimization() {
   }
 }
 
-TEST_F(TestIntegerDictionaryEncoder, InfrequentKeyOptimization) {
+TEST_F(TestIntegerDictionaryEncoder, infrequentKeyOptimization) {
   testInfrequentKeyOptimization<int16_t>();
   testInfrequentKeyOptimization<int32_t>();
   testInfrequentKeyOptimization<int64_t>();

--- a/velox/dwio/dwrf/test/TestStringDictionaryEncoder.cpp
+++ b/velox/dwio/dwrf/test/TestStringDictionaryEncoder.cpp
@@ -30,7 +30,7 @@ class TestStringDictionaryEncoder : public ::testing::Test {
   }
 };
 
-TEST_F(TestStringDictionaryEncoder, AddKey) {
+TEST_F(TestStringDictionaryEncoder, addKey) {
   struct TestCase {
     explicit TestCase(
         const std::vector<std::string_view>& addKeySequence,
@@ -58,7 +58,7 @@ TEST_F(TestStringDictionaryEncoder, AddKey) {
   }
 }
 
-TEST_F(TestStringDictionaryEncoder, GetIndex) {
+TEST_F(TestStringDictionaryEncoder, getIndex) {
   struct TestCase {
     explicit TestCase(
         const std::vector<std::string_view>& addKeySequence,
@@ -106,7 +106,7 @@ TEST_F(TestStringDictionaryEncoder, GetIndex) {
   }
 }
 
-TEST_F(TestStringDictionaryEncoder, GetCount) {
+TEST_F(TestStringDictionaryEncoder, getCount) {
   struct TestCase {
     explicit TestCase(
         const std::vector<std::string_view>& addKeySequence,
@@ -156,7 +156,7 @@ TEST_F(TestStringDictionaryEncoder, GetCount) {
   }
 }
 
-TEST_F(TestStringDictionaryEncoder, GetStride) {
+TEST_F(TestStringDictionaryEncoder, getStride) {
   struct TestCase {
     explicit TestCase(
         const std::vector<std::pair<std::string_view, size_t>>& addKeySequence,
@@ -216,7 +216,7 @@ std::string genPaddedIntegerString(size_t integer, size_t length) {
   return padding + origString;
 }
 
-TEST_F(TestStringDictionaryEncoder, Clear) {
+TEST_F(TestStringDictionaryEncoder, clear) {
   auto pool = memory::memoryManager()->addLeafPool();
   StringDictionaryEncoder stringDictEncoder{*pool, *pool};
   std::string baseString{"jjkkll"};
@@ -238,7 +238,7 @@ TEST_F(TestStringDictionaryEncoder, Clear) {
   EXPECT_LT(pool->usedBytes(), peakMemory);
 }
 
-TEST_F(TestStringDictionaryEncoder, MemBenchmark) {
+TEST_F(TestStringDictionaryEncoder, memBenchmark) {
   auto pool = memory::memoryManager()->addLeafPool();
   StringDictionaryEncoder stringDictEncoder{*pool, *pool};
   std::string baseString{"jjkkll"};
@@ -249,7 +249,7 @@ TEST_F(TestStringDictionaryEncoder, MemBenchmark) {
   LOG(INFO) << "Total memory bytes: " << pool->usedBytes();
 }
 
-TEST_F(TestStringDictionaryEncoder, Limit) {
+TEST_F(TestStringDictionaryEncoder, limit) {
   auto pool = memory::memoryManager()->addLeafPool();
   StringDictionaryEncoder encoder{*pool, *pool};
   encoder.addKey(std::string_view{"abc"}, 0);

--- a/velox/dwio/dwrf/test/TestStripeDictionaryCache.cpp
+++ b/velox/dwio/dwrf/test/TestStripeDictionaryCache.cpp
@@ -66,7 +66,7 @@ class StripeDictionaryCacheTest : public testing::Test {
 };
 } // namespace
 
-TEST_F(StripeDictionaryCacheTest, RegisterDictionary) {
+TEST_F(StripeDictionaryCacheTest, registerDictionary) {
   {
     StripeDictionaryCache cache{pool_.get()};
     cache.registerIntDictionary({9, 0}, genConsecutiveRangeBuffer(0, 100));
@@ -100,7 +100,7 @@ TEST_F(StripeDictionaryCacheTest, RegisterDictionary) {
   }
 }
 
-TEST_F(StripeDictionaryCacheTest, GetDictionaryBuffer) {
+TEST_F(StripeDictionaryCacheTest, getDictionaryBuffer) {
   {
     StripeDictionaryCache cache{pool_.get()};
 

--- a/velox/dwio/dwrf/test/WriterContextTest.cpp
+++ b/velox/dwio/dwrf/test/WriterContextTest.cpp
@@ -31,7 +31,7 @@ class WriterContextTest : public testing::Test {
   }
 };
 
-TEST_F(WriterContextTest, GetIntDictionaryEncoder) {
+TEST_F(WriterContextTest, getIntDictionaryEncoder) {
   auto config = std::make_shared<Config>();
   WriterContext context{
       config, memory::memoryManager()->addRootPool("GetIntDictionaryEncoder")};
@@ -64,7 +64,7 @@ TEST_F(WriterContextTest, GetIntDictionaryEncoder) {
   EXPECT_EQ(2, context.dictEncoders_.size());
 }
 
-TEST_F(WriterContextTest, RemoveIntDictionaryEncoderForNode) {
+TEST_F(WriterContextTest, removeIntDictionaryEncoderForNode) {
   auto config = std::make_shared<Config>();
   config->set(Config::MAP_FLAT_DICT_SHARE, false);
   WriterContext context{
@@ -117,7 +117,7 @@ TEST_F(WriterContextTest, RemoveIntDictionaryEncoderForNode) {
   EXPECT_EQ(0, context.dictEncoders_.size());
 }
 
-TEST_F(WriterContextTest, BuildPhysicalSizeAggregators) {
+TEST_F(WriterContextTest, buildPhysicalSizeAggregators) {
   auto config = std::make_shared<Config>();
   WriterContext context{
       config,

--- a/velox/dwio/dwrf/test/WriterExtendedTests.cpp
+++ b/velox/dwio/dwrf/test/WriterExtendedTests.cpp
@@ -96,7 +96,7 @@ class E2EWriterTest : public testing::Test {
   }
 };
 
-TEST_F(E2EWriterTest, FlushPolicySimpleEncoding) {
+TEST_F(E2EWriterTest, flushPolicySimpleEncoding) {
   const size_t batchCount = 200;
   const size_t batchSize = 1000;
   auto pool = facebook::velox::memory::memoryManager()->addLeafPool();
@@ -152,7 +152,7 @@ TEST_F(E2EWriterTest, FlushPolicySimpleEncoding) {
 
 // Many streams are not yet allocated prior to the first flush, hence first
 // flush is delayed if we rely on stream usage to estimate stripe size.
-TEST_F(E2EWriterTest, FlushPolicyDictionaryEncoding) {
+TEST_F(E2EWriterTest, flushPolicyDictionaryEncoding) {
   const size_t batchCount = 500;
   const size_t batchSize = 1000;
   auto pool = facebook::velox::memory::memoryManager()->addLeafPool();
@@ -277,7 +277,7 @@ TEST_F(E2EWriterTest, FlushPolicyDictionaryEncoding) {
 }
 
 // stream usage seems to have a delta that is close to compression block size?
-TEST_F(E2EWriterTest, FlushPolicyNestedTypes) {
+TEST_F(E2EWriterTest, flushPolicyNestedTypes) {
   const size_t batchCount = 10;
   const size_t batchSize = 1000;
   auto pool = facebook::velox::memory::memoryManager()->addLeafPool();
@@ -326,7 +326,7 @@ TEST_F(E2EWriterTest, FlushPolicyNestedTypes) {
 }
 
 // Flat map has 1.5 orders of magnitude inflated stream memory usage.
-TEST_F(E2EWriterTest, FlushPolicyFlatMap) {
+TEST_F(E2EWriterTest, flushPolicyFlatMap) {
   const size_t batchCount = 10;
   const size_t batchSize = 500;
   auto pool = facebook::velox::memory::memoryManager()->addLeafPool();
@@ -423,7 +423,7 @@ TEST_F(E2EWriterTest, FlushPolicyFlatMap) {
   }
 }
 
-TEST_F(E2EWriterTest, MemoryPoolBasedFlushPolicySimpleEncoding) {
+TEST_F(E2EWriterTest, memoryPoolBasedFlushPolicySimpleEncoding) {
   const size_t batchCount = 2000;
   const size_t batchSize = 5000;
   auto pool = facebook::velox::memory::memoryManager()->addLeafPool();
@@ -481,7 +481,7 @@ TEST_F(E2EWriterTest, MemoryPoolBasedFlushPolicySimpleEncoding) {
 
 // Many streams are not yet allocated prior to the first flush, hence first
 // flush is delayed if we rely on stream usage to estimate stripe size.
-TEST_F(E2EWriterTest, MemoryPoolBasedFlushPolicyDictionaryEncoding) {
+TEST_F(E2EWriterTest, memoryPoolBasedFlushPolicyDictionaryEncoding) {
   const size_t batchCount = 1000;
   const size_t batchSize = 2000;
   auto pool = facebook::velox::memory::memoryManager()->addLeafPool();
@@ -618,7 +618,7 @@ TEST_F(E2EWriterTest, MemoryPoolBasedFlushPolicyDictionaryEncoding) {
 }
 
 // stream usage seems to have a delta that is close to compression block size?
-TEST_F(E2EWriterTest, MemoryPoolBasedFlushPolicyNestedTypes) {
+TEST_F(E2EWriterTest, memoryPoolBasedFlushPolicyNestedTypes) {
   const size_t batchCount = 100;
   const size_t batchSize = 1000;
   auto pool = facebook::velox::memory::memoryManager()->addLeafPool();

--- a/velox/dwio/dwrf/test/WriterFlushTest.cpp
+++ b/velox/dwio/dwrf/test/WriterFlushTest.cpp
@@ -271,7 +271,7 @@ class DummyWriter : public velox::dwrf::Writer {
   MOCK_METHOD0(resetImpl, void());
 
   friend class WriterFlushTestHelper;
-  VELOX_FRIEND_TEST(TestWriterFlush, CheckAgainstMemoryBudget);
+  VELOX_FRIEND_TEST(TestWriterFlush, checkAgainstMemoryBudget);
 };
 
 // Big idea is to directly manipulate context states (num rows) + memory pool
@@ -496,7 +496,7 @@ class TestWriterFlush : public testing::Test {
 };
 
 // This test checks against constructed test cases.
-TEST_F(TestWriterFlush, CheckAgainstMemoryBudget) {
+TEST_F(TestWriterFlush, checkAgainstMemoryBudget) {
   auto pool = MockMemoryPool::create();
   {
     auto writer = WriterFlushTestHelper::prepWriter(pool, 1024);
@@ -646,7 +646,7 @@ TEST_F(TestWriterFlush, CheckAgainstMemoryBudget) {
 }
 
 // Tests the number of stripes produced based on random results.
-TEST_F(TestWriterFlush, MemoryBasedFlushRandom) {
+TEST_F(TestWriterFlush, memoryBasedFlushRandom) {
   struct TestCase {
     TestCase(
         uint32_t seed,

--- a/velox/dwio/dwrf/test/WriterSinkTest.cpp
+++ b/velox/dwio/dwrf/test/WriterSinkTest.cpp
@@ -50,7 +50,7 @@ class WriterSinkTest : public Test {
   std::array<char, 1024> data;
 };
 
-TEST_F(WriterSinkTest, Checksum) {
+TEST_F(WriterSinkTest, checksum) {
   auto pool = memoryManager()->addLeafPool();
   MemorySink out{1024 + 3, {.pool = pool.get()}};
   Config config;
@@ -93,7 +93,7 @@ TEST_F(WriterSinkTest, Checksum) {
   ASSERT_EQ(sink.size(), out.size() - offset);
 }
 
-TEST_F(WriterSinkTest, NoChecksum) {
+TEST_F(WriterSinkTest, noChecksum) {
   auto pool = memoryManager()->addLeafPool();
   MemorySink out{1024 + 3, {.pool = pool.get()}};
   Config config;
@@ -110,7 +110,7 @@ TEST_F(WriterSinkTest, NoChecksum) {
   checkOutput(out, offset);
 }
 
-TEST_F(WriterSinkTest, NoCache) {
+TEST_F(WriterSinkTest, noCache) {
   auto pool = memoryManager()->addLeafPool();
   MemorySink out{1024, {.pool = pool.get()}};
   Config config;
@@ -135,7 +135,7 @@ TEST_F(WriterSinkTest, NoCache) {
   ASSERT_EQ(out.size() - offset, 512);
 }
 
-TEST_F(WriterSinkTest, CacheIndex) {
+TEST_F(WriterSinkTest, cacheIndex) {
   auto pool = memoryManager()->addLeafPool();
   MemorySink out{1024, {.pool = pool.get()}};
   Config config;
@@ -178,7 +178,7 @@ TEST_F(WriterSinkTest, CacheIndex) {
       std::string(out.data() + offset, 128));
 }
 
-TEST_F(WriterSinkTest, CacheFooter) {
+TEST_F(WriterSinkTest, cacheFooter) {
   auto pool = memoryManager()->addLeafPool();
   MemorySink out{1024, {.pool = pool.get()}};
   Config config;
@@ -221,7 +221,7 @@ TEST_F(WriterSinkTest, CacheFooter) {
       std::string(out.data() + offset + 384, 128));
 }
 
-TEST_F(WriterSinkTest, CacheBothEmptyIndex) {
+TEST_F(WriterSinkTest, cacheBothEmptyIndex) {
   auto pool = memoryManager()->addLeafPool();
   MemorySink out{1024, {.pool = pool.get()}};
   Config config;
@@ -250,7 +250,7 @@ TEST_F(WriterSinkTest, CacheBothEmptyIndex) {
   ASSERT_EQ(sink.getCacheSize(), 128);
 }
 
-TEST_F(WriterSinkTest, CacheBoth) {
+TEST_F(WriterSinkTest, cacheBoth) {
   auto pool = memoryManager()->addLeafPool();
   MemorySink out{1024, {.pool = pool.get()}};
   Config config;
@@ -299,7 +299,7 @@ TEST_F(WriterSinkTest, CacheBoth) {
       std::string(out.data() + offset + 512, 128));
 }
 
-TEST_F(WriterSinkTest, CacheExceedsLimit) {
+TEST_F(WriterSinkTest, cacheExceedsLimit) {
   auto pool = memoryManager()->addLeafPool();
   MemorySink out{1024, {.pool = pool.get()}};
   Config config;
@@ -427,7 +427,7 @@ TEST_F(WriterSinkTest, CacheExceedsLimit) {
   }
 }
 
-TEST_F(WriterSinkTest, CacheLarge) {
+TEST_F(WriterSinkTest, cacheLarge) {
   auto pool = memoryManager()->addLeafPool();
   MemorySink out{10 * 1024 * 1024 + 3, {.pool = pool.get()}};
   Config config;
@@ -454,7 +454,7 @@ TEST_F(WriterSinkTest, CacheLarge) {
   ASSERT_EQ(out.size() - offset, total * 2);
 }
 
-TEST_F(WriterSinkTest, SetModeOutOfOrder) {
+TEST_F(WriterSinkTest, setModeOutOfOrder) {
   auto pool = memoryManager()->addLeafPool();
   MemorySink out{1024, {.pool = pool.get()}};
   Config config;

--- a/velox/dwio/dwrf/test/WriterTest.cpp
+++ b/velox/dwio/dwrf/test/WriterTest.cpp
@@ -205,7 +205,7 @@ TEST_P(AllWriterCompressionTest, compression) {
           : compressionKind_);
 }
 
-TEST_P(SupportedCompressionTest, WriteFooter) {
+TEST_P(SupportedCompressionTest, writeFooter) {
   auto config = std::make_shared<Config>();
   config->set(Config::COMPRESSION, supportedCompressionKind_);
   auto& writer = createWriter(config);
@@ -298,7 +298,7 @@ TEST_P(SupportedCompressionTest, WriteFooter) {
   }
 }
 
-TEST_P(SupportedCompressionTest, AddStripeInfo) {
+TEST_P(SupportedCompressionTest, addStripeInfo) {
   auto config = std::make_shared<Config>();
   config->set(Config::COMPRESSION, supportedCompressionKind_);
   auto& writer = createWriter(config);
@@ -320,7 +320,7 @@ TEST_P(SupportedCompressionTest, AddStripeInfo) {
   writer.close();
 }
 
-TEST_P(SupportedCompressionTest, NoChecksum) {
+TEST_P(SupportedCompressionTest, noChecksum) {
   auto config = std::make_shared<Config>();
   config->set(Config::CHECKSUM_ALGORITHM, proto::ChecksumAlgorithm::NULL_);
   config->set(Config::COMPRESSION, supportedCompressionKind_);
@@ -352,7 +352,7 @@ TEST_P(SupportedCompressionTest, NoChecksum) {
   ASSERT_EQ(footer.checksumAlgorithm(), proto::ChecksumAlgorithm::NULL_);
 }
 
-TEST_P(SupportedCompressionTest, NoCache) {
+TEST_P(SupportedCompressionTest, noCache) {
   auto config = std::make_shared<Config>();
   config->set(Config::STRIPE_CACHE_MODE, StripeCacheMode::NA);
   config->set(Config::COMPRESSION, supportedCompressionKind_);
@@ -390,7 +390,7 @@ TEST_P(SupportedCompressionTest, NoCache) {
   ASSERT_EQ(reader->metadataCache(), nullptr);
 }
 
-TEST_P(SupportedCompressionTest, ValidateStreamSizeConfigDisabled) {
+TEST_P(SupportedCompressionTest, validateStreamSizeConfigDisabled) {
   auto config = std::make_shared<Config>();
   config->set(Config::STREAM_SIZE_ABOVE_THRESHOLD_CHECK_ENABLED, false);
   config->set(Config::COMPRESSION, supportedCompressionKind_);
@@ -400,7 +400,7 @@ TEST_P(SupportedCompressionTest, ValidateStreamSizeConfigDisabled) {
   writer.close();
 }
 
-TEST_P(SupportedCompressionTest, ValidateStreamSizeConfigEnabled) {
+TEST_P(SupportedCompressionTest, validateStreamSizeConfigEnabled) {
   auto config = std::make_shared<Config>();
   ASSERT_TRUE(config->get(Config::STREAM_SIZE_ABOVE_THRESHOLD_CHECK_ENABLED));
   config->set(Config::COMPRESSION, supportedCompressionKind_);
@@ -451,7 +451,7 @@ void abandonWriterWithoutClosing() {
   // guard.dismiss();
 }
 
-TEST_F(WriterTest, DoNotCrashDbgModeOnAbort) {
+TEST_F(WriterTest, doNotCrashDbgModeOnAbort) {
   EXPECT_THROW(abandonWriterWithoutClosing(), std::runtime_error);
 }
 
@@ -479,7 +479,7 @@ class MockFileSink : public dwio::common::FileSink {
 #pragma GCC diagnostic pop
 };
 
-TEST_F(WriterTest, FlushWriterSinkUponClose) {
+TEST_F(WriterTest, flushWriterSinkUponClose) {
   auto config = std::make_shared<Config>();
   auto pool = memory::memoryManager()->addRootPool("FlushWriterSinkUponClose");
   auto sink = std::make_unique<MockFileSink>();

--- a/velox/dwio/dwrf/utils/test/BitIteratorTests.cpp
+++ b/velox/dwio/dwrf/utils/test/BitIteratorTests.cpp
@@ -24,7 +24,7 @@ using namespace ::testing;
 
 namespace facebook::velox::dwrf::utils {
 
-TEST(BulkBitIterator, Basic) {
+TEST(BulkBitIterator, basic) {
   std::vector<char> charBuffer1{
       std::numeric_limits<char>::max(), 102, 40, -120};
   std::vector<char> charBuffer2{125, 85, 42, std::numeric_limits<char>::min()};

--- a/velox/dwio/dwrf/utils/test/BufferedWriterTest.cpp
+++ b/velox/dwio/dwrf/utils/test/BufferedWriterTest.cpp
@@ -44,7 +44,7 @@ class BufferedWriterTest : public testing::TestWithParam<bool> {
   const std::shared_ptr<memory::MemoryPool> pool_;
 };
 
-TEST_P(BufferedWriterTest, Basic) {
+TEST_P(BufferedWriterTest, basic) {
   const int bufferSize = 1024;
 
   struct {

--- a/velox/dwio/dwrf/utils/test/ProtoUtilsTests.cpp
+++ b/velox/dwio/dwrf/utils/test/ProtoUtilsTests.cpp
@@ -22,7 +22,7 @@
 using namespace facebook::velox::dwrf;
 using namespace facebook::velox::type::fbhive;
 
-TEST(ProtoUtilsTests, AllTypes) {
+TEST(ProtoUtilsTests, allTypes) {
   std::vector<std::string> types{
       "struct<a:boolean,b:tinyint,c:smallint,d:int,e:bigint,f:float,g:double,f:string,g:binary,h:timestamp>",
       "struct<a:map<int,array<struct<a:map<string,int>,b:array<int>>>>>"};
@@ -41,7 +41,7 @@ TEST(ProtoUtilsTests, AllTypes) {
   }
 }
 
-TEST(ProtoUtilsTests, Projection) {
+TEST(ProtoUtilsTests, projection) {
   HiveTypeParser parser;
   auto schema = parser.parse(
       "struct<a:boolean,b:tinyint,c:smallint,d:struct<a:int,b:int,c:int>>");

--- a/velox/dwio/dwrf/writer/ColumnWriter.h
+++ b/velox/dwio/dwrf/writer/ColumnWriter.h
@@ -291,9 +291,9 @@ class BaseColumnWriter : public ColumnWriter {
   // in_map stream
   const std::function<void(IndexBuilder&)> onRecordPosition_;
 
-  VELOX_FRIEND_TEST(ColumnWriterTest, LowMemoryModeConfig);
-  VELOX_FRIEND_TEST(ColumnWriterTest, IntegerDictionaryEncodingEnabledConfig);
-  VELOX_FRIEND_TEST(ColumnWriterTest, StringDictionaryEncodingEnabledConfig);
+  VELOX_FRIEND_TEST(ColumnWriterTest, lowMemoryModeConfig);
+  VELOX_FRIEND_TEST(ColumnWriterTest, integerDictionaryEncodingEnabledConfig);
+  VELOX_FRIEND_TEST(ColumnWriterTest, stringDictionaryEncodingEnabledConfig);
   friend class ValueStatisticsBuilder;
   friend class ValueWriter;
 };

--- a/velox/dwio/dwrf/writer/IntegerDictionaryEncoder.h
+++ b/velox/dwio/dwrf/writer/IntegerDictionaryEncoder.h
@@ -277,9 +277,9 @@ class IntegerDictionaryEncoder : public AbstractIntegerDictionaryEncoder {
   }
 
  private:
-  VELOX_FRIEND_TEST(TestIntegerDictionaryEncoder, Clear);
-  VELOX_FRIEND_TEST(TestIntegerDictionaryEncoder, GetCount);
-  VELOX_FRIEND_TEST(WriterContextTest, GetIntDictionaryEncoder);
+  VELOX_FRIEND_TEST(TestIntegerDictionaryEncoder, clear);
+  VELOX_FRIEND_TEST(TestIntegerDictionaryEncoder, getCount);
+  VELOX_FRIEND_TEST(WriterContextTest, getIntDictionaryEncoder);
 
   // TODO: partially specialize for integers only.
   template <typename T>

--- a/velox/dwio/dwrf/writer/LayoutPlanner.h
+++ b/velox/dwio/dwrf/writer/LayoutPlanner.h
@@ -63,8 +63,8 @@ class EncodingIter {
 
   void next();
 
-  VELOX_FRIEND_TEST(TestEncodingIter, Ctor);
-  VELOX_FRIEND_TEST(TestEncodingIter, EncodingIterBeginAndEnd);
+  VELOX_FRIEND_TEST(TestEncodingIter, ctor);
+  VELOX_FRIEND_TEST(TestEncodingIter, encodingIterBeginAndEnd);
   bool emptyEncryptionGroups() const;
 
   const proto::StripeFooter& footer_;
@@ -148,7 +148,7 @@ class LayoutPlanner {
 
   folly::F14FastMap<uint32_t, uint32_t> nodeToColumnMap_;
 
-  VELOX_FRIEND_TEST(LayoutPlannerTests, Basic);
+  VELOX_FRIEND_TEST(LayoutPlannerTests, basic);
 };
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/writer/StringDictionaryEncoder.h
+++ b/velox/dwio/dwrf/writer/StringDictionaryEncoder.h
@@ -172,10 +172,10 @@ class StringDictionaryEncoder {
   }
 
  private:
-  VELOX_FRIEND_TEST(TestStringDictionaryEncoder, GetCount);
-  VELOX_FRIEND_TEST(TestStringDictionaryEncoder, GetIndex);
-  VELOX_FRIEND_TEST(TestStringDictionaryEncoder, GetStride);
-  VELOX_FRIEND_TEST(TestStringDictionaryEncoder, Clear);
+  VELOX_FRIEND_TEST(TestStringDictionaryEncoder, getCount);
+  VELOX_FRIEND_TEST(TestStringDictionaryEncoder, getIndex);
+  VELOX_FRIEND_TEST(TestStringDictionaryEncoder, getStride);
+  VELOX_FRIEND_TEST(TestStringDictionaryEncoder, clear);
 
   // Intended for testing only.
   uint32_t getIndex(std::string_view sv) {

--- a/velox/dwio/dwrf/writer/WriterBase.h
+++ b/velox/dwio/dwrf/writer/WriterBase.h
@@ -184,7 +184,7 @@ class WriterBase {
   std::unique_ptr<google::protobuf::Arena> arena_;
 
   friend class WriterTest;
-  VELOX_FRIEND_TEST(WriterBaseTest, FlushWriterSinkUponClose);
+  VELOX_FRIEND_TEST(WriterBaseTest, flushWriterSinkUponClose);
 };
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/writer/WriterContext.h
+++ b/velox/dwio/dwrf/writer/WriterContext.h
@@ -694,8 +694,8 @@ class WriterContext : public CompressionBufferPool {
   // TODO: remove once writer code is consolidated
   friend class WriterEncodingIndexTest2;
 
-  VELOX_FRIEND_TEST(WriterContextTest, GetIntDictionaryEncoder);
-  VELOX_FRIEND_TEST(WriterContextTest, RemoveIntDictionaryEncoderForNode);
+  VELOX_FRIEND_TEST(WriterContextTest, getIntDictionaryEncoder);
+  VELOX_FRIEND_TEST(WriterContextTest, removeIntDictionaryEncoderForNode);
 };
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/orc/test/ReaderTest.cpp
+++ b/velox/dwio/orc/test/ReaderTest.cpp
@@ -388,7 +388,7 @@ class OrcReaderTestP : public testing::TestWithParam<OrcFileDescription>,
 
 TEST_P(
     OrcReaderTestP,
-    DwrfReader_FetchesOrcMetadata_ExpectCorrectFooterAndMetadata) {
+    dwrfReader_FetchesOrcMetadata_ExpectCorrectFooterAndMetadata) {
   const std::string dateOrc(getFilename());
   dwio::common::ReaderOptions readerOpts{pool()};
   readerOpts.setDataIoStats(dataIoStats_);
@@ -424,7 +424,7 @@ TEST_P(
   }
 }
 
-TEST_P(OrcReaderTestP, DwrfRowReader_ReadAllColumnTypes_ExpectedRowDataRead) {
+TEST_P(OrcReaderTestP, dwrfRowReader_ReadAllColumnTypes_ExpectedRowDataRead) {
   // Create schema and scan spec
   std::string schemaString = GetParam().typeString;
   auto type = HiveTypeParser().parse(schemaString);

--- a/velox/dwio/parquet/tests/ParquetTpchTest.cpp
+++ b/velox/dwio/parquet/tests/ParquetTpchTest.cpp
@@ -164,106 +164,106 @@ std::shared_ptr<DuckDbQueryRunner> ParquetTpchTest::duckDb_ = nullptr;
 std::shared_ptr<TempDirectoryPath> ParquetTpchTest::tempDirectory_ = nullptr;
 std::shared_ptr<TpchQueryBuilder> ParquetTpchTest::tpchBuilder_ = nullptr;
 
-TEST_F(ParquetTpchTest, Q1) {
+TEST_F(ParquetTpchTest, q1) {
   assertQuery(1);
 }
 
-TEST_F(ParquetTpchTest, Q2) {
+TEST_F(ParquetTpchTest, q2) {
   std::vector<uint32_t> sortingKeys{0, 1, 2, 3};
   assertQuery(2, std::move(sortingKeys));
 }
 
-TEST_F(ParquetTpchTest, Q3) {
+TEST_F(ParquetTpchTest, q3) {
   std::vector<uint32_t> sortingKeys{1, 2};
   assertQuery(3, std::move(sortingKeys));
 }
 
-TEST_F(ParquetTpchTest, Q4) {
+TEST_F(ParquetTpchTest, q4) {
   std::vector<uint32_t> sortingKeys{0};
   assertQuery(4, std::move(sortingKeys));
 }
 
-TEST_F(ParquetTpchTest, Q5) {
+TEST_F(ParquetTpchTest, q5) {
   std::vector<uint32_t> sortingKeys{1};
   assertQuery(5, std::move(sortingKeys));
 }
 
-TEST_F(ParquetTpchTest, Q6) {
+TEST_F(ParquetTpchTest, q6) {
   assertQuery(6);
 }
 
-TEST_F(ParquetTpchTest, Q7) {
+TEST_F(ParquetTpchTest, q7) {
   std::vector<uint32_t> sortingKeys{0, 1, 2};
   assertQuery(7, std::move(sortingKeys));
 }
 
-TEST_F(ParquetTpchTest, Q8) {
+TEST_F(ParquetTpchTest, q8) {
   std::vector<uint32_t> sortingKeys{0};
   assertQuery(8, std::move(sortingKeys));
 }
 
-TEST_F(ParquetTpchTest, Q9) {
+TEST_F(ParquetTpchTest, q9) {
   std::vector<uint32_t> sortingKeys{0, 1};
   assertQuery(9, std::move(sortingKeys));
 }
 
-TEST_F(ParquetTpchTest, Q10) {
+TEST_F(ParquetTpchTest, q10) {
   std::vector<uint32_t> sortingKeys{2};
   assertQuery(10, std::move(sortingKeys));
 }
 
-TEST_F(ParquetTpchTest, Q11) {
+TEST_F(ParquetTpchTest, q11) {
   std::vector<uint32_t> sortingKeys{1};
   assertQuery(11, std::move(sortingKeys));
 }
 
-TEST_F(ParquetTpchTest, Q12) {
+TEST_F(ParquetTpchTest, q12) {
   std::vector<uint32_t> sortingKeys{0};
   assertQuery(12, std::move(sortingKeys));
 }
 
-TEST_F(ParquetTpchTest, Q13) {
+TEST_F(ParquetTpchTest, q13) {
   std::vector<uint32_t> sortingKeys{0, 1};
   assertQuery(13, std::move(sortingKeys));
 }
 
-TEST_F(ParquetTpchTest, Q14) {
+TEST_F(ParquetTpchTest, q14) {
   assertQuery(14);
 }
 
-TEST_F(ParquetTpchTest, Q15) {
+TEST_F(ParquetTpchTest, q15) {
   std::vector<uint32_t> sortingKeys{0};
   assertQuery(15, std::move(sortingKeys));
 }
 
-TEST_F(ParquetTpchTest, Q16) {
+TEST_F(ParquetTpchTest, q16) {
   std::vector<uint32_t> sortingKeys{0, 1, 2, 3};
   assertQuery(16, std::move(sortingKeys));
 }
 
-TEST_F(ParquetTpchTest, Q17) {
+TEST_F(ParquetTpchTest, q17) {
   assertQuery(17);
 }
 
-TEST_F(ParquetTpchTest, Q18) {
+TEST_F(ParquetTpchTest, q18) {
   assertQuery(18);
 }
 
-TEST_F(ParquetTpchTest, Q19) {
+TEST_F(ParquetTpchTest, q19) {
   assertQuery(19);
 }
 
-TEST_F(ParquetTpchTest, Q20) {
+TEST_F(ParquetTpchTest, q20) {
   std::vector<uint32_t> sortingKeys{0};
   assertQuery(20, std::move(sortingKeys));
 }
 
-TEST_F(ParquetTpchTest, Q21) {
+TEST_F(ParquetTpchTest, q21) {
   std::vector<uint32_t> sortingKeys{0, 1};
   assertQuery(21, std::move(sortingKeys));
 }
 
-TEST_F(ParquetTpchTest, Q22) {
+TEST_F(ParquetTpchTest, q22) {
   std::vector<uint32_t> sortingKeys{0};
   assertQuery(22, std::move(sortingKeys));
 }

--- a/velox/dwio/parquet/tests/common/LevelConversionTest.cpp
+++ b/velox/dwio/parquet/tests/common/LevelConversionTest.cpp
@@ -48,7 +48,7 @@ std::string BitmapToString(
   return BitmapToString(bitmap.data(), bitCount);
 }
 
-TEST(TestColumnReader, DefLevelsToBitmap) {
+TEST(TestColumnReader, defLevelsToBitmap) {
   // Bugs in this function were exposed in ARROW-3930
   std::vector<int16_t> defLevels = {3, 3, 3, 2, 3, 3, 3, 3, 3};
 
@@ -78,7 +78,7 @@ TEST(TestColumnReader, DefLevelsToBitmap) {
   ASSERT_EQ(current_byte, validBits[1]);
 }
 
-TEST(TestColumnReader, DefLevelsToBitmapPowerOfTwo) {
+TEST(TestColumnReader, defLevelsToBitmapPowerOfTwo) {
   // PARQUET-1623: Invalid memory access when decoding a valid bits vector that
   // has a length equal to a power of two and also using a non-zero
   // validBitsOffset.  This should not fail when run with ASAN or valgrind.
@@ -101,7 +101,7 @@ TEST(TestColumnReader, DefLevelsToBitmapPowerOfTwo) {
 }
 
 #if defined(ARROW_LITTLE_ENDIAN)
-TEST(GreaterThanBitmap, GeneratesExpectedBitmasks) {
+TEST(GreaterThanBitmap, generatesExpectedBitmasks) {
   std::vector<int16_t> levels = {
       0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5,
       6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3,
@@ -121,7 +121,7 @@ TEST(GreaterThanBitmap, GeneratesExpectedBitmasks) {
 }
 #endif
 
-TEST(DefLevelsToBitmap, WithRepetitionLevelFiltersOutEmptyListValues) {
+TEST(DefLevelsToBitmap, withRepetitionLevelFiltersOutEmptyListValues) {
   std::vector<uint8_t> validity_bitmap(/*count*/ 8, 0);
 
   ValidityBitmapInputOutput io;
@@ -242,7 +242,7 @@ using ConverterTypes = ::testing::Types<
     RepDefLevelConverter</*list_length_type=*/int64_t>>;
 TYPED_TEST_SUITE(NestedListTest, ConverterTypes);
 
-TYPED_TEST(NestedListTest, OuterMostTest) {
+TYPED_TEST(NestedListTest, outerMostTest) {
   // [null, [[1 , null, 3], []], []],
   // [[[]], [[], [1, 2]], null, [[3]]],
   // null,
@@ -264,7 +264,7 @@ TYPED_TEST(NestedListTest, OuterMostTest) {
   EXPECT_EQ(BitmapToString(this->validityIo_.validBits, /*length=*/4), "1101");
 }
 
-TYPED_TEST(NestedListTest, MiddleListTest) {
+TYPED_TEST(NestedListTest, middleListTest) {
   // [null, [[1 , null, 3], []], []],
   // [[[]], [[], [1, 2]], null, [[3]]],
   // null,
@@ -291,7 +291,7 @@ TYPED_TEST(NestedListTest, MiddleListTest) {
       BitmapToString(this->validityIo_.validBits, /*length=*/7), "0111101");
 }
 
-TYPED_TEST(NestedListTest, InnerMostListTest) {
+TYPED_TEST(NestedListTest, innerMostListTest) {
   // [null, [[1, null, 3], []], []],
   // [[[]], [[], [1, 2]], null, [[3]]],
   // null,
@@ -318,7 +318,7 @@ TYPED_TEST(NestedListTest, InnerMostListTest) {
       BitmapToString(this->validityIo_.validBits, /*length=*/6), "111111");
 }
 
-TYPED_TEST(NestedListTest, SimpleLongList) {
+TYPED_TEST(NestedListTest, simpleLongList) {
   LevelInfo levelInfo;
   levelInfo.repLevel = 1;
   levelInfo.defLevel = 2;
@@ -361,7 +361,7 @@ TYPED_TEST(NestedListTest, SimpleLongList) {
       "1");
 }
 
-TYPED_TEST(NestedListTest, TestOverflow) {
+TYPED_TEST(NestedListTest, testOverflow) {
   LevelInfo levelInfo;
   levelInfo.repLevel = 1;
   levelInfo.defLevel = 2;
@@ -393,7 +393,7 @@ TYPED_TEST(NestedListTest, TestOverflow) {
   this->Run(testData, levelInfo);
 }
 
-TEST(TestOnlyExtractBitsSoftware, BasicTest) {
+TEST(TestOnlyExtractBitsSoftware, basicTest) {
   auto check =
       [](uint64_t bitmap, uint64_t selection, uint64_t expected) -> void {
     EXPECT_EQ(TestOnlyExtractBitsSoftware(bitmap, selection), expected);

--- a/velox/dwio/parquet/tests/reader/BloomFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/BloomFilterTest.cpp
@@ -37,7 +37,7 @@ using namespace facebook::velox::parquet;
 
 class BloomFilterTest : public ParquetTestBase {};
 
-TEST_F(BloomFilterTest, ConstructorTest) {
+TEST_F(BloomFilterTest, constructorTest) {
   BlockSplitBloomFilter bloomFilter(leafPool_.get());
   EXPECT_NO_THROW(bloomFilter.init(1000));
 
@@ -53,7 +53,7 @@ TEST_F(BloomFilterTest, ConstructorTest) {
 
 // The BasicTest is used to test basic operations including InsertHash, FindHash
 // and serializing and de-serializing.
-TEST_F(BloomFilterTest, BasicTest) {
+TEST_F(BloomFilterTest, basicTest) {
   const std::vector<uint32_t> kBloomFilterSizes = {
       32,
       64,
@@ -160,7 +160,7 @@ std::string GetRandomString(uint32_t length) {
   return ret;
 }
 
-TEST_F(BloomFilterTest, FPPTest) {
+TEST_F(BloomFilterTest, fppTest) {
   // It counts the number of times FindHash returns true.
   int exist = 0;
 
@@ -216,7 +216,7 @@ TEST_F(BloomFilterTest, FPPTest) {
 // Step 2: Insert "hello", "parquet", "bloom", "filter" to Bloom filter.
 // Step 3: Call writeTo API to write to File.
 /*
-TEST(CompatibilityTest, TestBloomFilter) {
+TEST(CompatibilityTest, testBloomFilter) {
   const std::string test_string[4] = {"hello", "parquet", "bloom", "filter"};
   const std::string bloom_filter_test_binary =
       std::string(test::get_data_dir()) + "/bloom_filter.xxhash.bin";
@@ -276,7 +276,7 @@ uint8_t*>(test_string[i].c_str()));
 // where ndv is the number of distinct values and fpp is the false positive
 // probability. Also it is used to test whether OptimalNumOfBits returns value
 // between [MINIMUM_BLOOM_FILTER_SIZE, MAXIMUM_BLOOM_FILTER_SIZE].
-TEST_F(BloomFilterTest, OptimalValueTest) {
+TEST_F(BloomFilterTest, optimalValueTest) {
   auto testOptimalNumEstimation = [](uint32_t ndv,
                                      double fpp,
                                      uint32_t num_bits) {
@@ -358,7 +358,7 @@ const int64_t HASHES_OF_LOOPING_BYTES_WITH_SEED_0[32] = {
  *     }
  * }
  */
-TEST_F(BloomFilterTest, XxHashTest) {
+TEST_F(BloomFilterTest, xxHashTest) {
   constexpr int kNumValues = 32;
   uint8_t bytes[kNumValues] = {};
 
@@ -374,7 +374,7 @@ TEST_F(BloomFilterTest, XxHashTest) {
 }
 
 // Same as TestBloomFilter but using Batch interface
-TEST_F(BloomFilterTest, TestBloomFilterHashes) {
+TEST_F(BloomFilterTest, testBloomFilterHashes) {
   constexpr int kNumValues = 32;
   uint8_t bytes[kNumValues] = {};
 

--- a/velox/dwio/parquet/writer/arrow/Schema.h
+++ b/velox/dwio/parquet/writer/arrow/Schema.h
@@ -330,9 +330,9 @@ class PARQUET_EXPORT PrimitiveNode : public Node {
 
   bool equalsInternal(const PrimitiveNode* other) const;
 
-  FRIEND_TEST(TestPrimitiveNode, Attrs);
+  FRIEND_TEST(TestPrimitiveNode, attrs);
   FRIEND_TEST(TestPrimitiveNode, equals);
-  FRIEND_TEST(TestPrimitiveNode, PhysicalLogicalMapping);
+  FRIEND_TEST(TestPrimitiveNode, physicalLogicalMapping);
   FRIEND_TEST(TestPrimitiveNode, fromParquet);
 };
 
@@ -410,10 +410,10 @@ class PARQUET_EXPORT GroupNode : public Node {
   // Mapping between field name to the field index.
   std::unordered_multimap<std::string, int> fieldNameToIdx_;
 
-  FRIEND_TEST(TestGroupNode, Attrs);
+  FRIEND_TEST(TestGroupNode, attrs);
   FRIEND_TEST(TestGroupNode, equals);
   FRIEND_TEST(TestGroupNode, fieldIndex);
-  FRIEND_TEST(TestGroupNode, FieldIndexDuplicateName);
+  FRIEND_TEST(TestGroupNode, fieldIndexDuplicateName);
 };
 
 // ----------------------------------------------------------------------.

--- a/velox/dwio/parquet/writer/arrow/tests/BloomFilterTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/BloomFilterTest.cpp
@@ -42,7 +42,7 @@
 namespace facebook::velox::parquet::arrow {
 namespace test {
 
-TEST(ConstructorTest, TestBloomFilter) {
+TEST(ConstructorTest, testBloomFilter) {
   BlockSplitBloomFilter BloomFilter;
   EXPECT_NO_THROW(BloomFilter.init(1000));
 
@@ -58,7 +58,7 @@ TEST(ConstructorTest, TestBloomFilter) {
 
 // The BasicTest is used to test basic operations including InsertHash,
 // FindHash. And serializing and de-serializing.
-TEST(BasicTest, TestBloomFilter) {
+TEST(BasicTest, testBloomFilter) {
   const std::vector<uint32_t> kBloomFilterSizes = {
       32, 64, 128, 256, 512, 1024, 2048};
   const std::vector<int32_t> kIntInserts = {
@@ -148,7 +148,7 @@ std::string getRandomString(uint32_t length) {
   return ret;
 }
 
-TEST(FPPTest, TestBloomFilter) {
+TEST(FPPTest, testBloomFilter) {
   // It counts the number of times FindHash returns true.
   int exist = 0;
 
@@ -203,7 +203,7 @@ TEST(FPPTest, TestBloomFilter) {
 // Step 2: Insert "hello", "parquet", "bloom", "filter" to Bloom filter.
 // Step 3: Call writeTo API to write to File.
 /*
-TEST(CompatibilityTest, TestBloomFilter) {
+TEST(CompatibilityTest, testBloomFilter) {
   const std::string test_string[4] = {"hello", "parquet", "bloom", "filter"};
   const std::string bloom_filter_test_binary =
       std::string(test::get_data_dir()) + "/bloom_filter.xxhash.bin";
@@ -263,7 +263,7 @@ uint8_t*>(test_string[i].c_str()));
 // Where ndv is the number of distinct values and fpp is the false positive.
 // Probability. Also it is used to test whether OptimalNumOfBits returns value.
 // Between [MINIMUM_BLOOM_FILTER_SIZE, MAXIMUM_BLOOM_FILTER_SIZE].
-TEST(OptimalValueTest, TestBloomFilter) {
+TEST(OptimalValueTest, testBloomFilter) {
   auto testOptimalNumEstimation = [](uint32_t ndv,
                                      double fpp,
                                      uint32_t numBits) {
@@ -345,7 +345,7 @@ const int64_t HASHES_OF_LOOPING_BYTES_WITH_SEED_0[32] = {
  *     }
  * }
  */
-TEST(XxHashTest, TestBloomFilter) {
+TEST(XxHashTest, testBloomFilter) {
   constexpr int kNumValues = 32;
   uint8_t bytes[kNumValues] = {};
 
@@ -361,7 +361,7 @@ TEST(XxHashTest, TestBloomFilter) {
 }
 
 // Same as TestBloomFilter but using Batch interface.
-TEST(XxHashTest, TestBloomFilterHashes) {
+TEST(XxHashTest, testBloomFilterHashes) {
   constexpr int kNumValues = 32;
   uint8_t bytes[kNumValues] = {};
 
@@ -415,7 +415,7 @@ using BloomFilterTestTypes = ::testing::Types<
 
 TYPED_TEST_SUITE(TestBatchBloomFilter, BloomFilterTestTypes);
 
-TYPED_TEST(TestBatchBloomFilter, Basic) {
+TYPED_TEST(TestBatchBloomFilter, basic) {
   using Type = typename TypeParam::CType;
   std::vector<Type> testData = TestFixture::generateTestData();
   BlockSplitBloomFilter batchInsertFilter;

--- a/velox/dwio/parquet/writer/arrow/tests/ColumnReaderTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/ColumnReaderTest.cpp
@@ -283,7 +283,7 @@ class TestPrimitiveReader : public ::testing::Test {
   std::vector<uint8_t> dataBuffer_; // For BA and FLBA
 };
 
-TEST_F(TestPrimitiveReader, TestInt32FlatRequired) {
+TEST_F(TestPrimitiveReader, testInt32FlatRequired) {
   int levelsPerPage = 100;
   int numPages = 50;
   maxDefLevel_ = 0;
@@ -294,7 +294,7 @@ TEST_F(TestPrimitiveReader, TestInt32FlatRequired) {
   ASSERT_NO_FATAL_FAILURE(executeDict(numPages, levelsPerPage, &descr));
 }
 
-TEST_F(TestPrimitiveReader, TestInt32FlatOptional) {
+TEST_F(TestPrimitiveReader, testInt32FlatOptional) {
   int levelsPerPage = 100;
   int numPages = 50;
   maxDefLevel_ = 4;
@@ -305,7 +305,7 @@ TEST_F(TestPrimitiveReader, TestInt32FlatOptional) {
   ASSERT_NO_FATAL_FAILURE(executeDict(numPages, levelsPerPage, &descr));
 }
 
-TEST_F(TestPrimitiveReader, TestInt32FlatRepeated) {
+TEST_F(TestPrimitiveReader, testInt32FlatRepeated) {
   int levelsPerPage = 100;
   int numPages = 50;
   maxDefLevel_ = 4;
@@ -317,7 +317,7 @@ TEST_F(TestPrimitiveReader, TestInt32FlatRepeated) {
 }
 
 // Tests skipping around page boundaries.
-TEST_F(TestPrimitiveReader, TestSkipAroundPageBoundries) {
+TEST_F(TestPrimitiveReader, testSkipAroundPageBoundries) {
   int levelsPerPage = 100;
   int numPages = 7;
   maxDefLevel_ = 0;
@@ -427,7 +427,7 @@ TEST_F(TestPrimitiveReader, TestSkipAroundPageBoundries) {
 
 // Skip with repeated field. This test makes it clear that we are skipping.
 // Values and not records.
-TEST_F(TestPrimitiveReader, TestSkipRepeatedField) {
+TEST_F(TestPrimitiveReader, testSkipRepeatedField) {
   // Example schema: message M { repeated int32 b = 1 }
   maxDefLevel_ = 1;
   maxRepLevel_ = 1;
@@ -483,7 +483,7 @@ TEST_F(TestPrimitiveReader, TestSkipRepeatedField) {
 }
 
 // Page claims to have two values but only 1 is present.
-TEST_F(TestPrimitiveReader, TestReadValuesMissing) {
+TEST_F(TestPrimitiveReader, testReadValuesMissing) {
   maxDefLevel_ = 1;
   maxRepLevel_ = 0;
   constexpr int batchSize = 1;
@@ -533,7 +533,7 @@ TEST_F(TestPrimitiveReader, TestReadValuesMissing) {
 
 // Repetition level byte length reported in Page but Max Repetition level.
 // Is zero for the column.
-TEST_F(TestPrimitiveReader, TestRepetitionLvlBytesWithMaxRepetitionZero) {
+TEST_F(TestPrimitiveReader, testRepetitionLvlBytesWithMaxRepetitionZero) {
   constexpr int batchSize = 4;
   maxDefLevel_ = 1;
   maxRepLevel_ = 0;
@@ -572,7 +572,7 @@ TEST_F(TestPrimitiveReader, TestRepetitionLvlBytesWithMaxRepetitionZero) {
 }
 
 // Page claims to have two values but only 1 is present.
-TEST_F(TestPrimitiveReader, TestReadValuesMissingWithDictionary) {
+TEST_F(TestPrimitiveReader, testReadValuesMissingWithDictionary) {
   constexpr int batchSize = 1;
   maxDefLevel_ = 1;
   maxRepLevel_ = 0;
@@ -626,7 +626,7 @@ TEST_F(TestPrimitiveReader, TestReadValuesMissingWithDictionary) {
       ParquetException);
 }
 
-TEST_F(TestPrimitiveReader, TestDictionaryEncodedPages) {
+TEST_F(TestPrimitiveReader, testDictionaryEncodedPages) {
   maxDefLevel_ = 0;
   maxRepLevel_ = 0;
   NodePtr type = schema::int32("a", Repetition::kRequired);
@@ -691,7 +691,7 @@ TEST_F(TestPrimitiveReader, TestDictionaryEncodedPages) {
   pages_.clear();
 }
 
-TEST_F(TestPrimitiveReader, TestDictionaryEncodedPagesWithExposeEncoding) {
+TEST_F(TestPrimitiveReader, testDictionaryEncodedPagesWithExposeEncoding) {
   maxDefLevel_ = 0;
   maxRepLevel_ = 0;
   int levelsPerPage = 100;
@@ -755,7 +755,7 @@ TEST_F(TestPrimitiveReader, TestDictionaryEncodedPagesWithExposeEncoding) {
   pages_.clear();
 }
 
-TEST_F(TestPrimitiveReader, TestNonDictionaryEncodedPagesWithExposeEncoding) {
+TEST_F(TestPrimitiveReader, testNonDictionaryEncodedPagesWithExposeEncoding) {
   maxDefLevel_ = 0;
   maxRepLevel_ = 0;
   int64_t valueSize = 100;
@@ -889,7 +889,7 @@ class RecordReaderPrimitiveTypeTest
 
 // Tests reading a required field. The expected results are the same for.
 // Reading dense and spaced.
-TEST_P(RecordReaderPrimitiveTypeTest, ReadRequired) {
+TEST_P(RecordReaderPrimitiveTypeTest, readRequired) {
   init(schema::int32("b", Repetition::kRequired));
 
   // Records look like: {10, 20, 20, 30, 30, 30}
@@ -933,7 +933,7 @@ TEST_P(RecordReaderPrimitiveTypeTest, ReadRequired) {
 // Tests reading an optional field.
 // Use a max definition field > 1 to test both cases where parent is present or.
 // Parent is missing.
-TEST_P(RecordReaderPrimitiveTypeTest, ReadOptional) {
+TEST_P(RecordReaderPrimitiveTypeTest, readOptional) {
   NodePtr column = GroupNode::make(
       "a",
       Repetition::kOptional,
@@ -1003,7 +1003,7 @@ TEST_P(RecordReaderPrimitiveTypeTest, ReadOptional) {
 
 // Tests reading a required repeated field. The results are the same for
 // reading. Dense or spaced.
-TEST_P(RecordReaderPrimitiveTypeTest, ReadRequiredRepeated) {
+TEST_P(RecordReaderPrimitiveTypeTest, readRequiredRepeated) {
   NodePtr column = GroupNode::make(
       "p",
       Repetition::kRequired,
@@ -1054,7 +1054,7 @@ TEST_P(RecordReaderPrimitiveTypeTest, ReadRequiredRepeated) {
 
 // Tests reading a nullable repeated field. Tests reading null values at.
 // Differnet levels and reading an empty list.
-TEST_P(RecordReaderPrimitiveTypeTest, ReadNullableRepeated) {
+TEST_P(RecordReaderPrimitiveTypeTest, readNullableRepeated) {
   NodePtr column = GroupNode::make(
       "p",
       Repetition::kOptional,
@@ -1146,7 +1146,7 @@ TEST_P(RecordReaderPrimitiveTypeTest, ReadNullableRepeated) {
 }
 
 // Test that we can skip required top level field.
-TEST_P(RecordReaderPrimitiveTypeTest, SkipRequiredTopLevel) {
+TEST_P(RecordReaderPrimitiveTypeTest, skipRequiredTopLevel) {
   init(schema::int32("b", Repetition::kRequired));
 
   std::vector<std::shared_ptr<Page>> pages;
@@ -1179,7 +1179,7 @@ TEST_P(RecordReaderPrimitiveTypeTest, SkipRequiredTopLevel) {
 }
 
 // Skip an optional field. Intentionally included some null values.
-TEST_P(RecordReaderPrimitiveTypeTest, SkipOptional) {
+TEST_P(RecordReaderPrimitiveTypeTest, skipOptional) {
   init(schema::int32("b", Repetition::kOptional));
 
   // Records look like {null, 10, 20, 30, null, 40, 50, 60}
@@ -1256,7 +1256,7 @@ TEST_P(RecordReaderPrimitiveTypeTest, SkipOptional) {
 }
 
 // Test skipping for repeated fields.
-TEST_P(RecordReaderPrimitiveTypeTest, SkipRepeated) {
+TEST_P(RecordReaderPrimitiveTypeTest, skipRepeated) {
   init(schema::int32("b", Repetition::kRepeated));
 
   // Records look like {null, [20, 20, 20], null, [30, 30], [40]}
@@ -1334,7 +1334,7 @@ TEST_P(RecordReaderPrimitiveTypeTest, SkipRepeated) {
 
 // Tests that for repeated fields, we first consume what is in the buffer.
 // Before reading more levels.
-TEST_P(RecordReaderPrimitiveTypeTest, SkipRepeatedConsumeBufferFirst) {
+TEST_P(RecordReaderPrimitiveTypeTest, skipRepeatedConsumeBufferFirst) {
   init(schema::int32("b", Repetition::kRepeated));
 
   std::vector<std::shared_ptr<Page>> pages;
@@ -1381,7 +1381,7 @@ TEST_P(RecordReaderPrimitiveTypeTest, SkipRepeatedConsumeBufferFirst) {
 }
 
 // Test reading when one record spans multiple pages for a repeated field.
-TEST_P(RecordReaderPrimitiveTypeTest, ReadPartialRecord) {
+TEST_P(RecordReaderPrimitiveTypeTest, readPartialRecord) {
   init(schema::int32("b", Repetition::kRepeated));
 
   std::vector<std::shared_ptr<Page>> pages;
@@ -1470,7 +1470,7 @@ TEST_P(RecordReaderPrimitiveTypeTest, ReadPartialRecord) {
 
 // Test skipping for repeated fields for the case when one record spans
 // multiple. Pages.
-TEST_P(RecordReaderPrimitiveTypeTest, SkipPartialRecord) {
+TEST_P(RecordReaderPrimitiveTypeTest, skipPartialRecord) {
   init(schema::int32("b", Repetition::kRepeated));
 
   std::vector<std::shared_ptr<Page>> pages;
@@ -1780,7 +1780,7 @@ class ByteArrayRecordReaderTest : public ::testing::TestWithParam<bool> {
 // Tests reading and skipping a ByteArray field.
 // The binary readers only differ in DeocdeDense and DecodeSpaced functions, so.
 // Testing optional is sufficient in excercising those code paths.
-TEST_P(ByteArrayRecordReaderTest, ReadAndSkipOptional) {
+TEST_P(ByteArrayRecordReaderTest, readAndSkipOptional) {
   makeRecordReader(90, 1);
 
   // Read one-third of the page.
@@ -1801,7 +1801,7 @@ TEST_P(ByteArrayRecordReaderTest, ReadAndSkipOptional) {
 // Tests reading and skipping an optional FLBA field.
 // The binary readers only differ in DeocdeDense and DecodeSpaced functions, so.
 // Testing optional is sufficient in excercising those code paths.
-TEST_P(FLBARecordReaderTest, ReadAndSkipOptional) {
+TEST_P(FLBARecordReaderTest, readAndSkipOptional) {
   makeRecordReader(90, 1, 4);
 
   // Read one-third of the page.
@@ -1833,7 +1833,7 @@ INSTANTIATE_TEST_SUITE_P(
 class RecordReaderStressTest
     : public ::testing::TestWithParam<Repetition::type> {};
 
-TEST_P(RecordReaderStressTest, StressTest) {
+TEST_P(RecordReaderStressTest, stressTest) {
   LevelInfo levelInfo;
   // Define these boolean variables for improving readability below.
   bool repeated = false, required = false;

--- a/velox/dwio/parquet/writer/arrow/tests/ColumnWriterTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/ColumnWriterTest.cpp
@@ -515,124 +515,124 @@ using TestValuesWriterInt64Type = TestPrimitiveWriter<Int64Type>;
 using TestByteArrayValuesWriter = TestPrimitiveWriter<ByteArrayType>;
 using TestFixedLengthByteArrayValuesWriter = TestPrimitiveWriter<FLBAType>;
 
-TYPED_TEST(TestPrimitiveWriter, RequiredPlain) {
+TYPED_TEST(TestPrimitiveWriter, requiredPlain) {
   this->testRequiredWithEncoding(Encoding::kPlain);
 }
 
-TYPED_TEST(TestPrimitiveWriter, RequiredDictionary) {
+TYPED_TEST(TestPrimitiveWriter, requiredDictionary) {
   this->testRequiredWithEncoding(Encoding::kPlainDictionary);
 }
 
 /*
-TYPED_TEST(TestPrimitiveWriter, RequiredRLE) {
+TYPED_TEST(TestPrimitiveWriter, requiredRLE) {
   this->TestRequiredWithEncoding(Encoding::RLE);
 }
 
-TYPED_TEST(TestPrimitiveWriter, RequiredBitPacked) {
+TYPED_TEST(TestPrimitiveWriter, requiredBitPacked) {
   this->TestRequiredWithEncoding(Encoding::BIT_PACKED);
 }
 */
 
-TEST_F(TestValuesWriterInt32Type, RequiredDeltaBinaryPacked) {
+TEST_F(TestValuesWriterInt32Type, requiredDeltaBinaryPacked) {
   this->testRequiredWithEncoding(Encoding::kDeltaBinaryPacked);
 }
 
-TEST_F(TestValuesWriterInt64Type, RequiredDeltaBinaryPacked) {
+TEST_F(TestValuesWriterInt64Type, requiredDeltaBinaryPacked) {
   this->testRequiredWithEncoding(Encoding::kDeltaBinaryPacked);
 }
 
-TEST_F(TestByteArrayValuesWriter, RequiredDeltaLengthByteArray) {
+TEST_F(TestByteArrayValuesWriter, requiredDeltaLengthByteArray) {
   this->testRequiredWithEncoding(Encoding::kDeltaLengthByteArray);
 }
 
 /*
-TYPED_TEST(TestByteArrayValuesWriter, RequiredDeltaByteArray) {
+TYPED_TEST(TestByteArrayValuesWriter, requiredDeltaByteArray) {
   this->TestRequiredWithEncoding(Encoding::DELTA_BYTE_ARRAY);
 }
 
-TEST_F(TestFixedLengthByteArrayValuesWriter, RequiredDeltaByteArray) {
+TEST_F(TestFixedLengthByteArrayValuesWriter, requiredDeltaByteArray) {
   this->TestRequiredWithEncoding(Encoding::DELTA_BYTE_ARRAY);
 }
 */
 
-TYPED_TEST(TestPrimitiveWriter, RequiredRLEDictionary) {
+TYPED_TEST(TestPrimitiveWriter, requiredRLEDictionary) {
   this->testRequiredWithEncoding(Encoding::kRleDictionary);
 }
 
-TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithStats) {
+TYPED_TEST(TestPrimitiveWriter, requiredPlainWithStats) {
   this->testRequiredWithSettings(
       Encoding::kPlain, Compression::UNCOMPRESSED, false, true, LARGE_SIZE);
 }
 
-TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithSnappyCompression) {
+TYPED_TEST(TestPrimitiveWriter, requiredPlainWithSnappyCompression) {
   this->testRequiredWithSettings(
       Encoding::kPlain, Compression::SNAPPY, false, false, LARGE_SIZE);
 }
 
-TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithStatsAndSnappyCompression) {
+TYPED_TEST(TestPrimitiveWriter, requiredPlainWithStatsAndSnappyCompression) {
   this->testRequiredWithSettings(
       Encoding::kPlain, Compression::SNAPPY, false, true, LARGE_SIZE);
 }
 
 #ifdef ARROW_WITH_BROTLI
-TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithBrotliCompression) {
+TYPED_TEST(TestPrimitiveWriter, requiredPlainWithBrotliCompression) {
   this->testRequiredWithSettings(
       Encoding::kPlain, Compression::BROTLI, false, false, LARGE_SIZE);
 }
 
-TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithBrotliCompressionAndLevel) {
+TYPED_TEST(TestPrimitiveWriter, requiredPlainWithBrotliCompressionAndLevel) {
   this->testRequiredWithSettings(
       Encoding::kPlain, Compression::BROTLI, false, false, LARGE_SIZE, 10);
 }
 
-TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithStatsAndBrotliCompression) {
+TYPED_TEST(TestPrimitiveWriter, requiredPlainWithStatsAndBrotliCompression) {
   this->testRequiredWithSettings(
       Encoding::kPlain, Compression::BROTLI, false, true, LARGE_SIZE);
 }
 
 #endif
 
-TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithGzipCompression) {
+TYPED_TEST(TestPrimitiveWriter, requiredPlainWithGzipCompression) {
   this->testRequiredWithSettings(
       Encoding::kPlain, Compression::GZIP, false, false, LARGE_SIZE);
 }
 
-TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithGzipCompressionAndLevel) {
+TYPED_TEST(TestPrimitiveWriter, requiredPlainWithGzipCompressionAndLevel) {
   this->testRequiredWithSettings(
       Encoding::kPlain, Compression::GZIP, false, false, LARGE_SIZE, 10);
 }
 
-TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithStatsAndGzipCompression) {
+TYPED_TEST(TestPrimitiveWriter, requiredPlainWithStatsAndGzipCompression) {
   this->testRequiredWithSettings(
       Encoding::kPlain, Compression::GZIP, false, true, LARGE_SIZE);
 }
 
-TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithLz4Compression) {
+TYPED_TEST(TestPrimitiveWriter, requiredPlainWithLz4Compression) {
   this->testRequiredWithSettings(
       Encoding::kPlain, Compression::LZ4, false, false, LARGE_SIZE);
 }
 
-TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithStatsAndLz4Compression) {
+TYPED_TEST(TestPrimitiveWriter, requiredPlainWithStatsAndLz4Compression) {
   this->testRequiredWithSettings(
       Encoding::kPlain, Compression::LZ4, false, true, LARGE_SIZE);
 }
 
-TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithZstdCompression) {
+TYPED_TEST(TestPrimitiveWriter, requiredPlainWithZstdCompression) {
   this->testRequiredWithSettings(
       Encoding::kPlain, Compression::ZSTD, false, false, LARGE_SIZE);
 }
 
-TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithZstdCompressionAndLevel) {
+TYPED_TEST(TestPrimitiveWriter, requiredPlainWithZstdCompressionAndLevel) {
   this->testRequiredWithSettings(
       Encoding::kPlain, Compression::ZSTD, false, false, LARGE_SIZE, 6);
 }
 
-TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithStatsAndZstdCompression) {
+TYPED_TEST(TestPrimitiveWriter, requiredPlainWithStatsAndZstdCompression) {
   this->testRequiredWithSettings(
       Encoding::kPlain, Compression::ZSTD, false, true, LARGE_SIZE);
 }
 
-TYPED_TEST(TestPrimitiveWriter, Optional) {
+TYPED_TEST(TestPrimitiveWriter, optional) {
   // Optional and non-repeated, with definition levels.
   // But no repetition levels.
   this->setUpSchema(Repetition::kOptional);
@@ -656,7 +656,7 @@ TYPED_TEST(TestPrimitiveWriter, Optional) {
   ASSERT_EQ(this->values_, this->valuesOut_);
 }
 
-TYPED_TEST(TestPrimitiveWriter, OptionalSpaced) {
+TYPED_TEST(TestPrimitiveWriter, optionalSpaced) {
   // Optional and non-repeated, with definition levels.
   // But no repetition levels.
   this->setUpSchema(Repetition::kOptional);
@@ -692,7 +692,7 @@ TYPED_TEST(TestPrimitiveWriter, OptionalSpaced) {
   ASSERT_EQ(this->values_, this->valuesOut_);
 }
 
-TYPED_TEST(TestPrimitiveWriter, Repeated) {
+TYPED_TEST(TestPrimitiveWriter, repeated) {
   // Optional and repeated, so definition and repetition levels.
   this->setUpSchema(Repetition::kRepeated);
 
@@ -716,7 +716,7 @@ TYPED_TEST(TestPrimitiveWriter, Repeated) {
   ASSERT_EQ(this->values_, this->valuesOut_);
 }
 
-TYPED_TEST(TestPrimitiveWriter, RequiredLargeChunk) {
+TYPED_TEST(TestPrimitiveWriter, requiredLargeChunk) {
   this->generateData(LARGE_SIZE);
 
   // Test case 1: required and non-repeated, so no definition or repetition.
@@ -742,7 +742,7 @@ TYPED_TEST(TestPrimitiveWriter, dictionaryfallbackversion20) {
   this->testDictionaryFallbackEncoding(ParquetVersion::PARQUET_2_6);
 }
 
-TEST(TestWriter, NullValuesBuffer) {
+TEST(TestWriter, nullValuesBuffer) {
   std::shared_ptr<::arrow::io::BufferOutputStream> sink = createOutputStream();
 
   const auto itemNode = schema::PrimitiveNode::make(
@@ -777,7 +777,7 @@ TEST(TestWriter, NullValuesBuffer) {
       numValues, defLevels, repLevels, validBits, validBitsOffset, values);
 }
 
-TYPED_TEST(TestPrimitiveWriter, RequiredPlainChecksum) {
+TYPED_TEST(TestPrimitiveWriter, requiredPlainChecksum) {
   this->testRequiredWithSettings(
       Encoding::kPlain,
       Compression::UNCOMPRESSED,
@@ -788,7 +788,7 @@ TYPED_TEST(TestPrimitiveWriter, RequiredPlainChecksum) {
       /* enable_checksum */ true);
 }
 
-TYPED_TEST(TestPrimitiveWriter, RequiredDictChecksum) {
+TYPED_TEST(TestPrimitiveWriter, requiredDictChecksum) {
   this->testRequiredWithSettings(
       Encoding::kPlain,
       Compression::UNCOMPRESSED,
@@ -801,7 +801,7 @@ TYPED_TEST(TestPrimitiveWriter, RequiredDictChecksum) {
 
 // PARQUET-719.
 // Test case for NULL values.
-TEST_F(TestValuesWriterInt32Type, OptionalNullValueChunk) {
+TEST_F(TestValuesWriterInt32Type, optionalNullValueChunk) {
   this->setUpSchema(Repetition::kOptional);
 
   this->generateData(LARGE_SIZE);
@@ -826,7 +826,7 @@ TEST_F(TestValuesWriterInt32Type, OptionalNullValueChunk) {
 // PARQUET-764.
 // Correct bitpacking for boolean write at non-byte boundaries.
 using TestBooleanValuesWriter = TestPrimitiveWriter<BooleanType>;
-TEST_F(TestBooleanValuesWriter, AlternateBooleanValues) {
+TEST_F(TestBooleanValuesWriter, alternateBooleanValues) {
   this->setUpSchema(Repetition::kRequired);
   auto writer = this->buildWriter();
   for (int i = 0; i < SMALL_SIZE; i++) {
@@ -842,7 +842,7 @@ TEST_F(TestBooleanValuesWriter, AlternateBooleanValues) {
 
 // PARQUET-979.
 // Prevent writing large MIN, MAX stats.
-TEST_F(TestByteArrayValuesWriter, OmitStats) {
+TEST_F(TestByteArrayValuesWriter, omitStats) {
   int minLen = 1024 * 4;
   int maxLen = 1024 * 8;
   this->setUpSchema(Repetition::kRequired);
@@ -861,7 +861,7 @@ TEST_F(TestByteArrayValuesWriter, OmitStats) {
 
 // PARQUET-1405.
 // Prevent writing large stats in the DataPageHeader.
-TEST_F(TestByteArrayValuesWriter, OmitDataPageStats) {
+TEST_F(TestByteArrayValuesWriter, omitDataPageStats) {
   int minLen = static_cast<int>(std::pow(10, 7));
   int maxLen = static_cast<int>(std::pow(10, 7));
   this->setUpSchema(Repetition::kRequired);
@@ -877,7 +877,7 @@ TEST_F(TestByteArrayValuesWriter, OmitDataPageStats) {
   ASSERT_NO_THROW(this->readColumn());
 }
 
-TEST_F(TestByteArrayValuesWriter, LimitStats) {
+TEST_F(TestByteArrayValuesWriter, limitStats) {
   int minLen = 1024 * 4;
   int maxLen = 1024 * 8;
   this->setUpSchema(Repetition::kRequired);
@@ -894,7 +894,7 @@ TEST_F(TestByteArrayValuesWriter, LimitStats) {
   ASSERT_TRUE(this->metadataIsStatsSet());
 }
 
-TEST_F(TestByteArrayValuesWriter, CheckDefaultStats) {
+TEST_F(TestByteArrayValuesWriter, checkDefaultStats) {
   this->setUpSchema(Repetition::kRequired);
   auto writer = this->buildWriter();
   this->generateData(SMALL_SIZE);
@@ -905,7 +905,7 @@ TEST_F(TestByteArrayValuesWriter, CheckDefaultStats) {
   ASSERT_TRUE(this->metadataIsStatsSet());
 }
 
-TEST(TestColumnWriter, RepeatedListsUpdateSpacedBug) {
+TEST(TestColumnWriter, repeatedListsUpdateSpacedBug) {
   // In ARROW-3930 we discovered a bug when writing from Arrow when we had data.
   // That looks like this:
   //
@@ -1092,7 +1092,7 @@ void verifyDecodingMultipleSetData(
 
 // Test levels with maximum bit-width from 1 to 8.
 // Increase the repetition count for each iteration by a factor of 2.
-TEST(TestLevels, TestLevelsDecodeMultipleBitWidth) {
+TEST(TestLevels, testLevelsDecodeMultipleBitWidth) {
   int minRepeatFactor = 0;
   int maxRepeatFactor = 7; // 128
   int maxBitWidth = 8;
@@ -1126,7 +1126,7 @@ TEST(TestLevels, TestLevelsDecodeMultipleBitWidth) {
 }
 
 // Test multiple decoder SetData calls.
-TEST(TestLevels, TestLevelsDecodeMultipleSetData) {
+TEST(TestLevels, testLevelsDecodeMultipleSetData) {
   int minRepeatFactor = 3;
   int maxRepeatFactor = 7; // 128
   int bitWidth = 8;
@@ -1157,7 +1157,7 @@ TEST(TestLevels, TestLevelsDecodeMultipleSetData) {
   }
 }
 
-TEST(TestLevelEncoder, MinimumBufferSize) {
+TEST(TestLevelEncoder, minimumBufferSize) {
   // PARQUET-676, PARQUET-698.
   const int kNumToEncode = 1024;
 
@@ -1185,7 +1185,7 @@ TEST(TestLevelEncoder, MinimumBufferSize) {
   ASSERT_EQ(kNumToEncode, encodeCount);
 }
 
-TEST(TestLevelEncoder, MinimumBufferSize2) {
+TEST(TestLevelEncoder, minimumBufferSize2) {
   // PARQUET-708.
   // Test the worst case for bit_width=2 consisting of.
   // LiteralRun(size=8)
@@ -1222,7 +1222,7 @@ TEST(TestLevelEncoder, MinimumBufferSize2) {
   }
 }
 
-TEST(TestColumnWriter, WriteDataPageV2Header) {
+TEST(TestColumnWriter, writeDataPageV2Header) {
   auto sink = createOutputStream();
   auto schema = std::static_pointer_cast<GroupNode>(GroupNode::make(
       "schema",
@@ -1310,7 +1310,7 @@ TEST(TestColumnWriter, WriteDataPageV2Header) {
 
 // The test below checks that data page v2 changes on record boundaries for.
 // all repetition types (i.e. required, optional, and repeated)
-TEST(TestColumnWriter, WriteDataPagesChangeOnRecordBoundaries) {
+TEST(TestColumnWriter, writeDataPagesChangeOnRecordBoundaries) {
   auto sink = createOutputStream();
   auto schema = std::static_pointer_cast<GroupNode>(GroupNode::make(
       "schema",
@@ -1390,7 +1390,7 @@ TEST(TestColumnWriter, WriteDataPagesChangeOnRecordBoundaries) {
 
 // The test below checks that data page v2 changes on record boundaries for.
 // Repeated columns with small batches.
-TEST(TestColumnWriter, WriteDataPagesChangeOnRecordBoundariesWithSmallBatches) {
+TEST(TestColumnWriter, writeDataPagesChangeOnRecordBoundariesWithSmallBatches) {
   auto sink = createOutputStream();
   auto schema = std::static_pointer_cast<GroupNode>(GroupNode::make(
       "schema",
@@ -1545,7 +1545,7 @@ class ColumnWriterTestSizeEstimated : public ::testing::Test {
   std::unique_ptr<ColumnChunkMetaDataBuilder> metadata_;
 };
 
-TEST_F(ColumnWriterTestSizeEstimated, NonBuffered) {
+TEST_F(ColumnWriterTestSizeEstimated, nonBuffered) {
   auto requiredWriter =
       this->buildWriter(Compression::UNCOMPRESSED, /* buffered*/ false);
   // Write half page, page will not be flushed after loop.
@@ -1573,7 +1573,7 @@ TEST_F(ColumnWriterTestSizeEstimated, NonBuffered) {
   EXPECT_EQ(writtenSize, requiredWriter->totalCompressedBytesWritten());
 }
 
-TEST_F(ColumnWriterTestSizeEstimated, Buffered) {
+TEST_F(ColumnWriterTestSizeEstimated, buffered) {
   auto requiredWriter =
       this->buildWriter(Compression::UNCOMPRESSED, /* buffered*/ true);
   // Write half page, page will not be flushed after loop.
@@ -1601,7 +1601,7 @@ TEST_F(ColumnWriterTestSizeEstimated, Buffered) {
   EXPECT_EQ(writtenSize, requiredWriter->totalCompressedBytesWritten());
 }
 
-TEST_F(ColumnWriterTestSizeEstimated, NonBufferedDictionary) {
+TEST_F(ColumnWriterTestSizeEstimated, nonBufferedDictionary) {
   auto requiredWriter =
       this->buildWriter(Compression::UNCOMPRESSED, /* buffered*/ false, true);
   // For dict, keep all values equal.
@@ -1632,7 +1632,7 @@ TEST_F(ColumnWriterTestSizeEstimated, NonBufferedDictionary) {
   EXPECT_EQ(writtenSize, requiredWriter->totalCompressedBytesWritten());
 }
 
-TEST_F(ColumnWriterTestSizeEstimated, BufferedCompression) {
+TEST_F(ColumnWriterTestSizeEstimated, bufferedCompression) {
   auto requiredWriter = this->buildWriter(Compression::SNAPPY, true);
 
   // Write half page.
@@ -1660,7 +1660,7 @@ TEST_F(ColumnWriterTestSizeEstimated, BufferedCompression) {
   EXPECT_GT(writtenSize, requiredWriter->totalCompressedBytesWritten());
 }
 
-TEST(TestColumnWriter, WriteDataPageV2HeaderNullCount) {
+TEST(TestColumnWriter, writeDataPageV2HeaderNullCount) {
   auto sink = createOutputStream();
   auto listType = GroupNode::make(
       "list",

--- a/velox/dwio/parquet/writer/arrow/tests/FileDeserializeTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/FileDeserializeTest.cpp
@@ -368,7 +368,7 @@ void checkDataPageHeader(
   checkStatistics(expected, dataPage->statistics());
 }
 
-TEST_F(TestPageSerde, DataPageV1) {
+TEST_F(TestPageSerde, dataPageV1) {
   int statsSize = 512;
   const int32_t numRows = 4444;
   addDummyStats(statsSize, dataPageHeader_, /*fill_all_stats=*/true);
@@ -499,7 +499,7 @@ TYPED_TEST_SUITE(PageFilterTest, DataPageHeaderTypes);
 
 // Test that the returned encoded_statistics is nullptr when there are no.
 // Statistics in the page header.
-TYPED_TEST(PageFilterTest, TestPageWithoutStatistics) {
+TYPED_TEST(PageFilterTest, testPageWithoutStatistics) {
   this->writePageWithoutStats();
 
   auto stream = std::make_shared<::arrow::io::BufferReader>(this->outBuffer_);
@@ -523,7 +523,7 @@ TYPED_TEST(PageFilterTest, TestPageWithoutStatistics) {
 
 // Creates a number of pages and skips some of them with the page filter.
 // Callback.
-TYPED_TEST(PageFilterTest, TestPageFilterCallback) {
+TYPED_TEST(PageFilterTest, testPageFilterCallback) {
   this->writeStream();
 
   { // Read all pages.
@@ -604,7 +604,7 @@ TYPED_TEST(PageFilterTest, TestPageFilterCallback) {
 
 // Set the page filter more than once. The new filter should be effective.
 // On the next NextPage() call.
-TYPED_TEST(PageFilterTest, TestChangingPageFilter) {
+TYPED_TEST(PageFilterTest, testChangingPageFilter) {
   this->writeStream();
 
   auto stream = std::make_shared<::arrow::io::BufferReader>(this->outBuffer_);
@@ -626,7 +626,7 @@ TYPED_TEST(PageFilterTest, TestChangingPageFilter) {
 }
 
 // Test that we do not skip dictionary pages.
-TEST_F(TestPageSerde, DoesNotFilterDictionaryPages) {
+TEST_F(TestPageSerde, doesNotFilterDictionaryPages) {
   int dataSize = 1024;
   std::vector<uint8_t> fauxData(dataSize);
 
@@ -656,7 +656,7 @@ TEST_F(TestPageSerde, DoesNotFilterDictionaryPages) {
 }
 
 // Tests that we successfully skip non-data pages.
-TEST_F(TestPageSerde, SkipsNonDataPages) {
+TEST_F(TestPageSerde, skipsNonDataPages) {
   int dataSize = 1024;
   std::vector<uint8_t> fauxData(dataSize);
   ASSERT_NO_FATAL_FAILURE(writeIndexPageHeader(dataSize, dataSize));
@@ -687,7 +687,7 @@ TEST_F(TestPageSerde, SkipsNonDataPages) {
   ASSERT_EQ(pageReader_->nextPage(), nullptr);
 }
 
-TEST_F(TestPageSerde, DataPageV2) {
+TEST_F(TestPageSerde, dataPageV2) {
   int statsSize = 512;
   const int32_t numRows = 4444;
   addDummyStats(statsSize, dataPageHeaderV2_, /*fill_all_stats=*/true);
@@ -700,7 +700,7 @@ TEST_F(TestPageSerde, DataPageV2) {
       checkDataPageHeader(dataPageHeaderV2_, currentPage.get()));
 }
 
-TEST_F(TestPageSerde, TestLargePageHeaders) {
+TEST_F(TestPageSerde, testLargePageHeaders) {
   int statsSize = 256 * 1024; // 256 KB
   addDummyStats(statsSize, dataPageHeader_);
 
@@ -724,7 +724,7 @@ TEST_F(TestPageSerde, TestLargePageHeaders) {
       checkDataPageHeader(dataPageHeader_, currentPage.get()));
 }
 
-TEST_F(TestPageSerde, TestFailLargePageHeaders) {
+TEST_F(TestPageSerde, testFailLargePageHeaders) {
   const int32_t numRows = 1337; // dummy value
 
   int statsSize = 256 * 1024; // 256 KB
@@ -796,7 +796,7 @@ void TestPageSerde::testPageCompressionRoundTrip(
   }
 }
 
-TEST_F(TestPageSerde, Compression) {
+TEST_F(TestPageSerde, compression) {
   std::vector<int> pageSizes;
   pageSizes.reserve(10);
   for (int i = 0; i < 10; ++i) {
@@ -806,7 +806,7 @@ TEST_F(TestPageSerde, Compression) {
   this->testPageCompressionRoundTrip(pageSizes);
 }
 
-TEST_F(TestPageSerde, PageSizeResetWhenRead) {
+TEST_F(TestPageSerde, pageSizeResetWhenRead) {
   // GH-35423: Parquet SerializedPageReader need to.
   // Reset the size after getting a smaller page.
   std::vector<int> pageSizes;
@@ -818,7 +818,7 @@ TEST_F(TestPageSerde, PageSizeResetWhenRead) {
   this->testPageCompressionRoundTrip(pageSizes);
 }
 
-TEST_F(TestPageSerde, LZONotSupported) {
+TEST_F(TestPageSerde, lzoNotSupported) {
   // Must await PARQUET-530.
   int dataSize = 1024;
   std::vector<uint8_t> fauxData(dataSize);
@@ -828,7 +828,7 @@ TEST_F(TestPageSerde, LZONotSupported) {
       initSerializedPageReader(dataSize, Compression::LZO), ParquetException);
 }
 
-TEST_F(TestPageSerde, NoCrc) {
+TEST_F(TestPageSerde, noCrc) {
   int statsSize = 512;
   const int32_t numRows = 4444;
   addDummyStats(statsSize, dataPageHeader_, true);
@@ -844,7 +844,7 @@ TEST_F(TestPageSerde, NoCrc) {
       checkDataPageHeader(dataPageHeader_, currentPage.get()));
 }
 
-TEST_F(TestPageSerde, NoCrcDict) {
+TEST_F(TestPageSerde, noCrcDict) {
   const int32_t numRows = 4444;
   dictionaryPageHeader_.num_values = numRows;
 
@@ -861,35 +861,35 @@ TEST_F(TestPageSerde, NoCrcDict) {
   EXPECT_EQ(numRows, dictPage->numValues());
 }
 
-TEST_F(TestPageSerde, CrcCheckSuccessful) {
+TEST_F(TestPageSerde, crcCheckSuccessful) {
   this->testPageSerdeCrc(
       /* write_checksum */ true,
       /* write_page_corrupt */ false,
       /* verification_checksum */ true);
 }
 
-TEST_F(TestPageSerde, CrcCheckFail) {
+TEST_F(TestPageSerde, crcCheckFail) {
   this->testPageSerdeCrc(
       /* write_checksum */ true,
       /* write_page_corrupt */ true,
       /* verification_checksum */ true);
 }
 
-TEST_F(TestPageSerde, CrcCorruptNotChecked) {
+TEST_F(TestPageSerde, crcCorruptNotChecked) {
   this->testPageSerdeCrc(
       /* write_checksum */ true,
       /* write_page_corrupt */ true,
       /* verification_checksum */ false);
 }
 
-TEST_F(TestPageSerde, CrcCheckNonExistent) {
+TEST_F(TestPageSerde, crcCheckNonExistent) {
   this->testPageSerdeCrc(
       /* write_checksum */ false,
       /* write_page_corrupt */ false,
       /* verification_checksum */ true);
 }
 
-TEST_F(TestPageSerde, DictCrcCheckSuccessful) {
+TEST_F(TestPageSerde, dictCrcCheckSuccessful) {
   this->testPageSerdeCrc(
       /* write_checksum */ true,
       /* write_page_corrupt */ false,
@@ -897,7 +897,7 @@ TEST_F(TestPageSerde, DictCrcCheckSuccessful) {
       /* has_dictionary */ true);
 }
 
-TEST_F(TestPageSerde, DictCrcCheckFail) {
+TEST_F(TestPageSerde, dictCrcCheckFail) {
   this->testPageSerdeCrc(
       /* write_checksum */ true,
       /* write_page_corrupt */ true,
@@ -905,7 +905,7 @@ TEST_F(TestPageSerde, DictCrcCheckFail) {
       /* has_dictionary */ true);
 }
 
-TEST_F(TestPageSerde, DictCrcCorruptNotChecked) {
+TEST_F(TestPageSerde, dictCrcCorruptNotChecked) {
   this->testPageSerdeCrc(
       /* write_checksum */ true,
       /* write_page_corrupt */ true,
@@ -913,7 +913,7 @@ TEST_F(TestPageSerde, DictCrcCorruptNotChecked) {
       /* has_dictionary */ true);
 }
 
-TEST_F(TestPageSerde, DictCrcCheckNonExistent) {
+TEST_F(TestPageSerde, dictCrcCheckNonExistent) {
   this->testPageSerdeCrc(
       /* write_checksum */ false,
       /* write_page_corrupt */ false,
@@ -921,7 +921,7 @@ TEST_F(TestPageSerde, DictCrcCheckNonExistent) {
       /* has_dictionary */ true);
 }
 
-TEST_F(TestPageSerde, DataPageV2CrcCheckSuccessful) {
+TEST_F(TestPageSerde, dataPageV2CrcCheckSuccessful) {
   this->testPageSerdeCrc(
       /* write_checksum */ true,
       /* write_page_corrupt */ false,
@@ -930,7 +930,7 @@ TEST_F(TestPageSerde, DataPageV2CrcCheckSuccessful) {
       /* write_data_page_v2 */ true);
 }
 
-TEST_F(TestPageSerde, DataPageV2CrcCheckFail) {
+TEST_F(TestPageSerde, dataPageV2CrcCheckFail) {
   this->testPageSerdeCrc(
       /* write_checksum */ true,
       /* write_page_corrupt */ true,
@@ -939,7 +939,7 @@ TEST_F(TestPageSerde, DataPageV2CrcCheckFail) {
       /* write_data_page_v2 */ true);
 }
 
-TEST_F(TestPageSerde, DataPageV2CrcCorruptNotChecked) {
+TEST_F(TestPageSerde, dataPageV2CrcCorruptNotChecked) {
   this->testPageSerdeCrc(
       /* write_checksum */ true,
       /* write_page_corrupt */ true,
@@ -948,7 +948,7 @@ TEST_F(TestPageSerde, DataPageV2CrcCorruptNotChecked) {
       /* write_data_page_v2 */ true);
 }
 
-TEST_F(TestPageSerde, DataPageV2CrcCheckNonExistent) {
+TEST_F(TestPageSerde, dataPageV2CrcCheckNonExistent) {
   this->testPageSerdeCrc(
       /* write_checksum */ false,
       /* write_page_corrupt */ false,
@@ -987,14 +987,14 @@ class TestParquetFileReader : public ::testing::Test {
   }
 };
 
-TEST_F(TestParquetFileReader, InvalidHeader) {
+TEST_F(TestParquetFileReader, invalidHeader) {
   const char* badHeader = "PAR2";
 
   auto buffer = Buffer::Wrap(badHeader, strlen(badHeader));
   ASSERT_NO_FATAL_FAILURE(assertInvalidFileThrows(buffer));
 }
 
-TEST_F(TestParquetFileReader, InvalidFooter) {
+TEST_F(TestParquetFileReader, invalidFooter) {
   // File is smaller than FOOTER_SIZE.
   const char* badFile = "PAR1PAR";
   auto buffer = Buffer::Wrap(badFile, strlen(badFile));
@@ -1006,7 +1006,7 @@ TEST_F(TestParquetFileReader, InvalidFooter) {
   ASSERT_NO_FATAL_FAILURE(assertInvalidFileThrows(buffer));
 }
 
-TEST_F(TestParquetFileReader, IncompleteMetadata) {
+TEST_F(TestParquetFileReader, incompleteMetadata) {
   auto stream = createOutputStream();
 
   const char* magic = "PAR1";

--- a/velox/dwio/parquet/writer/arrow/tests/FileSerializeTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/FileSerializeTest.cpp
@@ -340,57 +340,57 @@ typedef ::testing::Types<
 
 TYPED_TEST_SUITE(TestSerialize, TestTypes);
 
-TYPED_TEST(TestSerialize, SmallFileUncompressed) {
+TYPED_TEST(TestSerialize, smallFileUncompressed) {
   ASSERT_NO_FATAL_FAILURE(this->fileSerializeTest(Compression::UNCOMPRESSED));
 }
 
-TYPED_TEST(TestSerialize, TooFewRows) {
+TYPED_TEST(TestSerialize, tooFewRows) {
   std::vector<int64_t> numRows = {100, 100, 100, 99};
   ASSERT_THROW(this->unequalNumRows(100, numRows), ParquetException);
   ASSERT_THROW(this->unequalNumRowsBuffered(100, numRows), ParquetException);
 }
 
-TYPED_TEST(TestSerialize, TooManyRows) {
+TYPED_TEST(TestSerialize, tooManyRows) {
   std::vector<int64_t> numRows = {100, 100, 100, 101};
   ASSERT_THROW(this->unequalNumRows(101, numRows), ParquetException);
   ASSERT_THROW(this->unequalNumRowsBuffered(101, numRows), ParquetException);
 }
 
-TYPED_TEST(TestSerialize, ZeroRows) {
+TYPED_TEST(TestSerialize, zeroRows) {
   ASSERT_NO_THROW(this->zeroRowsRowGroup());
 }
 
-TYPED_TEST(TestSerialize, RepeatedTooFewRows) {
+TYPED_TEST(TestSerialize, repeatedTooFewRows) {
   ASSERT_THROW(this->repeatedUnequalRows(), ParquetException);
 }
 
-TYPED_TEST(TestSerialize, SmallFileSnappy) {
+TYPED_TEST(TestSerialize, smallFileSnappy) {
   ASSERT_NO_FATAL_FAILURE(this->fileSerializeTest(Compression::SNAPPY));
 }
 
 #ifdef ARROW_WITH_BROTLI
-TYPED_TEST(TestSerialize, SmallFileBrotli) {
+TYPED_TEST(TestSerialize, smallFileBrotli) {
   ASSERT_NO_FATAL_FAILURE(this->fileSerializeTest(Compression::BROTLI));
 }
 #endif
 
-TYPED_TEST(TestSerialize, SmallFileGzip) {
+TYPED_TEST(TestSerialize, smallFileGzip) {
   ASSERT_NO_FATAL_FAILURE(this->fileSerializeTest(Compression::GZIP));
 }
 
-TYPED_TEST(TestSerialize, SmallFileLz4) {
+TYPED_TEST(TestSerialize, smallFileLz4) {
   ASSERT_NO_FATAL_FAILURE(this->fileSerializeTest(Compression::LZ4));
 }
 
-TYPED_TEST(TestSerialize, SmallFileLz4Hadoop) {
+TYPED_TEST(TestSerialize, smallFileLz4Hadoop) {
   ASSERT_NO_FATAL_FAILURE(this->fileSerializeTest(Compression::LZ4_HADOOP));
 }
 
-TYPED_TEST(TestSerialize, SmallFileZstd) {
+TYPED_TEST(TestSerialize, smallFileZstd) {
   ASSERT_NO_FATAL_FAILURE(this->fileSerializeTest(Compression::ZSTD));
 }
 
-TEST(TestBufferedRowGroupWriter, DisabledDictionary) {
+TEST(TestBufferedRowGroupWriter, disabledDictionary) {
   // PARQUET-1706:
   // Wrong dictionary_page_offset when writing only data pages via.
   // BufferedPageWriter.
@@ -419,7 +419,7 @@ TEST(TestBufferedRowGroupWriter, DisabledDictionary) {
   ASSERT_FALSE(rgReader->metadata()->columnChunk(0)->hasDictionaryPage());
 }
 
-TEST(TestBufferedRowGroupWriter, MultiPageDisabledDictionary) {
+TEST(TestBufferedRowGroupWriter, multiPageDisabledDictionary) {
   constexpr int kValueCount = 10000;
   constexpr int kPageSize = 16384;
   auto sink = createOutputStream();
@@ -471,7 +471,7 @@ TEST(TestBufferedRowGroupWriter, MultiPageDisabledDictionary) {
   }
 }
 
-TEST(ParquetRoundtrip, AllNulls) {
+TEST(ParquetRoundtrip, allNulls) {
   auto primitiveNode = PrimitiveNode::make(
       "nulls", Repetition::kOptional, nullptr, Type::kInt32);
   schema::NodeVector columns({primitiveNode});

--- a/velox/dwio/parquet/writer/arrow/tests/MetadataTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/MetadataTest.cpp
@@ -138,7 +138,7 @@ void assertEncodings(
   ASSERT_EQ(encodings, expected);
 }
 
-TEST(Metadata, TestBuildAccess) {
+TEST(Metadata, testBuildAccess) {
   schema::NodeVector fields;
   schema::NodePtr root;
   SchemaDescriptor schema;
@@ -324,7 +324,7 @@ TEST(Metadata, TestBuildAccess) {
   ASSERT_TRUE(fAccessor1->equals(*fAccessor->subset({2, 0})));
 }
 
-TEST(Metadata, TestV1Version) {
+TEST(Metadata, testV1Version) {
   // PARQUET-839.
   schema::NodeVector fields;
   schema::NodePtr root;
@@ -349,7 +349,7 @@ TEST(Metadata, TestV1Version) {
   ASSERT_EQ(ParquetVersion::PARQUET_1_0, fAccessor->version());
 }
 
-TEST(Metadata, TestKeyValueMetadata) {
+TEST(Metadata, testKeyValueMetadata) {
   schema::NodeVector fields;
   schema::NodePtr root;
   SchemaDescriptor schema;
@@ -377,7 +377,7 @@ TEST(Metadata, TestKeyValueMetadata) {
   EXPECT_TRUE(fAccessor->keyValueMetadata()->Equals(*kvmeta));
 }
 
-TEST(Metadata, TestAddKeyValueMetadata) {
+TEST(Metadata, testAddKeyValueMetadata) {
   schema::NodeVector fields;
   fields.push_back(schema::int32("int_col", Repetition::kRequired));
   auto schema = std::static_pointer_cast<schema::GroupNode>(
@@ -442,7 +442,7 @@ TEST(Metadata, TestAddKeyValueMetadata) {
 
 // TODO: disabled as they require Arrow parquet data dir.
 /*
-TEST(Metadata, TestHasBloomFilter) {
+TEST(Metadata, testHasBloomFilter) {
   std::string dir_string(test::get_data_dir());
   std::string path = dir_string + "/data_index_bloom_encoding_stats.parquet";
   auto reader = ParquetFileReader::OpenFile(path, false);
@@ -456,7 +456,7 @@ TEST(Metadata, TestHasBloomFilter) {
   ASSERT_EQ(192, bloom_filter_offset);
 }
 
-TEST(Metadata, TestReadPageIndex) {
+TEST(Metadata, testReadPageIndex) {
   std::string dir_string(test::get_data_dir());
   std::string path = dir_string + "/alltypes_tiny_pages.parquet";
   auto reader = ParquetFileReader::OpenFile(path, false);
@@ -495,7 +495,7 @@ TEST(Metadata, TestReadPageIndex) {
 }
 */
 
-TEST(Metadata, TestSortingColumns) {
+TEST(Metadata, testSortingColumns) {
   schema::NodeVector fields;
   fields.push_back(schema::int32("sort_col", Repetition::kRequired));
   fields.push_back(schema::int32("int_col", Repetition::kRequired));
@@ -556,7 +556,7 @@ TEST(Metadata, TestSortingColumns) {
   ASSERT_EQ(createdBy, reader->fileMetaData().createdBy());
 }
 
-TEST(ApplicationVersion, Basics) {
+TEST(ApplicationVersion, basics) {
   ApplicationVersion version("parquet-mr version 1.7.9");
   ApplicationVersion version1("parquet-mr version 1.8.0");
   ApplicationVersion version2("parquet-cpp version 1.0.0");
@@ -640,7 +640,7 @@ TEST(ApplicationVersion, empty) {
   ASSERT_EQ("", version.version.buildInfo);
 }
 
-TEST(ApplicationVersion, NoVersion) {
+TEST(ApplicationVersion, noVersion) {
   ApplicationVersion version("parquet-mr (build abcd)");
 
   ASSERT_EQ("parquet-mr (build abcd)", version.application_);
@@ -653,7 +653,7 @@ TEST(ApplicationVersion, NoVersion) {
   ASSERT_EQ("", version.version.buildInfo);
 }
 
-TEST(ApplicationVersion, VersionEmpty) {
+TEST(ApplicationVersion, versionEmpty) {
   ApplicationVersion version("parquet-mr version ");
 
   ASSERT_EQ("parquet-mr", version.application_);
@@ -666,7 +666,7 @@ TEST(ApplicationVersion, VersionEmpty) {
   ASSERT_EQ("", version.version.buildInfo);
 }
 
-TEST(ApplicationVersion, VersionNoMajor) {
+TEST(ApplicationVersion, versionNoMajor) {
   ApplicationVersion version("parquet-mr version .");
 
   ASSERT_EQ("parquet-mr", version.application_);
@@ -679,7 +679,7 @@ TEST(ApplicationVersion, VersionNoMajor) {
   ASSERT_EQ("", version.version.buildInfo);
 }
 
-TEST(ApplicationVersion, VersionInvalidMajor) {
+TEST(ApplicationVersion, versionInvalidMajor) {
   ApplicationVersion version("parquet-mr version x1");
 
   ASSERT_EQ("parquet-mr", version.application_);
@@ -692,7 +692,7 @@ TEST(ApplicationVersion, VersionInvalidMajor) {
   ASSERT_EQ("", version.version.buildInfo);
 }
 
-TEST(ApplicationVersion, VersionMajorOnly) {
+TEST(ApplicationVersion, versionMajorOnly) {
   ApplicationVersion version("parquet-mr version 1");
 
   ASSERT_EQ("parquet-mr", version.application_);
@@ -705,7 +705,7 @@ TEST(ApplicationVersion, VersionMajorOnly) {
   ASSERT_EQ("", version.version.buildInfo);
 }
 
-TEST(ApplicationVersion, VersionNoMinor) {
+TEST(ApplicationVersion, versionNoMinor) {
   ApplicationVersion version("parquet-mr version 1.");
 
   ASSERT_EQ("parquet-mr", version.application_);
@@ -718,7 +718,7 @@ TEST(ApplicationVersion, VersionNoMinor) {
   ASSERT_EQ("", version.version.buildInfo);
 }
 
-TEST(ApplicationVersion, VersionMajorMinorOnly) {
+TEST(ApplicationVersion, versionMajorMinorOnly) {
   ApplicationVersion version("parquet-mr version 1.7");
 
   ASSERT_EQ("parquet-mr", version.application_);
@@ -731,7 +731,7 @@ TEST(ApplicationVersion, VersionMajorMinorOnly) {
   ASSERT_EQ("", version.version.buildInfo);
 }
 
-TEST(ApplicationVersion, VersionInvalidMinor) {
+TEST(ApplicationVersion, versionInvalidMinor) {
   ApplicationVersion version("parquet-mr version 1.x7");
 
   ASSERT_EQ("parquet-mr", version.application_);
@@ -744,7 +744,7 @@ TEST(ApplicationVersion, VersionInvalidMinor) {
   ASSERT_EQ("", version.version.buildInfo);
 }
 
-TEST(ApplicationVersion, VersionNoPatch) {
+TEST(ApplicationVersion, versionNoPatch) {
   ApplicationVersion version("parquet-mr version 1.7.");
 
   ASSERT_EQ("parquet-mr", version.application_);
@@ -757,7 +757,7 @@ TEST(ApplicationVersion, VersionNoPatch) {
   ASSERT_EQ("", version.version.buildInfo);
 }
 
-TEST(ApplicationVersion, VersionInvalidPatch) {
+TEST(ApplicationVersion, versionInvalidPatch) {
   ApplicationVersion version("parquet-mr version 1.7.x9");
 
   ASSERT_EQ("parquet-mr", version.application_);
@@ -770,7 +770,7 @@ TEST(ApplicationVersion, VersionInvalidPatch) {
   ASSERT_EQ("", version.version.buildInfo);
 }
 
-TEST(ApplicationVersion, VersionNoUnknown) {
+TEST(ApplicationVersion, versionNoUnknown) {
   ApplicationVersion version("parquet-mr version 1.7.9-cdh5.5.0+cd");
 
   ASSERT_EQ("parquet-mr", version.application_);
@@ -783,7 +783,7 @@ TEST(ApplicationVersion, VersionNoUnknown) {
   ASSERT_EQ("cd", version.version.buildInfo);
 }
 
-TEST(ApplicationVersion, VersionNoPreRelease) {
+TEST(ApplicationVersion, versionNoPreRelease) {
   ApplicationVersion version("parquet-mr version 1.7.9ab+cd");
 
   ASSERT_EQ("parquet-mr", version.application_);
@@ -796,7 +796,7 @@ TEST(ApplicationVersion, VersionNoPreRelease) {
   ASSERT_EQ("cd", version.version.buildInfo);
 }
 
-TEST(ApplicationVersion, VersionNoUnknownNoPreRelease) {
+TEST(ApplicationVersion, versionNoUnknownNoPreRelease) {
   ApplicationVersion version("parquet-mr version 1.7.9+cd");
 
   ASSERT_EQ("parquet-mr", version.application_);
@@ -809,7 +809,7 @@ TEST(ApplicationVersion, VersionNoUnknownNoPreRelease) {
   ASSERT_EQ("cd", version.version.buildInfo);
 }
 
-TEST(ApplicationVersion, VersionNoUnknownBuildInfoPreRelease) {
+TEST(ApplicationVersion, versionNoUnknownBuildInfoPreRelease) {
   ApplicationVersion version("parquet-mr version 1.7.9+cd-cdh5.5.0");
 
   ASSERT_EQ("parquet-mr", version.application_);
@@ -822,7 +822,7 @@ TEST(ApplicationVersion, VersionNoUnknownBuildInfoPreRelease) {
   ASSERT_EQ("cd-cdh5.5.0", version.version.buildInfo);
 }
 
-TEST(ApplicationVersion, FullWithSpaces) {
+TEST(ApplicationVersion, fullWithSpaces) {
   ApplicationVersion version(
       " parquet-mr \t version \v 1.5.3ab-cdh5.5.0+cd \r (build \n abcd \f) ");
 

--- a/velox/dwio/parquet/writer/arrow/tests/PageIndexTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/PageIndexTest.cpp
@@ -152,7 +152,7 @@ TEST(PageIndex, determinePageIndexRangesInRowGroup) {
 /// Offsets in them. Then it validates if.
 /// PageIndexReader::DeterminePageIndexRangesInRowGroup() properly computes the.
 /// File range that contains the page index of selected columns.
-TEST(PageIndex, DeterminePageIndexRangesInRowGroupWithPartialColumnsSelected) {
+TEST(PageIndex, determinePageIndexRangesInRowGroupWithPartialColumnsSelected) {
   // No page index at all.
   validatePageIndexRange({{-1, -1, -1, -1}}, {0}, false, false, -1, -1, -1, -1);
   // Page index for single column chunk.
@@ -233,7 +233,7 @@ TEST(PageIndex, DeterminePageIndexRangesInRowGroupWithPartialColumnsSelected) {
 /// Offsets in them. Then it validates if.
 /// PageIndexReader::DeterminePageIndexRangesInRowGroup() properly detects if.
 /// Column index or offset index is missing.
-TEST(PageIndex, DeterminePageIndexRangesInRowGroupWithMissingPageIndex) {
+TEST(PageIndex, determinePageIndexRangesInRowGroupWithMissingPageIndex) {
   // No column index at all.
   validatePageIndexRange({{-1, -1, 15, 5}}, {}, false, true, -1, -1, 15, 5);
   // No offset index at all.
@@ -246,7 +246,7 @@ TEST(PageIndex, DeterminePageIndexRangesInRowGroupWithMissingPageIndex) {
       {{10, 5, -1, -1}, {15, 15, -1, -1}}, {}, true, false, 10, 20, -1, -1);
 }
 
-TEST(PageIndex, WriteOffsetIndex) {
+TEST(PageIndex, writeOffsetIndex) {
   /// Create offset index via the OffsetIndexBuilder interface.
   auto Builder = OffsetIndexBuilder::make();
   const size_t numPages = 5;
@@ -329,7 +329,7 @@ void testWriteTypedColumnIndex(
   }
 }
 
-TEST(PageIndex, WriteInt32ColumnIndex) {
+TEST(PageIndex, writeInt32ColumnIndex) {
   auto encode = [=](int32_t value) {
     return std::string(reinterpret_cast<const char*>(&value), sizeof(int32_t));
   };
@@ -344,7 +344,7 @@ TEST(PageIndex, WriteInt32ColumnIndex) {
       schema::int32("c1"), pageStats, BoundaryOrder::kAscending, true);
 }
 
-TEST(PageIndex, WriteInt64ColumnIndex) {
+TEST(PageIndex, writeInt64ColumnIndex) {
   auto encode = [=](int64_t value) {
     return std::string(reinterpret_cast<const char*>(&value), sizeof(int64_t));
   };
@@ -359,7 +359,7 @@ TEST(PageIndex, WriteInt64ColumnIndex) {
       schema::int64("c1"), pageStats, BoundaryOrder::kDescending, true);
 }
 
-TEST(PageIndex, WriteFloatColumnIndex) {
+TEST(PageIndex, writeFloatColumnIndex) {
   auto encode = [=](float value) {
     return std::string(reinterpret_cast<const char*>(&value), sizeof(float));
   };
@@ -374,7 +374,7 @@ TEST(PageIndex, WriteFloatColumnIndex) {
       schema::floatType("c1"), pageStats, BoundaryOrder::kUnordered, true);
 }
 
-TEST(PageIndex, WriteDoubleColumnIndex) {
+TEST(PageIndex, writeDoubleColumnIndex) {
   auto encode = [=](double value) {
     return std::string(reinterpret_cast<const char*>(&value), sizeof(double));
   };
@@ -389,7 +389,7 @@ TEST(PageIndex, WriteDoubleColumnIndex) {
       schema::doubleType("c1"), pageStats, BoundaryOrder::kUnordered, false);
 }
 
-TEST(PageIndex, WriteByteArrayColumnIndex) {
+TEST(PageIndex, writeByteArrayColumnIndex) {
   // Byte array values with identical min/max.
   std::vector<EncodedStatistics> pageStats(3);
   pageStats.at(0).setMin("bar").setMax("foo");
@@ -400,7 +400,7 @@ TEST(PageIndex, WriteByteArrayColumnIndex) {
       schema::byteArray("c1"), pageStats, BoundaryOrder::kAscending, false);
 }
 
-TEST(PageIndex, WriteFLBAColumnIndex) {
+TEST(PageIndex, writeFLBAColumnIndex) {
   // FLBA values in the ascending order with some null pages.
   std::vector<EncodedStatistics> pageStats(5);
   pageStats.at(0).setMin("abc").setMax("ABC");
@@ -419,7 +419,7 @@ TEST(PageIndex, WriteFLBAColumnIndex) {
       std::move(Node), pageStats, BoundaryOrder::kAscending, false);
 }
 
-TEST(PageIndex, WriteColumnIndexWithAllNullPages) {
+TEST(PageIndex, writeColumnIndexWithAllNullPages) {
   // All values are null.
   std::vector<EncodedStatistics> pageStats(3);
   pageStats.at(0).setNullCount(100).allNullValue = true;
@@ -430,7 +430,7 @@ TEST(PageIndex, WriteColumnIndexWithAllNullPages) {
       schema::int32("c1"), pageStats, BoundaryOrder::kUnordered, true);
 }
 
-TEST(PageIndex, WriteColumnIndexWithInvalidNullCounts) {
+TEST(PageIndex, writeColumnIndexWithInvalidNullCounts) {
   auto encode = [=](int32_t value) {
     return std::string(reinterpret_cast<const char*>(&value), sizeof(int32_t));
   };
@@ -445,7 +445,7 @@ TEST(PageIndex, WriteColumnIndexWithInvalidNullCounts) {
       schema::int32("c1"), pageStats, BoundaryOrder::kAscending, false);
 }
 
-TEST(PageIndex, WriteColumnIndexWithCorruptedStats) {
+TEST(PageIndex, writeColumnIndexWithCorruptedStats) {
   auto encode = [=](int32_t value) {
     return std::string(reinterpret_cast<const char*>(&value), sizeof(int32_t));
   };
@@ -469,7 +469,7 @@ TEST(PageIndex, WriteColumnIndexWithCorruptedStats) {
   EXPECT_EQ(0, buffer->size());
 }
 
-TEST(PageIndex, TestPageIndexBuilderWithZeroRowGroup) {
+TEST(PageIndex, testPageIndexBuilderWithZeroRowGroup) {
   schema::NodeVector fields = {schema::int32("c1"), schema::byteArray("c2")};
   schema::NodePtr root =
       schema::GroupNode::make("schema", Repetition::kRepeated, fields);
@@ -604,7 +604,7 @@ class PageIndexBuilderTest : public ::testing::Test {
   PageIndexLocation pageIndexLocation_;
 };
 
-TEST_F(PageIndexBuilderTest, SingleRowGroup) {
+TEST_F(PageIndexBuilderTest, singleRowGroup) {
   schema::NodePtr root = schema::GroupNode::make(
       "schema",
       Repetition::kRepeated,
@@ -645,7 +645,7 @@ TEST_F(PageIndexBuilderTest, SingleRowGroup) {
   ASSERT_EQ(nullptr, readOffsetIndex(0, 2));
 }
 
-TEST_F(PageIndexBuilderTest, TwoRowGroups) {
+TEST_F(PageIndexBuilderTest, twoRowGroups) {
   schema::NodePtr root = schema::GroupNode::make(
       "schema",
       Repetition::kRepeated,

--- a/velox/dwio/parquet/writer/arrow/tests/PropertiesTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/PropertiesTest.cpp
@@ -31,7 +31,7 @@ using schema::ColumnPath;
 
 namespace test {
 
-TEST(TestReaderProperties, Basics) {
+TEST(TestReaderProperties, basics) {
   ReaderProperties props;
 
   ASSERT_EQ(props.bufferSize(), kDefaultBufferSize);
@@ -39,7 +39,7 @@ TEST(TestReaderProperties, Basics) {
   ASSERT_FALSE(props.pageChecksumVerification());
 }
 
-TEST(TestWriterProperties, Basics) {
+TEST(TestWriterProperties, basics) {
   std::shared_ptr<WriterProperties> props = WriterProperties::Builder().build();
 
   ASSERT_EQ(kDefaultDataPageSize, props->dataPagesize());
@@ -50,7 +50,7 @@ TEST(TestWriterProperties, Basics) {
   ASSERT_FALSE(props->pageChecksumEnabled());
 }
 
-TEST(TestWriterProperties, AdvancedHandling) {
+TEST(TestWriterProperties, advancedHandling) {
   WriterProperties::Builder Builder;
   Builder.compression("gzip", Compression::GZIP);
   Builder.compression("zstd", Compression::ZSTD);
@@ -76,7 +76,7 @@ TEST(TestWriterProperties, AdvancedHandling) {
   ASSERT_EQ(ParquetDataPageVersion::V2, props->dataPageVersion());
 }
 
-TEST(TestReaderProperties, GetStreamInsufficientData) {
+TEST(TestReaderProperties, getStreamInsufficientData) {
   // ARROW-6058.
   std::string data = "shorter than expected";
   auto buf = std::make_shared<Buffer>(data);

--- a/velox/dwio/parquet/writer/arrow/tests/SchemaTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/SchemaTest.cpp
@@ -113,7 +113,7 @@ static void confirmGroupNodeRoundtrip(
 // ----------------------------------------------------------------------.
 // ColumnPath.
 
-TEST(TestColumnPath, TestAttrs) {
+TEST(TestColumnPath, testAttrs) {
   ColumnPath path(std::vector<std::string>({"toplevel", "leaf"}));
 
   ASSERT_EQ(path.toDotString(), "toplevel.leaf");
@@ -150,7 +150,7 @@ class TestPrimitiveNode : public ::testing::Test {
   std::unique_ptr<Node> node_;
 };
 
-TEST_F(TestPrimitiveNode, Attrs) {
+TEST_F(TestPrimitiveNode, attrs) {
   PrimitiveNode node1("foo", Repetition::kRepeated, Type::kInt32);
 
   PrimitiveNode node2(
@@ -303,7 +303,7 @@ TEST_F(TestPrimitiveNode, equals) {
   ASSERT_FALSE(flba1.equals(&flba5));
 }
 
-TEST_F(TestPrimitiveNode, PhysicalLogicalMapping) {
+TEST_F(TestPrimitiveNode, physicalLogicalMapping) {
   ASSERT_NO_THROW(
       PrimitiveNode::make(
           "foo", Repetition::kRequired, Type::kInt32, ConvertedType::kInt32));
@@ -464,7 +464,7 @@ class TestGroupNode : public ::testing::Test {
   }
 };
 
-TEST_F(TestGroupNode, Attrs) {
+TEST_F(TestGroupNode, attrs) {
   NodeVector fields = fields1();
 
   GroupNode node1("foo", Repetition::kRepeated, fields);
@@ -526,7 +526,7 @@ TEST_F(TestGroupNode, fieldIndex) {
   ASSERT_LT(group.fieldIndex(*nonFieldFamiliar), 0);
 }
 
-TEST_F(TestGroupNode, FieldIndexDuplicateName) {
+TEST_F(TestGroupNode, fieldIndexDuplicateName) {
   NodeVector fields = fields2();
   GroupNode group("group", Repetition::kRequired, fields);
   for (size_t i = 0; i < fields.size(); i++) {
@@ -575,7 +575,7 @@ bool checkForParentConsistency(const GroupNode* Node) {
   return true;
 }
 
-TEST_F(TestSchemaConverter, NestedExample) {
+TEST_F(TestSchemaConverter, nestedExample) {
   SchemaElement elt;
   std::vector<SchemaElement> elements;
   elements.push_back(newGroup(name_, FieldRepetitionType::REPEATED, 2, 0));
@@ -621,14 +621,14 @@ TEST_F(TestSchemaConverter, NestedExample) {
   ASSERT_TRUE(checkForParentConsistency(group_));
 }
 
-TEST_F(TestSchemaConverter, ZeroColumns) {
+TEST_F(TestSchemaConverter, zeroColumns) {
   // ARROW-3843.
   SchemaElement elements[1];
   elements[0] = newGroup("schema", FieldRepetitionType::REPEATED, 0, 0);
   ASSERT_NO_THROW(convert(elements, 1));
 }
 
-TEST_F(TestSchemaConverter, InvalidRoot) {
+TEST_F(TestSchemaConverter, invalidRoot) {
   // According to the Parquet specification, the first element in the.
   // list<SchemaElement> is a group whose children (and their descendants)
   // Contain all of the rest of the flattened schema elements. If the first.
@@ -652,7 +652,7 @@ TEST_F(TestSchemaConverter, InvalidRoot) {
   ASSERT_NO_FATAL_FAILURE(convert(elements, 2));
 }
 
-TEST_F(TestSchemaConverter, NotEnoughChildren) {
+TEST_F(TestSchemaConverter, notEnoughChildren) {
   // Throw a ParquetException, but don't core dump or anything.
   SchemaElement elt;
   std::vector<SchemaElement> elements;
@@ -678,7 +678,7 @@ class TestSchemaFlatten : public ::testing::Test {
   std::vector<facebook::velox::parquet::thrift::SchemaElement> elements_;
 };
 
-TEST_F(TestSchemaFlatten, DecimalMetadata) {
+TEST_F(TestSchemaFlatten, decimalMetadata) {
   // Checks that DecimalMetadata is only set for DecimalTypes.
   NodePtr Node = PrimitiveNode::make(
       "decimal",
@@ -720,7 +720,7 @@ TEST_F(TestSchemaFlatten, DecimalMetadata) {
   ASSERT_FALSE(elements_[0].__isset.scale);
 }
 
-TEST_F(TestSchemaFlatten, NestedExample) {
+TEST_F(TestSchemaFlatten, nestedExample) {
   SchemaElement elt;
   std::vector<SchemaElement> elements;
   elements.push_back(newGroup(name_, FieldRepetitionType::REPEATED, 2, 0));
@@ -767,7 +767,7 @@ TEST_F(TestSchemaFlatten, NestedExample) {
   }
 }
 
-TEST(TestColumnDescriptor, TestAttrs) {
+TEST(TestColumnDescriptor, testAttrs) {
   NodePtr Node = PrimitiveNode::make(
       "name", Repetition::kOptional, Type::kByteArray, ConvertedType::kUtf8);
   ColumnDescriptor descr(Node, 4, 1);
@@ -827,7 +827,7 @@ class TestSchemaDescriptor : public ::testing::Test {
   SchemaDescriptor descr_;
 };
 
-TEST_F(TestSchemaDescriptor, InitNonGroup) {
+TEST_F(TestSchemaDescriptor, initNonGroup) {
   NodePtr Node =
       PrimitiveNode::make("field", Repetition::kOptional, Type::kInt32);
 
@@ -1030,7 +1030,7 @@ static std::string print(const NodePtr& Node) {
   return ss.str();
 }
 
-TEST(TestSchemaPrinter, Examples) {
+TEST(TestSchemaPrinter, examples) {
   // Test schema 1.
   NodeVector fields;
   fields.push_back(int32("a", Repetition::kRequired, 1));
@@ -1106,7 +1106,7 @@ static void confirmFactoryEquivalence(
   return;
 }
 
-TEST(TestLogicalTypeConstruction, FactoryEquivalence) {
+TEST(TestLogicalTypeConstruction, factoryEquivalence) {
   // For each legacy converted type, ensure that the equivalent logical type.
   // object can be obtained from either the base class's FromConvertedType()
   // Factory method or the logical type type class's Make() method (accessed
@@ -1249,7 +1249,7 @@ static void confirmConvertedTypeCompatibility(
   return;
 }
 
-TEST(TestLogicalTypeConstruction, ConvertedTypeCompatibility) {
+TEST(TestLogicalTypeConstruction, convertedTypeCompatibility) {
   // For each legacy converted type, ensure that the equivalent logical type.
   // Emits correct, compatible converted type information and that the emitted.
   // Information can be used to reconstruct another equivalent logical type.
@@ -1349,7 +1349,7 @@ static void confirmNewTypeIncompatibility(
   return;
 }
 
-TEST(TestLogicalTypeConstruction, NewTypeIncompatibility) {
+TEST(TestLogicalTypeConstruction, newTypeIncompatibility) {
   // For each new logical type, ensure that the type.
   // Correctly reports that it has no legacy equivalent.
 
@@ -1390,7 +1390,7 @@ TEST(TestLogicalTypeConstruction, NewTypeIncompatibility) {
   }
 }
 
-TEST(TestLogicalTypeConstruction, FactoryExceptions) {
+TEST(TestLogicalTypeConstruction, factoryExceptions) {
   // Ensure that logical type construction catches invalid arguments.
 
   std::vector<std::function<void()>> cases = {
@@ -1439,7 +1439,7 @@ static void confirmLogicalTypeProperties(
   return;
 }
 
-TEST(TestLogicalTypeOperation, LogicalTypeProperties) {
+TEST(TestLogicalTypeOperation, logicalTypeProperties) {
   // For each logical type, ensure that the correct general properties are.
   // Reported.
 
@@ -1534,7 +1534,7 @@ static void confirmNoPrimitiveTypeApplicability(
   return;
 }
 
-TEST(TestLogicalTypeOperation, LogicalTypeApplicability) {
+TEST(TestLogicalTypeOperation, logicalTypeApplicability) {
   // Check that each logical type correctly reports which.
   // Underlying primitive type(s) it can be applied to.
 
@@ -1620,7 +1620,7 @@ TEST(TestLogicalTypeOperation, LogicalTypeApplicability) {
   }
 }
 
-TEST(TestLogicalTypeOperation, DecimalLogicalTypeApplicability) {
+TEST(TestLogicalTypeOperation, decimalLogicalTypeApplicability) {
   // Check that the decimal logical type correctly reports which.
   // Underlying primitive type(s) it can be applied to.
 
@@ -1695,7 +1695,7 @@ TEST(TestLogicalTypeOperation, DecimalLogicalTypeApplicability) {
   ASSERT_FALSE((DecimalLogicalType::make(16, 6))->isApplicable(Type::kDouble));
 }
 
-TEST(TestLogicalTypeOperation, LogicalTypeRepresentation) {
+TEST(TestLogicalTypeOperation, logicalTypeRepresentation) {
   // Ensure that each logical type prints a correct string and.
   // JSON representation.
 
@@ -1805,7 +1805,7 @@ TEST(TestLogicalTypeOperation, LogicalTypeRepresentation) {
   }
 }
 
-TEST(TestLogicalTypeOperation, LogicalTypeSortOrder) {
+TEST(TestLogicalTypeOperation, logicalTypeSortOrder) {
   // Ensure that each logical type reports the correct sort order.
 
   struct ExpectedSortOrder {
@@ -1910,7 +1910,7 @@ static void confirmGroupNodeFactoryEquivalence(
   return;
 }
 
-TEST(TestSchemaNodeCreation, FactoryEquivalence) {
+TEST(TestSchemaNodeCreation, factoryEquivalence) {
   // Ensure that the Node factory methods produce equivalent results regardless.
   // Of whether they are given a converted type or a logical type.
 
@@ -2044,7 +2044,7 @@ TEST(TestSchemaNodeCreation, FactoryEquivalence) {
       "list", LogicalType::list(), ConvertedType::kList);
 }
 
-TEST(TestSchemaNodeCreation, FactoryExceptions) {
+TEST(TestSchemaNodeCreation, factoryExceptions) {
   // Ensure that the Node factory method that accepts a logical type refuses to.
   // Create an object if compatibility conditions are not met.
 
@@ -2338,7 +2338,7 @@ class TestSchemaElementConstruction : public ::testing::Test {
  * serialization of an annotated schema node are correctly populated.
  */
 
-TEST_F(TestSchemaElementConstruction, SimpleCases) {
+TEST_F(TestSchemaElementConstruction, simpleCases) {
   auto checkNothing = []() {
     return true;
   }; // used for logical types that don't expect a logicalType to be set
@@ -2470,7 +2470,7 @@ class TestDecimalSchemaElementConstruction
   int32_t scale_;
 };
 
-TEST_F(TestDecimalSchemaElementConstruction, DecimalCases) {
+TEST_F(TestDecimalSchemaElementConstruction, decimalCases) {
   auto checkDecimal = [this]() {
     return element_->logicalType.__isset.DECIMAL;
   };
@@ -2623,7 +2623,7 @@ void TestTemporalSchemaElementConstruction::inspect<
   return;
 }
 
-TEST_F(TestTemporalSchemaElementConstruction, TemporalCases) {
+TEST_F(TestTemporalSchemaElementConstruction, temporalCases) {
   auto checkTime = [this]() { return element_->logicalType.__isset.TIME; };
 
   std::vector<SchemaElementConstructionArguments> timeCases = {
@@ -2786,7 +2786,7 @@ class TestIntegerSchemaElementConstruction
   bool signed_;
 };
 
-TEST_F(TestIntegerSchemaElementConstruction, IntegerCases) {
+TEST_F(TestIntegerSchemaElementConstruction, integerCases) {
   auto checkInteger = [this]() {
     return element_->logicalType.__isset.INTEGER;
   };
@@ -2863,7 +2863,7 @@ TEST_F(TestIntegerSchemaElementConstruction, IntegerCases) {
   }
 }
 
-TEST(TestLogicalTypeSerialization, SchemaElementNestedCases) {
+TEST(TestLogicalTypeSerialization, schemaElementNestedCases) {
   // Confirm that the intermediate Thrift objects created during node.
   // Serialization contain correct ConvertedType and ConvertedType information.
 
@@ -2935,7 +2935,7 @@ TEST(TestLogicalTypeSerialization, SchemaElementNestedCases) {
   ASSERT_TRUE(mapElements[0].logicalType.__isset.MAP);
 }
 
-TEST(TestLogicalTypeSerialization, Roundtrips) {
+TEST(TestLogicalTypeSerialization, roundtrips) {
   // Confirm that Thrift serialization-deserialization of nodes with logical.
   // Types produces equivalent reconstituted nodes.
 

--- a/velox/dwio/parquet/writer/arrow/tests/StatisticsTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/StatisticsTest.cpp
@@ -67,7 +67,7 @@ static FLBA fLBAFromString(const std::string& s) {
   return FLBA(ptr);
 }
 
-TEST(Comparison, SignedByteArray) {
+TEST(Comparison, signedByteArray) {
   // Signed byte array comparison is only used for Decimal comparison. When
   // decimals are encoded as byte arrays they use twos complement big-endian
   // encoded values. Comparisons of byte arrays of unequal types need to handle
@@ -126,7 +126,7 @@ TEST(Comparison, SignedByteArray) {
   }
 }
 
-TEST(Comparison, UnsignedByteArray) {
+TEST(Comparison, unsignedByteArray) {
   // Check if UTF-8 is compared using unsigned correctly.
   auto Comparator =
       makeComparator<ByteArrayType>(Type::kByteArray, SortOrder::kUnsigned);
@@ -151,7 +151,7 @@ TEST(Comparison, UnsignedByteArray) {
   ASSERT_TRUE(Comparator->compare(s1ba, s2ba));
 }
 
-TEST(Comparison, SignedFLBA) {
+TEST(Comparison, signedFLBA) {
   int size = 4;
   auto Comparator = makeComparator<FLBAType>(
       Type::kFixedLenByteArray, SortOrder::kSigned, size);
@@ -182,7 +182,7 @@ TEST(Comparison, SignedFLBA) {
   }
 }
 
-TEST(Comparison, UnsignedFLBA) {
+TEST(Comparison, unsignedFLBA) {
   int size = 10;
   auto Comparator = makeComparator<FLBAType>(
       Type::kFixedLenByteArray, SortOrder::kUnsigned, size);
@@ -200,7 +200,7 @@ TEST(Comparison, UnsignedFLBA) {
   ASSERT_TRUE(Comparator->compare(s1flba, s2flba));
 }
 
-TEST(Comparison, SignedInt96) {
+TEST(Comparison, signedInt96) {
   Int96 a{{1, 41, 14}}, b{{1, 41, 42}};
   Int96 aa{{1, 41, 14}}, bb{{1, 41, 14}};
   Int96 aaa{{1, 41, static_cast<uint32_t>(-14)}}, bbb{{1, 41, 42}};
@@ -212,7 +212,7 @@ TEST(Comparison, SignedInt96) {
   ASSERT_TRUE(Comparator->compare(aaa, bbb));
 }
 
-TEST(Comparison, UnsignedInt96) {
+TEST(Comparison, unsignedInt96) {
   Int96 a{{1, 41, 14}}, b{{1, static_cast<uint32_t>(-41), 42}};
   Int96 aa{{1, 41, 14}}, bb{{1, 41, static_cast<uint32_t>(-14)}};
   Int96 aaa, bbb;
@@ -249,7 +249,7 @@ TEST(Comparison, UnsignedInt96) {
   ASSERT_TRUE(Comparator->compare(aaa, bbb));
 }
 
-TEST(Comparison, SignedInt64) {
+TEST(Comparison, signedInt64) {
   int64_t a = 1, b = 4;
   int64_t aa = 1, bb = 1;
   int64_t aaa = -1, bbb = 1;
@@ -265,7 +265,7 @@ TEST(Comparison, SignedInt64) {
   ASSERT_TRUE(Comparator->compare(aaa, bbb));
 }
 
-TEST(Comparison, UnsignedInt64) {
+TEST(Comparison, unsignedInt64) {
   uint64_t a = 1, b = 4;
   uint64_t aa = 1, bb = 1;
   uint64_t aaa = 1, bbb = -1;
@@ -285,7 +285,7 @@ TEST(Comparison, UnsignedInt64) {
   ASSERT_TRUE(Comparator->compare(aaa, bbb));
 }
 
-TEST(Comparison, UnsignedInt32) {
+TEST(Comparison, unsignedInt32) {
   uint32_t a = 1, b = 4;
   uint32_t aa = 1, bb = 1;
   uint32_t aaa = 1, bbb = -1;
@@ -305,7 +305,7 @@ TEST(Comparison, UnsignedInt32) {
   ASSERT_TRUE(Comparator->compare(aaa, bbb));
 }
 
-TEST(Comparison, UnknownSortOrder) {
+TEST(Comparison, unknownSortOrder) {
   NodePtr Node = PrimitiveNode::make(
       "Unknown",
       Repetition::kRequired,
@@ -638,7 +638,7 @@ using Types = ::testing::Types<
 
 TYPED_TEST_SUITE(TestStatistics, Types);
 
-TYPED_TEST(TestStatistics, MinMaxEncode) {
+TYPED_TEST(TestStatistics, minMaxEncode) {
   this->setUpSchema(Repetition::kRequired);
   ASSERT_NO_FATAL_FAILURE(this->testMinMaxEncode());
 }
@@ -653,7 +653,7 @@ TYPED_TEST(TestStatistics, equals) {
   ASSERT_NO_FATAL_FAILURE(this->testEquals());
 }
 
-TYPED_TEST(TestStatistics, FullRoundtrip) {
+TYPED_TEST(TestStatistics, fullRoundtrip) {
   this->setUpSchema(Repetition::kOptional);
   ASSERT_NO_FATAL_FAILURE(this->testFullRoundtrip(100, 31));
   ASSERT_NO_FATAL_FAILURE(this->testFullRoundtrip(1000, 415));
@@ -839,19 +839,19 @@ class TestStatisticsHasFlag : public TestStatistics<TestType> {
 
 TYPED_TEST_SUITE(TestStatisticsHasFlag, Types);
 
-TYPED_TEST(TestStatisticsHasFlag, MergeDistinctCount) {
+TYPED_TEST(TestStatisticsHasFlag, mergeDistinctCount) {
   ASSERT_NO_FATAL_FAILURE(this->testMergeDistinctCount());
 }
 
-TYPED_TEST(TestStatisticsHasFlag, MergeNullCount) {
+TYPED_TEST(TestStatisticsHasFlag, mergeNullCount) {
   ASSERT_NO_FATAL_FAILURE(this->testMergeNullCount());
 }
 
-TYPED_TEST(TestStatisticsHasFlag, MergeMinMax) {
+TYPED_TEST(TestStatisticsHasFlag, mergeMinMax) {
   ASSERT_NO_FATAL_FAILURE(this->testMergeMinMax());
 }
 
-TYPED_TEST(TestStatisticsHasFlag, MissingNullCount) {
+TYPED_TEST(TestStatisticsHasFlag, missingNullCount) {
   ASSERT_NO_FATAL_FAILURE(this->testMissingNullCount());
 }
 
@@ -871,7 +871,7 @@ void assertStatsSet(
 }
 
 // Statistics are restricted for few types in older parquet version.
-TEST(CorruptStatistics, Basics) {
+TEST(CorruptStatistics, basics) {
   std::string createdBy = "parquet-mr version 1.8.0";
   ApplicationVersion version(createdBy);
   SchemaDescriptor schema;
@@ -923,7 +923,7 @@ TEST(CorruptStatistics, Basics) {
 }
 
 // Statistics for all types have no restrictions in newer parquet version.
-TEST(CorrectStatistics, Basics) {
+TEST(CorrectStatistics, basics) {
   std::string createdBy = "parquet-cpp version 1.3.0";
   ApplicationVersion version(createdBy);
   SchemaDescriptor schema;
@@ -1270,7 +1270,7 @@ void TestStatisticsSortOrder<FLBAType>::setValues() {
 
 TYPED_TEST_SUITE(TestStatisticsSortOrder, CompareTestTypes);
 
-TYPED_TEST(TestStatisticsSortOrder, MinMax) {
+TYPED_TEST(TestStatisticsSortOrder, minMax) {
   this->addNodes("Column ");
   this->setUpSchema();
   this->writeParquet();
@@ -1300,12 +1300,12 @@ void testByteArrayStatisticsFromArrow() {
   ASSERT_EQ(2, stats->nullCount());
 }
 
-TEST(testByteArrayStatisticsFromArrow, StringType) {
+TEST(testByteArrayStatisticsFromArrow, stringType) {
   // Part of ARROW-3246. Replicating TestStatisticsSortOrder test but via Arrow.
   testByteArrayStatisticsFromArrow<::arrow::StringType>();
 }
 
-TEST(testByteArrayStatisticsFromArrow, LargeStringType) {
+TEST(testByteArrayStatisticsFromArrow, largeStringType) {
   testByteArrayStatisticsFromArrow<::arrow::LargeStringType>();
 }
 
@@ -1506,10 +1506,10 @@ void checkExtrema() {
   }
 }
 
-TEST(TestStatistic, Int32Extrema) {
+TEST(TestStatistic, int32Extrema) {
   checkExtrema<Int32Type>();
 }
-TEST(TestStatistic, Int64Extrema) {
+TEST(TestStatistic, int64Extrema) {
   checkExtrema<Int64Type>();
 }
 
@@ -1559,16 +1559,16 @@ void checkNaNs() {
   EXPECT_EQ(otherStats->nanCount(), 2);
 }
 
-TEST(TestStatistic, NaNFloatValues) {
+TEST(TestStatistic, nanFloatValues) {
   checkNaNs<FloatType>();
 }
 
-TEST(TestStatistic, NaNDoubleValues) {
+TEST(TestStatistic, nanDoubleValues) {
   checkNaNs<DoubleType>();
 }
 
 // ARROW-7376.
-TEST(TestStatisticsSortOrderFloatNaN, NaNAndNullsInfiniteLoop) {
+TEST(TestStatisticsSortOrderFloatNaN, nanAndNullsInfiniteLoop) {
   constexpr int kNumValues = 8;
   NodePtr Node =
       PrimitiveNode::make("nan_float", Repetition::kOptional, Type::kFloat);
@@ -1636,11 +1636,11 @@ void checkNegativeZeroStats() {
   }
 }
 
-TEST(TestStatistics, FloatNegativeZero) {
+TEST(TestStatistics, floatNegativeZero) {
   checkNegativeZeroStats<FloatType>();
 }
 
-TEST(TestStatistics, DoubleNegativeZero) {
+TEST(TestStatistics, doubleNegativeZero) {
   checkNegativeZeroStats<DoubleType>();
 }
 
@@ -1696,16 +1696,16 @@ void checkInfinityStats() {
   }
 }
 
-TEST(TestStatistics, FloatInfinityValues) {
+TEST(TestStatistics, floatInfinityValues) {
   checkInfinityStats<FloatType>();
 }
 
-TEST(TestStatistics, DoubleInfinityValues) {
+TEST(TestStatistics, doubleInfinityValues) {
   checkInfinityStats<DoubleType>();
 }
 
 // Test infinity values with validity bitmap.
-TEST(TestStatistics, InfinityWithNullBitmap) {
+TEST(TestStatistics, infinityWithNullBitmap) {
   constexpr int kNumValues = 8;
   NodePtr Node = PrimitiveNode::make(
       "infinity_null_test", Repetition::kOptional, Type::kFloat);
@@ -1730,7 +1730,7 @@ TEST(TestStatistics, InfinityWithNullBitmap) {
 }
 
 // Test merging statistics with infinity values.
-TEST(TestStatistics, MergeInfinityStatistics) {
+TEST(TestStatistics, mergeInfinityStatistics) {
   NodePtr Node = PrimitiveNode::make(
       "merge_infinity", Repetition::kOptional, Type::kDouble);
   ColumnDescriptor descr(Node, 1, 1);
@@ -1756,7 +1756,7 @@ TEST(TestStatistics, MergeInfinityStatistics) {
   ASSERT_EQ(posInf, mergedStats->max());
 }
 
-TEST(TestStatistics, CleanInfinityStatistics) {
+TEST(TestStatistics, cleanInfinityStatistics) {
   constexpr int kNumValues = 4;
   NodePtr Node = PrimitiveNode::make(
       "clean_stat_nullopt", Repetition::kOptional, Type::kFloat);
@@ -1787,7 +1787,7 @@ TEST(TestStatistics, CleanInfinityStatistics) {
   }
 }
 
-TEST(TestStatistics, InfinityCleanStatisticValid) {
+TEST(TestStatistics, infinityCleanStatisticValid) {
   constexpr int kNumValues = 4;
   NodePtr Node = PrimitiveNode::make(
       "clean_stat_valid", Repetition::kOptional, Type::kDouble);
@@ -1813,7 +1813,7 @@ TEST(TestStatistics, InfinityCleanStatisticValid) {
 // TODO: disabled as it requires Arrow parquet data dir.
 // Test statistics for binary column with UNSIGNED sort order.
 /*
-TEST(TestStatisticsSortOrderMinMax, Unsigned) {
+TEST(TestStatisticsSortOrderMinMax, unsigned) {
   std::string dir_string(test::get_data_dir());
   std::stringstream ss;
   ss << dir_string << "/binary.parquet";
@@ -1840,7 +1840,7 @@ TEST(TestStatisticsSortOrderMinMax, Unsigned) {
   ASSERT_EQ(0x0b, stats->EncodeMax()[0]);
 }
 
-TEST(TestEncodedStatistics, CopySafe) {
+TEST(TestEncodedStatistics, copySafe) {
   EncodedStatistics encoded_statistics;
   encoded_statistics.set_max("abc");
   encoded_statistics.has_max = true;

--- a/velox/dwio/parquet/writer/arrow/tests/TypesTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/TypesTest.cpp
@@ -25,7 +25,7 @@
 
 namespace facebook::velox::parquet::arrow {
 
-TEST(TestTypeToString, PhysicalTypes) {
+TEST(TestTypeToString, physicalTypes) {
   ASSERT_STREQ("BOOLEAN", typeToString(Type::kBoolean).c_str());
   ASSERT_STREQ("INT32", typeToString(Type::kInt32).c_str());
   ASSERT_STREQ("INT64", typeToString(Type::kInt64).c_str());
@@ -37,7 +37,7 @@ TEST(TestTypeToString, PhysicalTypes) {
       "FIXED_LEN_BYTE_ARRAY", typeToString(Type::kFixedLenByteArray).c_str());
 }
 
-TEST(TestConvertedTypeToString, ConvertedTypes) {
+TEST(TestConvertedTypeToString, convertedTypes) {
   ASSERT_STREQ("NONE", convertedTypeToString(ConvertedType::kNone).c_str());
   ASSERT_STREQ("UTF8", convertedTypeToString(ConvertedType::kUtf8).c_str());
   ASSERT_STREQ("MAP", convertedTypeToString(ConvertedType::kMap).c_str());
@@ -84,7 +84,7 @@ TEST(TestConvertedTypeToString, ConvertedTypes) {
 #pragma warning(disable : 4996)
 #endif
 
-TEST(TypePrinter, StatisticsTypes) {
+TEST(TypePrinter, statisticsTypes) {
   std::string smin;
   std::string smax;
   int32_t intMin = 1024;
@@ -145,7 +145,7 @@ TEST(TypePrinter, StatisticsTypes) {
       "ijklmnop", formatStatValue(Type::kFixedLenByteArray, smax).c_str());
 }
 
-TEST(TestInt96Timestamp, Decoding) {
+TEST(TestInt96Timestamp, decoding) {
   auto check = [](int32_t julianDay, uint64_t nanoseconds) {
 #if ARROW_LITTLE_ENDIAN
     Int96 i96{

--- a/velox/exec/fuzzer/tests/LocalRunnerServiceTest.cpp
+++ b/velox/exec/fuzzer/tests/LocalRunnerServiceTest.cpp
@@ -158,7 +158,7 @@ class LocalRunnerServiceTest : public functions::test::FunctionBaseTest {
   RowVectorPtr testRowVectorWrapped_;
 };
 
-TEST_F(LocalRunnerServiceTest, ConvertToBatchesRoundTrip) {
+TEST_F(LocalRunnerServiceTest, convertToBatchesRoundTrip) {
   auto result = facebook::velox::runner::convertToBatches(
       {testRowVector_}, rootPool_.get());
 
@@ -199,7 +199,7 @@ TEST_F(LocalRunnerServiceTest, ConvertToBatchesRoundTrip) {
   assertEqualVectors(deserialized, testRowVector_);
 }
 
-TEST_F(LocalRunnerServiceTest, ServiceHandlerMockRequestIntegration) {
+TEST_F(LocalRunnerServiceTest, serviceHandlerMockRequestIntegration) {
   LocalRunnerServiceHandler handler;
 
   auto request = std::make_unique<ExecutePlanRequest>();
@@ -223,7 +223,7 @@ TEST_F(LocalRunnerServiceTest, ServiceHandlerMockRequestIntegration) {
   EXPECT_GT(batch.serializedData()->size(), 0);
 }
 
-TEST_F(LocalRunnerServiceTest, ServiceHandlerMockRequestIntegrationFailure) {
+TEST_F(LocalRunnerServiceTest, serviceHandlerMockRequestIntegrationFailure) {
   LocalRunnerServiceHandler handler;
 
   auto request = std::make_unique<ExecutePlanRequest>();

--- a/velox/exec/tests/TraceUtilTest.cpp
+++ b/velox/exec/tests/TraceUtilTest.cpp
@@ -83,7 +83,7 @@ TEST_F(TraceUtilTest, traceDir) {
   }
 }
 
-TEST_F(TraceUtilTest, OperatorTraceSummary) {
+TEST_F(TraceUtilTest, operatorTraceSummary) {
   exec::trace::OperatorTraceSummary summary;
   summary.opType = "summary";
   summary.inputRows = 100;

--- a/velox/exec/tests/WindowTest.cpp
+++ b/velox/exec/tests/WindowTest.cpp
@@ -921,7 +921,7 @@ DEBUG_ONLY_TEST_F(WindowTest, reserveMemorySort) {
   }
 }
 
-TEST_F(WindowTest, NaNFrameBound) {
+TEST_F(WindowTest, nanFrameBound) {
   const auto kNan = std::numeric_limits<double>::quiet_NaN();
   auto data = makeRowVector(
       {"c0", "s0", "off0", "off1"},

--- a/velox/experimental/breeze/test/algorithms/reduce_unittest.cpp
+++ b/velox/experimental/breeze/test/algorithms/reduce_unittest.cpp
@@ -40,7 +40,7 @@ using TestTypes = ::testing::Types<int, unsigned, long long, unsigned long long,
 
 TYPED_TEST_SUITE(AlgorithmTest, TestTypes);
 
-TYPED_TEST(AlgorithmTest, ReduceAdd) {
+TYPED_TEST(AlgorithmTest, reduceAdd) {
   constexpr int kBlockThreads = 32;
   constexpr int kItemsPerThread = 2;
   constexpr int kBlockItems = kBlockThreads * kItemsPerThread;
@@ -58,7 +58,7 @@ TYPED_TEST(AlgorithmTest, ReduceAdd) {
   EXPECT_EQ(expected_result, out);
 }
 
-TYPED_TEST(AlgorithmTest, ReduceMin) {
+TYPED_TEST(AlgorithmTest, reduceMin) {
   constexpr int kBlockThreads = 32;
   constexpr int kItemsPerThread = 2;
   constexpr int kBlockItems = kBlockThreads * kItemsPerThread;
@@ -75,7 +75,7 @@ TYPED_TEST(AlgorithmTest, ReduceMin) {
   EXPECT_EQ(expected_result, out);
 }
 
-TYPED_TEST(AlgorithmTest, ReduceMax) {
+TYPED_TEST(AlgorithmTest, reduceMax) {
   constexpr int kBlockThreads = 32;
   constexpr int kItemsPerThread = 2;
   constexpr int kBlockItems = kBlockThreads * kItemsPerThread;

--- a/velox/experimental/breeze/test/algorithms/scan_unittest.cpp
+++ b/velox/experimental/breeze/test/algorithms/scan_unittest.cpp
@@ -47,7 +47,7 @@ using try_make_unsigned =
     typename std::conditional<std::is_integral<T>::value, std::make_unsigned<T>,
                               identity<T>>::type;
 
-TYPED_TEST(AlgorithmTest, ScanAdd) {
+TYPED_TEST(AlgorithmTest, scanAdd) {
   constexpr int kBlockThreads = 32;
   constexpr int kItemsPerThread = 2;
   constexpr int kBlockItems = kBlockThreads * kItemsPerThread;
@@ -88,7 +88,7 @@ TYPED_TEST(AlgorithmTest, ScanAdd) {
 
 #if !defined(PLATFORM_OPENMP)
 
-TYPED_TEST(AlgorithmTest, ScanAddWithLookbackDistance64) {
+TYPED_TEST(AlgorithmTest, scanAddWithLookbackDistance64) {
   constexpr int kBlockThreads = 64;
   constexpr int kItemsPerThread = 2;
   constexpr int kBlockItems = kBlockThreads * kItemsPerThread;

--- a/velox/experimental/breeze/test/algorithms/sort_unittest.cpp
+++ b/velox/experimental/breeze/test/algorithms/sort_unittest.cpp
@@ -65,7 +65,7 @@ T extract_bits(T value, int start_bit, int num_pass_bits) {
 
 TYPED_TEST_SUITE(AlgorithmTest, TestTypes);
 
-TYPED_TEST(AlgorithmTest, RadixSortHistogram) {
+TYPED_TEST(AlgorithmTest, radixSortHistogram) {
   constexpr int kBlockItems = kBlockThreads * kItemsPerThread;
   constexpr int kTileSize = 1;
   constexpr int kTileItems = kBlockItems * kTileSize;
@@ -98,7 +98,7 @@ TYPED_TEST(AlgorithmTest, RadixSortHistogram) {
   EXPECT_EQ(expected_result, out);
 }
 
-TYPED_TEST(AlgorithmTest, RadixSortHistogramLargeTiles) {
+TYPED_TEST(AlgorithmTest, radixSortHistogramLargeTiles) {
   constexpr int kBlockItems = kBlockThreads * kItemsPerThread;
   constexpr int kTileSize = 4;
   constexpr int kTileItems = kBlockItems * kTileSize;
@@ -131,7 +131,7 @@ TYPED_TEST(AlgorithmTest, RadixSortHistogramLargeTiles) {
   EXPECT_EQ(expected_result, out);
 }
 
-TYPED_TEST(AlgorithmTest, RadixSort) {
+TYPED_TEST(AlgorithmTest, radixSort) {
   constexpr int kBlockItems = kBlockThreads * kItemsPerThread;
   constexpr int kRadixBits = 6;
   constexpr int kStartBit = 0;
@@ -174,7 +174,7 @@ TYPED_TEST(AlgorithmTest, RadixSort) {
   EXPECT_EQ(expected_result, out);
 }
 
-TYPED_TEST(AlgorithmTest, RadixSortKeyValues) {
+TYPED_TEST(AlgorithmTest, radixSortKeyValues) {
   constexpr int kBlockItems = kBlockThreads * kItemsPerThread;
   constexpr int kRadixBits = 6;
   constexpr int kStartBit = 0;

--- a/velox/experimental/breeze/test/functions/load_unittest.cpp
+++ b/velox/experimental/breeze/test/functions/load_unittest.cpp
@@ -34,7 +34,7 @@ using TestTypes =
 
 TYPED_TEST_SUITE(FunctionTest, TestTypes);
 
-TYPED_TEST(FunctionTest, Load) {
+TYPED_TEST(FunctionTest, load) {
   TypeParam src[] = {1, 2, 3, 4, 5, 6, 7, 8};
 
   std::vector<TypeParam> in(std::begin(src), std::end(src));
@@ -45,7 +45,7 @@ TYPED_TEST(FunctionTest, Load) {
   EXPECT_EQ(in, out);
 }
 
-TYPED_TEST(FunctionTest, LoadFewItems) {
+TYPED_TEST(FunctionTest, loadFewItems) {
   TypeParam src[] = {1, 2, 3};
 
   std::vector<TypeParam> in(std::begin(src), std::end(src));
@@ -56,7 +56,7 @@ TYPED_TEST(FunctionTest, LoadFewItems) {
   EXPECT_EQ(in, out);
 }
 
-TYPED_TEST(FunctionTest, LoadIf) {
+TYPED_TEST(FunctionTest, loadIf) {
   TypeParam src[] = {1, 2, 3, 4, 5, 6, 7, 8};
   int src_selection_flags[] = {0, 1, 1, 0, 0, 1, 0, 0};
 
@@ -73,7 +73,7 @@ TYPED_TEST(FunctionTest, LoadIf) {
   EXPECT_EQ(expected_out, out);
 }
 
-TYPED_TEST(FunctionTest, LoadIfFewItems) {
+TYPED_TEST(FunctionTest, loadIfFewItems) {
   TypeParam src[] = {1, 2, 3};
   int src_selection_flags[] = {0, 1, 0};
 
@@ -90,7 +90,7 @@ TYPED_TEST(FunctionTest, LoadIfFewItems) {
   EXPECT_EQ(expected_out, out);
 }
 
-TYPED_TEST(FunctionTest, LoadFrom) {
+TYPED_TEST(FunctionTest, loadFrom) {
   TypeParam src[] = {1, 2, 3, 4, 5, 6, 7, 8};
   int src_offsets[] = {7, 6, 5, 4, 3, 2, 1, 0};
 
@@ -106,7 +106,7 @@ TYPED_TEST(FunctionTest, LoadFrom) {
   EXPECT_EQ(expected_out, out);
 }
 
-TYPED_TEST(FunctionTest, LoadFromFewItems) {
+TYPED_TEST(FunctionTest, loadFromFewItems) {
   TypeParam src[] = {1, 2, 3};
   int src_offsets[] = {2, 1, 0};
 

--- a/velox/experimental/breeze/test/functions/reduce_unittest.cpp
+++ b/velox/experimental/breeze/test/functions/reduce_unittest.cpp
@@ -37,7 +37,7 @@ using TestTypes = ::testing::Types<int, unsigned, long long, unsigned long long,
 
 TYPED_TEST_SUITE(FunctionTest, TestTypes);
 
-TYPED_TEST(FunctionTest, ReduceAdd) {
+TYPED_TEST(FunctionTest, reduceAdd) {
   TypeParam src[] = {1, 6,  22, 8,  2,  3, 11, 5,  13, 9, 0,  16, 18,
                      7, 10, 4,  14, 0,  4, 21, 4,  7,  5, 10, 8,  20,
                      9, 6,  22, 30, 1,  3, 8,  12, 25, 9, 10, 25, 6,
@@ -53,7 +53,7 @@ TYPED_TEST(FunctionTest, ReduceAdd) {
   EXPECT_EQ(expected_result, out);
 }
 
-TYPED_TEST(FunctionTest, ReduceAddOneItemPerThread) {
+TYPED_TEST(FunctionTest, reduceAddOneItemPerThread) {
   TypeParam src[] = {1, 6,  22, 8,  2,  3, 11, 5,  13, 9, 0,  16, 18,
                      7, 10, 4,  14, 0,  4, 21, 4,  7,  5, 10, 8,  20,
                      9, 6,  22, 30, 1,  3, 8,  12, 25, 9, 10, 25, 6,
@@ -69,7 +69,7 @@ TYPED_TEST(FunctionTest, ReduceAddOneItemPerThread) {
   EXPECT_EQ(expected_result, out);
 }
 
-TYPED_TEST(FunctionTest, ReduceAddFew) {
+TYPED_TEST(FunctionTest, reduceAddFew) {
   TypeParam src[] = {1, 2, 3, 4, 5, 6, 7, 8};
 
   std::vector<TypeParam> in(std::begin(src), std::end(src));
@@ -110,7 +110,7 @@ std::vector<T> generate_bit_pattern_vector() {
   return values;
 }
 
-TYPED_TEST(FunctionTest, ReduceAddBitPatterns) {
+TYPED_TEST(FunctionTest, reduceAddBitPatterns) {
   auto in = generate_bit_pattern_vector<TypeParam>();
   TypeParam out = 0;
 
@@ -131,7 +131,7 @@ TYPED_TEST(FunctionTest, ReduceAddBitPatterns) {
   EXPECT_EQ(expected_result, out);
 }
 
-TYPED_TEST(FunctionTest, ReduceMin) {
+TYPED_TEST(FunctionTest, reduceMin) {
   TypeParam src[] = {1, 2, 3, 4, 5, 6, 7, 8};
 
   std::vector<TypeParam> in(std::begin(src), std::end(src));
@@ -143,7 +143,7 @@ TYPED_TEST(FunctionTest, ReduceMin) {
   EXPECT_EQ(expected_result, out);
 }
 
-TYPED_TEST(FunctionTest, ReduceMinBitPatterns) {
+TYPED_TEST(FunctionTest, reduceMinBitPatterns) {
   auto in = generate_bit_pattern_vector<TypeParam>();
   TypeParam out = 0;
 
@@ -153,7 +153,7 @@ TYPED_TEST(FunctionTest, ReduceMinBitPatterns) {
   EXPECT_EQ(expected_result, out);
 }
 
-TYPED_TEST(FunctionTest, ReduceMax) {
+TYPED_TEST(FunctionTest, reduceMax) {
   TypeParam src[] = {1, 2, 3, 4, 5, 6, 7, 8};
 
   std::vector<TypeParam> in(std::begin(src), std::end(src));
@@ -165,7 +165,7 @@ TYPED_TEST(FunctionTest, ReduceMax) {
   EXPECT_EQ(expected_result, out);
 }
 
-TYPED_TEST(FunctionTest, ReduceMaxBitPatterns) {
+TYPED_TEST(FunctionTest, reduceMaxBitPatterns) {
   auto in = generate_bit_pattern_vector<TypeParam>();
   TypeParam out = 0;
 

--- a/velox/experimental/breeze/test/functions/scan_unittest.cpp
+++ b/velox/experimental/breeze/test/functions/scan_unittest.cpp
@@ -36,7 +36,7 @@ using TestTypes = ::testing::Types<int, unsigned, long long, unsigned long long,
 
 TYPED_TEST_SUITE(FunctionTest, TestTypes);
 
-TYPED_TEST(FunctionTest, ScanAdd) {
+TYPED_TEST(FunctionTest, scanAdd) {
   TypeParam src[] = {1, 6,  22, 8,  2,  3, 11, 5,  13, 9, 0,  16, 18,
                      7, 10, 4,  14, 0,  4, 21, 4,  7,  5, 10, 8,  20,
                      9, 6,  22, 30, 1,  3, 8,  12, 25, 9, 10, 25, 6,
@@ -59,7 +59,7 @@ TYPED_TEST(FunctionTest, ScanAdd) {
   EXPECT_EQ(expected_out, out);
 }
 
-TYPED_TEST(FunctionTest, ScanAddOneItemPerThread) {
+TYPED_TEST(FunctionTest, scanAddOneItemPerThread) {
   TypeParam src[] = {1, 6,  22, 8,  2,  3, 11, 5,  13, 9, 0,  16, 18,
                      7, 10, 4,  14, 0,  4, 21, 4,  7,  5, 10, 8,  20,
                      9, 6,  22, 30, 1,  3, 8,  12, 25, 9, 10, 25, 6,
@@ -82,7 +82,7 @@ TYPED_TEST(FunctionTest, ScanAddOneItemPerThread) {
   EXPECT_EQ(expected_out, out);
 }
 
-TYPED_TEST(FunctionTest, ScanAddHalfBlock) {
+TYPED_TEST(FunctionTest, scanAddHalfBlock) {
   TypeParam src[] = {1,  6, 22, 8,  2, 3, 11, 5,  13, 9,  0, 16, 18, 7,  10, 4,
                      14, 0, 4,  21, 4, 7, 5,  10, 8,  20, 9, 6,  22, 30, 1,  3};
 
@@ -100,7 +100,7 @@ TYPED_TEST(FunctionTest, ScanAddHalfBlock) {
   EXPECT_EQ(expected_out, out);
 }
 
-TYPED_TEST(FunctionTest, ScanAddFew) {
+TYPED_TEST(FunctionTest, scanAddFew) {
   TypeParam src[] = {5, 0, 4, 2, 7, 9};
 
   std::vector<TypeParam> in(std::begin(src), std::end(src));
@@ -114,7 +114,7 @@ TYPED_TEST(FunctionTest, ScanAddFew) {
   EXPECT_EQ(expected_out, out);
 }
 
-TYPED_TEST(FunctionTest, ScanAddLowerHalfBitsSet) {
+TYPED_TEST(FunctionTest, scanAddLowerHalfBitsSet) {
   TypeParam lower_half_bits_set = (1llu << sizeof(TypeParam) * 4) - 1;
   std::vector<TypeParam> in(32, lower_half_bits_set);
   std::vector<TypeParam> out(in.size(), 0);

--- a/velox/experimental/breeze/test/functions/sort_unittest.cpp
+++ b/velox/experimental/breeze/test/functions/sort_unittest.cpp
@@ -46,7 +46,7 @@ constexpr int kItemsPerThread = 2;
 
 TYPED_TEST_SUITE(FunctionTest, TestTypes);
 
-TYPED_TEST(FunctionTest, RadixRank) {
+TYPED_TEST(FunctionTest, radixRank) {
   TypeParam src[] = {9,  33, 44, 32, 4,  1,  3,  31, 50, 43, 54, 29, 45, 8,  0,
                      56, 5,  39, 42, 11, 27, 63, 9,  2,  54, 33, 41, 3,  36, 43,
                      47, 3,  0,  14, 21, 18, 21, 18, 57, 40, 52, 3,  4,  21, 32,
@@ -77,7 +77,7 @@ TYPED_TEST(FunctionTest, RadixRank) {
   EXPECT_EQ(expected_out, out);
 }
 
-TYPED_TEST(FunctionTest, RadixRankFewItems) {
+TYPED_TEST(FunctionTest, radixRankFewItems) {
   TypeParam src[] = {12, 5,  42, 42, 44, 49, 41, 32, 16, 21, 51, 54, 20, 27, 12,
                      16, 29, 1,  23, 24, 20, 51, 3,  55, 59, 61, 57, 45, 62, 57,
                      28, 48, 61, 49, 50, 34, 63, 40, 24, 58, 10, 53, 60, 57, 58,
@@ -103,7 +103,7 @@ TYPED_TEST(FunctionTest, RadixRankFewItems) {
   EXPECT_EQ(expected_out, out);
 }
 
-TYPED_TEST(FunctionTest, RadixSort) {
+TYPED_TEST(FunctionTest, radixSort) {
   TypeParam src[] = {
       664706,   7283945,  30790572, 41729031, 58086583, 99033166, 74066752,
       45600109, 99632667, 211279,   42680291, 22703047, 30319982, 43100887,
@@ -145,7 +145,7 @@ TYPED_TEST(FunctionTest, RadixSort) {
   EXPECT_EQ(expected_out, out);
 }
 
-TYPED_TEST(FunctionTest, RadixSortFewItems) {
+TYPED_TEST(FunctionTest, radixSortFewItems) {
   TypeParam src[] = {
       25529826, 61919686, 62330816, 15232051, 7849881,  43025218, 78752072,
       52136080, 19555696, 24060484, 87158662, 42535624, 9089185,  95542843,
@@ -183,7 +183,7 @@ TYPED_TEST(FunctionTest, RadixSortFewItems) {
   EXPECT_EQ(expected_out, out);
 }
 
-TYPED_TEST(FunctionTest, RadixSortKeyValues) {
+TYPED_TEST(FunctionTest, radixSortKeyValues) {
   TypeParam src[] = {
       664706,   7283945,  30790572, 41729031, 58086583, 99033166, 74066752,
       45600109, 99632667, 211279,   42680291, 22703047, 30319982, 43100887,

--- a/velox/experimental/breeze/test/functions/store_unittest.cpp
+++ b/velox/experimental/breeze/test/functions/store_unittest.cpp
@@ -34,7 +34,7 @@ using TestTypes =
 
 TYPED_TEST_SUITE(FunctionTest, TestTypes);
 
-TYPED_TEST(FunctionTest, Store) {
+TYPED_TEST(FunctionTest, store) {
   TypeParam src[] = {1, 2};
 
   std::vector<TypeParam> in(std::begin(src), std::end(src));
@@ -48,7 +48,7 @@ TYPED_TEST(FunctionTest, Store) {
   EXPECT_EQ(expected_out, out);
 }
 
-TYPED_TEST(FunctionTest, StoreFewItems) {
+TYPED_TEST(FunctionTest, storeFewItems) {
   TypeParam src[] = {1, 2};
 
   std::vector<TypeParam> in(std::begin(src), std::end(src));
@@ -62,7 +62,7 @@ TYPED_TEST(FunctionTest, StoreFewItems) {
   EXPECT_EQ(expected_out, out);
 }
 
-TYPED_TEST(FunctionTest, StoreIf) {
+TYPED_TEST(FunctionTest, storeIf) {
   TypeParam src[] = {1, 2};
   int src_selection_flags[] = {0, 1};
 
@@ -79,7 +79,7 @@ TYPED_TEST(FunctionTest, StoreIf) {
   EXPECT_EQ(expected_out, out);
 }
 
-TYPED_TEST(FunctionTest, StoreIfFewItems) {
+TYPED_TEST(FunctionTest, storeIfFewItems) {
   TypeParam src[] = {1, 2};
   int src_selection_flags[] = {0, 1};
 
@@ -96,7 +96,7 @@ TYPED_TEST(FunctionTest, StoreIfFewItems) {
   EXPECT_EQ(expected_out, out);
 }
 
-TYPED_TEST(FunctionTest, StoreAt) {
+TYPED_TEST(FunctionTest, storeAt) {
   TypeParam src[] = {1, 2, 3, 4, 5, 6, 7, 8};
   int src_offsets[] = {7, 6, 5, 4, 3, 2, 1, 0};
 
@@ -112,7 +112,7 @@ TYPED_TEST(FunctionTest, StoreAt) {
   EXPECT_EQ(expected_out, out);
 }
 
-TYPED_TEST(FunctionTest, StoreAtIf) {
+TYPED_TEST(FunctionTest, storeAtIf) {
   TypeParam src[] = {1, 2, 3, 4, 5, 6, 7, 8};
   int src_offsets[] = {7, 6, 5, 4, 3, 2, 1, 0};
   int src_selection_flags[] = {0, 1, 1, 0, 1, 0, 1, 1};
@@ -131,7 +131,7 @@ TYPED_TEST(FunctionTest, StoreAtIf) {
   EXPECT_EQ(expected_out, out);
 }
 
-TYPED_TEST(FunctionTest, Fill) {
+TYPED_TEST(FunctionTest, fill) {
   TypeParam value = 49;
 
   std::vector<TypeParam> out(8);
@@ -144,7 +144,7 @@ TYPED_TEST(FunctionTest, Fill) {
   EXPECT_EQ(expected_out, out);
 }
 
-TYPED_TEST(FunctionTest, FillAtIf) {
+TYPED_TEST(FunctionTest, fillAtIf) {
   TypeParam value = 49;
 
   int src_offsets[] = {7, 6, 5, 4, 3, 2, 1, 0};

--- a/velox/experimental/cudf/tests/AggregationTest.cpp
+++ b/velox/experimental/cudf/tests/AggregationTest.cpp
@@ -808,7 +808,7 @@ INSTANTIATE_TEST_SUITE_P(
 /// Tests the spark scenario of having different types of aggs in the same
 /// planNode Specific example being tested is
 /// https://github.com/facebookincubator/velox/issues/12830#issuecomment-2783340233
-TEST_F(AggregationTest, CompanionAggs) {
+TEST_F(AggregationTest, companionAggs) {
   std::vector<int64_t> keys0{1, 1, 1, 2, 1, 1, 2, 2};
   std::vector<int64_t> keys1{1, 2, 1, 2, 1, 2, 1, 2};
   std::vector<int64_t> values{1, 2, 3, 4, 5, 6, 7, 8};

--- a/velox/experimental/cudf/tests/ConfigTest.cpp
+++ b/velox/experimental/cudf/tests/ConfigTest.cpp
@@ -20,7 +20,7 @@
 
 namespace facebook::velox::cudf_velox::test {
 
-TEST(ConfigTest, CudfConfig) {
+TEST(ConfigTest, cudfConfig) {
   std::unordered_map<std::string, std::string> options = {
       {CudfConfig::kCudfEnabled, "false"},
       {CudfConfig::kCudfDebugEnabled, "true"},

--- a/velox/experimental/cudf/tests/SubfieldFilterAstTest.cpp
+++ b/velox/experimental/cudf/tests/SubfieldFilterAstTest.cpp
@@ -164,7 +164,7 @@ class SubfieldFilterAstTest : public OperatorTestBase {
 };
 
 // Basic AST generation tests
-TEST_F(SubfieldFilterAstTest, Int32RangeInclusive) {
+TEST_F(SubfieldFilterAstTest, int32RangeInclusive) {
   const std::string columnName = "c0";
   auto rowType = ROW({{columnName, INTEGER()}});
   auto filter =
@@ -184,7 +184,7 @@ TEST_F(SubfieldFilterAstTest, Int32RangeInclusive) {
   testFilterExecution(rowType, columnName, *filter, vec, expr);
 }
 
-TEST_F(SubfieldFilterAstTest, DoubleRange) {
+TEST_F(SubfieldFilterAstTest, doubleRange) {
   const std::string columnName = "c1";
   auto rowType = ROW({{columnName, DOUBLE()}});
   auto filter = std::make_unique<common::DoubleRange>(
@@ -204,7 +204,7 @@ TEST_F(SubfieldFilterAstTest, DoubleRange) {
   testFilterExecution(rowType, columnName, *filter, vec, expr);
 }
 
-TEST_F(SubfieldFilterAstTest, StringInList) {
+TEST_F(SubfieldFilterAstTest, stringInList) {
   const std::string columnName = "c2";
   auto rowType = ROW({{columnName, VARCHAR()}});
   // Manually construct a VARCHAR column so IN-list values are guaranteed.
@@ -229,7 +229,7 @@ TEST_F(SubfieldFilterAstTest, StringInList) {
   testFilterExecution(rowType, columnName, *filter, vec, expr);
 }
 
-TEST_F(SubfieldFilterAstTest, StringNotInList) {
+TEST_F(SubfieldFilterAstTest, stringNotInList) {
   const std::string columnName = "c2";
   auto rowType = ROW({{columnName, VARCHAR()}});
   // Manually construct a VARCHAR column and a NOT IN list.
@@ -254,7 +254,7 @@ TEST_F(SubfieldFilterAstTest, StringNotInList) {
   testFilterExecution(rowType, columnName, *filter, vec, expr);
 }
 
-TEST_F(SubfieldFilterAstTest, StringRange) {
+TEST_F(SubfieldFilterAstTest, stringRange) {
   const std::string columnName = "c2";
   auto rowType = ROW({{columnName, VARCHAR()}});
   auto filter = std::make_unique<common::BytesRange>(
@@ -281,7 +281,7 @@ TEST_F(SubfieldFilterAstTest, StringRange) {
 }
 
 // Single value string range test
-TEST_F(SubfieldFilterAstTest, StringRangeSingleValue) {
+TEST_F(SubfieldFilterAstTest, stringRangeSingleValue) {
   const std::string columnName = "c2";
   auto rowType = ROW({{columnName, VARCHAR()}});
 
@@ -312,7 +312,7 @@ TEST_F(SubfieldFilterAstTest, StringRangeSingleValue) {
   testFilterExecution(rowType, columnName, *filter, vec, expr);
 }
 
-TEST_F(SubfieldFilterAstTest, BoolValue) {
+TEST_F(SubfieldFilterAstTest, boolValue) {
   const std::string columnName = "flag";
   auto rowType = ROW({{columnName, BOOLEAN()}});
   auto filter =
@@ -333,7 +333,7 @@ TEST_F(SubfieldFilterAstTest, BoolValue) {
 }
 
 // Single value range tests
-TEST_F(SubfieldFilterAstTest, BigintRangeSingleValue) {
+TEST_F(SubfieldFilterAstTest, bigintRangeSingleValue) {
   const std::string columnName = "c0";
   auto rowType = ROW({{columnName, BIGINT()}});
   auto filter =
@@ -356,7 +356,7 @@ TEST_F(SubfieldFilterAstTest, BigintRangeSingleValue) {
   testFilterExecution(rowType, columnName, *filter, vec, expr);
 }
 
-TEST_F(SubfieldFilterAstTest, Int32SingleValue) {
+TEST_F(SubfieldFilterAstTest, int32SingleValue) {
   const std::string columnName = "c0";
   auto rowType = ROW({{columnName, INTEGER()}}); // 32-bit int
   auto filter =
@@ -380,7 +380,7 @@ TEST_F(SubfieldFilterAstTest, Int32SingleValue) {
 
 // Single value that is outside the column's type range.
 // For an INT32 column, pick a 64-bit value greater than INT32_MAX.
-TEST_F(SubfieldFilterAstTest, Int32SingleValueOutOfRange) {
+TEST_F(SubfieldFilterAstTest, int32SingleValueOutOfRange) {
   const std::string columnName = "c0";
   auto rowType = ROW({{columnName, INTEGER()}}); // 32-bit int column
 
@@ -410,7 +410,7 @@ TEST_F(SubfieldFilterAstTest, Int32SingleValueOutOfRange) {
 
 // Single value at the exact type boundary (INT32_MAX on INTEGER column).
 // The value is representable so the filter should match.
-TEST_F(SubfieldFilterAstTest, Int32SingleValueAtMax) {
+TEST_F(SubfieldFilterAstTest, int32SingleValueAtMax) {
   const std::string columnName = "c0";
   auto rowType = ROW({{columnName, INTEGER()}});
   const int64_t value = std::numeric_limits<int32_t>::max();
@@ -432,7 +432,7 @@ TEST_F(SubfieldFilterAstTest, Int32SingleValueAtMax) {
 }
 
 // Single value at the exact type boundary (INT32_MIN on INTEGER column).
-TEST_F(SubfieldFilterAstTest, Int32SingleValueAtMin) {
+TEST_F(SubfieldFilterAstTest, int32SingleValueAtMin) {
   const std::string columnName = "c0";
   auto rowType = ROW({{columnName, INTEGER()}});
   const int64_t value = std::numeric_limits<int32_t>::min();
@@ -454,7 +454,7 @@ TEST_F(SubfieldFilterAstTest, Int32SingleValueAtMin) {
 }
 
 // Single value at TINYINT boundary (127 on TINYINT column).
-TEST_F(SubfieldFilterAstTest, TinyIntSingleValueAtMax) {
+TEST_F(SubfieldFilterAstTest, tinyIntSingleValueAtMax) {
   const std::string columnName = "c0";
   auto rowType = ROW({{columnName, TINYINT()}});
   const int64_t value = std::numeric_limits<int8_t>::max();
@@ -476,7 +476,7 @@ TEST_F(SubfieldFilterAstTest, TinyIntSingleValueAtMax) {
 }
 
 // Type boundary tests
-TEST_F(SubfieldFilterAstTest, IntegerOverflowBounds) {
+TEST_F(SubfieldFilterAstTest, integerOverflowBounds) {
   const std::string columnName = "c0";
   auto rowType = ROW({{columnName, INTEGER()}}); // 32-bit int
   auto filter = std::make_unique<common::BigintRange>(
@@ -501,7 +501,7 @@ TEST_F(SubfieldFilterAstTest, IntegerOverflowBounds) {
   testFilterExecution(rowType, columnName, *filter, vec, expr);
 }
 
-TEST_F(SubfieldFilterAstTest, PartialBoundsOutsideTypeRange) {
+TEST_F(SubfieldFilterAstTest, partialBoundsOutsideTypeRange) {
   const std::string columnName = "c0";
   auto rowType = ROW({{columnName, INTEGER()}}); // 32-bit int
   auto filter = std::make_unique<common::BigintRange>(
@@ -524,7 +524,7 @@ TEST_F(SubfieldFilterAstTest, PartialBoundsOutsideTypeRange) {
   testFilterExecution(rowType, columnName, *filter, vec, expr);
 }
 
-TEST_F(SubfieldFilterAstTest, SmallIntTypeBounds) {
+TEST_F(SubfieldFilterAstTest, smallIntTypeBounds) {
   const std::string columnName = "c0";
   auto rowType = ROW({{columnName, SMALLINT()}}); // 16-bit int
   auto filter = std::make_unique<common::BigintRange>(
@@ -547,7 +547,7 @@ TEST_F(SubfieldFilterAstTest, SmallIntTypeBounds) {
   testFilterExecution(rowType, columnName, *filter, vec, expr);
 }
 
-TEST_F(SubfieldFilterAstTest, DecimalRange) {
+TEST_F(SubfieldFilterAstTest, decimalRange) {
   const std::string columnName = "c0";
   auto rowType = ROW({{columnName, DECIMAL(20, 2)}});
   // Range [1.23, 4.56] encoded as unscaled integer values.
@@ -565,7 +565,7 @@ TEST_F(SubfieldFilterAstTest, DecimalRange) {
   testFilterExecution(rowType, columnName, *filter, vec, expr);
 }
 
-TEST_F(SubfieldFilterAstTest, DecimalInList) {
+TEST_F(SubfieldFilterAstTest, decimalInList) {
   const std::string columnName = "c0";
   auto rowType = ROW({{columnName, DECIMAL(20, 2)}});
   // Values [1.23, 4.56] encoded as unscaled integer values.
@@ -583,7 +583,7 @@ TEST_F(SubfieldFilterAstTest, DecimalInList) {
   testFilterExecution(rowType, columnName, *filter, vec, expr);
 }
 
-TEST_F(SubfieldFilterAstTest, EmptyInListHandling) {
+TEST_F(SubfieldFilterAstTest, emptyInListHandling) {
   auto rowType = ROW({{"c0", BIGINT()}});
   std::vector<int64_t> emptyVals = {};
 
@@ -601,7 +601,7 @@ TEST_F(SubfieldFilterAstTest, EmptyInListHandling) {
       VeloxException);
 }
 
-TEST_F(SubfieldFilterAstTest, MultipleSubfieldFilters) {
+TEST_F(SubfieldFilterAstTest, multipleSubfieldFilters) {
   // Schema with multiple columns to filter on.
   auto rowType = ROW({
       {"c0", INTEGER()},
@@ -741,7 +741,7 @@ static TypePtr buildTypeForKind(TypeKind kind) {
   }
 }
 
-TEST_P(IntInListParamTest, InListParam) {
+TEST_P(IntInListParamTest, inListParam) {
   const auto& p = GetParam();
   const std::string columnName = "c0";
   auto rowType = ROW({{columnName, buildTypeForKind(p.kind)}});
@@ -807,7 +807,7 @@ class BigintMultiRangeParamTest
     : public SubfieldFilterAstTest,
       public ::testing::WithParamInterface<BigintMultiRangeCase> {};
 
-TEST_P(BigintMultiRangeParamTest, BigintMultiRange) {
+TEST_P(BigintMultiRangeParamTest, bigintMultiRange) {
   const auto& p = GetParam();
   const std::string columnName = "c0";
   auto rowType = ROW({{columnName, buildTypeForKind(p.kind)}});
@@ -860,7 +860,7 @@ INSTANTIATE_TEST_SUITE_P(
 // MultiRange tests (FilterKind::kMultiRange)
 // MultiRange wraps arbitrary sub-filters with OR semantics. Common use case:
 // not-equal predicates represented as (< X) OR (> X).
-TEST_F(SubfieldFilterAstTest, MultiRangeDoubleNotEqual) {
+TEST_F(SubfieldFilterAstTest, multiRangeDoubleNotEqual) {
   const std::string columnName = "c0";
   auto rowType = ROW({{columnName, DOUBLE()}});
 
@@ -904,7 +904,7 @@ TEST_F(SubfieldFilterAstTest, MultiRangeDoubleNotEqual) {
   testFilterExecution(rowType, columnName, *filter, vec, expr);
 }
 
-TEST_F(SubfieldFilterAstTest, MultiRangeBytesNotEqual) {
+TEST_F(SubfieldFilterAstTest, multiRangeBytesNotEqual) {
   const std::string columnName = "c0";
   auto rowType = ROW({{columnName, VARCHAR()}});
 
@@ -950,7 +950,7 @@ TEST_F(SubfieldFilterAstTest, MultiRangeBytesNotEqual) {
   testFilterExecution(rowType, columnName, *filter, vec, expr);
 }
 
-TEST_F(SubfieldFilterAstTest, MultiRangeSingleFilter) {
+TEST_F(SubfieldFilterAstTest, multiRangeSingleFilter) {
   const std::string columnName = "c0";
   auto rowType = ROW({{columnName, DOUBLE()}});
 
@@ -983,7 +983,7 @@ TEST_F(SubfieldFilterAstTest, MultiRangeSingleFilter) {
   testFilterExecution(rowType, columnName, *filter, vec, expr);
 }
 
-TEST_F(SubfieldFilterAstTest, MultiRangeMixedFilters) {
+TEST_F(SubfieldFilterAstTest, multiRangeMixedFilters) {
   const std::string columnName = "c0";
   auto rowType = ROW({{columnName, REAL()}});
 
@@ -1034,7 +1034,7 @@ TEST_F(SubfieldFilterAstTest, MultiRangeMixedFilters) {
   testFilterExecution(rowType, columnName, *filter, vec, expr);
 }
 
-TEST_F(SubfieldFilterAstTest, EmptyMultiRangeThrows) {
+TEST_F(SubfieldFilterAstTest, emptyMultiRangeThrows) {
   auto rowType = ROW({{"c0", DOUBLE()}});
 
   // MultiRange with empty filter list should throw.

--- a/velox/expression/tests/GenericWriterTest.cpp
+++ b/velox/expression/tests/GenericWriterTest.cpp
@@ -86,7 +86,7 @@ TEST_F(GenericWriterTest, integer) {
       result);
 }
 
-TEST_F(GenericWriterTest, ArrayOfGeneric) {
+TEST_F(GenericWriterTest, arrayOfGeneric) {
   VectorPtr result;
   BaseVector::ensureWritable(
       SelectivityVector(2), ARRAY(BIGINT()), pool(), result);
@@ -127,7 +127,7 @@ struct ArrayTrimFunction {
   }
 };
 
-TEST_F(GenericWriterTest, ArrayTrim) {
+TEST_F(GenericWriterTest, arrayTrim) {
   registerFunction<
       ArrayTrimFunction,
       Array<Generic<T1>>,

--- a/velox/expression/tests/StringWriterTest.cpp
+++ b/velox/expression/tests/StringWriterTest.cpp
@@ -107,7 +107,7 @@ TEST_F(StringWriterTest, copyFromCString) {
   ASSERT_EQ(vector->valueAt(0), "1 2 3 4 5 "_sv);
 }
 
-TEST_F(StringWriterTest, CheckSizeLimit) {
+TEST_F(StringWriterTest, checkSizeLimit) {
   auto vector = makeFlatVector<StringView>(4);
   auto writer = exec::StringWriter(vector.get(), 0);
 

--- a/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
@@ -2514,7 +2514,7 @@ TEST_F(MinMaxByTest, nans) {
   testNanFloatValues<double>();
 }
 
-TEST_F(MinMaxByTest, TimestampWithTimezone) {
+TEST_F(MinMaxByTest, timestampWithTimezone) {
   auto data = makeRowVector(
       {// output column for min_by/max_by
        makeFlatVector<int32_t>({1, 2, 3, 4, 5, 6, 7, 8}),

--- a/velox/functions/prestosql/aggregates/tests/MinMaxTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxTest.cpp
@@ -673,7 +673,7 @@ TEST_F(MinMaxTest, failOnUnorderableType) {
   }
 }
 
-TEST_F(MinMaxTest, TimestampWithTimezone) {
+TEST_F(MinMaxTest, timestampWithTimezone) {
   auto data = makeRowVector({
       makeFlatVector<int64_t>(
           {pack(-1, 2),

--- a/velox/functions/prestosql/aggregates/tests/SetAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/SetAggTest.cpp
@@ -873,7 +873,7 @@ TEST_F(SetAggTest, nans) {
       {data}, {"c1"}, {"set_agg(c0)"}, {"array_sort(a0)", "c1"}, {expected});
 }
 
-TEST_F(SetAggTest, TimestampWithTimezone) {
+TEST_F(SetAggTest, timestampWithTimezone) {
   // Global aggregation, Primitive type.
   auto data = makeRowVector({
       makeFlatVector<int64_t>(

--- a/velox/functions/prestosql/aggregates/tests/SetUnionTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/SetUnionTest.cpp
@@ -606,7 +606,7 @@ TEST_F(SetUnionTest, nans) {
       {data}, {"c1"}, {"set_union(c0)"}, {"array_sort(a0)", "c1"}, {expected});
 }
 
-TEST_F(SetUnionTest, TimestampWithTimeZone) {
+TEST_F(SetUnionTest, timestampWithTimeZone) {
   // Global aggregation, Primitive type.
   auto data = makeRowVector({
       makeArrayVector<int64_t>(

--- a/velox/functions/prestosql/tests/ArraysOverlapTest.cpp
+++ b/velox/functions/prestosql/tests/ArraysOverlapTest.cpp
@@ -317,7 +317,7 @@ TEST_F(ArraysOverlapTest, dictionaryEncodedElementsInConstant) {
       {array});
 }
 
-TEST_F(ArraysOverlapTest, TimestampWithTimezone) {
+TEST_F(ArraysOverlapTest, timestampWithTimezone) {
   auto testArraysOverlap =
       [this](
           const std::vector<std::optional<int64_t>>& array1,

--- a/velox/functions/prestosql/tests/BinaryFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/BinaryFunctionsTest.cpp
@@ -167,7 +167,7 @@ TEST_F(BinaryFunctionsTest, spookyHashV264) {
       spookyHashV264("more_than_12_characters_string"));
 }
 
-TEST_F(BinaryFunctionsTest, HmacSha1) {
+TEST_F(BinaryFunctionsTest, hmacSha1) {
   const auto hmacSha1 = [&](std::optional<std::string> arg,
                             std::optional<std::string> key) {
     return evaluateOnce<std::string>(
@@ -205,7 +205,7 @@ TEST_F(BinaryFunctionsTest, HmacSha1) {
   EXPECT_EQ(std::nullopt, hmacSha1("velox", std::nullopt));
 }
 
-TEST_F(BinaryFunctionsTest, HmacSha256) {
+TEST_F(BinaryFunctionsTest, hmacSha256) {
   const auto hmacSha256 = [&](std::optional<std::string> arg,
                               std::optional<std::string> key) {
     return evaluateOnce<std::string>(
@@ -237,7 +237,7 @@ TEST_F(BinaryFunctionsTest, HmacSha256) {
   EXPECT_EQ(std::nullopt, hmacSha256(std::nullopt, "velox"));
 }
 
-TEST_F(BinaryFunctionsTest, HmacSha512) {
+TEST_F(BinaryFunctionsTest, hmacSha512) {
   const auto hmacSha512 = [&](std::optional<std::string> arg,
                               std::optional<std::string> key) {
     return evaluateOnce<std::string>(
@@ -259,7 +259,7 @@ TEST_F(BinaryFunctionsTest, HmacSha512) {
 
 // Note: this test fails in a FIPS enabled environment because OpenSSL restricts
 // usage of MD5 for hmacs.
-TEST_F(BinaryFunctionsTest, HmacMd5) {
+TEST_F(BinaryFunctionsTest, hmacMd5) {
   const auto hmacMd5 = [&](std::optional<std::string> arg,
                            std::optional<std::string> key) {
     return evaluateOnce<std::string>(

--- a/velox/functions/prestosql/tests/ComparisonsTest.cpp
+++ b/velox/functions/prestosql/tests/ComparisonsTest.cpp
@@ -935,7 +935,7 @@ TEST_F(ComparisonsTest, nanComparison) {
   testNaN("", input, false);
 }
 
-TEST_F(ComparisonsTest, TimestampWithTimezone) {
+TEST_F(ComparisonsTest, timestampWithTimezone) {
   auto makeTimestampWithTimezone = [](int64_t millis, const std::string& tz) {
     return pack(millis, tz::getTimeZoneID(tz));
   };
@@ -1167,7 +1167,7 @@ TEST_F(ComparisonsTest, TimestampWithTimezone) {
            false}));
 }
 
-TEST_F(ComparisonsTest, IPPrefixType) {
+TEST_F(ComparisonsTest, ipPrefixType) {
   auto ipprefix = [](const std::string& ipprefixString) {
     auto tryIpPrefix = ipaddress::tryParseIpPrefixString(ipprefixString);
     return variant::row(
@@ -1449,7 +1449,7 @@ TEST_F(ComparisonsTest, IPPrefixType) {
   }
 }
 
-TEST_F(ComparisonsTest, IpAddressType) {
+TEST_F(ComparisonsTest, ipAddressType) {
   auto makeIpAdressFromString = [](std::string_view ipAddr) -> int128_t {
     auto ret = ipaddress::tryGetIPv6asInt128FromString(ipAddr);
     return ret.value();
@@ -1712,7 +1712,7 @@ TEST_F(ComparisonsTest, IpAddressType) {
            std::nullopt}));
 }
 
-TEST_F(ComparisonsTest, CustomComparisonWithGenerics) {
+TEST_F(ComparisonsTest, customComparisonWithGenerics) {
   // Tests that functions that support signatures with generics handle custom
   // comparison correctly.
   auto input = makeRowVector({

--- a/velox/functions/prestosql/tests/IPAddressFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/IPAddressFunctionsTest.cpp
@@ -216,7 +216,7 @@ TEST_F(IPAddressFunctionsTest, ipSubnetMax) {
       "2001:db8:85a3:1:1:8a2e:370:7334");
 }
 
-TEST_F(IPAddressFunctionsTest, IPSubnetRange) {
+TEST_F(IPAddressFunctionsTest, ipSubnetRange) {
   ASSERT_EQ("192.0.0.0", ipSubnetRangeMin("192.64.1.1/9"));
   ASSERT_EQ("192.127.255.255", ipSubnetRangeMax("192.64.1.1/9"));
   ASSERT_EQ("0.0.0.0", ipSubnetRangeMin("192.64.1.1/0"));
@@ -271,7 +271,7 @@ TEST_F(IPAddressFunctionsTest, IPSubnetRange) {
   ASSERT_EQ("64:ff9b::17", ipSubnetRangeMax("64:ff9b::17/128"));
 }
 
-TEST_F(IPAddressFunctionsTest, IPSubnetOfIPPrefix) {
+TEST_F(IPAddressFunctionsTest, ipSubnetOfIPPrefix) {
   EXPECT_EQ(isSubnetOfIPPrefix("192.168.3.131/26", "192.168.3.144/30"), true);
   EXPECT_EQ(isSubnetOfIPPrefix("64:ff9b::17/64", "64:ffff::17/64"), false);
   EXPECT_EQ(isSubnetOfIPPrefix("64:ff9b::17/32", "64:ffff::17/24"), false);
@@ -298,7 +298,7 @@ TEST_F(IPAddressFunctionsTest, IPSubnetOfIPPrefix) {
   EXPECT_EQ(isSubnetOfIPPrefix("170.0.52.0/24", "170.0.52.0/22"), false);
 }
 
-TEST_F(IPAddressFunctionsTest, IPPrefixCollapseTest) {
+TEST_F(IPAddressFunctionsTest, ipPrefixCollapseTest) {
   auto makeIPPrefixFunc =
       [](const std::string& ipprefix) -> std::tuple<int128_t, int8_t> {
     auto ret = ipaddress::tryParseIpPrefixString(ipprefix);
@@ -553,7 +553,7 @@ TEST_F(IPAddressFunctionsTest, IPPrefixCollapseTest) {
   }
 }
 
-TEST_F(IPAddressFunctionsTest, IPPrefixSubnetsTest) {
+TEST_F(IPAddressFunctionsTest, ipPrefixSubnetsTest) {
   auto ipprefix = [](const std::string& ipprefixString) {
     auto tryIpPrefix = ipaddress::tryParseIpPrefixString(ipprefixString);
     return variant::row(
@@ -630,7 +630,7 @@ TEST_F(IPAddressFunctionsTest, IPPrefixSubnetsTest) {
   }
 }
 
-TEST_F(IPAddressFunctionsTest, IsPrivateIPTest) {
+TEST_F(IPAddressFunctionsTest, isPrivateIPTest) {
   const static std::vector<std::string> privateIpAddresses = {
       // The first and last IP address in each private range
       {"0.0.0.0"},

--- a/velox/functions/prestosql/tests/InPredicateTest.cpp
+++ b/velox/functions/prestosql/tests/InPredicateTest.cpp
@@ -1112,7 +1112,7 @@ TEST_F(InPredicateTest, nans) {
   testNaNs<double>();
 }
 
-TEST_F(InPredicateTest, TimestampWithTimeZone) {
+TEST_F(InPredicateTest, timestampWithTimeZone) {
   // The millis ranges from 0-17, but after every 17th row we increment the time
   // zone ID, so that no two rows have the same millis and time zone.  However,
   // by the semantics of TimestampWithTimeZone's comparison, it's the same 17
@@ -1123,7 +1123,7 @@ TEST_F(InPredicateTest, TimestampWithTimeZone) {
   testConstantValues<int64_t>(TIMESTAMP_WITH_TIME_ZONE(), valueAt);
 }
 
-TEST_F(InPredicateTest, BadTimestampsWithTry) {
+TEST_F(InPredicateTest, badTimestampsWithTry) {
   // Test that errors thrown while evaluating the filter are propagated
   // correctly to the TRY.
   // We do this using the maximum possible timestamp value, when evaulating the

--- a/velox/functions/prestosql/tests/SplitToMapTest.cpp
+++ b/velox/functions/prestosql/tests/SplitToMapTest.cpp
@@ -80,7 +80,7 @@ TEST_F(SplitToMapTest, basic) {
   tryCallFunc(data);
 }
 
-TEST_F(SplitToMapTest, MultiCharKeyValueDelimiter) {
+TEST_F(SplitToMapTest, multiCharKeyValueDelimiter) {
   const auto callFunc = [&](const RowVectorPtr& input) {
     return evaluate("split_to_map(c0, ',', ';=')", input);
   };
@@ -129,7 +129,7 @@ TEST_F(SplitToMapTest, MultiCharKeyValueDelimiter) {
   tryCallFunc(data);
 }
 
-TEST_F(SplitToMapTest, MultiCharEntryDelimiter) {
+TEST_F(SplitToMapTest, multiCharEntryDelimiter) {
   const auto callFunc = [&](const RowVectorPtr& input) {
     return evaluate("split_to_map(c0, ';;', ';')", input);
   };

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -300,7 +300,7 @@ class ArithmeticTest : public SparkFunctionBaseTest {
   static constexpr double kInfDouble = std::numeric_limits<double>::infinity();
 };
 
-TEST_F(ArithmeticTest, UnaryMinus) {
+TEST_F(ArithmeticTest, unaryMinus) {
   EXPECT_EQ(unaryminus<int8_t>(1), -1);
   EXPECT_EQ(unaryminus<int16_t>(2), -2);
   EXPECT_EQ(unaryminus<int32_t>(3), -3);
@@ -309,7 +309,7 @@ TEST_F(ArithmeticTest, UnaryMinus) {
   EXPECT_EQ(unaryminus<double>(6), -6);
 }
 
-TEST_F(ArithmeticTest, UnaryMinusOverflow) {
+TEST_F(ArithmeticTest, unaryMinusOverflow) {
   EXPECT_EQ(unaryminus<int8_t>(INT8_MIN), INT8_MIN);
   EXPECT_EQ(unaryminus<int16_t>(INT16_MIN), INT16_MIN);
   EXPECT_EQ(unaryminus<int32_t>(INT32_MIN), INT32_MIN);
@@ -320,7 +320,7 @@ TEST_F(ArithmeticTest, UnaryMinusOverflow) {
   EXPECT_TRUE(std::isnan(unaryminus<double>(kNan).value_or(0)));
 }
 
-TEST_F(ArithmeticTest, Divide) {
+TEST_F(ArithmeticTest, divide) {
   // Null cases.
   EXPECT_EQ(divide(std::nullopt, std::nullopt), std::nullopt);
   EXPECT_EQ(divide(std::nullopt, 1), std::nullopt);
@@ -488,7 +488,7 @@ class CeilFloorTest : public SparkFunctionBaseTest {
   }
 };
 
-TEST_F(CeilFloorTest, Limits) {
+TEST_F(CeilFloorTest, limits) {
   EXPECT_EQ(1, ceil<int64_t>(1));
   EXPECT_EQ(-1, ceil<int64_t>(-1));
   EXPECT_EQ(3, ceil<double>(2.878));

--- a/velox/functions/sparksql/tests/HashTest.cpp
+++ b/velox/functions/sparksql/tests/HashTest.cpp
@@ -68,7 +68,7 @@ class HashTest : public SparkFunctionBaseTest {
   }
 };
 
-TEST_F(HashTest, String) {
+TEST_F(HashTest, string) {
   EXPECT_EQ(hash<std::string>("Spark"), 228093765);
   EXPECT_EQ(hash<std::string>(""), 142593372);
   EXPECT_EQ(hash<std::string>("abcdefghijklmnopqrstuvwxyz"), -1990933474);
@@ -88,11 +88,11 @@ TEST_F(HashTest, longDecimal) {
 
 // Spark CLI select timestamp_micros(12345678) to get the Timestamp.
 // select hash(Timestamp("1970-01-01 00:00:12.345678")) to get the hash value.
-TEST_F(HashTest, Timestamp) {
+TEST_F(HashTest, timestamp) {
   EXPECT_EQ(hash<Timestamp>(Timestamp::fromMicros(12345678)), 1402875301);
 }
 
-TEST_F(HashTest, Int64) {
+TEST_F(HashTest, int64) {
   EXPECT_EQ(hash<int64_t>(0xcafecafedeadbeef), -256235155);
   EXPECT_EQ(hash<int64_t>(0xdeadbeefcafecafe), 673261790);
   EXPECT_EQ(hash<int64_t>(INT64_MAX), -1604625029);
@@ -103,7 +103,7 @@ TEST_F(HashTest, Int64) {
   EXPECT_EQ(hash<int64_t>(std::nullopt), 42);
 }
 
-TEST_F(HashTest, Int32) {
+TEST_F(HashTest, int32) {
   EXPECT_EQ(hash<int32_t>(0xdeadbeef), 141248195);
   EXPECT_EQ(hash<int32_t>(0xcafecafe), 638354558);
   EXPECT_EQ(hash<int32_t>(1), -559580957);
@@ -112,27 +112,27 @@ TEST_F(HashTest, Int32) {
   EXPECT_EQ(hash<int32_t>(std::nullopt), 42);
 }
 
-TEST_F(HashTest, Int16) {
+TEST_F(HashTest, int16) {
   EXPECT_EQ(hash<int16_t>(1), -559580957);
   EXPECT_EQ(hash<int16_t>(0), 933211791);
   EXPECT_EQ(hash<int16_t>(-1), -1604776387);
   EXPECT_EQ(hash<int16_t>(std::nullopt), 42);
 }
 
-TEST_F(HashTest, Int8) {
+TEST_F(HashTest, int8) {
   EXPECT_EQ(hash<int8_t>(1), -559580957);
   EXPECT_EQ(hash<int8_t>(0), 933211791);
   EXPECT_EQ(hash<int8_t>(-1), -1604776387);
   EXPECT_EQ(hash<int8_t>(std::nullopt), 42);
 }
 
-TEST_F(HashTest, Bool) {
+TEST_F(HashTest, bool) {
   EXPECT_EQ(hash<bool>(false), 933211791);
   EXPECT_EQ(hash<bool>(true), -559580957);
   EXPECT_EQ(hash<bool>(std::nullopt), 42);
 }
 
-TEST_F(HashTest, StringInt32) {
+TEST_F(HashTest, stringInt32) {
   auto hash = [&](std::optional<std::string> a, std::optional<int32_t> b) {
     return evaluateOnce<int32_t>("hash(c0, c1)", a, b);
   };
@@ -143,7 +143,7 @@ TEST_F(HashTest, StringInt32) {
   EXPECT_EQ(hash("", 0), 1143746540);
 }
 
-TEST_F(HashTest, Double) {
+TEST_F(HashTest, double) {
   using limits = std::numeric_limits<double>;
 
   EXPECT_EQ(hash<double>(std::nullopt), 42);
@@ -155,7 +155,7 @@ TEST_F(HashTest, Double) {
   EXPECT_EQ(hash<double>(-limits::infinity()), 461104036);
 }
 
-TEST_F(HashTest, Float) {
+TEST_F(HashTest, float) {
   using limits = std::numeric_limits<float>;
 
   EXPECT_EQ(hash<float>(std::nullopt), 42);

--- a/velox/functions/sparksql/tests/InTest.cpp
+++ b/velox/functions/sparksql/tests/InTest.cpp
@@ -126,7 +126,7 @@ class InTest : public SparkFunctionBaseTest {
   }
 };
 
-TEST_F(InTest, Int64) {
+TEST_F(InTest, int64) {
   EXPECT_EQ(in<int64_t>(1, {1, 2}), true);
   EXPECT_EQ(in<int64_t>(2, {1, 2}), true);
   EXPECT_EQ(in<int64_t>(3, {1, 2}), false);
@@ -137,7 +137,7 @@ TEST_F(InTest, Int64) {
   EXPECT_EQ(in<int64_t>(std::nullopt, {1, std::nullopt, 2}), std::nullopt);
 }
 
-TEST_F(InTest, Float) {
+TEST_F(InTest, float) {
   EXPECT_EQ(in<float>(1.0, {-1.0, 1.0, 2.0}), true);
   EXPECT_EQ(in<float>(0, {-1.0, 1.0}), false);
   EXPECT_EQ(in<float>(0, {std::nullopt, 1.0}), std::nullopt);
@@ -147,7 +147,7 @@ TEST_F(InTest, Float) {
   EXPECT_EQ(in<float>(std::nanf("1"), {kNan, -1.0, 0.0, 1.0}), true);
 }
 
-TEST_F(InTest, Double) {
+TEST_F(InTest, double) {
   EXPECT_EQ(in<double>(1.0, {-1.0, 1.0, 2.0}), true);
   EXPECT_EQ(in<double>(0, {-1.0, 1.0}), false);
   EXPECT_EQ(in<double>(-0.0, {-1.0, 0.0, 1.0}), true);
@@ -161,7 +161,7 @@ TEST_F(InTest, Double) {
   EXPECT_EQ(in<double>(-kInf, {kNan, -1.0, 0.0, 1.0, -kInf}), true);
 }
 
-TEST_F(InTest, String) {
+TEST_F(InTest, string) {
   EXPECT_EQ(in<std::string>("", {"", std::nullopt}), true);
   EXPECT_EQ(in<std::string>("a", {"", std::nullopt}), std::nullopt);
   EXPECT_EQ(in<std::string>("a", {"", "b"}), false);
@@ -173,7 +173,7 @@ TEST_F(InTest, String) {
       std::nullopt);
 }
 
-TEST_F(InTest, Timestamp) {
+TEST_F(InTest, timestamp) {
   EXPECT_EQ(
       in<Timestamp>(Timestamp(0, 0), {Timestamp(1, 0), std::nullopt}),
       std::nullopt);
@@ -193,12 +193,12 @@ TEST_F(InTest, Timestamp) {
       true);
 }
 
-TEST_F(InTest, Date) {
+TEST_F(InTest, date) {
   EXPECT_EQ(in<int32_t>(0, {1, std::nullopt}, DATE()), std::nullopt);
   EXPECT_EQ(in<int32_t>(0, {0}, DATE()), true);
 }
 
-TEST_F(InTest, Bool) {
+TEST_F(InTest, bool) {
   EXPECT_EQ(in<bool>(true, {true, false, std::nullopt}), true);
   EXPECT_EQ(in<bool>(true, {false, std::nullopt}), std::nullopt);
   EXPECT_EQ(in<bool>(true, {false}), false);
@@ -243,7 +243,7 @@ TEST_F(InTest, longDecimal) {
       true);
 }
 
-TEST_F(InTest, Const) {
+TEST_F(InTest, const) {
   const auto eval = [&](const std::string& expr) {
     return evaluateOnce<bool, bool>(expr, false);
   };
@@ -255,7 +255,7 @@ TEST_F(InTest, Const) {
 
 /// Test IN applied to first argument that is dictionary encoded, but has the
 /// same value in all requested rows.
-TEST_F(InTest, ConstantDictionary) {
+TEST_F(InTest, constantDictionary) {
   auto data = makeFlatVector<int32_t>({1, 2, 3, 4});
   EXPECT_EQ(
       evaluateOnce<bool>(

--- a/velox/functions/sparksql/tests/MapTest.cpp
+++ b/velox/functions/sparksql/tests/MapTest.cpp
@@ -45,7 +45,7 @@ class MapTest : public SparkFunctionBaseTest {
   }
 };
 
-TEST_F(MapTest, Basics) {
+TEST_F(MapTest, basics) {
   auto inputVector1 = makeNullableFlatVector<int64_t>({1, 2, 3});
   auto inputVector2 = makeNullableFlatVector<int64_t>({4, 5, 6});
   auto mapVector =
@@ -53,7 +53,7 @@ TEST_F(MapTest, Basics) {
   testMap("map(c0, c1)", {inputVector1, inputVector2}, mapVector);
 }
 
-TEST_F(MapTest, Nulls) {
+TEST_F(MapTest, nulls) {
   auto inputVector1 = makeNullableFlatVector<int64_t>({1, 2, 3});
   auto inputVector2 =
       makeNullableFlatVector<int64_t>({std::nullopt, 5, std::nullopt});

--- a/velox/functions/sparksql/tests/XxHash64Test.cpp
+++ b/velox/functions/sparksql/tests/XxHash64Test.cpp
@@ -97,7 +97,7 @@ TEST_F(XxHash64Test, longDecimal) {
 // Spark CLI select timestamp_micros(12345678) to get the Timestamp.
 // select xxhash64(Timestamp("1970-01-01 00:00:12.345678")) to get the hash
 // value.
-TEST_F(XxHash64Test, Timestamp) {
+TEST_F(XxHash64Test, timestamp) {
   EXPECT_EQ(
       xxhash64<Timestamp>(Timestamp::fromMicros(12345678)), 782671362992292307);
 }

--- a/velox/vector/tests/SimpleVectorTest.cpp
+++ b/velox/vector/tests/SimpleVectorTest.cpp
@@ -70,14 +70,14 @@ class SimpleVectorNonParameterizedTest : public SimpleVectorTest {
       {"àá"_sv, "abc"_sv, "xyz"_sv, "mno"_sv, "wv"_sv, "abc"_sv, "xyz"_sv};
 };
 
-TEST_F(SimpleVectorNonParameterizedTest, ConstantVectorTest) {
+TEST_F(SimpleVectorNonParameterizedTest, constantVectorTest) {
   ExpectedData<int64_t> expected(10, 123456);
   auto vector =
       maker_.encodedVector(VectorEncoding::Simple::CONSTANT, expected);
   assertVectorAndProperties(expected, vector);
 }
 
-TEST_F(SimpleVectorNonParameterizedTest, ConstantVectorTestIsNull) {
+TEST_F(SimpleVectorNonParameterizedTest, constantVectorTestIsNull) {
   ExpectedData<int64_t> expected(10, std::nullopt);
   auto vector =
       maker_.encodedVector(VectorEncoding::Simple::CONSTANT, expected);
@@ -85,7 +85,7 @@ TEST_F(SimpleVectorNonParameterizedTest, ConstantVectorTestIsNull) {
 }
 
 // Single Entry Tests
-TEST_F(SimpleVectorNonParameterizedTest, SingleEntryIntegerVector) {
+TEST_F(SimpleVectorNonParameterizedTest, singleEntryIntegerVector) {
   for (auto t : kFullValueTypes) {
     LOG(INFO) << "Running:" << t;
     ExpectedData<int64_t> expected = {{123456}};
@@ -94,7 +94,7 @@ TEST_F(SimpleVectorNonParameterizedTest, SingleEntryIntegerVector) {
   }
 }
 
-TEST_F(SimpleVectorNonParameterizedTest, SingleNullEntryIntegerVector) {
+TEST_F(SimpleVectorNonParameterizedTest, singleNullEntryIntegerVector) {
   for (auto t : kFullValueTypes) {
     LOG(INFO) << "Running:" << t;
     ExpectedData<int64_t> expected = {{std::nullopt}};
@@ -123,14 +123,14 @@ TEST_F(SimpleVectorNonParameterizedTest, roundTripSortedDescThenNullLastData) {
   }
 }
 
-TEST_F(SimpleVectorNonParameterizedTest, BasicRoundTrip) {
+TEST_F(SimpleVectorNonParameterizedTest, basicRoundTrip) {
   auto expected =
       genTestDataWithSequences<int64_t>(1000, 100, true, true, 100, 10);
   auto vector = maker_.flatVectorNullable<int64_t>(expected.data());
   assertVectorAndProperties<int64_t>(expected.data(), vector);
 }
 
-TEST_F(SimpleVectorNonParameterizedTest, ThreadSafeAsciiCompute) {
+TEST_F(SimpleVectorNonParameterizedTest, threadSafeAsciiCompute) {
   const size_t numRows{100};
   const size_t numThreads{10};
 

--- a/velox/vector/tests/VectorCompareTest.cpp
+++ b/velox/vector/tests/VectorCompareTest.cpp
@@ -549,7 +549,7 @@ TEST_F(VectorCompareTest, compareNullAsIndeterminateRow) {
   }
 }
 
-TEST_F(VectorCompareTest, CompareWithNullChildVector) {
+TEST_F(VectorCompareTest, compareWithNullChildVector) {
   auto pool = memory::memoryManager()->addLeafPool();
   test::VectorMaker maker{pool.get()};
   auto rowType = ROW({"a", "b", "c"}, {INTEGER(), INTEGER(), INTEGER()});

--- a/velox/vector/tests/VectorSaverTest.cpp
+++ b/velox/vector/tests/VectorSaverTest.cpp
@@ -612,7 +612,7 @@ TEST_F(VectorSaverTest, dictionaryRow) {
   testRoundTrip(fuzzer.fuzzDictionary(fuzzer.fuzzDictionary(flatVector)));
 }
 
-TEST_F(VectorSaverTest, LazyVector) {
+TEST_F(VectorSaverTest, lazyVector) {
   auto opts = fuzzerOptions();
   opts.nullRatio = 0.5;
   SCOPED_TRACE(fmt::format("seed: {}", seed_));


### PR DESCRIPTION
Updates regular `TEST`, `TEST_F`, `TEST_P`, and `TYPED_TEST` names that started with uppercase letters to lowercase.