### PR TITLE
feat(expression): Add ExpressionEvaluator overloads for optimize and constant folding

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -2497,4 +2497,28 @@ VectorPtr tryEvaluateConstantExpression(
       expr, pool, &execCtx, suppressEvaluationFailures);
 }
 
+VectorPtr tryEvaluateConstantExpression(
+    const core::TypedExprPtr& expr,
+    core::ExpressionEvaluator* evaluator,
+    bool suppressEvaluationFailures) {
+  auto exprSet = evaluator->compile(expr);
+  if (!exprSet->exprs()[0]->isConstantExpr()) {
+    return nullptr;
+  }
+  RowVector input(
+      evaluator->pool(), ROW({}, {}), nullptr, 1, std::vector<VectorPtr>{});
+  SelectivityVector rows(1);
+  VectorPtr result;
+  if (suppressEvaluationFailures) {
+    try {
+      evaluator->evaluate(exprSet.get(), rows, input, result);
+    } catch (const VeloxUserError&) {
+      return nullptr;
+    }
+  } else {
+    evaluator->evaluate(exprSet.get(), rows, input, result);
+  }
+  return result;
+}
+
 } // namespace facebook::velox::exec

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -1018,6 +1018,15 @@ VectorPtr tryEvaluateConstantExpression(
     core::QueryCtx* queryCtx,
     bool suppressEvaluationFailures);
 
+/// Variant of `tryEvaluateConstantExpression` that evaluates through a
+/// `core::ExpressionEvaluator` (e.g. the one a connector exposes for pushed
+/// down filters), for callers that have an evaluator but no QueryCtx. The
+/// evaluator supplies the memory pool.
+VectorPtr tryEvaluateConstantExpression(
+    const core::TypedExprPtr& expr,
+    core::ExpressionEvaluator* evaluator,
+    bool suppressEvaluationFailures = false);
+
 /// Returns a string representation of the expression trees annotated with
 /// runtime statistics. Expected to be called after calling ExprSet::eval one or
 /// more times. If called before ExprSet::eval runtime statistics will be all

