### PR TITLE
feat(iceberg): Support querying changelog table

### DIFF
--- a/velox/connectors/hive/FileDataSource.h
+++ b/velox/connectors/hive/FileDataSource.h
@@ -175,6 +175,10 @@ class FileDataSource : public DataSource {
 
   dwio::common::RuntimeStatistics runtimeStats_;
 
+  virtual const RowTypePtr getOutputType() {
+    return outputType_;
+  }
+
  private:
   // Configure extraction columns on the ScanSpec and build
   // readerProducedType_.  Called from the constructor after scanSpec_ is

--- a/velox/connectors/hive/FileSplitReader.h
+++ b/velox/connectors/hive/FileSplitReader.h
@@ -131,7 +131,7 @@ class FileSplitReader {
 
   void setConnectorQueryCtx(const ConnectorQueryCtx* connectorQueryCtx);
 
-  const RowTypePtr& readerOutputType() const {
+  virtual const RowTypePtr& readerOutputType() const {
     return readerOutputType_;
   }
 

--- a/velox/connectors/hive/TableHandle.cpp
+++ b/velox/connectors/hive/TableHandle.cpp
@@ -286,7 +286,10 @@ HiveTableHandle::HiveTableHandle(
     const std::unordered_map<std::string, std::string>& tableParameters,
     std::vector<HiveColumnHandlePtr> filterColumnHandles,
     double sampleRate,
-    std::string dbName)
+    std::string dbName,
+    bool isChangelogQuery,
+    const std::unordered_map<std::string, velox::connector::ColumnHandlePtr>&
+        dataColumnHandles)
     : FileTableHandle(std::move(connectorId)),
       tableName_(tableName),
       subfieldFilters_(std::move(subfieldFilters)),
@@ -296,7 +299,9 @@ HiveTableHandle::HiveTableHandle(
       indexColumns_(std::move(indexColumns)),
       tableParameters_(tableParameters),
       filterColumnHandles_(std::move(filterColumnHandles)),
-      dbName_(std::move(dbName)) {
+      dbName_(std::move(dbName)),
+      isChangelogQuery_(isChangelogQuery),
+      dataColumnHandles_(dataColumnHandles) {
   VELOX_CHECK_GT(sampleRate_, 0.0, "Sample rate must be positive");
   VELOX_CHECK_LE(sampleRate_, 1.0, "Sample rate must not exceed 1.0");
 }

--- a/velox/connectors/hive/TableHandle.h
+++ b/velox/connectors/hive/TableHandle.h
@@ -188,7 +188,10 @@ class HiveTableHandle : public FileTableHandle {
       const std::unordered_map<std::string, std::string>& tableParameters = {},
       std::vector<HiveColumnHandlePtr> filterColumnHandles = {},
       double sampleRate = 1.0,
-      std::string dbName = "");
+      std::string dbName = "",
+      bool isChangelogQuery = false,
+      const std::unordered_map<std::string, velox::connector::ColumnHandlePtr>&
+          dataColumnHandles = {});
 
   /// Legacy constructor without indexColumns parameter for backward
   /// compatibility.
@@ -259,6 +262,15 @@ class HiveTableHandle : public FileTableHandle {
     return dbName_;
   }
 
+  bool isChangelogQuery() const {
+    return isChangelogQuery_;
+  }
+
+  const std::unordered_map<std::string, velox::connector::ColumnHandlePtr>&
+  getDataColumnHandles() const {
+    return dataColumnHandles_;
+  }
+
   std::string toString() const override;
 
   folly::dynamic serialize() const override;
@@ -279,6 +291,13 @@ class HiveTableHandle : public FileTableHandle {
   const std::unordered_map<std::string, std::string> tableParameters_;
   const std::vector<HiveColumnHandlePtr> filterColumnHandles_;
   const std::string dbName_;
+  /// Set to true when querying a changelog metadata table.
+  const bool isChangelogQuery_{false};
+  /// Non-empty only when isChangelogQuery_ is true. Maps base data-table column
+  /// names to their column handles so the changelog source can pass them to the
+  /// base IcebergDataSource for column resolution.
+  const std::unordered_map<std::string, velox::connector::ColumnHandlePtr>
+      dataColumnHandles_;
 };
 
 using HiveTableHandlePtr = std::shared_ptr<const HiveTableHandle>;

--- a/velox/connectors/hive/iceberg/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/CMakeLists.txt
@@ -16,6 +16,7 @@ set(
   DeletionVectorReader.cpp
   DeletionVectorWriter.cpp
   EqualityDeleteFileReader.cpp
+  IcebergChangelogSplitReader.cpp
   IcebergColumnHandle.cpp
   IcebergConfig.cpp
   IcebergConnector.cpp
@@ -48,6 +49,8 @@ velox_add_library(
   DeletionVectorReader.h
   DeletionVectorWriter.h
   EqualityDeleteFileReader.h
+  IcebergChangelogSplitInfo.h
+  IcebergChangelogSplitReader.h
   IcebergColumnHandle.h
   IcebergConfig.h
   IcebergConnector.h

--- a/velox/connectors/hive/iceberg/IcebergChangelogSplitInfo.h
+++ b/velox/connectors/hive/iceberg/IcebergChangelogSplitInfo.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace facebook::velox::connector::hive::iceberg {
+
+/// Type of operation recorded in a changelog entry.
+enum class ChangelogOperation { INSERT, DELETE, UPDATE_BEFORE, UPDATE_AFTER };
+
+/// Metadata for a changelog split describing the operation type, sequence,
+/// and snapshot ID for a batch of changelog records.
+struct ChangelogSplitInfo {
+  /// Type of change: INSERT, DELETE, UPDATE_BEFORE, or UPDATE_AFTER.
+  ChangelogOperation operation;
+  /// Sequence number for ordering changes within a snapshot.
+  int64_t ordinal;
+  /// Snapshot this row-level change was made in.
+  int64_t snapshotId;
+
+  ChangelogSplitInfo(ChangelogOperation op, int64_t ord, int64_t snapId)
+      : operation(op), ordinal(ord), snapshotId(snapId) {}
+};
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergChangelogSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergChangelogSplitReader.cpp
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/IcebergChangelogSplitReader.h"
+
+#include "velox/connectors/hive/iceberg/IcebergSplit.h"
+#include "velox/vector/BaseVector.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+IcebergChangelogSplitReader::IcebergChangelogSplitReader(
+    const std::shared_ptr<const HiveIcebergSplit>& icebergSplit,
+    const FileTableHandlePtr& tableHandle,
+    const std::unordered_map<std::string, FileColumnHandlePtr>* partitionKeys,
+    const ConnectorQueryCtx* connectorQueryCtx,
+    const std::shared_ptr<const FileConfig>& fileConfig,
+    const RowTypePtr& dataReaderOutputType,
+    const std::shared_ptr<io::IoStatistics>& dataIoStats,
+    const std::shared_ptr<io::IoStatistics>& metadataIoStats,
+    const std::shared_ptr<IoStats>& ioStats,
+    FileHandleFactory* fileHandleFactory,
+    folly::Executor* executor,
+    const std::shared_ptr<common::ScanSpec>& scanSpec,
+    std::shared_ptr<ColumnHandleMap> columnHandles,
+    const RowTypePtr& changelogOutputType,
+    ColumnHandleMap changelogColumnHandles,
+    const common::SubfieldFilters* changelogFilters)
+    : IcebergSplitReader(
+          icebergSplit,
+          tableHandle,
+          partitionKeys,
+          connectorQueryCtx,
+          fileConfig,
+          dataReaderOutputType,
+          dataIoStats,
+          metadataIoStats,
+          ioStats,
+          fileHandleFactory,
+          executor,
+          scanSpec,
+          std::move(columnHandles)),
+      changelogOutputType_(changelogOutputType),
+      changelogColumnHandles_(std::move(changelogColumnHandles)),
+      changelogFilters_(changelogFilters) {}
+
+// ── prepareSplit
+// ────────────────────────────────────────────────────────────── Extracts
+// ChangelogSplitInfo from the split, evaluates the constant-column subfield
+// filters (operation/ordinal/snapshotid) against it, and — if any filter
+// rejects the constant value — marks the split as empty so no file I/O is
+// performed. For accepted splits, delegates to IcebergSplitReader to open
+// delete files and set up the row reader.
+
+void IcebergChangelogSplitReader::prepareSplit(
+    std::shared_ptr<common::MetadataFilter> metadataFilter,
+    dwio::common::RuntimeStatistics& runtimeStats,
+    const folly::F14FastMap<std::string, std::string>& fileReadOps) {
+  auto icebergSplit =
+      std::dynamic_pointer_cast<const HiveIcebergSplit>(fileSplit_);
+  VELOX_CHECK_NOT_NULL(icebergSplit, "Expected HiveIcebergSplit");
+  VELOX_CHECK_NOT_NULL(
+      icebergSplit->changelogSplitInfo,
+      "HiveIcebergSplit missing changelogSplitInfo for changelog query");
+  changelogSplitInfo_ = icebergSplit->changelogSplitInfo;
+
+  if (!applyChangelogFilters()) {
+    emptySplit_ = true;
+    return;
+  }
+
+  // Split passed constant-column filters — proceed with full preparation.
+  IcebergSplitReader::prepareSplit(metadataFilter, runtimeStats, fileReadOps);
+}
+
+bool IcebergChangelogSplitReader::applyChangelogFilters() const {
+  if (changelogFilters_ == nullptr) {
+    return true;
+  }
+  VELOX_CHECK_NOT_NULL(changelogSplitInfo_);
+
+  const auto& filters = *changelogFilters_;
+
+  std::string operationStr;
+  switch (changelogSplitInfo_->operation) {
+    case ChangelogOperation::INSERT:
+      operationStr = "INSERT";
+      break;
+    case ChangelogOperation::DELETE:
+      operationStr = "DELETE";
+      break;
+    case ChangelogOperation::UPDATE_BEFORE:
+      operationStr = "UPDATE_BEFORE";
+      break;
+    case ChangelogOperation::UPDATE_AFTER:
+      operationStr = "UPDATE_AFTER";
+      break;
+    default:
+      VELOX_FAIL("Unknown changelog operation");
+  }
+
+  auto test = [&](const std::string& colName, auto testFn) -> bool {
+    auto it = filters.find(common::Subfield(colName));
+    if (it == filters.end()) {
+      return true; // No filter on this column — pass.
+    }
+    return testFn(it->second.get());
+  };
+
+  return test(
+             "operation",
+             [&](const common::Filter* f) {
+               return f->testBytes(operationStr.data(), operationStr.size());
+             }) &&
+      test("ordinal",
+           [&](const common::Filter* f) {
+             return f->testInt64(changelogSplitInfo_->ordinal);
+           }) &&
+      test("snapshotid", [&](const common::Filter* f) {
+           return f->testInt64(changelogSplitInfo_->snapshotId);
+         });
+}
+
+// ── buildChangelogColumn
+// ──────────────────────────────────────────────────────
+
+VectorPtr IcebergChangelogSplitReader::buildChangelogColumn(
+    const RowVectorPtr& dataOutput,
+    const std::string& fieldName,
+    column_index_t colIdx,
+    vector_size_t positionCount) const {
+  VELOX_CHECK_NOT_NULL(changelogSplitInfo_);
+
+  if (fieldName == "operation") {
+    std::string operationStr;
+    switch (changelogSplitInfo_->operation) {
+      case ChangelogOperation::INSERT:
+        operationStr = "INSERT";
+        break;
+      case ChangelogOperation::DELETE:
+        operationStr = "DELETE";
+        break;
+      case ChangelogOperation::UPDATE_BEFORE:
+        operationStr = "UPDATE_BEFORE";
+        break;
+      case ChangelogOperation::UPDATE_AFTER:
+        operationStr = "UPDATE_AFTER";
+        break;
+      default:
+        VELOX_FAIL("Unknown changelog operation");
+    }
+    return BaseVector::createConstant(
+        VARCHAR(), variant(operationStr), positionCount, pool_);
+  }
+
+  if (fieldName == "ordinal") {
+    return BaseVector::createConstant(
+        BIGINT(), variant(changelogSplitInfo_->ordinal), positionCount, pool_);
+  }
+
+  if (fieldName == "snapshotid") {
+    return BaseVector::createConstant(
+        BIGINT(),
+        variant(changelogSplitInfo_->snapshotId),
+        positionCount,
+        pool_);
+  }
+
+  if (fieldName == "rowdata") {
+    auto rowdataType = changelogOutputType_->childAt(colIdx);
+    auto rowdataRowType = std::dynamic_pointer_cast<const RowType>(rowdataType);
+    VELOX_CHECK_NOT_NULL(
+        rowdataRowType, "Changelog 'rowdata' column type must be a RowType");
+    VELOX_CHECK_EQ(
+        rowdataRowType->size(),
+        dataOutput->childrenSize(),
+        "Changelog rowdata field count ({}) != data output column count ({})",
+        rowdataRowType->size(),
+        dataOutput->childrenSize());
+    return std::make_shared<RowVector>(
+        pool_,
+        rowdataType,
+        BufferPtr(nullptr),
+        positionCount,
+        dataOutput->children());
+  }
+
+  VELOX_FAIL("Unknown changelog column field name: '{}'", fieldName);
+}
+
+// ── next
+// ────────────────────────────────────────────────────────────────────── Reads
+// a base-table batch from IcebergSplitReader (which handles delete files,
+// schema evolution, etc.), then reshapes it into the changelog output schema:
+// (operation VARCHAR, ordinal BIGINT, snapshotid BIGINT, rowdata ROW). The
+// caller (FileDataSource::next) allocated output with changelogOutputType_, so
+// we replace it with the freshly constructed changelog RowVector.
+
+uint64_t IcebergChangelogSplitReader::next(uint64_t size, VectorPtr& output) {
+  VELOX_CHECK_NOT_NULL(changelogSplitInfo_);
+
+  // Pre-allocate the data output buffer if needed. The base row reader
+  // (SelectiveStructColumnReaderBase::next) requires a non-null output vector
+  // before it calls getValues(). readerOutputType_ holds the base-table schema.
+  if (!dataOutput_) {
+    dataOutput_ = BaseVector::create(readerOutputType_, 0, pool_);
+  }
+
+  // Read base-table rows into our private buffer.
+  const uint64_t rowsScanned = IcebergSplitReader::next(size, dataOutput_);
+  if (rowsScanned == 0) {
+    return 0;
+  }
+
+  auto* dataRowVector = dataOutput_->as<RowVector>();
+  VELOX_CHECK_NOT_NULL(dataRowVector, "Expected RowVector from base reader.");
+  const auto positionCount = static_cast<vector_size_t>(dataOutput_->size());
+
+  // Build the changelog output columns.
+  std::vector<VectorPtr> changelogColumns;
+  changelogColumns.reserve(changelogOutputType_->size());
+
+  for (column_index_t i = 0; i < changelogOutputType_->size(); ++i) {
+    const auto& outputColName = changelogOutputType_->nameOf(i);
+
+    // Resolve the physical field name via changelog column handles.
+    auto it = changelogColumnHandles_.find(outputColName);
+    VELOX_CHECK(
+        it != changelogColumnHandles_.end(),
+        "No column handle found for changelog output column '{}'.",
+        outputColName);
+    const auto& fieldName =
+        static_cast<const FileColumnHandle*>(it->second.get())->name();
+
+    changelogColumns.push_back(buildChangelogColumn(
+        std::dynamic_pointer_cast<RowVector>(dataOutput_),
+        fieldName,
+        i,
+        positionCount));
+  }
+
+  // Replace the caller-supplied output with the changelog RowVector.
+  output = std::make_shared<RowVector>(
+      pool_,
+      changelogOutputType_,
+      BufferPtr(nullptr),
+      positionCount,
+      std::move(changelogColumns));
+
+  return rowsScanned;
+}
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergChangelogSplitReader.h
+++ b/velox/connectors/hive/iceberg/IcebergChangelogSplitReader.h
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/connectors/Connector.h"
+#include "velox/connectors/hive/iceberg/IcebergChangelogSplitInfo.h"
+#include "velox/connectors/hive/iceberg/IcebergSplitReader.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+/// Split reader for Iceberg changelog table queries.
+///
+/// Inherits the full IcebergSplitReader file-reading pipeline (positional
+/// deletes, deletion vectors, equality deletes, schema evolution) and adds
+/// changelog-specific behaviour:
+///
+///   - readerOutputType(): reports the changelog output schema
+///     (operation, ordinal, snapshotid, rowdata) to FileDataSource so that
+///     output_ is allocated with the correct shape.
+///
+///   - next(): reads a base-table batch via IcebergSplitReader::next() into a
+///     private buffer, then transforms it into the changelog output schema
+///     before writing into the caller-supplied output vector.
+///
+///   - prepareSplit(): evaluates the constant-column subfield filters
+///     (operation / ordinal / snapshotid) from filters_ against the split's
+///     ChangelogSplitInfo. Marks the split empty when any filter rejects the
+///     constant, avoiding all file I/O.
+///
+/// The parent IcebergSplitReader is constructed with the base-table
+/// readerOutputType so its row reader reads the correct data columns.
+/// IcebergChangelogSplitReader keeps the changelog output type separately and
+/// overrides readerOutputType() so the FileDataSource layer sees the changelog
+/// schema for output allocation and remaining-filter evaluation.
+class IcebergChangelogSplitReader : public IcebergSplitReader {
+ public:
+  IcebergChangelogSplitReader(
+      const std::shared_ptr<const HiveIcebergSplit>& icebergSplit,
+      const FileTableHandlePtr& tableHandle,
+      const std::unordered_map<std::string, FileColumnHandlePtr>* partitionKeys,
+      const ConnectorQueryCtx* connectorQueryCtx,
+      const std::shared_ptr<const FileConfig>& fileConfig,
+      const RowTypePtr& dataReaderOutputType,
+      const std::shared_ptr<io::IoStatistics>& dataIoStats,
+      const std::shared_ptr<io::IoStatistics>& metadataIoStats,
+      const std::shared_ptr<IoStats>& ioStats,
+      FileHandleFactory* fileHandleFactory,
+      folly::Executor* executor,
+      const std::shared_ptr<common::ScanSpec>& scanSpec,
+      std::shared_ptr<ColumnHandleMap> columnHandles,
+      const RowTypePtr& changelogOutputType,
+      ColumnHandleMap changelogColumnHandles,
+      const common::SubfieldFilters* changelogFilters);
+
+  ~IcebergChangelogSplitReader() override = default;
+
+  /// Returns the changelog output schema so FileDataSource allocates output_
+  /// with the right shape and evaluates the remaining filter against changelog
+  /// column names.
+  const RowTypePtr& readerOutputType() const override {
+    return changelogOutputType_;
+  }
+
+  void prepareSplit(
+      std::shared_ptr<common::MetadataFilter> metadataFilter,
+      dwio::common::RuntimeStatistics& runtimeStats,
+      const folly::F14FastMap<std::string, std::string>& fileReadOps = {})
+      override;
+
+  uint64_t next(uint64_t size, VectorPtr& output) override;
+
+ protected:
+  /// Evaluates the changelog constant-column subfield filters
+  /// (operation/ordinal/snapshotid) against changelogSplitInfo_.
+  /// Returns true if the split passes all filters (or there are none),
+  /// false if any filter rejects the split's constant values.
+  /// Requires changelogSplitInfo_ to be set before calling.
+  bool applyChangelogFilters() const;
+
+  /// Builds a single constant or rowdata column vector for the changelog
+  /// output schema from a data batch produced by the base reader.
+  VectorPtr buildChangelogColumn(
+      const RowVectorPtr& dataOutput,
+      const std::string& fieldName,
+      column_index_t colIdx,
+      vector_size_t positionCount) const;
+
+  /// Changelog output schema: (operation VARCHAR, ordinal BIGINT,
+  /// snapshotid BIGINT, rowdata ROW<...>).
+  const RowTypePtr changelogOutputType_;
+
+  /// Column handles for changelog output columns, keyed by output column name.
+  const ColumnHandleMap changelogColumnHandles_;
+
+  /// Changelog metadata for the current split, set in prepareSplit().
+  std::shared_ptr<ChangelogSplitInfo> changelogSplitInfo_;
+
+  /// Pointer to FileDataSource::filters_, containing the changelog
+  /// constant-column subfield filters (operation/ordinal/snapshotid).
+  /// Not owned; lifetime is guaranteed by the owning FileDataSource.
+  const common::SubfieldFilters* const changelogFilters_;
+
+  /// Reusable buffer for the base-table batch produced by IcebergSplitReader.
+  VectorPtr dataOutput_;
+};
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergConnector.cpp
+++ b/velox/connectors/hive/iceberg/IcebergConnector.cpp
@@ -19,6 +19,7 @@
 #include <numeric>
 
 #include "velox/connectors/hive/HiveConnector.h"
+#include "velox/connectors/hive/TableHandle.h"
 #include "velox/connectors/hive/iceberg/IcebergConfig.h"
 #include "velox/connectors/hive/iceberg/IcebergDataSink.h"
 #include "velox/connectors/hive/iceberg/IcebergDataSource.h"

--- a/velox/connectors/hive/iceberg/IcebergDataSource.cpp
+++ b/velox/connectors/hive/iceberg/IcebergDataSource.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/connectors/hive/iceberg/IcebergDataSource.h"
 
+#include "velox/connectors/hive/TableHandle.h"
+#include "velox/connectors/hive/iceberg/IcebergChangelogSplitReader.h"
 #include "velox/connectors/hive/iceberg/IcebergSplit.h"
 #include "velox/connectors/hive/iceberg/IcebergSplitReader.h"
 
@@ -43,7 +45,82 @@ std::unique_ptr<FileSplitReader> IcebergDataSource::createSplitReader() {
   prepareSplit();
   auto icebergSplit = checkedPointerCast<const HiveIcebergSplit>(split_);
 
-  auto reader = std::make_unique<IcebergSplitReader>(
+  auto* hiveTableHandle =
+      dynamic_cast<const HiveTableHandle*>(tableHandle_.get());
+
+  if (hiveTableHandle && hiveTableHandle->isChangelogQuery()) {
+    // Changelog query: build a base-table readerOutputType and scanSpec from
+    // the data column handles stored in the table handle, then create an
+    // IcebergChangelogSplitReader that reads the data columns and wraps each
+    // batch into the changelog output schema.
+    const auto& dataColumns = tableHandle_->dataColumns();
+    VELOX_CHECK_NOT_NULL(
+        dataColumns,
+        "IcebergDataSource: changelog query requires tableHandle.dataColumns");
+
+    const auto& rawDataHandles = hiveTableHandle->getDataColumnHandles();
+    auto dataColumnHandles = std::make_shared<ColumnHandleMap>(rawDataHandles);
+
+    // Build the base-table readerOutputType: include columns present in both
+    // the table schema and the data column handles.
+    std::vector<std::string> dataNames;
+    std::vector<TypePtr> dataTypes;
+    for (uint32_t i = 0; i < dataColumns->size(); ++i) {
+      const auto& physName = dataColumns->nameOf(i);
+      if (rawDataHandles.count(physName)) {
+        dataNames.push_back(physName);
+        dataTypes.push_back(dataColumns->childAt(i));
+      }
+    }
+    auto dataReaderOutputType = ROW(std::move(dataNames), std::move(dataTypes));
+
+    // Build a data-scoped scanSpec covering the projected base-table columns.
+    // Pass empty filters: changelog metadata filters (operation/ordinal/
+    // snapshotid) are constant per-split and evaluated in
+    // IcebergChangelogSplitReader::prepareSplit(); they must NOT be forwarded
+    // to makeScanSpec because those names do not exist in the base-table schema
+    // and would cause "Field not found" errors.  Data-column predicates (e.g.
+    // rowdata.id < 50) reference the nested "rowdata" namespace and are not
+    // present as bare subfield filters here; any remaining predicate is
+    // evaluated by the downstream Filter operator.
+    auto dataScanSpec = makeScanSpec(
+        dataReaderOutputType,
+        subfields_,
+        common::SubfieldFilters{},
+        /*indexColumns=*/{},
+        tableHandle_->dataColumns(),
+        partitionKeys_,
+        infoColumns_,
+        specialColumns_,
+        fileConfig_->readStatsBasedFilterReorderDisabled(
+            connectorQueryCtx_->sessionProperties()),
+        pool_);
+
+    auto changelogOutputType = getOutputType();
+    // columnHandles_ holds the changelog output column handles
+    // (operation/ordinal/snapshotid/rowdata) — passed as
+    // changelogColumnHandles.
+    return std::make_unique<IcebergChangelogSplitReader>(
+        icebergSplit,
+        tableHandle_,
+        &partitionKeys_,
+        connectorQueryCtx_,
+        fileConfig_,
+        dataReaderOutputType,
+        dataIoStats_,
+        metadataIoStats_,
+        ioStats_,
+        fileHandleFactory_,
+        ioExecutor_,
+        dataScanSpec,
+        dataColumnHandles,
+        changelogOutputType, // changelog output type
+        *columnHandles_, // changelog column handles
+        &filters_);
+  }
+
+  // Regular (non-changelog) Iceberg query.
+  return std::make_unique<IcebergSplitReader>(
       icebergSplit,
       tableHandle_,
       &partitionKeys_,
@@ -57,8 +134,6 @@ std::unique_ptr<FileSplitReader> IcebergDataSource::createSplitReader() {
       ioExecutor_,
       scanSpec_,
       columnHandles_);
-
-  return reader;
 }
 
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergDataSource.h
+++ b/velox/connectors/hive/iceberg/IcebergDataSource.h
@@ -21,11 +21,16 @@ namespace facebook::velox::connector::hive::iceberg {
 
 /// Iceberg-specific data source that extends HiveDataSource.
 ///
-/// Provides Iceberg table format support by creating
-/// IcebergSplitReader instances that handle:
-/// - Positional delete files for row-level deletes.
-/// - Schema evolution with column adaptation.
-/// - Iceberg-specific metadata columns.
+/// Provides Iceberg table format support by creating IcebergSplitReader
+/// instances that handle positional delete files, schema evolution, and
+/// Iceberg-specific metadata columns.
+///
+/// When the table handle has isChangelogQuery() == true, createSplitReader()
+/// builds a data-scoped readerOutputType / scanSpec from the table handle's
+/// dataColumnHandles and instantiates an IcebergChangelogSplitReader that
+/// transforms each base-table batch into the changelog output schema
+/// (operation, ordinal, snapshotid, rowdata).  No separate data-source class
+/// is required for changelog queries.
 class IcebergDataSource : public HiveDataSource {
  public:
   IcebergDataSource(
@@ -38,15 +43,15 @@ class IcebergDataSource : public HiveDataSource {
       const std::shared_ptr<HiveConfig>& hiveConfig);
 
  protected:
-  /// Creates an IcebergSplitReader for reading Iceberg data files.
-  ///
-  /// Unlike the base HiveDataSource which creates a generic FileSplitReader,
-  /// this method creates an IcebergSplitReader that handles Iceberg-specific
-  /// features like positional delete files and schema evolution.
+  /// Creates an IcebergSplitReader (regular) or IcebergChangelogSplitReader
+  /// (changelog) depending on the table handle's isChangelogQuery() flag.
   std::unique_ptr<FileSplitReader> createSplitReader() override;
 
  private:
-  /// Column handles map for accessing column metadata.
+  /// Column handles for the output columns as passed to the constructor.
+  /// For regular queries these are the data column handles; for changelog
+  /// queries these are the changelog output column handles
+  /// (operation/ordinal/snapshotid/rowdata).
   std::shared_ptr<ColumnHandleMap> columnHandles_;
 };
 

--- a/velox/connectors/hive/iceberg/IcebergSplit.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplit.cpp
@@ -34,7 +34,8 @@ HiveIcebergSplit::HiveIcebergSplit(
     bool cacheable,
     const std::unordered_map<std::string, std::string>& infoColumns,
     std::optional<FileProperties> properties,
-    int64_t dataSequenceNumber)
+    int64_t dataSequenceNumber,
+    std::shared_ptr<ChangelogSplitInfo> changelogInfo)
     : HiveConnectorSplit(
           connectorId,
           filePath,
@@ -52,7 +53,8 @@ HiveIcebergSplit::HiveIcebergSplit(
           properties,
           std::nullopt,
           std::nullopt),
-      dataSequenceNumber(dataSequenceNumber) {
+      dataSequenceNumber(dataSequenceNumber),
+      changelogSplitInfo(std::move(changelogInfo)) {
   // TODO: Deserialize _extraFileInfo to get deleteFiles;
 }
 
@@ -72,7 +74,8 @@ HiveIcebergSplit::HiveIcebergSplit(
     std::vector<IcebergDeleteFile> deletes,
     const std::unordered_map<std::string, std::string>& infoColumns,
     std::optional<FileProperties> properties,
-    int64_t dataSequenceNumber)
+    int64_t dataSequenceNumber,
+    std::shared_ptr<ChangelogSplitInfo> changelogInfo)
     : HiveConnectorSplit(
           connectorId,
           filePath,
@@ -91,7 +94,8 @@ HiveIcebergSplit::HiveIcebergSplit(
           std::nullopt,
           std::nullopt),
       deleteFiles(std::move(deletes)),
-      dataSequenceNumber(dataSequenceNumber) {}
+      dataSequenceNumber(dataSequenceNumber),
+      changelogSplitInfo(std::move(changelogInfo)) {}
 
 std::shared_ptr<HiveIcebergSplit> IcebergSplitBuilder::build() const {
   return std::make_shared<HiveIcebergSplit>(
@@ -108,6 +112,7 @@ std::shared_ptr<HiveIcebergSplit> IcebergSplitBuilder::build() const {
       deleteFiles_,
       infoColumns_,
       std::nullopt,
-      dataSequenceNumber_);
+      dataSequenceNumber_,
+      changelogSplitInfo_);
 }
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergSplit.h
+++ b/velox/connectors/hive/iceberg/IcebergSplit.h
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "velox/connectors/hive/HiveConnectorSplit.h"
+#include "velox/connectors/hive/iceberg/IcebergChangelogSplitInfo.h"
 #include "velox/connectors/hive/iceberg/IcebergDeleteFile.h"
 
 namespace facebook::velox::connector::hive::iceberg {
@@ -36,6 +37,10 @@ struct HiveIcebergSplit : public connector::hive::HiveConnectorSplit {
   /// number. A value of 0 means "unassigned" (legacy V1 tables) and disables
   /// sequence number filtering.
   int64_t dataSequenceNumber{0};
+
+  /// Changelog split information. If present, this split represents a changelog
+  /// table query and contains metadata about the changelog operation.
+  std::shared_ptr<ChangelogSplitInfo> changelogSplitInfo;
 
   HiveIcebergSplit(
       const std::string& connectorId,
@@ -51,7 +56,8 @@ struct HiveIcebergSplit : public connector::hive::HiveConnectorSplit {
       bool cacheable = true,
       const std::unordered_map<std::string, std::string>& infoColumns = {},
       std::optional<FileProperties> fileProperties = std::nullopt,
-      int64_t dataSequenceNumber = 0);
+      int64_t dataSequenceNumber = 0,
+      std::shared_ptr<ChangelogSplitInfo> changelogSplitInfo = nullptr);
 
   // For tests only
   HiveIcebergSplit(
@@ -69,7 +75,8 @@ struct HiveIcebergSplit : public connector::hive::HiveConnectorSplit {
       std::vector<IcebergDeleteFile> deletes = {},
       const std::unordered_map<std::string, std::string>& infoColumns = {},
       std::optional<FileProperties> fileProperties = std::nullopt,
-      int64_t dataSequenceNumber = 0);
+      int64_t dataSequenceNumber = 0,
+      std::shared_ptr<ChangelogSplitInfo> changelogSplitInfo = nullptr);
 };
 
 /// Builds Iceberg splits with named parameters.
@@ -124,6 +131,12 @@ class IcebergSplitBuilder {
     return *this;
   }
 
+  IcebergSplitBuilder& changelogSplitInfo(
+      std::shared_ptr<ChangelogSplitInfo> info) {
+    changelogSplitInfo_ = std::move(info);
+    return *this;
+  }
+
   std::shared_ptr<HiveIcebergSplit> build() const;
 
  private:
@@ -136,6 +149,7 @@ class IcebergSplitBuilder {
   std::unordered_map<std::string, std::string> infoColumns_;
   std::vector<IcebergDeleteFile> deleteFiles_;
   int64_t dataSequenceNumber_{0};
+  std::shared_ptr<ChangelogSplitInfo> changelogSplitInfo_;
 };
 
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/tests/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/tests/CMakeLists.txt
@@ -200,4 +200,26 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
     GTest::gtest
     GTest::gtest_main
   )
+
+  add_executable(
+    velox_hive_iceberg_changelog_test
+    IcebergChangelogE2ETest.cpp
+    IcebergChangelogSplitReaderTest.cpp
+    IcebergTestBase.cpp
+    Main.cpp
+  )
+  velox_add_test_headers(velox_hive_iceberg_changelog_test IcebergTestBase.h)
+  add_test(velox_hive_iceberg_changelog_test velox_hive_iceberg_changelog_test)
+
+  target_link_libraries(
+    velox_hive_iceberg_changelog_test
+    velox_hive_connector
+    velox_hive_iceberg_splitreader
+    velox_exec_test_lib
+    velox_vector_test_lib
+    velox_dwio_parquet_reader
+    velox_dwio_parquet_writer
+    GTest::gtest
+    GTest::gtest_main
+  )
 endif()

--- a/velox/connectors/hive/iceberg/tests/IcebergChangelogE2ETest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergChangelogE2ETest.cpp
@@ -1,0 +1,876 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/file/FileSystems.h"
+#include "velox/connectors/hive/iceberg/IcebergSplit.h"
+#include "velox/connectors/hive/iceberg/tests/IcebergTestBase.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+using namespace facebook::velox::exec::test;
+using namespace facebook::velox::exec;
+
+namespace facebook::velox::connector::hive::iceberg {
+
+namespace {
+
+class IcebergChangelogE2ETest : public test::IcebergTestBase {
+ protected:
+  static constexpr int32_t kDefaultNumBatches = 2;
+  static constexpr int32_t kDefaultRowsPerBatch = 100;
+
+  std::string getDataFilePath(const std::string& dirPath) {
+    auto files = listFiles(dirPath);
+    VELOX_CHECK(!files.empty(), "listFiles returned empty list");
+    return files[0];
+  }
+
+  std::vector<RowVectorPtr> createChangelogTestData() {
+    std::vector<RowVectorPtr> batches;
+
+    for (auto i = 0; i < kDefaultNumBatches; i++) {
+      auto idVector = makeFlatVector<int64_t>(
+          kDefaultRowsPerBatch,
+          [i](auto row) { return i * kDefaultRowsPerBatch + row; });
+      auto nameVector =
+          makeFlatVector<std::string>(kDefaultRowsPerBatch, [i](auto row) {
+            return "name_" + std::to_string(i * kDefaultRowsPerBatch + row);
+          });
+      batches.push_back(makeRowVector({"id", "name"}, {idVector, nameVector}));
+    }
+    return batches;
+  }
+
+  std::shared_ptr<ConnectorSplit> makeChangelogSplit(
+      const std::string& dataFilePath,
+      ChangelogOperation operation,
+      int64_t ordinal,
+      int64_t snapshotId) {
+    auto changelogInfo =
+        std::make_shared<ChangelogSplitInfo>(operation, ordinal, snapshotId);
+
+    // Get actual file size
+    const auto file = filesystems::getFileSystem(dataFilePath, nullptr)
+                          ->openFileForRead(dataFilePath);
+
+    return IcebergSplitBuilder(dataFilePath)
+        .connectorId(test::kIcebergConnectorId)
+        .fileFormat(fileFormat_)
+        .start(0)
+        .length(file->size())
+        .changelogSplitInfo(changelogInfo)
+        .build();
+  }
+
+  RowTypePtr createChangelogOutputType(const RowTypePtr& dataRowType) {
+    return ROW(
+        {"operation", "ordinal", "snapshotid", "rowdata"},
+        {VARCHAR(), BIGINT(), BIGINT(), dataRowType});
+  }
+
+  ColumnHandleMap createChangelogColumnHandles(const RowTypePtr& dataType) {
+    ColumnHandleMap handles;
+    handles["operation"] = std::make_shared<HiveColumnHandle>(
+        "operation",
+        HiveColumnHandle::ColumnType::kRegular,
+        VARCHAR(),
+        VARCHAR());
+    handles["ordinal"] = std::make_shared<HiveColumnHandle>(
+        "ordinal", HiveColumnHandle::ColumnType::kRegular, BIGINT(), BIGINT());
+    handles["snapshotid"] = std::make_shared<HiveColumnHandle>(
+        "snapshotid",
+        HiveColumnHandle::ColumnType::kRegular,
+        BIGINT(),
+        BIGINT());
+    handles["rowdata"] = std::make_shared<HiveColumnHandle>(
+        "rowdata", HiveColumnHandle::ColumnType::kRegular, dataType, dataType);
+    return handles;
+  }
+
+  ColumnHandleMap createDataColumnHandles(const RowTypePtr& dataType) {
+    ColumnHandleMap handles;
+    for (size_t i = 0; i < dataType->size(); ++i) {
+      const auto& name = dataType->nameOf(i);
+      const auto& type = dataType->childAt(i);
+      handles[name] = std::make_shared<HiveColumnHandle>(
+          name, HiveColumnHandle::ColumnType::kRegular, type, type);
+    }
+    return handles;
+  }
+
+  std::shared_ptr<HiveTableHandle> createChangelogTableHandle(
+      const RowTypePtr& dataType) {
+    auto dataColumnHandles = createDataColumnHandles(dataType);
+    return std::make_shared<HiveTableHandle>(
+        test::kIcebergConnectorId,
+        "test_table",
+        common::SubfieldFilters{},
+        nullptr, // remainingFilter
+        dataType, // dataColumns
+        std::vector<std::string>{}, // indexColumns
+        std::unordered_map<std::string, std::string>{}, // tableParameters
+        std::vector<HiveColumnHandlePtr>{}, // filterColumnHandles
+        1.0, // sampleRate
+        "", // dbName
+        true, // isChangelogQuery
+        dataColumnHandles);
+  }
+
+  void verifyChangelogSchema(const RowTypePtr& outputType) {
+    ASSERT_EQ(outputType->size(), 4);
+    ASSERT_EQ(outputType->nameOf(0), "operation");
+    ASSERT_EQ(outputType->childAt(0)->kind(), TypeKind::VARCHAR);
+    ASSERT_EQ(outputType->nameOf(1), "ordinal");
+    ASSERT_EQ(outputType->childAt(1)->kind(), TypeKind::BIGINT);
+    ASSERT_EQ(outputType->nameOf(2), "snapshotid");
+    ASSERT_EQ(outputType->childAt(2)->kind(), TypeKind::BIGINT);
+    ASSERT_EQ(outputType->nameOf(3), "rowdata");
+    ASSERT_EQ(outputType->childAt(3)->kind(), TypeKind::ROW);
+  }
+
+  void verifyChangelogRecord(
+      const RowVectorPtr& resultVector,
+      int32_t rowIndex,
+      const std::string& expectedOperation,
+      int64_t expectedOrdinal,
+      int64_t expectedSnapshotId) {
+    // Verify operation
+    auto operationVector =
+        resultVector->childAt(0)->as<SimpleVector<StringView>>();
+    ASSERT_EQ(
+        operationVector->valueAt(rowIndex), StringView(expectedOperation));
+
+    // Verify ordinal
+    auto ordinalVector = resultVector->childAt(1)->as<SimpleVector<int64_t>>();
+    ASSERT_EQ(ordinalVector->valueAt(rowIndex), expectedOrdinal);
+
+    // Verify snapshotid
+    auto snapshotVector = resultVector->childAt(2)->as<SimpleVector<int64_t>>();
+    ASSERT_EQ(snapshotVector->valueAt(rowIndex), expectedSnapshotId);
+  }
+};
+
+TEST_F(IcebergChangelogE2ETest, differentOperations) {
+  auto batches = createChangelogTestData();
+  ASSERT_FALSE(batches.empty());
+
+  auto outputDirectory = test::TempDirectoryPath::create();
+  auto dataSink =
+      createDataSinkAndAppendData(batches, outputDirectory->getPath(), {});
+  dataSink->close();
+
+  std::string dataFilePath = getDataFilePath(outputDirectory->getPath());
+
+  std::vector<std::pair<ChangelogOperation, std::string>> operations = {
+      {ChangelogOperation::INSERT, "INSERT"},
+      {ChangelogOperation::DELETE, "DELETE"},
+      {ChangelogOperation::UPDATE_BEFORE, "UPDATE_BEFORE"},
+      {ChangelogOperation::UPDATE_AFTER, "UPDATE_AFTER"}};
+
+  auto dataRowType = ROW({"id", "name"}, {BIGINT(), VARCHAR()});
+  auto changelogOutputType = createChangelogOutputType(dataRowType);
+  auto changelogColumnHandles = createChangelogColumnHandles(dataRowType);
+  auto tableHandle = createChangelogTableHandle(dataRowType);
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(test::kIcebergConnectorId)
+                  .outputType(changelogOutputType)
+                  .tableHandle(tableHandle)
+                  .assignments(changelogColumnHandles)
+                  .endTableScan()
+                  .planNode();
+
+  // Verify all operation types produce correct changelog records
+  for (const auto& [operation, operationStr] : operations) {
+    auto changelogSplit = makeChangelogSplit(dataFilePath, operation, 1, 12345);
+
+    auto resultVector =
+        AssertQueryBuilder(plan).split(changelogSplit).copyResults(pool());
+
+    ASSERT_TRUE(resultVector != nullptr);
+    ASSERT_GT(resultVector->size(), 0);
+
+    // Verify changelog schema
+    verifyChangelogSchema(
+        std::dynamic_pointer_cast<const RowType>(resultVector->type()));
+
+    // Verify all rows have the correct operation
+    for (auto i = 0; i < resultVector->size(); i++) {
+      verifyChangelogRecord(resultVector, i, operationStr, 1, 12345);
+    }
+  }
+}
+
+TEST_F(IcebergChangelogE2ETest, multipleSnapshots) {
+  auto batches = createChangelogTestData();
+  ASSERT_FALSE(batches.empty());
+
+  auto outputDirectory = test::TempDirectoryPath::create();
+  auto dataSink =
+      createDataSinkAndAppendData(batches, outputDirectory->getPath(), {});
+  dataSink->close();
+
+  std::string dataFilePath = getDataFilePath(outputDirectory->getPath());
+
+  std::vector<std::shared_ptr<ConnectorSplit>> splits;
+  splits.push_back(
+      makeChangelogSplit(dataFilePath, ChangelogOperation::INSERT, 1, 100));
+  splits.push_back(makeChangelogSplit(
+      dataFilePath, ChangelogOperation::UPDATE_BEFORE, 2, 200));
+  splits.push_back(makeChangelogSplit(
+      dataFilePath, ChangelogOperation::UPDATE_AFTER, 3, 200));
+
+  auto dataRowType = ROW({"id", "name"}, {BIGINT(), VARCHAR()});
+  auto changelogOutputType = createChangelogOutputType(dataRowType);
+  auto changelogColumnHandles = createChangelogColumnHandles(dataRowType);
+  auto tableHandle = createChangelogTableHandle(dataRowType);
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(test::kIcebergConnectorId)
+                  .outputType(changelogOutputType)
+                  .tableHandle(tableHandle)
+                  .assignments(changelogColumnHandles)
+                  .endTableScan()
+                  .planNode();
+
+  // Verify multiple changelog splits can be read
+  auto resultVector =
+      AssertQueryBuilder(plan).splits(splits).copyResults(pool());
+
+  ASSERT_TRUE(resultVector != nullptr);
+
+  // Verify changelog schema
+  verifyChangelogSchema(
+      std::dynamic_pointer_cast<const RowType>(resultVector->type()));
+
+  int32_t expectedRowsPerSplit = 0;
+  for (const auto& batch : batches) {
+    expectedRowsPerSplit += batch->size();
+  }
+  int32_t expectedTotalRows = expectedRowsPerSplit * 3; // 3 splits
+
+  ASSERT_EQ(resultVector->size(), expectedTotalRows);
+
+  // Verify changelog records from each split
+  // First split: INSERT with ordinal=1, snapshotId=100
+  for (auto i = 0; i < expectedRowsPerSplit; i++) {
+    verifyChangelogRecord(resultVector, i, "INSERT", 1, 100);
+  }
+
+  // Second split: UPDATE_BEFORE with ordinal=2, snapshotId=200
+  for (auto i = expectedRowsPerSplit; i < expectedRowsPerSplit * 2; i++) {
+    verifyChangelogRecord(resultVector, i, "UPDATE_BEFORE", 2, 200);
+  }
+
+  // Third split: UPDATE_AFTER with ordinal=3, snapshotId=200
+  for (auto i = expectedRowsPerSplit * 2; i < expectedTotalRows; i++) {
+    verifyChangelogRecord(resultVector, i, "UPDATE_AFTER", 3, 200);
+  }
+}
+
+TEST_F(IcebergChangelogE2ETest, selectMetadataColumnsOnly) {
+  auto batches = createChangelogTestData();
+  ASSERT_FALSE(batches.empty());
+
+  auto outputDirectory = test::TempDirectoryPath::create();
+  auto dataSink =
+      createDataSinkAndAppendData(batches, outputDirectory->getPath(), {});
+  dataSink->close();
+
+  std::string dataFilePath = getDataFilePath(outputDirectory->getPath());
+
+  auto changelogSplit =
+      makeChangelogSplit(dataFilePath, ChangelogOperation::INSERT, 5, 99999);
+
+  // Select only metadata columns (operation, ordinal, snapshotid) without
+  // rowdata
+  auto dataRowType = ROW({"id", "name"}, {BIGINT(), VARCHAR()});
+  auto metadataOnlyType = ROW(
+      {"operation", "ordinal", "snapshotid"}, {VARCHAR(), BIGINT(), BIGINT()});
+
+  ColumnHandleMap metadataHandles;
+  metadataHandles["operation"] = std::make_shared<HiveColumnHandle>(
+      "operation",
+      HiveColumnHandle::ColumnType::kRegular,
+      VARCHAR(),
+      VARCHAR());
+  metadataHandles["ordinal"] = std::make_shared<HiveColumnHandle>(
+      "ordinal", HiveColumnHandle::ColumnType::kRegular, BIGINT(), BIGINT());
+  metadataHandles["snapshotid"] = std::make_shared<HiveColumnHandle>(
+      "snapshotid", HiveColumnHandle::ColumnType::kRegular, BIGINT(), BIGINT());
+
+  auto tableHandle = createChangelogTableHandle(dataRowType);
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(test::kIcebergConnectorId)
+                  .outputType(metadataOnlyType)
+                  .tableHandle(tableHandle)
+                  .assignments(metadataHandles)
+                  .endTableScan()
+                  .planNode();
+
+  auto resultVector =
+      AssertQueryBuilder(plan).split(changelogSplit).copyResults(pool());
+
+  ASSERT_TRUE(resultVector != nullptr);
+  ASSERT_EQ(resultVector->childrenSize(), 3);
+
+  int32_t expectedRows = 0;
+  for (const auto& batch : batches) {
+    expectedRows += batch->size();
+  }
+  ASSERT_EQ(resultVector->size(), expectedRows);
+
+  // Verify all rows have correct metadata
+  auto operationVector =
+      resultVector->childAt(0)->as<SimpleVector<StringView>>();
+  auto ordinalVector = resultVector->childAt(1)->as<SimpleVector<int64_t>>();
+  auto snapshotVector = resultVector->childAt(2)->as<SimpleVector<int64_t>>();
+
+  for (auto i = 0; i < resultVector->size(); i++) {
+    ASSERT_EQ(operationVector->valueAt(i), StringView("INSERT"));
+    ASSERT_EQ(ordinalVector->valueAt(i), 5);
+    ASSERT_EQ(snapshotVector->valueAt(i), 99999);
+  }
+}
+
+TEST_F(IcebergChangelogE2ETest, filterOnMetadataColumns) {
+  auto batches = createChangelogTestData();
+  ASSERT_FALSE(batches.empty());
+
+  auto outputDirectory = test::TempDirectoryPath::create();
+  auto dataSink =
+      createDataSinkAndAppendData(batches, outputDirectory->getPath(), {});
+  dataSink->close();
+
+  std::string dataFilePath = getDataFilePath(outputDirectory->getPath());
+
+  // Create splits with different operations and ordinals
+  std::vector<std::shared_ptr<ConnectorSplit>> splits;
+  splits.push_back(
+      makeChangelogSplit(dataFilePath, ChangelogOperation::INSERT, 1, 100));
+  splits.push_back(
+      makeChangelogSplit(dataFilePath, ChangelogOperation::DELETE, 2, 100));
+  splits.push_back(makeChangelogSplit(
+      dataFilePath, ChangelogOperation::UPDATE_AFTER, 3, 200));
+
+  auto dataRowType = ROW({"id", "name"}, {BIGINT(), VARCHAR()});
+  auto changelogOutputType = createChangelogOutputType(dataRowType);
+  auto changelogColumnHandles = createChangelogColumnHandles(dataRowType);
+  auto tableHandle = createChangelogTableHandle(dataRowType);
+
+  // Filter: operation = 'INSERT' OR ordinal > 2
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(test::kIcebergConnectorId)
+                  .outputType(changelogOutputType)
+                  .tableHandle(tableHandle)
+                  .assignments(changelogColumnHandles)
+                  .endTableScan()
+                  .filter("operation = 'INSERT' OR ordinal > 2")
+                  .planNode();
+
+  auto resultVector =
+      AssertQueryBuilder(plan).splits(splits).copyResults(pool());
+
+  ASSERT_TRUE(resultVector != nullptr);
+
+  int32_t expectedRowsPerSplit = 0;
+  for (const auto& batch : batches) {
+    expectedRowsPerSplit += batch->size();
+  }
+  // Should get rows from split 1 (INSERT) and split 3 (ordinal=3)
+  int32_t expectedTotalRows = expectedRowsPerSplit * 2;
+  ASSERT_EQ(resultVector->size(), expectedTotalRows);
+
+  // Verify filtered results
+  auto operationVector =
+      resultVector->childAt(0)->as<SimpleVector<StringView>>();
+  auto ordinalVector = resultVector->childAt(1)->as<SimpleVector<int64_t>>();
+
+  for (auto i = 0; i < resultVector->size(); i++) {
+    auto op = operationVector->valueAt(i);
+    auto ord = ordinalVector->valueAt(i);
+    // Each row should match the filter condition
+    ASSERT_TRUE(op == StringView("INSERT") || ord > 2);
+  }
+}
+
+TEST_F(IcebergChangelogE2ETest, filterOnRowdataNestedColumns) {
+  auto batches = createChangelogTestData();
+  ASSERT_FALSE(batches.empty());
+
+  auto outputDirectory = test::TempDirectoryPath::create();
+  auto dataSink =
+      createDataSinkAndAppendData(batches, outputDirectory->getPath(), {});
+  dataSink->close();
+
+  std::string dataFilePath = getDataFilePath(outputDirectory->getPath());
+
+  auto changelogSplit =
+      makeChangelogSplit(dataFilePath, ChangelogOperation::INSERT, 1, 12345);
+
+  auto dataRowType = ROW({"id", "name"}, {BIGINT(), VARCHAR()});
+  auto changelogOutputType = createChangelogOutputType(dataRowType);
+  auto changelogColumnHandles = createChangelogColumnHandles(dataRowType);
+  auto tableHandle = createChangelogTableHandle(dataRowType);
+
+  // Filter on nested rowdata column: rowdata.id < 50
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(test::kIcebergConnectorId)
+                  .outputType(changelogOutputType)
+                  .tableHandle(tableHandle)
+                  .assignments(changelogColumnHandles)
+                  .endTableScan()
+                  .filter("rowdata.id < 50")
+                  .planNode();
+
+  auto resultVector =
+      AssertQueryBuilder(plan).split(changelogSplit).copyResults(pool());
+
+  ASSERT_TRUE(resultVector != nullptr);
+  ASSERT_GT(resultVector->size(), 0);
+  ASSERT_LT(resultVector->size(), kDefaultNumBatches * kDefaultRowsPerBatch);
+
+  // Verify all filtered rows have id < 50
+  auto rowdataVector = resultVector->childAt(3)->as<RowVector>();
+  ASSERT_NE(rowdataVector, nullptr);
+  auto idVector = rowdataVector->childAt(0)->as<SimpleVector<int64_t>>();
+
+  for (auto i = 0; i < resultVector->size(); i++) {
+    ASSERT_LT(idVector->valueAt(i), 50);
+  }
+}
+
+TEST_F(IcebergChangelogE2ETest, selectRowdataSubfieldsOnly) {
+  auto batches = createChangelogTestData();
+  ASSERT_FALSE(batches.empty());
+
+  auto outputDirectory = test::TempDirectoryPath::create();
+  auto dataSink =
+      createDataSinkAndAppendData(batches, outputDirectory->getPath(), {});
+  dataSink->close();
+
+  std::string dataFilePath = getDataFilePath(outputDirectory->getPath());
+
+  auto changelogSplit = makeChangelogSplit(
+      dataFilePath, ChangelogOperation::UPDATE_AFTER, 7, 54321);
+
+  auto dataRowType = ROW({"id", "name"}, {BIGINT(), VARCHAR()});
+  auto changelogOutputType = createChangelogOutputType(dataRowType);
+  auto changelogColumnHandles = createChangelogColumnHandles(dataRowType);
+  auto tableHandle = createChangelogTableHandle(dataRowType);
+
+  // Project only rowdata subfields (no metadata columns)
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(test::kIcebergConnectorId)
+                  .outputType(changelogOutputType)
+                  .tableHandle(tableHandle)
+                  .assignments(changelogColumnHandles)
+                  .endTableScan()
+                  .project({"rowdata.id", "rowdata.name"})
+                  .planNode();
+
+  auto resultVector =
+      AssertQueryBuilder(plan).split(changelogSplit).copyResults(pool());
+
+  ASSERT_TRUE(resultVector != nullptr);
+  ASSERT_EQ(resultVector->childrenSize(), 2);
+
+  int32_t expectedRows = 0;
+  for (const auto& batch : batches) {
+    expectedRows += batch->size();
+  }
+  ASSERT_EQ(resultVector->size(), expectedRows);
+
+  // Verify projected columns - only data columns, no metadata
+  auto rowType = std::dynamic_pointer_cast<const RowType>(resultVector->type());
+  ASSERT_EQ(rowType->nameOf(0), "id");
+  ASSERT_EQ(rowType->nameOf(1), "name");
+
+  // Verify data columns
+  auto idVector = resultVector->childAt(0)->as<SimpleVector<int64_t>>();
+  auto nameVector = resultVector->childAt(1)->as<SimpleVector<StringView>>();
+
+  for (auto i = 0; i < resultVector->size(); i++) {
+    ASSERT_FALSE(idVector->isNullAt(i));
+    ASSERT_FALSE(nameVector->isNullAt(i));
+    ASSERT_EQ(idVector->valueAt(i), i);
+    std::string expectedName = "name_" + std::to_string(i);
+    ASSERT_EQ(nameVector->valueAt(i), StringView(expectedName));
+  }
+}
+
+TEST_F(IcebergChangelogE2ETest, testAggregations) {
+  auto batches = createChangelogTestData();
+  ASSERT_FALSE(batches.empty());
+
+  auto outputDirectory = test::TempDirectoryPath::create();
+  auto dataSink =
+      createDataSinkAndAppendData(batches, outputDirectory->getPath(), {});
+  dataSink->close();
+
+  std::string dataFilePath = getDataFilePath(outputDirectory->getPath());
+
+  auto dataRowType = ROW({"id", "name"}, {BIGINT(), VARCHAR()});
+  auto changelogOutputType = createChangelogOutputType(dataRowType);
+  auto changelogColumnHandles = createChangelogColumnHandles(dataRowType);
+  auto tableHandle = createChangelogTableHandle(dataRowType);
+
+  int32_t expectedRowsPerSplit = 0;
+  for (const auto& batch : batches) {
+    expectedRowsPerSplit += batch->size();
+  }
+
+  // Test 1: Count all changelog records (count(*))
+  // Create fresh splits for this query
+  std::vector<std::shared_ptr<ConnectorSplit>> countSplits;
+  countSplits.push_back(
+      makeChangelogSplit(dataFilePath, ChangelogOperation::INSERT, 1, 100));
+  countSplits.push_back(
+      makeChangelogSplit(dataFilePath, ChangelogOperation::DELETE, 2, 100));
+  countSplits.push_back(makeChangelogSplit(
+      dataFilePath, ChangelogOperation::UPDATE_AFTER, 3, 200));
+
+  auto countPlan = PlanBuilder()
+                       .startTableScan()
+                       .connectorId(test::kIcebergConnectorId)
+                       .outputType(changelogOutputType)
+                       .tableHandle(tableHandle)
+                       .assignments(changelogColumnHandles)
+                       .endTableScan()
+                       .singleAggregation({}, {"count(1)"})
+                       .planNode();
+
+  auto countResult =
+      AssertQueryBuilder(countPlan).splits(countSplits).copyResults(pool());
+
+  ASSERT_TRUE(countResult != nullptr);
+  ASSERT_EQ(countResult->size(), 1);
+
+  int64_t expectedTotal = expectedRowsPerSplit * 3; // 3 splits
+  auto countVector = countResult->childAt(0)->as<SimpleVector<int64_t>>();
+  ASSERT_EQ(countVector->valueAt(0), expectedTotal);
+
+  // Test 2: Group by operation and count
+  // Create fresh splits for this query
+  std::vector<std::shared_ptr<ConnectorSplit>> groupBySplits;
+  groupBySplits.push_back(
+      makeChangelogSplit(dataFilePath, ChangelogOperation::INSERT, 1, 100));
+  groupBySplits.push_back(
+      makeChangelogSplit(dataFilePath, ChangelogOperation::DELETE, 2, 100));
+  groupBySplits.push_back(makeChangelogSplit(
+      dataFilePath, ChangelogOperation::UPDATE_AFTER, 3, 200));
+
+  auto groupByPlan = PlanBuilder()
+                         .startTableScan()
+                         .connectorId(test::kIcebergConnectorId)
+                         .outputType(changelogOutputType)
+                         .tableHandle(tableHandle)
+                         .assignments(changelogColumnHandles)
+                         .endTableScan()
+                         .singleAggregation({"operation"}, {"count(1)"})
+                         .planNode();
+
+  auto groupByResult =
+      AssertQueryBuilder(groupByPlan).splits(groupBySplits).copyResults(pool());
+
+  ASSERT_TRUE(groupByResult != nullptr);
+  ASSERT_EQ(groupByResult->size(), 3); // 3 different operations
+
+  // Verify each operation has the correct count
+  auto operationVector =
+      groupByResult->childAt(0)->as<SimpleVector<StringView>>();
+  auto groupCountVector =
+      groupByResult->childAt(1)->as<SimpleVector<int64_t>>();
+
+  std::unordered_map<std::string, int64_t> operationCounts;
+  for (auto i = 0; i < groupByResult->size(); i++) {
+    std::string op(
+        operationVector->valueAt(i).data(), operationVector->valueAt(i).size());
+    operationCounts[op] = groupCountVector->valueAt(i);
+  }
+
+  ASSERT_EQ(operationCounts["INSERT"], expectedRowsPerSplit);
+  ASSERT_EQ(operationCounts["DELETE"], expectedRowsPerSplit);
+  ASSERT_EQ(operationCounts["UPDATE_AFTER"], expectedRowsPerSplit);
+
+  // Test 3: Group by rowdata nested column (rowdata.id) and count
+  // Project the nested field first, then group by it
+  std::vector<std::shared_ptr<ConnectorSplit>> groupByNestedSplits;
+  groupByNestedSplits.push_back(
+      makeChangelogSplit(dataFilePath, ChangelogOperation::INSERT, 1, 100));
+
+  auto groupByNestedPlan = PlanBuilder()
+                               .startTableScan()
+                               .connectorId(test::kIcebergConnectorId)
+                               .outputType(changelogOutputType)
+                               .tableHandle(tableHandle)
+                               .assignments(changelogColumnHandles)
+                               .endTableScan()
+                               .project({"rowdata.id AS id"})
+                               .singleAggregation({"id"}, {"count(1)"})
+                               .planNode();
+
+  auto groupByNestedResult = AssertQueryBuilder(groupByNestedPlan)
+                                 .splits(groupByNestedSplits)
+                                 .copyResults(pool());
+
+  ASSERT_TRUE(groupByNestedResult != nullptr);
+  ASSERT_EQ(groupByNestedResult->size(), expectedRowsPerSplit);
+
+  // Verify each id has count of 1 (each id is unique)
+  auto idGroupVector =
+      groupByNestedResult->childAt(0)->as<SimpleVector<int64_t>>();
+  auto idCountVector =
+      groupByNestedResult->childAt(1)->as<SimpleVector<int64_t>>();
+
+  for (auto i = 0; i < groupByNestedResult->size(); i++) {
+    ASSERT_EQ(idCountVector->valueAt(i), 1);
+  }
+
+  // Test 4: Group by metadata column (operation) and aggregate rowdata
+  // Select operation (group by key) and aggregated rowdata
+  std::vector<std::shared_ptr<ConnectorSplit>> groupByMetadataSplits;
+  groupByMetadataSplits.push_back(
+      makeChangelogSplit(dataFilePath, ChangelogOperation::INSERT, 1, 100));
+  groupByMetadataSplits.push_back(
+      makeChangelogSplit(dataFilePath, ChangelogOperation::DELETE, 2, 100));
+
+  auto groupByMetadataPlan =
+      PlanBuilder()
+          .startTableScan()
+          .connectorId(test::kIcebergConnectorId)
+          .outputType(changelogOutputType)
+          .tableHandle(tableHandle)
+          .assignments(changelogColumnHandles)
+          .endTableScan()
+          .singleAggregation({"operation"}, {"count(rowdata)"})
+          .planNode();
+
+  auto groupByMetadataResult = AssertQueryBuilder(groupByMetadataPlan)
+                                   .splits(groupByMetadataSplits)
+                                   .copyResults(pool());
+
+  ASSERT_TRUE(groupByMetadataResult != nullptr);
+  ASSERT_EQ(groupByMetadataResult->size(), 2); // 2 different operations
+
+  // Verify we got operation (group key) and count of rowdata
+  auto opGroupVector =
+      groupByMetadataResult->childAt(0)->as<SimpleVector<StringView>>();
+  auto rowdataCountVector =
+      groupByMetadataResult->childAt(1)->as<SimpleVector<int64_t>>();
+
+  std::unordered_map<std::string, int64_t> operationRowdataCounts;
+  for (auto i = 0; i < groupByMetadataResult->size(); i++) {
+    std::string op(
+        opGroupVector->valueAt(i).data(), opGroupVector->valueAt(i).size());
+    operationRowdataCounts[op] = rowdataCountVector->valueAt(i);
+  }
+
+  // Each operation should have expectedRowsPerSplit rows
+  ASSERT_EQ(operationRowdataCounts["INSERT"], expectedRowsPerSplit);
+  ASSERT_EQ(operationRowdataCounts["DELETE"], expectedRowsPerSplit);
+}
+
+TEST_F(IcebergChangelogE2ETest, orderAndGroup) {
+  auto batches = createChangelogTestData();
+  ASSERT_FALSE(batches.empty());
+
+  auto outputDirectory = test::TempDirectoryPath::create();
+  auto dataSink =
+      createDataSinkAndAppendData(batches, outputDirectory->getPath(), {});
+  dataSink->close();
+
+  std::string dataFilePath = getDataFilePath(outputDirectory->getPath());
+
+  auto dataRowType = ROW({"id", "name"}, {BIGINT(), VARCHAR()});
+  auto changelogOutputType = createChangelogOutputType(dataRowType);
+  auto changelogColumnHandles = createChangelogColumnHandles(dataRowType);
+  auto tableHandle = createChangelogTableHandle(dataRowType);
+
+  int32_t expectedRowsPerSplit = 0;
+  for (const auto& batch : batches) {
+    expectedRowsPerSplit += batch->size();
+  }
+
+  // Test 1: Order by ordinal ascending
+  // Create fresh splits for this query
+  std::vector<std::shared_ptr<ConnectorSplit>> orderBySplits;
+  orderBySplits.push_back(
+      makeChangelogSplit(dataFilePath, ChangelogOperation::INSERT, 3, 300));
+  orderBySplits.push_back(
+      makeChangelogSplit(dataFilePath, ChangelogOperation::DELETE, 1, 100));
+  orderBySplits.push_back(makeChangelogSplit(
+      dataFilePath, ChangelogOperation::UPDATE_AFTER, 2, 200));
+
+  auto orderByPlan = PlanBuilder()
+                         .startTableScan()
+                         .connectorId(test::kIcebergConnectorId)
+                         .outputType(changelogOutputType)
+                         .tableHandle(tableHandle)
+                         .assignments(changelogColumnHandles)
+                         .endTableScan()
+                         .orderBy({"ordinal ASC"}, false)
+                         .planNode();
+
+  auto orderByResult =
+      AssertQueryBuilder(orderByPlan).splits(orderBySplits).copyResults(pool());
+
+  ASSERT_TRUE(orderByResult != nullptr);
+  ASSERT_EQ(orderByResult->size(), expectedRowsPerSplit * 3);
+
+  // Verify ordering: first expectedRowsPerSplit rows should have ordinal=1,
+  // next should have ordinal=2, last should have ordinal=3
+  auto ordinalVector = orderByResult->childAt(1)->as<SimpleVector<int64_t>>();
+
+  for (auto i = 0; i < expectedRowsPerSplit; i++) {
+    ASSERT_EQ(ordinalVector->valueAt(i), 1);
+  }
+  for (auto i = expectedRowsPerSplit; i < expectedRowsPerSplit * 2; i++) {
+    ASSERT_EQ(ordinalVector->valueAt(i), 2);
+  }
+  for (auto i = expectedRowsPerSplit * 2; i < expectedRowsPerSplit * 3; i++) {
+    ASSERT_EQ(ordinalVector->valueAt(i), 3);
+  }
+
+  // Test 2: Group by snapshotid, count, and order by snapshotid
+  // Create fresh splits for this query
+  std::vector<std::shared_ptr<ConnectorSplit>> groupByOrderBySplits;
+  groupByOrderBySplits.push_back(
+      makeChangelogSplit(dataFilePath, ChangelogOperation::INSERT, 3, 300));
+  groupByOrderBySplits.push_back(
+      makeChangelogSplit(dataFilePath, ChangelogOperation::DELETE, 1, 100));
+  groupByOrderBySplits.push_back(makeChangelogSplit(
+      dataFilePath, ChangelogOperation::UPDATE_AFTER, 2, 200));
+
+  auto groupByOrderByPlan = PlanBuilder()
+                                .startTableScan()
+                                .connectorId(test::kIcebergConnectorId)
+                                .outputType(changelogOutputType)
+                                .tableHandle(tableHandle)
+                                .assignments(changelogColumnHandles)
+                                .endTableScan()
+                                .singleAggregation({"snapshotid"}, {"count(1)"})
+                                .orderBy({"snapshotid ASC"}, false)
+                                .planNode();
+
+  auto groupByOrderByResult = AssertQueryBuilder(groupByOrderByPlan)
+                                  .splits(groupByOrderBySplits)
+                                  .copyResults(pool());
+
+  ASSERT_TRUE(groupByOrderByResult != nullptr);
+  ASSERT_EQ(groupByOrderByResult->size(), 3); // 3 different snapshot IDs
+
+  // Verify results are ordered by snapshotid
+  auto snapshotVector =
+      groupByOrderByResult->childAt(0)->as<SimpleVector<int64_t>>();
+  auto countVector =
+      groupByOrderByResult->childAt(1)->as<SimpleVector<int64_t>>();
+
+  ASSERT_EQ(snapshotVector->valueAt(0), 100);
+  ASSERT_EQ(countVector->valueAt(0), expectedRowsPerSplit);
+
+  ASSERT_EQ(snapshotVector->valueAt(1), 200);
+  ASSERT_EQ(countVector->valueAt(1), expectedRowsPerSplit);
+
+  ASSERT_EQ(snapshotVector->valueAt(2), 300);
+  ASSERT_EQ(countVector->valueAt(2), expectedRowsPerSplit);
+
+  // Test 3: Order by metadata column (ordinal) but select only rowdata
+  std::vector<std::shared_ptr<ConnectorSplit>> orderByMetadataSplits;
+  orderByMetadataSplits.push_back(
+      makeChangelogSplit(dataFilePath, ChangelogOperation::INSERT, 3, 300));
+  orderByMetadataSplits.push_back(
+      makeChangelogSplit(dataFilePath, ChangelogOperation::DELETE, 1, 100));
+  orderByMetadataSplits.push_back(makeChangelogSplit(
+      dataFilePath, ChangelogOperation::UPDATE_AFTER, 2, 200));
+
+  auto orderByMetadataPlan = PlanBuilder()
+                                 .startTableScan()
+                                 .connectorId(test::kIcebergConnectorId)
+                                 .outputType(changelogOutputType)
+                                 .tableHandle(tableHandle)
+                                 .assignments(changelogColumnHandles)
+                                 .endTableScan()
+                                 .orderBy({"ordinal ASC"}, false)
+                                 .project({"rowdata"})
+                                 .planNode();
+
+  auto orderByMetadataResult = AssertQueryBuilder(orderByMetadataPlan)
+                                   .splits(orderByMetadataSplits)
+                                   .copyResults(pool());
+
+  ASSERT_TRUE(orderByMetadataResult != nullptr);
+  ASSERT_EQ(orderByMetadataResult->size(), expectedRowsPerSplit * 3);
+  ASSERT_EQ(orderByMetadataResult->childrenSize(), 1); // Only rowdata
+
+  // Verify we got rowdata (ordered by ordinal, but ordinal not in output)
+  auto orderedRowdata = orderByMetadataResult->childAt(0)->as<RowVector>();
+  ASSERT_NE(orderedRowdata, nullptr);
+  ASSERT_EQ(orderedRowdata->childrenSize(), 2); // id and name
+
+  // Test 4: Order by rowdata subfield (rowdata.id) and select only metadata
+  // Project the field first, then order by it, then project only metadata
+  std::vector<std::shared_ptr<ConnectorSplit>> orderByRowdataSplits;
+  orderByRowdataSplits.push_back(
+      makeChangelogSplit(dataFilePath, ChangelogOperation::INSERT, 1, 100));
+
+  auto orderByRowdataPlan =
+      PlanBuilder()
+          .startTableScan()
+          .connectorId(test::kIcebergConnectorId)
+          .outputType(changelogOutputType)
+          .tableHandle(tableHandle)
+          .assignments(changelogColumnHandles)
+          .endTableScan()
+          .project({"operation", "ordinal", "snapshotid", "rowdata.id AS id"})
+          .orderBy({"id ASC"}, false)
+          .project({"operation", "ordinal", "snapshotid"})
+          .planNode();
+
+  auto orderByRowdataResult = AssertQueryBuilder(orderByRowdataPlan)
+                                  .splits(orderByRowdataSplits)
+                                  .copyResults(pool());
+
+  ASSERT_TRUE(orderByRowdataResult != nullptr);
+  ASSERT_EQ(orderByRowdataResult->size(), expectedRowsPerSplit);
+  ASSERT_EQ(orderByRowdataResult->childrenSize(), 3); // Only metadata columns
+
+  // Verify we got metadata columns (ordered by rowdata.id, but id not in
+  // output)
+  auto orderedOpVector =
+      orderByRowdataResult->childAt(0)->as<SimpleVector<StringView>>();
+  auto orderedOrdinalVector =
+      orderByRowdataResult->childAt(1)->as<SimpleVector<int64_t>>();
+  auto orderedSnapshotVector =
+      orderByRowdataResult->childAt(2)->as<SimpleVector<int64_t>>();
+
+  // All rows should have same metadata since they're from same split
+  for (auto i = 0; i < orderByRowdataResult->size(); i++) {
+    ASSERT_EQ(orderedOpVector->valueAt(i), StringView("INSERT"));
+    ASSERT_EQ(orderedOrdinalVector->valueAt(i), 1);
+    ASSERT_EQ(orderedSnapshotVector->valueAt(i), 100);
+  }
+}
+
+} // namespace
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/tests/IcebergChangelogSplitReaderTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergChangelogSplitReaderTest.cpp
@@ -1,0 +1,359 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/IcebergChangelogSplitReader.h"
+#include "velox/connectors/hive/FileHandle.h"
+#include "velox/connectors/hive/HiveConnectorUtil.h"
+#include "velox/connectors/hive/iceberg/IcebergSplit.h"
+#include "velox/connectors/hive/iceberg/tests/IcebergTestBase.h"
+#include "velox/vector/BaseVector.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+namespace {
+
+class IcebergChangelogSplitReaderIntegrationTest
+    : public test::IcebergTestBase {
+ protected:
+  std::vector<RowVectorPtr> makeTestBatches() {
+    std::vector<RowVectorPtr> batches;
+    for (int32_t batch = 0; batch < 2; ++batch) {
+      auto idVector = makeFlatVector<int64_t>(100, [batch](auto row) {
+        return static_cast<int64_t>(batch * 100 + row);
+      });
+      auto nameVector = makeFlatVector<std::string>(100, [batch](auto row) {
+        return "name_" + std::to_string(batch * 100 + row);
+      });
+      batches.push_back(makeRowVector({"id", "name"}, {idVector, nameVector}));
+    }
+    return batches;
+  }
+
+  std::string getOnlyDataFilePath(const std::string& directory) {
+    auto files = listFiles(directory);
+    VELOX_CHECK_EQ(files.size(), 1);
+    return files.front();
+  }
+
+  std::shared_ptr<HiveIcebergSplit> makeChangelogSplit(
+      const std::string& filePath,
+      ChangelogOperation operation,
+      int64_t ordinal,
+      int64_t snapshotId) {
+    auto changelogInfo =
+        std::make_shared<ChangelogSplitInfo>(operation, ordinal, snapshotId);
+    auto splits = makeIcebergSplits(filePath);
+    VELOX_CHECK_EQ(splits.size(), 1);
+
+    auto split = std::dynamic_pointer_cast<HiveIcebergSplit>(splits.front());
+    VELOX_CHECK_NOT_NULL(split);
+    split->changelogSplitInfo = std::move(changelogInfo);
+    return split;
+  }
+
+  RowTypePtr makeChangelogOutputType(const RowTypePtr& dataType) {
+    return ROW(
+        {"operation", "ordinal", "snapshotid", "rowdata"},
+        {VARCHAR(), BIGINT(), BIGINT(), dataType});
+  }
+
+  ColumnHandleMap makeChangelogColumnHandles(const RowTypePtr& dataType) {
+    ColumnHandleMap handles;
+    handles["operation"] = std::make_shared<HiveColumnHandle>(
+        "operation",
+        HiveColumnHandle::ColumnType::kRegular,
+        VARCHAR(),
+        VARCHAR());
+    handles["ordinal"] = std::make_shared<HiveColumnHandle>(
+        "ordinal", HiveColumnHandle::ColumnType::kRegular, BIGINT(), BIGINT());
+    handles["snapshotid"] = std::make_shared<HiveColumnHandle>(
+        "snapshotid",
+        HiveColumnHandle::ColumnType::kRegular,
+        BIGINT(),
+        BIGINT());
+    handles["rowdata"] = std::make_shared<HiveColumnHandle>(
+        "rowdata", HiveColumnHandle::ColumnType::kRegular, dataType, dataType);
+    return handles;
+  }
+
+  std::shared_ptr<HiveTableHandle> makeChangelogTableHandle(
+      const RowTypePtr& dataType) {
+    return std::make_shared<HiveTableHandle>(
+        test::kIcebergConnectorId,
+        "test_table",
+        common::SubfieldFilters{},
+        nullptr,
+        dataType,
+        std::vector<std::string>{},
+        std::unordered_map<std::string, std::string>{},
+        std::vector<HiveColumnHandlePtr>{},
+        1.0,
+        "",
+        true,
+        makeColumnHandles(dataType));
+  }
+
+  std::unique_ptr<IcebergChangelogSplitReader> makeChangelogSplitReader(
+      const std::shared_ptr<HiveIcebergSplit>& split,
+      const RowTypePtr& dataType,
+      const RowTypePtr& changelogOutputType,
+      ColumnHandleMap changelogColumnHandles,
+      const common::SubfieldFilters* changelogFilters = nullptr) {
+    auto sessionProperties = std::make_shared<config::ConfigBase>(
+        std::unordered_map<std::string, std::string>());
+    auto hiveConfig = std::make_shared<HiveConfig>(sessionProperties);
+    fileHandleFactory_ = std::make_unique<FileHandleFactory>(
+        std::make_unique<SimpleLRUCache<FileHandleKey, FileHandle>>(
+            hiveConfig->numCacheFileHandles()),
+        std::make_unique<FileHandleGenerator>(sessionProperties));
+
+    return std::make_unique<IcebergChangelogSplitReader>(
+        split,
+        makeChangelogTableHandle(dataType),
+        nullptr,
+        connectorQueryCtx_.get(),
+        hiveConfig,
+        dataType,
+        ioStats_,
+        metadataIoStats_,
+        connectorIoStats_,
+        fileHandleFactory_.get(),
+        nullptr,
+        makeScanSpec(
+            dataType,
+            {},
+            {},
+            dataType,
+            {},
+            {},
+            SpecialColumnNames{},
+            false,
+            pool()),
+        std::make_shared<ColumnHandleMap>(makeColumnHandles(dataType)),
+        changelogOutputType,
+        std::move(changelogColumnHandles),
+        changelogFilters);
+  }
+
+  RowVectorPtr readAll(IcebergChangelogSplitReader& reader) {
+    dwio::common::RuntimeStatistics runtimeStats;
+    std::shared_ptr<random::RandomSkipTracker> randomSkip;
+    reader.configureReaderOptions(randomSkip);
+    reader.prepareSplit(nullptr, runtimeStats);
+    if (reader.emptySplit()) {
+      return nullptr;
+    }
+
+    std::vector<RowVectorPtr> batches;
+    VectorPtr output;
+    while (reader.next(1024, output) > 0) {
+      batches.push_back(std::dynamic_pointer_cast<RowVector>(output));
+    }
+
+    if (batches.empty()) {
+      return nullptr;
+    }
+
+    auto result = std::dynamic_pointer_cast<RowVector>(
+        BaseVector::create(batches[0]->type(), 0, pool()));
+    for (const auto& batch : batches) {
+      result->append(batch.get());
+    }
+    return result;
+  }
+
+  std::shared_ptr<io::IoStatistics> ioStats_{
+      std::make_shared<io::IoStatistics>()};
+  std::shared_ptr<io::IoStatistics> metadataIoStats_{
+      std::make_shared<io::IoStatistics>()};
+  std::shared_ptr<IoStats> connectorIoStats_{std::make_shared<IoStats>()};
+  std::unique_ptr<FileHandleFactory> fileHandleFactory_;
+};
+
+TEST_F(IcebergChangelogSplitReaderIntegrationTest, testChangelogSplitData) {
+  auto dataType = ROW({"id", "name"}, {BIGINT(), VARCHAR()});
+  const std::vector<
+      std::tuple<ChangelogOperation, std::string, int64_t, int64_t>>
+      cases = {
+          {ChangelogOperation::INSERT, "INSERT", 1, 1},
+          {ChangelogOperation::DELETE, "DELETE", 1, 1},
+          {ChangelogOperation::UPDATE_BEFORE, "UPDATE_BEFORE", 1, 1},
+          {ChangelogOperation::UPDATE_AFTER, "UPDATE_AFTER", 7, 12345},
+      };
+
+  auto batches = makeTestBatches();
+  auto outputDirectory = test::TempDirectoryPath::create();
+  auto sink =
+      createDataSinkAndAppendData(batches, outputDirectory->getPath(), {});
+  sink->close();
+
+  const auto filePath = getOnlyDataFilePath(outputDirectory->getPath());
+
+  for (
+      const auto& [operationValue, expectedOperation, ordinalValue, snapshotIdValue] :
+      cases) {
+    auto reader = makeChangelogSplitReader(
+        makeChangelogSplit(
+            filePath, operationValue, ordinalValue, snapshotIdValue),
+        dataType,
+        makeChangelogOutputType(dataType),
+        makeChangelogColumnHandles(dataType));
+
+    auto result = readAll(*reader);
+    ASSERT_NE(result, nullptr) << "op=" << expectedOperation;
+    ASSERT_EQ(result->size(), 200) << "op=" << expectedOperation;
+
+    auto operation = result->childAt(0)->as<SimpleVector<StringView>>();
+    auto ordinal = result->childAt(1)->as<SimpleVector<int64_t>>();
+    auto snapshotId = result->childAt(2)->as<SimpleVector<int64_t>>();
+    auto rowdata = result->childAt(3)->as<RowVector>();
+    auto ids = rowdata->childAt(0)->as<SimpleVector<int64_t>>();
+    auto names = rowdata->childAt(1)->as<SimpleVector<StringView>>();
+
+    for (int32_t row = 0; row < result->size(); ++row) {
+      ASSERT_EQ(operation->valueAt(row), StringView(expectedOperation));
+      ASSERT_EQ(ordinal->valueAt(row), ordinalValue);
+      ASSERT_EQ(snapshotId->valueAt(row), snapshotIdValue);
+      ASSERT_EQ(ids->valueAt(row), row);
+      const std::string expectedName = "name_" + std::to_string(row);
+      ASSERT_EQ(names->valueAt(row), StringView(expectedName));
+    }
+  }
+}
+
+TEST_F(IcebergChangelogSplitReaderIntegrationTest, testReaderOutputType) {
+  auto dataType = ROW({"x", "y", "z"}, {BIGINT(), INTEGER(), VARCHAR()});
+  auto changelogOutputType = makeChangelogOutputType(dataType);
+  auto batch = makeRowVector(
+      {"x", "y", "z"},
+      {makeFlatVector<int64_t>({1, 2, 3}),
+       makeFlatVector<int32_t>({10, 20, 30}),
+       makeFlatVector<std::string>({"a", "b", "c"})});
+
+  auto outputDirectory = test::TempDirectoryPath::create();
+  auto sink =
+      createDataSinkAndAppendData({batch}, outputDirectory->getPath(), {});
+  sink->close();
+
+  auto reader = makeChangelogSplitReader(
+      makeChangelogSplit(
+          getOnlyDataFilePath(outputDirectory->getPath()),
+          ChangelogOperation::INSERT,
+          1,
+          100),
+      dataType,
+      changelogOutputType,
+      makeChangelogColumnHandles(dataType));
+
+  const auto& reported = reader->readerOutputType();
+  ASSERT_EQ(reported->size(), 4);
+  ASSERT_EQ(reported->nameOf(0), "operation");
+  ASSERT_EQ(reported->childAt(0)->kind(), TypeKind::VARCHAR);
+  ASSERT_EQ(reported->nameOf(1), "ordinal");
+  ASSERT_EQ(reported->childAt(1)->kind(), TypeKind::BIGINT);
+  ASSERT_EQ(reported->nameOf(2), "snapshotid");
+  ASSERT_EQ(reported->childAt(2)->kind(), TypeKind::BIGINT);
+  ASSERT_EQ(reported->nameOf(3), "rowdata");
+  ASSERT_EQ(reported->childAt(3)->kind(), TypeKind::ROW);
+
+  auto result = readAll(*reader);
+  ASSERT_NE(result, nullptr);
+  ASSERT_EQ(result->size(), 3);
+
+  auto rowdata = result->childAt(3)->as<RowVector>();
+  ASSERT_NE(rowdata, nullptr);
+  ASSERT_EQ(rowdata->childrenSize(), 3);
+  const auto& rowdataType =
+      *std::dynamic_pointer_cast<const RowType>(rowdata->type());
+  ASSERT_EQ(rowdataType.nameOf(0), "x");
+  ASSERT_EQ(rowdataType.nameOf(1), "y");
+  ASSERT_EQ(rowdataType.nameOf(2), "z");
+}
+
+TEST_F(IcebergChangelogSplitReaderIntegrationTest, testFiltersRejects) {
+  auto batches = makeTestBatches();
+  auto outputDirectory = test::TempDirectoryPath::create();
+  auto sink =
+      createDataSinkAndAppendData(batches, outputDirectory->getPath(), {});
+  sink->close();
+
+  const auto filePath = getOnlyDataFilePath(outputDirectory->getPath());
+  auto dataType = ROW({"id", "name"}, {BIGINT(), VARCHAR()});
+
+  common::SubfieldFilters filters;
+  filters[common::Subfield("snapshotid")] =
+      std::make_shared<common::BigintRange>(999, 999, false);
+
+  auto reader = makeChangelogSplitReader(
+      makeChangelogSplit(filePath, ChangelogOperation::INSERT, 1, 100),
+      dataType,
+      makeChangelogOutputType(dataType),
+      makeChangelogColumnHandles(dataType),
+      &filters);
+
+  auto result = readAll(*reader);
+  ASSERT_EQ(result, nullptr);
+}
+
+TEST_F(IcebergChangelogSplitReaderIntegrationTest, testFilterAccepts) {
+  auto batches = makeTestBatches();
+  auto outputDirectory = test::TempDirectoryPath::create();
+  auto sink =
+      createDataSinkAndAppendData(batches, outputDirectory->getPath(), {});
+  sink->close();
+
+  const auto filePath = getOnlyDataFilePath(outputDirectory->getPath());
+  auto dataType = ROW({"id", "name"}, {BIGINT(), VARCHAR()});
+
+  common::SubfieldFilters filters;
+  filters[common::Subfield("snapshotid")] =
+      std::make_shared<common::BigintRange>(100, 100, false);
+
+  auto reader = makeChangelogSplitReader(
+      makeChangelogSplit(filePath, ChangelogOperation::INSERT, 1, 100),
+      dataType,
+      makeChangelogOutputType(dataType),
+      makeChangelogColumnHandles(dataType),
+      &filters);
+
+  auto result = readAll(*reader);
+  ASSERT_NE(result, nullptr);
+  ASSERT_EQ(result->size(), 200);
+}
+
+TEST_F(IcebergChangelogSplitReaderIntegrationTest, nextDrainsAllBatches) {
+  auto batches = makeTestBatches();
+  auto outputDirectory = test::TempDirectoryPath::create();
+  auto sink =
+      createDataSinkAndAppendData(batches, outputDirectory->getPath(), {});
+  sink->close();
+
+  auto reader = makeChangelogSplitReader(
+      makeChangelogSplit(
+          getOnlyDataFilePath(outputDirectory->getPath()),
+          ChangelogOperation::DELETE,
+          3,
+          42),
+      ROW({"id", "name"}, {BIGINT(), VARCHAR()}),
+      makeChangelogOutputType(ROW({"id", "name"}, {BIGINT(), VARCHAR()})),
+      makeChangelogColumnHandles(ROW({"id", "name"}, {BIGINT(), VARCHAR()})));
+
+  auto result = readAll(*reader);
+  ASSERT_NE(result, nullptr);
+  ASSERT_EQ(result->size(), 200);
+}
+
+} // namespace
+} // namespace facebook::velox::connector::hive::iceberg


### PR DESCRIPTION
## Summary

This change adds native Iceberg changelog read support to Presto Native / Velox.
Iceberg changelog queries expose rows in the shape:

- `operation`
- `ordinal`
- `snapshotid`
- `rowdata`

The implementation adds support for reading those splits in Velox while reusing the existing Iceberg split reader.

## Design

### New changelog split metadata

Added `ChangelogSplitInfo` in `IcebergChangelogSplitInfo.h `and attached it to `HiveIcebergSplit` `in IcebergSplit.h`.

This carries:

- changelog operation
- ordinal
- snapshot id

### New reader: `IcebergChangelogSplitReader`

Introduced `IcebergChangelogSplitReader` in `IcebergChangelogSplitReader.h`, a subclass of `IcebergSplitReader`

It adds changelog-specific behavior in three places:

- `readerOutputType()` :  returns changelog output schema instead of base-table schema
- `prepareSplit()` : evaluates split-level changelog metadata filters before file I/O
- `next()` : reads base-table rows through the parent reader, then reshapes them into:
  - constant `operation`
  - constant `ordinal`
  - constant `snapshotid`
  - `rowdata` wrapping the underlying data batch

This keeps the actual file read path fully delegated to the existing Iceberg reader.

### Data source integration

`IcebergDataSource::createSplitReader()` now detects changelog queries using `HiveTableHandle::isChangelogQuery()`.

For changelog scans it:

- builds a base-table `readerOutputType`
- builds a data-scoped `ScanSpec`
- instantiates `IcebergChangelogSplitReader`

For regular scans it continues to instantiate `IcebergSplitReader

### Table handle extensions

`HiveTableHandle` was extended with:

- `isChangelogQuery()`
- `getDataColumnHandles()`

This allows changelog scans to preserve the physical base data column handles needed by the underlying Iceberg reader.

## Filter behavior

Split-level filtering is supported for changelog metadata columns:

- `operation`
- `ordinal`
- `snapshotid`

These are evaluated in `applyChangelogFilters()` during `prepareSplit()`. If a filter rejects the split, the split is marked empty and no data file is opened. These filters are intentionally **not** passed into `makeScanSpec()`, because they are not physical columns in the data file schema.

## Testing

Coverage was added at multiple levels:

- `IcebergChangelogSplitReaderTest.cpp`
  - reader-level coverage for output shaping and split filter behavior
- `IcebergChangelogE2ETest.cpp`
  - end-to-end query coverage for changelog scans

## Why this approach

This design keeps the change surface minimal:

- no separate changelog data source hierarchy
- reuse of existing Iceberg row reading behavior and the existing filter application logic in FileDataSource
- changelog logic isolated to split metadata handling and output reshaping

**NOTE:** Changes to Java IcebergTableLayoutHandle and protocol will be made to pass the dataColumnHandles.