### PR TITLE
feat: Add missing TIME WITH TIME ZONE datetime function support

### DIFF
--- a/velox/docs/functions/presto/datetime.rst
+++ b/velox/docs/functions/presto/datetime.rst
@@ -44,21 +44,25 @@ Date and Time Operators
    :noindex:
 
     Returns the sum of ``x`` and ``y``. Both ``x`` and ``y`` are intervals day
-    to second or one of them can be timestamp. For addition of two intervals day to
-    second, returns ``-106751991167 07:12:55.808`` when the addition overflows
-    in positive and returns ``106751991167 07:12:55.807`` when the addition
-    overflows in negative. When addition of a timestamp with an interval day to
-    second, overflowed results are wrapped around.
+    to second or one of them can be timestamp, time, or time with time zone. For
+    addition of two intervals day to second, returns ``-106751991167 07:12:55.808``
+    when the addition overflows in positive and returns ``106751991167 07:12:55.807``
+    when the addition overflows in negative. When addition of a timestamp, time, or
+    time with time zone with an interval day to second, overflowed results are
+    wrapped around.
 
 .. function:: minus(x, y) -> [same as x]
    :noindex:
 
     Returns the result of subtracting ``y`` from ``x``. Both ``x`` and ``y``
-    are intervals day to second or ``x`` can be timestamp. For subtraction of
-    two intervals day to second, returns ``-106751991167 07:12:55.808`` when
-    the subtraction overflows in positive and returns ``106751991167 07:12:55.807``
-    when the subtraction overflows in negative. For subtraction of an interval
-    day to second from a timestamp, overflowed results are wrapped around.
+    are intervals day to second or ``x`` can be timestamp, time, or time with
+    time zone. For subtraction of two intervals day to second, returns
+    ``-106751991167 07:12:55.808`` when the subtraction overflows in positive
+    and returns ``106751991167 07:12:55.807`` when the subtraction overflows in
+    negative. For subtraction of an interval day to second from a timestamp, time,
+    or time with time zone, overflowed results are wrapped around. When both ``x``
+    and ``y`` are ``time`` or both are ``time with time zone``, returns an
+    ``interval day to second`` representing the difference.
 
 .. function:: multiply(interval day to second, x) -> interval day to second
 
@@ -418,7 +422,7 @@ arbitrary large timestamps.
 
     Returns the hour of the day from ``x``. The value ranges from 0 to 23.
     Supported types for ``x`` are: DATE, TIMESTAMP, TIMESTAMP WITH TIME ZONE,
-    INTERVAL DAY TO SECOND¶.
+    TIME, TIME WITH TIME ZONE, INTERVAL DAY TO SECOND¶.
 
 .. function:: last_day_of_month(x) -> date
 
@@ -427,12 +431,14 @@ arbitrary large timestamps.
 .. function:: millisecond(x) -> int64
 
     Returns the millisecond of the second from ``x``. Supported types for ``x`` are:
-    DATE, TIMESTAMP, TIMESTAMP WITH TIME ZONE, INTERVAL DAY TO SECOND¶.
+    DATE, TIMESTAMP, TIMESTAMP WITH TIME ZONE, TIME, TIME WITH TIME ZONE,
+    INTERVAL DAY TO SECOND¶.
 
 .. function:: minute(x) -> bigint
 
     Returns the minute of the hour from ``x``. Supported types for ``x`` are:
-    DATE, TIMESTAMP, TIMESTAMP WITH TIME ZONE, INTERVAL DAY TO SECOND¶.
+    DATE, TIMESTAMP, TIMESTAMP WITH TIME ZONE, TIME, TIME WITH TIME ZONE,
+    INTERVAL DAY TO SECOND¶.
 
 .. function:: month(x) -> bigint
 
@@ -446,7 +452,8 @@ arbitrary large timestamps.
 .. function:: second(x) -> bigint
 
     Returns the second of the minute from ``x``. Supported types for ``x`` are:
-    DATE, TIMESTAMP, TIMESTAMP WITH TIME ZONE, INTERVAL DAY TO SECOND¶.
+    DATE, TIMESTAMP, TIMESTAMP WITH TIME ZONE, TIME, TIME WITH TIME ZONE,
+    INTERVAL DAY TO SECOND¶.
 
 .. function:: timezone_hour(timestamp) -> bigint
 

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -550,6 +550,15 @@ struct TimePlusInterval {
       const arg_type<IntervalDayTime>& interval) {
     result = addToTime(time, interval);
   }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<TimeWithTimezone>& result,
+      const arg_type<TimeWithTimezone>& time,
+      const arg_type<IntervalDayTime>& interval) {
+    result = util::pack(
+        addToTime(util::unpackMillisUtc(*time), interval),
+        util::unpackZoneOffset(*time));
+  }
 };
 
 template <typename T>
@@ -561,6 +570,15 @@ struct TimeMinusInterval {
       const arg_type<Time>& time,
       const arg_type<IntervalDayTime>& interval) {
     result = addToTime(time, -interval);
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<TimeWithTimezone>& result,
+      const arg_type<TimeWithTimezone>& time,
+      const arg_type<IntervalDayTime>& interval) {
+    result = util::pack(
+        addToTime(util::unpackMillisUtc(*time), -interval),
+        util::unpackZoneOffset(*time));
   }
 };
 
@@ -584,6 +602,23 @@ struct TimeMinusFunction {
 
     // Simple subtraction returns interval in milliseconds
     result = a - b;
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<IntervalDayTime>& result,
+      const arg_type<TimeWithTimezone>& a,
+      const arg_type<TimeWithTimezone>& b) {
+    const int64_t millisUtcA = util::unpackMillisUtc(*a);
+    const int64_t millisUtcB = util::unpackMillisUtc(*b);
+    VELOX_USER_CHECK(
+        millisUtcA >= 0 && millisUtcA < kMillisInDay,
+        "TIME WITH TIME ZONE value {} is out of range [0, 86400000)",
+        millisUtcA);
+    VELOX_USER_CHECK(
+        millisUtcB >= 0 && millisUtcB < kMillisInDay,
+        "TIME WITH TIME ZONE value {} is out of range [0, 86400000)",
+        millisUtcB);
+    result = millisUtcA - millisUtcB;
   }
 };
 
@@ -668,6 +703,15 @@ struct IntervalPlusTime {
       const arg_type<IntervalDayTime>& interval,
       const arg_type<Time>& time) {
     result = addToTime(time, interval);
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<TimeWithTimezone>& result,
+      const arg_type<IntervalDayTime>& interval,
+      const arg_type<TimeWithTimezone>& time) {
+    result = util::pack(
+        addToTime(util::unpackMillisUtc(*time), interval),
+        util::unpackZoneOffset(*time));
   }
 };
 
