### PR TITLE
fix(tdigest): Name destructure_tdigest output row fields

### DIFF
--- a/velox/docs/functions/presto/tdigest.rst
+++ b/velox/docs/functions/presto/tdigest.rst
@@ -48,12 +48,12 @@ Functions
     * ``sum`` - sum of all values
     * ``count`` - total count of values
 
-.. function:: destructure_tdigest(digest: tdigest<double>) -> row(means array<double>, counts array<integer>, compression double, min double, max double, sum double, count bigint)
+.. function:: destructure_tdigest(digest: tdigest<double>) -> row(centroid_means array<double>, centroid_weights array<integer>, compression double, min double, max double, sum double, count bigint)
 
     Destructures a T-digest into its component parts, returning a row containing:
 
-    * ``means`` - array of centroid means
-    * ``counts`` - array of centroid counts
+    * ``centroid_means`` - array of centroid means
+    * ``centroid_weights`` - array of centroid counts (weights)
     * ``compression`` - compression factor
     * ``min`` - minimum value
     * ``max`` - maximum value

--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -42,6 +42,7 @@ velox_add_library(
   ArraySum.cpp
   Comparisons.cpp
   DecimalFunctions.cpp
+  DestructureTDigest.cpp
   ElementAt.cpp
   FilterFunctions.cpp
   FindFirst.cpp

--- a/velox/functions/prestosql/DestructureTDigest.cpp
+++ b/velox/functions/prestosql/DestructureTDigest.cpp
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <algorithm>
+#include "velox/expression/DecodedArgs.h"
+#include "velox/expression/VectorFunction.h"
+#include "velox/functions/lib/TDigest.h"
+
+namespace facebook::velox::functions {
+
+namespace {
+
+class DestructureTDigestFunction : public exec::VectorFunction {
+ public:
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    const exec::DecodedArgs decodedArgs(rows, args, context);
+    DecodedVector* input = decodedArgs.at(0);
+    auto* pool = context.pool();
+    const auto numRows = rows.end();
+
+    auto compression =
+        BaseVector::create<FlatVector<double>>(DOUBLE(), numRows, pool);
+    auto minValues =
+        BaseVector::create<FlatVector<double>>(DOUBLE(), numRows, pool);
+    auto maxValues =
+        BaseVector::create<FlatVector<double>>(DOUBLE(), numRows, pool);
+    auto sumValues =
+        BaseVector::create<FlatVector<double>>(DOUBLE(), numRows, pool);
+    auto counts =
+        BaseVector::create<FlatVector<int64_t>>(BIGINT(), numRows, pool);
+
+    // Means and weights share offsets/sizes (identical per-row counts).
+    BufferPtr offsets = allocateOffsets(numRows, pool);
+    BufferPtr sizes = allocateSizes(numRows, pool);
+    auto* rawOffsets = offsets->asMutable<vector_size_t>();
+    auto* rawSizes = sizes->asMutable<vector_size_t>();
+
+    std::vector<double> meansElements;
+    std::vector<int32_t> weightsElements;
+    vector_size_t elementOffset{0};
+    rows.applyToSelected([&](vector_size_t row) {
+      auto serialized = input->valueAt<StringView>(row);
+      auto digest = TDigest<>::fromSerialized(serialized.data());
+      compression->set(row, digest.compression());
+      minValues->set(row, digest.min());
+      maxValues->set(row, digest.max());
+      sumValues->set(row, digest.sum());
+
+      const double* means = digest.means();
+      const double* weights = digest.weights();
+      const auto numCentroids = static_cast<vector_size_t>(digest.size());
+      rawOffsets[row] = elementOffset;
+      rawSizes[row] = numCentroids;
+      int64_t count{0};
+      for (vector_size_t i = 0; i < numCentroids; ++i) {
+        meansElements.push_back(means[i]);
+        weightsElements.push_back(static_cast<int32_t>(weights[i]));
+        count += static_cast<int64_t>(weights[i]);
+      }
+      elementOffset += numCentroids;
+      counts->set(row, count);
+    });
+
+    auto meansVector =
+        BaseVector::create<FlatVector<double>>(DOUBLE(), elementOffset, pool);
+    std::copy(
+        meansElements.begin(),
+        meansElements.end(),
+        meansVector->mutableRawValues());
+    auto weightsVector =
+        BaseVector::create<FlatVector<int32_t>>(INTEGER(), elementOffset, pool);
+    std::copy(
+        weightsElements.begin(),
+        weightsElements.end(),
+        weightsVector->mutableRawValues());
+
+    auto centroidMeans = std::make_shared<ArrayVector>(
+        pool,
+        ARRAY(DOUBLE()),
+        BufferPtr(nullptr),
+        numRows,
+        offsets,
+        sizes,
+        meansVector);
+    auto centroidWeights = std::make_shared<ArrayVector>(
+        pool,
+        ARRAY(INTEGER()),
+        BufferPtr(nullptr),
+        numRows,
+        offsets,
+        sizes,
+        weightsVector);
+
+    auto rowResult = std::make_shared<RowVector>(
+        pool,
+        outputType,
+        BufferPtr(nullptr),
+        numRows,
+        std::vector<VectorPtr>{
+            centroidMeans,
+            centroidWeights,
+            compression,
+            minValues,
+            maxValues,
+            sumValues,
+            counts,
+        });
+    context.moveOrCopyResult(rowResult, rows, result);
+  }
+
+  static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
+    return {exec::FunctionSignatureBuilder()
+                .returnType(
+                    "row(centroid_means array(double), "
+                    "centroid_weights array(integer), compression double, "
+                    "min double, max double, sum double, count bigint)")
+                .argumentType("tdigest(double)")
+                .build()};
+  }
+};
+
+} // namespace
+
+VELOX_DECLARE_VECTOR_FUNCTION(
+    udf_destructure_tdigest,
+    DestructureTDigestFunction::signatures(),
+    std::make_unique<DestructureTDigestFunction>());
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/TDigestFunctions.h
+++ b/velox/functions/prestosql/TDigestFunctions.h
@@ -174,53 +174,6 @@ struct ConstructTDigestFunction {
 };
 
 template <typename T>
