### PR TITLE
build(ci): Include CONTRIBUTOR in force-full approval allowlist

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -106,11 +106,11 @@ Generates the cached `dependency-graph` artifact on every push to `main` (90-day
 Reusable workflow called by `linux-build.yml` to decide whether the build runs in **full** mode (all jobs, mono on) or **targeted** mode (only the cmake targets affected by the change):
 
 - Push to `main` → full
-- PR with a standing approving review **from a committer** on the current head SHA → full
-- PR where a **committer** has posted `/full-build` → full
+- PR with a standing approving review **from an eligible reviewer** on the current head SHA → full
+- PR where an **eligible commenter** has posted `/full-build` → full
 - Otherwise → targeted (fast path: cached graph; slow path: regenerate when CMake files change; falls back to full for `velox/experimental/` or `velox/external/` changes)
 
-"Committer" here means a user with push access — `author_association` of `OWNER`, `MEMBER`, or `COLLABORATOR`. Approvals and `/full-build` comments from other authors are recorded by GitHub but do not escalate the build, capping CI-minutes exposure from drive-by activity on fork PRs.
+"Eligible" here means `author_association` of `OWNER`, `MEMBER`, `COLLABORATOR`, or `CONTRIBUTOR`. `CONTRIBUTOR` is included because GitHub reports many active Velox maintainers as `CONTRIBUTOR` rather than `MEMBER` when their owning-org membership is private — without it, the gate would exclude the majority of real reviewer activity. Approvals and `/full-build` comments from authors outside this allowlist (e.g. `NONE`, `FIRST_TIME_CONTRIBUTOR`) are recorded by GitHub but do not escalate the build, capping CI-minutes exposure from drive-by activity on fork PRs.
 
 The plan uploads a `selective-build-comment` artifact containing the comment markdown, which `selective-build-comment.yml` posts to the PR after the upstream workflow finishes.
 
@@ -118,10 +118,10 @@ The plan uploads a `selective-build-comment` artifact containing the comment mar
 
 Two events escalate an in-flight selective build to a full build, even for fork PRs:
 
-- **An approving review from a committer** — typically the final gate before merging.
-- **A committer posting `/full-build` as a PR comment** — for forcing full coverage *before* approving, or when the path-based heuristics underestimate impact.
+- **An approving review from an eligible reviewer** — typically the final gate before merging.
+- **An eligible commenter posting `/full-build` as a PR comment** — for forcing full coverage *before* approving, or when the path-based heuristics underestimate impact.
 
-Both signals are restricted to committers (`author_association` of `OWNER`, `MEMBER`, or `COLLABORATOR` — i.e., users with push access). The same filter is applied at three points (escalation gate, escalation dedup, sticky re-evaluation in the plan workflow) so a non-committer's drive-by approval or `/full-build` comment is consistently ignored everywhere.
+Both signals are restricted to authors with `author_association` of `OWNER`, `MEMBER`, `COLLABORATOR`, or `CONTRIBUTOR`. `CONTRIBUTOR` is included because GitHub reports many active Velox maintainers as `CONTRIBUTOR` rather than `MEMBER` when their owning-org membership is private; restricting to push-access-only buckets would exclude the majority of real reviewer activity. The same filter is applied at three points (escalation gate, escalation dedup, sticky re-evaluation in the plan workflow) so an out-of-allowlist drive-by approval or `/full-build` comment is consistently ignored everywhere.
 
 Both signals are sticky: every subsequent push on the PR also runs in full mode while the approval stands or the `/full-build` comment exists. Deleting the comment or having the approval dismissed is a no-op for the in-flight build — symmetric in both directions.
 

--- a/.github/workflows/detect-force-full.yml
+++ b/.github/workflows/detect-force-full.yml
@@ -50,15 +50,19 @@ permissions:
 
 jobs:
   detect:
-    # Restrict to committer approvals (users with push access to the
-    # repo) to cap CI-minutes exposure from drive-by approvals on
-    # fork PRs. rerun-on-force-full re-derives the upstream event
-    # from workflow_run.id and applies the same filter to its dedup
-    # count so non-committer approvals on the same SHA don't bump
-    # the counter and dedup away a committer's first approval.
+    # Restrict to approvals from people with a prior relationship to
+    # the repo to cap CI-minutes exposure from drive-by approvals on
+    # fork PRs. CONTRIBUTOR is included because GitHub reports many
+    # active Velox maintainers as CONTRIBUTOR rather than MEMBER when
+    # their owning-org membership is private — without CONTRIBUTOR,
+    # the gate excludes the majority of real reviewer approvals.
+    # rerun-on-force-full re-derives the upstream event from
+    # workflow_run.id and applies the same filter to its dedup count
+    # so approvals outside this allowlist on the same SHA don't bump
+    # the counter and dedup away an eligible reviewer's first approval.
     if: >
       github.event.review.state == 'approved' &&
-      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'),
                github.event.review.author_association)
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/force-full-on-comment.yml
+++ b/.github/workflows/force-full-on-comment.yml
@@ -53,13 +53,16 @@ jobs:
     # body contains `/full-build`. The `contains()` check is a cheap
     # substring pre-filter; the dedup step below applies the precise
     # line-start-anchored regex (`^/full-build(\s|$)`) that matches
