### PR TITLE
perf(function): Allow `LIKE` substrings fast path when escape is inert

### DIFF
--- a/velox/benchmarks/basic/LikeBenchmark.cpp
+++ b/velox/benchmarks/basic/LikeBenchmark.cpp
@@ -129,11 +129,9 @@ int main(int argc, char** argv) {
           "substrings", vectorMaker.rowVector({"col0"}, {substringsInput}))
       .addExpression("substrings_no_escape", R"(like(col0, '%foo%bar%'))")
       .addExpression(
-          "substrings_inert_default_escape",
-          R"(like(col0, '%foo%bar%', '\'))")
+          "substrings_inert_default_escape", R"(like(col0, '%foo%bar%', '\'))")
       .addExpression(
-          "substrings_inert_custom_escape",
-          R"(like(col0, '%foo%bar%', '!'))");
+          "substrings_inert_custom_escape", R"(like(col0, '%foo%bar%', '!'))");
 
   benchmarkBuilder.registerBenchmarks();
   benchmarkBuilder.testBenchmarks();

--- a/velox/benchmarks/basic/LikeBenchmark.cpp
+++ b/velox/benchmarks/basic/LikeBenchmark.cpp
@@ -77,6 +77,9 @@ int main(int argc, char** argv) {
   auto prefixUnicodeInput = makeInput(vectorSize, false, true, "你_好_啊");
   auto suffixInput = makeInput(vectorSize, true, false);
   auto suffixUnicodeInput = makeInput(vectorSize, true, false, "你_好_啊");
+  // Strings shaped like 'xxxfooxxxbarxxx' so that '%foo%bar%' matches.
+  auto substringsInput =
+      makeInput(vectorSize, true, true, "foo***bar", "xxxxx");
 
   benchmarkBuilder
       .addBenchmarkSet(
@@ -116,6 +119,21 @@ int main(int argc, char** argv) {
       .addBenchmarkSet(
           "generic", vectorMaker.rowVector({"col0"}, {substringInput}))
       .addExpression("generic", R"(like(col0, '%a%b%c'))");
+
+  // Multi-substring patterns (kSubstrings). All three expressions are
+  // semantically equivalent because the supplied escape character does not
+  // appear in the pattern; the comparison shows that supplying an unused
+  // escape no longer disables the SIMD-backed string::find fast path.
+  benchmarkBuilder
+      .addBenchmarkSet(
+          "substrings", vectorMaker.rowVector({"col0"}, {substringsInput}))
+      .addExpression("substrings_no_escape", R"(like(col0, '%foo%bar%'))")
+      .addExpression(
+          "substrings_inert_default_escape",
+          R"(like(col0, '%foo%bar%', '\'))")
+      .addExpression(
+          "substrings_inert_custom_escape",
+          R"(like(col0, '%foo%bar%', '!'))");
 
   benchmarkBuilder.registerBenchmarks();
   benchmarkBuilder.testBenchmarks();

--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -2286,10 +2286,14 @@ std::shared_ptr<exec::VectorFunction> makeLike(
 
   PatternMetadata patternMetadata = PatternMetadata::generic();
   try {
-    // Fast path for substrings search.
-    if (!escapeChar.has_value()) {
-      auto substrings =
-          PatternMetadata::parseSubstrings(std::string_view(pattern));
+    // Fast path for substrings search. The escape character can be ignored if
+    // it does not appear in the pattern, so callers that always emit a default
+    // escape (e.g. Spark/Gluten emits '\') still hit this path.
+    const auto patternView = std::string_view(pattern);
+    const bool escapeIsInert = !escapeChar.has_value() ||
+        patternView.find(escapeChar.value()) == std::string_view::npos;
+    if (escapeIsInert) {
+      auto substrings = PatternMetadata::parseSubstrings(patternView);
       if (substrings.size() > 0) {
         patternMetadata = PatternMetadata::substrings(std::move(substrings));
         return std::make_shared<OptimizedLike<PatternKind::kSubstrings>>(
@@ -2297,8 +2301,7 @@ std::shared_ptr<exec::VectorFunction> makeLike(
       }
     }
 
-    patternMetadata =
-        determinePatternKind(std::string_view(pattern), escapeChar);
+    patternMetadata = determinePatternKind(patternView, escapeChar);
   } catch (...) {
     return std::make_shared<exec::AlwaysFailingVectorFunction>(
         std::current_exception());

--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -2286,9 +2286,10 @@ std::shared_ptr<exec::VectorFunction> makeLike(
 
   PatternMetadata patternMetadata = PatternMetadata::generic();
   try {
-    // Fast path for substrings search. The escape character can be ignored if
-    // it does not appear in the pattern, so callers that always emit a default
-    // escape (e.g. Spark/Gluten emits '\') still hit this path.
+    // Fast path for substrings search. The escape character can be ignored
+    // when it does not appear in the pattern, so callers that always supply
+    // an escape argument still hit this path as long as the escape character
+    // is not actually used in the pattern.
     const auto patternView = std::string_view(pattern);
     const bool escapeIsInert = !escapeChar.has_value() ||
         patternView.find(escapeChar.value()) == std::string_view::npos;

--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -1077,6 +1077,19 @@ TEST_F(Re2FunctionsTest, likeSubstringPattern) {
       true);
 }
 
+// Verifies the substrings fast path is taken when an escape character is
+// supplied but does not appear in the pattern. Spark always emits a default
+// escape '\' on its Like expression, so without this case patterns like
+// '%foo%bar%' incorrectly fall back to the RE2 engine.
+TEST_F(Re2FunctionsTest, likeSubstringPatternWithInertEscape) {
+  testLike("hello special requests today", "%special%requests%", '\\', true);
+  testLike("requests special hello", "%special%requests%", '\\', false);
+  testLike("aXbYcZ", "%a%b%c%", '\\', true);
+  testLike("aXbY", "%a%b%c%", '\\', false);
+  // Custom escape character that does not appear in the pattern.
+  testLike("aXbYcZ", "%a%b%c%", '!', true);
+}
+
 TEST_F(Re2FunctionsTest, nullConstantPatternOrEscape) {
   // Test null pattern.
   ASSERT_TRUE(

--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -1078,9 +1078,10 @@ TEST_F(Re2FunctionsTest, likeSubstringPattern) {
 }
 
 // Verifies the substrings fast path is taken when an escape character is
-// supplied but does not appear in the pattern. Spark always emits a default
-// escape '\' on its Like expression, so without this case patterns like
-// '%foo%bar%' incorrectly fall back to the RE2 engine.
+// supplied but does not appear in the pattern. Without this case, callers
+// that always pass an escape argument (e.g. SQL `LIKE ... ESCAPE 'x'` where
+// 'x' is not used in the pattern) would unnecessarily fall back to the RE2
+// engine on patterns like '%foo%bar%'.
 TEST_F(Re2FunctionsTest, likeSubstringPatternWithInertEscape) {
   testLike("hello special requests today", "%special%requests%", '\\', true);
   testLike("requests special hello", "%special%requests%", '\\', false);


### PR DESCRIPTION
### Summary:

`LIKE` patterns of the form `'%a%b%c%'` currently fall back to `RE2` whenever an
escape character is supplied, even if that character does not appear in the
pattern. This is the default Spark/Gluten code path because Spark's `Like`
expression always carries a default escape `\`.

The escape character only changes pattern semantics when it actually appears
in the pattern, so the existing `kSubstrings` fast path can be entered when
the escape is supplied but absent from the pattern. The check is a single
linear scan over the constant pattern, performed at expression compile time —
no runtime overhead.

### Performance

Profiling Gluten TPC-H Q13 at 6 TB scale (whose hot filter is
`l_comment NOT LIKE '%special%requests%'`) showed
`re2::DFA::InlinedSearchLoop` accounting for **>8% of total CPU cycles** on
the Velox side. Routing the same query shape through Gluten's 2-arg
workaround in apache/gluten#12152 reduced Q13 end-to-end latency by **>6%**.

#### Micro Benchmark 
Added a `substrings` benchmark set in `velox/benchmarks/basic/LikeBenchmark.cpp`. 
   | Case                                          | Speedup |
   |-----------------------------------------------|--------:|
   | `substrings_no_escape` (baseline)             | 1.00x   |
   | `substrings_inert_default_escape` (3-arg `\`) | ~69x    |
   | `substrings_inert_custom_escape` (3-arg `!`)  | ~69x    |


### Test plan

- New `Re2FunctionsTest.likeSubstringPatternWithInertEscape` covers
  `'%a%b%c%'` patterns with a default `\` escape and with a custom escape
  that does not appear in the pattern.
- All existing `Re2FunctionsTest.*` cases continue to pass — pattern
  semantics are unchanged when the escape character is actually present.

Fixes the Velox-side gap behind apache/gluten#12152.
