### PR TITLE
fix(cudf): Transfer hash join build input ownership

### DIFF
--- a/velox/experimental/cudf/exec/CMakeLists.txt
+++ b/velox/experimental/cudf/exec/CMakeLists.txt
@@ -55,6 +55,7 @@ target_link_libraries(
     velox_cudf_vector
     velox_exception
     velox_exec
+    velox_test_util
 )
 
 target_compile_options(velox_cudf_exec PRIVATE -Wno-missing-field-initializers)

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -24,6 +24,7 @@
 #include "velox/experimental/cudf/expression/AstExpressionUtils.h"
 #include "velox/experimental/cudf/expression/ExpressionEvaluator.h"
 
+#include "velox/common/testutil/TestValue.h"
 #include "velox/core/PlanNode.h"
 #include "velox/exec/Task.h" // NOLINT(misc-unused-headers)
 #include "velox/type/TypeUtil.h"
@@ -52,6 +53,8 @@
 #include <rmm/exec_policy.hpp>
 
 #include <nvtx3/nvtx3.hpp>
+
+#include <iterator>
 
 namespace facebook::velox::cudf_velox {
 
@@ -193,7 +196,15 @@ void CudfHashJoinBuild::doNoMoreInput() {
     auto op = peer->findOperator(planNodeId());
     auto* build = dynamic_cast<CudfHashJoinBuild*>(op);
     VELOX_CHECK_NOT_NULL(build);
-    inputs_.insert(inputs_.end(), build->inputs_.begin(), build->inputs_.end());
+    inputs_.insert(
+        inputs_.end(),
+        std::make_move_iterator(build->inputs_.begin()),
+        std::make_move_iterator(build->inputs_.end()));
+    build->inputs_.clear();
+    auto retainedInputBatches = build->inputs_.size();
+    common::testutil::TestValue::adjust(
+        "facebook::velox::cudf_velox::CudfHashJoinBuild::doNoMoreInput::sourceDriverRetainedInputBatchesAfterTransfer",
+        &retainedInputBatches);
   }
 
   SCOPE_EXIT {

--- a/velox/experimental/cudf/tests/HashJoinTest.cpp
+++ b/velox/experimental/cudf/tests/HashJoinTest.cpp
@@ -230,8 +230,6 @@ DEBUG_ONLY_TEST_F(HashJoinTest, transferBuildInputOwnershipFromSourceDrivers) {
   // Run two build drivers, the last driver transfers input from the other
   // driver.
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-      // HashJoinBuilder defaults to extra spill-injection runs; this check only
-      // needs the ordinary two-driver build-input transfer path.
       .injectSpill(false)
       // Only the build side needs parallelization for this ownership transfer.
       .numDrivers(

--- a/velox/experimental/cudf/tests/HashJoinTest.cpp
+++ b/velox/experimental/cudf/tests/HashJoinTest.cpp
@@ -39,6 +39,8 @@
 #include <fmt/format.h>
 #include <re2/re2.h>
 
+#include <atomic>
+
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
@@ -210,6 +212,42 @@ TEST_P(MultiThreadedHashJoinTest, emptyProbe) {
         }
       })
       .run();
+}
+
+DEBUG_ONLY_TEST_F(HashJoinTest, transferBuildInputOwnershipFromSourceDrivers) {
+  std::atomic_size_t sourceDriversChecked{0};
+  std::atomic_size_t sourceDriversWithRetainedInputs{0};
+
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::cudf_velox::CudfHashJoinBuild::doNoMoreInput::sourceDriverRetainedInputBatchesAfterTransfer",
+      std::function<void(size_t*)>([&](size_t* retainedInputBatches) {
+        ++sourceDriversChecked;
+        if (*retainedInputBatches != 0) {
+          ++sourceDriversWithRetainedInputs;
+        }
+      }));
+
+  // Run two build drivers, the last driver transfers input from the other
+  // driver.
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      // HashJoinBuilder defaults to extra spill-injection runs; this check only
+      // needs the ordinary two-driver build-input transfer path.
+      .injectSpill(false)
+      // Only the build side needs parallelization for this ownership transfer.
+      .numDrivers(
+          2,
+          /*runParallelProbe=*/false,
+          /*runParallelBuild=*/true)
+      .keyTypes({BIGINT()})
+      .probeVectors(10, 1)
+      .buildVectors(10, 1)
+      .referenceQuery(
+          "SELECT t_k0, t_data, u_k0, u_data FROM t, u WHERE t_k0 = u_k0")
+      .run();
+
+  EXPECT_EQ(sourceDriversChecked.load(), 1);
+  EXPECT_EQ(sourceDriversWithRetainedInputs.load(), 0)
+      << "Source build drivers retained input batches after transfer";
 }
 
 TEST_P(MultiThreadedHashJoinTest, normalizedKey) {


### PR DESCRIPTION
* CudfHashJoinBuild gathers build-side inputs from peer drivers before constructing the shared cuDF hash join state. The lifetime of the peer driver's `std::shared_ptr` could exceed more than was necessary.

* Move peer driver's input references into the owning build operator and clear peer input vectors after transfer. This more closely matches expected ownership.

* Add debug-only coverage for the multi-driver transfer path to verify this behaviour.