### PR TITLE
feat(iceberg): Apply initial-default value for filter-only columns

### DIFF
--- a/velox/connectors/hive/FileConnectorUtil.cpp
+++ b/velox/connectors/hive/FileConnectorUtil.cpp
@@ -20,6 +20,7 @@
 #include "velox/connectors/hive/FileConfig.h"
 #include "velox/connectors/hive/FileConnectorSplit.h"
 #include "velox/connectors/hive/FileTableHandle.h"
+#include "velox/vector/DecodedVector.h"
 
 namespace facebook::velox::connector::hive {
 
@@ -228,6 +229,27 @@ bool applyPartitionFilter(
   }
 }
 
+// BytesValues does not override testNonNull(); dispatch by type directly.
+template <TypeKind KIND>
+bool applyFilterForKind(
+    const DecodedVector& decoded,
+    const common::Filter& filter) {
+  return common::applyFilter(
+      filter, decoded.valueAt<typename TypeTraits<KIND>::NativeType>(0));
+}
+
+bool testFilterOnConstant(
+    const VectorPtr& constant,
+    const common::Filter& filter) {
+  VELOX_DCHECK_NOT_NULL(constant);
+  if (constant->isNullAt(0)) {
+    return filter.testNull();
+  }
+  DecodedVector decoded(*constant);
+  return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+      applyFilterForKind, constant->typeKind(), decoded, filter);
+}
+
 } // namespace
 
 bool testFilters(
@@ -261,6 +283,18 @@ bool testFilters(
               handlesIter->second->isPartitionDateValueDaysSinceEpoch(),
               child->filter(),
               asLocalTime);
+        }
+        // Column has a default constant; test the filter against it rather than
+        // assuming null.
+        if (child->isConstant()) {
+          if (child->filter()->isDeterministic() &&
+              !testFilterOnConstant(child->constantValue(), *child->filter())) {
+            VLOG(1) << "Skipping " << filePath
+                    << " because constant value failed filter for column "
+                    << child->fieldName();
+            return false;
+          }
+          continue;
         }
         // Column is missing, most likely due to schema evolution. Or it's a
         // partition key but the partition value is NULL.

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -896,42 +896,61 @@ std::vector<TypePtr> IcebergSplitReader::adaptColumns(
                    partitionIt != fileSplit_->partitionKeys.end()) {
           setPartitionValue(childSpec.get(), fieldName, partitionIt->second);
         } else {
-          // Check if column has an initial-default value (Iceberg V3)
-          bool hasDefaultValue = false;
+          // Check if column has an initial-default value (Iceberg V3).
+          //
+          // For queries that do not project this column (e.g. COUNT(*) with
+          // WHERE default_col = X), the column won't appear in columnHandles_
+          // (which only covers projected output columns). In that case, fall
+          // back to tableHandle_->filterColumnHandles(), which holds predicate
+          // columns including their IcebergColumnHandle default values.
+          //
           // The columnHandles_ map is keyed by output name (which may be an
           // alias). We need to find the column handle where the handle's name()
           // matches fieldName. fieldName is the table column name from
           // readerOutputType_.
+
+          auto tryApplyDefault = [&](const auto& columnHandle) -> bool {
+            auto icebergHandle =
+                std::dynamic_pointer_cast<const IcebergColumnHandle>(
+                    columnHandle);
+            if (!icebergHandle ||
+                !icebergHandle->initialDefaultValue().has_value()) {
+              return false;
+            }
+            auto columnType = tableSchema->findChild(fieldName);
+            VELOX_CHECK_NOT_NULL(
+                columnType, "Column not found in table schema: {}", fieldName);
+            childSpec->setConstantValue(newConstantFromString(
+                columnType,
+                icebergHandle->initialDefaultValue().value(),
+                connectorQueryCtx_->memoryPool(),
+                readTimestampAsLocalTime,
+                false));
+            return true;
+          };
+
+          bool hasDefaultValue = false;
           for (const auto& [outputName, handle] : *columnHandles_) {
-            if (handle->name() == fieldName) {
-              auto icebergColumnHandle =
-                  std::dynamic_pointer_cast<const IcebergColumnHandle>(handle);
-              if (icebergColumnHandle &&
-                  icebergColumnHandle->initialDefaultValue().has_value()) {
-                // Use initial-default value for schema evolution.
-                auto columnType = tableSchema->findChild(fieldName);
-                VELOX_CHECK_NOT_NULL(
-                    columnType,
-                    "Column '{}' not found in table schema",
-                    fieldName);
-                auto constant = newConstantFromString(
-                    columnType,
-                    icebergColumnHandle->initialDefaultValue().value(),
-                    connectorQueryCtx_->memoryPool(),
-                    readTimestampAsLocalTime,
-                    false);
-                childSpec->setConstantValue(constant);
+            if (handle->name() == fieldName && tryApplyDefault(handle)) {
+              hasDefaultValue = true;
+              break;
+            }
+          }
+          if (!hasDefaultValue) {
+            for (const auto& filterHandle :
+                 tableHandle_->filterColumnHandles()) {
+              if (filterHandle->name() == fieldName &&
+                  tryApplyDefault(filterHandle)) {
                 hasDefaultValue = true;
                 break;
               }
             }
           }
 
-          // Fall back to NULL if no default value
           if (!hasDefaultValue) {
             auto columnType = tableSchema->findChild(fieldName);
             VELOX_CHECK_NOT_NULL(
-                columnType, "Column '{}' not found in table schema", fieldName);
+                columnType, "Column not found in table schema: {}", fieldName);
             childSpec->setConstantValue(
                 BaseVector::createNullConstant(
                     columnType, 1, connectorQueryCtx_->memoryPool()));

--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -1402,6 +1402,86 @@ TEST_F(HiveIcebergTest, defaultValueWithDeletesAndFilters) {
   }
 }
 
+// Test that default column values are applied correctly when the column is used
+// only as a filter (not projected in the output). This is the "count query"
+// scenario: COUNT(*) WHERE default_col = X should find all rows in old files
+// because the default value satisfies the filter, rather than treating the
+// missing column as NULL and returning zero rows.
+TEST_F(HiveIcebergTest, defaultValueFilterOnlyColumn) {
+  // Old data file has only c0 — 'country' was added later with default 'IN'.
+  std::vector<RowVectorPtr> dataVectors;
+  dataVectors.push_back(makeRowVector({makeFlatVector<int64_t>({1, 2, 3})}));
+  auto dataFilePath = TempFilePath::create();
+  writeToFile(dataFilePath->getPath(), dataVectors);
+
+  auto tableSchema = ROW({"c0", "country"}, {BIGINT(), VARCHAR()});
+  auto outputType = ROW({"c0"}, {BIGINT()});
+
+  ColumnHandleMap assignments;
+  assignments["c0"] = makeC0Handle();
+
+  // Declared as HiveColumnHandlePtr so it fits filterColumnHandles() directly;
+  // the underlying object is an IcebergColumnHandle for the dynamic_cast in
+  // IcebergSplitReader::adaptColumns to succeed.
+  HiveColumnHandlePtr countryHandle =
+      makeIcebergHandle("country", VARCHAR(), 2, "IN");
+
+  std::vector<RowVectorPtr> allRows;
+  allRows.push_back(
+      makeRowVector(outputType->names(), {makeFlatVector<int64_t>({1, 2, 3})}));
+
+  // country IS NOT NULL: default 'IN' is non-null → all 3 rows pass.
+  {
+    auto plan = PlanBuilder()
+                    .startTableScan()
+                    .connectorId(kIcebergConnectorId)
+                    .outputType(outputType)
+                    .dataColumns(tableSchema)
+                    .assignments(assignments)
+                    .filterColumnHandles({countryHandle})
+                    .remainingFilter("country IS NOT NULL")
+                    .endTableScan()
+                    .planNode();
+    AssertQueryBuilder(plan)
+        .splits(makeIcebergSplits(dataFilePath->getPath()))
+        .assertResults(allRows);
+  }
+
+  // country = 'IN': default matches → all 3 rows pass.
+  {
+    auto plan = PlanBuilder()
+                    .startTableScan()
+                    .connectorId(kIcebergConnectorId)
+                    .outputType(outputType)
+                    .dataColumns(tableSchema)
+                    .assignments(assignments)
+                    .filterColumnHandles({countryHandle})
+                    .remainingFilter("country = 'IN'")
+                    .endTableScan()
+                    .planNode();
+    AssertQueryBuilder(plan)
+        .splits(makeIcebergSplits(dataFilePath->getPath()))
+        .assertResults(allRows);
+  }
+
+  // country = 'US': default 'IN' does not match → no rows pass.
+  {
+    auto plan = PlanBuilder()
+                    .startTableScan()
+                    .connectorId(kIcebergConnectorId)
+                    .outputType(outputType)
+                    .dataColumns(tableSchema)
+                    .assignments(assignments)
+                    .filterColumnHandles({countryHandle})
+                    .remainingFilter("country = 'US'")
+                    .endTableScan()
+                    .planNode();
+    AssertQueryBuilder(plan)
+        .splits(makeIcebergSplits(dataFilePath->getPath()))
+        .assertEmptyResults();
+  }
+}
+
 // Test reading partition columns from Hive-migrated tables.
 // This tests the adaptColumns method handling partition columns that are not
 // stored in the data file but provided via partitionKeys map.


### PR DESCRIPTION
Old Iceberg data files written before a column was added do not contain that column. When reading such files, Velox fills in the column's `initialDefaultValue` from the `IcebergColumnHandle`. This works correctly when the column appears in the output projection, because those handles are in `columnHandles_`.

For filter-only columns (columns used in `WHERE` but not `SELECT`), `columnHandles_` does not contain an entry — it only covers projected output. As a result, the default lookup falls through to the NULL fallback, and a query like:

    SELECT count(*) FROM t WHERE country = 'IN'

returns 0 rows from old files even though the column's default value satisfies the predicate.

When the column is absent from `columnHandles_`, fall back to `tableHandle_->filterColumnHandles()`, which carries the `IcebergColumnHandle` metadata for all predicate columns including their initial-default values.

`IcebergReadTest.defaultValueFilterOnlyColumn` covers three cases: `IS NOT NULL`, `= <default>`, and `= <non-default>`.