### PR TITLE
fix(geo): Gate GooglePolyline on VELOX_ENABLE_GEO

### DIFF
--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -46,7 +46,6 @@ velox_add_library(
   FilterFunctions.cpp
   FindFirst.cpp
   FromUtf8.cpp
-  GooglePolylineFunctions.cpp
   InPredicate.cpp
   JsonFunctions.cpp
   Map.cpp
@@ -170,6 +169,8 @@ endif()
 
 if(VELOX_ENABLE_GEO)
   add_subdirectory(geospatial)
+
+  velox_sources(velox_functions_prestosql_impl PRIVATE GooglePolylineFunctions.cpp)
 
   # S2 cell operations are isolated in a separate library to prevent a
   # nallocx symbol conflict between s2geometry's malloc_extension.h and


### PR DESCRIPTION
Summary:
[[Nimble build break](https://github.com/facebookincubator/nimble/actions/runs/27595278029/job/81584210938?pr=876)]


When the google_polyline functions were added D107672113, GooglePolylineFunctions.cpp was placed in the unconditional source list of velox_functions_prestosql_impl, but its header pulls in GEOS, which is only fetched and added to the include path when VELOX_ENABLE_GEO is on. The test sources and the function registration were correctly gated behind VELOX_ENABLE_GEO, but the production compile unit was left in the unconditional list. Move it into the existing if(VELOX_ENABLE_GEO) block, using velox_sources so it routes correctly in mono-library builds, so a GEO=OFF build no longer compiles it.

Reviewed By: xiaoxmeng

Differential Revision: D108714293


