### PR TITLE
fix: Fix misleading "0B" in AsyncDataCache contiguous allocation failure message

### DIFF
--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -157,11 +157,12 @@ void AsyncDataCacheEntry::initialize(FileCacheKey key, bool contiguous) {
       cache->incrementCachedPages(memory::AllocationTraits::numPages(size_));
       return;
     }
+    const auto failedSize = size_;
     release();
     VELOX_CACHE_ERROR(
         fmt::format(
             "Failed to allocate {} for contiguous cache: {}",
-            succinctBytes(size_),
+            succinctBytes(failedSize),
             cache->allocator()->getAndClearFailureMessage()));
   }
 
@@ -171,11 +172,12 @@ void AsyncDataCacheEntry::initialize(FileCacheKey key, bool contiguous) {
     cache->incrementCachedPages(nonContiguousData().numPages());
     return;
   }
+  const auto failedPages = sizePages;
   release();
   VELOX_CACHE_ERROR(
       fmt::format(
           "Failed to allocate {} pages for cache: {}",
-          sizePages,
+          failedPages,
           cache->allocator()->getAndClearFailureMessage()));
 }
 


### PR DESCRIPTION
Summary:
CONTEXT: When `AsyncDataCacheEntry::initialize` fails to allocate contiguous memory, `release()` zeroes `size_` before the error format string reads it, producing a misleading "Failed to allocate 0B" message instead of the actual requested size.

WHAT: Capture `size_` (contiguous path) and `sizePages` (non-contiguous path) into local variables before calling `release()`, so the error message reports the correct allocation size.

Differential Revision: D109041626


