### PR TITLE
fix(sparksql): Make make_timestamp ANSI-aware

### DIFF
--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -212,6 +212,8 @@ These functions support TIMESTAMP and DATE input types.
 
 .. spark:function:: make_timestamp(year, month, day, hour, minute, second[, timezone]) -> timestamp
 
+    *(ANSI compliant)*
+
     Create timestamp from ``year``, ``month``, ``day``, ``hour``, ``minute`` and ``second`` fields.
     If the ``timezone`` parameter is provided,
     the function interprets the input time components as being in the specified ``timezone``.
@@ -232,15 +234,17 @@ These functions support TIMESTAMP and DATE input types.
         * timezone - the time zone identifier. For example, CET, UTC and etc.
 
     Returns the timestamp adjusted to the GMT time zone.
-    Returns NULL for invalid or NULL input. ::
+    When ``spark.ansi_enabled`` is true, invalid (non-NULL) inputs throw an
+    error; otherwise the function returns NULL. NULL inputs always return
+    NULL regardless of ANSI mode. ::
 
         SELECT make_timestamp(2014, 12, 28, 6, 30, 45.887); -- 2014-12-28 06:30:45.887
         SELECT make_timestamp(2014, 12, 28, 6, 30, 45.887, 'CET'); -- 2014-12-28 05:30:45.887
         SELECT make_timestamp(2019, 6, 30, 23, 59, 60); -- 2019-07-01 00:00:00
         SELECT make_timestamp(2019, 6, 30, 23, 59, 1); -- 2019-06-30 23:59:01
         SELECT make_timestamp(null, 7, 22, 15, 30, 0); -- NULL
-        SELECT make_timestamp(2014, 12, 28, 6, 30, 60.000001); -- NULL
-        SELECT make_timestamp(2014, 13, 28, 6, 30, 45.887); -- NULL
+        SELECT make_timestamp(2014, 12, 28, 6, 30, 60.000001); -- NULL (ANSI OFF) / ERROR (ANSI ON)
+        SELECT make_timestamp(2014, 13, 28, 6, 30, 45.887); -- NULL (ANSI OFF) / ERROR (ANSI ON)
 
 .. spark:function:: make_ym_interval([years[, months]]) -> interval year to month
 

