### PR TITLE
fix: Add missing link dependency for CustomMemoryResourceRegistry (#17672)

### DIFF
--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -243,6 +243,7 @@ velox_link_libraries(
   velox_core
   velox_connector
   velox_connector_registry
+  velox_custom_memory_resource_registry
   velox_exec_spill_stats
   velox_expression
   velox_file


### PR DESCRIPTION
Summary:

The recent commit that added the CustomMemoryResource framework modified velox/exec/Task.cpp to use CustomMemoryResourceRegistry::global() for resolving custom memory resources per query. However, the commit did not update velox/exec/CMakeLists.txt to link the velox_exec library against the new velox_custom_memory_resource_registry library.

This omission causes a linker error when building downstream projects that depend on velox_exec, such as presto-native-execution:

    undefined reference to `facebook::velox::memory::CustomMemoryResourceRegistry::global[abi:cxx11]()'

The fix adds velox_custom_memory_resource_registry to the velox_link_libraries call for velox_exec in velox/exec/CMakeLists.txt, ensuring the symbol is properly resolved during linking.

Differential Revision: D106906186


