### PR TITLE
fix(RowNumber): Preserve rows under backpressure (#17702)

### DIFF
--- a/velox/exec/RowNumber.cpp
+++ b/velox/exec/RowNumber.cpp
@@ -74,6 +74,16 @@ RowNumber::RowNumber(
 }
 
 void RowNumber::addInput(RowVectorPtr input) {
+  // needsInput() returns false while 'input_' is set, so the Driver must drain
+  // getOutput() before feeding the next batch. A non-null 'input_' on entry
+  // would mean a buffered batch is being overwritten and its rows silently
+  // lost, so fail loudly instead. Guards against a regression of the row-loss
+  // bug seen with a backpressuring downstream (e.g. a BATCH-mode RPC operator).
+  VELOX_CHECK_NULL(
+      input_,
+      "RowNumber::addInput() called while a previous input batch is still "
+      "buffered; needsInput() should have prevented this");
+
   const auto numInput = input->size();
 
   if (table_) {

--- a/velox/exec/RowNumber.h
+++ b/velox/exec/RowNumber.h
@@ -38,7 +38,14 @@ class RowNumber : public Operator {
   RowVectorPtr getOutput() override;
 
   bool needsInput() const override {
-    return !noMoreInput_ && !finishedEarly_;
+    // Guard on 'input_ == nullptr': RowNumber buffers a single input batch in
+    // 'input_' and addInput() overwrites it. Without this guard, when a
+    // downstream operator applies backpressure (e.g. a BATCH-mode RPC operator
+    // returning needsInput()=false while async requests are in flight), the
+    // Driver keeps feeding this operator and addInput() silently overwrites the
+    // undrained batch, dropping its rows. Mirrors the single-buffer pattern in
+    // Expand/MarkDistinct/Unnest/AssignUniqueId.
+    return !noMoreInput_ && !finishedEarly_ && input_ == nullptr;
   }
 
   BlockingReason isBlocked(ContinueFuture* /* unused */) override {

--- a/velox/exec/tests/RowNumberTest.cpp
+++ b/velox/exec/tests/RowNumberTest.cpp
@@ -17,6 +17,7 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/FileSystems.h"
 #include "velox/common/testutil/TempDirectoryPath.h"
+#include "velox/exec/Operator.h"
 #include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
@@ -610,6 +611,137 @@ DEBUG_ONLY_TEST_F(RowNumberTest, rowNumberSpillFileCreateConfig) {
       .assertResults("SELECT *, row_number() over (partition by c0) FROM tmp");
 
   ASSERT_TRUE(rowNumberConfigVerified.load());
+}
+
+namespace {
+
+// Defines a minimal plan node for the backpressuring downstream used by the
+// regression test below.
+class BackpressureNode : public core::PlanNode {
+ public:
+  BackpressureNode(const core::PlanNodeId& id, core::PlanNodePtr input)
+      : PlanNode(id), sources_{std::move(input)} {}
+
+  const RowTypePtr& outputType() const override {
+    return sources_[0]->outputType();
+  }
+
+  const std::vector<core::PlanNodePtr>& sources() const override {
+    return sources_;
+  }
+
+  std::string_view name() const override {
+    return "Backpressure";
+  }
+
+ private:
+  void addDetails(std::stringstream& /* stream */) const override {}
+
+  std::vector<core::PlanNodePtr> sources_;
+};
+
+// Passes input through but refuses it most of the time, keeping the upstream
+// RowNumber holding a buffered batch. Before the needsInput() fix this made the
+// Driver re-feed RowNumber and overwrite its undrained input_.
+class BackpressureOperator : public Operator {
+ public:
+  BackpressureOperator(
+      DriverCtx* ctx,
+      int32_t id,
+      const std::shared_ptr<const BackpressureNode>& node)
+      : Operator(ctx, node->outputType(), id, node->id(), "Backpressure") {}
+
+  bool needsInput() const override {
+    if (noMoreInput_ || input_ != nullptr) {
+      return false;
+    }
+    // Accept input only every 4th poll. The rejected polls are when the Driver
+    // would re-feed (and, before the fix, overwrite) the upstream RowNumber.
+    return (++polls_ % 4) == 0;
+  }
+
+  void addInput(RowVectorPtr input) override {
+    input_ = std::move(input);
+  }
+
+  RowVectorPtr getOutput() override {
+    return std::move(input_);
+  }
+
+  BlockingReason isBlocked(ContinueFuture* /* future */) override {
+    return BlockingReason::kNotBlocked;
+  }
+
+  bool isFinished() override {
+    return noMoreInput_ && input_ == nullptr;
+  }
+
+ private:
+  mutable int32_t polls_{0};
+};
+
+class BackpressureNodeFactory : public Operator::PlanNodeTranslator {
+ public:
+  std::unique_ptr<Operator> toOperator(
+      DriverCtx* ctx,
+      int32_t id,
+      const core::PlanNodePtr& node) override {
+    if (auto bpNode = std::dynamic_pointer_cast<const BackpressureNode>(node)) {
+      return std::make_unique<BackpressureOperator>(ctx, id, bpNode);
+    }
+    return nullptr;
+  }
+
+  std::optional<uint32_t> maxDrivers(const core::PlanNodePtr& node) override {
+    if (std::dynamic_pointer_cast<const BackpressureNode>(node)) {
+      // Single driver, mirroring the BATCH-mode RPC operator that exposed the
+      // bug.
+      return 1;
+    }
+    return std::nullopt;
+  }
+};
+
+} // namespace
+
+// Regression test: a window operator (RowNumber) feeding a backpressuring
+// downstream must not drop rows. Before the fix, RowNumber::needsInput() did
+// not check input_ == nullptr, so when the downstream returned
+// needsInput()=false the Driver re-fed RowNumber and addInput() overwrote the
+// undrained batch, silently dropping rows (seen in production with a BATCH-mode
+// RPC operator).
+TEST_F(RowNumberTest, noRowLossWithBackpressuringDownstream) {
+  Operator::registerOperator(std::make_unique<BackpressureNodeFactory>());
+
+  // Many small batches so the Driver repeatedly feeds RowNumber while the
+  // downstream refuses input.
+  const int32_t numBatches = 50;
+  const int32_t rowsPerBatch = 100;
+  std::vector<RowVectorPtr> batches;
+  batches.reserve(numBatches);
+  for (int32_t i = 0; i < numBatches; ++i) {
+    batches.push_back(makeRowVector(
+        {makeFlatVector<int64_t>(
+             rowsPerBatch,
+             [&](auto row) { return (i * rowsPerBatch + row) % 17; }),
+         makeFlatVector<int64_t>(
+             rowsPerBatch, [&](auto row) { return i * rowsPerBatch + row; })}));
+  }
+  const vector_size_t totalRows = numBatches * rowsPerBatch;
+
+  auto plan =
+      PlanBuilder()
+          .values(batches)
+          .rowNumber({"c0"})
+          .addNode([](const std::string& id, core::PlanNodePtr input) {
+            return std::make_shared<BackpressureNode>(id, std::move(input));
+          })
+          .planNode();
+
+  // Single driver so RowNumber and the backpressuring downstream share a
+  // pipeline, as with a BATCH-mode RPC operator (maxDrivers=1).
+  auto result = AssertQueryBuilder(plan).maxDrivers(1).copyResults(pool());
+  EXPECT_EQ(result->size(), totalRows);
 }
 
 } // namespace facebook::velox::exec::test


### PR DESCRIPTION
Summary:

A RowNumber operator could silently drop most of its input rows when its downstream operator applies backpressure. A query that wrapped its input in `row_number() over (partition by ...)` and fed a batched, asynchronously dispatched downstream operator returned only a small fraction of its rows: 20,000 input rows produced about 822 output rows, and the count varied run to run. The surviving rows were otherwise correct, so this was pure row loss, not wrong values.

RowNumber buffers a single input batch in `input_`, and `addInput()` overwrites it. Its `needsInput()` returned `!noMoreInput_ && !finishedEarly_` and did not check `input_ == nullptr`. The Driver drains an operator's `getOutput()` only when the next operator can accept input, but it feeds an operator whenever that operator's `needsInput()` is true. So when the downstream backpressures (returns `needsInput()=false`), the Driver stops draining RowNumber yet keeps feeding it, and `addInput()` overwrites the still-buffered batch.

The fix is not a new mechanism: it adds `&& input_ == nullptr` to `needsInput()`, the exact single-buffer guard that Expand, MarkDistinct, Unnest, and AssignUniqueId already use. RowNumber was the only single-input-buffer operator missing it. With the guard the Driver drains the buffered batch before feeding the next one. It is a no-op when the downstream keeps accepting input, since the batch was already drained before each feed. Spilling is unaffected: input spilling leaves `input_ == nullptr`, and spill restore runs after `noMoreInput_`, where `needsInput()` is already false. As a defense in depth, a `VELOX_CHECK_NULL` in `addInput()` now fails loudly if an undrained `input_` is ever about to be overwritten, turning any future regression into a hard error instead of silent row loss.

Reviewed By: feilong-liu, xiaoxmeng

Differential Revision: D107271793


