### PR TITLE
feat(spark): Support BINARY_OUTPUT_STYLE in to_pretty_string

### DIFF
--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -513,7 +513,17 @@ String Functions
 
     - It prints null input as "NULL" rather than producing null output.
 
-    - It prints binary values using the hex format.
+    - For binary values, the rendering follows the ``binary_output_style``
+      Spark session config (mirrors Spark's ``spark.sql.binaryOutputStyle``).
+      Supported values are ``HEX_DISCRETE`` (default), ``HEX``, ``BASE64``,
+      ``UTF-8``, and ``BASIC``. For the bytes ``[0x31, 0x32, 0x33]`` the
+      renderings are:
+
+      - ``HEX_DISCRETE``: ``[31 32 33]``
+      - ``HEX``: ``313233``
+      - ``BASE64``: ``MTIz``
+      - ``UTF-8``: ``123``
+      - ``BASIC``: ``[49, 50, 51]``
 
     ::
 

--- a/velox/functions/sparksql/SparkQueryConfig.cpp
+++ b/velox/functions/sparksql/SparkQueryConfig.cpp
@@ -35,6 +35,7 @@ SparkQueryConfig::registeredProperties() {
     VELOX_REGISTER_SPARK_CONFIG(kLegacyStatisticalAggregate);
     VELOX_REGISTER_SPARK_CONFIG(kJsonIgnoreNullFields);
     VELOX_REGISTER_SPARK_CONFIG(kCollectListIgnoreNulls);
+    VELOX_REGISTER_SPARK_CONFIG(kBinaryOutputStyle);
 
 #undef VELOX_REGISTER_SPARK_CONFIG
 

--- a/velox/functions/sparksql/SparkQueryConfig.h
+++ b/velox/functions/sparksql/SparkQueryConfig.h
@@ -162,6 +162,20 @@ class SparkQueryConfig {
       true,
       "If true, Spark collect_list() ignores nulls in the input.")
 
+  /// Style used to render binary values to strings. Mirrors Spark's
+  /// `spark.sql.binaryOutputStyle`. Valid values are "UTF-8", "BASIC",
+  /// "BASE64", "HEX", and "HEX_DISCRETE". An empty value defaults to
+  /// "HEX_DISCRETE", matching Spark's behavior when the config is unset.
+  VELOX_SPARK_CONFIG(
+      kBinaryOutputStyle,
+      binaryOutputStyle,
+      "binary_output_style",
+      std::string,
+      "",
+      "Style used to render binary values to strings: "
+      "UTF-8, BASIC, BASE64, HEX, or HEX_DISCRETE. "
+      "An empty value defaults to HEX_DISCRETE.")
+
   /// Returns all registered Spark config properties. Property names are
   /// unqualified (no "spark." prefix).
   static const std::vector<config::ConfigProperty>& registeredProperties();

--- a/velox/functions/sparksql/ToPrettyString.h
+++ b/velox/functions/sparksql/ToPrettyString.h
@@ -16,8 +16,10 @@
 #pragma once
 
 #include <fmt/format.h>
+#include "velox/common/encode/Base64.h"
 #include "velox/expression/CastExpr.h"
 #include "velox/functions/Udf.h"
+#include "velox/functions/sparksql/SparkQueryConfig.h"
 #include "velox/type/Conversions.h"
 #include "velox/type/Timestamp.h"
 #include "velox/type/tz/TimeZoneMap.h"
@@ -25,7 +27,46 @@
 namespace facebook::velox::functions::sparksql {
 namespace detail {
 static const StringView kNull = "NULL";
+
+/// Style used to render binary values to strings. Mirrors Spark's
+/// `spark.sql.binaryOutputStyle`.
+enum class BinaryOutputStyle {
+  // "[31 32]" -- hex digits separated by spaces and wrapped in square
+  // brackets. Default when the Spark config is unset.
+  kHexDiscrete,
+  // "3132" -- uppercase hex digits with no separators.
+  kHex,
+  // "MTI" -- base64 encoded with no padding.
+  kBase64,
+  // "12" -- raw bytes interpreted as a UTF-8 string.
+  kUtf8,
+  // "[49, 50]" -- decimal byte values separated by ", " and wrapped in square
+  // brackets.
+  kBasic,
+};
+
+inline BinaryOutputStyle parseBinaryOutputStyle(const std::string& style) {
+  if (style.empty() || style == "HEX_DISCRETE") {
+    return BinaryOutputStyle::kHexDiscrete;
+  }
+  if (style == "HEX") {
+    return BinaryOutputStyle::kHex;
+  }
+  if (style == "BASE64") {
+    return BinaryOutputStyle::kBase64;
+  }
+  if (style == "UTF-8") {
+    return BinaryOutputStyle::kUtf8;
+  }
+  if (style == "BASIC") {
+    return BinaryOutputStyle::kBasic;
+  }
+  VELOX_USER_FAIL(
+      "Unsupported value for binary output style: '{}'. "
+      "Expected one of: HEX_DISCRETE, HEX, BASE64, UTF-8, BASIC.",
+      style);
 }
+} // namespace detail
 
 /// to_pretty_string(x) -> varchar
 /// Returns pretty string for int8, int16, int32, int64, bool, Date, Varchar. It
@@ -82,33 +123,131 @@ struct ToPrettyStringFunction {
 /// Returns pretty string for varbinary. It has several differences with
 /// cast(varbinary as string):
 /// 1) It prints null input as "NULL" rather than producing null output.
-/// 2) It prints binary value as hex string representation rather than UTF-8.
-/// The pretty string is composed of the hex digits of bytes and spaces between
-/// them. E.g., the result of to_pretty_string("abc") is "[31 32 33]".
+/// 2) The binary value is rendered according to the Spark session config
+///    `spark.binary_output_style` (see SparkQueryConfig::kBinaryOutputStyle).
+///    Supported values are HEX_DISCRETE (default), HEX, BASE64, UTF-8, and
+///    BASIC. Examples for the bytes [0x31, 0x32, 0x33]:
+///      HEX_DISCRETE: "[31 32 33]"
+///      HEX:          "313233"
+///      BASE64:       "MTIz"
+///      UTF-8:        "123"
+///      BASIC:        "[49, 50, 51]"
 template <typename TExec>
 struct ToPrettyStringVarbinaryFunction {
   VELOX_DEFINE_FUNCTION_TYPES(TExec);
 
+  template <typename A>
+  void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& config,
+      A* /*a*/) {
+    style_ = detail::parseBinaryOutputStyle(
+        SparkQueryConfig{config}.binaryOutputStyle());
+  }
+
   template <typename TInput>
   void callNullable(out_type<Varchar>& result, const TInput* input) {
-    if (input) {
-      // One byte spares 2 char, and with the spaces and the boxes.
-      // Byte size: 2 * input->size(), spaces size: input->size() - 1, boxes
-      // size: 2, its sum is 1 + 3 * input->size().
-      result.resize(1 + 3 * input->size());
-      char* const startPosition = result.data();
-      char* pos = startPosition;
-      *pos++ = '[';
-      for (auto i = 0; i < input->size(); i++) {
-        fmt::format_to(pos, "{:02X}", static_cast<int>(input->data()[i]));
-        pos += 2;
-        *pos++ = ' ';
-      }
-      *--pos = ']';
-    } else {
+    if (!input) {
       result.setNoCopy(detail::kNull);
+      return;
+    }
+    switch (style_) {
+      case detail::BinaryOutputStyle::kHexDiscrete:
+        writeHexDiscrete(result, *input);
+        return;
+      case detail::BinaryOutputStyle::kHex:
+        writeHex(result, *input);
+        return;
+      case detail::BinaryOutputStyle::kBase64:
+        writeBase64(result, *input);
+        return;
+      case detail::BinaryOutputStyle::kUtf8:
+        result.setNoCopy(*input);
+        return;
+      case detail::BinaryOutputStyle::kBasic:
+        writeBasic(result, *input);
+        return;
     }
   }
+
+ private:
+  template <typename TInput>
+  static void writeHexDiscrete(out_type<Varchar>& result, const TInput& input) {
+    // "[XX XX XX]" -- 2 chars per byte + (size - 1) spaces + 2 brackets.
+    // For empty input the result is just "[]".
+    if (input.size() == 0) {
+      result.resize(2);
+      result.data()[0] = '[';
+      result.data()[1] = ']';
+      return;
+    }
+    result.resize(1 + 3 * input.size());
+    char* pos = result.data();
+    *pos++ = '[';
+    for (size_t i = 0; i < input.size(); ++i) {
+      fmt::format_to(pos, "{:02X}", static_cast<int>(input.data()[i]));
+      pos += 2;
+      *pos++ = ' ';
+    }
+    *--pos = ']';
+  }
+
+  template <typename TInput>
+  static void writeHex(out_type<Varchar>& result, const TInput& input) {
+    // "XXXX..." -- 2 uppercase hex chars per byte, no separators.
+    result.resize(2 * input.size());
+    char* pos = result.data();
+    for (size_t i = 0; i < input.size(); ++i) {
+      fmt::format_to(pos, "{:02X}", static_cast<int>(input.data()[i]));
+      pos += 2;
+    }
+  }
+
+  template <typename TInput>
+  static void writeBase64(out_type<Varchar>& result, const TInput& input) {
+    // Spark uses Base64 encoding without padding. Velox's Base64::encode
+    // always includes padding, so strip the trailing '=' characters.
+    std::string encoded = encoding::Base64::encode(input.data(), input.size());
+    while (!encoded.empty() && encoded.back() == '=') {
+      encoded.pop_back();
+    }
+    result.resize(encoded.size());
+    if (!encoded.empty()) {
+      std::memcpy(result.data(), encoded.data(), encoded.size());
+    }
+  }
+
+  template <typename TInput>
+  static void writeBasic(out_type<Varchar>& result, const TInput& input) {
+    // "[d, d, d]" -- signed decimal byte values separated by ", ".
+    if (input.size() == 0) {
+      result.resize(2);
+      result.data()[0] = '[';
+      result.data()[1] = ']';
+      return;
+    }
+    std::string buffer;
+    buffer.reserve(2 + 5 * input.size());
+    buffer.push_back('[');
+    for (size_t i = 0; i < input.size(); ++i) {
+      if (i > 0) {
+        buffer.append(", ");
+      }
+      // Spark interprets bytes as signed `Byte` (-128..127), so 0xFF
+      // renders as "-1". Cast through int8_t to force signed
+      // interpretation regardless of whether plain `char` is signed on
+      // the target platform.
+      fmt::format_to(
+          std::back_inserter(buffer),
+          "{}",
+          static_cast<int>(static_cast<int8_t>(input.data()[i])));
+    }
+    buffer.push_back(']');
+    result.resize(buffer.size());
+    std::memcpy(result.data(), buffer.data(), buffer.size());
+  }
+
+  detail::BinaryOutputStyle style_{detail::BinaryOutputStyle::kHexDiscrete};
 };
 
 /// Returns pretty string for Timestamp. It has one difference with

--- a/velox/functions/sparksql/tests/ToPrettyStringTest.cpp
+++ b/velox/functions/sparksql/tests/ToPrettyStringTest.cpp
@@ -15,6 +15,7 @@
  */
 #include <string>
 
+#include "velox/functions/sparksql/SparkQueryConfig.h"
 #include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
 
 namespace facebook::velox::functions::sparksql::test {
@@ -76,6 +77,54 @@ TEST_F(ToPrettyStringTest, binary) {
   EXPECT_EQ(toPrettyStringBinary("abcdef"), "[61 62 63 64 65 66]");
 
   EXPECT_EQ(toPrettyStringBinary("ABC."), "[41 42 43 2E]");
+}
+
+TEST_F(ToPrettyStringTest, binaryOutputStyle) {
+  auto withStyle = [&](const std::string& style,
+                       const std::optional<std::string>& input) {
+    queryCtx_->testingOverrideConfigUnsafe({
+        {SparkQueryConfig::qualify(SparkQueryConfig::kBinaryOutputStyle),
+         style},
+    });
+    return evaluateOnce<std::string>("to_pretty_string(c0)", VARBINARY(), input)
+        .value();
+  };
+
+  // HEX_DISCRETE matches the default behavior.
+  EXPECT_EQ(withStyle("HEX_DISCRETE", "12"), "[31 32]");
+  EXPECT_EQ(withStyle("HEX_DISCRETE", "ABC."), "[41 42 43 2E]");
+
+  // HEX produces a continuous uppercase hex string with no separators.
+  EXPECT_EQ(withStyle("HEX", "12"), "3132");
+  EXPECT_EQ(withStyle("HEX", "ABC."), "4142432E");
+  EXPECT_EQ(withStyle("HEX", "12346"), "3132333436");
+
+  // BASE64 uses Spark's no-padding variant.
+  EXPECT_EQ(withStyle("BASE64", "12"), "MTI");
+  EXPECT_EQ(withStyle("BASE64", "ABC."), "QUJDLg");
+  EXPECT_EQ(withStyle("BASE64", "12346"), "MTIzNDY");
+
+  // UTF-8 reinterprets the bytes as a UTF-8 string.
+  EXPECT_EQ(withStyle("UTF-8", "12"), "12");
+  EXPECT_EQ(withStyle("UTF-8", "ABC."), "ABC.");
+
+  // BASIC prints signed decimal byte values separated by ", ".
+  EXPECT_EQ(withStyle("BASIC", "12"), "[49, 50]");
+  EXPECT_EQ(withStyle("BASIC", "ABC."), "[65, 66, 67, 46]");
+  EXPECT_EQ(withStyle("BASIC", "12346"), "[49, 50, 51, 52, 54]");
+  // Bytes >= 0x80 are interpreted as signed (matches Spark's Byte).
+  EXPECT_EQ(withStyle("BASIC", std::string("\xFF", 1)), "[-1]");
+  EXPECT_EQ(withStyle("BASIC", std::string("\x80\x7F", 2)), "[-128, 127]");
+
+  // Empty input handles the bracketed and non-bracketed cases.
+  EXPECT_EQ(withStyle("HEX_DISCRETE", ""), "[]");
+  EXPECT_EQ(withStyle("HEX", ""), "");
+  EXPECT_EQ(withStyle("BASE64", ""), "");
+  EXPECT_EQ(withStyle("UTF-8", ""), "");
+  EXPECT_EQ(withStyle("BASIC", ""), "[]");
+
+  // Unsupported values raise a user error.
+  EXPECT_THROW(withStyle("INVALID", "12"), VeloxUserError);
 }
 
 TEST_F(ToPrettyStringTest, timestamp) {


### PR DESCRIPTION
Spark 4.0+ introduced spark.sql.binaryOutputStyle to control how binary values are rendered. Velox's to_pretty_string previously hard-coded the HEX_DISCRETE format. This change adds support for the other 4 styles (HEX, BASE64, UTF-8, BASIC), matching Spark's behavior.

The new SparkQueryConfig::kBinaryOutputStyle config (key: binary_output_style) accepts: HEX_DISCRETE (default), HEX, BASE64, UTF-8, BASIC. An invalid value raises a VeloxUserError.

Per-byte signedness in BASIC matches Spark's signed Byte interpretation (0xFF -> -1).

Related to apache/incubator-gluten#11570.