### PR TITLE
feat(spark): Add support for timestampadd(timestamp_utc)

### DIFF
--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -366,6 +366,20 @@ These functions support TIMESTAMP and DATE input types.
         SELECT timestampadd(SECOND, 10, '2019-03-01 10:00:00.500'); -- 2019-03-01 10:00:10.500
         SELECT timestampadd(MICROSECOND, 500, '2019-02-28 10:01:00.500999'); -- 2019-02-28 10:01:00.501499
 
+.. spark:function:: timestampadd(unit, value, timestamp_utc) -> timestamp_utc
+
+    Same semantics as ``timestampadd(unit, value, timestamp)``, not subject to the session timezone.
+
+    Under session timezone UTC: ::
+
+        SELECT timestampadd(SECOND, 10, TIMESTAMP_NTZ '2019-03-01 10:00:00.500'); -- 2019-03-01 10:00:10.500
+        SELECT timestampadd(DAY, 1, TIMESTAMP_NTZ '2020-02-29 10:00:00.500'); -- 2020-03-01 10:00:00.500
+
+    Under session timezone ``America/Los_Angeles`` (UTC-8): ::
+
+        SELECT timestampadd(SECOND, 10, TIMESTAMP_NTZ '2019-03-01 10:00:00.500'); -- 2019-03-01 10:00:10.500
+        SELECT timestampadd(DAY, 1, TIMESTAMP_NTZ '2020-02-29 10:00:00.500'); -- 2020-03-01 10:00:00.500
+
 .. spark:function:: timestampdiff(unit, timestamp1, timestamp2) -> bigint
 
     Returns ``timestamp2`` - ``timestamp1`` expressed in terms of ``unit``, the fraction

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -1123,7 +1123,7 @@ struct TimestampDiffFunction {
   std::optional<DateTimeUnit> unit_ = std::nullopt;
 };
 
-template <typename T>
+template <typename T, typename TTimestamp>
 struct TimestampAddFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
@@ -1133,7 +1133,7 @@ struct TimestampAddFunction {
       const core::QueryConfig& config,
       const arg_type<Varchar>* unitString,
       const TInput* /*value*/,
-      const arg_type<Timestamp>* /*timestamp*/) {
+      const arg_type<TTimestamp>* /*timestamp*/) {
     VELOX_USER_CHECK_NOT_NULL(unitString);
     std::string unitStr(*unitString);
     folly::toLowerAscii(unitStr);
@@ -1143,15 +1143,21 @@ struct TimestampAddFunction {
       unit_ = fromDateTimeUnitString(
           *unitString, /*throwIfInvalid=*/true, /*allowMicro=*/true);
     }
-    sessionTimeZone_ = getTimeZoneFromConfig(config);
+    if constexpr (std::is_same_v<TTimestamp, TimestampUtc>) {
+      // TIMESTAMP UTC represents a timestamp in UTC, not subject to session
+      // timezone adjustment.
+      sessionTimeZone_ = nullptr;
+    } else {
+      sessionTimeZone_ = getTimeZoneFromConfig(config);
+    }
   }
 
   template <typename TInput>
   FOLLY_ALWAYS_INLINE void call(
-      out_type<Timestamp>& result,
+      out_type<TTimestamp>& result,
       const arg_type<Varchar>& /*unitString*/,
       const TInput value,
-      const arg_type<Timestamp>& timestamp) {
+      const arg_type<TTimestamp>& timestamp) {
     const auto unit = unit_.value();
     result = addToTimestamp(unit, value, timestamp, sessionTimeZone_);
   }

--- a/velox/functions/sparksql/registration/RegisterDatetime.cpp
+++ b/velox/functions/sparksql/registration/RegisterDatetime.cpp
@@ -128,17 +128,29 @@ void registerDatetimeFunctions(const std::string& prefix) {
       Timestamp,
       Timestamp>({prefix + "timestampdiff"});
   registerFunction<
-      TimestampAddFunction,
+      ParameterBinder<TimestampAddFunction, Timestamp>,
       Timestamp,
       Varchar,
       int32_t,
       Timestamp>({prefix + "timestampadd"});
   registerFunction<
-      TimestampAddFunction,
+      ParameterBinder<TimestampAddFunction, Timestamp>,
       Timestamp,
       Varchar,
       int64_t,
       Timestamp>({prefix + "timestampadd"});
+  registerFunction<
+      ParameterBinder<TimestampAddFunction, TimestampUtc>,
+      TimestampUtc,
+      Varchar,
+      int32_t,
+      TimestampUtc>({prefix + "timestampadd"});
+  registerFunction<
+      ParameterBinder<TimestampAddFunction, TimestampUtc>,
+      TimestampUtc,
+      Varchar,
+      int64_t,
+      TimestampUtc>({prefix + "timestampadd"});
   registerFunction<MonthsBetweenFunction, double, Timestamp, Timestamp, bool>(
       {prefix + "months_between"});
 }

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <folly/ScopeGuard.h>
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
 #include "velox/type/Timestamp.h"
@@ -1916,6 +1917,45 @@ TEST_F(DateTimeFunctionsTest, timestampadd) {
           "year",
           10,
           Timestamp(1582970400, 500'999'999) /*2020-02-29 10:00:00.500*/));
+}
+
+TEST_F(DateTimeFunctionsTest, timestampAddTimestampUtc) {
+  const auto timestampAddUtc = [&](const std::string& unit,
+                                   std::optional<int32_t> value,
+                                   std::optional<Timestamp> ts) {
+    return evaluateOnce<Timestamp>(
+        fmt::format("timestampadd('{}', c0, c1)", unit),
+        {INTEGER(), TIMESTAMP_UTC()},
+        value,
+        ts);
+  };
+
+  // 2019-02-28 10:00:00.500 UTC
+  auto base = std::make_optional(Timestamp(1551348000, 500'999'999));
+
+  EXPECT_EQ(
+      Timestamp(1551348010, 500'999'999), timestampAddUtc("second", 10, base));
+  EXPECT_EQ(
+      Timestamp(1551348060, 500'999'999), timestampAddUtc("minute", 1, base));
+  EXPECT_EQ(
+      Timestamp(1551351600, 500'999'999), timestampAddUtc("hour", 1, base));
+  EXPECT_EQ(
+      Timestamp(1551434400, 500'999'999), timestampAddUtc("day", 1, base));
+
+  // TIMESTAMP UTC must not be affected by session timezone.
+  SCOPE_EXIT {
+    setQueryTimeZone("");
+  };
+  setQueryTimeZone("America/Los_Angeles");
+
+  EXPECT_EQ(
+      Timestamp(1551348010, 500'999'999), timestampAddUtc("second", 10, base));
+  EXPECT_EQ(
+      Timestamp(1551348060, 500'999'999), timestampAddUtc("minute", 1, base));
+  EXPECT_EQ(
+      Timestamp(1551351600, 500'999'999), timestampAddUtc("hour", 1, base));
+  EXPECT_EQ(
+      Timestamp(1551434400, 500'999'999), timestampAddUtc("day", 1, base));
 }
 
 TEST_F(DateTimeFunctionsTest, monthsBetween) {


### PR DESCRIPTION
This PR adds support for timestampadd(unit, value, timestamp_utc) following the same pattern as hour, minute and second (PRs #17557 and #17759).
Related type PR: #17091
Related issue: #17087
Spark reference: [datetimeExpressions.scala](https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala)