### PR TITLE
perf: Coalesce exact duplicate IO ranges

### DIFF
--- a/velox/common/base/CoalesceIo.h
+++ b/velox/common/base/CoalesceIo.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cstdint>
+#include <type_traits>
 #include <vector>
 
 #include "velox/common/base/IoCounter.h"
@@ -57,6 +58,7 @@ static constexpr int32_t kNoCoalesce = -1;
 template <
     typename Item,
     typename Range,
+    bool coalesceDuplicateRanges,
     typename ItemOffset,
     typename ItemSize,
     typename ItemNumRanges,
@@ -76,6 +78,8 @@ CoalesceIoStats coalesceIo(
   int32_t startItem = 0;
   auto startOffset = offsetFunc(startItem);
   auto lastEndOffset = startOffset;
+  auto prevItemOffset = startOffset;
+  std::decay_t<decltype(sizeFunc(startItem))> prevItemSize{};
   std::vector<Range> ranges;
   CoalesceIoStats result;
   for (int32_t i = 0; i < items.size(); ++i) {
@@ -88,7 +92,12 @@ CoalesceIoStats coalesceIo(
         (numRangesForItem == kNoCoalesce ||
          ranges.size() + numRangesForItem >= rangesPerIo) &&
         !ranges.empty();
-    if ((lastEndOffset != itemOffset) || enoughRanges) {
+    // Some callers, e.g. Nimble Velox writer stream deduplication, can produce
+    // adjacent logical reads for the same physical range. Keep exact duplicates
+    // in the same IO only when the caller can map them to the same bytes.
+    const bool duplicateRange = coalesceDuplicateRanges && i > 0 &&
+        itemOffset == prevItemOffset && itemSize == prevItemSize;
+    if (!duplicateRange && (lastEndOffset != itemOffset || enoughRanges)) {
       const int64_t gap = itemOffset - lastEndOffset;
       if (gap > 0) {
         result.gaps.increment(gap);
@@ -108,6 +117,8 @@ CoalesceIoStats coalesceIo(
     }
     addRanges(item, ranges);
     lastEndOffset = itemOffset + itemSize;
+    prevItemOffset = itemOffset;
+    prevItemSize = itemSize;
   }
   ioFunc(items, startItem, items.size(), startOffset, ranges);
   ++result.numIos;

--- a/velox/common/base/tests/CoalesceIoTest.cpp
+++ b/velox/common/base/tests/CoalesceIoTest.cpp
@@ -67,7 +67,7 @@ TEST(CoalesceIoTest, basic) {
   // process together.
   std::vector<std::vector<int32_t>> ioGroups;
 
-  auto stats = coalesceIo<IoUnit, Range>(
+  auto stats = coalesceIo<IoUnit, Range, /*coalesceDuplicateRanges=*/false>(
       data,
       20000,
       8,
@@ -126,6 +126,119 @@ TEST(CoalesceIoTest, basic) {
   EXPECT_EQ(270'000, stats.gaps.max());
 }
 
+TEST(CoalesceIoTest, exactDuplicateRangesCoalesce) {
+  std::vector<IoUnit> data;
+  data.emplace_back(1000, 100, 1);
+  data.emplace_back(1000, 100, 1);
+  data.emplace_back(1100, 50, 1);
+
+  std::vector<std::vector<int32_t>> ioGroups;
+  auto stats = coalesceIo<IoUnit, Range, /*coalesceDuplicateRanges=*/true>(
+      data,
+      1,
+      10,
+      [&](int32_t i) { return data[i].offset; },
+      [&](int32_t i) { return data[i].size; },
+      [&](int32_t) { return 1; },
+      [&](const IoUnit& item, std::vector<Range>& ranges) {
+        ranges.emplace_back(item.size, 1);
+      },
+      [&](int32_t skip, std::vector<Range>& ranges) {
+        ranges.emplace_back(skip, 0);
+      },
+      [&](const std::vector<IoUnit>&,
+          int32_t begin,
+          int32_t end,
+          uint64_t,
+          const std::vector<Range>&) {
+        ioGroups.emplace_back();
+        for (auto i = begin; i < end; ++i) {
+          ioGroups.back().push_back(i);
+        }
+      });
+
+  EXPECT_EQ(stats.numIos, 1);
+  EXPECT_EQ(stats.payloadBytes, 250);
+  EXPECT_EQ(stats.extraBytes, 0);
+  EXPECT_EQ(stats.gaps.count(), 0);
+  ASSERT_EQ(ioGroups.size(), 1);
+  EXPECT_EQ(ioGroups[0], (std::vector<int32_t>{0, 1, 2}));
+}
+
+TEST(CoalesceIoTest, exactDuplicateRangesDoNotCoalesceByDefault) {
+  std::vector<IoUnit> data;
+  data.emplace_back(1000, 100, 1);
+  data.emplace_back(1000, 100, 1);
+  data.emplace_back(1100, 50, 1);
+
+  std::vector<std::vector<int32_t>> ioGroups;
+  auto stats = coalesceIo<IoUnit, Range, /*coalesceDuplicateRanges=*/false>(
+      data,
+      1,
+      10,
+      [&](int32_t i) { return data[i].offset; },
+      [&](int32_t i) { return data[i].size; },
+      [&](int32_t) { return 1; },
+      [&](const IoUnit& item, std::vector<Range>& ranges) {
+        ranges.emplace_back(item.size, 1);
+      },
+      [&](int32_t skip, std::vector<Range>& ranges) {
+        ranges.emplace_back(skip, 0);
+      },
+      [&](const std::vector<IoUnit>&,
+          int32_t begin,
+          int32_t end,
+          uint64_t,
+          const std::vector<Range>&) {
+        ioGroups.emplace_back();
+        for (auto i = begin; i < end; ++i) {
+          ioGroups.back().push_back(i);
+        }
+      });
+
+  EXPECT_EQ(stats.numIos, 2);
+  ASSERT_EQ(ioGroups.size(), 2);
+  EXPECT_EQ(ioGroups[0], (std::vector<int32_t>{0}));
+  EXPECT_EQ(ioGroups[1], (std::vector<int32_t>{1, 2}));
+}
+
+TEST(CoalesceIoTest, exactDuplicateRangesIgnoreRangeLimitWhenEnabled) {
+  std::vector<IoUnit> data;
+  data.emplace_back(1000, 100, 1);
+  data.emplace_back(1000, 100, 1);
+  data.emplace_back(1100, 50, 1);
+
+  std::vector<std::vector<int32_t>> ioGroups;
+  auto stats = coalesceIo<IoUnit, Range, /*coalesceDuplicateRanges=*/true>(
+      data,
+      1,
+      2,
+      [&](int32_t i) { return data[i].offset; },
+      [&](int32_t i) { return data[i].size; },
+      [&](int32_t) { return 1; },
+      [&](const IoUnit& item, std::vector<Range>& ranges) {
+        ranges.emplace_back(item.size, 1);
+      },
+      [&](int32_t skip, std::vector<Range>& ranges) {
+        ranges.emplace_back(skip, 0);
+      },
+      [&](const std::vector<IoUnit>&,
+          int32_t begin,
+          int32_t end,
+          uint64_t,
+          const std::vector<Range>&) {
+        ioGroups.emplace_back();
+        for (auto i = begin; i < end; ++i) {
+          ioGroups.back().push_back(i);
+        }
+      });
+
+  EXPECT_EQ(stats.numIos, 2);
+  ASSERT_EQ(ioGroups.size(), 2);
+  EXPECT_EQ(ioGroups[0], (std::vector<int32_t>{0, 1}));
+  EXPECT_EQ(ioGroups[1], (std::vector<int32_t>{2}));
+}
+
 TEST(CoalesceIoTest, gaps) {
   struct TestParam {
     std::vector<IoUnit> data;
@@ -174,7 +287,7 @@ TEST(CoalesceIoTest, gaps) {
     SCOPED_TRACE(testData.debugString());
 
     const auto& data = testData.data;
-    auto stats = coalesceIo<IoUnit, Range>(
+    auto stats = coalesceIo<IoUnit, Range, /*coalesceDuplicateRanges=*/false>(
         data,
         testData.maxGap,
         10,

--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -1203,7 +1203,10 @@ CoalesceIoStats readPins(
         int32_t end,
         uint64_t offset,
         const std::vector<folly::Range<char*>>& buffers)> readFunc) {
-  return coalesceIo<CachePin, folly::Range<char*>>(
+  return coalesceIo<
+      CachePin,
+      folly::Range<char*>,
+      /*coalesceDuplicateRanges=*/false>(
       pins,
       maxGap,
       rangesPerIo,

--- a/velox/dwio/common/CachedBufferedInput.cpp
+++ b/velox/dwio/common/CachedBufferedInput.cpp
@@ -301,32 +301,33 @@ std::vector<int32_t> CachedBufferedInput::groupRequests(
   std::vector<int32_t> ends;
   ends.reserve(requests.size());
   std::vector<char> ranges;
-  const auto stats = coalesceIo<CacheRequest*, char>(
-      requests,
-      maxDistance,
-      std::numeric_limits<int32_t>::max(),
-      [&](int32_t index) { return getOffset<kSsd>(*requests[index]); },
-      [&](int32_t index) {
-        const auto size = requests[index]->size;
-        coalescedBytes += size;
-        return size;
-      },
-      [&](int32_t index) {
-        if (coalescedBytes > options_.maxCoalesceBytes()) {
-          coalescedBytes = 0;
-          return kNoCoalesce;
-        }
-        return requests[index]->coalesces ? 1 : kNoCoalesce;
-      },
-      [&](CacheRequest* /*request*/, std::vector<char>& ranges) {
-        ranges.push_back(0);
-      },
-      [&](int32_t /*gap*/, std::vector<char> /*ranges*/) { /*no op*/ },
-      [&](const std::vector<CacheRequest*>& /*requests*/,
-          int32_t /*begin*/,
-          int32_t end,
-          uint64_t /*offset*/,
-          const std::vector<char>& /*ranges*/) { ends.push_back(end); });
+  const auto stats =
+      coalesceIo<CacheRequest*, char, /*coalesceDuplicateRanges=*/false>(
+          requests,
+          maxDistance,
+          std::numeric_limits<int32_t>::max(),
+          [&](int32_t index) { return getOffset<kSsd>(*requests[index]); },
+          [&](int32_t index) {
+            const auto size = requests[index]->size;
+            coalescedBytes += size;
+            return size;
+          },
+          [&](int32_t index) {
+            if (coalescedBytes > options_.maxCoalesceBytes()) {
+              coalescedBytes = 0;
+              return kNoCoalesce;
+            }
+            return requests[index]->coalesces ? 1 : kNoCoalesce;
+          },
+          [&](CacheRequest* /*request*/, std::vector<char>& ranges) {
+            ranges.push_back(0);
+          },
+          [&](int32_t /*gap*/, std::vector<char> /*ranges*/) { /*no op*/ },
+          [&](const std::vector<CacheRequest*>& /*requests*/,
+              int32_t /*begin*/,
+              int32_t end,
+              uint64_t /*offset*/,
+              const std::vector<char>& /*ranges*/) { ends.push_back(end); });
   ioStatistics_->readGap().merge(stats.gaps);
   return ends;
 }

--- a/velox/dwio/common/DirectBufferedInput.cpp
+++ b/velox/dwio/common/DirectBufferedInput.cpp
@@ -150,38 +150,40 @@ std::vector<int32_t> DirectBufferedInput::groupRequests(
   std::vector<int32_t> ends;
   ends.reserve(requests.size());
   std::vector<char> ranges;
-  const auto stats = coalesceIo<LoadRequest*, char>(
-      requests,
-      maxDistance,
-      // Break batches up. Better load more short ones i parallel.
-      std::numeric_limits<int32_t>::max(), // limit coalesce by size, not count.
-      [&](int32_t index) { return requests[index]->region.offset; },
-      [&](int32_t index) -> int32_t {
-        auto size = requests[index]->region.length;
-        if (size > loadQuantum) {
-          coalescedBytes += loadQuantum;
-          return loadQuantum;
-        }
-        coalescedBytes += size;
-        return size;
-      },
-      [&](int32_t index) {
-        if (coalescedBytes > maxCoalesceBytes) {
-          coalescedBytes = 0;
-          return kNoCoalesce;
-        }
-        return 1;
-      },
-      [&](LoadRequest* /*request*/, std::vector<char>& ranges) {
-        // ranges.size() is used in coalesceIo so we cannot leave it empty.
-        ranges.push_back(0);
-      },
-      [&](int32_t /*gap*/, std::vector<char> /*ranges*/) { /*no op*/ },
-      [&](const std::vector<LoadRequest*>& /*requests*/,
-          int32_t /*begin*/,
-          int32_t end,
-          uint64_t /*offset*/,
-          const std::vector<char>& /*ranges*/) { ends.push_back(end); });
+  const auto stats =
+      coalesceIo<LoadRequest*, char, /*coalesceDuplicateRanges=*/false>(
+          requests,
+          maxDistance,
+          // Break batches up. Better load more short ones i parallel.
+          std::numeric_limits<int32_t>::max(), // limit coalesce by size, not
+                                               // count.
+          [&](int32_t index) { return requests[index]->region.offset; },
+          [&](int32_t index) -> int32_t {
+            auto size = requests[index]->region.length;
+            if (size > loadQuantum) {
+              coalescedBytes += loadQuantum;
+              return loadQuantum;
+            }
+            coalescedBytes += size;
+            return size;
+          },
+          [&](int32_t index) {
+            if (coalescedBytes > maxCoalesceBytes) {
+              coalescedBytes = 0;
+              return kNoCoalesce;
+            }
+            return 1;
+          },
+          [&](LoadRequest* /*request*/, std::vector<char>& ranges) {
+            // ranges.size() is used in coalesceIo so we cannot leave it empty.
+            ranges.push_back(0);
+          },
+          [&](int32_t /*gap*/, std::vector<char> /*ranges*/) { /*no op*/ },
+          [&](const std::vector<LoadRequest*>& /*requests*/,
+              int32_t /*begin*/,
+              int32_t end,
+              uint64_t /*offset*/,
+              const std::vector<char>& /*ranges*/) { ends.push_back(end); });
   ioStatistics_->readGap().merge(stats.gaps);
   return ends;
 }


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/nimble/pull/832

Teach shared `velox::coalesceIo` to keep adjacent exact duplicate ranges in the same coalesced IO instead of treating the negative gap as a hard split. Nimble stream deduplication can produce repeated logical streams with the same physical `{offset, length}` and no non-identical overlap; this special case lets `DirectDataInput` issue one physical read for the duplicate stream while preserving the existing split behavior for non-identical overlaps and decreasing ranges. `DirectDataInput` now uses the shared helper again, keeps a global non-decreasing-region check, and the regression coverage verifies both the base coalescer duplicate case and the direct data input duplicate-stream repro.

Differential Revision: D107566265


