### PR TITLE
feat: Add CompressionKind_LZ4_HADOOP

### DIFF
--- a/velox/common/compression/Compression.cpp
+++ b/velox/common/compression/Compression.cpp
@@ -81,6 +81,8 @@ std::string compressionKindToString(CompressionKind kind) {
       return "lz4";
     case CompressionKind_GZIP:
       return "gzip";
+    case CompressionKind_LZ4_HADOOP:
+      return "lz4_hadoop";
   }
   return folly::to<std::string>("unknown - ", kind);
 }
@@ -94,7 +96,8 @@ CompressionKind stringToCompressionKind(const std::string& kind) {
           {"lzo", CompressionKind_LZO},
           {"zstd", CompressionKind_ZSTD},
           {"lz4", CompressionKind_LZ4},
-          {"gzip", CompressionKind_GZIP}};
+          {"gzip", CompressionKind_GZIP},
+          {"lz4_hadoop", CompressionKind_LZ4_HADOOP}};
   auto iter = stringToCompressionKindMap.find(kind);
   if (iter != stringToCompressionKindMap.end()) {
     return iter->second;

--- a/velox/common/compression/Compression.h
+++ b/velox/common/compression/Compression.h
@@ -33,6 +33,7 @@ enum CompressionKind {
   CompressionKind_ZSTD = 4,
   CompressionKind_LZ4 = 5,
   CompressionKind_GZIP = 6,
+  CompressionKind_LZ4_HADOOP = 7,
   CompressionKind_MAX = INT64_MAX
 };
 

--- a/velox/common/compression/tests/CompressionTest.cpp
+++ b/velox/common/compression/tests/CompressionTest.cpp
@@ -376,6 +376,7 @@ TEST_F(CompressionTest, testCompressionNames) {
   EXPECT_EQ("lz4", compressionKindToString(CompressionKind_LZ4));
   EXPECT_EQ("zstd", compressionKindToString(CompressionKind_ZSTD));
   EXPECT_EQ("gzip", compressionKindToString(CompressionKind_GZIP));
+  EXPECT_EQ("lz4_hadoop", compressionKindToString(CompressionKind_LZ4_HADOOP));
   EXPECT_EQ(
       "unknown - 99",
       compressionKindToString(static_cast<CompressionKind>(99)));
@@ -401,6 +402,7 @@ TEST_F(CompressionTest, stringToCompressionKind) {
   EXPECT_EQ(stringToCompressionKind("lz4"), CompressionKind_LZ4);
   EXPECT_EQ(stringToCompressionKind("zstd"), CompressionKind_ZSTD);
   EXPECT_EQ(stringToCompressionKind("gzip"), CompressionKind_GZIP);
+  EXPECT_EQ(stringToCompressionKind("lz4_hadoop"), CompressionKind_LZ4_HADOOP);
   VELOX_ASSERT_THROW(
       stringToCompressionKind("bz2"), "Not support compression kind bz2");
 }

--- a/velox/dwio/common/compression/Compression.cpp
+++ b/velox/dwio/common/compression/Compression.cpp
@@ -739,6 +739,7 @@ std::unique_ptr<dwio::common::SeekableInputStream> createDecompressor(
           streamDebugInfo);
       break;
     case CompressionKind::CompressionKind_LZ4:
+    case CompressionKind::CompressionKind_LZ4_HADOOP:
       decompressor = std::make_unique<Lz4Decompressor>(
           blockSize,
           options.format.lz4_lzo.isHadoopFrameFormat,

--- a/velox/dwio/parquet/reader/Metadata.cpp
+++ b/velox/dwio/parquet/reader/Metadata.cpp
@@ -332,7 +332,7 @@ common::CompressionKind thriftCodecToCompressionKind(
     case thrift::CompressionCodec::LZO:
       return common::CompressionKind::CompressionKind_LZO;
     case thrift::CompressionCodec::LZ4:
-      return common::CompressionKind::CompressionKind_LZ4;
+      return common::CompressionKind::CompressionKind_LZ4_HADOOP;
     case thrift::CompressionCodec::ZSTD:
       return common::CompressionKind::CompressionKind_ZSTD;
     case thrift::CompressionCodec::LZ4_RAW:

--- a/velox/dwio/parquet/reader/PageReader.h
+++ b/velox/dwio/parquet/reader/PageReader.h
@@ -565,7 +565,7 @@ getParquetDecompressionOptions(common::CompressionKind kind) {
     options.format.zlib.windowBits =
         dwio::common::compression::Compressor::PARQUET_ZLIB_WINDOW_BITS;
   } else if (
-      kind == common::CompressionKind_LZ4 ||
+      kind == common::CompressionKind_LZ4_HADOOP ||
       kind == common::CompressionKind_LZO) {
     options.format.lz4_lzo.isHadoopFrameFormat = true;
   }

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -175,6 +175,7 @@ std::vector<CompressionKind> params = {
     CompressionKind::CompressionKind_SNAPPY,
     CompressionKind::CompressionKind_ZSTD,
     CompressionKind::CompressionKind_LZ4,
+    CompressionKind::CompressionKind_LZ4_HADOOP,
     CompressionKind::CompressionKind_GZIP,
 };
 

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -124,6 +124,8 @@ Compression::type getArrowParquetCompression(
   } else if (compression == common::CompressionKind_NONE) {
     return Compression::UNCOMPRESSED;
   } else if (compression == common::CompressionKind_LZ4) {
+    return Compression::LZ4;
+  } else if (compression == common::CompressionKind_LZ4_HADOOP) {
     return Compression::LZ4_HADOOP;
   } else {
     VELOX_FAIL("Unsupported compression {}", compression);


### PR DESCRIPTION
Add LZ4_HADOOP compression kind and map Parquet LZ4 to Hadoop-framed LZ4, while keeping LZ4_RAW mapped to raw LZ4 for correct reader/writer handling.
Parquet defines two LZ4 codecs: the deprecated `LZ4` codec (which uses Hadoop framing) and the newer `LZ4_RAW` codec (raw block format with no framing header). Velox mapped both to `CompressionKind_LZ4`, so the reader always applied Hadoop framing when decompressing, corrupting any file written with `LZ4_RAW`. On the write side, requesting `CompressionKind_LZ4` produced Arrow's `LZ4_HADOOP`, meaning Velox never wrote raw `LZ4_RAW` pages at all.

Add `CompressionKind_LZ4_HADOOP = 7` to the `CompressionKind` enum. The Parquet metadata reader now maps the deprecated `LZ4` Thrift codec to `CompressionKind_LZ4_HADOOP` and leaves `LZ4_RAW` mapped to the existing `CompressionKind_LZ4`. `PageReader` sets the Hadoop-frame flag only for `CompressionKind_LZ4_HADOOP` (and LZO), so `LZ4_RAW` pages are decompressed without that framing. The writer maps `CompressionKind_LZ4` to Arrow `LZ4` and `CompressionKind_LZ4_HADOOP` to Arrow `LZ4_HADOOP`, emitting the correct Parquet codec metadata for each.
As part of refactoring effort https://github.com/facebookincubator/velox/pull/11886 