### PR TITLE
feat(torchwave): Zero-copy parallel reference-frame load (#17751)

### DIFF
--- a/velox/experimental/torchwave/Utils.cpp
+++ b/velox/experimental/torchwave/Utils.cpp
@@ -18,11 +18,19 @@
 #include "velox/experimental/torchwave/NodePrinter.h"
 #include "velox/experimental/torchwave/WaveConfig.h"
 
-#include <type_traits>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
+#include <cstring>
 #include <fstream>
+#include <memory>
+#include <type_traits>
+#include <vector>
 
 #include <ATen/ATen.h>
+#include <ATen/Parallel.h>
 #include <ATen/core/dispatch/Dispatcher.h>
 #include <c10/util/StringUtil.h>
 #include <fmt/format.h>
@@ -575,59 +583,170 @@ std::string tensorToString(const at::Tensor& t) {
   return ss.str();
 }
 
-void saveReferenceFrame(
-    const nativert::ExecutionFrame& frame,
-    const nativert::Graph& graph,
-    const std::string& path) {
-  c10::impl::GenericDict dict(c10::IntType::get(), c10::AnyType::get());
-  for (const auto* value : graph.values()) {
-    if (!value) {
-      continue;
-    }
-    auto id = value->id();
-    const auto& iv = frame.getIValue(id);
-    if (iv.isNone()) {
-      continue;
-    }
-    if (iv.isTensor()) {
-      const auto& t = iv.toTensor();
-      if (t.numel() > 0) {
-        dict.insert(static_cast<int64_t>(id), c10::IValue(t.cpu()));
-      }
-    } else if (iv.isInt() || iv.isDouble() || iv.isBool()) {
-      dict.insert(static_cast<int64_t>(id), iv);
-    }
-  }
-  auto data = torch::jit::pickle_save(c10::IValue(dict));
-  std::ofstream out(path, std::ios::binary);
-  out.write(data.data(), static_cast<std::streamsize>(data.size()));
+// Reference-frame binary format ("TWREF\0\0\1").
+//
+// The reference frame is a {valueId -> tensor|scalar} map that can be very
+// large (10K+ tensors, multiple GB). The flat-pickle format (torch::jit::
+// pickle_save) inlines every tensor's bytes in one stream, so loading it
+// requires reading the whole file and then memcpy-ing every tensor into a
+// freshly allocated storage, all single-threaded.
+//
+// This format stores each tensor's raw bytes as a separately addressable,
+// 64-byte-aligned region after a small header. Loading mmaps the file and
+// constructs each tensor as a zero-copy view (at::from_blob) over the mapping,
+// in parallel. No per-tensor allocation or copy happens. The mmap is kept
+// alive for the lifetime of the returned tensors via a shared_ptr captured in
+// each tensor's deleter. Endianness is host-native (internal tool).
+namespace {
+
+constexpr char kRefMagic[8] = {'T', 'W', 'R', 'E', 'F', '\0', '\0', '1'};
+
+enum RefKind : int32_t {
+  kRefTensor = 0,
+  kRefInt = 1,
+  kRefDouble = 2,
+  kRefBool = 3,
+};
+
+uint64_t roundUp64(uint64_t x) {
+  return (x + 63) & ~static_cast<uint64_t>(63);
 }
 
-void saveReferenceFrame(
-    const nativert::ExecutionFrame& frame,
-    int32_t numValues,
-    const std::string& path) {
-  c10::impl::GenericDict dict(c10::IntType::get(), c10::AnyType::get());
-  for (int32_t id = 0; id < numValues; ++id) {
-    const auto& iv = frame.getIValue(id);
-    if (iv.isNone()) {
-      continue;
-    }
-    if (iv.isTensor()) {
-      const auto& t = iv.toTensor();
-      if (t.numel() > 0) {
-        dict.insert(static_cast<int64_t>(id), c10::IValue(t.cpu()));
-      }
-    } else if (iv.isInt() || iv.isDouble() || iv.isBool()) {
-      dict.insert(static_cast<int64_t>(id), iv);
+struct RefEntry {
+  int32_t id{0};
+  int32_t kind{0};
+  int32_t scalarType{0}; // tensor only
+  std::vector<int64_t> dims; // tensor only
+  uint64_t offset{0}; // tensor: byte offset of blob; scalar: raw value bits
+  uint64_t length{0}; // tensor: blob byte length; scalar: 0
+};
+
+// RAII holder for an mmap region, shared across all tensors that view it.
+// Non-copyable so the mapping is unmapped exactly once, when the last tensor
+// viewing it is destroyed.
+struct MmapHolder {
+  void* addr;
+  size_t size;
+  MmapHolder(void* a, size_t s) : addr(a), size(s) {}
+  MmapHolder(const MmapHolder&) = delete;
+  MmapHolder& operator=(const MmapHolder&) = delete;
+  MmapHolder(MmapHolder&&) = delete;
+  MmapHolder& operator=(MmapHolder&&) = delete;
+  ~MmapHolder() {
+    if (addr != nullptr && addr != MAP_FAILED) {
+      ::munmap(addr, size);
     }
   }
-  auto data = torch::jit::pickle_save(c10::IValue(dict));
-  std::ofstream out(path, std::ios::binary);
-  out.write(data.data(), static_cast<std::streamsize>(data.size()));
+};
+
+template <typename T>
+void appendPod(std::vector<char>& buf, const T& v) {
+  const char* p = reinterpret_cast<const char*>(&v);
+  buf.insert(buf.end(), p, p + sizeof(T));
 }
 
-std::unordered_map<int32_t, c10::IValue> loadReferenceFrame(
+// Serializes a list of (id, IValue) entries to the TWREF format.
+void serializeReferenceFrame(
+    const std::vector<std::pair<int32_t, c10::IValue>>& items,
+    const std::string& path) {
+  // Hold contiguous CPU copies of tensors alive until they are written.
+  std::vector<at::Tensor> heldTensors;
+  std::vector<RefEntry> entries;
+  std::vector<const void*> blobs;
+  entries.reserve(items.size());
+  blobs.reserve(items.size());
+
+  for (const auto& [id, iv] : items) {
+    RefEntry e{};
+    e.id = id;
+    if (iv.isTensor()) {
+      auto t = iv.toTensor().cpu().contiguous();
+      heldTensors.push_back(t);
+      e.kind = kRefTensor;
+      e.scalarType = static_cast<int32_t>(t.scalar_type());
+      e.dims = t.sizes().vec();
+      e.length = static_cast<uint64_t>(t.nbytes());
+      blobs.push_back(t.data_ptr());
+    } else if (iv.isInt()) {
+      e.kind = kRefInt;
+      int64_t v = iv.toInt();
+      std::memcpy(&e.offset, &v, sizeof(int64_t));
+      blobs.push_back(nullptr);
+    } else if (iv.isDouble()) {
+      e.kind = kRefDouble;
+      double v = iv.toDouble();
+      std::memcpy(&e.offset, &v, sizeof(double));
+      blobs.push_back(nullptr);
+    } else if (iv.isBool()) {
+      e.kind = kRefBool;
+      e.offset = iv.toBool() ? 1 : 0;
+      blobs.push_back(nullptr);
+    } else {
+      continue;
+    }
+    entries.push_back(std::move(e));
+  }
+
+  // Compute header size and per-tensor blob offsets.
+  uint64_t headerSize = sizeof(kRefMagic) + sizeof(uint32_t);
+  for (const auto& e : entries) {
+    headerSize += 4 + 4 + 4 + 4; // id, kind, scalarType, ndim
+    headerSize += sizeof(int64_t) * e.dims.size(); // dims
+    headerSize += 8 + 8; // offset, length
+  }
+  uint64_t dataStart = roundUp64(headerSize);
+  uint64_t cursor = dataStart;
+  for (auto& e : entries) {
+    if (e.kind == kRefTensor) {
+      e.offset = cursor;
+      cursor += roundUp64(e.length);
+    }
+  }
+
+  // Build the header buffer.
+  std::vector<char> header;
+  header.reserve(headerSize);
+  header.insert(header.end(), kRefMagic, kRefMagic + sizeof(kRefMagic));
+  appendPod(header, static_cast<uint32_t>(entries.size()));
+  for (const auto& e : entries) {
+    appendPod(header, e.id);
+    appendPod(header, e.kind);
+    appendPod(header, e.scalarType);
+    appendPod(header, static_cast<int32_t>(e.dims.size()));
+    for (int64_t d : e.dims) {
+      appendPod(header, d);
+    }
+    appendPod(header, e.offset);
+    appendPod(header, e.length);
+  }
+
+  std::ofstream out(path, std::ios::binary);
+  TORCH_CHECK(out.good(), "Cannot open reference frame for write: ", path);
+  out.write(header.data(), static_cast<std::streamsize>(header.size()));
+  // Pad to dataStart.
+  static const char zeros[64] = {0};
+  uint64_t pad = dataStart - header.size();
+  out.write(zeros, static_cast<std::streamsize>(pad));
+  // Write each tensor blob, 64-byte padded.
+  for (size_t i = 0; i < entries.size(); ++i) {
+    const auto& e = entries[i];
+    if (e.kind != kRefTensor) {
+      continue;
+    }
+    out.write(
+        reinterpret_cast<const char*>(blobs[i]),
+        static_cast<std::streamsize>(e.length));
+    uint64_t bpad = roundUp64(e.length) - e.length;
+    while (bpad > 0) {
+      auto n = std::min<uint64_t>(bpad, sizeof(zeros));
+      out.write(zeros, static_cast<std::streamsize>(n));
+      bpad -= n;
+    }
+  }
+}
+
+// Fallback loader for the legacy flat-pickle format.
+std::unordered_map<int32_t, c10::IValue> loadReferenceFramePickle(
     const std::string& path) {
   std::ifstream in(path, std::ios::binary | std::ios::ate);
   TORCH_CHECK(in.good(), "Cannot open reference frame: ", path);
@@ -640,6 +759,164 @@ std::unordered_map<int32_t, c10::IValue> loadReferenceFrame(
   std::unordered_map<int32_t, c10::IValue> result;
   for (const auto& entry : ivalue.toGenericDict()) {
     result[static_cast<int32_t>(entry.key().toInt())] = entry.value();
+  }
+  return result;
+}
+
+} // namespace
+
+void saveReferenceFrame(
+    const nativert::ExecutionFrame& frame,
+    const nativert::Graph& graph,
+    const std::string& path) {
+  std::vector<std::pair<int32_t, c10::IValue>> items;
+  for (const auto* value : graph.values()) {
+    if (!value) {
+      continue;
+    }
+    auto id = value->id();
+    const auto& iv = frame.getIValue(id);
+    if (iv.isNone()) {
+      continue;
+    }
+    if (iv.isTensor()) {
+      if (iv.toTensor().numel() > 0) {
+        items.emplace_back(static_cast<int32_t>(id), iv);
+      }
+    } else if (iv.isInt() || iv.isDouble() || iv.isBool()) {
+      items.emplace_back(static_cast<int32_t>(id), iv);
+    }
+  }
+  serializeReferenceFrame(items, path);
+}
+
+void saveReferenceFrame(
+    const nativert::ExecutionFrame& frame,
+    int32_t numValues,
+    const std::string& path) {
+  std::vector<std::pair<int32_t, c10::IValue>> items;
+  for (int32_t id = 0; id < numValues; ++id) {
+    const auto& iv = frame.getIValue(id);
+    if (iv.isNone()) {
+      continue;
+    }
+    if (iv.isTensor()) {
+      if (iv.toTensor().numel() > 0) {
+        items.emplace_back(id, iv);
+      }
+    } else if (iv.isInt() || iv.isDouble() || iv.isBool()) {
+      items.emplace_back(id, iv);
+    }
+  }
+  serializeReferenceFrame(items, path);
+}
+
+std::unordered_map<int32_t, c10::IValue> loadReferenceFrame(
+    const std::string& path) {
+  int fd = ::open(path.c_str(), O_RDONLY);
+  TORCH_CHECK(fd >= 0, "Cannot open reference frame: ", path);
+  struct stat st{};
+  TORCH_CHECK(::fstat(fd, &st) == 0, "fstat failed: ", path);
+  size_t fileSize = static_cast<size_t>(st.st_size);
+
+  // Detect the format from the magic header; fall back to flat pickle.
+  bool isTwref = false;
+  if (fileSize >= sizeof(kRefMagic)) {
+    char magic[sizeof(kRefMagic)];
+    isTwref = (::pread(fd, magic, sizeof(magic), 0) ==
+               static_cast<ssize_t>(sizeof(magic))) &&
+        std::memcmp(magic, kRefMagic, sizeof(kRefMagic)) == 0;
+  }
+  if (!isTwref) {
+    ::close(fd);
+    return loadReferenceFramePickle(path);
+  }
+
+  void* addr = ::mmap(nullptr, fileSize, PROT_READ, MAP_PRIVATE, fd, 0);
+  ::close(fd);
+  TORCH_CHECK(addr != MAP_FAILED, "mmap failed: ", path);
+  ::madvise(addr, fileSize, MADV_WILLNEED);
+  auto holder = std::make_shared<MmapHolder>(addr, fileSize);
+  const char* base = static_cast<const char*>(addr);
+
+  // Parse the (small) header sequentially.
+  size_t cursor = sizeof(kRefMagic);
+  uint32_t count = 0;
+  std::memcpy(&count, base + cursor, sizeof(count));
+  cursor += sizeof(count);
+
+  std::vector<RefEntry> entries(count);
+  for (uint32_t i = 0; i < count; ++i) {
+    RefEntry& e = entries[i];
+    std::memcpy(&e.id, base + cursor, 4);
+    cursor += 4;
+    std::memcpy(&e.kind, base + cursor, 4);
+    cursor += 4;
+    std::memcpy(&e.scalarType, base + cursor, 4);
+    cursor += 4;
+    int32_t ndim = 0;
+    std::memcpy(&ndim, base + cursor, 4);
+    cursor += 4;
+    e.dims.resize(ndim);
+    for (int32_t d = 0; d < ndim; ++d) {
+      std::memcpy(&e.dims[d], base + cursor, sizeof(int64_t));
+      cursor += sizeof(int64_t);
+    }
+    std::memcpy(&e.offset, base + cursor, 8);
+    cursor += 8;
+    std::memcpy(&e.length, base + cursor, 8);
+    cursor += 8;
+  }
+
+  // Build the IValues in parallel: tensors are zero-copy views over the mmap.
+  std::vector<c10::IValue> values(count);
+  at::parallel_for(
+      0, count, /*grain_size=*/64, [&](int64_t begin, int64_t end) {
+        for (int64_t i = begin; i < end; ++i) {
+          const RefEntry& e = entries[i];
+          switch (e.kind) {
+            case kRefTensor: {
+              auto options =
+                  at::TensorOptions()
+                      .dtype(static_cast<at::ScalarType>(e.scalarType))
+                      .device(at::kCPU);
+              void* data =
+                  const_cast<void*>(static_cast<const void*>(base + e.offset));
+              values[i] = c10::IValue(
+                  at::from_blob(
+                      data,
+                      e.dims,
+                      [holder](
+                          void*) { /* mapping freed when last tensor dies */ },
+                      options));
+              break;
+            }
+            case kRefInt: {
+              int64_t v = 0;
+              std::memcpy(&v, &e.offset, sizeof(int64_t));
+              values[i] = c10::IValue(v);
+              break;
+            }
+            case kRefDouble: {
+              double v = 0;
+              std::memcpy(&v, &e.offset, sizeof(double));
+              values[i] = c10::IValue(v);
+              break;
+            }
+            case kRefBool: {
+              values[i] = c10::IValue(e.offset != 0);
+              break;
+            }
+            default:
+              break;
+          }
+        }
+      });
+
+  std::unordered_map<int32_t, c10::IValue> result;
+  result.reserve(count);
+  for (uint32_t i = 0; i < count; ++i) {
+    result.emplace(entries[i].id, std::move(values[i]));
   }
   return result;
 }


### PR DESCRIPTION
Summary:

Speeds up loading the TorchWave reference frame by switching it from the flat-pickle format (`torch::jit::pickle_save`/`pickle_load`) to a per-tensor record format that can be memory-mapped and loaded with zero copies, in parallel.

The flat pickle inlines every tensor's bytes in one stream, so loading a large frame (10K+ tensors, multiple GB) reads the whole file and then `memcpy`s every tensor into a freshly allocated storage, single-threaded — roughly 2x the tensor bytes copied plus one allocation per tensor, all serial.

New `TWREF` format (magic `TWREF\0\0\1`): a small header of `(id, kind, scalarType, dims, offset, length)` entries followed by each tensor's raw bytes at a 64-byte-aligned offset. `loadReferenceFrame` now `mmap`s the file, parses the header, and constructs each tensor as a zero-copy `at::from_blob` view over the mapping, building the entries with `at::parallel_for`. No per-tensor allocation or copy occurs. The mapping is kept alive for the lifetime of the returned tensors via a `shared_ptr<MmapHolder>` captured in each tensor's deleter (unmapped when the last viewing tensor dies). Scalars (int/double/bool) are stored inline in the header.

`loadReferenceFrame` detects the format from the magic header and falls back to the legacy flat-pickle loader for older files, so existing `.pt` reference frames still load. Both `saveReferenceFrame` overloads share a single `serializeReferenceFrame` writer. Endianness is host-native (internal tool).

Reviewed By: Yuhta

Differential Revision: D107695770


