### PR TITLE
fix: Gate GooglePolyline and format Nimble tests

### DIFF
--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -46,7 +46,6 @@ velox_add_library(
   FilterFunctions.cpp
   FindFirst.cpp
   FromUtf8.cpp
-  GooglePolylineFunctions.cpp
   InPredicate.cpp
   JsonFunctions.cpp
   Map.cpp
@@ -165,22 +164,32 @@ velox_link_libraries(
 
 if(VELOX_ENABLE_FAISS)
   velox_link_libraries(velox_functions_prestosql_impl FAISS::faiss)
+  # @lint-ignore LINEWRAP
   velox_compile_definitions(velox_functions_prestosql_impl PRIVATE VELOX_ENABLE_FAISS)
 endif()
 
 if(VELOX_ENABLE_GEO)
   add_subdirectory(geospatial)
+  # @lint-ignore LINEWRAP
+  velox_sources(velox_functions_prestosql_impl PRIVATE GooglePolylineFunctions.cpp)
+  # @lint-ignore LINEWRAP
+  velox_compile_definitions(velox_functions_prestosql_impl PRIVATE VELOX_ENABLE_GEO)
 
   # S2 cell operations are isolated in a separate library to prevent a
   # nallocx symbol conflict between s2geometry's malloc_extension.h and
   # folly's MallocImpl.h.
+  # @lint-ignore LINEWRAP
   velox_add_library(velox_s2_cell_operations S2CellOperations.cpp HEADERS S2CellOperations.h)
   velox_link_libraries(velox_s2_cell_operations s2::s2 GEOS::geos)
 
+  # @lint-ignore LINEWRAP
+  velox_link_libraries(velox_functions_prestosql_impl velox_common_geospatial_serde GEOS::geos)
+  # @lint-ignore LINEWRAP
   velox_link_libraries(velox_functions_prestosql_impl velox_functions_geo velox_s2_cell_operations)
 endif()
 
 if(NOT VELOX_MONO_LIBRARY)
+  # @lint-ignore LINEWRAP
   set_property(TARGET velox_functions_prestosql_impl PROPERTY JOB_POOL_COMPILE high_memory_pool)
 endif()
 

--- a/velox/functions/prestosql/GooglePolylineFunctions.cpp
+++ b/velox/functions/prestosql/GooglePolylineFunctions.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#ifdef VELOX_ENABLE_GEO
 #include "velox/functions/prestosql/GooglePolylineFunctions.h"
 
 namespace facebook::velox::functions {
@@ -89,3 +90,5 @@ Status validateAndComputePrecision(
 } // namespace detail
 
 } // namespace facebook::velox::functions
+
+#endif // VELOX_ENABLE_GEO


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/nimble/pull/868

Move GooglePolylineFunctions.cpp behind VELOX_ENABLE_GEO in CMake so OSS builds without GEOS do not compile it, declare the direct geo dependencies explicitly, and apply clang-format fixes required by the Nimble GitHub pre-commit job.

Differential Revision: D108570476


