### PR TITLE
build: Exclude ucx-exchange sources from clang-tidy

### DIFF
--- a/scripts/checks/run-clang-tidy.py
+++ b/scripts/checks/run-clang-tidy.py
@@ -53,6 +53,7 @@ def git_changed_lines(commit):
             if (
                 "cudf/" not in matched_file
                 and "wave/" not in matched_file
+                and "ucx-exchange/" not in matched_file
                 and not matched_file.endswith("-inl.h")
             ):
                 file = matched_file
@@ -83,7 +84,11 @@ def tidy(args):
 
     # Exclude files in cudf, wave, and torchwave directories
     # as clang-tidy doesn't support CUDA compiler flags and CUDA headers
-    files = [file for file in files if "cudf/" not in file and "wave/" not in file]
+    files = [
+        file
+        for file in files
+        if "cudf/" not in file and "wave/" not in file and "ucx-exchange/" not in file
+    ]
 
     # Exclude *-inl.h files: they are designed to be included from their
     # corresponding header and cannot be compiled as standalone translation


### PR DESCRIPTION
## Summary

Exclude `ucx-exchange/` sources from `scripts/checks/run-clang-tidy.py`, mirroring
the existing `cudf/` and `wave/` exclusions.

## Motivation

The `ucx-exchange` GPU transport plugin (under `velox/experimental/`) is built on
top of cuDF and UCX. Its sources pull in CUDA compiler flags and CUDA/UCX headers,
which clang-tidy does not support — the same reason `cudf/` and `wave/` are already
excluded. Without this exclusion, clang-tidy fails when it encounters changed
`ucx-exchange/` files.

## Changes

- Add `"ucx-exchange/" not in matched_file` to the changed-line detection in
  `git_changed_lines`, so changed lines in those files are not collected for
  tidying.
- Add `"ucx-exchange/" not in file` to the file-list filter in `tidy`, so those
  files are excluded from the clang-tidy run.
