### PR TITLE
feat: Use CachedBufferedInput in NimbleIndexProjector when cache is available (#17603)

### DIFF
--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -789,6 +789,16 @@ class ReaderOptions : public io::ReaderOptions {
     pinIndex_ = value;
   }
 
+  /// If true, caches data column reads in the async data cache. Default false
+  /// keeps the cache scoped to metadata/index only.
+  bool cacheData() const {
+    return cacheData_;
+  }
+
+  void setCacheData(bool value) {
+    cacheData_ = value;
+  }
+
   /// Whether to load and initialize the cluster index during file open.
   /// When true, the cluster index section is preloaded and the structured
   /// ClusterIndex object is created. Default false.
@@ -865,6 +875,7 @@ class ReaderOptions : public io::ReaderOptions {
   bool pinMetadata_{false};
   bool cacheIndex_{false};
   bool pinIndex_{false};
+  bool cacheData_{true};
   bool loadClusterIndex_{false};
   bool preloadIndex_{false};
   bool loadChunkIndex_{true};

--- a/velox/dwio/common/tests/OptionsTests.cpp
+++ b/velox/dwio/common/tests/OptionsTests.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 #include <gtest/gtest.h>
+
+#include "velox/common/memory/Memory.h"
 #include "velox/dwio/common/Options.h"
 
 using namespace ::testing;
@@ -55,4 +57,18 @@ TEST(OptionsTests, testRowNumberColumnInfoInCopy) {
       rowReaderOptionsSecondCopy.rowNumberColumnInfo().value();
   ASSERT_EQ(rowNumberColumnInfo.insertPosition, rowNumberColumn.insertPosition);
   ASSERT_EQ(rowNumberColumnInfo.name, rowNumberColumn.name);
+}
+
+TEST(OptionsTests, cacheData) {
+  facebook::velox::memory::MemoryManager::testingSetInstance({});
+  auto pool =
+      facebook::velox::memory::memoryManager()->addRootPool("cacheDataTest");
+  facebook::velox::dwio::common::ReaderOptions options(pool.get());
+  EXPECT_TRUE(options.cacheData());
+
+  options.setCacheData(false);
+  EXPECT_FALSE(options.cacheData());
+
+  options.setCacheData(true);
+  EXPECT_TRUE(options.cacheData());
 }


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookincubator/nimble/pull/766

CONTEXT: NimbleIndexProjector always creates a plain BufferedInput, bypassing the AsyncDataCache even when it is initialized. This means metadata and index reads cannot benefit from caching in the projector path.

WHAT:
- Add a `createBufferedInput()` free function in NimbleIndexProjector.cpp that creates a `CachedBufferedInput` when `AsyncDataCache::getInstance()` is non-null, otherwise falls back to plain `BufferedInput`.
- In the benchmark, when `enable_cache=true` but `cache_data=false` (metadata/index only), use a small 1GB default cache instead of the large auto-sized cache (file size + 10GB).

Reviewed By: duxiao1212, tanjialiang

Differential Revision: D106043231


