### PR TITLE
test: Fix failing table scan and table writer tests

### DIFF
--- a/velox/exec/tests/TableWriterTest.cpp
+++ b/velox/exec/tests/TableWriterTest.cpp
@@ -3317,8 +3317,13 @@ DEBUG_ONLY_TEST_F(TableWriterArbitrationTest, reclaimFromSortTableWriter) {
               return;
             }
 
+            // Base the fake allocation on usedBytes() rather than
+            // reservedBytes() so it consumes all genuinely free capacity and
+            // forces the arbitrator to reclaim the sort writer's buffered
+            // memory by spilling, instead of being satisfied from unused
+            // reserved capacity.
             const auto fakeAllocationSize =
-                kQueryMemoryCapacity - op->pool()->parent()->reservedBytes();
+                kQueryMemoryCapacity - op->pool()->parent()->usedBytes();
             if (writerSpillEnabled) {
               auto* buffer = op->pool()->allocate(fakeAllocationSize);
               op->pool()->free(buffer, fakeAllocationSize);


### PR DESCRIPTION
Summary:
Three tests were failing.

TableScanTest: The table scan adaptive-batch tests assert the exact output batch sizes produced for fuzzer-generated inputs. A recent `VectorFuzzer` change shifted those generated inputs, so the hardcoded expectations no longer matched. Refreshed the expectations to the current output.

TableWriterTest (flaky): (unrelated to the VectorFuzzer change) The sort table writer reclaim test asserts that the writer spills under memory pressure, but it no longer drove the writer hard enough to spill. Adjusted the test so it reliably forces a spill.

Differential Revision: D109738074


