### PR TITLE
fix(cudf): Support count(*) through batch concat

### DIFF
--- a/velox/experimental/cudf/exec/CudfBatchConcat.cpp
+++ b/velox/experimental/cudf/exec/CudfBatchConcat.cpp
@@ -21,6 +21,18 @@
 #include "velox/experimental/cudf/exec/Utilities.h"
 
 namespace facebook::velox::cudf_velox {
+namespace {
+
+RowTypePtr getConcatOutputType(
+    const std::shared_ptr<const core::PlanNode>& planNode) {
+  VELOX_CHECK_EQ(
+      planNode->sources().size(),
+      1,
+      "CudfBatchConcat expects a single-source plan node");
+  return planNode->sources()[0]->outputType();
+}
+
+} // namespace
 
 CudfBatchConcat::CudfBatchConcat(
     int32_t operatorId,
@@ -29,7 +41,7 @@ CudfBatchConcat::CudfBatchConcat(
     : CudfOperatorBase(
           operatorId,
           driverCtx,
-          planNode->outputType(),
+          getConcatOutputType(planNode),
           planNode->id(),
           "CudfBatchConcat",
           nvtx3::rgb{211, 211, 211}, /* LightGrey */
@@ -40,15 +52,37 @@ CudfBatchConcat::CudfBatchConcat(
       targetRows_(CudfConfig::getInstance().batchSizeMinThreshold) {}
 
 void CudfBatchConcat::doAddInput(RowVectorPtr input) {
+  if (input->size() == 0) {
+    return;
+  }
+
   auto cudfVector = std::dynamic_pointer_cast<CudfVector>(input);
   VELOX_CHECK_NOT_NULL(cudfVector, "CudfBatchConcat expects CudfVector input");
 
   // Push input cudf table to buffer
-  currentNumRows_ += cudfVector->getTableView().num_rows();
+  currentNumRows_ += cudfVector->size();
   buffer_.push_back(std::move(cudfVector));
 }
 
 RowVectorPtr CudfBatchConcat::doGetOutput() {
+  if (outputType_->size() == 0) {
+    if (buffer_.empty() || (currentNumRows_ < targetRows_ && !noMoreInput_)) {
+      return nullptr;
+    }
+
+    outputQueueStream_ = buffer_[0]->stream();
+    const auto rowCount = currentNumRows_;
+    buffer_.clear();
+    currentNumRows_ = 0;
+
+    return std::make_shared<CudfVector>(
+        pool(),
+        outputType_,
+        rowCount,
+        makeEmptyTable(outputType_),
+        outputQueueStream_);
+  }
+
   // Drain the queue if there is any output to be flushed
   if (!outputQueue_.empty()) {
     auto table = std::move(outputQueue_.front());

--- a/velox/experimental/cudf/exec/CudfBatchConcat.cpp
+++ b/velox/experimental/cudf/exec/CudfBatchConcat.cpp
@@ -20,6 +20,9 @@
 #include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
 
+#include <algorithm>
+#include <limits>
+
 namespace facebook::velox::cudf_velox {
 namespace {
 
@@ -30,6 +33,18 @@ RowTypePtr getConcatOutputType(
       1,
       "CudfBatchConcat expects a single-source plan node");
   return planNode->sources()[0]->outputType();
+}
+
+size_t maxConcatRows() {
+  const auto& config = CudfConfig::getInstance();
+  if (config.batchSizeMaxThreshold) {
+    VELOX_CHECK_GT(
+        config.batchSizeMaxThreshold.value(),
+        0,
+        "CudfBatchConcat max batch size must be positive");
+    return static_cast<size_t>(config.batchSizeMaxThreshold.value());
+  }
+  return static_cast<size_t>(std::numeric_limits<cudf::size_type>::max());
 }
 
 } // namespace
@@ -66,21 +81,61 @@ void CudfBatchConcat::doAddInput(RowVectorPtr input) {
 
 RowVectorPtr CudfBatchConcat::doGetOutput() {
   if (outputType_->size() == 0) {
+    if (!zeroColumnOutputQueue_.empty()) {
+      const auto rowCount = zeroColumnOutputQueue_.front();
+      zeroColumnOutputQueue_.pop();
+      return std::make_shared<CudfVector>(
+          pool(),
+          outputType_,
+          rowCount,
+          makeEmptyTable(outputType_),
+          outputQueueStream_);
+    }
+
     if (buffer_.empty() || (currentNumRows_ < targetRows_ && !noMoreInput_)) {
       return nullptr;
     }
 
     outputQueueStream_ = buffer_[0]->stream();
-    const auto rowCount = currentNumRows_;
+    auto remainingRows = currentNumRows_;
     buffer_.clear();
     currentNumRows_ = 0;
+    const auto maxRows = maxConcatRows();
 
-    return std::make_shared<CudfVector>(
-        pool(),
-        outputType_,
-        rowCount,
-        makeEmptyTable(outputType_),
-        outputQueueStream_);
+    while (remainingRows > 0) {
+      const auto chunkRows = std::min(remainingRows, maxRows);
+      remainingRows -= chunkRows;
+
+      VELOX_CHECK_LE(
+          chunkRows,
+          static_cast<size_t>(std::numeric_limits<vector_size_t>::max()),
+          "CudfBatchConcat zero-column output exceeds vector size limit");
+
+      if (!noMoreInput_ && remainingRows == 0 && chunkRows < targetRows_) {
+        currentNumRows_ = chunkRows;
+        buffer_.push_back(std::make_shared<CudfVector>(
+            pool(),
+            outputType_,
+            static_cast<vector_size_t>(chunkRows),
+            makeEmptyTable(outputType_),
+            outputQueueStream_));
+      } else {
+        zeroColumnOutputQueue_.push(static_cast<vector_size_t>(chunkRows));
+      }
+    }
+
+    if (!zeroColumnOutputQueue_.empty()) {
+      const auto rowCount = zeroColumnOutputQueue_.front();
+      zeroColumnOutputQueue_.pop();
+      return std::make_shared<CudfVector>(
+          pool(),
+          outputType_,
+          rowCount,
+          makeEmptyTable(outputType_),
+          outputQueueStream_);
+    }
+
+    return nullptr;
   }
 
   // Drain the queue if there is any output to be flushed
@@ -115,13 +170,8 @@ RowVectorPtr CudfBatchConcat::doGetOutput() {
 
     if (!noMoreInput_ && rowCount < targetRows_) {
       currentNumRows_ = rowCount;
-      buffer_.push_back(
-          std::make_shared<CudfVector>(
-              pool(),
-              outputType_,
-              rowCount,
-              std::move(last),
-              outputQueueStream_));
+      buffer_.push_back(std::make_shared<CudfVector>(
+          pool(), outputType_, rowCount, std::move(last), outputQueueStream_));
     } else {
       outputQueue_.push(std::move(last));
     }
@@ -140,7 +190,8 @@ RowVectorPtr CudfBatchConcat::doGetOutput() {
 }
 
 bool CudfBatchConcat::isFinished() {
-  return noMoreInput_ && buffer_.empty() && outputQueue_.empty();
+  return noMoreInput_ && buffer_.empty() && outputQueue_.empty() &&
+      zeroColumnOutputQueue_.empty();
 }
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/CudfBatchConcat.cpp
+++ b/velox/experimental/cudf/exec/CudfBatchConcat.cpp
@@ -20,8 +20,7 @@
 #include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
 
-#include <algorithm>
-#include <limits>
+#include <utility>
 
 namespace facebook::velox::cudf_velox {
 namespace {
@@ -33,18 +32,6 @@ RowTypePtr getConcatOutputType(
       1,
       "CudfBatchConcat expects a single-source plan node");
   return planNode->sources()[0]->outputType();
-}
-
-size_t maxConcatRows() {
-  const auto& config = CudfConfig::getInstance();
-  if (config.batchSizeMaxThreshold) {
-    VELOX_CHECK_GT(
-        config.batchSizeMaxThreshold.value(),
-        0,
-        "CudfBatchConcat max batch size must be positive");
-    return static_cast<size_t>(config.batchSizeMaxThreshold.value());
-  }
-  return static_cast<size_t>(std::numeric_limits<cudf::size_type>::max());
 }
 
 } // namespace
@@ -67,12 +54,12 @@ CudfBatchConcat::CudfBatchConcat(
       targetRows_(CudfConfig::getInstance().batchSizeMinThreshold) {}
 
 void CudfBatchConcat::doAddInput(RowVectorPtr input) {
-  if (input->size() == 0) {
-    return;
-  }
-
   auto cudfVector = std::dynamic_pointer_cast<CudfVector>(input);
   VELOX_CHECK_NOT_NULL(cudfVector, "CudfBatchConcat expects CudfVector input");
+
+  if (cudfVector->size() == 0) {
+    return;
+  }
 
   // Push input cudf table to buffer
   currentNumRows_ += cudfVector->size();
@@ -80,109 +67,48 @@ void CudfBatchConcat::doAddInput(RowVectorPtr input) {
 }
 
 RowVectorPtr CudfBatchConcat::doGetOutput() {
-  if (outputType_->size() == 0) {
-    if (!zeroColumnOutputQueue_.empty()) {
-      const auto rowCount = zeroColumnOutputQueue_.front();
-      zeroColumnOutputQueue_.pop();
-      return std::make_shared<CudfVector>(
-          pool(),
-          outputType_,
-          rowCount,
-          makeEmptyTable(outputType_),
-          outputQueueStream_);
-    }
-
-    if (buffer_.empty() || (currentNumRows_ < targetRows_ && !noMoreInput_)) {
-      return nullptr;
-    }
-
-    outputQueueStream_ = buffer_[0]->stream();
-    auto remainingRows = currentNumRows_;
-    buffer_.clear();
-    currentNumRows_ = 0;
-    const auto maxRows = maxConcatRows();
-
-    while (remainingRows > 0) {
-      const auto chunkRows = std::min(remainingRows, maxRows);
-      remainingRows -= chunkRows;
-
-      VELOX_CHECK_LE(
-          chunkRows,
-          static_cast<size_t>(std::numeric_limits<vector_size_t>::max()),
-          "CudfBatchConcat zero-column output exceeds vector size limit");
-
-      if (!noMoreInput_ && remainingRows == 0 && chunkRows < targetRows_) {
-        currentNumRows_ = chunkRows;
-        buffer_.push_back(std::make_shared<CudfVector>(
-            pool(),
-            outputType_,
-            static_cast<vector_size_t>(chunkRows),
-            makeEmptyTable(outputType_),
-            outputQueueStream_));
-      } else {
-        zeroColumnOutputQueue_.push(static_cast<vector_size_t>(chunkRows));
-      }
-    }
-
-    if (!zeroColumnOutputQueue_.empty()) {
-      const auto rowCount = zeroColumnOutputQueue_.front();
-      zeroColumnOutputQueue_.pop();
-      return std::make_shared<CudfVector>(
-          pool(),
-          outputType_,
-          rowCount,
-          makeEmptyTable(outputType_),
-          outputQueueStream_);
-    }
-
-    return nullptr;
-  }
-
   // Drain the queue if there is any output to be flushed
   if (!outputQueue_.empty()) {
-    auto table = std::move(outputQueue_.front());
-    auto rowCount = table->num_rows();
+    auto output = std::move(outputQueue_.front());
     outputQueue_.pop();
-    return std::make_shared<CudfVector>(
-        pool(), outputType_, rowCount, std::move(table), outputQueueStream_);
+    return output;
   }
 
   // Merge tables if there are enough rows
   if (!buffer_.empty() && (currentNumRows_ >= targetRows_ || noMoreInput_)) {
     // Use stream from existing buffer vectors
-    outputQueueStream_ = buffer_[0]->stream();
-    auto tables = getConcatenatedTableBatched(
+    const auto outputStream = buffer_[0]->stream();
+    auto outputVectors = getConcatenatedCudfVectorsBatched(
+        pool(),
         std::exchange(buffer_, {}),
         outputType_,
-        outputQueueStream_,
+        outputStream,
         get_output_mr());
 
     currentNumRows_ = 0;
+    VELOX_CHECK_GT(outputVectors.size(), 0);
 
-    for (auto it = tables.begin(); it + 1 != tables.end(); ++it) {
+    for (auto it = outputVectors.begin(); it + 1 != outputVectors.end(); ++it) {
       outputQueue_.push(std::move(*it));
     }
 
     // If last table is a smaller batch and we still expect more input and keep
     // it in buffer.
-    auto& last = tables.back();
-    auto rowCount = last->num_rows();
+    auto& last = outputVectors.back();
+    auto rowCount = last->size();
 
     if (!noMoreInput_ && rowCount < targetRows_) {
       currentNumRows_ = rowCount;
-      buffer_.push_back(std::make_shared<CudfVector>(
-          pool(), outputType_, rowCount, std::move(last), outputQueueStream_));
+      buffer_.push_back(std::move(last));
     } else {
       outputQueue_.push(std::move(last));
     }
 
     // Return the first batch from the new queue
     if (!outputQueue_.empty()) {
-      auto table = std::move(outputQueue_.front());
-      auto rowCount = table->num_rows();
+      auto output = std::move(outputQueue_.front());
       outputQueue_.pop();
-      return std::make_shared<CudfVector>(
-          pool(), outputType_, rowCount, std::move(table), outputQueueStream_);
+      return output;
     }
   }
 
@@ -190,8 +116,7 @@ RowVectorPtr CudfBatchConcat::doGetOutput() {
 }
 
 bool CudfBatchConcat::isFinished() {
-  return noMoreInput_ && buffer_.empty() && outputQueue_.empty() &&
-      zeroColumnOutputQueue_.empty();
+  return noMoreInput_ && buffer_.empty() && outputQueue_.empty();
 }
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/CudfBatchConcat.h
+++ b/velox/experimental/cudf/exec/CudfBatchConcat.h
@@ -35,7 +35,7 @@ class CudfBatchConcat : public CudfOperatorBase {
 
   bool needsInput() const override {
     return !noMoreInput_ && outputQueue_.empty() &&
-        zeroColumnOutputQueue_.empty() && currentNumRows_ < targetRows_;
+        currentNumRows_ < targetRows_;
   }
 
   exec::BlockingReason isBlocked(ContinueFuture* /*future*/) override {
@@ -51,9 +51,7 @@ class CudfBatchConcat : public CudfOperatorBase {
  private:
   exec::DriverCtx* const driverCtx_;
   std::vector<CudfVectorPtr> buffer_;
-  std::queue<std::unique_ptr<cudf::table>> outputQueue_;
-  std::queue<vector_size_t> zeroColumnOutputQueue_;
-  rmm::cuda_stream_view outputQueueStream_{rmm::cuda_stream_default};
+  std::queue<CudfVectorPtr> outputQueue_;
   size_t currentNumRows_{0};
   const size_t targetRows_{0};
 };

--- a/velox/experimental/cudf/exec/CudfBatchConcat.h
+++ b/velox/experimental/cudf/exec/CudfBatchConcat.h
@@ -35,7 +35,7 @@ class CudfBatchConcat : public CudfOperatorBase {
 
   bool needsInput() const override {
     return !noMoreInput_ && outputQueue_.empty() &&
-        currentNumRows_ < targetRows_;
+        zeroColumnOutputQueue_.empty() && currentNumRows_ < targetRows_;
   }
 
   exec::BlockingReason isBlocked(ContinueFuture* /*future*/) override {
@@ -52,6 +52,7 @@ class CudfBatchConcat : public CudfOperatorBase {
   exec::DriverCtx* const driverCtx_;
   std::vector<CudfVectorPtr> buffer_;
   std::queue<std::unique_ptr<cudf::table>> outputQueue_;
+  std::queue<vector_size_t> zeroColumnOutputQueue_;
   rmm::cuda_stream_view outputQueueStream_{rmm::cuda_stream_default};
   size_t currentNumRows_{0};
   const size_t targetRows_{0};

--- a/velox/experimental/cudf/exec/Utilities.cpp
+++ b/velox/experimental/cudf/exec/Utilities.cpp
@@ -25,7 +25,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 
 #include <cuda_runtime_api.h>
-
+#include <algorithm>
 #include <limits>
 #include <vector>
 
@@ -57,6 +57,25 @@ CudaEvent& eventForThread() {
     events[deviceIndex] = new CudaEvent(cudaEventDisableTiming);
   }
   return *events[deviceIndex];
+
+size_t maxBatchRows() {
+  const auto& cudfConfig = CudfConfig::getInstance();
+  if (cudfConfig.batchSizeMaxThreshold) {
+    VELOX_CHECK_GT(
+        cudfConfig.batchSizeMaxThreshold.value(),
+        0,
+        "cuDF max batch size must be positive");
+    return static_cast<size_t>(cudfConfig.batchSizeMaxThreshold.value());
+  }
+  return static_cast<size_t>(std::numeric_limits<cudf::size_type>::max());
+}
+
+vector_size_t checkedVectorSize(size_t rowCount) {
+  VELOX_CHECK_LE(
+      rowCount,
+      static_cast<size_t>(std::numeric_limits<vector_size_t>::max()),
+      "cuDF vector row count exceeds Velox vector size limit");
+  return static_cast<vector_size_t>(rowCount);
 }
 
 } // namespace
@@ -166,10 +185,7 @@ std::vector<std::unique_ptr<cudf::table>> getConcatenatedTableBatched(
   cudf::detail::join_streams(inputStreams, stream);
 
   std::vector<std::unique_ptr<cudf::table>> outputTables;
-  const auto& cudfConfig = CudfConfig::getInstance();
-  auto const maxRows = cudfConfig.batchSizeMaxThreshold
-      ? static_cast<size_t>(cudfConfig.batchSizeMaxThreshold.value())
-      : static_cast<size_t>(std::numeric_limits<cudf::size_type>::max());
+  auto const maxRows = maxBatchRows();
   size_t startpos = 0;
   size_t runningRows = 0;
   for (size_t i = 0; i < tableViews.size(); ++i) {
@@ -201,6 +217,58 @@ std::vector<std::unique_ptr<cudf::table>> getConcatenatedTableBatched(
 
   // Input tables are deallocated here when 'tables' goes out of scope.
   return outputTables;
+}
+
+std::vector<CudfVectorPtr> getConcatenatedCudfVectorsBatched(
+    memory::MemoryPool* pool,
+    std::vector<CudfVectorPtr>&& vectors,
+    const TypePtr& tableType,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  VELOX_CHECK_NOT_NULL(pool);
+
+  std::vector<CudfVectorPtr> outputVectors;
+  if (tableType->size() > 0) {
+    auto tables =
+        getConcatenatedTableBatched(std::move(vectors), tableType, stream, mr);
+    outputVectors.reserve(tables.size());
+    for (auto& table : tables) {
+      VELOX_CHECK_NOT_NULL(table);
+      const auto rowCount =
+          checkedVectorSize(static_cast<size_t>(table->num_rows()));
+      outputVectors.push_back(
+          std::make_shared<CudfVector>(
+              pool, tableType, rowCount, std::move(table), stream));
+    }
+    return outputVectors;
+  }
+
+  size_t remainingRows = 0;
+  for (const auto& vector : vectors) {
+    VELOX_CHECK_NOT_NULL(vector);
+    VELOX_CHECK_EQ(vector->getTableView().num_columns(), 0);
+    const auto rowCount = static_cast<size_t>(vector->size());
+    VELOX_CHECK_LE(
+        rowCount,
+        std::numeric_limits<size_t>::max() - remainingRows,
+        "zero-column cuDF vector row count overflow");
+    remainingRows += rowCount;
+  }
+
+  const auto maxRows = maxBatchRows();
+  do {
+    const auto chunkRows = std::min(remainingRows, maxRows);
+    outputVectors.push_back(
+        std::make_shared<CudfVector>(
+            pool,
+            tableType,
+            checkedVectorSize(chunkRows),
+            makeEmptyTable(tableType),
+            stream));
+    remainingRows -= chunkRows;
+  } while (remainingRows > 0);
+
+  return outputVectors;
 }
 
 void streamsWaitForStream(

--- a/velox/experimental/cudf/exec/Utilities.cpp
+++ b/velox/experimental/cudf/exec/Utilities.cpp
@@ -25,6 +25,7 @@
 #include <cudf/utilities/memory_resource.hpp>
 
 #include <cuda_runtime_api.h>
+
 #include <algorithm>
 #include <limits>
 #include <vector>
@@ -58,25 +59,25 @@ CudaEvent& eventForThread() {
   }
   return *events[deviceIndex];
 
-size_t maxBatchRows() {
-  const auto& cudfConfig = CudfConfig::getInstance();
-  if (cudfConfig.batchSizeMaxThreshold) {
-    VELOX_CHECK_GT(
-        cudfConfig.batchSizeMaxThreshold.value(),
-        0,
-        "cuDF max batch size must be positive");
-    return static_cast<size_t>(cudfConfig.batchSizeMaxThreshold.value());
+  size_t maxBatchRows() {
+    const auto& cudfConfig = CudfConfig::getInstance();
+    if (cudfConfig.batchSizeMaxThreshold) {
+      VELOX_CHECK_GT(
+          cudfConfig.batchSizeMaxThreshold.value(),
+          0,
+          "cuDF max batch size must be positive");
+      return static_cast<size_t>(cudfConfig.batchSizeMaxThreshold.value());
+    }
+    return static_cast<size_t>(std::numeric_limits<cudf::size_type>::max());
   }
-  return static_cast<size_t>(std::numeric_limits<cudf::size_type>::max());
-}
 
-vector_size_t checkedVectorSize(size_t rowCount) {
-  VELOX_CHECK_LE(
-      rowCount,
-      static_cast<size_t>(std::numeric_limits<vector_size_t>::max()),
-      "cuDF vector row count exceeds Velox vector size limit");
-  return static_cast<vector_size_t>(rowCount);
-}
+  vector_size_t checkedVectorSize(size_t rowCount) {
+    VELOX_CHECK_LE(
+        rowCount,
+        static_cast<size_t>(std::numeric_limits<vector_size_t>::max()),
+        "cuDF vector row count exceeds Velox vector size limit");
+    return static_cast<vector_size_t>(rowCount);
+  }
 
 } // namespace
 

--- a/velox/experimental/cudf/exec/Utilities.cpp
+++ b/velox/experimental/cudf/exec/Utilities.cpp
@@ -58,27 +58,27 @@ CudaEvent& eventForThread() {
     events[deviceIndex] = new CudaEvent(cudaEventDisableTiming);
   }
   return *events[deviceIndex];
+}
 
-  size_t maxBatchRows() {
-    const auto& cudfConfig = CudfConfig::getInstance();
-    if (cudfConfig.batchSizeMaxThreshold) {
-      VELOX_CHECK_GT(
-          cudfConfig.batchSizeMaxThreshold.value(),
-          0,
-          "cuDF max batch size must be positive");
-      return static_cast<size_t>(cudfConfig.batchSizeMaxThreshold.value());
-    }
-    return static_cast<size_t>(std::numeric_limits<cudf::size_type>::max());
+size_t maxBatchRows() {
+  const auto& cudfConfig = CudfConfig::getInstance();
+  if (cudfConfig.batchSizeMaxThreshold) {
+    VELOX_CHECK_GT(
+        cudfConfig.batchSizeMaxThreshold.value(),
+        0,
+        "cuDF max batch size must be positive");
+    return static_cast<size_t>(cudfConfig.batchSizeMaxThreshold.value());
   }
+  return static_cast<size_t>(std::numeric_limits<cudf::size_type>::max());
+}
 
-  vector_size_t checkedVectorSize(size_t rowCount) {
-    VELOX_CHECK_LE(
-        rowCount,
-        static_cast<size_t>(std::numeric_limits<vector_size_t>::max()),
-        "cuDF vector row count exceeds Velox vector size limit");
-    return static_cast<vector_size_t>(rowCount);
-  }
-
+vector_size_t checkedVectorSize(size_t rowCount) {
+  VELOX_CHECK_LE(
+      rowCount,
+      static_cast<size_t>(std::numeric_limits<vector_size_t>::max()),
+      "cuDF vector row count exceeds Velox vector size limit");
+  return static_cast<vector_size_t>(rowCount);
+}
 } // namespace
 
 std::unique_ptr<cudf::table> concatenateTables(

--- a/velox/experimental/cudf/exec/Utilities.h
+++ b/velox/experimental/cudf/exec/Utilities.h
@@ -33,9 +33,6 @@ namespace facebook::velox::cudf_velox {
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr);
 
-[[nodiscard]] std::unique_ptr<cudf::table> makeEmptyTable(
-    TypePtr const& inputType);
-
 /**
  * @brief Concatenates multiple CudfVectors into a single cudf::table.
  *
@@ -90,6 +87,20 @@ namespace facebook::velox::cudf_velox {
 [[nodiscard]] std::vector<std::unique_ptr<cudf::table>>
 getConcatenatedTableBatched(
     std::vector<CudfVectorPtr>&& tables,
+    const TypePtr& tableType,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr);
+
+/**
+ * @brief Concatenates multiple CudfVectors into CudfVector output batches.
+ *
+ * This wraps getConcatenatedTableBatched for column-bearing tables and
+ * preserves logical row counts from CudfVector::size() for zero-column tables,
+ * whose cuDF table views cannot represent the row count.
+ */
+[[nodiscard]] std::vector<CudfVectorPtr> getConcatenatedCudfVectorsBatched(
+    memory::MemoryPool* pool,
+    std::vector<CudfVectorPtr>&& vectors,
     const TypePtr& tableType,
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr);

--- a/velox/experimental/cudf/exec/Utilities.h
+++ b/velox/experimental/cudf/exec/Utilities.h
@@ -33,6 +33,9 @@ namespace facebook::velox::cudf_velox {
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr);
 
+[[nodiscard]] std::unique_ptr<cudf::table> makeEmptyTable(
+    TypePtr const& inputType);
+
 /**
  * @brief Concatenates multiple CudfVectors into a single cudf::table.
  *

--- a/velox/experimental/cudf/tests/BatchConcatTest.cpp
+++ b/velox/experimental/cudf/tests/BatchConcatTest.cpp
@@ -269,3 +269,40 @@ TEST_F(CudfBatchConcatTest, concatPreservesZeroColumnRowCountForCountStar) {
   EXPECT_EQ(concatIt->second->inputVectors, 1);
   EXPECT_EQ(concatIt->second->outputVectors, 1);
 }
+
+TEST_F(CudfBatchConcatTest, concatSplitsZeroColumnBatchesAtMaxThreshold) {
+  updateCudfConfig(/*min=*/30, /*max=*/20);
+  CudfConfig::getInstance().concatOptimizationEnabled = true;
+
+  std::vector<RowVectorPtr> vectors;
+  for (int i = 0; i < 3; ++i) {
+    vectors.push_back(makeRowVector({makeFlatSequence<int64_t>(i * 10, 10)}));
+  }
+  createDuckDbTable(vectors);
+
+  auto generator = std::make_shared<core::PlanNodeIdGenerator>();
+  core::PlanNodeId aggNodeId;
+
+  auto plan = PlanBuilder(generator)
+                  .addNode([&](auto id, auto pool) {
+                    return createFragmentedSource(vectors, generator);
+                  })
+                  .filter("c0 >= 0")
+                  .project({})
+                  .singleAggregation({}, {"count(*)"})
+                  .capturePlanNodeId(aggNodeId)
+                  .planNode();
+
+  auto task = AssertQueryBuilder(duckDbQueryRunner_)
+                  .plan(plan)
+                  .maxDrivers(1)
+                  .assertResults("SELECT count(*) FROM tmp WHERE c0 >= 0");
+
+  auto planStats = toPlanStats(task->taskStats());
+  auto& nodeStats = planStats.at(aggNodeId);
+  auto concatIt = nodeStats.operatorStats.find("CudfBatchConcat");
+  ASSERT_NE(concatIt, nodeStats.operatorStats.end());
+  EXPECT_EQ(concatIt->second->inputVectors, 3);
+  EXPECT_EQ(concatIt->second->outputVectors, 2)
+      << "30 zero-column rows should be split into 20-row and 10-row batches";
+}

--- a/velox/experimental/cudf/tests/BatchConcatTest.cpp
+++ b/velox/experimental/cudf/tests/BatchConcatTest.cpp
@@ -236,3 +236,36 @@ TEST_F(CudfBatchConcatTest, concatWithGroupedAggregation) {
   EXPECT_EQ(concatIt->second->inputVectors, 6);
   EXPECT_LT(concatIt->second->outputVectors, 6);
 }
+
+TEST_F(CudfBatchConcatTest, concatPreservesZeroColumnRowCountForCountStar) {
+  updateCudfConfig(/*min=*/30, /*max=*/std::nullopt);
+  CudfConfig::getInstance().concatOptimizationEnabled = true;
+
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>({1, 2, 3, 4}),
+  });
+  createDuckDbTable({data});
+
+  auto generator = std::make_shared<core::PlanNodeIdGenerator>();
+  core::PlanNodeId aggNodeId;
+
+  auto plan = PlanBuilder(generator)
+                  .values({data})
+                  .filter("c0 > 0")
+                  .project({})
+                  .singleAggregation({}, {"count(*)"})
+                  .capturePlanNodeId(aggNodeId)
+                  .planNode();
+
+  auto task = AssertQueryBuilder(duckDbQueryRunner_)
+                  .plan(plan)
+                  .maxDrivers(1)
+                  .assertResults("SELECT count(*) FROM tmp WHERE c0 > 0");
+
+  auto planStats = toPlanStats(task->taskStats());
+  auto& nodeStats = planStats.at(aggNodeId);
+  auto concatIt = nodeStats.operatorStats.find("CudfBatchConcat");
+  ASSERT_NE(concatIt, nodeStats.operatorStats.end());
+  EXPECT_EQ(concatIt->second->inputVectors, 1);
+  EXPECT_EQ(concatIt->second->outputVectors, 1);
+}


### PR DESCRIPTION
Fixes `CudfBatchConcat` for `count(*)` plans whose aggregation input
has zero output columns, such as a projection to an empty row type
before a global count. cuDF zero-column tables do not carry row
counts, so deriving the concat row count from `table_view::num_rows()`
can collapse non-empty input to zero rows before the aggregation sees
it.

This preserves logical row counts from `CudfVector::size()`, uses the
concat input type as the operator output type, skips empty inputs, and
emits empty cuDF tables with the correct Velox row count for
zero-column batches. It also makes the zero-column path respect
`batchSizeMaxThreshold`, so max batch splitting behaves the same way
as normal column-bearing concat output.

Adds regression coverage for `count(*)` through `CudfBatchConcat`,
including the zero-column row-count case and max-threshold splitting
for accumulated zero-column batches.
