### PR TITLE
fix(exec): Share AssignUniqueId row id pool across a task

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -2225,7 +2225,6 @@ AssignUniqueIdNode::AssignUniqueIdNode(
   names.emplace_back(idName);
   types.emplace_back(BIGINT());
   outputType_ = ROW(std::move(names), std::move(types));
-  uniqueIdCounter_ = std::make_shared<std::atomic_int64_t>();
 }
 
 void AssignUniqueIdNode::addDetails(std::stringstream& /* stream */) const {

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -5088,10 +5088,6 @@ class AssignUniqueIdNode : public PlanNode {
     return taskUniqueId_;
   }
 
-  const std::shared_ptr<std::atomic_int64_t>& uniqueIdCounter() const {
-    return uniqueIdCounter_;
-  }
-
   folly::dynamic serialize() const override;
 
   static PlanNodePtr create(const folly::dynamic& obj, void* context);
@@ -5102,7 +5098,6 @@ class AssignUniqueIdNode : public PlanNode {
   const int32_t taskUniqueId_;
   const std::vector<PlanNodePtr> sources_;
   RowTypePtr outputType_;
-  std::shared_ptr<std::atomic_int64_t> uniqueIdCounter_;
 };
 
 using AssignUniqueIdNodePtr = std::shared_ptr<const AssignUniqueIdNode>;

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -697,7 +697,7 @@ std::shared_ptr<Driver> DriverFactory::createDriver(
               ctx.get(),
               assignUniqueIdNode,
               assignUniqueIdNode->taskUniqueId(),
-              assignUniqueIdNode->uniqueIdCounter()));
+              ctx->task->uniqueRowIdPool()));
     } else if (
         const auto traceScanNode =
             std::dynamic_pointer_cast<const core::TraceScanNode>(planNode)) {

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -546,7 +546,11 @@ void Task::init(std::optional<common::SpillDiskOptions>&& spillDiskOpts) {
 
   taskStats_.executionStartTimeMs = getCurrentTimeMs();
   LocalPlanner::plan(
-      planFragment_, nullptr, &driverFactories_, queryCtx_->queryConfig(), 1);
+      planFragment_,
+      /*consumerSupplier=*/nullptr,
+      &driverFactories_,
+      queryCtx_->queryConfig(),
+      /*maxDrivers=*/1);
   exchangeClients_.resize(driverFactories_.size());
 
   // In Task::next() we always assume ungrouped execution.
@@ -976,7 +980,11 @@ bool Task::supportSerialExecutionMode() const {
 
   std::vector<std::unique_ptr<DriverFactory>> driverFactories;
   LocalPlanner::plan(
-      planFragment_, nullptr, &driverFactories, queryCtx_->queryConfig(), 1);
+      planFragment_,
+      /*consumerSupplier=*/nullptr,
+      &driverFactories,
+      queryCtx_->queryConfig(),
+      /*maxDrivers=*/1);
 
   for (const auto& factory : driverFactories) {
     if (!factory->supportsSerialExecution()) {

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -138,6 +138,14 @@ class Task : public std::enable_shared_from_this<Task> {
     return destination_;
   }
 
+  /// Returns the pool of unique row ids shared by all AssignUniqueId operators
+  /// in this task. Each operator atomically claims disjoint ranges from it, so
+  /// the ids it generates never collide across operators or drivers of the same
+  /// task.
+  const std::shared_ptr<std::atomic_int64_t>& uniqueRowIdPool() const {
+    return uniqueRowIdPool_;
+  }
+
   /// Configured cpu slice time limit for drivers. 0 (meaning slicing/yield
   /// disabled) when task is under serial mode.
   uint64_t driverCpuTimeSliceLimitMs() const;
@@ -1293,6 +1301,11 @@ class Task : public std::enable_shared_from_this<Task> {
   // process remaining remote splits after the task has completed early.
   std::unordered_map<core::PlanNodeId, std::shared_ptr<ExchangeClient>>
       exchangeClientByPlanNode_;
+
+  // Pool of unique row ids shared by all AssignUniqueId operators in this task.
+  // See uniqueRowIdPool().
+  const std::shared_ptr<std::atomic_int64_t> uniqueRowIdPool_{
+      std::make_shared<std::atomic_int64_t>(0)};
 
   ConsumerSupplier consumerSupplier_;
 

--- a/velox/exec/tests/AssignUniqueIdTest.cpp
+++ b/velox/exec/tests/AssignUniqueIdTest.cpp
@@ -158,14 +158,41 @@ TEST_F(AssignUniqueIdTest, maxRowIdLimit) {
 
   auto plan = PlanBuilder().values(input).assignUniqueId().planNode();
 
-  // Increase the counter to kMaxRowId.
-  std::dynamic_pointer_cast<const core::AssignUniqueIdNode>(plan)
-      ->uniqueIdCounter()
-      ->fetch_add(1L << 40);
+  CursorParameters params;
+  params.planNode = plan;
+  auto cursor = TaskCursor::create(params);
+
+  // Seed the pool to kMaxRowId to force overflow on the next request.
+  cursor->task()->uniqueRowIdPool()->fetch_add(1L << 40);
 
   VELOX_ASSERT_THROW(
-      AssertQueryBuilder(plan).copyResults(pool()),
-      "Ran out of unique IDs at 1099511627776");
+      cursor->moveNext(), "Ran out of unique IDs at 1099511627776");
+}
+
+TEST_F(AssignUniqueIdTest, sharedRowIdPool) {
+  const vector_size_t size = 100;
+  auto input = {
+      makeRowVector({makeFlatVector<int32_t>(size, folly::identity)})};
+
+  // The two nodes' generated ids are disjoint.
+  auto plan = PlanBuilder()
+                  .values(input)
+                  .assignUniqueId("a")
+                  .assignUniqueId("b")
+                  .planNode();
+
+  auto result = AssertQueryBuilder(plan).copyResults(pool());
+  ASSERT_EQ(result->size(), size);
+
+  auto* a = result->childAt(1)->asFlatVector<int64_t>();
+  auto* b = result->childAt(2)->asFlatVector<int64_t>();
+
+  std::set<int64_t> ids;
+  for (auto i = 0; i < size; ++i) {
+    ASSERT_TRUE(ids.insert(a->valueAt(i)).second);
+    ASSERT_TRUE(ids.insert(b->valueAt(i)).second);
+  }
+  ASSERT_EQ(ids.size(), 2 * size);
 }
 
 TEST_F(AssignUniqueIdTest, taskUniqueIdLimit) {

--- a/velox/experimental/cudf/exec/OperatorAdapters.cpp
+++ b/velox/experimental/cudf/exec/OperatorAdapters.cpp
@@ -801,7 +801,7 @@ class AssignUniqueIdAdapter : public OperatorAdapter {
             ctx,
             assignUniqueIdPlanNode,
             assignUniqueIdPlanNode->taskUniqueId(),
-            assignUniqueIdPlanNode->uniqueIdCounter()));
+            ctx->task->uniqueRowIdPool()));
     return result;
   }
 };

