### PR TITLE
fix: Force alwaysSingleBlock ops to a single block in makeGrid (#17769)

### DIFF
--- a/velox/experimental/torchwave/CompiledOp.cpp
+++ b/velox/experimental/torchwave/CompiledOp.cpp
@@ -366,6 +366,14 @@ int32_t makeGrid(
   sv.maxBlocks.resize(launches.size());
   const int32_t elementsPerBlock = blockSize * kMinElementsPerThread;
   for (size_t i = 0; i < launches.size(); ++i) {
+    // alwaysSingleBlock ops fold their cross-block barriers into __syncthreads
+    // and are only correct when run as a single block. Cap maxBlocks at 1 so
+    // neither the pro-rata assignment nor the latency-balancing pass below can
+    // grow them past one block.
+    if (launches[i].launch->op && launches[i].launch->op->alwaysSingleBlock()) {
+      sv.maxBlocks[i] = 1;
+      continue;
+    }
     sv.maxBlocks[i] = static_cast<int32_t>(
         (launches[i].numElements + elementsPerBlock - 1) / elementsPerBlock);
     if (sv.maxBlocks[i] < 1) {


### PR DESCRIPTION
Summary:

A fused op whose single-block kernel variant folds its cross-block barrier into a plain `__syncthreads()` (marked via `setAlwaysSingleBlock(true)` in `emitBarrier`) is only correct when launched as exactly one thread block. `makeGrid` initializes such ops to 1 block, but the subsequent latency-balancing pass was free to grow them back up to `maxBlocks[i]`, which was computed purely from element count and never capped for `alwaysSingleBlock` ops.

This bit the fused `clone` + `tw.index_put_elt_two` case under `--single_block 1`: the clone (11700 elements) is the highest-latency launch, so the balancing pass grew it from 1 block back to 12. With 12 blocks the `__syncthreads()` only orders the clone -> scatter phases within a block, not across blocks. The normal path got away with it (12 blocks run concurrently, a benign race where the clones usually finish first), but the `debug_single_ops` path runs each block fully and sequentially, so a later block's clone deterministically overwrites scatter values an earlier block already wrote into its clone region — producing missing scatter results (`actual=0 expected=1002`, 436 diffs).

Fix: cap `maxBlocks[i] = 1` for `alwaysSingleBlock` ops in `makeGrid`, so neither the pro-rata assignment nor the latency-balancing pass can grow them past one block. This restores the invariant the auto grid-choice path already relied on (single-block variants are only selected for small inputs, which are naturally 1 block) and also removes the latent race in the normal multi-block launch path.

Reviewed By: Yuhta

Differential Revision: D107782406


