### PR TITLE
fix(spark): Escape supplementary-plane chars in get_json_object object/array results

### DIFF
--- a/velox/docs/functions/spark/json.rst
+++ b/velox/docs/functions/spark/json.rst
@@ -75,8 +75,9 @@ JSON Functions
 
     When ``path`` resolves to an object or array, characters in the Unicode
     supplementary planes (code points >= U+10000, e.g. emoji) are escaped as
-    ``\uXXXX`` UTF-16 surrogate pairs, while Basic Multilingual Plane characters
-    (e.g. CJK) are left literal. Scalar string results are returned literal. ::
+    ``\uXXXX\uXXXX`` UTF-16 surrogate pairs, while Basic Multilingual Plane
+    (BMP) characters (e.g. Chinese/Japanese/Korean, CJK) are left literal.
+    Scalar string results are returned literal. ::
 
         SELECT get_json_object('{"a":{"n":"🧧会员"}}', '$.a'); -- '{"n":"\uD83E\uDDE7会员"}'
         SELECT get_json_object('{"a":["🥇"]}', '$.a'); -- '["\uD83E\uDD47"]'

--- a/velox/docs/functions/spark/json.rst
+++ b/velox/docs/functions/spark/json.rst
@@ -73,6 +73,15 @@ JSON Functions
         * Whitespace is allowed **after the dot** and **before the field name**, e.g., "$.  field".
         * Trailing whitespace after '$' is allowed, e.g., "$   ".
 
+    When ``path`` resolves to an object or array, characters in the Unicode
+    supplementary planes (code points >= U+10000, e.g. emoji) are escaped as
+    ``\uXXXX`` UTF-16 surrogate pairs, while Basic Multilingual Plane characters
+    (e.g. CJK) are left literal. Scalar string results are returned literal. ::
+
+        SELECT get_json_object('{"a":{"n":"🧧会员"}}', '$.a'); -- '{"n":"\uD83E\uDDE7会员"}'
+        SELECT get_json_object('{"a":["🥇"]}', '$.a'); -- '["\uD83E\uDD47"]'
+        SELECT get_json_object('{"a":"🥇"}', '$.a'); -- '🥇'
+
 .. spark:function:: json_array_length(jsonString) -> integer
 
     Returns the number of elements in the outermost JSON array from ``jsonString``.

--- a/velox/functions/lib/Utf8Utils.cpp
+++ b/velox/functions/lib/Utf8Utils.cpp
@@ -55,6 +55,34 @@ int firstByteCharLength(const char* u_input) {
   return -1;
 }
 
+namespace {
+FOLLY_ALWAYS_INLINE char hexDigit(uint8_t c) {
+  VELOX_DCHECK_LT(c, 16);
+  return c < 10 ? c + '0' : c - 10 + 'A';
+}
+} // namespace
+
+void writeHex(char16_t value, char*& out) {
+  *out++ = '\\';
+  *out++ = 'u';
+  *out++ = hexDigit((value >> 12) & 0x0F);
+  *out++ = hexDigit((value >> 8) & 0x0F);
+  *out++ = hexDigit((value >> 4) & 0x0F);
+  *out++ = hexDigit(value & 0x0F);
+}
+
+void encodeUtf16Hex(char32_t codePoint, char*& out) {
+  VELOX_DCHECK(codePoint <= 0x10FFFFu);
+  if (codePoint >= 0x10000u) {
+    // Supplementary plane: split into a UTF-16 surrogate pair.
+    const char32_t v = codePoint - 0x10000u;
+    writeHex(static_cast<char16_t>(0xD800u + ((v >> 10) & 0x3FFu)), out);
+    writeHex(static_cast<char16_t>(0xDC00u + (v & 0x3FFu)), out);
+    return;
+  }
+  writeHex(static_cast<char16_t>(codePoint), out);
+}
+
 int32_t
 tryGetUtf8CharLength(const char* input, int64_t size, int32_t& codePoint) {
   VELOX_DCHECK_NOT_NULL(input);

--- a/velox/functions/lib/Utf8Utils.cpp
+++ b/velox/functions/lib/Utf8Utils.cpp
@@ -62,7 +62,7 @@ FOLLY_ALWAYS_INLINE char hexDigit(uint8_t c) {
 }
 } // namespace
 
