### PR TITLE
perf(parquet): Inline bit extraction in DeltaBpDecoder::readLong

### DIFF
--- a/velox/dwio/parquet/reader/DeltaBpDecoder.h
+++ b/velox/dwio/parquet/reader/DeltaBpDecoder.h
@@ -206,12 +206,13 @@ class DeltaBpDecoder {
     uint64_t consumedBits =
         (valuesPerMiniBlock_ - valuesRemainingCurrentMiniBlock_) *
         deltaBitWidth_;
-    bits::copyBits(
-        reinterpret_cast<const uint64_t*>(bufferStart_),
-        consumedBits,
-        reinterpret_cast<uint64_t*>(&value),
-        0,
-        deltaBitWidth_);
+    if (deltaBitWidth_) {
+      value = bits::detail::loadBits<uint64_t>(
+          reinterpret_cast<const uint64_t*>(bufferStart_),
+          consumedBits,
+          deltaBitWidth_);
+      value &= (~0ULL >> (64 - deltaBitWidth_));
+    }
     // Addition between minDelta_, packed int and lastValue_ should be treated
     // as unsigned addition. Overflow is as expected.
     value = static_cast<uint64_t>(minDelta_) + static_cast<uint64_t>(value) +

--- a/velox/dwio/parquet/reader/PageReader.cpp
+++ b/velox/dwio/parquet/reader/PageReader.cpp
@@ -126,7 +126,9 @@ const char* PageReader::readBytes(int32_t size, BufferPtr& copy) {
       bufferStart_ = reinterpret_cast<const char*>(buffer);
       bufferEnd_ = bufferStart_ + bufferSize;
     }
-    if (bufferEnd_ - bufferStart_ >= size) {
+    // Fall through to the AlignedBuffer copy when the stream buffer does
+    // not have kPageReadPadding trailing bytes past 'size'.
+    if (bufferEnd_ - bufferStart_ >= size + kPageReadPadding) {
       bufferStart_ += size;
       return bufferStart_ - size;
     }

--- a/velox/dwio/parquet/reader/PageReader.h
+++ b/velox/dwio/parquet/reader/PageReader.h
@@ -216,10 +216,18 @@ class PageReader {
   // 'hasChunkRepDefs_' is false.
   void readPageDefLevels();
 
-  // Returns a pointer to contiguous space for the next 'size' bytes
-  // from current position. Copies data into 'copy' if the range
-  // straddles buffers. Allocates or resizes 'copy' as needed.
+  // Returns a pointer to contiguous space for the next 'size' bytes from
+  // current position, with at least 'kPageReadPadding' readable trailing
+  // bytes past 'size'. Copies into 'copy' if needed; allocates or resizes
+  // 'copy' as needed.
   const char* readBytes(int32_t size, BufferPtr& copy);
+
+  // Trailing readable bytes past readBytes()'s returned size. Sized
+  // for bits::detail::loadBits<uint64_t>, which touches bytes
+  // [offset, offset + 9) when the bit field straddles the 8-byte word
+  // boundary. For any value within a miniblock 'offset < size', so the
+  // furthest byte is at most 'size + 7' — 8 trailing bytes suffice.
+  static constexpr int kPageReadPadding = 8;
 
   // Decompresses data starting at 'pageData_', consuming 'compressedsize' and
   // producing up to 'uncompressedSize' bytes. The start of the decoding

--- a/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -1576,6 +1576,70 @@ TEST_F(ParquetTableScanTest, deltaByteArray) {
       "SELECT a from expected");
 }
 
+TEST_F(ParquetTableScanTest, deltaBinaryPackedConstantDelta) {
+  WriterOptions options;
+  options.enableDictionary = false;
+  options.encoding =
+      facebook::velox::parquet::arrow::Encoding::kDeltaBinaryPacked;
+
+  constexpr vector_size_t kSize = 1024;
+  auto vector = makeRowVector(
+      {"c"},
+      {makeFlatVector<int64_t>(kSize, [](auto row) { return 100 + 7 * row; })});
+  auto file = TempFilePath::create();
+  writeToParquetFile(file->getPath(), {vector}, options);
+  loadData(vector->rowType(), vector);
+
+  assertSelect({makeSplit(file->getPath())}, {"c"}, "SELECT c FROM tmp");
+}
+
+TEST_F(ParquetTableScanTest, deltaBinaryPackedNarrowBitWidth) {
+  auto run = [&]<typename T>() {
+    constexpr vector_size_t kSize = 4096;
+    auto vector = makeRowVector({"c"}, {makeFlatVector<T>(kSize, [](auto row) {
+                                  return static_cast<T>(row + row / 2);
+                                })});
+
+    for (bool useV2 : {false, true}) {
+      SCOPED_TRACE(fmt::format("T=int{} useV2={}", sizeof(T) * 8, useV2));
+      WriterOptions options;
+      options.enableDictionary = false;
+      options.encoding =
+          facebook::velox::parquet::arrow::Encoding::kDeltaBinaryPacked;
+      options.useParquetDataPageV2 = useV2;
+      options.compressionKind = common::CompressionKind::CompressionKind_NONE;
+
+      auto file = TempFilePath::create();
+      writeToParquetFile(file->getPath(), {vector}, options);
+      loadData(vector->rowType(), vector);
+      assertSelect({makeSplit(file->getPath())}, {"c"}, "SELECT c FROM tmp");
+    }
+  };
+
+  run.template operator()<int32_t>();
+  run.template operator()<int64_t>();
+}
+
+TEST_F(ParquetTableScanTest, deltaBinaryPackedWideAndNegative) {
+  WriterOptions options;
+  options.enableDictionary = false;
+  options.encoding =
+      facebook::velox::parquet::arrow::Encoding::kDeltaBinaryPacked;
+
+  constexpr vector_size_t kSize = 1024;
+  auto vector = makeRowVector(
+      {"c"}, {makeFlatVector<int64_t>(kSize, [](auto row) {
+        const int64_t steps[] = {
+            -1'000'000'000LL, 2'000'000'000LL, -500'000LL, 1'500'000'000LL};
+        return steps[row % 4] * row;
+      })});
+  auto file = TempFilePath::create();
+  writeToParquetFile(file->getPath(), {vector}, options);
+  loadData(vector->rowType(), vector);
+
+  assertSelect({makeSplit(file->getPath())}, {"c"}, "SELECT c FROM tmp");
+}
+
 TEST_F(ParquetTableScanTest, booleanRle) {
   WriterOptions options;
   options.enableDictionary = false;


### PR DESCRIPTION
Replace `bits::copyBits` with `bits::detail::loadBits` + a low-bits mask in `DeltaBpDecoder::readLong`. The output offset is always 0 and `bitWidth` is at most 64, so the generic byte-level copy in `copyBits` reduces to a single unaligned 64-bit load + shift, which is what `loadBits` already does. The `bitWidth == 0` case (constant-delta miniblock) is handled by an early skip before any shift.

`PageReader::readBytes` is updated to guarantee `kPageReadPadding` (8) addressable trailing bytes past the returned size, making the unaligned 64-bit load near miniblock boundaries explicitly safe. The fast path falls through to the existing `AlignedBuffer` copy when the input stream chunk lacks that slack.

## Impact

`DeltaBpDecoder` runs on DELTA-encoded parquet. Velox's writer can opt into DELTA via `WriterOptions::encoding = arrow::Encoding::kDeltaBinaryPacked` (off by default). Beyond `DELTA_BINARY_PACKED` itself, `DeltaBpDecoder` is also used internally for `DELTA_LENGTH_BYTE_ARRAY` (1 decoder for lengths) and `DELTA_BYTE_ARRAY` (2 decoders for prefix+suffix lengths). Typical columns: sorted/monotone IDs, timestamps, dates, dimension strings with shared prefixes.

## Performance

End-to-end on TPC-H Q12, SF10, lineitem re-encoded as DELTA.

```
                                 Wall      Lineitem scan CPU
Default (PLAIN/DICT, no DELTA):  479 ms     614 ms
DELTA, baseline (copyBits):     1.71 s     5.04 s
DELTA, PR (loadBits):           1.02 s     2.76 s
```

The same scan against PLAIN/DICT data uses ~614 ms of CPU, so on the DELTA path roughly 4.4 s of the 5.04 s scan CPU (~87%) is DeltaBp decoding. The PR halves that. End-to-end Q12 wall: **1.68x**. Default-encoded data is unchanged within noise — no regression on the non-DELTA path.