### PR TITLE
feat: Add footerCacheHit and footerBufferUnderread to RuntimeStatistics

### DIFF
--- a/velox/dwio/common/Statistics.h
+++ b/velox/dwio/common/Statistics.h
@@ -754,6 +754,10 @@ struct RuntimeStatistics {
 
   int64_t footerBufferOverread{0};
 
+  int64_t footerBufferUnderread{0};
+
+  int64_t footerCacheHit{0};
+
   int64_t numStripes{0};
 
   // Estimated bytes reported to the memory pool for the deserialized
@@ -792,6 +796,14 @@ struct RuntimeStatistics {
       result.emplace(
           "footerBufferOverread",
           RuntimeMetric(footerBufferOverread, RuntimeCounter::Unit::kBytes));
+    }
+    if (footerBufferUnderread > 0) {
+      result.emplace(
+          "footerBufferUnderread",
+          RuntimeMetric(footerBufferUnderread, RuntimeCounter::Unit::kBytes));
+    }
+    if (footerCacheHit > 0) {
+      result.emplace("footerCacheHit", RuntimeMetric(footerCacheHit));
     }
     if (numStripes > 0) {
       result.emplace("numStripes", RuntimeMetric(numStripes));


### PR DESCRIPTION
Summary: Add `footerCacheHit` and `footerBufferUnderread` counters to `RuntimeStatistics` for tracking footer IO behavior. `footerCacheHit` reports whether the footer was loaded from metadata cache (no file IO). `footerBufferUnderread` reports the bytes short when a speculative footer read was too small, requiring a second read.

Reviewed By: xiaoxmeng

Differential Revision: D106855895


