### PR TITLE
feat: Make Spark remainder function ANSI-compliant

### DIFF
--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -370,10 +370,12 @@ Mathematical Functions
 
     An alias for ``rand(seed)``.
 
-.. spark:function:: remainder(n, m) -> [same as n]
+.. spark:function:: remainder(n, m) -> [same as n] (ANSI compliant)
 
     Returns the modulus (remainder) of ``n`` divided by ``m``. Corresponds to Spark's operator ``%``.
     Supported types are: TINYINT, SMALLINT, INTEGER, BIGINT, REAL and DOUBLE.
+    When ``m`` is zero, returns NULL following the behavior when Spark ANSI mode
+    is disabled, and throws an exception when Spark ANSI mode is enabled.
 
 .. spark:function:: rint(x) -> double
 

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -66,12 +66,24 @@ struct AbsFunction {
 
 template <typename T>
 struct RemainderFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& config,
+      const TInput* /*a*/,
+      const TInput* /*n*/) {
+    ansiEnabled_ = SparkQueryConfig{config}.ansiEnabled();
+  }
+
   template <
       typename TInput,
       typename std::enable_if_t<!std::is_floating_point_v<TInput>, int> = 0>
   FOLLY_ALWAYS_INLINE bool
   call(TInput& result, const TInput a, const TInput n) {
     if (UNLIKELY(n == 0)) {
+      if (ansiEnabled_) {
+        VELOX_USER_FAIL("Division by zero");
+      }
       return false;
     }
     // std::numeric_limits<int64_t>::min() % -1 could crash the program since
@@ -92,6 +104,9 @@ struct RemainderFunction {
   FOLLY_ALWAYS_INLINE bool
   call(TInput& result, const TInput a, const TInput n) {
     if (UNLIKELY(n == 0)) {
+      if (ansiEnabled_) {
+        VELOX_USER_FAIL("Division by zero");
+      }
       return false;
     }
     // If either the dividend or the divisor is NaN, or if the dividend is
@@ -107,6 +122,9 @@ struct RemainderFunction {
     }
     return true;
   }
+
+ private:
+  bool ansiEnabled_ = false;
 };
 
 template <typename T>

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -177,6 +177,31 @@ TEST_F(RemainderTest, float) {
   EXPECT_TRUE(std::isnan(remainderValue<float>(kInf, kInf)));
 }
 
+TEST_F(RemainderTest, divisionByZeroAnsi) {
+  // Test remainder with ANSI off (default behavior): division by zero
+  // returns NULL.
+  queryCtx_->testingOverrideConfigUnsafe(
+      {{SparkQueryConfig::qualify(SparkQueryConfig::kAnsiEnabled), "false"}});
+
+  EXPECT_EQ(std::nullopt, remainder<int8_t>(1, 0));
+  EXPECT_EQ(std::nullopt, remainder<int16_t>(1, 0));
+  EXPECT_EQ(std::nullopt, remainder<int32_t>(1, 0));
+  EXPECT_EQ(std::nullopt, remainder<int64_t>(10, 0));
+  EXPECT_EQ(std::nullopt, remainder<float>(1.0f, 0.0f));
+  EXPECT_EQ(std::nullopt, remainder<double>(1.0, 0.0));
+
+  // Test remainder with ANSI on: division by zero throws.
+  queryCtx_->testingOverrideConfigUnsafe(
+      {{SparkQueryConfig::qualify(SparkQueryConfig::kAnsiEnabled), "true"}});
+
+  VELOX_ASSERT_THROW(remainder<int8_t>(1, 0), "Division by zero");
+  VELOX_ASSERT_THROW(remainder<int16_t>(1, 0), "Division by zero");
+  VELOX_ASSERT_THROW(remainder<int32_t>(1, 0), "Division by zero");
+  VELOX_ASSERT_THROW(remainder<int64_t>(10, 0), "Division by zero");
+  VELOX_ASSERT_THROW(remainder<float>(1.0f, 0.0f), "Division by zero");
+  VELOX_ASSERT_THROW(remainder<double>(1.0, 0.0), "Division by zero");
+}
+
 class ArithmeticTest : public SparkFunctionBaseTest {
  protected:
   template <typename T>


### PR DESCRIPTION
  ## Summary

  This PR makes `RemainderFunction` ANSI-compliant.

  - `RemainderFunction` now reads `SparkQueryConfig{config}.ansiEnabled()` in `initialize()` and consults it in both the integer and floating-point `call()` variants.
  - When ANSI is enabled, division by zero throws via `VELOX_USER_FAIL("Division by zero")`. When ANSI is disabled, the original behavior (return NULL) is preserved.
  - Call signature remains `bool call(...)` rather than the `Status call(...)` form used by `AbsFunction` / `UnaryMinusFunction`, because `Remainder`'s non-ANSI behavior is to *return
   NULL* on division by zero, which `Status`-returning SimpleFunctions cannot represent.

  ## Context

  This supersedes the stale-closed draft #16403. Original `CheckedRemainderFunction` approach was redesigned per review feedback; force-pushing the new commit broke the reopen path on
   the original PR, so filing fresh.

  ## How was this patch tested?

  Added `RemainderTest.divisionByZeroAnsi` that exercises both ANSI modes (off → NULL, on → throws) for all integer and floating-point types, mirroring the `absMinValueOverflow` test
  pattern. All 7 `RemainderTest.*` cases pass locally.

  Also updates `remainder` docs in `math.rst` to flag ANSI compliance and explain the dual behavior.
