### PR TITLE
fix(build): Account for AsyncIoContext.h header

### DIFF
--- a/velox/common/io/CMakeLists.txt
+++ b/velox/common/io/CMakeLists.txt
@@ -12,6 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-velox_add_library(velox_common_io IoStatistics.cpp HEADERS IoStatistics.h Options.h)
+velox_add_library(
+  velox_common_io
+  IoStatistics.cpp
+  HEADERS
+  AsyncIoContext.h
+  IoStatistics.h
+  Options.h
+)
 
 velox_link_libraries(velox_common_io Folly::folly glog::glog)


### PR DESCRIPTION
The header is introduced by #17628.
The PR itself does not actually build the newly added files currently. This may be on purpose.
Regardless, the header needs to be accounted for to pass pre-commit rules.