-struct DestructureTDigestFunction {
-  VELOX_DEFINE_FUNCTION_TYPES(T);
-  FOLLY_ALWAYS_INLINE bool call(
-      out_type<
-          Row<Array<double>,
-              Array<int32_t>,
-              double,
-              double,
-              double,
-              double,
-              int64_t>>& result,
-      const arg_type<SimpleTDigest<double>>& input) {
-    // Deserialize the TDigest
-    auto digest = TDigest<>::fromSerialized(input.data());
-    // Extract the components
-    double min = digest.min();
-    double max = digest.max();
-    double sum = digest.sum();
-    double compression = digest.compression();
-    int64_t count = 0;
-    // Get the centroids from the TDigest
-    std::vector<double> means;
-    std::vector<int32_t> weights;
-    const double* tDigestWeights = digest.weights();
-    const double* tDigestMeans = digest.means();
-    size_t numCentroids = digest.size();
-    for (int i = 0; i < numCentroids; i++) {
-      means.push_back(tDigestMeans[i]);
-      weights.push_back(static_cast<int32_t>(tDigestWeights[i]));
-      count += tDigestWeights[i];
-    }
-    // Create the result row
-    result.copy_from(
-        std::make_tuple(
-            std::move(means),
-            std::move(weights),
-            compression,
-            min,
-            max,
-            sum,
-            count));
-
-    return true;
-  }
-};
-
-template <typename T>
 struct TrimmedMeanFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
   FOLLY_ALWAYS_INLINE bool call(

--- a/velox/functions/prestosql/registration/TDigestFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/TDigestFunctionsRegistration.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/expression/VectorFunction.h"
 #include "velox/functions/Registerer.h"
 #include "velox/functions/prestosql/TDigestFunctions.h"
 #include "velox/functions/prestosql/types/TDigestRegistration.h"
@@ -60,16 +61,8 @@ void registerTDigestFunctions(const std::string& prefix) {
       double,
       double,
       int64_t>({prefix + "construct_tdigest"});
-  registerFunction<
-      DestructureTDigestFunction,
-      Row<Array<double>,
-          Array<int32_t>,
-          double,
-          double,
-          double,
-          double,
-          int64_t>,
-      SimpleTDigest<double>>({prefix + "destructure_tdigest"});
+  VELOX_REGISTER_VECTOR_FUNCTION(
+      udf_destructure_tdigest, prefix + "destructure_tdigest");
   registerFunction<
       TrimmedMeanFunction,
       double,

--- a/velox/functions/prestosql/tests/TDigestFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/TDigestFunctionsTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include <folly/base64.h>
+#include <gmock/gmock.h>
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/lib/TDigest.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
@@ -587,6 +588,48 @@ TEST_F(TDigestFunctionsTest, testDestructureTDigest) {
   ASSERT_NEAR(resultMax->valueAt(0), 9.0, 0.001);
   ASSERT_NEAR(resultSum->valueAt(0), 45.0, 0.001);
   ASSERT_EQ(resultCount->valueAt(0), 10);
+}
+
+TEST_F(TDigestFunctionsTest, testDestructureTDigestByName) {
+  std::vector<std::vector<double>> means = {
+      {0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0}};
+  auto meansArg = makeArrayVector<double>(means);
+  std::vector<std::vector<double>> weights = {
+      {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0}};
+  auto weightsArg = makeArrayVector<double>(weights);
+  auto compressionArg = makeFlatVector<double>(std::vector<double>{100.0});
+  auto minArg = makeFlatVector<double>(std::vector<double>{0.0});
+  auto maxArg = makeFlatVector<double>(std::vector<double>{9.0});
+  auto sumArg = makeFlatVector<double>(std::vector<double>{45.0});
+  auto countArg = makeFlatVector<int64_t>(std::vector<int64_t>{10});
+
+  auto tdigest = evaluate(
+      "construct_tdigest(c0, c1, c2, c3, c4, c5, c6)",
+      makeRowVector(
+          {meansArg,
+           weightsArg,
+           compressionArg,
+           minArg,
+           maxArg,
+           sumArg,
+           countArg}));
+
+  auto result = evaluate("destructure_tdigest(c0)", makeRowVector({tdigest}));
+
+  EXPECT_THAT(
+      result->type()->asRow().names(),
+      ::testing::ElementsAre(
+          "centroid_means",
+          "centroid_weights",
+          "compression",
+          "min",
+          "max",
+          "sum",
+          "count"));
+
+  auto max =
+      evaluate("(destructure_tdigest(c0)).max", makeRowVector({tdigest}));
+  ASSERT_NEAR(max->as<FlatVector<double>>()->valueAt(0), 9.0, 0.001);
 }
 
 TEST_F(TDigestFunctionsTest, testDestructureTDigestLarge) {


### PR DESCRIPTION
Summary:
destructure_tdigest returned a row whose fields had no names, so accessing a field by name failed. For example:

    SELECT destructure_tdigest(digest).max

failed with:

    Invalid field name: max. Available names are: , , , , , ,

A simple function's Row<> return type cannot carry field names, so destructure_tdigest is now a vector function whose signature declares the named row:

    row(centroid_means array(double), centroid_weights array(integer), compression double, min double, max double, sum double, count bigint)

 The change is additive: the components, their order, and their values are unchanged, and positional access still works, only by-name access is newly resolvable.

Differential Revision: D109498648