--- a/velox/experimental/cudf/tests/AssignUniqueIdTest.cpp
+++ b/velox/experimental/cudf/tests/AssignUniqueIdTest.cpp
@@ -172,14 +172,15 @@ TEST_F(AssignUniqueIdTest, maxRowIdLimit) {
 
   auto plan = PlanBuilder().values(input).assignUniqueId().planNode();
 
-  // Increase the counter to kMaxRowId.
-  std::dynamic_pointer_cast<const core::AssignUniqueIdNode>(plan)
-      ->uniqueIdCounter()
-      ->fetch_add(1L << 40);
+  CursorParameters params;
+  params.planNode = plan;
+  auto cursor = TaskCursor::create(params);
+
+  // Seed the pool to kMaxRowId to force overflow on the next request.
+  cursor->task()->uniqueRowIdPool()->fetch_add(1L << 40);
 
   VELOX_ASSERT_THROW(
-      AssertQueryBuilder(plan).copyResults(pool()),
-      "Ran out of unique IDs at 1099511627776");
+      cursor->moveNext(), "Ran out of unique IDs at 1099511627776");
 }
 
 TEST_F(AssignUniqueIdTest, taskUniqueIdLimit) {


### PR DESCRIPTION
Summary:
AssignUniqueId appends an int64 column with a unique id per row, built as `(taskUniqueId << 40) | counter`. Each plan node owned its own counter, so two AssignUniqueId operators in the same task with the same `taskUniqueId` both counted from zero and emitted overlapping ids. The counter now lives on the Task and is shared by every AssignUniqueId operator in it, so the generated ids are unique across all operators and drivers of a task.

The shared counter moves from `AssignUniqueIdNode` to `Task::uniqueRowIdPool()`, which also removes the last piece of mutable per-task state from the plan node. `taskUniqueId` still lives on the node; relocating it needs a backward-compatible constructor change and is left for a follow-up.

Part of https://github.com/facebookincubator/velox/issues/17645

Differential Revision: D109563888


