### PR TITLE
fix: Initialize null children in `SelectiveMapAsStructColumnReader::getValues` (#17720)

### DIFF
--- a/velox/dwio/common/SelectiveRepeatedColumnReader.cpp
+++ b/velox/dwio/common/SelectiveRepeatedColumnReader.cpp
@@ -597,7 +597,22 @@ void SelectiveMapAsStructColumnReader::getValues(
   BaseVector::prepareForReuse(*result, rows.size());
   auto* resultRow = result->get()->asChecked<RowVector>();
   setComplexNulls(rows, *result);
-  for (auto& child : resultRow->children()) {
+  for (column_index_t i = 0; i < resultRow->childrenSize(); ++i) {
+    auto& child = resultRow->childAt(i);
+    // prepareForReuse() above reuses or reallocates existing children, but it
+    // skips children left as nullptr by prepareResult() in
+    // SelectiveStructColumnReaderBase, which only pre-allocates ROW-typed
+    // children -- the non-ROW value columns of a flat-map-as-struct result are
+    // left null. Unlike a regular struct, this reader scatters into its
+    // children with copyRanges() rather than recreating them per batch, so it
+    // must ensure they exist. Create any missing child here (directly at the
+    // final size); resize the rest, which prepareForReuse() shrank to 0.
+    if (FOLLY_UNLIKELY(!child)) {
+      child =
+          BaseVector::create(resultRow->type()->childAt(i), rows.size(), pool_);
+    } else {
+      child->resize(rows.size());
+    }
     bits::fillBits(child->mutableRawNulls(), 0, rows.size(), bits::kNull);
   }
   numValues_ = rows.size();

--- a/velox/dwio/dwrf/test/ReaderTest.cpp
+++ b/velox/dwio/dwrf/test/ReaderTest.cpp
@@ -3076,6 +3076,54 @@ TEST_F(TestReader, mapAsStructFilterAfterRead) {
   assertEqualVectors(expected, batch);
 }
 
+TEST_F(TestReader, mapAsStructNullChildrenWithReuse) {
+  // Reproduces the SIGSEGV fixed by initializing null children in
+  // SelectiveMapAsStructColumnReader::getValues. A filter on the
+  // flat-map-as-struct column routes the parent struct reader to call
+  // getValues() directly. The result is not singly referenced (a second
+  // reference is held, as a real downstream consumer would), so prepareResult()
+  // reallocates it via fillRowVectorChildren(), which leaves the
+  // flat-map-as-struct's non-ROW children as nullptr. getValues() must
+  // initialize those children rather than dereference them.
+  //
+  // This is identical to mapAsStructFilterAfterRead except for the held
+  // reference that forces the reallocation path.
+  auto row = makeRowVector({
+      makeMapVector<int32_t, int64_t>({{{1, 4}, {2, 5}}, {}, {{1, 6}, {3, 7}}}),
+      makeRowVector(
+          {makeConstant<int64_t>(0, 3)}, [](auto i) { return i == 0; }),
+  });
+  auto [writer, reader] =
+      createWriterReader({row}, pool(), dataIoStats_, metadataIoStats_);
+  auto outType =
+      ROW({"c0", "c1"}, {ROW({"3", "1"}, BIGINT()), ROW({"c0"}, BIGINT())});
+  auto spec = std::make_shared<common::ScanSpec>("<root>");
+  spec->addAllChildFields(*outType);
+  auto* c0Spec = spec->childByName("c0");
+  c0Spec->setFlatMapAsStruct(true);
+  c0Spec->setFilter(std::make_shared<common::IsNotNull>());
+  spec->childByName("c1")->setFilter(std::make_shared<common::IsNotNull>());
+  RowReaderOptions rowReaderOpts;
+  rowReaderOpts.setScanSpec(spec);
+  auto rowReader = reader->createRowReader(rowReaderOpts);
+  VectorPtr batch = BaseVector::create(outType, 0, pool());
+  // Hold a second reference so the result is not singly referenced; this forces
+  // prepareResult() down the fillRowVectorChildren() path, producing a
+  // flat-map-as-struct child whose non-ROW children are null.
+  VectorPtr holder = batch;
+  ASSERT_EQ(rowReader->next(10, batch), 3);
+  auto expected = makeRowVector({
+      makeRowVector(
+          {"3", "1"},
+          {
+              makeNullableFlatVector<int64_t>({std::nullopt, 7}),
+              makeNullableFlatVector<int64_t>({std::nullopt, 6}),
+          }),
+      makeRowVector({makeConstant<int64_t>(0, 2)}),
+  });
+  assertEqualVectors(expected, batch);
+}
+
 TEST_F(TestReader, mapAsStructAllEmpty) {
   auto row = makeRowVector({makeMapVector<int32_t, int64_t>({{}, {}})});
   auto [writer, reader] =


### PR DESCRIPTION
Summary:

`SelectiveMapAsStructColumnReader::getValues()` iterates over all children of the result RowVector and calls `mutableRawNulls()` on each to initialize null bits. However, when the result RowVector comes from `prepareResult()` in `SelectiveStructColumnReaderBase`, non-ROW children are intentionally left as nullptr (only ROW children are pre-allocated, per the design documented at `SelectiveStructColumnReader.cpp:35-39`). Calling `mutableRawNulls()` on a nullptr child causes a SIGSEGV.

This manifests when delta UPDATE files with MAP-typed columns are read via the Metalake merge-on-read path with `readFlatmapAsStruct` enabled. The `DeltaUpdateReader::loadValues()` copies delta values across Nimble stripes, which triggers lazy loading of MAP-as-struct columns, hitting the null children in `getValues()`.

This diff creates properly-typed empty vectors for any null children before the null-initialization loop, matching the contract that all children start as null (all bits set to `kNull`) before `makeCopyRanges` populates the ones with actual data.

Differential Revision: D107328181


