### PR TITLE
fix(iceberg): Support reading flatmap as struct (#17741)

### DIFF
--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -718,7 +718,19 @@ std::vector<TypePtr> IcebergSplitReader::adaptColumns(
         }
         childSpec->setConstantValue(nullptr);
         auto& outputType = readerOutputType_->childAt(*outputTypeIdx);
-        columnTypes[*fileTypeIdx] = outputType;
+        auto& columnType = columnTypes[*fileTypeIdx];
+        if (childSpec->isFlatMapAsStruct()) {
+          VELOX_CHECK(
+              outputType->isRow(),
+              "Unexpected output type for flat-map-as-struct column: {}.",
+              outputType->toString());
+          VELOX_CHECK(
+              columnType->isMap(),
+              "Unexpected column type for flat-map-as-struct column: {}.",
+              columnType->toString());
+        } else {
+          columnType = outputType;
+        }
       } else if (!fileTypeIdx.has_value()) {
         // Handle columns missing from the data file in several scenarios:
         // 1. Partition columns from a Hive-migrated table where partition

--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -2017,4 +2017,72 @@ TEST_F(HiveIcebergTest, positionalDeleteSequenceNumberZeroDisablesFilter) {
   AssertQueryBuilder(plan).split(split).assertResults({expected});
 }
 
+TEST_F(HiveIcebergTest, flatMapAsStruct) {
+  // Write a DWRF file with a MAP<BIGINT, DOUBLE> column.
+  auto mapType = MAP(BIGINT(), DOUBLE());
+  auto dataSchema = ROW({"id", "features"}, {BIGINT(), mapType});
+
+  auto dataFilePath = TempFilePath::create();
+  writeToFile(
+      dataFilePath->getPath(),
+      {makeRowVector(
+          {"id", "features"},
+          {makeFlatVector<int64_t>({1, 2}),
+           makeMapVector(
+               {0, 3},
+               makeFlatVector<int64_t>({1, 2, 3, 1, 2, 3}),
+               makeFlatVector<double>(
+                   {10.0, 20.0, 30.0, 100.0, 200.0, 300.0}))})});
+
+  // Build struct-encoded column handle for "features": keys {1, 2} as
+  // struct fields {"1", "2"}.
+  std::vector<common::Subfield> subfields;
+  for (auto key : {"1", "2"}) {
+    std::vector<std::unique_ptr<common::Subfield::PathElement>> path;
+    path.push_back(std::make_unique<common::Subfield::NestedField>("features"));
+    path.push_back(
+        std::make_unique<common::Subfield::NestedField>(std::string(key)));
+    subfields.emplace_back(std::move(path));
+  }
+
+  auto structType = ROW({"1", "2"}, {DOUBLE(), DOUBLE()});
+  ColumnHandleMap assignments;
+  assignments["id"] = std::make_shared<HiveColumnHandle>(
+      "id",
+      HiveColumnHandle::ColumnType::kRegular,
+      BIGINT(),
+      BIGINT(),
+      std::vector<common::Subfield>{});
+  assignments["features"] = std::make_shared<HiveColumnHandle>(
+      "features",
+      HiveColumnHandle::ColumnType::kRegular,
+      mapType,
+      mapType,
+      std::move(subfields));
+
+  // Output type has ROW for the struct-encoded column.
+  auto outputType = ROW({"id", "features"}, {BIGINT(), structType});
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kIcebergConnectorId)
+                  .outputType(outputType)
+                  .dataColumns(dataSchema)
+                  .assignments(assignments)
+                  .endTableScan()
+                  .planNode();
+
+  auto splits = makeIcebergSplits(dataFilePath->getPath());
+
+  auto expected = makeRowVector(
+      {"id", "features"},
+      {makeFlatVector<int64_t>({1, 2}),
+       makeRowVector(
+           {"1", "2"},
+           {makeFlatVector<double>({10.0, 100.0}),
+            makeFlatVector<double>({20.0, 200.0})})});
+
+  AssertQueryBuilder(plan).splits(splits).assertResults({expected});
+}
+
 } // namespace facebook::velox::connector::hive::iceberg


### PR DESCRIPTION
Summary:

IcebergSplitReader::adaptColumns unconditionally overwrites the column type with the output type when a column exists in both the file and the output schema. For flat-map-as-struct columns (where the output type is ROW but the file type is MAP), this causes the Velox reader to receive requestedType=ROW for a column that is physically stored as MAP. The reader's checkTypeCompatibility then rejects the MAP→ROW mismatch with a SCHEMA_MISMATCH error before it can dispatch to SelectiveMapAsStructColumnReader.

Both HiveSplitReader::adaptColumns and FileSplitReader::adaptColumns already guard against this by checking childSpec->isFlatMapAsStruct() — when true, they leave the column type as MAP so the reader can handle the MAP→ROW conversion internally. IcebergSplitReader::adaptColumns was missing this check.

The fix adds the same isFlatMapAsStruct guard to IcebergSplitReader::adaptColumns, aligning its behavior with the other two split readers.

Reviewed By: apurva-meta

Differential Revision: D107581639


