### PR TITLE
perf(dwio): Avoid copying row names in reader (#17783)

### DIFF
--- a/velox/connectors/hive/tests/CMakeLists.txt
+++ b/velox/connectors/hive/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ target_link_libraries(
   velox_hive_connector
   velox_hive_partition_function
   velox_dwio_common_exception
+  velox_dwio_orc_reader
   velox_vector_fuzzer
   velox_vector_test_lib
   velox_exec

--- a/velox/dwio/common/Reader.cpp
+++ b/velox/dwio/common/Reader.cpp
@@ -149,9 +149,7 @@ RowReader::ProjectColumnsResult RowReader::projectColumnsWithSelection(
       rowTypes.push_back(
           children[i] ? children[i]->type() : rowType->childAt(i));
     }
-    rowType =
-        ROW(std::vector<std::string>(rowNames.begin(), rowNames.end()),
-            std::move(rowTypes));
+    rowType = ROW(std::move(rowNames), std::move(rowTypes));
   }
 
   auto output = std::make_shared<RowVector>(


### PR DESCRIPTION
Summary:

Post-read extraction transforms rebuild a `RowType` when child vector types change. Move the copied field-name vector into `ROW()` instead of copying it again with a range constructor.

Reviewed By: stanley-shi

Differential Revision: D107883918


