### PR TITLE
feat: Add IO gap distribution tracking to CoalesceIoStats and NimbleIndexProjector (#17673)

### DIFF
--- a/velox/common/base/CMakeLists.txt
+++ b/velox/common/base/CMakeLists.txt
@@ -23,7 +23,13 @@ velox_add_library(
 )
 velox_link_libraries(
   velox_exception
-  PUBLIC velox_flag_definitions velox_process Folly::folly fmt::fmt gflags::gflags glog::glog
+  PUBLIC
+    velox_flag_definitions
+    velox_process
+    Folly::folly
+    fmt::fmt
+    gflags::gflags
+    glog::glog
 )
 
 velox_add_library(
@@ -58,6 +64,7 @@ velox_add_library(
   GTestMacros.h
   IOUtils.h
   IndexedPriorityQueue.h
+  IoCounter.h
   Nulls.h
   PeriodicStatsReporter.h
   Pointers.h
@@ -84,7 +91,12 @@ velox_add_library(
 velox_link_libraries(
   velox_common_base
   PUBLIC velox_exception Folly::folly fmt::fmt xsimd
-  PRIVATE velox_caching velox_common_compression velox_process velox_test_util glog::glog
+  PRIVATE
+    velox_caching
+    velox_common_compression
+    velox_process
+    velox_test_util
+    glog::glog
 )
 
 if(${VELOX_BUILD_TESTING})
@@ -107,7 +119,11 @@ velox_link_libraries(
 )
 
 velox_add_library(velox_status Status.cpp HEADERS Status.h)
-velox_link_libraries(velox_status PUBLIC fmt::fmt Folly::folly PRIVATE glog::glog)
+velox_link_libraries(
+  velox_status
+  PUBLIC fmt::fmt Folly::folly
+  PRIVATE glog::glog
+)
 
 velox_add_library(velox_compare_flags INTERFACE HEADERS CompareFlags.h)
 
@@ -115,6 +131,10 @@ velox_add_library(velox_macros INTERFACE HEADERS Macros.h)
 
 velox_add_library(velox_async_source INTERFACE HEADERS AsyncSource.h)
 
-velox_add_library(velox_lazy_cpu_thread_pool_executor INTERFACE HEADERS LazyCPUThreadPoolExecutor.h)
+velox_add_library(
+  velox_lazy_cpu_thread_pool_executor
+  INTERFACE
+  HEADERS LazyCPUThreadPoolExecutor.h
+)
 
 velox_add_library(velox_exception_helper INTERFACE HEADERS ExceptionHelper.h)

--- a/velox/common/base/CoalesceIo.h
+++ b/velox/common/base/CoalesceIo.h
@@ -18,6 +18,9 @@
 
 #include <cstdint>
 #include <vector>
+
+#include "velox/common/base/IoCounter.h"
+
 namespace facebook::velox {
 /// Utility for combining IOs to nearby location into fewer coalesced IOs. This
 /// may increase data transfer but generally reduces latency and may reduce
@@ -32,6 +35,11 @@ struct CoalesceIoStats {
   int64_t payloadBytes{0};
   /// Number of bytes read and discarded due to coalescing.
   int64_t extraBytes{0};
+
+  /// Distribution of gaps (in bytes) between consecutive items before
+  /// coalescing. Measures how spread out the read regions are on disk:
+  /// smaller gaps indicate better data locality for the access pattern.
+  io::IoCounter gaps;
 };
 
 static constexpr int32_t kNoCoalesce = -1;
@@ -82,6 +90,9 @@ CoalesceIoStats coalesceIo(
         !ranges.empty();
     if ((lastEndOffset != itemOffset) || enoughRanges) {
       const int64_t gap = itemOffset - lastEndOffset;
+      if (gap > 0) {
+        result.gaps.increment(gap);
+      }
       if (gap > 0 && gap < maxGap && !enoughRanges) {
         // The next one is after the previous and no farther than maxGap bytes,
         // we read the gap but drop the bytes.

--- a/velox/common/base/IoCounter.h
+++ b/velox/common/base/IoCounter.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <limits>
+
+namespace facebook::velox::io {
+
+class IoCounter {
+ public:
+  IoCounter() = default;
+
+  IoCounter(const IoCounter& other) noexcept
+      : count_{other.count_.load(std::memory_order_relaxed)},
+        sum_{other.sum_.load(std::memory_order_relaxed)},
+        min_{other.min_.load(std::memory_order_relaxed)},
+        max_{other.max_.load(std::memory_order_relaxed)} {}
+
+  IoCounter& operator=(const IoCounter& other) noexcept {
+    if (this != &other) {
+      count_.store(
+          other.count_.load(std::memory_order_relaxed),
+          std::memory_order_relaxed);
+      sum_.store(
+          other.sum_.load(std::memory_order_relaxed),
+          std::memory_order_relaxed);
+      min_.store(
+          other.min_.load(std::memory_order_relaxed),
+          std::memory_order_relaxed);
+      max_.store(
+          other.max_.load(std::memory_order_relaxed),
+          std::memory_order_relaxed);
+    }
+    return *this;
+  }
+
+  uint64_t count() const {
+    return count_;
+  }
+
+  uint64_t sum() const {
+    return sum_;
+  }
+
+  uint64_t min() const {
+    return min_;
+  }
+
+  uint64_t max() const {
+    return max_;
+  }
+
+  void increment(uint64_t amount) {
+    ++count_;
+    sum_ += amount;
+    casLoop(min_, amount, std::greater());
+    casLoop(max_, amount, std::less());
+  }
+
+  void merge(const IoCounter& other) {
+    sum_ += other.sum_;
+    count_ += other.count_;
+    casLoop(min_, other.min_, std::greater());
+    casLoop(max_, other.max_, std::less());
+  }
+
+ private:
+  template <typename Compare>
+  static void
+  casLoop(std::atomic<uint64_t>& value, uint64_t newValue, Compare compare) {
+    uint64_t old = value;
+    while (compare(old, newValue) &&
+           !value.compare_exchange_weak(old, newValue)) {
+    }
+  }
+
+  std::atomic<uint64_t> count_{0};
+  std::atomic<uint64_t> sum_{0};
+  std::atomic<uint64_t> min_{std::numeric_limits<uint64_t>::max()};
+  std::atomic<uint64_t> max_{0};
+};
+
+} // namespace facebook::velox::io

--- a/velox/common/base/tests/CoalesceIoTest.cpp
+++ b/velox/common/base/tests/CoalesceIoTest.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/common/base/CoalesceIo.h"
 
+#include <fmt/format.h>
 #include <gtest/gtest.h>
 
 using namespace facebook::velox;
@@ -112,4 +113,89 @@ TEST(CoalesceIoTest, basic) {
   EXPECT_EQ(2, ioGroups[1].size());
   EXPECT_EQ(1, ioGroups[2].size());
   EXPECT_EQ(1, ioGroups[3].size());
+
+  // Gap distribution: tracks gaps between consecutive items before coalescing.
+  // data[0] ends at 101'000, data[1] starts at 105'000 -> gap 4'000
+  // data[1] ends at 205'000, data[2] starts at 220'000 -> gap 15'000
+  // data[2] ends at 320'000, data[3] starts at 330'000 -> gap 10'000
+  // data[3] ends at 430'000, data[4] starts at 700'000 -> gap 270'000
+  // data[4] ends at 800'000, data[5] starts at 810'000 -> gap 10'000
+  EXPECT_EQ(5, stats.gaps.count());
+  EXPECT_EQ(4'000 + 15'000 + 10'000 + 270'000 + 10'000, stats.gaps.sum());
+  EXPECT_EQ(4'000, stats.gaps.min());
+  EXPECT_EQ(270'000, stats.gaps.max());
+}
+
+TEST(CoalesceIoTest, gaps) {
+  struct TestParam {
+    std::vector<IoUnit> data;
+    int32_t maxGap;
+    uint64_t expectedCount;
+    uint64_t expectedSum;
+    uint64_t expectedMin;
+    uint64_t expectedMax;
+
+    std::string debugString() const {
+      return fmt::format(
+          "items {}, maxGap {}, expectedCount {}",
+          data.size(),
+          maxGap,
+          expectedCount);
+    }
+  };
+
+  auto makeItems = [](std::initializer_list<std::tuple<int64_t, int32_t>> specs)
+      -> std::vector<IoUnit> {
+    std::vector<IoUnit> items;
+    for (const auto& [offset, size] : specs) {
+      items.emplace_back(offset, size, 1);
+    }
+    return items;
+  };
+
+  std::vector<TestParam> testSettings = {
+      // Contiguous reads (no gaps).
+      {makeItems({{0, 100}, {100, 200}, {300, 150}}),
+       1'000,
+       0,
+       0,
+       std::numeric_limits<uint64_t>::max(),
+       0},
+      // Gaps of 50, 200, 1'000 bytes.
+      {makeItems({{0, 100}, {150, 100}, {450, 100}, {1'550, 100}}),
+       500,
+       3,
+       1'250,
+       50,
+       1'000},
+  };
+
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+
+    const auto& data = testData.data;
+    auto stats = coalesceIo<IoUnit, Range>(
+        data,
+        testData.maxGap,
+        10,
+        [&](int32_t i) { return data[i].offset; },
+        [&](int32_t i) { return data[i].size; },
+        [&](int32_t) { return 1; },
+        [&](const IoUnit& item, std::vector<Range>& ranges) {
+          ranges.emplace_back(item.size, 1);
+        },
+        [&](int32_t skip, std::vector<Range>& ranges) {
+          ranges.emplace_back(skip, 0);
+        },
+        [&](const std::vector<IoUnit>&,
+            int32_t,
+            int32_t,
+            uint64_t,
+            const std::vector<Range>&) {});
+
+    EXPECT_EQ(stats.gaps.count(), testData.expectedCount);
+    EXPECT_EQ(stats.gaps.sum(), testData.expectedSum);
+    EXPECT_EQ(stats.gaps.min(), testData.expectedMin);
+    EXPECT_EQ(stats.gaps.max(), testData.expectedMax);
+  }
 }

--- a/velox/common/base/tests/IoCounterTest.cpp
+++ b/velox/common/base/tests/IoCounterTest.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/IoCounter.h"
+
+#include <limits>
+
+#include <gtest/gtest.h>
+
+namespace facebook::velox::io {
+
+TEST(IoCounterTest, increment) {
+  IoCounter counter;
+  EXPECT_EQ(counter.count(), 0);
+  EXPECT_EQ(counter.sum(), 0);
+  EXPECT_EQ(counter.min(), std::numeric_limits<uint64_t>::max());
+  EXPECT_EQ(counter.max(), 0);
+
+  counter.increment(100);
+  counter.increment(200);
+  counter.increment(50);
+
+  EXPECT_EQ(counter.count(), 3);
+  EXPECT_EQ(counter.sum(), 350);
+  EXPECT_EQ(counter.min(), 50);
+  EXPECT_EQ(counter.max(), 200);
+}
+
+TEST(IoCounterTest, merge) {
+  IoCounter counter;
+  counter.increment(100);
+  counter.increment(200);
+
+  IoCounter other;
+  other.increment(50);
+  other.increment(500);
+
+  counter.merge(other);
+  EXPECT_EQ(counter.count(), 4);
+  EXPECT_EQ(counter.sum(), 850);
+  EXPECT_EQ(counter.min(), 50);
+  EXPECT_EQ(counter.max(), 500);
+}
+
+TEST(IoCounterTest, copyConstructor) {
+  IoCounter counter;
+  counter.increment(100);
+  counter.increment(200);
+  counter.increment(50);
+
+  IoCounter copied(counter);
+  EXPECT_EQ(copied.count(), 3);
+  EXPECT_EQ(copied.sum(), 350);
+  EXPECT_EQ(copied.min(), 50);
+  EXPECT_EQ(copied.max(), 200);
+
+  copied.increment(1);
+  EXPECT_EQ(counter.count(), 3);
+  EXPECT_EQ(counter.sum(), 350);
+}
+
+TEST(IoCounterTest, copyAssignment) {
+  IoCounter counter;
+  counter.increment(100);
+  counter.increment(200);
+
+  IoCounter assigned;
+  assigned.increment(999);
+  assigned = counter;
+  EXPECT_EQ(assigned.count(), 2);
+  EXPECT_EQ(assigned.sum(), 300);
+  EXPECT_EQ(assigned.min(), 100);
+  EXPECT_EQ(assigned.max(), 200);
+}
+
+TEST(IoCounterTest, copyDefaultEmpty) {
+  IoCounter counter;
+  IoCounter copied(counter);
+  EXPECT_EQ(copied.count(), 0);
+  EXPECT_EQ(copied.sum(), 0);
+  EXPECT_EQ(copied.min(), std::numeric_limits<uint64_t>::max());
+  EXPECT_EQ(copied.max(), 0);
+
+  copied.increment(1);
+  EXPECT_EQ(counter.count(), 0);
+  EXPECT_EQ(counter.sum(), 0);
+}
+
+} // namespace facebook::velox::io

--- a/velox/common/io/CMakeLists.txt
+++ b/velox/common/io/CMakeLists.txt
@@ -22,4 +22,4 @@ velox_add_library(
   Options.h
 )
 
-velox_link_libraries(velox_common_io Folly::folly glog::glog)
+velox_link_libraries(velox_common_io velox_common_base Folly::folly glog::glog)

--- a/velox/common/io/IoStatistics.cpp
+++ b/velox/common/io/IoStatistics.cpp
@@ -124,6 +124,7 @@ void IoStatistics::merge(const IoStatistics& other) {
   cacheWaitLatencyUs_.merge(other.cacheWaitLatencyUs_);
   coalescedSsdLoadLatencyUs_.merge(other.coalescedSsdLoadLatencyUs_);
   coalescedStorageLoadLatencyUs_.merge(other.coalescedStorageLoadLatencyUs_);
+  readGap_.merge(other.readGap_);
   {
     const auto& otherOperationStats = other.operationStats();
     std::lock_guard<std::mutex> l(operationStatsMutex_);

--- a/velox/common/io/IoStatistics.h
+++ b/velox/common/io/IoStatistics.h
@@ -16,13 +16,13 @@
 
 #pragma once
 
-#include <atomic>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <unordered_map>
 
 #include <folly/dynamic.h>
+#include "velox/common/base/IoCounter.h"
 
 namespace facebook::velox::io {
 
@@ -39,72 +39,6 @@ struct OperationCounters {
   uint64_t delayInjectedInSecs{0};
 
   void merge(const OperationCounters& other);
-};
-
-class IoCounter {
- public:
-  IoCounter& operator=(const IoCounter& other) noexcept {
-    if (this != &other) {
-      count_.store(
-          other.count_.load(std::memory_order_relaxed),
-          std::memory_order_relaxed);
-      sum_.store(
-          other.sum_.load(std::memory_order_relaxed),
-          std::memory_order_relaxed);
-      min_.store(
-          other.min_.load(std::memory_order_relaxed),
-          std::memory_order_relaxed);
-      max_.store(
-          other.max_.load(std::memory_order_relaxed),
-          std::memory_order_relaxed);
-    }
-    return *this;
-  }
-
-  uint64_t count() const {
-    return count_;
-  }
-
-  uint64_t sum() const {
-    return sum_;
-  }
-
-  uint64_t min() const {
-    return min_;
-  }
-
-  uint64_t max() const {
-    return max_;
-  }
-
-  void increment(uint64_t amount) {
-    ++count_;
-    sum_ += amount;
-    casLoop(min_, amount, std::greater());
-    casLoop(max_, amount, std::less());
-  }
-
-  void merge(const IoCounter& other) {
-    sum_ += other.sum_;
-    count_ += other.count_;
-    casLoop(min_, other.min_, std::greater());
-    casLoop(max_, other.max_, std::less());
-  }
-
- private:
-  template <typename Compare>
-  static void
-  casLoop(std::atomic<uint64_t>& value, uint64_t newValue, Compare compare) {
-    uint64_t old = value;
-    while (compare(old, newValue) &&
-           !value.compare_exchange_weak(old, newValue)) {
-    }
-  }
-
-  std::atomic<uint64_t> count_{0};
-  std::atomic<uint64_t> sum_{0};
-  std::atomic<uint64_t> min_{std::numeric_limits<uint64_t>::max()};
-  std::atomic<uint64_t> max_{0};
 };
 
 class IoStatistics {
@@ -163,6 +97,16 @@ class IoStatistics {
 
   IoCounter& coalescedStorageLoadLatencyUs() {
     return coalescedStorageLoadLatencyUs_;
+  }
+
+  /// Distribution of gaps (in bytes) between consecutive read regions
+  /// before coalescing. Measures data locality on disk.
+  IoCounter& readGap() {
+    return readGap_;
+  }
+
+  const IoCounter& readGap() const {
+    return readGap_;
   }
 
   void incOperationCounters(
@@ -225,6 +169,9 @@ class IoStatistics {
 
   // Time spent waiting for coalesced loads from remote storage
   IoCounter coalescedStorageLoadLatencyUs_;
+
+  // Gap between consecutive read regions before coalescing.
+  IoCounter readGap_;
 
   std::unordered_map<std::string, OperationCounters> operationStats_;
   mutable std::mutex operationStatsMutex_;

--- a/velox/common/io/tests/IoStatisticsTest.cpp
+++ b/velox/common/io/tests/IoStatisticsTest.cpp
@@ -59,4 +59,26 @@ TEST(IoStatisticsTest, totalScanTimeNs) {
   EXPECT_EQ(stats.totalScanTimeNs(), 4'000);
 }
 
+TEST(IoStatisticsTest, readGap) {
+  IoStatistics stats;
+  EXPECT_EQ(stats.readGap().count(), 0);
+
+  stats.readGap().increment(1'000);
+  stats.readGap().increment(500);
+  stats.readGap().increment(2'000);
+  EXPECT_EQ(stats.readGap().count(), 3);
+  EXPECT_EQ(stats.readGap().sum(), 3'500);
+  EXPECT_EQ(stats.readGap().min(), 500);
+  EXPECT_EQ(stats.readGap().max(), 2'000);
+
+  IoStatistics stats2;
+  stats2.readGap().increment(100);
+  stats2.readGap().increment(5'000);
+  stats.merge(stats2);
+  EXPECT_EQ(stats.readGap().count(), 5);
+  EXPECT_EQ(stats.readGap().sum(), 8'600);
+  EXPECT_EQ(stats.readGap().min(), 100);
+  EXPECT_EQ(stats.readGap().max(), 5'000);
+}
+
 } // namespace facebook::velox::io

--- a/velox/connectors/hive/FileDataSource.cpp
+++ b/velox/connectors/hive/FileDataSource.cpp
@@ -151,6 +151,11 @@ void addIoStatsToRuntimeStats(
       key(FileDataSource::kRamReadBytes),
       RuntimeCounter::Unit::kBytes,
       res);
+  addIoStatsMetric(
+      ioStats.readGap(),
+      key(FileDataSource::kReadGapBytes),
+      RuntimeCounter::Unit::kBytes,
+      res);
 }
 
 } // namespace

--- a/velox/connectors/hive/FileDataSource.h
+++ b/velox/connectors/hive/FileDataSource.h
@@ -67,6 +67,7 @@ class FileDataSource : public DataSource {
   static constexpr std::string_view kLocalReadBytes{"localReadBytes"};
   static constexpr std::string_view kNumRamRead{"numRamRead"};
   static constexpr std::string_view kRamReadBytes{"ramReadBytes"};
+  static constexpr std::string_view kReadGapBytes{"readGapBytes"};
 
   FileDataSource(
       const RowTypePtr& outputType,

--- a/velox/docs/monitoring/stats.rst
+++ b/velox/docs/monitoring/stats.rst
@@ -541,3 +541,9 @@ Metadata IO stats (footer, stripe groups, index) use a ``metadata.`` prefix
      - bytes
      - The total bytes read from the in-memory (RAM) cache, including min and
        max per read operation.
+   * - readGapBytes
+     - bytes
+     - The total gap bytes between consecutive read regions before I/O
+       coalescing. Measures data locality on disk — smaller gaps indicate
+       co-accessed columns are physically adjacent in the file. Includes
+       min and max per gap.

--- a/velox/dwio/common/BufferedInput.cpp
+++ b/velox/dwio/common/BufferedInput.cpp
@@ -237,12 +237,15 @@ void BufferedInput::mergeRegions() {
 bool BufferedInput::tryMerge(Region& first, const Region& second) {
   VELOX_CHECK_GE(second.offset, first.offset, "regions should be sorted.");
   const int64_t gap = second.offset - first.offset - first.length;
-
   // Duplicate regions (extension==0) is the only case allowed to merge for
   // useVRead()
   const int64_t extension = gap + second.length;
   if (useVRead()) {
     return extension == 0;
+  }
+
+  if (gap > 0 && input_->getStats() != nullptr) {
+    input_->getStats()->readGap().increment(gap);
   }
 
   // compare with 0 since it's comparison in different types

--- a/velox/dwio/common/CachedBufferedInput.cpp
+++ b/velox/dwio/common/CachedBufferedInput.cpp
@@ -302,7 +302,7 @@ std::vector<int32_t> CachedBufferedInput::groupRequests(
   std::vector<int32_t> ends;
   ends.reserve(requests.size());
   std::vector<char> ranges;
-  coalesceIo<CacheRequest*, char>(
+  const auto stats = coalesceIo<CacheRequest*, char>(
       requests,
       maxDistance,
       std::numeric_limits<int32_t>::max(),
@@ -328,6 +328,7 @@ std::vector<int32_t> CachedBufferedInput::groupRequests(
           int32_t end,
           uint64_t /*offset*/,
           const std::vector<char>& /*ranges*/) { ends.push_back(end); });
+  ioStatistics_->readGap().merge(stats.gaps);
   return ends;
 }
 

--- a/velox/dwio/common/DirectBufferedInput.cpp
+++ b/velox/dwio/common/DirectBufferedInput.cpp
@@ -151,7 +151,7 @@ std::vector<int32_t> DirectBufferedInput::groupRequests(
   std::vector<int32_t> ends;
   ends.reserve(requests.size());
   std::vector<char> ranges;
-  coalesceIo<LoadRequest*, char>(
+  const auto stats = coalesceIo<LoadRequest*, char>(
       requests,
       maxDistance,
       // Break batches up. Better load more short ones i parallel.
@@ -183,6 +183,7 @@ std::vector<int32_t> DirectBufferedInput::groupRequests(
           int32_t end,
           uint64_t /*offset*/,
           const std::vector<char>& /*ranges*/) { ends.push_back(end); });
+  ioStatistics_->readGap().merge(stats.gaps);
   return ends;
 }
 

--- a/velox/dwio/common/tests/BufferedInputTest.cpp
+++ b/velox/dwio/common/tests/BufferedInputTest.cpp
@@ -796,3 +796,49 @@ TEST_F(CustomBufferedInputTest, basic) {
               fileHandle, readerOpts, nullptr, ioStatistics, ioStats, nullptr),
       "Not implemented in CustomBufferedInputBuilder");
 }
+
+TEST_F(BufferedInputTest, readGapTracking) {
+  constexpr int32_t kContentSize = 1 << 20; // 1MB
+  std::string content(kContentSize, 'x');
+  auto readFile = std::make_shared<facebook::velox::InMemoryReadFile>(content);
+
+  struct TestCase {
+    std::vector<Region> regions;
+    uint64_t expectedGapCount;
+    uint64_t expectedGapSum;
+    uint64_t expectedGapMin;
+    uint64_t expectedGapMax;
+    std::string debugString() const {
+      return fmt::format(
+          "regions {}, expectedGapCount {}", regions.size(), expectedGapCount);
+    }
+  };
+
+  std::vector<TestCase> testCases = {
+      // Scattered regions: gaps of 9'900 and 39'900 bytes.
+      {{{0, 100}, {10'000, 100}, {50'000, 100}}, 2, 49'800, 9'900, 39'900},
+      // Contiguous regions: no gaps.
+      {{{0, 100}, {100, 100}, {200, 100}},
+       0,
+       0,
+       std::numeric_limits<uint64_t>::max(),
+       0},
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.debugString());
+
+    auto ioStats = std::make_shared<facebook::velox::io::IoStatistics>();
+    BufferedInput input(readFile, *pool_, MetricsLog::voidLog(), ioStats.get());
+
+    for (const auto& region : testCase.regions) {
+      input.enqueue(region);
+    }
+    input.load(LogType::TEST);
+
+    EXPECT_EQ(ioStats->readGap().count(), testCase.expectedGapCount);
+    EXPECT_EQ(ioStats->readGap().sum(), testCase.expectedGapSum);
+    EXPECT_EQ(ioStats->readGap().min(), testCase.expectedGapMin);
+    EXPECT_EQ(ioStats->readGap().max(), testCase.expectedGapMax);
+  }
+}

--- a/velox/dwio/common/tests/CachedBufferedInputTest.cpp
+++ b/velox/dwio/common/tests/CachedBufferedInputTest.cpp
@@ -1730,4 +1730,70 @@ TEST_F(CachedBufferedInputTest, cloneNonCacheable) {
   EXPECT_FALSE(cache_->testingIsEvictable(cacheKey2));
 }
 
+TEST_F(CachedBufferedInputTest, readGapTracking) {
+  constexpr int32_t kContentSize = 1 << 20; // 1MB
+  std::string content(kContentSize, 'x');
+  auto readFile = std::make_shared<InMemoryReadFile>(content);
+  auto& ids = fileIds();
+
+  struct TestCase {
+    std::vector<common::Region> regions;
+    uint64_t expectedGapCount;
+    uint64_t expectedGapSum;
+    uint64_t expectedGapMin;
+    uint64_t expectedGapMax;
+    std::string debugString() const {
+      return fmt::format(
+          "regions {}, expectedGapCount {}", regions.size(), expectedGapCount);
+    }
+  };
+
+  std::vector<TestCase> testCases = {
+      // Scattered regions: gaps of 9'900 and 39'900 bytes.
+      {{{0, 100}, {10'000, 100}, {50'000, 100}}, 2, 49'800, 9'900, 39'900},
+      // Contiguous regions: no gaps.
+      {{{0, 100}, {100, 100}, {200, 100}},
+       0,
+       0,
+       std::numeric_limits<uint64_t>::max(),
+       0},
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.debugString());
+
+    auto ioStats = std::make_shared<IoStatistics>();
+    io::ReaderOptions readerOptions(pool_.get());
+    readerOptions.setDataIoStats(ioStats);
+    readerOptions.setMetadataIoStats(std::make_shared<IoStatistics>());
+    readerOptions.setMaxCoalesceDistance(0);
+
+    StringIdLease fileId(
+        ids, fmt::format("file_{}", testCase.expectedGapCount));
+    StringIdLease groupId(
+        ids, fmt::format("group_{}", testCase.expectedGapCount));
+    CachedBufferedInput input(
+        readFile,
+        MetricsLog::voidLog(),
+        std::move(fileId),
+        cache_.get(),
+        tracker_,
+        std::move(groupId),
+        ioStats,
+        nullptr,
+        executor_.get(),
+        readerOptions);
+
+    for (const auto& region : testCase.regions) {
+      input.enqueue(region, nullptr);
+    }
+    input.load(LogType::TEST);
+
+    EXPECT_EQ(ioStats->readGap().count(), testCase.expectedGapCount);
+    EXPECT_EQ(ioStats->readGap().sum(), testCase.expectedGapSum);
+    EXPECT_EQ(ioStats->readGap().min(), testCase.expectedGapMin);
+    EXPECT_EQ(ioStats->readGap().max(), testCase.expectedGapMax);
+  }
+}
+
 } // namespace

--- a/velox/dwio/common/tests/DirectBufferedInputTest.cpp
+++ b/velox/dwio/common/tests/DirectBufferedInputTest.cpp
@@ -915,4 +915,69 @@ TEST_F(DirectBufferedInputTest, hasCache) {
       input.findCachedRegion(0), "findCachedRegion requires a backing cache");
 }
 
+TEST_F(DirectBufferedInputTest, readGapTracking) {
+  constexpr int32_t kContentSize = 1 << 20; // 1MB
+  std::string content(kContentSize, 'x');
+  auto readFile = std::make_shared<InMemoryReadFile>(content);
+  auto& ids = fileIds();
+
+  struct TestCase {
+    std::vector<common::Region> regions;
+    uint64_t expectedGapCount;
+    uint64_t expectedGapSum;
+    uint64_t expectedGapMin;
+    uint64_t expectedGapMax;
+    std::string debugString() const {
+      return fmt::format(
+          "regions {}, expectedGapCount {}", regions.size(), expectedGapCount);
+    }
+  };
+
+  std::vector<TestCase> testCases = {
+      // Scattered regions: gaps of 9'900 and 39'900 bytes.
+      {{{0, 100}, {10'000, 100}, {50'000, 100}}, 2, 49'800, 9'900, 39'900},
+      // Contiguous regions: no gaps.
+      {{{0, 100}, {100, 100}, {200, 100}},
+       0,
+       0,
+       std::numeric_limits<uint64_t>::max(),
+       0},
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.debugString());
+
+    auto ioStats = std::make_shared<IoStatistics>();
+    io::ReaderOptions readerOptions(pool_.get());
+    readerOptions.setDataIoStats(ioStats);
+    readerOptions.setMetadataIoStats(std::make_shared<IoStatistics>());
+    readerOptions.setMaxCoalesceDistance(0);
+
+    StringIdLease fileId(
+        ids, fmt::format("file_{}", testCase.expectedGapCount));
+    StringIdLease groupId(
+        ids, fmt::format("group_{}", testCase.expectedGapCount));
+    DirectBufferedInput input(
+        readFile,
+        MetricsLog::voidLog(),
+        std::move(fileId),
+        tracker_,
+        std::move(groupId),
+        ioStats,
+        nullptr,
+        executor_.get(),
+        readerOptions);
+
+    for (const auto& region : testCase.regions) {
+      input.enqueue(region, nullptr);
+    }
+    input.load(LogType::TEST);
+
+    EXPECT_EQ(ioStats->readGap().count(), testCase.expectedGapCount);
+    EXPECT_EQ(ioStats->readGap().sum(), testCase.expectedGapSum);
+    EXPECT_EQ(ioStats->readGap().min(), testCase.expectedGapMin);
+    EXPECT_EQ(ioStats->readGap().max(), testCase.expectedGapMax);
+  }
+}
+
 } // namespace


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookincubator/nimble/pull/800

CONTEXT: Nimble index projector does 12x more IO ops than TDB with 13x smaller avg IO size (14.69 KB vs 189.78 KB). To optimize file layout for IO coalescing, we need to measure how spread out the read regions are on disk — the gap between consecutive stream reads directly reflects file layout quality for the access pattern.

WHAT: Add `IoDistributionCounter` to `CoalesceIoStats` in `CoalesceIo.h` to track the distribution (min/max/count/sum) of gaps between consecutive items before coalescing. Also add `ioGap` field to `NimbleIndexProjector::Stats` and update `toString()` to report `ioGap=[min=..., max=..., avg=..., count=...]`. The `ioGap` field will be populated by the coroutine IO path in a follow-up diff.

Reviewed By: tanjialiang

Differential Revision: D106889281
