### PR TITLE
feat(cudf): Optimize Velox-cudf Iceberg schema evolution

### DIFF
--- a/velox/experimental/cudf/connectors/hive/CudfSplitReader.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfSplitReader.cpp
@@ -130,7 +130,7 @@ std::optional<std::unique_ptr<cudf::table>> CudfSplitReader::next(
   if (!chunkOpt.has_value()) {
     return std::nullopt;
   }
-  auto cudfTable = std::move(chunkOpt.value());
+  auto cudfTable = std::move(chunkOpt.value().tbl);
 
   TotalScanTimeCallbackData* callbackData =
       new TotalScanTimeCallbackData{startTimeUs, ioStatistics_};
@@ -142,7 +142,7 @@ std::optional<std::unique_ptr<cudf::table>> CudfSplitReader::next(
   return cudfTable;
 }
 
-std::optional<std::unique_ptr<cudf::table>> CudfSplitReader::readNextChunk(
+std::optional<cudf::io::table_with_metadata> CudfSplitReader::readNextChunk(
     rmm::device_async_resource_ref output_mr) {
   if (!useExperimentalCudfReader_) {
     // Read table using the regular cudf parquet reader
@@ -152,8 +152,7 @@ std::optional<std::unique_ptr<cudf::table>> CudfSplitReader::readNextChunk(
       return std::nullopt;
     }
 
-    auto tableWithMetadata = splitReader_->read_chunk();
-    return std::move(tableWithMetadata.tbl);
+    return splitReader_->read_chunk();
   }
 
   // Read table using the experimental parquet reader
@@ -215,8 +214,7 @@ std::optional<std::unique_ptr<cudf::table>> CudfSplitReader::readNextChunk(
     return std::nullopt;
   }
 
-  auto tableWithMetadata = exptSplitReader_->materialize_all_columns_chunk();
-  return std::move(tableWithMetadata.tbl);
+  return exptSplitReader_->materialize_all_columns_chunk();
 }
 
 void CudfSplitReader::resetSplit() {

--- a/velox/experimental/cudf/connectors/hive/CudfSplitReader.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfSplitReader.cpp
@@ -318,6 +318,10 @@ void CudfSplitReader::setupCudfDataSource() {
       std::make_unique<BufferedInputDataSource>(std::move(bufferedInput));
 }
 
+bool CudfSplitReader::hasSubfieldFilter() const {
+  return subfieldFilterExpr_ != nullptr;
+}
+
 void CudfSplitReader::setupReaderOptions() {
   VELOX_CHECK_NOT_NULL(
       dataSource_,

--- a/velox/experimental/cudf/connectors/hive/CudfSplitReader.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfSplitReader.cpp
@@ -119,9 +119,6 @@ void CudfSplitReader::prepareSplit(
 std::optional<std::unique_ptr<cudf::table>> CudfSplitReader::next(
     uint64_t /*size*/) {
   VELOX_NVTX_OPERATOR_FUNC_RANGE();
-  VELOX_CHECK(
-      splitReader_ or exptSplitReader_,
-      "No Cudf Split reader present. Call prepareSplit() first.");
 
   // Record start time before reading chunk
   auto startTimeUs = getCurrentTimeMicro();
@@ -316,10 +313,6 @@ void CudfSplitReader::setupCudfDataSource() {
   }
   dataSource_ =
       std::make_unique<BufferedInputDataSource>(std::move(bufferedInput));
-}
-
-bool CudfSplitReader::hasSubfieldFilter() const {
-  return subfieldFilterExpr_ != nullptr;
 }
 
 void CudfSplitReader::setupReaderOptions() {

--- a/velox/experimental/cudf/connectors/hive/CudfSplitReader.h
+++ b/velox/experimental/cudf/connectors/hive/CudfSplitReader.h
@@ -86,7 +86,6 @@ class CudfSplitReader : public NvtxHelper {
   /// Clear splitReaders and datasources after split has been fully processed.
   void resetSplit();
 
-  /// Read the next raw chunk from the parquet reader (regular or hybrid).
   /// Read the next table chunk with metadata from the parquet reader (regular
   /// or hybrid). Returns nullopt when no more data.
   virtual std::optional<cudf::io::table_with_metadata> readNextChunk(

--- a/velox/experimental/cudf/connectors/hive/CudfSplitReader.h
+++ b/velox/experimental/cudf/connectors/hive/CudfSplitReader.h
@@ -87,8 +87,9 @@ class CudfSplitReader : public NvtxHelper {
   void resetSplit();
 
   /// Read the next raw chunk from the parquet reader (regular or hybrid).
-  /// Returns nullopt when no more data.
-  virtual std::optional<std::unique_ptr<cudf::table>> readNextChunk(
+  /// Read the next table chunk with metadata from the parquet reader (regular
+  /// or hybrid). Returns nullopt when no more data.
+  virtual std::optional<cudf::io::table_with_metadata> readNextChunk(
       rmm::device_async_resource_ref output_mr);
 
   std::shared_ptr<CudfHiveConnectorSplit> split_;

--- a/velox/experimental/cudf/connectors/hive/CudfSplitReader.h
+++ b/velox/experimental/cudf/connectors/hive/CudfSplitReader.h
@@ -77,17 +77,20 @@ class CudfSplitReader : public NvtxHelper {
   }
 
  protected:
-  /// Create the chunked parquet reader.
+  // Create the chunked parquet reader.
   virtual void createCudfReader(rmm::device_async_resource_ref output_mr);
 
-  /// Setup the cuDF data source
+  // Setup the cuDF data source
   void setupCudfDataSource();
 
-  /// Clear splitReaders and datasources after split has been fully processed.
+  // Whether a pushed-down subfield filter is set on this split reader.
+  bool hasSubfieldFilter() const;
+
+  // Clear splitReaders and datasources after split has been fully processed.
   void resetSplit();
 
-  /// Read the next table chunk with metadata from the parquet reader (regular
-  /// or hybrid). Returns nullopt when no more data.
+  // Read the next table chunk with metadata from the parquet reader (regular
+  // or hybrid). Returns nullopt when no more data.
   virtual std::optional<cudf::io::table_with_metadata> readNextChunk(
       rmm::device_async_resource_ref output_mr);
 

--- a/velox/experimental/cudf/connectors/hive/CudfSplitReader.h
+++ b/velox/experimental/cudf/connectors/hive/CudfSplitReader.h
@@ -84,7 +84,14 @@ class CudfSplitReader : public NvtxHelper {
   void setupCudfDataSource();
 
   // Whether a pushed-down subfield filter is set on this split reader.
-  bool hasSubfieldFilter() const;
+  bool hasSubfieldFilter() const {
+    return subfieldFilterExpr_ != nullptr;
+  }
+
+  // The pushed-down subfield filter AST, or nullptr if none.
+  cudf::ast::expression const* subfieldFilterExpr() const {
+    return subfieldFilterExpr_;
+  }
 
   // Clear splitReaders and datasources after split has been fully processed.
   void resetSplit();

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergConnector.h
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergConnector.h
@@ -18,7 +18,7 @@
 #include "velox/experimental/cudf/connectors/hive/CudfHiveConfig.h"
 
 #include "velox/connectors/hive/HiveConnector.h"
-#include "velox/connectors/hive/iceberg/IcebergConfig.h"
+#include "velox/connectors/hive/iceberg/IcebergConnector.h"
 
 namespace facebook::velox::cudf_velox::connector::hive::iceberg {
 
@@ -67,9 +67,10 @@ class CudfIcebergConnector final
 /// Factory for creating CudfIcebergConnector instances.
 class CudfIcebergConnectorFactory final : public ConnectorFactory {
  public:
-  static constexpr const char* kCudfIcebergConnectorName = "cudf-iceberg";
-
-  CudfIcebergConnectorFactory() : ConnectorFactory(kCudfIcebergConnectorName) {}
+  CudfIcebergConnectorFactory()
+      : ConnectorFactory(
+            ::facebook::velox::connector::hive::iceberg::
+                IcebergConnectorFactory::kIcebergConnectorName) {}
 
   explicit CudfIcebergConnectorFactory(const char* connectorName)
       : ConnectorFactory(connectorName) {}

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergDataSource.cpp
@@ -23,8 +23,6 @@
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/connectors/hive/iceberg/IcebergSplit.h"
 
-#include <algorithm>
-
 namespace facebook::velox::cudf_velox::connector::hive::iceberg {
 
 namespace velox_connector = ::facebook::velox::connector;
@@ -59,23 +57,6 @@ void CudfIcebergDataSource::convertSplit(
   VELOX_CHECK(
       icebergSplit_->start == 0,
       "Sub-splits are not yet supported in CudfIcebergDataSource");
-
-  // Subfield filters are not supported when positional deletes are present as
-  // the row positions may have been altered.
-  // TODO(mh): Re-enable when https://github.com/rapidsai/cudf/pull/23077 merges
-  if (subfieldFilterExpr_ != nullptr and
-      std::any_of(
-          icebergSplit_->deleteFiles.begin(),
-          icebergSplit_->deleteFiles.end(),
-          [](const auto& deleteFile) {
-            return deleteFile.content ==
-                velox_iceberg::FileContent::kPositionalDeletes or
-                deleteFile.content ==
-                velox_iceberg::FileContent::kDeletionVector;
-          })) {
-    VELOX_NYI(
-        "cuDF Iceberg reader does not yet support subfield filters when positional deletes are present");
-  }
 
   // Convert `ConnectorSplit` to `CudfHiveConnectorSplit`
   CudfHiveDataSource::convertSplit(split);

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergDataSource.cpp
@@ -23,6 +23,8 @@
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/connectors/hive/iceberg/IcebergSplit.h"
 
+#include <algorithm>
+
 namespace facebook::velox::cudf_velox::connector::hive::iceberg {
 
 namespace velox_connector = ::facebook::velox::connector;
@@ -57,6 +59,23 @@ void CudfIcebergDataSource::convertSplit(
   VELOX_CHECK(
       icebergSplit_->start == 0,
       "Sub-splits are not yet supported in CudfIcebergDataSource");
+
+  // Subfield filters are not supported when positional deletes are present as
+  // the row positions may have been altered.
+  // TODO(mh): Re-enable when https://github.com/rapidsai/cudf/pull/23077 merges
+  if (subfieldFilterExpr_ != nullptr and
+      std::any_of(
+          icebergSplit_->deleteFiles.begin(),
+          icebergSplit_->deleteFiles.end(),
+          [](const auto& deleteFile) {
+            return deleteFile.content ==
+                velox_iceberg::FileContent::kPositionalDeletes or
+                deleteFile.content ==
+                velox_iceberg::FileContent::kDeletionVector;
+          })) {
+    VELOX_NYI(
+        "cuDF Iceberg reader does not yet support subfield filters when positional deletes are present");
+  }
 
   // Convert `ConnectorSplit` to `CudfHiveConnectorSplit`
   CudfHiveDataSource::convertSplit(split);

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergDeletionHelpers.cu
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergDeletionHelpers.cu
@@ -26,6 +26,7 @@
 
 #include <cuda/iterator>
 #include <cuda/std/type_traits>
+#include <thrust/count.h>
 #include <thrust/scatter.h>
 #include <thrust/sequence.h>
 #include <thrust/transform.h>
@@ -60,6 +61,17 @@ void applyBitmapToMask(
       deleteMask.begin<bool>(),
       deleteMask.begin<bool>(),
       IsDeletedRow{bitmap.data()});
+}
+
+cudf::size_type countDeletedRows(
+    cudf::column_view const& deleteMask,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref temp_mr) {
+  return static_cast<cudf::size_type>(thrust::count(
+      rmm::exec_policy_nosync(stream, temp_mr),
+      deleteMask.begin<bool>(),
+      deleteMask.end<bool>(),
+      true));
 }
 
 void scatterDeletesToMask(

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergDeletionHelpers.h
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergDeletionHelpers.h
@@ -40,6 +40,17 @@ void applyBitmapToMask(
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref temp_mr);
 
+/// Counts the number of deleted rows (set to `true`) in the supplied deletion
+/// mask.
+/// @param deleteMask Deletion mask column (row is deleted iff `true`)
+/// @param stream CUDA stream to use
+/// @param temp_mr Memory resource for temporary allocations
+/// @return Number of deleted rows
+cudf::size_type countDeletedRows(
+    cudf::column_view const& deleteMask,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref temp_mr);
+
 /// Scatters deletes to the deletion mask at positions indicated by `indices`
 /// (anti-join semantics).
 /// @param deleteMask Mutable view of deletion mask column

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
@@ -605,9 +605,9 @@ std::unique_ptr<cudf::table> CudfIcebergSplitReader::buildOutputTable(
   VELOX_CHECK_EQ(
       output.size(),
       outputType_->size(),
-      "Mismatch between number of columns in the output schema and the assembled Iceberg table. Output schema: {}, Assembled table: {}",
+      "Mismatch between number of columns in the output schema and the assembled Iceberg table. Output schema: {}, Assembled columns: {}",
       outputType_->toString(),
-      table->schema().toString());
+      output.size());
 
   VELOX_CHECK_EQ(
       output.size() + extraEqualityColumns_.size(),
@@ -616,7 +616,7 @@ std::unique_ptr<cudf::table> CudfIcebergSplitReader::buildOutputTable(
       "Read columns: {}, Consumed: {}, Equality columns: {}",
       fileColumnIndex_.size(),
       output.size(),
-      extraEqualityColumns_.size(), );
+      extraEqualityColumns_.size());
 
   return std::make_unique<cudf::table>(std::move(output));
 }

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
@@ -575,6 +575,9 @@ std::unique_ptr<cudf::table> CudfIcebergSplitReader::buildOutputTable(
   std::vector<std::unique_ptr<cudf::column>> output;
   output.reserve(outputType_->size());
 
+  // Number of read columns referenced in the output table.
+  size_t consumedReadColumns = 0;
+
   for (size_t i = 0; i < outputType_->size(); ++i) {
     const auto& fieldName = outputType_->nameOf(i);
     const auto& veloxType = outputType_->childAt(i);
@@ -591,6 +594,7 @@ std::unique_ptr<cudf::table> CudfIcebergSplitReader::buildOutputTable(
                fileIt != fileColumnIndex_.end()) {
       // Column read from the data file.
       output.push_back(std::move(columns[fileIt->second]));
+      ++consumedReadColumns;
     } else {
       // Schema evolution: column added after this data file was written and
       // absent from the file. Emit a typed NULL column.
@@ -609,13 +613,16 @@ std::unique_ptr<cudf::table> CudfIcebergSplitReader::buildOutputTable(
       outputType_->toString(),
       output.size());
 
+  // Every read column must be accounted for: either an output column, or
+  // intentionally dropped (equality-delete key column). Any leftover means a
+  // read column was silently dropped (a bug).
   VELOX_CHECK_EQ(
-      output.size() + extraEqualityColumns_.size(),
+      consumedReadColumns + extraEqualityColumns_.size(),
       fileColumnIndex_.size(),
-      "Read table columns were not fully accounted for during Iceberg table assembly."
+      "Read table columns were not fully accounted for during Iceberg table assembly. "
       "Read columns: {}, Consumed: {}, Equality columns: {}",
       fileColumnIndex_.size(),
-      output.size(),
+      consumedReadColumns,
       extraEqualityColumns_.size());
 
   return std::make_unique<cudf::table>(std::move(output));

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
@@ -280,15 +280,23 @@ CudfIcebergSplitReader::readNextChunk(
   // tables so post-delete empty chunks still have the expected number and order
   // of output columns.
 
-  // Compute the row count override if all projected columns are missing
-  auto rowCountOverride = (allColumnsMissing and isApplyingDeletes)
-      ? std::optional<cudf::size_type>(
-            numRows - countDeletedRows(deleteMaskView_, stream_, get_temp_mr()))
-      : std::nullopt;
-  VELOX_CHECK(
-      not rowCountOverride.has_value() or rowCountOverride.value() >= 0,
-      "Encountered a negative row count override for the synthetic table: {}",
-      rowCountOverride.value());
+  // Compute the row count override if all projected columns are missing.
+  std::optional<cudf::size_type> rowCountOverride = std::nullopt;
+  if (allColumnsMissing) {
+    if (isApplyingDeletes) {
+      const auto deletedRows = static_cast<std::size_t>(
+          countDeletedRows(deleteMaskView_, stream_, get_temp_mr()));
+      VELOX_CHECK_LE(
+          deletedRows,
+          numRows,
+          "Deleted rows exceed input rows for synthetic table. numRows={}, deletedRows={}",
+          numRows,
+          deletedRows);
+      rowCountOverride = numRows - deletedRows;
+    } else {
+      rowCountOverride = numRows;
+    }
+  }
 
   // Build the output table with an optional row count override indicating if
   // all projected columns are missing

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
@@ -618,10 +618,10 @@ std::unique_ptr<cudf::table> CudfIcebergSplitReader::buildOutputTable(
   // read column was silently dropped (a bug).
   VELOX_CHECK_EQ(
       consumedReadColumns + extraEqualityColumns_.size(),
-      fileColumnIndex_.size(),
+      columns.size(),
       "Read table columns were not fully accounted for during Iceberg table assembly. "
       "Read columns: {}, Consumed: {}, Equality columns: {}",
-      fileColumnIndex_.size(),
+      columns.size(),
       consumedReadColumns,
       extraEqualityColumns_.size());
 

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
@@ -32,6 +32,7 @@
 
 #include <cudf/column/column_factories.hpp>
 #include <cudf/io/parquet.hpp>
+#include <cudf/io/parquet_metadata.hpp>
 #include <cudf/null_mask.hpp>
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/scalar/scalar_factories.hpp>
@@ -107,18 +108,23 @@ CudfIcebergSplitReader::CudfIcebergSplitReader(
           useExperimentalCudfReader,
           subfieldFilterExpr),
       icebergSplit_(std::move(icebergSplit)),
-      hiveConfig_(hiveConfig) {}
+      hiveConfig_(hiveConfig) {
+  // Extract physical names of target data columns from readColumnNames
+  VELOX_CHECK_GE(readColumnNames.size(), outputType->size());
+  physicalNames_.assign(
+      readColumnNames.begin(), readColumnNames.begin() + outputType->size());
+}
 
 void CudfIcebergSplitReader::prepareSplit(
     dwio::common::RuntimeStatistics& runtimeStats) {
   // Clear existing delete file readers and other state
   deletionVectorReader_.reset();
-  positionalDeleteFileReaders_.clear();
   equalityDeleteFileReaders_.clear();
   extraEqualityColumns_.clear();
   injectedColumns_.clear();
   fileColumnNames_.clear();
   fileColumnIndex_.clear();
+  fileRowCount_.reset();
   baseReadOffset_ = 0;
 
   // Must setup delete file readers before calling base `prepareSplit` so
@@ -173,8 +179,14 @@ CudfIcebergSplitReader::readNextChunk(
   // Lazily cache column names and their positions
   ensureFileColumnIndex(schemaInfo);
 
-  // Number of table rows read by cuDF (before any deletes)
-  const auto numRows = cudfTable->num_rows();
+  // Check if all projected columns are schema-evolution (missing) columns
+  const bool allColumnsMissing = cudfTable->num_columns() == 0;
+
+  // Number of rows before any deletes from cuDF table or parquet footer if all
+  // columns are missing
+  const auto numRows = allColumnsMissing
+      ? fileRowCount()
+      : static_cast<size_t>(cudfTable->num_rows());
 
   // Determine if we are applying any deletes
   const auto isApplyingDeletes = numRows > 0 and
@@ -182,6 +194,12 @@ CudfIcebergSplitReader::readNextChunk(
        equalityDeleteFileReaders_.size());
 
   if (isApplyingDeletes) {
+    // Equality deletes require reading their key columns, so
+    // `allColumnsMissing` must be false
+    VELOX_CHECK(
+        not allColumnsMissing or equalityDeleteFileReaders_.empty(),
+        "Equality deletes are not expected when all projected columns are missing from the file");
+
     // Allocate deletion mask column if needed (nothing is deleted)
     if (not deleteMask_ or std::cmp_less(deleteMask_->size(), numRows)) {
       auto false_scalar =
@@ -207,26 +225,39 @@ CudfIcebergSplitReader::readNextChunk(
 
     // Apply deletion vector
     if (deletionVectorReader_) {
-      applyDeletionVector(cudfTable->view());
+      applyDeletionVector(numRows);
     }
     // Apply positional deletes
     if (positionalDeleteFileReaders_.size()) {
-      applyPositionalDeletes(cudfTable->view());
+      applyPositionalDeletes(numRows);
     }
     // Apply equality deletes
     if (equalityDeleteFileReaders_.size()) {
       applyEqualityDeletes(cudfTable->view());
     }
 
-    cudfTable = cudf::apply_deletion_mask(
-        cudfTable->view(), deleteMaskView_, stream_, get_output_mr());
+    // Only apply deletes if there are physical columns to filter
+    if (not allColumnsMissing) {
+      cudfTable = cudf::apply_deletion_mask(
+          cudfTable->view(), deleteMaskView_, stream_, get_output_mr());
+    }
   }
 
   // Reorder read columns, inject info and partition columns and fill
   // schema-evolution columns with typed NULLs. This must run even for 0-row
   // tables so post-delete empty chunks still have the expected number and order
   // of output columns.
-  cudfTable = buildOutputTable(std::move(cudfTable), output_mr);
+
+  // Compute the row count override if all projected columns are missing
+  auto rowCountOverride = allColumnsMissing
+      ? std::optional<cudf::size_type>(
+            numRows - countDeletedRows(deleteMaskView_, stream_, get_temp_mr()))
+      : std::nullopt;
+
+  // Build the output table with an optional row count override indicating if
+  // all projected columns are missing
+  cudfTable =
+      buildOutputTable(std::move(cudfTable), output_mr, rowCountOverride);
 
   // Update the base read offset
   baseReadOffset_ += numRows;
@@ -373,16 +404,14 @@ void CudfIcebergSplitReader::setupDeleteFileReaders(
   }
 }
 
-void CudfIcebergSplitReader::applyDeletionVector(cudf::table_view input) {
+void CudfIcebergSplitReader::applyDeletionVector(std::size_t numRows) {
   // Apply deletion vector into the deleteMask_
-  const auto numRows = input.num_rows();
   deletionVectorReader_->applyDeletes(
       deleteMaskView_, baseReadOffset_, numRows, stream_, get_temp_mr());
 }
 
-void CudfIcebergSplitReader::applyPositionalDeletes(cudf::table_view input) {
+void CudfIcebergSplitReader::applyPositionalDeletes(std::size_t numRows) {
   // Apply positional deletes into the deleteMask_
-  const auto numRows = input.num_rows();
 
   // Initialize host and device delete bitmaps
   const auto numWords = cudf::num_bitmask_words(numRows);
@@ -483,27 +512,24 @@ void CudfIcebergSplitReader::setupColumnProjection() {
 }
 
 void CudfIcebergSplitReader::adaptColumns() {
-  // Detect info columns and partition columns
+  // Detect info and partition columns. Split-metadata lookups use the physical
+  // names as outputType may carry logical aliases
   for (size_t i = 0; i < outputType_->size(); ++i) {
-    const auto& fieldName = outputType_->nameOf(i);
+    const auto& fieldName = physicalNames_[i];
+    const auto& veloxType = outputType_->childAt(i);
 
     if (auto iter = split_->infoColumns.find(fieldName);
         iter != split_->infoColumns.end()) {
       injectedColumns_.emplace(
-          fieldName, InjectedColumn{iter->second, outputType_->childAt(i)});
+          fieldName, InjectedColumn{iter->second, veloxType});
     } else if (auto it = icebergSplit_->partitionKeys.find(fieldName);
                it != icebergSplit_->partitionKeys.end()) {
       // Partition columns: Hive migrated table. In Hive-written data
       // files, partition column values are stored in partition metadata
       // rather than in the data file itself, following Hive's
       // partitioning convention.
-      VELOX_CHECK(
-          it->second.has_value(),
-          "Iceberg partition key '{}' has no value in split metadata",
-          fieldName);
       injectedColumns_.emplace(
-          fieldName,
-          InjectedColumn{it->second.value(), outputType_->childAt(i)});
+          fieldName, InjectedColumn{it->second, veloxType});
     }
   }
 
@@ -531,36 +557,62 @@ void CudfIcebergSplitReader::ensureFileColumnIndex(
   }
 }
 
+std::size_t CudfIcebergSplitReader::fileRowCount() {
+  if (fileRowCount_.has_value()) {
+    return fileRowCount_.value();
+  }
+  setupCudfDataSource();
+  VELOX_CHECK_NOT_NULL(
+      dataSource_, "CudfIcebergSplitReader failed to setup a cuDF datasource");
+
+  // TODO(mh): Compute using selected row group when we support sub-splits
+  const auto meta =
+      cudf::io::read_parquet_metadata(cudf::io::source_info{dataSource_.get()});
+  VELOX_CHECK_LE(
+      meta.num_rows(),
+      std::numeric_limits<cudf::size_type>::max(),
+      "File row count exceeds max cudf::size_type value");
+  fileRowCount_ = static_cast<std::size_t>(meta.num_rows());
+  return fileRowCount_.value();
+}
+
 std::unique_ptr<cudf::table> CudfIcebergSplitReader::buildOutputTable(
     std::unique_ptr<cudf::table>&& table,
-    rmm::device_async_resource_ref mr) {
-  const auto numRows = table->num_rows();
-  auto columns = table->release();
+    rmm::device_async_resource_ref mr,
+    std::optional<cudf::size_type> rowCountOverride) {
+  const auto numRows = rowCountOverride.value_or(table->num_rows());
+  auto columns = rowCountOverride.has_value()
+      ? std::vector<std::unique_ptr<cudf::column>>{}
+      : table->release();
+  const bool readAsLocalTime =
+      hiveConfig_->readTimestampPartitionValueAsLocalTime(
+          connectorQueryCtx_->sessionProperties());
 
-  // Build a cudf scalar for an info/partition column from its string value.
+  // Build a cudf scalar for an info/partition column from its optional string
+  // value. A `nullopt` value yields a typed NULL partition key column.
   auto makeConstantScalar =
       [&](const std::string& name,
-          const std::string& value,
+          const std::optional<std::string>& value,
           const TypePtr& veloxType) -> std::unique_ptr<cudf::scalar> {
     try {
       // DATE values arrive in two format-disjoint encodings: Iceberg-native
       // days-since-epoch integers (e.g. "20244") or Hive-migrated date strings
       // (e.g. "2025-06-05"). A bare integer is unambiguously days-since-epoch
       // (date strings contain '-' separators that fail an integer parse).
-      const bool isDaysSinceEpoch =
-          veloxType->isDate() && folly::tryTo<int32_t>(value).hasValue();
+      const bool isDaysSinceEpoch = veloxType->isDate() and
+          value.has_value() and folly::tryTo<int32_t>(value.value()).hasValue();
       const VectorPtr constant = velox::connector::hive::newConstantFromString(
           veloxType,
           value,
           connectorQueryCtx_->memoryPool(),
-          /*isLocalTimestamp=*/false,
+          readAsLocalTime,
           isDaysSinceEpoch);
       return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
           cudf_velox::createCudfScalar, veloxType->kind(), constant);
     } catch (const std::exception& e) {
       VELOX_FAIL(
           "Bad partition value '{}' for column '{}' (type {}): {}",
-          value,
+          value.value_or("<null>"),
           name,
           veloxType->toString(),
           e.what());
@@ -579,7 +631,7 @@ std::unique_ptr<cudf::table> CudfIcebergSplitReader::buildOutputTable(
   size_t consumedReadColumns = 0;
 
   for (size_t i = 0; i < outputType_->size(); ++i) {
-    const auto& fieldName = outputType_->nameOf(i);
+    const auto& fieldName = physicalNames_[i];
     const auto& veloxType = outputType_->childAt(i);
     const auto cudfType = cudf_velox::veloxToCudfDataType(veloxType);
 
@@ -613,16 +665,38 @@ std::unique_ptr<cudf::table> CudfIcebergSplitReader::buildOutputTable(
       outputType_->toString(),
       output.size());
 
-  // Every read column must be accounted for: either an output column, or
-  // intentionally dropped (equality-delete key column). Any leftover means a
-  // read column was silently dropped (a bug).
+  // Append remaining filter-only columns in `readColumnNames_` order.
+  const std::unordered_set<std::string> equalityColumnSet(
+      extraEqualityColumns_.begin(), extraEqualityColumns_.end());
+  size_t filterOnlyColumns = 0;
+  for (const auto& name : readColumnNames_) {
+    // Drop Equality-delete key columns
+    if (equalityColumnSet.contains(name)) {
+      continue;
+    }
+    // Skip missing and already moved-out output columns leaving only
+    // filter-only columns.
+    auto fileIt = fileColumnIndex_.find(name);
+    if (fileIt == fileColumnIndex_.end() or
+        columns[fileIt->second] == nullptr) {
+      continue;
+    }
+    output.push_back(std::move(columns[fileIt->second]));
+    ++consumedReadColumns;
+    ++filterOnlyColumns;
+  }
+
+  // Every read column must be accounted for: an output column, a
+  // filter-only column, or intentionally dropped (equality-delete key
+  // column). Any leftover means a read column was silently dropped (a bug).
   VELOX_CHECK_EQ(
       consumedReadColumns + extraEqualityColumns_.size(),
       columns.size(),
       "Read table columns were not fully accounted for during Iceberg table assembly. "
-      "Read columns: {}, Consumed: {}, Equality columns: {}",
+      "Read columns: {}, Consumed: {} including {} filter-only columns, Equality columns: {}",
       columns.size(),
       consumedReadColumns,
+      filterOnlyColumns,
       extraEqualityColumns_.size());
 
   return std::make_unique<cudf::table>(std::move(output));

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
@@ -281,10 +281,14 @@ CudfIcebergSplitReader::readNextChunk(
   // of output columns.
 
   // Compute the row count override if all projected columns are missing
-  auto rowCountOverride = allColumnsMissing
+  auto rowCountOverride = (allColumnsMissing and isApplyingDeletes)
       ? std::optional<cudf::size_type>(
             numRows - countDeletedRows(deleteMaskView_, stream_, get_temp_mr()))
       : std::nullopt;
+  VELOX_CHECK(
+      not rowCountOverride.has_value() or rowCountOverride.value() >= 0,
+      "Encountered a negative row count override for the synthetic table: {}",
+      rowCountOverride.value());
 
   // Build the output table with an optional row count override indicating if
   // all projected columns are missing

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
@@ -37,6 +37,7 @@
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/scalar/scalar_factories.hpp>
 #include <cudf/stream_compaction.hpp>
+#include <cudf/transform.hpp>
 #include <cudf/unary.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/span.hpp>
@@ -170,7 +171,10 @@ CudfIcebergSplitReader::determineCudfMemoryResource() {
 
 void CudfIcebergSplitReader::createCudfReader(
     rmm::device_async_resource_ref output_mr) {
-  CudfSplitReader::createCudfReader(determineCudfMemoryResource());
+  // Only set up a reader if there are physical columns to read
+  if (not noColumnsToRead_) {
+    CudfSplitReader::createCudfReader(determineCudfMemoryResource());
+  }
 }
 
 std::optional<cudf::io::table_with_metadata>
@@ -284,8 +288,18 @@ CudfIcebergSplitReader::readNextChunk(
 
   // Build the output table with an optional row count override indicating if
   // all projected columns are missing
-  cudfTable =
-      buildOutputTable(std::move(cudfTable), output_mr, rowCountOverride);
+  if (noColumnsToRead_ and hasSubfieldFilter()) {
+    cudfTable =
+        buildOutputTable(std::move(cudfTable), get_temp_mr(), rowCountOverride);
+    // Apply the subfield filter when every output column is injected
+    auto filterMask = cudf::compute_column(
+        cudfTable->view(), *subfieldFilterExpr(), stream_, get_temp_mr());
+    cudfTable = cudf::apply_boolean_mask(
+        cudfTable->view(), filterMask->view(), stream_, output_mr);
+  } else {
+    cudfTable =
+        buildOutputTable(std::move(cudfTable), output_mr, rowCountOverride);
+  }
 
   // Update the base read offset
   baseReadOffset_ += numRows;

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
@@ -20,17 +20,18 @@
 #include "velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.h"
 #include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
+#include "velox/experimental/cudf/expression/AstUtils.h"
 
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/encode/Base64.h"
+#include "velox/connectors/hive/FileSplitReader.h"
 #include "velox/connectors/hive/iceberg/IcebergMetadataColumns.h"
 #include "velox/dwio/common/BufferUtil.h"
 #include "velox/type/Type.h"
 
 #include <cudf/column/column_factories.hpp>
 #include <cudf/io/parquet.hpp>
-#include <cudf/io/parquet_metadata.hpp>
 #include <cudf/null_mask.hpp>
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/scalar/scalar_factories.hpp>
@@ -116,6 +117,8 @@ void CudfIcebergSplitReader::prepareSplit(
   equalityDeleteFileReaders_.clear();
   extraEqualityColumns_.clear();
   injectedColumns_.clear();
+  fileColumnNames_.clear();
+  fileColumnIndex_.clear();
   baseReadOffset_ = 0;
 
   // Must setup delete file readers before calling base `prepareSplit` so
@@ -129,10 +132,9 @@ void CudfIcebergSplitReader::prepareSplit(
   // `prepareSplit`
   setupColumnProjection();
 
-  // Schema evolution: Detect info columns, partition columns, and
-  // schema-evolution missing columns. Filters them from readColumnNames_ so the
-  // parquet reader doesn't try to read them, and records them for post-read
-  // injection.
+  // Detect info and (Hive-migrated) partition columns and remove them from
+  // `readColumnNames_` so the parquet reader doesn't try to read them, and
+  // record them for post-read injection.
   adaptColumns();
 
   // Call base to setup stream, datasource, options, and the cudf reader
@@ -154,17 +156,22 @@ void CudfIcebergSplitReader::createCudfReader(
   CudfSplitReader::createCudfReader(determineCudfMemoryResource());
 }
 
-std::optional<std::unique_ptr<cudf::table>>
+std::optional<cudf::io::table_with_metadata>
 CudfIcebergSplitReader::readNextChunk(
     rmm::device_async_resource_ref output_mr) {
   // Determine the memory resource to use for `readNextChunk`
   auto mr = determineCudfMemoryResource();
 
   // Read the next table chunk from the cuDF reader
-  auto cudfTable = CudfSplitReader::readNextChunk(mr).value_or(nullptr);
-  if (not cudfTable) {
+  auto chunkOpt = CudfSplitReader::readNextChunk(mr);
+  if (not chunkOpt.has_value()) {
     return std::nullopt;
   }
+  auto cudfTable = std::move(chunkOpt.value().tbl);
+  const auto& schemaInfo = chunkOpt.value().metadata.schema_info;
+
+  // Lazily cache column names and their positions
+  ensureFileColumnIndex(schemaInfo);
 
   // Number of table rows read by cuDF (before any deletes)
   const auto numRows = cudfTable->num_rows();
@@ -215,29 +222,16 @@ CudfIcebergSplitReader::readNextChunk(
         cudfTable->view(), deleteMaskView_, stream_, get_output_mr());
   }
 
-  // Strip extra equality delete key columns added by
-  // setupColumnProjection()
-  if (not extraEqualityColumns_.empty()) {
-    auto columns = cudfTable->release();
-    VELOX_CHECK_GE(
-        columns.size(),
-        extraEqualityColumns_.size(),
-        "cuDF table has fewer columns than the appended equality delete keys");
-    columns.resize(columns.size() - extraEqualityColumns_.size());
-    cudfTable = std::make_unique<cudf::table>(std::move(columns));
-  }
-
-  // Inject partition columns and schema-evolution NULL columns.
-  // This must run even for 0-row tables so post-delete empty chunks still
-  // have the expected number and order of output columns.
-  if (not injectedColumns_.empty()) {
-    cudfTable = injectMissingColumns(std::move(cudfTable), output_mr);
-  }
+  // Reorder read columns, inject info and partition columns and fill
+  // schema-evolution columns with typed NULLs. This must run even for 0-row
+  // tables so post-delete empty chunks still have the expected number and order
+  // of output columns.
+  cudfTable = buildOutputTable(std::move(cudfTable), output_mr);
 
   // Update the base read offset
   baseReadOffset_ += numRows;
 
-  return cudfTable;
+  return cudf::io::table_with_metadata{std::move(cudfTable), {}};
 }
 
 void CudfIcebergSplitReader::setupDeleteFileReaders(
@@ -440,11 +434,8 @@ void CudfIcebergSplitReader::applyPositionalDeletes(cudf::table_view input) {
 
 void CudfIcebergSplitReader::applyEqualityDeletes(cudf::table_view input) {
   // Apply equality deletes against the running deleteMask_.
-  const auto numRows = input.num_rows();
-
-  // Iteratively apply equality deletes, if any
   for (auto& reader : equalityDeleteFileReaders_) {
-    reader->applyDeletes(input, readColumnNames_, deleteMaskView_, stream_);
+    reader->applyDeletes(input, fileColumnNames_, deleteMaskView_, stream_);
   }
 }
 
@@ -493,172 +484,139 @@ void CudfIcebergSplitReader::setupColumnProjection() {
 
 void CudfIcebergSplitReader::adaptColumns() {
   // Detect info columns and partition columns
-  std::unordered_set<std::string> injectedNames;
   for (size_t i = 0; i < outputType_->size(); ++i) {
     const auto& fieldName = outputType_->nameOf(i);
 
     if (auto iter = split_->infoColumns.find(fieldName);
         iter != split_->infoColumns.end()) {
-      injectedColumns_.push_back(
-          {i, fieldName, iter->second, outputType_->childAt(i)});
-      injectedNames.insert(fieldName);
+      injectedColumns_.emplace(
+          fieldName, InjectedColumn{iter->second, outputType_->childAt(i)});
     } else if (auto it = icebergSplit_->partitionKeys.find(fieldName);
                it != icebergSplit_->partitionKeys.end()) {
       // Partition columns: Hive migrated table. In Hive-written data
       // files, partition column values are stored in partition metadata
       // rather than in the data file itself, following Hive's
       // partitioning convention.
-      injectedColumns_.push_back(
-          {i, fieldName, it->second, outputType_->childAt(i)});
-      injectedNames.insert(fieldName);
+      VELOX_CHECK(
+          it->second.has_value(),
+          "Iceberg partition key '{}' has no value in split metadata",
+          fieldName);
+      injectedColumns_.emplace(
+          fieldName,
+          InjectedColumn{it->second.value(), outputType_->childAt(i)});
     }
   }
 
-  // Detect schema-evolution missing columns by reading the parquet
-  // footer. Only needed if there are output columns not yet accounted for.
-  if (injectedNames.size() < outputType_->size()) {
-    setupCudfDataSource();
-    VELOX_CHECK_NOT_NULL(
-        dataSource_,
-        "CudfIcebergSplitReader failed to setup a cuDF datasource");
-    auto meta = cudf::io::read_parquet_metadata(
-        cudf::io::source_info{dataSource_.get()});
-    const auto& rootSchema = meta.schema().root();
-    std::unordered_set<std::string> fileColumns;
-    fileColumns.reserve(rootSchema.num_children());
-    std::transform(
-        rootSchema.children().begin(),
-        rootSchema.children().end(),
-        std::inserter(fileColumns, fileColumns.end()),
-        [](const auto& col) { return col.name(); });
-
-    for (size_t i = 0; i < outputType_->size(); ++i) {
-      const auto& fieldName = outputType_->nameOf(i);
-      if (injectedNames.contains(fieldName)) {
-        continue;
-      }
-      if (not fileColumns.contains(fieldName)) {
-        // Schema evolution: Column was added after the data file was written
-        // and doesn't exist in older data files.
-        injectedColumns_.push_back(
-            {i, fieldName, std::nullopt, outputType_->childAt(i)});
-        injectedNames.insert(fieldName);
-      }
-    }
-  }
-
-  // Remove all injected columns from readColumnNames_
+  // Remove the metadata-sourced columns from readColumnNames_ so the parquet
+  // reader does not attempt to read them from the file.
   if (not injectedColumns_.empty()) {
-    std::erase_if(readColumnNames_, [&injectedNames](const auto& name) {
-      return injectedNames.contains(name);
+    std::erase_if(readColumnNames_, [this](const auto& name) {
+      return injectedColumns_.contains(name);
     });
-    // Sort injected columns by output index once here
-    std::sort(
-        injectedColumns_.begin(),
-        injectedColumns_.end(),
-        [](const auto& a, const auto& b) {
-          return a.outputIndex < b.outputIndex;
-        });
   }
 }
 
-std::unique_ptr<cudf::table> CudfIcebergSplitReader::injectMissingColumns(
+void CudfIcebergSplitReader::ensureFileColumnIndex(
+    const std::vector<cudf::io::column_name_info>& schemaInfo) {
+  // The reader returns the same columns in the same order for every chunk, so
+  // build the name list and the name -> position lookup only once per split.
+  if (not fileColumnNames_.empty()) {
+    return;
+  }
+  fileColumnNames_.reserve(schemaInfo.size());
+  fileColumnIndex_.reserve(schemaInfo.size());
+  for (size_t i = 0; i < schemaInfo.size(); ++i) {
+    fileColumnNames_.push_back(schemaInfo[i].name);
+    fileColumnIndex_.emplace(schemaInfo[i].name, i);
+  }
+}
+
+std::unique_ptr<cudf::table> CudfIcebergSplitReader::buildOutputTable(
     std::unique_ptr<cudf::table>&& table,
     rmm::device_async_resource_ref mr) {
   const auto numRows = table->num_rows();
   auto columns = table->release();
 
-  // Creates a scalar from a string partition value for the given cudf type.
-  auto makePartitionScalar =
-      [&](const std::string& value,
-          cudf::data_type cudfType,
-          const InjectedColumn& col) -> std::unique_ptr<cudf::scalar> {
-    if (cudfType.id() != cudf::type_id::STRING and
-        cudfType.id() != cudf::type_id::INT32 and
-        cudfType.id() != cudf::type_id::INT64 and
-        cudfType.id() != cudf::type_id::TIMESTAMP_DAYS) {
-      VELOX_NYI(
-          "Identity partition columns are limited to VARCHAR, INTEGER, BIGINT, and DATE only. Other types are not yet supported. Column: '{}', Type: {}",
-          col.name,
-          col.veloxType->toString());
-    }
+  // Build a cudf scalar for an info/partition column from its string value.
+  auto makeConstantScalar =
+      [&](const std::string& name,
+          const std::string& value,
+          const TypePtr& veloxType) -> std::unique_ptr<cudf::scalar> {
     try {
-      switch (cudfType.id()) {
-        case cudf::type_id::STRING:
-          return std::make_unique<cudf::string_scalar>(
-              value, true, stream_, mr);
-        case cudf::type_id::INT32:
-          return std::make_unique<cudf::numeric_scalar<int32_t>>(
-              folly::to<int32_t>(value), true, stream_, mr);
-        case cudf::type_id::INT64:
-          return std::make_unique<cudf::numeric_scalar<int64_t>>(
-              folly::to<int64_t>(value), true, stream_, mr);
-        case cudf::type_id::TIMESTAMP_DAYS: {
-          // DATE partition values arrive either as days-since-epoch (Iceberg
-          // native) or as a date string such as "2025-06-05" (Hive migrated).
-          // The two encodings are disjoint: DATE()->toDays() uses Presto cast
-          // semantics, which reject a bare integer, while a date string always
-          // contains '-' separators that fail integer parsing. So an all-digit
-          // value is unambiguously days-since-epoch, and anything else is
-          // parsed as a date string.
-          const int32_t days = [&] {
-            if (auto parsed = folly::tryTo<int32_t>(value)) {
-              return parsed.value();
-            }
-            return DATE()->toDays(value);
-          }();
-          return std::make_unique<cudf::timestamp_scalar<cudf::timestamp_D>>(
-              days, true, stream_, mr);
-        }
-        default:
-          VELOX_UNREACHABLE();
-      }
+      // DATE values arrive in two format-disjoint encodings: Iceberg-native
+      // days-since-epoch integers (e.g. "20244") or Hive-migrated date strings
+      // (e.g. "2025-06-05"). A bare integer is unambiguously days-since-epoch
+      // (date strings contain '-' separators that fail an integer parse).
+      const bool isDaysSinceEpoch =
+          veloxType->isDate() && folly::tryTo<int32_t>(value).hasValue();
+      const VectorPtr constant = velox::connector::hive::newConstantFromString(
+          veloxType,
+          value,
+          connectorQueryCtx_->memoryPool(),
+          /*isLocalTimestamp=*/false,
+          isDaysSinceEpoch);
+      return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+          cudf_velox::createCudfScalar, veloxType->kind(), constant);
     } catch (const std::exception& e) {
       VELOX_FAIL(
           "Bad partition value '{}' for column '{}' (type {}): {}",
           value,
-          col.name,
-          col.veloxType->toString(),
+          name,
+          veloxType->toString(),
           e.what());
     }
   };
 
-  // Merge data columns and injected constant columns in output order.
-  const auto totalColumns = columns.size() + injectedColumns_.size();
+  // Assemble the output in output-schema order. Each output column is sourced
+  // from exactly one of: an injected info/partition constant, the read data
+  // table (by name), or a typed NULL constant (schema evolution). Read columns
+  // that are not part of the output schema (equality-delete key columns)
+  // are dropped.
   std::vector<std::unique_ptr<cudf::column>> output;
-  output.reserve(totalColumns);
+  output.reserve(outputType_->size());
 
-  auto injectedColIter = injectedColumns_.begin();
-  auto dataColIter = columns.begin();
+  for (size_t i = 0; i < outputType_->size(); ++i) {
+    const auto& fieldName = outputType_->nameOf(i);
+    const auto& veloxType = outputType_->childAt(i);
+    const auto cudfType = cudf_velox::veloxToCudfDataType(veloxType);
 
-  for (size_t outIdx = 0; outIdx < totalColumns; ++outIdx) {
-    if (injectedColIter != injectedColumns_.end() &&
-        injectedColIter->outputIndex == outIdx) {
-      const auto& col = *injectedColIter;
-      auto cudfType = cudf_velox::veloxToCudfDataType(col.veloxType);
-
-      std::unique_ptr<cudf::scalar> scalar;
-      if (col.partitionValue.has_value()) {
-        scalar = makePartitionScalar(col.partitionValue.value(), cudfType, col);
-      } else {
-        scalar = cudf::make_default_constructed_scalar(cudfType, stream_, mr);
-        scalar->set_valid_async(false, stream_);
-      }
+    if (auto injectedIt = injectedColumns_.find(fieldName);
+        injectedIt != injectedColumns_.end()) {
+      // Info column or Hive-migrated partition column: constant value.
+      auto scalar =
+          makeConstantScalar(fieldName, injectedIt->second.value, veloxType);
       output.push_back(
           cudf::make_column_from_scalar(*scalar, numRows, stream_, mr));
-      injectedColIter++;
+    } else if (auto fileIt = fileColumnIndex_.find(fieldName);
+               fileIt != fileColumnIndex_.end()) {
+      // Column read from the data file.
+      output.push_back(std::move(columns[fileIt->second]));
     } else {
-      VELOX_CHECK(
-          dataColIter != columns.end(),
-          "Data column index out of range during column injection");
-      output.push_back(std::move(*dataColIter));
-      dataColIter++;
+      // Schema evolution: column added after this data file was written and
+      // absent from the file. Emit a typed NULL column.
+      auto scalar =
+          cudf::make_default_constructed_scalar(cudfType, stream_, mr);
+      scalar->set_valid_async(false, stream_);
+      output.push_back(
+          cudf::make_column_from_scalar(*scalar, numRows, stream_, mr));
     }
   }
 
-  VELOX_CHECK(
-      dataColIter == columns.end(),
-      "Not all data columns were consumed during column injection");
+  VELOX_CHECK_EQ(
+      output.size(),
+      outputType_->size(),
+      "Mismatch between number of columns in the output schema and the assembled Iceberg table. Output schema: {}, Assembled table: {}",
+      outputType_->toString(),
+      table->schema().toString());
+
+  VELOX_CHECK_EQ(
+      output.size() + extraEqualityColumns_.size(),
+      fileColumnIndex_.size(),
+      "Read table columns were not fully accounted for during Iceberg table assembly."
+      "Read columns: {}, Consumed: {}, Equality columns: {}",
+      fileColumnIndex_.size(),
+      output.size(),
+      extraEqualityColumns_.size(), );
 
   return std::make_unique<cudf::table>(std::move(output));
 }

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
@@ -173,15 +173,9 @@ void CudfIcebergSplitReader::createCudfReader(
   CudfSplitReader::createCudfReader(determineCudfMemoryResource());
 }
 
-std::optional<std::unique_ptr<cudf::table>>
-CudfIcebergSplitReader::nextInputChunk() {}
-
 std::optional<cudf::io::table_with_metadata>
 CudfIcebergSplitReader::readNextChunk(
     rmm::device_async_resource_ref output_mr) {
-  // Determine the memory resource to use for `readNextChunk`
-  auto mr = determineCudfMemoryResource();
-
   auto chunkOpt = [&]() -> std::optional<std::unique_ptr<cudf::table>> {
     // If every output column is injected, skip `readNextChunk` and
     // emit a single chunk synthesized.

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
@@ -125,6 +125,8 @@ void CudfIcebergSplitReader::prepareSplit(
   fileColumnNames_.clear();
   fileColumnIndex_.clear();
   fileRowCount_.reset();
+  noColumnsToRead_ = false;
+  syntheticTableProduced_ = false;
   baseReadOffset_ = 0;
 
   // Must setup delete file readers before calling base `prepareSplit` so
@@ -132,6 +134,15 @@ void CudfIcebergSplitReader::prepareSplit(
   // reader. Pass the DataSource's runtimeStats so delete readers accumulate
   // stats directly into the DataSource's stats object.
   setupDeleteFileReaders(runtimeStats);
+
+  // Subfield filters along with positional deletes are not supported as the
+  // original row positions may have been altered by the filter.
+  // TODO(mh): Re-enable when https://github.com/rapidsai/cudf/pull/23077 merges
+  if (hasSubfieldFilter() and
+      (deletionVectorReader_ or positionalDeleteFileReaders_.size())) {
+    VELOX_NYI(
+        "cuDF Iceberg reader does not yet support subfield filters together with positional deletes");
+  }
 
   // Setup column projection to include any equality delete key columns that
   // are not already in the output projection. Must be called before base
@@ -162,22 +173,45 @@ void CudfIcebergSplitReader::createCudfReader(
   CudfSplitReader::createCudfReader(determineCudfMemoryResource());
 }
 
+std::optional<std::unique_ptr<cudf::table>>
+CudfIcebergSplitReader::nextInputChunk() {}
+
 std::optional<cudf::io::table_with_metadata>
 CudfIcebergSplitReader::readNextChunk(
     rmm::device_async_resource_ref output_mr) {
   // Determine the memory resource to use for `readNextChunk`
   auto mr = determineCudfMemoryResource();
 
-  // Read the next table chunk from the cuDF reader
-  auto chunkOpt = CudfSplitReader::readNextChunk(mr);
+  auto chunkOpt = [&]() -> std::optional<std::unique_ptr<cudf::table>> {
+    // If every output column is injected, skip `readNextChunk` and
+    // emit a single chunk synthesized.
+    if (noColumnsToRead_) {
+      // No more synthetic table chunks
+      if (syntheticTableProduced_) {
+        return std::nullopt;
+      }
+      syntheticTableProduced_ = true;
+      return std::make_unique<cudf::table>(
+          std::vector<std::unique_ptr<cudf::column>>{});
+    }
+
+    // Otherwise, read the next table chunk from the cuDF reader.
+    auto chunkOpt =
+        CudfSplitReader::readNextChunk(determineCudfMemoryResource());
+    // No more table chunks
+    if (not chunkOpt.has_value()) {
+      return std::nullopt;
+    }
+    // Lazily cache column names and their positions.
+    ensureFileColumnIndex(chunkOpt.value().metadata.schema_info);
+    return std::move(chunkOpt.value().tbl);
+  }();
+
+  // No more table chunks
   if (not chunkOpt.has_value()) {
     return std::nullopt;
   }
-  auto cudfTable = std::move(chunkOpt.value().tbl);
-  const auto& schemaInfo = chunkOpt.value().metadata.schema_info;
-
-  // Lazily cache column names and their positions
-  ensureFileColumnIndex(schemaInfo);
+  auto cudfTable = std::move(chunkOpt.value());
 
   // Check if all projected columns are schema-evolution (missing) columns
   const bool allColumnsMissing = cudfTable->num_columns() == 0;
@@ -540,6 +574,10 @@ void CudfIcebergSplitReader::adaptColumns() {
       return injectedColumns_.contains(name);
     });
   }
+
+  // If every output column is injected (info/partition), no columns need to be
+  // read from the data file.
+  noColumnsToRead_ = readColumnNames_.empty();
 }
 
 void CudfIcebergSplitReader::ensureFileColumnIndex(

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.h
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.h
@@ -110,7 +110,7 @@ class CudfIcebergSplitReader : public CudfSplitReader {
   // Classifies each output column into one of:
   //
   // 1. Info columns:
-  //    Column is a synthesized using a constant value (e.g., $file_size) from
+  //    Column is synthesized using a constant value (e.g., $file_size) from
   //    the split metadata. Recorded for post-read injection as a constant.
   //
   // 2. Regular columns present in file:
@@ -120,7 +120,7 @@ class CudfIcebergSplitReader : public CudfSplitReader {
   //
   // 3. Columns missing from file:
   //    a) Partition columns (Hive-migrated tables):
-  //       Column is a partition key in  the Iceberg split.
+  //       Column is a partition key in the Iceberg split.
   //       In Hive-written Iceberg tables, partition column values are stored
   //       in partition metadata, not in the data file itself. Value is read
   //       from partition metadata and set as a constant.

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.h
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.h
@@ -26,6 +26,7 @@
 #include "velox/connectors/hive/iceberg/PositionalDeleteFileReader.h"
 
 #include <list>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -87,13 +88,13 @@ class CudfIcebergSplitReader : public CudfSplitReader {
   // passed to delete file readers for stats accumulation.
   void setupDeleteFileReaders(dwio::common::RuntimeStatistics& runtimeStats);
 
-  // Apply deletion vector (V3) to the input cudf table.
-  void applyDeletionVector(cudf::table_view input);
+  // Apply deletion vector (V3).
+  void applyDeletionVector(std::size_t numRows);
 
-  // Apply positional deletes (V2) to the input cudf table.
-  void applyPositionalDeletes(cudf::table_view input);
+  // Apply positional deletes (V2).
+  void applyPositionalDeletes(std::size_t numRows);
 
-  // Apply equality deletes (V2) to the input cudf table.
+  // Apply equality deletes (V2).
   void applyEqualityDeletes(cudf::table_view input);
 
   // Setup column projection to include any equality delete key columns
@@ -131,17 +132,28 @@ class CudfIcebergSplitReader : public CudfSplitReader {
   //       schema.
   void adaptColumns();
 
-  // Assemble the final output table. Reorder read columns, inject
-  // info/partition constants, fill typed NULL columns for schema-evolution
-  // columns and drop equality delete key columns.
+  // Assemble the final output table.
+  //
+  // Reorder read columns, inject info/partition constants, fill typed NULL
+  // columns for schema-evolution columns, drop equality delete key columns and
+  // finally append remaining filter-only columns.
+  // @param table Input table
+  // @param mr Memory resource to allocate injected columns
+  // @param rowCountOverride Override row count if input table has no columns
+  // (all injected constants and typed NULLs)
   std::unique_ptr<cudf::table> buildOutputTable(
       std::unique_ptr<cudf::table>&& table,
-      rmm::device_async_resource_ref mr);
+      rmm::device_async_resource_ref mr,
+      std::optional<cudf::size_type> rowCountOverride);
 
   // Lazily builds `fileColumnNames_` and `fileColumnIndex_` from the cuDF
   // table's schema info for reuse across chunks
   void ensureFileColumnIndex(
       const std::vector<cudf::io::column_name_info>& schemaInfo);
+
+  // Returns the total number of rows in the data file using the parquet footer.
+  // Used when all projected columns missing.
+  std::size_t fileRowCount();
 
   std::shared_ptr<const velox_iceberg::HiveIcebergSplit> icebergSplit_;
   std::shared_ptr<const velox_hive::HiveConfig> hiveConfig_;
@@ -166,13 +178,20 @@ class CudfIcebergSplitReader : public CudfSplitReader {
   // column or a Hive-migrated partition column) and is injected as a constant
   // after reading the table.
   struct InjectedColumn {
-    std::string value; // info-column / partition-key string value
+    std::optional<std::string> value; // info-column / partition-key value.
+    // `nullopt` denotes a NULL partition (schema evolution)
     TypePtr veloxType;
   };
 
-  // Columns to inject after reading, keyed by output column name.
+  // Columns to inject after reading, keyed by physical column name.
   // This is populated by `adaptColumns()`.
   std::unordered_map<std::string, InjectedColumn> injectedColumns_;
+
+  // Physical column name for each output column
+  std::vector<std::string> physicalNames_;
+
+  // Cached total rows in the data file
+  std::optional<std::size_t> fileRowCount_;
 
   // Column names from the cudf reader, in reader order, and a name ->
   // position lookup over them.

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.h
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.h
@@ -190,6 +190,14 @@ class CudfIcebergSplitReader : public CudfSplitReader {
   // Physical column name for each output column
   std::vector<std::string> physicalNames_;
 
+  // True when every output column is injected (info/partition), so no columns
+  // are read from the data file
+  bool noColumnsToRead_{false};
+
+  // Ensures we only produce a single synthetic table when `noColumnsToRead_` is
+  // true.
+  bool syntheticTableProduced_{false};
+
   // Cached total rows in the data file
   std::optional<std::size_t> fileRowCount_;
 

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.h
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.h
@@ -26,6 +26,9 @@
 #include "velox/connectors/hive/iceberg/PositionalDeleteFileReader.h"
 
 #include <list>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 namespace facebook::velox::cudf_velox::connector::hive::iceberg {
 
@@ -70,7 +73,7 @@ class CudfIcebergSplitReader : public CudfSplitReader {
   void createCudfReader(rmm::device_async_resource_ref output_mr) override;
 
   // Override to apply Iceberg deletes after reading a cudf table chunk.
-  std::optional<std::unique_ptr<cudf::table>> readNextChunk(
+  std::optional<cudf::io::table_with_metadata> readNextChunk(
       rmm::device_async_resource_ref output_mr) override;
 
  private:
@@ -107,33 +110,38 @@ class CudfIcebergSplitReader : public CudfSplitReader {
   // Classifies each output column into one of:
   //
   // 1. Info columns:
-  //    Column is a synthesized info column (e.g., $file_size) from the
-  //    split metadata. Recorded for post-read injection as a constant.
+  //    Column is a synthesized using a constant value (e.g., $file_size) from
+  //    the split metadata. Recorded for post-read injection as a constant.
   //
-  // 2. Columns present in File:
-  //    Column exists in the parquet file and will be read normally.
-  //    Type coercion is handled by the cudf parquet reader options.
+  // 2. Regular columns present in file:
+  //    Column exists in both fileType and readerOutputType. Type is adapted
+  //    from fileType to match the expected output type, handling schema
+  //    evolution where column types may have changed.
   //
-  // 3. Columns missing from File:
+  // 3. Columns missing from file:
   //    a) Partition columns (Hive-migrated tables):
-  //       Column is a partition key in the Iceberg split. In Hive-written
-  //       Iceberg tables, partition column values are stored in partition
-  //       metadata, not in the data file itself. Recorded for post-read
-  //       injection as a constant.
-  //    b) Schema evolution (newly added columns):
+  //       Column is a partition key in  the Iceberg split.
+  //       In Hive-written Iceberg tables, partition column values are stored
+  //       in partition metadata, not in the data file itself. Value is read
+  //       from partition metadata and set as a constant.
+  //    b) Schema evolution (newly added columns - NOT detected here):
   //       Column was added to the table schema after this data file was
-  //       written. Recorded for post-read injection as a typed NULL column.
-  //
-  // Columns are recorded in injectedColumns_ and removed from readColumnNames_
-  // so they are injected after reading using `injectMissingColumns()`.
+  //       written. Injected as NULL constant since the old file doesn't contain
+  //       this column by `buildOutputTable()` after reading the table's
+  //       schema.
   void adaptColumns();
 
-  // Inject partition columns and schema-evolution NULL columns into the
-  // cudf table after reading. Returns a new table with all output columns
-  // in the correct order.
-  std::unique_ptr<cudf::table> injectMissingColumns(
+  // Assemble the final output table. Reorder read columns, inject
+  // info/partition constants, fill typed NULL columns for schema-evolution
+  // columns and drop equality delete key columns.
+  std::unique_ptr<cudf::table> buildOutputTable(
       std::unique_ptr<cudf::table>&& table,
       rmm::device_async_resource_ref mr);
+
+  // Lazily builds `fileColumnNames_` and `fileColumnIndex_` from the cuDF
+  // table's schema info for reuse across chunks
+  void ensureFileColumnIndex(
+      const std::vector<cudf::io::column_name_info>& schemaInfo);
 
   std::shared_ptr<const velox_iceberg::HiveIcebergSplit> icebergSplit_;
   std::shared_ptr<const velox_hive::HiveConfig> hiveConfig_;
@@ -154,18 +162,22 @@ class CudfIcebergSplitReader : public CudfSplitReader {
   // are not part of the output projection.
   std::vector<std::string> extraEqualityColumns_;
 
-  // Describes a column that must be injected after reading because it is
-  // not present in the parquet file (partition column or schema evolution).
+  // Describes a column whose value is known from the split metadata (an info
+  // column or a Hive-migrated partition column) and is injected as a constant
+  // after reading the table.
   struct InjectedColumn {
-    size_t outputIndex; // position in the final output schema
-    std::string name;
-    std::optional<std::string>
-        partitionValue; // nullopt = NULL (schema evolution)
+    std::string value; // info-column / partition-key string value
     TypePtr veloxType;
   };
 
-  // Columns to inject after reading. Populated by adaptColumns().
-  std::vector<InjectedColumn> injectedColumns_;
+  // Columns to inject after reading, keyed by output column name.
+  // This is populated by `adaptColumns()`.
+  std::unordered_map<std::string, InjectedColumn> injectedColumns_;
+
+  // Column names from the cudf reader, in reader order, and a name ->
+  // position lookup over them.
+  std::vector<std::string> fileColumnNames_;
+  std::unordered_map<std::string, size_t> fileColumnIndex_;
 
   // Tracks the absolute row offset within the data file. Each chunk advances
   // this by the number of rows read (before deletes).

--- a/velox/experimental/cudf/tests/iceberg/CudfIcebergReadTest.cpp
+++ b/velox/experimental/cudf/tests/iceberg/CudfIcebergReadTest.cpp
@@ -687,6 +687,43 @@ TEST_F(CudfIcebergReadTest, partitionOnlyProjection) {
   AssertQueryBuilder(plan)
       .splits(makeIcebergSplits(dataFile->getPath(), {}, partitionKeys))
       .assertResults({expected});
+
+  // A non-matching subfield filter on the (injected) partition column must
+  // produce an empty result. Because no columns are read from the data file,
+  // the cuDF reader is bypassed; the filter must still be applied to the
+  // synthesized constant column. Previously the filter was dropped and this
+  // returned three "US" rows.
+  auto filteredNoMatchPlan = PlanBuilder()
+                                 .startTableScan()
+                                 .connectorId(kCudfIcebergConnectorId)
+                                 .outputType(outputType)
+                                 .dataColumns(tableType)
+                                 .assignments(assignments)
+                                 .subfieldFilter("country = 'CA'")
+                                 .endTableScan()
+                                 .planNode();
+
+  auto emptyExpected =
+      makeRowVector({"country"}, {makeFlatVector<std::string>({})});
+
+  AssertQueryBuilder(filteredNoMatchPlan)
+      .splits(makeIcebergSplits(dataFile->getPath(), {}, partitionKeys))
+      .assertResults({emptyExpected});
+
+  // A matching subfield filter keeps all rows.
+  auto filteredMatchPlan = PlanBuilder()
+                               .startTableScan()
+                               .connectorId(kCudfIcebergConnectorId)
+                               .outputType(outputType)
+                               .dataColumns(tableType)
+                               .assignments(assignments)
+                               .subfieldFilter("country = 'US'")
+                               .endTableScan()
+                               .planNode();
+
+  AssertQueryBuilder(filteredMatchPlan)
+      .splits(makeIcebergSplits(dataFile->getPath(), {}, partitionKeys))
+      .assertResults({expected});
 }
 
 /// A remaining filter on an unprojected column (`c1`) adds `c1` to the
@@ -1246,6 +1283,74 @@ TEST_F(CudfIcebergReadTest, subfieldFilterWithSkippedPositionalDelete) {
                   .planNode();
 
   // The delete is skipped, so `c0 < 4` simply keeps {0, 1, 2, 3}.
+  auto expected = makeRowVector({makeFlatVector<int64_t>({0, 1, 2, 3})});
+  AssertQueryBuilder(plan).splits(splits).assertResults({expected});
+}
+
+// A subfield filter combined with a positional delete file that applies only to
+// a different data file must not be rejected.
+TEST_F(
+    CudfIcebergReadTest,
+    DISABLED_subfieldFilterWithPositionalDeleteForDifferentFile) {
+  auto pathColumn = IcebergMetadataColumn::icebergDeleteFilePathColumn();
+  auto posColumn = IcebergMetadataColumn::icebergDeletePosColumn();
+  auto rowType = ROW({"c0"}, {BIGINT()});
+
+  auto dataFilePath = TempFilePath::create();
+  writeToFile(
+      dataFilePath->getPath(),
+      {makeRowVector({makeFlatVector<int64_t>({0, 1, 2, 3, 4})})});
+
+  auto baseFilePath = dataFilePath->getPath();
+  auto otherDataFilePath = TempFilePath::create();
+
+  // The delete file's positions reference a different data file, so its
+  // file_path column statistics exclude `baseFilePath` and `testFilters` prunes
+  // the reader during construction.
+  auto deleteFilePath = TempFilePath::create();
+  writeDeleteFile(
+      DeleteFileFormat::DWRF,
+      deleteFilePath->getPath(),
+      {makeRowVector(
+          {pathColumn->name, posColumn->name},
+          {
+              makeFlatVector<std::string>(
+                  2,
+                  [&](vector_size_t) { return otherDataFilePath->getPath(); }),
+              makeFlatVector<int64_t>({1, 3}),
+          })});
+
+  // Equal sequence numbers make the positional delete applicable, ensuring it
+  // reaches file-path pruning inside `PositionalDeleteFileReader`.
+  IcebergDeleteFile deleteFile(
+      FileContent::kPositionalDeletes,
+      deleteFilePath->getPath(),
+      dwio::common::FileFormat::DWRF,
+      2,
+      getFileSize(deleteFilePath->getPath()),
+      {},
+      {},
+      {},
+      /*dataSequenceNumber=*/10);
+
+  auto splits = makeIcebergSplits(
+      baseFilePath,
+      {deleteFile},
+      {},
+      1,
+      /*dataSequenceNumber=*/10);
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kCudfIcebergConnectorId)
+                  .outputType(rowType)
+                  .dataColumns(rowType)
+                  .subfieldFilter("c0 < 4")
+                  .endTableScan()
+                  .planNode();
+
+  // The positional delete file contains no entries for this data file, so
+  // `c0 < 4` simply keeps {0, 1, 2, 3}.
   auto expected = makeRowVector({makeFlatVector<int64_t>({0, 1, 2, 3})});
   AssertQueryBuilder(plan).splits(splits).assertResults({expected});
 }

--- a/velox/experimental/cudf/tests/iceberg/CudfIcebergReadTest.cpp
+++ b/velox/experimental/cudf/tests/iceberg/CudfIcebergReadTest.cpp
@@ -22,6 +22,7 @@
 
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/FileSystems.h"
+#include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/connectors/hive/iceberg/IcebergDeleteFile.h"
 #include "velox/connectors/hive/iceberg/IcebergMetadataColumns.h"
@@ -29,6 +30,8 @@
 #include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/type/Timestamp.h"
+#include "velox/type/TimestampConversion.h"
 
 #include <folly/Random.h>
 #include <folly/String.h>
@@ -520,6 +523,379 @@ TEST_F(CudfIcebergReadTest, multipleSplits) {
                   .planNode();
 
   assertQuery(plan, allSplits, "SELECT * FROM tmp", 0);
+}
+
+/// All missing (schema evolution) columns. Reader must emit the correct number
+/// of typed NULL rows.
+TEST_F(CudfIcebergReadTest, allSchemaEvolutionColumns) {
+  auto dataVector = makeRowVector(
+      {"old_col"},
+      {
+          makeFlatVector<int64_t>({100, 200, 300}),
+      });
+  auto dataFilePath = TempFilePath::create();
+  writeToFile(dataFilePath->getPath(), dataVector);
+
+  auto newRowType = ROW({"new_col"}, {BIGINT()});
+  auto expected = makeRowVector(
+      {"new_col"},
+      {
+          makeNullConstant(TypeKind::BIGINT, 3),
+      });
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kCudfIcebergConnectorId)
+                  .outputType(newRowType)
+                  .dataColumns(newRowType)
+                  .endTableScan()
+                  .planNode();
+
+  AssertQueryBuilder(plan)
+      .splits(makeIcebergSplits(dataFilePath->getPath()))
+      .assertResults({expected});
+}
+
+/// Column alias: output column `a` -> physical file column `c0`
+TEST_F(CudfIcebergReadTest, columnAliasUsesPhysicalFileName) {
+  auto data = makeRowVector(
+      {"c0"},
+      {
+          makeFlatVector<int64_t>({10, 20, 30}),
+      });
+
+  auto dataFile = TempFilePath::create();
+  writeToFile(dataFile->getPath(), data);
+
+  auto fileType = ROW({"c0"}, {BIGINT()});
+  auto outputType = ROW({"a"}, {BIGINT()});
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kCudfIcebergConnectorId)
+                  .outputType(outputType)
+                  .dataColumns(fileType)
+                  .columnAliases({{"a", "c0"}})
+                  .endTableScan()
+                  .planNode();
+
+  auto expected = makeRowVector(
+      {"a"},
+      {
+          makeFlatVector<int64_t>({10, 20, 30}),
+      });
+
+  AssertQueryBuilder(plan)
+      .splits(makeIcebergSplits(dataFile->getPath()))
+      .assertResults({expected});
+}
+
+/// A nonempty data file in a NULL partition must return one NULL partition
+/// value per row
+TEST_F(CudfIcebergReadTest, nullPartitionColumn) {
+  auto data = makeRowVector(
+      {"c0"},
+      {
+          makeFlatVector<int64_t>({1, 2, 3}),
+      });
+
+  auto dataFile = TempFilePath::create();
+  writeToFile(dataFile->getPath(), data);
+
+  auto tableType = ROW({"c0", "country"}, {BIGINT(), VARCHAR()});
+
+  facebook::velox::connector::ColumnHandleMap assignments;
+  assignments["c0"] = std::make_shared<HiveColumnHandle>(
+      "c0",
+      HiveColumnHandle::ColumnType::kRegular,
+      BIGINT(),
+      BIGINT(),
+      std::vector<common::Subfield>{});
+  assignments["country"] = std::make_shared<HiveColumnHandle>(
+      "country",
+      HiveColumnHandle::ColumnType::kPartitionKey,
+      VARCHAR(),
+      VARCHAR(),
+      std::vector<common::Subfield>{});
+
+  std::unordered_map<std::string, std::optional<std::string>> partitionKeys = {
+      {"country", std::nullopt}};
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kCudfIcebergConnectorId)
+                  .outputType(tableType)
+                  .dataColumns(tableType)
+                  .assignments(assignments)
+                  .endTableScan()
+                  .planNode();
+
+  auto expected = makeRowVector(
+      {"c0", "country"},
+      {
+          data->childAt(0),
+          makeNullConstant(TypeKind::VARCHAR, 3),
+      });
+
+  AssertQueryBuilder(plan)
+      .splits(makeIcebergSplits(dataFile->getPath(), {}, partitionKeys))
+      .assertResults({expected});
+}
+
+/// A remaining filter on an unprojected column (`c1`) adds `c1` to the
+/// projection for post-scan filtering and removal
+TEST_F(CudfIcebergReadTest, unprojectedRemainingFilterColumn) {
+  auto data = makeRowVector(
+      {"c0", "c1"},
+      {
+          makeFlatVector<int64_t>({10, 20, 30, 40}),
+          makeFlatVector<int64_t>({1, 2, 3, 4}),
+      });
+
+  auto dataFile = TempFilePath::create();
+  writeToFile(dataFile->getPath(), data);
+
+  auto dataType = ROW({"c0", "c1"}, {BIGINT(), BIGINT()});
+  auto outputType = ROW({"c0"}, {BIGINT()});
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kCudfIcebergConnectorId)
+                  .outputType(outputType)
+                  .dataColumns(dataType)
+                  .remainingFilter("c1 % 2 = 0")
+                  .endTableScan()
+                  .planNode();
+
+  auto expected = makeRowVector(
+      {"c0"},
+      {
+          makeFlatVector<int64_t>({20, 40}),
+      });
+
+  AssertQueryBuilder(plan)
+      .splits(makeIcebergSplits(dataFile->getPath()))
+      .assertResults({expected});
+}
+
+// A timezone-less TIMESTAMP partition value is
+// interpreted in the default timezone and converted to UTC when the Hive config
+// is true.
+TEST_F(CudfIcebergReadTest, timestampPartitionHonorsLocalTimeSetting) {
+  auto data = makeRowVector(
+      {"c0"},
+      {
+          makeFlatVector<int64_t>({1, 2, 3}),
+      });
+
+  auto dataFile = TempFilePath::create();
+  writeToFile(dataFile->getPath(), data);
+
+  auto tableType = ROW({"c0", "pkey"}, {BIGINT(), TIMESTAMP()});
+
+  facebook::velox::connector::ColumnHandleMap assignments;
+  assignments["c0"] = std::make_shared<HiveColumnHandle>(
+      "c0",
+      HiveColumnHandle::ColumnType::kRegular,
+      BIGINT(),
+      BIGINT(),
+      std::vector<common::Subfield>{});
+  assignments["pkey"] = std::make_shared<HiveColumnHandle>(
+      "pkey",
+      HiveColumnHandle::ColumnType::kPartitionKey,
+      TIMESTAMP(),
+      TIMESTAMP(),
+      std::vector<common::Subfield>{});
+
+  const std::string partitionValue = "2023-10-14 07:00:00";
+  std::unordered_map<std::string, std::optional<std::string>> partitionKeys = {
+      {"pkey", partitionValue}};
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kCudfIcebergConnectorId)
+                  .outputType(tableType)
+                  .dataColumns(tableType)
+                  .assignments(assignments)
+                  .endTableScan()
+                  .planNode();
+
+  auto utcTimestamp =
+      util::fromTimestampString(
+          StringView(partitionValue), util::TimestampParseMode::kPrestoCast)
+          .value();
+
+  auto localTimestamp = utcTimestamp;
+  localTimestamp.toGMT(Timestamp::defaultTimezone());
+
+  auto assertValue = [&](bool readAsLocalTime, Timestamp expectedTimestamp) {
+    auto expected = makeRowVector(
+        {"c0", "pkey"},
+        {
+            data->childAt(0),
+            makeFlatVector<Timestamp>(
+                {expectedTimestamp, expectedTimestamp, expectedTimestamp}),
+        });
+
+    AssertQueryBuilder(plan)
+        .connectorSessionProperty(
+            kCudfIcebergConnectorId,
+            facebook::velox::connector::hive::HiveConfig::
+                kReadTimestampPartitionValueAsLocalTimeSession,
+            readAsLocalTime ? "true" : "false")
+        .splits(makeIcebergSplits(dataFile->getPath(), {}, partitionKeys))
+        .assertResults({expected});
+  };
+
+  // Interpret the partition string as already being in UTC.
+  assertValue(false, utcTimestamp);
+
+  // Interpret the partition string as local time and convert it to UTC.
+  assertValue(true, localTimestamp);
+}
+
+/// A remaining filter is allowed with positional deletes
+TEST_F(CudfIcebergReadTest, remainingFilterAndPositionalDeletes) {
+  auto data = makeRowVector(
+      {"c0", "c1"},
+      {
+          makeFlatVector<int64_t>({10, 20, 30, 40}),
+          makeFlatVector<int64_t>({1, 2, 3, 4}),
+      });
+
+  auto dataFile = TempFilePath::create();
+  writeToFile(dataFile->getPath(), data);
+
+  // Positional delete file removing row 1 (c0=20, c1=2).
+  auto deleteFilePath = TempFilePath::create();
+  auto pathColumn = IcebergMetadataColumn::icebergDeleteFilePathColumn();
+  auto posColumn = IcebergMetadataColumn::icebergDeletePosColumn();
+  auto deleteVector = makeRowVector(
+      {pathColumn->name, posColumn->name},
+      {
+          makeFlatVector<std::string>(
+              1, [&](vector_size_t) { return dataFile->getPath(); }),
+          makeFlatVector<int64_t>({1}),
+      });
+  writeDeleteFile(
+      DeleteFileFormat::DWRF, deleteFilePath->getPath(), {deleteVector});
+
+  IcebergDeleteFile deleteFile(
+      FileContent::kPositionalDeletes,
+      deleteFilePath->getPath(),
+      dwio::common::FileFormat::DWRF,
+      1,
+      getFileSize(deleteFilePath->getPath()));
+
+  auto dataType = ROW({"c0", "c1"}, {BIGINT(), BIGINT()});
+  auto outputType = ROW({"c0"}, {BIGINT()});
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kCudfIcebergConnectorId)
+                  .outputType(outputType)
+                  .dataColumns(dataType)
+                  .remainingFilter("c1 % 2 = 0")
+                  .endTableScan()
+                  .planNode();
+
+  // Row 1 (c1=2) is deleted; of the remaining c1={1,3,4}, `c1 % 2 = 0` keeps
+  // c1=4, i.e. c0=40.
+  auto expected = makeRowVector(
+      {"c0"},
+      {
+          makeFlatVector<int64_t>({40}),
+      });
+
+  AssertQueryBuilder(plan)
+      .splits(makeIcebergSplits(dataFile->getPath(), {deleteFile}))
+      .assertResults({expected});
+}
+
+// A subfield filter and positional deletes are rejected as the row
+// positions are altered by the filter
+TEST_F(CudfIcebergReadTest, rejectSubfieldFilterAndPositionalDeletes) {
+  auto data = makeRowVector({makeFlatVector<int64_t>({10, 20, 30, 40})});
+  auto dataFile = TempFilePath::create();
+  writeToFile(dataFile->getPath(), data);
+
+  // Positional delete file removing row 0.
+  auto deleteFilePath = TempFilePath::create();
+  auto pathColumn = IcebergMetadataColumn::icebergDeleteFilePathColumn();
+  auto posColumn = IcebergMetadataColumn::icebergDeletePosColumn();
+  auto deleteVector = makeRowVector(
+      {pathColumn->name, posColumn->name},
+      {
+          makeFlatVector<std::string>(
+              1, [&](vector_size_t) { return dataFile->getPath(); }),
+          makeFlatVector<int64_t>({0}),
+      });
+  writeDeleteFile(
+      DeleteFileFormat::DWRF, deleteFilePath->getPath(), {deleteVector});
+
+  IcebergDeleteFile deleteFile(
+      FileContent::kPositionalDeletes,
+      deleteFilePath->getPath(),
+      dwio::common::FileFormat::DWRF,
+      1,
+      getFileSize(deleteFilePath->getPath()));
+
+  // Unlike a remaining filter, `c0 < 30` is a simple range filter that is
+  // pushed down as a subfield filter, so `subfieldFilterExpr_` is set.
+  auto dataType = ROW({"c0"}, {BIGINT()});
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kCudfIcebergConnectorId)
+                  .outputType(dataType)
+                  .dataColumns(dataType)
+                  .subfieldFilter("c0 < 30")
+                  .endTableScan()
+                  .planNode();
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan)
+          .splits(makeIcebergSplits(dataFile->getPath(), {deleteFile}))
+          .copyResults(pool()),
+      "cuDF Iceberg reader does not yet support subfield filters when positional deletes are present");
+}
+
+// A subfield filter is allowed with equality deletes
+TEST_F(CudfIcebergReadTest, subfieldFilterAndEqualityDeletes) {
+  auto data = makeRowVector({makeFlatVector<int64_t>({10, 20, 30, 40})});
+  auto dataFile = TempFilePath::create();
+  writeToFile(dataFile->getPath(), data);
+
+  // Equality delete file removing rows where c0=20.
+  auto deleteData = makeRowVector({"c0"}, {makeFlatVector<int64_t>({20})});
+  auto eqDeleteFile = TempFilePath::create();
+  writeDeleteFile(
+      DeleteFileFormat::DWRF, eqDeleteFile->getPath(), {deleteData});
+
+  IcebergDeleteFile deleteFile(
+      FileContent::kEqualityDeletes,
+      eqDeleteFile->getPath(),
+      dwio::common::FileFormat::DWRF,
+      1,
+      getFileSize(eqDeleteFile->getPath()),
+      /*equalityFieldIds=*/{1});
+
+  auto dataType = ROW({"c0"}, {BIGINT()});
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kCudfIcebergConnectorId)
+                  .outputType(dataType)
+                  .dataColumns(dataType)
+                  .subfieldFilter("c0 < 35")
+                  .endTableScan()
+                  .planNode();
+
+  // `c0 < 35` keeps {10, 20, 30}; the equality delete then removes c0=20,
+  // leaving {10, 30}.
+  auto expected = makeRowVector({makeFlatVector<int64_t>({10, 30})});
+
+  AssertQueryBuilder(plan)
+      .splits(makeIcebergSplits(dataFile->getPath(), {deleteFile}))
+      .assertResults({expected});
 }
 
 TEST_F(CudfIcebergReadTest, singleBaseFileSinglePositionalDeleteFile) {

--- a/velox/experimental/cudf/tests/iceberg/CudfIcebergReadTest.cpp
+++ b/velox/experimental/cudf/tests/iceberg/CudfIcebergReadTest.cpp
@@ -642,6 +642,53 @@ TEST_F(CudfIcebergReadTest, nullPartitionColumn) {
       .assertResults({expected});
 }
 
+/// A projection containing only injected columns. e.g., partition column, leads
+/// to no columns being read from the data file and the output is synthesized
+/// from the injected columns only
+TEST_F(CudfIcebergReadTest, partitionOnlyProjection) {
+  auto data = makeRowVector(
+      {"c0"},
+      {
+          makeFlatVector<int64_t>({1, 2, 3}),
+      });
+
+  auto dataFile = TempFilePath::create();
+  writeToFile(dataFile->getPath(), data);
+
+  auto tableType = ROW({"c0", "country"}, {BIGINT(), VARCHAR()});
+  auto outputType = ROW({"country"}, {VARCHAR()});
+
+  facebook::velox::connector::ColumnHandleMap assignments;
+  assignments["country"] = std::make_shared<HiveColumnHandle>(
+      "country",
+      HiveColumnHandle::ColumnType::kPartitionKey,
+      VARCHAR(),
+      VARCHAR(),
+      std::vector<common::Subfield>{});
+
+  std::unordered_map<std::string, std::optional<std::string>> partitionKeys = {
+      {"country", "US"}};
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kCudfIcebergConnectorId)
+                  .outputType(outputType)
+                  .dataColumns(tableType)
+                  .assignments(assignments)
+                  .endTableScan()
+                  .planNode();
+
+  auto expected = makeRowVector(
+      {"country"},
+      {
+          makeFlatVector<std::string>({"US", "US", "US"}),
+      });
+
+  AssertQueryBuilder(plan)
+      .splits(makeIcebergSplits(dataFile->getPath(), {}, partitionKeys))
+      .assertResults({expected});
+}
+
 /// A remaining filter on an unprojected column (`c1`) adds `c1` to the
 /// projection for post-scan filtering and removal
 TEST_F(CudfIcebergReadTest, unprojectedRemainingFilterColumn) {
@@ -856,7 +903,8 @@ TEST_F(CudfIcebergReadTest, rejectSubfieldFilterAndPositionalDeletes) {
       AssertQueryBuilder(plan)
           .splits(makeIcebergSplits(dataFile->getPath(), {deleteFile}))
           .copyResults(pool()),
-      "cuDF Iceberg reader does not yet support subfield filters when positional deletes are present");
+      "cuDF Iceberg reader does not yet support subfield filters together with "
+      "positional deletes");
 }
 
 // A subfield filter is allowed with equality deletes
@@ -1138,6 +1186,67 @@ TEST_F(CudfIcebergReadTest, positionalDeleteSequenceNumberSkipped) {
                   .planNode();
 
   auto expected = makeRowVector({makeFlatVector<int64_t>({0, 1, 2, 3, 4})});
+  AssertQueryBuilder(plan).splits(splits).assertResults({expected});
+}
+
+// A subfield filter combined with a positional delete that is skipped by
+// sequence-number resolution must not be rejected: the delete does not apply,
+// so the row positions are not altered. This exercises the guard that runs
+// after `setupDeleteFileReaders()` in `CudfIcebergSplitReader::prepareSplit()`.
+TEST_F(CudfIcebergReadTest, subfieldFilterWithSkippedPositionalDelete) {
+  auto pathColumn = IcebergMetadataColumn::icebergDeleteFilePathColumn();
+  auto posColumn = IcebergMetadataColumn::icebergDeletePosColumn();
+  auto rowType = ROW({"c0"}, {BIGINT()});
+
+  auto dataFilePath = TempFilePath::create();
+  writeToFile(
+      dataFilePath->getPath(),
+      {makeRowVector({makeFlatVector<int64_t>({0, 1, 2, 3, 4})})});
+
+  auto deleteFilePath = TempFilePath::create();
+  auto baseFilePath = dataFilePath->getPath();
+  writeDeleteFile(
+      DeleteFileFormat::DWRF,
+      deleteFilePath->getPath(),
+      {makeRowVector(
+          {pathColumn->name, posColumn->name},
+          {
+              makeFlatVector<std::string>(
+                  2, [&](vector_size_t) { return baseFilePath; }),
+              makeFlatVector<int64_t>({1, 3}),
+          })});
+
+  // Positional delete with dataSequenceNumber (5) < the data file's sequence
+  // number (10), so it is skipped by sequence-number resolution.
+  IcebergDeleteFile deleteFile(
+      FileContent::kPositionalDeletes,
+      deleteFilePath->getPath(),
+      dwio::common::FileFormat::DWRF,
+      2,
+      getFileSize(deleteFilePath->getPath()),
+      {},
+      {},
+      {},
+      /*dataSequenceNumber=*/5);
+
+  auto splits = makeIcebergSplits(
+      baseFilePath,
+      {deleteFile},
+      {},
+      1,
+      /*dataSequenceNumber=*/10);
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kCudfIcebergConnectorId)
+                  .outputType(rowType)
+                  .dataColumns(rowType)
+                  .subfieldFilter("c0 < 4")
+                  .endTableScan()
+                  .planNode();
+
+  // The delete is skipped, so `c0 < 4` simply keeps {0, 1, 2, 3}.
+  auto expected = makeRowVector({makeFlatVector<int64_t>({0, 1, 2, 3})});
   AssertQueryBuilder(plan).splits(splits).assertResults({expected});
 }
 


### PR DESCRIPTION
Simplify schema evolution and output table assembly in Velox-cuDF's Iceberg reader. Also, eliminate an extra parquet file footer read to identify schema evolution columns and reuse existing functions for velox -> cudf type conversions and string -> scalar conversion optimizing the speed and code quality.