### PR TITLE
refactor(hive): Pass maxNumBuckets to FileNameGenerator gen()

### DIFF
--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -156,10 +156,10 @@ std::unique_ptr<core::PartitionFunction> createBucketFunction(
 
 std::string computeBucketedFileName(
     const std::string& queryId,
-    uint32_t maxBucketCount,
+    uint32_t maxNumBuckets,
     uint32_t bucket) {
   const uint32_t kMaxBucketCountPadding =
-      std::to_string(maxBucketCount - 1).size();
+      std::to_string(maxNumBuckets - 1).size();
   const std::string bucketValueStr = std::to_string(bucket);
   return fmt::format(
       "0{:0>{}}_0_{}", bucketValueStr, kMaxBucketCountPadding, queryId);
@@ -732,43 +732,19 @@ WriterParameters HiveDataSink::getWriterParameters(
 
 std::pair<std::string, std::string> HiveDataSink::getWriterFileNames(
     std::optional<uint32_t> bucketId) const {
-  if (auto hiveInsertFileNameGenerator =
-          std::dynamic_pointer_cast<const HiveInsertFileNameGenerator>(
-              fileNameGenerator_)) {
-    return hiveInsertFileNameGenerator->gen(
-        bucketId,
-        insertTableHandle_,
-        *connectorQueryCtx_,
-        hiveConfig_,
-        isCommitRequired());
-  }
-
   return fileNameGenerator_->gen(
-      bucketId, insertTableHandle_, *connectorQueryCtx_, isCommitRequired());
-}
-
-std::pair<std::string, std::string> HiveInsertFileNameGenerator::gen(
-    std::optional<uint32_t> bucketId,
-    const std::shared_ptr<const HiveInsertTableHandle> insertTableHandle,
-    const ConnectorQueryCtx& connectorQueryCtx,
-    bool commitRequired) const {
-  auto defaultHiveConfig =
-      std::make_shared<const HiveConfig>(std::make_shared<config::ConfigBase>(
-          std::unordered_map<std::string, std::string>()));
-
-  return this->gen(
       bucketId,
-      insertTableHandle,
-      connectorQueryCtx,
-      defaultHiveConfig,
-      commitRequired);
+      insertTableHandle_,
+      *connectorQueryCtx_,
+      hiveConfig_->maxBucketCount(connectorQueryCtx_->sessionProperties()),
+      isCommitRequired());
 }
 
 std::pair<std::string, std::string> HiveInsertFileNameGenerator::gen(
     std::optional<uint32_t> bucketId,
     const std::shared_ptr<const HiveInsertTableHandle> insertTableHandle,
     const ConnectorQueryCtx& connectorQueryCtx,
-    const std::shared_ptr<const HiveConfig>& hiveConfig,
+    uint32_t maxNumBuckets,
     bool commitRequired) const {
   auto targetFileName = insertTableHandle->locationHandle()->targetFileName();
   const bool generateFileName = targetFileName.empty();
@@ -776,9 +752,7 @@ std::pair<std::string, std::string> HiveInsertFileNameGenerator::gen(
     VELOX_CHECK(generateFileName);
     // TODO: add hive.file_renaming_enabled support.
     targetFileName = computeBucketedFileName(
-        connectorQueryCtx.queryId(),
-        hiveConfig->maxBucketCount(connectorQueryCtx.sessionProperties()),
-        bucketId.value());
+        connectorQueryCtx.queryId(), maxNumBuckets, bucketId.value());
     // queryId may contain unsafe characters.
     sanitizeFileName(targetFileName);
   } else if (generateFileName) {

--- a/velox/connectors/hive/HiveDataSink.h
+++ b/velox/connectors/hive/HiveDataSink.h
@@ -196,10 +196,16 @@ class FileNameGenerator : public ISerializable {
  public:
   virtual ~FileNameGenerator() = default;
 
+  /// Generates the target and write file names for a single output file.
+  /// @param maxNumBuckets Upper bound on the number of buckets, used to
+  /// zero-pad the bucket id in bucketed file names to a fixed width. Resolved
+  /// from the configurable hive.max-bucket-count. Generators that do not
+  /// produce bucketed names may ignore it.
   virtual std::pair<std::string, std::string> gen(
       std::optional<uint32_t> bucketId,
       const std::shared_ptr<const HiveInsertTableHandle> insertTableHandle,
       const ConnectorQueryCtx& connectorQueryCtx,
+      uint32_t maxNumBuckets,
       bool commitRequired) const = 0;
 
   virtual std::string toString() const = 0;
@@ -213,16 +219,8 @@ class HiveInsertFileNameGenerator : public FileNameGenerator {
       std::optional<uint32_t> bucketId,
       const std::shared_ptr<const HiveInsertTableHandle> insertTableHandle,
       const ConnectorQueryCtx& connectorQueryCtx,
+      uint32_t maxNumBuckets,
       bool commitRequired) const override;
-
-  /// Version of file generation that takes hiveConfig into account when
-  /// generating file names
-  std::pair<std::string, std::string> gen(
-      std::optional<uint32_t> bucketId,
-      const std::shared_ptr<const HiveInsertTableHandle> insertTableHandle,
-      const ConnectorQueryCtx& connectorQueryCtx,
-      const std::shared_ptr<const HiveConfig>& hiveConfig,
-      bool commitRequired) const;
 
   static void registerSerDe();
 

--- a/velox/connectors/hive/iceberg/IcebergDataSink.cpp
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.cpp
@@ -90,6 +90,7 @@ class IcebergFileNameGenerator : public FileNameGenerator {
       std::optional<uint32_t> bucketId,
       const std::shared_ptr<const HiveInsertTableHandle> insertTableHandle,
       const ConnectorQueryCtx& connectorQueryCtx,
+      uint32_t maxNumBuckets,
       bool commitRequired) const override;
 
   folly::dynamic serialize() const override;
@@ -105,6 +106,7 @@ std::pair<std::string, std::string> IcebergFileNameGenerator::gen(
     std::optional<uint32_t> bucketId,
     const std::shared_ptr<const HiveInsertTableHandle> insertTableHandle,
     const ConnectorQueryCtx& connectorQueryCtx,
+    uint32_t /* maxNumBuckets */,
     bool commitRequired) const {
   auto targetFileName = insertTableHandle->locationHandle()->targetFileName();
   if (targetFileName.empty()) {


### PR DESCRIPTION
Summary:
`HiveInsertFileNameGenerator` previously had two `gen()` overloads — the base `FileNameGenerator` interface version and a config-aware one added in D74924060 — dispatched via a `dynamic_pointer_cast` in `HiveDataSink::getWriterFileNames()`. This consolidates them into a single `gen()` on the base interface.

The config-aware overload existed only to read one value, `maxNumBuckets`, used to zero-pad bucket ids in bucketed file names. Rather than thread the Hive-specific `HiveConfig` type through the shared `FileNameGenerator` interface — which would force `IcebergFileNameGenerator` and `PrismDeltaFileNameGenerator` to accept a config they ignore — the single `gen()` takes `uint32_t maxNumBuckets` directly:
- `HiveDataSink::getWriterFileNames()` resolves the value once via `hiveConfig_->maxNumBuckets(session)` and passes the integer; the `dynamic_pointer_cast` dispatch is removed.
- The base `FileNameGenerator::gen()` no longer references the Hive-specific `HiveConfig` type.
- `IcebergFileNameGenerator` and `PrismDeltaFileNameGenerator` overrides take the (unused) `uint32_t` instead.

No behavior change: bucket padding/file-name logic is preserved. Serialization is untouched.

Follow-up cleanup to D74924060.

[Session trajectory link](https://www.internalfb.com/intern/devai/devmate/inspector/?id=eea3cea9-fb7a-4da3-91e8-40c0c542a050)

Differential Revision: D109262273


