### PR TITLE
fix: Link ORC reader into Hive connector tests

### DIFF
--- a/velox/connectors/hive/tests/CMakeLists.txt
+++ b/velox/connectors/hive/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ target_link_libraries(
   velox_hive_connector
   velox_hive_partition_function
   velox_dwio_common_exception
+  velox_dwio_orc_reader
   velox_vector_fuzzer
   velox_vector_test_lib
   velox_exec


### PR DESCRIPTION
Summary: `velox_hive_connector_test` calls `orc::registerOrcReaderFactory()` and `orc::unregisterOrcReaderFactory()` from `FileConnectorUtilTest` and `HiveConnectorUtilTest`, but the CMake test target did not link `velox_dwio_orc_reader`, which defines those symbols. Link the ORC reader library explicitly so OSS CMake builds can resolve the registrations.

Resolves: https://github.com/facebookincubator/velox/issues/17816

Differential Revision: D108435242


