### PR TITLE
test(rpc): Add DemoBatchRPCFunction for batch-mode operator testing (#17854)

### DIFF
--- a/velox/exec/rpc/CMakeLists.txt
+++ b/velox/exec/rpc/CMakeLists.txt
@@ -64,5 +64,18 @@ if(${VELOX_BUILD_TESTING})
     velox_async_rpc_function
   )
 
+  velox_add_library(
+    velox_demo_batch_rpc_function
+    tests/DemoBatchRPCFunction.cpp
+    HEADERS
+    tests/DemoBatchRPCFunction.h
+  )
+
+  velox_link_libraries(
+    velox_demo_batch_rpc_function
+    velox_expression_functions
+    velox_async_rpc_function
+  )
+
   add_subdirectory(tests)
 endif()

--- a/velox/exec/rpc/tests/DemoBatchRPCFunction.cpp
+++ b/velox/exec/rpc/tests/DemoBatchRPCFunction.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/rpc/tests/DemoBatchRPCFunction.h"
+
+#include <algorithm>
+
+namespace facebook::velox::exec::rpc {
+
+DemoBatchRPCFunction::DemoBatchRPCFunction(
+    ResponseOrder order,
+    std::unordered_set<int32_t> failingRowIndices)
+    : responseOrder_(order), failingRowIndices_(std::move(failingRowIndices)) {}
+
+void DemoBatchRPCFunction::initialize(
+    const core::QueryConfig& /*queryConfig*/,
+    const std::vector<TypePtr>& /*inputTypes*/,
+    const std::vector<VectorPtr>& /*constantInputs*/) {}
+
+std::vector<std::pair<vector_size_t, folly::SemiFuture<RPCResponse>>>
+DemoBatchRPCFunction::dispatchPerRow(
+    const SelectivityVector& /*rows*/,
+    const std::vector<VectorPtr>& /*args*/) {
+  VELOX_UNSUPPORTED(
+      "DemoBatchRPCFunction is batch-only; use accumulateBatch/flushBatch");
+}
+
+std::vector<vector_size_t> DemoBatchRPCFunction::accumulateBatch(
+    const SelectivityVector& rows,
+    const std::vector<VectorPtr>& args) {
+  std::vector<vector_size_t> indices;
+
+  if (args.empty()) {
+    return indices;
+  }
+
+  auto* promptVector = args[0]->as<SimpleVector<StringView>>();
+  if (!promptVector) {
+    return indices;
+  }
+
+  rows.applyToSelected([&](vector_size_t row) {
+    indices.push_back(row);
+    if (promptVector->isNullAt(row)) {
+      pendingRows_.push_back({.prompt = "", .isNull = true});
+    } else {
+      pendingRows_.push_back(
+          {.prompt = promptVector->valueAt(row).str(), .isNull = false});
+    }
+  });
+
+  totalAccumulatedCount_ += static_cast<int32_t>(indices.size());
+  return indices;
+}
+
+folly::SemiFuture<std::vector<RPCResponse>> DemoBatchRPCFunction::flushBatch(
+    int32_t maxRows) {
+  auto flushCount = maxRows > 0
+      ? std::min(static_cast<int32_t>(pendingRows_.size()), maxRows)
+      : static_cast<int32_t>(pendingRows_.size());
+
+  std::vector<PendingRow> toFlush(
+      pendingRows_.begin(), pendingRows_.begin() + flushCount);
+  pendingRows_.erase(pendingRows_.begin(), pendingRows_.begin() + flushCount);
+
+  std::vector<RPCResponse> responses;
+  responses.reserve(toFlush.size());
+
+  // The index within this flush determines the "global accumulated index"
+  // used to check failingRowIndices_. We use totalAccumulatedCount_ minus
+  // the remaining pending rows to compute the starting offset.
+  auto startOffset = totalAccumulatedCount_ -
+      static_cast<int32_t>(pendingRows_.size()) - flushCount;
+
+  for (int32_t i = 0; i < flushCount; ++i) {
+    RPCResponse response;
+    response.rowId = i;
+
+    if (toFlush[i].isNull) {
+      response.error = "null_input";
+    } else if (failingRowIndices_.count(startOffset + i)) {
+      response.error = "simulated_failure";
+    } else {
+      response.result = "Batch response for: " + toFlush[i].prompt;
+    }
+    responses.push_back(std::move(response));
+  }
+
+  if (responseOrder_ == ResponseOrder::kReversed) {
+    std::reverse(responses.begin(), responses.end());
+  }
+
+  return folly::makeSemiFuture(std::move(responses));
+}
+
+int32_t DemoBatchRPCFunction::pendingBatchSize() const {
+  return static_cast<int32_t>(pendingRows_.size());
+}
+
+std::vector<std::shared_ptr<exec::FunctionSignature>>
+DemoBatchRPCFunction::signatures() {
+  auto sig = exec::FunctionSignatureBuilder()
+                 .returnType("varchar")
+                 .argumentType("varchar")
+                 .build();
+  return {std::move(sig)};
+}
+
+} // namespace facebook::velox::exec::rpc

