### PR TITLE
refactor: Move Parquet writer tests out of E2EFilterTest

### DIFF
--- a/velox/dwio/parquet/tests/ParquetTestBase.h
+++ b/velox/dwio/parquet/tests/ParquetTestBase.h
@@ -196,13 +196,16 @@ class ParquetTestBase : public testing::Test,
 
   dwio::common::MemorySink* write(
       const RowVectorPtr& data,
-      const WriterOptions& writerOptions) {
+      const WriterOptions& writerOptions,
+      const RowTypePtr& rowType = nullptr) {
     auto sink = std::make_unique<dwio::common::MemorySink>(
         200 * 1024 * 1024,
         dwio::common::FileSink::Options{.pool = leafPool_.get()});
     auto* sinkPtr = sink.get();
     auto writer = std::make_unique<Writer>(
-        std::move(sink), writerOptions, data->rowType());
+        std::move(sink),
+        writerOptions,
+        rowType != nullptr ? rowType : data->rowType());
     writer->write(data);
     writer->close();
     writers_.push_back(std::move(writer));

--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -17,7 +17,6 @@
 #include "velox/common/io/IoStatistics.h"
 #include "velox/dwio/common/tests/utils/E2EFilterTestBase.h"
 #include "velox/dwio/parquet/reader/ParquetReader.h"
-#include "velox/dwio/parquet/reader/ParquetTypeWithId.h"
 #include "velox/dwio/parquet/writer/Writer.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
@@ -101,19 +100,6 @@ class E2EFilterTest : public E2EFilterTestBase,
   uint64_t rowsInRowGroup_ = 10'000;
   int64_t bytesInRowGroup_ = 128 * 1'024 * 1'024;
 };
