### PR TITLE
perf: Preload small Nimble files to reduce WarmStorage round trips (#17821)

### DIFF
--- a/velox/common/file/File.h
+++ b/velox/common/file/File.h
@@ -41,6 +41,7 @@
 #include <folly/futures/Future.h>
 #include <folly/io/IOBuf.h>
 
+#include "velox/buffer/Buffer.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/RuntimeMetrics.h"
 #include "velox/common/file/FileIoTracer.h"
@@ -288,6 +289,13 @@ class InMemoryReadFile : public ReadFile {
   explicit InMemoryReadFile(std::string file)
       : ownedFile_(std::move(file)), file_(ownedFile_) {}
 
+  /// Constructs a file that takes ownership of 'buffer' and reads from it.
+  explicit InMemoryReadFile(BufferPtr buffer)
+      : ownedBuffer_(std::move(buffer)),
+        file_(
+            ownedBuffer_->as<char>(),
+            static_cast<size_t>(ownedBuffer_->size())) {}
+
   std::string_view pread(
       uint64_t offset,
       uint64_t length,
@@ -325,6 +333,11 @@ class InMemoryReadFile : public ReadFile {
   }
 
  private:
+  // Exactly one owning store is populated, depending on the constructor used:
+  // 'ownedBuffer_' (BufferPtr ctor) or 'ownedFile_' (std::string ctor); both
+  // stay empty for the non-owning string_view ctor. 'file_' views the active
+  // one.
+  const BufferPtr ownedBuffer_;
   const std::string ownedFile_;
   const std::string_view file_;
   bool shouldCoalesce_ = false;

--- a/velox/common/file/tests/FileTest.cpp
+++ b/velox/common/file/tests/FileTest.cpp
@@ -166,6 +166,24 @@ TEST(InMemoryFile, preadv) {
   EXPECT_EQ(expected, values);
 }
 
+TEST(InMemoryFile, ownedBuffer) {
+  memory::MemoryManager::Options options;
+  memory::MemoryManager manager{options};
+  auto pool = manager.addLeafPool();
+
+  const std::string data = "abcdefghij";
+  std::shared_ptr<InMemoryReadFile> readFile;
+  {
+    auto buffer = AlignedBuffer::allocate<char>(data.size(), pool.get());
+    memcpy(buffer->asMutable<char>(), data.data(), data.size());
+    readFile = std::make_shared<InMemoryReadFile>(std::move(buffer));
+  }
+
+  // The file owns the buffer, so reads succeed after the local handle is gone.
+  EXPECT_EQ(readFile->size(), data.size());
+  EXPECT_EQ(readFile->pread(0, data.size()), data);
+}
+
 class FaultyFsTest : public ::testing::Test {
  protected:
   FaultyFsTest() {}


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookincubator/nimble/pull/854

For small Nimble files (≤ filePreloadThreshold, default 4MB for presto batch  - same as DWRF), read the
entire file into memory once via ReadFile::pread(), then back both
TabletReader and BufferedInput with an InMemoryReadFile wrapping that
buffer.

This gives 1 storage round trip total:
- TabletReader::init() reads footer/metadata from InMemoryReadFile (memory)
- StripeStreams::enqueue() + BufferedInput::load() reads stripe data from
  InMemoryReadFile (memory)

Without this change, a small file with N stripes requires 1 + N round trips
(1 speculative tail read for footer + 1 per stripe for stream data).

This mirrors the DWRF reader's small-file preload optimization in
dwrf::ReaderBase which calls input_->preload() for files below the
threshold.

Reviewed By: xiaoxmeng

Differential Revision: D105470326


