### PR TITLE
perf: Use move instead of object copy (#17792)

### DIFF
--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -314,7 +314,7 @@ OperatorStats Operator::stats(bool clear) {
     stats = *stats_.rlock();
   } else {
     auto lockedStats = stats_.wlock();
-    stats = *lockedStats;
+    stats = std::move(*lockedStats);
     lockedStats->clear();
   }
 


### PR DESCRIPTION
Summary:

We noticed this function showing up in profiles. This is an AI generated (but human reviewed) performance optimization:

Optimized `facebook::velox::exec::OperatorStats::operator=` by replacing a copy assignment with a move assignment in `Operator::stats(bool clear)` (fbcode/velox/exec/Operator.cpp, line 295). When `clear` is true, the code previously copied `*lockedStats` into the local `stats` variable and then called `lockedStats->clear()`. Since the source is cleared immediately after, the copy is unnecessary — a `std::move` achieves the same result without copying the expensive members (`std::unordered_map`, `std::string`, `std::optional<std::function>`, `std::unordered_set`). This eliminates one full copy of `OperatorStats` per call to `Operator::stats(true)`.

Differential Revision: D106165021


