### PR TITLE
refactor: Unify partitioned and non-partitioned paths with SplitGroup (#17772)

### DIFF
--- a/velox/connectors/hive/HiveIndexSource.cpp
+++ b/velox/connectors/hive/HiveIndexSource.cpp
@@ -1166,23 +1166,11 @@ void HiveIndexSource::addSplits(
   }
 
   if (partitionIndexConditions_.empty()) {
-    // Non-partitioned path: single shared scan spec for all readers.
-    // Partition constants (if any) come from the first split's metadata.
-    // This is correct under partition-aware grouped execution (one partition
-    // per lifespan) and when the table has no partition columns. Under
-    // standard grouped execution with multiple partitions and partition
-    // columns in the output, each split may have different partition values
-    // but we apply only the first split's values to the shared scan spec.
-    // TODO: support per-split partition constants when splits span multiple
-    // partitions without partition index conditions.
-    const auto* partitionValues =
-        hiveSplits.empty() ? nullptr : &hiveSplits.front()->partitionKeys;
-    createReadersFromSplits(
-        std::move(hiveSplits), buildScanSpec(partitionValues));
-    defaultReaders_.reserve(readers_.size());
-    for (auto& reader : readers_) {
-      defaultReaders_.push_back(reader.get());
-    }
+    // Non-partitioned path: single group with all splits. Partition
+    // constants come from the first split only.
+    // TODO: Build per-split scan specs when splits span multiple partitions
+    // and partition columns appear in the output.
+    createSplitGroup(std::move(hiveSplits));
     return;
   }
   // Partitioned path: group splits by partition values, build a per-group
@@ -1201,38 +1189,11 @@ void HiveIndexSource::buildPartitionGroups(
     return;
   }
 
-  const bool readTimestampAsLocal =
-      hiveConfig_->readTimestampPartitionValueAsLocalTime(
-          connectorQueryCtx_->sessionProperties());
-
-  // For each distinct partition, build typed routing constants and a per-group
-  // scan spec where partition columns are emitted as constants by the
-  // underlying reader.
-  partitionGroups_.reserve(splitGroups.size());
+  // For each distinct partition, build a SplitGroup with its own scan spec,
+  // routing constants, and readers.
+  splitGroups_.reserve(splitGroups.size());
   for (auto& [_, groupSplits] : splitGroups) {
-    PartitionGroup group;
-    const auto& split = *groupSplits.front();
-
-    group.partitionValues.reserve(partitionIndexConditions_.size());
-    for (const auto& cond : partitionIndexConditions_) {
-      const auto& partitionValue =
-          extractPartitionValue(split, cond.partitionColumnName);
-      const auto& handle = partitionKeyHandles_.at(cond.partitionColumnName);
-      group.partitionValues.emplace_back(newConstantFromString(
-          handle->dataType(),
-          partitionValue,
-          pool_,
-          readTimestampAsLocal,
-          cond.isPartitionDateValueDaysSinceEpoch));
-    }
-
-    const auto groupReadersStartIdx = readers_.size();
-    createReadersFromSplits(
-        std::move(groupSplits), buildScanSpec(&split.partitionKeys));
-    for (size_t i = groupReadersStartIdx; i < readers_.size(); ++i) {
-      group.readers.emplace_back(readers_[i].get());
-    }
-    partitionGroups_.push_back(std::move(group));
+    createSplitGroup(std::move(groupSplits));
   }
 }
 
@@ -1272,9 +1233,35 @@ std::optional<std::string> HiveIndexSource::makePartitionKey(
   return key;
 }
 
