### PR TITLE
fix: Don't emit duplicate default global grouping-set rows with multiple drivers

### DIFF
--- a/velox/exec/BlockingReason.cpp
+++ b/velox/exec/BlockingReason.cpp
@@ -39,6 +39,7 @@ const auto& blockingReasonNames() {
       {BlockingReason::kWaitForIndexLookup, "kWaitForIndexLookup"},
       {BlockingReason::kWaitForIndexSplits, "kWaitForIndexSplits"},
       {BlockingReason::kWaitForRPC, "kWaitForRPC"},
+      {BlockingReason::kWaitForAggregationPeers, "kWaitForAggregationPeers"},
   };
   return kNames;
 }

--- a/velox/exec/BlockingReason.h
+++ b/velox/exec/BlockingReason.h
@@ -62,6 +62,9 @@ enum class BlockingReason {
   /// Used by RPC operators, indicating that the operator is blocked waiting
   /// for an async RPC response (e.g., LLM inference, embedding lookups).
   kWaitForRPC,
+  /// Used by HashAggregation with a global grouping set: a driver waits for its
+  /// peers so only the last one emits the default rows on empty input.
+  kWaitForAggregationPeers,
 };
 
 VELOX_DECLARE_ENUM_NAME(BlockingReason);

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -818,10 +818,6 @@ bool GroupingSet::getOutput(
     return getGlobalAggregationOutput(iterator, result);
   }
 
-  if (hasDefaultGlobalGroupingSetOutput()) {
-    return getDefaultGlobalGroupingSetOutput(iterator, result);
-  }
-
   if (hasSpilled()) {
     return getOutputWithSpill(maxOutputRows, maxOutputBytes, result);
   }

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -114,12 +114,14 @@ class GroupingSet {
     return table_ ? table_->numDistinct() : 0;
   }
 
