### PR TITLE
refactor: Format-specific DWIO reader options

### DIFF
--- a/velox/common/config/Config.cpp
+++ b/velox/common/config/Config.cpp
@@ -139,6 +139,23 @@ std::unordered_map<std::string, std::string> ConfigBase::rawConfigsCopy()
   return configs_;
 }
 
+std::unordered_map<std::string, std::string> ConfigBase::rawConfigsWithPrefix(
+    std::string_view prefix) const {
+  std::unordered_map<std::string, std::string> filteredConfigs;
+  if (prefix.empty()) {
+    return filteredConfigs;
+  }
+
+  std::shared_lock<std::shared_mutex> l(mutex_);
+  for (const auto& [key, value] : configs_) {
+    if (key.size() >= prefix.size() &&
+        key.compare(0, prefix.size(), prefix) == 0) {
+      filteredConfigs.emplace(key.substr(prefix.size()), value);
+    }
+  }
+  return filteredConfigs;
+}
+
 std::string ConfigBase::toConfigKey(std::string_view sessionKey) {
   std::string configKey{sessionKey};
   std::replace(configKey.begin(), configKey.end(), '_', '-');

--- a/velox/common/config/Config.cpp
+++ b/velox/common/config/Config.cpp
@@ -148,8 +148,7 @@ std::unordered_map<std::string, std::string> ConfigBase::rawConfigsWithPrefix(
 
   std::shared_lock<std::shared_mutex> l(mutex_);
   for (const auto& [key, value] : configs_) {
-    if (key.size() >= prefix.size() &&
-        key.compare(0, prefix.size(), prefix) == 0) {
+    if (key.starts_with(prefix)) {
       filteredConfigs.emplace(key.substr(prefix.size()), value);
     }
   }

--- a/velox/common/config/Config.h
+++ b/velox/common/config/Config.h
@@ -119,6 +119,14 @@ class ConfigBase : public IConfig {
 
   const std::unordered_map<std::string, std::string>& rawConfigs() const;
 
+  template <typename Visitor>
+  void visitConfigs(Visitor&& visitor) const {
+    std::shared_lock<std::shared_mutex> l(mutex_);
+    for (const auto& entry : configs_) {
+      visitor(entry);
+    }
+  }
+
   std::unordered_map<std::string, std::string> rawConfigsCopy() const final;
 
   /// Converts a session key to a config key by replacing '_' with '-'.

--- a/velox/common/config/Config.h
+++ b/velox/common/config/Config.h
@@ -119,15 +119,12 @@ class ConfigBase : public IConfig {
 
   const std::unordered_map<std::string, std::string>& rawConfigs() const;
 
-  template <typename Visitor>
-  void visitConfigs(Visitor&& visitor) const {
-    std::shared_lock<std::shared_mutex> l(mutex_);
-    for (const auto& entry : configs_) {
-      visitor(entry);
-    }
-  }
-
   std::unordered_map<std::string, std::string> rawConfigsCopy() const final;
+
+  /// Returns configs whose keys start with 'prefix'. The prefix is stripped
+  /// from keys in the returned map.
+  std::unordered_map<std::string, std::string> rawConfigsWithPrefix(
+      std::string_view prefix) const;
 
   /// Converts a session key to a config key by replacing '_' with '-'.
   static std::string toConfigKey(std::string_view sessionKey);

--- a/velox/common/config/tests/ConfigTest.cpp
+++ b/velox/common/config/tests/ConfigTest.cpp
@@ -97,25 +97,23 @@ TEST_F(ConfigTest, creation) {
   }
 }
 
-TEST_F(ConfigTest, visitMutableConfig) {
+TEST_F(ConfigTest, rawConfigsWithPrefix) {
   auto config = std::make_shared<TestConfig>(
       std::unordered_map<std::string, std::string>{
-          {"first", "1"},
-          {"second", "2"},
+          {"parquet.first", "1"},
+          {"parquet.second", "2"},
+          {"orc.first", "3"},
       },
       true);
 
-  std::unordered_map<std::string, std::string> visitedConfigs;
-  config->visitConfigs([&](const auto& entry) {
-    visitedConfigs.emplace(entry.first, entry.second);
-  });
-
   EXPECT_EQ(
-      visitedConfigs,
+      config->rawConfigsWithPrefix("parquet."),
       (std::unordered_map<std::string, std::string>{
           {"first", "1"},
           {"second", "2"},
       }));
+  EXPECT_TRUE(config->rawConfigsWithPrefix("missing.").empty());
+  EXPECT_TRUE(config->rawConfigsWithPrefix("").empty());
 }
 
 TEST_F(ConfigTest, immutableConfig) {

--- a/velox/common/config/tests/ConfigTest.cpp
+++ b/velox/common/config/tests/ConfigTest.cpp
@@ -97,6 +97,27 @@ TEST_F(ConfigTest, creation) {
   }
 }
 
+TEST_F(ConfigTest, visitMutableConfig) {
+  auto config = std::make_shared<TestConfig>(
+      std::unordered_map<std::string, std::string>{
+          {"first", "1"},
+          {"second", "2"},
+      },
+      true);
+
+  std::unordered_map<std::string, std::string> visitedConfigs;
+  config->visitConfigs([&](const auto& entry) {
+    visitedConfigs.emplace(entry.first, entry.second);
+  });
+
+  EXPECT_EQ(
+      visitedConfigs,
+      (std::unordered_map<std::string, std::string>{
+          {"first", "1"},
+          {"second", "2"},
+      }));
+}
+
 TEST_F(ConfigTest, immutableConfig) {
   // Testing default values
   auto config = std::make_shared<TestConfig>(

--- a/velox/connectors/hive/CMakeLists.txt
+++ b/velox/connectors/hive/CMakeLists.txt
@@ -15,6 +15,10 @@
 velox_add_library(velox_hive_config OBJECT FileConfig.cpp HiveConfig.cpp)
 velox_link_libraries(velox_hive_config velox_core velox_exception)
 
+if(VELOX_ENABLE_PARQUET)
+  velox_link_libraries(velox_hive_config velox_dwio_parquet_common)
+endif()
+
 add_subdirectory(iceberg)
 add_subdirectory(paimon)
 
@@ -84,6 +88,10 @@ velox_link_libraries(
     velox_hive_partition_function
     velox_key_encoder
 )
+
+if(VELOX_ENABLE_PARQUET)
+  velox_link_libraries(velox_hive_connector PRIVATE velox_dwio_parquet_common)
+endif()
 
 velox_add_library(velox_hive_partition_function HivePartitionFunction.cpp)
 

--- a/velox/connectors/hive/FileConfig.cpp
+++ b/velox/connectors/hive/FileConfig.cpp
@@ -27,17 +27,13 @@ const std::vector<config::ConfigProperty>& FileConfig::registeredProperties() {
   config::registerConfigProperty<FileConfig::constName##Property>(properties)
 
     VELOX_HIVE_CONFIG_REGISTER(kOrcUseColumnNamesSession);
-    VELOX_HIVE_CONFIG_REGISTER(kParquetUseColumnNamesSession);
-    VELOX_HIVE_CONFIG_REGISTER(kAllowInt32NarrowingSession);
     VELOX_HIVE_CONFIG_REGISTER(kReadTimestampPartitionValueAsLocalTimeSession);
     VELOX_HIVE_CONFIG_REGISTER(kPreserveFlatMapsInMemorySession);
     VELOX_HIVE_CONFIG_REGISTER(kReaderCollectColumnCpuMetricsSession);
     VELOX_HIVE_CONFIG_REGISTER(kOrcFooterSpeculativeIoSizeSession);
-    VELOX_HIVE_CONFIG_REGISTER(kParquetFooterSpeculativeIoSizeSession);
     VELOX_HIVE_CONFIG_REGISTER(kNimbleFooterSpeculativeIoSizeSession);
     VELOX_HIVE_CONFIG_REGISTER(kNimbleStringDecoderZeroCopySession);
     VELOX_HIVE_CONFIG_REGISTER(kNimblePreserveDictionaryEncodingSession);
-    VELOX_HIVE_CONFIG_REGISTER(kParquetFooterMemoryTrackingThresholdSession);
     VELOX_HIVE_CONFIG_REGISTER(kFileColumnNamesReadAsLowerCaseSession);
     VELOX_HIVE_CONFIG_REGISTER(kIgnoreMissingFilesSession);
     VELOX_HIVE_CONFIG_REGISTER(kMaxCoalescedBytesSession);

--- a/velox/connectors/hive/FileConfig.h
+++ b/velox/connectors/hive/FileConfig.h
@@ -276,6 +276,12 @@ class FileConfig {
 
   virtual ~FileConfig() = default;
 
+  /// Returns the connector-owned config prefix. For example, "hive" returns
+  /// "hive.".
+  static std::string makeConnectorConfigPrefix(std::string_view connectorName) {
+    return std::string(connectorName) + ".";
+  }
+
   int32_t maxCoalescedDistanceBytes(const config::ConfigBase* session) const;
 
   int32_t prefetchRowGroups() const;

--- a/velox/connectors/hive/FileConfig.h
+++ b/velox/connectors/hive/FileConfig.h
@@ -17,6 +17,8 @@
 
 #include <limits>
 #include <string>
+#include <string_view>
+#include <utility>
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/config/Config.h"
 #include "velox/common/config/ConfigProperty.h"
@@ -43,26 +45,6 @@ class FileConfig {
       bool,
       false,
       "Map ORC table field names to file field names using names, not indices.")
-
-  VELOX_HIVE_CONFIG_LEGACY(
-      kParquetUseColumnNamesSession,
-      kParquetUseColumnNames,
-      isParquetUseColumnNames,
-      "parquet_use_column_names",
-      "hive.parquet.use-column-names",
-      bool,
-      false,
-      "Map Parquet table field names to file field names using names, not indices.")
-
-  VELOX_HIVE_CONFIG_LEGACY(
-      kAllowInt32NarrowingSession,
-      kAllowInt32Narrowing,
-      allowInt32Narrowing,
-      "parquet_allow_int32_narrowing",
-      "hive.parquet.allow-int32-narrowing",
-      bool,
-      false,
-      "Allow reading INT32 Parquet columns as a narrower integer type.")
 
   VELOX_HIVE_CONFIG_LEGACY(
       kReadTimestampPartitionValueAsLocalTimeSession,
@@ -103,16 +85,6 @@ class FileConfig {
       uint64_t,
       256UL << 10,
       "Speculative tail-read size in bytes for ORC files.")
-
-  VELOX_HIVE_CONFIG_LEGACY(
-      kParquetFooterSpeculativeIoSizeSession,
-      kParquetFooterSpeculativeIoSize,
-      parquetFooterSpeculativeIoSize,
-      "parquet_footer_speculative_io_size",
-      "hive.parquet.footer-speculative-io-size",
-      uint64_t,
-      256UL << 10,
-      "Speculative tail-read size in bytes for Parquet files.")
 
   VELOX_HIVE_CONFIG_LEGACY(
       kNimbleFooterSpeculativeIoSizeSession,
@@ -257,18 +229,6 @@ class FileConfig {
       true,
       "Enable selective Nimble reader.")
 
-  VELOX_HIVE_CONFIG_LEGACY(
-      kParquetFooterMemoryTrackingThresholdSession,
-      kParquetFooterMemoryTrackingThreshold,
-      parquetFooterMemoryTrackingThreshold,
-      "parquet_footer_memory_tracking_threshold",
-      "hive.parquet.footer-memory-tracking-threshold",
-      uint64_t,
-      std::numeric_limits<uint64_t>::max(),
-      "Serialized footer size in bytes beyond which the Parquet reader "
-      "estimates and reports the deserialized footer's heap footprint to "
-      "the memory pool. Defaults to disabled (max uint64).")
-
   // --- VELOX_HIVE_CONFIG_PROPERTY properties ---
 
   VELOX_HIVE_CONFIG_PROPERTY(
@@ -305,7 +265,10 @@ class FileConfig {
   /// meta data together. Optimization to decrease the small IO requests.
   static constexpr const char* kFilePreloadThreshold = "file-preload-threshold";
 
-  explicit FileConfig(std::shared_ptr<const config::ConfigBase> config) {
+  explicit FileConfig(
+      std::shared_ptr<const config::ConfigBase> config,
+      std::string connectorConfigPrefix)
+      : connectorConfigPrefix_(std::move(connectorConfigPrefix)) {
     VELOX_CHECK_NOT_NULL(
         config, "Config is null for FileConfig initialization");
     config_ = std::move(config);
@@ -326,6 +289,10 @@ class FileConfig {
 
   const std::shared_ptr<const config::ConfigBase>& config() const {
     return config_;
+  }
+
+  std::string_view connectorConfigPrefix() const {
+    return connectorConfigPrefix_;
   }
 
  protected:
@@ -362,6 +329,7 @@ class FileConfig {
   }
 
   std::shared_ptr<const config::ConfigBase> config_;
+  const std::string connectorConfigPrefix_;
 };
 
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/FileConfig.h
+++ b/velox/connectors/hive/FileConfig.h
@@ -267,8 +267,8 @@ class FileConfig {
 
   explicit FileConfig(
       std::shared_ptr<const config::ConfigBase> config,
-      std::string connectorConfigPrefix)
-      : connectorConfigPrefix_(std::move(connectorConfigPrefix)) {
+      std::string connectorName)
+      : connectorName_(std::move(connectorName)) {
     VELOX_CHECK_NOT_NULL(
         config, "Config is null for FileConfig initialization");
     config_ = std::move(config);
@@ -276,10 +276,8 @@ class FileConfig {
 
   virtual ~FileConfig() = default;
 
-  /// Returns the connector-owned config prefix. For example, "hive" returns
-  /// "hive.".
-  static std::string makeConnectorConfigPrefix(std::string_view connectorName) {
-    return std::string(connectorName) + ".";
+  std::string_view connectorName() const {
+    return connectorName_;
   }
 
   int32_t maxCoalescedDistanceBytes(const config::ConfigBase* session) const;
@@ -295,10 +293,6 @@ class FileConfig {
 
   const std::shared_ptr<const config::ConfigBase>& config() const {
     return config_;
-  }
-
-  std::string_view connectorConfigPrefix() const {
-    return connectorConfigPrefix_;
   }
 
  protected:
@@ -335,7 +329,7 @@ class FileConfig {
   }
 
   std::shared_ptr<const config::ConfigBase> config_;
-  const std::string connectorConfigPrefix_;
+  const std::string connectorName_;
 };
 
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/FileConnectorUtil.cpp
+++ b/velox/connectors/hive/FileConnectorUtil.cpp
@@ -16,12 +16,45 @@
 
 #include "velox/connectors/hive/FileConnectorUtil.h"
 
+#include <string_view>
+#include <unordered_map>
+
+#include "velox/common/config/Config.h"
 #include "velox/connectors/hive/FileColumnHandle.h"
 #include "velox/connectors/hive/FileConfig.h"
 #include "velox/connectors/hive/FileConnectorSplit.h"
 #include "velox/connectors/hive/FileTableHandle.h"
+#include "velox/dwio/common/ReaderFactory.h"
 
 namespace facebook::velox::connector::hive {
+
+namespace {
+
+std::string formatConfigPrefix(dwio::common::FileFormat format) {
+  if (format == dwio::common::FileFormat::UNKNOWN) {
+    return "";
+  }
+  return std::string(dwio::common::toString(format)) + ".";
+}
+
+config::ConfigBase filterConfigByPrefix(
+    const config::ConfigBase& config,
+    std::string_view prefix) {
+  std::unordered_map<std::string, std::string> filteredConfigs;
+  if (prefix.empty()) {
+    return config::ConfigBase(std::move(filteredConfigs));
+  }
+
+  for (const auto& [key, value] : config.rawConfigs()) {
+    if (key.size() >= prefix.size() &&
+        key.compare(0, prefix.size(), prefix) == 0) {
+      filteredConfigs.emplace(key.substr(prefix.size()), value);
+    }
+  }
+  return config::ConfigBase(std::move(filteredConfigs));
+}
+
+} // namespace
 
 void configureReaderOptions(
     const std::shared_ptr<const FileConfig>& fileConfig,
@@ -63,14 +96,6 @@ void configureReaderOptions(
           : dwio::common::ColumnMappingMode::kPosition;
       break;
     }
-    case dwio::common::FileFormat::PARQUET: {
-      columnMappingMode = fileConfig->isParquetUseColumnNames(sessionProperties)
-          ? dwio::common::ColumnMappingMode::kName
-          : dwio::common::ColumnMappingMode::kPosition;
-      readerOptions.setAllowInt32Narrowing(
-          fileConfig->allowInt32Narrowing(sessionProperties));
-      break;
-    }
     default:
       columnMappingMode = dwio::common::ColumnMappingMode::kPosition;
   }
@@ -78,8 +103,6 @@ void configureReaderOptions(
   readerOptions.setColumnMappingMode(columnMappingMode);
   readerOptions.setFileSchema(fileSchema);
   readerOptions.setFilePreloadThreshold(fileConfig->filePreloadThreshold());
-  readerOptions.setParquetFooterMemoryTrackingThreshold(
-      fileConfig->parquetFooterMemoryTrackingThreshold(sessionProperties));
   readerOptions.setPrefetchRowGroups(fileConfig->prefetchRowGroups());
   readerOptions.setCacheable(fileSplit->cacheable);
   const auto& sessionTzName = connectorQueryCtx->sessionTimezone();
@@ -113,8 +136,6 @@ void configureReaderOptions(
           fileConfig->orcFooterSpeculativeIoSize(sessionProperties));
       break;
     case dwio::common::FileFormat::PARQUET:
-      readerOptions.setFooterSpeculativeIoSize(
-          fileConfig->parquetFooterSpeculativeIoSize(sessionProperties));
       break;
     case dwio::common::FileFormat::NIMBLE:
       readerOptions.setFooterSpeculativeIoSize(
@@ -136,6 +157,19 @@ void configureReaderOptions(
   } else {
     readerOptions.setFileFormat(fileSplit->fileFormat);
   }
+
+  const auto formatPrefix = formatConfigPrefix(fileSplit->fileFormat);
+  const auto connectorFormatPrefix = formatPrefix.empty()
+      ? std::string()
+      : std::string(fileConfig->connectorConfigPrefix()) + formatPrefix;
+  auto formatConnectorConfig =
+      filterConfigByPrefix(*fileConfig->config(), connectorFormatPrefix);
+  auto formatSessionProperties =
+      filterConfigByPrefix(*sessionProperties, connectorFormatPrefix);
+  readerOptions.setFormatSpecificOptions(
+      dwio::common::getReaderFactory(fileSplit->fileFormat)
+          ->createFormatOptions(
+              formatConnectorConfig, formatSessionProperties));
 }
 
 void configureRowReaderOptions(

--- a/velox/connectors/hive/FileConnectorUtil.cpp
+++ b/velox/connectors/hive/FileConnectorUtil.cpp
@@ -30,11 +30,13 @@ namespace facebook::velox::connector::hive {
 
 namespace {
 
-std::string formatConfigPrefix(dwio::common::FileFormat format) {
+std::string formatConfigPrefix(
+    dwio::common::FileFormat format,
+    std::string_view seperator) {
   if (format == dwio::common::FileFormat::UNKNOWN) {
     return "";
   }
-  return std::string(dwio::common::toString(format)) + ".";
+  return std::string(dwio::common::toString(format)) + std::string(seperator);
 }
 
 config::ConfigBase filterConfigByPrefix(
@@ -45,12 +47,13 @@ config::ConfigBase filterConfigByPrefix(
     return config::ConfigBase(std::move(filteredConfigs));
   }
 
-  for (const auto& [key, value] : config.rawConfigs()) {
+  config.visitConfigs([&](const auto& entry) {
+    const auto& [key, value] = entry;
     if (key.size() >= prefix.size() &&
         key.compare(0, prefix.size(), prefix) == 0) {
       filteredConfigs.emplace(key.substr(prefix.size()), value);
     }
-  }
+  });
   return config::ConfigBase(std::move(filteredConfigs));
 }
 
@@ -158,14 +161,14 @@ void configureReaderOptions(
     readerOptions.setFileFormat(fileSplit->fileFormat);
   }
 
-  const auto formatPrefix = formatConfigPrefix(fileSplit->fileFormat);
+  const auto formatPrefix = formatConfigPrefix(fileSplit->fileFormat, ".");
   const auto connectorFormatPrefix = formatPrefix.empty()
       ? std::string()
       : std::string(fileConfig->connectorConfigPrefix()) + formatPrefix;
   auto formatConnectorConfig =
       filterConfigByPrefix(*fileConfig->config(), connectorFormatPrefix);
-  auto formatSessionProperties =
-      filterConfigByPrefix(*sessionProperties, connectorFormatPrefix);
+  auto formatSessionProperties = filterConfigByPrefix(
+      *sessionProperties, formatConfigPrefix(fileSplit->fileFormat, "_"));
   readerOptions.setFormatSpecificOptions(
       dwio::common::getReaderFactory(fileSplit->fileFormat)
           ->createFormatOptions(

--- a/velox/connectors/hive/FileConnectorUtil.cpp
+++ b/velox/connectors/hive/FileConnectorUtil.cpp
@@ -140,16 +140,16 @@ void configureReaderOptions(
     readerOptions.setFileFormat(fileSplit->fileFormat);
   }
 
-  const auto formatPrefix =
-      dwio::common::formatConfigPrefix(fileSplit->fileFormat, ".");
-  const auto connectorFormatPrefix = formatPrefix.empty()
-      ? std::string()
-      : std::string(fileConfig->connectorConfigPrefix()) + formatPrefix;
-  auto formatConnectorConfig =
-      filterConfigByPrefix(*fileConfig->config(), connectorFormatPrefix);
+  auto formatConnectorConfig = filterConfigByPrefix(
+      *fileConfig->config(),
+      fmt::format(
+          "{}.{}.",
+          fileConfig->connectorName(),
+          dwio::common::FileFormatName::toName(fileSplit->fileFormat)));
   auto formatSessionProperties = filterConfigByPrefix(
       *sessionProperties,
-      dwio::common::formatConfigPrefix(fileSplit->fileFormat, "_"));
+      fmt::format(
+          "{}_", dwio::common::FileFormatName::toName(fileSplit->fileFormat)));
   readerOptions.setFormatSpecificOptions(
       dwio::common::getReaderFactory(fileSplit->fileFormat)
           ->createFormatOptions(

--- a/velox/connectors/hive/FileConnectorUtil.cpp
+++ b/velox/connectors/hive/FileConnectorUtil.cpp
@@ -30,31 +30,10 @@ namespace facebook::velox::connector::hive {
 
 namespace {
 
-std::string formatConfigPrefix(
-    dwio::common::FileFormat format,
-    std::string_view seperator) {
-  if (format == dwio::common::FileFormat::UNKNOWN) {
-    return "";
-  }
-  return std::string(dwio::common::toString(format)) + std::string(seperator);
-}
-
 config::ConfigBase filterConfigByPrefix(
     const config::ConfigBase& config,
     std::string_view prefix) {
-  std::unordered_map<std::string, std::string> filteredConfigs;
-  if (prefix.empty()) {
-    return config::ConfigBase(std::move(filteredConfigs));
-  }
-
-  config.visitConfigs([&](const auto& entry) {
-    const auto& [key, value] = entry;
-    if (key.size() >= prefix.size() &&
-        key.compare(0, prefix.size(), prefix) == 0) {
-      filteredConfigs.emplace(key.substr(prefix.size()), value);
-    }
-  });
-  return config::ConfigBase(std::move(filteredConfigs));
+  return config::ConfigBase(config.rawConfigsWithPrefix(prefix));
 }
 
 } // namespace
@@ -161,14 +140,16 @@ void configureReaderOptions(
     readerOptions.setFileFormat(fileSplit->fileFormat);
   }
 
-  const auto formatPrefix = formatConfigPrefix(fileSplit->fileFormat, ".");
+  const auto formatPrefix =
+      dwio::common::formatConfigPrefix(fileSplit->fileFormat, ".");
   const auto connectorFormatPrefix = formatPrefix.empty()
       ? std::string()
       : std::string(fileConfig->connectorConfigPrefix()) + formatPrefix;
   auto formatConnectorConfig =
       filterConfigByPrefix(*fileConfig->config(), connectorFormatPrefix);
   auto formatSessionProperties = filterConfigByPrefix(
-      *sessionProperties, formatConfigPrefix(fileSplit->fileFormat, "_"));
+      *sessionProperties,
+      dwio::common::formatConfigPrefix(fileSplit->fileFormat, "_"));
   readerOptions.setFormatSpecificOptions(
       dwio::common::getReaderFactory(fileSplit->fileFormat)
           ->createFormatOptions(

--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -68,7 +68,7 @@ const std::vector<config::ConfigProperty>& HiveConfig::registeredProperties() {
 #undef VELOX_HIVE_CONFIG_REGISTER
 
 #ifdef VELOX_ENABLE_PARQUET
-    parquet::ParquetConfig::registerProperties(properties, kLegacyPrefix);
+    parquet::ParquetConfig::registerProperties(properties);
 #endif
 
     return properties;

--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -19,6 +19,9 @@
 #include <boost/algorithm/string.hpp>
 #include "velox/common/config/Config.h"
 #include "velox/dwio/common/Options.h"
+#ifdef VELOX_ENABLE_PARQUET
+#include "velox/dwio/parquet/common/ParquetConfig.h"
+#endif
 
 namespace facebook::velox::connector::hive {
 
@@ -63,6 +66,10 @@ const std::vector<config::ConfigProperty>& HiveConfig::registeredProperties() {
     VELOX_HIVE_CONFIG_REGISTER(kMaxRowsPerIndexRequestSession);
 
 #undef VELOX_HIVE_CONFIG_REGISTER
+
+#ifdef VELOX_ENABLE_PARQUET
+    parquet::ParquetConfig::registerProperties(properties, kLegacyPrefix);
+#endif
 
     return properties;
   }();

--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -68,7 +68,10 @@ const std::vector<config::ConfigProperty>& HiveConfig::registeredProperties() {
 #undef VELOX_HIVE_CONFIG_REGISTER
 
 #ifdef VELOX_ENABLE_PARQUET
-    parquet::ParquetConfig::registerProperties(properties);
+    parquet::ParquetConfig::registerProperties(
+        properties,
+        dwio::common::formatConfigPrefix(
+            dwio::common::FileFormat::PARQUET, "_"));
 #endif
 
     return properties;

--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -18,6 +18,7 @@
 
 #include <boost/algorithm/string.hpp>
 #include "velox/common/config/Config.h"
+#include "velox/connectors/hive/HiveConnector.h"
 #include "velox/dwio/common/Options.h"
 #ifdef VELOX_ENABLE_PARQUET
 #include "velox/dwio/parquet/common/ParquetConfig.h"
@@ -41,6 +42,9 @@ stringToInsertExistingPartitionsBehavior(const std::string& strValue) {
 }
 
 } // namespace
+
+HiveConfig::HiveConfig(std::shared_ptr<const config::ConfigBase> config)
+    : FileConfig(std::move(config), HiveConnectorFactory::kHiveConnectorName) {}
 
 const std::vector<config::ConfigProperty>& HiveConfig::registeredProperties() {
   static const std::vector<config::ConfigProperty> kProperties = [] {
@@ -70,8 +74,10 @@ const std::vector<config::ConfigProperty>& HiveConfig::registeredProperties() {
 #ifdef VELOX_ENABLE_PARQUET
     parquet::ParquetConfig::registerProperties(
         properties,
-        dwio::common::formatConfigPrefix(
-            dwio::common::FileFormat::PARQUET, "_"));
+        fmt::format(
+            "{}_",
+            dwio::common::FileFormatName::toName(
+                dwio::common::FileFormat::PARQUET)));
 #endif
 
     return properties;

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -252,8 +252,12 @@ class HiveConfig : public FileConfig {
       dwio::common::FileFormat fileFormat,
       const config::ConfigBase* session) const;
 
+  static constexpr std::string_view kConnectorName = "hive";
+
   explicit HiveConfig(std::shared_ptr<const config::ConfigBase> config)
-      : FileConfig(std::move(config), "hive.") {}
+      : FileConfig(
+            std::move(config),
+            makeConnectorConfigPrefix(kConnectorName)) {}
 };
 
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -253,7 +253,7 @@ class HiveConfig : public FileConfig {
       const config::ConfigBase* session) const;
 
   explicit HiveConfig(std::shared_ptr<const config::ConfigBase> config)
-      : FileConfig(std::move(config)) {}
+      : FileConfig(std::move(config), "hive.") {}
 };
 
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -252,12 +252,7 @@ class HiveConfig : public FileConfig {
       dwio::common::FileFormat fileFormat,
       const config::ConfigBase* session) const;
 
-  static constexpr std::string_view kConnectorName = "hive";
-
-  explicit HiveConfig(std::shared_ptr<const config::ConfigBase> config)
-      : FileConfig(
-            std::move(config),
-            makeConnectorConfigPrefix(kConnectorName)) {}
+  explicit HiveConfig(std::shared_ptr<const config::ConfigBase> config);
 };
 
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/paimon/CMakeLists.txt
+++ b/velox/connectors/hive/paimon/CMakeLists.txt
@@ -29,6 +29,7 @@ velox_link_libraries(velox_hive_paimon_split velox_connector velox_hive_connecto
 
 velox_add_library(
   velox_hive_paimon_connector
+  PaimonConfig.cpp
   PaimonConnector.cpp
   PaimonDataSource.cpp
   PaimonSplitReader.cpp

--- a/velox/connectors/hive/paimon/PaimonConfig.cpp
+++ b/velox/connectors/hive/paimon/PaimonConfig.cpp
@@ -13,17 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#pragma once
 
-#include "velox/connectors/hive/FileConfig.h"
+#include "velox/connectors/hive/paimon/PaimonConfig.h"
+
+#include "velox/connectors/hive/paimon/PaimonConnector.h"
 
 namespace facebook::velox::connector::hive::paimon {
 
-/// Paimon-specific connector configuration.
-/// Extends FileConfig with Paimon-specific settings.
-class PaimonConfig : public FileConfig {
- public:
-  explicit PaimonConfig(std::shared_ptr<const config::ConfigBase> config);
-};
+PaimonConfig::PaimonConfig(std::shared_ptr<const config::ConfigBase> config)
+    : FileConfig(
+          std::move(config),
+          PaimonConnectorFactory::kPaimonConnectorName) {}
 
 } // namespace facebook::velox::connector::hive::paimon

--- a/velox/connectors/hive/paimon/PaimonConfig.h
+++ b/velox/connectors/hive/paimon/PaimonConfig.h
@@ -24,7 +24,7 @@ namespace facebook::velox::connector::hive::paimon {
 class PaimonConfig : public FileConfig {
  public:
   explicit PaimonConfig(std::shared_ptr<const config::ConfigBase> config)
-      : FileConfig(std::move(config)) {}
+      : FileConfig(std::move(config), "paimon.") {}
 };
 
 } // namespace facebook::velox::connector::hive::paimon

--- a/velox/connectors/hive/paimon/PaimonConfig.h
+++ b/velox/connectors/hive/paimon/PaimonConfig.h
@@ -23,8 +23,12 @@ namespace facebook::velox::connector::hive::paimon {
 /// Extends FileConfig with Paimon-specific settings.
 class PaimonConfig : public FileConfig {
  public:
+  static constexpr std::string_view kConnectorName = "paimon";
+
   explicit PaimonConfig(std::shared_ptr<const config::ConfigBase> config)
-      : FileConfig(std::move(config), "paimon.") {}
+      : FileConfig(
+            std::move(config),
+            makeConnectorConfigPrefix(kConnectorName)) {}
 };
 
 } // namespace facebook::velox::connector::hive::paimon

--- a/velox/connectors/hive/tests/FileConfigTest.cpp
+++ b/velox/connectors/hive/tests/FileConfigTest.cpp
@@ -157,7 +157,7 @@ TEST(FileConfigTest, overrideSession) {
 
 TEST(FileConfigTest, nullConfig) {
   VELOX_ASSERT_THROW(
-      FileConfig(nullptr, "hive."),
+      FileConfig(nullptr, "hive"),
       "Config is null for FileConfig initialization");
 }
 
@@ -165,7 +165,7 @@ TEST(FileConfigTest, invalidTimestampUnit) {
   FileConfig config(
       std::make_shared<config::ConfigBase>(
           std::unordered_map<std::string, std::string>()),
-      "hive.");
+      "hive");
   std::unordered_map<std::string, std::string> sessionOverride = {
       {FileConfig::kReadTimestampUnitSession, "5"},
   };

--- a/velox/connectors/hive/tests/FileConfigTest.cpp
+++ b/velox/connectors/hive/tests/FileConfigTest.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/connectors/hive/FileConfig.h"
 #include <gtest/gtest.h>
+#include <algorithm>
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/config/Config.h"
 
@@ -25,12 +26,12 @@ using namespace facebook::velox::connector::hive;
 TEST(FileConfigTest, defaultConfig) {
   FileConfig config(
       std::make_shared<config::ConfigBase>(
-          std::unordered_map<std::string, std::string>()));
+          std::unordered_map<std::string, std::string>()),
+      "hive.");
   const auto emptySession = std::make_unique<config::ConfigBase>(
       std::unordered_map<std::string, std::string>());
 
   EXPECT_FALSE(config.isOrcUseColumnNames(emptySession.get()));
-  EXPECT_FALSE(config.isParquetUseColumnNames(emptySession.get()));
   EXPECT_FALSE(config.isFileColumnNamesReadAsLowerCase(emptySession.get()));
   EXPECT_FALSE(config.ignoreMissingFiles(emptySession.get()));
   EXPECT_EQ(config.maxCoalescedBytes(emptySession.get()), 128 << 20);
@@ -52,8 +53,6 @@ TEST(FileConfigTest, defaultConfig) {
   EXPECT_FALSE(config.pinIndex(emptySession.get()));
   EXPECT_EQ(config.orcFooterSpeculativeIoSize(emptySession.get()), 256UL << 10);
   EXPECT_EQ(
-      config.parquetFooterSpeculativeIoSize(emptySession.get()), 256UL << 10);
-  EXPECT_EQ(
       config.nimbleFooterSpeculativeIoSize(emptySession.get()), 8UL << 20);
   EXPECT_FALSE(config.nimbleStringDecoderZeroCopy(emptySession.get()));
   EXPECT_FALSE(config.nimblePreserveDictionaryEncoding(emptySession.get()));
@@ -62,7 +61,6 @@ TEST(FileConfigTest, defaultConfig) {
 TEST(FileConfigTest, overrideConfig) {
   std::unordered_map<std::string, std::string> configFromFile = {
       {FileConfig::kOrcUseColumnNames, "true"},
-      {FileConfig::kParquetUseColumnNames, "true"},
       {FileConfig::kFileColumnNamesReadAsLowerCase, "true"},
       {FileConfig::kMaxCoalescedBytes, "100"},
       {FileConfig::kMaxCoalescedDistance, "100kB"},
@@ -78,18 +76,16 @@ TEST(FileConfigTest, overrideConfig) {
       {FileConfig::kCacheIndex, "true"},
       {FileConfig::kPinIndex, "true"},
       {FileConfig::kOrcFooterSpeculativeIoSize, std::to_string(512UL << 10)},
-      {FileConfig::kParquetFooterSpeculativeIoSize, std::to_string(1UL << 20)},
       {FileConfig::kNimbleFooterSpeculativeIoSize, std::to_string(4UL << 20)},
       {FileConfig::kNimbleStringDecoderZeroCopy, "true"},
       {FileConfig::kNimblePreserveDictionaryEncoding, "true"},
   };
   FileConfig config(
-      std::make_shared<config::ConfigBase>(std::move(configFromFile)));
+      std::make_shared<config::ConfigBase>(std::move(configFromFile)), "hive.");
   const auto emptySession = std::make_unique<config::ConfigBase>(
       std::unordered_map<std::string, std::string>());
 
   EXPECT_TRUE(config.isOrcUseColumnNames(emptySession.get()));
-  EXPECT_TRUE(config.isParquetUseColumnNames(emptySession.get()));
   EXPECT_TRUE(config.isFileColumnNamesReadAsLowerCase(emptySession.get()));
   EXPECT_EQ(config.maxCoalescedBytes(emptySession.get()), 100);
   EXPECT_EQ(config.maxCoalescedDistanceBytes(emptySession.get()), 100 << 10);
@@ -106,8 +102,6 @@ TEST(FileConfigTest, overrideConfig) {
   EXPECT_TRUE(config.pinIndex(emptySession.get()));
   EXPECT_EQ(config.orcFooterSpeculativeIoSize(emptySession.get()), 512UL << 10);
   EXPECT_EQ(
-      config.parquetFooterSpeculativeIoSize(emptySession.get()), 1UL << 20);
-  EXPECT_EQ(
       config.nimbleFooterSpeculativeIoSize(emptySession.get()), 4UL << 20);
   EXPECT_TRUE(config.nimbleStringDecoderZeroCopy(emptySession.get()));
   EXPECT_TRUE(config.nimblePreserveDictionaryEncoding(emptySession.get()));
@@ -116,10 +110,10 @@ TEST(FileConfigTest, overrideConfig) {
 TEST(FileConfigTest, overrideSession) {
   FileConfig config(
       std::make_shared<config::ConfigBase>(
-          std::unordered_map<std::string, std::string>()));
+          std::unordered_map<std::string, std::string>()),
+      "hive.");
   std::unordered_map<std::string, std::string> sessionOverride = {
       {FileConfig::kOrcUseColumnNamesSession, "true"},
-      {FileConfig::kParquetUseColumnNamesSession, "true"},
       {FileConfig::kFileColumnNamesReadAsLowerCaseSession, "true"},
       {FileConfig::kIgnoreMissingFilesSession, "true"},
       {FileConfig::kMaxCoalescedDistanceSession, "3MB"},
@@ -134,8 +128,6 @@ TEST(FileConfigTest, overrideSession) {
       {FileConfig::kPinIndexSession, "true"},
       {FileConfig::kOrcFooterSpeculativeIoSizeSession,
        std::to_string(128UL << 10)},
-      {FileConfig::kParquetFooterSpeculativeIoSizeSession,
-       std::to_string(512UL << 10)},
       {FileConfig::kNimbleFooterSpeculativeIoSizeSession,
        std::to_string(2UL << 20)},
       {FileConfig::kNimbleStringDecoderZeroCopySession, "true"},
@@ -145,7 +137,6 @@ TEST(FileConfigTest, overrideSession) {
       std::make_unique<config::ConfigBase>(std::move(sessionOverride));
 
   EXPECT_TRUE(config.isOrcUseColumnNames(session.get()));
-  EXPECT_TRUE(config.isParquetUseColumnNames(session.get()));
   EXPECT_TRUE(config.isFileColumnNamesReadAsLowerCase(session.get()));
   EXPECT_TRUE(config.ignoreMissingFiles(session.get()));
   EXPECT_EQ(config.maxCoalescedDistanceBytes(session.get()), 3 << 20);
@@ -159,61 +150,22 @@ TEST(FileConfigTest, overrideSession) {
   EXPECT_TRUE(config.cacheIndex(session.get()));
   EXPECT_TRUE(config.pinIndex(session.get()));
   EXPECT_EQ(config.orcFooterSpeculativeIoSize(session.get()), 128UL << 10);
-  EXPECT_EQ(config.parquetFooterSpeculativeIoSize(session.get()), 512UL << 10);
   EXPECT_EQ(config.nimbleFooterSpeculativeIoSize(session.get()), 2UL << 20);
   EXPECT_TRUE(config.nimbleStringDecoderZeroCopy(session.get()));
   EXPECT_TRUE(config.nimblePreserveDictionaryEncoding(session.get()));
 }
 
-TEST(FileConfigTest, parquetCanonicalSessionKeys) {
-  FileConfig config(
-      std::make_shared<config::ConfigBase>(
-          std::unordered_map<std::string, std::string>()));
-  std::unordered_map<std::string, std::string> sessionOverride = {
-      {FileConfig::kParquetUseColumnNamesSession, "true"},
-      {FileConfig::kAllowInt32NarrowingSession, "true"},
-      {FileConfig::kParquetFooterSpeculativeIoSizeSession,
-       std::to_string(512UL << 10)},
-      {FileConfig::kParquetFooterMemoryTrackingThresholdSession, "1024"},
-  };
-  const auto session =
-      std::make_unique<config::ConfigBase>(std::move(sessionOverride));
-
-  EXPECT_TRUE(config.isParquetUseColumnNames(session.get()));
-  EXPECT_TRUE(config.allowInt32Narrowing(session.get()));
-  EXPECT_EQ(config.parquetFooterSpeculativeIoSize(session.get()), 512UL << 10);
-  EXPECT_EQ(config.parquetFooterMemoryTrackingThreshold(session.get()), 1024);
-}
-
-TEST(FileConfigTest, parquetCanonicalConfigKeys) {
-  std::unordered_map<std::string, std::string> configFromFile = {
-      {FileConfig::kParquetUseColumnNames, "true"},
-      {FileConfig::kAllowInt32Narrowing, "true"},
-      {FileConfig::kParquetFooterSpeculativeIoSize, std::to_string(1UL << 20)},
-      {FileConfig::kParquetFooterMemoryTrackingThreshold, "2048"},
-  };
-  FileConfig config(
-      std::make_shared<config::ConfigBase>(std::move(configFromFile)));
-  const auto emptySession = std::make_unique<config::ConfigBase>(
-      std::unordered_map<std::string, std::string>());
-
-  EXPECT_TRUE(config.isParquetUseColumnNames(emptySession.get()));
-  EXPECT_TRUE(config.allowInt32Narrowing(emptySession.get()));
-  EXPECT_EQ(
-      config.parquetFooterSpeculativeIoSize(emptySession.get()), 1UL << 20);
-  EXPECT_EQ(
-      config.parquetFooterMemoryTrackingThreshold(emptySession.get()), 2048);
-}
-
 TEST(FileConfigTest, nullConfig) {
   VELOX_ASSERT_THROW(
-      FileConfig(nullptr), "Config is null for FileConfig initialization");
+      FileConfig(nullptr, "hive."),
+      "Config is null for FileConfig initialization");
 }
 
 TEST(FileConfigTest, invalidTimestampUnit) {
   FileConfig config(
       std::make_shared<config::ConfigBase>(
-          std::unordered_map<std::string, std::string>()));
+          std::unordered_map<std::string, std::string>()),
+      "hive.");
   std::unordered_map<std::string, std::string> sessionOverride = {
       {FileConfig::kReadTimestampUnitSession, "5"},
   };

--- a/velox/connectors/hive/tests/FileConnectorUtilTest.cpp
+++ b/velox/connectors/hive/tests/FileConnectorUtilTest.cpp
@@ -24,6 +24,7 @@
 #include "velox/connectors/hive/FileConnectorSplit.h"
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/dwio/dwrf/reader/DwrfReader.h"
+#include "velox/dwio/orc/reader/OrcReader.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/type/Filter.h"
 
@@ -31,6 +32,16 @@ namespace facebook::velox::connector {
 
 class FileConnectorUtilTest : public exec::test::HiveConnectorTestBase {
  protected:
+  void SetUp() override {
+    HiveConnectorTestBase::SetUp();
+    orc::registerOrcReaderFactory();
+  }
+
+  void TearDown() override {
+    orc::unregisterOrcReaderFactory();
+    HiveConnectorTestBase::TearDown();
+  }
+
   struct QueryCtxHolder {
     std::shared_ptr<config::ConfigBase> sessionProperties;
     std::unique_ptr<ConnectorQueryCtx> ctx;
@@ -40,7 +51,7 @@ class FileConnectorUtilTest : public exec::test::HiveConnectorTestBase {
       std::unordered_map<std::string, std::string> sessionProps = {}) {
     QueryCtxHolder holder;
     holder.sessionProperties =
-        std::make_shared<config::ConfigBase>(std::move(sessionProps), true);
+        std::make_shared<config::ConfigBase>(std::move(sessionProps));
     holder.ctx = std::make_unique<ConnectorQueryCtx>(
         pool_.get(),
         pool_.get(),
@@ -60,7 +71,7 @@ class FileConnectorUtilTest : public exec::test::HiveConnectorTestBase {
   std::shared_ptr<const hive::FileConfig> makeFileConfig(
       std::unordered_map<std::string, std::string> props = {}) {
     return std::make_shared<hive::FileConfig>(
-        std::make_shared<config::ConfigBase>(std::move(props)));
+        std::make_shared<config::ConfigBase>(std::move(props)), "hive.");
   }
 
   std::shared_ptr<const hive::FileConnectorSplit> makeSplit(
@@ -140,28 +151,6 @@ TEST_F(FileConnectorUtilTest, configureReaderOptions) {
         readerOptions);
 
     EXPECT_EQ(readerOptions.fileFormat(), dwio::common::FileFormat::ORC);
-    EXPECT_EQ(
-        readerOptions.columnMappingMode(),
-        dwio::common::ColumnMappingMode::kName);
-  }
-
-  // Test with Parquet format and useColumnNames enabled via session.
-  {
-    auto holder = makeConnectorQueryCtx(
-        {{hive::FileConfig::kParquetUseColumnNamesSession, "true"}});
-    auto split = makeSplit(dwio::common::FileFormat::PARQUET);
-    dwio::common::ReaderOptions readerOptions(pool_.get());
-    readerOptions.setDataIoStats(dataIoStats_);
-    readerOptions.setMetadataIoStats(metadataIoStats_);
-    hive::configureReaderOptions(
-        fileConfig,
-        holder.ctx.get(),
-        /*fileSchema=*/nullptr,
-        split,
-        /*tableParameters=*/{},
-        readerOptions);
-
-    EXPECT_EQ(readerOptions.fileFormat(), dwio::common::FileFormat::PARQUET);
     EXPECT_EQ(
         readerOptions.columnMappingMode(),
         dwio::common::ColumnMappingMode::kName);

--- a/velox/connectors/hive/tests/HiveConfigTest.cpp
+++ b/velox/connectors/hive/tests/HiveConfigTest.cpp
@@ -260,7 +260,7 @@ TEST(HiveConfigTest, maxTargetFileSizeConfigAndSessionKeys) {
 }
 
 #ifdef VELOX_ENABLE_PARQUET
-TEST(HiveConfigTest, registeredParquetPropertiesUseHivePrefix) {
+TEST(HiveConfigTest, registeredParquetPropertiesUseSessionPrefix) {
   const auto& properties = HiveConfig::registeredProperties();
 
   auto hasProperty = [&](const std::string& name) {
@@ -270,11 +270,12 @@ TEST(HiveConfigTest, registeredParquetPropertiesUseHivePrefix) {
         });
   };
 
-  const auto useColumnNames = std::string("hive.parquet.") +
+  const auto useColumnNames =
+      std::string(parquet::ParquetConfig::kSessionPrefix) +
       std::string(parquet::ParquetConfig::kUseColumnNamesSession);
   EXPECT_TRUE(hasProperty(useColumnNames));
   EXPECT_FALSE(hasProperty(
-      std::string("parquet.") +
+      std::string("hive.parquet.") +
       std::string(parquet::ParquetConfig::kUseColumnNamesSession)));
 }
 #endif

--- a/velox/connectors/hive/tests/HiveConfigTest.cpp
+++ b/velox/connectors/hive/tests/HiveConfigTest.cpp
@@ -270,9 +270,10 @@ TEST(HiveConfigTest, registeredParquetPropertiesUseSessionPrefix) {
         });
   };
 
-  const auto useColumnNames =
-      dwio::common::formatConfigPrefix(dwio::common::FileFormat::PARQUET, "_") +
-      std::string(parquet::ParquetConfig::kUseColumnNamesSession);
+  const auto useColumnNames = fmt::format(
+      "{}_{}",
+      dwio::common::FileFormatName::toName(dwio::common::FileFormat::PARQUET),
+      parquet::ParquetConfig::kUseColumnNamesSession);
   EXPECT_TRUE(hasProperty(useColumnNames));
   EXPECT_FALSE(hasProperty(
       std::string("hive.parquet.") +

--- a/velox/connectors/hive/tests/HiveConfigTest.cpp
+++ b/velox/connectors/hive/tests/HiveConfigTest.cpp
@@ -271,7 +271,7 @@ TEST(HiveConfigTest, registeredParquetPropertiesUseSessionPrefix) {
   };
 
   const auto useColumnNames =
-      std::string(parquet::ParquetConfig::kSessionPrefix) +
+      dwio::common::formatConfigPrefix(dwio::common::FileFormat::PARQUET, "_") +
       std::string(parquet::ParquetConfig::kUseColumnNamesSession);
   EXPECT_TRUE(hasProperty(useColumnNames));
   EXPECT_FALSE(hasProperty(

--- a/velox/connectors/hive/tests/HiveConfigTest.cpp
+++ b/velox/connectors/hive/tests/HiveConfigTest.cpp
@@ -18,6 +18,11 @@
 #include "gtest/gtest.h"
 #include "velox/common/config/Config.h"
 #include "velox/dwio/common/Options.h"
+#ifdef VELOX_ENABLE_PARQUET
+#include "velox/dwio/parquet/common/ParquetConfig.h"
+#endif
+
+#include <algorithm>
 
 using namespace facebook::velox;
 using namespace facebook::velox::connector::hive;
@@ -62,9 +67,6 @@ TEST(HiveConfigTest, defaultConfig) {
   ASSERT_EQ(
       hiveConfig.orcFooterSpeculativeIoSize(emptySession.get()), 256UL << 10);
   ASSERT_EQ(
-      hiveConfig.parquetFooterSpeculativeIoSize(emptySession.get()),
-      256UL << 10);
-  ASSERT_EQ(
       hiveConfig.nimbleFooterSpeculativeIoSize(emptySession.get()), 8UL << 20);
   ASSERT_FALSE(hiveConfig.nimbleStringDecoderZeroCopy(emptySession.get()));
   ASSERT_FALSE(hiveConfig.nimblePreserveDictionaryEncoding(emptySession.get()));
@@ -96,7 +98,6 @@ TEST(HiveConfigTest, overrideConfig) {
       {HiveConfig::kCacheMetadata, "true"},
       {HiveConfig::kCacheIndex, "true"},
       {HiveConfig::kOrcFooterSpeculativeIoSize, std::to_string(512UL << 10)},
-      {HiveConfig::kParquetFooterSpeculativeIoSize, std::to_string(1UL << 20)},
       {HiveConfig::kNimbleFooterSpeculativeIoSize, std::to_string(4UL << 20)},
       {HiveConfig::kNimbleStringDecoderZeroCopy, "true"},
       {HiveConfig::kNimblePreserveDictionaryEncoding, "true"},
@@ -138,8 +139,6 @@ TEST(HiveConfigTest, overrideConfig) {
   ASSERT_EQ(
       hiveConfig.orcFooterSpeculativeIoSize(emptySession.get()), 512UL << 10);
   ASSERT_EQ(
-      hiveConfig.parquetFooterSpeculativeIoSize(emptySession.get()), 1UL << 20);
-  ASSERT_EQ(
       hiveConfig.nimbleFooterSpeculativeIoSize(emptySession.get()), 4UL << 20);
   ASSERT_TRUE(hiveConfig.nimbleStringDecoderZeroCopy(emptySession.get()));
   ASSERT_TRUE(hiveConfig.nimblePreserveDictionaryEncoding(emptySession.get()));
@@ -168,8 +167,6 @@ TEST(HiveConfigTest, overrideSession) {
       {HiveConfig::kCacheIndexSession, "true"},
       {HiveConfig::kOrcFooterSpeculativeIoSizeSession,
        std::to_string(128UL << 10)},
-      {HiveConfig::kParquetFooterSpeculativeIoSizeSession,
-       std::to_string(512UL << 10)},
       {HiveConfig::kNimbleFooterSpeculativeIoSizeSession,
        std::to_string(2UL << 20)},
       {HiveConfig::kNimbleStringDecoderZeroCopySession, "true"},
@@ -205,8 +202,6 @@ TEST(HiveConfigTest, overrideSession) {
   ASSERT_TRUE(hiveConfig.cacheMetadata(session.get()));
   ASSERT_TRUE(hiveConfig.cacheIndex(session.get()));
   ASSERT_EQ(hiveConfig.orcFooterSpeculativeIoSize(session.get()), 128UL << 10);
-  ASSERT_EQ(
-      hiveConfig.parquetFooterSpeculativeIoSize(session.get()), 512UL << 10);
   ASSERT_EQ(hiveConfig.nimbleFooterSpeculativeIoSize(session.get()), 2UL << 20);
   ASSERT_TRUE(hiveConfig.nimbleStringDecoderZeroCopy(session.get()));
   ASSERT_TRUE(hiveConfig.nimblePreserveDictionaryEncoding(session.get()));
@@ -263,3 +258,23 @@ TEST(HiveConfigTest, maxTargetFileSizeConfigAndSessionKeys) {
           dwio::common::FileFormat::NIMBLE, session.get()),
       56UL << 20);
 }
+
+#ifdef VELOX_ENABLE_PARQUET
+TEST(HiveConfigTest, registeredParquetPropertiesUseHivePrefix) {
+  const auto& properties = HiveConfig::registeredProperties();
+
+  auto hasProperty = [&](const std::string& name) {
+    return std::any_of(
+        properties.begin(), properties.end(), [&](const auto& property) {
+          return property.name == name;
+        });
+  };
+
+  const auto useColumnNames = std::string("hive.parquet.") +
+      std::string(parquet::ParquetConfig::kUseColumnNamesSession);
+  EXPECT_TRUE(hasProperty(useColumnNames));
+  EXPECT_FALSE(hasProperty(
+      std::string("parquet.") +
+      std::string(parquet::ParquetConfig::kUseColumnNamesSession)));
+}
+#endif

--- a/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
@@ -364,6 +364,9 @@ TEST_F(HiveConnectorUtilTest, footerSpeculativeIoSizeByFormat) {
       std::unordered_map<std::string, std::string>{
           {"nimble.unused", "1"},
           {"parquet.unused", "2"},
+          {"parquet_footer_speculative_io_size", "7777"},
+          {"parquet_footer_memory_tracking_threshold", "6666"},
+          {"hive.parquet.footer_speculative_io_size", "8888"},
           {"unrelated.unused", "3"},
       }};
   auto connectorQueryCtx = std::make_unique<connector::ConnectorQueryCtx>(
@@ -481,8 +484,8 @@ TEST_F(HiveConnectorUtilTest, footerSpeculativeIoSizeByFormat) {
         readerOptions);
     auto parquetOptions = checkedPointerCast<parquet::ParquetReaderOptions>(
         readerOptions.formatSpecificOptions());
-    EXPECT_EQ(parquetOptions->footerSpeculativeIoSize, 2222);
-    EXPECT_EQ(parquetOptions->footerMemoryTrackingThreshold, 5555);
+    EXPECT_EQ(parquetOptions->footerSpeculativeIoSize, 7777);
+    EXPECT_EQ(parquetOptions->footerMemoryTrackingThreshold, 6666);
   }
 
   // Test Nimble format.

--- a/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
@@ -16,12 +16,15 @@
 
 #include "velox/connectors/hive/HiveConnectorUtil.h"
 #include <gtest/gtest.h>
+#include "velox/common/Casts.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/io/IoStatistics.h"
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/core/Expressions.h"
+#include "velox/dwio/common/ReaderFactory.h"
+#include "velox/dwio/orc/reader/OrcReader.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/expression/Expr.h"
 #include "velox/expression/ExprToSubfieldFilter.h"
@@ -32,6 +35,8 @@
 #include "velox/dwio/dwrf/writer/Writer.h"
 
 #ifdef VELOX_ENABLE_PARQUET
+#include "velox/dwio/parquet/common/ParquetConfig.h"
+#include "velox/dwio/parquet/reader/ParquetReader.h"
 #include "velox/dwio/parquet/writer/Writer.h"
 #endif
 
@@ -55,10 +60,59 @@ const std::vector<UnsupportedFilterType> kUnsupportedFilterTypes = {
     {ROW({{"a", BIGINT()}}),
      variant::row({variant::create<TypeKind::BIGINT>(1)})},
 };
+
+class DummyNimbleReaderFactory : public dwio::common::ReaderFactory {
+ public:
+  explicit DummyNimbleReaderFactory(FileFormat format)
+      : ReaderFactory(format) {}
+
+  std::unique_ptr<dwio::common::Reader> createReader(
+      std::unique_ptr<dwio::common::BufferedInput>,
+      const dwio::common::ReaderOptions&) override {
+    VELOX_NYI("Test reader factory could not create readers.");
+  }
+
+  std::shared_ptr<dwio::common::FormatSpecificOptions> createFormatOptions(
+      const config::ConfigBase& connectorConfig,
+      const config::ConfigBase& session) const override {
+    assertUnqualifiedFormatConfigs(connectorConfig);
+    assertUnqualifiedFormatConfigs(session);
+    return nullptr;
+  }
+
+ private:
+  static void assertUnqualifiedFormatConfigs(const config::ConfigBase& config) {
+    for (const auto& [key, _] : config.rawConfigs()) {
+      VELOX_CHECK(
+          key.find('.') == std::string::npos,
+          "Unexpected qualified format config key: {}",
+          key);
+    }
+  }
+};
 } // namespace
 
 class HiveConnectorUtilTest : public exec::test::HiveConnectorTestBase {
  protected:
+  void SetUp() override {
+    HiveConnectorTestBase::SetUp();
+    orc::registerOrcReaderFactory();
+#ifdef VELOX_ENABLE_PARQUET
+    parquet::registerParquetReaderFactory();
+#endif
+    dwio::common::registerReaderFactory(
+        std::make_shared<DummyNimbleReaderFactory>(FileFormat::NIMBLE));
+  }
+
+  void TearDown() override {
+    dwio::common::unregisterReaderFactory(FileFormat::NIMBLE);
+#ifdef VELOX_ENABLE_PARQUET
+    parquet::unregisterParquetReaderFactory();
+#endif
+    orc::unregisterOrcReaderFactory();
+    HiveConnectorTestBase::TearDown();
+  }
+
   static bool compareSerDeOptions(
       const SerDeOptions& l,
       const SerDeOptions& r) {
@@ -157,11 +211,6 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
     auto expectedMappingMode = dwio::common::ColumnMappingMode::kPosition;
     if (fileFormat == FileFormat::DWRF || fileFormat == FileFormat::ORC) {
       expectedMappingMode = hiveConfig->isOrcUseColumnNames(&sessionProperties)
-          ? dwio::common::ColumnMappingMode::kName
-          : dwio::common::ColumnMappingMode::kPosition;
-    } else if (fileFormat == FileFormat::PARQUET) {
-      expectedMappingMode =
-          hiveConfig->isParquetUseColumnNames(&sessionProperties)
           ? dwio::common::ColumnMappingMode::kName
           : dwio::common::ColumnMappingMode::kPosition;
     }
@@ -312,7 +361,11 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
 
 TEST_F(HiveConnectorUtilTest, footerSpeculativeIoSizeByFormat) {
   config::ConfigBase sessionProperties{
-      std::unordered_map<std::string, std::string>{}};
+      std::unordered_map<std::string, std::string>{
+          {"nimble.unused", "1"},
+          {"parquet.unused", "2"},
+          {"unrelated.unused", "3"},
+      }};
   auto connectorQueryCtx = std::make_unique<connector::ConnectorQueryCtx>(
       pool_.get(),
       pool_.get(),
@@ -329,8 +382,14 @@ TEST_F(HiveConnectorUtilTest, footerSpeculativeIoSizeByFormat) {
 
   std::unordered_map<std::string, std::string> customHiveConfigProps;
   customHiveConfigProps[hive::HiveConfig::kOrcFooterSpeculativeIoSize] = "1111";
-  customHiveConfigProps[hive::HiveConfig::kParquetFooterSpeculativeIoSize] =
-      "2222";
+#ifdef VELOX_ENABLE_PARQUET
+  customHiveConfigProps["parquet.footer-speculative-io-size"] = "9999";
+  customHiveConfigProps["parquet.footer-memory-tracking-threshold"] = "9999";
+  customHiveConfigProps["hive.parquet.footer-speculative-io-size"] = "2222";
+  customHiveConfigProps["hive.parquet.footer-memory-tracking-threshold"] =
+      "5555";
+  customHiveConfigProps["iceberg.parquet.footer-speculative-io-size"] = "4444";
+#endif
   customHiveConfigProps[hive::HiveConfig::kNimbleFooterSpeculativeIoSize] =
       "3333";
   auto hiveConfig = std::make_shared<hive::HiveConfig>(
@@ -420,10 +479,10 @@ TEST_F(HiveConnectorUtilTest, footerSpeculativeIoSizeByFormat) {
         split,
         split->serdeParameters,
         readerOptions);
-    EXPECT_EQ(
-        readerOptions.footerSpeculativeIoSize(),
-        hiveConfig->parquetFooterSpeculativeIoSize(&sessionProperties));
-    EXPECT_EQ(readerOptions.footerSpeculativeIoSize(), 2222);
+    auto parquetOptions = checkedPointerCast<parquet::ParquetReaderOptions>(
+        readerOptions.formatSpecificOptions());
+    EXPECT_EQ(parquetOptions->footerSpeculativeIoSize, 2222);
+    EXPECT_EQ(parquetOptions->footerMemoryTrackingThreshold, 5555);
   }
 
   // Test Nimble format.

--- a/velox/dwio/common/Options.cpp
+++ b/velox/dwio/common/Options.cpp
@@ -63,6 +63,13 @@ FileFormat toFileFormat(std::string_view s) {
   return FileFormatName::tryToFileFormat(s).value_or(FileFormat::UNKNOWN);
 }
 
+std::string formatConfigPrefix(FileFormat fmt, std::string_view separator) {
+  if (fmt == FileFormat::UNKNOWN) {
+    return "";
+  }
+  return std::string(toString(fmt)) + std::string(separator);
+}
+
 ColumnReaderOptions makeColumnReaderOptions(const ReaderOptions& options) {
   ColumnReaderOptions columnReaderOptions;
   columnReaderOptions.columnMappingMode_ = options.columnMappingMode();

--- a/velox/dwio/common/Options.cpp
+++ b/velox/dwio/common/Options.cpp
@@ -63,13 +63,6 @@ FileFormat toFileFormat(std::string_view s) {
   return FileFormatName::tryToFileFormat(s).value_or(FileFormat::UNKNOWN);
 }
 
-std::string formatConfigPrefix(FileFormat fmt, std::string_view separator) {
-  if (fmt == FileFormat::UNKNOWN) {
-    return "";
-  }
-  return std::string(toString(fmt)) + std::string(separator);
-}
-
 ColumnReaderOptions makeColumnReaderOptions(const ReaderOptions& options) {
   ColumnReaderOptions columnReaderOptions;
   columnReaderOptions.columnMappingMode_ = options.columnMappingMode();

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -76,6 +76,11 @@ VELOX_DECLARE_ENUM_NAME(FileFormat);
 
 FileFormat toFileFormat(std::string_view s);
 
+/// Returns a format-scoped config prefix using the file format's canonical
+/// string token. For example, PARQUET with "." returns "parquet.", while
+/// PARQUET with "_" returns "parquet_".
+std::string formatConfigPrefix(FileFormat fmt, std::string_view separator);
+
 /// Controls how a reader maps the requested table schema to physical file
 /// columns.
 enum class ColumnMappingMode {

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -202,6 +202,8 @@ struct RowNumberColumnInfo {
   std::string name;
 };
 
+/// Carries format-owned reader and writer options through the common reader
+/// interfaces.
 class FormatSpecificOptions {
  public:
   virtual ~FormatSpecificOptions() = default;
@@ -647,8 +649,6 @@ class ReaderOptions : public io::ReaderOptions {
       1024 * 1024; // 1MB
   static constexpr uint64_t kDefaultFilePreloadThreshold =
       1024 * 1024 * 8; // 8MB
-  static constexpr uint64_t kDefaultParquetFooterMemoryTrackingThreshold =
-      std::numeric_limits<uint64_t>::max(); // Disabled by default.
 
   explicit ReaderOptions(velox::memory::MemoryPool* pool)
       : io::ReaderOptions(pool) {}
@@ -699,11 +699,6 @@ class ReaderOptions : public io::ReaderOptions {
     footerSpeculativeIoSize_ = size;
     return *this;
   }
-  ReaderOptions& setParquetFooterMemoryTrackingThreshold(uint64_t size) {
-    parquetFooterMemoryTrackingThreshold_ = size;
-    return *this;
-  }
-
   ReaderOptions& setFilePreloadThreshold(uint64_t threshold) {
     filePreloadThreshold_ = threshold;
     return *this;
@@ -744,6 +739,15 @@ class ReaderOptions : public io::ReaderOptions {
     return properties_;
   }
 
+  const std::shared_ptr<FormatSpecificOptions>& formatSpecificOptions() const {
+    return formatSpecificOptions_;
+  }
+
+  void setFormatSpecificOptions(
+      std::shared_ptr<FormatSpecificOptions> options) {
+    formatSpecificOptions_ = std::move(options);
+  }
+
   /// Gets the file schema.
   const std::shared_ptr<const velox::RowType>& fileSchema() const {
     return fileSchema_;
@@ -763,10 +767,6 @@ class ReaderOptions : public io::ReaderOptions {
 
   uint64_t footerSpeculativeIoSize() const {
     return footerSpeculativeIoSize_;
-  }
-
-  uint64_t parquetFooterMemoryTrackingThreshold() const {
-    return parquetFooterMemoryTrackingThreshold_;
   }
 
   uint64_t filePreloadThreshold() const {
@@ -919,20 +919,6 @@ class ReaderOptions : public io::ReaderOptions {
     allowEmptyFile_ = value;
   }
 
-  /// Allows reading INT32 physical type columns as a narrower integer type
-  /// (e.g., INT32 -> TINYINT/SMALLINT). Some Parquet writers store INT_8 and
-  /// INT_16 values as plain INT32 without a converted type annotation. When
-  /// enabled, the value is silently truncated on overflow. When disabled
-  /// (default), only annotated type-matching reads are allowed (e.g.,
-  /// INT_8 -> TINYINT, INT_16 -> SMALLINT, INT_32 -> INTEGER).
-  bool allowInt32Narrowing() const {
-    return allowInt32Narrowing_;
-  }
-
-  void setAllowInt32Narrowing(bool value) {
-    allowInt32Narrowing_ = value;
-  }
-
   /// File handle providing the cache key (uuid) for metadata caching in
   /// Nimble's TabletReader. The pointer is only dereferenced during reader
   /// construction to extract the uuid; it does not need to outlive the
@@ -964,6 +950,7 @@ class ReaderOptions : public io::ReaderOptions {
   RowTypePtr fileSchema_;
   SerDeOptions serDeOptions_;
   std::unordered_map<std::string, std::string> properties_{};
+  std::shared_ptr<FormatSpecificOptions> formatSpecificOptions_;
   std::shared_ptr<encryption::DecrypterFactory> decrypterFactory_;
   uint64_t footerSpeculativeIoSize_{kDefaultFooterSpeculativeIoSize};
   uint64_t filePreloadThreshold_{kDefaultFilePreloadThreshold};
@@ -983,11 +970,8 @@ class ReaderOptions : public io::ReaderOptions {
   bool preloadIndex_{false};
   bool loadChunkIndex_{true};
   bool allowEmptyFile_{false};
-  bool allowInt32Narrowing_{false};
   const FileHandle* fileHandle_{nullptr};
   cache::AsyncDataCache* cache_{nullptr};
-  uint64_t parquetFooterMemoryTrackingThreshold_{
-      kDefaultParquetFooterMemoryTrackingThreshold};
 };
 
 struct WriterOptions {

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -76,11 +76,6 @@ VELOX_DECLARE_ENUM_NAME(FileFormat);
 
 FileFormat toFileFormat(std::string_view s);
 
-/// Returns a format-scoped config prefix using the file format's canonical
-/// string token. For example, PARQUET with "." returns "parquet.", while
-/// PARQUET with "_" returns "parquet_".
-std::string formatConfigPrefix(FileFormat fmt, std::string_view separator);
-
 /// Controls how a reader maps the requested table schema to physical file
 /// columns.
 enum class ColumnMappingMode {

--- a/velox/dwio/common/ReaderFactory.h
+++ b/velox/dwio/common/ReaderFactory.h
@@ -18,6 +18,7 @@
 
 #include <memory>
 
+#include "velox/common/config/Config.h"
 #include "velox/dwio/common/BufferedInput.h"
 #include "velox/dwio/common/Options.h"
 #include "velox/dwio/common/Reader.h"
@@ -59,6 +60,12 @@ class ReaderFactory {
   virtual std::unique_ptr<Reader> createReader(
       std::unique_ptr<BufferedInput>,
       const ReaderOptions& options) = 0;
+
+  virtual std::shared_ptr<FormatSpecificOptions> createFormatOptions(
+      const config::ConfigBase& /*connectorConfig*/,
+      const config::ConfigBase& /*session*/) const {
+    return nullptr;
+  }
 
  private:
   const FileFormat format_;

--- a/velox/dwio/common/tests/OptionsTests.cpp
+++ b/velox/dwio/common/tests/OptionsTests.cpp
@@ -32,6 +32,12 @@ TEST(OptionsTests, fluxFileFormatRoundTrip) {
   ASSERT_EQ("flux", FileFormatName::toName(FileFormat::FLUX));
 }
 
+TEST(OptionsTests, formatConfigPrefix) {
+  EXPECT_EQ("parquet.", formatConfigPrefix(FileFormat::PARQUET, "."));
+  EXPECT_EQ("parquet_", formatConfigPrefix(FileFormat::PARQUET, "_"));
+  EXPECT_EQ("", formatConfigPrefix(FileFormat::UNKNOWN, "."));
+}
+
 TEST(OptionsTests, setRowNumberColumnInfoTest) {
   RowReaderOptions rowReaderOptions;
   RowNumberColumnInfo rowNumberColumnInfo;

--- a/velox/dwio/common/tests/OptionsTests.cpp
+++ b/velox/dwio/common/tests/OptionsTests.cpp
@@ -32,12 +32,6 @@ TEST(OptionsTests, fluxFileFormatRoundTrip) {
   ASSERT_EQ("flux", FileFormatName::toName(FileFormat::FLUX));
 }
 
-TEST(OptionsTests, formatConfigPrefix) {
-  EXPECT_EQ("parquet.", formatConfigPrefix(FileFormat::PARQUET, "."));
-  EXPECT_EQ("parquet_", formatConfigPrefix(FileFormat::PARQUET, "_"));
-  EXPECT_EQ("", formatConfigPrefix(FileFormat::UNKNOWN, "."));
-}
-
 TEST(OptionsTests, setRowNumberColumnInfoTest) {
   RowReaderOptions rowReaderOptions;
   RowNumberColumnInfo rowNumberColumnInfo;

--- a/velox/dwio/parquet/common/CMakeLists.txt
+++ b/velox/dwio/parquet/common/CMakeLists.txt
@@ -25,6 +25,7 @@ velox_add_library(
   LevelComparison.h
   LevelConversion.h
   LevelConversionUtil.h
+  ParquetConfig.h
   RleEncodingInternal.h
   XxHasher.h
 )

--- a/velox/dwio/parquet/common/ParquetConfig.h
+++ b/velox/dwio/parquet/common/ParquetConfig.h
@@ -59,6 +59,8 @@ namespace facebook::velox::parquet {
 class ParquetConfig {
  public:
   static constexpr std::string_view kPrefix = "parquet.";
+  static constexpr std::string_view kSessionPrefix = "parquet_";
+
   VELOX_PARQUET_CONFIG(
       kUseColumnNamesSession,
       kUseColumnNames,
@@ -105,26 +107,19 @@ class ParquetConfig {
 
   /// Registers Parquet reader session properties with a config provider.
   static void registerProperties(
-      std::vector<config::ConfigProperty>& properties,
-      std::string_view connectorPrefix) {
-    registerProperty<kUseColumnNamesSessionProperty>(
-        properties, connectorPrefix);
-    registerProperty<kFooterSpeculativeIoSizeSessionProperty>(
-        properties, connectorPrefix);
-    registerProperty<kAllowInt32NarrowingSessionProperty>(
-        properties, connectorPrefix);
-    registerProperty<kFooterMemoryTrackingThresholdSessionProperty>(
-        properties, connectorPrefix);
+      std::vector<config::ConfigProperty>& properties) {
+    registerProperty<kUseColumnNamesSessionProperty>(properties);
+    registerProperty<kFooterSpeculativeIoSizeSessionProperty>(properties);
+    registerProperty<kAllowInt32NarrowingSessionProperty>(properties);
+    registerProperty<kFooterMemoryTrackingThresholdSessionProperty>(properties);
   }
 
  private:
   template <typename Property>
   static void registerProperty(
-      std::vector<config::ConfigProperty>& properties,
-      std::string_view connectorPrefix) {
+      std::vector<config::ConfigProperty>& properties) {
     properties.push_back({
-        std::string(connectorPrefix) + std::string(kPrefix) +
-            std::string(Property::key),
+        std::string(kSessionPrefix) + std::string(Property::key),
         config::detail::configPropertyTypeOf<typename Property::type>(),
         config::detail::configPropertyDefaultToString<typename Property::type>(
             Property::defaultValue),

--- a/velox/dwio/parquet/common/ParquetConfig.h
+++ b/velox/dwio/parquet/common/ParquetConfig.h
@@ -58,9 +58,6 @@ namespace facebook::velox::parquet {
 /// Defines Parquet reader config and session properties.
 class ParquetConfig {
  public:
-  static constexpr std::string_view kPrefix = "parquet.";
-  static constexpr std::string_view kSessionPrefix = "parquet_";
-
   VELOX_PARQUET_CONFIG(
       kUseColumnNamesSession,
       kUseColumnNames,
@@ -107,19 +104,24 @@ class ParquetConfig {
 
   /// Registers Parquet reader session properties with a config provider.
   static void registerProperties(
-      std::vector<config::ConfigProperty>& properties) {
-    registerProperty<kUseColumnNamesSessionProperty>(properties);
-    registerProperty<kFooterSpeculativeIoSizeSessionProperty>(properties);
-    registerProperty<kAllowInt32NarrowingSessionProperty>(properties);
-    registerProperty<kFooterMemoryTrackingThresholdSessionProperty>(properties);
+      std::vector<config::ConfigProperty>& properties,
+      std::string_view sessionPrefix) {
+    registerProperty<kUseColumnNamesSessionProperty>(properties, sessionPrefix);
+    registerProperty<kFooterSpeculativeIoSizeSessionProperty>(
+        properties, sessionPrefix);
+    registerProperty<kAllowInt32NarrowingSessionProperty>(
+        properties, sessionPrefix);
+    registerProperty<kFooterMemoryTrackingThresholdSessionProperty>(
+        properties, sessionPrefix);
   }
 
  private:
   template <typename Property>
   static void registerProperty(
-      std::vector<config::ConfigProperty>& properties) {
+      std::vector<config::ConfigProperty>& properties,
+      std::string_view sessionPrefix) {
     properties.push_back({
-        std::string(kSessionPrefix) + std::string(Property::key),
+        std::string(sessionPrefix) + std::string(Property::key),
         config::detail::configPropertyTypeOf<typename Property::type>(),
         config::detail::configPropertyDefaultToString<typename Property::type>(
             Property::defaultValue),

--- a/velox/dwio/parquet/common/ParquetConfig.h
+++ b/velox/dwio/parquet/common/ParquetConfig.h
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "velox/common/config/Config.h"
+#include "velox/common/config/ConfigProperty.h"
+
+namespace facebook::velox::parquet {
+
+#define VELOX_PARQUET_CONFIG_PROPERTY(               \
+    constName, keyStr, CppType, defaultVal, desc)    \
+  struct constName##Property {                       \
+    using type = CppType;                            \
+    static constexpr std::string_view key = keyStr;  \
+    static constexpr auto defaultValue = defaultVal; \
+    static constexpr const char* description = desc; \
+  };                                                 \
+  static constexpr std::string_view constName = keyStr;
+
+#define VELOX_PARQUET_CONFIG(                                              \
+    constName,                                                             \
+    configConstName,                                                       \
+    accessorName,                                                          \
+    key,                                                                   \
+    configKey,                                                             \
+    CppType,                                                               \
+    defaultVal,                                                            \
+    desc)                                                                  \
+  VELOX_PARQUET_CONFIG_PROPERTY(constName, key, CppType, defaultVal, desc) \
+  static constexpr std::string_view configConstName = configKey;           \
+  static CppType accessorName(                                             \
+      const config::ConfigBase& connectorConfig,                           \
+      const config::ConfigBase& session) {                                 \
+    return session.getWithFallback<CppType>(constName, connectorConfig)    \
+        .value_or(constName##Property::defaultValue);                      \
+  }
+
+/// Defines Parquet reader config and session properties.
+class ParquetConfig {
+ public:
+  static constexpr std::string_view kPrefix = "parquet.";
+  VELOX_PARQUET_CONFIG(
+      kUseColumnNamesSession,
+      kUseColumnNames,
+      useColumnNames,
+      "use_column_names",
+      "use-column-names",
+      bool,
+      false,
+      "Map Parquet table field names to file field names using names, not indices.")
+
+  VELOX_PARQUET_CONFIG(
+      kFooterSpeculativeIoSizeSession,
+      kFooterSpeculativeIoSize,
+      footerSpeculativeIoSize,
+      "footer_speculative_io_size",
+      "footer-speculative-io-size",
+      uint64_t,
+      256UL << 10,
+      "Speculative tail-read size in bytes for Parquet files.")
+
+  VELOX_PARQUET_CONFIG(
+      kAllowInt32NarrowingSession,
+      kAllowInt32Narrowing,
+      allowInt32Narrowing,
+      "allow_int32_narrowing",
+      "allow-int32-narrowing",
+      bool,
+      false,
+      "Allow reading INT32 Parquet columns as a narrower integer type.")
+
+  static constexpr uint64_t kDefaultFooterMemoryTrackingThreshold =
+      std::numeric_limits<uint64_t>::max();
+  VELOX_PARQUET_CONFIG(
+      kFooterMemoryTrackingThresholdSession,
+      kFooterMemoryTrackingThreshold,
+      footerMemoryTrackingThreshold,
+      "footer_memory_tracking_threshold",
+      "footer-memory-tracking-threshold",
+      uint64_t,
+      kDefaultFooterMemoryTrackingThreshold,
+      "Serialized footer size in bytes beyond which the Parquet reader "
+      "estimates and reports the deserialized footer's heap footprint to "
+      "the memory pool. Defaults to disabled (max uint64).")
+
+  /// Registers Parquet reader session properties with a config provider.
+  static void registerProperties(
+      std::vector<config::ConfigProperty>& properties,
+      std::string_view connectorPrefix) {
+    registerProperty<kUseColumnNamesSessionProperty>(
+        properties, connectorPrefix);
+    registerProperty<kFooterSpeculativeIoSizeSessionProperty>(
+        properties, connectorPrefix);
+    registerProperty<kAllowInt32NarrowingSessionProperty>(
+        properties, connectorPrefix);
+    registerProperty<kFooterMemoryTrackingThresholdSessionProperty>(
+        properties, connectorPrefix);
+  }
+
+ private:
+  template <typename Property>
+  static void registerProperty(
+      std::vector<config::ConfigProperty>& properties,
+      std::string_view connectorPrefix) {
+    properties.push_back({
+        std::string(connectorPrefix) + std::string(kPrefix) +
+            std::string(Property::key),
+        config::detail::configPropertyTypeOf<typename Property::type>(),
+        config::detail::configPropertyDefaultToString<typename Property::type>(
+            Property::defaultValue),
+        Property::description,
+    });
+  }
+};
+
+#undef VELOX_PARQUET_CONFIG
+#undef VELOX_PARQUET_CONFIG_PROPERTY
+
+} // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -18,6 +18,7 @@
 
 #include <thrift/lib/cpp2/FieldRef.h>
 
+#include "velox/common/Casts.h"
 #include "velox/dwio/common/StatisticsBuilder.h"
 #include "velox/dwio/parquet/reader/ParquetColumnReader.h"
 #include "velox/dwio/parquet/reader/ParquetStatsContext.h"
@@ -134,7 +135,38 @@ bool isInt64Compatible(const TypePtr& type) {
   return type->kind() == TypeKind::BIGINT;
 }
 
+ParquetReaderOptions getParquetReaderOptions(
+    const dwio::common::ReaderOptions& options) {
+  if (options.formatSpecificOptions()) {
+    return *checkedPointerCast<ParquetReaderOptions>(
+        options.formatSpecificOptions());
+  }
+
+  ParquetReaderOptions parquetOptions;
+  parquetOptions.footerSpeculativeIoSize = options.footerSpeculativeIoSize();
+  parquetOptions.columnMappingMode = options.columnMappingMode();
+  return parquetOptions;
+}
+
 } // namespace
+
+std::shared_ptr<dwio::common::FormatSpecificOptions>
+ParquetReaderFactory::createFormatOptions(
+    const config::ConfigBase& connectorConfig,
+    const config::ConfigBase& session) const {
+  auto options = std::make_shared<ParquetReaderOptions>();
+  options->footerSpeculativeIoSize =
+      ParquetConfig::footerSpeculativeIoSize(connectorConfig, session);
+  options->allowInt32Narrowing =
+      ParquetConfig::allowInt32Narrowing(connectorConfig, session);
+  options->footerMemoryTrackingThreshold =
+      ParquetConfig::footerMemoryTrackingThreshold(connectorConfig, session);
+  const auto useColumnNames =
+      ParquetConfig::useColumnNames(connectorConfig, session);
+  options->columnMappingMode =
+      useColumnNames ? ColumnMappingMode::kName : ColumnMappingMode::kPosition;
+  return options;
+}
 
 /// Metadata and options for reading Parquet.
 class ReaderBase {
@@ -256,10 +288,12 @@ class ReaderBase {
       bool fileColumnNamesReadAsLowerCase);
 
   memory::MemoryPool& pool_;
-  const uint64_t footerSpeculativeIoSize_;
   const uint64_t filePreloadThreshold_;
   // Copy of options. Must be owned by 'this'.
   const dwio::common::ReaderOptions options_;
+  // Copy of Parquet-specific options, or defaults for direct ParquetReader
+  // callers that do not go through ParquetReaderFactory.
+  const ParquetReaderOptions parquetReaderOptions_;
   std::shared_ptr<velox::dwio::common::BufferedInput> input_;
   uint64_t fileLength_;
   std::unique_ptr<thrift::FileMetaData> fileMetaData_;
@@ -294,9 +328,9 @@ ReaderBase::ReaderBase(
     std::unique_ptr<dwio::common::BufferedInput> input,
     const dwio::common::ReaderOptions& options)
     : pool_{options.memoryPool()},
-      footerSpeculativeIoSize_{options.footerSpeculativeIoSize()},
       filePreloadThreshold_{options.filePreloadThreshold()},
       options_{options},
+      parquetReaderOptions_{getParquetReaderOptions(options)},
       input_{std::move(input)},
       fileLength_{input_->getReadFile()->size()} {
   VELOX_CHECK_GT(fileLength_, 0, "Parquet file is empty");
@@ -331,9 +365,11 @@ void ReaderBase::releaseThriftBytes(size_t bytes) {
 }
 
 void ReaderBase::loadFileMetaData() {
-  bool preloadFile =
-      fileLength_ <= std::max(filePreloadThreshold_, footerSpeculativeIoSize_);
-  uint64_t readSize = preloadFile ? fileLength_ : footerSpeculativeIoSize_;
+  bool preloadFile = fileLength_ <=
+      std::max(filePreloadThreshold_,
+               parquetReaderOptions_.footerSpeculativeIoSize);
+  uint64_t readSize =
+      preloadFile ? fileLength_ : parquetReaderOptions_.footerSpeculativeIoSize;
 
   std::unique_ptr<dwio::common::SeekableInputStream> stream;
   if (preloadFile) {
@@ -377,7 +413,7 @@ void ReaderBase::loadFileMetaData() {
       std::string_view(
           reinterpret_cast<char*>(copy.data() + footerOffsetInBuffer),
           footerLength));
-  if (footerLength > options().parquetFooterMemoryTrackingThreshold()) {
+  if (footerLength > parquetReaderOptions_.footerMemoryTrackingThreshold) {
     thriftSize_ = fileMetaData().estimateFileMetadataSize();
   }
 }
@@ -386,7 +422,8 @@ void ReaderBase::initializeSchema() {
   if (fileMetaData_->encryption_algorithm()) {
     VELOX_UNSUPPORTED("Encrypted Parquet files are not supported");
   }
-  if (options_.columnMappingMode() == ColumnMappingMode::kParquetFieldId) {
+  if (parquetReaderOptions_.columnMappingMode ==
+      ColumnMappingMode::kParquetFieldId) {
     VELOX_NYI("Parquet field ID column mapping is not implemented yet.");
   }
 
@@ -478,7 +515,7 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
     name = functions::stringImpl::utf8StrToLowerCopy(name);
   }
 
-  if (options_.columnMappingMode() != ColumnMappingMode::kName &&
+  if (parquetReaderOptions_.columnMappingMode != ColumnMappingMode::kName &&
       options_.fileSchema()) {
     if (isParquetReservedKeyword(name, parentSchemaIdx, curSchemaIdx)) {
       columnNames.push_back(name);
@@ -525,7 +562,8 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
         }
 
         if (requestedRowType) {
-          if (options_.columnMappingMode() == ColumnMappingMode::kName) {
+          if (parquetReaderOptions_.columnMappingMode ==
+              ColumnMappingMode::kName) {
             auto fileTypeIdx = requestedRowType->getChildIdxIfExists(childName);
             if (fileTypeIdx.has_value()) {
               childRequestedType = requestedRowType->childAt(*fileTypeIdx);
@@ -907,7 +945,7 @@ TypePtr ReaderBase::convertType(
       "Converted type {} is not allowed for requested type {} for file column '{}'";
   const bool isRepeated = schemaElement.repetition_type() &&
       *schemaElement.repetition_type() == thrift::FieldRepetitionType::REPEATED;
-  const bool allowNarrowing = options_.allowInt32Narrowing();
+  const bool allowNarrowing = parquetReaderOptions_.allowInt32Narrowing;
   if (schemaElement.converted_type()) {
     switch (*schemaElement.converted_type()) {
       case thrift::ConvertedType::INT_8:

--- a/velox/dwio/parquet/reader/ParquetReader.h
+++ b/velox/dwio/parquet/reader/ParquetReader.h
@@ -16,8 +16,12 @@
 
 #pragma once
 
+#include <cstdint>
+
+#include "velox/dwio/common/Options.h"
 #include "velox/dwio/common/Reader.h"
 #include "velox/dwio/common/ReaderFactory.h"
+#include "velox/dwio/parquet/common/ParquetConfig.h"
 #include "velox/dwio/parquet/reader/Metadata.h"
 
 namespace facebook::velox::dwio::common {
@@ -34,6 +38,26 @@ enum class ParquetMetricsType { HEADER, FILE_METADATA, FILE, BLOCK, TEST };
 class StructColumnReader;
 
 class ReaderBase;
+
+/// Carries Parquet-specific options through the common reader interface.
+class ParquetReaderOptions : public dwio::common::FormatSpecificOptions {
+ public:
+  // Speculative tail-read size in bytes for reading Parquet footers.
+  uint64_t footerSpeculativeIoSize{
+      ParquetConfig::kFooterSpeculativeIoSizeSessionProperty::defaultValue};
+
+  // Allows reading INT32 physical columns as narrower integer types.
+  bool allowInt32Narrowing{
+      ParquetConfig::kAllowInt32NarrowingSessionProperty::defaultValue};
+
+  // Serialized footer size threshold above which heap tracking is enabled.
+  uint64_t footerMemoryTrackingThreshold{
+      ParquetConfig::kDefaultFooterMemoryTrackingThreshold};
+
+  // Maps table fields to Parquet file fields by position or name.
+  dwio::common::ColumnMappingMode columnMappingMode{
+      dwio::common::ColumnMappingMode::kPosition};
+};
 
 /// Implements the RowReader interface for Parquet.
 class ParquetRowReader : public dwio::common::RowReader {
@@ -116,6 +140,10 @@ class ParquetReaderFactory : public dwio::common::ReaderFactory {
       const dwio::common::ReaderOptions& options) override {
     return std::make_unique<ParquetReader>(std::move(input), options);
   }
+
+  std::shared_ptr<dwio::common::FormatSpecificOptions> createFormatOptions(
+      const config::ConfigBase& connectorConfig,
+      const config::ConfigBase& session) const override;
 };
 
 void registerParquetReaderFactory();

--- a/velox/dwio/parquet/reader/ParquetReader.h
+++ b/velox/dwio/parquet/reader/ParquetReader.h
@@ -42,19 +42,19 @@ class ReaderBase;
 /// Carries Parquet-specific options through the common reader interface.
 class ParquetReaderOptions : public dwio::common::FormatSpecificOptions {
  public:
-  // Speculative tail-read size in bytes for reading Parquet footers.
+  /// Speculative tail-read size in bytes for reading Parquet footers.
   uint64_t footerSpeculativeIoSize{
       ParquetConfig::kFooterSpeculativeIoSizeSessionProperty::defaultValue};
 
-  // Allows reading INT32 physical columns as narrower integer types.
+  /// Allows reading INT32 physical columns as narrower integer types.
   bool allowInt32Narrowing{
       ParquetConfig::kAllowInt32NarrowingSessionProperty::defaultValue};
 
-  // Serialized footer size threshold above which heap tracking is enabled.
+  /// Serialized footer size threshold above which heap tracking is enabled.
   uint64_t footerMemoryTrackingThreshold{
       ParquetConfig::kDefaultFooterMemoryTrackingThreshold};
 
-  // Maps table fields to Parquet file fields by position or name.
+  /// Maps table fields to Parquet file fields by position or name.
   dwio::common::ColumnMappingMode columnMappingMode{
       dwio::common::ColumnMappingMode::kPosition};
 };

--- a/velox/dwio/parquet/tests/ParquetTestBase.h
+++ b/velox/dwio/parquet/tests/ParquetTestBase.h
@@ -138,9 +138,8 @@ class ParquetTestBase : public testing::Test,
   }
 
   // Creates a ReaderOptions pre-populated with the test's shared IoStatistics
-  // and the leaf memory pool. Callers needing extra settings (e.g.
-  // setFileSchema, setAllowInt32Narrowing) should obtain a copy via this
-  // method and then apply their overrides.
+  // and the leaf memory pool. Callers needing extra settings should obtain a
+  // copy via this method and then apply their overrides.
   dwio::common::ReaderOptions makeDefaultReaderOptions() const;
 
   // Returns RowReaderOptions with a ColumnSelector for the given schema.

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/common/Casts.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/dwio/common/Mutation.h"
 #include "velox/dwio/parquet/reader/ParquetStatsContext.h"
@@ -63,10 +64,34 @@ class ParquetReaderTest : public ParquetTestBase {
   // path enabled by a 1-byte threshold so any footer engages tracking.
   dwio::common::ReaderOptions makeThriftTrackingReaderOptions() {
     auto readerOptions = makeDefaultReaderOptions();
-    readerOptions.setParquetFooterMemoryTrackingThreshold(1);
+    auto parquetOptions = std::make_shared<ParquetReaderOptions>();
+    parquetOptions->footerMemoryTrackingThreshold = 1;
+    readerOptions.setFormatSpecificOptions(std::move(parquetOptions));
     return readerOptions;
   }
 };
+
+TEST_F(ParquetReaderTest, createFormatOptions) {
+  config::ConfigBase connectorConfig({
+      {std::string(ParquetConfig::kUseColumnNames), "true"},
+      {std::string(ParquetConfig::kFooterSpeculativeIoSize), "99"},
+      {std::string(ParquetConfig::kAllowInt32Narrowing), "false"},
+      {std::string(ParquetConfig::kFooterMemoryTrackingThreshold), "99"},
+  });
+  config::ConfigBase session({
+      {std::string(ParquetConfig::kFooterSpeculativeIoSizeSession), "2"},
+      {std::string(ParquetConfig::kAllowInt32NarrowingSession), "true"},
+      {std::string(ParquetConfig::kFooterMemoryTrackingThresholdSession), "1"},
+  });
+
+  ParquetReaderFactory factory;
+  auto parquetOptions = checkedPointerCast<ParquetReaderOptions>(
+      factory.createFormatOptions(connectorConfig, session));
+  EXPECT_EQ(parquetOptions->columnMappingMode, ColumnMappingMode::kName);
+  EXPECT_EQ(parquetOptions->footerSpeculativeIoSize, 2);
+  EXPECT_TRUE(parquetOptions->allowInt32Narrowing);
+  EXPECT_EQ(parquetOptions->footerMemoryTrackingThreshold, 1);
+}
 
 TEST_F(ParquetReaderTest, parseSample) {
   // sample.parquet holds two columns (a: BIGINT, b: DOUBLE) and

--- a/velox/dwio/parquet/tests/reader/ParquetReaderWideningTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderWideningTest.cpp
@@ -33,7 +33,9 @@ class ParquetReaderWideningTest : public ParquetTestBase {
       bool allowInt32Narrowing = false) const {
     auto opts = makeDefaultReaderOptions();
     opts.setFileSchema(readSchema);
-    opts.setAllowInt32Narrowing(allowInt32Narrowing);
+    auto parquetOptions = std::make_shared<ParquetReaderOptions>();
+    parquetOptions->allowInt32Narrowing = allowInt32Narrowing;
+    opts.setFormatSpecificOptions(std::move(parquetOptions));
     return opts;
   }
 
@@ -1068,7 +1070,9 @@ TEST_F(ParquetReaderWideningTest, allowInt32Narrowing) {
 
   // Default: flag is false.
   auto readerOptions = makeDefaultReaderOptions();
-  ASSERT_FALSE(readerOptions.allowInt32Narrowing());
+  auto parquetOptions = std::make_shared<ParquetReaderOptions>();
+  ASSERT_FALSE(parquetOptions->allowInt32Narrowing);
+  readerOptions.setFormatSpecificOptions(parquetOptions);
 
   // INT32->TINYINT narrowing rejected by default.
   readerOptions.setFileSchema(ROW("c1", TINYINT()));
@@ -1111,7 +1115,7 @@ TEST_F(ParquetReaderWideningTest, allowInt32Narrowing) {
   }
 
   // With flag enabled, narrowing is allowed with silent truncation.
-  readerOptions.setAllowInt32Narrowing(true);
+  parquetOptions->allowInt32Narrowing = true;
 
   // INT32->TINYINT: values are truncated via static_cast<int8_t>.
   {

--- a/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -804,7 +804,8 @@ TEST_F(ParquetTableScanTest, array) {
   AssertQueryBuilder(plan, duckDbQueryRunner_)
       .connectorSessionProperty(
           kHiveConnectorId,
-          connector::hive::HiveConfig::kParquetUseColumnNamesSession,
+          std::string("hive.parquet.") +
+              std::string(ParquetConfig::kUseColumnNamesSession),
           "true")
       .splits({makeSplit(getExampleFilePath("nested_array_struct.parquet"))})
       .assertResults(expected);
@@ -1431,7 +1432,8 @@ TEST_F(ParquetTableScanTest, schemaMatchWithComplexTypes) {
   result = AssertQueryBuilder(op)
                .connectorSessionProperty(
                    kHiveConnectorId,
-                   connector::hive::HiveConfig::kParquetUseColumnNamesSession,
+                   std::string("hive.parquet.") +
+                       std::string(ParquetConfig::kUseColumnNamesSession),
                    "true")
                .split(makeSplit(filePath))
                .copyResults(pool());
@@ -1505,7 +1507,8 @@ TEST_F(ParquetTableScanTest, schemaMatch) {
   result = AssertQueryBuilder(op)
                .connectorSessionProperty(
                    kHiveConnectorId,
-                   connector::hive::HiveConfig::kParquetUseColumnNamesSession,
+                   std::string("hive.parquet.") +
+                       std::string(ParquetConfig::kUseColumnNamesSession),
                    "true")
                .split(makeSplit(filePath))
                .copyResults(pool());
@@ -1976,7 +1979,8 @@ TEST_F(ParquetTableScanTest, intReadWithNarrowerType) {
       AssertQueryBuilder(op)
           .connectorSessionProperty(
               kHiveConnectorId,
-              connector::hive::HiveConfig::kAllowInt32NarrowingSession,
+              std::string("hive.parquet.") +
+                  std::string(ParquetConfig::kAllowInt32NarrowingSession),
               "true")
           .split(split)
           .copyResults(pool());

--- a/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -44,6 +44,12 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
  protected:
   using OperatorTestBase::assertQuery;
 
+  static std::string parquetSessionProperty(std::string_view key) {
+    return dwio::common::formatConfigPrefix(
+               dwio::common::FileFormat::PARQUET, "_") +
+        std::string(key);
+  }
+
   void SetUp() override {
     HiveConnectorTestBase::SetUp();
     parquet::registerParquetReaderFactory();
@@ -804,8 +810,7 @@ TEST_F(ParquetTableScanTest, array) {
   AssertQueryBuilder(plan, duckDbQueryRunner_)
       .connectorSessionProperty(
           kHiveConnectorId,
-          std::string(ParquetConfig::kSessionPrefix) +
-              std::string(ParquetConfig::kUseColumnNamesSession),
+          parquetSessionProperty(ParquetConfig::kUseColumnNamesSession),
           "true")
       .splits({makeSplit(getExampleFilePath("nested_array_struct.parquet"))})
       .assertResults(expected);
@@ -1429,14 +1434,14 @@ TEST_F(ParquetTableScanTest, schemaMatchWithComplexTypes) {
 
   // Now run query with column mapping using names - we should not be able to
   // find any names.
-  result = AssertQueryBuilder(op)
-               .connectorSessionProperty(
-                   kHiveConnectorId,
-                   std::string(ParquetConfig::kSessionPrefix) +
-                       std::string(ParquetConfig::kUseColumnNamesSession),
-                   "true")
-               .split(makeSplit(filePath))
-               .copyResults(pool());
+  result =
+      AssertQueryBuilder(op)
+          .connectorSessionProperty(
+              kHiveConnectorId,
+              parquetSessionProperty(ParquetConfig::kUseColumnNamesSession),
+              "true")
+          .split(makeSplit(filePath))
+          .copyResults(pool());
   rows = result->as<RowVector>();
   // check for rest of the selected columns
   auto nullBigIntVector = makeFlatVector<int64_t>(
@@ -1504,14 +1509,14 @@ TEST_F(ParquetTableScanTest, schemaMatch) {
            .endTableScan()
            .planNode();
 
-  result = AssertQueryBuilder(op)
-               .connectorSessionProperty(
-                   kHiveConnectorId,
-                   std::string(ParquetConfig::kSessionPrefix) +
-                       std::string(ParquetConfig::kUseColumnNamesSession),
-                   "true")
-               .split(makeSplit(filePath))
-               .copyResults(pool());
+  result =
+      AssertQueryBuilder(op)
+          .connectorSessionProperty(
+              kHiveConnectorId,
+              parquetSessionProperty(ParquetConfig::kUseColumnNamesSession),
+              "true")
+          .split(makeSplit(filePath))
+          .copyResults(pool());
 
   rows = result->as<RowVector>();
   auto nullVector = makeFlatVector<std::string>(
@@ -1975,15 +1980,14 @@ TEST_F(ParquetTableScanTest, intReadWithNarrowerType) {
                 .planNode();
 
   auto split = makeSplit(dataFile->getPath());
-  auto result =
-      AssertQueryBuilder(op)
-          .connectorSessionProperty(
-              kHiveConnectorId,
-              std::string(ParquetConfig::kSessionPrefix) +
-                  std::string(ParquetConfig::kAllowInt32NarrowingSession),
-              "true")
-          .split(split)
-          .copyResults(pool());
+  auto result = AssertQueryBuilder(op)
+                    .connectorSessionProperty(
+                        kHiveConnectorId,
+                        parquetSessionProperty(
+                            ParquetConfig::kAllowInt32NarrowingSession),
+                        "true")
+                    .split(split)
+                    .copyResults(pool());
   auto rows = result->as<RowVector>();
 
   assertEqualVectors(smallerIntVectors->childAt(0), rows->childAt(0));

--- a/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -45,9 +45,10 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
   using OperatorTestBase::assertQuery;
 
   static std::string parquetSessionProperty(std::string_view key) {
-    return dwio::common::formatConfigPrefix(
-               dwio::common::FileFormat::PARQUET, "_") +
-        std::string(key);
+    return fmt::format(
+        "{}_{}",
+        dwio::common::FileFormatName::toName(dwio::common::FileFormat::PARQUET),
+        key);
   }
 
   void SetUp() override {

--- a/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -804,7 +804,7 @@ TEST_F(ParquetTableScanTest, array) {
   AssertQueryBuilder(plan, duckDbQueryRunner_)
       .connectorSessionProperty(
           kHiveConnectorId,
-          std::string("hive.parquet.") +
+          std::string(ParquetConfig::kSessionPrefix) +
               std::string(ParquetConfig::kUseColumnNamesSession),
           "true")
       .splits({makeSplit(getExampleFilePath("nested_array_struct.parquet"))})
@@ -1432,7 +1432,7 @@ TEST_F(ParquetTableScanTest, schemaMatchWithComplexTypes) {
   result = AssertQueryBuilder(op)
                .connectorSessionProperty(
                    kHiveConnectorId,
-                   std::string("hive.parquet.") +
+                   std::string(ParquetConfig::kSessionPrefix) +
                        std::string(ParquetConfig::kUseColumnNamesSession),
                    "true")
                .split(makeSplit(filePath))
@@ -1507,7 +1507,7 @@ TEST_F(ParquetTableScanTest, schemaMatch) {
   result = AssertQueryBuilder(op)
                .connectorSessionProperty(
                    kHiveConnectorId,
-                   std::string("hive.parquet.") +
+                   std::string(ParquetConfig::kSessionPrefix) +
                        std::string(ParquetConfig::kUseColumnNamesSession),
                    "true")
                .split(makeSplit(filePath))
@@ -1979,7 +1979,7 @@ TEST_F(ParquetTableScanTest, intReadWithNarrowerType) {
       AssertQueryBuilder(op)
           .connectorSessionProperty(
               kHiveConnectorId,
-              std::string("hive.parquet.") +
+              std::string(ParquetConfig::kSessionPrefix) +
                   std::string(ParquetConfig::kAllowInt32NarrowingSession),
               "true")
           .split(split)


### PR DESCRIPTION
Format-specific reader options currently leak into shared `dwio::common` and connector infrastructure. `ReaderOptions` and `FileConfig` have to know about Parquet-only settings, and the Hive connector ends up translating per-format config itself before the reader ever sees it. That makes every reader carry fields that only one format understands, and adding a new format means touching shared code instead of keeping the logic with the format that owns it.

This refactor moves the reader-side configuration boundary to the format factories. `dwio::common::ReaderOptions` now carries an opaque `FormatSpecificOptions` payload, and each `ReaderFactory` gets a `createFormatOptions()` hook to translate the connector config and session config into the typed options its reader actually consumes. The connector now passes each factory only the config view for that format rather than unpacking format-specific fields in shared code.

As part of that split, Parquet-only reader settings move out of `FileConfig` and into `ParquetConfig`, so the shared Hive config layer no longer has to model Parquet internals. The result is that shared dwio and connector code only handles common reader concerns, while Parquet and other formats own their option types, defaults, and config translation end to end.

This PR only moves parquet reader configs. Parquet writer configs, ORC and Nimble configs will be moved later.



Fix(1/2) of https://github.com/facebookincubator/velox/issues/17632