### PR TITLE
fix(build): Fix build failure of TraceHistoryTest

### DIFF
--- a/velox/common/process/tests/TraceHistoryTest.cpp
+++ b/velox/common/process/tests/TraceHistoryTest.cpp
@@ -19,6 +19,7 @@
 #include <fmt/format.h>
 #include <folly/synchronization/Baton.h>
 #include <folly/synchronization/Latch.h>
+#include <folly/system/ThreadId.h>
 #include <gtest/gtest.h>
 
 namespace facebook::velox::process {


### PR DESCRIPTION
Summary:
Fixes build error
```
velox/common/process/tests/TraceHistoryTest.cpp:49:40: error: no member named 'getOSThreadID' in namespace 'folly'
   49 |     ASSERT_EQ(results[0].osTid, folly::getOSThreadID());
      |                                 ~~~~~~~^
```

Differential Revision: D108903759


