### PR TITLE
feat(sparksql): Add casts between TIMESTAMP  and TIMESTAMP_UTC

### DIFF
--- a/velox/docs/functions/spark/conversion.rst
+++ b/velox/docs/functions/spark/conversion.rst
@@ -414,3 +414,38 @@ Valid examples
 
   SELECT cast(true as timestamp); -- 1970-01-01 00:00:00.000001
   SELECT cast(false as timestamp); -- 1970-01-01 00:00:00
+
+From TIMESTAMP_UTC
+^^^^^^^^^^^^^^^^^^
+
+Casting a TIMESTAMP_UTC to TIMESTAMP interprets the stored timestamp as a local
+timestamp in the session timezone and returns the corresponding UTC epoch. When
+the local timestamp falls in a DST spring-forward gap, Spark adjusts to the
+post-transition timestamp instead of throwing.
+
+Valid examples
+
+::
+
+  -- Stored epoch 1577808000 represents local 2019-12-31 16:00:00.
+  -- In America/Los_Angeles (UTC-8) that is 2020-01-01 00:00:00 UTC.
+  SELECT cast(TIMESTAMP_NTZ '2019-12-31 16:00:00' as timestamp); -- 2020-01-01 00:00:00
+
+Cast to TIMESTAMP UTC
+---------------------
+
+From TIMESTAMP
+^^^^^^^^^^^^^^
+
+Casting a TIMESTAMP to TIMESTAMP_UTC applies the session timezone offset so
+that the local timestamp is preserved. The stored epoch in TIMESTAMP_UTC
+represents the same timestamp fields as the local timestamp, treated as a UTC
+epoch. When no session timezone is configured the cast is an identity operation.
+
+Valid examples
+
+::
+
+  -- 2020-01-01 00:00:00 UTC in America/Los_Angeles is local 2019-12-31 16:00:00.
+  -- TIMESTAMP_UTC stores that local time as epoch 1577808000.
+  SELECT cast(timestamp '2020-01-01 00:00:00' as timestamp_ntz); -- 2019-12-31 16:00:00

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -868,11 +868,31 @@ void CastExpr::applyPeeled(
             fromType,
             toType);
     }
