### PR TITLE
feat(types): Serialize enum types in toSql and parse enum kinds case-insensitively

### DIFF
--- a/velox/common/encode/Base32.cpp
+++ b/velox/common/encode/Base32.cpp
@@ -63,6 +63,43 @@ constexpr const Base32::ReverseIndex kBase32ReverseIndexTable = {
     255, 255, 255, 255, 255, 255, 255 // 240-255
 };
 
+// Forward lookup table for encoding (RFC 4648 alphabet).
+constexpr std::string_view kBase32Charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+
+constexpr int kBitsPerByte = 8;
+// Each Base32 symbol encodes 5 bits; kSymbolMask isolates one symbol.
+constexpr int kBitsPerSymbol = 5;
+constexpr uint32_t kSymbolMask = (1U << kBitsPerSymbol) - 1;
+
+// static
+std::string Base32::encode(std::string_view input) {
+  std::string encoded;
+  // Each binary block encodes to one encoded block; round up.
+  encoded.reserve(
+      (input.size() + kBinaryBlockByteSize - 1) / kBinaryBlockByteSize *
+      kEncodedBlockByteSize);
+  uint32_t buffer{0};
+  int bitsLeft{0};
+  for (unsigned char byte : input) {
+    buffer = (buffer << kBitsPerByte) | byte;
+    bitsLeft += kBitsPerByte;
+    while (bitsLeft >= kBitsPerSymbol) {
+      bitsLeft -= kBitsPerSymbol;
+      encoded.push_back(kBase32Charset[(buffer >> bitsLeft) & kSymbolMask]);
+    }
+  }
+  // Encode the remaining bits, padding with zero bits on the right.
+  if (bitsLeft > 0) {
+    encoded.push_back(
+        kBase32Charset[(buffer << (kBitsPerSymbol - bitsLeft)) & kSymbolMask]);
+  }
+  // Pad to a multiple of the encoded block size.
+  while (encoded.size() % kEncodedBlockByteSize != 0) {
+    encoded.push_back(kPadding);
+  }
+  return encoded;
+}
+
 // static
 folly::Expected<uint8_t, Status> Base32::base32ReverseLookup(
     char encodedChar,

--- a/velox/common/encode/Base32.h
+++ b/velox/common/encode/Base32.h
@@ -39,6 +39,10 @@ class Base32 {
   /// within the encoding base.
   using ReverseIndex = std::array<uint8_t, kReverseIndexSize>;
 
+  /// Encodes 'input' to a padded RFC 4648 Base32 string (uppercase A-Z, 2-7),
+  /// matching Google Guava's BaseEncoding.base32().
+  static std::string encode(std::string_view input);
+
   /// Decodes the specified number of characters from the 'input' and writes the
   /// result to the 'outputBuffer'.
   static Status decode(

--- a/velox/common/encode/tests/Base32Test.cpp
+++ b/velox/common/encode/tests/Base32Test.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/encode/Base32.h"
+
+#include <gtest/gtest.h>
+
+namespace facebook::velox::encoding {
+
+TEST(Base32Test, encode) {
+  // RFC 4648 test vectors.
+  EXPECT_EQ(Base32::encode(""), "");
+  EXPECT_EQ(Base32::encode("f"), "MY======");
+  EXPECT_EQ(Base32::encode("fo"), "MZXQ====");
+  EXPECT_EQ(Base32::encode("foo"), "MZXW6===");
+  EXPECT_EQ(Base32::encode("foob"), "MZXW6YQ=");
+  EXPECT_EQ(Base32::encode("fooba"), "MZXW6YTB");
+  EXPECT_EQ(Base32::encode("foobar"), "MZXW6YTBOI======");
+}
+
+TEST(Base32Test, roundTrip) {
+  // Encodes 'value', decodes the result, and verifies it matches the original.
+  auto verify = [](std::string_view value) {
+    auto encoded = Base32::encode(value);
+
+    auto size = Base32::calculateDecodedSize(encoded.data(), encoded.size());
+    ASSERT_FALSE(size.hasError());
+
+    std::string decoded(size.value(), '\0');
+    auto status = Base32::decode(
+        encoded.data(), encoded.size(), decoded.data(), decoded.size());
+    ASSERT_TRUE(status.ok());
+
+    EXPECT_EQ(decoded, value);
+  };
+
+  for (const auto& value :
+       {"", "a", "ab", "abc", "abcd", "abcde", "hello world", "red_value"}) {
+    verify(value);
+  }
+}
+
+} // namespace facebook::velox::encoding

--- a/velox/common/encode/tests/CMakeLists.txt
+++ b/velox/common/encode/tests/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(velox_common_encode_test Base64Test.cpp ZigZagTest.cpp)
+add_executable(velox_common_encode_test Base32Test.cpp Base64Test.cpp ZigZagTest.cpp)
 add_test(velox_common_encode_test velox_common_encode_test)
 target_link_libraries(
   velox_common_encode_test

--- a/velox/functions/prestosql/types/BigintEnumType.cpp
+++ b/velox/functions/prestosql/types/BigintEnumType.cpp
@@ -23,7 +23,11 @@ BigintEnumType::BigintEnumType(const LongEnumParameter& parameters)
     : EnumTypeBase<int64_t, LongEnumParameter, BigintType>(parameters) {}
 
 std::string BigintEnumType::toString() const {
-  return fmt::format("{}:BigintEnum({})", name_, flippedMapToString());
+  return fmt::format("{}:{}({})", name_, kKind, flippedMapToString());
+}
+
+std::string BigintEnumType::toSql() const {
+  return toSqlImpl(kKind, [](int64_t value) { return std::to_string(value); });
 }
 
 BigintEnumTypePtr BigintEnumType::get(const LongEnumParameter& parameter) {

--- a/velox/functions/prestosql/types/BigintEnumType.h
+++ b/velox/functions/prestosql/types/BigintEnumType.h
@@ -31,11 +31,18 @@ class BigintEnumType
  public:
   static BigintEnumTypePtr get(const LongEnumParameter& parameter);
 
+  /// Presto type signature kind, used by toString(), toSql() and the type
+  /// parser.
+  static constexpr std::string_view kKind = "BigintEnum";
+
   const char* name() const override {
     return "BIGINT_ENUM";
   }
 
   std::string toString() const override;
+
+  /// Serializes to a Presto type signature that round-trips through parseType.
+  std::string toSql() const;
 
   folly::dynamic serialize() const override;
 

--- a/velox/functions/prestosql/types/CMakeLists.txt
+++ b/velox/functions/prestosql/types/CMakeLists.txt
@@ -95,6 +95,7 @@ velox_link_libraries(
   velox_presto_types
   velox_type
   velox_memory
+  velox_encode
   velox_expression
   velox_functions_util
   velox_functions_json

--- a/velox/functions/prestosql/types/EnumTypeBase.h
+++ b/velox/functions/prestosql/types/EnumTypeBase.h
@@ -15,8 +15,13 @@
  */
 #pragma once
 
+#include <fmt/format.h>
 #include <folly/Synchronized.h>
 #include <folly/container/EvictingCacheMap.h>
+
+#include <algorithm>
+#include <string_view>
+#include <vector>
 
 #include "velox/type/Type.h"
 
@@ -86,6 +91,36 @@ class EnumTypeBase : public TPhysical {
 
   /// Converts the flipped map to a string representation for toString() method.
   std::string flippedMapToString() const;
+
+  // Serializes the enum to its Presto type signature
+  // "name:Kind(name{"KEY": value, ...})", with keys sorted for deterministic
+  // output that round-trips through parseType. 'formatValue' renders a single
+  // value: a raw integer for bigint enums, a quoted base32 string for varchar
+  // enums.
+  template <typename FormatValue>
+  std::string toSqlImpl(std::string_view kind, FormatValue&& formatValue)
+      const {
+    const auto& valuesMap = forwardMap();
+    std::vector<const std::pair<const std::string, TValue>*> entries;
+    entries.reserve(valuesMap.size());
+    for (const auto& entry : valuesMap) {
+      entries.push_back(&entry);
+    }
+    std::sort(
+        entries.begin(), entries.end(), [](const auto* lhs, const auto* rhs) {
+          return lhs->first < rhs->first;
+        });
+
+    std::string body;
+    for (const auto* entry : entries) {
+      if (!body.empty()) {
+        body += ", ";
+      }
+      body +=
+          fmt::format("\"{}\": {}", entry->first, formatValue(entry->second));
+    }
+    return fmt::format("{0}:{1}({0}{{{2}}})", name_, kind, body);
+  }
 
   /// Returns cached instance of enum type or creates and returns a new enum
   /// type if the type has not already been instantiated with the given

--- a/velox/functions/prestosql/types/PrestoTypes.cpp
+++ b/velox/functions/prestosql/types/PrestoTypes.cpp
@@ -20,6 +20,8 @@
 #include <velox/common/base/Exceptions.h>
 #include <iomanip>
 #include <sstream>
+#include "velox/functions/prestosql/types/BigintEnumType.h"
+#include "velox/functions/prestosql/types/VarcharEnumType.h"
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/SimpleVector.h"
 
@@ -88,6 +90,14 @@ std::string PrestoTypes::toSql(const TypePtr& type) {
     }
     sql << ")";
     return sql.str();
+  }
+
+  if (isBigintEnumType(*type)) {
+    return asBigintEnum(type)->toSql();
+  }
+
+  if (isVarcharEnumType(*type)) {
+    return asVarcharEnum(type)->toSql();
   }
 
   // Primitive types and custom types (e.g. IPPREFIX, BINGTILE).

--- a/velox/functions/prestosql/types/VarcharEnumType.cpp
+++ b/velox/functions/prestosql/types/VarcharEnumType.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/functions/prestosql/types/VarcharEnumType.h"
 
+#include "velox/common/encode/Base32.h"
+
 namespace facebook::velox {
 
 // Should only be called from get() to create a new instance.
@@ -24,7 +26,14 @@ VarcharEnumType::VarcharEnumType(const VarcharEnumParameter& parameters)
 }
 
 std::string VarcharEnumType::toString() const {
-  return fmt::format("{}:VarcharEnum({})", name_, flippedMapToString());
+  return fmt::format("{}:{}({})", name_, kKind, flippedMapToString());
+}
+
+std::string VarcharEnumType::toSql() const {
+  // Values are base32-encoded to match Presto's TypeSignature format.
+  return toSqlImpl(kKind, [](const std::string& value) {
+    return "\"" + encoding::Base32::encode(value) + "\"";
+  });
 }
 
 VarcharEnumTypePtr VarcharEnumType::get(const VarcharEnumParameter& parameter) {

--- a/velox/functions/prestosql/types/VarcharEnumType.h
+++ b/velox/functions/prestosql/types/VarcharEnumType.h
@@ -31,11 +31,18 @@ class VarcharEnumType
  public:
   static VarcharEnumTypePtr get(const VarcharEnumParameter& parameter);
 
+  /// Presto type signature kind, used by toString(), toSql() and the type
+  /// parser.
+  static constexpr std::string_view kKind = "VarcharEnum";
+
   const char* name() const override {
     return "VARCHAR_ENUM";
   }
 
   std::string toString() const override;
+
+  /// Serializes to a Presto type signature that round-trips through parseType.
+  std::string toSql() const;
 
   folly::dynamic serialize() const override;
 

--- a/velox/functions/prestosql/types/parser/ParserUtil.cpp
+++ b/velox/functions/prestosql/types/parser/ParserUtil.cpp
@@ -16,6 +16,8 @@
 
 #include <boost/algorithm/string.hpp>
 #include <string>
+#include "velox/functions/prestosql/types/BigintEnumType.h"
+#include "velox/functions/prestosql/types/VarcharEnumType.h"
 #include "velox/type/Type.h"
 
 namespace facebook::velox::functions::prestosql {
@@ -180,12 +182,14 @@ TypePtr getEnumType(
     const std::string& enumName,
     const std::string& valuesMap) {
   std::vector<TypeParameter> params;
-  if (enumType == "BigintEnum") {
+  if (boost::iequals(enumType, BigintEnumType::kKind)) {
     LongEnumParameter longEnumParameter(
         enumName, parseMapFromString<int64_t>(valuesMap));
     params.emplace_back(TypeParameter(longEnumParameter));
     return getType("BIGINT_ENUM", params);
-  } else if (enumType == "VarcharEnum") {
+  }
+
+  if (boost::iequals(enumType, VarcharEnumType::kKind)) {
     VarcharEnumParameter varcharEnumParameter(
         enumName, parseMapFromString<std::string>(valuesMap));
     params.emplace_back(TypeParameter(varcharEnumParameter));
@@ -193,6 +197,9 @@ TypePtr getEnumType(
   }
 
   VELOX_UNREACHABLE(
-      "Invalid type {}, expected BigintEnum or VarcharEnum", enumType);
+      "Invalid type {}, expected {} or {}",
+      enumType,
+      BigintEnumType::kKind,
+      VarcharEnumType::kKind);
 }
 } // namespace facebook::velox::functions::prestosql

--- a/velox/functions/prestosql/types/parser/TypeParser.yy
+++ b/velox/functions/prestosql/types/parser/TypeParser.yy
@@ -1,6 +1,10 @@
 %{
 #include <FlexLexer.h>
+#include <fmt/format.h>
+#include <boost/algorithm/string/predicate.hpp>
 #include "velox/common/base/Exceptions.h"
+#include "velox/functions/prestosql/types/BigintEnumType.h"
+#include "velox/functions/prestosql/types/VarcharEnumType.h"
 #include "velox/type/Type.h"
 #include "velox/functions/prestosql/types/parser/ParserUtil.h"
 %}
@@ -173,9 +177,14 @@ enum_map_entry : QUOTED_ID COLON SIGNED_INT {  $$ = "[" + $1 + "," + std::to_str
                | QUOTED_ID COLON QUOTED_ID  {  $$ = "[" + $1 + "," + $3 + "]"; }
                ;
 
-enum_kind : WORD { if ($1 != "BigintEnum" && $1 != "VarcharEnum" )
+enum_kind : WORD { if (!boost::iequals($1, BigintEnumType::kKind) &&
+                       !boost::iequals($1, VarcharEnumType::kKind))
                     {
-                        std::string msg = "Invalid type " + $1 + ", expected BigintEnum or VarcharEnum";
+                        std::string msg = fmt::format(
+                            "Invalid type {}, expected {} or {}",
+                            $1,
+                            BigintEnumType::kKind,
+                            VarcharEnumType::kKind);
                         error(msg.c_str());
                     }
                 $$ = $1; }

--- a/velox/functions/prestosql/types/parser/tests/TypeParserTest.cpp
+++ b/velox/functions/prestosql/types/parser/tests/TypeParserTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <fmt/format.h>
 #include <gtest/gtest.h>
 
 #include "velox/common/base/tests/GTestUtils.h"
@@ -561,6 +562,54 @@ TEST_F(TypeParserTest, varcharEnumBasic) {
       *parseType(
           "row(c0 test.enum.mood:VarcharEnum(test.enum.mood{\"CURIOUS\":\"ONXW2ZKWMFWHKZI=\", \"HAPPY\":\"ONXW2ZJAOZQWY5LF\" , \"SAD\":\"KNHU2RJAKZAUYVKF\"}))"),
       *ROW({"c0"}, {VARCHAR_ENUM(moodInfo)}));
+}
+
+TEST_F(TypeParserTest, enumKindCaseInsensitive) {
+  registerBigintEnumType();
+  registerVarcharEnumType();
+
+  // The enum kind ("BigintEnum"/"VarcharEnum") is matched case-insensitively,
+  // consistent with the caseless lexer and Presto's case-insensitive
+  // TypeSignature contract. This matters because a serialized signature may be
+  // lowercased before it is parsed back.
+  LongEnumParameter moodInfo("test.enum.mood", {{"CURIOUS", 2}, {"HAPPY", 0}});
+  for (const auto& kind : {"bigintenum", "BIGINTENUM", "BigIntEnum"}) {
+    ASSERT_EQ(
+        *parseType(
+            fmt::format(
+                R"(test.enum.mood:{}(test.enum.mood{{"CURIOUS":2, "HAPPY":0}}))",
+                kind)),
+        *BIGINT_ENUM(moodInfo))
+        << "kind: " << kind;
+  }
+
+  // A fully lowercased signature (kind and keys) parses to the same type:
+  // keys are canonicalized back to uppercase by the parser.
+  ASSERT_EQ(
+      *parseType(
+          R"(test.enum.mood:bigintenum(test.enum.mood{"curious":2, "happy":0}))"),
+      *BIGINT_ENUM(moodInfo));
+
+  // Base32 values reused from varcharEnumBasic: "ONXW2ZKWMFWHKZI=" decodes to
+  // "someValue" and "ONXW2ZJAOZQWY5LF" to "some value".
+  VarcharEnumParameter colorInfo(
+      "test.enum.color", {{"RED", "someValue"}, {"BLUE", "some value"}});
+  for (const auto& kind : {"varcharenum", "VARCHARENUM", "VarCharEnum"}) {
+    ASSERT_EQ(
+        *parseType(
+            fmt::format(
+                R"(test.enum.color:{}(test.enum.color{{"RED":"ONXW2ZKWMFWHKZI=", "BLUE":"ONXW2ZJAOZQWY5LF"}}))",
+                kind)),
+        *VARCHAR_ENUM(colorInfo))
+        << "kind: " << kind;
+  }
+
+  // A fully lowercased varchar signature parses too: the base32 value decoder
+  // is case-insensitive and keys canonicalize to uppercase.
+  ASSERT_EQ(
+      *parseType(
+          R"(test.enum.color:varcharenum(test.enum.color{"red":"onxw2zkwmfwhkzi=", "blue":"onxw2zjaozqwy5lf"}))"),
+      *VARCHAR_ENUM(colorInfo));
 }
 
 TEST_F(TypeParserTest, invalidVarcharEnums) {

--- a/velox/functions/prestosql/types/tests/PrestoTypesTest.cpp
+++ b/velox/functions/prestosql/types/tests/PrestoTypesTest.cpp
@@ -17,6 +17,8 @@
 #include <gtest/gtest.h>
 
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/prestosql/types/BigintEnumRegistration.h"
+#include "velox/functions/prestosql/types/BigintEnumType.h"
 #include "velox/functions/prestosql/types/BingTileType.h"
 #include "velox/functions/prestosql/types/HyperLogLogType.h"
 #include "velox/functions/prestosql/types/IPAddressType.h"
@@ -31,6 +33,9 @@
 #include "velox/functions/prestosql/types/TDigestType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/functions/prestosql/types/UuidType.h"
+#include "velox/functions/prestosql/types/VarcharEnumRegistration.h"
+#include "velox/functions/prestosql/types/VarcharEnumType.h"
+#include "velox/functions/prestosql/types/parser/TypeParser.h"
 #include "velox/type/Time.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
@@ -69,6 +74,33 @@ TEST(PrestoTypeSqlTest, custom) {
   EXPECT_EQ(PrestoTypes::toSql(IPPREFIX()), "IPPREFIX");
   EXPECT_EQ(PrestoTypes::toSql(UUID()), "UUID");
   EXPECT_EQ(PrestoTypes::toSql(BINGTILE()), "BINGTILE");
+}
+
+TEST(PrestoTypeSqlTest, enums) {
+  registerBigintEnumType();
+  registerVarcharEnumType();
+
+  auto bigintEnum = BIGINT_ENUM(
+      LongEnumParameter("test.enum.mood", {{"CURIOUS", -2}, {"HAPPY", 0}}));
+  // Keys are sorted and rendered with their raw integer values.
+  EXPECT_EQ(
+      PrestoTypes::toSql(bigintEnum),
+      R"(test.enum.mood:BigintEnum(test.enum.mood{"CURIOUS": -2, "HAPPY": 0}))");
+  // toSql output round-trips through parseType back to the same type.
+  EXPECT_EQ(
+      *functions::prestosql::parseType(PrestoTypes::toSql(bigintEnum)),
+      *bigintEnum);
+
+  auto varcharEnum = VARCHAR_ENUM(VarcharEnumParameter(
+      "test.enum.color", {{"RED", "red"}, {"BLUE", "blue"}}));
+  // Keys are sorted and values are base32-encoded: "blue" -> "MJWHKZI=",
+  // "red" -> "OJSWI===".
+  EXPECT_EQ(
+      PrestoTypes::toSql(varcharEnum),
+      R"(test.enum.color:VarcharEnum(test.enum.color{"BLUE": "MJWHKZI=", "RED": "OJSWI==="}))");
+  EXPECT_EQ(
+      *functions::prestosql::parseType(PrestoTypes::toSql(varcharEnum)),
+      *varcharEnum);
 }
 
 TEST(PrestoTypeSqlTest, complex) {


### PR DESCRIPTION
Summary:
`PrestoTypes::toSql()` did not support BIGINT_ENUM or VARCHAR_ENUM — it threw `VELOX_UNSUPPORTED` for the `kLongEnumLiteral` and `kVarcharEnumLiteral` parameter kinds. This blocked serializing an enum-typed result column to a Presto type signature (e.g. when a native coordinator returns an enum column to a client).

Add Presto-SQL serialization to the enum types themselves: `BigintEnumType::toSql()` and `VarcharEnumType::toSql()`, with the shared formatting in a protected `EnumTypeBase::toSqlImpl()` helper. `PrestoTypes::toSql()` simply dispatches to them, matching the existing `isXxxType`/`asXxx` pattern, so the central function does not grow a branch per custom type. Output is `name:BigintEnum(name{"KEY": value, ...})` with keys sorted for deterministic output that round-trips through `parseType`. Varchar values are base32-encoded to match Presto's TypeSignature format, so this also adds `Base32::encode` to `velox/common/encode/Base32` (which previously had only `decode`).

The kind label (`BigintEnum`/`VarcharEnum`) now lives in a single `kKind` constant on each enum type, referenced by `toString()`, `toSql()`, and the type parser, replacing the copies that were previously hardcoded in each place.

Also matches the enum kind case-insensitively in the type parser, consistent with the caseless lexer and the case-insensitive TypeSignature contract, so a signature that was lowercased before parsing still resolves.

Reviewed By: mbasmanova

Differential Revision: D107405785


