### PR TITLE
feat(spark): Add Spark sin, tan, tanh, radians, and ln math functions

### DIFF
--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -290,6 +290,10 @@ Mathematical Functions
     Returns true if x is Nan, or false otherwise. Returns false is x is NULL.
     Supported types are: REAL, DOUBLE.
 
+.. spark:function:: ln(x) -> double
+
+    Returns the natural logarithm of ``x``. Return null for zero and non-positive input.
+
 .. spark:function:: log(base, expr) -> double
 
     Returns the logarithm of ``expr`` with ``base``.
@@ -344,6 +348,10 @@ Mathematical Functions
 .. spark:function:: power(x, p) -> double
 
     Returns ``x`` raised to the power of ``p``.
+
+.. spark:function:: radians(x) -> double
+
+    Converts angle x in degrees to radians.
 
 .. spark:function:: rand() -> double
 
@@ -407,6 +415,10 @@ Mathematical Functions
     * 1.0 if the argument is +Infinity,
     * -1.0 if the argument is -Infinity.
 
+.. spark:function:: sin(x) -> double
+
+    Returns the sine of ``x``.
+
 .. spark:function:: sinh(x) -> double
 
     Returns hyperbolic sine of ``x``.
@@ -427,6 +439,14 @@ Mathematical Functions
         SELECT CAST(-999999999999999999999999999.999 as DECIMAL(30, 3)) - CAST(-999999999999999999999999999.999 as DECIMAL(30, 3)); -- DECIMAL(31, 3) 0.000
         SELECT CAST(99999999999999999999999999999999.99998 as DECIMAL(38, 6)) - CAST(-0.00001 as DECIMAL(38, 5)); -- DECIMAL(38, 6) 99999999999999999999999999999999.999990
         SELECT CAST(-99999999999999999999999999999999990.0 as DECIMAL(38, 3)) - CAST(0.00001 as DECIMAL(38, 7)); -- DECIMAL(38, 6) NULL
+
+.. spark:function:: tan(x) -> double
+
+    Returns the tangent of ``x``.
+
+.. spark:function:: tanh(x) -> double
+
+    Returns the hyperbolic tangent of ``x``.
 
 .. spark:function:: unaryminus(x) -> [same as x]
 

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -332,6 +332,20 @@ struct Log2Function {
 };
 
 template <typename T>
