### PR TITLE
build(cuda): Allow DNF fallback for adapter CUDA installs

### DIFF
--- a/scripts/setup-centos-adapters.sh
+++ b/scripts/setup-centos-adapters.sh
@@ -35,6 +35,14 @@ VELOX_UCX_VERSION=${UCX_VERSION:-"1.19.0"}
 SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 source "$SCRIPT_DIR"/setup-centos9.sh
 
+function configure_dnf_for_cuda {
+  if grep -q '^best=' /etc/dnf/dnf.conf; then
+    sed -i 's/^best=.*/best=False/' /etc/dnf/dnf.conf
+  else
+    echo "best=False" >>/etc/dnf/dnf.conf
+  fi
+}
+
 function install_ucx {
   dnf_install rdma-core-devel
   local UCX_REPO_NAME="openucx/ucx"
@@ -84,6 +92,7 @@ function setup_cuda_repo {
     return 1
   fi
 
+  configure_dnf_for_cuda
   dnf config-manager --add-repo "$repo_url"
 }
 

--- a/scripts/setup-centos-adapters.sh
+++ b/scripts/setup-centos-adapters.sh
@@ -36,6 +36,9 @@ SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 source "$SCRIPT_DIR"/setup-centos9.sh
 
 function configure_dnf_for_cuda {
+  # CUDA 13.3 renamed cuda-cccl to cccl, and the new package obsoletes the
+  # CUDA 12.9 package that the installed 12.9 devel packages still require.
+  # This workaround can be dropped when updating to CUDA >=13.3.
   if grep -q '^best=' /etc/dnf/dnf.conf; then
     sed -i 's/^best=.*/best=False/' /etc/dnf/dnf.conf
   else

--- a/scripts/setup-centos9.sh
+++ b/scripts/setup-centos9.sh
@@ -44,21 +44,12 @@ function dnf_install {
   dnf install -y -q --setopt=install_weak_deps=False "$@"
 }
 
-function configure_dnf {
-  if grep -q '^best=' /etc/dnf/dnf.conf; then
-    sed -i 's/^best=.*/best=False/' /etc/dnf/dnf.conf
-  else
-    echo "best=False" >>/etc/dnf/dnf.conf
-  fi
-}
-
 function install_clang15 {
   dnf_install clang15 gcc-toolset-13-libatomic-devel
 }
 
 # Install packages required for build.
 function install_build_prerequisites {
-  configure_dnf
   dnf update -y
   dnf_install epel-release dnf-plugins-core # For ccache, ninja
   if grep -q CentOS /etc/os-release; then

--- a/scripts/setup-centos9.sh
+++ b/scripts/setup-centos9.sh
@@ -44,12 +44,21 @@ function dnf_install {
   dnf install -y -q --setopt=install_weak_deps=False "$@"
 }
 
+function configure_dnf {
+  if grep -q '^best=' /etc/dnf/dnf.conf; then
+    sed -i 's/^best=.*/best=False/' /etc/dnf/dnf.conf
+  else
+    echo "best=False" >>/etc/dnf/dnf.conf
+  fi
+}
+
 function install_clang15 {
   dnf_install clang15 gcc-toolset-13-libatomic-devel
 }
 
 # Install packages required for build.
 function install_build_prerequisites {
+  configure_dnf
   dnf update -y
   dnf_install epel-release dnf-plugins-core # For ccache, ninja
   if grep -q CentOS /etc/os-release; then


### PR DESCRIPTION
## Summary

Configure `dnf` with `best=False` when installing CUDA packages.

Resolves #17714.