### PR TITLE
fix: Clean up parquet thrift (#17784)

### DIFF
--- a/velox/dwio/parquet/thrift/parquet.thrift
+++ b/velox/dwio/parquet/thrift/parquet.thrift
@@ -37,10 +37,7 @@
  * File format description for the parquet file format
  */
 
-include "thrift/annotation/thrift.thrift"
-
 namespace cpp2 facebook.velox.parquet.thrift
-namespace java org.apache.parquet.format
 
 /**
  * Types supported by Parquet.  These types are intended to be used in combination


### PR DESCRIPTION
Summary:

Addressed 2 problems:
1. unused include
2. deprecated java namespace

Differential Revision: D108050899


