### PR TITLE
feat: Add forwardedProbeColumns to IndexLookupJoinNode (#17737)

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -1823,7 +1823,8 @@ IndexLookupJoinNode::IndexLookupJoinNode(
     std::optional<bool> splitOutput,
     PlanNodePtr left,
     TableScanNodePtr right,
-    RowTypePtr outputType)
+    RowTypePtr outputType,
+    std::vector<FieldAccessTypedExprPtr> forwardedProbeColumns)
     : IndexLookupJoinNode(
           id,
           joinType,
@@ -1835,7 +1836,8 @@ IndexLookupJoinNode::IndexLookupJoinNode(
           std::move(left),
           std::move(right),
           std::move(outputType),
-          splitOutput) {}
+          splitOutput,
+          std::move(forwardedProbeColumns)) {}
 
 IndexLookupJoinNode::IndexLookupJoinNode(
     const PlanNodeId& id,
@@ -1848,7 +1850,8 @@ IndexLookupJoinNode::IndexLookupJoinNode(
     PlanNodePtr left,
     TableScanNodePtr right,
     RowTypePtr outputType,
-    std::optional<bool> splitOutput)
+    std::optional<bool> splitOutput,
+    std::vector<FieldAccessTypedExprPtr> forwardedProbeColumns)
     : AbstractJoinNode(
           id,
           joinType,
@@ -1861,7 +1864,8 @@ IndexLookupJoinNode::IndexLookupJoinNode(
       lookupSourceNode_(std::move(right)),
       joinConditions_(joinConditions),
       hasMarker_(hasMarker),
-      splitOutput_(splitOutput) {
+      splitOutput_(splitOutput),
+      forwardedProbeColumns_(std::move(forwardedProbeColumns)) {
   VELOX_USER_CHECK(
       !leftKeys.empty(),
       "The index lookup join node requires at least one join key");
@@ -1889,6 +1893,39 @@ IndexLookupJoinNode::IndexLookupJoinNode(
         leftType->containsChild(key->name()),
         "Left side join key not found in left side output: {}",
         key->name());
+  }
+  // Validate forwarded probe columns: each must exist in the probe input,
+  // must not overlap with any leftKey, and must not duplicate another
+  // forwarded column. Overlap with joinCondition-referenced probe columns
+  // is enforced by the operator's initLookupInput at runtime where the
+  // full set of referenced names is already being assembled.
+  if (!forwardedProbeColumns_.empty()) {
+    folly::F14FastSet<std::string> leftKeyNames;
+    leftKeyNames.reserve(leftKeys_.size());
+    for (const auto& key : leftKeys_) {
+      leftKeyNames.insert(key->name());
+    }
+    folly::F14FastSet<std::string> forwardedNames;
+    forwardedNames.reserve(forwardedProbeColumns_.size());
+    for (const auto& col : forwardedProbeColumns_) {
+      VELOX_CHECK_NOT_NULL(
+          col, "Forwarded probe column expression must not be null");
+      const auto& name = col->name();
+      VELOX_CHECK(
+          leftType->containsChild(name),
+          "Forwarded probe column not found in probe input: {}",
+          name);
+      VELOX_CHECK_EQ(
+          leftKeyNames.count(name),
+          0,
+          "Forwarded probe column {} overlaps with a leftKey; remove it "
+          "from forwardedProbeColumns (left keys are forwarded already).",
+          name);
+      VELOX_CHECK(
+          forwardedNames.insert(name).second,
+          "Duplicate forwarded probe column: {}",
+          name);
+    }
   }
   auto rightType = sources_[1]->outputType();
   for (const auto& key : rightKeys_) {
@@ -1953,6 +1990,12 @@ PlanNodePtr IndexLookupJoinNode::create(
     splitOutput = obj["splitOutput"].asBool();
   }
 
+  std::vector<FieldAccessTypedExprPtr> forwardedProbeColumns;
+  if (obj.count("forwardedProbeColumns")) {
+    forwardedProbeColumns =
+        deserializeFields(obj["forwardedProbeColumns"], context);
+  }
+
   auto outputType = deserializeRowType(obj["outputType"]);
 
   return std::make_shared<IndexLookupJoinNode>(
@@ -1966,7 +2009,8 @@ PlanNodePtr IndexLookupJoinNode::create(
       splitOutput,
       sources[0],
       std::move(lookupSource),
-      std::move(outputType));
+      std::move(outputType),
+      std::move(forwardedProbeColumns));
 }
 
 folly::dynamic IndexLookupJoinNode::serialize() const {
@@ -1985,6 +2029,13 @@ folly::dynamic IndexLookupJoinNode::serialize() const {
   if (splitOutput_.has_value()) {
     obj["splitOutput"] = splitOutput_.value();
   }
+  if (!forwardedProbeColumns_.empty()) {
+    folly::dynamic serializedForwarded = folly::dynamic::array();
+    for (const auto& col : forwardedProbeColumns_) {
+      serializedForwarded.push_back(col->serialize());
+    }
+    obj["forwardedProbeColumns"] = std::move(serializedForwarded);
+  }
   return obj;
 }
 
@@ -1994,19 +2045,26 @@ bool IndexLookupJoinNode::needsIndexSplit() const {
 
 void IndexLookupJoinNode::addDetails(std::stringstream& stream) const {
   AbstractJoinNode::addDetails(stream);
-  if (joinConditions_.empty()) {
-    return;
+  if (!joinConditions_.empty()) {
+    std::vector<std::string> joinConditionstrs;
+    joinConditionstrs.reserve(joinConditions_.size());
+    for (const auto& joinCondition : joinConditions_) {
+      joinConditionstrs.push_back(joinCondition->toString());
+    }
+    stream << ", joinConditions: [" << folly::join(", ", joinConditionstrs)
+           << " ], filter: ["
+           << (filter_ == nullptr ? "null" : filter_->toString())
+           << "], hasMarker: [" << (hasMarker_ ? "true" : "false") << "]";
   }
-
-  std::vector<std::string> joinConditionstrs;
-  joinConditionstrs.reserve(joinConditions_.size());
-  for (const auto& joinCondition : joinConditions_) {
-    joinConditionstrs.push_back(joinCondition->toString());
+  if (!forwardedProbeColumns_.empty()) {
+    std::vector<std::string> forwardedNames;
+    forwardedNames.reserve(forwardedProbeColumns_.size());
+    for (const auto& col : forwardedProbeColumns_) {
+      forwardedNames.push_back(col->name());
+    }
+    stream << ", forwardedProbeColumns: [" << folly::join(", ", forwardedNames)
+           << "]";
   }
-  stream << ", joinConditions: [" << folly::join(", ", joinConditionstrs)
-         << " ], filter: ["
-         << (filter_ == nullptr ? "null" : filter_->toString())
-         << "], hasMarker: [" << (hasMarker_ ? "true" : "false") << "]";
 }
 
 void IndexLookupJoinNode::accept(

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -3701,6 +3701,14 @@ class IndexLookupJoinNode : public AbstractJoinNode {
   /// @param hasMarker if true, the output type includes a boolean
   /// column at the end to indicate if a join output row has a match or not.
   /// This only applies for left join.
+  /// @param forwardedProbeColumns Probe-side columns that the operator must
+  /// include in the connector's lookup input vector even when no join key or
+  /// join condition references them. Connectors that need per-row probe
+  /// values (e.g. cumulative-weight caps fetched per probe) use this to
+  /// declare which columns they expect to find in the request input. Defaults
+  /// to empty, in which case behavior is unchanged. A forwarded column may
+  /// not overlap with any column already referenced by leftKeys or by a join
+  /// condition.
   IndexLookupJoinNode(
       const PlanNodeId& id,
       JoinType joinType,
@@ -3712,7 +3720,8 @@ class IndexLookupJoinNode : public AbstractJoinNode {
       PlanNodePtr left,
       TableScanNodePtr right,
       RowTypePtr outputType,
-      std::optional<bool> splitOutput = std::nullopt);
+      std::optional<bool> splitOutput = std::nullopt,
+      std::vector<FieldAccessTypedExprPtr> forwardedProbeColumns = {});
 
   /// @param splitOutput Optional flag to control whether the operator should
   /// split output batches if they are too large. If true, output is split into
@@ -3731,7 +3740,8 @@ class IndexLookupJoinNode : public AbstractJoinNode {
       std::optional<bool> splitOutput,
       PlanNodePtr left,
       TableScanNodePtr right,
-      RowTypePtr outputType);
+      RowTypePtr outputType,
+      std::vector<FieldAccessTypedExprPtr> forwardedProbeColumns = {});
 
   class Builder
       : public AbstractJoinNode::Builder<IndexLookupJoinNode, Builder> {
@@ -3744,6 +3754,7 @@ class IndexLookupJoinNode : public AbstractJoinNode {
       filter_ = other.filter();
       hasMarker_ = other.hasMarker();
       splitOutput_ = other.splitOutput();
+      forwardedProbeColumns_ = other.forwardedProbeColumns();
     }
 
     /// Set lookup conditions for index lookup that can't be converted into
@@ -3773,6 +3784,15 @@ class IndexLookupJoinNode : public AbstractJoinNode {
       return *this;
     }
 
+    /// Set probe-side columns that should be forwarded to the connector's
+    /// lookup input even though no join key or join condition references
+    /// them. See the IndexLookupJoinNode constructor for the contract.
+    Builder& forwardedProbeColumns(
+        std::vector<FieldAccessTypedExprPtr> forwardedProbeColumns) {
+      forwardedProbeColumns_ = std::move(forwardedProbeColumns);
+      return *this;
+    }
+
     std::shared_ptr<IndexLookupJoinNode> build() const {
       VELOX_USER_CHECK(id_.has_value(), "IndexLookupJoinNode id is not set");
       VELOX_USER_CHECK(
@@ -3799,13 +3819,15 @@ class IndexLookupJoinNode : public AbstractJoinNode {
           splitOutput_,
           left_.value(),
           std::dynamic_pointer_cast<const TableScanNode>(right_.value()),
-          outputType_.value());
+          outputType_.value(),
+          forwardedProbeColumns_);
     }
 
    private:
     std::vector<IndexLookupConditionPtr> joinConditions_;
     bool hasMarker_{false};
     std::optional<bool> splitOutput_;
+    std::vector<FieldAccessTypedExprPtr> forwardedProbeColumns_;
   };
 
   bool supportsBarrier() const override {
@@ -3824,6 +3846,14 @@ class IndexLookupJoinNode : public AbstractJoinNode {
   /// simple equality join conditions.
   const std::vector<IndexLookupConditionPtr>& joinConditions() const {
     return joinConditions_;
+  }
+
+  /// Probe-side columns the operator forwards into the connector's lookup
+  /// input vector beyond what leftKeys and joinConditions reference. Connectors
+  /// that need per-row probe values (e.g. cumulative-weight caps) declare
+  /// them here. Empty by default.
+  const std::vector<FieldAccessTypedExprPtr>& forwardedProbeColumns() const {
+    return forwardedProbeColumns_;
   }
 
   std::string_view name() const override {
@@ -3866,6 +3896,12 @@ class IndexLookupJoinNode : public AbstractJoinNode {
   /// Optional flag to control whether to split output batches. When set,
   /// overrides the index_lookup_join_split_output QueryConfig.
   const std::optional<bool> splitOutput_;
+
+  /// Probe-side columns to forward to the connector's lookup input even if
+  /// they are not referenced by leftKeys or joinConditions. Validated in the
+  /// constructor to be present in the probe input type and to not overlap
+  /// with leftKeys or joinCondition-referenced columns.
+  const std::vector<FieldAccessTypedExprPtr> forwardedProbeColumns_;
 };
 
 using IndexLookupJoinNodePtr = std::shared_ptr<const IndexLookupJoinNode>;

--- a/velox/exec/IndexLookupJoin.cpp
+++ b/velox/exec/IndexLookupJoin.cpp
@@ -322,6 +322,7 @@ IndexLookupJoin::IndexLookupJoin(
           joinNode->leftKeys(),
           joinNode->rightKeys(),
           joinNode->joinConditions())},
+      forwardedProbeColumns_(joinNode->forwardedProbeColumns()),
       lookupColumnHandles_(joinNode->lookupSource()->assignments()),
       connectorQueryCtx_{operatorCtx_->createConnectorQueryCtx(
           lookupTableHandle_->connectorId(),
@@ -535,6 +536,33 @@ void IndexLookupJoin::initLookupInput() {
     }
 
     VELOX_UNSUPPORTED("Unsupported join condition type");
+  }
+
+  // Append the connector's forwarded probe columns after the join-condition
+  // walk. The plan-node constructor has already verified that each forwarded
+  // column exists in the probe input and does not overlap with any leftKey.
+  // Here we additionally throw on overlap with any column the join-condition
+  // walk above already added (e.g. a probe column referenced by a Between
+  // bound), since the caller's intent is ambiguous when the same column
+  // appears in both places.
+  for (const auto& forwardedColumn : forwardedProbeColumns_) {
+    const auto& name = forwardedColumn->name();
+    VELOX_CHECK_EQ(
+        lookupInputColumnSet.count(name),
+        0,
+        "Forwarded probe column {} overlaps with a column already referenced "
+        "by a join condition; remove it from forwardedProbeColumns.",
+        name);
+    const auto channel = probeType_->getChildIdx(name);
+    const auto& type = probeType_->childAt(channel);
+    addLookupInputColumn(
+        name,
+        type,
+        channel,
+        lookupInputNames,
+        lookupInputTypes,
+        lookupInputChannels_,
+        lookupInputColumnSet);
   }
 }
 

--- a/velox/exec/IndexLookupJoin.h
+++ b/velox/exec/IndexLookupJoin.h
@@ -351,6 +351,10 @@ class IndexLookupJoin : public Operator {
   const core::PlanNodeId indexSourceNodeId_;
   const connector::ConnectorTableHandlePtr lookupTableHandle_;
   const std::vector<core::IndexLookupConditionPtr> joinConditions_;
+  // Probe-side columns the connector wants forwarded into its lookup input
+  // even when no join key or join condition references them. Mirrors
+  // IndexLookupJoinNode::forwardedProbeColumns(). Empty by default.
+  const std::vector<core::FieldAccessTypedExprPtr> forwardedProbeColumns_;
   const connector::ColumnHandleMap lookupColumnHandles_;
   const std::shared_ptr<connector::ConnectorQueryCtx> connectorQueryCtx_;
   const std::shared_ptr<connector::Connector> connector_;

--- a/velox/exec/tests/IndexLookupJoinTest.cpp
+++ b/velox/exec/tests/IndexLookupJoinTest.cpp
@@ -514,6 +514,27 @@ TEST_P(IndexLookupJoinTest, planNodeAndSerde) {
     testSerde(plan);
   }
 
+  // with forwardedProbeColumns.
+  {
+    auto plan = PlanBuilder(planNodeIdGenerator)
+                    .values({left})
+                    .startIndexLookupJoin()
+                    .leftKeys({"t0"})
+                    .rightKeys({"u0"})
+                    .indexSource(indexTableScan)
+                    .outputLayout({"t0", "u1", "t2", "t1"})
+                    .joinType(core::JoinType::kInner)
+                    .forwardedProbeColumns({"t1", "t2"})
+                    .endIndexLookupJoin()
+                    .planNode();
+    auto indexLookupJoinNode =
+        std::dynamic_pointer_cast<const core::IndexLookupJoinNode>(plan);
+    ASSERT_EQ(indexLookupJoinNode->forwardedProbeColumns().size(), 2);
+    ASSERT_EQ(indexLookupJoinNode->forwardedProbeColumns()[0]->name(), "t1");
+    ASSERT_EQ(indexLookupJoinNode->forwardedProbeColumns()[1]->name(), "t2");
+    testSerde(plan);
+  }
+
   // bad join type.
   {
     VELOX_ASSERT_USER_THROW(
@@ -576,6 +597,116 @@ TEST_P(IndexLookupJoinTest, planNodeAndSerde) {
             .planNode(),
         "The index lookup join node requires at least one join key");
   }
+
+  // Forwarded probe column not found in probe input.
+  {
+    VELOX_ASSERT_THROW(
+        PlanBuilder(planNodeIdGenerator)
+            .values({left})
+            .startIndexLookupJoin()
+            .leftKeys({"t0"})
+            .rightKeys({"u0"})
+            .indexSource(indexTableScan)
+            .outputLayout({"t0", "u1", "t2", "t1"})
+            .forwardedProbeColumns({"missing_column"})
+            .endIndexLookupJoin()
+            .planNode(),
+        "Field not found: missing_column");
+  }
+
+  // Forwarded probe column overlaps with a leftKey.
+  {
+    VELOX_ASSERT_THROW(
+        PlanBuilder(planNodeIdGenerator)
+            .values({left})
+            .startIndexLookupJoin()
+            .leftKeys({"t0"})
+            .rightKeys({"u0"})
+            .indexSource(indexTableScan)
+            .outputLayout({"t0", "u1", "t2", "t1"})
+            .forwardedProbeColumns({"t0"})
+            .endIndexLookupJoin()
+            .planNode(),
+        "Forwarded probe column t0 overlaps with a leftKey");
+  }
+
+  // Duplicate forwarded probe columns.
+  {
+    VELOX_ASSERT_THROW(
+        PlanBuilder(planNodeIdGenerator)
+            .values({left})
+            .startIndexLookupJoin()
+            .leftKeys({"t0"})
+            .rightKeys({"u0"})
+            .indexSource(indexTableScan)
+            .outputLayout({"t0", "u1", "t2", "t1"})
+            .forwardedProbeColumns({"t1", "t1"})
+            .endIndexLookupJoin()
+            .planNode(),
+        "Duplicate forwarded probe column: t1");
+  }
+}
+
+TEST_F(IndexLookupJoinTest, forwardedProbeColumnOverlapsWithCondition) {
+  // The plan-node ctor catches forwarded columns that overlap with leftKeys.
+  // The remaining case — overlap with a probe column referenced by a join
+  // condition (e.g. a BETWEEN bound) — is caught by the operator at runtime
+  // when it walks the join conditions and assembles the lookup input set.
+  // This test verifies that runtime check fires with the expected message.
+  TestIndexTableHandle::registerSerDe();
+  auto indexConnectorHandle = makeIndexTableHandle(nullptr, true);
+
+  auto left = makeRowVector(
+      {"t0", "t1", "t2", "t3", "t4"},
+      {makeFlatVector<int64_t>({1, 2, 3}),
+       makeFlatVector<int64_t>({10, 20, 30}),
+       makeFlatVector<int64_t>({40, 50, 60}),
+       makeArrayVector<int64_t>(
+           3,
+           [](auto row) { return row; },
+           [](auto /*unused*/, auto index) { return index; }),
+       makeArrayVector<int64_t>(
+           3,
+           [](auto row) { return row; },
+           [](auto /*unused*/, auto index) { return index; })});
+  auto right = makeRowVector(
+      {"u0", "u1", "u2"},
+      {makeFlatVector<int64_t>({1, 2, 3}),
+       makeFlatVector<int64_t>({10, 20, 30}),
+       makeFlatVector<int64_t>({10, 30, 20})});
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto planBuilder = PlanBuilder();
+  auto indexTableScan = std::dynamic_pointer_cast<const core::TableScanNode>(
+      PlanBuilder::TableScanBuilder(planBuilder)
+          .tableHandle(indexConnectorHandle)
+          .outputType(asRowType(right->type()))
+          .endTableScan()
+          .planNode());
+
+  // BETWEEN's lower bound is t1 (a probe column reference). The operator's
+  // join-condition walk will add t1 to its lookup input set. Then the
+  // forwardedProbeColumns walk attempts to add t1 again and throws.
+  auto plan = PlanBuilder(planNodeIdGenerator, pool_.get())
+                  .values({left})
+                  .startIndexLookupJoin()
+                  .leftKeys({"t0"})
+                  .rightKeys({"u0"})
+                  .indexSource(indexTableScan)
+                  .joinConditions({"u1 between t1 AND t2"})
+                  .outputLayout({"t0", "u1", "t2", "t1"})
+                  .joinType(core::JoinType::kInner)
+                  .forwardedProbeColumns({"t1"})
+                  .endIndexLookupJoin()
+                  .planNode();
+
+  // The plan itself constructs fine — leftKeys is {t0}, forwarded is {t1};
+  // no leftKey overlap. The overlap with the BETWEEN bound is detected at
+  // operator initialize() time.
+  VELOX_ASSERT_THROW(
+      exec::test::AssertQueryBuilder(plan).copyResults(pool_.get()),
+      "Forwarded probe column t1 overlaps with a column already referenced "
+      "by a join condition");
 }
 
 TEST_P(IndexLookupJoinTest, DISABLED_equalJoin) {

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -2737,6 +2737,9 @@ core::PlanNodePtr PlanBuilder::IndexLookupJoinBuilder::build(
         filter_, inputType, planBuilder_.options_, planBuilder_.pool_);
   }
 
+  auto forwardedProbeColumnFields = PlanBuilder::fields(
+      planBuilder_.planNode_->outputType(), forwardedProbeColumns_);
+
   return std::make_shared<core::IndexLookupJoinNode>(
       id,
       joinType_,
@@ -2748,6 +2751,7 @@ core::PlanNodePtr PlanBuilder::IndexLookupJoinBuilder::build(
       splitOutput_,
       std::move(planBuilder_.planNode_),
       indexSource_,
-      std::move(outputType));
+      std::move(outputType),
+      std::move(forwardedProbeColumnFields));
 }
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -449,6 +449,16 @@ class PlanBuilder {
       return *this;
     }
 
+    /// @param forwardedProbeColumns Probe-side column names the operator
+    /// should include in the connector's lookup input even when no join key
+    /// or join condition references them. See IndexLookupJoinNode for the
+    /// full contract.
+    IndexLookupJoinBuilder& forwardedProbeColumns(
+        std::vector<std::string> forwardedProbeColumns) {
+      forwardedProbeColumns_ = std::move(forwardedProbeColumns);
+      return *this;
+    }
+
     /// Stop the IndexLookupJoinBuilder.
     PlanBuilder& endIndexLookupJoin() {
       planBuilder_.planNode_ = build(planBuilder_.nextPlanNodeId());
@@ -469,6 +479,7 @@ class PlanBuilder {
     std::vector<std::string> outputLayout_;
     core::JoinType joinType_{core::JoinType::kInner};
     std::optional<bool> splitOutput_;
+    std::vector<std::string> forwardedProbeColumns_;
   };
 
   /// Start an IndexLookupJoinBuilder.


### PR DESCRIPTION
Summary:

Some IndexLookupJoin connectors need probe-side columns that are not referenced by any join key or join condition. Today the operator strips such columns from the connector's `request.input`.

This adds an optional `forwardedProbeColumns` field on `IndexLookupJoinNode`. When set, the operator appends each named probe column to its lookup input after the join-condition walk, so the connector receives the column in `request.input` alongside the join-key columns.

Validation:
- Plan-node constructor rejects forwarded columns missing from the probe input, columns overlapping with `leftKeys`, and duplicates.
- Operator's `initLookupInput` rejects overlap with columns already referenced by a join condition.

The field defaults to empty. Existing callers, serialized plans, and `PlanBuilder` usage are unchanged.

Reviewed By: kevinwilfong

Differential Revision: D107554577


