### PR TITLE
misc: Add @PingLiuPing as code owner for Parquet and Connectors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,13 +37,13 @@ velox/experimental/breeze @dreveman
 velox/experimental/cudf/ @bdice @karthikeyann @devavret @mhaseeb123 @shrshi @simoneves @mattgara @jinchengchenghh
 
 # Parquet
-velox/dwio/parquet/ @majetideepak
+velox/dwio/parquet/ @majetideepak @PingLiuPing
 
 # Storage Adapters
 velox/connectors/hive/storage_adapters/ @majetideepak
 
 # Connectors
-velox/connectors/ @majetideepak
+velox/connectors/ @majetideepak @PingLiuPing
 
 # Caching
 velox/common/caching/ @majetideepak


### PR DESCRIPTION
- Add @PingLiuPing as code owner for `velox/dwio/parquet/` and `velox/connectors/`.
- @PingLiuPing has been actively contributing to and reviewing Parquet and Iceberg changes.