### PR TITLE
fix(dwio): Fix use-after-free in `prepareKeyPredicate<StringView>`

### DIFF
--- a/velox/dwio/common/FlatMapHelper.h
+++ b/velox/dwio/common/FlatMapHelper.h
@@ -144,6 +144,33 @@ class KeyValue {
   }
 };
 
+// Specialization for StringView that owns the string data. The generic
+// KeyValue<StringView> would store a non-owning StringView, which leads to
+// use-after-free when the source string is destroyed (e.g., when a
+// folly::dynamic from JSON parsing goes out of scope).
+template <>
+class KeyValue<StringView> {
+ private:
+  std::string owned_;
+  size_t h_;
+
+ public:
+  explicit KeyValue(StringView value)
+      : owned_(value), h_{std::hash<StringView>()(value)} {}
+
+  StringView get() const {
+    return StringView(owned_);
+  }
+
+  std::size_t hash() const {
+    return h_;
+  }
+
+  bool operator==(const KeyValue<StringView>& other) const {
+    return owned_ == other.owned_;
+  }
+};
+
 template <typename T>
 struct KeyValueHash {
   std::size_t operator()(const KeyValue<T>& kv) const {
@@ -172,7 +199,7 @@ struct KeyProjection {
 template <typename T>
 KeyProjection<T> convertDynamic(const folly::dynamic& v) {
   constexpr char reject_prefix = '!';
-  const auto str = v.asString();
+  const auto& str = v.asString();
   const std::string_view view(str);
   if (!view.empty() && view.front() == reject_prefix) {
     return {

--- a/velox/dwio/common/SelectiveStructColumnReader.h
+++ b/velox/dwio/common/SelectiveStructColumnReader.h
@@ -506,7 +506,7 @@ void SelectiveFlatMapColumnReaderHelper<T, KeyNode, FormatData>::copyValues(
       flatKeys->addStringBuffer(buf);
       strKeySize = 0;
       for (int k = 0; k < reader_.children_.size(); ++k) {
-        auto& s = keyNodes_[k].key.get();
+        auto s = keyNodes_[k].key.get();
         if (!s.isInline()) {
           memcpy(&rawStrKeyBuffer[strKeySize], s.data(), s.size());
           strKeySize += s.size();

--- a/velox/dwio/common/tests/ColumnSelectorTests.cpp
+++ b/velox/dwio/common/tests/ColumnSelectorTests.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 #include "velox/common/base/VeloxException.h"
 #include "velox/dwio/common/ColumnSelector.h"
+#include "velox/dwio/common/FlatMapHelper.h"
 #include "velox/type/Type.h"
 #include "velox/type/fbhive/HiveTypeParser.h"
 
@@ -680,4 +681,42 @@ TEST(TestColumnSelector, fileColumnNamesReadAsLowerCaseDuplicateColFilters) {
   EXPECT_THROW(
       ColumnSelector cs(schema, std::vector<std::string>{"id"}, nullptr, true),
       facebook::velox::VeloxException);
+}
+
+using facebook::velox::StringView;
+using namespace facebook::velox::dwio::common::flatmap;
+
+TEST(ColumnSelectorTests, prepareKeyPredicateStringViewOwnership) {
+  // Verify that KeyPredicate<StringView> correctly owns the string data from
+  // the JSON expression. Without the fix, convertDynamic<StringView> returned
+  // a StringView pointing to a local std::string that was destroyed on return,
+  // causing heap-use-after-free when the predicate was later evaluated.
+  // Keys must exceed SSO threshold (~22 chars) to trigger heap allocation,
+  // otherwise ASan cannot detect the use-after-free.
+  auto predicate = prepareKeyPredicate<StringView>(
+      R"(["key_alpha_long_name_for_testing", "key_beta_long_name_for_testing", "key_gamma_long_name_for_testing"])");
+
+  // Allocate strings to overwrite any freed memory from folly::dynamic.
+  std::vector<std::string> overwrite(
+      100, "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ");
+
+  EXPECT_TRUE(predicate(
+      KeyValue<StringView>(StringView("key_alpha_long_name_for_testing"))));
+  EXPECT_TRUE(predicate(
+      KeyValue<StringView>(StringView("key_beta_long_name_for_testing"))));
+  EXPECT_TRUE(predicate(
+      KeyValue<StringView>(StringView("key_gamma_long_name_for_testing"))));
+  EXPECT_FALSE(predicate(
+      KeyValue<StringView>(StringView("key_delta_long_name_for_testing"))));
+  EXPECT_FALSE(predicate(KeyValue<StringView>(StringView("other_long_key"))));
+}
+
+TEST(ColumnSelectorTests, prepareKeyPredicateStringViewRejectMode) {
+  auto predicate = prepareKeyPredicate<StringView>(
+      R"(["!rejected_key_long_name_for_testing"])");
+
+  EXPECT_TRUE(predicate(
+      KeyValue<StringView>(StringView("any_other_key_long_name_testing"))));
+  EXPECT_FALSE(predicate(
+      KeyValue<StringView>(StringView("rejected_key_long_name_for_testing"))));
 }

--- a/velox/dwio/dwrf/reader/FlatMapColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/FlatMapColumnReader.cpp
@@ -34,7 +34,7 @@ StringKeyBuffer::StringKeyBuffer(
     : data_{pool, nodes.size() + 1} {
   uint64_t size = 0;
   for (auto& node : nodes) {
-    auto& str = node->getKey().get();
+    auto str = node->getKey().get();
     size += str.size();
   }
   buffer_ = AlignedBuffer::allocate<char>(size, &pool);
@@ -43,7 +43,7 @@ StringKeyBuffer::StringKeyBuffer(
   uint32_t ordinal = 0;
   for (auto& node : nodes) {
     node->setOrdinal(ordinal);
-    auto& str = node->getKey().get();
+    auto str = node->getKey().get();
     std::memcpy(data, str.data(), str.size());
     data_[ordinal++] = data;
     data += str.size();


### PR DESCRIPTION
Summary:
`convertDynamic<StringView>` in `FlatMapHelper.h` created a `KeyValue<StringView>` containing a `StringView` pointing to a local `std::string` copy of `v.asString()`. The `StringView` dangled the moment `convertDynamic` returned. The `KeyPredicate`'s allowlist hash set held these dangling `StringView`s, causing key filter comparisons to read freed memory when matching flatmap keys during struct encoding reads.

Depending on what happened to occupy the freed memory, different keys would match or not match the projection filter, producing wrong flatmap-as-struct column assignments.

Fix: specialize `KeyValue<StringView>` to store an owned `std::string` instead of a non-owning `StringView`. This fixes the lifetime issue at the root — every `KeyValue<StringView>` now owns its data, so `convertDynamic`, `prepareKeyPredicate`, `KeyPredicate`, and all other users are safe without any changes. Also fix `convertDynamic` to use `const auto&` for `v.asString()` to avoid the unnecessary copy that created the dangling pointer.

Differential Revision: D107163687


