### PR TITLE
feat: IcebergMergeSink: composite DataSink for UPDATE/MERGE (#17738)

### DIFF
--- a/velox/connectors/hive/iceberg/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/CMakeLists.txt
@@ -22,6 +22,9 @@ set(
   IcebergDataFileStatistics.cpp
   IcebergDataSink.cpp
   IcebergDataSource.cpp
+  IcebergDeletionVectorSink.cpp
+  IcebergMergeProcessor.cpp
+  IcebergMergeSink.cpp
   IcebergPartitionName.cpp
   IcebergSplit.cpp
   IcebergSplitReader.cpp
@@ -50,6 +53,9 @@ velox_add_library(
   IcebergDataSink.h
   IcebergDataSource.h
   IcebergDeleteFile.h
+  IcebergDeletionVectorSink.h
+  IcebergMergeProcessor.h
+  IcebergMergeSink.h
   IcebergMetadataColumns.h
   IcebergParquetStatsCollector.h
   IcebergPartitionName.h

--- a/velox/connectors/hive/iceberg/DeletionVectorReader.h
+++ b/velox/connectors/hive/iceberg/DeletionVectorReader.h
@@ -16,11 +16,8 @@
 
 #pragma once
 
-#include <memory>
 #include <vector>
 
-#include "velox/common/base/BitUtil.h"
-#include "velox/common/memory/Memory.h"
 #include "velox/connectors/hive/iceberg/IcebergDeleteFile.h"
 
 namespace facebook::velox::connector::hive::iceberg {

--- a/velox/connectors/hive/iceberg/DeletionVectorWriter.cpp
+++ b/velox/connectors/hive/iceberg/DeletionVectorWriter.cpp
@@ -17,12 +17,13 @@
 #include "velox/connectors/hive/iceberg/DeletionVectorWriter.h"
 
 #include <algorithm>
-#include <fstream>
 
 #include <folly/json.h>
 #include <folly/lang/Bits.h>
 
 #include "velox/common/base/Exceptions.h"
+#include "velox/dwio/common/DataBuffer.h"
+#include "velox/dwio/common/FileSink.h"
 
 namespace facebook::velox::connector::hive::iceberg {
 
@@ -202,7 +203,8 @@ void DeletionVectorWriter::clear() {
 }
 
 std::pair<uint64_t, uint64_t> writePuffinFile(
-    const std::string& filePath,
+    dwio::common::FileSink& sink,
+    memory::MemoryPool& pool,
     const std::string& blobData,
     const std::string& referencedDataFile) {
   uint64_t blobOffset = kPuffinMagicSize;
@@ -242,13 +244,15 @@ std::pair<uint64_t, uint64_t> writePuffinFile(
       sizeof(littleEndianFlags));
   fileContent.append(kPuffinMagic, kPuffinMagicSize);
 
-  std::ofstream out(filePath, std::ios::binary | std::ios::trunc);
-  VELOX_CHECK(
-      out.good(), "Failed to open Puffin file for writing: {}", filePath);
-  out.write(
-      fileContent.data(), static_cast<std::streamsize>(fileContent.size()));
-  out.close();
-  VELOX_CHECK(!out.fail(), "Failed to write Puffin file: {}", filePath);
+  // Stage the serialized puffin bytes into a DataBuffer<char> and write
+  // them through the registered FileSink. Going through the sink lets the
+  // bytes land on whatever filesystem (local, warm storage, S3, ...) has a
+  // FileSink factory registered for the destination URI scheme.
+  // DataBuffer::append reserves and copies the bytes internally, so the
+  // staging copy stays inside the bounds-checked buffer API.
+  dwio::common::DataBuffer<char> buffer(pool);
+  buffer.append(0, fileContent.data(), fileContent.size());
+  sink.write(std::move(buffer));
 
   return {blobOffset, blobLength};
 }

--- a/velox/connectors/hive/iceberg/DeletionVectorWriter.h
+++ b/velox/connectors/hive/iceberg/DeletionVectorWriter.h
@@ -17,9 +17,16 @@
 #pragma once
 
 #include <cstdint>
-#include <map>
 #include <string>
 #include <vector>
+
+namespace facebook::velox::memory {
+class MemoryPool;
+} // namespace facebook::velox::memory
+
+namespace facebook::velox::dwio::common {
+class FileSink;
+} // namespace facebook::velox::dwio::common
 
 namespace facebook::velox::connector::hive::iceberg {
 
@@ -83,19 +90,28 @@ class DeletionVectorWriter {
   std::vector<int64_t> positions_;
 };
 
-/// Writes a Puffin file containing a single deletion vector blob.
+/// Writes a Puffin file containing a single deletion vector blob to the
+/// provided file sink.
 ///
 /// The Puffin file format consists of:
 ///   - 4-byte magic: "PUF1"
 ///   - Blob data (the serialized roaring bitmap)
 ///   - Footer: blob metadata + footer payload size + magic
 ///
-/// @param filePath Path to write the Puffin file.
+/// The caller owns 'sink' and is responsible for opening it before this call
+/// and closing it after. Routing the bytes through 'sink' lets the puffin
+/// file land on any filesystem (local, warm storage, S3, etc.) that has a
+/// registered FileSink factory — matching how IcebergDataSink writes data
+/// files.
+///
+/// @param sink Opened file sink to write the Puffin bytes into.
+/// @param pool Memory pool used to allocate the in-memory staging buffer.
 /// @param blobData Serialized roaring bitmap bytes.
 /// @param referencedDataFile Path of the data file this DV applies to.
 /// @return Pair of (blobOffset, blobLength) within the written file.
 std::pair<uint64_t, uint64_t> writePuffinFile(
-    const std::string& filePath,
+    dwio::common::FileSink& sink,
+    memory::MemoryPool& pool,
     const std::string& blobData,
     const std::string& referencedDataFile);
 

--- a/velox/connectors/hive/iceberg/IcebergConnector.cpp
+++ b/velox/connectors/hive/iceberg/IcebergConnector.cpp
@@ -16,10 +16,14 @@
 
 #include "velox/connectors/hive/iceberg/IcebergConnector.h"
 
+#include <numeric>
+
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/hive/iceberg/IcebergConfig.h"
 #include "velox/connectors/hive/iceberg/IcebergDataSink.h"
 #include "velox/connectors/hive/iceberg/IcebergDataSource.h"
+#include "velox/connectors/hive/iceberg/IcebergDeletionVectorSink.h"
+#include "velox/connectors/hive/iceberg/IcebergMergeSink.h"
 
 namespace facebook::velox::connector::hive::iceberg {
 
@@ -71,13 +75,60 @@ std::unique_ptr<DataSink> IcebergConnector::createDataSink(
   auto icebergInsertHandle = checkedPointerCast<const IcebergInsertTableHandle>(
       connectorInsertTableHandle);
 
-  return std::make_unique<IcebergDataSink>(
-      inputType,
-      icebergInsertHandle,
-      connectorQueryCtx,
-      commitStrategy,
-      hiveConfig_,
-      icebergConfig_);
+  switch (icebergInsertHandle->writeKind()) {
+    case IcebergInsertTableHandle::WriteKind::kData:
+      return std::make_unique<IcebergDataSink>(
+          inputType,
+          icebergInsertHandle,
+          connectorQueryCtx,
+          commitStrategy,
+          hiveConfig_,
+          icebergConfig_);
+    case IcebergInsertTableHandle::WriteKind::kDeletionVector:
+      return std::make_unique<IcebergDeletionVectorSink>(
+          inputType,
+          icebergInsertHandle,
+          connectorQueryCtx,
+          commitStrategy,
+          hiveConfig_);
+    case IcebergInsertTableHandle::WriteKind::kMerge: {
+      // The IcebergMergeProcessor (Layer 1) emits the convention:
+      //   [target cols 0..N-1, operation TINYINT @N, row_id ROW @N+1,
+      //    insert_from_update TINYINT @N+2].
+      // Derive the channel indices from the handle's inputColumns count.
+      const auto numTargetColumns = static_cast<column_index_t>(
+          icebergInsertHandle->inputColumns().size());
+      std::vector<column_index_t> targetColumnChannels(numTargetColumns);
+      std::iota(targetColumnChannels.begin(), targetColumnChannels.end(), 0);
+      const column_index_t operationChannel = numTargetColumns;
+      const column_index_t rowIdChannel = numTargetColumns + 1;
+      return std::make_unique<IcebergMergeSink>(
+          inputType,
+          icebergInsertHandle,
+          connectorQueryCtx,
+          commitStrategy,
+          hiveConfig_,
+          icebergConfig_,
+          std::move(targetColumnChannels),
+          operationChannel,
+          rowIdChannel);
+    }
+    case IcebergInsertTableHandle::WriteKind::kPositionDelete:
+      // V2 position-delete sink: not yet implemented in Velox. V2 DELETE
+      // currently runs through the Java row-id-rewrite path on the
+      // coordinator, so this dispatch arm is never hit in production
+      // today. Wired up so the WriteKind enum is exhaustive and a future
+      // V2 native port has a clear plug-in point. See
+      // ~/.llms/plans/iceberg_v2_native_positional_delete_sink.plan.md.
+      VELOX_NYI(
+          "Iceberg V2 native position-delete sink is not implemented. "
+          "V2 DELETE flows through the Java row-id-rewrite path; if "
+          "this NYI fires, the planner unexpectedly routed a V2 delete "
+          "through the native bridge.");
+  }
+  VELOX_UNREACHABLE(
+      "Unhandled IcebergInsertTableHandle::WriteKind: {}",
+      static_cast<int32_t>(icebergInsertHandle->writeKind()));
 }
 
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergDataSink.cpp
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.cpp
@@ -39,8 +39,6 @@
 
 #include "velox/connectors/hive/iceberg/TransformExprBuilder.h"
 #include "velox/connectors/hive/iceberg/WriterOptionsAdapter.h"
-#include "velox/dwio/dwrf/writer/Writer.h"
-#include "velox/exec/OperatorUtils.h"
 #include "velox/type/Type.h"
 
 using facebook::velox::common::testutil::TestValue;
@@ -129,7 +127,8 @@ IcebergInsertTableHandle::IcebergInsertTableHandle(
     dwio::common::FileFormat tableStorageFormat,
     IcebergPartitionSpecPtr partitionSpec,
     std::optional<common::CompressionKind> compressionKind,
-    const std::unordered_map<std::string, std::string>& serdeParameters)
+    const std::unordered_map<std::string, std::string>& serdeParameters,
+    WriteKind writeKind)
     : HiveInsertTableHandle(
           std::vector<HiveColumnHandlePtr>(
               inputColumns.begin(),
@@ -142,10 +141,18 @@ IcebergInsertTableHandle::IcebergInsertTableHandle(
           nullptr,
           false,
           std::make_shared<const HiveInsertFileNameGenerator>()),
-      partitionSpec_(partitionSpec) {
-  VELOX_USER_CHECK(
-      !inputColumns_.empty(),
-      "Input columns cannot be empty for Iceberg tables.");
+      partitionSpec_(partitionSpec),
+      writeKind_(writeKind) {
+  // Data-file writes and merge writes both require the input row type to
+  // have inputColumns populated (the data file sub-sink consumes them and
+  // the merge sink projects them into a narrow data batch). The
+  // deletion-vector path passes a synthetic (file_path, pos) row that is
+  // intentionally narrower, so skip the inputColumns check for that path.
+  if (writeKind_ == WriteKind::kData || writeKind_ == WriteKind::kMerge) {
+    VELOX_USER_CHECK(
+        !inputColumns_.empty(),
+        "Input columns cannot be empty for Iceberg tables.");
+  }
   VELOX_USER_CHECK_NOT_NULL(
       locationHandle_, "Location handle is required for Iceberg tables.");
   VELOX_USER_CHECK(
@@ -243,6 +250,30 @@ RowTypePtr createPartitionRowType(
   }
 
   return ROW(std::move(partitionKeyNames), std::move(partitionKeyTypes));
+}
+
+// Builds the CommitTaskData JSON object Presto consumes for one written file.
+// Iceberg "content" is derived from the sink's WriteKind: INSERT (kData) emits
+// "DATA"; the V3 deletion-vector path (kDeletionVector) emits
+// "POSITION_DELETES" because Iceberg classifies deletion vectors as a
+// Puffin-encoded form of position deletes for catalog accounting.
+folly::dynamic buildIcebergCommitData(
+    std::string path,
+    uint64_t fileSizeInBytes,
+    folly::dynamic metrics,
+    int32_t partitionSpecId,
+    std::string fileFormat,
+    bool isDeletionVector) {
+  folly::dynamic commitData = folly::dynamic::object;
+  commitData["path"] = std::move(path);
+  commitData["fileSizeInBytes"] = fileSizeInBytes;
+  commitData["metrics"] = std::move(metrics);
+  commitData["partitionSpecJson"] = partitionSpecId;
+  // Sort order evolution is not supported. Default id 0 (unsorted order).
+  commitData["sortOrderId"] = 0;
+  commitData["fileFormat"] = std::move(fileFormat);
+  commitData["content"] = isDeletionVector ? "POSITION_DELETES" : "DATA";
+  return commitData;
 }
 
 } // namespace
@@ -350,20 +381,18 @@ std::vector<std::string> IcebergDataSink::commitMessage() const {
     for (auto fileIdx = 0; fileIdx < writerInfo->writtenFiles.size();
          ++fileIdx) {
       const auto& fileInfo = writerInfo->writtenFiles[fileIdx];
-      // clang-format off
-      folly::dynamic commitData = folly::dynamic::object(
-        "path", (fs::path(writerInfo->writerParameters.targetDirectory()) /
-                      fileInfo.targetFileName).string())
-        ("fileSizeInBytes", fileInfo.fileSize)
-        ("metrics", dataFileStats_[i][fileIdx]->toJson())
-        ("partitionSpecJson",
-          icebergInsertTableHandle_->partitionSpec() ?
-            icebergInsertTableHandle_->partitionSpec()->specId : 0)
-        // Sort order evolution is not supported. Set default id to 0 ( unsorted order).
-        ("sortOrderId", 0)
-        ("fileFormat", toManifestFormatString(icebergInsertTableHandle_->storageFormat()))
-        ("content", "DATA");
-      // clang-format on
+      folly::dynamic commitData = buildIcebergCommitData(
+          (fs::path(writerInfo->writerParameters.targetDirectory()) /
+           fileInfo.targetFileName)
+              .string(),
+          fileInfo.fileSize,
+          dataFileStats_[i][fileIdx]->toJson(),
+          icebergInsertTableHandle_->partitionSpec()
+              ? icebergInsertTableHandle_->partitionSpec()->specId
+              : 0,
+          toManifestFormatString(icebergInsertTableHandle_->storageFormat()),
+          icebergInsertTableHandle_->writeKind() ==
+              IcebergInsertTableHandle::WriteKind::kDeletionVector);
       if (!commitPartitionValue_.empty() &&
           !commitPartitionValue_[i].isNull()) {
         commitData["partitionDataJson"] = folly::toJson(

--- a/velox/connectors/hive/iceberg/IcebergDataSink.h
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.h
@@ -41,6 +41,29 @@ namespace facebook::velox::connector::hive::iceberg {
 /// Represents a request for Iceberg write.
 class IcebergInsertTableHandle final : public HiveInsertTableHandle {
  public:
+  /// Identifies which kind of file the sink should produce. Used by
+  /// IcebergConnector::createDataSink to dispatch between:
+  ///  - the data-file IcebergDataSink (kData, INSERT and UPDATE-insert
+  ///    halves),
+  ///  - the V3 deletion-vector IcebergDeletionVectorSink (kDeletionVector,
+  ///    Puffin blobs encoding deleted positions per data file),
+  ///  - the V2 position-delete sink (kPositionDelete, position-delete
+  ///    Parquet/AVRO files). The V2 sink is not yet implemented; today
+  ///    V2 DELETE flows through the Java row-id-rewrite path. See
+  ///    ~/.llms/plans/iceberg_v2_native_positional_delete_sink.plan.md
+  ///    for the full design.
+  ///  - the composite IcebergMergeSink (kMerge, mixed INSERT+DELETE
+  ///    stream produced by an UPDATE or MERGE plan; internally routes
+  ///    INSERT rows to a kData sub-sink and DELETE rows to a
+  ///    kDeletionVector sub-sink so a single atomic Iceberg snapshot
+  ///    commits both file kinds together).
+  enum class WriteKind {
+    kData,
+    kDeletionVector,
+    kPositionDelete,
+    kMerge,
+  };
+
   /// @param inputColumns Columns from the table schema to write.
   /// The input RowVector must have the same number of columns and matching
   /// types in the same order.
@@ -57,13 +80,17 @@ class IcebergInsertTableHandle final : public HiveInsertTableHandle {
   /// @param compressionKind Optional compression to apply to data files.
   /// @param serdeParameters Additional serialization/deserialization parameters
   /// for the file format.
+  /// @param writeKind Selects between data-file emission (default) and V3
+  /// deletion-vector emission. The default preserves existing INSERT
+  /// semantics.
   IcebergInsertTableHandle(
       std::vector<IcebergColumnHandlePtr> inputColumns,
       LocationHandlePtr locationHandle,
       dwio::common::FileFormat tableStorageFormat,
       IcebergPartitionSpecPtr partitionSpec,
       std::optional<common::CompressionKind> compressionKind = {},
-      const std::unordered_map<std::string, std::string>& serdeParameters = {});
+      const std::unordered_map<std::string, std::string>& serdeParameters = {},
+      WriteKind writeKind = WriteKind::kData);
 
   /// Returns the Iceberg partition specification that defines how the table
   /// is partitioned.
@@ -71,8 +98,15 @@ class IcebergInsertTableHandle final : public HiveInsertTableHandle {
     return partitionSpec_;
   }
 
+  /// Returns the requested write kind. kData routes to IcebergDataSink;
+  /// kDeletionVector routes to IcebergDeletionVectorSink.
+  WriteKind writeKind() const {
+    return writeKind_;
+  }
+
  private:
   const IcebergPartitionSpecPtr partitionSpec_;
+  const WriteKind writeKind_;
 };
 
 using IcebergInsertTableHandlePtr =

--- a/velox/connectors/hive/iceberg/IcebergDeletionVectorSink.cpp
+++ b/velox/connectors/hive/iceberg/IcebergDeletionVectorSink.cpp
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/IcebergDeletionVectorSink.h"
+
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+
+#include <folly/json.h>
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/connectors/hive/HiveConfig.h"
+#include "velox/dwio/common/FileSink.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+namespace {
+
+// Position-delete input rows always carry exactly two columns:
+// file_path: VARCHAR, pos: BIGINT.
+constexpr int32_t kFilePathChannel = 0;
+constexpr int32_t kPositionChannel = 1;
+constexpr int32_t kExpectedChannelCount = 2;
+
+// Builds the JSON commit fragment the coordinator consumes for one written
+// deletion-vector Puffin file.
+std::string buildDeletionVectorCommitMessage(
+    const std::string& puffinPath,
+    uint64_t fileSize,
+    uint64_t recordCount,
+    int64_t partitionSpecId,
+    const std::string& referencedDataFile,
+    uint64_t contentOffset,
+    uint64_t contentLength) {
+  folly::dynamic msg = folly::dynamic::object;
+  msg["path"] = puffinPath;
+  msg["fileSizeInBytes"] = static_cast<int64_t>(fileSize);
+  msg["metrics"] =
+      folly::dynamic::object("recordCount", static_cast<int64_t>(recordCount));
+  msg["partitionSpecJson"] = partitionSpecId;
+  msg["fileFormat"] = "PUFFIN";
+  msg["referencedDataFile"] = referencedDataFile;
+  msg["content"] = "POSITION_DELETES";
+  msg["contentOffset"] = static_cast<int64_t>(contentOffset);
+  msg["contentSizeInBytes"] = static_cast<int64_t>(contentLength);
+  return folly::toJson(msg);
+}
+
+} // namespace
+
+IcebergDeletionVectorSink::IcebergDeletionVectorSink(
+    RowTypePtr inputType,
+    IcebergInsertTableHandlePtr insertTableHandle,
+    const ConnectorQueryCtx* connectorQueryCtx,
+    CommitStrategy commitStrategy,
+    std::shared_ptr<const HiveConfig> hiveConfig)
+    : inputType_(std::move(inputType)),
+      insertTableHandle_(std::move(insertTableHandle)),
+      connectorQueryCtx_(connectorQueryCtx),
+      commitStrategy_(commitStrategy),
+      hiveConfig_(std::move(hiveConfig)) {
+  VELOX_USER_CHECK_NOT_NULL(
+      insertTableHandle_,
+      "IcebergDeletionVectorSink requires a non-null insert table handle.");
+  VELOX_USER_CHECK_NOT_NULL(
+      inputType_, "IcebergDeletionVectorSink requires a non-null input type.");
+  VELOX_USER_CHECK_NOT_NULL(
+      hiveConfig_,
+      "IcebergDeletionVectorSink requires a non-null hive config.");
+  VELOX_USER_CHECK_EQ(
+      static_cast<int32_t>(inputType_->size()),
+      kExpectedChannelCount,
+      "IcebergDeletionVectorSink expects a 2-column input (file_path, pos)");
+}
+
+void IcebergDeletionVectorSink::appendData(RowVectorPtr input) {
+  VELOX_USER_CHECK(!finished_, "appendData() called after finish()");
+  VELOX_USER_CHECK(!aborted_, "appendData() called after abort()");
+  if (input == nullptr || input->size() == 0) {
+    return;
+  }
+  VELOX_USER_CHECK_EQ(
+      static_cast<int32_t>(input->childrenSize()),
+      kExpectedChannelCount,
+      "IcebergDeletionVectorSink expects 2-column input pages");
+
+  const auto* filePathVector = input->childAt(kFilePathChannel)->loadedVector();
+  const auto* positionVector = input->childAt(kPositionChannel)->loadedVector();
+
+  DecodedVector decodedFilePath(
+      *filePathVector, SelectivityVector(input->size()));
+  DecodedVector decodedPosition(
+      *positionVector, SelectivityVector(input->size()));
+
+  for (vector_size_t i = 0; i < input->size(); ++i) {
+    VELOX_USER_CHECK(
+        !decodedFilePath.isNullAt(i), "Null file_path in DELETE input row");
+    VELOX_USER_CHECK(
+        !decodedPosition.isNullAt(i), "Null pos in DELETE input row");
+    const auto pathSlice = decodedFilePath.valueAt<StringView>(i);
+    const std::string path(pathSlice.data(), pathSlice.size());
+    PerFileState& state = findOrCreatePerFile(path);
+    state.writer.addDeletedPosition(decodedPosition.valueAt<int64_t>(i));
+  }
+}
+
+IcebergDeletionVectorSink::PerFileState&
+IcebergDeletionVectorSink::findOrCreatePerFile(const std::string& path) {
+  if (auto it = perFileIndex_.find(path); it != perFileIndex_.end()) {
+    return perFile_[it->second].second;
+  }
+  const size_t index = perFile_.size();
+  perFile_.emplace_back(path, PerFileState{});
+  perFileIndex_.emplace(path, index);
+  return perFile_.back().second;
+}
+
+bool IcebergDeletionVectorSink::finish() {
+  // Single-shot finish: serialize each per-file roaring bitmap, write a Puffin
+  // file, and emit a commit message. No yielding mid-finish today; can be
+  // extended once we expose intermediate progress.
+  if (finished_) {
+    return true;
+  }
+  finished_ = true;
+  // Memory pool used to stage puffin bytes for the FileSink::write call.
+  // Use the operator memory pool from the connector context. In test paths
+  // that pass nullptr for connectorQueryCtx_, fall back to a leaf pool
+  // derived from the connector handle's pool. Tests without a connector
+  // context must supply a non-null connectorQueryCtx_ for this path; the
+  // existing test fixture is updated accordingly.
+  VELOX_CHECK_NOT_NULL(
+      connectorQueryCtx_,
+      "IcebergDeletionVectorSink::finish requires a connector query ctx for "
+      "FileSink buffer allocation.");
+  auto* pool = connectorQueryCtx_->memoryPool();
+  for (auto& entry : perFile_) {
+    if (entry.second.writer.numPositions() == 0) {
+      continue;
+    }
+    const std::string puffinPath = puffinPathFor(entry.first);
+    const std::string blob = entry.second.writer.serialize();
+
+    // Build a per-puffin FileSink. The Options mirror the data-file sink
+    // initialised by createHiveFileSink in HiveDataSink.cpp so that the
+    // puffin file lands through the same registered filesystem dispatch
+    // (local, warm storage, S3, ...) as the data file. Stats pointers are
+    // null because the deletion vector sink does not surface per-puffin
+    // IO statistics; cumulative numWrittenBytes_/numWrittenFiles_ are
+    // tracked locally below.
+    dwio::common::FileSink::Options sinkOptions{
+        .bufferWrite = false,
+        .connectorProperties = hiveConfig_->config(),
+        .fileCreateConfig = hiveConfig_->writeFileCreateConfig(),
+        .pool = pool,
+        .metricLogger = dwio::common::MetricsLog::voidLog(),
+        .stats = nullptr,
+        .fileSystemStats = nullptr,
+        .storageParameters = insertTableHandle_->storageParameters(),
+    };
+    auto sink = dwio::common::FileSink::create(puffinPath, sinkOptions);
+    VELOX_CHECK_NOT_NULL(
+        sink, "Failed to create file sink for Puffin file: {}", puffinPath);
+
+    const auto [offset, length] =
+        writePuffinFile(*sink, *pool, blob, entry.first);
+    const uint64_t fileSize = sink->size();
+    sink->close();
+
+    numWrittenBytes_ += fileSize;
+    numWrittenFiles_ += 1;
+
+    // Use the real partition spec id when the target table is partitioned;
+    // unpartitioned tables (or sinks constructed without a spec) emit 0
+    // (the default unpartitioned spec id).
+    const int64_t partitionSpecId = insertTableHandle_->partitionSpec()
+        ? insertTableHandle_->partitionSpec()->specId
+        : 0;
+    commitMessages_.push_back(buildDeletionVectorCommitMessage(
+        puffinPath,
+        fileSize,
+        entry.second.writer.numPositions(),
+        partitionSpecId,
+        entry.first,
+        offset,
+        length));
+  }
+  return true;
+}
+
+std::vector<std::string> IcebergDeletionVectorSink::close() {
+  if (!finished_) {
+    (void)finish();
+  }
+  return commitMessages_;
+}
+
+void IcebergDeletionVectorSink::abort() {
+  if (finished_ || aborted_) {
+    return;
+  }
+  aborted_ = true;
+  perFile_.clear();
+  perFileIndex_.clear();
+}
+
+DataSink::Stats IcebergDeletionVectorSink::stats() const {
+  Stats stats;
+  stats.numWrittenBytes = numWrittenBytes_;
+  stats.numWrittenFiles = numWrittenFiles_;
+  return stats;
+}
+
+std::string IcebergDeletionVectorSink::puffinPathFor(
+    const std::string& dataFile) const {
+  // Co-locate the puffin file with the referenced data file so that a
+  // partitioned V3 table's puffin blobs land in the same partition
+  // sub-directory as their data files. Falling back to the location handle's
+  // target path keeps unpartitioned tables and tests (which pass a synthetic
+  // dataFile without a parent directory) functional.
+  //
+  // Derive the parent directory via string ops rather than
+  // std::filesystem::path, which is not URI-safe: for scheme-based paths like
+  // "ws://bucket/dir/file" it collapses "//" to "/" and corrupts the
+  // scheme/authority prefix.
+  const auto lastSlash = dataFile.rfind('/');
+  std::string parentDir;
+  if (lastSlash == std::string::npos) {
+    parentDir = insertTableHandle_->locationHandle()->targetPath();
+  } else {
+    parentDir = dataFile.substr(0, lastSlash);
+  }
+  const std::string uuid =
+      boost::uuids::to_string(boost::uuids::random_generator()());
+  return parentDir + "/dv-" + uuid + ".puffin";
+}
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergDeletionVectorSink.h
+++ b/velox/connectors/hive/iceberg/IcebergDeletionVectorSink.h
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <folly/container/F14Map.h>
+
+#include "velox/connectors/Connector.h"
+#include "velox/connectors/hive/iceberg/DeletionVectorWriter.h"
+#include "velox/connectors/hive/iceberg/IcebergDataSink.h"
+
+namespace facebook::velox::connector::hive {
+class HiveConfig;
+} // namespace facebook::velox::connector::hive
+
+namespace facebook::velox::connector::hive::iceberg {
+
+/// V3 deletion-vector sink. Consumes (file_path, pos) rows produced by the
+/// coordinator's DELETE plan and emits one Puffin file per referenced data
+/// file. Each Puffin file contains a single deletion-vector-v1 blob holding
+/// the deleted positions encoded as a 64-bit roaring bitmap.
+///
+/// Selected by IcebergConnector::createDataSink when the incoming
+/// IcebergInsertTableHandle has writeKind() == kDeletionVector. Native
+/// execution dispatches to this sink for V3 tables; V2 tables continue to
+/// flow through the row-id-rewrite path on the coordinator and never reach
+/// this sink.
+///
+/// Commit messages emitted by close() follow the existing Iceberg connector
+/// CommitTaskData JSON contract with the V3 additions:
+///   {
+///     "path": "<puffin file path>",
+///     "fileSizeInBytes": <total file size>,
+///     "metrics": {"recordCount": <numPositions>},
+///     "partitionSpecJson": 0,
+///     "fileFormat": "PUFFIN",
+///     "referencedDataFile": "<data file path>",
+///     "content": "POSITION_DELETES",
+///     "contentOffset": <blob offset within puffin>,
+///     "contentSizeInBytes": <blob length>
+///   }
+class IcebergDeletionVectorSink : public DataSink {
+ public:
+  IcebergDeletionVectorSink(
+      RowTypePtr inputType,
+      IcebergInsertTableHandlePtr insertTableHandle,
+      const ConnectorQueryCtx* connectorQueryCtx,
+      CommitStrategy commitStrategy,
+      std::shared_ptr<const HiveConfig> hiveConfig);
+
+  void appendData(RowVectorPtr input) override;
+
+  bool finish() override;
+
+  std::vector<std::string> close() override;
+
+  void abort() override;
+
+  Stats stats() const override;
+
+  // Per-referenced-data-file accumulator. Builds a roaring bitmap from
+  // incoming positions; flushed to a Puffin file in close().
+  struct PerFileState {
+    DeletionVectorWriter writer;
+  };
+
+ private:
+  // Resolves the puffin output path for 'dataFile'. Today returns
+  // "<base location>/<uuid>.puffin"; in production this should be folded
+  // through the same LocationHandle / FileNameGenerator path that
+  // IcebergDataSink uses for data files so the puffin lands next to the data.
+  std::string puffinPathFor(const std::string& dataFile) const;
+
+  // Returns the accumulator for 'path', creating it on first use. Lookups are
+  // O(1) via 'perFileIndex_'; new entries are appended to 'perFile_' so the
+  // overall insertion order (and hence commit-message order) stays
+  // deterministic.
+  PerFileState& findOrCreatePerFile(const std::string& path);
+
+  const RowTypePtr inputType_;
+  const IcebergInsertTableHandlePtr insertTableHandle_;
+  const ConnectorQueryCtx* const connectorQueryCtx_;
+  const CommitStrategy commitStrategy_;
+  // HiveConfig is used to build the FileSink::Options for each puffin file
+  // (mainly writeFileCreateConfig() so warm-storage writes get the right
+  // namespace / oncall / queryId).
+  const std::shared_ptr<const HiveConfig> hiveConfig_;
+
+  // Indexed by referenced data file path; preserves insertion order so
+  // commit messages come back deterministically.
+  std::vector<std::pair<std::string, PerFileState>> perFile_;
+
+  // Maps a referenced data file path to its index in 'perFile_' so
+  // findOrCreatePerFile() is O(1) instead of a linear scan on every row.
+  folly::F14FastMap<std::string, size_t> perFileIndex_;
+
+  // Cached commit messages produced by close(); populated once and returned
+  // on each close() call to match the DataSink contract.
+  std::vector<std::string> commitMessages_;
+
+  bool finished_{false};
+  bool aborted_{false};
+
+  // Cumulative stats for the Stats() accessor.
+  uint64_t numWrittenBytes_{0};
+  uint32_t numWrittenFiles_{0};
+};
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergMergeProcessor.cpp
+++ b/velox/connectors/hive/iceberg/IcebergMergeProcessor.cpp
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/IcebergMergeProcessor.h"
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/type/Type.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+namespace {
+
+// Returns the merge_row child as a RowVector. The merge_row column is
+// expected to be a flat ROW after the caller has decoded any
+// dictionary/lazy/constant wrappers. `transform` flattens its input
+// merge_row child via `BaseVector::flattenVector` before calling this; this
+// helper is a final defensive type-check that the result really is a
+// `RowVector` and not, for example, a flat top-level Row whose children
+// are still encoded.
+const RowVector* asMergeRowVector(const VectorPtr& mergeRowChild) {
+  VELOX_CHECK_NOT_NULL(mergeRowChild, "merge_row column is null.");
+  const auto loaded = mergeRowChild->loadedVector();
+  const auto* rowVector = loaded->as<RowVector>();
+  VELOX_CHECK_NOT_NULL(
+      rowVector,
+      "merge_row column must be a flat RowVector, got encoding: {}",
+      static_cast<int>(loaded->encoding()));
+  return rowVector;
+}
+
+// Returns the operation TINYINT child of merge_row. Position is
+// `numMergeFields - 2` per the documented merge_row layout
+// (`ConnectorMergeSink.storeMergedRows` Javadoc): the last two fields are
+// operation and case_number, in that order.
+const FlatVector<int8_t>* asOperationVector(const RowVector& mergeRow) {
+  const auto numMergeFields = mergeRow.childrenSize();
+  VELOX_CHECK_GE(
+      numMergeFields,
+      2,
+      "merge_row must have at least operation + case_number fields, got {}",
+      numMergeFields);
+  const auto& operationChild =
+      mergeRow.childAt(static_cast<column_index_t>(numMergeFields - 2));
+  VELOX_CHECK_NOT_NULL(operationChild, "operation field of merge_row is null.");
+  const auto* operationVector =
+      operationChild->loadedVector()->asFlatVector<int8_t>();
+  VELOX_CHECK_NOT_NULL(
+      operationVector,
+      "operation field of merge_row must be a flat TINYINT vector.");
+  return operationVector;
+}
+
+} // namespace
+
+IcebergMergeProcessor::IcebergMergeProcessor(
+    std::vector<TypePtr> targetColumnTypes,
+    std::vector<std::string> outputColumnNames,
+    TypePtr rowIdType,
+    column_index_t targetRowIdChannel,
+    column_index_t mergeRowChannel)
+    : targetColumnTypes_(std::move(targetColumnTypes)),
+      outputColumnNames_(std::move(outputColumnNames)),
+      rowIdType_(std::move(rowIdType)),
+      targetRowIdChannel_(targetRowIdChannel),
+      mergeRowChannel_(mergeRowChannel),
+      numTargetColumns_(targetColumnTypes_.size()),
+      outputType_(
+          buildOutputType(targetColumnTypes_, outputColumnNames_, rowIdType_)) {
+  VELOX_CHECK_NOT_NULL(rowIdType_, "rowIdType is null.");
+  VELOX_CHECK_EQ(
+      outputColumnNames_.size(),
+      targetColumnTypes_.size() + 3,
+      "outputColumnNames size must be targetColumnTypes.size() + 3 "
+      "(target cols + operation + row_id + insert_from_update).");
+  VELOX_CHECK_NE(
+      targetRowIdChannel_,
+      mergeRowChannel_,
+      "targetRowIdChannel and mergeRowChannel must differ.");
+}
+
+RowTypePtr IcebergMergeProcessor::buildOutputType(
+    const std::vector<TypePtr>& targetColumnTypes,
+    const std::vector<std::string>& outputColumnNames,
+    const TypePtr& rowIdType) {
+  VELOX_CHECK_EQ(
+      outputColumnNames.size(),
+      targetColumnTypes.size() + 3,
+      "outputColumnNames size must be targetColumnTypes.size() + 3.");
+  std::vector<std::string> names;
+  std::vector<TypePtr> types;
+  const auto numTargetColumns = targetColumnTypes.size();
+  names.reserve(numTargetColumns + 3);
+  types.reserve(numTargetColumns + 3);
+  for (size_t i = 0; i < numTargetColumns; ++i) {
+    VELOX_CHECK_NOT_NULL(
+        targetColumnTypes[i], "targetColumnTypes[{}] is null.", i);
+    // Output names come from the planner-declared output variables so
+    // downstream nodes (TableWriter::setTypeMappings) bind by name to
+    // iceberg/planner-correct identifiers, not synthetic placeholders.
+    names.push_back(outputColumnNames[i]);
+    types.push_back(targetColumnTypes[i]);
+  }
+  // Trailing three columns: operation TINYINT, rowId, insert_from_update
+  // TINYINT — names from the planner output list, types fixed by the
+  // IcebergMergeProcessor contract.
+  names.push_back(outputColumnNames[numTargetColumns]);
+  types.push_back(TINYINT());
+  names.push_back(outputColumnNames[numTargetColumns + 1]);
+  types.push_back(rowIdType);
+  names.push_back(outputColumnNames[numTargetColumns + 2]);
+  types.push_back(TINYINT());
+  return ROW(std::move(names), std::move(types));
+}
+
+IcebergMergeProcessor::OperationCounts IcebergMergeProcessor::countOperations(
+    const FlatVector<int8_t>& operationVector,
+    vector_size_t numRows) const {
+  OperationCounts counts;
+  for (vector_size_t i = 0; i < numRows; ++i) {
+    VELOX_USER_CHECK(
+        !operationVector.isNullAt(i),
+        "merge_row operation field is null at position {}.",
+        i);
+    const int8_t operation = operationVector.valueAt(i);
+    switch (operation) {
+      case kDefaultCaseOperationNumber:
+        break;
+      case kInsertOperationNumber:
+        ++counts.numInsert;
+        break;
+      case kDeleteOperationNumber:
+        ++counts.numDelete;
+        break;
+      case kUpdateOperationNumber:
+        ++counts.numUpdate;
+        break;
+      default:
+        VELOX_USER_FAIL(
+            "Unknown merge operation byte: {}", static_cast<int>(operation));
+    }
+  }
+  return counts;
+}
+
+std::vector<VectorPtr> IcebergMergeProcessor::allocateOutputChildren(
+    vector_size_t numRows,
+    memory::MemoryPool* pool) const {
+  // BaseVector::create gives each child the correct null-vector and value
+  // storage to be mutated by setNull / copy / set by the caller.
+  std::vector<VectorPtr> outputChildren;
+  outputChildren.reserve(numTargetColumns_ + 3);
+  for (size_t c = 0; c < numTargetColumns_; ++c) {
+    outputChildren.push_back(
+        BaseVector::create(targetColumnTypes_[c], numRows, pool));
+  }
+  outputChildren.push_back(BaseVector::create(TINYINT(), numRows, pool));
+  outputChildren.push_back(BaseVector::create(rowIdType_, numRows, pool));
+  outputChildren.push_back(BaseVector::create(TINYINT(), numRows, pool));
+  return outputChildren;
+}
+
+RowVectorPtr IcebergMergeProcessor::transform(
+    const RowVectorPtr& input,
+    memory::MemoryPool* pool) const {
+  VELOX_CHECK_NOT_NULL(input, "Input row vector is null.");
+  VELOX_CHECK_NOT_NULL(pool, "Memory pool is null.");
+
+  const vector_size_t inputPositions = input->size();
+  if (inputPositions == 0) {
+    return BaseVector::create<RowVector>(outputType_, 0, pool);
+  }
+
+  VELOX_CHECK_LT(
+      targetRowIdChannel_,
+      input->childrenSize(),
+      "targetRowIdChannel out of range.");
+  VELOX_CHECK_LT(
+      mergeRowChannel_, input->childrenSize(), "mergeRowChannel out of range.");
+
+  const auto& rowIdInput = input->childAt(targetRowIdChannel_);
+  VELOX_CHECK_NOT_NULL(rowIdInput, "targetRowId column is null.");
+
+  // The merge_row column may arrive dictionary- or constant-encoded when
+  // upstream operators wrap it in a Project rather than materializing a flat
+  // ROW. The per-row fan-out below indexes children positionally, which
+  // requires a flat RowVector with flat children. Flatten the column (and
+  // its children) in place before passing it to asMergeRowVector so the
+  // downstream encoding-strict check passes.
+  auto mergeRowChild = input->childAt(mergeRowChannel_);
+  BaseVector::flattenVector(mergeRowChild);
+  const auto* mergeRow = asMergeRowVector(mergeRowChild);
+  const auto* operationVector = asOperationVector(*mergeRow);
+
+  VELOX_CHECK_GE(
+      mergeRow->childrenSize(),
+      numTargetColumns_ + 2,
+      "merge_row must have at least {} fields (target + operation + "
+      "case_number), got {}",
+      numTargetColumns_ + 2,
+      mergeRow->childrenSize());
+
+  const OperationCounts counts =
+      countOperations(*operationVector, inputPositions);
+  const vector_size_t totalOutput = static_cast<vector_size_t>(
+      counts.numInsert + counts.numDelete + 2 * counts.numUpdate);
+
+  // Allocate output children with capacity for `totalOutput` positions.
+  std::vector<VectorPtr> outputChildren =
+      allocateOutputChildren(totalOutput, pool);
+
+  const size_t operationOutIndex = numTargetColumns_;
+  const size_t rowIdOutIndex = numTargetColumns_ + 1;
+  const size_t insertFromUpdateOutIndex = numTargetColumns_ + 2;
+
+  auto* operationOut =
+      outputChildren[operationOutIndex]->asFlatVector<int8_t>();
+  auto& rowIdOut = outputChildren[rowIdOutIndex];
+  auto* insertFromUpdateOut =
+      outputChildren[insertFromUpdateOutIndex]->asFlatVector<int8_t>();
+  VELOX_CHECK_NOT_NULL(operationOut, "operation output is not flat.");
+  VELOX_CHECK_NOT_NULL(
+      insertFromUpdateOut, "insert_from_update output is not flat.");
+
+  vector_size_t outIdx = 0;
+
+  // Emits a DELETE output row sourced from the target-row-id column. Target
+  // columns are nulled because they are not meaningful on a DELETE row (the
+  // output schema is shared with INSERT rows).
+  auto emitDeleteRow = [&](vector_size_t inputIdx) {
+    for (size_t c = 0; c < numTargetColumns_; ++c) {
+      outputChildren[c]->setNull(outIdx, true);
+    }
+    operationOut->set(outIdx, kDeleteOperationNumber);
+    rowIdOut->copy(rowIdInput.get(), outIdx, inputIdx, 1);
+    insertFromUpdateOut->set(outIdx, 0);
+    ++outIdx;
+  };
+
+  // Emits an INSERT output row whose target column values come from the
+  // leading fields of merge_row, in the same order as targetColumnTypes_.
+  // 'fromUpdate' is 1 when this INSERT is the second half of an UPDATE, 0 for
+  // a plain INSERT (downstream sinks ignore it today; kept for OSS parity).
+  auto emitInsertRow = [&](vector_size_t inputIdx, bool fromUpdate) {
+    for (size_t c = 0; c < numTargetColumns_; ++c) {
+      outputChildren[c]->copy(
+          mergeRow->childAt(static_cast<column_index_t>(c)).get(),
+          outIdx,
+          inputIdx,
+          1);
+    }
+    operationOut->set(outIdx, kInsertOperationNumber);
+    rowIdOut->setNull(outIdx, true);
+    insertFromUpdateOut->set(outIdx, fromUpdate ? 1 : 0);
+    ++outIdx;
+  };
+
+  for (vector_size_t i = 0; i < inputPositions; ++i) {
+    const int8_t operation = operationVector->valueAt(i);
+    if (operation == kDefaultCaseOperationNumber) {
+      continue;
+    }
+    // DELETE and UPDATE both emit a DELETE row.
+    if (operation == kDeleteOperationNumber ||
+        operation == kUpdateOperationNumber) {
+      emitDeleteRow(i);
+    }
+    // INSERT and UPDATE both emit an INSERT row.
+    if (operation == kInsertOperationNumber ||
+        operation == kUpdateOperationNumber) {
+      emitInsertRow(i, operation == kUpdateOperationNumber);
+    }
+  }
+
+  VELOX_CHECK_EQ(
+      outIdx,
+      totalOutput,
+      "Emitted output positions {} do not match precomputed total {}.",
+      outIdx,
+      totalOutput);
+
+  return std::make_shared<RowVector>(
+      pool,
+      outputType_,
+      /*nulls=*/nullptr,
+      totalOutput,
+      std::move(outputChildren));
+}
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergMergeProcessor.h
+++ b/velox/connectors/hive/iceberg/IcebergMergeProcessor.h
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "velox/vector/ComplexVector.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+/// Stateless page-level transform that fans MERGE / UPDATE input rows out into
+/// delete + insert rows for connectors using the
+/// `DELETE_ROW_AND_INSERT_ROW` row-change paradigm (Iceberg). Mirrors the
+/// behavior of the OSS Java reference
+/// `presto-main-base/.../operator/DeleteAndInsertMergeProcessor.java`.
+///
+/// Input contract (channels in this fixed order, mirroring
+/// `MergeRowChangeProcessor.transformPage`):
+///   0. unique_id        BIGINT       (not consumed by this transform)
+///   1. target_row_id    ROW          (Iceberg row id — opaque here; copied
+///                                      verbatim into the output)
+///   2. merge_row        ROW          (target column 0..N-1, then operation
+///                                      TINYINT, then case_number INTEGER)
+///   3. case_number      INTEGER      (not consumed)
+///   4. is_distinct      BOOLEAN      (not consumed)
+///
+/// The channel indices for target_row_id and merge_row are configurable via
+/// the constructor (the unused channels are not consulted at all, so callers
+/// may pass any layout that places these two channels at the configured
+/// positions).
+///
+/// Output contract:
+///   columns 0..N-1     : target column values, with `targetColumnTypes`
+///                        in order. Set to NULL on DELETE rows; copied from
+///                        the merge_row's leading fields on INSERT rows.
+///   column N           : operation TINYINT — INSERT (1) or DELETE (2).
+///                        DEFAULT (-1) rows are dropped before output;
+///                        UPDATE (3) is fanned out to a DELETE row + an
+///                        INSERT row, so the output operation is always
+///                        INSERT or DELETE.
+///   column N+1         : rowId, same type as the input row id. Copied
+///                        verbatim on DELETE; NULL on INSERT.
+///   column N+2         : insert_from_update TINYINT — 1 if this row was
+///                        produced as the INSERT half of an UPDATE,
+///                        0 otherwise. Matches Java which uses TINYINT
+///                        rather than BOOLEAN.
+///
+/// Total output positions equal `numInsert + numDelete + 2 * numUpdate`
+/// where the counts are over the input operation column. Inputs with
+/// DEFAULT_CASE are skipped (no output).
+class IcebergMergeProcessor {
+ public:
+  /// Operation byte values defined by `ConnectorMergeSink.java:22-38`. Kept
+  /// in sync with the Java side so the per-row dispatch stays compatible
+  /// with the coordinator-emitted merge_row payload.
+  static constexpr int8_t kInsertOperationNumber = 1;
+  static constexpr int8_t kDeleteOperationNumber = 2;
+  static constexpr int8_t kUpdateOperationNumber = 3;
+
+  /// DEFAULT_CASE marker defined by
+  /// `MergeRowChangeProcessor.java:DEFAULT_CASE_OPERATION_NUMBER = -1`. Rows
+  /// with this operation byte are dropped from the output (they correspond
+  /// to MERGE WHEN cases whose source row matched no WHEN clause).
+  static constexpr int8_t kDefaultCaseOperationNumber = -1;
+
+  /// @param targetColumnTypes Types of the target table data columns, in the
+  /// same order as they appear at the leading fields of the merge_row ROW.
+  /// The number of entries determines how many leading fields of merge_row
+  /// will be consumed for INSERT rows and how many leading columns the
+  /// output will carry.
+  /// @param outputColumnNames Names of every output column, in order:
+  ///   [target columns ...] ++ [operation, row_id, insert_from_update]
+  /// Size must equal `targetColumnTypes.size() + 3`. The trailing three
+  /// names are taken from the planner's row-id / insert-from-update
+  /// variables rather than hardcoded so downstream Velox nodes that bind
+  /// by name (TableWriter::setTypeMappings) see the iceberg/planner names
+  /// rather than synthetic positional placeholders.
+  /// @param rowIdType Type of the Iceberg target row id. Used both to type
+  /// the corresponding output column and as the source/destination type when
+  /// copying row ids on DELETE rows. Treated as opaque — the inner struct
+  /// shape is not inspected.
+  /// @param targetRowIdChannel Index in the input RowVector that holds the
+  /// row id column. Typically 1, but configurable to keep this transform
+  /// independent of the exact upstream channel layout.
+  /// @param mergeRowChannel Index in the input RowVector that holds the
+  /// merge_row column (a ROW with target column values + operation +
+  /// case_number). Typically 2.
+  IcebergMergeProcessor(
+      std::vector<TypePtr> targetColumnTypes,
+      std::vector<std::string> outputColumnNames,
+      TypePtr rowIdType,
+      column_index_t targetRowIdChannel,
+      column_index_t mergeRowChannel);
+
+  /// Returns the output RowType produced by `transform`. Useful for
+  /// constructing the consuming operator's expected output type.
+  const RowTypePtr& outputType() const {
+    return outputType_;
+  }
+
+  /// Returns the per-row fan-out of `input`. The returned RowVector is
+  /// allocated from `pool` and has type `outputType()`. A zero-position
+  /// input returns a zero-position output. `pool` must outlive the returned
+  /// vector.
+  RowVectorPtr transform(const RowVectorPtr& input, memory::MemoryPool* pool)
+      const;
+
+ private:
+  // Counts INSERT / DELETE / UPDATE / DEFAULT_CASE positions in
+  // `operationVector` over [0, numRows). Throws VELOX_USER_FAIL on any
+  // other operation value.
+  struct OperationCounts {
+    uint64_t numInsert{0};
+    uint64_t numDelete{0};
+    uint64_t numUpdate{0};
+  };
+
+  OperationCounts countOperations(
+      const FlatVector<int8_t>& operationVector,
+      vector_size_t numRows) const;
+
+  // Allocates the output children for a page of `numRows` positions: the
+  // target columns followed by the trailing operation / rowId /
+  // insertFromUpdate columns, each sized to `numRows`.
+  std::vector<VectorPtr> allocateOutputChildren(
+      vector_size_t numRows,
+      memory::MemoryPool* pool) const;
+
+  // Builds the output RowType once at construction time:
+  //   targetColumnTypes_ ... ++ [TINYINT, rowIdType_, TINYINT].
+  // Output names come from `outputColumnNames` (size N+3) in the same
+  // order; the trailing three positions still carry the operation /
+  // rowId / insertFromUpdate types respectively.
+  static RowTypePtr buildOutputType(
+      const std::vector<TypePtr>& targetColumnTypes,
+      const std::vector<std::string>& outputColumnNames,
+      const TypePtr& rowIdType);
+
+  const std::vector<TypePtr> targetColumnTypes_;
+  const std::vector<std::string> outputColumnNames_;
+  const TypePtr rowIdType_;
+  const column_index_t targetRowIdChannel_;
+  const column_index_t mergeRowChannel_;
+  const size_t numTargetColumns_;
+  const RowTypePtr outputType_;
+};
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergMergeSink.cpp
+++ b/velox/connectors/hive/iceberg/IcebergMergeSink.cpp
@@ -1,0 +1,407 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/IcebergMergeSink.h"
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+namespace {
+
+// Returns the operation TINYINT child as a flat vector. Throws if the
+// operation column at `channel` is not a flat TINYINT.
+const FlatVector<int8_t>* asOperationFlatVector(
+    const RowVectorPtr& input,
+    column_index_t channel) {
+  const auto& column = input->childAt(channel);
+  VELOX_USER_CHECK_NOT_NULL(column, "operation column is null");
+  const auto* flat = column->loadedVector()->asFlatVector<int8_t>();
+  VELOX_USER_CHECK_NOT_NULL(
+      flat, "operation column must be a flat TINYINT vector");
+  return flat;
+}
+
+// Returns the row_id ROW child. Throws if the row_id column at `channel` is
+// not a RowVector with at least 2 children whose first two field types are
+// VARCHAR and BIGINT (matching the DV sub-sink's input contract).
+const RowVector* asRowIdRowVector(
+    const RowVectorPtr& input,
+    column_index_t channel) {
+  const auto& column = input->childAt(channel);
+  VELOX_USER_CHECK_NOT_NULL(column, "row_id column is null");
+  const auto* rowVector = column->loadedVector()->as<RowVector>();
+  VELOX_USER_CHECK_NOT_NULL(
+      rowVector, "row_id column must be a flat ROW vector");
+  VELOX_USER_CHECK_GE(
+      rowVector->childrenSize(),
+      2,
+      "row_id must have at least 2 fields (file_path, pos), got {}",
+      rowVector->childrenSize());
+  VELOX_USER_CHECK(
+      rowVector->childAt(0)->type()->isVarchar(),
+      "row_id field 0 must be VARCHAR (file_path)");
+  VELOX_USER_CHECK(
+      rowVector->childAt(1)->type()->isBigint(),
+      "row_id field 1 must be BIGINT (pos)");
+  return rowVector;
+}
+
+// Allocates a buffer big enough for `size` row indices. Returned buffer is
+// uninitialized — caller must populate before use.
+BufferPtr allocateIndicesBuffer(vector_size_t size, memory::MemoryPool* pool) {
+  return AlignedBuffer::allocate<vector_size_t>(size, pool);
+}
+
+// Folds the deletion-vector sub-sink's IO/codec counters into the data
+// sub-sink's stats. SpillStats are intentionally not merged: the DV sub-sink
+// has no spilling path, so the data sub-sink's spillStats is authoritative.
+DataSink::Stats mergeSubSinkStats(
+    DataSink::Stats dataStats,
+    const DataSink::Stats& dvStats) {
+  dataStats.numWrittenBytes += dvStats.numWrittenBytes;
+  dataStats.numWrittenFiles += dvStats.numWrittenFiles;
+  dataStats.writeIOTimeUs += dvStats.writeIOTimeUs;
+  dataStats.numCompressedBytes += dvStats.numCompressedBytes;
+  dataStats.recodeTimeNs += dvStats.recodeTimeNs;
+  dataStats.compressionTimeNs += dvStats.compressionTimeNs;
+  return dataStats;
+}
+
+} // namespace
+
+IcebergInsertTableHandlePtr IcebergMergeSink::cloneHandleWithKind(
+    const IcebergInsertTableHandle& original,
+    IcebergInsertTableHandle::WriteKind kind) {
+  // Reconstruct the input columns vector from the parent class accessor.
+  // HiveInsertTableHandle::inputColumns() returns the wider
+  // HiveColumnHandlePtr base type; downcast each back to IcebergColumnHandle
+  // (the original construction guarantees this is valid).
+  const auto& hiveInputs = original.inputColumns();
+  std::vector<IcebergColumnHandlePtr> icebergInputs;
+  icebergInputs.reserve(hiveInputs.size());
+  for (const auto& col : hiveInputs) {
+    icebergInputs.emplace_back(
+        checkedPointerCast<const IcebergColumnHandle>(col));
+  }
+  return std::make_shared<const IcebergInsertTableHandle>(
+      std::move(icebergInputs),
+      original.locationHandle(),
+      original.storageFormat(),
+      original.partitionSpec(),
+      original.compressionKind(),
+      original.serdeParameters(),
+      kind);
+}
+
+RowTypePtr IcebergMergeSink::projectDataInputType(
+    const RowTypePtr& inputType,
+    const std::vector<column_index_t>& targetColumnChannels,
+    const IcebergInsertTableHandle& insertTableHandle) {
+  const auto& handleInputColumns = insertTableHandle.inputColumns();
+  VELOX_USER_CHECK_EQ(
+      targetColumnChannels.size(),
+      handleInputColumns.size(),
+      "targetColumnChannels ({}) and insertTableHandle.inputColumns() ({}) "
+      "must have the same arity",
+      targetColumnChannels.size(),
+      handleInputColumns.size());
+  std::vector<std::string> names;
+  std::vector<TypePtr> types;
+  names.reserve(targetColumnChannels.size());
+  types.reserve(targetColumnChannels.size());
+  for (size_t i = 0; i < targetColumnChannels.size(); ++i) {
+    const auto channel = targetColumnChannels[i];
+    VELOX_USER_CHECK_LT(
+        channel,
+        inputType->size(),
+        "targetColumnChannel {} out of range for inputType of size {}",
+        channel,
+        inputType->size());
+    // Names come from the iceberg insert table handle so the writer's
+    // name-based binding always sees iceberg-schema names regardless of
+    // upstream naming drift; types still come from the source RowVector
+    // schema since that is what we actually receive at runtime.
+    VELOX_USER_CHECK_NOT_NULL(
+        handleInputColumns[i],
+        "insertTableHandle.inputColumns()[{}] is null",
+        i);
+    names.emplace_back(handleInputColumns[i]->name());
+    types.emplace_back(inputType->childAt(channel));
+  }
+  return ROW(std::move(names), std::move(types));
+}
+
+RowTypePtr IcebergMergeSink::makeDeletionVectorInputType() {
+  return ROW({"file_path", "pos"}, {VARCHAR(), BIGINT()});
+}
+
+IcebergMergeSink::IcebergMergeSink(
+    RowTypePtr inputType,
+    IcebergInsertTableHandlePtr insertTableHandle,
+    const ConnectorQueryCtx* connectorQueryCtx,
+    CommitStrategy commitStrategy,
+    const std::shared_ptr<const HiveConfig>& hiveConfig,
+    const IcebergConfigPtr& icebergConfig,
+    std::vector<column_index_t> targetColumnChannels,
+    column_index_t operationChannel,
+    column_index_t rowIdChannel)
+    : inputType_(std::move(inputType)),
+      insertTableHandle_(std::move(insertTableHandle)),
+      connectorQueryCtx_(connectorQueryCtx),
+      targetColumnChannels_(std::move(targetColumnChannels)),
+      operationChannel_(operationChannel),
+      rowIdChannel_(rowIdChannel),
+      dataInputType_(projectDataInputType(
+          inputType_,
+          targetColumnChannels_,
+          *insertTableHandle_)),
+      deletionVectorInputType_(makeDeletionVectorInputType()) {
+  VELOX_USER_CHECK_NOT_NULL(
+      insertTableHandle_,
+      "IcebergMergeSink requires a non-null insert table handle.");
+  VELOX_USER_CHECK_NOT_NULL(
+      inputType_, "IcebergMergeSink requires a non-null input type.");
+  VELOX_USER_CHECK_NOT_NULL(
+      connectorQueryCtx, "IcebergMergeSink requires a connector query ctx.");
+  VELOX_USER_CHECK_LT(
+      operationChannel_, inputType_->size(), "operationChannel out of range");
+  VELOX_USER_CHECK_LT(
+      rowIdChannel_, inputType_->size(), "rowIdChannel out of range");
+  VELOX_USER_CHECK(
+      inputType_->childAt(operationChannel_)->isTinyint(),
+      "operation column must be TINYINT");
+  VELOX_USER_CHECK(
+      inputType_->childAt(rowIdChannel_)->isRow(),
+      "row_id column must be a ROW type");
+  VELOX_USER_CHECK_EQ(
+      targetColumnChannels_.size(),
+      insertTableHandle_->inputColumns().size(),
+      "targetColumnChannels size {} must match handle inputColumns size {}",
+      targetColumnChannels_.size(),
+      insertTableHandle_->inputColumns().size());
+
+  // Build the two narrow handles and instantiate sub-sinks eagerly. Eager
+  // construction keeps the lifecycle simple — both sub-sinks always exist
+  // and respond to finish / close / abort even if a particular workload
+  // produces zero rows for one branch.
+  auto dataHandle = cloneHandleWithKind(
+      *insertTableHandle_, IcebergInsertTableHandle::WriteKind::kData);
+  auto dvHandle = cloneHandleWithKind(
+      *insertTableHandle_,
+      IcebergInsertTableHandle::WriteKind::kDeletionVector);
+
+  dataSink_ = std::make_unique<IcebergDataSink>(
+      dataInputType_,
+      std::move(dataHandle),
+      connectorQueryCtx_,
+      commitStrategy,
+      hiveConfig,
+      icebergConfig);
+  deletionVectorSink_ = std::make_unique<IcebergDeletionVectorSink>(
+      deletionVectorInputType_,
+      std::move(dvHandle),
+      connectorQueryCtx_,
+      commitStrategy,
+      hiveConfig);
+}
+
+RowVectorPtr IcebergMergeSink::makeInsertBatch(
+    const RowVectorPtr& input,
+    const BufferPtr& insertIndices,
+    vector_size_t insertSize) const {
+  std::vector<VectorPtr> projectedChildren;
+  projectedChildren.reserve(targetColumnChannels_.size());
+  for (auto channel : targetColumnChannels_) {
+    projectedChildren.push_back(
+        BaseVector::wrapInDictionary(
+            /*nulls=*/nullptr,
+            insertIndices,
+            insertSize,
+            input->childAt(channel)));
+  }
+  return std::make_shared<RowVector>(
+      connectorQueryCtx_->memoryPool(),
+      dataInputType_,
+      /*nulls=*/nullptr,
+      insertSize,
+      std::move(projectedChildren));
+}
+
+RowVectorPtr IcebergMergeSink::makeDeleteBatch(
+    const RowVectorPtr& input,
+    const BufferPtr& deleteIndices,
+    vector_size_t deleteSize) const {
+  const auto* rowIdRowVector = asRowIdRowVector(input, rowIdChannel_);
+  // The DV sink consumes (file_path, pos). The first two children of the
+  // row_id ROW carry exactly these. Extra trailing fields (spec_id,
+  // partition_data on the full Iceberg row id) are tolerated and ignored.
+  auto wrappedFilePath = BaseVector::wrapInDictionary(
+      /*nulls=*/nullptr, deleteIndices, deleteSize, rowIdRowVector->childAt(0));
+  auto wrappedPos = BaseVector::wrapInDictionary(
+      /*nulls=*/nullptr, deleteIndices, deleteSize, rowIdRowVector->childAt(1));
+  return std::make_shared<RowVector>(
+      connectorQueryCtx_->memoryPool(),
+      deletionVectorInputType_,
+      /*nulls=*/nullptr,
+      deleteSize,
+      std::vector<VectorPtr>{
+          std::move(wrappedFilePath), std::move(wrappedPos)});
+}
+
+void IcebergMergeSink::appendData(RowVectorPtr input) {
+  VELOX_USER_CHECK(!finished_, "appendData() called after finish()");
+  VELOX_USER_CHECK(!aborted_, "appendData() called after abort()");
+  if (input == nullptr || input->size() == 0) {
+    return;
+  }
+
+  const auto numRows = input->size();
+  const auto* operationVector = asOperationFlatVector(input, operationChannel_);
+
+  // First pass: count inserts/deletes and validate operation bytes.
+  vector_size_t numInserts = 0;
+  vector_size_t numDeletes = 0;
+  for (vector_size_t i = 0; i < numRows; ++i) {
+    VELOX_USER_CHECK(
+        !operationVector->isNullAt(i), "operation byte is null at row {}", i);
+    const int8_t op = operationVector->valueAt(i);
+    switch (op) {
+      case kInsertOperationNumber:
+        ++numInserts;
+        break;
+      case kDeleteOperationNumber:
+        ++numDeletes;
+        break;
+      default:
+        VELOX_USER_FAIL(
+            "IcebergMergeSink only accepts INSERT (1) and DELETE (2) "
+            "operation bytes (UPDATE / DEFAULT must be fanned out by "
+            "IcebergMergeProcessor first). Got byte {} at row {}.",
+            static_cast<int>(op),
+            i);
+    }
+  }
+
+  // Second pass: bucket row indices by op type.
+  auto* pool = connectorQueryCtx_->memoryPool();
+  BufferPtr insertIndices;
+  BufferPtr deleteIndices;
+  vector_size_t* rawInsertIndices = nullptr;
+  vector_size_t* rawDeleteIndices = nullptr;
+  if (numInserts > 0) {
+    insertIndices = allocateIndicesBuffer(numInserts, pool);
+    rawInsertIndices = insertIndices->asMutable<vector_size_t>();
+  }
+  if (numDeletes > 0) {
+    deleteIndices = allocateIndicesBuffer(numDeletes, pool);
+    rawDeleteIndices = deleteIndices->asMutable<vector_size_t>();
+  }
+  vector_size_t insertPos = 0;
+  vector_size_t deletePos = 0;
+  for (vector_size_t i = 0; i < numRows; ++i) {
+    const int8_t op = operationVector->valueAt(i);
+    if (op == kInsertOperationNumber) {
+      rawInsertIndices[insertPos++] = i;
+    } else {
+      rawDeleteIndices[deletePos++] = i;
+    }
+  }
+
+  if (numInserts > 0) {
+    dataSink_->appendData(makeInsertBatch(input, insertIndices, numInserts));
+  }
+  if (numDeletes > 0) {
+    deletionVectorSink_->appendData(
+        makeDeleteBatch(input, deleteIndices, numDeletes));
+  }
+}
+
+bool IcebergMergeSink::finish() {
+  if (finished_) {
+    return true;
+  }
+  // Drive each sub-sink to finish independently, tracking sticky completion
+  // so we never re-enter an already-finished sub-sink. Composite reports
+  // finished only when both sub-sinks report finished.
+  if (!dataSinkFinished_) {
+    dataSinkFinished_ = dataSink_->finish();
+  }
+  if (!deletionVectorSinkFinished_) {
+    deletionVectorSinkFinished_ = deletionVectorSink_->finish();
+  }
+  finished_ = dataSinkFinished_ && deletionVectorSinkFinished_;
+  return finished_;
+}
+
+std::vector<std::string> IcebergMergeSink::close() {
+  // close() is idempotent: drain the sub-sinks once and cache the result.
+  // Sub-sink close() is not safe to call twice, so guard re-entry here.
+  if (closed_) {
+    return commitMessages_;
+  }
+  closed_ = true;
+  // Ensure both sub-sinks have completed their flush state machines. Some
+  // sub-sinks (HiveDataSink) may need multiple finish() ticks; close()
+  // forces them through to completion. Bound the loop so a sub-sink that
+  // never reports finished fails loudly instead of spinning forever.
+  constexpr int32_t kMaxFinishIterations = 1'000'000;
+  int32_t finishIterations = 0;
+  while (!finish()) {
+    VELOX_CHECK_LT(
+        ++finishIterations,
+        kMaxFinishIterations,
+        "IcebergMergeSink::close() did not converge after {} finish() "
+        "iterations; a sub-sink is stuck mid-flush.",
+        kMaxFinishIterations);
+  }
+  auto dataMessages = dataSink_->close();
+  auto deletionMessages = deletionVectorSink_->close();
+  // Concatenate commit messages so the coordinator sees a single fragment
+  // stream covering both the new data files and the puffin delete files.
+  std::vector<std::string> combined;
+  combined.reserve(dataMessages.size() + deletionMessages.size());
+  combined.insert(
+      combined.end(),
+      std::make_move_iterator(dataMessages.begin()),
+      std::make_move_iterator(dataMessages.end()));
+  combined.insert(
+      combined.end(),
+      std::make_move_iterator(deletionMessages.begin()),
+      std::make_move_iterator(deletionMessages.end()));
+  commitMessages_ = std::move(combined);
+  return commitMessages_;
+}
+
+void IcebergMergeSink::abort() {
+  if (aborted_) {
+    return;
+  }
+  aborted_ = true;
+  // Abort the data sub-sink first because it owns the heavier writer state
+  // (open files, memory-pool reservations). The DV sub-sink only holds
+  // in-memory roaring bitmaps until finish(); aborting it is essentially
+  // free.
+  dataSink_->abort();
+  deletionVectorSink_->abort();
+}
+
+DataSink::Stats IcebergMergeSink::stats() const {
+  return mergeSubSinkStats(dataSink_->stats(), deletionVectorSink_->stats());
+}
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergMergeSink.h
+++ b/velox/connectors/hive/iceberg/IcebergMergeSink.h
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "velox/connectors/Connector.h"
+#include "velox/connectors/hive/iceberg/IcebergConfig.h"
+#include "velox/connectors/hive/iceberg/IcebergDataSink.h"
+#include "velox/connectors/hive/iceberg/IcebergDeletionVectorSink.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+/// Composite DataSink that fans an input RowVector tagged with a per-row
+/// `operation` byte out to two underlying sinks:
+///   - INSERT rows  → an inner `IcebergDataSink`              (kData)
+///   - DELETE rows  → an inner `IcebergDeletionVectorSink`    (kDeletionVector)
+///
+/// Selected by `IcebergConnector::createDataSink` when the incoming
+/// `IcebergInsertTableHandle` has `writeKind() == kMerge`. Mirrors the
+/// connector-side behavior of OSS Java `IcebergAbstractMetadata.finishMerge` /
+/// `finishUpdate` which absorbs a single mixed fragment stream into one
+/// Iceberg snapshot (positional-delete files + new data files committed
+/// atomically).
+///
+/// Upstream contract:
+///   - The composite is fed by Layer 1's `IcebergMergeProcessor`, whose
+///     output schema is `[target_cols…, operation TINYINT, row_id ROW,
+///     insert_from_update TINYINT]`.
+///   - UPDATE (3) and DEFAULT_CASE (-1) bytes are fanned out / dropped by
+///     `IcebergMergeProcessor` before reaching this sink; only INSERT (1)
+///     and DELETE (2) bytes are valid here. Any other value triggers
+///     `VELOX_USER_FAIL`.
+///   - The constructor takes explicit channel indices so the upstream
+///     plan-node ordering is decoupled from the sink — Layer 3 wires these
+///     up from the protocol payload.
+///
+/// Sub-sink wiring:
+///   The composite clones the incoming `IcebergInsertTableHandle` into two
+///   narrow handles — one with `WriteKind::kData` for the data sink and one
+///   with `WriteKind::kDeletionVector` for the DV sink. The narrow handles
+///   share the same `locationHandle`, `partitionSpec`, `inputColumns`,
+///   `storageFormat`, `compressionKind`, and `serdeParameters` as the
+///   original. Sub-sinks see their normal handle types; no invariant
+///   relaxation is required.
+class IcebergMergeSink : public DataSink {
+ public:
+  /// Operation byte values that may appear on the composite's input. Mirrors
+  /// `IcebergMergeProcessor::k{Insert,Delete}OperationNumber`; UPDATE and
+  /// DEFAULT_CASE are intentionally NOT accepted here (Layer 1 must have
+  /// fanned them out / dropped them already).
+  static constexpr int8_t kInsertOperationNumber = 1;
+  static constexpr int8_t kDeleteOperationNumber = 2;
+
+  /// @param inputType Schema of every RowVector passed to `appendData`. Must
+  /// have at least `max(targetColumnChannels) + 1`,
+  /// `operationChannel + 1`, and `rowIdChannel + 1` fields.
+  /// @param insertTableHandle The original `kMerge` handle. Cloned twice
+  /// internally into narrow `kData` / `kDeletionVector` handles.
+  /// @param targetColumnChannels Indices of the target table data columns
+  /// within `inputType`, in the same order as the target table schema. The
+  /// inner data sink will see exactly these columns. The set must match the
+  /// `inputColumns()` count on `insertTableHandle`.
+  /// @param operationChannel Index of the TINYINT operation column.
+  /// @param rowIdChannel Index of the row id ROW column (must be a ROW
+  /// type whose first two fields are file_path VARCHAR and pos BIGINT —
+  /// extra trailing fields are tolerated and ignored).
+  IcebergMergeSink(
+      RowTypePtr inputType,
+      IcebergInsertTableHandlePtr insertTableHandle,
+      const ConnectorQueryCtx* connectorQueryCtx,
+      CommitStrategy commitStrategy,
+      const std::shared_ptr<const HiveConfig>& hiveConfig,
+      const IcebergConfigPtr& icebergConfig,
+      std::vector<column_index_t> targetColumnChannels,
+      column_index_t operationChannel,
+      column_index_t rowIdChannel);
+
+  void appendData(RowVectorPtr input) override;
+
+  bool finish() override;
+
+  std::vector<std::string> close() override;
+
+  void abort() override;
+
+  Stats stats() const override;
+
+ private:
+  // Builds a narrow data-sub-sink batch (one row per insert-tagged input
+  // row) by dictionary-wrapping the target column children using the
+  // pre-computed `insertIndices` buffer. Returned RowVector has type
+  // `dataInputType_`.
+  RowVectorPtr makeInsertBatch(
+      const RowVectorPtr& input,
+      const BufferPtr& insertIndices,
+      vector_size_t insertSize) const;
+
+  // Builds a narrow DV-sub-sink batch (one row per delete-tagged input row)
+  // by extracting the first two children of the row_id ROW field
+  // (file_path, pos) and dictionary-wrapping each using the pre-computed
+  // `deleteIndices` buffer. Returned RowVector has type
+  // `deletionVectorInputType_`.
+  RowVectorPtr makeDeleteBatch(
+      const RowVectorPtr& input,
+      const BufferPtr& deleteIndices,
+      vector_size_t deleteSize) const;
+
+  // Builds an `IcebergInsertTableHandle` identical to `original` except for
+  // its `writeKind`. Used to construct narrow `kData` / `kDeletionVector`
+  // handles for the inner sub-sinks.
+  static IcebergInsertTableHandlePtr cloneHandleWithKind(
+      const IcebergInsertTableHandle& original,
+      IcebergInsertTableHandle::WriteKind kind);
+
+  // Projects `inputType` to a RowType containing only the columns named by
+  // `targetColumnChannels`, but using the iceberg-schema column names from
+  // `insertTableHandle.inputColumns()` (one entry per channel, in order).
+  // Deriving names from the handle rather than the source RowVector makes
+  // `dataInputType_` independent of whatever upstream named the columns,
+  // so the writer's name-based binding (TableWriter::setTypeMappings) always
+  // sees the iceberg-correct names.
+  static RowTypePtr projectDataInputType(
+      const RowTypePtr& inputType,
+      const std::vector<column_index_t>& targetColumnChannels,
+      const IcebergInsertTableHandle& insertTableHandle);
+
+  // The 2-column ROW type the DV sub-sink consumes: (file_path VARCHAR,
+  // pos BIGINT). Validated against the first two children of the row_id
+  // ROW at construction time.
+  static RowTypePtr makeDeletionVectorInputType();
+
+  const RowTypePtr inputType_;
+  const IcebergInsertTableHandlePtr insertTableHandle_;
+  const ConnectorQueryCtx* const connectorQueryCtx_;
+  const std::vector<column_index_t> targetColumnChannels_;
+  const column_index_t operationChannel_;
+  const column_index_t rowIdChannel_;
+  const RowTypePtr dataInputType_;
+  const RowTypePtr deletionVectorInputType_;
+
+  std::unique_ptr<IcebergDataSink> dataSink_;
+  std::unique_ptr<IcebergDeletionVectorSink> deletionVectorSink_;
+
+  // Sub-sink completion latches. `finish()` may yield by returning false
+  // when the inner data sink is mid-flush; on the next call we must not
+  // re-finish a sink that already returned true.
+  bool dataSinkFinished_{false};
+  bool deletionVectorSinkFinished_{false};
+  bool finished_{false};
+  bool aborted_{false};
+
+  // close() latch. The first close() drains both sub-sinks and caches their
+  // combined commit messages here; subsequent close() calls return the cached
+  // vector unchanged, so close() is idempotent (sub-sink close() is not).
+  bool closed_{false};
+  std::vector<std::string> commitMessages_;
+};
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergMetadataColumns.h
+++ b/velox/connectors/hive/iceberg/IcebergMetadataColumns.h
@@ -38,10 +38,26 @@ struct IcebergMetadataColumn {
   static constexpr const char* kRowIdColumnName = "_row_id";
   static constexpr const char* kLastUpdatedSequenceNumberColumnName =
       "_last_updated_sequence_number";
+  // Synthesized Iceberg MERGE INTO row-id column. Produced at read time by
+  // IcebergSplitReader as a 4-field composite:
+  //   ROW(file_path:VARCHAR, row_position:BIGINT, spec_id:INTEGER,
+  //       partition_data:VARCHAR).
+  // Mirrors the Java IcebergPageSourceProvider synthesis path that backs
+  // MERGE_TARGET_ROW_ID_DATA. The downstream MergeProcessor + IcebergMergeSink
+  // consume the composite to issue per-file positional deletes.
+  static constexpr const char* kTargetTableRowIdColumnName =
+      "$target_table_row_id";
   // Info column keys provided in the split's infoColumns map.
   static constexpr const char* kFirstRowIdInfoColumn = "$first_row_id";
   static constexpr const char* kDataSequenceNumberInfoColumn =
       "$data_sequence_number";
+  // Partition spec ID for the data file in the split. Required to synthesize
+  // the spec_id field of $target_table_row_id.
+  static constexpr const char* kSpecIdInfoColumn = "$spec_id";
+  // Iceberg PartitionData JSON for the data file in the split, used to
+  // synthesize the partition_data field of $target_table_row_id. Empty string
+  // when the table is unpartitioned.
+  static constexpr const char* kPartitionDataInfoColumn = "partition_data";
 
   IcebergMetadataColumn(
       int _id,

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -157,7 +157,7 @@ void IcebergSplitReader::prepareSplit(
             IcebergMetadataColumn::kLastUpdatedSequenceNumberColumnName}) {
         if (readerOutputType_->containsChild(colName) &&
             !originalFileSchema->containsChild(colName)) {
-          names.emplace_back(std::string(colName));
+          names.emplace_back(colName);
           types.emplace_back(BIGINT());
           modified = true;
         }
@@ -224,6 +224,36 @@ void IcebergSplitReader::prepareSplit(
         IcebergMetadataColumn::kRowIdColumnName);
   }
 
+  // Iceberg MERGE INTO row-id synthesis: detect projection of
+  // $target_table_row_id and cache the constant fields (spec_id,
+  // partition_data) so next() can build the composite RowVector cheaply.
+  // file_path comes from the split's filePath directly; row_position is
+  // computed per row in next() using either the injected row-number column
+  // (filter / skip / positional-delete paths) or the contiguous formula.
+  targetTableRowIdOutputIndex_ = std::nullopt;
+  targetTableSpecId_ = std::nullopt;
+  targetTablePartitionData_ = std::nullopt;
+  if (readerOutputType_->containsChild(
+          IcebergMetadataColumn::kTargetTableRowIdColumnName)) {
+    targetTableRowIdOutputIndex_ = readerOutputType_->getChildIdxIfExists(
+        IcebergMetadataColumn::kTargetTableRowIdColumnName);
+    if (auto it = icebergSplit_->infoColumns.find(
+            IcebergMetadataColumn::kSpecIdInfoColumn);
+        it != icebergSplit_->infoColumns.end()) {
+      try {
+        targetTableSpecId_ = folly::to<int32_t>(it->second);
+      } catch (const folly::ConversionError&) {
+        VELOX_FAIL(
+            "Invalid $spec_id value in split info columns: {}", it->second);
+      }
+    }
+    if (auto it = icebergSplit_->infoColumns.find(
+            IcebergMetadataColumn::kPartitionDataInfoColumn);
+        it != icebergSplit_->infoColumns.end()) {
+      targetTablePartitionData_ = it->second;
+    }
+  }
+
   if (checkIfSplitIsEmpty(runtimeStats)) {
     VELOX_CHECK(emptySplit_);
     return;
@@ -232,7 +262,9 @@ void IcebergSplitReader::prepareSplit(
   // Inject a row-number column when filters, random-skip, or positional
   // deletes make the output-to-file-position mapping non-contiguous.
   // Check split metadata rather than positionalDeleteFileReaders_ because
-  // the row reader must be configured before delete files are opened.
+  // the row reader must be configured before delete files are opened. Both
+  // _row_id and $target_table_row_id need accurate file-absolute positions,
+  // so request injection when either is projected.
   const bool hasPositionalDeletes = std::any_of(
       icebergSplit_->deleteFiles.begin(),
       icebergSplit_->deleteFiles.end(),
@@ -240,7 +272,8 @@ void IcebergSplitReader::prepareSplit(
         return deleteFile.content == FileContent::kPositionalDeletes &&
             deleteFile.recordCount > 0;
       });
-  useRowNumberColumn_ = rowIdOutputIndex_.has_value() &&
+  useRowNumberColumn_ = (rowIdOutputIndex_.has_value() ||
+                         targetTableRowIdOutputIndex_.has_value()) &&
       (scanSpec_->hasFilter() || baseReaderOpts_.randomSkip() != nullptr ||
        hasPositionalDeletes);
   if (useRowNumberColumn_) {
@@ -560,7 +593,8 @@ uint64_t IcebergSplitReader::next(uint64_t size, VectorPtr& output) {
 
   if (rowsScanned > 0 &&
       (lastUpdatedSeqNumOutputIndex_.has_value() ||
-       rowIdOutputIndex_.has_value())) {
+       rowIdOutputIndex_.has_value() ||
+       targetTableRowIdOutputIndex_.has_value())) {
     auto* rowOutput = output->as<RowVector>();
     VELOX_DCHECK_NOT_NULL(
         rowOutput, "Expected RowVector output from table scan");
@@ -573,36 +607,99 @@ uint64_t IcebergSplitReader::next(uint64_t size, VectorPtr& output) {
           seqNumChild, pool, [seqNum](vector_size_t) { return seqNum; });
     }
 
+    // Resolve file-absolute row positions once and reuse for both
+    // _row_id and $target_table_row_id. When useRowNumberColumn_ is true,
+    // the reader appended a row-number column at index
+    // readerOutputType_->size(). Otherwise the output is contiguous and we
+    // derive positions from the split offset plus per-row index.
+    const bool needRowPositions = rowIdOutputIndex_.has_value() ||
+        targetTableRowIdOutputIndex_.has_value();
+    std::optional<DecodedVector> decodedRowNumsHolder;
+    if (needRowPositions && useRowNumberColumn_) {
+      decodedRowNumsHolder.emplace(
+          *rowOutput->childAt(readerOutputType_->size()));
+    }
+    auto rowPositionAt = [&](vector_size_t i) -> int64_t {
+      if (useRowNumberColumn_) {
+        return decodedRowNumsHolder->valueAt<int64_t>(i);
+      }
+      return static_cast<int64_t>(splitOffset_ + baseReadOffset_) +
+          static_cast<int64_t>(i);
+    };
+
     if (rowIdOutputIndex_.has_value() && firstRowId_.has_value()) {
       auto& rowIdChild = rowOutput->childAt(*rowIdOutputIndex_);
-      if (useRowNumberColumn_) {
-        // Use the injected row-number column for file-absolute positions.
-        // The row-number column is always appended last (at index
-        // readerOutputType_->size()).
-        const DecodedVector decodedRowNums(
-            *rowOutput->childAt(readerOutputType_->size()));
-        const int64_t firstRowId = static_cast<int64_t>(*firstRowId_);
-        fillNullsWithInt64(rowIdChild, pool, [&](vector_size_t i) {
-          return firstRowId + decodedRowNums.valueAt<int64_t>(i);
-        });
+      const int64_t firstRowId = static_cast<int64_t>(*firstRowId_);
+      fillNullsWithInt64(rowIdChild, pool, [&](vector_size_t i) {
+        return firstRowId + rowPositionAt(i);
+      });
+    }
 
-        // Strip the injected row-number column (always last) from the output.
-        auto children = rowOutput->children();
-        children.pop_back();
-        output = std::make_shared<RowVector>(
-            rowOutput->pool(),
-            readerOutputType_,
-            rowOutput->nulls(),
-            rowOutput->size(),
-            std::move(children));
-      } else {
-        // Contiguous output: _row_id = firstRowId_ + file_pos.
-        const int64_t base = static_cast<int64_t>(*firstRowId_) +
-            static_cast<int64_t>(splitOffset_ + baseReadOffset_);
-        fillNullsWithInt64(rowIdChild, pool, [base](vector_size_t i) {
-          return base + static_cast<int64_t>(i);
-        });
+    if (targetTableRowIdOutputIndex_.has_value()) {
+      // Build the 4-field composite ROW for Iceberg MERGE INTO row-id:
+      //   ROW(file_path:VARCHAR, row_position:BIGINT, spec_id:INTEGER,
+      //       partition_data:VARCHAR).
+      // file_path and partition_data are constant per split; spec_id is
+      // constant per split. row_position is per row, sourced from
+      // rowPositionAt(). Use ConstantVector children for the constants so
+      // we avoid copying the file path / partition data once per row.
+      static const std::string emptyPartitionData;
+      const auto& rowIdType =
+          readerOutputType_->childAt(*targetTableRowIdOutputIndex_);
+      VELOX_CHECK(
+          rowIdType->isRow() && rowIdType->size() == 4,
+          "$target_table_row_id must be a 4-field ROW; got {}",
+          rowIdType->toString());
+      const auto& rowIdRowType = rowIdType->asRow();
+      const auto numRows = static_cast<vector_size_t>(rowsScanned);
+
+      auto filePathConst = BaseVector::createConstant(
+          rowIdRowType.childAt(0),
+          variant(icebergSplit_->filePath),
+          numRows,
+          pool);
+
+      auto rowPositionFlat = BaseVector::create<FlatVector<int64_t>>(
+          rowIdRowType.childAt(1), numRows, pool);
+      for (vector_size_t i = 0; i < numRows; ++i) {
+        rowPositionFlat->set(i, rowPositionAt(i));
       }
+
+      const int32_t specId = targetTableSpecId_.value_or(0);
+      auto specIdConst = BaseVector::createConstant(
+          rowIdRowType.childAt(2), variant(specId), numRows, pool);
+
+      const std::string& partitionData = targetTablePartitionData_.has_value()
+          ? *targetTablePartitionData_
+          : emptyPartitionData;
+      auto partitionDataConst = BaseVector::createConstant(
+          rowIdRowType.childAt(3), variant(partitionData), numRows, pool);
+
+      std::vector<VectorPtr> children = {
+          std::move(filePathConst),
+          std::move(rowPositionFlat),
+          std::move(specIdConst),
+          std::move(partitionDataConst)};
+      rowOutput->childAt(*targetTableRowIdOutputIndex_) =
+          std::make_shared<RowVector>(
+              pool,
+              rowIdType,
+              /*nulls=*/nullptr,
+              numRows,
+              std::move(children));
+    }
+
+    // Strip the injected row-number column (always last, allocated when
+    // useRowNumberColumn_ is true). Done once for both row-id paths.
+    if (useRowNumberColumn_) {
+      auto children = rowOutput->children();
+      children.pop_back();
+      output = std::make_shared<RowVector>(
+          rowOutput->pool(),
+          readerOutputType_,
+          rowOutput->nulls(),
+          rowOutput->size(),
+          std::move(children));
     }
   }
 
@@ -762,6 +859,23 @@ std::vector<TypePtr> IcebergSplitReader::adaptColumns(
           childSpec->setConstantValue(
               BaseVector::createNullConstant(
                   BIGINT(), 1, connectorQueryCtx_->memoryPool()));
+        } else if (
+            fieldName == IcebergMetadataColumn::kTargetTableRowIdColumnName) {
+          // Synthesized Iceberg MERGE row-id column. Install a null
+          // placeholder constant of the full ROW type so the reader
+          // allocates the output slot with the right shape; next() will
+          // overwrite the child with a freshly built flat RowVector whose
+          // four fields (file_path, row_position, spec_id, partition_data)
+          // are populated from the split's info columns and the file row
+          // positions. This mirrors the Java IcebergPageSourceProvider
+          // synthesis path that backs MERGE_TARGET_ROW_ID_DATA.
+          auto columnType = readerOutputType_->findChild(fieldName);
+          VELOX_CHECK_NOT_NULL(
+              columnType,
+              "$target_table_row_id type missing from readerOutputType");
+          childSpec->setConstantValue(
+              BaseVector::createNullConstant(
+                  columnType, 1, connectorQueryCtx_->memoryPool()));
         } else if (childSpec->isConstant()) {
           // Constant already set (equality-delete partition column, or set on
           // a previous prepareSplit call for the same scanSpec). Nothing to do.

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.h
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.h
@@ -170,6 +170,17 @@ class IcebergSplitReader : public FileSplitReader {
   std::optional<int64_t> firstRowId_;
   // Output column index of _row_id, if projected.
   std::optional<column_index_t> rowIdOutputIndex_;
+  // Output column index of $target_table_row_id, if projected. Populated in
+  // prepareSplit() when the reader output includes the synthetic MERGE INTO
+  // row-id ROW column. next() consumes this index to overwrite the placeholder
+  // child set by adaptColumns() with a freshly synthesized 4-field RowVector.
+  std::optional<column_index_t> targetTableRowIdOutputIndex_;
+  // Constant values needed to synthesize the spec_id and partition_data
+  // fields of $target_table_row_id. Sourced from the split's infoColumns map
+  // ($spec_id and partition_data). file_path comes from the split's filePath
+  // directly. row_position is computed in next() per row.
+  std::optional<int32_t> targetTableSpecId_;
+  std::optional<std::string> targetTablePartitionData_;
   // Whether an implicit row-number column is needed for _row_id computation
   // (set when filters, random-skip, or positional deletes make output
   // positions non-contiguous).

--- a/velox/connectors/hive/iceberg/WriterOptionsAdapter.cpp
+++ b/velox/connectors/hive/iceberg/WriterOptionsAdapter.cpp
@@ -91,13 +91,17 @@ class NimbleWriterOptionsAdapter : public WriterOptionsAdapter {
 
 std::unique_ptr<WriterOptionsAdapter> createWriterOptionsAdapter(
     dwio::common::FileFormat format) {
-  // ORC is intentionally excluded until a dedicated ORC end-to-end test
-  // exists.
   // NOLINTNEXTLINE(clang-diagnostic-switch-enum)
   switch (format) {
     case dwio::common::FileFormat::PARQUET:
       return std::make_unique<ParquetWriterOptionsAdapter>();
+    case dwio::common::FileFormat::ORC:
     case dwio::common::FileFormat::DWRF:
+      // ORC and DWRF share the same on-disk family — Meta's DWRF is an
+      // ORC implementation. Iceberg manifests have no DWRF enum, so both
+      // are reported as "ORC" per the cross-engine convention shared
+      // with the Java planner (see FileFormat.DWRF.toIceberg() in
+      // presto-facebook-iceberg).
       return std::make_unique<DwrfWriterOptionsAdapter>();
     case dwio::common::FileFormat::NIMBLE:
       return std::make_unique<NimbleWriterOptionsAdapter>();

--- a/velox/connectors/hive/iceberg/WriterOptionsAdapter.h
+++ b/velox/connectors/hive/iceberg/WriterOptionsAdapter.h
@@ -57,6 +57,8 @@ std::unique_ptr<WriterOptionsAdapter> createWriterOptionsAdapter(
     dwio::common::FileFormat format);
 
 /// True if the Iceberg DataSink can write the given file format.
+/// Supported formats: PARQUET, ORC, DWRF, NIMBLE. ORC and DWRF share
+/// the same on-disk family and route through the same adapter.
 bool isSupportedFileFormat(dwio::common::FileFormat format);
 
 /// Maps a Velox file format to the string used in Iceberg manifest commit

--- a/velox/connectors/hive/iceberg/tests/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/tests/CMakeLists.txt
@@ -99,6 +99,46 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
     GTest::gtest_main
   )
 
+  add_executable(velox_hive_iceberg_merge_processor_test IcebergMergeProcessorTest.cpp)
+  add_test(velox_hive_iceberg_merge_processor_test velox_hive_iceberg_merge_processor_test)
+
+  target_link_libraries(
+    velox_hive_iceberg_merge_processor_test
+    velox_hive_connector
+    velox_hive_iceberg_splitreader
+    velox_vector_test_lib
+    GTest::gtest
+    GTest::gtest_main
+  )
+
+  add_executable(
+    velox_hive_iceberg_merge_sink_test
+    IcebergMergeSinkTest.cpp
+    IcebergTestBase.cpp
+    Main.cpp
+  )
+  velox_add_test_headers(velox_hive_iceberg_merge_sink_test IcebergTestBase.h)
+  add_test(velox_hive_iceberg_merge_sink_test velox_hive_iceberg_merge_sink_test)
+
+  target_link_libraries(
+    velox_hive_iceberg_merge_sink_test
+    velox_exec_test_lib
+    velox_hive_connector
+    velox_hive_iceberg_splitreader
+    velox_vector_test_lib
+    velox_vector_fuzzer
+    GTest::gtest
+    GTest::gtest_main
+  )
+
+  if(VELOX_ENABLE_PARQUET)
+    target_link_libraries(
+      velox_hive_iceberg_merge_sink_test
+      velox_dwio_parquet_reader
+      velox_dwio_parquet_writer
+    )
+  endif()
+
   if(VELOX_ENABLE_PARQUET)
     target_link_libraries(velox_hive_iceberg_test velox_dwio_parquet_reader)
 

--- a/velox/connectors/hive/iceberg/tests/DeletionVectorWriterTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/DeletionVectorWriterTest.cpp
@@ -24,8 +24,10 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/FileSystems.h"
 #include "velox/common/memory/Memory.h"
+#include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/common/testutil/TempFilePath.h"
 #include "velox/connectors/hive/iceberg/DeletionVectorReader.h"
+#include "velox/dwio/common/FileSink.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::connector::hive::iceberg;
@@ -55,6 +57,11 @@ class DeletionVectorWriterTest : public ::testing::Test {
 
   void SetUp() override {
     filesystems::registerLocalFileSystem();
+    // writePuffinFile now writes through dwio::common::FileSink::create, which
+    // dispatches by URI scheme to a registered factory. Register the
+    // local-filesystem sink so plain temp-file paths land through the same
+    // dispatch the production binary uses.
+    dwio::common::LocalFileSink::registerFactory();
     pool_ = memory::memoryManager()->addLeafPool("DeletionVectorWriterTest");
   }
 
@@ -252,9 +259,17 @@ TEST_F(DeletionVectorWriterTest, puffinFileRoundTrip) {
   writer.addDeletedPositions({3, 7, 42, 100});
   auto blobData = writer.serialize();
 
-  auto tempFile = TempFilePath::create();
-  auto [blobOffset, blobLength] = writePuffinFile(
-      tempFile->getPath(), blobData, "/data/test-data-file.parquet");
+  auto tempDir = TempDirectoryPath::create();
+  const std::string puffinPath =
+      std::string(tempDir->getPath()) + "/test-dv.puffin";
+  // FileSink::create dispatches by URI scheme; the registered LocalFileSink
+  // factory writes the puffin bytes to the local path.
+  auto sink = dwio::common::FileSink::create(
+      "file:" + puffinPath, {.pool = pool_.get()});
+  VELOX_CHECK_NOT_NULL(sink);
+  auto [blobOffset, blobLength] =
+      writePuffinFile(*sink, *pool_, blobData, "/data/test-data-file.parquet");
+  sink->close();
 
   EXPECT_EQ(blobOffset, 4); // After "PUF1" magic.
   EXPECT_EQ(blobLength, blobData.size());
@@ -268,12 +283,12 @@ TEST_F(DeletionVectorWriterTest, puffinFileRoundTrip) {
       std::to_string(blobLength);
 
   // Get full file size.
-  std::ifstream in(tempFile->getPath(), std::ios::binary | std::ios::ate);
+  std::ifstream in(puffinPath, std::ios::binary | std::ios::ate);
   auto fileSize = static_cast<uint64_t>(in.tellg());
 
   IcebergDeleteFile dvFile(
       FileContent::kDeletionVector,
-      tempFile->getPath(),
+      puffinPath,
       dwio::common::FileFormat::DWRF,
       4,
       fileSize,

--- a/velox/connectors/hive/iceberg/tests/IcebergDeletionVectorSinkTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergDeletionVectorSinkTest.cpp
@@ -1,0 +1,380 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/IcebergDeletionVectorSink.h"
+
+#include <filesystem>
+
+#include <folly/json.h>
+#include <gtest/gtest.h>
+
+#include "velox/common/base/BitUtil.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/common/testutil/TempDirectoryPath.h"
+#include "velox/connectors/hive/HiveConfig.h"
+#include "velox/connectors/hive/iceberg/DeletionVectorReader.h"
+#include "velox/core/QueryCtx.h"
+#include "velox/dwio/common/FileSink.h"
+#include "velox/vector/tests/utils/VectorMaker.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::connector::hive::iceberg;
+using namespace facebook::velox::common::testutil;
+
+namespace {
+
+// Builds a minimal IcebergInsertTableHandle for use by
+// IcebergDeletionVectorSink. The sink only consults locationHandle() (for
+// the Puffin output directory) and writeKind(); inputColumns and partition
+// spec are not exercised by the deletion-vector path.
+IcebergInsertTableHandlePtr makeDeletionVectorHandle(
+    const std::string& outputDirectory) {
+  auto locationHandle = std::make_shared<connector::hive::LocationHandle>(
+      outputDirectory,
+      outputDirectory,
+      connector::hive::LocationHandle::TableType::kExisting);
+  return std::make_shared<const IcebergInsertTableHandle>(
+      /*inputColumns=*/std::vector<IcebergColumnHandlePtr>{},
+      locationHandle,
+      /*tableStorageFormat=*/dwio::common::FileFormat::PARQUET,
+      /*partitionSpec=*/nullptr,
+      /*compressionKind=*/std::nullopt,
+      /*serdeParameters=*/std::unordered_map<std::string, std::string>{},
+      IcebergInsertTableHandle::WriteKind::kDeletionVector);
+}
+
+// Allocates a bit-packed buffer big enough to hold 'numBits' bits, zeroed.
+BufferPtr allocateBitmap(uint64_t numBits, memory::MemoryPool* pool) {
+  return AlignedBuffer::allocate<uint8_t>(bits::nbytes(numBits), pool, 0);
+}
+
+// Returns the indices of all set bits in 'bitmap[0..numBits)'.
+std::vector<uint64_t> getSetBits(const BufferPtr& bitmap, uint64_t numBits) {
+  const auto* raw = bitmap->as<uint8_t>();
+  std::vector<uint64_t> result;
+  for (uint64_t i = 0; i < numBits; ++i) {
+    if (bits::isBitSet(raw, i)) {
+      result.push_back(i);
+    }
+  }
+  return result;
+}
+
+// Reads the puffin blob at 'puffinPath' between [offset, offset+length)
+// through DeletionVectorReader and returns the set positions in [0, maxPos].
+std::vector<uint64_t> readBackDeletedPositions(
+    const std::string& puffinPath,
+    uint64_t offset,
+    uint64_t length,
+    uint64_t recordCount,
+    uint64_t maxPos,
+    memory::MemoryPool* pool) {
+  std::unordered_map<int32_t, std::string> lowerBounds;
+  std::unordered_map<int32_t, std::string> upperBounds;
+  lowerBounds[DeletionVectorReader::kDvOffsetFieldId] = std::to_string(offset);
+  upperBounds[DeletionVectorReader::kDvLengthFieldId] = std::to_string(length);
+
+  IcebergDeleteFile dvFile(
+      FileContent::kDeletionVector,
+      puffinPath,
+      dwio::common::FileFormat::DWRF,
+      recordCount,
+      /*fileSizeInBytes=*/std::filesystem::file_size(puffinPath),
+      /*equalityFieldIds=*/{},
+      lowerBounds,
+      upperBounds);
+
+  DeletionVectorReader reader(dvFile, 0, pool);
+  const uint64_t batchSize = 1024;
+  const uint64_t totalRows = maxPos + batchSize;
+
+  std::vector<uint64_t> deleted;
+  for (uint64_t base = 0; base < totalRows; base += batchSize) {
+    auto bitmap = allocateBitmap(batchSize, pool);
+    reader.readDeletePositions(base, batchSize, bitmap);
+    for (auto offsetInBatch : getSetBits(bitmap, batchSize)) {
+      deleted.push_back(base + offsetInBatch);
+    }
+  }
+  return deleted;
+}
+
+} // namespace
+
+class IcebergDeletionVectorSinkTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    memory::MemoryManager::initialize(memory::MemoryManager::Options{});
+  }
+
+  void SetUp() override {
+    filesystems::registerLocalFileSystem();
+    // The deletion-vector sink now opens puffin output through
+    // dwio::common::FileSink::create, which dispatches by URI scheme to a
+    // registered factory. Register the local-filesystem factory so test
+    // paths under TempDirectoryPath (plain '/tmp/...' paths) land through
+    // the same dispatch the production binary uses.
+    dwio::common::LocalFileSink::registerFactory();
+
+    pool_ =
+        memory::memoryManager()->addLeafPool("IcebergDeletionVectorSinkTest");
+    connectorPool_ = memory::memoryManager()->addRootPool(
+        "IcebergDeletionVectorSinkTestConnector");
+    vectorMaker_ = std::make_unique<test::VectorMaker>(pool_.get());
+
+    sessionProperties_ = std::make_shared<config::ConfigBase>(
+        std::unordered_map<std::string, std::string>(), true);
+    hiveConfig_ = std::make_shared<connector::hive::HiveConfig>(
+        std::make_shared<config::ConfigBase>(
+            std::unordered_map<std::string, std::string>()));
+
+    queryCtx_ = core::QueryCtx::create(nullptr, core::QueryConfig({}));
+    connectorQueryCtx_ = std::make_unique<connector::ConnectorQueryCtx>(
+        pool_.get(),
+        connectorPool_.get(),
+        sessionProperties_.get(),
+        /*spillConfig=*/nullptr,
+        common::PrefixSortConfig(),
+        /*expressionEvaluator=*/nullptr,
+        /*cache=*/nullptr,
+        /*queryId=*/"query.IcebergDeletionVectorSinkTest",
+        /*taskId=*/"task.IcebergDeletionVectorSinkTest",
+        /*planNodeId=*/"planNodeId.IcebergDeletionVectorSinkTest",
+        /*driverId=*/0,
+        /*sessionTimezone=*/"",
+        /*adjustTimestampToTimezone=*/false);
+  }
+
+  RowVectorPtr makePositionDeleteRows(
+      const std::vector<std::string>& filePaths,
+      const std::vector<int64_t>& positions) {
+    VELOX_CHECK_EQ(filePaths.size(), positions.size());
+    auto filePathVector = vectorMaker_->flatVector<StringView>(
+        static_cast<vector_size_t>(filePaths.size()),
+        [&](vector_size_t i) { return StringView(filePaths[i]); });
+    auto positionVector = vectorMaker_->flatVector<int64_t>(positions);
+    return vectorMaker_->rowVector(
+        {"file_path", "pos"}, {filePathVector, positionVector});
+  }
+
+  std::shared_ptr<memory::MemoryPool> pool_;
+  std::shared_ptr<memory::MemoryPool> connectorPool_;
+  std::shared_ptr<config::ConfigBase> sessionProperties_;
+  std::shared_ptr<connector::hive::HiveConfig> hiveConfig_;
+  std::shared_ptr<core::QueryCtx> queryCtx_;
+  std::unique_ptr<connector::ConnectorQueryCtx> connectorQueryCtx_;
+  std::unique_ptr<test::VectorMaker> vectorMaker_;
+};
+
+TEST_F(IcebergDeletionVectorSinkTest, singleFileSinglePosition) {
+  auto tempDir = TempDirectoryPath::create();
+  auto handle = makeDeletionVectorHandle(tempDir->getPath());
+
+  IcebergDeletionVectorSink sink(
+      ROW({"file_path", "pos"}, {VARCHAR(), BIGINT()}),
+      handle,
+      connectorQueryCtx_.get(),
+      connector::CommitStrategy::kNoCommit,
+      hiveConfig_);
+
+  // Place the synthetic data file under tempDir so the puffin writer can
+  // create its output next to it.
+  const std::string dataFile = tempDir->getPath() + "/data-file.parquet";
+  sink.appendData(makePositionDeleteRows({dataFile}, {42}));
+  EXPECT_TRUE(sink.finish());
+  auto commitMessages = sink.close();
+
+  ASSERT_EQ(commitMessages.size(), 1);
+  auto parsed = folly::parseJson(commitMessages[0]);
+  EXPECT_EQ(parsed["content"].asString(), "POSITION_DELETES");
+  EXPECT_EQ(parsed["fileFormat"].asString(), "PUFFIN");
+  EXPECT_EQ(parsed["referencedDataFile"].asString(), dataFile);
+  EXPECT_EQ(parsed["metrics"]["recordCount"].asInt(), 1);
+  ASSERT_TRUE(parsed.find("path") != parsed.items().end());
+  ASSERT_TRUE(parsed.find("contentOffset") != parsed.items().end());
+  ASSERT_TRUE(parsed.find("contentSizeInBytes") != parsed.items().end());
+
+  // Verify the emitted Puffin file is readable by DeletionVectorReader and
+  // round-trips the position we wrote.
+  const auto puffinPath = parsed["path"].asString();
+  const auto offset = static_cast<uint64_t>(parsed["contentOffset"].asInt());
+  const auto length =
+      static_cast<uint64_t>(parsed["contentSizeInBytes"].asInt());
+  const auto recordCount =
+      static_cast<uint64_t>(parsed["metrics"]["recordCount"].asInt());
+  auto deleted = readBackDeletedPositions(
+      puffinPath, offset, length, recordCount, /*maxPos=*/42, pool_.get());
+  EXPECT_EQ(deleted, std::vector<uint64_t>{42});
+}
+
+TEST_F(IcebergDeletionVectorSinkTest, multipleFilesDemultiplexed) {
+  auto tempDir = TempDirectoryPath::create();
+  auto handle = makeDeletionVectorHandle(tempDir->getPath());
+
+  IcebergDeletionVectorSink sink(
+      ROW({"file_path", "pos"}, {VARCHAR(), BIGINT()}),
+      handle,
+      connectorQueryCtx_.get(),
+      connector::CommitStrategy::kNoCommit,
+      hiveConfig_);
+
+  const std::string fileA = tempDir->getPath() + "/A.parquet";
+  const std::string fileB = tempDir->getPath() + "/B.parquet";
+  sink.appendData(makePositionDeleteRows(
+      {fileA, fileB, fileA, fileB, fileA}, {1, 2, 3, 5, 7}));
+  EXPECT_TRUE(sink.finish());
+  auto commitMessages = sink.close();
+
+  // Two referenced data files -> two Puffin files -> two commit messages.
+  ASSERT_EQ(commitMessages.size(), 2);
+
+  // Insertion order is preserved: fileA appears first in the input page so
+  // its commit message comes first.
+  auto first = folly::parseJson(commitMessages[0]);
+  auto second = folly::parseJson(commitMessages[1]);
+  EXPECT_EQ(first["referencedDataFile"].asString(), fileA);
+  EXPECT_EQ(second["referencedDataFile"].asString(), fileB);
+  EXPECT_EQ(first["metrics"]["recordCount"].asInt(), 3);
+  EXPECT_EQ(second["metrics"]["recordCount"].asInt(), 2);
+
+  // Round-trip each Puffin to confirm the right positions landed under the
+  // right file.
+  auto fileAPositions = readBackDeletedPositions(
+      first["path"].asString(),
+      static_cast<uint64_t>(first["contentOffset"].asInt()),
+      static_cast<uint64_t>(first["contentSizeInBytes"].asInt()),
+      static_cast<uint64_t>(first["metrics"]["recordCount"].asInt()),
+      /*maxPos=*/7,
+      pool_.get());
+  auto fileBPositions = readBackDeletedPositions(
+      second["path"].asString(),
+      static_cast<uint64_t>(second["contentOffset"].asInt()),
+      static_cast<uint64_t>(second["contentSizeInBytes"].asInt()),
+      static_cast<uint64_t>(second["metrics"]["recordCount"].asInt()),
+      /*maxPos=*/7,
+      pool_.get());
+
+  EXPECT_EQ(fileAPositions, (std::vector<uint64_t>{1, 3, 7}));
+  EXPECT_EQ(fileBPositions, (std::vector<uint64_t>{2, 5}));
+}
+
+TEST_F(IcebergDeletionVectorSinkTest, emptyInputProducesNoCommitMessages) {
+  auto tempDir = TempDirectoryPath::create();
+  auto handle = makeDeletionVectorHandle(tempDir->getPath());
+
+  IcebergDeletionVectorSink sink(
+      ROW({"file_path", "pos"}, {VARCHAR(), BIGINT()}),
+      handle,
+      connectorQueryCtx_.get(),
+      connector::CommitStrategy::kNoCommit,
+      hiveConfig_);
+
+  // No appendData call -> no perFile state -> finish() must still be safe.
+  EXPECT_TRUE(sink.finish());
+  EXPECT_TRUE(sink.close().empty());
+  auto stats = sink.stats();
+  EXPECT_EQ(stats.numWrittenFiles, 0u);
+  EXPECT_EQ(stats.numWrittenBytes, 0u);
+}
+
+TEST_F(IcebergDeletionVectorSinkTest, abortBeforeFinishDropsState) {
+  auto tempDir = TempDirectoryPath::create();
+  auto handle = makeDeletionVectorHandle(tempDir->getPath());
+
+  IcebergDeletionVectorSink sink(
+      ROW({"file_path", "pos"}, {VARCHAR(), BIGINT()}),
+      handle,
+      connectorQueryCtx_.get(),
+      connector::CommitStrategy::kNoCommit,
+      hiveConfig_);
+
+  sink.appendData(makePositionDeleteRows({"/path/to/A.parquet"}, {100}));
+  sink.abort();
+
+  // After abort, no Puffin files should be flushed and close() returns an
+  // empty commit-message list. We do not check the temp directory for
+  // file presence because the sink never reached its writePuffinFile call.
+  EXPECT_TRUE(sink.close().empty());
+}
+
+TEST_F(IcebergDeletionVectorSinkTest, rejectsWrongChannelCount) {
+  auto tempDir = TempDirectoryPath::create();
+  auto handle = makeDeletionVectorHandle(tempDir->getPath());
+
+  IcebergDeletionVectorSink sink(
+      ROW({"file_path", "pos"}, {VARCHAR(), BIGINT()}),
+      handle,
+      connectorQueryCtx_.get(),
+      connector::CommitStrategy::kNoCommit,
+      hiveConfig_);
+
+  // Construct a 1-column page; the sink expects exactly 2 channels.
+  auto badPage = vectorMaker_->rowVector(
+      {"pos"}, {vectorMaker_->flatVector<int64_t>({1, 2, 3})});
+  VELOX_ASSERT_USER_THROW(
+      sink.appendData(badPage),
+      "IcebergDeletionVectorSink expects 2-column input pages");
+}
+
+// Regression guard for the warm-storage (ws://) write path. The puffin
+// writer used to hand-roll std::ofstream which silently failed on any
+// non-local URI scheme. Today the writer routes through
+// dwio::common::FileSink::create, which dispatches by URI scheme. We
+// exercise that dispatch by passing a 'file:' prefixed path — the
+// LocalFileSink factory strips the prefix and routes the bytes through
+// the same Velox FileSink machinery the production binary uses. A future
+// refactor that re-hard-codes std::ofstream will break this test because
+// 'file:' is not a valid POSIX filesystem path.
+TEST_F(IcebergDeletionVectorSinkTest, writesThroughRegisteredFileSinkFactory) {
+  auto tempDir = TempDirectoryPath::create();
+  const std::string schemePrefix = "file:";
+  auto handle = makeDeletionVectorHandle(schemePrefix + tempDir->getPath());
+
+  IcebergDeletionVectorSink sink(
+      ROW({"file_path", "pos"}, {VARCHAR(), BIGINT()}),
+      handle,
+      connectorQueryCtx_.get(),
+      connector::CommitStrategy::kNoCommit,
+      hiveConfig_);
+
+  const std::string dataFile =
+      schemePrefix + tempDir->getPath() + "/data-file.parquet";
+  sink.appendData(
+      makePositionDeleteRows({dataFile, dataFile, dataFile}, {7, 13, 21}));
+  EXPECT_TRUE(sink.finish());
+  auto commitMessages = sink.close();
+
+  ASSERT_EQ(commitMessages.size(), 1);
+  auto parsed = folly::parseJson(commitMessages[0]);
+  // The puffin output path keeps the 'file:' scheme prefix because the
+  // sink computes it from the data file path. Strip the prefix when we
+  // read back through DeletionVectorReader, which expects a local path.
+  const auto puffinPath = parsed["path"].asString();
+  EXPECT_TRUE(puffinPath.starts_with(schemePrefix))
+      << "puffin path lost its scheme: " << puffinPath;
+  const auto localPuffinPath = puffinPath.substr(schemePrefix.size());
+
+  const auto offset = static_cast<uint64_t>(parsed["contentOffset"].asInt());
+  const auto length =
+      static_cast<uint64_t>(parsed["contentSizeInBytes"].asInt());
+  const auto recordCount =
+      static_cast<uint64_t>(parsed["metrics"]["recordCount"].asInt());
+  auto deleted = readBackDeletedPositions(
+      localPuffinPath, offset, length, recordCount, /*maxPos=*/21, pool_.get());
+  EXPECT_EQ(deleted, (std::vector<uint64_t>{7, 13, 21}));
+}

--- a/velox/connectors/hive/iceberg/tests/IcebergMergeProcessorTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergMergeProcessorTest.cpp
@@ -1,0 +1,498 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/IcebergMergeProcessor.h"
+
+#include <gtest/gtest.h>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/type/Type.h"
+#include "velox/vector/tests/utils/VectorMaker.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+namespace {
+
+using IMP = IcebergMergeProcessor;
+
+// Channel indices used by every test. The transform only reads
+// `targetRowIdChannel` and `mergeRowChannel`; the other channels of the
+// input RowVector exist purely to mirror the OSS contract documented by
+// `MergeRowChangeProcessor.transformPage` and are populated with valid but
+// unused data.
+constexpr column_index_t kTargetRowIdChannel = 1;
+constexpr column_index_t kMergeRowChannel = 2;
+
+// Shapes used across the test fixture. Two target columns: BIGINT (id) and
+// VARCHAR (name). The row id is a small ROW(VARCHAR file_path, BIGINT pos)
+// — enough to verify verbatim row-id copy semantics without dragging the
+// full Iceberg row id schema (file_path, pos, spec_id, partition_data) into
+// the test.
+const RowTypePtr kRowIdType = ROW({"file_path", "pos"}, {VARCHAR(), BIGINT()});
+const RowTypePtr kMergeRowType =
+    ROW({"id", "name", "operation", "case_number"},
+        {BIGINT(), VARCHAR(), TINYINT(), INTEGER()});
+
+class IcebergMergeProcessorTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    memory::MemoryManager::initialize(memory::MemoryManager::Options{});
+  }
+
+  void SetUp() override {
+    pool_ = memory::memoryManager()->addLeafPool("IcebergMergeProcessorTest");
+    vectorMaker_ = std::make_unique<velox::test::VectorMaker>(pool_.get());
+  }
+
+  // Builds the 5-channel input RowVector specified by
+  // MergeRowChangeProcessor.transformPage:
+  //   0 unique_id BIGINT
+  //   1 target_row_id ROW(file_path, pos)
+  //   2 merge_row ROW(id, name, operation, case_number)
+  //   3 case_number INTEGER
+  //   4 is_distinct BOOLEAN
+  // Channels 0/3/4 are populated with deterministic-but-unused values so
+  // any accidental dereference would be obvious in a debugger.
+  RowVectorPtr makeInput(
+      const std::vector<std::optional<std::string>>& filePaths,
+      const std::vector<std::optional<int64_t>>& positions,
+      const std::vector<std::optional<int64_t>>& mergeIds,
+      const std::vector<std::optional<std::string>>& mergeNames,
+      const std::vector<int8_t>& operations,
+      const std::vector<int32_t>& caseNumbers) {
+    const auto numRows = static_cast<vector_size_t>(operations.size());
+    auto uniqueId = vectorMaker_->flatVector<int64_t>(
+        numRows, [](vector_size_t i) { return 1'000 + i; });
+
+    auto filePathField =
+        vectorMaker_->flatVectorNullable<StringView>(toStringViews(filePaths));
+    auto posField = vectorMaker_->flatVectorNullable<int64_t>(positions);
+    auto rowId = std::make_shared<RowVector>(
+        pool_.get(),
+        kRowIdType,
+        /*nulls=*/nullptr,
+        numRows,
+        std::vector<VectorPtr>{filePathField, posField});
+
+    auto idField = vectorMaker_->flatVectorNullable<int64_t>(mergeIds);
+    auto nameField =
+        vectorMaker_->flatVectorNullable<StringView>(toStringViews(mergeNames));
+    auto operationField = vectorMaker_->flatVector<int8_t>(operations);
+    auto caseNumberField = vectorMaker_->flatVector<int32_t>(caseNumbers);
+    auto mergeRow = std::make_shared<RowVector>(
+        pool_.get(),
+        kMergeRowType,
+        /*nulls=*/nullptr,
+        numRows,
+        std::vector<VectorPtr>{
+            idField, nameField, operationField, caseNumberField});
+
+    auto caseNumberCh = vectorMaker_->flatVector<int32_t>(caseNumbers);
+    auto isDistinct = vectorMaker_->flatVector<bool>(
+        numRows, [](vector_size_t /*i*/) { return true; });
+
+    return std::make_shared<RowVector>(
+        pool_.get(),
+        ROW({"unique_id",
+             "target_row_id",
+             "merge_row",
+             "case_number",
+             "is_distinct"},
+            {BIGINT(), kRowIdType, kMergeRowType, INTEGER(), BOOLEAN()}),
+        /*nulls=*/nullptr,
+        numRows,
+        std::vector<VectorPtr>{
+            uniqueId, rowId, mergeRow, caseNumberCh, isDistinct});
+  }
+
+  IMP makeProcessor() const {
+    return IMP(
+        /*targetColumnTypes=*/{BIGINT(), VARCHAR()},
+        /*outputColumnNames=*/
+        {"id",
+         "name",
+         "operation",
+         "$target_table_row_id",
+         "insert_from_update"},
+        /*rowIdType=*/kRowIdType,
+        /*targetRowIdChannel=*/kTargetRowIdChannel,
+        /*mergeRowChannel=*/kMergeRowChannel);
+  }
+
+  static std::vector<std::optional<StringView>> toStringViews(
+      const std::vector<std::optional<std::string>>& values) {
+    std::vector<std::optional<StringView>> result;
+    result.reserve(values.size());
+    for (const auto& v : values) {
+      if (v.has_value()) {
+        result.emplace_back(StringView(*v));
+      } else {
+        result.emplace_back(std::nullopt);
+      }
+    }
+    return result;
+  }
+
+  std::shared_ptr<memory::MemoryPool> pool_;
+  std::unique_ptr<velox::test::VectorMaker> vectorMaker_;
+};
+
+TEST_F(IcebergMergeProcessorTest, emptyInputProducesEmptyOutput) {
+  auto processor = makeProcessor();
+  auto input = makeInput({}, {}, {}, {}, {}, {});
+  auto output = processor.transform(input, pool_.get());
+
+  EXPECT_EQ(output->size(), 0);
+  EXPECT_EQ(*output->type(), *processor.outputType());
+  EXPECT_EQ(output->childrenSize(), 5);
+}
+
+TEST_F(IcebergMergeProcessorTest, allInsertOperationsCopyTargetColumns) {
+  auto processor = makeProcessor();
+  // 3 INSERT rows. row_id is irrelevant for INSERT — set to null to make
+  // it obvious if the transform mistakenly copies it onto INSERT output.
+  auto input = makeInput(
+      /*filePaths=*/{std::nullopt, std::nullopt, std::nullopt},
+      /*positions=*/{std::nullopt, std::nullopt, std::nullopt},
+      /*mergeIds=*/{10, 20, 30},
+      /*mergeNames=*/
+      {{std::string("a")}, {std::string("b")}, {std::string("c")}},
+      /*operations=*/
+      {IMP::kInsertOperationNumber,
+       IMP::kInsertOperationNumber,
+       IMP::kInsertOperationNumber},
+      /*caseNumbers=*/{0, 0, 0});
+
+  auto output = processor.transform(input, pool_.get());
+  ASSERT_EQ(output->size(), 3);
+
+  auto* ids = output->childAt(0)->asFlatVector<int64_t>();
+  auto* names = output->childAt(1)->asFlatVector<StringView>();
+  auto* operations = output->childAt(2)->asFlatVector<int8_t>();
+  const auto& rowIds = output->childAt(3);
+  auto* insertFromUpdate = output->childAt(4)->asFlatVector<int8_t>();
+
+  for (vector_size_t i = 0; i < 3; ++i) {
+    EXPECT_FALSE(ids->isNullAt(i));
+    EXPECT_EQ(ids->valueAt(i), 10 * (i + 1));
+    EXPECT_FALSE(names->isNullAt(i));
+    EXPECT_EQ(operations->valueAt(i), IMP::kInsertOperationNumber);
+    EXPECT_TRUE(rowIds->isNullAt(i));
+    EXPECT_EQ(insertFromUpdate->valueAt(i), 0);
+  }
+  EXPECT_EQ(names->valueAt(0).str(), "a");
+  EXPECT_EQ(names->valueAt(1).str(), "b");
+  EXPECT_EQ(names->valueAt(2).str(), "c");
+}
+
+TEST_F(IcebergMergeProcessorTest, allDeleteOperationsNullTargetCopyRowId) {
+  auto processor = makeProcessor();
+  // 3 DELETE rows. mergeId / mergeName are irrelevant for DELETE — set
+  // to non-null so we can verify the transform does NOT copy them through.
+  auto input = makeInput(
+      /*filePaths=*/
+      {{std::string("file-1.parquet")},
+       {std::string("file-2.parquet")},
+       {std::string("file-3.parquet")}},
+      /*positions=*/{100, 200, 300},
+      /*mergeIds=*/{999, 999, 999},
+      /*mergeNames=*/
+      {{std::string("ignore")},
+       {std::string("ignore")},
+       {std::string("ignore")}},
+      /*operations=*/
+      {IMP::kDeleteOperationNumber,
+       IMP::kDeleteOperationNumber,
+       IMP::kDeleteOperationNumber},
+      /*caseNumbers=*/{0, 0, 0});
+
+  auto output = processor.transform(input, pool_.get());
+  ASSERT_EQ(output->size(), 3);
+
+  auto* ids = output->childAt(0)->asFlatVector<int64_t>();
+  auto* names = output->childAt(1)->asFlatVector<StringView>();
+  auto* operations = output->childAt(2)->asFlatVector<int8_t>();
+  const auto* rowIds = output->childAt(3)->as<RowVector>();
+  auto* insertFromUpdate = output->childAt(4)->asFlatVector<int8_t>();
+  ASSERT_NE(rowIds, nullptr);
+
+  auto* outFilePath = rowIds->childAt(0)->asFlatVector<StringView>();
+  auto* outPos = rowIds->childAt(1)->asFlatVector<int64_t>();
+
+  for (vector_size_t i = 0; i < 3; ++i) {
+    EXPECT_TRUE(ids->isNullAt(i)) << "DELETE must null out the id column.";
+    EXPECT_TRUE(names->isNullAt(i)) << "DELETE must null out the name column.";
+    EXPECT_EQ(operations->valueAt(i), IMP::kDeleteOperationNumber);
+    EXPECT_FALSE(rowIds->isNullAt(i));
+    EXPECT_EQ(outPos->valueAt(i), 100 * (i + 1));
+    EXPECT_EQ(insertFromUpdate->valueAt(i), 0)
+        << "Plain DELETE is not derived from UPDATE.";
+  }
+  EXPECT_EQ(outFilePath->valueAt(0).str(), "file-1.parquet");
+  EXPECT_EQ(outFilePath->valueAt(1).str(), "file-2.parquet");
+  EXPECT_EQ(outFilePath->valueAt(2).str(), "file-3.parquet");
+}
+
+TEST_F(IcebergMergeProcessorTest, updateOperationsFanOutDeleteThenInsert) {
+  auto processor = makeProcessor();
+  // 2 UPDATE rows → 4 output rows in (DELETE, INSERT) order per input row.
+  auto input = makeInput(
+      /*filePaths=*/
+      {{std::string("u-1.parquet")}, {std::string("u-2.parquet")}},
+      /*positions=*/{50, 60},
+      /*mergeIds=*/{42, 84},
+      /*mergeNames=*/
+      {{std::string("new-a")}, {std::string("new-b")}},
+      /*operations=*/
+      {IMP::kUpdateOperationNumber, IMP::kUpdateOperationNumber},
+      /*caseNumbers=*/{0, 0});
+
+  auto output = processor.transform(input, pool_.get());
+  ASSERT_EQ(output->size(), 4);
+
+  auto* ids = output->childAt(0)->asFlatVector<int64_t>();
+  auto* names = output->childAt(1)->asFlatVector<StringView>();
+  auto* operations = output->childAt(2)->asFlatVector<int8_t>();
+  const auto* rowIds = output->childAt(3)->as<RowVector>();
+  auto* insertFromUpdate = output->childAt(4)->asFlatVector<int8_t>();
+  ASSERT_NE(rowIds, nullptr);
+
+  auto* outFilePath = rowIds->childAt(0)->asFlatVector<StringView>();
+  auto* outPos = rowIds->childAt(1)->asFlatVector<int64_t>();
+
+  // Output row 0 — DELETE half of UPDATE #0.
+  EXPECT_TRUE(ids->isNullAt(0));
+  EXPECT_TRUE(names->isNullAt(0));
+  EXPECT_EQ(operations->valueAt(0), IMP::kDeleteOperationNumber);
+  EXPECT_FALSE(rowIds->isNullAt(0));
+  EXPECT_EQ(outFilePath->valueAt(0).str(), "u-1.parquet");
+  EXPECT_EQ(outPos->valueAt(0), 50);
+  EXPECT_EQ(insertFromUpdate->valueAt(0), 0);
+
+  // Output row 1 — INSERT half of UPDATE #0.
+  EXPECT_FALSE(ids->isNullAt(1));
+  EXPECT_EQ(ids->valueAt(1), 42);
+  EXPECT_FALSE(names->isNullAt(1));
+  EXPECT_EQ(names->valueAt(1).str(), "new-a");
+  EXPECT_EQ(operations->valueAt(1), IMP::kInsertOperationNumber);
+  EXPECT_TRUE(rowIds->isNullAt(1));
+  EXPECT_EQ(insertFromUpdate->valueAt(1), 1)
+      << "INSERT half of UPDATE must mark insert_from_update=1.";
+
+  // Output row 2 — DELETE half of UPDATE #1.
+  EXPECT_TRUE(ids->isNullAt(2));
+  EXPECT_EQ(operations->valueAt(2), IMP::kDeleteOperationNumber);
+  EXPECT_EQ(outFilePath->valueAt(2).str(), "u-2.parquet");
+  EXPECT_EQ(outPos->valueAt(2), 60);
+  EXPECT_EQ(insertFromUpdate->valueAt(2), 0);
+
+  // Output row 3 — INSERT half of UPDATE #1.
+  EXPECT_EQ(ids->valueAt(3), 84);
+  EXPECT_EQ(names->valueAt(3).str(), "new-b");
+  EXPECT_EQ(operations->valueAt(3), IMP::kInsertOperationNumber);
+  EXPECT_TRUE(rowIds->isNullAt(3));
+  EXPECT_EQ(insertFromUpdate->valueAt(3), 1);
+}
+
+TEST_F(IcebergMergeProcessorTest, defaultCaseRowsAreDroppedFromOutput) {
+  auto processor = makeProcessor();
+  // 2 DEFAULT rows surrounding 1 INSERT — output should contain only the
+  // INSERT row. This mirrors the OSS Java behavior where MERGE WHEN cases
+  // that match no clause emit DEFAULT_CASE rows that the processor must
+  // drop.
+  auto input = makeInput(
+      /*filePaths=*/{std::nullopt, std::nullopt, std::nullopt},
+      /*positions=*/{std::nullopt, std::nullopt, std::nullopt},
+      /*mergeIds=*/{77, 88, 99},
+      /*mergeNames=*/
+      {{std::string("x")}, {std::string("y")}, {std::string("z")}},
+      /*operations=*/
+      {IMP::kDefaultCaseOperationNumber,
+       IMP::kInsertOperationNumber,
+       IMP::kDefaultCaseOperationNumber},
+      /*caseNumbers=*/{0, 0, 0});
+
+  auto output = processor.transform(input, pool_.get());
+  ASSERT_EQ(output->size(), 1);
+
+  auto* ids = output->childAt(0)->asFlatVector<int64_t>();
+  auto* names = output->childAt(1)->asFlatVector<StringView>();
+  auto* operations = output->childAt(2)->asFlatVector<int8_t>();
+  EXPECT_EQ(ids->valueAt(0), 88);
+  EXPECT_EQ(names->valueAt(0).str(), "y");
+  EXPECT_EQ(operations->valueAt(0), IMP::kInsertOperationNumber);
+}
+
+TEST_F(IcebergMergeProcessorTest, mixedOperationsProduceExpectedRowCount) {
+  auto processor = makeProcessor();
+  // 1 INSERT + 2 DELETE + 2 UPDATE + 1 DEFAULT = 1 + 2 + 4 + 0 = 7 output
+  // rows. Verifies the precomputed total counts agree with the second-pass
+  // emission so the internal VELOX_CHECK_EQ guard holds.
+  auto input = makeInput(
+      /*filePaths=*/
+      {std::nullopt,
+       {std::string("d-1.parquet")},
+       {std::string("d-2.parquet")},
+       {std::string("u-1.parquet")},
+       {std::string("u-2.parquet")},
+       std::nullopt},
+      /*positions=*/
+      {std::nullopt, 1, 2, 3, 4, std::nullopt},
+      /*mergeIds=*/{1, 999, 999, 30, 40, 555},
+      /*mergeNames=*/
+      {{std::string("ins")},
+       {std::string("ignore")},
+       {std::string("ignore")},
+       {std::string("upd-a")},
+       {std::string("upd-b")},
+       {std::string("ignore")}},
+      /*operations=*/
+      {IMP::kInsertOperationNumber,
+       IMP::kDeleteOperationNumber,
+       IMP::kDeleteOperationNumber,
+       IMP::kUpdateOperationNumber,
+       IMP::kUpdateOperationNumber,
+       IMP::kDefaultCaseOperationNumber},
+      /*caseNumbers=*/{0, 0, 0, 0, 0, 0});
+
+  auto output = processor.transform(input, pool_.get());
+  EXPECT_EQ(output->size(), 7);
+
+  auto* operations = output->childAt(2)->asFlatVector<int8_t>();
+  auto* insertFromUpdate = output->childAt(4)->asFlatVector<int8_t>();
+  // Order should be:
+  //   0: INSERT     (from input row 0)
+  //   1: DELETE     (from input row 1)
+  //   2: DELETE     (from input row 2)
+  //   3,4: DELETE,INSERT (from UPDATE input row 3)
+  //   5,6: DELETE,INSERT (from UPDATE input row 4)
+  EXPECT_EQ(operations->valueAt(0), IMP::kInsertOperationNumber);
+  EXPECT_EQ(operations->valueAt(1), IMP::kDeleteOperationNumber);
+  EXPECT_EQ(operations->valueAt(2), IMP::kDeleteOperationNumber);
+  EXPECT_EQ(operations->valueAt(3), IMP::kDeleteOperationNumber);
+  EXPECT_EQ(operations->valueAt(4), IMP::kInsertOperationNumber);
+  EXPECT_EQ(operations->valueAt(5), IMP::kDeleteOperationNumber);
+  EXPECT_EQ(operations->valueAt(6), IMP::kInsertOperationNumber);
+
+  // INSERT-derived-from-UPDATE markers: only positions 4 and 6 (the INSERT
+  // halves of the two UPDATE input rows) should be 1.
+  EXPECT_EQ(insertFromUpdate->valueAt(0), 0);
+  EXPECT_EQ(insertFromUpdate->valueAt(1), 0);
+  EXPECT_EQ(insertFromUpdate->valueAt(2), 0);
+  EXPECT_EQ(insertFromUpdate->valueAt(3), 0);
+  EXPECT_EQ(insertFromUpdate->valueAt(4), 1);
+  EXPECT_EQ(insertFromUpdate->valueAt(5), 0);
+  EXPECT_EQ(insertFromUpdate->valueAt(6), 1);
+}
+
+TEST_F(IcebergMergeProcessorTest, unknownOperationByteThrowsUserError) {
+  auto processor = makeProcessor();
+  auto input = makeInput(
+      /*filePaths=*/{std::nullopt},
+      /*positions=*/{std::nullopt},
+      /*mergeIds=*/{1},
+      /*mergeNames=*/{{std::string("oops")}},
+      /*operations=*/{static_cast<int8_t>(7)},
+      /*caseNumbers=*/{0});
+
+  VELOX_ASSERT_USER_THROW(
+      processor.transform(input, pool_.get()), "Unknown merge operation byte");
+}
+
+TEST_F(IcebergMergeProcessorTest, outputTypeReflectsConstructorArgs) {
+  auto processor = makeProcessor();
+  const auto& outType = processor.outputType();
+  ASSERT_EQ(outType->size(), 5);
+  EXPECT_TRUE(outType->childAt(0)->equivalent(*BIGINT()));
+  EXPECT_TRUE(outType->childAt(1)->equivalent(*VARCHAR()));
+  EXPECT_TRUE(outType->childAt(2)->equivalent(*TINYINT()));
+  EXPECT_TRUE(outType->childAt(3)->equivalent(*kRowIdType));
+  EXPECT_TRUE(outType->childAt(4)->equivalent(*TINYINT()));
+  // All output column names come from the outputColumnNames ctor arg,
+  // including the trailing operation / rowId / insert_from_update names.
+  EXPECT_EQ(outType->nameOf(0), "id");
+  EXPECT_EQ(outType->nameOf(1), "name");
+  EXPECT_EQ(outType->nameOf(2), "operation");
+  EXPECT_EQ(outType->nameOf(3), "$target_table_row_id");
+  EXPECT_EQ(outType->nameOf(4), "insert_from_update");
+}
+
+TEST_F(IcebergMergeProcessorTest, outputColumnNamesArityMismatchThrows) {
+  VELOX_ASSERT_THROW(
+      IMP(
+          /*targetColumnTypes=*/{BIGINT(), VARCHAR()},
+          /*outputColumnNames=*/{"id", "name"}, // intentionally wrong arity.
+          /*rowIdType=*/kRowIdType,
+          /*targetRowIdChannel=*/kTargetRowIdChannel,
+          /*mergeRowChannel=*/kMergeRowChannel),
+      "outputColumnNames size must be targetColumnTypes.size() + 3");
+}
+
+// Upstream operators (e.g. SWITCH/ROW_CONSTRUCTOR in a Project) can wrap
+// the merge_row column in a dictionary or constant encoding rather than
+// materializing it flat. The transform must decode the wrapper before per-
+// row indexing rather than failing the strict flat-RowVector check.
+TEST_F(IcebergMergeProcessorTest, dictionaryEncodedMergeRowIsFlattened) {
+  auto processor = makeProcessor();
+  // Build a 2-row input via the regular helper, then dictionary-wrap the
+  // merge_row column with an identity index buffer. Identity indices are
+  // sufficient to exercise the flatten path — the decoded result must
+  // equal the original flat data, and the transform's output must match
+  // what an un-wrapped input would have produced.
+  auto input = makeInput(
+      /*filePaths=*/{std::string("/d.parquet"), std::nullopt},
+      /*positions=*/{int64_t(5), std::nullopt},
+      /*mergeIds=*/{int64_t(1), int64_t(2)},
+      /*mergeNames=*/{std::string("a"), std::string("b")},
+      /*operations=*/
+      {IMP::kDeleteOperationNumber, IMP::kInsertOperationNumber},
+      /*caseNumbers=*/{1, 1});
+
+  const auto numRows = input->size();
+  auto indices = AlignedBuffer::allocate<vector_size_t>(numRows, pool_.get());
+  auto* rawIndices = indices->asMutable<vector_size_t>();
+  for (vector_size_t i = 0; i < numRows; ++i) {
+    rawIndices[i] = i;
+  }
+  auto wrappedMergeRow = BaseVector::wrapInDictionary(
+      /*nulls=*/nullptr, indices, numRows, input->childAt(kMergeRowChannel));
+
+  std::vector<VectorPtr> children;
+  children.reserve(input->childrenSize());
+  for (size_t c = 0; c < input->childrenSize(); ++c) {
+    children.push_back(
+        c == kMergeRowChannel ? wrappedMergeRow
+                              : input->childAt(static_cast<column_index_t>(c)));
+  }
+  auto wrappedInput = std::make_shared<RowVector>(
+      pool_.get(),
+      input->type(),
+      /*nulls=*/nullptr,
+      numRows,
+      std::move(children));
+
+  // Should not throw "merge_row column must be a flat RowVector".
+  auto output = processor.transform(wrappedInput, pool_.get());
+  // 1 DELETE + 1 INSERT = 2 output rows; operation column reflects each.
+  ASSERT_EQ(output->size(), 2);
+  const auto* operationOut = output->childAt(2)->asFlatVector<int8_t>();
+  ASSERT_NE(operationOut, nullptr);
+  EXPECT_EQ(operationOut->valueAt(0), IMP::kDeleteOperationNumber);
+  EXPECT_EQ(operationOut->valueAt(1), IMP::kInsertOperationNumber);
+}
+
+} // namespace
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/tests/IcebergMergeSinkTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergMergeSinkTest.cpp
@@ -1,0 +1,473 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/IcebergMergeSink.h"
+
+#include <folly/json.h>
+#include <gtest/gtest.h>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
+#include "velox/connectors/hive/iceberg/tests/IcebergTestBase.h"
+#include "velox/dwio/parquet/RegisterParquetWriter.h"
+#include "velox/vector/tests/utils/VectorMaker.h"
+
+namespace facebook::velox::connector::hive::iceberg::test {
+namespace {
+
+using IMS = IcebergMergeSink;
+
+// Two target table columns: id BIGINT and name VARCHAR.
+// The row_id ROW carries (file_path VARCHAR, pos BIGINT) — the inner two
+// fields the DV sub-sink actually consumes. Extra trailing Iceberg row id
+// fields (spec_id, partition_data) are intentionally omitted to keep the
+// test small; the merge sink tolerates them when present.
+const RowTypePtr kRowIdType = ROW({"file_path", "pos"}, {VARCHAR(), BIGINT()});
+
+// Composite-sink input schema as produced by Layer 1's
+// IcebergMergeProcessor: target cols, then operation, then row_id, then
+// insert_from_update. createDataSink's kMerge case relies on this exact
+// layout.
+const RowTypePtr kMergeInputType =
+    ROW({"id", "name", "operation", "row_id", "insert_from_update"},
+        {BIGINT(), VARCHAR(), TINYINT(), kRowIdType, TINYINT()});
+
+class IcebergMergeSinkTest : public IcebergTestBase {
+ protected:
+  void SetUp() override {
+    IcebergTestBase::SetUp();
+    // IcebergTestBase only registers the Parquet writer factory when its
+    // own translation unit was compiled with VELOX_ENABLE_PARQUET. The
+    // composite sink relies on the Parquet writer (via the inner
+    // IcebergDataSink), so register the factory unconditionally here.
+    // Idempotent: registerWriterFactory tolerates already-registered
+    // formats.
+    parquet::registerParquetWriterFactory();
+  }
+
+  IcebergInsertTableHandlePtr makeMergeHandle(const std::string& outputDir) {
+    // Construct the target column handles for (id, name). Field IDs match
+    // a fresh Iceberg V1 schema (1, 2).
+    std::vector<IcebergColumnHandlePtr> columnHandles;
+    columnHandles.emplace_back(
+        std::make_shared<const IcebergColumnHandle>(
+            "id",
+            FileColumnHandle::ColumnType::kRegular,
+            BIGINT(),
+            parquet::ParquetFieldId{1, {}}));
+    columnHandles.emplace_back(
+        std::make_shared<const IcebergColumnHandle>(
+            "name",
+            FileColumnHandle::ColumnType::kRegular,
+            VARCHAR(),
+            parquet::ParquetFieldId{2, {}}));
+
+    auto locationHandle = std::make_shared<LocationHandle>(
+        outputDir, outputDir, LocationHandle::TableType::kNew);
+
+    return std::make_shared<const IcebergInsertTableHandle>(
+        /*inputColumns=*/std::move(columnHandles),
+        locationHandle,
+        /*tableStorageFormat=*/dwio::common::FileFormat::PARQUET,
+        /*partitionSpec=*/nullptr,
+        /*compressionKind=*/common::CompressionKind::CompressionKind_ZSTD,
+        /*serdeParameters=*/std::unordered_map<std::string, std::string>{},
+        IcebergInsertTableHandle::WriteKind::kMerge);
+  }
+
+  std::unique_ptr<IcebergMergeSink> makeSink(const std::string& outputDir) {
+    auto handle = makeMergeHandle(outputDir);
+    return std::make_unique<IcebergMergeSink>(
+        kMergeInputType,
+        handle,
+        connectorQueryCtx_.get(),
+        CommitStrategy::kNoCommit,
+        getHiveConfig(),
+        getIcebergConfig(),
+        /*targetColumnChannels=*/std::vector<column_index_t>{0, 1},
+        /*operationChannel=*/2,
+        /*rowIdChannel=*/3);
+  }
+
+  // Builds a RowVector matching kMergeInputType from parallel vectors. Use
+  // std::nullopt for null cells. operation bytes are passed directly so
+  // tests can include invalid bytes to exercise error paths.
+  RowVectorPtr makeInput(
+      const std::vector<std::optional<int64_t>>& ids,
+      const std::vector<std::optional<std::string>>& names,
+      const std::vector<int8_t>& operations,
+      const std::vector<std::optional<std::string>>& filePaths,
+      const std::vector<std::optional<int64_t>>& positions,
+      const std::vector<int8_t>& insertFromUpdate) {
+    const auto numRows = operations.size();
+    auto* pool = opPool_.get();
+    velox::test::VectorMaker maker(pool);
+
+    auto idCol = maker.flatVectorNullable<int64_t>(ids);
+    auto nameCol = maker.flatVectorNullable<StringView>(toStringViews(names));
+    auto opCol = maker.flatVector<int8_t>(operations);
+
+    auto filePathCol =
+        maker.flatVectorNullable<StringView>(toStringViews(filePaths));
+    auto posCol = maker.flatVectorNullable<int64_t>(positions);
+    auto rowIdCol = std::make_shared<RowVector>(
+        pool,
+        kRowIdType,
+        /*nulls=*/nullptr,
+        numRows,
+        std::vector<VectorPtr>{filePathCol, posCol});
+
+    auto insertFromUpdateCol = maker.flatVector<int8_t>(insertFromUpdate);
+
+    return std::make_shared<RowVector>(
+        pool,
+        kMergeInputType,
+        /*nulls=*/nullptr,
+        numRows,
+        std::vector<VectorPtr>{
+            idCol, nameCol, opCol, rowIdCol, insertFromUpdateCol});
+  }
+
+  // Returns the hive/iceberg configs from the base fixture via friend-free
+  // accessors built on top of IcebergTestBase's setup. We re-read them
+  // from a fresh ConfigBase to match what the base creates internally.
+  std::shared_ptr<const HiveConfig> getHiveConfig() {
+    return std::make_shared<HiveConfig>(std::make_shared<config::ConfigBase>(
+        std::unordered_map<std::string, std::string>()));
+  }
+
+  IcebergConfigPtr getIcebergConfig() {
+    return std::make_shared<IcebergConfig>(std::make_shared<config::ConfigBase>(
+        std::unordered_map<std::string, std::string>{
+            {IcebergConfig::kFunctionPrefixConfig,
+             IcebergConfig::kDefaultFunctionPrefix}}));
+  }
+
+  // Lookup keys for commit-message JSON entries.
+  static constexpr const char* kContentKey = "content";
+  static constexpr const char* kFileFormatKey = "fileFormat";
+
+  static std::vector<std::optional<StringView>> toStringViews(
+      const std::vector<std::optional<std::string>>& values) {
+    std::vector<std::optional<StringView>> result;
+    result.reserve(values.size());
+    for (const auto& v : values) {
+      if (v.has_value()) {
+        result.emplace_back(StringView(*v));
+      } else {
+        result.emplace_back(std::nullopt);
+      }
+    }
+    return result;
+  }
+
+  // Returns the count of commit messages whose "content" field equals
+  // `content` (e.g. "DATA" for data files, "POSITION_DELETES" for puffin
+  // delete files). Tests use this to verify which sub-sink produced each
+  // message after `close()`.
+  static size_t countContent(
+      const std::vector<std::string>& messages,
+      const std::string& content) {
+    size_t count = 0;
+    for (const auto& msg : messages) {
+      const auto parsed = folly::parseJson(msg);
+      if (parsed.count(kContentKey) > 0 &&
+          parsed[kContentKey].asString() == content) {
+        ++count;
+      }
+    }
+    return count;
+  }
+};
+
+TEST_F(IcebergMergeSinkTest, insertOnlyBatchProducesOnlyDataFiles) {
+  auto tempDir = TempDirectoryPath::create();
+  auto sink = makeSink(tempDir->getPath());
+
+  // 3 INSERTs; row_id and insert_from_update are null/0 (ignored on INSERT
+  // by the data sub-sink, which only sees the target columns).
+  auto input = makeInput(
+      /*ids=*/{1, 2, 3},
+      /*names=*/{{std::string("a")}, {std::string("b")}, {std::string("c")}},
+      /*operations=*/
+      {IMS::kInsertOperationNumber,
+       IMS::kInsertOperationNumber,
+       IMS::kInsertOperationNumber},
+      /*filePaths=*/{std::nullopt, std::nullopt, std::nullopt},
+      /*positions=*/{std::nullopt, std::nullopt, std::nullopt},
+      /*insertFromUpdate=*/{0, 0, 0});
+
+  sink->appendData(input);
+  EXPECT_TRUE(sink->finish());
+  auto messages = sink->close();
+
+  // Exactly one data file (single partition) and zero puffin files.
+  EXPECT_EQ(countContent(messages, "DATA"), 1u);
+  EXPECT_EQ(countContent(messages, "POSITION_DELETES"), 0u);
+}
+
+TEST_F(IcebergMergeSinkTest, deleteOnlyBatchProducesOnlyPuffinFiles) {
+  auto tempDir = TempDirectoryPath::create();
+  auto sink = makeSink(tempDir->getPath());
+
+  const std::string dataFile = tempDir->getPath() + "/d.parquet";
+  // 3 DELETEs against one referenced data file; target cols are null
+  // (ignored on DELETE).
+  auto input = makeInput(
+      /*ids=*/{std::nullopt, std::nullopt, std::nullopt},
+      /*names=*/{std::nullopt, std::nullopt, std::nullopt},
+      /*operations=*/
+      {IMS::kDeleteOperationNumber,
+       IMS::kDeleteOperationNumber,
+       IMS::kDeleteOperationNumber},
+      /*filePaths=*/{{dataFile}, {dataFile}, {dataFile}},
+      /*positions=*/{10, 20, 30},
+      /*insertFromUpdate=*/{0, 0, 0});
+
+  sink->appendData(input);
+  EXPECT_TRUE(sink->finish());
+  auto messages = sink->close();
+
+  // Zero data files and exactly one puffin file (one referenced data file).
+  EXPECT_EQ(countContent(messages, "DATA"), 0u);
+  EXPECT_EQ(countContent(messages, "POSITION_DELETES"), 1u);
+}
+
+TEST_F(IcebergMergeSinkTest, mixedBatchProducesBothKinds) {
+  auto tempDir = TempDirectoryPath::create();
+  auto sink = makeSink(tempDir->getPath());
+
+  const std::string dataFile = tempDir->getPath() + "/m.parquet";
+  // 2 INSERTs interleaved with 2 DELETEs.
+  auto input = makeInput(
+      /*ids=*/{1, std::nullopt, 2, std::nullopt},
+      /*names=*/
+      {{std::string("a")}, std::nullopt, {std::string("b")}, std::nullopt},
+      /*operations=*/
+      {IMS::kInsertOperationNumber,
+       IMS::kDeleteOperationNumber,
+       IMS::kInsertOperationNumber,
+       IMS::kDeleteOperationNumber},
+      /*filePaths=*/
+      {std::nullopt, {dataFile}, std::nullopt, {dataFile}},
+      /*positions=*/{std::nullopt, 5, std::nullopt, 6},
+      /*insertFromUpdate=*/{0, 0, 0, 0});
+
+  sink->appendData(input);
+  EXPECT_TRUE(sink->finish());
+  auto messages = sink->close();
+
+  EXPECT_EQ(countContent(messages, "DATA"), 1u);
+  EXPECT_EQ(countContent(messages, "POSITION_DELETES"), 1u);
+}
+
+TEST_F(IcebergMergeSinkTest, emptyBatchProducesNoCommitMessages) {
+  auto tempDir = TempDirectoryPath::create();
+  auto sink = makeSink(tempDir->getPath());
+
+  // No appendData call. finish() must still be safe and close() returns no
+  // messages (neither sub-sink saw any data).
+  EXPECT_TRUE(sink->finish());
+  auto messages = sink->close();
+
+  EXPECT_EQ(countContent(messages, "DATA"), 0u);
+  EXPECT_EQ(countContent(messages, "POSITION_DELETES"), 0u);
+}
+
+TEST_F(IcebergMergeSinkTest, updateOperationByteIsRejected) {
+  auto tempDir = TempDirectoryPath::create();
+  auto sink = makeSink(tempDir->getPath());
+
+  // UPDATE (3) must have been fanned out by Layer 1 before reaching here.
+  // The sink must reject it explicitly so a missing fan-out is caught
+  // early rather than producing silently wrong data.
+  auto input = makeInput(
+      /*ids=*/{1},
+      /*names=*/{{std::string("x")}},
+      /*operations=*/{static_cast<int8_t>(3)},
+      /*filePaths=*/{std::nullopt},
+      /*positions=*/{std::nullopt},
+      /*insertFromUpdate=*/{0});
+
+  VELOX_ASSERT_USER_THROW(
+      sink->appendData(input),
+      "IcebergMergeSink only accepts INSERT (1) and DELETE (2)");
+}
+
+TEST_F(IcebergMergeSinkTest, defaultCaseByteIsRejected) {
+  auto tempDir = TempDirectoryPath::create();
+  auto sink = makeSink(tempDir->getPath());
+
+  auto input = makeInput(
+      /*ids=*/{1},
+      /*names=*/{{std::string("x")}},
+      /*operations=*/{static_cast<int8_t>(-1)},
+      /*filePaths=*/{std::nullopt},
+      /*positions=*/{std::nullopt},
+      /*insertFromUpdate=*/{0});
+
+  VELOX_ASSERT_USER_THROW(
+      sink->appendData(input),
+      "IcebergMergeSink only accepts INSERT (1) and DELETE (2)");
+}
+
+TEST_F(IcebergMergeSinkTest, abortPropagatesToBothSubsinks) {
+  auto tempDir = TempDirectoryPath::create();
+  auto sink = makeSink(tempDir->getPath());
+
+  // Feed one INSERT + one DELETE, then abort. abort() must propagate to both
+  // sub-sinks so they discard pending state and reject any subsequent
+  // appendData().
+  const std::string dataFile = tempDir->getPath() + "/a.parquet";
+  auto input = makeInput(
+      /*ids=*/{1, std::nullopt},
+      /*names=*/{{std::string("a")}, std::nullopt},
+      /*operations=*/
+      {IMS::kInsertOperationNumber, IMS::kDeleteOperationNumber},
+      /*filePaths=*/{std::nullopt, {dataFile}},
+      /*positions=*/{std::nullopt, 1},
+      /*insertFromUpdate=*/{0, 0});
+
+  sink->appendData(input);
+  sink->abort();
+
+  // After abort, subsequent appendData must throw.
+  VELOX_ASSERT_USER_THROW(
+      sink->appendData(input), "appendData() called after abort()");
+}
+
+TEST_F(IcebergMergeSinkTest, statsAggregateAcrossSubsinks) {
+  auto tempDir = TempDirectoryPath::create();
+  auto sink = makeSink(tempDir->getPath());
+
+  const std::string dataFile = tempDir->getPath() + "/s.parquet";
+  auto input = makeInput(
+      /*ids=*/{1, std::nullopt},
+      /*names=*/{{std::string("a")}, std::nullopt},
+      /*operations=*/
+      {IMS::kInsertOperationNumber, IMS::kDeleteOperationNumber},
+      /*filePaths=*/{std::nullopt, {dataFile}},
+      /*positions=*/{std::nullopt, 7},
+      /*insertFromUpdate=*/{0, 0});
+
+  sink->appendData(input);
+  EXPECT_TRUE(sink->finish());
+  sink->close();
+
+  const auto stats = sink->stats();
+  // Two files: one data file + one puffin. Bytes > 0 because both writers
+  // produced non-trivial output.
+  EXPECT_EQ(stats.numWrittenFiles, 2u);
+  EXPECT_GT(stats.numWrittenBytes, 0u);
+}
+
+TEST_F(IcebergMergeSinkTest, closeIsIdempotent) {
+  auto tempDir = TempDirectoryPath::create();
+  auto sink = makeSink(tempDir->getPath());
+
+  // Two close() calls should return identical commit-message vectors. The
+  // composite's underlying sub-sinks are individually idempotent on close;
+  // verify the composite preserves that contract.
+  const std::string dataFile = tempDir->getPath() + "/i.parquet";
+  auto input = makeInput(
+      /*ids=*/{1, std::nullopt},
+      /*names=*/{{std::string("a")}, std::nullopt},
+      /*operations=*/
+      {IMS::kInsertOperationNumber, IMS::kDeleteOperationNumber},
+      /*filePaths=*/{std::nullopt, {dataFile}},
+      /*positions=*/{std::nullopt, 3},
+      /*insertFromUpdate=*/{0, 0});
+
+  sink->appendData(input);
+  EXPECT_TRUE(sink->finish());
+  // First close().
+  auto first = sink->close();
+  // Second close() must return an identical commit-message vector without
+  // re-closing the sub-sinks.
+  auto second = sink->close();
+  EXPECT_EQ(second, first);
+  EXPECT_EQ(countContent(first, "DATA"), 1u);
+  EXPECT_EQ(countContent(first, "POSITION_DELETES"), 1u);
+}
+
+// Verifies that the sink derives its inner data sub-sink's column names
+// from the IcebergInsertTableHandle's input columns rather than from the
+// source RowVector names. The inputType here uses positional column names
+// ("c0", "c1") while the handle declares iceberg-schema names ("id",
+// "name") — the sink must still construct successfully and write the
+// expected data file. This guards against upstream rename drift breaking
+// the writer's name-based binding.
+TEST_F(IcebergMergeSinkTest, dataInputTypeNamesComeFromHandleNotSource) {
+  auto tempDir = TempDirectoryPath::create();
+  auto handle = makeMergeHandle(tempDir->getPath());
+
+  // Source RowVector uses positional names instead of iceberg-schema names.
+  const RowTypePtr positionalInputType =
+      ROW({"c0", "c1", "operation", "row_id", "insert_from_update"},
+          {BIGINT(), VARCHAR(), TINYINT(), kRowIdType, TINYINT()});
+
+  auto sink = std::make_unique<IcebergMergeSink>(
+      positionalInputType,
+      handle,
+      connectorQueryCtx_.get(),
+      CommitStrategy::kNoCommit,
+      getHiveConfig(),
+      getIcebergConfig(),
+      /*targetColumnChannels=*/std::vector<column_index_t>{0, 1},
+      /*operationChannel=*/2,
+      /*rowIdChannel=*/3);
+
+  // Build an input vector with the same positional schema; the sink should
+  // still successfully write the insert batch by matching by channel
+  // rather than by source-page name.
+  auto* pool = opPool_.get();
+  velox::test::VectorMaker maker(pool);
+  auto idCol = maker.flatVector<int64_t>(std::vector<int64_t>{1, 2});
+  auto nameCol = maker.flatVector<StringView>(
+      std::vector<StringView>{StringView("a"), StringView("b")});
+  auto opCol = maker.flatVector<int8_t>(std::vector<int8_t>{
+      IMS::kInsertOperationNumber, IMS::kInsertOperationNumber});
+  auto filePathCol = maker.flatVectorNullable<StringView>(
+      std::vector<std::optional<StringView>>{std::nullopt, std::nullopt});
+  auto posCol = maker.flatVectorNullable<int64_t>(
+      std::vector<std::optional<int64_t>>{std::nullopt, std::nullopt});
+  auto rowIdCol = std::make_shared<RowVector>(
+      pool,
+      kRowIdType,
+      /*nulls=*/nullptr,
+      2,
+      std::vector<VectorPtr>{filePathCol, posCol});
+  auto insertFromUpdateCol =
+      maker.flatVector<int8_t>(std::vector<int8_t>{0, 0});
+  auto input = std::make_shared<RowVector>(
+      pool,
+      positionalInputType,
+      /*nulls=*/nullptr,
+      2,
+      std::vector<VectorPtr>{
+          idCol, nameCol, opCol, rowIdCol, insertFromUpdateCol});
+
+  sink->appendData(input);
+  EXPECT_TRUE(sink->finish());
+  auto messages = sink->close();
+  EXPECT_EQ(countContent(messages, "DATA"), 1u);
+}
+
+// VELOX_ENABLE_PARQUET guard removed: rely on the iceberg_connector
+// target's unconditional Parquet writer dependency.
+
+} // namespace
+} // namespace facebook::velox::connector::hive::iceberg::test

--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -1711,6 +1711,75 @@ TEST_F(HiveIcebergTest, rowLineage) {
   });
 }
 
+// Tests Iceberg MERGE INTO row-id synthesis: the projection of the synthetic
+// $target_table_row_id ROW column produced at read time from the split's
+// infoColumns ($path, $spec_id, partition_data) plus the file row positions.
+// Mirrors the IcebergPageSourceProvider Java path that backs
+// MERGE_TARGET_ROW_ID_DATA.
+TEST_F(HiveIcebergTest, targetTableRowIdSynthesis) {
+  folly::SingletonVault::singleton()->registrationComplete();
+
+  static const std::string kPartitionDataJson =
+      "{\"partitionValues\":[\"2024-01-01\"]}";
+
+  // Write a small data file containing only c0 (the synthetic row-id column
+  // never appears in the file).
+  std::vector<RowVectorPtr> inputVectors = {
+      makeRowVector({"c0"}, {makeFlatVector<int64_t>({10, 20, 30})})};
+  auto dataFilePath = TempFilePath::create();
+  writeToFile(dataFilePath->getPath(), inputVectors);
+
+  std::unordered_map<std::string, std::string> infoColumns = {
+      {IcebergMetadataColumn::kSpecIdInfoColumn, "7"},
+      {IcebergMetadataColumn::kPartitionDataInfoColumn, kPartitionDataJson},
+  };
+
+  auto split = makeIcebergSplitWithInfoColumns(
+      dataFilePath->getPath(), infoColumns, /*deleteFiles=*/{});
+
+  const auto rowIdType =
+      ROW({"file_path", "row_position", "spec_id", "partition_data"},
+          {VARCHAR(), BIGINT(), INTEGER(), VARCHAR()});
+  const auto outputType =
+      ROW({"c0", IcebergMetadataColumn::kTargetTableRowIdColumnName},
+          {BIGINT(), rowIdType});
+  const auto tableDataColumns = ROW({"c0"}, {BIGINT()});
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kIcebergConnectorId)
+                  .outputType(outputType)
+                  .dataColumns(tableDataColumns)
+                  .endTableScan()
+                  .planNode();
+
+  // Contiguous case: row_position = file position [0, 1, 2]. file_path,
+  // spec_id, and partition_data are split-level constants.
+  auto expected = makeRowVector(
+      {"c0", IcebergMetadataColumn::kTargetTableRowIdColumnName},
+      {
+          makeFlatVector<int64_t>({10, 20, 30}),
+          makeRowVector(
+              {"file_path", "row_position", "spec_id", "partition_data"},
+              {
+                  makeFlatVector<std::string>(
+                      3,
+                      [&](vector_size_t /*row*/) {
+                        return dataFilePath->getPath();
+                      }),
+                  makeFlatVector<int64_t>({0, 1, 2}),
+                  makeFlatVector<int32_t>({7, 7, 7}),
+                  makeFlatVector<std::string>(
+                      3,
+                      [&](vector_size_t /*row*/) {
+                        return kPartitionDataJson;
+                      }),
+              }),
+      });
+
+  AssertQueryBuilder(plan).splits({split}).assertResults({expected});
+}
+
 #ifdef VELOX_ENABLE_PARQUET
 TEST_F(HiveIcebergTest, positionalDeleteFileWithRowGroupFilter) {
   // This file contains three row groups, each with about 100 rows.

--- a/velox/connectors/hive/iceberg/tests/WriterOptionsAdapterTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/WriterOptionsAdapterTest.cpp
@@ -25,20 +25,22 @@ namespace facebook::velox::connector::hive::iceberg {
 namespace {
 
 // Verifies the dispatch table in createWriterOptionsAdapter():
-// PARQUET, DWRF, NIMBLE return non-null adapters; everything else returns
-// null. This is the single source of truth for which file formats the
-// Iceberg DataSink supports on the write path.
+// PARQUET, ORC, DWRF, NIMBLE return non-null adapters; everything else
+// returns null. This is the single source of truth for which file formats
+// the Iceberg DataSink supports on the write path. ORC routes through the
+// same DwrfWriterOptionsAdapter because Meta's DWRF is an ORC
+// implementation.
 TEST(WriterOptionsAdapterTest, createWriterOptionsAdapterDispatch) {
   EXPECT_NE(
       createWriterOptionsAdapter(dwio::common::FileFormat::PARQUET), nullptr);
+  EXPECT_NE(createWriterOptionsAdapter(dwio::common::FileFormat::ORC), nullptr);
   EXPECT_NE(
       createWriterOptionsAdapter(dwio::common::FileFormat::DWRF), nullptr);
   EXPECT_NE(
       createWriterOptionsAdapter(dwio::common::FileFormat::NIMBLE), nullptr);
 
-  // ORC, TEXT, JSON, ALPHA, etc. are intentionally unsupported on the
+  // TEXT, JSON, ALPHA, etc. are intentionally unsupported on the
   // write path until each gets its own end-to-end coverage.
-  EXPECT_EQ(createWriterOptionsAdapter(dwio::common::FileFormat::ORC), nullptr);
   EXPECT_EQ(
       createWriterOptionsAdapter(dwio::common::FileFormat::TEXT), nullptr);
   EXPECT_EQ(
@@ -48,10 +50,10 @@ TEST(WriterOptionsAdapterTest, createWriterOptionsAdapterDispatch) {
 // Verifies isSupportedFileFormat() agrees with createWriterOptionsAdapter().
 TEST(WriterOptionsAdapterTest, isSupportedFileFormatMatchesDispatch) {
   EXPECT_TRUE(isSupportedFileFormat(dwio::common::FileFormat::PARQUET));
+  EXPECT_TRUE(isSupportedFileFormat(dwio::common::FileFormat::ORC));
   EXPECT_TRUE(isSupportedFileFormat(dwio::common::FileFormat::DWRF));
   EXPECT_TRUE(isSupportedFileFormat(dwio::common::FileFormat::NIMBLE));
 
-  EXPECT_FALSE(isSupportedFileFormat(dwio::common::FileFormat::ORC));
   EXPECT_FALSE(isSupportedFileFormat(dwio::common::FileFormat::TEXT));
   EXPECT_FALSE(isSupportedFileFormat(dwio::common::FileFormat::JSON));
 }
@@ -67,6 +69,7 @@ TEST(WriterOptionsAdapterTest, isSupportedFileFormatMatchesDispatch) {
 TEST(WriterOptionsAdapterTest, toManifestFormatString) {
   EXPECT_EQ(
       toManifestFormatString(dwio::common::FileFormat::PARQUET), "PARQUET");
+  EXPECT_EQ(toManifestFormatString(dwio::common::FileFormat::ORC), "ORC");
   EXPECT_EQ(toManifestFormatString(dwio::common::FileFormat::DWRF), "ORC");
   EXPECT_EQ(toManifestFormatString(dwio::common::FileFormat::NIMBLE), "ORC");
 }
@@ -111,14 +114,34 @@ TEST(WriterOptionsAdapterTest, dwrfPostConfigsOverridesTimestampFields) {
   EXPECT_EQ(options.sessionTimezone, nullptr);
 }
 
+// Verifies ORC routes through the same DwrfWriterOptionsAdapter as DWRF:
+// the post-config hook overrides the same dwrf::WriterOptions timestamp
+// fields. This proves that the ORC dispatch is wired to the DWRF adapter
+// (the cross-engine convention — Meta's DWRF is an ORC implementation).
+TEST(WriterOptionsAdapterTest, orcRoutesToDwrfAdapter) {
+  auto adapter = createWriterOptionsAdapter(dwio::common::FileFormat::ORC);
+  ASSERT_NE(adapter, nullptr);
+
+  EXPECT_EQ(adapter->manifestFormatString(), "ORC");
+
+  dwrf::WriterOptions options;
+  options.adjustTimestampToTimezone = true;
+  options.sessionTimezone = tz::locateZone("America/Los_Angeles");
+
+  adapter->applyPostConfigs(options);
+
+  EXPECT_FALSE(options.adjustTimestampToTimezone);
+  EXPECT_EQ(options.sessionTimezone, nullptr);
+}
+
 // Verifies toManifestFormatString() throws for unsupported formats rather
 // than silently returning an incorrect string.
 TEST(WriterOptionsAdapterTest, toManifestFormatStringThrowsForUnsupported) {
   VELOX_ASSERT_THROW(
-      toManifestFormatString(dwio::common::FileFormat::ORC),
+      toManifestFormatString(dwio::common::FileFormat::TEXT),
       "Unsupported file format for Iceberg manifest");
   VELOX_ASSERT_THROW(
-      toManifestFormatString(dwio::common::FileFormat::TEXT),
+      toManifestFormatString(dwio::common::FileFormat::JSON),
       "Unsupported file format for Iceberg manifest");
 }
 


### PR DESCRIPTION
Summary:

Adds `IcebergMergeSink`, a composite `connector::DataSink` that consumes
the output of Layer 1's `IcebergMergeProcessor` (per-row INSERT/DELETE)
and routes each row to one of two inner sub-sinks:
- INSERT rows → inner `IcebergDataSink` (kData) for data-file writes.
- DELETE rows → inner `IcebergDeletionVectorSink` (kDeletionVector) for
  V3 Puffin blobs.

Per-row dispatch is zero-copy: the composite builds a per-branch row-index
buffer, then dictionary-wraps each child vector of the projected branch.
The DELETE branch extracts `file_path` / `pos` from the row_id ROW
struct's first two children, tolerating extra trailing Iceberg row id
fields (spec_id, partition_data).

### Wiring changes

- New `IcebergInsertTableHandle::WriteKind::kMerge` enum value
  (`IcebergDataSink.h`).
- `IcebergInsertTableHandle` ctor now requires `inputColumns` to be
  non-empty for both `kData` and `kMerge` (the inner data sub-sink
  consumes them on the merge path).
- `IcebergConnector::createDataSink` adds a `kMerge` dispatch arm that
  derives the channel layout from the
  `IcebergMergeProcessor` output convention
  (`[target cols 0..N-1, operation N, row_id N+1, insert_from_update N+2]`)
  and constructs the composite. Pre-existing `kData` /
  `kDeletionVector` / `kPositionDelete` arms are unchanged.

### Sub-sink construction

The composite clones the incoming `kMerge` handle into two narrow
handles — one `kData`, one `kDeletionVector` — sharing the same
`locationHandle`, `partitionSpec`, `inputColumns`, `storageFormat`,
`compressionKind`, and `serdeParameters`. Neither sub-sink needs to know
about the composite; their existing invariants (`kData` requires
`inputColumns`, `kDeletionVector` accepts a 2-column synthetic row) hold
unchanged.

### Lifecycle

- `appendData`: rejects UPDATE (3) / DEFAULT (-1) bytes — Layer 1 must
  fan them out first. INSERT (1) and DELETE (2) are the only valid bytes
  at the sink; any other byte triggers `VELOX_USER_FAIL`.
- `finish`: drives each sub-sink with a sticky completion latch so
  partial yields don't re-enter an already-finished sub-sink.
- `close`: concatenates commit-message vectors from both sub-sinks. The
  coordinator already accepts heterogeneous `content: DATA` and
  `content: POSITION_DELETES` entries in a single fragment stream (per
  Phase B's V3 DV support).
- `abort`: forwards to both sub-sinks (data first because it owns
  heavier writer state).
- `stats`: element-wise sum of numeric fields.

### Test coverage

`IcebergMergeSinkTest` (9 test cases) covers:
- INSERT-only, DELETE-only, mixed, and empty batches.
- Stats aggregation across both sub-sinks.
- UPDATE / DEFAULT_CASE / unknown operation bytes rejected.
- `abort` propagation (subsequent `appendData` throws).
- `close` idempotency.

Reviewed By: srsuryadev

Differential Revision: D106431022


