### PR TITLE
fix(tests): Resolve test data file paths when running binaries directly

### DIFF
--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -1680,7 +1680,7 @@ TEST_F(HiveIcebergTest, positionalDeleteFileWithRowGroupFilter) {
   // resulting in records in the position delete file being mapped to incorrect
   // rows.
   auto path = test::getDataFilePath(
-      "velox/connectors/hive/iceberg/test", "examples/three_groups.parquet");
+      "velox/connectors/hive/iceberg/tests", "examples/three_groups.parquet");
   const auto deletedPositionSize = 100;
   std::vector<int64_t> deletePositionsVec(
       deletedPositionSize); // allocate 100 elements, [100, 199].

--- a/velox/dwio/common/tests/utils/DataFiles.cpp
+++ b/velox/dwio/common/tests/utils/DataFiles.cpp
@@ -15,19 +15,44 @@
  */
 
 #include "velox/dwio/common/tests/utils/DataFiles.h"
-#include <boost/algorithm/string.hpp>
+#include <string_view>
+#include "velox/common/base/Exceptions.h"
 #include "velox/common/base/Fs.h"
 
 namespace facebook::velox::test {
 
+namespace {
+
+constexpr std::string_view kDataFilesSourceSuffix =
+    "velox/dwio/common/tests/utils/DataFiles.cpp";
+
+// Computes the project root from this source file location so test data lookup
+// does not depend on the process working directory.
+const fs::path& projectRoot() {
+  static const fs::path root = [] {
+    const std::string sourcePath =
+        fs::path{__FILE__}.lexically_normal().string();
+    VELOX_CHECK(
+        sourcePath.ends_with(kDataFilesSourceSuffix),
+        "DataFiles.cpp path does not end with expected suffix: {}",
+        sourcePath);
+    return fs::path{sourcePath.substr(
+        0, sourcePath.size() - kDataFilesSourceSuffix.size())};
+  }();
+  return root;
+}
+
+} // namespace
+
 std::string getDataFilePath(
     const std::string& baseDir,
     const std::string& filePath) {
-  std::string current_path = fs::current_path().c_str();
-  if (boost::algorithm::ends_with(current_path, "fbcode")) {
-    return current_path + "/" + baseDir + "/" + filePath;
+  const fs::path requestedPath{filePath};
+  if (requestedPath.is_absolute()) {
+    return requestedPath.string();
   }
-  return current_path + "/" + filePath;
+
+  return (projectRoot() / baseDir / requestedPath).lexically_normal().string();
 }
 
 } // namespace facebook::velox::test

--- a/velox/dwio/common/tests/utils/DataFiles.cpp
+++ b/velox/dwio/common/tests/utils/DataFiles.cpp
@@ -42,6 +42,20 @@ const fs::path& projectRoot() {
   return root;
 }
 
+// Preserves the legacy cwd-based lookup for builds where __FILE__ is rewritten
+// to be source-relative, e.g. by -ffile-prefix-map.
+std::string getDataFilePathFromCurrentDirectory(
+    const std::string& baseDir,
+    const fs::path& requestedPath) {
+  const std::string currentPath = fs::current_path().string();
+  if (currentPath.ends_with("fbcode")) {
+    return (fs::path{currentPath} / baseDir / requestedPath)
+        .lexically_normal()
+        .string();
+  }
+  return (fs::path{currentPath} / requestedPath).lexically_normal().string();
+}
+
 } // namespace
 
 std::string getDataFilePath(
@@ -52,7 +66,12 @@ std::string getDataFilePath(
     return requestedPath.string();
   }
 
-  return (projectRoot() / baseDir / requestedPath).lexically_normal().string();
+  const auto& root = projectRoot();
+  if (root.is_absolute()) {
+    return (root / baseDir / requestedPath).lexically_normal().string();
+  }
+
+  return getDataFilePathFromCurrentDirectory(baseDir, requestedPath);
 }
 
 } // namespace facebook::velox::test

--- a/velox/dwio/common/tests/utils/DataFiles.h
+++ b/velox/dwio/common/tests/utils/DataFiles.h
@@ -19,8 +19,9 @@
 
 namespace facebook::velox::test {
 
+/// Returns the path to a test data file under the Velox source tree.
 std::string getDataFilePath(
     const std::string& baseDir,
     const std::string& filePath);
 
-}
+} // namespace facebook::velox::test

--- a/velox/dwio/common/tests/utils/DataFiles.h
+++ b/velox/dwio/common/tests/utils/DataFiles.h
@@ -19,7 +19,7 @@
 
 namespace facebook::velox::test {
 
-/// Returns the path to a test data file under the Velox source tree.
+/// Returns the path to a test data file used by Velox tests.
 std::string getDataFilePath(
     const std::string& baseDir,
     const std::string& filePath);


### PR DESCRIPTION
# Problem:
 getDataFilePath("velox/dwio/parquet/tests/reader", "../examples/lzo.parquet") works via ctest (which sets WORKING_DIRECTORY to the source dir) but fails when running the binary directly from the repo root. The old code ignores baseDir when cwd doesn't end with "fbcode", so the path becomes cwd/../examples/lzo.parquet instead of cwd/velox/dwio/parquet/tests/reader/../examples/lzo.parquet.

### Works:
ctest -R velox_dwio_parquet_reader_test

### Fails from repo root:
_build/debug/.../velox_dwio_parquet_reader_test --gtest_filter="ParquetReaderTest.testLzoDataPage"

# Error: 
No such file: /path/to/velox/../examples/lzo.parquet

### Test

ctest -R velox_dwio_parquet_reader_test
./velox_dwio_parquet_reader_test
_build/debug/velox/dwio/parquet/tests/reader/velox_dwio_parquet_reader_test

cp velox_dwio_parquet_reader_test ~
then ./velox_dwio_parquet_reader_test

