### PR TITLE
fix: Add missing FBThrift::thriftcpp2 link dep to velox_rpc_error_classification (#17922)

### DIFF
--- a/velox/exec/rpc/CMakeLists.txt
+++ b/velox/exec/rpc/CMakeLists.txt
@@ -16,7 +16,7 @@
 
 velox_add_library(velox_rpc_error_classification HEADERS RpcErrorClassification.h)
 
-velox_link_libraries(velox_rpc_error_classification Folly::folly)
+velox_link_libraries(velox_rpc_error_classification Folly::folly FBThrift::thriftcpp2)
 
 velox_add_library(
   velox_rpc_state


### PR DESCRIPTION
Summary:

The header-only `velox_rpc_error_classification` CMake target includes `<thrift/lib/cpp/TApplicationException.h>` and `<thrift/lib/cpp/transport/TTransportException.h>`, and the test (`velox_rpc_error_classification_test`) instantiates those types. The CMake target was missing `FBThrift::thriftcpp2` linkage, causing a linker failure in the GitHub CI "Linux release with adapters" build (PR #17886).

Differential Revision: D109648012


