### PR TITLE
feat: add kPositionDelete WriteKind value (V2 stub) (#17659)

### DIFF
--- a/velox/connectors/hive/iceberg/IcebergConnector.cpp
+++ b/velox/connectors/hive/iceberg/IcebergConnector.cpp
@@ -20,6 +20,7 @@
 #include "velox/connectors/hive/iceberg/IcebergConfig.h"
 #include "velox/connectors/hive/iceberg/IcebergDataSink.h"
 #include "velox/connectors/hive/iceberg/IcebergDataSource.h"
+#include "velox/connectors/hive/iceberg/IcebergDeletionVectorSink.h"
 
 namespace facebook::velox::connector::hive::iceberg {
 
@@ -71,13 +72,22 @@ std::unique_ptr<DataSink> IcebergConnector::createDataSink(
   auto icebergInsertHandle = checkedPointerCast<const IcebergInsertTableHandle>(
       connectorInsertTableHandle);
 
-  return std::make_unique<IcebergDataSink>(
-      inputType,
-      icebergInsertHandle,
-      connectorQueryCtx,
-      commitStrategy,
-      hiveConfig_,
-      icebergConfig_);
+  switch (icebergInsertHandle->writeKind()) {
+    case IcebergInsertTableHandle::WriteKind::kData:
+      return std::make_unique<IcebergDataSink>(
+          inputType,
+          icebergInsertHandle,
+          connectorQueryCtx,
+          commitStrategy,
+          hiveConfig_,
+          icebergConfig_);
+    case IcebergInsertTableHandle::WriteKind::kDeletionVector:
+      return std::make_unique<IcebergDeletionVectorSink>(
+          inputType, icebergInsertHandle, connectorQueryCtx, commitStrategy);
+  }
+  VELOX_UNREACHABLE(
+      "Unhandled IcebergInsertTableHandle::WriteKind: {}",
+      static_cast<int32_t>(icebergInsertHandle->writeKind()));
 }
 
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergConnector.cpp
+++ b/velox/connectors/hive/iceberg/IcebergConnector.cpp
@@ -84,6 +84,18 @@ std::unique_ptr<DataSink> IcebergConnector::createDataSink(
     case IcebergInsertTableHandle::WriteKind::kDeletionVector:
       return std::make_unique<IcebergDeletionVectorSink>(
           inputType, icebergInsertHandle, connectorQueryCtx, commitStrategy);
+    case IcebergInsertTableHandle::WriteKind::kPositionDelete:
+      // V2 position-delete sink: not yet implemented in Velox. V2 DELETE
+      // currently runs through the Java row-id-rewrite path on the
+      // coordinator, so this dispatch arm is never hit in production
+      // today. Wired up so the WriteKind enum is exhaustive and a future
+      // V2 native port has a clear plug-in point. See
+      // ~/.llms/plans/iceberg_v2_native_positional_delete_sink.plan.md.
+      VELOX_NYI(
+          "Iceberg V2 native position-delete sink is not implemented. "
+          "V2 DELETE flows through the Java row-id-rewrite path; if "
+          "this NYI fires, the planner unexpectedly routed a V2 delete "
+          "through the native bridge.");
   }
   VELOX_UNREACHABLE(
       "Unhandled IcebergInsertTableHandle::WriteKind: {}",

--- a/velox/connectors/hive/iceberg/IcebergDataSink.cpp
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.cpp
@@ -129,7 +129,8 @@ IcebergInsertTableHandle::IcebergInsertTableHandle(
     dwio::common::FileFormat tableStorageFormat,
     IcebergPartitionSpecPtr partitionSpec,
     std::optional<common::CompressionKind> compressionKind,
-    const std::unordered_map<std::string, std::string>& serdeParameters)
+    const std::unordered_map<std::string, std::string>& serdeParameters,
+    WriteKind writeKind)
     : HiveInsertTableHandle(
           std::vector<HiveColumnHandlePtr>(
               inputColumns.begin(),
@@ -142,10 +143,16 @@ IcebergInsertTableHandle::IcebergInsertTableHandle(
           nullptr,
           false,
           std::make_shared<const HiveInsertFileNameGenerator>()),
-      partitionSpec_(partitionSpec) {
-  VELOX_USER_CHECK(
-      !inputColumns_.empty(),
-      "Input columns cannot be empty for Iceberg tables.");
+      partitionSpec_(partitionSpec),
+      writeKind_(writeKind) {
+  // Data-file writes require the input row type to match inputColumns; the
+  // deletion-vector path passes a synthetic (file_path, pos) row that is
+  // intentionally narrower, so skip the inputColumns check for that path.
+  if (writeKind_ == WriteKind::kData) {
+    VELOX_USER_CHECK(
+        !inputColumns_.empty(),
+        "Input columns cannot be empty for Iceberg tables.");
+  }
   VELOX_USER_CHECK_NOT_NULL(
       locationHandle_, "Location handle is required for Iceberg tables.");
   VELOX_USER_CHECK(
@@ -362,7 +369,15 @@ std::vector<std::string> IcebergDataSink::commitMessage() const {
         // Sort order evolution is not supported. Set default id to 0 ( unsorted order).
         ("sortOrderId", 0)
         ("fileFormat", toManifestFormatString(icebergInsertTableHandle_->storageFormat()))
-        ("content", "DATA");
+      // Iceberg "content" is derived from the sink's WriteKind. INSERT (kData)
+      // emits "DATA"; the V3 deletion-vector path (kDeletionVector) emits
+      // "POSITION_DELETES" because Iceberg classifies deletion vectors as a
+      // Puffin-encoded form of position deletes for catalog accounting.
+        ("content",
+          icebergInsertTableHandle_->writeKind() ==
+              IcebergInsertTableHandle::WriteKind::kDeletionVector
+              ? "POSITION_DELETES"
+              : "DATA");
       // clang-format on
       if (!commitPartitionValue_.empty() &&
           !commitPartitionValue_[i].isNull()) {

--- a/velox/connectors/hive/iceberg/IcebergDataSink.h
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.h
@@ -41,6 +41,14 @@ namespace facebook::velox::connector::hive::iceberg {
 /// Represents a request for Iceberg write.
 class IcebergInsertTableHandle final : public HiveInsertTableHandle {
  public:
+  /// Identifies which kind of file the sink should produce. Used by
+  /// IcebergConnector::createDataSink to dispatch between the data-file
+  /// IcebergDataSink and the V3 deletion-vector IcebergDeletionVectorSink.
+  enum class WriteKind {
+    kData,
+    kDeletionVector,
+  };
+
   /// @param inputColumns Columns from the table schema to write.
   /// The input RowVector must have the same number of columns and matching
   /// types in the same order.
@@ -57,13 +65,17 @@ class IcebergInsertTableHandle final : public HiveInsertTableHandle {
   /// @param compressionKind Optional compression to apply to data files.
   /// @param serdeParameters Additional serialization/deserialization parameters
   /// for the file format.
+  /// @param writeKind Selects between data-file emission (default) and V3
+  /// deletion-vector emission. The default preserves existing INSERT
+  /// semantics.
   IcebergInsertTableHandle(
       std::vector<IcebergColumnHandlePtr> inputColumns,
       LocationHandlePtr locationHandle,
       dwio::common::FileFormat tableStorageFormat,
       IcebergPartitionSpecPtr partitionSpec,
       std::optional<common::CompressionKind> compressionKind = {},
-      const std::unordered_map<std::string, std::string>& serdeParameters = {});
+      const std::unordered_map<std::string, std::string>& serdeParameters = {},
+      WriteKind writeKind = WriteKind::kData);
 
   /// Returns the Iceberg partition specification that defines how the table
   /// is partitioned.
@@ -71,8 +83,15 @@ class IcebergInsertTableHandle final : public HiveInsertTableHandle {
     return partitionSpec_;
   }
 
+  /// Returns the requested write kind. kData routes to IcebergDataSink;
+  /// kDeletionVector routes to IcebergDeletionVectorSink.
+  WriteKind writeKind() const {
+    return writeKind_;
+  }
+
  private:
   const IcebergPartitionSpecPtr partitionSpec_;
+  const WriteKind writeKind_;
 };
 
 using IcebergInsertTableHandlePtr =

--- a/velox/connectors/hive/iceberg/IcebergDataSink.h
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.h
@@ -42,11 +42,20 @@ namespace facebook::velox::connector::hive::iceberg {
 class IcebergInsertTableHandle final : public HiveInsertTableHandle {
  public:
   /// Identifies which kind of file the sink should produce. Used by
-  /// IcebergConnector::createDataSink to dispatch between the data-file
-  /// IcebergDataSink and the V3 deletion-vector IcebergDeletionVectorSink.
+  /// IcebergConnector::createDataSink to dispatch between:
+  ///  - the data-file IcebergDataSink (kData, INSERT and UPDATE-insert
+  ///    halves),
+  ///  - the V3 deletion-vector IcebergDeletionVectorSink (kDeletionVector,
+  ///    Puffin blobs encoding deleted positions per data file), and
+  ///  - the V2 position-delete sink (kPositionDelete, position-delete
+  ///    Parquet/AVRO files). The V2 sink is not yet implemented; today
+  ///    V2 DELETE flows through the Java row-id-rewrite path. See
+  ///    ~/.llms/plans/iceberg_v2_native_positional_delete_sink.plan.md
+  ///    for the full design.
   enum class WriteKind {
     kData,
     kDeletionVector,
+    kPositionDelete,
   };
 
   /// @param inputColumns Columns from the table schema to write.

--- a/velox/connectors/hive/iceberg/IcebergDeletionVectorSink.cpp
+++ b/velox/connectors/hive/iceberg/IcebergDeletionVectorSink.cpp
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/IcebergDeletionVectorSink.h"
+
+#include <filesystem>
+
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+
+#include <folly/json.h>
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+namespace {
+
+// Position-delete input rows always carry exactly two columns:
+// file_path: VARCHAR, pos: BIGINT.
+constexpr int32_t kFilePathChannel = 0;
+constexpr int32_t kPositionChannel = 1;
+constexpr int32_t kExpectedChannelCount = 2;
+
+// Lookup or lazily insert a per-file state entry, preserving the original
+// insertion order so commit messages come back deterministically.
+IcebergDeletionVectorSink::PerFileState* findOrCreate(
+    std::vector<
+        std::pair<std::string, IcebergDeletionVectorSink::PerFileState>>&
+        perFile,
+    const std::string& path) {
+  for (auto& entry : perFile) {
+    if (entry.first == path) {
+      return &entry.second;
+    }
+  }
+  perFile.emplace_back(path, IcebergDeletionVectorSink::PerFileState{});
+  return &perFile.back().second;
+}
+
+} // namespace
+
+IcebergDeletionVectorSink::IcebergDeletionVectorSink(
+    RowTypePtr inputType,
+    IcebergInsertTableHandlePtr insertTableHandle,
+    const ConnectorQueryCtx* connectorQueryCtx,
+    CommitStrategy commitStrategy)
+    : inputType_(std::move(inputType)),
+      insertTableHandle_(std::move(insertTableHandle)),
+      connectorQueryCtx_(connectorQueryCtx),
+      commitStrategy_(commitStrategy) {
+  VELOX_USER_CHECK_NOT_NULL(
+      insertTableHandle_,
+      "IcebergDeletionVectorSink requires a non-null insert table handle.");
+  VELOX_USER_CHECK_NOT_NULL(
+      inputType_, "IcebergDeletionVectorSink requires a non-null input type.");
+  VELOX_USER_CHECK_EQ(
+      static_cast<int32_t>(inputType_->size()),
+      kExpectedChannelCount,
+      "IcebergDeletionVectorSink expects a 2-column input (file_path, pos)");
+}
+
+void IcebergDeletionVectorSink::appendData(RowVectorPtr input) {
+  VELOX_USER_CHECK(!finished_, "appendData() called after finish()");
+  VELOX_USER_CHECK(!aborted_, "appendData() called after abort()");
+  if (input == nullptr || input->size() == 0) {
+    return;
+  }
+  VELOX_USER_CHECK_EQ(
+      static_cast<int32_t>(input->childrenSize()),
+      kExpectedChannelCount,
+      "IcebergDeletionVectorSink expects 2-column input pages");
+
+  const auto* filePathVector = input->childAt(kFilePathChannel)->loadedVector();
+  const auto* positionVector = input->childAt(kPositionChannel)->loadedVector();
+
+  DecodedVector decodedFilePath(
+      *filePathVector, SelectivityVector(input->size()));
+  DecodedVector decodedPosition(
+      *positionVector, SelectivityVector(input->size()));
+
+  for (vector_size_t i = 0; i < input->size(); ++i) {
+    VELOX_USER_CHECK(
+        !decodedFilePath.isNullAt(i), "Null file_path in DELETE input row");
+    VELOX_USER_CHECK(
+        !decodedPosition.isNullAt(i), "Null pos in DELETE input row");
+    const auto pathSlice = decodedFilePath.valueAt<StringView>(i);
+    const std::string path(pathSlice.data(), pathSlice.size());
+    PerFileState* state = findOrCreate(perFile_, path);
+    state->writer.addDeletedPosition(decodedPosition.valueAt<int64_t>(i));
+  }
+}
+
+bool IcebergDeletionVectorSink::finish() {
+  // Single-shot finish: serialize each per-file roaring bitmap, write a Puffin
+  // file, and emit a commit message. No yielding mid-finish today; can be
+  // extended once we expose intermediate progress.
+  if (finished_) {
+    return true;
+  }
+  finished_ = true;
+  for (auto& entry : perFile_) {
+    if (entry.second.writer.numPositions() == 0) {
+      continue;
+    }
+    const std::string puffinPath = puffinPathFor(entry.first);
+    const std::string blob = entry.second.writer.serialize();
+    const auto [offset, length] =
+        writePuffinFile(puffinPath, blob, entry.first);
+
+    const auto fileSize = std::filesystem::file_size(puffinPath);
+    numWrittenBytes_ += fileSize;
+    numWrittenFiles_ += 1;
+
+    folly::dynamic msg = folly::dynamic::object;
+    msg["path"] = puffinPath;
+    msg["fileSizeInBytes"] = static_cast<int64_t>(fileSize);
+    msg["metrics"] = folly::dynamic::object(
+        "recordCount",
+        static_cast<int64_t>(entry.second.writer.numPositions()));
+    // Use the real partition spec id when the target table is partitioned;
+    // unpartitioned tables (or sinks constructed without a spec) emit 0
+    // (the default unpartitioned spec id).
+    msg["partitionSpecJson"] = static_cast<int64_t>(
+        insertTableHandle_->partitionSpec()
+            ? insertTableHandle_->partitionSpec()->specId
+            : 0);
+    msg["fileFormat"] = "PUFFIN";
+    msg["referencedDataFile"] = entry.first;
+    msg["content"] = "POSITION_DELETES";
+    msg["contentOffset"] = static_cast<int64_t>(offset);
+    msg["contentSizeInBytes"] = static_cast<int64_t>(length);
+    commitMessages_.push_back(folly::toJson(msg));
+  }
+  return true;
+}
+
+std::vector<std::string> IcebergDeletionVectorSink::close() {
+  if (!finished_) {
+    (void)finish();
+  }
+  return commitMessages_;
+}
+
+void IcebergDeletionVectorSink::abort() {
+  if (finished_ || aborted_) {
+    return;
+  }
+  aborted_ = true;
+  perFile_.clear();
+}
+
+DataSink::Stats IcebergDeletionVectorSink::stats() const {
+  Stats stats;
+  stats.numWrittenBytes = numWrittenBytes_;
+  stats.numWrittenFiles = numWrittenFiles_;
+  return stats;
+}
+
+std::string IcebergDeletionVectorSink::puffinPathFor(
+    const std::string& dataFile) const {
+  // Co-locate the puffin file with the referenced data file so that a
+  // partitioned V3 table's puffin blobs land in the same partition
+  // sub-directory as their data files. Falling back to the location handle's
+  // target path keeps unpartitioned tables and tests (which pass a synthetic
+  // dataFile without a parent directory) functional.
+  std::string parentDir;
+  if (dataFile.find('/') != std::string::npos) {
+    parentDir = std::filesystem::path(dataFile).parent_path().string();
+  } else {
+    parentDir = insertTableHandle_->locationHandle()->targetPath();
+  }
+  const std::string uuid =
+      boost::uuids::to_string(boost::uuids::random_generator()());
+  return parentDir + "/dv-" + uuid + ".puffin";
+}
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergDeletionVectorSink.h
+++ b/velox/connectors/hive/iceberg/IcebergDeletionVectorSink.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "velox/connectors/Connector.h"
+#include "velox/connectors/hive/iceberg/DeletionVectorWriter.h"
+#include "velox/connectors/hive/iceberg/IcebergDataSink.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+/// V3 deletion-vector sink. Consumes (file_path, pos) rows produced by the
+/// coordinator's DELETE plan and emits one Puffin file per referenced data
+/// file. Each Puffin file contains a single deletion-vector-v1 blob holding
+/// the deleted positions encoded as a 64-bit roaring bitmap.
+///
+/// Selected by IcebergConnector::createDataSink when the incoming
+/// IcebergInsertTableHandle has writeKind() == kDeletionVector. Native
+/// execution dispatches to this sink for V3 tables; V2 tables continue to
+/// flow through the row-id-rewrite path on the coordinator and never reach
+/// this sink.
+///
+/// Commit messages emitted by close() follow the existing Iceberg connector
+/// CommitTaskData JSON contract with the V3 additions:
+///   {
+///     "path": "<puffin file path>",
+///     "fileSizeInBytes": <total file size>,
+///     "metrics": {"recordCount": <numPositions>},
+///     "partitionSpecJson": 0,
+///     "fileFormat": "PUFFIN",
+///     "referencedDataFile": "<data file path>",
+///     "content": "POSITION_DELETES",
+///     "contentOffset": <blob offset within puffin>,
+///     "contentSizeInBytes": <blob length>
+///   }
+class IcebergDeletionVectorSink : public DataSink {
+ public:
+  IcebergDeletionVectorSink(
+      RowTypePtr inputType,
+      IcebergInsertTableHandlePtr insertTableHandle,
+      const ConnectorQueryCtx* connectorQueryCtx,
+      CommitStrategy commitStrategy);
+
+  void appendData(RowVectorPtr input) override;
+
+  bool finish() override;
+
+  std::vector<std::string> close() override;
+
+  void abort() override;
+
+  Stats stats() const override;
+
+  // Per-referenced-data-file accumulator. Builds a roaring bitmap from
+  // incoming positions; flushed to a Puffin file in close(). Public so the
+  // helpers in IcebergDeletionVectorSink.cpp's anonymous namespace can
+  // construct one.
+  struct PerFileState {
+    DeletionVectorWriter writer;
+  };
+
+ private:
+  // Resolves the puffin output path for 'dataFile'. Today returns
+  // "<base location>/<uuid>.puffin"; in production this should be folded
+  // through the same LocationHandle / FileNameGenerator path that
+  // IcebergDataSink uses for data files so the puffin lands next to the data.
+  std::string puffinPathFor(const std::string& dataFile) const;
+
+  const RowTypePtr inputType_;
+  const IcebergInsertTableHandlePtr insertTableHandle_;
+  const ConnectorQueryCtx* const connectorQueryCtx_;
+  const CommitStrategy commitStrategy_;
+
+  // Indexed by referenced data file path; preserves insertion order so
+  // commit messages come back deterministically.
+  std::vector<std::pair<std::string, PerFileState>> perFile_;
+
+  // Cached commit messages produced by close(); populated once and returned
+  // on each close() call to match the DataSink contract.
+  std::vector<std::string> commitMessages_;
+
+  bool finished_{false};
+  bool aborted_{false};
+
+  // Cumulative stats for the Stats() accessor.
+  uint64_t numWrittenBytes_{0};
+  uint32_t numWrittenFiles_{0};
+};
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/tests/IcebergDeletionVectorSinkTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergDeletionVectorSinkTest.cpp
@@ -1,0 +1,288 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/IcebergDeletionVectorSink.h"
+
+#include <filesystem>
+
+#include <folly/json.h>
+#include <gtest/gtest.h>
+
+#include "velox/common/base/BitUtil.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/common/testutil/TempDirectoryPath.h"
+#include "velox/connectors/hive/iceberg/DeletionVectorReader.h"
+#include "velox/vector/tests/utils/VectorMaker.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::connector::hive::iceberg;
+using namespace facebook::velox::common::testutil;
+
+namespace {
+
+// Builds a minimal IcebergInsertTableHandle for use by
+// IcebergDeletionVectorSink. The sink only consults locationHandle() (for
+// the Puffin output directory) and writeKind(); inputColumns and partition
+// spec are not exercised by the deletion-vector path.
+IcebergInsertTableHandlePtr makeDeletionVectorHandle(
+    const std::string& outputDirectory) {
+  auto locationHandle = std::make_shared<connector::hive::LocationHandle>(
+      outputDirectory,
+      outputDirectory,
+      connector::hive::LocationHandle::TableType::kExisting);
+  return std::make_shared<const IcebergInsertTableHandle>(
+      /*inputColumns=*/std::vector<IcebergColumnHandlePtr>{},
+      locationHandle,
+      /*tableStorageFormat=*/dwio::common::FileFormat::PARQUET,
+      /*partitionSpec=*/nullptr,
+      /*compressionKind=*/std::nullopt,
+      /*serdeParameters=*/std::unordered_map<std::string, std::string>{},
+      IcebergInsertTableHandle::WriteKind::kDeletionVector);
+}
+
+// Allocates a bit-packed buffer big enough to hold 'numBits' bits, zeroed.
+BufferPtr allocateBitmap(uint64_t numBits, memory::MemoryPool* pool) {
+  return AlignedBuffer::allocate<uint8_t>(bits::nbytes(numBits), pool, 0);
+}
+
+// Returns the indices of all set bits in 'bitmap[0..numBits)'.
+std::vector<uint64_t> getSetBits(const BufferPtr& bitmap, uint64_t numBits) {
+  const auto* raw = bitmap->as<uint8_t>();
+  std::vector<uint64_t> result;
+  for (uint64_t i = 0; i < numBits; ++i) {
+    if (bits::isBitSet(raw, i)) {
+      result.push_back(i);
+    }
+  }
+  return result;
+}
+
+// Reads the puffin blob at 'puffinPath' between [offset, offset+length)
+// through DeletionVectorReader and returns the set positions in [0, maxPos].
+std::vector<uint64_t> readBackDeletedPositions(
+    const std::string& puffinPath,
+    uint64_t offset,
+    uint64_t length,
+    uint64_t recordCount,
+    uint64_t maxPos,
+    memory::MemoryPool* pool) {
+  std::unordered_map<int32_t, std::string> lowerBounds;
+  std::unordered_map<int32_t, std::string> upperBounds;
+  lowerBounds[DeletionVectorReader::kDvOffsetFieldId] = std::to_string(offset);
+  upperBounds[DeletionVectorReader::kDvLengthFieldId] = std::to_string(length);
+
+  IcebergDeleteFile dvFile(
+      FileContent::kDeletionVector,
+      puffinPath,
+      dwio::common::FileFormat::DWRF,
+      recordCount,
+      /*fileSizeInBytes=*/std::filesystem::file_size(puffinPath),
+      /*equalityFieldIds=*/{},
+      lowerBounds,
+      upperBounds);
+
+  DeletionVectorReader reader(dvFile, 0, pool);
+  const uint64_t batchSize = 1024;
+  const uint64_t totalRows = maxPos + batchSize;
+
+  std::vector<uint64_t> deleted;
+  for (uint64_t base = 0; base < totalRows; base += batchSize) {
+    auto bitmap = allocateBitmap(batchSize, pool);
+    reader.readDeletePositions(base, batchSize, bitmap);
+    for (auto offsetInBatch : getSetBits(bitmap, batchSize)) {
+      deleted.push_back(base + offsetInBatch);
+    }
+  }
+  return deleted;
+}
+
+} // namespace
+
+class IcebergDeletionVectorSinkTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    memory::MemoryManager::initialize(memory::MemoryManager::Options{});
+  }
+
+  void SetUp() override {
+    filesystems::registerLocalFileSystem();
+    pool_ =
+        memory::memoryManager()->addLeafPool("IcebergDeletionVectorSinkTest");
+    vectorMaker_ = std::make_unique<test::VectorMaker>(pool_.get());
+  }
+
+  RowVectorPtr makePositionDeleteRows(
+      const std::vector<std::string>& filePaths,
+      const std::vector<int64_t>& positions) {
+    VELOX_CHECK_EQ(filePaths.size(), positions.size());
+    auto filePathVector = vectorMaker_->flatVector<StringView>(
+        filePaths.size(),
+        [&](vector_size_t i) { return StringView(filePaths[i]); });
+    auto positionVector = vectorMaker_->flatVector<int64_t>(positions);
+    return vectorMaker_->rowVector(
+        {"file_path", "pos"}, {filePathVector, positionVector});
+  }
+
+  std::shared_ptr<memory::MemoryPool> pool_;
+  std::unique_ptr<test::VectorMaker> vectorMaker_;
+};
+
+TEST_F(IcebergDeletionVectorSinkTest, singleFileSinglePosition) {
+  auto tempDir = TempDirectoryPath::create();
+  auto handle = makeDeletionVectorHandle(tempDir->getPath());
+
+  IcebergDeletionVectorSink sink(
+      ROW({"file_path", "pos"}, {VARCHAR(), BIGINT()}),
+      handle,
+      /*connectorQueryCtx=*/nullptr,
+      connector::CommitStrategy::kNoCommit);
+
+  // Place the synthetic data file under tempDir so the puffin writer can
+  // create its output next to it.
+  const std::string dataFile = tempDir->getPath() + "/data-file.parquet";
+  sink.appendData(makePositionDeleteRows({dataFile}, {42}));
+  EXPECT_TRUE(sink.finish());
+  auto commitMessages = sink.close();
+
+  ASSERT_EQ(commitMessages.size(), 1);
+  auto parsed = folly::parseJson(commitMessages[0]);
+  EXPECT_EQ(parsed["content"].asString(), "POSITION_DELETES");
+  EXPECT_EQ(parsed["fileFormat"].asString(), "PUFFIN");
+  EXPECT_EQ(parsed["referencedDataFile"].asString(), dataFile);
+  EXPECT_EQ(parsed["metrics"]["recordCount"].asInt(), 1);
+  ASSERT_TRUE(parsed.find("path") != parsed.items().end());
+  ASSERT_TRUE(parsed.find("contentOffset") != parsed.items().end());
+  ASSERT_TRUE(parsed.find("contentSizeInBytes") != parsed.items().end());
+
+  // Verify the emitted Puffin file is readable by DeletionVectorReader and
+  // round-trips the position we wrote.
+  const auto puffinPath = parsed["path"].asString();
+  const auto offset = static_cast<uint64_t>(parsed["contentOffset"].asInt());
+  const auto length =
+      static_cast<uint64_t>(parsed["contentSizeInBytes"].asInt());
+  const auto recordCount =
+      static_cast<uint64_t>(parsed["metrics"]["recordCount"].asInt());
+  auto deleted = readBackDeletedPositions(
+      puffinPath, offset, length, recordCount, /*maxPos=*/42, pool_.get());
+  EXPECT_EQ(deleted, std::vector<uint64_t>{42});
+}
+
+TEST_F(IcebergDeletionVectorSinkTest, multipleFilesDemultiplexed) {
+  auto tempDir = TempDirectoryPath::create();
+  auto handle = makeDeletionVectorHandle(tempDir->getPath());
+
+  IcebergDeletionVectorSink sink(
+      ROW({"file_path", "pos"}, {VARCHAR(), BIGINT()}),
+      handle,
+      nullptr,
+      connector::CommitStrategy::kNoCommit);
+
+  const std::string fileA = tempDir->getPath() + "/A.parquet";
+  const std::string fileB = tempDir->getPath() + "/B.parquet";
+  sink.appendData(makePositionDeleteRows(
+      {fileA, fileB, fileA, fileB, fileA}, {1, 2, 3, 5, 7}));
+  EXPECT_TRUE(sink.finish());
+  auto commitMessages = sink.close();
+
+  // Two referenced data files -> two Puffin files -> two commit messages.
+  ASSERT_EQ(commitMessages.size(), 2);
+
+  // Insertion order is preserved: fileA appears first in the input page so
+  // its commit message comes first.
+  auto first = folly::parseJson(commitMessages[0]);
+  auto second = folly::parseJson(commitMessages[1]);
+  EXPECT_EQ(first["referencedDataFile"].asString(), fileA);
+  EXPECT_EQ(second["referencedDataFile"].asString(), fileB);
+  EXPECT_EQ(first["metrics"]["recordCount"].asInt(), 3);
+  EXPECT_EQ(second["metrics"]["recordCount"].asInt(), 2);
+
+  // Round-trip each Puffin to confirm the right positions landed under the
+  // right file.
+  auto fileAPositions = readBackDeletedPositions(
+      first["path"].asString(),
+      static_cast<uint64_t>(first["contentOffset"].asInt()),
+      static_cast<uint64_t>(first["contentSizeInBytes"].asInt()),
+      static_cast<uint64_t>(first["metrics"]["recordCount"].asInt()),
+      /*maxPos=*/7,
+      pool_.get());
+  auto fileBPositions = readBackDeletedPositions(
+      second["path"].asString(),
+      static_cast<uint64_t>(second["contentOffset"].asInt()),
+      static_cast<uint64_t>(second["contentSizeInBytes"].asInt()),
+      static_cast<uint64_t>(second["metrics"]["recordCount"].asInt()),
+      /*maxPos=*/7,
+      pool_.get());
+
+  EXPECT_EQ(fileAPositions, (std::vector<uint64_t>{1, 3, 7}));
+  EXPECT_EQ(fileBPositions, (std::vector<uint64_t>{2, 5}));
+}
+
+TEST_F(IcebergDeletionVectorSinkTest, emptyInputProducesNoCommitMessages) {
+  auto tempDir = TempDirectoryPath::create();
+  auto handle = makeDeletionVectorHandle(tempDir->getPath());
+
+  IcebergDeletionVectorSink sink(
+      ROW({"file_path", "pos"}, {VARCHAR(), BIGINT()}),
+      handle,
+      nullptr,
+      connector::CommitStrategy::kNoCommit);
+
+  // No appendData call -> no perFile state -> finish() must still be safe.
+  EXPECT_TRUE(sink.finish());
+  EXPECT_TRUE(sink.close().empty());
+  auto stats = sink.stats();
+  EXPECT_EQ(stats.numWrittenFiles, 0u);
+  EXPECT_EQ(stats.numWrittenBytes, 0u);
+}
+
+TEST_F(IcebergDeletionVectorSinkTest, abortBeforeFinishDropsState) {
+  auto tempDir = TempDirectoryPath::create();
+  auto handle = makeDeletionVectorHandle(tempDir->getPath());
+
+  IcebergDeletionVectorSink sink(
+      ROW({"file_path", "pos"}, {VARCHAR(), BIGINT()}),
+      handle,
+      nullptr,
+      connector::CommitStrategy::kNoCommit);
+
+  sink.appendData(makePositionDeleteRows({"/path/to/A.parquet"}, {100}));
+  sink.abort();
+
+  // After abort, no Puffin files should be flushed and close() returns an
+  // empty commit-message list. We do not check the temp directory for
+  // file presence because the sink never reached its writePuffinFile call.
+  EXPECT_TRUE(sink.close().empty());
+}
+
+TEST_F(IcebergDeletionVectorSinkTest, rejectsWrongChannelCount) {
+  auto tempDir = TempDirectoryPath::create();
+  auto handle = makeDeletionVectorHandle(tempDir->getPath());
+
+  IcebergDeletionVectorSink sink(
+      ROW({"file_path", "pos"}, {VARCHAR(), BIGINT()}),
+      handle,
+      nullptr,
+      connector::CommitStrategy::kNoCommit);
+
+  // Construct a 1-column page; the sink expects exactly 2 channels.
+  auto badPage = vectorMaker_->rowVector(
+      {"pos"}, {vectorMaker_->flatVector<int64_t>({1, 2, 3})});
+  VELOX_ASSERT_USER_THROW(
+      sink.appendData(badPage),
+      "IcebergDeletionVectorSink expects 2-column input pages");
+}


### PR DESCRIPTION
Summary:

Extends the IcebergInsertTableHandle::WriteKind enum with a third
value, kPositionDelete, paired with a VELOX_NYI dispatch arm in
IcebergConnector::createDataSink that documents where the V2 native
position-delete sink will plug in. Today V2 DELETE flows through the
Java row-id-rewrite path; this enum value is a forward-compat
placeholder so a future V2 native port has a clear hook.

What changes:
* IcebergDataSink.h: WriteKind enum gains kPositionDelete. The class
  comment is expanded to describe all three values.
* IcebergConnector.cpp createDataSink: new switch arm for
  kPositionDelete that raises VELOX_NYI with a message pointing at
  the follow-up plan and explaining the only way the arm would fire
  is if the planner unexpectedly routed a V2 delete through the
  native bridge.

What stays:
* No bridge change. presto_cpp's
  IcebergPrestoToVeloxConnector::toVeloxInsertTableHandle(DeleteHandle*)
  still maps POSITION_DELETES to kData (defensive fallback). The V2
  follow-up plan
  (~/.llms/plans/iceberg_v2_native_positional_delete_sink.plan.md)
  flips that mapping when the V2 sink lands.
* The existing kData + kDeletionVector dispatch arms are unchanged;
  build is byte-identical for INSERT and V3 DELETE traffic.

Reviewed By: srsuryadev

Differential Revision: D105895367
