### PR TITLE
docs: Fix duplicate object description warnings in Sphinx doc build

### DIFF
--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -468,6 +468,7 @@ __ https://www.cse.ust.hk/~raywong/comp5331/References/EfficientComputationOfFre
         --{30.0->1.0, 22.5->2.0, 12.5->2.0}
 
 .. function:: numeric_histogram(buckets, value) -> map<double, double>
+   :noindex:
 
     Computes an approximate histogram with up to ``buckets`` number of buckets
     for all ``value``\ s. This function is equivalent to the variant of
@@ -575,6 +576,7 @@ To find the `ROC curve <https://en.wikipedia.org/wiki/Receiver_operating_charact
     entries of ``y``, ``x``, and ``weight``, respectively.
 
 .. function:: classification_miss_rate(buckets, y, x) -> array<double>
+   :noindex:
 
     This function is equivalent to the variant of
     :func:`!classification_miss_rate` that takes a ``weight``, with a per-item weight of ``1``.
@@ -604,6 +606,7 @@ To find the `ROC curve <https://en.wikipedia.org/wiki/Receiver_operating_charact
     entries of ``y``, ``x``, and ``weight``, respectively.
 
 .. function:: classification_fall_out(buckets, y, x) -> array<double>
+   :noindex:
 
     This function is equivalent to the variant of
     :func:`!classification_fall_out` that takes a ``weight``, with a per-item weight of ``1``.
@@ -633,6 +636,7 @@ To find the `ROC curve <https://en.wikipedia.org/wiki/Receiver_operating_charact
     entries of ``y``, ``x``, and ``weight``, respectively.
 
 .. function:: classification_precision(buckets, y, x) -> array<double>
+   :noindex:
 
     This function is equivalent to the variant of
     :func:`!classification_precision` that takes a ``weight``, with a per-item weight of ``1``.
@@ -662,6 +666,7 @@ To find the `ROC curve <https://en.wikipedia.org/wiki/Receiver_operating_charact
     entries of ``y``, ``x``, and ``weight``, respectively.
 
 .. function:: classification_recall(buckets, y, x) -> array<double>
+   :noindex:
 
     This function is equivalent to the variant of
     :func:`!classification_recall` that takes a ``weight``, with a per-item weight of ``1``.
@@ -845,6 +850,7 @@ Counts, Sums, and Averages
     Otherwise, noise is drawn from a secure random.
 
 .. function:: noisy_sum_gaussian(col, noise_scale, lower, upper[, random_seed]) -> double
+   :noindex:
 
     Calculates the sum over the input values in ``col`` and then adds a normally distributed
     random double value with 0 mean and standard deviation of ``noise_scale``.
@@ -862,6 +868,7 @@ Counts, Sums, and Averages
     Otherwise, noise is drawn from a secure random.
 
 .. function:: noisy_avg_gaussian(col, noise_scale, lower, upper[, random_seed]) -> double
+   :noindex:
 
     Calculates the average (arithmetic mean) of all the input values in ``col`` and then adds a
     normally distributed random double value with 0 mean and standard deviation of ``noise_scale``.

--- a/velox/docs/functions/presto/array.rst
+++ b/velox/docs/functions/presto/array.rst
@@ -264,6 +264,7 @@ Array Functions
     For REAL and DOUBLE, NANs (Not-a-Number) are considered equal.
 
 .. function:: cardinality(x) -> bigint
+   :noindex:
 
     Returns the cardinality (size) of the array ``x``.
 
@@ -307,6 +308,7 @@ Array Functions
           SELECT dot_product(NULL, ARRAY[1, 2, 3]); -- NULL
 
 .. function:: dot_product(map(K, V), map(K, V)) -> bigint/double
+   :noindex:
 
     Computes the dot product of two maps. For maps, the dot product is computed by
     multiplying values with matching keys and summing the results. Keys present in only
@@ -392,6 +394,7 @@ Array Functions
           SELECT l2_norm(ARRAY[3, NULL, 4]); -- 5.0
 
 .. function:: l2_norm(map(K, V)) -> double
+   :noindex:
 
     Returns the Euclidean norm (L2 norm) of the values in a map.
     The L2 norm is calculated as the square root of the sum of squares of all values: sqrt(sum(v^2)).

--- a/velox/docs/functions/presto/binary.rst
+++ b/velox/docs/functions/presto/binary.rst
@@ -173,5 +173,6 @@ Binary Functions
     Computes the xxhash64 hash of ``binary``.
 
 .. function:: xxhash64(binary, bigint) -> varbinary
