### PR TITLE
fix: Delete lsan_suppressions.txt file that is accidentally committed (#17666)

### DIFF
--- a/velox/common/memory/tests/lsan_suppressions.txt
+++ b/velox/common/memory/tests/lsan_suppressions.txt
@@ -1,1 +1,0 @@
-leak:facebook::velox::exec::Task::create


### PR DESCRIPTION
Summary:

And breaking our precommit CI on license headers

Ex: https://github.com/facebookincubator/velox/actions/runs/26606999858/job/78533059861

Accidentally got added when merging https://github.com/facebookincubator/velox/pull/17529/

Reviewed By: kgpai

Differential Revision: D106831378


