### PR TITLE
fix(build): Fix Arrow patch application and uv install permissions

### DIFF
--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -236,16 +236,11 @@ function install_arrow {
 
     cd "$DEPENDENCY_DIR"/arrow || exit 1
     for patch in $VELOX_ARROW_CMAKE_PATCH; do
-      # Try patch command first (handles line number offsets), fall back to git apply
-      if command -v patch >/dev/null 2>&1; then
-        patch -p1 -i "$patch" || exit 1
-      else
-        git apply "$patch" || exit 1
-      fi
+      apply_patch "$patch"
     done
     # Presto needs this for Arrow Flight
     if [[ -n $EXTRA_ARROW_PATCH ]]; then
-      git apply "$EXTRA_ARROW_PATCH" || exit 1
+      apply_patch "$EXTRA_ARROW_PATCH"
     fi
   ) || exit 1
 
@@ -432,13 +427,13 @@ function install_uv {
     export UV_TOOL_BIN_DIR="${UV_TOOL_BIN_DIR:-$INSTALL_PREFIX/bin}"
     export UV_INSTALL_DIR=${UV_INSTALL_DIR:-"$UV_TOOL_BIN_DIR"}
 
-    curl -LsSf https://astral.sh/uv/install.sh | sh
+    curl -LsSf https://astral.sh/uv/install.sh | sudo --preserve-env sh
     uv tool update-shell
   fi
 }
 
 function uv_install {
-  uv tool install "$@" || {
+  sudo --preserve-env uv tool install "$@" || {
     ret=$?
     # exit code 2 means the binary already exists, so we can ignore that
     [ "$ret" -eq 2 ] || exit "$ret"

--- a/scripts/setup-helper-functions.sh
+++ b/scripts/setup-helper-functions.sh
@@ -213,6 +213,23 @@ if [[ ${BASH_SOURCE[0]} == "${0}" && $1 == "detect_sve_flags" ]]; then
   detect_sve_flags
 fi
 
+# Applies a patch with `patch -p1`, since the dependency directories are
+# extracted from tarballs rather than git checkouts and `git apply` silently
+# no-ops when run outside of a git working tree. Falls back to `git apply` if
+# `patch` isn't installed. Skips patches whose hunks are already present in
+# the source (e.g. already merged upstream in the dependency's release)
+# instead of failing.
+function apply_patch {
+  local PATCH_FILE=$1
+  if command -v patch >/dev/null 2>&1; then
+    if ! patch -p1 -R --dry-run --silent --force <"${PATCH_FILE}" 2>/dev/null; then
+      patch -p1 <"${PATCH_FILE}" || exit 1
+    fi
+  else
+    git apply "${PATCH_FILE}" || exit 1
+  fi
+}
+
 function wget_and_untar {
   local URL=$1
   local DIR=$2


### PR DESCRIPTION
fix(build): Fix Arrow patch application and uv install permissions

Running `scripts/setup-ubuntu.sh install_arrow` on a fresh checkout fails immediately with exit code 1, before Arrow is configured or built. `cmake-compatibility.patch`'s hunks are already part of Arrow 18.0.0's source, so `patch -p1 -i` reports:

    Reversed (or previously applied) patch detected!  Assume -R? [n]
    Apply anyway? [n]
    Skipping patch.
    2 out of 2 hunks ignored -- saving rejects to file cpp/cmake_modules/ThirdpartyToolchain.cmake.rej

and exits non-zero instead of treating the already-applied hunks as a no-op.

Add an `apply_patch` helper to `setup-helper-functions.sh` that checks with `patch -p1 -R --dry-run` whether a patch is already applied and skips it if so, applying with `patch -p1` otherwise; it falls back to `git apply` only if `patch` isn't installed. Both the `VELOX_ARROW_CMAKE_PATCH` loop and `EXTRA_ARROW_PATCH` now use this helper. `EXTRA_ARROW_PATCH` previously called `git apply` directly, which silently does nothing when run against the Arrow source: that directory is extracted from a tarball rather than a git checkout, so `git apply` walks up to Velox's own `.git`, finds no matching paths there, and reports success without changing anything.

Separately, `install_uv` and `uv_install` install `uv` and `cmake` into `UV_INSTALL_DIR`/`UV_TOOL_BIN_DIR`, which default to `INSTALL_PREFIX/bin` (e.g. `/usr/local/bin`), but run the installer and `uv tool install` as the invoking user. On a host where that directory isn't user-writable, both fail with `Permission denied`. Both now run under `sudo --preserve-env` so they keep the environment variables pointing `uv` at the right install directory while gaining permission to write there.

Test plan: The `sudo --preserve-env` fix for `install_uv`/`uv_install` was verified end-to-end by running `setup-ubuntu.sh`, which installed `uv` and `cmake==3.30.4` into `/usr/local/bin` successfully. `apply_patch` was verified to skip both Arrow patches when run against an already-patched Arrow 18.0.0 checkout (exit 0, no changes), and to apply `arrow-testing-boost.patch` cleanly against an unpatched checkout, correctly replacing `Boost::process` with `Boost::filesystem Boost::system` in `cpp/src/arrow/CMakeLists.txt`. The full Arrow CMake configure/build was not re-run in this session.
