### PR TITLE
perf: Use small_vector to reduce vector reallocations

### DIFF
--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 #include "velox/functions/lib/Re2Functions.h"
+
+#include <folly/container/span.h>
+#include <folly/small_vector.h>
+
 #include "velox/functions/lib/string/StringImpl.h"
 #include "velox/vector/FunctionVector.h"
 
@@ -466,12 +470,15 @@ struct SubPatternStats {
   }
 };
 
+using SubPatternKindVec = folly::small_vector<SubPatternKind, 8>;
+using SubPatternRangeVec = folly::small_vector<std::pair<size_t, size_t>, 8>;
+
 // Construct SubPatternMetadata from subPatternKinds, subPatternRanges.
 // Caller need to make sure the specified range only contains
 // fixed(kLiteralString, kSingleWildcard) patterns.
 size_t buildFixedSubPatterns(
-    const std::vector<SubPatternKind>& subPatternKinds,
-    const std::vector<std::pair<size_t, size_t>>& subPatternRanges,
+    folly::span<const SubPatternKind> subPatternKinds,
+    folly::span<const std::pair<size_t, size_t>> subPatternRanges,
     size_t start,
     size_t end,
     std::vector<SubPatternMetadata>& subPatterns) {
@@ -495,8 +502,8 @@ size_t buildFixedSubPatterns(
 // the pattern, it is mainly used to get the length of the fixed part in a
 // pattern, so we can extract the fixed part out.
 size_t fixedLength(
-    const std::vector<SubPatternKind>& subPatternKinds,
-    const std::vector<std::pair<size_t, size_t>>& subPatternRanges) {
+    folly::span<const SubPatternKind> subPatternKinds,
+    folly::span<const std::pair<size_t, size_t>> subPatternRanges) {
   size_t result = 0;
   for (auto i = 0; i < subPatternKinds.size(); i++) {
     if (subPatternKinds[i] != SubPatternKind::kAnyCharsWildcard) {
@@ -2041,8 +2048,8 @@ bool isOptimizedLikeCandidate(
 std::optional<std::string> parsePattern(
     std::string_view pattern,
     std::optional<char> escapeChar,
-    std::vector<SubPatternKind>& subPatternKinds,
-    std::vector<std::pair<size_t, size_t>>& subPatternRanges) {
+    SubPatternKindVec& subPatternKinds,
+    SubPatternRangeVec& subPatternRanges) {
   PatternStringIterator iterator{pattern, escapeChar};
 
   // Iterate through the pattern string to collect the stats for the simple
@@ -2104,8 +2111,8 @@ PatternMetadata determinePatternKind(
   }
 
   // Parse the pattern into sub-patterns.
-  std::vector<SubPatternKind> subPatternKinds;
-  std::vector<std::pair<size_t, size_t>> subPatternRanges;
+  SubPatternKindVec subPatternKinds;
+  SubPatternRangeVec subPatternRanges;
 
   std::optional<std::string> parsedPattern =
       parsePattern(pattern, escapeChar, subPatternKinds, subPatternRanges);


### PR DESCRIPTION
Summary:
The relevant code showed up in internal profiles. This is an AI-generated optimization (but already reviewed by humans):

Optimized `facebook::velox::functions::parsePattern` by replacing `std::vector<SubPatternKind>` and `std::vector<std::pair<size_t, size_t>>` with `folly::small_vector<SubPatternKind, 8>` and `folly::small_vector<std::pair<size_t, size_t>, 8>` respectively. This avoids heap allocation and reallocation for the common case where LIKE patterns produce ≤ 8 sub-patterns (which covers virtually all real-world SQL LIKE patterns). The inline capacity of 8 elements means `push_back` calls in `parsePattern` write directly to stack-allocated storage without any dynamic memory operations. For rare patterns with more than 8 sub-patterns, `folly::small_vector` falls back to heap allocation transparently, preserving correctness. Changes were made to: the vector type declarations in `determinePatternKind`, the `parsePattern` function signature, and the `buildFixedSubPatterns`/`fixedLength` parameter types (all file-local in an anonymous namespace).

Differential Revision: D107667817


