### PR TITLE
perf: Lazily evaluate RowVector's containsLazyNotLoaded_ state (#17642)

### DIFF
--- a/velox/dwio/common/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/common/SelectiveStructColumnReader.cpp
@@ -689,7 +689,7 @@ void SelectiveStructColumnReaderBase::getValues(
         makeColumnLoader(index), lazyType, rows.size(), pool_, childResult);
   }
 
-  resultRow->updateContainsLazyNotLoaded();
+  resultRow->invalidateContainsLazyNotLoaded();
 }
 
 namespace detail {

--- a/velox/exec/LocalPartition.cpp
+++ b/velox/exec/LocalPartition.cpp
@@ -415,7 +415,7 @@ RowVectorPtr LocalPartition::wrapChildren(
     }
   }
 
-  result->updateContainsLazyNotLoaded();
+  result->invalidateContainsLazyNotLoaded();
   return result;
 }
 

--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -446,7 +446,7 @@ void RowVector::prepareForReuse() {
       BaseVector::prepareForReuse(child, 0);
     }
   }
-  updateContainsLazyNotLoaded();
+  invalidateContainsLazyNotLoaded();
 }
 
 VectorPtr RowVector::slice(vector_size_t offset, vector_size_t length) const {
@@ -464,33 +464,45 @@ BaseVector* RowVector::loadedVector() {
   if (childrenLoaded_) {
     return this;
   }
-  containsLazyNotLoaded_ = false;
+  bool hasLazy = false;
   for (auto i = 0; i < childrenSize_; ++i) {
     if (!children_[i]) {
       continue;
     }
     auto& newChild = BaseVector::loadedVectorShared(children_[i]);
-    // This is not needed but can potentially optimize decoding speed later.
     if (children_[i].get() != newChild.get()) {
       children_[i] = newChild;
     }
     if (isLazyNotLoaded(*children_[i])) {
-      containsLazyNotLoaded_ = true;
+      hasLazy = true;
     }
   }
+  containsLazyNotLoaded_.store(hasLazy ? 1 : 0, std::memory_order_relaxed);
   childrenLoaded_ = true;
   return this;
 }
 
-void RowVector::updateContainsLazyNotLoaded() const {
+void RowVector::invalidateContainsLazyNotLoaded() const {
   childrenLoaded_ = false;
-  containsLazyNotLoaded_ = false;
-  for (auto& child : children_) {
+  containsLazyNotLoaded_.store(-1, std::memory_order_relaxed);
+}
+
+void RowVector::computeContainsLazyNotLoaded() const {
+  int8_t result = 0;
+  for (const auto& child : children_) {
     if (child && isLazyNotLoaded(*child)) {
-      containsLazyNotLoaded_ = true;
+      result = 1;
       break;
     }
   }
+  containsLazyNotLoaded_.store(result, std::memory_order_relaxed);
+}
+
+bool RowVector::containsLazyNotLoaded() const {
+  if (containsLazyNotLoaded_.load(std::memory_order_relaxed) < 0) {
+    computeContainsLazyNotLoaded();
+  }
+  return containsLazyNotLoaded_.load(std::memory_order_relaxed) == 1;
 }
 
 void ArrayVectorBase::copyRangesImpl(

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <atomic>
+
 #include <folly/container/F14Map.h>
 #include <folly/hash/Hash.h>
 #include <glog/logging.h>
@@ -68,7 +70,6 @@ class RowVector : public BaseVector {
             type->childAt(i)->toString());
       }
     }
-    updateContainsLazyNotLoaded();
   }
 
   static std::shared_ptr<RowVector> createEmpty(
@@ -221,11 +222,18 @@ class RowVector : public BaseVector {
 
   VectorPtr slice(vector_size_t offset, vector_size_t length) const override;
 
-  bool containsLazyNotLoaded() const {
-    return containsLazyNotLoaded_;
-  }
+  /// Whether any child is a lazy vector that has not been loaded yet. The
+  /// result is cached and computed lazily on first access to avoid scanning
+  /// children when the flag is never read (common for intermediate RowVectors).
+  /// Safe to call concurrently even when the cached flag is dirty; see
+  /// containsLazyNotLoaded_ for why it is atomic.
+  bool containsLazyNotLoaded() const;
 
-  void updateContainsLazyNotLoaded() const;
+  /// Invalidates the cached containsLazyNotLoaded flag, causing it to be
+  /// recomputed on next access. Must be called after directly manipulating or
+  /// replacing children (e.g. setting lazy fields, wrapping children in
+  /// dictionaries).
+  void invalidateContainsLazyNotLoaded() const;
 
   void validate(const VectorValidateOptions& options) const override;
 
@@ -297,19 +305,36 @@ class RowVector : public BaseVector {
   const size_t childrenSize_;
   mutable std::vector<VectorPtr> children_;
 
-  // Flag to indicate if any children of this vector contain lazy vector that
-  // has not been loaded.  Used to optimize recursive laziness check.  This will
-  // be initialized in the constructor, and should be updated by calling
-  // updateContainsLazyNotLoaded whenever a new lazy child is set (e.g. in table
-  // scan), or a lazy child is loaded (e.g. in LazyVector::ensureLoadedRows and
-  // loadedVector).
-  mutable bool containsLazyNotLoaded_;
+  void computeContainsLazyNotLoaded() const;
+
+  // Whether any child contains an unloaded lazy vector. -1 means dirty (needs
+  // recomputation on next access), 0 means false, 1 means true. Computed lazily
+  // on first read by computeContainsLazyNotLoaded().
+  //
+  // Atomic because that first-read recomputation can run concurrently on the
+  // same vector. isLazyNotLoaded() does not recurse into ARRAY/MAP children, so
+  // a RowVector nested inside an ARRAY/MAP keeps a dirty flag that is never
+  // evaluated at the ARRAY/MAP layer; a later code path can then read it from
+  // several driver threads at once when the same base vector is shared (e.g.
+  // MinMaxByNTest.groupByRow with ARRAY<ROW<..>> partitioned via
+  // LocalPartition). The race is benign -- there are no real lazy children so
+  // it always resolves to 0 -- but TSAN flags the unsynchronized read+write, so
+  // we load/store with memory_order_relaxed, which is free on x86.
+  //
+  // The cleaner fix is to forbid unloaded lazy ARRAY/MAP children at
+  // construction (a VELOX_CHECK in the ArrayVector/MapVector constructors).
+  // That barrier runs on the single constructing thread and would populate the
+  // nested Row's flag eagerly, removing the need for this to be atomic. We
+  // cannot add it yet: some internal code points still build ARRAY/MAP over
+  // lazy children. Until those callers are fixed the flag stays atomic.
+  mutable std::atomic<int8_t> containsLazyNotLoaded_{-1};
 
   // Flag to indicate all children has been loaded (non-recursively).  Used to
   // optimize loadedVector calls.  If this is true, we don't recurse into
   // children to check if they are loaded.  Will be set to true when
-  // loadedVector is called, and reset to false when updateContainsLazyNotLoaded
-  // is called (i.e. some children are likely updated to lazy).
+  // loadedVector is called, and reset to false when
+  // invalidateContainsLazyNotLoaded is called (i.e. some children are likely
+  // updated to lazy).
   mutable bool childrenLoaded_ = false;
 
   // For some non-selective reader, we need to keep the original vector that is

--- a/velox/vector/EncodedVectorCopy.cpp
+++ b/velox/vector/EncodedVectorCopy.cpp
@@ -717,7 +717,7 @@ void copyIntoRow(
       copyImpl(
           options, source.childAt(i), ranges, targetChild, targetChildMutable);
     }
-    targetRow->updateContainsLazyNotLoaded();
+    targetRow->invalidateContainsLazyNotLoaded();
   } else {
     BufferPtr nulls;
     if (target->rawNulls() || sourceNulls) {

--- a/velox/vector/LazyVector.cpp
+++ b/velox/vector/LazyVector.cpp
@@ -182,7 +182,7 @@ void LazyVector::ensureLoadedRowsImpl(
         decodedChild.decode(*child, baseRows, false);
         ensureLoadedRowsImpl(child, decodedChild, baseRows, childRows);
       }
-      rowVector->updateContainsLazyNotLoaded();
+      rowVector->invalidateContainsLazyNotLoaded();
       vector->loadedVector();
     }
     return;

--- a/velox/vector/tests/LazyVectorTest.cpp
+++ b/velox/vector/tests/LazyVectorTest.cpp
@@ -718,5 +718,35 @@ TEST_F(LazyVectorTest, chain) {
   assertEqualVectors(expected, lazy);
 }
 
+// Verify containsLazyNotLoaded is lazily evaluated and correctly recomputed
+// after invalidation for RowVectors.
+TEST_F(LazyVectorTest, containsLazyNotLoadedLazyEvaluation) {
+  constexpr vector_size_t size = 100;
+
+  // RowVector with no lazy children.
+  auto flat = makeFlatVector<int32_t>(size, folly::identity);
+  auto rowVector = makeRowVector({flat});
+  EXPECT_FALSE(rowVector->containsLazyNotLoaded());
+
+  // RowVector with a lazy child.
+  auto lazy = vectorMaker_.lazyFlatVector<int32_t>(
+      size, [](vector_size_t row) { return row; });
+  auto rowWithLazy = makeRowVector({flat, lazy});
+  EXPECT_TRUE(rowWithLazy->containsLazyNotLoaded());
+
+  // After loading the lazy child, invalidate and verify recomputation.
+  lazy->loadedVector();
+  rowWithLazy->invalidateContainsLazyNotLoaded();
+  EXPECT_FALSE(rowWithLazy->containsLazyNotLoaded());
+
+  // Replace a child with a new lazy vector after invalidation, verify
+  // recomputation picks it up.
+  auto lazy2 = vectorMaker_.lazyFlatVector<int32_t>(
+      size, [](vector_size_t row) { return row * 2; });
+  rowWithLazy->childAt(1) = lazy2;
+  rowWithLazy->invalidateContainsLazyNotLoaded();
+  EXPECT_TRUE(rowWithLazy->containsLazyNotLoaded());
+}
+
 } // namespace
 } // namespace facebook::velox


### PR DESCRIPTION
Summary:

This diff optimizes RowVector's `containsLazyNotLoaded_` flag computation from eager to lazy evaluation, addressing up to 10% CPU overhead in workloads with wide RowVectors.

**Problem:**
The `containsLazyNotLoaded_` flag was eagerly computed in the constructor and on every child mutation. This is wasteful for intermediate RowVectors where the flag is never read (e.g., top-level RowVectors from operators), causing significant overhead in cases with many columns.

**Solution:**
- Changed flag to be lazily computed on first access via `containsLazyNotLoaded()`
- Renamed `updateContainsLazyNotLoaded()` → `invalidateContainsLazyNotLoaded()` to mark the flag dirty rather than recompute eagerly
- Made flag a `std::atomic<int8_t>` (values: -1=dirty, 0=false, 1=true) to handle concurrent reads on nested RowVectors in ARRAY/MAP children

**Thread Safety:**
RowVectors nested inside ARRAY/MAP can have their flag read concurrently from multiple driver threads (since `isLazyNotLoaded()` doesn't recurse into ARRAY/MAP). Using `memory_order_relaxed` atomics eliminates TSAN warnings without measurable performance cost on x86.

**Future Work:**
The atomic can be removed once we enforce the "no lazy children in ARRAY/MAP" invariant at construction time. This requires first migrating code paths that currently generate these kind of vectors since its not considered valid. These instances are benign though since they only use it as a container to handover the lazy elements vector to the caller where it is promptly disassembled.

Reviewed By: Yuhta

Differential Revision: D105378872


