### PR TITLE
perf: Optimize right semi no-filter probe marking in HashJoin

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ of available functions [can be found here.](https://facebookincubator.github.io/
 
 Recent blog posts ([all posts](https://velox-lib.io/blog)):
 
+- [Why RIGHT SEMI JOIN Can Be Slower Than LEFT SEMI JOIN in Velox](https://velox-lib.io/blog/right-semi-join-performance) (2026-06-26)
 - [From copyBits to SIMD: Accelerating Parquet DELTA Decoding in Velox](https://velox-lib.io/blog/parquet-delta-decoding) (2026-06-17)
 - [FlatMapVector Adoption for Scaling High-Performance AI/ML Data Pre-Processing](https://velox-lib.io/blog/flatmapvector) (2026-05-01)
-- [Nimble Cluster Index: Efficient Indexed Lookups on Columnar Data](https://velox-lib.io/blog/nimble-cluster-index) (2026-04-27)
 
 ## Community
 

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -1062,6 +1062,33 @@ RowVectorPtr HashProbe::getOutput() {
   return getOutputInternal(/*toSpillOutput=*/false);
 }
 
+void HashProbe::processRightSemiNoFilter(bool emptyBuildSide) {
+  if (emptyBuildSide) {
+    input_ = nullptr;
+    return;
+  }
+
+  auto* rows = table_->rows();
+  const int32_t nextOffset = rows->nextOffset();
+  for (const auto probeRow : lookup_->rows) {
+    char* hit = lookup_->hits[probeRow];
+    while (hit != nullptr) {
+      // Duplicate build rows are linked by nextOffset. The first probe that
+      // reaches a key marks the whole chain. If the head row is already
+      // marked, all duplicates for this key have already been marked.
+      if (!rows->testAndSetProbedFlag(hit)) {
+        break;
+      }
+      if (nextOffset == 0) {
+        break;
+      }
+      hit = *reinterpret_cast<char**>(hit + nextOffset);
+    }
+  }
+
+  input_ = nullptr;
+}
+
 RowVectorPtr HashProbe::getOutputInternal(bool toSpillOutput) {
   if (isFinished()) {
     return nullptr;
@@ -1150,8 +1177,15 @@ RowVectorPtr HashProbe::getOutputInternal(bool toSpillOutput) {
   const bool isLeftSemiOrAntiJoinNoFilter = !filter_ &&
       (isLeftSemiFilterJoin(joinType_) || isLeftSemiProjectJoin(joinType_) ||
        isAntiJoin(joinType_) || isCountingJoin(joinType_));
+  const bool isRightSemiFilterJoinNoFilter =
+      !filter_ && isRightSemiFilterJoin(joinType_);
 
   const bool emptyBuildSide = (table_->numDistinct() == 0);
+
+  if (isRightSemiFilterJoinNoFilter) {
+    processRightSemiNoFilter(emptyBuildSide);
+    return nullptr;
+  }
 
   // Left semi and anti joins are always cardinality reducing, e.g. for a
   // given row of input they produce zero or 1 row of output. Therefore, if

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -158,6 +158,11 @@ class HashProbe : public Operator {
   // arbitration.
   RowVectorPtr getOutputInternal(bool toSpillOutput);
 
+  // Handles the right semi filter join fast path when there is no extra
+  // filter. Marks matching build rows as probed and consumes the current
+  // input batch.
+  void processRightSemiNoFilter(bool emptyBuildSide);
+
   // Check if output_ can be re-used and if not make a new one.
   void prepareOutput(vector_size_t size);
 

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -991,12 +991,29 @@ void RowContainer::clear() {
 }
 
 void RowContainer::setProbedFlag(char** rows, int32_t numRows) {
-  for (auto i = 0; i < numRows; i++) {
+  const int32_t probedFlagByte = probedFlagOffset_ / 8;
+  const uint8_t probedFlagMask = uint8_t{1} << (probedFlagOffset_ & 7);
+  for (int32_t i = 0; i < numRows; ++i) {
     // Row may be null in case of a FULL join.
     if (rows[i]) {
-      setBit(rows[i], probedFlagOffset_);
+      uint8_t* flagsByte = reinterpret_cast<uint8_t*>(rows[i]) + probedFlagByte;
+      if ((*flagsByte & probedFlagMask) == 0) {
+        *flagsByte |= probedFlagMask;
+      }
     }
   }
+}
+
+bool RowContainer::testAndSetProbedFlag(char* row) {
+  VELOX_DCHECK_NOT_NULL(row);
+  const int32_t probedFlagByte = probedFlagOffset_ / 8;
+  const uint8_t probedFlagMask = uint8_t{1} << (probedFlagOffset_ & 7);
+  uint8_t* flagsByte = reinterpret_cast<uint8_t*>(row) + probedFlagByte;
+  const bool wasSet = (*flagsByte & probedFlagMask) != 0;
+  if (!wasSet) {
+    *flagsByte |= probedFlagMask;
+  }
+  return !wasSet;
 }
 
 void RowContainer::extractProbedFlags(

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -711,6 +711,15 @@ class RowContainer {
 #endif
   void setProbedFlag(char** rows, int32_t numRows);
 
+  /// Sets 'probed' flag for a single non-null row. Returns true if the flag
+  /// transitioned from false to true.
+#if defined(__has_feature)
+#if __has_feature(thread_sanitizer)
+  __attribute__((__no_sanitize__("thread")))
+#endif
+#endif
+  bool testAndSetProbedFlag(char* row);
+
   /// Compares the value at 'column' in 'row' with the value at 'index' in
   /// 'decoded'. Returns 0 for equal, < 0 for 'row' < 'decoded', > 0 otherwise.
   /// 'mayHaveNulls' specifies if nulls need to be checked. This is a fast path

--- a/velox/exec/benchmarks/CMakeLists.txt
+++ b/velox/exec/benchmarks/CMakeLists.txt
@@ -88,6 +88,16 @@ target_link_libraries(
   Folly::follybenchmark
 )
 
+add_executable(velox_hash_join_right_semi_benchmark HashJoinRightSemiBenchmark.cpp)
+
+target_link_libraries(
+  velox_hash_join_right_semi_benchmark
+  velox_exec
+  velox_exec_test_lib
+  velox_vector_test_lib
+  Folly::follybenchmark
+)
+
 add_executable(velox_hash_join_prepare_join_table_benchmark HashJoinPrepareJoinTableBenchmark.cpp)
 
 target_link_libraries(

--- a/velox/exec/benchmarks/HashJoinRightSemiBenchmark.cpp
+++ b/velox/exec/benchmarks/HashJoinRightSemiBenchmark.cpp
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include <random>
+
+#include "velox/common/memory/Memory.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/parse/TypeResolver.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec::test;
+using namespace facebook::velox::test;
+
+namespace {
+
+struct BenchmarkParams {
+  int32_t numDistinctKeys;
+  int32_t buildDuplicates;
+  int32_t probeDuplicates;
+  int32_t numProbeBatches;
+  bool withFilter;
+  std::string title;
+};
+
+struct BenchmarkData {
+  std::vector<RowVectorPtr> buildVectors;
+  std::vector<RowVectorPtr> probeVectors;
+};
+
+struct BenchmarkCase {
+  BenchmarkParams params;
+  BenchmarkData data;
+};
+
+class HashJoinRightSemiBenchmark : public VectorTestBase {
+ public:
+  BenchmarkData prepareData(const BenchmarkParams& params) {
+    BenchmarkData data;
+
+    auto buildKeys = makeKeys(
+        params.numDistinctKeys,
+        params.buildDuplicates,
+        31 /*seed for deterministic shuffling*/);
+    auto probeKeys = makeKeys(
+        params.numDistinctKeys,
+        params.probeDuplicates,
+        97 /*seed for deterministic shuffling*/);
+
+    data.buildVectors = makeBatchesFromKeys(buildKeys, 1, 0);
+    data.probeVectors =
+        makeBatchesFromKeys(probeKeys, params.numProbeBatches, 10'000'000);
+    return data;
+  }
+
+  int64_t run(const BenchmarkParams& params, const BenchmarkData& data) {
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+    const std::string filter = params.withFilter ? "t1 >= 0" : "";
+
+    auto plan = PlanBuilder(planNodeIdGenerator, pool_.get())
+                    .values(data.probeVectors)
+                    .project({"c0 AS t0", "c1 AS t1"})
+                    .hashJoin(
+                        {"t0"},
+                        {"u0"},
+                        PlanBuilder(planNodeIdGenerator, pool_.get())
+                            .values(data.buildVectors)
+                            .project({"c0 AS u0", "c1 AS u1"})
+                            .planNode(),
+                        filter,
+                        {"u1"},
+                        core::JoinType::kRightSemiFilter)
+                    .planNode();
+
+    auto results = AssertQueryBuilder(plan).maxDrivers(1).copyResults(pool());
+    return results->size();
+  }
+
+ private:
+  std::vector<int64_t>
+  makeKeys(int32_t numDistinctKeys, int32_t duplicates, uint32_t seed) {
+    VELOX_CHECK_GT(numDistinctKeys, 0);
+    VELOX_CHECK_GT(duplicates, 0);
+
+    std::vector<int64_t> keys(numDistinctKeys * duplicates);
+    for (int64_t i = 0; i < keys.size(); ++i) {
+      keys[i] = i % numDistinctKeys;
+    }
+
+    std::mt19937 random(seed);
+    std::shuffle(keys.begin(), keys.end(), random);
+    return keys;
+  }
+
+  std::vector<RowVectorPtr> makeBatchesFromKeys(
+      const std::vector<int64_t>& keys,
+      int32_t numBatches,
+      int64_t payloadBase) {
+    VELOX_CHECK_GT(numBatches, 0);
+
+    std::vector<RowVectorPtr> batches;
+    batches.reserve(numBatches);
+
+    const int32_t totalSize = keys.size();
+    const int32_t batchSize = std::max(1, totalSize / numBatches);
+    int32_t start = 0;
+
+    while (start < totalSize) {
+      const int32_t end = std::min(totalSize, start + batchSize);
+      const int32_t size = end - start;
+
+      std::vector<VectorPtr> children;
+      children.push_back(makeFlatVector<int64_t>(size, [&](vector_size_t row) {
+        return keys[start + row];
+      }));
+      children.push_back(makeFlatVector<int64_t>(size, [&](vector_size_t row) {
+        return payloadBase + static_cast<int64_t>(start + row);
+      }));
+
+      batches.push_back(makeRowVector(children));
+      start = end;
+    }
+
+    return batches;
+  }
+};
+
+} // namespace
+
+int main(int argc, char** argv) {
+  folly::Init init{&argc, &argv};
+  memory::MemoryManager::initialize(memory::MemoryManager::Options{});
+  functions::prestosql::registerAllScalarFunctions();
+  parse::registerTypeResolver();
+
+  auto benchmark = std::make_unique<HashJoinRightSemiBenchmark>();
+  std::vector<BenchmarkCase> benchmarkCases;
+
+  const std::vector<BenchmarkParams> params = {
+      {// A moderate duplicate workload.
+       .numDistinctKeys = 20'000,
+       .buildDuplicates = 8,
+       .probeDuplicates = 8,
+       .numProbeBatches = 4,
+       .withFilter = false,
+       .title = "right_semi_no_filter_dup8x8"},
+      {// A heavy duplicate/skew-sensitive workload.
+       .numDistinctKeys = 10'000,
+       .buildDuplicates = 32,
+       .probeDuplicates = 32,
+       .numProbeBatches = 4,
+       .withFilter = false,
+       .title = "right_semi_no_filter_dup32x32"},
+      {// Control: keep filter=true path to compare against no-filter fast path.
+       .numDistinctKeys = 10'000,
+       .buildDuplicates = 32,
+       .probeDuplicates = 32,
+       .numProbeBatches = 4,
+       .withFilter = true,
+       .title = "right_semi_with_filter_dup32x32"},
+  };
+
+  for (const auto& param : params) {
+    benchmarkCases.push_back({param, benchmark->prepareData(param)});
+  }
+
+  for (const auto& benchmarkCase : benchmarkCases) {
+    folly::addBenchmark(
+        __FILE__, benchmarkCase.params.title, [&benchmark, &benchmarkCase]() {
+          auto outputRows =
+              benchmark->run(benchmarkCase.params, benchmarkCase.data);
+          folly::doNotOptimizeAway(outputRows);
+          return 1;
+        });
+  }
+
+  folly::runBenchmarks();
+  return 0;
+}

--- a/website/blog/2026-06-26-right-semi-join-performance.mdx
+++ b/website/blog/2026-06-26-right-semi-join-performance.mdx
@@ -1,0 +1,184 @@
+---
+slug: right-semi-join-performance
+title: "Why RIGHT SEMI JOIN Can Be Slower Than LEFT SEMI JOIN in Velox"
+date: 2026-06-26
+authors: [rui-mo]
+tags: [tech-blog, performance, query-execution]
+description: "A deep dive into RIGHT SEMI JOIN performance in Velox, why probed-flag marking became a hotspot, and how a probe-time fast path removes redundant work."
+---
+
+## TL;DR
+
+A query rewrite from `A LEFT SEMI JOIN B` to `B RIGHT SEMI JOIN A` can be much
+slower in Velox, even though the two forms are semantically equivalent.
+
+At first glance, this rewrite looks attractive when `A` is much smaller than
+`B`: building on `A` should reduce build-side work and often helps regular hash
+joins. In one real query, we made exactly this change expecting a speedup, but
+instead observed roughly a **10x regression**.
+
+The root cause is execution asymmetry:
+
+- RIGHT SEMI needs to mark build-side rows as matched.
+- That marking (`setProbedFlag`) is random-memory-write heavy.
+- With duplicate or skewed keys, redundant marking work grows quickly.
+
+A targeted optimization for **RIGHT SEMI FILTER without extra filter** moves
+marking into probe-time hit traversal and adds early stop logic for duplicate
+chains, significantly reducing redundant work.
+
+<!-- truncate -->
+
+## The Symptom
+
+In profiling, a large fraction of CPU was concentrated in
+`RowContainer::setProbedFlag`, with additional time in join result listing and
+runtime plumbing.
+
+This aligned with prior intuition from the community:
+
+- setting probed flags is expensive due to random access in row storage,
+- and marking during probing may be more efficient than marking later from
+  expanded join results.
+
+## Why LEFT SEMI and RIGHT SEMI Differ in Cost
+
+`A LEFT SEMI JOIN B` and `B RIGHT SEMI JOIN A` are result-equivalent, but they
+are not implementation-equivalent.
+
+### LEFT SEMI (no extra filter)
+
+The operator mainly answers: does this probe row have at least one match?
+
+That keeps the path probe-centric and avoids right-side matched-row tracking
+machinery.
+
+### RIGHT SEMI FILTER
+
+The operator must output build-side rows that matched at least one probe row.
+That requires:
+
+1. a probed flag per relevant build row,
+2. setting the flag when matches are found,
+3. scanning build rows and outputting those with `probed = true`.
+
+This extra state tracking and scan are absent in the same form on LEFT SEMI.
+
+## Root Cause: Redundant Marking Under Duplicates
+
+Before the optimization, no-filter RIGHT SEMI still relied on generic join
+result listing before marking.
+
+Under duplicate/skewed keys:
+
+- many probe rows map to the same build key,
+- duplicate build chains are revisited repeatedly,
+- the same probed flag bytes are touched many times.
+
+Because row hits are pointer-based and scattered in arena memory, this becomes
+cache-unfriendly write traffic.
+
+## The Optimization
+
+The patch introduces a fast path for RIGHT SEMI FILTER with no extra filter.
+
+### 1) Probe-time direct marking
+
+In `HashProbe::getOutputInternal`, when join type is right semi filter and
+`filter_` is null, the code now:
+
+- iterates probe hits directly,
+- marks build rows immediately,
+- consumes the input batch without building intermediate output rows.
+
+RIGHT SEMI output remains unchanged: build-side rows are still returned later by
+probing-flag-based build scan.
+
+### 2) `testAndSetProbedFlag` API
+
+A new single-row API was added:
+
+- `bool RowContainer::testAndSetProbedFlag(char* row)`
+
+Semantics:
+
+- returns `true` when the flag transitions from 0 to 1,
+- returns `false` if it was already set.
+
+### 3) Duplicate-chain early stop
+
+Duplicate build rows are linked via `nextOffset`.
+
+For a hot key:
+
+- the first probe marks the chain,
+- subsequent probes detect an already-marked head and stop early.
+
+This prevents repeatedly walking and writing the full duplicate chain.
+
+### 4) Minor micro-optimization in batch flag set
+
+`setProbedFlag` was also simplified to precompute byte offset/mask and update
+flag bytes directly. This helps, but the primary gain comes from the new
+algorithmic path above.
+
+## Why This Is Correct
+
+RIGHT SEMI FILTER semantics are: output each build row that has at least one
+match.
+
+The fast path preserves this:
+
+1. Every probe row still follows its matching hit chain.
+2. Every matched build row gets marked.
+3. Marking is idempotent.
+4. Build-side output still comes from the existing `listProbedRows` scan.
+
+Early stop is valid because when the duplicate-chain head is already marked,
+that chain has already been fully marked by an earlier probe for the same key.
+
+## Benchmark Results
+
+The new benchmark in `velox/exec/benchmarks/HashJoinRightSemiBenchmark.cpp`
+shows clear wins on the no-filter RIGHT SEMI path.
+
+| Benchmark | Before (time/iter) | After (time/iter) | Speedup |
+|-----------|--------------------:|------------------:|--------:|
+| `right_semi_no_filter_dup8x8` | 23.66 ms | 9.50 ms | **2.49x** |
+| `right_semi_no_filter_dup32x32` | 190.89 ms | 19.37 ms | **9.86x** |
+| `right_semi_with_filter_dup32x32` | 272.42 ms | 251.30 ms | **1.08x** |
+
+Key takeaways:
+
+- The optimized no-filter path improves substantially under duplicates.
+- The high-duplicate case (`dup32x32`) shows the largest gain, consistent with
+  reduced duplicate-chain reprocessing.
+- The with-filter case changes only modestly, as expected, because the new fast
+  path targets RIGHT SEMI FILTER without an extra filter.
+
+## Scope and Next Steps
+
+Current fast path scope:
+
+- RIGHT SEMI FILTER,
+- no extra filter.
+
+Still open:
+
+- RIGHT SEMI PROJECT,
+- RIGHT/FULL joins on related probed-flag workflows,
+- potential redesign with a dedicated compact probed-bitmask array for better
+  locality.
+
+## Closing Thoughts
+
+This regression is a good reminder that SQL rewrites can preserve semantics but
+still shift execution into very different cost surfaces.
+
+In this case, moving probed-flag work to probe-time and avoiding redundant
+duplicate-chain passes provides a focused, low-risk way to unlock substantial
+speedups on skewed workloads.
+
+## Acknowledgements
+
+Thanks to <a href="https://github.com/Yuhta">Jimmy Lu</a> and <a href="https://github.com/mbasmanova">Masha Basmanova</a> for their early suggestions, which directly motivated this optimization.

--- a/website/blog/authors.yml
+++ b/website/blog/authors.yml
@@ -161,3 +161,9 @@ jaylisde:
   title: Software Engineer
   url: https://github.com/jaylisde
   image_url: https://github.com/jaylisde.png
+
+rui-mo:
+  name: Rui Mo
+  title: Software Engineer
+  url: https://github.com/rui-mo
+  image_url: https://github.com/rui-mo.png


### PR DESCRIPTION
This change speeds up right semi joins without an extra filter by moving build-
row probed-flag updates into probe-time hit traversal. It adds a fast path in 
HashProbe plus a new RowContainer `testAndSetProbedFlag` helper, and short-
circuits duplicate-chain walks once the head is already marked. Semantics are 
unchanged because final output still comes from probed build rows.

The new benchmark in `velox/exec/benchmarks/HashJoinRightSemiBenchmark.cpp`
shows clear wins on the no-filter RIGHT SEMI path.

| Benchmark | Before (time/iter) | After (time/iter) | Speedup |
|-----------|--------------------:|------------------:|--------:|
| `right_semi_no_filter_dup8x8` | 23.66 ms | 9.50 ms | 2.49x |
| `right_semi_no_filter_dup32x32` | 190.89 ms | 19.37 ms | 9.86x |
| `right_semi_with_filter_dup32x32` | 272.42 ms | 251.30 ms | 1.08x |

This PR also adds a blog post summarizing the root cause, optimization approach,
and measured results.

Issue: https://github.com/facebookincubator/velox/issues/9980.