--- a/velox/exec/rpc/tests/DemoBatchRPCFunction.h
+++ b/velox/exec/rpc/tests/DemoBatchRPCFunction.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <unordered_set>
+
+#include "velox/expression/FunctionSignature.h"
+#include "velox/expression/rpc/AsyncRPCFunction.h"
+
+namespace facebook::velox::exec::rpc {
+
+/// Batch-capable AsyncRPCFunction for testing RPCOperator's BATCH mode.
+///
+/// Supports configurable response behaviors to exercise correctness
+/// edge cases in the batch dispatch pipeline:
+///   - In-order responses (default, happy path)
+///   - Reversed responses (simulates backend returning out of order)
+///   - Per-row failures (simulates partial batch failure)
+///
+/// Returns "Batch response for: <prompt>" for each non-null, non-failing row.
+/// Null inputs produce RPCResponse{.error = "null_input"}.
+/// Failing rows produce RPCResponse{.error = "simulated_failure"}.
+class DemoBatchRPCFunction : public AsyncRPCFunction {
+ public:
+  enum class ResponseOrder {
+    kInOrder,
+    kReversed,
+  };
+
+  explicit DemoBatchRPCFunction(
+      ResponseOrder order = ResponseOrder::kInOrder,
+      std::unordered_set<int32_t> failingRowIndices = {});
+
+  void initialize(
+      const core::QueryConfig& queryConfig,
+      const std::vector<TypePtr>& inputTypes,
+      const std::vector<VectorPtr>& constantInputs) override;
+
+  std::string name() const override {
+    return "demo_batch_rpc";
+  }
+
+  TypePtr resultType() const override {
+    return VARCHAR();
+  }
+
+  std::vector<std::pair<vector_size_t, folly::SemiFuture<RPCResponse>>>
+  dispatchPerRow(
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args) override;
+
+  std::vector<vector_size_t> accumulateBatch(
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args) override;
+
+  folly::SemiFuture<std::vector<RPCResponse>> flushBatch(
+      int32_t maxRows) override;
+
+  int32_t pendingBatchSize() const override;
+
+  static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures();
+
+ private:
+  struct PendingRow {
+    std::string prompt;
+    bool isNull;
+  };
+
+  std::vector<PendingRow> pendingRows_;
+  ResponseOrder responseOrder_;
+  std::unordered_set<int32_t> failingRowIndices_;
+  int32_t totalAccumulatedCount_{0};
+};
+
+} // namespace facebook::velox::exec::rpc


### PR DESCRIPTION
Summary:

The RPCOperator's BATCH mode path had zero end-to-end test coverage — the existing DemoAsyncRPCFunction only implements dispatchPerRow(), so all RPCOperatorTest cases exercised PER_ROW mode exclusively.

DemoBatchRPCFunction is a batch-capable AsyncRPCFunction mock that enables testing the batch dispatch pipeline with configurable response behaviors: in-order, reversed (simulates out-of-order backend), per-row failures, and null input handling. Returns `"Batch response for: <prompt>"` for each non-null, non-failing row. No external dependencies — runs entirely in-process.

Reviewed By: xiaoxmeng

Differential Revision: D108340979


