### PR TITLE
refactor(writer): Clean up writer performance stats (#17719)

### DIFF
--- a/velox/common/base/RuntimeMetrics.cpp
+++ b/velox/common/base/RuntimeMetrics.cpp
@@ -120,4 +120,12 @@ void addThreadLocalRuntimeStat(
   }
 }
 
+void setThreadLocalRuntimeStat(
+    std::string_view name,
+    const RuntimeMetric& metric) {
+  if (localRuntimeStatWriter) {
+    localRuntimeStatWriter->setRuntimeStat(name, metric);
+  }
+}
+
 } // namespace facebook::velox

--- a/velox/common/base/RuntimeMetrics.h
+++ b/velox/common/base/RuntimeMetrics.h
@@ -87,6 +87,11 @@ class BaseRuntimeStatWriter {
   virtual void addRuntimeStat(
       std::string_view /* name */,
       const RuntimeCounter& /* value */) {}
+
+  /// Sets a runtime metric by name, replacing any existing value for that key.
+  virtual void setRuntimeStat(
+      std::string_view /* name */,
+      const RuntimeMetric& /* metric */) {}
 };
 
 /// Setting a concrete runtime stats writer on the thread will ensure that any
@@ -103,6 +108,12 @@ BaseRuntimeStatWriter* getThreadLocalRunTimeStatWriter();
 void addThreadLocalRuntimeStat(
     std::string_view name,
     const RuntimeCounter& value);
+
+/// Sets a runtime metric on the current Operator, overriding any existing
+/// value for the given name.
+void setThreadLocalRuntimeStat(
+    std::string_view name,
+    const RuntimeMetric& metric);
 
 /// Scope guard to conveniently set and revert back the current stat writer.
 class RuntimeStatWriterScopeGuard {

--- a/velox/common/base/tests/RuntimeMetricsTest.cpp
+++ b/velox/common/base/tests/RuntimeMetricsTest.cpp
@@ -99,4 +99,81 @@ TEST_F(RuntimeMetricsTest, saturateCast) {
   EXPECT_EQ(rm.max, maxInt64);
 }
 
+class SetThreadLocalRuntimeStatTest : public testing::Test {
+ protected:
+  class RuntimeStatCollector : public BaseRuntimeStatWriter {
+   public:
+    void setRuntimeStat(std::string_view name, const RuntimeMetric& metric)
+        override {
+      stats_.insert_or_assign(std::string(name), metric);
+    }
+
+    const RuntimeMetric* getMetric(const std::string& name) const {
+      auto it = stats_.find(name);
+      return it != stats_.end() ? &it->second : nullptr;
+    }
+
+   private:
+    std::unordered_map<std::string, RuntimeMetric> stats_;
+  };
+};
+
+TEST_F(SetThreadLocalRuntimeStatTest, singleMetric) {
+  RuntimeStatCollector collector;
+  RuntimeStatWriterScopeGuard guard(&collector);
+
+  RuntimeMetric metric(RuntimeCounter::Unit::kNone);
+  metric.addValue(10);
+  metric.addValue(20);
+  metric.addValue(30);
+
+  setThreadLocalRuntimeStat("test.metric", metric);
+
+  const auto* result = collector.getMetric("test.metric");
+  ASSERT_NE(result, nullptr);
+  EXPECT_EQ(result->count, 3);
+  EXPECT_EQ(result->sum, 60);
+  EXPECT_EQ(result->min, 10);
+  EXPECT_EQ(result->max, 30);
+}
+
+TEST_F(SetThreadLocalRuntimeStatTest, existingMetric) {
+  RuntimeStatCollector collector;
+  RuntimeStatWriterScopeGuard guard(&collector);
+
+  RuntimeMetric first(RuntimeCounter::Unit::kNone);
+  first.addValue(100);
+  setThreadLocalRuntimeStat("test.metric", first);
+
+  RuntimeMetric second(RuntimeCounter::Unit::kNone);
+  second.addValue(5);
+  second.addValue(15);
+  setThreadLocalRuntimeStat("test.metric", second);
+
+  const auto* result = collector.getMetric("test.metric");
+  ASSERT_NE(result, nullptr);
+  EXPECT_EQ(result->count, 2);
+  EXPECT_EQ(result->sum, 20);
+  EXPECT_EQ(result->min, 5);
+  EXPECT_EQ(result->max, 15);
+}
+
+TEST_F(SetThreadLocalRuntimeStatTest, emptyMetric) {
+  RuntimeStatCollector collector;
+  RuntimeStatWriterScopeGuard guard(&collector);
+
+  RuntimeMetric empty(RuntimeCounter::Unit::kNone);
+  setThreadLocalRuntimeStat("test.empty", empty);
+
+  const auto* result = collector.getMetric("test.empty");
+  ASSERT_NE(result, nullptr);
+  EXPECT_EQ(result->count, 0);
+}
+
+TEST_F(SetThreadLocalRuntimeStatTest, noWriter) {
+  RuntimeMetric metric(RuntimeCounter::Unit::kNanos);
+  metric.addValue(42);
+  setThreadLocalRuntimeStat("test.nowriter", metric);
+}
+
 } // namespace facebook::velox

