### PR TITLE
refactor: Consolidate coercion into a recursive coerce() (#17921)

### DIFF
--- a/velox/docs/develop/types.rst
+++ b/velox/docs/develop/types.rst
@@ -467,16 +467,14 @@ used by Target DECIMAL above (extending a fixed-width target to a wider
 caller-requested DECIMAL) and by ``LongDecimalType::commonSuperType``
 for DECIMAL -> DECIMAL reconciliation.
 
-``coerceTypeBase`` vs ``coercible``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+``coerce``
+^^^^^^^^^^
 
-``coerceTypeBase(from, to)`` is a single-rule lookup. It does NOT recurse
-into container children -- ``coerceTypeBase(ARRAY<INT>, ARRAY<BIGINT>)``
-returns ``nullopt`` because no flat rule keys on
-``("ARRAY", "ARRAY")``. ``coercible(from, to)`` is the structural
-predicate: for primitives it delegates to ``coerceTypeBase``; for
-containers it requires matching names and arities, then sums child
-coercion costs.
+``coerce(from, to)`` is the single recursive coercion primitive: scalars
+resolve via a single rule lookup, a bare UNKNOWN coerces to any resolved
+target, and containers match on name and arity then recurse element-wise,
+summing child costs (so ``coerce(ARRAY<INT>, ARRAY<BIGINT>)`` succeeds while
+a mismatched name or arity returns ``nullopt``).
 
 Default coercion rules
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/velox/expression/CaseExpr.cpp
+++ b/velox/expression/CaseExpr.cpp
@@ -493,9 +493,9 @@ TypePtr CaseCallToSpecialForm::resolveTypeWithCoercions(
   for (size_t i = 0; i < numCases; i++) {
     const auto& thenType = argTypes[2 * i + 2];
     if (*thenType != *resultType) {
-      if (coercer.coercible(thenType, resultType)) {
+      if (coercer.coerce(thenType, resultType)) {
         coercions[2 * i + 2] = resultType;
-      } else if (coercer.coercible(resultType, thenType)) {
+      } else if (coercer.coerce(resultType, thenType)) {
         resultType = thenType;
         for (size_t j = 0; j < i; j++) {
           coercions[2 * j + 2] = resultType;
@@ -513,9 +513,9 @@ TypePtr CaseCallToSpecialForm::resolveTypeWithCoercions(
   if (hasElse) {
     const auto& elseType = argTypes.back();
     if (*elseType != *resultType) {
-      if (coercer.coercible(elseType, resultType)) {
+      if (coercer.coerce(elseType, resultType)) {
         coercions.back() = resultType;
-      } else if (coercer.coercible(resultType, elseType)) {
+      } else if (coercer.coerce(resultType, elseType)) {
         resultType = elseType;
         for (size_t i = 0; i < numCases; i++) {
           coercions[2 * i + 2] = resultType;

--- a/velox/expression/CoalesceExpr.cpp
+++ b/velox/expression/CoalesceExpr.cpp
@@ -45,12 +45,12 @@ TypePtr resolveTypeInt(
       continue;
     }
 
-    if (allowedCoercions && coercer.coercible(argTypes[i], resultType)) {
+    if (allowedCoercions && coercer.coerce(argTypes[i], resultType)) {
       coercions[i] = resultType;
       continue;
     }
 
-    if (allowedCoercions && coercer.coercible(resultType, argTypes[i])) {
+    if (allowedCoercions && coercer.coerce(resultType, argTypes[i])) {
       resultType = argTypes[i];
       for (auto j = 0; j < i; j++) {
         coercions[j] = resultType;

--- a/velox/expression/SignatureBinder.cpp
+++ b/velox/expression/SignatureBinder.cpp
@@ -189,9 +189,9 @@ bool SignatureBinder::tryBind(
           }
 
           for (auto i = numFormalArgs; i < numActualTypes; i++) {
-            if (auto cost = coercer_.coercible(actualTypes_[i], firstType)) {
-              if (cost.value() > 0) {
-                coercions[i] = Coercion{firstType, cost.value()};
+            if (auto coercion = coercer_.coerce(actualTypes_[i], firstType)) {
+              if (coercion->cost > 0) {
+                coercions[i] = Coercion{firstType, coercion->cost};
               }
             } else {
               return false;
@@ -287,12 +287,12 @@ std::optional<bool> SignatureBinderBase::checkSetTypeVariable(
     VELOX_CHECK(bindingIt != typeVariablesBindings_.end());
 
     const auto& boundType = bindingIt->second;
-    const auto cost = coercer_.coercible(actualType, boundType);
-    VELOX_CHECK(cost.has_value());
+    const auto availableCoercion = coercer_.coerce(actualType, boundType);
+    VELOX_CHECK(availableCoercion.has_value());
 
-    if (cost.value() > 0) {
+    if (availableCoercion->cost > 0) {
       coercion.type = boundType;
-      coercion.cost = cost.value();
+      coercion.cost = availableCoercion->cost;
     }
     return true;
   }
@@ -420,8 +420,8 @@ bool SignatureBinderBase::tryBind(
   const auto& baseName = typeSignature.baseName();
   auto typeName = boost::algorithm::to_upper_copy(baseName);
   if (!boost::algorithm::iequals(typeName, actualType->name())) {
-    if (allowCoercion && actualType->isUnknown() &&
-        !typeSignature.parameters().empty()) {
+    if (allowCoercion &&
+        (typeSignature.parameters().empty() || actualType->isUnknown())) {
       auto resolvedType = SignatureBinder::tryResolveType(
           typeSignature,
           variables(),
@@ -429,20 +429,12 @@ bool SignatureBinderBase::tryBind(
           integerVariablesBindings_,
           longEnumVariablesBindings_,
           varcharEnumVariablesBindings_);
-      // This path only coerces UNKNOWN to complex types.
-      if (!resolvedType || resolvedType->size() == 0) {
-        return false;
-      }
-      auto availableCoercion = coercer_.coerce(UNKNOWN(), resolvedType);
-      VELOX_CHECK(availableCoercion.has_value());
-      coercion = availableCoercion.value();
-      return true;
-    }
-    if (allowCoercion && typeSignature.parameters().empty()) {
-      if (auto availableCoercion =
-              coercer_.coerceTypeBase(actualType, typeName)) {
-        coercion = availableCoercion.value();
-        return true;
+      if (resolvedType) {
+        if (auto availableCoercion =
+                coercer_.coerce(actualType, resolvedType)) {
+          coercion = availableCoercion.value();
+          return true;
+        }
       }
     }
     return false;

--- a/velox/expression/SwitchExpr.cpp
+++ b/velox/expression/SwitchExpr.cpp
@@ -268,9 +268,9 @@ TypePtr resolveTypeInt(
         "Condition of  SWITCH statement is not bool");
 
     if (*thenType != *resultType) {
-      if (allowedCoercions && coercer.coercible(thenType, resultType)) {
+      if (allowedCoercions && coercer.coerce(thenType, resultType)) {
         coercions[i * 2 + 1] = resultType;
-      } else if (allowedCoercions && coercer.coercible(resultType, thenType)) {
+      } else if (allowedCoercions && coercer.coerce(resultType, thenType)) {
         resultType = thenType;
         setCoercionsUpTo(i * 2 - 1, resultType);
       } else {
@@ -288,9 +288,9 @@ TypePtr resolveTypeInt(
     const auto& elseType = argTypes.back();
 
     if (*elseType != *resultType) {
-      if (allowedCoercions && coercer.coercible(elseType, resultType)) {
+      if (allowedCoercions && coercer.coerce(elseType, resultType)) {
         coercions.back() = resultType;
-      } else if (allowedCoercions && coercer.coercible(resultType, elseType)) {
+      } else if (allowedCoercions && coercer.coerce(resultType, elseType)) {
         resultType = elseType;
         setCoercionsUpTo(numArgs - 2, resultType);
       } else {

--- a/velox/expression/tests/SignatureBinderTest.cpp
+++ b/velox/expression/tests/SignatureBinderTest.cpp
@@ -1736,20 +1736,23 @@ TEST(SignatureBinderTest, unknownDoesNotBindWithoutCoercion) {
                               .build();
 
   assertCannotBind(decimalSignature, {UNKNOWN()}, /*allowCoercion=*/true);
+}
 
-  // Shared (p, s) resolves the UNKNOWN arg to a decimal scalar; no coercion.
-  auto boundDecimalSignature = exec::FunctionSignatureBuilder()
-                                   .integerVariable("p")
-                                   .integerVariable("s")
-                                   .returnType("decimal(p, s)")
-                                   .argumentType("decimal(p, s)")
-                                   .argumentType("decimal(p, s)")
-                                   .build();
+TEST(SignatureBinderTest, unknownCoercesToBoundDecimal) {
+  // Shared (p, s): the concrete arg pins p=10, s=2.
+  auto signature = exec::FunctionSignatureBuilder()
+                       .integerVariable("p")
+                       .integerVariable("s")
+                       .returnType("decimal(p, s)")
+                       .argumentType("decimal(p, s)")
+                       .argumentType("decimal(p, s)")
+                       .build();
 
-  assertCannotBind(
-      boundDecimalSignature,
+  testCoercions(
+      signature,
       {DECIMAL(10, 2), UNKNOWN()},
-      /*allowCoercion=*/true);
+      {nullptr, DECIMAL(10, 2)},
+      DECIMAL(10, 2));
 }
 
 TEST(SignatureBinderTest, unknownArgUnifiesWithConcreteArg) {

--- a/velox/functions/prestosql/coercion/tests/PrestoCoercionsTest.cpp
+++ b/velox/functions/prestosql/coercion/tests/PrestoCoercionsTest.cpp
@@ -29,9 +29,9 @@ namespace {
 TEST(PrestoCoercionsTest, bigintRow) {
   const auto& tc = typeCoercer();
 
-  auto toDecimal = tc.coerceTypeBase(BIGINT(), DECIMAL(19, 0));
-  auto toReal = tc.coerceTypeBase(BIGINT(), REAL());
-  auto toDouble = tc.coerceTypeBase(BIGINT(), DOUBLE());
+  auto toDecimal = tc.coerce(BIGINT(), DECIMAL(19, 0));
+  auto toReal = tc.coerce(BIGINT(), REAL());
+  auto toDouble = tc.coerce(BIGINT(), DOUBLE());
 
   ASSERT_TRUE(toDecimal.has_value());
   ASSERT_TRUE(toReal.has_value());
@@ -45,11 +45,11 @@ TEST(PrestoCoercionsTest, bigintRow) {
 TEST(PrestoCoercionsTest, sanity) {
   const auto& tc = typeCoercer();
 
-  EXPECT_TRUE(tc.coercible(INTEGER(), BIGINT()).has_value());
-  EXPECT_TRUE(tc.coercible(BIGINT(), DOUBLE()).has_value());
-  EXPECT_TRUE(tc.coercible(DATE(), TIMESTAMP()).has_value());
-  EXPECT_TRUE(tc.coercible(REAL(), DOUBLE()).has_value());
-  EXPECT_TRUE(tc.coercible(UNKNOWN(), VARCHAR()).has_value());
+  EXPECT_TRUE(tc.coerce(INTEGER(), BIGINT()).has_value());
+  EXPECT_TRUE(tc.coerce(BIGINT(), DOUBLE()).has_value());
+  EXPECT_TRUE(tc.coerce(DATE(), TIMESTAMP()).has_value());
+  EXPECT_TRUE(tc.coerce(REAL(), DOUBLE()).has_value());
+  EXPECT_TRUE(tc.coerce(UNKNOWN(), VARCHAR()).has_value());
 }
 
 } // namespace

--- a/velox/functions/prestosql/types/tests/CustomTypeCoercionTest.cpp
+++ b/velox/functions/prestosql/types/tests/CustomTypeCoercionTest.cpp
@@ -41,50 +41,42 @@ class CustomTypeCoercionTest : public testing::Test {
 };
 
 TEST_F(CustomTypeCoercionTest, timestampWithTimeZone) {
-  auto coercion = TypeCoercer::defaults().coerceTypeBase(
-      TIMESTAMP(), TIMESTAMP_WITH_TIME_ZONE()->name());
+  auto coercion =
+      TypeCoercer::defaults().coerce(TIMESTAMP(), TIMESTAMP_WITH_TIME_ZONE());
   ASSERT_TRUE(coercion.has_value());
   VELOX_EXPECT_EQ_TYPES(coercion->type, TIMESTAMP_WITH_TIME_ZONE());
   EXPECT_EQ(coercion->cost, 1);
 
-  coercion = TypeCoercer::defaults().coerceTypeBase(
-      DATE(), TIMESTAMP_WITH_TIME_ZONE()->name());
+  coercion = TypeCoercer::defaults().coerce(DATE(), TIMESTAMP_WITH_TIME_ZONE());
   ASSERT_TRUE(coercion.has_value());
   VELOX_EXPECT_EQ_TYPES(coercion->type, TIMESTAMP_WITH_TIME_ZONE());
   EXPECT_EQ(coercion->cost, 2);
 
   // Reverse directions are explicit-only, not coercible.
   ASSERT_FALSE(
-      TypeCoercer::defaults().coerceTypeBase(
-          TIMESTAMP_WITH_TIME_ZONE(), TIMESTAMP()->name()));
+      TypeCoercer::defaults().coerce(TIMESTAMP_WITH_TIME_ZONE(), TIMESTAMP()));
   ASSERT_FALSE(
-      TypeCoercer::defaults().coerceTypeBase(
-          TIMESTAMP_WITH_TIME_ZONE(), DATE()->name()));
+      TypeCoercer::defaults().coerce(TIMESTAMP_WITH_TIME_ZONE(), DATE()));
 }
 
 TEST_F(CustomTypeCoercionTest, timeWithTimeZone) {
-  auto coercion = TypeCoercer::defaults().coerceTypeBase(
-      TIME(), TIME_WITH_TIME_ZONE()->name());
+  auto coercion = TypeCoercer::defaults().coerce(TIME(), TIME_WITH_TIME_ZONE());
   ASSERT_TRUE(coercion.has_value());
   VELOX_EXPECT_EQ_TYPES(coercion->type, TIME_WITH_TIME_ZONE());
 
   // Reverse directions are explicit-only, not coercible.
-  ASSERT_FALSE(
-      TypeCoercer::defaults().coerceTypeBase(
-          TIME_WITH_TIME_ZONE(), TIME()->name()));
-  ASSERT_FALSE(
-      TypeCoercer::defaults().coerceTypeBase(
-          TIME_WITH_TIME_ZONE(), DATE()->name()));
+  ASSERT_FALSE(TypeCoercer::defaults().coerce(TIME_WITH_TIME_ZONE(), TIME()));
+  ASSERT_FALSE(TypeCoercer::defaults().coerce(TIME_WITH_TIME_ZONE(), DATE()));
 }
 
 TEST_F(CustomTypeCoercionTest, digests) {
   EXPECT_FALSE(
       TypeCoercer::defaults()
-          .coerceTypeBase(TDIGEST(DOUBLE()), "QDIGEST")
+          .coerce(TDIGEST(DOUBLE()), QDIGEST(DOUBLE()))
           .has_value());
   EXPECT_FALSE(
       TypeCoercer::defaults()
-          .coerceTypeBase(QDIGEST(DOUBLE()), "TDIGEST")
+          .coerce(QDIGEST(DOUBLE()), TDIGEST(DOUBLE()))
           .has_value());
 }
 

--- a/velox/functions/tests/FunctionRegistryTest.cpp
+++ b/velox/functions/tests/FunctionRegistryTest.cpp
@@ -1116,7 +1116,7 @@ TEST_F(FunctionRegistryTest, unknownArgToParameterizedFunction) {
 
   // A scalar overload outranks a complex one on a bare null. varbinary (the
   // highest-cost scalar UNKNOWN coercion) still beats array(T) because
-  // unknownToComplexCost is one above it.
+  // unknownFallbackCost is one above it.
   {
     SCOPE_EXIT {
       removeFunction("foo");
@@ -1133,6 +1133,21 @@ TEST_F(FunctionRegistryTest, unknownArgToParameterizedFunction) {
         std::make_unique<DummyVectorFunction>());
 
     testCoercions("foo", {UNKNOWN()}, VARBINARY(), {VARBINARY()});
+  }
+
+  // A plain-scalar overload outranks a parameterized-scalar one on a bare null.
+  {
+    SCOPE_EXIT {
+      removeFunction("foo");
+    };
+
+    exec::registerVectorFunction(
+        "foo",
+        {makeSignature("bigint", {"bigint"}),
+         makeSignature("bigint", {"decimal(10, 2)"})},
+        std::make_unique<DummyVectorFunction>());
+
+    testCoercions("foo", {UNKNOWN()}, BIGINT(), {BIGINT()});
   }
 
   // Vector resolver: differing return types stay ambiguous.

--- a/velox/type/TypeCoercer.cpp
+++ b/velox/type/TypeCoercer.cpp
@@ -167,7 +167,7 @@ TypeCoercer::TypeCoercer(const std::vector<CoercionEntry>& rules) {
         entry.to->name());
   }
 
-  unknownToComplexCost_ = maxUnknownCost + 1;
+  unknownFallbackCost_ = maxUnknownCost + 1;
 }
 
 // static
@@ -179,10 +179,28 @@ const TypeCoercer& TypeCoercer::defaults() {
 std::optional<Coercion> TypeCoercer::coerce(
     const TypePtr& fromType,
     const TypePtr& toType) const {
-  if (fromType->isUnknown() && toType->size() > 0) {
-    return Coercion{.type = toType, .cost = unknownToComplexCost_};
+  if (fromType->size() == 0 && toType->size() == 0) {
+    if (auto coercion = coerceTypeBase(fromType, toType)) {
+      return coercion;
+    }
+  } else if (
+      fromType->name() == toType->name() &&
+      fromType->size() == toType->size()) {
+    int32_t totalCost = 0;
+    for (auto i = 0; i < fromType->size(); ++i) {
+      const auto child = coerce(fromType->childAt(i), toType->childAt(i));
+      if (!child) {
+        return std::nullopt;
+      }
+      totalCost += child->cost;
+    }
+    return Coercion{.type = toType, .cost = totalCost};
   }
-  return coerceTypeBase(fromType, toType);
+
+  if (fromType->isUnknown() && !toType->isUnknown()) {
+    return Coercion{.type = toType, .cost = unknownFallbackCost_};
+  }
+  return std::nullopt;
 }
 
 std::optional<Coercion> TypeCoercer::coerceTypeBase(
@@ -218,73 +236,6 @@ std::optional<Coercion> TypeCoercer::coerceTypeBase(
   }
 
   return std::nullopt;
-}
-
-std::optional<Coercion> TypeCoercer::coerceTypeBase(
-    const TypePtr& fromType,
-    const std::string& toTypeName) const {
-  if (fromType->name() == toTypeName) {
-    return Coercion{.type = fromType, .cost = 0};
-  }
-
-  // Check this coercer's rule set first.
-  auto it = rules_.find({fromType->name(), toTypeName});
-  if (it != rules_.end()) {
-    return it->second;
-  }
-
-  // Fall back to CastRulesRegistry for custom type coercions. Skip
-  // parameterized types -- we cannot construct the target type without knowing
-  // its type parameters.
-  // getCustomType() returns nullptr for built-in types. Callers must not
-  // pass parametric custom type names (e.g., "BIGINT_ENUM") because their
-  // factories throw when called with empty parameters. SignatureBinder
-  // guards against this by checking typeSignature.parameters().empty().
-  if (fromType->size() == 0 && fromType->parameters().empty()) {
-    if (auto toType = getCustomType(toTypeName, {})) {
-      if (auto cost =
-              CastRulesRegistry::instance().canCoerce(fromType, toType)) {
-        return Coercion{.type = std::move(toType), .cost = *cost};
-      }
-    }
-  }
-
-  return std::nullopt;
-}
-
-std::optional<int32_t> TypeCoercer::coercible(
-    const TypePtr& fromType,
-    const TypePtr& toType) const {
-  if (fromType->isUnknown()) {
-    if (toType->isUnknown()) {
-      return 0;
-    }
-    return 1;
-  }
-
-  if (fromType->size() == 0) {
-    if (auto coercion = coerceTypeBase(fromType, toType)) {
-      return coercion->cost;
-    }
-
-    return std::nullopt;
-  }
-
-  if (fromType->name() != toType->name() ||
-      fromType->size() != toType->size()) {
-    return std::nullopt;
-  }
-
-  int32_t totalCost = 0;
-  for (auto i = 0; i < fromType->size(); i++) {
-    if (auto cost = coercible(fromType->childAt(i), toType->childAt(i))) {
-      totalCost += cost.value();
-    } else {
-      return std::nullopt;
-    }
-  }
-
-  return totalCost;
 }
 
 namespace {

--- a/velox/type/TypeCoercer.h
+++ b/velox/type/TypeCoercer.h
@@ -227,7 +227,7 @@ struct CoercionEntry {
 /// Container types (ARRAY, MAP, ROW) and FUNCTION/OPAQUE are not
 /// customizable directly -- coercibility for those is structural (names and
 /// arities must match, children are recursed element-wise, see
-/// coercible()), so a dialect controls their behavior only indirectly via
+/// coerce()), so a dialect controls their behavior only indirectly via
 /// element-type rules.
 ///
 /// Custom types (e.g. JSON, TIMESTAMP WITH TIME ZONE) are out of scope for
@@ -245,50 +245,12 @@ class TypeCoercer {
   /// Used by callers that have not selected a dialect-specific coercer.
   static const TypeCoercer& defaults();
 
-  /// Returns the coercion from 'fromType' to 'toType', or std::nullopt. A bare
-  /// UNKNOWN coerces to any complex target at a cost above every
-  /// UNKNOWN->scalar coercion; all other cases defer to coerceTypeBase().
+  /// Returns the coercion from 'fromType' to 'toType', or std::nullopt.
+  /// Scalars resolve via a single rule lookup; containers match on name and
+  /// arity, then recurse element-wise. A bare UNKNOWN coerces to any resolved
+  /// target, ranked above every UNKNOWN->scalar rule.
   std::optional<Coercion> coerce(const TypePtr& fromType, const TypePtr& toType)
       const;
-
-  /// Checks if 'fromType' can be implicitly converted to 'toType' via a
-  /// single rule lookup. Does NOT recurse into container children -- for
-  /// container coercibility (e.g., ARRAY<INT> vs ARRAY<BIGINT>), use
-  /// coercible() instead.
-  ///
-  /// Prefer this over the string overload when the target type is available,
-  /// as it avoids reconstructing the type from a name (which can throw for
-  /// parametric custom types like BigintEnum).
-  ///
-  /// For DECIMAL targets, the rule's stored type is the minimum-width
-  /// decimal for the source. If 'toType' is a wider DECIMAL that the
-  /// minimum can be coerced to (per ShortDecimalType / LongDecimalType
-  /// isCoercibleTo), the returned Coercion carries 'toType' and the rule's
-  /// cost. If 'toType' is too narrow, returns nullopt.
-  ///
-  /// @return "to" type and cost if conversion is possible.
-  std::optional<Coercion> coerceTypeBase(
-      const TypePtr& fromType,
-      const TypePtr& toType) const;
-
-  /// Checks if the base of 'fromType' can be implicitly converted to a type
-  /// with the given name. Used by SignatureBinder which only has a type name.
-  ///
-  /// @return "to" type and cost if conversion is possible.
-  std::optional<Coercion> coerceTypeBase(
-      const TypePtr& fromType,
-      const std::string& toTypeName) const;
-
-  /// Checks if 'fromType' can be implicitly converted to 'toType', recursing
-  /// into container children. For primitives this delegates to
-  /// coerceTypeBase(); for containers (ARRAY, MAP, ROW, FUNCTION) the names
-  /// and arities must match, then each child must be element-wise coercible.
-  ///
-  /// @return Total cost (sum of child costs for containers) if possible.
-  /// std::nullopt otherwise.
-  std::optional<int32_t> coercible(
-      const TypePtr& fromType,
-      const TypePtr& toType) const;
 
   /// Returns least common type for 'a' and 'b', i.e. a type that both 'a' and
   /// 'b' are coercible to. Returns nullptr if no such type exists.
@@ -299,6 +261,12 @@ class TypeCoercer {
   TypePtr leastCommonSuperType(const TypePtr& a, const TypePtr& b) const;
 
  private:
+  // Returns the coercion from scalar 'fromType' to 'toType' via a single rule
+  // lookup, or std::nullopt.
+  std::optional<Coercion> coerceTypeBase(
+      const TypePtr& fromType,
+      const TypePtr& toType) const;
+
   struct PairHash {
     size_t operator()(const std::pair<std::string, std::string>& p) const {
       return folly::hash::hash_combine(
@@ -312,7 +280,7 @@ class TypeCoercer {
       rules_;
 
   // Derived from the rule set at construction (max UNKNOWN->scalar cost + 1).
-  int32_t unknownToComplexCost_{1};
+  int32_t unknownFallbackCost_{1};
 };
 
 } // namespace facebook::velox

--- a/velox/type/tests/TypeCoercerTest.cpp
+++ b/velox/type/tests/TypeCoercerTest.cpp
@@ -23,22 +23,19 @@ namespace facebook::velox {
 namespace {
 
 void testCoercion(const TypePtr& fromType, const TypePtr& toType) {
-  auto coercion =
-      TypeCoercer::defaults().coerceTypeBase(fromType, toType->name());
+  auto coercion = TypeCoercer::defaults().coerce(fromType, toType);
   ASSERT_TRUE(coercion.has_value());
   VELOX_EXPECT_EQ_TYPES(coercion->type, toType);
 }
 
 void testBaseCoercion(const TypePtr& fromType) {
-  auto coercion =
-      TypeCoercer::defaults().coerceTypeBase(fromType, fromType->kindName());
+  auto coercion = TypeCoercer::defaults().coerce(fromType, fromType);
   ASSERT_TRUE(coercion.has_value());
   VELOX_EXPECT_EQ_TYPES(coercion->type, fromType);
 }
 
 void testNoCoercion(const TypePtr& fromType, const TypePtr& toType) {
-  auto coercion =
-      TypeCoercer::defaults().coerceTypeBase(fromType, toType->name());
+  auto coercion = TypeCoercer::defaults().coerce(fromType, toType);
   ASSERT_FALSE(coercion.has_value());
 }
 
@@ -63,9 +60,9 @@ TEST(TypeCoercerTest, decimal) {
   testNoCoercion(DECIMAL(10, 2), VARCHAR());
   testNoCoercion(DECIMAL(10, 2), BIGINT());
 
-  ASSERT_TRUE(TypeCoercer::defaults().coercible(DECIMAL(10, 2), DOUBLE()));
-  ASSERT_TRUE(TypeCoercer::defaults().coercible(DECIMAL(10, 2), REAL()));
-  ASSERT_FALSE(TypeCoercer::defaults().coercible(DOUBLE(), DECIMAL(10, 2)));
+  ASSERT_TRUE(TypeCoercer::defaults().coerce(DECIMAL(10, 2), DOUBLE()));
+  ASSERT_TRUE(TypeCoercer::defaults().coerce(DECIMAL(10, 2), REAL()));
+  ASSERT_FALSE(TypeCoercer::defaults().coerce(DOUBLE(), DECIMAL(10, 2)));
 }
 
 TEST(TypeCoercerTest, integerToDecimal) {
@@ -74,25 +71,25 @@ TEST(TypeCoercerTest, integerToDecimal) {
   testCoercion(INTEGER(), DECIMAL(10, 0));
   testCoercion(BIGINT(), DECIMAL(19, 0));
 
-  ASSERT_TRUE(TypeCoercer::defaults().coercible(TINYINT(), DECIMAL(10, 2)));
-  ASSERT_TRUE(TypeCoercer::defaults().coercible(SMALLINT(), DECIMAL(10, 2)));
-  ASSERT_TRUE(TypeCoercer::defaults().coercible(INTEGER(), DECIMAL(38, 4)));
-  ASSERT_TRUE(TypeCoercer::defaults().coercible(BIGINT(), DECIMAL(38, 4)));
+  ASSERT_TRUE(TypeCoercer::defaults().coerce(TINYINT(), DECIMAL(10, 2)));
+  ASSERT_TRUE(TypeCoercer::defaults().coerce(SMALLINT(), DECIMAL(10, 2)));
+  ASSERT_TRUE(TypeCoercer::defaults().coerce(INTEGER(), DECIMAL(38, 4)));
+  ASSERT_TRUE(TypeCoercer::defaults().coerce(BIGINT(), DECIMAL(38, 4)));
 
-  ASSERT_TRUE(TypeCoercer::defaults().coercible(TINYINT(), DECIMAL(3, 0)));
-  ASSERT_TRUE(TypeCoercer::defaults().coercible(SMALLINT(), DECIMAL(5, 0)));
-  ASSERT_TRUE(TypeCoercer::defaults().coercible(INTEGER(), DECIMAL(10, 0)));
-  ASSERT_TRUE(TypeCoercer::defaults().coercible(BIGINT(), DECIMAL(19, 0)));
+  ASSERT_TRUE(TypeCoercer::defaults().coerce(TINYINT(), DECIMAL(3, 0)));
+  ASSERT_TRUE(TypeCoercer::defaults().coerce(SMALLINT(), DECIMAL(5, 0)));
+  ASSERT_TRUE(TypeCoercer::defaults().coerce(INTEGER(), DECIMAL(10, 0)));
+  ASSERT_TRUE(TypeCoercer::defaults().coerce(BIGINT(), DECIMAL(19, 0)));
 
-  ASSERT_FALSE(TypeCoercer::defaults().coercible(TINYINT(), DECIMAL(2, 0)));
-  ASSERT_FALSE(TypeCoercer::defaults().coercible(SMALLINT(), DECIMAL(4, 0)));
-  ASSERT_FALSE(TypeCoercer::defaults().coercible(INTEGER(), DECIMAL(9, 0)));
-  ASSERT_FALSE(TypeCoercer::defaults().coercible(BIGINT(), DECIMAL(18, 0)));
-  ASSERT_FALSE(TypeCoercer::defaults().coercible(INTEGER(), DECIMAL(4, 2)));
-  ASSERT_FALSE(TypeCoercer::defaults().coercible(BIGINT(), DECIMAL(10, 2)));
+  ASSERT_FALSE(TypeCoercer::defaults().coerce(TINYINT(), DECIMAL(2, 0)));
+  ASSERT_FALSE(TypeCoercer::defaults().coerce(SMALLINT(), DECIMAL(4, 0)));
+  ASSERT_FALSE(TypeCoercer::defaults().coerce(INTEGER(), DECIMAL(9, 0)));
+  ASSERT_FALSE(TypeCoercer::defaults().coerce(BIGINT(), DECIMAL(18, 0)));
+  ASSERT_FALSE(TypeCoercer::defaults().coerce(INTEGER(), DECIMAL(4, 2)));
+  ASSERT_FALSE(TypeCoercer::defaults().coerce(BIGINT(), DECIMAL(10, 2)));
 
-  ASSERT_FALSE(TypeCoercer::defaults().coercible(DECIMAL(10, 2), INTEGER()));
-  ASSERT_FALSE(TypeCoercer::defaults().coercible(DECIMAL(10, 2), BIGINT()));
+  ASSERT_FALSE(TypeCoercer::defaults().coerce(DECIMAL(10, 2), INTEGER()));
+  ASSERT_FALSE(TypeCoercer::defaults().coerce(DECIMAL(10, 2), BIGINT()));
 }
 
 TEST(TypeCoercerTest, integerToDecimalLeastCommonSuperType) {
@@ -168,13 +165,13 @@ TEST(TypeCoercerTest, date) {
 }
 
 TEST(TypeCoercerTest, unknown) {
-  ASSERT_TRUE(TypeCoercer::defaults().coercible(UNKNOWN(), BOOLEAN()));
-  ASSERT_TRUE(TypeCoercer::defaults().coercible(UNKNOWN(), BIGINT()));
-  ASSERT_TRUE(TypeCoercer::defaults().coercible(UNKNOWN(), VARCHAR()));
-  ASSERT_TRUE(TypeCoercer::defaults().coercible(UNKNOWN(), ARRAY(INTEGER())));
+  ASSERT_TRUE(TypeCoercer::defaults().coerce(UNKNOWN(), BOOLEAN()));
+  ASSERT_TRUE(TypeCoercer::defaults().coerce(UNKNOWN(), BIGINT()));
+  ASSERT_TRUE(TypeCoercer::defaults().coerce(UNKNOWN(), VARCHAR()));
+  ASSERT_TRUE(TypeCoercer::defaults().coerce(UNKNOWN(), ARRAY(INTEGER())));
 }
 
-TEST(TypeCoercerTest, coerceTypeBaseFromUnknown) {
+TEST(TypeCoercerTest, coerceUnknownToScalar) {
   // Test coercion from UNKNOWN to various types.
   testCoercion(UNKNOWN(), TINYINT());
   testCoercion(UNKNOWN(), BOOLEAN());
@@ -187,12 +184,52 @@ TEST(TypeCoercerTest, coerceTypeBaseFromUnknown) {
   testCoercion(UNKNOWN(), VARBINARY());
 }
 
+TEST(TypeCoercerTest, coerceUnknownToParameterizedScalar) {
+  auto coercion = TypeCoercer::defaults().coerce(UNKNOWN(), DECIMAL(10, 2));
+  ASSERT_TRUE(coercion.has_value());
+  VELOX_EXPECT_EQ_TYPES(coercion->type, DECIMAL(10, 2));
+}
+
+TEST(TypeCoercerTest, coerceContainerResolvesToTargetType) {
+  const auto& coercer = TypeCoercer::defaults();
+
+  auto coercion = coercer.coerce(ARRAY(UNKNOWN()), ARRAY(INTEGER()));
+  ASSERT_TRUE(coercion.has_value());
+  VELOX_EXPECT_EQ_TYPES(coercion->type, ARRAY(INTEGER()));
+
+  coercion =
+      coercer.coerce(MAP(UNKNOWN(), UNKNOWN()), MAP(INTEGER(), DOUBLE()));
+  ASSERT_TRUE(coercion.has_value());
+  VELOX_EXPECT_EQ_TYPES(coercion->type, MAP(INTEGER(), DOUBLE()));
+
+  coercion = coercer.coerce(ARRAY(ARRAY(UNKNOWN())), ARRAY(ARRAY(INTEGER())));
+  ASSERT_TRUE(coercion.has_value());
+  VELOX_EXPECT_EQ_TYPES(coercion->type, ARRAY(ARRAY(INTEGER())));
+
+  ASSERT_FALSE(coercer.coerce(ARRAY(BIGINT()), ARRAY(REAL())).has_value());
+
+  // Mismatched container name or arity is not coercible.
+  ASSERT_FALSE(
+      coercer.coerce(ARRAY(INTEGER()), MAP(INTEGER(), INTEGER())).has_value());
+  ASSERT_FALSE(
+      coercer.coerce(ROW({INTEGER(), BIGINT()}), ROW({INTEGER()})).has_value());
+}
+
+TEST(TypeCoercerTest, unknownToContainerRanksAboveScalar) {
+  const auto& coercer = TypeCoercer::defaults();
+
+  // A bare UNKNOWN coerces to a container at a higher cost than to any scalar.
+  EXPECT_GT(
+      coercer.coerce(UNKNOWN(), ARRAY(INTEGER()))->cost,
+      coercer.coerce(UNKNOWN(), VARBINARY())->cost);
+}
+
 TEST(TypeCoercerTest, noCost) {
   auto assertNoCost = [](const TypePtr& type) {
     SCOPED_TRACE(type->toString());
-    auto cost = TypeCoercer::defaults().coercible(type, type);
-    ASSERT_TRUE(cost.has_value());
-    EXPECT_EQ(cost.value(), 0);
+    auto coercion = TypeCoercer::defaults().coerce(type, type);
+    ASSERT_TRUE(coercion.has_value());
+    EXPECT_EQ(coercion->cost, 0);
   };
 
   assertNoCost(UNKNOWN());
@@ -218,65 +255,63 @@ TEST(TypeCoercerTest, noCost) {
 
 TEST(TypeCoercerTest, array) {
   ASSERT_TRUE(
-      TypeCoercer::defaults().coercible(ARRAY(UNKNOWN()), ARRAY(INTEGER())));
+      TypeCoercer::defaults().coerce(ARRAY(UNKNOWN()), ARRAY(INTEGER())));
   ASSERT_TRUE(
-      TypeCoercer::defaults().coercible(
+      TypeCoercer::defaults().coerce(
           ARRAY(UNKNOWN()), ARRAY(ARRAY(VARCHAR()))));
 
+  ASSERT_FALSE(TypeCoercer::defaults().coerce(ARRAY(BIGINT()), ARRAY(REAL())));
   ASSERT_FALSE(
-      TypeCoercer::defaults().coercible(ARRAY(BIGINT()), ARRAY(REAL())));
+      TypeCoercer::defaults().coerce(ARRAY(UNKNOWN()), MAP(INTEGER(), REAL())));
   ASSERT_FALSE(
-      TypeCoercer::defaults().coercible(
-          ARRAY(UNKNOWN()), MAP(INTEGER(), REAL())));
-  ASSERT_FALSE(
-      TypeCoercer::defaults().coercible(ARRAY(UNKNOWN()), ROW({UNKNOWN()})));
-  ASSERT_FALSE(TypeCoercer::defaults().coercible(ARRAY(VARCHAR()), VARCHAR()));
+      TypeCoercer::defaults().coerce(ARRAY(UNKNOWN()), ROW({UNKNOWN()})));
+  ASSERT_FALSE(TypeCoercer::defaults().coerce(ARRAY(VARCHAR()), VARCHAR()));
 }
 
 TEST(TypeCoercerTest, map) {
   ASSERT_TRUE(
-      TypeCoercer::defaults().coercible(
+      TypeCoercer::defaults().coerce(
           MAP(UNKNOWN(), UNKNOWN()), MAP(INTEGER(), REAL())));
   ASSERT_TRUE(
-      TypeCoercer::defaults().coercible(
+      TypeCoercer::defaults().coerce(
           MAP(VARCHAR(), REAL()), MAP(VARCHAR(), DOUBLE())));
   ASSERT_TRUE(
-      TypeCoercer::defaults().coercible(
+      TypeCoercer::defaults().coerce(
           MAP(INTEGER(), REAL()), MAP(BIGINT(), DOUBLE())));
 
   ASSERT_FALSE(
-      TypeCoercer::defaults().coercible(
+      TypeCoercer::defaults().coerce(
           MAP(INTEGER(), REAL()), MAP(BIGINT(), INTEGER())));
   ASSERT_FALSE(
-      TypeCoercer::defaults().coercible(
+      TypeCoercer::defaults().coerce(
           MAP(UNKNOWN(), UNKNOWN()), ARRAY(BIGINT())));
   ASSERT_FALSE(
-      TypeCoercer::defaults().coercible(
+      TypeCoercer::defaults().coerce(
           MAP(UNKNOWN(), UNKNOWN()), ROW({INTEGER(), BIGINT()})));
 }
 
 TEST(TypeCoercerTest, row) {
   ASSERT_TRUE(
-      TypeCoercer::defaults().coercible(
+      TypeCoercer::defaults().coerce(
           ROW({UNKNOWN(), INTEGER(), REAL()}),
           ROW({SMALLINT(), BIGINT(), DOUBLE()})));
 
   ASSERT_FALSE(
-      TypeCoercer::defaults().coercible(
+      TypeCoercer::defaults().coerce(
           ROW({UNKNOWN(), INTEGER(), REAL()}),
           ROW({SMALLINT(), VARCHAR(), DOUBLE()})));
 
   ASSERT_FALSE(
-      TypeCoercer::defaults().coercible(
+      TypeCoercer::defaults().coerce(
           ROW({UNKNOWN(), INTEGER(), REAL()}), ARRAY(INTEGER())));
   ASSERT_FALSE(
-      TypeCoercer::defaults().coercible(
+      TypeCoercer::defaults().coerce(
           ROW({UNKNOWN(), INTEGER(), REAL()}), MAP(INTEGER(), REAL())));
   ASSERT_FALSE(
-      TypeCoercer::defaults().coercible(
+      TypeCoercer::defaults().coerce(
           ROW({UNKNOWN(), INTEGER(), REAL()}), ROW({UNKNOWN(), INTEGER()})));
   ASSERT_FALSE(
-      TypeCoercer::defaults().coercible(
+      TypeCoercer::defaults().coerce(
           ROW({UNKNOWN(), INTEGER(), REAL()}), BIGINT()));
 }
 
@@ -339,13 +374,6 @@ TEST(TypeCoercerTest, leastCommonSuperType) {
   ASSERT_TRUE(
       TypeCoercer::defaults().leastCommonSuperType(
           MAP(INTEGER(), REAL()), ROW({INTEGER(), REAL()})) == nullptr);
-}
-
-TEST(TypeCoercerTest, parametricBuiltinTargetDoesNotThrow) {
-  // Parametric built-in factories throw on empty params. Verify graceful
-  // handling.
-  EXPECT_EQ(
-      TypeCoercer::defaults().coerceTypeBase(BIGINT(), "ARRAY"), std::nullopt);
 }
 
 TEST(TypeCoercerTest, ctorRejectsDuplicateCostForSameSource) {


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/axiom/pull/1519


**Issue:**
Currently, the coercion logic is spread across three overlapping functions: coerceTypeBase(), coerce(), and coercible() that can be simplified. Also coerce() does not recurse into containers.

This change makes coerce() the single recursive function for coercion.

**Fix:**
In coerce() -
- Scalars go through the rule table
- Bare UNKNOWN coerces to any resolved target
- Containers recurse element-wise and sum the child costs.

For the other two functions
- coercible() is removed; its callers now call coerce() directly
- coerceTypeBase() is now private, the scalar lookup that coerce() calls.

The SignatureBinder coercion paths (scalar formal, UNKNOWN to parameterized) also merge into one: resolve the formal type, then call coerce().

This feeds overload resolution, but no overload resolves differently.

**Follow Up:**
Letting a non-UNKNOWN value coerce into a parameterized formal is a *behavior change*, so it is left out of this diff. e.g. `INTEGER` → `DECIMAL(p,s)` would cast into DECIMAL(p,s) instead of current REAL behavior.

Differential Revision: D109596959


