### PR TITLE
fix(iceberg): Filter pushdown with initial-default columns

### DIFF
--- a/velox/connectors/hive/FileConnectorUtil.cpp
+++ b/velox/connectors/hive/FileConnectorUtil.cpp
@@ -252,13 +252,31 @@ bool applyPartitionFilter(
       }
       return applyFilter(*filter, result.value());
     }
-    case TypeKind::VARCHAR: {
+    case TypeKind::VARCHAR:
+    case TypeKind::VARBINARY: {
       return applyFilter(*filter, partitionValue);
     }
     default:
       VELOX_FAIL(
           "Bad type {} for partition value: {}", type->kind(), partitionValue);
   }
+}
+
+template <TypeKind kind>
+bool testFilterTyped(const common::Filter* filter, const VectorPtr& vec) {
+  using T = typename TypeTraits<kind>::NativeType;
+  return applyFilter(*filter, vec->as<SimpleVector<T>>()->valueAt(0));
+}
+
+// Tests a filter against a non-null constant vector value (e.g., an
+// initial-default column missing from the data file).
+bool testFilterOnConstantVector(
+    const common::Filter* filter,
+    const VectorPtr& constantVec) {
+  VELOX_CHECK_EQ(constantVec->size(), 1);
+  VELOX_CHECK(!constantVec->isNullAt(0));
+  return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH_ALL(
+      testFilterTyped, constantVec->typeKind(), filter, constantVec);
 }
 
 } // namespace
@@ -295,9 +313,20 @@ bool testFilters(
               child->filter(),
               asLocalTime);
         }
