### PR TITLE
fix(cudf): Order packed table release on materialization stream

### DIFF
--- a/velox/experimental/cudf/tests/CudfVectorTest.cpp
+++ b/velox/experimental/cudf/tests/CudfVectorTest.cpp
@@ -199,6 +199,8 @@ TEST_F(CudfVectorTest, rebindPackedTableDeallocationStream) {
       table->view(),
       allocationStream.view(),
       rmm::to_device_async_resource_ref_checked(&resource));
+  // CudfVector does not join producer streams. Synchronize the packing stream
+  // before handing the packed table to CudfVector.
   allocationStream.view().synchronize();
   auto tableView = cudf::unpack(packedColumns);
   auto packedTable = std::make_unique<cudf::packed_table>(
@@ -235,6 +237,8 @@ TEST_F(CudfVectorTest, packedTableReleaseUsesMaterializationStream) {
       table->view(),
       allocationStream.view(),
       rmm::to_device_async_resource_ref_checked(&resource));
+  // CudfVector does not join producer streams. Synchronize the packing stream
+  // before handing the packed table to CudfVector.
   allocationStream.view().synchronize();
   auto tableView = cudf::unpack(packedColumns);
   auto packedTable = std::make_unique<cudf::packed_table>(

--- a/velox/experimental/cudf/tests/CudfVectorTest.cpp
+++ b/velox/experimental/cudf/tests/CudfVectorTest.cpp
@@ -156,6 +156,22 @@ std::unique_ptr<cudf::table> makeTable(
   return std::make_unique<cudf::table>(std::move(columns));
 }
 
+std::unique_ptr<cudf::packed_table> makePackedTable(
+    rmm::cuda_stream_view stream,
+    RecordingAsyncDeviceResource& resource) {
+  auto table = makeTable(stream, cudf::get_current_device_resource_ref());
+  auto packedColumns = cudf::pack(
+      table->view(),
+      stream,
+      rmm::to_device_async_resource_ref_checked(&resource));
+  // CudfVector does not join producer streams. Synchronize the packing stream
+  // before handing the packed table to CudfVector.
+  stream.synchronize();
+  auto tableView = cudf::unpack(packedColumns);
+  return std::make_unique<cudf::packed_table>(
+      cudf::packed_table{tableView, std::move(packedColumns)});
+}
+
 class CudfVectorTest : public ::testing::Test, public VectorTestBase {
  protected:
   static void SetUpTestCase() {
@@ -192,19 +208,7 @@ TEST_F(CudfVectorTest, rebindPackedTableDeallocationStream) {
   TestCudaStream allocationStream;
   TestCudaStream targetStream;
   RecordingAsyncDeviceResource resource;
-
-  auto table = makeTable(
-      allocationStream.view(), cudf::get_current_device_resource_ref());
-  auto packedColumns = cudf::pack(
-      table->view(),
-      allocationStream.view(),
-      rmm::to_device_async_resource_ref_checked(&resource));
-  // CudfVector does not join producer streams. Synchronize the packing stream
-  // before handing the packed table to CudfVector.
-  allocationStream.view().synchronize();
-  auto tableView = cudf::unpack(packedColumns);
-  auto packedTable = std::make_unique<cudf::packed_table>(
-      cudf::packed_table{tableView, std::move(packedColumns)});
+  auto packedTable = makePackedTable(allocationStream.view(), resource);
 
   // Model the intra-node UCX path: the packed buffer was allocated on
   // allocationStream, but downstream work is associated with targetStream.
@@ -230,19 +234,7 @@ TEST_F(CudfVectorTest, packedTableReleaseUsesMaterializationStream) {
   TestCudaStream allocationStream;
   TestCudaStream targetStream;
   RecordingAsyncDeviceResource resource;
-
-  auto table = makeTable(
-      allocationStream.view(), cudf::get_current_device_resource_ref());
-  auto packedColumns = cudf::pack(
-      table->view(),
-      allocationStream.view(),
-      rmm::to_device_async_resource_ref_checked(&resource));
-  // CudfVector does not join producer streams. Synchronize the packing stream
-  // before handing the packed table to CudfVector.
-  allocationStream.view().synchronize();
-  auto tableView = cudf::unpack(packedColumns);
-  auto packedTable = std::make_unique<cudf::packed_table>(
-      cudf::packed_table{tableView, std::move(packedColumns)});
+  auto packedTable = makePackedTable(allocationStream.view(), resource);
 
   // CudfVector::release materializes from a table_view that points into the
   // packed buffer. The packed buffer must be freed on the materialization

--- a/velox/experimental/cudf/tests/CudfVectorTest.cpp
+++ b/velox/experimental/cudf/tests/CudfVectorTest.cpp
@@ -224,4 +224,40 @@ TEST_F(CudfVectorTest, rebindPackedTableDeallocationStream) {
   EXPECT_EQ(resource.lastDeallocationStream(), targetStream.value());
 }
 
+TEST_F(CudfVectorTest, packedTableReleaseUsesMaterializationStream) {
+  TestCudaStream allocationStream;
+  TestCudaStream targetStream;
+  RecordingAsyncDeviceResource resource;
+
+  auto table = makeTable(
+      allocationStream.view(), cudf::get_current_device_resource_ref());
+  auto packedColumns = cudf::pack(
+      table->view(),
+      allocationStream.view(),
+      rmm::to_device_async_resource_ref_checked(&resource));
+  allocationStream.view().synchronize();
+  auto tableView = cudf::unpack(packedColumns);
+  auto packedTable = std::make_unique<cudf::packed_table>(
+      cudf::packed_table{tableView, std::move(packedColumns)});
+
+  // CudfVector::release materializes from a table_view that points into the
+  // packed buffer. The packed buffer must be freed on the materialization
+  // stream, not the original packing stream.
+  CudfVector vector(
+      pool_.get(),
+      ROW({"c0"}, {INTEGER()}),
+      packedTable->table.num_rows(),
+      std::move(packedTable),
+      targetStream.view());
+  resource.reset();
+
+  auto materialized = vector.release();
+
+  EXPECT_GT(resource.deallocationCount(), 0);
+  EXPECT_EQ(resource.lastDeallocationStream(), targetStream.value());
+  targetStream.view().synchronize();
+  EXPECT_EQ(materialized->num_columns(), 1);
+  EXPECT_EQ(materialized->num_rows(), 4);
+}
+
 } // namespace

--- a/velox/experimental/cudf/vector/CudfVector.cpp
+++ b/velox/experimental/cudf/vector/CudfVector.cpp
@@ -169,6 +169,7 @@ std::unique_ptr<cudf::table> CudfVector::release() {
       std::get<std::unique_ptr<cudf::packed_table>>(tableStorage_);
   // Using same memory resource as packed_table
   auto mr = packedPtr->data.gpu_data->memory_resource();
+  packedPtr->data.gpu_data->set_stream(stream_);
   auto materializedTable = std::make_unique<cudf::table>(tabView_, stream_, mr);
   stream_.synchronize();
   // Clear the packed table since we've materialized

--- a/velox/experimental/cudf/vector/CudfVector.h
+++ b/velox/experimental/cudf/vector/CudfVector.h
@@ -35,6 +35,11 @@ namespace facebook::velox::cudf_velox {
 // When constructed from packed_table, the data remains packed and tabView_
 // references the table view inside packed_table without copying the underlying
 // GPU data.
+//
+// CudfVector assumes that the input table data is already ready to consume.
+// Constructors and rebindStream() do not insert CUDA stream waits for work that
+// populated the input buffers; callers must establish that ordering before
+// constructing or rebinding a CudfVector.
 class CudfVector : public RowVector {
  public:
   /// Constructs a CudfVector from an owned cudf::table.
@@ -69,6 +74,8 @@ class CudfVector : public RowVector {
   std::unique_ptr<cudf::table> release();
 
   /// Rebinds owned table buffers to use 'stream' for future deallocation.
+  /// This only changes future stream/deallocation association. It does not make
+  /// 'stream' wait on the previous stream or any producer stream.
   /// Returns false when the storage cannot be rebound without materializing.
   bool rebindStream(rmm::cuda_stream_view stream);
 


### PR DESCRIPTION
CudfVector::release() materializes a cudf::table from the table_view stored inside a cudf::packed_table. That view still points into the packed table's contiguous device buffer while the materialization copy runs on the CudfVector stream.

For packed tables, the owning rmm::device_buffer can still be bound to the original packing/allocation stream. If that stream differs from the CudfVector stream, resetting the packed_table frees the buffer on a stream that is not ordered after materialization. The materialization work can then read from a buffer that has already been freed or reused, which shows up as CUDA illegal memory access/use-after-free under sanitizer.

Set the packed buffer's deallocation stream to the CudfVector stream before materializing and releasing the packed_table. This makes destruction of the packed buffer ordered with the work that consumes it.

Add a regression test that creates this stream mismatch with a packed table and verifies the packed buffer is deallocated on the materialization stream.