### PR TITLE
fix(UCX): Fix UCX intra-node fast-path selection

### DIFF
--- a/velox/experimental/ucx-exchange/UcxQueues.cpp
+++ b/velox/experimental/ucx-exchange/UcxQueues.cpp
@@ -147,6 +147,7 @@ UcxOutputQueue::UcxOutputQueue(
   if (task_) {
     maxSize_ = task_->queryCtx()->queryConfig().maxOutputBufferSize();
     continueSize_ = (maxSize_ * kContinuePct) / 100;
+    initialized_.store(true, std::memory_order_release);
   } // else: maxSize_ and continueSize_ will be set once the task is created and
     // initialize called.
   // create a queue for each destination.
@@ -172,16 +173,15 @@ bool UcxOutputQueue::initialize(
   task_ = task;
   maxSize_ = task_->queryCtx()->queryConfig().maxOutputBufferSize();
   continueSize_ = (maxSize_ * kContinuePct) / 100;
+  // Publish task metadata before destination queue expansion. Acceptor only
+  // needs task/kind to choose the intra-node path; getData() takes mutex_ and
+  // waits for any queue expansion in this function to finish.
+  initialized_.store(true, std::memory_order_release);
   // create additional queues if there are more destinations.
   for (int i = queues_.size(); i < numDestinations; ++i) {
     // create the destination queues inside the vector using emplace_back.
     queues_.emplace_back(std::make_unique<UcxDestinationQueue>());
   }
-  // Publish the initialized flag last with release semantics. Lock-free
-  // readers (canUseIntraNode → isInitialized) use an acquire load, so
-  // all writes above (kind_, task_, queues_, etc.) are guaranteed visible
-  // once they observe initialized_ == true.
-  initialized_.store(true, std::memory_order_release);
   return true;
 }
 

--- a/velox/experimental/ucx-exchange/UcxQueues.h
+++ b/velox/experimental/ucx-exchange/UcxQueues.h
@@ -158,12 +158,10 @@ class UcxOutputQueue : public std::enable_shared_from_this<UcxOutputQueue> {
     return kind_;
   }
 
-  /// Returns true if this queue has been initialized via initializeTask()
+  /// Returns true once task metadata has been published via initializeTask()
   /// (not just a placeholder created by early getData() calls).
-  /// Uses an acquire load so that all fields written before the release
-  /// store in initialize() (kind_, numDrivers_, task_, etc.) are visible
-  /// to the caller. This makes lock-free reads from canUseIntraNode()
-  /// safe across threads.
+  /// This is published before destination queue expansion completes so local
+  /// UCX handshakes do not permanently fall back to the remote path.
   bool isInitialized() const {
     return initialized_.load(std::memory_order_acquire);
   }
@@ -274,9 +272,9 @@ class UcxOutputQueue : public std::enable_shared_from_this<UcxOutputQueue> {
   core::PartitionedOutputNode::Kind kind_{
       core::PartitionedOutputNode::Kind::kPartitioned};
 
-  // Set to true at the end of initialize() with memory_order_release.
-  // Lock-free readers (canUseIntraNode) load with memory_order_acquire
-  // so that all fields written before the store are visible.
+  // Set to true once task metadata is available. Lock-free readers
+  // (canUseIntraNode) load with memory_order_acquire so kind_ and task_
+  // written before the store are visible.
   std::atomic<bool> initialized_{false};
 
   // For broadcast: stores data for late-arriving destinations that need


### PR DESCRIPTION
...by publishing output queue readiness earlier.

UCX output queues can be created as placeholders when a consumer asks for data before the producing task has finished initializing its output queue. The acceptor uses UcxOutputQueueManager::canUseIntraNode() during handshake to decide whether a same-worker exchange can use the in-process intra-node path.

Before this change, UcxOutputQueue::initialized_ was published only after initialize() finished expanding destination queues. A handshake arriving in that window could observe the queue as uninitialized and permanently disable the intra-node path for that connection, even though task metadata was already available. That sent same-worker transfers down the remote UCX path and caused the Q21 performance regression.

Publish initialized_ immediately after task metadata is installed: task, kind, driver count, and output-buffer limits. This is enough for canUseIntraNode() to safely choose the intra-node path. Destination queue expansion still happens under UcxOutputQueue::mutex_, and getData() also takes that mutex, so consumers cannot race ahead of the queue expansion.

This changes the meaning of initialized_ from "all destination queues expanded" to "task metadata is published and the queue is safe for handshake-time routing".

(cherry picked from commit 9b7821394db81830e0a04bfa88867e412daa2f36)