### PR TITLE
fix(exec): Disarm probe-side peer barrier on early driver close

### DIFF
--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -1858,6 +1858,8 @@ void HashProbe::noMoreInputInternal() {
           shouldBlock ? promises_ : promises,
           peers,
           &released)) {
+    // We participated in the barrier, so close() must not disarm it later.
+    barrierReached_ = true;
     if (released) {
       // Barrier was disarmed by a peer that closed without reaching it.
       // Skip last-prober work and finish; build-side output coordination
@@ -1875,6 +1877,9 @@ void HashProbe::noMoreInputInternal() {
     return;
   }
 
+  // Last prober: we contributed to the barrier count, so close() must skip
+  // the disarm step that would otherwise poison the released flag.
+  barrierReached_ = true;
   VELOX_CHECK(promises.empty());
   lastProber_ = true;
   joinBridge_->resetUnclaimedRowContainerId();
@@ -2328,12 +2333,17 @@ void HashProbe::checkMaxSpillLevel(
 }
 
 void HashProbe::close() {
-  // Disarm the peer-synchronization barrier so that any peer drivers
-  // waiting at, or about to reach, the barrier proceed without blocking.
-  // This prevents kWaitForPeers deadlock when this driver terminates
-  // without first running noMoreInput() (i.e., the barrier counter for
-  // this driver is never incremented).
-  operatorCtx_->task()->releasePeerBarrier(splitGroupId(), planNodeId());
+  // Disarm the peer-synchronization barrier only if this operator never
+  // reached it (so its missing arrival would otherwise leave peers in
+  // kWaitForPeers forever). Operators that already participated in the
+  // barrier must not disarm it: doing so would set the released flag on a
+  // barrier that is either still actively counting peers or has already
+  // completed normally, causing future or concurrent allPeersFinished()
+  // callers to skip last-prober work (e.g. RIGHT/FULL outer-join
+  // build-side mismatch emission) and silently drop result rows.
+  if (!barrierReached_) {
+    operatorCtx_->task()->releasePeerBarrier(splitGroupId(), planNodeId());
+  }
 
   Operator::close();
 

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -1850,12 +1850,21 @@ void HashProbe::noMoreInputInternal() {
   const bool outputBuildRowsInParallel =
       canOutputBuildRowsInParallel_ && needLastProbe();
   const bool shouldBlock = canSpill() || outputBuildRowsInParallel;
+  bool released{false};
   if (!operatorCtx_->task()->allPeersFinished(
           planNodeId(),
           operatorCtx_->driver(),
           shouldBlock ? &future_ : nullptr,
           shouldBlock ? promises_ : promises,
-          peers)) {
+          peers,
+          &released)) {
+    if (released) {
+      // Barrier was disarmed by a peer that closed without reaching it.
+      // Skip last-prober work and finish; build-side output coordination
+      // and probeFinished signaling are left to Task teardown.
+      setState(ProbeOperatorState::kFinish);
+      return;
+    }
     if (shouldBlock) {
       VELOX_CHECK(future_.valid());
       setState(ProbeOperatorState::kWaitForPeers);
@@ -2319,6 +2328,13 @@ void HashProbe::checkMaxSpillLevel(
 }
 
 void HashProbe::close() {
+  // Disarm the peer-synchronization barrier so that any peer drivers
+  // waiting at, or about to reach, the barrier proceed without blocking.
+  // This prevents kWaitForPeers deadlock when this driver terminates
+  // without first running noMoreInput() (i.e., the barrier counter for
+  // this driver is never incremented).
+  operatorCtx_->task()->releasePeerBarrier(splitGroupId(), planNodeId());
+
   Operator::close();
 
   // Free up major memory usage.

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -438,6 +438,14 @@ class HashProbe : public Operator {
   // table from the previously spilled data.
   bool lastProber_{false};
 
+  // True once this operator has reached the peer-synchronization barrier in
+  // noMoreInputInternal(), regardless of whether it became the last prober or
+  // suspended waiting for peers. Used by close() to decide whether to disarm
+  // the barrier: only operators that close without ever reaching the barrier
+  // need to disarm it, because peers already there (or about to arrive) would
+  // otherwise wait for a count this operator will never contribute.
+  bool barrierReached_{false};
+
   std::unique_ptr<HashLookup> lookup_;
 
   // Channel of probe keys in 'input_'.

--- a/velox/exec/NestedLoopJoinProbe.cpp
+++ b/velox/exec/NestedLoopJoinProbe.cpp
@@ -164,6 +164,12 @@ BlockingReason NestedLoopJoinProbe::isBlocked(ContinueFuture* future) {
 }
 
 void NestedLoopJoinProbe::close() {
+  // Disarm the peer-synchronization barrier so that any peer drivers
+  // waiting at, or about to reach, the barrier proceed without blocking.
+  // This prevents kWaitForPeers deadlock when this driver terminates
+  // without first running noMoreInput() (i.e., the barrier counter for
+  // this driver is never incremented).
+  operatorCtx_->task()->releasePeerBarrier(splitGroupId(), planNodeId());
   if (joinCondition_ != nullptr) {
     joinCondition_->clear();
   }
@@ -770,8 +776,21 @@ void NestedLoopJoinProbe::beginBuildMismatch() {
   // this code will survive and move on to process build mismatches.
   std::vector<ContinuePromise> promises;
   std::vector<std::shared_ptr<Driver>> peers;
+  bool released{false};
   if (!operatorCtx_->task()->allPeersFinished(
-          planNodeId(), operatorCtx_->driver(), &future_, promises, peers)) {
+          planNodeId(),
+          operatorCtx_->driver(),
+          &future_,
+          promises,
+          peers,
+          &released)) {
+    if (released) {
+      // Barrier was disarmed by a peer that closed without reaching it.
+      // Skip build-mismatch output and finish without becoming a last
+      // prober.
+      setState(ProbeOperatorState::kFinish);
+      return;
+    }
     VELOX_CHECK(future_.valid());
     setState(ProbeOperatorState::kWaitForPeers);
     return;

--- a/velox/exec/NestedLoopJoinProbe.cpp
+++ b/velox/exec/NestedLoopJoinProbe.cpp
@@ -164,12 +164,17 @@ BlockingReason NestedLoopJoinProbe::isBlocked(ContinueFuture* future) {
 }
 
 void NestedLoopJoinProbe::close() {
-  // Disarm the peer-synchronization barrier so that any peer drivers
-  // waiting at, or about to reach, the barrier proceed without blocking.
-  // This prevents kWaitForPeers deadlock when this driver terminates
-  // without first running noMoreInput() (i.e., the barrier counter for
-  // this driver is never incremented).
-  operatorCtx_->task()->releasePeerBarrier(splitGroupId(), planNodeId());
+  // Disarm the peer-synchronization barrier only if this operator never
+  // reached it (so its missing arrival would otherwise leave peers in
+  // kWaitForPeers forever). Operators that already participated in the
+  // barrier must not disarm it: doing so would set the released flag on a
+  // barrier that is either still actively counting peers or has already
+  // completed normally, causing future or concurrent allPeersFinished()
+  // callers to skip last-prober work (e.g. RIGHT/FULL outer-join
+  // build-mismatch emission) and silently drop result rows.
+  if (!barrierReached_) {
+    operatorCtx_->task()->releasePeerBarrier(splitGroupId(), planNodeId());
+  }
   if (joinCondition_ != nullptr) {
     joinCondition_->clear();
   }
@@ -784,6 +789,8 @@ void NestedLoopJoinProbe::beginBuildMismatch() {
           promises,
           peers,
           &released)) {
+    // We participated in the barrier, so close() must not disarm it later.
+    barrierReached_ = true;
     if (released) {
       // Barrier was disarmed by a peer that closed without reaching it.
       // Skip build-mismatch output and finish without becoming a last
@@ -796,6 +803,9 @@ void NestedLoopJoinProbe::beginBuildMismatch() {
     return;
   }
 
+  // Last prober: we contributed to the barrier count, so close() must skip
+  // the disarm step that would otherwise poison the released flag.
+  barrierReached_ = true;
   lastProbe_ = true;
 
   // From now on, buildIndex_ is used to indexing into buildMismatched_

--- a/velox/exec/NestedLoopJoinProbe.h
+++ b/velox/exec/NestedLoopJoinProbe.h
@@ -378,6 +378,14 @@ class NestedLoopJoinProbe : public Operator {
   // operator (need to wait until all peers are finished).
   bool lastProbe_{false};
 
+  // True once this operator has reached the peer-synchronization barrier in
+  // beginBuildMismatch(), regardless of whether it became the last prober or
+  // suspended waiting for peers. Used by close() to decide whether to disarm
+  // the barrier: only operators that close without ever reaching the barrier
+  // need to disarm it, because peers already there (or about to arrive) would
+  // otherwise wait for a count this operator will never contribute.
+  bool barrierReached_{false};
+
   // Indicate if the probe side has empty input or not. For the last probe,
   // this indicates if all the probe sides are empty or not. This flag is used
   // for mismatched output producing.

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -2289,7 +2289,8 @@ bool Task::allPeersFinished(
     Driver* caller,
     ContinueFuture* future,
     std::vector<ContinuePromise>& promises,
-    std::vector<std::shared_ptr<Driver>>& peers) {
+    std::vector<std::shared_ptr<Driver>>& peers,
+    bool* released) {
   std::lock_guard<std::timed_mutex> l(mutex_);
   if (exception_) {
     VELOX_FAIL(
@@ -2299,6 +2300,16 @@ bool Task::allPeersFinished(
   const auto splitGroupId = caller->driverCtx()->splitGroupId;
   auto& barriers = splitGroupStates_[splitGroupId].barriers;
   auto& state = barriers[planNodeId];
+
+  // If the barrier has been disarmed by releasePeerBarrier() and the caller
+  // opted into the released contract, report it without setting 'future',
+  // 'peers', or 'promises'. Any suspended peers were already woken by the
+  // releaser. Callers that did not pass 'released' fall through to the
+  // regular peer-counting path for backward compatibility.
+  if (state.released && released != nullptr) {
+    *released = true;
+    return false;
+  }
 
   const auto numPeers = numDrivers(caller->driverCtx()->pipelineId);
   if (++state.numRequested == numPeers) {
@@ -2325,6 +2336,32 @@ bool Task::allPeersFinished(
     *future = state.allPeersFinishedPromises.back().getSemiFuture();
   }
   return false;
+}
+
+void Task::releasePeerBarrier(
+    uint32_t splitGroupId,
+    const core::PlanNodeId& planNodeId) {
+  std::vector<ContinuePromise> promises;
+  {
+    std::lock_guard<std::timed_mutex> l(mutex_);
+    auto groupIt = splitGroupStates_.find(splitGroupId);
+    if (groupIt == splitGroupStates_.end()) {
+      return;
+    }
+    // Create the barrier in the 'released' state if no peer has reached it
+    // yet, so any future caller of allPeersFinished() bypasses blocking.
+    auto& state = groupIt->second.barriers[planNodeId];
+    if (state.released) {
+      return;
+    }
+    state.released = true;
+    promises = std::move(state.allPeersFinishedPromises);
+  }
+  // Fulfill pending peer promises outside the lock to avoid re-entrancy via
+  // promise continuations.
+  for (auto& promise : promises) {
+    promise.setValue();
+  }
 }
 
 void Task::addHashJoinBridgesLocked(

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -539,12 +539,38 @@ class Task : public std::enable_shared_from_this<Task> {
   /// NOTE: The last peer (the one that got 'true' returned and a bunch of
   /// promises) is responsible for promises' fulfillment even in case of an
   /// exception!
+  ///
+  /// If 'released' is non-null and the barrier has been disarmed by an
+  /// earlier call to releasePeerBarrier(), '*released' is set to true and the
+  /// function returns false without setting 'future', 'peers', or 'promises'.
+  /// The caller must treat this case as "skip last-peer work and finish"
+  /// rather than as "wait for peers". When 'released' is null, the released
+  /// state is ignored and the regular peer-counting behavior is used; in
+  /// that case the caller must not rely on the released semantics.
   bool allPeersFinished(
       const core::PlanNodeId& planNodeId,
       Driver* caller,
       ContinueFuture* future,
       std::vector<ContinuePromise>& promises,
-      std::vector<std::shared_ptr<Driver>>& peers);
+      std::vector<std::shared_ptr<Driver>>& peers,
+      bool* released = nullptr);
+
+  /// Disarms the peer-synchronization barrier for the operator identified by
+  /// 'planNodeId' in 'splitGroupId' and fulfills any promises held by peers
+  /// already suspended on the barrier. Subsequent callers of
+  /// allPeersFinished() for the same barrier that pass a non-null 'released'
+  /// out-parameter receive '*released = true' and return value false (i.e.,
+  /// they are not treated as the "last" peer and they do not wait).
+  ///
+  /// Intended for operators that participate in a peer barrier but may have
+  /// their driver closed before reaching the barrier (e.g., when a
+  /// downstream operator finishes the pipeline early). Without a release,
+  /// peers already suspended at the barrier would wait forever for a count
+  /// that can never be reached. The call is idempotent and may be made
+  /// whether or not the barrier has been created.
+  void releasePeerBarrier(
+      uint32_t splitGroupId,
+      const core::PlanNodeId& planNodeId);
 
   /// Adds HashJoinBridge's for all the specified plan node IDs.
   void addHashJoinBridgesLocked(

--- a/velox/exec/TaskStructs.h
+++ b/velox/exec/TaskStructs.h
@@ -66,6 +66,12 @@ struct BarrierState {
   /// operator does that). After the last drier done its work, the promises are
   /// fulfilled and the non-last drivers can continue.
   std::vector<ContinuePromise> allPeersFinishedPromises;
+  /// Indicates whether this barrier has been disarmed by
+  /// Task::releasePeerBarrier(). When true, callers of
+  /// Task::allPeersFinished() that opt into the released contract receive
+  /// the released signal and return false: none is treated as the "last"
+  /// peer and none waits.
+  bool released{false};
 };
 
 using ConnectorSplitPreloadFunc =

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -1809,5 +1809,91 @@ VELOX_INSTANTIATE_TEST_SUITE_P(
       return TestParamToName(info.param);
     });
 
+// Non-parameterized fixture for regression tests that build their own plan
+// via PlanBuilder/TaskCursor rather than HashJoinBuilder.
+class HashJoinPeerBarrierDeadlockTest : public HiveConnectorTestBase {};
+
+// Verifies that a multi-driver HashProbe (RIGHT JOIN with parallel build-row
+// output enabled) does not deadlock when one driver is closed via an
+// early-terminating downstream Limit while peer drivers are still
+// approaching the peer barrier in HashProbe::noMoreInputInternal.
+//
+// Setup:
+//   - 4 drivers on the probe pipeline.
+//   - All probe rows share a single key value, so localPartition delivers
+//     every probe row to exactly one driver. The other three drivers
+//     receive no probe rows.
+//   - parallel_output_join_build_rows_enabled = true so HashProbe enters
+//     Task::allPeersFinished for RIGHT JOIN.
+//   - A per-driver Limit(1) immediately follows the join. The loaded
+//     driver hits Limit and closes without ever calling noMoreInput() on
+//     the probe operator, so its barrier counter is never incremented.
+//
+// Without the fix, the three empty drivers transition to kWaitForPeers and
+// block forever on a count that can never reach 4. The test uses an
+// external timeout to detect the hang.
+TEST_F(HashJoinPeerBarrierDeadlockTest, earlyLimitPeerBarrierDeadlock) {
+  const int kProbeRows = 32;
+  std::vector<RowVectorPtr> probeVectors = {
+      makeRowVector(
+          {"t0"},
+          {makeFlatVector<int64_t>(
+              kProbeRows, [](auto /*row*/) { return 1; })}),
+  };
+  // Build has matching (u0 == 1) and non-matching rows so RIGHT JOIN must
+  // emit build-mismatch rows, which is what drives the peer barrier when
+  // combined with parallel build-row output.
+  std::vector<RowVectorPtr> buildVectors = {
+      makeRowVector({"u0"}, {makeFlatVector<int64_t>({1, 2, 3})}),
+  };
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  CursorParameters params;
+  params.maxDrivers = 4;
+  params.queryCtx = core::QueryCtx::create(executor_.get());
+  // Force per-row output so Limit fires on the very first matched row.
+  params.queryConfigs[core::QueryConfig::kPreferredOutputBatchRows] = "1";
+  params.queryConfigs[core::QueryConfig::kParallelOutputJoinBuildRowsEnabled] =
+      "true";
+  params.planNode =
+      PlanBuilder(planNodeIdGenerator)
+          .values(probeVectors)
+          .localPartition({"t0"})
+          .hashJoin(
+              {"t0"},
+              {"u0"},
+              PlanBuilder(planNodeIdGenerator)
+                  .values(buildVectors)
+                  .localPartition({})
+                  .planNode(),
+              "",
+              {"t0", "u0"},
+              core::JoinType::kRight)
+          .limit(0, 1, /*isPartial=*/true)
+          .planNode();
+  auto cursor = TaskCursor::create(params);
+  auto task = cursor->task();
+  std::atomic<bool> done{false};
+  std::thread runner([&] {
+    while (cursor->moveNext()) {
+      // Drain results.
+    }
+    done.store(true);
+  });
+  const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(15);
+  while (!done.load() && std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  const bool deadlocked = !done.load();
+  if (deadlocked) {
+    // Force the task down so the cursor thread can exit.
+    task->requestCancel();
+  }
+  runner.join();
+  ASSERT_FALSE(deadlocked)
+      << "HashProbe peer barrier deadlock: task state at detection: "
+      << taskStateString(task->state());
+}
+
 } // namespace
 } // namespace facebook::velox::exec

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -1854,22 +1854,21 @@ TEST_F(HashJoinPeerBarrierDeadlockTest, earlyLimitPeerBarrierDeadlock) {
   params.queryConfigs[core::QueryConfig::kPreferredOutputBatchRows] = "1";
   params.queryConfigs[core::QueryConfig::kParallelOutputJoinBuildRowsEnabled] =
       "true";
-  params.planNode =
-      PlanBuilder(planNodeIdGenerator)
-          .values(probeVectors)
-          .localPartition({"t0"})
-          .hashJoin(
-              {"t0"},
-              {"u0"},
-              PlanBuilder(planNodeIdGenerator)
-                  .values(buildVectors)
-                  .localPartition({})
-                  .planNode(),
-              "",
-              {"t0", "u0"},
-              core::JoinType::kRight)
-          .limit(0, 1, /*isPartial=*/true)
-          .planNode();
+  params.planNode = PlanBuilder(planNodeIdGenerator)
+                        .values(probeVectors)
+                        .localPartition({"t0"})
+                        .hashJoin(
+                            {"t0"},
+                            {"u0"},
+                            PlanBuilder(planNodeIdGenerator)
+                                .values(buildVectors)
+                                .localPartition({})
+                                .planNode(),
+                            "",
+                            {"t0", "u0"},
+                            core::JoinType::kRight)
+                        .limit(0, 1, /*isPartial=*/true)
+                        .planNode();
   auto cursor = TaskCursor::create(params);
   auto task = cursor->task();
   std::atomic<bool> done{false};

--- a/velox/exec/tests/NestedLoopJoinTest.cpp
+++ b/velox/exec/tests/NestedLoopJoinTest.cpp
@@ -1043,20 +1043,19 @@ TEST_F(NestedLoopJoinTest, earlyLimitPeerBarrierDeadlock) {
   params.queryCtx = core::QueryCtx::create(executor_.get());
   // Force per-row output so Limit fires on the very first matched row.
   params.queryConfigs[core::QueryConfig::kPreferredOutputBatchRows] = "1";
-  params.planNode =
-      PlanBuilder(planNodeIdGenerator)
-          .values(probeVectors)
-          .localPartition({"t0"})
-          .nestedLoopJoin(
-              PlanBuilder(planNodeIdGenerator)
-                  .values(buildVectors)
-                  .localPartition({})
-                  .planNode(),
-              "t0 = u0",
-              {"t0", "u0"},
-              core::JoinType::kRight)
-          .limit(0, 1, /*isPartial=*/true)
-          .planNode();
+  params.planNode = PlanBuilder(planNodeIdGenerator)
+                        .values(probeVectors)
+                        .localPartition({"t0"})
+                        .nestedLoopJoin(
+                            PlanBuilder(planNodeIdGenerator)
+                                .values(buildVectors)
+                                .localPartition({})
+                                .planNode(),
+                            "t0 = u0",
+                            {"t0", "u0"},
+                            core::JoinType::kRight)
+                        .limit(0, 1, /*isPartial=*/true)
+                        .planNode();
   auto cursor = TaskCursor::create(params);
   auto task = cursor->task();
   std::atomic<bool> done{false};

--- a/velox/exec/tests/NestedLoopJoinTest.cpp
+++ b/velox/exec/tests/NestedLoopJoinTest.cpp
@@ -1006,5 +1006,82 @@ DEBUG_ONLY_TEST_F(NestedLoopJoinTest, longBatchDurationYield) {
       testSettings[0].numGetOutputCalls, testSettings[1].numGetOutputCalls);
 }
 
+// Verifies that a multi-driver NestedLoopJoinProbe (RIGHT JOIN with a
+// non-empty build) does not deadlock when one driver is closed via an
+// early-terminating downstream Limit while peer drivers are still
+// approaching the build-mismatch peer barrier.
+//
+// Setup:
+//   - 4 drivers on the probe pipeline.
+//   - All probe rows share a single key value, so localPartition delivers
+//     every probe row to exactly one driver. The other three drivers
+//     receive no probe rows.
+//   - A per-driver Limit(1) immediately follows the join. The loaded
+//     driver hits Limit and closes without ever calling noMoreInput() on
+//     the probe operator, so its barrier counter is never incremented.
+//
+// Without the fix, the three empty drivers reach beginBuildMismatch ->
+// Task::allPeersFinished, transition to kWaitForPeers, and block forever
+// on a count that can never reach 4. The test uses an external timeout to
+// detect the hang.
+TEST_F(NestedLoopJoinTest, earlyLimitPeerBarrierDeadlock) {
+  const int kProbeRows = 32;
+  std::vector<RowVectorPtr> probeVectors = {
+      makeRowVector(
+          {"t0"},
+          {makeFlatVector<int64_t>(
+              kProbeRows, [](auto /*row*/) { return 1; })}),
+  };
+  // Build has matching (u0 == 1) and non-matching rows so RIGHT JOIN must
+  // emit build-mismatch rows, which is what drives the peer barrier.
+  std::vector<RowVectorPtr> buildVectors = {
+      makeRowVector({"u0"}, {makeFlatVector<int64_t>({1, 2, 3})}),
+  };
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  CursorParameters params;
+  params.maxDrivers = 4;
+  params.queryCtx = core::QueryCtx::create(executor_.get());
+  // Force per-row output so Limit fires on the very first matched row.
+  params.queryConfigs[core::QueryConfig::kPreferredOutputBatchRows] = "1";
+  params.planNode =
+      PlanBuilder(planNodeIdGenerator)
+          .values(probeVectors)
+          .localPartition({"t0"})
+          .nestedLoopJoin(
+              PlanBuilder(planNodeIdGenerator)
+                  .values(buildVectors)
+                  .localPartition({})
+                  .planNode(),
+              "t0 = u0",
+              {"t0", "u0"},
+              core::JoinType::kRight)
+          .limit(0, 1, /*isPartial=*/true)
+          .planNode();
+  auto cursor = TaskCursor::create(params);
+  auto task = cursor->task();
+  std::atomic<bool> done{false};
+  std::thread runner([&] {
+    while (cursor->moveNext()) {
+      // Drain results.
+    }
+    done.store(true);
+  });
+  const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(15);
+  while (!done.load() && std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  const bool deadlocked = !done.load();
+  if (deadlocked) {
+    // Force the task down so the cursor thread can exit.
+    task->requestCancel();
+  }
+  runner.join();
+  ASSERT_FALSE(deadlocked)
+      << "NestedLoopJoinProbe peer barrier deadlock: task state at "
+         "detection: "
+      << taskStateString(task->state());
+}
+
 } // namespace
 } // namespace facebook::velox::exec::test


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                          
                                         
  In a multi-driver pipeline, `HashProbe` and `NestedLoopJoinProbe` deadlock at the `Task::allPeersFinished` peer barrier when one driver is closed by a downstream operator (e.g. `Limit`) before its
   probe reaches `noMoreInput()`. The barrier counter is only incremented from `noMoreInput()`, so the early-closed driver never arrives, the remaining peers transition to `kWaitForPeers`, and the
  task hangs forever.                                                                                                                                                                                 
                                                            
  This PR introduces an opt-in "release" mechanism that lets a probe operator's `close()` disarm the barrier, wake any suspended peers, and let subsequent arrivals skip last-peer work cleanly. The  
  disarm is gated so that only operators that close without ever reaching the barrier trigger it.
                                                                                                                                                                                                      
  ## Reproduction                                           

  Required to trigger:
  1. `numDrivers >= 2` on the probe pipeline.
  2. Probe operator enters the peer barrier — `NestedLoopJoinProbe` RIGHT/FULL JOIN with non-empty build, or `HashProbe` with `parallel_output_join_build_rows_enabled = true` / spill enabled.       
  3. A per-driver downstream operator (typically `Limit`) that finishes the pipeline early.                                                                                                           
  4. Data distribution where one driver hits early-termination while others are still draining.                                                                                                       
                                                                                                                                                                                                      
  New regression tests (15s watchdog; hang without the fix, complete in ms with it):                                                                                                                  
  - `NestedLoopJoinTest.earlyLimitPeerBarrierDeadlock`                                                                                                                                                
  - `HashJoinPeerBarrierDeadlockTest.earlyLimitPeerBarrierDeadlock`                                                                                                                                   
                                                                                                                                                                                                      
  ## Implementation                                                                                                                                                                                   
                                                                                                                                                                                                      
  **`Task::releasePeerBarrier(splitGroupId, planNodeId)`** marks the barrier disarmed, fulfills any suspended peers' promises (outside the lock), and is idempotent.                                  
                                                            
  **`Task::allPeersFinished`** gains an optional `bool* released = nullptr`. When the barrier is disarmed and the caller opts in, it returns `false` with `*released = true` and does not set         
  `future`/`peers`/`promises`. The caller treats this as "skip last-peer work and finish". Returning `true` instead would let every post-release driver redundantly run last-prober code
  (`resetUnclaimedRowContainerId`, `wakeupPeerOperators`) and race on the build-side row container id allocator.                                                                                      
                                                            
  **Callers updated:**
  - `HashProbe::close()` and `NestedLoopJoinProbe::close()` invoke `releasePeerBarrier()` **only when the operator did not participate in the barrier**, tracked via a `barrierReached_` flag set in
  both branches of the barrier callsite.                                                                                                                                                              
  - `HashProbe::noMoreInputInternal()` and `NestedLoopJoinProbe::beginBuildMismatch()` opt into the released contract and transition to `kFinish` on the released signal.

  **Backward compatibility:** `released == nullptr` is the default; build-side operators (`HashBuild`, `NestedLoopJoinBuild`, `SpatialJoinBuild`) and experimental callers in `cudf/` and `wave/` are 
  unchanged. Build operators are pipeline sinks and cannot be closed early.
                                                                                                                                                                                                      
  ## Semantic trade-off                                     

  When the barrier is disarmed before any peer reaches it, RIGHT/FULL mismatch rows from those peers are not emitted. This is acceptable because the disarm is triggered by an early-terminating      
  downstream operator that has already satisfied the result; those rows would be discarded anyway. **The trade-off applies only to the early-terminating path** — drivers that complete normally still
   contribute their share of mismatch rows because `close()` no longer disarms after the barrier has been reached.                                                                                    
                                                            
  For `HashProbe`, peers already suspended on the barrier are still woken and participate in build-side parallel output via the existing atomic `getAndIncrementUnclaimedRowContainerId` coordination,
   so partial mismatch output is preserved when at least one peer arrives before the disarm.
                                                                                                                                                                                                      