-void HiveIndexSource::createReadersFromSplits(
-    std::vector<std::shared_ptr<const HiveConnectorSplit>> hiveSplits,
-    const std::shared_ptr<common::ScanSpec>& scanSpec) {
+void HiveIndexSource::createSplitGroup(
+    std::vector<std::shared_ptr<const HiveConnectorSplit>> hiveSplits) {
+  VELOX_CHECK(!hiveSplits.empty());
+  const auto& split = *hiveSplits.front();
+  auto scanSpec = buildScanSpec(&split.partitionKeys);
+
+  auto& group = splitGroups_.emplace_back();
+
+  // Build typed routing constants from the splits' partition values. For the
+  // non-partitioned path partitionIndexConditions_ is empty, leaving
+  // partitionValues empty.
+  const bool readTimestampAsLocal =
+      hiveConfig_->readTimestampPartitionValueAsLocalTime(
+          connectorQueryCtx_->sessionProperties());
+  group.partitionValues.reserve(partitionIndexConditions_.size());
+  for (const auto& cond : partitionIndexConditions_) {
+    const auto& partitionValue =
+        extractPartitionValue(split, cond.partitionColumnName);
+    const auto& handle = partitionKeyHandles_.at(cond.partitionColumnName);
+    group.partitionValues.emplace_back(newConstantFromString(
+        handle->dataType(),
+        partitionValue,
+        pool_,
+        readTimestampAsLocal,
+        cond.isPartitionDateValueDaysSinceEpoch));
+  }
+
+  // Create readers for the splits.
+  const auto readersStartIdx = readers_.size();
   auto* registry = IndexReaderFactoryRegistry::getInstance();
   for (auto& hiveSplit : hiveSplits) {
     const auto* factory = registry->getFactory(hiveSplit->fileFormat);
@@ -1290,14 +1277,18 @@ void HiveIndexSource::createReadersFromSplits(
       createFileIndexReader(std::move(hiveSplit), scanSpec);
     }
   }
+  VELOX_CHECK_GT(
+      readers_.size(), readersStartIdx, "No index readers created from splits");
 
-  VELOX_CHECK(!readers_.empty(), "No index readers created from splits");
+  for (size_t i = readersStartIdx; i < readers_.size(); ++i) {
+    group.readers.emplace_back(readers_[i].get());
+  }
 }
 
-HiveIndexSource::PartitionGroup* HiveIndexSource::findPartitionGroup(
+HiveIndexSource::SplitGroup* HiveIndexSource::findSplitGroup(
     const RowVectorPtr& probeInput,
     vector_size_t row) {
-  for (auto& group : partitionGroups_) {
+  for (auto& group : splitGroups_) {
     bool match = true;
     for (size_t i = 0; i < partitionIndexConditions_.size(); ++i) {
       const auto& cond = partitionIndexConditions_[i];
@@ -1319,27 +1310,28 @@ std::shared_ptr<IndexSource::ResultIterator> HiveIndexSource::lookup(
   VELOX_CHECK_GT(request.input->size(), 0, "Empty lookup request");
   VELOX_CHECK(splitsAdded_, "No splits added before lookup");
 
-  // All splits may have been filtered out (e.g., all had NULL partition
-  // routing values). Return empty results for every lookup.
   if (readers_.empty()) {
+    // All splits were filtered out (e.g., all had NULL partition routing
+    // values).
     return EmptyIterator::instance();
   }
 
   auto options = SplitIndexReader::Options{
       .maxRowsPerRequest = static_cast<vector_size_t>(maxRowsPerIndexRequest_)};
 
-  if (partitionGroups_.empty()) {
-    return createLookupIterator(request, defaultReaders_, options);
+  // Non-partitioned path: single group, all rows match.
+  if (partitionIndexConditions_.empty()) {
+    VELOX_CHECK_EQ(splitGroups_.size(), 1);
+    return createLookupIterator(request, splitGroups_[0].readers, options);
   }
 
   const auto numRows = request.input->size();
 
-  // Map each row to its partition group.
-  folly::F14FastMap<PartitionGroup*, std::vector<vector_size_t>>
-      partitionRowMap;
-  partitionRowMap.reserve(partitionGroups_.size());
+  // Partitioned path: route each row to its matching split group.
+  folly::F14FastMap<SplitGroup*, std::vector<vector_size_t>> partitionRowMap;
+  partitionRowMap.reserve(splitGroups_.size());
   for (vector_size_t row = 0; row < numRows; ++row) {
-    auto* group = findPartitionGroup(request.input, row);
+    auto* group = findSplitGroup(request.input, row);
     if (group != nullptr) {
       partitionRowMap[group].emplace_back(row);
     }
@@ -1349,7 +1341,7 @@ std::shared_ptr<IndexSource::ResultIterator> HiveIndexSource::lookup(
   }
 
   if (partitionRowMap.empty()) {
-    // No partition group matched any probe row.
+    // No split group matched any probe row.
     return EmptyIterator::instance();
   }
 
@@ -1393,8 +1385,7 @@ HiveIndexSource::createLookupIterator(
 std::shared_ptr<IndexSource::ResultIterator>
 HiveIndexSource::createPartitionLookupIterator(
     const Request& request,
-    folly::F14FastMap<PartitionGroup*, std::vector<vector_size_t>>
-        partitionRowMap,
+    folly::F14FastMap<SplitGroup*, std::vector<vector_size_t>> partitionRowMap,
     const SplitIndexReader::Options& options) {
   // Create a PartitionIterator per group.
   std::vector<std::shared_ptr<IndexSource::ResultIterator>> partitionIters;

--- a/velox/connectors/hive/HiveIndexSource.h
+++ b/velox/connectors/hive/HiveIndexSource.h
@@ -185,18 +185,10 @@ class HiveIndexSource : public IndexSource,
       std::shared_ptr<const HiveConnectorSplit> split,
       const std::shared_ptr<common::ScanSpec>& scanSpec);
 
-  // Creates readers from splits into readers_. Uses a registered
-  // IndexReaderFactory when available, otherwise falls back to
-  // FileIndexReader.
-  void createReadersFromSplits(
-      std::vector<std::shared_ptr<const HiveConnectorSplit>> splits,
-      const std::shared_ptr<common::ScanSpec>& scanSpec);
-
   // Groups splits by their routing-column partition values, then builds
-  // one PartitionGroup per distinct partition with its own scan
-  // spec (partition columns set as constants) and routing constants for
-  // runtime probe matching. Populates partitionGroups_. Called from
-  // addSplits() when partitionIndexConditions_ is non-empty.
+  // one SplitGroup per distinct partition with its own scan spec and
+  // routing constants. Populates splitGroups_. Called from addSplits()
+  // when partitionIndexConditions_ is non-empty.
   void buildPartitionGroups(
       std::vector<std::shared_ptr<const HiveConnectorSplit>> hiveSplits);
 
@@ -213,30 +205,36 @@ class HiveIndexSource : public IndexSource,
   std::optional<std::string> makePartitionKey(
       const HiveConnectorSplit& split) const;
 
-  // Splits sharing the same partition values, grouped during addSplits().
-  // One group per distinct set of partition column values. Each group owns
-  // its own scan spec with partition-column constants set, so the underlying
-  // reader emits partition values directly.
-  struct PartitionGroup {
+  // A group of splits sharing a scan spec. For partitioned tables, one
+  // group per distinct set of partition column values. For non-partitioned
+  // tables, a single group holds all splits.
+  struct SplitGroup {
     // Raw pointers into readers_; ownership stays with readers_.
     std::vector<SplitIndexReader*> readers;
     // Typed constants aligned with partitionIndexConditions_, used by
-    // findPartitionGroup() to match against probe row values.
+    // findSplitGroup() to match against probe row values. Empty for the
+    // non-partitioned path.
     std::vector<VectorPtr> partitionValues;
   };
 
-  // Finds the partition group whose partition values match the given probe
+  // Builds a SplitGroup from a set of splits sharing the same partition and
+  // appends it to splitGroups_: builds the scan spec and routing constants
+  // from the splits' partition values, and creates the readers (via registered
+  // IndexReaderFactory or FileIndexReader, owned by readers_). The routing
+  // constants are empty for the non-partitioned path.
+  void createSplitGroup(
+      std::vector<std::shared_ptr<const HiveConnectorSplit>> splits);
+
+  // Finds the split group whose partition values match the given probe
   // row's partition column values. Returns nullptr if no group matches.
-  PartitionGroup* findPartitionGroup(
-      const RowVectorPtr& probeInput,
-      vector_size_t row);
+  SplitGroup* findSplitGroup(const RowVectorPtr& probeInput, vector_size_t row);
 
   // Creates a partitioned lookup iterator when probe rows target different
-  // partition groups. Takes a pre-built row-to-group mapping, dispatches
+  // split groups. Takes a pre-built row-to-group mapping, dispatches
   // each sub-batch to the matching group's readers, and merges results.
   std::shared_ptr<ResultIterator> createPartitionLookupIterator(
       const Request& request,
-      folly::F14FastMap<PartitionGroup*, std::vector<vector_size_t>>
+      folly::F14FastMap<SplitGroup*, std::vector<vector_size_t>>
           partitionRowMap,
       const SplitIndexReader::Options& options);
 
@@ -358,12 +356,10 @@ class HiveIndexSource : public IndexSource,
   // All index readers (both built-in and external). Owns every reader
   // regardless of partitioned vs non-partitioned path. Created by addSplits().
   std::vector<std::unique_ptr<SplitIndexReader>> readers_;
-  // Raw pointers into readers_ for the non-partitioned path. Built once
-  // in addSplits() to avoid per-lookup allocation.
-  std::vector<SplitIndexReader*> defaultReaders_;
-  // Partition groups built during addSplits() when partition index conditions
-  // are present. One group per distinct set of partition column values.
-  std::vector<PartitionGroup> partitionGroups_;
+  // Split groups built during addSplits(). For non-partitioned tables,
+  // contains a single group. For partitioned tables, one group per
+  // distinct set of partition column values.
+  std::vector<SplitGroup> splitGroups_;
 
   // Set to true after addSplits() is called. Used to distinguish "no splits
   // added" (programming error) from "all splits filtered out" (valid case).


### PR DESCRIPTION
Summary:

Rename `PartitionGroup` to `SplitGroup` and use `splitGroups_` for both the partitioned and non-partitioned code paths. Previously the non-partitioned path stored reader pointers in a separate `defaultReaders_` vector while the partitioned path used `partitionGroups_`. Now both paths populate `splitGroups_` — the non-partitioned case creates a single group with empty `partitionValues`.

This removes `defaultReaders_` and simplifies `lookup()` to branch on `partitionIndexConditions_.empty()` instead of checking separate data structures.

Reviewed By: xiaoxmeng

Differential Revision: D107915419


