### PR TITLE
fix(parquet): Honor hive.parquet.writer.max-target-file-size during file rotation

### DIFF
--- a/velox/connectors/hive/iceberg/tests/IcebergInsertTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergInsertTest.cpp
@@ -243,10 +243,12 @@ TEST_F(IcebergInsertTest, partitionMultiColumns) {
 }
 
 TEST_F(IcebergInsertTest, maxTargetFileSizeRotation) {
-  constexpr int32_t kNumBatches = 100;
+  constexpr int32_t kNumBatches = 10;
   constexpr vector_size_t kRowsPerBatch = 100;
   constexpr int32_t kPayloadSize = 96;
 
+  // Generate fixed-size, per-row-varying strings for predictable size
+  // accounting without relying on fuzzed VARCHAR lengths.
   auto makePayload = [](int64_t value) {
     std::string payload;
     payload.reserve(kPayloadSize);
@@ -260,16 +262,17 @@ TEST_F(IcebergInsertTest, maxTargetFileSizeRotation) {
   std::vector<RowVectorPtr> vectors;
   vectors.reserve(kNumBatches);
   for (int32_t batch = 0; batch < kNumBatches; ++batch) {
+    const auto batchOffset = batch * kRowsPerBatch;
     vectors.push_back(makeRowVector(
         rowType->names(),
         {
             makeFlatVector<int64_t>(
                 kRowsPerBatch,
-                [batch](auto row) { return batch * kRowsPerBatch + row; }),
+                [batchOffset](auto row) { return batchOffset + row; }),
             makeFlatVector<std::string>(
                 kRowsPerBatch,
-                [&, batch](auto row) {
-                  return makePayload(batch * kRowsPerBatch + row);
+                [&, batchOffset](auto row) {
+                  return makePayload(batchOffset + row);
                 }),
         }));
   }
@@ -297,16 +300,8 @@ TEST_F(IcebergInsertTest, maxTargetFileSizeRotation) {
     return files.size();
   };
 
-  const auto smallTargetFileCount = writeAndRead("1KB");
-  const auto mediumTargetFileCount = writeAndRead("32KB");
-  const auto largeTargetFileCount = writeAndRead("10MB");
-
-  // Rotation uses rawBytesWritten(), which advances when Parquet flushes a row
-  // group. Counts therefore follow row group flush boundaries rather than
-  // scaling linearly with maxTargetFileSize.
-  ASSERT_EQ(smallTargetFileCount, 100);
-  ASSERT_EQ(mediumTargetFileCount, 4);
-  ASSERT_EQ(largeTargetFileCount, 1);
+  ASSERT_EQ(writeAndRead("1KB"), kNumBatches);
+  ASSERT_EQ(writeAndRead("10MB"), 1);
 }
 
 #endif

--- a/velox/connectors/hive/iceberg/tests/IcebergInsertTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergInsertTest.cpp
@@ -243,24 +243,42 @@ TEST_F(IcebergInsertTest, partitionMultiColumns) {
 }
 
 TEST_F(IcebergInsertTest, maxTargetFileSizeRotation) {
-  setConnectorSessionProperty(
-      HiveConfig::kParquetMaxTargetFileSizeSession, "4KB");
-
-  const auto outputPath = TempDirectoryPath::create()->getPath();
   const auto rowType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
-  const auto vectors = createTestData(rowType, 10, 1'000);
-  const auto dataSink = createDataSinkAndAppendData(vectors, outputPath);
-  const auto commitTasks = dataSink->close();
+  const auto vectors = createTestData(rowType, 100, 100);
 
-  ASSERT_EQ(listFiles(outputPath).size(), 5);
+  auto writeAndRead = [&](const std::string& maxTargetFileSize) {
+    setConnectorSessionProperty(
+        HiveConfig::kParquetMaxTargetFileSizeSession, maxTargetFileSize);
 
-  auto splits = createSplitsForDirectory(outputPath);
-  auto plan = exec::test::PlanBuilder()
-                  .startTableScan(test::kIcebergConnectorId)
-                  .outputType(rowType)
-                  .endTableScan()
-                  .planNode();
-  exec::test::AssertQueryBuilder(plan).splits(splits).assertResults(vectors);
+    const auto outputDirectory = TempDirectoryPath::create();
+    const auto outputPath = outputDirectory->getPath();
+    const auto dataSink = createDataSinkAndAppendData(vectors, outputPath);
+    const auto commitTasks = dataSink->close();
+    const auto files = listFiles(outputPath);
+    EXPECT_EQ(files.size(), commitTasks.size());
+
+    auto splits = createSplitsForDirectory(outputPath);
+    auto plan = exec::test::PlanBuilder()
+                    .startTableScan()
+                    .connectorId(test::kIcebergConnectorId)
+                    .outputType(rowType)
+                    .endTableScan()
+                    .planNode();
+    exec::test::AssertQueryBuilder(plan).splits(splits).assertResults(vectors);
+
+    return files.size();
+  };
+
+  const auto smallTargetFileCount = writeAndRead("1KB");
+  const auto mediumTargetFileCount = writeAndRead("32KB");
+  const auto largeTargetFileCount = writeAndRead("10MB");
+
+  // Rotation uses rawBytesWritten(), which advances when Parquet flushes a row
+  // group. Counts therefore follow row group flush boundaries rather than
+  // scaling linearly with maxTargetFileSize.
+  ASSERT_EQ(smallTargetFileCount, 80);
+  ASSERT_EQ(mediumTargetFileCount, 14);
+  ASSERT_EQ(largeTargetFileCount, 1);
 }
 
 #endif

--- a/velox/connectors/hive/iceberg/tests/IcebergInsertTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergInsertTest.cpp
@@ -243,8 +243,36 @@ TEST_F(IcebergInsertTest, partitionMultiColumns) {
 }
 
 TEST_F(IcebergInsertTest, maxTargetFileSizeRotation) {
+  constexpr int32_t kNumBatches = 100;
+  constexpr vector_size_t kRowsPerBatch = 100;
+  constexpr int32_t kPayloadSize = 96;
+
+  auto makePayload = [](int64_t value) {
+    std::string payload;
+    payload.reserve(kPayloadSize);
+    for (auto i = 0; i < kPayloadSize; ++i) {
+      payload.push_back(static_cast<char>('a' + ((value + i) % 26)));
+    }
+    return payload;
+  };
+
   const auto rowType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
-  const auto vectors = createTestData(rowType, 100, 100);
+  std::vector<RowVectorPtr> vectors;
+  vectors.reserve(kNumBatches);
+  for (int32_t batch = 0; batch < kNumBatches; ++batch) {
+    vectors.push_back(makeRowVector(
+        rowType->names(),
+        {
+            makeFlatVector<int64_t>(
+                kRowsPerBatch,
+                [batch](auto row) { return batch * kRowsPerBatch + row; }),
+            makeFlatVector<std::string>(
+                kRowsPerBatch,
+                [&, batch](auto row) {
+                  return makePayload(batch * kRowsPerBatch + row);
+                }),
+        }));
+  }
 
   auto writeAndRead = [&](const std::string& maxTargetFileSize) {
     setConnectorSessionProperty(
@@ -276,8 +304,8 @@ TEST_F(IcebergInsertTest, maxTargetFileSizeRotation) {
   // Rotation uses rawBytesWritten(), which advances when Parquet flushes a row
   // group. Counts therefore follow row group flush boundaries rather than
   // scaling linearly with maxTargetFileSize.
-  ASSERT_EQ(smallTargetFileCount, 80);
-  ASSERT_EQ(mediumTargetFileCount, 14);
+  ASSERT_EQ(smallTargetFileCount, 100);
+  ASSERT_EQ(mediumTargetFileCount, 4);
   ASSERT_EQ(largeTargetFileCount, 1);
 }
 

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -549,10 +549,6 @@ void Writer::write(const VectorPtr& data) {
 
   auto bytes = data->estimateFlatSize();
   auto numRows = data->size();
-  if (flushPolicy_->shouldFlush(getStripeProgress(
-          arrowContext_->stagingRows, arrowContext_->stagingBytes))) {
-    flush();
-  }
 
   for (int colIdx = 0; colIdx < recordBatch->num_columns(); colIdx++) {
     arrowContext_->stagingChunks.at(colIdx).push_back(

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -560,6 +560,14 @@ void Writer::write(const VectorPtr& data) {
   }
   arrowContext_->stagingRows += numRows;
   arrowContext_->stagingBytes += bytes;
+
+  // Flush as soon as the current write pushes the staged row group past the
+  // policy threshold. Otherwise callers that rotate files based on raw written
+  // bytes won't observe the row group until the next write.
+  if (flushPolicy_->shouldFlush(getStripeProgress(
+          arrowContext_->stagingRows, arrowContext_->stagingBytes))) {
+    flush();
+  }
 }
 
 bool Writer::isCodecAvailable(common::CompressionKind compression) {


### PR DESCRIPTION
**Summary**

Fix Parquet max target file size rotation by flushing the current staged row group as soon as a write crosses the flush policy threshold.

`kParquetMaxTargetFileSizeSession` already updates the Parquet flush policy by capping `bytesInRowGroup` to `maxTargetFileSizeBytes`, but the writer only checked `shouldFlush()` **before** adding the current batch. If the current batch pushed stagingBytes over the threshold, the row group stayed buffered until the next write or close. Since FileDataSink rotates files using `rawBytesWritten()`, and `rawBytesWritten()` only advances after Parquet flushes bytes to the sink, rotation could happen one append late or not reflect the configured target promptly.

This PR move the policy check after staging the current batch, so crossing the row-group byte threshold flushes immediately and `rawBytesWritten()` is updated before FileDataSink checks whether to rotate.

**Before:**
check flush policy
add current batch
return with row group still buffered
FileDataSink sees stale rawBytesWritten()

**After:**
add current batch
check flush policy
flush if threshold is crossed
FileDataSink sees updated rawBytesWritten()

This makes `kParquetMaxTargetFileSizeSession` effective for Parquet file rotation while still preserving the existing policy-driven flush behavior.

Fix https://github.com/facebookincubator/velox/issues/17729.