### PR TITLE
feat: Iceberg V3 field-id support for DWRF (proto, writer, reader, connector) [velox][dwrf] (#17843)

### DIFF
--- a/velox/connectors/hive/iceberg/IcebergDataSink.cpp
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.cpp
@@ -39,6 +39,9 @@
 
 #include "velox/connectors/hive/iceberg/TransformExprBuilder.h"
 #include "velox/connectors/hive/iceberg/WriterOptionsAdapter.h"
+#include "velox/dwio/common/TypeWithId.h"
+#include "velox/dwio/dwrf/writer/Writer.h"
+#include "velox/exec/OperatorUtils.h"
 #include "velox/type/Type.h"
 
 using facebook::velox::common::testutil::TestValue;
@@ -277,6 +280,53 @@ folly::dynamic buildIcebergCommitData(
   return commitData;
 }
 
+// Recursively records the "iceberg.id" attribute for 'node' and its
+// descendants, keyed by pre-order schema node id (matching the DWRF writer's
+// footer node ids). 'fieldId' is the field-id tree aligned to 'node'.
+void stampFieldIdAttributes(
+    const dwio::common::TypeWithId& node,
+    const dwio::common::ParquetFieldId& fieldId,
+    std::unordered_map<
+        uint32_t,
+        std::vector<std::pair<std::string, std::string>>>& attributes) {
+  attributes[node.id()] = {{"iceberg.id", std::to_string(fieldId.fieldId)}};
+  const auto numChildren =
+      std::min<size_t>(node.size(), fieldId.children.size());
+  for (size_t i = 0; i < numChildren; ++i) {
+    stampFieldIdAttributes(
+        *node.childAt(static_cast<uint32_t>(i)),
+        fieldId.children.at(i),
+        attributes);
+  }
+}
+
+// Builds the per-node "iceberg.id" attribute map for the DWRF writer from the
+// Iceberg input column handles, aligned to 'schema' (the written row type).
+std::unordered_map<uint32_t, std::vector<std::pair<std::string, std::string>>>
+buildDwrfSchemaAttributes(
+    const RowTypePtr& schema,
+    const std::vector<std::shared_ptr<const HiveColumnHandle>>& inputColumns) {
+  std::unordered_map<uint32_t, std::vector<std::pair<std::string, std::string>>>
+      attributes;
+  if (schema == nullptr) {
+    return attributes;
+  }
+  const auto schemaWithId = dwio::common::TypeWithId::create(schema);
+  const auto numColumns =
+      std::min<size_t>(schemaWithId->size(), inputColumns.size());
+  for (size_t i = 0; i < numColumns; ++i) {
+    const auto icebergHandle =
+        std::dynamic_pointer_cast<const IcebergColumnHandle>(inputColumns[i]);
+    if (icebergHandle != nullptr) {
+      stampFieldIdAttributes(
+          *schemaWithId->childAt(static_cast<uint32_t>(i)),
+          icebergHandle->field(),
+          attributes);
+    }
+  }
+  return attributes;
+}
+
 } // namespace
 
 IcebergDataSink::IcebergDataSink(
@@ -464,6 +514,16 @@ IcebergDataSink::createWriterOptions(size_t writerIndex) const {
     }
   }
 #endif
