### PR TITLE
feat: Collect per-column statistics for DWRF/ORC Iceberg writes (#17881)

### DIFF
--- a/velox/connectors/hive/iceberg/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/CMakeLists.txt
@@ -23,11 +23,13 @@ set(
   IcebergDataSink.cpp
   IcebergDataSource.cpp
   IcebergDeletionVectorSink.cpp
+  IcebergDwrfStatsCollector.cpp
   IcebergMergeProcessor.cpp
   IcebergMergeSink.cpp
   IcebergPartitionName.cpp
   IcebergSplit.cpp
   IcebergSplitReader.cpp
+  IcebergStatsCollector.cpp
   PartitionSpec.cpp
   PositionalDeleteFileReader.cpp
   TransformEvaluator.cpp
@@ -54,6 +56,7 @@ velox_add_library(
   IcebergDataSource.h
   IcebergDeleteFile.h
   IcebergDeletionVectorSink.h
+  IcebergDwrfStatsCollector.h
   IcebergMergeProcessor.h
   IcebergMergeSink.h
   IcebergMetadataColumns.h
@@ -61,6 +64,7 @@ velox_add_library(
   IcebergPartitionName.h
   IcebergSplit.h
   IcebergSplitReader.h
+  IcebergStatsCollector.h
   PartitionSpec.h
   PositionalDeleteFileReader.h
   TransformEvaluator.h

--- a/velox/connectors/hive/iceberg/IcebergDataSink.cpp
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.cpp
@@ -31,6 +31,7 @@
 #include "velox/common/testutil/TestValue.h"
 #include "velox/connectors/hive/PartitionIdGenerator.h"
 #include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
+#include "velox/connectors/hive/iceberg/IcebergStatsCollector.h"
 
 #ifdef VELOX_ENABLE_PARQUET
 #include "velox/connectors/hive/iceberg/IcebergParquetStatsCollector.h"
@@ -40,6 +41,8 @@
 #include "velox/connectors/hive/iceberg/TransformExprBuilder.h"
 #include "velox/connectors/hive/iceberg/WriterOptionsAdapter.h"
 #include "velox/dwio/common/TypeWithId.h"
+#include "velox/dwio/dwrf/common/Config.h"
+#include "velox/dwio/dwrf/common/Statistics.h"
 #include "velox/dwio/dwrf/writer/Writer.h"
 #include "velox/exec/OperatorUtils.h"
 #include "velox/type/Type.h"
@@ -280,53 +283,6 @@ folly::dynamic buildIcebergCommitData(
   return commitData;
 }
 
-// Recursively records the "iceberg.id" attribute for 'node' and its
-// descendants, keyed by pre-order schema node id (matching the DWRF writer's
-// footer node ids). 'fieldId' is the field-id tree aligned to 'node'.
-void stampFieldIdAttributes(
-    const dwio::common::TypeWithId& node,
-    const dwio::common::ParquetFieldId& fieldId,
-    std::unordered_map<
-        uint32_t,
-        std::vector<std::pair<std::string, std::string>>>& attributes) {
-  attributes[node.id()] = {{"iceberg.id", std::to_string(fieldId.fieldId)}};
-  const auto numChildren =
-      std::min<size_t>(node.size(), fieldId.children.size());
-  for (size_t i = 0; i < numChildren; ++i) {
-    stampFieldIdAttributes(
-        *node.childAt(static_cast<uint32_t>(i)),
-        fieldId.children.at(i),
-        attributes);
-  }
-}
-
-// Builds the per-node "iceberg.id" attribute map for the DWRF writer from the
-// Iceberg input column handles, aligned to 'schema' (the written row type).
-std::unordered_map<uint32_t, std::vector<std::pair<std::string, std::string>>>
-buildDwrfSchemaAttributes(
-    const RowTypePtr& schema,
-    const std::vector<std::shared_ptr<const HiveColumnHandle>>& inputColumns) {
-  std::unordered_map<uint32_t, std::vector<std::pair<std::string, std::string>>>
-      attributes;
-  if (schema == nullptr) {
-    return attributes;
-  }
-  const auto schemaWithId = dwio::common::TypeWithId::create(schema);
-  const auto numColumns =
-      std::min<size_t>(schemaWithId->size(), inputColumns.size());
-  for (size_t i = 0; i < numColumns; ++i) {
-    const auto icebergHandle =
-        std::dynamic_pointer_cast<const IcebergColumnHandle>(inputColumns[i]);
-    if (icebergHandle != nullptr) {
-      stampFieldIdAttributes(
-          *schemaWithId->childAt(static_cast<uint32_t>(i)),
-          icebergHandle->field(),
-          attributes);
-    }
-  }
-  return attributes;
-}
-
 } // namespace
 
 IcebergDataSink::IcebergDataSink(
@@ -403,19 +359,19 @@ IcebergDataSink::IcebergDataSink(
       icebergInsertTableHandle_(insertTableHandle) {
   commitPartitionValue_.resize(maxOpenWriters_);
 
-#ifdef VELOX_ENABLE_PARQUET
-  // Only initialize Parquet stats collector for Parquet format tables
-  if (insertTableHandle->storageFormat() == dwio::common::FileFormat::PARQUET) {
-    std::vector<IcebergColumnHandlePtr> columnHandles;
-    columnHandles.reserve(insertTableHandle->inputColumns().size());
-    for (auto& column : insertTableHandle->inputColumns()) {
-      columnHandles.emplace_back(
-          checkedPointerCast<const IcebergColumnHandle>(column));
-    }
-    parquetStatsCollector_ = std::make_shared<IcebergParquetStatsCollector>(
-        std::move(columnHandles));
+  // Build the column handle list once for whichever format-specific stats
+  // collector applies.
+  std::vector<IcebergColumnHandlePtr> columnHandles;
+  columnHandles.reserve(insertTableHandle->inputColumns().size());
+  for (auto& column : insertTableHandle->inputColumns()) {
+    columnHandles.emplace_back(
+        checkedPointerCast<const IcebergColumnHandle>(column));
   }
-#endif
+
+  // Statistics extraction and field-id wiring are format-specific; the factory
+  // returns the matching collector, or nullptr for formats without support.
+  statsCollector_ = IcebergStatsCollector::create(
+      insertTableHandle->storageFormat(), columnHandles, inputType_);
 }
 
 std::vector<std::string> IcebergDataSink::commitMessage() const {
@@ -504,25 +460,10 @@ IcebergDataSink::createWriterOptions(size_t writerIndex) const {
     adapter->applyPreConfigs(*options);
   }
 
-#ifdef VELOX_ENABLE_PARQUET
-  // Iceberg-runtime stats collector is not a static config; wire it inline.
-  if (auto parquetOptions =
-          std::dynamic_pointer_cast<parquet::WriterOptions>(options)) {
-    if (parquetStatsCollector_) {
-      parquetOptions->parquetFieldIds =
-          parquetStatsCollector_->parquetFieldIds().children;
-    }
-  }
-#endif
-
-  // For DWRF/ORC, Iceberg field ids are carried as per-type "iceberg.id"
-  // attributes stamped into the footer. Build the per-node attribute map from
-  // the input column handles so the reader can resolve columns by field id.
-  if (auto dwrfOptions =
-          std::dynamic_pointer_cast<dwrf::WriterOptions>(options)) {
-    dwrfOptions->schemaAttributes = buildDwrfSchemaAttributes(
-        std::dynamic_pointer_cast<const RowType>(dwrfOptions->schema),
-        icebergInsertTableHandle_->inputColumns());
+  // Wire Iceberg field ids into the writer options. The collector applies the
+  // wiring only when 'options' matches its format and is a no-op otherwise.
+  if (statsCollector_ != nullptr) {
+    statsCollector_->configureWriterOptions(*options);
   }
 
   options->processConfigs(
@@ -561,19 +502,22 @@ void IcebergDataSink::closeWriterAndCollectStats(size_t index) {
   if (!fileAdded) {
     return;
   }
-#ifdef VELOX_ENABLE_PARQUET
-  if (parquetStatsCollector_) {
-    dataFileStats_[index].emplace_back(
-        parquetStatsCollector_->aggregate(std::move(metadata)));
-    return;
+  // Collect format-specific per-file statistics: DWRF/ORC read the live
+  // writer's footer, Parquet consumes the close() metadata. A null result
+  // falls through to the row-count-only estimate below.
+  if (statsCollector_ != nullptr) {
+    if (auto stats = statsCollector_->collect(*writers_[index], metadata)) {
+      dataFileStats_[index].emplace_back(std::move(stats));
+      return;
+    }
   }
-#endif
-  // ORC/DWRF (and any other format without a stats collector) path: we don't
-  // have file-level metadata that exposes row count, so derive it from
-  // writerInfo_->numWrittenRows. That counter accumulates across all files
-  // written by this writer (rotated files included), so compute per-file
-  // recordCount as the delta since the previous closeWriterAndCollectStats
-  // call for this writer index.
+
+  // Fallback path for any format without a usable stats collector or footer
+  // (e.g. ORC written by a non-dwrf writer): we don't have file-level metadata
+  // that exposes row count, so derive it from writerInfo_->numWrittenRows. That
+  // counter accumulates across all files written by this writer (rotated files
+  // included), so compute per-file recordCount as the delta since the previous
+  // closeWriterAndCollectStats call for this writer index.
   //
   // Without this, the manifest writes recordCount=0 for every DWRF/ORC file,
   // which makes the DELETE/UPDATE/MERGE planner believe each file is empty
@@ -587,10 +531,9 @@ void IcebergDataSink::closeWriterAndCollectStats(size_t index) {
 
   auto stats = std::make_shared<IcebergDataFileStatistics>();
   stats->numRecords = thisFileRows;
-  // Column-level stats (min/max/null counts) are still empty here. That only
-  // degrades predicate pruning (a perf optimization), not correctness. The
-  // proper fix is to add an IcebergDwrfStatsCollector that mirrors the
-  // Parquet path and consumes per-stripe stats from the DWRF writer footer.
+  // Column-level stats (min/max/null counts) are empty on this fallback path.
+  // That only degrades predicate pruning (a perf optimization), not
+  // correctness.
   dataFileStats_[index].emplace_back(std::move(stats));
 }
 

--- a/velox/connectors/hive/iceberg/IcebergDataSink.h
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.h
@@ -25,10 +25,7 @@
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
 #include "velox/connectors/hive/iceberg/IcebergDataFileStatistics.h"
-
-#ifdef VELOX_ENABLE_PARQUET
-#include "velox/connectors/hive/iceberg/IcebergParquetStatsCollector.h"
-#endif
+#include "velox/connectors/hive/iceberg/IcebergStatsCollector.h"
 
 #include "velox/connectors/hive/iceberg/IcebergConfig.h"
 #include "velox/connectors/hive/iceberg/IcebergPartitionName.h"
@@ -298,9 +295,11 @@ class IcebergDataSink : public HiveDataSink {
 
   const IcebergInsertTableHandlePtr icebergInsertTableHandle_;
 
-#ifdef VELOX_ENABLE_PARQUET
-  std::shared_ptr<IcebergParquetStatsCollector> parquetStatsCollector_;
-#endif
+  // Collects per-file Iceberg column statistics and wires Iceberg field ids
+  // into the writer options. Polymorphic over the table's file format; created
+  // via IcebergStatsCollector::create() and reused across all writers. Null
+  // when the format has no Iceberg statistics support compiled in.
+  std::shared_ptr<IcebergStatsCollector> statsCollector_;
 };
 
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergDwrfStatsCollector.cpp
+++ b/velox/connectors/hive/iceberg/IcebergDwrfStatsCollector.cpp
@@ -1,0 +1,483 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/IcebergDwrfStatsCollector.h"
+
+#include <array>
+#include <cstring>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/encode/Base64.h"
+#include "velox/dwio/common/Statistics.h"
+#include "velox/dwio/dwrf/common/Config.h"
+#include "velox/dwio/dwrf/common/FileMetadata.h"
+#include "velox/dwio/dwrf/common/Statistics.h"
+#include "velox/dwio/dwrf/writer/Writer.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+namespace {
+
+// Recursively inserts 'field' and all of its descendant field ids.
+void addAllRecursive(
+    const parquet::ParquetFieldId& field,
+    const TypePtr& type,
+    folly::F14FastSet<int32_t>& fieldIds) {
+  fieldIds.insert(field.fieldId);
+  const auto numChildren =
+      std::min<size_t>(field.children.size(), type->size());
+  for (size_t i = 0; i < numChildren; ++i) {
+    addAllRecursive(
+        field.children.at(i),
+        type->childAt(static_cast<uint32_t>(i)),
+        fieldIds);
+  }
+}
+
+// Collects the field ids that should skip bounds collection: MAP and ARRAY
+// types and all of their descendants (Iceberg does not store bounds for
+// repeated types). Mirrors
+// IcebergParquetStatsCollector::collectSkipBoundsFieldIds.
+void collectSkipBoundsFieldIds(
+    const parquet::ParquetFieldId& field,
+    const TypePtr& type,
+    folly::F14FastSet<int32_t>& fieldIds) {
+  VELOX_CHECK_NOT_NULL(type, "Input column type cannot be null.");
+
+  if (type->isMap() || type->isArray()) {
+    addAllRecursive(field, type, fieldIds);
+    return;
+  }
+
+  const auto numChildren =
+      std::min<size_t>(field.children.size(), type->size());
+  for (size_t i = 0; i < numChildren; ++i) {
+    collectSkipBoundsFieldIds(
+        field.children.at(i),
+        type->childAt(static_cast<uint32_t>(i)),
+        fieldIds);
+  }
+}
+
+// Serializes an integer as 'numBytes' little-endian two's-complement bytes.
+std::string encodeLittleEndian(int64_t value, int32_t numBytes) {
+  std::string out(numBytes, '\0');
+  auto bits = static_cast<uint64_t>(value);
+  for (int32_t i = 0; i < numBytes; ++i) {
+    out[i] = static_cast<char>((bits >> (8 * i)) & 0xFF);
+  }
+  return out;
+}
+
+// Serializes a float as 4-byte little-endian IEEE-754.
+std::string encodeFloatLittleEndian(float value) {
+  uint32_t bits;
+  std::memcpy(&bits, &value, sizeof(bits));
+  std::string out(4, '\0');
+  for (int32_t i = 0; i < 4; ++i) {
+    out[i] = static_cast<char>((bits >> (8 * i)) & 0xFF);
+  }
+  return out;
+}
+
+// Serializes a double as 8-byte little-endian IEEE-754.
+std::string encodeDoubleLittleEndian(double value) {
+  uint64_t bits;
+  std::memcpy(&bits, &value, sizeof(bits));
+  std::string out(8, '\0');
+  for (int32_t i = 0; i < 8; ++i) {
+    out[i] = static_cast<char>((bits >> (8 * i)) & 0xFF);
+  }
+  return out;
+}
+
+// Serializes an unscaled decimal as the minimal-length big-endian two's
+// complement byte array required by the Iceberg single-value spec.
+std::string encodeDecimalBigEndian(int128_t value) {
+  std::array<uint8_t, 16> bytes{};
+  auto bits = static_cast<__uint128_t>(value);
+  for (int32_t i = 15; i >= 0; --i) {
+    bytes[i] = static_cast<uint8_t>(bits & 0xFF);
+    bits >>= 8;
+  }
+
+  const bool negative = value < 0;
+  const uint8_t pad = negative ? 0xFF : 0x00;
+  // Trim redundant leading sign bytes while preserving the sign bit.
+  size_t start = 0;
+  while (start < 15) {
+    const bool nextSignBitSet = (bytes[start + 1] & 0x80) != 0;
+    if (bytes[start] == pad && nextSignBitSet == negative) {
+      ++start;
+    } else {
+      break;
+    }
+  }
+  return std::string(
+      reinterpret_cast<const char*>(bytes.data() + start), 16 - start);
+}
+
+// Decodes a UTF-8 string into Unicode code points.
+std::vector<char32_t> utf8Decode(std::string_view input) {
+  std::vector<char32_t> codePoints;
+  size_t i = 0;
+  while (i < input.size()) {
+    const auto byte = static_cast<unsigned char>(input[i]);
+    size_t length = 1;
+    char32_t codePoint = byte;
+    if (byte >= 0xF0) {
+      length = 4;
+      codePoint = byte & 0x07;
+    } else if (byte >= 0xE0) {
+      length = 3;
+      codePoint = byte & 0x0F;
+    } else if (byte >= 0xC0) {
+      length = 2;
+      codePoint = byte & 0x1F;
+    }
+    for (size_t j = 1; j < length && i + j < input.size(); ++j) {
+      codePoint =
+          (codePoint << 6) | (static_cast<unsigned char>(input[i + j]) & 0x3F);
+    }
+    codePoints.push_back(codePoint);
+    i += length;
+  }
+  return codePoints;
+}
+
+// Encodes Unicode code points into a UTF-8 string.
+std::string utf8Encode(const std::vector<char32_t>& codePoints) {
+  std::string out;
+  for (const auto codePoint : codePoints) {
+    if (codePoint < 0x80) {
+      out.push_back(static_cast<char>(codePoint));
+    } else if (codePoint < 0x800) {
+      out.push_back(static_cast<char>(0xC0 | (codePoint >> 6)));
+      out.push_back(static_cast<char>(0x80 | (codePoint & 0x3F)));
+    } else if (codePoint < 0x10000) {
+      out.push_back(static_cast<char>(0xE0 | (codePoint >> 12)));
+      out.push_back(static_cast<char>(0x80 | ((codePoint >> 6) & 0x3F)));
+      out.push_back(static_cast<char>(0x80 | (codePoint & 0x3F)));
+    } else {
+      out.push_back(static_cast<char>(0xF0 | (codePoint >> 18)));
+      out.push_back(static_cast<char>(0x80 | ((codePoint >> 12) & 0x3F)));
+      out.push_back(static_cast<char>(0x80 | ((codePoint >> 6) & 0x3F)));
+      out.push_back(static_cast<char>(0x80 | (codePoint & 0x3F)));
+    }
+  }
+  return out;
+}
+
+constexpr char32_t kMaxCodePoint{0x10FFFF};
+constexpr char32_t kSurrogateLow{0xD800};
+constexpr char32_t kSurrogateHigh{0xDFFF};
+
+// Truncates a lower bound to at most 'maxCodePoints' code points. A prefix of a
+// string sorts before the full string, so simple truncation yields a valid
+// (<= actual minimum) lower bound.
+std::string truncateLowerBound(std::string_view value, int32_t maxCodePoints) {
+  auto codePoints = utf8Decode(value);
+  if (static_cast<int32_t>(codePoints.size()) <= maxCodePoints) {
+    return std::string(value);
+  }
+  codePoints.resize(maxCodePoints);
+  return utf8Encode(codePoints);
+}
+
+// Truncates an upper bound to at most 'maxCodePoints' code points, then rounds
+// up so the result remains >= the actual maximum. Returns nullopt when the
+// value cannot be rounded up (all leading code points are the max code point),
+// in which case the upper bound is omitted. Matches Iceberg's
+// UnicodeUtil.truncateStringMax behavior.
+std::optional<std::string> truncateUpperBound(
+    std::string_view value,
+    int32_t maxCodePoints) {
+  auto codePoints = utf8Decode(value);
+  if (static_cast<int32_t>(codePoints.size()) <= maxCodePoints) {
+    return std::string(value);
+  }
+  codePoints.resize(maxCodePoints);
+  for (int32_t i = maxCodePoints - 1; i >= 0; --i) {
+    if (codePoints[i] < kMaxCodePoint) {
+      ++codePoints[i];
+      if (codePoints[i] >= kSurrogateLow && codePoints[i] <= kSurrogateHigh) {
+        codePoints[i] = kSurrogateHigh + 1;
+      }
+      codePoints.resize(i + 1);
+      return utf8Encode(codePoints);
+    }
+  }
+  return std::nullopt;
+}
+
+std::string base64Encode(std::string_view bytes) {
+  return encoding::Base64::encode(bytes.data(), bytes.size());
+}
+
+// Serializes the integer min/max for a column to Iceberg single-value binary,
+// choosing width/encoding from the logical type. Returns nullopt for types
+// without a defined integer serialization.
+std::optional<std::pair<std::string, std::string>>
+serializeIntegerBounds(const TypePtr& type, int64_t min, int64_t max) {
+  if (type->isDate()) {
+    return std::pair{encodeLittleEndian(min, 4), encodeLittleEndian(max, 4)};
+  }
+  if (type->isShortDecimal()) {
+    return std::pair{
+        encodeDecimalBigEndian(static_cast<int128_t>(min)),
+        encodeDecimalBigEndian(static_cast<int128_t>(max))};
+  }
+  const auto kind = type->kind();
+  if (kind == TypeKind::TINYINT || kind == TypeKind::SMALLINT ||
+      kind == TypeKind::INTEGER) {
+    return std::pair{encodeLittleEndian(min, 4), encodeLittleEndian(max, 4)};
+  }
+  if (kind == TypeKind::BIGINT || kind == TypeKind::TIMESTAMP) {
+    return std::pair{encodeLittleEndian(min, 8), encodeLittleEndian(max, 8)};
+  }
+  return std::nullopt;
+}
+
+// Populates lower/upper bounds for a column from its converted DWRF statistics.
+// Skips types whose typed stats do not expose scalar min/max (binary, boolean,
+// long decimal) or whose min/max is absent (all-null columns).
+void setBounds(
+    const dwio::common::ColumnStatistics& columnStatistics,
+    const TypePtr& type,
+    int32_t truncateLength,
+    IcebergDataFileStatistics::ColumnStats& out) {
+  if (const auto* intStats =
+          dynamic_cast<const dwio::common::IntegerColumnStatistics*>(
+              &columnStatistics)) {
+    const auto min = intStats->getMinimum();
+    const auto max = intStats->getMaximum();
+    if (!min.has_value() || !max.has_value()) {
+      return;
+    }
+    if (auto bounds = serializeIntegerBounds(type, min.value(), max.value())) {
+      out.lowerBound = base64Encode(bounds->first);
+      out.upperBound = base64Encode(bounds->second);
+    }
+    return;
+  }
+
+  if (const auto* doubleStats =
+          dynamic_cast<const dwio::common::DoubleColumnStatistics*>(
+              &columnStatistics)) {
+    const auto min = doubleStats->getMinimum();
+    const auto max = doubleStats->getMaximum();
+    if (!min.has_value() || !max.has_value()) {
+      return;
+    }
+    if (type->isReal()) {
+      out.lowerBound = base64Encode(
+          encodeFloatLittleEndian(static_cast<float>(min.value())));
+      out.upperBound = base64Encode(
+          encodeFloatLittleEndian(static_cast<float>(max.value())));
+    } else {
+      out.lowerBound = base64Encode(encodeDoubleLittleEndian(min.value()));
+      out.upperBound = base64Encode(encodeDoubleLittleEndian(max.value()));
+    }
+    return;
+  }
+
+  if (const auto* stringStats =
+          dynamic_cast<const dwio::common::StringColumnStatistics*>(
+              &columnStatistics)) {
+    const auto& min = stringStats->getMinimum();
+    const auto& max = stringStats->getMaximum();
+    if (!min.has_value() || !max.has_value()) {
+      return;
+    }
+    out.lowerBound =
+        base64Encode(truncateLowerBound(min.value(), truncateLength));
+    if (auto upper = truncateUpperBound(max.value(), truncateLength)) {
+      out.upperBound = base64Encode(upper.value());
+    }
+  }
+}
+
+// Recursively records the "iceberg.id" attribute for 'node' and its
+// descendants, keyed by pre-order schema node id (matching the DWRF/ORC
+// footer node ids). 'fieldId' is the field-id tree aligned to 'node'.
+void stampFieldIdAttributes(
+    const dwio::common::TypeWithId& node,
+    const parquet::ParquetFieldId& fieldId,
+    std::unordered_map<
+        uint32_t,
+        std::vector<std::pair<std::string, std::string>>>& attributes) {
+  attributes[node.id()] = {{"iceberg.id", std::to_string(fieldId.fieldId)}};
+  const auto numChildren =
+      std::min<size_t>(node.size(), fieldId.children.size());
+  for (size_t i = 0; i < numChildren; ++i) {
+    stampFieldIdAttributes(
+        *node.childAt(static_cast<uint32_t>(i)),
+        fieldId.children.at(i),
+        attributes);
+  }
+}
+
+// Builds the per-node "iceberg.id" attribute map for the DWRF/ORC writer from
+// the Iceberg input column handles, aligned to 'schema' (the written row
+// type).
+std::unordered_map<uint32_t, std::vector<std::pair<std::string, std::string>>>
+buildDwrfSchemaAttributes(
+    const RowTypePtr& schema,
+    const std::vector<IcebergColumnHandlePtr>& inputColumns) {
+  std::unordered_map<uint32_t, std::vector<std::pair<std::string, std::string>>>
+      attributes;
+  if (schema == nullptr) {
+    return attributes;
+  }
+  const auto schemaWithId = dwio::common::TypeWithId::create(schema);
+  const auto numColumns =
+      std::min<size_t>(schemaWithId->size(), inputColumns.size());
+  for (size_t i = 0; i < numColumns; ++i) {
+    stampFieldIdAttributes(
+        *schemaWithId->childAt(static_cast<uint32_t>(i)),
+        inputColumns[i]->field(),
+        attributes);
+  }
+  return attributes;
+}
+
+} // namespace
+
+IcebergDwrfStatsCollector::IcebergDwrfStatsCollector(
+    const std::vector<IcebergColumnHandlePtr>& inputColumns,
+    const RowTypePtr& schema)
+    : inputColumns_(inputColumns) {
+  VELOX_CHECK_NOT_NULL(schema, "Schema cannot be null.");
+  const auto schemaWithId = dwio::common::TypeWithId::create(schema);
+  const auto numColumns =
+      std::min<size_t>(schemaWithId->size(), inputColumns.size());
+  for (size_t i = 0; i < numColumns; ++i) {
+    const auto& field = inputColumns[i]->field();
+    buildNodeInfo(
+        *schemaWithId->childAt(static_cast<uint32_t>(i)),
+        field,
+        /*topLevel=*/true);
+    collectSkipBoundsFieldIds(
+        field, inputColumns[i]->dataType(), skipBoundsFieldIds_);
+  }
+}
+
+void IcebergDwrfStatsCollector::buildNodeInfo(
+    const dwio::common::TypeWithId& node,
+    const parquet::ParquetFieldId& field,
+    bool topLevel) {
+  const auto& type = node.type();
+  const bool flat =
+      topLevel && !type->isRow() && !type->isArray() && !type->isMap();
+  nodeInfo_[node.id()] = NodeInfo{field.fieldId, type, flat};
+
+  const auto numChildren = std::min<size_t>(node.size(), field.children.size());
+  for (size_t i = 0; i < numChildren; ++i) {
+    buildNodeInfo(
+        *node.childAt(static_cast<uint32_t>(i)),
+        field.children.at(i),
+        /*topLevel=*/false);
+  }
+}
+
+IcebergDataFileStatisticsPtr IcebergDwrfStatsCollector::aggregate(
+    const dwrf::FooterWrapper& footer,
+    const dwrf::StatsContext& statsContext) const {
+  auto dataFileStats = std::make_shared<IcebergDataFileStatistics>();
+  const int64_t numRecords = static_cast<int64_t>(footer.numberOfRows());
+  dataFileStats->numRecords = numRecords;
+
+  const auto statisticsSize = footer.statisticsSize();
+  for (const auto& [nodeId, info] : nodeInfo_) {
+    if (nodeId >= static_cast<uint32_t>(statisticsSize)) {
+      continue;
+    }
+
+    const auto columnStatistics = dwrf::buildColumnStatisticsFromProto(
+        footer.statistics(static_cast<int>(nodeId)), statsContext);
+    if (columnStatistics == nullptr) {
+      continue;
+    }
+
+    auto& stats = dataFileStats->columnStats[info.fieldId];
+
+    if (columnStatistics->getSize().has_value()) {
+      stats.columnSize =
+          static_cast<int64_t>(columnStatistics->getSize().value());
+    }
+
+    const auto numValues = columnStatistics->getNumberOfValues();
+    if (info.topLevelFlat) {
+      // For a primitive top-level column the Iceberg value count equals the
+      // row count (non-null + null), and DWRF's non-null count yields the null
+      // count directly.
+      stats.valueCount = numRecords;
+      if (numValues.has_value()) {
+        stats.nullValueCount =
+            numRecords - static_cast<int64_t>(numValues.value());
+      }
+    } else if (numValues.has_value()) {
+      // For nested columns DWRF reports the non-null occurrence count. Use it
+      // as the value count and leave the null count unset, since it is not 1:1
+      // with the row count.
+      stats.valueCount = static_cast<int64_t>(numValues.value());
+    }
+
+    if (shouldStoreBounds(info.fieldId)) {
+      setBounds(*columnStatistics, info.type, kDefaultTruncateLength, stats);
+    }
+  }
+
+  return dataFileStats;
+}
+
+void IcebergDwrfStatsCollector::configureWriterOptions(
+    dwio::common::WriterOptions& options) const {
+  auto* dwrfOptions = dynamic_cast<dwrf::WriterOptions*>(&options);
+  if (dwrfOptions == nullptr) {
+    return;
+  }
+  dwrfOptions->schemaAttributes = buildDwrfSchemaAttributes(
+      std::dynamic_pointer_cast<const RowType>(dwrfOptions->schema),
+      inputColumns_);
+}
+
+IcebergDataFileStatisticsPtr IcebergDwrfStatsCollector::collect(
+    dwio::common::Writer& writer,
+    std::unique_ptr<dwio::common::FileMetadata>& /* closeMetadata */) const {
+  // dwrf::Writer::close() returns an empty placeholder, so the column
+  // statistics are read from the still-alive writer's footer proto.
+  auto* dwrfWriter = dynamic_cast<dwrf::Writer*>(&writer);
+  if (dwrfWriter == nullptr) {
+    return nullptr;
+  }
+  const auto& footerWriteWrapper = dwrfWriter->getFooter();
+  if (footerWriteWrapper == nullptr) {
+    return nullptr;
+  }
+  const auto footer = footerWriteWrapper->format() == dwrf::DwrfFormat::kDwrf
+      ? dwrf::FooterWrapper(footerWriteWrapper->getDwrfPtr())
+      : dwrf::FooterWrapper(footerWriteWrapper->getOrcPtr());
+  const auto writerVersion =
+      dwrfWriter->getContext().getConfig(dwrf::Config::WRITER_VERSION);
+  const dwrf::StatsContext statsContext(writerVersion);
+  return aggregate(footer, statsContext);
+}
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergDwrfStatsCollector.h
+++ b/velox/connectors/hive/iceberg/IcebergDwrfStatsCollector.h
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <folly/container/F14Map.h>
+#include <folly/container/F14Set.h>
+
+#include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
+#include "velox/connectors/hive/iceberg/IcebergDataFileStatistics.h"
+#include "velox/connectors/hive/iceberg/IcebergStatsCollector.h"
+#include "velox/dwio/common/TypeWithId.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox::dwrf {
+class FooterWrapper;
+struct StatsContext;
+} // namespace facebook::velox::dwrf
+
+namespace facebook::velox::connector::hive::iceberg {
+
+/// Aggregates per-file Iceberg column statistics (column sizes, value counts,
+/// null counts, lower/upper bounds) from the DWRF/ORC writer footer.
+///
+/// Unlike Parquet (whose writer returns a self-describing FileMetadata),
+/// dwrf::Writer::close() returns an empty placeholder. DWRF column statistics
+/// live in the footer proto (one proto::ColumnStatistics per pre-order schema
+/// node id), reachable from the still-alive writer via
+/// dwrf::Writer::getFooter(). aggregate() therefore consumes a
+/// dwrf::FooterWrapper read from the live writer rather than a FileMetadata.
+///
+/// Create one instance per IcebergDataSink and reuse it across all writers.
+class IcebergDwrfStatsCollector : public IcebergStatsCollector {
+ public:
+  /// @param inputColumns The Iceberg input column handles. Each carries the
+  /// hierarchical Iceberg field-id tree (ParquetFieldId) for one top-level
+  /// column.
+  /// @param schema The written row type. Walked together with the field-id
+  /// trees to map pre-order DWRF footer node ids to Iceberg field ids.
+  IcebergDwrfStatsCollector(
+      const std::vector<IcebergColumnHandlePtr>& inputColumns,
+      const RowTypePtr& schema);
+
+  /// Aggregates DWRF footer statistics into Iceberg data file statistics.
+  /// For each schema node that maps to an Iceberg field id, reads the footer's
+  /// per-node ColumnStatistics and populates:
+  /// - columnSize from the column's total stream length.
+  /// - valueCount: numRecords for top-level flat columns, otherwise the
+  ///   non-null value count from the stats (caveat: DWRF reports non-null
+  ///   count, not total occurrences, for nested columns).
+  /// - nullValueCount: numRecords - nonNullCount for top-level flat columns;
+  ///   left unset for nested columns (the mapping is not 1:1 with row count).
+  /// - lower/upper bounds (base64-encoded Iceberg single-value binary) for
+  ///   types that expose scalar min/max in DWRF stats and are not MAP/ARRAY
+  ///   descendants.
+  /// @param footer The DWRF footer read from the live writer.
+  /// @param statsContext Writer name/version used to interpret the proto stats.
+  IcebergDataFileStatisticsPtr aggregate(
+      const dwrf::FooterWrapper& footer,
+      const dwrf::StatsContext& statsContext) const;
+
+  void configureWriterOptions(
+      dwio::common::WriterOptions& options) const override;
+
+  IcebergDataFileStatisticsPtr collect(
+      dwio::common::Writer& writer,
+      std::unique_ptr<dwio::common::FileMetadata>& closeMetadata)
+      const override;
+
+  /// TODO: Need to support this config property.
+  /// 16 is default value. See DEFAULT_WRITE_METRICS_MODE_DEFAULT in
+  /// org.apache.iceberg.TableProperties.
+  constexpr static int32_t kDefaultTruncateLength{16};
+
+ private:
+  // Per-node metadata captured during the schema walk.
+  struct NodeInfo {
+    // Iceberg field id for this node.
+    int32_t fieldId{};
+    // Velox logical type, used to choose the bound serializer (e.g. DATE vs
+    // INTEGER, TIMESTAMP vs BIGINT, decimal precision/scale).
+    TypePtr type;
+    // True only for primitive columns that are direct children of the root
+    // row. valueCount/nullValueCount are row-count-derived only for these.
+    bool topLevelFlat{};
+  };
+
+  bool shouldStoreBounds(int32_t fieldId) const {
+    return !skipBoundsFieldIds_.contains(fieldId);
+  }
+
+  // Recursively records NodeInfo for 'node' and its descendants, keyed by
+  // pre-order schema node id (matching the DWRF footer node ids). 'field' is
+  // the Iceberg field-id tree aligned to 'node'.
+  void buildNodeInfo(
+      const dwio::common::TypeWithId& node,
+      const parquet::ParquetFieldId& field,
+      bool topLevel);
+
+  // Maps pre-order DWRF footer node id to its Iceberg field id and type.
+  folly::F14FastMap<uint32_t, NodeInfo> nodeInfo_;
+
+  // Iceberg field ids whose bounds collection is skipped: MAP and ARRAY types
+  // and all of their descendants.
+  folly::F14FastSet<int32_t> skipBoundsFieldIds_;
+
+  // Iceberg input column handles, retained to build the DWRF/ORC "iceberg.id"
+  // schema attributes in configureWriterOptions().
+  std::vector<IcebergColumnHandlePtr> inputColumns_;
+};
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergParquetStatsCollector.cpp
+++ b/velox/connectors/hive/iceberg/IcebergParquetStatsCollector.cpp
@@ -80,7 +80,7 @@ IcebergParquetStatsCollector::IcebergParquetStatsCollector(
 }
 
 IcebergDataFileStatisticsPtr IcebergParquetStatsCollector::aggregate(
-    std::unique_ptr<dwio::common::FileMetadata> fileMetadata) {
+    std::unique_ptr<dwio::common::FileMetadata> fileMetadata) const {
   // Empty data file.
   if (!fileMetadata) {
     return std::make_shared<IcebergDataFileStatistics>(
@@ -169,6 +169,22 @@ IcebergDataFileStatisticsPtr IcebergParquetStatsCollector::aggregate(
     }
   }
   return dataFileStats;
+}
+
+void IcebergParquetStatsCollector::configureWriterOptions(
+    dwio::common::WriterOptions& options) const {
+  auto* parquetOptions = dynamic_cast<parquet::WriterOptions*>(&options);
+  if (parquetOptions == nullptr) {
+    return;
+  }
+  parquetOptions->parquetFieldIds = parquetFieldIds_.children;
+}
+
+IcebergDataFileStatisticsPtr IcebergParquetStatsCollector::collect(
+    dwio::common::Writer& /* writer */,
+    std::unique_ptr<dwio::common::FileMetadata>& closeMetadata) const {
+  // Parquet statistics come from the FileMetadata returned by Writer::close().
+  return aggregate(std::move(closeMetadata));
 }
 
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergParquetStatsCollector.h
+++ b/velox/connectors/hive/iceberg/IcebergParquetStatsCollector.h
@@ -19,6 +19,7 @@
 
 #include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
 #include "velox/connectors/hive/iceberg/IcebergDataFileStatistics.h"
+#include "velox/connectors/hive/iceberg/IcebergStatsCollector.h"
 #include "velox/dwio/common/FileMetadata.h"
 #include "velox/dwio/common/ParquetFieldId.h"
 
@@ -30,7 +31,7 @@ namespace facebook::velox::connector::hive::iceberg {
 /// and reused across all writers; aggregate() is invoked after each Parquet
 /// file is closed. Also exposes the Parquet field IDs for the input columns
 /// so they can be threaded into the writer's column metadata.
-class IcebergParquetStatsCollector {
+class IcebergParquetStatsCollector : public IcebergStatsCollector {
  public:
   explicit IcebergParquetStatsCollector(
       const std::vector<IcebergColumnHandlePtr>& inputColumns);
@@ -49,7 +50,15 @@ class IcebergParquetStatsCollector {
   ///   ARRAY types and all their descendants.
   /// @param fileMetadata The Parquet file metadata to aggregate.
   IcebergDataFileStatisticsPtr aggregate(
-      std::unique_ptr<dwio::common::FileMetadata> fileMetadata);
+      std::unique_ptr<dwio::common::FileMetadata> fileMetadata) const;
+
+  void configureWriterOptions(
+      dwio::common::WriterOptions& options) const override;
+
+  IcebergDataFileStatisticsPtr collect(
+      dwio::common::Writer& writer,
+      std::unique_ptr<dwio::common::FileMetadata>& closeMetadata)
+      const override;
 
   /// TODO: Need to support this config property.
   /// 16 is default value. See DEFAULT_WRITE_METRICS_MODE_DEFAULT in

--- a/velox/connectors/hive/iceberg/IcebergStatsCollector.cpp
+++ b/velox/connectors/hive/iceberg/IcebergStatsCollector.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/IcebergStatsCollector.h"
+
+#include "velox/connectors/hive/iceberg/IcebergDwrfStatsCollector.h"
+#ifdef VELOX_ENABLE_PARQUET
+#include "velox/connectors/hive/iceberg/IcebergParquetStatsCollector.h"
+#endif
+
+namespace facebook::velox::connector::hive::iceberg {
+
+std::shared_ptr<IcebergStatsCollector> IcebergStatsCollector::create(
+    dwio::common::FileFormat format,
+    const std::vector<IcebergColumnHandlePtr>& inputColumns,
+    const RowTypePtr& schema) {
+  switch (format) {
+    case dwio::common::FileFormat::DWRF:
+    case dwio::common::FileFormat::ORC:
+      // DWRF/ORC statistics are read from the writer footer; the collector maps
+      // footer node ids to Iceberg field ids using the written row type.
+      return std::make_shared<IcebergDwrfStatsCollector>(inputColumns, schema);
+#ifdef VELOX_ENABLE_PARQUET
+    case dwio::common::FileFormat::PARQUET:
+      return std::make_shared<IcebergParquetStatsCollector>(inputColumns);
+#endif
+    default:
+      return nullptr;
+  }
+}
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergStatsCollector.h
+++ b/velox/connectors/hive/iceberg/IcebergStatsCollector.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
+#include "velox/connectors/hive/iceberg/IcebergDataFileStatistics.h"
+#include "velox/dwio/common/FileMetadata.h"
+#include "velox/dwio/common/Options.h"
+#include "velox/dwio/common/Writer.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+/// Collects per-file Iceberg column statistics (column sizes, value counts,
+/// null counts, lower/upper bounds) from a closed file writer, and wires the
+/// Iceberg field ids into the writer options.
+///
+/// Each file format extracts statistics from a different source: DWRF/ORC read
+/// the writer's footer proto from the still-alive writer, while Parquet reads
+/// the FileMetadata returned by Writer::close(). That format-specific logic is
+/// encapsulated behind this interface so IcebergDataSink holds a single base
+/// pointer and never branches on file format. Create one instance per
+/// IcebergDataSink via create() and reuse it across all writers.
+class IcebergStatsCollector {
+ public:
+  virtual ~IcebergStatsCollector() = default;
+
+  /// Wires the Iceberg field ids for the input columns into the format-specific
+  /// writer options (Parquet column metadata or DWRF/ORC "iceberg.id"
+  /// attributes). A no-op when 'options' is not for this collector's format.
+  virtual void configureWriterOptions(
+      dwio::common::WriterOptions& options) const = 0;
+
+  /// Aggregates per-file Iceberg column statistics from a just-closed writer.
+  /// @param writer The live writer (DWRF/ORC read its footer proto).
+  /// @param closeMetadata The metadata returned by Writer::close() (Parquet
+  /// consumes it; DWRF/ORC return an empty placeholder and ignore it).
+  /// @return The aggregated statistics, or nullptr when statistics are
+  /// unavailable, in which case the caller derives a row-count-only estimate.
+  virtual IcebergDataFileStatisticsPtr collect(
+      dwio::common::Writer& writer,
+      std::unique_ptr<dwio::common::FileMetadata>& closeMetadata) const = 0;
+
+  /// Creates the statistics collector for 'format', or nullptr when the format
+  /// has no Iceberg statistics support compiled in (e.g. Parquet without
+  /// VELOX_ENABLE_PARQUET).
+  /// @param inputColumns The Iceberg input column handles (carry the field-id
+  /// trees).
+  /// @param schema The written row type.
+  static std::shared_ptr<IcebergStatsCollector> create(
+      dwio::common::FileFormat format,
+      const std::vector<IcebergColumnHandlePtr>& inputColumns,
+      const RowTypePtr& schema);
+};
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/tests/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/tests/CMakeLists.txt
@@ -189,28 +189,6 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
     GTest::gtest_main
   )
 
-  add_executable(
-    velox_hive_iceberg_dwrf_insert_test
-    IcebergDwrfInsertTest.cpp
-    IcebergTestBase.cpp
-    Main.cpp
-  )
-  add_test(velox_hive_iceberg_dwrf_insert_test velox_hive_iceberg_dwrf_insert_test)
-
-  target_link_libraries(
-    velox_hive_iceberg_dwrf_insert_test
-    velox_hive_connector
-    velox_hive_iceberg_splitreader
-    velox_exec_test_lib
-    velox_dwio_common_test_utils
-    velox_dwio_dwrf_reader
-    velox_dwio_dwrf_writer
-    velox_dwio_parquet_reader
-    velox_dwio_parquet_writer
-    GTest::gtest
-    GTest::gtest_main
-  )
-
   add_executable(velox_hive_writer_options_adapter_test WriterOptionsAdapterTest.cpp)
   add_test(velox_hive_writer_options_adapter_test velox_hive_writer_options_adapter_test)
 

--- a/velox/connectors/hive/iceberg/tests/IcebergDwrfStatsTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergDwrfStatsTest.cpp
@@ -1,0 +1,542 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Conv.h>
+#include <folly/json.h>
+#include <gtest/gtest.h>
+
+#include "velox/common/encode/Base64.h"
+#include "velox/connectors/hive/iceberg/IcebergDataFileStatistics.h"
+#include "velox/connectors/hive/iceberg/tests/IcebergTestBase.h"
+#include "velox/dwio/dwrf/RegisterDwrfReader.h"
+#include "velox/dwio/dwrf/RegisterDwrfWriter.h"
+
+using namespace facebook::velox::common::testutil;
+
+namespace facebook::velox::connector::hive::iceberg {
+
+namespace {
+
+// Reconstructs IcebergDataFileStatistics from the JSON metrics that the sink
+// emits in each commit task. Mirrors the helper in IcebergParquetStatsTest so
+// the DWRF stats path is exercised end-to-end through commitMessage().
+class IcebergDwrfStatsTest : public test::IcebergTestBase {
+ protected:
+  void SetUp() override {
+    IcebergTestBase::SetUp();
+    dwrf::registerDwrfReaderFactory();
+    dwrf::registerDwrfWriterFactory();
+    fileFormat_ = dwio::common::FileFormat::DWRF;
+  }
+
+  static IcebergDataFileStatisticsPtr statsFromMetrics(
+      const folly::dynamic& metrics) {
+    VELOX_CHECK(metrics.isObject());
+    VELOX_CHECK(metrics.count("recordCount") > 0);
+    auto stats = std::make_shared<IcebergDataFileStatistics>();
+    stats->numRecords = metrics["recordCount"].asInt();
+
+    auto setIntField = [&](const folly::dynamic& map, auto setter) {
+      if (!map.isObject()) {
+        return;
+      }
+      for (const auto& item : map.items()) {
+        const auto fieldId = folly::to<int32_t>(item.first.asString());
+        auto& column = stats->columnStats[fieldId];
+        setter(column, item.second);
+      }
+    };
+
+    setIntField(metrics["columnSizes"], [](auto& column, const auto& value) {
+      column.columnSize = value.asInt();
+    });
+    setIntField(metrics["valueCounts"], [](auto& column, const auto& value) {
+      column.valueCount = value.asInt();
+    });
+    setIntField(
+        metrics["nullValueCounts"], [](auto& column, const auto& value) {
+          column.nullValueCount = value.asInt();
+        });
+
+    const auto& lowerBounds = metrics["lowerBounds"];
+    if (lowerBounds.isObject()) {
+      for (const auto& item : lowerBounds.items()) {
+        const auto fieldId = folly::to<int32_t>(item.first.asString());
+        stats->columnStats[fieldId].lowerBound = item.second.asString();
+      }
+    }
+    const auto& upperBounds = metrics["upperBounds"];
+    if (upperBounds.isObject()) {
+      for (const auto& item : upperBounds.items()) {
+        const auto fieldId = folly::to<int32_t>(item.first.asString());
+        stats->columnStats[fieldId].upperBound = item.second.asString();
+      }
+    }
+
+    return stats;
+  }
+
+  static std::vector<IcebergDataFileStatisticsPtr> statsFromCommitTasks(
+      const std::vector<std::string>& commitTasks) {
+    std::vector<IcebergDataFileStatisticsPtr> stats;
+    stats.reserve(commitTasks.size());
+    for (const auto& task : commitTasks) {
+      auto taskJson = folly::parseJson(task);
+      VELOX_CHECK(taskJson.isObject());
+      VELOX_CHECK(taskJson.count("metrics") > 0);
+      stats.emplace_back(statsFromMetrics(taskJson["metrics"]));
+    }
+    return stats;
+  }
+
+  std::vector<IcebergDataFileStatisticsPtr> writeDataAndGetAllStats(
+      const RowVectorPtr& data,
+      const std::vector<test::PartitionField>& partitionFields = {}) {
+    const auto outputDir = TempDirectoryPath::create();
+    auto dataSink = createDataSinkAndAppendData(
+        {data}, outputDir->getPath(), partitionFields);
+    auto commitTasks = dataSink->close();
+    EXPECT_FALSE(commitTasks.empty());
+    return statsFromCommitTasks(commitTasks);
+  }
+
+  // Decodes a little-endian fixed-width bound back to a typed value.
+  template <typename T>
+  static std::pair<T, T> decodeBounds(
+      const IcebergDataFileStatisticsPtr& stats,
+      int32_t fieldId) {
+    auto decode = [](const std::string& base64Encoded) {
+      const std::string decoded = encoding::Base64::decode(base64Encoded);
+      T value;
+      std::memcpy(&value, decoded.data(), sizeof(T));
+      return value;
+    };
+
+    const auto& columnStats = stats->columnStats.at(fieldId);
+    VELOX_CHECK(columnStats.lowerBound.has_value());
+    VELOX_CHECK(columnStats.upperBound.has_value());
+    return {
+        decode(columnStats.lowerBound.value()),
+        decode(columnStats.upperBound.value())};
+  }
+
+  static void verifyBasicStats(
+      const IcebergDataFileStatisticsPtr& stats,
+      int64_t expectedRecords,
+      const std::unordered_map<int32_t, int64_t>& expectedValueCounts,
+      const std::unordered_map<int32_t, int64_t>& expectedNullCounts) {
+    EXPECT_EQ(stats->numRecords, expectedRecords);
+    for (const auto& [fieldId, count] : expectedValueCounts) {
+      ASSERT_TRUE(stats->columnStats.contains(fieldId));
+      EXPECT_EQ(stats->columnStats.at(fieldId).valueCount, count);
+    }
+    for (const auto& [fieldId, count] : expectedNullCounts) {
+      ASSERT_TRUE(stats->columnStats.contains(fieldId));
+      EXPECT_EQ(stats->columnStats.at(fieldId).nullValueCount, count);
+    }
+  }
+
+  static void verifyBoundsExist(
+      const IcebergDataFileStatisticsPtr& stats,
+      const std::vector<int32_t>& fieldIds) {
+    for (const int32_t fieldId : fieldIds) {
+      ASSERT_TRUE(stats->columnStats.contains(fieldId));
+      const auto& columnStats = stats->columnStats.at(fieldId);
+      ASSERT_TRUE(columnStats.lowerBound.has_value());
+      ASSERT_TRUE(columnStats.upperBound.has_value());
+      EXPECT_FALSE(columnStats.lowerBound.value().empty());
+      EXPECT_FALSE(columnStats.upperBound.value().empty());
+    }
+  }
+
+  static void verifyBoundsNotExist(
+      const IcebergDataFileStatisticsPtr& stats,
+      const std::vector<int32_t>& fieldIds) {
+    for (const int32_t fieldId : fieldIds) {
+      if (stats->columnStats.contains(fieldId)) {
+        const auto& columnStats = stats->columnStats.at(fieldId);
+        ASSERT_FALSE(columnStats.lowerBound.has_value());
+        ASSERT_FALSE(columnStats.upperBound.has_value());
+      }
+    }
+  }
+};
+
+TEST_F(IcebergDwrfStatsTest, integer) {
+  constexpr vector_size_t size = 100;
+  constexpr int32_t expectedNulls = 34;
+  constexpr int32_t intColId = 1;
+
+  const auto stats =
+      writeDataAndGetAllStats(makeRowVector({makeFlatVector<int32_t>(
+          size, [](vector_size_t row) { return row * 10; }, nullEvery(3))}));
+  verifyBasicStats(
+      stats[0], size, {{intColId, size}}, {{intColId, expectedNulls}});
+  verifyBoundsExist(stats[0], {intColId});
+
+  const auto [minVal, maxVal] = decodeBounds<int32_t>(stats[0], intColId);
+  EXPECT_EQ(minVal, 10);
+  EXPECT_EQ(maxVal, 980);
+}
+
+TEST_F(IcebergDwrfStatsTest, smallint) {
+  constexpr vector_size_t size = 100;
+  constexpr int32_t smallintColId = 1;
+
+  const auto stats =
+      writeDataAndGetAllStats(makeRowVector({makeFlatVector<int16_t>(
+          size,
+          [](vector_size_t row) { return static_cast<int16_t>(row); },
+          nullEvery(7))}));
+  verifyBoundsExist(stats[0], {smallintColId});
+
+  // SMALLINT serializes to Iceberg int (4-byte little-endian).
+  const auto [minVal, maxVal] = decodeBounds<int32_t>(stats[0], smallintColId);
+  EXPECT_EQ(minVal, 1);
+  EXPECT_EQ(maxVal, 99);
+}
+
+TEST_F(IcebergDwrfStatsTest, bigint) {
+  constexpr vector_size_t size = 100;
+  constexpr int32_t expectedNulls = 25;
+  constexpr int32_t bigintColId = 1;
+
+  const auto stats =
+      writeDataAndGetAllStats(makeRowVector({makeFlatVector<int64_t>(
+          size,
+          [](vector_size_t row) { return row * 1'000'000'000LL; },
+          nullEvery(4))}));
+  verifyBasicStats(
+      stats[0], size, {{bigintColId, size}}, {{bigintColId, expectedNulls}});
+  verifyBoundsExist(stats[0], {bigintColId});
+
+  const auto [minVal, maxVal] = decodeBounds<int64_t>(stats[0], bigintColId);
+  EXPECT_EQ(minVal, 1'000'000'000LL);
+  EXPECT_EQ(maxVal, 99'000'000'000LL);
+}
+
+TEST_F(IcebergDwrfStatsTest, real) {
+  constexpr vector_size_t size = 100;
+  constexpr int32_t expectedNulls = 20;
+  constexpr int32_t realColId = 1;
+
+  const auto stats =
+      writeDataAndGetAllStats(makeRowVector({makeFlatVector<float>(
+          size,
+          [](vector_size_t row) { return static_cast<float>(row) * 1.5f; },
+          nullEvery(5),
+          REAL())}));
+  verifyBasicStats(
+      stats[0], size, {{realColId, size}}, {{realColId, expectedNulls}});
+  verifyBoundsExist(stats[0], {realColId});
+
+  const auto [minVal, maxVal] = decodeBounds<float>(stats[0], realColId);
+  // Row 0 is null (nullEvery(5)); smallest non-null is row 1 -> 1.5.
+  EXPECT_FLOAT_EQ(minVal, 1.5f);
+  EXPECT_FLOAT_EQ(maxVal, 99 * 1.5f);
+}
+
+TEST_F(IcebergDwrfStatsTest, doubleType) {
+  constexpr vector_size_t size = 100;
+  constexpr int32_t expectedNulls = 15;
+  constexpr int32_t doubleColId = 1;
+
+  const auto stats =
+      writeDataAndGetAllStats(makeRowVector({makeFlatVector<double>(
+          size,
+          [](vector_size_t row) { return row * 2.5; },
+          nullEvery(7),
+          DOUBLE())}));
+  verifyBasicStats(
+      stats[0], size, {{doubleColId, size}}, {{doubleColId, expectedNulls}});
+  verifyBoundsExist(stats[0], {doubleColId});
+
+  const auto [minVal, maxVal] = decodeBounds<double>(stats[0], doubleColId);
+  // Row 0 is null; smallest non-null is row 1 -> 2.5.
+  EXPECT_DOUBLE_EQ(minVal, 2.5);
+  EXPECT_DOUBLE_EQ(maxVal, 99 * 2.5);
+}
+
+TEST_F(IcebergDwrfStatsTest, varchar) {
+  constexpr vector_size_t size = 100;
+  constexpr int32_t varcharColId = 1;
+  constexpr int32_t expectedNulls = 17;
+
+  // Keep values <= 16 codepoints so bounds are not truncated.
+  const auto stats =
+      writeDataAndGetAllStats(makeRowVector({makeFlatVector<std::string>(
+          size,
+          [](vector_size_t row) { return fmt::format("key_{:06}", row); },
+          nullEvery(6))}));
+  verifyBasicStats(
+      stats[0], size, {{varcharColId, size}}, {{varcharColId, expectedNulls}});
+  verifyBoundsExist(stats[0], {varcharColId});
+
+  // Row 0 is null; smallest non-null is row 1 -> "key_000001"; max is row 99.
+  EXPECT_EQ(
+      encoding::Base64::decode(
+          stats[0]->columnStats.at(varcharColId).lowerBound.value()),
+      "key_000001");
+  EXPECT_EQ(
+      encoding::Base64::decode(
+          stats[0]->columnStats.at(varcharColId).upperBound.value()),
+      "key_000099");
+}
+
+TEST_F(IcebergDwrfStatsTest, date) {
+  constexpr vector_size_t size = 100;
+  constexpr int32_t expectedNulls = 20;
+  constexpr int32_t dateColId = 1;
+
+  const auto stats =
+      writeDataAndGetAllStats(makeRowVector({makeFlatVector<int32_t>(
+          size,
+          [](vector_size_t row) { return 18262 + row; },
+          nullEvery(5),
+          DATE())}));
+  verifyBasicStats(
+      stats[0], size, {{dateColId, size}}, {{dateColId, expectedNulls}});
+  verifyBoundsExist(stats[0], {dateColId});
+
+  const auto [minVal, maxVal] = decodeBounds<int32_t>(stats[0], dateColId);
+  // Row 0 is null; smallest non-null is row 1 -> 18263.
+  EXPECT_EQ(minVal, 18263);
+  EXPECT_EQ(maxVal, 18262 + 99);
+}
+
+// DWRF does not expose scalar min/max for TIMESTAMP through
+// buildColumnStatisticsFromProto, so counts are populated but bounds are not.
+TEST_F(IcebergDwrfStatsTest, timestampHasCountsButNoBounds) {
+  constexpr vector_size_t size = 100;
+  constexpr int32_t timestampColId = 1;
+
+  const auto stats =
+      writeDataAndGetAllStats(makeRowVector({makeFlatVector<Timestamp>(
+          size,
+          [](vector_size_t row) { return Timestamp(row, 0); },
+          nullEvery(5))}));
+  EXPECT_EQ(stats[0]->numRecords, size);
+  EXPECT_EQ(stats[0]->columnStats.at(timestampColId).valueCount, size);
+  EXPECT_EQ(stats[0]->columnStats.at(timestampColId).nullValueCount, 20);
+  verifyBoundsNotExist(stats[0], {timestampColId});
+}
+
+// Short decimal is stored by the DWRF writer as an integer column; bounds are
+// serialized as Iceberg big-endian two's-complement of the unscaled value.
+TEST_F(IcebergDwrfStatsTest, shortDecimal) {
+  constexpr vector_size_t size = 100;
+  constexpr int32_t decimalColId = 1;
+  constexpr int32_t expectedNulls = 20;
+
+  const auto stats =
+      writeDataAndGetAllStats(makeRowVector({makeFlatVector<int64_t>(
+          size,
+          [](vector_size_t row) { return row * 100LL; },
+          nullEvery(5),
+          DECIMAL(10, 2))}));
+  verifyBasicStats(
+      stats[0], size, {{decimalColId, size}}, {{decimalColId, expectedNulls}});
+  verifyBoundsExist(stats[0], {decimalColId});
+}
+
+TEST_F(IcebergDwrfStatsTest, multipleDataTypes) {
+  constexpr vector_size_t size = 100;
+  constexpr int32_t intColId = 1;
+  constexpr int32_t bigintColId = 2;
+  constexpr int32_t realColId = 3;
+  constexpr int32_t varcharColId = 4;
+
+  auto rowVector = makeRowVector(
+      {makeFlatVector<int32_t>(
+           size, [](vector_size_t row) { return row * 10; }, nullEvery(3)),
+       makeFlatVector<int64_t>(
+           size,
+           [](vector_size_t row) { return row * 1'000'000'000LL; },
+           nullEvery(4)),
+       makeFlatVector<float>(
+           size,
+           [](vector_size_t row) { return static_cast<float>(row) * 1.5f; },
+           nullEvery(5),
+           REAL()),
+       makeFlatVector<std::string>(
+           size,
+           [](vector_size_t row) { return "str_" + std::to_string(row); },
+           nullEvery(6))});
+  const auto stats = writeDataAndGetAllStats(rowVector);
+
+  verifyBasicStats(
+      stats[0],
+      size,
+      {
+          {intColId, size},
+          {bigintColId, size},
+          {realColId, size},
+          {varcharColId, size},
+      },
+      {
+          {intColId, 34},
+          {bigintColId, 25},
+          {realColId, 20},
+          {varcharColId, 17},
+      });
+  verifyBoundsExist(stats[0], {intColId, bigintColId, realColId, varcharColId});
+}
+
+TEST_F(IcebergDwrfStatsTest, nullValues) {
+  constexpr vector_size_t size = 100;
+  constexpr int32_t intColId = 1;
+
+  const auto stats = writeDataAndGetAllStats(makeRowVector(
+      {makeNullConstant(TypeKind::INTEGER, size),
+       makeNullConstant(TypeKind::VARCHAR, size)}));
+  EXPECT_EQ(stats[0]->numRecords, size);
+  EXPECT_EQ(stats[0]->columnStats.at(intColId).nullValueCount, size);
+  // No bounds for all-null columns.
+  for (const auto& [fieldId, columnStats] : stats[0]->columnStats) {
+    ASSERT_FALSE(columnStats.lowerBound.has_value());
+    ASSERT_FALSE(columnStats.upperBound.has_value());
+  }
+}
+
+// DWRF writes a file footer even when no rows are appended (unlike Parquet,
+// which produces no file). The collector must report numRecords = 0 from the
+// footer and emit no bounds.
+TEST_F(IcebergDwrfStatsTest, emptyFile) {
+  const auto outputDir = TempDirectoryPath::create();
+  auto dataSink = createDataSinkAndAppendData(
+      {makeRowVector(
+          {makeFlatVector<int32_t>(0), makeFlatVector<StringView>(0)})},
+      outputDir->getPath());
+  auto commitTasks = dataSink->close();
+
+  for (const auto& stats : statsFromCommitTasks(commitTasks)) {
+    EXPECT_EQ(stats->numRecords, 0);
+    for (const auto& [fieldId, columnStats] : stats->columnStats) {
+      EXPECT_FALSE(columnStats.lowerBound.has_value());
+      EXPECT_FALSE(columnStats.upperBound.has_value());
+    }
+  }
+}
+
+// Map values carry counts but no bounds (skipBounds=true for repeated types).
+TEST_F(IcebergDwrfStatsTest, mapType) {
+  constexpr vector_size_t size = 100;
+  constexpr int32_t intColId = 1;
+  constexpr int32_t mapValueColId = 3;
+
+  std::vector<std::optional<
+      std::vector<std::pair<int32_t, std::optional<std::string>>>>>
+      mapData;
+  for (auto i = 0; i < size; ++i) {
+    std::vector<std::pair<int32_t, std::optional<std::string>>> mapRow;
+    mapRow.reserve(5);
+    for (auto j = 0; j < 5; ++j) {
+      mapRow.emplace_back(j, fmt::format("value_{}", i * 5 + j));
+    }
+    mapData.emplace_back(std::move(mapRow));
+  }
+
+  const auto stats = writeDataAndGetAllStats(makeRowVector(
+      {makeFlatVector<int32_t>(size, [](auto row) { return row * 10; }),
+       makeNullableMapVector<int32_t, std::string>(mapData)}));
+  verifyBasicStats(stats[0], size, {{intColId, size}}, {{intColId, 0}});
+
+  EXPECT_EQ(stats[0]->columnStats.at(mapValueColId).valueCount, size * 5);
+  verifyBoundsNotExist(stats[0], {mapValueColId});
+}
+
+// Array elements carry counts but no bounds (skipBounds=true for repeated
+// types).
+TEST_F(IcebergDwrfStatsTest, arrayType) {
+  constexpr vector_size_t size = 100;
+  constexpr int32_t intColId = 1;
+  constexpr int32_t arrayElementColId = 3;
+
+  std::vector<std::vector<std::optional<std::string>>> arrayData;
+  for (auto i = 0; i < size; ++i) {
+    std::vector<std::optional<std::string>> arrayRow;
+    arrayRow.reserve(3);
+    for (auto j = 0; j < 3; ++j) {
+      arrayRow.emplace_back(fmt::format("item_{}", i * 3 + j));
+    }
+    arrayData.emplace_back(std::move(arrayRow));
+  }
+
+  const auto stats = writeDataAndGetAllStats(makeRowVector(
+      {makeFlatVector<int32_t>(size, [](auto row) { return row * 10; }),
+       makeNullableArrayVector<std::string>(arrayData)}));
+  verifyBasicStats(stats[0], size, {{intColId, size}}, {{intColId, 0}});
+
+  EXPECT_EQ(stats[0]->columnStats.at(arrayElementColId).valueCount, size * 3);
+  verifyBoundsNotExist(stats[0], {arrayElementColId});
+}
+
+// Nested struct leaf fields carry bounds matched by field id.
+// Field ids (depth-first from 1):
+//   int_col: 1
+//   struct_col: 2 (parent, no bounds)
+//     first_level_id: 3
+//     first_level_name: 4
+//     nested_struct: 5 (parent, no bounds)
+//       second_level_id: 6
+//       second_level_name: 7
+TEST_F(IcebergDwrfStatsTest, structType) {
+  constexpr vector_size_t size = 100;
+  constexpr int32_t intColId = 1;
+  constexpr int32_t firstLevelIdColId = 3;
+  constexpr int32_t secondLevelIdColId = 6;
+  constexpr int32_t secondLevelNameColId = 7;
+
+  auto firstLevelId = makeFlatVector<int32_t>(
+      size, [](vector_size_t row) { return row; }, nullEvery(5));
+  auto firstLevelName = makeFlatVector<std::string>(
+      size,
+      [](vector_size_t row) { return fmt::format("name_{:04}", row); },
+      nullEvery(7));
+  auto secondLevelId = makeFlatVector<int32_t>(
+      size, [](vector_size_t row) { return row * 2; }, nullEvery(6));
+  auto secondLevelName = makeFlatVector<std::string>(
+      size,
+      [](vector_size_t row) { return fmt::format("nested_{:04}", row); },
+      nullEvery(8));
+
+  auto nestedStruct = makeRowVector({secondLevelId, secondLevelName});
+  auto structVector =
+      makeRowVector({firstLevelId, firstLevelName, nestedStruct});
+  auto rowVector = makeRowVector(
+      {makeFlatVector<int32_t>(size, [](auto row) { return row * 10; }),
+       structVector});
+
+  const auto stats = writeDataAndGetAllStats(rowVector);
+  EXPECT_EQ(stats[0]->numRecords, size);
+
+  verifyBoundsExist(
+      stats[0],
+      {intColId, firstLevelIdColId, secondLevelIdColId, secondLevelNameColId});
+
+  EXPECT_EQ(
+      encoding::Base64::decode(
+          stats[0]->columnStats.at(secondLevelNameColId).lowerBound.value()),
+      "nested_0001");
+  EXPECT_EQ(
+      encoding::Base64::decode(
+          stats[0]->columnStats.at(secondLevelNameColId).upperBound.value()),
+      "nested_0099");
+}
+
+} // namespace
+
+} // namespace facebook::velox::connector::hive::iceberg


### PR DESCRIPTION
Summary:

**Context:**
When the Velox IcebergDataSink writes DWRF/ORC data files, the resulting
Iceberg manifest entries carried only numRecords. Per-column statistics
(value_counts, null_value_counts, column_sizes, lower_bounds, upper_bounds)
were left empty, which was called out as a TODO in
IcebergDataSink::closeWriterAndCollectStats. The Parquet path already
populates these via IcebergParquetStatsCollector, giving the engine predicate
pruning; DWRF writes got none.

**Motivation:**
Without column bounds, the planner cannot skip DWRF/ORC files whose value
ranges exclude a filter, so DWRF Iceberg tables lose file-level pruning.
Unlike Parquet, dwrf::Writer::close() returns an empty placeholder, so the
statistics must be read from the still-alive writer's footer proto.

**This diff:**
- Adds IcebergDwrfStatsCollector, which walks the written row type alongside
  each column's Iceberg field-id tree to map pre-order DWRF footer node ids to
  field ids, then aggregates per-column counts and bounds from the footer.
- Serializes Iceberg single-value bounds (little-endian int32/int64, IEEE
  float/double, big-endian two's-complement decimal, UTF-8 codepoint-aware
  truncated strings), base64-encoded; skips MAP/ARRAY descendants and types
  with no scalar min/max (binary, boolean, timestamp, long decimal).
- Wires the collector into IcebergDataSink: constructs it for DWRF/ORC, reads
  the live writer footer in closeWriterAndCollectStats, and keeps the existing
  per-file numRecords delta as a fallback.
- Registers the new sources/headers in BUCK and CMake (unconditional, not
  Parquet-gated).
- Adds IcebergDwrfStatsTest covering counts and bounds per field id across
  integer, bigint, smallint, real, double, varchar, date, short-decimal,
  timestamp, null-only, nested struct, map, array, and empty-file cases.

Reviewed By: srsuryadev

Differential Revision: D108398109


