### PR TITLE
fix: Handle NULL partition values in makePartitionKey (#17723)

### DIFF
--- a/velox/connectors/hive/HiveIndexSource.cpp
+++ b/velox/connectors/hive/HiveIndexSource.cpp
@@ -446,6 +446,12 @@ class UnionResultIterator : public IndexSource::ResultIterator {
 // partition group matches the probe input.
 class EmptyIterator : public IndexSource::ResultIterator {
  public:
+  static const std::shared_ptr<IndexSource::ResultIterator>& instance() {
+    static const std::shared_ptr<IndexSource::ResultIterator> kInstance =
+        std::make_shared<EmptyIterator>();
+    return kInstance;
+  }
+
   bool hasNext() override {
     return false;
   }
@@ -1146,9 +1152,9 @@ void HiveIndexSource::setPartitionValue(
 void HiveIndexSource::addSplits(
     std::vector<std::shared_ptr<ConnectorSplit>> splits) {
   VELOX_CHECK(
-      readers_.empty(),
-      "addSplits can only be called once for HiveIndexSource");
+      !splitsAdded_, "addSplits can only be called once for HiveIndexSource");
   VELOX_CHECK(!splits.empty(), "addSplits called with empty splits");
+  splitsAdded_ = true;
 
   std::vector<std::shared_ptr<const HiveConnectorSplit>> hiveSplits;
   hiveSplits.reserve(splits.size());
@@ -1178,14 +1184,19 @@ void HiveIndexSource::addSplits(
   }
   // Partitioned path: group splits by partition values, build a per-group
   // scan spec with partition constants set, and create readers per group.
+  // NOTE: splits with NULL routing partition values are silently skipped
+  // during grouping. If all splits are skipped, readers_ remains empty
+  // and lookup() returns an EmptyIterator for every request.
   buildPartitionGroups(std::move(hiveSplits));
 }
 
 void HiveIndexSource::buildPartitionGroups(
     std::vector<std::shared_ptr<const HiveConnectorSplit>> hiveSplits) {
   auto splitGroups = groupSplitsByPartitions(std::move(hiveSplits));
-  VELOX_CHECK(
-      !splitGroups.empty(), "No partition groups from non-empty splits");
+  if (splitGroups.empty()) {
+    // All splits had NULL routing partition values and were skipped.
+    return;
+  }
 
   const bool readTimestampAsLocal =
       hiveConfig_->readTimestampPartitionValueAsLocalTime(
@@ -1233,24 +1244,25 @@ HiveIndexSource::groupSplitsByPartitions(
   PartitionSplitGroupMap splitGroups;
   for (auto& split : hiveSplits) {
     auto key = makePartitionKey(*split);
-    splitGroups[std::move(key)].push_back(std::move(split));
+    if (key.has_value()) {
+      splitGroups[std::move(key.value())].push_back(std::move(split));
+    }
   }
   return splitGroups;
 }
 
-std::string HiveIndexSource::makePartitionKey(
+std::optional<std::string> HiveIndexSource::makePartitionKey(
     const HiveConnectorSplit& split) const {
   // Encodes the partition values into an opaque grouping key using '\0' as
-  // field separator. Safe because Hive partition values come from filesystem
-  // directory names which cannot contain '\0'.
+  // field separator. Returns nullopt if any routing partition column has a
+  // NULL value — no probe row can match such splits (NULL != NULL).
   std::string key;
   for (const auto& cond : partitionIndexConditions_) {
     const auto& partitionValue =
         extractPartitionValue(split, cond.partitionColumnName);
-    VELOX_CHECK(
-        partitionValue.has_value(),
-        "Split has null partition value for routing column: {}",
-        cond.partitionColumnName);
+    if (!partitionValue.has_value()) {
+      return std::nullopt;
+    }
     key += *partitionValue;
     key += '\0';
   }
@@ -1302,7 +1314,13 @@ HiveIndexSource::PartitionGroup* HiveIndexSource::findPartitionGroup(
 std::shared_ptr<IndexSource::ResultIterator> HiveIndexSource::lookup(
     const Request& request) {
   VELOX_CHECK_GT(request.input->size(), 0, "Empty lookup request");
-  VELOX_CHECK(!readers_.empty(), "No index readers available for lookup");
+  VELOX_CHECK(splitsAdded_, "No splits added before lookup");
+
+  // All splits may have been filtered out (e.g., all had NULL partition
+  // routing values). Return empty results for every lookup.
+  if (readers_.empty()) {
+    return EmptyIterator::instance();
+  }
 
   auto options = SplitIndexReader::Options{
       .maxRowsPerRequest = static_cast<vector_size_t>(maxRowsPerIndexRequest_)};
@@ -1329,9 +1347,7 @@ std::shared_ptr<IndexSource::ResultIterator> HiveIndexSource::lookup(
 
   if (partitionRowMap.empty()) {
     // No partition group matched any probe row.
-    static const std::shared_ptr<IndexSource::ResultIterator> kEmpty =
-        std::make_shared<EmptyIterator>();
-    return kEmpty;
+    return EmptyIterator::instance();
   }
 
   if (partitionRowMap.size() == 1) {

--- a/velox/connectors/hive/HiveIndexSource.h
+++ b/velox/connectors/hive/HiveIndexSource.h
@@ -200,7 +200,8 @@ class HiveIndexSource : public IndexSource,
   void buildPartitionGroups(
       std::vector<std::shared_ptr<const HiveConnectorSplit>> hiveSplits);
 
-  // Groups splits by their partition column values.
+  // Groups splits by their partition column values. Splits with NULL
+  // routing partition values are skipped.
   folly::F14FastMap<
       std::string,
       std::vector<std::shared_ptr<const HiveConnectorSplit>>>
@@ -208,7 +209,9 @@ class HiveIndexSource : public IndexSource,
       std::vector<std::shared_ptr<const HiveConnectorSplit>> hiveSplits) const;
 
   // Encodes a split's partition values into an opaque grouping key.
-  std::string makePartitionKey(const HiveConnectorSplit& split) const;
+  // Returns nullopt if any routing partition column has a NULL value.
+  std::optional<std::string> makePartitionKey(
+      const HiveConnectorSplit& split) const;
 
   // Splits sharing the same partition values, grouped during addSplits().
   // One group per distinct set of partition column values. Each group owns
@@ -361,6 +364,10 @@ class HiveIndexSource : public IndexSource,
   // Partition groups built during addSplits() when partition index conditions
   // are present. One group per distinct set of partition column values.
   std::vector<PartitionGroup> partitionGroups_;
+
+  // Set to true after addSplits() is called. Used to distinguish "no splits
+  // added" (programming error) from "all splits filtered out" (valid case).
+  bool splitsAdded_{false};
 
   // Cached empty output vector.
   RowVectorPtr emptyOutput_;


### PR DESCRIPTION
Summary:

`makePartitionKey()` crashed with a `VELOX_CHECK` when a split had a NULL partition value (Hive `__HIVE_DEFAULT_PARTITION__`). NULL partitions are valid on the index side — they contain real data, but no probe row can match them since `equalValueAt()` returns false for null-vs-null comparisons.

Skip splits with NULL routing partition values in `groupSplitsByPartitions()` instead of crashing. `makePartitionKey()` returns `std::optional<std::string>`, returning `nullopt` for splits with any NULL routing column. Handle the case where all splits are filtered out by returning an `EmptyIterator` from `lookup()`. Add a `splitsAdded_` flag to distinguish "no splits added" (programming error) from "all splits filtered out" (valid case).

Also extract `EmptyIterator::instance()` as a static singleton accessor to avoid duplicating the `kEmpty` pattern at multiple call sites.

Reviewed By: xiaoxmeng

Differential Revision: D107459764


