### PR TITLE
fix(ucx): Preserve shared exchange client on operator close

### DIFF
--- a/velox/experimental/ucx-exchange/UcxExchange.cpp
+++ b/velox/experimental/ucx-exchange/UcxExchange.cpp
@@ -44,6 +44,7 @@ UcxExchange::UcxExchange(
           fmt::format("[{}]", planNode->id())),
       preferredOutputBatchBytes_{
           driverCtx->queryConfig().preferredOutputBatchBytes()},
+      closeExchangeClientOnClose_{ucxExchangeClient == nullptr},
       processSplits_{driverCtx->driverId == 0},
       pipelineId_{driverCtx->pipelineId},
       driverId_{driverCtx->driverId} {
@@ -217,7 +218,9 @@ void UcxExchange::close() {
   currentData_.reset();
   if (exchangeClient_) {
     recordExchangeClientStats();
-    exchangeClient_->close();
+    if (closeExchangeClientOnClose_) {
+      exchangeClient_->close();
+    }
   }
   exchangeClient_ = nullptr;
 }

--- a/velox/experimental/ucx-exchange/UcxExchange.h
+++ b/velox/experimental/ucx-exchange/UcxExchange.h
@@ -77,6 +77,7 @@ class UcxExchange : public SourceOperator, public cudf_velox::NvtxHelper {
   std::shared_ptr<UcxExchangeClient> exchangeClient_;
 
   const uint64_t preferredOutputBatchBytes_;
+  const bool closeExchangeClientOnClose_;
 
   /// True if this operator is responsible for fetching splits from the Task
   /// and passing these to ExchangeClient. When running with multile drivers,

--- a/velox/experimental/ucx-exchange/UcxExchange.h
+++ b/velox/experimental/ucx-exchange/UcxExchange.h
@@ -77,6 +77,8 @@ class UcxExchange : public SourceOperator, public cudf_velox::NvtxHelper {
   std::shared_ptr<UcxExchangeClient> exchangeClient_;
 
   const uint64_t preferredOutputBatchBytes_;
+  // True only when this operator created the client itself. An externally
+  // shared client is left for its owner or final shared_ptr release to close.
   const bool closeExchangeClientOnClose_;
 
   /// True if this operator is responsible for fetching splits from the Task

--- a/velox/experimental/ucx-exchange/tests/UcxExchangeTest.cpp
+++ b/velox/experimental/ucx-exchange/tests/UcxExchangeTest.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/experimental/ucx-exchange/UcxExchange.h"
 #include <cudf/column/column_factories.hpp>
 #include <cudf/contiguous_split.hpp>
 #include <cudf/copying.hpp>
@@ -36,7 +37,6 @@
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/ucx-exchange/Communicator.h"
-#include "velox/experimental/ucx-exchange/UcxExchange.h"
 #include "velox/experimental/ucx-exchange/UcxExchangeProtocol.h"
 #include "velox/experimental/ucx-exchange/UcxOutputQueueManager.h"
 #include "velox/experimental/ucx-exchange/tests/SinkDriverMock.h"

--- a/velox/experimental/ucx-exchange/tests/UcxExchangeTest.cpp
+++ b/velox/experimental/ucx-exchange/tests/UcxExchangeTest.cpp
@@ -59,6 +59,8 @@ struct ExchangeTestParams {
   int numRowsPerChunk;
   int numUpstreamTasks;
   TableType tableType = TableType::NARROW; // Default to narrow table
+
+  bool operator==(const ExchangeTestParams&) const = default;
 };
 
 // Helper function to generate test parameters with different numUpstreamTasks
@@ -827,19 +829,15 @@ TEST_P(UcxExchangeTest, realPartitionedOutputDataIntegrityTest) {
   VLOG(3) << "- UcxExchangeTest::realPartitionedOutputDataIntegrityTest";
 }
 
-// Regression test for shared UcxExchangeClient ownership. Multiple
-// UcxExchange operators in a sink task share one client. Closing one operator
-// must not close the shared client while another operator still needs to drain
-// data.
+// Focused regression test for shared UcxExchangeClient ownership. This
+// intentionally creates and seeds the client directly, bypassing the normal
+// task-split path, to isolate close behavior after the client is populated.
+// Closing one operator must not close the shared client while another operator
+// still needs to drain data.
 TEST_P(UcxExchangeTest, sharedClientSurvivesOneExchangeClose) {
   // This test doesn't use parameters - run only for the first param set.
-  {
-    ExchangeTestParams p = GetParam();
-    if (p.numSrcDrivers != 1 || p.numDstDrivers != 1 || p.numPartitions != 1 ||
-        p.numChunks != 100 || p.numUpstreamTasks != 1 ||
-        p.tableType != TableType::NARROW) {
-      GTEST_SKIP() << "sharedClientSurvivesOneExchangeClose: runs only once";
-    }
+  if (GetParam() != generateTestParams().front()) {
+    GTEST_SKIP() << "sharedClientSurvivesOneExchangeClose: runs only once";
   }
 
   const std::string taskPrefix = getUniqueTaskPrefix();

--- a/velox/experimental/ucx-exchange/tests/UcxExchangeTest.cpp
+++ b/velox/experimental/ucx-exchange/tests/UcxExchangeTest.cpp
@@ -36,6 +36,7 @@
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/ucx-exchange/Communicator.h"
+#include "velox/experimental/ucx-exchange/UcxExchange.h"
 #include "velox/experimental/ucx-exchange/UcxExchangeProtocol.h"
 #include "velox/experimental/ucx-exchange/UcxOutputQueueManager.h"
 #include "velox/experimental/ucx-exchange/tests/SinkDriverMock.h"
@@ -824,6 +825,101 @@ TEST_P(UcxExchangeTest, realPartitionedOutputDataIntegrityTest) {
   queueManager_->removeTask(srcTaskId);
 
   VLOG(3) << "- UcxExchangeTest::realPartitionedOutputDataIntegrityTest";
+}
+
+// Regression test for shared UcxExchangeClient ownership. Multiple
+// UcxExchange operators in a sink task share one client. Closing one operator
+// must not close the shared client while another operator still needs to drain
+// data.
+TEST_P(UcxExchangeTest, sharedClientSurvivesOneExchangeClose) {
+  // This test doesn't use parameters - run only for the first param set.
+  {
+    ExchangeTestParams p = GetParam();
+    if (p.numSrcDrivers != 1 || p.numDstDrivers != 1 || p.numPartitions != 1 ||
+        p.numChunks != 100 || p.numUpstreamTasks != 1 ||
+        p.tableType != TableType::NARROW) {
+      GTEST_SKIP() << "sharedClientSurvivesOneExchangeClose: runs only once";
+    }
+  }
+
+  const std::string taskPrefix = getUniqueTaskPrefix();
+  const std::string srcTaskId = taskPrefix + "sharedClientSrc";
+  const std::string sinkTaskId = taskPrefix + "sharedClientSink";
+  const int numPartitions = 1;
+  const int partitionId = 0;
+  const int numSourceDrivers = 1;
+  const int numSinkDrivers = 2;
+  const int numChunks = 5;
+  const int numRowsPerChunk = 1000;
+
+  auto rowType = UcxTestData::kTestRowType;
+  auto srcTask = createSourceTask(srcTaskId, pool_, rowType);
+  queueManager_->initializeTask(
+      srcTask,
+      core::PartitionedOutputNode::Kind::kPartitioned,
+      numPartitions,
+      numSourceDrivers);
+
+  auto sourceMock = std::make_shared<UcxPartitionedOutputMock>(
+      srcTaskId, numSourceDrivers, numPartitions, numChunks, numRowsPerChunk);
+  sourceMock->run();
+  sourceMock->joinThreads();
+
+  core::PlanNodeId exchangeNodeId;
+  auto sinkTask =
+      createExchangeTask(sinkTaskId, rowType, partitionId, exchangeNodeId);
+  auto exchangeClient = std::make_shared<UcxExchangeClient>(
+      sinkTask->taskId(), sinkTask->destination(), numSinkDrivers);
+
+  auto split = remoteSplit(srcTaskId, partitionId);
+  auto remoteConnectorSplit =
+      std::dynamic_pointer_cast<exec::RemoteConnectorSplit>(
+          split.connectorSplit);
+  ASSERT_NE(remoteConnectorSplit, nullptr);
+  exchangeClient->addRemoteTaskId(remoteConnectorSplit->taskId);
+  exchangeClient->noMoreRemoteTasks();
+
+  const uint32_t pipelineId = 0;
+  const uint32_t partition = 0;
+  auto planNode = sinkTask->planFragment().planNode;
+  auto closingDriverCtx = std::make_shared<DriverCtx>(
+      sinkTask, 0, pipelineId, kUngroupedGroupId, partition);
+  auto drainingDriverCtx = std::make_shared<DriverCtx>(
+      sinkTask, 1, pipelineId, kUngroupedGroupId, partition);
+
+  UcxExchange closingExchange(
+      0, closingDriverCtx.get(), planNode, exchangeClient);
+  UcxExchange drainingExchange(
+      1, drainingDriverCtx.get(), planNode, exchangeClient);
+
+  closingExchange.close();
+
+  uint64_t rowsReceived = 0;
+  while (true) {
+    ContinueFuture future;
+    auto blocked = drainingExchange.isBlocked(&future);
+    if (blocked != BlockingReason::kNotBlocked) {
+      future.wait();
+      continue;
+    }
+
+    RowVectorPtr result = drainingExchange.getOutput();
+    if (result) {
+      auto cudfResult =
+          std::dynamic_pointer_cast<cudf_velox::CudfVector>(result);
+      ASSERT_NE(cudfResult, nullptr);
+      rowsReceived += cudfResult->getTableView().num_rows();
+    }
+
+    if (drainingExchange.isFinished()) {
+      break;
+    }
+  }
+  drainingExchange.close();
+
+  EXPECT_EQ(rowsReceived, static_cast<uint64_t>(numChunks) * numRowsPerChunk);
+
+  queueManager_->removeTask(srcTaskId);
 }
 
 // Test that verifies intra-node exchange does not livelock when a producing


### PR DESCRIPTION
UcxExchange operators can share a UcxExchangeClient across sink drivers. Closing one operator should release its reference, but must not close the shared client while sibling operators still need to drain data.

Track whether the operator created the client itself and only close internally owned clients from UcxExchange::close(). Externally supplied clients are left to their owner / final shared_ptr release.

Add a regression test that closes one exchange sharing a client and verifies a second exchange can still receive all rows.

Validated via the ucx_exchange_test regression fails before the fix and passes after it.