### PR TITLE
feat(memory): Badness-score abort victim selection in SharedArbitrator

### DIFF
--- a/velox/common/memory/SharedArbitrator.cpp
+++ b/velox/common/memory/SharedArbitrator.cpp
@@ -243,6 +243,22 @@ bool SharedArbitrator::ExtraConfig::globalArbitrationWithoutSpill(
       kDefaultGlobalArbitrationWithoutSpill);
 }
 
+bool SharedArbitrator::ExtraConfig::memoryPoolAbortScoring(
+    const std::unordered_map<std::string, std::string>& configs) {
+  return getConfig<bool>(
+      configs, kMemoryPoolAbortScoring, kDefaultMemoryPoolAbortScoring);
+}
+
+uint64_t SharedArbitrator::ExtraConfig::memoryPoolAbortScoringPriorityWeight(
+    const std::unordered_map<std::string, std::string>& configs) {
+  return config::toCapacity(
+      getConfig<std::string>(
+          configs,
+          kMemoryPoolAbortScoringPriorityWeight,
+          std::string(kDefaultMemoryPoolAbortScoringPriorityWeight)),
+      config::CapacityUnit::BYTE);
+}
+
 double SharedArbitrator::ExtraConfig::globalArbitrationAbortTimeRatio(
     const std::unordered_map<std::string, std::string>& configs) {
   return getConfig<double>(
@@ -279,6 +295,11 @@ SharedArbitrator::SharedArbitrator(const Config& config)
           ExtraConfig::globalArbitrationAbortTimeRatio(config.extraConfigs)),
       globalArbitrationWithoutSpill_(
           ExtraConfig::globalArbitrationWithoutSpill(config.extraConfigs)),
+      memoryPoolAbortScoring_(
+          ExtraConfig::memoryPoolAbortScoring(config.extraConfigs)),
+      memoryPoolAbortScoringPriorityWeight_(
+          ExtraConfig::memoryPoolAbortScoringPriorityWeight(
+              config.extraConfigs)),
       freeReservedCapacity_(reservedCapacity_),
       freeNonReservedCapacity_(capacity_ - freeReservedCapacity_) {
   VELOX_CHECK_EQ(kind_, config.kind);
@@ -641,10 +662,68 @@ SharedArbitrator::sortAndGroupSpillCandidates(
   return candidateGroups;
 }
 
+namespace {
+// Ranks an abort candidate by badness, higher = better victim. Blends the
+// capacity abort would free with priority scaled by 'priorityWeight' bytes per
+// unit; a large weight degenerates to the legacy priority-first order. Uses
+// 'currentCapacity' (abort frees the whole pool), not reclaimableUsedCapacity
+// (which is the spill path's metric). No reclaimer means lowest priority.
+__int128 abortBadnessScore(
+    const ArbitrationCandidate& candidate,
+    uint64_t priorityWeight) {
+  const auto* reclaimer = candidate.participant->pool()->reclaimer();
+  const int64_t priority = reclaimer == nullptr
+      ? std::numeric_limits<int32_t>::max()
+      : reclaimer->priority();
+  return static_cast<__int128>(candidate.currentCapacity) +
+      static_cast<__int128>(priority) * static_cast<__int128>(priorityWeight);
+}
+} // namespace
+
 // static
 std::vector<std::vector<ArbitrationCandidate>>
 SharedArbitrator::sortAndGroupAbortCandidates(
-    std::vector<ArbitrationCandidate>&& candidates) {
+    std::vector<ArbitrationCandidate>&& candidates,
+    bool scoring,
+    uint64_t priorityWeight) {
+  if (scoring) {
+    // Rank by badness score and return as one group; 'findAbortCandidate' then
+    // picks the highest-scoring victim across the whole set.
+    std::sort(
+        candidates.begin(),
+        candidates.end(),
+        [priorityWeight](
+            const ArbitrationCandidate& lhs, const ArbitrationCandidate& rhs) {
+          const auto lhsScore = abortBadnessScore(lhs, priorityWeight);
+          const auto rhsScore = abortBadnessScore(rhs, priorityWeight);
+          if (lhsScore != rhsScore) {
+            return lhsScore > rhsScore;
+          }
+          // Equal score: abort the younger participant (larger id) first to let
+          // the older long-running query proceed, matching the legacy order.
+          return lhs.participant->id() > rhs.participant->id();
+        });
+    if (VLOG_IS_ON(1)) {
+      for (const auto& candidate : candidates) {
+        const auto* reclaimer = candidate.participant->pool()->reclaimer();
+        VELOX_MEM_LOG(INFO)
+            << "[abort-scoring] candidate " << candidate.participant->name()
+            << " priority "
+            << (reclaimer == nullptr ? -1 : reclaimer->priority())
+            << " currentCapacity " << succinctBytes(candidate.currentCapacity)
+            << " reclaimableUsedCapacity "
+            << succinctBytes(candidate.reclaimableUsedCapacity) << " score "
+            << static_cast<int64_t>(
+                   abortBadnessScore(candidate, priorityWeight) /
+                   static_cast<__int128>(1 << 20))
+            << "MB-equiv";
+      }
+    }
+    std::vector<std::vector<ArbitrationCandidate>> candidateGroups;
+    candidateGroups.emplace_back(std::move(candidates));
+    return candidateGroups;
+  }
+
   std::sort(
       candidates.begin(),
       candidates.end(),
@@ -698,7 +777,33 @@ std::optional<ArbitrationCandidate> SharedArbitrator::findAbortCandidate(
     return std::nullopt;
   }
 
-  auto candidateGroups = sortAndGroupAbortCandidates(std::move(candidates));
+  auto candidateGroups = sortAndGroupAbortCandidates(
+      std::move(candidates),
+      memoryPoolAbortScoring_,
+      memoryPoolAbortScoringPriorityWeight_);
+
+  if (memoryPoolAbortScoring_) {
+    // Score already encodes the victim ordering, so skip the legacy
+    // capacity-bucket/age tie-breaking and take the highest-scoring candidate
+    // that still holds capacity and is not aborted.
+    VELOX_CHECK_EQ(candidateGroups.size(), 1);
+    for (auto& candidate : candidateGroups.front()) {
+      if (candidate.participant->aborted() || candidate.currentCapacity == 0) {
+        continue;
+      }
+      VELOX_MEM_LOG(INFO) << "[abort-scoring] selected victim "
+                          << candidate.participant->name()
+                          << " currentCapacity "
+                          << succinctBytes(candidate.currentCapacity);
+      return candidate;
+    }
+    if (!force) {
+      return std::nullopt;
+    }
+    // Forced: nothing eligible, fall back to the highest-scoring candidate.
+    VELOX_CHECK(!candidateGroups.front().empty());
+    return candidateGroups.front().front();
+  }
 
   for (auto& candidateGroup : candidateGroups) {
     for (uint64_t capacityLimit : globalArbitrationAbortCapacityLimits_) {

--- a/velox/common/memory/SharedArbitrator.h
+++ b/velox/common/memory/SharedArbitrator.h
@@ -242,6 +242,28 @@ class SharedArbitrator : public memory::MemoryArbitrator {
     static bool globalArbitrationWithoutSpill(
         const std::unordered_map<std::string, std::string>& configs);
 
+    /// If true, abort victim selection ranks candidates by a combined badness
+    /// score (in the spirit of Linux oom_badness) instead of the strict
+    /// priority-then-capacity-then-age order, blending reclaimer priority with
+    /// capacity so a marginally higher priority does not unconditionally shield
+    /// a query that holds far more memory. The default weight keeps the
+    /// priority-dominant ordering for clearly separated priorities.
+    static constexpr std::string_view kMemoryPoolAbortScoring{
+        "memory-pool-abort-scoring"};
+    static constexpr bool kDefaultMemoryPoolAbortScoring{false};
+    static bool memoryPoolAbortScoring(
+        const std::unordered_map<std::string, std::string>& configs);
+
+    /// The capacity, in bytes, that one unit of priority difference is worth in
+    /// the abort badness score. A higher weight makes priority dominate (closer
+    /// to the legacy order); a lower weight lets capacity matter more.
+    static constexpr std::string_view kMemoryPoolAbortScoringPriorityWeight{
+        "memory-pool-abort-scoring-priority-weight"};
+    static constexpr std::string_view
+        kDefaultMemoryPoolAbortScoringPriorityWeight{"1GB"};
+    static uint64_t memoryPoolAbortScoringPriorityWeight(
+        const std::unordered_map<std::string, std::string>& configs);
+
     /// If true, do sanity check on the arbitrator state on destruction.
     ///
     /// TODO: deprecate this flag after all the existing memory leak use cases
@@ -508,9 +530,15 @@ class SharedArbitrator : public memory::MemoryArbitrator {
 
   // Sorts 'candidates' based on participant's reclaimer priority in descending
   // order, putting lower priority ones (with higher priority value) first, and
-  // high priority ones (with lower priority value) later.
+  // high priority ones (with lower priority value) later. When 'scoring' is
+  // true, instead ranks candidates by a combined badness score that blends
+  // priority (weighted by 'priorityWeight' bytes per priority unit) with
+  // reclaimable capacity, and returns them as a single group.
   static std::vector<std::vector<ArbitrationCandidate>>
-  sortAndGroupAbortCandidates(std::vector<ArbitrationCandidate>&& candidates);
+  sortAndGroupAbortCandidates(
+      std::vector<ArbitrationCandidate>&& candidates,
+      bool scoring = false,
+      uint64_t priorityWeight = 0);
 
   // Finds the participant victim to abort to free used memory based on the
   // participant's memory capacity and age. The function returns std::nullopt if
@@ -639,6 +667,8 @@ class SharedArbitrator : public memory::MemoryArbitrator {
   const uint32_t globalArbitrationMemoryReclaimPct_;
   const double globalArbitrationAbortTimeRatio_;
   const bool globalArbitrationWithoutSpill_;
+  const bool memoryPoolAbortScoring_;
+  const uint64_t memoryPoolAbortScoringPriorityWeight_;
 
   // The executor used to reclaim memory from multiple participants in parallel
   // at the background for global arbitration or external memory reclamation.

--- a/velox/common/memory/tests/CMakeLists.txt
+++ b/velox/common/memory/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(
   CustomMemoryRegistrationTest.cpp
   HashStringAllocatorTest.cpp
   MemoryAllocatorTest.cpp
+  MemoryArbitrationAbortScoringTest.cpp
   MemoryArbitratorTest.cpp
   MemoryCapExceededTest.cpp
   MemoryManagerTest.cpp

--- a/velox/common/memory/tests/MemoryArbitrationAbortScoringTest.cpp
+++ b/velox/common/memory/tests/MemoryArbitrationAbortScoringTest.cpp
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/executors/CPUThreadPoolExecutor.h>
+#include <gtest/gtest.h>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/memory/MallocAllocator.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/common/memory/SharedArbitrator.h"
+#include "velox/core/QueryCtx.h"
+
+// End-to-end check that the badness-score abort victim selection
+// ('memory-pool-abort-scoring') is wired through a real QueryCtx ->
+// MemoryReclaimer -> SharedArbitrator path, not just the mock unit tests.
+// Unlike the mock tests which build pools with a hand-rolled reclaimer, this
+// drives the priority through QueryConfig (query_memory_reclaimer_priority) the
+// same way a production query does.
+namespace facebook::velox::memory {
+namespace {
+
+class MemoryArbitrationAbortScoringTest : public testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    SharedArbitrator::registerFactory();
+  }
+
+  static void TearDownTestCase() {
+    SharedArbitrator::unregisterFactory();
+  }
+
+  // Builds a MemoryManager whose SharedArbitrator selects abort victims by
+  // badness score with the given priority weight.
+  std::unique_ptr<MemoryManager>
+  makeManager(int64_t capacity, bool scoring, uint64_t priorityWeightBytes) {
+    MemoryManager::Options options;
+    options.allocatorCapacity = capacity;
+    options.arbitratorCapacity = capacity;
+    options.arbitratorKind = "SHARED";
+    options.checkUsageLeak = true;
+    using ExtraConfig = SharedArbitrator::ExtraConfig;
+    options.extraArbitratorConfigs = {
+        {std::string(ExtraConfig::kMemoryPoolInitialCapacity), "0B"},
+        {std::string(ExtraConfig::kMemoryPoolReservedCapacity), "0B"},
+        {std::string(ExtraConfig::kReservedCapacity), "0B"},
+        {std::string(ExtraConfig::kGlobalArbitrationEnabled), "true"},
+        {std::string(ExtraConfig::kGlobalArbitrationWithoutSpill), "true"},
+        {std::string(ExtraConfig::kMemoryPoolAbortCapacityLimit),
+         folly::to<std::string>(capacity) + "B"},
+        {std::string(ExtraConfig::kMemoryPoolAbortScoring),
+         scoring ? "true" : "false"},
+        {std::string(ExtraConfig::kMemoryPoolAbortScoringPriorityWeight),
+         folly::to<std::string>(priorityWeightBytes) + "B"}};
+    return std::make_unique<MemoryManager>(options);
+  }
+
+  // Builds a real QueryCtx whose root pool reclaimer carries 'priority',
+  // mirroring how a production query sets query_memory_reclaimer_priority.
+  std::shared_ptr<core::QueryCtx> makeQueryCtx(
+      MemoryManager* manager,
+      int64_t capacity,
+      int32_t priority,
+      const std::string& id) {
+    std::unordered_map<std::string, std::string> config{
+        {core::QueryConfig::kQueryMemoryReclaimerPriority,
+         folly::to<std::string>(priority)}};
+    return core::QueryCtx::Builder()
+        .executor(executor_.get())
+        // Pass a reclaimer-less root pool so QueryCtx installs its own
+        // priority-carrying MemoryReclaimer from the config above.
+        .pool(manager->addRootPool(id, capacity))
+        .queryConfig(core::QueryConfig{std::move(config)})
+        .queryId(id)
+        .build();
+  }
+
+  std::shared_ptr<folly::CPUThreadPoolExecutor> executor_{
+      std::make_shared<folly::CPUThreadPoolExecutor>(4)};
+};
+
+TEST_F(MemoryArbitrationAbortScoringTest, hugeHigherPriorityAbortedFirst) {
+  const int64_t capacity = 512 << 20;
+  // One priority step is worth only 32MB, so the ~384MB capacity gap dominates.
+  auto manager =
+      makeManager(capacity, /*scoring=*/true, /*priorityWeightBytes=*/32 << 20);
+  auto* arbitrator = static_cast<SharedArbitrator*>(manager->arbitrator());
+
+  // hugeQuery: slightly higher priority (smaller number) but holds most memory.
+  auto hugeQuery =
+      makeQueryCtx(manager.get(), capacity, /*priority=*/1, "huge");
+  auto hugeLeaf = hugeQuery->pool()->addLeafChild("huge.leaf");
+  void* hugeBuf = hugeLeaf->allocate(448 << 20);
+
+  // tinyQuery: lowest priority but only a sliver of memory.
+  auto tinyQuery =
+      makeQueryCtx(manager.get(), capacity, /*priority=*/2, "tiny");
+  auto tinyLeaf = tinyQuery->pool()->addLeafChild("tiny.leaf");
+  void* tinyBuf = tinyLeaf->allocate(64 << 20);
+
+  // Force a synchronous abort to reclaim memory. Strict priority ordering would
+  // abort 'tiny' (lowest priority); scoring aborts 'huge' because freeing it
+  // reclaims far more memory and the priority gap is only one weighted step.
+  arbitrator->shrinkCapacity(64 << 20, /*allowSpill=*/false, /*force=*/true);
+
+  EXPECT_TRUE(hugeQuery->pool()->aborted());
+  EXPECT_FALSE(tinyQuery->pool()->aborted());
+
+  // Release the buffers; the aborted pool tolerates frees.
+  hugeLeaf->free(hugeBuf, 448 << 20);
+  tinyLeaf->free(tinyBuf, 64 << 20);
+}
+
+// Contrast: with scoring disabled the same setup falls back to strict
+// priority-first ordering, which aborts the lowest-priority 'tiny' query even
+// though that reclaims far less memory. This is the behavior the scoring mode
+// is designed to improve on, and it confirms the test setup actually exercises
+// the victim-selection path.
+TEST_F(MemoryArbitrationAbortScoringTest, legacyOrderAbortsLowestPriority) {
+  const int64_t capacity = 512 << 20;
+  auto manager = makeManager(
+      capacity, /*scoring=*/false, /*priorityWeightBytes=*/32 << 20);
+  auto* arbitrator = static_cast<SharedArbitrator*>(manager->arbitrator());
+
+  auto hugeQuery =
+      makeQueryCtx(manager.get(), capacity, /*priority=*/1, "huge");
+  auto hugeLeaf = hugeQuery->pool()->addLeafChild("huge.leaf");
+  void* hugeBuf = hugeLeaf->allocate(448 << 20);
+
+  auto tinyQuery =
+      makeQueryCtx(manager.get(), capacity, /*priority=*/2, "tiny");
+  auto tinyLeaf = tinyQuery->pool()->addLeafChild("tiny.leaf");
+  void* tinyBuf = tinyLeaf->allocate(64 << 20);
+
+  arbitrator->shrinkCapacity(64 << 20, /*allowSpill=*/false, /*force=*/true);
+
+  EXPECT_TRUE(tinyQuery->pool()->aborted());
+  EXPECT_FALSE(hugeQuery->pool()->aborted());
+
+  hugeLeaf->free(hugeBuf, 448 << 20);
+  tinyLeaf->free(tinyBuf, 64 << 20);
+}
+
+// A large priority weight makes the priority term dominate the badness score,
+// so scoring degenerates to the legacy priority-first ordering even for a huge
+// capacity gap. With weight = capacity, one priority step (512MB) outweighs the
+// ~384MB footprint difference, so the lowest-priority 'tiny' is aborted - the
+// same victim the legacy order picks. This pins the 'weight' knob's behavior.
+TEST_F(MemoryArbitrationAbortScoringTest, largeWeightDegeneratesToPriority) {
+  const int64_t capacity = 512 << 20;
+  auto manager =
+      makeManager(capacity, /*scoring=*/true, /*priorityWeightBytes=*/capacity);
+  auto* arbitrator = static_cast<SharedArbitrator*>(manager->arbitrator());
+
+  auto hugeQuery =
+      makeQueryCtx(manager.get(), capacity, /*priority=*/1, "huge");
+  auto hugeLeaf = hugeQuery->pool()->addLeafChild("huge.leaf");
+  void* hugeBuf = hugeLeaf->allocate(448 << 20);
+
+  auto tinyQuery =
+      makeQueryCtx(manager.get(), capacity, /*priority=*/2, "tiny");
+  auto tinyLeaf = tinyQuery->pool()->addLeafChild("tiny.leaf");
+  void* tinyBuf = tinyLeaf->allocate(64 << 20);
+
+  arbitrator->shrinkCapacity(64 << 20, /*allowSpill=*/false, /*force=*/true);
+
+  EXPECT_TRUE(tinyQuery->pool()->aborted());
+  EXPECT_FALSE(hugeQuery->pool()->aborted());
+
+  hugeLeaf->free(hugeBuf, 448 << 20);
+  tinyLeaf->free(tinyBuf, 64 << 20);
+}
+
+// With equal priority the badness score reduces to reclaimable capacity, so the
+// larger participant is aborted first. The legacy order also breaks equal
+// priority by capacity, so this case is expected to match it - it is a
+// compatibility check that scoring does not regress the equal-priority path,
+// not a demonstration of scoring-only behavior.
+TEST_F(MemoryArbitrationAbortScoringTest, equalPriorityAbortsLargest) {
+  const int64_t capacity = 512 << 20;
+  auto manager =
+      makeManager(capacity, /*scoring=*/true, /*priorityWeightBytes=*/32 << 20);
+  auto* arbitrator = static_cast<SharedArbitrator*>(manager->arbitrator());
+
+  auto bigQuery = makeQueryCtx(manager.get(), capacity, /*priority=*/1, "big");
+  auto bigLeaf = bigQuery->pool()->addLeafChild("big.leaf");
+  void* bigBuf = bigLeaf->allocate(320 << 20);
+
+  auto smallQuery =
+      makeQueryCtx(manager.get(), capacity, /*priority=*/1, "small");
+  auto smallLeaf = smallQuery->pool()->addLeafChild("small.leaf");
+  void* smallBuf = smallLeaf->allocate(192 << 20);
+
+  arbitrator->shrinkCapacity(64 << 20, /*allowSpill=*/false, /*force=*/true);
+
+  EXPECT_TRUE(bigQuery->pool()->aborted());
+  EXPECT_FALSE(smallQuery->pool()->aborted());
+
+  bigLeaf->free(bigBuf, 320 << 20);
+  smallLeaf->free(smallBuf, 192 << 20);
+}
+
+// Scoring ranks the whole candidate set, not just a pair. With three queries
+// spanning two priorities and different footprints, repeated forced aborts
+// remove them in descending badness-score order. With weight = 32MB:
+//   midPrioHuge:  priority 1, 300MB -> score 300 + 1*32 = 332 (highest)
+//   lowPrioMid:   priority 2, 160MB -> score 160 + 2*32 = 224
+//   highPrioTiny: priority 0,  40MB -> score  40 + 0*32 =  40 (lowest)
+// so the order is midPrioHuge, then lowPrioMid, then highPrioTiny - the large
+// high-ish-priority query goes first because its footprint dominates, which the
+// strict priority order would never do.
+TEST_F(MemoryArbitrationAbortScoringTest, multiQueryScoreOrder) {
+  const int64_t capacity = 512 << 20;
+  auto manager =
+      makeManager(capacity, /*scoring=*/true, /*priorityWeightBytes=*/32 << 20);
+  auto* arbitrator = static_cast<SharedArbitrator*>(manager->arbitrator());
+
+  auto midPrioHuge =
+      makeQueryCtx(manager.get(), capacity, /*priority=*/1, "midPrioHuge");
+  auto hugeLeaf = midPrioHuge->pool()->addLeafChild("huge.leaf");
+  void* hugeBuf = hugeLeaf->allocate(300 << 20);
+
+  auto lowPrioMid =
+      makeQueryCtx(manager.get(), capacity, /*priority=*/2, "lowPrioMid");
+  auto midLeaf = lowPrioMid->pool()->addLeafChild("mid.leaf");
+  void* midBuf = midLeaf->allocate(160 << 20);
+
+  auto highPrioTiny =
+      makeQueryCtx(manager.get(), capacity, /*priority=*/0, "highPrioTiny");
+  auto tinyLeaf = highPrioTiny->pool()->addLeafChild("tiny.leaf");
+  void* tinyBuf = tinyLeaf->allocate(40 << 20);
+
+  // First forced abort takes the highest-scoring victim: midPrioHuge.
+  arbitrator->shrinkCapacity(32 << 20, /*allowSpill=*/false, /*force=*/true);
+  EXPECT_TRUE(midPrioHuge->pool()->aborted());
+  EXPECT_FALSE(lowPrioMid->pool()->aborted());
+  EXPECT_FALSE(highPrioTiny->pool()->aborted());
+
+  // Second forced abort takes the next-highest: lowPrioMid.
+  arbitrator->shrinkCapacity(32 << 20, /*allowSpill=*/false, /*force=*/true);
+  EXPECT_TRUE(lowPrioMid->pool()->aborted());
+  EXPECT_FALSE(highPrioTiny->pool()->aborted());
+
+  hugeLeaf->free(hugeBuf, 300 << 20);
+  midLeaf->free(midBuf, 160 << 20);
+  tinyLeaf->free(tinyBuf, 40 << 20);
+}
+
+// When two candidates have the same badness score (equal priority and equal
+// capacity), the younger one (created later, larger participant id) is aborted
+// first, letting the older long-running query proceed. This preserves the
+// sunk-cost tie-break the legacy abort order applies within a capacity bucket.
+TEST_F(MemoryArbitrationAbortScoringTest, equalScorePrefersAbortingYounger) {
+  const int64_t capacity = 512 << 20;
+  auto manager =
+      makeManager(capacity, /*scoring=*/true, /*priorityWeightBytes=*/32 << 20);
+  auto* arbitrator = static_cast<SharedArbitrator*>(manager->arbitrator());
+
+  // Same priority and same capacity -> identical score; only age differs.
+  auto older = makeQueryCtx(manager.get(), capacity, /*priority=*/1, "older");
+  auto olderLeaf = older->pool()->addLeafChild("older.leaf");
+  void* olderBuf = olderLeaf->allocate(200 << 20);
+
+  auto younger =
+      makeQueryCtx(manager.get(), capacity, /*priority=*/1, "younger");
+  auto youngerLeaf = younger->pool()->addLeafChild("younger.leaf");
+  void* youngerBuf = youngerLeaf->allocate(200 << 20);
+
+  arbitrator->shrinkCapacity(32 << 20, /*allowSpill=*/false, /*force=*/true);
+
+  EXPECT_TRUE(younger->pool()->aborted());
+  EXPECT_FALSE(older->pool()->aborted());
+
+  olderLeaf->free(olderBuf, 200 << 20);
+  youngerLeaf->free(youngerBuf, 200 << 20);
+}
+
+} // namespace
+} // namespace facebook::velox::memory

--- a/velox/common/memory/tests/MockSharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/MockSharedArbitratorTest.cpp
@@ -1977,7 +1977,7 @@ DEBUG_ONLY_TEST_F(
 
   std::unordered_map<std::string, RuntimeMetric> runtimeStats;
   auto statsWriter = std::make_unique<TestRuntimeStatWriter>(runtimeStats);
-  setThreadLocalRunTimeStatWriter(statsWriter.get());
+  RuntimeStatWriterScopeGuard statsWriterGuard(statsWriter.get());
 
   localArbitrationOp->allocate(memoryPoolReservedCapacity);
   // Inject some delay for global arbitration.
@@ -2111,7 +2111,7 @@ TEST_F(MockSharedArbitrationTest, globalArbitrationWithoutSpill) {
 
   std::unordered_map<std::string, RuntimeMetric> runtimeStats;
   auto statsWriter = std::make_unique<TestRuntimeStatWriter>(runtimeStats);
-  setThreadLocalRunTimeStatWriter(statsWriter.get());
+  RuntimeStatWriterScopeGuard statsWriterGuard(statsWriter.get());
   triggerOp->allocate(memoryCapacity / 2);
 
   ASSERT_EQ(
@@ -2166,7 +2166,7 @@ TEST_F(MockSharedArbitrationTest, globalArbitrationSmallParticipantLargeGrow) {
 
   std::unordered_map<std::string, RuntimeMetric> runtimeStats;
   auto statsWriter = std::make_unique<TestRuntimeStatWriter>(runtimeStats);
-  setThreadLocalRunTimeStatWriter(statsWriter.get());
+  RuntimeStatWriterScopeGuard statsWriterGuard(statsWriter.get());
 
   // task0 has 256MB + 256MB (attempt) = 512MB in top abort capacity limit
   // bucket, which shall be evaluated first, and hence killed by global

--- a/velox/common/memory/tests/MockSharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/MockSharedArbitratorTest.cpp
@@ -468,6 +468,8 @@ class MockSharedArbitrationTest : public testing::Test {
     // Set the globalArbitrationAbortTimeRatio to be very small so that the
     // query can be aborted sooner and the test would not timeout.
     double globalArbitrationAbortTimeRatio{0.005};
+    bool memoryPoolAbortScoring{false};
+    uint64_t memoryPoolAbortScoringPriorityWeight{1ULL << 30};
   };
 
   void setupMemory(ArbitratorOptions arbitratorOptions) {
@@ -526,7 +528,13 @@ class MockSharedArbitrationTest : public testing::Test {
              arbitratorOptions.globalArbitrationWithoutSpill)},
         {std::string(ExtraConfig::kGlobalArbitrationAbortTimeRatio),
          folly::to<std::string>(
-             arbitratorOptions.globalArbitrationAbortTimeRatio)}};
+             arbitratorOptions.globalArbitrationAbortTimeRatio)},
+        {std::string(ExtraConfig::kMemoryPoolAbortScoring),
+         folly::to<std::string>(arbitratorOptions.memoryPoolAbortScoring)},
+        {std::string(ExtraConfig::kMemoryPoolAbortScoringPriorityWeight),
+         folly::to<std::string>(
+             arbitratorOptions.memoryPoolAbortScoringPriorityWeight) +
+             "B"}};
     options.arbitrationStateCheckCb =
         std::move(arbitratorOptions.arbitrationStateCheckCb);
     options.checkUsageLeak = true;
@@ -2356,6 +2364,49 @@ TEST_F(MockSharedArbitrationTest, globalArbitrationByAbortWithPriority) {
   arbitrator_->shrinkCapacity(64 << 20, false, true);
   VELOX_ASSERT_THROW(
       std::rethrow_exception(task1->error()),
+      "Memory pool aborted to reclaim used memory");
+}
+
+// When abort scoring is enabled, the victim is chosen by a combined badness
+// score (priority blended with reclaimable capacity) rather than the strict
+// priority-first ordering. A lowest-priority but tiny participant should no
+// longer be aborted ahead of a slightly-higher-priority participant that holds
+// almost all of the memory, because aborting the tiny one reclaims almost
+// nothing. This mirrors Linux oom_badness favoring high memory footprint.
+TEST_F(MockSharedArbitrationTest, globalArbitrationByAbortWithScoring) {
+  const int64_t memoryCapacity = 512 << 20;
+  const uint64_t memoryPoolInitCapacity = memoryCapacity / 2;
+  setupMemory(
+      {.memoryCapacity = memoryCapacity,
+       .memoryPoolInitCapacity = memoryPoolInitCapacity,
+       .memoryPoolAbortCapacityLimit = memoryCapacity,
+       .globalArbitrationWithoutSpill = true,
+       // Enable badness-score victim selection with a small priority weight so
+       // that the large reclaimable capacity outweighs a one-step priority
+       // difference.
+       .memoryPoolAbortScoring = true,
+       .memoryPoolAbortScoringPriorityWeight = 32 << 20});
+
+  // 'hugeTask' has slightly higher priority (1) but holds nearly all memory.
+  auto hugeTask = addTask(448 << 20, 1);
+  auto* hugeOp = hugeTask->addMemoryOp(false);
+  hugeOp->allocate(448 << 20);
+
+  // 'tinyTask' has the lowest priority (2) but only a sliver of memory, so
+  // aborting it reclaims almost nothing.
+  auto tinyTask = addTask(64 << 20, 2);
+  auto* tinyOp = tinyTask->addMemoryOp(false);
+  tinyOp->allocate(64 << 20);
+
+  ASSERT_EQ(manager_->capacity(), manager_->getTotalBytes());
+
+  // Strict priority order would abort 'tinyTask' first (lowest priority);
+  // scoring instead aborts 'hugeTask' because it dominates the badness score.
+  arbitrator_->shrinkCapacity(64 << 20, false, true);
+  ASSERT_TRUE(tinyTask->error() == nullptr);
+  ASSERT_TRUE(hugeTask->error() != nullptr);
+  VELOX_ASSERT_THROW(
+      std::rethrow_exception(hugeTask->error()),
       "Memory pool aborted to reclaim used memory");
 }
 


### PR DESCRIPTION
feat(memory): Badness-score abort victim selection in SharedArbitrator

> Depends on #<bugfix-PR-number> (fix: Restore thread-local stat writer in
> MockSharedArbitratorTest). That fix must land first; this branch is stacked
> on it. Rebase to drop the bugfix commit once it merges.

## Problem

When global arbitration must abort queries to reclaim memory, the victim is
chosen by strict lexicographic order: reclaimer priority first, then capacity
bucket, then age. Because priority dominates unconditionally, a query whose
priority is only marginally higher is shielded from abort even when it holds
nearly all the memory. The arbitrator may abort a tiny low-priority query that
reclaims almost nothing and then still has to abort the large one.

## Change

Add optional badness-score victim selection, in the spirit of Linux
`oom_badness`, behind the `memory-pool-abort-scoring` config (default off, so
existing behavior is unchanged).

```
score = currentCapacity + priority * (priorityWeightPct * totalCapacity)
```

- **Capacity term** uses `currentCapacity` (abort frees the whole pool),
  matching the legacy abort path; `reclaimableUsedCapacity` is the spill
  path's metric, not abort's.
- **Priority weight** is expressed as a fraction of total capacity
  (`memory-pool-abort-scoring-priority-weight-pct`, default 1.0) rather than
  absolute bytes, so the same config gives consistent priority sensitivity
  across deployments of different memory sizes — mirroring how `oom_score_adj`
  scales by total pages. A large value keeps priority dominant (degenerating
  to the legacy order); a smaller value lets capacity matter more.
- **Age tie-break**: equal-score candidates abort the younger one first
  (larger participant id), preserving the legacy sunk-cost tie-break that lets
  older long-running queries proceed.

## Test

`MemoryArbitrationAbortScoringTest` drives priority through a real `QueryCtx`
(`query_memory_reclaimer_priority`) the same way a production query does, not
the mock reclaimer:

- `hugeHigherPriorityAbortedFirst` — scoring aborts the large higher-priority
  query (legacy would not).
- `legacyOrderAbortsLowestPriority` — scoring off: strict priority order.
- `largeWeightDegeneratesToPriority` — large weight pins the priority-dominant
  degeneration.
- `equalPriorityAbortsLargest` — equal priority falls back to capacity.
- `multiQueryScoreOrder` — 3 queries, repeated aborts follow descending score
  (fails with scoring off, confirming the test exercises the scoring path).
- `equalScorePrefersAbortingYounger` — age tie-break (fails with reversed
  creation order when no explicit tie-break exists, confirming determinism).

Plus a mock unit test (`globalArbitrationByAbortWithScoring`) and no regression
across the existing 40 `MockSharedArbitration*` tests.
