### PR TITLE
perf: Remove TraceContext from DWIO I/O hot paths

### DIFF
--- a/velox/dwio/common/CacheInputStream.cpp
+++ b/velox/dwio/common/CacheInputStream.cpp
@@ -16,7 +16,6 @@
 
 #include <folly/executors/QueuedImmediateExecutor.h>
 
-#include "velox/common/process/TraceContext.h"
 #include "velox/common/time/Timer.h"
 #include "velox/dwio/common/CacheInputStream.h"
 #include "velox/dwio/common/CachedBufferedInput.h"
@@ -177,7 +176,6 @@ void CacheInputStream::setRemainingBytes(uint64_t remainingBytes) {
 }
 
 void CacheInputStream::loadSync(const Region& region) {
-  process::TraceContext trace("loadSync");
   int64_t hitSize = region.length;
   if (window_.has_value()) {
     const int64_t regionEnd = region.offset + region.length;
@@ -292,7 +290,7 @@ bool CacheInputStream::loadFromSsd(
     file.load(ssdPins, pins);
   } catch (const std::exception& e) {
     LOG(ERROR) << "IOERR: Failed SSD loadSync " << entry.toString() << ' '
-               << e.what() << process::TraceContext::statusLine()
+               << e.what()
                << fmt::format(
                       "stream region {} {}b, start of load {} file {}",
                       region_.offset,

--- a/velox/dwio/common/CachedBufferedInput.cpp
+++ b/velox/dwio/common/CachedBufferedInput.cpp
@@ -18,7 +18,6 @@
 #include "folly/io/Cursor.h"
 #include "velox/common/Casts.h"
 #include "velox/common/memory/Allocation.h"
-#include "velox/common/process/TraceContext.h"
 #include "velox/common/time/Timer.h"
 #include "velox/dwio/common/CacheInputStream.h"
 
@@ -583,7 +582,6 @@ void CachedBufferedInput::readRegions(
       if (load->state() == CoalescedLoad::State::kPlanned) {
         executor_->add(
             [pendingLoad = load, ssdSavable = options_.cacheable()]() {
-              process::TraceContext trace("Read Ahead");
               pendingLoad->loadOrFuture(nullptr, ssdSavable);
             });
       }

--- a/velox/dwio/common/ColumnLoader.cpp
+++ b/velox/dwio/common/ColumnLoader.cpp
@@ -16,8 +16,6 @@
 
 #include "velox/dwio/common/ColumnLoader.h"
 
-#include "velox/common/process/TraceContext.h"
-
 namespace facebook::velox::dwio::common {
 
 namespace {
@@ -94,7 +92,6 @@ void ColumnLoader::loadInternal(
     ValueHook* hook,
     vector_size_t resultSize,
     VectorPtr* result) {
-  process::TraceContext trace("ColumnLoader::loadInternal");
   ExceptionContextSetter exceptionContext(
       {[](VeloxException::Type /*exceptionType*/, auto* reader) {
          return static_cast<SelectiveStructColumnReaderBase*>(reader)
@@ -121,7 +118,6 @@ void TransformColumnLoader::loadInternal(
     ValueHook* hook,
     vector_size_t resultSize,
     VectorPtr* result) {
-  process::TraceContext trace("TransformColumnLoader::loadInternal");
   VectorPtr fileResult;
   ColumnLoader::loadInternal(rows, hook, resultSize, &fileResult);
   if (fileResult) {
@@ -134,7 +130,6 @@ void DeltaUpdateColumnLoader::loadInternal(
     ValueHook* hook,
     vector_size_t resultSize,
     VectorPtr* result) {
-  process::TraceContext trace("DeltaUpdateColumnLoader::loadInternal");
   ExceptionContextSetter exceptionContext(
       {[](VeloxException::Type /*exceptionType*/, auto* reader) {
          return static_cast<SelectiveStructColumnReaderBase*>(reader)

--- a/velox/dwio/common/DirectBufferedInput.cpp
+++ b/velox/dwio/common/DirectBufferedInput.cpp
@@ -16,7 +16,6 @@
 
 #include "velox/dwio/common/DirectBufferedInput.h"
 #include "velox/common/memory/Allocation.h"
-#include "velox/common/process/TraceContext.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/dwio/common/DirectInputStream.h"
 
@@ -229,7 +228,6 @@ void DirectBufferedInput::readRegions(
         AsyncLoadHolder loadHolder{
             .load = load, .pool = pool_->shared_from_this()};
         executor_->add([asyncLoad = std::move(loadHolder)]() {
-          process::TraceContext trace("Read Ahead");
           VELOX_CHECK_NOT_NULL(asyncLoad.load);
           asyncLoad.load->loadOrFuture(nullptr);
         });

--- a/velox/dwio/common/DirectInputStream.cpp
+++ b/velox/dwio/common/DirectInputStream.cpp
@@ -16,7 +16,6 @@
 
 #include <folly/executors/QueuedImmediateExecutor.h>
 
-#include "velox/common/process/TraceContext.h"
 #include "velox/common/time/Timer.h"
 #include "velox/dwio/common/DirectBufferedInput.h"
 #include "velox/dwio/common/DirectInputStream.h"
@@ -142,8 +141,6 @@ void DirectInputStream::loadSync() {
       bufferedInput_->pool()->allocateNonContiguous(numPages, data_);
     }
   }
-
-  process::TraceContext trace("DirectInputStream::loadSync");
 
   ioStats_->incRawBytesRead(loadedRegion_.length);
   auto ranges = makeRanges(loadedRegion_.length, data_, tinyData_);

--- a/velox/dwio/common/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/common/SelectiveStructColumnReader.cpp
@@ -16,7 +16,6 @@
 
 #include "velox/dwio/common/SelectiveStructColumnReader.h"
 
-#include "velox/common/process/TraceContext.h"
 #include "velox/dwio/common/ColumnLoader.h"
 
 namespace facebook::velox::dwio::common {
@@ -321,7 +320,6 @@ void SelectiveStructColumnReaderBase::next(
     uint64_t numValues,
     VectorPtr& result,
     const Mutation* mutation) {
-  process::TraceContext trace("SelectiveStructColumnReaderBase::next");
   mutation_ = mutation;
   hasDeletion_ = common::hasDeletion(mutation);
   const RowSet rows(iota(numValues, rows_), numValues);


### PR DESCRIPTION
Summary:
CONTEXT: Strobelight profiling shows `TraceContext::TraceContext` consuming significant CPU on the I/O read path. Each constructor call allocates a `std::string` label, reads `steady_clock::now()`, pushes to `TraceHistory`, and updates the thread-local registry — all on every batch read, column load, and I/O operation.

WHAT: Remove all `process::TraceContext` usage from the DWIO I/O hot paths:
- `ColumnLoader::loadInternal` (called per lazy column load)
- `TransformColumnLoader::loadInternal`
- `DeltaUpdateColumnLoader::loadInternal`
- `SelectiveStructColumnReaderBase::next` (called per batch)
- `DirectInputStream::loadSync` (called per I/O read)
- `CacheInputStream::loadSync` (called per cache load)
- `CachedBufferedInput` and `DirectBufferedInput` read-ahead lambdas
- `CacheInputStream` error-path `TraceContext::statusLine()` call

Reviewed By: tanjialiang

Differential Revision: D107201661


