### PR TITLE
feat: Add fixed point operator plan nodes (#17814)

### DIFF
--- a/velox/core/CMakeLists.txt
+++ b/velox/core/CMakeLists.txt
@@ -18,6 +18,7 @@ endif()
 velox_add_library(
   velox_core
   Expressions.cpp
+  FixedPointPlanNodes.cpp
   ITypedExpr.cpp
   PlanConsistencyChecker.cpp
   PlanFragment.cpp
@@ -29,6 +30,7 @@ velox_add_library(
   HEADERS
   CoreTypeSystem.h
   Expressions.h
+  FixedPointPlanNodes.h
   ITypedExpr.h
   PlanConsistencyChecker.h
   PlanFragment.h

--- a/velox/core/FixedPointPlanNodes.cpp
+++ b/velox/core/FixedPointPlanNodes.cpp
@@ -1,0 +1,665 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/core/FixedPointPlanNodes.h"
+
+#include <folly/String.h>
+#include <unordered_set>
+
+namespace facebook::velox::core {
+namespace {
+
+// Returns the deepest node on a plan's primary (first-source) input chain --
+// the operator the plan "starts with".
+const PlanNode* primaryLeaf(const PlanNode* node) {
+  while (node != nullptr && !node->sources().empty()) {
+    node = node->sources().front().get();
+  }
+  return node;
+}
+
+// Returns true if 'node' or any of its sources requires splits (e.g. a
+// TableScan or an Exchange) -- i.e. the coordinator must assign it source
+// splits.
+bool containsSplitSource(const PlanNodePtr& node) {
+  if (node == nullptr) {
+    return false;
+  }
+  if (node->requiresSplits()) {
+    return true;
+  }
+  for (const auto& source : node->sources()) {
+    if (containsSplitSource(source)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Returns the schema of the VectorStateDeclaration named 'name' -- the fixed
+// point's mutable output entry, whose schema is the node's output type.  Throws
+// if no vector entry of that name is declared.
+RowTypePtr outputEntrySchema(
+    const std::vector<StateDeclarationPtr>& declarations,
+    const std::string& name) {
+  for (const auto& declaration : declarations) {
+    auto vector =
+        std::dynamic_pointer_cast<const VectorStateDeclaration>(declaration);
+    if (vector != nullptr && vector->name() == name) {
+      return vector->schema();
+    }
+  }
+  VELOX_USER_FAIL(
+      "FixedPointNode: outputStateEntry must name a declared vector state "
+      "entry: {}",
+      name);
+}
+
+// Collects every node of type NodeT reachable from 'root' (inclusive) by a
+// depth-first walk over sources.
+template <typename NodeT>
+void collectNodes(const PlanNodePtr& root, std::vector<const NodeT*>& out) {
+  if (root == nullptr) {
+    return;
+  }
+  if (const auto* typed = dynamic_cast<const NodeT*>(root.get())) {
+    out.push_back(typed);
+  }
+  for (const auto& source : root->sources()) {
+    collectNodes<NodeT>(source, out);
+  }
+}
+
+// Finds the declaration of subtype DeclT named 'name', or nullptr if none.
+template <typename DeclT>
+const DeclT* findDeclaration(
+    const std::vector<StateDeclarationPtr>& declarations,
+    const std::string& name) {
+  for (const auto& declaration : declarations) {
+    const auto* typed = dynamic_cast<const DeclT*>(declaration.get());
+    if (typed != nullptr && typed->name() == name) {
+      return typed;
+    }
+  }
+  return nullptr;
+}
+
+// Returns the number of payload (dependent) columns of a hash-table entry: the
+// columns after the leading key columns.
+int32_t numPayloadColumns(const HashTableStateDeclaration& declaration) {
+  return static_cast<int32_t>(declaration.schema()->size()) -
+      static_cast<int32_t>(declaration.keyColumns().size());
+}
+
+// Joins the state declarations' toString() outputs with ", " for plan printing.
+std::string declarationsToString(
+    const std::vector<StateDeclarationPtr>& declarations) {
+  std::vector<std::string> parts;
+  parts.reserve(declarations.size());
+  for (const auto& declaration : declarations) {
+    parts.push_back(declaration->toString());
+  }
+  return folly::join(", ", parts);
+}
+
+} // namespace
+
+FixedPointNode::FixedPointNode(
+    PlanNodeId id,
+    std::vector<StateDeclarationPtr> stateDeclarations,
+    std::vector<PlanNodePtr> plans,
+    ConvergenceConfig convergenceConfig,
+    std::string outputStateEntry)
+    : PlanNode{std::move(id)},
+      stateDeclarations_{std::move(stateDeclarations)},
+      plans_{std::move(plans)},
+      convergenceConfig_{std::move(convergenceConfig)},
+      outputStateEntry_{std::move(outputStateEntry)},
+      outputType_{outputEntrySchema(stateDeclarations_, outputStateEntry_)} {
+  VELOX_USER_CHECK_GT(
+      convergenceConfig_.maxIterations,
+      0,
+      "FixedPointNode: maxIterations must be positive");
+  validatePlans();
+  resolveAndValidateStateReferences();
+  // errorWhenMaxIterationReached fails the loop when maxIterations is reached
+  // without converging; that is only meaningful with a convergence plan (a
+  // null plan never converges, so it would always fail).
+  VELOX_USER_CHECK(
+      !convergenceConfig_.errorWhenMaxIterationReached ||
+          convergenceConfig_.plan != nullptr,
+      "FixedPointNode: errorWhenMaxIterationReached requires a convergence "
+      "plan; set it false for a fixed-count loop with no convergence plan");
+}
+
+void FixedPointNode::addDetails(std::stringstream& stream) const {
+  stream << "outputStateEntry: " << outputStateEntry_ << ", states: ["
+         << declarationsToString(stateDeclarations_)
+         << "], plans: " << plans_.size() << ", "
+         << convergenceConfig_.toString();
+}
+
+bool FixedPointNode::requiresSplits() const {
+  if (!plans_.empty() &&
+      std::dynamic_pointer_cast<const core::PartitionedOutputNode>(
+          plans_.front()) != nullptr) {
+    return true;
+  }
+  // A non-first body plan that shuffles in (an Exchange) consumes splits the
+  // coordinator must assign; without this a multi-plan shuffling fixed point
+  // would report requiresSplits()==false and deadlock waiting for peers.
+  for (size_t i = 1; i < plans_.size(); ++i) {
+    if (containsSplitSource(plans_[i])) {
+      return true;
+    }
+  }
+  for (const auto& declaration : stateDeclarations_) {
+    if (containsSplitSource(declaration->initialPlan())) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void FixedPointNode::validatePlans() const {
+  VELOX_USER_CHECK(
+      !plans_.empty(), "FixedPointNode requires at least one plan");
+  const auto numPlans = plans_.size();
+  for (size_t i = 0; i < numPlans; ++i) {
+    VELOX_USER_CHECK_NOT_NULL(
+        plans_[i], "FixedPointNode: plan {} must not be null", i);
+    const auto* root = plans_[i].get();
+    const auto* leaf = primaryLeaf(root);
+    const std::string leafName =
+        leaf != nullptr ? std::string(leaf->name()) : "nothing";
+    // The first plan reads from state; every later plan receives the previous
+    // plan's shuffle through an Exchange.
+    if (i == 0) {
+      VELOX_USER_CHECK(
+          dynamic_cast<const StateSourceNode*>(leaf) != nullptr,
+          "FixedPointNode: the first plan must start with a StateSourceNode, "
+          "but it starts with {}",
+          leafName);
+    } else {
+      VELOX_USER_CHECK(
+          dynamic_cast<const core::ExchangeNode*>(leaf) != nullptr,
+          "FixedPointNode: every non-first plan must start with an Exchange, "
+          "but plan {} starts with {}",
+          i,
+          leafName);
+    }
+    // The last plan produces the rows the framework writes back to the output
+    // state entry, so it must not end with a PartitionedOutput; every earlier
+    // plan shuffles to the next through one.
+    if (i + 1 == numPlans) {
+      VELOX_USER_CHECK(
+          dynamic_cast<const core::PartitionedOutputNode*>(root) == nullptr,
+          "FixedPointNode: the last plan must produce the rows written back to "
+          "the output state entry, not shuffle through a PartitionedOutput, but "
+          "plan {} ends with {}",
+          i,
+          root != nullptr ? std::string(root->name()) : "nothing");
+    } else {
+      VELOX_USER_CHECK(
+          dynamic_cast<const core::PartitionedOutputNode*>(root) != nullptr,
+          "FixedPointNode: every non-last plan must end with a "
+          "PartitionedOutput, but plan {} ends with {}",
+          i,
+          root != nullptr ? std::string(root->name()) : "nothing");
+    }
+  }
+}
+
+void FixedPointNode::resolveAndValidateStateReferences() const {
+  // State declaration names are the linking mechanism, so they must be unique
+  // across all kinds (vector + hash table); a duplicate makes resolution
+  // ambiguous.
+  std::unordered_set<std::string> declaredNames;
+  for (const auto& declaration : stateDeclarations_) {
+    VELOX_USER_CHECK(
+        declaredNames.insert(declaration->name()).second,
+        "FixedPointNode: duplicate state declaration name: {}",
+        declaration->name());
+  }
+
+  // Resolve and check every StateSource / StateHashJoin in every body plan and
+  // in the convergence plan (which also reads state via a StateSource).
+  std::vector<PlanNodePtr> referencingPlans = plans_;
+  if (convergenceConfig_.plan != nullptr) {
+    referencingPlans.push_back(convergenceConfig_.plan);
+  }
+  for (const auto& plan : referencingPlans) {
+    std::vector<const StateSourceNode*> sources;
+    collectNodes<StateSourceNode>(plan, sources);
+    for (const auto* source : sources) {
+      const auto* entry = findDeclaration<VectorStateDeclaration>(
+          stateDeclarations_, source->stateName());
+      VELOX_USER_CHECK_NOT_NULL(
+          entry,
+          "FixedPointNode: StateSource references no declared vector state "
+          "entry: {}",
+          source->stateName());
+      VELOX_USER_CHECK(
+          source->outputType()->equivalent(*entry->schema()),
+          "FixedPointNode: StateSource output type must match the state entry "
+          "schema for entry: {}",
+          source->stateName());
+    }
+
+    std::vector<const StateHashJoinNode*> joins;
+    collectNodes<StateHashJoinNode>(plan, joins);
+    for (const auto* join : joins) {
+      const auto* entry = findDeclaration<HashTableStateDeclaration>(
+          stateDeclarations_, join->stateName());
+      VELOX_USER_CHECK_NOT_NULL(
+          entry,
+          "FixedPointNode: StateHashJoin references no declared hash table "
+          "state entry: {}",
+          join->stateName());
+      VELOX_USER_CHECK_EQ(
+          join->probeKeys().size(),
+          entry->keyColumns().size(),
+          "FixedPointNode: StateHashJoin probe key count must match the hash "
+          "table key count for entry: {}",
+          join->stateName());
+
+      // The output is the probe input columns followed by the table's payload
+      // (dependent) columns -- the columns after the leading key columns.
+      const auto& probeType = join->sources().front()->outputType();
+      const auto numProbe = static_cast<int32_t>(probeType->size());
+      const auto numPayload = numPayloadColumns(*entry);
+      VELOX_USER_CHECK_EQ(
+          static_cast<int32_t>(join->outputType()->size()),
+          numProbe + numPayload,
+          "FixedPointNode: StateHashJoin output arity must equal probe columns "
+          "plus hash table payload columns for entry: {}",
+          join->stateName());
+      const auto& entrySchema = entry->schema();
+      const auto numKeys = static_cast<int32_t>(entry->keyColumns().size());
+      // Keys-first contract: the probe input's leading key columns must occupy
+      // the same channels and share the type of the hash table's build keys.
+      for (int32_t channel = 0; channel < numKeys; ++channel) {
+        VELOX_USER_CHECK(
+            probeType->childAt(channel)->equivalent(
+                *entrySchema->childAt(channel)),
+            "FixedPointNode: StateHashJoin probe key column type at channel {} "
+            "must match the hash table build key type for entry: {}",
+            channel,
+            join->stateName());
+      }
+      for (int32_t channel = 0; channel < numProbe; ++channel) {
+        VELOX_USER_CHECK(
+            join->outputType()->childAt(channel)->equivalent(
+                *probeType->childAt(channel)),
+            "FixedPointNode: StateHashJoin output probe column type mismatch at "
+            "channel {} for entry: {}",
+            channel,
+            join->stateName());
+      }
+      for (int32_t channel = 0; channel < numPayload; ++channel) {
+        VELOX_USER_CHECK(
+            join->outputType()
+                ->childAt(numProbe + channel)
+                ->equivalent(*entrySchema->childAt(numKeys + channel)),
+            "FixedPointNode: StateHashJoin output payload column type mismatch "
+            "at channel {} for entry: {}",
+            numProbe + channel,
+            join->stateName());
+      }
+    }
+  }
+
+  // Each initial plan's output must match its declared entry schema.
+  for (const auto& declaration : stateDeclarations_) {
+    const auto& initialPlan = declaration->initialPlan();
+    if (initialPlan == nullptr) {
+      continue;
+    }
+    // Initial plans run in Phase 1 before any state is populated, so they must
+    // not read state.
+    std::vector<const StateSourceNode*> initialSources;
+    collectNodes<StateSourceNode>(initialPlan, initialSources);
+    std::vector<const StateHashJoinNode*> initialJoins;
+    collectNodes<StateHashJoinNode>(initialPlan, initialJoins);
+    VELOX_USER_CHECK(
+        initialSources.empty() && initialJoins.empty(),
+        "FixedPointNode: initial plan must not read state (it runs in Phase 1 "
+        "before state is populated) for entry: {}",
+        declaration->name());
+    if (const auto* vector =
+            dynamic_cast<const VectorStateDeclaration*>(declaration.get())) {
+      VELOX_USER_CHECK(
+          initialPlan->outputType()->equivalent(*vector->schema()),
+          "FixedPointNode: initial plan output must match the vector state "
+          "entry schema for entry: {}",
+          vector->name());
+    } else if (
+        const auto* hashTable =
+            dynamic_cast<const HashTableStateDeclaration*>(declaration.get())) {
+      VELOX_USER_CHECK(
+          initialPlan->outputType()->equivalent(*hashTable->schema()),
+          "FixedPointNode: initial plan output must match the hash table state "
+          "entry schema for entry: {}",
+          hashTable->name());
+    }
+  }
+
+  // The last plan's output must match the node's output type (the output
+  // entry's schema), since the framework writes that output back into the
+  // entry.
+  VELOX_USER_CHECK(
+      plans_.back()->outputType()->equivalent(*outputType_),
+      "FixedPointNode: last plan output must match the output state entry "
+      "schema for entry: {}",
+      outputStateEntry_);
+
+  // The convergence plan (when present) starts with a StateSourceNode and emits
+  // exactly one BOOLEAN column.
+  if (convergenceConfig_.plan != nullptr) {
+    const auto* leaf = primaryLeaf(convergenceConfig_.plan.get());
+    VELOX_USER_CHECK(
+        dynamic_cast<const StateSourceNode*>(leaf) != nullptr,
+        "FixedPointNode: the convergence plan must start with a StateSourceNode,"
+        " but it starts with {}",
+        leaf != nullptr ? std::string(leaf->name()) : "nothing");
+    const auto& convergenceType = convergenceConfig_.plan->outputType();
+    VELOX_USER_CHECK_EQ(
+        convergenceType->size(),
+        1,
+        "FixedPointNode: the convergence plan must produce exactly one output "
+        "column");
+    VELOX_USER_CHECK(
+        convergenceType->childAt(0)->isBoolean(),
+        "FixedPointNode: the convergence plan output column must be BOOLEAN, but"
+        " got: {}",
+        convergenceType->childAt(0)->toString());
+  }
+}
+
+namespace {
+// Deserializes the single source of a node that has exactly one source.
+PlanNodePtr deserializeSingleSource(const folly::dynamic& obj, void* context) {
+  auto sources = ISerializable::deserialize<std::vector<PlanNode>>(
+      obj["sources"], context);
+  VELOX_CHECK_EQ(1, sources.size());
+  return sources[0];
+}
+} // namespace
+
+folly::dynamic StateDeclaration::serializeBase(std::string_view type) const {
+  folly::dynamic obj = folly::dynamic::object;
+  obj["type"] = type;
+  obj["name"] = name_;
+  if (initialPlan_ != nullptr) {
+    obj["initialPlan"] = initialPlan_->serialize();
+  }
+  return obj;
+}
+
+// static
+std::shared_ptr<const StateDeclaration> StateDeclaration::deserialize(
+    const folly::dynamic& obj,
+    void* context) {
+  const auto type = obj["type"].asString();
+  auto name = obj["name"].asString();
+  PlanNodePtr initialPlan;
+  if (obj.count("initialPlan") != 0u) {
+    initialPlan =
+        ISerializable::deserialize<PlanNode>(obj["initialPlan"], context);
+  }
+  auto schema = ISerializable::deserialize<RowType>(obj["schema"]);
+  if (type == "vector") {
+    return std::make_shared<VectorStateDeclaration>(
+        std::move(name),
+        schema,
+        std::move(initialPlan),
+        obj["append"].asBool());
+  }
+  if (type == "hashTable") {
+    auto keyColumns =
+        ISerializable::deserialize<std::vector<std::string>>(obj["keyColumns"]);
+    return std::make_shared<HashTableStateDeclaration>(
+        std::move(name), schema, std::move(keyColumns), std::move(initialPlan));
+  }
+  VELOX_FAIL("Unknown StateDeclaration type: {}", type);
+}
+
+folly::dynamic VectorStateDeclaration::serialize() const {
+  auto obj = serializeBase("vector");
+  obj["schema"] = schema_->serialize();
+  obj["append"] = append_;
+  return obj;
+}
+
+std::string VectorStateDeclaration::toString() const {
+  return fmt::format(
+      "{} (vector, {}{})",
+      name(),
+      append_ ? "append" : "replace",
+      initialPlan() != nullptr ? ", initialized" : "");
+}
+
+VectorState& VectorState::initial(PlanNodePtr initialPlan) {
+  initialPlan_ = std::move(initialPlan);
+  return *this;
+}
+
+HashTableStateDeclaration::HashTableStateDeclaration(
+    std::string name,
+    RowTypePtr schema,
+    std::vector<std::string> keyColumns,
+    PlanNodePtr initialPlan)
+    : StateDeclaration{std::move(name), std::move(initialPlan)},
+      schema_{std::move(schema)},
+      keyColumns_{std::move(keyColumns)} {
+  VELOX_USER_CHECK(
+      !keyColumns_.empty(),
+      "HashTableStateDeclaration requires at least one key column for entry: {}",
+      this->name());
+  std::unordered_set<std::string> seenKeys;
+  for (const auto& key : keyColumns_) {
+    VELOX_USER_CHECK(
+        schema_->containsChild(key),
+        "HashTableStateDeclaration key column is not in the schema: {}",
+        key);
+    VELOX_USER_CHECK(
+        seenKeys.insert(key).second,
+        "HashTableStateDeclaration key columns must be unique, but got a "
+        "duplicate: {}",
+        key);
+  }
+  // Keys must be the leading schema columns, in order (keys-first).  Downstream
+  // StateHashJoin validation and payload-column computation rely on this
+  // positional invariant.
+  const auto numKeys = static_cast<int32_t>(keyColumns_.size());
+  for (int32_t i = 0; i < numKeys; ++i) {
+    VELOX_USER_CHECK_EQ(
+        schema_->nameOf(i),
+        keyColumns_[i],
+        "HashTableStateDeclaration key columns must be the leading schema "
+        "columns in order (keys-first) for entry: {}",
+        this->name());
+  }
+}
+
+folly::dynamic HashTableStateDeclaration::serialize() const {
+  auto obj = serializeBase("hashTable");
+  obj["schema"] = schema_->serialize();
+  obj["keyColumns"] = ISerializable::serialize(keyColumns_);
+  return obj;
+}
+
+std::string HashTableStateDeclaration::toString() const {
+  return fmt::format(
+      "{} (hashTable, keys: [{}]{})",
+      name(),
+      folly::join(", ", keyColumns_),
+      initialPlan() != nullptr ? ", initialized" : "");
+}
+
+HashTableState& HashTableState::initial(PlanNodePtr initialPlan) {
+  initialPlan_ = std::move(initialPlan);
+  return *this;
+}
+
+// static
+ConvergenceConfig ConvergenceConfig::withMaxIterations(int32_t maxIterations) {
+  return ConvergenceConfig{
+      .plan = nullptr,
+      .maxIterations = maxIterations,
+      .errorWhenMaxIterationReached = false};
+}
+
+// static
+ConvergenceConfig ConvergenceConfig::converging(
+    PlanNodePtr plan,
+    int32_t maxIterations) {
+  return ConvergenceConfig{
+      .plan = std::move(plan),
+      .maxIterations = maxIterations,
+      .errorWhenMaxIterationReached = true};
+}
+
+folly::dynamic ConvergenceConfig::serialize() const {
+  folly::dynamic obj = folly::dynamic::object;
+  if (plan != nullptr) {
+    obj["plan"] = plan->serialize();
+  }
+  obj["maxIterations"] = maxIterations;
+  obj["errorWhenMaxIterationReached"] = errorWhenMaxIterationReached;
+  return obj;
+}
+
+std::string ConvergenceConfig::toString() const {
+  return fmt::format(
+      "maxIterations: {}, errorWhenMaxIterationReached: {}, "
+      "convergencePlan: {}",
+      maxIterations,
+      errorWhenMaxIterationReached ? "true" : "false",
+      plan != nullptr ? "present" : "none");
+}
+
+// static
+ConvergenceConfig ConvergenceConfig::deserialize(
+    const folly::dynamic& obj,
+    void* context) {
+  ConvergenceConfig config;
+  if (obj.count("plan") != 0u) {
+    config.plan = ISerializable::deserialize<PlanNode>(obj["plan"], context);
+  }
+  config.maxIterations = static_cast<int32_t>(obj["maxIterations"].asInt());
+  config.errorWhenMaxIterationReached =
+      obj["errorWhenMaxIterationReached"].asBool();
+  return config;
+}
+
+folly::dynamic FixedPointNode::serialize() const {
+  auto obj = PlanNode::serialize();
+  folly::dynamic declarations = folly::dynamic::array;
+  for (const auto& declaration : stateDeclarations_) {
+    declarations.push_back(declaration->serialize());
+  }
+  obj["stateDeclarations"] = std::move(declarations);
+  folly::dynamic plans = folly::dynamic::array;
+  for (const auto& plan : plans_) {
+    plans.push_back(plan->serialize());
+  }
+  obj["plans"] = std::move(plans);
+  obj["convergenceConfig"] = convergenceConfig_.serialize();
+  obj["outputStateEntry"] = outputStateEntry_;
+  return obj;
+}
+
+// static
+PlanNodePtr FixedPointNode::create(const folly::dynamic& obj, void* context) {
+  std::vector<StateDeclarationPtr> stateDeclarations;
+  for (const auto& declaration : obj["stateDeclarations"]) {
+    stateDeclarations.push_back(
+        StateDeclaration::deserialize(declaration, context));
+  }
+  std::vector<PlanNodePtr> plans;
+  for (const auto& plan : obj["plans"]) {
+    plans.push_back(ISerializable::deserialize<PlanNode>(plan, context));
+  }
+  return std::make_shared<FixedPointNode>(
+      obj["id"].asString(),
+      std::move(stateDeclarations),
+      std::move(plans),
+      ConvergenceConfig::deserialize(obj["convergenceConfig"], context),
+      obj["outputStateEntry"].asString());
+}
+
+folly::dynamic StateSourceNode::serialize() const {
+  auto obj = PlanNode::serialize();
+  obj["stateName"] = stateName_;
+  obj["outputType"] = outputType_->serialize();
+  obj["delta"] = delta_;
+  return obj;
+}
+
+// static
+PlanNodePtr StateSourceNode::create(
+    const folly::dynamic& obj,
+    void* /*context*/) {
+  return std::make_shared<StateSourceNode>(
+      obj["id"].asString(),
+      obj["stateName"].asString(),
+      ISerializable::deserialize<RowType>(obj["outputType"]),
+      obj["delta"].asBool());
+}
+
+StateHashJoinNode::StateHashJoinNode(
+    PlanNodeId id,
+    std::string stateName,
+    std::vector<std::string> probeKeys,
+    RowTypePtr outputType,
+    PlanNodePtr source)
+    : PlanNode{std::move(id)},
+      stateName_{std::move(stateName)},
+      probeKeys_{std::move(probeKeys)},
+      outputType_{std::move(outputType)},
+      sources_{std::move(source)} {
+  VELOX_USER_CHECK_NOT_NULL(
+      sources_[0], "StateHashJoin requires a non-null probe source");
+  VELOX_USER_CHECK(
+      !probeKeys_.empty(), "StateHashJoin requires at least one probe key");
+}
+
+folly::dynamic StateHashJoinNode::serialize() const {
+  auto obj = PlanNode::serialize();
+  obj["stateName"] = stateName_;
+  obj["probeKeys"] = ISerializable::serialize(probeKeys_);
+  obj["outputType"] = outputType_->serialize();
+  return obj;
+}
+
+void StateHashJoinNode::addDetails(std::stringstream& stream) const {
+  stream << "state: " << stateName_ << ", probeKeys: ["
+         << folly::join(", ", probeKeys_) << "]";
+}
+
+// static
+PlanNodePtr StateHashJoinNode::create(
+    const folly::dynamic& obj,
+    void* context) {
+  return std::make_shared<StateHashJoinNode>(
+      obj["id"].asString(),
+      obj["stateName"].asString(),
+      ISerializable::deserialize<std::vector<std::string>>(obj["probeKeys"]),
+      ISerializable::deserialize<RowType>(obj["outputType"]),
+      deserializeSingleSource(obj, context));
+}
+
+} // namespace facebook::velox::core

--- a/velox/core/FixedPointPlanNodes.h
+++ b/velox/core/FixedPointPlanNodes.h
@@ -1,0 +1,512 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/core/PlanNode.h"
+
+namespace facebook::velox::core {
+
+/// Declares a named persistent state entry that survives across iterations.
+///
+/// Subclasses define the storage type and access pattern.  The fixed point
+/// operator stores these by shared_ptr and does not interpret the contents —
+/// operators in the body plans access the state through type-specific
+/// mechanisms.
+class StateDeclaration : public ISerializable {
+ public:
+  const std::string& name() const {
+    return name_;
+  }
+
+  /// Optional plan that produces the initial value of this state entry.
+  /// Runs once in Phase 1.  nullptr means the state starts empty.
+  const PlanNodePtr& initialPlan() const {
+    return initialPlan_;
+  }
+
+  /// Serializes this declaration, including its concrete subtype so that
+  /// deserialize() can reconstruct the right class.
+  folly::dynamic serialize() const override = 0;
+
+  /// Reconstructs the concrete StateDeclaration named by obj["type"].
+  static std::shared_ptr<const StateDeclaration> deserialize(
+      const folly::dynamic& obj,
+      void* context);
+
+  /// Renders this declaration's name and kind-specific properties for plan
+  /// printing (FixedPointNode::addDetails).
+  virtual std::string toString() const = 0;
+
+ protected:
+  StateDeclaration(std::string name, PlanNodePtr initialPlan)
+      : name_{std::move(name)}, initialPlan_{std::move(initialPlan)} {}
+
+  // Serializes the common name + initialPlan fields under the subtype tag
+  // 'type'; subclasses extend the returned object with their own fields.
+  folly::dynamic serializeBase(std::string_view type) const;
+
+ private:
+  std::string name_;
+  PlanNodePtr initialPlan_;
+};
+
+using StateDeclarationPtr = std::shared_ptr<const StateDeclaration>;
+
+/// Stores row batches as a std::vector<RowVectorPtr> persistent state entry.
+///
+/// Choose this when the entry is scanned or accumulated, or is the mutable loop
+/// variable -- anything read sequentially rather than probed by key (a probed
+/// index belongs in HashTableStateDeclaration).
+///
+/// Read via StateSourceNode; the framework writes the mutable output entry each
+/// iteration.  Imperative operators can extract raw pointers via
+/// FlatVector<T>::mutableRawValues().  An entry is either replace-mode (default
+/// -- each write overwrites it) or append-mode (writes accumulate across
+/// iterations); whether to accumulate is a property of the entry, declared
+/// here, not of the write.
+class VectorStateDeclaration : public StateDeclaration {
+ public:
+  VectorStateDeclaration(
+      std::string name,
+      RowTypePtr schema,
+      PlanNodePtr initialPlan = nullptr,
+      bool append = false)
+      : StateDeclaration{std::move(name), std::move(initialPlan)},
+        schema_{std::move(schema)},
+        append_{append} {}
+
+  const RowTypePtr& schema() const {
+    return schema_;
+  }
+
+  /// When true, writing this entry appends its rows rather than replacing the
+  /// entry, so it accumulates across iterations (e.g. a recursive CTE's UNION
+  /// ALL).  The fixed point's output is then the entry's final contents.
+  bool append() const {
+    return append_;
+  }
+
+  folly::dynamic serialize() const override;
+
+  std::string toString() const override;
+
+ private:
+  RowTypePtr schema_;
+
+  // Whether writes to this entry append (accumulate) or replace (default).
+  bool append_;
+};
+
+/// Fluent builder for a VectorStateDeclaration -- declares a vector state entry
+/// without a raw make_shared, e.g.
+///
+///   VectorState("n", rowType, /*append=*/true).initial(seedPlan)
+class VectorState {
+ public:
+  VectorState(std::string name, RowTypePtr schema, bool append = false)
+      : name_{std::move(name)}, schema_{std::move(schema)}, append_{append} {}
+
+  /// Sets the plan producing the entry's initial value (run once in Phase 1).
+  VectorState& initial(PlanNodePtr initialPlan);
+
+  /// Builds the declaration.  Implicit so the builder can be passed wherever a
+  /// StateDeclarationPtr is expected (e.g. fixedPoint's state list).
+  operator StateDeclarationPtr() const {
+    return std::make_shared<VectorStateDeclaration>(
+        name_, schema_, initialPlan_, append_);
+  }
+
+ private:
+  std::string name_;
+  RowTypePtr schema_;
+  bool append_;
+  PlanNodePtr initialPlan_;
+};
+
+/// Holds a BaseHashTable for key-value lookups or key-only membership
+/// checks.
+///
+/// Choose this when the entry is probed by key each iteration (a built-once
+/// index): declare its `keyColumns` and read it via StateHashJoinNode.  An
+/// entry scanned or accumulated sequentially belongs in VectorStateDeclaration
+/// instead.
+///
+/// Operators access directly (not via StateSourceNode).
+/// Extensible: additional StateDeclaration subclasses (e.g., for FAISS
+/// index) can be added in the future.
+class HashTableStateDeclaration : public StateDeclaration {
+ public:
+  HashTableStateDeclaration(
+      std::string name,
+      RowTypePtr schema,
+      std::vector<std::string> keyColumns,
+      PlanNodePtr initialPlan = nullptr);
+
+  /// Full row schema (key + value columns).
+  const RowTypePtr& schema() const {
+    return schema_;
+  }
+
+  /// Columns that form the hash table key.
+  const std::vector<std::string>& keyColumns() const {
+    return keyColumns_;
+  }
+
+  folly::dynamic serialize() const override;
+
+  std::string toString() const override;
+
+ private:
+  RowTypePtr schema_;
+  std::vector<std::string> keyColumns_;
+};
+
+/// Fluent builder for a HashTableStateDeclaration, e.g.
+///
+///   HashTableState("friends", schema, {"person"}).initial(friendsPlan)
+class HashTableState {
+ public:
+  HashTableState(
+      std::string name,
+      RowTypePtr schema,
+      std::vector<std::string> keyColumns)
+      : name_{std::move(name)},
+        schema_{std::move(schema)},
+        keyColumns_{std::move(keyColumns)} {}
+
+  /// Sets the plan producing the table's build rows (run once in Phase 1).
+  HashTableState& initial(PlanNodePtr initialPlan);
+
+  /// Builds the declaration.  Implicit so the builder can be passed wherever a
+  /// StateDeclarationPtr is expected (e.g. fixedPoint's state list).
+  operator StateDeclarationPtr() const {
+    return std::make_shared<HashTableStateDeclaration>(
+        name_, schema_, keyColumns_, initialPlan_);
+  }
+
+ private:
+  std::string name_;
+  RowTypePtr schema_;
+  std::vector<std::string> keyColumns_;
+  PlanNodePtr initialPlan_;
+};
+
+/// Configures convergence checking for the fixed point iteration.
+///
+/// Expresses "aggregate + predicate over a state entry" as a plan.  After each
+/// iteration the framework runs `plan` and inspects its single BOOLEAN output
+/// column; a true value stops the iteration.  The plan begins with a
+/// StateSourceNode reading the convergence state entry and typically takes the
+/// shape:
+///
+///   StateSource(entry) -> Aggregation(global) -> Project(predicate AS
+///   converged)
+///
+/// Unifies all convergence modes:
+///
+///   count(1) == 0       -> false until empty   (VLP: empty frontier)
+///   bool_or(isTarget)   -> target found        (SHORTEST)
+///   sum(active) == 0    -> no changes          (CC)
+///   max(delta) < eps    -> centroids settled   (KMeans)
+///
+/// When the convergence state entry is empty the plan may emit zero rows; the
+/// framework treats "no output row" as converged (the canonical empty-frontier
+/// terminal state).  maxIterations (a ConvergenceConfig field below) is always
+/// active as a safety bound.
+///
+/// Multi-worker contract: each worker evaluates `plan` over its own local
+/// shard, so for a shuffling fixed point (N > 1) the verdict must be globally
+/// consistent -- every worker must reach the same value on the same iteration,
+/// or lockstep breaks and the shuffle deadlocks.  Making it consistent is the
+/// plan's responsibility: synchronize the convergence-deciding state across
+/// workers through the body's shuffle (e.g. replicate it), so each worker's
+/// local read agrees.  The framework deliberately performs no cross-worker
+/// reduction (that would add an all-reduce shuffle).  A null plan means "never
+/// converge" (the loop is bounded only by maxIterations) and is always safe.
+struct ConvergenceConfig {
+  /// Plan producing exactly one BOOLEAN output column.  Starts with a
+  /// StateSourceNode.  The framework reads that single column after each
+  /// iteration; a true value stops the loop.  Null means never converge (loop
+  /// bounded by maxIterations).
+  PlanNodePtr plan{nullptr};
+
+  /// Maximum iterations the loop runs -- always active as a safety bound, and
+  /// the sole bound when `plan` is null (a fixed-count loop).
+  int32_t maxIterations{0};
+
+  /// Decides what happens when `maxIterations` is reached before the
+  /// convergence `plan` signals convergence.  When true (the default), the
+  /// fixed point fails -- a guard against silently returning a non-converged
+  /// result.  When false, the loop instead stops at the cap and returns the
+  /// current approximate result without failing: best-effort convergence (run
+  /// toward convergence, but accept the partial result if the cap is hit
+  /// first), as in an early-stopped KMeans.  Requires a convergence `plan`
+  /// (FixedPointNode validates this) -- a null plan never converges, so set
+  /// this false for a fixed-count loop with no convergence plan, where the cap
+  /// is the intended stopping point rather than a best-effort cutoff.
+  bool errorWhenMaxIterationReached{true};
+
+  /// Builds a fixed-count loop config: no convergence plan, bounded only by
+  /// `maxIterations`, so it never errors on reaching the bound.  Use for loops
+  /// with a known iteration count (e.g. Fibonacci, a bounded expansion).
+  static ConvergenceConfig withMaxIterations(int32_t maxIterations);
+
+  /// Builds a convergence-plan loop config: runs `plan` after each iteration
+  /// and stops when its BOOLEAN output is true, failing if `maxIterations` is
+  /// reached first.
+  static ConvergenceConfig converging(PlanNodePtr plan, int32_t maxIterations);
+
+  folly::dynamic serialize() const;
+
+  static ConvergenceConfig deserialize(
+      const folly::dynamic& obj,
+      void* context);
+
+  /// Renders the convergence properties for plan printing
+  /// (FixedPointNode::addDetails): max iteration bound, whether reaching it is
+  /// an error, and whether a convergence plan is present.
+  std::string toString() const;
+};
+
+/// Orchestrates iterative computation over persistent state, expressing
+/// recursive CTEs, variable-length graph paths, shortest path, connected
+/// components, and KMeans/PageRank-style iteration as one node.  Holds a list
+/// of StateDeclarations (named state that survives across iterations), a list
+/// of body plans run sequentially as sub-tasks each iteration, and a
+/// ConvergenceConfig (the termination test plus an iteration bound).  Exactly
+/// one VectorStateDeclaration -- named by `outputStateEntry` -- is the mutable
+/// loop variable: the framework writes each iteration's last plan output back
+/// into it (appending or replacing per its declaration) and emits its final
+/// contents as the node's output; every other state entry is seeded once and
+/// read-only thereafter.
+class FixedPointNode : public PlanNode {
+ public:
+  FixedPointNode(
+      PlanNodeId id,
+      std::vector<StateDeclarationPtr> stateDeclarations,
+      std::vector<PlanNodePtr> plans,
+      ConvergenceConfig convergenceConfig,
+      std::string outputStateEntry);
+
+  const RowTypePtr& outputType() const override {
+    return outputType_;
+  }
+
+  /// Returns empty — plans are sub-tasks, not pipeline sources.
+  const std::vector<PlanNodePtr>& sources() const override {
+    return kEmptySources;
+  }
+
+  std::string_view name() const override {
+    return "FixedPoint";
+  }
+
+  const std::vector<StateDeclarationPtr>& stateDeclarations() const {
+    return stateDeclarations_;
+  }
+
+  const std::vector<PlanNodePtr>& plans() const {
+    return plans_;
+  }
+
+  int32_t maxIterations() const {
+    return convergenceConfig_.maxIterations;
+  }
+
+  const ConvergenceConfig& convergenceConfig() const {
+    return convergenceConfig_;
+  }
+
+  /// The mutable loop variable: the VectorStateDeclaration whose final contents
+  /// this node emits and into which the framework writes each iteration's last
+  /// plan output.  Output shaping (e.g. a recursive CTE's UNION ALL of every
+  /// iteration) is expressed by declaring this entry append-mode, not by a
+  /// framework output mode.
+  const std::string& outputStateEntry() const {
+    return outputStateEntry_;
+  }
+
+  /// A fixed point is a split source when the coordinator must assign it
+  /// splits: the body shuffles (first plan ends with PartitionedOutput, so the
+  /// coordinator names peer workers), or an initial plan reads from a split
+  /// source (a TableScan's file splits, or an Exchange's upstream task).  A
+  /// fully local fixed point needs no splits.
+  bool requiresSplits() const override;
+
+  folly::dynamic serialize() const override;
+
+  static PlanNodePtr create(const folly::dynamic& obj, void* context);
+
+ protected:
+  void addDetails(std::stringstream& stream) const override;
+
+ private:
+  static inline const std::vector<PlanNodePtr> kEmptySources{};
+
+  // Validates the sub-plan chaining convention (see the class comment): plans
+  // are joined only by shuffle, so the first reads state, the last produces the
+  // rows written back, and adjacent plans are linked by PartitionedOutput ->
+  // Exchange.  Throws a VeloxUserError if violated.  Defined in the .cpp, which
+  // sees the complete node types it inspects.
+  void validatePlans() const;
+
+  // Resolves every StateSource / StateHashJoin reference (in the body plans and
+  // the convergence plan) to a declared state entry of the matching kind, and
+  // checks that referenced schemas, probe-key arity, initial-plan and last-plan
+  // output schemas, and the convergence-plan contract are consistent.  Throws a
+  // VeloxUserError if violated.
+  void resolveAndValidateStateReferences() const;
+
+  std::vector<StateDeclarationPtr> stateDeclarations_;
+
+  // Plans to run sequentially each iteration as separate sub-tasks.
+  std::vector<PlanNodePtr> plans_;
+
+  ConvergenceConfig convergenceConfig_;
+
+  // Name of the mutable vector state entry this node writes and outputs.
+  std::string outputStateEntry_;
+
+  // Derived in the constructor from the schema of the VectorStateDeclaration
+  // named by outputStateEntry_.
+  RowTypePtr outputType_;
+};
+
+/// Reads a Vector persistent state entry as row batches into the pipeline.
+///
+/// Always a leaf node (no sources).  Used as the first operator in a plan
+/// within a FixedPointNode iteration.  Reads from the named state entry in the
+/// parent task's persistent state.  `delta` selects what an append entry
+/// yields: true returns the latest delta -- the rows written in the most recent
+/// iteration (the in-loop frontier); false returns the entry's full
+/// accumulation.  For a replace entry the two are identical.
+class StateSourceNode : public PlanNode {
+ public:
+  StateSourceNode(
+      PlanNodeId id,
+      std::string stateName,
+      RowTypePtr outputType,
+      bool delta)
+      : PlanNode{std::move(id)},
+        stateName_{std::move(stateName)},
+        outputType_{std::move(outputType)},
+        delta_{delta} {}
+
+  const RowTypePtr& outputType() const override {
+    return outputType_;
+  }
+
+  const std::vector<PlanNodePtr>& sources() const override {
+    return kEmptySources;
+  }
+
+  std::string_view name() const override {
+    return "StateSource";
+  }
+
+  const std::string& stateName() const {
+    return stateName_;
+  }
+
+  /// When true, an in-loop read yields the append entry's latest delta (the
+  /// frontier); when false, its full accumulation.  Immaterial for a replace
+  /// entry, where the two coincide.
+  bool delta() const {
+    return delta_;
+  }
+
+  folly::dynamic serialize() const override;
+
+  static PlanNodePtr create(const folly::dynamic& obj, void* context);
+
+ protected:
+  void addDetails(std::stringstream& stream) const override {
+    stream << "state: " << stateName_ << (delta_ ? ", delta" : ", full");
+  }
+
+ private:
+  static inline const std::vector<PlanNodePtr> kEmptySources{};
+
+  // Name of the persistent state entry to read from.
+  std::string stateName_;
+
+  RowTypePtr outputType_;
+
+  // Whether an in-loop read yields the append entry's latest delta (frontier)
+  // or its full accumulation.  Immaterial for a replace entry.
+  bool delta_;
+};
+
+/// Inner-joins the input (probe) against a HashTable persistent state entry
+/// that is built once and reused across iterations (hash-table reuse). Output
+/// rows are the probe input columns followed by the hash table's dependent
+/// (payload) columns.  The probe input's join key columns must occupy the same
+/// channels as the build key columns (keys-first on both sides).
+///
+/// Only inner join is supported: probe rows with no match are dropped (this is
+/// what gives VLP / recursive CTE its empty-frontier termination).  Supporting
+/// other join types would require a JoinType parameter here, emitting null
+/// build columns on misses in the operator, and build-side probed-flag/dedup
+/// handling for semi/anti joins.
+class StateHashJoinNode : public PlanNode {
+ public:
+  StateHashJoinNode(
+      PlanNodeId id,
+      std::string stateName,
+      std::vector<std::string> probeKeys,
+      RowTypePtr outputType,
+      PlanNodePtr source);
+
+  const RowTypePtr& outputType() const override {
+    return outputType_;
+  }
+
+  const std::vector<PlanNodePtr>& sources() const override {
+    return sources_;
+  }
+
+  std::string_view name() const override {
+    return "StateHashJoin";
+  }
+
+  const std::string& stateName() const {
+    return stateName_;
+  }
+
+  const std::vector<std::string>& probeKeys() const {
+    return probeKeys_;
+  }
+
+  folly::dynamic serialize() const override;
+
+  static PlanNodePtr create(const folly::dynamic& obj, void* context);
+
+ protected:
+  void addDetails(std::stringstream& stream) const override;
+
+ private:
+  // Name of the HashTable persistent state entry to probe.
+  std::string stateName_;
+
+  // Probe-side join key column names.
+  std::vector<std::string> probeKeys_;
+
+  RowTypePtr outputType_;
+
+  std::vector<PlanNodePtr> sources_;
+};
+
+} // namespace facebook::velox::core

--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -20,6 +20,7 @@
 #include "velox/core/PlanNode.h"
 
 #include "velox/common/EnumDefine.h"
+#include "velox/core/FixedPointPlanNodes.h"
 #include "velox/core/TableWriteTraits.h"
 #include "velox/vector/VectorSaver.h"
 
@@ -4084,6 +4085,9 @@ void PlanNode::registerSerDe() {
   registry.Register("MarkDistinctNode", MarkDistinctNode::create);
   registry.Register("MixedUnionNode", MixedUnionNode::create);
   registry.Register("RPCNode", RPCNode::create);
+  registry.Register("FixedPointNode", FixedPointNode::create);
+  registry.Register("StateSourceNode", StateSourceNode::create);
+  registry.Register("StateHashJoinNode", StateHashJoinNode::create);
   registry.Register(
       "GatherPartitionFunctionSpec", GatherPartitionFunctionSpec::deserialize);
 }

--- a/velox/core/tests/PlanNodeTest.cpp
+++ b/velox/core/tests/PlanNodeTest.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/core/Expressions.h"
+#include "velox/core/FixedPointPlanNodes.h"
 #include "velox/parse/PlanNodeIdGenerator.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
@@ -732,6 +733,200 @@ TEST_F(PlanNodeTest, rpcNodeSerdeWithConstants) {
   EXPECT_EQ(
       promptVec->as<ConstantVector<StringView>>()->valueAt(0).str(),
       "You are helpful.");
+}
+
+// The FixedPointNode constructor and the state declarations validate their
+// inputs up front, so a malformed plan fails at construction rather than at
+// execution.
+TEST_F(PlanNodeTest, fixedPointValidation) {
+  auto vecSchema = ROW("x", BIGINT());
+  auto htSchema = ROW({"k", "v"}, BIGINT());
+
+  // A single body that reads the output entry -- the minimal valid body, reused
+  // as the valid baseline that each case mutates one field of.
+  auto body =
+      std::make_shared<StateSourceNode>("b", "n", vecSchema, /*delta=*/true);
+  auto vectorN = [&] {
+    return std::make_shared<VectorStateDeclaration>(
+        "n", vecSchema, /*initialPlan=*/nullptr, /*append=*/true);
+  };
+
+  // maxIterations must be positive.
+  VELOX_ASSERT_USER_THROW(
+      std::make_shared<FixedPointNode>(
+          "fp",
+          std::vector<StateDeclarationPtr>{vectorN()},
+          std::vector<PlanNodePtr>{body},
+          ConvergenceConfig{
+              .maxIterations = 0, .errorWhenMaxIterationReached = false},
+          "n"),
+      "maxIterations must be positive");
+
+  // A hash table needs at least one key column, and every key must be in the
+  // schema -- checked when the declaration is built.
+  VELOX_ASSERT_USER_THROW(
+      std::make_shared<HashTableStateDeclaration>(
+          "h", htSchema, std::vector<std::string>{}),
+      "at least one key column");
+  VELOX_ASSERT_USER_THROW(
+      std::make_shared<HashTableStateDeclaration>(
+          "h", htSchema, std::vector<std::string>{"missing"}),
+      "key column is not in the schema");
+  VELOX_ASSERT_USER_THROW(
+      std::make_shared<HashTableStateDeclaration>(
+          "h", htSchema, std::vector<std::string>{"k", "k"}),
+      "key columns must be unique");
+
+  // StateHashJoin needs a non-null probe source and at least one probe key.
+  VELOX_ASSERT_USER_THROW(
+      std::make_shared<StateHashJoinNode>(
+          "j", "h", std::vector<std::string>{"k"}, htSchema, nullptr),
+      "non-null probe source");
+  VELOX_ASSERT_USER_THROW(
+      std::make_shared<StateHashJoinNode>(
+          "j", "h", std::vector<std::string>{}, htSchema, body),
+      "at least one probe key");
+
+  // State declaration names must be unique across all kinds.
+  VELOX_ASSERT_USER_THROW(
+      std::make_shared<FixedPointNode>(
+          "fp",
+          std::vector<StateDeclarationPtr>{
+              vectorN(),
+              std::make_shared<VectorStateDeclaration>("n", vecSchema)},
+          std::vector<PlanNodePtr>{body},
+          ConvergenceConfig{
+              .maxIterations = 5, .errorWhenMaxIterationReached = false},
+          "n"),
+      "duplicate state declaration name");
+
+  // A StateSource must reference a declared vector entry.
+  auto typoBody =
+      std::make_shared<StateSourceNode>("b", "typo", vecSchema, /*delta=*/true);
+  VELOX_ASSERT_USER_THROW(
+      std::make_shared<FixedPointNode>(
+          "fp",
+          std::vector<StateDeclarationPtr>{vectorN()},
+          std::vector<PlanNodePtr>{typoBody},
+          ConvergenceConfig{
+              .maxIterations = 5, .errorWhenMaxIterationReached = false},
+          "n"),
+      "StateSource references no declared vector state entry");
+
+  // errorWhenMaxIterationReached requires a convergence plan (a null plan never
+  // converges, so it would always fail).
+  VELOX_ASSERT_USER_THROW(
+      std::make_shared<FixedPointNode>(
+          "fp",
+          std::vector<StateDeclarationPtr>{vectorN()},
+          std::vector<PlanNodePtr>{body},
+          ConvergenceConfig{
+              .maxIterations = 5, .errorWhenMaxIterationReached = true},
+          "n"),
+      "errorWhenMaxIterationReached requires a convergence plan");
+
+  // A convergence plan must emit exactly one BOOLEAN column.
+  auto nonBoolConvergence =
+      std::make_shared<StateSourceNode>("c", "n", vecSchema, /*delta=*/false);
+  VELOX_ASSERT_USER_THROW(
+      std::make_shared<FixedPointNode>(
+          "fp",
+          std::vector<StateDeclarationPtr>{vectorN()},
+          std::vector<PlanNodePtr>{body},
+          ConvergenceConfig{.plan = nonBoolConvergence, .maxIterations = 5},
+          "n"),
+      "convergence plan output column must be BOOLEAN");
+
+  auto twoColSchema = ROW({"a", "b"}, BOOLEAN());
+  auto twoColConvergence = std::make_shared<StateSourceNode>(
+      "c", "flags", twoColSchema, /*delta=*/false);
+  VELOX_ASSERT_USER_THROW(
+      std::make_shared<FixedPointNode>(
+          "fp",
+          std::vector<StateDeclarationPtr>{
+              vectorN(),
+              std::make_shared<VectorStateDeclaration>("flags", twoColSchema)},
+          std::vector<PlanNodePtr>{body},
+          ConvergenceConfig{.plan = twoColConvergence, .maxIterations = 5},
+          "n"),
+      "exactly one output column");
+
+  // A StateHashJoin output arity must equal probe columns plus the hash table's
+  // payload columns.
+  auto badArityJoin = std::make_shared<StateHashJoinNode>(
+      "j",
+      "h",
+      std::vector<std::string>{"x"},
+      vecSchema,
+      std::make_shared<StateSourceNode>("b", "n", vecSchema, /*delta=*/true));
+  VELOX_ASSERT_USER_THROW(
+      std::make_shared<FixedPointNode>(
+          "fp",
+          std::vector<StateDeclarationPtr>{
+              vectorN(),
+              std::make_shared<HashTableStateDeclaration>(
+                  "h", htSchema, std::vector<std::string>{"k"})},
+          std::vector<PlanNodePtr>{badArityJoin},
+          ConvergenceConfig{
+              .maxIterations = 5, .errorWhenMaxIterationReached = false},
+          "n"),
+      "output arity must equal probe columns plus hash table payload columns");
+
+  // A StateHashJoin's leading probe key column types must match the hash
+  // table's build key types (keys-first on both sides).
+  auto varcharProbe = ROW("k", VARCHAR());
+  auto badKeyTypeJoin = std::make_shared<StateHashJoinNode>(
+      "j",
+      "h",
+      std::vector<std::string>{"k"},
+      ROW({"k", "v"}, {VARCHAR(), BIGINT()}),
+      std::make_shared<StateSourceNode>(
+          "s", "probe", varcharProbe, /*delta=*/true));
+  VELOX_ASSERT_USER_THROW(
+      std::make_shared<FixedPointNode>(
+          "fp",
+          std::vector<StateDeclarationPtr>{
+              std::make_shared<VectorStateDeclaration>("probe", varcharProbe),
+              std::make_shared<HashTableStateDeclaration>(
+                  "h", htSchema, std::vector<std::string>{"k"})},
+          std::vector<PlanNodePtr>{badKeyTypeJoin},
+          ConvergenceConfig{
+              .maxIterations = 5, .errorWhenMaxIterationReached = false},
+          "probe"),
+      "probe key column type at channel 0 must match the hash table build key");
+
+  // A null body plan is rejected with a clean error rather than crashing.
+  VELOX_ASSERT_USER_THROW(
+      std::make_shared<FixedPointNode>(
+          "fp",
+          std::vector<StateDeclarationPtr>{vectorN()},
+          std::vector<PlanNodePtr>{nullptr},
+          ConvergenceConfig{
+              .maxIterations = 5, .errorWhenMaxIterationReached = false},
+          "n"),
+      "plan 0 must not be null");
+
+  // Hash table key columns must be the leading schema columns (keys-first).
+  VELOX_ASSERT_USER_THROW(
+      std::make_shared<HashTableStateDeclaration>(
+          "h", ROW({"v", "k"}, BIGINT()), std::vector<std::string>{"k"}),
+      "leading schema columns in order");
+
+  // An initial plan must not read state -- it runs in Phase 1 before state
+  // exists.
+  auto stateReadingInitial =
+      std::make_shared<StateSourceNode>("s", "n", vecSchema, /*delta=*/true);
+  VELOX_ASSERT_USER_THROW(
+      std::make_shared<FixedPointNode>(
+          "fp",
+          std::vector<StateDeclarationPtr>{
+              std::make_shared<VectorStateDeclaration>(
+                  "n", vecSchema, stateReadingInitial, /*append=*/true)},
+          std::vector<PlanNodePtr>{body},
+          ConvergenceConfig{
+              .maxIterations = 5, .errorWhenMaxIterationReached = false},
+          "n"),
+      "initial plan must not read state");
 }
 
 } // namespace

--- a/velox/exec/tests/PlanNodeSerdeTest.cpp
+++ b/velox/exec/tests/PlanNodeSerdeTest.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/connectors/hive/HiveConnector.h"
+#include "velox/core/FixedPointPlanNodes.h"
 #include "velox/exec/PartitionFunction.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
@@ -1047,6 +1048,176 @@ TEST_F(PlanNodeSerdeTest, countingJoin) {
                     .planNode();
     testSerde(plan);
   }
+}
+
+// Fixed-point plan nodes.  Each named computation is one recognizable shape;
+// the same catalog drives PlanNodeToStringTest, and execution is covered by
+// FixedPointTest.  The simplest shape (Sequence) leads.
+
+TEST_F(PlanNodeSerdeTest, fixedPointSequence) {
+  // Shape (1): a fixed-count loop producing x = 1..10.  One append-mode vector
+  // state, a single body plan, and no convergence plan (bounded by
+  // maxIterations).
+  auto idGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto schema = ROW("x", BIGINT());
+  auto seed =
+      PlanBuilder(idGenerator)
+          .values({makeRowVector({"x"}, {makeFlatVector<int64_t>({1})})})
+          .planNode();
+  auto plan =
+      PlanBuilder(idGenerator)
+          .fixedPoint(
+              core::VectorState("n", schema, /*append=*/true).initial(seed),
+              PlanBuilder(idGenerator)
+                  .stateSource("n", schema)
+                  .project({"x + 1 AS x"}),
+              core::ConvergenceConfig::withMaxIterations(9))
+          .planNode();
+  testSerde(plan);
+}
+
+TEST_F(PlanNodeSerdeTest, fixedPointFibonacci) {
+  // Shape (2): iterate Fibonacci until the latest value exceeds a bound.  A
+  // replace-mode vector state read in full each iteration, with a convergence
+  // plan -- the convergence-driven counterpart to the fixed-count sequence.
+  auto idGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto schema = ROW({"a", "b"}, BIGINT());
+  auto seed =
+      PlanBuilder(idGenerator)
+          .values({makeRowVector(
+              {"a", "b"},
+              {makeFlatVector<int64_t>({0}), makeFlatVector<int64_t>({1})})})
+          .planNode();
+  auto convergence = PlanBuilder(idGenerator)
+                         .stateSource("fib", schema, /*delta=*/false)
+                         .project({"b > 100 AS converged"})
+                         .planNode();
+  auto plan = PlanBuilder(idGenerator)
+                  .fixedPoint(
+                      core::VectorState("fib", schema).initial(seed),
+                      PlanBuilder(idGenerator)
+                          .stateSource("fib", schema, /*delta=*/false)
+                          .project({"b AS a", "a + b AS b"}),
+                      core::ConvergenceConfig::converging(convergence, 100))
+                  .planNode();
+  testSerde(plan);
+}
+
+TEST_F(PlanNodeSerdeTest, fixedPointThreeDegrees) {
+  // Shape (3): people within 3 degrees in the social graph, modeled as
+  // hash-table reuse -- a HashTable state (the graph) built once and probed via
+  // StateHashJoin each iteration, an append-mode frontier read as a delta, and
+  // empty-frontier convergence.  Keeps the structural round-trip assertions
+  // because toString() does not surface every serialized field.
+  auto people = ROW({"id", "depth"}, BIGINT());
+  auto edges = ROW({"src", "dst"}, BIGINT());
+  auto joinOutput = ROW({"id", "depth", "dst"}, BIGINT());
+  auto idGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+
+  auto me =
+      PlanBuilder(idGenerator)
+          .values({makeRowVector(
+              {"id", "depth"},
+              {makeFlatVector<int64_t>({1}), makeFlatVector<int64_t>({0})})})
+          .planNode();
+  auto graph = PlanBuilder(idGenerator)
+                   .values({makeRowVector(
+                       {"src", "dst"},
+                       {makeFlatVector<int64_t>({1, 2}),
+                        makeFlatVector<int64_t>({2, 3})})})
+                   .planNode();
+
+  // Body: read the frontier delta, probe the graph, append the next hop.
+  auto body = PlanBuilder(idGenerator)
+                  .stateSource("reach", people, /*delta=*/true)
+                  .stateHashJoin("graph", {"id"}, joinOutput)
+                  .project({"dst AS id", "depth + 1 AS depth"})
+                  .planNode();
+  // Converged once the last iteration appended no rows.
+  auto convergence = PlanBuilder(idGenerator)
+                         .stateSource("reach", people, /*delta=*/true)
+                         .singleAggregation({}, {"count(1)"})
+                         .project({"a0 = 0 AS converged"})
+                         .planNode();
+
+  auto plan =
+      PlanBuilder(idGenerator)
+          .fixedPoint(
+              {core::HashTableState("graph", edges, {"src"}).initial(graph),
+               core::VectorState("reach", people, /*append=*/true).initial(me)},
+              {body},
+              core::ConvergenceConfig::converging(convergence, 3),
+              "reach")
+          .planNode();
+
+  testSerde(plan);
+
+  // toString() does not surface every field, so assert the structurally
+  // significant ones survive the round-trip directly.
+  const auto copy = velox::ISerializable::deserialize<core::PlanNode>(
+      plan->serialize(), pool());
+  const auto* fixedPoint =
+      dynamic_cast<const core::FixedPointNode*>(copy.get());
+  ASSERT_NE(fixedPoint, nullptr);
+  EXPECT_EQ(fixedPoint->outputStateEntry(), "reach");
+  ASSERT_EQ(fixedPoint->stateDeclarations().size(), 2);
+  ASSERT_NE(fixedPoint->convergenceConfig().plan, nullptr);
+
+  const auto& hashTableState =
+      dynamic_cast<const core::HashTableStateDeclaration&>(
+          *fixedPoint->stateDeclarations()[0]);
+  EXPECT_EQ(hashTableState.keyColumns(), std::vector<std::string>{"src"});
+
+  const auto& vectorState = dynamic_cast<const core::VectorStateDeclaration&>(
+      *fixedPoint->stateDeclarations()[1]);
+  EXPECT_TRUE(vectorState.append());
+  ASSERT_NE(vectorState.initialPlan(), nullptr);
+
+  // The body's StateHashJoin probe keys and StateSource delta flag survive.
+  ASSERT_EQ(fixedPoint->plans().size(), 1);
+  const auto* project =
+      dynamic_cast<const core::ProjectNode*>(fixedPoint->plans()[0].get());
+  ASSERT_NE(project, nullptr);
+  const auto* join =
+      dynamic_cast<const core::StateHashJoinNode*>(project->sources()[0].get());
+  ASSERT_NE(join, nullptr);
+  EXPECT_EQ(join->probeKeys(), std::vector<std::string>{"id"});
+  const auto* bodySource =
+      dynamic_cast<const core::StateSourceNode*>(join->sources()[0].get());
+  ASSERT_NE(bodySource, nullptr);
+  EXPECT_TRUE(bodySource->delta());
+}
+
+TEST_F(PlanNodeSerdeTest, fixedPointDistributed) {
+  // Shape (4): one worker of a sharded reachability fixed point -- a two-plan
+  // body that shuffles (PartitionedOutput -> Exchange).  The cross-worker
+  // (N-way) topology is the coordinator's split-wiring, exercised by
+  // FixedPointTest, not a serialized field of this node.
+  auto idGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto schema = ROW({"key", "val"}, BIGINT());
+  auto seed = PlanBuilder(idGenerator)
+                  .values({makeRowVector(
+                      {"key", "val"},
+                      {makeFlatVector<int64_t>({0, 1}),
+                       makeFlatVector<int64_t>({1, 1})})})
+                  .planNode();
+  auto producer = PlanBuilder(idGenerator)
+                      .stateSource("frontier", schema)
+                      .partitionedOutput({"key"}, 2)
+                      .planNode();
+  auto consumer = PlanBuilder(idGenerator)
+                      .exchange(schema, "Presto")
+                      .singleAggregation({"key"}, {"sum(val)"})
+                      .project({"key", "a0 AS val"})
+                      .planNode();
+  auto plan = PlanBuilder(idGenerator)
+                  .fixedPoint(
+                      {core::VectorState("frontier", schema).initial(seed)},
+                      {producer, consumer},
+                      core::ConvergenceConfig::withMaxIterations(3),
+                      "frontier")
+                  .planNode();
+  testSerde(plan);
 }
 
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/connectors/hive/HiveConnector.h"
+#include "velox/core/FixedPointPlanNodes.h"
 #include "velox/exec/WindowFunction.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
@@ -1125,6 +1126,189 @@ TEST_F(PlanNodeToStringTest, countingJoin) {
   ASSERT_EQ("-- HashJoin[3]\n", plan->toString());
   ASSERT_EQ(
       "-- HashJoin[3][COUNTING LEFT SEMI (FILTER) c0=u_c0] -> c0:SMALLINT, c1:INTEGER\n",
+      plan->toString(true, false));
+}
+
+// Fixed-point plan nodes.  Each named computation is one recognizable shape;
+// the same catalog drives PlanNodeSerdeTest, and execution is covered by
+// FixedPointTest.
+
+// Leaf state-access nodes have a stable toString independent of the fixed
+// point's own details.
+TEST_F(PlanNodeToStringTest, stateSource) {
+  auto schema = ROW({"id", "depth"}, BIGINT());
+
+  // delta: an append entry's in-loop frontier (rows written last iteration).
+  auto frontier =
+      PlanBuilder().stateSource("reach", schema, /*delta=*/true).planNode();
+  ASSERT_EQ("-- StateSource[0]\n", frontier->toString());
+  ASSERT_EQ(
+      "-- StateSource[0][state: reach, delta] -> id:BIGINT, depth:BIGINT\n",
+      frontier->toString(true, false));
+
+  // full: the entry's whole accumulation.
+  auto full =
+      PlanBuilder().stateSource("reach", schema, /*delta=*/false).planNode();
+  ASSERT_EQ(
+      "-- StateSource[0][state: reach, full] -> id:BIGINT, depth:BIGINT\n",
+      full->toString(true, false));
+}
+
+TEST_F(PlanNodeToStringTest, stateHashJoin) {
+  auto schema = ROW({"id", "depth"}, BIGINT());
+  auto joinOutput = ROW({"id", "depth", "dst"}, BIGINT());
+  auto plan = PlanBuilder()
+                  .stateSource("reach", schema)
+                  .stateHashJoin("graph", {"id"}, joinOutput)
+                  .planNode();
+
+  ASSERT_EQ("-- StateHashJoin[1]\n", plan->toString());
+  ASSERT_EQ(
+      "-- StateHashJoin[1][state: graph, probeKeys: [id]] -> id:BIGINT, depth:BIGINT, dst:BIGINT\n",
+      plan->toString(true, false));
+}
+
+// Catalog shape (1): a fixed-count loop producing the sequence 1..10.  One
+// append-mode vector state, a single body plan, and no convergence plan
+// (bounded by maxIterations).
+TEST_F(PlanNodeToStringTest, fixedPointSequence) {
+  auto idGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto schema = ROW("x", BIGINT());
+  auto seed =
+      PlanBuilder(idGenerator)
+          .values({makeRowVector({"x"}, {makeFlatVector<int64_t>({1})})})
+          .planNode();
+  auto plan =
+      PlanBuilder(idGenerator)
+          .fixedPoint(
+              core::VectorState("n", schema, /*append=*/true).initial(seed),
+              PlanBuilder(idGenerator)
+                  .stateSource("n", schema)
+                  .project({"x + 1 AS x"}),
+              core::ConvergenceConfig::withMaxIterations(9))
+          .planNode();
+
+  ASSERT_EQ("-- FixedPoint[3]\n", plan->toString());
+  ASSERT_EQ(
+      "-- FixedPoint[3][outputStateEntry: n, states: [n (vector, append, initialized)], plans: 1, maxIterations: 9, errorWhenMaxIterationReached: false, convergencePlan: none] -> x:BIGINT\n",
+      plan->toString(true, false));
+}
+
+// Catalog shape (2): Fibonacci, iterate until the latest value exceeds a bound.
+// Replace-mode state read in full each iteration, with a convergence plan --
+// the convergence-driven counterpart to the fixed-count sequence.
+TEST_F(PlanNodeToStringTest, fixedPointFibonacci) {
+  auto idGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto schema = ROW({"a", "b"}, BIGINT());
+  auto seed =
+      PlanBuilder(idGenerator)
+          .values({makeRowVector(
+              {"a", "b"},
+              {makeFlatVector<int64_t>({0}), makeFlatVector<int64_t>({1})})})
+          .planNode();
+  auto convergence = PlanBuilder(idGenerator)
+                         .stateSource("fib", schema, /*delta=*/false)
+                         .project({"b > 100 AS converged"})
+                         .planNode();
+  auto plan = PlanBuilder(idGenerator)
+                  .fixedPoint(
+                      core::VectorState("fib", schema).initial(seed),
+                      PlanBuilder(idGenerator)
+                          .stateSource("fib", schema, /*delta=*/false)
+                          .project({"b AS a", "a + b AS b"}),
+                      core::ConvergenceConfig::converging(convergence, 100))
+                  .planNode();
+
+  ASSERT_EQ("-- FixedPoint[5]\n", plan->toString());
+  ASSERT_EQ(
+      "-- FixedPoint[5][outputStateEntry: fib, states: [fib (vector, replace, initialized)], plans: 1, maxIterations: 100, errorWhenMaxIterationReached: true, convergencePlan: present] -> a:BIGINT, b:BIGINT\n",
+      plan->toString(true, false));
+}
+
+// Catalog shape (3): people within 3 degrees in a social graph, modeled as
+// hash-table reuse -- a HashTable state (the graph) probed via StateHashJoin
+// each iteration, an append-mode frontier read as a delta, and empty-frontier
+// convergence.
+TEST_F(PlanNodeToStringTest, fixedPointThreeDegrees) {
+  auto idGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto people = ROW({"id", "depth"}, BIGINT());
+  auto edges = ROW({"src", "dst"}, BIGINT());
+  auto joinOutput = ROW({"id", "depth", "dst"}, BIGINT());
+
+  auto me =
+      PlanBuilder(idGenerator)
+          .values({makeRowVector(
+              {"id", "depth"},
+              {makeFlatVector<int64_t>({1}), makeFlatVector<int64_t>({0})})})
+          .planNode();
+  auto graph = PlanBuilder(idGenerator)
+                   .values({makeRowVector(
+                       {"src", "dst"},
+                       {makeFlatVector<int64_t>({1, 2}),
+                        makeFlatVector<int64_t>({2, 3})})})
+                   .planNode();
+
+  auto body = PlanBuilder(idGenerator)
+                  .stateSource("reach", people, /*delta=*/true)
+                  .stateHashJoin("graph", {"id"}, joinOutput)
+                  .project({"dst AS id", "depth + 1 AS depth"})
+                  .planNode();
+  auto convergence = PlanBuilder(idGenerator)
+                         .stateSource("reach", people, /*delta=*/true)
+                         .singleAggregation({}, {"count(1)"})
+                         .project({"a0 = 0 AS converged"})
+                         .planNode();
+
+  auto plan =
+      PlanBuilder(idGenerator)
+          .fixedPoint(
+              {core::HashTableState("graph", edges, {"src"}).initial(graph),
+               core::VectorState("reach", people, /*append=*/true).initial(me)},
+              {body},
+              core::ConvergenceConfig::converging(convergence, 3),
+              "reach")
+          .planNode();
+
+  ASSERT_EQ("-- FixedPoint[8]\n", plan->toString());
+  ASSERT_EQ(
+      "-- FixedPoint[8][outputStateEntry: reach, states: [graph (hashTable, keys: [src], initialized), reach (vector, append, initialized)], plans: 1, maxIterations: 3, errorWhenMaxIterationReached: true, convergencePlan: present] -> id:BIGINT, depth:BIGINT\n",
+      plan->toString(true, false));
+}
+
+// Catalog shape (4): one worker of a distributed reachability fixed point.  The
+// body shuffles -- plan 0 gathers the frontier through a PartitionedOutput,
+// plan 1 receives it via an Exchange.  The cross-worker (N-way) topology is the
+// coordinator's split-wiring, exercised by FixedPointTest, not a field of this
+// node.
+TEST_F(PlanNodeToStringTest, fixedPointDistributed) {
+  auto idGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto schema = ROW({"key", "val"}, BIGINT());
+  auto seed = PlanBuilder(idGenerator)
+                  .values({makeRowVector(
+                      {"key", "val"},
+                      {makeFlatVector<int64_t>({0, 1}),
+                       makeFlatVector<int64_t>({1, 1})})})
+                  .planNode();
+  auto producer = PlanBuilder(idGenerator)
+                      .stateSource("frontier", schema)
+                      .partitionedOutput({"key"}, 2)
+                      .planNode();
+  auto consumer = PlanBuilder(idGenerator)
+                      .exchange(schema, "Presto")
+                      .singleAggregation({"key"}, {"sum(val)"})
+                      .project({"key", "a0 AS val"})
+                      .planNode();
+  auto plan = PlanBuilder(idGenerator)
+                  .fixedPoint(
+                      {core::VectorState("frontier", schema).initial(seed)},
+                      {producer, consumer},
+                      core::ConvergenceConfig::withMaxIterations(3),
+                      "frontier")
+                  .planNode();
+
+  ASSERT_EQ("-- FixedPoint[6]\n", plan->toString());
+  ASSERT_EQ(
+      "-- FixedPoint[6][outputStateEntry: frontier, states: [frontier (vector, replace, initialized)], plans: 2, maxIterations: 3, errorWhenMaxIterationReached: false, convergencePlan: none] -> key:BIGINT, val:BIGINT\n",
       plan->toString(true, false));
 }
 

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -1365,6 +1365,88 @@ PlanBuilder& PlanBuilder::limit(int64_t offset, int64_t count, bool isPartial) {
   return *this;
 }
 
+PlanBuilder& PlanBuilder::fixedPoint(
+    std::vector<core::StateDeclarationPtr> stateDeclarations,
+    std::vector<core::PlanNodePtr> plans,
+    core::ConvergenceConfig convergenceConfig,
+    std::string outputStateEntry) {
+  VELOX_CHECK_NULL(
+      planNode_, "FixedPoint is a leaf node and cannot have an input");
+  planNode_ = std::make_shared<core::FixedPointNode>(
+      nextPlanNodeId(),
+      std::move(stateDeclarations),
+      std::move(plans),
+      std::move(convergenceConfig),
+      std::move(outputStateEntry));
+  return *this;
+}
+
+namespace {
+// Resolves the implicit output state entry: the name of the last
+// VectorStateDeclaration in 'declarations'.  Used when fixedPoint() is called
+// without an explicit outputStateEntry.
+std::string defaultOutputStateEntry(
+    const std::vector<core::StateDeclarationPtr>& declarations) {
+  for (auto it = declarations.rbegin(); it != declarations.rend(); ++it) {
+    if (auto vector =
+            std::dynamic_pointer_cast<const core::VectorStateDeclaration>(
+                *it)) {
+      return vector->name();
+    }
+  }
+  VELOX_USER_FAIL(
+      "fixedPoint requires at least one VectorStateDeclaration to use as the "
+      "output state entry");
+}
+} // namespace
+
+PlanBuilder& PlanBuilder::fixedPoint(
+    std::vector<core::StateDeclarationPtr> stateDeclarations,
+    const PlanBuilder& body,
+    core::ConvergenceConfig convergenceConfig,
+    std::optional<std::string> outputStateEntry) {
+  auto entry = outputStateEntry.has_value()
+      ? std::move(outputStateEntry).value()
+      : defaultOutputStateEntry(stateDeclarations);
+  return fixedPoint(
+      std::move(stateDeclarations),
+      std::vector<core::PlanNodePtr>{body.planNode()},
+      std::move(convergenceConfig),
+      std::move(entry));
+}
+
+PlanBuilder& PlanBuilder::fixedPoint(
+    core::StateDeclarationPtr stateDeclaration,
+    const PlanBuilder& body,
+    core::ConvergenceConfig convergenceConfig,
+    std::optional<std::string> outputStateEntry) {
+  return fixedPoint(
+      std::vector<core::StateDeclarationPtr>{std::move(stateDeclaration)},
+      body,
+      std::move(convergenceConfig),
+      std::move(outputStateEntry));
+}
+
+PlanBuilder& PlanBuilder::stateSource(
+    const std::string& stateName,
+    const RowTypePtr& outputType,
+    bool delta) {
+  VELOX_CHECK_NULL(planNode_, "StateSource must be the source node");
+  planNode_ = std::make_shared<core::StateSourceNode>(
+      nextPlanNodeId(), stateName, outputType, delta);
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::stateHashJoin(
+    const std::string& stateName,
+    std::vector<std::string> probeKeys,
+    const RowTypePtr& outputType) {
+  VELOX_CHECK_NOT_NULL(planNode_, "StateHashJoin cannot be the source node");
+  planNode_ = std::make_shared<core::StateHashJoinNode>(
+      nextPlanNodeId(), stateName, std::move(probeKeys), outputType, planNode_);
+  return *this;
+}
+
 PlanBuilder& PlanBuilder::enforceSingleRow() {
   planNode_ =
       std::make_shared<core::EnforceSingleRowNode>(nextPlanNodeId(), planNode_);

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -21,6 +21,7 @@
 #include <velox/core/PlanFragment.h>
 #include <velox/core/PlanNode.h>
 #include "velox/connectors/hive/HiveDataSink.h"
+#include "velox/core/FixedPointPlanNodes.h"
 #include "velox/parse/ExpressionsParser.h"
 #include "velox/parse/IExpr.h"
 #include "velox/parse/PlanNodeIdGenerator.h"
@@ -1173,6 +1174,56 @@ class PlanBuilder {
   /// final. Partial limit can run multi-threaded. Final limit must run
   /// single-threaded.
   PlanBuilder& limit(int64_t offset, int64_t count, bool isPartial);
+
+  /// Add a FixedPointNode as the root of the plan (a leaf in pipeline terms --
+  /// its iteration plans run as sub-tasks, not as pipeline sources).  Must be
+  /// the first node (no input).
+  ///
+  /// @param stateDeclarations Persistent state entries surviving across
+  /// iterations.
+  /// @param plans Per-iteration plans, run sequentially as sub-tasks.
+  /// @param convergenceConfig Convergence checking + iteration bound.
+  /// @param outputStateEntry The mutable vector state entry whose final
+  /// contents are emitted and into which each iteration's last plan output is
+  /// written.
+  PlanBuilder& fixedPoint(
+      std::vector<core::StateDeclarationPtr> stateDeclarations,
+      std::vector<core::PlanNodePtr> plans,
+      core::ConvergenceConfig convergenceConfig,
+      std::string outputStateEntry);
+
+  /// Add a FixedPointNode with a single per-iteration body plan (the common
+  /// case: no in-iteration shuffle).  `outputStateEntry` defaults to the last
+  /// declared VectorState when omitted.
+  PlanBuilder& fixedPoint(
+      std::vector<core::StateDeclarationPtr> stateDeclarations,
+      const PlanBuilder& body,
+      core::ConvergenceConfig convergenceConfig,
+      std::optional<std::string> outputStateEntry = std::nullopt);
+
+  /// Convenience overload for a single state declaration and a single body
+  /// plan.
+  PlanBuilder& fixedPoint(
+      core::StateDeclarationPtr stateDeclaration,
+      const PlanBuilder& body,
+      core::ConvergenceConfig convergenceConfig,
+      std::optional<std::string> outputStateEntry = std::nullopt);
+
+  /// Add a StateSourceNode as the source node, reading the named vector state
+  /// entry of the enclosing fixed point.  `delta` selects an append entry's
+  /// latest delta (the in-loop frontier) over its full accumulation; immaterial
+  /// for a replace entry.  Must be the first node (no input).
+  PlanBuilder& stateSource(
+      const std::string& stateName,
+      const RowTypePtr& outputType,
+      bool delta = true);
+
+  /// Add a StateHashJoinNode probing the named HashTable state entry of the
+  /// enclosing fixed point with the current plan as the probe input.
+  PlanBuilder& stateHashJoin(
+      const std::string& stateName,
+      std::vector<std::string> probeKeys,
+      const RowTypePtr& outputType);
 
   /// Add an EnforceSingleRowNode to ensure input has at most one row at
   /// runtime.


### PR DESCRIPTION
Summary:

Split out of the fixed point operator change (D107265824) so the plan-node contract reviews on its own.

Adds `FixedPointPlanNodes.h`: the `FixedPointNode` plan node that orchestrates iterative computation over persistent state, the `StateSourceNode` / `StateHashJoinNode` body nodes that read that state (the framework writes the last plan's output back into the output entry -- there is no sink node), the `StateDeclaration` hierarchy (`VectorStateDeclaration` and `HashTableStateDeclaration`), and `ConvergenceConfig`. These are plan-node (IR) definitions only; the operators, the `FixedPointTask` that runs the loop, and the core `Task` integration that consume them land in the dependent commit.

Reviewed By: mbasmanova

Differential Revision: D108331595