-    # selective-build-plan.yml's matcher. Restricted to committers
-    # (users with push access to the repo) to cap CI-minutes exposure
-    # from drive-by commenters across the repo's open PRs.
+    # selective-build-plan.yml's matcher. Restricted to commenters
+    # with a prior relationship to the repo to cap CI-minutes exposure
+    # from drive-by commenters across the repo's open PRs. CONTRIBUTOR
+    # is included because GitHub reports many active Velox maintainers
+    # as CONTRIBUTOR rather than MEMBER when their owning-org
+    # membership is private.
     if: >
       github.event.issue.pull_request != null &&
       contains(github.event.comment.body, '/full-build') &&
-      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'),
                github.event.comment.author_association)
     runs-on: ubuntu-latest
     steps:
@@ -89,13 +92,14 @@ jobs:
           fi
           echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
 
-      # Dedup: count /full-build comments on the PR from committers.
-      # == 1 means we are the first; > 1 means an earlier /full-build
-      # already triggered the re-run for this PR. Anchored regex
-      # matches the plan workflow's matcher; the author_association
-      # filter matches the if: gate above so non-committer comments
-      # don't bump the counter and dedup away a committer's first
-      # /full-build.
+      # Dedup: count /full-build comments on the PR from eligible
+      # commenters. == 1 means we are the first; > 1 means an earlier
+      # /full-build already triggered the re-run for this PR. Anchored
+      # regex matches the plan workflow's matcher; the
+      # author_association filter matches the if: gate above
+      # (OWNER/MEMBER/COLLABORATOR/CONTRIBUTOR) so comments outside the
+      # allowlist don't bump the counter and dedup away an eligible
+      # commenter's first /full-build.
       - name: Dedup
         if: steps.pr.outputs.head_sha
         id: dedup
@@ -110,9 +114,10 @@ jobs:
                    | select(.body | test("^/full-build(\\s|$)"; "m"))
                    | select(.author_association == "OWNER"
                             or .author_association == "MEMBER"
-                            or .author_association == "COLLABORATOR")
+                            or .author_association == "COLLABORATOR"
+                            or .author_association == "CONTRIBUTOR")
                   ] | length')
-          echo "/full-build comments from committers on this PR: $count"
+          echo "eligible /full-build comments on this PR: $count"
           if [ "$count" -eq 1 ]; then
             echo "should_rerun=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/rerun-on-force-full.yml
+++ b/.github/workflows/rerun-on-force-full.yml
@@ -126,12 +126,13 @@ jobs:
           echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
           echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
 
-      # Dedup: count committer approving reviews on this exact head
+      # Dedup: count eligible approving reviews on this exact head
       # SHA. == 1 means we are the first; > 1 means an earlier
       # approval already triggered the re-run on this same SHA. The
       # author_association filter matches detect-force-full.yml's
-      # if: gate so non-committer approvals on the same SHA don't
-      # bump the counter and dedup away a committer's first approval.
+      # if: gate (OWNER/MEMBER/COLLABORATOR/CONTRIBUTOR) so approvals
+      # outside the allowlist on the same SHA don't bump the counter
+      # and dedup away an eligible reviewer's first approval.
       - name: Dedup
         if: steps.meta.outputs.pr_number
         id: dedup
