### PR TITLE
feat: Add AsyncIoContext for io_uring async IO and MemoryPool aligned allocation (#17628)

### DIFF
--- a/velox/common/io/AsyncIoContext.cpp
+++ b/velox/common/io/AsyncIoContext.cpp
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/io/AsyncIoContext.h"
+
+#include <fmt/format.h>
+
+#include <folly/executors/thread_factory/NamedThreadFactory.h>
+#include <glog/logging.h>
+
+#include "velox/common/Casts.h"
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/memory/Allocation.h"
+
+#if __has_include(<folly/io/async/IoUringBackend.h>)
+#include <folly/io/async/IoUringBackend.h>
+#define VELOX_HAS_IO_URING 1
+#else
+#define VELOX_HAS_IO_URING 0
+#endif
+
+namespace facebook::velox::io {
+
+using memory::AllocationTraits;
+
+namespace {
+
+inline void checkPageAligned(const void* ptr, const char* label) {
+  VELOX_CHECK_EQ(
+      reinterpret_cast<uintptr_t>(ptr) % AllocationTraits::kPageSize,
+      0,
+      "{} must be page-aligned ({}-byte)",
+      label,
+      AllocationTraits::kPageSize);
+}
+
+inline void checkPageAligned(off_t offset, const char* label) {
+  VELOX_CHECK_EQ(
+      offset % AllocationTraits::kPageSize,
+      0,
+      "{} must be page-aligned ({}-byte)",
+      label,
+      AllocationTraits::kPageSize);
+}
+
+AsyncIoConfig& globalConfig() {
+  static AsyncIoConfig config;
+  return config;
+}
+
+#if VELOX_HAS_IO_URING
+std::unique_ptr<folly::IoUringBackend> createIoUringBackend(
+    const AsyncIoConfig& config) {
+  folly::IoUringOptions options;
+  options.setMaxSubmit(config.maxSubmit);
+  options.setCapacity(config.maxCapacity);
+  options.setMinCapacity(config.minCapacity);
+  options.setRegisterRingFd(true);
+
+  if (config.sqpoll) {
+    // SQ poll: kernel spawns a dedicated thread that polls the submission and
+    // completion queues, eliminating syscall overhead at the cost of burning a
+    // CPU core. Best for sustained high-throughput IO.
+    options.setFlags(
+        folly::IoUringOptions::POLL_SQ | folly::IoUringOptions::POLL_CQ);
+    options.setSQIdle(std::chrono::milliseconds(config.sqpollIdleMs));
+  } else {
+    // Coop + DeferTaskRun: no dedicated kernel thread. Completions are deferred
+    // until we explicitly enter the kernel, avoiding interrupt storms and
+    // context switches. Lower CPU cost than SQ poll, slightly higher latency.
+    options.setTaskRunCoop(true);
+    options.setDeferTaskRun(true);
+  }
+
+  // Pre-register file descriptors with io_uring to skip per-IO fd lookup
+  // (fget/fput) in the kernel. Operations reference fds by index into the
+  // kernel's internal array instead of the process fd table.
+  if (config.registeredFds > 0) {
+    options.setUseRegisteredFds(config.registeredFds);
+  }
+
+  return std::make_unique<folly::IoUringBackend>(std::move(options));
+}
+
+folly::IoUringBackend* ioUringBackend(folly::EventBase* eventBase) {
+  return checkedPointerCast<folly::IoUringBackend>(eventBase->getBackend());
+}
+#endif // VELOX_HAS_IO_URING
+
+} // namespace
+
+std::string AsyncIoConfig::toString() const {
+  return fmt::format(
+      "AsyncIoConfig(numThreads={}, maxSubmit={}, maxCapacity={}, minCapacity={}, "
+      "registeredFds={}, sqpoll={}, sqpollIdleMs={})",
+      numThreads,
+      maxSubmit,
+      maxCapacity,
+      minCapacity,
+      registeredFds,
+      sqpoll,
+      sqpollIdleMs);
+}
+
+AsyncIoContext::AsyncIoContext(const AsyncIoConfig& config) {
+#if VELOX_HAS_IO_URING
+  LOG(INFO) << "AsyncIoContext: " << config.toString();
+
+  ebm_ = std::make_unique<folly::EventBaseManager>(
+      folly::EventBase::Options().setBackendFactory(
+          [config]() { return createIoUringBackend(config); }));
+
+  executor_ = std::make_unique<folly::IOThreadPoolExecutor>(
+      config.numThreads,
+      std::make_shared<folly::NamedThreadFactory>("VeloxAsyncIO"),
+      ebm_.get());
+#else
+  VELOX_NYI("AsyncIoContext requires io_uring support (folly::IoUringBackend)");
+#endif
+}
+
+/*static*/ void AsyncIoContext::setConfig(AsyncIoConfig config) {
+  globalConfig() = std::move(config);
+}
+
+/*static*/ const AsyncIoConfig& AsyncIoContext::config() {
+  return globalConfig();
+}
+
+/*static*/ AsyncIoContext& AsyncIoContext::get() {
+  static AsyncIoContext instance(globalConfig());
+  return instance;
+}
+
+/*static*/ bool AsyncIoContext::available() {
+#if VELOX_HAS_IO_URING
+  return folly::IoUringBackend::isAvailable();
+#else
+  return false;
+#endif
+}
+
+#if VELOX_HAS_IO_URING
+folly::EventBase* AsyncIoContext::getEventBase() {
+  return executor_->getEventBase();
+}
+
+folly::coro::Task<int>
+AsyncIoContext::coPread(int fd, off_t offset, void* buf, size_t size) {
+  checkPageAligned(buf, "coPread buffer");
+  checkPageAligned(offset, "coPread offset");
+  auto* eventBase = getEventBase();
+  auto* backend = ioUringBackend(eventBase);
+
+  auto [promise, future] = folly::makePromiseContract<int>();
+  eventBase->runInEventBaseThread([backend,
+                                   fd,
+                                   buf,
+                                   size,
+                                   offset,
+                                   _promise = std::move(promise)]() mutable {
+    backend->queueRead(
+        fd,
+        buf,
+        size,
+        offset,
+        [_promise = std::move(_promise)](int result) mutable {
+          _promise.setValue(result);
+        });
+  });
+  co_return co_await std::move(future);
+}
+
+folly::coro::Task<int>
+AsyncIoContext::coPreadv(int fd, off_t offset, const iovec* iov, int iovcnt) {
+  checkPageAligned(offset, "coPreadv offset");
+  for (int i = 0; i < iovcnt; ++i) {
+    checkPageAligned(iov[i].iov_base, "coPreadv iovec buffer");
+  }
+  auto* eventBase = getEventBase();
+  auto* backend = ioUringBackend(eventBase);
+
+  auto [promise, future] = folly::makePromiseContract<int>();
+  eventBase->runInEventBaseThread([backend,
+                                   fd,
+                                   iov,
+                                   iovcnt,
+                                   offset,
+                                   _promise = std::move(promise)]() mutable {
+    backend->queueReadv(
+        fd,
+        folly::Range<const iovec*>(iov, iovcnt),
+        offset,
+        [_promise = std::move(_promise)](int result) mutable {
+          _promise.setValue(result);
+        });
+  });
+  co_return co_await std::move(future);
+}
+#endif // VELOX_HAS_IO_URING
+
+} // namespace facebook::velox::io

--- a/velox/common/io/AsyncIoContext.h
+++ b/velox/common/io/AsyncIoContext.h
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <sys/uio.h>
+#include <memory>
+#include <string>
+
+#include <folly/coro/Task.h>
+#include <folly/executors/IOThreadPoolExecutor.h>
+#include <folly/io/async/EventBaseManager.h>
+
+namespace facebook::velox::io {
+
+/// Configuration for the io_uring-backed async IO context.
+/// Must be set via AsyncIoContext::setConfig() before the first get() call.
+struct AsyncIoConfig {
+  /// Number of IO threads. Each thread gets its own io_uring instance — no
+  /// sharing or contention across threads. IO requests are distributed
+  /// round-robin. Total system-wide in-flight IO capacity is
+  /// numThreads * maxCapacity.
+  uint32_t numThreads{4};
+
+  /// Maximum SQEs (submission queue entries) pushed to the kernel per
+  /// io_uring_enter syscall. Also determines the SQ ring size (2 * maxSubmit).
+  /// Larger values batch more IOs per syscall (lower overhead) but increase
+  /// per-call latency.
+  uint32_t maxSubmit{512};
+
+  /// Maximum in-flight IO operations per io_uring instance. Sets the CQ
+  /// (completion queue) ring size — a fixed kernel allocation created at
+  /// io_uring_setup, never resized after. When all slots are occupied, new
+  /// submissions suspend the calling coroutine until a completion frees a slot.
+  uint32_t maxCapacity{1'024};
+
+  /// Minimum CQ ring size. If the kernel cannot allocate maxCapacity entries
+  /// (e.g., due to memory limits), folly halves the capacity and retries down
+  /// to this floor. Provides graceful degradation at the cost of reduced IO
+  /// concurrency.
+  uint32_t minCapacity{512};
+
+  /// Number of pre-registered fd slots per io_uring instance (0 disables).
+  /// Pre-registering file descriptors skips the per-IO fd lookup (fget/fput)
+  /// in the kernel — operations reference fds by index into a kernel-side
+  /// array instead of the process fd table. Should be >= the number of files
+  /// opened concurrently. Managed internally by folly, transparent to callers.
+  uint32_t registeredFds{4'096};
+  /// Enable kernel-side SQ polling thread (eliminates io_uring_enter syscalls
+  /// under sustained load).
+  bool sqpoll{false};
+  /// SQ poll thread idle timeout before sleeping (sqpoll mode only). After this
+  /// duration with no IO, the kernel poll thread sleeps to save CPU. The next
+  /// IO submission pays one io_uring_enter syscall to wake it. Larger values
+  /// keep the thread spinning longer between bursts (lower wake-up latency,
+  /// more CPU waste); smaller values save CPU but add a syscall on the first IO
+  /// after idle. Ignored when sqpoll is false.
+  uint32_t sqpollIdleMs{2'000};
+
+  std::string toString() const;
+};
+
+/// Provides async file IO via io_uring, integrated with folly coroutines.
+///
+/// Wraps a pool of io_uring-backed EventBase threads. Each thread owns its own
+/// io_uring instance — no contention across threads. IO requests are
+/// distributed round-robin across threads.
+///
+/// Modeled after rexdb/tiny_file/AsyncIO. The coroutine methods use a
+/// promise/future bridge: the calling coroutine suspends, the IO is submitted
+/// on an EventBase thread via backend->queueRead(), and the coroutine resumes
+/// when the CQE completion fulfills the promise.
+///
+/// Usage:
+///   AsyncIoContext::setConfig({.numThreads = 8});
+///   auto& ctx = AsyncIoContext::get();
+///   int bytesRead = co_await ctx.coPread(fd, offset, buf, size);
+class AsyncIoContext {
+ public:
+  explicit AsyncIoContext(const AsyncIoConfig& config);
+  ~AsyncIoContext() = default;
+
+  /// Sets the global config. Must be called before the first get().
+  static void setConfig(AsyncIoConfig config);
+
+  /// Returns the global config.
+  static const AsyncIoConfig& config();
+
+  /// Returns the shared singleton. Lazily constructed on first call using the
+  /// global config.
+  static AsyncIoContext& get();
+
+  /// Returns true if the kernel supports io_uring.
+  static bool available();
+
+  /// Async positioned read via io_uring.
+  folly::coro::Task<int> coPread(int fd, off_t offset, void* buf, size_t size);
+
+  /// Async positioned vectored read via io_uring.
+  folly::coro::Task<int>
+  coPreadv(int fd, off_t offset, const iovec* iov, int iovcnt);
+
+ private:
+  // Returns an EventBase chosen round-robin across IO threads. Each call
+  // returns the next thread's EventBase in rotation, distributing IO requests
+  // evenly across io_uring instances. May return a different EventBase on each
+  // call.
+  folly::EventBase* getEventBase();
+
+  // Controls how EventBase instances are created for each IO thread. We inject
+  // a custom backendFactory so each thread gets an EventBase backed by
+  // IoUringBackend instead of the default epoll. Must outlive executor_.
+  std::unique_ptr<folly::EventBaseManager> ebm_;
+  // Pool of IO threads, each running an EventBase::loopForever() that drives
+  // its own io_uring ring (submit SQEs, reap CQEs, invoke callbacks).
+  // getEventBase() round-robins across these threads.
+  std::unique_ptr<folly::IOThreadPoolExecutor> executor_;
+};
+
+} // namespace facebook::velox::io

--- a/velox/common/io/tests/AsyncIoContextTest.cpp
+++ b/velox/common/io/tests/AsyncIoContextTest.cpp
@@ -1,0 +1,335 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/io/AsyncIoContext.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <cstring>
+#include <random>
+
+#include <fmt/format.h>
+
+#include <folly/coro/BlockingWait.h>
+#include <folly/coro/Collect.h>
+#include <gtest/gtest.h>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/file/File.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/common/testutil/TempFilePath.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::io;
+using namespace facebook::velox::common::testutil;
+
+// Tests that run regardless of io_uring availability.
+TEST(AsyncIoConfigTest, defaultValues) {
+  AsyncIoConfig config;
+  EXPECT_EQ(config.numThreads, 4);
+  EXPECT_EQ(config.maxSubmit, 512);
+  EXPECT_EQ(config.maxCapacity, 1'024);
+  EXPECT_EQ(config.minCapacity, 512);
+  EXPECT_EQ(config.registeredFds, 4'096);
+  EXPECT_FALSE(config.sqpoll);
+  EXPECT_EQ(config.sqpollIdleMs, 2'000);
+}
+
+TEST(AsyncIoConfigTest, toString) {
+  struct TestCase {
+    AsyncIoConfig config;
+    std::vector<std::string> expectedSubstrings;
+    std::string debugString() const {
+      return config.toString();
+    }
+  };
+  std::vector<TestCase> testCases = {
+      {AsyncIoConfig{},
+       {"numThreads=4", "maxSubmit=512", "maxCapacity=1024", "sqpoll=false"}},
+      {AsyncIoConfig{.numThreads = 8, .sqpoll = true, .sqpollIdleMs = 500},
+       {"numThreads=8", "sqpoll=true", "sqpollIdleMs=500"}},
+  };
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.debugString());
+    const auto str = testCase.config.toString();
+    for (const auto& expected : testCase.expectedSubstrings) {
+      EXPECT_NE(str.find(expected), std::string::npos)
+          << "missing: " << expected;
+    }
+  }
+}
+
+// Parameterized over sqpoll mode: false = coop+defer, true = sqpoll.
+class AsyncIoContextTest : public ::testing::TestWithParam<bool> {
+ protected:
+  void SetUp() override {
+    if (!AsyncIoContext::available()) {
+      GTEST_SKIP() << "io_uring not available on this kernel";
+    }
+    if (GetParam()) {
+      // SQPOLL requires CAP_SYS_NICE or root — skip if unprivileged.
+      if (geteuid() != 0) {
+        GTEST_SKIP() << "sqpoll mode requires root or CAP_SYS_NICE";
+      }
+    }
+    memory::MemoryManager::testingSetInstance({});
+    pool_ = memory::memoryManager()->addLeafPool("AsyncIoContextTest");
+    AsyncIoConfig config;
+    config.numThreads = 2;
+    config.sqpoll = GetParam();
+    ctx_ = std::make_shared<AsyncIoContext>(config);
+  }
+
+  void* allocateAligned(int64_t size) {
+    return pool_->allocateAligned(size, kPageSize);
+  }
+
+  void freeAligned(void* buffer, int64_t size) {
+    pool_->freeAligned(buffer, size, kPageSize);
+  }
+
+  std::shared_ptr<TempFilePath> createTestFile(const std::string& data) {
+    auto tempFile = TempFilePath::create();
+    {
+      LocalWriteFile writeFile(
+          tempFile->getPath(),
+          /*shouldCreateParentDirectories=*/false,
+          /*shouldThrowOnFileAlreadyExists=*/false);
+      writeFile.append(data);
+      writeFile.close();
+    }
+    return tempFile;
+  }
+
+  std::string modeName() const {
+    return GetParam() ? "sqpoll" : "non-sqpoll";
+  }
+
+  static constexpr size_t kPageSize = memory::AllocationTraits::kPageSize;
+
+  std::shared_ptr<memory::MemoryPool> pool_;
+  std::shared_ptr<AsyncIoContext> ctx_;
+};
+
+TEST_P(AsyncIoContextTest, read) {
+  SCOPED_TRACE(modeName());
+
+  constexpr int kNumPages = 16;
+  std::string fileData(kNumPages * kPageSize, '\0');
+  for (int i = 0; i < kNumPages; ++i) {
+    std::memset(fileData.data() + i * kPageSize, 'A' + (i % 26), kPageSize);
+  }
+  auto tempFile = createTestFile(fileData);
+
+  const int fd = ::open(tempFile->getPath().c_str(), O_RDONLY | O_DIRECT);
+  ASSERT_GE(fd, 0);
+
+  struct TestCase {
+    off_t offset;
+    size_t size;
+    std::string debugString() const {
+      return fmt::format("offset={}, size={}", offset, size);
+    }
+  };
+  std::vector<TestCase> testCases = {
+      {0, kPageSize},
+      {0, 2 * kPageSize},
+      {static_cast<off_t>(kPageSize), kPageSize},
+      {0, kNumPages * kPageSize},
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.debugString());
+    auto* buf = allocateAligned(testCase.size);
+
+    const int bytesRead = folly::coro::blockingWait(
+        ctx_->coPread(fd, testCase.offset, buf, testCase.size));
+
+    EXPECT_EQ(bytesRead, testCase.size);
+    EXPECT_EQ(
+        std::memcmp(buf, fileData.data() + testCase.offset, testCase.size), 0);
+
+    freeAligned(buf, testCase.size);
+  }
+
+  ::close(fd);
+}
+
+TEST_P(AsyncIoContextTest, preadv) {
+  SCOPED_TRACE(modeName());
+
+  constexpr int kMaxIovecs = 4;
+  std::string fileData(kMaxIovecs * kPageSize, '\0');
+  for (int i = 0; i < kMaxIovecs; ++i) {
+    std::memset(fileData.data() + i * kPageSize, 'A' + i, kPageSize);
+  }
+  auto tempFile = createTestFile(fileData);
+
+  const int fd = ::open(tempFile->getPath().c_str(), O_RDONLY | O_DIRECT);
+  ASSERT_GE(fd, 0);
+
+  for (int iovcnt : {1, 2, 4}) {
+    SCOPED_TRACE(fmt::format("iovcnt={}", iovcnt));
+
+    std::vector<void*> buffers(iovcnt);
+    std::vector<struct iovec> iovecs(iovcnt);
+    for (int i = 0; i < iovcnt; ++i) {
+      buffers[i] = allocateAligned(kPageSize);
+      iovecs[i] = {buffers[i], kPageSize};
+    }
+
+    const int bytesRead =
+        folly::coro::blockingWait(ctx_->coPreadv(fd, 0, iovecs.data(), iovcnt));
+
+    EXPECT_EQ(bytesRead, iovcnt * kPageSize);
+    for (int i = 0; i < iovcnt; ++i) {
+      const std::string expected(kPageSize, 'A' + i);
+      EXPECT_EQ(std::memcmp(buffers[i], expected.data(), kPageSize), 0);
+    }
+
+    for (auto* buf : buffers) {
+      freeAligned(buf, kPageSize);
+    }
+  }
+
+  ::close(fd);
+}
+
+TEST_P(AsyncIoContextTest, concurrentReads) {
+  SCOPED_TRACE(modeName());
+
+  constexpr int kNumPages = 16;
+  std::string fileData(kNumPages * kPageSize, '\0');
+  for (int i = 0; i < kNumPages; ++i) {
+    std::memset(fileData.data() + i * kPageSize, 'A' + (i % 26), kPageSize);
+  }
+  auto tempFile = createTestFile(fileData);
+
+  const int fd = ::open(tempFile->getPath().c_str(), O_RDONLY | O_DIRECT);
+  ASSERT_GE(fd, 0);
+
+  // Stress test: repeatedly launch batches of concurrent coPread and
+  // coPreadv calls for 10 seconds, randomly mixing both interfaces.
+  constexpr auto kDuration = std::chrono::seconds(10);
+  constexpr int kBatchSize = 32;
+  const auto deadline = std::chrono::steady_clock::now() + kDuration;
+  std::mt19937 rng(42);
+  int totalOps = 0;
+
+  while (std::chrono::steady_clock::now() < deadline) {
+    std::vector<folly::coro::Task<int>> tasks;
+    std::vector<void*> buffers;
+    std::vector<int> pageIndices;
+    // Whether each task uses preadv (true) or pread (false).
+    std::vector<bool> isPreadv;
+    // For preadv tasks, the iovec arrays must outlive the coroutine.
+    std::vector<std::vector<struct iovec>> iovecStorage;
+
+    for (int i = 0; i < kBatchSize; ++i) {
+      const int pageIdx = rng() % kNumPages;
+      const bool usePreadv = rng() % 2 == 0;
+      isPreadv.push_back(usePreadv);
+      pageIndices.push_back(pageIdx);
+
+      if (usePreadv) {
+        const int iovcnt =
+            std::min(1 + static_cast<int>(rng() % 3), kNumPages - pageIdx);
+        std::vector<struct iovec> iovecs(iovcnt);
+        for (int j = 0; j < iovcnt; ++j) {
+          auto* buf = allocateAligned(kPageSize);
+          buffers.push_back(buf);
+          iovecs[j] = {buf, kPageSize};
+        }
+        iovecStorage.push_back(std::move(iovecs));
+        auto& storedIovecs = iovecStorage.back();
+        tasks.emplace_back(ctx_->coPreadv(
+            fd, pageIdx * kPageSize, storedIovecs.data(), storedIovecs.size()));
+      } else {
+        auto* buf = allocateAligned(kPageSize);
+        buffers.push_back(buf);
+        tasks.emplace_back(
+            ctx_->coPread(fd, pageIdx * kPageSize, buf, kPageSize));
+      }
+    }
+
+    auto results = folly::coro::blockingWait(
+        folly::coro::collectAllRange(std::move(tasks)));
+
+    // Verify results.
+    int bufIdx = 0;
+    int iovecIdx = 0;
+    for (int i = 0; i < kBatchSize; ++i) {
+      if (isPreadv[i]) {
+        const auto& iovecs = iovecStorage[iovecIdx++];
+        EXPECT_EQ(results[i], iovecs.size() * kPageSize);
+        for (size_t j = 0; j < iovecs.size(); ++j) {
+          const std::string expected(
+              kPageSize, 'A' + ((pageIndices[i] + j) % 26));
+          EXPECT_EQ(
+              std::memcmp(buffers[bufIdx], expected.data(), kPageSize), 0);
+          freeAligned(buffers[bufIdx], kPageSize);
+          ++bufIdx;
+        }
+      } else {
+        EXPECT_EQ(results[i], kPageSize);
+        const std::string expected(kPageSize, 'A' + (pageIndices[i] % 26));
+        EXPECT_EQ(std::memcmp(buffers[bufIdx], expected.data(), kPageSize), 0);
+        freeAligned(buffers[bufIdx], kPageSize);
+        ++bufIdx;
+      }
+    }
+
+    totalOps += kBatchSize;
+  }
+
+  LOG(INFO) << "concurrentReads completed " << totalOps << " ops in 10s ("
+            << modeName() << ")";
+
+  ::close(fd);
+}
+
+TEST_P(AsyncIoContextTest, misalignedBuffer) {
+  SCOPED_TRACE(modeName());
+  auto* aligned = static_cast<char*>(allocateAligned(2 * kPageSize));
+  void* misaligned = aligned + 1;
+
+  VELOX_ASSERT_THROW(
+      folly::coro::blockingWait(
+          ctx_->coPread(/*fd=*/0, /*offset=*/0, misaligned, kPageSize)),
+      "page-aligned");
+
+  freeAligned(aligned, 2 * kPageSize);
+}
+
+TEST_P(AsyncIoContextTest, misalignedOffset) {
+  SCOPED_TRACE(modeName());
+  auto* buf = allocateAligned(kPageSize);
+
+  VELOX_ASSERT_THROW(
+      folly::coro::blockingWait(
+          ctx_->coPread(/*fd=*/0, /*offset=*/1, buf, kPageSize)),
+      "page-aligned");
+
+  freeAligned(buf, kPageSize);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    IoModes,
+    AsyncIoContextTest,
+    ::testing::Values(false, true),
+    [](const ::testing::TestParamInfo<bool>& info) {
+      return info.param ? "sqpoll" : "nonSqpoll";
+    });

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -65,7 +65,7 @@ class MemoryManager {
   struct Options {
     Options() {}
     /// Specifies the default memory allocation alignment.
-    uint16_t alignment{MemoryAllocator::kMaxAlignment};
+    uint16_t alignment{MemoryAllocator::kDefaultAlignment};
 
     /// If true, enable memory usage tracking in the default memory pool.
     bool trackDefaultUsage{

--- a/velox/common/memory/MemoryAllocator.cpp
+++ b/velox/common/memory/MemoryAllocator.cpp
@@ -148,8 +148,7 @@ bool MemoryAllocator::isAlignmentValid(
   // alignmentBytes must be a power of two, so we can replace the expensive
   // modulo operation with bitwise and.
   return (alignmentBytes == kMinAlignment) ||
-      (alignmentBytes >= kMinAlignment && alignmentBytes <= kMaxAlignment &&
-       bits::isPowerOfTwo(alignmentBytes) &&
+      (alignmentBytes >= kMinAlignment && bits::isPowerOfTwo(alignmentBytes) &&
        (allocateBytes & (alignmentBytes - 1)) == 0);
 }
 

--- a/velox/common/memory/MemoryAllocator.h
+++ b/velox/common/memory/MemoryAllocator.h
@@ -269,7 +269,7 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
 
   static constexpr int32_t kMaxSizeClasses = 12;
   static constexpr uint16_t kMinAlignment = alignof(max_align_t);
-  static constexpr uint16_t kMaxAlignment = 64;
+  static constexpr uint16_t kDefaultAlignment = 64;
 
   /// Returns the kind of this memory allocator. For AsyncDataCache, it returns
   /// the kind of the delegated memory allocator underneath.
@@ -362,8 +362,7 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
   /// space from 'cache()' if registered. But sufficient space is not
   /// guaranteed.
   ///
-  /// NOTE: 'alignment' must be power of two and in range of
-  /// [kMinAlignment, kMaxAlignment].
+  /// NOTE: 'alignment' must be power of two and >= kMinAlignment.
   void* allocateBytes(uint64_t bytes, uint16_t alignment = kMinAlignment);
 
   /// Allocates a zero-filled contiguous bytes. Returns nullptr if there is no

--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -654,6 +654,39 @@ void MemoryPoolImpl::free(void* p, int64_t size) {
   release(alignedSize);
 }
 
+void* MemoryPoolImpl::allocateAligned(int64_t size, uint32_t alignment) {
+  VELOX_CHECK_GT(size, 0);
+  VELOX_CHECK(
+      bits::isPowerOfTwo(alignment),
+      "Alignment {} must be power of two.",
+      alignment);
+  const auto alignedSize = sizeAlign(size, alignment);
+  CHECK_AND_INC_MEM_OP_STATS(this, Allocs);
+  reserve(alignedSize);
+  void* buffer = allocator_->allocateBytes(alignedSize, alignment);
+  if (FOLLY_UNLIKELY(buffer == nullptr)) {
+    release(alignedSize);
+    VELOX_MEM_ALLOC_ERROR(
+        fmt::format(
+            "allocateAligned failed with {} aligned to {} from {}",
+            succinctBytes(size),
+            alignment,
+            toString()));
+  }
+  return buffer;
+}
+
+void MemoryPoolImpl::freeAligned(
+    void* buffer,
+    int64_t size,
+    uint32_t alignment) {
+  VELOX_CHECK_NOT_NULL(buffer);
+  CHECK_AND_INC_MEM_OP_STATS(this, Frees);
+  const auto alignedSize = sizeAlign(size, alignment);
+  allocator_->freeBytes(buffer, alignedSize);
+  release(alignedSize);
+}
+
 bool MemoryPoolImpl::transferTo(MemoryPool* dest, void* buffer, uint64_t size) {
   if (!isLeaf() || !dest->isLeaf()) {
     return false;

--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -128,7 +128,7 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
 
   struct Options {
     /// Specifies the memory allocation alignment through this memory pool.
-    uint16_t alignment{MemoryAllocator::kMaxAlignment};
+    uint16_t alignment{MemoryAllocator::kDefaultAlignment};
 
     /// Specifies the max memory capacity of this memory pool.
     int64_t maxCapacity{kMaxMemory};
@@ -261,6 +261,18 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
 
   /// Frees an allocated buffer.
   virtual void free(void* p, int64_t size) = 0;
+
+  /// Allocates a buffer with arbitrary power-of-two alignment (e.g., 4096 for
+  /// O_DIRECT). Unlike allocate(), which is limited to the pool's fixed
+  /// alignment, this supports any power-of-two alignment >= kMinAlignment.
+  virtual void* allocateAligned(int64_t size, uint32_t alignment) {
+    VELOX_NYI("allocateAligned not implemented for {}", toString());
+  }
+
+  /// Frees a buffer allocated by allocateAligned.
+  virtual void freeAligned(void* buffer, int64_t size, uint32_t alignment) {
+    VELOX_NYI("freeAligned not implemented for {}", toString());
+  }
 
   /// Transfer the ownership of memory at 'buffer' for 'size' bytes to the
   /// memory pool 'dest'. Returns true if the transfer succeeds.
@@ -648,6 +660,10 @@ class MemoryPoolImpl : public MemoryPool {
 
   void free(void* p, int64_t size) override;
 
+  void* allocateAligned(int64_t size, uint32_t alignment) override;
+
+  void freeAligned(void* buffer, int64_t size, uint32_t alignment) override;
+
   bool transferTo(MemoryPool* dest, void* buffer, uint64_t size) override;
 
   void reportExternalFree(int64_t size) override;
@@ -811,7 +827,13 @@ class MemoryPoolImpl : public MemoryPool {
   }
 
   FOLLY_ALWAYS_INLINE int64_t sizeAlign(int64_t size) const {
-    return (size + alignment_ - 1) & ~(alignment_ - 1);
+    return sizeAlign(size, alignment_);
+  }
+
+  static FOLLY_ALWAYS_INLINE int64_t
+  sizeAlign(int64_t size, uint32_t alignment) {
+    const auto mask = static_cast<int64_t>(alignment) - 1;
+    return checkedPlus(size, mask) & ~mask;
   }
 
   // Returns a rounded up delta based on adding 'delta' to 'size'. Adding the

--- a/velox/common/memory/MmapAllocator.h
+++ b/velox/common/memory/MmapAllocator.h
@@ -316,8 +316,7 @@ class MmapAllocator : public MemoryAllocator {
   // track sizes and enforce caps etc. If 'alignment' is not kMinAlignment,
   // then 'bytes' must be a multiple of 'alignment'.
   //
-  // NOTE: 'alignment' must be power of two and in range of [kMinAlignment,
-  // kMaxAlignment].
+  // NOTE: 'alignment' must be power of two and >= kMinAlignment.
   void* allocateBytesWithoutRetry(uint64_t bytes, uint16_t alignment) override;
 
   // Ensures that there are at least 'newMappedNeeded' pages that are

--- a/velox/common/memory/tests/MemoryAllocatorTest.cpp
+++ b/velox/common/memory/tests/MemoryAllocatorTest.cpp
@@ -1315,7 +1315,7 @@ TEST_P(MemoryAllocatorTest, reallocateBytesWithAlignment) {
   // non-default alignment since ::realloc() cannot guarantee it).
   const uint64_t kInitialSize = 1024;
   const uint64_t kNewSize = 4096;
-  const uint16_t kAlignment = MemoryAllocator::kMaxAlignment;
+  const uint16_t kAlignment = MemoryAllocator::kDefaultAlignment;
   void* p = instance_->allocateBytes(kInitialSize, kAlignment);
   ASSERT_NE(nullptr, p);
   ASSERT_EQ(0, reinterpret_cast<uintptr_t>(p) % kAlignment);
@@ -1371,34 +1371,46 @@ TEST_P(MemoryAllocatorTest, allocateBytesWithAlignment) {
        MemoryAllocator::kMinAlignment + 1,
        false},
       {AllocationTraits::kPageSize / 4,
-       MemoryAllocator::kMaxAlignment + 1,
+       MemoryAllocator::kDefaultAlignment + 1,
        false},
       {AllocationTraits::kPageSize / 5,
-       MemoryAllocator::kMaxAlignment * 2,
+       MemoryAllocator::kDefaultAlignment * 2,
        false},
       {AllocationTraits::kPageSize / 4,
-       MemoryAllocator::kMaxAlignment * 2,
+       MemoryAllocator::kDefaultAlignment * 2,
+       true},
+      {AllocationTraits::kPageSize / 5,
+       MemoryAllocator::kDefaultAlignment,
        false},
-      {AllocationTraits::kPageSize / 5, MemoryAllocator::kMaxAlignment, false},
-      {AllocationTraits::kPageSize, MemoryAllocator::kMaxAlignment + 1, false},
-      {AllocationTraits::kPageSize, MemoryAllocator::kMaxAlignment * 2, false},
-      {AllocationTraits::kPageSize, MemoryAllocator::kMaxAlignment, true},
-      {AllocationTraits::kPageSize, MemoryAllocator::kMaxAlignment / 2, true},
-      {AllocationTraits::kPageSize * 2, MemoryAllocator::kMaxAlignment, true},
+      {AllocationTraits::kPageSize,
+       MemoryAllocator::kDefaultAlignment + 1,
+       false},
+      {AllocationTraits::kPageSize,
+       MemoryAllocator::kDefaultAlignment * 2,
+       true},
+      {AllocationTraits::kPageSize, MemoryAllocator::kDefaultAlignment, true},
+      {AllocationTraits::kPageSize,
+       MemoryAllocator::kDefaultAlignment / 2,
+       true},
       {AllocationTraits::kPageSize * 2,
-       MemoryAllocator::kMaxAlignment / 2,
+       MemoryAllocator::kDefaultAlignment,
        true},
-      {MemoryAllocator::kMaxAlignment, MemoryAllocator::kMaxAlignment, true},
-      {MemoryAllocator::kMaxAlignment / 2,
-       MemoryAllocator::kMaxAlignment / 2,
+      {AllocationTraits::kPageSize * 2,
+       MemoryAllocator::kDefaultAlignment / 2,
        true},
-      {MemoryAllocator::kMaxAlignment / 2,
+      {MemoryAllocator::kDefaultAlignment,
+       MemoryAllocator::kDefaultAlignment,
+       true},
+      {MemoryAllocator::kDefaultAlignment / 2,
+       MemoryAllocator::kDefaultAlignment / 2,
+       true},
+      {MemoryAllocator::kDefaultAlignment / 2,
        MemoryAllocator::kMinAlignment,
        true},
-      {MemoryAllocator::kMaxAlignment / 2,
+      {MemoryAllocator::kDefaultAlignment / 2,
        MemoryAllocator::kMinAlignment - 1,
        false},
-      {MemoryAllocator::kMaxAlignment / 2, 0, false}};
+      {MemoryAllocator::kDefaultAlignment / 2, 0, false}};
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(
         fmt::format("UseMmap: {}, {}", useMmap_, testData.debugString()));
@@ -1419,6 +1431,19 @@ TEST_P(MemoryAllocatorTest, allocateBytesWithAlignment) {
   }
 }
 
+TEST_P(MemoryAllocatorTest, allocateBytesLargeAlignment) {
+  for (uint16_t alignment : {128, 256, 512, 1'024, 4'096}) {
+    SCOPED_TRACE(fmt::format("alignment={}", alignment));
+    const uint64_t size = static_cast<uint64_t>(alignment) * 2;
+    auto* ptr = instance_->allocateBytes(size, alignment);
+    ASSERT_NE(ptr, nullptr);
+    EXPECT_EQ(reinterpret_cast<uintptr_t>(ptr) % alignment, 0);
+    std::memset(ptr, 0x42, size);
+    instance_->freeBytes(ptr, size);
+    ASSERT_TRUE(instance_->checkConsistency());
+  }
+}
+
 TEST_P(MemoryAllocatorTest, allocateZeroFilled) {
   constexpr int32_t kNumAllocs = 50;
   // Different sizes, including below minimum and above largest size class.
@@ -1428,7 +1453,7 @@ TEST_P(MemoryAllocatorTest, allocateZeroFilled) {
       1000000,
       instance_->sizeClasses().back() * AllocationTraits::kPageSize + 100000};
   const std::vector<uint64_t> alignments = {
-      8, 16, 32, MemoryAllocator::kMaxAlignment};
+      8, 16, 32, MemoryAllocator::kDefaultAlignment};
   folly::Random::DefaultGenerator rng;
   rng.seed(1);
 

--- a/velox/common/memory/tests/MemoryManagerTest.cpp
+++ b/velox/common/memory/tests/MemoryManagerTest.cpp
@@ -57,7 +57,7 @@ TEST_F(MemoryManagerTest, ctor) {
     ASSERT_EQ(manager.numPools(), 3);
     ASSERT_EQ(manager.capacity(), kMaxMemory);
     ASSERT_EQ(0, manager.getTotalBytes());
-    ASSERT_EQ(manager.alignment(), MemoryAllocator::kMaxAlignment);
+    ASSERT_EQ(manager.alignment(), MemoryAllocator::kDefaultAlignment);
     ASSERT_EQ(manager.deprecatedSysRootPool().alignment(), manager.alignment());
     ASSERT_EQ(manager.deprecatedSysRootPool().capacity(), kMaxMemory);
     ASSERT_EQ(manager.deprecatedSysRootPool().maxCapacity(), kMaxMemory);
@@ -523,10 +523,10 @@ TEST_F(MemoryManagerTest, alignmentOptionCheck) {
       {MemoryAllocator::kMinAlignment, true},
       {MemoryAllocator::kMinAlignment * 2, true},
       {MemoryAllocator::kMinAlignment + 1, false},
-      {MemoryAllocator::kMaxAlignment - 1, false},
-      {MemoryAllocator::kMaxAlignment, true},
-      {MemoryAllocator::kMaxAlignment + 1, false},
-      {MemoryAllocator::kMaxAlignment * 2, false}};
+      {MemoryAllocator::kDefaultAlignment - 1, false},
+      {MemoryAllocator::kDefaultAlignment, true},
+      {MemoryAllocator::kDefaultAlignment + 1, false},
+      {MemoryAllocator::kDefaultAlignment * 2, true}};
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
     MemoryManager::Options options;

--- a/velox/common/memory/tests/MemoryPoolBenchmark.cpp
+++ b/velox/common/memory/tests/MemoryPoolBenchmark.cpp
@@ -24,7 +24,8 @@
 
 using namespace facebook::velox::memory;
 
-constexpr int64_t kMemoryFootprintIncrement = MemoryAllocator::kMaxAlignment;
+constexpr int64_t kMemoryFootprintIncrement =
+    MemoryAllocator::kDefaultAlignment;
 
 namespace facebook::velox::memory {
 

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -774,7 +774,7 @@ TEST_P(MemoryPoolTest, alignmentCheck) {
       0,
       MemoryAllocator::kMinAlignment,
       MemoryAllocator::kMinAlignment * 2,
-      MemoryAllocator::kMaxAlignment};
+      MemoryAllocator::kDefaultAlignment};
   for (const auto& alignment : alignments) {
     SCOPED_TRACE(fmt::format("alignment:{}", alignment));
     MemoryManager::Options options;
@@ -924,7 +924,7 @@ TEST(MemoryPoolTest, GetAlignment) {
     MemoryManager::Options options;
     options.allocatorCapacity = kMaxMemory;
     EXPECT_EQ(
-        MemoryAllocator::kMaxAlignment,
+        MemoryAllocator::kDefaultAlignment,
         MemoryManager{options}.addRootPool()->alignment());
   }
   {
@@ -934,6 +934,56 @@ TEST(MemoryPoolTest, GetAlignment) {
     MemoryManager manager{options};
     EXPECT_EQ(64, manager.addRootPool()->alignment());
   }
+}
+
+TEST(MemoryPoolTest, allocateAligned) {
+  MemoryManager::testingSetInstance({});
+  auto pool = memoryManager()->addLeafPool("allocateAlignedTest");
+
+  struct TestCase {
+    int64_t size;
+    uint32_t alignment;
+    std::string debugString() const {
+      return fmt::format("size={}, alignment={}", size, alignment);
+    }
+  };
+  std::vector<TestCase> testCases = {
+      {4'096, 4'096},
+      {8'192, 4'096},
+      {4'096, 128},
+      {1'024, 512},
+      {16'384, 4'096},
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.debugString());
+    auto* buffer = pool->allocateAligned(testCase.size, testCase.alignment);
+    ASSERT_NE(buffer, nullptr);
+    EXPECT_EQ(reinterpret_cast<uintptr_t>(buffer) % testCase.alignment, 0);
+    std::memset(buffer, 0x42, testCase.size);
+    pool->freeAligned(buffer, testCase.size, testCase.alignment);
+  }
+}
+
+TEST(MemoryPoolTest, allocateAlignedInvalidAlignment) {
+  MemoryManager::testingSetInstance({});
+  auto pool = memoryManager()->addLeafPool("allocateAlignedInvalidTest");
+
+  VELOX_ASSERT_THROW(pool->allocateAligned(4'096, 3), "power of two");
+  VELOX_ASSERT_THROW(pool->allocateAligned(0, 4'096), "");
+}
+
+TEST(MemoryPoolTest, allocateAlignedTracksUsage) {
+  MemoryManager::testingSetInstance({});
+  auto root =
+      memoryManager()->addRootPool("allocateAlignedUsageRoot", kMaxMemory);
+  auto pool = root->addLeafChild("allocateAlignedUsageTest");
+
+  const auto statsBefore = pool->stats();
+  auto* buffer = pool->allocateAligned(4'096, 4'096);
+  EXPECT_GT(pool->stats().numAllocs, statsBefore.numAllocs);
+  pool->freeAligned(buffer, 4'096, 4'096);
+  EXPECT_GT(pool->stats().numFrees, statsBefore.numFrees);
 }
 
 TEST_P(MemoryPoolTest, MemoryManagerGlobalCap) {


### PR DESCRIPTION
Summary:

Introduces `AsyncIoContext`, a singleton wrapping `folly::IoUringBackend` + `IOThreadPoolExecutor` for async file IO via io_uring. Each IO thread owns its own io_uring instance — no contention across threads. Coroutine methods (`co_pread`, `co_preadv`) use a promise/future bridge: the calling coroutine suspends, IO is submitted on an EventBase thread via `backend->queueRead()`, and the coroutine resumes when the CQE completion fulfills the promise. Modeled after `rexdb/tiny_file/AsyncIO`.

Also adds `allocateAlignedBytes`/`freeAlignedBytes` to `MemoryPool` for arbitrary power-of-two alignment (e.g., 4096 for O_DIRECT). Bypasses the `MemoryAllocator` which caps alignment at 64 bytes, using `::aligned_alloc` directly while tracking memory through the pool.

Reviewed By: tanjialiang

Differential Revision: D106430937


