### PR TITLE
refactor: Rename inconsistent Hive Parquet config keys

### DIFF
--- a/velox/connectors/hive/FileConfig.h
+++ b/velox/connectors/hive/FileConfig.h
@@ -49,7 +49,7 @@ class FileConfig {
       kParquetUseColumnNames,
       isParquetUseColumnNames,
       "parquet_use_column_names",
-      "parquet.use-column-names",
+      "hive.parquet.use-column-names",
       bool,
       false,
       "Map Parquet table field names to file field names using names, not indices.")
@@ -58,8 +58,8 @@ class FileConfig {
       kAllowInt32NarrowingSession,
       kAllowInt32Narrowing,
       allowInt32Narrowing,
-      "allow_int32_narrowing",
-      "parquet.allow-int32-narrowing",
+      "parquet_allow_int32_narrowing",
+      "hive.parquet.allow-int32-narrowing",
       bool,
       false,
       "Allow reading INT32 Parquet columns as a narrower integer type.")
@@ -109,7 +109,7 @@ class FileConfig {
       kParquetFooterSpeculativeIoSize,
       parquetFooterSpeculativeIoSize,
       "parquet_footer_speculative_io_size",
-      "parquet.footer-speculative-io-size",
+      "hive.parquet.footer-speculative-io-size",
       uint64_t,
       256UL << 10,
       "Speculative tail-read size in bytes for Parquet files.")
@@ -249,10 +249,12 @@ class FileConfig {
       true,
       "Enable selective Nimble reader.")
 
