### PR TITLE
fix(expr): Push OR of varchar ranges down as subfield filter

### DIFF
--- a/velox/expression/ExprToSubfieldFilter.cpp
+++ b/velox/expression/ExprToSubfieldFilter.cpp
@@ -796,6 +796,34 @@ std::unique_ptr<common::Filter> tryMergeFloatingPointRanges(
       });
 }
 
+std::unique_ptr<common::Filter> tryMergeBytesRanges(
+    std::vector<std::unique_ptr<common::Filter>>& disjuncts) {
+  if (!std::all_of(disjuncts.begin(), disjuncts.end(), [](const auto& filter) {
+        return isBytesRange(filter);
+      })) {
+    return nullptr;
+  }
+
+  const bool nullAllowed = isNullAllowed(disjuncts);
+  std::sort(
+      disjuncts.begin(), disjuncts.end(), [](const auto& lhs, const auto& rhs) {
+        const auto* lhsRange = lhs->template as<common::BytesRange>();
+        const auto* rhsRange = rhs->template as<common::BytesRange>();
+        if (lhsRange->isLowerUnbounded() && rhsRange->isLowerUnbounded()) {
+          return false;
+        }
+        if (lhsRange->isLowerUnbounded()) {
+          return true;
+        }
+        if (rhsRange->isLowerUnbounded()) {
+          return false;
+        }
+        return lhsRange->lower() < rhsRange->lower();
+      });
+  return std::make_unique<common::MultiRange>(
+      std::move(disjuncts), nullAllowed);
+}
+
 std::unique_ptr<common::Filter> tryMergeBytesValues(
     std::vector<std::unique_ptr<common::Filter>>& disjuncts) {
   if (!std::all_of(disjuncts.begin(), disjuncts.end(), [](const auto& filter) {
@@ -842,6 +870,10 @@ std::unique_ptr<common::Filter> ExprToSubfieldFilterParser::makeOrFilter(
   }
 
   if (auto merged = tryMergeBytesValues(disjuncts)) {
+    return merged;
+  }
+
+  if (auto merged = tryMergeBytesRanges(disjuncts)) {
     return merged;
   }
 

--- a/velox/expression/tests/ExprToSubfieldFilterTest.cpp
+++ b/velox/expression/tests/ExprToSubfieldFilterTest.cpp
@@ -503,6 +503,68 @@ TEST_F(ExprToSubfieldFilterTest, makeOrFilterBytesRange) {
   }
 }
 
+TEST_F(ExprToSubfieldFilterTest, makeOrFilterBytesRangeBounded) {
+  // a between 'A' and 'C' OR a between 'F' and 'J'
+  {
+    auto expected = orFilter(between("A", "C"), between("F", "J"));
+    VELOX_ASSERT_FILTER(expected, makeOr(between("A", "C"), between("F", "J")));
+    VELOX_ASSERT_FILTER(expected, makeOr(between("F", "J"), between("A", "C")));
+  }
+
+  // a > 'A' and a < 'C' OR a > 'F' and a < 'J'
+  {
+    auto expected =
+        orFilter(betweenExclusive("A", "C"), betweenExclusive("F", "J"));
+    VELOX_ASSERT_FILTER(
+        expected,
+        makeOr(betweenExclusive("A", "C"), betweenExclusive("F", "J")));
+  }
+
+  // a < 'C' OR a >= 'F'
+  {
+    auto expected = orFilter(lessThan("C"), greaterThanOrEqual("F"));
+    VELOX_ASSERT_FILTER(
+        expected, makeOr(lessThan("C"), greaterThanOrEqual("F")));
+  }
+
+  // a between 'A' and 'C' OR a between 'F' and 'J' OR a between 'M' and 'P'
+  {
+    std::vector<std::unique_ptr<common::Filter>> expectedRanges;
+    expectedRanges.emplace_back(between("A", "C"));
+    expectedRanges.emplace_back(between("F", "J"));
+    expectedRanges.emplace_back(between("M", "P"));
+    auto expected = std::make_unique<common::MultiRange>(
+        std::move(expectedRanges), /*nullAllowed=*/false);
+    VELOX_ASSERT_FILTER(
+        expected,
+        makeOr(between("A", "C"), between("F", "J"), between("M", "P")));
+  }
+
+  // nullAllowed on any disjunct propagates.
+  {
+    auto expected = orFilter(
+        between("A", "C"),
+        between("F", "J", /*nullAllowed=*/true),
+        /*nullAllowed=*/true);
+    VELOX_ASSERT_FILTER(
+        expected,
+        makeOr(between("A", "C"), between("F", "J", /*nullAllowed=*/true)));
+  }
+
+  // a < 'C' OR a < 'F'
+  {
+    auto expected = orFilter(lessThan("C"), lessThan("F"));
+    VELOX_ASSERT_FILTER(expected, makeOr(lessThan("C"), lessThan("F")));
+  }
+
+  // a < 'C' OR a between 'F' and 'J'
+  {
+    auto expected = orFilter(lessThan("C"), between("F", "J"));
+    VELOX_ASSERT_FILTER(expected, makeOr(lessThan("C"), between("F", "J")));
+    VELOX_ASSERT_FILTER(expected, makeOr(between("F", "J"), lessThan("C")));
+  }
+}
+
 // Test NULL comparison handling - comparisons with NULL should return
 // AlwaysFalse as per SQL three-valued logic
 TEST_F(ExprToSubfieldFilterTest, eqNull) {


### PR DESCRIPTION
Summary:
extractFiltersFromRemainingFilter could already lower a disjunction of range
filters into a MultiRange subfield filter for bigint and floating-point columns,
but for varchar it only handled the IN-list case (single-value BytesRange via
tryMergeBytesValues). Predicates like `(c >= A AND c < B) OR (c >= C AND c < D)`
were dropped to remainingFilter, defeating partition pruning on string-typed
partition columns (e.g. ds varchar). Connectors that already translate
MultiRange (Hive, Prism, Iceberg, ...) take it from here.

Differential Revision: D107547729


