### PR TITLE
fix: Surface `readGapBytes` stat in `HiveIndexSource::runtimeStats()`

### DIFF
--- a/velox/connectors/hive/HiveIndexSource.cpp
+++ b/velox/connectors/hive/HiveIndexSource.cpp
@@ -1167,6 +1167,15 @@ std::unordered_map<std::string, RuntimeMetric> HiveIndexSource::runtimeStats() {
           static_cast<int64_t>(ssdRead.max()),
           RuntimeCounter::Unit::kBytes);
     }
+    const auto& readGap = ioStatistics_->readGap();
+    if (readGap.count() > 0) {
+      stats[std::string(FileDataSource::kReadGapBytes)] = RuntimeMetric(
+          static_cast<int64_t>(readGap.sum()),
+          readGap.count(),
+          static_cast<int64_t>(readGap.min()),
+          static_cast<int64_t>(readGap.max()),
+          RuntimeCounter::Unit::kBytes);
+    }
   }
 
   return stats;


### PR DESCRIPTION
Summary:
`HiveIndexSource::runtimeStats()` was missing the `readGapBytes` IO stat. Unlike `FileDataSource` which calls `addIoStatsToRuntimeStats()` to extract all IO counters, `HiveIndexSource` manually extracts only `read()`, `ramHit()`, and `ssdRead()` from `ioStatistics_`. The `readGap()` counter was being populated by the IO coalescing layer but never surfaced in the runtime stats.

Add `readGap()` extraction alongside the existing IO stat blocks.

Reviewed By: tanjialiang

Differential Revision: D106950810


