### PR TITLE
fix(ci): Disable sparse-checkout cone mode for Claude context files

### DIFF
--- a/.github/workflows/ci-failure-comment.yml
+++ b/.github/workflows/ci-failure-comment.yml
@@ -155,6 +155,9 @@ jobs:
             CLAUDE.md
             .claude/CLAUDE.md
             .claude/skills/ci-failure-analysis/SKILL.md
+          # Cone mode (the default) rejects file paths as of git 2.54; the
+          # entries above are files, not directories, so disable cone mode.
+          sparse-checkout-cone-mode: false
           persist-credentials: false
 
       - name: Prepare analysis prompt


### PR DESCRIPTION
## Summary

The `CI Failure Comment` workflow has been failing on every run since git 2.54 landed on `ubuntu-latest` runners (around May 20). The `Checkout for Claude context and prompt` step passes file paths to sparse-checkout:

```yaml
sparse-checkout: |
  CLAUDE.md
  .claude/CLAUDE.md
  .claude/skills/ci-failure-analysis/SKILL.md
```

`actions/checkout` enables cone mode by default, and git 2.54 hard-rejects non-directory entries in cone mode:

```
fatal: '.claude/CLAUDE.md' is not a directory; to treat it as a directory anyway, rerun with --skip-checks
```

Earlier git versions on the runner (e.g. 2.53.0 on May 15 runs) accepted file paths in cone mode, which is why the same YAML used to work.

This change sets `sparse-checkout-cone-mode: false` on the affected step so file paths are accepted. The earlier `.github/scripts` checkout stays in cone mode — it is a directory and works fine.