### PR TITLE
feat: Iceberg V3 field-id resolver + NIMBLE reader/writer (FB-internal)[nimble] (#17895)

### DIFF
--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -751,6 +751,14 @@ class ReaderOptions : public io::ReaderOptions {
     return *this;
   }
 
+  /// Sets the per-type attribute key under which the file encodes field ids
+  /// (e.g. Iceberg's "iceberg.id"). Consumed when
+  /// columnMappingMode() == kFieldId.
+  ReaderOptions& setFieldIdAttributeKey(std::string key) {
+    fieldIdAttributeKey_ = std::move(key);
+    return *this;
+  }
+
   ReaderOptions& setSessionTimezone(const tz::TimeZone* sessionTimezone) {
     sessionTimezone_ = sessionTimezone;
     return *this;
@@ -793,6 +801,13 @@ class ReaderOptions : public io::ReaderOptions {
   /// Gets the requested schema field ids for ColumnMappingMode::kFieldId.
   const std::vector<ParquetFieldId>& fieldIds() const {
     return fieldIds_;
+  }
+
+  /// Gets the per-type attribute key under which the file encodes field ids
+  /// (e.g. Iceberg's "iceberg.id"). Consumed when
+  /// columnMappingMode() == kFieldId.
+  const std::string& fieldIdAttributeKey() const {
+    return fieldIdAttributeKey_;
   }
 
   SerDeOptions& serDeOptions() {
@@ -991,6 +1006,7 @@ class ReaderOptions : public io::ReaderOptions {
   FileFormat fileFormat_{FileFormat::UNKNOWN};
   RowTypePtr fileSchema_;
   std::vector<ParquetFieldId> fieldIds_;
+  std::string fieldIdAttributeKey_;
   SerDeOptions serDeOptions_;
   std::unordered_map<std::string, std::string> properties_{};
   std::shared_ptr<FormatSpecificOptions> formatSpecificOptions_;


### PR DESCRIPTION
Summary:

FB-internal NIMBLE reader/writer support for Iceberg V3 field-ids, in
dwio/nimble/velox/{reader,writer}/fb (stripped from OSS export). Depends on the OSS
nimble schema changes below it.

- reader/fb: IcebergFieldIdResolver + NimbleReader field-id resolution.
- writer/fb: NimbleWriter(+OptionBuilder) and NimbleFileMetadata carrying field-id /
  type-attribute metadata.
- BUCK wiring (reader/writer/tests) + NimbleReaderIcebergFieldIdTest (the test
  #includes fb/IcebergFieldIdResolver.h, so it ships with the fb code).

Split out of the former combined velox diff D108699499.

Reviewed By: srsuryadev

Differential Revision: D108700350