--- a/velox/expression/ExprOptimizer.cpp
+++ b/velox/expression/ExprOptimizer.cpp
@@ -22,18 +22,28 @@ namespace facebook::velox::expression {
 
 namespace {
 
-// Tries constant folding input `expr` with `tryEvaluateConstantExpression` API
-// and returns the evaluated expression if constant folding succeeds. If
-// `tryEvaluateConstantExpression` throws a `VeloxUserError`, returns the
-// result of applying `makeFailExpr` to `expr`, otherwise returns `expr`.
+// Folds an all-constant expression to a single-row vector. Returns nullptr if
+// the expression cannot be folded. The two public optimize() overloads supply
+// an evaluator backed by a QueryCtx or an ExpressionEvaluator.
+using ConstantEvaluator = std::function<
+    VectorPtr(const core::TypedExprPtr& expr, bool suppressEvaluationFailures)>;
+
+core::TypedExprPtr optimize(
+    const core::TypedExprPtr& expr,
+    const ConstantEvaluator& constantEvaluator,
+    const MakeFailExpr& makeFailExpr);
+
+// Tries constant folding input `expr` with `constantEvaluator` and returns
+// the evaluated expression if constant folding succeeds. If
+// `constantEvaluator` throws a `VeloxUserError`, returns the result of
+// applying `makeFailExpr` to `expr`, otherwise returns `expr`.
 core::TypedExprPtr tryConstantFold(
     const core::TypedExprPtr& expr,
-    core::QueryCtx* queryCtx,
-    memory::MemoryPool* pool,
+    const ConstantEvaluator& constantEvaluator,
     const MakeFailExpr& makeFailExpr) {
   try {
     if (auto results =
-            exec::tryEvaluateConstantExpression(expr, pool, queryCtx, false)) {
+            constantEvaluator(expr, /*suppressEvaluationFailures=*/false)) {
       return std::make_shared<core::ConstantTypedExpr>(results);
     }
   } catch (VeloxUserError& e) {
@@ -57,14 +67,14 @@ core::TypedExprPtr tryConstantFold(
 // kind as expr but with optimized inputs.
 core::TypedExprPtr optimizeInputs(
     const core::TypedExprPtr& expr,
-    core::QueryCtx* queryCtx,
-    memory::MemoryPool* pool,
+    const ConstantEvaluator& constantEvaluator,
     const MakeFailExpr& makeFailExpr) {
   if (expr->isCallKind() || expr->isNullIfKind()) {
     std::vector<core::TypedExprPtr> optimizedInputs;
     optimizedInputs.reserve(expr->inputs().size());
     for (const auto& input : expr->inputs()) {
-      optimizedInputs.push_back(optimize(input, queryCtx, pool, makeFailExpr));
+      optimizedInputs.push_back(
+          optimize(input, constantEvaluator, makeFailExpr));
     }
 
     if (expr->isCallKind()) {
@@ -80,7 +90,7 @@ core::TypedExprPtr optimizeInputs(
 
   if (expr->isCastKind()) {
     const auto optimizedInput =
-        optimize(expr->inputs().at(0), queryCtx, pool, makeFailExpr);
+        optimize(expr->inputs().at(0), constantEvaluator, makeFailExpr);
     const auto* castExpr = expr->asUnchecked<core::CastTypedExpr>();
     return std::make_shared<core::CastTypedExpr>(
         expr->type(), optimizedInput, castExpr->isTryCast());
@@ -89,19 +99,16 @@ core::TypedExprPtr optimizeInputs(
   if (expr->isLambdaKind()) {
     const auto* lambdaExpr = expr->asUnchecked<core::LambdaTypedExpr>();
     const auto foldedBody =
-        optimize(lambdaExpr->body(), queryCtx, pool, makeFailExpr);
+        optimize(lambdaExpr->body(), constantEvaluator, makeFailExpr);
     return std::make_shared<core::LambdaTypedExpr>(
         lambdaExpr->signature(), foldedBody);
   }
 
   return expr;
 }
-} // namespace
-
 core::TypedExprPtr optimize(
     const core::TypedExprPtr& expr,
-    core::QueryCtx* queryCtx,
-    memory::MemoryPool* pool,
+    const ConstantEvaluator& constantEvaluator,
     const MakeFailExpr& makeFailExpr) {
   auto result = expr;
   // cast(1 AS BIGINT) -> 1.
@@ -117,7 +124,7 @@ core::TypedExprPtr optimize(
     return result;
   }
 
-  result = optimizeInputs(result, queryCtx, pool, makeFailExpr);
+  result = optimizeInputs(result, constantEvaluator, makeFailExpr);
   bool allInputsConstant = true;
   for (const auto& input : result->inputs()) {
     if (!input->isConstantKind()) {
@@ -127,9 +134,40 @@ core::TypedExprPtr optimize(
   }
 
   if (allInputsConstant) {
-    return tryConstantFold(result, queryCtx, pool, makeFailExpr);
+    return tryConstantFold(result, constantEvaluator, makeFailExpr);
   }
   return ExprRewriteRegistry::instance().rewrite(result);
+}
+
+} // namespace
+
+core::TypedExprPtr optimize(
+    const core::TypedExprPtr& expr,
+    core::QueryCtx* queryCtx,
+    memory::MemoryPool* pool,
+    const MakeFailExpr& makeFailExpr) {
+  return optimize(
+      expr,
+      [queryCtx, pool](
+          const core::TypedExprPtr& foldExpr, bool suppressEvaluationFailures) {
+        return exec::tryEvaluateConstantExpression(
+            foldExpr, pool, queryCtx, suppressEvaluationFailures);
+      },
+      makeFailExpr);
+}
+
+core::TypedExprPtr optimize(
+    const core::TypedExprPtr& expr,
+    core::ExpressionEvaluator* evaluator,
+    const MakeFailExpr& makeFailExpr) {
+  return optimize(
+      expr,
+      [evaluator](
+          const core::TypedExprPtr& foldExpr, bool suppressEvaluationFailures) {
+        return exec::tryEvaluateConstantExpression(
+            foldExpr, evaluator, suppressEvaluationFailures);
+      },
+      makeFailExpr);
 }
 
 } // namespace facebook::velox::expression

--- a/velox/expression/ExprOptimizer.h
+++ b/velox/expression/ExprOptimizer.h
@@ -13,8 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#pragma once
+
 #include "velox/core/Expressions.h"
 #include "velox/core/QueryCtx.h"
+
+namespace facebook::velox::core {
+class ExpressionEvaluator;
+}
 
 namespace facebook::velox::expression {
 
@@ -27,19 +33,25 @@ using MakeFailExpr = std::function<core::TypedExprPtr(
     const std::string& errorMessage,
     const TypePtr& resultType)>;
 
-/// Optimizes expression through a combination of constant folding and rewrites;
-/// all possible subtrees of the expression are constant folded first in a
-/// bottom up manner, then the folded expression is rewritten. If an exception
-/// (i.e VeloxUserError) is encountered during constant folding of any subtree
-/// of the expression and the function `makeFailExpr` is provided, the failing
-/// subexpression is replaced by the result of applying `makeFailExpr`, allowing
-/// users to define custom logic for handling constant folding errors during
-/// expression optimization. When `makeFailExpr` is not provided, exceptions
-/// encountered while constant folding subexpressions are ignored and failing
-/// subexpressions are left unchanged in the expression tree.
+/// Optimizes an expression through a combination of constant folding and
+/// rewrites; all possible subtrees are constant folded bottom-up, then the
+/// folded expression is rewritten. Constant subtrees are folded with
+/// `exec::tryEvaluateConstantExpression` using `queryCtx` and `pool`. If a
+/// `VeloxUserError` is encountered while folding a subtree and `makeFailExpr`
+/// is provided, the failing subexpression is replaced by the result of applying
+/// `makeFailExpr`; otherwise exceptions are ignored and the subexpression is
+/// left unchanged.
 core::TypedExprPtr optimize(
     const core::TypedExprPtr& expr,
     core::QueryCtx* queryCtx,
     memory::MemoryPool* pool,
+    const MakeFailExpr& makeFailExpr = nullptr);
+
+/// Variant of `optimize` that folds constant subtrees with `evaluator` (e.g.
+/// the ExpressionEvaluator a connector exposes for pushed down filters), for
+/// callers that have an ExpressionEvaluator but no QueryCtx.
+core::TypedExprPtr optimize(
+    const core::TypedExprPtr& expr,
+    core::ExpressionEvaluator* evaluator,
     const MakeFailExpr& makeFailExpr = nullptr);
 } // namespace facebook::velox::expression

--- a/velox/expression/ExprToSubfieldFilter.cpp
+++ b/velox/expression/ExprToSubfieldFilter.cpp
@@ -29,20 +29,8 @@ namespace {
 VectorPtr toConstant(
     const core::TypedExprPtr& expr,
     core::ExpressionEvaluator* evaluator) {
-  auto exprSet = evaluator->compile(expr);
-  if (!exprSet->exprs()[0]->isConstantExpr()) {
-    return nullptr;
-  }
-  RowVector input(
-      evaluator->pool(), ROW({}, {}), nullptr, 1, std::vector<VectorPtr>{});
-  SelectivityVector rows(1);
-  VectorPtr result;
-  try {
-    evaluator->evaluate(exprSet.get(), rows, input, result);
-  } catch (const VeloxUserError&) {
-    return nullptr;
-  }
-  return result;
+  return tryEvaluateConstantExpression(
+      expr, evaluator, /*suppressEvaluationFailures=*/true);
 }
 
 template <typename T>

--- a/velox/expression/tests/ExprOptimizerTest.cpp
+++ b/velox/expression/tests/ExprOptimizerTest.cpp
@@ -18,6 +18,7 @@
 
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/core/Expressions.h"
+#include "velox/expression/Expr.h"
 #include "velox/expression/ExprOptimizer.h"
 #include "velox/expression/ExprRewriteRegistry.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
@@ -297,6 +298,22 @@ TEST_F(ExprOptimizerTest, queryCtx) {
   testFromUnixtime("hour", "America/Los_Angeles", "7");
   testFromUnixtime("minute", "Pacific/Apia", "4");
   testFromUnixtime("minute", "America/Los_Angeles", "4");
+}
+
+TEST_F(ExprOptimizerTest, expressionEvaluatorOverload) {
+  // optimize can fold through a core::ExpressionEvaluator, for callers (e.g.
+  // connectors) that have an evaluator but no QueryCtx.
+  const auto emptyRow = ROW({});
+  const auto typedExpr = makeTypedExpr("1 + 2 * 3", emptyRow);
+  const auto queryCtx = core::QueryCtx::create();
+  exec::SimpleExpressionEvaluator evaluator(queryCtx.get(), pool());
+
+  const auto optimized = expression::optimize(typedExpr, &evaluator);
+  ASSERT_TRUE(*optimized == *makeTypedExpr("7", emptyRow));
+
+  // Results match the default QueryCtx-based overload.
+  ASSERT_TRUE(
+      *optimized == *expression::optimize(typedExpr, queryCtx.get(), pool()));
 }
 
 /// Test cast optimization that avoids expression evaluation when input to


### PR DESCRIPTION
## Summary

`expression::optimize()` and `exec::tryEvaluateConstantExpression()` previously
required a `core::QueryCtx` and a memory pool in order to constant-fold
subtrees of an expression. Callers that only hold a `core::ExpressionEvaluator`, 
for instance connectors that expose an evaluator to constant-fold pushed-down
filter expressions via `ConnectorQueryCtx`, had no way of invoking the expression 
optimizer for constant folding.

This change adds `core::ExpressionEvaluator` based overload for `optimize`.

## Motivation

Split out from the cuDF expression-compiler work: https://github.com/facebookincubator/velox/pull/17108. 
`CudfHiveDataSource` holds an `core::ExpressionEvaluator` but not a `core::QueryCtx`, 
which motivated the evaluator-based overloads.