-  /// Returns number of global grouping sets rows if there is default output.
-  std::optional<vector_size_t> numDefaultGlobalGroupingSetRows() const {
-    if (hasDefaultGlobalGroupingSetOutput()) {
-      return globalGroupingSets_.size();
-    }
-    return std::nullopt;
+  /// Returns the number of raw input rows received.
+  uint64_t numInputRows() const {
+    return numInputRows_;
+  }
+
+  /// Returns the number of global grouping sets.
+  vector_size_t numGlobalGroupingSets() const {
+    return static_cast<vector_size_t>(globalGroupingSets_.size());
   }
 
   const HashLookup& hashLookup() const;

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -50,6 +50,8 @@ HashAggregation::HashAggregation(
       isPartialOutput_(isPartialOutput(aggregationNode->step())),
       isGlobal_(aggregationNode->groupingKeys().empty()),
       isDistinct_(!isGlobal_ && aggregationNode->aggregates().empty()),
+      isRawInput_(isRawInput(aggregationNode->step())),
+      hasGlobalGroupingSets_(!aggregationNode->globalGroupingSets().empty()),
       memoryCompactionEnabled_(
           driverCtx->queryConfig().aggregationMemoryCompactionReclaimEnabled()),
       maxExtendedPartialAggregationMemoryUsage_(
@@ -118,7 +120,7 @@ void HashAggregation::initialize() {
       std::move(aggregateInfos),
       aggregationNode_->ignoreNullKeys(),
       isPartialOutput_,
-      isRawInput(aggregationNode_->step()),
+      isRawInput_,
       aggregationNode_->globalGroupingSets(),
       groupIdChannel,
       spillConfig_.has_value() ? &spillConfig_.value() : nullptr,
@@ -402,11 +404,14 @@ RowVectorPtr HashAggregation::getOutput() {
       output_);
   if (!hasData) {
     resultIterator_.reset();
-    if (noMoreInput_) {
-      finished_ = true;
-    }
     resetPartialOutputIfNeed();
     finishDrain();
+    if (noMoreInput_) {
+      finished_ = true;
+      if (emitDefaultGlobalGroupingSetRows_) {
+        return getDefaultGlobalGroupingSetOutput();
+      }
+    }
     return nullptr;
   }
   numOutputRows_ += output_->size();
@@ -450,13 +455,9 @@ RowVectorPtr HashAggregation::getDistinctOutput() {
   if (!groupingSet_->hasSpilled()) {
     if (noMoreInput_) {
       finished_ = true;
-      if (auto numRows = groupingSet_->numDefaultGlobalGroupingSetRows()) {
-        prepareOutput(numRows.value());
-        if (groupingSet_->getDefaultGlobalGroupingSetOutput(
-                resultIterator_, output_)) {
-          numOutputRows_ += output_->size();
-          return output_;
-        }
+      resultIterator_.reset();
+      if (emitDefaultGlobalGroupingSetRows_) {
+        return getDefaultGlobalGroupingSetOutput();
       }
     }
     return nullptr;
@@ -481,12 +482,72 @@ RowVectorPtr HashAggregation::getDistinctOutput() {
   return output_;
 }
 
+bool HashAggregation::shouldEmitDefaultGlobalGroupingSetRows() {
+  if (!hasGlobalGroupingSets_ || !isRawInput_) {
+    return false;
+  }
+  // Single driver has no peers; emit based on its own input.
+  if (operatorCtx_->task()->numDrivers(operatorCtx_->driver()) <= 1) {
+    return groupingSet_->numInputRows() == 0;
+  }
+  return electDefaultGlobalGroupingSetDriver();
+}
+
+bool HashAggregation::electDefaultGlobalGroupingSetDriver() {
+  std::vector<ContinuePromise> promises;
+  std::vector<std::shared_ptr<Driver>> peers;
+  if (!operatorCtx_->task()->allPeersFinished(
+          planNodeId(), operatorCtx_->driver(), &future_, promises, peers)) {
+    VELOX_CHECK(future_.valid());
+    return false;
+  }
+
+  SCOPE_EXIT {
+    peers.clear();
+    for (auto& promise : promises) {
+      promise.setValue();
+    }
+  };
+
+  // allPeersFinished returned true, so every peer has finished noMoreInput()
+  // and its input count is final.
+  uint64_t totalInputRows = groupingSet_->numInputRows();
+  for (auto& peer : peers) {
+    auto* aggregation =
+        dynamic_cast<HashAggregation*>(peer->findOperator(planNodeId()));
+    VELOX_CHECK_NOT_NULL(aggregation);
+    totalInputRows += aggregation->groupingSet_->numInputRows();
+  }
+  return totalInputRows == 0;
+}
+
+RowVectorPtr HashAggregation::getDefaultGlobalGroupingSetOutput() {
+  prepareOutput(groupingSet_->numGlobalGroupingSets());
+  VELOX_CHECK(groupingSet_->getDefaultGlobalGroupingSetOutput(
+      resultIterator_, output_));
+  numOutputRows_ += output_->size();
+  return output_;
+}
+
 void HashAggregation::noMoreInput() {
   updateEstimatedOutputRowSize();
   groupingSet_->noMoreInput();
   Operator::noMoreInput();
+
+  // May park this driver on 'future_' for the peer election, surfaced by
+  // isBlocked() as kWaitForAggregationPeers.
+  emitDefaultGlobalGroupingSetRows_ = shouldEmitDefaultGlobalGroupingSetRows();
+
   // Release the extra reserved memory right after processing all the inputs.
   pool()->release();
+}
+
+BlockingReason HashAggregation::isBlocked(ContinueFuture* future) {
+  if (future_.valid()) {
+    *future = std::move(future_);
+    return BlockingReason::kWaitForAggregationPeers;
+  }
+  return BlockingReason::kNotBlocked;
 }
 
 bool HashAggregation::isFinished() {

--- a/velox/exec/HashAggregation.h
+++ b/velox/exec/HashAggregation.h
@@ -57,9 +57,7 @@ class HashAggregation : public Operator {
 
   void noMoreInput() override;
 
-  BlockingReason isBlocked(ContinueFuture* /* unused */) override {
-    return BlockingReason::kNotBlocked;
-  }
+  BlockingReason isBlocked(ContinueFuture* future) override;
 
   bool isFinished() override;
 
@@ -109,11 +107,27 @@ class HashAggregation : public Operator {
 
   void updateEstimatedOutputRowSize();
 
+  // Returns whether this driver should emit the default global grouping set
+  // rows.
+  bool shouldEmitDefaultGlobalGroupingSetRows();
+
+  // Barrier across peers. True only on the elected last driver when input is
+  // globally empty; false when parked on 'future_' or input is non-empty.
+  bool electDefaultGlobalGroupingSetDriver();
+
+  // Returns the default global grouping set rows for the () set.
+  RowVectorPtr getDefaultGlobalGroupingSetOutput();
+
   std::shared_ptr<const core::AggregationNode> aggregationNode_;
 
   const bool isPartialOutput_;
   const bool isGlobal_;
   const bool isDistinct_;
+  // True for raw-input steps (kSingle/kPartial).
+  const bool isRawInput_;
+  // True when the aggregation has a global grouping set: the empty () set that
+  // yields one grand-total row over all input.
+  const bool hasGlobalGroupingSets_;
   const bool memoryCompactionEnabled_;
   const int64_t maxExtendedPartialAggregationMemoryUsage_;
   // Minimum number of rows to see before deciding to give up on partial
@@ -155,6 +169,14 @@ class HashAggregation : public Operator {
 
   // Possibly reusable output vector.
   RowVectorPtr output_;
+
+  // Set in noMoreInput() to park a non-last driver for the peer election;
+  // consumed by the next isBlocked().
+  ContinueFuture future_{ContinueFuture::makeEmpty()};
+
+  // Set only on the single elected driver when the input is globally empty;
+  // that driver emits the default () grouping-set rows.
+  bool emitDefaultGlobalGroupingSetRows_{false};
 };
 
 } // namespace facebook::velox::exec

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -1637,6 +1637,95 @@ TEST_F(AggregationTest, groupingSetsEmptyInput) {
       }));
 }
 
+// Multi-driver empty input emits exactly one grand-total default row for the ()
+// set, not one per empty driver. The barrier fires on both the single-step and
+// the partial step.
+TEST_F(AggregationTest, globalGroupingSetDefaultRowMultiDriverEmpty) {
+  auto data = makeRowVector(
+      {"a"}, {makeFlatVector<int64_t>(std::vector<int64_t>{1, 2, 3, 4})});
+
+  // One default row: a null for the () set, group_id 1, count 0.
+  auto expected = makeRowVector({
+      makeNullableFlatVector<int64_t>({std::nullopt}),
+      makeFlatVector<int64_t>(std::vector<int64_t>{1}),
+      makeFlatVector<int64_t>(std::vector<int64_t>{0}),
+  });
+
+  // A local partition fans the empty GroupId output across drivers. When
+  // 'split' is true, a partial + final aggregation also exercises the partial
+  // step.
+  auto run = [&](bool split) {
+    core::PlanNodeId rawInputAggId;
+    PlanBuilder builder(std::make_shared<core::PlanNodeIdGenerator>());
+    builder.values({data})
+        .filter("a < 0")
+        .groupId({"a"}, {{"a"}, {}}, {})
+        .localPartition({"a", "group_id"});
+    if (split) {
+      builder.partialAggregation({"a", "group_id"}, {"count(1) as count_1"}, {})
+          .capturePlanNodeId(rawInputAggId)
+          .localPartition({})
+          .finalAggregation();
+    } else {
+      builder.singleAggregation({"a", "group_id"}, {"count(1) as count_1"})
+          .capturePlanNodeId(rawInputAggId);
+    }
+    auto task = AssertQueryBuilder(builder.planNode())
+                    .maxDrivers(4)
+                    .assertResults(expected);
+    // The raw-input aggregation must run on multiple drivers to exercise the
+    // peer barrier.
+    EXPECT_GT(toPlanStats(task->taskStats()).at(rawInputAggId).numDrivers, 1)
+        << (split ? "partial+final" : "single-step");
+  };
+  run(/*split=*/false);
+  run(/*split=*/true);
+}
+
+// Skewed non-empty input (all rows on one key) must not emit a spurious
+// count==0 default row from the starved drivers, for either the single-step or
+// the partial + final aggregation.
+TEST_F(AggregationTest, globalGroupingSetDefaultRowMultiDriverNonEmpty) {
+  auto data = makeRowVector(
+      {"a"}, {makeFlatVector<int64_t>(std::vector<int64_t>{1, 1, 1, 1})});
+
+  // Two rows: per-key (1, 0, 4) and grand total (null, 1, 4). No count==0 row.
+  auto expected = makeRowVector({
+      makeNullableFlatVector<int64_t>({1, std::nullopt}),
+      makeFlatVector<int64_t>(std::vector<int64_t>{0, 1}),
+      makeFlatVector<int64_t>(std::vector<int64_t>{4, 4}),
+  });
+
+  // A local partition fans the GroupId output across drivers. When 'split' is
+  // true, a partial + final aggregation also exercises the partial step.
+  auto run = [&](bool split) {
+    core::PlanNodeId rawInputAggId;
+    PlanBuilder builder(std::make_shared<core::PlanNodeIdGenerator>());
+    builder.values({data})
+        .filter("a >= 0")
+        .groupId({"a"}, {{"a"}, {}}, {})
+        .localPartition({"a", "group_id"});
+    if (split) {
+      builder.partialAggregation({"a", "group_id"}, {"count(1) as count_1"}, {})
+          .capturePlanNodeId(rawInputAggId)
+          .localPartition({})
+          .finalAggregation();
+    } else {
+      builder.singleAggregation({"a", "group_id"}, {"count(1) as count_1"})
+          .capturePlanNodeId(rawInputAggId);
+    }
+    auto task = AssertQueryBuilder(builder.planNode())
+                    .maxDrivers(4)
+                    .assertResults(expected);
+    // The raw-input aggregation must run on multiple drivers to exercise the
+    // peer barrier.
+    EXPECT_GT(toPlanStats(task->taskStats()).at(rawInputAggId).numDrivers, 1)
+        << (split ? "partial+final" : "single-step");
+  };
+  run(/*split=*/false);
+  run(/*split=*/true);
+}
+
 TEST_F(AggregationTest, disableNonBooleanMasks) {
   auto data = makeRowVector(
       {"c0", "c1"},

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -1111,6 +1111,22 @@ PlanBuilder::AggregatesAndNames PlanBuilder::createAggregateExpressionsAndNames(
   return {aggs, names};
 }
 
+namespace {
+// Returns the GroupIdNode at 'planNode', or under a single-source local
+// partition, or nullptr.
+const core::GroupIdNode* findGroupIdNode(const core::PlanNode* planNode) {
+  if (auto* groupId = dynamic_cast<const core::GroupIdNode*>(planNode)) {
+    return groupId;
+  }
+  if (auto* partition =
+          dynamic_cast<const core::LocalPartitionNode*>(planNode)) {
+    return dynamic_cast<const core::GroupIdNode*>(
+        partition->sources()[0].get());
+  }
+  return nullptr;
+}
+} // namespace
+
 PlanBuilder& PlanBuilder::aggregation(
     const std::vector<std::string>& groupingKeys,
     const std::vector<std::string>& preGroupedKeys,
@@ -1126,8 +1142,7 @@ PlanBuilder& PlanBuilder::aggregation(
   // need to be populated.
   std::vector<vector_size_t> globalGroupingSets;
   std::optional<core::FieldAccessTypedExprPtr> groupId;
-  if (auto groupIdNode =
-          dynamic_cast<const core::GroupIdNode*>(planNode_.get())) {
+  if (auto* groupIdNode = findGroupIdNode(planNode_.get())) {
     for (auto i = 0; i < groupIdNode->groupingSets().size(); i++) {
       if (groupIdNode->groupingSets().at(i).empty()) {
         globalGroupingSets.push_back(i);


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/axel/pull/115

A single-step aggregation with a global grouping set (the () set from ROLLUP/CUBE/GROUPING SETS) emitted one default grand-total row per empty driver instead of one overall. Behind a local exchange with N drivers, an empty query returned N identical default rows. A skewed query returned the real total plus a spurious count=0 row from each starved driver.

Root cause: GroupingSet decided whether to emit the default row from its own per-driver input count. That stops meaning "the whole input was empty" once a LocalPartition splits input across drivers.

Fix: only one driver emits the default rows, and only when input across all drivers is empty. HashAggregation reuses the allPeersFinished barrier, as HashBuild and HashProbe do. The last driver to finish sums every peer's input count and emits only if the total is zero; the rest emit nothing.

  SELECT count(*) FROM t GROUP BY ROLLUP(a)   -- single value of a, 4 drivers
  before: 1 grand-total row + 3 spurious count=0 rows
  after:  1 grand-total row

Single-driver behavior is unchanged.

Reviewed By: kagamiori

Differential Revision: D107777264
