### PR TITLE
build(cxl): Install libnuma in the setup scripts

### DIFF
--- a/scripts/setup-centos9.sh
+++ b/scripts/setup-centos9.sh
@@ -73,7 +73,7 @@ function install_velox_deps_from_dnf {
   dnf_install libevent-devel \
     openssl-devel re2-devel libzstd-devel lz4-devel double-conversion-devel \
     libdwarf-devel elfutils-libelf-devel curl-devel libicu-devel bison flex \
-    libsodium-devel zlib-devel gtest-devel gmock-devel xxhash-devel
+    libsodium-devel zlib-devel gtest-devel gmock-devel xxhash-devel numactl-devel
 
   install_faiss_deps
 }

--- a/scripts/setup-fedora.sh
+++ b/scripts/setup-fedora.sh
@@ -61,7 +61,8 @@ function install_velox_deps_from_dnf {
     elfutils-libelf-devel flex gflags-devel glog-devel gmock-devel \
     gtest-devel libdwarf-devel libevent-devel libicu-devel \
     libsodium-devel libzstd-devel lz4-devel openssl-devel-engine \
-    re2-devel snappy-devel xxhash-devel zlib-devel grpc-devel grpc-plugins
+    re2-devel snappy-devel xxhash-devel zlib-devel grpc-devel grpc-plugins \
+    numactl-devel
 
   install_faiss_deps
 }

--- a/scripts/setup-manylinux.sh
+++ b/scripts/setup-manylinux.sh
@@ -68,7 +68,7 @@ function install_velox_deps_from_dnf {
   dnf_install libevent-devel \
     openssl-devel re2-devel libzstd-devel lz4-devel double-conversion-devel \
     libdwarf-devel elfutils-libelf-devel curl-devel libicu-devel bison flex \
-    libsodium-devel zlib-devel gtest-devel gmock-devel xxhash-devel
+    libsodium-devel zlib-devel gtest-devel gmock-devel xxhash-devel numactl-devel
 }
 
 function install_conda {

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -126,6 +126,7 @@ function install_velox_deps_from_apt {
     flex \
     libfl-dev \
     tzdata \
+    libnuma-dev \
     libxxhash-dev
 }
 


### PR DESCRIPTION
First of the four PRs splitting #17856 (see #17908 for the overall plan).

The CXL experimental memory subsystem binds allocator pages to a NUMA node with libnuma's `numa_tonode_memory`, so building it needs the libnuma development headers. This adds them to the dependency installers: `numactl-devel` on the dnf-based distros (CentOS 9, Fedora, manylinux) and `libnuma-dev` on Ubuntu.

Nothing links libnuma yet — this lands the dependency ahead of the CMake wiring and the allocator, which follow in later PRs.

cc @kgpai

🤖 Generated with [Claude Code](https://claude.com/claude-code)