### PR TITLE
fix(ci): Disable cone mode in CI Failure Comment sparse-checkout

### DIFF
--- a/.github/workflows/ci-failure-comment.yml
+++ b/.github/workflows/ci-failure-comment.yml
@@ -155,6 +155,7 @@ jobs:
             CLAUDE.md
             .claude/CLAUDE.md
             .claude/skills/ci-failure-analysis/SKILL.md
+          sparse-checkout-cone-mode: false
           persist-credentials: false
 
       - name: Prepare analysis prompt


### PR DESCRIPTION
## Problem

The `CI Failure Comment` workflow has been failing on every CI failure on `main` since the sparse-checkout step was added to the `Checkout for Claude context and prompt` job. Example run:

https://github.com/facebookincubator/velox/actions/runs/26917977234/job/79412006526

```
fatal: '.claude/CLAUDE.md' is not a directory; to treat it as a directory anyway, rerun with --skip-checks
The process '/usr/bin/git' failed with exit code 128
```

## Cause

`actions/checkout@v5.0.0` runs `git sparse-checkout set` in **cone mode** by default, which only accepts directory patterns. The step's `sparse-checkout` list contains individual files (`CLAUDE.md`, `.claude/CLAUDE.md`, `.claude/skills/ci-failure-analysis/SKILL.md`), so git refuses.

## Fix

Set `sparse-checkout-cone-mode: false` on the offending step. In non-cone mode the entries are interpreted as gitignore-style patterns, which permit individual files.

Reproduced locally: cone mode dies with the same error; non-cone mode exits 0 and checks out the expected files. Pre-commit (yamllint, zizmor, "Validate GitHub Actions workflows") all pass.