### PR TITLE
fix(spark): Extend split fast path to support plain string

### DIFF
--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -389,20 +389,29 @@ String Functions
 
 .. spark:function:: split(string, delimiter[, limit]) -> array(string)
 
-    Splits ``string`` around occurrences that match ``delimiter`` and returns an array with a length of
-    at most ``limit``. ``delimiter`` is a string representing regular expression. ``limit`` is an integer
-    which controls the number of times the regex is applied. By default, ``limit`` is -1. When ``limit`` > 0,
-    the resulting array's length will not be more than ``limit``, and the resulting array's last entry will
-    contain all input beyond the last matched regex. When ``limit`` <= 0, ``regex`` will be applied as many
-    times as possible, and the resulting array can be of any size. When ``delimiter`` is empty, if ``limit``
-    is smaller than the size of ``string``, the resulting array only contains ``limit`` number of single characters
-    splitting from ``string``, if ``limit`` is not provided or is larger than the size of ``string``, the resulting
-    array contains all the single characters of ``string`` and does not include an empty tail character.
-    The split function align with vanilla spark 3.4+ split function. ::
+    Splits ``string`` around matches of ``delimiter`` and returns an array with at most ``limit`` elements.
+    ``delimiter`` is a string pattern, and ``limit`` is an integer that controls how many times the pattern
+    is applied. By default, ``limit`` is -1.
 
-        SELECT split('oneAtwoBthreeC', '[ABC]'); -- ["one","two","three",""]
-        SELECT split('oneAtwoBthreeC', '[ABC]', 2); -- ["one","twoBthreeC"]
-        SELECT split('oneAtwoBthreeC', '[ABC]', 5); -- ["one","two","three",""]
+    When ``limit`` > 0, the result length is at most ``limit``, and the last element contains the remaining
+    input after the final match. When ``limit`` <= 0, the pattern is applied as many times as possible, and
+    the result can have any length.
+
+    When ``delimiter`` is empty, the input is split into single characters. If ``limit`` is smaller than
+    ``string`` length, only ``limit`` characters are returned. If ``limit`` is not provided or is greater than
+    ``string`` length, all characters are returned without an empty trailing element.
+
+    This behavior aligns with Spark 3.4+.
+
+    Note that ``delimiter`` is always interpreted as a regular expression if it contains regex metacharacters.
+    An example pitfall is ``split(path, '.')`` splits on any character rather than literal dots.
+
+    For ``delimiter`` without regex metacharacters, Velox uses literal-matching fast paths. In this case, regex
+    compilation is skipped and these delimiters do not count toward the ``expression.max_compiled_regexes`` cache
+    limit.
+
+    ::
+
         SELECT split('one', '1'); -- ["one"]
         SELECT split('abcd', ''); -- ["a","b","c","d"]
         SELECT split('abcd', '', 3); -- ["a","b","c"]

--- a/velox/functions/sparksql/Split.h
+++ b/velox/functions/sparksql/Split.h
@@ -15,6 +15,9 @@
  */
 #pragma once
 
