### PR TITLE
refactor: Remove the GCC 11.1 / 11.2 workaround

### DIFF
--- a/velox/common/config/IConfig.h
+++ b/velox/common/config/IConfig.h
@@ -31,23 +31,13 @@ namespace facebook::velox::config {
 /// externally managed system configuration.
 class IConfig {
  public:
-  // Do not inline this member function as lambda. Otherwise, a GCC bug
-  // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=103186 might be triggered
-  // with GCC 11.1 and 11.2.
-  // This is currently a required workaround specifically for Apache Gluten
-  // that still relies on GCC 11.2:
-  // https://github.com/apache/gluten/issues/11991. The workaround is needed
-  // until Apache Gluten migrates away from the old compiler.
-  template <typename T>
-  static T defaultToT(std::string /* unused */, std::string value) {
-    return folly::to<T>(value);
-  }
-
   template <typename T>
   std::optional<T> get(
       const std::string& key,
       const std::function<T(std::string, std::string)>& toT =
-          defaultToT<T>) const {
+          [](auto /* unused */, auto value) {
+            return folly::to<T>(value);
+          }) const {
     if (auto val = access(key)) {
       return toT(key, *val);
     }
@@ -59,7 +49,9 @@ class IConfig {
       const std::string& key,
       const T& defaultValue,
       const std::function<T(std::string, std::string)>& toT =
-          defaultToT<T>) const {
+          [](auto /* unused */, auto value) {
+            return folly::to<T>(value);
+          }) const {
     if (auto val = access(key)) {
       return toT(key, *val);
     }


### PR DESCRIPTION
This PR reverts "fix(build): GCC 11.2 build regression (#17208)", because Apache Gluten's CI has migrated onto GCC 13, so no longer relies on the previous compiler workaround.

Discussed at https://github.com/facebookincubator/velox/pull/17208#discussion_r3317465117.