### PR TITLE
feat: Support casting from large negative-exponent string to decimal

### DIFF
--- a/velox/type/DecimalUtil.h
+++ b/velox/type/DecimalUtil.h
@@ -181,19 +181,18 @@ class DecimalUtil {
           &rescaledValue);
     } else {
       scaleDifference = -scaleDifference;
-      VELOX_RETURN_IF(
-          scaleDifference > LongDecimalType::kMaxPrecision,
-          Status::UserError(
-              "Decimal scale difference is too large: {} vs max {}.",
-              scaleDifference,
-              LongDecimalType::kMaxPrecision));
-      const auto scalingFactor = DecimalUtil::kPowersOfTen[scaleDifference];
-      rescaledValue /= scalingFactor;
-      int128_t remainder = inputValue % scalingFactor;
-      if (inputValue >= 0 && remainder >= scalingFactor / 2) {
-        ++rescaledValue;
-      } else if (remainder <= -scalingFactor / 2) {
-        --rescaledValue;
+      if (scaleDifference > LongDecimalType::kMaxPrecision) {
+        rescaledValue = 0;
+      } else {
+        VELOX_DCHECK_LT(scaleDifference, std::size(DecimalUtil::kPowersOfTen));
+        const auto scalingFactor = DecimalUtil::kPowersOfTen[scaleDifference];
+        rescaledValue /= scalingFactor;
+        int128_t remainder = inputValue % scalingFactor;
+        if (inputValue >= 0 && remainder >= scalingFactor / 2) {
+          ++rescaledValue;
+        } else if (remainder <= -scalingFactor / 2) {
+          --rescaledValue;
+        }
       }
     }
     // Check overflow.

--- a/velox/type/tests/DecimalTest.cpp
+++ b/velox/type/tests/DecimalTest.cpp
@@ -795,9 +795,28 @@ TEST(DecimalTest, castFromStringError) {
       "9e", 12, 2, "Value is not a number. The exponent part is empty.");
   testCastFromString<int64_t>(
       "09{xi+yD", 12, 2, "Value is not a number. Chars are invalid.");
+}
 
-  // Large negative exponent string.
-  testCastFromString<int128_t>("6E-120", 38, 0, "Value too large.");
+TEST(DecimalTest, castFromStringNegativeExponent) {
+  testCastFromString<int64_t>(
+      std::vector<std::string>{
+          "123E-2",
+          "123E-3",
+          "567E-3",
+          "567E-4",
+          "5E-1",
+          "4E-1",
+          "-5E-1",
+          "-4E-1",
+          "500E-3",
+          "499E-3",
+          "6E-120",
+          "99999999999999999999999999999999999999E-38",
+          "50000000000000000000000000000000000000E-38",
+          "49999999999999999999999999999999999999E-38"},
+      38,
+      0,
+      std::vector<int64_t>{1, 0, 1, 0, 1, 0, -1, 0, 1, 0, 0, 1, 1, 0});
 }
 } // namespace
 } // namespace facebook::velox

--- a/velox/type/tests/DecimalTest.cpp
+++ b/velox/type/tests/DecimalTest.cpp
@@ -798,7 +798,7 @@ TEST(DecimalTest, castFromStringError) {
 }
 
 TEST(DecimalTest, castFromStringNegativeExponent) {
-  testCastFromString<int64_t>(
+  testCastFromString<int128_t>(
       std::vector<std::string>{
           "123E-2",
           "123E-3",
@@ -816,7 +816,7 @@ TEST(DecimalTest, castFromStringNegativeExponent) {
           "49999999999999999999999999999999999999E-38"},
       38,
       0,
-      std::vector<int64_t>{1, 0, 1, 0, 1, 0, -1, 0, 1, 0, 0, 1, 1, 0});
+      std::vector<int128_t>{1, 0, 1, 0, 1, 0, -1, 0, 1, 0, 0, 1, 1, 0});
 }
 } // namespace
 } // namespace facebook::velox


### PR DESCRIPTION
The PR adds support for casting from large negative-exponent string to decimal zero, to align with Spark and Presto.

E.g., the PR adds support for `CAST('6E-120' AS DECIMAL(38, 0)) == 0`, instead of returning an error.

This is the step 2 in https://github.com/facebookincubator/velox/issues/17593, following the previous fix https://github.com/facebookincubator/velox/pull/17594.