### PR TITLE
Optimize MAP_UNION_SUM hot loop: decode-once + single-probe

### DIFF
--- a/velox/functions/prestosql/aggregates/MapUnionSumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapUnionSumAggregate.cpp
@@ -39,59 +39,72 @@ struct Accumulator {
     return sums.size();
   }
 
+  // Adds all entries of a single input map to the running sums. The map's keys
+  // and values are decoded once per batch by the caller; 'offset' and 'size'
+  // delimit this map's entries within the decoded child vectors.
   void addValues(
-      const MapVector* mapVector,
-      const VectorPtr& mapKeys,
-      const VectorPtr& mapValues,
-      vector_size_t row,
-      HashStringAllocator* allocator) {
-    auto keys = mapKeys->template as<SimpleVector<K>>();
-    auto values = mapValues->template as<SimpleVector<S>>();
-    auto offset = mapVector->offsetAt(row);
-    auto size = mapVector->sizeAt(row);
+      const DecodedVector& decodedKeys,
+      const DecodedVector& decodedValues,
+      vector_size_t offset,
+      vector_size_t size,
+      HashStringAllocator* /*allocator*/) {
+    if (!decodedValues.mayHaveNulls()) {
+      // Null-free fast path: every value is present, so no null branch and no
+      // +0 registration is needed in the inner loop.
+      for (auto i = offset; i < offset + size; ++i) {
+        if (decodedKeys.isNullAt(i)) {
+          continue;
+        }
+        addValue(decodedKeys.valueAt<K>(i), decodedValues.valueAt<S>(i));
+      }
+      return;
+    }
 
-    for (auto i = 0; i < size; ++i) {
+    for (auto i = offset; i < offset + size; ++i) {
       // Ignore null map keys.
-      if (!keys->isNullAt(offset + i)) {
-        auto key = keys->valueAt(offset + i);
-        addValue(key, values, offset + i, values->typeKind());
+      if (decodedKeys.isNullAt(i)) {
+        continue;
+      }
+      auto key = decodedKeys.valueAt<K>(i);
+      if (decodedValues.isNullAt(i)) {
+        // A null value still registers the key with +0.
+        sums.try_emplace(key, S{0});
+      } else {
+        addValue(key, decodedValues.valueAt<S>(i));
       }
     }
   }
 
-  void addValue(
-      K key,
-      const SimpleVector<S>* mapValues,
-      vector_size_t row,
-      TypeKind valueKind) {
-    if (mapValues->isNullAt(row)) {
-      sums[key] += 0;
+  // Adds 'value' to the running sum for 'key', inserting the key if absent.
+  // Probes the F14 map exactly once and updates the sum in place.
+  void addValue(K key, S value) {
+    auto [it, inserted] = sums.try_emplace(key, S{0});
+
+    if constexpr (std::is_same_v<S, double> || std::is_same_v<S, float>) {
+      it->second += value;
     } else {
-      auto value = mapValues->valueAt(row);
+      // Add into a local so an overflow throw leaves the existing accumulator
+      // entry unchanged; only commit the result when no overflow occurred.
+      const S previousSum = it->second;
+      S checkedSum;
+      auto overflow = __builtin_add_overflow(previousSum, value, &checkedSum);
 
-      if constexpr (std::is_same_v<S, double> || std::is_same_v<S, float>) {
-        sums[key] += value;
-      } else {
-        S checkedSum;
-        auto overflow = __builtin_add_overflow(sums[key], value, &checkedSum);
+      if (UNLIKELY(overflow)) {
+        auto errorValue = (int128_t(previousSum) + int128_t(value));
 
-        if (UNLIKELY(overflow)) {
-          auto errorValue = (int128_t(sums[key]) + int128_t(value));
-
-          if (errorValue < 0) {
-            VELOX_ARITHMETIC_ERROR(
-                "Arithmetic overflow in MAP_UNION_SUM: Value {} is less than {}",
-                errorValue,
-                std::numeric_limits<S>::min());
-          } else {
-            VELOX_ARITHMETIC_ERROR(
-                "Arithmetic overflow in MAP_UNION_SUM: Value {} exceeds {}",
-                errorValue,
-                std::numeric_limits<S>::max());
-          }
+        if (errorValue < 0) {
+          VELOX_ARITHMETIC_ERROR(
+              "Arithmetic overflow in MAP_UNION_SUM: Value {} is less than {}",
+              errorValue,
+              std::numeric_limits<S>::min());
+        } else {
+          VELOX_ARITHMETIC_ERROR(
+              "Arithmetic overflow in MAP_UNION_SUM: Value {} exceeds {}",
+              errorValue,
+              std::numeric_limits<S>::max());
         }
-        sums[key] = checkedSum;
       }
+      it->second = checkedSum;
     }
   }
 
@@ -130,31 +143,33 @@ struct StringViewAccumulator {
   }
 
   void addValues(
-      const MapVector* mapVector,
-      const VectorPtr& mapKeys,
-      const VectorPtr& mapValues,
-      vector_size_t row,
+      const DecodedVector& decodedKeys,
+      const DecodedVector& decodedValues,
+      vector_size_t offset,
+      vector_size_t size,
       HashStringAllocator* allocator) {
-    auto keys = mapKeys->template as<SimpleVector<StringView>>();
-    auto values = mapValues->template as<SimpleVector<S>>();
-    auto offset = mapVector->offsetAt(row);
-    auto size = mapVector->sizeAt(row);
-
-    for (auto i = 0; i < size; ++i) {
+    const bool valuesMayHaveNulls = decodedValues.mayHaveNulls();
+    for (auto i = offset; i < offset + size; ++i) {
       // Ignore null map keys.
-      if (!keys->isNullAt(offset + i)) {
-        auto key = keys->valueAt(offset + i);
+      if (decodedKeys.isNullAt(i)) {
+        continue;
+      }
+      auto key = decodedKeys.valueAt<StringView>(i);
 
-        if (!key.isInline()) {
-          auto it = base.sums.find(key);
-          if (it != base.sums.end()) {
-            key = it->first;
-          } else {
-            key = strings.append(key, *allocator);
-          }
+      if (!key.isInline()) {
+        auto it = base.sums.find(key);
+        if (it != base.sums.end()) {
+          key = it->first;
+        } else {
+          key = strings.append(key, *allocator);
         }
+      }
 
-        base.addValue(key, values, offset + i, values->typeKind());
+      if (valuesMayHaveNulls && decodedValues.isNullAt(i)) {
+        // A null value still registers the key with +0.
+        base.sums.try_emplace(key, S{0});
+      } else {
+        base.addValue(key, decodedValues.valueAt<S>(i));
       }
     }
   }
@@ -195,54 +210,60 @@ struct ComplexTypeAccumulator {
                 16>(allocator)} {}
 
   void addValues(
-      const MapVector* mapVector,
-      const VectorPtr& mapKeys,
-      const VectorPtr& mapValues,
-      vector_size_t row,
+      const DecodedVector& decodedKeys,
+      const DecodedVector& decodedValues,
+      vector_size_t offset,
+      vector_size_t size,
       HashStringAllocator* allocator) {
-    auto offset = mapVector->offsetAt(row);
-    auto size = mapVector->sizeAt(row);
-    auto values = mapValues->template as<SimpleVector<V>>();
+    const bool valuesMayHaveNulls = decodedValues.mayHaveNulls();
+    for (auto i = offset; i < offset + size; ++i) {
+      if (decodedKeys.isNullAt(i)) {
+        continue;
+      }
+      // Get entry and value to add.
+      auto entry = serializedKeys.append(decodedKeys, i, allocator);
+      auto value = (valuesMayHaveNulls && decodedValues.isNullAt(i))
+          ? V{0}
+          : decodedValues.valueAt<V>(i);
 
-    for (auto i = 0; i < size; ++i) {
-      if (!mapKeys->isNullAt(offset + i) && (offset + i) < mapKeys->size()) {
-        // Get entry and value to add.
-        auto entry =
-            serializedKeys.append(*mapKeys.get(), offset + i, allocator);
-        auto value =
-            (values->isNullAt(offset + i)) ? 0 : values->valueAt(offset + i);
+      auto [it, inserted] = sums.try_emplace(entry, V{0});
 
-        // New entry.
-        if (!sums.contains(entry)) {
-          sums[entry] = value;
-        } else {
-          // Existing entry.
-          if constexpr (std::is_same_v<V, double> || std::is_same_v<V, float>) {
-            sums[entry] += value;
+      // New entry: keep the serialized key and set the value.
+      if (inserted) {
+        it->second = value;
+        continue;
+      }
+
+      // Existing entry: the freshly serialized key is a duplicate and must be
+      // released after combining with the existing sum.
+      if constexpr (std::is_same_v<V, double> || std::is_same_v<V, float>) {
+        it->second += value;
+        serializedKeys.removeLast(entry);
+      } else {
+        // Add into a local so an overflow throw leaves the existing
+        // accumulator entry unchanged. Release the duplicate serialized key
+        // before any potential throw so it is not orphaned in the arena.
+        const V previousSum = it->second;
+        V checkedSum;
+        auto overflow = __builtin_add_overflow(previousSum, value, &checkedSum);
+        serializedKeys.removeLast(entry);
+
+        if (UNLIKELY(overflow)) {
+          auto errorValue = (int128_t(previousSum) + int128_t(value));
+
+          if (errorValue < 0) {
+            VELOX_ARITHMETIC_ERROR(
+                "Arithmetic overflow in MAP_UNION_SUM: Value {} is less than {}",
+                errorValue,
+                std::numeric_limits<V>::min());
           } else {
-            V checkedSum;
-            auto overflow =
-                __builtin_add_overflow(sums[entry], value, &checkedSum);
-
-            if (UNLIKELY(overflow)) {
-              auto errorValue = (int128_t(sums[entry]) + int128_t(value));
-
-              if (errorValue < 0) {
-                VELOX_ARITHMETIC_ERROR(
-                    "Arithmetic overflow in MAP_UNION_SUM: Value {} is less than {}",
-                    errorValue,
-                    std::numeric_limits<V>::min());
-              } else {
-                VELOX_ARITHMETIC_ERROR(
-                    "Arithmetic overflow in MAP_UNION_SUM: Value {} exceeds {}",
-                    errorValue,
-                    std::numeric_limits<V>::max());
-              }
-            }
-            sums[entry] = checkedSum;
-            serializedKeys.removeLast(entry);
+            VELOX_ARITHMETIC_ERROR(
+                "Arithmetic overflow in MAP_UNION_SUM: Value {} exceeds {}",
+                errorValue,
+                std::numeric_limits<V>::max());
           }
         }
+        it->second = checkedSum;
       }
     }
   }
@@ -360,8 +381,11 @@ class MapUnionSumAggregate : public exec::Aggregate {
       bool /*mayPushdown*/) override {
     decodedMaps_.decode(*args[0], rows);
     auto mapVector = decodedMaps_.base()->template as<MapVector>();
-    auto mapKeys = mapVector->mapKeys();
-    auto mapValues = mapVector->mapValues();
+
+    // Decode the key and value child vectors once per batch so the per-element
+    // inner loop reads from decoded raw data instead of re-casting per row.
+    decodedKeys_.decode(*mapVector->mapKeys());
+    decodedValues_.decode(*mapVector->mapValues());
 
     rows.applyToSelected([&](auto row) {
       if (!decodedMaps_.isNullAt(row)) {
@@ -370,7 +394,7 @@ class MapUnionSumAggregate : public exec::Aggregate {
 
         auto tracker = trackRowSize(group);
         auto groupMap = value<AccumulatorType>(group);
-        addMap(*groupMap, mapVector, mapKeys, mapValues, row);
+        addMap(*groupMap, mapVector, row);
       }
     });
   }
@@ -382,8 +406,11 @@ class MapUnionSumAggregate : public exec::Aggregate {
       bool /* mayPushdown */) override {
     decodedMaps_.decode(*args[0], rows);
     auto mapVector = decodedMaps_.base()->template as<MapVector>();
-    auto mapKeys = mapVector->mapKeys();
-    auto mapValues = mapVector->mapValues();
+
+    // Decode the key and value child vectors once per batch so the per-element
+    // inner loop reads from decoded raw data instead of re-casting per row.
+    decodedKeys_.decode(*mapVector->mapKeys());
+    decodedValues_.decode(*mapVector->mapValues());
 
     auto groupMap = value<AccumulatorType>(group);
 
@@ -391,7 +418,7 @@ class MapUnionSumAggregate : public exec::Aggregate {
     rows.applyToSelected([&](auto row) {
       if (!decodedMaps_.isNullAt(row)) {
         clearNull(group);
-        addMap(*groupMap, mapVector, mapKeys, mapValues, row);
+        addMap(*groupMap, mapVector, row);
       }
     });
   }
@@ -443,11 +470,11 @@ class MapUnionSumAggregate : public exec::Aggregate {
   void addMap(
       AccumulatorType& groupMap,
       const MapVector* mapVector,
-      const VectorPtr& mapKeys,
-      const VectorPtr& mapValues,
       vector_size_t row) const {
     auto decodedRow = decodedMaps_.index(row);
-    groupMap.addValues(mapVector, mapKeys, mapValues, decodedRow, allocator_);
+    auto offset = mapVector->offsetAt(decodedRow);
+    auto size = mapVector->sizeAt(decodedRow);
+    groupMap.addValues(decodedKeys_, decodedValues_, offset, size, allocator_);
   }
 
   vector_size_t countElements(char** groups, int32_t numGroups) const {
@@ -459,6 +486,8 @@ class MapUnionSumAggregate : public exec::Aggregate {
   }
 
   DecodedVector decodedMaps_;
+  DecodedVector decodedKeys_;
+  DecodedVector decodedValues_;
 };
 
 template <typename K>

--- a/velox/functions/prestosql/aggregates/benchmarks/MapUnionSum.cpp
+++ b/velox/functions/prestosql/aggregates/benchmarks/MapUnionSum.cpp
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <fmt/format.h>
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include <string>
+
+#include "velox/exec/Cursor.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec::test;
+
+namespace {
+
+// Emulates the "deltoid" workload: many small integer-keyed maps with ~5-20
+// keys each, aggregated with map_union_sum both globally and grouped.
+static constexpr int32_t kNumVectors = 100;
+static constexpr int32_t kRowsPerVector = 10'000;
+
+// Number of distinct map keys drawn per row. Keys come from a small universe so
+// that the accumulator map stays compact and repeatedly hits existing keys.
+static constexpr int32_t kKeysPerMap = 10;
+static constexpr int32_t kKeyUniverse = 64;
+
+// Number of distinct group-by keys for the grouped benchmark.
+static constexpr int32_t kNumGroups = 1'000;
+
+class MapUnionSumBenchmark : public HiveConnectorTestBase {
+ public:
+  MapUnionSumBenchmark() {
+    HiveConnectorTestBase::SetUp();
+
+    inputType_ = ROW({
+        {"g", INTEGER()},
+        {"m_i64", MAP(INTEGER(), BIGINT())},
+        {"m_i64_nulls", MAP(INTEGER(), BIGINT())},
+        {"m_f64", MAP(INTEGER(), DOUBLE())},
+    });
+
+    std::vector<RowVectorPtr> vectors;
+    for (auto vectorIndex = 0; vectorIndex < kNumVectors; ++vectorIndex) {
+      const auto base = vectorIndex * kRowsPerVector;
+
+      auto groupKeys = makeFlatVector<int32_t>(
+          kRowsPerVector, [](auto row) { return row % kNumGroups; });
+
+      auto sizeAt = [](vector_size_t /*row*/) { return kKeysPerMap; };
+      // Spread the key window across rows so different rows touch overlapping
+      // but not identical key ranges, exercising both insert and update paths.
+      auto keyAt = [base](vector_size_t index) {
+        const auto row = index / kKeysPerMap;
+        const auto offset = index % kKeysPerMap;
+        return static_cast<int32_t>(((base + row) + offset) % kKeyUniverse);
+      };
+      auto int64ValueAt = [](vector_size_t index) {
+        return static_cast<int64_t>(index % 7);
+      };
+      auto doubleValueAt = [](vector_size_t index) {
+        return static_cast<double>(index % 7);
+      };
+      // Every 4th value is null to exercise the null-value (+0) path.
+      auto valueIsNullAt = [](vector_size_t index) { return index % 4 == 0; };
+
+      auto mapI64 = makeMapVector<int32_t, int64_t>(
+          kRowsPerVector, sizeAt, keyAt, int64ValueAt);
+      auto mapI64Nulls = makeMapVector<int32_t, int64_t>(
+          kRowsPerVector, sizeAt, keyAt, int64ValueAt, nullptr, valueIsNullAt);
+      auto mapF64 = makeMapVector<int32_t, double>(
+          kRowsPerVector, sizeAt, keyAt, doubleValueAt);
+
+      vectors.emplace_back(makeRowVector(
+          inputType_->names(), {groupKeys, mapI64, mapI64Nulls, mapF64}));
+    }
+
+    filePath_ = TempFilePath::create();
+    writeToFile(filePath_->getPath(), vectors);
+  }
+
+  ~MapUnionSumBenchmark() override {
+    HiveConnectorTestBase::TearDown();
+  }
+
+  MapUnionSumBenchmark(const MapUnionSumBenchmark&) = delete;
+  MapUnionSumBenchmark& operator=(const MapUnionSumBenchmark&) = delete;
+  MapUnionSumBenchmark(MapUnionSumBenchmark&&) = delete;
+  MapUnionSumBenchmark& operator=(MapUnionSumBenchmark&&) = delete;
+
+  void TestBody() override {}
+
+  void run(const std::vector<std::string>& keys, const std::string& aggregate) {
+    folly::BenchmarkSuspender suspender;
+
+    auto plan = PlanBuilder()
+                    .tableScan(inputType_)
+                    .partialAggregation(keys, {aggregate})
+                    .finalAggregation()
+                    .planFragment();
+
+    vector_size_t numResultRows = 0;
+    auto task = makeTask(plan);
+
+    task->addSplit(
+        "0", exec::Split(makeHiveConnectorSplit(filePath_->getPath())));
+    task->noMoreSplits("0");
+
+    suspender.dismiss();
+
+    while (auto result = task->next()) {
+      numResultRows += result->size();
+    }
+
+    folly::doNotOptimizeAway(numResultRows);
+  }
+
+  std::shared_ptr<exec::Task> makeTask(core::PlanFragment plan) {
+    return exec::Task::create(
+        "t",
+        std::move(plan),
+        0,
+        core::QueryCtx::create(executor_.get()),
+        exec::Task::ExecutionMode::kSerial,
+        exec::Consumer{});
+  }
+
+ private:
+  RowTypePtr inputType_;
+  std::shared_ptr<TempFilePath> filePath_;
+};
+
+// NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
+std::unique_ptr<MapUnionSumBenchmark> benchmark;
+
+void doRunGlobal(uint32_t, const std::string& aggregate) {
+  benchmark->run({}, aggregate);
+}
+
+void doRunGrouped(uint32_t, const std::string& aggregate) {
+  benchmark->run({"g"}, aggregate);
+}
+
+// Global (no group-by) map_union_sum.
+BENCHMARK_NAMED_PARAM(doRunGlobal, global_i64, "map_union_sum(m_i64)");
+BENCHMARK_NAMED_PARAM(
+    doRunGlobal,
+    global_i64_nulls,
+    "map_union_sum(m_i64_nulls)");
+BENCHMARK_NAMED_PARAM(doRunGlobal, global_f64, "map_union_sum(m_f64)");
+BENCHMARK_DRAW_LINE();
+
+// Grouped map_union_sum.
+BENCHMARK_NAMED_PARAM(doRunGrouped, grouped_i64, "map_union_sum(m_i64)");
+BENCHMARK_NAMED_PARAM(
+    doRunGrouped,
+    grouped_i64_nulls,
+    "map_union_sum(m_i64_nulls)");
+BENCHMARK_NAMED_PARAM(doRunGrouped, grouped_f64, "map_union_sum(m_f64)");
+BENCHMARK_DRAW_LINE();
+
+} // namespace
+
+int main(int argc, char** argv) {
+  folly::Init init{&argc, &argv};
+  OperatorTestBase::SetUpTestCase();
+  benchmark = std::make_unique<MapUnionSumBenchmark>();
+  folly::runBenchmarks();
+  benchmark.reset();
+  OperatorTestBase::TearDownTestCase();
+  return 0;
+}

--- a/velox/functions/prestosql/aggregates/tests/MapUnionSumTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MapUnionSumTest.cpp
@@ -58,8 +58,9 @@ TEST_F(MapUnionSumTest, globalVarcharKey) {
       "Expansive vistas",
   };
   std::vector<StringView> keys;
+  keys.reserve(keyStrings.size());
   for (const auto& key : keyStrings) {
-    keys.push_back(StringView(key));
+    keys.emplace_back(key);
   }
 
   auto data = makeRowVector({
@@ -129,6 +130,110 @@ TEST_F(MapUnionSumTest, nullAndEmptyMaps) {
 
   testAggregations(
       {emptyAndNullMaps}, {}, {"map_union_sum(c0)"}, {expectedEmpty});
+}
+
+TEST_F(MapUnionSumTest, nullValuesInMap) {
+  // Exercises the slow (mayHaveNulls) merge path where null map values still
+  // register their key with a +0 contribution. Key 1 sums 5 (null + 5),
+  // key 2 stays 20, and key 3 is registered with 0 from its null value.
+  auto data = makeRowVector({
+      makeNullableMapVector<int64_t, int64_t>({
+          {{{1, std::nullopt}, {2, 20}}},
+          {{{1, 5}, {3, std::nullopt}}},
+      }),
+  });
+
+  auto expected = makeRowVector({
+      makeMapVector<int64_t, int64_t>({
+          {{1, 5}, {2, 20}, {3, 0}},
+      }),
+  });
+
+  testAggregations({data}, {}, {"map_union_sum(c0)"}, {expected});
+}
+
+TEST_F(MapUnionSumTest, nullValuesInVarcharKeyMap) {
+  // Exercises the StringView-key accumulator's null-value branch, where a null
+  // map value still registers its key with a +0 contribution. Uses non-inline
+  // (long) keys so the string-interning path is also covered. Key 0 sums 5
+  // (null + 5), key 1 stays 20, and key 2 is registered with 0 from its null
+  // value.
+  std::vector<std::string> keyStrings = {
+      "Tall mountains and wide rivers",
+      "Deep oceans and thick dark forests",
+      "Expansive vistas as far as the eye can see",
+  };
+  std::vector<StringView> keys;
+  keys.reserve(keyStrings.size());
+  for (const auto& key : keyStrings) {
+    keys.emplace_back(key);
+  }
+
+  auto data = makeRowVector({
+      makeNullableMapVector<StringView, int64_t>({
+          {{{keys[0], std::nullopt}, {keys[1], 20}}},
+          {{{keys[0], 5}, {keys[2], std::nullopt}}},
+      }),
+  });
+
+  auto expected = makeRowVector({
+      makeMapVector<StringView, int64_t>({
+          {{keys[0], 5}, {keys[1], 20}, {keys[2], 0}},
+      }),
+  });
+
+  testAggregations({data}, {}, {"map_union_sum(c0)"}, {expected});
+}
+
+TEST_F(MapUnionSumTest, complexKeyDoubleValue) {
+  // Exercises the complex-key float/double existing-entry path, where a
+  // duplicate serialized key must be released via removeLast() after combining
+  // with the existing sum. The ROW key [1, 1] repeats across input maps so the
+  // merge takes the existing-entry branch for a DOUBLE value type.
+  auto data = makeRowVector(
+      {makeMapVector(
+           {0, 2, 4},
+           makeRowVector(
+               {makeFlatVector<int64_t>({1, 2, 1, 3, 1, 2}),
+                makeFlatVector<int64_t>({1, 4, 1, 5, 1, 4})}),
+           makeFlatVector<double>({1.5, 2.5, 3.0, 4.0, 2.0, 6.0})),
+       makeFlatVector<int32_t>({1, 1, 1})});
+
+  // Key [1, 1] is summed across all three maps: 1.5 + 3.0 + 2.0 = 6.5.
+  // Key [2, 4] appears in maps 0 and 2: 2.5 + 6.0 = 8.5.
+  // Key [3, 5] appears once: 4.0.
+  auto expectedResult = makeRowVector({makeMapVector(
+      {0},
+      makeRowVector(
+          {makeFlatVector<int64_t>({1, 2, 3}),
+           makeFlatVector<int64_t>({1, 4, 5})}),
+      makeFlatVector<double>({6.5, 8.5, 4.0}))});
+
+  testAggregations({data}, {}, {"map_union_sum(c0)"}, {expectedResult});
+}
+
+TEST_F(MapUnionSumTest, complexKeyIntegerOverflow) {
+  // Exercises the complex-key integer existing-entry overflow path, where the
+  // duplicate serialized key is released via removeLast() before the overflow
+  // throw. The ROW key [1, 1] repeats across input maps with TINYINT values
+  // that overflow int8_t when combined on the existing-entry branch.
+  auto data = makeRowVector(
+      {makeMapVector(
+           {0, 2, 4},
+           makeRowVector(
+               {makeFlatVector<int64_t>({1, 2, 1, 3, 1, 2}),
+                makeFlatVector<int64_t>({1, 4, 1, 5, 1, 4})}),
+           makeFlatVector<int8_t>({100, 2, 100, 4, 100, 6})),
+       makeFlatVector<int32_t>({1, 1, 1})});
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .singleAggregation({}, {"map_union_sum(c0)"})
+                  .planNode();
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()),
+      "Arithmetic overflow in MAP_UNION_SUM: Value 200 exceeds 127");
 }
 
 TEST_F(MapUnionSumTest, tinyintOverflow) {
@@ -355,8 +460,9 @@ TEST_F(MapUnionSumTest, groupByVarcharKey) {
       "Expansive vistas",
   };
   std::vector<StringView> keys;
+  keys.reserve(keyStrings.size());
   for (const auto& key : keyStrings) {
-    keys.push_back(StringView(key));
+    keys.emplace_back(key);
   }
 
   auto data = makeRowVector({


### PR DESCRIPTION
Summary:
MAP_UNION_SUM is a fleet-hot aggregate. Two hot-merge-loop optimizations,
plus a latent accumulator memory-leak fix.

- Decode the map keys/values once per batch with DecodedVector instead of
  re-casting as<SimpleVector<K/S>>() per input row, and add a null-free fast
  path. This exploits dictionary/constant encoding of the key/value child
  vectors and removes the per-element null branch in the common case (mirrors
  the once-per-batch decode in MapAggregateBase).
- Merge each element with a single try_emplace + in-place add instead of
  probing the accumulator map twice (sums[key] read then sums[key] write) on
  the integer/float paths. The pre-overflow operand is captured before the
  in-place add so overflow error messages stay correct.
- Fix a latent leak: the complex-key REAL/DOUBLE existing-entry path never
  called serializedKeys.removeLast(), orphaning serialized keys in the arena
  for duplicate complex keys; now removeLast() runs on both int and float
  existing-entry branches.

Adds a benchmark (benchmarks/MapUnionSum.cpp) modeling the common pattern of
many small integer-keyed maps, global and grouped.