--- a/velox/exec/IndexLookupJoin.cpp
+++ b/velox/exec/IndexLookupJoin.cpp
@@ -50,9 +50,9 @@ void IndexLookupJoin::IndexStatWriter::addRuntimeStat(
 }
 
 void IndexLookupJoin::IndexStatWriter::setRuntimeStat(
-    const std::string& name,
+    std::string_view name,
     const RuntimeMetric& metric) {
-  runtimeStats_.wlock()->insert_or_assign(name, metric);
+  runtimeStats_.wlock()->insert_or_assign(std::string(name), metric);
 }
 
 std::unordered_map<std::string, RuntimeMetric>

--- a/velox/exec/IndexLookupJoin.h
+++ b/velox/exec/IndexLookupJoin.h
@@ -98,7 +98,8 @@ class IndexLookupJoin : public Operator {
         override;
 
     // Sets a runtime metric in the index source stats map. Thread-safe.
-    void setRuntimeStat(const std::string& name, const RuntimeMetric& metric);
+    void setRuntimeStat(std::string_view name, const RuntimeMetric& metric)
+        override;
 
     // Returns a snapshot of the accumulated index source runtime stats.
     std::unordered_map<std::string, RuntimeMetric> runtimeStats() const;

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -548,6 +548,12 @@ void OperatorStats::addRuntimeStat(
   addOperatorRuntimeStats(name, value, runtimeStats);
 }
 
+void OperatorStats::setRuntimeStat(
+    std::string_view name,
+    const RuntimeMetric& metric) {
+  setOperatorRuntimeStats(name, metric, runtimeStats);
+}
+
 void OperatorStats::add(const OperatorStats& other) {
   numSplits += other.numSplits;
   rawInputBytes += other.rawInputBytes;

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -351,6 +351,12 @@ class Operator : public BaseRuntimeStatWriter {
     stats_.wlock()->addRuntimeStat(name, value);
   }
 
+  /// Sets a runtime metric on operator stats, overriding any existing value.
+  void setRuntimeStat(std::string_view name, const RuntimeMetric& metric)
+      override {
+    stats_.wlock()->setRuntimeStat(name, metric);
+  }
+
   /// Returns reference to the operator stats synchronized object to gain bulk
   /// read/write access to the stats.
   folly::Synchronized<OperatorStats>& stats() {

--- a/velox/exec/OperatorStats.h
+++ b/velox/exec/OperatorStats.h
@@ -237,6 +237,9 @@ struct OperatorStats {
   }
 
   void addRuntimeStat(std::string_view name, const RuntimeCounter& value);
+
+  /// Sets a named runtime metric, replacing any existing value for that name.
+  void setRuntimeStat(std::string_view name, const RuntimeMetric& metric);
   void add(const OperatorStats& other);
   void clear();
 };

--- a/velox/exec/OperatorUtils.cpp
+++ b/velox/exec/OperatorUtils.cpp
@@ -490,6 +490,13 @@ void addOperatorRuntimeStats(
   statIt->second.addValue(value.value);
 }
 
+void setOperatorRuntimeStats(
+    std::string_view name,
+    const RuntimeMetric& metric,
+    std::unordered_map<std::string, RuntimeMetric>& stats) {
+  stats.insert_or_assign(std::string(name), metric);
+}
+
 void aggregateOperatorRuntimeStats(
     std::unordered_map<std::string, RuntimeMetric>& stats) {
   for (auto& runtimeMetric : stats) {

--- a/velox/exec/OperatorUtils.h
+++ b/velox/exec/OperatorUtils.h
@@ -161,6 +161,12 @@ void addOperatorRuntimeStats(
     const RuntimeCounter& value,
     std::unordered_map<std::string, RuntimeMetric>& stats);
 
+/// Sets a runtime metric on operator 'stats', overriding any existing value.
+void setOperatorRuntimeStats(
+    std::string_view name,
+    const RuntimeMetric& metric,
+    std::unordered_map<std::string, RuntimeMetric>& stats);
+
 /// Aggregates runtime metrics we want to see per operator rather than per
 /// event.
 void aggregateOperatorRuntimeStats(


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookincubator/nimble/pull/802

Follow-up cleanup for D106147104. Addresses review comments from xiaoxmeng.

- Remove `totalFlushTiming_` / `stripeFlushTiming_` — `encodingTiming` subsumes flush timing
- Write I/O uses `NanosecondTimer` (wall-only) since CPU time is not meaningful for I/O; remove `writeCpuTimeNs`
- Replace `folly::StreamingStats<uint64_t>` with `velox::RuntimeMetric` for `chunkSizeStats` in `FieldWriterContext` and `VeloxWriter::Stats`
- Replace `std::vector<uint64_t> rowsPerStripe` with `velox::RuntimeMetric` in `VeloxWriter::Stats`
- Remove `inputBufferReallocCount` / `inputBufferReallocItemCount` from `Stats`
- Move chunk size and `rowsPerStripe` reporting from `customStats_` to `addThreadLocalRuntimeStat`
- Fix `FileWriter.cpp` `ws_pwrite` latency to use `writeWallTimeNs` instead of encoding timing
- Rename `writerStats` to `stats` in `NimbleWriter.cpp`

Reviewed By: xiaoxmeng

Differential Revision: D106909562
