### PR TITLE
fix: Core dump when import UnknownType arrow array

### DIFF
--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -2310,9 +2310,9 @@ VectorPtr importFromArrowImpl(
   // First parse and generate a Velox type.
   auto type = importFromArrow(arrowSchema);
 
-  if (type->isUnknown()) {
+  if (type->isUnknown() && !arrowSchema.dictionary) {
     VELOX_USER_CHECK_EQ(
-        arrowArray.n_buffers, 0, "Null type expects zero buffers as input.");
+        arrowArray.n_buffers, 0, "NullType expects zero buffers as input.");
     return BaseVector::createNullConstant(type, arrowArray.length, pool);
   }
 

--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -2310,6 +2310,12 @@ VectorPtr importFromArrowImpl(
   // First parse and generate a Velox type.
   auto type = importFromArrow(arrowSchema);
 
+  if (type->isUnknown()) {
+    VELOX_USER_CHECK_EQ(
+        arrowArray.n_buffers, 0, "Null type expects zero buffers as input.");
+    return BaseVector::createNullConstant(type, arrowArray.length, pool);
+  }
+
   // Wrap the nulls buffer into a Velox BufferView (zero-copy). Null buffer size
   // needs to be at least one bit per element.
   BufferPtr nulls = nullptr;

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -1580,9 +1580,9 @@ class ArrowBridgeArrayImportTest : public ArrowBridgeArrayExportTest {
         });
   }
 
-  void testImportNullType() {
+  void testImportNullType(int64_t nullCount) {
     ArrowSchema arrowSchema = makeArrowSchema("n");
-    ArrowArray arrowArray = makeArrowArray(nullptr, 0, 4, 4);
+    ArrowArray arrowArray = makeArrowArray(nullptr, 0, 4, nullCount);
 
     auto output = importFromArrow(arrowSchema, arrowArray, pool_.get());
 
@@ -1592,6 +1592,30 @@ class ArrowBridgeArrayImportTest : public ArrowBridgeArrayExportTest {
     EXPECT_EQ(4, *output->getNullCount());
     for (vector_size_t i = 0; i < output->size(); ++i) {
       EXPECT_TRUE(output->isNullAt(i));
+    }
+  }
+
+  void testImportDictionaryEncodedNullType() {
+    const int32_t indices[] = {0, 0, 0, 0};
+    const void* buffers[] = {nullptr, indices};
+
+    ArrowSchema arrowSchema = makeArrowSchema("i");
+    ArrowSchema dictionarySchema = makeArrowSchema("n");
+    arrowSchema.dictionary = &dictionarySchema;
+
+    ArrowArray arrowArray = makeArrowArray(buffers, 2, 4, 0);
+    ArrowArray dictionaryArray = makeArrowArray(nullptr, 0, 1, 1);
+    arrowArray.dictionary = &dictionaryArray;
+
+    auto output = importFromArrow(arrowSchema, arrowArray, pool_.get());
+
+    ASSERT_EQ(*output->type(), *UNKNOWN());
+    EXPECT_EQ(output->size(), 4);
+
+    DecodedVector decoded(*output);
+    EXPECT_TRUE(decoded.mayHaveNulls());
+    for (vector_size_t i = 0; i < output->size(); ++i) {
+      EXPECT_TRUE(decoded.isNullAt(i));
     }
   }
 
@@ -2129,7 +2153,8 @@ TEST_F(ArrowBridgeArrayImportAsViewerTest, stringview) {
 }
 
 TEST_F(ArrowBridgeArrayImportAsViewerTest, nullType) {
-  testImportNullType();
+  testImportNullType(4);
+  testImportNullType(-1);
 }
 
 TEST_F(ArrowBridgeArrayImportAsViewerTest, row) {
@@ -2146,6 +2171,10 @@ TEST_F(ArrowBridgeArrayImportAsViewerTest, map) {
 
 TEST_F(ArrowBridgeArrayImportAsViewerTest, dictionary) {
   testImportDictionary();
+}
+
+TEST_F(ArrowBridgeArrayImportAsViewerTest, dictionaryEncodedNullType) {
+  testImportDictionaryEncodedNullType();
 }
 
 TEST_F(ArrowBridgeArrayImportAsViewerTest, ree) {
@@ -2243,7 +2272,8 @@ TEST_F(ArrowBridgeArrayImportAsOwnerTest, stringview) {
 }
 
 TEST_F(ArrowBridgeArrayImportAsOwnerTest, nullType) {
-  testImportNullType();
+  testImportNullType(4);
+  testImportNullType(-1);
 }
 
 TEST_F(ArrowBridgeArrayImportAsOwnerTest, row) {
@@ -2260,6 +2290,10 @@ TEST_F(ArrowBridgeArrayImportAsOwnerTest, map) {
 
 TEST_F(ArrowBridgeArrayImportAsOwnerTest, dictionary) {
   testImportDictionary();
+}
+
+TEST_F(ArrowBridgeArrayImportAsOwnerTest, dictionaryEncodedNullType) {
+  testImportDictionaryEncodedNullType();
 }
 
 TEST_F(ArrowBridgeArrayImportAsOwnerTest, ree) {

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -1580,6 +1580,21 @@ class ArrowBridgeArrayImportTest : public ArrowBridgeArrayExportTest {
         });
   }
 
+  void testImportNullType() {
+    ArrowSchema arrowSchema = makeArrowSchema("n");
+    ArrowArray arrowArray = makeArrowArray(nullptr, 0, 4, 4);
+
+    auto output = importFromArrow(arrowSchema, arrowArray, pool_.get());
+
+    EXPECT_TRUE(output->type()->kindEquals(UNKNOWN()));
+    EXPECT_EQ(4, output->size());
+    ASSERT_TRUE(output->mayHaveNulls());
+    EXPECT_EQ(4, *output->getNullCount());
+    for (vector_size_t i = 0; i < output->size(); ++i) {
+      EXPECT_TRUE(output->isNullAt(i));
+    }
+  }
+
  private:
   // Creates short decimals from int128 and asserts the content of actual vector
   // with the expected values.
@@ -2113,6 +2128,10 @@ TEST_F(ArrowBridgeArrayImportAsViewerTest, stringview) {
   testImportStringView();
 }
 
+TEST_F(ArrowBridgeArrayImportAsViewerTest, nullType) {
+  testImportNullType();
+}
+
 TEST_F(ArrowBridgeArrayImportAsViewerTest, row) {
   testImportRow();
 }
@@ -2221,6 +2240,10 @@ TEST_F(ArrowBridgeArrayImportAsOwnerTest, string64) {
 
 TEST_F(ArrowBridgeArrayImportAsOwnerTest, stringview) {
   testImportStringView();
+}
+
+TEST_F(ArrowBridgeArrayImportAsOwnerTest, nullType) {
+  testImportNullType();
 }
 
 TEST_F(ArrowBridgeArrayImportAsOwnerTest, row) {

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -1609,8 +1609,8 @@ class ArrowBridgeArrayImportTest : public ArrowBridgeArrayExportTest {
 
     auto output = importFromArrow(arrowSchema, arrowArray, pool_.get());
 
-    ASSERT_EQ(*output->type(), *UNKNOWN());
-    EXPECT_EQ(output->size(), 4);
+    ASSERT_EQ(*UNKNOWN(), *output->type());
+    EXPECT_EQ(4, output->size());
 
     DecodedVector decoded(*output);
     EXPECT_TRUE(decoded.mayHaveNulls());


### PR DESCRIPTION
In arrow, the UnknownType has 0 buffer, it would cause coredump when importing.

Fix https://github.com/facebookincubator/velox/issues/17731