### PR TITLE
fix: Skip the fuzzer test for Spark regexp_instr function

### DIFF
--- a/velox/expression/fuzzer/SparkExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/SparkExpressionFuzzerTest.cpp
@@ -64,6 +64,8 @@ int main(int argc, char** argv) {
       "regexp_extract",
       // https://github.com/facebookincubator/velox/issues/8438
       "regexp_replace",
+      // https://github.com/facebookincubator/velox/issues/17697
+      "regexp_instr",
       "rlike",
       "chr",
       "replace",


### PR DESCRIPTION
The regex cache limit makes expression evaluation order-dependent. Common eval 
and simplified eval process rows in different orders, so they hit the cache 
limit on different rows, producing different results. This PR skips the uzzer 
test for Spark regexp_instr function.

Fixes https://github.com/facebookincubator/velox/issues/17697.