### PR TITLE
perf: Report SST encode CPU as backgroundTiming in VeloxPlan stats (#17832)

### DIFF
--- a/velox/connectors/Connector.cpp
+++ b/velox/connectors/Connector.cpp
@@ -53,7 +53,8 @@ bool hasConnector(const std::string& connectorId) {
 }
 
 bool DataSink::Stats::empty() const {
-  return numWrittenBytes == 0 && numWrittenFiles == 0 && spillStats.empty();
+  return numWrittenBytes == 0 && numWrittenFiles == 0 &&
+      writerRuntimeStats.empty() && spillStats.empty();
 }
 
 std::string DataSink::Stats::toString() const {

--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -34,6 +34,7 @@
 #include "velox/vector/ComplexVector.h"
 
 #include <folly/Synchronized.h>
+#include <folly/container/F14Map.h>
 
 namespace facebook::velox {
 class Config;
@@ -214,6 +215,7 @@ class DataSink {
     uint64_t numCompressedBytes{0};
     uint64_t recodeTimeNs{0};
     uint64_t compressionTimeNs{0};
+    folly::F14FastMap<std::string, RuntimeMetric> writerRuntimeStats;
 
     exec::SpillStats spillStats;
 

--- a/velox/connectors/hive/FileDataSink.cpp
+++ b/velox/connectors/hive/FileDataSink.cpp
@@ -36,6 +36,18 @@ std::shared_ptr<memory::MemoryPool> createSortPool(
     const std::shared_ptr<memory::MemoryPool>& writerPool) {
   return writerPool->addLeafChild(fmt::format("{}.sort", writerPool->name()));
 }
+
+void mergeWriterStats(
+    folly::F14FastMap<std::string, RuntimeMetric>& mergedStats,
+    const folly::F14FastMap<std::string, RuntimeMetric>& stats) {
+  for (const auto& [name, metric] : stats) {
+    auto [it, inserted] = mergedStats.emplace(name, metric);
+    if (!inserted) {
+      VELOX_CHECK_EQ(it->second.unit, metric.unit);
+      it->second.merge(metric);
+    }
+  }
+}
 } // namespace
 
 const WriterId& WriterId::unpartitionedId() {
@@ -244,6 +256,8 @@ void FileDataSink::rotateWriter(size_t index) {
   // Finalize the current file state.
   finalizeWriterFile(index);
 
+  mergeWriterStats(closedWriterStats_, writers_[index]->runtimeStats());
+
   // Release old writer's memory pools. The new writer will be created lazily
   // on the next write to avoid creating empty files.
   writers_[index].reset();
@@ -279,6 +293,15 @@ DataSink::Stats FileDataSink::stats() const {
 
   if (state_ != State::kClosed) {
     return stats;
+  }
+
+  stats.writerRuntimeStats = closedWriterStats_;
+  for (const auto& writer : writers_) {
+    // Null entries are rotated writers whose stats are already in
+    // closedWriterStats_.
+    if (writer != nullptr) {
+      mergeWriterStats(stats.writerRuntimeStats, writer->runtimeStats());
+    }
   }
 
   // Count total files written, including rotated files.

--- a/velox/connectors/hive/FileDataSink.h
+++ b/velox/connectors/hive/FileDataSink.h
@@ -414,6 +414,7 @@ class FileDataSink : public DataSink {
   // writers_ are both indexed by partitionId.
   std::vector<std::shared_ptr<WriterInfo>> writerInfo_;
   std::vector<std::unique_ptr<dwio::common::Writer>> writers_;
+  folly::F14FastMap<std::string, RuntimeMetric> closedWriterStats_;
 
   // Below are structures updated when processing current input. partitionIds_
   // are indexed by the row of input_. partitionRows_, rawPartitionRows_ and

--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -19,6 +19,7 @@
 #include "velox/common/io/IoStatistics.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 
+#include <folly/ScopeGuard.h>
 #include <folly/init/Init.h>
 #include <folly/system/HardwareConcurrency.h>
 #include <re2/re2.h>
@@ -30,9 +31,11 @@
 #include "velox/connectors/hive/HiveDataSink.h"
 #include "velox/dwio/common/BufferedInput.h"
 #include "velox/dwio/common/Options.h"
+#include "velox/dwio/common/tests/utils/RuntimeStatsInjectingWriter.h"
 #include "velox/dwio/dwrf/reader/DwrfReader.h"
 #include "velox/dwio/dwrf/writer/FlushPolicy.h"
 #include "velox/dwio/dwrf/writer/Writer.h"
+#include "velox/exec/Operator.h"
 
 #ifdef VELOX_ENABLE_PARQUET
 #include "velox/dwio/parquet/RegisterParquetReader.h"
@@ -51,6 +54,7 @@ namespace {
 using namespace facebook::velox::common;
 using namespace facebook::velox::exec::test;
 using namespace facebook::velox::common::testutil;
+using namespace facebook::velox::dwio::common::test;
 
 class HiveDataSinkTest : public exec::test::HiveConnectorTestBase {
  protected:
@@ -1780,6 +1784,98 @@ TEST_F(HiveDataSinkTest, fileRotationWriteIOTimeAccumulation) {
   // writeIOTimeUs should be non-zero (actual I/O happened)
   // Note: This may be 0 on very fast systems, so we just check it's >= 0
   ASSERT_GE(stats.writeIOTimeUs, 0);
+
+  createDuckDbTable(vectors);
+  verifyWrittenData(outputDirectory->getPath(), stats.numWrittenFiles);
+}
+
+TEST_F(HiveDataSinkTest, writerRuntimeStatsPropagation) {
+  const auto outputDirectory = TempDirectoryPath::create();
+
+  folly::F14FastMap<std::string, RuntimeMetric> injectedStats;
+  injectedStats.emplace(
+      std::string{exec::Operator::kBackgroundCpuTimeNanos},
+      RuntimeMetric(42'000'000, RuntimeCounter::Unit::kNanos));
+
+  auto originalFactory =
+      dwio::common::getWriterFactory(dwio::common::FileFormat::DWRF);
+  auto injectingFactory = std::make_shared<RuntimeStatsInjectingWriterFactory>(
+      originalFactory, injectedStats);
+  dwio::common::unregisterWriterFactory(dwio::common::FileFormat::DWRF);
+  dwio::common::registerWriterFactory(injectingFactory);
+  auto restoreFactory = folly::makeGuard([&]() {
+    dwio::common::unregisterWriterFactory(dwio::common::FileFormat::DWRF);
+    dwio::common::registerWriterFactory(originalFactory);
+  });
+
+  auto dataSink = createDataSink(rowType_, outputDirectory->getPath());
+
+  const auto vectors = createVectors(500, 10);
+  for (const auto& vector : vectors) {
+    dataSink->appendData(vector);
+  }
+  ASSERT_TRUE(dataSink->finish());
+  dataSink->close();
+  const auto stats = dataSink->stats();
+
+  ASSERT_EQ(
+      stats.writerRuntimeStats.count(
+          std::string{exec::Operator::kBackgroundCpuTimeNanos}),
+      1);
+  const auto& metric = stats.writerRuntimeStats.at(
+      std::string{exec::Operator::kBackgroundCpuTimeNanos});
+  ASSERT_EQ(metric.unit, RuntimeCounter::Unit::kNanos);
+  ASSERT_EQ(metric.sum, 42'000'000);
+}
+
+TEST_F(HiveDataSinkTest, writerRuntimeStatsAccumulatedAcrossRotation) {
+  const auto outputDirectory = TempDirectoryPath::create();
+
+  folly::F14FastMap<std::string, RuntimeMetric> injectedStats;
+  injectedStats.emplace(
+      std::string{exec::Operator::kBackgroundCpuTimeNanos},
+      RuntimeMetric(10'000'000, RuntimeCounter::Unit::kNanos));
+
+  auto originalFactory =
+      dwio::common::getWriterFactory(dwio::common::FileFormat::DWRF);
+  auto injectingFactory = std::make_shared<RuntimeStatsInjectingWriterFactory>(
+      originalFactory, injectedStats);
+  dwio::common::unregisterWriterFactory(dwio::common::FileFormat::DWRF);
+  dwio::common::registerWriterFactory(injectingFactory);
+  auto restoreFactory = folly::makeGuard([&]() {
+    dwio::common::unregisterWriterFactory(dwio::common::FileFormat::DWRF);
+    dwio::common::registerWriterFactory(originalFactory);
+  });
+
+  std::unordered_map<std::string, std::string> connectorConfig;
+  connectorConfig.emplace(HiveConfig::kOrcMaxTargetFileSize, "512KB");
+  connectorConfig.emplace("hive.orc.writer.stripe-max-size", "128KB");
+  connectorConfig_ = std::make_shared<HiveConfig>(
+      std::make_shared<config::ConfigBase>(std::move(connectorConfig)));
+
+  auto dataSink = createDataSink(rowType_, outputDirectory->getPath());
+
+  const int numBatches = 60;
+  const auto vectors = createVectors(500, numBatches);
+  for (const auto& vector : vectors) {
+    dataSink->appendData(vector);
+  }
+  ASSERT_TRUE(dataSink->finish());
+  dataSink->close();
+  const auto stats = dataSink->stats();
+
+  ASSERT_GT(stats.numWrittenFiles, 1)
+      << "Rotation must occur for this test to be meaningful";
+  ASSERT_EQ(
+      stats.writerRuntimeStats.count(
+          std::string{exec::Operator::kBackgroundCpuTimeNanos}),
+      1);
+  const auto& metric = stats.writerRuntimeStats.at(
+      std::string{exec::Operator::kBackgroundCpuTimeNanos});
+  ASSERT_EQ(metric.unit, RuntimeCounter::Unit::kNanos);
+  ASSERT_EQ(
+      metric.sum, 10'000'000 * static_cast<int64_t>(stats.numWrittenFiles));
+  ASSERT_EQ(metric.count, stats.numWrittenFiles);
 
   createDuckDbTable(vectors);
   verifyWrittenData(outputDirectory->getPath(), stats.numWrittenFiles);

--- a/velox/dwio/common/SortingWriter.h
+++ b/velox/dwio/common/SortingWriter.h
@@ -46,6 +46,10 @@ class SortingWriter : public Writer {
   /// available (e.g. for an empty file).
   std::unique_ptr<FileMetadata> close() override;
 
+  folly::F14FastMap<std::string, RuntimeMetric> runtimeStats() const override {
+    return outputWriter_->runtimeStats();
+  }
+
   void abort() override;
 
  private:

--- a/velox/dwio/common/Writer.h
+++ b/velox/dwio/common/Writer.h
@@ -19,7 +19,10 @@
 #include <ostream>
 #include <string>
 
+#include <folly/container/F14Map.h>
+
 #include "velox/common/base/Portability.h"
+#include "velox/common/base/RuntimeMetrics.h"
 #include "velox/dwio/common/FileMetadata.h"
 #include "velox/vector/BaseVector.h"
 
@@ -76,6 +79,13 @@ class Writer {
   ///
   /// NOTE: this must be called after the last finish() which returns true.
   virtual std::unique_ptr<FileMetadata> close() = 0;
+
+  /// Returns runtime statistics accumulated by this writer (default: none).
+  /// CPU spent off the driver thread (e.g. parallel encode) is reported under
+  /// the well-known "backgroundCpuTimeNanos" key so the owner can surface it.
+  virtual folly::F14FastMap<std::string, RuntimeMetric> runtimeStats() const {
+    return {};
+  }
 
   /// Aborts the writing by closing the writer and dropping everything.
   /// Data can no longer be written.

--- a/velox/dwio/common/tests/utils/CMakeLists.txt
+++ b/velox/dwio/common/tests/utils/CMakeLists.txt
@@ -28,6 +28,7 @@ velox_add_test_headers(
   DataSetBuilder.h
   E2EFilterTestBase.h
   FilterGenerator.h
+  RuntimeStatsInjectingWriter.h
   UnitLoaderTestTools.h
 )
 

--- a/velox/dwio/common/tests/utils/RuntimeStatsInjectingWriter.h
+++ b/velox/dwio/common/tests/utils/RuntimeStatsInjectingWriter.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/dwio/common/WriterFactory.h"
+
+namespace facebook::velox::dwio::common::test {
+
+/// Test-only Writer decorator that delegates all I/O to a wrapped writer
+/// and overlays a caller-supplied runtimeStats() map. Used to verify the
+/// writer-runtimeStats -> DataSink -> TableWriter -> backgroundTiming path.
+class RuntimeStatsInjectingWriter : public Writer {
+ public:
+  RuntimeStatsInjectingWriter(
+      std::unique_ptr<Writer> delegate,
+      folly::F14FastMap<std::string, RuntimeMetric> injectedStats)
+      : delegate_(std::move(delegate)),
+        injectedStats_(std::move(injectedStats)) {}
+
+  // NOTE: state_ is not synced from the delegate. Tests that introspect
+  // state() should query the delegate directly.
+
+  void write(const VectorPtr& data) override {
+    delegate_->write(data);
+  }
+
+  void flush() override {
+    delegate_->flush();
+  }
+
+  bool finish() override {
+    return delegate_->finish();
+  }
+
+  std::unique_ptr<dwio::common::FileMetadata> close() override {
+    return delegate_->close();
+  }
+
+  void abort() override {
+    delegate_->abort();
+  }
+
+  folly::F14FastMap<std::string, RuntimeMetric> runtimeStats() const override {
+    auto stats = delegate_->runtimeStats();
+    for (const auto& [name, metric] : injectedStats_) {
+      auto [it, inserted] = stats.emplace(name, metric);
+      if (!inserted) {
+        it->second.merge(metric);
+      }
+    }
+    return stats;
+  }
+
+ private:
+  std::unique_ptr<Writer> delegate_;
+  const folly::F14FastMap<std::string, RuntimeMetric> injectedStats_;
+};
+
+class RuntimeStatsInjectingWriterFactory : public WriterFactory {
+ public:
+  RuntimeStatsInjectingWriterFactory(
+      std::shared_ptr<WriterFactory> delegate,
+      folly::F14FastMap<std::string, RuntimeMetric> injectedStats)
+      : WriterFactory(delegate->fileFormat()),
+        delegate_(std::move(delegate)),
+        injectedStats_(std::move(injectedStats)) {}
+
+  std::unique_ptr<Writer> createWriter(
+      std::unique_ptr<FileSink> sink,
+      const std::shared_ptr<WriterOptions>& options) override {
+    auto writer = delegate_->createWriter(std::move(sink), options);
+    return std::make_unique<RuntimeStatsInjectingWriter>(
+        std::move(writer), injectedStats_);
+  }
+
+  std::unique_ptr<WriterOptions> createWriterOptions() override {
+    return delegate_->createWriterOptions();
+  }
+
+ private:
+  std::shared_ptr<WriterFactory> delegate_;
+  const folly::F14FastMap<std::string, RuntimeMetric> injectedStats_;
+};
+
+} // namespace facebook::velox::dwio::common::test

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -317,6 +317,19 @@ void TableWriter::updateStats(const connector::DataSink::Stats& stats) {
           RuntimeCounter(
               stats.compressionTimeNs, RuntimeCounter::Unit::kNanos));
     }
+    for (const auto& [name, metric] : stats.writerRuntimeStats) {
+      lockedStats->setRuntimeStat(name, metric);
+    }
+    const auto backgroundTimingStat =
+        stats.writerRuntimeStats.find(std::string{kBackgroundCpuTimeNanos});
+    if (backgroundTimingStat != stats.writerRuntimeStats.end()) {
+      lockedStats->backgroundTiming.clear();
+      lockedStats->backgroundTiming.add(
+          CpuWallTiming{
+              backgroundTimingStat->second.count,
+              0,
+              static_cast<uint64_t>(backgroundTimingStat->second.sum)});
+    }
     lockedStats->addRuntimeStat(
         kRunningWallNanos,
         RuntimeCounter(

--- a/velox/exec/tests/TableWriterTest.cpp
+++ b/velox/exec/tests/TableWriterTest.cpp
@@ -23,6 +23,7 @@
 #include "velox/common/testutil/TestValue.h"
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/dwio/common/WriterFactory.h"
+#include "velox/dwio/common/tests/utils/RuntimeStatsInjectingWriter.h"
 #include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/TableWriter.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
@@ -30,6 +31,7 @@
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 
+#include <folly/ScopeGuard.h>
 #include <re2/re2.h>
 #include <string>
 #include "folly/synchronization/EventCount.h"
@@ -40,6 +42,7 @@
 
 namespace velox::exec::test {
 using namespace facebook::velox::common::testutil;
+using namespace facebook::velox::dwio::common::test;
 
 constexpr uint64_t kQueryMemoryCapacity = 512 * MB;
 
@@ -189,6 +192,59 @@ TEST_F(BasicTableWriterTest, targetFileName) {
       .split(makeHiveConnectorSplit(
           fmt::format("{}/{}", directory->getPath(), kFileName)))
       .assertResults(data);
+}
+
+TEST_F(BasicTableWriterTest, writerRuntimeStatsReachOperatorStats) {
+  constexpr int64_t kInjectedNanos = 42'000'000;
+
+  folly::F14FastMap<std::string, RuntimeMetric> injectedStats;
+  injectedStats.emplace(
+      std::string{Operator::kBackgroundCpuTimeNanos},
+      RuntimeMetric(kInjectedNanos, RuntimeCounter::Unit::kNanos));
+
+  auto originalFactory =
+      dwio::common::getWriterFactory(dwio::common::FileFormat::DWRF);
+  auto injectingFactory = std::make_shared<RuntimeStatsInjectingWriterFactory>(
+      originalFactory, injectedStats);
+  dwio::common::unregisterWriterFactory(dwio::common::FileFormat::DWRF);
+  dwio::common::registerWriterFactory(injectingFactory);
+  auto restoreFactory = folly::makeGuard([&]() {
+    dwio::common::unregisterWriterFactory(dwio::common::FileFormat::DWRF);
+    dwio::common::registerWriterFactory(originalFactory);
+  });
+
+  auto data = makeRowVector({makeFlatVector<int64_t>(1'000, folly::identity)});
+
+  auto directory = TempDirectoryPath::create();
+  auto plan =
+      PlanBuilder().values({data}).tableWrite(directory->getPath()).planNode();
+
+  std::shared_ptr<Task> task;
+  AssertQueryBuilder(plan).copyResults(pool(), task);
+
+  auto taskStats = task->taskStats();
+  const OperatorStats* writerOpStats = nullptr;
+  for (const auto& pipelineStats : taskStats.pipelineStats) {
+    for (const auto& opStats : pipelineStats.operatorStats) {
+      if (opStats.operatorType == "TableWrite") {
+        writerOpStats = &opStats;
+        break;
+      }
+    }
+    if (writerOpStats) {
+      break;
+    }
+  }
+  ASSERT_NE(writerOpStats, nullptr) << "TableWrite operator not found";
+  ASSERT_GT(writerOpStats->backgroundTiming.cpuNanos, 0);
+  ASSERT_EQ(
+      writerOpStats->backgroundTiming.cpuNanos,
+      static_cast<uint64_t>(kInjectedNanos));
+  ASSERT_EQ(
+      writerOpStats->runtimeStats
+          .at(std::string{Operator::kBackgroundCpuTimeNanos})
+          .sum,
+      kInjectedNanos);
 }
 
 class PartitionedTableWriterTest


### PR DESCRIPTION
Summary:

SstWriter performs its heaviest CPU work — encoding keys/values — on a
dedicated folly thread pool (encodeExecutor_), off the Velox driver thread.
Velox only accounts CPU on driver threads, so this encode CPU was invisible
in plan stats: the tableWrite stage reported CPU time far below wall time
(see P2363388463), making it look nearly free.

Fix: measure per-thread CPU inside encode() (accumulated atomically across the
encode threads, mirroring the existing keyEncodeMs_/valueEncodeMs_ wall
timers), and report the total at close() via a new IoStatistics counter. The
value flows through the existing writer-stats channel —
IoStatistics::backgroundCpuTimeNs -> DataSink::Stats::backgroundCpuTimeNs ->
TableWriter::updateStats() -> OperatorStats::backgroundTiming — so the
tableWrite operator surfaces it as backgroundTiming. Each velox-core addition
mirrors an adjacent sibling field (writeIOTimeUs/recodeTimeNs). Non-SST writers
report 0 and are unaffected (the routing is guarded). This surfaces the encode
CPU specifically, not all writer background CPU.

Reviewed By: jiahaol-work

Differential Revision: D108106578


