### PR TITLE
fix: Use plain string for Spark CAST(decimal as string) when ANSI is enabled

### DIFF
--- a/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/functions/sparksql/specialforms/SparkCastHooks.h"
 #include "velox/functions/lib/string/StringImpl.h"
+#include "velox/functions/sparksql/SparkQueryConfig.h"
 #include "velox/type/TimestampConversion.h"
 #include "velox/type/tz/TimeZoneMap.h"
 
@@ -132,4 +133,11 @@ exec::PolicyType SparkCastHooks::getPolicy() const {
   }
   return exec::PolicyType::SparkCastPolicy;
 }
+
+bool SparkCastHooks::isScientific() const {
+  // When casting decimal as string, Spark always use plain string when ANSI
+  // mode is enabled.
+  return !SparkQueryConfig{config_}.ansiEnabled();
+}
+
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
@@ -203,4 +203,11 @@ exec::PolicyType SparkCastHooks::getPolicy() const {
   }
   return exec::PolicyType::SparkCastPolicy;
 }
+
+bool SparkCastHooks::isScientific() const {
+  // When casting decimal as string, Spark always use plain string when ANSI
+  // mode is enabled.
+  return !SparkQueryConfig{config_}.ansiEnabled();
+}
+
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.h
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.h
@@ -78,9 +78,7 @@ class SparkCastHooks : public exec::CastHooks {
 
   exec::PolicyType getPolicy() const override;
 
-  bool isScientific() const override {
-    return true;
-  }
+  bool isScientific() const override;
 
  private:
   // Casts a number to a timestamp. The number is treated as the number of

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.h
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.h
@@ -105,9 +105,7 @@ class SparkCastHooks : public exec::CastHooks {
       Timestamp& timestamp,
       const tz::TimeZone& timeZone) const override;
 
-  bool isScientific() const override {
-    return true;
-  }
+  bool isScientific() const override;
 
  private:
   // Casts a number to a timestamp. The number is treated as the number of

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -280,7 +280,7 @@ class SparkCastExprTest : public functions::test::CastBaseTest {
     testDecimalToIntegralCasts<int8_t>();
   }
 
-  void testDecimalToString() {
+  void testDecimalToString(bool useScientificNotation) {
     testCast(
         makeFlatVector<int64_t>(
             {100, 1230, 12345, 0, -100, -1230, -12345}, DECIMAL(10, 2)),
@@ -314,16 +314,31 @@ class SparkCastExprTest : public functions::test::CastBaseTest {
              -HugeInt::build(0, 12345000000)},
             DECIMAL(20, 10)),
         makeFlatVector<std::string>(
-            {"1.0000000000",
-             "1.2300000000",
-             "1.2345000000",
-             "0E-10",
-             "5.5E-9",
-             "1E-10",
-             "-3E-10",
-             "-1.0000000000",
-             "-1.2300000000",
-             "-1.2345000000"}));
+            useScientificNotation
+                ? std::vector<std::string>{
+                      "1.0000000000",
+                      "1.2300000000",
+                      "1.2345000000",
+                      "0E-10",
+                      "5.5E-9",
+                      "1E-10",
+                      "-3E-10",
+                      "-1.0000000000",
+                      "-1.2300000000",
+                      "-1.2345000000",
+                  }
+                : std::vector<std::string>{
+                      "1.0000000000",
+                      "1.2300000000",
+                      "1.2345000000",
+                      "0.0000000000",
+                      "0.0000000055",
+                      "0.0000000001",
+                      "-0.0000000003",
+                      "-1.0000000000",
+                      "-1.2300000000",
+                      "-1.2345000000",
+                  }));
 
     testCast(
         makeFlatVector<int64_t>({100, 200, 300}, DECIMAL(10, 0)),
@@ -333,14 +348,27 @@ class SparkCastExprTest : public functions::test::CastBaseTest {
         makeFlatVector<int64_t>(
             {0, 12, 55, 120, 1200, -3, -12, -120}, DECIMAL(10, 8)),
         makeFlatVector<std::string>(
-            {"0E-8",
-             "1.2E-7",
-             "5.5E-7",
-             "0.00000120",
-             "0.00001200",
-             "-3E-8",
-             "-1.2E-7",
-             "-0.00000120"}));
+            useScientificNotation
+                ? std::vector<std::string>{
+                      "0E-8",
+                      "1.2E-7",
+                      "5.5E-7",
+                      "0.00000120",
+                      "0.00001200",
+                      "-3E-8",
+                      "-1.2E-7",
+                      "-0.00000120",
+                  }
+                : std::vector<std::string>{
+                      "0.00000000",
+                      "0.00000012",
+                      "0.00000055",
+                      "0.00000120",
+                      "0.00001200",
+                      "-0.00000003",
+                      "-0.00000012",
+                      "-0.00000120",
+                  }));
 
     testCast(
         makeNullableFlatVector<int64_t>(
@@ -1072,7 +1100,7 @@ TEST_F(SparkCastExprTestAnsiOn, bigIntToBinary) {
 }
 
 TEST_F(SparkCastExprTestAnsiOn, decimalToString) {
-  testDecimalToString();
+  testDecimalToString(false);
 }
 
 TEST_F(SparkCastExprTestAnsiOn, decimalToIntegral) {
@@ -1319,7 +1347,7 @@ TEST_F(SparkCastExprTestAnsiOff, decimalToIntegral) {
 }
 
 TEST_F(SparkCastExprTestAnsiOff, decimalToString) {
-  testDecimalToString();
+  testDecimalToString(true);
 }
 
 TEST_F(SparkCastExprTestAnsiOff, floatToTimestamp) {

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -286,7 +286,7 @@ class SparkCastExprTest : public functions::test::CastBaseTest {
     testDecimalToIntegralCasts<int8_t>();
   }
 
-  void testDecimalToString() {
+  void testDecimalToString(bool useScientificNotation) {
     testCast(
         makeFlatVector<int64_t>(
             {100, 1230, 12345, 0, -100, -1230, -12345}, DECIMAL(10, 2)),
@@ -320,16 +320,31 @@ class SparkCastExprTest : public functions::test::CastBaseTest {
              -HugeInt::build(0, 12345000000)},
             DECIMAL(20, 10)),
         makeFlatVector<std::string>(
-            {"1.0000000000",
-             "1.2300000000",
-             "1.2345000000",
-             "0E-10",
-             "5.5E-9",
-             "1E-10",
-             "-3E-10",
-             "-1.0000000000",
-             "-1.2300000000",
-             "-1.2345000000"}));
+            useScientificNotation
+                ? std::vector<std::string>{
+                      "1.0000000000",
+                      "1.2300000000",
+                      "1.2345000000",
+                      "0E-10",
+                      "5.5E-9",
+                      "1E-10",
+                      "-3E-10",
+                      "-1.0000000000",
+                      "-1.2300000000",
+                      "-1.2345000000",
+                  }
+                : std::vector<std::string>{
+                      "1.0000000000",
+                      "1.2300000000",
+                      "1.2345000000",
+                      "0.0000000000",
+                      "0.0000000055",
+                      "0.0000000001",
+                      "-0.0000000003",
+                      "-1.0000000000",
+                      "-1.2300000000",
+                      "-1.2345000000",
+                  }));
 
     testCast(
         makeFlatVector<int64_t>({100, 200, 300}, DECIMAL(10, 0)),
@@ -339,14 +354,27 @@ class SparkCastExprTest : public functions::test::CastBaseTest {
         makeFlatVector<int64_t>(
             {0, 12, 55, 120, 1200, -3, -12, -120}, DECIMAL(10, 8)),
         makeFlatVector<std::string>(
-            {"0E-8",
-             "1.2E-7",
-             "5.5E-7",
-             "0.00000120",
-             "0.00001200",
-             "-3E-8",
-             "-1.2E-7",
-             "-0.00000120"}));
+            useScientificNotation
+                ? std::vector<std::string>{
+                      "0E-8",
+                      "1.2E-7",
+                      "5.5E-7",
+                      "0.00000120",
+                      "0.00001200",
+                      "-3E-8",
+                      "-1.2E-7",
+                      "-0.00000120",
+                  }
+                : std::vector<std::string>{
+                      "0.00000000",
+                      "0.00000012",
+                      "0.00000055",
+                      "0.00000120",
+                      "0.00001200",
+                      "-0.00000003",
+                      "-0.00000012",
+                      "-0.00000120",
+                  }));
 
     testCast(
         makeNullableFlatVector<int64_t>(
@@ -1803,7 +1831,7 @@ TEST_F(SparkCastExprTestAnsiOn, bigIntToBinary) {
 }
 
 TEST_F(SparkCastExprTestAnsiOn, decimalToString) {
-  testDecimalToString();
+  testDecimalToString(false);
 }
 
 TEST_F(SparkCastExprTestAnsiOn, decimalToIntegral) {
@@ -2349,7 +2377,7 @@ TEST_F(SparkCastExprTestAnsiOff, decimalToFloat) {
 }
 
 TEST_F(SparkCastExprTestAnsiOff, decimalToString) {
-  testDecimalToString();
+  testDecimalToString(true);
 }
 
 TEST_F(SparkCastExprTestAnsiOff, floatToTimestamp) {


### PR DESCRIPTION
Currently, casting decimal as string type will result in strings with 
exponential notations if the adjusted exponent is less than -6. Since Spark 
3.4, when ANSI mode is enabled, Spark always uses plain string representation 
when casting decimal values to strings.

Spark Jira: https://issues.apache.org/jira/browse/SPARK-39749
Follow-up for: https://github.com/facebookincubator/velox/pull/14910#issuecomment-4124878748