### PR TITLE
fix(iceberg): Fix Iceberg partition transform input row type

### DIFF
--- a/velox/connectors/hive/iceberg/IcebergDataSink.cpp
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.cpp
@@ -417,8 +417,28 @@ void IcebergDataSink::computePartitionAndBucketIds(const RowVectorPtr& input) {
   VELOX_CHECK(isPartitioned());
   VELOX_CHECK_NOT_NULL(transformEvaluator_);
   VELOX_CHECK_NOT_NULL(partitionIdGenerator_);
+  std::vector<VectorPtr> children;
+  children.reserve(input->childrenSize());
+
+  for (column_index_t i = 0; i < input->childrenSize(); ++i) {
+    VELOX_CHECK(
+        input->childAt(i)->type()->equivalent(*inputType_->childAt(i)),
+        "Iceberg write input type mismatch at column {}. Expected {}, got {}.",
+        i,
+        inputType_->childAt(i)->toString(),
+        input->childAt(i)->type()->toString());
+
+    children.push_back(input->childAt(i));
+  }
+
+  auto inputForTransforms = std::make_shared<RowVector>(
+      input->pool(),
+      inputType_,
+      input->nulls(),
+      input->size(),
+      std::move(children));
   // Step 1: Apply transforms to input partition columns.
-  auto transformedColumns = transformEvaluator_->evaluate(input);
+  auto transformedColumns = transformEvaluator_->evaluate(inputForTransforms);
 
   // Step 2: Create RowVector based on transformed columns.
   const auto& transformedRowVector = std::make_shared<RowVector>(

--- a/velox/connectors/hive/iceberg/tests/IcebergInsertTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergInsertTest.cpp
@@ -263,6 +263,33 @@ TEST_F(IcebergInsertTest, maxTargetFileSizeRotation) {
   exec::test::AssertQueryBuilder(plan).splits(splits).assertResults(vectors);
 }
 
+TEST_F(IcebergInsertTest, partitionTransformUsesExpectedInputFieldNames) {
+  auto tableRowType = ROW({
+      {"name", VARCHAR()},
+      {"id", INTEGER()},
+  });
+  const auto outputPath = TempDirectoryPath::create()->getPath();
+  const std::vector<test::PartitionField> partitionFields = {
+      {0, TransformType::kIdentity, std::nullopt}};
+
+  auto sink = createDataSink(tableRowType, outputPath, partitionFields);
+
+  auto actualInputType = ROW({
+      {"generated1", VARCHAR()},
+      {"generated2", INTEGER()},
+  });
+
+  std::vector<VectorPtr> children{
+      makeFlatVector<std::string>({"name1", "name2"}),
+      makeFlatVector<int32_t>({1, 2}),
+  };
+
+  auto input = std::make_shared<RowVector>(
+      pool(), actualInputType, nullptr, 2, std::move(children));
+
+  EXPECT_NO_THROW({ sink->appendData(input); });
+}
+
 #endif
 
 } // namespace


### PR DESCRIPTION
Iceberg partition transforms are resolved using table column names, but incoming Gluten row vectors may use generated field names. This change re-wraps the input children with the expected Iceberg input row type before evaluating partition transforms. The data is not copied or changed; only the row type metadata is normalized so field resolution succeeds.