### PR TITLE
feat: Support lazy reader creation in HiveIndexSource

### DIFF
--- a/velox/connectors/hive/HiveIndexSource.cpp
+++ b/velox/connectors/hive/HiveIndexSource.cpp
@@ -18,6 +18,7 @@
 #include <folly/ScopeGuard.h>
 #include <folly/container/F14Set.h>
 #include "velox/common/base/RuntimeMetrics.h"
+#include "velox/common/testutil/TestValue.h"
 #include "velox/common/time/CpuWallTimer.h"
 #include "velox/common/time/Timer.h"
 #include "velox/connectors/hive/FileDataSource.h"
@@ -1167,7 +1168,8 @@ void HiveIndexSource::addSplits(
 
   if (partitionIndexConditions_.empty()) {
     // Non-partitioned path: single group with all splits. Partition
-    // constants come from the first split only.
+    // constants come from the first split only. Readers are created
+    // lazily on first lookup.
     // TODO: Build per-split scan specs when splits span multiple partitions
     // and partition columns appear in the output.
     createSplitGroup(std::move(hiveSplits));
@@ -1237,9 +1239,9 @@ void HiveIndexSource::createSplitGroup(
     std::vector<std::shared_ptr<const HiveConnectorSplit>> hiveSplits) {
   VELOX_CHECK(!hiveSplits.empty());
   const auto& split = *hiveSplits.front();
-  auto scanSpec = buildScanSpec(&split.partitionKeys);
 
   auto& group = splitGroups_.emplace_back();
+  group.scanSpec = buildScanSpec(&split.partitionKeys);
 
   // Build typed routing constants from the splits' partition values. For the
   // non-partitioned path partitionIndexConditions_ is empty, leaving
@@ -1260,10 +1262,24 @@ void HiveIndexSource::createSplitGroup(
         cond.isPartitionDateValueDaysSinceEpoch));
   }
 
-  // Create readers for the splits.
+  // Store splits for lazy reader creation on first access.
+  group.splits = std::move(hiveSplits);
+}
+
+void HiveIndexSource::ensureReadersCreated(SplitGroup& group) {
+  if (group.splits.empty()) {
+    // Readers already created: splits and scan spec were consumed, and the
+    // group holds its readers.
+    VELOX_CHECK_NULL(group.scanSpec);
+    VELOX_CHECK(!group.readers.empty());
+    return;
+  }
+  VELOX_CHECK_NOT_NULL(group.scanSpec);
+  VELOX_CHECK(group.readers.empty());
+
   const auto readersStartIdx = readers_.size();
   auto* registry = IndexReaderFactoryRegistry::getInstance();
-  for (auto& hiveSplit : hiveSplits) {
+  for (auto& hiveSplit : group.splits) {
     const auto* factory = registry->getFactory(hiveSplit->fileFormat);
     if (factory != nullptr) {
       createCustomIndexReader(*factory, std::move(hiveSplit));
@@ -1274,15 +1290,23 @@ void HiveIndexSource::createSplitGroup(
               hiveSplit->fileFormat == dwio::common::FileFormat::SST,
           "No IndexReaderFactory registered for format: {}",
           dwio::common::toString(hiveSplit->fileFormat));
-      createFileIndexReader(std::move(hiveSplit), scanSpec);
+      createFileIndexReader(std::move(hiveSplit), group.scanSpec);
     }
   }
   VELOX_CHECK_GT(
       readers_.size(), readersStartIdx, "No index readers created from splits");
 
+  auto numReadersCreated = readers_.size() - readersStartIdx;
+  common::testutil::TestValue::adjust(
+      "facebook::velox::connector::hive::HiveIndexSource::ensureReadersCreated",
+      &numReadersCreated);
+
+  group.readers.reserve(numReadersCreated);
   for (size_t i = readersStartIdx; i < readers_.size(); ++i) {
     group.readers.emplace_back(readers_[i].get());
   }
+  group.scanSpec.reset();
+  group.splits.clear();
 }
 
 HiveIndexSource::SplitGroup* HiveIndexSource::findSplitGroup(
@@ -1310,7 +1334,7 @@ std::shared_ptr<IndexSource::ResultIterator> HiveIndexSource::lookup(
   VELOX_CHECK_GT(request.input->size(), 0, "Empty lookup request");
   VELOX_CHECK(splitsAdded_, "No splits added before lookup");
 
-  if (readers_.empty()) {
+  if (splitGroups_.empty()) {
     // All splits were filtered out (e.g., all had NULL partition routing
     // values).
     return EmptyIterator::instance();
@@ -1322,6 +1346,7 @@ std::shared_ptr<IndexSource::ResultIterator> HiveIndexSource::lookup(
   // Non-partitioned path: single group, all rows match.
   if (partitionIndexConditions_.empty()) {
     VELOX_CHECK_EQ(splitGroups_.size(), 1);
+    ensureReadersCreated(splitGroups_[0]);
     return createLookupIterator(request, splitGroups_[0].readers, options);
   }
 
@@ -1343,6 +1368,11 @@ std::shared_ptr<IndexSource::ResultIterator> HiveIndexSource::lookup(
   if (partitionRowMap.empty()) {
     // No split group matched any probe row.
     return EmptyIterator::instance();
+  }
+
+  // Create readers lazily for matched groups.
+  for (auto& [group, rows] : partitionRowMap) {
+    ensureReadersCreated(*group);
   }
 
   if (partitionRowMap.size() == 1) {

--- a/velox/connectors/hive/HiveIndexSource.h
+++ b/velox/connectors/hive/HiveIndexSource.h
@@ -207,9 +207,14 @@ class HiveIndexSource : public IndexSource,
 
   // A group of splits sharing a scan spec. For partitioned tables, one
   // group per distinct set of partition column values. For non-partitioned
-  // tables, a single group holds all splits.
+  // tables, a single group holds all splits. Readers are created lazily
+  // on first access to avoid opening files for groups that are never probed.
   struct SplitGroup {
-    // Raw pointers into readers_; ownership stays with readers_.
+    // Splits and scan spec stored at addSplits() time. Consumed by
+    // ensureReadersCreated() on first access.
+    std::vector<std::shared_ptr<const HiveConnectorSplit>> splits;
+    std::shared_ptr<common::ScanSpec> scanSpec;
+    // Raw pointers into readers_; populated by ensureReadersCreated().
     std::vector<SplitIndexReader*> readers;
     // Typed constants aligned with partitionIndexConditions_, used by
     // findSplitGroup() to match against probe row values. Empty for the
@@ -219,11 +224,16 @@ class HiveIndexSource : public IndexSource,
 
   // Builds a SplitGroup from a set of splits sharing the same partition and
   // appends it to splitGroups_: builds the scan spec and routing constants
-  // from the splits' partition values, and creates the readers (via registered
-  // IndexReaderFactory or FileIndexReader, owned by readers_). The routing
-  // constants are empty for the non-partitioned path.
+  // from the splits' partition values, and stores the splits for lazy reader
+  // creation. The routing constants are empty for the non-partitioned path.
   void createSplitGroup(
       std::vector<std::shared_ptr<const HiveConnectorSplit>> splits);
+
+  // Creates readers for a split group on first access (via registered
+  // IndexReaderFactory or FileIndexReader, owned by readers_) and populates
+  // the group's reader pointers. No-op if readers have already been created
+  // (splits vector empty).
+  void ensureReadersCreated(SplitGroup& group);
 
   // Finds the split group whose partition values match the given probe
   // row's partition column values. Returns nullptr if no group matches.
@@ -354,7 +364,8 @@ class HiveIndexSource : public IndexSource,
   // constants via the scan spec's setConstantValue().
   RowTypePtr readerOutputType_;
   // All index readers (both built-in and external). Owns every reader
-  // regardless of partitioned vs non-partitioned path. Created by addSplits().
+  // regardless of partitioned vs non-partitioned path. Populated lazily
+  // via ensureReadersCreated().
   std::vector<std::unique_ptr<SplitIndexReader>> readers_;
   // Split groups built during addSplits(). For non-partitioned tables,
   // contains a single group. For partitioned tables, one group per


### PR DESCRIPTION
Summary:
Defer reader creation from `addSplits()` to the first `lookup()` that routes to a given split group. Previously all readers were created eagerly at `addSplits()` time, paying the file-open and cluster-index-load cost for every split even if its partition was never probed.

Store splits and scan specs in `SplitGroup` during `addSplits()`, then create readers on demand via `ensureReadersCreated()` when a probe batch first routes to that group. `runtimeStats()` only collects stats from readers that were already created — never-probed partitions contribute no stats and incur no file I/O.

Reviewed By: xiaoxmeng

Differential Revision: D107915432