+
+  // For DWRF/ORC, Iceberg field ids are carried as per-type "iceberg.id"
+  // attributes stamped into the footer. Build the per-node attribute map from
+  // the input column handles so the reader can resolve columns by field id.
+  if (auto dwrfOptions =
+          std::dynamic_pointer_cast<dwrf::WriterOptions>(options)) {
+    dwrfOptions->schemaAttributes = buildDwrfSchemaAttributes(
+        std::dynamic_pointer_cast<const RowType>(dwrfOptions->schema),
+        icebergInsertTableHandle_->inputColumns());
+  }
 
   options->processConfigs(
       *hiveConfig_->config(), *connectorQueryCtx_->sessionProperties());

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -133,6 +133,57 @@ IcebergSplitReader::IcebergSplitReader(
       deleteBitmap_(nullptr),
       columnHandles_(std::move(columnHandles)) {}
 
+void IcebergSplitReader::configureBaseReaderOptions() {
+  FileSplitReader::configureBaseReaderOptions();
+  const auto fileFormat = fileSplit_->fileFormat;
+  if (fileFormat != dwio::common::FileFormat::DWRF &&
+      fileFormat != dwio::common::FileFormat::ORC) {
+    // Parquet resolves field ids from physical metadata, not from the
+    // attribute-based kFieldId path.
+    return;
+  }
+  auto fieldIds = buildFieldIds();
+  if (fieldIds.empty()) {
+    return;
+  }
+  baseReaderOpts_.setColumnMappingMode(
+      dwio::common::ColumnMappingMode::kFieldId);
+  baseReaderOpts_.setFieldIds(std::move(fieldIds));
+}
+
+std::vector<dwio::common::ParquetFieldId> IcebergSplitReader::buildFieldIds()
+    const {
+  std::vector<dwio::common::ParquetFieldId> fieldIds;
+  const auto& dataColumns = tableHandle_->dataColumns();
+  if (dataColumns == nullptr || columnHandles_ == nullptr) {
+    return fieldIds;
+  }
+  // Column handles are keyed by output alias; index them by the underlying
+  // data-column name so we can align to dataColumns() order.
+  std::unordered_map<std::string, const IcebergColumnHandle*> handleByName;
+  for (const auto& [outputName, handle] : *columnHandles_) {
+    if (auto* icebergHandle =
+            dynamic_cast<const IcebergColumnHandle*>(handle.get())) {
+      handleByName.emplace(icebergHandle->name(), icebergHandle);
+    }
+  }
+  if (handleByName.empty()) {
+    return fieldIds;
+  }
+
+  fieldIds.reserve(dataColumns->size());
+  int32_t sentinelFieldId = -1;
+  for (size_t i = 0; i < dataColumns->size(); ++i) {
+    auto it = handleByName.find(dataColumns->nameOf(static_cast<uint32_t>(i)));
+    if (it != handleByName.end()) {
+      fieldIds.push_back(it->second->field());
+    } else {
+      fieldIds.push_back(dwio::common::ParquetFieldId{sentinelFieldId--, {}});
+    }
+  }
+  return fieldIds;
+}
+
 void IcebergSplitReader::prepareSplit(
     std::shared_ptr<common::MetadataFilter> metadataFilter,
     dwio::common::RuntimeStatistics& runtimeStats,

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.h
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.h
@@ -57,6 +57,19 @@ class IcebergSplitReader : public FileSplitReader {
   uint64_t next(uint64_t size, VectorPtr& output) override;
 
  private:
+  // Configures the base reader options. For DWRF/ORC Iceberg reads, selects
+  // ColumnMappingMode::kFieldId and populates ReaderOptions::fieldIds() from
+  // the Iceberg column handles so the reader resolves columns by field id,
+  // enabling schema evolution (rename, reorder, delete, drop + re-add with same
+  // name).
+  void configureBaseReaderOptions() override;
+
+  // Builds the requested-schema field-id trees, one per top-level column,
+  // aligned to tableHandle_->dataColumns(). Data columns without an Iceberg
+  // handle (e.g. unprojected) get a negative sentinel id that matches no
+  // physical field. Returns empty when no Iceberg handles are available.
+  std::vector<dwio::common::ParquetFieldId> buildFieldIds() const;
+
   /// Adapts the data file schema to match the table schema expected by the
   /// query.
   ///

--- a/velox/connectors/hive/iceberg/tests/IcebergDwrfInsertTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergDwrfInsertTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/connectors/hive/HiveConfig.h"
+#include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
 #include "velox/connectors/hive/iceberg/tests/IcebergTestBase.h"
 #include "velox/dwio/dwrf/RegisterDwrfReader.h"
 #include "velox/dwio/dwrf/RegisterDwrfWriter.h"
@@ -262,6 +263,173 @@ TEST_F(IcebergDwrfInsertTest, ensureWriterNonPartitioned) {
   auto taskJson = folly::parseJson(commitTasks[0]);
   // Unpartitioned tables must not emit partitionDataJson.
   EXPECT_EQ(taskJson.count("partitionDataJson"), 0);
+}
+
+// Builds an Iceberg column handle with an explicit field-id tree, used to drive
+// reads whose requested schema differs from the written schema.
+std::shared_ptr<const connector::ColumnHandle> makeIcebergColumnHandle(
+    const std::string& name,
+    const TypePtr& type,
+    const parquet::ParquetFieldId& field) {
+  return std::make_shared<const IcebergColumnHandle>(
+      name, FileColumnHandle::ColumnType::kRegular, type, field);
+}
+
+// Schema evolution: a top-level column is renamed (c -> c2, id 3) and
+// reordered, another is dropped from the projection (b, id 2), and a new column
+// is added (d, id 9) that is absent from the file. Field-id resolution must
+// read c2/a from the file by id and null-fill d.
+TEST_F(IcebergDwrfInsertTest, fieldIdRenameReorderDropAdd) {
+  auto writeSchema = ROW({"a", "b", "c"}, {BIGINT(), INTEGER(), VARCHAR()});
+  auto writeVector = makeRowVector(
+      {"a", "b", "c"},
+      {makeFlatVector<int64_t>({1, 2, 3}),
+       makeFlatVector<int32_t>({10, 20, 30}),
+       makeFlatVector<std::string>({"x", "y", "z"})});
+
+  const auto dir = TempDirectoryPath::create();
+  const auto path = dir->getPath();
+  createDataSinkAndAppendData({writeVector}, path)->close();
+  auto splits = createSplitsForDirectory(path);
+
+  // Written field ids (assigned depth-first from 1): a=1, b=2, c=3.
+  auto readSchema = ROW({"c2", "a", "d"}, {VARCHAR(), BIGINT(), INTEGER()});
+  std::
+      unordered_map<std::string, std::shared_ptr<const connector::ColumnHandle>>
+          assignments{
+              {"c2", makeIcebergColumnHandle("c2", VARCHAR(), {3, {}})},
+              {"a", makeIcebergColumnHandle("a", BIGINT(), {1, {}})},
+              {"d", makeIcebergColumnHandle("d", INTEGER(), {9, {}})}};
+
+  auto plan = exec::test::PlanBuilder()
+                  .startTableScan()
+                  .connectorId(test::kIcebergConnectorId)
+                  .outputType(readSchema)
+                  .dataColumns(readSchema)
+                  .assignments(assignments)
+                  .endTableScan()
+                  .planNode();
+
+  auto expected = makeRowVector(
+      {"c2", "a", "d"},
+      {makeFlatVector<std::string>({"x", "y", "z"}),
+       makeFlatVector<int64_t>({1, 2, 3}),
+       makeNullConstant(TypeKind::INTEGER, 3)});
+  exec::test::AssertQueryBuilder(plan).splits(splits).assertResults({expected});
+}
+
+// Schema evolution: column c (id 1) is dropped and a new column with the same
+// name c (id 9) is added. The stale file column must NOT bind to the new c by
+// name; the new c must read as null.
+TEST_F(IcebergDwrfInsertTest, fieldIdDropReaddSameName) {
+  auto writeVector = makeRowVector({"c"}, {makeFlatVector<int32_t>({1, 2, 3})});
+
+  const auto dir = TempDirectoryPath::create();
+  const auto path = dir->getPath();
+  createDataSinkAndAppendData({writeVector}, path)->close();
+  auto splits = createSplitsForDirectory(path);
+
+  // Written field id: c=1. The re-added c has id 9.
+  auto readSchema = ROW({"c"}, {INTEGER()});
+  std::
+      unordered_map<std::string, std::shared_ptr<const connector::ColumnHandle>>
+          assignments{{"c", makeIcebergColumnHandle("c", INTEGER(), {9, {}})}};
+
+  auto plan = exec::test::PlanBuilder()
+                  .startTableScan()
+                  .connectorId(test::kIcebergConnectorId)
+                  .outputType(readSchema)
+                  .dataColumns(readSchema)
+                  .assignments(assignments)
+                  .endTableScan()
+                  .planNode();
+
+  auto expected =
+      makeRowVector({"c"}, {makeNullConstant(TypeKind::INTEGER, 3)});
+  exec::test::AssertQueryBuilder(plan).splits(splits).assertResults({expected});
+}
+
+// Schema evolution inside a struct: a nested field is dropped (y) and the
+// remaining nested fields are reordered (z before x). Field-id resolution must
+// match nested columns by id, not position.
+TEST_F(IcebergDwrfInsertTest, fieldIdNestedStructReorderDrop) {
+  auto writeVector = makeRowVector(
+      {"s"},
+      {makeRowVector(
+          {"x", "y", "z"},
+          {makeFlatVector<int32_t>({1, 2, 3}),
+           makeFlatVector<int32_t>({4, 5, 6}),
+           makeFlatVector<int32_t>({7, 8, 9})})});
+
+  const auto dir = TempDirectoryPath::create();
+  const auto path = dir->getPath();
+  createDataSinkAndAppendData({writeVector}, path)->close();
+  auto splits = createSplitsForDirectory(path);
+
+  // Written field ids (depth-first): s=1, x=2, y=3, z=4.
+  auto readSchema = ROW({"s"}, {ROW({"z", "x"}, {INTEGER(), INTEGER()})});
+  std::
+      unordered_map<std::string, std::shared_ptr<const connector::ColumnHandle>>
+          assignments{
+              {"s",
+               makeIcebergColumnHandle(
+                   "s",
+                   ROW({"z", "x"}, {INTEGER(), INTEGER()}),
+                   {1, {{4, {}}, {2, {}}}})}};
+
+  auto plan = exec::test::PlanBuilder()
+                  .startTableScan()
+                  .connectorId(test::kIcebergConnectorId)
+                  .outputType(readSchema)
+                  .dataColumns(readSchema)
+                  .assignments(assignments)
+                  .endTableScan()
+                  .planNode();
+
+  auto expected = makeRowVector(
+      {"s"},
+      {makeRowVector(
+          {"z", "x"},
+          {makeFlatVector<int32_t>({7, 8, 9}),
+           makeFlatVector<int32_t>({1, 2, 3})})});
+  exec::test::AssertQueryBuilder(plan).splits(splits).assertResults({expected});
+}
+
+// Allowable type promotion under field-id resolution: a column written as
+// INTEGER is read as BIGINT, and one written as REAL is read as DOUBLE.
+TEST_F(IcebergDwrfInsertTest, fieldIdTypePromotion) {
+  auto writeVector = makeRowVector(
+      {"a", "b"},
+      {makeFlatVector<int32_t>({1, 2, 3}),
+       makeFlatVector<float>({1.5, 2.5, 3.5})});
+
+  const auto dir = TempDirectoryPath::create();
+  const auto path = dir->getPath();
+  createDataSinkAndAppendData({writeVector}, path)->close();
+  auto splits = createSplitsForDirectory(path);
+
+  // Written field ids: a=1, b=2.
+  auto readSchema = ROW({"a", "b"}, {BIGINT(), DOUBLE()});
+  std::
+      unordered_map<std::string, std::shared_ptr<const connector::ColumnHandle>>
+          assignments{
+              {"a", makeIcebergColumnHandle("a", BIGINT(), {1, {}})},
+              {"b", makeIcebergColumnHandle("b", DOUBLE(), {2, {}})}};
+
+  auto plan = exec::test::PlanBuilder()
+                  .startTableScan()
+                  .connectorId(test::kIcebergConnectorId)
+                  .outputType(readSchema)
+                  .dataColumns(readSchema)
+                  .assignments(assignments)
+                  .endTableScan()
+                  .planNode();
+
+  auto expected = makeRowVector(
+      {"a", "b"},
+      {makeFlatVector<int64_t>({1, 2, 3}),
+       makeFlatVector<double>({1.5, 2.5, 3.5})});
+  exec::test::AssertQueryBuilder(plan).splits(splits).assertResults({expected});
 }
 
 } // namespace

--- a/velox/dwio/common/Options.cpp
+++ b/velox/dwio/common/Options.cpp
@@ -47,6 +47,7 @@ const auto& columnMappingModeNames() {
       {ColumnMappingMode::kPosition, "POSITION"},
       {ColumnMappingMode::kName, "NAME"},
       {ColumnMappingMode::kParquetFieldId, "PARQUET_FIELD_ID"},
+      {ColumnMappingMode::kFieldId, "FIELD_ID"},
   };
   return kNames;
 }

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -37,6 +37,7 @@
 #include "velox/dwio/common/FlatMapHelper.h"
 #include "velox/dwio/common/FlushPolicy.h"
 #include "velox/dwio/common/InputStream.h"
+#include "velox/dwio/common/ParquetFieldId.h"
 #include "velox/dwio/common/ScanSpec.h"
 #include "velox/dwio/common/UnitLoader.h"
 #include "velox/dwio/common/encryption/Encryption.h"
@@ -119,6 +120,24 @@ enum class ColumnMappingMode {
   /// This is Parquet-specific. Readers for other formats should reject this
   /// mode instead of interpreting it as a generic column identity mechanism.
   kParquetFieldId,
+
+  /// Matches physical fields to requested columns by Iceberg field id carried
+  /// as per-type string attributes ("iceberg.id") in the file schema.
+  ///
+  /// Use this mode for DWRF/ORC files written for Iceberg, where a column's
+  /// identity is its field id rather than its name or position. Unlike
+  /// kParquetFieldId (which reads physical Parquet field_id metadata), this
+  /// mode
+  /// reads the ORC-spec attribute convention that DWRF/ORC writers stamp onto
+  /// each schema node. The caller provides ReaderOptions::fieldIds() describing
+  /// the requested (table) schema's field ids, aligned to fileSchema() at every
+  /// row-typed level. The reader renames the file's columns to the requested
+  /// names that share their field id, so a downstream name-based read resolves
+  /// renames, reorders, deletions, and drop/re-add-with-same-name correctly.
+  /// Physical nodes without an "iceberg.id" attribute do not match any positive
+  /// requested field id and are surfaced as missing (the connector materializes
+  /// them as null or the table format's default value).
+  kFieldId,
 };
 
 VELOX_DECLARE_ENUM_NAME(ColumnMappingMode);
@@ -724,6 +743,14 @@ class ReaderOptions : public io::ReaderOptions {
     return *this;
   }
 
+  /// Sets the requested (table) schema field ids for
+  /// ColumnMappingMode::kFieldId, one ParquetFieldId tree per top-level column,
+  /// aligned to fileSchema().
+  ReaderOptions& setFieldIds(std::vector<ParquetFieldId> fieldIds) {
+    fieldIds_ = std::move(fieldIds);
+    return *this;
+  }
+
   ReaderOptions& setSessionTimezone(const tz::TimeZone* sessionTimezone) {
     sessionTimezone_ = sessionTimezone;
     return *this;
@@ -761,6 +788,11 @@ class ReaderOptions : public io::ReaderOptions {
   /// Gets the file schema.
   const std::shared_ptr<const velox::RowType>& fileSchema() const {
     return fileSchema_;
+  }
+
+  /// Gets the requested schema field ids for ColumnMappingMode::kFieldId.
+  const std::vector<ParquetFieldId>& fieldIds() const {
+    return fieldIds_;
   }
 
   SerDeOptions& serDeOptions() {
@@ -958,6 +990,7 @@ class ReaderOptions : public io::ReaderOptions {
   uint64_t tailLocation_{std::numeric_limits<uint64_t>::max()};
   FileFormat fileFormat_{FileFormat::UNKNOWN};
   RowTypePtr fileSchema_;
+  std::vector<ParquetFieldId> fieldIds_;
   SerDeOptions serDeOptions_;
   std::unordered_map<std::string, std::string> properties_{};
   std::shared_ptr<FormatSpecificOptions> formatSpecificOptions_;

--- a/velox/dwio/dwrf/common/FileMetadata.h
+++ b/velox/dwio/dwrf/common/FileMetadata.h
@@ -357,6 +357,25 @@ class TypeWrapper : public ProtoWrapperBase {
                                         : orcPtr()->fieldnames(index);
   }
 
+  /// Number of string-keyed attributes on this type. Iceberg encodes per-field
+  /// metadata (e.g. "iceberg.id") here for files manifest-tagged as ORC.
+  int attributesSize() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->attributes_size()
+                                        : orcPtr()->attributes_size();
+  }
+
+  /// Returns the (key, value) attribute pair at 'index'. Insertion order is
+  /// preserved on the wire, matching how it was stamped at write time.
+  std::pair<std::string, std::string> attribute(int index) const {
+    return format_ == DwrfFormat::kDwrf
+        ? std::make_pair(
+              dwrfPtr()->attributes(index).key(),
+              dwrfPtr()->attributes(index).value())
+        : std::make_pair(
+              orcPtr()->attributes(index).key(),
+              orcPtr()->attributes(index).value());
+  }
+
  private:
   // private helper with no format checking
   inline const proto::Type* dwrfPtr() const {
@@ -1165,6 +1184,20 @@ class TypeWriteWrapper : public ProtoWriteWrapperBase {
   void addSubtypes(int fieldName) {
     format_ == DwrfFormat::kDwrf ? dwrfPtr()->add_subtypes(fieldName)
                                  : orcPtr()->add_subtypes(fieldName);
+  }
+
+  /// Appends a string-keyed attribute to this type. Iceberg uses this to stamp
+  /// per-field metadata such as "iceberg.id" for files manifest-tagged as ORC.
+  void addAttribute(const std::string& key, const std::string& value) {
+    if (format_ == DwrfFormat::kDwrf) {
+      auto* attribute = dwrfPtr()->add_attributes();
+      attribute->set_key(key);
+      attribute->set_value(value);
+    } else {
+      auto* attribute = orcPtr()->add_attributes();
+      attribute->set_key(key);
+      attribute->set_value(value);
+    }
   }
 
  private:

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -16,14 +16,18 @@
 
 #include "velox/dwio/dwrf/reader/DwrfReader.h"
 
+#include <charconv>
 #include <chrono>
 
+#include <fmt/format.h>
 #include "velox/dwio/common/OnDemandUnitLoader.h"
 #include "velox/dwio/common/ParallelUnitLoader.h"
 #include "velox/dwio/common/TypeUtils.h"
+#include "velox/dwio/common/TypeWithId.h"
 #include "velox/dwio/common/exception/Exception.h"
 #include "velox/dwio/dwrf/reader/ColumnReader.h"
 #include "velox/dwio/dwrf/reader/StreamLabels.h"
+#include "velox/dwio/dwrf/utils/ProtoUtils.h"
 #include "velox/vector/FlatVector.h"
 
 namespace facebook::velox::dwrf {
@@ -878,10 +882,14 @@ DwrfReader::DwrfReader(
   // code. So we rename column names in the file schema to match table schema.
   // We test the options to have 'fileSchema' (actually table schema) as most
   // of the unit tests fail to provide it.
-  if (readerBase_->readerOptions().columnMappingMode() !=
-          dwio::common::ColumnMappingMode::kName &&
-      (readerBase_->readerOptions().fileSchema() != nullptr)) {
-    updateColumnNamesFromTableSchema();
+  const auto columnMappingMode =
+      readerBase_->readerOptions().columnMappingMode();
+  if (readerBase_->readerOptions().fileSchema() != nullptr) {
+    if (columnMappingMode == dwio::common::ColumnMappingMode::kFieldId) {
+      updateColumnNamesFromFieldIds();
+    } else if (columnMappingMode != dwio::common::ColumnMappingMode::kName) {
+      updateColumnNamesFromTableSchema();
+    }
   }
 }
 
@@ -891,6 +899,151 @@ void DwrfReader::updateColumnNamesFromTableSchema() {
   readerBase_->setSchema(
       std::dynamic_pointer_cast<const RowType>(
           updateColumnNames(fileSchema, tableSchema)));
+}
+
+namespace {
+
+constexpr std::string_view kIcebergFieldIdKey{"iceberg.id"};
+
+using AttributesByNode = std::
+    unordered_map<uint32_t, std::vector<std::pair<std::string, std::string>>>;
+
+// Returns the Iceberg field id ("iceberg.id") attribute on the schema node with
+// the given pre-order id, if present and parseable.
+std::optional<int32_t> icebergFieldId(
+    const AttributesByNode& attributesByNode,
+    uint32_t nodeId) {
+  auto it = attributesByNode.find(nodeId);
+  if (it == attributesByNode.end()) {
+    return std::nullopt;
+  }
+  for (const auto& [key, value] : it->second) {
+    if (key == kIcebergFieldIdKey) {
+      int32_t parsed = 0;
+      const auto* begin = value.data();
+      const auto* end = begin + value.size();
+      const auto result = std::from_chars(begin, end, parsed);
+      if (result.ec == std::errc{} && result.ptr == end) {
+        return parsed;
+      }
+    }
+  }
+  return std::nullopt;
+}
+
+// Recursively rebuilds the file node's type, renaming file columns to the
+// requested (table) names that share their Iceberg field id. 'tableType' is the
+// matched requested node and 'tableChildFieldIds' holds its children's field id
+// trees. File columns without a matching requested field id are renamed to a
+// non-colliding sentinel so a downstream name match cannot bind them (this is
+// what makes drop + re-add of a column with the same name resolve correctly).
+TypePtr renameByFieldId(
+    const dwio::common::TypeWithId& fileNode,
+    const AttributesByNode& attributesByNode,
+    const TypePtr& tableType,
+    const std::vector<dwio::common::ParquetFieldId>& tableChildFieldIds) {
+  const auto& fileType = fileNode.type();
+  if (fileType->kind() != tableType->kind()) {
+    return fileType;
+  }
+
+  if (fileType->isRow()) {
+    const auto& tableRow = tableType->asRow();
+    const auto numTableChildren =
+        std::min<size_t>(tableRow.size(), tableChildFieldIds.size());
+    std::unordered_map<int32_t, size_t> tableChildByFieldId;
+    tableChildByFieldId.reserve(numTableChildren);
+    for (size_t j = 0; j < numTableChildren; ++j) {
+      tableChildByFieldId.emplace(tableChildFieldIds[j].fieldId, j);
+    }
+
+    std::vector<std::string> names;
+    std::vector<TypePtr> types;
+    names.reserve(fileNode.size());
+    types.reserve(fileNode.size());
+    for (size_t i = 0; i < fileNode.size(); ++i) {
+      const auto& fileChild = *fileNode.childAt(static_cast<uint32_t>(i));
+      const auto fieldId = icebergFieldId(attributesByNode, fileChild.id());
+      std::optional<size_t> tableChildIdx;
+      if (fieldId.has_value()) {
+        auto match = tableChildByFieldId.find(*fieldId);
+        if (match != tableChildByFieldId.end()) {
+          tableChildIdx = match->second;
+        }
+      }
+      if (tableChildIdx.has_value()) {
+        names.push_back(tableRow.nameOf(static_cast<uint32_t>(*tableChildIdx)));
+        types.push_back(renameByFieldId(
+            fileChild,
+            attributesByNode,
+            tableRow.childAt(static_cast<uint32_t>(*tableChildIdx)),
+            tableChildFieldIds[*tableChildIdx].children));
+      } else {
+        names.push_back(fmt::format("$dwrf_unmatched_{}", fileChild.id()));
+        types.push_back(fileChild.type());
+      }
+    }
+    return ROW(std::move(names), std::move(types));
+  }
+
+  if (fileType->isArray()) {
+    if (tableChildFieldIds.empty() || fileNode.size() == 0) {
+      return fileType;
+    }
+    return ARRAY(renameByFieldId(
+        *fileNode.childAt(0),
+        attributesByNode,
+        tableType->asArray().elementType(),
+        tableChildFieldIds[0].children));
+  }
+
+  if (fileType->isMap()) {
+    if (tableChildFieldIds.size() < 2 || fileNode.size() < 2) {
+      return fileType;
+    }
+    auto keyType = renameByFieldId(
+        *fileNode.childAt(0),
+        attributesByNode,
+        tableType->asMap().keyType(),
+        tableChildFieldIds[0].children);
+    auto valueType = renameByFieldId(
+        *fileNode.childAt(1),
+        attributesByNode,
+        tableType->asMap().valueType(),
+        tableChildFieldIds[1].children);
+    return MAP(std::move(keyType), std::move(valueType));
+  }
+
+  return fileType;
+}
+
+} // namespace
+
+void DwrfReader::updateColumnNamesFromFieldIds() {
+  const auto& options = readerBase_->readerOptions();
+  const auto& tableSchema = options.fileSchema();
+  const auto& fieldIds = options.fieldIds();
+  const auto& footer = readerBase_->footer();
+  // Field ids are carried as "iceberg.id" attributes on the footer types, in
+  // either the DWRF or ORC proto variant (Iceberg manifest-tags DWRF as ORC).
+  const auto attributesByNode = ProtoUtils::readAttributes(footer);
+  if (attributesByNode.empty()) {
+    // The file carries no Iceberg field-id attributes (written before field-id
+    // support, by a non-Iceberg writer, or a Hive-migrated table). Field-id
+    // resolution is impossible, so fall back to position-based name mapping
+    // (rename file columns to the requested table names by position), matching
+    // the behavior used for non-field-id column mapping. This keeps
+    // physically-present columns bound to the file instead of being treated as
+    // missing and wrongly filled with defaults/nulls.
+    updateColumnNamesFromTableSchema();
+    return;
+  }
+
+  const auto fileWithId =
+      dwio::common::TypeWithId::create(readerBase_->schema());
+  auto renamed =
+      renameByFieldId(*fileWithId, attributesByNode, tableSchema, fieldIds);
+  readerBase_->setSchema(std::dynamic_pointer_cast<const RowType>(renamed));
 }
 
 std::unique_ptr<StripeInformation> DwrfReader::getStripe(

--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -358,6 +358,12 @@ class DwrfReader : public dwio::common::Reader {
   // column indices.
   void updateColumnNamesFromTableSchema();
 
+  // Renames the file schema's columns to the requested (table) schema names
+  // that share their Iceberg field id ("iceberg.id" attribute), recursively.
+  // Used for ColumnMappingMode::kFieldId so a downstream name-based read
+  // resolves renames, reorders, deletions, and drop/re-add-with-same-name.
+  void updateColumnNamesFromFieldIds();
+
  private:
   std::shared_ptr<ReaderBase> readerBase_;
 };

--- a/velox/dwio/dwrf/test/E2EWriterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EWriterTest.cpp
@@ -281,6 +281,110 @@ class E2EWriterTest : public testing::Test {
   std::shared_ptr<MemoryPool> leafPool_;
 };
 
+// Writes a DWRF file with 'fileSchema' and per-node iceberg.id attributes, then
+// opens it with ColumnMappingMode::kFieldId against 'tableSchema'/'fieldIds'
+// and returns the reader's (field-id-renamed) row type.
+RowTypePtr readWithFieldIds(
+    memory::MemoryPool* rootPool,
+    memory::MemoryPool* leafPool,
+    const RowTypePtr& fileSchema,
+    const std::unordered_map<
+        uint32_t,
+        std::vector<std::pair<std::string, std::string>>>& schemaAttributes,
+    const RowTypePtr& tableSchema,
+    const std::vector<dwio::common::ParquetFieldId>& fieldIds) {
+  auto sink = std::make_unique<MemorySink>(
+      16 * 1024 * 1024, dwio::common::FileSink::Options{.pool = leafPool});
+  auto* sinkPtr = sink.get();
+
+  dwrf::WriterOptions options;
+  options.config = std::make_shared<dwrf::Config>();
+  options.schema = fileSchema;
+  options.memoryPool = rootPool;
+  options.schemaAttributes = schemaAttributes;
+  dwrf::Writer writer{std::move(sink), options};
+  writer.write(BatchMaker::createBatch(fileSchema, 10, *leafPool, nullptr, 0));
+  writer.close();
+
+  dwio::common::ReaderOptions readerOpts(leafPool);
+  readerOpts.setColumnMappingMode(dwio::common::ColumnMappingMode::kFieldId);
+  readerOpts.setFileSchema(tableSchema);
+  readerOpts.setFieldIds(fieldIds);
+  std::string_view data(sinkPtr->data(), sinkPtr->size());
+  auto reader = std::make_unique<dwrf::DwrfReader>(
+      readerOpts,
+      std::make_unique<BufferedInput>(
+          std::make_shared<InMemoryReadFile>(data), readerOpts.memoryPool()));
+  return reader->rowType();
+}
+
+TEST_F(E2EWriterTest, FieldIdMappingRenameReorderDrop) {
+  // File node ids: 0=root, 1=a, 2=b, 3=c.
+  auto fileSchema = ROW({"a", "b", "c"}, {INTEGER(), BIGINT(), VARCHAR()});
+  // Requested: c renamed to c2 (id 3, reordered first), a kept (id 1), b
+  // dropped (id 2 absent), d added (id 9 absent from file).
+  auto tableSchema = ROW({"c2", "a", "d"}, {VARCHAR(), INTEGER(), INTEGER()});
+  auto rowType = readWithFieldIds(
+      rootPool_.get(),
+      leafPool_.get(),
+      fileSchema,
+      {{1, {{"iceberg.id", "1"}}},
+       {2, {{"iceberg.id", "2"}}},
+       {3, {{"iceberg.id", "3"}}}},
+      tableSchema,
+      {{3, {}}, {1, {}}, {9, {}}});
+
+  // File order is preserved; matched columns take the requested name, the
+  // dropped column (id 2) gets a non-colliding sentinel name.
+  ASSERT_EQ(rowType->size(), 3);
+  EXPECT_EQ(rowType->nameOf(0), "a");
+  EXPECT_EQ(rowType->nameOf(1), "$dwrf_unmatched_2");
+  EXPECT_EQ(rowType->nameOf(2), "c2");
+}
+
+TEST_F(E2EWriterTest, FieldIdMappingDropReaddSameName) {
+  // File has column c with field id 5; the table dropped it and re-added a new
+  // column c with field id 9. The stale file column must NOT bind to the new c.
+  auto fileSchema = ROW({"c"}, {INTEGER()});
+  auto tableSchema = ROW({"c"}, {INTEGER()});
+  auto rowType = readWithFieldIds(
+      rootPool_.get(),
+      leafPool_.get(),
+      fileSchema,
+      {{1, {{"iceberg.id", "5"}}}},
+      tableSchema,
+      {{9, {}}});
+
+  ASSERT_EQ(rowType->size(), 1);
+  EXPECT_EQ(rowType->nameOf(0), "$dwrf_unmatched_1");
+}
+
+TEST_F(E2EWriterTest, FieldIdMappingNestedStruct) {
+  // File node ids: 0=root, 1=s, 2=s.x, 3=s.y.
+  auto fileSchema = ROW({"s"}, {ROW({"x", "y"}, {INTEGER(), INTEGER()})});
+  // Requested struct reorders children and renames y->y2; ids: s=10, x=11,
+  // y=12.
+  auto tableSchema = ROW({"s"}, {ROW({"y2", "x"}, {INTEGER(), INTEGER()})});
+  std::vector<dwio::common::ParquetFieldId> fieldIds{
+      {10, {{12, {}}, {11, {}}}}};
+  auto rowType = readWithFieldIds(
+      rootPool_.get(),
+      leafPool_.get(),
+      fileSchema,
+      {{1, {{"iceberg.id", "10"}}},
+       {2, {{"iceberg.id", "11"}}},
+       {3, {{"iceberg.id", "12"}}}},
+      tableSchema,
+      fieldIds);
+
+  // Nested children keep file order but take the requested names matched by id.
+  ASSERT_EQ(rowType->size(), 1);
+  auto& nested = rowType->childAt(0)->asRow();
+  ASSERT_EQ(nested.size(), 2);
+  EXPECT_EQ(nested.nameOf(0), "x");
+  EXPECT_EQ(nested.nameOf(1), "y2");
+}
+
 // This test can be run to generate test files. Run it with following command
 // buck test velox/dwio/dwrf/test:velox_dwrf_e2e_writer_tests --
 // DISABLED_TestFileCreation

--- a/velox/dwio/dwrf/test/WriterTest.cpp
+++ b/velox/dwio/dwrf/test/WriterTest.cpp
@@ -33,7 +33,7 @@ namespace facebook::velox::dwrf {
 
 class WriterTest : public Test {
  public:
-  static void SetUpTestCase() {
+  static void SetUpTestSuite() {
     MemoryManager::testingSetInstance(MemoryManager::Options{});
   }
 
@@ -203,6 +203,41 @@ TEST_P(AllWriterCompressionTest, compression) {
       compressionKind_ == CompressionKind::CompressionKind_MAX
           ? config->get(Config::COMPRESSION)
           : compressionKind_);
+}
+
+TEST_F(WriterTest, SchemaAttributesStamped) {
+  // Attributes set on the writer must be stamped into the footer per node id
+  // and survive a write/read round-trip. Node ids: 0=root, 1=a, 2=b, 3=c.
+  auto config = std::make_shared<Config>();
+  config->set(Config::COMPRESSION, CompressionKind::CompressionKind_NONE);
+  auto& writer = createWriter(config);
+  writer.setSchemaAttributes(
+      {{1, {{"iceberg.id", "10"}}},
+       {2, {{"iceberg.id", "20"}}},
+       {3, {{"iceberg.id", "30"}}}});
+
+  HiveTypeParser parser;
+  auto schema = parser.parse("struct<a:int,b:float,c:string>");
+  // writeFooter requires one statistics entry per type node.
+  for (size_t i = 0; i < 4; ++i) {
+    getFooter()->addStatistics();
+  }
+  writeFooter(*schema);
+  writer.close();
+
+  auto reader = createReader();
+  auto& footer = reader->footer();
+  ASSERT_EQ(footer.typesSize(), 4);
+  EXPECT_EQ(footer.types(0).attributesSize(), 0);
+  EXPECT_EQ(
+      footer.types(1).attribute(0),
+      std::make_pair(std::string("iceberg.id"), std::string("10")));
+  EXPECT_EQ(
+      footer.types(2).attribute(0),
+      std::make_pair(std::string("iceberg.id"), std::string("20")));
+  EXPECT_EQ(
+      footer.types(3).attribute(0),
+      std::make_pair(std::string("iceberg.id"), std::string("30")));
 }
 
 TEST_P(SupportedCompressionTest, WriteFooter) {

--- a/velox/dwio/dwrf/utils/ProtoUtils.cpp
+++ b/velox/dwio/dwrf/utils/ProtoUtils.cpp
@@ -52,10 +52,12 @@ CREATE_TYPE_TRAIT(ROW, STRUCT)
 void ProtoUtils::writeType(
     const Type& type,
     FooterWriteWrapper& footer,
-    TypeWriteWrapper* parent) {
+    TypeWriteWrapper* parent,
+    const AttributeProvider& attributeProvider) {
   auto self = footer.addTypes();
+  const uint32_t typeId = footer.typesSize() - 1;
   if (parent) {
-    parent->addSubtypes(footer.typesSize() - 1);
+    parent->addSubtypes(static_cast<int>(typeId));
   }
 
   auto kind =
@@ -63,28 +65,58 @@ void ProtoUtils::writeType(
   auto typeKindWrapper = TypeKindWrapper(&kind);
   self.setKind(typeKindWrapper);
 
+  // Stamp per-type attributes (e.g. Iceberg field ids) before recursing into
+  // children. An empty result keeps the wire format byte-identical to the
+  // pre-attributes serialization for callers that do not provide attributes.
+  if (attributeProvider) {
+    for (const auto& [key, value] : attributeProvider(typeId)) {
+      self.addAttribute(key, value);
+    }
+  }
+
   switch (type.kind()) {
     case TypeKind::ROW: {
       auto& row = type.asRow();
       for (size_t i = 0; i < row.size(); ++i) {
         self.addFieldnames(row.nameOf(i));
-        writeType(*row.childAt(i), footer, &self);
+        writeType(*row.childAt(i), footer, &self, attributeProvider);
       }
       break;
     }
     case TypeKind::ARRAY:
-      writeType(*type.asArray().elementType(), footer, &self);
+      writeType(
+          *type.asArray().elementType(), footer, &self, attributeProvider);
       break;
     case TypeKind::MAP: {
       auto& map = type.asMap();
-      writeType(*map.keyType(), footer, &self);
-      writeType(*map.valueType(), footer, &self);
+      writeType(*map.keyType(), footer, &self, attributeProvider);
+      writeType(*map.valueType(), footer, &self, attributeProvider);
       break;
     }
     default:
       DWIO_ENSURE(type.isPrimitiveType());
       break;
   }
+}
+
+std::unordered_map<uint32_t, std::vector<std::pair<std::string, std::string>>>
+ProtoUtils::readAttributes(const FooterWrapper& footer) {
+  std::unordered_map<uint32_t, std::vector<std::pair<std::string, std::string>>>
+      result;
+  for (int32_t i = 0; i < footer.typesSize(); ++i) {
+    const auto type = footer.types(i);
+    const auto numAttributes = type.attributesSize();
+    if (numAttributes == 0) {
+      continue;
+    }
+    std::vector<std::pair<std::string, std::string>> attributes;
+    attributes.reserve(numAttributes);
+    for (int32_t j = 0; j < numAttributes; ++j) {
+      attributes.emplace_back(type.attribute(j));
+    }
+    result.emplace(static_cast<uint32_t>(i), std::move(attributes));
+  }
+  return result;
 }
 
 std::shared_ptr<const Type> ProtoUtils::fromFooter(

--- a/velox/dwio/dwrf/utils/ProtoUtils.h
+++ b/velox/dwio/dwrf/utils/ProtoUtils.h
@@ -16,6 +16,12 @@
 
 #pragma once
 
+#include <functional>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
 #include "velox/dwio/common/SeekableInputStream.h"
 #include "velox/dwio/dwrf/common/FileMetadata.h"
 #include "velox/dwio/dwrf/common/wrap/dwrf-proto-wrapper.h"
@@ -25,15 +31,31 @@ namespace facebook::velox::dwrf {
 
 class ProtoUtils final {
  public:
+  /// Provides the string-keyed attributes to stamp on the type whose pre-order
+  /// node id is passed in. Returns an empty list for nodes without attributes.
+  using AttributeProvider =
+      std::function<std::vector<std::pair<std::string, std::string>>(
+          uint32_t typeId)>;
+
   static void writeType(
       const Type& type,
       FooterWriteWrapper&,
-      TypeWriteWrapper* parent = nullptr);
+      TypeWriteWrapper* parent = nullptr,
+      const AttributeProvider& attributeProvider = {});
 
   static std::shared_ptr<const Type> fromFooter(
       const proto::Footer& footer,
       std::function<bool(uint32_t)> selector = [](uint32_t) { return true; },
       uint32_t index = 0);
+
+  /// Reads the per-type string attributes from 'footer', keyed by pre-order
+  /// node id (the index into footer.types(), which matches TypeWithId::id()).
+  /// Types without attributes are omitted, so legacy files yield an empty map.
+  /// Handles both DWRF and ORC footers via FooterWrapper, since Iceberg field
+  /// ids are carried as attributes in either proto variant.
+  static std::
+      unordered_map<uint32_t, std::vector<std::pair<std::string, std::string>>>
+      readAttributes(const FooterWrapper& footer);
 
   // Deserialize proto from inputStream. Caller can optionally pass in the
   // object to serialize to.

--- a/velox/dwio/dwrf/utils/test/ProtoUtilsTests.cpp
+++ b/velox/dwio/dwrf/utils/test/ProtoUtilsTests.cpp
@@ -55,3 +55,89 @@ TEST(ProtoUtilsTests, Projection) {
 
   EXPECT_EQ("struct<a:boolean,c:smallint,d:struct<b:int,c:int>>", res);
 }
+
+TEST(ProtoUtilsTests, AttributesRoundTrip) {
+  // iceberg.id stamped on a subset of nodes must survive footer serialization
+  // and come back keyed by the same pre-order node id, leaving the schema
+  // intact. Node ids: 0=root, 1=a, 2=b, 3=c, 4=c.x, 5=c.y.
+  HiveTypeParser parser;
+  auto schema = parser.parse("struct<a:int,b:bigint,c:struct<x:int,y:int>>");
+  proto::Footer footer;
+  auto footerWrapper = FooterWriteWrapper(&footer);
+
+  const std::unordered_map<uint32_t, std::string> idByNode{
+      {1, "10"}, {2, "20"}, {4, "40"}};
+  ProtoUtils::writeType(
+      *schema, footerWrapper, /*parent=*/nullptr, [&](uint32_t typeId) {
+        std::vector<std::pair<std::string, std::string>> attributes;
+        auto it = idByNode.find(typeId);
+        if (it != idByNode.end()) {
+          attributes.emplace_back("iceberg.id", it->second);
+        }
+        return attributes;
+      });
+
+  std::string serialized;
+  ASSERT_TRUE(footer.SerializeToString(&serialized));
+  proto::Footer parsed;
+  ASSERT_TRUE(parsed.ParseFromString(serialized));
+
+  const std::
+      unordered_map<uint32_t, std::vector<std::pair<std::string, std::string>>>
+          expected{
+              {1, {{"iceberg.id", "10"}}},
+              {2, {{"iceberg.id", "20"}}},
+              {4, {{"iceberg.id", "40"}}}};
+  EXPECT_EQ(ProtoUtils::readAttributes(FooterWrapper(&parsed)), expected);
+  EXPECT_EQ(
+      HiveTypeSerializer::serialize(ProtoUtils::fromFooter(parsed)),
+      "struct<a:int,b:bigint,c:struct<x:int,y:int>>");
+}
+
+TEST(ProtoUtilsTests, AttributesRoundTripOrc) {
+  // The same iceberg.id round-trip must work for ORC footers: DWRF/ORC Iceberg
+  // reads resolve columns by field id from these attributes, and Iceberg
+  // manifest-tags DWRF files as ORC. Node ids: 0=root, 1=a, 2=b, 3=c, 4=c.x,
+  // 5=c.y.
+  HiveTypeParser parser;
+  auto schema = parser.parse("struct<a:int,b:bigint,c:struct<x:int,y:int>>");
+  proto::orc::Footer footer;
+  auto footerWrapper = FooterWriteWrapper(&footer);
+
+  const std::unordered_map<uint32_t, std::string> idByNode{
+      {1, "10"}, {2, "20"}, {4, "40"}};
+  ProtoUtils::writeType(
+      *schema, footerWrapper, /*parent=*/nullptr, [&](uint32_t typeId) {
+        std::vector<std::pair<std::string, std::string>> attributes;
+        auto it = idByNode.find(typeId);
+        if (it != idByNode.end()) {
+          attributes.emplace_back("iceberg.id", it->second);
+        }
+        return attributes;
+      });
+
+  std::string serialized;
+  ASSERT_TRUE(footer.SerializeToString(&serialized));
+  proto::orc::Footer parsed;
+  ASSERT_TRUE(parsed.ParseFromString(serialized));
+
+  const std::
+      unordered_map<uint32_t, std::vector<std::pair<std::string, std::string>>>
+          expected{
+              {1, {{"iceberg.id", "10"}}},
+              {2, {{"iceberg.id", "20"}}},
+              {4, {{"iceberg.id", "40"}}}};
+  EXPECT_EQ(ProtoUtils::readAttributes(FooterWrapper(&parsed)), expected);
+}
+
+TEST(ProtoUtilsTests, AttributesAbsentByDefault) {
+  // A type written without an attribute provider -- the existing path for every
+  // DWRF file today -- yields an empty attribute map.
+  HiveTypeParser parser;
+  auto schema = parser.parse("struct<a:int,b:bigint>");
+  proto::Footer footer;
+  auto footerWrapper = FooterWriteWrapper(&footer);
+  ProtoUtils::writeType(*schema, footerWrapper);
+
+  EXPECT_TRUE(ProtoUtils::readAttributes(FooterWrapper(&footer)).empty());
+}

--- a/velox/dwio/dwrf/writer/Writer.cpp
+++ b/velox/dwio/dwrf/writer/Writer.cpp
@@ -177,6 +177,7 @@ Writer::Writer(
       options.adjustTimestampToTimezone,
       std::move(handler),
       options.memoryBudget);
+  writerBase_->setSchemaAttributes(options.schemaAttributes);
   auto& context = writerBase_->getContext();
   VELOX_CHECK_EQ(
       context.getTotalMemoryUsage(),

--- a/velox/dwio/dwrf/writer/Writer.h
+++ b/velox/dwio/dwrf/writer/Writer.h
@@ -18,6 +18,10 @@
 
 #include <iterator>
 #include <limits>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include "velox/dwio/common/FileMetadata.h"
 #include "velox/dwio/common/Writer.h"
@@ -49,6 +53,13 @@ struct WriterOptions : public dwio::common::WriterOptions {
   const tz::TimeZone* sessionTimezone{nullptr};
   bool adjustTimestampToTimezone{false};
   DwrfFormat format{DwrfFormat::kDwrf};
+
+  /// Per-type string attributes (e.g. Iceberg "iceberg.id") keyed by pre-order
+  /// schema node id (the index into the footer's types(), matching
+  /// TypeWithId::id()). Stamped into the footer proto at write time. Empty by
+  /// default, which keeps the footer wire format byte-identical.
+  std::unordered_map<uint32_t, std::vector<std::pair<std::string, std::string>>>
+      schemaAttributes;
 
   void processConfigs(
       const config::ConfigBase& connectorConfig,

--- a/velox/dwio/dwrf/writer/WriterBase.cpp
+++ b/velox/dwio/dwrf/writer/WriterBase.cpp
@@ -36,7 +36,18 @@ void WriterBase::writeFooter(const Type& type) {
     pos = writerSink_->size();
   }
 
-  ProtoUtils::writeType(type, *footer_);
+  ProtoUtils::writeType(
+      type,
+      *footer_,
+      /*parent=*/nullptr,
+      [this](
+          uint32_t typeId) -> std::vector<std::pair<std::string, std::string>> {
+        auto it = schemaAttributes_.find(typeId);
+        if (it == schemaAttributes_.end()) {
+          return {};
+        }
+        return it->second;
+      });
   DWIO_ENSURE_EQ(footer_->typesSize(), footer_->statisticsSize());
   auto writerVersion =
       static_cast<uint32_t>(context_->getConfig(Config::WRITER_VERSION));

--- a/velox/dwio/dwrf/writer/WriterBase.h
+++ b/velox/dwio/dwrf/writer/WriterBase.h
@@ -16,6 +16,11 @@
 
 #pragma once
 
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
 #include "velox/common/base/GTestMacros.h"
 #include "velox/dwio/common/Arena.h"
 #include "velox/dwio/dwrf/writer/WriterContext.h"
@@ -70,6 +75,15 @@ class WriterBase {
 
   void addUserMetadata(const std::string& key, const std::string& value) {
     userMetadata_[key] = value;
+  }
+
+  /// Sets the per-type attributes (e.g. Iceberg "iceberg.id") to stamp into the
+  /// footer, keyed by pre-order schema node id. Empty by default.
+  void setSchemaAttributes(
+      std::unordered_map<
+          uint32_t,
+          std::vector<std::pair<std::string, std::string>>> schemaAttributes) {
+    schemaAttributes_ = std::move(schemaAttributes);
   }
 
   // protected:
@@ -181,6 +195,8 @@ class WriterBase {
   std::unique_ptr<FooterWriteWrapper> footer_;
   proto::orc::Metadata metadata_;
   std::unordered_map<std::string, std::string> userMetadata_;
+  std::unordered_map<uint32_t, std::vector<std::pair<std::string, std::string>>>
+      schemaAttributes_;
   std::unique_ptr<google::protobuf::Arena> arena_;
 
   friend class WriterTest;


### PR DESCRIPTION
Summary:

Consolidates the DWRF Iceberg V3 field-id work into a single velox diff:

- Round-trip per-type attributes through the DWRF/ORC footer proto:
  ProtoUtils::writeType takes an AttributeProvider; readAttributes() reads
  attributes via the format-agnostic FooterWrapper so both DWRF and ORC
  footers are handled.
- Stamp per-type "iceberg.id" attributes from the DWRF writer into the footer
  (WriterOptions::schemaAttributes -> WriterBase::writeFooter).
- Resolve DWRF/ORC columns by Iceberg field id on read
  (ColumnMappingMode::kFieldId, DwrfReader::updateColumnNamesFromFieldIds),
  enabling schema evolution (rename, reorder, drop, drop + re-add same name)
  without relying on column names or positions.
- Wire the IcebergDataSink writer and IcebergSplitReader reader to the field-id
  plumbing and add schema-evolution e2e tests.

Reviewed By: srsuryadev

Differential Revision: D107668179


