### PR TITLE
feat: add IcebergDeletionVectorSink + WriteKind dispatch (#17657)

### DIFF
--- a/velox/connectors/hive/iceberg/IcebergConnector.cpp
+++ b/velox/connectors/hive/iceberg/IcebergConnector.cpp
@@ -20,6 +20,7 @@
 #include "velox/connectors/hive/iceberg/IcebergConfig.h"
 #include "velox/connectors/hive/iceberg/IcebergDataSink.h"
 #include "velox/connectors/hive/iceberg/IcebergDataSource.h"
+#include "velox/connectors/hive/iceberg/IcebergDeletionVectorSink.h"
 
 namespace facebook::velox::connector::hive::iceberg {
 
@@ -71,13 +72,22 @@ std::unique_ptr<DataSink> IcebergConnector::createDataSink(
   auto icebergInsertHandle = checkedPointerCast<const IcebergInsertTableHandle>(
       connectorInsertTableHandle);
 
-  return std::make_unique<IcebergDataSink>(
-      inputType,
-      icebergInsertHandle,
-      connectorQueryCtx,
-      commitStrategy,
-      hiveConfig_,
-      icebergConfig_);
+  switch (icebergInsertHandle->writeKind()) {
+    case IcebergInsertTableHandle::WriteKind::kData:
+      return std::make_unique<IcebergDataSink>(
+          inputType,
+          icebergInsertHandle,
+          connectorQueryCtx,
+          commitStrategy,
+          hiveConfig_,
+          icebergConfig_);
+    case IcebergInsertTableHandle::WriteKind::kDeletionVector:
+      return std::make_unique<IcebergDeletionVectorSink>(
+          inputType, icebergInsertHandle, connectorQueryCtx, commitStrategy);
+  }
+  VELOX_UNREACHABLE(
+      "Unhandled IcebergInsertTableHandle::WriteKind: {}",
+      static_cast<int32_t>(icebergInsertHandle->writeKind()));
 }
 
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergDataSink.cpp
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.cpp
@@ -129,7 +129,8 @@ IcebergInsertTableHandle::IcebergInsertTableHandle(
     dwio::common::FileFormat tableStorageFormat,
     IcebergPartitionSpecPtr partitionSpec,
     std::optional<common::CompressionKind> compressionKind,
-    const std::unordered_map<std::string, std::string>& serdeParameters)
+    const std::unordered_map<std::string, std::string>& serdeParameters,
+    WriteKind writeKind)
     : HiveInsertTableHandle(
           std::vector<HiveColumnHandlePtr>(
               inputColumns.begin(),
@@ -142,10 +143,16 @@ IcebergInsertTableHandle::IcebergInsertTableHandle(
           nullptr,
           false,
           std::make_shared<const HiveInsertFileNameGenerator>()),
-      partitionSpec_(partitionSpec) {
-  VELOX_USER_CHECK(
-      !inputColumns_.empty(),
-      "Input columns cannot be empty for Iceberg tables.");
+      partitionSpec_(partitionSpec),
+      writeKind_(writeKind) {
+  // Data-file writes require the input row type to match inputColumns; the
+  // deletion-vector path passes a synthetic (file_path, pos) row that is
+  // intentionally narrower, so skip the inputColumns check for that path.
+  if (writeKind_ == WriteKind::kData) {
+    VELOX_USER_CHECK(
+        !inputColumns_.empty(),
+        "Input columns cannot be empty for Iceberg tables.");
+  }
   VELOX_USER_CHECK_NOT_NULL(
       locationHandle_, "Location handle is required for Iceberg tables.");
   VELOX_USER_CHECK(
@@ -362,7 +369,15 @@ std::vector<std::string> IcebergDataSink::commitMessage() const {
         // Sort order evolution is not supported. Set default id to 0 ( unsorted order).
         ("sortOrderId", 0)
         ("fileFormat", toManifestFormatString(icebergInsertTableHandle_->storageFormat()))
-        ("content", "DATA");
+      // Iceberg "content" is derived from the sink's WriteKind. INSERT (kData)
+      // emits "DATA"; the V3 deletion-vector path (kDeletionVector) emits
+      // "POSITION_DELETES" because Iceberg classifies deletion vectors as a
+      // Puffin-encoded form of position deletes for catalog accounting.
+        ("content",
+          icebergInsertTableHandle_->writeKind() ==
+              IcebergInsertTableHandle::WriteKind::kDeletionVector
+              ? "POSITION_DELETES"
+              : "DATA");
       // clang-format on
       if (!commitPartitionValue_.empty() &&
           !commitPartitionValue_[i].isNull()) {

--- a/velox/connectors/hive/iceberg/IcebergDataSink.h
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.h
@@ -41,6 +41,14 @@ namespace facebook::velox::connector::hive::iceberg {
 /// Represents a request for Iceberg write.
 class IcebergInsertTableHandle final : public HiveInsertTableHandle {
  public:
+  /// Identifies which kind of file the sink should produce. Used by
+  /// IcebergConnector::createDataSink to dispatch between the data-file
+  /// IcebergDataSink and the V3 deletion-vector IcebergDeletionVectorSink.
+  enum class WriteKind {
+    kData,
+    kDeletionVector,
+  };
+
   /// @param inputColumns Columns from the table schema to write.
   /// The input RowVector must have the same number of columns and matching
   /// types in the same order.
@@ -57,13 +65,17 @@ class IcebergInsertTableHandle final : public HiveInsertTableHandle {
   /// @param compressionKind Optional compression to apply to data files.
   /// @param serdeParameters Additional serialization/deserialization parameters
   /// for the file format.
+  /// @param writeKind Selects between data-file emission (default) and V3
+  /// deletion-vector emission. The default preserves existing INSERT
+  /// semantics.
   IcebergInsertTableHandle(
       std::vector<IcebergColumnHandlePtr> inputColumns,
       LocationHandlePtr locationHandle,
       dwio::common::FileFormat tableStorageFormat,
       IcebergPartitionSpecPtr partitionSpec,
       std::optional<common::CompressionKind> compressionKind = {},
-      const std::unordered_map<std::string, std::string>& serdeParameters = {});
+      const std::unordered_map<std::string, std::string>& serdeParameters = {},
+      WriteKind writeKind = WriteKind::kData);
 
   /// Returns the Iceberg partition specification that defines how the table
   /// is partitioned.
@@ -71,8 +83,15 @@ class IcebergInsertTableHandle final : public HiveInsertTableHandle {
     return partitionSpec_;
   }
 
+  /// Returns the requested write kind. kData routes to IcebergDataSink;
+  /// kDeletionVector routes to IcebergDeletionVectorSink.
+  WriteKind writeKind() const {
+    return writeKind_;
+  }
+
  private:
   const IcebergPartitionSpecPtr partitionSpec_;
+  const WriteKind writeKind_;
 };
 
 using IcebergInsertTableHandlePtr =

--- a/velox/connectors/hive/iceberg/IcebergDeletionVectorSink.cpp
+++ b/velox/connectors/hive/iceberg/IcebergDeletionVectorSink.cpp
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/IcebergDeletionVectorSink.h"
+
+#include <filesystem>
+
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+
+#include <folly/json.h>
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+namespace {
+
+// Position-delete input rows always carry exactly two columns:
+// file_path: VARCHAR, pos: BIGINT.
+constexpr int32_t kFilePathChannel = 0;
+constexpr int32_t kPositionChannel = 1;
+constexpr int32_t kExpectedChannelCount = 2;
+
+// Lookup or lazily insert a per-file state entry, preserving the original
+// insertion order so commit messages come back deterministically.
+IcebergDeletionVectorSink::PerFileState* findOrCreate(
+    std::vector<
+        std::pair<std::string, IcebergDeletionVectorSink::PerFileState>>&
+        perFile,
+    const std::string& path) {
+  for (auto& entry : perFile) {
+    if (entry.first == path) {
+      return &entry.second;
+    }
+  }
+  perFile.emplace_back(path, IcebergDeletionVectorSink::PerFileState{});
+  return &perFile.back().second;
+}
+
+} // namespace
+
+IcebergDeletionVectorSink::IcebergDeletionVectorSink(
+    RowTypePtr inputType,
+    IcebergInsertTableHandlePtr insertTableHandle,
+    const ConnectorQueryCtx* connectorQueryCtx,
+    CommitStrategy commitStrategy)
+    : inputType_(std::move(inputType)),
+      insertTableHandle_(std::move(insertTableHandle)),
+      connectorQueryCtx_(connectorQueryCtx),
+      commitStrategy_(commitStrategy) {
+  VELOX_USER_CHECK_NOT_NULL(
+      insertTableHandle_,
+      "IcebergDeletionVectorSink requires a non-null insert table handle.");
+  VELOX_USER_CHECK_NOT_NULL(
+      inputType_, "IcebergDeletionVectorSink requires a non-null input type.");
+  VELOX_USER_CHECK_EQ(
+      static_cast<int32_t>(inputType_->size()),
+      kExpectedChannelCount,
+      "IcebergDeletionVectorSink expects a 2-column input (file_path, pos)");
+}
+
+void IcebergDeletionVectorSink::appendData(RowVectorPtr input) {
+  VELOX_USER_CHECK(!finished_, "appendData() called after finish()");
+  VELOX_USER_CHECK(!aborted_, "appendData() called after abort()");
+  if (input == nullptr || input->size() == 0) {
+    return;
+  }
+  VELOX_USER_CHECK_EQ(
+      static_cast<int32_t>(input->childrenSize()),
+      kExpectedChannelCount,
+      "IcebergDeletionVectorSink expects 2-column input pages");
+
+  const auto* filePathVector = input->childAt(kFilePathChannel)->loadedVector();
+  const auto* positionVector = input->childAt(kPositionChannel)->loadedVector();
+
+  DecodedVector decodedFilePath(
+      *filePathVector, SelectivityVector(input->size()));
+  DecodedVector decodedPosition(
+      *positionVector, SelectivityVector(input->size()));
+
+  for (vector_size_t i = 0; i < input->size(); ++i) {
+    VELOX_USER_CHECK(
+        !decodedFilePath.isNullAt(i), "Null file_path in DELETE input row");
+    VELOX_USER_CHECK(
+        !decodedPosition.isNullAt(i), "Null pos in DELETE input row");
+    const auto pathSlice = decodedFilePath.valueAt<StringView>(i);
+    const std::string path(pathSlice.data(), pathSlice.size());
+    PerFileState* state = findOrCreate(perFile_, path);
+    state->writer.addDeletedPosition(decodedPosition.valueAt<int64_t>(i));
+  }
+}
+
+bool IcebergDeletionVectorSink::finish() {
+  // Single-shot finish: serialize each per-file roaring bitmap, write a Puffin
+  // file, and emit a commit message. No yielding mid-finish today; can be
+  // extended once we expose intermediate progress.
+  if (finished_) {
+    return true;
+  }
+  finished_ = true;
+  for (auto& entry : perFile_) {
+    if (entry.second.writer.numPositions() == 0) {
+      continue;
+    }
+    const std::string puffinPath = puffinPathFor(entry.first);
+    const std::string blob = entry.second.writer.serialize();
+    const auto [offset, length] =
+        writePuffinFile(puffinPath, blob, entry.first);
+
+    const auto fileSize = std::filesystem::file_size(puffinPath);
+    numWrittenBytes_ += fileSize;
+    numWrittenFiles_ += 1;
+
+    folly::dynamic msg = folly::dynamic::object;
+    msg["path"] = puffinPath;
+    msg["fileSizeInBytes"] = static_cast<int64_t>(fileSize);
+    msg["metrics"] = folly::dynamic::object(
+        "recordCount",
+        static_cast<int64_t>(entry.second.writer.numPositions()));
+    // Use the real partition spec id when the target table is partitioned;
+    // unpartitioned tables (or sinks constructed without a spec) emit 0
+    // (the default unpartitioned spec id).
+    msg["partitionSpecJson"] = static_cast<int64_t>(
+        insertTableHandle_->partitionSpec()
+            ? insertTableHandle_->partitionSpec()->specId
+            : 0);
+    msg["fileFormat"] = "PUFFIN";
+    msg["referencedDataFile"] = entry.first;
+    msg["content"] = "POSITION_DELETES";
+    msg["contentOffset"] = static_cast<int64_t>(offset);
+    msg["contentSizeInBytes"] = static_cast<int64_t>(length);
+    commitMessages_.push_back(folly::toJson(msg));
+  }
+  return true;
+}
+
+std::vector<std::string> IcebergDeletionVectorSink::close() {
+  if (!finished_) {
+    (void)finish();
+  }
+  return commitMessages_;
+}
+
+void IcebergDeletionVectorSink::abort() {
+  if (finished_ || aborted_) {
+    return;
+  }
+  aborted_ = true;
+  perFile_.clear();
+}
+
+DataSink::Stats IcebergDeletionVectorSink::stats() const {
+  Stats stats;
+  stats.numWrittenBytes = numWrittenBytes_;
+  stats.numWrittenFiles = numWrittenFiles_;
+  return stats;
+}
+
+std::string IcebergDeletionVectorSink::puffinPathFor(
+    const std::string& dataFile) const {
+  // Co-locate the puffin file with the referenced data file so that a
+  // partitioned V3 table's puffin blobs land in the same partition
+  // sub-directory as their data files. Falling back to the location handle's
+  // target path keeps unpartitioned tables and tests (which pass a synthetic
+  // dataFile without a parent directory) functional.
+  std::string parentDir;
+  if (dataFile.find('/') != std::string::npos) {
+    parentDir = std::filesystem::path(dataFile).parent_path().string();
+  } else {
+    parentDir = insertTableHandle_->locationHandle()->targetPath();
+  }
+  const std::string uuid =
+      boost::uuids::to_string(boost::uuids::random_generator()());
+  return parentDir + "/dv-" + uuid + ".puffin";
+}
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergDeletionVectorSink.h
+++ b/velox/connectors/hive/iceberg/IcebergDeletionVectorSink.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "velox/connectors/Connector.h"
+#include "velox/connectors/hive/iceberg/DeletionVectorWriter.h"
+#include "velox/connectors/hive/iceberg/IcebergDataSink.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+/// V3 deletion-vector sink. Consumes (file_path, pos) rows produced by the
+/// coordinator's DELETE plan and emits one Puffin file per referenced data
+/// file. Each Puffin file contains a single deletion-vector-v1 blob holding
+/// the deleted positions encoded as a 64-bit roaring bitmap.
+///
+/// Selected by IcebergConnector::createDataSink when the incoming
+/// IcebergInsertTableHandle has writeKind() == kDeletionVector. Native
+/// execution dispatches to this sink for V3 tables; V2 tables continue to
+/// flow through the row-id-rewrite path on the coordinator and never reach
+/// this sink.
+///
+/// Commit messages emitted by close() follow the existing Iceberg connector
+/// CommitTaskData JSON contract with the V3 additions:
+///   {
+///     "path": "<puffin file path>",
+///     "fileSizeInBytes": <total file size>,
+///     "metrics": {"recordCount": <numPositions>},
+///     "partitionSpecJson": 0,
+///     "fileFormat": "PUFFIN",
+///     "referencedDataFile": "<data file path>",
+///     "content": "POSITION_DELETES",
+///     "contentOffset": <blob offset within puffin>,
+///     "contentSizeInBytes": <blob length>
+///   }
+class IcebergDeletionVectorSink : public DataSink {
+ public:
+  IcebergDeletionVectorSink(
+      RowTypePtr inputType,
+      IcebergInsertTableHandlePtr insertTableHandle,
+      const ConnectorQueryCtx* connectorQueryCtx,
+      CommitStrategy commitStrategy);
+
+  void appendData(RowVectorPtr input) override;
+
+  bool finish() override;
+
+  std::vector<std::string> close() override;
+
+  void abort() override;
+
+  Stats stats() const override;
+
+  // Per-referenced-data-file accumulator. Builds a roaring bitmap from
+  // incoming positions; flushed to a Puffin file in close(). Public so the
+  // helpers in IcebergDeletionVectorSink.cpp's anonymous namespace can
+  // construct one.
+  struct PerFileState {
+    DeletionVectorWriter writer;
+  };
+
+ private:
+  // Resolves the puffin output path for 'dataFile'. Today returns
+  // "<base location>/<uuid>.puffin"; in production this should be folded
+  // through the same LocationHandle / FileNameGenerator path that
+  // IcebergDataSink uses for data files so the puffin lands next to the data.
+  std::string puffinPathFor(const std::string& dataFile) const;
+
+  const RowTypePtr inputType_;
+  const IcebergInsertTableHandlePtr insertTableHandle_;
+  const ConnectorQueryCtx* const connectorQueryCtx_;
+  const CommitStrategy commitStrategy_;
+
+  // Indexed by referenced data file path; preserves insertion order so
+  // commit messages come back deterministically.
+  std::vector<std::pair<std::string, PerFileState>> perFile_;
+
+  // Cached commit messages produced by close(); populated once and returned
+  // on each close() call to match the DataSink contract.
+  std::vector<std::string> commitMessages_;
+
+  bool finished_{false};
+  bool aborted_{false};
+
+  // Cumulative stats for the Stats() accessor.
+  uint64_t numWrittenBytes_{0};
+  uint32_t numWrittenFiles_{0};
+};
+
+} // namespace facebook::velox::connector::hive::iceberg


### PR DESCRIPTION
Summary:

Diff 3 of the V3 DELETE port stack. Adds a Velox-side sink that emits
Iceberg V3 deletion vectors (Puffin files containing a single
deletion-vector-v1 roaring-bitmap blob), and wires
IcebergConnector::createDataSink to dispatch between the existing
data-file sink and the new sink based on a WriteKind enum on
IcebergInsertTableHandle.

What's added:

* IcebergInsertTableHandle::WriteKind enum (kData / kDeletionVector)
  + writeKind_ field + writeKind() getter + ctor parameter
  (default = kData, preserving existing INSERT semantics).
  - The inputColumns non-empty check is relaxed for kDeletionVector
    because the synthetic (file_path, pos) input is intentionally
    narrower than a data-file insert.
* IcebergDeletionVectorSink (new):
  - Implements connector::DataSink.
  - Consumes 2-column RowVectors (file_path: VARCHAR, pos: BIGINT)
    produced by the coordinator's DELETE plan.
  - Demultiplexes positions by file_path into per-file
    DeletionVectorWriter instances (each backed by a 64-bit roaring
    bitmap).
  - On finish(), serializes each bitmap, calls the existing
    writePuffinFile() primitive, and emits one CommitTaskData-shaped
    JSON per puffin file with:
      content = POSITION_DELETES (Iceberg semantic for both V2
        position-delete files and V3 deletion vectors),
      fileFormat = PUFFIN,
      referencedDataFile = <data file>,
      contentOffset / contentSizeInBytes = blob coordinates within
        the Puffin file.
  - close() returns the cached commit messages; abort() is a
    best-effort cleanup that drops all accumulated state.
  - stats() reports numWrittenBytes + numWrittenFiles for the
    DataSink::Stats accessor.
* IcebergConnector::createDataSink: switches on
  icebergInsertHandle->writeKind(). kData -> existing IcebergDataSink.
  kDeletionVector -> new IcebergDeletionVectorSink. VELOX_UNREACHABLE
  on any future WriteKind value.
* BUCK: IcebergDeletionVectorSink.{h,cpp} added to iceberg_connector
  srcs/headers; iceberg_connector now exports DeletionVectorWriter as
  a dep (needed for the new sink).

What's deferred (kept out of scope intentionally):

* V2 native position-delete sink (kPositionDelete). V2 continues to
  flow through the Java row-id-rewrite path; the WriteKind enum does
  not yet have a kPositionDelete value.
* Reusing IcebergDataSink's FileNameGenerator / LocationHandle paths
  for puffin file naming. The current implementation derives a uuid
  suffix; production should route through the same naming machinery
  as data files for naming consistency. Marked as a TODO in
  puffinPathFor().
* Updating the existing IcebergDataSink::commitMessage() to emit
  "content" derived from the writeKind rather than hard-coded
  "DATA". The kDeletionVector path emits its own messages so this
  is non-blocking, but worth doing for consistency.

Reviewed By: srsuryadev

Differential Revision: D105893770


