### PR TITLE
Fix SIGSEGV in Task destructor by destroying plan tree before pool (#17629)

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -505,8 +505,8 @@ Task::~Task() {
   CLEAR(customTaskPools_.clear());
   CLEAR(customChildPools_.clear());
   CLEAR(childPools_.clear());
-  CLEAR(pool_.reset());
   CLEAR(planFragment_ = core::PlanFragment());
+  CLEAR(pool_.reset());
   CLEAR(queryCtx_.reset());
   clearStage = "exiting ~Task()";
 


### PR DESCRIPTION
Summary:

CONTEXT: When a `callNullable` UDF with `Map<int32_t, ...>` args is used under `LocalMergeNode`, the plan tree contains `ConstantTypedExpr` nodes with `valueVector_` allocated from the Task pool. During `Task::~Task()`, the pool is destroyed (line 491) before the plan tree (line 492). When the plan tree is subsequently destroyed, `ConstantTypedExpr::~ConstantTypedExpr()` tries to free its `AlignedBuffer` back to the dead pool, causing SIGSEGV in `AlignedBuffer::freeToPool()`.

The `ConstantTypedExpr(VectorPtr)` path is triggered by constant folding of `Cast(null MAP)` expressions in `ExprOptimizer::tryConstantFold()`. This happens when Spark inserts implicit Cast nodes for `Map<int32_t, ...>` args (but not `Map<int64_t, ...>` which matches Spark native types exactly). The constant-folded result is a pool-allocated `ConstantVector<ComplexType>` embedded in the plan tree.

WHAT: Swap the destruction order of `pool_` and `planFragment_` in `Task::~Task()`. The plan tree is now destroyed first (freeing all pool-allocated vectors), then the pool is destroyed. This is safe because:
- `planFragment_` does not hold references to the Task pool (plan nodes are constructed with a different pool)
- `childPools_` and `nodePools_` are already cleared before both
- The hard constraint (`pool_.reset()` before `queryCtx_.reset()`) is preserved

Root cause analysis: https://docs.google.com/document/d/1-S3GhQfKSxipjyvxONib4xdByK2ejLzch-bTMUSAqz0/edit

Reviewed By: jiahaol-work, xiaoxmeng

Differential Revision: D106226631


