### PR TITLE
fix(spark): Fix integer overflow in Spark repeat function

### DIFF
--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -1299,13 +1299,13 @@ struct RepeatFunction {
 
   FOLLY_ALWAYS_INLINE void
   call(out_type<Varchar>& result, const arg_type<Varchar>& input, int32_t n) {
-    static constexpr size_t resultMaxSize = 1024 * 1024; // 1MB
+    static constexpr int64_t resultMaxSize = 1024 * 1024; // 1MB
     auto inputSize = input.size();
     if (inputSize == 0 || n <= 0) {
       result.resize(0);
       return;
     }
-    int32_t newSize = velox::checkedMultiply<int32_t>(inputSize, n);
+    int64_t newSize = static_cast<int64_t>(inputSize) * n;
     VELOX_USER_CHECK_LE(
         newSize,
         resultMaxSize,

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -544,7 +544,7 @@ TEST_F(StringTest, repeat) {
       "Result size must be less than or equal to 1048576");
   VELOX_ASSERT_USER_THROW(
       stringRepeat(std::string(214749, 'l'), 10000),
-      "integer overflow: 214749 * 10000");
+      "Result size must be less than or equal to 1048576");
 }
 
 TEST_F(StringTest, replace) {


### PR DESCRIPTION
Fixes the Spark `repeat` string function throwing `ARITHMETIC_ERROR` (integer overflow)
  instead of the intended result-size user error when `inputSize * n` overflows `int32_t`.

  The root cause is that `checkedMultiply<int32_t>` throws before the existing 1MB size
  check can run. The fix widens the multiplication to `int64_t`, which cannot overflow
  for two `int32_t` operands, letting the `VELOX_USER_CHECK_LE` handle all too-large
  inputs with a clean error message.

  Fixes #15576
