### PR TITLE
build: Fix missing fbthrift generated headers when Velox is imported as CMake submodule

### DIFF
--- a/CMake/third-party/FBThriftCppLibrary.cmake
+++ b/CMake/third-party/FBThriftCppLibrary.cmake
@@ -44,7 +44,7 @@ function(add_fbthrift_cpp_library LIB_NAME THRIFT_FILE)
   # Generate relative paths in #includes
   file(
     RELATIVE_PATH include_prefix
-    "${CMAKE_SOURCE_DIR}"
+    "${PROJECT_SOURCE_DIR}"
     "${CMAKE_CURRENT_SOURCE_DIR}/${THRIFT_FILE}"
   )
   get_filename_component(include_prefix ${include_prefix} DIRECTORY)
@@ -123,7 +123,7 @@ function(add_fbthrift_cpp_library LIB_NAME THRIFT_FILE)
       -o "${output_dir}"
       "${CMAKE_CURRENT_SOURCE_DIR}/${THRIFT_FILE}"
     WORKING_DIRECTORY
-      "${CMAKE_BINARY_DIR}"
+      "${PROJECT_BINARY_DIR}"
     MAIN_DEPENDENCY
       "${THRIFT_FILE}"
     DEPENDS
@@ -136,7 +136,7 @@ function(add_fbthrift_cpp_library LIB_NAME THRIFT_FILE)
   target_include_directories(
     "${LIB_NAME}"
     PUBLIC
-      "$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>"
+      "$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>"
       "$<INSTALL_INTERFACE:${ARG_INCLUDE_DIR}>"
       ${Xxhash_INCLUDE_DIR}
   )
@@ -173,7 +173,7 @@ function(add_fbthrift_cpp_library LIB_NAME THRIFT_FILE)
   target_include_directories(
     "${LIB_NAME}.thrift_includes"
     INTERFACE
-      "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>"
+      "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>"
       "$<INSTALL_INTERFACE:${ARG_THRIFT_INCLUDE_DIR}>"
   )
   foreach(dep IN LISTS ARG_DEPENDS)


### PR DESCRIPTION
The patch fixes the following build error, in the case that Velox is imported in other project via `FetchContent(velox, ...)`.

```
[488/1435] Building CXX object _deps/velox-build/velox/dwio/parquet/thrift/CMakeFiles/velox_dwio_parquet_thrift_raw.dir/gen-cpp2/parquet_types_serialization.cpp.o
FAILED: [code=1] _deps/velox-build/velox/dwio/parquet/thrift/CMakeFiles/velox_dwio_parquet_thrift_raw.dir/gen-cpp2/parquet_types_serialization.cpp.o
/usr/bin/ccache /usr/bin/c++ -DBOOST_ATOMIC_DYN_LINK -DBOOST_ATOMIC_NO_LIB -DBOOST_CONTEXT_DYN_LINK -DBOOST_CONTEXT_NO_LIB -DBOOST_FILESYSTEM_DYN_LINK -DBOOST_FILESYSTEM_NO_LIB -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_REGEX_DYN_LINK -DBOOST_REGEX_NO_LIB -DBOOST_THREAD_DYN_LINK -DBOOST_THREAD_NO_LIB -DFOLLY_HAS_COROUTINES=1 -DGFLAGS_IS_A_DLL=0 -DVELOX_ENABLE_PARQUET -I/root/Public/code/velox4j/src/main/cpp/cmake-build-debug/_deps/velox-src/. -I/root/Public/code/velox4j/src/main/cpp/cmake-build-debug/_deps/velox-src/velox/external/xxhash -I/root/Public/code/velox4j/src/main/cpp/cmake-build-debug -isystem /root/Public/code/velox4j/src/main/cpp/cmake-build-debug/_deps/velox-src/velox -isystem /root/Public/code/velox4j/src/main/cpp/cmake-build-debug/_deps/velox-src/velox/external -isystem /root/Public/code/velox4j/src/main/cpp/cmake-build-debug/_deps/folly-src -isystem /root/Public/code/velox4j/src/main/cpp/cmake-build-debug/_deps/folly-build -isystem /usr/include/libdwarf -mavx2 -mfma -mavx -mf16c -mlzcnt -mbmi2 -DUSE_VELOX_COMMON_BASE -DHAS_UNCAUGHT_EXCEPTIONS -Wall -Wextra -Wno-unused        -Wno-unused-parameter        -Wno-sign-compare        -Wno-ignored-qualifiers        -Wno-implicit-fallthrough          -Wno-class-memaccess          -Wno-comment          -Wno-int-in-bool-context          -Wno-redundant-move          -Wno-array-bounds          -Wno-maybe-uninitialized          -Wno-unused-result          -Wno-format-overflow          -Wno-strict-aliasing -g -std=gnu++20 -fPIC -fdiagnostics-color=always -fcoroutines -fsized-deallocation -MD -MT _deps/velox-build/velox/dwio/parquet/thrift/CMakeFiles/velox_dwio_parquet_thrift_raw.dir/gen-cpp2/parquet_types_serialization.cpp.o -MF _deps/velox-build/velox/dwio/parquet/thrift/CMakeFiles/velox_dwio_parquet_thrift_raw.dir/gen-cpp2/parquet_types_serialization.cpp.o.d -o _deps/velox-build/velox/dwio/parquet/thrift/CMakeFiles/velox_dwio_parquet_thrift_raw.dir/gen-cpp2/parquet_types_serialization.cpp.o -c /root/Public/code/velox4j/src/main/cpp/cmake-build-debug/_deps/velox-build/velox/dwio/parquet/thrift/gen-cpp2/parquet_types_serialization.cpp
/root/Public/code/velox4j/src/main/cpp/cmake-build-debug/_deps/velox-build/velox/dwio/parquet/thrift/gen-cpp2/parquet_types_serialization.cpp:7:10: fatal error: cmake-build-debug/_deps/velox-src/velox/dwio/parquet/thrift/gen-cpp2/parquet_types_custom_protocol.h: No such file or directory
    7 | #include "cmake-build-debug/_deps/velox-src/velox/dwio/parquet/thrift/gen-cpp2/parquet_types_custom_protocol.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

The fix follows a standard way to change `CMAKE_SOURCE_DIR` / `CMAKE_BINARY_DIR` to `PROJECT_SOURCE_DIR` / `PROJECT_BINARY_DIR`, to ensure the CMake portability of `FBThriftCppLibrary.cmake`.

Verified locally.

Fixes https://github.com/facebookincubator/velox/issues/17853.