### PR TITLE
fix(iceberg): Min max statistics for decimal type when encoded as int32

### DIFF
--- a/velox/connectors/hive/iceberg/tests/IcebergParquetStatsTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergParquetStatsTest.cpp
@@ -14,10 +14,13 @@
  * limitations under the License.
  */
 
+#include <arrow/util/endian.h>
 #include <folly/Conv.h>
 #include <folly/json.h>
 #include <gtest/gtest.h>
 
+#include "dwio/parquet/writer/arrow/Schema.h"
+#include "dwio/parquet/writer/arrow/Statistics.h"
 #include "velox/common/encode/Base64.h"
 #include "velox/connectors/hive/iceberg/IcebergDataFileStatistics.h"
 #include "velox/connectors/hive/iceberg/tests/IcebergTestBase.h"
@@ -215,21 +218,50 @@ TEST_F(IcebergParquetStatsTest, bigint) {
 }
 
 TEST_F(IcebergParquetStatsTest, decimal) {
-  constexpr vector_size_t size = 100;
-  constexpr int32_t expectedNulls = 20;
-  constexpr int32_t decimalColId = 1;
+  {
+    constexpr vector_size_t size = 100;
+    constexpr int32_t expectedNulls = 20;
+    constexpr int32_t decimalColId = 1;
 
-  const auto& stats =
-      writeDataAndGetAllStats(makeRowVector({makeFlatVector<int128_t>(
-          size,
-          [](vector_size_t row) { return HugeInt::build(row, row * 123); },
-          nullEvery(5),
-          DECIMAL(38, 3))}));
-  verifyBasicStats(
-      stats[0], size, {{decimalColId, size}}, {{decimalColId, expectedNulls}});
-  verifyBoundsExist(stats[0], {decimalColId});
+    const auto& stats =
+        writeDataAndGetAllStats(makeRowVector({makeFlatVector<int128_t>(
+            size,
+            [](vector_size_t row) { return HugeInt::build(row, row * 123); },
+            nullEvery(5),
+            DECIMAL(38, 3))}));
+    verifyBasicStats(
+        stats[0],
+        size,
+        {{decimalColId, size}},
+        {{decimalColId, expectedNulls}});
+    verifyBoundsExist(stats[0], {decimalColId});
+  }
+  {
+    const auto& statsTemp =
+        writeDataAndGetAllStats(makeRowVector({makeFlatVector<int64_t>(
+            2,
+            [](vector_size_t row) { return row == 0 ? 19900 : 20000; },
+            nullptr,
+            DECIMAL(7, 2))}));
+
+    const auto& columnStats = statsTemp[0]->columnStats.at(1);
+
+    ASSERT_TRUE(columnStats.lowerBound.has_value());
+    ASSERT_TRUE(columnStats.upperBound.has_value());
+
+    auto decodeDecimalInt32 = [](const std::string& base64Value) {
+      const auto decoded = encoding::Base64::decode(base64Value);
+      EXPECT_EQ(decoded.size(), sizeof(int32_t));
+
+      int32_t value;
+      std::memcpy(&value, decoded.data(), sizeof(value));
+      return ::arrow::bit_util::FromBigEndian(value);
+    };
+
+    EXPECT_EQ(decodeDecimalInt32(columnStats.lowerBound.value()), 19900);
+    EXPECT_EQ(decodeDecimalInt32(columnStats.upperBound.value()), 20000);
+  }
 }
-
 TEST_F(IcebergParquetStatsTest, varchar) {
   constexpr vector_size_t size = 100;
   constexpr int32_t varcharColId = 1;

--- a/velox/connectors/hive/iceberg/tests/IcebergParquetStatsTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergParquetStatsTest.cpp
@@ -19,8 +19,8 @@
 #include <folly/json.h>
 #include <gtest/gtest.h>
 
-#include "dwio/parquet/writer/arrow/Schema.h"
-#include "dwio/parquet/writer/arrow/Statistics.h"
+#include "velox/dwio/parquet/writer/arrow/Schema.h"
+#include "velox/dwio/parquet/writer/arrow/Statistics.h"
 #include "velox/common/encode/Base64.h"
 #include "velox/connectors/hive/iceberg/IcebergDataFileStatistics.h"
 #include "velox/connectors/hive/iceberg/tests/IcebergTestBase.h"

--- a/velox/connectors/hive/iceberg/tests/IcebergParquetStatsTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergParquetStatsTest.cpp
@@ -19,11 +19,11 @@
 #include <folly/json.h>
 #include <gtest/gtest.h>
 
-#include "velox/dwio/parquet/writer/arrow/Schema.h"
-#include "velox/dwio/parquet/writer/arrow/Statistics.h"
 #include "velox/common/encode/Base64.h"
 #include "velox/connectors/hive/iceberg/IcebergDataFileStatistics.h"
 #include "velox/connectors/hive/iceberg/tests/IcebergTestBase.h"
+#include "velox/dwio/parquet/writer/arrow/Schema.h"
+#include "velox/dwio/parquet/writer/arrow/Statistics.h"
 
 using namespace facebook::velox::common::testutil;
 

--- a/velox/dwio/parquet/writer/arrow/Statistics.cpp
+++ b/velox/dwio/parquet/writer/arrow/Statistics.cpp
@@ -556,7 +556,9 @@ TypedComparatorImpl<false, ByteArrayType>::getMinMax(
 template <typename T>
 std::string encodeDecimalToBigEndian(T value) {
   uint8_t buffer[sizeof(T)];
-  if constexpr (std::is_same_v<T, int64_t>) {
+  if constexpr (std::is_same_v<T, int32_t>) {
+    *reinterpret_cast<int32_t*>(buffer) = ::arrow::bit_util::ToBigEndian(value);
+  } else if constexpr (std::is_same_v<T, int64_t>) {
     *reinterpret_cast<int64_t*>(buffer) = ::arrow::bit_util::ToBigEndian(value);
   } else if constexpr (std::is_same_v<T, int128_t>) {
     *reinterpret_cast<int128_t*>(buffer) = DecimalUtil::bigEndian(value);
@@ -787,6 +789,11 @@ class TypedStatisticsImpl : public TypedStatistics<DType> {
   }
 
   std::string icebergLowerBoundInclusive(int32_t truncateTo) const override {
+    if constexpr (std::is_same_v<T, int32_t>) {
+      if (descr_->logicalType()->isDecimal()) {
+        return encodeDecimalToBigEndian(min_);
+      }
+    }
     if constexpr (std::is_same_v<T, int64_t>) {
       if (descr_->logicalType()->isDecimal()) {
         return encodeDecimalToBigEndian(min_);
@@ -819,6 +826,11 @@ class TypedStatisticsImpl : public TypedStatistics<DType> {
 
   std::optional<std::string> icebergUpperBoundExclusive(
       int32_t truncateTo) const override {
+    if constexpr (std::is_same_v<T, int32_t>) {
+      if (descr_->logicalType()->isDecimal()) {
+        return encodeDecimalToBigEndian(max_);
+      }
+    }
     if constexpr (std::is_same_v<T, int64_t>) {
       if (descr_->logicalType()->isDecimal()) {
         return encodeDecimalToBigEndian(max_);


### PR DESCRIPTION
Decimal types can also be int32 and the icebergLowerBoundInclusive & icebergUpperBoundExclusive functions are not encoding the types correctly in that case.