### PR TITLE
docs: Add Ping Liu as Iceberg and Parquet maintainer (#17859)

### DIFF
--- a/website/docs/community/03-components-and-maintainers.md
+++ b/website/docs/community/03-components-and-maintainers.md
@@ -78,6 +78,11 @@ maintainers of that component.
 #### Parquet
 
 * Deepak Majeti - [majetideepak](https://github.com/majetideepak) / deepak.majeti@ibm.com
+* Ping Liu - [PingLiuPing](https://github.com/PingLiuPing) / ping.liu.ping@gmail.com
+
+#### Iceberg
+
+* Ping Liu - [PingLiuPing](https://github.com/PingLiuPing) / ping.liu.ping@gmail.com
 
 #### ORC, DWRF, and Nimble
 


### PR DESCRIPTION
Summary:

Add Ping Liu (PingLiuPing) as a maintainer for Iceberg and Parquet components.

Reviewed By: mbasmanova

Differential Revision: D108850460


