### PR TITLE
fix(exec): Move iteration of preloadingSplits_ inside Task::mutex_ in Task::terminate (#17646)

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -601,7 +601,7 @@ std::vector<std::shared_ptr<Task>> Task::getRunningTasks() {
   std::vector<std::shared_ptr<Task>> tasks;
   std::shared_lock guard(taskListLock());
   tasks.reserve(taskList().size());
-  for (auto taskEntry : taskList()) {
+  for (const auto& taskEntry : taskList()) {
     if (auto task = taskEntry.taskPtr.lock()) {
       tasks.push_back(std::move(task));
     }
@@ -646,7 +646,7 @@ SplitsState& Task::getPlanNodeSplitsStateLocked(
 
 bool Task::allNodesReceivedNoMoreSplitsMessageLocked() const {
   for (const auto& it : splitsStates_) {
-    if (not it.second.noMoreSplits) {
+    if (!it.second.noMoreSplits) {
       return false;
     }
   }
@@ -1504,12 +1504,12 @@ void Task::removeDriver(std::shared_ptr<Task> self, Driver* driver) {
 
 void Task::ensureSplitGroupsAreBeingProcessedLocked() {
   // Only try creating more drivers if we are running.
-  if (not isRunningLocked() or (numDriversPerSplitGroup_ == 0)) {
+  if (!isRunningLocked() || (numDriversPerSplitGroup_ == 0)) {
     return;
   }
 
-  while (numRunningSplitGroups_ < concurrentSplitGroups_ and
-         not queuedSplitGroups_.empty()) {
+  while (numRunningSplitGroups_ < concurrentSplitGroups_ &&
+         !queuedSplitGroups_.empty()) {
     const uint32_t splitGroupId = queuedSplitGroups_.front();
     queuedSplitGroups_.pop();
 
@@ -2108,7 +2108,7 @@ bool Task::isGroupedExecution() const {
 }
 
 bool Task::isUngroupedExecution() const {
-  return not isGroupedExecution();
+  return !isGroupedExecution();
 }
 
 bool Task::hasMixedExecutionGroupJoin(
@@ -2603,6 +2603,8 @@ ContinueFuture Task::terminate(TaskState terminalState) {
 
   std::vector<ContinuePromise> splitPromises;
   std::vector<std::shared_ptr<JoinBridge>> oldBridges;
+  folly::F14FastSet<std::shared_ptr<connector::ConnectorSplit>>
+      preloadingSplitsCopy;
   std::vector<SplitGroupState> splitGroupStates;
   std::
       unordered_map<core::PlanNodeId, std::pair<std::vector<exec::Split>, bool>>
@@ -2650,6 +2652,10 @@ ContinueFuture Task::terminate(TaskState terminalState) {
         }
       }
     }
+
+    preloadingSplitsCopy.swap(preloadingSplits_);
+    // preloadingSplits_ is now empty; safe to iterate preloadingSplitsCopy
+    // outside the lock
   }
 
   TestValue::adjust("facebook::velox::exec::Task::terminate", this);
@@ -2682,10 +2688,9 @@ ContinueFuture Task::terminate(TaskState terminalState) {
     bridge->cancel();
   }
 
-  for (auto split : preloadingSplits_) {
+  for (auto& split : preloadingSplitsCopy) {
     split->dataSource->close();
   }
-  preloadingSplits_.clear();
 
   for (auto& barrierPromise : barrierPromises) {
     barrierPromise.setValue();
@@ -2992,7 +2997,7 @@ ContinueFuture Task::stateChangeFuture(uint64_t maxWaitMicros) {
   std::lock_guard<std::timed_mutex> l(mutex_);
   // If 'this' is running, the future is realized on timeout or when
   // this no longer is running.
-  if (not isRunningLocked()) {
+  if (!isRunningLocked()) {
     return ContinueFuture();
   }
   auto [promise, future] = makeVeloxContinuePromiseContract(
@@ -3008,7 +3013,7 @@ ContinueFuture Task::taskCompletionFuture() {
   std::lock_guard<std::timed_mutex> l(mutex_);
   // If 'this' is running, the future is realized on timeout or when
   // this no longer is running.
-  if (not isRunningLocked()) {
+  if (!isRunningLocked()) {
     return makeFinishFutureLocked(
         fmt::format("Task::taskCompletionFuture {}", taskId_).data());
   }
@@ -3307,7 +3312,7 @@ void Task::setError(const std::exception_ptr& exception) {
   TestValue::adjust("facebook::velox::exec::Task::setError", this);
   {
     std::lock_guard<std::timed_mutex> l(mutex_);
-    if (not isRunningLocked()) {
+    if (!isRunningLocked()) {
       return;
     }
     if (exception_ != nullptr) {


### PR DESCRIPTION
Summary:

`Task::terminate()` iterates `preloadingSplits_` (a `folly::F14FastSet<std::shared_ptr<connector::ConnectorSplit>>`) after dropping `mutex_`, copy-constructing each `shared_ptr` in the set. The only inserter into `preloadingSplits_` is `SplitsStore::getSplit()` (`maxPreloadSplits > 0` path), reached from `Task::getSplitOrFuture()` which holds `Task::mutex_`. After `terminate()` releases the lock, a driver scheduled on the executor can acquire it, insert into `preloadingSplits_`, and trigger an F14 rehash that frees the chunk array the in-flight iteration is still walking — yielding a use-after-free that surfaces as a SIGSEGV inside `_Sp_counted_base::_M_add_ref_copy` on the next copy. `Task::getSplitOrFuture()` does not check `terminateRequested_`, so this is reachable after the abort path has run.

Swap `preloadingSplits_` into a local set under the existing second-lock scope (which already moves out split-group state, join bridges, and split promises) and iterate the local copy outside the lock. Drops the now-redundant `preloadingSplits_.clear()` — the swap leaves the member empty.

Reviewed By: xiaoxmeng

Differential Revision: D106582904


