### PR TITLE
fix: Add direct `ThreadId` dependency to process tests

### DIFF
--- a/velox/common/process/tests/TraceHistoryTest.cpp
+++ b/velox/common/process/tests/TraceHistoryTest.cpp
@@ -19,6 +19,7 @@
 #include <fmt/format.h>
 #include <folly/synchronization/Baton.h>
 #include <folly/synchronization/Latch.h>
+#include <folly/system/ThreadId.h>
 #include <gtest/gtest.h>
 
 namespace facebook::velox::process {


### PR DESCRIPTION
Summary:
`TraceHistoryTest.cpp` calls `folly::getOSThreadID()`, but the test target did not directly include or depend on the Folly `ThreadId` API. A recent header/dependency change exposed that transitive dependency and caused `fbcode//velox/common/process/tests:test` to fail during compilation.

This diff makes the dependency explicit by including `folly/system/ThreadId.h` in `TraceHistoryTest.cpp` and adding `//folly/system:thread_id` to the test target.

Differential Revision: D108897043


