### PR TITLE
feat(selective): Enable dictionary path for filtered string reads (#17810)

### DIFF
--- a/velox/dwio/common/ColumnVisitors.h
+++ b/velox/dwio/common/ColumnVisitors.h
@@ -827,6 +827,15 @@ class DictionaryColumnVisitor
                                                                          : 2),
         state_(reader->scanState().rawState) {}
 
+  // Re-reads the cached scan-state snapshot from the reader. Nimble rebuilds
+  // the per-chunk filter dictionary at each chunk boundary during a multi-chunk
+  // dictionary read; the visitor must re-snapshot so valueInDictionary() sees
+  // the current chunk's dictionary rather than the stale copy captured at
+  // construction.
+  void refreshScanState() {
+    state_ = this->reader().scanState().rawState;
+  }
+
   FOLLY_ALWAYS_INLINE bool isInDict() {
     if (inDict()) {
       return bits::isBitSet(inDict(), super::currentRow());


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/nimble/pull/862


Enable the dictionary vector path for string columns with filter pushdown. Previously, `readWithDictionary` rejected all queries with `scanSpec_->hasFilter()`, forcing filtered string reads through the flat `FlatVector<StringView>` path.

The filter is applied post-hoc after bulk index reading: `filterDictionaryIndices` iterates the materialized dictionary indices, evaluates the filter on `alphabet[index]` using a `filterCache` (avoiding redundant evaluations for repeated dictionary entries), and compacts passing indices into `rawValues_` while populating `outputRows_`.

This approach is necessary because Nimble's `readIndicesWithVisitor` uses bulk `materializeIndices` which bypasses the visitor's per-row `process()` — so the framework's `StringDictionaryColumnVisitor` filterCache logic is never reached. The post-materialization filter works with both the no-filter and filter paths without changing the index reading flow.

Changes:
- Remove `hasFilter()` gate from `readWithDictionary` (keep `valueHook()` gate — see TODO)
- Add `filterDictionaryIndices` with scalar filterCache evaluation loop
- Add `ensureFilterCache` for lazy filterCache initialization/extension
- Add `filterCache` to `DictionaryState` (cleared with alphabet on chunk boundary changes)
- Relax `!kHasFilter` assertions in `DictionaryEncoding::readIndicesWithVisitor` and `MainlyConstantEncoding::readIndicesWithVisitor` to `!kHasHook`
- Filter is saved/cloned and temporarily cleared from scanSpec during index reading so the visitor sees `AlwaysTrue`, then restored before `filterDictionaryIndices`

Benchmark (ke_benchmark l_returnflag, `BytesValues('R')`, selective reader, batch_size=1024, read_count=500, concurrency=16, column 8 only):

```
buck run @//mode/opt fbcode//dwio/nimble/tools/fb:parallel_reader -- \
  /home/huamengjiang/ke_benchmark_no_dict_vector_repro.nimble \
  --batch_size 1024 --reader_types selective --read_count 500 \
  --concurrency 16 --string_decoder_zero_copy \
  --filter_column l_returnflag --filter_values R --columns 8
```

| Config | P50 wall (ms) |
|--------|---------------|
| Flat (flag OFF) | 130 |
| Dict + scalar filter (flag ON) | 70 (-46%) |

Reviewed By: xiaoxmeng

Differential Revision: D100057063


