### PR TITLE
feat(cudf): Add GPU TopNRowNumber operator with tests

### DIFF
--- a/velox/experimental/cudf/exec/CMakeLists.txt
+++ b/velox/experimental/cudf/exec/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(
   CudfOrderBy.cpp
   CudfReduce.cpp
   CudfTopN.cpp
+  CudfTopNRowNumber.cpp
   CudfWindow.cpp
   DebugUtil.cpp
   DecimalAggregationDevice.cu

--- a/velox/experimental/cudf/exec/CudfTopNRowNumber.cpp
+++ b/velox/experimental/cudf/exec/CudfTopNRowNumber.cpp
@@ -203,9 +203,8 @@ RowVectorPtr CudfTopNRowNumber::doGetOutput() {
         stream,
         mr);
     // cuDF row_number is int32; Velox expects bigint.
-    const auto rowNumberCudfType = cudf::data_type(
-        cudf_velox::veloxToCudfTypeId(
-            outputType_->childAt(outputType_->size() - 1)));
+    const auto rowNumberCudfType = cudf_velox::veloxToCudfDataType(
+        outputType_->childAt(outputType_->size() - 1));
     if (filtRowNums->type() != rowNumberCudfType) {
       filtRowNums = cudf::cast(*filtRowNums, rowNumberCudfType, stream, mr);
     }

--- a/velox/experimental/cudf/exec/CudfTopNRowNumber.cpp
+++ b/velox/experimental/cudf/exec/CudfTopNRowNumber.cpp
@@ -23,6 +23,8 @@
 #include <cudf/binaryop.hpp>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/copying.hpp>
+#include <cudf/detail/utilities/stream_pool.hpp>
+#include <cudf/merge.hpp>
 #include <cudf/rolling.hpp>
 #include <cudf/sorting.hpp>
 #include <cudf/stream_compaction.hpp>
@@ -47,6 +49,44 @@ cudf::table_view makePartitionKeys(
   return cudf::table_view{{singlePartitionCol->view()}};
 }
 
+// Computes row_number() over `view` grouped by the columns at
+// `partitionKeyIndices` (or a single implicit partition if empty), assuming
+// `view` is already sorted by partition+ordering keys. The value column fed
+// to grouped_rolling_window is arbitrary (row_number ignores it); column(0)
+// is used for convenience.
+std::unique_ptr<cudf::column> computeRowNumbers(
+    cudf::table_view view,
+    const std::vector<cudf::size_type>& partitionKeyIndices,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  std::unique_ptr<cudf::column> singlePartitionCol;
+  auto partKeys = makePartitionKeys(
+      view, partitionKeyIndices, stream, mr, singlePartitionCol);
+  auto firstCol = view.column(0);
+  auto rowNumberAgg =
+      cudf::make_row_number_aggregation<cudf::rolling_aggregation>();
+  auto unbounded = cudf::window_bounds::unbounded();
+  auto currentRow = cudf::window_bounds::get(0);
+  return cudf::grouped_rolling_window(
+      partKeys, firstCol, unbounded, currentRow, 1, *rowNumberAgg, stream, mr);
+}
+
+// Filters `rowNums` to <= limit and returns the resulting boolean mask.
+std::unique_ptr<cudf::column> makeLimitMask(
+    const cudf::column& rowNums,
+    int32_t limit,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  auto limitScalar = cudf::numeric_scalar<int64_t>(limit, true, stream, mr);
+  return cudf::binary_operation(
+      rowNums.view(),
+      limitScalar,
+      cudf::binary_operator::LESS_EQUAL,
+      cudf::data_type(cudf::type_id::BOOL8),
+      stream,
+      mr);
+}
+
 } // namespace
 
 CudfTopNRowNumber::CudfTopNRowNumber(
@@ -65,16 +105,17 @@ CudfTopNRowNumber::CudfTopNRowNumber(
           node),
       node_(node),
       limit_(node->limit()),
-      generateRowNumber_(node->generateRowNumber()) {
+      generateRowNumber_(node->generateRowNumber()),
+      inputType_(node->sources()[0]->outputType()),
+      cudaEvent_(std::make_unique<CudaEvent>(cudaEventDisableTiming)) {
   VELOX_CHECK_EQ(
       node->rankFunction(),
       core::TopNRowNumberNode::RankFunction::kRowNumber,
       "CudfTopNRowNumber only supports row_number");
 
-  const auto inputType = node->sources()[0]->outputType();
   partitionKeyIndices_.reserve(node->partitionKeys().size());
   for (const auto& key : node->partitionKeys()) {
-    partitionKeyIndices_.push_back(exec::exprToChannel(key.get(), inputType));
+    partitionKeyIndices_.push_back(exec::exprToChannel(key.get(), inputType_));
   }
 
   sortKeyIndices_.reserve(node->sortingKeys().size());
@@ -82,7 +123,7 @@ CudfTopNRowNumber::CudfTopNRowNumber(
   nullOrders_.reserve(node->sortingKeys().size());
   for (size_t i = 0; i < node->sortingKeys().size(); ++i) {
     sortKeyIndices_.push_back(
-        exec::exprToChannel(node->sortingKeys()[i].get(), inputType));
+        exec::exprToChannel(node->sortingKeys()[i].get(), inputType_));
     const auto& order = node->sortingOrders()[i];
     sortOrders_.push_back(
         order.isAscending() ? cudf::order::ASCENDING : cudf::order::DESCENDING);
@@ -91,20 +132,122 @@ CudfTopNRowNumber::CudfTopNRowNumber(
             ? cudf::null_order::BEFORE
             : cudf::null_order::AFTER);
   }
+
+  allSortKeys_.reserve(partitionKeyIndices_.size() + sortKeyIndices_.size());
+  allOrders_.reserve(partitionKeyIndices_.size() + sortKeyIndices_.size());
+  allNullOrders_.reserve(partitionKeyIndices_.size() + sortKeyIndices_.size());
+  localPartitionKeyIndices_.reserve(partitionKeyIndices_.size());
+
+  for (size_t i = 0; i < partitionKeyIndices_.size(); ++i) {
+    allSortKeys_.push_back(partitionKeyIndices_[i]);
+    allOrders_.push_back(cudf::order::ASCENDING);
+    allNullOrders_.push_back(cudf::null_order::BEFORE);
+    localPartitionKeyIndices_.push_back(static_cast<cudf::size_type>(i));
+  }
+  for (size_t i = 0; i < sortKeyIndices_.size(); ++i) {
+    allSortKeys_.push_back(sortKeyIndices_[i]);
+    allOrders_.push_back(sortOrders_[i]);
+    allNullOrders_.push_back(nullOrders_[i]);
+  }
+}
+
+CudfVectorPtr CudfTopNRowNumber::reduceBatchToLocalCandidates(
+    const CudfVectorPtr& cudfInput,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  auto inputView = cudfInput->getTableView();
+  auto keyTable = inputView.select(allSortKeys_);
+  auto indices = cudf::stable_sorted_order(
+      keyTable, allOrders_, allNullOrders_, stream, mr);
+  auto sortedKeyTable = cudf::gather(
+      keyTable,
+      indices->view(),
+      cudf::out_of_bounds_policy::DONT_CHECK,
+      cudf::negative_index_policy::NOT_ALLOWED,
+      stream,
+      mr);
+  auto rowNums = computeRowNumbers(
+      sortedKeyTable->view(), localPartitionKeyIndices_, stream, mr);
+  auto mask = makeLimitMask(*rowNums, limit_, stream, mr);
+
+  // Filter the sort permutation to the surviving rows before gathering the
+  // full payload, so batches with many rows per partition don't pay for
+  // materializing rows that will be pruned immediately after.
+  auto filteredIndicesTable = cudf::apply_boolean_mask(
+      cudf::table_view{{indices->view()}}, mask->view(), stream, mr);
+  auto filteredIndices = filteredIndicesTable->view().column(0);
+
+  auto localCandidatesTable = cudf::gather(
+      inputView,
+      filteredIndices,
+      cudf::out_of_bounds_policy::DONT_CHECK,
+      cudf::negative_index_policy::NOT_ALLOWED,
+      stream,
+      mr);
+  auto const size = localCandidatesTable->num_rows();
+  return std::make_shared<CudfVector>(
+      cudfInput->pool(),
+      inputType_,
+      size,
+      std::move(localCandidatesTable),
+      stream);
+}
+
+CudfVectorPtr CudfTopNRowNumber::mergeAndPruneCandidates(
+    const CudfVectorPtr& previous,
+    const CudfVectorPtr& incoming,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  std::vector<rmm::cuda_stream_view> inputStreams{
+      previous->stream(), incoming->stream()};
+  cudf::detail::join_streams(inputStreams, stream);
+
+  std::vector<cudf::table_view> tableViews{
+      previous->getTableView(), incoming->getTableView()};
+  auto merged = cudf::merge(
+      tableViews, allSortKeys_, allOrders_, allNullOrders_, stream, mr);
+
+  // Ensure input-stream deallocations don't race with the merge kernel.
+  streamsWaitForStream(*cudaEvent_, inputStreams, stream);
+
+  auto rowNums =
+      computeRowNumbers(merged->view(), partitionKeyIndices_, stream, mr);
+  auto mask = makeLimitMask(*rowNums, limit_, stream, mr);
+  auto pruned =
+      cudf::apply_boolean_mask(merged->view(), mask->view(), stream, mr);
+
+  auto const size = pruned->num_rows();
+  return std::make_shared<CudfVector>(
+      previous->pool(), inputType_, size, std::move(pruned), stream);
 }
 
 void CudfTopNRowNumber::doAddInput(RowVectorPtr input) {
-  if (input->size() == 0) {
+  if (limit_ == 0 || input->size() == 0) {
     return;
   }
   auto cudfInput = std::dynamic_pointer_cast<CudfVector>(input);
   VELOX_CHECK_NOT_NULL(cudfInput, "CudfTopNRowNumber expects CudfVector");
-  inputBatches_.push_back(std::move(cudfInput));
+
+  auto mr = get_output_mr();
+  auto localCandidates =
+      reduceBatchToLocalCandidates(cudfInput, cudfInput->stream(), mr);
+
+  if (candidates_ == nullptr) {
+    candidates_ = std::move(localCandidates);
+    return;
+  }
+
+  // Merge on a fresh stream (rather than either input's stream) so the
+  // merge/prune work can be scheduled independently of both producers; see
+  // CudfTopN::mergeTopK for the same pattern.
+  auto mergeStream = cudfGlobalStreamPool().get_stream();
+  candidates_ =
+      mergeAndPruneCandidates(candidates_, localCandidates, mergeStream, mr);
 }
 
 void CudfTopNRowNumber::doNoMoreInput() {
   Operator::noMoreInput();
-  if (inputBatches_.empty()) {
+  if (candidates_ == nullptr) {
     finished_ = true;
   }
 }
@@ -117,110 +260,34 @@ RowVectorPtr CudfTopNRowNumber::doGetOutput() {
   if (finished_ || !noMoreInput_) {
     return nullptr;
   }
-  if (inputBatches_.empty()) {
-    finished_ = true;
+  finished_ = true;
+  if (candidates_ == nullptr) {
     return nullptr;
   }
 
-  auto stream = cudfGlobalStreamPool().get_stream();
+  if (!generateRowNumber_) {
+    return std::move(candidates_);
+  }
+
+  auto stream = candidates_->stream();
   auto mr = get_output_mr();
-  auto pool = inputBatches_[0]->pool();
-  const auto inputType = node_->sources()[0]->outputType();
-
-  auto allData = getConcatenatedTable(
-      std::exchange(inputBatches_, {}), inputType, stream, mr);
-  auto allView = allData->view();
-
-  std::vector<cudf::size_type> allSortKeys;
-  std::vector<cudf::order> allOrders;
-  std::vector<cudf::null_order> allNullOrders;
-  allSortKeys.reserve(partitionKeyIndices_.size() + sortKeyIndices_.size());
-  allOrders.reserve(partitionKeyIndices_.size() + sortKeyIndices_.size());
-  allNullOrders.reserve(partitionKeyIndices_.size() + sortKeyIndices_.size());
-
-  for (auto idx : partitionKeyIndices_) {
-    allSortKeys.push_back(idx);
-    allOrders.push_back(cudf::order::ASCENDING);
-    allNullOrders.push_back(cudf::null_order::BEFORE);
-  }
-  for (size_t i = 0; i < sortKeyIndices_.size(); ++i) {
-    allSortKeys.push_back(sortKeyIndices_[i]);
-    allOrders.push_back(sortOrders_[i]);
-    allNullOrders.push_back(nullOrders_[i]);
+  auto rowNums = computeRowNumbers(
+      candidates_->getTableView(), partitionKeyIndices_, stream, mr);
+  // cuDF row_number is int32; Velox expects bigint.
+  const auto rowNumberCudfType = cudf_velox::veloxToCudfDataType(
+      outputType_->childAt(outputType_->size() - 1));
+  if (rowNums->type() != rowNumberCudfType) {
+    rowNums = cudf::cast(*rowNums, rowNumberCudfType, stream, mr);
   }
 
-  auto keyTable = allView.select(allSortKeys);
-  auto indices =
-      cudf::stable_sorted_order(keyTable, allOrders, allNullOrders, stream, mr);
-  auto sortedData = cudf::gather(
-      allView,
-      indices->view(),
-      cudf::out_of_bounds_policy::DONT_CHECK,
-      cudf::negative_index_policy::NOT_ALLOWED,
-      stream,
-      mr);
-  auto sortedView = sortedData->view();
+  auto pool = candidates_->pool();
+  auto const size = candidates_->size();
+  auto cols = candidates_->release()->release();
+  cols.push_back(std::move(rowNums));
+  auto finalTable = std::make_unique<cudf::table>(std::move(cols));
 
-  std::unique_ptr<cudf::column> singlePartitionCol;
-  auto partKeys = makePartitionKeys(
-      sortedView, partitionKeyIndices_, stream, mr, singlePartitionCol);
-  auto firstCol = sortedView.column(0);
-  auto rowNumberAgg =
-      cudf::make_row_number_aggregation<cudf::rolling_aggregation>();
-  auto unbounded = cudf::window_bounds::unbounded();
-  auto currentRow = cudf::window_bounds::get(0);
-  auto rowNums = cudf::grouped_rolling_window(
-      partKeys, firstCol, unbounded, currentRow, 1, *rowNumberAgg, stream, mr);
-
-  auto limitScalar = cudf::numeric_scalar<int64_t>(limit_, true, stream, mr);
-  auto mask = cudf::binary_operation(
-      rowNums->view(),
-      limitScalar,
-      cudf::binary_operator::LESS_EQUAL,
-      cudf::data_type(cudf::type_id::BOOL8),
-      stream,
-      mr);
-  auto filteredTable =
-      cudf::apply_boolean_mask(sortedView, mask->view(), stream, mr);
-
-  if (generateRowNumber_) {
-    auto filteredView = filteredTable->view();
-    std::unique_ptr<cudf::column> filteredSinglePartitionCol;
-    auto filtPartKeys = makePartitionKeys(
-        filteredView,
-        partitionKeyIndices_,
-        stream,
-        mr,
-        filteredSinglePartitionCol);
-    auto filtFirstCol = filteredView.column(0);
-    auto filtRowNums = cudf::grouped_rolling_window(
-        filtPartKeys,
-        filtFirstCol,
-        unbounded,
-        currentRow,
-        1,
-        *rowNumberAgg,
-        stream,
-        mr);
-    // cuDF row_number is int32; Velox expects bigint.
-    const auto rowNumberCudfType = cudf_velox::veloxToCudfDataType(
-        outputType_->childAt(outputType_->size() - 1));
-    if (filtRowNums->type() != rowNumberCudfType) {
-      filtRowNums = cudf::cast(*filtRowNums, rowNumberCudfType, stream, mr);
-    }
-
-    auto cols = filteredTable->release();
-    cols.push_back(std::move(filtRowNums));
-    filteredTable = std::make_unique<cudf::table>(std::move(cols));
-  }
-
-  finished_ = true;
   return std::make_shared<CudfVector>(
-      pool,
-      outputType_,
-      filteredTable->num_rows(),
-      std::move(filteredTable),
-      stream);
+      pool, outputType_, size, std::move(finalTable), stream);
 }
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/CudfTopNRowNumber.cpp
+++ b/velox/experimental/cudf/exec/CudfTopNRowNumber.cpp
@@ -17,6 +17,7 @@
 #include "velox/experimental/cudf/exec/CudfTopNRowNumber.h"
 #include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
+#include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
 
 #include <cudf/aggregation.hpp>
 #include <cudf/binaryop.hpp>
@@ -25,6 +26,7 @@
 #include <cudf/rolling.hpp>
 #include <cudf/sorting.hpp>
 #include <cudf/stream_compaction.hpp>
+#include <cudf/unary.hpp>
 
 namespace facebook::velox::cudf_velox {
 
@@ -200,6 +202,13 @@ RowVectorPtr CudfTopNRowNumber::doGetOutput() {
         *rowNumberAgg,
         stream,
         mr);
+    // cuDF row_number is int32; Velox expects bigint.
+    const auto rowNumberCudfType = cudf::data_type(cudf_velox::veloxToCudfTypeId(
+        outputType_->childAt(outputType_->size() - 1)));
+    if (filtRowNums->type() != rowNumberCudfType) {
+      filtRowNums =
+          cudf::cast(*filtRowNums, rowNumberCudfType, stream, mr);
+    }
 
     auto cols = filteredTable->release();
     cols.push_back(std::move(filtRowNums));

--- a/velox/experimental/cudf/exec/CudfTopNRowNumber.cpp
+++ b/velox/experimental/cudf/exec/CudfTopNRowNumber.cpp
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/experimental/cudf/CudfNoDefaults.h"
+#include "velox/experimental/cudf/exec/CudfTopNRowNumber.h"
+#include "velox/experimental/cudf/exec/GpuResources.h"
+#include "velox/experimental/cudf/exec/Utilities.h"
+
+#include <cudf/aggregation.hpp>
+#include <cudf/binaryop.hpp>
+#include <cudf/copying.hpp>
+#include <cudf/rolling.hpp>
+#include <cudf/sorting.hpp>
+
+namespace facebook::velox::cudf_velox {
+
+namespace {
+
+cudf::table_view makePartitionKeys(
+    cudf::table_view sortedView,
+    const std::vector<cudf::size_type>& partitionKeyIndices,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr,
+    std::unique_ptr<cudf::column>& singlePartitionCol) {
+  if (!partitionKeyIndices.empty()) {
+    return sortedView.select(partitionKeyIndices);
+  }
+  auto zero = cudf::numeric_scalar<int8_t>(0, true, stream, mr);
+  singlePartitionCol =
+      cudf::make_column_from_scalar(zero, sortedView.num_rows(), stream, mr);
+  return cudf::table_view{{singlePartitionCol->view()}};
+}
+
+} // namespace
+
+CudfTopNRowNumber::CudfTopNRowNumber(
+    int32_t operatorId,
+    exec::DriverCtx* driverCtx,
+    const std::shared_ptr<const core::TopNRowNumberNode>& node)
+    : CudfOperatorBase(
+          operatorId,
+          driverCtx,
+          node->outputType(),
+          node->id(),
+          "CudfTopNRowNumber",
+          nvtx3::rgb{255, 200, 100},
+          NvtxMethodFlag::kAll,
+          std::nullopt,
+          node),
+      node_(node),
+      limit_(node->limit()),
+      generateRowNumber_(node->generateRowNumber()) {
+  VELOX_CHECK_EQ(
+      node->rankFunction(),
+      core::TopNRowNumberNode::RankFunction::kRowNumber,
+      "CudfTopNRowNumber only supports row_number");
+
+  const auto inputType = node->sources()[0]->outputType();
+  partitionKeyIndices_.reserve(node->partitionKeys().size());
+  for (const auto& key : node->partitionKeys()) {
+    partitionKeyIndices_.push_back(
+        exec::exprToChannel(key.get(), inputType));
+  }
+
+  sortKeyIndices_.reserve(node->sortingKeys().size());
+  sortOrders_.reserve(node->sortingKeys().size());
+  nullOrders_.reserve(node->sortingKeys().size());
+  for (size_t i = 0; i < node->sortingKeys().size(); ++i) {
+    sortKeyIndices_.push_back(
+        exec::exprToChannel(node->sortingKeys()[i].get(), inputType));
+    const auto& order = node->sortingOrders()[i];
+    sortOrders_.push_back(
+        order.isAscending() ? cudf::order::ASCENDING
+                            : cudf::order::DESCENDING);
+    nullOrders_.push_back(
+        (order.isNullsFirst() ^ !order.isAscending())
+            ? cudf::null_order::BEFORE
+            : cudf::null_order::AFTER);
+  }
+}
+
+void CudfTopNRowNumber::doAddInput(RowVectorPtr input) {
+  if (input->size() == 0) {
+    return;
+  }
+  auto cudfInput = std::dynamic_pointer_cast<CudfVector>(input);
+  VELOX_CHECK_NOT_NULL(cudfInput, "CudfTopNRowNumber expects CudfVector");
+  inputBatches_.push_back(std::move(cudfInput));
+}
+
+void CudfTopNRowNumber::doNoMoreInput() {
+  Operator::noMoreInput();
+  if (inputBatches_.empty()) {
+    finished_ = true;
+  }
+}
+
+bool CudfTopNRowNumber::isFinished() {
+  return finished_;
+}
+
+RowVectorPtr CudfTopNRowNumber::doGetOutput() {
+  if (finished_ || !noMoreInput_) {
+    return nullptr;
+  }
+  if (inputBatches_.empty()) {
+    finished_ = true;
+    return nullptr;
+  }
+
+  auto stream = cudfGlobalStreamPool().get_stream();
+  auto mr = get_output_mr();
+  auto pool = inputBatches_[0]->pool();
+  const auto inputType = node_->sources()[0]->outputType();
+
+  auto allData = getConcatenatedTable(
+      std::exchange(inputBatches_, {}), inputType, stream, mr);
+  auto allView = allData->view();
+
+  std::vector<cudf::size_type> allSortKeys;
+  std::vector<cudf::order> allOrders;
+  std::vector<cudf::null_order> allNullOrders;
+  allSortKeys.reserve(partitionKeyIndices_.size() + sortKeyIndices_.size());
+  allOrders.reserve(partitionKeyIndices_.size() + sortKeyIndices_.size());
+  allNullOrders.reserve(partitionKeyIndices_.size() + sortKeyIndices_.size());
+
+  for (auto idx : partitionKeyIndices_) {
+    allSortKeys.push_back(idx);
+    allOrders.push_back(cudf::order::ASCENDING);
+    allNullOrders.push_back(cudf::null_order::BEFORE);
+  }
+  for (size_t i = 0; i < sortKeyIndices_.size(); ++i) {
+    allSortKeys.push_back(sortKeyIndices_[i]);
+    allOrders.push_back(sortOrders_[i]);
+    allNullOrders.push_back(nullOrders_[i]);
+  }
+
+  auto keyTable = allView.select(allSortKeys);
+  auto indices = cudf::stable_sorted_order(
+      keyTable, allOrders, allNullOrders, stream, mr);
+  auto sortedData = cudf::gather(
+      allView,
+      indices->view(),
+      cudf::out_of_bounds_policy::DONT_CHECK,
+      cudf::negative_index_policy::NOT_ALLOWED,
+      stream,
+      mr);
+  auto sortedView = sortedData->view();
+
+  std::unique_ptr<cudf::column> singlePartitionCol;
+  auto partKeys = makePartitionKeys(
+      sortedView, partitionKeyIndices_, stream, mr, singlePartitionCol);
+  auto firstCol = sortedView.column(0);
+  auto countAgg = cudf::make_count_aggregation(cudf::null_policy::INCLUDE);
+  auto unbounded = cudf::window_bounds::unbounded();
+  auto current = cudf::window_bounds::get(1);
+  auto rowNums = cudf::grouped_rolling_window(
+      partKeys, firstCol, unbounded, current, 1, *countAgg, stream, mr);
+
+  auto limitScalar =
+      cudf::numeric_scalar<int64_t>(limit_, true, stream, mr);
+  auto mask = cudf::binary_operation(
+      rowNums->view(),
+      limitScalar,
+      cudf::binary_operator::LESS_EQUAL,
+      cudf::data_type(cudf::type_id::BOOL8),
+      stream,
+      mr);
+  auto filteredTable =
+      cudf::apply_boolean_mask(sortedView, mask->view(), stream, mr);
+
+  if (generateRowNumber_) {
+    auto filteredView = filteredTable->view();
+    std::unique_ptr<cudf::column> filteredSinglePartitionCol;
+    auto filtPartKeys = makePartitionKeys(
+        filteredView,
+        partitionKeyIndices_,
+        stream,
+        mr,
+        filteredSinglePartitionCol);
+    auto filtFirstCol = filteredView.column(0);
+    auto filtRowNums = cudf::grouped_rolling_window(
+        filtPartKeys,
+        filtFirstCol,
+        unbounded,
+        current,
+        1,
+        *countAgg,
+        stream,
+        mr);
+
+    auto cols = filteredTable->release();
+    cols.push_back(std::move(filtRowNums));
+    filteredTable = std::make_unique<cudf::table>(std::move(cols));
+  }
+
+  finished_ = true;
+  return std::make_shared<CudfVector>(
+      pool,
+      outputType_,
+      filteredTable->num_rows(),
+      std::move(filteredTable),
+      stream);
+}
+
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/CudfTopNRowNumber.cpp
+++ b/velox/experimental/cudf/exec/CudfTopNRowNumber.cpp
@@ -203,11 +203,11 @@ RowVectorPtr CudfTopNRowNumber::doGetOutput() {
         stream,
         mr);
     // cuDF row_number is int32; Velox expects bigint.
-    const auto rowNumberCudfType = cudf::data_type(cudf_velox::veloxToCudfTypeId(
-        outputType_->childAt(outputType_->size() - 1)));
+    const auto rowNumberCudfType = cudf::data_type(
+        cudf_velox::veloxToCudfTypeId(
+            outputType_->childAt(outputType_->size() - 1)));
     if (filtRowNums->type() != rowNumberCudfType) {
-      filtRowNums =
-          cudf::cast(*filtRowNums, rowNumberCudfType, stream, mr);
+      filtRowNums = cudf::cast(*filtRowNums, rowNumberCudfType, stream, mr);
     }
 
     auto cols = filteredTable->release();

--- a/velox/experimental/cudf/exec/CudfTopNRowNumber.cpp
+++ b/velox/experimental/cudf/exec/CudfTopNRowNumber.cpp
@@ -72,8 +72,7 @@ CudfTopNRowNumber::CudfTopNRowNumber(
   const auto inputType = node->sources()[0]->outputType();
   partitionKeyIndices_.reserve(node->partitionKeys().size());
   for (const auto& key : node->partitionKeys()) {
-    partitionKeyIndices_.push_back(
-        exec::exprToChannel(key.get(), inputType));
+    partitionKeyIndices_.push_back(exec::exprToChannel(key.get(), inputType));
   }
 
   sortKeyIndices_.reserve(node->sortingKeys().size());
@@ -84,8 +83,7 @@ CudfTopNRowNumber::CudfTopNRowNumber(
         exec::exprToChannel(node->sortingKeys()[i].get(), inputType));
     const auto& order = node->sortingOrders()[i];
     sortOrders_.push_back(
-        order.isAscending() ? cudf::order::ASCENDING
-                            : cudf::order::DESCENDING);
+        order.isAscending() ? cudf::order::ASCENDING : cudf::order::DESCENDING);
     nullOrders_.push_back(
         (order.isNullsFirst() ^ !order.isAscending())
             ? cudf::null_order::BEFORE
@@ -150,8 +148,8 @@ RowVectorPtr CudfTopNRowNumber::doGetOutput() {
   }
 
   auto keyTable = allView.select(allSortKeys);
-  auto indices = cudf::stable_sorted_order(
-      keyTable, allOrders, allNullOrders, stream, mr);
+  auto indices =
+      cudf::stable_sorted_order(keyTable, allOrders, allNullOrders, stream, mr);
   auto sortedData = cudf::gather(
       allView,
       indices->view(),
@@ -172,8 +170,7 @@ RowVectorPtr CudfTopNRowNumber::doGetOutput() {
   auto rowNums = cudf::grouped_rolling_window(
       partKeys, firstCol, unbounded, currentRow, 1, *rowNumberAgg, stream, mr);
 
-  auto limitScalar =
-      cudf::numeric_scalar<int64_t>(limit_, true, stream, mr);
+  auto limitScalar = cudf::numeric_scalar<int64_t>(limit_, true, stream, mr);
   auto mask = cudf::binary_operation(
       rowNums->view(),
       limitScalar,

--- a/velox/experimental/cudf/exec/CudfTopNRowNumber.cpp
+++ b/velox/experimental/cudf/exec/CudfTopNRowNumber.cpp
@@ -20,9 +20,11 @@
 
 #include <cudf/aggregation.hpp>
 #include <cudf/binaryop.hpp>
+#include <cudf/column/column_factories.hpp>
 #include <cudf/copying.hpp>
 #include <cudf/rolling.hpp>
 #include <cudf/sorting.hpp>
+#include <cudf/stream_compaction.hpp>
 
 namespace facebook::velox::cudf_velox {
 
@@ -163,11 +165,12 @@ RowVectorPtr CudfTopNRowNumber::doGetOutput() {
   auto partKeys = makePartitionKeys(
       sortedView, partitionKeyIndices_, stream, mr, singlePartitionCol);
   auto firstCol = sortedView.column(0);
-  auto countAgg = cudf::make_count_aggregation(cudf::null_policy::INCLUDE);
+  auto rowNumberAgg =
+      cudf::make_row_number_aggregation<cudf::rolling_aggregation>();
   auto unbounded = cudf::window_bounds::unbounded();
-  auto current = cudf::window_bounds::get(1);
+  auto currentRow = cudf::window_bounds::get(0);
   auto rowNums = cudf::grouped_rolling_window(
-      partKeys, firstCol, unbounded, current, 1, *countAgg, stream, mr);
+      partKeys, firstCol, unbounded, currentRow, 1, *rowNumberAgg, stream, mr);
 
   auto limitScalar =
       cudf::numeric_scalar<int64_t>(limit_, true, stream, mr);
@@ -195,9 +198,9 @@ RowVectorPtr CudfTopNRowNumber::doGetOutput() {
         filtPartKeys,
         filtFirstCol,
         unbounded,
-        current,
+        currentRow,
         1,
-        *countAgg,
+        *rowNumberAgg,
         stream,
         mr);
 

--- a/velox/experimental/cudf/exec/CudfTopNRowNumber.h
+++ b/velox/experimental/cudf/exec/CudfTopNRowNumber.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/experimental/cudf/exec/CudfOperator.h"
+#include "velox/experimental/cudf/vector/CudfVector.h"
+
+namespace facebook::velox::cudf_velox {
+
+/// GPU-accelerated TopNRowNumber: partitioned top-N with row_number.
+/// Used when the optimizer rewrites ROW_NUMBER() OVER (...) WHERE rn <= limit
+/// into a TopNRowNumber plan node.
+class CudfTopNRowNumber : public CudfOperatorBase {
+ public:
+  CudfTopNRowNumber(
+      int32_t operatorId,
+      exec::DriverCtx* driverCtx,
+      const std::shared_ptr<const core::TopNRowNumberNode>& node);
+
+  bool needsInput() const override {
+    return !noMoreInput_;
+  }
+
+  exec::BlockingReason isBlocked(ContinueFuture* /*future*/) override {
+    return exec::BlockingReason::kNotBlocked;
+  }
+
+  bool isFinished() override;
+
+ protected:
+  void doAddInput(RowVectorPtr input) override;
+  RowVectorPtr doGetOutput() override;
+  void doNoMoreInput() override;
+
+ private:
+  const std::shared_ptr<const core::TopNRowNumberNode> node_;
+  const int32_t limit_;
+  const bool generateRowNumber_;
+
+  std::vector<cudf::size_type> partitionKeyIndices_;
+  std::vector<cudf::size_type> sortKeyIndices_;
+  std::vector<cudf::order> sortOrders_;
+  std::vector<cudf::null_order> nullOrders_;
+
+  std::vector<CudfVectorPtr> inputBatches_;
+  bool finished_{false};
+};
+
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/CudfTopNRowNumber.h
+++ b/velox/experimental/cudf/exec/CudfTopNRowNumber.h
@@ -20,9 +20,18 @@
 
 namespace facebook::velox::cudf_velox {
 
+class CudaEvent;
+
 /// GPU-accelerated TopNRowNumber: partitioned top-N with row_number.
 /// Used when the optimizer rewrites ROW_NUMBER() OVER (...) WHERE rn <= limit
 /// into a TopNRowNumber plan node.
+///
+/// Retained state is bounded to O(limit * distinct partitions) rather than
+/// the full input: each input batch is locally reduced to its own top-`limit`
+/// rows per partition, then merged with the running `candidates_` (which
+/// already holds the top-`limit` rows per partition across all prior
+/// batches) and pruned back down to `limit` rows per partition. See
+/// reduceBatchToLocalCandidates() and mergeAndPruneCandidates().
 class CudfTopNRowNumber : public CudfOperatorBase {
  public:
   CudfTopNRowNumber(
@@ -46,17 +55,54 @@ class CudfTopNRowNumber : public CudfOperatorBase {
   void doNoMoreInput() override;
 
  private:
+  /// Reduces a single input batch to its own top-`limit_` rows per
+  /// partition: sorts by partition+ordering keys, computes row_number
+  /// locally, filters the sort permutation to row_number <= limit_, and only
+  /// then gathers the full payload for the surviving rows.
+  CudfVectorPtr reduceBatchToLocalCandidates(
+      const CudfVectorPtr& cudfInput,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr);
+
+  /// Merges two candidate sets (each already sorted by partition+ordering
+  /// keys and containing at most `limit_` rows per partition) via
+  /// cudf::merge, recomputes row_number over the merged rows, and prunes
+  /// back down to `limit_` rows per partition.
+  CudfVectorPtr mergeAndPruneCandidates(
+      const CudfVectorPtr& previous,
+      const CudfVectorPtr& incoming,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr);
+
   const std::shared_ptr<const core::TopNRowNumberNode> node_;
   const int32_t limit_;
   const bool generateRowNumber_;
+  const TypePtr inputType_;
 
   std::vector<cudf::size_type> partitionKeyIndices_;
   std::vector<cudf::size_type> sortKeyIndices_;
   std::vector<cudf::order> sortOrders_;
   std::vector<cudf::null_order> nullOrders_;
 
-  std::vector<CudfVectorPtr> inputBatches_;
+  // Combined partition+ordering sort/merge key (partition keys first, then
+  // ordering keys), precomputed once and reused for every stable_sorted_order
+  // / cudf::merge call.
+  std::vector<cudf::size_type> allSortKeys_;
+  std::vector<cudf::order> allOrders_;
+  std::vector<cudf::null_order> allNullOrders_;
+  // Positions of the partition keys within the narrower key-only table
+  // selected via allSortKeys_ (always the prefix [0, partitionKeyIndices_.
+  // size()), since partition keys are listed first in allSortKeys_).
+  std::vector<cudf::size_type> localPartitionKeyIndices_;
+
+  // Bounded candidate state: at most `limit_` rows per distinct partition
+  // seen so far, sorted by partition+ordering keys, with the schema of
+  // inputType_ (the row_number column, if any, is only materialized once in
+  // doGetOutput()). Updated incrementally after each input batch instead of
+  // retaining the full input.
+  CudfVectorPtr candidates_;
   bool finished_{false};
+  std::unique_ptr<CudaEvent> cudaEvent_;
 };
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/OperatorAdapters.cpp
+++ b/velox/experimental/cudf/exec/OperatorAdapters.cpp
@@ -33,6 +33,7 @@
 #include "velox/experimental/cudf/exec/CudfOrderBy.h"
 #include "velox/experimental/cudf/exec/CudfReduce.h"
 #include "velox/experimental/cudf/exec/CudfTopN.h"
+#include "velox/experimental/cudf/exec/CudfTopNRowNumber.h"
 #include "velox/experimental/cudf/exec/CudfWindow.h"
 #include "velox/experimental/cudf/exec/OperatorAdapters.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
@@ -59,6 +60,7 @@
 #include "velox/exec/TableScan.h"
 #include "velox/exec/Task.h"
 #include "velox/exec/TopN.h"
+#include "velox/exec/TopNRowNumber.h"
 #include "velox/exec/Values.h"
 #include "velox/exec/Window.h"
 
@@ -640,6 +642,50 @@ class TopNAdapter : public OperatorAdapter {
   }
 };
 
+/// TopNRowNumberAdapter - Replaces with CudfTopNRowNumber
+class TopNRowNumberAdapter : public OperatorAdapter {
+ public:
+  TopNRowNumberAdapter() : OperatorAdapter("TopNRowNumber") {}
+
+  bool canHandle(const exec::Operator* op) const override {
+    return dynamic_cast<const exec::TopNRowNumber*>(op) != nullptr;
+  }
+
+  bool canRunOnGPU(
+      const exec::Operator* /*op*/,
+      const core::PlanNodePtr& planNode,
+      exec::DriverCtx* /*ctx*/) const override {
+    auto node =
+        std::dynamic_pointer_cast<const core::TopNRowNumberNode>(planNode);
+    if (!node) {
+      return false;
+    }
+    return node->rankFunction() ==
+        core::TopNRowNumberNode::RankFunction::kRowNumber;
+  }
+
+  bool acceptsGpuInput() const override {
+    return true;
+  }
+
+  bool producesGpuOutput() const override {
+    return true;
+  }
+
+  std::vector<std::unique_ptr<exec::Operator>> createReplacements(
+      const exec::Operator* /*op*/,
+      const core::PlanNodePtr& planNode,
+      exec::DriverCtx* ctx,
+      int32_t operatorId) const override {
+    auto node =
+        std::dynamic_pointer_cast<const core::TopNRowNumberNode>(planNode);
+    std::vector<std::unique_ptr<exec::Operator>> result;
+    result.push_back(
+        std::make_unique<CudfTopNRowNumber>(operatorId, ctx, node));
+    return result;
+  }
+};
+
 /// LimitAdapter - Replaces with CudfLimit
 class LimitAdapter : public OperatorAdapter {
  public:
@@ -1092,6 +1138,7 @@ void registerAllOperatorAdapters() {
   registry.registerAdapter(std::make_unique<NestedLoopJoinProbeAdapter>());
   registry.registerAdapter(std::make_unique<OrderByAdapter>());
   registry.registerAdapter(std::make_unique<TopNAdapter>());
+  registry.registerAdapter(std::make_unique<TopNRowNumberAdapter>());
   registry.registerAdapter(std::make_unique<LimitAdapter>());
   registry.registerAdapter(std::make_unique<LocalPartitionAdapter>());
   registry.registerAdapter(std::make_unique<LocalExchangeAdapter>());

--- a/velox/experimental/cudf/tests/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/CMakeLists.txt
@@ -283,6 +283,12 @@ velox_add_cudf_test(
 )
 
 velox_add_cudf_test(
+  NAME velox_cudf_topnrownumber_test
+  SOURCES Main.cpp TopNRowNumberTest.cpp
+  LIBS ${CUDF_TEST_DEFAULT_LIBS} fmt::fmt
+)
+
+velox_add_cudf_test(
   NAME velox_cudf_window_test
   SOURCES Main.cpp WindowTest.cpp
   LIBS ${CUDF_TEST_DEFAULT_LIBS} velox_window

--- a/velox/experimental/cudf/tests/TopNRowNumberTest.cpp
+++ b/velox/experimental/cudf/tests/TopNRowNumberTest.cpp
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/experimental/cudf/CudfConfig.h"
+#include "velox/experimental/cudf/exec/ToCudf.h"
+
+#include "velox/exec/PlanNodeStats.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec::test;
+
+class TopNRowNumberTest : public OperatorTestBase {
+ public:
+  void SetUp() override {
+    OperatorTestBase::SetUp();
+    cudf_velox::registerCudf();
+  }
+
+  void TearDown() override {
+    cudf_velox::unregisterCudf();
+    OperatorTestBase::TearDown();
+  }
+
+ protected:
+  static bool wasCudfTopNRowNumberUsed(
+      const std::shared_ptr<exec::Task>& task) {
+    auto stats = task->taskStats();
+    for (const auto& pipelineStats : stats.pipelineStats) {
+      for (const auto& operatorStats : pipelineStats.operatorStats) {
+        if (operatorStats.operatorType == "CudfTopNRowNumber") {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  static bool wasCpuTopNRowNumberUsed(
+      const std::shared_ptr<exec::Task>& task) {
+    auto stats = task->taskStats();
+    for (const auto& pipelineStats : stats.pipelineStats) {
+      for (const auto& operatorStats : pipelineStats.operatorStats) {
+        if (operatorStats.operatorType == "TopNRowNumber") {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  void assertGpuTopNRowNumber(
+      const core::PlanNodePtr& plan,
+      const std::string& duckDbSql) {
+    auto task = assertQuery(plan, duckDbSql);
+    ASSERT_TRUE(wasCudfTopNRowNumberUsed(task));
+    ASSERT_FALSE(wasCpuTopNRowNumberUsed(task));
+  }
+};
+
+TEST_F(TopNRowNumberTest, basic) {
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>({1, 1, 2, 2, 1, 2, 1}),
+      makeFlatVector<int64_t>({77, 66, 55, 44, 33, 22, 11}),
+      makeFlatVector<int64_t>({10, 20, 30, 40, 50, 60, 70}),
+  });
+  createDuckDbTable({data});
+
+  auto testLimit = [&](int32_t limit) {
+    SCOPED_TRACE(fmt::format("limit={}", limit));
+
+    auto plan = PlanBuilder()
+                    .values({data})
+                    .topNRowNumber({"c0"}, {"c1"}, limit, true)
+                    .planNode();
+    assertGpuTopNRowNumber(
+        plan,
+        fmt::format(
+            "SELECT * FROM (SELECT *, row_number() over (partition by c0 order by c1) as row_number FROM tmp) "
+            "WHERE row_number <= {}",
+            limit));
+
+    plan = PlanBuilder()
+               .values({data})
+               .topNRowNumber({"c0"}, {"c1"}, limit, false)
+               .planNode();
+    assertGpuTopNRowNumber(
+        plan,
+        fmt::format(
+            "SELECT c0, c1, c2 FROM (SELECT *, row_number() over (partition by c0 order by c1) as row_number FROM tmp) "
+            "WHERE row_number <= {}",
+            limit));
+
+    plan = PlanBuilder()
+               .values({data})
+               .topNRowNumber({}, {"c1"}, limit, true)
+               .planNode();
+    assertGpuTopNRowNumber(
+        plan,
+        fmt::format(
+            "SELECT * FROM (SELECT *, row_number() over (order by c1) as row_number FROM tmp) "
+            "WHERE row_number <= {}",
+            limit));
+  };
+
+  testLimit(1);
+  testLimit(2);
+  testLimit(3);
+  testLimit(5);
+}
+
+TEST_F(TopNRowNumberTest, basicWithPeers) {
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>({1, 1, 2, 2, 1, 2, 1, 1, 1, 1, 1}),
+      makeFlatVector<int64_t>({33, 11, 55, 44, 11, 22, 11, 11, 11, 33, 33}),
+      makeFlatVector<int64_t>({10, 50, 30, 40, 50, 60, 50, 50, 50, 10, 10}),
+  });
+  createDuckDbTable({data});
+
+  auto testLimit = [&](int32_t limit) {
+    SCOPED_TRACE(fmt::format("limit={}", limit));
+
+    auto plan = PlanBuilder()
+                    .values({data})
+                    .topNRowNumber({"c0"}, {"c1"}, limit, true)
+                    .planNode();
+    assertGpuTopNRowNumber(
+        plan,
+        fmt::format(
+            "SELECT * FROM (SELECT *, row_number() over (partition by c0 order by c1) as row_number FROM tmp) "
+            "WHERE row_number <= {}",
+            limit));
+  };
+
+  testLimit(1);
+  testLimit(2);
+  testLimit(3);
+  testLimit(5);
+}
+
+TEST_F(TopNRowNumberTest, descendingSort) {
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>({1, 1, 1, 2, 2, 2}),
+      makeFlatVector<int64_t>({10, 20, 30, 40, 50, 60}),
+      makeFlatVector<int64_t>({100, 200, 300, 400, 500, 600}),
+  });
+  createDuckDbTable({data});
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .topNRowNumber({"c0"}, {"c1 DESC"}, 2, true)
+                  .planNode();
+  assertGpuTopNRowNumber(
+      plan,
+      "SELECT * FROM (SELECT *, row_number() over (partition by c0 order by c1 DESC) as row_number FROM tmp) "
+      "WHERE row_number <= 2");
+}
+
+TEST_F(TopNRowNumberTest, multiBatch) {
+  const vector_size_t batchSize = 1000;
+  std::vector<RowVectorPtr> vectors;
+  for (int32_t batch = 0; batch < 3; ++batch) {
+    vectors.push_back(makeRowVector({
+        makeFlatVector<int64_t>(
+            batchSize, [&](vector_size_t row) { return (batch * batchSize + row) % 5; }),
+        makeFlatVector<int64_t>(
+            batchSize, [&](vector_size_t row) { return batch * batchSize + row; }),
+        makeFlatVector<int64_t>(
+            batchSize, [&](vector_size_t row) { return row; }),
+    }));
+  }
+  createDuckDbTable(vectors);
+
+  auto plan = PlanBuilder()
+                  .values(vectors)
+                  .topNRowNumber({"c0"}, {"c1"}, 3, false)
+                  .planNode();
+  assertGpuTopNRowNumber(
+      plan,
+      "SELECT c0, c1, c2 FROM (SELECT *, row_number() over (partition by c0 order by c1) as row_number FROM tmp) "
+      "WHERE row_number <= 3");
+}
+
+TEST_F(TopNRowNumberTest, rankFallsBackToCpu) {
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>({1, 1, 2, 2}),
+      makeFlatVector<int64_t>({10, 20, 30, 40}),
+      makeFlatVector<int64_t>({100, 200, 300, 400}),
+  });
+  createDuckDbTable({data});
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .topNRank("rank", {"c0"}, {"c1"}, 2, true)
+                  .planNode();
+  auto task = assertQuery(
+      plan,
+      "SELECT * FROM (SELECT *, rank() over (partition by c0 order by c1) as row_number FROM tmp) "
+      "WHERE row_number <= 2");
+  ASSERT_FALSE(wasCudfTopNRowNumberUsed(task));
+  ASSERT_TRUE(wasCpuTopNRowNumberUsed(task));
+}

--- a/velox/experimental/cudf/tests/TopNRowNumberTest.cpp
+++ b/velox/experimental/cudf/tests/TopNRowNumberTest.cpp
@@ -196,6 +196,75 @@ TEST_F(TopNRowNumberTest, multiBatch) {
       "WHERE row_number <= 3");
 }
 
+TEST_F(TopNRowNumberTest, multiBatchWithRowNumber) {
+  // Same shape as multiBatch, but with generateRowNumber=true so the
+  // row_number column must be recomputed correctly across the incremental
+  // merge/prune steps in CudfTopNRowNumber::mergeAndPruneCandidates, not just
+  // the filtered row set.
+  const vector_size_t batchSize = 1000;
+  std::vector<RowVectorPtr> vectors;
+  for (int32_t batch = 0; batch < 3; ++batch) {
+    vectors.push_back(makeRowVector({
+        makeFlatVector<int64_t>(
+            batchSize,
+            [&](vector_size_t row) { return (batch * batchSize + row) % 5; }),
+        makeFlatVector<int64_t>(
+            batchSize,
+            [&](vector_size_t row) { return batch * batchSize + row; }),
+        makeFlatVector<int64_t>(
+            batchSize, [&](vector_size_t row) { return row; }),
+    }));
+  }
+  createDuckDbTable(vectors);
+
+  auto plan = PlanBuilder()
+                  .values(vectors)
+                  .topNRowNumber({"c0"}, {"c1"}, 3, true)
+                  .planNode();
+  assertGpuTopNRowNumber(
+      plan,
+      "SELECT * FROM (SELECT *, row_number() over (partition by c0 order by c1) as row_number FROM tmp) "
+      "WHERE row_number <= 3");
+}
+
+TEST_F(TopNRowNumberTest, manySmallBatchesStaggeredPartitions) {
+  // Exercises the per-batch merge/prune path many times (one merge per
+  // batch) with partitions that only start appearing partway through the
+  // stream, and with candidate state from earlier batches getting displaced
+  // by later, better-ranked rows within the same partition.
+  const vector_size_t batchSize = 20;
+  const int32_t numBatches = 15;
+  std::vector<RowVectorPtr> vectors;
+  for (int32_t batch = 0; batch < numBatches; ++batch) {
+    // Partition 'batch % 4' only starts contributing rows once 'batch' is at
+    // least that value, e.g. partition 3 first appears in batch 3.
+    vectors.push_back(makeRowVector({
+        makeFlatVector<int64_t>(
+            batchSize, [&](vector_size_t row) { return (batch + row) % 4; }),
+        // Descending c1 so later batches (smaller multiplier applied via
+        // batch-dependent offset) sometimes outrank earlier candidates,
+        // forcing candidates_ to be displaced during merges.
+        makeFlatVector<int64_t>(
+            batchSize,
+            [&](vector_size_t row) {
+              return (numBatches - batch) * 1000 + row;
+            }),
+        makeFlatVector<int64_t>(
+            batchSize, [&](vector_size_t row) { return row; }),
+    }));
+  }
+  createDuckDbTable(vectors);
+
+  auto plan = PlanBuilder()
+                  .values(vectors)
+                  .topNRowNumber({"c0"}, {"c1"}, 4, true)
+                  .planNode();
+  assertGpuTopNRowNumber(
+      plan,
+      "SELECT * FROM (SELECT *, row_number() over (partition by c0 order by c1) as row_number FROM tmp) "
+      "WHERE row_number <= 4");
+}
+
 TEST_F(TopNRowNumberTest, rankFallsBackToCpu) {
   auto data = makeRowVector({
       makeFlatVector<int64_t>({1, 1, 2, 2}),

--- a/velox/experimental/cudf/tests/TopNRowNumberTest.cpp
+++ b/velox/experimental/cudf/tests/TopNRowNumberTest.cpp
@@ -50,8 +50,7 @@ class TopNRowNumberTest : public OperatorTestBase {
     return false;
   }
 
-  static bool wasCpuTopNRowNumberUsed(
-      const std::shared_ptr<exec::Task>& task) {
+  static bool wasCpuTopNRowNumberUsed(const std::shared_ptr<exec::Task>& task) {
     auto stats = task->taskStats();
     for (const auto& pipelineStats : stats.pipelineStats) {
       for (const auto& operatorStats : pipelineStats.operatorStats) {
@@ -176,9 +175,11 @@ TEST_F(TopNRowNumberTest, multiBatch) {
   for (int32_t batch = 0; batch < 3; ++batch) {
     vectors.push_back(makeRowVector({
         makeFlatVector<int64_t>(
-            batchSize, [&](vector_size_t row) { return (batch * batchSize + row) % 5; }),
+            batchSize,
+            [&](vector_size_t row) { return (batch * batchSize + row) % 5; }),
         makeFlatVector<int64_t>(
-            batchSize, [&](vector_size_t row) { return batch * batchSize + row; }),
+            batchSize,
+            [&](vector_size_t row) { return batch * batchSize + row; }),
         makeFlatVector<int64_t>(
             batchSize, [&](vector_size_t row) { return row; }),
     }));


### PR DESCRIPTION
## Summary
- Revives the focused `CudfTopNRowNumber` work from closed PR #16599
- GPU path: sort by partition + order keys, compute `row_number` via `grouped_rolling_window`, filter `rn <= limit`
- Registers `TopNRowNumberAdapter` (row_number only; rank/dense_rank fall back to CPU)
- Adds `TopNRowNumberTest` asserting `CudfTopNRowNumber` is used and CPU `TopNRowNumber` is not

## Test plan
- [ ] `velox_cudf_topnrownumber_test` (basic, peers, descending, multi-batch, rank CPU fallback)
- [ ] Existing cuDF test suite green on CUDA CI