### PR TITLE
refactor(parquet): Avoid copying logical type

### DIFF
--- a/velox/dwio/parquet/reader/IntegerColumnReader.h
+++ b/velox/dwio/parquet/reader/IntegerColumnReader.h
@@ -60,7 +60,7 @@ class IntegerColumnReader : public dwio::common::SelectiveIntegerColumnReader {
 
   void getValues(const RowSet& rows, VectorPtr* result) override {
     auto& fileType = static_cast<const ParquetTypeWithId&>(*fileType_);
-    auto logicalType = fileType.logicalType_;
+    const auto& logicalType = fileType.logicalType_;
     if (logicalType &&
         logicalType->getType() == thrift::LogicalType::Type::INTEGER &&
         !*logicalType->get_INTEGER().isSigned()) {


### PR DESCRIPTION
Summary: Integer column reads inspect Parquet logical type metadata for every batch. Bind the optional logical type by const reference and use `operator->` so unsigned integer handling does not copy the thrift metadata.

Reviewed By: stanley-shi

Differential Revision: D107883919