-  VELOX_HIVE_CONFIG(
+  VELOX_HIVE_CONFIG_LEGACY(
       kParquetFooterMemoryTrackingThresholdSession,
+      kParquetFooterMemoryTrackingThreshold,
       parquetFooterMemoryTrackingThreshold,
       "parquet_footer_memory_tracking_threshold",
+      "hive.parquet.footer-memory-tracking-threshold",
       uint64_t,
       std::numeric_limits<uint64_t>::max(),
       "Serialized footer size in bytes beyond which the Parquet reader "

--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -18,6 +18,7 @@
 
 #include <boost/algorithm/string.hpp>
 #include "velox/common/config/Config.h"
+#include "velox/dwio/common/Options.h"
 
 namespace facebook::velox::connector::hive {
 
@@ -47,7 +48,9 @@ const std::vector<config::ConfigProperty>& HiveConfig::registeredProperties() {
 
     VELOX_HIVE_CONFIG_REGISTER(kInsertExistingPartitionsBehaviorSession);
     VELOX_HIVE_CONFIG_REGISTER(kSortWriterMaxOutputBytesSession);
-    VELOX_HIVE_CONFIG_REGISTER(kMaxTargetFileSizeSession);
+    VELOX_HIVE_CONFIG_REGISTER(kParquetMaxTargetFileSizeSession);
+    VELOX_HIVE_CONFIG_REGISTER(kOrcMaxTargetFileSizeSession);
+    VELOX_HIVE_CONFIG_REGISTER(kNimbleMaxTargetFileSizeSession);
     VELOX_HIVE_CONFIG_REGISTER(kMaxPartitionsPerWritersSession);
     VELOX_HIVE_CONFIG_REGISTER(kAllowNullPartitionKeysSession);
     VELOX_HIVE_CONFIG_REGISTER(kPartitionPathAsLowerCaseSession);
@@ -152,12 +155,38 @@ uint64_t HiveConfig::sortWriterMaxOutputBytes(
 }
 
 uint64_t HiveConfig::maxTargetFileSizeBytes(
+    dwio::common::FileFormat fileFormat,
     const config::ConfigBase* session) const {
+  const char* sessionKey;
+  const char* configKey;
+  const char* defaultValue;
+  switch (fileFormat) {
+    case dwio::common::FileFormat::PARQUET:
+      sessionKey = kParquetMaxTargetFileSizeSession;
+      configKey = kParquetMaxTargetFileSize;
+      defaultValue = kParquetMaxTargetFileSizeSessionProperty::defaultValue;
+      break;
+    case dwio::common::FileFormat::DWRF:
+    case dwio::common::FileFormat::ORC:
+      sessionKey = kOrcMaxTargetFileSizeSession;
+      configKey = kOrcMaxTargetFileSize;
+      defaultValue = kOrcMaxTargetFileSizeSessionProperty::defaultValue;
+      break;
+    case dwio::common::FileFormat::NIMBLE:
+      sessionKey = kNimbleMaxTargetFileSizeSession;
+      configKey = kNimbleMaxTargetFileSize;
+      defaultValue = kNimbleMaxTargetFileSizeSessionProperty::defaultValue;
+      break;
+    default:
+      return 0;
+  }
+
+  auto maxTargetFileSize = session->get<std::string>(sessionKey);
+  if (!maxTargetFileSize.has_value()) {
+    maxTargetFileSize = config_->get<std::string>(configKey);
+  }
   return config::toCapacity(
-      session->get<std::string>(
-          kMaxTargetFileSizeSession,
-          config_->get<std::string>(kMaxTargetFileSize, "0B")),
-      config::CapacityUnit::BYTE);
+      maxTargetFileSize.value_or(defaultValue), config::CapacityUnit::BYTE);
 }
 
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -77,7 +77,7 @@ class HiveConfig : public FileConfig {
       "0B",
       "Maximum ORC target file size. 0 means no limit.")
   static constexpr const char* kOrcMaxTargetFileSize =
-      "hive.orc.max-target-file-size";
+      "hive.orc.writer.max-target-file-size";
 
   VELOX_HIVE_CONFIG_PROPERTY(
       kNimbleMaxTargetFileSizeSession,
@@ -86,7 +86,7 @@ class HiveConfig : public FileConfig {
       "0B",
       "Maximum nimble target file size. 0 means no limit.")
   static constexpr const char* kNimbleMaxTargetFileSize =
-      "hive.nimble.max-target-file-size";
+      "hive.nimble.writer.max-target-file-size";
 
   // --- VELOX_HIVE_CONFIG properties ---
 

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -18,6 +18,10 @@
 #include "velox/connectors/hive/FileConfig.h"
 #include "velox/connectors/hive/HiveConfigMacrosDefine.h"
 
+namespace facebook::velox::dwio::common {
+enum class FileFormat;
+}
+
 namespace facebook::velox::connector::hive {
 
 /// Hive connector configs. Extends FileConfig with Hive-specific settings
@@ -58,12 +62,31 @@ class HiveConfig : public FileConfig {
       "sort-writer-max-output-bytes";
 
   VELOX_HIVE_CONFIG_PROPERTY(
-      kMaxTargetFileSizeSession,
-      "max_target_file_size",
+      kParquetMaxTargetFileSizeSession,
+      "parquet_writer_max_target_file_size",
       std::string,
       "0B",
       "Maximum target file size. 0 means no limit.")
-  static constexpr const char* kMaxTargetFileSize = "max-target-file-size";
+  static constexpr const char* kParquetMaxTargetFileSize =
+      "hive.parquet.writer.max-target-file-size";
+
+  VELOX_HIVE_CONFIG_PROPERTY(
+      kOrcMaxTargetFileSizeSession,
+      "orc_writer_max_target_file_size",
+      std::string,
+      "0B",
+      "Maximum ORC target file size. 0 means no limit.")
+  static constexpr const char* kOrcMaxTargetFileSize =
+      "hive.orc.max-target-file-size";
+
+  VELOX_HIVE_CONFIG_PROPERTY(
+      kNimbleMaxTargetFileSizeSession,
+      "nimble_writer_max_target_file_size",
+      std::string,
+      "0B",
+      "Maximum nimble target file size. 0 means no limit.")
+  static constexpr const char* kNimbleMaxTargetFileSize =
+      "hive.nimble.max-target-file-size";
 
   // --- VELOX_HIVE_CONFIG properties ---
 
@@ -225,7 +248,9 @@ class HiveConfig : public FileConfig {
 
   uint64_t sortWriterMaxOutputBytes(const config::ConfigBase* session) const;
 
-  uint64_t maxTargetFileSizeBytes(const config::ConfigBase* session) const;
+  uint64_t maxTargetFileSizeBytes(
+      dwio::common::FileFormat fileFormat,
+      const config::ConfigBase* session) const;
 
   explicit HiveConfig(std::shared_ptr<const config::ConfigBase> config)
       : FileConfig(std::move(config)) {}

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -638,6 +638,7 @@ std::shared_ptr<dwio::common::WriterOptions> HiveDataSink::createWriterOptions(
   options->sessionTimezoneName = connectorQueryCtx_->sessionTimezone();
   options->adjustTimestampToTimezone =
       connectorQueryCtx_->adjustTimestampToTimezone();
+  options->maxTargetFileSizeBytes = maxTargetFileBytes_;
   options->processConfigs(*hiveConfig_->config(), *connectorSessionProperties);
   return options;
 }

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -444,6 +444,7 @@ HiveDataSink::HiveDataSink(
           std::move(partitionIdGenerator),
           dwio::common::getWriterFactory(insertTableHandle->storageFormat()),
           hiveConfig->maxTargetFileSizeBytes(
+              insertTableHandle->storageFormat(),
               connectorQueryCtx->sessionProperties()),
           hiveConfig->isPartitionPathAsLowerCase(
               connectorQueryCtx->sessionProperties()),

--- a/velox/connectors/hive/iceberg/tests/IcebergInsertTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergInsertTest.cpp
@@ -246,7 +246,8 @@ TEST_F(IcebergInsertTest, partitionMultiColumns) {
 }
 
 TEST_F(IcebergInsertTest, maxTargetFileSizeRotation) {
-  setConnectorSessionProperty(HiveConfig::kMaxTargetFileSizeSession, "4KB");
+  setConnectorSessionProperty(
+      HiveConfig::kParquetMaxTargetFileSizeSession, "4KB");
 
   const auto outputPath = TempDirectoryPath::create()->getPath();
   const auto rowType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});

--- a/velox/connectors/hive/tests/FileConfigTest.cpp
+++ b/velox/connectors/hive/tests/FileConfigTest.cpp
@@ -165,6 +165,46 @@ TEST(FileConfigTest, overrideSession) {
   EXPECT_TRUE(config.nimblePreserveDictionaryEncoding(session.get()));
 }
 
+TEST(FileConfigTest, parquetCanonicalSessionKeys) {
+  FileConfig config(
+      std::make_shared<config::ConfigBase>(
+          std::unordered_map<std::string, std::string>()));
+  std::unordered_map<std::string, std::string> sessionOverride = {
+      {FileConfig::kParquetUseColumnNamesSession, "true"},
+      {FileConfig::kAllowInt32NarrowingSession, "true"},
+      {FileConfig::kParquetFooterSpeculativeIoSizeSession,
+       std::to_string(512UL << 10)},
+      {FileConfig::kParquetFooterMemoryTrackingThresholdSession, "1024"},
+  };
+  const auto session =
+      std::make_unique<config::ConfigBase>(std::move(sessionOverride));
+
+  EXPECT_TRUE(config.isParquetUseColumnNames(session.get()));
+  EXPECT_TRUE(config.allowInt32Narrowing(session.get()));
+  EXPECT_EQ(config.parquetFooterSpeculativeIoSize(session.get()), 512UL << 10);
+  EXPECT_EQ(config.parquetFooterMemoryTrackingThreshold(session.get()), 1024);
+}
+
+TEST(FileConfigTest, parquetCanonicalConfigKeys) {
+  std::unordered_map<std::string, std::string> configFromFile = {
+      {FileConfig::kParquetUseColumnNames, "true"},
+      {FileConfig::kAllowInt32Narrowing, "true"},
+      {FileConfig::kParquetFooterSpeculativeIoSize, std::to_string(1UL << 20)},
+      {FileConfig::kParquetFooterMemoryTrackingThreshold, "2048"},
+  };
+  FileConfig config(
+      std::make_shared<config::ConfigBase>(std::move(configFromFile)));
+  const auto emptySession = std::make_unique<config::ConfigBase>(
+      std::unordered_map<std::string, std::string>());
+
+  EXPECT_TRUE(config.isParquetUseColumnNames(emptySession.get()));
+  EXPECT_TRUE(config.allowInt32Narrowing(emptySession.get()));
+  EXPECT_EQ(
+      config.parquetFooterSpeculativeIoSize(emptySession.get()), 1UL << 20);
+  EXPECT_EQ(
+      config.parquetFooterMemoryTrackingThreshold(emptySession.get()), 2048);
+}
+
 TEST(FileConfigTest, nullConfig) {
   VELOX_ASSERT_THROW(
       FileConfig(nullptr), "Config is null for FileConfig initialization");

--- a/velox/connectors/hive/tests/HiveConfigTest.cpp
+++ b/velox/connectors/hive/tests/HiveConfigTest.cpp
@@ -221,6 +221,7 @@ TEST(HiveConfigTest, maxTargetFileSizeConfigAndSessionKeys) {
           std::unordered_map<std::string, std::string>{
               {HiveConfig::kParquetMaxTargetFileSize, "16MB"},
               {HiveConfig::kOrcMaxTargetFileSize, "24MB"},
+              {HiveConfig::kNimbleMaxTargetFileSize, "40MB"},
           }));
   EXPECT_EQ(
       config.maxTargetFileSizeBytes(
@@ -234,11 +235,16 @@ TEST(HiveConfigTest, maxTargetFileSizeConfigAndSessionKeys) {
       config.maxTargetFileSizeBytes(
           dwio::common::FileFormat::ORC, emptySession.get()),
       24UL << 20);
+  EXPECT_EQ(
+      config.maxTargetFileSizeBytes(
+          dwio::common::FileFormat::NIMBLE, emptySession.get()),
+      40UL << 20);
 
   auto session = std::make_unique<config::ConfigBase>(
       std::unordered_map<std::string, std::string>{
           {HiveConfig::kParquetMaxTargetFileSizeSession, "32MB"},
           {HiveConfig::kOrcMaxTargetFileSizeSession, "48MB"},
+          {HiveConfig::kNimbleMaxTargetFileSizeSession, "56MB"},
       });
   EXPECT_EQ(
       config.maxTargetFileSizeBytes(
@@ -252,4 +258,8 @@ TEST(HiveConfigTest, maxTargetFileSizeConfigAndSessionKeys) {
       config.maxTargetFileSizeBytes(
           dwio::common::FileFormat::ORC, session.get()),
       48UL << 20);
+  EXPECT_EQ(
+      config.maxTargetFileSizeBytes(
+          dwio::common::FileFormat::NIMBLE, session.get()),
+      56UL << 20);
 }

--- a/velox/connectors/hive/tests/HiveConfigTest.cpp
+++ b/velox/connectors/hive/tests/HiveConfigTest.cpp
@@ -17,6 +17,7 @@
 #include "velox/connectors/hive/HiveConfig.h"
 #include "gtest/gtest.h"
 #include "velox/common/config/Config.h"
+#include "velox/dwio/common/Options.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::connector::hive;
@@ -209,4 +210,46 @@ TEST(HiveConfigTest, overrideSession) {
   ASSERT_EQ(hiveConfig.nimbleFooterSpeculativeIoSize(session.get()), 2UL << 20);
   ASSERT_TRUE(hiveConfig.nimbleStringDecoderZeroCopy(session.get()));
   ASSERT_TRUE(hiveConfig.nimblePreserveDictionaryEncoding(session.get()));
+}
+
+TEST(HiveConfigTest, maxTargetFileSizeConfigAndSessionKeys) {
+  auto emptySession = std::make_unique<config::ConfigBase>(
+      std::unordered_map<std::string, std::string>());
+
+  HiveConfig config(
+      std::make_shared<config::ConfigBase>(
+          std::unordered_map<std::string, std::string>{
+              {HiveConfig::kParquetMaxTargetFileSize, "16MB"},
+              {HiveConfig::kOrcMaxTargetFileSize, "24MB"},
+          }));
+  EXPECT_EQ(
+      config.maxTargetFileSizeBytes(
+          dwio::common::FileFormat::PARQUET, emptySession.get()),
+      16UL << 20);
+  EXPECT_EQ(
+      config.maxTargetFileSizeBytes(
+          dwio::common::FileFormat::DWRF, emptySession.get()),
+      24UL << 20);
+  EXPECT_EQ(
+      config.maxTargetFileSizeBytes(
+          dwio::common::FileFormat::ORC, emptySession.get()),
+      24UL << 20);
+
+  auto session = std::make_unique<config::ConfigBase>(
+      std::unordered_map<std::string, std::string>{
+          {HiveConfig::kParquetMaxTargetFileSizeSession, "32MB"},
+          {HiveConfig::kOrcMaxTargetFileSizeSession, "48MB"},
+      });
+  EXPECT_EQ(
+      config.maxTargetFileSizeBytes(
+          dwio::common::FileFormat::PARQUET, session.get()),
+      32UL << 20);
+  EXPECT_EQ(
+      config.maxTargetFileSizeBytes(
+          dwio::common::FileFormat::DWRF, session.get()),
+      48UL << 20);
+  EXPECT_EQ(
+      config.maxTargetFileSizeBytes(
+          dwio::common::FileFormat::ORC, session.get()),
+      48UL << 20);
 }

--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -1334,7 +1334,7 @@ TEST_F(HiveDataSinkTest, fileRotationBasic) {
   const auto outputDirectory = TempDirectoryPath::create();
 
   std::unordered_map<std::string, std::string> connectorConfig;
-  connectorConfig.emplace("max-target-file-size", "1MB");
+  connectorConfig.emplace(HiveConfig::kOrcMaxTargetFileSize, "1MB");
   connectorConfig.emplace("hive.orc.writer.stripe-max-size", "256KB");
   connectorConfig_ = std::make_shared<HiveConfig>(
       std::make_shared<config::ConfigBase>(std::move(connectorConfig)));
@@ -1375,7 +1375,7 @@ TEST_F(HiveDataSinkTest, fileRotationNoEmptyTrailingFile) {
   const auto outputDirectory = TempDirectoryPath::create();
 
   std::unordered_map<std::string, std::string> connectorConfig;
-  connectorConfig.emplace("max-target-file-size", "1KB");
+  connectorConfig.emplace(HiveConfig::kOrcMaxTargetFileSize, "1KB");
   connectorConfig.emplace("hive.orc.writer.stripe-max-size", "1KB");
   connectorConfig_ = std::make_shared<HiveConfig>(
       std::make_shared<config::ConfigBase>(std::move(connectorConfig)));
@@ -1409,7 +1409,7 @@ TEST_F(HiveDataSinkTest, fileRotationDisabledForBucketedTables) {
   const auto outputDirectory = TempDirectoryPath::create();
 
   std::unordered_map<std::string, std::string> connectorConfig;
-  connectorConfig.emplace("max-target-file-size", "100KB");
+  connectorConfig.emplace(HiveConfig::kOrcMaxTargetFileSize, "100KB");
   connectorConfig_ = std::make_shared<HiveConfig>(
       std::make_shared<config::ConfigBase>(std::move(connectorConfig)));
 
@@ -1456,7 +1456,7 @@ TEST_F(HiveDataSinkTest, fileRotationDisabledForBucketedTables) {
 TEST_F(HiveDataSinkTest, fileRotationDisabledByDefault) {
   const auto outputDirectory = TempDirectoryPath::create();
 
-  // Don't set max-target-file-size (use default which is disabled)
+  // Don't set max target file size (use default which is disabled)
   auto dataSink = createDataSink(rowType_, outputDirectory->getPath());
 
   // Write a lot of data
@@ -1517,7 +1517,7 @@ TEST_F(HiveDataSinkTest, fileRotationIoStatsAccumulation) {
   const auto outputDirectory = TempDirectoryPath::create();
 
   std::unordered_map<std::string, std::string> connectorConfig;
-  connectorConfig.emplace("max-target-file-size", "1MB");
+  connectorConfig.emplace(HiveConfig::kOrcMaxTargetFileSize, "1MB");
   connectorConfig.emplace("hive.orc.writer.stripe-max-size", "256KB");
   connectorConfig_ = std::make_shared<HiveConfig>(
       std::make_shared<config::ConfigBase>(std::move(connectorConfig)));
@@ -1572,7 +1572,7 @@ TEST_F(HiveDataSinkTest, fileRotationFileInfoConsistency) {
   const auto outputDirectory = TempDirectoryPath::create();
 
   std::unordered_map<std::string, std::string> connectorConfig;
-  connectorConfig.emplace("max-target-file-size", "500KB");
+  connectorConfig.emplace(HiveConfig::kOrcMaxTargetFileSize, "500KB");
   connectorConfig.emplace("hive.orc.writer.stripe-max-size", "128KB");
   connectorConfig_ = std::make_shared<HiveConfig>(
       std::make_shared<config::ConfigBase>(std::move(connectorConfig)));
@@ -1649,7 +1649,7 @@ TEST_F(HiveDataSinkTest, fileRotationStatsProgressDuringWrite) {
   const auto outputDirectory = TempDirectoryPath::create();
 
   std::unordered_map<std::string, std::string> connectorConfig;
-  connectorConfig.emplace("max-target-file-size", "256KB");
+  connectorConfig.emplace(HiveConfig::kOrcMaxTargetFileSize, "256KB");
   connectorConfig.emplace("hive.orc.writer.stripe-max-size", "64KB");
   connectorConfig_ = std::make_shared<HiveConfig>(
       std::make_shared<config::ConfigBase>(std::move(connectorConfig)));
@@ -1689,7 +1689,7 @@ TEST_F(HiveDataSinkTest, fileRotationWithPartitionedTable) {
   const auto outputDirectory = TempDirectoryPath::create();
 
   std::unordered_map<std::string, std::string> connectorConfig;
-  connectorConfig.emplace("max-target-file-size", "256KB");
+  connectorConfig.emplace(HiveConfig::kOrcMaxTargetFileSize, "256KB");
   connectorConfig.emplace("hive.orc.writer.stripe-max-size", "64KB");
   connectorConfig_ = std::make_shared<HiveConfig>(
       std::make_shared<config::ConfigBase>(std::move(connectorConfig)));
@@ -1757,7 +1757,7 @@ TEST_F(HiveDataSinkTest, fileRotationWriteIOTimeAccumulation) {
   const auto outputDirectory = TempDirectoryPath::create();
 
   std::unordered_map<std::string, std::string> connectorConfig;
-  connectorConfig.emplace("max-target-file-size", "512KB");
+  connectorConfig.emplace(HiveConfig::kOrcMaxTargetFileSize, "512KB");
   connectorConfig.emplace("hive.orc.writer.stripe-max-size", "128KB");
   connectorConfig_ = std::make_shared<HiveConfig>(
       std::make_shared<config::ConfigBase>(std::move(connectorConfig)));
@@ -1794,7 +1794,7 @@ TEST_F(HiveDataSinkTest, fileRotationWithMemoryReclaim) {
 
   std::unordered_map<std::string, std::string> connectorConfig;
   // Use small file size to trigger multiple rotations
-  connectorConfig.emplace("max-target-file-size", "256KB");
+  connectorConfig.emplace(HiveConfig::kOrcMaxTargetFileSize, "256KB");
   connectorConfig.emplace("hive.orc.writer.stripe-max-size", "64KB");
   connectorConfig_ = std::make_shared<HiveConfig>(
       std::make_shared<config::ConfigBase>(std::move(connectorConfig)));

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -709,8 +709,12 @@ Hive Connector
 Hive Connector config is initialized on velox runtime startup and is shared among queries as the default config.
 Each query can override the config by setting corresponding query session properties such as in Prestissimo.
 
-Configuration property names use kebab-case (e.g., ``max-bucket-count``).
-Session property names use snake_case (e.g., ``max_bucket_count``).
+Most configuration property names use kebab-case (e.g., ``max-bucket-count``)
+and most session property names use snake_case (e.g., ``max_bucket_count``).
+Parquet-specific Hive connector configuration properties use the
+``hive.parquet.`` prefix. Parquet session properties do not include a connector
+prefix because they are scoped by catalog or connector ID by the engine.
+Configuration keys use dashes and session keys use underscores.
 Properties without a session property name in the table below are fixed for the lifetime of the process
 and cannot be modified per query.
 
@@ -757,6 +761,16 @@ must be specified as raw byte counts.
      - false
      - True if reading the source file column names as lower case, and planner should guarantee
        the input column name and filter is also lower case to achive case-insensitive read.
+   * - hive.parquet.use-column-names
+     - parquet_use_column_names
+     - bool
+     - false
+     - Map Parquet table field names to file field names using names, not indices.
+   * - hive.parquet.allow-int32-narrowing
+     - parquet_allow_int32_narrowing
+     - bool
+     - false
+     - Allow reading INT32 Parquet columns as a narrower integer type.
    * - partition_path_as_lower_case
      -
      - bool
@@ -812,8 +826,8 @@ must be specified as raw byte counts.
      - capacity
      - 10MB
      - Maximum bytes for sort writer in one batch of output. This is to limit the memory usage of sort writer.
-   * - max-target-file-size
-     - max_target_file_size
+   * - hive.parquet.writer.max-target-file-size
+     - parquet_writer_max_target_file_size
      - capacity
      - 0B
      - Maximum target file size for writers. When a file exceeds this size during writing, the writer
@@ -901,14 +915,14 @@ must be specified as raw byte counts.
      - Speculative tail-read size in bytes when opening ORC files. Controls how many bytes are read from the end
        of the file to load the footer and nearby metadata in a single IO operation.
        Set to 0 for adaptive mode.
-   * - parquet.footer-speculative-io-size
+   * - hive.parquet.footer-speculative-io-size
      - parquet_footer_speculative_io_size
      - integer
      - 256KB
      - Speculative tail-read size in bytes when opening Parquet files. Controls how many bytes are read from the end
        of the file to load the footer and nearby metadata in a single IO operation.
        Set to 0 for adaptive mode.
-   * - parquet-footer-memory-tracking-threshold
+   * - hive.parquet.footer-memory-tracking-threshold
      - parquet_footer_memory_tracking_threshold
      - integer
      - disabled (max uint64)
@@ -982,6 +996,14 @@ must be specified as raw byte counts.
      - bool
      - true
      - Enables historical based stripe size estimation after compression.
+   * - hive.orc.max-target-file-size
+     - orc_writer_max_target_file_size
+     - capacity
+     - 0B
+     - Maximum target file size for ORC writers. When a file exceeds this size during writing, the writer
+       closes the current file and starts writing to a new file. Accepts human-readable values like
+       "1GB". Zero means no limit (default). File rotation is not supported for bucketed tables or
+       sorted writes.
    * - hive.orc.writer.min-compression-size
      - orc_writer_min_compression_size
      - integer

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -709,11 +709,12 @@ Hive Connector
 Hive Connector config is initialized on velox runtime startup and is shared among queries as the default config.
 Each query can override the config by setting corresponding query session properties such as in Prestissimo.
 
-Most configuration property names use kebab-case (e.g., ``max-bucket-count``)
-and most session property names use snake_case (e.g., ``max_bucket_count``).
-Parquet-specific Hive connector configuration properties use the
-``hive.parquet.`` prefix. Parquet session properties do not include a connector
-prefix because they are scoped by catalog or connector ID by the engine.
+Configuration property names use kebab-case (e.g., ``max-bucket-count``)
+and session property names use snake_case (e.g., ``max_bucket_count``).
+Format-specific Hive connector configuration properties use prefixes such as
+``hive.parquet.``, ``hive.orc.``, and ``hive.nimble.``. Format-specific session
+properties do not include a connector prefix because they are scoped by catalog
+or connector ID by the engine.
 Configuration keys use dashes and session keys use underscores.
 Properties without a session property name in the table below are fixed for the lifetime of the process
 and cannot be modified per query.
@@ -830,7 +831,7 @@ must be specified as raw byte counts.
      - parquet_writer_max_target_file_size
      - capacity
      - 0B
-     - Maximum target file size for writers. When a file exceeds this size during writing, the writer
+     - Maximum target file size for Parquet writers. When a file exceeds this size during writing, the writer
        closes the current file and starts writing to a new file. Accepts human-readable values like
        "1GB". Zero means no limit (default). File rotation is not supported for bucketed tables or
        sorted writes.
@@ -996,11 +997,19 @@ must be specified as raw byte counts.
      - bool
      - true
      - Enables historical based stripe size estimation after compression.
-   * - hive.orc.max-target-file-size
+   * - hive.orc.writer.max-target-file-size
      - orc_writer_max_target_file_size
      - capacity
      - 0B
      - Maximum target file size for ORC writers. When a file exceeds this size during writing, the writer
+       closes the current file and starts writing to a new file. Accepts human-readable values like
+       "1GB". Zero means no limit (default). File rotation is not supported for bucketed tables or
+       sorted writes.
+   * - hive.nimble.writer.max-target-file-size
+     - nimble_writer_max_target_file_size
+     - capacity
+     - 0B
+     - Maximum target file size for Nimble writers. When a file exceeds this size during writing, the writer
        closes the current file and starts writing to a new file. Accepts human-readable values like
        "1GB". Zero means no limit (default). File rotation is not supported for bucketed tables or
        sorted writes.

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -992,6 +992,7 @@ struct WriterOptions {
   std::map<std::string, std::string> serdeParameters;
   std::function<std::unique_ptr<dwio::common::FlushPolicy>()>
       flushPolicyFactory;
+  uint64_t maxTargetFileSizeBytes{0};
 
   std::string sessionTimezoneName;
   bool adjustTimestampToTimezone{false};

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -25,6 +25,7 @@
 #include "velox/common/base/Pointers.h"
 #include "velox/common/config/Config.h"
 #include "velox/common/testutil/TestValue.h"
+#include "velox/connectors/hive/HiveConfig.h"
 #include "velox/core/QueryConfig.h"
 #include "velox/dwio/parquet/writer/arrow/ArrowSchema.h"
 #include "velox/dwio/parquet/writer/arrow/Properties.h"
@@ -688,8 +689,10 @@ void WriterOptions::processConfigs(
   // row group byte threshold so we flush earlier and rawBytesWritten() grows
   // during writes.
   auto maxTargetFileSize =
-      toParquetPageSize(session.getWithFallback<std::string>(
-          WriterConfig::kParquetSessionMaxTargetFileSize, connectorConfig));
+      toParquetPageSize(session.getLegacyWithFallback<std::string>(
+          connector::hive::HiveConfig::kParquetMaxTargetFileSizeSession,
+          connectorConfig,
+          connector::hive::HiveConfig::kParquetMaxTargetFileSize));
   if (maxTargetFileSize.has_value()) {
     if (!flushPolicyFactory) {
       auto bytesInRowGroup = std::min<int64_t>(

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -25,7 +25,6 @@
 #include "velox/common/base/Pointers.h"
 #include "velox/common/config/Config.h"
 #include "velox/common/testutil/TestValue.h"
-#include "velox/connectors/hive/HiveConfig.h"
 #include "velox/core/QueryConfig.h"
 #include "velox/dwio/parquet/writer/arrow/ArrowSchema.h"
 #include "velox/dwio/parquet/writer/arrow/Properties.h"
@@ -684,25 +683,17 @@ void WriterOptions::processConfigs(
 
   // Parquet only updates ioStats_->rawBytesWritten() when a row group is
   // flushed. With the default flush policy (1M rows / 128MB), small
-  // maxTargetFileBytes_ would never trigger rotation because rawBytesWritten()
-  // stays at 0 while data is buffered. To honor maxTargetFileBytes_, cap the
-  // row group byte threshold so we flush earlier and rawBytesWritten() grows
-  // during writes.
-  auto maxTargetFileSize =
-      toParquetPageSize(session.getLegacyWithFallback<std::string>(
-          connector::hive::HiveConfig::kParquetMaxTargetFileSizeSession,
-          connectorConfig,
-          connector::hive::HiveConfig::kParquetMaxTargetFileSize));
-  if (maxTargetFileSize.has_value()) {
-    if (!flushPolicyFactory) {
-      auto bytesInRowGroup = std::min<int64_t>(
-          DefaultFlushPolicy::kDefaultBytesInRowGroup,
-          maxTargetFileSize.value());
-      flushPolicyFactory = [bytesInRowGroup]() {
-        return std::make_unique<DefaultFlushPolicy>(
-            DefaultFlushPolicy::kDefaultRowsInGroup, bytesInRowGroup);
-      };
-    }
+  // maxTargetFileSizeBytes would never trigger rotation because
+  // rawBytesWritten() stays at 0 while data is buffered. To honor
+  // maxTargetFileSizeBytes, cap the row group byte threshold so we flush
+  // earlier and rawBytesWritten() grows during writes.
+  if (maxTargetFileSizeBytes > 0 && !flushPolicyFactory) {
+    auto bytesInRowGroup = static_cast<int64_t>(std::min<uint64_t>(
+        DefaultFlushPolicy::kDefaultBytesInRowGroup, maxTargetFileSizeBytes));
+    flushPolicyFactory = [bytesInRowGroup]() {
+      return std::make_unique<DefaultFlushPolicy>(
+          DefaultFlushPolicy::kDefaultRowsInGroup, bytesInRowGroup);
+    };
   }
 }
 

--- a/velox/dwio/parquet/writer/WriterConfig.h
+++ b/velox/dwio/parquet/writer/WriterConfig.h
@@ -62,11 +62,6 @@ struct WriterConfig {
   static constexpr const char* kParquetHiveConnectorCreatedBy =
       "hive.parquet.writer.created-by";
 
-  // Use the same property name from HiveConfig::kMaxTargetFileSize.
-  static constexpr const char* kParquetConnectorMaxTargetFileSize =
-      "max-target-file-size";
-  static constexpr const char* kParquetSessionMaxTargetFileSize =
-      "max_target_file_size";
   // Serde parameter keys for timestamp settings. These can be set via
   // serdeParameters map to override the default timestamp behavior.
   // The timezone key accepts a timezone string or empty string to disable

--- a/velox/exec/fuzzer/WriterFuzzer.cpp
+++ b/velox/exec/fuzzer/WriterFuzzer.cpp
@@ -868,7 +868,7 @@ RowVectorPtr WriterFuzzer::execute(
           "400")
       .connectorSessionProperty(
           kHiveConnectorId,
-          connector::hive::HiveConfig::kMaxTargetFileSizeSession,
+          connector::hive::HiveConfig::kOrcMaxTargetFileSizeSession,
           maxTargetFileSizeBytes)
       .copyResults(pool_.get());
 }


### PR DESCRIPTION
Summary:

**BREAKING CHANGE**

- Rename Hive Parquet connector configuration keys to consistently use the `hive.parquet.` prefix with dash-separated config names.
- Rename Parquet session properties to use underscore-separated names without connector prefixes, e.g. `parquet_use_column_names` and `parquet_writer_max_target_file_size`.
- The old shared target max file size limit is split into:
  - Parquet: hive.parquet.writer.max-target-file-size / parquet_writer_max_target_file_size
  - ORC: hive.orc.writer.max-target-file-size / orc_writer_max_target_file_size
  - Nimble: hive.nimble.writer.max-target-file-size / nimble_writer_max_target_file_size
- HiveDataSink now chooses the file size limit by file format instead of using one generic key.

Config key
| Before | After |
|---|---|
| `parquet.use-column-names` | `hive.parquet.use-column-names` |
| `parquet.allow-int32-narrowing` | `hive.parquet.allow-int32-narrowing` |
| `parquet.footer-speculative-io-size` | `hive.parquet.footer-speculative-io-size` |
| `parquet-footer-memory-tracking-threshold` | `hive.parquet.footer-memory-tracking-threshold` |
| `max-target-file-size` | `hive.parquet.writer.max-target-file-size` |
| `none` | `hive.orc.writer.max-target-file-size` |
| `none` | `hive.nimble.writer.max-target-file-size` |

Session key
| Before | After |
|---|---|
| `allow_int32_narrowing` | `parquet_allow_int32_narrowing` |
| `parquet_footer_speculative_io_size` | `parquet_footer_speculative_io_size` |
| `parquet_footer_memory_tracking_threshold` | `parquet_footer_memory_tracking_threshold` |
| `max_target_file_size` | `parquet_writer_max_target_file_size` |
| `none` | `orc_writer_max_target_file_size` |
| `none` | `nimble_writer_max_target_file_size` |
