### PR TITLE
refactor: Eliminate redundant findPartitionGroup calls

### DIFF
--- a/velox/connectors/hive/HiveIndexSource.cpp
+++ b/velox/connectors/hive/HiveIndexSource.cpp
@@ -1167,9 +1167,9 @@ void HiveIndexSource::buildPartitionGroups(
       hiveConfig_->readTimestampPartitionValueAsLocalTime(
           connectorQueryCtx_->sessionProperties());
 
-  // For each distinct partition, build typed routing constants (used by
-  // findPartitionGroup() at lookup time) and a per-group scan spec where
-  // partition columns are emitted as constants by the underlying reader.
+  // For each distinct partition, build typed routing constants and a per-group
+  // scan spec where partition columns are emitted as constants by the
+  // underlying reader.
   partitionGroups_.reserve(splitGroups.size());
   for (auto& [_, groupSplits] : splitGroups) {
     PartitionGroup group;
@@ -1289,27 +1289,41 @@ std::shared_ptr<IndexSource::ResultIterator> HiveIndexSource::lookup(
 
   const auto numRows = request.input->size();
 
-  // Fast path: check if all rows route to the same partition group.
-  auto* firstGroup = findPartitionGroup(request.input, 0);
-  bool singleGroup = true;
-  for (vector_size_t row = 1; row < numRows; ++row) {
-    if (findPartitionGroup(request.input, row) != firstGroup) {
-      singleGroup = false;
-      break;
+  // Map each row to its partition group.
+  folly::F14FastMap<PartitionGroup*, std::vector<vector_size_t>>
+      partitionRowMap;
+  partitionRowMap.reserve(partitionGroups_.size());
+  for (vector_size_t row = 0; row < numRows; ++row) {
+    auto* group = findPartitionGroup(request.input, row);
+    if (group != nullptr) {
+      partitionRowMap[group].emplace_back(row);
     }
+    // NOTE: Rows with no matching group are intentionally dropped — they
+    // produce no output. IndexLookupJoin detects the gap in inputHits and
+    // emits nulls for LEFT JOIN or skips for INNER JOIN.
   }
 
-  if (singleGroup) {
+  if (partitionRowMap.empty()) {
     // No partition group matched any probe row.
-    if (firstGroup == nullptr) {
-      static const std::shared_ptr<IndexSource::ResultIterator> kEmpty =
-          std::make_shared<EmptyIterator>();
-      return kEmpty;
-    }
-    return createLookupIterator(request, firstGroup->readers, options);
+    static const std::shared_ptr<IndexSource::ResultIterator> kEmpty =
+        std::make_shared<EmptyIterator>();
+    return kEmpty;
   }
-  // Slow path: probe rows target different partition groups.
-  return createPartitionLookupIterator(request, options);
+
+  if (partitionRowMap.size() == 1) {
+    const auto* group = partitionRowMap.begin()->first;
+    if (partitionRowMap.begin()->second.size() == numRows) {
+      // Fast path: all rows matched the same group.
+      return createLookupIterator(request, group->readers, options);
+    }
+    // NOTE: When a single group matched but not all rows (some had no
+    // matching partition), we still go through createPartitionLookupIterator
+    // so that unmatched rows are excluded from the sub-batch and their
+    // inputHit gaps signal misses to IndexLookupJoin.
+  }
+
+  return createPartitionLookupIterator(
+      request, std::move(partitionRowMap), options);
 }
 
 std::shared_ptr<IndexSource::ResultIterator>
@@ -1336,27 +1350,13 @@ HiveIndexSource::createLookupIterator(
 std::shared_ptr<IndexSource::ResultIterator>
 HiveIndexSource::createPartitionLookupIterator(
     const Request& request,
+    folly::F14FastMap<PartitionGroup*, std::vector<vector_size_t>>
+        partitionRowMap,
     const SplitIndexReader::Options& options) {
-  const auto numRows = request.input->size();
-
-  // Map each row to its partition group.
-  folly::F14FastMap<PartitionGroup*, std::vector<vector_size_t>>
-      partitionGroups;
-  partitionGroups.reserve(partitionGroups_.size());
-  for (vector_size_t row = 0; row < numRows; ++row) {
-    auto* group = findPartitionGroup(request.input, row);
-    if (group != nullptr) {
-      partitionGroups[group].push_back(row);
-    }
-    // Rows with no matching group are intentionally dropped — they produce
-    // no output. IndexLookupJoin detects the gap in inputHits and emits
-    // nulls for LEFT JOIN or skips for INNER JOIN.
-  }
-
   // Create a PartitionIterator per group.
   std::vector<std::shared_ptr<IndexSource::ResultIterator>> partitionIters;
-  partitionIters.reserve(partitionGroups.size());
-  for (auto& [partition, partitionRows] : partitionGroups) {
+  partitionIters.reserve(partitionRowMap.size());
+  for (auto& [partition, partitionRows] : partitionRowMap) {
     const auto numPartitionRows =
         static_cast<vector_size_t>(partitionRows.size());
     auto partitionIndices = allocateIndices(numPartitionRows, pool_);

--- a/velox/connectors/hive/HiveIndexSource.h
+++ b/velox/connectors/hive/HiveIndexSource.h
@@ -157,13 +157,6 @@ class HiveIndexSource : public IndexSource,
       const std::vector<SplitIndexReader*>& readers,
       const SplitIndexReader::Options& options);
 
-  // Creates a partitioned lookup iterator when probe rows target different
-  // partition groups. Splits the probe batch by partition, dispatches each
-  // sub-batch to the matching group's readers, and merges results.
-  std::shared_ptr<ResultIterator> createPartitionLookupIterator(
-      const Request& request,
-      const SplitIndexReader::Options& options);
-
   // Creates a SplitIndexReader using a registered IndexReaderFactory.
   void createCustomIndexReader(
       const IndexReaderFactory& factory,
@@ -213,11 +206,18 @@ class HiveIndexSource : public IndexSource,
 
   // Finds the partition group whose partition values match the given probe
   // row's partition column values. Returns nullptr if no group matches.
-  // TODO: accept a batch of rows and return a per-row group mapping to
-  // avoid redundant per-row calls from PartitionDispatchIterator.
   PartitionGroup* findPartitionGroup(
       const RowVectorPtr& probeInput,
       vector_size_t row);
+
+  // Creates a partitioned lookup iterator when probe rows target different
+  // partition groups. Takes a pre-built row-to-group mapping, dispatches
+  // each sub-batch to the matching group's readers, and merges results.
+  std::shared_ptr<ResultIterator> createPartitionLookupIterator(
+      const Request& request,
+      folly::F14FastMap<PartitionGroup*, std::vector<vector_size_t>>
+          partitionRowMap,
+      const SplitIndexReader::Options& options);
 
   // Per-iteration timing breakdown for index lookups.
   struct IterationStats {


### PR DESCRIPTION
Summary:
Merge the partition-routing loop from `createPartitionLookupIterator()` into `lookup()` so that `findPartitionGroup()` is called once per probe row instead of twice on the multi-partition path. Previously `lookup()` scanned all rows to detect the single-group fast path, then `createPartitionLookupIterator()` scanned them again to build the row-to-group mapping.

Now `lookup()` builds the mapping in one pass and passes it to `createPartitionLookupIterator()`, which no longer calls `findPartitionGroup()` at all.

Differential Revision: D107302237


