### PR TITLE
fix(rpc): Fix batch response row-alignment

### DIFF
--- a/velox/common/rpc/RPCTypes.h
+++ b/velox/common/rpc/RPCTypes.h
@@ -98,6 +98,14 @@ struct RPCRequest {
 /// This is a minimal, domain-agnostic structure that works for any backend.
 struct RPCResponse {
   /// Row ID for correlating response with the original request.
+  ///
+  /// Two meanings depending on context:
+  ///   - In flushBatch() return values: the 0-based index of this response
+  ///     within the flushed batch (set by the function). The operator uses
+  ///     this to scatter responses into the correct positions before
+  ///     stamping the global row ID.
+  ///   - After operator processing: a globally unique ID assigned by the
+  ///     operator for downstream result tracking.
   int64_t rowId{0};
 
   /// The response result (opaque to the framework).

--- a/velox/exec/rpc/CMakeLists.txt
+++ b/velox/exec/rpc/CMakeLists.txt
@@ -64,5 +64,18 @@ if(${VELOX_BUILD_TESTING})
     velox_async_rpc_function
   )
 
+  velox_add_library(
+    velox_demo_batch_rpc_function
+    tests/DemoBatchRPCFunction.cpp
+    HEADERS
+    tests/DemoBatchRPCFunction.h
+  )
+
+  velox_link_libraries(
+    velox_demo_batch_rpc_function
+    velox_expression_functions
+    velox_async_rpc_function
+  )
+
   add_subdirectory(tests)
 endif()

--- a/velox/exec/rpc/RPCOperator.cpp
+++ b/velox/exec/rpc/RPCOperator.cpp
@@ -235,7 +235,13 @@ void RPCOperator::flushBatchRequests(int32_t maxRows) {
   auto token = std::make_shared<RPCRateLimiter::Token>(
       RPCRateLimiter::acquire(tierKey_));
 
-  // Stamp rowIds onto responses.
+  // Scatter responses into batch-position order using each response's
+  // function-assigned rowId (its position within the batch), then stamp
+  // the global rowIds. Functions may return results out of order (e.g.,
+  // MetaGen's batchDialogCompletion streams results in arbitrary order).
+  // Without this, responses[i] would be paired with rowLocations[i] in
+  // buildOutputFromReadyBatch, silently mis-mapping results to wrong
+  // passthrough rows.
   auto wrapped =
       std::move(future)
           .within(kBatchRpcTimeout)
@@ -247,10 +253,26 @@ void RPCOperator::flushBatchRequests(int32_t maxRows) {
                 "RPC batch response count ({}) does not match row count ({})",
                 resps.size(),
                 rowIds.size());
-            for (size_t i = 0; i < resps.size(); ++i) {
-              resps[i].rowId = rowIds[i];
+            std::vector<RPCResponse> sorted(resps.size());
+            std::vector<bool> seen(resps.size(), false);
+            for (auto& resp : resps) {
+              auto batchIdx = resp.rowId;
+              VELOX_CHECK_GE(batchIdx, 0);
+              VELOX_CHECK_LT(
+                  static_cast<size_t>(batchIdx),
+                  rowIds.size(),
+                  "RPC batch response rowId ({}) out of range (0-{})",
+                  batchIdx,
+                  rowIds.size() - 1);
+              VELOX_CHECK(
+                  !seen[static_cast<size_t>(batchIdx)],
+                  "Duplicate batch response rowId ({})",
+                  batchIdx);
+              seen[static_cast<size_t>(batchIdx)] = true;
+              resp.rowId = rowIds[static_cast<size_t>(batchIdx)];
+              sorted[static_cast<size_t>(batchIdx)] = std::move(resp);
             }
-            return resps;
+            return sorted;
           })
           .deferError([token](folly::exception_wrapper ew) {
             RPC_OP_LOG(ERROR) << "RPC batch failed: " << ew.what();

--- a/velox/exec/rpc/RPCState.cpp
+++ b/velox/exec/rpc/RPCState.cpp
@@ -214,12 +214,17 @@ void RPCState::addPendingBatch(
     std::shared_ptr<RPCState> selfPtr,
     folly::SemiFuture<std::vector<RPCResponse>> future,
     std::vector<RowLocation> rowLocations) {
-  std::lock_guard<std::mutex> l(mutex_);
-
-  int64_t batchId = nextBatchId_++;
-
-  // Attach a completion callback that notifies waiters when the batch
-  // completes. We use .via().thenValue() to run the callback eagerly.
+  // Build the callback chain OUTSIDE the lock. The .via(InlineExecutor)
+  // may drive the chain synchronously if the future is already resolved,
+  // and the thenValue/thenError callbacks acquire mutex_ to notify
+  // waiters. Holding mutex_ here would deadlock.
+  //
+  // If the chain completes inline, notifyWaitersLocked() fires before
+  // the batch is inserted into pendingBatches_ below. This is safe:
+  // RPCState is per-driver (owned by RPCOperator, never shared), so no
+  // other thread can be blocked in tryPollBatchOrWait during addInput —
+  // promises_ is empty and the notification is a no-op. The batch is
+  // found as already-ready by tryPollBatchOrWait on the next isBlocked.
   auto callbackFuture =
       std::move(future)
           .via(folly::getKeepAliveToken(folly::InlineExecutor::instance()))
@@ -243,14 +248,18 @@ void RPCState::addPendingBatch(
           })
           .semi();
 
-  pendingBatches_.push_back(
-      PendingBatch{
-          .batchId = batchId,
-          .future = std::move(callbackFuture),
-          .rowLocations = std::move(rowLocations)});
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    auto batchId = nextBatchId_++;
+    pendingBatches_.push_back(
+        PendingBatch{
+            .batchId = batchId,
+            .future = std::move(callbackFuture),
+            .rowLocations = std::move(rowLocations)});
 
-  RPC_STATE_VLOG(1) << "addPendingBatch: batchId=" << batchId
-                    << ", totalPending=" << pendingBatches_.size();
+    RPC_STATE_VLOG(1) << "addPendingBatch: batchId=" << batchId
+                      << ", totalPending=" << pendingBatches_.size();
+  }
 }
 
 RPCState::BatchPollResult RPCState::tryPollBatchOrWait(

--- a/velox/exec/rpc/tests/CMakeLists.txt
+++ b/velox/exec/rpc/tests/CMakeLists.txt
@@ -84,6 +84,7 @@ add_executable(velox_rpc_operator_test RPCOperatorTest.cpp Main.cpp)
 
 target_link_libraries(
   velox_rpc_operator_test
+  velox_demo_batch_rpc_function
   velox_demo_rpc_function
   velox_rpc_plan_node_translator
   velox_async_rpc_function_registry

--- a/velox/exec/rpc/tests/DemoBatchRPCFunction.cpp
+++ b/velox/exec/rpc/tests/DemoBatchRPCFunction.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/rpc/tests/DemoBatchRPCFunction.h"
+
+#include <algorithm>
+
+namespace facebook::velox::exec::rpc {
+
+DemoBatchRPCFunction::DemoBatchRPCFunction(
+    ResponseOrder order,
+    std::unordered_set<int32_t> failingRowIndices)
+    : responseOrder_(order), failingRowIndices_(std::move(failingRowIndices)) {}
+
+void DemoBatchRPCFunction::initialize(
+    const core::QueryConfig& /*queryConfig*/,
+    const std::vector<TypePtr>& /*inputTypes*/,
+    const std::vector<VectorPtr>& /*constantInputs*/) {}
+
+std::vector<std::pair<vector_size_t, folly::SemiFuture<RPCResponse>>>
+DemoBatchRPCFunction::dispatchPerRow(
+    const SelectivityVector& /*rows*/,
+    const std::vector<VectorPtr>& /*args*/) {
+  VELOX_UNSUPPORTED(
+      "DemoBatchRPCFunction is batch-only; use accumulateBatch/flushBatch");
+}
+
+std::vector<vector_size_t> DemoBatchRPCFunction::accumulateBatch(
+    const SelectivityVector& rows,
+    const std::vector<VectorPtr>& args) {
+  std::vector<vector_size_t> indices;
+
+  if (args.empty()) {
+    return indices;
+  }
+
+  auto* promptVector = args[0]->as<SimpleVector<StringView>>();
+  if (!promptVector) {
+    return indices;
+  }
+
+  rows.applyToSelected([&](vector_size_t row) {
+    indices.push_back(row);
+    if (promptVector->isNullAt(row)) {
+      pendingRows_.push_back({.prompt = "", .isNull = true});
+    } else {
+      pendingRows_.push_back(
+          {.prompt = promptVector->valueAt(row).str(), .isNull = false});
+    }
+  });
+
+  totalAccumulatedCount_ += static_cast<int32_t>(indices.size());
+  return indices;
+}
+
+folly::SemiFuture<std::vector<RPCResponse>> DemoBatchRPCFunction::flushBatch(
+    int32_t maxRows) {
+  auto flushCount = maxRows > 0
+      ? std::min(static_cast<int32_t>(pendingRows_.size()), maxRows)
+      : static_cast<int32_t>(pendingRows_.size());
+
+  std::vector<PendingRow> toFlush(
+      pendingRows_.begin(), pendingRows_.begin() + flushCount);
+  pendingRows_.erase(pendingRows_.begin(), pendingRows_.begin() + flushCount);
+
+  std::vector<RPCResponse> responses;
+  responses.reserve(toFlush.size());
+
+  // The index within this flush determines the "global accumulated index"
+  // used to check failingRowIndices_. We use totalAccumulatedCount_ minus
+  // the remaining pending rows to compute the starting offset.
+  auto startOffset = totalAccumulatedCount_ -
+      static_cast<int32_t>(pendingRows_.size()) - flushCount;
+
+  for (int32_t i = 0; i < flushCount; ++i) {
+    RPCResponse response;
+    response.rowId = i;
+
+    if (toFlush[i].isNull) {
+      response.error = "null_input";
+    } else if (failingRowIndices_.count(startOffset + i)) {
+      response.error = "simulated_failure";
+    } else {
+      response.result = "Batch response for: " + toFlush[i].prompt;
+    }
+    responses.push_back(std::move(response));
+  }
+
+  if (responseOrder_ == ResponseOrder::kReversed) {
+    std::reverse(responses.begin(), responses.end());
+  }
+
+  return folly::makeSemiFuture(std::move(responses));
+}
+
+int32_t DemoBatchRPCFunction::pendingBatchSize() const {
+  return static_cast<int32_t>(pendingRows_.size());
+}
+
+std::vector<std::shared_ptr<exec::FunctionSignature>>
+DemoBatchRPCFunction::signatures() {
+  auto sig = exec::FunctionSignatureBuilder()
+                 .returnType("varchar")
+                 .argumentType("varchar")
+                 .build();
+  return {std::move(sig)};
+}
+
+} // namespace facebook::velox::exec::rpc

--- a/velox/exec/rpc/tests/DemoBatchRPCFunction.h
+++ b/velox/exec/rpc/tests/DemoBatchRPCFunction.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <unordered_set>
+
+#include "velox/expression/FunctionSignature.h"
+#include "velox/expression/rpc/AsyncRPCFunction.h"
+
+namespace facebook::velox::exec::rpc {
+
+/// Batch-capable AsyncRPCFunction for testing RPCOperator's BATCH mode.
+///
+/// Supports configurable response behaviors to exercise correctness
+/// edge cases in the batch dispatch pipeline:
+///   - In-order responses (default, happy path)
+///   - Reversed responses (simulates backend returning out of order)
+///   - Per-row failures (simulates partial batch failure)
+///
+/// Returns "Batch response for: <prompt>" for each non-null, non-failing row.
+/// Null inputs produce RPCResponse{.error = "null_input"}.
+/// Failing rows produce RPCResponse{.error = "simulated_failure"}.
+class DemoBatchRPCFunction : public AsyncRPCFunction {
+ public:
+  enum class ResponseOrder {
+    kInOrder,
+    kReversed,
+  };
+
+  explicit DemoBatchRPCFunction(
+      ResponseOrder order = ResponseOrder::kInOrder,
+      std::unordered_set<int32_t> failingRowIndices = {});
+
+  void initialize(
+      const core::QueryConfig& queryConfig,
+      const std::vector<TypePtr>& inputTypes,
+      const std::vector<VectorPtr>& constantInputs) override;
+
+  std::string name() const override {
+    return "demo_batch_rpc";
+  }
+
+  TypePtr resultType() const override {
+    return VARCHAR();
+  }
+
+  std::vector<std::pair<vector_size_t, folly::SemiFuture<RPCResponse>>>
+  dispatchPerRow(
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args) override;
+
+  std::vector<vector_size_t> accumulateBatch(
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args) override;
+
+  folly::SemiFuture<std::vector<RPCResponse>> flushBatch(
+      int32_t maxRows) override;
+
+  int32_t pendingBatchSize() const override;
+
+  static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures();
+
+ private:
+  struct PendingRow {
+    std::string prompt;
+    bool isNull;
+  };
+
+  std::vector<PendingRow> pendingRows_;
+  ResponseOrder responseOrder_;
+  std::unordered_set<int32_t> failingRowIndices_;
+  int32_t totalAccumulatedCount_{0};
+};
+
+} // namespace facebook::velox::exec::rpc

--- a/velox/exec/rpc/tests/RPCOperatorTest.cpp
+++ b/velox/exec/rpc/tests/RPCOperatorTest.cpp
@@ -45,6 +45,10 @@ class RPCOperatorTest : public OperatorTestBase {
     AsyncRPCFunctionRegistry::registerFunction("demo_batch_rpc", []() {
       return std::make_shared<DemoBatchRPCFunction>();
     });
+    AsyncRPCFunctionRegistry::registerFunction("demo_batch_rpc_reversed", []() {
+      return std::make_shared<DemoBatchRPCFunction>(
+          DemoBatchRPCFunction::ResponseOrder::kReversed);
+    });
     AsyncRPCFunctionRegistry::registerFunction(
         "demo_batch_rpc_partial_fail", []() {
           return std::make_shared<DemoBatchRPCFunction>(
@@ -260,6 +264,44 @@ TEST_F(RPCOperatorTest, batchBasic) {
   EXPECT_EQ(rows["hello"], "Batch response for: hello");
   EXPECT_EQ(rows["world"], "Batch response for: world");
   EXPECT_EQ(rows["batch"], "Batch response for: batch");
+}
+
+// Reversed responses: the mock returns results in reverse order.
+// Before the fix in RPCOperator::flushBatchRequests (scatter by rowId instead
+// of positional stamping), this test would fail — each row would receive
+// another row's result because the operator stamped rowIds positionally
+// onto the reversed response vector.
+TEST_F(RPCOperatorTest, batchReversedResponseOrder) {
+  auto input = makeRowVector(
+      {"id", "prompt"},
+      {makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+       makeFlatVector<StringView>(
+           {"alpha", "bravo", "charlie", "delta", "echo"})});
+
+  auto plan = makeBatchRPCNode(
+      PlanBuilder().values({input}).planNode(),
+      {"prompt"},
+      "demo_batch_rpc_reversed");
+
+  auto result = AssertQueryBuilder(plan).copyResults(pool());
+
+  ASSERT_EQ(result->size(), 5);
+
+  auto* ids = result->childAt(0)->asFlatVector<int64_t>();
+  auto* prompts = result->childAt(1)->asFlatVector<StringView>();
+  auto* results = result->childAt(2)->asFlatVector<StringView>();
+
+  std::map<int64_t, std::pair<std::string, std::string>> rowMap;
+  for (vector_size_t i = 0; i < result->size(); ++i) {
+    rowMap[ids->valueAt(i)] = {
+        prompts->valueAt(i).str(), results->valueAt(i).str()};
+  }
+
+  EXPECT_EQ(rowMap[1].second, "Batch response for: alpha");
+  EXPECT_EQ(rowMap[2].second, "Batch response for: bravo");
+  EXPECT_EQ(rowMap[3].second, "Batch response for: charlie");
+  EXPECT_EQ(rowMap[4].second, "Batch response for: delta");
+  EXPECT_EQ(rowMap[5].second, "Batch response for: echo");
 }
 
 // Partial batch failure: rows at indices 1 and 3 fail, others succeed.

--- a/velox/exec/rpc/tests/RPCOperatorTest.cpp
+++ b/velox/exec/rpc/tests/RPCOperatorTest.cpp
@@ -24,6 +24,7 @@
 
 #include "velox/exec/rpc/RPCPlanNodeTranslator.h"
 #include "velox/exec/rpc/RPCRateLimiter.h"
+#include "velox/exec/rpc/tests/DemoBatchRPCFunction.h"
 #include "velox/exec/rpc/tests/DemoRPCFunction.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
@@ -41,6 +42,15 @@ class RPCOperatorTest : public OperatorTestBase {
     registerRPCPlanNodeTranslator();
     AsyncRPCFunctionRegistry::registerFunction(
         "demo_rpc", []() { return std::make_shared<DemoAsyncRPCFunction>(); });
+    AsyncRPCFunctionRegistry::registerFunction("demo_batch_rpc", []() {
+      return std::make_shared<DemoBatchRPCFunction>();
+    });
+    AsyncRPCFunctionRegistry::registerFunction(
+        "demo_batch_rpc_partial_fail", []() {
+          return std::make_shared<DemoBatchRPCFunction>(
+              DemoBatchRPCFunction::ResponseOrder::kInOrder,
+              std::unordered_set<int32_t>{1, 3});
+        });
   }
 
   static void TearDownTestCase() {
@@ -56,7 +66,44 @@ class RPCOperatorTest : public OperatorTestBase {
     OperatorTestBase::TearDown();
   }
 
-  /// Build an RPCNode on top of a source plan node.
+  /// Build a BATCH-mode RPCNode on top of a source plan node.
+  core::PlanNodePtr makeBatchRPCNode(
+      const core::PlanNodePtr& source,
+      const std::vector<std::string>& argumentColumnNames,
+      const std::string& functionName = "demo_batch_rpc",
+      int32_t dispatchBatchSize = 0) {
+    auto sourceType = source->outputType();
+
+    std::vector<std::string> argCols;
+    std::vector<TypePtr> argTypes;
+    std::vector<VectorPtr> constantInputs;
+    for (const auto& colName : argumentColumnNames) {
+      argCols.push_back(colName);
+      argTypes.push_back(sourceType->findChild(colName));
+      constantInputs.push_back(nullptr);
+    }
+
+    auto outputNames = sourceType->names();
+    auto outputTypes = sourceType->children();
+    outputNames.emplace_back("__rpc_result");
+    outputTypes.push_back(VARCHAR());
+    auto outputType = ROW(std::move(outputNames), std::move(outputTypes));
+
+    return std::make_shared<core::RPCNode>(
+        "rpc-0",
+        source,
+        functionName,
+        VARCHAR(),
+        "__rpc_result",
+        outputType,
+        argCols,
+        argTypes,
+        constantInputs,
+        RPCStreamingMode::kBatch,
+        dispatchBatchSize);
+  }
+
+  /// Build a PER_ROW-mode RPCNode on top of a source plan node.
   /// argumentColumnNames specifies which source columns are RPC arguments.
   core::PlanNodePtr makeRPCNode(
       const core::PlanNodePtr& source,
@@ -184,6 +231,152 @@ TEST_F(RPCOperatorTest, multipleColumns) {
   EXPECT_EQ(ids->valueAt(i2), 200);
   EXPECT_EQ(extras->valueAt(i2), 2.5);
   EXPECT_EQ(results->valueAt(i2).str(), "Response for: question two");
+}
+
+// ============================================================
+// BATCH mode tests — exercise accumulateBatch/flushBatch path
+// ============================================================
+
+// Basic batch mode: responses in order, verify passthrough + result.
+TEST_F(RPCOperatorTest, batchBasic) {
+  auto input = makeRowVector(
+      {"prompt"}, {makeFlatVector<StringView>({"hello", "world", "batch"})});
+
+  auto plan =
+      makeBatchRPCNode(PlanBuilder().values({input}).planNode(), {"prompt"});
+
+  auto result = AssertQueryBuilder(plan).maxDrivers(1).copyResults(pool());
+
+  ASSERT_EQ(result->size(), 3);
+
+  auto* prompts = result->childAt(0)->asFlatVector<StringView>();
+  auto* results = result->childAt(1)->asFlatVector<StringView>();
+
+  std::map<std::string, std::string> rows;
+  for (vector_size_t i = 0; i < result->size(); ++i) {
+    rows[prompts->valueAt(i).str()] = results->valueAt(i).str();
+  }
+
+  EXPECT_EQ(rows["hello"], "Batch response for: hello");
+  EXPECT_EQ(rows["world"], "Batch response for: world");
+  EXPECT_EQ(rows["batch"], "Batch response for: batch");
+}
+
+// Partial batch failure: rows at indices 1 and 3 fail, others succeed.
+// Verifies that failed rows produce NULL results while successful rows
+// are correctly mapped to their prompts.
+TEST_F(RPCOperatorTest, batchPartialFailure) {
+  auto input = makeRowVector(
+      {"prompt"},
+      {makeFlatVector<StringView>(
+          {"row0", "row1_fail", "row2", "row3_fail", "row4"})});
+
+  auto plan = makeBatchRPCNode(
+      PlanBuilder().values({input}).planNode(),
+      {"prompt"},
+      "demo_batch_rpc_partial_fail");
+
+  auto result = AssertQueryBuilder(plan).copyResults(pool());
+
+  ASSERT_EQ(result->size(), 5);
+
+  auto* prompts = result->childAt(0)->asFlatVector<StringView>();
+  auto* results = result->childAt(1)->asFlatVector<StringView>();
+
+  std::map<std::string, vector_size_t> rowIndex;
+  for (vector_size_t i = 0; i < result->size(); ++i) {
+    rowIndex[prompts->valueAt(i).str()] = i;
+  }
+
+  EXPECT_FALSE(results->isNullAt(rowIndex["row0"]));
+  EXPECT_EQ(
+      results->valueAt(rowIndex["row0"]).str(), "Batch response for: row0");
+  EXPECT_TRUE(results->isNullAt(rowIndex["row1_fail"]));
+  EXPECT_FALSE(results->isNullAt(rowIndex["row2"]));
+  EXPECT_TRUE(results->isNullAt(rowIndex["row3_fail"]));
+  EXPECT_FALSE(results->isNullAt(rowIndex["row4"]));
+}
+
+// Null inputs in batch mode produce null results.
+TEST_F(RPCOperatorTest, batchNullInput) {
+  auto input = makeRowVector(
+      {"prompt"},
+      {makeNullableFlatVector<StringView>(
+          {"valid1"_sv, std::nullopt, "valid2"_sv, std::nullopt})});
+
+  auto plan =
+      makeBatchRPCNode(PlanBuilder().values({input}).planNode(), {"prompt"});
+
+  auto result = AssertQueryBuilder(plan).copyResults(pool());
+
+  ASSERT_EQ(result->size(), 4);
+
+  auto* prompts = result->childAt(0)->asFlatVector<StringView>();
+  auto* results = result->childAt(1)->asFlatVector<StringView>();
+
+  for (vector_size_t i = 0; i < result->size(); ++i) {
+    if (prompts->isNullAt(i)) {
+      EXPECT_TRUE(results->isNullAt(i));
+    } else {
+      EXPECT_FALSE(results->isNullAt(i));
+      auto prompt = prompts->valueAt(i).str();
+      EXPECT_EQ(results->valueAt(i).str(), "Batch response for: " + prompt);
+    }
+  }
+}
+
+// Multiple input batches: two separate addInput() calls, both processed
+// correctly in batch mode.
+TEST_F(RPCOperatorTest, batchMultipleInputBatches) {
+  auto batch1 =
+      makeRowVector({"prompt"}, {makeFlatVector<StringView>({"a", "b", "c"})});
+  auto batch2 =
+      makeRowVector({"prompt"}, {makeFlatVector<StringView>({"d", "e"})});
+
+  auto plan = makeBatchRPCNode(
+      PlanBuilder().values({batch1, batch2}).planNode(), {"prompt"});
+
+  auto result = AssertQueryBuilder(plan).copyResults(pool());
+
+  ASSERT_EQ(result->size(), 5);
+
+  auto* results = result->childAt(1)->asFlatVector<StringView>();
+
+  std::set<std::string> resultSet;
+  for (vector_size_t i = 0; i < result->size(); ++i) {
+    EXPECT_FALSE(results->isNullAt(i));
+    resultSet.insert(results->valueAt(i).str());
+  }
+
+  EXPECT_EQ(resultSet.count("Batch response for: a"), 1);
+  EXPECT_EQ(resultSet.count("Batch response for: b"), 1);
+  EXPECT_EQ(resultSet.count("Batch response for: c"), 1);
+  EXPECT_EQ(resultSet.count("Batch response for: d"), 1);
+  EXPECT_EQ(resultSet.count("Batch response for: e"), 1);
+}
+
+// Pipelined batch dispatch: with dispatchBatchSize=2, the operator flushes
+// mid-addInput() instead of waiting for noMoreInput(). Verifies all rows
+// are still accounted for.
+TEST_F(RPCOperatorTest, batchPipelinedDispatch) {
+  auto input = makeRowVector(
+      {"prompt"},
+      {makeFlatVector<StringView>({"p1", "p2", "p3", "p4", "p5", "p6", "p7"})});
+
+  auto plan = makeBatchRPCNode(
+      PlanBuilder().values({input}).planNode(),
+      {"prompt"},
+      "demo_batch_rpc",
+      /*dispatchBatchSize=*/2);
+
+  auto result = AssertQueryBuilder(plan).copyResults(pool());
+
+  ASSERT_EQ(result->size(), 7);
+
+  auto* results = result->childAt(1)->asFlatVector<StringView>();
+  for (vector_size_t i = 0; i < result->size(); ++i) {
+    EXPECT_FALSE(results->isNullAt(i));
+  }
 }
 
 } // namespace facebook::velox::exec::rpc

--- a/velox/expression/rpc/AsyncRPCFunction.h
+++ b/velox/expression/rpc/AsyncRPCFunction.h
@@ -142,7 +142,13 @@ class AsyncRPCFunction {
   /// accumulated state and dispatches it.
   ///
   /// @param maxRows Maximum number of rows to flush. 0 means flush all.
-  /// Returns responses for the flushed rows. Null rows get
+  ///
+  /// Returns exactly maxRows responses (or all remaining if maxRows is
+  /// 0). Each response's rowId MUST be set to its 0-based index within
+  /// the flushed batch — the operator uses this to scatter responses
+  /// into the correct positions before stamping global row IDs. The
+  /// responses may appear in any order in the vector; the operator
+  /// reorders them by rowId. Null rows get
   /// RPCResponse{.error = "null_input"}. This keeps the operator
   /// completely agnostic to null handling in batch mode.
   virtual folly::SemiFuture<std::vector<RPCResponse>> flushBatch(


### PR DESCRIPTION
Summary:
RPCOperator::flushBatchRequests stamped global row IDs onto batch responses positionally: `resps[i].rowId = rowIds[i]`. This silently mis-maps results when the function returns responses out of order — input i receives input j's completion. For example, with five rows ["alpha", "bravo", "charlie", "delta", "echo"], a reversed response vector caused row 1 ("alpha") to receive "Batch response for: echo" and vice versa.

Fix: scatter responses into their original batch positions using each response's function-assigned rowId before stamping global IDs. The new code creates a sorted vector where `sorted[batchIdx] = resp`, ensuring `responses[i]` aligns with `rowLocations[i]` in buildOutputFromReadyBatch regardless of the order the function returned them. A `VELOX_CHECK` validates that each batch index is in range and that no two responses share the same index (catches duplicates that would silently overwrite a slot).

Also documents the dual meaning of `RPCResponse::rowId` in RPCTypes.h (batch-local index when returned from flushBatch, global ID after operator processing) and the ordering contract on `flushBatch()` in AsyncRPCFunction.h.

Reviewed By: zhichenxu-meta

Differential Revision: D108443866
