### PR TITLE
feat: Add GroupingOperationExpr IExpr node for GROUPING() SQL operations

### DIFF
--- a/velox/parse/Expressions.cpp
+++ b/velox/parse/Expressions.cpp
@@ -55,6 +55,7 @@ const auto& kindNames() {
       {IExpr::Kind::kSubquery, "Subquery"},
       {IExpr::Kind::kAggregate, "Aggregate"},
       {IExpr::Kind::kWindow, "Window"},
+      {IExpr::Kind::kGroupingOperation, "GroupingOperation"},
   };
   return kNames;
 }
@@ -470,6 +471,36 @@ bool ConcatExpr::operator==(const IExpr& other) const {
 size_t ConcatExpr::localHash() const {
   size_t hash = 0;
   for (const auto& name : fieldNames_) {
+    hash = bits::hashMix(hash, std::hash<std::string>{}(name));
+  }
+  return hash;
+}
+
+ExprPtr GroupingOperationExpr::replaceInputs(
+    std::vector<ExprPtr> newInputs) const {
+  VELOX_CHECK_EQ(newInputs.size(), 0);
+  return std::make_shared<GroupingOperationExpr>(columnNames_);
+}
+
+ExprPtr GroupingOperationExpr::dropAlias() const {
+  return std::make_shared<GroupingOperationExpr>(columnNames_);
+}
+
+bool GroupingOperationExpr::operator==(const IExpr& other) const {
+  if (!other.is(Kind::kGroupingOperation)) {
+    return false;
+  }
+  return columnNames_ == other.as<GroupingOperationExpr>()->columnNames_ &&
+      compareAliasAndInputs(other);
+}
+
+std::string GroupingOperationExpr::toString() const {
+  return fmt::format("grouping({})", folly::join(", ", columnNames_));
+}
+
+size_t GroupingOperationExpr::localHash() const {
+  size_t hash = 0;
+  for (const auto& name : columnNames_) {
     hash = bits::hashMix(hash, std::hash<std::string>{}(name));
   }
   return hash;

--- a/velox/parse/Expressions.h
+++ b/velox/parse/Expressions.h
@@ -347,6 +347,37 @@ class WindowCallExpr : public CallExpr {
   const bool ignoreNulls_;
 };
 
+/// Placeholder for a GROUPING() SQL operation. Carries the referenced column
+/// names so the SQL planner can resolve them after grouping set expansion.
+/// The planner replaces this with the resolved bitmask expression before
+/// the plan reaches the execution engine.
+class GroupingOperationExpr : public IExpr {
+ public:
+  explicit GroupingOperationExpr(std::vector<std::string> columnNames)
+      : IExpr(IExpr::Kind::kGroupingOperation, {}),
+        columnNames_(std::move(columnNames)) {}
+
+  const std::vector<std::string>& columnNames() const {
+    return columnNames_;
+  }
+
+  std::string toString() const override;
+
+  ExprPtr replaceInputs(std::vector<ExprPtr> newInputs) const override;
+
+  ExprPtr dropAlias() const final;
+
+  bool operator==(const IExpr& other) const override;
+
+  VELOX_DEFINE_CLASS_NAME(GroupingOperationExpr)
+
+ protected:
+  size_t localHash() const override;
+
+ private:
+  const std::vector<std::string> columnNames_;
+};
+
 class ConstantExpr : public IExpr,
                      public std::enable_shared_from_this<ConstantExpr> {
  public:

--- a/velox/parse/IExpr.h
+++ b/velox/parse/IExpr.h
@@ -45,6 +45,7 @@ class IExpr {
     kConcat = 7,
     kAggregate = 8,
     kWindow = 9,
+    kGroupingOperation = 10,
   };
 
   VELOX_DECLARE_EMBEDDED_ENUM_NAME(Kind)


### PR DESCRIPTION
Summary:
Add kGroupingOperation to the IExpr::Kind enum and GroupingOperationExpr class to Expressions.h. This is a placeholder node that carries column names referenced by a GROUPING() SQL call. The SQL planner creates it during expression translation and resolves it after grouping set expansion, mirroring how AggregateCallExpr and WindowCallExpr work.

The node never reaches the execution engine — the planner replaces it with the resolved bitmask expression (element_at(array[...], $grouping_set_id + 1)) before optimization.

Differential Revision: D106391572


