### PR TITLE
feat: Add PforEncoding (Patched FOR for data with rare outliers) (#17622)

### DIFF
--- a/velox/common/base/BitUtil.h
+++ b/velox/common/base/BitUtil.h
@@ -134,7 +134,7 @@ constexpr inline T divRoundUp(T value, U factor) {
 }
 
 constexpr inline uint64_t lowMask(int32_t bits) {
-  return (1ULL << bits) - 1;
+  return bits >= 64 ? ~uint64_t{0} : (1ULL << bits) - 1;
 }
 
 constexpr inline uint64_t highMask(int32_t bits) {


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/nimble/pull/784


Pull requests resolved:  
- https://github.com/facebookincubator/nimble/pull/784  
- https://github.com/facebookincubator/velox/pull/17622  

Pfor decomposes integer streams into a baseline plus residuals. It bit-packs ~90% of residuals using a narrow base bit width, and stores the remaining outliers in a varint side-channel. This outperforms FixedBitWidth on datasets where only a small fraction of values are large outliers.


  Wire format (after common prefix):
  [sizeof(T): baseline] [1B: baseBitWidth] [4B: numExceptions]
  [numExceptions varints: exception positions (ascending)]
  [numExceptions varints: exception values (full residuals)]
  [FixedBitArray: baseBitWidth bits × rowCount, omitted when baseBitWidth=0]

- Branchless, two-pass decode:  
  - **Pass 1:** bulk-unpack all residuals via `FixedBitArray::bulkGetWithBaseline32/64`  
  - **Pass 2:** patch the exception positions

Reviewed By: xiaoxmeng, HuamengJiang, tanjialiang

Differential Revision: D105270894