@@ -1054,6 +1098,86 @@ struct MillisecondFromIntervalFunction {
       int64_t& result,
       const arg_type<IntervalDayTime>& millis) {
     result = millis % Timestamp::kMillisecondsInSecond;
+  }
+};
+
+namespace {
+
+// Converts a packed TIME WITH TIME ZONE value to local milliseconds since
+// midnight.
+FOLLY_ALWAYS_INLINE int64_t
+timeWithTimezoneToLocalMs(int64_t timeWithTimezone) {
+  const int64_t millisUtc = util::unpackMillisUtc(timeWithTimezone);
+  VELOX_USER_CHECK(
+      millisUtc >= 0 && millisUtc < kMillisInDay,
+      "TIME WITH TIME ZONE time component {} is out of range [0, 86400000)",
+      millisUtc);
+  const int16_t encodedOffset = util::unpackZoneOffset(timeWithTimezone);
+  VELOX_USER_CHECK(
+      encodedOffset >= 0 && encodedOffset <= 2 * util::kTimeZoneBias,
+      "TIME WITH TIME ZONE timezone offset is out of range [0, 1680]: {}",
+      encodedOffset);
+
+  return util::utcToLocalTime(
+      millisUtc, util::decodeTimezoneOffset(encodedOffset));
+}
+
+} // namespace
+
+// Dedicated functions for TIME WITH TIME ZONE field extraction.
+template <typename T>
+struct HourTimeWithTimezoneFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      int64_t& result,
+      const arg_type<TimeWithTimezone>& timeWithTimezone) {
+    result = std::chrono::duration_cast<std::chrono::hours>(
+                 std::chrono::milliseconds(
+                     timeWithTimezoneToLocalMs(*timeWithTimezone)))
+                 .count();
+  }
+};
+
+template <typename T>
+struct MinuteTimeWithTimezoneFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      int64_t& result,
+      const arg_type<TimeWithTimezone>& timeWithTimezone) {
+    result = std::chrono::duration_cast<std::chrono::minutes>(
+                 std::chrono::milliseconds(
+                     timeWithTimezoneToLocalMs(*timeWithTimezone)))
+                 .count() %
+        kMinutesInHour;
+  }
+};
+
+template <typename T>
+struct SecondTimeWithTimezoneFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      int64_t& result,
+      const arg_type<TimeWithTimezone>& timeWithTimezone) {
+    result = std::chrono::duration_cast<std::chrono::seconds>(
+                 std::chrono::milliseconds(
+                     timeWithTimezoneToLocalMs(*timeWithTimezone)))
+                 .count() %
+        kSecondsInMinute;
+  }
+};
+
+template <typename T>
+struct MillisecondTimeWithTimezoneFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      int64_t& result,
+      const arg_type<TimeWithTimezone>& timeWithTimezone) {
+    result = timeWithTimezoneToLocalMs(*timeWithTimezone) %
+        Timestamp::kMillisecondsInSecond;
   }
 };
 

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -608,17 +608,7 @@ struct TimeMinusFunction {
       out_type<IntervalDayTime>& result,
       const arg_type<TimeWithTimezone>& a,
       const arg_type<TimeWithTimezone>& b) {
-    const int64_t millisUtcA = util::unpackMillisUtc(*a);
-    const int64_t millisUtcB = util::unpackMillisUtc(*b);
-    VELOX_USER_CHECK(
-        millisUtcA >= 0 && millisUtcA < kMillisInDay,
-        "TIME WITH TIME ZONE value {} is out of range [0, 86400000)",
-        millisUtcA);
-    VELOX_USER_CHECK(
-        millisUtcB >= 0 && millisUtcB < kMillisInDay,
-        "TIME WITH TIME ZONE value {} is out of range [0, 86400000)",
-        millisUtcB);
-    result = millisUtcA - millisUtcB;
+    result = util::unpackMillisUtc(*a) - util::unpackMillisUtc(*b);
   }
 };
 
@@ -925,6 +915,20 @@ struct YearOfWeekFunction : public InitSessionTimezone<T>,
   }
 };
 
+namespace {
+
+// Converts a packed TIME WITH TIME ZONE value to local milliseconds since
+// midnight.
+FOLLY_ALWAYS_INLINE int64_t
+timeWithTimezoneToLocalMs(int64_t timeWithTimezone) {
+  const int64_t millisUtc = util::unpackMillisUtc(timeWithTimezone);
+  const int16_t encodedOffset = util::unpackZoneOffset(timeWithTimezone);
+  return util::utcToLocalTime(
+      millisUtc, util::decodeTimezoneOffset(encodedOffset));
+}
+
+} // namespace
+
 template <typename T>
 struct HourFunction : public InitSessionTimezone<T>,
                       public TimestampWithTimezoneSupport<T> {
@@ -1101,30 +1105,8 @@ struct MillisecondFromIntervalFunction {
   }
 };
 
-namespace {
-
-// Converts a packed TIME WITH TIME ZONE value to local milliseconds since
-// midnight.
-FOLLY_ALWAYS_INLINE int64_t
-timeWithTimezoneToLocalMs(int64_t timeWithTimezone) {
-  const int64_t millisUtc = util::unpackMillisUtc(timeWithTimezone);
-  VELOX_USER_CHECK(
-      millisUtc >= 0 && millisUtc < kMillisInDay,
-      "TIME WITH TIME ZONE time component {} is out of range [0, 86400000)",
-      millisUtc);
-  const int16_t encodedOffset = util::unpackZoneOffset(timeWithTimezone);
-  VELOX_USER_CHECK(
-      encodedOffset >= 0 && encodedOffset <= 2 * util::kTimeZoneBias,
-      "TIME WITH TIME ZONE timezone offset is out of range [0, 1680]: {}",
-      encodedOffset);
-
-  return util::utcToLocalTime(
-      millisUtc, util::decodeTimezoneOffset(encodedOffset));
-}
-
-} // namespace
-
-// Dedicated functions for TIME WITH TIME ZONE field extraction.
+// Returns the hour-of-day (0–23) in the local time zone of a TIME WITH TIME
+// ZONE value.
 template <typename T>
 struct HourTimeWithTimezoneFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
@@ -1139,6 +1121,8 @@ struct HourTimeWithTimezoneFunction {
   }
 };
 
+// Returns the minute-of-hour (0–59) in the local time zone of a TIME WITH TIME
+// ZONE value.
 template <typename T>
 struct MinuteTimeWithTimezoneFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
@@ -1154,6 +1138,8 @@ struct MinuteTimeWithTimezoneFunction {
   }
 };
 
+// Returns the second-of-minute (0–59) in the local time zone of a TIME WITH
+// TIME ZONE value.
 template <typename T>
 struct SecondTimeWithTimezoneFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
@@ -1169,6 +1155,8 @@ struct SecondTimeWithTimezoneFunction {
   }
 };
 
+// Returns the millisecond-of-second (0–999) in the local time zone of a TIME
+// WITH TIME ZONE value.
 template <typename T>
 struct MillisecondTimeWithTimezoneFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -549,6 +549,15 @@ struct TimePlusInterval {
       const arg_type<IntervalDayTime>& interval) {
     result = addToTime(time, interval);
   }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<TimeWithTimezone>& result,
+      const arg_type<TimeWithTimezone>& time,
+      const arg_type<IntervalDayTime>& interval) {
+    result = util::pack(
+        addToTime(util::unpackMillisUtc(*time), interval),
+        util::unpackZoneOffset(*time));
+  }
 };
 
 template <typename T>
@@ -560,6 +569,15 @@ struct TimeMinusInterval {
       const arg_type<Time>& time,
       const arg_type<IntervalDayTime>& interval) {
     result = addToTime(time, -interval);
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<TimeWithTimezone>& result,
+      const arg_type<TimeWithTimezone>& time,
+      const arg_type<IntervalDayTime>& interval) {
+    result = util::pack(
+        addToTime(util::unpackMillisUtc(*time), -interval),
+        util::unpackZoneOffset(*time));
   }
 };
 
@@ -583,6 +601,23 @@ struct TimeMinusFunction {
 
     // Simple subtraction returns interval in milliseconds
     result = a - b;
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<IntervalDayTime>& result,
+      const arg_type<TimeWithTimezone>& a,
+      const arg_type<TimeWithTimezone>& b) {
+    const int64_t millisUtcA = util::unpackMillisUtc(*a);
+    const int64_t millisUtcB = util::unpackMillisUtc(*b);
+    VELOX_USER_CHECK(
+        millisUtcA >= 0 && millisUtcA < kMillisInDay,
+        "TIME WITH TIME ZONE value {} is out of range [0, 86400000)",
+        millisUtcA);
+    VELOX_USER_CHECK(
+        millisUtcB >= 0 && millisUtcB < kMillisInDay,
+        "TIME WITH TIME ZONE value {} is out of range [0, 86400000)",
+        millisUtcB);
+    result = millisUtcA - millisUtcB;
   }
 };
 
@@ -667,6 +702,15 @@ struct IntervalPlusTime {
       const arg_type<IntervalDayTime>& interval,
       const arg_type<Time>& time) {
     result = addToTime(time, interval);
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<TimeWithTimezone>& result,
+      const arg_type<IntervalDayTime>& interval,
+      const arg_type<TimeWithTimezone>& time) {
+    result = util::pack(
+        addToTime(util::unpackMillisUtc(*time), interval),
+        util::unpackZoneOffset(*time));
   }
 };
 
@@ -879,6 +923,20 @@ struct YearOfWeekFunction : public InitSessionTimezone<T>,
   }
 };
 
+namespace {
+
+// Converts a packed TIME WITH TIME ZONE value to local milliseconds since
+// midnight.
+FOLLY_ALWAYS_INLINE int64_t
+timeWithTimezoneToLocalMs(int64_t timeWithTimezone) {
+  const int64_t millisUtc = util::unpackMillisUtc(timeWithTimezone);
+  const int16_t encodedOffset = util::unpackZoneOffset(timeWithTimezone);
+  return util::utcToLocalTime(
+      millisUtc, util::decodeTimezoneOffset(encodedOffset));
+}
+
+} // namespace
+
 template <typename T>
 struct HourFunction : public InitSessionTimezone<T>,
                       public TimestampWithTimezoneSupport<T> {
@@ -1052,6 +1110,70 @@ struct MillisecondFromIntervalFunction {
       int64_t& result,
       const arg_type<IntervalDayTime>& millis) {
     result = millis % Timestamp::kMillisecondsInSecond;
+  }
+};
+
+// Returns the hour-of-day (0–23) in the local time zone of a TIME WITH TIME
+// ZONE value.
+template <typename T>
+struct HourTimeWithTimezoneFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      int64_t& result,
+      const arg_type<TimeWithTimezone>& timeWithTimezone) {
+    result = std::chrono::duration_cast<std::chrono::hours>(
+                 std::chrono::milliseconds(
+                     timeWithTimezoneToLocalMs(*timeWithTimezone)))
+                 .count();
+  }
+};
+
+// Returns the minute-of-hour (0–59) in the local time zone of a TIME WITH TIME
+// ZONE value.
+template <typename T>
+struct MinuteTimeWithTimezoneFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      int64_t& result,
+      const arg_type<TimeWithTimezone>& timeWithTimezone) {
+    result = std::chrono::duration_cast<std::chrono::minutes>(
+                 std::chrono::milliseconds(
+                     timeWithTimezoneToLocalMs(*timeWithTimezone)))
+                 .count() %
+        kMinutesInHour;
+  }
+};
+
+// Returns the second-of-minute (0–59) in the local time zone of a TIME WITH
+// TIME ZONE value.
+template <typename T>
+struct SecondTimeWithTimezoneFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      int64_t& result,
+      const arg_type<TimeWithTimezone>& timeWithTimezone) {
+    result = std::chrono::duration_cast<std::chrono::seconds>(
+                 std::chrono::milliseconds(
+                     timeWithTimezoneToLocalMs(*timeWithTimezone)))
+                 .count() %
+        kSecondsInMinute;
+  }
+};
+
+// Returns the millisecond-of-second (0–999) in the local time zone of a TIME
+// WITH TIME ZONE value.
+template <typename T>
+struct MillisecondTimeWithTimezoneFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      int64_t& result,
+      const arg_type<TimeWithTimezone>& timeWithTimezone) {
+    result = timeWithTimezoneToLocalMs(*timeWithTimezone) %
+        Timestamp::kMillisecondsInSecond;
   }
 };
 

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -160,13 +160,37 @@ void registerSimpleFunctions(const std::string& prefix) {
   registerFunction<IntervalPlusTime, Time, IntervalDayTime, Time>(
       {prefix + "plus"});
 
+  registerFunction<
+      TimePlusInterval,
+      TimeWithTimezone,
+      TimeWithTimezone,
+      IntervalDayTime>({prefix + "plus"});
+
+  registerFunction<
+      IntervalPlusTime,
+      TimeWithTimezone,
+      IntervalDayTime,
+      TimeWithTimezone>({prefix + "plus"});
+
   // Register Time - Interval function
   registerFunction<TimeMinusInterval, Time, Time, IntervalDayTime>(
       {prefix + "minus"});
 
+  registerFunction<
+      TimeMinusInterval,
+      TimeWithTimezone,
+      TimeWithTimezone,
+      IntervalDayTime>({prefix + "minus"});
+
   // Register Time - Time function (returns IntervalDayTime)
   registerFunction<TimeMinusFunction, IntervalDayTime, Time, Time>(
       {prefix + "minus"});
+
+  registerFunction<
+      TimeMinusFunction,
+      IntervalDayTime,
+      TimeWithTimezone,
+      TimeWithTimezone>({prefix + "minus"});
 
   // Use optimized vector function for Time + IntervalYearMonth (identity
   // function)
@@ -220,6 +244,8 @@ void registerSimpleFunctions(const std::string& prefix) {
   registerFunction<HourFunction, int64_t, TimestampWithTimezone>(
       {prefix + "hour"});
   registerFunction<HourFunction, int64_t, Time>({prefix + "hour"});
+  registerFunction<HourTimeWithTimezoneFunction, int64_t, TimeWithTimezone>(
+      {prefix + "hour"});
   registerFunction<HourFromIntervalFunction, int64_t, IntervalDayTime>(
       {prefix + "hour"});
 
@@ -235,6 +261,8 @@ void registerSimpleFunctions(const std::string& prefix) {
   registerFunction<MinuteFunction, int64_t, TimestampWithTimezone>(
       {prefix + "minute"});
   registerFunction<MinuteFunction, int64_t, Time>({prefix + "minute"});
+  registerFunction<MinuteTimeWithTimezoneFunction, int64_t, TimeWithTimezone>(
+      {prefix + "minute"});
   registerFunction<MinuteFromIntervalFunction, int64_t, IntervalDayTime>(
       {prefix + "minute"});
 
@@ -243,6 +271,8 @@ void registerSimpleFunctions(const std::string& prefix) {
   registerFunction<SecondFunction, int64_t, TimestampWithTimezone>(
       {prefix + "second"});
   registerFunction<SecondFunction, int64_t, Time>({prefix + "second"});
+  registerFunction<SecondTimeWithTimezoneFunction, int64_t, TimeWithTimezone>(
+      {prefix + "second"});
   registerFunction<SecondFromIntervalFunction, int64_t, IntervalDayTime>(
       {prefix + "second"});
 
@@ -254,6 +284,10 @@ void registerSimpleFunctions(const std::string& prefix) {
       {prefix + "millisecond"});
   registerFunction<MillisecondFunction, int64_t, Time>(
       {prefix + "millisecond"});
+  registerFunction<
+      MillisecondTimeWithTimezoneFunction,
+      int64_t,
+      TimeWithTimezone>({prefix + "millisecond"});
   registerFunction<MillisecondFromIntervalFunction, int64_t, IntervalDayTime>(
       {prefix + "millisecond"});
 

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -120,9 +120,6 @@ class DateTimeFunctionsTest : public functions::test::FunctionBaseTest {
       std::optional<int64_t> result,
       int64_t expected) {
     ASSERT_TRUE(result.has_value());
-    EXPECT_EQ(
-        util::unpackZoneOffset(result.value()),
-        util::unpackZoneOffset(expected));
     EXPECT_EQ(result.value(), expected);
   }
 
@@ -827,8 +824,6 @@ TEST_F(DateTimeFunctionsTest, hourTime) {
 }
 
 TEST_F(DateTimeFunctionsTest, hourTimeWithTimezone) {
-  using namespace facebook::velox::util;
-
   const auto hour = [&](std::optional<int64_t> timeWithTimezone) {
     return evaluateOnce<int64_t>(
         "hour(c0)", TIME_WITH_TIME_ZONE(), timeWithTimezone);
@@ -1185,8 +1180,6 @@ TEST_F(DateTimeFunctionsTest, timestampWithTimeZonePlusIntervalDayTime) {
 }
 
 TEST_F(DateTimeFunctionsTest, timeWithTimezoneIntervalDayTime) {
-  using namespace facebook::velox::util;
-
   const auto testTimePlusIntervalCommutative =
       [&](int64_t timeWithTimezone,
           int64_t interval) -> std::optional<int64_t> {
@@ -1226,11 +1219,29 @@ TEST_F(DateTimeFunctionsTest, timeWithTimezoneIntervalDayTime) {
   auto result4 = testTimePlusIntervalCommutative(
       makeTimeWithTz("12:30:45.123+00:00"), oneDay);
   expectTimeWithTzEq(result4, makeTimeWithTz("12:30:45.123+00:00"));
+
+  // Negative-interval wrap: 01:00:00 + (-2h) wraps to 23:00:00.
+  auto result5 = testTimePlusIntervalCommutative(
+      makeTimeWithTz("01:00:00.000+05:30"), -twoHours);
+  expectTimeWithTzEq(result5, makeTimeWithTz("23:00:00.000+05:30"));
+
+  // Positive wrap past midnight: 23:00:00 + 2h wraps to 01:00:00.
+  auto result6 = testTimePlusIntervalCommutative(
+      makeTimeWithTz("23:00:00.000+00:00"), twoHours);
+  expectTimeWithTzEq(result6, makeTimeWithTz("01:00:00.000+00:00"));
+
+  // Null propagation.
+  auto nullResult = evaluateOnce<int64_t>(
+      "plus(c0, c1)",
+      makeRowVector({
+          makeNullableFlatVector<int64_t>(
+              {std::nullopt}, TIME_WITH_TIME_ZONE()),
+          makeNullableFlatVector<int64_t>({threeHours}, INTERVAL_DAY_TIME()),
+      }));
+  EXPECT_EQ(std::nullopt, nullResult);
 }
 
 TEST_F(DateTimeFunctionsTest, timeWithTimezoneMinusIntervalDayTime) {
-  using namespace facebook::velox::util;
-
   const auto timeMinusInterval =
       [&](int64_t timeWithTimezone,
           int64_t interval) -> std::optional<int64_t> {
@@ -1249,11 +1260,24 @@ TEST_F(DateTimeFunctionsTest, timeWithTimezoneMinusIntervalDayTime) {
   auto result2 =
       timeMinusInterval(makeTimeWithTz("01:00:00.000+05:30"), threeHours);
   expectTimeWithTzEq(result2, makeTimeWithTz("22:00:00.000+05:30"));
+
+  // Negative wrap: 01:00:00 - 2h wraps to 23:00:00.
+  auto result3 =
+      timeMinusInterval(makeTimeWithTz("01:00:00.000+00:00"), twoHours);
+  expectTimeWithTzEq(result3, makeTimeWithTz("23:00:00.000+00:00"));
+
+  // Null propagation.
+  auto nullResult = evaluateOnce<int64_t>(
+      "minus(c0, c1)",
+      makeRowVector({
+          makeNullableFlatVector<int64_t>(
+              {std::nullopt}, TIME_WITH_TIME_ZONE()),
+          makeNullableFlatVector<int64_t>({twoHours}, INTERVAL_DAY_TIME()),
+      }));
+  EXPECT_EQ(std::nullopt, nullResult);
 }
 
 TEST_F(DateTimeFunctionsTest, timeWithTimezoneMinusTimeWithTimezone) {
-  using namespace facebook::velox::util;
-
   const auto timeMinusTime = [&](int64_t time1,
                                  int64_t time2) -> std::optional<int64_t> {
     return evaluateOnce<int64_t>(
@@ -2117,8 +2141,6 @@ TEST_F(DateTimeFunctionsTest, minuteTime) {
 }
 
 TEST_F(DateTimeFunctionsTest, minuteTimeWithTimezone) {
-  using namespace facebook::velox::util;
-
   const auto minute = [&](std::optional<int64_t> timeWithTimezone) {
     return evaluateOnce<int64_t>(
         "minute(c0)", TIME_WITH_TIME_ZONE(), timeWithTimezone);
@@ -2276,8 +2298,6 @@ TEST_F(DateTimeFunctionsTest, secondTime) {
 }
 
 TEST_F(DateTimeFunctionsTest, secondTimeWithTimezone) {
-  using namespace facebook::velox::util;
-
   const auto second = [&](std::optional<int64_t> timeWithTimezone) {
     return evaluateOnce<int64_t>(
         "second(c0)", TIME_WITH_TIME_ZONE(), timeWithTimezone);
@@ -2451,8 +2471,6 @@ TEST_F(DateTimeFunctionsTest, millisecondTime) {
 }
 
 TEST_F(DateTimeFunctionsTest, millisecondTimeWithTimezone) {
-  using namespace facebook::velox::util;
-
   const auto millisecond = [&](std::optional<int64_t> timeWithTimezone) {
     return evaluateOnce<int64_t>(
         "millisecond(c0)", TIME_WITH_TIME_ZONE(), timeWithTimezone);
@@ -6580,8 +6598,6 @@ TEST_F(DateTimeFunctionsTest, atTimezoneTest) {
 }
 
 TEST_F(DateTimeFunctionsTest, atTimezoneTimeWithTimezoneTest) {
-  using namespace facebook::velox::util;
-
   const auto at_timezone = [&](std::optional<int64_t> timeWithTimezone,
                                std::optional<std::string> targetTimezone) {
     return evaluateOnce<int64_t>(

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -91,6 +91,41 @@ class DateTimeFunctionsTest : public functions::test::FunctionBaseTest {
     });
   }
 
+  static int64_t makeTimeWithTz(const std::string& timeStr) {
+    auto result =
+        util::fromTimeWithTimezoneString(timeStr.c_str(), timeStr.size());
+    VELOX_CHECK(
+        !result.hasError(), "Parse error: {}", result.error().message());
+    return result.value();
+  }
+
+  RowVectorPtr makeTimeWithTzAndIntervalRow(
+      int64_t timeWithTimezone,
+      int64_t interval) {
+    return makeRowVector({
+        makeNullableFlatVector<int64_t>(
+            {timeWithTimezone}, TIME_WITH_TIME_ZONE()),
+        makeNullableFlatVector<int64_t>({interval}, INTERVAL_DAY_TIME()),
+    });
+  }
+
+  RowVectorPtr makeTimeWithTzRow(int64_t time1, int64_t time2) {
+    return makeRowVector({
+        makeNullableFlatVector<int64_t>({time1}, TIME_WITH_TIME_ZONE()),
+        makeNullableFlatVector<int64_t>({time2}, TIME_WITH_TIME_ZONE()),
+    });
+  }
+
+  static void expectTimeWithTzEq(
+      std::optional<int64_t> result,
+      int64_t expected) {
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(
+        util::unpackZoneOffset(result.value()),
+        util::unpackZoneOffset(expected));
+    EXPECT_EQ(result.value(), expected);
+  }
+
  public:
   // Helper class to manipulate timestamp with timezone types in tests. Provided
   // only for convenience.
@@ -791,6 +826,23 @@ TEST_F(DateTimeFunctionsTest, hourTime) {
       VeloxUserError); // overflow case
 }
 
+TEST_F(DateTimeFunctionsTest, hourTimeWithTimezone) {
+  using namespace facebook::velox::util;
+
+  const auto hour = [&](std::optional<int64_t> timeWithTimezone) {
+    return evaluateOnce<int64_t>(
+        "hour(c0)", TIME_WITH_TIME_ZONE(), timeWithTimezone);
+  };
+
+  // null handling
+  EXPECT_EQ(std::nullopt, hour(std::nullopt));
+
+  EXPECT_EQ(0, hour(makeTimeWithTz("00:59:59.999+00:00")));
+  EXPECT_EQ(10, hour(makeTimeWithTz("10:30:00.000+05:30")));
+  EXPECT_EQ(14, hour(makeTimeWithTz("14:00:00.000-08:00")));
+  EXPECT_EQ(23, hour(makeTimeWithTz("23:59:59.999+00:00")));
+}
+
 TEST_F(DateTimeFunctionsTest, dayOfMonth) {
   const auto day = [&](std::optional<Timestamp> date) {
     return evaluateOnce<int64_t>("day_of_month(c0)", date);
@@ -1130,6 +1182,137 @@ TEST_F(DateTimeFunctionsTest, timestampWithTimeZonePlusIntervalDayTime) {
   EXPECT_EQ(
       "2024-11-03 01:30:00.000 America/Los_Angeles",
       test("2024-11-03 01:30 America/Los_Angeles", 1 * kMillisInHour));
+}
+
+TEST_F(DateTimeFunctionsTest, timeWithTimezoneIntervalDayTime) {
+  using namespace facebook::velox::util;
+
+  const auto testTimePlusIntervalCommutative =
+      [&](int64_t timeWithTimezone,
+          int64_t interval) -> std::optional<int64_t> {
+    auto result1 = evaluateOnce<int64_t>(
+        "plus(c0, c1)",
+        makeTimeWithTzAndIntervalRow(timeWithTimezone, interval));
+
+    auto result2 = evaluateOnce<int64_t>(
+        "plus(c0, c1)",
+        makeRowVector({
+            makeNullableFlatVector<int64_t>({interval}, INTERVAL_DAY_TIME()),
+            makeNullableFlatVector<int64_t>(
+                {timeWithTimezone}, TIME_WITH_TIME_ZONE()),
+        }));
+
+    EXPECT_EQ(result1, result2);
+    return result1;
+  };
+
+  const int64_t threeHours = 3 * util::kMillisInHour;
+  const int64_t ninetyMinutes = 90 * util::kMillisInMinute;
+  const int64_t twoHours = 2 * util::kMillisInHour;
+  const int64_t oneDay = util::kMillisInDay;
+
+  auto result1 = testTimePlusIntervalCommutative(
+      makeTimeWithTz("03:04:05.321+00:00"), threeHours);
+  expectTimeWithTzEq(result1, makeTimeWithTz("06:04:05.321+00:00"));
+
+  auto result2 = testTimePlusIntervalCommutative(
+      makeTimeWithTz("03:04:05.321+05:30"), ninetyMinutes);
+  expectTimeWithTzEq(result2, makeTimeWithTz("04:34:05.321+05:30"));
+
+  auto result3 = testTimePlusIntervalCommutative(
+      makeTimeWithTz("03:04:05.321-08:00"), -twoHours);
+  expectTimeWithTzEq(result3, makeTimeWithTz("01:04:05.321-08:00"));
+
+  auto result4 = testTimePlusIntervalCommutative(
+      makeTimeWithTz("12:30:45.123+00:00"), oneDay);
+  expectTimeWithTzEq(result4, makeTimeWithTz("12:30:45.123+00:00"));
+}
+
+TEST_F(DateTimeFunctionsTest, timeWithTimezoneMinusIntervalDayTime) {
+  using namespace facebook::velox::util;
+
+  const auto timeMinusInterval =
+      [&](int64_t timeWithTimezone,
+          int64_t interval) -> std::optional<int64_t> {
+    return evaluateOnce<int64_t>(
+        "minus(c0, c1)",
+        makeTimeWithTzAndIntervalRow(timeWithTimezone, interval));
+  };
+
+  const int64_t twoHours = 2 * util::kMillisInHour;
+  const int64_t threeHours = 3 * util::kMillisInHour;
+
+  auto result1 =
+      timeMinusInterval(makeTimeWithTz("10:00:00.000+00:00"), twoHours);
+  expectTimeWithTzEq(result1, makeTimeWithTz("08:00:00.000+00:00"));
+
+  auto result2 =
+      timeMinusInterval(makeTimeWithTz("01:00:00.000+05:30"), threeHours);
+  expectTimeWithTzEq(result2, makeTimeWithTz("22:00:00.000+05:30"));
+}
+
+TEST_F(DateTimeFunctionsTest, timeWithTimezoneMinusTimeWithTimezone) {
+  using namespace facebook::velox::util;
+
+  const auto timeMinusTime = [&](int64_t time1,
+                                 int64_t time2) -> std::optional<int64_t> {
+    return evaluateOnce<int64_t>(
+        "minus(c0, c1)", makeTimeWithTzRow(time1, time2));
+  };
+
+  // Test basic subtraction: 10:00:00+00:00 - 08:00:00+00:00 = 2 hours
+  const int64_t time1 = makeTimeWithTz("10:00:00.000+00:00");
+  const int64_t time2 = makeTimeWithTz("08:00:00.000+00:00");
+  const int64_t twoHours = 2 * util::kMillisInHour;
+  EXPECT_EQ(twoHours, timeMinusTime(time1, time2));
+
+  // Test reverse (negative result): 08:00:00+00:00 - 10:00:00+00:00 = -2 hours
+  EXPECT_EQ(-twoHours, timeMinusTime(time2, time1));
+
+  // Test same time: 10:00:00+00:00 - 10:00:00+00:00 = 0
+  EXPECT_EQ(0, timeMinusTime(time1, time1));
+
+  // Test with millisecond precision
+  const int64_t time3 = makeTimeWithTz("12:30:45.123+00:00");
+  const int64_t time4 = makeTimeWithTz("06:04:05.321+00:00");
+  const int64_t expected =
+      (12 * util::kMillisInHour + 30 * util::kMillisInMinute +
+       45 * util::kMillisInSecond + 123) -
+      (6 * util::kMillisInHour + 4 * util::kMillisInMinute +
+       5 * util::kMillisInSecond + 321);
+  EXPECT_EQ(expected, timeMinusTime(time3, time4));
+
+  // Test with different timezones - should use UTC time for calculation
+  const int64_t time5 = makeTimeWithTz("10:00:00.000+05:30");
+  const int64_t time6 = makeTimeWithTz("08:00:00.000+00:00");
+  const int64_t threeAndHalfHours = -210 * util::kMillisInMinute;
+  EXPECT_EQ(threeAndHalfHours, timeMinusTime(time5, time6));
+
+  // Test midnight cases
+  const int64_t almostMidnight = makeTimeWithTz("23:59:59.999+00:00");
+  const int64_t midnight = makeTimeWithTz("00:00:00.000+00:00");
+  EXPECT_EQ(util::kMillisInDay - 1, timeMinusTime(almostMidnight, midnight));
+
+  // Test with same UTC time but different timezones
+  const int64_t time7 = makeTimeWithTz("00:00:00.000+00:00");
+  const int64_t time8 = makeTimeWithTz("01:00:00.000+01:00");
+  EXPECT_EQ(0, timeMinusTime(time7, time8));
+
+  // Test with NULL values
+  const auto timeMinusTimeWithNull =
+      [&](std::optional<int64_t> t1,
+          std::optional<int64_t> t2) -> std::optional<int64_t> {
+    return evaluateOnce<int64_t>(
+        "minus(c0, c1)",
+        makeRowVector({
+            makeNullableFlatVector<int64_t>({t1}, TIME_WITH_TIME_ZONE()),
+            makeNullableFlatVector<int64_t>({t2}, TIME_WITH_TIME_ZONE()),
+        }));
+  };
+
+  EXPECT_EQ(std::nullopt, timeMinusTimeWithNull(std::nullopt, std::nullopt));
+  EXPECT_EQ(std::nullopt, timeMinusTimeWithNull(time1, std::nullopt));
+  EXPECT_EQ(std::nullopt, timeMinusTimeWithNull(std::nullopt, time2));
 }
 
 TEST_F(DateTimeFunctionsTest, minusTimestamp) {
@@ -1933,6 +2116,39 @@ TEST_F(DateTimeFunctionsTest, minuteTime) {
   }
 }
 
+TEST_F(DateTimeFunctionsTest, minuteTimeWithTimezone) {
+  using namespace facebook::velox::util;
+
+  const auto minute = [&](std::optional<int64_t> timeWithTimezone) {
+    return evaluateOnce<int64_t>(
+        "minute(c0)", TIME_WITH_TIME_ZONE(), timeWithTimezone);
+  };
+
+  // null handling
+  EXPECT_EQ(std::nullopt, minute(std::nullopt));
+
+  // Test minute extraction from TIME WITH TIME ZONE
+  EXPECT_EQ(0, minute(makeTimeWithTz("00:00:00.000+00:00"))); // midnight
+  EXPECT_EQ(59, minute(makeTimeWithTz("23:59:59.999+00:00"))); // last minute
+
+  // Boundary values
+  EXPECT_EQ(
+      0, minute(makeTimeWithTz("00:00:59.999+00:00"))); // last sec of first min
+  EXPECT_EQ(
+      1,
+      minute(makeTimeWithTz("00:01:00.000+00:00"))); // first sec of second min
+  EXPECT_EQ(
+      59,
+      minute(makeTimeWithTz("00:59:59.999+00:00"))); // last sec of first hour
+  EXPECT_EQ(
+      0,
+      minute(makeTimeWithTz("01:00:00.000+00:00"))); // first sec of second hour
+
+  EXPECT_EQ(30, minute(makeTimeWithTz("10:30:00.000+05:30")));
+  EXPECT_EQ(0, minute(makeTimeWithTz("14:00:00.000-08:00")));
+  EXPECT_EQ(15, minute(makeTimeWithTz("00:15:30.123+00:00")));
+}
+
 TEST_F(DateTimeFunctionsTest, minuteTimeInvalidRange) {
   const auto minute = [&](int64_t time) {
     return evaluateOnce<int64_t>(
@@ -2057,6 +2273,23 @@ TEST_F(DateTimeFunctionsTest, secondTime) {
   EXPECT_THROW(
       second(std::numeric_limits<int64_t>::max()),
       VeloxUserError); // overflow case
+}
+
+TEST_F(DateTimeFunctionsTest, secondTimeWithTimezone) {
+  using namespace facebook::velox::util;
+
+  const auto second = [&](std::optional<int64_t> timeWithTimezone) {
+    return evaluateOnce<int64_t>(
+        "second(c0)", TIME_WITH_TIME_ZONE(), timeWithTimezone);
+  };
+
+  // null handling
+  EXPECT_EQ(std::nullopt, second(std::nullopt));
+
+  EXPECT_EQ(0, second(makeTimeWithTz("00:00:00.999+00:00")));
+  EXPECT_EQ(30, second(makeTimeWithTz("00:00:30.000+00:00")));
+  EXPECT_EQ(3, second(makeTimeWithTz("01:02:03.123+00:00")));
+  EXPECT_EQ(0, second(makeTimeWithTz("14:00:00.000-08:00")));
 }
 
 TEST_F(DateTimeFunctionsTest, millisecond) {
@@ -2215,6 +2448,22 @@ TEST_F(DateTimeFunctionsTest, millisecondTime) {
   auto expectedWithNulls = makeNullableFlatVector<int64_t>(
       {0, std::nullopt, 123, std::nullopt, 999});
   assertEqualVectors(expectedWithNulls, resultWithNulls);
+}
+
+TEST_F(DateTimeFunctionsTest, millisecondTimeWithTimezone) {
+  using namespace facebook::velox::util;
+
+  const auto millisecond = [&](std::optional<int64_t> timeWithTimezone) {
+    return evaluateOnce<int64_t>(
+        "millisecond(c0)", TIME_WITH_TIME_ZONE(), timeWithTimezone);
+  };
+
+  // Null handling.
+  EXPECT_EQ(std::nullopt, millisecond(std::nullopt));
+
+  EXPECT_EQ(123, millisecond(makeTimeWithTz("01:02:03.123+00:00")));
+  EXPECT_EQ(456, millisecond(makeTimeWithTz("12:00:00.456+05:30")));
+  EXPECT_EQ(789, millisecond(makeTimeWithTz("23:59:59.789-08:00")));
 }
 
 TEST_F(DateTimeFunctionsTest, extractFromIntervalDayTime) {
@@ -6340,15 +6589,6 @@ TEST_F(DateTimeFunctionsTest, atTimezoneTimeWithTimezoneTest) {
         {TIME_WITH_TIME_ZONE(), VARCHAR()},
         timeWithTimezone,
         targetTimezone);
-  };
-
-  // Helper to create TIME WITH TIME ZONE values
-  const auto makeTimeWithTz = [](const std::string& timeStr) -> int64_t {
-    auto result = fromTimeWithTimezoneString(timeStr.c_str(), timeStr.size());
-    if (result.hasError()) {
-      throw std::runtime_error("Parse error: " + result.error().message());
-    }
-    return result.value();
   };
 
   // Test 1: Change from +05:30 to +08:00

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -91,6 +91,38 @@ class DateTimeFunctionsTest : public functions::test::FunctionBaseTest {
     });
   }
 
+  static int64_t makeTimeWithTz(const std::string& timeStr) {
+    auto result =
+        util::fromTimeWithTimezoneString(timeStr.c_str(), timeStr.size());
+    VELOX_CHECK(
+        !result.hasError(), "Parse error: {}", result.error().message());
+    return result.value();
+  }
+
+  RowVectorPtr makeTimeWithTzAndIntervalRow(
+      int64_t timeWithTimezone,
+      int64_t interval) {
+    return makeRowVector({
+        makeNullableFlatVector<int64_t>(
+            {timeWithTimezone}, TIME_WITH_TIME_ZONE()),
+        makeNullableFlatVector<int64_t>({interval}, INTERVAL_DAY_TIME()),
+    });
+  }
+
+  RowVectorPtr makeTimeWithTzRow(int64_t time1, int64_t time2) {
+    return makeRowVector({
+        makeNullableFlatVector<int64_t>({time1}, TIME_WITH_TIME_ZONE()),
+        makeNullableFlatVector<int64_t>({time2}, TIME_WITH_TIME_ZONE()),
+    });
+  }
+
+  static void expectTimeWithTzEq(
+      std::optional<int64_t> result,
+      int64_t expected) {
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value(), expected);
+  }
+
  public:
   // Helper class to manipulate timestamp with timezone types in tests. Provided
   // only for convenience.
@@ -791,6 +823,21 @@ TEST_F(DateTimeFunctionsTest, hourTime) {
       VeloxUserError); // overflow case
 }
 
+TEST_F(DateTimeFunctionsTest, hourTimeWithTimezone) {
+  const auto hour = [&](std::optional<int64_t> timeWithTimezone) {
+    return evaluateOnce<int64_t>(
+        "hour(c0)", TIME_WITH_TIME_ZONE(), timeWithTimezone);
+  };
+
+  // null handling
+  EXPECT_EQ(std::nullopt, hour(std::nullopt));
+
+  EXPECT_EQ(0, hour(makeTimeWithTz("00:59:59.999+00:00")));
+  EXPECT_EQ(10, hour(makeTimeWithTz("10:30:00.000+05:30")));
+  EXPECT_EQ(14, hour(makeTimeWithTz("14:00:00.000-08:00")));
+  EXPECT_EQ(23, hour(makeTimeWithTz("23:59:59.999+00:00")));
+}
+
 TEST_F(DateTimeFunctionsTest, dayOfMonth) {
   const auto day = [&](std::optional<Timestamp> date) {
     return evaluateOnce<int64_t>("day_of_month(c0)", date);
@@ -1168,6 +1215,188 @@ TEST_F(DateTimeFunctionsTest, timestampWithTimeZonePlusLargeIntervalDayTime) {
   EXPECT_EQ(
       "2025-05-30 02:50:00.000 America/Los_Angeles",
       plus("2024-12-01 01:50 America/Los_Angeles"));
+}
+
+TEST_F(DateTimeFunctionsTest, timeWithTimezoneIntervalDayTime) {
+  const auto testTimePlusIntervalCommutative =
+      [&](int64_t timeWithTimezone,
+          int64_t interval) -> std::optional<int64_t> {
+    auto result1 = evaluateOnce<int64_t>(
+        "plus(c0, c1)",
+        makeTimeWithTzAndIntervalRow(timeWithTimezone, interval));
+
+    auto result2 = evaluateOnce<int64_t>(
+        "plus(c0, c1)",
+        makeRowVector({
+            makeNullableFlatVector<int64_t>({interval}, INTERVAL_DAY_TIME()),
+            makeNullableFlatVector<int64_t>(
+                {timeWithTimezone}, TIME_WITH_TIME_ZONE()),
+        }));
+
+    EXPECT_EQ(result1, result2);
+    return result1;
+  };
+
+  const int64_t threeHours = 3 * util::kMillisInHour;
+  const int64_t ninetyMinutes = 90 * util::kMillisInMinute;
+  const int64_t twoHours = 2 * util::kMillisInHour;
+  const int64_t oneDay = util::kMillisInDay;
+
+  auto result1 = testTimePlusIntervalCommutative(
+      makeTimeWithTz("03:04:05.321+00:00"), threeHours);
+  expectTimeWithTzEq(result1, makeTimeWithTz("06:04:05.321+00:00"));
+
+  auto result2 = testTimePlusIntervalCommutative(
+      makeTimeWithTz("03:04:05.321+05:30"), ninetyMinutes);
+  expectTimeWithTzEq(result2, makeTimeWithTz("04:34:05.321+05:30"));
+
+  auto result3 = testTimePlusIntervalCommutative(
+      makeTimeWithTz("03:04:05.321-08:00"), -twoHours);
+  expectTimeWithTzEq(result3, makeTimeWithTz("01:04:05.321-08:00"));
+
+  auto result4 = testTimePlusIntervalCommutative(
+      makeTimeWithTz("12:30:45.123+00:00"), oneDay);
+  expectTimeWithTzEq(result4, makeTimeWithTz("12:30:45.123+00:00"));
+
+  // Negative-interval wrap: 01:00:00 + (-2h) wraps to 23:00:00.
+  auto result5 = testTimePlusIntervalCommutative(
+      makeTimeWithTz("01:00:00.000+05:30"), -twoHours);
+  expectTimeWithTzEq(result5, makeTimeWithTz("23:00:00.000+05:30"));
+
+  // Positive wrap past midnight: 23:00:00 + 2h wraps to 01:00:00.
+  auto result6 = testTimePlusIntervalCommutative(
+      makeTimeWithTz("23:00:00.000+00:00"), twoHours);
+  expectTimeWithTzEq(result6, makeTimeWithTz("01:00:00.000+00:00"));
+
+  // Null propagation.
+  auto nullResult = evaluateOnce<int64_t>(
+      "plus(c0, c1)",
+      makeRowVector({
+          makeNullableFlatVector<int64_t>(
+              {std::nullopt}, TIME_WITH_TIME_ZONE()),
+          makeNullableFlatVector<int64_t>({threeHours}, INTERVAL_DAY_TIME()),
+      }));
+  EXPECT_EQ(std::nullopt, nullResult);
+}
+
+TEST_F(DateTimeFunctionsTest, timeWithTimezoneMinusIntervalDayTime) {
+  const auto timeMinusInterval =
+      [&](int64_t timeWithTimezone,
+          int64_t interval) -> std::optional<int64_t> {
+    return evaluateOnce<int64_t>(
+        "minus(c0, c1)",
+        makeTimeWithTzAndIntervalRow(timeWithTimezone, interval));
+  };
+
+  const int64_t twoHours = 2 * util::kMillisInHour;
+  const int64_t threeHours = 3 * util::kMillisInHour;
+
+  auto result1 =
+      timeMinusInterval(makeTimeWithTz("10:00:00.000+00:00"), twoHours);
+  expectTimeWithTzEq(result1, makeTimeWithTz("08:00:00.000+00:00"));
+
+  auto result2 =
+      timeMinusInterval(makeTimeWithTz("01:00:00.000+05:30"), threeHours);
+  expectTimeWithTzEq(result2, makeTimeWithTz("22:00:00.000+05:30"));
+
+  // Negative wrap: 01:00:00 - 2h wraps to 23:00:00.
+  auto result3 =
+      timeMinusInterval(makeTimeWithTz("01:00:00.000+00:00"), twoHours);
+  expectTimeWithTzEq(result3, makeTimeWithTz("23:00:00.000+00:00"));
+
+  // Null propagation.
+  auto nullResult = evaluateOnce<int64_t>(
+      "minus(c0, c1)",
+      makeRowVector({
+          makeNullableFlatVector<int64_t>(
+              {std::nullopt}, TIME_WITH_TIME_ZONE()),
+          makeNullableFlatVector<int64_t>({twoHours}, INTERVAL_DAY_TIME()),
+      }));
+  EXPECT_EQ(std::nullopt, nullResult);
+}
+
+TEST_F(DateTimeFunctionsTest, timeWithTimezoneMinusTimeWithTimezone) {
+  const auto timeMinusTime = [&](int64_t time1,
+                                 int64_t time2) -> std::optional<int64_t> {
+    return evaluateOnce<int64_t>(
+        "minus(c0, c1)", makeTimeWithTzRow(time1, time2));
+  };
+
+  // Test basic subtraction: 10:00:00+00:00 - 08:00:00+00:00 = 2 hours
+  const int64_t time1 = makeTimeWithTz("10:00:00.000+00:00");
+  const int64_t time2 = makeTimeWithTz("08:00:00.000+00:00");
+  const int64_t twoHours = 2 * util::kMillisInHour;
+  EXPECT_EQ(twoHours, timeMinusTime(time1, time2));
+
+  // Test reverse (negative result): 08:00:00+00:00 - 10:00:00+00:00 = -2 hours
+  EXPECT_EQ(-twoHours, timeMinusTime(time2, time1));
+
+  // Test same time: 10:00:00+00:00 - 10:00:00+00:00 = 0
+  EXPECT_EQ(0, timeMinusTime(time1, time1));
+
+  // Test with millisecond precision
+  const int64_t time3 = makeTimeWithTz("12:30:45.123+00:00");
+  const int64_t time4 = makeTimeWithTz("06:04:05.321+00:00");
+  const int64_t expected =
+      (12 * util::kMillisInHour + 30 * util::kMillisInMinute +
+       45 * util::kMillisInSecond + 123) -
+      (6 * util::kMillisInHour + 4 * util::kMillisInMinute +
+       5 * util::kMillisInSecond + 321);
+  EXPECT_EQ(expected, timeMinusTime(time3, time4));
+
+  // Test with different timezones - should use UTC time for calculation
+  const int64_t time5 = makeTimeWithTz("10:00:00.000+05:30");
+  const int64_t time6 = makeTimeWithTz("08:00:00.000+00:00");
+  const int64_t threeAndHalfHours = -210 * util::kMillisInMinute;
+  EXPECT_EQ(threeAndHalfHours, timeMinusTime(time5, time6));
+
+  // Test midnight cases
+  const int64_t almostMidnight = makeTimeWithTz("23:59:59.999+00:00");
+  const int64_t midnight = makeTimeWithTz("00:00:00.000+00:00");
+  EXPECT_EQ(util::kMillisInDay - 1, timeMinusTime(almostMidnight, midnight));
+
+  // Test with same UTC time but different timezones
+  const int64_t time7 = makeTimeWithTz("00:00:00.000+00:00");
+  const int64_t time8 = makeTimeWithTz("01:00:00.000+01:00");
+  EXPECT_EQ(0, timeMinusTime(time7, time8));
+
+  // Test with NULL values
+  const auto timeMinusTimeWithNull =
+      [&](std::optional<int64_t> t1,
+          std::optional<int64_t> t2) -> std::optional<int64_t> {
+    return evaluateOnce<int64_t>(
+        "minus(c0, c1)",
+        makeRowVector({
+            makeNullableFlatVector<int64_t>({t1}, TIME_WITH_TIME_ZONE()),
+            makeNullableFlatVector<int64_t>({t2}, TIME_WITH_TIME_ZONE()),
+        }));
+  };
+
+  EXPECT_EQ(std::nullopt, timeMinusTimeWithNull(std::nullopt, std::nullopt));
+  EXPECT_EQ(std::nullopt, timeMinusTimeWithNull(time1, std::nullopt));
+  EXPECT_EQ(std::nullopt, timeMinusTimeWithNull(std::nullopt, time2));
+
+  // Test range validation: first argument out of range.
+  // Craft packed values with raw millisUtc outside [0, kMillisInDay).
+  const int16_t utcKey = util::biasEncode(0); // UTC timezone key
+  const int64_t negativeMillis = util::pack(-1, utcKey); // millisUtc = -1 < 0
+  const int64_t tooLargeMillis = util::pack(
+      util::kMillisInDay, utcKey); // millisUtc = kMillisInDay >= kMillisInDay
+
+  VELOX_ASSERT_THROW(
+      timeMinusTime(negativeMillis, time1),
+      "TIME WITH TIME ZONE value -1 is out of range [0, 86400000)");
+  VELOX_ASSERT_THROW(
+      timeMinusTime(tooLargeMillis, time1),
+      "TIME WITH TIME ZONE value 86400000 is out of range [0, 86400000)");
+
+  // Test range validation: second argument out of range.
+  VELOX_ASSERT_THROW(
+      timeMinusTime(time1, negativeMillis),
+      "TIME WITH TIME ZONE value -1 is out of range [0, 86400000)");
+  VELOX_ASSERT_THROW(
+      timeMinusTime(time1, tooLargeMillis),
+      "TIME WITH TIME ZONE value 86400000 is out of range [0, 86400000)");
 }
 
 TEST_F(DateTimeFunctionsTest, minusTimestamp) {
@@ -1971,6 +2200,37 @@ TEST_F(DateTimeFunctionsTest, minuteTime) {
   }
 }
 
+TEST_F(DateTimeFunctionsTest, minuteTimeWithTimezone) {
+  const auto minute = [&](std::optional<int64_t> timeWithTimezone) {
+    return evaluateOnce<int64_t>(
+        "minute(c0)", TIME_WITH_TIME_ZONE(), timeWithTimezone);
+  };
+
+  // null handling
+  EXPECT_EQ(std::nullopt, minute(std::nullopt));
+
+  // Test minute extraction from TIME WITH TIME ZONE
+  EXPECT_EQ(0, minute(makeTimeWithTz("00:00:00.000+00:00"))); // midnight
+  EXPECT_EQ(59, minute(makeTimeWithTz("23:59:59.999+00:00"))); // last minute
+
+  // Boundary values
+  EXPECT_EQ(
+      0, minute(makeTimeWithTz("00:00:59.999+00:00"))); // last sec of first min
+  EXPECT_EQ(
+      1,
+      minute(makeTimeWithTz("00:01:00.000+00:00"))); // first sec of second min
+  EXPECT_EQ(
+      59,
+      minute(makeTimeWithTz("00:59:59.999+00:00"))); // last sec of first hour
+  EXPECT_EQ(
+      0,
+      minute(makeTimeWithTz("01:00:00.000+00:00"))); // first sec of second hour
+
+  EXPECT_EQ(30, minute(makeTimeWithTz("10:30:00.000+05:30")));
+  EXPECT_EQ(0, minute(makeTimeWithTz("14:00:00.000-08:00")));
+  EXPECT_EQ(15, minute(makeTimeWithTz("00:15:30.123+00:00")));
+}
+
 TEST_F(DateTimeFunctionsTest, minuteTimeInvalidRange) {
   const auto minute = [&](int64_t time) {
     return evaluateOnce<int64_t>(
@@ -2095,6 +2355,21 @@ TEST_F(DateTimeFunctionsTest, secondTime) {
   EXPECT_THROW(
       second(std::numeric_limits<int64_t>::max()),
       VeloxUserError); // overflow case
+}
+
+TEST_F(DateTimeFunctionsTest, secondTimeWithTimezone) {
+  const auto second = [&](std::optional<int64_t> timeWithTimezone) {
+    return evaluateOnce<int64_t>(
+        "second(c0)", TIME_WITH_TIME_ZONE(), timeWithTimezone);
+  };
+
+  // null handling
+  EXPECT_EQ(std::nullopt, second(std::nullopt));
+
+  EXPECT_EQ(0, second(makeTimeWithTz("00:00:00.999+00:00")));
+  EXPECT_EQ(30, second(makeTimeWithTz("00:00:30.000+00:00")));
+  EXPECT_EQ(3, second(makeTimeWithTz("01:02:03.123+00:00")));
+  EXPECT_EQ(0, second(makeTimeWithTz("14:00:00.000-08:00")));
 }
 
 TEST_F(DateTimeFunctionsTest, millisecond) {
@@ -2253,6 +2528,20 @@ TEST_F(DateTimeFunctionsTest, millisecondTime) {
   auto expectedWithNulls = makeNullableFlatVector<int64_t>(
       {0, std::nullopt, 123, std::nullopt, 999});
   assertEqualVectors(expectedWithNulls, resultWithNulls);
+}
+
+TEST_F(DateTimeFunctionsTest, millisecondTimeWithTimezone) {
+  const auto millisecond = [&](std::optional<int64_t> timeWithTimezone) {
+    return evaluateOnce<int64_t>(
+        "millisecond(c0)", TIME_WITH_TIME_ZONE(), timeWithTimezone);
+  };
+
+  // Null handling.
+  EXPECT_EQ(std::nullopt, millisecond(std::nullopt));
+
+  EXPECT_EQ(123, millisecond(makeTimeWithTz("01:02:03.123+00:00")));
+  EXPECT_EQ(456, millisecond(makeTimeWithTz("12:00:00.456+05:30")));
+  EXPECT_EQ(789, millisecond(makeTimeWithTz("23:59:59.789-08:00")));
 }
 
 TEST_F(DateTimeFunctionsTest, extractFromIntervalDayTime) {
@@ -6369,8 +6658,6 @@ TEST_F(DateTimeFunctionsTest, atTimezoneTest) {
 }
 
 TEST_F(DateTimeFunctionsTest, atTimezoneTimeWithTimezoneTest) {
-  using namespace facebook::velox::util;
-
   const auto at_timezone = [&](std::optional<int64_t> timeWithTimezone,
                                std::optional<std::string> targetTimezone) {
     return evaluateOnce<int64_t>(
@@ -6378,15 +6665,6 @@ TEST_F(DateTimeFunctionsTest, atTimezoneTimeWithTimezoneTest) {
         {TIME_WITH_TIME_ZONE(), VARCHAR()},
         timeWithTimezone,
         targetTimezone);
-  };
-
-  // Helper to create TIME WITH TIME ZONE values
-  const auto makeTimeWithTz = [](const std::string& timeStr) -> int64_t {
-    auto result = fromTimeWithTimezoneString(timeStr.c_str(), timeStr.size());
-    if (result.hasError()) {
-      throw std::runtime_error("Parse error: " + result.error().message());
-    }
-    return result.value();
   };
 
   // Test 1: Change from +05:30 to +08:00


### PR DESCRIPTION
# Summary
This fixes missing `TIME WITH TIME ZONE` support in Velox PrestoSQL datetime functions used by `current_time`.
## Issue
Two valid query patterns were failing in native execution:

**Query 1**
```
SELECT
    current_time AS full_time,
    HOUR(current_time) AS hour,
    MINUTE(current_time) AS minute,
    SECOND(current_time) AS second;
```
**Failure:**
- `hour(time with time zone)` was not registered
- similarly, `minute(time with time zone)` and `second(time with time zone)` were missing

**Query 2**
```
SELECT
    current_time AS now,
    current_time + INTERVAL '2' HOUR AS two_hours_later,
    current_time - INTERVAL '30' MINUTE AS thirty_minutes_ago;
```
**Failure:**

- `plus(time with time zone, interval day to second)` was not registered
- corresponding `interval + time with time zone` and `time with time zone - interval` support was also missing 
- `time with time zone`-`time with time zone` support was missing as well

Since `current_time` returns `TIME WITH TIME ZONE`, these overloads are required for native execution to match Presto semantics.

## What changed

### Registration updates
Added missing registrations for:

- `hour(time with time zone) -> bigint`
- `minute(time with time zone) -> bigint`
- `second(time with time zone) -> bigint`

and for interval arithmetic:

- `plus(time with time zone, interval day to second) -> time with time zone`
- `plus(interval day to second, time with time zone) -> time with time zone`
- `minus(time with time zone, interval day to second) -> time with time zone`
- `minus(time with time zone, time with time zone) -> interval day to second`

### Function implementation updates
Extended the underlying datetime UDFs to support `TimeWithTimezone`:

  - `TimePlusInterval`
  - `IntervalPlusTime`
  - `TimeMinusInterval`
  - `TimeMinusFunction`
  
The arithmetic implementation:
  - preserves the original zone key
  - updates the UTC millis component
  - matches existing Presto behavior for `TIME WITH TIME ZONE`

## Why this is needed
Velox already supports `current_time` as `TIME WITH TIME ZONE`, but some downstream datetime functions were only registered or implemented for `TIME`. This caused native function resolution failures for otherwise valid Presto queries.

This change closes that gap and aligns native execution with expected PrestoSQL behavior.

## Notes
This change is limited to missing `TIME WITH TIME ZONE` support for:
- extract-style functions: `hour`, `minute`, `second`
- interval arithmetic on `TIME WITH TIME ZONE`

It does not change unrelated datetime semantics.