### PR TITLE
test: Make cached duplicate-region test deterministic

### DIFF
--- a/velox/dwio/common/tests/CachedBufferedInputTest.cpp
+++ b/velox/dwio/common/tests/CachedBufferedInputTest.cpp
@@ -167,6 +167,8 @@ class CachedBufferedInputTest : public testing::Test {
     const auto ssdStatsBefore =
         useSsd ? cache_->ssdCache()->stats() : SsdCacheStats{};
 
+    // Disable async prefetch so the shared coalesced load is consumed by the
+    // first stream access below.
     CachedBufferedInput input(
         readFile,
         MetricsLog::voidLog(),
@@ -176,7 +178,7 @@ class CachedBufferedInputTest : public testing::Test {
         std::move(groupId),
         dataIoStats_,
         nullptr,
-        executor_.get(),
+        nullptr,
         readerOptions);
 
     auto stream1 = input.enqueue(common::Region{kOffset, kRegionSize}, nullptr);


### PR DESCRIPTION
Summary: `CachedBufferedInputTest.duplicateRegionsShareCoalescedRead` and `CachedBufferedInputTest.duplicateRegionsShareCoalescedSsdRead` expect the shared coalesced load to be consumed by the first stream access. Disable the async prefetch executor in this helper so `input.load()` records the coalesced load without racing ahead on a background thread.

Differential Revision: D108033409


