### PR TITLE
refactor(iceberg): Reuse IcebergTestBase across tests and split positional-delete tests

### DIFF
--- a/velox/connectors/hive/iceberg/IcebergSplit.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplit.cpp
@@ -16,8 +16,6 @@
 
 #include "velox/connectors/hive/iceberg/IcebergSplit.h"
 
-#include <utility>
-
 #include "velox/connectors/hive/iceberg/IcebergDeleteFile.h"
 
 namespace facebook::velox::connector::hive::iceberg {
@@ -95,61 +93,7 @@ HiveIcebergSplit::HiveIcebergSplit(
       deleteFiles(std::move(deletes)),
       dataSequenceNumber(dataSequenceNumber) {}
 
-HiveIcebergSplitBuilder::HiveIcebergSplitBuilder(std::string filePath)
-    : filePath_{std::move(filePath)} {
-  infoColumns_["$path"] = filePath_;
-}
-
-HiveIcebergSplitBuilder& HiveIcebergSplitBuilder::connectorId(
-    std::string connectorId) {
-  connectorId_ = std::move(connectorId);
-  return *this;
-}
-
-HiveIcebergSplitBuilder& HiveIcebergSplitBuilder::fileFormat(
-    dwio::common::FileFormat fileFormat) {
-  fileFormat_ = fileFormat;
-  return *this;
-}
-
-HiveIcebergSplitBuilder& HiveIcebergSplitBuilder::start(uint64_t start) {
-  start_ = start;
-  return *this;
-}
-
-HiveIcebergSplitBuilder& HiveIcebergSplitBuilder::length(uint64_t length) {
-  length_ = length;
-  return *this;
-}
-
-HiveIcebergSplitBuilder& HiveIcebergSplitBuilder::partitionKeys(
-    const std::unordered_map<std::string, std::optional<std::string>>&
-        partitionKeys) {
-  partitionKeys_ = partitionKeys;
-  return *this;
-}
-
-HiveIcebergSplitBuilder& HiveIcebergSplitBuilder::infoColumns(
-    const std::unordered_map<std::string, std::string>& infoColumns) {
-  for (const auto& [name, value] : infoColumns) {
-    infoColumns_[name] = value;
-  }
-  return *this;
-}
-
-HiveIcebergSplitBuilder& HiveIcebergSplitBuilder::deleteFiles(
-    std::vector<IcebergDeleteFile> deleteFiles) {
-  deleteFiles_ = std::move(deleteFiles);
-  return *this;
-}
-
-HiveIcebergSplitBuilder& HiveIcebergSplitBuilder::dataSequenceNumber(
-    int64_t dataSequenceNumber) {
-  dataSequenceNumber_ = dataSequenceNumber;
-  return *this;
-}
-
-std::shared_ptr<HiveIcebergSplit> HiveIcebergSplitBuilder::build() const {
+std::shared_ptr<HiveIcebergSplit> IcebergSplitBuilder::build() const {
   return std::make_shared<HiveIcebergSplit>(
       connectorId_,
       filePath_,

--- a/velox/connectors/hive/iceberg/IcebergSplit.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplit.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/connectors/hive/iceberg/IcebergSplit.h"
 
+#include <utility>
+
 #include "velox/connectors/hive/iceberg/IcebergDeleteFile.h"
 
 namespace facebook::velox::connector::hive::iceberg {
@@ -92,4 +94,76 @@ HiveIcebergSplit::HiveIcebergSplit(
           std::nullopt),
       deleteFiles(std::move(deletes)),
       dataSequenceNumber(dataSequenceNumber) {}
+
+HiveIcebergSplitBuilder::HiveIcebergSplitBuilder(std::string filePath)
+    : filePath_{std::move(filePath)} {
+  infoColumns_["$path"] = filePath_;
+}
+
+HiveIcebergSplitBuilder& HiveIcebergSplitBuilder::connectorId(
+    std::string connectorId) {
+  connectorId_ = std::move(connectorId);
+  return *this;
+}
+
+HiveIcebergSplitBuilder& HiveIcebergSplitBuilder::fileFormat(
+    dwio::common::FileFormat fileFormat) {
+  fileFormat_ = fileFormat;
+  return *this;
+}
+
+HiveIcebergSplitBuilder& HiveIcebergSplitBuilder::start(uint64_t start) {
+  start_ = start;
+  return *this;
+}
+
+HiveIcebergSplitBuilder& HiveIcebergSplitBuilder::length(uint64_t length) {
+  length_ = length;
+  return *this;
+}
+
+HiveIcebergSplitBuilder& HiveIcebergSplitBuilder::partitionKeys(
+    const std::unordered_map<std::string, std::optional<std::string>>&
+        partitionKeys) {
+  partitionKeys_ = partitionKeys;
+  return *this;
+}
+
+HiveIcebergSplitBuilder& HiveIcebergSplitBuilder::infoColumns(
+    const std::unordered_map<std::string, std::string>& infoColumns) {
+  for (const auto& [name, value] : infoColumns) {
+    infoColumns_[name] = value;
+  }
+  return *this;
+}
+
+HiveIcebergSplitBuilder& HiveIcebergSplitBuilder::deleteFiles(
+    std::vector<IcebergDeleteFile> deleteFiles) {
+  deleteFiles_ = std::move(deleteFiles);
+  return *this;
+}
+
+HiveIcebergSplitBuilder& HiveIcebergSplitBuilder::dataSequenceNumber(
+    int64_t dataSequenceNumber) {
+  dataSequenceNumber_ = dataSequenceNumber;
+  return *this;
+}
+
+std::shared_ptr<HiveIcebergSplit> HiveIcebergSplitBuilder::build() const {
+  return std::make_shared<HiveIcebergSplit>(
+      connectorId_,
+      filePath_,
+      fileFormat_,
+      start_,
+      length_,
+      partitionKeys_,
+      std::nullopt,
+      std::unordered_map<std::string, std::string>{},
+      nullptr,
+      /*cacheable=*/true,
+      deleteFiles_,
+      infoColumns_,
+      std::nullopt,
+      dataSequenceNumber_);
+}
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergSplit.h
+++ b/velox/connectors/hive/iceberg/IcebergSplit.h
@@ -15,7 +15,11 @@
  */
 #pragma once
 
+#include <memory>
+#include <optional>
 #include <string>
+#include <unordered_map>
+#include <vector>
 
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/connectors/hive/iceberg/IcebergDeleteFile.h"
@@ -65,6 +69,45 @@ struct HiveIcebergSplit : public connector::hive::HiveConnectorSplit {
       const std::unordered_map<std::string, std::string>& infoColumns = {},
       std::optional<FileProperties> fileProperties = std::nullopt,
       int64_t dataSequenceNumber = 0);
+};
+
+/// Builds HiveIcebergSplit instances with named parameters.
+class HiveIcebergSplitBuilder {
+ public:
+  explicit HiveIcebergSplitBuilder(std::string filePath);
+
+  HiveIcebergSplitBuilder& connectorId(std::string connectorId);
+
+  HiveIcebergSplitBuilder& fileFormat(dwio::common::FileFormat fileFormat);
+
+  HiveIcebergSplitBuilder& start(uint64_t start);
+
+  HiveIcebergSplitBuilder& length(uint64_t length);
+
+  HiveIcebergSplitBuilder& partitionKeys(
+      const std::unordered_map<std::string, std::optional<std::string>>&
+          partitionKeys);
+
+  HiveIcebergSplitBuilder& infoColumns(
+      const std::unordered_map<std::string, std::string>& infoColumns);
+
+  HiveIcebergSplitBuilder& deleteFiles(
+      std::vector<IcebergDeleteFile> deleteFiles);
+
+  HiveIcebergSplitBuilder& dataSequenceNumber(int64_t dataSequenceNumber);
+
+  std::shared_ptr<HiveIcebergSplit> build() const;
+
+ private:
+  const std::string filePath_;
+  std::string connectorId_;
+  dwio::common::FileFormat fileFormat_{dwio::common::FileFormat::DWRF};
+  uint64_t start_{0};
+  uint64_t length_{std::numeric_limits<uint64_t>::max()};
+  std::unordered_map<std::string, std::optional<std::string>> partitionKeys_;
+  std::unordered_map<std::string, std::string> infoColumns_;
+  std::vector<IcebergDeleteFile> deleteFiles_;
+  int64_t dataSequenceNumber_{0};
 };
 
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergSplit.h
+++ b/velox/connectors/hive/iceberg/IcebergSplit.h
@@ -19,6 +19,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "velox/connectors/hive/HiveConnectorSplit.h"
@@ -71,30 +72,57 @@ struct HiveIcebergSplit : public connector::hive::HiveConnectorSplit {
       int64_t dataSequenceNumber = 0);
 };
 
-/// Builds HiveIcebergSplit instances with named parameters.
-class HiveIcebergSplitBuilder {
+/// Builds Iceberg splits with named parameters.
+class IcebergSplitBuilder {
  public:
-  explicit HiveIcebergSplitBuilder(std::string filePath);
+  explicit IcebergSplitBuilder(std::string filePath)
+      : filePath_{std::move(filePath)} {
+    infoColumns_["$path"] = filePath_;
+  }
 
-  HiveIcebergSplitBuilder& connectorId(std::string connectorId);
+  IcebergSplitBuilder& connectorId(std::string id) {
+    connectorId_ = std::move(id);
+    return *this;
+  }
 
-  HiveIcebergSplitBuilder& fileFormat(dwio::common::FileFormat fileFormat);
+  IcebergSplitBuilder& fileFormat(dwio::common::FileFormat format) {
+    fileFormat_ = format;
+    return *this;
+  }
 
-  HiveIcebergSplitBuilder& start(uint64_t start);
+  IcebergSplitBuilder& start(uint64_t start) {
+    start_ = start;
+    return *this;
+  }
 
-  HiveIcebergSplitBuilder& length(uint64_t length);
+  IcebergSplitBuilder& length(uint64_t length) {
+    length_ = length;
+    return *this;
+  }
 
-  HiveIcebergSplitBuilder& partitionKeys(
-      const std::unordered_map<std::string, std::optional<std::string>>&
-          partitionKeys);
+  IcebergSplitBuilder& partitionKeys(
+      const std::unordered_map<std::string, std::optional<std::string>>& keys) {
+    partitionKeys_ = keys;
+    return *this;
+  }
 
-  HiveIcebergSplitBuilder& infoColumns(
-      const std::unordered_map<std::string, std::string>& infoColumns);
+  IcebergSplitBuilder& infoColumns(
+      const std::unordered_map<std::string, std::string>& columns) {
+    for (const auto& [name, value] : columns) {
+      infoColumns_[name] = value;
+    }
+    return *this;
+  }
 
-  HiveIcebergSplitBuilder& deleteFiles(
-      std::vector<IcebergDeleteFile> deleteFiles);
+  IcebergSplitBuilder& deleteFiles(std::vector<IcebergDeleteFile> files) {
+    deleteFiles_ = std::move(files);
+    return *this;
+  }
 
-  HiveIcebergSplitBuilder& dataSequenceNumber(int64_t dataSequenceNumber);
+  IcebergSplitBuilder& dataSequenceNumber(int64_t sequenceNumber) {
+    dataSequenceNumber_ = sequenceNumber;
+    return *this;
+  }
 
   std::shared_ptr<HiveIcebergSplit> build() const;
 

--- a/velox/connectors/hive/iceberg/tests/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/tests/CMakeLists.txt
@@ -39,7 +39,13 @@ if(VELOX_ENABLE_BENCHMARKS)
 endif()
 
 if(NOT VELOX_DISABLE_GOOGLETEST)
-  add_executable(velox_hive_iceberg_test IcebergReadTest.cpp IcebergSplitReaderBenchmarkTest.cpp)
+  add_executable(
+    velox_hive_iceberg_test
+    IcebergPositionalDeleteTest.cpp
+    IcebergReadTest.cpp
+    IcebergSplitReaderBenchmarkTest.cpp
+    IcebergTestBase.cpp
+  )
   add_test(velox_hive_iceberg_test velox_hive_iceberg_test)
 
   target_link_libraries(
@@ -140,7 +146,11 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
   endif()
 
   if(VELOX_ENABLE_PARQUET)
-    target_link_libraries(velox_hive_iceberg_test velox_dwio_parquet_reader)
+    target_link_libraries(
+      velox_hive_iceberg_test
+      velox_dwio_parquet_reader
+      velox_dwio_parquet_writer
+    )
 
     file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/examples DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 

--- a/velox/connectors/hive/iceberg/tests/EqualityDeleteFileReaderTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/EqualityDeleteFileReaderTest.cpp
@@ -133,8 +133,7 @@ class EqualityDeleteFileReaderTest : public HiveConnectorTestBase {
       const RowTypePtr& outputType,
       const RowTypePtr& dataColumns) {
     return PlanBuilder()
-        .startTableScan()
-        .connectorId(kIcebergConnectorId)
+        .startTableScan(kIcebergConnectorId)
         .outputType(outputType)
         .dataColumns(dataColumns)
         .endTableScan()
@@ -604,8 +603,7 @@ TEST_F(EqualityDeleteFileReaderTest, equalityFilterOnlyColumnNotInProjection) {
   // delete then removes id=4 and id=8, leaving values {d->skipped} no, we
   // expect surviving values for ids {3,5,6,7,9}, projected as 'value' only.
   auto plan = PlanBuilder()
-                  .startTableScan()
-                  .connectorId(kIcebergConnectorId)
+                  .startTableScan(kIcebergConnectorId)
                   .outputType(outputType)
                   .dataColumns(tableType)
                   .subfieldFilter("id >= 3")

--- a/velox/connectors/hive/iceberg/tests/IcebergDwrfInsertTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergDwrfInsertTest.cpp
@@ -53,8 +53,7 @@ class IcebergDwrfInsertTest : public test::IcebergTestBase {
     auto splits = createSplitsForDirectory(dataPath);
     ASSERT_EQ(splits.size(), commitTasks.size());
     auto plan = exec::test::PlanBuilder()
-                    .startTableScan()
-                    .connectorId(test::kIcebergConnectorId)
+                    .startTableScan(test::kIcebergConnectorId)
                     .outputType(rowType)
                     .endTableScan()
                     .planNode();
@@ -233,8 +232,7 @@ TEST_F(IcebergDwrfInsertTest, partitioned) {
   auto splits = createSplitsForDirectory(dataPath);
   ASSERT_EQ(splits.size(), commitTasks.size());
   auto plan = exec::test::PlanBuilder()
-                  .startTableScan()
-                  .connectorId(test::kIcebergConnectorId)
+                  .startTableScan(test::kIcebergConnectorId)
                   .outputType(rowType)
                   .endTableScan()
                   .planNode();

--- a/velox/connectors/hive/iceberg/tests/IcebergInsertTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergInsertTest.cpp
@@ -42,8 +42,7 @@ class IcebergInsertTest : public test::IcebergTestBase {
     auto splits = createSplitsForDirectory(dataPath);
     ASSERT_EQ(splits.size(), commitTasks.size());
     auto plan = exec::test::PlanBuilder()
-                    .startTableScan()
-                    .connectorId(test::kIcebergConnectorId)
+                    .startTableScan(test::kIcebergConnectorId)
                     .outputType(rowType)
                     .endTableScan()
                     .planNode();
@@ -119,8 +118,7 @@ TEST_F(IcebergInsertTest, singleColumnPartition) {
     }
 
     auto plan = exec::test::PlanBuilder()
-                    .startTableScan()
-                    .connectorId(test::kIcebergConnectorId)
+                    .startTableScan(test::kIcebergConnectorId)
                     .outputType(rowType)
                     .endTableScan()
                     .planNode();
@@ -236,8 +234,7 @@ TEST_F(IcebergInsertTest, partitionMultiColumns) {
     ASSERT_EQ(splits.size(), commitTasks.size());
 
     auto plan = exec::test::PlanBuilder()
-                    .startTableScan()
-                    .connectorId(test::kIcebergConnectorId)
+                    .startTableScan(test::kIcebergConnectorId)
                     .outputType(rowType)
                     .endTableScan()
                     .planNode();
@@ -259,8 +256,7 @@ TEST_F(IcebergInsertTest, maxTargetFileSizeRotation) {
 
   auto splits = createSplitsForDirectory(outputPath);
   auto plan = exec::test::PlanBuilder()
-                  .startTableScan()
-                  .connectorId(test::kIcebergConnectorId)
+                  .startTableScan(test::kIcebergConnectorId)
                   .outputType(rowType)
                   .endTableScan()
                   .planNode();

--- a/velox/connectors/hive/iceberg/tests/IcebergPositionalDeleteTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergPositionalDeleteTest.cpp
@@ -33,6 +33,7 @@
 #include "velox/dwio/dwrf/reader/ReaderBase.h"
 #include "velox/dwio/dwrf/writer/FlushPolicy.h"
 #include "velox/exec/PlanNodeStats.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 
 namespace facebook::velox::connector::hive::iceberg {
@@ -47,7 +48,7 @@ class IcebergPositionalDeleteTest : public test::IcebergTestBase {
       std::string,
       std::multimap<std::string, std::vector<int64_t>>>;
 
-  static constexpr int32_t rowCount = 20000;
+  static constexpr int32_t kRowCount = 20000;
 
   void SetUp() override {
     test::IcebergTestBase::SetUp();
@@ -100,7 +101,7 @@ class IcebergPositionalDeleteTest : public test::IcebergTestBase {
       const std::vector<int64_t>& deletePositions,
       int32_t fileCount,
       int32_t numPrefetchSplits,
-      int rowCountPerFile = rowCount,
+      int rowCountPerFile = kRowCount,
       int32_t splitCountPerFile = 1) {
     RowGroupSizesForFiles rowGroupSizesForFiles;
     DeleteFilesForBaseDataFiles deleteFilesForBaseDatafiles;
@@ -196,8 +197,7 @@ class IcebergPositionalDeleteTest : public test::IcebergTestBase {
     }
 
     auto plan = exec::test::PlanBuilder()
-                    .startTableScan()
-                    .connectorId(test::kIcebergConnectorId)
+                    .startTableScan(test::kIcebergConnectorId)
                     .outputType(ROW({"c0"}, {BIGINT()}))
                     .endTableScan()
                     .planNode();
@@ -304,12 +304,16 @@ class IcebergPositionalDeleteTest : public test::IcebergTestBase {
     auto deleteFile = makePositionalDeleteFile(
         dataFilePath->getPath(), {1, 3}, deleteFilePath, deleteSequenceNumber);
 
+    auto plan = exec::test::PlanBuilder()
+                    .startTableScan(test::kIcebergConnectorId)
+                    .outputType(ROW({"c0"}, {BIGINT()}))
+                    .endTableScan()
+                    .planNode();
     auto expected = makeRowVector({makeFlatVector<int64_t>(expectedValues)});
-    assertTableScan(
-        ROW({"c0"}, {BIGINT()}),
-        {makeIcebergSplitWithInfoColumns(
-            dataFilePath->getPath(), {}, {deleteFile}, dataSequenceNumber)},
-        {expected});
+    exec::test::AssertQueryBuilder(plan)
+        .splits({makeIcebergSplitWithInfoColumns(
+            dataFilePath->getPath(), {}, {deleteFile}, dataSequenceNumber)})
+        .assertResults({expected});
   }
 
  private:
@@ -527,10 +531,10 @@ TEST_F(
   assertMultipleBaseFileSingleDeleteFile({10000, 10002, 19999});
   assertMultipleBaseFileSingleDeleteFile({10000, 10002, 19999});
   assertMultipleBaseFileSingleDeleteFile(
-      makeRandomIncreasingValues(0, rowCount));
+      makeRandomIncreasingValues(0, kRowCount));
   assertMultipleBaseFileSingleDeleteFile({});
   assertMultipleBaseFileSingleDeleteFile(
-      makeContinuousIncreasingValues(0, rowCount));
+      makeContinuousIncreasingValues(0, kRowCount));
 }
 
 /// This test creates one base data file/split with multiple delete files. The
@@ -707,7 +711,7 @@ TEST_F(IcebergPositionalDeleteTest, skipDeleteFileByPositionUpperBound) {
   reader->loadCache();
   ASSERT_GE(reader->footer().stripesSize(), 2);
   const uint64_t splitStart = reader->footer().stripes(1).offset();
-  auto split = std::make_shared<HiveIcebergSplit>(
+  std::shared_ptr<ConnectorSplit> split = std::make_shared<HiveIcebergSplit>(
       test::kIcebergConnectorId,
       dataFilePath->getPath(),
       fileFormat_,
@@ -723,7 +727,13 @@ TEST_F(IcebergPositionalDeleteTest, skipDeleteFileByPositionUpperBound) {
   // The second half of the file should be returned with no rows deleted.
   auto expected = makeRowVector(
       {makeFlatVector<int64_t>(makeContinuousIncreasingValues(50, 100))});
-  assertTableScan(ROW({"c0"}, {BIGINT()}), {split}, {expected});
+  auto plan = exec::test::PlanBuilder()
+                  .startTableScan(test::kIcebergConnectorId)
+                  .outputType(ROW({"c0"}, {BIGINT()}))
+                  .endTableScan()
+                  .planNode();
+  exec::test::AssertQueryBuilder(plan).splits({split}).assertResults(
+      {expected});
 }
 #ifdef VELOX_ENABLE_PARQUET
 TEST_F(IcebergPositionalDeleteTest, positionalDeleteFileWithRowGroupFilter) {
@@ -739,8 +749,7 @@ TEST_F(IcebergPositionalDeleteTest, positionalDeleteFileWithRowGroupFilter) {
 
   assertQuery(
       exec::test::PlanBuilder()
-          .startTableScan()
-          .connectorId(test::kIcebergConnectorId)
+          .startTableScan(test::kIcebergConnectorId)
           .outputType(ROW({"id"}, {BIGINT()}))
           .remainingFilter("id >= 100")
           .endTableScan()

--- a/velox/connectors/hive/iceberg/tests/IcebergPositionalDeleteTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergPositionalDeleteTest.cpp
@@ -1,0 +1,789 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/tests/IcebergTestBase.h"
+
+#include <algorithm>
+#include <map>
+#include <numeric>
+#include <random>
+
+#include <folly/Random.h>
+#include <folly/Singleton.h>
+#include <folly/lang/Bits.h>
+
+#include "velox/common/encode/Base64.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/connectors/hive/iceberg/IcebergMetadataColumns.h"
+#include "velox/connectors/hive/iceberg/IcebergSplit.h"
+#include "velox/dwio/common/tests/utils/DataFiles.h"
+#include "velox/dwio/dwrf/reader/ReaderBase.h"
+#include "velox/dwio/dwrf/writer/FlushPolicy.h"
+#include "velox/exec/PlanNodeStats.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+namespace {
+
+using TempFilePath = common::testutil::TempFilePath;
+
+class IcebergPositionalDeleteTest : public test::IcebergTestBase {
+ protected:
+  using RowGroupSizesForFiles = std::map<std::string, std::vector<int64_t>>;
+  using DeleteFilesForBaseDataFiles = std::unordered_map<
+      std::string,
+      std::multimap<std::string, std::vector<int64_t>>>;
+
+  static constexpr int32_t rowCount = 20000;
+
+  void SetUp() override {
+    test::IcebergTestBase::SetUp();
+    folly::SingletonVault::singleton()->registrationComplete();
+    fileFormat_ = dwio::common::FileFormat::DWRF;
+  }
+
+  std::shared_ptr<TempFilePath> writeBigintDataFile(
+      const std::vector<int64_t>& values) {
+    auto dataFilePath = TempFilePath::create();
+    writeToFile(
+        dataFilePath->getPath(),
+        {makeRowVector({makeFlatVector<int64_t>(values)})});
+    return dataFilePath;
+  }
+
+  void assertSingleBaseFileSingleDeleteFile(
+      const std::vector<int64_t>& deletePositionsVec) {
+    assertPositionalDeletes(
+        {{"data_file_1", {10000, 10000}}},
+        {{"delete_file_1", {{"data_file_1", deletePositionsVec}}}},
+        0);
+  }
+
+  void assertMultipleBaseFileSingleDeleteFile(
+      const std::vector<int64_t>& deletePositionsVec) {
+    assertPositionalDeletes(
+        {
+            {"data_file_0", {500}},
+            {"data_file_1", {10000, 10000}},
+            {"data_file_2", {500}},
+        },
+        {{"delete_file_1", {{"data_file_1", deletePositionsVec}}}},
+        0);
+  }
+
+  void assertSingleBaseFileMultipleDeleteFiles(
+      const std::vector<std::vector<int64_t>>& deletePositionsVecs) {
+    DeleteFilesForBaseDataFiles deleteFilesForBaseDatafiles;
+    for (int32_t i = 0; i < deletePositionsVecs.size(); ++i) {
+      deleteFilesForBaseDatafiles[fmt::format("delete_file_{}", i)] = {
+          {"data_file_1", deletePositionsVecs[i]}};
+    }
+
+    assertPositionalDeletes(
+        {{"data_file_1", {10000, 10000}}}, deleteFilesForBaseDatafiles, 0);
+  }
+
+  void assertMultipleSplits(
+      const std::vector<int64_t>& deletePositions,
+      int32_t fileCount,
+      int32_t numPrefetchSplits,
+      int rowCountPerFile = rowCount,
+      int32_t splitCountPerFile = 1) {
+    RowGroupSizesForFiles rowGroupSizesForFiles;
+    DeleteFilesForBaseDataFiles deleteFilesForBaseDatafiles;
+    for (int32_t i = 0; i < fileCount; ++i) {
+      const auto dataFileName = fmt::format("data_file_{}", i);
+      rowGroupSizesForFiles[dataFileName] = {rowCountPerFile};
+      deleteFilesForBaseDatafiles[fmt::format("delete_file_{}", i)] = {
+          {dataFileName, deletePositions}};
+    }
+
+    assertPositionalDeletes(
+        rowGroupSizesForFiles,
+        deleteFilesForBaseDatafiles,
+        numPrefetchSplits,
+        splitCountPerFile);
+  }
+
+  std::vector<int64_t> makeRandomIncreasingValues(int64_t begin, int64_t end) {
+    VELOX_CHECK(begin < end);
+
+    std::mt19937 gen{0};
+    std::vector<int64_t> values;
+    values.reserve(end - begin);
+    for (int64_t i = begin; i < end; ++i) {
+      if (folly::Random::rand32(0, 10, gen) > 8) {
+        values.push_back(i);
+      }
+    }
+    return values;
+  }
+
+  static std::vector<int64_t> makeContinuousIncreasingValues(
+      int64_t begin,
+      int64_t end) {
+    std::vector<int64_t> values(end - begin);
+    std::iota(values.begin(), values.end(), begin);
+    return values;
+  }
+
+  /// @rowGroupSizesForFiles The key is the file name, and the value is a vector
+  /// of RowGroup sizes
+  /// @deleteFilesForBaseDatafiles The key is the delete file name, and the
+  /// value contains the information about the content of this delete file.
+  /// e.g. {
+  ///         "delete_file_1",
+  ///         {
+  ///             {"data_file_1", {1, 2, 3}},
+  ///             {"data_file_1", {4, 5, 6}},
+  ///             {"data_file_2", {0, 2, 4}}
+  ///         }
+  ///     }
+  /// represents one delete file called delete_file_1, which contains delete
+  /// positions for data_file_1 and data_file_2. THere are 3 RowGroups in this
+  /// delete file, the first two contain positions for data_file_1, and the last
+  /// contain positions for data_file_2
+  void assertPositionalDeletes(
+      const RowGroupSizesForFiles& rowGroupSizesForFiles,
+      const DeleteFilesForBaseDataFiles& deleteFilesForBaseDatafiles,
+      int32_t numPrefetchSplits = 0,
+      int32_t splitCount = 1) {
+    auto dataFilePaths = writeDataFiles(rowGroupSizesForFiles);
+    auto deleteFilePaths =
+        writePositionDeleteFiles(deleteFilesForBaseDatafiles, dataFilePaths);
+
+    std::vector<std::shared_ptr<ConnectorSplit>> splits;
+
+    for (const auto& dataFile : dataFilePaths) {
+      const auto& baseFileName = dataFile.first;
+      const auto& baseFilePath = dataFile.second->getPath();
+      std::vector<IcebergDeleteFile> deleteFiles;
+
+      for (const auto& deleteFile : deleteFilesForBaseDatafiles) {
+        const auto& deleteFileName = deleteFile.first;
+        const auto& deleteFileContent = deleteFile.second;
+
+        if (!deleteFileContent.contains(baseFileName)) {
+          continue;
+        }
+
+        const auto deleteFilePath =
+            deleteFilePaths[deleteFileName].second->getPath();
+        deleteFiles.emplace_back(
+            FileContent::kPositionalDeletes,
+            deleteFilePath,
+            fileFormat_,
+            deleteFilePaths[deleteFileName].first,
+            getFileSize(deleteFilePath));
+      }
+
+      auto icebergSplits =
+          makeIcebergSplits(baseFilePath, deleteFiles, {}, splitCount);
+      splits.insert(splits.end(), icebergSplits.begin(), icebergSplits.end());
+    }
+
+    auto plan = exec::test::PlanBuilder()
+                    .startTableScan()
+                    .connectorId(test::kIcebergConnectorId)
+                    .outputType(ROW({"c0"}, {BIGINT()}))
+                    .endTableScan()
+                    .planNode();
+    auto task = assertQuery(
+        plan,
+        splits,
+        getDuckDBQuery(rowGroupSizesForFiles, deleteFilesForBaseDatafiles),
+        numPrefetchSplits);
+
+    const auto planStats = exec::toPlanStats(task->taskStats());
+    const auto it = planStats.find(plan->id());
+    ASSERT_TRUE(it != planStats.end());
+    ASSERT_TRUE(it->second.peakMemoryBytes > 0);
+  }
+
+  IcebergDeleteFile makePositionalDeleteFile(
+      const std::string& baseFilePath,
+      const std::vector<int64_t>& deletePositions,
+      const std::shared_ptr<TempFilePath>& deleteFilePath,
+      int64_t dataSequenceNumber = 0,
+      bool includePositionUpperBound = false) {
+    writeToFile(
+        deleteFilePath->getPath(),
+        {makeRowVector(
+            {pathColumn_->name, posColumn_->name},
+            {
+                makeFlatVector<std::string>(
+                    static_cast<vector_size_t>(deletePositions.size()),
+                    [&](vector_size_t) { return baseFilePath; }),
+                makeFlatVector<int64_t>(deletePositions),
+            })});
+
+    std::unordered_map<int32_t, std::string> upperBounds;
+    if (includePositionUpperBound && !deletePositions.empty()) {
+      const uint64_t upperBound = static_cast<uint64_t>(
+          *std::max_element(deletePositions.begin(), deletePositions.end()));
+      const auto upperBoundLE = folly::Endian::little(upperBound);
+      upperBounds[posColumn_->id] = encoding::Base64::encode(
+          std::string_view(
+              reinterpret_cast<const char*>(&upperBoundLE),
+              sizeof(upperBoundLE)));
+    }
+
+    return IcebergDeleteFile(
+        FileContent::kPositionalDeletes,
+        deleteFilePath->getPath(),
+        fileFormat_,
+        static_cast<int64_t>(deletePositions.size()),
+        getFileSize(deleteFilePath->getPath()),
+        {},
+        {},
+        upperBounds,
+        dataSequenceNumber);
+  }
+
+#ifdef VELOX_ENABLE_PARQUET
+  std::vector<std::shared_ptr<ConnectorSplit>> createParquetDeleteFileAndSplits(
+      const std::string& path,
+      const std::vector<int64_t>& deletePositionsVec,
+      int32_t deletedPositionSize,
+      const std::shared_ptr<TempFilePath>& deleteFilePath) {
+    writeToFile(
+        deleteFilePath->getPath(),
+        {makeRowVector(
+            {pathColumn_->name, posColumn_->name},
+            {
+                makeFlatVector<std::string>(
+                    static_cast<vector_size_t>(deletedPositionSize),
+                    [&](vector_size_t) { return path; }),
+                makeFlatVector<int64_t>(deletePositionsVec),
+            })});
+
+    IcebergDeleteFile icebergDeleteFile(
+        FileContent::kPositionalDeletes,
+        deleteFilePath->getPath(),
+        fileFormat_,
+        deletedPositionSize,
+        getFileSize(deleteFilePath->getPath()));
+    auto file =
+        filesystems::getFileSystem(path, nullptr)->openFileForRead(path);
+
+    return {std::make_shared<HiveIcebergSplit>(
+        test::kIcebergConnectorId,
+        path,
+        dwio::common::FileFormat::PARQUET,
+        0,
+        file->size(),
+        std::unordered_map<std::string, std::optional<std::string>>{},
+        std::nullopt,
+        std::unordered_map<std::string, std::string>{},
+        nullptr,
+        /*cacheable=*/true,
+        std::vector<IcebergDeleteFile>{icebergDeleteFile})};
+  }
+#endif
+
+  void assertDeleteSequenceScenario(
+      int64_t dataSequenceNumber,
+      int64_t deleteSequenceNumber,
+      const std::vector<int64_t>& expectedValues) {
+    auto dataFilePath = writeBigintDataFile({0, 1, 2, 3, 4});
+    auto deleteFilePath = TempFilePath::create();
+
+    auto deleteFile = makePositionalDeleteFile(
+        dataFilePath->getPath(), {1, 3}, deleteFilePath, deleteSequenceNumber);
+
+    auto expected = makeRowVector({makeFlatVector<int64_t>(expectedValues)});
+    assertTableScan(
+        ROW({"c0"}, {BIGINT()}),
+        {makeIcebergSplitWithInfoColumns(
+            dataFilePath->getPath(), {}, {deleteFile}, dataSequenceNumber)},
+        {expected});
+  }
+
+ private:
+  std::map<std::string, std::shared_ptr<TempFilePath>> writeDataFiles(
+      const RowGroupSizesForFiles& rowGroupSizesForFiles) {
+    std::map<std::string, std::shared_ptr<TempFilePath>> dataFilePaths;
+
+    std::vector<RowVectorPtr> dataVectorsJoined;
+    dataVectorsJoined.reserve(rowGroupSizesForFiles.size());
+
+    int64_t startingValue = 0;
+    for (auto& dataFile : rowGroupSizesForFiles) {
+      dataFilePaths[dataFile.first] = TempFilePath::create();
+      // We make the values continuously increasing even across base data files.
+      // This makes constructing DuckDB queries easier.
+      auto dataVectors = makeVectors(dataFile.second, startingValue);
+      writeToFile(dataFilePaths[dataFile.first]->getPath(), dataVectors);
+      dataVectorsJoined.insert(
+          dataVectorsJoined.end(), dataVectors.begin(), dataVectors.end());
+    }
+
+    createDuckDbTable(dataVectorsJoined);
+    return dataFilePaths;
+  }
+
+  std::unordered_map<
+      std::string,
+      std::pair<int64_t, std::shared_ptr<TempFilePath>>>
+  writePositionDeleteFiles(
+      const DeleteFilesForBaseDataFiles& deleteFilesForBaseDatafiles,
+      std::map<std::string, std::shared_ptr<TempFilePath>> baseFilePaths) {
+    std::unordered_map<
+        std::string,
+        std::pair<int64_t, std::shared_ptr<TempFilePath>>>
+        deleteFilePaths;
+    deleteFilePaths.reserve(deleteFilesForBaseDatafiles.size());
+
+    for (const auto& deleteFile : deleteFilesForBaseDatafiles) {
+      const auto& deleteFileName = deleteFile.first;
+      const auto& deleteFileContent = deleteFile.second;
+      auto deleteFilePath = TempFilePath::create();
+
+      std::vector<RowVectorPtr> deleteFileVectors;
+      int64_t totalPositionsInDeleteFile = 0;
+
+      for (const auto& deleteFileRowGroup : deleteFileContent) {
+        const auto& baseFileName = deleteFileRowGroup.first;
+        const auto& positionsInRowGroup = deleteFileRowGroup.second;
+        const auto& baseFilePath = baseFilePaths[baseFileName]->getPath();
+
+        deleteFileVectors.push_back(makeRowVector(
+            {pathColumn_->name, posColumn_->name},
+            {
+                makeFlatVector<std::string>(
+                    static_cast<vector_size_t>(positionsInRowGroup.size()),
+                    [&](vector_size_t) { return baseFilePath; }),
+                makeFlatVector<int64_t>(positionsInRowGroup),
+            }));
+        totalPositionsInDeleteFile +=
+            static_cast<int64_t>(positionsInRowGroup.size());
+      }
+
+      writeToFile(deleteFilePath->getPath(), deleteFileVectors);
+      deleteFilePaths[deleteFileName] =
+          std::make_pair(totalPositionsInDeleteFile, deleteFilePath);
+    }
+
+    return deleteFilePaths;
+  }
+
+  std::vector<RowVectorPtr> makeVectors(
+      const std::vector<int64_t>& vectorSizes,
+      int64_t& startingValue) {
+    std::vector<RowVectorPtr> vectors;
+    vectors.reserve(vectorSizes.size());
+
+    for (auto vectorSize : vectorSizes) {
+      auto data = makeContinuousIncreasingValues(
+          startingValue, startingValue + vectorSize);
+      vectors.push_back(makeRowVector({makeFlatVector<int64_t>(data)}));
+      startingValue += vectorSize;
+    }
+
+    return vectors;
+  }
+
+  std::string getDuckDBQuery(
+      const RowGroupSizesForFiles& rowGroupSizesForFiles,
+      const DeleteFilesForBaseDataFiles& deleteFilesForBaseDatafiles) {
+    int64_t totalNumRowsInAllBaseFiles = 0;
+    std::map<std::string, int64_t> baseFileSizes;
+    for (const auto& rowGroupSizesInFile : rowGroupSizesForFiles) {
+      // Sum up the row counts in all RowGroups in each base file.
+      baseFileSizes[rowGroupSizesInFile.first] += std::accumulate(
+          rowGroupSizesInFile.second.begin(),
+          rowGroupSizesInFile.second.end(),
+          0LL);
+      totalNumRowsInAllBaseFiles += baseFileSizes[rowGroupSizesInFile.first];
+    }
+
+    std::map<std::string, std::vector<std::vector<int64_t>>>
+        deletePosVectorsForAllBaseFiles;
+    for (const auto& deleteFile : deleteFilesForBaseDatafiles) {
+      // Group the delete vectors by baseFileName.
+      for (const auto& rowGroup : deleteFile.second) {
+        deletePosVectorsForAllBaseFiles[rowGroup.first].push_back(
+            rowGroup.second);
+      }
+    }
+
+    std::map<std::string, std::vector<int64_t>>
+        flattenedDeletePosVectorsForAllBaseFiles;
+    int64_t totalNumDeletePositions = 0;
+    for (const auto& deleteVectorsForBaseFile :
+         deletePosVectorsForAllBaseFiles) {
+      // Flatten and deduplicate the delete position vectors in
+      // deletePosVectorsForAllBaseFiles from previous step, and count the total
+      // number of distinct delete positions for all base files.
+      auto deletePositionVector = flattenAndDedup(
+          deleteVectorsForBaseFile.second,
+          baseFileSizes[deleteVectorsForBaseFile.first]);
+      flattenedDeletePosVectorsForAllBaseFiles[deleteVectorsForBaseFile.first] =
+          deletePositionVector;
+      totalNumDeletePositions +=
+          static_cast<int64_t>(deletePositionVector.size());
+    }
+
+    if (totalNumDeletePositions == 0) {
+      return "SELECT * FROM tmp";
+    }
+
+    if (totalNumDeletePositions >= totalNumRowsInAllBaseFiles) {
+      return "SELECT * FROM tmp WHERE 1 = 0";
+    }
+
+    std::vector<int64_t> allDeleteValues;
+    int64_t numRowsInPreviousBaseFiles = 0;
+    // Now build the DuckDB query by converting delete positions in all base
+    // files into c0 values.
+    for (const auto& baseFileSize : baseFileSizes) {
+      auto deletePositions =
+          flattenedDeletePosVectorsForAllBaseFiles[baseFileSize.first];
+
+      if (numRowsInPreviousBaseFiles > 0) {
+        for (int64_t& deleteValue : deletePositions) {
+          deleteValue += numRowsInPreviousBaseFiles;
+        }
+      }
+
+      allDeleteValues.insert(
+          allDeleteValues.end(),
+          deletePositions.begin(),
+          deletePositions.end());
+      numRowsInPreviousBaseFiles += baseFileSize.second;
+    }
+
+    return fmt::format(
+        "SELECT * FROM tmp WHERE c0 NOT IN ({})",
+        folly::join(", ", allDeleteValues));
+  }
+
+  std::vector<int64_t> flattenAndDedup(
+      const std::vector<std::vector<int64_t>>& deletePositionVectors,
+      int64_t baseFileSize) {
+    std::vector<int64_t> deletePositionVector;
+    for (const auto& vec : deletePositionVectors) {
+      for (auto pos : vec) {
+        if (pos >= 0 && pos < baseFileSize) {
+          deletePositionVector.push_back(pos);
+        }
+      }
+    }
+
+    std::sort(deletePositionVector.begin(), deletePositionVector.end());
+    deletePositionVector.erase(
+        std::unique(deletePositionVector.begin(), deletePositionVector.end()),
+        deletePositionVector.end());
+    return deletePositionVector;
+  }
+
+  std::shared_ptr<IcebergMetadataColumn> pathColumn_ =
+      IcebergMetadataColumn::icebergDeleteFilePathColumn();
+  std::shared_ptr<IcebergMetadataColumn> posColumn_ =
+      IcebergMetadataColumn::icebergDeletePosColumn();
+};
+
+/// This test creates one single data file and one delete file. The parameter
+/// passed to assertSingleBaseFileSingleDeleteFile is the delete positions.
+TEST_F(IcebergPositionalDeleteTest, singleBaseFileSinglePositionalDeleteFile) {
+  // Delete the first and last row in each batch (10000 rows per batch).
+  assertSingleBaseFileSingleDeleteFile({{0, 1, 2, 3}});
+  assertSingleBaseFileSingleDeleteFile({{0, 9999, 10000, 19999}});
+  // Delete several rows in the second batch (10000 rows per batch).
+  assertSingleBaseFileSingleDeleteFile({{10000, 10002, 19999}});
+  // Delete random rows.
+  assertSingleBaseFileSingleDeleteFile({makeRandomIncreasingValues(0, 20000)});
+  // Delete 0 rows.
+  assertSingleBaseFileSingleDeleteFile({});
+  // Delete all rows.
+  assertSingleBaseFileSingleDeleteFile(
+      makeContinuousIncreasingValues(0, 20000));
+  // Delete rows that don't exist.
+  assertSingleBaseFileSingleDeleteFile({{20000, 29999}});
+}
+
+/// This test creates 3 base data files, only the middle one has corresponding
+/// delete positions. The parameter passed to
+/// assertSingleBaseFileSingleDeleteFile is the delete positions for the middle
+/// base file.
+TEST_F(
+    IcebergPositionalDeleteTest,
+    multipleBaseFilesSinglePositionalDeleteFile) {
+  assertMultipleBaseFileSingleDeleteFile({0, 1, 2, 3});
+  assertMultipleBaseFileSingleDeleteFile({0, 9999, 10000, 19999});
+  assertMultipleBaseFileSingleDeleteFile({10000, 10002, 19999});
+  assertMultipleBaseFileSingleDeleteFile({10000, 10002, 19999});
+  assertMultipleBaseFileSingleDeleteFile(
+      makeRandomIncreasingValues(0, rowCount));
+  assertMultipleBaseFileSingleDeleteFile({});
+  assertMultipleBaseFileSingleDeleteFile(
+      makeContinuousIncreasingValues(0, rowCount));
+}
+
+/// This test creates one base data file/split with multiple delete files. The
+/// parameter passed to assertSingleBaseFileMultipleDeleteFiles is the vector of
+/// delete files. Each leaf vector represents the delete positions in that
+/// delete file.
+TEST_F(
+    IcebergPositionalDeleteTest,
+    singleBaseFileMultiplePositionalDeleteFiles) {
+  // Delete row 0, 1, 2, 3 from the first batch out of two.
+  assertSingleBaseFileMultipleDeleteFiles({{1}, {2}, {3}, {4}});
+  // Delete the first and last row in each batch (10000 rows per batch).
+  assertSingleBaseFileMultipleDeleteFiles({{0}, {9999}, {10000}, {19999}});
+  assertSingleBaseFileMultipleDeleteFiles({{500, 21000}});
+  assertSingleBaseFileMultipleDeleteFiles(
+      {makeRandomIncreasingValues(0, 10000),
+       makeRandomIncreasingValues(10000, 20000),
+       makeRandomIncreasingValues(5000, 15000)});
+  assertSingleBaseFileMultipleDeleteFiles(
+      {makeContinuousIncreasingValues(0, 10000),
+       makeContinuousIncreasingValues(10000, 20000)});
+  assertSingleBaseFileMultipleDeleteFiles(
+      {makeContinuousIncreasingValues(0, 10000),
+       makeContinuousIncreasingValues(10000, 20000),
+       makeRandomIncreasingValues(5000, 15000)});
+  assertSingleBaseFileMultipleDeleteFiles(
+      {makeContinuousIncreasingValues(0, 20000),
+       makeContinuousIncreasingValues(0, 20000)});
+  assertSingleBaseFileMultipleDeleteFiles(
+      {makeRandomIncreasingValues(0, 20000),
+       {},
+       makeRandomIncreasingValues(5000, 15000)});
+  assertSingleBaseFileMultipleDeleteFiles({{}, {}});
+}
+
+/// This test creates 2 base data files, and 1 or 2 delete files, with
+/// unaligned RowGroup boundaries.
+TEST_F(
+    IcebergPositionalDeleteTest,
+    multipleBaseFileMultiplePositionalDeleteFiles) {
+  // Create two data files, each with two RowGroups.
+  RowGroupSizesForFiles rowGroupSizesForFiles = {
+      {"data_file_1", {100, 85}},
+      {"data_file_2", {99, 1}},
+  };
+  DeleteFilesForBaseDataFiles deleteFilesForBaseDatafiles;
+
+  // Delete 3 rows from the first RowGroup in data_file_1.
+  deleteFilesForBaseDatafiles["delete_file_1"] = {{"data_file_1", {0, 1, 99}}};
+  assertPositionalDeletes(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
+
+  // Delete 3 rows from the second RowGroup in data_file_1.
+  deleteFilesForBaseDatafiles["delete_file_1"] = {
+      {"data_file_1", {100, 101, 184}}};
+  assertPositionalDeletes(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
+
+  // Delete random rows from both RowGroups in data_file_1.
+  deleteFilesForBaseDatafiles["delete_file_1"] = {
+      {"data_file_1", makeRandomIncreasingValues(0, 185)}};
+  assertPositionalDeletes(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
+
+  // Delete all rows in data_file_1.
+  deleteFilesForBaseDatafiles["delete_file_1"] = {
+      {"data_file_1", makeContinuousIncreasingValues(0, 185)}};
+  assertPositionalDeletes(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
+
+  // Delete non-existent rows from data_file_1.
+  deleteFilesForBaseDatafiles["delete_file_1"] = {
+      {"data_file_1", makeRandomIncreasingValues(186, 300)}};
+  assertPositionalDeletes(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
+
+  deleteFilesForBaseDatafiles.clear();
+  // Delete several rows from both RowGroups in both data files.
+  deleteFilesForBaseDatafiles["delete_file_1"] = {
+      {"data_file_1", {0, 100, 102, 184}}, {"data_file_2", {1, 98, 99}}};
+  assertPositionalDeletes(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
+
+  deleteFilesForBaseDatafiles.clear();
+  // The delete file delete_file_1 contains 3 RowGroups itself, with the first
+  // rows deleting some repeating rows in data_file_1, and the last rows
+  // deleting some repeating rows in data_file_2.
+  deleteFilesForBaseDatafiles["delete_file_1"] = {
+      {"data_file_1", {0, 1, 2, 3}},
+      {"data_file_1", {1, 2, 3, 4}},
+      {"data_file_1", makeRandomIncreasingValues(0, 185)},
+      {"data_file_2", {1, 3, 5, 7}},
+      {"data_file_2", makeRandomIncreasingValues(0, 100)}};
+  assertPositionalDeletes(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
+
+  deleteFilesForBaseDatafiles.clear();
+  // delete_file_2 contains non-overlapping delete rows for each data file in
+  // each RowGroup.
+  deleteFilesForBaseDatafiles["delete_file_1"] = {
+      {"data_file_1", {0, 1, 2, 3}}, {"data_file_2", {1, 3, 5, 7}}};
+  deleteFilesForBaseDatafiles["delete_file_2"] = {
+      {"data_file_1", {1, 2, 3, 4}},
+      {"data_file_1", {98, 99, 100, 101, 184}},
+      {"data_file_2", {3, 5, 7, 9}},
+      {"data_file_2", {98, 99, 100}}};
+  assertPositionalDeletes(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
+
+  deleteFilesForBaseDatafiles.clear();
+  // Two delete files each containing overlapping delete rows for both data
+  // files.
+  deleteFilesForBaseDatafiles["delete_file_1"] = {
+      {"data_file_1", makeRandomIncreasingValues(0, 185)},
+      {"data_file_2", makeRandomIncreasingValues(0, 100)}};
+  deleteFilesForBaseDatafiles["delete_file_2"] = {
+      {"data_file_1", makeRandomIncreasingValues(10, 120)},
+      {"data_file_2", makeRandomIncreasingValues(50, 100)}};
+  assertPositionalDeletes(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
+}
+
+TEST_F(IcebergPositionalDeleteTest, positionalDeletesMultipleSplits) {
+  assertMultipleSplits({1, 2, 3, 4}, 10, 5);
+  assertMultipleSplits({1, 2, 3, 4}, 10, 0);
+  assertMultipleSplits({1, 2, 3, 4}, 10, 10);
+  assertMultipleSplits({0, 9999, 10000, 19999}, 10, 3);
+  assertMultipleSplits(makeRandomIncreasingValues(0, 20000), 10, 3);
+  assertMultipleSplits(makeContinuousIncreasingValues(0, 20000), 10, 3);
+  assertMultipleSplits({}, 10, 3);
+  assertMultipleSplits({1, 2, 3, 4}, 10, 5, 30000, 3);
+
+  assertPositionalDeletes(
+      {
+          {"data_file_0", {500}},
+          {"data_file_1", {10000, 10000}},
+          {"data_file_2", {500}},
+      },
+      {{"delete_file_1",
+        {{"data_file_1", makeRandomIncreasingValues(0, 20000)}}}},
+      0,
+      3);
+
+  assertMultipleSplits({1000, 9000, 20000}, 1, 0, 20000, 3);
+}
+
+// Test that positional delete files are skipped when their position upper bound
+// is before the split offset. When a delete file's upperBound is less than the
+// split's starting row, all deletes in that file are not relevant to this
+// split.
+TEST_F(IcebergPositionalDeleteTest, skipDeleteFileByPositionUpperBound) {
+  // Create a data file with 100 rows (2 stripes of 50 rows each).
+  auto dataFilePath = TempFilePath::create();
+  writeToFile(
+      dataFilePath->getPath(),
+      {
+          makeRowVector(
+              {makeFlatVector<int64_t>(makeContinuousIncreasingValues(0, 50))}),
+          makeRowVector({makeFlatVector<int64_t>(
+              makeContinuousIncreasingValues(50, 100))}),
+      },
+      std::make_shared<dwrf::Config>(),
+      []() {
+        return std::make_unique<dwrf::LambdaFlushPolicy>([]() { return true; });
+      });
+
+  // Create a delete file targeting positions 0, 1, 2.
+  auto deleteFilePath = TempFilePath::create();
+  auto deleteFile = makePositionalDeleteFile(
+      dataFilePath->getPath(), {0, 1, 2}, deleteFilePath, 0, true);
+
+  // Create a split that starts at the middle of the file. The split offset
+  // will be greater than the delete file's upper bound (2), so the delete
+  // file should be skipped completely.
+  auto filePtr = filesystems::getFileSystem(dataFilePath->getPath(), nullptr)
+                     ->openFileForRead(dataFilePath->getPath());
+  const uint64_t fileSize = filePtr->size();
+  std::shared_ptr<ReadFile> file = std::move(filePtr);
+  dwio::common::ReaderOptions readerOptions{pool()};
+  auto input = std::make_unique<dwio::common::BufferedInput>(file, *pool());
+  auto reader =
+      std::make_unique<dwrf::ReaderBase>(readerOptions, std::move(input));
+  reader->loadCache();
+  ASSERT_GE(reader->footer().stripesSize(), 2);
+  const uint64_t splitStart = reader->footer().stripes(1).offset();
+  auto split = std::make_shared<HiveIcebergSplit>(
+      test::kIcebergConnectorId,
+      dataFilePath->getPath(),
+      fileFormat_,
+      splitStart,
+      fileSize - splitStart,
+      std::unordered_map<std::string, std::optional<std::string>>{},
+      std::nullopt,
+      std::unordered_map<std::string, std::string>{},
+      nullptr,
+      /*cacheable=*/true,
+      std::vector<IcebergDeleteFile>{deleteFile});
+
+  // The second half of the file should be returned with no rows deleted.
+  auto expected = makeRowVector(
+      {makeFlatVector<int64_t>(makeContinuousIncreasingValues(50, 100))});
+  assertTableScan(ROW({"c0"}, {BIGINT()}), {split}, {expected});
+}
+#ifdef VELOX_ENABLE_PARQUET
+TEST_F(IcebergPositionalDeleteTest, positionalDeleteFileWithRowGroupFilter) {
+  // This file contains three row groups. The remaining filter prunes the
+  // middle row group, which verifies that position deletes still align with
+  // the correct file offsets.
+  auto path = facebook::velox::test::getDataFilePath(
+      "velox/connectors/hive/iceberg/tests", "examples/three_groups.parquet");
+  const int32_t deletedPositionSize = 100;
+  std::vector<int64_t> deletePositionsVec(deletedPositionSize);
+  std::iota(deletePositionsVec.begin(), deletePositionsVec.end(), 100);
+  auto deleteFilePath = TempFilePath::create();
+
+  assertQuery(
+      exec::test::PlanBuilder()
+          .startTableScan()
+          .connectorId(test::kIcebergConnectorId)
+          .outputType(ROW({"id"}, {BIGINT()}))
+          .remainingFilter("id >= 100")
+          .endTableScan()
+          .planNode(),
+      createParquetDeleteFileAndSplits(
+          path, deletePositionsVec, deletedPositionSize, deleteFilePath),
+      "SELECT i AS id FROM range(100, 300) AS t(i)",
+      0);
+}
+#endif
+
+TEST_F(IcebergPositionalDeleteTest, positionalDeleteSequenceNumberApplied) {
+  // Sequence number filtering tests for positional deletes (Diff 2).
+  // Per the Iceberg V2+ spec, a positional delete file should only apply to
+  // data files whose dataSequenceNumber is strictly less than the delete
+  // file's.
+  assertDeleteSequenceScenario(
+      /*dataSequenceNumber=*/5, /*deleteSequenceNumber=*/10, {0, 2, 4});
+}
+
+TEST_F(IcebergPositionalDeleteTest, positionalDeleteSequenceNumberSkipped) {
+  assertDeleteSequenceScenario(
+      /*dataSequenceNumber=*/10, /*deleteSequenceNumber=*/5, {0, 1, 2, 3, 4});
+}
+
+// Verifies that same-snapshot positional deletes apply (deleteSeqNum ==
+// dataSeqNum). Per the Iceberg spec, positional deletes in the same snapshot
+// SHOULD apply, so the skip condition uses strict < (not <=).
+TEST_F(
+    IcebergPositionalDeleteTest,
+    positionalDeleteSequenceNumberEqualApplied) {
+  // Same-snapshot delete applied: positions 1 and 3 deleted → [0, 2, 4].
+  assertDeleteSequenceScenario(
+      /*dataSequenceNumber=*/5, /*deleteSequenceNumber=*/5, {0, 2, 4});
+}
+
+TEST_F(
+    IcebergPositionalDeleteTest,
+    positionalDeleteSequenceNumberZeroDisablesFilter) {
+  // SeqNum=0 disables filtering → delete applied: [0, 2, 4].
+  assertDeleteSequenceScenario(
+      /*dataSequenceNumber=*/100, /*deleteSequenceNumber=*/0, {0, 2, 4});
+}
+
+} // namespace
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/tests/IcebergPositionalDeleteTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergPositionalDeleteTest.cpp
@@ -17,11 +17,8 @@
 #include "velox/connectors/hive/iceberg/tests/IcebergTestBase.h"
 
 #include <algorithm>
-#include <map>
 #include <numeric>
-#include <random>
 
-#include <folly/Random.h>
 #include <folly/Singleton.h>
 #include <folly/lang/Bits.h>
 
@@ -32,7 +29,6 @@
 #include "velox/dwio/common/tests/utils/DataFiles.h"
 #include "velox/dwio/dwrf/reader/ReaderBase.h"
 #include "velox/dwio/dwrf/writer/FlushPolicy.h"
-#include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 
@@ -43,10 +39,20 @@ using TempFilePath = common::testutil::TempFilePath;
 
 class IcebergPositionalDeleteTest : public test::IcebergTestBase {
  protected:
-  using RowGroupSizesForFiles = std::map<std::string, std::vector<int64_t>>;
-  using DeleteFilesForBaseDataFiles = std::unordered_map<
-      std::string,
-      std::multimap<std::string, std::vector<int64_t>>>;
+  struct DataFileSpec {
+    std::string name;
+    std::vector<int64_t> rowGroupSizes;
+  };
+
+  struct DeleteRowGroup {
+    std::string dataFileName;
+    std::vector<int64_t> positions;
+  };
+
+  struct DeleteFileSpec {
+    std::string name;
+    std::vector<DeleteRowGroup> rowGroups;
+  };
 
   static constexpr int32_t kRowCount = 20000;
 
@@ -66,133 +72,121 @@ class IcebergPositionalDeleteTest : public test::IcebergTestBase {
   }
 
   void assertSingleBaseFileSingleDeleteFile(
-      const std::vector<int64_t>& deletePositionsVec) {
+      const std::vector<int64_t>& deletePositions,
+      const std::vector<int64_t>& expectedValues) {
     assertPositionalDeletes(
         {{"data_file_1", {10000, 10000}}},
-        {{"delete_file_1", {{"data_file_1", deletePositionsVec}}}},
-        0);
+        {{"delete_file_1", {{"data_file_1", deletePositions}}}},
+        expectedValues);
   }
 
   void assertMultipleBaseFileSingleDeleteFile(
-      const std::vector<int64_t>& deletePositionsVec) {
+      const std::vector<int64_t>& deletePositions,
+      const std::vector<int64_t>& expectedValues) {
     assertPositionalDeletes(
         {
-            {"data_file_0", {500}},
-            {"data_file_1", {10000, 10000}},
-            {"data_file_2", {500}},
+            {"data_file_0", {5}},
+            {"data_file_1", {10}},
+            {"data_file_2", {5}},
         },
-        {{"delete_file_1", {{"data_file_1", deletePositionsVec}}}},
-        0);
+        {{"delete_file_1", {{"data_file_1", deletePositions}}}},
+        expectedValues);
   }
 
   void assertSingleBaseFileMultipleDeleteFiles(
-      const std::vector<std::vector<int64_t>>& deletePositionsVecs) {
-    DeleteFilesForBaseDataFiles deleteFilesForBaseDatafiles;
-    for (int32_t i = 0; i < deletePositionsVecs.size(); ++i) {
-      deleteFilesForBaseDatafiles[fmt::format("delete_file_{}", i)] = {
-          {"data_file_1", deletePositionsVecs[i]}};
+      const std::vector<std::vector<int64_t>>& deletePositionLists,
+      const std::vector<int64_t>& expectedValues) {
+    std::vector<DeleteFileSpec> deleteFiles;
+    for (int32_t i = 0; i < deletePositionLists.size(); ++i) {
+      deleteFiles.push_back(
+          {fmt::format("delete_file_{}", i),
+           {{"data_file_1", deletePositionLists[i]}}});
     }
 
     assertPositionalDeletes(
-        {{"data_file_1", {10000, 10000}}}, deleteFilesForBaseDatafiles, 0);
+        {{"data_file_1", {20}}}, deleteFiles, expectedValues);
   }
 
   void assertMultipleSplits(
       const std::vector<int64_t>& deletePositions,
       int32_t fileCount,
       int32_t numPrefetchSplits,
+      const std::vector<int64_t>& expectedValues,
       int rowCountPerFile = kRowCount,
       int32_t splitCountPerFile = 1) {
-    RowGroupSizesForFiles rowGroupSizesForFiles;
-    DeleteFilesForBaseDataFiles deleteFilesForBaseDatafiles;
+    std::vector<DataFileSpec> dataFiles;
+    std::vector<DeleteFileSpec> deleteFiles;
     for (int32_t i = 0; i < fileCount; ++i) {
       const auto dataFileName = fmt::format("data_file_{}", i);
-      rowGroupSizesForFiles[dataFileName] = {rowCountPerFile};
-      deleteFilesForBaseDatafiles[fmt::format("delete_file_{}", i)] = {
-          {dataFileName, deletePositions}};
+      dataFiles.push_back({dataFileName, {rowCountPerFile}});
+      deleteFiles.push_back(
+          {fmt::format("delete_file_{}", i),
+           {{dataFileName, deletePositions}}});
     }
 
     assertPositionalDeletes(
-        rowGroupSizesForFiles,
-        deleteFilesForBaseDatafiles,
+        dataFiles,
+        deleteFiles,
+        expectedValues,
         numPrefetchSplits,
         splitCountPerFile);
   }
 
-  std::vector<int64_t> makeRandomIncreasingValues(int64_t begin, int64_t end) {
-    VELOX_CHECK(begin < end);
-
-    std::mt19937 gen{0};
-    std::vector<int64_t> values;
-    values.reserve(end - begin);
-    for (int64_t i = begin; i < end; ++i) {
-      if (folly::Random::rand32(0, 10, gen) > 8) {
-        values.push_back(i);
-      }
-    }
-    return values;
-  }
-
-  static std::vector<int64_t> makeContinuousIncreasingValues(
-      int64_t begin,
-      int64_t end) {
+  static std::vector<int64_t> sequence(int64_t begin, int64_t end) {
     std::vector<int64_t> values(end - begin);
     std::iota(values.begin(), values.end(), begin);
     return values;
   }
 
-  /// @rowGroupSizesForFiles The key is the file name, and the value is a vector
-  /// of RowGroup sizes
-  /// @deleteFilesForBaseDatafiles The key is the delete file name, and the
-  /// value contains the information about the content of this delete file.
-  /// e.g. {
-  ///         "delete_file_1",
-  ///         {
-  ///             {"data_file_1", {1, 2, 3}},
-  ///             {"data_file_1", {4, 5, 6}},
-  ///             {"data_file_2", {0, 2, 4}}
-  ///         }
-  ///     }
-  /// represents one delete file called delete_file_1, which contains delete
-  /// positions for data_file_1 and data_file_2. THere are 3 RowGroups in this
-  /// delete file, the first two contain positions for data_file_1, and the last
-  /// contain positions for data_file_2
+  static std::vector<int64_t> concat(
+      std::initializer_list<std::vector<int64_t>> ranges) {
+    std::vector<int64_t> values;
+    for (const auto& range : ranges) {
+      values.insert(values.end(), range.begin(), range.end());
+    }
+    return values;
+  }
+
+  // Writes the requested data files and delete files, then verifies the table
+  // scan output against explicit expected values.
   void assertPositionalDeletes(
-      const RowGroupSizesForFiles& rowGroupSizesForFiles,
-      const DeleteFilesForBaseDataFiles& deleteFilesForBaseDatafiles,
+      const std::vector<DataFileSpec>& dataFiles,
+      const std::vector<DeleteFileSpec>& deleteFiles,
+      const std::vector<int64_t>& expectedValues,
       int32_t numPrefetchSplits = 0,
       int32_t splitCount = 1) {
-    auto dataFilePaths = writeDataFiles(rowGroupSizesForFiles);
-    auto deleteFilePaths =
-        writePositionDeleteFiles(deleteFilesForBaseDatafiles, dataFilePaths);
+    auto dataFilePaths = writeDataFiles(dataFiles);
+    auto deleteFilePaths = writePositionDeleteFiles(deleteFiles, dataFilePaths);
 
     std::vector<std::shared_ptr<ConnectorSplit>> splits;
 
-    for (const auto& dataFile : dataFilePaths) {
-      const auto& baseFileName = dataFile.first;
-      const auto& baseFilePath = dataFile.second->getPath();
-      std::vector<IcebergDeleteFile> deleteFiles;
+    for (const auto& dataFile : dataFiles) {
+      const auto& baseFilePath = dataFilePaths.at(dataFile.name)->getPath();
+      std::vector<IcebergDeleteFile> matchingDeleteFiles;
 
-      for (const auto& deleteFile : deleteFilesForBaseDatafiles) {
-        const auto& deleteFileName = deleteFile.first;
-        const auto& deleteFileContent = deleteFile.second;
-
-        if (!deleteFileContent.contains(baseFileName)) {
+      for (const auto& deleteFile : deleteFiles) {
+        const auto hasDeletesForDataFile = std::any_of(
+            deleteFile.rowGroups.begin(),
+            deleteFile.rowGroups.end(),
+            [&](const auto& rowGroup) {
+              return rowGroup.dataFileName == dataFile.name;
+            });
+        if (!hasDeletesForDataFile) {
           continue;
         }
 
         const auto deleteFilePath =
-            deleteFilePaths[deleteFileName].second->getPath();
-        deleteFiles.emplace_back(
+            deleteFilePaths.at(deleteFile.name).second->getPath();
+        matchingDeleteFiles.emplace_back(
             FileContent::kPositionalDeletes,
             deleteFilePath,
             fileFormat_,
-            deleteFilePaths[deleteFileName].first,
+            deleteFilePaths.at(deleteFile.name).first,
             getFileSize(deleteFilePath));
       }
 
       auto icebergSplits =
-          makeIcebergSplits(baseFilePath, deleteFiles, {}, splitCount);
+          makeIcebergSplits(baseFilePath, matchingDeleteFiles, {}, splitCount);
       splits.insert(splits.end(), icebergSplits.begin(), icebergSplits.end());
     }
 
@@ -201,16 +195,11 @@ class IcebergPositionalDeleteTest : public test::IcebergTestBase {
                     .outputType(ROW({"c0"}, {BIGINT()}))
                     .endTableScan()
                     .planNode();
-    auto task = assertQuery(
-        plan,
-        splits,
-        getDuckDBQuery(rowGroupSizesForFiles, deleteFilesForBaseDatafiles),
-        numPrefetchSplits);
-
-    const auto planStats = exec::toPlanStats(task->taskStats());
-    const auto it = planStats.find(plan->id());
-    ASSERT_TRUE(it != planStats.end());
-    ASSERT_TRUE(it->second.peakMemoryBytes > 0);
+    exec::test::AssertQueryBuilder(plan)
+        .config(core::QueryConfig::kMaxSplitPreloadPerDriver, numPrefetchSplits)
+        .splits(splits)
+        .assertResults(
+            makeRowVector({makeFlatVector<int64_t>(expectedValues)}));
   }
 
   IcebergDeleteFile makePositionalDeleteFile(
@@ -256,7 +245,7 @@ class IcebergPositionalDeleteTest : public test::IcebergTestBase {
 #ifdef VELOX_ENABLE_PARQUET
   std::vector<std::shared_ptr<ConnectorSplit>> createParquetDeleteFileAndSplits(
       const std::string& path,
-      const std::vector<int64_t>& deletePositionsVec,
+      const std::vector<int64_t>& deletePositions,
       int32_t deletedPositionSize,
       const std::shared_ptr<TempFilePath>& deleteFilePath) {
     writeToFile(
@@ -267,7 +256,7 @@ class IcebergPositionalDeleteTest : public test::IcebergTestBase {
                 makeFlatVector<std::string>(
                     static_cast<vector_size_t>(deletedPositionSize),
                     [&](vector_size_t) { return path; }),
-                makeFlatVector<int64_t>(deletePositionsVec),
+                makeFlatVector<int64_t>(deletePositions),
             })});
 
     IcebergDeleteFile icebergDeleteFile(
@@ -279,18 +268,12 @@ class IcebergPositionalDeleteTest : public test::IcebergTestBase {
     auto file =
         filesystems::getFileSystem(path, nullptr)->openFileForRead(path);
 
-    return {std::make_shared<HiveIcebergSplit>(
-        test::kIcebergConnectorId,
-        path,
-        dwio::common::FileFormat::PARQUET,
-        0,
-        file->size(),
-        std::unordered_map<std::string, std::optional<std::string>>{},
-        std::nullopt,
-        std::unordered_map<std::string, std::string>{},
-        nullptr,
-        /*cacheable=*/true,
-        std::vector<IcebergDeleteFile>{icebergDeleteFile})};
+    return {IcebergSplitBuilder(path)
+                .connectorId(test::kIcebergConnectorId)
+                .fileFormat(dwio::common::FileFormat::PARQUET)
+                .length(file->size())
+                .deleteFiles({icebergDeleteFile})
+                .build()};
   }
 #endif
 
@@ -317,25 +300,18 @@ class IcebergPositionalDeleteTest : public test::IcebergTestBase {
   }
 
  private:
-  std::map<std::string, std::shared_ptr<TempFilePath>> writeDataFiles(
-      const RowGroupSizesForFiles& rowGroupSizesForFiles) {
-    std::map<std::string, std::shared_ptr<TempFilePath>> dataFilePaths;
-
-    std::vector<RowVectorPtr> dataVectorsJoined;
-    dataVectorsJoined.reserve(rowGroupSizesForFiles.size());
-
+  std::unordered_map<std::string, std::shared_ptr<TempFilePath>> writeDataFiles(
+      const std::vector<DataFileSpec>& dataFiles) {
+    std::unordered_map<std::string, std::shared_ptr<TempFilePath>>
+        dataFilePaths;
     int64_t startingValue = 0;
-    for (auto& dataFile : rowGroupSizesForFiles) {
-      dataFilePaths[dataFile.first] = TempFilePath::create();
-      // We make the values continuously increasing even across base data files.
-      // This makes constructing DuckDB queries easier.
-      auto dataVectors = makeVectors(dataFile.second, startingValue);
-      writeToFile(dataFilePaths[dataFile.first]->getPath(), dataVectors);
-      dataVectorsJoined.insert(
-          dataVectorsJoined.end(), dataVectors.begin(), dataVectors.end());
+
+    for (const auto& dataFile : dataFiles) {
+      dataFilePaths[dataFile.name] = TempFilePath::create();
+      auto dataVectors = makeVectors(dataFile.rowGroupSizes, startingValue);
+      writeToFile(dataFilePaths[dataFile.name]->getPath(), dataVectors);
     }
 
-    createDuckDbTable(dataVectorsJoined);
     return dataFilePaths;
   }
 
@@ -343,41 +319,40 @@ class IcebergPositionalDeleteTest : public test::IcebergTestBase {
       std::string,
       std::pair<int64_t, std::shared_ptr<TempFilePath>>>
   writePositionDeleteFiles(
-      const DeleteFilesForBaseDataFiles& deleteFilesForBaseDatafiles,
-      std::map<std::string, std::shared_ptr<TempFilePath>> baseFilePaths) {
+      const std::vector<DeleteFileSpec>& deleteFiles,
+      const std::unordered_map<std::string, std::shared_ptr<TempFilePath>>&
+          baseFilePaths) {
     std::unordered_map<
         std::string,
         std::pair<int64_t, std::shared_ptr<TempFilePath>>>
         deleteFilePaths;
-    deleteFilePaths.reserve(deleteFilesForBaseDatafiles.size());
+    deleteFilePaths.reserve(deleteFiles.size());
 
-    for (const auto& deleteFile : deleteFilesForBaseDatafiles) {
-      const auto& deleteFileName = deleteFile.first;
-      const auto& deleteFileContent = deleteFile.second;
+    for (const auto& deleteFile : deleteFiles) {
       auto deleteFilePath = TempFilePath::create();
 
       std::vector<RowVectorPtr> deleteFileVectors;
       int64_t totalPositionsInDeleteFile = 0;
 
-      for (const auto& deleteFileRowGroup : deleteFileContent) {
-        const auto& baseFileName = deleteFileRowGroup.first;
-        const auto& positionsInRowGroup = deleteFileRowGroup.second;
-        const auto& baseFilePath = baseFilePaths[baseFileName]->getPath();
+      for (const auto& deleteFileRowGroup : deleteFile.rowGroups) {
+        const auto& baseFilePath =
+            baseFilePaths.at(deleteFileRowGroup.dataFileName)->getPath();
 
         deleteFileVectors.push_back(makeRowVector(
             {pathColumn_->name, posColumn_->name},
             {
                 makeFlatVector<std::string>(
-                    static_cast<vector_size_t>(positionsInRowGroup.size()),
+                    static_cast<vector_size_t>(
+                        deleteFileRowGroup.positions.size()),
                     [&](vector_size_t) { return baseFilePath; }),
-                makeFlatVector<int64_t>(positionsInRowGroup),
+                makeFlatVector<int64_t>(deleteFileRowGroup.positions),
             }));
         totalPositionsInDeleteFile +=
-            static_cast<int64_t>(positionsInRowGroup.size());
+            static_cast<int64_t>(deleteFileRowGroup.positions.size());
       }
 
       writeToFile(deleteFilePath->getPath(), deleteFileVectors);
-      deleteFilePaths[deleteFileName] =
+      deleteFilePaths[deleteFile.name] =
           std::make_pair(totalPositionsInDeleteFile, deleteFilePath);
     }
 
@@ -391,107 +366,12 @@ class IcebergPositionalDeleteTest : public test::IcebergTestBase {
     vectors.reserve(vectorSizes.size());
 
     for (auto vectorSize : vectorSizes) {
-      auto data = makeContinuousIncreasingValues(
-          startingValue, startingValue + vectorSize);
+      auto data = sequence(startingValue, startingValue + vectorSize);
       vectors.push_back(makeRowVector({makeFlatVector<int64_t>(data)}));
       startingValue += vectorSize;
     }
 
     return vectors;
-  }
-
-  std::string getDuckDBQuery(
-      const RowGroupSizesForFiles& rowGroupSizesForFiles,
-      const DeleteFilesForBaseDataFiles& deleteFilesForBaseDatafiles) {
-    int64_t totalNumRowsInAllBaseFiles = 0;
-    std::map<std::string, int64_t> baseFileSizes;
-    for (const auto& rowGroupSizesInFile : rowGroupSizesForFiles) {
-      // Sum up the row counts in all RowGroups in each base file.
-      baseFileSizes[rowGroupSizesInFile.first] += std::accumulate(
-          rowGroupSizesInFile.second.begin(),
-          rowGroupSizesInFile.second.end(),
-          0LL);
-      totalNumRowsInAllBaseFiles += baseFileSizes[rowGroupSizesInFile.first];
-    }
-
-    std::map<std::string, std::vector<std::vector<int64_t>>>
-        deletePosVectorsForAllBaseFiles;
-    for (const auto& deleteFile : deleteFilesForBaseDatafiles) {
-      // Group the delete vectors by baseFileName.
-      for (const auto& rowGroup : deleteFile.second) {
-        deletePosVectorsForAllBaseFiles[rowGroup.first].push_back(
-            rowGroup.second);
-      }
-    }
-
-    std::map<std::string, std::vector<int64_t>>
-        flattenedDeletePosVectorsForAllBaseFiles;
-    int64_t totalNumDeletePositions = 0;
-    for (const auto& deleteVectorsForBaseFile :
-         deletePosVectorsForAllBaseFiles) {
-      // Flatten and deduplicate the delete position vectors in
-      // deletePosVectorsForAllBaseFiles from previous step, and count the total
-      // number of distinct delete positions for all base files.
-      auto deletePositionVector = flattenAndDedup(
-          deleteVectorsForBaseFile.second,
-          baseFileSizes[deleteVectorsForBaseFile.first]);
-      flattenedDeletePosVectorsForAllBaseFiles[deleteVectorsForBaseFile.first] =
-          deletePositionVector;
-      totalNumDeletePositions +=
-          static_cast<int64_t>(deletePositionVector.size());
-    }
-
-    if (totalNumDeletePositions == 0) {
-      return "SELECT * FROM tmp";
-    }
-
-    if (totalNumDeletePositions >= totalNumRowsInAllBaseFiles) {
-      return "SELECT * FROM tmp WHERE 1 = 0";
-    }
-
-    std::vector<int64_t> allDeleteValues;
-    int64_t numRowsInPreviousBaseFiles = 0;
-    // Now build the DuckDB query by converting delete positions in all base
-    // files into c0 values.
-    for (const auto& baseFileSize : baseFileSizes) {
-      auto deletePositions =
-          flattenedDeletePosVectorsForAllBaseFiles[baseFileSize.first];
-
-      if (numRowsInPreviousBaseFiles > 0) {
-        for (int64_t& deleteValue : deletePositions) {
-          deleteValue += numRowsInPreviousBaseFiles;
-        }
-      }
-
-      allDeleteValues.insert(
-          allDeleteValues.end(),
-          deletePositions.begin(),
-          deletePositions.end());
-      numRowsInPreviousBaseFiles += baseFileSize.second;
-    }
-
-    return fmt::format(
-        "SELECT * FROM tmp WHERE c0 NOT IN ({})",
-        folly::join(", ", allDeleteValues));
-  }
-
-  std::vector<int64_t> flattenAndDedup(
-      const std::vector<std::vector<int64_t>>& deletePositionVectors,
-      int64_t baseFileSize) {
-    std::vector<int64_t> deletePositionVector;
-    for (const auto& vec : deletePositionVectors) {
-      for (auto pos : vec) {
-        if (pos >= 0 && pos < baseFileSize) {
-          deletePositionVector.push_back(pos);
-        }
-      }
-    }
-
-    std::sort(deletePositionVector.begin(), deletePositionVector.end());
-    deletePositionVector.erase(
-        std::unique(deletePositionVector.begin(), deletePositionVector.end()),
-        deletePositionVector.end());
-    return deletePositionVector;
   }
 
   std::shared_ptr<IcebergMetadataColumn> pathColumn_ =
@@ -500,176 +380,105 @@ class IcebergPositionalDeleteTest : public test::IcebergTestBase {
       IcebergMetadataColumn::icebergDeletePosColumn();
 };
 
-/// This test creates one single data file and one delete file. The parameter
-/// passed to assertSingleBaseFileSingleDeleteFile is the delete positions.
+// Verifies one data file with one positional delete file.
 TEST_F(IcebergPositionalDeleteTest, singleBaseFileSinglePositionalDeleteFile) {
-  // Delete the first and last row in each batch (10000 rows per batch).
-  assertSingleBaseFileSingleDeleteFile({{0, 1, 2, 3}});
-  assertSingleBaseFileSingleDeleteFile({{0, 9999, 10000, 19999}});
-  // Delete several rows in the second batch (10000 rows per batch).
-  assertSingleBaseFileSingleDeleteFile({{10000, 10002, 19999}});
-  // Delete random rows.
-  assertSingleBaseFileSingleDeleteFile({makeRandomIncreasingValues(0, 20000)});
-  // Delete 0 rows.
-  assertSingleBaseFileSingleDeleteFile({});
-  // Delete all rows.
+  assertSingleBaseFileSingleDeleteFile({0, 1, 2, 3}, sequence(4, kRowCount));
   assertSingleBaseFileSingleDeleteFile(
-      makeContinuousIncreasingValues(0, 20000));
-  // Delete rows that don't exist.
-  assertSingleBaseFileSingleDeleteFile({{20000, 29999}});
+      {0, 9999, 10000, 19999},
+      concat({sequence(1, 9999), sequence(10001, 19999)}));
+  assertSingleBaseFileSingleDeleteFile(
+      {10000, 10002, 19999},
+      concat({sequence(0, 10000), {10001}, sequence(10003, 19999)}));
+  assertSingleBaseFileSingleDeleteFile({}, sequence(0, kRowCount));
+  assertSingleBaseFileSingleDeleteFile(sequence(0, kRowCount), {});
+  assertSingleBaseFileSingleDeleteFile({20000, 29999}, sequence(0, kRowCount));
 }
 
-/// This test creates 3 base data files, only the middle one has corresponding
-/// delete positions. The parameter passed to
-/// assertSingleBaseFileSingleDeleteFile is the delete positions for the middle
-/// base file.
+// Verifies that deletes for one base file do not affect neighboring files.
 TEST_F(
     IcebergPositionalDeleteTest,
     multipleBaseFilesSinglePositionalDeleteFile) {
-  assertMultipleBaseFileSingleDeleteFile({0, 1, 2, 3});
-  assertMultipleBaseFileSingleDeleteFile({0, 9999, 10000, 19999});
-  assertMultipleBaseFileSingleDeleteFile({10000, 10002, 19999});
-  assertMultipleBaseFileSingleDeleteFile({10000, 10002, 19999});
   assertMultipleBaseFileSingleDeleteFile(
-      makeRandomIncreasingValues(0, kRowCount));
-  assertMultipleBaseFileSingleDeleteFile({});
+      {0, 3, 9}, {0, 1, 2, 3, 4, 6, 7, 9, 10, 11, 12, 13, 15, 16, 17, 18, 19});
+  assertMultipleBaseFileSingleDeleteFile({}, sequence(0, 20));
   assertMultipleBaseFileSingleDeleteFile(
-      makeContinuousIncreasingValues(0, kRowCount));
+      sequence(0, 10), concat({sequence(0, 5), sequence(15, 20)}));
 }
 
-/// This test creates one base data file/split with multiple delete files. The
-/// parameter passed to assertSingleBaseFileMultipleDeleteFiles is the vector of
-/// delete files. Each leaf vector represents the delete positions in that
-/// delete file.
+// Verifies one base data file with multiple positional delete files.
 TEST_F(
     IcebergPositionalDeleteTest,
     singleBaseFileMultiplePositionalDeleteFiles) {
-  // Delete row 0, 1, 2, 3 from the first batch out of two.
-  assertSingleBaseFileMultipleDeleteFiles({{1}, {2}, {3}, {4}});
-  // Delete the first and last row in each batch (10000 rows per batch).
-  assertSingleBaseFileMultipleDeleteFiles({{0}, {9999}, {10000}, {19999}});
-  assertSingleBaseFileMultipleDeleteFiles({{500, 21000}});
   assertSingleBaseFileMultipleDeleteFiles(
-      {makeRandomIncreasingValues(0, 10000),
-       makeRandomIncreasingValues(10000, 20000),
-       makeRandomIncreasingValues(5000, 15000)});
+      {{1}, {2}, {3}, {4}}, concat({{0}, sequence(5, 20)}));
   assertSingleBaseFileMultipleDeleteFiles(
-      {makeContinuousIncreasingValues(0, 10000),
-       makeContinuousIncreasingValues(10000, 20000)});
+      {{0, 1, 2}, {2, 3, 4}, {25}}, sequence(5, 20));
+  assertSingleBaseFileMultipleDeleteFiles({{}, {}}, sequence(0, 20));
   assertSingleBaseFileMultipleDeleteFiles(
-      {makeContinuousIncreasingValues(0, 10000),
-       makeContinuousIncreasingValues(10000, 20000),
-       makeRandomIncreasingValues(5000, 15000)});
-  assertSingleBaseFileMultipleDeleteFiles(
-      {makeContinuousIncreasingValues(0, 20000),
-       makeContinuousIncreasingValues(0, 20000)});
-  assertSingleBaseFileMultipleDeleteFiles(
-      {makeRandomIncreasingValues(0, 20000),
-       {},
-       makeRandomIncreasingValues(5000, 15000)});
-  assertSingleBaseFileMultipleDeleteFiles({{}, {}});
+      {sequence(0, 20), sequence(0, 20)}, {});
 }
 
-/// This test creates 2 base data files, and 1 or 2 delete files, with
-/// unaligned RowGroup boundaries.
+// Verifies multiple base files and delete files with unaligned row-group
+// boundaries.
 TEST_F(
     IcebergPositionalDeleteTest,
     multipleBaseFileMultiplePositionalDeleteFiles) {
-  // Create two data files, each with two RowGroups.
-  RowGroupSizesForFiles rowGroupSizesForFiles = {
-      {"data_file_1", {100, 85}},
-      {"data_file_2", {99, 1}},
+  std::vector<DataFileSpec> dataFiles = {
+      {"data_file_1", {3, 2}},
+      {"data_file_2", {2, 3}},
   };
-  DeleteFilesForBaseDataFiles deleteFilesForBaseDatafiles;
 
-  // Delete 3 rows from the first RowGroup in data_file_1.
-  deleteFilesForBaseDatafiles["delete_file_1"] = {{"data_file_1", {0, 1, 99}}};
-  assertPositionalDeletes(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
+  assertPositionalDeletes(
+      dataFiles,
+      {{"delete_file_1", {{"data_file_1", {0, 1}}, {"data_file_2", {2, 4}}}}},
+      {2, 3, 4, 5, 6, 8});
 
-  // Delete 3 rows from the second RowGroup in data_file_1.
-  deleteFilesForBaseDatafiles["delete_file_1"] = {
-      {"data_file_1", {100, 101, 184}}};
-  assertPositionalDeletes(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
-
-  // Delete random rows from both RowGroups in data_file_1.
-  deleteFilesForBaseDatafiles["delete_file_1"] = {
-      {"data_file_1", makeRandomIncreasingValues(0, 185)}};
-  assertPositionalDeletes(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
-
-  // Delete all rows in data_file_1.
-  deleteFilesForBaseDatafiles["delete_file_1"] = {
-      {"data_file_1", makeContinuousIncreasingValues(0, 185)}};
-  assertPositionalDeletes(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
-
-  // Delete non-existent rows from data_file_1.
-  deleteFilesForBaseDatafiles["delete_file_1"] = {
-      {"data_file_1", makeRandomIncreasingValues(186, 300)}};
-  assertPositionalDeletes(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
-
-  deleteFilesForBaseDatafiles.clear();
-  // Delete several rows from both RowGroups in both data files.
-  deleteFilesForBaseDatafiles["delete_file_1"] = {
-      {"data_file_1", {0, 100, 102, 184}}, {"data_file_2", {1, 98, 99}}};
-  assertPositionalDeletes(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
-
-  deleteFilesForBaseDatafiles.clear();
-  // The delete file delete_file_1 contains 3 RowGroups itself, with the first
-  // rows deleting some repeating rows in data_file_1, and the last rows
-  // deleting some repeating rows in data_file_2.
-  deleteFilesForBaseDatafiles["delete_file_1"] = {
-      {"data_file_1", {0, 1, 2, 3}},
-      {"data_file_1", {1, 2, 3, 4}},
-      {"data_file_1", makeRandomIncreasingValues(0, 185)},
-      {"data_file_2", {1, 3, 5, 7}},
-      {"data_file_2", makeRandomIncreasingValues(0, 100)}};
-  assertPositionalDeletes(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
-
-  deleteFilesForBaseDatafiles.clear();
-  // delete_file_2 contains non-overlapping delete rows for each data file in
-  // each RowGroup.
-  deleteFilesForBaseDatafiles["delete_file_1"] = {
-      {"data_file_1", {0, 1, 2, 3}}, {"data_file_2", {1, 3, 5, 7}}};
-  deleteFilesForBaseDatafiles["delete_file_2"] = {
-      {"data_file_1", {1, 2, 3, 4}},
-      {"data_file_1", {98, 99, 100, 101, 184}},
-      {"data_file_2", {3, 5, 7, 9}},
-      {"data_file_2", {98, 99, 100}}};
-  assertPositionalDeletes(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
-
-  deleteFilesForBaseDatafiles.clear();
-  // Two delete files each containing overlapping delete rows for both data
-  // files.
-  deleteFilesForBaseDatafiles["delete_file_1"] = {
-      {"data_file_1", makeRandomIncreasingValues(0, 185)},
-      {"data_file_2", makeRandomIncreasingValues(0, 100)}};
-  deleteFilesForBaseDatafiles["delete_file_2"] = {
-      {"data_file_1", makeRandomIncreasingValues(10, 120)},
-      {"data_file_2", makeRandomIncreasingValues(50, 100)}};
-  assertPositionalDeletes(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
+  assertPositionalDeletes(
+      dataFiles,
+      {
+          {"delete_file_1", {{"data_file_1", {0, 3}}, {"data_file_2", {1}}}},
+          {"delete_file_2",
+           {{"data_file_1", {1, 3, 4}}, {"data_file_2", {3, 4}}}},
+      },
+      {2, 5, 7});
 }
 
 TEST_F(IcebergPositionalDeleteTest, positionalDeletesMultipleSplits) {
-  assertMultipleSplits({1, 2, 3, 4}, 10, 5);
-  assertMultipleSplits({1, 2, 3, 4}, 10, 0);
-  assertMultipleSplits({1, 2, 3, 4}, 10, 10);
-  assertMultipleSplits({0, 9999, 10000, 19999}, 10, 3);
-  assertMultipleSplits(makeRandomIncreasingValues(0, 20000), 10, 3);
-  assertMultipleSplits(makeContinuousIncreasingValues(0, 20000), 10, 3);
-  assertMultipleSplits({}, 10, 3);
-  assertMultipleSplits({1, 2, 3, 4}, 10, 5, 30000, 3);
+  assertMultipleSplits(
+      {1, 2, 3, 4},
+      3,
+      5,
+      concat({{0}, sequence(5, 21), sequence(25, 41), sequence(45, 60)}),
+      20);
+  assertMultipleSplits(
+      {1, 2, 3, 4},
+      3,
+      0,
+      concat({{0}, sequence(5, 21), sequence(25, 41), sequence(45, 60)}),
+      20);
+  assertMultipleSplits(
+      {0, 19}, 2, 3, concat({sequence(1, 19), sequence(21, 39)}), 20);
+  assertMultipleSplits({}, 2, 3, sequence(0, 40), 20);
+  assertMultipleSplits(
+      {1, 2, 3, 4}, 1, 5, concat({{0}, sequence(5, 30)}), 30, 3);
 
   assertPositionalDeletes(
       {
-          {"data_file_0", {500}},
-          {"data_file_1", {10000, 10000}},
-          {"data_file_2", {500}},
+          {"data_file_0", {5}},
+          {"data_file_1", {10, 10}},
+          {"data_file_2", {5}},
       },
-      {{"delete_file_1",
-        {{"data_file_1", makeRandomIncreasingValues(0, 20000)}}}},
+      {{"delete_file_1", {{"data_file_1", {0, 10, 19}}}}},
+      concat(
+          {sequence(0, 5),
+           sequence(6, 15),
+           sequence(16, 24),
+           sequence(25, 30)}),
       0,
       3);
 
-  assertMultipleSplits({1000, 9000, 20000}, 1, 0, 20000, 3);
+  assertMultipleSplits(
+      {10, 19, 20}, 1, 0, concat({sequence(0, 10), sequence(11, 19)}), 20, 3);
 }
 
 // Test that positional delete files are skipped when their position upper bound
@@ -682,10 +491,8 @@ TEST_F(IcebergPositionalDeleteTest, skipDeleteFileByPositionUpperBound) {
   writeToFile(
       dataFilePath->getPath(),
       {
-          makeRowVector(
-              {makeFlatVector<int64_t>(makeContinuousIncreasingValues(0, 50))}),
-          makeRowVector({makeFlatVector<int64_t>(
-              makeContinuousIncreasingValues(50, 100))}),
+          makeRowVector({makeFlatVector<int64_t>(sequence(0, 50))}),
+          makeRowVector({makeFlatVector<int64_t>(sequence(50, 100))}),
       },
       std::make_shared<dwrf::Config>(),
       []() {
@@ -711,22 +518,17 @@ TEST_F(IcebergPositionalDeleteTest, skipDeleteFileByPositionUpperBound) {
   reader->loadCache();
   ASSERT_GE(reader->footer().stripesSize(), 2);
   const uint64_t splitStart = reader->footer().stripes(1).offset();
-  std::shared_ptr<ConnectorSplit> split = std::make_shared<HiveIcebergSplit>(
-      test::kIcebergConnectorId,
-      dataFilePath->getPath(),
-      fileFormat_,
-      splitStart,
-      fileSize - splitStart,
-      std::unordered_map<std::string, std::optional<std::string>>{},
-      std::nullopt,
-      std::unordered_map<std::string, std::string>{},
-      nullptr,
-      /*cacheable=*/true,
-      std::vector<IcebergDeleteFile>{deleteFile});
+  std::shared_ptr<ConnectorSplit> split =
+      IcebergSplitBuilder(dataFilePath->getPath())
+          .connectorId(test::kIcebergConnectorId)
+          .fileFormat(fileFormat_)
+          .start(splitStart)
+          .length(fileSize - splitStart)
+          .deleteFiles({deleteFile})
+          .build();
 
   // The second half of the file should be returned with no rows deleted.
-  auto expected = makeRowVector(
-      {makeFlatVector<int64_t>(makeContinuousIncreasingValues(50, 100))});
+  auto expected = makeRowVector({makeFlatVector<int64_t>(sequence(50, 100))});
   auto plan = exec::test::PlanBuilder()
                   .startTableScan(test::kIcebergConnectorId)
                   .outputType(ROW({"c0"}, {BIGINT()}))
@@ -781,7 +583,7 @@ TEST_F(IcebergPositionalDeleteTest, positionalDeleteSequenceNumberSkipped) {
 TEST_F(
     IcebergPositionalDeleteTest,
     positionalDeleteSequenceNumberEqualApplied) {
-  // Same-snapshot delete applied: positions 1 and 3 deleted → [0, 2, 4].
+  // Same-snapshot delete applied: positions 1 and 3 deleted -> [0, 2, 4].
   assertDeleteSequenceScenario(
       /*dataSequenceNumber=*/5, /*deleteSequenceNumber=*/5, {0, 2, 4});
 }
@@ -789,7 +591,7 @@ TEST_F(
 TEST_F(
     IcebergPositionalDeleteTest,
     positionalDeleteSequenceNumberZeroDisablesFilter) {
-  // SeqNum=0 disables filtering → delete applied: [0, 2, 4].
+  // SeqNum=0 disables filtering -> delete applied: [0, 2, 4].
   assertDeleteSequenceScenario(
       /*dataSequenceNumber=*/100, /*deleteSequenceNumber=*/0, {0, 2, 4});
 }

--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -14,305 +14,53 @@
  * limitations under the License.
  */
 
+#include "velox/connectors/hive/iceberg/tests/IcebergTestBase.h"
+
+#include <algorithm>
+
 #include <folly/Singleton.h>
 #include <folly/lang/Bits.h>
+
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/encode/Base64.h"
-#include "velox/common/file/FileSystems.h"
-#include "velox/connectors/ConnectorRegistry.h"
-#include "velox/connectors/hive/HiveConnectorSplit.h"
-#include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
-#include "velox/connectors/hive/iceberg/IcebergConnector.h"
-#include "velox/connectors/hive/iceberg/IcebergDeleteFile.h"
+#include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/iceberg/IcebergMetadataColumns.h"
-#include "velox/connectors/hive/iceberg/IcebergSplit.h"
-#include "velox/dwio/common/tests/utils/DataFiles.h"
-#include "velox/exec/PlanNodeStats.h"
-#include "velox/exec/tests/utils/AssertQueryBuilder.h"
-#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
-#include "velox/exec/tests/utils/PlanBuilder.h"
-
-#ifdef VELOX_ENABLE_PARQUET
-#include "velox/dwio/parquet/RegisterParquetReader.h"
-#endif
-
-using namespace facebook::velox::exec::test;
-using namespace facebook::velox::exec;
-using namespace facebook::velox::dwio::common;
-using namespace facebook::velox::test;
-using namespace facebook::velox::common::testutil;
 
 namespace facebook::velox::connector::hive::iceberg {
 
 namespace {
-// Return the file size for the given path using Velox's filesystem API.
-uint64_t getTestFileSize(const std::string& path) {
-  return filesystems::getFileSystem(path, nullptr)
-      ->openFileForRead(path)
-      ->size();
-}
-} // namespace
 
-static const char* kIcebergConnectorId = "test-iceberg";
+using TempFilePath = common::testutil::TempFilePath;
 
-class HiveIcebergTest : public HiveConnectorTestBase {
- public:
-  void SetUp() override {
-    HiveConnectorTestBase::SetUp();
-#ifdef VELOX_ENABLE_PARQUET
-    parquet::registerParquetReaderFactory();
-#endif
-    // Register IcebergConnector.
-    IcebergConnectorFactory icebergFactory;
-    auto icebergConnector = icebergFactory.newConnector(
-        kIcebergConnectorId,
-        std::make_shared<config::ConfigBase>(
-            std::unordered_map<std::string, std::string>()),
-        ioExecutor_.get());
-    connector::ConnectorRegistry::global().insert(
-        icebergConnector->connectorId(), icebergConnector);
-  }
-
-  void TearDown() override {
-    connector::ConnectorRegistry::global().erase(kIcebergConnectorId);
-    HiveConnectorTestBase::TearDown();
-  }
-
-  HiveIcebergTest()
-      : config_{std::make_shared<facebook::velox::dwrf::Config>()} {
-    // Make the writers flush per batch so that we can create non-aligned
-    // RowGroups between the base data files and delete files
-    flushPolicyFactory_ = []() {
-      return std::make_unique<dwrf::LambdaFlushPolicy>([]() { return true; });
-    };
-  }
-
-  /// Create 1 base data file data_file_1 with 2 RowGroups of 10000 rows each.
-  /// Also create 1 delete file delete_file_1 which contains delete positions
-  /// for data_file_1.
-  void assertSingleBaseFileSingleDeleteFile(
-      const std::vector<int64_t>& deletePositionsVec) {
-    std::map<std::string, std::vector<int64_t>> rowGroupSizesForFiles = {
-        {"data_file_1", {10000, 10000}}};
-    std::unordered_map<
-        std::string,
-        std::multimap<std::string, std::vector<int64_t>>>
-        deleteFilesForBaseDatafiles = {
-            {"delete_file_1", {{"data_file_1", deletePositionsVec}}}};
-
-    assertPositionalDeletes(
-        rowGroupSizesForFiles, deleteFilesForBaseDatafiles, 0);
-  }
-
-  /// Create 3 base data files, where the first file data_file_0 has 500 rows,
-  /// the second file data_file_1 contains 2 RowGroups of 10000 rows each, and
-  /// the third file data_file_2 contains 500 rows. It creates 1 positional
-  /// delete file delete_file_1, which contains delete positions for
-  /// data_file_1.
-  void assertMultipleBaseFileSingleDeleteFile(
-      const std::vector<int64_t>& deletePositionsVec) {
-    int64_t previousFileRowCount = 500;
-    int64_t afterFileRowCount = 500;
-
-    assertPositionalDeletes(
-        {
-            {"data_file_0", {previousFileRowCount}},
-            {"data_file_1", {10000, 10000}},
-            {"data_file_2", {afterFileRowCount}},
-        },
-        {{"delete_file_1", {{"data_file_1", deletePositionsVec}}}},
-        0);
-  }
-
-  /// Create 1 base data file data_file_1 with 2 RowGroups of 10000 rows each.
-  /// Create multiple delete files with name data_file_1, data_file_2, and so on
-  void assertSingleBaseFileMultipleDeleteFiles(
-      const std::vector<std::vector<int64_t>>& deletePositionsVecs) {
-    std::map<std::string, std::vector<int64_t>> rowGroupSizesForFiles = {
-        {"data_file_1", {10000, 10000}}};
-
-    std::unordered_map<
-        std::string,
-        std::multimap<std::string, std::vector<int64_t>>>
-        deleteFilesForBaseDatafiles;
-    for (int i = 0; i < deletePositionsVecs.size(); i++) {
-      std::string deleteFileName = fmt::format("delete_file_{}", i);
-      deleteFilesForBaseDatafiles[deleteFileName] = {
-          {"data_file_1", deletePositionsVecs[i]}};
-    }
-    assertPositionalDeletes(
-        rowGroupSizesForFiles, deleteFilesForBaseDatafiles, 0);
-  }
-
-  void assertMultipleSplits(
-      const std::vector<int64_t>& deletePositions,
-      int32_t fileCount,
-      int32_t numPrefetchSplits,
-      int rowCountPerFile = rowCount,
-      int32_t splitCountPerFile = 1) {
-    std::map<std::string, std::vector<int64_t>> rowGroupSizesForFiles;
-    for (int32_t i = 0; i < fileCount; i++) {
-      std::string dataFileName = fmt::format("data_file_{}", i);
-      rowGroupSizesForFiles[dataFileName] = {rowCountPerFile};
-    }
-
-    std::unordered_map<
-        std::string,
-        std::multimap<std::string, std::vector<int64_t>>>
-        deleteFilesForBaseDatafiles;
-    for (int i = 0; i < fileCount; i++) {
-      std::string deleteFileName = fmt::format("delete_file_{}", i);
-      deleteFilesForBaseDatafiles[deleteFileName] = {
-          {fmt::format("data_file_{}", i), deletePositions}};
-    }
-
-    assertPositionalDeletes(
-        rowGroupSizesForFiles,
-        deleteFilesForBaseDatafiles,
-        numPrefetchSplits,
-        splitCountPerFile);
-  }
-
-  std::vector<int64_t> makeRandomIncreasingValues(int64_t begin, int64_t end) {
-    VELOX_CHECK(begin < end);
-
-    std::mt19937 gen{0};
-    std::vector<int64_t> values;
-    values.reserve(end - begin);
-    for (int i = begin; i < end; i++) {
-      if (folly::Random::rand32(0, 10, gen) > 8) {
-        values.push_back(i);
-      }
-    }
-    return values;
-  }
-
-  static std::vector<int64_t> makeContinuousIncreasingValues(
-      int64_t begin,
-      int64_t end) {
-    std::vector<int64_t> values;
-    values.resize(end - begin);
-    std::iota(values.begin(), values.end(), begin);
-    return values;
-  }
-
-  /// @rowGroupSizesForFiles The key is the file name, and the value is a vector
-  /// of RowGroup sizes
-  /// @deleteFilesForBaseDatafiles The key is the delete file name, and the
-  /// value contains the information about the content of this delete file.
-  /// e.g. {
-  ///         "delete_file_1",
-  ///         {
-  ///             {"data_file_1", {1, 2, 3}},
-  ///             {"data_file_1", {4, 5, 6}},
-  ///             {"data_file_2", {0, 2, 4}}
-  ///         }
-  ///     }
-  /// represents one delete file called delete_file_1, which contains delete
-  /// positions for data_file_1 and data_file_2. THere are 3 RowGroups in this
-  /// delete file, the first two contain positions for data_file_1, and the last
-  /// contain positions for data_file_2
-  void assertPositionalDeletes(
-      const std::map<std::string, std::vector<int64_t>>& rowGroupSizesForFiles,
-      const std::unordered_map<
-          std::string,
-          std::multimap<std::string, std::vector<int64_t>>>&
-          deleteFilesForBaseDatafiles,
-      int32_t numPrefetchSplits = 0,
-      int32_t splitCount = 1) {
-    // Keep the reference to the deleteFilePath, otherwise the corresponding
-    // file will be deleted.
-    std::map<std::string, std::shared_ptr<TempFilePath>> dataFilePaths =
-        writeDataFiles(rowGroupSizesForFiles);
-    std::unordered_map<
-        std::string,
-        std::pair<int64_t, std::shared_ptr<TempFilePath>>>
-        deleteFilePaths = writePositionDeleteFiles(
-            deleteFilesForBaseDatafiles, dataFilePaths);
-
-    std::vector<std::shared_ptr<ConnectorSplit>> splits;
-
-    for (const auto& dataFile : dataFilePaths) {
-      std::string baseFileName = dataFile.first;
-      std::string baseFilePath = dataFile.second->getPath();
-
-      std::vector<IcebergDeleteFile> deleteFiles;
-
-      for (auto const& deleteFile : deleteFilesForBaseDatafiles) {
-        std::string deleteFileName = deleteFile.first;
-        std::multimap<std::string, std::vector<int64_t>> deleteFileContent =
-            deleteFile.second;
-
-        if (deleteFileContent.count(baseFileName) != 0) {
-          // If this delete file contains rows for the target base file, then
-          // add it to the split
-          auto deleteFilePath =
-              deleteFilePaths[deleteFileName].second->getPath();
-          IcebergDeleteFile icebergDeleteFile(
-              FileContent::kPositionalDeletes,
-              deleteFilePath,
-              fileFormat_,
-              deleteFilePaths[deleteFileName].first,
-              getTestFileSize(deleteFilePath));
-          deleteFiles.push_back(icebergDeleteFile);
-        }
-      }
-
-      auto icebergSplits =
-          makeIcebergSplits(baseFilePath, deleteFiles, {}, splitCount);
-      splits.insert(splits.end(), icebergSplits.begin(), icebergSplits.end());
-    }
-
-    std::string duckdbSql =
-        getDuckDBQuery(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
-    auto plan = PlanBuilder()
-                    .startTableScan()
-                    .connectorId(kIcebergConnectorId)
-                    .outputType(ROW({"c0"}, {BIGINT()}))
-                    .endTableScan()
-                    .planNode();
-    auto task = assertQuery(plan, splits, duckdbSql, numPrefetchSplits);
-
-    auto planStats = toPlanStats(task->taskStats());
-
-    auto it = planStats.find(plan->id());
-    ASSERT_TRUE(it != planStats.end());
-    ASSERT_TRUE(it->second.peakMemoryBytes > 0);
-  }
-
-  const static int rowCount = 20000;
-
+class IcebergReadTest : public test::IcebergTestBase {
  protected:
-  std::shared_ptr<dwrf::Config> config_;
-  std::function<std::unique_ptr<dwrf::DWRFFlushPolicy>()> flushPolicyFactory_;
-  FileFormat fileFormat_{FileFormat::DWRF};
+  struct AssignmentSpec {
+    std::string outputName;
+    std::string sourceName;
+    TypePtr type;
+    int fieldId;
+    std::optional<std::string> defaultValue = std::nullopt;
+  };
 
-  /// Helper to create a standard c0 HiveColumnHandle (BIGINT).
-  std::shared_ptr<HiveColumnHandle> makeC0Handle() {
-    return std::make_shared<HiveColumnHandle>(
-        "c0",
-        HiveColumnHandle::ColumnType::kRegular,
-        BIGINT(),
-        BIGINT(),
-        std::vector<common::Subfield>{});
+  struct RowLineageTestCase {
+    std::vector<int64_t> values;
+    std::optional<std::vector<std::optional<int64_t>>> storedRowIds =
+        std::nullopt;
+    std::optional<std::vector<std::optional<int64_t>>> storedSequenceNumbers =
+        std::nullopt;
+    std::optional<int64_t> firstRowId = std::nullopt;
+    std::optional<int64_t> dataSequenceNumber = std::nullopt;
+    std::vector<int64_t> deletePositions;
+    std::string subfieldFilter;
+    std::vector<RowVectorPtr> expectedVectors;
+  };
+
+  void SetUp() override {
+    test::IcebergTestBase::SetUp();
+    folly::SingletonVault::singleton()->registrationComplete();
+    fileFormat_ = dwio::common::FileFormat::DWRF;
   }
 
-  /// Helper to create an IcebergColumnHandle with default value.
-  std::shared_ptr<IcebergColumnHandle> makeIcebergHandle(
-      const std::string& name,
-      const TypePtr& type,
-      int fieldId,
-      const std::string& defaultValue) {
-    return std::make_shared<IcebergColumnHandle>(
-        name,
-        HiveColumnHandle::ColumnType::kRegular,
-        type,
-        parquet::ParquetFieldId(fieldId),
-        std::vector<common::Subfield>{},
-        std::optional<std::string>{defaultValue});
-  }
-
-  /// Helper function to test schema evolution with initial default values.
   void assertDefaultValues(
       const RowTypePtr& outputType,
       const RowTypePtr& scanSpecType,
@@ -321,195 +69,54 @@ class HiveIcebergTest : public HiveConnectorTestBase {
       const std::vector<RowVectorPtr>& expected,
       const std::unordered_map<std::string, std::string>& sessionProperties =
           {}) {
-    // Write data file with old schema
     auto dataFilePath = TempFilePath::create();
     writeToFile(dataFilePath->getPath(), data);
-    auto icebergSplits = makeIcebergSplits(dataFilePath->getPath());
-
-    // Build plan
-    auto plan = PlanBuilder()
-                    .startTableScan()
-                    .connectorId(kIcebergConnectorId)
-                    .outputType(outputType)
-                    .dataColumns(scanSpecType)
-                    .assignments(assignments)
-                    .endTableScan()
-                    .planNode();
-
-    // Build query and add session properties if provided
-    auto queryBuilder = AssertQueryBuilder(plan);
-    for (const auto& [key, value] : sessionProperties) {
-      queryBuilder.connectorSessionProperty(kIcebergConnectorId, key, value);
-    }
-    queryBuilder.splits(icebergSplits).assertResults(expected);
+    assertTableScan(
+        outputType,
+        makeIcebergSplits(dataFilePath->getPath()),
+        expected,
+        scanSpecType,
+        assignments,
+        "",
+        "",
+        "",
+        sessionProperties);
   }
 
-  std::vector<std::shared_ptr<ConnectorSplit>> makeIcebergSplits(
-      const std::string& dataFilePath,
-      const std::vector<IcebergDeleteFile>& deleteFiles = {},
-      const std::unordered_map<std::string, std::optional<std::string>>&
-          partitionKeys = {},
-      const uint32_t splitCount = 1) {
-    auto file = filesystems::getFileSystem(dataFilePath, nullptr)
-                    ->openFileForRead(dataFilePath);
-    const int64_t fileSize = file->size();
-    const uint64_t splitSize = std::floor((fileSize) / splitCount);
-
-    std::vector<std::shared_ptr<ConnectorSplit>> splits;
-    splits.reserve(splitCount);
-
-    for (int i = 0; i < splitCount; ++i) {
-      splits.emplace_back(
-          std::make_shared<HiveIcebergSplit>(
-              kIcebergConnectorId,
-              dataFilePath,
-              fileFormat_,
-              i * splitSize,
-              splitSize,
-              partitionKeys,
-              std::nullopt,
-              std::unordered_map<std::string, std::string>{},
-              nullptr,
-              /*cacheable=*/true,
-              deleteFiles));
-    }
-
-    return splits;
+  std::vector<RowVectorPtr> makeSingleBigintData(
+      const std::vector<int64_t>& values) {
+    return {makeRowVector({makeFlatVector<int64_t>(values)})};
   }
 
-  ColumnHandleMap makeColumnHandles(
-      const RowTypePtr& rowType,
-      const std::unordered_set<int>& partitionIndices = {}) {
+  ColumnHandleMap makeAssignments(std::initializer_list<AssignmentSpec> specs) {
     ColumnHandleMap assignments;
-    for (auto i = 0; i < rowType->size(); ++i) {
-      const auto& columnName = rowType->nameOf(i);
-      const auto& columnType = rowType->childAt(i);
-      auto columnHandleType = partitionIndices.contains(i)
-          ? FileColumnHandle::ColumnType::kPartitionKey
-          : FileColumnHandle::ColumnType::kRegular;
-
-      assignments.insert(
-          {columnName,
-           std::make_shared<HiveColumnHandle>(
-               columnName,
-               columnHandleType,
-               columnType,
-               columnType,
-               std::vector<common::Subfield>{})});
+    for (const auto& spec : specs) {
+      assignments[spec.outputName] = spec.defaultValue.has_value()
+          ? makeIcebergHandle(
+                spec.sourceName, spec.type, spec.fieldId, *spec.defaultValue)
+          : makeIcebergHandle(spec.sourceName, spec.type, spec.fieldId);
     }
-
     return assignments;
   }
 
-#ifdef VELOX_ENABLE_PARQUET
-  std::vector<std::shared_ptr<ConnectorSplit>> createParquetDeleteFileAndSplits(
-      const std::string& path,
-      const std::vector<int64_t>& deletePositionsVec,
-      int32_t deletedPositionSize,
-      const std::shared_ptr<TempFilePath>& deleteFilePath) {
-    writeToFile(
-        deleteFilePath->getPath(),
-        {makeRowVector(
-            {pathColumn_->name, posColumn_->name},
-            {
-                makeFlatVector<std::string>(
-                    static_cast<vector_size_t>(deletedPositionSize),
-                    [&](vector_size_t) { return path; }),
-                makeFlatVector<int64_t>(deletePositionsVec),
-            })});
-
-    IcebergDeleteFile icebergDeleteFile(
-        FileContent::kPositionalDeletes,
-        deleteFilePath->getPath(),
-        fileFormat_,
-        deletedPositionSize,
-        getTestFileSize(deleteFilePath->getPath()));
-    auto fileSize = filesystems::getFileSystem(path, nullptr)
-                        ->openFileForRead(path)
-                        ->size();
-
-    std::unordered_map<std::string, std::optional<std::string>> partitionKeys;
-    return {std::make_shared<HiveIcebergSplit>(
-        kIcebergConnectorId,
-        path,
-        FileFormat::PARQUET,
-        0,
-        fileSize,
-        partitionKeys,
-        std::nullopt,
-        std::unordered_map<std::string, std::string>{},
-        nullptr,
-        /*cacheable=*/true,
-        std::vector<IcebergDeleteFile>{icebergDeleteFile})};
-  }
-#endif
-
-  /// Creates a single HiveIcebergSplit from the full data file with info
-  /// columns (e.g. $first_row_id, $data_sequence_number) and optional
-  /// delete files.
-  std::shared_ptr<ConnectorSplit> makeIcebergSplitWithInfoColumns(
-      const std::string& dataFilePath,
-      const std::unordered_map<std::string, std::string>& infoColumns,
-      const std::vector<IcebergDeleteFile>& deleteFiles = {}) {
-    auto file = filesystems::getFileSystem(dataFilePath, nullptr)
-                    ->openFileForRead(dataFilePath);
-    return std::make_shared<HiveIcebergSplit>(
-        kIcebergConnectorId,
-        dataFilePath,
-        fileFormat_,
-        0,
-        file->size(),
-        std::unordered_map<std::string, std::optional<std::string>>{},
-        std::nullopt,
-        std::unordered_map<std::string, std::string>{},
-        nullptr,
-        /*cacheable=*/true,
-        deleteFiles,
-        infoColumns);
+  std::vector<RowVectorPtr> makeBigintAndVarcharExpected(
+      const std::vector<std::string>& names,
+      const RowVectorPtr& data,
+      const std::vector<std::string>& values) {
+    return {makeRowVector(
+        names, {data->childAt(0), makeFlatVector<std::string>(values)})};
   }
 
-  struct RowLineageTestCase {
-    std::vector<int64_t> values{};
-    // Physically stored _row_id values; nullopt entries write a file null.
-    // Absent means no _row_id column in the file; reader derives from
-    // firstRowId. Always paired with storedSequenceNumbers.
-    std::optional<std::vector<std::optional<int64_t>>> storedRowIds =
-        std::nullopt;
-    // Physically stored _last_updated_sequence_number values; nullopt entries
-    // write a file null. Absent means no column in the file; reader derives
-    // from dataSequenceNumber. Always paired with storedRowIds.
-    std::optional<std::vector<std::optional<int64_t>>> storedSequenceNumbers =
-        std::nullopt;
-    // Passed as first_row_id in the split's info columns.
-    std::optional<int64_t> firstRowId = std::nullopt;
-    // Passed as data_sequence_number in the split's info columns.
-    std::optional<int64_t> dataSequenceNumber = std::nullopt;
-    // File positions to delete; empty means no delete file is created.
-    std::vector<int64_t> deletePositions{};
-    // Subfield filter expression (e.g., "c0 > 20"); empty means no filter.
-    std::string subfieldFilter{};
-    // Expected output rows: (c0, _row_id, _last_updated_sequence_number).
-    std::vector<RowVectorPtr> expectedVectors{};
-  };
-
-  // Writes tc to a temp data file, executes a table scan over
-  // (c0, _row_id, _last_updated_sequence_number), and asserts the result.
   void assertRowLineage(const RowLineageTestCase& tc) {
     VELOX_CHECK_EQ(
         tc.storedRowIds.has_value(),
         tc.storedSequenceNumbers.has_value(),
         "rowIds and sequenceNumbers must both be set or both absent.");
 
-    auto pathColumn = IcebergMetadataColumn::icebergDeleteFilePathColumn();
-    auto posColumn = IcebergMetadataColumn::icebergDeletePosColumn();
-
-    // Build the data file vectors from the explicit column fields.
     std::vector<RowVectorPtr> inputVectors;
     if (!tc.storedRowIds.has_value()) {
-      // No physical lineage columns: file contains only c0.
       inputVectors = {makeRowVector({makeFlatVector<int64_t>(tc.values)})};
     } else {
-      // Physical lineage columns are present in the file.
       static const std::vector<std::string> kFileColumns = {
           "c0", "_row_id", "_last_updated_sequence_number"};
       inputVectors = {makeRowVector(
@@ -527,20 +134,25 @@ class HiveIcebergTest : public HiveConnectorTestBase {
     std::vector<IcebergDeleteFile> deleteFiles;
     std::shared_ptr<TempFilePath> deleteFilePath;
     if (!tc.deletePositions.empty()) {
+      auto pathColumn = IcebergMetadataColumn::icebergDeleteFilePathColumn();
+      auto posColumn = IcebergMetadataColumn::icebergDeletePosColumn();
       deleteFilePath = TempFilePath::create();
       writeToFile(
           deleteFilePath->getPath(),
           {makeRowVector(
               {pathColumn->name, posColumn->name},
-              {makeFlatVector<std::string>(
-                   static_cast<vector_size_t>(tc.deletePositions.size()),
-                   [&](auto) { return dataFilePath->getPath(); }),
-               makeFlatVector<int64_t>(tc.deletePositions)})});
+              {
+                  makeFlatVector<std::string>(
+                      static_cast<vector_size_t>(tc.deletePositions.size()),
+                      [&](vector_size_t) { return dataFilePath->getPath(); }),
+                  makeFlatVector<int64_t>(tc.deletePositions),
+              })});
 
+      std::unordered_map<int32_t, std::string> upperBounds;
       const uint64_t upperBound = static_cast<uint64_t>(*std::max_element(
           tc.deletePositions.begin(), tc.deletePositions.end()));
       const auto upperBoundLE = folly::Endian::little(upperBound);
-      const auto encodedUpperBound = encoding::Base64::encode(
+      upperBounds[posColumn->id] = encoding::Base64::encode(
           std::string_view(
               reinterpret_cast<const char*>(&upperBoundLE),
               sizeof(upperBoundLE)));
@@ -550,10 +162,11 @@ class HiveIcebergTest : public HiveConnectorTestBase {
           deleteFilePath->getPath(),
           fileFormat_,
           static_cast<int64_t>(tc.deletePositions.size()),
-          getTestFileSize(deleteFilePath->getPath()),
+          this->getFileSize(deleteFilePath->getPath()),
           {},
           {},
-          {{posColumn->id, encodedUpperBound}}));
+          upperBounds,
+          0));
     }
 
     std::unordered_map<std::string, std::string> infoColumns;
@@ -566,571 +179,119 @@ class HiveIcebergTest : public HiveConnectorTestBase {
           std::to_string(*tc.dataSequenceNumber);
     }
 
-    auto split = makeIcebergSplitWithInfoColumns(
-        dataFilePath->getPath(), infoColumns, deleteFiles);
-
     const auto outputType =
         ROW({"c0", "_row_id", "_last_updated_sequence_number"},
             {BIGINT(), BIGINT(), BIGINT()});
     const auto tableDataColumns = ROW({"c0"}, {BIGINT()});
-
-    core::PlanNodePtr plan;
-    if (!tc.subfieldFilter.empty()) {
-      plan = PlanBuilder()
-                 .startTableScan()
-                 .connectorId(kIcebergConnectorId)
-                 .outputType(outputType)
-                 .dataColumns(tableDataColumns)
-                 .subfieldFilter(tc.subfieldFilter)
-                 .endTableScan()
-                 .planNode();
-    } else {
-      plan = PlanBuilder()
-                 .startTableScan()
-                 .connectorId(kIcebergConnectorId)
-                 .outputType(outputType)
-                 .dataColumns(tableDataColumns)
-                 .endTableScan()
-                 .planNode();
-    }
-
-    AssertQueryBuilder(plan).splits({split}).assertResults(tc.expectedVectors);
+    assertTableScan(
+        outputType,
+        {makeIcebergSplitWithInfoColumns(
+            dataFilePath->getPath(), infoColumns, deleteFiles)},
+        tc.expectedVectors,
+        tableDataColumns,
+        {},
+        "",
+        "",
+        tc.subfieldFilter);
   }
-
- private:
-  std::map<std::string, std::shared_ptr<TempFilePath>> writeDataFiles(
-      std::map<std::string, std::vector<int64_t>> rowGroupSizesForFiles) {
-    std::map<std::string, std::shared_ptr<TempFilePath>> dataFilePaths;
-
-    std::vector<RowVectorPtr> dataVectorsJoined;
-    dataVectorsJoined.reserve(rowGroupSizesForFiles.size());
-
-    int64_t startingValue = 0;
-    for (auto& dataFile : rowGroupSizesForFiles) {
-      dataFilePaths[dataFile.first] = TempFilePath::create();
-
-      // We make the values are continuously increasing even across base data
-      // files. This is to make constructing DuckDB queries easier
-      std::vector<RowVectorPtr> dataVectors =
-          makeVectors(dataFile.second, startingValue);
-      writeToFile(dataFilePaths[dataFile.first]->getPath(), dataVectors);
-
-      for (int i = 0; i < dataVectors.size(); i++) {
-        dataVectorsJoined.push_back(dataVectors[i]);
-      }
-    }
-
-    createDuckDbTable(dataVectorsJoined);
-    return dataFilePaths;
-  }
-
-  /// Input is like <"deleteFile1", <"dataFile1", {pos_RG1, pos_RG2,..}>,
-  /// <"dataFile2", {pos_RG1, pos_RG2,..}>
-  std::unordered_map<
-      std::string,
-      std::pair<int64_t, std::shared_ptr<TempFilePath>>>
-  writePositionDeleteFiles(
-      const std::unordered_map<
-          std::string, // delete file name
-          std::multimap<
-              std::string,
-              std::vector<int64_t>>>&
-          deleteFilesForBaseDatafiles, // <base file name, delete position
-                                       // vector for all RowGroups>
-      std::map<std::string, std::shared_ptr<TempFilePath>> baseFilePaths) {
-    std::unordered_map<
-        std::string,
-        std::pair<int64_t, std::shared_ptr<TempFilePath>>>
-        deleteFilePaths;
-    deleteFilePaths.reserve(deleteFilesForBaseDatafiles.size());
-
-    for (auto& deleteFile : deleteFilesForBaseDatafiles) {
-      auto deleteFileName = deleteFile.first;
-      auto deleteFileContent = deleteFile.second;
-      auto deleteFilePath = TempFilePath::create();
-
-      std::vector<RowVectorPtr> deleteFileVectors;
-      int64_t totalPositionsInDeleteFile = 0;
-
-      for (auto& deleteFileRowGroup : deleteFileContent) {
-        auto baseFileName = deleteFileRowGroup.first;
-        auto baseFilePath = baseFilePaths[baseFileName]->getPath();
-        auto positionsInRowGroup = deleteFileRowGroup.second;
-
-        auto filePathVector = makeFlatVector<std::string>(
-            static_cast<vector_size_t>(positionsInRowGroup.size()),
-            [&](vector_size_t row) { return baseFilePath; });
-        auto deletePosVector = makeFlatVector<int64_t>(positionsInRowGroup);
-
-        RowVectorPtr deleteFileVector = makeRowVector(
-            {pathColumn_->name, posColumn_->name},
-            {filePathVector, deletePosVector});
-
-        deleteFileVectors.push_back(deleteFileVector);
-        totalPositionsInDeleteFile += positionsInRowGroup.size();
-      }
-
-      writeToFile(deleteFilePath->getPath(), deleteFileVectors);
-
-      deleteFilePaths[deleteFileName] =
-          std::make_pair(totalPositionsInDeleteFile, deleteFilePath);
-    }
-
-    return deleteFilePaths;
-  }
-
-  std::vector<RowVectorPtr> makeVectors(
-      std::vector<int64_t> vectorSizes,
-      int64_t& startingValue) {
-    std::vector<RowVectorPtr> vectors;
-    vectors.reserve(vectorSizes.size());
-
-    vectors.reserve(vectorSizes.size());
-    for (int j = 0; j < vectorSizes.size(); j++) {
-      auto data = makeContinuousIncreasingValues(
-          startingValue, startingValue + vectorSizes[j]);
-      vectors.push_back(makeRowVector({makeFlatVector<int64_t>(data)}));
-      startingValue += vectorSizes[j];
-    }
-
-    return vectors;
-  }
-
-  std::string getDuckDBQuery(
-      const std::map<std::string, std::vector<int64_t>>& rowGroupSizesForFiles,
-      const std::unordered_map<
-          std::string,
-          std::multimap<std::string, std::vector<int64_t>>>&
-          deleteFilesForBaseDatafiles) {
-    int64_t totalNumRowsInAllBaseFiles = 0;
-    std::map<std::string, int64_t> baseFileSizes;
-    for (auto rowGroupSizesInFile : rowGroupSizesForFiles) {
-      // Sum up the row counts in all RowGroups in each base file
-      baseFileSizes[rowGroupSizesInFile.first] += std::accumulate(
-          rowGroupSizesInFile.second.begin(),
-          rowGroupSizesInFile.second.end(),
-          0LL);
-      totalNumRowsInAllBaseFiles += baseFileSizes[rowGroupSizesInFile.first];
-    }
-
-    // Group the delete vectors by baseFileName
-    std::map<std::string, std::vector<std::vector<int64_t>>>
-        deletePosVectorsForAllBaseFiles;
-    for (auto& deleteFile : deleteFilesForBaseDatafiles) {
-      auto deleteFileContent = deleteFile.second;
-      for (auto& rowGroup : deleteFileContent) {
-        auto baseFileName = rowGroup.first;
-        deletePosVectorsForAllBaseFiles[baseFileName].push_back(
-            rowGroup.second);
-      }
-    }
-
-    // Flatten and deduplicate the delete position vectors in
-    // deletePosVectorsForAllBaseFiles from previous step, and count the total
-    // number of distinct delete positions for all base files
-    std::map<std::string, std::vector<int64_t>>
-        flattenedDeletePosVectorsForAllBaseFiles;
-    int64_t totalNumDeletePositions = 0;
-    for (auto& deleteVectorsForBaseFile : deletePosVectorsForAllBaseFiles) {
-      auto baseFileName = deleteVectorsForBaseFile.first;
-      auto deletePositionVectors = deleteVectorsForBaseFile.second;
-      std::vector<int64_t> deletePositionVector =
-          flattenAndDedup(deletePositionVectors, baseFileSizes[baseFileName]);
-      flattenedDeletePosVectorsForAllBaseFiles[baseFileName] =
-          deletePositionVector;
-      totalNumDeletePositions += deletePositionVector.size();
-    }
-
-    // Now build the DuckDB queries
-    if (totalNumDeletePositions == 0) {
-      return "SELECT * FROM tmp";
-    }
-
-    if (totalNumDeletePositions >= totalNumRowsInAllBaseFiles) {
-      return "SELECT * FROM tmp WHERE 1 = 0";
-    }
-
-    {
-      // Convert the delete positions in all base files into column values
-      std::vector<int64_t> allDeleteValues;
-
-      int64_t numRowsInPreviousBaseFiles = 0;
-      for (auto& baseFileSize : baseFileSizes) {
-        auto deletePositions =
-            flattenedDeletePosVectorsForAllBaseFiles[baseFileSize.first];
-
-        if (numRowsInPreviousBaseFiles > 0) {
-          for (int64_t& deleteValue : deletePositions) {
-            deleteValue += numRowsInPreviousBaseFiles;
-          }
-        }
-
-        allDeleteValues.insert(
-            allDeleteValues.end(),
-            deletePositions.begin(),
-            deletePositions.end());
-
-        numRowsInPreviousBaseFiles += baseFileSize.second;
-      }
-
-      return fmt::format(
-          "SELECT * FROM tmp WHERE c0 NOT IN ({})",
-          folly::join(", ", allDeleteValues));
-    }
-  }
-
-  std::vector<int64_t> flattenAndDedup(
-      const std::vector<std::vector<int64_t>>& deletePositionVectors,
-      int64_t baseFileSize) {
-    std::vector<int64_t> deletePositionVector;
-    for (auto& vec : deletePositionVectors) {
-      for (auto pos : vec) {
-        if (pos >= 0 && pos < baseFileSize) {
-          deletePositionVector.push_back(pos);
-        }
-      }
-    }
-
-    std::sort(deletePositionVector.begin(), deletePositionVector.end());
-    auto last =
-        std::unique(deletePositionVector.begin(), deletePositionVector.end());
-    deletePositionVector.erase(last, deletePositionVector.end());
-
-    return deletePositionVector;
-  }
-
-  std::shared_ptr<IcebergMetadataColumn> pathColumn_ =
-      IcebergMetadataColumn::icebergDeleteFilePathColumn();
-
-  std::shared_ptr<IcebergMetadataColumn> posColumn_ =
-      IcebergMetadataColumn::icebergDeletePosColumn();
 };
 
-/// This test creates one single data file and one delete file. The parameter
-/// passed to assertSingleBaseFileSingleDeleteFile is the delete positions.
-TEST_F(HiveIcebergTest, singleBaseFileSinglePositionalDeleteFile) {
-  folly::SingletonVault::singleton()->registrationComplete();
-
-  assertSingleBaseFileSingleDeleteFile({{0, 1, 2, 3}});
-  // Delete the first and last row in each batch (10000 rows per batch)
-  assertSingleBaseFileSingleDeleteFile({{0, 9999, 10000, 19999}});
-  // Delete several rows in the second batch (10000 rows per batch)
-  assertSingleBaseFileSingleDeleteFile({{10000, 10002, 19999}});
-  // Delete random rows
-  assertSingleBaseFileSingleDeleteFile({makeRandomIncreasingValues(0, 20000)});
-  // Delete 0 rows
-  assertSingleBaseFileSingleDeleteFile({});
-  // Delete all rows
-  assertSingleBaseFileSingleDeleteFile(
-      {makeContinuousIncreasingValues(0, 20000)});
-  // Delete rows that don't exist
-  assertSingleBaseFileSingleDeleteFile({{20000, 29999}});
-}
-
-/// This test creates 3 base data files, only the middle one has corresponding
-/// delete positions. The parameter passed to
-/// assertSingleBaseFileSingleDeleteFile is the delete positions.for the middle
-/// base file.
-TEST_F(HiveIcebergTest, multipleBaseFilesSinglePositionalDeleteFile) {
-  folly::SingletonVault::singleton()->registrationComplete();
-
-  assertMultipleBaseFileSingleDeleteFile({0, 1, 2, 3});
-  assertMultipleBaseFileSingleDeleteFile({0, 9999, 10000, 19999});
-  assertMultipleBaseFileSingleDeleteFile({10000, 10002, 19999});
-  assertMultipleBaseFileSingleDeleteFile({10000, 10002, 19999});
-  assertMultipleBaseFileSingleDeleteFile(
-      makeRandomIncreasingValues(0, rowCount));
-  assertMultipleBaseFileSingleDeleteFile({});
-  assertMultipleBaseFileSingleDeleteFile(
-      makeContinuousIncreasingValues(0, rowCount));
-}
-
-/// This test creates one base data file/split with multiple delete files. The
-/// parameter passed to assertSingleBaseFileMultipleDeleteFiles is the vector of
-/// delete files. Each leaf vector represents the delete positions in that
-/// delete file.
-TEST_F(HiveIcebergTest, singleBaseFileMultiplePositionalDeleteFiles) {
-  folly::SingletonVault::singleton()->registrationComplete();
-
-  // Delete row 0, 1, 2, 3 from the first batch out of two.
-  assertSingleBaseFileMultipleDeleteFiles({{1}, {2}, {3}, {4}});
-  // Delete the first and last row in each batch (10000 rows per batch).
-  assertSingleBaseFileMultipleDeleteFiles({{0}, {9999}, {10000}, {19999}});
-
-  assertSingleBaseFileMultipleDeleteFiles({{500, 21000}});
-
-  assertSingleBaseFileMultipleDeleteFiles(
-      {makeRandomIncreasingValues(0, 10000),
-       makeRandomIncreasingValues(10000, 20000),
-       makeRandomIncreasingValues(5000, 15000)});
-
-  assertSingleBaseFileMultipleDeleteFiles(
-      {makeContinuousIncreasingValues(0, 10000),
-       makeContinuousIncreasingValues(10000, 20000)});
-
-  assertSingleBaseFileMultipleDeleteFiles(
-      {makeContinuousIncreasingValues(0, 10000),
-       makeContinuousIncreasingValues(10000, 20000),
-       makeRandomIncreasingValues(5000, 15000)});
-
-  assertSingleBaseFileMultipleDeleteFiles(
-      {makeContinuousIncreasingValues(0, 20000),
-       makeContinuousIncreasingValues(0, 20000)});
-
-  assertSingleBaseFileMultipleDeleteFiles(
-      {makeRandomIncreasingValues(0, 20000),
-       {},
-       makeRandomIncreasingValues(5000, 15000)});
-
-  assertSingleBaseFileMultipleDeleteFiles({{}, {}});
-}
-
-/// This test creates 2 base data files, and 1 or 2 delete files, with unaligned
-/// RowGroup boundaries
-TEST_F(HiveIcebergTest, multipleBaseFileMultiplePositionalDeleteFiles) {
-  folly::SingletonVault::singleton()->registrationComplete();
-
-  std::map<std::string, std::vector<int64_t>> rowGroupSizesForFiles;
-  std::unordered_map<
-      std::string,
-      std::multimap<std::string, std::vector<int64_t>>>
-      deleteFilesForBaseDatafiles;
-
-  // Create two data files, each with two RowGroups
-  rowGroupSizesForFiles["data_file_1"] = {100, 85};
-  rowGroupSizesForFiles["data_file_2"] = {99, 1};
-
-  // Delete 3 rows from the first RowGroup in data_file_1
-  deleteFilesForBaseDatafiles["delete_file_1"] = {{"data_file_1", {0, 1, 99}}};
-  assertPositionalDeletes(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
-
-  // Delete 3 rows from the second RowGroup in data_file_1
-  deleteFilesForBaseDatafiles["delete_file_1"] = {
-      {"data_file_1", {100, 101, 184}}};
-  assertPositionalDeletes(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
-
-  // Delete random rows from the both RowGroups in data_file_1
-  deleteFilesForBaseDatafiles["delete_file_1"] = {
-      {"data_file_1", makeRandomIncreasingValues(0, 185)}};
-  assertPositionalDeletes(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
-
-  // Delete all rows in data_file_1
-  deleteFilesForBaseDatafiles["delete_file_1"] = {
-      {"data_file_1", makeContinuousIncreasingValues(0, 185)}};
-  assertPositionalDeletes(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
-  //
-  // Delete non-existent rows from data_file_1
-  deleteFilesForBaseDatafiles["delete_file_1"] = {
-      {"data_file_1", makeRandomIncreasingValues(186, 300)}};
-  assertPositionalDeletes(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
-
-  // Delete several rows from both RowGroups in both data files
-  deleteFilesForBaseDatafiles.clear();
-  deleteFilesForBaseDatafiles["delete_file_1"] = {
-      {"data_file_1", {0, 100, 102, 184}}, {"data_file_2", {1, 98, 99}}};
-  assertPositionalDeletes(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
-
-  // The delete file delete_file_1 contains 3 RowGroups itself, with the first 3
-  // deleting some repeating rows in data_file_1, and the last 2 RowGroups
-  // deleting some  repeating rows in data_file_2
-  deleteFilesForBaseDatafiles.clear();
-  deleteFilesForBaseDatafiles["delete_file_1"] = {
-      {"data_file_1", {0, 1, 2, 3}},
-      {"data_file_1", {1, 2, 3, 4}},
-      {"data_file_1", makeRandomIncreasingValues(0, 185)},
-      {"data_file_2", {1, 3, 5, 7}},
-      {"data_file_2", makeRandomIncreasingValues(0, 100)}};
-  assertPositionalDeletes(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
-
-  // delete_file_2 contains non-overlapping delete rows for each data files in
-  // each RowGroup
-  deleteFilesForBaseDatafiles.clear();
-  deleteFilesForBaseDatafiles["delete_file_1"] = {
-      {"data_file_1", {0, 1, 2, 3}}, {"data_file_2", {1, 3, 5, 7}}};
-  deleteFilesForBaseDatafiles["delete_file_2"] = {
-      {"data_file_1", {1, 2, 3, 4}},
-      {"data_file_1", {98, 99, 100, 101, 184}},
-      {"data_file_2", {3, 5, 7, 9}},
-      {"data_file_2", {98, 99, 100}}};
-  assertPositionalDeletes(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
-
-  // Two delete files each containing overlapping delete rows for both data
-  // files
-  deleteFilesForBaseDatafiles.clear();
-  deleteFilesForBaseDatafiles["delete_file_1"] = {
-      {"data_file_1", makeRandomIncreasingValues(0, 185)},
-      {"data_file_2", makeRandomIncreasingValues(0, 100)}};
-  deleteFilesForBaseDatafiles["delete_file_2"] = {
-      {"data_file_1", makeRandomIncreasingValues(10, 120)},
-      {"data_file_2", makeRandomIncreasingValues(50, 100)}};
-  assertPositionalDeletes(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
-}
-
-TEST_F(HiveIcebergTest, positionalDeletesMultipleSplits) {
-  folly::SingletonVault::singleton()->registrationComplete();
-
-  assertMultipleSplits({1, 2, 3, 4}, 10, 5);
-  assertMultipleSplits({1, 2, 3, 4}, 10, 0);
-  assertMultipleSplits({1, 2, 3, 4}, 10, 10);
-  assertMultipleSplits({0, 9999, 10000, 19999}, 10, 3);
-  assertMultipleSplits(makeRandomIncreasingValues(0, 20000), 10, 3);
-  assertMultipleSplits(makeContinuousIncreasingValues(0, 20000), 10, 3);
-  assertMultipleSplits({}, 10, 3);
-
-  assertMultipleSplits({1, 2, 3, 4}, 10, 5, 30000, 3);
-  assertPositionalDeletes(
-      {
-          {"data_file_0", {500}},
-          {"data_file_1", {10000, 10000}},
-          {"data_file_2", {500}},
-      },
-      {{"delete_file_1",
-        {{"data_file_1", makeRandomIncreasingValues(0, 20000)}}}},
-      0,
-      3);
-
-  // Include only upper bound(which is exclusive) in delete positions for the
-  // second 10k batch of rows.
-  assertMultipleSplits({1000, 9000, 20000}, 1, 0, 20000, 3);
-}
-
-TEST_F(HiveIcebergTest, schemaEvolutionRemoveColumn) {
+TEST_F(IcebergReadTest, schemaEvolutionRemoveColumn) {
+  // Write data file with old schema (c0, c1, c2).
   auto oldRowType = ROW({"c0", "c1", "c2"}, {BIGINT(), INTEGER(), VARCHAR()});
   auto newRowType = ROW({"c0", "c2"}, {BIGINT(), VARCHAR()});
 
-  // Write data file with old schema (c0, c1, c2).
-  std::vector<RowVectorPtr> dataVectors;
-  dataVectors.push_back(makeRowVector(
+  std::vector<RowVectorPtr> dataVectors = {makeRowVector(
       oldRowType->names(),
       {
           makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
           makeFlatVector<int32_t>({10, 20, 30, 40, 50}),
           makeFlatVector<std::string>({"a", "b", "c", "d", "e"}),
-      }));
-
+      })};
   auto dataFilePath = TempFilePath::create();
   writeToFile(dataFilePath->getPath(), dataVectors);
 
-  auto icebergSplits = makeIcebergSplits(dataFilePath->getPath());
-
-  // Expected result: c0 and c2 have values, c1 is not present.
-  std::vector<RowVectorPtr> expectedVectors;
-  expectedVectors.push_back(makeRowVector(
+  std::vector<RowVectorPtr> expectedVectors = {makeRowVector(
       newRowType->names(),
-      {
-          dataVectors[0]->childAt(0),
-          dataVectors[0]->childAt(2),
-      }));
+      {dataVectors[0]->childAt(0), dataVectors[0]->childAt(2)})};
 
   // Read with new schema (c0 and c2 only, c1 removed).
-  auto plan = PlanBuilder()
-                  .startTableScan()
-                  .connectorId(kIcebergConnectorId)
-                  .outputType(newRowType)
-                  .endTableScan()
-                  .planNode();
-  AssertQueryBuilder(plan).splits(icebergSplits).assertResults(expectedVectors);
+  assertTableScan(
+      newRowType, makeIcebergSplits(dataFilePath->getPath()), expectedVectors);
 }
 
-TEST_F(HiveIcebergTest, schemaEvolutionAddColumns) {
+TEST_F(IcebergReadTest, schemaEvolutionAddColumns) {
+  // Write data file with old schema (only c0).
   auto oldRowType = ROW({"c0"}, {BIGINT()});
   auto newRowType = ROW({"c0", "c1", "c2"}, {BIGINT(), INTEGER(), VARCHAR()});
 
-  // Write data file with old schema (only c0).
-  std::vector<RowVectorPtr> dataVectors;
-  dataVectors.push_back(makeRowVector({
-      makeFlatVector<int64_t>({100, 200, 300}),
-  }));
+  std::vector<RowVectorPtr> dataVectors = {
+      makeRowVector({makeFlatVector<int64_t>({100, 200, 300})})};
   auto dataFilePath = TempFilePath::create();
   writeToFile(dataFilePath->getPath(), dataVectors);
-  auto icebergSplits = makeIcebergSplits(dataFilePath->getPath());
 
-  // Expected result: c0 has values, c1 and c2 are NULL.
-  std::vector<RowVectorPtr> expectedVectors;
-  expectedVectors.push_back(makeRowVector({
-      dataVectors[0]->childAt(0),
-      makeNullConstant(TypeKind::INTEGER, 3),
-      makeNullConstant(TypeKind::VARCHAR, 3),
-  }));
+  std::vector<RowVectorPtr> expectedVectors = {makeRowVector(
+      {dataVectors[0]->childAt(0),
+       makeNullConstant(TypeKind::INTEGER, 3),
+       makeNullConstant(TypeKind::VARCHAR, 3)})};
 
   // Read with new schema (c0, c1, and c2).
-  auto plan = PlanBuilder()
-                  .startTableScan()
-                  .connectorId(kIcebergConnectorId)
-                  .outputType(newRowType)
-                  .dataColumns(newRowType)
-                  .endTableScan()
-                  .planNode();
-  AssertQueryBuilder(plan).splits(icebergSplits).assertResults(expectedVectors);
+  assertTableScan(
+      newRowType,
+      makeIcebergSplits(dataFilePath->getPath()),
+      expectedVectors,
+      newRowType);
 }
 
-// Test Iceberg V3 initial-default: a column added after data files were written
-// should return its initial-default value (not NULL) for those historical rows.
-TEST_F(HiveIcebergTest, addColumnWithDefault) {
+TEST_F(IcebergReadTest, addColumnWithDefault) {
+  // Test Iceberg V3 initial-default: a column added after data files were
+  // written should return its initial-default value, not NULL.
   auto newRowType = ROW({"c0", "country"}, {BIGINT(), VARCHAR()});
-
-  std::vector<RowVectorPtr> dataVectors;
-  dataVectors.push_back(makeRowVector({makeFlatVector<int64_t>({1, 2, 3})}));
-
-  ColumnHandleMap assignments;
-  assignments["c0"] = makeC0Handle();
-  assignments["country"] = makeIcebergHandle("country", VARCHAR(), 2, "IN");
-
-  std::vector<RowVectorPtr> expectedVectors;
-  expectedVectors.push_back(makeRowVector(
-      newRowType->names(),
-      {dataVectors[0]->childAt(0),
-       makeFlatVector<std::string>({"IN", "IN", "IN"})}));
+  auto dataVectors = makeSingleBigintData({1, 2, 3});
+  auto assignments = makeAssignments(
+      {{"c0", "c0", BIGINT(), 1}, {"country", "country", VARCHAR(), 2, "IN"}});
+  auto expectedVectors = makeBigintAndVarcharExpected(
+      newRowType->names(), dataVectors[0], {"IN", "IN", "IN"});
 
   assertDefaultValues(
       newRowType, newRowType, assignments, dataVectors, expectedVectors);
 }
 
-TEST_F(HiveIcebergTest, addColumnWithDefaultAndAlias) {
+TEST_F(IcebergReadTest, addColumnWithDefaultAndAlias) {
   auto outputType = ROW({"c0", "region"}, {BIGINT(), VARCHAR()});
   auto dataColumns = ROW({"c0", "country"}, {BIGINT(), VARCHAR()});
-
-  std::vector<RowVectorPtr> dataVectors;
-  dataVectors.push_back(makeRowVector({makeFlatVector<int64_t>({1, 2, 3})}));
-
-  ColumnHandleMap assignments;
-  assignments["c0"] = makeC0Handle();
-  // Key is "region" (alias), but handle refers to "country" (table column)
+  auto dataVectors = makeSingleBigintData({1, 2, 3});
+  auto assignments = makeAssignments({{"c0", "c0", BIGINT(), 1}});
+  // Key is "region" (alias), but handle refers to "country" (table column).
   assignments["region"] = makeIcebergHandle("country", VARCHAR(), 2, "IN");
-
-  std::vector<RowVectorPtr> expectedVectors;
-  expectedVectors.push_back(makeRowVector(
-      outputType->names(),
-      {dataVectors[0]->childAt(0),
-       makeFlatVector<std::string>({"IN", "IN", "IN"})}));
+  auto expectedVectors = makeBigintAndVarcharExpected(
+      outputType->names(), dataVectors[0], {"IN", "IN", "IN"});
 
   assertDefaultValues(
       outputType, dataColumns, assignments, dataVectors, expectedVectors);
 }
 
-TEST_F(HiveIcebergTest, fileValueOverridesDefault) {
+TEST_F(IcebergReadTest, fileValueOverridesDefault) {
   auto rowType = ROW({"c0", "country"}, {BIGINT(), VARCHAR()});
 
-  std::vector<RowVectorPtr> dataVectors;
-  dataVectors.push_back(makeRowVector(
+  std::vector<RowVectorPtr> dataVectors = {makeRowVector(
       {makeFlatVector<int64_t>({1, 2, 3}),
-       makeFlatVector<std::string>({"US", "UK", "CA"})}));
+       makeFlatVector<std::string>({"US", "UK", "CA"})})};
 
   ColumnHandleMap assignments;
-  assignments["c0"] = makeC0Handle();
+  assignments["c0"] = makeIcebergHandle("c0", BIGINT(), 1);
   assignments["country"] = makeIcebergHandle("country", VARCHAR(), 2, "IN");
 
-  // Expected: file values ("US", "UK", "CA"), NOT the default "IN"
-  std::vector<RowVectorPtr> expectedVectors;
-  expectedVectors.push_back(makeRowVector(
+  // Expected: file values ("US", "UK", "CA"), not the default "IN".
+  std::vector<RowVectorPtr> expectedVectors = {makeRowVector(
       rowType->names(),
-      {dataVectors[0]->childAt(0), dataVectors[0]->childAt(1)}));
+      {dataVectors[0]->childAt(0), dataVectors[0]->childAt(1)})};
 
   assertDefaultValues(
       rowType, rowType, assignments, dataVectors, expectedVectors);
 }
 
-TEST_F(HiveIcebergTest, addColumnWithDefaultAllTypes) {
+TEST_F(IcebergReadTest, addColumnWithDefaultAllTypes) {
   auto newRowType =
       ROW({"c0",
            "tiny_val",
@@ -1159,11 +320,11 @@ TEST_F(HiveIcebergTest, addColumnWithDefaultAllTypes) {
            DATE(),
            TIMESTAMP()});
 
-  std::vector<RowVectorPtr> dataVectors;
-  dataVectors.push_back(makeRowVector({makeFlatVector<int64_t>({1, 2, 3})}));
+  std::vector<RowVectorPtr> dataVectors = {
+      makeRowVector({makeFlatVector<int64_t>({1, 2, 3})})};
 
   ColumnHandleMap assignments;
-  assignments["c0"] = makeC0Handle();
+  assignments["c0"] = makeIcebergHandle("c0", BIGINT(), 1);
   assignments["tiny_val"] = makeIcebergHandle("tiny_val", TINYINT(), 2, "10");
   assignments["small_val"] =
       makeIcebergHandle("small_val", SMALLINT(), 3, "100");
@@ -1187,15 +348,14 @@ TEST_F(HiveIcebergTest, addColumnWithDefaultAllTypes) {
   assignments["timestamp_val"] = makeIcebergHandle(
       "timestamp_val", TIMESTAMP(), 13, "2024-01-15 10:30:00");
 
-  std::vector<RowVectorPtr> expectedVectors;
-  expectedVectors.push_back(makeRowVector(
+  std::vector<RowVectorPtr> expectedVectors = {makeRowVector(
       newRowType->names(),
       {dataVectors[0]->childAt(0),
        makeFlatVector<int8_t>({10, 10, 10}),
        makeFlatVector<int16_t>({100, 100, 100}),
        makeFlatVector<int32_t>({1000, 1000, 1000}),
        makeFlatVector<int64_t>({10000, 10000, 10000}),
-       makeFlatVector<float>({3.14f, 3.14f, 3.14f}),
+       makeFlatVector<float>({3.14F, 3.14F, 3.14F}),
        makeFlatVector<double>({2.718, 2.718, 2.718}),
        makeFlatVector<bool>({true, true, true}),
        makeFlatVector<std::string>(
@@ -1210,7 +370,7 @@ TEST_F(HiveIcebergTest, addColumnWithDefaultAllTypes) {
        makeFlatVector<Timestamp>(
            {Timestamp(1705314600, 0),
             Timestamp(1705314600, 0),
-            Timestamp(1705314600, 0)})}));
+            Timestamp(1705314600, 0)})})};
 
   assertDefaultValues(
       newRowType,
@@ -1221,338 +381,184 @@ TEST_F(HiveIcebergTest, addColumnWithDefaultAllTypes) {
       {{HiveConfig::kReadTimestampPartitionValueAsLocalTimeSession, "false"}});
 }
 
-TEST_F(HiveIcebergTest, addColumnWithInvalidDefault) {
+TEST_F(IcebergReadTest, addColumnWithInvalidDefault) {
   auto newRowType = ROW({"c0", "age"}, {BIGINT(), INTEGER()});
 
-  std::vector<RowVectorPtr> dataVectors;
-  dataVectors.push_back(makeRowVector({makeFlatVector<int64_t>({1, 2, 3})}));
+  std::vector<RowVectorPtr> dataVectors = {
+      makeRowVector({makeFlatVector<int64_t>({1, 2, 3})})};
   auto dataFilePath = TempFilePath::create();
   writeToFile(dataFilePath->getPath(), dataVectors);
-  auto icebergSplits = makeIcebergSplits(dataFilePath->getPath());
 
   ColumnHandleMap assignments;
-  assignments["c0"] = makeC0Handle();
+  assignments["c0"] = makeIcebergHandle("c0", BIGINT(), 1);
   assignments["age"] = makeIcebergHandle("age", INTEGER(), 2, "IN");
 
-  auto plan = PlanBuilder()
-                  .startTableScan()
-                  .connectorId(kIcebergConnectorId)
-                  .outputType(newRowType)
-                  .dataColumns(newRowType)
-                  .assignments(assignments)
-                  .endTableScan()
-                  .planNode();
-
   VELOX_ASSERT_THROW(
-      AssertQueryBuilder(plan).splits(icebergSplits).copyResults(pool()),
+      assertTableScan(
+          newRowType,
+          makeIcebergSplits(dataFilePath->getPath()),
+          {},
+          newRowType,
+          assignments),
       "Invalid");
 }
 
-TEST_F(HiveIcebergTest, addColumnWithEmptyStringDefault) {
+TEST_F(IcebergReadTest, addColumnWithEmptyStringDefault) {
   auto newRowType = ROW({"c0", "name"}, {BIGINT(), VARCHAR()});
-
-  std::vector<RowVectorPtr> dataVectors;
-  dataVectors.push_back(makeRowVector({makeFlatVector<int64_t>({1, 2, 3})}));
-
-  ColumnHandleMap assignments;
-  assignments["c0"] = makeC0Handle();
-  assignments["name"] = makeIcebergHandle("name", VARCHAR(), 2, "");
-
-  std::vector<RowVectorPtr> expectedVectors;
-  expectedVectors.push_back(makeRowVector(
-      newRowType->names(),
-      {dataVectors[0]->childAt(0), makeFlatVector<std::string>({"", "", ""})}));
+  auto dataVectors = makeSingleBigintData({1, 2, 3});
+  auto assignments = makeAssignments(
+      {{"c0", "c0", BIGINT(), 1}, {"name", "name", VARCHAR(), 2, ""}});
+  auto expectedVectors = makeBigintAndVarcharExpected(
+      newRowType->names(), dataVectors[0], {"", "", ""});
 
   assertDefaultValues(
-      newRowType, newRowType, assignments, dataVectors, expectedVectors, {});
+      newRowType, newRowType, assignments, dataVectors, expectedVectors);
 }
 
-TEST_F(HiveIcebergTest, defaultValueWithDeletesAndFilters) {
+TEST_F(IcebergReadTest, defaultValueWithDeletesAndFilters) {
   auto newRowType = ROW({"c0", "country"}, {BIGINT(), VARCHAR()});
-
-  // Write data file with old schema (only c0) containing rows 1-10.
-  std::vector<RowVectorPtr> dataVectors;
-  dataVectors.push_back(makeRowVector(
-      {makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6, 7, 8, 9, 10})}));
+  std::vector<RowVectorPtr> dataVectors = {makeRowVector(
+      {makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6, 7, 8, 9, 10})})};
   auto dataFilePath = TempFilePath::create();
+  // Write data file with old schema (only c0) containing rows 1-10.
   writeToFile(dataFilePath->getPath(), dataVectors);
 
-  // Create delete file that deletes positions 1, 3, 5 (rows 2, 4, 6).
   auto deleteFilePath = TempFilePath::create();
-  std::vector<int64_t> deletePositions = {1, 3, 5};
+  // Create delete file that deletes positions 1, 3, 5 (rows 2, 4, 6).
   auto pathColumn = IcebergMetadataColumn::icebergDeleteFilePathColumn();
   auto posColumn = IcebergMetadataColumn::icebergDeletePosColumn();
   writeToFile(
       deleteFilePath->getPath(),
       {makeRowVector(
           {pathColumn->name, posColumn->name},
-          {makeFlatVector<std::string>(
-               3, [&](vector_size_t) { return dataFilePath->getPath(); }),
-           makeFlatVector<int64_t>(deletePositions)})});
-
-  IcebergDeleteFile icebergDeleteFile(
+          {
+              makeFlatVector<std::string>(
+                  static_cast<vector_size_t>(3),
+                  [&](vector_size_t) { return dataFilePath->getPath(); }),
+              makeFlatVector<int64_t>({1, 3, 5}),
+          })});
+  IcebergDeleteFile deleteFile(
       FileContent::kPositionalDeletes,
       deleteFilePath->getPath(),
-      dwio::common::FileFormat::DWRF,
+      fileFormat_,
       3,
-      getTestFileSize(deleteFilePath->getPath()));
+      this->getFileSize(deleteFilePath->getPath()));
 
   ColumnHandleMap assignments;
-  assignments["c0"] = makeC0Handle();
-  assignments["country"] = makeIcebergHandle("country", VARCHAR(), 2, "IN");
+  assignments = makeAssignments(
+      {{"c0", "c0", BIGINT(), 1}, {"country", "country", VARCHAR(), 2, "IN"}});
 
-  // Test 1: No filter - rows 1,3,5,7,8,9,10 (after deletes: 2,4,6 removed)
-  {
-    auto icebergSplits =
-        makeIcebergSplits(dataFilePath->getPath(), {icebergDeleteFile}, {}, 1);
-    std::vector<RowVectorPtr> expectedVectors;
-    expectedVectors.push_back(makeRowVector(
+  const auto makeSplits = [&]() {
+    return makeIcebergSplits(dataFilePath->getPath(), {deleteFile});
+  };
+  const auto makeExpected = [&](const std::vector<int64_t>& values) {
+    return std::vector<RowVectorPtr>{makeRowVector(
         newRowType->names(),
-        {makeFlatVector<int64_t>({1, 3, 5, 7, 8, 9, 10}),
+        {makeFlatVector<int64_t>(values),
          makeFlatVector<std::string>(
-             {"IN", "IN", "IN", "IN", "IN", "IN", "IN"})}));
+             static_cast<vector_size_t>(values.size()),
+             [](vector_size_t) { return "IN"; })})};
+  };
 
-    auto plan = PlanBuilder()
-                    .startTableScan()
-                    .connectorId(kIcebergConnectorId)
-                    .outputType(newRowType)
-                    .dataColumns(newRowType)
-                    .assignments(assignments)
-                    .endTableScan()
-                    .planNode();
-    AssertQueryBuilder(plan)
-        .splits(icebergSplits)
-        .assertResults(expectedVectors);
-  }
-
-  // Test 2: Filter on file column (c0 > 5) with deletes
-  // After deletes: 1,3,5,7,8,9,10 remain. Filter c0 > 5: 7,8,9,10
-  {
-    auto icebergSplits =
-        makeIcebergSplits(dataFilePath->getPath(), {icebergDeleteFile}, {}, 1);
-    std::vector<RowVectorPtr> expectedVectors;
-    expectedVectors.push_back(makeRowVector(
-        newRowType->names(),
-        {makeFlatVector<int64_t>({7, 8, 9, 10}),
-         makeFlatVector<std::string>({"IN", "IN", "IN", "IN"})}));
-
-    auto plan = PlanBuilder()
-                    .startTableScan()
-                    .connectorId(kIcebergConnectorId)
-                    .outputType(newRowType)
-                    .dataColumns(newRowType)
-                    .assignments(assignments)
-                    .endTableScan()
-                    .filter("c0 > 5")
-                    .planNode();
-    AssertQueryBuilder(plan)
-        .splits(icebergSplits)
-        .assertResults(expectedVectors);
-  }
-
-  // Test 3: Filter on default value column (country = 'IN') with deletes
-  // All remaining rows should match since default is 'IN'
-  {
-    auto icebergSplits =
-        makeIcebergSplits(dataFilePath->getPath(), {icebergDeleteFile}, {}, 1);
-    std::vector<RowVectorPtr> expectedVectors;
-    expectedVectors.push_back(makeRowVector(
-        newRowType->names(),
-        {makeFlatVector<int64_t>({1, 3, 5, 7, 8, 9, 10}),
-         makeFlatVector<std::string>(
-             {"IN", "IN", "IN", "IN", "IN", "IN", "IN"})}));
-
-    auto plan = PlanBuilder()
-                    .startTableScan()
-                    .connectorId(kIcebergConnectorId)
-                    .outputType(newRowType)
-                    .dataColumns(newRowType)
-                    .assignments(assignments)
-                    .endTableScan()
-                    .filter("country = 'IN'")
-                    .planNode();
-    AssertQueryBuilder(plan)
-        .splits(icebergSplits)
-        .assertResults(expectedVectors);
-  }
-
-  // Test 4: Combined filter (c0 > 3 AND country = 'IN') with deletes
-  // After deletes: 1,3,5,7,8,9,10. Filter c0 > 3: 5,7,8,9,10
-  {
-    auto icebergSplits =
-        makeIcebergSplits(dataFilePath->getPath(), {icebergDeleteFile}, {}, 1);
-    std::vector<RowVectorPtr> expectedVectors;
-    expectedVectors.push_back(makeRowVector(
-        newRowType->names(),
-        {makeFlatVector<int64_t>({5, 7, 8, 9, 10}),
-         makeFlatVector<std::string>({"IN", "IN", "IN", "IN", "IN"})}));
-
-    auto plan = PlanBuilder()
-                    .startTableScan()
-                    .connectorId(kIcebergConnectorId)
-                    .outputType(newRowType)
-                    .dataColumns(newRowType)
-                    .assignments(assignments)
-                    .endTableScan()
-                    .filter("c0 > 3 AND country = 'IN'")
-                    .planNode();
-    AssertQueryBuilder(plan)
-        .splits(icebergSplits)
-        .assertResults(expectedVectors);
-  }
+  assertTableScan(
+      newRowType,
+      makeSplits(),
+      // Test 1: No filter. After deletes, rows 1, 3, 5, 7, 8, 9, 10 remain.
+      makeExpected({1, 3, 5, 7, 8, 9, 10}),
+      newRowType,
+      assignments);
+  assertTableScan(
+      newRowType,
+      makeSplits(),
+      // Test 2: Filter on file column (c0 > 5) with deletes.
+      makeExpected({7, 8, 9, 10}),
+      newRowType,
+      assignments,
+      "c0 > 5");
+  assertTableScan(
+      newRowType,
+      makeSplits(),
+      // Test 3: Filter on default value column (country = 'IN') with deletes.
+      makeExpected({1, 3, 5, 7, 8, 9, 10}),
+      newRowType,
+      assignments,
+      "country = 'IN'");
+  assertTableScan(
+      newRowType,
+      makeSplits(),
+      // Test 4: Combined filter (c0 > 3 AND country = 'IN') with deletes.
+      makeExpected({5, 7, 8, 9, 10}),
+      newRowType,
+      assignments,
+      "c0 > 3 AND country = 'IN'");
 }
 
-// Test reading partition columns from Hive-migrated tables.
-// This tests the adaptColumns method handling partition columns that are not
-// stored in the data file but provided via partitionKeys map.
-// This scenario occurs when reading Hive-written data files where partition
-// column values are stored in partition metadata rather than in the data file.
-TEST_F(HiveIcebergTest, partitionColumnsFromHive) {
+TEST_F(IcebergReadTest, partitionColumnsFromHive) {
+  // Test reading partition columns from Hive-migrated tables.
+  // This tests the adaptColumns method handling partition columns that are not
+  // stored in the data file but provided via partitionKeys map.
+  // This scenario occurs when reading Hive-written data files where partition
+  // column values are stored in partition metadata rather than in the data
+  // file.
   auto fileRowType = ROW({"c0", "c1"}, {BIGINT(), INTEGER()});
   auto tableRowType =
       ROW({"c0", "c1", "region", "year"},
           {BIGINT(), INTEGER(), VARCHAR(), INTEGER()});
 
-  // Write data file with only non-partition columns (c0, c1).
-  std::vector<RowVectorPtr> dataVectors;
-  dataVectors.push_back(makeRowVector({
-      makeFlatVector<int64_t>({1, 2, 3}),
-      makeFlatVector<int32_t>({10, 20, 30}),
-  }));
+  std::vector<RowVectorPtr> dataVectors = {makeRowVector(
+      {makeFlatVector<int64_t>({1, 2, 3}),
+       makeFlatVector<int32_t>({10, 20, 30})})};
   auto dataFilePath = TempFilePath::create();
+  // Write data file with only non-partition columns (c0, c1).
   writeToFile(dataFilePath->getPath(), dataVectors);
 
   // Set partition keys for region and year.
-  std::unordered_map<std::string, std::optional<std::string>> partitionKeys;
-  partitionKeys["region"] = "US";
-  partitionKeys["year"] = "2025";
+  std::unordered_map<std::string, std::optional<std::string>> partitionKeys = {
+      {"region", "US"},
+      {"year", "2025"},
+  };
 
-  auto icebergSplits =
-      makeIcebergSplits(dataFilePath->getPath(), {}, partitionKeys);
-  auto assignments = makeColumnHandles(tableRowType, {2, 3});
-
-  // Expected result: c0 and c1 from file, region and year from partition keys.
-  std::vector<RowVectorPtr> expectedVectors;
-  expectedVectors.push_back(makeRowVector(
+  std::vector<RowVectorPtr> expectedVectors = {makeRowVector(
       tableRowType->names(),
       {
           dataVectors[0]->childAt(0),
           dataVectors[0]->childAt(1),
           makeFlatVector<std::string>({"US", "US", "US"}),
           makeFlatVector<int32_t>({2025, 2025, 2025}),
-      }));
+      })};
 
-  // Read with table schema including partition columns.
-  auto plan = PlanBuilder()
-                  .startTableScan()
-                  .connectorId(kIcebergConnectorId)
-                  .outputType(tableRowType)
-                  .dataColumns(tableRowType)
-                  .assignments(assignments)
-                  .endTableScan()
-                  .planNode();
-  AssertQueryBuilder(plan).splits(icebergSplits).assertResults(expectedVectors);
+  assertTableScan(
+      tableRowType,
+      makeIcebergSplits(dataFilePath->getPath(), {}, partitionKeys),
+      expectedVectors,
+      tableRowType,
+      makeColumnHandles(tableRowType, {2, 3}));
 }
 
-// Test that positional delete files are skipped when their position upper bound
-// is before the split offset. When a delete file's upperBound is less than the
-// split's starting row, all deletes in that file are not relevant to this
-// split.
-TEST_F(HiveIcebergTest, skipDeleteFileByPositionUpperBound) {
-  folly::SingletonVault::singleton()->registrationComplete();
-
-  auto pathColumn = IcebergMetadataColumn::icebergDeleteFilePathColumn();
-  auto posColumn = IcebergMetadataColumn::icebergDeletePosColumn();
-
-  // Create a data file with 100 rows.
-  auto dataFilePath = TempFilePath::create();
-  std::vector<RowVectorPtr> dataVectors = {makeRowVector(
-      {makeFlatVector<int64_t>(makeContinuousIncreasingValues(0, 100))})};
-  writeToFile(dataFilePath->getPath(), dataVectors);
-
-  // Create a delete file targeting positions 0, 1, 2.
-  auto deleteFilePath = TempFilePath::create();
-  std::vector<RowVectorPtr> deleteVectors = {makeRowVector(
-      {pathColumn->name, posColumn->name},
-      {makeFlatVector<std::string>(
-           3, [&](auto) { return dataFilePath->getPath(); }),
-       makeFlatVector<int64_t>({0, 1, 2})})};
-  writeToFile(deleteFilePath->getPath(), deleteVectors);
-
-  // upperBound "2" is the max position in the delete file. Iceberg stores
-  // long bounds as 8-byte little-endian binary, then Base64 encodes them.
-  uint64_t upperBound = 2;
-  auto upperBoundLE = folly::Endian::little(upperBound);
-  auto encodedUpperBound = encoding::Base64::encode(
-      std::string_view(
-          reinterpret_cast<const char*>(&upperBoundLE), sizeof(upperBoundLE)));
-  IcebergDeleteFile deleteFile(
-      FileContent::kPositionalDeletes,
-      deleteFilePath->getPath(),
-      FileFormat::DWRF,
-      3,
-      getTestFileSize(deleteFilePath->getPath()),
-      {},
-      {},
-      {{posColumn->id, encodedUpperBound}});
-
-  auto plan = PlanBuilder()
-                  .startTableScan()
-                  .connectorId(kIcebergConnectorId)
-                  .outputType(ROW({"c0"}, {BIGINT()}))
-                  .endTableScan()
-                  .planNode();
-
-  // Create a split that starts at the middle of the file. The split offset
-  // will be greater than the delete file's upper bound (2), so the delete
-  // file should be skipped completely.
-  auto file = filesystems::getFileSystem(dataFilePath->getPath(), nullptr)
-                  ->openFileForRead(dataFilePath->getPath());
-  const int64_t fileSize = file->size();
-  std::vector<IcebergDeleteFile> deleteFiles = {deleteFile};
-  auto split = std::make_shared<HiveIcebergSplit>(
-      kIcebergConnectorId,
-      dataFilePath->getPath(),
-      FileFormat::DWRF,
-      static_cast<uint64_t>(fileSize / 2),
-      static_cast<uint64_t>(fileSize / 2),
-      std::unordered_map<std::string, std::optional<std::string>>{},
-      std::nullopt,
-      std::unordered_map<std::string, std::string>{},
-      std::shared_ptr<std::string>{},
-      true,
-      deleteFiles);
-
-  // The second half of the file should be returned with no rows deleted.
-  createDuckDbTable({makeRowVector(
-      {makeFlatVector<int64_t>(makeContinuousIncreasingValues(50, 50))})});
-  assertQuery(plan, {split}, "SELECT * FROM tmp", 0);
-}
-
-// Row lineage scenarios for _row_id and _last_updated_sequence_number:
-//   1. Pre-V3: no info columns, no physical columns → both null.
-//   2. V3 new insert: no physical columns; derived from info columns.
-//   3. V3 rewrite: physical values take precedence over info columns.
-//   4. Physical columns all null: falls back to info column derivation.
-//   5. Mixed null/non-null: null slots derived, non-null slots preserved.
-//   6. first_row_id = 0 is a valid value.
-//   7. Positional deletes: _row_id uses file-absolute positions.
-//   8. Subfield filter: _row_id uses file-absolute positions, not output
-//   indices.
-//   9. data_sequence_number without first_row_id: both _row_id and
-//      _last_updated_sequence_number are null.
-//  10. Physical lineage columns present with data_sequence_number but no
-//      first_row_id: both columns are null (spec requires null when
-//      first_row_id is absent, regardless of physical storage).
-TEST_F(HiveIcebergTest, rowLineage) {
-  folly::SingletonVault::singleton()->registrationComplete();
-
+TEST_F(IcebergReadTest, rowLineage) {
+  // Row lineage scenarios for _row_id and _last_updated_sequence_number:
+  //   1. Pre-V3: no info columns, no physical columns → both null.
+  //   2. V3 new insert: no physical columns; derived from info columns.
+  //   3. V3 rewrite: physical values take precedence over info columns.
+  //   4. Physical columns all null: falls back to info column derivation.
+  //   5. Mixed null/non-null: null slots derived, non-null slots preserved.
+  //   6. first_row_id = 0 is a valid value.
+  //   7. Positional deletes: _row_id uses file-absolute positions.
+  //   8. Subfield filter: _row_id uses file-absolute positions, not output
+  //   indices.
+  //   9. data_sequence_number without first_row_id: both _row_id and
+  //      _last_updated_sequence_number are null.
+  //  10. Physical lineage columns present with data_sequence_number but no
+  //      first_row_id: both columns are null (spec requires null when
+  //      first_row_id is absent, regardless of physical storage).
   static const std::vector<std::string> kOutputNames = {
       "c0", "_row_id", "_last_updated_sequence_number"};
 
   // 1. Pre-V3.
   assertRowLineage({
       .values = {1, 2, 3},
+      .deletePositions = {},
+      .subfieldFilter = "",
       .expectedVectors = {makeRowVector(
           kOutputNames,
           {
@@ -1569,6 +575,8 @@ TEST_F(HiveIcebergTest, rowLineage) {
       .values = {10, 20, 30},
       .firstRowId = 100,
       .dataSequenceNumber = 7,
+      .deletePositions = {},
+      .subfieldFilter = "",
       .expectedVectors = {makeRowVector(
           kOutputNames,
           {
@@ -1585,6 +593,8 @@ TEST_F(HiveIcebergTest, rowLineage) {
       .storedSequenceNumbers = {{3, 5, 3}},
       .firstRowId = 999,
       .dataSequenceNumber = 99,
+      .deletePositions = {},
+      .subfieldFilter = "",
       .expectedVectors = {makeRowVector(
           kOutputNames,
           {
@@ -1601,6 +611,8 @@ TEST_F(HiveIcebergTest, rowLineage) {
       .storedSequenceNumbers = {{std::nullopt, std::nullopt, std::nullopt}},
       .firstRowId = 50,
       .dataSequenceNumber = 42,
+      .deletePositions = {},
+      .subfieldFilter = "",
       .expectedVectors = {makeRowVector(
           kOutputNames,
           {
@@ -1612,16 +624,14 @@ TEST_F(HiveIcebergTest, rowLineage) {
 
   // 5. Mixed null/non-null: null slots derived from info columns, non-null
   // preserved.
-  //   pos 0: _row_id=null→10+0=10, seq_num=null→42
-  //   pos 1: _row_id=99,           seq_num=5
-  //   pos 2: _row_id=null→10+2=12, seq_num=null→42
-  //   pos 3: _row_id=77,           seq_num=10
   assertRowLineage({
       .values = {10, 20, 30, 40},
       .storedRowIds = {{std::nullopt, 99, std::nullopt, 77}},
       .storedSequenceNumbers = {{std::nullopt, 5, std::nullopt, 10}},
       .firstRowId = 10,
       .dataSequenceNumber = 42,
+      .deletePositions = {},
+      .subfieldFilter = "",
       .expectedVectors = {makeRowVector(
           kOutputNames,
           {
@@ -1636,6 +646,8 @@ TEST_F(HiveIcebergTest, rowLineage) {
       .values = {5, 6, 7},
       .firstRowId = 0,
       .dataSequenceNumber = 5,
+      .deletePositions = {},
+      .subfieldFilter = "",
       .expectedVectors = {makeRowVector(
           kOutputNames,
           {
@@ -1651,6 +663,7 @@ TEST_F(HiveIcebergTest, rowLineage) {
       .firstRowId = 200,
       .dataSequenceNumber = 42,
       .deletePositions = {1, 3},
+      .subfieldFilter = "",
       .expectedVectors = {makeRowVector(
           kOutputNames,
           {
@@ -1666,6 +679,7 @@ TEST_F(HiveIcebergTest, rowLineage) {
       .values = {10, 20, 30, 40, 50},
       .firstRowId = 100,
       .dataSequenceNumber = 15,
+      .deletePositions = {},
       .subfieldFilter = "c0 > 20",
       .expectedVectors = {makeRowVector(
           kOutputNames,
@@ -1681,6 +695,8 @@ TEST_F(HiveIcebergTest, rowLineage) {
   assertRowLineage({
       .values = {1, 2, 3},
       .dataSequenceNumber = 7,
+      .deletePositions = {},
+      .subfieldFilter = "",
       .expectedVectors = {makeRowVector(
           kOutputNames,
           {
@@ -1701,6 +717,8 @@ TEST_F(HiveIcebergTest, rowLineage) {
       .storedRowIds = {{500, 501, 502}},
       .storedSequenceNumbers = {{3, 5, 3}},
       .dataSequenceNumber = 7,
+      .deletePositions = {},
+      .subfieldFilter = "",
       .expectedVectors = {makeRowVector(
           kOutputNames,
           {
@@ -1718,26 +736,14 @@ TEST_F(HiveIcebergTest, rowLineage) {
 // infoColumns ($path, $spec_id, partition_data) plus the file row positions.
 // Mirrors the IcebergPageSourceProvider Java path that backs
 // MERGE_TARGET_ROW_ID_DATA.
-TEST_F(HiveIcebergTest, targetTableRowIdSynthesis) {
-  folly::SingletonVault::singleton()->registrationComplete();
-
+TEST_F(IcebergReadTest, targetTableRowIdSynthesis) {
   static const std::string kPartitionDataJson =
-      "{\"partitionValues\":[\"2024-01-01\"]}";
+      R"({"partitionValues":["2024-01-01"]})";
 
-  // Write a small data file containing only c0 (the synthetic row-id column
-  // never appears in the file).
   std::vector<RowVectorPtr> inputVectors = {
       makeRowVector({"c0"}, {makeFlatVector<int64_t>({10, 20, 30})})};
   auto dataFilePath = TempFilePath::create();
   writeToFile(dataFilePath->getPath(), inputVectors);
-
-  std::unordered_map<std::string, std::string> infoColumns = {
-      {IcebergMetadataColumn::kSpecIdInfoColumn, "7"},
-      {IcebergMetadataColumn::kPartitionDataInfoColumn, kPartitionDataJson},
-  };
-
-  auto split = makeIcebergSplitWithInfoColumns(
-      dataFilePath->getPath(), infoColumns, /*deleteFiles=*/{});
 
   const auto rowIdType =
       ROW({"file_path", "row_position", "spec_id", "partition_data"},
@@ -1745,18 +751,7 @@ TEST_F(HiveIcebergTest, targetTableRowIdSynthesis) {
   const auto outputType =
       ROW({"c0", IcebergMetadataColumn::kTargetTableRowIdColumnName},
           {BIGINT(), rowIdType});
-  const auto tableDataColumns = ROW({"c0"}, {BIGINT()});
 
-  auto plan = PlanBuilder()
-                  .startTableScan()
-                  .connectorId(kIcebergConnectorId)
-                  .outputType(outputType)
-                  .dataColumns(tableDataColumns)
-                  .endTableScan()
-                  .planNode();
-
-  // Contiguous case: row_position = file position [0, 1, 2]. file_path,
-  // spec_id, and partition_data are split-level constants.
   auto expected = makeRowVector(
       {"c0", IcebergMetadataColumn::kTargetTableRowIdColumnName},
       {
@@ -1765,330 +760,30 @@ TEST_F(HiveIcebergTest, targetTableRowIdSynthesis) {
               {"file_path", "row_position", "spec_id", "partition_data"},
               {
                   makeFlatVector<std::string>(
-                      3,
-                      [&](vector_size_t /*row*/) {
-                        return dataFilePath->getPath();
-                      }),
+                      static_cast<vector_size_t>(3),
+                      [&](vector_size_t) { return dataFilePath->getPath(); }),
                   makeFlatVector<int64_t>({0, 1, 2}),
                   makeFlatVector<int32_t>({7, 7, 7}),
                   makeFlatVector<std::string>(
-                      3,
-                      [&](vector_size_t /*row*/) {
-                        return kPartitionDataJson;
-                      }),
+                      static_cast<vector_size_t>(3),
+                      [&](vector_size_t) { return kPartitionDataJson; }),
               }),
       });
 
-  AssertQueryBuilder(plan).splits({split}).assertResults({expected});
-}
-
-#ifdef VELOX_ENABLE_PARQUET
-TEST_F(HiveIcebergTest, positionalDeleteFileWithRowGroupFilter) {
-  // This file contains three row groups, each with about 100 rows.
-  // Each row group has min/max values: [200, 299], [0, 99], [100, 199].
-  // The filter here is id >= 100, which will cause the parquet reader to filter
-  // out the middle row group ([0, 99]). This can lead to a mismatch between the
-  // baseReadOffset tracked by Iceberg's split reader and the actual offset,
-  // resulting in records in the position delete file being mapped to incorrect
-  // rows.
-  auto path = test::getDataFilePath(
-      "velox/connectors/hive/iceberg/tests", "examples/three_groups.parquet");
-  const auto deletedPositionSize = 100;
-  std::vector<int64_t> deletePositionsVec(
-      deletedPositionSize); // allocate 100 elements, [100, 199].
-  std::iota(deletePositionsVec.begin(), deletePositionsVec.end(), 100);
-  auto deleteFilePath = TempFilePath::create();
-  assertQuery(
-      PlanBuilder()
-          .startTableScan()
-          .connectorId(kIcebergConnectorId)
-          .outputType(ROW({"id"}, {BIGINT()}))
-          .remainingFilter("id >= 100")
-          .endTableScan()
-          .planNode(),
-
-      createParquetDeleteFileAndSplits(
-          path, deletePositionsVec, deletedPositionSize, deleteFilePath),
-      "SELECT i AS id FROM range(100, 300) AS t(i)",
-      0);
-}
-#endif
-
-// Sequence number filtering tests for positional deletes (Diff 2).
-// Per the Iceberg V2+ spec, a positional delete file should only apply to
-// data files whose dataSequenceNumber is strictly less than the delete file's.
-
-TEST_F(HiveIcebergTest, positionalDeleteSequenceNumberApplied) {
-  folly::SingletonVault::singleton()->registrationComplete();
-
-  auto pathColumn = IcebergMetadataColumn::icebergDeleteFilePathColumn();
-  auto posColumn = IcebergMetadataColumn::icebergDeletePosColumn();
-  auto rowType = ROW({"c0"}, {BIGINT()});
-
-  // Write base data file: c0 = [0, 1, 2, 3, 4].
-  auto dataFilePath = TempFilePath::create();
-  writeToFile(
-      dataFilePath->getPath(),
-      {makeRowVector({makeFlatVector<int64_t>({0, 1, 2, 3, 4})})});
-
-  // Write positional delete file targeting positions 1 and 3.
-  auto deleteFilePath = TempFilePath::create();
-  auto baseFilePath = dataFilePath->getPath();
-  writeToFile(
-      deleteFilePath->getPath(),
-      {makeRowVector(
-          {pathColumn->name, posColumn->name},
+  assertTableScan(
+      outputType,
+      {makeIcebergSplitWithInfoColumns(
+          dataFilePath->getPath(),
           {
-              makeFlatVector<std::string>(
-                  2, [&](vector_size_t) { return baseFilePath; }),
-              makeFlatVector<int64_t>({1, 3}),
-          })});
-
-  // Delete file seqNum=10 > data seqNum=5 → delete should be applied.
-  IcebergDeleteFile deleteFile(
-      FileContent::kPositionalDeletes,
-      deleteFilePath->getPath(),
-      dwio::common::FileFormat::DWRF,
-      2,
-      getTestFileSize(deleteFilePath->getPath()),
-      {},
-      {},
-      {},
-      /*dataSequenceNumber=*/10);
-
-  auto file = filesystems::getFileSystem(baseFilePath, nullptr)
-                  ->openFileForRead(baseFilePath);
-  auto split = std::make_shared<HiveIcebergSplit>(
-      kIcebergConnectorId,
-      baseFilePath,
-      dwio::common::FileFormat::DWRF,
-      0,
-      file->size(),
-      std::unordered_map<std::string, std::optional<std::string>>{},
-      std::nullopt,
-      std::unordered_map<std::string, std::string>{},
-      nullptr,
-      true,
-      std::vector<IcebergDeleteFile>{deleteFile},
-      std::unordered_map<std::string, std::string>{},
-      std::nullopt,
-      /*dataSequenceNumber=*/5);
-
-  auto plan = PlanBuilder()
-                  .startTableScan()
-                  .connectorId(kIcebergConnectorId)
-                  .outputType(rowType)
-                  .endTableScan()
-                  .planNode();
-
-  // Positions 1 and 3 deleted → remaining: [0, 2, 4].
-  auto expected = makeRowVector({makeFlatVector<int64_t>({0, 2, 4})});
-  AssertQueryBuilder(plan).split(split).assertResults({expected});
+              {IcebergMetadataColumn::kSpecIdInfoColumn, "7"},
+              {IcebergMetadataColumn::kPartitionDataInfoColumn,
+               kPartitionDataJson},
+          })},
+      {expected},
+      ROW({"c0"}, {BIGINT()}));
 }
 
-TEST_F(HiveIcebergTest, positionalDeleteSequenceNumberSkipped) {
-  folly::SingletonVault::singleton()->registrationComplete();
-
-  auto pathColumn = IcebergMetadataColumn::icebergDeleteFilePathColumn();
-  auto posColumn = IcebergMetadataColumn::icebergDeletePosColumn();
-  auto rowType = ROW({"c0"}, {BIGINT()});
-
-  auto dataFilePath = TempFilePath::create();
-  writeToFile(
-      dataFilePath->getPath(),
-      {makeRowVector({makeFlatVector<int64_t>({0, 1, 2, 3, 4})})});
-
-  auto deleteFilePath = TempFilePath::create();
-  auto baseFilePath = dataFilePath->getPath();
-  writeToFile(
-      deleteFilePath->getPath(),
-      {makeRowVector(
-          {pathColumn->name, posColumn->name},
-          {
-              makeFlatVector<std::string>(
-                  2, [&](vector_size_t) { return baseFilePath; }),
-              makeFlatVector<int64_t>({1, 3}),
-          })});
-
-  // Delete file seqNum=5 < data seqNum=10 → delete should be skipped.
-  IcebergDeleteFile deleteFile(
-      FileContent::kPositionalDeletes,
-      deleteFilePath->getPath(),
-      dwio::common::FileFormat::DWRF,
-      2,
-      getTestFileSize(deleteFilePath->getPath()),
-      {},
-      {},
-      {},
-      /*dataSequenceNumber=*/5);
-
-  auto file = filesystems::getFileSystem(baseFilePath, nullptr)
-                  ->openFileForRead(baseFilePath);
-  auto split = std::make_shared<HiveIcebergSplit>(
-      kIcebergConnectorId,
-      baseFilePath,
-      dwio::common::FileFormat::DWRF,
-      0,
-      file->size(),
-      std::unordered_map<std::string, std::optional<std::string>>{},
-      std::nullopt,
-      std::unordered_map<std::string, std::string>{},
-      nullptr,
-      true,
-      std::vector<IcebergDeleteFile>{deleteFile},
-      std::unordered_map<std::string, std::string>{},
-      std::nullopt,
-      /*dataSequenceNumber=*/10);
-
-  auto plan = PlanBuilder()
-                  .startTableScan()
-                  .connectorId(kIcebergConnectorId)
-                  .outputType(rowType)
-                  .endTableScan()
-                  .planNode();
-
-  // Delete skipped → all rows survive: [0, 1, 2, 3, 4].
-  auto expected = makeRowVector({makeFlatVector<int64_t>({0, 1, 2, 3, 4})});
-  AssertQueryBuilder(plan).split(split).assertResults({expected});
-}
-
-// Verifies that same-snapshot positional deletes apply (deleteSeqNum ==
-// dataSeqNum). Per the Iceberg spec, positional deletes in the same snapshot
-// SHOULD apply, so the skip condition uses strict < (not <=).
-TEST_F(HiveIcebergTest, positionalDeleteSequenceNumberEqualApplied) {
-  folly::SingletonVault::singleton()->registrationComplete();
-
-  auto pathColumn = IcebergMetadataColumn::icebergDeleteFilePathColumn();
-  auto posColumn = IcebergMetadataColumn::icebergDeletePosColumn();
-  auto rowType = ROW({"c0"}, {BIGINT()});
-
-  auto dataFilePath = TempFilePath::create();
-  writeToFile(
-      dataFilePath->getPath(),
-      {makeRowVector({makeFlatVector<int64_t>({0, 1, 2, 3, 4})})});
-
-  auto deleteFilePath = TempFilePath::create();
-  auto baseFilePath = dataFilePath->getPath();
-  writeToFile(
-      deleteFilePath->getPath(),
-      {makeRowVector(
-          {pathColumn->name, posColumn->name},
-          {
-              makeFlatVector<std::string>(
-                  2, [&](vector_size_t) { return baseFilePath; }),
-              makeFlatVector<int64_t>({1, 3}),
-          })});
-
-  // Delete file seqNum=5 == data seqNum=5 → delete should be applied
-  // (same-snapshot positional deletes apply per Iceberg spec).
-  IcebergDeleteFile deleteFile(
-      FileContent::kPositionalDeletes,
-      deleteFilePath->getPath(),
-      dwio::common::FileFormat::DWRF,
-      2,
-      getTestFileSize(deleteFilePath->getPath()),
-      {},
-      {},
-      {},
-      /*dataSequenceNumber=*/5);
-
-  auto file = filesystems::getFileSystem(baseFilePath, nullptr)
-                  ->openFileForRead(baseFilePath);
-  auto split = std::make_shared<HiveIcebergSplit>(
-      kIcebergConnectorId,
-      baseFilePath,
-      dwio::common::FileFormat::DWRF,
-      0,
-      file->size(),
-      std::unordered_map<std::string, std::optional<std::string>>{},
-      std::nullopt,
-      std::unordered_map<std::string, std::string>{},
-      nullptr,
-      true,
-      std::vector<IcebergDeleteFile>{deleteFile},
-      std::unordered_map<std::string, std::string>{},
-      std::nullopt,
-      /*dataSequenceNumber=*/5);
-
-  auto plan = PlanBuilder()
-                  .startTableScan()
-                  .connectorId(kIcebergConnectorId)
-                  .outputType(rowType)
-                  .endTableScan()
-                  .planNode();
-
-  // Same-snapshot delete applied: positions 1 and 3 deleted → [0, 2, 4].
-  auto expected = makeRowVector({makeFlatVector<int64_t>({0, 2, 4})});
-  AssertQueryBuilder(plan).split(split).assertResults({expected});
-}
-
-TEST_F(HiveIcebergTest, positionalDeleteSequenceNumberZeroDisablesFilter) {
-  folly::SingletonVault::singleton()->registrationComplete();
-
-  auto pathColumn = IcebergMetadataColumn::icebergDeleteFilePathColumn();
-  auto posColumn = IcebergMetadataColumn::icebergDeletePosColumn();
-  auto rowType = ROW({"c0"}, {BIGINT()});
-
-  auto dataFilePath = TempFilePath::create();
-  writeToFile(
-      dataFilePath->getPath(),
-      {makeRowVector({makeFlatVector<int64_t>({0, 1, 2, 3, 4})})});
-
-  auto deleteFilePath = TempFilePath::create();
-  auto baseFilePath = dataFilePath->getPath();
-  writeToFile(
-      deleteFilePath->getPath(),
-      {makeRowVector(
-          {pathColumn->name, posColumn->name},
-          {
-              makeFlatVector<std::string>(
-                  2, [&](vector_size_t) { return baseFilePath; }),
-              makeFlatVector<int64_t>({1, 3}),
-          })});
-
-  // Delete file seqNum=0 (unassigned/V1 legacy) → always applied regardless.
-  IcebergDeleteFile deleteFile(
-      FileContent::kPositionalDeletes,
-      deleteFilePath->getPath(),
-      dwio::common::FileFormat::DWRF,
-      2,
-      getTestFileSize(deleteFilePath->getPath()),
-      {},
-      {},
-      {},
-      /*dataSequenceNumber=*/0);
-
-  auto file = filesystems::getFileSystem(baseFilePath, nullptr)
-                  ->openFileForRead(baseFilePath);
-  auto split = std::make_shared<HiveIcebergSplit>(
-      kIcebergConnectorId,
-      baseFilePath,
-      dwio::common::FileFormat::DWRF,
-      0,
-      file->size(),
-      std::unordered_map<std::string, std::optional<std::string>>{},
-      std::nullopt,
-      std::unordered_map<std::string, std::string>{},
-      nullptr,
-      true,
-      std::vector<IcebergDeleteFile>{deleteFile},
-      std::unordered_map<std::string, std::string>{},
-      std::nullopt,
-      /*dataSequenceNumber=*/100);
-
-  auto plan = PlanBuilder()
-                  .startTableScan()
-                  .connectorId(kIcebergConnectorId)
-                  .outputType(rowType)
-                  .endTableScan()
-                  .planNode();
-
-  // SeqNum=0 disables filtering → delete applied: [0, 2, 4].
-  auto expected = makeRowVector({makeFlatVector<int64_t>({0, 2, 4})});
-  AssertQueryBuilder(plan).split(split).assertResults({expected});
-}
-
-TEST_F(HiveIcebergTest, flatMapAsStruct) {
+TEST_F(IcebergReadTest, flatMapAsStruct) {
   // Write a DWRF file with a MAP<BIGINT, DOUBLE> column.
   auto mapType = MAP(BIGINT(), DOUBLE());
   auto dataSchema = ROW({"id", "features"}, {BIGINT(), mapType});
@@ -2107,43 +802,19 @@ TEST_F(HiveIcebergTest, flatMapAsStruct) {
 
   // Build struct-encoded column handle for "features": keys {1, 2} as
   // struct fields {"1", "2"}.
-  std::vector<common::Subfield> subfields;
-  for (auto key : {"1", "2"}) {
-    std::vector<std::unique_ptr<common::Subfield::PathElement>> path;
-    path.push_back(std::make_unique<common::Subfield::NestedField>("features"));
-    path.push_back(
-        std::make_unique<common::Subfield::NestedField>(std::string(key)));
-    subfields.emplace_back(std::move(path));
-  }
-
   auto structType = ROW({"1", "2"}, {DOUBLE(), DOUBLE()});
   ColumnHandleMap assignments;
-  assignments["id"] = std::make_shared<HiveColumnHandle>(
-      "id",
-      HiveColumnHandle::ColumnType::kRegular,
-      BIGINT(),
-      BIGINT(),
-      std::vector<common::Subfield>{});
-  assignments["features"] = std::make_shared<HiveColumnHandle>(
-      "features",
-      HiveColumnHandle::ColumnType::kRegular,
-      mapType,
-      mapType,
-      std::move(subfields));
-
-  // Output type has ROW for the struct-encoded column.
-  auto outputType = ROW({"id", "features"}, {BIGINT(), structType});
-
-  auto plan = PlanBuilder()
-                  .startTableScan()
-                  .connectorId(kIcebergConnectorId)
-                  .outputType(outputType)
-                  .dataColumns(dataSchema)
-                  .assignments(assignments)
-                  .endTableScan()
-                  .planNode();
-
-  auto splits = makeIcebergSplits(dataFilePath->getPath());
+  assignments["id"] = std::shared_ptr<HiveColumnHandle>(
+      exec::test::HiveConnectorTestBase::makeColumnHandle(
+          "id", BIGINT(), std::vector<std::string>{})
+          .release());
+  assignments["features"] = std::shared_ptr<HiveColumnHandle>(
+      exec::test::HiveConnectorTestBase::makeColumnHandle(
+          "features",
+          mapType,
+          mapType,
+          std::vector<std::string>{"features.1", "features.2"})
+          .release());
 
   auto expected = makeRowVector(
       {"id", "features"},
@@ -2153,7 +824,14 @@ TEST_F(HiveIcebergTest, flatMapAsStruct) {
            {makeFlatVector<double>({10.0, 100.0}),
             makeFlatVector<double>({20.0, 200.0})})});
 
-  AssertQueryBuilder(plan).splits(splits).assertResults({expected});
+  // Output type has ROW for the struct-encoded column.
+  assertTableScan(
+      ROW({"id", "features"}, {BIGINT(), structType}),
+      makeIcebergSplits(dataFilePath->getPath()),
+      {expected},
+      dataSchema,
+      assignments);
 }
 
+} // namespace
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -26,6 +26,8 @@
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
 #include "velox/connectors/hive/iceberg/IcebergMetadataColumns.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
 
 namespace facebook::velox::connector::hive::iceberg {
 
@@ -100,16 +102,19 @@ class IcebergReadTest : public test::IcebergTestBase {
           {}) {
     auto dataFilePath = TempFilePath::create();
     writeToFile(dataFilePath->getPath(), data);
-    assertTableScan(
-        outputType,
-        makeIcebergSplits(dataFilePath->getPath()),
-        expected,
-        scanSpecType,
-        assignments,
-        "",
-        "",
-        "",
-        sessionProperties);
+    auto plan = exec::test::PlanBuilder()
+                    .startTableScan(test::kIcebergConnectorId)
+                    .outputType(outputType)
+                    .dataColumns(scanSpecType)
+                    .assignments(assignments)
+                    .endTableScan()
+                    .planNode();
+
+    exec::test::AssertQueryBuilder(plan)
+        .connectorSessionProperties(
+            {{test::kIcebergConnectorId, sessionProperties}})
+        .splits(makeIcebergSplits(dataFilePath->getPath()))
+        .assertResults(expected);
   }
 
   std::vector<RowVectorPtr> makeSingleBigintData(
@@ -212,16 +217,19 @@ class IcebergReadTest : public test::IcebergTestBase {
         ROW({"c0", "_row_id", "_last_updated_sequence_number"},
             {BIGINT(), BIGINT(), BIGINT()});
     const auto tableDataColumns = ROW({"c0"}, {BIGINT()});
-    assertTableScan(
-        outputType,
-        {makeIcebergSplitWithInfoColumns(
-            dataFilePath->getPath(), infoColumns, deleteFiles)},
-        tc.expectedVectors,
-        tableDataColumns,
-        {},
-        "",
-        "",
-        tc.subfieldFilter);
+    exec::test::PlanBuilder planBuilder;
+    auto& tableScanBuilder =
+        planBuilder.startTableScan(test::kIcebergConnectorId)
+            .outputType(outputType)
+            .dataColumns(tableDataColumns);
+    if (!tc.subfieldFilter.empty()) {
+      tableScanBuilder.subfieldFilter(tc.subfieldFilter);
+    }
+    auto plan = tableScanBuilder.endTableScan().planNode();
+    exec::test::AssertQueryBuilder(plan)
+        .splits({makeIcebergSplitWithInfoColumns(
+            dataFilePath->getPath(), infoColumns, deleteFiles)})
+        .assertResults(tc.expectedVectors);
   }
 };
 
@@ -245,8 +253,14 @@ TEST_F(IcebergReadTest, schemaEvolutionRemoveColumn) {
       {dataVectors[0]->childAt(0), dataVectors[0]->childAt(2)})};
 
   // Read with new schema (c0 and c2 only, c1 removed).
-  assertTableScan(
-      newRowType, makeIcebergSplits(dataFilePath->getPath()), expectedVectors);
+  auto plan = exec::test::PlanBuilder()
+                  .startTableScan(test::kIcebergConnectorId)
+                  .outputType(newRowType)
+                  .endTableScan()
+                  .planNode();
+  exec::test::AssertQueryBuilder(plan)
+      .splits(makeIcebergSplits(dataFilePath->getPath()))
+      .assertResults(expectedVectors);
 }
 
 TEST_F(IcebergReadTest, schemaEvolutionAddColumns) {
@@ -265,11 +279,15 @@ TEST_F(IcebergReadTest, schemaEvolutionAddColumns) {
        makeNullConstant(TypeKind::VARCHAR, 3)})};
 
   // Read with new schema (c0, c1, and c2).
-  assertTableScan(
-      newRowType,
-      makeIcebergSplits(dataFilePath->getPath()),
-      expectedVectors,
-      newRowType);
+  auto plan = exec::test::PlanBuilder()
+                  .startTableScan(test::kIcebergConnectorId)
+                  .outputType(newRowType)
+                  .dataColumns(newRowType)
+                  .endTableScan()
+                  .planNode();
+  exec::test::AssertQueryBuilder(plan)
+      .splits(makeIcebergSplits(dataFilePath->getPath()))
+      .assertResults(expectedVectors);
 }
 
 TEST_F(IcebergReadTest, addColumnWithDefault) {
@@ -423,12 +441,16 @@ TEST_F(IcebergReadTest, addColumnWithInvalidDefault) {
   assignments["age"] = makeIcebergHandle("age", INTEGER(), 2, "IN");
 
   VELOX_ASSERT_THROW(
-      assertTableScan(
-          newRowType,
-          makeIcebergSplits(dataFilePath->getPath()),
-          {},
-          newRowType,
-          assignments),
+      exec::test::AssertQueryBuilder(
+          exec::test::PlanBuilder()
+              .startTableScan(test::kIcebergConnectorId)
+              .outputType(newRowType)
+              .dataColumns(newRowType)
+              .assignments(assignments)
+              .endTableScan()
+              .planNode())
+          .splits(makeIcebergSplits(dataFilePath->getPath()))
+          .assertResults(std::vector<RowVectorPtr>{}),
       "Invalid");
 }
 
@@ -489,37 +511,61 @@ TEST_F(IcebergReadTest, defaultValueWithDeletesAndFilters) {
              [](vector_size_t) { return "IN"; })})};
   };
 
-  assertTableScan(
-      newRowType,
-      makeSplits(),
-      // Test 1: No filter. After deletes, rows 1, 3, 5, 7, 8, 9, 10 remain.
-      makeExpected({1, 3, 5, 7, 8, 9, 10}),
-      newRowType,
-      assignments);
-  assertTableScan(
-      newRowType,
-      makeSplits(),
-      // Test 2: Filter on file column (c0 > 5) with deletes.
-      makeExpected({7, 8, 9, 10}),
-      newRowType,
-      assignments,
-      "c0 > 5");
-  assertTableScan(
-      newRowType,
-      makeSplits(),
-      // Test 3: Filter on default value column (country = 'IN') with deletes.
-      makeExpected({1, 3, 5, 7, 8, 9, 10}),
-      newRowType,
-      assignments,
-      "country = 'IN'");
-  assertTableScan(
-      newRowType,
-      makeSplits(),
-      // Test 4: Combined filter (c0 > 3 AND country = 'IN') with deletes.
-      makeExpected({5, 7, 8, 9, 10}),
-      newRowType,
-      assignments,
-      "c0 > 3 AND country = 'IN'");
+  {
+    // Test 1: No filter. After deletes, rows 1, 3, 5, 7, 8, 9, 10 remain.
+    auto plan = exec::test::PlanBuilder()
+                    .startTableScan(test::kIcebergConnectorId)
+                    .outputType(newRowType)
+                    .dataColumns(newRowType)
+                    .assignments(assignments)
+                    .endTableScan()
+                    .planNode();
+    exec::test::AssertQueryBuilder(plan)
+        .splits(makeSplits())
+        .assertResults(makeExpected({1, 3, 5, 7, 8, 9, 10}));
+  }
+  {
+    // Test 2: Filter on file column (c0 > 5) with deletes.
+    auto plan = exec::test::PlanBuilder()
+                    .startTableScan(test::kIcebergConnectorId)
+                    .outputType(newRowType)
+                    .dataColumns(newRowType)
+                    .assignments(assignments)
+                    .endTableScan()
+                    .filter("c0 > 5")
+                    .planNode();
+    exec::test::AssertQueryBuilder(plan)
+        .splits(makeSplits())
+        .assertResults(makeExpected({7, 8, 9, 10}));
+  }
+  {
+    // Test 3: Filter on default value column (country = 'IN') with deletes.
+    auto plan = exec::test::PlanBuilder()
+                    .startTableScan(test::kIcebergConnectorId)
+                    .outputType(newRowType)
+                    .dataColumns(newRowType)
+                    .assignments(assignments)
+                    .endTableScan()
+                    .filter("country = 'IN'")
+                    .planNode();
+    exec::test::AssertQueryBuilder(plan)
+        .splits(makeSplits())
+        .assertResults(makeExpected({1, 3, 5, 7, 8, 9, 10}));
+  }
+  {
+    // Test 4: Combined filter (c0 > 3 AND country = 'IN') with deletes.
+    auto plan = exec::test::PlanBuilder()
+                    .startTableScan(test::kIcebergConnectorId)
+                    .outputType(newRowType)
+                    .dataColumns(newRowType)
+                    .assignments(assignments)
+                    .endTableScan()
+                    .filter("c0 > 3 AND country = 'IN'")
+                    .planNode();
+    exec::test::AssertQueryBuilder(plan)
+        .splits(makeSplits())
+        .assertResults(makeExpected({5, 7, 8, 9, 10}));
+  }
 }
 
 TEST_F(IcebergReadTest, partitionColumnsFromHive) {
@@ -556,12 +602,16 @@ TEST_F(IcebergReadTest, partitionColumnsFromHive) {
           makeFlatVector<int32_t>({2025, 2025, 2025}),
       })};
 
-  assertTableScan(
-      tableRowType,
-      makeIcebergSplits(dataFilePath->getPath(), {}, partitionKeys),
-      expectedVectors,
-      tableRowType,
-      makeColumnHandles(tableRowType, {2, 3}));
+  auto plan = exec::test::PlanBuilder()
+                  .startTableScan(test::kIcebergConnectorId)
+                  .outputType(tableRowType)
+                  .dataColumns(tableRowType)
+                  .assignments(makeColumnHandles(tableRowType, {2, 3}))
+                  .endTableScan()
+                  .planNode();
+  exec::test::AssertQueryBuilder(plan)
+      .splits(makeIcebergSplits(dataFilePath->getPath(), {}, partitionKeys))
+      .assertResults(expectedVectors);
 }
 
 TEST_F(IcebergReadTest, rowLineage) {
@@ -799,17 +849,21 @@ TEST_F(IcebergReadTest, targetTableRowIdSynthesis) {
               }),
       });
 
-  assertTableScan(
-      outputType,
-      {makeIcebergSplitWithInfoColumns(
+  auto plan = exec::test::PlanBuilder()
+                  .startTableScan(test::kIcebergConnectorId)
+                  .outputType(outputType)
+                  .dataColumns(ROW({"c0"}, {BIGINT()}))
+                  .endTableScan()
+                  .planNode();
+  exec::test::AssertQueryBuilder(plan)
+      .splits({makeIcebergSplitWithInfoColumns(
           dataFilePath->getPath(),
           {
               {IcebergMetadataColumn::kSpecIdInfoColumn, "7"},
               {IcebergMetadataColumn::kPartitionDataInfoColumn,
                kPartitionDataJson},
-          })},
-      {expected},
-      ROW({"c0"}, {BIGINT()}));
+          })})
+      .assertResults({expected});
 }
 
 TEST_F(IcebergReadTest, flatMapAsStruct) {
@@ -854,12 +908,16 @@ TEST_F(IcebergReadTest, flatMapAsStruct) {
             makeFlatVector<double>({20.0, 200.0})})});
 
   // Output type has ROW for the struct-encoded column.
-  assertTableScan(
-      ROW({"id", "features"}, {BIGINT(), structType}),
-      makeIcebergSplits(dataFilePath->getPath()),
-      {expected},
-      dataSchema,
-      assignments);
+  auto plan = exec::test::PlanBuilder()
+                  .startTableScan(test::kIcebergConnectorId)
+                  .outputType(ROW({"id", "features"}, {BIGINT(), structType}))
+                  .dataColumns(dataSchema)
+                  .assignments(assignments)
+                  .endTableScan()
+                  .planNode();
+  exec::test::AssertQueryBuilder(plan)
+      .splits(makeIcebergSplits(dataFilePath->getPath()))
+      .assertResults({expected});
 }
 
 } // namespace

--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -24,6 +24,7 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/encode/Base64.h"
 #include "velox/connectors/hive/HiveConfig.h"
+#include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
 #include "velox/connectors/hive/iceberg/IcebergMetadataColumns.h"
 
 namespace facebook::velox::connector::hive::iceberg {
@@ -59,6 +60,34 @@ class IcebergReadTest : public test::IcebergTestBase {
     test::IcebergTestBase::SetUp();
     folly::SingletonVault::singleton()->registrationComplete();
     fileFormat_ = dwio::common::FileFormat::DWRF;
+  }
+
+  std::shared_ptr<IcebergColumnHandle> makeIcebergHandle(
+      const std::string& name,
+      const TypePtr& type,
+      int fieldId,
+      const std::string& defaultValue) {
+    return std::make_shared<IcebergColumnHandle>(
+        name,
+        HiveColumnHandle::ColumnType::kRegular,
+        type,
+        parquet::ParquetFieldId(fieldId),
+        std::vector<common::Subfield>{},
+        std::optional<std::string>{defaultValue});
+  }
+
+  std::shared_ptr<IcebergColumnHandle> makeIcebergHandle(
+      const std::string& name,
+      const TypePtr& type,
+      int fieldId,
+      FileColumnHandle::ColumnType columnType =
+          FileColumnHandle::ColumnType::kRegular) {
+    return std::make_shared<IcebergColumnHandle>(
+        name,
+        columnType,
+        type,
+        parquet::ParquetFieldId(fieldId),
+        std::vector<common::Subfield>{});
   }
 
   void assertDefaultValues(

--- a/velox/connectors/hive/iceberg/tests/IcebergTestBase.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergTestBase.cpp
@@ -25,6 +25,8 @@
 #include "velox/connectors/hive/iceberg/IcebergDataSink.h"
 #include "velox/connectors/hive/iceberg/IcebergSplit.h"
 #include "velox/connectors/hive/iceberg/PartitionSpec.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/expression/Expr.h"
 
 namespace facebook::velox::connector::hive::iceberg::test {
@@ -168,6 +170,12 @@ std::shared_ptr<IcebergPartitionSpec> IcebergTestBase::createPartitionSpec(
 }
 
 namespace {
+
+uint64_t getTestFileSize(const std::string& path) {
+  return filesystems::getFileSystem(path, nullptr)
+      ->openFileForRead(path)
+      ->size();
+}
 
 parquet::ParquetFieldId makeField(const TypePtr& type, int32_t& fieldId) {
   const int32_t currentId = fieldId++;
@@ -325,6 +333,146 @@ IcebergTestBase::createSplitsForDirectory(const std::string& directory) {
   }
 
   return splits;
+}
+
+uint64_t IcebergTestBase::getFileSize(const std::string& path) const {
+  return getTestFileSize(path);
+}
+
+std::vector<std::shared_ptr<ConnectorSplit>> IcebergTestBase::makeIcebergSplits(
+    const std::string& dataFilePath,
+    const std::vector<IcebergDeleteFile>& deleteFiles,
+    const std::unordered_map<std::string, std::optional<std::string>>&
+        partitionKeys,
+    uint32_t splitCount,
+    const std::unordered_map<std::string, std::string>& infoColumns,
+    int64_t dataSequenceNumber) {
+  std::vector<std::shared_ptr<ConnectorSplit>> splits;
+  auto baseSplits = makeHiveConnectorSplits(
+      dataFilePath, splitCount, fileFormat_, partitionKeys, infoColumns);
+  splits.reserve(baseSplits.size());
+
+  for (const auto& baseSplit : baseSplits) {
+    splits.emplace_back(
+        std::make_shared<HiveIcebergSplit>(
+            kIcebergConnectorId,
+            baseSplit->filePath,
+            baseSplit->fileFormat,
+            baseSplit->start,
+            baseSplit->length,
+            baseSplit->partitionKeys,
+            baseSplit->tableBucketNumber,
+            baseSplit->customSplitInfo,
+            baseSplit->extraFileInfo,
+            baseSplit->cacheable,
+            deleteFiles,
+            baseSplit->infoColumns,
+            baseSplit->properties,
+            dataSequenceNumber));
+  }
+
+  return splits;
+}
+
+std::shared_ptr<ConnectorSplit>
+IcebergTestBase::makeIcebergSplitWithInfoColumns(
+    const std::string& dataFilePath,
+    const std::unordered_map<std::string, std::string>& infoColumns,
+    const std::vector<IcebergDeleteFile>& deleteFiles,
+    int64_t dataSequenceNumber) {
+  auto splits = makeIcebergSplits(
+      dataFilePath, deleteFiles, {}, 1, infoColumns, dataSequenceNumber);
+  VELOX_CHECK_EQ(splits.size(), 1);
+  return splits.front();
+}
+
+std::shared_ptr<IcebergColumnHandle> IcebergTestBase::makeIcebergHandle(
+    const std::string& name,
+    const TypePtr& type,
+    int fieldId,
+    const std::string& defaultValue) {
+  return std::make_shared<IcebergColumnHandle>(
+      name,
+      HiveColumnHandle::ColumnType::kRegular,
+      type,
+      parquet::ParquetFieldId(fieldId),
+      std::vector<common::Subfield>{},
+      std::optional<std::string>{defaultValue});
+}
+
+std::shared_ptr<IcebergColumnHandle> IcebergTestBase::makeIcebergHandle(
+    const std::string& name,
+    const TypePtr& type,
+    int fieldId,
+    FileColumnHandle::ColumnType columnType) {
+  return std::make_shared<IcebergColumnHandle>(
+      name,
+      columnType,
+      type,
+      parquet::ParquetFieldId(fieldId),
+      std::vector<common::Subfield>{});
+}
+
+ColumnHandleMap IcebergTestBase::makeColumnHandles(
+    const RowTypePtr& rowType,
+    const std::unordered_set<int>& partitionIndices) {
+  ColumnHandleMap assignments;
+  for (auto i = 0; i < rowType->size(); ++i) {
+    const auto& columnName = rowType->nameOf(i);
+    const auto& columnType = rowType->childAt(i);
+    const auto columnHandleType = partitionIndices.contains(i)
+        ? FileColumnHandle::ColumnType::kPartitionKey
+        : FileColumnHandle::ColumnType::kRegular;
+    assignments.insert(
+        {columnName,
+         std::make_shared<HiveColumnHandle>(
+             columnName,
+             columnHandleType,
+             columnType,
+             columnType,
+             std::vector<common::Subfield>{})});
+  }
+
+  return assignments;
+}
+
+void IcebergTestBase::assertTableScan(
+    const RowTypePtr& outputType,
+    const std::vector<std::shared_ptr<ConnectorSplit>>& splits,
+    const std::vector<RowVectorPtr>& expected,
+    const RowTypePtr& dataColumns,
+    const ColumnHandleMap& assignments,
+    const std::string& filter,
+    const std::string& remainingFilter,
+    const std::string& subfieldFilter,
+    const std::unordered_map<std::string, std::string>& sessionProperties) {
+  exec::test::PlanBuilder tableScanPlanBuilder;
+  auto& builder = tableScanPlanBuilder.startTableScan();
+  builder.connectorId(kIcebergConnectorId);
+  builder.outputType(outputType);
+  if (dataColumns != nullptr) {
+    builder.dataColumns(dataColumns);
+  }
+  if (!assignments.empty()) {
+    builder.assignments(assignments);
+  }
+  if (!subfieldFilter.empty()) {
+    builder.subfieldFilter(subfieldFilter);
+  }
+  if (!remainingFilter.empty()) {
+    builder.remainingFilter(remainingFilter);
+  }
+  auto& planBuilder = builder.endTableScan();
+  if (!filter.empty()) {
+    planBuilder.filter(filter);
+  }
+  auto plan = planBuilder.planNode();
+
+  auto queryBuilder = exec::test::AssertQueryBuilder(plan);
+  for (const auto& [key, value] : sessionProperties) {
+    queryBuilder.connectorSessionProperty(kIcebergConnectorId, key, value);
+  }
+  queryBuilder.splits(splits).assertResults(expected);
 }
 
 } // namespace facebook::velox::connector::hive::iceberg::test

--- a/velox/connectors/hive/iceberg/tests/IcebergTestBase.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergTestBase.cpp
@@ -171,12 +171,6 @@ std::shared_ptr<IcebergPartitionSpec> IcebergTestBase::createPartitionSpec(
 
 namespace {
 
-uint64_t getTestFileSize(const std::string& path) {
-  return filesystems::getFileSystem(path, nullptr)
-      ->openFileForRead(path)
-      ->size();
-}
-
 parquet::ParquetFieldId makeField(const TypePtr& type, int32_t& fieldId) {
   const int32_t currentId = fieldId++;
   std::vector<parquet::ParquetFieldId> children;
@@ -336,7 +330,9 @@ IcebergTestBase::createSplitsForDirectory(const std::string& directory) {
 }
 
 uint64_t IcebergTestBase::getFileSize(const std::string& path) const {
-  return getTestFileSize(path);
+  return filesystems::getFileSystem(path, nullptr)
+      ->openFileForRead(path)
+      ->size();
 }
 
 std::vector<std::shared_ptr<ConnectorSplit>> IcebergTestBase::makeIcebergSplits(
@@ -384,33 +380,6 @@ IcebergTestBase::makeIcebergSplitWithInfoColumns(
       dataFilePath, deleteFiles, {}, 1, infoColumns, dataSequenceNumber);
   VELOX_CHECK_EQ(splits.size(), 1);
   return splits.front();
-}
-
-std::shared_ptr<IcebergColumnHandle> IcebergTestBase::makeIcebergHandle(
-    const std::string& name,
-    const TypePtr& type,
-    int fieldId,
-    const std::string& defaultValue) {
-  return std::make_shared<IcebergColumnHandle>(
-      name,
-      HiveColumnHandle::ColumnType::kRegular,
-      type,
-      parquet::ParquetFieldId(fieldId),
-      std::vector<common::Subfield>{},
-      std::optional<std::string>{defaultValue});
-}
-
-std::shared_ptr<IcebergColumnHandle> IcebergTestBase::makeIcebergHandle(
-    const std::string& name,
-    const TypePtr& type,
-    int fieldId,
-    FileColumnHandle::ColumnType columnType) {
-  return std::make_shared<IcebergColumnHandle>(
-      name,
-      columnType,
-      type,
-      parquet::ParquetFieldId(fieldId),
-      std::vector<common::Subfield>{});
 }
 
 ColumnHandleMap IcebergTestBase::makeColumnHandles(

--- a/velox/connectors/hive/iceberg/tests/IcebergTestBase.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergTestBase.cpp
@@ -25,8 +25,6 @@
 #include "velox/connectors/hive/iceberg/IcebergDataSink.h"
 #include "velox/connectors/hive/iceberg/IcebergSplit.h"
 #include "velox/connectors/hive/iceberg/PartitionSpec.h"
-#include "velox/exec/tests/utils/AssertQueryBuilder.h"
-#include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/expression/Expr.h"
 
 namespace facebook::velox::connector::hive::iceberg::test {
@@ -329,7 +327,7 @@ IcebergTestBase::createSplitsForDirectory(const std::string& directory) {
   return splits;
 }
 
-uint64_t IcebergTestBase::getFileSize(const std::string& path) const {
+uint64_t IcebergTestBase::getFileSize(const std::string& path) {
   return filesystems::getFileSystem(path, nullptr)
       ->openFileForRead(path)
       ->size();
@@ -343,27 +341,28 @@ std::vector<std::shared_ptr<ConnectorSplit>> IcebergTestBase::makeIcebergSplits(
     uint32_t splitCount,
     const std::unordered_map<std::string, std::string>& infoColumns,
     int64_t dataSequenceNumber) {
+  VELOX_CHECK_GT(splitCount, 0);
   std::vector<std::shared_ptr<ConnectorSplit>> splits;
-  auto baseSplits = makeHiveConnectorSplits(
-      dataFilePath, splitCount, fileFormat_, partitionKeys, infoColumns);
-  splits.reserve(baseSplits.size());
+  const auto fileSize = getFileSize(dataFilePath);
+  const auto splitSize = fileSize / splitCount;
+  splits.reserve(splitCount);
 
-  for (const auto& baseSplit : baseSplits) {
+  for (auto i = 0; i < splitCount; ++i) {
     splits.emplace_back(
         std::make_shared<HiveIcebergSplit>(
             kIcebergConnectorId,
-            baseSplit->filePath,
-            baseSplit->fileFormat,
-            baseSplit->start,
-            baseSplit->length,
-            baseSplit->partitionKeys,
-            baseSplit->tableBucketNumber,
-            baseSplit->customSplitInfo,
-            baseSplit->extraFileInfo,
-            baseSplit->cacheable,
+            dataFilePath,
+            fileFormat_,
+            i * splitSize,
+            splitSize,
+            partitionKeys,
+            std::nullopt,
+            std::unordered_map<std::string, std::string>{},
+            nullptr,
+            /*cacheable=*/true,
             deleteFiles,
-            baseSplit->infoColumns,
-            baseSplit->properties,
+            infoColumns,
+            std::nullopt,
             dataSequenceNumber));
   }
 
@@ -403,45 +402,6 @@ ColumnHandleMap IcebergTestBase::makeColumnHandles(
   }
 
   return assignments;
-}
-
-void IcebergTestBase::assertTableScan(
-    const RowTypePtr& outputType,
-    const std::vector<std::shared_ptr<ConnectorSplit>>& splits,
-    const std::vector<RowVectorPtr>& expected,
-    const RowTypePtr& dataColumns,
-    const ColumnHandleMap& assignments,
-    const std::string& filter,
-    const std::string& remainingFilter,
-    const std::string& subfieldFilter,
-    const std::unordered_map<std::string, std::string>& sessionProperties) {
-  exec::test::PlanBuilder tableScanPlanBuilder;
-  auto& builder = tableScanPlanBuilder.startTableScan();
-  builder.connectorId(kIcebergConnectorId);
-  builder.outputType(outputType);
-  if (dataColumns != nullptr) {
-    builder.dataColumns(dataColumns);
-  }
-  if (!assignments.empty()) {
-    builder.assignments(assignments);
-  }
-  if (!subfieldFilter.empty()) {
-    builder.subfieldFilter(subfieldFilter);
-  }
-  if (!remainingFilter.empty()) {
-    builder.remainingFilter(remainingFilter);
-  }
-  auto& planBuilder = builder.endTableScan();
-  if (!filter.empty()) {
-    planBuilder.filter(filter);
-  }
-  auto plan = planBuilder.planNode();
-
-  auto queryBuilder = exec::test::AssertQueryBuilder(plan);
-  for (const auto& [key, value] : sessionProperties) {
-    queryBuilder.connectorSessionProperty(kIcebergConnectorId, key, value);
-  }
-  queryBuilder.splits(splits).assertResults(expected);
 }
 
 } // namespace facebook::velox::connector::hive::iceberg::test

--- a/velox/connectors/hive/iceberg/tests/IcebergTestBase.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergTestBase.cpp
@@ -309,7 +309,7 @@ IcebergTestBase::createSplitsForDirectory(const std::string& directory) {
 
     const auto file = filesystems::getFileSystem(filePath, nullptr)
                           ->openFileForRead(filePath);
-    splits.push_back(HiveIcebergSplitBuilder(filePath)
+    splits.push_back(IcebergSplitBuilder(filePath)
                          .connectorId(kIcebergConnectorId)
                          .fileFormat(fileFormat_)
                          .length(file->size())
@@ -341,7 +341,7 @@ std::vector<std::shared_ptr<ConnectorSplit>> IcebergTestBase::makeIcebergSplits(
   splits.reserve(splitCount);
 
   for (auto i = 0; i < splitCount; ++i) {
-    splits.emplace_back(HiveIcebergSplitBuilder(dataFilePath)
+    splits.emplace_back(IcebergSplitBuilder(dataFilePath)
                             .connectorId(kIcebergConnectorId)
                             .fileFormat(fileFormat_)
                             .start(i * splitSize)

--- a/velox/connectors/hive/iceberg/tests/IcebergTestBase.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergTestBase.cpp
@@ -309,19 +309,12 @@ IcebergTestBase::createSplitsForDirectory(const std::string& directory) {
 
     const auto file = filesystems::getFileSystem(filePath, nullptr)
                           ->openFileForRead(filePath);
-    splits.push_back(
-        std::make_shared<HiveIcebergSplit>(
-            kIcebergConnectorId,
-            filePath,
-            fileFormat_,
-            0,
-            file->size(),
-            partitionKeys,
-            std::nullopt,
-            std::unordered_map<std::string, std::string>{},
-            nullptr,
-            /*cacheable=*/true,
-            std::vector<IcebergDeleteFile>()));
+    splits.push_back(HiveIcebergSplitBuilder(filePath)
+                         .connectorId(kIcebergConnectorId)
+                         .fileFormat(fileFormat_)
+                         .length(file->size())
+                         .partitionKeys(partitionKeys)
+                         .build());
   }
 
   return splits;
@@ -348,22 +341,16 @@ std::vector<std::shared_ptr<ConnectorSplit>> IcebergTestBase::makeIcebergSplits(
   splits.reserve(splitCount);
 
   for (auto i = 0; i < splitCount; ++i) {
-    splits.emplace_back(
-        std::make_shared<HiveIcebergSplit>(
-            kIcebergConnectorId,
-            dataFilePath,
-            fileFormat_,
-            i * splitSize,
-            splitSize,
-            partitionKeys,
-            std::nullopt,
-            std::unordered_map<std::string, std::string>{},
-            nullptr,
-            /*cacheable=*/true,
-            deleteFiles,
-            infoColumns,
-            std::nullopt,
-            dataSequenceNumber));
+    splits.emplace_back(HiveIcebergSplitBuilder(dataFilePath)
+                            .connectorId(kIcebergConnectorId)
+                            .fileFormat(fileFormat_)
+                            .start(i * splitSize)
+                            .length(splitSize)
+                            .partitionKeys(partitionKeys)
+                            .deleteFiles(deleteFiles)
+                            .infoColumns(infoColumns)
+                            .dataSequenceNumber(dataSequenceNumber)
+                            .build());
   }
 
   return splits;

--- a/velox/connectors/hive/iceberg/tests/IcebergTestBase.h
+++ b/velox/connectors/hive/iceberg/tests/IcebergTestBase.h
@@ -18,12 +18,17 @@
 
 #include <gtest/gtest.h>
 #include <memory>
+#include <optional>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "velox/common/testutil/TempDirectoryPath.h"
+#include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
 #include "velox/connectors/hive/iceberg/IcebergConfig.h"
 #include "velox/connectors/hive/iceberg/IcebergDataSink.h"
+#include "velox/connectors/hive/iceberg/IcebergDeleteFile.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 #ifdef VELOX_ENABLE_PARQUET
@@ -68,6 +73,52 @@ class IcebergTestBase : public exec::test::HiveConnectorTestBase {
 
   std::vector<std::shared_ptr<ConnectorSplit>> createSplitsForDirectory(
       const std::string& directory);
+
+  uint64_t getFileSize(const std::string& path) const;
+
+  std::vector<std::shared_ptr<ConnectorSplit>> makeIcebergSplits(
+      const std::string& dataFilePath,
+      const std::vector<IcebergDeleteFile>& deleteFiles = {},
+      const std::unordered_map<std::string, std::optional<std::string>>&
+          partitionKeys = {},
+      uint32_t splitCount = 1,
+      const std::unordered_map<std::string, std::string>& infoColumns = {},
+      int64_t dataSequenceNumber = 0);
+
+  std::shared_ptr<ConnectorSplit> makeIcebergSplitWithInfoColumns(
+      const std::string& dataFilePath,
+      const std::unordered_map<std::string, std::string>& infoColumns,
+      const std::vector<IcebergDeleteFile>& deleteFiles = {},
+      int64_t dataSequenceNumber = 0);
+
+  std::shared_ptr<IcebergColumnHandle> makeIcebergHandle(
+      const std::string& name,
+      const TypePtr& type,
+      int fieldId,
+      const std::string& defaultValue);
+
+  std::shared_ptr<IcebergColumnHandle> makeIcebergHandle(
+      const std::string& name,
+      const TypePtr& type,
+      int fieldId,
+      FileColumnHandle::ColumnType columnType =
+          FileColumnHandle::ColumnType::kRegular);
+
+  ColumnHandleMap makeColumnHandles(
+      const RowTypePtr& rowType,
+      const std::unordered_set<int>& partitionIndices = {});
+
+  void assertTableScan(
+      const RowTypePtr& outputType,
+      const std::vector<std::shared_ptr<ConnectorSplit>>& splits,
+      const std::vector<RowVectorPtr>& expected,
+      const RowTypePtr& dataColumns = nullptr,
+      const ColumnHandleMap& assignments = {},
+      const std::string& filter = "",
+      const std::string& remainingFilter = "",
+      const std::string& subfieldFilter = "",
+      const std::unordered_map<std::string, std::string>& sessionProperties =
+          {});
 
   std::vector<std::string> listFiles(const std::string& dirPath);
 

--- a/velox/connectors/hive/iceberg/tests/IcebergTestBase.h
+++ b/velox/connectors/hive/iceberg/tests/IcebergTestBase.h
@@ -25,7 +25,6 @@
 #include <vector>
 
 #include "velox/common/testutil/TempDirectoryPath.h"
-#include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
 #include "velox/connectors/hive/iceberg/IcebergConfig.h"
 #include "velox/connectors/hive/iceberg/IcebergDataSink.h"
 #include "velox/connectors/hive/iceberg/IcebergDeleteFile.h"
@@ -90,19 +89,6 @@ class IcebergTestBase : public exec::test::HiveConnectorTestBase {
       const std::unordered_map<std::string, std::string>& infoColumns,
       const std::vector<IcebergDeleteFile>& deleteFiles = {},
       int64_t dataSequenceNumber = 0);
-
-  std::shared_ptr<IcebergColumnHandle> makeIcebergHandle(
-      const std::string& name,
-      const TypePtr& type,
-      int fieldId,
-      const std::string& defaultValue);
-
-  std::shared_ptr<IcebergColumnHandle> makeIcebergHandle(
-      const std::string& name,
-      const TypePtr& type,
-      int fieldId,
-      FileColumnHandle::ColumnType columnType =
-          FileColumnHandle::ColumnType::kRegular);
 
   ColumnHandleMap makeColumnHandles(
       const RowTypePtr& rowType,

--- a/velox/connectors/hive/iceberg/tests/IcebergTestBase.h
+++ b/velox/connectors/hive/iceberg/tests/IcebergTestBase.h
@@ -73,8 +73,12 @@ class IcebergTestBase : public exec::test::HiveConnectorTestBase {
   std::vector<std::shared_ptr<ConnectorSplit>> createSplitsForDirectory(
       const std::string& directory);
 
-  uint64_t getFileSize(const std::string& path) const;
+  /// Returns the size of a test file.
+  static uint64_t getFileSize(const std::string& path);
 
+  /// Creates Iceberg connector splits for a data file. Tests can attach delete
+  /// files, partition keys, info columns, and a data sequence number to each
+  /// split.
   std::vector<std::shared_ptr<ConnectorSplit>> makeIcebergSplits(
       const std::string& dataFilePath,
       const std::vector<IcebergDeleteFile>& deleteFiles = {},
@@ -84,27 +88,19 @@ class IcebergTestBase : public exec::test::HiveConnectorTestBase {
       const std::unordered_map<std::string, std::string>& infoColumns = {},
       int64_t dataSequenceNumber = 0);
 
+  /// Creates one Iceberg connector split for a full data file with info
+  /// columns.
   std::shared_ptr<ConnectorSplit> makeIcebergSplitWithInfoColumns(
       const std::string& dataFilePath,
       const std::unordered_map<std::string, std::string>& infoColumns,
       const std::vector<IcebergDeleteFile>& deleteFiles = {},
       int64_t dataSequenceNumber = 0);
 
+  /// Creates Hive column handles for all columns in 'rowType', marking
+  /// specified columns as partition keys.
   ColumnHandleMap makeColumnHandles(
       const RowTypePtr& rowType,
       const std::unordered_set<int>& partitionIndices = {});
-
-  void assertTableScan(
-      const RowTypePtr& outputType,
-      const std::vector<std::shared_ptr<ConnectorSplit>>& splits,
-      const std::vector<RowVectorPtr>& expected,
-      const RowTypePtr& dataColumns = nullptr,
-      const ColumnHandleMap& assignments = {},
-      const std::string& filter = "",
-      const std::string& remainingFilter = "",
-      const std::string& subfieldFilter = "",
-      const std::unordered_map<std::string, std::string>& sessionProperties =
-          {});
 
   std::vector<std::string> listFiles(const std::string& dirPath);
 

--- a/velox/connectors/hive/iceberg/tests/TransformE2ETest.cpp
+++ b/velox/connectors/hive/iceberg/tests/TransformE2ETest.cpp
@@ -209,8 +209,7 @@ class TransformE2ETest : public test::IcebergTestBase {
     auto splits = createSplitsForDirectory(outputPath);
 
     const auto plan = PlanBuilder()
-                          .startTableScan()
-                          .connectorId(test::kIcebergConnectorId)
+                          .startTableScan(test::kIcebergConnectorId)
                           .outputType(rowType)
                           .endTableScan()
                           .planNode();
@@ -228,8 +227,7 @@ class TransformE2ETest : public test::IcebergTestBase {
       const std::string& partitionFilter,
       const int32_t expectedRowCount) {
     auto scanPlan = PlanBuilder()
-                        .startTableScan()
-                        .connectorId(test::kIcebergConnectorId)
+                        .startTableScan(test::kIcebergConnectorId)
                         .outputType(rowType)
                         .endTableScan()
                         .planNode();
@@ -242,8 +240,7 @@ class TransformE2ETest : public test::IcebergTestBase {
     ASSERT_EQ(actualRowCount, expectedRowCount);
 
     const auto filterPlan = PlanBuilder()
-                                .startTableScan()
-                                .connectorId(test::kIcebergConnectorId)
+                                .startTableScan(test::kIcebergConnectorId)
                                 .outputType(rowType)
                                 .endTableScan()
                                 .filter(partitionFilter)
@@ -429,8 +426,7 @@ TEST_F(TransformE2ETest, bucket) {
   for (const auto& dir : partitionDirs) {
     auto splits = createSplitsForDirectory(dir);
     auto countPlan = PlanBuilder()
-                         .startTableScan()
-                         .connectorId(test::kIcebergConnectorId)
+                         .startTableScan(test::kIcebergConnectorId)
                          .outputType(rowType)
                          .endTableScan()
                          .planNode();
@@ -451,8 +447,7 @@ TEST_F(TransformE2ETest, bucket) {
     const int32_t expectedBucket = std::stoi(v);
 
     auto dataPlan = PlanBuilder()
-                        .startTableScan()
-                        .connectorId(test::kIcebergConnectorId)
+                        .startTableScan(test::kIcebergConnectorId)
                         .outputType(rowType)
                         .endTableScan()
                         .project({"c_varchar"})
@@ -531,8 +526,7 @@ TEST_F(TransformE2ETest, year) {
       if (name == expectedDirName) {
         foundPartition = true;
         auto datePlan = PlanBuilder()
-                            .startTableScan()
-                            .connectorId(test::kIcebergConnectorId)
+                            .startTableScan(test::kIcebergConnectorId)
                             .outputType(rowType)
                             .endTableScan()
                             .filter(yearFilter(year))
@@ -543,8 +537,7 @@ TEST_F(TransformE2ETest, year) {
                                      .countResults();
 
         auto countPlan = PlanBuilder()
-                             .startTableScan()
-                             .connectorId(test::kIcebergConnectorId)
+                             .startTableScan(test::kIcebergConnectorId)
                              .outputType(rowType)
                              .endTableScan()
                              .planNode();
@@ -700,8 +693,7 @@ TEST_F(TransformE2ETest, multipleTransformsOnSameColumn) {
         // Verify the partition has data.
         auto splits = createSplitsForDirectory(thirdDir);
         auto countPlan = PlanBuilder()
-                             .startTableScan()
-                             .connectorId(test::kIcebergConnectorId)
+                             .startTableScan(test::kIcebergConnectorId)
                              .outputType(rowType)
                              .endTableScan()
                              .planNode();
@@ -779,8 +771,7 @@ TEST_F(TransformE2ETest, dateIdentityPartitionWithFilter) {
   };
 
   auto filterPlan = PlanBuilder()
-                        .startTableScan()
-                        .connectorId(test::kIcebergConnectorId)
+                        .startTableScan(test::kIcebergConnectorId)
                         .outputType(rowType)
                         .assignments(assignments)
                         .remainingFilter("c_date = DATE '2025-02-28'")

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -380,9 +380,11 @@ class PlanBuilder {
     common::SubfieldFilters subfieldFiltersMap_;
   };
 
-  /// Start a TableScanBuilder.
-  TableScanBuilder& startTableScan() {
+  /// Start a TableScanBuilder using the specified connector.
+  TableScanBuilder& startTableScan(
+      std::string connectorId = std::string(kHiveDefaultConnectorId)) {
     tableScanBuilder_.reset(new TableScanBuilder(*this));
+    tableScanBuilder_->connectorId(std::move(connectorId));
     return *tableScanBuilder_;
   }
 


### PR DESCRIPTION
Refactor the Iceberg read tests so shared scan setup lives in `IcebergTestBase`, while scenario-specific helpers stay with the test suites that use them.

Before this change, `IcebergReadTest.cpp` mixed schema-evolution/default-value coverage with positional-delete setup and helpers. After this change, read/schema tests remain in `IcebergReadTest.cpp`, positional-delete coverage moves to `IcebergPositionalDeleteTest.cpp`, and only common Iceberg scan utilities are shared through `IcebergTestBase`.

Added `IcebergSplitBuilder` helper.
Added `PlanBuilder::startTableScan(connectorId)` overload.
Also change EqualityDeleteFileReaderTest, IcebergDwrfInsertTest, IcebergInsertTest, and TransformE2ETest to use the new overload API `PlanBuilder::startTableScan(connectorId)`.