### PR TITLE
fix: Change git apply to patch in arrow setup script if available

### DIFF
--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -236,7 +236,12 @@ function install_arrow {
 
     cd "$DEPENDENCY_DIR"/arrow || exit 1
     for patch in $VELOX_ARROW_CMAKE_PATCH; do
-      git apply "$patch" || exit 1
+      # Try patch command first (handles line number offsets), fall back to git apply
+      if command -v patch >/dev/null 2>&1; then
+        patch -p1 -i "$patch" || exit 1
+      else
+        git apply "$patch" || exit 1 
+      fi
     done
     # Presto needs this for Arrow Flight
     if [[ -n $EXTRA_ARROW_PATCH ]]; then


### PR DESCRIPTION
Without this change the diff would not be applied and resulted in an error like

```
CMake Error at cmake_modules/BuildUtils.cmake:297 (target_link_libraries):
  Target "arrow_testing_objlib" links to:

    Boost::process

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.

Call Stack (most recent call first):
  src/arrow/CMakeLists.txt:1124 (add_arrow_lib)


CMake Error at cmake_modules/BuildUtils.cmake:381 (target_link_libraries):
  Target "arrow_testing_shared" links to:

    Boost::process

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.

Call Stack (most recent call first):
  src/arrow/CMakeLists.txt:1124 (add_arrow_lib)


CMake Error at cmake_modules/BuildUtils.cmake:475 (target_link_libraries):
  Target "arrow_testing_static" links to:

    Boost::process

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.

Call Stack (most recent call first):
  src/arrow/CMakeLists.txt:1124 (add_arrow_lib)


-- Generating done (0.1s)
CMake Warning:
  Manually-specified variables were not used by the project:

    BOOST_ROOT
    BUILD_TESTING
    CMAKE_POLICY_VERSION_MINIMUM
```    

First run failures in
`Ubuntu Bundled Dependencies / Ubuntu debug with bundled dependencies` match runs from other PR's. 
Ex.
https://github.com/facebookincubator/velox/actions/runs/27309236739/job/80674991418