+   :noindex:
 
     Computes the xxhash64 hash of ``binary`` with ``bigint`` seed.

--- a/velox/docs/functions/presto/datetime.rst
+++ b/velox/docs/functions/presto/datetime.rst
@@ -41,6 +41,7 @@ Date and Time Operators
      - ``0 00:00:10.000``
 
 .. function:: plus(x, y) -> [same as x]
+   :noindex:
 
     Returns the sum of ``x`` and ``y``. Both ``x`` and ``y`` are intervals day
     to second or one of them can be timestamp. For addition of two intervals day to
@@ -50,6 +51,7 @@ Date and Time Operators
     second, overflowed results are wrapped around.
 
 .. function:: minus(x, y) -> [same as x]
+   :noindex:
 
     Returns the result of subtracting ``y`` from ``x``. Both ``x`` and ``y``
     are intervals day to second or ``x`` can be timestamp. For subtraction of
@@ -67,6 +69,7 @@ Date and Time Operators
     when ``x`` is -infinity or when the multiplication overflow in negiative.
 
 .. function:: multiply(x, interval day to second) -> interval day to second
+   :noindex:
 
     Returns the result of multiplying ``x`` by ``interval day to second``.
     Same as ``multiply(interval day to second, x)``.
@@ -156,6 +159,7 @@ Date and Time Functions
     using ``string`` for the time zone.
 
 .. function:: from_unixtime(unixtime, hours, minutes) -> timestamp with time zone
+   :noindex:
 
     Returns the UNIX timestamp ``unixtime`` as a timestamp with time zone
     using ``hours`` and ``minutes`` for the time zone offset.

--- a/velox/docs/functions/presto/decimal.rst
+++ b/velox/docs/functions/presto/decimal.rst
@@ -244,6 +244,7 @@ Decimal Functions
         pr = min(38, p - s + min(s, 1))
 
 .. function:: divide(x: decimal(p1, s1), y: decimal(p2, s2)) -> r: decimal(p, s)
+   :noindex:
 
     Returns the result of dividing x by y (r = x / y).
 
@@ -292,6 +293,7 @@ Decimal Functions
     Throws if y is zero.
 
 .. function:: multiply(x: decimal(p1, s1), y: decimal(p2, s2)) -> r: decimal(p, s)
+   :noindex:
 
     Returns the result of multiplying x by y (r = x * y).
 
@@ -332,6 +334,7 @@ Decimal Functions
         pr = min(38, p - s + min(s, 1))
 
 .. function:: round(x: decimal(p, s), d: integer) -> r: decimal(rp, s)
+   :noindex:
 
     Returns 'x' rounded to 'd' decimal places. The scale of the result is
     the same as the scale of the input. The precision is calculated as:
@@ -361,6 +364,7 @@ Decimal Functions
         pr = max(p - s, 1)
 
 .. function:: truncate(x: decimal(p, s), d: integer) -> r: decimal(rp, s)
+   :noindex:
 
     Returns ``x`` truncated to ``d`` decimal places.
     The precision and scale of the result are the same as the precision and scale of the input.

--- a/velox/docs/functions/presto/geospatial.rst
+++ b/velox/docs/functions/presto/geospatial.rst
@@ -268,6 +268,7 @@ Accessors
    return an error if the input geometry is not a LineString or MultiLineString.
 
 .. function:: ST_Length(sphericalgeography: SphericalGeography) -> length: double
+   :noindex:
 
     Returns the length of a ``LineString`` or ``MultiLineString`` on a spherical model of the
     Earth. This is equivalent to the sum of great-circle distances between adjacent points
@@ -323,6 +324,7 @@ Accessors
     return 0.
 
 .. function:: ST_Area(sphericalgeography: SphericalGeography) -> area: double
+   :noindex:
 
     Returns the area of a polygon or multi-polygon in square meters using a spherical model for Earth.
 
@@ -332,6 +334,7 @@ Accessors
     Empty geometry inputs result in null output.
 
 .. function:: ST_Centroid(SphericalGeography) -> Point
+   :noindex:
 
     Returns the point value that is the mathematical centroid of a spherical geometry.
     Empty geometry inputs result in null output.
@@ -349,6 +352,7 @@ Accessors
     between two geometries in projected units. Empty geometries result in null output.
 
 .. function:: ST_Distance(sphericalgeography1: SphericalGeography, sphericalgeography2: SphericalGeography) -> distance: double