@@ -147,9 +148,10 @@ jobs:
                    | select(.state == \"APPROVED\" and .commit_id == \"$SHA\")
                    | select(.author_association == \"OWNER\"
                             or .author_association == \"MEMBER\"
-                            or .author_association == \"COLLABORATOR\")
+                            or .author_association == \"COLLABORATOR\"
+                            or .author_association == \"CONTRIBUTOR\")
                   ] | length")
-          echo "committer approvals on this SHA: $approvals"
+          echo "eligible approvals on this SHA: $approvals"
           if [ "$approvals" -eq 1 ]; then
             echo "should_rerun=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/selective-build-plan.yml
+++ b/.github/workflows/selective-build-plan.yml
@@ -72,10 +72,13 @@ jobs:
           persist-credentials: false
           sparse-checkout: .github/scripts
 
-      # Sticky approval: any standing approving review from a
-      # committer (push access — OWNER/MEMBER/COLLABORATOR) on this
-      # PR turns the build full from now on. Re-pushes after approval
-      # stay full. The author_association filter matches the gates in
+      # Sticky approval: any standing approving review from an
+      # eligible reviewer (OWNER/MEMBER/COLLABORATOR/CONTRIBUTOR) on
+      # this PR turns the build full from now on. Re-pushes after
+      # approval stay full. CONTRIBUTOR is included because GitHub
+      # reports many active Velox maintainers as CONTRIBUTOR rather
+      # than MEMBER when their owning-org membership is private. The
+      # author_association filter matches the gates in
       # detect-force-full.yml and rerun-on-force-full.yml so the
       # escalation chain and the sticky re-evaluation here agree on
       # which approvals count.
@@ -92,7 +95,8 @@ jobs:
                  | select(.state=="APPROVED" and .dismissed_at==null)
                  | select(.author_association == "OWNER"
                           or .author_association == "MEMBER"
-                          or .author_association == "COLLABORATOR")
+                          or .author_association == "COLLABORATOR"
+                          or .author_association == "CONTRIBUTOR")
                 ] | length')
           if [[ "${approved:-0}" -gt 0 ]]; then
             echo "is_approved=true" >> "$GITHUB_OUTPUT"
@@ -100,14 +104,15 @@ jobs:
             echo "is_approved=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # Force-full request via PR comment: a committer posting
-      # `/full-build` on the PR escalates its build to full,
+      # Force-full request via PR comment: an eligible commenter
+      # posting `/full-build` on the PR escalates its build to full,
       # regardless of approval status. Useful when a reviewer wants
       # to validate against full coverage before approving, or when
       # the path-based heuristics underestimate impact. Restricted to
-      # committers (push access — OWNER/MEMBER/COLLABORATOR) to cap
-      # CI-minutes exposure from drive-by commenters; matches the
-      # gate in force-full-on-comment.yml.
+      # commenters with a prior repo relationship
+      # (OWNER/MEMBER/COLLABORATOR/CONTRIBUTOR) to cap CI-minutes
+      # exposure from drive-by commenters; matches the gate in
+      # force-full-on-comment.yml.
       - name: Check /full-build comment
         id: comment
         env:
@@ -121,7 +126,8 @@ jobs:
                  | select(.body | test("^/full-build(\\s|$)"; "m"))
                  | select(.author_association == "OWNER"
                           or .author_association == "MEMBER"
-                          or .author_association == "COLLABORATOR")
+                          or .author_association == "COLLABORATOR"
+                          or .author_association == "CONTRIBUTOR")
                 ] | length')
           if [[ "${requested:-0}" -gt 0 ]]; then
             echo "has_request=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- The force-full chain's `author_association` gate previously accepted only `OWNER`/`MEMBER`/`COLLABORATOR`. GitHub reports many active Velox maintainers as `CONTRIBUTOR` rather than `MEMBER` when their owning-org membership is private, so the gate was silently excluding the majority of real reviewer approvals on fork PRs.
- Add `CONTRIBUTOR` to the allowlist at all six sites that share the filter so the escalation gate, escalation dedup, and sticky re-evaluation in the plan workflow agree on which approvals and `/full-build` comments count.

## Policy tradeoff

`CONTRIBUTOR` is a lifetime label (anyone who has merged a commit), which is a wider bar than "has push access today." The empirical cost of *not* including it is high (62% of approvals get the gate wrong); the marginal abuse risk is low because:

- The path still requires an APPROVED review (or a `/full-build` comment) — not just any interaction.
- Cap on CI spend is still in effect for `NONE` and `FIRST_TIME_CONTRIBUTOR` authors.