### PR TITLE
feat(parquet): Read columns by field ID

### DIFF
--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -172,11 +172,20 @@ std::vector<dwio::common::ParquetFieldId> IcebergSplitReader::buildFieldIds()
   // Column handles are keyed by output alias; index them by the underlying
   // data-column name so we can align to dataColumns() order.
   std::unordered_map<std::string, const IcebergColumnHandle*> handleByName;
-  for (const auto& [outputName, handle] : *columnHandles_) {
+  const auto addIcebergHandle = [&handleByName](const auto& handle) {
     if (auto* icebergHandle =
             dynamic_cast<const IcebergColumnHandle*>(handle.get())) {
       handleByName.emplace(icebergHandle->name(), icebergHandle);
     }
+  };
+  for (const auto& columnHandle : *columnHandles_) {
+    addIcebergHandle(columnHandle.second);
+  }
+  // Remaining filters can add columns to the reader output that are not
+  // projected by the table scan. Include those handles so filter-only columns
+  // are still matched by Iceberg field ID.
+  for (const auto& handle : tableHandle_->filterColumnHandles()) {
+    addIcebergHandle(handle);
   }
   if (handleByName.empty()) {
     return fieldIds;

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -144,7 +144,7 @@ void IcebergSplitReader::configureBaseReaderOptions() {
     if (!fieldIds.empty()) {
       baseReaderOpts_.setColumnMappingMode(
           dwio::common::ColumnMappingMode::kParquetFieldId);
-      baseReaderOpts_.setParquetFieldIds(std::move(fieldIds));
+      baseReaderOpts_.setFieldIds(std::move(fieldIds));
     }
     return;
   }

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -139,10 +139,18 @@ IcebergSplitReader::IcebergSplitReader(
 void IcebergSplitReader::configureBaseReaderOptions() {
   FileSplitReader::configureBaseReaderOptions();
   const auto fileFormat = fileSplit_->fileFormat;
+  if (fileFormat == dwio::common::FileFormat::PARQUET) {
+    auto fieldIds = buildFieldIds();
+    if (!fieldIds.empty()) {
+      baseReaderOpts_.setColumnMappingMode(
+          dwio::common::ColumnMappingMode::kParquetFieldId);
+      baseReaderOpts_.setParquetFieldIds(std::move(fieldIds));
+    }
+    return;
+  }
+
   if (fileFormat != dwio::common::FileFormat::DWRF &&
       fileFormat != dwio::common::FileFormat::ORC) {
-    // Parquet resolves field ids from physical metadata, not from the
-    // attribute-based kFieldId path.
     return;
   }
   auto fieldIds = buildFieldIds();

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.h
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.h
@@ -65,9 +65,10 @@ class IcebergSplitReader : public FileSplitReader {
   void configureBaseReaderOptions() override;
 
   // Builds the requested-schema field-id trees, one per top-level column,
-  // aligned to tableHandle_->dataColumns(). Data columns without an Iceberg
-  // handle (e.g. unprojected) get a negative sentinel id that matches no
-  // physical field. Returns empty when no Iceberg handles are available.
+  // aligned to tableHandle_->dataColumns(). Projected and filter-only Iceberg
+  // handles provide field IDs. Data columns without an Iceberg handle get a
+  // negative sentinel id that matches no physical field. Returns empty when no
+  // Iceberg handles are available.
   std::vector<dwio::common::ParquetFieldId> buildFieldIds() const;
 
   /// Adapts the data file schema to match the table schema expected by the

--- a/velox/connectors/hive/iceberg/tests/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/tests/CMakeLists.txt
@@ -156,9 +156,7 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
       velox_dwio_parquet_reader
       velox_dwio_parquet_writer
     )
-  endif()
 
-  if(VELOX_ENABLE_PARQUET)
     target_link_libraries(
       velox_hive_iceberg_test
       velox_dwio_parquet_reader

--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -67,16 +67,88 @@ class IcebergReadTest : public test::IcebergTestBase {
   std::shared_ptr<IcebergColumnHandle> makeIcebergHandle(
       const std::string& name,
       const TypePtr& type,
-      int fieldId,
-      std::optional<std::string> defaultValue = std::nullopt) {
+      parquet::ParquetFieldId fieldId,
+      std::optional<std::string> defaultValue = std::nullopt,
+      std::vector<common::Subfield> requiredSubfields = {}) {
     return std::make_shared<IcebergColumnHandle>(
         name,
         HiveColumnHandle::ColumnType::kRegular,
         type,
-        parquet::ParquetFieldId{fieldId, {}},
-        std::vector<common::Subfield>{},
+        std::move(fieldId),
+        std::move(requiredSubfields),
         defaultValue);
   }
+
+  std::shared_ptr<IcebergColumnHandle> makeIcebergHandle(
+      const std::string& name,
+      const TypePtr& type,
+      int fieldId,
+      std::optional<std::string> defaultValue = std::nullopt) {
+    return makeIcebergHandle(
+        name, type, parquet::ParquetFieldId{fieldId, {}}, defaultValue);
+  }
+
+#ifdef VELOX_ENABLE_PARQUET
+  parquet::ParquetFieldId makeFieldId(int32_t fieldId) {
+    return parquet::ParquetFieldId{fieldId, {}};
+  }
+
+  parquet::ParquetFieldId makeFieldId(
+      int32_t fieldId,
+      std::vector<parquet::ParquetFieldId> children) {
+    return parquet::ParquetFieldId{fieldId, std::move(children)};
+  }
+
+  struct FieldIdColumnSpec {
+    std::string outputName;
+    std::string dataName;
+    TypePtr type;
+    parquet::ParquetFieldId fieldId;
+    std::vector<std::string> requiredSubfields;
+  };
+
+  ColumnHandleMap makeFieldIdAssignments(
+      const std::vector<FieldIdColumnSpec>& columns) {
+    ColumnHandleMap assignments;
+    for (const auto& column : columns) {
+      std::vector<common::Subfield> requiredSubfields;
+      requiredSubfields.reserve(column.requiredSubfields.size());
+      for (const auto& subfield : column.requiredSubfields) {
+        requiredSubfields.emplace_back(subfield);
+      }
+      assignments[column.outputName] = makeIcebergHandle(
+          column.dataName,
+          column.type,
+          column.fieldId,
+          std::nullopt,
+          std::move(requiredSubfields));
+    }
+    return assignments;
+  }
+
+  void assertParquetFieldIdRead(
+      const std::string& outputDirectory,
+      const RowTypePtr& outputType,
+      const RowTypePtr& scanSpecType,
+      const std::vector<FieldIdColumnSpec>& columns,
+      const std::vector<RowVectorPtr>& expected,
+      const std::optional<std::string>& subfieldFilter = std::nullopt) {
+    exec::test::PlanBuilder planBuilder;
+    auto& tableScanBuilder = planBuilder.startTableScan()
+                                 .connectorId(test::kIcebergConnectorId)
+                                 .outputType(outputType)
+                                 .dataColumns(scanSpecType)
+                                 .assignments(makeFieldIdAssignments(columns));
+    if (subfieldFilter.has_value()) {
+      tableScanBuilder.subfieldFilter(*subfieldFilter);
+    }
+    auto plan = tableScanBuilder.endTableScan().planNode();
+
+    exec::test::AssertQueryBuilder(plan)
+        .splits(createSplitsForDirectory(outputDirectory))
+        .assertResults(expected);
+  }
+#endif
 
   void assertDefaultValues(
       const RowTypePtr& outputType,
@@ -275,6 +347,299 @@ TEST_F(IcebergReadTest, schemaEvolutionAddColumns) {
       .splits(makeIcebergSplits(dataFilePath->getPath()))
       .assertResults(expectedVectors);
 }
+
+#ifdef VELOX_ENABLE_PARQUET
+TEST_F(IcebergReadTest, readParquetSchemaEvolutionByFieldId) {
+  fileFormat_ = dwio::common::FileFormat::PARQUET;
+
+  const auto writeType =
+      ROW({"id", "flag", "status"}, {BIGINT(), BOOLEAN(), VARCHAR()});
+  const std::vector<RowVectorPtr> data{makeRowVector(
+      writeType->names(),
+      {makeFlatVector<int64_t>({10, 20, 30}),
+       makeFlatVector<bool>({true, false, true}),
+       makeFlatVector<std::string>({"old-a", "old-b", "old-c"})})};
+  const auto outputDirectory = test::TempDirectoryPath::create();
+  {
+    const auto dataSink =
+        createDataSinkAndAppendData(data, outputDirectory->getPath());
+    dataSink->close();
+  }
+
+  struct ReadCase {
+    std::string name;
+    RowTypePtr outputType;
+    RowTypePtr scanSpecType;
+    std::vector<FieldIdColumnSpec> columns;
+    RowVectorPtr expected;
+  };
+
+  const std::vector<ReadCase> cases{
+      {
+          "rename and reorder columns",
+          ROW({"enabled", "id"}, {BOOLEAN(), BIGINT()}),
+          ROW({"id", "flag", "status"}, {BIGINT(), BOOLEAN(), VARCHAR()}),
+          {
+              {"id", "id", BIGINT(), makeFieldId(1)},
+              {"enabled", "flag", BOOLEAN(), makeFieldId(2)},
+              {"status", "status", VARCHAR(), makeFieldId(3)},
+          },
+          makeRowVector(
+              {"enabled", "id"},
+              {makeFlatVector<bool>({true, false, true}),
+               makeFlatVector<int64_t>({10, 20, 30})}),
+      },
+      {
+          "add column",
+          ROW({"id", "flag", "status", "score"},
+              {BIGINT(), BOOLEAN(), VARCHAR(), INTEGER()}),
+          ROW({"id", "flag", "status", "score"},
+              {BIGINT(), BOOLEAN(), VARCHAR(), INTEGER()}),
+          {
+              {"id", "id", BIGINT(), makeFieldId(1)},
+              {"flag", "flag", BOOLEAN(), makeFieldId(2)},
+              {"status", "status", VARCHAR(), makeFieldId(3)},
+              {"score", "score", INTEGER(), makeFieldId(4)},
+          },
+          makeRowVector(
+              {"id", "flag", "status", "score"},
+              {makeFlatVector<int64_t>({10, 20, 30}),
+               makeFlatVector<bool>({true, false, true}),
+               makeFlatVector<std::string>({"old-a", "old-b", "old-c"}),
+               makeNullableFlatVector<int32_t>(
+                   {std::nullopt, std::nullopt, std::nullopt})}),
+      },
+      {
+          "delete column",
+          ROW({"id", "status"}, {BIGINT(), VARCHAR()}),
+          ROW({"id", "status"}, {BIGINT(), VARCHAR()}),
+          {
+              {"id", "id", BIGINT(), makeFieldId(1)},
+              {"status", "status", VARCHAR(), makeFieldId(3)},
+          },
+          makeRowVector(
+              {"id", "status"},
+              {makeFlatVector<int64_t>({10, 20, 30}),
+               makeFlatVector<std::string>({"old-a", "old-b", "old-c"})}),
+      },
+      {
+          "project only added column",
+          ROW({"score"}, {INTEGER()}),
+          ROW({"score"}, {INTEGER()}),
+          {
+              {"score", "score", INTEGER(), makeFieldId(4)},
+          },
+          makeRowVector(
+              {"score"},
+              {makeNullableFlatVector<int32_t>(
+                  {std::nullopt, std::nullopt, std::nullopt})}),
+      },
+      {
+          "delete and add back column with same name but different type",
+          ROW({"id", "status"}, {BIGINT(), BOOLEAN()}),
+          ROW({"id", "status"}, {BIGINT(), BOOLEAN()}),
+          {
+              {"id", "id", BIGINT(), makeFieldId(1)},
+              {"status", "status", BOOLEAN(), makeFieldId(4)},
+          },
+          makeRowVector(
+              {"id", "status"},
+              {makeFlatVector<int64_t>({10, 20, 30}),
+               makeNullableFlatVector<bool>(
+                   {std::nullopt, std::nullopt, std::nullopt})}),
+      },
+  };
+
+  for (const auto& readCase : cases) {
+    SCOPED_TRACE(readCase.name);
+    assertParquetFieldIdRead(
+        outputDirectory->getPath(),
+        readCase.outputType,
+        readCase.scanSpecType,
+        readCase.columns,
+        {readCase.expected});
+  }
+
+  const auto addressWriteType = ROW({"city", "zip"}, {VARCHAR(), VARCHAR()});
+  const auto profileWriteType =
+      ROW({"name", "address"}, {VARCHAR(), addressWriteType});
+  const auto profileWriteData = makeRowVector(
+      profileWriteType->names(),
+      {makeFlatVector<std::string>({"Ada", "Ben", "Cy"}),
+       makeRowVector(
+           addressWriteType->names(),
+           {makeFlatVector<std::string>({"New York", "Boston", "New York"}),
+            makeFlatVector<std::string>({"10001", "02108", "10001"})})});
+  const auto profileTableType = ROW({"profile"}, {profileWriteType});
+  const std::vector<RowVectorPtr> profileData{
+      makeRowVector(profileTableType->names(), {profileWriteData})};
+  const auto profileOutputDirectory = test::TempDirectoryPath::create();
+  {
+    const auto profileDataSink = createDataSinkAndAppendData(
+        profileData, profileOutputDirectory->getPath());
+    profileDataSink->close();
+  }
+  common::SubfieldFilters profileFilters;
+  profileFilters.emplace(
+      common::Subfield("profile.address.zip"),
+      std::make_shared<common::BytesRange>(
+          "10001", false, false, "10001", false, false, false));
+  exec::test::PlanBuilder profilePlanBuilder;
+  auto& profileTableScanBuilder =
+      profilePlanBuilder.startTableScan()
+          .connectorId(test::kIcebergConnectorId)
+          .outputType(profileTableType)
+          .dataColumns(profileTableType)
+          .assignments(makeFieldIdAssignments({
+              {"profile",
+               "profile",
+               profileWriteType,
+               makeFieldId(
+                   1,
+                   {makeFieldId(2),
+                    makeFieldId(3, {makeFieldId(4), makeFieldId(5)})}),
+               {"profile.name", "profile.address.city"}},
+          }))
+          .subfieldFiltersMap(profileFilters);
+  auto profilePlan = profileTableScanBuilder.endTableScan()
+                         .project({"profile.name as name", "profile.address"})
+                         .project({"name", "address.city"})
+                         .planNode();
+  exec::test::AssertQueryBuilder(profilePlan)
+      .splits(createSplitsForDirectory(profileOutputDirectory->getPath()))
+      .assertResults({makeRowVector(
+          {makeFlatVector<std::string>({"Ada", "Cy"}),
+           makeFlatVector<std::string>({"New York", "New York"})})});
+
+  const auto nestedWriteType =
+      ROW({"items"}, {ARRAY(ROW({"name", "quantity"}, {VARCHAR(), BIGINT()}))});
+  const auto nestedElements = makeRowVector(
+      {"name", "quantity"},
+      {makeFlatVector<std::string>({"apple", "banana", "pear"}),
+       makeFlatVector<int64_t>({5, 7, 11})});
+  const std::vector<RowVectorPtr> nestedData{makeRowVector(
+      nestedWriteType->names(), {makeArrayVector({0, 2}, nestedElements)})};
+  const auto nestedOutputDirectory = test::TempDirectoryPath::create();
+  {
+    const auto nestedDataSink = createDataSinkAndAppendData(
+        nestedData, nestedOutputDirectory->getPath());
+    nestedDataSink->close();
+  }
+
+  const auto nestedReadType =
+      ROW({"items"}, {ARRAY(ROW({"amount", "label"}, {BIGINT(), VARCHAR()}))});
+  const auto nestedExpectedElements = makeRowVector(
+      {"amount", "label"},
+      {makeFlatVector<int64_t>({5, 7, 11}),
+       makeFlatVector<std::string>({"apple", "banana", "pear"})});
+  auto nestedExpected = makeRowVector(
+      nestedReadType->names(),
+      {makeArrayVector({0, 2}, nestedExpectedElements)});
+
+  assertParquetFieldIdRead(
+      nestedOutputDirectory->getPath(),
+      nestedReadType,
+      nestedReadType,
+      {
+          {"items",
+           "items",
+           nestedReadType->childAt(0),
+           makeFieldId(1, {makeFieldId(2, {makeFieldId(4), makeFieldId(3)})})},
+      },
+      {nestedExpected});
+
+  const auto nestedProjectedReadType =
+      ROW({"items"}, {ARRAY(ROW({"amount"}, {BIGINT()}))});
+  const auto nestedProjectedElements =
+      makeRowVector({"amount"}, {makeFlatVector<int64_t>({5, 7, 11})});
+  auto nestedProjectedExpected = makeRowVector(
+      nestedProjectedReadType->names(),
+      {makeArrayVector({0, 2}, nestedProjectedElements)});
+  assertParquetFieldIdRead(
+      nestedOutputDirectory->getPath(),
+      nestedProjectedReadType,
+      nestedProjectedReadType,
+      {
+          {"items",
+           "items",
+           nestedProjectedReadType->childAt(0),
+           makeFieldId(1, {makeFieldId(2, {makeFieldId(4)})})},
+      },
+      {nestedProjectedExpected});
+
+  const auto mapValueWriteType = ROW({"name", "score"}, {VARCHAR(), BIGINT()});
+  const auto mapWriteType =
+      ROW({"attributes"}, {MAP(VARCHAR(), mapValueWriteType)});
+  const auto mapValueElements = makeRowVector(
+      mapValueWriteType->names(),
+      {makeFlatVector<std::string>({"silver", "gold"}),
+       makeFlatVector<int64_t>({11, 17})});
+  const std::vector<RowVectorPtr> mapData{makeRowVector(
+      mapWriteType->names(),
+      {makeMapVector(
+          {0, 1},
+          makeFlatVector<std::string>({"left", "right"}),
+          mapValueElements)})};
+  const auto mapOutputDirectory = test::TempDirectoryPath::create();
+  {
+    const auto mapDataSink =
+        createDataSinkAndAppendData(mapData, mapOutputDirectory->getPath());
+    mapDataSink->close();
+  }
+
+  const auto mapValueReadType = ROW({"points", "label"}, {BIGINT(), VARCHAR()});
+  const auto mapReadType =
+      ROW({"attributes"}, {MAP(VARCHAR(), mapValueReadType)});
+  const auto mapExpectedValues = makeRowVector(
+      mapValueReadType->names(),
+      {makeFlatVector<int64_t>({11, 17}),
+       makeFlatVector<std::string>({"silver", "gold"})});
+  auto mapExpected = makeRowVector(
+      mapReadType->names(),
+      {makeMapVector(
+          {0, 1},
+          makeFlatVector<std::string>({"left", "right"}),
+          mapExpectedValues)});
+
+  assertParquetFieldIdRead(
+      mapOutputDirectory->getPath(),
+      mapReadType,
+      mapReadType,
+      {
+          {"attributes",
+           "attributes",
+           mapReadType->childAt(0),
+           makeFieldId(
+               1,
+               {makeFieldId(2),
+                makeFieldId(3, {makeFieldId(5), makeFieldId(4)})})},
+      },
+      {mapExpected});
+
+  const auto mapValueProjectedReadType = ROW({"points"}, {BIGINT()});
+  const auto mapProjectedReadType =
+      ROW({"attributes"}, {MAP(VARCHAR(), mapValueProjectedReadType)});
+  const auto mapProjectedExpectedValues =
+      makeRowVector({"points"}, {makeFlatVector<int64_t>({11, 17})});
+  auto mapProjectedExpected = makeRowVector(
+      mapProjectedReadType->names(),
+      {makeMapVector(
+          {0, 1},
+          makeFlatVector<std::string>({"left", "right"}),
+          mapProjectedExpectedValues)});
+  assertParquetFieldIdRead(
+      mapOutputDirectory->getPath(),
+      mapProjectedReadType,
+      mapProjectedReadType,
+      {
+          {"attributes",
+           "attributes",
+           mapProjectedReadType->childAt(0),
+           makeFieldId(1, {makeFieldId(2), makeFieldId(3, {makeFieldId(5)})})},
+      },
+      {mapProjectedExpected});
+}
+#endif
 
 TEST_F(IcebergReadTest, addColumnWithDefault) {
   // Test Iceberg V3 initial-default: a column added after data files were

--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -148,6 +148,32 @@ class IcebergReadTest : public test::IcebergTestBase {
         .splits(createSplitsForDirectory(outputDirectory))
         .assertResults(expected);
   }
+
+  std::shared_ptr<test::TempDirectoryPath> writeParquetData(
+      const std::vector<RowVectorPtr>& data) {
+    fileFormat_ = dwio::common::FileFormat::PARQUET;
+    auto outputDirectory = test::TempDirectoryPath::create();
+    const auto dataSink =
+        createDataSinkAndAppendData(data, outputDirectory->getPath());
+    dataSink->close();
+    return outputDirectory;
+  }
+
+  struct FlatParquetFieldIdData {
+    RowTypePtr writeType;
+    std::shared_ptr<test::TempDirectoryPath> outputDirectory;
+  };
+
+  FlatParquetFieldIdData writeFlatParquetFieldIdData() {
+    const auto writeType =
+        ROW({"id", "flag", "status"}, {BIGINT(), BOOLEAN(), VARCHAR()});
+    const std::vector<RowVectorPtr> data{makeRowVector(
+        writeType->names(),
+        {makeFlatVector<int64_t>({10, 20, 30}),
+         makeFlatVector<bool>({true, false, true}),
+         makeFlatVector<std::string>({"old-a", "old-b", "old-c"})})};
+    return {writeType, writeParquetData(data)};
+  }
 #endif
 
   void assertDefaultValues(
@@ -349,23 +375,8 @@ TEST_F(IcebergReadTest, schemaEvolutionAddColumns) {
 }
 
 #ifdef VELOX_ENABLE_PARQUET
-TEST_F(IcebergReadTest, readParquetSchemaEvolutionByFieldId) {
-  fileFormat_ = dwio::common::FileFormat::PARQUET;
-
-  const auto writeType =
-      ROW({"id", "flag", "status"}, {BIGINT(), BOOLEAN(), VARCHAR()});
-  const std::vector<RowVectorPtr> data{makeRowVector(
-      writeType->names(),
-      {makeFlatVector<int64_t>({10, 20, 30}),
-       makeFlatVector<bool>({true, false, true}),
-       makeFlatVector<std::string>({"old-a", "old-b", "old-c"})})};
-  const auto outputDirectory = test::TempDirectoryPath::create();
-  {
-    const auto dataSink =
-        createDataSinkAndAppendData(data, outputDirectory->getPath());
-    dataSink->close();
-  }
-
+TEST_F(IcebergReadTest, readParquetFlatSchemaEvolutionByFieldId) {
+  const auto testData = writeFlatParquetFieldIdData();
   struct ReadCase {
     std::string name;
     RowTypePtr outputType;
@@ -453,18 +464,22 @@ TEST_F(IcebergReadTest, readParquetSchemaEvolutionByFieldId) {
   for (const auto& readCase : cases) {
     SCOPED_TRACE(readCase.name);
     assertParquetFieldIdRead(
-        outputDirectory->getPath(),
+        testData.outputDirectory->getPath(),
         readCase.outputType,
         readCase.scanSpecType,
         readCase.columns,
         {readCase.expected});
   }
+}
+
+TEST_F(IcebergReadTest, readParquetFilterOnlyColumnByFieldId) {
+  const auto testData = writeFlatParquetFieldIdData();
 
   auto filterOnlyColumnPlan =
       exec::test::PlanBuilder()
           .startTableScan(test::kIcebergConnectorId)
           .outputType(ROW({"id"}, {BIGINT()}))
-          .dataColumns(writeType)
+          .dataColumns(testData.writeType)
           .assignments(makeFieldIdAssignments({
               {"id", "id", BIGINT(), makeFieldId(1)},
           }))
@@ -475,9 +490,11 @@ TEST_F(IcebergReadTest, readParquetSchemaEvolutionByFieldId) {
           .endTableScan()
           .planNode();
   exec::test::AssertQueryBuilder(filterOnlyColumnPlan)
-      .splits(createSplitsForDirectory(outputDirectory->getPath()))
+      .splits(createSplitsForDirectory(testData.outputDirectory->getPath()))
       .assertResults({makeRowVector({makeFlatVector<int64_t>({20})})});
+}
 
+TEST_F(IcebergReadTest, readParquetNestedStructByFieldId) {
   const auto addressWriteType = ROW({"city", "zip"}, {VARCHAR(), VARCHAR()});
   const auto profileWriteType =
       ROW({"name", "address"}, {VARCHAR(), addressWriteType});
@@ -491,12 +508,7 @@ TEST_F(IcebergReadTest, readParquetSchemaEvolutionByFieldId) {
   const auto profileTableType = ROW({"profile"}, {profileWriteType});
   const std::vector<RowVectorPtr> profileData{
       makeRowVector(profileTableType->names(), {profileWriteData})};
-  const auto profileOutputDirectory = test::TempDirectoryPath::create();
-  {
-    const auto profileDataSink = createDataSinkAndAppendData(
-        profileData, profileOutputDirectory->getPath());
-    profileDataSink->close();
-  }
+  const auto profileOutputDirectory = writeParquetData(profileData);
   common::SubfieldFilters profileFilters;
   profileFilters.emplace(
       common::Subfield("profile.address.zip"),
@@ -528,7 +540,9 @@ TEST_F(IcebergReadTest, readParquetSchemaEvolutionByFieldId) {
       .assertResults({makeRowVector(
           {makeFlatVector<std::string>({"Ada", "Cy"}),
            makeFlatVector<std::string>({"New York", "New York"})})});
+}
 
+TEST_F(IcebergReadTest, readParquetArrayByFieldId) {
   const auto nestedWriteType =
       ROW({"items"}, {ARRAY(ROW({"name", "quantity"}, {VARCHAR(), BIGINT()}))});
   const auto nestedElements = makeRowVector(
@@ -537,12 +551,7 @@ TEST_F(IcebergReadTest, readParquetSchemaEvolutionByFieldId) {
        makeFlatVector<int64_t>({5, 7, 11})});
   const std::vector<RowVectorPtr> nestedData{makeRowVector(
       nestedWriteType->names(), {makeArrayVector({0, 2}, nestedElements)})};
-  const auto nestedOutputDirectory = test::TempDirectoryPath::create();
-  {
-    const auto nestedDataSink = createDataSinkAndAppendData(
-        nestedData, nestedOutputDirectory->getPath());
-    nestedDataSink->close();
-  }
+  const auto nestedOutputDirectory = writeParquetData(nestedData);
 
   const auto nestedReadType =
       ROW({"items"}, {ARRAY(ROW({"amount", "label"}, {BIGINT(), VARCHAR()}))});
@@ -554,17 +563,21 @@ TEST_F(IcebergReadTest, readParquetSchemaEvolutionByFieldId) {
       nestedReadType->names(),
       {makeArrayVector({0, 2}, nestedExpectedElements)});
 
-  assertParquetFieldIdRead(
-      nestedOutputDirectory->getPath(),
-      nestedReadType,
-      nestedReadType,
-      {
-          {"items",
-           "items",
-           nestedReadType->childAt(0),
-           makeFieldId(1, {makeFieldId(2, {makeFieldId(4), makeFieldId(3)})})},
-      },
-      {nestedExpected});
+  {
+    SCOPED_TRACE("full array element row");
+    assertParquetFieldIdRead(
+        nestedOutputDirectory->getPath(),
+        nestedReadType,
+        nestedReadType,
+        {
+            {"items",
+             "items",
+             nestedReadType->childAt(0),
+             makeFieldId(
+                 1, {makeFieldId(2, {makeFieldId(4), makeFieldId(3)})})},
+        },
+        {nestedExpected});
+  }
 
   const auto nestedProjectedReadType =
       ROW({"items"}, {ARRAY(ROW({"amount"}, {BIGINT()}))});
@@ -573,18 +586,23 @@ TEST_F(IcebergReadTest, readParquetSchemaEvolutionByFieldId) {
   auto nestedProjectedExpected = makeRowVector(
       nestedProjectedReadType->names(),
       {makeArrayVector({0, 2}, nestedProjectedElements)});
-  assertParquetFieldIdRead(
-      nestedOutputDirectory->getPath(),
-      nestedProjectedReadType,
-      nestedProjectedReadType,
-      {
-          {"items",
-           "items",
-           nestedProjectedReadType->childAt(0),
-           makeFieldId(1, {makeFieldId(2, {makeFieldId(4)})})},
-      },
-      {nestedProjectedExpected});
+  {
+    SCOPED_TRACE("projected array element row");
+    assertParquetFieldIdRead(
+        nestedOutputDirectory->getPath(),
+        nestedProjectedReadType,
+        nestedProjectedReadType,
+        {
+            {"items",
+             "items",
+             nestedProjectedReadType->childAt(0),
+             makeFieldId(1, {makeFieldId(2, {makeFieldId(4)})})},
+        },
+        {nestedProjectedExpected});
+  }
+}
 
+TEST_F(IcebergReadTest, readParquetMapByFieldId) {
   const auto mapValueWriteType = ROW({"name", "score"}, {VARCHAR(), BIGINT()});
   const auto mapWriteType =
       ROW({"attributes"}, {MAP(VARCHAR(), mapValueWriteType)});
@@ -598,12 +616,7 @@ TEST_F(IcebergReadTest, readParquetSchemaEvolutionByFieldId) {
           {0, 1},
           makeFlatVector<std::string>({"left", "right"}),
           mapValueElements)})};
-  const auto mapOutputDirectory = test::TempDirectoryPath::create();
-  {
-    const auto mapDataSink =
-        createDataSinkAndAppendData(mapData, mapOutputDirectory->getPath());
-    mapDataSink->close();
-  }
+  const auto mapOutputDirectory = writeParquetData(mapData);
 
   const auto mapValueReadType = ROW({"points", "label"}, {BIGINT(), VARCHAR()});
   const auto mapReadType =
@@ -619,20 +632,23 @@ TEST_F(IcebergReadTest, readParquetSchemaEvolutionByFieldId) {
           makeFlatVector<std::string>({"left", "right"}),
           mapExpectedValues)});
 
-  assertParquetFieldIdRead(
-      mapOutputDirectory->getPath(),
-      mapReadType,
-      mapReadType,
-      {
-          {"attributes",
-           "attributes",
-           mapReadType->childAt(0),
-           makeFieldId(
-               1,
-               {makeFieldId(2),
-                makeFieldId(3, {makeFieldId(5), makeFieldId(4)})})},
-      },
-      {mapExpected});
+  {
+    SCOPED_TRACE("full map value row");
+    assertParquetFieldIdRead(
+        mapOutputDirectory->getPath(),
+        mapReadType,
+        mapReadType,
+        {
+            {"attributes",
+             "attributes",
+             mapReadType->childAt(0),
+             makeFieldId(
+                 1,
+                 {makeFieldId(2),
+                  makeFieldId(3, {makeFieldId(5), makeFieldId(4)})})},
+        },
+        {mapExpected});
+  }
 
   const auto mapValueProjectedReadType = ROW({"points"}, {BIGINT()});
   const auto mapProjectedReadType =
@@ -645,17 +661,21 @@ TEST_F(IcebergReadTest, readParquetSchemaEvolutionByFieldId) {
           {0, 1},
           makeFlatVector<std::string>({"left", "right"}),
           mapProjectedExpectedValues)});
-  assertParquetFieldIdRead(
-      mapOutputDirectory->getPath(),
-      mapProjectedReadType,
-      mapProjectedReadType,
-      {
-          {"attributes",
-           "attributes",
-           mapProjectedReadType->childAt(0),
-           makeFieldId(1, {makeFieldId(2), makeFieldId(3, {makeFieldId(5)})})},
-      },
-      {mapProjectedExpected});
+  {
+    SCOPED_TRACE("projected map value row");
+    assertParquetFieldIdRead(
+        mapOutputDirectory->getPath(),
+        mapProjectedReadType,
+        mapProjectedReadType,
+        {
+            {"attributes",
+             "attributes",
+             mapProjectedReadType->childAt(0),
+             makeFieldId(
+                 1, {makeFieldId(2), makeFieldId(3, {makeFieldId(5)})})},
+        },
+        {mapProjectedExpected});
+  }
 }
 #endif
 

--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -460,6 +460,24 @@ TEST_F(IcebergReadTest, readParquetSchemaEvolutionByFieldId) {
         {readCase.expected});
   }
 
+  auto filterOnlyColumnPlan =
+      exec::test::PlanBuilder()
+          .startTableScan(test::kIcebergConnectorId)
+          .outputType(ROW({"id"}, {BIGINT()}))
+          .dataColumns(writeType)
+          .assignments(makeFieldIdAssignments({
+              {"id", "id", BIGINT(), makeFieldId(1)},
+          }))
+          .filterColumnHandles({
+              makeIcebergHandle("status", VARCHAR(), makeFieldId(3)),
+          })
+          .remainingFilter("status = 'old-b'")
+          .endTableScan()
+          .planNode();
+  exec::test::AssertQueryBuilder(filterOnlyColumnPlan)
+      .splits(createSplitsForDirectory(outputDirectory->getPath()))
+      .assertResults({makeRowVector({makeFlatVector<int64_t>({20})})});
+
   const auto addressWriteType = ROW({"city", "zip"}, {VARCHAR(), VARCHAR()});
   const auto profileWriteType =
       ROW({"name", "address"}, {VARCHAR(), addressWriteType});

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -109,8 +109,8 @@ enum class ColumnMappingMode {
   /// reordered, deleted, or added back later with the same name but a different
   /// type.
   ///
-  /// The caller must provide ReaderOptions::parquetFieldIds() ordered to match
-  /// ReaderOptions::fileSchema() at every row-typed level. Each ParquetFieldId
+  /// The caller must provide ReaderOptions::fieldIds() ordered to match
+  /// ReaderOptions::fileSchema() at every row-typed level. Each field-id
   /// entry describes the table field ID for the corresponding requested column,
   /// and nested children describe field IDs below structs, arrays, and maps.
   ///
@@ -779,15 +779,6 @@ class ReaderOptions : public io::ReaderOptions {
     return *this;
   }
 
-  /// Sets the requested schema field ids for
-  /// ColumnMappingMode::kParquetFieldId, one ParquetFieldId tree per top-level
-  /// column, aligned to fileSchema().
-  ReaderOptions& setParquetFieldIds(
-      std::vector<parquet::ParquetFieldId> fieldIds) {
-    parquetFieldIds_ = std::move(fieldIds);
-    return *this;
-  }
-
   ReaderOptions& setSessionTimezone(const tz::TimeZone* sessionTimezone) {
     sessionTimezone_ = sessionTimezone;
     return *this;
@@ -873,11 +864,6 @@ class ReaderOptions : public io::ReaderOptions {
 
   ColumnMappingMode columnMappingMode() const {
     return columnMappingMode_;
-  }
-
-  /// Returns ordered Parquet field IDs matching fileSchema() child order.
-  const std::vector<parquet::ParquetFieldId>& parquetFieldIds() const {
-    return parquetFieldIds_;
   }
 
   const std::shared_ptr<random::RandomSkipTracker>& randomSkip() const {
@@ -1062,8 +1048,6 @@ class ReaderOptions : public io::ReaderOptions {
   bool fileColumnNamesReadAsLowerCase_{false};
   // Controls how physical file columns are matched to requested schema columns.
   ColumnMappingMode columnMappingMode_{ColumnMappingMode::kPosition};
-  // Ordered field IDs, already aligned with fileSchema() child order.
-  std::vector<parquet::ParquetFieldId> parquetFieldIds_;
   std::shared_ptr<random::RandomSkipTracker> randomSkip_;
   std::shared_ptr<velox::common::ScanSpec> scanSpec_;
   const tz::TimeZone* sessionTimezone_{nullptr};

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -779,6 +779,15 @@ class ReaderOptions : public io::ReaderOptions {
     return *this;
   }
 
+  /// Sets the requested schema field ids for
+  /// ColumnMappingMode::kParquetFieldId, one ParquetFieldId tree per top-level
+  /// column, aligned to fileSchema().
+  ReaderOptions& setParquetFieldIds(
+      std::vector<parquet::ParquetFieldId> fieldIds) {
+    parquetFieldIds_ = std::move(fieldIds);
+    return *this;
+  }
+
   ReaderOptions& setSessionTimezone(const tz::TimeZone* sessionTimezone) {
     sessionTimezone_ = sessionTimezone;
     return *this;
@@ -864,6 +873,11 @@ class ReaderOptions : public io::ReaderOptions {
 
   ColumnMappingMode columnMappingMode() const {
     return columnMappingMode_;
+  }
+
+  /// Returns ordered Parquet field IDs matching fileSchema() child order.
+  const std::vector<parquet::ParquetFieldId>& parquetFieldIds() const {
+    return parquetFieldIds_;
   }
 
   const std::shared_ptr<random::RandomSkipTracker>& randomSkip() const {
@@ -1046,7 +1060,10 @@ class ReaderOptions : public io::ReaderOptions {
   uint64_t footerSpeculativeIoSize_{kDefaultFooterSpeculativeIoSize};
   uint64_t filePreloadThreshold_{kDefaultFilePreloadThreshold};
   bool fileColumnNamesReadAsLowerCase_{false};
+  // Controls how physical file columns are matched to requested schema columns.
   ColumnMappingMode columnMappingMode_{ColumnMappingMode::kPosition};
+  // Ordered field IDs, already aligned with fileSchema() child order.
+  std::vector<parquet::ParquetFieldId> parquetFieldIds_;
   std::shared_ptr<random::RandomSkipTracker> randomSkip_;
   std::shared_ptr<velox::common::ScanSpec> scanSpec_;
   const tz::TimeZone* sessionTimezone_{nullptr};

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -16,9 +16,12 @@
 
 #include "velox/dwio/parquet/reader/ParquetReader.h"
 
+#include <limits>
+
 #include <thrift/lib/cpp2/FieldRef.h>
 
 #include "velox/common/Casts.h"
+#include "velox/dwio/common/ParquetFieldId.h"
 #include "velox/dwio/common/StatisticsBuilder.h"
 #include "velox/dwio/parquet/reader/ParquetColumnReader.h"
 #include "velox/dwio/parquet/reader/ParquetStatsContext.h"
@@ -62,6 +65,59 @@ bool isParquetReservedKeyword(
             name == "array_element")))
       ? true
       : false;
+}
+
+constexpr int32_t kMissingPhysicalFieldId = std::numeric_limits<int32_t>::min();
+
+int32_t fieldIdOrMissing(const thrift::SchemaElement& schemaElement) {
+  return schemaElement.field_id().value_or(kMissingPhysicalFieldId);
+}
+
+std::string schemaElementNameOrFieldId(
+    const thrift::SchemaElement& schemaElement,
+    dwio::common::ColumnMappingMode mode) {
+  if (mode == dwio::common::ColumnMappingMode::kParquetFieldId) {
+    return std::to_string(fieldIdOrMissing(schemaElement));
+  }
+  return *schemaElement.name();
+}
+
+// Consumes a physical Parquet schema subtree that is not selected by the
+// requested field IDs. Even though the node is skipped from the reader schema,
+// the traversal must still advance schemaIdx and leaf columnIdx, and keep
+// columnNames aligned with physical schema indexes for later lookups by
+// curSchemaIdx.
+void skipParquetSchemaNode(
+    const std::vector<thrift::SchemaElement>& schema,
+    dwio::common::ColumnMappingMode mappingMode,
+    bool fileColumnNamesReadAsLowerCase,
+    uint32_t& schemaIdx,
+    uint32_t& columnIdx,
+    std::vector<std::string>& columnNames) {
+  auto name = schemaElementNameOrFieldId(schema[schemaIdx], mappingMode);
+  if (fileColumnNamesReadAsLowerCase) {
+    name = functions::stringImpl::utf8StrToLowerCopy(name);
+  }
+  columnNames.push_back(name);
+
+  const auto& schemaElement = schema[schemaIdx];
+  if (schemaElement.type()) {
+    ++columnIdx;
+  } else {
+    VELOX_CHECK(
+        schemaElement.num_children() && *schemaElement.num_children() > 0,
+        "Node has no children but should");
+    for (auto i = 0; i < *schemaElement.num_children(); ++i) {
+      ++schemaIdx;
+      skipParquetSchemaNode(
+          schema,
+          mappingMode,
+          fileColumnNamesReadAsLowerCase,
+          schemaIdx,
+          columnIdx,
+          columnNames);
+    }
+  }
 }
 
 // An unannotated array in Parquet is a repeated field that is not explicitly
@@ -271,6 +327,7 @@ class ReaderBase {
       uint32_t& columnIdx,
       const TypePtr& requestedType,
       const TypePtr& parentRequestedType,
+      const ParquetFieldId* requestedFieldIds,
       std::vector<std::string>& columnNames) const;
 
   TypePtr convertType(
@@ -422,9 +479,6 @@ void ReaderBase::initializeSchema() {
   if (fileMetaData_->encryption_algorithm()) {
     VELOX_UNSUPPORTED("Encrypted Parquet files are not supported");
   }
-  if (options_.columnMappingMode() == ColumnMappingMode::kParquetFieldId) {
-    VELOX_NYI("Parquet field ID column mapping is not implemented yet.");
-  }
 
   VELOX_CHECK_GT(
       fileMetaData_->schema()->size(),
@@ -449,6 +503,8 @@ void ReaderBase::initializeSchema() {
   uint32_t columnIdx = 0;
   uint32_t maxSchemaElementIdx = fileMetaData_->schema()->size() - 1;
   std::vector<std::string> columnNames;
+  const auto& fieldIds = options_.parquetFieldIds();
+  ParquetFieldId rootFieldIds{-1, fieldIds};
   // Setting the parent schema index of the root("hive_schema") to be 0, which
   // is the root itself. This is ok because it's never required to check the
   // parent of the root in getParquetColumnInfo().
@@ -461,6 +517,7 @@ void ReaderBase::initializeSchema() {
       columnIdx,
       options_.fileSchema(),
       nullptr,
+      fieldIds.empty() ? nullptr : &rootFieldIds,
       columnNames);
   schema_ = createRowType(
       schemaWithId_->getChildren(), isFileColumnNamesReadAsLowerCase());
@@ -483,6 +540,7 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
     uint32_t& columnIdx,
     const TypePtr& requestedType,
     const TypePtr& parentRequestedType,
+    const ParquetFieldId* requestedFieldIds,
     std::vector<std::string>& columnNames) const {
   VELOX_CHECK(fileMetaData_ != nullptr);
   VELOX_CHECK_LT(schemaIdx, fileMetaData_->schema()->size());
@@ -509,13 +567,22 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
     }
   }
 
-  auto name = *schemaElement.name();
+  const auto mappingMode = options_.columnMappingMode();
+  auto physicalName = *schemaElement.name();
+  if (isFileColumnNamesReadAsLowerCase()) {
+    physicalName = functions::stringImpl::utf8StrToLowerCopy(physicalName);
+  }
+  auto name = schemaElementNameOrFieldId(schemaElement, mappingMode);
   if (isFileColumnNamesReadAsLowerCase()) {
     name = functions::stringImpl::utf8StrToLowerCopy(name);
   }
 
-  if (options_.columnMappingMode() != ColumnMappingMode::kName &&
-      options_.fileSchema()) {
+  const bool parentProvidesChildNames =
+      (mappingMode == dwio::common::ColumnMappingMode::kPosition ||
+       (mappingMode == dwio::common::ColumnMappingMode::kParquetFieldId &&
+        requestedFieldIds != nullptr && requestedType != nullptr)) &&
+      options_.fileSchema();
+  if (parentProvidesChildNames) {
     if (isParquetReservedKeyword(name, parentSchemaIdx, curSchemaIdx)) {
       columnNames.push_back(name);
     }
@@ -536,12 +603,14 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
     auto curSchemaIdx = schemaIdx;
     for (int32_t i = 0; i < *schemaElement.num_children(); i++) {
       ++schemaIdx;
-      auto childName = *schema[schemaIdx].name();
+      auto childName =
+          schemaElementNameOrFieldId(schema[schemaIdx], mappingMode);
       if (isFileColumnNamesReadAsLowerCase()) {
         childName = functions::stringImpl::utf8StrToLowerCopy(childName);
       }
 
       TypePtr childRequestedType = nullptr;
+      const ParquetFieldId* childRequestedFieldIds = nullptr;
       bool followChild = true;
 
       {
@@ -561,10 +630,42 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
         }
 
         if (requestedRowType) {
-          if (options_.columnMappingMode() == ColumnMappingMode::kName) {
+          if (mappingMode == dwio::common::ColumnMappingMode::kName) {
             auto fileTypeIdx = requestedRowType->getChildIdxIfExists(childName);
             if (fileTypeIdx.has_value()) {
               childRequestedType = requestedRowType->childAt(*fileTypeIdx);
+            }
+          } else if (
+              mappingMode == dwio::common::ColumnMappingMode::kParquetFieldId) {
+            if (requestedFieldIds != nullptr) {
+              const auto fieldId = fieldIdOrMissing(schema[schemaIdx]);
+              std::optional<uint32_t> requestedIndex;
+              for (auto fieldIndex = 0; fieldIndex < requestedRowType->size() &&
+                   fieldIndex < requestedFieldIds->children.size();
+                   ++fieldIndex) {
+                if (requestedFieldIds->children[fieldIndex].fieldId ==
+                    fieldId) {
+                  requestedIndex = fieldIndex;
+                  break;
+                }
+              }
+              if (requestedIndex.has_value()) {
+                columnNames.push_back(
+                    requestedRowType->nameOf(*requestedIndex));
+                childRequestedType = requestedRowType->childAt(*requestedIndex);
+                childRequestedFieldIds =
+                    &requestedFieldIds->children[*requestedIndex];
+              } else {
+                followChild = false;
+              }
+            } else {
+              auto fileTypeIdx =
+                  requestedRowType->getChildIdxIfExists(childName);
+              if (fileTypeIdx.has_value()) {
+                childRequestedType = requestedRowType->childAt(*fileTypeIdx);
+              } else {
+                followChild = false;
+              }
             }
           } else {
             // Handle schema evolution.
@@ -582,15 +683,48 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
       if (!requestedType && parentRequestedType) {
         if (parentRequestedType->isArray()) {
           childRequestedType = parentRequestedType->asArray().elementType();
+          childRequestedFieldIds =
+              (requestedFieldIds && !requestedFieldIds->children.empty())
+              ? &requestedFieldIds->children[0]
+              : nullptr;
+          if (mappingMode == dwio::common::ColumnMappingMode::kParquetFieldId &&
+              childRequestedFieldIds != nullptr) {
+            columnNames.push_back("element");
+          }
         } else if (parentRequestedType->isMap()) {
           auto mapType = parentRequestedType->asMap();
           // Processing map keys
           if (i == 0) {
             childRequestedType = mapType.keyType();
+            childRequestedFieldIds =
+                (requestedFieldIds && !requestedFieldIds->children.empty())
+                ? &requestedFieldIds->children[0]
+                : nullptr;
+            if (mappingMode ==
+                    dwio::common::ColumnMappingMode::kParquetFieldId &&
+                childRequestedFieldIds != nullptr) {
+              columnNames.push_back("key");
+            }
           } else {
             childRequestedType = mapType.valueType();
+            childRequestedFieldIds =
+                (requestedFieldIds && requestedFieldIds->children.size() > 1)
+                ? &requestedFieldIds->children[1]
+                : nullptr;
+            if (mappingMode ==
+                    dwio::common::ColumnMappingMode::kParquetFieldId &&
+                childRequestedFieldIds != nullptr) {
+              columnNames.push_back("value");
+            }
           }
         }
+      }
+
+      if (mappingMode == dwio::common::ColumnMappingMode::kParquetFieldId &&
+          requestedFieldIds != nullptr && requestedType &&
+          (requestedType->isArray() || requestedType->isMap()) &&
+          childRequestedFieldIds == nullptr) {
+        childRequestedFieldIds = requestedFieldIds;
       }
 
       if (followChild) {
@@ -603,11 +737,24 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
             columnIdx,
             childRequestedType,
             requestedType,
+            childRequestedFieldIds,
             columnNames);
         children.push_back(std::move(child));
+      } else {
+        skipParquetSchemaNode(
+            schema,
+            mappingMode,
+            isFileColumnNamesReadAsLowerCase(),
+            schemaIdx,
+            columnIdx,
+            columnNames);
       }
     }
-    VELOX_CHECK(!children.empty());
+    VELOX_CHECK(
+        !children.empty() ||
+            (mappingMode == dwio::common::ColumnMappingMode::kParquetFieldId &&
+             requestedFieldIds != nullptr),
+        "Parquet schema node has no selected children");
     name = columnNames.at(curSchemaIdx);
 
     if (schemaElement.converted_type()) {
@@ -723,8 +870,8 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
           // also an indication of this is a list type
           // child of LIST
           VELOX_CHECK_GE(children.size(), 1);
-          if (children.size() == 1 && name != "array" &&
-              name != *schema[parentSchemaIdx].name() + "_tuple") {
+          if (children.size() == 1 && physicalName != "array" &&
+              physicalName != *schema[parentSchemaIdx].name() + "_tuple") {
             auto type =
                 TypeFactory<TypeKind::ARRAY>::create(children[0]->type());
             return std::make_unique<ParquetTypeWithId>(

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -16,7 +16,9 @@
 
 #include "velox/dwio/parquet/reader/ParquetReader.h"
 
+#include <algorithm>
 #include <limits>
+#include <unordered_map>
 
 #include <thrift/lib/cpp2/FieldRef.h>
 
@@ -84,9 +86,12 @@ std::string schemaElementNameOrFieldId(
 
 // Consumes a physical Parquet schema subtree that is not selected by the
 // requested field IDs. Even though the node is skipped from the reader schema,
-// the traversal must still advance schemaIdx and leaf columnIdx, and keep
-// columnNames aligned with physical schema indexes for later lookups by
-// curSchemaIdx.
+// the traversal must still advance schemaIdx and leaf columnIdx.
+//
+// columnNames has one entry per physical schema node, in DFS order, indexed by
+// schemaIdx. This helper must push exactly one name for each physical node it
+// visits; otherwise getParquetColumnInfo() can later read the wrong name with
+// columnNames.at(curSchemaIdx).
 void skipParquetSchemaNode(
     const std::vector<thrift::SchemaElement>& schema,
     dwio::common::ColumnMappingMode mappingMode,
@@ -545,6 +550,10 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
   VELOX_CHECK(fileMetaData_ != nullptr);
   VELOX_CHECK_LT(schemaIdx, fileMetaData_->schema()->size());
 
+  // columnNames has one entry per physical schema node, in DFS order, indexed
+  // by schemaIdx. Each branch in this function must either push exactly one
+  // name for the current physical node or rely on its parent to have already
+  // pushed that node's requested name before recursing.
   auto& schema = *fileMetaData_->schema();
   uint32_t curSchemaIdx = schemaIdx;
   auto& schemaElement = schema[curSchemaIdx];
@@ -600,6 +609,33 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
 
     std::vector<std::unique_ptr<ParquetTypeWithId::TypeWithId>> children;
 
+    RowTypePtr requestedRowType = nullptr;
+    if (requestedType) {
+      if (requestedType->isRow()) {
+        requestedRowType =
+            std::dynamic_pointer_cast<const velox::RowType>(requestedType);
+      } else if (
+          requestedType->isArray() && isRepeated &&
+          requestedType->asArray().elementType()->isRow()) {
+        // Handle the case of unannotated array of structs (repeated group
+        // without LIST annotation).
+        requestedRowType = std::dynamic_pointer_cast<const velox::RowType>(
+            requestedType->asArray().elementType());
+      }
+    }
+
+    std::unordered_map<int32_t, uint32_t> requestedIndexByFieldId;
+    if (mappingMode == dwio::common::ColumnMappingMode::kParquetFieldId &&
+        requestedFieldIds != nullptr && requestedRowType != nullptr) {
+      const auto numFields = std::min(
+          requestedRowType->size(),
+          static_cast<uint32_t>(requestedFieldIds->children.size()));
+      for (uint32_t fieldIndex = 0; fieldIndex < numFields; ++fieldIndex) {
+        requestedIndexByFieldId.emplace(
+            requestedFieldIds->children[fieldIndex].fieldId, fieldIndex);
+      }
+    }
+
     auto curSchemaIdx = schemaIdx;
     for (int32_t i = 0; i < *schemaElement.num_children(); i++) {
       ++schemaIdx;
@@ -613,68 +649,42 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
       const ParquetFieldId* childRequestedFieldIds = nullptr;
       bool followChild = true;
 
-      {
-        RowTypePtr requestedRowType = nullptr;
-        if (requestedType) {
-          if (requestedType->isRow()) {
-            requestedRowType =
-                std::dynamic_pointer_cast<const velox::RowType>(requestedType);
-          } else if (
-              requestedType->isArray() && isRepeated &&
-              requestedType->asArray().elementType()->isRow()) {
-            // Handle the case of unannotated array of structs (repeated group
-            // without LIST annotation).
-            requestedRowType = std::dynamic_pointer_cast<const velox::RowType>(
-                requestedType->asArray().elementType());
+      if (requestedRowType) {
+        if (mappingMode == dwio::common::ColumnMappingMode::kName) {
+          auto fileTypeIdx = requestedRowType->getChildIdxIfExists(childName);
+          if (fileTypeIdx.has_value()) {
+            childRequestedType = requestedRowType->childAt(*fileTypeIdx);
           }
-        }
-
-        if (requestedRowType) {
-          if (mappingMode == dwio::common::ColumnMappingMode::kName) {
-            auto fileTypeIdx = requestedRowType->getChildIdxIfExists(childName);
-            if (fileTypeIdx.has_value()) {
-              childRequestedType = requestedRowType->childAt(*fileTypeIdx);
-            }
-          } else if (
-              mappingMode == dwio::common::ColumnMappingMode::kParquetFieldId) {
-            if (requestedFieldIds != nullptr) {
-              const auto fieldId = fieldIdOrMissing(schema[schemaIdx]);
-              std::optional<uint32_t> requestedIndex;
-              for (auto fieldIndex = 0; fieldIndex < requestedRowType->size() &&
-                   fieldIndex < requestedFieldIds->children.size();
-                   ++fieldIndex) {
-                if (requestedFieldIds->children[fieldIndex].fieldId ==
-                    fieldId) {
-                  requestedIndex = fieldIndex;
-                  break;
-                }
-              }
-              if (requestedIndex.has_value()) {
-                columnNames.push_back(
-                    requestedRowType->nameOf(*requestedIndex));
-                childRequestedType = requestedRowType->childAt(*requestedIndex);
-                childRequestedFieldIds =
-                    &requestedFieldIds->children[*requestedIndex];
-              } else {
-                followChild = false;
-              }
-            } else {
-              auto fileTypeIdx =
-                  requestedRowType->getChildIdxIfExists(childName);
-              if (fileTypeIdx.has_value()) {
-                childRequestedType = requestedRowType->childAt(*fileTypeIdx);
-              } else {
-                followChild = false;
-              }
-            }
-          } else {
-            // Handle schema evolution.
-            if (i < requestedRowType->size()) {
-              columnNames.push_back(requestedRowType->nameOf(i));
-              childRequestedType = requestedRowType->childAt(i);
+        } else if (
+            mappingMode == dwio::common::ColumnMappingMode::kParquetFieldId) {
+          if (requestedFieldIds != nullptr) {
+            const auto fieldId = fieldIdOrMissing(schema[schemaIdx]);
+            const auto requestedIndex = requestedIndexByFieldId.find(fieldId);
+            if (requestedIndex != requestedIndexByFieldId.end()) {
+              columnNames.push_back(
+                  requestedRowType->nameOf(requestedIndex->second));
+              childRequestedType =
+                  requestedRowType->childAt(requestedIndex->second);
+              childRequestedFieldIds =
+                  &requestedFieldIds->children[requestedIndex->second];
             } else {
               followChild = false;
             }
+          } else {
+            auto fileTypeIdx = requestedRowType->getChildIdxIfExists(childName);
+            if (fileTypeIdx.has_value()) {
+              childRequestedType = requestedRowType->childAt(*fileTypeIdx);
+            } else {
+              followChild = false;
+            }
+          }
+        } else {
+          // Handle schema evolution.
+          if (i < requestedRowType->size()) {
+            columnNames.push_back(requestedRowType->nameOf(i));
+            childRequestedType = requestedRowType->childAt(i);
+          } else {
+            followChild = false;
           }
         }
       }

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -503,7 +503,7 @@ void ReaderBase::initializeSchema() {
   uint32_t columnIdx = 0;
   uint32_t maxSchemaElementIdx = fileMetaData_->schema()->size() - 1;
   std::vector<std::string> columnNames;
-  const auto& fieldIds = options_.parquetFieldIds();
+  const auto& fieldIds = options_.fieldIds();
   ParquetFieldId rootFieldIds{-1, fieldIds};
   // Setting the parent schema index of the root("hive_schema") to be 0, which
   // is the root itself. This is ok because it's never required to check the

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -164,7 +164,7 @@ TEST_F(ParquetReaderTest, parquetFieldIdColumnMapping) {
   auto readerOptions = makeDefaultReaderOptions();
   readerOptions.setFileSchema(outputType);
   readerOptions.setColumnMappingMode(ColumnMappingMode::kParquetFieldId);
-  readerOptions.setParquetFieldIds({
+  readerOptions.setFieldIds({
       ParquetFieldId{20, {}},
       ParquetFieldId{
           40,
@@ -218,7 +218,7 @@ TEST_F(ParquetReaderTest, parquetFieldIdColumnMapping) {
   projectedReaderOptions.setFileSchema(projectedOutputType);
   projectedReaderOptions.setColumnMappingMode(
       ColumnMappingMode::kParquetFieldId);
-  projectedReaderOptions.setParquetFieldIds({
+  projectedReaderOptions.setFieldIds({
       ParquetFieldId{40, {ParquetFieldId{41, {ParquetFieldId{43, {}}}}}},
       ParquetFieldId{
           50,

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -105,13 +105,147 @@ TEST_F(ParquetReaderTest, parseSample) {
       sampleSchema(), *readerBundle.rowReader, expected, *leafPool_);
 }
 
-TEST_F(ParquetReaderTest, parquetFieldIdColumnMappingNotImplemented) {
-  auto readerOptions = makeDefaultReaderOptions();
-  readerOptions.setColumnMappingMode(ColumnMappingMode::kParquetFieldId);
+TEST_F(ParquetReaderTest, parquetFieldIdColumnMapping) {
+  const auto itemWriteType = ROW({"name", "quantity"}, {VARCHAR(), BIGINT()});
+  const auto attributeWriteType = ROW({"name", "score"}, {VARCHAR(), BIGINT()});
+  const auto writeType =
+      ROW({"id", "flag", "ignored", "items", "attributes"},
+          {BIGINT(),
+           BOOLEAN(),
+           VARCHAR(),
+           ARRAY(itemWriteType),
+           MAP(VARCHAR(), attributeWriteType)});
+  const auto itemValues = makeRowVector(
+      itemWriteType->names(),
+      {makeFlatVector<std::string>({"apple", "banana", "pear"}),
+       makeFlatVector<int64_t>({5, 7, 11})});
+  const auto attributeValues = makeRowVector(
+      attributeWriteType->names(),
+      {makeFlatVector<std::string>({"first", "second"}),
+       makeFlatVector<int64_t>({101, 202})});
+  auto data = makeRowVector(
+      writeType->names(),
+      {makeFlatVector<int64_t>({10, 20}),
+       makeFlatVector<bool>({true, false}),
+       makeFlatVector<std::string>({"skip-a", "skip-b"}),
+       makeArrayVector({0, 2}, itemValues),
+       makeMapVector(
+           {0, 1},
+           makeFlatVector<std::string>({"left", "right"}),
+           attributeValues)});
 
-  VELOX_ASSERT_THROW(
-      createReader("sample.parquet", readerOptions),
-      "Parquet field ID column mapping is not implemented yet.");
+  ParquetWriterOptions writerOptions;
+  writerOptions.parquetFieldIds = {
+      ParquetFieldId{10, {}},
+      ParquetFieldId{20, {}},
+      ParquetFieldId{30, {}},
+      ParquetFieldId{
+          40,
+          {ParquetFieldId{
+              41, {ParquetFieldId{42, {}}, ParquetFieldId{43, {}}}}}},
+      ParquetFieldId{
+          50,
+          {ParquetFieldId{51, {}},
+           ParquetFieldId{
+               52, {ParquetFieldId{53, {}}, ParquetFieldId{54, {}}}}}},
+  };
+  auto* sink = write(data, writerOptions);
+
+  const auto itemReadType = ROW({"amount", "label"}, {BIGINT(), VARCHAR()});
+  const auto attributeReadType =
+      ROW({"points", "title"}, {BIGINT(), VARCHAR()});
+  const auto outputType =
+      ROW({"enabled", "items", "attributes", "id"},
+          {BOOLEAN(),
+           ARRAY(itemReadType),
+           MAP(VARCHAR(), attributeReadType),
+           BIGINT()});
+
+  auto readerOptions = makeDefaultReaderOptions();
+  readerOptions.setFileSchema(outputType);
+  readerOptions.setColumnMappingMode(ColumnMappingMode::kParquetFieldId);
+  readerOptions.setParquetFieldIds({
+      ParquetFieldId{20, {}},
+      ParquetFieldId{
+          40,
+          {ParquetFieldId{
+              41, {ParquetFieldId{43, {}}, ParquetFieldId{42, {}}}}}},
+      ParquetFieldId{
+          50,
+          {ParquetFieldId{51, {}},
+           ParquetFieldId{
+               52, {ParquetFieldId{54, {}}, ParquetFieldId{53, {}}}}}},
+      ParquetFieldId{10, {}},
+  });
+
+  auto readerBundle =
+      readerBuilder(*sink, outputType).options(readerOptions).build();
+  EXPECT_EQ(readerBundle.reader->numberOfRows(), 2ULL);
+  auto type = readerBundle.reader->typeWithId();
+  EXPECT_EQ(type->size(), 4ULL);
+  EXPECT_EQ(type->childByName("enabled")->type()->kind(), TypeKind::BOOLEAN);
+  EXPECT_EQ(type->childByName("items")->type()->kind(), TypeKind::ARRAY);
+  EXPECT_EQ(type->childByName("attributes")->type()->kind(), TypeKind::MAP);
+  EXPECT_EQ(type->childByName("id")->type()->kind(), TypeKind::BIGINT);
+
+  const auto expectedItemValues = makeRowVector(
+      itemReadType->names(),
+      {makeFlatVector<int64_t>({5, 7, 11}),
+       makeFlatVector<std::string>({"apple", "banana", "pear"})});
+  const auto expectedAttributeValues = makeRowVector(
+      attributeReadType->names(),
+      {makeFlatVector<int64_t>({101, 202}),
+       makeFlatVector<std::string>({"first", "second"})});
+  auto expected = makeRowVector(
+      outputType->names(),
+      {makeFlatVector<bool>({true, false}),
+       makeArrayVector({0, 2}, expectedItemValues),
+       makeMapVector(
+           {0, 1},
+           makeFlatVector<std::string>({"left", "right"}),
+           expectedAttributeValues),
+       makeFlatVector<int64_t>({10, 20})});
+  assertReadWithReaderAndExpected(
+      outputType, *readerBundle.rowReader, expected, *leafPool_);
+
+  const auto projectedItemReadType = ROW({"amount"}, {BIGINT()});
+  const auto projectedAttributeReadType = ROW({"points"}, {BIGINT()});
+  const auto projectedOutputType =
+      ROW({"items", "attributes"},
+          {ARRAY(projectedItemReadType),
+           MAP(VARCHAR(), projectedAttributeReadType)});
+  auto projectedReaderOptions = makeDefaultReaderOptions();
+  projectedReaderOptions.setFileSchema(projectedOutputType);
+  projectedReaderOptions.setColumnMappingMode(
+      ColumnMappingMode::kParquetFieldId);
+  projectedReaderOptions.setParquetFieldIds({
+      ParquetFieldId{40, {ParquetFieldId{41, {ParquetFieldId{43, {}}}}}},
+      ParquetFieldId{
+          50,
+          {ParquetFieldId{51, {}},
+           ParquetFieldId{52, {ParquetFieldId{54, {}}}}}},
+  });
+
+  auto projectedReaderBundle = readerBuilder(*sink, projectedOutputType)
+                                   .options(projectedReaderOptions)
+                                   .build();
+  const auto projectedExpectedItemValues = makeRowVector(
+      projectedItemReadType->names(), {makeFlatVector<int64_t>({5, 7, 11})});
+  const auto projectedExpectedAttributeValues = makeRowVector(
+      projectedAttributeReadType->names(),
+      {makeFlatVector<int64_t>({101, 202})});
+  auto projectedExpected = makeRowVector(
+      projectedOutputType->names(),
+      {makeArrayVector({0, 2}, projectedExpectedItemValues),
+       makeMapVector(
+           {0, 1},
+           makeFlatVector<std::string>({"left", "right"}),
+           projectedExpectedAttributeValues)});
+  assertReadWithReaderAndExpected(
+      projectedOutputType,
+      *projectedReaderBundle.rowReader,
+      projectedExpected,
+      *leafPool_);
 }
 
 TEST_F(ParquetReaderTest, parseEmptyNestedList) {

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -513,6 +513,35 @@ TEST_F(ParquetReaderTest, parseArrayOfRowHiveReservedKeywords) {
       "price");
 }
 
+TEST_F(ParquetReaderTest, parseArrayOfRowWithPositionMapping) {
+  // Covers kPosition when requested names differ from physical names for a
+  // legacy LIST layout. The LIST shape must still be inferred from the physical
+  // repeated-node names, not the requested positional names.
+  const auto itemType =
+      ROW({"renamed_name", "renamed_quantity", "renamed_price"},
+          {VARCHAR(), INTEGER(), DOUBLE()});
+  const auto outputType =
+      ROW({"renamed_id", "renamed_items"}, {INTEGER(), ARRAY(itemType)});
+  auto readerOptions = makeDefaultReaderOptions();
+  readerOptions.setFileSchema(outputType);
+  readerOptions.setColumnMappingMode(ColumnMappingMode::kPosition);
+  auto readerBundle =
+      readerBuilder("array_of_row_hive_reserved_keywords.parquet", outputType)
+          .options(readerOptions)
+          .build();
+
+  EXPECT_EQ(readerBundle.reader->rowType()->toString(), outputType->toString());
+  auto type = readerBundle.reader->typeWithId();
+  ASSERT_EQ(type->size(), 2ULL);
+
+  auto items = type->childByName("renamed_items");
+  ASSERT_EQ(items->type()->kind(), TypeKind::ARRAY);
+  ASSERT_EQ(items->size(), 1ULL);
+  auto arrayElement = items->childAt(0);
+  EXPECT_EQ(arrayElement->type()->kind(), TypeKind::ROW);
+  EXPECT_EQ(arrayElement->type()->toString(), itemType->toString());
+}
+
 TEST_F(ParquetReaderTest, parseSampleRange1) {
   auto readerBundle =
       readerBuilder("sample.parquet", sampleSchema()).byteRange(0, 200).build();


### PR DESCRIPTION
Support read parquet file columns by Parquet field_id (unique) instead of relying on column names or positions. This lets a file written with old columns like id, flag, and status be read through an evolved Iceberg schema where columns were renamed, reordered, deleted, or re-added with the same name and a different type.

The Iceberg split reader now builds requested field-id trees for Parquet scans and configures the Parquet reader to resolve columns by physical Parquet field_id metadata. The Parquet reader matches nested row, array, and map fields by field ID, skips unmatched physical columns, and keeps Parquet physical names separate from mapped output names for LIST/MAP layout compatibility checks.

This also handles filter-only columns: when remaining filters reference columns that are not projected by the table scan output, Iceberg now still passes their field IDs so Parquet can resolve those filter inputs correctly.