+   :noindex:
 
     Returns the great-circle distance in meters between two SphericalGeography points.
 
@@ -478,6 +482,7 @@ Accessors
     must be less than or equal to the coordinate dimension.
 
 .. function:: ST_ExteriorRing(geometry: Geometry) -> output: Geometry
+   :noindex:
 
     Returns a line string representing the exterior ring of the input polygon.
 
@@ -553,6 +558,7 @@ for more details.
     described above.  Invalid parameters will return a User Error.
 
 .. function:: bing_tile(quadKey: varchar) -> tile: BingTile
+   :noindex:
 
     Creates a Bing tile object from a quadkey. An invalid quadkey will return a User Error.
 
@@ -562,6 +568,7 @@ for more details.
     by the latitude and longitude arguments at a given zoom level.
 
 .. function:: bing_tiles_around(latitude, longitude, zoom_level, radius_in_km) -> array(BingTile)
+   :noindex:
 
     Returns a minimum set of Bing tiles at specified zoom level that cover a circle of specified
     radius in km around a specified (latitude, longitude) point.
@@ -580,6 +587,7 @@ for more details.
     exception if tile is at zoom level 0.
 
 .. function:: bing_tile_parent(tile, parentZoom) -> parent: BingTile
+   :noindex:
 
     Returns the parent of the Bing tile at the specified lower zoom level.
     Throws an exception if parentZoom is less than 0, or parentZoom is greater
@@ -591,6 +599,7 @@ for more details.
     exception if tile is at max zoom level.
 
 .. function:: bing_tile_children(tile, childZoom) -> children: array(BingTile)
+   :noindex:
 
     Returns the children of the Bing tile at the specified higher zoom level.
     Throws an exception if childZoom is greater than the max zoom level, or
@@ -692,6 +701,7 @@ that use the token format.
     ``[0, 30]`` range.
 
 .. function:: s2_cells(geometry: Geometry, min_level: integer, max_level: integer, max_cells: integer) -> cell_ids: array(bigint)
+   :noindex:
 
     Returns a compact set of S2 cell IDs at mixed levels that cover the given
     geometry, similar to ``geometry_to_dissolved_bing_tiles``. The coverer uses

--- a/velox/docs/functions/presto/hyperloglog.rst
+++ b/velox/docs/functions/presto/hyperloglog.rst
@@ -67,6 +67,7 @@ Functions
     the range of ``[0.0040625, 0.26000]``.
 
 .. function:: merge(HyperLogLog) -> HyperLogLog
+   :noindex:
 
     Returns the ``HyperLogLog`` of the aggregate union of the individual ``hll``
     HyperLogLog structures.

--- a/velox/docs/functions/presto/ipaddress.rst
+++ b/velox/docs/functions/presto/ipaddress.rst
@@ -43,6 +43,7 @@ IP Functions
         SELECT is_subnet_of(IPPREFIX '64:fa9b::17/64', IPADDRESS '64:ffff::17'); -- false
 
 .. function:: is_subnet_of(ip_prefix1, ip_prefix2) -> boolean
+   :noindex:
 
     Returns ``true`` if ``ip_prefix2`` is a subnet of ``ip_prefix1``. ::
 
@@ -81,6 +82,7 @@ IP Functions
         SELECT ip_version(IPADDRESS '2001:db8::1'); -- 6
 
 .. function:: ip_version(ip_prefix) -> bigint
+   :noindex:
 
     Returns ``4`` if ``ip_prefix`` contains an IPv4 address, ``6`` if it contains an IPv6 address.
     IPv4-mapped IPv6 prefixes are treated as IPv4.

--- a/velox/docs/functions/presto/khyperloglog.rst
+++ b/velox/docs/functions/presto/khyperloglog.rst
@@ -27,6 +27,7 @@ Aggregate Functions
     the unique identifiers associated with each key.
 
 .. function:: merge(KHyperLogLog) -> KHyperLogLog
+   :noindex:
 
     Returns the ``KHyperLogLog`` of the aggregate union of the individual ``KHyperLogLog``
     structures.
@@ -35,6 +36,7 @@ Scalar Functions
 ----------------
 
 .. function:: cardinality(khll) -> bigint
+   :noindex:
 
     Returns the estimated total cardinality (number of unique keys) from the
     ``KHyperLogLog`` sketch ``khll``.

