### PR TITLE
fix: Reject nullAllowed filters in index lookup extraction (#17928)

### DIFF
--- a/velox/connectors/hive/HiveIndexSourceUtils.cpp
+++ b/velox/connectors/hive/HiveIndexSourceUtils.cpp
@@ -25,6 +25,10 @@ namespace facebook::velox::connector::hive {
 std::optional<variant> extractPointLookupValue(const common::Filter* filter) {
   VELOX_CHECK_NOT_NULL(filter);
 
+  if (filter->nullAllowed()) {
+    return std::nullopt;
+  }
+
   switch (filter->kind()) {
     case common::FilterKind::kBigintRange: {
       const auto* range = filter->as<common::BigintRange>();
@@ -77,6 +81,10 @@ std::optional<variant> extractPointLookupValue(const common::Filter* filter) {
 std::optional<std::pair<variant, variant>> extractRangeBounds(
     const common::Filter* filter) {
   VELOX_CHECK_NOT_NULL(filter);
+
+  if (filter->nullAllowed()) {
+    return std::nullopt;
+  }
 
   switch (filter->kind()) {
     case common::FilterKind::kBigintRange: {

--- a/velox/connectors/hive/tests/HiveIndexSourceUtilsTest.cpp
+++ b/velox/connectors/hive/tests/HiveIndexSourceUtilsTest.cpp
@@ -213,6 +213,44 @@ TEST_F(ExtractRangeBoundsTest, floatRangeUnboundedReturnsNullopt) {
   EXPECT_FALSE(result.has_value());
 }
 
+// --- nullAllowed tests ---
+// Filters with nullAllowed=true must not be converted, because the
+// caller erases the original filter after conversion and the simplified
+// condition cannot represent IS NULL semantics.
+
+TEST_F(ExtractRangeBoundsTest, bigintRangeNullAllowedReturnsNullopt) {
+  auto filter = std::make_unique<common::BigintRange>(
+      /*lower=*/10, /*upper=*/20, /*nullAllowed=*/true);
+  auto result = extractRangeBounds(filter.get());
+  EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(ExtractRangeBoundsTest, doubleRangeNullAllowedReturnsNullopt) {
+  auto filter = std::make_unique<common::DoubleRange>(
+      /*lower=*/1.0,
+      /*lowerUnbounded=*/false,
+      /*lowerExclusive=*/false,
+      /*upper=*/5.0,
+      /*upperUnbounded=*/false,
+      /*upperExclusive=*/false,
+      /*nullAllowed=*/true);
+  auto result = extractRangeBounds(filter.get());
+  EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(ExtractRangeBoundsTest, floatRangeNullAllowedReturnsNullopt) {
+  auto filter = std::make_unique<common::FloatRange>(
+      /*lower=*/1.0f,
+      /*lowerUnbounded=*/false,
+      /*lowerExclusive=*/false,
+      /*upper=*/5.0f,
+      /*upperUnbounded=*/false,
+      /*upperExclusive=*/false,
+      /*nullAllowed=*/true);
+  auto result = extractRangeBounds(filter.get());
+  EXPECT_FALSE(result.has_value());
+}
+
 // --- extractPointLookupValue tests ---
 
 class ExtractPointLookupValueTest : public ::testing::Test {};
@@ -295,6 +333,42 @@ TEST_F(ExtractPointLookupValueTest, floatExclusiveNotPoint) {
       /*upperUnbounded=*/false,
       /*upperExclusive=*/true,
       /*nullAllowed=*/false);
+  auto result = extractPointLookupValue(filter.get());
+  EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(ExtractPointLookupValueTest, bigintNullAllowedReturnsNullopt) {
+  // key = 42 OR key IS NULL
+  auto filter = std::make_unique<common::BigintRange>(
+      /*lower=*/42, /*upper=*/42, /*nullAllowed=*/true);
+  auto result = extractPointLookupValue(filter.get());
+  EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(ExtractPointLookupValueTest, doubleNullAllowedReturnsNullopt) {
+  // score = 3.14 OR score IS NULL
+  auto filter = std::make_unique<common::DoubleRange>(
+      /*lower=*/3.14,
+      /*lowerUnbounded=*/false,
+      /*lowerExclusive=*/false,
+      /*upper=*/3.14,
+      /*upperUnbounded=*/false,
+      /*upperExclusive=*/false,
+      /*nullAllowed=*/true);
+  auto result = extractPointLookupValue(filter.get());
+  EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(ExtractPointLookupValueTest, floatNullAllowedReturnsNullopt) {
+  // score = 2.5f OR score IS NULL
+  auto filter = std::make_unique<common::FloatRange>(
+      /*lower=*/2.5f,
+      /*lowerUnbounded=*/false,
+      /*lowerExclusive=*/false,
+      /*upper=*/2.5f,
+      /*upperUnbounded=*/false,
+      /*upperExclusive=*/false,
+      /*nullAllowed=*/true);
   auto result = extractPointLookupValue(filter.get());
   EXPECT_FALSE(result.has_value());
 }


### PR DESCRIPTION
Summary:

When a filter has `nullAllowed=true` (e.g., `key = 5 OR key IS NULL`), converting it to a plain `EqualIndexLookupCondition` or `BetweenIndexLookupCondition` loses the IS NULL semantics. The caller then erases the original filter from `filters_`, so null rows silently pass or are dropped.

Return `std::nullopt` from both `extractPointLookupValue()` and `extractRangeBounds()` when `nullAllowed()` is true. This keeps the original filter in the `filters_` map so it is applied as a residual filter that preserves the null semantics.

Reviewed By: xiaoxmeng

Differential Revision: D109478344


