### PR TITLE
build: Guard Lemire BMI-based decode procedure and remove aarch64 compat layers

### DIFF
--- a/velox/dwio/common/tests/BitPackDecoderBenchmark.cpp
+++ b/velox/dwio/common/tests/BitPackDecoderBenchmark.cpp
@@ -295,10 +295,9 @@ void fastpforlib(uint8_t bitWidth, T* result) {
 }
 
 void lemirebmi2(uint8_t bitWidth, uint32_t* result) {
+#ifdef __BMI2__
   const uint8_t* inputIter =
       reinterpret_cast<const uint8_t*>(bitPackedData[bitWidth].data());
-
-#ifdef __BMI2__
   bmiunpack32(inputIter, kNumValues, bitWidth, result);
 #else
   VELOX_FAIL("bmiunpack32 is not supported on this platform.");

--- a/velox/dwio/common/tests/Lemire/bmipacking32.h
+++ b/velox/dwio/common/tests/Lemire/bmipacking32.h
@@ -33,6 +33,8 @@ always unpack them fully.
 
 #pragma once
 
+#ifdef __BMI2__
+
 #include <immintrin.h>
 #include <x86intrin.h>
 #include <cstring>
@@ -3762,3 +3764,5 @@ void bmiunpack32(
     bitunpack(&in, &out);
   }
 }
+
+#endif


### PR DESCRIPTION
Summary:
Only enable bmi-based packing when compiling targetting BMI.

Remove dependency on aarch64 compat layers, required towards enablement of ARM-backed M55s

Reviewed By: YifanYuan3

Differential Revision: D106299665


