### PR TITLE
docs(review): Make design and maintainability a first-class review pass

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -155,8 +155,11 @@ Brief overall assessment (1-2 sentences)
 ### Issues Found
 List any issue, categorized by severity:
  - 🔴 **Critical**: Must fix before merge
- - 🟡 **Suggestion**: Should consider
- - 🟢 **Nitpick**: Minor style issues
+ - 🟡 **Suggestion**: Design, structure, and maintainability concerns —
+   abstraction boundaries, duplicated ownership, over-general APIs, coupling
+   that undercuts the PR's goal. "It works" does not downgrade these.
+ - 🟢 **Nitpick**: Cosmetic only — typos, formatting, a single local name.
+   Structural concerns are never 🟢.
 
 Each issue should also include:
 - File and line reference

--- a/scripts/review/REVIEW_GUIDE.md
+++ b/scripts/review/REVIEW_GUIDE.md
@@ -16,6 +16,40 @@ and have I verified the claims?" If the answer is no, dig deeper before
 drafting. The most common mistake is focusing on code details before
 understanding the change.
 
+## Design pass (do this before the mechanical review)
+
+Mechanical correctness — does it compile, is CI green, are prior comments
+addressed — is **necessary but never sufficient**. It answers "does it work,"
+not "is it right." Never let green CI or "addressed all comments" shortcut this
+pass or justify an approve. Do the design pass first; it sets the verdict.
+
+1. **State the PR's goal/invariant in one sentence** — in your own words, from
+   the description and the code (e.g., "generic code must not know about
+   formats"). If you can't, the description isn't clear enough — say so.
+
+2. **Hunt the diff for violations of that invariant.** This is the highest-yield
+   step. Make it concrete: grep for the pattern the PR claims to remove. If a PR
+   says it removes format knowledge from generic code, grep the generic files
+   for `switch.*Format`, `format ==`, and format-name string literals. A
+   surviving hit is usually the most important finding in the review.
+
+3. **Check the refactor is complete, not carved out.** Did it convert every
+   instance of the pattern, or migrate one case (e.g., Parquet) and leave the
+   siblings (ORC, DWRF, Nimble) on the old path? A partial migration that leaves
+   one concept with **two homes** (a shared field *and* a format-owned field for
+   the same value) is a finding, not a detail. If the split is intentional, the
+   PR must say so.
+
+4. **Scrutinize new API on shared/core types.** For each new public method or
+   field added to a widely-used class: how many callers does it have (one caller
+   for a general API is a smell)? Does it need to be that general? Does it expose
+   internals — locks, raw iteration, arbitrary callbacks — to outside code?
+
+5. **Grep each new public symbol for usages.** Dead constants/methods (declared,
+   never referenced) ship surprisingly often. Flag them.
+
+Only after this pass, move to the mechanical checks below.
+
 ## Tone
 
 - **Opening:** "Thank you for the fix/contribution!" — then straight to the
@@ -88,6 +122,25 @@ tests pass":
   tests (unless closing a pre-existing coverage gap in a separate PR).
 
 ## What to check
+
+### Maintainability & structure (not nits)
+
+This code is read far more than it is written and lives for years. Structure is
+a primary review dimension, co-equal with correctness — not a cosmetic
+afterthought. The following are **design findings, never 🟢 nits**:
+
+- Wrong or leaky abstraction boundary; generic code depending on specific code.
+- One concept with two owners (duplicated state, parallel sources of truth).
+- A new API more general than its single caller needs.
+- Hardcoded values that should be supplied by the caller/registrar.
+- Coupling that violates the change's own stated goal.
+- Code that works but a maintainer would misread (e.g., an empty switch case
+  with no explanation — though the fix may be to remove the case, not comment
+  it).
+
+True 🟢 nits are cosmetic only: typos, formatting, a single local variable's
+name. If a comment is about how the code is *organized* or *who owns what*, it
+is not a nit — rank it as a suggestion or higher and lead with it.
 
 ### Correctness
 


### PR DESCRIPTION
Reviews can over-index on whether a change works — CI is green, prior comments are addressed — and treat structure and maintainability concerns as nitpicks. That misses the highest-yield findings on refactors, where the real question is whether the change achieves its own stated goal.

This updates the reviewer guidance (used directly by the `pr-review` skill):

- Adds a **design pass** to `REVIEW_GUIDE.md` that runs before the mechanical checks: state the PR's goal in one sentence, hunt the diff for code that violates it, verify the refactor is complete rather than carved out, scrutinize new API on shared types, and flag dead symbols. "CI green / comments addressed" is necessary but not sufficient.
- Promotes **maintainability and structure** to a primary review dimension, co-equal with correctness.
- Reclassifies the severity scale in the `pr-review` skill so abstraction, ownership, and coupling problems are suggestions rather than nitpicks; nitpick is reserved for cosmetic issues.

Docs only — no code or behavior changes.