--- a/velox/docs/functions/presto/math.rst
+++ b/velox/docs/functions/presto/math.rst
@@ -3,6 +3,7 @@ Mathematical Functions
 ====================================
 
 .. function:: abs(x) -> [same as x]
+   :noindex:
 
     Returns the absolute value of ``x``.
 
@@ -11,6 +12,7 @@ Mathematical Functions
     Returns the cube root of ``x``.
 
 .. function:: ceil(x) -> [same as x]
+   :noindex:
 
     This is an alias for :func:`ceiling`.
 
@@ -39,6 +41,7 @@ Mathematical Functions
         SELECT cosine_similarity(MAP(ARRAY[], ARRAY[]), MAP(ARRAY['a', 'b'], ARRAY[2, 3])); -- NaN
 
 .. function:: cosine_similarity(array(double), array(double)) -> double
+   :noindex:
 
     Returns the `cosine similarity <https://en.wikipedia.org/wiki/Cosine_similarity>`_ between the vectors represented as array(double).
     If any input array is empty, the function returns NaN. If the input arrays have different sizes, the function throws VeloxUserError.
@@ -52,6 +55,7 @@ Mathematical Functions
         SELECT cosine_similarity(ARRAY[], ARRAY[]); -- NaN
 
 .. function:: cosine_similarity(array(real), array(real)) -> real
+   :noindex:
 
     Returns the `cosine similarity <https://en.wikipedia.org/wiki/Cosine_similarity>`_ between the vectors represented as array(real).
     If any input array is empty, the function returns NaN. If the input arrays have different sizes, the function throws VeloxUserError.
@@ -70,11 +74,13 @@ Mathematical Functions
         SELECT l2_squared(ARRAY[], ARRAY[]); -- NaN
 
 .. function:: l2_squared(array(double), array(double)) -> double
+   :noindex:
 
     Returns the squared `Euclidean distance <https://en.wikipedia.org/wiki/Euclidean_distance>`_ between the vectors represented as array(double).
     If any input array is empty, the function returns NaN. If the input arrays have different sizes, the function throws VeloxUserError.
 
 .. function:: dot_product(array(real), array(real)) -> real
+   :noindex:
 
     Returns the `Dot Product <https://en.wikipedia.org/wiki/Dot_product>`_ between the vectors represented as array(real).
     If any input array is empty, the function returns NaN. If the input arrays have different sizes, the function throws VeloxUserError.
@@ -88,6 +94,7 @@ Mathematical Functions
         SELECT dot_product(ARRAY[], ARRAY[]); -- NaN
 
 .. function:: dot_product(array(double), array(double)) -> double
+   :noindex:
 
     Returns the `Dot Product <https://en.wikipedia.org/wiki/Dot_product>`_ between the vectors represented as array(double).
     If any input array is empty, the function returns NaN. If the input arrays have different sizes, the function throws VeloxUserError.
@@ -97,6 +104,7 @@ Mathematical Functions
     Converts angle x in radians to degrees.
 
 .. function:: divide(x, y) -> [same as x]
+   :noindex:
 
     Returns the results of dividing x by y. The types of x and y must be the same.
     The result of dividing by zero depends on the input types. For integral types,
@@ -113,6 +121,7 @@ Mathematical Functions
     Returns Euler's number raised to the power of ``x``.
 
 .. function:: floor(x) -> [same as x]
+   :noindex:
 
     Returns ``x`` rounded down to the nearest integer.
 
@@ -133,6 +142,7 @@ Mathematical Functions
     Returns the base 10 logarithm of ``x``.
 
 .. function:: minus(x, y) -> [same as x]
+   :noindex:
 
     Returns the result of subtracting y from x. The types of x and y must be the same.
     For integral types, overflow results in an error.
@@ -142,11 +152,13 @@ Mathematical Functions
     Returns the modulus (remainder) of ``n`` divided by ``m``.
 
 .. function:: multiply(x, y) -> [same as x]
+   :noindex:
 
     Returns the result of multiplying x by y. The types of x and y must be the same.
     For integral types, overflow results in an error.
 
 .. function:: negate(x) -> [same as x]
+   :noindex:
 
     Returns the additive inverse of x, e.g. the number that, when added to x, yields zero.
 
@@ -155,6 +167,7 @@ Mathematical Functions
     Returns the value of Pi.
 
 .. function:: plus(x, y) -> [same as x]
+   :noindex:
 
     Returns the result of adding x to y. The types of x and y must be the same.
     For integral types, overflow results in an error.
