### PR TITLE
Support duplicate regions in DirectBufferedInput

### DIFF
--- a/velox/common/memory/Allocation.cpp
+++ b/velox/common/memory/Allocation.cpp
@@ -16,6 +16,9 @@
 
 #include "velox/common/memory/Allocation.h"
 
+#include <algorithm>
+#include <cstring>
+
 #include "velox/common/memory/Memory.h"
 
 namespace facebook::velox::memory {
@@ -52,6 +55,41 @@ void Allocation::appendMove(Allocation& other) {
   }
   other.runs_.clear();
   other.numPages_ = 0;
+}
+
+/*static*/ void
+Allocation::copy(const Allocation& source, Allocation& target, uint64_t bytes) {
+  VELOX_CHECK_LE(bytes, source.byteSize());
+  VELOX_CHECK_LE(bytes, target.byteSize());
+
+  int32_t sourceRunIndex = 0;
+  int32_t targetRunIndex = 0;
+  uint64_t sourceOffsetInRun = 0;
+  uint64_t targetOffsetInRun = 0;
+  uint64_t copiedBytes = 0;
+  while (copiedBytes < bytes) {
+    auto sourceRun = source.runAt(sourceRunIndex);
+    auto targetRun = target.runAt(targetRunIndex);
+    const auto bytesToCopy = std::min<uint64_t>(
+        {sourceRun.numBytes() - sourceOffsetInRun,
+         targetRun.numBytes() - targetOffsetInRun,
+         bytes - copiedBytes});
+    std::memcpy(
+        targetRun.data<char>() + targetOffsetInRun,
+        sourceRun.data<const char>() + sourceOffsetInRun,
+        bytesToCopy);
+    copiedBytes += bytesToCopy;
+    sourceOffsetInRun += bytesToCopy;
+    targetOffsetInRun += bytesToCopy;
+    if (sourceOffsetInRun == sourceRun.numBytes()) {
+      ++sourceRunIndex;
+      sourceOffsetInRun = 0;
+    }
+    if (targetOffsetInRun == targetRun.numBytes()) {
+      ++targetRunIndex;
+      targetOffsetInRun = 0;
+    }
+  }
 }
 
 void Allocation::findRun(uint64_t offset, int32_t* index, int32_t* offsetInRun)

--- a/velox/common/memory/Allocation.h
+++ b/velox/common/memory/Allocation.h
@@ -120,6 +120,10 @@ class Allocation {
     other.clear();
   }
 
+  /// Copies 'bytes' from 'source' to 'target'.
+  static void
+  copy(const Allocation& source, Allocation& target, uint64_t bytes);
+
   MachinePageCount numPages() const {
     return numPages_;
   }
@@ -194,6 +198,8 @@ class Allocation {
   VELOX_FRIEND_TEST(MemoryAllocatorTest, allocationClass2);
   VELOX_FRIEND_TEST(AllocationTest, append);
   VELOX_FRIEND_TEST(AllocationTest, appendMove);
+  VELOX_FRIEND_TEST(AllocationTest, copy);
+  VELOX_FRIEND_TEST(AllocationTest, copyOutOfRange);
   VELOX_FRIEND_TEST(AllocationTest, maxPageRunLimit);
 };
 

