### PR TITLE
fix(build): Dwrf proto build error

### DIFF
--- a/velox/dwio/dwrf/proto/CMakeLists.txt
+++ b/velox/dwio/dwrf/proto/CMakeLists.txt
@@ -32,7 +32,7 @@ endforeach()
 add_custom_command(
   OUTPUT ${PROTO_OUTPUT_FILES}
   COMMAND protobuf::protoc ${PROTO_PATH_ARGS} --cpp_out ${PROJECT_BINARY_DIR} ${PROTO_FILES_FULL}
-  DEPENDS protobuf::protoc
+  DEPENDS protobuf::protoc ${PROTO_FILES_FULL}
   COMMENT "Running PROTO compiler"
   VERBATIM
 )


### PR DESCRIPTION
```
/velox/velox/dwio/dwrf/utils/test/TypeAttributesTest.cpp:90:22: error: no member named 'attributes' in 'facebook::velox::dwrf::proto::Type'
   90 |     EXPECT_EQ(parsed.attributes(i).value(), kIcebergAttrs[i].second);
```

Root cause is stale protobuf generation, dwrf_proto.proto changed, but the protoc rule did not depend on the .proto inputs, so builds could keep using an old dwrf_proto.pb.h without the new changes.