-        // Column is missing, most likely due to schema evolution. Or it's a
-        // partition key but the partition value is NULL.
-        if (child->filter()->isDeterministic() &&
+        // Column is missing from the file. If it has a constant value (e.g.,
+        // an initial-default from schema evolution), test the filter against
+        // it. Otherwise treat the column as NULL.
+        bool filterMatchedConstant = false;
+        if (child->isConstant()) {
+          auto constantVec = child->constantValue();
+          if (!constantVec->isNullAt(0)) {
+            if (!testFilterOnConstantVector(child->filter(), constantVec)) {
+              return false;
+            }
+            filterMatchedConstant = true;
+          }
+        }
+        if (!filterMatchedConstant && child->filter()->isDeterministic() &&
             !child->filter()->testNull()) {
           VLOG(1) << "Skipping " << filePath
                   << " because the filter testNull() failed for column "

--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -68,28 +68,14 @@ class IcebergReadTest : public test::IcebergTestBase {
       const std::string& name,
       const TypePtr& type,
       int fieldId,
-      const std::string& defaultValue) {
+      std::optional<std::string> defaultValue = std::nullopt) {
     return std::make_shared<IcebergColumnHandle>(
         name,
         HiveColumnHandle::ColumnType::kRegular,
         type,
         parquet::ParquetFieldId(fieldId),
         std::vector<common::Subfield>{},
-        std::optional<std::string>{defaultValue});
-  }
-
-  std::shared_ptr<IcebergColumnHandle> makeIcebergHandle(
-      const std::string& name,
-      const TypePtr& type,
-      int fieldId,
-      FileColumnHandle::ColumnType columnType =
-          FileColumnHandle::ColumnType::kRegular) {
-    return std::make_shared<IcebergColumnHandle>(
-        name,
-        columnType,
-        type,
-        parquet::ParquetFieldId(fieldId),
-        std::vector<common::Subfield>{});
+        defaultValue);
   }
 
   void assertDefaultValues(
@@ -566,6 +552,140 @@ TEST_F(IcebergReadTest, defaultValueWithDeletesAndFilters) {
         .splits(makeSplits())
         .assertResults(makeExpected({5, 7, 8, 9, 10}));
   }
+}
+
+// Test filter pushdown (remainingFilter) with initial-default columns.
+// This test validates that when a filter is pushed down to the split reader,
+// files with missing columns that have initial-defaults are correctly handled
+// during checkIfSplitIsEmpty().
+TEST_F(IcebergReadTest, filterPushdownWithInitialDefault) {
+  auto newRowType =
+      ROW({"c0", "country", "status"}, {BIGINT(), VARCHAR(), VARCHAR()});
+
+  // Write data file with old schema (only c0) containing rows 1-5.
+  std::vector<RowVectorPtr> dataVectors;
+  dataVectors.push_back(
+      makeRowVector({makeFlatVector<int64_t>({1, 2, 3, 4, 5})}));
+  auto dataFilePath = TempFilePath::create();
+  writeToFile(dataFilePath->getPath(), dataVectors);
+
+  ColumnHandleMap assignments;
+  assignments["c0"] = makeIcebergHandle("c0", BIGINT(), 1);
+  assignments["country"] = makeIcebergHandle("country", VARCHAR(), 2, "IN");
+  assignments["status"] = makeIcebergHandle("status", VARCHAR(), 3);
+
+  // Test 1: Filter pushdown on initial-default column (matching value)
+  // Without the fix, checkIfSplitIsEmpty() would incorrectly skip this file
+  // because it treats missing 'country' column as NULL, and NULL != 'IN'.
+  std::vector<RowVectorPtr> allRowsExpected;
+  allRowsExpected.push_back(makeRowVector(
+      newRowType->names(),
+      {makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+       makeFlatVector<std::string>({"IN", "IN", "IN", "IN", "IN"}),
+       makeNullableFlatVector<std::string>(
+           {std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt})}));
+
+  auto filteredExpected = std::vector<RowVectorPtr>{makeRowVector(
+      newRowType->names(),
+      {makeFlatVector<int64_t>({3, 4, 5}),
+       makeFlatVector<std::string>({"IN", "IN", "IN"}),
+       makeNullableFlatVector<std::string>(
+           {std::nullopt, std::nullopt, std::nullopt})})};
+
+  auto assertFilter = [&](const std::string& filter,
+                          const std::vector<RowVectorPtr>& expected,
+                          int32_t numSplitsSkipped = 0) {
+    auto plan = exec::test::PlanBuilder()
+                    .startTableScan()
+                    .connectorId(test::kIcebergConnectorId)
+                    .outputType(newRowType)
+                    .dataColumns(newRowType)
+                    .assignments(assignments)
+                    .remainingFilter(filter)
+                    .endTableScan()
+                    .planNode();
+    auto task = exec::test::AssertQueryBuilder(plan)
+                    .splits(makeIcebergSplits(dataFilePath->getPath()))
+                    .assertResults(expected);
+    ASSERT_EQ(
+        task->taskStats()
+            .pipelineStats[0]
+            .operatorStats[0]
+            .runtimeStats["skippedSplits"]
+            .sum,
+        numSplitsSkipped);
+  };
+
+  assertFilter("country = 'IN'", allRowsExpected);
+  assertFilter("country IS NOT NULL", allRowsExpected);
+  assertFilter("status IS NULL", allRowsExpected);
+  assertFilter("status IS NOT NULL", {}, 1);
+  assertFilter("c0 > 2 AND country = 'IN'", filteredExpected);
+  assertFilter("country = 'US'", {}, 1);
+}
+
+// Test filter pushdown with non-VARCHAR initial-default columns (INTEGER,
+// REAL). This validates that the type casting in testFilterOnConstantVector()
+// works correctly for numeric types.
+TEST_F(IcebergReadTest, filterPushdownWithNumericInitialDefaults) {
+  auto newRowType = ROW({"c0", "age", "score"}, {BIGINT(), INTEGER(), REAL()});
+
+  // Write data file with old schema (only c0) containing rows 1-5.
+  std::vector<RowVectorPtr> dataVectors;
+  dataVectors.push_back(
+      makeRowVector({makeFlatVector<int64_t>({1, 2, 3, 4, 5})}));
+  auto dataFilePath = TempFilePath::create();
+  writeToFile(dataFilePath->getPath(), dataVectors);
+
+  ColumnHandleMap assignments;
+  assignments["c0"] = makeIcebergHandle("c0", BIGINT(), 1);
+  assignments["age"] = makeIcebergHandle("age", INTEGER(), 2, "25");
+  assignments["score"] = makeIcebergHandle("score", REAL(), 3, "3.14");
+
+  std::vector<RowVectorPtr> allRowsExpected;
+  allRowsExpected.push_back(makeRowVector(
+      newRowType->names(),
+      {makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+       makeFlatVector<int32_t>({25, 25, 25, 25, 25}),
+       makeFlatVector<float>({3.14f, 3.14f, 3.14f, 3.14f, 3.14f})}));
+
+  auto assertFilter = [&](const std::string& filter,
+                          const std::vector<RowVectorPtr>& expected,
+                          int32_t numSplitsSkipped = 0) {
+    auto plan = exec::test::PlanBuilder()
+                    .startTableScan()
+                    .connectorId(test::kIcebergConnectorId)
+                    .outputType(newRowType)
+                    .dataColumns(newRowType)
+                    .assignments(assignments)
+                    .remainingFilter(filter)
+                    .endTableScan()
+                    .planNode();
+    auto task = exec::test::AssertQueryBuilder(plan)
+                    .splits(makeIcebergSplits(dataFilePath->getPath()))
+                    .assertResults(expected);
+    ASSERT_EQ(
+        task->taskStats()
+            .pipelineStats[0]
+            .operatorStats[0]
+            .runtimeStats["skippedSplits"]
+            .sum,
+        numSplitsSkipped);
+  };
+
+  assertFilter("age = cast(25 as INTEGER)", allRowsExpected);
+  assertFilter("age = cast(30 as INTEGER)", {}, 1);
+  assertFilter("score = cast(3.14 as REAL)", allRowsExpected);
+  assertFilter("score > cast(5.0 as REAL)", {}, 1);
+  assertFilter(
+      "age = cast(25 as INTEGER) AND score = cast(3.14 as REAL)",
+      allRowsExpected);
+  assertFilter(
+      "age = cast(25 as INTEGER) AND score > cast(5.0 as REAL)", {}, 1);
 }
 
 TEST_F(IcebergReadTest, partitionColumnsFromHive) {


### PR DESCRIPTION
When filter pushdown is applied to Iceberg tables, files with missing columns that have `initial-default` values were incorrectly skipped during `checkIfSplitIsEmpty()`. The generic `testFilters()` treated missing columns as `NULL`, causing filters like "country = 'IN'" to reject files even when the column has `initial-default 'IN'`.

This was discovered while running Presto query, added test scenario `testSelectWithInitialDefaultAndFilters()` to validate filter pushdown on C++ workers for Iceberg V3 columns with `initial-default `values. This test exposes a bug where C++ workers return 0 rows when filtering on 
columns with `initial-defaults` in historical data files. - https://github.com/prestodb/presto/pull/27957