### PR TITLE
Support duplicate regions in CachedBufferedInput

### DIFF
--- a/velox/common/base/CoalesceIo.h
+++ b/velox/common/base/CoalesceIo.h
@@ -36,6 +36,10 @@ struct CoalesceIoStats {
   int64_t payloadBytes{0};
   /// Number of bytes read and discarded due to coalescing.
   int64_t extraBytes{0};
+  /// Number of items with the same offset and size as the previous item.
+  int64_t duplicateRegions{0};
+  /// Number of payload bytes requested by duplicate regions.
+  int64_t duplicateBytes{0};
 
   /// Distribution of gaps (in bytes) between consecutive items before
   /// coalescing. Measures how spread out the read regions are on disk:
@@ -58,7 +62,6 @@ static constexpr int32_t kNoCoalesce = -1;
 template <
     typename Item,
     typename Range,
-    bool coalesceDuplicateRanges,
     typename ItemOffset,
     typename ItemSize,
     typename ItemNumRanges,
@@ -92,11 +95,14 @@ CoalesceIoStats coalesceIo(
         (numRangesForItem == kNoCoalesce ||
          ranges.size() + numRangesForItem >= rangesPerIo) &&
         !ranges.empty();
-    // Some callers, e.g. Nimble Velox writer stream deduplication, can produce
-    // adjacent logical reads for the same physical range. Keep exact duplicates
-    // in the same IO only when the caller can map them to the same bytes.
-    const bool duplicateRange = coalesceDuplicateRanges && i > 0 &&
-        itemOffset == prevItemOffset && itemSize == prevItemSize;
+    // Some callers can produce adjacent logical reads for the same physical
+    // range. Exact duplicates stay in the same IO group.
+    const bool duplicateRange =
+        i > 0 && itemOffset == prevItemOffset && itemSize == prevItemSize;
+    if (duplicateRange) {
+      ++result.duplicateRegions;
+      result.duplicateBytes += itemSize;
+    }
     if (!duplicateRange && (lastEndOffset != itemOffset || enoughRanges)) {
       const int64_t gap = itemOffset - lastEndOffset;
       if (gap > 0) {

--- a/velox/common/base/tests/CoalesceIoTest.cpp
+++ b/velox/common/base/tests/CoalesceIoTest.cpp
@@ -67,7 +67,7 @@ TEST(CoalesceIoTest, basic) {
   // process together.
   std::vector<std::vector<int32_t>> ioGroups;
 
-  auto stats = coalesceIo<IoUnit, Range, /*coalesceDuplicateRanges=*/false>(
+  auto stats = coalesceIo<IoUnit, Range>(
       data,
       20000,
       8,
@@ -106,6 +106,8 @@ TEST(CoalesceIoTest, basic) {
   EXPECT_EQ(4, stats.numIos);
   EXPECT_EQ(1500000, stats.payloadBytes);
   EXPECT_EQ(14000, stats.extraBytes);
+  EXPECT_EQ(0, stats.duplicateRegions);
+  EXPECT_EQ(0, stats.duplicateBytes);
 
   std::vector<int64_t> expectedOffsets{1000, 220000, 700000, 810000};
   EXPECT_EQ(expectedOffsets, offsets);
@@ -133,7 +135,7 @@ TEST(CoalesceIoTest, exactDuplicateRangesCoalesce) {
   data.emplace_back(1100, 50, 1);
 
   std::vector<std::vector<int32_t>> ioGroups;
-  auto stats = coalesceIo<IoUnit, Range, /*coalesceDuplicateRanges=*/true>(
+  auto stats = coalesceIo<IoUnit, Range>(
       data,
       1,
       10,
@@ -160,56 +162,21 @@ TEST(CoalesceIoTest, exactDuplicateRangesCoalesce) {
   EXPECT_EQ(stats.numIos, 1);
   EXPECT_EQ(stats.payloadBytes, 250);
   EXPECT_EQ(stats.extraBytes, 0);
+  EXPECT_EQ(stats.duplicateRegions, 1);
+  EXPECT_EQ(stats.duplicateBytes, 100);
   EXPECT_EQ(stats.gaps.count(), 0);
   ASSERT_EQ(ioGroups.size(), 1);
   EXPECT_EQ(ioGroups[0], (std::vector<int32_t>{0, 1, 2}));
 }
 
-TEST(CoalesceIoTest, exactDuplicateRangesDoNotCoalesceByDefault) {
+TEST(CoalesceIoTest, exactDuplicateRangesIgnoreRangeLimit) {
   std::vector<IoUnit> data;
   data.emplace_back(1000, 100, 1);
   data.emplace_back(1000, 100, 1);
   data.emplace_back(1100, 50, 1);
 
   std::vector<std::vector<int32_t>> ioGroups;
-  auto stats = coalesceIo<IoUnit, Range, /*coalesceDuplicateRanges=*/false>(
-      data,
-      1,
-      10,
-      [&](int32_t i) { return data[i].offset; },
-      [&](int32_t i) { return data[i].size; },
-      [&](int32_t) { return 1; },
-      [&](const IoUnit& item, std::vector<Range>& ranges) {
-        ranges.emplace_back(item.size, 1);
-      },
-      [&](int32_t skip, std::vector<Range>& ranges) {
-        ranges.emplace_back(skip, 0);
-      },
-      [&](const std::vector<IoUnit>&,
-          int32_t begin,
-          int32_t end,
-          uint64_t,
-          const std::vector<Range>&) {
-        ioGroups.emplace_back();
-        for (auto i = begin; i < end; ++i) {
-          ioGroups.back().push_back(i);
-        }
-      });
-
-  EXPECT_EQ(stats.numIos, 2);
-  ASSERT_EQ(ioGroups.size(), 2);
-  EXPECT_EQ(ioGroups[0], (std::vector<int32_t>{0}));
-  EXPECT_EQ(ioGroups[1], (std::vector<int32_t>{1, 2}));
-}
-
-TEST(CoalesceIoTest, exactDuplicateRangesIgnoreRangeLimitWhenEnabled) {
-  std::vector<IoUnit> data;
-  data.emplace_back(1000, 100, 1);
-  data.emplace_back(1000, 100, 1);
-  data.emplace_back(1100, 50, 1);
-
-  std::vector<std::vector<int32_t>> ioGroups;
-  auto stats = coalesceIo<IoUnit, Range, /*coalesceDuplicateRanges=*/true>(
+  auto stats = coalesceIo<IoUnit, Range>(
       data,
       1,
       2,
@@ -234,9 +201,53 @@ TEST(CoalesceIoTest, exactDuplicateRangesIgnoreRangeLimitWhenEnabled) {
       });
 
   EXPECT_EQ(stats.numIos, 2);
+  EXPECT_EQ(stats.duplicateRegions, 1);
+  EXPECT_EQ(stats.duplicateBytes, 100);
   ASSERT_EQ(ioGroups.size(), 2);
   EXPECT_EQ(ioGroups[0], (std::vector<int32_t>{0, 1}));
   EXPECT_EQ(ioGroups[1], (std::vector<int32_t>{2}));
+}
+
+TEST(CoalesceIoTest, multipleExactDuplicateRanges) {
+  std::vector<IoUnit> data;
+  data.emplace_back(1000, 100, 1);
+  data.emplace_back(1000, 100, 1);
+  data.emplace_back(1100, 50, 1);
+  data.emplace_back(2000, 200, 1);
+  data.emplace_back(2000, 200, 1);
+  data.emplace_back(2000, 200, 1);
+
+  std::vector<std::vector<int32_t>> ioGroups;
+  auto stats = coalesceIo<IoUnit, Range>(
+      data,
+      1,
+      10,
+      [&](int32_t i) { return data[i].offset; },
+      [&](int32_t i) { return data[i].size; },
+      [&](int32_t) { return 1; },
+      [&](const IoUnit& item, std::vector<Range>& ranges) {
+        ranges.emplace_back(item.size, 1);
+      },
+      [&](int32_t skip, std::vector<Range>& ranges) {
+        ranges.emplace_back(skip, 0);
+      },
+      [&](const std::vector<IoUnit>&,
+          int32_t begin,
+          int32_t end,
+          uint64_t,
+          const std::vector<Range>&) {
+        ioGroups.emplace_back();
+        for (auto i = begin; i < end; ++i) {
+          ioGroups.back().push_back(i);
+        }
+      });
+
+  EXPECT_EQ(stats.numIos, 2);
+  EXPECT_EQ(stats.duplicateRegions, 3);
+  EXPECT_EQ(stats.duplicateBytes, 500);
+  ASSERT_EQ(ioGroups.size(), 2);
+  EXPECT_EQ(ioGroups[0], (std::vector<int32_t>{0, 1, 2}));
+  EXPECT_EQ(ioGroups[1], (std::vector<int32_t>{3, 4, 5}));
 }
 
 TEST(CoalesceIoTest, gaps) {
@@ -287,7 +298,7 @@ TEST(CoalesceIoTest, gaps) {
     SCOPED_TRACE(testData.debugString());
 
     const auto& data = testData.data;
-    auto stats = coalesceIo<IoUnit, Range, /*coalesceDuplicateRanges=*/false>(
+    auto stats = coalesceIo<IoUnit, Range>(
         data,
         testData.maxGap,
         10,

--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -1203,10 +1203,7 @@ CoalesceIoStats readPins(
         int32_t end,
         uint64_t offset,
         const std::vector<folly::Range<char*>>& buffers)> readFunc) {
-  return coalesceIo<
-      CachePin,
-      folly::Range<char*>,
-      /*coalesceDuplicateRanges=*/false>(
+  return coalesceIo<CachePin, folly::Range<char*>>(
       pins,
       maxGap,
       rangesPerIo,

--- a/velox/common/io/IoStatistics.cpp
+++ b/velox/common/io/IoStatistics.cpp
@@ -50,6 +50,14 @@ uint64_t IoStatistics::writeIOTimeUs() const {
   return writeIOTimeUs_.load(std::memory_order_relaxed);
 }
 
+uint64_t IoStatistics::duplicateReadRegions() const {
+  return duplicateReadRegions_.load(std::memory_order_relaxed);
+}
+
+uint64_t IoStatistics::duplicateReadBytes() const {
+  return duplicateReadBytes_.load(std::memory_order_relaxed);
+}
+
 uint64_t IoStatistics::incRawBytesRead(int64_t v) {
   return rawBytesRead_.fetch_add(v, std::memory_order_relaxed);
 }
@@ -76,6 +84,11 @@ uint64_t IoStatistics::incTotalScanTimeNs(int64_t v) {
 
 uint64_t IoStatistics::incWriteIOTimeUs(int64_t v) {
   return writeIOTimeUs_.fetch_add(v, std::memory_order_relaxed);
+}
+
+void IoStatistics::incDuplicateRead(int64_t regions, int64_t bytes) {
+  duplicateReadRegions_.fetch_add(regions, std::memory_order_relaxed);
+  duplicateReadBytes_.fetch_add(bytes, std::memory_order_relaxed);
 }
 
 void IoStatistics::incOperationCounters(
@@ -112,6 +125,8 @@ void IoStatistics::merge(const IoStatistics& other) {
   rawBytesRead_ += other.rawBytesRead_;
   rawBytesWritten_ += other.rawBytesWritten_;
   totalScanTimeNs_ += other.totalScanTimeNs_;
+  duplicateReadRegions_ += other.duplicateReadRegions_;
+  duplicateReadBytes_ += other.duplicateReadBytes_;
 
   rawOverreadBytes_ += other.rawOverreadBytes_;
   prefetch_.merge(other.prefetch_);

--- a/velox/common/io/IoStatistics.h
+++ b/velox/common/io/IoStatistics.h
@@ -50,6 +50,8 @@ class IoStatistics {
   uint64_t outputBatchSize() const;
   uint64_t totalScanTimeNs() const;
   uint64_t writeIOTimeUs() const;
+  uint64_t duplicateReadRegions() const;
+  uint64_t duplicateReadBytes() const;
 
   uint64_t incRawBytesRead(int64_t);
   uint64_t incRawOverreadBytes(int64_t);
@@ -58,6 +60,7 @@ class IoStatistics {
   uint64_t incOutputBatchSize(int64_t);
   uint64_t incTotalScanTimeNs(int64_t);
   uint64_t incWriteIOTimeUs(int64_t);
+  void incDuplicateRead(int64_t regions, int64_t bytes);
 
   IoCounter& prefetch() {
     return prefetch_;
@@ -128,13 +131,15 @@ class IoStatistics {
   folly::dynamic getOperationStatsSnapshot() const;
 
  private:
-  std::atomic<uint64_t> rawBytesRead_{0};
-  std::atomic<uint64_t> rawBytesWritten_{0};
-  std::atomic<uint64_t> inputBatchSize_{0};
-  std::atomic<uint64_t> outputBatchSize_{0};
-  std::atomic<uint64_t> rawOverreadBytes_{0};
-  std::atomic<uint64_t> totalScanTimeNs_{0};
-  std::atomic<uint64_t> writeIOTimeUs_{0};
+  std::atomic_uint64_t rawBytesRead_{0};
+  std::atomic_uint64_t rawBytesWritten_{0};
+  std::atomic_uint64_t inputBatchSize_{0};
+  std::atomic_uint64_t outputBatchSize_{0};
+  std::atomic_uint64_t rawOverreadBytes_{0};
+  std::atomic_uint64_t totalScanTimeNs_{0};
+  std::atomic_uint64_t writeIOTimeUs_{0};
+  std::atomic_uint64_t duplicateReadRegions_{0};
+  std::atomic_uint64_t duplicateReadBytes_{0};
 
   // Planned read from storage or SSD.
   IoCounter prefetch_;

--- a/velox/common/io/tests/IoStatisticsTest.cpp
+++ b/velox/common/io/tests/IoStatisticsTest.cpp
@@ -81,4 +81,20 @@ TEST(IoStatisticsTest, readGap) {
   EXPECT_EQ(stats.readGap().max(), 5'000);
 }
 
+TEST(IoStatisticsTest, duplicateRead) {
+  IoStatistics stats;
+  EXPECT_EQ(stats.duplicateReadRegions(), 0);
+  EXPECT_EQ(stats.duplicateReadBytes(), 0);
+
+  stats.incDuplicateRead(2, 1'000);
+  EXPECT_EQ(stats.duplicateReadRegions(), 2);
+  EXPECT_EQ(stats.duplicateReadBytes(), 1'000);
+
+  IoStatistics stats2;
+  stats2.incDuplicateRead(3, 500);
+  stats.merge(stats2);
+  EXPECT_EQ(stats.duplicateReadRegions(), 5);
+  EXPECT_EQ(stats.duplicateReadBytes(), 1'500);
+}
+
 } // namespace facebook::velox::io

--- a/velox/common/memory/Allocation.cpp
+++ b/velox/common/memory/Allocation.cpp
@@ -16,6 +16,9 @@
 
 #include "velox/common/memory/Allocation.h"
 
+#include <algorithm>
+#include <cstring>
+
 #include "velox/common/memory/Memory.h"
 
 namespace facebook::velox::memory {
@@ -52,6 +55,41 @@ void Allocation::appendMove(Allocation& other) {
   }
   other.runs_.clear();
   other.numPages_ = 0;
+}
+
+/*static*/ void
+Allocation::copy(const Allocation& source, Allocation& target, uint64_t bytes) {
+  VELOX_CHECK_LE(bytes, source.byteSize());
+  VELOX_CHECK_LE(bytes, target.byteSize());
+
+  int32_t sourceRunIndex = 0;
+  int32_t targetRunIndex = 0;
+  uint64_t sourceOffsetInRun = 0;
+  uint64_t targetOffsetInRun = 0;
+  uint64_t copiedBytes = 0;
+  while (copiedBytes < bytes) {
+    auto sourceRun = source.runAt(sourceRunIndex);
+    auto targetRun = target.runAt(targetRunIndex);
+    const auto bytesToCopy = std::min<uint64_t>(
+        {sourceRun.numBytes() - sourceOffsetInRun,
+         targetRun.numBytes() - targetOffsetInRun,
+         bytes - copiedBytes});
+    std::memcpy(
+        targetRun.data<char>() + targetOffsetInRun,
+        sourceRun.data<const char>() + sourceOffsetInRun,
+        bytesToCopy);
+    copiedBytes += bytesToCopy;
+    sourceOffsetInRun += bytesToCopy;
+    targetOffsetInRun += bytesToCopy;
+    if (sourceOffsetInRun == sourceRun.numBytes()) {
+      ++sourceRunIndex;
+      sourceOffsetInRun = 0;
+    }
+    if (targetOffsetInRun == targetRun.numBytes()) {
+      ++targetRunIndex;
+      targetOffsetInRun = 0;
+    }
+  }
 }
 
 void Allocation::findRun(uint64_t offset, int32_t* index, int32_t* offsetInRun)

--- a/velox/common/memory/Allocation.h
+++ b/velox/common/memory/Allocation.h
@@ -120,6 +120,10 @@ class Allocation {
     other.clear();
   }
 
+  /// Copies 'bytes' from 'source' to 'target'.
+  static void
+  copy(const Allocation& source, Allocation& target, uint64_t bytes);
+
   MachinePageCount numPages() const {
     return numPages_;
   }
@@ -194,6 +198,8 @@ class Allocation {
   VELOX_FRIEND_TEST(MemoryAllocatorTest, allocationClass2);
   VELOX_FRIEND_TEST(AllocationTest, append);
   VELOX_FRIEND_TEST(AllocationTest, appendMove);
+  VELOX_FRIEND_TEST(AllocationTest, copy);
+  VELOX_FRIEND_TEST(AllocationTest, copyOutOfRange);
   VELOX_FRIEND_TEST(AllocationTest, maxPageRunLimit);
 };
 

--- a/velox/common/memory/tests/AllocationTest.cpp
+++ b/velox/common/memory/tests/AllocationTest.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/common/memory/Allocation.h"
 
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include "velox/common/base/tests/GTestUtils.h"
@@ -23,6 +25,42 @@
 namespace facebook::velox::memory {
 
 class AllocationTest : public testing::Test {};
+
+namespace {
+
+void fillAllocation(Allocation& allocation, uint64_t bytes) {
+  uint64_t offset = 0;
+  for (int32_t i = 0; i < allocation.numRuns(); ++i) {
+    auto run = allocation.runAt(i);
+    const auto bytesInRun = std::min<uint64_t>(run.numBytes(), bytes - offset);
+    for (uint64_t j = 0; j < bytesInRun; ++j) {
+      run.data<uint8_t>()[j] = static_cast<uint8_t>((offset + j) % 251);
+    }
+    offset += bytesInRun;
+    if (offset == bytes) {
+      return;
+    }
+  }
+}
+
+void expectAllocationBytes(const Allocation& allocation, uint64_t bytes) {
+  uint64_t offset = 0;
+  for (int32_t i = 0; i < allocation.numRuns(); ++i) {
+    auto run = allocation.runAt(i);
+    const auto bytesInRun = std::min<uint64_t>(run.numBytes(), bytes - offset);
+    for (uint64_t j = 0; j < bytesInRun; ++j) {
+      EXPECT_EQ(
+          run.data<const uint8_t>()[j],
+          static_cast<uint8_t>((offset + j) % 251));
+    }
+    offset += bytesInRun;
+    if (offset == bytes) {
+      return;
+    }
+  }
+}
+
+} // namespace
 
 TEST_F(AllocationTest, basic) {
   ASSERT_EQ(AllocationTraits::numPagesInHugePage(), 512);
@@ -81,6 +119,57 @@ TEST_F(AllocationTest, appendMove) {
   ASSERT_EQ(2, allocation.numRuns());
   ASSERT_EQ(0, otherAllocation.numRuns());
   allocation.clear();
+}
+
+TEST_F(AllocationTest, copy) {
+  constexpr auto kPageBytes = AllocationTraits::kPageSize;
+  constexpr uint64_t kBytes = (2 * kPageBytes) + 123;
+
+  std::vector<uint8_t> sourceRun1(kPageBytes);
+  std::vector<uint8_t> sourceRun2(2 * kPageBytes);
+  std::vector<uint8_t> targetRun1(2 * kPageBytes);
+  std::vector<uint8_t> targetRun2(kPageBytes);
+
+  Allocation source;
+  source.append(sourceRun1.data(), 1);
+  source.append(sourceRun2.data(), 2);
+  Allocation target;
+  target.append(targetRun1.data(), 2);
+  target.append(targetRun2.data(), 1);
+
+  fillAllocation(source, kBytes);
+  Allocation::copy(source, target, kBytes);
+  expectAllocationBytes(target, kBytes);
+
+  source.clear();
+  target.clear();
+}
+
+TEST_F(AllocationTest, copyOutOfRange) {
+  constexpr auto kPageBytes = AllocationTraits::kPageSize;
+  std::vector<uint8_t> sourceBuffer(kPageBytes);
+  std::vector<uint8_t> targetBuffer(kPageBytes);
+  std::vector<uint8_t> largerTargetBuffer(2 * kPageBytes);
+  std::vector<uint8_t> largerSourceBuffer(2 * kPageBytes);
+
+  Allocation source;
+  source.append(sourceBuffer.data(), 1);
+  Allocation target;
+  target.append(targetBuffer.data(), 1);
+  Allocation largerTarget;
+  largerTarget.append(largerTargetBuffer.data(), 2);
+  Allocation largerSource;
+  largerSource.append(largerSourceBuffer.data(), 2);
+
+  VELOX_ASSERT_THROW(
+      Allocation::copy(source, largerTarget, kPageBytes + 1), "");
+  VELOX_ASSERT_THROW(
+      Allocation::copy(largerSource, target, kPageBytes + 1), "");
+
+  source.clear();
+  target.clear();
+  largerTarget.clear();
+  largerSource.clear();
 }
 
 TEST_F(AllocationTest, maxPageRunLimit) {

--- a/velox/dwio/common/CachedBufferedInput.cpp
+++ b/velox/dwio/common/CachedBufferedInput.cpp
@@ -301,34 +301,34 @@ std::vector<int32_t> CachedBufferedInput::groupRequests(
   std::vector<int32_t> ends;
   ends.reserve(requests.size());
   std::vector<char> ranges;
-  const auto stats =
-      coalesceIo<CacheRequest*, char, /*coalesceDuplicateRanges=*/false>(
-          requests,
-          maxDistance,
-          std::numeric_limits<int32_t>::max(),
-          [&](int32_t index) { return getOffset<kSsd>(*requests[index]); },
-          [&](int32_t index) {
-            const auto size = requests[index]->size;
-            coalescedBytes += size;
-            return size;
-          },
-          [&](int32_t index) {
-            if (coalescedBytes > options_.maxCoalesceBytes()) {
-              coalescedBytes = 0;
-              return kNoCoalesce;
-            }
-            return requests[index]->coalesces ? 1 : kNoCoalesce;
-          },
-          [&](CacheRequest* /*request*/, std::vector<char>& ranges) {
-            ranges.push_back(0);
-          },
-          [&](int32_t /*gap*/, std::vector<char> /*ranges*/) { /*no op*/ },
-          [&](const std::vector<CacheRequest*>& /*requests*/,
-              int32_t /*begin*/,
-              int32_t end,
-              uint64_t /*offset*/,
-              const std::vector<char>& /*ranges*/) { ends.push_back(end); });
+  const auto stats = coalesceIo<CacheRequest*, char>(
+      requests,
+      maxDistance,
+      std::numeric_limits<int32_t>::max(),
+      [&](int32_t index) { return getOffset<kSsd>(*requests[index]); },
+      [&](int32_t index) {
+        const auto size = requests[index]->size;
+        coalescedBytes += size;
+        return size;
+      },
+      [&](int32_t index) {
+        if (coalescedBytes > options_.maxCoalesceBytes()) {
+          coalescedBytes = 0;
+          return kNoCoalesce;
+        }
+        return requests[index]->coalesces ? 1 : kNoCoalesce;
+      },
+      [&](CacheRequest* /*request*/, std::vector<char>& ranges) {
+        ranges.push_back(0);
+      },
+      [&](int32_t /*gap*/, std::vector<char> /*ranges*/) { /*no op*/ },
+      [&](const std::vector<CacheRequest*>& /*requests*/,
+          int32_t /*begin*/,
+          int32_t end,
+          uint64_t /*offset*/,
+          const std::vector<char>& /*ranges*/) { ends.push_back(end); });
   ioStatistics_->readGap().merge(stats.gaps);
+  ioStatistics_->incDuplicateRead(stats.duplicateRegions, stats.duplicateBytes);
   return ends;
 }
 

--- a/velox/dwio/common/DirectBufferedInput.cpp
+++ b/velox/dwio/common/DirectBufferedInput.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/dwio/common/DirectBufferedInput.h"
+
 #include "velox/common/memory/Allocation.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/dwio/common/DirectInputStream.h"
@@ -151,7 +152,7 @@ std::vector<int32_t> DirectBufferedInput::groupRequests(
   ends.reserve(requests.size());
   std::vector<char> ranges;
   const auto stats =
-      coalesceIo<LoadRequest*, char, /*coalesceDuplicateRanges=*/false>(
+      coalesceIo<LoadRequest*, char, /*coalesceDuplicateRanges=*/true>(
           requests,
           maxDistance,
           // Break batches up. Better load more short ones i parallel.
@@ -285,6 +286,28 @@ void appendRanges(
     }
   }
 }
+
+bool duplicateRegion(const LoadRequest& source, const LoadRequest& duplicate) {
+  return duplicate.region.offset == source.region.offset &&
+      duplicate.region.length == source.region.length;
+}
+
+void copyDuplicateRegion(
+    const LoadRequest& source,
+    LoadRequest& duplicate,
+    memory::MemoryPool* pool) {
+  VELOX_CHECK_EQ(source.loadSize, duplicate.loadSize);
+  if (source.data.numPages() > 0) {
+    const auto numPages =
+        memory::AllocationTraits::numPages(duplicate.loadSize);
+    pool->allocateNonContiguous(numPages, duplicate.data);
+    memory::Allocation::copy(source.data, duplicate.data, duplicate.loadSize);
+  } else {
+    VELOX_CHECK(
+        !source.tinyData.empty(), "Duplicate tiny region source is empty");
+    duplicate.tinyData = source.tinyData;
+  }
+}
 } // namespace
 
 void DirectBufferedInput::preload() {
@@ -357,8 +380,15 @@ std::vector<cache::CachePin> DirectCoalescedLoad::loadData(bool prefetch) {
   int64_t size = 0;
   int64_t overread = 0;
 
-  for (auto& request : requests_) {
+  for (size_t i = 0; i < requests_.size(); ++i) {
+    auto& request = requests_[i];
     const auto& region = request.region;
+    if (i > 0 && duplicateRegion(requests_[i - 1], request)) {
+      const auto& prev = requests_[i - 1];
+      request.loadSize = prev.loadSize;
+      continue;
+    }
+
     if (region.offset > lastEnd) {
       buffers.push_back(
           folly::Range<char*>(
@@ -405,6 +435,13 @@ std::vector<cache::CachePin> DirectCoalescedLoad::loadData(bool prefetch) {
   if (prefetch) {
     ioStatistics_->prefetch().increment(size + overread);
   }
+  for (size_t i = 0; i < requests_.size(); ++i) {
+    auto& request = requests_[i];
+    if (i == 0 || !duplicateRegion(requests_[i - 1], request)) {
+      continue;
+    }
+    copyDuplicateRegion(requests_[i - 1], request, pool_);
+  }
   TestValue::adjust(
       "facebook::velox::cache::DirectCoalescedLoad::loadData", this);
   return {};
@@ -421,8 +458,18 @@ int32_t DirectCoalescedLoad::getData(
   if (it == requests_.cend() || it->region.offset != offset) {
     return 0;
   }
+  // Duplicate regions have the same offset. Skip buffers already handed to
+  // earlier streams so each duplicate stream gets its own copied buffer.
+  while (it != requests_.end() && it->region.offset == offset &&
+         it->bufferConsumed) {
+    ++it;
+  }
+  if (it == requests_.cend() || it->region.offset != offset) {
+    return 0;
+  }
   data = std::move(it->data);
   tinyData = std::move(it->tinyData);
+  it->bufferConsumed = true;
   return it->loadSize;
 }
 

--- a/velox/dwio/common/DirectBufferedInput.cpp
+++ b/velox/dwio/common/DirectBufferedInput.cpp
@@ -151,41 +151,41 @@ std::vector<int32_t> DirectBufferedInput::groupRequests(
   std::vector<int32_t> ends;
   ends.reserve(requests.size());
   std::vector<char> ranges;
-  const auto stats =
-      coalesceIo<LoadRequest*, char, /*coalesceDuplicateRanges=*/true>(
-          requests,
-          maxDistance,
-          // Break batches up. Better load more short ones i parallel.
-          std::numeric_limits<int32_t>::max(), // limit coalesce by size, not
-                                               // count.
-          [&](int32_t index) { return requests[index]->region.offset; },
-          [&](int32_t index) -> int32_t {
-            auto size = requests[index]->region.length;
-            if (size > loadQuantum) {
-              coalescedBytes += loadQuantum;
-              return loadQuantum;
-            }
-            coalescedBytes += size;
-            return size;
-          },
-          [&](int32_t index) {
-            if (coalescedBytes > maxCoalesceBytes) {
-              coalescedBytes = 0;
-              return kNoCoalesce;
-            }
-            return 1;
-          },
-          [&](LoadRequest* /*request*/, std::vector<char>& ranges) {
-            // ranges.size() is used in coalesceIo so we cannot leave it empty.
-            ranges.push_back(0);
-          },
-          [&](int32_t /*gap*/, std::vector<char> /*ranges*/) { /*no op*/ },
-          [&](const std::vector<LoadRequest*>& /*requests*/,
-              int32_t /*begin*/,
-              int32_t end,
-              uint64_t /*offset*/,
-              const std::vector<char>& /*ranges*/) { ends.push_back(end); });
+  const auto stats = coalesceIo<LoadRequest*, char>(
+      requests,
+      maxDistance,
+      // Break batches up. Better load more short ones i parallel.
+      std::numeric_limits<int32_t>::max(), // limit coalesce by size, not
+                                           // count.
+      [&](int32_t index) { return requests[index]->region.offset; },
+      [&](int32_t index) -> int32_t {
+        auto size = requests[index]->region.length;
+        if (size > loadQuantum) {
+          coalescedBytes += loadQuantum;
+          return loadQuantum;
+        }
+        coalescedBytes += size;
+        return size;
+      },
+      [&](int32_t index) {
+        if (coalescedBytes > maxCoalesceBytes) {
+          coalescedBytes = 0;
+          return kNoCoalesce;
+        }
+        return 1;
+      },
+      [&](LoadRequest* /*request*/, std::vector<char>& ranges) {
+        // ranges.size() is used in coalesceIo so we cannot leave it empty.
+        ranges.push_back(0);
+      },
+      [&](int32_t /*gap*/, std::vector<char> /*ranges*/) { /*no op*/ },
+      [&](const std::vector<LoadRequest*>& /*requests*/,
+          int32_t /*begin*/,
+          int32_t end,
+          uint64_t /*offset*/,
+          const std::vector<char>& /*ranges*/) { ends.push_back(end); });
   ioStatistics_->readGap().merge(stats.gaps);
+  ioStatistics_->incDuplicateRead(stats.duplicateRegions, stats.duplicateBytes);
   return ends;
 }
 

--- a/velox/dwio/common/DirectBufferedInput.h
+++ b/velox/dwio/common/DirectBufferedInput.h
@@ -51,6 +51,10 @@ struct LoadRequest {
   std::string tinyData;
   /// Number of bytes in 'data/tinyData'.
   int32_t loadSize{0};
+  // Set after getData() moves 'data/tinyData' to the owning stream. Duplicate
+  // regions share an offset, so getData() skips consumed buffers to find the
+  // next duplicate buffer.
+  bool bufferConsumed{false};
 };
 
 /// Represents planned loads that should be performed as a single IO.

--- a/velox/dwio/common/tests/CachedBufferedInputTest.cpp
+++ b/velox/dwio/common/tests/CachedBufferedInputTest.cpp
@@ -20,23 +20,30 @@
 
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/caching/FileIds.h"
+#include "velox/common/caching/SsdCache.h"
+#include "velox/common/file/FileSystems.h"
 #include "velox/common/file/tests/TestUtils.h"
 #include "velox/common/io/IoStatistics.h"
 #include "velox/common/io/Options.h"
 #include "velox/common/memory/MallocAllocator.h"
+#include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/common/testutil/TestValue.h"
 
 #include <folly/executors/CPUThreadPoolExecutor.h>
 #include <folly/io/IOBuf.h>
 #include <folly/synchronization/Baton.h>
 
+#include <cstring>
 #include <thread>
 
 using namespace facebook::velox;
 using namespace facebook::velox::dwio::common;
 using namespace facebook::velox::cache;
 using namespace facebook::velox::memory;
+using facebook::velox::common::testutil::TempDirectoryPath;
 using facebook::velox::common::testutil::TestValue;
+
+DECLARE_bool(velox_ssd_odirect);
 
 namespace {
 
@@ -59,6 +66,7 @@ class CachedBufferedInputTest : public testing::Test {
   }
 
   void SetUp() override {
+    filesystems::registerLocalFileSystem();
     executor_ = std::make_unique<folly::CPUThreadPoolExecutor>(10);
     allocator_ = std::make_shared<MallocAllocator>(MemoryAllocator::Options{
         .capacity = 512 << 20, .reservationByteLimit = 0});
@@ -69,10 +77,149 @@ class CachedBufferedInputTest : public testing::Test {
   }
 
   void TearDown() override {
-    executor_.reset();
     cache_->shutdown();
     cache_.reset();
     allocator_.reset();
+    tempDirectory_.reset();
+    executor_.reset();
+  }
+
+  void resetCacheWithSsd() {
+    cache_->shutdown();
+    cache_.reset();
+    allocator_.reset();
+    allocator_ = std::make_shared<MallocAllocator>(MemoryAllocator::Options{
+        .capacity = 512 << 20, .reservationByteLimit = 0});
+
+    // tmpfs does not support O_DIRECT.
+    FLAGS_velox_ssd_odirect = false;
+    tempDirectory_ = TempDirectoryPath::create();
+    auto ssdCache = std::make_unique<SsdCache>(SsdCache::Config(
+        tempDirectory_->getPath() + "/cache", 64 << 20, 1, executor_.get()));
+    cache_ = AsyncDataCache::create(allocator_.get(), std::move(ssdCache));
+  }
+
+  void seedSsd(uint64_t fileNum, uint64_t offset, std::string_view data) {
+    auto pin = cache_->findOrCreate(
+        RawFileCacheKey{fileNum, offset}, data.size(), false);
+    ASSERT_FALSE(pin.empty());
+    auto* entry = pin.checkedEntry();
+    ASSERT_TRUE(entry->isExclusive());
+
+    size_t copiedBytes = 0;
+    for (auto range : entry->dataRanges(data.size())) {
+      std::memcpy(range.data(), data.data() + copiedBytes, range.size());
+      copiedBytes += range.size();
+    }
+    ASSERT_EQ(copiedBytes, data.size());
+    entry->setExclusiveToShared();
+
+    auto* ssdCache = cache_->ssdCache();
+    ASSERT_NE(ssdCache, nullptr);
+    ASSERT_TRUE(ssdCache->startWrite());
+    cache_->saveToSsd(true);
+    ssdCache->waitForWriteToFinish();
+    EXPECT_GE(ssdCache->stats().entriesWritten, 1);
+
+    pin.clear();
+    cache_->clear();
+    EXPECT_EQ(cache_->refreshStats().numEntries, 0);
+  }
+
+  void testDuplicateRegionsShareCoalescedRead(bool useSsd) {
+    if (useSsd) {
+      resetCacheWithSsd();
+    }
+
+    constexpr int32_t kContentSize = 4 << 20; // 4MB
+    std::string content;
+    content.resize(kContentSize);
+    for (int32_t i = 0; i < kContentSize; ++i) {
+      content[i] = static_cast<char>(i % 251);
+    }
+    auto readFile = std::make_shared<tests::utils::CountingReadFile>(content);
+
+    io::ReaderOptions readerOptions(pool_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
+    readerOptions.setLoadQuantum(1 << 20);
+
+    auto& ids = fileIds();
+    StringIdLease fileId(
+        ids, useSsd ? "duplicateRegionsSsd" : "duplicateRegionsMemory");
+    StringIdLease groupId(
+        ids,
+        useSsd ? "duplicateRegionsSsdGroup" : "duplicateRegionsMemoryGroup");
+
+    constexpr uint64_t kOffset = 123;
+    constexpr uint64_t kRegionSize = 8 << 10; // 8KB
+    if (useSsd) {
+      seedSsd(
+          fileId.id(),
+          kOffset,
+          std::string_view(content).substr(kOffset, kRegionSize));
+    }
+
+    const auto readCountBefore = readFile->numReads();
+    const auto cacheStatsBefore = cache_->refreshStats();
+    const auto duplicateRegionsBefore = dataIoStats_->duplicateReadRegions();
+    const auto duplicateBytesBefore = dataIoStats_->duplicateReadBytes();
+    const auto ssdStatsBefore =
+        useSsd ? cache_->ssdCache()->stats() : SsdCacheStats{};
+
+    CachedBufferedInput input(
+        readFile,
+        MetricsLog::voidLog(),
+        std::move(fileId),
+        cache_.get(),
+        tracker_,
+        std::move(groupId),
+        dataIoStats_,
+        nullptr,
+        executor_.get(),
+        readerOptions);
+
+    auto stream1 = input.enqueue(common::Region{kOffset, kRegionSize}, nullptr);
+    auto stream2 = input.enqueue(common::Region{kOffset, kRegionSize}, nullptr);
+    ASSERT_NE(stream1, nullptr);
+    ASSERT_NE(stream2, nullptr);
+
+    input.load(LogType::TEST);
+
+    EXPECT_EQ(input.testingStreamToCoalescedLoadSize(), 2);
+    EXPECT_EQ(input.testingCoalescedLoads().size(), 1);
+    EXPECT_EQ(dataIoStats_->duplicateReadRegions() - duplicateRegionsBefore, 1);
+    EXPECT_EQ(
+        dataIoStats_->duplicateReadBytes() - duplicateBytesBefore, kRegionSize);
+    EXPECT_EQ(readFile->numReads(), readCountBefore);
+
+    auto next1 = getNext(*stream1);
+    ASSERT_TRUE(next1.has_value());
+    EXPECT_EQ(next1.value(), content.substr(kOffset, kRegionSize));
+    if (useSsd) {
+      EXPECT_EQ(readFile->numReads(), readCountBefore);
+      const auto ssdStats = cache_->ssdCache()->stats() - ssdStatsBefore;
+      EXPECT_EQ(ssdStats.entriesRead, 1);
+      EXPECT_EQ(ssdStats.bytesRead, kRegionSize);
+    } else {
+      EXPECT_EQ(readFile->numReads() - readCountBefore, 1);
+    }
+
+    auto next2 = getNext(*stream2);
+    ASSERT_TRUE(next2.has_value());
+    EXPECT_EQ(next2.value(), content.substr(kOffset, kRegionSize));
+    if (useSsd) {
+      EXPECT_EQ(readFile->numReads(), readCountBefore);
+      const auto ssdStats = cache_->ssdCache()->stats() - ssdStatsBefore;
+      EXPECT_EQ(ssdStats.entriesRead, 1);
+      EXPECT_EQ(ssdStats.bytesRead, kRegionSize);
+    } else {
+      EXPECT_EQ(readFile->numReads() - readCountBefore, 1);
+    }
+
+    const auto cacheStats = cache_->refreshStats();
+    EXPECT_EQ(cacheStats.numEntries - cacheStatsBefore.numEntries, 1);
+    EXPECT_EQ(cacheStats.numNew - cacheStatsBefore.numNew, 1);
   }
 
   const std::shared_ptr<IoStatistics> dataIoStats_{
@@ -85,6 +232,7 @@ class CachedBufferedInputTest : public testing::Test {
   std::shared_ptr<MallocAllocator> allocator_;
   std::shared_ptr<AsyncDataCache> cache_;
   std::shared_ptr<ScanTracker> tracker_;
+  std::shared_ptr<TempDirectoryPath> tempDirectory_;
 };
 
 enum class CacheRegionApi {
@@ -277,6 +425,14 @@ TEST_F(CachedBufferedInputTest, reset) {
   EXPECT_EQ(stats.sharedPinnedBytes, 0);
   EXPECT_EQ(stats.exclusivePinnedBytes, 0);
   EXPECT_EQ(stats.numEntries, 4);
+}
+
+TEST_F(CachedBufferedInputTest, duplicateRegionsShareCoalescedRead) {
+  testDuplicateRegionsShareCoalescedRead(false);
+}
+
+TEST_F(CachedBufferedInputTest, duplicateRegionsShareCoalescedSsdRead) {
+  testDuplicateRegionsShareCoalescedRead(true);
 }
 
 TEST_F(CachedBufferedInputTest, readAfterReset) {

--- a/velox/dwio/common/tests/DirectBufferedInputTest.cpp
+++ b/velox/dwio/common/tests/DirectBufferedInputTest.cpp
@@ -327,10 +327,15 @@ TEST_F(DirectBufferedInputTest, duplicateRegionsShareCoalescedRead) {
     ASSERT_NE(stream1, nullptr);
     ASSERT_NE(stream2, nullptr);
 
+    const auto duplicateRegionsBefore = dataIoStats_->duplicateReadRegions();
+    const auto duplicateBytesBefore = dataIoStats_->duplicateReadBytes();
     input.load(LogType::TEST);
 
     EXPECT_EQ(input.testingStreamToCoalescedLoadSize(), 2);
     EXPECT_EQ(input.testingCoalescedLoads().size(), 1);
+    EXPECT_EQ(dataIoStats_->duplicateReadRegions() - duplicateRegionsBefore, 1);
+    EXPECT_EQ(
+        dataIoStats_->duplicateReadBytes() - duplicateBytesBefore, regionSize);
     EXPECT_EQ(readFile->numReads(), 0);
 
     auto next1 = getNext(*stream1);

--- a/velox/dwio/common/tests/DirectBufferedInputTest.cpp
+++ b/velox/dwio/common/tests/DirectBufferedInputTest.cpp
@@ -285,6 +285,66 @@ TEST_F(DirectBufferedInputTest, readAfterReset) {
   }
 }
 
+TEST_F(DirectBufferedInputTest, duplicateRegionsShareCoalescedRead) {
+  constexpr int32_t kContentSize = 4 << 20; // 4MB
+  std::string content;
+  content.resize(kContentSize);
+  for (int32_t i = 0; i < kContentSize; ++i) {
+    content[i] = static_cast<char>(i % 251);
+  }
+
+  for (const bool tinyRegion : {false, true}) {
+    SCOPED_TRACE(fmt::format("tinyRegion: {}", tinyRegion));
+
+    const uint64_t regionSize = tinyRegion
+        ? DirectBufferedInput::kTinySize - 100
+        : DirectBufferedInput::kTinySize + 1000;
+    auto readFile = std::make_shared<tests::utils::CountingReadFile>(content);
+
+    io::ReaderOptions readerOptions(pool_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
+    readerOptions.setLoadQuantum(1 << 20);
+
+    auto& ids = fileIds();
+    StringIdLease fileId(ids, fmt::format("duplicateRegions{}", tinyRegion));
+    StringIdLease groupId(
+        ids, fmt::format("duplicateRegionsGroup{}", tinyRegion));
+
+    DirectBufferedInput input(
+        readFile,
+        MetricsLog::voidLog(),
+        std::move(fileId),
+        tracker_,
+        std::move(groupId),
+        dataIoStats_,
+        nullptr,
+        executor_.get(),
+        readerOptions);
+
+    auto stream1 = input.enqueue(common::Region{123, regionSize}, nullptr);
+    auto stream2 = input.enqueue(common::Region{123, regionSize}, nullptr);
+    ASSERT_NE(stream1, nullptr);
+    ASSERT_NE(stream2, nullptr);
+
+    input.load(LogType::TEST);
+
+    EXPECT_EQ(input.testingStreamToCoalescedLoadSize(), 2);
+    EXPECT_EQ(input.testingCoalescedLoads().size(), 1);
+    EXPECT_EQ(readFile->numReads(), 0);
+
+    auto next1 = getNext(*stream1);
+    ASSERT_TRUE(next1.has_value());
+    EXPECT_EQ(next1.value(), content.substr(123, regionSize));
+    EXPECT_EQ(readFile->numReads(), 1);
+
+    auto next2 = getNext(*stream2);
+    ASSERT_TRUE(next2.has_value());
+    EXPECT_EQ(next2.value(), content.substr(123, regionSize));
+    EXPECT_EQ(readFile->numReads(), 1);
+  }
+}
+
 DEBUG_ONLY_TEST_F(DirectBufferedInputTest, resetInputWithBeforeLoading) {
   constexpr int32_t kContentSize = 4 << 20; // 4MB
   std::string content;


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/nimble/pull/835

Allow `CachedBufferedInput` to keep exact duplicate cache requests in the same coalesced load using `coalesceDuplicateRanges=true`. The cached path does not need duplicate buffer copies because each stream performs its normal cache lookup after the shared coalesced load populates the single cache entry.

Add coverage that enqueues two streams for the same region and verifies they share one coalesced load, perform one storage read, populate one cache entry, and both return the expected bytes.

Differential Revision: D107766691