--- a/velox/common/memory/tests/AllocationTest.cpp
+++ b/velox/common/memory/tests/AllocationTest.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/common/memory/Allocation.h"
 
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "velox/common/base/tests/GTestUtils.h"
@@ -23,6 +25,42 @@
 namespace facebook::velox::memory {
 
 class AllocationTest : public testing::Test {};
+
+namespace {
+
+void fillAllocation(Allocation& allocation, uint64_t bytes) {
+  uint64_t offset = 0;
+  for (int32_t i = 0; i < allocation.numRuns(); ++i) {
+    auto run = allocation.runAt(i);
+    const auto bytesInRun = std::min<uint64_t>(run.numBytes(), bytes - offset);
+    for (uint64_t j = 0; j < bytesInRun; ++j) {
+      run.data<uint8_t>()[j] = static_cast<uint8_t>((offset + j) % 251);
+    }
+    offset += bytesInRun;
+    if (offset == bytes) {
+      return;
+    }
+  }
+}
+
+void expectAllocationBytes(const Allocation& allocation, uint64_t bytes) {
+  uint64_t offset = 0;
+  for (int32_t i = 0; i < allocation.numRuns(); ++i) {
+    auto run = allocation.runAt(i);
+    const auto bytesInRun = std::min<uint64_t>(run.numBytes(), bytes - offset);
+    for (uint64_t j = 0; j < bytesInRun; ++j) {
+      EXPECT_EQ(
+          run.data<const uint8_t>()[j],
+          static_cast<uint8_t>((offset + j) % 251));
+    }
+    offset += bytesInRun;
+    if (offset == bytes) {
+      return;
+    }
+  }
+}
+
+} // namespace
 
 TEST_F(AllocationTest, basic) {
   ASSERT_EQ(AllocationTraits::numPagesInHugePage(), 512);
@@ -81,6 +119,57 @@ TEST_F(AllocationTest, appendMove) {
   ASSERT_EQ(2, allocation.numRuns());
   ASSERT_EQ(0, otherAllocation.numRuns());
   allocation.clear();
+}
+
+TEST_F(AllocationTest, copy) {
+  constexpr auto kPageBytes = AllocationTraits::kPageSize;
+  constexpr uint64_t kBytes = (2 * kPageBytes) + 123;
+
+  std::vector<uint8_t> sourceRun1(kPageBytes);
+  std::vector<uint8_t> sourceRun2(2 * kPageBytes);
+  std::vector<uint8_t> targetRun1(2 * kPageBytes);
+  std::vector<uint8_t> targetRun2(kPageBytes);
+
+  Allocation source;
+  source.append(sourceRun1.data(), 1);
+  source.append(sourceRun2.data(), 2);
+  Allocation target;
+  target.append(targetRun1.data(), 2);
+  target.append(targetRun2.data(), 1);
+
+  fillAllocation(source, kBytes);
+  Allocation::copy(source, target, kBytes);
+  expectAllocationBytes(target, kBytes);
+
+  source.clear();
+  target.clear();
+}
+
+TEST_F(AllocationTest, copyOutOfRange) {
+  constexpr auto kPageBytes = AllocationTraits::kPageSize;
+  std::vector<uint8_t> sourceBuffer(kPageBytes);
+  std::vector<uint8_t> targetBuffer(kPageBytes);
+  std::vector<uint8_t> largerTargetBuffer(2 * kPageBytes);
+  std::vector<uint8_t> largerSourceBuffer(2 * kPageBytes);
+
+  Allocation source;
+  source.append(sourceBuffer.data(), 1);
+  Allocation target;
+  target.append(targetBuffer.data(), 1);
+  Allocation largerTarget;
+  largerTarget.append(largerTargetBuffer.data(), 2);
+  Allocation largerSource;
+  largerSource.append(largerSourceBuffer.data(), 2);
+
+  VELOX_ASSERT_THROW(
+      Allocation::copy(source, largerTarget, kPageBytes + 1), "");
+  VELOX_ASSERT_THROW(
+      Allocation::copy(largerSource, target, kPageBytes + 1), "");
+
+  source.clear();
+  target.clear();
+  largerTarget.clear();
+  largerSource.clear();
 }
 
 TEST_F(AllocationTest, maxPageRunLimit) {

--- a/velox/dwio/common/DirectBufferedInput.cpp
+++ b/velox/dwio/common/DirectBufferedInput.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/dwio/common/DirectBufferedInput.h"
+
 #include "velox/common/memory/Allocation.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/dwio/common/DirectInputStream.h"
@@ -151,7 +152,7 @@ std::vector<int32_t> DirectBufferedInput::groupRequests(
   ends.reserve(requests.size());
   std::vector<char> ranges;
   const auto stats =
-      coalesceIo<LoadRequest*, char, /*coalesceDuplicateRanges=*/false>(
+      coalesceIo<LoadRequest*, char, /*coalesceDuplicateRanges=*/true>(
           requests,
           maxDistance,
           // Break batches up. Better load more short ones i parallel.
@@ -285,6 +286,28 @@ void appendRanges(
     }
   }
 }
+
+bool duplicateRegion(const LoadRequest& source, const LoadRequest& duplicate) {
+  return duplicate.region.offset == source.region.offset &&
+      duplicate.region.length == source.region.length;
+}
+
+void copyDuplicateRegion(
+    const LoadRequest& source,
+    LoadRequest& duplicate,
+    memory::MemoryPool* pool) {
+  VELOX_CHECK_EQ(source.loadSize, duplicate.loadSize);
+  if (source.data.numPages() > 0) {
+    const auto numPages =
+        memory::AllocationTraits::numPages(duplicate.loadSize);
+    pool->allocateNonContiguous(numPages, duplicate.data);
+    memory::Allocation::copy(source.data, duplicate.data, duplicate.loadSize);
+  } else {
+    VELOX_CHECK(
+        !source.tinyData.empty(), "Duplicate tiny region source is empty");
+    duplicate.tinyData = source.tinyData;
+  }
+}
 } // namespace
 
 void DirectBufferedInput::preload() {
@@ -357,8 +380,15 @@ std::vector<cache::CachePin> DirectCoalescedLoad::loadData(bool prefetch) {
   int64_t size = 0;
   int64_t overread = 0;
 
-  for (auto& request : requests_) {
+  for (size_t i = 0; i < requests_.size(); ++i) {
+    auto& request = requests_[i];
     const auto& region = request.region;
+    if (i > 0 && duplicateRegion(requests_[i - 1], request)) {
+      const auto& prev = requests_[i - 1];
+      request.loadSize = prev.loadSize;
+      continue;
+    }
+
     if (region.offset > lastEnd) {
       buffers.push_back(
           folly::Range<char*>(
@@ -405,6 +435,13 @@ std::vector<cache::CachePin> DirectCoalescedLoad::loadData(bool prefetch) {
   if (prefetch) {
     ioStatistics_->prefetch().increment(size + overread);
   }
+  for (size_t i = 0; i < requests_.size(); ++i) {
+    auto& request = requests_[i];
+    if (i == 0 || !duplicateRegion(requests_[i - 1], request)) {
+      continue;
+    }
+    copyDuplicateRegion(requests_[i - 1], request, pool_);
+  }
   TestValue::adjust(
       "facebook::velox::cache::DirectCoalescedLoad::loadData", this);
   return {};
@@ -421,8 +458,18 @@ int32_t DirectCoalescedLoad::getData(
   if (it == requests_.cend() || it->region.offset != offset) {
     return 0;
   }
+  // Duplicate regions have the same offset. Skip buffers already handed to
+  // earlier streams so each duplicate stream gets its own copied buffer.
+  while (it != requests_.end() && it->region.offset == offset &&
+         it->bufferConsumed) {
+    ++it;
+  }
+  if (it == requests_.cend() || it->region.offset != offset) {
+    return 0;
+  }
   data = std::move(it->data);
   tinyData = std::move(it->tinyData);
+  it->bufferConsumed = true;
   return it->loadSize;
 }
 

--- a/velox/dwio/common/DirectBufferedInput.h
+++ b/velox/dwio/common/DirectBufferedInput.h
@@ -51,6 +51,10 @@ struct LoadRequest {
   std::string tinyData;
   /// Number of bytes in 'data/tinyData'.
   int32_t loadSize{0};
+  // Set after getData() moves 'data/tinyData' to the owning stream. Duplicate
+  // regions share an offset, so getData() skips consumed buffers to find the
+  // next duplicate buffer.
+  bool bufferConsumed{false};
 };
 
 /// Represents planned loads that should be performed as a single IO.

--- a/velox/dwio/common/tests/DirectBufferedInputTest.cpp
+++ b/velox/dwio/common/tests/DirectBufferedInputTest.cpp
@@ -285,6 +285,66 @@ TEST_F(DirectBufferedInputTest, readAfterReset) {
   }
 }
 
+TEST_F(DirectBufferedInputTest, duplicateRegionsShareCoalescedRead) {
+  constexpr int32_t kContentSize = 4 << 20; // 4MB
+  std::string content;
+  content.resize(kContentSize);
+  for (int32_t i = 0; i < kContentSize; ++i) {
+    content[i] = static_cast<char>(i % 251);
+  }
+
+  for (const bool tinyRegion : {false, true}) {
+    SCOPED_TRACE(fmt::format("tinyRegion: {}", tinyRegion));
+
+    const uint64_t regionSize = tinyRegion
+        ? DirectBufferedInput::kTinySize - 100
+        : DirectBufferedInput::kTinySize + 1000;
+    auto readFile = std::make_shared<tests::utils::CountingReadFile>(content);
+
+    io::ReaderOptions readerOptions(pool_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
+    readerOptions.setLoadQuantum(1 << 20);
+
+    auto& ids = fileIds();
+    StringIdLease fileId(ids, fmt::format("duplicateRegions{}", tinyRegion));
+    StringIdLease groupId(
+        ids, fmt::format("duplicateRegionsGroup{}", tinyRegion));
+
+    DirectBufferedInput input(
+        readFile,
+        MetricsLog::voidLog(),
+        std::move(fileId),
+        tracker_,
+        std::move(groupId),
+        dataIoStats_,
+        nullptr,
+        executor_.get(),
+        readerOptions);
+
+    auto stream1 = input.enqueue(common::Region{123, regionSize}, nullptr);
+    auto stream2 = input.enqueue(common::Region{123, regionSize}, nullptr);
+    ASSERT_NE(stream1, nullptr);
+    ASSERT_NE(stream2, nullptr);
+
+    input.load(LogType::TEST);
+
+    EXPECT_EQ(input.testingStreamToCoalescedLoadSize(), 2);
+    EXPECT_EQ(input.testingCoalescedLoads().size(), 1);
+    EXPECT_EQ(readFile->numReads(), 0);
+
+    auto next1 = getNext(*stream1);
+    ASSERT_TRUE(next1.has_value());
+    EXPECT_EQ(next1.value(), content.substr(123, regionSize));
+    EXPECT_EQ(readFile->numReads(), 1);
+
+    auto next2 = getNext(*stream2);
+    ASSERT_TRUE(next2.has_value());
+    EXPECT_EQ(next2.value(), content.substr(123, regionSize));
+    EXPECT_EQ(readFile->numReads(), 1);
+  }
+}
+
 DEBUG_ONLY_TEST_F(DirectBufferedInputTest, resetInputWithBeforeLoading) {
   constexpr int32_t kContentSize = 4 << 20; // 4MB
   std::string content;


### PR DESCRIPTION
Summary: Allow `DirectBufferedInput` to coalesce exact duplicate regions using `coalesceDuplicateRanges=true`. Duplicate regions now contribute one destination to the vectored storage read, then copy the loaded bytes to the duplicate stream buffer so each `DirectInputStream` can take ownership independently.

Differential Revision: D107759899


