### PR TITLE
feat(expr): Support the varargs IN form in subfield filter conversion (#17823)

### DIFF
--- a/velox/duckdb/conversion/DuckParser.cpp
+++ b/velox/duckdb/conversion/DuckParser.cpp
@@ -437,121 +437,151 @@ static bool areAllChildrenConstant(const OperatorExpression& operExpr) {
   return true;
 }
 
-// Parse an "operator", like NOT.
-core::ExprPtr parseOperatorExpr(
-    ParsedExpression& expr,
-    const ParseOptions& options) {
-  const auto& operExpr = dynamic_cast<OperatorExpression&>(expr);
-
-  // Code for array literal parsing (e.g. "ARRAY[1, 2, 3]")
-  if (expr.GetExpressionType() == ExpressionType::ARRAY_CONSTRUCTOR) {
-    if (areAllChildrenConstant(operExpr)) {
-      std::vector<Variant> arrayElements;
-      arrayElements.reserve(operExpr.children.size());
-
-      TypePtr valueType = UNKNOWN();
-      for (const auto& child : operExpr.children) {
-        if (auto constantExpr =
-                dynamic_cast<ConstantExpression*>(child.get())) {
-          auto& value = constantExpr->value;
-          if (value.type().id() == LogicalTypeId::INTEGER &&
-              options.parseIntegerAsBigint) {
-            value = Value::BIGINT(value.GetValue<int32_t>());
-          }
-          if (options.parseDecimalAsDouble &&
-              value.type().id() == duckdb::LogicalTypeId::DECIMAL) {
-            value = Value::DOUBLE(value.GetValue<double>());
-          }
-          arrayElements.emplace_back(duckValueToVariant(value));
-          if (!value.IsNull()) {
-            valueType = toVeloxType(value.type());
-          }
-        } else {
-          VELOX_UNREACHABLE();
-        }
+// Folds one constant array/IN-list element into 'values', widening
+// INTEGER->BIGINT and DECIMAL->DOUBLE per 'options', and tracks the array
+// element type from the non-null elements. Handles a plain constant and a cast
+// of a constant (the IN parser emits CAST(NULL AS T) for a typed NULL). Sharing
+// this keeps `a IN (x, y)` equivalent to `a IN ARRAY[x, y]`.
+void appendConstantArrayElement(
+    ParsedExpression& element,
+    const ParseOptions& options,
+    std::vector<Variant>& values,
+    TypePtr& valueType) {
+  if (const auto castExpr = dynamic_cast<CastExpression*>(&element)) {
+    if (castExpr->child->GetExpressionType() ==
+        ExpressionType::VALUE_CONSTANT) {
+      auto constExpr = dynamic_cast<ConstantExpression*>(castExpr->child.get());
+      if (constExpr->value.IsNull()) {
+        // A typed NULL (e.g. CAST(NULL AS BIGINT)) has no value to cast;
+        // represent it as an UNKNOWN null and let the non-null elements
+        // determine the array element type.
+        values.emplace_back(Variant(TypeKind::UNKNOWN));
+      } else {
+        auto value = constExpr->value.DefaultCastAs(
+            castExpr->cast_type, !castExpr->try_cast);
+        values.emplace_back(duckValueToVariant(value));
+        valueType = toVeloxType(castExpr->cast_type);
       }
-      return std::make_shared<const core::ConstantExpr>(
-          ARRAY(valueType), Variant::array(arrayElements), getAlias(expr));
-    } else {
-      std::vector<core::ExprPtr> params;
-      params.reserve(operExpr.children.size());
-
-      for (const auto& child : operExpr.children) {
-        params.emplace_back(parseExpr(*child, options));
-      }
-      return callExpr(
-          "array_constructor", std::move(params), getAlias(expr), options);
+      return;
     }
   }
 
-  // Check if the operator is "IN" or "NOT IN".
-  if (expr.GetExpressionType() == ExpressionType::COMPARE_IN ||
-      expr.GetExpressionType() == ExpressionType::COMPARE_NOT_IN) {
-    auto numValues = operExpr.children.size() - 1;
+  if (auto constantExpr = dynamic_cast<ConstantExpression*>(&element)) {
+    auto& value = constantExpr->value;
+    if (value.type().id() == LogicalTypeId::INTEGER &&
+        options.parseIntegerAsBigint) {
+      value = Value::BIGINT(value.GetValue<int32_t>());
+    }
+    if (options.parseDecimalAsDouble &&
+        value.type().id() == duckdb::LogicalTypeId::DECIMAL) {
+      value = Value::DOUBLE(value.GetValue<double>());
+    }
+    values.emplace_back(duckValueToVariant(value));
+    if (!value.IsNull()) {
+      valueType = toVeloxType(value.type());
+    }
+    return;
+  }
 
+  VELOX_UNSUPPORTED("Array / IN-list elements must be constant");
+}
+
+// Parses an array literal such as "ARRAY[1, 2, 3]".
+core::ExprPtr parseArrayConstructorExpr(
+    ParsedExpression& expr,
+    const ParseOptions& options) {
+  const auto& operExpr = dynamic_cast<OperatorExpression&>(expr);
+  if (areAllChildrenConstant(operExpr)) {
     std::vector<Variant> values;
-    if (options.parseInListAsArray) {
-      values.reserve(numValues);
-    }
-
-    std::vector<core::ExprPtr> params;
-    if (!options.parseInListAsArray) {
-      params.reserve(numValues + 1);
-    }
-    params.emplace_back(parseExpr(*operExpr.children[0], options));
-
+    values.reserve(operExpr.children.size());
     TypePtr valueType = UNKNOWN();
-    for (auto i = 0; i < numValues; i++) {
-      auto valueExpr = operExpr.children[i + 1].get();
+    for (const auto& child : operExpr.children) {
+      appendConstantArrayElement(*child, options, values, valueType);
+    }
+    return std::make_shared<const core::ConstantExpr>(
+        ARRAY(valueType), Variant::array(values), getAlias(expr));
+  }
+
+  std::vector<core::ExprPtr> params;
+  params.reserve(operExpr.children.size());
+  for (const auto& child : operExpr.children) {
+    params.emplace_back(parseExpr(*child, options));
+  }
+  return callExpr(
+      "array_constructor", std::move(params), getAlias(expr), options);
+}
+
+// Parses an IN or NOT IN predicate. With 'parseInListAsArray' the value list is
+// folded into a single array constant; otherwise it stays as varargs.
+core::ExprPtr parseInExpr(ParsedExpression& expr, const ParseOptions& options) {
+  const auto& operExpr = dynamic_cast<OperatorExpression&>(expr);
+  const auto numChildren = operExpr.children.size();
+
+  std::vector<core::ExprPtr> params;
+  params.reserve(options.parseInListAsArray ? 2 : numChildren);
+  params.emplace_back(parseExpr(*operExpr.children[0], options));
+
+  if (options.parseInListAsArray) {
+    // Fold the value list into a single array constant, identically to an
+    // `ARRAY[...]` literal, so `a IN (x, y)` == `a IN ARRAY[x, y]`.
+    std::vector<Variant> values;
+    values.reserve(numChildren - 1);
+    TypePtr valueType = UNKNOWN();
+    for (size_t i = 1; i < numChildren; ++i) {
+      appendConstantArrayElement(
+          *operExpr.children[i], options, values, valueType);
+    }
+    params.emplace_back(
+        std::make_shared<const core::ConstantExpr>(
+            ARRAY(valueType), Variant::array(values), std::nullopt));
+  } else {
+    for (size_t i = 1; i < numChildren; ++i) {
+      auto valueExpr = operExpr.children[i].get();
       if (const auto castExpr = dynamic_cast<CastExpression*>(valueExpr)) {
         if (castExpr->child->GetExpressionType() ==
             ExpressionType::VALUE_CONSTANT) {
           auto constExpr =
               dynamic_cast<ConstantExpression*>(castExpr->child.get());
-          auto value = constExpr->value.DefaultCastAs(
-              castExpr->cast_type, !castExpr->try_cast);
-          if (options.parseInListAsArray) {
-            values.emplace_back(duckValueToVariant(value));
-            valueType = toVeloxType(castExpr->cast_type);
-          } else {
-            params.emplace_back(parseExpr(*castExpr->child, options));
-          }
+          // Preserve the cast for a typed NULL so its type survives
+          // (parseCastExpr folds CAST(NULL AS T) to a typed null constant);
+          // a non-null constant keeps its folded value.
+          params.emplace_back(
+              constExpr->value.IsNull() ? parseExpr(*valueExpr, options)
+                                        : parseExpr(*castExpr->child, options));
           continue;
         }
       }
-
-      if (auto constantExpr = dynamic_cast<ConstantExpression*>(valueExpr)) {
-        if (options.parseInListAsArray) {
-          auto& value = constantExpr->value;
-          if (options.parseDecimalAsDouble &&
-              value.type().id() == duckdb::LogicalTypeId::DECIMAL) {
-            value = Value::DOUBLE(value.GetValue<double>());
-          }
-          values.emplace_back(duckValueToVariant(value));
-          if (!value.IsNull()) {
-            valueType = toVeloxType(value.type());
-          }
-        } else {
-          params.emplace_back(parseExpr(*constantExpr, options));
-        }
+      if (dynamic_cast<ConstantExpression*>(valueExpr)) {
+        params.emplace_back(parseExpr(*valueExpr, options));
         continue;
       }
-
       VELOX_UNSUPPORTED("IN list values need to be constant");
     }
-
-    if (options.parseInListAsArray) {
-      params.emplace_back(
-          std::make_shared<const core::ConstantExpr>(
-              ARRAY(valueType), Variant::array(values), std::nullopt));
-    }
-    auto inExpr = callExpr("in", std::move(params), getAlias(expr), options);
-    // Translate COMPARE_NOT_IN into NOT(IN()).
-    return (expr.GetExpressionType() == ExpressionType::COMPARE_IN)
-        ? inExpr
-        : callExpr("not", inExpr, std::nullopt, options);
   }
 
+  auto inExpr = callExpr("in", std::move(params), getAlias(expr), options);
+  // Translate COMPARE_NOT_IN into NOT(IN()).
+  return (expr.GetExpressionType() == ExpressionType::COMPARE_IN)
+      ? inExpr
+      : callExpr("not", inExpr, std::nullopt, options);
+}
+
+// Parses an operator expression: array literals, IN / NOT IN, STRUCT_EXTRACT,
+// IS NOT NULL, and the generic operator-to-function fallback.
+core::ExprPtr parseOperatorExpr(
+    ParsedExpression& expr,
+    const ParseOptions& options) {
+  switch (expr.GetExpressionType()) {
+    case ExpressionType::ARRAY_CONSTRUCTOR:
+      return parseArrayConstructorExpr(expr, options);
+    case ExpressionType::COMPARE_IN:
+    case ExpressionType::COMPARE_NOT_IN:
+      return parseInExpr(expr, options);
+    default:
+      break;
+  }
+
+  const auto& operExpr = dynamic_cast<OperatorExpression&>(expr);
   std::vector<core::ExprPtr> params;
   params.reserve(operExpr.children.size());
 

--- a/velox/duckdb/conversion/tests/DuckParserTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckParserTest.cpp
@@ -50,6 +50,34 @@ TEST(DuckParserTest, constants) {
   // Nulls
   EXPECT_EQ("null", parseExpr("NULL")->toString());
   EXPECT_EQ("null", parseExpr("NULL::double")->toString());
+  EXPECT_EQ("null", parseExpr("NULL::bigint")->toString());
+  EXPECT_EQ("null", parseExpr("NULL::integer")->toString());
+  EXPECT_EQ("null", parseExpr("NULL::varchar")->toString());
+  EXPECT_EQ("null", parseExpr("CAST(NULL AS bigint)")->toString());
+
+  // Typed NULL inside an IN list (folded to an array constant). Without the
+  // null handling in the cast branch, DefaultCastAs + GetValue would throw on
+  // the null.
+  EXPECT_EQ(
+      "in(\"a\",{1, 2, null})",
+      parseExpr("a in (1, 2, NULL::bigint)")->toString());
+  EXPECT_EQ(
+      "in(\"a\",{1, 2, null})",
+      parseExpr("a in (1, 2, NULL::integer)")->toString());
+  EXPECT_EQ(
+      "in(\"a\",{x, null})",
+      parseExpr("a in ('x', NULL::varchar)")->toString());
+
+  // The same IN list in varargs form (parseInListAsArray = false) keeps the
+  // typed NULL's type rather than collapsing it to an untyped UNKNOWN, so it
+  // can still resolve against the (T, T...) signature.
+  {
+    ParseOptions varargs;
+    varargs.parseInListAsArray = false;
+    EXPECT_EQ(
+        "in(\"a\",1,2,null)",
+        parseExpr("a in (1, 2, NULL::bigint)", varargs)->toString());
+  }
 
   // Booleans
   EXPECT_EQ("true", parseExpr("TRUE")->toString());

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -2714,9 +2714,14 @@ TEST_F(TableScanTest, statsBasedSkippingConstants) {
   writeToFile(filePaths[0]->getPath(), rowVector);
   createDuckDbTable({rowVector});
 
+  // Keep integer literals as INTEGER so an IN over an INTEGER column (c1) stays
+  // a subfield filter rather than getting a column cast that blocks skipping.
+  parse::ParseOptions parseOptions;
+  parseOptions.parseIntegerAsBigint = false;
   auto assertQuery = [&](const std::string& filter) {
     return TableScanTest::assertQuery(
         PlanBuilder(pool_.get())
+            .setParseOptions(parseOptions)
             .tableScan(asRowType(rowVector->type()), {filter})
             .planNode(),
         filePaths,

--- a/velox/exec/tests/utils/TpchQueryBuilder.cpp
+++ b/velox/exec/tests/utils/TpchQueryBuilder.cpp
@@ -1798,7 +1798,13 @@ TpchPlan TpchQueryBuilder::getQ16Plan() const {
   core::PlanNodeId supplierScanNodeId;
   core::PlanNodeId partsuppScanNodeId;
 
+  // Keep the IN-list literals as INTEGER so they match the INTEGER p_size
+  // column; widening them to BIGINT would cast the column and block the
+  // subfield filter pushdown.
+  parse::ParseOptions parseOptions;
+  parseOptions.parseIntegerAsBigint = false;
   auto part = PlanBuilder(planNodeIdGenerator, pool_.get())
+                  .setParseOptions(parseOptions)
                   .filtersAsNode(filtersAsNode_)
                   .tableScan(
                       kPart,

--- a/velox/expression/ExprToSubfieldFilter.cpp
+++ b/velox/expression/ExprToSubfieldFilter.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/expression/ExprToSubfieldFilter.h"
 
+#include <span>
+
 #include "velox/expression/Expr.h"
 
 using namespace facebook::velox;
@@ -48,6 +50,14 @@ T singleValue(const VectorPtr& vector) {
   auto simpleVector = vector->as<SimpleVector<T>>();
   VELOX_CHECK_NOT_NULL(simpleVector);
   return simpleVector->valueAt(0);
+}
+
+// True if 'kind' is an IN-list element type for which a subfield filter is
+// built (string BytesValues or widened-int BigintValues).
+bool isSupportedInElementKind(TypeKind kind) {
+  return kind == TypeKind::VARCHAR || kind == TypeKind::TINYINT ||
+      kind == TypeKind::SMALLINT || kind == TypeKind::INTEGER ||
+      kind == TypeKind::BIGINT;
 }
 
 bool isBigintRange(const std::unique_ptr<common::Filter>& filter) {
@@ -84,6 +94,27 @@ std::unique_ptr<common::BigintRange> asBigintRange(
   return asUniquePtr<common::BigintRange>(std::move(ptr));
 }
 
+// Builds an IN (or NOT IN) filter from the collected non-NULL 'values'.
+// 'hasNull' records whether the list contained a NULL. An IN over only NULLs,
+// and a NOT IN over any list containing a NULL, can never pass (SQL
+// three-valued logic: `a [NOT] IN (..., NULL)` is NULL), so both become
+// AlwaysFalse. Works for both int64 and string value lists via the overloaded
+// in()/notIn() helpers.
+template <typename T>
+std::unique_ptr<common::Filter>
+finishInFilter(std::vector<T> values, bool hasNull, bool negated) {
+  if (values.empty()) {
+    return std::make_unique<common::AlwaysFalse>();
+  }
+  if (negated) {
+    if (hasNull) {
+      return std::make_unique<common::AlwaysFalse>();
+    }
+    return notIn(values);
+  }
+  return in(values);
+}
+
 template <typename T>
 std::unique_ptr<common::Filter> toInt64In(
     const VectorPtr& vector,
@@ -108,16 +139,67 @@ std::unique_ptr<common::Filter> toInt64In(
     }
   }
 
-  if (negated) {
-    if (hasNull) {
-      // If values contain NULL, the input cannot pass the filter, e.g. '1
-      // not in (2, NULL)' evaluates to NULL.
-      return std::make_unique<common::AlwaysFalse>();
-    }
-    return notIn(values);
-  }
+  return finishInFilter(std::move(values), hasNull, negated);
+}
 
-  return in(values);
+// Builds an int64 IN filter from a list of single-row constant vectors (the
+// varargs `in(col, a, b, c, ...)` elements), widening from the integral element
+// type 'T'. Counterpart to the range-based toInt64In above.
+template <typename T>
+std::unique_ptr<common::Filter> toInt64In(
+    const std::vector<VectorPtr>& constants,
+    bool negated) {
+  std::vector<int64_t> values;
+  values.reserve(constants.size());
+  bool hasNull = false;
+  for (const auto& constant : constants) {
+    if (constant->isNullAt(0)) {
+      hasNull = true;
+    } else {
+      values.push_back(singleValue<T>(constant));
+    }
+  }
+  return finishInFilter(std::move(values), hasNull, negated);
+}
+
+// Builds a string IN filter from the [start, start + size) slice of 'vector'
+// (the `in(col, <ARRAY(VARCHAR) constant>)` elements).
+std::unique_ptr<common::Filter> toVarcharIn(
+    const VectorPtr& vector,
+    vector_size_t start,
+    vector_size_t size,
+    bool negated) {
+  auto strings = vector->as<SimpleVector<StringView>>();
+  std::vector<std::string> values;
+  values.reserve(size);
+  bool hasNull = false;
+  for (auto i = 0; i < size; i++) {
+    if (strings->isNullAt(start + i)) {
+      hasNull = true;
+    } else {
+      values.push_back(std::string(strings->valueAt(start + i)));
+    }
+  }
+  return finishInFilter(std::move(values), hasNull, negated);
+}
+
+// Builds a string IN filter from a list of single-row constant vectors (the
+// varargs `in(col, a, b, c, ...)` elements). Counterpart to the slice-based
+// toVarcharIn above.
+std::unique_ptr<common::Filter> toVarcharIn(
+    const std::vector<VectorPtr>& constants,
+    bool negated) {
+  std::vector<std::string> values;
+  values.reserve(constants.size());
+  bool hasNull = false;
+  for (const auto& constant : constants) {
+    if (constant->isNullAt(0)) {
+      hasNull = true;
+    } else {
+      values.push_back(std::string(singleValue<StringView>(constant)));
+    }
+  }
+  return finishInFilter(std::move(values), hasNull, negated);
 }
 
 } // namespace
@@ -467,9 +549,10 @@ std::unique_ptr<common::Filter> ExprToSubfieldFilterParser::makeInFilter(
     core::ExpressionEvaluator* evaluator,
     bool negated) {
   auto vector = toConstant(expr, evaluator);
-  if (!(vector && vector->type()->isArray())) {
+  if (!vector) {
     return nullptr;
   }
+  VELOX_CHECK(vector->type()->isArray());
 
   auto arrayVector = vector->valueVector()->as<ArrayVector>();
   auto index = vector->as<ConstantVector<ComplexType>>()->index();
@@ -487,37 +570,44 @@ std::unique_ptr<common::Filter> ExprToSubfieldFilterParser::makeInFilter(
       return toInt64In<int32_t>(elements, offset, size, negated);
     case TypeKind::BIGINT:
       return toInt64In<int64_t>(elements, offset, size, negated);
-    case TypeKind::VARCHAR: {
-      auto stringElements = elements->as<SimpleVector<StringView>>();
-      std::vector<std::string> values;
-      values.reserve(size);
-      bool hasNull = false;
-      if (!stringElements->mayHaveNulls()) {
-        for (auto i = 0; i < size; i++) {
-          values.push_back(std::string(stringElements->valueAt(offset + i)));
-        }
-      } else {
-        for (auto i = 0; i < size; i++) {
-          if (!stringElements->isNullAt(offset + i)) {
-            values.push_back(std::string(stringElements->valueAt(offset + i)));
-          } else if (!hasNull) {
-            hasNull = true;
-          }
-        }
-      }
-
-      if (negated) {
-        if (hasNull) {
-          // If values contain NULL, the input cannot pass the filter, e.g. 'a'
-          // not in ('b', NULL) evaluates to NULL.
-          return std::make_unique<common::AlwaysFalse>();
-        }
-        return notIn(values);
-      }
-      return in(values);
-    }
+    case TypeKind::VARCHAR:
+      return toVarcharIn(elements, offset, size, negated);
     default:
+      VELOX_UNREACHABLE();
+  }
+}
+
+// static
+std::unique_ptr<common::Filter> ExprToSubfieldFilterParser::makeVarargsInFilter(
+    std::span<const core::TypedExprPtr> valueExprs,
+    core::ExpressionEvaluator* evaluator,
+    bool negated) {
+  VELOX_CHECK(!valueExprs.empty());
+  const auto kind = valueExprs[0]->type()->kind();
+
+  std::vector<VectorPtr> constants;
+  constants.reserve(valueExprs.size());
+  for (const auto& expr : valueExprs) {
+    auto constant = toConstant(expr, evaluator);
+    if (!constant) {
       return nullptr;
+    }
+    constants.push_back(std::move(constant));
+  }
+
+  switch (kind) {
+    case TypeKind::TINYINT:
+      return toInt64In<int8_t>(constants, negated);
+    case TypeKind::SMALLINT:
+      return toInt64In<int16_t>(constants, negated);
+    case TypeKind::INTEGER:
+      return toInt64In<int32_t>(constants, negated);
+    case TypeKind::BIGINT:
+      return toInt64In<int64_t>(constants, negated);
+    case TypeKind::VARCHAR:
+      return toVarcharIn(constants, negated);
+    default:
+      VELOX_UNREACHABLE();
   }
 }
 
@@ -951,9 +1041,33 @@ PrestoExprToSubfieldFilterParser::leafCallToSubfieldFilter(
       return combine(subfield, filter);
     }
   } else if (call.name() == "in") {
-    if (toSubfield(leftSide, subfield)) {
-      auto filter = makeInFilter(call.inputs()[1], evaluator, negated);
-      return combine(subfield, filter);
+    const auto elementKind = leftSide->type()->kind();
+    if (isSupportedInElementKind(elementKind) &&
+        toSubfield(leftSide, subfield)) {
+      const auto& listType = call.inputs()[1]->type();
+
+      // Two encodings. The element kind is a supported scalar, so a second
+      // argument of that same kind is the varargs form `in(col, a, b, c, ...)`;
+      // otherwise it is the `in(col, <ARRAY(colType) constant>)` form.
+      std::unique_ptr<common::Filter> filter;
+      if (listType->kind() == elementKind) {
+        filter = makeVarargsInFilter(
+            std::span<const core::TypedExprPtr>(call.inputs()).subspan(1),
+            evaluator,
+            negated);
+      } else if (listType->isUnknown()) {
+        filter = std::make_unique<common::AlwaysFalse>();
+      } else {
+        VELOX_CHECK(listType->isArray());
+        if (listType->childAt(0)->isUnknown()) {
+          filter = std::make_unique<common::AlwaysFalse>();
+        } else {
+          filter = makeInFilter(call.inputs()[1], evaluator, negated);
+        }
+      }
+      if (filter) {
+        return combine(subfield, filter);
+      }
     }
   } else if (call.name() == "is_null") {
     if (toSubfield(leftSide, subfield)) {

--- a/velox/expression/ExprToSubfieldFilter.h
+++ b/velox/expression/ExprToSubfieldFilter.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <span>
+
 #include "velox/core/ExpressionEvaluator.h"
 #include "velox/core/Expressions.h"
 #include "velox/core/ITypedExpr.h"
@@ -545,6 +547,17 @@ class ExprToSubfieldFilterParser {
   // Creates an in subfield filter against the given vector.
   static std::unique_ptr<common::Filter> makeInFilter(
       const core::TypedExprPtr& expr,
+      core::ExpressionEvaluator* evaluator,
+      bool negated);
+
+  // Creates an in subfield filter from the varargs form
+  // `in(col, a, b, c, ...)` where 'valueExprs' are the list elements (each a
+  // constant of the column type). Counterpart to makeInFilter, which handles
+  // the `in(col, <constant array>)` form. Returns nullptr if an element is not
+  // constant-foldable. The caller guarantees the element type has a subfield
+  // IN filter.
+  static std::unique_ptr<common::Filter> makeVarargsInFilter(
+      std::span<const core::TypedExprPtr> valueExprs,
       core::ExpressionEvaluator* evaluator,
       bool negated);
 

--- a/velox/expression/tests/ExprToSubfieldFilterTest.cpp
+++ b/velox/expression/tests/ExprToSubfieldFilterTest.cpp
@@ -50,16 +50,22 @@ class ExprToSubfieldFilterTest : public testing::Test {
 
   core::TypedExprPtr parseExpr(
       const std::string& expr,
-      const RowTypePtr& type) {
+      const RowTypePtr& type,
+      bool parseInListAsArray = true) {
+    parse::ParseOptions options;
+    options.parseInListAsArray = parseInListAsArray;
     return core::Expressions::inferTypes(
-        parse::DuckSqlExpressionsParser().parseExpr(expr), type, pool_.get());
+        parse::DuckSqlExpressionsParser(options).parseExpr(expr),
+        type,
+        pool_.get());
   }
 
   core::CallTypedExprPtr parseCallExpr(
       const std::string& expr,
-      const RowTypePtr& type) {
+      const RowTypePtr& type,
+      bool parseInListAsArray = true) {
     auto call = std::dynamic_pointer_cast<const core::CallTypedExpr>(
-        parseExpr(expr, type));
+        parseExpr(expr, type, parseInListAsArray));
     VELOX_CHECK_NOT_NULL(call);
     return call;
   }
@@ -203,48 +209,103 @@ TEST_F(ExprToSubfieldFilterTest, between) {
   VELOX_ASSERT_FILTER(between(40, 42), filter);
 }
 
+// IN pushes as a subfield filter in both list encodings: the folded
+// `in(col, ARRAY[...])` form (parseInListAsArray = true) and the varargs
+// `in(col, a, b, ...)` form (false). The expectations are identical.
 TEST_F(ExprToSubfieldFilterTest, in) {
-  {
-    auto call = parseCallExpr("a in (40, 42)", ROW("a", BIGINT()));
-    auto [subfield, filter] = leafCallToSubfieldFilter(call);
+  for (bool inListAsArray : {true, false}) {
+    SCOPED_TRACE(inListAsArray ? "array" : "varargs");
+    auto toSubfieldFilter = [&](const auto& sql, const auto& type) {
+      return leafCallToSubfieldFilter(
+          parseCallExpr(sql, ROW("a", type), inListAsArray));
+    };
 
-    ASSERT_TRUE(filter);
-    validateSubfield(subfield, {"a"});
+    {
+      auto [subfield, filter] = toSubfieldFilter("a in (40, 42)", BIGINT());
+      ASSERT_TRUE(filter);
+      validateSubfield(subfield, {"a"});
+      VELOX_ASSERT_FILTER(in({40, 42}), filter);
+    }
 
-    VELOX_ASSERT_FILTER(in({40, 42}), filter);
-  }
+    {
+      auto [subfield, filter] = toSubfieldFilter("a in ('x', 'y')", VARCHAR());
+      ASSERT_TRUE(filter);
+      validateSubfield(subfield, {"a"});
+      VELOX_ASSERT_FILTER(in({"x", "y"}), filter);
+    }
 
-  {
-    auto call = parseCallExpr("a in (40, 42, null)", ROW("a", BIGINT()));
-    auto [subfield, filter] = leafCallToSubfieldFilter(call);
-
-    ASSERT_TRUE(filter);
-    validateSubfield(subfield, {"a"});
-
-    VELOX_ASSERT_FILTER(in({40, 42}), filter);
+    // A NULL element is dropped from the IN list.
+    {
+      auto [subfield, filter] =
+          toSubfieldFilter("a in (40, 42, null::bigint)", BIGINT());
+      ASSERT_TRUE(filter);
+      validateSubfield(subfield, {"a"});
+      VELOX_ASSERT_FILTER(in({40, 42}), filter);
+    }
   }
 }
 
 TEST_F(ExprToSubfieldFilterTest, notIn) {
-  {
-    auto call = parseCallExpr("a in (40, 42)", ROW("a", BIGINT()));
-    auto [subfield, filter] = leafCallToSubfieldFilter(call, true);
+  for (bool inListAsArray : {true, false}) {
+    SCOPED_TRACE(inListAsArray ? "array" : "varargs");
+    auto toSubfieldFilter = [&](const auto& sql, const auto& type) {
+      return leafCallToSubfieldFilter(
+          parseCallExpr(sql, ROW("a", type), inListAsArray), /*negated=*/true);
+    };
 
-    ASSERT_TRUE(filter);
-    validateSubfield(subfield, {"a"});
+    {
+      auto [subfield, filter] = toSubfieldFilter("a in (40, 42)", BIGINT());
+      ASSERT_TRUE(filter);
+      validateSubfield(subfield, {"a"});
+      VELOX_ASSERT_FILTER(notIn({40, 42}), filter);
+    }
 
-    VELOX_ASSERT_FILTER(notIn({40, 42}), filter);
+    {
+      auto [subfield, filter] = toSubfieldFilter("a in ('x', 'y')", VARCHAR());
+      ASSERT_TRUE(filter);
+      validateSubfield(subfield, {"a"});
+      VELOX_ASSERT_FILTER(notIn({"x", "y"}), filter);
+    }
+
+    // A NULL in the list makes NOT IN never pass.
+    {
+      auto [subfield, filter] =
+          toSubfieldFilter("a in (40, 42, null::bigint)", BIGINT());
+      ASSERT_TRUE(filter);
+      validateSubfield(subfield, {"a"});
+      VELOX_ASSERT_FILTER(std::make_unique<common::AlwaysFalse>(), filter);
+    }
   }
+}
 
-  {
-    auto call = parseCallExpr("a in (40, 42, null)", ROW("a", BIGINT()));
-    auto [subfield, filter] = leafCallToSubfieldFilter(call, true);
+// An all-NULL list never passes IN or NOT IN, in both encodings: the array form
+// is an `array(unknown)` constant; the varargs form collects no values, so
+// finishInFilter returns AlwaysFalse.
+TEST_F(ExprToSubfieldFilterTest, inAllNull) {
+  for (bool inListAsArray : {true, false}) {
+    SCOPED_TRACE(inListAsArray ? "array" : "varargs");
 
-    ASSERT_TRUE(filter);
-    validateSubfield(subfield, {"a"});
+    for (bool negated : {false, true}) {
+      auto toSubfieldFilter = [&](const auto& sql, const auto& type) {
+        return leafCallToSubfieldFilter(
+            parseCallExpr(sql, ROW("a", type), inListAsArray), negated);
+      };
 
-    auto expected = std::make_unique<common::AlwaysFalse>();
-    VELOX_ASSERT_FILTER(expected, filter);
+      {
+        auto [subfield, filter] =
+            toSubfieldFilter("a in (null::bigint, null::bigint)", BIGINT());
+        ASSERT_TRUE(filter);
+        validateSubfield(subfield, {"a"});
+        VELOX_ASSERT_FILTER(std::make_unique<common::AlwaysFalse>(), filter);
+      }
+      {
+        auto [subfield, filter] =
+            toSubfieldFilter("a in (null::varchar, null::varchar)", VARCHAR());
+        ASSERT_TRUE(filter);
+        validateSubfield(subfield, {"a"});
+        VELOX_ASSERT_FILTER(std::make_unique<common::AlwaysFalse>(), filter);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Summary:

`ExprToSubfieldFilter` only recognized the array IN form,
`in(col, ARRAY[a, b, c])`. The varargs form `in(col, a, b, c)` fell through to
a remaining filter, so the scan read every row and filtered afterwards instead
of pushing the value set into the table handle. Both forms now convert to a
subfield IN / NOT IN filter.

The `in` branch dispatches on the second argument: a scalar of the column type
is the varargs form, handled by a new `makeVarargsInFilter`; an array is the
existing path. An all-NULL list can never pass, so it pushes as an AlwaysFalse
filter — whether it arrives as an `array(unknown)` constant or as a varargs
list that collects no non-null values.

Reviewed By: xiaoxmeng

Differential Revision: D108517151


