### PR TITLE
Add string-keyed attributes field for Iceberg V3 interop

### DIFF
--- a/velox/dwio/dwrf/proto/dwrf_proto.proto
+++ b/velox/dwio/dwrf/proto/dwrf_proto.proto
@@ -160,6 +160,15 @@ message StripeFooter {
   repeated bytes encryptionGroups = 3;
 }
 
+// A generic string-keyed attribute pair attached to a schema node.
+// Wire-layout-compatible with Apache ORC's `StringPair` so DWRF and ORC
+// can carry the same per-Type attribute bag (e.g. Iceberg field-id
+// metadata: `iceberg.id`, `iceberg.required`, `iceberg.long-type`, etc).
+message StringPair {
+  optional string key = 1;
+  optional string value = 2;
+}
+
 message Type {
   enum Kind {
     BOOLEAN = 0;
@@ -180,6 +189,24 @@ message Type {
   required Kind kind = 1;
   repeated uint32 subtypes = 2 [ packed = true ];
   repeated string fieldNames = 3;
+  // Slots 4, 5, 6 are intentionally reserved to remain wire-layout-aligned
+  // with Apache ORC's `Type.maximumLength`, `Type.precision`, `Type.scale`
+  // (orc_proto.proto). DWRF does not use them today but reserving them
+  // keeps `attributes` at the same field number as ORC.
+  // reserved 4, 5, 6;
+  // Per-Type string-keyed attribute bag. Matches Apache ORC's
+  // `Type.attributes` (slot 7). Iceberg V3 stores its column id and type
+  // disambiguation metadata here, per the Iceberg spec's ORC mapping
+  // (Appendix A: Format-specific Requirements -> ORC):
+  //   - iceberg.id            : decimal-string field id (e.g. "12")
+  //   - iceberg.required      : "true" / "false"
+  //   - iceberg.long-type     : "LONG"
+  //   - iceberg.timestamp-unit: "MICROS" / "NANOS"
+  //   - iceberg.binary-type   : FIXED / UUID / Variant disambiguation
+  //   - iceberg.length        : decimal-string width for FIXED
+  //   - iceberg.struct-type   : enum string for Variant
+  // Optional; old readers ignore unknown fields (proto2 wire compat).
+  repeated StringPair attributes = 7;
 }
 
 message StripeInformation {

--- a/velox/dwio/dwrf/test/CommonTests.cpp
+++ b/velox/dwio/dwrf/test/CommonTests.cpp
@@ -181,4 +181,112 @@ TEST_F(
     EXPECT_EQ(stream.kind(), veloxStreamKind);
   }
 }
+// ---------------------------------------------------------------------------
+// Iceberg V3 interop: per-Type `attributes` field on the DWRF `Type` proto.
+//
+// The Iceberg spec (Appendix A: Format-specific Requirements -> ORC) requires
+// ORC-family Iceberg files to encode their column ids and type-disambiguation
+// metadata as string-keyed attributes on each schema node. DWRF and NIMBLE
+// files are reported as `FileFormat.ORC` in Iceberg manifests, so they must
+// carry the same attribute bag to be Iceberg-spec compliant. The tests below
+// pin the wire-format invariants this depends on.
+// ---------------------------------------------------------------------------
+
+TEST_F(CommonTest, TypeAttributesFieldNumberMatchesApacheOrc) {
+  // Apache ORC's Type.attributes lives at proto field number 7. Keeping our
+  // slot number aligned is what lets a spec-compliant external reader -- one
+  // that only knows Apache ORC -- consume our DWRF files (manifest-tagged as
+  // ORC) and find `iceberg.id` where it expects to. If this assertion ever
+  // changes, the property-bag contract with the Iceberg spec is broken.
+  EXPECT_EQ(proto::Type::kAttributesFieldNumber, 7);
+  EXPECT_EQ(proto::StringPair::kKeyFieldNumber, 1);
+  EXPECT_EQ(proto::StringPair::kValueFieldNumber, 2);
+}
+
+TEST_F(CommonTest, TypeAttributesEmptyByDefaultForBackwardCompat) {
+  // Existing DWRF files do not set `attributes`. Verify that a freshly
+  // constructed Type behaves as if the field is absent (empty list, no
+  // attributes considered present). This protects the no-op upgrade path for
+  // every DWRF file written before this proto bump.
+  proto::Type type;
+  type.set_kind(proto::Type_Kind_LONG);
+  EXPECT_EQ(type.attributes_size(), 0);
+
+  std::string bytes;
+  ASSERT_TRUE(type.SerializeToString(&bytes));
+
+  proto::Type parsed;
+  ASSERT_TRUE(parsed.ParseFromString(bytes));
+  EXPECT_EQ(parsed.attributes_size(), 0);
+  EXPECT_EQ(parsed.kind(), proto::Type_Kind_LONG);
+}
+
+TEST_F(CommonTest, TypeAttributesRoundTripIcebergV3Keys) {
+  // All Iceberg V3 attribute keys round-trip through the proto with string
+  // values, matching the encoding documented in Iceberg's ORC mapping and
+  // produced by Presto-Iceberg's TypeConverter (see ORC_ICEBERG_ID_KEY /
+  // ORC_ICEBERG_REQUIRED_KEY in presto-iceberg's TypeConverter.java).
+  proto::Type type;
+  type.set_kind(proto::Type_Kind_LONG);
+
+  const std::vector<std::pair<std::string, std::string>> kIcebergAttrs = {
+      {"iceberg.id", "12"},
+      {"iceberg.required", "true"},
+      {"iceberg.long-type", "LONG"},
+      {"iceberg.timestamp-unit", "NANOS"},
+      {"iceberg.binary-type", "UUID"},
+      {"iceberg.length", "16"},
+      {"iceberg.struct-type", "Variant"},
+  };
+  for (const auto& [k, v] : kIcebergAttrs) {
+    auto* attr = type.add_attributes();
+    attr->set_key(k);
+    attr->set_value(v);
+  }
+
+  std::string bytes;
+  ASSERT_TRUE(type.SerializeToString(&bytes));
+
+  proto::Type parsed;
+  ASSERT_TRUE(parsed.ParseFromString(bytes));
+  ASSERT_EQ(parsed.attributes_size(), static_cast<int>(kIcebergAttrs.size()));
+  for (size_t i = 0; i < kIcebergAttrs.size(); ++i) {
+    EXPECT_EQ(parsed.attributes(i).key(), kIcebergAttrs[i].first);
+    EXPECT_EQ(parsed.attributes(i).value(), kIcebergAttrs[i].second);
+  }
+}
+
+TEST_F(CommonTest, TypeAttributesUnknownFieldFromOldReaderIsPreserved) {
+  // proto2 forward compatibility: bytes carrying `attributes` produced by a
+  // new writer must round-trip cleanly through a Type containing only
+  // recognized fields. The unknown-field set keeps the bytes intact so a
+  // pass-through reader does not silently strip Iceberg metadata.
+  proto::Type writerType;
+  writerType.set_kind(proto::Type_Kind_LONG);
+  auto* attr = writerType.add_attributes();
+  attr->set_key("iceberg.id");
+  attr->set_value("42");
+
+  std::string bytes;
+  ASSERT_TRUE(writerType.SerializeToString(&bytes));
+
+  // Parse, then re-serialize. The repeated `attributes` field must be
+  // emitted again byte-for-byte. (We compare normalized re-serialization
+  // rather than the raw byte sequence because protobuf does not guarantee
+  // canonical encoding ordering across versions.)
+  proto::Type roundTripped;
+  ASSERT_TRUE(roundTripped.ParseFromString(bytes));
+  ASSERT_EQ(roundTripped.attributes_size(), 1);
+  EXPECT_EQ(roundTripped.attributes(0).key(), "iceberg.id");
+  EXPECT_EQ(roundTripped.attributes(0).value(), "42");
+
+  std::string reSerialized;
+  ASSERT_TRUE(roundTripped.SerializeToString(&reSerialized));
+  proto::Type secondParse;
+  ASSERT_TRUE(secondParse.ParseFromString(reSerialized));
+  ASSERT_EQ(secondParse.attributes_size(), 1);
+  EXPECT_EQ(secondParse.attributes(0).key(), "iceberg.id");
+  EXPECT_EQ(secondParse.attributes(0).value(), "42");
+}
+
 } // namespace facebook::velox::dwrf


### PR DESCRIPTION
Summary:
Add a `repeated StringPair attributes` (proto) / `attributes:[StringPair]`
(flatbuffer) slot to the per-schema-node messages in DWRF and NIMBLE so
both formats can carry the same per-column metadata bag that Apache ORC
carries today.

This is the wire-format prerequisite for Iceberg V3 field-id support in
DWRF and NIMBLE. Per the Apache Iceberg spec (Appendix A: Format-specific
Requirements -> ORC, https://iceberg.apache.org/spec/), ORC-family Iceberg
files encode their column ids and type-disambiguation metadata as
string-keyed attributes on each schema node:

  iceberg.id             : decimal-string field id, e.g. "12"
  iceberg.required       : "true" / "false"
  iceberg.long-type      : "LONG"
  iceberg.timestamp-unit : "MICROS" / "NANOS" (V3)
  iceberg.binary-type    : FIXED / UUID / Variant disambiguation
  iceberg.length         : decimal-string width for FIXED
  iceberg.struct-type    : enum string for Variant

Iceberg currently reports DWRF and NIMBLE files as `FileFormat.ORC` in
manifests (the upstream spec has no DWRF/NIMBLE enum), so any
spec-compliant external reader -- Spark, Trino, Iceberg-Java,
Iceberg-Python -- that picks one of our files up dispatches to its ORC
reader and looks for `iceberg.id` on the per-Type attribute map. Without
this slot DWRF/NIMBLE cannot represent Iceberg V3 field ids in a way that
is observable to any reader outside the Velox/Prestissimo stack.

Changes:

1. `velox/dwio/dwrf/proto/dwrf_proto.proto`:
   - Add `message StringPair { optional string key = 1;
     optional string value = 2; }`.
   - Add `repeated StringPair attributes = 7;` to `message Type`.
   - Field number 7 matches Apache ORC's `Type.attributes` slot. Slots
     4, 5, 6 are intentionally left open (commented) to remain
     wire-layout-aligned with ORC's `maximumLength`, `precision`, `scale`
     so a future ORC-shaped extension can land cleanly.

2. `fbjava/bbio/hive-dwrf/proto/orc_proto.proto`: identical change for
   the Java hive-dwrf proto (kept in sync with the Velox proto).

3. `dwio/nimble/velox/Schema.fbs`:
   - Add `table StringPair { key:string; value:string; }`.
   - Add `attributes:[StringPair];` to `table SchemaNode`, appended at
     the end of the table so existing files (no `attributes` set) round-
     trip through new readers and old readers ignore the new field
     (standard flatbuffer wire-compat for trailing optional fields).

Wire compatibility:
  - DWRF/ORC proto: `optional` / `repeated` proto2 fields with new field
    numbers are forward+backward compatible. Existing DWRF/ORC files
    have no `attributes` set and old readers ignore the new tag.
  - NIMBLE flatbuffer: appended fields on a `table` are forward+backward
    compatible. Existing NIMBLE files round-trip unchanged.

Out of scope (follow-up diffs):
  - DWRF writer plumbing: a per-column attributes input on
    `dwrf::WriterOptions` and the schema-emit path that calls
    `Type::add_attributes(...)` per node when writing the footer.
  - DWRF reader plumbing: extend `ColumnMappingMode` with a new
    `kIcebergFieldId` mode that resolves projected columns by reading
    `attributes["iceberg.id"]` instead of by position. Today
    `DwrfReader.cpp:865-871` rejects `kParquetFieldId` outright; that
    rejection becomes obsolete once the new mode lands.
  - NIMBLE writer/reader plumbing: `SchemaNode` in
    `dwio/nimble/velox/SchemaTypes.h` does not yet carry attributes;
    `SchemaBuilder`, `SchemaSerialization`, and the Velox reader path
    need parallel changes to round-trip the new flatbuffer field.
  - `IcebergDataSink` wiring: a DWRF and NIMBLE branch in
    `createWriterOptions()` to propagate
    `IcebergColumnHandle::field()` into the new options field --
    analogous to the existing Parquet branch
    (`IcebergDataSink.cpp:427-434`).
  - `IcebergSplitReader` wiring: set the new column-mapping mode on
    DWRF/NIMBLE splits and supply the table-side field-id tree.
  - `IcebergDwrfStatsCollector` / `IcebergNimbleStatsCollector` to
    aggregate per-field-id stats from the file footer.

Relation to D106713217: this supersedes D106713217's
`optional uint32 field_id = 4` approach. That dedicated proto slot
would be invisible to any Iceberg-spec-compliant reader (they look on
the attribute bag for `iceberg.id`), so it would not carry forward to
non-Meta engines that pick up DWRF files manifest-tagged as ORC. The
attribute-bag approach in this diff is what the OSS Iceberg Java
`org.apache.iceberg.orc.ORCSchemaUtil`, the Apache ORC reference test
suites, and the Presto-Iceberg `TypeConverter` (`ORC_ICEBERG_ID_KEY =
"iceberg.id"`) all already produce and consume.

Differential Revision: D107136290


