### PR TITLE
fix(cmake): Fix gersemi formatting in common/io CMakeLists

### DIFF
--- a/velox/common/io/CMakeLists.txt
+++ b/velox/common/io/CMakeLists.txt
@@ -12,12 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-velox_add_library(
-  velox_common_io
-  IoStatistics.cpp
-  HEADERS
-  IoStatistics.h
-  Options.h
-)
+velox_add_library(velox_common_io IoStatistics.cpp HEADERS IoStatistics.h Options.h)
 
 velox_link_libraries(velox_common_io velox_common_base Folly::folly glog::glog)


### PR DESCRIPTION
## Summary

Commit e5d15ee37 (#17788) removed `AsyncIoContext` from the `velox_common_io` target, leaving a `velox_add_library` call that gersemi now wants collapsed to a single line. Since the pre-commit workflow runs with `--all-files` against the PR merge ref, this dirty file currently fails the `pre-commit` check on **every open PR** (example: #17745).

This applies gersemi's suggested formatting verbatim.

## Test plan
- [ ] CI pre-commit check goes green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)