-
-TEST_F(E2EFilterTest, writerMagic) {
-  rowType_ = ROW({"c0"}, {INTEGER()});
-  std::vector<RowVectorPtr> batches;
-  batches.push_back(
-      std::static_pointer_cast<RowVector>(test::BatchMaker::createBatch(
-          rowType_, 20000, *leafPool_, nullptr, 0)));
-  writeToMemory(rowType_, batches, false);
-  auto data = sinkData_.data();
-  auto size = sinkData_.size();
-  EXPECT_EQ("PAR1", std::string(data, 4));
-  EXPECT_EQ("PAR1", std::string(data + size - 4, 4));
-}
 
 TEST_F(E2EFilterTest, boolean) {
   testWithTypes(
@@ -676,27 +662,6 @@ TEST_F(E2EFilterTest, varbinaryDictionary) {
       20);
 }
 
-TEST_F(E2EFilterTest, largeMetadata) {
-  rowsInRowGroup_ = 1;
-
-  rowType_ = ROW({"c0"}, {INTEGER()});
-  std::vector<RowVectorPtr> batches;
-  batches.push_back(
-      std::static_pointer_cast<RowVector>(test::BatchMaker::createBatch(
-          rowType_, 1000, *leafPool_, nullptr, 0)));
-  writeToMemory(rowType_, batches, false);
-  dwio::common::ReaderOptions readerOpts(leafPool_.get());
-  readerOpts.setDataIoStats(dataIoStats_);
-  readerOpts.setMetadataIoStats(metadataIoStats_);
-  readerOpts.setFooterSpeculativeIoSize(1024);
-  readerOpts.setFilePreloadThreshold(1024 * 8);
-  dwio::common::RowReaderOptions rowReaderOpts;
-  auto input = std::make_unique<BufferedInput>(
-      std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
-  auto reader = makeReader(readerOpts, std::move(input));
-  EXPECT_EQ(1000, reader->numberOfRows());
-}
-
 TEST_F(E2EFilterTest, date) {
   testWithTypes(
       "date_val:date",
@@ -929,78 +894,6 @@ TEST_F(E2EFilterTest, parquetMRVersionStringStatsRowGroupFiltering) {
   writeAndGetStats("parquet-mr version 1.8.1", stats181);
   EXPECT_EQ(stats181.skippedStrides, 0);
   EXPECT_EQ(stats181.processedStrides, 2);
-}
-
-TEST_F(E2EFilterTest, writeDecimalAsInteger) {
-  auto rowVector = makeRowVector(
-      {makeFlatVector<int64_t>({1, 2}, DECIMAL(8, 2)),
-       makeFlatVector<int64_t>({1, 2}, DECIMAL(10, 2)),
-       makeFlatVector<int128_t>({1, 2}, DECIMAL(19, 2))});
-  writeToMemory(rowVector->type(), {rowVector}, false);
-  dwio::common::ReaderOptions readerOpts(leafPool_.get());
-  readerOpts.setDataIoStats(dataIoStats_);
-  readerOpts.setMetadataIoStats(metadataIoStats_);
-  auto input = std::make_unique<BufferedInput>(
-      std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
-  auto reader = makeReader(readerOpts, std::move(input));
-  auto parquetReader = dynamic_cast<ParquetReader&>(*reader.get());
-
-  auto types = parquetReader.typeWithId()->getChildren();
-  auto c0 = std::dynamic_pointer_cast<const ParquetTypeWithId>(types[0]);
-  EXPECT_EQ(c0->parquetType_.value(), thrift::Type::type::INT32);
-  auto c1 = std::dynamic_pointer_cast<const ParquetTypeWithId>(types[1]);
-  EXPECT_EQ(c1->parquetType_.value(), thrift::Type::type::INT64);
-  auto c2 = std::dynamic_pointer_cast<const ParquetTypeWithId>(types[2]);
-  EXPECT_EQ(c2->parquetType_.value(), thrift::Type::type::FIXED_LEN_BYTE_ARRAY);
-}
-
-TEST_F(E2EFilterTest, configurableWriteSchema) {
-  auto test = [&](auto& type, auto& newType) {
-    std::vector<RowVectorPtr> batches;
-    for (auto i = 0; i < 5; i++) {
-      auto vector = BaseVector::create(type, 100, pool());
-      auto rowVector = std::dynamic_pointer_cast<RowVector>(vector);
-      batches.push_back(rowVector);
-    }
-
-    writeToMemory(newType, batches, false);
-    dwio::common::ReaderOptions readerOpts(leafPool_.get());
-    readerOpts.setDataIoStats(dataIoStats_);
-    readerOpts.setMetadataIoStats(metadataIoStats_);
-    auto input = std::make_unique<BufferedInput>(
-        std::make_shared<InMemoryReadFile>(sinkData_), readerOpts.memoryPool());
-    auto reader = makeReader(readerOpts, std::move(input));
-    auto parquetReader = dynamic_cast<ParquetReader&>(*reader.get());
-
-    EXPECT_EQ(parquetReader.rowType()->toString(), newType->toString());
-  };
-
-  // ROW(ROW(ROW))
-  auto type =
-      ROW({"a", "b"}, {INTEGER(), ROW({"c"}, {ROW({"d"}, {INTEGER()})})});
-  auto newType =
-      ROW({"aa", "bb"}, {INTEGER(), ROW({"cc"}, {ROW({"dd"}, {INTEGER()})})});
-  test(type, newType);
-
-  // ARRAY(ROW)
-  type =
-      ROW({"a", "b"}, {ARRAY(ROW({"c", "d"}, {BIGINT(), BIGINT()})), BIGINT()});
-  newType = ROW(
-      {"aa", "bb"}, {ARRAY(ROW({"cc", "dd"}, {BIGINT(), BIGINT()})), BIGINT()});
-  test(type, newType);
-
-  // // MAP(ROW)
-  type =
-      ROW({"a", "b"},
-          {MAP(ROW({"c", "d"}, {BIGINT(), BIGINT()}),
-               ROW({"e", "f"}, {BIGINT(), BIGINT()})),
-           BIGINT()});
-  newType =
-      ROW({"aa", "bb"},
-          {MAP(ROW({"cc", "dd"}, {BIGINT(), BIGINT()}),
-               ROW({"ee", "ff"}, {BIGINT(), BIGINT()})),
-           BIGINT()});
-  test(type, newType);
 }
 
 TEST_F(E2EFilterTest, booleanRle) {

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -28,6 +28,7 @@
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
 #include "velox/dwio/parquet/RegisterParquetWriter.h" // @manual
 #include "velox/dwio/parquet/reader/PageReader.h"
+#include "velox/dwio/parquet/reader/ParquetTypeWithId.h"
 #include "velox/dwio/parquet/tests/ParquetTestBase.h"
 #include "velox/dwio/parquet/writer/WriterConfig.h"
 #include "velox/dwio/parquet/writer/arrow/tests/ColumnReader.h"
@@ -746,22 +747,156 @@ TEST_F(ParquetWriterTest, preEpochInt96Timestamp) {
   }
 }
 
+TEST_F(ParquetWriterTest, writerMagic) {
+  const auto data = makeRowVector(
+      {makeFlatVector<int32_t>(20'000, [](auto row) { return row; })});
+
+  parquet::WriterOptions writerOptions;
+  writerOptions.memoryPool = rootPool_.get();
+
+  const auto* sinkPtr = write(data, writerOptions);
+  const auto fileData = std::string_view(sinkPtr->data(), sinkPtr->size());
+
+  EXPECT_EQ("PAR1", std::string(fileData.data(), 4));
+  EXPECT_EQ("PAR1", std::string(fileData.data() + fileData.size() - 4, 4));
+}
+
+TEST_F(ParquetWriterTest, largeMetadata) {
+  const auto data = makeRowVector(
+      {makeFlatVector<int32_t>(1'000, [](auto row) { return row; })});
+
+  parquet::WriterOptions writerOptions;
+  writerOptions.memoryPool = rootPool_.get();
+  writerOptions.flushPolicyFactory = []() {
+    return std::make_unique<DefaultFlushPolicy>(
+        /*rowsInRowGroup=*/1,
+        /*bytesInRowGroup=*/128 * 1'024 * 1'024);
+  };
+
+  const auto* sinkPtr = write(data, writerOptions);
+
+  dwio::common::ReaderOptions readerOpts(leafPool_.get());
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
+  readerOpts.setFooterSpeculativeIoSize(1024);
+  readerOpts.setFilePreloadThreshold(1024 * 8);
+
+  const auto reader = createReaderInMemory(*sinkPtr, readerOpts);
+  EXPECT_EQ(1'000, reader->numberOfRows());
+  EXPECT_EQ(1'000, reader->fileMetaData().numRowGroups());
+}
+
+TEST_F(ParquetWriterTest, writeDecimalAsInteger) {
+  const auto rowVector = makeRowVector(
+      {makeFlatVector<int64_t>({1, 2}, DECIMAL(8, 2)),
+       makeFlatVector<int64_t>({1, 2}, DECIMAL(10, 2)),
+       makeFlatVector<int128_t>({1, 2}, DECIMAL(19, 2))});
+
+  parquet::WriterOptions writerOptions;
+  writerOptions.memoryPool = rootPool_.get();
+
+  const auto* sinkPtr = write(rowVector, writerOptions);
+
+  dwio::common::ReaderOptions readerOpts(leafPool_.get());
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
+  const auto reader = createReaderInMemory(*sinkPtr, readerOpts);
+
+  const auto types = reader->typeWithId()->getChildren();
+  ASSERT_GE(types.size(), 3);
+  const auto c0 = std::dynamic_pointer_cast<const ParquetTypeWithId>(types[0]);
+  ASSERT_NE(c0, nullptr);
+  EXPECT_EQ(c0->parquetType_.value(), thrift::Type::type::INT32);
+  const auto c1 = std::dynamic_pointer_cast<const ParquetTypeWithId>(types[1]);
+  ASSERT_NE(c1, nullptr);
+  EXPECT_EQ(c1->parquetType_.value(), thrift::Type::type::INT64);
+  const auto c2 = std::dynamic_pointer_cast<const ParquetTypeWithId>(types[2]);
+  ASSERT_NE(c2, nullptr);
+  EXPECT_EQ(c2->parquetType_.value(), thrift::Type::type::FIXED_LEN_BYTE_ARRAY);
+}
+
+TEST_F(ParquetWriterTest, configurableWriteSchema) {
+  const auto test = [&](const RowTypePtr& type, const RowTypePtr& newType) {
+    constexpr int32_t kNumBatches = 5;
+    constexpr int32_t kBatchSize = 100;
+    auto batches = createBatches(type, kNumBatches, kBatchSize);
+    constexpr vector_size_t kNumRows = kNumBatches * kBatchSize;
+
+    auto data = std::dynamic_pointer_cast<RowVector>(
+        BaseVector::create(type, kNumRows, pool()));
+    auto expected = std::dynamic_pointer_cast<RowVector>(
+        BaseVector::create(newType, kNumRows, pool()));
+    vector_size_t offset = 0;
+    for (const auto& batch : batches) {
+      data->copy(batch.get(), offset, 0, batch->size());
+      expected->copy(batch.get(), offset, 0, batch->size());
+      offset += batch->size();
+    }
+
+    parquet::WriterOptions writerOptions;
+    writerOptions.memoryPool = rootPool_.get();
+    const auto* sinkPtr = write(data, writerOptions, newType);
+    dwio::common::ReaderOptions readerOpts(leafPool_.get());
+    readerOpts.setDataIoStats(dataIoStats_);
+    readerOpts.setMetadataIoStats(metadataIoStats_);
+    auto reader = createReaderInMemory(*sinkPtr, readerOpts);
+
+    ASSERT_EQ(reader->numberOfRows(), kNumRows);
+    EXPECT_EQ(reader->rowType()->toString(), newType->toString());
+
+    auto rowReader = createRowReaderWithSchema(std::move(reader), newType);
+    assertReadWithReaderAndExpected(newType, *rowReader, expected, *leafPool_);
+  };
+
+  test(
+      ROW({"a", "b"}, {INTEGER(), ROW({"c"}, {ROW({"d"}, INTEGER())})}),
+      ROW({"aa", "bb"}, {INTEGER(), ROW({"cc"}, {ROW({"dd"}, INTEGER())})}));
+
+  test(
+      ROW({"a", "b"}, {ARRAY(ROW({"c", "d"}, BIGINT())), BIGINT()}),
+      ROW({"aa", "bb"}, {ARRAY(ROW({"cc", "dd"}, BIGINT())), BIGINT()}));
+
+  test(
+      ROW({"a", "b"},
+          {MAP(ROW({"c", "d"}, BIGINT()), ROW({"e", "f"}, BIGINT())),
+           BIGINT()}),
+      ROW({"aa", "bb"},
+          {MAP(ROW({"cc", "dd"}, BIGINT()), ROW({"ee", "ff"}, BIGINT())),
+           BIGINT()}));
+}
+
 TEST_F(ParquetWriterTest, updateWriterOptionsFromHiveConfig) {
   std::unordered_map<std::string, std::string> configFromFile = {
       {config::ConfigBase::toConfigKey(
            parquet::WriterConfig::kParquetSessionWriteTimestampUnit),
        "3"}};
-  const config::ConfigBase connectorConfig(std::move(configFromFile));
-  const config::ConfigBase connectorSessionProperties({});
+  const std::vector<Timestamp> timestamps = {
+      Timestamp(1, 123'456'789),
+      Timestamp(2, 987'654'321),
+  };
+  const auto data = makeRowVector({makeFlatVector<Timestamp>(timestamps)});
+  const auto expected = makeRowVector({makeFlatVector<Timestamp>({
+      Timestamp::fromMillis(timestamps[0].toMillis()),
+      Timestamp::fromMillis(timestamps[1].toMillis()),
+  })});
 
-  parquet::WriterOptions options;
-  options.compressionKind = facebook::velox::common::CompressionKind_ZLIB;
+  const auto* sinkPtr = write(data, std::move(configFromFile), {});
 
-  options.processConfigs(connectorConfig, connectorSessionProperties);
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
+  auto reader = createReaderInMemory(*sinkPtr, readerOptions);
 
-  ASSERT_EQ(
-      options.parquetWriteTimestampUnit.value(),
-      TimestampPrecision::kMilliseconds);
+  ASSERT_EQ(reader->numberOfRows(), data->size());
+  ASSERT_EQ(*reader->rowType(), *data->rowType());
+
+  auto rowReaderOpts = getReaderOpts(data->rowType());
+  auto scanSpec = makeScanSpec(data->rowType());
+  rowReaderOpts.setScanSpec(scanSpec);
+  rowReaderOpts.setTimestampPrecision(TimestampPrecision::kNanoseconds);
+  auto rowReader = reader->createRowReader(rowReaderOpts);
+  assertReadWithReaderAndExpected(
+      data->rowType(), *rowReader, expected, *leafPool_);
 }
 
 #ifdef VELOX_ENABLE_PARQUET


### PR DESCRIPTION
1. Move Parquet writer-focused tests from `E2EFilterTest` to `ParquetWriterTest`, since these cases do not exercise filter pushdown.
2. Rewrite the moved tests to use the Parquet writer test infrastructure and in-memory reader helpers.
3. Strengthen validation by checking metadata/schema details and reading written data back where applicable.
4. Add coverage that writer config changes affect serialized output, including timestamp precision behavior.