### PR TITLE
refactor(exec): Move AssignUniqueId task id to PlanFragment

### DIFF
--- a/velox/core/PlanFragment.h
+++ b/velox/core/PlanFragment.h
@@ -16,6 +16,7 @@
 #pragma once
 #include <folly/container/F14Map.h>
 #include <memory>
+#include <optional>
 #include <string_view>
 #include <unordered_set>
 #include <vector>
@@ -68,6 +69,14 @@ struct PlanFragment {
   /// the map uses TransportKind::kHttp.
   folly::F14FastMap<PlanNodeId, std::string> inputTransportTypes;
   folly::F14FastMap<PlanNodeId, std::string> outputTransportTypes;
+
+  /// Identifies this task among all tasks running the same query stage.
+  /// Supplied by the consumer at task creation time. AssignUniqueId packs it
+  /// into the high 24 bits of each generated id and the per-row counter into
+  /// the low 40 bits, so it must fit in 24 bits (0 <= taskUniqueId < 2^24).
+  /// When unset, AssignUniqueId falls back to the value carried on its plan
+  /// node (0 in the canonical construction path).
+  std::optional<int32_t> taskUniqueId{};
 
   /// Validates that every node ID in inputTransportTypes refers to an Exchange
   /// node and every node ID in outputTransportTypes refers to a

--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -2225,7 +2225,6 @@ AssignUniqueIdNode::AssignUniqueIdNode(
   names.emplace_back(idName);
   types.emplace_back(BIGINT());
   outputType_ = ROW(std::move(names), std::move(types));
-  uniqueIdCounter_ = std::make_shared<std::atomic_int64_t>();
 }
 
 void AssignUniqueIdNode::addDetails(std::stringstream& /* stream */) const {

--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -2213,19 +2213,25 @@ PlanNodePtr NestedLoopJoinNode::create(
       outputType);
 }
 
+// static
+RowTypePtr AssignUniqueIdNode::makeOutputType(
+    const PlanNodePtr& source,
+    const std::string& idName) {
+  std::vector<std::string> names(source->outputType()->names());
+  std::vector<TypePtr> types(source->outputType()->children());
+  names.emplace_back(idName);
+  types.emplace_back(BIGINT());
+  return ROW(std::move(names), std::move(types));
+}
+
 AssignUniqueIdNode::AssignUniqueIdNode(
     const PlanNodeId& id,
     const std::string& idName,
-    const int32_t taskUniqueId,
     PlanNodePtr source)
-    : PlanNode(id), taskUniqueId_(taskUniqueId), sources_{std::move(source)} {
-  std::vector<std::string> names(sources_[0]->outputType()->names());
-  std::vector<TypePtr> types(sources_[0]->outputType()->children());
-
-  names.emplace_back(idName);
-  types.emplace_back(BIGINT());
-  outputType_ = ROW(std::move(names), std::move(types));
-}
+    : PlanNode(id),
+      taskUniqueId_(0),
+      sources_{std::move(source)},
+      outputType_(makeOutputType(sources_[0], idName)) {}
 
 void AssignUniqueIdNode::addDetails(std::stringstream& /* stream */) const {
   // Nothing to add.
@@ -2234,7 +2240,6 @@ void AssignUniqueIdNode::addDetails(std::stringstream& /* stream */) const {
 folly::dynamic AssignUniqueIdNode::serialize() const {
   auto obj = PlanNode::serialize();
   obj["idName"] = outputType_->names().back();
-  obj["taskUniqueId"] = taskUniqueId_;
   return obj;
 }
 
@@ -2251,10 +2256,7 @@ PlanNodePtr AssignUniqueIdNode::create(
   auto source = deserializeSingleSource(obj, context);
 
   return std::make_shared<AssignUniqueIdNode>(
-      deserializePlanNodeId(obj),
-      obj["idName"].asString(),
-      obj["taskUniqueId"].asInt(),
-      std::move(source));
+      deserializePlanNodeId(obj), obj["idName"].asString(), std::move(source));
 }
 
 namespace {

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -5088,10 +5088,6 @@ class AssignUniqueIdNode : public PlanNode {
     return taskUniqueId_;
   }
 
-  const std::shared_ptr<std::atomic_int64_t>& uniqueIdCounter() const {
-    return uniqueIdCounter_;
-  }
-
   folly::dynamic serialize() const override;
 
   static PlanNodePtr create(const folly::dynamic& obj, void* context);
@@ -5102,7 +5098,6 @@ class AssignUniqueIdNode : public PlanNode {
   const int32_t taskUniqueId_;
   const std::vector<PlanNodePtr> sources_;
   RowTypePtr outputType_;
-  std::shared_ptr<std::atomic_int64_t> uniqueIdCounter_;
 };
 
 using AssignUniqueIdNodePtr = std::shared_ptr<const AssignUniqueIdNode>;

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -4999,19 +4999,33 @@ using EnforceSingleRowNodePtr = std::shared_ptr<const EnforceSingleRowNode>;
 /// with unique int64_t value per input row.
 ///
 /// 64-bit unique id is built in following way:
-///  - first 24 bits - task unique id
-///  - next 40 bits - operator counter value
+///  - high 24 bits - task unique id
+///  - low 40 bits - operator counter value
 ///
-/// The task unique id is added to ensure the generated id is unique
-/// across all the nodes executing the same query stage in a distributed
-/// query execution.
+/// The task unique id ensures the generated id is unique across all the tasks
+/// executing the same query stage in a distributed query. It is supplied by the
+/// executing Task via PlanFragment::taskUniqueId.
 class AssignUniqueIdNode : public PlanNode {
  public:
   AssignUniqueIdNode(
       const PlanNodeId& id,
       const std::string& idName,
-      const int32_t taskUniqueId,
       PlanNodePtr source);
+
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+  // Legacy constructor for read-only synced consumers that still pass
+  // taskUniqueId on the node. The value is not serialized; it is consumed at
+  // execution as the fallback for an unset PlanFragment::taskUniqueId.
+  AssignUniqueIdNode(
+      const PlanNodeId& id,
+      const std::string& idName,
+      int32_t taskUniqueId,
+      PlanNodePtr source)
+      : PlanNode(id),
+        taskUniqueId_(taskUniqueId),
+        sources_{std::move(source)},
+        outputType_(makeOutputType(sources_[0], idName)) {}
+#endif
 
   bool supportsBarrier() const override {
     return true;
@@ -5024,7 +5038,6 @@ class AssignUniqueIdNode : public PlanNode {
     explicit Builder(const AssignUniqueIdNode& other) {
       id_ = other.id();
       idName_ = other.outputType()->names().back();
-      taskUniqueId_ = other.taskUniqueId();
       VELOX_CHECK_EQ(other.sources().size(), 1);
       source_ = other.sources()[0];
     }
@@ -5039,11 +5052,6 @@ class AssignUniqueIdNode : public PlanNode {
       return *this;
     }
 
-    Builder& taskUniqueId(int32_t taskUniqueId) {
-      taskUniqueId_ = taskUniqueId;
-      return *this;
-    }
-
     Builder& source(PlanNodePtr source) {
       source_ = std::move(source);
       return *this;
@@ -5054,18 +5062,15 @@ class AssignUniqueIdNode : public PlanNode {
       VELOX_USER_CHECK(
           idName_.has_value(), "AssignUniqueIdNode idName not set");
       VELOX_USER_CHECK(
-          taskUniqueId_.has_value(), "AssignUniqueIdNode taskUniqueId not set");
-      VELOX_USER_CHECK(
           source_.has_value(), "AssignUniqueIdNode source is not set");
 
       return std::make_shared<AssignUniqueIdNode>(
-          id_.value(), idName_.value(), taskUniqueId_.value(), source_.value());
+          id_.value(), idName_.value(), source_.value());
     }
 
    private:
     std::optional<PlanNodeId> id_;
     std::optional<std::string> idName_;
-    std::optional<int32_t> taskUniqueId_;
     std::optional<PlanNodePtr> source_;
   };
 
@@ -5093,6 +5098,12 @@ class AssignUniqueIdNode : public PlanNode {
   static PlanNodePtr create(const folly::dynamic& obj, void* context);
 
  private:
+  // Builds the output row type: the source columns followed by the BIGINT id
+  // column named 'idName'.
+  static RowTypePtr makeOutputType(
+      const PlanNodePtr& source,
+      const std::string& idName);
+
   void addDetails(std::stringstream& stream) const override;
 
   const int32_t taskUniqueId_;

--- a/velox/core/tests/PlanNodeBuilderTest.cpp
+++ b/velox/core/tests/PlanNodeBuilderTest.cpp
@@ -1067,13 +1067,11 @@ TEST_F(PlanNodeBuilderTest, enforceSingleRowNode) {
 TEST_F(PlanNodeBuilderTest, assignUniqueIdNode) {
   const PlanNodeId id = "assign_unique_id_id";
   const std::string idName = "unique_id";
-  const int32_t taskUniqueId = 42;
 
   const auto verify =
       [&](const std::shared_ptr<const AssignUniqueIdNode>& node) {
         EXPECT_EQ(node->id(), id);
         EXPECT_EQ(node->outputType()->names().back(), idName);
-        EXPECT_EQ(node->taskUniqueId(), taskUniqueId);
         EXPECT_EQ(node->sources().size(), 1);
         EXPECT_EQ(node->sources()[0], source_);
       };
@@ -1081,7 +1079,6 @@ TEST_F(PlanNodeBuilderTest, assignUniqueIdNode) {
   const auto node = AssignUniqueIdNode::Builder()
                         .id(id)
                         .idName(idName)
-                        .taskUniqueId(taskUniqueId)
                         .source(source_)
                         .build();
   verify(node);

--- a/velox/exec/Cursor.cpp
+++ b/velox/exec/Cursor.cpp
@@ -233,6 +233,8 @@ class TaskCursorBase : public TaskCursor {
         params.executionStrategy,
         params.numSplitGroups,
         params.groupedExecutionLeafNodeIds};
+    planFragment_.taskUniqueId = params.taskUniqueId;
+    beforeTaskStart_ = params.beforeTaskStart;
 
     if (!params.spillDirectory.empty()) {
       taskSpillDirectory_ = params.spillDirectory + "/" + taskId_;
@@ -264,6 +266,7 @@ class TaskCursorBase : public TaskCursor {
   core::PlanFragment planFragment_;
   std::string taskSpillDirectory_;
   std::function<std::string()> taskSpillDirectoryCb_;
+  std::function<void(Task&)> beforeTaskStart_;
 
  private:
   std::shared_ptr<folly::Executor> executor_;
@@ -336,6 +339,10 @@ class MultiThreadedTaskCursor : public TaskCursorBase {
           }
           queue->close();
         });
+
+    if (beforeTaskStart_) {
+      beforeTaskStart_(*task_);
+    }
   }
 
   ~MultiThreadedTaskCursor() override {
@@ -484,6 +491,10 @@ class SingleThreadedTaskCursor : public TaskCursorBase {
     VELOX_CHECK(
         task_->supportSerialExecutionMode(),
         "Plan doesn't support serial execution mode");
+
+    if (beforeTaskStart_) {
+      beforeTaskStart_(*task_);
+    }
   }
 
   ~SingleThreadedTaskCursor() override {

--- a/velox/exec/Cursor.h
+++ b/velox/exec/Cursor.h
@@ -80,6 +80,14 @@ struct CursorParameters {
 
   bool barrierExecution = false;
 
+  /// Per-task unique id used by AssignUniqueId operators. See
+  /// core::PlanFragment::taskUniqueId.
+  std::optional<int32_t> taskUniqueId{};
+
+  /// Callback invoked with the Task after it is created but before it is
+  /// started, allowing tests to tweak runtime task state.
+  std::function<void(Task&)> beforeTaskStart{};
+
   /// If both 'queryConfigs' and 'queryCtx' are specified, the configurations
   /// in 'queryCtx' will be overridden by 'queryConfig'.
   std::unordered_map<std::string, std::string> queryConfigs = {};

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -696,7 +696,8 @@ std::shared_ptr<Driver> DriverFactory::createDriver(
               id,
               ctx.get(),
               assignUniqueIdNode,
-              assignUniqueIdNode->taskUniqueId(),
+              ctx->task->planFragment().taskUniqueId.value_or(
+                  assignUniqueIdNode->taskUniqueId()),
               ctx->task->uniqueRowIdPool()));
     } else if (
         const auto traceScanNode =

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -697,7 +697,7 @@ std::shared_ptr<Driver> DriverFactory::createDriver(
               ctx.get(),
               assignUniqueIdNode,
               assignUniqueIdNode->taskUniqueId(),
-              assignUniqueIdNode->uniqueIdCounter()));
+              ctx->task->uniqueRowIdPool()));
     } else if (
         const auto traceScanNode =
             std::dynamic_pointer_cast<const core::TraceScanNode>(planNode)) {

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -546,7 +546,11 @@ void Task::init(std::optional<common::SpillDiskOptions>&& spillDiskOpts) {
 
   taskStats_.executionStartTimeMs = getCurrentTimeMs();
   LocalPlanner::plan(
-      planFragment_, nullptr, &driverFactories_, queryCtx_->queryConfig(), 1);
+      planFragment_,
+      /*consumerSupplier=*/nullptr,
+      &driverFactories_,
+      queryCtx_->queryConfig(),
+      /*maxDrivers=*/1);
   exchangeClients_.resize(driverFactories_.size());
 
   // In Task::next() we always assume ungrouped execution.
@@ -976,7 +980,11 @@ bool Task::supportSerialExecutionMode() const {
 
   std::vector<std::unique_ptr<DriverFactory>> driverFactories;
   LocalPlanner::plan(
-      planFragment_, nullptr, &driverFactories, queryCtx_->queryConfig(), 1);
+      planFragment_,
+      /*consumerSupplier=*/nullptr,
+      &driverFactories,
+      queryCtx_->queryConfig(),
+      /*maxDrivers=*/1);
 
   for (const auto& factory : driverFactories) {
     if (!factory->supportsSerialExecution()) {

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -138,6 +138,14 @@ class Task : public std::enable_shared_from_this<Task> {
     return destination_;
   }
 
+  /// Returns the pool of unique row ids shared by all AssignUniqueId operators
+  /// in this task. Each operator atomically claims disjoint ranges from it, so
+  /// the ids it generates never collide across operators or drivers of the same
+  /// task.
+  const std::shared_ptr<std::atomic_int64_t>& uniqueRowIdPool() const {
+    return uniqueRowIdPool_;
+  }
+
   /// Configured cpu slice time limit for drivers. 0 (meaning slicing/yield
   /// disabled) when task is under serial mode.
   uint64_t driverCpuTimeSliceLimitMs() const;
@@ -1293,6 +1301,11 @@ class Task : public std::enable_shared_from_this<Task> {
   // process remaining remote splits after the task has completed early.
   std::unordered_map<core::PlanNodeId, std::shared_ptr<ExchangeClient>>
       exchangeClientByPlanNode_;
+
+  // Pool of unique row ids shared by all AssignUniqueId operators in this task.
+  // See uniqueRowIdPool().
+  const std::shared_ptr<std::atomic_int64_t> uniqueRowIdPool_{
+      std::make_shared<std::atomic_int64_t>(0)};
 
   ConsumerSupplier consumerSupplier_;
 

--- a/velox/exec/tests/AssignUniqueIdTest.cpp
+++ b/velox/exec/tests/AssignUniqueIdTest.cpp
@@ -158,15 +158,15 @@ TEST_F(AssignUniqueIdTest, maxRowIdLimit) {
 
   auto plan = PlanBuilder().values(input).assignUniqueId().planNode();
 
-  CursorParameters params;
-  params.planNode = plan;
-  auto cursor = TaskCursor::create(params);
-
-  // Seed the pool to kMaxRowId to force overflow on the next request.
-  cursor->task()->uniqueRowIdPool()->fetch_add(1L << 40);
-
   VELOX_ASSERT_THROW(
-      cursor->moveNext(), "Ran out of unique IDs at 1099511627776");
+      AssertQueryBuilder(plan)
+          .beforeTaskStart([](Task& task) {
+            // Advance the pool to the end of the 40-bit row id space so the
+            // next request overflows.
+            task.uniqueRowIdPool()->fetch_add(1L << 40);
+          })
+          .copyResults(pool()),
+      "Ran out of unique IDs at 1099511627776");
 }
 
 TEST_F(AssignUniqueIdTest, sharedRowIdPool) {
@@ -198,12 +198,11 @@ TEST_F(AssignUniqueIdTest, sharedRowIdPool) {
 TEST_F(AssignUniqueIdTest, taskUniqueIdLimit) {
   auto input = {makeRowVector({makeFlatVector<int32_t>({1, 2, 3})})};
 
-  auto plan =
-      PlanBuilder().values(input).assignUniqueId("unique", 1L << 24).planNode();
+  auto plan = PlanBuilder().values(input).assignUniqueId().planNode();
 
   VELOX_ASSERT_THROW(
-      AssertQueryBuilder(plan).copyResults(pool()),
-      "(16777216 vs. 16777216) Unique 24-bit ID specified for AssignUniqueId exceeds the limit");
+      AssertQueryBuilder(plan).taskUniqueId(1L << 24).copyResults(pool()),
+      "Unique 24-bit ID specified for AssignUniqueId exceeds the limit");
 }
 
 TEST_F(AssignUniqueIdTest, barrier) {

--- a/velox/exec/tests/AssignUniqueIdTest.cpp
+++ b/velox/exec/tests/AssignUniqueIdTest.cpp
@@ -158,14 +158,41 @@ TEST_F(AssignUniqueIdTest, maxRowIdLimit) {
 
   auto plan = PlanBuilder().values(input).assignUniqueId().planNode();
 
-  // Increase the counter to kMaxRowId.
-  std::dynamic_pointer_cast<const core::AssignUniqueIdNode>(plan)
-      ->uniqueIdCounter()
-      ->fetch_add(1L << 40);
+  CursorParameters params;
+  params.planNode = plan;
+  auto cursor = TaskCursor::create(params);
+
+  // Seed the pool to kMaxRowId to force overflow on the next request.
+  cursor->task()->uniqueRowIdPool()->fetch_add(1L << 40);
 
   VELOX_ASSERT_THROW(
-      AssertQueryBuilder(plan).copyResults(pool()),
-      "Ran out of unique IDs at 1099511627776");
+      cursor->moveNext(), "Ran out of unique IDs at 1099511627776");
+}
+
+TEST_F(AssignUniqueIdTest, sharedRowIdPool) {
+  const vector_size_t size = 100;
+  auto input = {
+      makeRowVector({makeFlatVector<int32_t>(size, folly::identity)})};
+
+  // The two nodes' generated ids are disjoint.
+  auto plan = PlanBuilder()
+                  .values(input)
+                  .assignUniqueId("a")
+                  .assignUniqueId("b")
+                  .planNode();
+
+  auto result = AssertQueryBuilder(plan).copyResults(pool());
+  ASSERT_EQ(result->size(), size);
+
+  auto* a = result->childAt(1)->asFlatVector<int64_t>();
+  auto* b = result->childAt(2)->asFlatVector<int64_t>();
+
+  std::set<int64_t> ids;
+  for (auto i = 0; i < size; ++i) {
+    ASSERT_TRUE(ids.insert(a->valueAt(i)).second);
+    ASSERT_TRUE(ids.insert(b->valueAt(i)).second);
+  }
+  ASSERT_EQ(ids.size(), 2 * size);
 }
 
 TEST_F(AssignUniqueIdTest, taskUniqueIdLimit) {

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -568,7 +568,7 @@ TEST_F(PlanNodeToStringTest, enforceSingleRow) {
 
 TEST_F(PlanNodeToStringTest, assignUniqueId) {
   auto plan =
-      PlanBuilder().values({data_}).assignUniqueId("unique_id", 123).planNode();
+      PlanBuilder().values({data_}).assignUniqueId("unique_id").planNode();
 
   ASSERT_EQ("-- AssignUniqueId[1]\n", plan->toString());
   ASSERT_EQ(

--- a/velox/exec/tests/utils/AssertQueryBuilder.cpp
+++ b/velox/exec/tests/utils/AssertQueryBuilder.cpp
@@ -38,14 +38,18 @@ AssertQueryBuilder::AssertQueryBuilder(
     DuckDbQueryRunner& duckDbQueryRunner)
     : duckDbQueryRunner_{&duckDbQueryRunner} {
   params_.planNode = plan;
+  params_.taskUniqueId = 1;
 }
 
 AssertQueryBuilder::AssertQueryBuilder(DuckDbQueryRunner& duckDbQueryRunner)
-    : duckDbQueryRunner_{&duckDbQueryRunner} {}
+    : duckDbQueryRunner_{&duckDbQueryRunner} {
+  params_.taskUniqueId = 1;
+}
 
 AssertQueryBuilder::AssertQueryBuilder(const core::PlanNodePtr& plan)
     : duckDbQueryRunner_(nullptr) {
   params_.planNode = plan;
+  params_.taskUniqueId = 1;
 }
 
 AssertQueryBuilder& AssertQueryBuilder::plan(const core::PlanNodePtr& plan) {

--- a/velox/exec/tests/utils/AssertQueryBuilder.h
+++ b/velox/exec/tests/utils/AssertQueryBuilder.h
@@ -51,6 +51,20 @@ class AssertQueryBuilder {
   /// Default is false.
   AssertQueryBuilder& barrierExecution(bool barrier);
 
+  /// Sets the per-task unique id used by AssignUniqueId operators. Default
+  /// is 1. See core::PlanFragment::taskUniqueId.
+  AssertQueryBuilder& taskUniqueId(int32_t taskUniqueId) {
+    params_.taskUniqueId = taskUniqueId;
+    return *this;
+  }
+
+  /// Sets a callback invoked with the Task after it is created but before it is
+  /// started, allowing tests to tweak runtime task state.
+  AssertQueryBuilder& beforeTaskStart(std::function<void(Task&)> callback) {
+    params_.beforeTaskStart = std::move(callback);
+    return *this;
+  }
+
   /// Set configuration property. May be called multiple times to set multiple
   /// properties.
   AssertQueryBuilder& config(const std::string& key, const std::string& value);

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -1371,11 +1371,9 @@ PlanBuilder& PlanBuilder::enforceSingleRow() {
   return *this;
 }
 
-PlanBuilder& PlanBuilder::assignUniqueId(
-    const std::string& idName,
-    const int32_t taskUniqueId) {
+PlanBuilder& PlanBuilder::assignUniqueId(const std::string& idName) {
   planNode_ = std::make_shared<core::AssignUniqueIdNode>(
-      nextPlanNodeId(), idName, taskUniqueId, planNode_);
+      nextPlanNodeId(), idName, planNode_);
   VELOX_CHECK(planNode_->supportsBarrier());
   return *this;
 }

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -1183,12 +1183,7 @@ class PlanBuilder {
   ///
   /// @param idName The name of output column that contains the unique ID.
   /// Column type is assumed as BIGINT.
-  /// @param taskUniqueId ID of the Task that will be used to run the query
-  /// plan. The ID must be unique across all the tasks of a single query. Tasks
-  /// may possibly run on different machines.
-  PlanBuilder& assignUniqueId(
-      const std::string& idName = "unique",
-      const int32_t taskUniqueId = 1);
+  PlanBuilder& assignUniqueId(const std::string& idName = "unique");
 
   /// Add a PartitionedOutputNode to hash-partition the input on the specified
   /// keys using exec::HashPartitionFunction.

--- a/velox/experimental/cudf/exec/OperatorAdapters.cpp
+++ b/velox/experimental/cudf/exec/OperatorAdapters.cpp
@@ -801,7 +801,7 @@ class AssignUniqueIdAdapter : public OperatorAdapter {
             ctx,
             assignUniqueIdPlanNode,
             assignUniqueIdPlanNode->taskUniqueId(),
-            assignUniqueIdPlanNode->uniqueIdCounter()));
+            ctx->task->uniqueRowIdPool()));
     return result;
   }
 };

--- a/velox/experimental/cudf/exec/OperatorAdapters.cpp
+++ b/velox/experimental/cudf/exec/OperatorAdapters.cpp
@@ -800,7 +800,8 @@ class AssignUniqueIdAdapter : public OperatorAdapter {
             operatorId,
             ctx,
             assignUniqueIdPlanNode,
-            assignUniqueIdPlanNode->taskUniqueId(),
+            ctx->task->planFragment().taskUniqueId.value_or(
+                assignUniqueIdPlanNode->taskUniqueId()),
             ctx->task->uniqueRowIdPool()));
     return result;
   }

--- a/velox/experimental/cudf/tests/AssignUniqueIdTest.cpp
+++ b/velox/experimental/cudf/tests/AssignUniqueIdTest.cpp
@@ -172,14 +172,15 @@ TEST_F(AssignUniqueIdTest, maxRowIdLimit) {
 
   auto plan = PlanBuilder().values(input).assignUniqueId().planNode();
 
-  // Increase the counter to kMaxRowId.
-  std::dynamic_pointer_cast<const core::AssignUniqueIdNode>(plan)
-      ->uniqueIdCounter()
-      ->fetch_add(1L << 40);
+  CursorParameters params;
+  params.planNode = plan;
+  auto cursor = TaskCursor::create(params);
+
+  // Seed the pool to kMaxRowId to force overflow on the next request.
+  cursor->task()->uniqueRowIdPool()->fetch_add(1L << 40);
 
   VELOX_ASSERT_THROW(
-      AssertQueryBuilder(plan).copyResults(pool()),
-      "Ran out of unique IDs at 1099511627776");
+      cursor->moveNext(), "Ran out of unique IDs at 1099511627776");
 }
 
 TEST_F(AssignUniqueIdTest, taskUniqueIdLimit) {

--- a/velox/experimental/cudf/tests/AssignUniqueIdTest.cpp
+++ b/velox/experimental/cudf/tests/AssignUniqueIdTest.cpp
@@ -172,26 +172,25 @@ TEST_F(AssignUniqueIdTest, maxRowIdLimit) {
 
   auto plan = PlanBuilder().values(input).assignUniqueId().planNode();
 
-  CursorParameters params;
-  params.planNode = plan;
-  auto cursor = TaskCursor::create(params);
-
-  // Seed the pool to kMaxRowId to force overflow on the next request.
-  cursor->task()->uniqueRowIdPool()->fetch_add(1L << 40);
-
   VELOX_ASSERT_THROW(
-      cursor->moveNext(), "Ran out of unique IDs at 1099511627776");
+      AssertQueryBuilder(plan)
+          .beforeTaskStart([](Task& task) {
+            // Advance the pool to the end of the 40-bit row id space so the
+            // next request overflows.
+            task.uniqueRowIdPool()->fetch_add(1L << 40);
+          })
+          .copyResults(pool()),
+      "Ran out of unique IDs at 1099511627776");
 }
 
 TEST_F(AssignUniqueIdTest, taskUniqueIdLimit) {
   auto input = {makeRowVector({makeFlatVector<int32_t>({1, 2, 3})})};
 
-  auto plan =
-      PlanBuilder().values(input).assignUniqueId("unique", 1L << 24).planNode();
+  auto plan = PlanBuilder().values(input).assignUniqueId().planNode();
 
   VELOX_ASSERT_THROW(
-      AssertQueryBuilder(plan).copyResults(pool()),
-      "(16777216 vs. 16777216) Unique 24-bit ID specified for AssignUniqueId exceeds the limit");
+      AssertQueryBuilder(plan).taskUniqueId(1L << 24).copyResults(pool()),
+      "Unique 24-bit ID specified for AssignUniqueId exceeds the limit");
 }
 
 // TODO: Add test for barrier execution, other operators does not support


### PR DESCRIPTION
Summary:
taskUniqueId identifies a task within a query stage. It was stored on the `AssignUniqueIdNode` plan node, which tied a plan to one task and prevented sharing a plan across the tasks of a stage. Move it to `core::PlanFragment`, supplied when the task is created, so the same plan can be reused across tasks.

The AssignUniqueId operator now gets taskUniqueId from the Task's `PlanFragment` instead of the plan node. The new `AssignUniqueIdNode` constructor drops the taskUniqueId argument, and the field is no longer serialized. The old 4-argument constructor is kept only under `VELOX_ENABLE_BACKWARD_COMPATIBILITY` for the read-only Prestissimo code. Axiom sets `PlanFragment::taskUniqueId` per task; `AssertQueryBuilder` and `CursorParameters` gain a `taskUniqueId` setter and a `beforeTaskStart` hook for tests.

Fixes https://github.com/facebookincubator/velox/issues/17645

bypass-github-export-checks

Differential Revision: D109567862


