### PR TITLE
feat(cudf): Support DATE identity partition columns in Iceberg reader

### DIFF
--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
@@ -26,19 +26,23 @@
 #include "velox/common/encode/Base64.h"
 #include "velox/connectors/hive/iceberg/IcebergMetadataColumns.h"
 #include "velox/dwio/common/BufferUtil.h"
+#include "velox/type/Type.h"
 
 #include <cudf/column/column_factories.hpp>
 #include <cudf/io/parquet.hpp>
 #include <cudf/io/parquet_metadata.hpp>
 #include <cudf/null_mask.hpp>
+#include <cudf/scalar/scalar.hpp>
 #include <cudf/scalar/scalar_factories.hpp>
 #include <cudf/stream_compaction.hpp>
 #include <cudf/unary.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/span.hpp>
+#include <cudf/wrappers/timestamps.hpp>
 
 #include <rmm/device_buffer.hpp>
 
+#include <folly/Conv.h>
 #include <folly/lang/Bits.h>
 
 #include <cstring>
@@ -571,9 +575,10 @@ std::unique_ptr<cudf::table> CudfIcebergSplitReader::injectMissingColumns(
           const InjectedColumn& col) -> std::unique_ptr<cudf::scalar> {
     if (cudfType.id() != cudf::type_id::STRING and
         cudfType.id() != cudf::type_id::INT32 and
-        cudfType.id() != cudf::type_id::INT64) {
+        cudfType.id() != cudf::type_id::INT64 and
+        cudfType.id() != cudf::type_id::TIMESTAMP_DAYS) {
       VELOX_NYI(
-          "Identity partition columns are limited to VARCHAR, INTEGER, and BIGINT only. Other types are not yet supported. Column: '{}', Type: {}",
+          "Identity partition columns are limited to VARCHAR, INTEGER, BIGINT, and DATE only. Other types are not yet supported. Column: '{}', Type: {}",
           col.name,
           col.veloxType->toString());
     }
@@ -588,6 +593,23 @@ std::unique_ptr<cudf::table> CudfIcebergSplitReader::injectMissingColumns(
         case cudf::type_id::INT64:
           return std::make_unique<cudf::numeric_scalar<int64_t>>(
               folly::to<int64_t>(value), true, stream_, mr);
+        case cudf::type_id::TIMESTAMP_DAYS: {
+          // DATE partition values arrive either as days-since-epoch (Iceberg
+          // native) or as a date string such as "2025-06-05" (Hive migrated).
+          // The two encodings are disjoint: DATE()->toDays() uses Presto cast
+          // semantics, which reject a bare integer, while a date string always
+          // contains '-' separators that fail integer parsing. So an all-digit
+          // value is unambiguously days-since-epoch, and anything else is
+          // parsed as a date string.
+          const int32_t days = [&] {
+            if (auto parsed = folly::tryTo<int32_t>(value)) {
+              return parsed.value();
+            }
+            return DATE()->toDays(value);
+          }();
+          return std::make_unique<cudf::timestamp_scalar<cudf::timestamp_D>>(
+              days, true, stream_, mr);
+        }
         default:
           VELOX_UNREACHABLE();
       }

--- a/velox/experimental/cudf/tests/iceberg/CudfIcebergReadTest.cpp
+++ b/velox/experimental/cudf/tests/iceberg/CudfIcebergReadTest.cpp
@@ -1180,4 +1180,70 @@ TEST_F(CudfIcebergReadTest, partitionColumnsFromHive) {
   AssertQueryBuilder(plan).splits(icebergSplits).assertResults({expected});
 }
 
+// Test reading a DATE identity partition column. DATE partition values arrive
+// in two encodings: Hive-migrated tables store a date string ("2025-06-05")
+// while Iceberg-native tables store days-since-epoch ("20244"). Both must
+// decode to the same DATE result.
+TEST_F(CudfIcebergReadTest, partitionColumnsDate) {
+  auto fileRowType = ROW({"c0"}, {BIGINT()});
+  auto tableRowType = ROW({"c0", "partitiondate"}, {BIGINT(), DATE()});
+
+  // Write a data file with only the non-partition column c0.
+  auto dataVector = makeRowVector({
+      makeFlatVector<int64_t>({1, 2, 3}),
+  });
+  auto dataFilePath = TempFilePath::create();
+  writeToFile(dataFilePath->getPath(), dataVector);
+
+  // 2025-06-05 is 20244 days since the Unix epoch.
+  const int32_t kDays = DATE()->toDays("2025-06-05");
+
+  // Build column handles marking partitiondate as a partition key.
+  facebook::velox::connector::ColumnHandleMap assignments;
+  for (uint32_t i = 0; i < tableRowType->size(); ++i) {
+    const auto& name = tableRowType->nameOf(i);
+    auto columnType = (i >= fileRowType->size())
+        ? HiveColumnHandle::ColumnType::kPartitionKey
+        : HiveColumnHandle::ColumnType::kRegular;
+    assignments[name] = std::make_shared<HiveColumnHandle>(
+        name,
+        columnType,
+        tableRowType->childAt(i),
+        tableRowType->childAt(i),
+        std::vector<common::Subfield>{});
+  }
+
+  auto expected = makeRowVector(
+      tableRowType->names(),
+      {
+          dataVector->childAt(0),
+          makeFlatVector<int32_t>({kDays, kDays, kDays}, DATE()),
+      });
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kCudfIcebergConnectorId)
+                  .outputType(tableRowType)
+                  .dataColumns(tableRowType)
+                  .assignments(assignments)
+                  .endTableScan()
+                  .planNode();
+
+  // Encoding 1: Hive-migrated date string.
+  {
+    std::unordered_map<std::string, std::optional<std::string>> partitionKeys;
+    partitionKeys["partitiondate"] = "2025-06-05";
+    auto splits = makeIcebergSplits(dataFilePath->getPath(), {}, partitionKeys);
+    AssertQueryBuilder(plan).splits(splits).assertResults({expected});
+  }
+
+  // Encoding 2: Iceberg-native days-since-epoch.
+  {
+    std::unordered_map<std::string, std::optional<std::string>> partitionKeys;
+    partitionKeys["partitiondate"] = folly::to<std::string>(kDays);
+    auto splits = makeIcebergSplits(dataFilePath->getPath(), {}, partitionKeys);
+    AssertQueryBuilder(plan).splits(splits).assertResults({expected});
+  }
+}
+
 } // namespace facebook::velox::cudf_velox::exec::test


