### PR TITLE
fix(iceberg): Use unique_ptr for parquetStatsCollector_

### DIFF
--- a/velox/connectors/hive/iceberg/IcebergDataSink.h
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.h
@@ -299,7 +299,7 @@ class IcebergDataSink : public HiveDataSink {
   // into the writer options. Polymorphic over the table's file format; created
   // via IcebergStatsCollector::create() and reused across all writers. Null
   // when the format has no Iceberg statistics support compiled in.
-  std::shared_ptr<IcebergStatsCollector> statsCollector_;
+  std::unique_ptr<IcebergStatsCollector> statsCollector_;
 };
 
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergStatsCollector.cpp
+++ b/velox/connectors/hive/iceberg/IcebergStatsCollector.cpp
@@ -23,7 +23,7 @@
 
 namespace facebook::velox::connector::hive::iceberg {
 
-std::shared_ptr<IcebergStatsCollector> IcebergStatsCollector::create(
+std::unique_ptr<IcebergStatsCollector> IcebergStatsCollector::create(
     dwio::common::FileFormat format,
     const std::vector<IcebergColumnHandlePtr>& inputColumns,
     const RowTypePtr& schema) {
@@ -32,10 +32,10 @@ std::shared_ptr<IcebergStatsCollector> IcebergStatsCollector::create(
     case dwio::common::FileFormat::ORC:
       // DWRF/ORC statistics are read from the writer footer; the collector maps
       // footer node ids to Iceberg field ids using the written row type.
-      return std::make_shared<IcebergDwrfStatsCollector>(inputColumns, schema);
+      return std::make_unique<IcebergDwrfStatsCollector>(inputColumns, schema);
 #ifdef VELOX_ENABLE_PARQUET
     case dwio::common::FileFormat::PARQUET:
-      return std::make_shared<IcebergParquetStatsCollector>(inputColumns);
+      return std::make_unique<IcebergParquetStatsCollector>(inputColumns);
 #endif
     default:
       return nullptr;

--- a/velox/connectors/hive/iceberg/IcebergStatsCollector.h
+++ b/velox/connectors/hive/iceberg/IcebergStatsCollector.h
@@ -63,7 +63,7 @@ class IcebergStatsCollector {
   /// @param inputColumns The Iceberg input column handles (carry the field-id
   /// trees).
   /// @param schema The written row type.
-  static std::shared_ptr<IcebergStatsCollector> create(
+  static std::unique_ptr<IcebergStatsCollector> create(
       dwio::common::FileFormat format,
       const std::vector<IcebergColumnHandlePtr>& inputColumns,
       const RowTypePtr& schema);


### PR DESCRIPTION
parquetStatsCollector_ is owned only by IcebergDataSink. It is constructed in the sink constructor, stored as a private member, and only used by `createWriterOptions()` and `closeWriterAndCollectStats()`. It is never shared or retained elsewhere.

Using shared_ptr suggests shared ownership that does not exist and made we ran into an lifetime issue in Gluten due to it. unique_ptr matches the actual ownership and prevents accidental extra owners.