### PR TITLE
test(parquet): Verify WriterOptions::encoding is forwarded to Arrow writer

### DIFF
--- a/velox/dwio/parquet/reader/Metadata.cpp
+++ b/velox/dwio/parquet/reader/Metadata.cpp
@@ -400,6 +400,10 @@ int64_t ColumnChunkMetaDataPtr::totalCompressedSize() const {
   return thriftColumnChunkPtr(ptr_)->meta_data.total_compressed_size;
 }
 
+std::vector<thrift::Encoding::type> ColumnChunkMetaDataPtr::encodings() const {
+  return thriftColumnChunkPtr(ptr_)->meta_data.encodings;
+}
+
 int64_t ColumnChunkMetaDataPtr::totalUncompressedSize() const {
   return thriftColumnChunkPtr(ptr_)->meta_data.total_uncompressed_size;
 }

--- a/velox/dwio/parquet/reader/Metadata.h
+++ b/velox/dwio/parquet/reader/Metadata.h
@@ -18,6 +18,7 @@
 
 #include "velox/dwio/common/Statistics.h"
 #include "velox/dwio/common/compression/Compression.h"
+#include "velox/dwio/parquet/thrift/ParquetThriftTypes.h"
 
 namespace facebook::velox::parquet {
 
@@ -63,6 +64,9 @@ class ColumnChunkMetaDataPtr {
 
   /// The compression.
   common::CompressionKind compression() const;
+
+  /// Returns the list of encodings used for all pages in this column chunk.
+  std::vector<thrift::Encoding::type> encodings() const;
 
   /// Total byte size of all the compressed (and potentially encrypted)
   /// column data in this row group.

--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -91,6 +91,29 @@ class E2EFilterTest : public E2EFilterTestBase,
     return std::make_unique<ParquetReader>(std::move(input), opts);
   }
 
+  // Returns true if the given encoding appears in the encodings list of the
+  // first column chunk of the first row group of the most recently written
+  // file. Uses ColumnChunkMetaDataPtr::encodings() — no PageReader needed.
+  bool columnChunkUsesEncoding(
+      facebook::velox::parquet::arrow::Encoding::type encoding) {
+    dwio::common::ReaderOptions readerOpts(leafPool_.get());
+    readerOpts.setDataIoStats(dataIoStats_);
+    readerOpts.setMetadataIoStats(metadataIoStats_);
+    auto reader = std::make_unique<ParquetReader>(
+        std::make_unique<dwio::common::BufferedInput>(
+            std::make_shared<InMemoryReadFile>(std::string(sinkData_)),
+            readerOpts.memoryPool()),
+        readerOpts);
+    const auto expected = static_cast<thrift::Encoding::type>(encoding);
+    for (const auto fileEncoding :
+         reader->fileMetaData().rowGroup(0).columnChunk(0).encodings()) {
+      if (fileEncoding == expected) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   std::shared_ptr<velox::io::IoStatistics> dataIoStats_ =
       std::make_shared<velox::io::IoStatistics>();
   std::shared_ptr<velox::io::IoStatistics> metadataIoStats_ =
@@ -130,6 +153,7 @@ TEST_F(E2EFilterTest, integerDeltaBinaryPack) {
   options_.enableDictionary = false;
   options_.encoding =
       facebook::velox::parquet::arrow::Encoding::kDeltaBinaryPacked;
+  const auto expectedEncoding = options_.encoding;
 
   testWithTypes(
       "short_val:smallint,"
@@ -140,6 +164,7 @@ TEST_F(E2EFilterTest, integerDeltaBinaryPack) {
       true,
       {"short_val", "int_val", "long_val"},
       20);
+  EXPECT_TRUE(columnChunkUsesEncoding(expectedEncoding));
 }
 
 TEST_F(E2EFilterTest, compression) {
@@ -519,6 +544,7 @@ TEST_F(E2EFilterTest, stringDeltaByteArray) {
   options_.enableDictionary = false;
   options_.encoding =
       facebook::velox::parquet::arrow::Encoding::kDeltaByteArray;
+  const auto expectedEncoding = options_.encoding;
 
   testWithTypes(
       "string_val:string,"
@@ -530,12 +556,14 @@ TEST_F(E2EFilterTest, stringDeltaByteArray) {
       true,
       {"string_val", "string_val_2"},
       20);
+  EXPECT_TRUE(columnChunkUsesEncoding(expectedEncoding));
 }
 
 TEST_F(E2EFilterTest, stringDeltaLengthByteArray) {
   options_.enableDictionary = false;
   options_.encoding =
       facebook::velox::parquet::arrow::Encoding::kDeltaLengthByteArray;
+  const auto expectedEncoding = options_.encoding;
 
   testWithTypes(
       "string_val:string,"
@@ -547,6 +575,7 @@ TEST_F(E2EFilterTest, stringDeltaLengthByteArray) {
       true,
       {"string_val", "string_val_2"},
       20);
+  EXPECT_TRUE(columnChunkUsesEncoding(expectedEncoding));
 }
 
 TEST_F(E2EFilterTest, dedictionarize) {
@@ -724,6 +753,12 @@ TEST_F(E2EFilterTest, time) {
         false,
         {"time_val"},
         20);
+    // kPlain always appears in the encodings list (dictionary pages use PLAIN),
+    // so skip the check for it — it would pass regardless of whether the option
+    // was forwarded.
+    if (testCase.encoding != parquet::arrow::Encoding::kPlain) {
+      EXPECT_TRUE(columnChunkUsesEncoding(testCase.encoding));
+    }
   }
 }
 
@@ -772,6 +807,12 @@ TEST_F(E2EFilterTest, timeMicros) {
         false,
         {"time_val"},
         20);
+    // kPlain always appears in the encodings list (dictionary pages use PLAIN),
+    // so skip the check for it — it would pass regardless of whether the option
+    // was forwarded.
+    if (testCase.encoding != parquet::arrow::Encoding::kPlain) {
+      EXPECT_TRUE(columnChunkUsesEncoding(testCase.encoding));
+    }
   }
 }
 
@@ -900,6 +941,7 @@ TEST_F(E2EFilterTest, booleanRle) {
   options_.enableDictionary = false;
   options_.encoding = facebook::velox::parquet::arrow::Encoding::kRle;
   options_.useParquetDataPageV2 = true;
+  const auto expectedEncoding = options_.encoding;
 
   testWithTypes(
       "boolean_val:boolean,"
@@ -908,6 +950,7 @@ TEST_F(E2EFilterTest, booleanRle) {
       false,
       {"boolean_val"},
       20);
+  EXPECT_TRUE(columnChunkUsesEncoding(expectedEncoding));
 }
 
 // Define main so that gflags get processed.


### PR DESCRIPTION
## Summary

`WriterOptions::encoding` is wired in `Writer.cpp` as:

```cpp
properties = properties->encoding(options.encoding);
```

Several `E2EFilterTest` tests already write with non-default encodings
(`kDeltaBinaryPacked`, `kDeltaByteArray`, `kDeltaLengthByteArray`,
`kRle`) and verify data correctness via `testWithTypes`, but none of
them verified the encoding was actually forwarded. Data reads back
correctly regardless of what encoding is used, so a silent fallback to
`PLAIN` (e.g. if the wiring line above were accidentally deleted) would
have gone undetected — all tests would still pass.

## Changes

**`Metadata.h` / `Metadata.cpp`**
Add `ColumnChunkMetaDataPtr::encodings()` that returns the thrift column
chunk's `meta_data.encodings` list directly from file metadata. No
`PageReader` or raw byte seeking needed.

**`E2EFilterTest.cpp`**
Add `columnChunkUsesEncoding()` helper that creates a `ParquetReader`
from `sinkData_`, reads `rowGroup(0).columnChunk(0).encodings()`, and
returns whether the given encoding appears in the list.

Add `EXPECT_TRUE(columnChunkUsesEncoding(expectedEncoding))` to all six
tests that explicitly set `options_.encoding`:
`integerDeltaBinaryPack`, `stringDeltaByteArray`,
`stringDeltaLengthByteArray`, `booleanRle`, and the `time`/`timeMicros`
loop tests. For the loop tests, the check is skipped for `kPlain`
iterations — PLAIN always appears in the column chunk encodings list
(dictionary pages use PLAIN), so the assertion would be trivially true
and tests nothing. The check runs for `kDeltaBinaryPacked` iterations
where it is meaningful.

For single tests, `expectedEncoding` is captured before calling
`testWithTypes` to be robust against any future modification of
`options_` inside the framework.

## Test plan

- All six tests pass locally.
- Removing `Writer.cpp:156` (`properties->encoding(options.encoding)`)
  causes `integerDeltaBinaryPack` to fail: Arrow falls back to `PLAIN`,
  so `DELTA_BINARY_PACKED` is absent from the encodings list and
  `columnChunkUsesEncoding` returns `false`. Without this PR the test
  would still pass — `testWithTypes` checks data correctness, not encoding.

Closes #9499