### PR TITLE
refactor: Function fromDaysAndNanos days parameter from int32_t to int64_t

### DIFF
--- a/velox/dwio/parquet/reader/TimestampColumnReader.h
+++ b/velox/dwio/parquet/reader/TimestampColumnReader.h
@@ -38,9 +38,18 @@ Timestamp toInt64Timestamp(int64_t value, TimestampPrecision filePrecision) {
 
 Timestamp toInt96Timestamp(const int128_t& value) {
   // Convert int128_t to Int96 Timestamp by extracting days and nanos.
-  const int32_t days = static_cast<int32_t>(value >> 64);
+  const auto days = static_cast<int32_t>(value >> 64);
   const uint64_t nanos = value & ((((1ULL << 63) - 1ULL) << 1) + 1);
-  return Timestamp::fromDaysAndNanos(days, nanos);
+
+  // Check for overflow before casting to int64_t
+  VELOX_USER_CHECK_LE(
+      nanos,
+      static_cast<uint64_t>(std::numeric_limits<int64_t>::max()),
+      "Nanos value {} exceeds int64_t maximum, potential overflow in timestamp conversion",
+      nanos);
+
+  return Timestamp::fromDaysAndNanos(
+      static_cast<int64_t>(days), static_cast<int64_t>(nanos));
 }
 
 // Range filter for Parquet Timestamp.
@@ -143,8 +152,10 @@ class TimestampColumnReader : public IntegerColumnReader {
       if (resultVector->isNullAt(i)) {
         continue;
       }
-
-      const int128_t encoded = reinterpret_cast<int128_t&>(rawValues[i]);
+      const uint64_t seconds = static_cast<uint64_t>(rawValues[i].getSeconds());
+      const uint64_t nanos = static_cast<uint64_t>(rawValues[i].getNanos());
+      const __int128_t encoded = (static_cast<__int128_t>(nanos) << 64) |
+          static_cast<__int128_t>(seconds);
       if constexpr (std::is_same_v<T, int64_t>) {
         rawValues[i] = toInt64Timestamp(encoded, filePrecision_);
         if (needsConversion_) {

--- a/velox/type/Timestamp.cpp
+++ b/velox/type/Timestamp.cpp
@@ -46,7 +46,8 @@ folly::dynamic Timestamp::serialize() const {
 }
 
 // static
-Timestamp Timestamp::fromDaysAndNanos(int32_t days, int64_t nanos) {
+Timestamp Timestamp::fromDaysAndNanos(int64_t days, int64_t nanos);
+{
   int64_t seconds =
       (days - kJulianToUnixEpochDays) * kSecondsInDay + nanos / kNanosInSecond;
   int64_t remainingNanos = nanos % kNanosInSecond;

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -118,7 +118,7 @@ struct Timestamp {
 
   /// Creates a timestamp from the number of days since the Julian epoch
   /// and the number of nanoseconds.
-  static Timestamp fromDaysAndNanos(int32_t days, int64_t nanos);
+  static Timestamp fromDaysAndNanos(int64_t days, int64_t nanos);
 
   // date is the number of days since unix epoch.
   static Timestamp fromDate(int32_t date);


### PR DESCRIPTION
Updated function fromDaysAndNanos days parameter from int32_t to int64_t.
As part of refactoring effort https://github.com/facebookincubator/velox/pull/11886