### PR TITLE
feat: Populate recordCount on DWRF/ORC IcebergDataSink commits (#17654)

### DIFF
--- a/velox/connectors/hive/iceberg/IcebergDataSink.cpp
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.cpp
@@ -478,9 +478,30 @@ void IcebergDataSink::closeWriterAndCollectStats(size_t index) {
     return;
   }
 #endif
-  dataFileStats_[index].emplace_back(
-      std::make_shared<IcebergDataFileStatistics>(
-          IcebergDataFileStatistics::empty()));
+  // ORC/DWRF (and any other format without a stats collector) path: we don't
+  // have file-level metadata that exposes row count, so derive it from
+  // writerInfo_->numWrittenRows. That counter accumulates across all files
+  // written by this writer (rotated files included), so compute per-file
+  // recordCount as the delta since the previous closeWriterAndCollectStats
+  // call for this writer index.
+  //
+  // Without this, the manifest writes recordCount=0 for every DWRF/ORC file,
+  // which makes the DELETE/UPDATE/MERGE planner believe each file is empty
+  // and skip it entirely (no rewrite, no DV puffin, no visible delete).
+  if (reportedRowsPerWriter_.size() <= index) {
+    reportedRowsPerWriter_.resize(index + 1, 0);
+  }
+  const int64_t totalRows = writerInfo_[index]->numWrittenRows;
+  const int64_t thisFileRows = totalRows - reportedRowsPerWriter_[index];
+  reportedRowsPerWriter_[index] = totalRows;
+
+  auto stats = std::make_shared<IcebergDataFileStatistics>();
+  stats->numRecords = thisFileRows;
+  // Column-level stats (min/max/null counts) are still empty here. That only
+  // degrades predicate pruning (a perf optimization), not correctness. The
+  // proper fix is to add an IcebergDwrfStatsCollector that mirrors the
+  // Parquet path and consumes per-stripe stats from the DWRF writer footer.
+  dataFileStats_[index].emplace_back(std::move(stats));
 }
 
 void IcebergDataSink::rotateWriter(size_t index) {

--- a/velox/connectors/hive/iceberg/IcebergDataSink.h
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.h
@@ -251,6 +251,17 @@ class IcebergDataSink : public HiveDataSink {
   // individual data file.
   std::vector<std::vector<IcebergDataFileStatisticsPtr>> dataFileStats_;
 
+  // Per-writer running total of rows that have already been accounted for in
+  // an emitted dataFileStats_ entry. Used to compute per-file recordCount as
+  // (writerInfo_[index]->numWrittenRows - reportedRowsPerWriter_[index]) when
+  // we don't have a format-specific stats collector (DWRF/ORC path). Required
+  // because writerInfo_->numWrittenRows accumulates across all files written
+  // by the writer (including rotated files), but Iceberg manifests need a
+  // per-file recordCount. Without this the manifest reports recordCount=0
+  // for every file and DELETE/UPDATE/MERGE plans no-op because the planner
+  // believes the files are empty.
+  std::vector<int64_t> reportedRowsPerWriter_;
+
   const IcebergInsertTableHandlePtr icebergInsertTableHandle_;
 
 #ifdef VELOX_ENABLE_PARQUET

--- a/velox/connectors/hive/iceberg/tests/IcebergDwrfInsertTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergDwrfInsertTest.cpp
@@ -100,6 +100,91 @@ TEST_F(IcebergDwrfInsertTest, commitMessageFormat) {
   }
 }
 
+/// Regression test for the DWRF/ORC recordCount=0 manifest bug. Before the
+/// fix, IcebergDataSink::closeWriterAndCollectStats emplaced
+/// IcebergDataFileStatistics::empty() (numRecords = 0) on every non-Parquet
+/// commit, which makes the iceberg manifest report DataFile.recordCount() == 0
+/// and silently breaks DELETE/UPDATE/MERGE planning (planner treats files as
+/// empty and skips them).
+///
+/// Writes a single batch of N rows to an unpartitioned table and asserts the
+/// resulting commit message reports metrics.recordCount = N. Without the fix
+/// the assertion fails with 0.
+TEST_F(IcebergDwrfInsertTest, recordCountUnpartitioned) {
+  const auto outputDirectory = TempDirectoryPath::create();
+  const auto dataPath = outputDirectory->getPath();
+  auto rowType = ROW({"c1", "c2"}, {BIGINT(), VARCHAR()});
+  constexpr int32_t kNumRows = 100;
+  const auto vectors = createTestData(rowType, /*numBatches=*/1, kNumRows);
+  const auto dataSink = createDataSinkAndAppendData(vectors, dataPath);
+  const auto commitTasks = dataSink->close();
+
+  ASSERT_EQ(commitTasks.size(), 1);
+  auto taskJson = folly::parseJson(commitTasks[0]);
+  ASSERT_GT(taskJson.count("metrics"), 0);
+  ASSERT_GT(taskJson["metrics"].count("recordCount"), 0);
+  EXPECT_EQ(taskJson["metrics"]["recordCount"].asInt(), kNumRows);
+}
+
+/// Multi-batch single-writer accumulation. closeWriterAndCollectStats reads
+/// writerInfo_->numWrittenRows, which the FileDataSink accumulates across
+/// every appendData call to the same writer. The per-file delta should equal
+/// the SUM of all batches' rows when only one file is produced.
+TEST_F(IcebergDwrfInsertTest, recordCountMultiBatchAccumulated) {
+  const auto outputDirectory = TempDirectoryPath::create();
+  const auto dataPath = outputDirectory->getPath();
+  auto rowType = ROW({"c1", "c2"}, {BIGINT(), VARCHAR()});
+  constexpr int32_t kNumBatches = 4;
+  constexpr int32_t kRowsPerBatch = 25;
+  const auto vectors = createTestData(rowType, kNumBatches, kRowsPerBatch);
+  const auto dataSink = createDataSinkAndAppendData(vectors, dataPath);
+  const auto commitTasks = dataSink->close();
+
+  ASSERT_EQ(commitTasks.size(), 1);
+  auto taskJson = folly::parseJson(commitTasks[0]);
+  EXPECT_EQ(
+      taskJson["metrics"]["recordCount"].asInt(), kNumBatches * kRowsPerBatch);
+}
+
+/// Multi-partition per-writer delta. Two partitions => two distinct writer
+/// indices => two commit messages, each with its own DataFileStatistics
+/// derived from the reportedRowsPerWriter_[index] delta. If the index
+/// bookkeeping is wrong (e.g., shared counter across writers), totals would
+/// double-count or under-count.
+///
+/// Asserts: (a) exactly 2 commits, (b) every commit reports a positive
+/// recordCount, (c) the sum across commits equals the total rows written.
+TEST_F(IcebergDwrfInsertTest, recordCountPartitionedPerWriter) {
+  auto rowType = ROW({"c1", "c2"}, {BIGINT(), VARCHAR()});
+  const auto outputDirectory = TempDirectoryPath::create();
+  const auto dataPath = outputDirectory->getPath();
+  constexpr int32_t kNumBatches = 2;
+  constexpr int32_t kRowsPerBatch = 60;
+  const auto vectors = createTestData(rowType, kNumBatches, kRowsPerBatch, 0.0);
+
+  // Partition by c2 (VARCHAR). createTestData populates strings from a small
+  // randomized pool, so distinct partition values are produced reliably for
+  // 60 rows; assertions below tolerate any partition count >= 2.
+  std::vector<test::PartitionField> partitionTransforms = {
+      {1, TransformType::kIdentity, std::nullopt}};
+  const auto dataSink =
+      createDataSinkAndAppendData(vectors, dataPath, partitionTransforms);
+  const auto commitTasks = dataSink->close();
+
+  ASSERT_GE(commitTasks.size(), 2)
+      << "Expected at least 2 partition files; got " << commitTasks.size();
+
+  int64_t totalRecords = 0;
+  for (const auto& task : commitTasks) {
+    auto taskJson = folly::parseJson(task);
+    const int64_t recordCount = taskJson["metrics"]["recordCount"].asInt();
+    EXPECT_GT(recordCount, 0)
+        << "Per-partition recordCount must be positive; task: " << task;
+    totalRecords += recordCount;
+  }
+  EXPECT_EQ(totalRecords, kNumBatches * kRowsPerBatch);
+}
+
 /// Round-trips TIMESTAMP values through the DWRF write path with the session
 /// configured for non-UTC timezone and adjustTimestampToTimezone=true. The
 /// Iceberg spec requires timestamps NOT be adjusted to UTC; the DataSink


### PR DESCRIPTION
Summary:

IcebergDataSink::closeWriterAndCollectStats had no stats collector for
the non-Parquet path; it emplaced IcebergDataFileStatistics::empty()
(numRecords = 0, columnStats = {}) for every ORC/DWRF file written.
That zero propagates through commitMessage() into the Java
CommitTaskData.metrics.recordCount, then into the iceberg manifest as
DataFile.recordCount() == 0.

Downstream impact (silent data correctness bug):
  - SHOW STATS / $snapshots / $files all report 0 rows for every
    DWRF/ORC table even though the file has the data.
  - DELETE/UPDATE/MERGE planners read the manifest stats to decide which
    files need rewrite. recordCount=0 = "file is empty" = nothing to do
    = no rewrite. The V3 DV puffin writer is never invoked because the
    planner never selects the data file for delete-rewrite. SELECT
    returns the unchanged rows; user sees "DELETE returned 0 rows but
    the row is still there".

Repro (any ORC table on a hybrid cluster with V3 enabled):
  CREATE TABLE t (id INT) WITH ("format-version"='3', format='ORC');
  INSERT INTO t VALUES (1),(2),(3),(4),(5);   -- INSERT: 5 rows
  SELECT COUNT(*) FROM t;                     -- 5
  SELECT record_count FROM t$files;          -- 0  (the bug)
  DELETE FROM t WHERE id = 1;                 -- DELETE: 0 rows
  SELECT COUNT(*) FROM t;                     -- still 5

Fix: track per-writer cumulative numWrittenRows (already counted by
FileDataSink::write at writerInfo_[index]->numWrittenRows += ...). When
constructing the stats for the DWRF/ORC path, compute per-file delta as
(numWrittenRows now) - (numWrittenRows at previous closeWriterAndCollect
for this writer) and put it into IcebergDataFileStatistics::numRecords.

Column-level stats (min/max/null/nan counts) are still empty on this
path. That only degrades min/max predicate pruning (perf), not
correctness. Proper fix tracked separately: populate DwrfFileMetadata
+ add IcebergDwrfStatsCollector to mirror the Parquet path end-to-end.

Reviewed By: srsuryadev

Differential Revision: D106686066


