### PR TITLE
feat: Generate garbage data behind nulls in VectorFuzzer (#17878)

### DIFF
--- a/velox/vector/EncodedVectorCopy.cpp
+++ b/velox/vector/EncodedVectorCopy.cpp
@@ -945,6 +945,10 @@ void copyIntoFlatMapMutable(
         targetInMapsBuffer =
             AlignedBuffer::allocate<bool>(size, options.pool, false);
       }
+      if (targetInMapsBuffer->isView()) {
+        targetInMapsBuffer =
+            AlignedBuffer::copy(options.pool, targetInMapsBuffer);
+      }
       auto* targetInMaps = targetInMapsBuffer->asMutable<uint64_t>();
 
       applyToEachRange(

--- a/velox/vector/fuzzer/VectorFuzzer.cpp
+++ b/velox/vector/fuzzer/VectorFuzzer.cpp
@@ -681,13 +681,14 @@ VectorPtr VectorFuzzer::fuzzDictionary(const VectorPtr& vector) {
 VectorPtr VectorFuzzer::fuzzDictionary(
     const VectorPtr& vector,
     vector_size_t size) {
-  const size_t vectorSize = vector->size();
+  const vector_size_t vectorSize = vector->size();
   VELOX_CHECK(
       vectorSize > 0 || size == 0,
       "Cannot build a non-empty dictionary on an empty underlying vector");
-  BufferPtr indices = fuzzIndices(size, vectorSize);
 
   auto nulls = opts_.dictionaryHasNulls ? fuzzNulls(size) : nullptr;
+  BufferPtr indices =
+      fuzzIndices(size, vectorSize, nulls ? nulls->as<uint64_t>() : nullptr);
   return BaseVector::wrapInDictionary(nulls, indices, size, vector);
 }
 
@@ -695,7 +696,8 @@ void VectorFuzzer::fuzzOffsetsAndSizes(
     BufferPtr& offsets,
     BufferPtr& sizes,
     size_t elementsSize,
-    size_t size) {
+    size_t size,
+    const uint64_t* rawNullsForGarbage) {
   offsets = allocateOffsets(size, pool_);
   sizes = allocateSizes(size, pool_);
   auto rawOffsets = offsets->asMutable<vector_size_t>();
@@ -704,8 +706,18 @@ void VectorFuzzer::fuzzOffsetsAndSizes(
   size_t containerAvgLength = std::max(elementsSize / size, 1UL);
   size_t childSize = 0;
   size_t length = 0;
+  const auto bound = static_cast<vector_size_t>(elementsSize);
 
   for (auto i = 0; i < size; ++i) {
+    if (rawNullsForGarbage != nullptr &&
+        bits::isBitNull(rawNullsForGarbage, i)) {
+      // Null rows get out-of-range offsets/sizes so any read behind the null
+      // is out of bounds.
+      rawOffsets[i] = rand<vector_size_t>(rng_, bound + 1, 2 * bound + 1);
+      rawSizes[i] = rand<vector_size_t>(rng_, 1, bound + 1);
+      continue;
+    }
+
     rawOffsets[i] = childSize;
 
     // If variable length, generate a random number between zero and 2 *
@@ -740,23 +752,24 @@ ArrayVectorPtr VectorFuzzer::fuzzArray(
 ArrayVectorPtr VectorFuzzer::fuzzArray(
     const VectorPtr& elements,
     vector_size_t size) {
+  auto nulls = fuzzNulls(size);
   BufferPtr offsets, sizes;
-  fuzzOffsetsAndSizes(offsets, sizes, elements->size(), size);
-  return std::make_shared<ArrayVector>(
-      pool_,
-      ARRAY(elements->type()),
-      fuzzNulls(size),
-      size,
+  fuzzOffsetsAndSizes(
       offsets,
       sizes,
-      elements);
+      elements->size(),
+      size,
+      nulls ? nulls->as<uint64_t>() : nullptr);
+  return std::make_shared<ArrayVector>(
+      pool_, ARRAY(elements->type()), nulls, size, offsets, sizes, elements);
 }
 
 VectorPtr VectorFuzzer::normalizeMapKeys(
     const VectorPtr& keys,
     size_t mapSize,
     BufferPtr& offsets,
-    BufferPtr& sizes) {
+    BufferPtr& sizes,
+    const uint64_t* rawNulls) {
   // Map keys cannot be null.
   const auto& nulls = keys->nulls();
   if (nulls) {
@@ -772,6 +785,12 @@ VectorPtr VectorFuzzer::normalizeMapKeys(
   // Looks for duplicate key values.
   std::unordered_set<uint64_t> set;
   for (size_t i = 0; i < mapSize; ++i) {
+    // Null rows carry out-of-range garbage offsets/sizes; skip them so we
+    // never dereference out-of-range positions.
+    if (rawNulls != nullptr &&
+        bits::isBitNull(rawNulls, static_cast<uint32_t>(i))) {
+      continue;
+    }
     set.clear();
 
     for (size_t j = 0; j < rawSizes[i]; ++j) {
@@ -797,17 +816,22 @@ MapVectorPtr VectorFuzzer::fuzzMap(
     const VectorPtr& values,
     vector_size_t size) {
   size_t elementsSize = std::min(keys->size(), values->size());
+  auto nulls = fuzzNulls(size);
+  const uint64_t* rawNulls = nulls ? nulls->as<uint64_t>() : nullptr;
   BufferPtr offsets, sizes;
-  fuzzOffsetsAndSizes(offsets, sizes, elementsSize, size);
+  fuzzOffsetsAndSizes(offsets, sizes, elementsSize, size, rawNulls);
+  auto mapKeys = keys;
+  if (opts_.normalizeMapKeys) {
+    mapKeys = normalizeMapKeys(keys, size, offsets, sizes, rawNulls);
+  }
   return std::make_shared<MapVector>(
       pool_,
       MAP(keys->type(), values->type()),
-      fuzzNulls(size),
+      nulls,
       size,
       offsets,
       sizes,
-      opts_.normalizeMapKeys ? normalizeMapKeys(keys, size, offsets, sizes)
-                             : keys,
+      std::move(mapKeys),
       values);
 }
 
@@ -992,13 +1016,22 @@ BufferPtr VectorFuzzer::fuzzNulls(vector_size_t size) {
 
 BufferPtr VectorFuzzer::fuzzIndices(
     vector_size_t size,
-    vector_size_t baseVectorSize) {
+    vector_size_t baseVectorSize,
+    const uint64_t* rawNullsForGarbage) {
   VELOX_CHECK_GE(size, 0);
   BufferPtr indices = AlignedBuffer::allocate<vector_size_t>(size, pool_);
   auto rawIndices = indices->asMutable<vector_size_t>();
 
   for (size_t i = 0; i < size; ++i) {
-    rawIndices[i] = rand<vector_size_t>(rng_) % baseVectorSize;
+    if (rawNullsForGarbage != nullptr &&
+        bits::isBitNull(rawNullsForGarbage, static_cast<uint32_t>(i))) {
+      // Out-of-range index (>= baseVectorSize) so a read behind the null is out
+      // of bounds.
+      rawIndices[i] =
+          rand<vector_size_t>(rng_, baseVectorSize, 2 * baseVectorSize - 1);
+    } else {
+      rawIndices[i] = rand<vector_size_t>(rng_) % baseVectorSize;
+    }
   }
   return indices;
 }

--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -421,8 +421,12 @@ class VectorFuzzer {
   BufferPtr fuzzNulls(vector_size_t size);
 
   /// Generate a random indices buffer of 'size' with maximum possible index
-  /// pointing to (baseVectorSize-1).
-  BufferPtr fuzzIndices(vector_size_t size, vector_size_t baseVectorSize);
+  /// pointing to (baseVectorSize-1). If 'rawNullsForGarbage' is non-null,
+  /// null rows get out-of-range indices so reads behind a null are caught.
+  BufferPtr fuzzIndices(
+      vector_size_t size,
+      vector_size_t baseVectorSize,
+      const uint64_t* rawNullsForGarbage = nullptr);
 
   /// Generate a random inMap buffer (for use with flat map vectors) of 'size'
   /// number of rows. This should randomize the keys per row in the map.
@@ -458,21 +462,27 @@ class VectorFuzzer {
   // flat.
   VectorPtr fuzzComplex(const TypePtr& type, vector_size_t size);
 
+  // When 'rawNullsForGarbage' is non-null, null rows get out-of-range
+  // offsets/sizes instead of consuming elements.
   void fuzzOffsetsAndSizes(
       BufferPtr& offsets,
       BufferPtr& sizes,
       size_t elementsSize,
-      size_t size);
+      size_t size,
+      const uint64_t* rawNullsForGarbage);
 
   // Normalize a vector to be used as map key.
   // For each map element, if duplicate key values are found, remove them (and
   // any subsequent key values) by cutting the map short (reducing its size).
-  // Throws if the keys vector contains null values.
+  // Throws if the keys vector contains null values. Rows that are null in
+  // 'rawNulls' (when non-null) are skipped, since their offsets/sizes may be
+  // out-of-range garbage.
   VectorPtr normalizeMapKeys(
       const VectorPtr& keys,
       size_t mapSize,
       BufferPtr& offsets,
-      BufferPtr& sizes);
+      BufferPtr& sizes,
+      const uint64_t* rawNulls);
 
   VectorFuzzer::Options opts_;
 

--- a/velox/vector/fuzzer/tests/VectorFuzzerTest.cpp
+++ b/velox/vector/fuzzer/tests/VectorFuzzerTest.cpp
@@ -69,7 +69,10 @@ class VectorFuzzerTest : public testing::Test {
 
     std::unordered_map<uint64_t, vector_size_t> map;
 
-    for (size_t i = 0; i < mapVector->size(); ++i) {
+    for (vector_size_t i = 0; i < mapVector->size(); ++i) {
+      if (mapVector->isNullAt(i)) {
+        continue;
+      }
       vector_size_t offset = mapVector->offsetAt(i);
       map.clear();
 
@@ -446,6 +449,107 @@ TEST_F(VectorFuzzerTest, array) {
   checkElementSize(kElementMaxSize);
   checkElementSize(kElementMaxSize - 70);
   checkElementSize(kElementMaxSize + 50);
+}
+
+TEST_F(VectorFuzzerTest, fuzzDataBehindNulls) {
+  // Null rows of arrays/maps/dictionaries carry out-of-range "garbage"
+  // offsets/sizes/indices, while the vector still passes validate() (which
+  // skips null rows).
+  constexpr vector_size_t kSize = 200;
+
+  auto arrayRowInRange = [](const ArrayVectorBase* arrayVector,
+                            vector_size_t i,
+                            int64_t elementsSize) {
+    const int64_t offset = arrayVector->offsetAt(i);
+    const int64_t size = arrayVector->sizeAt(i);
+    return offset >= 0 && size >= 0 && offset + size <= elementsSize;
+  };
+
+  // Arrays: every null row must carry out-of-range offsets/sizes.
+  {
+    VectorFuzzer::Options opts;
+    opts.nullRatio = 0.5;
+    VectorFuzzer fuzzer(opts, pool());
+
+    auto vector = fuzzer.fuzzArray(fuzzer.fuzzFlat(BIGINT(), kSize), kSize);
+    ASSERT_NO_THROW(vector->validate({}));
+
+    auto* arrayVector = vector->as<ArrayVector>();
+    const int64_t elementsSize = arrayVector->elements()->size();
+    bool sawNull = false;
+    for (vector_size_t i = 0; i < kSize; ++i) {
+      if (arrayVector->isNullAt(i)) {
+        sawNull = true;
+        EXPECT_FALSE(arrayRowInRange(arrayVector, i, elementsSize))
+            << "null row " << i << " should have out-of-range offset/size";
+      } else {
+        EXPECT_TRUE(arrayRowInRange(arrayVector, i, elementsSize));
+      }
+    }
+    EXPECT_TRUE(sawNull);
+  }
+
+  // Maps (also exercises normalizeMapKeys skipping null rows with garbage
+  // offsets/sizes): every null row must carry out-of-range offsets/sizes.
+  {
+    VectorFuzzer::Options opts;
+    opts.nullRatio = 0.5;
+    opts.normalizeMapKeys = true;
+    VectorFuzzer fuzzer(opts, pool());
+
+    auto vector = fuzzer.fuzzMap(
+        fuzzer.fuzzFlatNotNull(BIGINT(), kSize),
+        fuzzer.fuzzFlat(BIGINT(), kSize),
+        kSize);
+    ASSERT_NO_THROW(vector->validate({}));
+
+    auto* mapVector = vector->as<MapVector>();
+    const int64_t elementsSize =
+        std::min(mapVector->mapKeys()->size(), mapVector->mapValues()->size());
+    bool sawNull = false;
+    for (vector_size_t i = 0; i < kSize; ++i) {
+      if (mapVector->isNullAt(i)) {
+        sawNull = true;
+        EXPECT_FALSE(arrayRowInRange(mapVector, i, elementsSize))
+            << "null row " << i << " should have out-of-range offset/size";
+      }
+    }
+    EXPECT_TRUE(sawNull);
+  }
+
+  // Dictionaries: every row that is null in the dictionary's own (wrapper)
+  // nulls buffer must carry an out-of-range index. We check the wrapper nulls
+  // directly rather than isNullAt(), because isNullAt() also reports rows whose
+  // valid in-range index points at a null base element -- a different,
+  // legitimate kind of null that carries no garbage index.
+  {
+    VectorFuzzer::Options opts;
+    opts.nullRatio = 0.5;
+    opts.dictionaryHasNulls = true;
+    VectorFuzzer fuzzer(opts, pool());
+
+    auto vector =
+        fuzzer.fuzzDictionary(fuzzer.fuzzFlat(BIGINT(), kSize), kSize);
+    ASSERT_NO_THROW(vector->validate({}));
+
+    auto* dictionary = vector->as<DictionaryVector<int64_t>>();
+    ASSERT_TRUE(dictionary != nullptr);
+    const auto* rawIndices = dictionary->indices()->as<vector_size_t>();
+    const uint64_t* rawNulls = dictionary->rawNulls();
+    ASSERT_TRUE(rawNulls != nullptr);
+    bool sawNull = false;
+    for (vector_size_t i = 0; i < kSize; ++i) {
+      if (bits::isBitNull(rawNulls, i)) {
+        sawNull = true;
+        EXPECT_GE(rawIndices[i], kSize)
+            << "null row " << i << " should have an out-of-range index";
+      } else {
+        EXPECT_GE(rawIndices[i], 0);
+        EXPECT_LT(rawIndices[i], kSize);
+      }
+    }
+    EXPECT_TRUE(sawNull);
+  }
 }
 
 TEST_F(VectorFuzzerTest, map) {

--- a/velox/vector/tests/EncodedVectorCopyTest.cpp
+++ b/velox/vector/tests/EncodedVectorCopyTest.cpp
@@ -681,6 +681,13 @@ TEST_P(EncodedVectorCopyTest, flatMapVector) {
   }
 }
 
+namespace {
+struct InMapViewReleaser {
+  void addRef() {}
+  void release() {}
+};
+} // namespace
+
 /// Tests copying into an existing FlatMapVector target.
 TEST_P(EncodedVectorCopyTest, flatMapVectorCopyInto) {
   {
@@ -835,6 +842,58 @@ TEST_P(EncodedVectorCopyTest, flatMapVectorCopyInto) {
     auto expected = makeMapVector<int64_t, int64_t>({
         {{1, 10}, {2, 20}},
         {{2, 200}, {3, 300}},
+    });
+    test::assertEqualVectors(expected, target);
+  }
+
+  {
+    SCOPED_TRACE("Copy into different keys with view inMaps buffers");
+    using InMapView = BufferView<InMapViewReleaser&>;
+    static InMapViewReleaser releaser;
+
+    auto mapType = MAP(BIGINT(), BIGINT());
+    auto distinctKeys = makeFlatVector<int64_t>({1, 2});
+    vector_size_t size = 3;
+
+    std::vector<BufferPtr> ownedInMaps;
+    std::vector<BufferPtr> viewInMaps;
+    for (int i = 0; i < 2; ++i) {
+      auto owned =
+          AlignedBuffer::allocate<bool>(size, pool(), /*initValue=*/true);
+      auto view = InMapView::create(owned, releaser);
+      ownedInMaps.push_back(std::move(owned));
+      viewInMaps.push_back(std::move(view));
+    }
+
+    std::vector<VectorPtr> targetValues;
+    targetValues.push_back(makeFlatVector<int64_t>({10, 20, 30}));
+    targetValues.push_back(makeFlatVector<int64_t>({40, 50, 60}));
+
+    VectorPtr target = std::make_shared<FlatMapVector>(
+        pool(),
+        mapType,
+        nullptr,
+        size,
+        distinctKeys,
+        std::move(targetValues),
+        std::move(viewInMaps));
+
+    auto* targetFlatMap = target->asChecked<FlatMapVector>();
+    ASSERT_TRUE(targetFlatMap->inMapsAt(0)->isView());
+    ASSERT_TRUE(targetFlatMap->inMapsAt(1)->isView());
+
+    auto source = vectorMaker_.flatMapVector<int64_t, int64_t>({
+        {{3, 300}},
+        {{3, 400}},
+    });
+
+    BaseVector::CopyRange range = {0, 0, 2};
+    copy(source, folly::Range(&range, 1), target);
+
+    auto expected = makeMapVector<int64_t, int64_t>({
+        {{3, 300}},
+        {{3, 400}},
+        {{1, 30}, {2, 60}},
     });
     test::assertEqualVectors(expected, target);
   }


### PR DESCRIPTION
Summary:

VectorFuzzer can now optionally write garbage data behind NULL rows to catch expressions that incorrectly read null-masked values. When `fuzzDataBehindNulls` is enabled, array/map null rows get out-of-range offsets and sizes, dictionary null rows get out-of-range indices, and ASan will trip if any UDF dereferences them. Flat primitives already get random data at every position, so no change needed. The expression fuzzer exposes this via `--velox_fuzzer_data_behind_nulls`.

Reviewed By: kgpai

Differential Revision: D108452341