@@ -185,6 +198,7 @@ Mathematical Functions
     Returns a pseudo-random value in the range 0.0 <= x < n.
 
 .. function:: round(x) -> [same as x]
+   :noindex:
 
     Returns ``x`` rounded to the nearest integer.
 
@@ -202,6 +216,7 @@ Mathematical Functions
     Returns a cryptographically secure random value in the range 0.0 <= x < 1.0.
 
 .. function:: secure_random(lower, upper) -> [same as input]
+   :noindex:
 
     Returns a cryptographically secure random value in the range lower <= x < upper, where lower < upper.
 
@@ -226,6 +241,7 @@ Mathematical Functions
     Returns the base-``radix`` representation of ``x``. ``radix`` must be between 2 and 36.
 
 .. function:: truncate(x) -> [same as x]
+   :noindex:
 
     Returns x rounded to integer by dropping digits after decimal point.
     Supported types of ``x`` are: REAL and DOUBLE.
@@ -425,13 +441,6 @@ Probability Functions: inverse_cdf
     Compute the inverse of the Fisher F cdf with a given ``df1`` (numerator degrees of freedom) and ``df2`` (denominator degrees of freedom) parameters
     for the cumulative probability (p): P(N < n). The numerator and denominator df parameters must be positive real numbers.
     The probability ``p`` must lie on the interval [0, 1].
-
-.. function:: inverse_normal_cdf(mean, sd, p) -> double
-
-    Compute the inverse of the Normal cdf with given mean and standard
-    deviation (sd) for the cumulative probability (p): P(N < n). The mean must be
-    a real value and the standard deviation must be a real and positive value (both of type DOUBLE).
-    The probability p must lie on the interval (0, 1).
 
 .. function:: inverse_gamma_cdf(shape, scale, p) -> double
 

--- a/velox/docs/functions/presto/misc.rst
+++ b/velox/docs/functions/presto/misc.rst
@@ -7,14 +7,17 @@ Miscellaneous Functions
     Throws user error with the specified message.
 
 .. function:: fail(code, message)
+   :noindex:
 
     Throws user error with the specified message. Ignores 'code' argument.
 
 .. function:: fail(json)
+   :noindex:
 
     Throws user error with the message specified in 'message' field of the JSON.
 
 .. function:: fail(code, message)
+   :noindex:
 
     Throws user error with the message specified in 'message' field of the JSON.
     Ignores 'code' argument.

--- a/velox/docs/functions/presto/qdigest.rst
+++ b/velox/docs/functions/presto/qdigest.rst
@@ -33,6 +33,7 @@ Functions
 ---------
 
 .. function:: merge(qdigest<T>) -> qdigest<T>
+   :noindex:
 
     Merges all input ``qdigest``\ s into a single ``qdigest``.
 

--- a/velox/docs/functions/presto/regexp.rst
+++ b/velox/docs/functions/presto/regexp.rst
@@ -99,6 +99,7 @@ limited to 20 different expressions per instance and thread of execution.
         SELECT regexp_replace('[{}]', '\}\]', '\}'); -- '[{}'
 
 .. function:: regexp_replace(string, pattern, function) -> varchar
+   :noindex:
 
     Replaces every instance of the substring matched by the regular expression
     ``pattern`` in ``string`` using ``function``. The lambda expression

--- a/velox/docs/functions/presto/setdigest.rst
+++ b/velox/docs/functions/presto/setdigest.rst
@@ -42,12 +42,14 @@ Scalar Functions
 ----------------
 
 .. function:: cardinality(setdigest) -> bigint
+   :noindex:
 
     Returns the estimated cardinality of the set represented by the ``SetDigest`` sketch.
     If the digest is exact (low cardinality), returns the exact count.
     Otherwise, returns an approximation using HyperLogLog.
 
 .. function:: intersection_cardinality(setdigest1, setdigest2) -> bigint
+   :noindex:
 
     Returns the estimated intersection cardinality between two ``SetDigest`` sketches.
 
@@ -58,6 +60,7 @@ Scalar Functions
     ensure logical consistency.
 
 .. function:: jaccard_index(setdigest1, setdigest2) -> double
+   :noindex:
 
     Returns the Jaccard index (similarity coefficient) between two ``SetDigest`` sketches.
     The Jaccard index is a value in [0, 1] where:

