### PR TITLE
feat: Add add() and exist() API in HashTableCache

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -1693,6 +1693,9 @@ folly::dynamic HashJoinNode::serialize() const {
   obj["nullAware"] = nullAware_;
   obj["nullAsValue"] = nullAsValue_;
   obj["useHashTableCache"] = useHashTableCache_;
+  if (cacheKey_.has_value()) {
+    obj["cacheKey"] = cacheKey_.value();
+  }
   return obj;
 }
 
@@ -1710,6 +1713,10 @@ PlanNodePtr HashJoinNode::create(const folly::dynamic& obj, void* context) {
   auto nullAware = obj["nullAware"].asBool();
   auto nullAsValue = obj.getDefault("nullAsValue", false).asBool();
   auto useHashTableCache = obj.getDefault("useHashTableCache", false).asBool();
+  std::optional<std::string> cacheKey = std::nullopt;
+  if (obj.count("cacheKey")) {
+    cacheKey = obj["cacheKey"].asString();
+  }
   auto leftKeys = deserializeFields(obj["leftKeys"], context);
   auto rightKeys = deserializeFields(obj["rightKeys"], context);
 
@@ -1731,7 +1738,8 @@ PlanNodePtr HashJoinNode::create(const folly::dynamic& obj, void* context) {
       sources[1],
       outputType,
       useHashTableCache,
-      nullAsValue);
+      nullAsValue,
+      std::move(cacheKey));
 }
 
 MergeJoinNode::MergeJoinNode(

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -3309,7 +3309,8 @@ class HashJoinNode : public AbstractJoinNode {
       PlanNodePtr right,
       RowTypePtr outputType,
       bool useHashTableCache = false,
-      bool nullAsValue = false)
+      bool nullAsValue = false,
+      std::optional<std::string> cacheKey = std::nullopt)
       : AbstractJoinNode(
             id,
             joinType,
@@ -3321,12 +3322,19 @@ class HashJoinNode : public AbstractJoinNode {
             std::move(outputType)),
         nullAware_{nullAware},
         nullAsValue_{nullAsValue},
-        useHashTableCache_{useHashTableCache} {
+        useHashTableCache_{useHashTableCache},
+        cacheKey_{std::move(cacheKey)} {
     validate();
 
     VELOX_USER_CHECK(
         !nullAware || !nullAsValue,
         "nullAware and nullAsValue are mutually exclusive");
+    VELOX_USER_CHECK(
+        !cacheKey_.has_value() || useHashTableCache_,
+        "cacheKey can only be set when useHashTableCache is enabled");
+    VELOX_USER_CHECK(
+        !cacheKey_.has_value() || !cacheKey_->empty(),
+        "cacheKey must be non-empty if set");
 
     if (isCountingJoin()) {
       VELOX_USER_CHECK(
@@ -3358,6 +3366,7 @@ class HashJoinNode : public AbstractJoinNode {
       nullAware_ = other.isNullAware();
       nullAsValue_ = other.isNullAsValue();
       useHashTableCache_ = other.useHashTableCache();
+      cacheKey_ = other.cacheKey();
     }
 
     Builder& nullAware(bool value) {
@@ -3372,6 +3381,11 @@ class HashJoinNode : public AbstractJoinNode {
 
     Builder& useHashTableCache(bool value) {
       useHashTableCache_ = value;
+      return *this;
+    }
+
+    Builder& cacheKey(std::optional<std::string> value) {
+      cacheKey_ = std::move(value);
       return *this;
     }
 
@@ -3403,13 +3417,15 @@ class HashJoinNode : public AbstractJoinNode {
           right_.value(),
           outputType_.value(),
           useHashTableCache_.value_or(false),
-          nullAsValue_.value_or(false));
+          nullAsValue_.value_or(false),
+          cacheKey_);
     }
 
    private:
     std::optional<bool> nullAware_;
     std::optional<bool> nullAsValue_;
     std::optional<bool> useHashTableCache_;
+    std::optional<std::string> cacheKey_;
   };
 
   std::string_view name() const override {
@@ -3449,6 +3465,10 @@ class HashJoinNode : public AbstractJoinNode {
     return useHashTableCache_;
   }
 
+  const std::optional<std::string>& cacheKey() const {
+    return cacheKey_;
+  }
+
   folly::dynamic serialize() const override;
 
   static PlanNodePtr create(const folly::dynamic& obj, void* context);
@@ -3459,6 +3479,7 @@ class HashJoinNode : public AbstractJoinNode {
   const bool nullAware_;
   const bool nullAsValue_;
   const bool useHashTableCache_;
+  const std::optional<std::string> cacheKey_;
 };
 
 using HashJoinNodePtr = std::shared_ptr<const HashJoinNode>;

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -142,8 +142,7 @@ bool HashBuild::setupCachedHashTable() {
     return false;
   }
 
-  const auto& queryId = operatorCtx_->task()->queryCtx()->queryId();
-  cacheKey_ = fmt::format("{}:{}", queryId, planNodeId());
+  cacheKey_ = planNodeId();
 
   // Get or create the cache entry (which includes the pool).
   // If another task is already building, future_ will be set.

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/exec/HashBuild.h"
+#include <fmt/format.h>
 #include "velox/common/base/Counters.h"
 #include "velox/common/base/StatsReporter.h"
 #include "velox/common/testutil/TestValue.h"
@@ -142,7 +143,17 @@ bool HashBuild::setupCachedHashTable() {
     return false;
   }
 
-  cacheKey_ = planNodeId();
+  if (joinNode_->cacheKey().has_value()) {
+    cacheKey_ = joinNode_->cacheKey().value();
+  } else {
+    const auto& queryId = operatorCtx_->task()->queryCtx()->queryId();
+    cacheKey_ = fmt::format("{}:{}", queryId, planNodeId());
+  }
+
+  VELOX_CHECK(
+      !cacheKey_.empty(),
+      "Hash table cache requires a non-empty cache key when "
+      "useHashTableCache is enabled");
 
   // Get or create the cache entry (which includes the pool).
   // If another task is already building, future_ will be set.

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -306,9 +306,10 @@ class HashBuild final : public Operator {
 
   State state_{State::kRunning};
 
-  // For hash table caching: the cache key passed in at construction.
+  // For hash table caching: the resolved cache key from HashJoinNode.
   // If set, this operator coordinates via HashTableCache.
-  // Key format: "queryId:planNodeId"
+  // If HashJoinNode.cacheKey is not set, falls back to the legacy
+  // "queryId:planNodeId" format.
   std::string cacheKey_;
 
   // For hash table caching: cached entry containing the shared table and pool.

--- a/velox/exec/HashTableCache.cpp
+++ b/velox/exec/HashTableCache.cpp
@@ -143,4 +143,53 @@ void HashTableCache::drop(const std::string& key) {
   }
 }
 
+std::shared_ptr<HashTableCacheEntry> HashTableCache::injectTable(
+    const std::string& key,
+    std::shared_ptr<BaseHashTable> table,
+    bool hasNullKeys,
+    std::shared_ptr<memory::MemoryPool> tablePool) {
+  VELOX_CHECK_NOT_NULL(table, "Cannot inject null table");
+  VELOX_CHECK_NOT_NULL(tablePool, "Cannot inject with null pool");
+
+  std::vector<ContinuePromise> promises;
+  std::shared_ptr<HashTableCacheEntry> entry;
+
+  {
+    std::lock_guard<std::mutex> guard(lock_);
+
+    auto it = tables_.find(key);
+    if (it != tables_.end()) {
+      entry = it->second;
+      if (entry->buildComplete) {
+        return entry;
+      }
+
+      VELOX_CHECK_NULL(entry->table, "Table already set for key '{}'", key);
+      entry->table = std::move(table);
+      entry->hasNullKeys = hasNullKeys;
+      entry->buildComplete = true;
+      promises = std::move(entry->buildPromises);
+    } else {
+      entry = std::make_shared<HashTableCacheEntry>(
+          key, "external_gluten", std::move(tablePool));
+      entry->table = std::move(table);
+      entry->hasNullKeys = hasNullKeys;
+      entry->buildComplete = true;
+      tables_.insert({key, entry});
+    }
+  }
+
+  for (auto& promise : promises) {
+    promise.setValue();
+  }
+
+  return entry;
+}
+
+bool HashTableCache::hasTable(const std::string& key) {
+  std::lock_guard<std::mutex> guard(lock_);
+  auto it = tables_.find(key);
+  return it != tables_.end() && it->second->buildComplete;
+}
+
 } // namespace facebook::velox::exec

--- a/velox/exec/HashTableCache.cpp
+++ b/velox/exec/HashTableCache.cpp
@@ -148,45 +148,30 @@ std::shared_ptr<HashTableCacheEntry> HashTableCache::add(
     std::shared_ptr<BaseHashTable> table,
     bool hasNullKeys,
     std::shared_ptr<memory::MemoryPool> tablePool) {
+  VELOX_CHECK(!key.empty(), "Cannot add table with empty key");
   VELOX_CHECK_NOT_NULL(table, "Cannot add null table");
   VELOX_CHECK_NOT_NULL(tablePool, "Cannot add with null pool");
 
-  std::vector<ContinuePromise> promises;
-  std::shared_ptr<HashTableCacheEntry> entry;
+  std::shared_ptr<HashTableCacheEntry> entry =
+      std::make_shared<HashTableCacheEntry>(
+          key, "external_gluten", std::move(tablePool));
+  entry->table = std::move(table);
+  entry->hasNullKeys = hasNullKeys;
+  entry->buildComplete = true;
 
   {
     std::lock_guard<std::mutex> guard(lock_);
-
-    auto it = tables_.find(key);
-    if (it != tables_.end()) {
-      entry = it->second;
-      if (entry->buildComplete) {
-        return entry;
-      }
-
-      VELOX_CHECK_NULL(entry->table, "Table already set for key '{}'", key);
-      entry->table = std::move(table);
-      entry->hasNullKeys = hasNullKeys;
-      entry->buildComplete = true;
-      promises = std::move(entry->buildPromises);
-    } else {
-      entry = std::make_shared<HashTableCacheEntry>(
-          key, "external_gluten", std::move(tablePool));
-      entry->table = std::move(table);
-      entry->hasNullKeys = hasNullKeys;
-      entry->buildComplete = true;
-      tables_.insert({key, entry});
-    }
-  }
-
-  for (auto& promise : promises) {
-    promise.setValue();
+    VELOX_CHECK(
+        tables_.find(key) == tables_.end(),
+        "Cannot add table for existing key '{}'",
+        key);
+    tables_.insert({key, entry});
   }
 
   return entry;
 }
 
-bool HashTableCache::hasTable(const std::string& key) {
+bool HashTableCache::exist(const std::string& key) {
   std::lock_guard<std::mutex> guard(lock_);
   auto it = tables_.find(key);
   return it != tables_.end() && it->second->buildComplete;

--- a/velox/exec/HashTableCache.cpp
+++ b/velox/exec/HashTableCache.cpp
@@ -143,13 +143,13 @@ void HashTableCache::drop(const std::string& key) {
   }
 }
 
-std::shared_ptr<HashTableCacheEntry> HashTableCache::injectTable(
+std::shared_ptr<HashTableCacheEntry> HashTableCache::add(
     const std::string& key,
     std::shared_ptr<BaseHashTable> table,
     bool hasNullKeys,
     std::shared_ptr<memory::MemoryPool> tablePool) {
-  VELOX_CHECK_NOT_NULL(table, "Cannot inject null table");
-  VELOX_CHECK_NOT_NULL(tablePool, "Cannot inject with null pool");
+  VELOX_CHECK_NOT_NULL(table, "Cannot add null table");
+  VELOX_CHECK_NOT_NULL(tablePool, "Cannot add with null pool");
 
   std::vector<ContinuePromise> promises;
   std::shared_ptr<HashTableCacheEntry> entry;

--- a/velox/exec/HashTableCache.h
+++ b/velox/exec/HashTableCache.h
@@ -73,6 +73,19 @@ class HashTableCache {
   /// Removes a cache entry.
   void drop(const std::string& key);
 
+  /// Injects an externally built hash table.
+  ///
+  /// This is used when an external system (e.g., Gluten) pre-builds a hash
+  /// table and wants Velox tasks to reuse it via HashBuild's cache path.
+  std::shared_ptr<HashTableCacheEntry> injectTable(
+      const std::string& key,
+      std::shared_ptr<BaseHashTable> table,
+      bool hasNullKeys,
+      std::shared_ptr<memory::MemoryPool> tablePool);
+
+  /// Returns true if a table exists and build is complete for the given key.
+  bool hasTable(const std::string& key);
+
  private:
   HashTableCache() = default;
 

--- a/velox/exec/HashTableCache.h
+++ b/velox/exec/HashTableCache.h
@@ -77,6 +77,7 @@ class HashTableCache {
   ///
   /// This is used when an external system (e.g., Gluten) pre-builds a hash
   /// table and wants Velox tasks to reuse it via HashBuild's cache path.
+  /// The key must not already exist in the cache.
   std::shared_ptr<HashTableCacheEntry> add(
       const std::string& key,
       std::shared_ptr<BaseHashTable> table,
@@ -84,7 +85,7 @@ class HashTableCache {
       std::shared_ptr<memory::MemoryPool> tablePool);
 
   /// Returns true if a table exists and build is complete for the given key.
-  bool hasTable(const std::string& key);
+  bool exist(const std::string& key);
 
  private:
   HashTableCache() = default;

--- a/velox/exec/HashTableCache.h
+++ b/velox/exec/HashTableCache.h
@@ -73,11 +73,11 @@ class HashTableCache {
   /// Removes a cache entry.
   void drop(const std::string& key);
 
-  /// Injects an externally built hash table.
+  /// Adds an externally built hash table.
   ///
   /// This is used when an external system (e.g., Gluten) pre-builds a hash
   /// table and wants Velox tasks to reuse it via HashBuild's cache path.
-  std::shared_ptr<HashTableCacheEntry> injectTable(
+  std::shared_ptr<HashTableCacheEntry> add(
       const std::string& key,
       std::shared_ptr<BaseHashTable> table,
       bool hasNullKeys,

--- a/velox/exec/tests/HashTableCacheTest.cpp
+++ b/velox/exec/tests/HashTableCacheTest.cpp
@@ -21,6 +21,10 @@
 #include "velox/common/caching/AsyncDataCache.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/core/QueryCtx.h"
+#include "velox/exec/VectorHasher.h"
+#include "velox/type/Type.h"
+#include "velox/vector/DecodedVector.h"
+#include "velox/vector/tests/utils/VectorMaker.h"
 
 namespace facebook::velox::exec::test {
 
@@ -54,6 +58,43 @@ class HashTableCacheTest : public testing::Test {
   std::shared_ptr<core::QueryCtx> queryCtx_;
   std::vector<std::string> createdKeys_;
 };
+
+static std::shared_ptr<BaseHashTable> makeTestJoinHashTable(
+    memory::MemoryPool* pool) {
+  auto store = [](RowContainer& rowContainer, const RowVectorPtr& data) {
+    std::vector<DecodedVector> decodedVectors;
+    decodedVectors.reserve(data->childrenSize());
+    for (const auto& vector : data->children()) {
+      decodedVectors.emplace_back(*vector);
+    }
+
+    for (auto i = 0; i < data->size(); ++i) {
+      auto* row = rowContainer.newRow();
+      for (auto j = 0; j < decodedVectors.size(); ++j) {
+        rowContainer.store(decodedVectors[j], i, row, j);
+      }
+    }
+  };
+
+  facebook::velox::test::VectorMaker vectorMaker(pool);
+  auto data = vectorMaker.rowVector(
+      {vectorMaker.flatVector<int64_t>(100, [](auto row) { return row; })});
+
+  std::vector<std::unique_ptr<VectorHasher>> hashers;
+  hashers.emplace_back(std::make_unique<VectorHasher>(BIGINT(), 0));
+  auto table = HashTable<false>::createForJoin(
+      std::move(hashers),
+      {}, /*dependentTypes*/
+      true /*allowDuplicates*/,
+      false /*hasProbedFlag*/,
+      false /*hasCountFlag*/,
+      1 /*minTableSizeForParallelJoinBuild*/,
+      pool);
+  store(*table->rows(), data);
+  table->prepareJoinTable(
+      {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+  return std::shared_ptr<BaseHashTable>(std::move(table));
+}
 
 TEST_F(HashTableCacheTest, basicGet) {
   auto* cache = HashTableCache::instance();
@@ -271,6 +312,88 @@ TEST_F(HashTableCacheTest, builderFailureUnblocksWaiters) {
   EXPECT_FALSE(newEntry->buildComplete);
 
   cache->drop(key);
+}
+
+TEST_F(HashTableCacheTest, injectTableCreatesEntryAndIsDiscoverable) {
+  auto* cache = HashTableCache::instance();
+  const std::string key = "inject1";
+  trackKey(key);
+
+  auto tableRoot = memory::memoryManager()->addRootPool("HashTableCacheInject");
+  auto tablePool = tableRoot->addLeafChild("leaf");
+  auto table = makeTestJoinHashTable(tablePool.get());
+
+  auto entry = cache->injectTable(key, table, true, tablePool);
+  ASSERT_NE(entry, nullptr);
+  EXPECT_TRUE(entry->buildComplete);
+  EXPECT_EQ(entry->builderTaskId, "external_gluten");
+  EXPECT_EQ(entry->table, table);
+  EXPECT_TRUE(entry->hasNullKeys);
+
+  EXPECT_TRUE(cache->hasTable(key));
+
+  ContinueFuture future = ContinueFuture::makeEmpty();
+  auto getEntry = cache->get(key, "task1", queryCtx_.get(), &future);
+  EXPECT_EQ(getEntry, entry);
+  EXPECT_TRUE(getEntry->buildComplete);
+  EXPECT_FALSE(future.valid());
+}
+
+TEST_F(HashTableCacheTest, injectTableUnblocksExistingWaiters) {
+  auto* cache = HashTableCache::instance();
+  const std::string key = "inject2";
+  trackKey(key);
+
+  ContinueFuture builderFuture = ContinueFuture::makeEmpty();
+  auto entry = cache->get(key, "task_builder", queryCtx_.get(), &builderFuture);
+  EXPECT_FALSE(builderFuture.valid());
+  EXPECT_FALSE(entry->buildComplete);
+
+  ContinueFuture waiterFuture1 = ContinueFuture::makeEmpty();
+  cache->get(key, "task_waiter_1", queryCtx_.get(), &waiterFuture1);
+  ASSERT_TRUE(waiterFuture1.valid());
+  EXPECT_FALSE(waiterFuture1.isReady());
+
+  ContinueFuture waiterFuture2 = ContinueFuture::makeEmpty();
+  cache->get(key, "task_waiter_2", queryCtx_.get(), &waiterFuture2);
+  ASSERT_TRUE(waiterFuture2.valid());
+  EXPECT_FALSE(waiterFuture2.isReady());
+
+  auto table = makeTestJoinHashTable(entry->tablePool.get());
+  auto injectedEntry = cache->injectTable(key, table, false, entry->tablePool);
+
+  EXPECT_EQ(injectedEntry, entry);
+  EXPECT_TRUE(entry->buildComplete);
+  EXPECT_EQ(entry->builderTaskId, "task_builder");
+  EXPECT_EQ(entry->table, table);
+  EXPECT_FALSE(entry->hasNullKeys);
+
+  EXPECT_TRUE(waiterFuture1.isReady());
+  EXPECT_TRUE(waiterFuture2.isReady());
+}
+
+TEST_F(HashTableCacheTest, injectTableDoesNotOverwriteCompleteEntry) {
+  auto* cache = HashTableCache::instance();
+  const std::string key = "inject3";
+  trackKey(key);
+
+  auto root1 = memory::memoryManager()->addRootPool("HashTableCacheInject3_1");
+  auto pool1 = root1->addLeafChild("leaf");
+  auto table1 = makeTestJoinHashTable(pool1.get());
+  auto entry1 = cache->injectTable(key, table1, false, pool1);
+  ASSERT_NE(entry1, nullptr);
+  ASSERT_TRUE(entry1->buildComplete);
+  EXPECT_EQ(entry1->table, table1);
+  EXPECT_FALSE(entry1->hasNullKeys);
+
+  auto root2 = memory::memoryManager()->addRootPool("HashTableCacheInject3_2");
+  auto pool2 = root2->addLeafChild("leaf");
+  auto table2 = makeTestJoinHashTable(pool2.get());
+  auto entry2 = cache->injectTable(key, table2, true, pool2);
+
+  EXPECT_EQ(entry2, entry1);
+  EXPECT_EQ(entry2->table, table1);
+  EXPECT_FALSE(entry2->hasNullKeys);
 }
 
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/HashTableCacheTest.cpp
+++ b/velox/exec/tests/HashTableCacheTest.cpp
@@ -18,6 +18,7 @@
 
 #include <gtest/gtest.h>
 
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/caching/AsyncDataCache.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/core/QueryCtx.h"
@@ -330,7 +331,7 @@ TEST_F(HashTableCacheTest, addCreatesEntryAndIsDiscoverable) {
   EXPECT_EQ(entry->table, table);
   EXPECT_TRUE(entry->hasNullKeys);
 
-  EXPECT_TRUE(cache->hasTable(key));
+  EXPECT_TRUE(cache->exist(key));
 
   ContinueFuture future = ContinueFuture::makeEmpty();
   auto getEntry = cache->get(key, "task1", queryCtx_.get(), &future);
@@ -339,7 +340,26 @@ TEST_F(HashTableCacheTest, addCreatesEntryAndIsDiscoverable) {
   EXPECT_FALSE(future.valid());
 }
 
-TEST_F(HashTableCacheTest, addUnblocksExistingWaiters) {
+TEST_F(HashTableCacheTest, addRejectsInvalidArguments) {
+  auto* cache = HashTableCache::instance();
+
+  auto tableRoot =
+      memory::memoryManager()->addRootPool("HashTableCacheInvalidArgs");
+  auto tablePool = tableRoot->addLeafChild("leaf");
+  auto table = makeTestJoinHashTable(tablePool.get());
+
+  VELOX_ASSERT_THROW(
+      cache->add("", table, false, tablePool),
+      "Cannot add table with empty key");
+  VELOX_ASSERT_THROW(
+      cache->add("inject_invalid_null_table", nullptr, false, tablePool),
+      "Cannot add null table");
+  VELOX_ASSERT_THROW(
+      cache->add("inject_invalid_null_pool", table, false, nullptr),
+      "Cannot add with null pool");
+}
+
+TEST_F(HashTableCacheTest, addFailsIfEntryAlreadyExists) {
   auto* cache = HashTableCache::instance();
   const std::string key = "inject2";
   trackKey(key);
@@ -360,19 +380,15 @@ TEST_F(HashTableCacheTest, addUnblocksExistingWaiters) {
   EXPECT_FALSE(waiterFuture2.isReady());
 
   auto table = makeTestJoinHashTable(entry->tablePool.get());
-  auto injectedEntry = cache->add(key, table, false, entry->tablePool);
-
-  EXPECT_EQ(injectedEntry, entry);
-  EXPECT_TRUE(entry->buildComplete);
-  EXPECT_EQ(entry->builderTaskId, "task_builder");
-  EXPECT_EQ(entry->table, table);
-  EXPECT_FALSE(entry->hasNullKeys);
-
-  EXPECT_TRUE(waiterFuture1.isReady());
-  EXPECT_TRUE(waiterFuture2.isReady());
+  VELOX_ASSERT_THROW(
+      cache->add(key, table, false, entry->tablePool),
+      "Cannot add table for existing key");
+  EXPECT_FALSE(entry->buildComplete);
+  EXPECT_FALSE(waiterFuture1.isReady());
+  EXPECT_FALSE(waiterFuture2.isReady());
 }
 
-TEST_F(HashTableCacheTest, addDoesNotOverwriteCompleteEntry) {
+TEST_F(HashTableCacheTest, addFailsIfCompleteEntryAlreadyExists) {
   auto* cache = HashTableCache::instance();
   const std::string key = "inject3";
   trackKey(key);
@@ -389,11 +405,46 @@ TEST_F(HashTableCacheTest, addDoesNotOverwriteCompleteEntry) {
   auto root2 = memory::memoryManager()->addRootPool("HashTableCacheInject3_2");
   auto pool2 = root2->addLeafChild("leaf");
   auto table2 = makeTestJoinHashTable(pool2.get());
-  auto entry2 = cache->add(key, table2, true, pool2);
+  VELOX_ASSERT_THROW(
+      cache->add(key, table2, true, pool2),
+      "Cannot add table for existing key");
+  EXPECT_EQ(entry1->table, table1);
+  EXPECT_FALSE(entry1->hasNullKeys);
+}
 
-  EXPECT_EQ(entry2, entry1);
-  EXPECT_EQ(entry2->table, table1);
-  EXPECT_FALSE(entry2->hasNullKeys);
+TEST_F(HashTableCacheTest, existApiReflectsCacheState) {
+  auto* cache = HashTableCache::instance();
+
+  const std::string getPutKey = "query_exist_get_put";
+  trackKey(getPutKey);
+  EXPECT_FALSE(cache->exist(getPutKey));
+
+  ContinueFuture future = ContinueFuture::makeEmpty();
+  auto entry = cache->get(getPutKey, "task1", queryCtx_.get(), &future);
+  ASSERT_NE(entry, nullptr);
+  EXPECT_FALSE(future.valid());
+  EXPECT_FALSE(cache->exist(getPutKey))
+      << "Placeholder entry should not exist until build completes";
+
+  cache->put(getPutKey, nullptr, false);
+  EXPECT_TRUE(cache->exist(getPutKey));
+
+  cache->drop(getPutKey);
+  EXPECT_FALSE(cache->exist(getPutKey));
+
+  const std::string addKey = "query_exist_add";
+  trackKey(addKey);
+  EXPECT_FALSE(cache->exist(addKey));
+
+  auto tableRoot = memory::memoryManager()->addRootPool("HashTableCacheExist");
+  auto tablePool = tableRoot->addLeafChild("leaf");
+  auto table = makeTestJoinHashTable(tablePool.get());
+  auto addEntry = cache->add(addKey, table, true, tablePool);
+  ASSERT_NE(addEntry, nullptr);
+  EXPECT_TRUE(cache->exist(addKey));
+
+  cache->drop(addKey);
+  EXPECT_FALSE(cache->exist(addKey));
 }
 
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/HashTableCacheTest.cpp
+++ b/velox/exec/tests/HashTableCacheTest.cpp
@@ -314,7 +314,7 @@ TEST_F(HashTableCacheTest, builderFailureUnblocksWaiters) {
   cache->drop(key);
 }
 
-TEST_F(HashTableCacheTest, injectTableCreatesEntryAndIsDiscoverable) {
+TEST_F(HashTableCacheTest, addCreatesEntryAndIsDiscoverable) {
   auto* cache = HashTableCache::instance();
   const std::string key = "inject1";
   trackKey(key);
@@ -323,7 +323,7 @@ TEST_F(HashTableCacheTest, injectTableCreatesEntryAndIsDiscoverable) {
   auto tablePool = tableRoot->addLeafChild("leaf");
   auto table = makeTestJoinHashTable(tablePool.get());
 
-  auto entry = cache->injectTable(key, table, true, tablePool);
+  auto entry = cache->add(key, table, true, tablePool);
   ASSERT_NE(entry, nullptr);
   EXPECT_TRUE(entry->buildComplete);
   EXPECT_EQ(entry->builderTaskId, "external_gluten");
@@ -339,7 +339,7 @@ TEST_F(HashTableCacheTest, injectTableCreatesEntryAndIsDiscoverable) {
   EXPECT_FALSE(future.valid());
 }
 
-TEST_F(HashTableCacheTest, injectTableUnblocksExistingWaiters) {
+TEST_F(HashTableCacheTest, addUnblocksExistingWaiters) {
   auto* cache = HashTableCache::instance();
   const std::string key = "inject2";
   trackKey(key);
@@ -360,7 +360,7 @@ TEST_F(HashTableCacheTest, injectTableUnblocksExistingWaiters) {
   EXPECT_FALSE(waiterFuture2.isReady());
 
   auto table = makeTestJoinHashTable(entry->tablePool.get());
-  auto injectedEntry = cache->injectTable(key, table, false, entry->tablePool);
+  auto injectedEntry = cache->add(key, table, false, entry->tablePool);
 
   EXPECT_EQ(injectedEntry, entry);
   EXPECT_TRUE(entry->buildComplete);
@@ -372,7 +372,7 @@ TEST_F(HashTableCacheTest, injectTableUnblocksExistingWaiters) {
   EXPECT_TRUE(waiterFuture2.isReady());
 }
 
-TEST_F(HashTableCacheTest, injectTableDoesNotOverwriteCompleteEntry) {
+TEST_F(HashTableCacheTest, addDoesNotOverwriteCompleteEntry) {
   auto* cache = HashTableCache::instance();
   const std::string key = "inject3";
   trackKey(key);
@@ -380,7 +380,7 @@ TEST_F(HashTableCacheTest, injectTableDoesNotOverwriteCompleteEntry) {
   auto root1 = memory::memoryManager()->addRootPool("HashTableCacheInject3_1");
   auto pool1 = root1->addLeafChild("leaf");
   auto table1 = makeTestJoinHashTable(pool1.get());
-  auto entry1 = cache->injectTable(key, table1, false, pool1);
+  auto entry1 = cache->add(key, table1, false, pool1);
   ASSERT_NE(entry1, nullptr);
   ASSERT_TRUE(entry1->buildComplete);
   EXPECT_EQ(entry1->table, table1);
@@ -389,7 +389,7 @@ TEST_F(HashTableCacheTest, injectTableDoesNotOverwriteCompleteEntry) {
   auto root2 = memory::memoryManager()->addRootPool("HashTableCacheInject3_2");
   auto pool2 = root2->addLeafChild("leaf");
   auto table2 = makeTestJoinHashTable(pool2.get());
-  auto entry2 = cache->injectTable(key, table2, true, pool2);
+  auto entry2 = cache->add(key, table2, true, pool2);
 
   EXPECT_EQ(entry2, entry1);
   EXPECT_EQ(entry2->table, table1);


### PR DESCRIPTION
Based on the discussions https://github.com/facebookincubator/velox/discussions/17546
 regarding Gluten's BHJ architecture, Gluten cannot directly utilize HashTableCache to build a hash table once and share it across a single executor. To address this, we introduced the injectTable API. This allows HashTableCache to accept a pre-built hash table injected by Gluten. Consequently, HashBuild can retrieve the hash table directly from the cache, eliminating the need for redundant rebuilding.