### PR TITLE
docs: Add blog post on Parquet DELTA decoding with SIMD

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ of available functions [can be found here.](https://facebookincubator.github.io/
 
 Recent blog posts ([all posts](https://velox-lib.io/blog)):
 
+- [From copyBits to SIMD: Accelerating Parquet DELTA Decoding in Velox](https://velox-lib.io/blog/parquet-delta-decoding) (2026-06-17)
 - [FlatMapVector Adoption for Scaling High-Performance AI/ML Data Pre-Processing](https://velox-lib.io/blog/flatmapvector) (2026-05-01)
 - [Nimble Cluster Index: Efficient Indexed Lookups on Columnar Data](https://velox-lib.io/blog/nimble-cluster-index) (2026-04-27)
-- [Axiom: Composable Query Engines Built on Velox](https://velox-lib.io/blog/axiom-composable-query-engines) (2026-04-23)
 
 ## Community
 

--- a/website/blog/2026-04-27-nimble-cluster-index.mdx
+++ b/website/blog/2026-04-27-nimble-cluster-index.mdx
@@ -13,6 +13,8 @@ Nimble's **Cluster Index** bridges this gap. It is a lightweight, hierarchical i
 
 We have integrated the cluster index with **Presto** for analytical index joins and are actively integrating with **ZippyDB** for prefix key scans — both powered by the same underlying index structure, served through Velox.
 
+<!-- truncate -->
+
 ## Motivation
 
 Consider a common pattern in data warehousing: a large fact table needs to be joined with a dimension table on a key column. Traditional hash joins materialize both sides into memory. For selective lookups — where the probe side touches only a fraction of the build side — this is wasteful.

--- a/website/blog/2026-06-17-parquet-delta-decoding.mdx
+++ b/website/blog/2026-06-17-parquet-delta-decoding.mdx
@@ -1,0 +1,178 @@
+---
+slug: parquet-delta-decoding
+title: "From copyBits to SIMD: Accelerating Parquet DELTA Decoding in Velox"
+date: 2026-06-17
+authors: [jaylisde, mbasmanova, PingLiuPing]
+tags: [tech-blog, performance]
+description: "SIMD-accelerated Parquet DELTA decoding in Velox: from 8× slower than PLAIN to within 1.8×, cutting TPC-H Q12 wall time by 2.9×."
+---
+
+## TL;DR
+
+Velox's Parquet `DELTA_BINARY_PACKED` decoders exhibit approximately 8x higher
+CPU cost relative to the PLAIN and dictionary-encoded paths. On a TPC-H Q12
+scan over a DELTA-encoded `lineitem` table, decoding accounts for approximately
+5.0 s of CPU time, compared with 0.6 s for an equivalent dataset stored under
+PLAIN or dictionary encoding.
+
+To address this performance disparity, two optimizations are contributed: first,
+replacing a general-purpose bit-copy routine with a single unaligned memory
+load, eliminating per-value function-call overhead; second, introducing a
+batched decode path that leverages SIMD bit-unpack kernels to amortize
+instruction costs across multiple values.
+
+Together, these optimizations reduce Q12 scan CPU time from **5.0 s to 1.1 s**
+(a 4.5x improvement) and end-to-end wall-clock time from **1.71 s to 0.59 s**
+(a 2.9x speedup).
+
+
+## Background: DELTA encoding
+
+`DELTA_BINARY_PACKED` is Parquet's delta encoding for integers. Rather than
+storing values, it stores the *differences* between consecutive values, then
+bit-packs them. Because real integer columns are often sorted or slowly varying
+(IDs, timestamps, dates, dictionary keys), the deltas are small and pack into
+very few bits, so DELTA files are compact. The encoding is also reused
+internally: `DELTA_LENGTH_BYTE_ARRAY` decodes string lengths through one delta
+decoder, and `DELTA_BYTE_ARRAY` decodes prefix and suffix lengths through two,
+so the integer decoder sits on the string read path too.
+
+## Problem
+
+Velox's Parquet writer can opt into DELTA
+(`WriterOptions::encoding = arrow::Encoding::kDeltaBinaryPacked`, off by
+default). Re-encoding TPC-H `lineitem` as DELTA and running Q12 at SF10, the
+`lineitem` scan that costs ~0.6 s of CPU on
+PLAIN/dictionary data cost ~5.0 s on DELTA. Profiling pinned ~87% of the scan
+CPU on DELTA decoding itself, making it the clear optimization target.
+
+## Following the profile: a general-purpose bit-copy
+
+The profile pointed straight at `DeltaBpDecoder::readLong`, and specifically at
+the call it used to extract each bit-packed delta:
+
+```cpp
+bits::copyBits(
+    reinterpret_cast<const uint64_t*>(bufferStart_),
+    consumedBits,         // source bit offset
+    reinterpret_cast<uint64_t*>(&value),
+    0,                    // destination bit offset, always 0
+    deltaBitWidth_);      // at most 64
+```
+
+`bits::copyBits` is a fully general bit-range memmove: arbitrary source *and*
+destination offsets, arbitrary length, looping byte by byte. The destination
+offset is always 0 and the width is at most 64, so the call reduces to a single
+unaligned 64-bit load and shift (`bits::detail::loadBits`), plus a low-bits
+mask.
+
+`readLong` runs once per value, so collapsing a byte-loop to one load yields a
+significant improvement:
+on its own it took Q12 scan CPU from **5.0 s to 2.8 s** and wall time
+**1.71 s to 1.02 s**.
+
+## Still 4.5× off: the unpack was still scalar
+
+The single-load fix improved throughput, but DELTA scan CPU was still ~4.5× the
+PLAIN/dictionary baseline. Two costs remained: the bit-unpack still handled one
+value at a time, and the read path called the column visitor's `process()` once
+per row, paying per-row dispatch even when no filter was active. Both required
+separate solutions.
+
+<figure style={{textAlign: 'center'}}>
+  <img src="/img/parquet-delta-scalar-vs-batched.svg" alt="Scalar per-value decoding vs batched SIMD decoding of a miniblock" width="100%" />
+</figure>
+
+### Vectorizing the unpack
+
+Every value in a miniblock shares the same bit width, which makes the unpack a
+tight, predictable loop, a natural SIMD target. The solution is
+`decodeMiniBlockSimd`, a kernel templated on a compile-time `bitWidth` (shifts
+and masks become constants) and dispatched at runtime by an index-sequence fold.
+The strategy depends on the width:
+
+| bit width | strategy |
+|-----------|----------|
+| 0 | constant-delta: prefix-sum of `min_delta` only, no loads |
+| 1–16 | 4 values per iteration from one unaligned 64-bit load (`4 × bw ≤ 64`) |
+| 17–32 | 2 values per iteration via a `__uint128_t` window (lowers to an `SHRD` funnel shift on x86_64) |
+| 33–64 | scalar fallback (a single value can straddle > 64 bits after byte-misalignment; rare in practice) |
+
+The prefix sum is *fused into the unpack*: each kernel keeps a running
+`cumulative` and writes finished values straight out, so there's no second pass
+to turn deltas into values. Per the Parquet spec the arithmetic is unsigned mod
+2⁶⁴, which makes overflow well-defined and lets the compiler vectorize freely.
+
+<figure style={{textAlign: 'center'}}>
+  <img src="/img/parquet-delta-bit-unpack.svg" alt="Bit-unpack strategies: 4-value 64-bit load for widths 1-16, 128-bit funnel shift for widths 17-32" width="100%" />
+</figure>
+
+### Once per chunk invocation
+
+For the dispatch cost, `ColumnVisitor::processRun()`, a bulk variant of
+per-row `process()`, hands a decoded chunk to the visitor at once instead of
+one row at a time. For unfiltered reads the decode writes straight into the
+output with no per-row work; for filtered reads a deterministic comparison runs
+in SIMD batches.
+
+Sparse (filtered) reads decode a batch of 1024 values into a stack buffer and
+index into it by row. DELTA's prefix-sum chain forces every physical value to
+be decoded anyway (random-access to value *N* requires computing 0…*N*), so
+one sequential, cache-friendly pass followed by array indexing outperforms
+per-row seeking.
+
+### The string decoder
+
+Profiling the `DELTA_BYTE_ARRAY` path surfaced three steady-state costs in
+`DeltaByteArrayDecoder`, all removed:
+
+- Devirtualized `readString()` by removing the virtual base class.
+- Replaced `make_unique` child decoders (allocated per page) with
+  `std::optional` + `reset()`, eliminating per-page-boundary allocations.
+- Replaced the `std::string` "last value" with `std::vector<char>` + length,
+  dropping the `std::string::_M_replace` overhead (~6.5% of the string path)
+  from the prefix-share copy.
+
+These improvements were measured on a `DELTA_BYTE_ARRAY`-encoded column and
+are not reflected in the Q12 integer results below.
+
+## Where it landed
+
+TPC-H Q12, SF10, `lineitem` re-encoded as `DELTA_BINARY_PACKED`,
+`num_drivers=4 --num_repeats=5 --warmup_after_clear=true`, 5-run median:
+
+| Configuration                          |    Wall   | `lineitem` scan CPU |
+| -------------------------------------- | --------: | ------------------: |
+| PLAIN / dictionary (no DELTA)          |   0.479 s |             0.614 s |
+| DELTA, original (`copyBits`)           |   1.71 s  |             5.04 s  |
+| DELTA, after the single-load fix       |   1.02 s  |             2.76 s  |
+| **DELTA, after SIMD batched decode**   | **0.594 s** |         **1.11 s** |
+
+The first fix is a **1.7× wall** improvement; the batched SIMD path reduces
+wall time by another **42%** and scan CPU by **60%** on top. The DELTA-vs-PLAIN scan-CPU gap shrank
+from ~8× to ~1.8×. The PLAIN/dictionary path was re-measured throughout and
+stayed within noise; this work is confined to the DELTA decoders.
+
+## Takeaways
+
+- **Let the profile pick the target.** Comparing DELTA against the
+  PLAIN/dictionary scan on the *same* data made both the size of the gap and how
+  much was decoding unambiguous.
+- **General-purpose primitives carry a tax.** `bits::copyBits` is correct for
+  any offset and length; where the offset is 0 and the width ≤ 64 it collapses
+  to one load. Specializing the hot call site was the biggest win per line
+  changed.
+- **Attack each layer of overhead separately.** Batching the visitor call
+  removed per-row dispatch; SIMD kernels removed per-value unpack cost; fusing
+  the prefix sum into the unpack removed a whole pass.
+
+## Acknowledgements
+
+Thanks to <a href="https://github.com/mbasmanova">Masha Basmanova</a> and
+<a href="https://github.com/PingLiuPing">Ping Liu</a> for the detailed reviews
+that shaped the safety invariants and pushed for comprehensive bit-width test
+coverage. In particular, Masha's early performance question on
+<a href="https://github.com/facebookincubator/velox/pull/17633">#17633</a>
+directly motivated the SIMD batched decode work in
+<a href="https://github.com/facebookincubator/velox/pull/17728">#17728</a>
+that brought the gap down to ~1.8x.

--- a/website/blog/authors.yml
+++ b/website/blog/authors.yml
@@ -155,3 +155,9 @@ amitkdutta:
   title: Software Engineer @ Meta
   url: https://github.com/amitkdutta
   image_url: https://github.com/amitkdutta.png
+
+jaylisde:
+  name: Shaojie Li
+  title: Software Engineer
+  url: https://github.com/jaylisde
+  image_url: https://github.com/jaylisde.png

--- a/website/static/img/parquet-delta-bit-unpack.svg
+++ b/website/static/img/parquet-delta-bit-unpack.svg
@@ -1,0 +1,81 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1500" height="1000" viewBox="0 0 1500 1000">
+  <defs>
+    <style>
+
+      text { font-family: 'Comic Sans MS', 'Segoe Print', cursive; fill: #000; stroke: #000; stroke-width: 0.4px; paint-order: stroke fill; }
+    </style>
+    <filter id="sk" x="-10%" y="-30%" width="120%" height="160%"><feTurbulence type="fractalNoise" baseFrequency="0.018" numOctaves="2" seed="3" result="n"/><feDisplacementMap in="SourceGraphic" in2="n" scale="2"/></filter>
+    <marker id="bk2" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
+      <path d="M0,0 L7,4 L0,8 Z" fill="#000"/>
+    </marker>
+  </defs>
+
+  <!-- ============ GROUP A: width 1-16 (blue dashed) ============ -->
+  <rect filter="url(#sk)" x="20" y="20" width="1460" height="440" rx="18" fill="#dce7f5" stroke="#6b8fbf" stroke-width="2.5" stroke-dasharray="8 6"/>
+  <text x="55" y="65" font-size="28" fill="#2c5092">bit_width 1-16: one 64-bit load yields 4 values</text>
+
+  <!-- memory bytes -->
+  <text x="55" y="110" font-size="28" fill="#444">memory (little-endian): 8 bytes loaded as uint64_t</text>
+  <g font-size="28" fill="#222">
+    <rect filter="url(#sk)" x="55"  y="130" width="165" height="60" rx="8" fill="#fff" stroke="#444" stroke-width="1.5"/>
+    <rect filter="url(#sk)" x="220" y="130" width="165" height="60" rx="8" fill="#f3f5f8" stroke="#444" stroke-width="1.5"/>
+    <rect filter="url(#sk)" x="385" y="130" width="165" height="60" rx="8" fill="#fff" stroke="#444" stroke-width="1.5"/>
+    <rect filter="url(#sk)" x="550" y="130" width="165" height="60" rx="8" fill="#f3f5f8" stroke="#444" stroke-width="1.5"/>
+    <rect filter="url(#sk)" x="715" y="130" width="165" height="60" rx="8" fill="#fff" stroke="#444" stroke-width="1.5"/>
+    <rect filter="url(#sk)" x="880" y="130" width="165" height="60" rx="8" fill="#f3f5f8" stroke="#444" stroke-width="1.5"/>
+    <rect filter="url(#sk)" x="1045" y="130" width="165" height="60" rx="8" fill="#fff" stroke="#444" stroke-width="1.5"/>
+    <rect filter="url(#sk)" x="1210" y="130" width="165" height="60" rx="8" fill="#f3f5f8" stroke="#444" stroke-width="1.5"/>
+    <text x="137" y="168" text-anchor="middle">byte0</text>
+    <text x="302" y="168" text-anchor="middle">byte1</text>
+    <text x="467" y="168" text-anchor="middle">byte2</text>
+    <text x="632" y="168" text-anchor="middle">byte3</text>
+    <text x="797" y="168" text-anchor="middle">byte4</text>
+    <text x="962" y="168" text-anchor="middle">byte5</text>
+    <text x="1127" y="168" text-anchor="middle">byte6</text>
+    <text x="1292" y="168" text-anchor="middle">byte7</text>
+  </g>
+
+  <!-- arrow: reinterpret -->
+  <line x1="750" y1="190" x2="750" y2="235" stroke="#000" stroke-width="2.5" marker-end="url(#bk2)"/>
+  <text x="775" y="228" font-size="28" fill="#444">reinterpret as packed delta fields (width w)</text>
+
+  <!-- packed delta fields -->
+  <g fill="#222">
+    <rect filter="url(#sk)" x="55"  y="248" width="330" height="70" rx="10" fill="#dae6f5" stroke="#6b8fbf" stroke-width="2"/>
+    <rect filter="url(#sk)" x="385" y="248" width="330" height="70" rx="10" fill="#c6d8ef" stroke="#6b8fbf" stroke-width="2"/>
+    <rect filter="url(#sk)" x="715" y="248" width="330" height="70" rx="10" fill="#dae6f5" stroke="#6b8fbf" stroke-width="2"/>
+    <rect filter="url(#sk)" x="1045" y="248" width="330" height="70" rx="10" fill="#c6d8ef" stroke="#6b8fbf" stroke-width="2"/>
+    <rect filter="url(#sk)" x="1375" y="248" width="50"  height="70" rx="10" fill="#eef4fb" stroke="#6b8fbf" stroke-width="2" stroke-dasharray="4 4"/>
+    <text x="220" y="292" text-anchor="middle" font-size="28">delta 0</text>
+    <text x="550" y="292" text-anchor="middle" font-size="28">delta 1</text>
+    <text x="880" y="292" text-anchor="middle" font-size="28">delta 2</text>
+    <text x="1210" y="292" text-anchor="middle" font-size="28">delta 3</text>
+  </g>
+
+  <!-- extract node -->
+  <line x1="750" y1="318" x2="750" y2="360" stroke="#000" stroke-width="2.5" marker-end="url(#bk2)"/>
+  <rect filter="url(#sk)" x="150" y="365" width="1200" height="70" rx="10" fill="#fff" stroke="#444" stroke-width="2"/>
+  <text x="750" y="409" text-anchor="middle" font-size="28" fill="#000">extract: (word >> (k * w)) &amp; mask,  4*w &lt;= 64, no further loads</text>
+
+  <!-- ============ GROUP B: width 17-32 (purple dashed) ============ -->
+  <rect filter="url(#sk)" x="20" y="510" width="1460" height="470" rx="18" fill="#e6dcf2" stroke="#9678c4" stroke-width="2.5" stroke-dasharray="8 6"/>
+  <text x="55" y="555" font-size="28" fill="#5b3f82">bit_width 17-32: value straddles 64-bit edge, 128-bit window</text>
+
+  <!-- two load nodes -->
+  <rect filter="url(#sk)" x="70"  y="585" width="600" height="70" rx="10" fill="#fff" stroke="#444" stroke-width="2"/>
+  <text x="370" y="629" text-anchor="middle" font-size="28" fill="#000">load A: uint64 at p + byteOff</text>
+  <rect filter="url(#sk)" x="830" y="585" width="600" height="70" rx="10" fill="#fff" stroke="#444" stroke-width="2"/>
+  <text x="1130" y="629" text-anchor="middle" font-size="28" fill="#000">load B: uint64 at p + byteOff + 8</text>
+
+  <!-- combine node (purple) -->
+  <line x1="370" y1="655" x2="620" y2="710" stroke="#000" stroke-width="2.5" marker-end="url(#bk2)"/>
+  <line x1="1130" y1="655" x2="880" y2="710" stroke="#000" stroke-width="2.5" marker-end="url(#bk2)"/>
+  <rect filter="url(#sk)" x="300" y="715" width="900" height="70" rx="10" fill="#e0d5f0" stroke="#9678c4" stroke-width="2"/>
+  <text x="750" y="759" text-anchor="middle" font-size="28" fill="#000">__uint128_t window = (B &lt;&lt; 64) | A</text>
+
+  <!-- shift node -->
+  <line x1="750" y1="785" x2="750" y2="825" stroke="#000" stroke-width="2.5" marker-end="url(#bk2)"/>
+  <rect filter="url(#sk)" x="220" y="830" width="1060" height="110" rx="10" fill="#fff" stroke="#444" stroke-width="2"/>
+  <text x="750" y="876" text-anchor="middle" font-size="28" fill="#000">word = window >> bitInByte</text>
+  <text x="750" y="920" text-anchor="middle" font-size="28" fill="#444">=> 2 values per iteration (SHRD on x86_64)</text>
+</svg>

--- a/website/static/img/parquet-delta-scalar-vs-batched.svg
+++ b/website/static/img/parquet-delta-scalar-vs-batched.svg
@@ -1,0 +1,101 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1500" height="960" viewBox="0 0 1500 960">
+  <defs>
+    <style>
+
+      text { font-family: 'Comic Sans MS', 'Segoe Print', cursive; fill: #000; stroke: #000; stroke-width: 0.4px; paint-order: stroke fill; }
+    </style>
+    <filter id="sk" x="-10%" y="-30%" width="120%" height="160%"><feTurbulence type="fractalNoise" baseFrequency="0.018" numOctaves="2" seed="3" result="n"/><feDisplacementMap in="SourceGraphic" in2="n" scale="2"/></filter>
+    <marker id="bk" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
+      <path d="M0,0 L7,4 L0,8 Z" fill="#000"/>
+    </marker>
+  </defs>
+
+  <!-- ===================== LEFT: per-value scalar ===================== -->
+  <text x="360" y="50" text-anchor="middle" font-size="28" fill="#000">Before: per-value scalar loop</text>
+
+  <rect filter="url(#sk)" x="20" y="70" width="690" height="600" rx="18" fill="#fde6cf" stroke="#d6a44a" stroke-width="2.5" stroke-dasharray="8 6"/>
+  <text x="55" y="115" font-size="28" fill="#9a6b1f">DeltaBpDecoder::readLong()  xN</text>
+
+  <!-- packed input strip -->
+  <g font-size="28" fill="#222">
+    <rect filter="url(#sk)" x="70" y="140" width="90" height="60" rx="8" fill="#dae6f5" stroke="#6b8fbf" stroke-width="2"/>
+    <rect filter="url(#sk)" x="160" y="140" width="90" height="60" rx="8" fill="#e8eff8" stroke="#6b8fbf" stroke-width="2"/>
+    <rect filter="url(#sk)" x="250" y="140" width="90" height="60" rx="8" fill="#dae6f5" stroke="#6b8fbf" stroke-width="2"/>
+    <rect filter="url(#sk)" x="340" y="140" width="90" height="60" rx="8" fill="#e8eff8" stroke="#6b8fbf" stroke-width="2"/>
+    <rect filter="url(#sk)" x="430" y="140" width="60" height="60" rx="8" fill="#f5f8fc" stroke="#6b8fbf" stroke-width="2" stroke-dasharray="4 4"/>
+    <text x="115" y="178" text-anchor="middle">d0</text>
+    <text x="205" y="178" text-anchor="middle">d1</text>
+    <text x="295" y="178" text-anchor="middle">d2</text>
+    <text x="385" y="178" text-anchor="middle">d3</text>
+    <text x="460" y="178" text-anchor="middle" fill="#999">...</text>
+    <text x="520" y="178" fill="#444" font-size="24">packed deltas</text>
+  </g>
+
+  <rect filter="url(#sk)" x="45" y="250" width="640" height="70" rx="10" fill="#ffffff" stroke="#444" stroke-width="2"/>
+  <text x="365" y="294" text-anchor="middle" font-size="28" fill="#000">copyBits: byte-by-byte extract (1 value)</text>
+
+  <rect filter="url(#sk)" x="45" y="360" width="640" height="70" rx="10" fill="#ffffff" stroke="#444" stroke-width="2"/>
+  <text x="365" y="404" text-anchor="middle" font-size="28" fill="#000">+ min_delta + running prefix sum</text>
+
+  <rect filter="url(#sk)" x="45" y="470" width="640" height="70" rx="10" fill="#ffffff" stroke="#444" stroke-width="2"/>
+  <text x="365" y="514" text-anchor="middle" font-size="28" fill="#000">write 1 value</text>
+
+  <line x1="365" y1="200" x2="365" y2="250" stroke="#000" stroke-width="2.5" marker-end="url(#bk)"/>
+  <line x1="365" y1="320" x2="365" y2="360" stroke="#000" stroke-width="2.5" marker-end="url(#bk)"/>
+  <line x1="365" y1="430" x2="365" y2="470" stroke="#000" stroke-width="2.5" marker-end="url(#bk)"/>
+
+  <rect filter="url(#sk)" x="45" y="585" width="640" height="70" rx="10" fill="#e0d5f0" stroke="#9678c4" stroke-width="2"/>
+  <text x="365" y="629" text-anchor="middle" font-size="28" fill="#000">visitor.process(): once per row</text>
+  <line x1="365" y1="540" x2="365" y2="585" stroke="#000" stroke-width="2.5" marker-end="url(#bk)"/>
+
+  <text x="365" y="720" text-anchor="middle" font-size="28" fill="#444">N loads, N dispatches</text>
+
+  <!-- ===================== RIGHT: batched SIMD ===================== -->
+  <text x="1120" y="50" text-anchor="middle" font-size="28" fill="#000">After: batched SIMD per miniblock</text>
+
+  <rect filter="url(#sk)" x="790" y="70" width="690" height="600" rx="18" fill="#d9ead3" stroke="#7caa5c" stroke-width="2.5" stroke-dasharray="8 6"/>
+  <text x="825" y="115" font-size="28" fill="#3f6b29">decodeMiniBlockSimd&lt;bw&gt;  x(N/4)  <tspan font-size="20" fill="#5a8a42">(N/2 if bw>16)</tspan></text>
+
+  <!-- packed input strip -->
+  <g font-size="28">
+    <rect filter="url(#sk)" x="840" y="140" width="440" height="60" rx="8" fill="#cfe4d6" stroke="#5f9670" stroke-width="2"/>
+    <text x="1060" y="178" text-anchor="middle" fill="#000">1 load => d0 d1 d2 d3</text>
+    <rect filter="url(#sk)" x="1282" y="140" width="60" height="60" rx="8" fill="#e9f3ec" stroke="#5f9670" stroke-width="2" stroke-dasharray="4 4"/>
+    <text x="1312" y="178" text-anchor="middle" fill="#999">...</text>
+    <text x="1370" y="178" fill="#444" font-size="24">packed</text>
+  </g>
+
+  <rect filter="url(#sk)" x="815" y="250" width="640" height="70" rx="10" fill="#ffffff" stroke="#444" stroke-width="2"/>
+  <text x="1135" y="294" text-anchor="middle" font-size="28" fill="#000">shift + mask => 4 deltas / iteration</text>
+
+  <rect filter="url(#sk)" x="815" y="360" width="640" height="70" rx="10" fill="#ffffff" stroke="#444" stroke-width="2"/>
+  <text x="1135" y="404" text-anchor="middle" font-size="28" fill="#000">fused prefix sum (+cumulative)</text>
+
+  <rect filter="url(#sk)" x="815" y="470" width="640" height="70" rx="10" fill="#ffffff" stroke="#444" stroke-width="2"/>
+  <text x="1135" y="514" text-anchor="middle" font-size="28" fill="#000">write 4 values straight to output</text>
+
+  <line x1="1135" y1="200" x2="1135" y2="250" stroke="#000" stroke-width="2.5" marker-end="url(#bk)"/>
+  <line x1="1135" y1="320" x2="1135" y2="360" stroke="#000" stroke-width="2.5" marker-end="url(#bk)"/>
+  <line x1="1135" y1="430" x2="1135" y2="470" stroke="#000" stroke-width="2.5" marker-end="url(#bk)"/>
+
+  <rect filter="url(#sk)" x="815" y="585" width="640" height="70" rx="10" fill="#e0d5f0" stroke="#9678c4" stroke-width="2"/>
+  <text x="1135" y="629" text-anchor="middle" font-size="28" fill="#000">visitor.processRun(): once per chunk</text>
+  <line x1="1135" y1="540" x2="1135" y2="585" stroke="#000" stroke-width="2.5" marker-end="url(#bk)"/>
+
+  <text x="1135" y="720" text-anchor="middle" font-size="28" fill="#444">1 load / 4 values, 1 dispatch / chunk</text>
+
+  <!-- bottom shared output buffer -->
+  <rect filter="url(#sk)" x="20" y="780" width="1460" height="140" rx="18" fill="#efefef" stroke="#999" stroke-width="2.5" stroke-dasharray="8 6"/>
+  <text x="750" y="825" text-anchor="middle" font-size="28" fill="#444">output value buffer (decoded int column)</text>
+  <g>
+    <rect filter="url(#sk)" x="480" y="845" width="70" height="50" rx="6" fill="#f4cccc" stroke="#c47" stroke-width="1.5"/>
+    <rect filter="url(#sk)" x="550" y="845" width="70" height="50" rx="6" fill="#d9ead3" stroke="#7caa5c" stroke-width="1.5"/>
+    <rect filter="url(#sk)" x="620" y="845" width="70" height="50" rx="6" fill="#fff" stroke="#999" stroke-width="1.5"/>
+    <rect filter="url(#sk)" x="690" y="845" width="70" height="50" rx="6" fill="#dae6f5" stroke="#6b8fbf" stroke-width="1.5"/>
+    <rect filter="url(#sk)" x="760" y="845" width="70" height="50" rx="6" fill="#f4cccc" stroke="#c47" stroke-width="1.5"/>
+    <rect filter="url(#sk)" x="830" y="845" width="70" height="50" rx="6" fill="#d9ead3" stroke="#7caa5c" stroke-width="1.5"/>
+    <text x="935" y="878" font-size="24" fill="#444">decoded values</text>
+  </g>
+  <line x1="365" y1="740" x2="365" y2="780" stroke="#000" stroke-width="2.5" marker-end="url(#bk)"/>
+  <line x1="1135" y1="740" x2="1135" y2="780" stroke="#000" stroke-width="2.5" marker-end="url(#bk)"/>
+</svg>


### PR DESCRIPTION
## Summary

- Add blog post "From copyBits to SIMD: Parquet DELTA Decoding in Velox"
- Two SVG diagrams (scalar-vs-batched flow, bit-unpack strategies)
- Author entry for jaylisde in authors.yml

## Related PRs

- #17633 perf(parquet): Inline bit extraction in DeltaBpDecoder::readLong
- #17728 perf(parquet): Batched DELTA decoding with SIMD bit-unpack