### PR TITLE
refactor: Extract HiveIndexSourceUtils from anonymous namespace

### DIFF
--- a/velox/connectors/hive/CMakeLists.txt
+++ b/velox/connectors/hive/CMakeLists.txt
@@ -43,6 +43,7 @@ velox_add_library(
   HiveDataSink.cpp
   HiveDataSource.cpp
   HiveIndexSource.cpp
+  HiveIndexSourceUtils.cpp
   HivePartitionName.cpp
   HiveSplitReader.cpp
   PartitionIdGenerator.cpp
@@ -70,6 +71,7 @@ velox_add_library(
   HiveDataSink.h
   HiveDataSource.h
   HiveIndexSource.h
+  HiveIndexSourceUtils.h
   HivePartitionFunction.h
   HivePartitionName.h
   HiveSplitReader.h

--- a/velox/connectors/hive/HiveIndexSource.cpp
+++ b/velox/connectors/hive/HiveIndexSource.cpp
@@ -26,133 +26,13 @@
 #include "velox/connectors/hive/FileSplitReader.h"
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/HiveConnectorUtil.h"
+#include "velox/connectors/hive/HiveIndexSourceUtils.h"
 #include "velox/exec/OperatorUtils.h"
 #include "velox/expression/FieldReference.h"
 #include "velox/vector/LazyVector.h"
 
 namespace facebook::velox::connector::hive {
 namespace {
-
-// Extracts a constant value from a point lookup filter (single value equality).
-// Returns nullopt if the filter is not a point lookup or cannot be converted.
-std::optional<variant> extractPointLookupValue(const common::Filter* filter) {
-  VELOX_CHECK_NOT_NULL(filter);
-
-  switch (filter->kind()) {
-    case common::FilterKind::kBigintRange: {
-      const auto* range = filter->as<common::BigintRange>();
-      if (range->isSingleValue()) {
-        return variant(range->lower());
-      }
-      return std::nullopt;
-    }
-    case common::FilterKind::kDoubleRange: {
-      const auto* range = filter->as<common::DoubleRange>();
-      if (!range->lowerUnbounded() && !range->upperUnbounded() &&
-          range->lower() == range->upper() && !range->lowerExclusive() &&
-          !range->upperExclusive()) {
-        return variant(range->lower());
-      }
-      return std::nullopt;
-    }
-    case common::FilterKind::kFloatRange: {
-      const auto* range = filter->as<common::FloatRange>();
-      if (!range->lowerUnbounded() && !range->upperUnbounded() &&
-          range->lower() == range->upper() && !range->lowerExclusive() &&
-          !range->upperExclusive()) {
-        return variant(range->lower());
-      }
-      return std::nullopt;
-    }
-    case common::FilterKind::kBytesRange: {
-      const auto* range = filter->as<common::BytesRange>();
-      if (range->isSingleValue()) {
-        return variant(range->lower());
-      }
-      return std::nullopt;
-    }
-    case common::FilterKind::kBytesValues: {
-      const auto* values = filter->as<common::BytesValues>();
-      if (values->values().size() == 1) {
-        return variant(*values->values().begin());
-      }
-      return std::nullopt;
-    }
-    case common::FilterKind::kBoolValue: {
-      const auto* boolFilter = filter->as<common::BoolValue>();
-      // BoolValue doesn't expose value() getter - use testBool to determine the
-      // value
-      return variant(boolFilter->testBool(true));
-    }
-    default:
-      return std::nullopt;
-  }
-}
-
-// Extracts range bounds from a range filter.
-// Returns a pair of (lower, upper) variants. If a bound is unbounded, the
-// corresponding variant will be null.
-// Returns nullopt if the filter is not a range filter or cannot be converted.
-std::optional<std::pair<variant, variant>> extractRangeBounds(
-    const common::Filter* filter) {
-  VELOX_CHECK_NOT_NULL(filter);
-
-  switch (filter->kind()) {
-    case common::FilterKind::kBigintRange: {
-      const auto* range = filter->as<common::BigintRange>();
-      return std::make_pair(variant(range->lower()), variant(range->upper()));
-    }
-    case common::FilterKind::kDoubleRange: {
-      const auto* range = filter->as<common::DoubleRange>();
-      if (range->lowerUnbounded() || range->upperUnbounded()) {
-        // Cannot convert unbounded ranges to BetweenCondition.
-        return std::nullopt;
-      }
-      return std::make_pair(variant(range->lower()), variant(range->upper()));
-    }
-    case common::FilterKind::kFloatRange: {
-      const auto* range = filter->as<common::FloatRange>();
-      if (range->lowerUnbounded() || range->upperUnbounded()) {
-        return std::nullopt;
-      }
-      return std::make_pair(variant(range->lower()), variant(range->upper()));
-    }
-    case common::FilterKind::kBytesRange: {
-      const auto* range = filter->as<common::BytesRange>();
-      if (!range->isSingleValue()) {
-        // Only convert bounded range filters.
-        return std::make_pair(variant(range->lower()), variant(range->upper()));
-      }
-      return std::nullopt;
-    }
-    default:
-      return std::nullopt;
-  }
-}
-
-// Creates an EqualIndexLookupCondition with a constant value.
-core::IndexLookupConditionPtr createEqualConditionWithConstant(
-    const std::string& columnName,
-    const TypePtr& type,
-    const variant& value) {
-  auto keyExpr = std::make_shared<core::FieldAccessTypedExpr>(type, columnName);
-  auto constantExpr = std::make_shared<core::ConstantTypedExpr>(type, value);
-  return std::make_shared<core::EqualIndexLookupCondition>(
-      std::move(keyExpr), std::move(constantExpr));
-}
-
-// Creates a BetweenIndexLookupCondition with constant bounds.
-core::IndexLookupConditionPtr createBetweenConditionWithConstants(
-    const std::string& columnName,
-    const TypePtr& type,
-    const variant& lowerValue,
-    const variant& upperValue) {
-  auto keyExpr = std::make_shared<core::FieldAccessTypedExpr>(type, columnName);
-  auto lowerExpr = std::make_shared<core::ConstantTypedExpr>(type, lowerValue);
-  auto upperExpr = std::make_shared<core::ConstantTypedExpr>(type, upperValue);
-  return std::make_shared<core::BetweenIndexLookupCondition>(
-      std::move(keyExpr), std::move(lowerExpr), std::move(upperExpr));
-}
 
 // Checks that a HiveColumnHandle is a regular column type.
 void checkColumnHandleIsRegular(const FileColumnHandle& handle) {

--- a/velox/connectors/hive/HiveIndexSourceUtils.cpp
+++ b/velox/connectors/hive/HiveIndexSourceUtils.cpp
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/connectors/hive/HiveIndexSourceUtils.h"
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::connector::hive {
+
+std::optional<variant> extractPointLookupValue(const common::Filter* filter) {
+  VELOX_CHECK_NOT_NULL(filter);
+
+  switch (filter->kind()) {
+    case common::FilterKind::kBigintRange: {
+      const auto* range = filter->as<common::BigintRange>();
+      if (range->isSingleValue()) {
+        return variant(range->lower());
+      }
+      return std::nullopt;
+    }
+    case common::FilterKind::kDoubleRange: {
+      const auto* range = filter->as<common::DoubleRange>();
+      if (!range->lowerUnbounded() && !range->upperUnbounded() &&
+          range->lower() == range->upper() && !range->lowerExclusive() &&
+          !range->upperExclusive()) {
+        return variant(range->lower());
+      }
+      return std::nullopt;
+    }
+    case common::FilterKind::kFloatRange: {
+      const auto* range = filter->as<common::FloatRange>();
+      if (!range->lowerUnbounded() && !range->upperUnbounded() &&
+          range->lower() == range->upper() && !range->lowerExclusive() &&
+          !range->upperExclusive()) {
+        return variant(range->lower());
+      }
+      return std::nullopt;
+    }
+    case common::FilterKind::kBytesRange: {
+      const auto* range = filter->as<common::BytesRange>();
+      if (range->isSingleValue()) {
+        return variant(range->lower());
+      }
+      return std::nullopt;
+    }
+    case common::FilterKind::kBytesValues: {
+      const auto* values = filter->as<common::BytesValues>();
+      if (values->values().size() == 1) {
+        return variant(*values->values().begin());
+      }
+      return std::nullopt;
+    }
+    case common::FilterKind::kBoolValue: {
+      const auto* boolFilter = filter->as<common::BoolValue>();
+      return variant(boolFilter->testBool(true));
+    }
+    default:
+      return std::nullopt;
+  }
+}
+
+std::optional<std::pair<variant, variant>> extractRangeBounds(
+    const common::Filter* filter) {
+  VELOX_CHECK_NOT_NULL(filter);
+
+  switch (filter->kind()) {
+    case common::FilterKind::kBigintRange: {
+      const auto* range = filter->as<common::BigintRange>();
+      return std::make_pair(variant(range->lower()), variant(range->upper()));
+    }
+    case common::FilterKind::kDoubleRange: {
+      const auto* range = filter->as<common::DoubleRange>();
+      if (range->lowerUnbounded() || range->upperUnbounded()) {
+        return std::nullopt;
+      }
+      return std::make_pair(variant(range->lower()), variant(range->upper()));
+    }
+    case common::FilterKind::kFloatRange: {
+      const auto* range = filter->as<common::FloatRange>();
+      if (range->lowerUnbounded() || range->upperUnbounded()) {
+        return std::nullopt;
+      }
+      return std::make_pair(variant(range->lower()), variant(range->upper()));
+    }
+    case common::FilterKind::kBytesRange: {
+      const auto* range = filter->as<common::BytesRange>();
+      if (!range->isSingleValue()) {
+        return std::make_pair(variant(range->lower()), variant(range->upper()));
+      }
+      return std::nullopt;
+    }
+    default:
+      return std::nullopt;
+  }
+}
+
+core::IndexLookupConditionPtr createEqualConditionWithConstant(
+    const std::string& columnName,
+    const TypePtr& type,
+    const variant& value) {
+  auto keyExpr = std::make_shared<core::FieldAccessTypedExpr>(type, columnName);
+  auto constantExpr = std::make_shared<core::ConstantTypedExpr>(type, value);
+  return std::make_shared<core::EqualIndexLookupCondition>(
+      std::move(keyExpr), std::move(constantExpr));
+}
+
+core::IndexLookupConditionPtr createBetweenConditionWithConstants(
+    const std::string& columnName,
+    const TypePtr& type,
+    const variant& lowerValue,
+    const variant& upperValue) {
+  auto keyExpr = std::make_shared<core::FieldAccessTypedExpr>(type, columnName);
+  auto lowerExpr = std::make_shared<core::ConstantTypedExpr>(type, lowerValue);
+  auto upperExpr = std::make_shared<core::ConstantTypedExpr>(type, upperValue);
+  return std::make_shared<core::BetweenIndexLookupCondition>(
+      std::move(keyExpr), std::move(lowerExpr), std::move(upperExpr));
+}
+
+} // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveIndexSourceUtils.h
+++ b/velox/connectors/hive/HiveIndexSourceUtils.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <optional>
+#include <utility>
+#include "velox/core/PlanNode.h"
+#include "velox/type/Filter.h"
+#include "velox/type/Variant.h"
+
+namespace facebook::velox::connector::hive {
+
+/// Extracts a constant value from a point lookup filter (single value
+/// equality). Returns nullopt if the filter is not a point lookup or cannot be
+/// converted.
+std::optional<variant> extractPointLookupValue(const common::Filter* filter);
+
+/// Extracts range bounds from a range filter. Returns a pair of (lower, upper)
+/// inclusive variants suitable for creating a BetweenIndexLookupCondition.
+/// Returns nullopt if the filter is not a range filter or cannot be converted.
+std::optional<std::pair<variant, variant>> extractRangeBounds(
+    const common::Filter* filter);
+
+/// Creates an EqualIndexLookupCondition with a constant value.
+core::IndexLookupConditionPtr createEqualConditionWithConstant(
+    const std::string& columnName,
+    const TypePtr& type,
+    const variant& value);
+
+/// Creates a BetweenIndexLookupCondition with constant bounds.
+core::IndexLookupConditionPtr createBetweenConditionWithConstants(
+    const std::string& columnName,
+    const TypePtr& type,
+    const variant& lowerValue,
+    const variant& upperValue);
+
+} // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/tests/CMakeLists.txt
+++ b/velox/connectors/hive/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(
   velox_hive_connector_test
   FileColumnHandleTest.cpp
   FileConfigTest.cpp
+  HiveIndexSourceUtilsTest.cpp
   FileConnectorSplitTest.cpp
   FileConnectorUtilTest.cpp
   FileHandleTest.cpp

--- a/velox/connectors/hive/tests/HiveIndexSourceUtilsTest.cpp
+++ b/velox/connectors/hive/tests/HiveIndexSourceUtilsTest.cpp
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/HiveIndexSourceUtils.h"
+#include <gtest/gtest.h>
+
+namespace facebook::velox::connector::hive {
+namespace {
+
+class ExtractRangeBoundsTest : public ::testing::Test {};
+
+// --- BigintRange tests ---
+
+TEST_F(ExtractRangeBoundsTest, bigintRangeInclusive) {
+  auto filter = std::make_unique<common::BigintRange>(
+      /*lower=*/10, /*upper=*/20, /*nullAllowed=*/false);
+  auto result = extractRangeBounds(filter.get());
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->first.value<int64_t>(), 10);
+  EXPECT_EQ(result->second.value<int64_t>(), 20);
+}
+
+TEST_F(ExtractRangeBoundsTest, bigintRangeSingleValue) {
+  auto filter = std::make_unique<common::BigintRange>(
+      /*lower=*/42, /*upper=*/42, /*nullAllowed=*/false);
+  auto result = extractRangeBounds(filter.get());
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->first.value<int64_t>(), 42);
+  EXPECT_EQ(result->second.value<int64_t>(), 42);
+}
+
+// --- DoubleRange tests ---
+
+TEST_F(ExtractRangeBoundsTest, doubleRangeBothInclusive) {
+  auto filter = std::make_unique<common::DoubleRange>(
+      /*lower=*/1.0,
+      /*lowerUnbounded=*/false,
+      /*lowerExclusive=*/false,
+      /*upper=*/5.0,
+      /*upperUnbounded=*/false,
+      /*upperExclusive=*/false,
+      /*nullAllowed=*/false);
+  auto result = extractRangeBounds(filter.get());
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->first.value<double>(), 1.0);
+  EXPECT_EQ(result->second.value<double>(), 5.0);
+}
+
+TEST_F(ExtractRangeBoundsTest, doubleRangeUnboundedReturnsNullopt) {
+  auto filter = std::make_unique<common::DoubleRange>(
+      /*lower=*/1.0,
+      /*lowerUnbounded=*/false,
+      /*lowerExclusive=*/true,
+      /*upper=*/0.0,
+      /*upperUnbounded=*/true,
+      /*upperExclusive=*/true,
+      /*nullAllowed=*/false);
+  auto result = extractRangeBounds(filter.get());
+  EXPECT_FALSE(result.has_value());
+}
+
+// --- FloatRange tests ---
+// FloatingPointRange::lower()/upper() return double regardless of T,
+// so the variant is always DOUBLE kind.
+
+TEST_F(ExtractRangeBoundsTest, floatRangeBothInclusive) {
+  auto filter = std::make_unique<common::FloatRange>(
+      /*lower=*/1.0f,
+      /*lowerUnbounded=*/false,
+      /*lowerExclusive=*/false,
+      /*upper=*/5.0f,
+      /*upperUnbounded=*/false,
+      /*upperExclusive=*/false,
+      /*nullAllowed=*/false);
+  auto result = extractRangeBounds(filter.get());
+  ASSERT_TRUE(result.has_value());
+  EXPECT_DOUBLE_EQ(result->first.value<double>(), 1.0);
+  EXPECT_DOUBLE_EQ(result->second.value<double>(), 5.0);
+}
+
+TEST_F(ExtractRangeBoundsTest, floatRangeUnboundedReturnsNullopt) {
+  auto filter = std::make_unique<common::FloatRange>(
+      /*lower=*/0.0f,
+      /*lowerUnbounded=*/true,
+      /*lowerExclusive=*/true,
+      /*upper=*/5.0f,
+      /*upperUnbounded=*/false,
+      /*upperExclusive=*/true,
+      /*nullAllowed=*/false);
+  auto result = extractRangeBounds(filter.get());
+  EXPECT_FALSE(result.has_value());
+}
+
+// --- extractPointLookupValue tests ---
+
+class ExtractPointLookupValueTest : public ::testing::Test {};
+
+TEST_F(ExtractPointLookupValueTest, bigintSingleValue) {
+  auto filter = std::make_unique<common::BigintRange>(
+      /*lower=*/42, /*upper=*/42, /*nullAllowed=*/false);
+  auto result = extractPointLookupValue(filter.get());
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->value<int64_t>(), 42);
+}
+
+TEST_F(ExtractPointLookupValueTest, bigintRangeNotPoint) {
+  auto filter = std::make_unique<common::BigintRange>(
+      /*lower=*/10, /*upper=*/20, /*nullAllowed=*/false);
+  auto result = extractPointLookupValue(filter.get());
+  EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(ExtractPointLookupValueTest, doubleExactPoint) {
+  auto filter = std::make_unique<common::DoubleRange>(
+      /*lower=*/3.14,
+      /*lowerUnbounded=*/false,
+      /*lowerExclusive=*/false,
+      /*upper=*/3.14,
+      /*upperUnbounded=*/false,
+      /*upperExclusive=*/false,
+      /*nullAllowed=*/false);
+  auto result = extractPointLookupValue(filter.get());
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->value<double>(), 3.14);
+}
+
+TEST_F(ExtractPointLookupValueTest, doubleExclusiveNotPoint) {
+  auto filter = std::make_unique<common::DoubleRange>(
+      /*lower=*/3.14,
+      /*lowerUnbounded=*/false,
+      /*lowerExclusive=*/true,
+      /*upper=*/3.14,
+      /*upperUnbounded=*/false,
+      /*upperExclusive=*/true,
+      /*nullAllowed=*/false);
+  auto result = extractPointLookupValue(filter.get());
+  EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(ExtractPointLookupValueTest, doubleRangeNotPoint) {
+  auto filter = std::make_unique<common::DoubleRange>(
+      /*lower=*/1.0,
+      /*lowerUnbounded=*/false,
+      /*lowerExclusive=*/false,
+      /*upper=*/5.0,
+      /*upperUnbounded=*/false,
+      /*upperExclusive=*/false,
+      /*nullAllowed=*/false);
+  auto result = extractPointLookupValue(filter.get());
+  EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(ExtractPointLookupValueTest, floatExactPoint) {
+  auto filter = std::make_unique<common::FloatRange>(
+      /*lower=*/2.5f,
+      /*lowerUnbounded=*/false,
+      /*lowerExclusive=*/false,
+      /*upper=*/2.5f,
+      /*upperUnbounded=*/false,
+      /*upperExclusive=*/false,
+      /*nullAllowed=*/false);
+  auto result = extractPointLookupValue(filter.get());
+  ASSERT_TRUE(result.has_value());
+  EXPECT_DOUBLE_EQ(result->value<double>(), 2.5);
+}
+
+TEST_F(ExtractPointLookupValueTest, floatExclusiveNotPoint) {
+  auto filter = std::make_unique<common::FloatRange>(
+      /*lower=*/2.5f,
+      /*lowerUnbounded=*/false,
+      /*lowerExclusive=*/false,
+      /*upper=*/2.5f,
+      /*upperUnbounded=*/false,
+      /*upperExclusive=*/true,
+      /*nullAllowed=*/false);
+  auto result = extractPointLookupValue(filter.get());
+  EXPECT_FALSE(result.has_value());
+}
+
+// --- createEqualConditionWithConstant tests ---
+
+class CreateEqualConditionTest : public ::testing::Test {};
+
+TEST_F(CreateEqualConditionTest, bigintConstant) {
+  auto condition = createEqualConditionWithConstant(
+      "id", BIGINT(), variant(static_cast<int64_t>(42)));
+  ASSERT_NE(condition, nullptr);
+  auto equal =
+      std::dynamic_pointer_cast<core::EqualIndexLookupCondition>(condition);
+  ASSERT_NE(equal, nullptr);
+  EXPECT_EQ(equal->key->name(), "id");
+  EXPECT_EQ(*equal->key->type(), *BIGINT());
+  auto constant =
+      std::dynamic_pointer_cast<const core::ConstantTypedExpr>(equal->value);
+  ASSERT_NE(constant, nullptr);
+  EXPECT_EQ(constant->value().value<int64_t>(), 42);
+}
+
+TEST_F(CreateEqualConditionTest, doubleConstant) {
+  auto condition =
+      createEqualConditionWithConstant("score", DOUBLE(), variant(3.14));
+  auto equal =
+      std::dynamic_pointer_cast<core::EqualIndexLookupCondition>(condition);
+  ASSERT_NE(equal, nullptr);
+  EXPECT_EQ(equal->key->name(), "score");
+  auto constant =
+      std::dynamic_pointer_cast<const core::ConstantTypedExpr>(equal->value);
+  ASSERT_NE(constant, nullptr);
+  EXPECT_EQ(constant->value().value<double>(), 3.14);
+}
+
+// --- createBetweenConditionWithConstants tests ---
+
+class CreateBetweenConditionTest : public ::testing::Test {};
+
+TEST_F(CreateBetweenConditionTest, bigintRange) {
+  auto condition = createBetweenConditionWithConstants(
+      "id",
+      BIGINT(),
+      variant(static_cast<int64_t>(10)),
+      variant(static_cast<int64_t>(20)));
+  ASSERT_NE(condition, nullptr);
+  auto between =
+      std::dynamic_pointer_cast<core::BetweenIndexLookupCondition>(condition);
+  ASSERT_NE(between, nullptr);
+  EXPECT_EQ(between->key->name(), "id");
+  EXPECT_EQ(*between->key->type(), *BIGINT());
+  auto lower =
+      std::dynamic_pointer_cast<const core::ConstantTypedExpr>(between->lower);
+  auto upper =
+      std::dynamic_pointer_cast<const core::ConstantTypedExpr>(between->upper);
+  ASSERT_NE(lower, nullptr);
+  ASSERT_NE(upper, nullptr);
+  EXPECT_EQ(lower->value().value<int64_t>(), 10);
+  EXPECT_EQ(upper->value().value<int64_t>(), 20);
+}
+
+TEST_F(CreateBetweenConditionTest, doubleRange) {
+  auto condition = createBetweenConditionWithConstants(
+      "score", DOUBLE(), variant(1.0), variant(5.0));
+  auto between =
+      std::dynamic_pointer_cast<core::BetweenIndexLookupCondition>(condition);
+  ASSERT_NE(between, nullptr);
+  EXPECT_EQ(between->key->name(), "score");
+  auto lower =
+      std::dynamic_pointer_cast<const core::ConstantTypedExpr>(between->lower);
+  auto upper =
+      std::dynamic_pointer_cast<const core::ConstantTypedExpr>(between->upper);
+  ASSERT_NE(lower, nullptr);
+  ASSERT_NE(upper, nullptr);
+  EXPECT_EQ(lower->value().value<double>(), 1.0);
+  EXPECT_EQ(upper->value().value<double>(), 5.0);
+}
+
+} // namespace
+} // namespace facebook::velox::connector::hive


### PR DESCRIPTION
Summary:
Extract `extractPointLookupValue`, `extractRangeBounds`, `createEqualConditionWithConstant`, and `createBetweenConditionWithConstants` from the anonymous namespace in `HiveIndexSource.cpp` into a new `HiveIndexSourceUtils.{h,cpp}` in the `hive` namespace. This makes these functions testable from a separate translation unit.

Add 17 unit tests covering all existing correct behavior: BigintRange, DoubleRange, FloatRange point lookups and range bounds, unbounded ranges returning nullopt, and the two condition factory functions.

Differential Revision: D109478345


