### PR TITLE
feat: Enable TIMESTAMP_UTC in CompactRow and UnsafeRowFast

### DIFF
--- a/velox/row/CompactRow.cpp
+++ b/velox/row/CompactRow.cpp
@@ -141,7 +141,6 @@ void serializeTyped<TypeKind::TIMESTAMP>(
     const raw_vector<uint8_t*>& nulls,
     char* buffer,
     std::vector<size_t>& offsets) {
-  VELOX_DCHECK(decoded.base()->type()->equivalent(*TIMESTAMP()));
   const auto* rawData = decoded.data<Timestamp>();
   if (!decoded.mayHaveNulls()) {
     for (auto i = 0; i < rows.size(); ++i) {
@@ -260,7 +259,6 @@ void CompactRow::initialize(const TypePtr& type) {
       supportsBulkCopy_ = decoded_.isIdentityMapping();
       break;
     case TypeKind::TIMESTAMP:
-      VELOX_DCHECK(type->equivalent(*TIMESTAMP()));
       valueBytes_ = sizeof(int64_t);
       fixedWidthTypeKind_ = true;
       break;
@@ -283,7 +281,6 @@ void CompactRow::initialize(const TypePtr& type) {
 namespace {
 std::optional<int32_t> fixedValueSize(const TypePtr& type) {
   if (type->isTimestamp()) {
-    VELOX_DCHECK(type->equivalent(*TIMESTAMP()));
     return sizeof(int64_t);
   }
   if (type->isFixedWidth()) {
@@ -674,7 +671,6 @@ void CompactRow::serializeFixedWidth(vector_size_t index, char* buffer) const {
       *reinterpret_cast<bool*>(buffer) = decoded_.valueAt<bool>(index);
       break;
     case TypeKind::TIMESTAMP: {
-      VELOX_DCHECK(decoded_.base()->type()->equivalent(*TIMESTAMP()));
       auto micros = decoded_.valueAt<Timestamp>(index).toMicros();
       ::memcpy(buffer, &micros, sizeof(int64_t));
       break;

--- a/velox/row/UnsafeRowFast.cpp
+++ b/velox/row/UnsafeRowFast.cpp
@@ -108,7 +108,6 @@ void UnsafeRowFast::initialize(const TypePtr& type) {
       supportsBulkCopy_ = decoded_.isIdentityMapping();
       break;
     case TypeKind::TIMESTAMP:
-      VELOX_DCHECK(type->equivalent(*TIMESTAMP()));
       valueBytes_ = sizeof(int64_t);
       fixedWidthTypeKind_ = true;
       break;
@@ -182,7 +181,6 @@ void UnsafeRowFast::serializeFixedWidth(vector_size_t index, char* buffer)
       *reinterpret_cast<bool*>(buffer) = decoded_.valueAt<bool>(index);
       break;
     case TypeKind::TIMESTAMP:
-      VELOX_DCHECK(decoded_.base()->type()->equivalent(*TIMESTAMP()));
       *reinterpret_cast<int64_t*>(buffer) =
           decoded_.valueAt<Timestamp>(index).toMicros();
       break;

--- a/velox/row/tests/CompactRowTest.cpp
+++ b/velox/row/tests/CompactRowTest.cpp
@@ -135,6 +135,7 @@ TEST_F(CompactRowTest, fixedRowSize) {
   ASSERT_EQ(1 + 4, CompactRow::fixedRowSize(ROW({INTEGER()})));
   ASSERT_EQ(1 + 2, CompactRow::fixedRowSize(ROW({SMALLINT()})));
   ASSERT_EQ(1 + 8, CompactRow::fixedRowSize(ROW({DOUBLE()})));
+  ASSERT_EQ(1 + 8, CompactRow::fixedRowSize(ROW({TIMESTAMP_UTC()})));
   ASSERT_EQ(std::nullopt, CompactRow::fixedRowSize(ROW({VARCHAR()})));
   ASSERT_EQ(std::nullopt, CompactRow::fixedRowSize(ROW({ARRAY(BIGINT())})));
   ASSERT_EQ(
@@ -346,6 +347,36 @@ TEST_F(CompactRowTest, timestamp) {
           ts(123'456),
           Timestamp::min(),
       }),
+  });
+
+  data->childAt(0)->setNull(1, true);
+  data->childAt(0)->setNull(3, true);
+
+  testRoundTrip(data);
+}
+
+TEST_F(CompactRowTest, timestampUtc) {
+  auto data = makeRowVector({
+      makeFlatVector<Timestamp>(
+          {
+              ts(0),
+              ts(1),
+              ts(2),
+          },
+          TIMESTAMP_UTC()),
+  });
+
+  testRoundTrip(data);
+
+  data = makeRowVector({
+      makeFlatVector<Timestamp>(
+          {
+              ts(0),
+              Timestamp::max(),
+              ts(123'456),
+              Timestamp::min(),
+          },
+          TIMESTAMP_UTC()),
   });
 
   data->childAt(0)->setNull(1, true);

--- a/velox/row/tests/UnsafeRowTest.cpp
+++ b/velox/row/tests/UnsafeRowTest.cpp
@@ -222,5 +222,31 @@ TEST_F(UnsafeRowTest, constantVector) {
   testRoundTrip(data);
 }
 
+TEST_F(UnsafeRowTest, timestampUtc) {
+  auto data = makeRowVector({
+      makeFlatVector<Timestamp>(
+          {Timestamp::fromMicros(0), Timestamp::fromMicros(1)},
+          TIMESTAMP_UTC()),
+  });
+
+  testRoundTrip(data);
+
+  data = makeRowVector({
+      makeFlatVector<Timestamp>(
+          {
+              Timestamp::fromMicros(0),
+              Timestamp::max(),
+              Timestamp::fromMicros(1'000),
+              Timestamp::min(),
+          },
+          TIMESTAMP_UTC()),
+  });
+
+  data->childAt(0)->setNull(1, true);
+  data->childAt(0)->setNull(3, true);
+
+  testRoundTrip(data);
+}
+
 } // namespace
 } // namespace facebook::velox::row


### PR DESCRIPTION
This PR enables TimestampUtcType in CompactRow and UnsafeRowFast by removing 
TIMESTAMP-only DCHECK restrictions in the serialization path. Both 
TimestampType and TimestampUtcType share the same physical representation 
Timestamp, so the same fixed-width encoding and decoding logic is valid for 
both.

Related issue: https://github.com/facebookincubator/velox/issues/17087.