### PR TITLE
feat(spark): Add support for minute/second(timestamp_utc)

### DIFF
--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -261,9 +261,27 @@ These functions support TIMESTAMP and DATE input types.
 
 .. spark:function:: minute(timestamp) -> integer
 
-    Returns the minutes of ``timestamp``.::
+    Returns the minutes of ``timestamp``, subject to the session timezone.
+
+    Under session timezone UTC: ::
 
         SELECT minute('2009-07-30 12:58:59'); -- 58
+
+    Under session timezone ``Asia/Kolkata`` (UTC+5:30): ::
+
+        SELECT minute('2009-07-30 12:58:59 UTC'); -- 28
+
+.. spark:function:: minute(timestamp_utc) -> integer
+
+    Returns the minutes of ``timestamp_utc``, not subject to the session timezone.
+
+    Under session timezone UTC: ::
+
+        SELECT minute(TIMESTAMP_NTZ '2009-07-30 12:58:59'); -- 58
+
+    Under session timezone ``Asia/Kolkata`` (UTC+5:30): ::
+
+        SELECT minute(TIMESTAMP_NTZ '2009-07-30 12:58:59'); -- 58
 
 .. spark:function:: month(date) -> integer
 
@@ -318,9 +336,16 @@ These functions support TIMESTAMP and DATE input types.
 
 .. spark:function:: second(timestamp) -> integer
 
-    Returns the seconds of ``timestamp``. ::
+    Returns the seconds of ``timestamp``. The result is not affected by the session
+    timezone since all timezone offsets are whole-minute multiples. ::
 
         SELECT second('2009-07-30 12:58:59'); -- 59
+
+.. spark:function:: second(timestamp_utc) -> integer
+
+    Returns the seconds of ``timestamp_utc``, not subject to the session timezone. ::
+
+        SELECT second(TIMESTAMP_NTZ '2009-07-30 12:58:59'); -- 59
 
 .. spark:function:: timestampadd(unit, value, timestamp) -> timestamp
 

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -909,24 +909,37 @@ struct HourFunction : public InitSessionTimezone<T> {
   }
 };
 
-template <typename T>
+template <typename T, typename TTimestamp>
 struct MinuteFunction : public InitSessionTimezone<T> {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& inputTypes,
+      const core::QueryConfig& config,
+      const arg_type<TTimestamp>* timestamp) {
+    if constexpr (std::is_same_v<TTimestamp, TimestampUtc>) {
+      // TIMESTAMP UTC represents a timestamp in UTC, not subject to session
+      // timezone adjustment.
+      this->timeZone_ = nullptr;
+    } else {
+      InitSessionTimezone<T>::initialize(inputTypes, config, timestamp);
+    }
+  }
+
   FOLLY_ALWAYS_INLINE void call(
       int32_t& result,
-      const arg_type<Timestamp>& timestamp) {
+      const arg_type<TTimestamp>& timestamp) {
     result = getDateTime(timestamp, this->timeZone_).tm_min;
   }
 };
 
-template <typename T>
+template <typename T, typename TTimestamp>
 struct SecondFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   FOLLY_ALWAYS_INLINE void call(
       int32_t& result,
-      const arg_type<Timestamp>& timestamp) {
+      const arg_type<TTimestamp>& timestamp) {
     result = getDateTime(timestamp, nullptr).tm_sec;
   }
 };

