### PR TITLE
fix: Return done instead of nullopt from HiveIndexSource EmptyIterator

### DIFF
--- a/velox/connectors/hive/HiveIndexSource.cpp
+++ b/velox/connectors/hive/HiveIndexSource.cpp
@@ -459,7 +459,10 @@ class EmptyIterator : public IndexSource::ResultIterator {
   std::optional<std::unique_ptr<IndexSource::Result>> next(
       vector_size_t /*size*/,
       ContinueFuture& /*future*/) override {
-    return std::nullopt;
+    // Return a null Result to signal "done", not std::nullopt which means
+    // "async started, wait on future" and trips lookupFuture.valid() in
+    // IndexLookupJoin.
+    return std::unique_ptr<IndexSource::Result>(nullptr);
   }
 };
 


### PR DESCRIPTION
Summary:
`EmptyIterator::next()` returned `std::nullopt`, which in the `ResultIterator::next()` contract means "async work started, wait on the out-parameter future". It never set a future, so when `HiveIndexSource::lookup()` returned an `EmptyIterator` (probe batch whose partition values match no partition reader group), `IndexLookupJoin::getLookupResults` hit `VELOX_CHECK(batch.lookupFuture.valid())` and the query crashed with a `VeloxRuntimeError`.

Return a null `Result` (`std::unique_ptr<IndexSource::Result>(nullptr)`) instead, which signals "done / no more results" -- matching how `HiveLookupIterator` signals completion. Probe rows with no matching partition correctly produce zero join output.

Differential Revision: D107482794


