### PR TITLE
feat: Make nimble_lazy_column_io a session-overridable config (#17871)

### DIFF
--- a/velox/connectors/hive/FileConfig.cpp
+++ b/velox/connectors/hive/FileConfig.cpp
@@ -34,13 +34,13 @@ const std::vector<config::ConfigProperty>& FileConfig::registeredProperties() {
     VELOX_HIVE_CONFIG_REGISTER(kNimbleFooterSpeculativeIoSizeSession);
     VELOX_HIVE_CONFIG_REGISTER(kNimbleStringDecoderZeroCopySession);
     VELOX_HIVE_CONFIG_REGISTER(kNimblePreserveDictionaryEncodingSession);
+    VELOX_HIVE_CONFIG_REGISTER(kNimbleLazyColumnIoSession);
     VELOX_HIVE_CONFIG_REGISTER(kFileColumnNamesReadAsLowerCaseSession);
     VELOX_HIVE_CONFIG_REGISTER(kIgnoreMissingFilesSession);
     VELOX_HIVE_CONFIG_REGISTER(kMaxCoalescedBytesSession);
     VELOX_HIVE_CONFIG_REGISTER(kLoadQuantumSession);
     VELOX_HIVE_CONFIG_REGISTER(kReadStatsBasedFilterReorderDisabledSession);
     VELOX_HIVE_CONFIG_REGISTER(kIndexEnabledSession);
-    VELOX_HIVE_CONFIG_REGISTER(kLazyColumnIoSession);
     VELOX_HIVE_CONFIG_REGISTER(kCacheMetadataSession);
     VELOX_HIVE_CONFIG_REGISTER(kPinMetadataSession);
     VELOX_HIVE_CONFIG_REGISTER(kCacheIndexSession);

--- a/velox/connectors/hive/FileConfig.h
+++ b/velox/connectors/hive/FileConfig.h
@@ -116,6 +116,16 @@ class FileConfig {
       false,
       "Preserve dictionary encoding for Nimble string column reads.")
 
+  VELOX_HIVE_CONFIG_LEGACY(
+      kNimbleLazyColumnIoSession,
+      kNimbleLazyColumnIo,
+      nimbleLazyColumnIo,
+      "nimble_lazy_column_io",
+      "nimble.lazy-column-io",
+      bool,
+      false,
+      "Defer I/O for projected columns without pushdown filters, remaining filters, or transforms.")
+
   // --- VELOX_HIVE_CONFIG properties ---
 
   VELOX_HIVE_CONFIG(
@@ -176,14 +186,6 @@ class FileConfig {
       false,
       "Use cluster index for filter-based row pruning.")
   static constexpr const char* kIndexEnabled = "index-enabled";
-
-  VELOX_HIVE_CONFIG(
-      kLazyColumnIoSession,
-      lazyColumnIo,
-      "nimble.lazy_column_io",
-      bool,
-      false,
-      "Defer I/O for projected columns without pushdown filters, remaining filters, or transforms.")
 
   VELOX_HIVE_CONFIG(
       kCacheMetadataSession,

--- a/velox/connectors/hive/FileConnectorUtil.cpp
+++ b/velox/connectors/hive/FileConnectorUtil.cpp
@@ -197,7 +197,7 @@ void configureRowReaderOptions(
     rowReaderOptions.setIndexEnabled(
         fileConfig->indexEnabled(sessionProperties));
     rowReaderOptions.setLazyColumnIo(
-        fileConfig->lazyColumnIo(sessionProperties));
+        fileConfig->nimbleLazyColumnIo(sessionProperties));
     rowReaderOptions.setCollectColumnCpuMetrics(
         fileConfig->readerCollectColumnCpuMetrics(sessionProperties));
   }

--- a/velox/connectors/hive/tests/FileConfigTest.cpp
+++ b/velox/connectors/hive/tests/FileConfigTest.cpp
@@ -56,6 +56,7 @@ TEST(FileConfigTest, defaultConfig) {
       config.nimbleFooterSpeculativeIoSize(emptySession.get()), 8UL << 20);
   EXPECT_FALSE(config.nimbleStringDecoderZeroCopy(emptySession.get()));
   EXPECT_FALSE(config.nimblePreserveDictionaryEncoding(emptySession.get()));
+  EXPECT_FALSE(config.nimbleLazyColumnIo(emptySession.get()));
 }
 
 TEST(FileConfigTest, overrideConfig) {
@@ -79,6 +80,7 @@ TEST(FileConfigTest, overrideConfig) {
       {FileConfig::kNimbleFooterSpeculativeIoSize, std::to_string(4UL << 20)},
       {FileConfig::kNimbleStringDecoderZeroCopy, "true"},
       {FileConfig::kNimblePreserveDictionaryEncoding, "true"},
+      {FileConfig::kNimbleLazyColumnIo, "true"},
   };
   FileConfig config(
       std::make_shared<config::ConfigBase>(std::move(configFromFile)), "hive.");
@@ -105,6 +107,7 @@ TEST(FileConfigTest, overrideConfig) {
       config.nimbleFooterSpeculativeIoSize(emptySession.get()), 4UL << 20);
   EXPECT_TRUE(config.nimbleStringDecoderZeroCopy(emptySession.get()));
   EXPECT_TRUE(config.nimblePreserveDictionaryEncoding(emptySession.get()));
+  EXPECT_TRUE(config.nimbleLazyColumnIo(emptySession.get()));
 }
 
 TEST(FileConfigTest, overrideSession) {
@@ -132,6 +135,7 @@ TEST(FileConfigTest, overrideSession) {
        std::to_string(2UL << 20)},
       {FileConfig::kNimbleStringDecoderZeroCopySession, "true"},
       {FileConfig::kNimblePreserveDictionaryEncodingSession, "true"},
+      {FileConfig::kNimbleLazyColumnIoSession, "true"},
   };
   const auto session =
       std::make_unique<config::ConfigBase>(std::move(sessionOverride));
@@ -153,6 +157,7 @@ TEST(FileConfigTest, overrideSession) {
   EXPECT_EQ(config.nimbleFooterSpeculativeIoSize(session.get()), 2UL << 20);
   EXPECT_TRUE(config.nimbleStringDecoderZeroCopy(session.get()));
   EXPECT_TRUE(config.nimblePreserveDictionaryEncoding(session.get()));
+  EXPECT_TRUE(config.nimbleLazyColumnIo(session.get()));
 }
 
 TEST(FileConfigTest, nullConfig) {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -1006,7 +1006,7 @@ must be specified as raw byte counts.
        of the file to load the footer and nearby metadata in a single IO operation.
        Set to 0 for adaptive mode.
    * - nimble.lazy-column-io
-     - nimble.lazy_column_io
+     - nimble_lazy_column_io
      - boolean
      - false
      - Lazy IO for Nimble projected columns without pushdown filters, remaining filters, or transforms.


### PR DESCRIPTION
Summary:

Convert lazy_column_io from VELOX_HIVE_CONFIG to VELOX_HIVE_CONFIG_LEGACY so it exposes a distinct session key (nimble_lazy_column_io) and connector config key
(nimble.lazy-column-io), grouped with the other Nimble LEGACY props, and rename
the C++ identifiers to the kNimble*/nimble* convention used by the sibling Nimble
configs. 

The catalog-config path (nimble.lazy-column-io) is unchanged.

Differential Revision: D108982523