### PR DESCRIPTION
## Summary

The cuDF Iceberg reader injects identity partition columns as constant columns
when they are absent from the Parquet data files. The current implementation
restricts these columns to `VARCHAR`, `INTEGER`, and `BIGINT`, so a `DATE`
identity partition column fails with:

```
VELOX_NYI: Identity partition columns are limited to VARCHAR, INTEGER, and
BIGINT only ... Column: 'partitiondate', Type: DATE
```

This was introduced in #17054.

This PR adds `DATE` support. `DATE()` already maps to
`cudf::type_id::TIMESTAMP_DAYS` (int32 days since epoch), so only scalar
construction from the partition value string was missing.

## Encoding

DATE partition values arrive in one of two encodings, which are format-disjoint:

- **Iceberg native** — days-since-epoch integer (e.g. `20244`).
- **Hive migrated** — a date string such as `2025-06-05`.

The two are distinguished by attempting an integer parse first (Iceberg native);
on failure we fall back to `DATE()->toDays(value)` (Hive date string).
`DATE()->toDays()` uses Presto cast semantics, which reject a bare integer, while
a date string always contains `-` separators that fail integer parsing — so an
all-digit value is unambiguously days-since-epoch and anything else is parsed as
a date string.

## Test plan

Added `CudfIcebergReadTest.partitionColumnsDate`, which exercises both encodings
(a Hive date string `2025-06-05` and the equivalent days-since-epoch integer) and
asserts the same expected `DATE` column. The full
`velox_cudf_iceberg_read_test` suite passes.
