### PR TITLE
fix(test): Build the libraries DynamicLinkTest dlopens

### DIFF
--- a/velox/common/dynamic_registry/tests/CMakeLists.txt
+++ b/velox/common/dynamic_registry/tests/CMakeLists.txt
@@ -93,4 +93,20 @@ target_compile_definitions(
   PRIVATE VELOX_TEST_DYNAMIC_LIBRARY_PATH_SUFFIX="${CMAKE_SHARED_LIBRARY_SUFFIX}"
 )
 
+# The test loads these libraries at runtime via dlopen(), so there is no
+# link-time edge for CMake to follow. Declare them as explicit build
+# dependencies so any build that targets only the test (e.g. CI selective
+# builds) still produces the .so files; otherwise the test fails at runtime
+# with "cannot open shared object file".
+add_dependencies(
+  velox_function_dynamic_link_test
+  velox_function_dynamic
+  velox_overwrite_int_function_dynamic
+  velox_overwrite_varchar_function_dynamic
+  velox_function_err_dynamic
+  velox_overload_int_function_dynamic
+  velox_overload_varchar_function_dynamic
+  velox_function_non_default_dynamic
+)
+
 add_test(NAME velox_function_dynamic_link_test COMMAND velox_function_dynamic_link_test)


### PR DESCRIPTION
## Summary

`DynamicLinkTest` loads its helper functions from sibling `.so` libraries via `dlopen` at runtime. Nothing links them, so CMake had no build dependency from the test to those libraries. A build that compiles only the test target — like the CI selective build — never built the `.so` files, so all six tests failed with `cannot open shared object file`. `add_dependencies()` declares the libraries as build dependencies of the test so they are built alongside it.

Surfaced by the selective build on #17814 and few other PRs; the gap itself is general.

## Test plan

Deleted the prebuilt `.so` files, built only `velox_function_dynamic_link_test`, and confirmed the libraries rebuild and the test passes.