-void writeHex(char16_t value, char*& out) {
+void writeUtf16Escape(char16_t value, char*& out) {
   *out++ = '\\';
   *out++ = 'u';
   *out++ = hexDigit((value >> 12) & 0x0F);
@@ -76,11 +76,12 @@ void encodeUtf16Hex(char32_t codePoint, char*& out) {
   if (codePoint >= 0x10000u) {
     // Supplementary plane: split into a UTF-16 surrogate pair.
     const char32_t v = codePoint - 0x10000u;
-    writeHex(static_cast<char16_t>(0xD800u + ((v >> 10) & 0x3FFu)), out);
-    writeHex(static_cast<char16_t>(0xDC00u + (v & 0x3FFu)), out);
+    writeUtf16Escape(
+        static_cast<char16_t>(0xD800u + ((v >> 10) & 0x3FFu)), out);
+    writeUtf16Escape(static_cast<char16_t>(0xDC00u + (v & 0x3FFu)), out);
     return;
   }
-  writeHex(static_cast<char16_t>(codePoint), out);
+  writeUtf16Escape(static_cast<char16_t>(codePoint), out);
 }
 
 int32_t

--- a/velox/functions/lib/Utf8Utils.h
+++ b/velox/functions/lib/Utf8Utils.h
@@ -88,6 +88,17 @@ FOLLY_ALWAYS_INLINE int validateAndGetNextUtf8Length(
 /// -1 for invalid UTF-8 first byte.
 int firstByteCharLength(const char* u_input);
 
+/// Writes `value` as a '\uXXXX' escape (backslash, 'u', then 4 uppercase hex
+/// digits) and advances `out` past the 6 written bytes. The caller must ensure
+/// `out` has room for 6 bytes.
+void writeHex(char16_t value, char*& out);
+
+/// Encodes `codePoint` as a JSON '\u' escape and advances `out`: a single
+/// '\uXXXX' for a Basic Multilingual Plane code point, or a '\uXXXX\uXXXX'
+/// UTF-16 surrogate pair for a supplementary-plane code point (>= U+10000). The
+/// caller must ensure `out` has room (6 bytes for BMP, 12 for supplementary).
+void encodeUtf16Hex(char32_t codePoint, char*& out);
+
 /// Invalid character replacement matrix.
 constexpr std::array<std::string_view, 6> kReplacementCharacterStrings{
     "\xef\xbf\xbd",

--- a/velox/functions/lib/Utf8Utils.h
+++ b/velox/functions/lib/Utf8Utils.h
@@ -91,7 +91,7 @@ int firstByteCharLength(const char* u_input);
 /// Writes `value` as a '\uXXXX' escape (backslash, 'u', then 4 uppercase hex
 /// digits) and advances `out` past the 6 written bytes. The caller must ensure
 /// `out` has room for 6 bytes.
-void writeHex(char16_t value, char*& out);
+void writeUtf16Escape(char16_t value, char*& out);
 
 /// Encodes `codePoint` as a JSON '\u' escape and advances `out`: a single
 /// '\uXXXX' for a Basic Multilingual Plane code point, or a '\uXXXX\uXXXX'

--- a/velox/functions/prestosql/json/JsonStringUtil.cpp
+++ b/velox/functions/prestosql/json/JsonStringUtil.cpp
@@ -27,11 +27,6 @@ using namespace facebook::velox::functions;
 namespace facebook::velox {
 namespace {
 
-FOLLY_ALWAYS_INLINE char hexDigit(uint8_t c) {
-  VELOX_DCHECK_LT(c, 16);
-  return c < 10 ? c + '0' : c - 10 + 'A';
-}
-
 FOLLY_ALWAYS_INLINE int32_t digitToHex(char c) {
   if (c >= '0' && c <= '9') {
     return c - '0';
@@ -44,16 +39,6 @@ FOLLY_ALWAYS_INLINE int32_t digitToHex(char c) {
   }
 
   VELOX_USER_FAIL("Invalid escape digit: {}", c);
-}
-
-FOLLY_ALWAYS_INLINE void writeHex(char16_t value, char*& out) {
-  value = folly::Endian::little(value);
-  *out++ = '\\';
-  *out++ = 'u';
-  *out++ = hexDigit((value >> 12) & 0x0F);
-  *out++ = hexDigit((value >> 8) & 0x0F);
-  *out++ = hexDigit((value >> 4) & 0x0F);
-  *out++ = hexDigit(value & 0x0F);
 }
 
 std::array<int8_t, 128> getAsciiEscapes() {
@@ -97,25 +82,6 @@ std::array<int8_t, 128> getEncodedAsciiSizes() {
   return sizes;
 }
 static const std::array<int8_t, 128> encodedAsciiSizes = getEncodedAsciiSizes();
-
-// Encode `codePoint` value into one or two UTF-16 code units. Write each code
-// unit as prefixed hexadecimals of 6 chars.
-FOLLY_ALWAYS_INLINE void encodeUtf16Hex(char32_t codePoint, char*& out) {
-  VELOX_DCHECK(codePoint <= 0x10FFFFu);
-  // Two 16-bit code units are needed.
-  if (codePoint >= 0x10000u) {
-    writeHex(
-        static_cast<char16_t>(
-            0xD800u + (((codePoint - 0x10000u) >> 10) & 0x3FFu)),
-        out);
-    writeHex(
-        static_cast<char16_t>(0xDC00u + ((codePoint - 0x10000u) & 0x3FFu)),
-        out);
-    return;
-  }
-  // One 16-bit code unit is needed.
-  writeHex(static_cast<char16_t>(codePoint), out);
-}
 
 } // namespace
 

--- a/velox/functions/prestosql/json/JsonStringUtil.cpp
+++ b/velox/functions/prestosql/json/JsonStringUtil.cpp
@@ -63,7 +63,7 @@ FOLLY_ALWAYS_INLINE void encodeAscii(int8_t value, char*& out) {
     *out++ = '\\';
     *out++ = char(escapeCode);
   } else {
-    writeHex(value, out);
+    writeUtf16Escape(value, out);
   }
 }
 
@@ -117,14 +117,14 @@ void normalizeForJsonCast(const char* input, size_t length, char* output) {
       case 4: {
         char32_t codePoint = folly::utf8ToCodePoint(start, end, true);
         if (codePoint == U'\ufffd') {
-          writeHex(0xFFFDu, pos);
+          writeUtf16Escape(0xFFFDu, pos);
           continue;
         }
         encodeUtf16Hex(codePoint, pos);
         continue;
       }
       default: {
-        writeHex(0xFFFDu, pos);
+        writeUtf16Escape(0xFFFDu, pos);
         start++;
       }
     }
@@ -133,7 +133,7 @@ void normalizeForJsonCast(const char* input, size_t length, char* output) {
 }
 
 size_t normalizedSizeForJsonCast(const char* input, size_t length) {
-  // 6 chars that is returned by `writeHex`.
+  // 6 chars that is returned by `writeUtf16Escape`.
   constexpr size_t kEncodedHexSize = 6;
 
   size_t outSize = 0;
@@ -375,7 +375,7 @@ size_t normalizeForJsonParse(const char* input, size_t length, char* output) {
       }
       case 4: {
         if (codePoint == U'\ufffd') {
-          writeHex(0xFFFDu, pos);
+          writeUtf16Escape(0xFFFDu, pos);
         } else {
           encodeUtf16Hex(codePoint, pos);
         }

--- a/velox/functions/sparksql/CMakeLists.txt
+++ b/velox/functions/sparksql/CMakeLists.txt
@@ -39,6 +39,7 @@ velox_add_library(
   DecimalCompare.cpp
   FilterFunction.cpp
   FormatNumber.cpp
+  GetJsonObject.cpp
   Hash.cpp
   In.cpp
   LeastGreatest.cpp

--- a/velox/functions/sparksql/GetJsonObject.cpp
+++ b/velox/functions/sparksql/GetJsonObject.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/sparksql/GetJsonObject.h"
+
+#include <cstddef>
+#include <string>
+#include <string_view>
+
+namespace facebook::velox::functions::sparksql::detail {
+
+namespace {
+
+// Appends `value` as a 4-hex-digit '\uXXXX' escape (uppercase) to `out`.
+void appendUtf16Hex(char16_t value, std::string& out) {
+  static constexpr char kHexDigits[] = "0123456789ABCDEF";
+  out.push_back('\\');
+  out.push_back('u');
+  out.push_back(kHexDigits[(value >> 12) & 0x0F]);
+  out.push_back(kHexDigits[(value >> 8) & 0x0F]);
+  out.push_back(kHexDigits[(value >> 4) & 0x0F]);
+  out.push_back(kHexDigits[value & 0x0F]);
+}
+
+// Returns whether `p` begins a valid 4-byte UTF-8 sequence (a supplementary
+// plane code point, >= U+10000) within [p, end). 1-/2-/3-byte sequences encode
+// BMP code points (<= U+FFFF), which Spark leaves literal.
+bool isSupplementaryLead(const unsigned char* p, const unsigned char* end) {
+  // Lead byte 11110xxx, followed by three 10xxxxxx continuation bytes.
+  return (*p & 0xF8) == 0xF0 && end - p >= 4 && (p[1] & 0xC0) == 0x80 &&
+      (p[2] & 0xC0) == 0x80 && (p[3] & 0xC0) == 0x80;
+}
+
+} // namespace
+
+size_t countSupplementaryCharacters(std::string_view raw) {
+  size_t count = 0;
+  const auto* p = reinterpret_cast<const unsigned char*>(raw.data());
+  const auto* end = p + raw.size();
+  while (p < end) {
+    if (isSupplementaryLead(p, end)) {
+      ++count;
+      p += 4;
+    } else {
+      ++p;
+    }
+  }
+  return count;
+}
+
+void escapeSupplementaryCharacters(std::string_view raw, std::string& out) {
+  const auto* const base = reinterpret_cast<const unsigned char*>(raw.data());
+  const auto* const end = base + raw.size();
+  const auto* p = base;
+  const auto* runStart = base;
+  while (p < end) {
+    if (isSupplementaryLead(p, end)) {
+      // Flush the verbatim run accumulated before this sequence in one copy.
+      if (p > runStart) {
+        out.append(
+            reinterpret_cast<const char*>(runStart),
+            static_cast<size_t>(p - runStart));
+      }
+      const char32_t codePoint = (*p & 0x07) << 18 | (p[1] & 0x3F) << 12 |
+          (p[2] & 0x3F) << 6 | (p[3] & 0x3F);
+      const char32_t v = codePoint - 0x10000u;
+      appendUtf16Hex(
+          static_cast<char16_t>(0xD800u + ((v >> 10) & 0x3FFu)), out);
+      appendUtf16Hex(static_cast<char16_t>(0xDC00u + (v & 0x3FFu)), out);
+      p += 4;
+      runStart = p;
+    } else {
+      ++p;
+    }
+  }
+  // Flush the trailing verbatim run.
+  if (p > runStart) {
+    out.append(
+        reinterpret_cast<const char*>(runStart),
+        static_cast<size_t>(p - runStart));
+  }
+}
+
+} // namespace facebook::velox::functions::sparksql::detail

--- a/velox/functions/sparksql/GetJsonObject.cpp
+++ b/velox/functions/sparksql/GetJsonObject.cpp
@@ -17,8 +17,11 @@
 #include "velox/functions/sparksql/GetJsonObject.h"
 
 #include <cstddef>
+#include <cstring>
 #include <string>
 #include <string_view>
+
+#include "folly/Unicode.h"
 
 #include "velox/functions/lib/Utf8Utils.h"
 
@@ -26,93 +29,57 @@ namespace facebook::velox::functions::sparksql::detail {
 
 namespace {
 
-// Appends `value` as a 4-hex-digit '\uXXXX' escape (uppercase) to `out`.
-void appendUtf16Hex(char16_t value, std::string& out) {
-  static constexpr char kHexDigits[] = "0123456789ABCDEF";
-  out.push_back('\\');
-  out.push_back('u');
-  out.push_back(kHexDigits[(value >> 12) & 0x0F]);
-  out.push_back(kHexDigits[(value >> 8) & 0x0F]);
-  out.push_back(kHexDigits[(value >> 4) & 0x0F]);
-  out.push_back(kHexDigits[value & 0x0F]);
-}
-
-// Returns the byte length of the UTF-8 character at [p, end) and, when it is a
-// supplementary-plane character (code point >= U+10000, i.e. a 4-byte
-// sequence), sets `isSupplementary` and fills `codePoint`. For BMP characters
-// (<= U+FFFF, which Spark leaves literal) and for invalid sequences, advances
-// by the reported length without setting `isSupplementary`; the caller copies
-// those bytes verbatim.
-size_t nextCharLength(
-    const unsigned char* p,
-    const unsigned char* end,
-    bool& isSupplementary,
-    char32_t& codePoint) {
-  isSupplementary = false;
-  int32_t decoded;
-  const int32_t length = tryGetUtf8CharLength(
-      reinterpret_cast<const char*>(p), static_cast<int64_t>(end - p), decoded);
-  if (length < 0) {
-    // Invalid sequence; copy its bytes verbatim.
-    return static_cast<size_t>(-length);
-  }
-  if (length == 4) {
-    isSupplementary = true;
-    codePoint = static_cast<char32_t>(decoded);
-  }
-  return static_cast<size_t>(length);
-}
-
 // Counts the supplementary-plane characters (4-byte UTF-8 sequences) in `raw`,
 // to pick the fast path (none) and to size the escape buffer exactly.
 size_t countSupplementaryCharacters(std::string_view raw) {
   size_t count = 0;
   const auto* p = reinterpret_cast<const unsigned char*>(raw.data());
-  const auto* end = p + raw.size();
+  const auto* const end = p + raw.size();
   while (p < end) {
-    bool isSupplementary;
-    char32_t codePoint;
-    p += nextCharLength(p, end, isSupplementary, codePoint);
-    if (isSupplementary) {
+    const int length = validateAndGetNextUtf8Length(p, end);
+    // A 4-byte sequence is a supplementary-plane code point; shorter sequences
+    // are BMP (left literal) and a negative length marks invalid bytes.
+    if (length == 4) {
       ++count;
     }
+    p += length > 0 ? length : 1;
   }
   return count;
 }
 
 // Copies `raw` into `out`, rewriting each supplementary-plane character into a
 // '\uXXXX\uXXXX' surrogate-pair escape and copying every other byte verbatim in
-// bulk runs.
-void escapeSupplementaryCharacters(std::string_view raw, std::string& out) {
+// bulk runs. `out` must have room for the escaped result (see
+// countSupplementaryCharacters for sizing); returns the past-the-end write
+// position.
+char* escapeSupplementaryCharacters(std::string_view raw, char* out) {
   const auto* const base = reinterpret_cast<const unsigned char*>(raw.data());
   const auto* const end = base + raw.size();
   const auto* p = base;
   const auto* runStart = base;
   while (p < end) {
-    bool isSupplementary;
-    char32_t codePoint;
-    const size_t length = nextCharLength(p, end, isSupplementary, codePoint);
-    if (isSupplementary) {
+    const int length = validateAndGetNextUtf8Length(p, end);
+    if (length == 4) {
       // Flush the verbatim run accumulated before this sequence in one copy.
       if (p > runStart) {
-        out.append(
-            reinterpret_cast<const char*>(runStart),
-            static_cast<size_t>(p - runStart));
+        const auto runSize = static_cast<size_t>(p - runStart);
+        std::memcpy(out, runStart, runSize);
+        out += runSize;
       }
-      const char32_t v = codePoint - 0x10000u;
-      appendUtf16Hex(
-          static_cast<char16_t>(0xD800u + ((v >> 10) & 0x3FFu)), out);
-      appendUtf16Hex(static_cast<char16_t>(0xDC00u + (v & 0x3FFu)), out);
-      runStart = p + length;
+      // folly::utf8ToCodePoint advances `p` past the 4-byte sequence.
+      encodeUtf16Hex(folly::utf8ToCodePoint(p, end, true), out);
+      runStart = p;
+    } else {
+      p += length > 0 ? length : 1;
     }
-    p += length;
   }
   // Flush the trailing verbatim run.
   if (p > runStart) {
-    out.append(
-        reinterpret_cast<const char*>(runStart),
-        static_cast<size_t>(p - runStart));
+    const auto runSize = static_cast<size_t>(p - runStart);
+    std::memcpy(out, runStart, runSize);
+    out += runSize;
   }
+  return out;
 }
 
 } // namespace
@@ -130,8 +97,10 @@ void appendWithSupplementaryEscapes(
   // Each 4-byte sequence (1 char) becomes a 12-byte surrogate-pair escape
   // ('\uXXXX\uXXXX'), i.e. 8 bytes larger than the raw 4.
   std::string escaped;
-  escaped.reserve(raw.size() + 8 * supplementaryCount);
-  escapeSupplementaryCharacters(raw, escaped);
+  escaped.resize(raw.size() + 8 * supplementaryCount);
+  char* const begin = escaped.data();
+  const char* const written = escapeSupplementaryCharacters(raw, begin);
+  escaped.resize(static_cast<size_t>(written - begin));
   out.append(escaped);
 }
 

--- a/velox/functions/sparksql/GetJsonObject.cpp
+++ b/velox/functions/sparksql/GetJsonObject.cpp
@@ -44,8 +44,8 @@ bool isSupplementaryLead(const unsigned char* p, const unsigned char* end) {
       (p[2] & 0xC0) == 0x80 && (p[3] & 0xC0) == 0x80;
 }
 
-} // namespace
-
+// Counts the supplementary-plane characters (4-byte UTF-8 sequences) in `raw`,
+// to pick the fast path (none) and to size the escape buffer exactly.
 size_t countSupplementaryCharacters(std::string_view raw) {
   size_t count = 0;
   const auto* p = reinterpret_cast<const unsigned char*>(raw.data());
@@ -61,6 +61,9 @@ size_t countSupplementaryCharacters(std::string_view raw) {
   return count;
 }
 
+// Copies `raw` into `out`, rewriting each supplementary-plane character into a
+// '\uXXXX\uXXXX' surrogate-pair escape and copying every other byte verbatim in
+// bulk runs.
 void escapeSupplementaryCharacters(std::string_view raw, std::string& out) {
   const auto* const base = reinterpret_cast<const unsigned char*>(raw.data());
   const auto* const end = base + raw.size();
@@ -92,6 +95,26 @@ void escapeSupplementaryCharacters(std::string_view raw, std::string& out) {
         reinterpret_cast<const char*>(runStart),
         static_cast<size_t>(p - runStart));
   }
+}
+
+} // namespace
+
+void appendWithSupplementaryEscapes(
+    std::string_view raw,
+    exec::StringWriter& out) {
+  const size_t supplementaryCount = countSupplementaryCharacters(raw);
+  if (supplementaryCount == 0) {
+    // Fast path: no supplementary-plane characters, so the raw slice already
+    // matches Spark. Append it directly, no allocation.
+    out.append(raw);
+    return;
+  }
+  // Each 4-byte sequence (1 char) becomes a 12-byte surrogate-pair escape
+  // ('\uXXXX\uXXXX'), i.e. 8 bytes larger than the raw 4.
+  std::string escaped;
+  escaped.reserve(raw.size() + 8 * supplementaryCount);
+  escapeSupplementaryCharacters(raw, escaped);
+  out.append(escaped);
 }
 
 } // namespace facebook::velox::functions::sparksql::detail

--- a/velox/functions/sparksql/GetJsonObject.cpp
+++ b/velox/functions/sparksql/GetJsonObject.cpp
@@ -28,16 +28,13 @@ namespace facebook::velox::functions::sparksql::detail {
 
 namespace {
 
-// Counts the supplementary-plane characters (4-byte UTF-8 sequences) in `raw`,
-// to pick the fast path (none) and to size the escape buffer exactly.
+// Counts the supplementary-plane characters (4-byte UTF-8 sequences) in `raw`.
 size_t countSupplementaryCharacters(std::string_view raw) {
   size_t count = 0;
   const auto* p = reinterpret_cast<const unsigned char*>(raw.data());
   const auto* const end = p + raw.size();
   while (p < end) {
     const int length = validateAndGetNextUtf8Length(p, end);
-    // A 4-byte sequence is a supplementary-plane code point; shorter sequences
-    // are BMP (left literal) and a negative length marks invalid bytes.
     if (length == 4) {
       ++count;
     }
@@ -46,9 +43,8 @@ size_t countSupplementaryCharacters(std::string_view raw) {
   return count;
 }
 
-// Copies `raw` into `out`, rewriting each supplementary-plane character into a
-// '\uXXXX\uXXXX' surrogate-pair escape and copying every other byte verbatim in
-// bulk runs. `out` must have room for the escaped result (see
+// Writes `raw` to `out`, applying the escaping described on
+// appendWithSupplementaryEscapes. `out` must have room for the result (see
 // countSupplementaryCharacters for sizing); returns the past-the-end write
 // position.
 char* escapeSupplementaryCharacters(std::string_view raw, char* out) {
@@ -88,8 +84,7 @@ void appendWithSupplementaryEscapes(
     exec::StringWriter& out) {
   const size_t supplementaryCount = countSupplementaryCharacters(raw);
   if (supplementaryCount == 0) {
-    // Fast path: no supplementary-plane characters, so the raw slice already
-    // matches Spark. Append it directly, no allocation.
+    // Fast path: nothing to escape, the raw slice already matches Spark.
     out.append(raw);
     return;
   }

--- a/velox/functions/sparksql/GetJsonObject.cpp
+++ b/velox/functions/sparksql/GetJsonObject.cpp
@@ -20,6 +20,8 @@
 #include <string>
 #include <string_view>
 
+#include "velox/functions/lib/Utf8Utils.h"
+
 namespace facebook::velox::functions::sparksql::detail {
 
 namespace {
@@ -35,13 +37,30 @@ void appendUtf16Hex(char16_t value, std::string& out) {
   out.push_back(kHexDigits[value & 0x0F]);
 }
 
-// Returns whether `p` begins a valid 4-byte UTF-8 sequence (a supplementary
-// plane code point, >= U+10000) within [p, end). 1-/2-/3-byte sequences encode
-// BMP code points (<= U+FFFF), which Spark leaves literal.
-bool isSupplementaryLead(const unsigned char* p, const unsigned char* end) {
-  // Lead byte 11110xxx, followed by three 10xxxxxx continuation bytes.
-  return (*p & 0xF8) == 0xF0 && end - p >= 4 && (p[1] & 0xC0) == 0x80 &&
-      (p[2] & 0xC0) == 0x80 && (p[3] & 0xC0) == 0x80;
+// Returns the byte length of the UTF-8 character at [p, end) and, when it is a
+// supplementary-plane character (code point >= U+10000, i.e. a 4-byte
+// sequence), sets `isSupplementary` and fills `codePoint`. For BMP characters
+// (<= U+FFFF, which Spark leaves literal) and for invalid sequences, advances
+// by the reported length without setting `isSupplementary`; the caller copies
+// those bytes verbatim.
+size_t nextCharLength(
+    const unsigned char* p,
+    const unsigned char* end,
+    bool& isSupplementary,
+    char32_t& codePoint) {
+  isSupplementary = false;
+  int32_t decoded;
+  const int32_t length = tryGetUtf8CharLength(
+      reinterpret_cast<const char*>(p), static_cast<int64_t>(end - p), decoded);
+  if (length < 0) {
+    // Invalid sequence; copy its bytes verbatim.
+    return static_cast<size_t>(-length);
+  }
+  if (length == 4) {
+    isSupplementary = true;
+    codePoint = static_cast<char32_t>(decoded);
+  }
+  return static_cast<size_t>(length);
 }
 
 // Counts the supplementary-plane characters (4-byte UTF-8 sequences) in `raw`,
@@ -51,11 +70,11 @@ size_t countSupplementaryCharacters(std::string_view raw) {
   const auto* p = reinterpret_cast<const unsigned char*>(raw.data());
   const auto* end = p + raw.size();
   while (p < end) {
-    if (isSupplementaryLead(p, end)) {
+    bool isSupplementary;
+    char32_t codePoint;
+    p += nextCharLength(p, end, isSupplementary, codePoint);
+    if (isSupplementary) {
       ++count;
-      p += 4;
-    } else {
-      ++p;
     }
   }
   return count;
@@ -70,24 +89,23 @@ void escapeSupplementaryCharacters(std::string_view raw, std::string& out) {
   const auto* p = base;
   const auto* runStart = base;
   while (p < end) {
-    if (isSupplementaryLead(p, end)) {
+    bool isSupplementary;
+    char32_t codePoint;
+    const size_t length = nextCharLength(p, end, isSupplementary, codePoint);
+    if (isSupplementary) {
       // Flush the verbatim run accumulated before this sequence in one copy.
       if (p > runStart) {
         out.append(
             reinterpret_cast<const char*>(runStart),
             static_cast<size_t>(p - runStart));
       }
-      const char32_t codePoint = (*p & 0x07) << 18 | (p[1] & 0x3F) << 12 |
-          (p[2] & 0x3F) << 6 | (p[3] & 0x3F);
       const char32_t v = codePoint - 0x10000u;
       appendUtf16Hex(
           static_cast<char16_t>(0xD800u + ((v >> 10) & 0x3FFu)), out);
       appendUtf16Hex(static_cast<char16_t>(0xDC00u + (v & 0x3FFu)), out);
-      p += 4;
-      runStart = p;
-    } else {
-      ++p;
+      runStart = p + length;
     }
+    p += length;
   }
   // Flush the trailing verbatim run.
   if (p > runStart) {

--- a/velox/functions/sparksql/GetJsonObject.cpp
+++ b/velox/functions/sparksql/GetJsonObject.cpp
@@ -18,7 +18,6 @@
 
 #include <cstddef>
 #include <cstring>
-#include <string>
 #include <string_view>
 
 #include "folly/Unicode.h"
@@ -95,13 +94,15 @@ void appendWithSupplementaryEscapes(
     return;
   }
   // Each 4-byte sequence (1 char) becomes a 12-byte surrogate-pair escape
-  // ('\uXXXX\uXXXX'), i.e. 8 bytes larger than the raw 4.
-  std::string escaped;
-  escaped.resize(raw.size() + 8 * supplementaryCount);
-  char* const begin = escaped.data();
+  // ('\uXXXX\uXXXX'), i.e. 8 bytes larger than the raw 4. Escape directly into
+  // `out`'s buffer -- reserve the exact worst case, write in place, then resize
+  // down to what was actually written, avoiding an intermediate string + copy.
+  const size_t oldSize = out.size();
+  const size_t maxSize = oldSize + raw.size() + 8 * supplementaryCount;
+  out.reserve(maxSize);
+  char* const begin = out.data() + oldSize;
   const char* const written = escapeSupplementaryCharacters(raw, begin);
-  escaped.resize(static_cast<size_t>(written - begin));
-  out.append(escaped);
+  out.resize(oldSize + static_cast<size_t>(written - begin));
 }
 
 } // namespace facebook::velox::functions::sparksql::detail

--- a/velox/functions/sparksql/GetJsonObject.h
+++ b/velox/functions/sparksql/GetJsonObject.h
@@ -23,6 +23,7 @@
 #include <string_view>
 
 #include "velox/core/QueryConfig.h"
+#include "velox/expression/StringWriter.h"
 #include "velox/functions/Macros.h"
 #include "velox/functions/lib/JsonUtil.h"
 #include "velox/functions/prestosql/json/SIMDJsonUtil.h"
@@ -169,29 +170,21 @@ class JsonPathNormalizer {
   State state_{State::kAfterDollar};
 };
 
-// Counts the supplementary-plane characters (4-byte UTF-8 sequences) in `raw`.
-// Used to pick the fast path (none ⇒ copy the raw slice verbatim) and to size
-// the output buffer exactly when escaping is needed. Defined in
-// GetJsonObject.cpp.
-size_t countSupplementaryCharacters(std::string_view raw);
-
-// Copies `raw` to `out`, rewriting characters in the Unicode supplementary
-// planes (code points >= U+10000, encoded as 4-byte UTF-8) into
-// '\\uXXXX\\uXXXX' UTF-16 surrogate-pair escapes. All other bytes (ASCII,
-// 2-/3-byte BMP sequences, existing escapes) are copied verbatim, in bulk runs.
+// Appends the raw JSON object/array slice `raw` to `out`, rewriting characters
+// in the Unicode supplementary planes (code points >= U+10000, encoded as
+// 4-byte UTF-8) into '\\uXXXX\\uXXXX' UTF-16 surrogate-pair escapes. All other
+// bytes (ASCII, 2-/3-byte BMP sequences, existing escapes) are appended
+// verbatim, in bulk runs. When `raw` has no supplementary-plane character it is
+// appended directly with no extra allocation.
 //
 // Spark's get_json_object re-serializes an object/array result through a
 // Jackson JsonGenerator, which escapes supplementary-plane characters as
 // surrogate-pair '\\u' escapes while leaving BMP characters (e.g. CJK) literal.
-// Velox returns the raw JSON slice directly via simdjson, so a literal emoji in
-// the source is otherwise emitted literally, diverging from Spark. See
-// https://github.com/facebookincubator/velox/issues/17923.
-//
-// Callers should only invoke this when `raw` contains at least one
-// supplementary-plane character (see countSupplementaryCharacters); otherwise
-// the raw slice can be appended directly without any allocation. Defined in
-// GetJsonObject.cpp.
-void escapeSupplementaryCharacters(std::string_view raw, std::string& out);
+// The raw simdjson slice keeps them literal, so this aligns Velox with Spark.
+// See https://github.com/facebookincubator/velox/issues/17923.
+void appendWithSupplementaryEscapes(
+    std::string_view raw,
+    exec::StringWriter& out);
 
 } // namespace detail
 
@@ -274,10 +267,9 @@ struct GetJsonObjectFunction {
   bool extractStringResult(
       simdjson::simdjson_result<simdjson::ondemand::value> rawResult,
       out_type<Varchar>& result) {
-    std::stringstream ss;
     switch (rawResult.type()) {
       // For number and bool types, we need to explicitly get the value
-      // for specific types instead of using `ss << rawResult`. Thus, we
+      // for specific types instead of taking their raw token. Thus, we
       // can make simdjson's internal parsing position moved and then we
       // can check the validity of ending character.
       case simdjson::ondemand::json_type::number: {
@@ -326,27 +318,13 @@ struct GetJsonObjectFunction {
       // "$.my" will return an object type.
       case simdjson::ondemand::json_type::object:
       case simdjson::ondemand::json_type::array: {
-        ss << rawResult;
-        // Spark re-serializes object/array results through Jackson, which
-        // escapes supplementary-plane characters (e.g. emoji) as '\\u'
-        // surrogate pairs. simdjson returns the raw slice verbatim, so escape
-        // them here to align with Spark. See
-        // https://github.com/facebookincubator/velox/issues/17923.
-        const std::string raw = ss.str();
-        const size_t supplementaryCount =
-            detail::countSupplementaryCharacters(raw);
-        if (supplementaryCount == 0) {
-          // Fast path: no supplementary-plane characters, so the raw slice
-          // already matches Spark. Append it directly, no allocation.
-          result.append(raw);
-        } else {
-          // Each 4-byte sequence (1 char) becomes a 12-byte surrogate-pair
-          // escape ('\\uXXXX\\uXXXX'), i.e. 8 bytes larger than the raw 4.
-          std::string escaped;
-          escaped.reserve(raw.size() + 8 * supplementaryCount);
-          detail::escapeSupplementaryCharacters(raw, escaped);
-          result.append(escaped);
+        // simdjson returns the object/array as its raw input slice, verbatim
+        // (no unescaping) -- exactly what we want.
+        std::string_view raw;
+        if (rawResult.raw_json().get(raw)) {
+          return false;
         }
+        detail::appendWithSupplementaryEscapes(raw, result);
         return true;
       }
       default:

--- a/velox/functions/sparksql/GetJsonObject.h
+++ b/velox/functions/sparksql/GetJsonObject.h
@@ -17,7 +17,10 @@
 #pragma once
 
 #include <folly/Likely.h>
+#include <cstddef>
 #include <cstring>
+#include <string>
+#include <string_view>
 
 #include "velox/core/QueryConfig.h"
 #include "velox/functions/Macros.h"
@@ -166,6 +169,30 @@ class JsonPathNormalizer {
   State state_{State::kAfterDollar};
 };
 
+// Counts the supplementary-plane characters (4-byte UTF-8 sequences) in `raw`.
+// Used to pick the fast path (none ⇒ copy the raw slice verbatim) and to size
+// the output buffer exactly when escaping is needed. Defined in
+// GetJsonObject.cpp.
+size_t countSupplementaryCharacters(std::string_view raw);
+
+// Copies `raw` to `out`, rewriting characters in the Unicode supplementary
+// planes (code points >= U+10000, encoded as 4-byte UTF-8) into
+// '\\uXXXX\\uXXXX' UTF-16 surrogate-pair escapes. All other bytes (ASCII,
+// 2-/3-byte BMP sequences, existing escapes) are copied verbatim, in bulk runs.
+//
+// Spark's get_json_object re-serializes an object/array result through a
+// Jackson JsonGenerator, which escapes supplementary-plane characters as
+// surrogate-pair '\\u' escapes while leaving BMP characters (e.g. CJK) literal.
+// Velox returns the raw JSON slice directly via simdjson, so a literal emoji in
+// the source is otherwise emitted literally, diverging from Spark. See
+// https://github.com/facebookincubator/velox/issues/17923.
+//
+// Callers should only invoke this when `raw` contains at least one
+// supplementary-plane character (see countSupplementaryCharacters); otherwise
+// the raw slice can be appended directly without any allocation. Defined in
+// GetJsonObject.cpp.
+void escapeSupplementaryCharacters(std::string_view raw, std::string& out);
+
 } // namespace detail
 
 /// Parses a JSON string and returns the value at the specified path.
@@ -300,7 +327,26 @@ struct GetJsonObjectFunction {
       case simdjson::ondemand::json_type::object:
       case simdjson::ondemand::json_type::array: {
         ss << rawResult;
-        result.append(ss.str());
+        // Spark re-serializes object/array results through Jackson, which
+        // escapes supplementary-plane characters (e.g. emoji) as '\\u'
+        // surrogate pairs. simdjson returns the raw slice verbatim, so escape
+        // them here to align with Spark. See
+        // https://github.com/facebookincubator/velox/issues/17923.
+        const std::string raw = ss.str();
+        const size_t supplementaryCount =
+            detail::countSupplementaryCharacters(raw);
+        if (supplementaryCount == 0) {
+          // Fast path: no supplementary-plane characters, so the raw slice
+          // already matches Spark. Append it directly, no allocation.
+          result.append(raw);
+        } else {
+          // Each 4-byte sequence (1 char) becomes a 12-byte surrogate-pair
+          // escape ('\\uXXXX\\uXXXX'), i.e. 8 bytes larger than the raw 4.
+          std::string escaped;
+          escaped.reserve(raw.size() + 8 * supplementaryCount);
+          detail::escapeSupplementaryCharacters(raw, escaped);
+          result.append(escaped);
+        }
         return true;
       }
       default:

--- a/velox/functions/sparksql/tests/GetJsonObjectTest.cpp
+++ b/velox/functions/sparksql/tests/GetJsonObjectTest.cpp
@@ -134,6 +134,35 @@ TEST_F(GetJsonObjectTest, basic) {
   EXPECT_EQ(getJsonObject(R"({"hello": "\u000A"})", "$.hello"), "\n");
 }
 
+TEST_F(GetJsonObjectTest, supplementaryPlaneInObject) {
+  // When an object/array result contains supplementary-plane characters
+  // (code points >= U+10000, e.g. emoji) stored as literal UTF-8 in the
+  // source, Spark re-serializes them as '\\u' surrogate-pair escapes while
+  // leaving BMP characters (e.g. CJK) literal. Velox must match this.
+  // See https://github.com/facebookincubator/velox/issues/17923.
+
+  // Literal emoji U+1F9E7 (🧧) inside an object value, alongside a CJK string
+  // (会员) that must stay literal.
+  EXPECT_EQ(
+      getJsonObject(R"({"a": {"name": "🧧会员"}})", "$.a"),
+      R"({"name": "\uD83E\uDDE7会员"})");
+
+  // Literal emoji U+1F947 (🥇) inside an array.
+  EXPECT_EQ(getJsonObject(R"({"a": ["🥇"]})", "$.a"), R"(["\uD83E\uDD47"])");
+
+  // Already-escaped '\u' input arrives as ASCII bytes and is preserved
+  // verbatim (no double escaping). Inside a raw string literal the backslash
+  // is literal, so the input/expected below are the literal bytes
+  // \ u D 8 3 E \ u D D E 7 g i f t.
+  EXPECT_EQ(
+      getJsonObject(R"({"a": {"name": "\uD83E\uDDE7gift"}})", "$.a"),
+      R"({"name": "\uD83E\uDDE7gift"})");
+
+  // A supplementary-plane character extracted as a scalar string leaf is
+  // decoded to its literal form (matching Spark), unaffected by this change.
+  EXPECT_EQ(getJsonObject(R"({"a": "🥇"})", "$.a"), "🥇");
+}
+
 TEST_F(GetJsonObjectTest, nullResult) {
   // Field not found.
   EXPECT_EQ(getJsonObject(R"({"hello": "3.5"})", "$.hi"), std::nullopt);

--- a/velox/functions/sparksql/tests/GetJsonObjectTest.cpp
+++ b/velox/functions/sparksql/tests/GetJsonObjectTest.cpp
@@ -135,19 +135,15 @@ TEST_F(GetJsonObjectTest, basic) {
 }
 
 TEST_F(GetJsonObjectTest, supplementaryPlaneInObject) {
-  // When an object/array result contains supplementary-plane characters
-  // (code points >= U+10000, e.g. emoji) stored as literal UTF-8 in the
-  // source, Spark re-serializes them as '\\u' surrogate-pair escapes while
-  // leaving BMP characters (e.g. CJK) literal. Velox must match this.
-  // See https://github.com/facebookincubator/velox/issues/17923.
+  // See appendWithSupplementaryEscapes for the behavior under test.
 
-  // Literal emoji U+1F9E7 (🧧) inside an object value, alongside a CJK string
-  // (会员) that must stay literal.
+  // Literal emoji U+1F9E7 inside an object value, alongside a CJK string
+  // that must stay literal.
   EXPECT_EQ(
       getJsonObject(R"({"a": {"name": "🧧会员"}})", "$.a"),
       R"({"name": "\uD83E\uDDE7会员"})");
 
-  // Literal emoji U+1F947 (🥇) inside an array.
+  // Literal emoji U+1F947 inside an array.
   EXPECT_EQ(getJsonObject(R"({"a": ["🥇"]})", "$.a"), R"(["\uD83E\uDD47"])");
 
   // Already-escaped '\u' input arrives as ASCII bytes and is preserved
@@ -159,7 +155,7 @@ TEST_F(GetJsonObjectTest, supplementaryPlaneInObject) {
       R"({"name": "\uD83E\uDDE7gift"})");
 
   // A supplementary-plane character extracted as a scalar string leaf is
-  // decoded to its literal form (matching Spark), unaffected by this change.
+  // decoded to its literal form, unaffected by this change.
   EXPECT_EQ(getJsonObject(R"({"a": "🥇"})", "$.a"), "🥇");
 }
 


### PR DESCRIPTION
When get_json_object resolves a path to a JSON object or array, Velox returns the raw simdjson slice verbatim, so a literal supplementary-plane character (code point >= U+10000, e.g. emoji) in the source is emitted literally. Vanilla Spark re-serializes the subtree through a Jackson JsonGenerator (built without ESCAPE_NON_ASCII), which escapes supplementary-plane characters as \uXXXX\uXXXX surrogate pairs while leaving BMP characters (e.g. CJK) literal. The two outputs are semantically equal but differ byte-for-byte.

Rewrite supplementary-plane characters (4-byte UTF-8 sequences) in the object/array result into surrogate-pair escapes before appending, leaving ASCII, 2-/3-byte BMP sequences, and existing escapes verbatim. Scalar string/number/ bool results are unchanged.

Fixes https://github.com/facebookincubator/velox/issues/17923.