--- a/velox/functions/sparksql/AnsiMode.h
+++ b/velox/functions/sparksql/AnsiMode.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <folly/Likely.h>
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::functions::sparksql {
+
+/// Standard "throw under ANSI, return NULL otherwise" branch for Spark vector
+/// functions whose row-processing helpers return std::optional<T>.
+///
+/// When `ansiEnabled` is true, throws a user error formatted from the trailing
+/// fmt + args (forwarded to VELOX_USER_FAIL). When false, returns
+/// `std::nullopt` from the *enclosing function*. The macro exits control flow
+/// either way; the `RETURN_NULL_OR_FAIL` name is chosen so this is obvious at
+/// the call site.
+///
+/// Usage:
+///   if (hour < 0 || hour >= 24) {
+///     VELOX_SPARK_RETURN_NULL_OR_FAIL(
+///         ansiEnabled, "Invalid value for hour, must be in [0, 24): {}",
+///         hour);
+///   }
+///
+/// Caller contract:
+///   - The enclosing function must have a return type convertible from
+///     `std::nullopt` (e.g. std::optional<T>).
+///   - Error messages should follow Velox convention: static description
+///     first, runtime values at the end of the format string.
+#define VELOX_SPARK_RETURN_NULL_OR_FAIL(ansiEnabled, /*fmt, args...*/...) \
+  do {                                                                    \
+    if (FOLLY_UNLIKELY(ansiEnabled)) {                                    \
+      VELOX_USER_FAIL(__VA_ARGS__);                                       \
+    }                                                                     \
+    return std::nullopt;                                                  \
+  } while (0)
+
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/AnsiMode.h
+++ b/velox/functions/sparksql/AnsiMode.h
@@ -15,39 +15,37 @@
  */
 #pragma once
 
+#include <fmt/format.h>
 #include <folly/Likely.h>
+
+#include <optional>
 
 #include "velox/common/base/Exceptions.h"
 
 namespace facebook::velox::functions::sparksql {
 
-/// Standard "throw under ANSI, return NULL otherwise" branch for Spark vector
-/// functions whose row-processing helpers return std::optional<T>.
+/// Returns std::nullopt when ANSI mode is disabled; throws a user error
+/// formatted from 'fmt' and 'args' when enabled. Use at validation sites in
+/// Spark functions that return NULL on invalid input unless ANSI mode
+/// requires an error:
 ///
-/// When `ansiEnabled` is true, throws a user error formatted from the trailing
-/// fmt + args (forwarded to VELOX_USER_FAIL). When false, returns
-/// `std::nullopt` from the *enclosing function*. The macro exits control flow
-/// either way; the `RETURN_NULL_OR_FAIL` name is chosen so this is obvious at
-/// the call site.
-///
-/// Usage:
 ///   if (hour < 0 || hour >= 24) {
-///     VELOX_SPARK_RETURN_NULL_OR_FAIL(
+///     return nullOrUserFail(
 ///         ansiEnabled, "Invalid value for hour, must be in [0, 24): {}",
 ///         hour);
 ///   }
 ///
-/// Caller contract:
-///   - The enclosing function must have a return type convertible from
-///     `std::nullopt` (e.g. std::optional<T>).
-///   - Error messages should follow Velox convention: static description
-///     first, runtime values at the end of the format string.
-#define VELOX_SPARK_RETURN_NULL_OR_FAIL(ansiEnabled, /*fmt, args...*/...) \
-  do {                                                                    \
-    if (FOLLY_UNLIKELY(ansiEnabled)) {                                    \
-      VELOX_USER_FAIL(__VA_ARGS__);                                       \
-    }                                                                     \
-    return std::nullopt;                                                  \
-  } while (0)
+/// Error messages should follow Velox convention: static description first,
+/// runtime values at the end of the format string.
+template <typename... Args>
+std::nullopt_t nullOrUserFail(
+    bool ansiEnabled,
+    fmt::format_string<Args...> fmt,
+    Args&&... args) {
+  if (FOLLY_UNLIKELY(ansiEnabled)) {
+    VELOX_USER_FAIL("{}", fmt::format(fmt, std::forward<Args>(args)...));
+  }
+  return std::nullopt;
+}
 
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/CMakeLists.txt
+++ b/velox/functions/sparksql/CMakeLists.txt
@@ -51,6 +51,7 @@ velox_add_library(
   Transform.cpp
   UnscaledValueFunction.cpp
   HEADERS
+  AnsiMode.h
   Arena.h
   Arithmetic.h
   ArrayAppend.h

--- a/velox/functions/sparksql/MakeTimestamp.cpp
+++ b/velox/functions/sparksql/MakeTimestamp.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/expression/DecodedArgs.h"
 #include "velox/expression/VectorFunction.h"
+#include "velox/functions/sparksql/AnsiMode.h"
+#include "velox/functions/sparksql/SparkQueryConfig.h"
 #include "velox/functions/sparksql/TimestampUtils.h"
 #include "velox/type/tz/TimeZoneMap.h"
 
@@ -29,25 +31,37 @@ std::optional<Timestamp> makeTimeStampFromDecodedArgs(
     DecodedVector* dayVector,
     DecodedVector* hourVector,
     DecodedVector* minuteVector,
-    DecodedVector* microsVector) {
+    DecodedVector* microsVector,
+    bool ansiEnabled) {
   // Check hour.
   auto hour = hourVector->valueAt<int32_t>(row);
   if (hour < 0 || hour >= 24) {
-    return std::nullopt;
+    VELOX_SPARK_RETURN_NULL_OR_FAIL(
+        ansiEnabled, "Invalid value for hour, must be in [0, 24): {}", hour);
   }
   // Check minute.
   auto minute = minuteVector->valueAt<int32_t>(row);
   if (minute < 0 || minute >= 60) {
-    return std::nullopt;
+    VELOX_SPARK_RETURN_NULL_OR_FAIL(
+        ansiEnabled,
+        "Invalid value for minute, must be in [0, 60): {}",
+        minute);
   }
   // Check microseconds.
   auto micros = microsVector->valueAt<int64_t>(row);
   if (micros < 0) {
-    return std::nullopt;
+    VELOX_SPARK_RETURN_NULL_OR_FAIL(
+        ansiEnabled,
+        "Invalid value for second microseconds, must be non-negative: {}",
+        micros);
   }
   auto seconds = micros / util::kMicrosPerSec;
   if (seconds > 60 || (seconds == 60 && micros % util::kMicrosPerSec != 0)) {
-    return std::nullopt;
+    VELOX_SPARK_RETURN_NULL_OR_FAIL(
+        ansiEnabled,
+        "Invalid value for second, must be in [0, 60] with 0 microseconds at 60: {}.{:06d}",
+        seconds,
+        micros % util::kMicrosPerSec);
   }
 
   // Year, month, day will be checked in utils::daysSinceEpochFromDate.
@@ -57,7 +71,8 @@ std::optional<Timestamp> makeTimeStampFromDecodedArgs(
       dayVector->valueAt<int32_t>(row));
   if (daysSinceEpoch.hasError()) {
     VELOX_DCHECK(daysSinceEpoch.error().isUserError());
-    return std::nullopt;
+    VELOX_SPARK_RETURN_NULL_OR_FAIL(
+        ansiEnabled, "{}", daysSinceEpoch.error().message());
   }
 
   // Micros has at most 8 digits (2 for seconds + 6 for microseconds),
@@ -97,8 +112,8 @@ void setTimestampOrNull(
 
 class MakeTimestampFunction : public exec::VectorFunction {
  public:
-  MakeTimestampFunction(const tz::TimeZone* sessionTimeZone)
-      : sessionTimeZone_(sessionTimeZone) {}
+  MakeTimestampFunction(const tz::TimeZone* sessionTimeZone, bool ansiEnabled)
+      : sessionTimeZone_(sessionTimeZone), ansiEnabled_(ansiEnabled) {}
 
   void apply(
       const SelectivityVector& rows,
@@ -130,9 +145,9 @@ class MakeTimestampFunction : public exec::VectorFunction {
           context.setErrors(rows, std::current_exception());
           return;
         }
-        rows.applyToSelected([&](vector_size_t row) {
+        context.applyToSelectedNoThrow(rows, [&](auto row) {
           auto timestamp = makeTimeStampFromDecodedArgs(
-              row, year, month, day, hour, minute, micros);
+              row, year, month, day, hour, minute, micros, ansiEnabled_);
           setTimestampOrNull(
               row, timestamp, constantTimeZone, resultFlatVector);
         });
@@ -140,15 +155,15 @@ class MakeTimestampFunction : public exec::VectorFunction {
         auto* timeZone = decodedArgs.at(6);
         context.applyToSelectedNoThrow(rows, [&](auto row) {
           auto timestamp = makeTimeStampFromDecodedArgs(
-              row, year, month, day, hour, minute, micros);
+              row, year, month, day, hour, minute, micros, ansiEnabled_);
           setTimestampOrNull(row, timestamp, timeZone, resultFlatVector);
         });
       }
     } else {
       // Otherwise use session timezone.
-      rows.applyToSelected([&](vector_size_t row) {
+      context.applyToSelectedNoThrow(rows, [&](auto row) {
         auto timestamp = makeTimeStampFromDecodedArgs(
-            row, year, month, day, hour, minute, micros);
+            row, year, month, day, hour, minute, micros, ansiEnabled_);
         setTimestampOrNull(row, timestamp, sessionTimeZone_, resultFlatVector);
       });
     }
@@ -184,6 +199,7 @@ class MakeTimestampFunction : public exec::VectorFunction {
 
  private:
   const tz::TimeZone* sessionTimeZone_;
+  const bool ansiEnabled_;
 };
 
 std::shared_ptr<exec::VectorFunction> createMakeTimestampFunction(
@@ -208,7 +224,8 @@ std::shared_ptr<exec::VectorFunction> createMakeTimestampFunction(
       "Seconds fraction must have 6 digits for microseconds but got {}",
       secondsScale);
 
-  return std::make_shared<MakeTimestampFunction>(sessionTimeZone);
+  const bool ansiEnabled = SparkQueryConfig{config}.ansiEnabled();
+  return std::make_shared<MakeTimestampFunction>(sessionTimeZone, ansiEnabled);
 }
 } // namespace
 

--- a/velox/functions/sparksql/MakeTimestamp.cpp
+++ b/velox/functions/sparksql/MakeTimestamp.cpp
@@ -36,13 +36,13 @@ std::optional<Timestamp> makeTimeStampFromDecodedArgs(
   // Check hour.
   auto hour = hourVector->valueAt<int32_t>(row);
   if (hour < 0 || hour >= 24) {
-    VELOX_SPARK_RETURN_NULL_OR_FAIL(
+    return nullOrUserFail(
         ansiEnabled, "Invalid value for hour, must be in [0, 24): {}", hour);
   }
   // Check minute.
   auto minute = minuteVector->valueAt<int32_t>(row);
   if (minute < 0 || minute >= 60) {
-    VELOX_SPARK_RETURN_NULL_OR_FAIL(
+    return nullOrUserFail(
         ansiEnabled,
         "Invalid value for minute, must be in [0, 60): {}",
         minute);
@@ -50,14 +50,14 @@ std::optional<Timestamp> makeTimeStampFromDecodedArgs(
   // Check microseconds.
   auto micros = microsVector->valueAt<int64_t>(row);
   if (micros < 0) {
-    VELOX_SPARK_RETURN_NULL_OR_FAIL(
+    return nullOrUserFail(
         ansiEnabled,
         "Invalid value for second microseconds, must be non-negative: {}",
         micros);
   }
   auto seconds = micros / util::kMicrosPerSec;
   if (seconds > 60 || (seconds == 60 && micros % util::kMicrosPerSec != 0)) {
-    VELOX_SPARK_RETURN_NULL_OR_FAIL(
+    return nullOrUserFail(
         ansiEnabled,
         "Invalid value for second, must be in [0, 60] with 0 microseconds at 60: {}.{:06d}",
         seconds,
@@ -71,8 +71,7 @@ std::optional<Timestamp> makeTimeStampFromDecodedArgs(
       dayVector->valueAt<int32_t>(row));
   if (daysSinceEpoch.hasError()) {
     VELOX_DCHECK(daysSinceEpoch.error().isUserError());
-    VELOX_SPARK_RETURN_NULL_OR_FAIL(
-        ansiEnabled, "{}", daysSinceEpoch.error().message());
+    return nullOrUserFail(ansiEnabled, "{}", daysSinceEpoch.error().message());
   }
 
   // Micros has at most 8 digits (2 for seconds + 6 for microseconds),
@@ -110,8 +109,7 @@ std::optional<Timestamp> makeTimestampWithTimeZone(
     return std::nullopt;
   }
   if (timeZone == nullptr) {
-    VELOX_SPARK_RETURN_NULL_OR_FAIL(
-        ansiEnabled, "Unknown time zone: '{}'", timeZoneName);
+    return nullOrUserFail(ansiEnabled, "Unknown time zone: '{}'", timeZoneName);
   }
   toGMTWithGapCorrection(timestamp.value(), *timeZone);
   return timestamp;

--- a/velox/functions/sparksql/MakeTimestamp.cpp
+++ b/velox/functions/sparksql/MakeTimestamp.cpp
@@ -82,28 +82,46 @@ std::optional<Timestamp> makeTimeStampFromDecodedArgs(
   return util::fromDatetime(daysSinceEpoch.value(), localMicros);
 }
 
-void setTimestampOrNull(
-    int32_t row,
-    std::optional<Timestamp> timestamp,
-    DecodedVector* timeZoneVector,
-    FlatVector<Timestamp>* result) {
-  const auto timeZoneName = timeZoneVector->valueAt<StringView>(row);
-  const auto* timeZone = tz::locateZone(std::string_view(timeZoneName));
-  if (timestamp.has_value()) {
-    toGMTWithGapCorrection(timestamp.value(), *timeZone);
-    result->set(row, *timestamp);
-  } else {
-    result->setNull(row, true);
+// Builds the timestamp from the datetime fields and adjusts it to GMT using
+// 'timeZone'. 'timeZone' is nullptr when the timezone argument did not resolve
+// to a known zone; this follows the same ANSI rule as invalid datetime fields.
+// Fields are validated before the timezone to match Spark's evaluation order.
+std::optional<Timestamp> makeTimestampWithTimeZone(
+    vector_size_t row,
+    DecodedVector* yearVector,
+    DecodedVector* monthVector,
+    DecodedVector* dayVector,
+    DecodedVector* hourVector,
+    DecodedVector* minuteVector,
+    DecodedVector* microsVector,
+    const tz::TimeZone* timeZone,
+    std::string_view timeZoneName,
+    bool ansiEnabled) {
+  auto timestamp = makeTimeStampFromDecodedArgs(
+      row,
+      yearVector,
+      monthVector,
+      dayVector,
+      hourVector,
+      minuteVector,
+      microsVector,
+      ansiEnabled);
+  if (!timestamp.has_value()) {
+    return std::nullopt;
   }
+  if (timeZone == nullptr) {
+    VELOX_SPARK_RETURN_NULL_OR_FAIL(
+        ansiEnabled, "Unknown time zone: '{}'", timeZoneName);
+  }
+  toGMTWithGapCorrection(timestamp.value(), *timeZone);
+  return timestamp;
 }
 
 void setTimestampOrNull(
     int32_t row,
     std::optional<Timestamp> timestamp,
-    const tz::TimeZone* timeZone,
     FlatVector<Timestamp>* result) {
   if (timestamp.has_value()) {
-    toGMTWithGapCorrection(timestamp.value(), *timeZone);
     result->set(row, *timestamp);
   } else {
     result->setNull(row, true);
@@ -136,35 +154,60 @@ class MakeTimestampFunction : public exec::VectorFunction {
       // If the timezone argument is specified, treat the input timestamp as the
       // time in that timezone.
       if (args[6]->isConstantEncoding()) {
-        auto tz =
+        const auto timeZoneName =
             args[6]->asUnchecked<ConstantVector<StringView>>()->valueAt(0);
-        const tz::TimeZone* constantTimeZone = nullptr;
-        try {
-          constantTimeZone = tz::locateZone(std::string_view(tz));
-        } catch (const VeloxException&) {
-          context.setErrors(rows, std::current_exception());
-          return;
-        }
+        const auto* constantTimeZone = tz::locateZone(
+            std::string_view(timeZoneName), /*failOnError=*/false);
         context.applyToSelectedNoThrow(rows, [&](auto row) {
-          auto timestamp = makeTimeStampFromDecodedArgs(
-              row, year, month, day, hour, minute, micros, ansiEnabled_);
-          setTimestampOrNull(
-              row, timestamp, constantTimeZone, resultFlatVector);
+          auto timestamp = makeTimestampWithTimeZone(
+              row,
+              year,
+              month,
+              day,
+              hour,
+              minute,
+              micros,
+              constantTimeZone,
+              std::string_view(timeZoneName),
+              ansiEnabled_);
+          setTimestampOrNull(row, timestamp, resultFlatVector);
         });
       } else {
         auto* timeZone = decodedArgs.at(6);
         context.applyToSelectedNoThrow(rows, [&](auto row) {
-          auto timestamp = makeTimeStampFromDecodedArgs(
-              row, year, month, day, hour, minute, micros, ansiEnabled_);
-          setTimestampOrNull(row, timestamp, timeZone, resultFlatVector);
+          const auto timeZoneName = timeZone->valueAt<StringView>(row);
+          const auto* rowTimeZone = tz::locateZone(
+              std::string_view(timeZoneName), /*failOnError=*/false);
+          auto timestamp = makeTimestampWithTimeZone(
+              row,
+              year,
+              month,
+              day,
+              hour,
+              minute,
+              micros,
+              rowTimeZone,
+              std::string_view(timeZoneName),
+              ansiEnabled_);
+          setTimestampOrNull(row, timestamp, resultFlatVector);
         });
       }
     } else {
-      // Otherwise use session timezone.
+      // Otherwise use session timezone, which is validated at function
+      // creation and is never null.
       context.applyToSelectedNoThrow(rows, [&](auto row) {
-        auto timestamp = makeTimeStampFromDecodedArgs(
-            row, year, month, day, hour, minute, micros, ansiEnabled_);
-        setTimestampOrNull(row, timestamp, sessionTimeZone_, resultFlatVector);
+        auto timestamp = makeTimestampWithTimeZone(
+            row,
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            micros,
+            sessionTimeZone_,
+            /*timeZoneName=*/{},
+            ansiEnabled_);
+        setTimestampOrNull(row, timestamp, resultFlatVector);
       });
     }
   }

--- a/velox/functions/sparksql/tests/MakeTimestampTest.cpp
+++ b/velox/functions/sparksql/tests/MakeTimestampTest.cpp
@@ -30,16 +30,6 @@ class MakeTimestampTest : public SparkFunctionBaseTest {
         {core::QueryConfig::kAdjustTimestampToTimezone, "true"},
     });
   }
-
-  void setAnsiEnabled(bool enabled) {
-    // testingOverrideConfigUnsafe replaces the entire config, so merge with
-    // existing values to avoid wiping out the session timezone or other
-    // settings established by setQueryTimeZone.
-    auto config = queryCtx_->queryConfig().rawConfigsCopy();
-    config[SparkQueryConfig::qualify(SparkQueryConfig::kAnsiEnabled)] =
-        enabled ? "true" : "false";
-    queryCtx_->testingOverrideConfigUnsafe(std::move(config));
-  }
 };
 
 TEST_F(MakeTimestampTest, basic) {
@@ -159,9 +149,7 @@ TEST_F(MakeTimestampTest, errors) {
       "make_timestamp requires session time zone to be set.");
 
   setQueryTimeZone("Asia/Shanghai");
-  // ANSI off: invalid input returns NULL instead of throwing.
-  setAnsiEnabled(false);
-  // Invalid input returns null.
+  // Invalid input returns null (ANSI is off by default).
   const auto year = makeFlatVector<int32_t>(
       {facebook::velox::util::kMinYear - 1,
        facebook::velox::util::kMaxYear + 1,
@@ -204,8 +192,11 @@ TEST_F(MakeTimestampTest, ansiErrors) {
   // Under ANSI mode each invalid argument throws with a field-specific
   // message rather than returning NULL.
   const auto microsType = DECIMAL(16, 6);
-  setQueryTimeZone("Asia/Shanghai");
-  setAnsiEnabled(true);
+  queryCtx_->testingOverrideConfigUnsafe({
+      {core::QueryConfig::kSessionTimezone, "Asia/Shanghai"},
+      {core::QueryConfig::kAdjustTimestampToTimezone, "true"},
+      {SparkQueryConfig::qualify(SparkQueryConfig::kAnsiEnabled), "true"},
+  });
 
   const auto eval = [&](int32_t year,
                         int32_t month,

--- a/velox/functions/sparksql/tests/MakeTimestampTest.cpp
+++ b/velox/functions/sparksql/tests/MakeTimestampTest.cpp
@@ -32,9 +32,13 @@ class MakeTimestampTest : public SparkFunctionBaseTest {
   }
 
   void setAnsiEnabled(bool enabled) {
-    queryCtx_->testingOverrideConfigUnsafe(
-        {{SparkQueryConfig::qualify(SparkQueryConfig::kAnsiEnabled),
-          enabled ? "true" : "false"}});
+    // testingOverrideConfigUnsafe replaces the entire config, so merge with
+    // existing values to avoid wiping out the session timezone or other
+    // settings established by setQueryTimeZone.
+    auto config = queryCtx_->queryConfig().rawConfigsCopy();
+    config[SparkQueryConfig::qualify(SparkQueryConfig::kAnsiEnabled)] =
+        enabled ? "true" : "false";
+    queryCtx_->testingOverrideConfigUnsafe(std::move(config));
   }
 };
 

--- a/velox/functions/sparksql/tests/MakeTimestampTest.cpp
+++ b/velox/functions/sparksql/tests/MakeTimestampTest.cpp
@@ -261,14 +261,17 @@ TEST_F(MakeTimestampTest, ansiErrors) {
 }
 
 TEST_F(MakeTimestampTest, invalidTimezone) {
+  // Use valid datetime fields throughout so the timezone is the only invalid
+  // argument. Fields are validated before the timezone, so an invalid field
+  // would mask the timezone error under ANSI mode.
   const auto microsType = DECIMAL(16, 6);
-  const auto year = makeFlatVector<int32_t>({2021, 2021, 2021, 2021, 2021});
-  const auto month = makeFlatVector<int32_t>({7, 7, 7, 7, 7});
-  const auto day = makeFlatVector<int32_t>({11, 11, 11, 11, 11});
-  const auto hour = makeFlatVector<int32_t>({6, 6, 6, -6, 6});
-  const auto minute = makeFlatVector<int32_t>({30, 30, 30, 30, 30});
-  const auto micros = makeNullableFlatVector<int64_t>(
-      {45678000, 1e6, 6e7, 59999999, std::nullopt}, microsType);
+  const auto year = makeFlatVector<int32_t>({2021, 2021, 2021});
+  const auto month = makeFlatVector<int32_t>({7, 7, 7});
+  const auto day = makeFlatVector<int32_t>({11, 11, 11});
+  const auto hour = makeFlatVector<int32_t>({6, 6, 6});
+  const auto minute = makeFlatVector<int32_t>({30, 30, 30});
+  const auto micros = makeFlatVector<int64_t>(
+      {45'678'000, 1'000'000, 60'000'000}, microsType);
   auto data = makeRowVector({year, month, day, hour, minute, micros});
 
   // Time zone is not set.
@@ -276,8 +279,33 @@ TEST_F(MakeTimestampTest, invalidTimezone) {
       evaluate("make_timestamp(c0, c1, c2, c3, c4, c5)", data),
       "make_timestamp requires session time zone to be set.");
 
-  // Invalid constant time zone.
+  const auto allNull = makeNullableFlatVector<Timestamp>(
+      {std::nullopt, std::nullopt, std::nullopt});
+  const auto invalidTimeZones =
+      makeFlatVector<StringView>({"Invalid", "", "Bad/Zone"});
+  auto dataWithTimeZones =
+      makeRowVector({year, month, day, hour, minute, micros, invalidTimeZones});
+
+  // ANSI off: invalid timezone yields NULL, matching Spark's codegen
+  // semantics.
   setQueryTimeZone("GMT");
+  for (auto timeZone : {"Invalid", ""}) {
+    SCOPED_TRACE(fmt::format("timezone: {}", timeZone));
+    auto result = evaluate(
+        fmt::format("make_timestamp(c0, c1, c2, c3, c4, c5, '{}')", timeZone),
+        data);
+    facebook::velox::test::assertEqualVectors(allNull, result);
+  }
+  auto result =
+      evaluate("make_timestamp(c0, c1, c2, c3, c4, c5, c6)", dataWithTimeZones);
+  facebook::velox::test::assertEqualVectors(allNull, result);
+
+  // ANSI on: invalid timezone throws.
+  queryCtx_->testingOverrideConfigUnsafe({
+      {core::QueryConfig::kSessionTimezone, "GMT"},
+      {core::QueryConfig::kAdjustTimestampToTimezone, "true"},
+      {SparkQueryConfig::qualify(SparkQueryConfig::kAnsiEnabled), "true"},
+  });
   for (auto timeZone : {"Invalid", ""}) {
     SCOPED_TRACE(fmt::format("timezone: {}", timeZone));
     VELOX_ASSERT_USER_THROW(
@@ -287,21 +315,9 @@ TEST_F(MakeTimestampTest, invalidTimezone) {
             data),
         fmt::format("Unknown time zone: '{}'", timeZone));
   }
-
-  // Invalid timezone from vector.
-  auto timeZones = makeFlatVector<StringView>(
-      {"GMT", "CET", "Asia/Shanghai", "Invalid", "GMT"});
-  data = makeRowVector({year, month, day, hour, minute, micros, timeZones});
   VELOX_ASSERT_USER_THROW(
-      evaluate("make_timestamp(c0, c1, c2, c3, c4, c5, c6)", data),
+      evaluate("make_timestamp(c0, c1, c2, c3, c4, c5, c6)", dataWithTimeZones),
       "Unknown time zone: 'Invalid'");
-
-  timeZones =
-      makeFlatVector<StringView>({"GMT", "CET", "Asia/Shanghai", "", "GMT"});
-  data = makeRowVector({year, month, day, hour, minute, micros, timeZones});
-  VELOX_ASSERT_USER_THROW(
-      evaluate("make_timestamp(c0, c1, c2, c3, c4, c5, c6)", data),
-      "Unknown time zone: ''");
 }
 
 } // namespace

--- a/velox/functions/sparksql/tests/MakeTimestampTest.cpp
+++ b/velox/functions/sparksql/tests/MakeTimestampTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/sparksql/SparkQueryConfig.h"
 #include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
 #include "velox/type/tz/TimeZoneMap.h"
 
@@ -28,6 +29,12 @@ class MakeTimestampTest : public SparkFunctionBaseTest {
         {core::QueryConfig::kSessionTimezone, timeZone},
         {core::QueryConfig::kAdjustTimestampToTimezone, "true"},
     });
+  }
+
+  void setAnsiEnabled(bool enabled) {
+    queryCtx_->testingOverrideConfigUnsafe(
+        {{SparkQueryConfig::qualify(SparkQueryConfig::kAnsiEnabled),
+          enabled ? "true" : "false"}});
   }
 };
 
@@ -148,6 +155,8 @@ TEST_F(MakeTimestampTest, errors) {
       "make_timestamp requires session time zone to be set.");
 
   setQueryTimeZone("Asia/Shanghai");
+  // ANSI off: invalid input returns NULL instead of throwing.
+  setAnsiEnabled(false);
   // Invalid input returns null.
   const auto year = makeFlatVector<int32_t>(
       {facebook::velox::util::kMinYear - 1,
@@ -185,6 +194,75 @@ TEST_F(MakeTimestampTest, errors) {
       "Scalar function signature is not supported: "
       "make_timestamp(INTEGER, INTEGER, INTEGER, INTEGER, INTEGER, "
       "DECIMAL(16, 8)).");
+}
+
+TEST_F(MakeTimestampTest, ansiErrors) {
+  // Under ANSI mode each invalid argument throws with a field-specific
+  // message rather than returning NULL.
+  const auto microsType = DECIMAL(16, 6);
+  setQueryTimeZone("Asia/Shanghai");
+  setAnsiEnabled(true);
+
+  const auto eval = [&](int32_t year,
+                        int32_t month,
+                        int32_t day,
+                        int32_t hour,
+                        int32_t minute,
+                        int64_t micros) {
+    return evaluateOnce<Timestamp>(
+        "make_timestamp(c0, c1, c2, c3, c4, c5)",
+        {INTEGER(), INTEGER(), INTEGER(), INTEGER(), INTEGER(), microsType},
+        std::optional<int32_t>(year),
+        std::optional<int32_t>(month),
+        std::optional<int32_t>(day),
+        std::optional<int32_t>(hour),
+        std::optional<int32_t>(minute),
+        std::optional<int64_t>(micros));
+  };
+
+  // Hour out of range.
+  VELOX_ASSERT_USER_THROW(
+      eval(2021, 7, 11, 24, 30, 0),
+      "Invalid value for hour, must be in [0, 24): 24");
+  VELOX_ASSERT_USER_THROW(
+      eval(2021, 7, 11, -1, 30, 0),
+      "Invalid value for hour, must be in [0, 24): -1");
+  VELOX_ASSERT_USER_THROW(
+      eval(2021, 7, 11, 25, 30, 0),
+      "Invalid value for hour, must be in [0, 24): 25");
+
+  // Minute out of range.
+  VELOX_ASSERT_USER_THROW(
+      eval(2021, 7, 11, 6, 60, 0),
+      "Invalid value for minute, must be in [0, 60): 60");
+  VELOX_ASSERT_USER_THROW(
+      eval(2021, 7, 11, 6, -1, 0),
+      "Invalid value for minute, must be in [0, 60): -1");
+
+  // Negative microseconds.
+  VELOX_ASSERT_USER_THROW(
+      eval(2021, 7, 11, 6, 30, -1),
+      "Invalid value for second microseconds, must be non-negative: -1");
+
+  // Seconds out of range.
+  VELOX_ASSERT_USER_THROW(
+      eval(2021, 7, 11, 6, 30, 61'000'000),
+      "Invalid value for second, must be in [0, 60] with 0 microseconds at 60: 61.000000");
+  VELOX_ASSERT_USER_THROW(
+      eval(2021, 7, 11, 6, 30, 60'007'000),
+      "Invalid value for second, must be in [0, 60] with 0 microseconds at 60: 60.007000");
+
+  // Invalid date components.
+  VELOX_ASSERT_USER_THROW(eval(2021, 0, 11, 6, 30, 0), "Date out of range");
+  VELOX_ASSERT_USER_THROW(eval(2021, 13, 11, 6, 30, 0), "Date out of range");
+  VELOX_ASSERT_USER_THROW(eval(2021, 7, 0, 6, 30, 0), "Date out of range");
+  VELOX_ASSERT_USER_THROW(eval(2021, 7, 32, 6, 30, 0), "Date out of range");
+  VELOX_ASSERT_USER_THROW(
+      eval(facebook::velox::util::kMinYear - 1, 7, 11, 6, 30, 0),
+      "Date out of range");
+  VELOX_ASSERT_USER_THROW(
+      eval(facebook::velox::util::kMaxYear + 1, 7, 11, 6, 30, 0),
+      "Date out of range");
 }
 
 TEST_F(MakeTimestampTest, invalidTimezone) {

--- a/velox/functions/sparksql/tests/MakeTimestampTest.cpp
+++ b/velox/functions/sparksql/tests/MakeTimestampTest.cpp
@@ -270,8 +270,8 @@ TEST_F(MakeTimestampTest, invalidTimezone) {
   const auto day = makeFlatVector<int32_t>({11, 11, 11});
   const auto hour = makeFlatVector<int32_t>({6, 6, 6});
   const auto minute = makeFlatVector<int32_t>({30, 30, 30});
-  const auto micros = makeFlatVector<int64_t>(
-      {45'678'000, 1'000'000, 60'000'000}, microsType);
+  const auto micros =
+      makeFlatVector<int64_t>({45'678'000, 1'000'000, 60'000'000}, microsType);
   auto data = makeRowVector({year, month, day, hour, minute, micros});
 
   // Time zone is not set.


### PR DESCRIPTION
## Summary

Wires `spark.ansi_enabled` into `make_timestamp`. When ANSI is on, invalid year/month/day/hour/minute/second/timezone values throw a user error with a field-specific message instead of returning NULL. When ANSI is off, invalid inputs return NULL (the previous behavior, except invalid timezones, which used to throw unconditionally — Spark's codegen path returns NULL for them with ANSI off).

Also introduces `velox/functions/sparksql/AnsiMode.h` with the `VELOX_SPARK_RETURN_NULL_OR_FAIL` macro (folded in from #17744), which collapses the standard "throw under ANSI, return NULL otherwise" branch into one line. All five validation sites in `make_timestamp` use it; the row loops in `apply()` contain no ANSI branching or try/catch. The ANSI work queued in apache/incubator-gluten#10134 is expected to adopt the same helper.

Fields are validated before the timezone, matching Spark's evaluation order (`LocalDateTime.of` before `atZone`).

Tracks apache/incubator-gluten#10134 section 3 (Date/Time Functions — ANSI Validation).

## Test plan
- [x] `MakeTimestampTest.ansiErrors` covers each validation site under ANSI.
- [x] `MakeTimestampTest.errors` covers NULL behavior with ANSI off.
- [x] `MakeTimestampTest.invalidTimezone` covers invalid timezones under both modes.
- [x] CI verifies full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)