### PR TITLE
refactor: FileFormat's hand-rolled toString() switch to VELOX_DEFINE_ENUM_NAME

### DIFF
--- a/velox/connectors/hive/FileConnectorUtil.cpp
+++ b/velox/connectors/hive/FileConnectorUtil.cpp
@@ -131,8 +131,8 @@ void configureReaderOptions(
     VELOX_CHECK(
         readerOptions.fileFormat() == fileSplit->fileFormat,
         "HiveDataSource received splits of different formats: {} and {}",
-        dwio::common::toString(readerOptions.fileFormat()),
-        dwio::common::toString(fileSplit->fileFormat));
+        dwio::common::FileFormatName::toName(readerOptions.fileFormat()),
+        dwio::common::FileFormatName::toName(fileSplit->fileFormat));
   } else {
     readerOptions.setFileFormat(fileSplit->fileFormat);
   }

--- a/velox/connectors/hive/FileDataSink.cpp
+++ b/velox/connectors/hive/FileDataSink.cpp
@@ -453,7 +453,9 @@ uint32_t FileDataSink::appendWriter(const WriterId& id) {
   setMemoryReclaimers(writerInfo_.back().get(), ioStats_.back().get());
   writers_.emplace_back(createWriterForIndex(writerInfo_.size() - 1));
   addThreadLocalRuntimeStat(
-      fmt::format("{}WriterCount", dwio::common::toString(storageFormat_)),
+      fmt::format(
+          "{}WriterCount",
+          dwio::common::FileFormatName::toName(storageFormat_)),
       RuntimeCounter(1));
   // Extends the buffer used for partition rows calculations.
   partitionSizes_.emplace_back(0);

--- a/velox/connectors/hive/HiveConnectorSplit.cpp
+++ b/velox/connectors/hive/HiveConnectorSplit.cpp
@@ -37,7 +37,7 @@ folly::dynamic HiveConnectorSplit::serialize() const {
   obj["splitWeight"] = splitWeight;
   obj["cacheable"] = cacheable;
   obj["filePath"] = filePath;
-  obj["fileFormat"] = dwio::common::toString(fileFormat);
+  obj["fileFormat"] = dwio::common::FileFormatName::toName(fileFormat);
   obj["start"] = start;
   obj["length"] = length;
 

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -892,7 +892,8 @@ folly::dynamic HiveInsertTableHandle::serialize() const {
 
   obj["inputColumns"] = arr;
   obj["locationHandle"] = locationHandle_->serialize();
-  obj["tableStorageFormat"] = dwio::common::toString(storageFormat_);
+  obj["tableStorageFormat"] =
+      dwio::common::FileFormatName::toName(storageFormat_);
 
   if (bucketProperty_) {
     obj["bucketProperty"] = bucketProperty_->serialize();
@@ -976,7 +977,8 @@ void HiveInsertTableHandle::registerSerDe() {
 
 std::string HiveInsertTableHandle::toString() const {
   std::ostringstream out;
-  out << "HiveInsertTableHandle [" << dwio::common::toString(storageFormat_);
+  out << "HiveInsertTableHandle ["
+      << dwio::common::FileFormatName::toName(storageFormat_);
   if (compressionKind_.has_value()) {
     out << " " << common::compressionKindToString(compressionKind_.value());
   } else {

--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -165,7 +165,8 @@ HiveDataSource::getRuntimeStats() {
   }
   for (const auto& [format, count] : numSplitsByFileFormat_) {
     result.insert(
-        {fmt::format("{}{}", kFileFormat, dwio::common::toString(format)),
+        {fmt::format(
+             "{}{}", kFileFormat, dwio::common::FileFormatName::toName(format)),
          RuntimeMetric(count)});
   }
   return result;

--- a/velox/connectors/hive/HiveIndexSource.cpp
+++ b/velox/connectors/hive/HiveIndexSource.cpp
@@ -1286,7 +1286,7 @@ void HiveIndexSource::createReadersFromSplits(
               hiveSplit->fileFormat == dwio::common::FileFormat::FLUX ||
               hiveSplit->fileFormat == dwio::common::FileFormat::SST,
           "No IndexReaderFactory registered for format: {}",
-          dwio::common::toString(hiveSplit->fileFormat));
+          dwio::common::FileFormatName::toName(hiveSplit->fileFormat));
       createFileIndexReader(std::move(hiveSplit), scanSpec);
     }
   }
@@ -1668,7 +1668,7 @@ void HiveIndexSource::createCustomIndexReader(
   VELOX_CHECK_NOT_NULL(
       reader,
       "IndexReaderFactory returned null for format: {}",
-      dwio::common::toString(split->fileFormat));
+      dwio::common::FileFormatName::toName(split->fileFormat));
   readers_.push_back(std::move(reader));
 }
 

--- a/velox/connectors/hive/IndexReader.h
+++ b/velox/connectors/hive/IndexReader.h
@@ -120,7 +120,7 @@ class IndexReaderFactoryRegistry {
     VELOX_CHECK(
         inserted,
         "IndexReaderFactory already registered for format: {}",
-        dwio::common::toString(format));
+        dwio::common::FileFormatName::toName(format));
   }
 
   /// Unregisters the factory for the given file format. Returns true if a

--- a/velox/connectors/hive/iceberg/IcebergDataSink.cpp
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.cpp
@@ -104,7 +104,8 @@ std::pair<std::string, std::string> IcebergFileNameGenerator::gen(
   if (targetFileName.empty()) {
     targetFileName = fmt::format("{}", makeUuid());
   }
-  auto fileFormat = dwio::common::toString(insertTableHandle->storageFormat());
+  auto fileFormat =
+      dwio::common::FileFormatName::toName(insertTableHandle->storageFormat());
   auto fileName = fmt::format("{}.{}", targetFileName, fileFormat);
   return {fileName, fileName};
 }
@@ -158,7 +159,7 @@ IcebergInsertTableHandle::IcebergInsertTableHandle(
   VELOX_USER_CHECK(
       isSupportedFileFormat(tableStorageFormat),
       "Unsupported file format for writing Iceberg tables: {}",
-      dwio::common::toString(tableStorageFormat));
+      dwio::common::FileFormatName::toName(tableStorageFormat));
 }
 
 namespace {

--- a/velox/connectors/hive/iceberg/WriterOptionsAdapter.cpp
+++ b/velox/connectors/hive/iceberg/WriterOptionsAdapter.cpp
@@ -119,7 +119,7 @@ std::string toManifestFormatString(dwio::common::FileFormat format) {
   VELOX_CHECK_NOT_NULL(
       adapter,
       "Unsupported file format for Iceberg manifest: {}",
-      dwio::common::toString(format));
+      dwio::common::FileFormatName::toName(format));
   return adapter->manifestFormatString();
 }
 

--- a/velox/connectors/hive/paimon/PaimonConnectorSplit.cpp
+++ b/velox/connectors/hive/paimon/PaimonConnectorSplit.cpp
@@ -117,7 +117,7 @@ folly::dynamic PaimonConnectorSplit::serialize() const {
       ? folly::dynamic(tableBucketNumber_.value())
       : nullptr;
 
-  obj["fileFormat"] = dwio::common::toString(fileFormat_);
+  obj["fileFormat"] = dwio::common::FileFormatName::toName(fileFormat_);
 
   return obj;
 }

--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -692,7 +692,7 @@ DEBUG_ONLY_TEST_F(HiveDataSinkTest, memoryReclaim) {
     std::string debugString() const {
       return fmt::format(
           "format: {}, sortWriter: {}, writerSpillEnabled: {}, writerFlushThreshold: {}, expectedWriterReclaimEnabled: {}, expectedWriterReclaimed: {}",
-          dwio::common::toString(format),
+          dwio::common::FileFormatName::toName(format),
           sortWriter,
           writerSpillEnabled,
           succinctBytes(writerFlushThreshold),
@@ -842,7 +842,7 @@ TEST_F(HiveDataSinkTest, memoryReclaimAfterClose) {
     std::string debugString() const {
       return fmt::format(
           "format: {}, sortWriter: {}, writerSpillEnabled: {}, close: {}, expectedWriterReclaimEnabled: {}",
-          dwio::common::toString(format),
+          dwio::common::FileFormatName::toName(format),
           sortWriter,
           writerSpillEnabled,
           close,

--- a/velox/dwio/common/Options.cpp
+++ b/velox/dwio/common/Options.cpp
@@ -22,6 +22,26 @@ namespace facebook::velox::dwio::common {
 
 namespace {
 
+const auto& fileFormatNames() {
+  static const folly::F14FastMap<FileFormat, std::string_view> kNames = {
+      {FileFormat::UNKNOWN, "unknown"},
+      {FileFormat::DWRF, "dwrf"},
+      {FileFormat::RC, "rc"},
+      {FileFormat::RC_TEXT, "rc:text"},
+      {FileFormat::RC_BINARY, "rc:binary"},
+      {FileFormat::TEXT, "text"},
+      {FileFormat::JSON, "json"},
+      {FileFormat::PARQUET, "parquet"},
+      {FileFormat::NIMBLE, "nimble"},
+      {FileFormat::ORC, "orc"},
+      {FileFormat::SST, "sst"},
+      {FileFormat::FLUX, "flux"},
+      {FileFormat::AVRO, "avro"},
+      {FileFormat::PUFFIN, "puffin"},
+  };
+  return kNames;
+}
+
 const auto& columnMappingModeNames() {
   static const folly::F14FastMap<ColumnMappingMode, std::string_view> kNames = {
       {ColumnMappingMode::kPosition, "POSITION"},
@@ -33,70 +53,14 @@ const auto& columnMappingModeNames() {
 
 } // namespace
 
+VELOX_DEFINE_ENUM_NAME(FileFormat, fileFormatNames);
 VELOX_DEFINE_ENUM_NAME(ColumnMappingMode, columnMappingModeNames);
 
 FileFormat toFileFormat(std::string_view s) {
-  if (s == "dwrf") {
-    return FileFormat::DWRF;
-  } else if (s == "rc") {
-    return FileFormat::RC;
-  } else if (s == "rc:text") {
-    return FileFormat::RC_TEXT;
-  } else if (s == "rc:binary") {
-    return FileFormat::RC_BINARY;
-  } else if (s == "text") {
-    return FileFormat::TEXT;
-  } else if (s == "json") {
-    return FileFormat::JSON;
-  } else if (s == "parquet") {
-    return FileFormat::PARQUET;
-  } else if (s == "nimble" || s == "alpha") {
+  if (s == "alpha") {
     return FileFormat::NIMBLE;
-  } else if (s == "orc") {
-    return FileFormat::ORC;
-  } else if (s == "sst") {
-    return FileFormat::SST;
-  } else if (s == "flux") {
-    return FileFormat::FLUX;
-  } else if (s == "avro") {
-    return FileFormat::AVRO;
-  } else if (s == "puffin") {
-    return FileFormat::PUFFIN;
   }
-  return FileFormat::UNKNOWN;
-}
-
-std::string_view toString(FileFormat fmt) {
-  switch (fmt) {
-    case FileFormat::DWRF:
-      return "dwrf";
-    case FileFormat::RC:
-      return "rc";
-    case FileFormat::RC_TEXT:
-      return "rc:text";
-    case FileFormat::RC_BINARY:
-      return "rc:binary";
-    case FileFormat::TEXT:
-      return "text";
-    case FileFormat::JSON:
-      return "json";
-    case FileFormat::PARQUET:
-      return "parquet";
-    case FileFormat::NIMBLE:
-      return "nimble";
-    case FileFormat::ORC:
-      return "orc";
-    case FileFormat::SST:
-      return "sst";
-    case FileFormat::FLUX:
-      return "flux";
-    case FileFormat::AVRO:
-      return "avro";
-    case FileFormat::PUFFIN:
-      return "puffin";
-    default:
-      return "unknown";
-  }
+  return FileFormatName::tryToFileFormat(s).value_or(FileFormat::UNKNOWN);
 }
 
 ColumnReaderOptions makeColumnReaderOptions(const ReaderOptions& options) {

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -72,15 +72,9 @@ enum class FileFormat {
           // Iceberg connector via FileSystem::pread of the blob byte-range.
 };
 
-FileFormat toFileFormat(std::string_view s);
-std::string_view toString(FileFormat fmt);
+VELOX_DECLARE_ENUM_NAME(FileFormat);
 
-FOLLY_ALWAYS_INLINE std::ostream& operator<<(
-    std::ostream& output,
-    const FileFormat& fmt) {
-  output << toString(fmt);
-  return output;
-}
+FileFormat toFileFormat(std::string_view s);
 
 /// Controls how a reader maps the requested table schema to physical file
 /// columns.
@@ -1045,7 +1039,7 @@ struct fmt::formatter<facebook::velox::dwio::common::FileFormat>
   auto format(facebook::velox::dwio::common::FileFormat fmt, FormatContext& ctx)
       const {
     return formatter<std::string_view>::format(
-        facebook::velox::dwio::common::toString(fmt), ctx);
+        facebook::velox::dwio::common::FileFormatName::toName(fmt), ctx);
   }
 };
 

--- a/velox/dwio/common/ReaderFactory.cpp
+++ b/velox/dwio/common/ReaderFactory.cpp
@@ -38,7 +38,7 @@ bool registerReaderFactory(std::shared_ptr<ReaderFactory> factory) {
   VELOX_CHECK(
       ok,
       "ReaderFactory is already registered for format {}",
-      toString(factory->fileFormat()));
+      FileFormatName::toName(factory->fileFormat()));
 #endif
   return true;
 }
@@ -53,7 +53,7 @@ std::shared_ptr<ReaderFactory> getReaderFactory(FileFormat format) {
   VELOX_CHECK(
       it != readerFactories().end(),
       "ReaderFactory is not registered for format {}",
-      toString(format));
+      FileFormatName::toName(format));
   return it->second;
 }
 

--- a/velox/dwio/common/WriterFactory.cpp
+++ b/velox/dwio/common/WriterFactory.cpp
@@ -37,7 +37,7 @@ bool registerWriterFactory(std::shared_ptr<WriterFactory> factory) {
   VELOX_CHECK(
       ok,
       "WriterFactory is already registered for format {}",
-      toString(factory->fileFormat()));
+      FileFormatName::toName(factory->fileFormat()));
 #endif
   return true;
 }
@@ -50,7 +50,8 @@ std::shared_ptr<WriterFactory> getWriterFactory(FileFormat format) {
   auto it = writerFactories().find(format);
   if (it == writerFactories().end()) {
     VELOX_UNSUPPORTED(
-        "WriterFactory is not registered for format {}", toString(format));
+        "WriterFactory is not registered for format {}",
+        FileFormatName::toName(format));
   }
   return it->second;
 }

--- a/velox/dwio/common/tests/OptionsTests.cpp
+++ b/velox/dwio/common/tests/OptionsTests.cpp
@@ -29,7 +29,7 @@ TEST(OptionsTests, defaultRowNumberColumnInfoTest) {
 
 TEST(OptionsTests, fluxFileFormatRoundTrip) {
   ASSERT_EQ(FileFormat::FLUX, toFileFormat("flux"));
-  ASSERT_EQ("flux", toString(FileFormat::FLUX));
+  ASSERT_EQ("flux", FileFormatName::toName(FileFormat::FLUX));
 }
 
 TEST(OptionsTests, setRowNumberColumnInfoTest) {

--- a/velox/exec/tests/utils/TableWriterTestBase.cpp
+++ b/velox/exec/tests/utils/TableWriterTestBase.cpp
@@ -73,7 +73,7 @@ bool TableWriterTestBase::TestParam::scaleWriter() const {
 std::string TableWriterTestBase::TestParam::toString() const {
   return fmt::format(
       "FileFormat_{}_TestMode_{}_commitStrategy_{}_bucketKind_{}_bucketSort_{}_multiDrivers_{}_compression_{}_scaleWriter_{}",
-      dwio::common::toString((fileFormat())),
+      dwio::common::FileFormatName::toName((fileFormat())),
       testModeString(testMode()),
       CommitStrategyName::toName(commitStrategy()),
       HiveBucketProperty::kindString(bucketKind()),

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSink.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSink.cpp
@@ -498,7 +498,8 @@ folly::dynamic CudfHiveInsertTableHandle::serialize() const {
 
   obj["inputColumns"] = arr;
   obj["locationHandle"] = locationHandle_->serialize();
-  obj["tableStorageFormat"] = dwio::common::toString(storageFormat_);
+  obj["tableStorageFormat"] =
+      dwio::common::FileFormatName::toName(storageFormat_);
 
   if (compressionKind_.has_value()) {
     obj["compressionKind"] = common::compressionKindToString(*compressionKind_);
@@ -530,7 +531,7 @@ CudfHiveInsertTableHandlePtr CudfHiveInsertTableHandle::create(
 std::string CudfHiveInsertTableHandle::toString() const {
   std::ostringstream out;
   out << "CudfHiveInsertTableHandle ["
-      << dwio::common::toString(storageFormat_);
+      << dwio::common::FileFormatName::toName(storageFormat_);
   if (compressionKind_.has_value()) {
     out << " " << common::compressionKindToString(compressionKind_.value());
   } else {

--- a/velox/experimental/cudf/tests/TableWriteTest.cpp
+++ b/velox/experimental/cudf/tests/TableWriteTest.cpp
@@ -138,7 +138,7 @@ struct TestParam {
   std::string toString() const {
     return fmt::format(
         "FileFormat[{}] TestMode[{}] commitStrategy[{}] multiDrivers[{}] compression[{}]",
-        dwio::common::toString((fileFormat())),
+        dwio::common::FileFormatName::toName((fileFormat())),
         testModeString(testMode()),
         CommitStrategyName::toName(commitStrategy()),
         multiDrivers(),

--- a/velox/tool/trace/TableWriterReplayer.cpp
+++ b/velox/tool/trace/TableWriterReplayer.cpp
@@ -52,7 +52,8 @@ makeHiveInsertTableHandle(
     LOG(INFO) << fmt::format("\t{}: {}", key, value);
   }
   LOG(INFO) << fmt::format(
-      "Storage format: {}", dwio::common::toString(storageFormat));
+      "Storage format: {}",
+      dwio::common::FileFormatName::toName(storageFormat));
   return std::make_shared<connector::hive::HiveInsertTableHandle>(
       inputColumns,
       std::make_shared<connector::hive::LocationHandle>(


### PR DESCRIPTION
Convert FileFormat's hand-rolled toString() switch to VELOX_DEFINE_ENUM_NAME.
Update call site to use FileFormatName::toName(...).