### PR TITLE
feat: Gate `cacheMetadata` and `cacheIndex` on split `cacheable`

### DIFF
--- a/velox/connectors/hive/FileConnectorUtil.cpp
+++ b/velox/connectors/hive/FileConnectorUtil.cpp
@@ -108,9 +108,11 @@ void configureReaderOptions(
     readerOptions.setSelectiveNimbleReaderEnabled(
         connectorQueryCtx->selectiveNimbleReaderEnabled());
   }
-  readerOptions.setCacheMetadata(fileConfig->cacheMetadata(sessionProperties));
+  readerOptions.setCacheMetadata(
+      fileConfig->cacheMetadata(sessionProperties) && fileSplit->cacheable);
   readerOptions.setPinMetadata(fileConfig->pinMetadata(sessionProperties));
-  readerOptions.setCacheIndex(fileConfig->cacheIndex(sessionProperties));
+  readerOptions.setCacheIndex(
+      fileConfig->cacheIndex(sessionProperties) && fileSplit->cacheable);
   readerOptions.setPinIndex(fileConfig->pinIndex(sessionProperties));
 
   // Set footer speculative IO size based on file format.

--- a/velox/connectors/hive/tests/FileConnectorUtilTest.cpp
+++ b/velox/connectors/hive/tests/FileConnectorUtilTest.cpp
@@ -76,9 +76,16 @@ class FileConnectorUtilTest : public exec::test::HiveConnectorTestBase {
 
   std::shared_ptr<const hive::FileConnectorSplit> makeSplit(
       dwio::common::FileFormat format = dwio::common::FileFormat::DWRF,
-      const std::string& path = "/tmp/testfile") {
+      const std::string& path = "/tmp/testfile",
+      bool cacheable = true) {
     return std::make_shared<hive::FileConnectorSplit>(
-        "testConnectorId", path, format);
+        "testConnectorId",
+        path,
+        format,
+        /*_start=*/0,
+        /*_length=*/std::numeric_limits<uint64_t>::max(),
+        /*splitWeight=*/0,
+        cacheable);
   }
 
   std::string writeDataFile(const RowVectorPtr& data) {
@@ -173,6 +180,97 @@ TEST_F(FileConnectorUtilTest, configureReaderOptions) {
             /*tableParameters=*/{},
             readerOptions),
         "received splits of different formats");
+  }
+}
+
+TEST_F(FileConnectorUtilTest, cacheMetadataRequiresCacheableSplit) {
+  // When cache_metadata/cache_index session properties are enabled but the
+  // split is not cacheable (non-preferred node in soft affinity), metadata and
+  // index caching should be disabled to avoid polluting the cache with entries
+  // unlikely to be reused.
+  auto fileConfig = makeFileConfig();
+
+  // cache_metadata=true, cacheable split => cacheMetadata=true.
+  {
+    auto holder = makeConnectorQueryCtx(
+        {{hive::FileConfig::kCacheMetadataSession, "true"},
+         {hive::FileConfig::kCacheIndexSession, "true"}});
+    auto split = makeSplit(
+        dwio::common::FileFormat::NIMBLE, "/tmp/test", /*cacheable=*/true);
+    dwio::common::ReaderOptions readerOptions(pool_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
+    hive::configureReaderOptions(
+        fileConfig,
+        holder.ctx.get(),
+        /*fileSchema=*/nullptr,
+        split,
+        /*tableParameters=*/{},
+        readerOptions);
+    EXPECT_TRUE(readerOptions.cacheMetadata());
+    EXPECT_TRUE(readerOptions.cacheIndex());
+  }
+
+  // cache_metadata=true, non-cacheable split => cacheMetadata=false.
+  {
+    auto holder = makeConnectorQueryCtx(
+        {{hive::FileConfig::kCacheMetadataSession, "true"},
+         {hive::FileConfig::kCacheIndexSession, "true"}});
+    auto split = makeSplit(
+        dwio::common::FileFormat::NIMBLE, "/tmp/test", /*cacheable=*/false);
+    dwio::common::ReaderOptions readerOptions(pool_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
+    hive::configureReaderOptions(
+        fileConfig,
+        holder.ctx.get(),
+        /*fileSchema=*/nullptr,
+        split,
+        /*tableParameters=*/{},
+        readerOptions);
+    EXPECT_FALSE(readerOptions.cacheMetadata());
+    EXPECT_FALSE(readerOptions.cacheIndex());
+  }
+
+  // cache_metadata=false, cacheable split => cacheMetadata=false.
+  {
+    auto holder = makeConnectorQueryCtx();
+    auto split = makeSplit(
+        dwio::common::FileFormat::NIMBLE, "/tmp/test", /*cacheable=*/true);
+    dwio::common::ReaderOptions readerOptions(pool_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
+    hive::configureReaderOptions(
+        fileConfig,
+        holder.ctx.get(),
+        /*fileSchema=*/nullptr,
+        split,
+        /*tableParameters=*/{},
+        readerOptions);
+    EXPECT_FALSE(readerOptions.cacheMetadata());
+    EXPECT_FALSE(readerOptions.cacheIndex());
+  }
+
+  // pinMetadata/pinIndex are NOT gated on cacheable — they control per-reader
+  // in-process cache, not AsyncDataCache.
+  {
+    auto holder = makeConnectorQueryCtx(
+        {{hive::FileConfig::kPinMetadataSession, "true"},
+         {hive::FileConfig::kPinIndexSession, "true"}});
+    auto split = makeSplit(
+        dwio::common::FileFormat::NIMBLE, "/tmp/test", /*cacheable=*/false);
+    dwio::common::ReaderOptions readerOptions(pool_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
+    hive::configureReaderOptions(
+        fileConfig,
+        holder.ctx.get(),
+        /*fileSchema=*/nullptr,
+        split,
+        /*tableParameters=*/{},
+        readerOptions);
+    EXPECT_TRUE(readerOptions.pinMetadata());
+    EXPECT_TRUE(readerOptions.pinIndex());
   }
 }
 


### PR DESCRIPTION
Summary: Gate Nimble `cacheMetadata` and `cacheIndex` on `fileSplit->cacheable` so metadata/index are only cached in `AsyncDataCache` when the split is assigned to a preferred node via soft affinity. Non-cacheable splits are unlikely to revisit the same worker, so caching their metadata wastes cache space. `pinMetadata`/`pinIndex` are unaffected as they control per-reader in-process cache, not `AsyncDataCache`.

Differential Revision: D108930816


