### PR TITLE
fix: Enable Pyrefly in velox

### DIFF
--- a/python/pyvelox/utils/data_generator.py
+++ b/python/pyvelox/utils/data_generator.py
@@ -68,6 +68,7 @@ def generate_tpch_data(
     plan_builder.tpch_gen(
         table_name=table,
         connector_id=TPCH_CONNECTOR_NAME,
+        # pyrefly: ignore [bad-argument-type]
         scale_factor=scale_factor,
         num_parts=num_files,
     ).table_write(

--- a/velox/experimental/torchwave/tests/fold_test.py
+++ b/velox/experimental/torchwave/tests/fold_test.py
@@ -35,15 +35,19 @@ class FoldTestPreproc(nn.Module):
         # --- Foldable subgraphs (depend only on weights) ---
 
         # Folds to a constant tensor: element-wise on weights only.
+        # pyrefly: ignore [unsupported-operation]
         folded_sum = self.w1 + self.w2
 
         # Folds to a constant scalar via reduction.
+        # pyrefly: ignore [not-callable]
         folded_scalar = self.w1.sum()
 
         # Folds to a constant mask: w1 % 10 < 9 (90% true).
+        # pyrefly: ignore [unsupported-operation]
         folded_mask = self.w1 % 10 < 9
 
         # Folds to a constant tensor: masked_select with constant input and mask.
+        # pyrefly: ignore [bad-argument-type]
         folded_selected = torch.masked_select(self.w2, folded_mask)
 
         # --- Dynamic ops with redundant views ---
@@ -51,6 +55,7 @@ class FoldTestPreproc(nn.Module):
         # Chain 1: view, view, masked_select with folded mask.
         t1 = x.view(-1)
         t2 = t1.view(-1)
+        # pyrefly: ignore [bad-argument-type]
         s1 = torch.masked_select(t2, folded_mask)
 
         # Chain 2: view, view, masked_select with dynamic mask.
@@ -72,6 +77,7 @@ class FoldTestPreproc(nn.Module):
         o3 = folded_selected + 1
 
         # Another foldable scalar: product of weight shapes.
+        # pyrefly: ignore [bad-index]
         folded_numel = torch.tensor(self.w1.shape[0] * self.w2.shape[0])
         o4 = x + folded_numel
 

--- a/velox/experimental/torchwave/tests/large_element_test.py
+++ b/velox/experimental/torchwave/tests/large_element_test.py
@@ -96,6 +96,7 @@ class LargeElementTest(nn.Module):
             for op_code, inp_idx, scalar_val, nest_right in ops:
                 rhs = scalar_val if inp_idx == -1 else inputs[inp_idx]
                 if nest_right:
+                    # pyrefly: ignore [bad-argument-type]
                     val = _apply_op(op_code, rhs, val)
                 else:
                     val = _apply_op(op_code, val, rhs)


### PR DESCRIPTION
Summary:
Automated migration to enable Pyrefly type checking for `fbcode/velox`.

- Added `python.set_pyrefly(True)` to PACKAGE file
- Suppressed pre-existing type errors

Pyrefly is Meta's next-generation Python type checker, replacing Pyre.

If you encounter issues, you can revert the PACKAGE change by removing
the `python.set_pyrefly(True)` line.
#pyreupgrade

Differential Revision: D108312072


