### PR TITLE
fix: Remove Fedora tzdata pin

### DIFF
--- a/scripts/docker/fedora.dockerfile
+++ b/scripts/docker/fedora.dockerfile
@@ -12,15 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# tzdata is pinned to a known-good version so docker rebuilds (any time
-# scripts/docker/*.dockerfile or scripts/setup-*.sh changes) don't
-# silently bump tzdata in the image. See issue #17522 for the bug class
-# this prevents — version mismatch between OS tzdata and consumers'
-# bundled tzdb code can produce silent 1-hour offsets in TIMESTAMP
-# WITH TIME ZONE values. To bump intentionally: change the default and
-# rebuild locally to confirm before merging.
-ARG FEDORA_TZDATA_VERSION=2025c-1.fc42
-
 ########################
 # Stage 1: Base Build  #
 ########################

--- a/scripts/docker/fedora.dockerfile
+++ b/scripts/docker/fedora.dockerfile
@@ -18,10 +18,6 @@
 ARG base=quay.io/fedora/fedora:42-x86_64
 FROM $base AS base-build
 
-ARG FEDORA_TZDATA_VERSION
-RUN dnf -y install "tzdata-${FEDORA_TZDATA_VERSION}.noarch" || \
-      dnf -y downgrade "tzdata-${FEDORA_TZDATA_VERSION}.noarch"
-
 COPY scripts/setup-helper-functions.sh /
 COPY scripts/setup-versions.sh /
 COPY scripts/setup-common.sh /
@@ -54,10 +50,6 @@ RUN bash /setup-fedora.sh && \
 # Stage 2: Base Image  #
 ########################
 FROM $base AS fedora
-
-ARG FEDORA_TZDATA_VERSION
-RUN dnf -y install "tzdata-${FEDORA_TZDATA_VERSION}.noarch" || \
-      dnf -y downgrade "tzdata-${FEDORA_TZDATA_VERSION}.noarch"
 
 COPY scripts/setup-helper-functions.sh /
 COPY scripts/setup-versions.sh /


### PR DESCRIPTION
This PR removes the `tzdata` pinning for Fedora images to unblock CI. Currently the builds report an error:

```
No match for argument: tzdata-2025c-1.fc42.noarch
```

Solution proposed by @kgpai in https://github.com/facebookincubator/velox/pull/17712#issuecomment-4625816513.
