### PR TITLE
feat: Add TpchQueryBuilder::getAltPlan

### DIFF
--- a/velox/exec/tests/utils/TpchQueryBuilder.cpp
+++ b/velox/exec/tests/utils/TpchQueryBuilder.cpp
@@ -159,7 +159,7 @@ TpchPlan TpchQueryBuilder::getQueryPlan(int queryId) const {
     case 8:
       return getQ8Plan();
     case 9:
-      return getQ9Plan();
+      return getQ9Plan("p_name like '%green%'");
     case 10:
       return getQ10Plan();
     case 11:
@@ -188,6 +188,15 @@ TpchPlan TpchQueryBuilder::getQueryPlan(int queryId) const {
       return getQ22Plan();
     default:
       VELOX_NYI("TPC-H query {} is not supported yet", queryId);
+  }
+}
+
+TpchPlan TpchQueryBuilder::getAltPlan(int queryId) const {
+  switch (queryId) {
+    case 9:
+      return getQ9Plan("p_size <= 3");
+    default:
+      VELOX_NYI("TPC-H query {} has no alternate plan", queryId);
   }
 }
 
@@ -1108,7 +1117,7 @@ TpchPlan TpchQueryBuilder::getQ8Plan() const {
   return context;
 }
 
-TpchPlan TpchQueryBuilder::getQ9Plan() const {
+TpchPlan TpchQueryBuilder::getQ9Plan(const std::string& partFilter) const {
   std::vector<std::string> lineitemColumns = {
       "l_suppkey",
       "l_partkey",
@@ -1116,7 +1125,7 @@ TpchPlan TpchQueryBuilder::getQ9Plan() const {
       "l_extendedprice",
       "l_orderkey",
       "l_quantity"};
-  std::vector<std::string> partColumns = {"p_name", "p_partkey"};
+  std::vector<std::string> partColumns = {"p_name", "p_size", "p_partkey"};
   std::vector<std::string> supplierColumns = {"s_suppkey", "s_nationkey"};
   std::vector<std::string> partsuppColumns = {
       "ps_partkey", "ps_suppkey", "ps_supplycost"};
@@ -1147,16 +1156,13 @@ TpchPlan TpchQueryBuilder::getQ9Plan() const {
   const std::vector<std::string> lineitemCommonColumns = {
       "l_extendedprice", "l_discount", "l_quantity"};
 
-  auto part = PlanBuilder(planNodeIdGenerator, pool_.get())
-                  .filtersAsNode(filtersAsNode_)
-                  .tableScan(
-                      kPart,
-                      partSelectedRowType,
-                      partFileColumns,
-                      {},
-                      "p_name like '%green%'")
-                  .captureScanNodeId(partScanNodeId)
-                  .planNode();
+  auto part =
+      PlanBuilder(planNodeIdGenerator, pool_.get())
+          .filtersAsNode(filtersAsNode_)
+          .tableScan(
+              kPart, partSelectedRowType, partFileColumns, {}, partFilter)
+          .captureScanNodeId(partScanNodeId)
+          .planNode();
 
   auto supplier =
       PlanBuilder(planNodeIdGenerator, pool_.get())

--- a/velox/exec/tests/utils/TpchQueryBuilder.h
+++ b/velox/exec/tests/utils/TpchQueryBuilder.h
@@ -70,6 +70,19 @@ class TpchQueryBuilder {
   /// @param queryId TPC-H query number
   TpchPlan getQueryPlan(int queryId) const;
 
+  /// Get an alternate plan for a TPC-H query whose original predicate is not
+  /// estimable from column statistics (e.g. a substring `like`). A cost-based
+  /// optimizer mis-estimates such a predicate's selectivity and may pick a
+  /// non-optimal join order, so there is no single plan to assert against. The
+  /// alternate swaps in an estimable filter of similar selectivity, giving
+  /// optimizer tests a stable, optimal reference plan.
+  ///
+  /// Supported alterations:
+  ///   q9: part filter `p_name like '%green%'` -> `p_size <= 3` (~6%).
+  ///
+  /// @param queryId TPC-H query number
+  TpchPlan getAltPlan(int queryId) const;
+
   /// Returns a plan for select max(c1), max(c2), .. from lineitem where partkey
   /// between
   /// ... such that 'columnPct' columns are aggregated with max(c) for numbers
@@ -96,7 +109,10 @@ class TpchQueryBuilder {
   TpchPlan getQ6Plan() const;
   TpchPlan getQ7Plan() const;
   TpchPlan getQ8Plan() const;
-  TpchPlan getQ9Plan() const;
+  // 'partFilter' is the part-table remaining filter. The part scan reads
+  // 'p_name' and 'p_size' so either q9's 'like' filter or an estimable
+  // substitute (e.g. 'p_size <= 3', used by getAltPlan) resolves.
+  TpchPlan getQ9Plan(const std::string& partFilter) const;
   TpchPlan getQ10Plan() const;
   TpchPlan getQ11Plan() const;
   TpchPlan getQ12Plan() const;


### PR DESCRIPTION
Summary:
`getQueryPlan(9)` filters `part` by `p_name like '%green%'`, a substring `like` whose selectivity a cost-based optimizer cannot estimate from column statistics, so there is no single optimal plan for an optimizer test to assert against. `getAltPlan(9)` returns q9 with that filter swapped for the estimable `p_size <= 3` (~6%, similar selectivity), giving such tests a stable, optimal reference plan.

`getAltPlan(int)` mirrors `getQueryPlan(int)` and currently supports only q9.

Differential Revision: D108562426


