### PR TITLE
feat: Add layout-invariance verification to the expression fuzzer (#17883)

### DIFF
--- a/velox/docs/develop/testing/expression-fuzzer.rst
+++ b/velox/docs/develop/testing/expression-fuzzer.rst
@@ -15,7 +15,11 @@ vector can have random and potentially nested encodings.
 To ensure that evaluation engine and UDFs handle vector encodings correctly, the
 expression fuzzer evaluates each expression twice and asserts the results to be
 the same: using regular evaluation path and using simplified evaluation that
-flattens all input vectors before evaluating an expression.
+normalizes all input vectors -- flattening encodings, compacting array/map
+elements, and clearing garbage behind nulls -- before evaluating an expression.
+This also verifies that results depend only on logical input values, not on
+their physical layout, catching UDFs that read the raw elements buffer or
+otherwise ignore offsets/sizes.
 
 How to integrate
 ---------------------------------------

--- a/velox/expression/tests/ExpressionRunner.cpp
+++ b/velox/expression/tests/ExpressionRunner.cpp
@@ -323,8 +323,18 @@ void ExpressionRunner::run(
       auto& testCase = inputTestCases[i];
       SelectivityVector rows = adjustRows(numRows, testCase.activeRows);
       std::cout << "Executing Input " << i << std::endl;
-      auto results = evaluateAndPrintResults(
-          *exprSet, testCase.inputVector, rows, execCtx);
+      RowVectorPtr inputVector;
+      if (mode == "simplified") {
+        // The verifier runs the simplified path on a compacted copy of the
+        // input when verifying layout invariance. Mirror that here so
+        // "simplified" mode reproduces the same evaluation.
+        inputVector = std::static_pointer_cast<RowVector>(
+            BaseVector::copy(*testCase.inputVector));
+      } else {
+        inputVector = testCase.inputVector;
+      }
+      auto results =
+          evaluateAndPrintResults(*exprSet, inputVector, rows, execCtx);
       if (!storeResultPath.empty()) {
         auto fileName = fmt::format("resultVector_{}", i);
         saveResults(results, storeResultPath, fileName);

--- a/velox/expression/tests/ExpressionVerifier.cpp
+++ b/velox/expression/tests/ExpressionVerifier.cpp
@@ -504,10 +504,16 @@ ExpressionVerifier::verify(
     } else {
       VLOG(1) << "Execute with simplified expression eval path.";
       try {
+        // Normalize the input for the simplified path: deep-copy produces a
+        // flat vector with contiguous array/map elements and no garbage behind
+        // nulls, so the common-vs-simplified comparison also flags any result
+        // that depends on the input's physical layout.
+        RowVectorPtr simplifiedInput =
+            std::static_pointer_cast<RowVector>(BaseVector::copy(*rowVector));
         exec::EvalCtx evalCtxSimplified(
-            execCtx_, &exprSetSimplified, rowVector.get());
+            execCtx_, &exprSetSimplified, simplifiedInput.get());
 
-        auto copy = BaseVector::copy(*rowVector);
+        auto copy = BaseVector::copy(*simplifiedInput);
         exprSetSimplified.eval(
             0,
             exprSetSimplified.size(),
@@ -520,7 +526,7 @@ ExpressionVerifier::verify(
         // nested.
         fuzzer::compareVectors(
             copy,
-            BaseVector::copy(*rowVector),
+            BaseVector::copy(*simplifiedInput),
             "Copy of original input",
             "Input after simplified",
             rows);


### PR DESCRIPTION
Summary:

The expression fuzzer can generate inputs with tricky physical layouts — non-contiguous array/map elements or garbage data behind null rows — to catch UDFs that incorrectly read the raw backing buffers. This makes the simplified eval path unconditionally normalize inputs via deep-copy (flat, contiguous elements, no garbage behind nulls) while the common path runs on the raw input. If the results diverge, the UDF is reading physical layout incorrectly instead of logical values.

Differential Revision: D109167549