--- a/velox/functions/sparksql/registration/RegisterDatetime.cpp
+++ b/velox/functions/sparksql/registration/RegisterDatetime.cpp
@@ -83,8 +83,22 @@ void registerDatetimeFunctions(const std::string& prefix) {
       ParameterBinder<HourFunction, TimestampUtc>,
       int32_t,
       TimestampUtc>({prefix + "hour"});
-  registerFunction<MinuteFunction, int32_t, Timestamp>({prefix + "minute"});
-  registerFunction<SecondFunction, int32_t, Timestamp>({prefix + "second"});
+  registerFunction<
+      ParameterBinder<MinuteFunction, Timestamp>,
+      int32_t,
+      Timestamp>({prefix + "minute"});
+  registerFunction<
+      ParameterBinder<MinuteFunction, TimestampUtc>,
+      int32_t,
+      TimestampUtc>({prefix + "minute"});
+  registerFunction<
+      ParameterBinder<SecondFunction, Timestamp>,
+      int32_t,
+      Timestamp>({prefix + "second"});
+  registerFunction<
+      ParameterBinder<SecondFunction, TimestampUtc>,
+      int32_t,
+      TimestampUtc>({prefix + "second"});
   registerFunction<MakeYMIntervalFunction, IntervalYearMonth>(
       {prefix + "make_ym_interval"});
   registerFunction<MakeYMIntervalFunction, IntervalYearMonth, int32_t>(

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -990,6 +990,26 @@ TEST_F(DateTimeFunctionsTest, minute) {
   EXPECT_EQ(13, minute("1969-01-01 13:43:00.001"));
 }
 
+TEST_F(DateTimeFunctionsTest, minuteTimestampUtc) {
+  const auto minuteUtc = [&](StringView timestampStr) {
+    auto ts = std::make_optional(parseTimestamp(timestampStr));
+    return evaluateOnce<int32_t>("minute(c0)", TIMESTAMP_UTC(), ts);
+  };
+
+  EXPECT_EQ(23, minuteUtc("2024-01-08 00:23:00.001"));
+  EXPECT_EQ(59, minuteUtc("2024-01-08 00:59:59.999"));
+  EXPECT_EQ(10, minuteUtc("2015-04-08 13:10:15"));
+
+  // TIMESTAMP UTC must not be affected by session timezone.
+  // Asia/Kolkata (UTC+5:30) has a 30-minute offset that would shift minutes
+  // for a regular TIMESTAMP.
+  setQueryTimeZone("Asia/Kolkata");
+
+  EXPECT_EQ(23, minuteUtc("2024-01-08 00:23:00.001"));
+  EXPECT_EQ(59, minuteUtc("2024-01-08 00:59:59.999"));
+  EXPECT_EQ(10, minuteUtc("2015-04-08 13:10:15"));
+}
+
 TEST_F(DateTimeFunctionsTest, second) {
   const auto second = [&](const StringView& timestampStr) {
     const auto timeStamp = std::make_optional(parseTimestamp(timestampStr));
@@ -1000,6 +1020,24 @@ TEST_F(DateTimeFunctionsTest, second) {
   EXPECT_EQ(59, second("2024-01-08 00:59:59.999"));
   EXPECT_EQ(15, second("2015-04-08 13:10:15"));
   EXPECT_EQ(0, second("1969-01-01 13:43:00.001"));
+}
+
+TEST_F(DateTimeFunctionsTest, secondTimestampUtc) {
+  const auto secondUtc = [&](StringView timestampStr) {
+    auto ts = std::make_optional(parseTimestamp(timestampStr));
+    return evaluateOnce<int32_t>("second(c0)", TIMESTAMP_UTC(), ts);
+  };
+
+  EXPECT_EQ(0, secondUtc("2024-01-08 00:23:00.001"));
+  EXPECT_EQ(59, secondUtc("2024-01-08 00:59:59.999"));
+  EXPECT_EQ(15, secondUtc("2015-04-08 13:10:15"));
+
+  // TIMESTAMP UTC must not be affected by session timezone.
+  setQueryTimeZone("Pacific/Apia");
+
+  EXPECT_EQ(0, secondUtc("2024-01-08 00:23:00.001"));
+  EXPECT_EQ(59, secondUtc("2024-01-08 00:59:59.999"));
+  EXPECT_EQ(15, secondUtc("2015-04-08 13:10:15"));
 }
 
 TEST_F(DateTimeFunctionsTest, fromUnixtime) {


### PR DESCRIPTION
This PR adds support for minute(timestamp_utc) and second(timestamp_utc) in Spark functions.

TimestampUtcType (Velox's representation of Spark's TIMESTAMP_NTZ) stores timestamps without timezone information. The value is taken as-is with no session timezone adjustment applied. Accordingly, minute(timestamp_utc) and second(timestamp_utc) return the stored minute and second directly without adjusting for the session timezone.

Related type PR: [#17091](https://github.com/facebookincubator/velox/pull/17091)
Related issue: [#17087](https://github.com/facebookincubator/velox/issues/17087)
Spark reference: [datetimeExpressions.scala](https://github.com/apache/spark/blob/v4.0.0/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala)