### PR TITLE
fix: CompositeKernel::warmup() compile hang in heavyweight hosts

### DIFF
--- a/velox/experimental/torchwave/CompiledOp.cpp
+++ b/velox/experimental/torchwave/CompiledOp.cpp
@@ -1102,7 +1102,12 @@ CompositeKernel::CompositeKernel(
     }
   }
 
-  // Only compile the kernel if a GPU is available.
+  // Only compile the kernel if a GPU is available. The one-time
+  // NVRTC/system-header initialization (CompiledKernel::initialize()) is run
+  // eagerly on the main thread by torch::wave::initialize() before any kernel
+  // is compiled, so the async compile enqueued below never triggers it lazily
+  // on a Wave compile-pool thread (which deadlocks warmup() in heavyweight
+  // NCCL/Thrift/folly hosts -- T275179010).
   if (facebook::velox::wave::currentDevice()) {
     auto genFunc = [code = std::move(code),
                     entryPoint,

--- a/velox/experimental/torchwave/Executor.cpp
+++ b/velox/experimental/torchwave/Executor.cpp
@@ -99,6 +99,14 @@ void initialize() {
     return;
   }
   facebook::velox::wave::setDevice(device);
+  // Run the one-time NVRTC/system-header initialization here, on the
+  // (main) thread that sets up the executor, unless it was already done
+  // elsewhere. ensureInit() touches the filesystem and publishes the shared
+  // /tmp/wavesystemheaders.txt; doing it lazily on a Wave compile-pool thread
+  // inside a heavyweight host (NCCL/Thrift/folly) is what hangs warmup()
+  // (T275179010). initialize() is idempotent, so this is a cheap no-op if the
+  // header init has already happened.
+  facebook::velox::wave::CompiledKernel::initialize();
   auto* g = globals();
   // Unit allocation size for host-device communication buffers. Tensors are
   // allocated separately from the PyTorch caching allocator.

--- a/velox/experimental/wave/common/Compile.cu
+++ b/velox/experimental/wave/common/Compile.cu
@@ -92,6 +92,10 @@ class CompiledModuleImpl : public CompiledModule {
   int64_t compileMs_;
 };
 
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+
 namespace {
 
 void addFlag(
@@ -172,16 +176,24 @@ bool readSystemHeaders(std::map<std::string, std::string>& headers) {
 }
 
 void saveSystemHeaders(std::map<std::string, std::string>& map) {
-  std::ofstream out(fmt::format("/tmp/h.{}", getpid()));
-  for (auto& pair : map) {
-    out << pair.first << std::endl
-        << pair.second.size() << std::endl
-        << pair.second;
+  auto tmpPath = fmt::format("/tmp/h.{}", getpid());
+  {
+    std::ofstream out(tmpPath);
+    for (auto& pair : map) {
+      out << pair.first << std::endl
+          << pair.second.size() << std::endl
+          << pair.second;
+    }
   }
-  out.close();
-  system(
-      fmt::format(" mv /tmp/h.{} /tmp/wavesystemheaders.txt", getpid())
-          .c_str());
+  // Use rename(2) instead of system("mv ...") to publish the headers file.
+  // system() calls fork(), and forking from a Wave compile-pool thread inside
+  // a heavyweight host (NCCL/Thrift/folly executors) can deadlock the child
+  // before exec via lock inheritance, hanging warmup() forever (T275179010).
+  // rename is a single atomic syscall within the same filesystem (/tmp).
+  if (std::rename(tmpPath.c_str(), "/tmp/wavesystemheaders.txt") != 0) {
+    LOG(WARNING) << "Failed to rename " << tmpPath
+                 << " to /tmp/wavesystemheaders.txt: " << std::strerror(errno);
+  }
 }
 
 // Adds a trailing zero to make the string.data() a C char*.


### PR DESCRIPTION
Summary:
`torch.compile(model, backend="torchwave")` on the real ROO train preproc hung indefinitely in `CompositeKernel::warmup()` (T275179010). The main thread blocked on the kernel-compile `folly::SemiFuture<CompiledModule>`, which never completed; zero kernels compiled and the process sat near-idle. The toy backend tests passed because they never stand up the heavyweight host (`init.training()` -> Thrift + NCCL + folly executors).

Root cause: the one-time NVRTC/system-header init (`ensureInit` in `Compile.cu`) ran lazily on a Wave compile-pool thread inside the first `CompiledModule::create`. On a cache miss it published the headers file via `saveSystemHeaders()` -> `system("mv ...")`, i.e. a `fork()`. Forking from a folly compile-pool thread in a process full of NCCL/Thrift/folly threads can deadlock the child before `exec` via lock inheritance, so the compile task never finishes and `warmup()` blocks forever. Running fragile filesystem/init work lazily on the pool thread is the core fragility.

Fixes:
- `Executor.cpp` `initialize()`: run `CompiledKernel::initialize()` on the (main) thread that sets up the executor, right after the device is selected. This is a single, idempotent place for the one-time NVRTC/system-header init, so it runs only if it was not already done elsewhere. Kernel compilation only happens once a device is set (which `initialize()` does), so the header init is guaranteed to have already run on the main thread before any async kernel compile is enqueued; the pool thread's `CompiledModule::create` then finds init already done. This replaces the eager per-node call that an earlier version of this diff added in `CompiledOp.cpp`, which is now removed.
- `Compile.cu` `saveSystemHeaders`: replace `system("mv ...")` with `std::rename(2)` — a single atomic syscall within `/tmp`, eliminating the `fork()` entirely.

Reviewed By: apurva-meta, varun2784

Differential Revision: D108366320


