### PR TITLE
feat: Add pairedColumn to BetweenIndexLookupCondition (#17750)

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -1904,6 +1904,56 @@ IndexLookupJoinNode::IndexLookupJoinNode(
         "Index lookup koin key types on the left and right sides must match");
   }
 
+  // A paired BETWEEN must have a matching IN condition in the same join.
+  // If the BETWEEN says "pair me with column X", a sibling IN condition
+  // must use X as its list.
+  //
+  // Example: this join is valid because both conditions reference
+  // `event_types`:
+  //     event_type IN event_types
+  //     AND ts BETWEEN lower_ts AND upper_ts (paired with event_types)
+  //
+  // Why it matters: the IN condition is what brings `event_types` into the
+  // connector's lookup input. Without it the connector would receive the
+  // bound arrays but have no per-row values to pair them against, and the
+  // paired BETWEEN would be meaningless.
+  //
+  // The check lives here (not in BetweenIndexLookupCondition::validate())
+  // because a single condition only sees itself, not its siblings.
+  folly::F14FastSet<std::string> inListNames;
+  for (const auto& condition : joinConditions_) {
+    if (const auto inCondition =
+            std::dynamic_pointer_cast<const InIndexLookupCondition>(
+                condition)) {
+      if (inCondition->list != nullptr &&
+          inCondition->list->isFieldAccessKind()) {
+        inListNames.insert(
+            std::dynamic_pointer_cast<const FieldAccessTypedExpr>(
+                inCondition->list)
+                ->name());
+      }
+    }
+  }
+  for (const auto& condition : joinConditions_) {
+    const auto betweenCondition =
+        std::dynamic_pointer_cast<const BetweenIndexLookupCondition>(condition);
+    if (betweenCondition == nullptr ||
+        betweenCondition->pairedColumn == nullptr) {
+      continue;
+    }
+    const auto& pairedName = betweenCondition->pairedColumn->name();
+    VELOX_CHECK(
+        leftType->containsChild(pairedName),
+        "Paired between column not found in probe input: {}",
+        pairedName);
+    VELOX_CHECK_EQ(
+        inListNames.count(pairedName),
+        1,
+        "Paired between column {} must also appear as the list of a sibling "
+        "IN condition in the same join.",
+        pairedName);
+  }
+
   auto numOutputColumns = outputType_->size();
   if (hasMarker_) {
     VELOX_USER_CHECK(
@@ -4172,15 +4222,26 @@ folly::dynamic BetweenIndexLookupCondition::serialize() const {
   obj["type"] = "between";
   obj["lower"] = lower->serialize();
   obj["upper"] = upper->serialize();
+  if (pairedColumn != nullptr) {
+    obj["pairedColumn"] = pairedColumn->serialize();
+  }
   return obj;
 }
 
 std::string BetweenIndexLookupCondition::toString() const {
+  if (pairedColumn == nullptr) {
+    return fmt::format(
+        "{} BETWEEN {} AND {}",
+        key->toString(),
+        lower->toString(),
+        upper->toString());
+  }
   return fmt::format(
-      "{} BETWEEN {} AND {}",
+      "{} BETWEEN {} AND {} PAIRED WITH {}",
       key->toString(),
       lower->toString(),
-      upper->toString());
+      upper->toString(),
+      pairedColumn->toString());
 }
 
 IndexLookupConditionPtr BetweenIndexLookupCondition::create(
@@ -4188,10 +4249,16 @@ IndexLookupConditionPtr BetweenIndexLookupCondition::create(
     void* context) {
   auto key =
       ISerializable::deserialize<FieldAccessTypedExpr>(obj["key"], context);
+  FieldAccessTypedExprPtr pairedColumn;
+  if (obj.count("pairedColumn")) {
+    pairedColumn = ISerializable::deserialize<FieldAccessTypedExpr>(
+        obj["pairedColumn"], context);
+  }
   return std::make_shared<BetweenIndexLookupCondition>(
       key,
       ISerializable::deserialize<ITypedExpr>(obj["lower"], context),
-      ISerializable::deserialize<ITypedExpr>(obj["upper"], context));
+      ISerializable::deserialize<ITypedExpr>(obj["upper"], context),
+      std::move(pairedColumn));
 }
 
 void BetweenIndexLookupCondition::validate() const {
@@ -4208,15 +4275,52 @@ void BetweenIndexLookupCondition::validate() const {
       "Invalid upper between condition {}",
       upper->toString());
 
-  VELOX_CHECK_EQ(
-      key->type()->kind(),
-      lower->type()->kind(),
-      "Index key and lower condition must have the same type");
+  if (pairedColumn == nullptr) {
+    VELOX_CHECK_EQ(
+        key->type()->kind(),
+        lower->type()->kind(),
+        "Index key and lower condition must have the same type");
 
+    VELOX_CHECK_EQ(
+        key->type()->kind(),
+        upper->type()->kind(),
+        "Index key and upper condition must have the same type");
+    return;
+  }
+
+  // Paired BETWEEN: bounds must be arrays (ARRAY type) whose element type
+  // matches the index key. The per-row pairing happens connector-side; the
+  // operator just forwards the bound arrays and the paired column to the
+  // connector.
+  VELOX_CHECK(
+      lower->type()->isArray(),
+      "Paired between lower bound must be of type ARRAY, got {}",
+      lower->type()->toString());
+  VELOX_CHECK(
+      upper->type()->isArray(),
+      "Paired between upper bound must be of type ARRAY, got {}",
+      upper->type()->toString());
   VELOX_CHECK_EQ(
       key->type()->kind(),
-      upper->type()->kind(),
-      "Index key and upper condition must have the same type");
+      lower->type()->asArray().elementType()->kind(),
+      "Index key and paired lower bound element type must match");
+  VELOX_CHECK_EQ(
+      key->type()->kind(),
+      upper->type()->asArray().elementType()->kind(),
+      "Index key and paired upper bound element type must match");
+  // Constant bounds would make per-row size validation against the IN list
+  // a special case (constant array size vs varying IN-list size). Requiring
+  // FieldAccess keeps the size invariant uniform: the operator can compare
+  // the three array vectors row-by-row without branching on whether a bound
+  // is shared across rows.
+  VELOX_CHECK(
+      lower->isFieldAccessKind(),
+      "Paired between lower bound must be a column reference, got {}",
+      lower->toString());
+  VELOX_CHECK(
+      upper->isFieldAccessKind(),
+      "Paired between upper bound must be a column reference, got {}",
+      upper->toString());
 }
 
 bool EqualIndexLookupCondition::isFilter() const {

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -3590,7 +3590,10 @@ struct InIndexLookupCondition : public IndexLookupCondition {
 using InIndexLookupConditionPtr = std::shared_ptr<InIndexLookupCondition>;
 
 /// Represents BETWEEN index lookup condition: 'key' between 'lower' and
-/// 'upper'. 'lower' and 'upper' have the same type of 'key'.
+/// 'upper'. 'lower' and 'upper' have the same type of 'key' when
+/// 'pairedColumn' is null. When 'pairedColumn' is set, 'lower' and 'upper'
+/// are ARRAY-typed and pair element-wise with the values of the named
+/// paired column.
 struct BetweenIndexLookupCondition : public IndexLookupCondition {
   /// The between bound either reference to a probe input column or a constant
   /// value.
@@ -3599,13 +3602,23 @@ struct BetweenIndexLookupCondition : public IndexLookupCondition {
   TypedExprPtr lower;
   TypedExprPtr upper;
 
+  /// Optional. When set, the BETWEEN runs per element instead of per row.
+  /// The i-th value of 'pairedColumn' is tested against the bounds at
+  /// 'lower[i]' and 'upper[i]'. Both 'lower' and 'upper' must therefore
+  /// be arrays (Velox type ARRAY(elementType)) whose element type matches
+  /// 'key'. A sibling InIndexLookupCondition must reference the same
+  /// column as its list.
+  FieldAccessTypedExprPtr pairedColumn;
+
   BetweenIndexLookupCondition(
       FieldAccessTypedExprPtr _key,
       TypedExprPtr _lower,
-      TypedExprPtr _upper)
+      TypedExprPtr _upper,
+      FieldAccessTypedExprPtr _pairedColumn = nullptr)
       : IndexLookupCondition(std::move(_key)),
         lower(std::move(_lower)),
-        upper(std::move(_upper)) {
+        upper(std::move(_upper)),
+        pairedColumn(std::move(_pairedColumn)) {
     validate();
   }
 

--- a/velox/exec/IndexLookupJoin.cpp
+++ b/velox/exec/IndexLookupJoin.cpp
@@ -130,21 +130,26 @@ std::vector<core::IndexLookupConditionPtr> getJoinConditions(
 
 // Validates one of between bound, and update the lookup input channels and type
 // to include the corresponding probe input column if the bound is not constant.
+// When 'isPaired' is true, the bound is expected to be ARRAY-typed (with
+// element type matching 'indexKeyType'); the connector pairs the i-th element
+// with the i-th value of the BETWEEN's pairedColumn at lookup time.
 bool addBetweenConditionBound(
     const core::TypedExprPtr& typeExpr,
     const RowTypePtr& inputType,
     const TypePtr& indexKeyType,
+    bool isPaired,
     std::vector<std::string>& lookupInputNames,
     std::vector<TypePtr>& lookupInputTypes,
     std::vector<column_index_t>& lookupInputChannels,
     folly::F14FastSet<std::string>& lookupInputNameSet) {
   const bool isConstant = core::TypedExprs::isConstant(typeExpr);
+  const auto expectedType = isPaired ? ARRAY(indexKeyType) : indexKeyType;
   if (!isConstant) {
     const auto conditionColumnName = getColumnName(typeExpr);
     const auto conditionColumnChannel =
         inputType->getChildIdx(conditionColumnName);
     const auto conditionColumnType = inputType->childAt(conditionColumnChannel);
-    VELOX_USER_CHECK(conditionColumnType->equivalent(*indexKeyType));
+    VELOX_USER_CHECK(conditionColumnType->equivalent(*expectedType));
     addLookupInputColumn(
         conditionColumnName,
         conditionColumnType,
@@ -156,14 +161,16 @@ bool addBetweenConditionBound(
   } else {
     VELOX_USER_CHECK(
         core::TypedExprs::asConstant(typeExpr)->type()->equivalent(
-            *indexKeyType));
+            *expectedType));
   }
   return isConstant;
 }
 
 // Process a between join condition by validating the lower and upper bound
 // types, and updating the lookup input channels and type to include the probe
-// input columns which contain the between condition bounds.
+// input columns which contain the between condition bounds. When the BETWEEN
+// has a pairedColumn set, the bounds are expected to be ARRAY-typed and the
+// paired column is added to the lookup input by the sibling IN condition.
 void addBetweenCondition(
     const core::BetweenIndexLookupConditionPtr& betweenCondition,
     const RowTypePtr& inputType,
@@ -172,11 +179,13 @@ void addBetweenCondition(
     std::vector<TypePtr>& lookupInputTypes,
     std::vector<column_index_t>& lookupInputChannels,
     folly::F14FastSet<std::string>& lookupInputNameSet) {
+  const bool isPaired = betweenCondition->pairedColumn != nullptr;
   size_t numConstants{0};
   numConstants += !!addBetweenConditionBound(
       betweenCondition->lower,
       inputType,
       indexKeyType,
+      isPaired,
       lookupInputNames,
       lookupInputTypes,
       lookupInputChannels,
@@ -185,6 +194,7 @@ void addBetweenCondition(
       betweenCondition->upper,
       inputType,
       indexKeyType,
+      isPaired,
       lookupInputNames,
       lookupInputTypes,
       lookupInputChannels,
@@ -849,6 +859,7 @@ RowVectorPtr IndexLookupJoin::getOutput() {
 void IndexLookupJoin::prepareLookup(InputBatchState& batch) {
   VELOX_CHECK_GT(numInputBatches(), 0);
   VELOX_CHECK_NOT_NULL(batch.input);
+  validatePairedBetweenSizes(batch);
   const size_t numLookupRows = batch.lookupInputHasNullKeys
       ? batch.nonNullInputRows.countSelected()
       : batch.input->size();
@@ -890,6 +901,68 @@ void IndexLookupJoin::prepareLookup(InputBatchState& batch) {
         batch.nonNullInputMappings,
         numLookupRows,
         batch.input->childAt(lookupInputChannels_[i]));
+  }
+}
+
+void IndexLookupJoin::validatePairedBetweenSizes(
+    const InputBatchState& batch) const {
+  for (const auto& condition : joinConditions_) {
+    const auto between =
+        std::dynamic_pointer_cast<const core::BetweenIndexLookupCondition>(
+            condition);
+    if (between == nullptr || between->pairedColumn == nullptr) {
+      continue;
+    }
+    if (!between->lower->isFieldAccessKind() ||
+        !between->upper->isFieldAccessKind()) {
+      continue;
+    }
+    const auto& inListVec = batch.input->childAt(
+        probeType_->getChildIdx(between->pairedColumn->name()));
+    const auto& lowerVec = batch.input->childAt(
+        probeType_->getChildIdx(getColumnName(between->lower)));
+    const auto& upperVec = batch.input->childAt(
+        probeType_->getChildIdx(getColumnName(between->upper)));
+    inListVec->loadedVector();
+    lowerVec->loadedVector();
+    upperVec->loadedVector();
+
+    DecodedVector decodedIn(*inListVec);
+    DecodedVector decodedLower(*lowerVec);
+    DecodedVector decodedUpper(*upperVec);
+    const auto* inArray = decodedIn.base()->as<ArrayVector>();
+    const auto* lowerArray = decodedLower.base()->as<ArrayVector>();
+    const auto* upperArray = decodedUpper.base()->as<ArrayVector>();
+    VELOX_CHECK_NOT_NULL(inArray);
+    VELOX_CHECK_NOT_NULL(lowerArray);
+    VELOX_CHECK_NOT_NULL(upperArray);
+
+    // decodeAndDetectNonNullKeys (called from addInput before prepareLookup)
+    // already deselected any row with a null in the IN-list, lower-bound, or
+    // upper-bound column (all three are in lookupInputChannels_ and therefore
+    // in lookupKeyOrConditionHashers_). So every row applyToSelected hands us
+    // is guaranteed non-null in all three; no per-row null guard needed.
+    batch.nonNullInputRows.applyToSelected([&](vector_size_t row) {
+      const auto inSize = inArray->sizeAt(decodedIn.index(row));
+      const auto lowerSize = lowerArray->sizeAt(decodedLower.index(row));
+      const auto upperSize = upperArray->sizeAt(decodedUpper.index(row));
+      VELOX_USER_CHECK_EQ(
+          inSize,
+          lowerSize,
+          "Paired BETWEEN bound and IN list array sizes must match per row; "
+          "row {}: IN list size {} vs lower bound size {}",
+          row,
+          inSize,
+          lowerSize);
+      VELOX_USER_CHECK_EQ(
+          inSize,
+          upperSize,
+          "Paired BETWEEN bound and IN list array sizes must match per row; "
+          "row {}: IN list size {} vs upper bound size {}",
+          row,
+          inSize,
+          upperSize);
+    });
   }
 }
 

--- a/velox/exec/IndexLookupJoin.h
+++ b/velox/exec/IndexLookupJoin.h
@@ -206,6 +206,12 @@ class IndexLookupJoin : public Operator {
   void ensureInputLoaded(const InputBatchState& batch);
   // Prepare index source lookup for a given 'input_'.
   void prepareLookup(InputBatchState& batch);
+  // For each paired BETWEEN whose IN list and bounds are FieldAccess, verify
+  // that every selected row's IN-list, lower-bound, and upper-bound arrays
+  // have the same length. The connector relies on this invariant to pair the
+  // i-th IN-list element with the i-th bound; a mismatch makes the pairing
+  // ill-defined.
+  void validatePairedBetweenSizes(const InputBatchState& batch) const;
   void startLookup(InputBatchState& batch);
 
   // Helper function to merge batch.partialOutputs into a single

--- a/velox/exec/tests/IndexLookupJoinTest.cpp
+++ b/velox/exec/tests/IndexLookupJoinTest.cpp
@@ -578,6 +578,661 @@ TEST_P(IndexLookupJoinTest, planNodeAndSerde) {
   }
 }
 
+TEST_F(IndexLookupJoinTest, pairedBetweenJoinCondition) {
+  TestIndexTableHandle::registerSerDe();
+  auto indexConnectorHandle = makeIndexTableHandle(nullptr, true);
+
+  // Probe input shaped to cover all paired BETWEEN scenarios:
+  //   sid           BIGINT             - left key
+  //   event_types   ARRAY<INTEGER>     - IN list + BETWEEN pairedColumn
+  //   regions       ARRAY<VARCHAR>     - second IN list + second pairedColumn
+  //   lower_ts      ARRAY<BIGINT>      - BETWEEN lower bound array
+  //   upper_ts      ARRAY<BIGINT>      - BETWEEN upper bound array
+  //   lower_users   ARRAY<INTEGER>     - second BETWEEN lower bound array
+  //   upper_users   ARRAY<INTEGER>     - second BETWEEN upper bound array
+  auto left = makeRowVector(
+      {"sid",
+       "event_types",
+       "regions",
+       "lower_ts",
+       "upper_ts",
+       "lower_users",
+       "upper_users"},
+      {makeFlatVector<int64_t>({1}),
+       makeArrayVector<int32_t>(
+           1, [](auto) { return 1; }, [](auto, auto idx) { return idx; }),
+       makeArrayVector<StringView>(
+           1,
+           [](auto) { return 1; },
+           [](auto, auto /*idx*/) { return StringView("us"); }),
+       makeArrayVector<int64_t>(
+           1, [](auto) { return 1; }, [](auto, auto idx) { return idx; }),
+       makeArrayVector<int64_t>(
+           1, [](auto) { return 1; }, [](auto, auto idx) { return idx + 100; }),
+       makeArrayVector<int32_t>(
+           1, [](auto) { return 1; }, [](auto, auto idx) { return idx; }),
+       makeArrayVector<int32_t>(
+           1,
+           [](auto) { return 1; },
+           [](auto, auto idx) { return idx + 100; })});
+
+  auto right = makeRowVector(
+      {"u_sid", "event_type", "region", "ts", "ts2", "user_count"},
+      {makeFlatVector<int64_t>({1}),
+       makeFlatVector<int32_t>({1}),
+       makeFlatVector<StringView>({StringView("us")}),
+       makeFlatVector<int64_t>({100}),
+       makeFlatVector<int64_t>({200}),
+       makeFlatVector<int32_t>({50})});
+
+  auto planBuilder = PlanBuilder();
+  auto indexTableScan = std::dynamic_pointer_cast<const core::TableScanNode>(
+      PlanBuilder::TableScanBuilder(planBuilder)
+          .tableHandle(indexConnectorHandle)
+          .outputType(asRowType(right->type()))
+          .endTableScan()
+          .planNode());
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto probeNode = PlanBuilder(planNodeIdGenerator).values({left}).planNode();
+
+  auto eventTypesField = std::make_shared<core::FieldAccessTypedExpr>(
+      ARRAY(INTEGER()), "event_types");
+  auto lowerTsField =
+      std::make_shared<core::FieldAccessTypedExpr>(ARRAY(BIGINT()), "lower_ts");
+  auto upperTsField =
+      std::make_shared<core::FieldAccessTypedExpr>(ARRAY(BIGINT()), "upper_ts");
+
+  auto inCondition = std::make_shared<core::InIndexLookupCondition>(
+      std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "event_type"),
+      eventTypesField);
+
+  auto buildPlan = [&](std::vector<core::IndexLookupConditionPtr> conditions) {
+    return std::make_shared<core::IndexLookupJoinNode>(
+        planNodeIdGenerator->next(),
+        core::JoinType::kInner,
+        std::vector<core::FieldAccessTypedExprPtr>{
+            std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "sid")},
+        std::vector<core::FieldAccessTypedExprPtr>{
+            std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "u_sid")},
+        std::move(conditions),
+        /*filter=*/nullptr,
+        /*hasMarker=*/false,
+        probeNode,
+        indexTableScan,
+        ROW({"sid", "ts"}, {BIGINT(), BIGINT()}));
+  };
+
+  // Happy path: paired BETWEEN with a matching IN sibling. Serde round-trips
+  // the pairedColumn field.
+  {
+    auto pairedBetween = std::make_shared<core::BetweenIndexLookupCondition>(
+        std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "ts"),
+        lowerTsField,
+        upperTsField,
+        eventTypesField);
+    auto plan = buildPlan({inCondition, pairedBetween});
+    ASSERT_EQ(plan->joinConditions().size(), 2);
+    const auto between =
+        std::dynamic_pointer_cast<const core::BetweenIndexLookupCondition>(
+            plan->joinConditions()[1]);
+    ASSERT_NE(between->pairedColumn, nullptr);
+    ASSERT_EQ(between->pairedColumn->name(), "event_types");
+    testSerde(plan);
+  }
+
+  // Reject: paired BETWEEN with a scalar (non-ARRAY) lower bound. The
+  // BetweenIndexLookupCondition constructor's validate() catches it.
+  {
+    auto scalarLower =
+        std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "sid");
+    VELOX_ASSERT_THROW(
+        std::make_shared<core::BetweenIndexLookupCondition>(
+            std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "ts"),
+            scalarLower,
+            upperTsField,
+            eventTypesField),
+        "Paired between lower bound must be of type ARRAY");
+  }
+
+  // Reject: paired BETWEEN with a constant ARRAY lower bound. Constant bounds
+  // are disallowed because they would force the per-row size check to
+  // special-case "constant array size vs varying IN-list size"; requiring
+  // FieldAccess keeps the invariant uniform across rows.
+  {
+    auto constantLower = std::make_shared<core::ConstantTypedExpr>(
+        ARRAY(BIGINT()),
+        velox::Variant::array({
+            velox::Variant(int64_t(10)),
+            velox::Variant(int64_t(20)),
+        }));
+    VELOX_ASSERT_THROW(
+        std::make_shared<core::BetweenIndexLookupCondition>(
+            std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "ts"),
+            constantLower,
+            upperTsField,
+            eventTypesField),
+        "Paired between lower bound must be a column reference");
+  }
+
+  // Reject: paired BETWEEN with a constant ARRAY upper bound. Mirror of the
+  // case above — confirms both bounds are checked.
+  {
+    auto constantUpper = std::make_shared<core::ConstantTypedExpr>(
+        ARRAY(BIGINT()),
+        velox::Variant::array({
+            velox::Variant(int64_t(100)),
+            velox::Variant(int64_t(200)),
+        }));
+    VELOX_ASSERT_THROW(
+        std::make_shared<core::BetweenIndexLookupCondition>(
+            std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "ts"),
+            lowerTsField,
+            constantUpper,
+            eventTypesField),
+        "Paired between upper bound must be a column reference");
+  }
+
+  // Reject: paired BETWEEN without a matching IN sibling. The
+  // IndexLookupJoinNode constructor's cross-condition check catches it.
+  {
+    auto pairedBetween = std::make_shared<core::BetweenIndexLookupCondition>(
+        std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "ts"),
+        lowerTsField,
+        upperTsField,
+        eventTypesField);
+    VELOX_ASSERT_THROW(
+        buildPlan({pairedBetween}),
+        "must also appear as the list of a sibling IN condition");
+  }
+
+  // Happy path: two paired BETWEENs paired with different IN columns. Each
+  // BETWEEN's pairedColumn names its own partner, so the validation handles
+  // them independently.
+  {
+    auto regionsField = std::make_shared<core::FieldAccessTypedExpr>(
+        ARRAY(VARCHAR()), "regions");
+    auto lowerUsersField = std::make_shared<core::FieldAccessTypedExpr>(
+        ARRAY(INTEGER()), "lower_users");
+    auto upperUsersField = std::make_shared<core::FieldAccessTypedExpr>(
+        ARRAY(INTEGER()), "upper_users");
+    auto inRegions = std::make_shared<core::InIndexLookupCondition>(
+        std::make_shared<core::FieldAccessTypedExpr>(VARCHAR(), "region"),
+        regionsField);
+    auto betweenTs = std::make_shared<core::BetweenIndexLookupCondition>(
+        std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "ts"),
+        lowerTsField,
+        upperTsField,
+        eventTypesField);
+    auto betweenUsers = std::make_shared<core::BetweenIndexLookupCondition>(
+        std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "user_count"),
+        lowerUsersField,
+        upperUsersField,
+        regionsField);
+    auto plan = buildPlan({inCondition, inRegions, betweenTs, betweenUsers});
+    ASSERT_EQ(plan->joinConditions().size(), 4);
+    testSerde(plan);
+  }
+
+  // Happy path: two paired BETWEENs sharing the same paired column. One IN
+  // condition is enough to satisfy both.
+  {
+    auto betweenTs = std::make_shared<core::BetweenIndexLookupCondition>(
+        std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "ts"),
+        lowerTsField,
+        upperTsField,
+        eventTypesField);
+    auto betweenTs2 = std::make_shared<core::BetweenIndexLookupCondition>(
+        std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "ts2"),
+        lowerTsField,
+        upperTsField,
+        eventTypesField);
+    auto plan = buildPlan({inCondition, betweenTs, betweenTs2});
+    ASSERT_EQ(plan->joinConditions().size(), 3);
+    testSerde(plan);
+  }
+
+  // Happy path: a paired BETWEEN and an unpaired BETWEEN in the same join.
+  // The unpaired BETWEEN's bounds are scalars; it does not need any IN
+  // sibling. The cross-condition check should only fire for the paired one.
+  {
+    auto pairedBetween = std::make_shared<core::BetweenIndexLookupCondition>(
+        std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "ts"),
+        lowerTsField,
+        upperTsField,
+        eventTypesField);
+    auto unpairedBetween = std::make_shared<core::BetweenIndexLookupCondition>(
+        std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "ts2"),
+        std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "sid"),
+        std::make_shared<core::ConstantTypedExpr>(
+            BIGINT(), velox::Variant(int64_t(1000))));
+    auto plan = buildPlan({inCondition, pairedBetween, unpairedBetween});
+    ASSERT_EQ(plan->joinConditions().size(), 3);
+    testSerde(plan);
+  }
+}
+
+// Exercises the operator's runtime path for paired BETWEEN:
+// IndexLookupJoin::addBetweenConditionBound is called with isPaired=true,
+// which validates that each bound's probe-input column has type
+// ARRAY(indexKeyType). Plan-construction tests above don't reach this code
+// path because they stop at validate()/serde without running the operator.
+TEST_F(IndexLookupJoinTest, pairedBetweenOperatorRuntime) {
+  TestIndexTableHandle::registerSerDe();
+
+  // TestIndexTable requires every column referenced by a join condition's key
+  // to live in keyData (beyond the numEqualJoinKeys prefix). `event_type` (IN
+  // key) and `ts` (BETWEEN key) go in keyData; valueData carries a placeholder
+  // because valueType must have at least one column.
+  auto keyData = makeRowVector(
+      {"u_sid", "event_type", "ts"},
+      {makeFlatVector<int64_t>({1}),
+       makeFlatVector<int32_t>({1}),
+       makeFlatVector<int64_t>({150})});
+  auto valueData = makeRowVector({"_unused"}, {makeFlatVector<int64_t>({0})});
+  const auto indexTable = TestIndexTable::create(
+      /*numEqualJoinKeys=*/1, keyData, valueData, *pool());
+  const auto indexTableHandle =
+      makeIndexTableHandle(indexTable, /*asyncLookup=*/true);
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  const auto scanOutputType =
+      ROW({"u_sid", "event_type", "ts"}, {BIGINT(), INTEGER(), BIGINT()});
+  const auto indexScanNode = makeIndexScanNode(
+      planNodeIdGenerator,
+      indexTableHandle,
+      scanOutputType,
+      makeIndexColumnHandles({"u_sid", "event_type", "ts"}));
+
+  auto probeInput = makeRowVector(
+      {"sid", "event_types", "lower_ts", "upper_ts"},
+      {makeFlatVector<int64_t>({1}),
+       makeArrayVector<int32_t>(
+           1, [](auto) { return 1; }, [](auto, auto) { return 1; }),
+       makeArrayVector<int64_t>(
+           1, [](auto) { return 1; }, [](auto, auto) { return 100; }),
+       makeArrayVector<int64_t>(
+           1, [](auto) { return 1; }, [](auto, auto) { return 200; })});
+  auto probeNode =
+      PlanBuilder(planNodeIdGenerator).values({probeInput}).planNode();
+
+  auto eventTypesField = std::make_shared<core::FieldAccessTypedExpr>(
+      ARRAY(INTEGER()), "event_types");
+  std::vector<core::IndexLookupConditionPtr> conditions = {
+      std::make_shared<core::InIndexLookupCondition>(
+          std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "event_type"),
+          eventTypesField),
+      std::make_shared<core::BetweenIndexLookupCondition>(
+          std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "ts"),
+          std::make_shared<core::FieldAccessTypedExpr>(
+              ARRAY(BIGINT()), "lower_ts"),
+          std::make_shared<core::FieldAccessTypedExpr>(
+              ARRAY(BIGINT()), "upper_ts"),
+          eventTypesField),
+  };
+
+  auto plan = std::make_shared<core::IndexLookupJoinNode>(
+      planNodeIdGenerator->next(),
+      core::JoinType::kInner,
+      std::vector<core::FieldAccessTypedExprPtr>{
+          std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "sid")},
+      std::vector<core::FieldAccessTypedExprPtr>{
+          std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "u_sid")},
+      std::move(conditions),
+      /*filter=*/nullptr,
+      /*hasMarker=*/false,
+      probeNode,
+      indexScanNode,
+      ROW({"sid", "ts"}, {BIGINT(), BIGINT()}));
+
+  // Running the plan drives the operator's initLookupInput, which calls
+  // addBetweenConditionBound for both `lower_ts` and `upper_ts` with
+  // isPaired=true. The test passes if the operator's type check accepts
+  // ARRAY(BIGINT) for both bounds against the BIGINT index key `ts`.
+  ASSERT_NO_THROW(
+      exec::test::AssertQueryBuilder(plan).copyResults(pool_.get()));
+}
+
+// Null in any of the IN list / lower / upper probe columns: the row is
+// deselected upstream by decodeAndDetectNonNullKeys (every paired-BETWEEN
+// probe column is in lookupKeyOrConditionHashers_), so
+// validatePairedBetweenSizes never sees it. Each sub-case nulls a different
+// column to prove the upstream filter covers all three; if a future refactor
+// drops one from the hasher set this test flips red.
+TEST_F(IndexLookupJoinTest, pairedBetweenNullRowSkipped) {
+  TestIndexTableHandle::registerSerDe();
+
+  auto keyData = makeRowVector(
+      {"u_sid", "event_type", "ts"},
+      {makeFlatVector<int64_t>({1, 2}),
+       makeFlatVector<int32_t>({1, 1}),
+       makeFlatVector<int64_t>({150, 150})});
+  auto valueData =
+      makeRowVector({"_unused"}, {makeFlatVector<int64_t>({0, 0})});
+  const auto indexTable = TestIndexTable::create(
+      /*numEqualJoinKeys=*/1, keyData, valueData, *pool());
+  const auto indexTableHandle =
+      makeIndexTableHandle(indexTable, /*asyncLookup=*/true);
+
+  // For each null-column choice, row 0 is valid (sizes 1/1/1) and row 1 has
+  // a null in the named column with bound sizes that would mismatch if the
+  // size check ever ran on row 1. The runtime should not throw.
+  enum class NullColumn { kIn, kLower, kUpper };
+  auto runWithNullColumn = [&](NullColumn nullColumn) {
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+    const auto indexScanNode = makeIndexScanNode(
+        planNodeIdGenerator,
+        indexTableHandle,
+        ROW({"u_sid", "event_type", "ts"}, {BIGINT(), INTEGER(), BIGINT()}),
+        makeIndexColumnHandles({"u_sid", "event_type", "ts"}));
+
+    // Row 1's non-null arrays are size 2; the would-be IN-list size for that
+    // row (if it weren't null) is 1. Asymmetric sizes ensure any branch that
+    // reads row 1 hits a mismatch. Use makeArrayVector in the non-null branch
+    // to avoid an overload-resolution ambiguity with makeNullableArrayVector
+    // when no std::nullopt is present.
+    auto eventTypes = nullColumn == NullColumn::kIn
+        ? makeNullableArrayVector<int32_t>({{{1}}, std::nullopt})
+        : makeArrayVector<int32_t>({{1}, {1}});
+    auto lowerTs = nullColumn == NullColumn::kLower
+        ? makeNullableArrayVector<int64_t>({{{100}}, std::nullopt})
+        : makeArrayVector<int64_t>({{100}, {100, 110}});
+    auto upperTs = nullColumn == NullColumn::kUpper
+        ? makeNullableArrayVector<int64_t>({{{200}}, std::nullopt})
+        : makeArrayVector<int64_t>({{200}, {200, 210}});
+
+    auto probeInput = makeRowVector(
+        {"sid", "event_types", "lower_ts", "upper_ts"},
+        {makeFlatVector<int64_t>({1, 2}), eventTypes, lowerTs, upperTs});
+    auto probeNode =
+        PlanBuilder(planNodeIdGenerator).values({probeInput}).planNode();
+
+    auto eventTypesField = std::make_shared<core::FieldAccessTypedExpr>(
+        ARRAY(INTEGER()), "event_types");
+    std::vector<core::IndexLookupConditionPtr> conditions = {
+        std::make_shared<core::InIndexLookupCondition>(
+            std::make_shared<core::FieldAccessTypedExpr>(
+                INTEGER(), "event_type"),
+            eventTypesField),
+        std::make_shared<core::BetweenIndexLookupCondition>(
+            std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "ts"),
+            std::make_shared<core::FieldAccessTypedExpr>(
+                ARRAY(BIGINT()), "lower_ts"),
+            std::make_shared<core::FieldAccessTypedExpr>(
+                ARRAY(BIGINT()), "upper_ts"),
+            eventTypesField),
+    };
+
+    auto plan = std::make_shared<core::IndexLookupJoinNode>(
+        planNodeIdGenerator->next(),
+        core::JoinType::kInner,
+        std::vector<core::FieldAccessTypedExprPtr>{
+            std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "sid")},
+        std::vector<core::FieldAccessTypedExprPtr>{
+            std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "u_sid")},
+        std::move(conditions),
+        /*filter=*/nullptr,
+        /*hasMarker=*/false,
+        probeNode,
+        indexScanNode,
+        ROW({"sid", "ts"}, {BIGINT(), BIGINT()}));
+
+    ASSERT_NO_THROW(
+        exec::test::AssertQueryBuilder(plan).copyResults(pool_.get()));
+  };
+
+  runWithNullColumn(NullColumn::kIn);
+  runWithNullColumn(NullColumn::kLower);
+  runWithNullColumn(NullColumn::kUpper);
+}
+
+// Null rows must not mask a real size mismatch elsewhere in the same batch.
+// Row 0 is valid, row 1 has a null IN list (gets filtered upstream), and
+// row 2 has non-null arrays whose sizes disagree. The operator must still
+// throw and must name row 2 in the error so the offending row is identifiable.
+// Guards against a future refactor that accidentally short-circuits the whole
+// check when any row in the batch is null.
+TEST_F(IndexLookupJoinTest, pairedBetweenNullDoesNotMaskMismatch) {
+  TestIndexTableHandle::registerSerDe();
+
+  auto keyData = makeRowVector(
+      {"u_sid", "event_type", "ts"},
+      {makeFlatVector<int64_t>({1, 2, 3}),
+       makeFlatVector<int32_t>({1, 1, 1}),
+       makeFlatVector<int64_t>({150, 150, 150})});
+  auto valueData =
+      makeRowVector({"_unused"}, {makeFlatVector<int64_t>({0, 0, 0})});
+  const auto indexTable = TestIndexTable::create(
+      /*numEqualJoinKeys=*/1, keyData, valueData, *pool());
+  const auto indexTableHandle =
+      makeIndexTableHandle(indexTable, /*asyncLookup=*/true);
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  const auto indexScanNode = makeIndexScanNode(
+      planNodeIdGenerator,
+      indexTableHandle,
+      ROW({"u_sid", "event_type", "ts"}, {BIGINT(), INTEGER(), BIGINT()}),
+      makeIndexColumnHandles({"u_sid", "event_type", "ts"}));
+
+  // Row 0: valid (sizes 1/1/1).
+  // Row 1: event_types null — upstream filter drops this row.
+  // Row 2: event_types size 2, lower/upper size 1 — must trigger the throw.
+  auto probeInput = makeRowVector(
+      {"sid", "event_types", "lower_ts", "upper_ts"},
+      {makeFlatVector<int64_t>({1, 2, 3}),
+       makeNullableArrayVector<int32_t>({{{1}}, std::nullopt, {{1, 2}}}),
+       makeArrayVector<int64_t>({{100}, {100}, {100}}),
+       makeArrayVector<int64_t>({{200}, {200}, {200}})});
+  auto probeNode =
+      PlanBuilder(planNodeIdGenerator).values({probeInput}).planNode();
+
+  auto eventTypesField = std::make_shared<core::FieldAccessTypedExpr>(
+      ARRAY(INTEGER()), "event_types");
+  std::vector<core::IndexLookupConditionPtr> conditions = {
+      std::make_shared<core::InIndexLookupCondition>(
+          std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "event_type"),
+          eventTypesField),
+      std::make_shared<core::BetweenIndexLookupCondition>(
+          std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "ts"),
+          std::make_shared<core::FieldAccessTypedExpr>(
+              ARRAY(BIGINT()), "lower_ts"),
+          std::make_shared<core::FieldAccessTypedExpr>(
+              ARRAY(BIGINT()), "upper_ts"),
+          eventTypesField),
+  };
+
+  auto plan = std::make_shared<core::IndexLookupJoinNode>(
+      planNodeIdGenerator->next(),
+      core::JoinType::kInner,
+      std::vector<core::FieldAccessTypedExprPtr>{
+          std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "sid")},
+      std::vector<core::FieldAccessTypedExprPtr>{
+          std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "u_sid")},
+      std::move(conditions),
+      /*filter=*/nullptr,
+      /*hasMarker=*/false,
+      probeNode,
+      indexScanNode,
+      ROW({"sid", "ts"}, {BIGINT(), BIGINT()}));
+
+  VELOX_ASSERT_THROW(
+      exec::test::AssertQueryBuilder(plan).copyResults(pool_.get()),
+      "row 2: IN list size 2 vs lower bound size 1");
+}
+
+// Per-row size invariant: the IN list and BETWEEN bound arrays must agree in
+// length on every row, because the connector pairs the i-th IN-list element
+// with the i-th lower/upper bound. The operator catches a mismatch in
+// prepareLookup before dispatching to the connector. Each sub-case targets a
+// different shape of mismatch (IN vs lower, IN vs upper, multi-row,
+// empty-array) to make sure no direction or batch position slips through.
+TEST_F(IndexLookupJoinTest, pairedBetweenSizeMismatchRejected) {
+  TestIndexTableHandle::registerSerDe();
+
+  auto keyData = makeRowVector(
+      {"u_sid", "event_type", "ts"},
+      {makeFlatVector<int64_t>({1, 2}),
+       makeFlatVector<int32_t>({1, 1}),
+       makeFlatVector<int64_t>({150, 150})});
+  auto valueData =
+      makeRowVector({"_unused"}, {makeFlatVector<int64_t>({0, 0})});
+  const auto indexTable = TestIndexTable::create(
+      /*numEqualJoinKeys=*/1, keyData, valueData, *pool());
+  const auto indexTableHandle =
+      makeIndexTableHandle(indexTable, /*asyncLookup=*/true);
+
+  // Builds a one-row probe + plan for a given (inSize, lowerSize, upperSize)
+  // triple. Returns the plan; caller asserts the expected throw.
+  auto buildOneRowPlan = [&](vector_size_t inSize,
+                             vector_size_t lowerSize,
+                             vector_size_t upperSize) {
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+    const auto indexScanNode = makeIndexScanNode(
+        planNodeIdGenerator,
+        indexTableHandle,
+        ROW({"u_sid", "event_type", "ts"}, {BIGINT(), INTEGER(), BIGINT()}),
+        makeIndexColumnHandles({"u_sid", "event_type", "ts"}));
+    auto probeInput = makeRowVector(
+        {"sid", "event_types", "lower_ts", "upper_ts"},
+        {makeFlatVector<int64_t>({1}),
+         makeArrayVector<int32_t>(
+             1,
+             [inSize](auto) { return inSize; },
+             [](auto, auto idx) { return idx + 1; }),
+         makeArrayVector<int64_t>(
+             1,
+             [lowerSize](auto) { return lowerSize; },
+             [](auto, auto) { return 100; }),
+         makeArrayVector<int64_t>(
+             1,
+             [upperSize](auto) { return upperSize; },
+             [](auto, auto) { return 200; })});
+    auto probeNode =
+        PlanBuilder(planNodeIdGenerator).values({probeInput}).planNode();
+    auto eventTypesField = std::make_shared<core::FieldAccessTypedExpr>(
+        ARRAY(INTEGER()), "event_types");
+    std::vector<core::IndexLookupConditionPtr> conditions = {
+        std::make_shared<core::InIndexLookupCondition>(
+            std::make_shared<core::FieldAccessTypedExpr>(
+                INTEGER(), "event_type"),
+            eventTypesField),
+        std::make_shared<core::BetweenIndexLookupCondition>(
+            std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "ts"),
+            std::make_shared<core::FieldAccessTypedExpr>(
+                ARRAY(BIGINT()), "lower_ts"),
+            std::make_shared<core::FieldAccessTypedExpr>(
+                ARRAY(BIGINT()), "upper_ts"),
+            eventTypesField),
+    };
+    return std::make_shared<core::IndexLookupJoinNode>(
+        planNodeIdGenerator->next(),
+        core::JoinType::kInner,
+        std::vector<core::FieldAccessTypedExprPtr>{
+            std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "sid")},
+        std::vector<core::FieldAccessTypedExprPtr>{
+            std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "u_sid")},
+        std::move(conditions),
+        /*filter=*/nullptr,
+        /*hasMarker=*/false,
+        probeNode,
+        indexScanNode,
+        ROW({"sid", "ts"}, {BIGINT(), BIGINT()}));
+  };
+
+  // 1. IN list larger than lower bound (IN=2, lower=1, upper=1). Lower is
+  //    checked first, so the error reports the lower-bound size mismatch.
+  VELOX_ASSERT_THROW(
+      exec::test::AssertQueryBuilder(buildOneRowPlan(2, 1, 1))
+          .copyResults(pool_.get()),
+      "IN list size 2 vs lower bound size 1");
+
+  // 2. IN list smaller than lower bound (IN=1, lower=2, upper=1). Same lower
+  //    check fires, but with the inequality reversed.
+  VELOX_ASSERT_THROW(
+      exec::test::AssertQueryBuilder(buildOneRowPlan(1, 2, 1))
+          .copyResults(pool_.get()),
+      "IN list size 1 vs lower bound size 2");
+
+  // 3. Upper bound mismatches IN, lower matches (IN=1, lower=1, upper=2).
+  //    Lower passes, so the failure must come from the upper-bound check.
+  VELOX_ASSERT_THROW(
+      exec::test::AssertQueryBuilder(buildOneRowPlan(1, 1, 2))
+          .copyResults(pool_.get()),
+      "IN list size 1 vs upper bound size 2");
+
+  // 4. IN agrees with lower but not upper (IN=2, lower=2, upper=3). Confirms
+  //    we don't only catch when the inequality bracket is "lower != IN".
+  VELOX_ASSERT_THROW(
+      exec::test::AssertQueryBuilder(buildOneRowPlan(2, 2, 3))
+          .copyResults(pool_.get()),
+      "IN list size 2 vs upper bound size 3");
+
+  // 5. Empty IN list with a non-empty bound (IN=0, lower=1, upper=1).
+  //    Catches the boundary case where the IN list has no elements.
+  VELOX_ASSERT_THROW(
+      exec::test::AssertQueryBuilder(buildOneRowPlan(0, 1, 1))
+          .copyResults(pool_.get()),
+      "IN list size 0 vs lower bound size 1");
+
+  // 6. Mismatch on the second row of a multi-row batch (row 0 OK, row 1 bad).
+  //    Confirms the check iterates all rows, not just the first, and the
+  //    error message names the offending row index.
+  {
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+    const auto indexScanNode = makeIndexScanNode(
+        planNodeIdGenerator,
+        indexTableHandle,
+        ROW({"u_sid", "event_type", "ts"}, {BIGINT(), INTEGER(), BIGINT()}),
+        makeIndexColumnHandles({"u_sid", "event_type", "ts"}));
+    auto probeInput = makeRowVector(
+        {"sid", "event_types", "lower_ts", "upper_ts"},
+        {makeFlatVector<int64_t>({1, 2}),
+         // Row 0: IN size 1; row 1: IN size 2.
+         makeArrayVector<int32_t>(
+             2,
+             [](auto row) { return row == 0 ? 1 : 2; },
+             [](auto, auto idx) { return idx + 1; }),
+         // Both rows have lower/upper size 1 — row 1 is the mismatch.
+         makeArrayVector<int64_t>(
+             2, [](auto) { return 1; }, [](auto, auto) { return 100; }),
+         makeArrayVector<int64_t>(
+             2, [](auto) { return 1; }, [](auto, auto) { return 200; })});
+    auto probeNode =
+        PlanBuilder(planNodeIdGenerator).values({probeInput}).planNode();
+    auto eventTypesField = std::make_shared<core::FieldAccessTypedExpr>(
+        ARRAY(INTEGER()), "event_types");
+    std::vector<core::IndexLookupConditionPtr> conditions = {
+        std::make_shared<core::InIndexLookupCondition>(
+            std::make_shared<core::FieldAccessTypedExpr>(
+                INTEGER(), "event_type"),
+            eventTypesField),
+        std::make_shared<core::BetweenIndexLookupCondition>(
+            std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "ts"),
+            std::make_shared<core::FieldAccessTypedExpr>(
+                ARRAY(BIGINT()), "lower_ts"),
+            std::make_shared<core::FieldAccessTypedExpr>(
+                ARRAY(BIGINT()), "upper_ts"),
+            eventTypesField),
+    };
+    auto plan = std::make_shared<core::IndexLookupJoinNode>(
+        planNodeIdGenerator->next(),
+        core::JoinType::kInner,
+        std::vector<core::FieldAccessTypedExprPtr>{
+            std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "sid")},
+        std::vector<core::FieldAccessTypedExprPtr>{
+            std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "u_sid")},
+        std::move(conditions),
+        /*filter=*/nullptr,
+        /*hasMarker=*/false,
+        probeNode,
+        indexScanNode,
+        ROW({"sid", "ts"}, {BIGINT(), BIGINT()}));
+    VELOX_ASSERT_THROW(
+        exec::test::AssertQueryBuilder(plan).copyResults(pool_.get()),
+        "row 1: IN list size 2 vs lower bound size 1");
+  }
+}
+
 TEST_P(IndexLookupJoinTest, DISABLED_equalJoin) {
   struct {
     std::vector<int> keyCardinalities;

--- a/velox/exec/tests/utils/TestIndexStorageConnector.cpp
+++ b/velox/exec/tests/utils/TestIndexStorageConnector.cpp
@@ -156,6 +156,14 @@ core::TypedExprPtr toJoinConditionExpr(
     if (auto betweenCondition =
             std::dynamic_pointer_cast<core::BetweenIndexLookupCondition>(
                 condition)) {
+      // Paired BETWEEN's per-element pairing semantics aren't expressible
+      // as a single scalar `between(scalar, scalar, scalar)` call. The
+      // test connector skips it here; the IndexLookupJoin operator has
+      // already validated the paired bounds (ARRAY type + element kind
+      // match) before the connector is invoked.
+      if (betweenCondition->pairedColumn != nullptr) {
+        continue;
+      }
       conditionExprs.push_back(
           std::make_shared<const core::CallTypedExpr>(
               BOOLEAN(),


### PR DESCRIPTION
Summary:

Some IndexLookupJoin use cases need a BETWEEN condition whose bounds vary per element of a sibling IN list, rather than per row.

Example. A query joins on:
    event_type IN event_types
    AND ts BETWEEN lower_ts AND upper_ts (paired with event_types)

`event_types`, `lower_ts`, and `upper_ts` are arrays on the probe row. For each probe row, the i-th element of `event_types` is checked against the storage `event_type`, and the BETWEEN evaluates `ts` against `lower_ts[i]` and `upper_ts[i]` for that same i. Without the pairing, the connector would flatten the bounds into a single range across all event types, losing per-element granularity.

This adds an optional `pairedColumn` field on `BetweenIndexLookupCondition`. When set, `lower` and `upper` must be arrays (Velox type `ARRAY(elementType)` matching `key`). The connector forwards the bound arrays and the paired column to its backend, which evaluates the per-element pairing at lookup time.

Validation:
- `BetweenIndexLookupCondition` constructor rejects paired bounds that are not ARRAY, or whose element type does not match the key.
- `IndexLookupJoinNode` constructor rejects a paired BETWEEN whose `pairedColumn` is not also the list of some sibling IN condition in the same join.
- Operator's `addBetweenConditionBound` expects the corresponding probe column to be ARRAY-typed when the BETWEEN is paired.

The field defaults to `nullptr`. Existing callers, serialized plans, and behavior are unchanged.

Differential Revision: D107683671