--- a/velox/docs/functions/presto/string.rst
+++ b/velox/docs/functions/presto/string.rst
@@ -34,6 +34,7 @@ String Functions
     Returns the Unicode code point of the only character of ``string``.
 
 .. function:: concat(string1, ..., stringN) -> varchar
+   :noindex:
 
     Returns the concatenation of ``string1``, ``string2``, ``...``, ``stringN``.
     This function provides the same functionality as the
@@ -71,6 +72,7 @@ String Functions
     Returns the Jaro-Winkler similarity of ``string1`` and ``string2``.
 
 .. function:: length(string) -> bigint
+   :noindex:
 
     Returns the length of ``string`` in characters.
 
@@ -187,6 +189,7 @@ String Functions
     Raises an error if there are duplicate keys.
 
 .. function:: split_to_map(string, entryDelimiter, keyValueDelimiter, function(K,V1,V2,R)) -> map<varchar, varchar>
+   :noindex:
 
     Splits ``string`` by ``entryDelimiter`` and ``keyValueDelimiter`` and returns a map.
     ``entryDelimiter`` splits ``string`` into key-value pairs. ``keyValueDelimiter`` splits
@@ -311,6 +314,7 @@ String Functions
     the ``word`` in lowercase is returned.
 
 .. function:: word_stem(word, lang) -> varchar
+   :noindex:
 
     Returns the stem of ``word`` in the ``lang`` language. This function supports the following languages:
 
@@ -350,6 +354,7 @@ Unicode Functions
     Transforms ``string`` with NFC normalization form.
 
 .. function:: normalize(string, form) -> varchar
+   :noindex:
 
     Reference: https://unicode.org/reports/tr15/#Norm_Forms
     Transforms ``string`` with the specified normalization form.

--- a/velox/docs/functions/presto/tdigest.rst
+++ b/velox/docs/functions/presto/tdigest.rst
@@ -61,6 +61,7 @@ Functions
     * ``count`` - total count of values
 
 .. function:: merge(tdigest<double>) -> tdigest<double>
+   :noindex:
 
     Merges all input ``tdigest``\ s into a single ``tdigest``.
 
@@ -155,11 +156,13 @@ Functions
     means more accuracy at the cost of more memory.
 
 .. function:: value_at_quantile(digest: tdigest<double>, quantile: double) -> double
+   :noindex:
 
     Returns the approximate percentile value from the T-digest ``digest`` at the given ``quantile``.
     The ``quantile`` must be between zero and one (inclusive).
 
 .. function:: values_at_quantiles(digest: tdigest<double>, quantiles: array<double>) -> array<double>
+   :noindex:
 
     Returns the approximate percentile values as an array from the T-digest ``digest`` at each of the specified quantiles given in the ``quantiles`` array.
     All quantile values must be between zero and one (inclusive).

--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -474,6 +474,7 @@ These functions support TIMESTAMP and DATE input types.
         SELECT unix_timestamp(CAST(-1739933174 AS TIMESTAMP)); -- -1739933174
 
 .. function:: week_of_year(x) -> integer
+   :noindex:
 
     Returns the `ISO-Week`_ of the year from x. The value ranges from ``1`` to ``53``.
     A week is considered to start on a Monday and week 1 is the first week with >3 days.


### PR DESCRIPTION
Fixes all `WARNING: duplicate object description` warnings that appear
when building the Velox docs with Sphinx.

## Reproduce

```bash
pip install sphinx sphinx-rtd-theme
cd velox/docs

# Before — 88 duplicate warnings
make html 2>&1 | grep "duplicate" | wc -l  # 88

# After
make html 2>&1 | grep "duplicate" | wc -l  # 0
```

## Root cause

Sphinx builds a cross-reference index keyed on function base name. When
two `.. function::` directives share a name (e.g. `round` in `math.rst`
and `decimal.rst`, or `cardinality` across five files), Sphinx warns and
picks one arbitrarily for cross-references.

All duplicates are legitimate: overloaded signatures, type-specific
variants (decimal vs numeric), or engine-specific variants (Spark vs
Presto). The documentation text for each is distinct and should stay.

## Fix

- Add `:noindex:` to the secondary occurrence of every duplicated
  function name so Sphinx indexes only the primary entry while keeping
  all documentation text visible.
- Remove two true duplicates (identical signature and description):
  - `math.rst`: second copy of `inverse_normal_cdf` pasted in the wrong
    section
  - `geospatial.rst`: shorter, less-detailed second copy of
    `ST_ExteriorRing`

Closes #8117