-  } else if (
-      fromType->kind() == TypeKind::TIMESTAMP &&
-      (toType->kind() == TypeKind::VARCHAR ||
-       toType->kind() == TypeKind::VARBINARY)) {
-    if (fromType->equivalent(*TIMESTAMP_UTC())) {
+  } else if (toType->equivalent(*TIMESTAMP_UTC())) {
+    if (fromType->equivalent(*TIMESTAMP())) {
+      VELOX_USER_CHECK(
+          hooks_->supportsTimestampUtc(),
+          "Cast from {} to {} is not supported",
+          fromType->toString(),
+          toType->toString());
+      result = applyTimestampTimestampUtcCast<true>(rows, context, input);
+    } else {
+      VELOX_UNSUPPORTED(
+          "Cast from {} to {} is not supported",
+          fromType->toString(),
+          toType->toString());
+    }
+  } else if (fromType->equivalent(*TIMESTAMP_UTC())) {
+    if (toType->equivalent(*TIMESTAMP())) {
+      VELOX_USER_CHECK(
+          hooks_->supportsTimestampUtc(),
+          "Cast from {} to {} is not supported",
+          fromType->toString(),
+          toType->toString());
+      result = applyTimestampTimestampUtcCast<false>(rows, context, input);
+    } else if (
+        toType->kind() == TypeKind::VARCHAR ||
+        toType->kind() == TypeKind::VARBINARY) {
       VELOX_USER_CHECK(
           hooks_->supportsTimestampUtc(),
           "Cast from {} to {} is not supported",
@@ -881,9 +901,17 @@ void CastExpr::applyPeeled(
       result = applyTimestampToVarcharCast(
           toType, rows, context, input, hooks_->timestampUtcToStringOptions());
     } else {
-      result = applyTimestampToVarcharCast(
-          toType, rows, context, input, hooks_->timestampToStringOptions());
+      VELOX_UNSUPPORTED(
+          "Cast from {} to {} is not supported",
+          fromType->toString(),
+          toType->toString());
     }
+  } else if (
+      fromType->kind() == TypeKind::TIMESTAMP &&
+      (toType->kind() == TypeKind::VARCHAR ||
+       toType->kind() == TypeKind::VARBINARY)) {
+    result = applyTimestampToVarcharCast(
+        toType, rows, context, input, hooks_->timestampToStringOptions());
   } else if (toType->kind() == TypeKind::VARBINARY) {
     switch (fromType->kind()) {
       case TypeKind::TINYINT:
@@ -981,6 +1009,38 @@ VectorPtr CastExpr::applyTimestampToVarcharCast(
 
   // Update the exact buffer size.
   buffer->setSize(rawBuffer - buffer->asMutable<char>());
+  return result;
+}
+
+template <bool kToUtc>
+VectorPtr CastExpr::applyTimestampTimestampUtcCast(
+    const SelectivityVector& rows,
+    exec::EvalCtx& context,
+    const BaseVector& input) {
+  VectorPtr result;
+  if constexpr (kToUtc) {
+    context.ensureWritable(rows, TIMESTAMP_UTC(), result);
+  } else {
+    context.ensureWritable(rows, TIMESTAMP(), result);
+  }
+  (*result).clearNulls(rows);
+  auto* resultVector = result->asFlatVector<Timestamp>();
+  const auto& inputVector = *input.as<SimpleVector<Timestamp>>();
+  const auto* sessionTimeZone =
+      getTimeZoneFromConfig(context.execCtx()->queryCtx()->queryConfig());
+  applyToSelectedNoThrowLocal(context, rows, result, [&](vector_size_t row) {
+    Timestamp ts = inputVector.valueAt(row);
+    if (sessionTimeZone) {
+      if constexpr (kToUtc) {
+        ts.toTimezone(*sessionTimeZone);
+      } else {
+        // Convert from local timestamp representation to UTC, applying DST gap
+        // correction for spring-forward transitions.
+        hooks_->castDateTimestampToGMT(ts, *sessionTimeZone);
+      }
+    }
+    resultVector->set(row, ts);
+  });
   return result;
 }
 

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -302,6 +302,18 @@ class CastExpr : public SpecialForm {
       const BaseVector& input,
       const TimestampToStringOptions& options);
 
+  // Casts between TIMESTAMP and TIMESTAMP UTC.
+  // Casting TIMESTAMP_UTC to TIMESTAMP converts from local timestamp
+  // representation to UTC. Casting TIMESTAMP to TIMESTAMP_UTC applies the
+  // session timezone offset so that the local timestamp is preserved.
+  // @tparam kToUtc If true, casts TIMESTAMP to TIMESTAMP UTC. Otherwise,
+  // casts TIMESTAMP UTC to TIMESTAMP.
+  template <bool kToUtc>
+  VectorPtr applyTimestampTimestampUtcCast(
+      const SelectivityVector& rows,
+      exec::EvalCtx& context,
+      const BaseVector& input);
+
   // Casts basic numeric types to wider types.
   template <TypeKind ToKind, TypeKind FromKind>
   void applyNumericUpcast(

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <folly/ScopeGuard.h>
 #include "velox/core/Expressions.h"
 #include "velox/core/QueryConfig.h"
 #include "velox/functions/prestosql/tests/CastBaseTest.h"
@@ -1692,6 +1693,109 @@ TEST_F(SparkCastExprTestAnsiOn, dateToTimestampTimezoneGap) {
   auto expected =
       makeFlatVector<Timestamp>({Timestamp(-884248200, 0)}, TIMESTAMP());
   testCast(input, expected);
+}
+
+// Cast TIMESTAMP → TIMESTAMP_UTC: applies the session timezone offset so the
+// local timestamp is preserved as a UTC epoch in TIMESTAMP_UTC.
+TEST_F(SparkCastExprTestAnsiOff, timestampToTimestampUtc) {
+  // No session timezone: identity cast.
+  testCast(
+      makeFlatVector<Timestamp>(
+          {Timestamp(0, 0), Timestamp(1'000'000'000, 123)}, TIMESTAMP()),
+      makeFlatVector<Timestamp>(
+          {Timestamp(0, 0), Timestamp(1'000'000'000, 123)}, TIMESTAMP_UTC()));
+
+  // America/Los_Angeles (PST = UTC-8): 2020-01-01 00:00:00 UTC
+  // → local 2019-12-31 16:00:00 → stored as epoch 1577808000.
+  SCOPE_EXIT {
+    setTimezone("");
+  };
+  setTimezone("America/Los_Angeles");
+  testCast(
+      makeFlatVector<Timestamp>({Timestamp(1'577'836'800, 0)}, TIMESTAMP()),
+      makeFlatVector<Timestamp>(
+          {Timestamp(1'577'808'000, 0)}, TIMESTAMP_UTC()));
+
+  // Asia/Kolkata (IST = UTC+5:30): epoch 0 → local 05:30:00
+  // → stored as epoch 19800.
+  setTimezone("Asia/Kolkata");
+  testCast(
+      makeFlatVector<Timestamp>({Timestamp(0, 0)}, TIMESTAMP()),
+      makeFlatVector<Timestamp>({Timestamp(19'800, 0)}, TIMESTAMP_UTC()));
+}
+
+TEST_F(SparkCastExprTestAnsiOn, timestampToTimestampUtc) {
+  SCOPE_EXIT {
+    setTimezone("");
+  };
+  setTimezone("America/Los_Angeles");
+  testCast(
+      makeFlatVector<Timestamp>({Timestamp(1'577'836'800, 0)}, TIMESTAMP()),
+      makeFlatVector<Timestamp>(
+          {Timestamp(1'577'808'000, 0)}, TIMESTAMP_UTC()));
+}
+
+// Cast TIMESTAMP_UTC → TIMESTAMP: converts from the stored local timestamp
+// epoch back to a UTC epoch using the session timezone.
+TEST_F(SparkCastExprTestAnsiOff, timestampUtcToTimestamp) {
+  // No session timezone: identity cast.
+  testCast(
+      makeFlatVector<Timestamp>(
+          {Timestamp(0, 0), Timestamp(1'000'000'000, 123)}, TIMESTAMP_UTC()),
+      makeFlatVector<Timestamp>(
+          {Timestamp(0, 0), Timestamp(1'000'000'000, 123)}, TIMESTAMP()));
+
+  // America/Los_Angeles (PST = UTC-8): stored epoch 1577808000
+  // → local 2019-12-31 16:00:00 → UTC 2020-01-01 00:00:00 = epoch 1577836800.
+  SCOPE_EXIT {
+    setTimezone("");
+  };
+  setTimezone("America/Los_Angeles");
+  testCast(
+      makeFlatVector<Timestamp>({Timestamp(1'577'808'000, 0)}, TIMESTAMP_UTC()),
+      makeFlatVector<Timestamp>({Timestamp(1'577'836'800, 0)}, TIMESTAMP()));
+
+  // Asia/Kolkata (IST = UTC+5:30): stored epoch 19800
+  // → local 05:30:00 → UTC 00:00:00 = epoch 0.
+  setTimezone("Asia/Kolkata");
+  testCast(
+      makeFlatVector<Timestamp>({Timestamp(19'800, 0)}, TIMESTAMP_UTC()),
+      makeFlatVector<Timestamp>({Timestamp(0, 0)}, TIMESTAMP()));
+}
+
+TEST_F(SparkCastExprTestAnsiOn, timestampUtcToTimestamp) {
+  SCOPE_EXIT {
+    setTimezone("");
+  };
+  setTimezone("America/Los_Angeles");
+  testCast(
+      makeFlatVector<Timestamp>({Timestamp(1'577'808'000, 0)}, TIMESTAMP_UTC()),
+      makeFlatVector<Timestamp>({Timestamp(1'577'836'800, 0)}, TIMESTAMP()));
+}
+
+// Verify that casting TIMESTAMP_UTC to TIMESTAMP in a timezone where the
+// stored local time falls in a DST gap does not throw.
+TEST_F(SparkCastExprTestAnsiOff, timestampUtcToTimestampDSTGap) {
+  // 1941-12-25 in Hong Kong: clocks jumped from HKWT (UTC+8) to JST (UTC+9),
+  // making midnight nonexistent. Spark adjusts to 00:30:00 JST, which is
+  // 1941-12-24 15:30:00 UTC.
+  SCOPE_EXIT {
+    setTimezone("");
+  };
+  setTimezone("Asia/Hong_Kong");
+  testCast(
+      makeFlatVector<Timestamp>({Timestamp(-884'217'600, 0)}, TIMESTAMP_UTC()),
+      makeFlatVector<Timestamp>({Timestamp(-884'248'200, 0)}, TIMESTAMP()));
+}
+
+TEST_F(SparkCastExprTestAnsiOn, timestampUtcToTimestampDSTGap) {
+  SCOPE_EXIT {
+    setTimezone("");
+  };
+  setTimezone("Asia/Hong_Kong");
+  testCast(
+      makeFlatVector<Timestamp>({Timestamp(-884'217'600, 0)}, TIMESTAMP_UTC()),
+      makeFlatVector<Timestamp>({Timestamp(-884'248'200, 0)}, TIMESTAMP()));
 }
 } // namespace
 } // namespace facebook::velox::test


### PR DESCRIPTION
This PR adds support for casting between `TIMESTAMP` and `TIMESTAMP UTC`
(`TIMESTAMP_NTZ` in Spark) in `CastExpr`.
- TIMESTAMP to TIMESTAMP_UTC`: applies the session timezone offset to convert
  to local date-time, stored as a UTC epoch in TIMESTAMP_UTC.
- TIMESTAMP_UTC to TIMESTAMP`: converts back to UTC using the session timezone,
  with DST gap correction matching Spark's behavior.
