### PR TITLE
fix: Restore thread-local stat writer in MockSharedArbitratorTest

### DIFF
--- a/velox/common/memory/tests/MockSharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/MockSharedArbitratorTest.cpp
@@ -1977,7 +1977,7 @@ DEBUG_ONLY_TEST_F(
 
   std::unordered_map<std::string, RuntimeMetric> runtimeStats;
   auto statsWriter = std::make_unique<TestRuntimeStatWriter>(runtimeStats);
-  setThreadLocalRunTimeStatWriter(statsWriter.get());
+  RuntimeStatWriterScopeGuard statsWriterGuard(statsWriter.get());
 
   localArbitrationOp->allocate(memoryPoolReservedCapacity);
   // Inject some delay for global arbitration.
@@ -2111,7 +2111,7 @@ TEST_F(MockSharedArbitrationTest, globalArbitrationWithoutSpill) {
 
   std::unordered_map<std::string, RuntimeMetric> runtimeStats;
   auto statsWriter = std::make_unique<TestRuntimeStatWriter>(runtimeStats);
-  setThreadLocalRunTimeStatWriter(statsWriter.get());
+  RuntimeStatWriterScopeGuard statsWriterGuard(statsWriter.get());
   triggerOp->allocate(memoryCapacity / 2);
 
   ASSERT_EQ(
@@ -2166,7 +2166,7 @@ TEST_F(MockSharedArbitrationTest, globalArbitrationSmallParticipantLargeGrow) {
 
   std::unordered_map<std::string, RuntimeMetric> runtimeStats;
   auto statsWriter = std::make_unique<TestRuntimeStatWriter>(runtimeStats);
-  setThreadLocalRunTimeStatWriter(statsWriter.get());
+  RuntimeStatWriterScopeGuard statsWriterGuard(statsWriter.get());
 
   // task0 has 256MB + 256MB (attempt) = 512MB in top abort capacity limit
   // bucket, which shall be evaluated first, and hence killed by global


### PR DESCRIPTION
fix: Restore thread-local stat writer in MockSharedArbitratorTest

## What

Three tests in `MockSharedArbitratorTest` set the thread-local runtime stat
writer to a stack-owned `TestRuntimeStatWriter` on the main thread via a bare
`setThreadLocalRunTimeStatWriter()` call, but never restore it:
`globalArbitrationWithoutSpill`, `globalArbitrationSmallParticipantLargeGrow`,
and a `DEBUG_ONLY` test.

`localRuntimeStatWriter` is a `thread_local` raw pointer. Once the
`TestRuntimeStatWriter` is destroyed at test exit, the pointer dangles. The
next test that runs on the main thread and reaches `addThreadLocalRuntimeStat`
(e.g. any global arbitration that calls `finishArbitration` during
`growCapacity`) dereferences the freed writer and segfaults.

## Symptom

The tests pass in isolation but crash when run after one of these, depending
on gtest execution order. Reproduced on a clean checkout:

- `globalArbitrationSmallParticipantLargeGrow` alone: pass
- `globalArbitrationBySpillWithPriority` alone: pass
- the two run back-to-back: SIGSEGV in `addThreadLocalRuntimeStat`

gdb backtrace:
```
#0 addThreadLocalRuntimeStat
#1 SharedArbitrator::finishArbitration
#2 ScopedArbitration::~ScopedArbitration
#3 SharedArbitrator::growCapacity
#9 ...BySpillWithPriority_Test::TestBody
```

## Fix

Use the existing RAII `RuntimeStatWriterScopeGuard`, which restores the
previous writer on destruction, so the thread-local pointer is never left
dangling.

## Test

All `MockSharedArbitration*` tests pass back-to-back with no segfault.