+struct LnFunction {
+  // Returns NULL (rather than NaN or -Infinity) when the argument is at or
+  // below the zero asymptote. This matches Spark's UnaryLogExpression, which
+  // inherits the convention from Hive.
+  FOLLY_ALWAYS_INLINE bool call(double& result, double a) {
+    if (a <= 0.0) {
+      return false;
+    }
+    result = std::log(a);
+    return true;
+  }
+};
+
+template <typename T>
 struct Log1pFunction {
   FOLLY_ALWAYS_INLINE bool call(double& result, double a) {
     if (a <= -1) {

--- a/velox/functions/sparksql/registration/RegisterMath.cpp
+++ b/velox/functions/sparksql/registration/RegisterMath.cpp
@@ -42,11 +42,15 @@ void registerMathFunctions(const std::string& prefix) {
   registerFunction<AtanhFunction, double, double>({prefix + "atanh"});
   registerFunction<SecFunction, double, double>({prefix + "sec"});
   registerFunction<CscFunction, double, double>({prefix + "csc"});
+  registerFunction<SinFunction, double, double>({prefix + "sin"});
   registerFunction<SinhFunction, double, double>({prefix + "sinh"});
   registerFunction<CosFunction, double, double>({prefix + "cos"});
   registerFunction<CoshFunction, double, double>({prefix + "cosh"});
   registerFunction<CotFunction, double, double>({prefix + "cot"});
+  registerFunction<TanFunction, double, double>({prefix + "tan"});
+  registerFunction<TanhFunction, double, double>({prefix + "tanh"});
   registerFunction<DegreesFunction, double, double>({prefix + "degrees"});
+  registerFunction<RadiansFunction, double, double>({prefix + "radians"});
   registerFunction<Atan2Function, double, double, double>({prefix + "atan2"});
   registerFunction<Log1pFunction, double, double>({prefix + "log1p"});
   registerFunction<ToBinaryStringFunction, Varchar, int64_t>({prefix + "bin"});
@@ -81,6 +85,7 @@ void registerMathFunctions(const std::string& prefix) {
       {prefix + "floor"});
   registerDecimalFloor(prefix);
   registerFunction<HypotFunction, double, double, double>({prefix + "hypot"});
+  registerFunction<sparksql::LnFunction, double, double>({prefix + "ln"});
   registerFunction<sparksql::Log2Function, double, double>({prefix + "log2"});
   registerFunction<sparksql::Log10Function, double, double>({prefix + "log10"});
   registerFunction<sparksql::LogarithmFunction, double, double, double>(

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -564,6 +564,57 @@ TEST_F(ArithmeticTest, sinh) {
   EXPECT_TRUE(std::isnan(sinh(kNan).value_or(0)));
 }
 
+TEST_F(ArithmeticTest, sin) {
+  const auto sin = [&](std::optional<double> a) {
+    return evaluateOnce<double>("sin(c0)", a);
+  };
+
+  EXPECT_EQ(sin(0), 0);
+  EXPECT_EQ(sin(std::nullopt), std::nullopt);
+  EXPECT_TRUE(std::isnan(sin(kInf).value_or(0)));
+  EXPECT_TRUE(std::isnan(sin(-kInf).value_or(0)));
+  EXPECT_TRUE(std::isnan(sin(kNan).value_or(0)));
+}
+
+TEST_F(ArithmeticTest, tan) {
+  const auto tan = [&](std::optional<double> a) {
+    return evaluateOnce<double>("tan(c0)", a);
+  };
+
+  EXPECT_EQ(tan(0), 0);
+  EXPECT_EQ(tan(std::nullopt), std::nullopt);
+  EXPECT_TRUE(std::isnan(tan(kInf).value_or(0)));
+  EXPECT_TRUE(std::isnan(tan(-kInf).value_or(0)));
+  EXPECT_TRUE(std::isnan(tan(kNan).value_or(0)));
+}
+
+TEST_F(ArithmeticTest, tanh) {
+  const auto tanh = [&](std::optional<double> a) {
+    return evaluateOnce<double>("tanh(c0)", a);
+  };
+
+  EXPECT_EQ(tanh(0), 0);
+  EXPECT_EQ(tanh(kInf), 1);
+  EXPECT_EQ(tanh(-kInf), -1);
+  EXPECT_EQ(tanh(std::nullopt), std::nullopt);
+  EXPECT_TRUE(std::isnan(tanh(kNan).value_or(0)));
+}
+
+TEST_F(ArithmeticTest, radians) {
+  const auto radians = [&](std::optional<double> a) {
+    return evaluateOnce<double>("radians(c0)", a);
+  };
+
+  EXPECT_EQ(radians(0), 0);
+  EXPECT_DOUBLE_EQ(radians(180).value(), M_PI);
+  EXPECT_DOUBLE_EQ(radians(-180).value(), -M_PI);
+  EXPECT_DOUBLE_EQ(radians(360).value(), 2 * M_PI);
+  EXPECT_EQ(radians(kInf), kInf);
+  EXPECT_EQ(radians(-kInf), -kInf);
+  EXPECT_EQ(radians(std::nullopt), std::nullopt);
+  EXPECT_TRUE(std::isnan(radians(kNan).value_or(0)));
+}
+
 TEST_F(ArithmeticTest, log1p) {
   const double kE = std::exp(1);
 
@@ -892,6 +943,18 @@ TEST_F(LogNTest, log2) {
   EXPECT_EQ(log2(-1.0), std::nullopt);
   EXPECT_EQ(log2(0.0), std::nullopt);
   EXPECT_EQ(log2(kInf), kInf);
+}
+
+TEST_F(LogNTest, ln) {
+  const auto ln = [&](std::optional<double> a) {
+    return evaluateOnce<double>("ln(c0)", a);
+  };
+  EXPECT_EQ(ln(1.0), 0.0);
+  EXPECT_DOUBLE_EQ(ln(std::exp(1)).value(), 1.0);
+  EXPECT_EQ(ln(0.0), std::nullopt);
+  EXPECT_EQ(ln(-1.0), std::nullopt);
+  EXPECT_EQ(ln(kInf), kInf);
+  EXPECT_TRUE(std::isnan(ln(kNan).value_or(0)));
 }
 
 TEST_F(LogNTest, log10) {


### PR DESCRIPTION
## Summary

Five math scalar functions are not registered in Spark:

  `sin`, `tan`, `tanh`, `radians`, `ln`

Each Velox implementation already exists. For `sin` / `tan` / `tanh` / `radians` the prestosql impls are reused unqualified — their semantics are identical to Spark's `Math.*` (`std::sin` / `std::tan` / `std::tanh` and `x * (π/180)`), matching the existing pattern for `sinh`, `cos`, `cosh`, `degrees`, etc.

`ln` needs Spark-specific handling: Spark's `UnaryLogExpression` returns NULL for arguments at or below the zero asymptote (inherited from Hive), whereas `std::log` would return `-Infinity` or `NaN`. A new `sparksql::LnFunction` mirrors the existing `sparksql::Log2Function` pattern (`bool call(...)` returning `false` to signal NULL), and is explicitly qualified at the registration site to disambiguate from the prestosql namespace's `LnFunction`.

## Test plan

- [x] `ArithmeticTest.sin` — zero, ±∞ (NaN), NaN, null
- [x] `ArithmeticTest.tan` — zero, ±∞ (NaN), NaN, null
- [x] `ArithmeticTest.tanh` — zero, +∞ (=1), −∞ (=−1), NaN, null
- [x] `ArithmeticTest.radians` — zero, 180 (=π), −180, 360 (=2π), ±∞, NaN, null
- [x] `LogNTest.ln` — `ln(1)=0`, `ln(e)=1`, `ln(0)` → null, `ln(−1)` → null,
      `ln(+∞)`, `ln(NaN)`
- [x] Existing `LogNTest.log2` / `LogNTest.log10` / `LogNTest.log` and the
      full `ArithmeticTest` suite still pass (51 tests total in the affected
      suites)

Surfaced by https://github.com/apache/incubator-gluten/issues/12157.