### PR TITLE
test: Make DirectBufferedInputTest.duplicateRegionsShareCoalescedRead deterministic

### DIFF
--- a/velox/dwio/common/tests/DirectBufferedInputTest.cpp
+++ b/velox/dwio/common/tests/DirectBufferedInputTest.cpp
@@ -319,7 +319,7 @@ TEST_F(DirectBufferedInputTest, duplicateRegionsShareCoalescedRead) {
         std::move(groupId),
         dataIoStats_,
         nullptr,
-        executor_.get(),
+        nullptr,
         readerOptions);
 
     auto stream1 = input.enqueue(common::Region{123, regionSize}, nullptr);


### PR DESCRIPTION
Closes https://github.com/facebookincubator/velox/issues/17911.

This is the same fix as #17780 applied to another test that showed similar problems.