### PR TITLE
fix(build): Additional Apple toolchain fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -728,6 +728,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
   # Explicitly enable folly coroutines when compiler supports them.
   # This is required for folly::coro::AsyncGenerator to work correctly.
   add_compile_definitions(FOLLY_HAS_COROUTINES=1)
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "AppleClang")
+  # Handle Apple toolchain Clang change of name of variable.
+  # Remove when upgrading to the latest FBOS version where this has been addressed.
+  add_compile_options(-D_LIBCPP_HAS_NO_ASAN)
 endif()
 
 if(VELOX_BUILD_TESTING AND NOT VELOX_ENABLE_DUCKDB)

--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -236,7 +236,12 @@ function install_arrow {
 
     cd "$DEPENDENCY_DIR"/arrow || exit 1
     for patch in $VELOX_ARROW_CMAKE_PATCH; do
-      git apply "$patch" || exit 1
+      # Try patch command first (handles line number offsets), fall back to git apply
+      if command -v patch >/dev/null 2>&1; then
+        patch -p1 -i "$patch" || exit 1
+      else
+        git apply "$patch" || exit 1
+      fi
     done
     # Presto needs this for Arrow Flight
     if [[ -n $EXTRA_ARROW_PATCH ]]; then

--- a/velox/common/base/CMakeLists.txt
+++ b/velox/common/base/CMakeLists.txt
@@ -26,6 +26,7 @@ velox_link_libraries(
   PUBLIC velox_flag_definitions velox_process Folly::folly fmt::fmt gflags::gflags glog::glog
 )
 
+include_directories(${FLEX_INCLUDE_DIRS})
 velox_add_library(
   velox_common_base
   AdmissionController.cpp


### PR DESCRIPTION
This fixes a problem with the Apple Clang toolchain identified in issue https://github.com/facebookincubator/velox/issues/17537.
- Fix sanitzer flag inclusion previously fixed for FBThrift but now also included in Velox
- Fix missing Flex include directory to make sure we pick the right Flex headers for the shim
- Fix git not applying the arrow testing patch reliably on all macOS environments