### PR TITLE
fix: Handle exclusive floating-point bounds in extractRangeBounds (#17916)

### DIFF
--- a/velox/connectors/hive/HiveIndexSourceUtils.cpp
+++ b/velox/connectors/hive/HiveIndexSourceUtils.cpp
@@ -15,6 +15,9 @@
  */
 #include "velox/connectors/hive/HiveIndexSourceUtils.h"
 
+#include <cmath>
+#include <limits>
+
 #include "velox/common/base/Exceptions.h"
 
 namespace facebook::velox::connector::hive {
@@ -77,6 +80,9 @@ std::optional<std::pair<variant, variant>> extractRangeBounds(
 
   switch (filter->kind()) {
     case common::FilterKind::kBigintRange: {
+      // BigintRange is always inclusive: exclusive comparisons are normalized
+      // into the bound value at filter construction (e.g. 'x > 1' becomes
+      // lower=2), so no exclusive-to-inclusive adjustment is needed here.
       const auto* range = filter->as<common::BigintRange>();
       return std::make_pair(variant(range->lower()), variant(range->upper()));
     }
@@ -85,14 +91,30 @@ std::optional<std::pair<variant, variant>> extractRangeBounds(
       if (range->lowerUnbounded() || range->upperUnbounded()) {
         return std::nullopt;
       }
-      return std::make_pair(variant(range->lower()), variant(range->upper()));
+      double lower = range->lower();
+      double upper = range->upper();
+      if (range->lowerExclusive()) {
+        lower = std::nextafter(lower, std::numeric_limits<double>::infinity());
+      }
+      if (range->upperExclusive()) {
+        upper = std::nextafter(upper, -std::numeric_limits<double>::infinity());
+      }
+      return std::make_pair(variant(lower), variant(upper));
     }
     case common::FilterKind::kFloatRange: {
       const auto* range = filter->as<common::FloatRange>();
       if (range->lowerUnbounded() || range->upperUnbounded()) {
         return std::nullopt;
       }
-      return std::make_pair(variant(range->lower()), variant(range->upper()));
+      double lower = range->lower();
+      double upper = range->upper();
+      if (range->lowerExclusive()) {
+        lower = std::nextafter(lower, std::numeric_limits<double>::infinity());
+      }
+      if (range->upperExclusive()) {
+        upper = std::nextafter(upper, -std::numeric_limits<double>::infinity());
+      }
+      return std::make_pair(variant(lower), variant(upper));
     }
     case common::FilterKind::kBytesRange: {
       const auto* range = filter->as<common::BytesRange>();

--- a/velox/connectors/hive/tests/HiveIndexSourceUtilsTest.cpp
+++ b/velox/connectors/hive/tests/HiveIndexSourceUtilsTest.cpp
@@ -15,6 +15,9 @@
  */
 
 #include "velox/connectors/hive/HiveIndexSourceUtils.h"
+#include <cmath>
+#include <limits>
+
 #include <gtest/gtest.h>
 
 namespace facebook::velox::connector::hive {
@@ -59,6 +62,62 @@ TEST_F(ExtractRangeBoundsTest, doubleRangeBothInclusive) {
   EXPECT_EQ(result->second.value<double>(), 5.0);
 }
 
+TEST_F(ExtractRangeBoundsTest, doubleRangeBothExclusive) {
+  // score > 1.0 AND score < 5.0
+  auto filter = std::make_unique<common::DoubleRange>(
+      /*lower=*/1.0,
+      /*lowerUnbounded=*/false,
+      /*lowerExclusive=*/true,
+      /*upper=*/5.0,
+      /*upperUnbounded=*/false,
+      /*upperExclusive=*/true,
+      /*nullAllowed=*/false);
+  auto result = extractRangeBounds(filter.get());
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(
+      result->first.value<double>(),
+      std::nextafter(1.0, std::numeric_limits<double>::infinity()));
+  EXPECT_EQ(
+      result->second.value<double>(),
+      std::nextafter(5.0, -std::numeric_limits<double>::infinity()));
+}
+
+TEST_F(ExtractRangeBoundsTest, doubleRangeLowerExclusive) {
+  // score > 1.0 AND score <= 5.0
+  auto filter = std::make_unique<common::DoubleRange>(
+      /*lower=*/1.0,
+      /*lowerUnbounded=*/false,
+      /*lowerExclusive=*/true,
+      /*upper=*/5.0,
+      /*upperUnbounded=*/false,
+      /*upperExclusive=*/false,
+      /*nullAllowed=*/false);
+  auto result = extractRangeBounds(filter.get());
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(
+      result->first.value<double>(),
+      std::nextafter(1.0, std::numeric_limits<double>::infinity()));
+  EXPECT_EQ(result->second.value<double>(), 5.0);
+}
+
+TEST_F(ExtractRangeBoundsTest, doubleRangeUpperExclusive) {
+  // score >= 1.0 AND score < 5.0
+  auto filter = std::make_unique<common::DoubleRange>(
+      /*lower=*/1.0,
+      /*lowerUnbounded=*/false,
+      /*lowerExclusive=*/false,
+      /*upper=*/5.0,
+      /*upperUnbounded=*/false,
+      /*upperExclusive=*/true,
+      /*nullAllowed=*/false);
+  auto result = extractRangeBounds(filter.get());
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->first.value<double>(), 1.0);
+  EXPECT_EQ(
+      result->second.value<double>(),
+      std::nextafter(5.0, -std::numeric_limits<double>::infinity()));
+}
+
 TEST_F(ExtractRangeBoundsTest, doubleRangeUnboundedReturnsNullopt) {
   auto filter = std::make_unique<common::DoubleRange>(
       /*lower=*/1.0,
@@ -89,6 +148,56 @@ TEST_F(ExtractRangeBoundsTest, floatRangeBothInclusive) {
   ASSERT_TRUE(result.has_value());
   EXPECT_DOUBLE_EQ(result->first.value<double>(), 1.0);
   EXPECT_DOUBLE_EQ(result->second.value<double>(), 5.0);
+}
+
+TEST_F(ExtractRangeBoundsTest, floatRangeBothExclusive) {
+  // score > 1.0f AND score < 5.0f
+  auto filter = std::make_unique<common::FloatRange>(
+      /*lower=*/1.0f,
+      /*lowerUnbounded=*/false,
+      /*lowerExclusive=*/true,
+      /*upper=*/5.0f,
+      /*upperUnbounded=*/false,
+      /*upperExclusive=*/true,
+      /*nullAllowed=*/false);
+  auto result = extractRangeBounds(filter.get());
+  ASSERT_TRUE(result.has_value());
+  double lower = result->first.value<double>();
+  double upper = result->second.value<double>();
+  EXPECT_GT(lower, 1.0);
+  EXPECT_LT(upper, 5.0);
+}
+
+TEST_F(ExtractRangeBoundsTest, floatRangeLowerExclusive) {
+  // score > 1.0f AND score <= 5.0f
+  auto filter = std::make_unique<common::FloatRange>(
+      /*lower=*/1.0f,
+      /*lowerUnbounded=*/false,
+      /*lowerExclusive=*/true,
+      /*upper=*/5.0f,
+      /*upperUnbounded=*/false,
+      /*upperExclusive=*/false,
+      /*nullAllowed=*/false);
+  auto result = extractRangeBounds(filter.get());
+  ASSERT_TRUE(result.has_value());
+  EXPECT_GT(result->first.value<double>(), 1.0);
+  EXPECT_DOUBLE_EQ(result->second.value<double>(), 5.0);
+}
+
+TEST_F(ExtractRangeBoundsTest, floatRangeUpperExclusive) {
+  // score >= 1.0f AND score < 5.0f
+  auto filter = std::make_unique<common::FloatRange>(
+      /*lower=*/1.0f,
+      /*lowerUnbounded=*/false,
+      /*lowerExclusive=*/false,
+      /*upper=*/5.0f,
+      /*upperUnbounded=*/false,
+      /*upperExclusive=*/true,
+      /*nullAllowed=*/false);
+  auto result = extractRangeBounds(filter.get());
+  ASSERT_TRUE(result.has_value());
+  EXPECT_DOUBLE_EQ(result->first.value<double>(), 1.0);
+  EXPECT_LT(result->second.value<double>(), 5.0);
 }
 
 TEST_F(ExtractRangeBoundsTest, floatRangeUnboundedReturnsNullopt) {


### PR DESCRIPTION
Summary:

`BetweenIndexLookupCondition` bounds are always inclusive, but `DoubleRange` and `FloatRange` filters can have exclusive lower/upper bounds (e.g., `score > 1.0 AND score < 5.0`). Previously, `extractRangeBounds()` ignored the `lowerExclusive()`/`upperExclusive()` flags and returned the raw boundary values. After conversion, the original filter was erased from the `filters_` map, so no residual check caught the boundary values — rows exactly at the boundary incorrectly passed through.

Use `std::nextafter()` to convert exclusive bounds to their nearest inclusive equivalents before returning them as variants. For exclusive lower bounds, bump up toward +inf; for exclusive upper bounds, bump down toward -inf.

`BigintRange` is not affected because it already bakes exclusivity into its integer bounds (e.g., `x > 1` becomes `lower=2`).

Reviewed By: xiaoxmeng

Differential Revision: D109478347