+#include <string_view>
+
+#include "velox/functions/Udf.h"
 #include "velox/functions/lib/Utf8Utils.h"
 
 namespace facebook::velox::functions::sparksql {
@@ -72,6 +75,12 @@ struct Split {
   }
 
  private:
+  enum class FastPathKind {
+    kNone,
+    kSingleChar,
+    kLiteralString,
+  };
+
   void doCall(
       out_type<Array<Varchar>>& result,
       const arg_type<Varchar>& input,
@@ -142,30 +151,43 @@ struct Split {
   // characters ".$|()[{^?*+\\", or
   // (2)two-char string and the first char is the backslash and the second is
   // not the ascii digit or ascii letter, or
-  // (3)octal string that falls within the range of ASCII characters.
+  // (3)octal string that falls within the range of ASCII characters, or
+  // (4)non-empty plain string without any RegEx meta character.
   void initializeFastPath(const char* delimiterStr, size_t delimiterSize) {
     // Referencing from
     // https://github.com/openjdk/jdk8/blob/master/jdk/src/share/classes/java/lang/String.java#L2325
     // to align with Spark.
-    const std::string reservedChars = ".$|()[{^?*+\\";
+    static constexpr std::string_view kReservedChars = ".$|()[{^?*+\\";
 
     if (delimiterSize == 1) {
       singleCharDelimiter_ = delimiterStr[0];
-      if (reservedChars.find(singleCharDelimiter_) == std::string::npos) {
-        fastPath_ = true;
+      if (kReservedChars.find(singleCharDelimiter_) == std::string_view::npos) {
+        fastPathKind_ = FastPathKind::kSingleChar;
+        return;
       }
     } else if (delimiterSize == 2 && delimiterStr[0] == '\\') {
       singleCharDelimiter_ = delimiterStr[1];
-      if (!std::isdigit(singleCharDelimiter_) &&
-          !std::isalpha(singleCharDelimiter_)) {
-        fastPath_ = true;
+      const auto delimiterChar =
+          static_cast<unsigned char>(singleCharDelimiter_);
+      if (!std::isdigit(delimiterChar) && !std::isalpha(delimiterChar)) {
+        fastPathKind_ = FastPathKind::kSingleChar;
+        return;
       }
     } else if (isOctalString(
                    delimiterStr, singleCharDelimiter_, delimiterSize)) {
-      fastPath_ = true;
-    } else {
-      fastPath_ = false;
+      fastPathKind_ = FastPathKind::kSingleChar;
+      return;
     }
+
+    if (delimiterSize > 1 &&
+        std::string_view{delimiterStr, delimiterSize}.find_first_of(
+            kReservedChars) == std::string_view::npos) {
+      fastPathKind_ = FastPathKind::kLiteralString;
+      literalDelimiter_.assign(delimiterStr, delimiterSize);
+      return;
+    }
+
+    fastPathKind_ = FastPathKind::kNone;
   }
 
   // Split with a non-empty delimiter. If limit > 0, The resulting array's
@@ -197,7 +219,7 @@ struct Split {
       initializeFastPath(delimiter.data(), delimiter.size());
     }
 
-    if (fastPath_) {
+    if (fastPathKind_ == FastPathKind::kSingleChar) {
       for (size_t i = 0; i < end; ++i) {
         if (start[i] == singleCharDelimiter_) {
           result.add_item().setNoCopy(StringView(start + pos, i - pos));
@@ -206,6 +228,24 @@ struct Split {
           if (addedElements + 1 == limit) {
             break;
           }
+        }
+      }
+    } else if (fastPathKind_ == FastPathKind::kLiteralString) {
+      std::string_view inputView{start, end};
+      std::string_view delimiterView{literalDelimiter_};
+      while (true) {
+        const size_t found = inputView.find(delimiterView, pos);
+        if (found == std::string_view::npos) {
+          break;
+        }
+
+        result.add_item().setNoCopy(StringView(start + pos, found - pos));
+        pos = found + literalDelimiter_.size();
+
+        ++addedElements;
+        // If the next element should be the last, leave the loop.
+        if (addedElements + 1 == limit) {
+          break;
         }
       }
     } else {
@@ -261,9 +301,11 @@ struct Split {
   }
 
   mutable facebook::velox::functions::detail::ReCache cache_;
-  bool fastPath_{false};
+  FastPathKind fastPathKind_{FastPathKind::kNone};
   // Single character delimiter for fast path.
   char singleCharDelimiter_;
+  // Non-empty delimiter for the literal-string fast path.
+  std::string literalDelimiter_;
   bool isConstantDelimiter_{false};
 };
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/tests/SplitTest.cpp
+++ b/velox/functions/sparksql/tests/SplitTest.cpp
@@ -317,6 +317,53 @@ TEST_F(SplitTest, fastPath) {
   // Octal string delimiter that is outside the range of ASCII characters.
   testSplit(input, "\\251", std::nullopt, 1, expected);
   testSplitConstantDelim(input, "\\251", std::nullopt, 1, expected);
+
+  input = std::vector<std::string>{
+      {"I--he--she--they"}, // Simple
+      {"one------four--"}, // Empty strings
+      {"a--\xED--\xA0--123"}, // Not a well-formed UTF-8 string
+      {""}, // The whole string is empty
+  };
+
+  // Multi-character plain string delimiter.
+  testSplit(input, "--", std::nullopt, 1, expected);
+  testSplitConstantDelim(input, "--", std::nullopt, 1, expected);
+
+  expected = {
+      {"I", "he", "she--they"},
+      {"one", "", "--four--"},
+      {"a", "\xED", "\xA0--123"},
+      {""},
+  };
+  testSplit(input, "--", 3, 1, expected);
+  testSplitConstantDelim(input, "--", 3, 1, expected);
 }
+
+TEST_F(SplitTest, bypassRegexCacheLimit) {
+  auto guard =
+      folly::makeGuard([&]() { queryCtx_->testingOverrideConfigUnsafe({}); });
+  queryCtx_->testingOverrideConfigUnsafe(
+      {{core::QueryConfig::kExprMaxCompiledRegexes, "5"}});
+
+  auto input = makeFlatVector<std::string>(
+      {"a11b11c", "a22b22c", "a33b33c", "a44b44c", "a55b55c", "a66b66c"});
+  auto delimiters =
+      makeFlatVector<std::string>({"11", "22", "33", "44", "55", "66"});
+  auto expected = makeArrayVector<std::string>(
+      {{"a", "b", "c"},
+       {"a", "b", "c"},
+       {"a", "b", "c"},
+       {"a", "b", "c"},
+       {"a", "b", "c"},
+       {"a", "b", "c"}});
+
+  // Before the plain-string fast path, this would try to compile six
+  // different regex patterns and throw due to the cache limit of five.
+  VectorPtr result;
+  EXPECT_NO_THROW(
+      result = evaluate("split(c0, c1)", makeRowVector({input, delimiters})));
+  assertEqualVectors(expected, result);
+}
+
 } // namespace
 } // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
**Problem**
The Spark split function can throw when evaluated with many distinct delimiter 
values. In a query like:

```sql
select split(dir_path, location_path)[1] as partition_name from test_tbl
```

the delimiter is treated as a regex. For high-cardinality plain delimiters, it may
compile and cache each pattern, and once `expression.max_compiled_regexes`
is reached, evaluation fails.

**Solution**
Extend the Spark split fast path to handle plain string delimiters with length
greater than 1 (that is, delimiters without regex metacharacters). For these
delimiters, use literal substring matching instead of compiling/executing regex.

This change:

Prevents cache-limit exceptions for many distinct plain string delimiters.
Avoids unnecessary regex compilation overhead.
Preserves existing behavior for true regex delimiters by falling back to the regex path
when metacharacters are present.

More context: https://velox-lib.io/blog/regex-hidden-traps.
Follow-up for: https://github.com/facebookincubator/velox/pull/15953.