### PR TITLE
feat(sparksql): Add ANSI throw-or-null helper macro

### DIFF
--- a/velox/functions/sparksql/AnsiMode.h
+++ b/velox/functions/sparksql/AnsiMode.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <folly/Likely.h>
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::functions::sparksql {
+
+/// Standard "throw under ANSI, return NULL otherwise" branch for Spark vector
+/// functions whose row-processing helpers return std::optional<T>.
+///
+/// When `ansiEnabled` is true, throws a user error formatted from the trailing
+/// fmt + args (forwarded to VELOX_USER_FAIL). When false, returns
+/// `std::nullopt` from the *enclosing function*. The macro exits control flow
+/// either way; the `RETURN_NULL_OR_FAIL` name is chosen so this is obvious at
+/// the call site.
+///
+/// Usage:
+///   if (hour < 0 || hour >= 24) {
+///     VELOX_SPARK_RETURN_NULL_OR_FAIL(
+///         ansiEnabled, "Invalid value for hour, must be in [0, 24): {}",
+///         hour);
+///   }
+///
+/// Caller contract:
+///   - The enclosing function must have a return type convertible from
+///     `std::nullopt` (e.g. std::optional<T>).
+///   - Error messages should follow Velox convention: static description
+///     first, runtime values at the end of the format string.
+#define VELOX_SPARK_RETURN_NULL_OR_FAIL(ansiEnabled, /*fmt, args...*/...) \
+  do {                                                                    \
+    if (FOLLY_UNLIKELY(ansiEnabled)) {                                    \
+      VELOX_USER_FAIL(__VA_ARGS__);                                       \
+    }                                                                     \
+    return std::nullopt;                                                  \
+  } while (0)
+
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/CMakeLists.txt
+++ b/velox/functions/sparksql/CMakeLists.txt
@@ -51,6 +51,7 @@ velox_add_library(
   Transform.cpp
   UnscaledValueFunction.cpp
   HEADERS
+  AnsiMode.h
   Arena.h
   Arithmetic.h
   ArrayAppend.h


### PR DESCRIPTION
## Summary

Introduces `VELOX_SPARK_RETURN_NULL_OR_FAIL` in a new header `velox/functions/sparksql/AnsiMode.h`. The macro collapses the standard "throw under ANSI mode, return NULL otherwise" branch used by Spark vector functions whose row-processing helpers return `std::optional<T>` into one readable line.

```cpp
if (hour < 0 || hour >= 24) {
  VELOX_SPARK_RETURN_NULL_OR_FAIL(
      ansiEnabled, "Invalid value for hour, must be in [0, 24): {}", hour);
}
```

When `ansiEnabled` is true the macro throws via `VELOX_USER_FAIL`; otherwise it returns `std::nullopt` from the enclosing function.

This lands ahead of the queue of ANSI-aware functions in apache/incubator-gluten#10134 to standardize the pattern. First adopter `make_timestamp` follows in #17745.

## Test plan
- [x] Header parses cleanly (verified via incremental rebuild after a transient include).
- [x] Clang-format clean.
- [ ] Macro exercised end-to-end by the follow-up `make_timestamp` PR (#17745).