### PR TITLE
refactor(velox): Rename timer classes to clarify clock source (#17919)

### DIFF
--- a/velox/common/base/AdmissionController.cpp
+++ b/velox/common/base/AdmissionController.cpp
@@ -53,7 +53,7 @@ void AdmissionController::accept(uint64_t resourceUnits) {
   }
   uint64_t waitTimeUs{0};
   {
-    MicrosecondTimer timer(&waitTimeUs);
+    MicrosecondWallTimer timer(&waitTimeUs);
     future.wait();
   }
   if (!config_.resourceQueuedTimeMsHistogramMetric.empty()) {

--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -1006,7 +1006,7 @@ uint64_t AsyncDataCache::shrink(uint64_t targetBytes) {
   uint64_t evictedBytes{0};
   uint64_t shrinkTimeUs{0};
   {
-    MicrosecondTimer timer(&shrinkTimeUs);
+    MicrosecondWallTimer timer(&shrinkTimeUs);
     for (int shard = 0; shard < shards_.size(); ++shard) {
       AcquiredMemory acquired;
       evictedBytes += shards_[shardCounter_++ & shardMask_]->evict(

--- a/velox/common/caching/FileHandle.cpp
+++ b/velox/common/caching/FileHandle.cpp
@@ -49,7 +49,7 @@ std::unique_ptr<FileHandle> FileHandleGenerator::operator()(
   uint64_t elapsedTimeUs{0};
   std::unique_ptr<FileHandle> fileHandle;
   {
-    MicrosecondTimer timer(&elapsedTimeUs);
+    MicrosecondWallTimer timer(&elapsedTimeUs);
     fileHandle = std::make_unique<FileHandle>();
     filesystems::FileOptions options;
     options.stats = stats;

--- a/velox/common/file/FileInputStream.cpp
+++ b/velox/common/file/FileInputStream.cpp
@@ -57,7 +57,7 @@ void FileInputStream::readNextRange() {
   int32_t readBytes{0};
   uint64_t readTimeNs{0};
   {
-    NanosecondTimer timer{&readTimeNs};
+    NanosecondWallTimer timer{&readTimeNs};
     if (readAheadWait_.valid()) {
       readBytes = std::move(readAheadWait_)
                       .via(&folly::QueuedImmediateExecutor::instance())
@@ -71,7 +71,7 @@ void FileInputStream::readNextRange() {
       readBytes = readSize();
       VELOX_CHECK_LT(
           0, readBytes, "Read past end of FileInputStream {}", fileSize_);
-      NanosecondTimer timer_2{&readTimeNs};
+      NanosecondWallTimer timer_2{&readTimeNs};
       file_->pread(fileOffset_, readBytes, buffer()->asMutable<char>());
     }
   }

--- a/velox/common/memory/MemoryArbitrator.cpp
+++ b/velox/common/memory/MemoryArbitrator.cpp
@@ -191,7 +191,7 @@ uint64_t MemoryReclaimer::run(
   uint64_t execTimeUs{0};
   int64_t reclaimedBytes{0};
   {
-    MicrosecondTimer timer{&execTimeUs};
+    MicrosecondWallTimer timer{&execTimeUs};
     reclaimedBytes = func();
   }
   VELOX_CHECK_GE(reclaimedBytes, 0);

--- a/velox/common/memory/SharedArbitrator.cpp
+++ b/velox/common/memory/SharedArbitrator.cpp
@@ -1089,7 +1089,7 @@ void SharedArbitrator::runGlobalArbitration() {
   for (;; ++round) {
     uint64_t arbitrationTimeNs{0};
     {
-      NanosecondTimer timer(&arbitrationTimeNs);
+      NanosecondWallTimer timer(&arbitrationTimeNs);
       const uint64_t targetBytes = getGlobalArbitrationTarget();
       if (targetBytes == 0) {
         break;
@@ -1395,7 +1395,7 @@ uint64_t SharedArbitrator::reclaim(
   uint64_t reclaimedBytes{0};
   MemoryReclaimer::Stats stats;
   {
-    NanosecondTimer reclaimTimer(&reclaimTimeNs);
+    NanosecondWallTimer reclaimTimer(&reclaimTimeNs);
     reclaimedBytes = participant->reclaim(targetBytes, timeoutNs, stats);
   }
   // NOTE: if memory reclaim fails, then the participant is also aborted. If

--- a/velox/common/time/Timer.h
+++ b/velox/common/time/Timer.h
@@ -21,18 +21,19 @@
 #include <chrono>
 #include <optional>
 
+#include "velox/common/process/ProcessBase.h"
+
 namespace facebook::velox {
 
-/// Measures the time between construction and destruction with
-/// std::chrono::steady_clock and increments a user-supplied counter with the
-/// elapsed time in microseconds.
-class MicrosecondTimer {
+/// Measures wall time (steady_clock) between construction and destruction,
+/// incrementing a user-supplied counter in microseconds.
+class MicrosecondWallTimer {
  public:
-  explicit MicrosecondTimer(uint64_t* timer) : timer_(timer) {
+  explicit MicrosecondWallTimer(uint64_t* timer) : timer_(timer) {
     start_ = std::chrono::steady_clock::now();
   }
 
-  ~MicrosecondTimer() {
+  ~MicrosecondWallTimer() {
     auto duration = std::chrono::duration_cast<std::chrono::microseconds>(
         std::chrono::steady_clock::now() - start_);
 
@@ -44,13 +45,15 @@ class MicrosecondTimer {
   uint64_t* timer_;
 };
 
-class NanosecondTimer {
+/// Measures wall time (steady_clock) between construction and destruction,
+/// incrementing a user-supplied counter in nanoseconds.
+class NanosecondWallTimer {
  public:
-  explicit NanosecondTimer(uint64_t* timer) : timer_(timer) {
+  explicit NanosecondWallTimer(uint64_t* timer) : timer_(timer) {
     start_ = std::chrono::steady_clock::now();
   }
 
-  ~NanosecondTimer() {
+  ~NanosecondWallTimer() {
     auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(
         std::chrono::steady_clock::now() - start_);
 
@@ -61,6 +64,43 @@ class NanosecondTimer {
   std::chrono::steady_clock::time_point start_;
   uint64_t* timer_;
 };
+
+/// Measures per-thread CPU time (CLOCK_THREAD_CPUTIME_ID) between construction
+/// and destruction, incrementing a user-supplied counter in microseconds.
+/// Excludes time spent sleeping or blocked on I/O.
+class MicrosecondCPUTimer {
+ public:
+  explicit MicrosecondCPUTimer(uint64_t* timer)
+      : timer_(timer), start_(process::threadCpuNanos()) {}
+
+  ~MicrosecondCPUTimer() {
+    (*timer_) += (process::threadCpuNanos() - start_) / 1'000;
+  }
+
+ private:
+  uint64_t* timer_;
+  uint64_t start_;
+};
+
+/// Measures per-thread CPU time (CLOCK_THREAD_CPUTIME_ID) between construction
+/// and destruction, incrementing a user-supplied counter in nanoseconds.
+/// Excludes time spent sleeping or blocked on I/O.
+class NanosecondCPUTimer {
+ public:
+  explicit NanosecondCPUTimer(uint64_t* timer)
+      : timer_(timer), start_(process::threadCpuNanos()) {}
+
+  ~NanosecondCPUTimer() {
+    (*timer_) += process::threadCpuNanos() - start_;
+  }
+
+ private:
+  uint64_t* timer_;
+  uint64_t start_;
+};
+
+using MicrosecondTimer = MicrosecondWallTimer;
+using NanosecondTimer = NanosecondWallTimer;
 
 /// Measures the time between construction and destruction with CPU clock
 /// counter (rdtsc on X86) and increments a user-supplied counter with the cycle

--- a/velox/connectors/hive/HiveIndexSource.cpp
+++ b/velox/connectors/hive/HiveIndexSource.cpp
@@ -1447,7 +1447,7 @@ vector_size_t HiveIndexSource::evaluateRemainingFilter(
   uint64_t filterTimeNs{0};
   vector_size_t numRemainingRows{0};
   {
-    NanosecondTimer timer(&filterTimeNs);
+    NanosecondWallTimer timer(&filterTimeNs);
     expressionEvaluator_->evaluate(
         remainingFilterExprSet_.get(),
         remainingFilterRows_,

--- a/velox/dwio/common/BufferedInput.cpp
+++ b/velox/dwio/common/BufferedInput.cpp
@@ -128,7 +128,7 @@ void BufferedInput::readToBuffer(
     const LogType logType) {
   uint64_t storageReadTimeUs = 0;
   {
-    MicrosecondTimer timer(&storageReadTimeUs);
+    MicrosecondWallTimer timer(&storageReadTimeUs);
     input_->read(allocated.data(), allocated.size(), offset, logType);
   }
   if (auto* stats = input_->getStats()) {

--- a/velox/dwio/common/CacheInputStream.cpp
+++ b/velox/dwio/common/CacheInputStream.cpp
@@ -206,7 +206,7 @@ void CacheInputStream::loadSync(const Region& region) {
       VELOX_CHECK(cacheLoadWait.valid());
       uint64_t waitUs{0};
       {
-        MicrosecondTimer timer(&waitUs);
+        MicrosecondWallTimer timer(&waitUs);
         std::move(cacheLoadWait)
             .via(&folly::QueuedImmediateExecutor::instance())
             .wait();
@@ -235,7 +235,7 @@ void CacheInputStream::loadSync(const Region& region) {
     const auto ranges = entry->dataRanges(region.length);
     uint64_t storageReadUs{0};
     {
-      MicrosecondTimer timer(&storageReadUs);
+      MicrosecondWallTimer timer(&storageReadUs);
       input_->read(ranges, region.offset, LogType::FILE);
     }
     ioStats_->read().increment(region.length);
@@ -286,7 +286,7 @@ bool CacheInputStream::loadFromSsd(
   std::vector<cache::CachePin> pins;
   pins.push_back(std::move(pin_));
   try {
-    MicrosecondTimer timer(&ssdLoadUs);
+    MicrosecondWallTimer timer(&ssdLoadUs);
     file.load(ssdPins, pins);
   } catch (const std::exception& e) {
     LOG(ERROR) << "IOERR: Failed SSD loadSync " << entry.toString() << ' '
@@ -331,7 +331,7 @@ void CacheInputStream::loadPosition() {
       folly::SemiFuture<bool> waitFuture(false);
       uint64_t loadUs{0};
       {
-        MicrosecondTimer timer(&loadUs);
+        MicrosecondWallTimer timer(&loadUs);
         try {
           if (!load->loadOrFuture(&waitFuture, cacheable_)) {
             waitFuture.wait();

--- a/velox/dwio/common/CachedBufferedInput.cpp
+++ b/velox/dwio/common/CachedBufferedInput.cpp
@@ -183,7 +183,7 @@ void CachedBufferedInput::preload() {
     if (preloadPin_.empty()) {
       uint64_t waitUs{0};
       {
-        MicrosecondTimer timer(&waitUs);
+        MicrosecondWallTimer timer(&waitUs);
         std::move(waitFuture).wait();
       }
       ioStatistics_->queryThreadIoLatencyUs().increment(waitUs);
@@ -207,7 +207,7 @@ void CachedBufferedInput::preload() {
   auto ranges = entry->dataRanges(fileSize_);
   uint64_t storageReadUs{0};
   {
-    MicrosecondTimer timer(&storageReadUs);
+    MicrosecondWallTimer timer(&storageReadUs);
     input_->read(ranges, 0, LogType::FILE);
   }
   ioStatistics_->read().increment(fileSize_);
@@ -743,7 +743,7 @@ std::optional<CachedRegion> CachedBufferedInput::findCachedRegion(
     // Entry is exclusive — wait for it to become shared, then retry.
     uint64_t waitUs{0};
     {
-      MicrosecondTimer timer(&waitUs);
+      MicrosecondWallTimer timer(&waitUs);
       std::move(waitFuture)
           .via(&folly::QueuedImmediateExecutor::instance())
           .wait();

--- a/velox/dwio/common/DirectBufferedInput.cpp
+++ b/velox/dwio/common/DirectBufferedInput.cpp
@@ -317,7 +317,7 @@ void DirectBufferedInput::preload() {
   preloadData_->size = fileSize_;
   uint64_t storageReadUs{0};
   {
-    MicrosecondTimer timer(&storageReadUs);
+    MicrosecondWallTimer timer(&storageReadUs);
     if (fileSize_ <= kTinySize) {
       preloadData_->tinyData.resize(fileSize_);
       input_->read(preloadData_->tinyData.data(), fileSize_, 0, LogType::FILE);
@@ -422,7 +422,7 @@ std::vector<cache::CachePin> DirectCoalescedLoad::loadData(bool prefetch) {
 
   uint64_t usecs = 0;
   {
-    MicrosecondTimer timer(&usecs);
+    MicrosecondWallTimer timer(&usecs);
     input_->read(buffers, requests_[0].region.offset, LogType::FILE);
   }
 

--- a/velox/dwio/common/DirectInputStream.cpp
+++ b/velox/dwio/common/DirectInputStream.cpp
@@ -146,7 +146,7 @@ void DirectInputStream::loadSync() {
   auto ranges = makeRanges(loadedRegion_.length, data_, tinyData_);
   uint64_t usecs = 0;
   {
-    MicrosecondTimer timer(&usecs);
+    MicrosecondWallTimer timer(&usecs);
     input_->read(ranges, loadedRegion_.offset, LogType::FILE);
   }
   ioStats_->read().increment(loadedRegion_.length);
@@ -176,7 +176,7 @@ void DirectInputStream::loadPosition() {
       folly::SemiFuture<bool> waitFuture(false);
       uint64_t loadUs = 0;
       {
-        MicrosecondTimer timer(&loadUs);
+        MicrosecondWallTimer timer(&loadUs);
         if (!load->loadOrFuture(&waitFuture)) {
           waitFuture.wait();
         }

--- a/velox/dwio/common/FileSink.cpp
+++ b/velox/dwio/common/FileSink.cpp
@@ -56,7 +56,7 @@ void FileSink::write(DataBuffer<char> buffer) {
 void FileSink::writeWithLogging(std::vector<DataBuffer<char>>& buffers) {
   uint64_t timeUs{0};
   {
-    MicrosecondTimer timer(&timeUs);
+    MicrosecondWallTimer timer(&timeUs);
     write(buffers);
   }
   metricLogger_->logWrite(
@@ -70,7 +70,7 @@ void FileSink::writeImpl(
   const uint64_t oldSize = size_;
   uint64_t writeTimeUs{0};
   {
-    MicrosecondTimer timer(&writeTimeUs);
+    MicrosecondWallTimer timer(&writeTimeUs);
     for (auto& buf : buffers) {
       // NOTE: we need to update 'size_' after each 'callback' invocation as
       // some file sink implementation like MemorySink depends on the updated

--- a/velox/dwio/common/InputStream.cpp
+++ b/velox/dwio/common/InputStream.cpp
@@ -81,7 +81,7 @@ void ReadFileInputStream::read(
   uint64_t readTimeUs{0};
   std::string_view readData;
   {
-    MicrosecondTimer timer(&readTimeUs);
+    MicrosecondWallTimer timer(&readTimeUs);
     readData = readFile_->pread(offset, length, buf, fileIoContext_);
   }
   if (stats_) {

--- a/velox/dwio/common/OnDemandUnitLoader.cpp
+++ b/velox/dwio/common/OnDemandUnitLoader.cpp
@@ -54,7 +54,7 @@ class OnDemandUnitLoader : public UnitLoader {
 
     uint64_t unitLoadNanos{0};
     {
-      NanosecondTimer timer{&unitLoadNanos};
+      NanosecondWallTimer timer{&unitLoadNanos};
       auto measure = measureTimeIfCallback(blockedOnIoCallback_);
       loadUnits_[unit]->load();
     }

--- a/velox/dwio/common/ParallelUnitLoader.cpp
+++ b/velox/dwio/common/ParallelUnitLoader.cpp
@@ -97,7 +97,7 @@ class ParallelUnitLoader : public UnitLoader {
 
     uint64_t unitLoadNanos{0};
     try {
-      NanosecondTimer timer{&unitLoadNanos};
+      NanosecondWallTimer timer{&unitLoadNanos};
       asyncSources_[unit]->move();
     } catch (const std::exception& e) {
       VELOX_FAIL("Failed to load unit {}: {}", unit, e.what());

--- a/velox/dwio/common/Statistics.h
+++ b/velox/dwio/common/Statistics.h
@@ -23,6 +23,7 @@
 #include <type_traits>
 #include <utility>
 #include "velox/common/time/CpuWallTimer.h"
+#include "velox/common/time/Timer.h"
 #include "velox/dwio/common/Options.h"
 #include "velox/dwio/common/TypeWithId.h"
 #include "velox/dwio/common/UnitLoader.h"
@@ -548,15 +549,18 @@ class Statistics {
   virtual uint32_t getNumberOfColumns() const = 0;
 };
 
-/// Runs 'func' and records decompression stats if 'counter' is non-null.
+/// Runs 'func' and records decompression CPU time if 'counter' is non-null.
 template <typename F>
 auto withDecompressStats(io::IoCounter* counter, F&& func)
     -> std::enable_if_t<!std::is_void_v<decltype(func())>, decltype(func())> {
   if (counter) {
-    DeltaCpuWallTimer timer([counter](const CpuWallTiming& timing) {
-      counter->increment(timing.cpuNanos);
-    });
-    return func();
+    uint64_t cpuNanos = 0;
+    auto result = [&] {
+      NanosecondCPUTimer timer{&cpuNanos};
+      return func();
+    }();
+    counter->increment(cpuNanos);
+    return result;
   }
   return func();
 }
@@ -565,10 +569,12 @@ template <typename F>
 auto withDecompressStats(io::IoCounter* counter, F&& func)
     -> std::enable_if_t<std::is_void_v<decltype(func())>> {
   if (counter) {
-    DeltaCpuWallTimer timer([counter](const CpuWallTiming& timing) {
-      counter->increment(timing.cpuNanos);
-    });
-    func();
+    uint64_t cpuNanos = 0;
+    {
+      NanosecondCPUTimer timer{&cpuNanos};
+      func();
+    }
+    counter->increment(cpuNanos);
     return;
   }
   func();

--- a/velox/dwio/common/tests/ColumnReaderStatisticsTests.cpp
+++ b/velox/dwio/common/tests/ColumnReaderStatisticsTests.cpp
@@ -382,6 +382,22 @@ TEST(ColumnReaderStatisticsTest, MergeFromBothWithDecodingStats) {
   EXPECT_EQ(result["column_1.BIGINT.decompressCPUTimeNanos"].sum, 3'000);
 }
 
+TEST(WithDecompressStatsTest, NonVoidWithCounter) {
+  facebook::velox::io::IoCounter counter;
+  int result = withDecompressStats(&counter, [] { return 42; });
+  EXPECT_EQ(result, 42);
+  EXPECT_EQ(counter.count(), 1);
+}
+
+TEST(WithDecompressStatsTest, NullCounter) {
+  int result = withDecompressStats(nullptr, [] { return 7; });
+  EXPECT_EQ(result, 7);
+
+  int sideEffect = 0;
+  withDecompressStats(nullptr, [&] { sideEffect = 3; });
+  EXPECT_EQ(sideEffect, 3);
+}
+
 TEST(ColumnReaderStatisticsTest, MergeFromWithoutDecodingStats) {
   ColumnReaderStatistics src;
   src.flattenStringDictionaryValues = 100;

--- a/velox/dwio/parquet/reader/PageReader.cpp
+++ b/velox/dwio/parquet/reader/PageReader.cpp
@@ -126,7 +126,7 @@ void PageReader::updateBufferPointersAfterDeserialization(
 const char* PageReader::readBytes(int32_t size, BufferPtr& copy) {
   uint64_t readUs{0};
   {
-    MicrosecondTimer timer(&readUs);
+    MicrosecondWallTimer timer(&readUs);
     if (bufferEnd_ == bufferStart_) {
       const void* buffer = nullptr;
       int32_t bufferSize = 0;
@@ -464,7 +464,7 @@ void PageReader::prepareDictionary(const PageHeader& pageHeader) {
       } else {
         uint64_t readUs{0};
         {
-          MicrosecondTimer timer(&readUs);
+          MicrosecondWallTimer timer(&readUs);
           dwio::common::readBytes(
               numBytes,
               inputStream_.get(),
@@ -504,7 +504,7 @@ void PageReader::prepareDictionary(const PageHeader& pageHeader) {
       } else {
         uint64_t readUs{0};
         {
-          MicrosecondTimer timer(&readUs);
+          MicrosecondWallTimer timer(&readUs);
           dwio::common::readBytes(
               numBytes,
               inputStream_.get(),
@@ -541,7 +541,7 @@ void PageReader::prepareDictionary(const PageHeader& pageHeader) {
       } else {
         uint64_t readUs{0};
         {
-          MicrosecondTimer timer(&readUs);
+          MicrosecondWallTimer timer(&readUs);
           dwio::common::readBytes(
               numBytes, inputStream_.get(), strings, bufferStart_, bufferEnd_);
         }
@@ -570,7 +570,7 @@ void PageReader::prepareDictionary(const PageHeader& pageHeader) {
       } else {
         uint64_t readUs{0};
         {
-          MicrosecondTimer timer(&readUs);
+          MicrosecondWallTimer timer(&readUs);
           dwio::common::readBytes(
               numParquetBytes,
               inputStream_.get(),

--- a/velox/dwio/parquet/thrift/ParquetThrift.h
+++ b/velox/dwio/parquet/thrift/ParquetThrift.h
@@ -88,7 +88,7 @@ struct StreamReader {
     bool haveData;
     uint64_t readUs{0};
     {
-      MicrosecondTimer timer(&readUs);
+      MicrosecondWallTimer timer(&readUs);
       haveData = input->Next(data, dataBytes);
     }
     totalReadUs += readUs;

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -91,7 +91,7 @@ bool SpillerBase::fillSpillRuns(RowContainerIterator* iterator) {
   bool lastRun{false};
   uint64_t execTimeNs{0};
   {
-    NanosecondTimer timer(&execTimeNs);
+    NanosecondWallTimer timer(&execTimeNs);
 
     // Number of rows to hash and divide into spill partitions at a time.
     constexpr int32_t kHashBatchSize = 4096;
@@ -229,7 +229,7 @@ void SpillerBase::ensureSorted(SpillRun& run) {
 
   uint64_t sortTimeNs{0};
   {
-    NanosecondTimer timer(&sortTimeNs);
+    NanosecondWallTimer timer(&sortTimeNs);
 
     if (!state_.prefixSortConfig().has_value()) {
       gfx::timsort(
@@ -267,7 +267,7 @@ int64_t SpillerBase::extractSpillVector(
   int32_t numRows = 0;
   int64_t bytes = 0;
   {
-    NanosecondTimer timer(&extractNs);
+    NanosecondWallTimer timer(&extractNs);
     for (; numRows < limit; ++numRows) {
       bytes += container_->rowSize(rows[nextBatchIndex + numRows]);
       if (bytes > maxBytes) {
@@ -458,7 +458,7 @@ void SortOutputSpiller::spill(SpillRows& rows) {
   checkEmptySpillRuns();
   uint64_t execTimeNs{0};
   {
-    NanosecondTimer timer(&execTimeNs);
+    NanosecondWallTimer timer(&execTimeNs);
     auto& spillRun = createOrGetSpillRun(SpillPartitionId(0));
     spillRun.rows =
         SpillRows(rows.begin(), rows.end(), spillRun.rows.get_allocator());

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -218,7 +218,7 @@ RowVectorPtr TableScan::getOutput() {
     uint64_t ioTimeUs{0};
     std::optional<RowVectorPtr> dataOptional;
     {
-      MicrosecondTimer timer(&ioTimeUs);
+      MicrosecondWallTimer timer(&ioTimeUs);
       auto lk = driverCtx_->driver->pushdownFilters()->at(0).rlock();
       dataOptional = dataSource_->next(readBatchSize, blockingFuture_);
     }
@@ -414,7 +414,7 @@ bool TableScan::getSplit() {
   } else {
     uint64_t addSplitTimeUs{0};
     {
-      MicrosecondTimer timer(&addSplitTimeUs);
+      MicrosecondWallTimer timer(&addSplitTimeUs);
       auto lk = driverCtx_->driver->pushdownFilters()->at(0).rlock();
       dataSource_->addSplit(connectorSplit);
     }

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -3809,7 +3809,7 @@ uint64_t Task::MemoryReclaimer::reclaim(
   uint64_t reclaimWaitTimeUs{0};
   uint64_t reclaimedBytes{0};
   {
-    MicrosecondTimer timer{&reclaimWaitTimeUs};
+    MicrosecondWallTimer timer{&reclaimWaitTimeUs};
     reclaimedBytes = reclaimTask(task, targetBytes, maxWaitMs, stats);
   }
   ++task->taskStats_.memoryReclaimCount;
@@ -3834,7 +3834,7 @@ uint64_t Task::MemoryReclaimer::reclaimTask(
   uint64_t reclaimWaitTimeUs{0};
   bool paused{true};
   {
-    MicrosecondTimer timer{&reclaimWaitTimeUs};
+    MicrosecondWallTimer timer{&reclaimWaitTimeUs};
     if (maxWaitMs == 0) {
       task->requestPause().wait();
     } else {
@@ -3865,7 +3865,7 @@ uint64_t Task::MemoryReclaimer::reclaimTask(
   try {
     uint64_t reclaimExecTimeUs{0};
     {
-      MicrosecondTimer timer{&reclaimExecTimeUs};
+      MicrosecondWallTimer timer{&reclaimExecTimeUs};
       reclaimedBytes = memory::MemoryReclaimer::reclaim(
           task->pool(), targetBytes, maxWaitMs, stats);
     }

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
@@ -234,7 +234,7 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
 
   uint64_t filterTimeUs{0};
   if (remainingFilterExprSet_) {
-    MicrosecondTimer filterTimer(&filterTimeUs);
+    MicrosecondWallTimer filterTimer(&filterTimeUs);
     auto cudfTableColumns = cudfTable->release();
     std::vector<cudf::column_view> inputViews;
     inputViews.reserve(cudfTableColumns.size());

--- a/velox/serializers/SerializedPageFile.cpp
+++ b/velox/serializers/SerializedPageFile.cpp
@@ -124,7 +124,7 @@ uint64_t SerializedPageFileWriter::flush() {
       *pool_, nullptr, std::max<int64_t>(64 * 1024, batch_->size()));
   uint64_t flushTimeNs{0};
   {
-    NanosecondTimer timer(&flushTimeNs);
+    NanosecondWallTimer timer(&flushTimeNs);
     batch_->flush(&out);
   }
   batch_.reset();
@@ -133,7 +133,7 @@ uint64_t SerializedPageFileWriter::flush() {
   uint64_t writtenBytes{0};
   auto iobuf = out.getIOBuf();
   {
-    NanosecondTimer timer(&writeTimeNs);
+    NanosecondWallTimer timer(&writeTimeNs);
     writtenBytes = file->write(std::move(iobuf));
   }
   updateWriteStats(writtenBytes, flushTimeNs, writeTimeNs);
@@ -151,7 +151,7 @@ uint64_t SerializedPageFileWriter::write(
 
   uint64_t timeNs{0};
   {
-    NanosecondTimer timer(&timeNs);
+    NanosecondWallTimer timer(&timeNs);
     if (batch_ == nullptr) {
       batch_ = std::make_unique<VectorStreamGroup>(pool_, serde_);
       batch_->createStreamTree(
@@ -210,7 +210,7 @@ bool SerializedPageFileReader::nextBatch(RowVectorPtr& rowVector) {
 
   uint64_t timeNs{0};
   {
-    NanosecondTimer timer{&timeNs};
+    NanosecondWallTimer timer{&timeNs};
     VectorStreamGroup::read(
         input_.get(), pool_, type_, serde_, &rowVector, readOptions_.get());
   }


### PR DESCRIPTION
Summary:

CONTEXT: `MicrosecondTimer` and `NanosecondTimer` use wall time (`steady_clock`) but the names do not make this explicit. This causes confusion when comparing against CPU time metrics.

WHAT:
- Rename `MicrosecondTimer` -> `MicrosecondWallTimer` (35 call sites)
- Rename `NanosecondTimer` -> `NanosecondWallTimer` (19 call sites)
- Add `MicrosecondCPUTimer` — per-thread CPU time via `process::threadCpuNanos()`, in microseconds
- Add `NanosecondCPUTimer` — same clock source, in nanoseconds
- Keep backward-compatible `using` aliases
- Refactor `withDecompressStats()` in `Statistics.h` to use `NanosecondCPUTimer` instead of `DeltaCpuWallTimer` — simpler, avoids capturing unused wall time

Reviewed By: xiaoxmeng

Differential Revision: D109631236


