### PR TITLE
feat(config): Make ConfigProvider config-file aware

### DIFF
--- a/velox/common/config/Config.cpp
+++ b/velox/common/config/Config.cpp
@@ -145,6 +145,12 @@ std::string ConfigBase::toConfigKey(std::string_view sessionKey) {
   return configKey;
 }
 
+std::string ConfigBase::toSessionKey(std::string_view configKey) {
+  std::string sessionKey{configKey};
+  std::replace(sessionKey.begin(), sessionKey.end(), '-', '_');
+  return sessionKey;
+}
+
 std::optional<std::string> ConfigBase::access(const std::string& key) const {
   std::shared_lock l{mutex_};
   if (auto it = configs_.find(key); it != configs_.end()) {

--- a/velox/common/config/Config.h
+++ b/velox/common/config/Config.h
@@ -121,9 +121,11 @@ class ConfigBase : public IConfig {
 
   std::unordered_map<std::string, std::string> rawConfigsCopy() const final;
 
-  /// Converts a session key to another config key by replacing
-  /// '_' with '-'.
+  /// Converts a session key to a config key by replacing '_' with '-'.
   static std::string toConfigKey(std::string_view sessionKey);
+
+  /// Converts a config key to a session key by replacing '-' with '_'.
+  static std::string toSessionKey(std::string_view configKey);
 
   /// Returns the value for 'key' if present; otherwise checks 'fallback'.
   /// Fallback key is derived from 'key' by replacing '_' with '-'.

--- a/velox/common/config/ConfigProvider.h
+++ b/velox/common/config/ConfigProvider.h
@@ -20,9 +20,11 @@
 namespace facebook::velox::config {
 
 /// Declares and normalizes configuration properties for a component.
-/// A ConfigProvider is shared and stateless — it does not hold per-session
-/// values. It knows only its own property names (e.g., "session_timezone"),
-/// not how they are exposed to the user.
+/// Each provider knows its own property names (e.g., "session_timezone"),
+/// types, code defaults, and validation rules. Providers may be initialized
+/// with config-file values at construction to override code defaults,
+/// enabling a three-layer cascade: code default → config file → session
+/// override.
 class ConfigProvider {
  public:
   virtual ~ConfigProvider() = default;

--- a/velox/connectors/hive/HiveConfigProvider.cpp
+++ b/velox/connectors/hive/HiveConfigProvider.cpp
@@ -15,12 +15,38 @@
  */
 #include "velox/connectors/hive/HiveConfigProvider.h"
 
+#include <glog/logging.h>
+#include "velox/common/config/Config.h"
 #include "velox/connectors/hive/HiveConfig.h"
 
 namespace facebook::velox::connector::hive {
 
 std::vector<config::ConfigProperty> HiveConfigProvider::properties() const {
-  return HiveConfig::registeredProperties();
+  auto props = HiveConfig::registeredProperties();
+  if (catalogConfig_ == nullptr) {
+    return props;
+  }
+
+  // Build a lookup map from session property name to index in props.
+  std::unordered_map<std::string, size_t> propIndex;
+  for (size_t i = 0; i < props.size(); ++i) {
+    propIndex[props[i].name] = i;
+  }
+
+  // Iterate config-file entries, convert each key to session property name,
+  // and override the code default. Log unrecognized keys.
+  for (const auto& [configKey, value] : catalogConfig_->rawConfigs()) {
+    auto sessionKey = config::ConfigBase::toSessionKey(configKey);
+    auto it = propIndex.find(sessionKey);
+    if (it != propIndex.end()) {
+      props[it->second].defaultValue = normalize(sessionKey, value);
+    } else {
+      LOG(WARNING) << "Unrecognized config property in catalog '"
+                   << catalogName_ << "': " << configKey;
+    }
+  }
+
+  return props;
 }
 
 std::string HiveConfigProvider::normalize(

--- a/velox/connectors/hive/HiveConfigProvider.h
+++ b/velox/connectors/hive/HiveConfigProvider.h
@@ -17,17 +17,40 @@
 
 #include "velox/common/config/ConfigProvider.h"
 
+namespace facebook::velox::config {
+class ConfigBase;
+} // namespace facebook::velox::config
+
 namespace facebook::velox::connector::hive {
 
 /// Exposes Hive connector session-overridable properties.
+/// Optionally initialized with config-file values from the catalog's
+/// .properties file. When provided, config-file values override code
+/// defaults in ConfigProperty::defaultValue, enabling a three-layer
+/// cascade: code default → config file → session override.
 class HiveConfigProvider : public config::ConfigProvider {
  public:
+  /// Creates a provider with code defaults only.
+  HiveConfigProvider() = default;
+
+  /// Creates a provider with config-file overrides. For each session
+  /// property, the corresponding config-file key is looked up via
+  /// ConfigBase::toConfigKey() (underscore → dash conversion).
+  HiveConfigProvider(
+      const std::string& catalogName,
+      const config::ConfigBase* catalogConfig)
+      : catalogName_(catalogName), catalogConfig_(catalogConfig) {}
+
   /// Returns all session-overridable Hive connector properties.
   std::vector<config::ConfigProperty> properties() const override;
 
   /// Validates and normalizes a property value.
   std::string normalize(std::string_view name, std::string_view value)
       const override;
+
+ private:
+  std::string catalogName_;
+  const config::ConfigBase* catalogConfig_{nullptr};
 };
 
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -36,6 +36,7 @@ HiveConnector::HiveConnector(
     folly::Executor* ioExecutor)
     : Connector(id, std::move(config)),
       hiveConfig_(std::make_shared<HiveConfig>(connectorConfig())),
+      configProvider_(id, connectorConfig().get()),
       fileHandleFactory_(
           hiveConfig_->isFileHandleCacheEnabled()
               ? std::make_unique<SimpleLRUCache<FileHandleKey, FileHandle>>(
@@ -56,8 +57,7 @@ HiveConnector::HiveConnector(
 }
 
 const config::ConfigProvider* HiveConnector::configProvider() const {
-  static const HiveConfigProvider kProvider;
-  return &kProvider;
+  return &configProvider_;
 }
 
 std::unique_ptr<DataSource> HiveConnector::createDataSource(

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -18,6 +18,7 @@
 #include "velox/connectors/Connector.h"
 #include "velox/connectors/hive/FileHandle.h"
 #include "velox/connectors/hive/HiveConfig.h"
+#include "velox/connectors/hive/HiveConfigProvider.h"
 #include "velox/core/PlanNode.h"
 
 namespace facebook::velox::dwio::common {
@@ -87,6 +88,7 @@ class HiveConnector : public Connector {
 
  protected:
   const std::shared_ptr<HiveConfig> hiveConfig_;
+  HiveConfigProvider configProvider_;
   FileHandleFactory fileHandleFactory_;
   folly::Executor* ioExecutor_;
 };

--- a/velox/core/QueryConfigProvider.cpp
+++ b/velox/core/QueryConfigProvider.cpp
@@ -15,12 +15,35 @@
  */
 #include "velox/core/QueryConfigProvider.h"
 
+#include <glog/logging.h>
 #include "velox/core/QueryConfig.h"
 
 namespace facebook::velox::core {
 
 std::vector<config::ConfigProperty> QueryConfigProvider::properties() const {
-  return QueryConfig::registeredProperties();
+  auto props = QueryConfig::registeredProperties();
+  if (configOverrides_.empty()) {
+    return props;
+  }
+
+  // Build a lookup map from property name to index.
+  std::unordered_map<std::string, size_t> propIndex;
+  for (size_t i = 0; i < props.size(); ++i) {
+    propIndex[props[i].name] = i;
+  }
+
+  // Override code defaults with config-file values. Warn on unknown keys.
+  for (const auto& [key, value] : configOverrides_) {
+    auto it = propIndex.find(key);
+    if (it != propIndex.end()) {
+      props[it->second].defaultValue = normalize(key, value);
+    } else {
+      LOG(WARNING) << "Unregistered session property in execution config: "
+                   << key;
+    }
+  }
+
+  return props;
 }
 
 std::string QueryConfigProvider::normalize(

--- a/velox/core/QueryConfigProvider.h
+++ b/velox/core/QueryConfigProvider.h
@@ -15,17 +15,30 @@
  */
 #pragma once
 
+#include <unordered_map>
 #include "velox/common/config/ConfigProvider.h"
 
 namespace facebook::velox::core {
 
 /// Exposes all QueryConfig properties as ConfigProperty entries.
+/// Optionally initialized with config-file values that override code
+/// defaults in ConfigProperty::defaultValue. The overrides map uses
+/// session property names (snake_case), matching QueryConfig keys.
 class QueryConfigProvider : public config::ConfigProvider {
  public:
+  QueryConfigProvider() = default;
+
+  explicit QueryConfigProvider(
+      std::unordered_map<std::string, std::string> configOverrides)
+      : configOverrides_(std::move(configOverrides)) {}
+
   std::vector<config::ConfigProperty> properties() const override;
 
   std::string normalize(std::string_view name, std::string_view value)
       const override;
+
+ private:
+  std::unordered_map<std::string, std::string> configOverrides_;
 };
 
 } // namespace facebook::velox::core

--- a/velox/core/tests/QueryConfigProviderTest.cpp
+++ b/velox/core/tests/QueryConfigProviderTest.cpp
@@ -87,6 +87,37 @@ TEST_F(QueryConfigProviderTest, knownProperties) {
   EXPECT_EQ(cpuOverhead->defaultValue, "1");
 }
 
+TEST(QueryConfigProviderConfigOverridesTest, overridesApplied) {
+  QueryConfigProvider provider(
+      {{QueryConfig::kSpillEnabled, "true"},
+       {QueryConfig::kSessionTimezone, "UTC"}});
+  auto props = provider.properties();
+
+  auto findProp =
+      [&](const std::string& name) -> std::optional<ConfigProperty> {
+    for (const auto& prop : props) {
+      if (prop.name == name) {
+        return prop;
+      }
+    }
+    return std::nullopt;
+  };
+
+  // Overridden properties reflect config-file values.
+  auto spillEnabled = findProp(QueryConfig::kSpillEnabled);
+  ASSERT_TRUE(spillEnabled.has_value());
+  EXPECT_EQ(spillEnabled->defaultValue, "true");
+
+  auto sessionTz = findProp(QueryConfig::kSessionTimezone);
+  ASSERT_TRUE(sessionTz.has_value());
+  EXPECT_EQ(sessionTz->defaultValue, "UTC");
+
+  // Non-overridden properties retain code defaults.
+  auto startTime = findProp(QueryConfig::kSessionStartTime);
+  ASSERT_TRUE(startTime.has_value());
+  EXPECT_EQ(startTime->defaultValue, "0");
+}
+
 TEST_F(QueryConfigProviderTest, normalizePassthrough) {
   EXPECT_EQ(provider_.normalize("spill_enabled", "true"), "true");
   EXPECT_EQ(provider_.normalize("session_timezone", "UTC"), "UTC");


### PR DESCRIPTION
Summary:
Enable ConfigProvider implementations to be initialized with
config-file values, so ConfigProperty::defaultValue reflects deployment
defaults rather than code defaults. This supports a three-layer configuration
cascade: code default → config file → session override.

Previously, ConfigProvider was stateless — properties() always returned
code-defined defaults. When an application loaded different values from config
files (e.g., spill-enabled=true in config.properties), there was no way to
reflect that in the provider. This caused SessionConfig::effectiveValues() to
return code defaults, which could shadow config-file values set by the
deployment.

Changes:
- ConfigBase: Added toSessionKey() — converts config-file keys (kebab-case) to
  session property names (snake_case). Reverse of the existing toConfigKey().
- QueryConfigProvider: Added optional constructor accepting a config overrides
  map (using session property names). Overrides are validated via normalize()
  and unknown keys produce a LOG(WARNING).
- HiveConfigProvider: Added optional constructor accepting a const ConfigBase*
  (the catalog's config). Iterates config-file entries, maps keys via
  toSessionKey(), validates via normalize(), and warns on unknown keys. Each
  property's defaultValue is updated to reflect the deployment config.
- HiveConnector: configProvider() now returns a per-instance HiveConfigProvider
  initialized from the connector's config, replacing the previous static
  singleton. This ensures each catalog (e.g., prism, prism_batch) has its own
  provider reflecting its own config file.
- ConfigProvider: Updated class documentation to describe the config-file
  awareness pattern.

No changes to ConfigRegistry, SessionConfig, or the ConfigProvider interface.
The config-file awareness is an implementation detail of each provider.

Reviewed By: arhimondr

Differential Revision: D103989628


