### PR TITLE
perf: Call vector reserve to avoid unnecessary growth during insertion

### DIFF
--- a/velox/functions/lib/MakeRowFromMap.h
+++ b/velox/functions/lib/MakeRowFromMap.h
@@ -240,6 +240,9 @@ class MakeRowFromMap {
     std::vector<bool> visited(keyToIndex_.size());
     std::vector<std::vector<BaseVector::CopyRange>> copyRangesFromBase(
         keyToIndex_.size());
+    for (auto& ranges : copyRangesFromBase) {
+      ranges.reserve(rows.countSelected());
+    }
     rows.applyToSelected([&](vector_size_t row) INLINE_LAMBDA {
       std::fill(visited.begin(), visited.end(), false);
       if (!decodedMap->isNullAt(row)) {


### PR DESCRIPTION
Pre-allocated capacity of `rows.countSelected()` for each inner vector in `copyRangesFromBase` within `MakeRowFromMap::toRowVectorImpl` (fbcode/velox/functions/lib/MakeRowFromMap.h). This function is called from `vectorFunction_->apply()` inside `Expr::invokeApplyWithListeners`. Strobelight profiling confirmed that `std::vector::_M_realloc_insert` was hot due to repeated `push_back` calls growing each inner vector from size 0. The reserve size `rows.countSelected()` is the exact upper bound per vector — the `visited[index]` check guarantees at most one CopyRange entry per selected row per key, so no over-allocation occurs in the common case where all keys are present in all rows.

Reviewed By: yuxuanchen1997

Differential Revision: D107608287


