### PR TITLE
feat(cursor): Add a non-blocking future to TaskCursor::moveNext (#17930)

### DIFF
--- a/velox/exec/Cursor.cpp
+++ b/velox/exec/Cursor.cpp
@@ -54,8 +54,13 @@ class TaskQueue {
   exec::BlockingReason
   enqueue(RowVectorPtr vector, bool drained, velox::ContinueFuture* future);
 
-  // Returns nullptr when all producers are at end. Otherwise blocks.
-  RowVectorPtr dequeue();
+  // Returns the next batch if one is available. Otherwise returns nullptr and,
+  // if more output may still arrive, sets '*future' to a future realized when
+  // the consumer should retry; when all producers are at end (or the queue is
+  // closed) returns nullptr and leaves '*future' untouched. The caller
+  // distinguishes "blocked" from "done" by whether '*future' is valid.
+  // 'future' must be non-null.
+  RowVectorPtr dequeue(velox::ContinueFuture* future);
 
   void close();
 
@@ -81,7 +86,6 @@ class TaskQueue {
   std::vector<ContinuePromise> producerUnblockPromises_;
   bool consumerBlocked_ = false;
   ContinuePromise consumerPromise_{ContinuePromise::makeEmpty()};
-  ContinueFuture consumerFuture_;
   bool closed_ = false;
 };
 
@@ -127,46 +131,48 @@ exec::BlockingReason TaskQueue::enqueue(
   return exec::BlockingReason::kNotBlocked;
 }
 
-RowVectorPtr TaskQueue::dequeue() {
-  for (;;) {
-    RowVectorPtr vector;
-    std::vector<ContinuePromise> mayContinue;
-    {
-      std::lock_guard<std::mutex> l(mutex_);
-      if (closed_) {
-        return nullptr;
-      }
+RowVectorPtr TaskQueue::dequeue(velox::ContinueFuture* future) {
+  VELOX_CHECK_NOT_NULL(future);
+  RowVectorPtr vector;
+  std::vector<ContinuePromise> mayContinue;
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    if (closed_) {
+      return nullptr;
+    }
 
-      if (!queue_.empty()) {
-        auto result = std::move(queue_.front());
-        queue_.pop_front();
-        totalBytes_ -= result.bytes;
-        vector = std::move(result.vector);
-        if (totalBytes_ < maxBytes_ / 2) {
-          mayContinue = std::move(producerUnblockPromises_);
-        }
-      } else if (
-          numProducers_.has_value() && producersFinished_ == numProducers_) {
-        return nullptr;
-      } else if (numDrainedProducers_ == numProducers_) {
-        return nullptr;
+    if (!queue_.empty()) {
+      auto result = std::move(queue_.front());
+      queue_.pop_front();
+      totalBytes_ -= result.bytes;
+      vector = std::move(result.vector);
+      if (totalBytes_ < maxBytes_ / 2) {
+        mayContinue = std::move(producerUnblockPromises_);
       }
+    } else if (
+        numProducers_.has_value() && producersFinished_ == numProducers_) {
+      return nullptr;
+    } else if (numDrainedProducers_ == numProducers_) {
+      return nullptr;
+    }
 
-      if (!vector) {
-        consumerBlocked_ = true;
-        consumerPromise_ = ContinuePromise("TaskQueue::dequeue");
-        consumerFuture_ = consumerPromise_.getFuture();
-      }
+    if (!vector) {
+      // No data yet but more may arrive: hand the consumer future to the caller
+      // so it can wait without blocking this thread. Single-consumer contract:
+      // the caller must wait on the previously handed-out future before
+      // re-calling. Always-on check: overwriting an unfulfilled promise would
+      // strand any waiter on the prior future in a silent, permanent hang.
+      VELOX_CHECK(!consumerBlocked_);
+      consumerBlocked_ = true;
+      consumerPromise_ = ContinuePromise("TaskQueue::dequeue");
+      *future = consumerPromise_.getFuture();
     }
-    // outside of 'mutex_'
-    for (auto& promise : mayContinue) {
-      promise.setValue();
-    }
-    if (vector) {
-      return vector;
-    }
-    consumerFuture_.wait();
   }
+  // outside of 'mutex_'
+  for (auto& promise : mayContinue) {
+    promise.setValue();
+  }
+  return vector;
 }
 
 void TaskQueue::close() {
@@ -372,18 +378,37 @@ class MultiThreadedTaskCursor : public TaskCursorBase {
 
   /// Fetches another batch from the task queue.
   /// Starts the task if not started yet.
-  bool moveNext() override {
-    start();
-    if (error_) {
-      std::rethrow_exception(error_);
-    }
+  bool moveNext(ContinueFuture* future) override {
+    while (true) {
+      start();
+      if (error_) {
+        std::rethrow_exception(error_);
+      }
 
-    // Task might be aborted before start.
-    checkTaskError();
-    current_ = queue_->dequeue();
+      // Task might be aborted before start.
+      ContinueFuture waitFuture = ContinueFuture::makeEmpty();
+      checkTaskError();
+      current_ = queue_->dequeue(&waitFuture);
+      checkTaskError();
 
-    checkTaskError();
-    if (!current_) {
+      if (current_) {
+        return true;
+      }
+      if (waitFuture.valid()) {
+        // More output may still arrive. Hand the future to the caller when
+        // non-blocking, otherwise wait here and retry.
+        if (future != nullptr) {
+          *future = std::move(waitFuture);
+          return false;
+        }
+        waitFuture.wait();
+        continue;
+      }
+      // No future from the queue means producers are at end (or drained).
+      // A completed drain returns false with an invalid '*future', the same
+      // signal as end-of-stream. This preserves the prior blocking contract
+      // (both yielded false); the moveNext() protocol does not distinguish a
+      // drain boundary from end-of-stream.
       if (queue_->numDrainedProducers_ > 0) {
         VELOX_CHECK(queue_->numProducers_.has_value());
         VELOX_CHECK_EQ(
@@ -392,12 +417,12 @@ class MultiThreadedTaskCursor : public TaskCursorBase {
         return false;
       }
       atEnd_ = true;
+      return false;
     }
-    return current_ != nullptr;
   }
 
   bool moveStep(const core::PlanNodeId& /*planId*/ = "") override {
-    return moveNext();
+    return moveNext(nullptr);
   }
 
   void setNoMoreSplits() override {
@@ -516,14 +541,20 @@ class SingleThreadedTaskCursor : public TaskCursorBase {
     return noMoreSplits_;
   }
 
-  bool moveNext() override {
-    if (!task_->isRunning()) {
-      return false;
-    }
-
+  bool moveNext(ContinueFuture* future) override {
     while (true) {
-      ContinueFuture future = ContinueFuture::makeEmpty();
-      RowVectorPtr next = task_->next(&future);
+      if (!task_->isRunning()) {
+        // Surface a cancellation/abort error rather than reporting "done", so
+        // an async caller can distinguish a terminated task from end-of-stream
+        // (matches the parallel cursor's checkTaskError() behavior).
+        if (auto error = task_->error()) {
+          std::rethrow_exception(error);
+        }
+        return false;
+      }
+
+      ContinueFuture waitFuture = ContinueFuture::makeEmpty();
+      RowVectorPtr next = task_->next(&waitFuture);
       if (next != nullptr) {
         if (outputPool_ && copyResult_) {
           VectorPtr copy = encodedVectorCopy(
@@ -534,20 +565,23 @@ class SingleThreadedTaskCursor : public TaskCursorBase {
         }
         return true;
       }
-      // When next is returned from task as a null pointer.
-      if (!future.valid()) {
-        VELOX_CHECK(!task_->isRunning() || !noMoreSplits_);
-        return false;
+      // next is null: either blocked on an external event (valid future) or
+      // the task is done (invalid future).
+      if (waitFuture.valid()) {
+        if (future != nullptr) {
+          *future = std::move(waitFuture);
+          return false;
+        }
+        waitFuture.wait();
+        continue;
       }
-      // Task is blocked for some reason. Wait and try again.
-      VELOX_CHECK_NULL(next);
-      future.wait();
+      VELOX_CHECK(!task_->isRunning() || !noMoreSplits_);
+      return false;
     }
-    return false;
   }
 
   bool moveStep(const core::PlanNodeId& /*planId*/ = "") override {
-    return moveNext();
+    return moveNext(nullptr);
   }
 
   RowVectorPtr& current() override {
@@ -584,6 +618,51 @@ class SingleThreadedTaskCursor : public TaskCursorBase {
 /// and inspecting intermediate results. Subclasses implement the execution
 /// model (serial vs parallel) via the `advance()` and `start()` methods.
 class TaskDebuggerCursorBase : public TaskCursorBase {
+ public:
+  // Debugging cursors are interactive and run synchronously, so they ignore
+  // 'future' and block, leaving it invalid.
+  bool moveNext(ContinueFuture* future) override {
+    if (future != nullptr) {
+      *future = ContinueFuture::makeEmpty();
+    }
+    return advance(false);
+  }
+
+  bool moveStep(const core::PlanNodeId& planId = "") override {
+    return advance(true, planId);
+  }
+
+  RowVectorPtr& current() override {
+    return current_;
+  }
+
+  core::PlanNodeId at() const override {
+    if (pendingTraceDriverState_) {
+      return pendingTraceDriverState_->planId;
+    }
+    return "";
+  }
+
+  void setNoMoreSplits() override {
+    VELOX_CHECK(!noMoreSplits_);
+    noMoreSplits_ = true;
+  }
+
+  bool noMoreSplits() const override {
+    return noMoreSplits_;
+  }
+
+  void setError(std::exception_ptr error) override {
+    error_ = error;
+    if (task_) {
+      task_->setError(error);
+    }
+  }
+
+  const std::shared_ptr<Task>& task() override {
+    return task_;
+  }
+
  protected:
   // Internal state for coordinating between the tracer and cursor.
   //
@@ -723,47 +802,6 @@ class TaskDebuggerCursorBase : public TaskCursorBase {
     }
   }
 
- public:
-  bool moveNext() override {
-    return advance(false);
-  }
-
-  bool moveStep(const core::PlanNodeId& planId = "") override {
-    return advance(true, planId);
-  }
-
-  RowVectorPtr& current() override {
-    return current_;
-  }
-
-  core::PlanNodeId at() const override {
-    if (pendingTraceDriverState_) {
-      return pendingTraceDriverState_->planId;
-    }
-    return "";
-  }
-
-  void setNoMoreSplits() override {
-    VELOX_CHECK(!noMoreSplits_);
-    noMoreSplits_ = true;
-  }
-
-  bool noMoreSplits() const override {
-    return noMoreSplits_;
-  }
-
-  void setError(std::exception_ptr error) override {
-    error_ = error;
-    if (task_) {
-      task_->setError(error);
-    }
-  }
-
-  const std::shared_ptr<Task>& task() override {
-    return task_;
-  }
-
- protected:
   // Advance to the next vector to produce, storing it in `current_`. If
   // `isStep` is true, move to the next trace point or task output. If false,
   // moves to the next task output.

--- a/velox/exec/Cursor.h
+++ b/velox/exec/Cursor.h
@@ -154,8 +154,36 @@ class TaskCursor {
   /// Fetches another batch from the task queue. Starts the task if not started
   /// yet.
   ///
-  /// @return Returns false is the task is done producing output.
-  virtual bool moveNext() = 0;
+  ///  - When 'future' is null (as in the convenience moveNext() overload),
+  ///    blocks until a batch is available or the task is done.
+  ///  - When 'future' is non-null, does not block. Returns true with the batch
+  ///    in current() if one is ready. Otherwise returns false and either sets
+  ///    '*future' to a future realized when the caller should retry (more
+  ///    output may still arrive) or leaves '*future' invalid when the task is
+  ///    done. A valid future means "blocked", an invalid future means "done".
+  ///    A completed drain boundary also returns false with an invalid future;
+  ///    this protocol does not distinguish it from end-of-stream.
+  ///    Honors task cancellation (requestCancel()) by surfacing the task error
+  ///    on a subsequent call (parallel and serial cursors alike). The error
+  ///    path is the one exception to "does not block": before rethrowing, the
+  ///    call waits (bounded) for the task to terminate and its drivers to
+  ///    finish, so the executor outlives the drivers still using it.
+  ///
+  /// Single-consumer protocol: when a non-null call hands back a valid future,
+  /// the caller must wait on it before issuing the next moveNext(&future) call.
+  /// Re-entering with a blocked cursor throws (the prior future would otherwise
+  /// be stranded).
+  ///
+  /// Cursors that cannot suspend (e.g. interactive debugging cursors) ignore
+  /// 'future' and block, leaving it invalid.
+  ///
+  /// @return Returns false if the task is done producing output.
+  virtual bool moveNext(ContinueFuture* future) = 0;
+
+  /// Blocking convenience overload; equivalent to moveNext(nullptr).
+  bool moveNext() {
+    return moveNext(nullptr);
+  }
 
   /// Steps through execution, returning either the input to the next operator
   /// with a breakpoint installed, or the next task output. If no breakpoints

--- a/velox/exec/tests/CursorTest.cpp
+++ b/velox/exec/tests/CursorTest.cpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/Cursor.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+using namespace facebook::velox;
+
+namespace facebook::velox::exec::test {
+
+class CursorTest : public OperatorTestBase {
+ protected:
+  void SetUp() override {
+    OperatorTestBase::SetUp();
+    input_ = makeRowVector({
+        makeFlatVector<int64_t>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}),
+    });
+  }
+
+  void TearDown() override {
+    // Release the input before OperatorTestBase::TearDown() resets pool_.
+    input_.reset();
+    OperatorTestBase::TearDown();
+  }
+
+  RowVectorPtr input_;
+
+  CursorParameters makeParams(bool serialExecution) {
+    CursorParameters params;
+    params.planNode =
+        PlanBuilder()
+            .values(
+                {input_, input_, input_}, /*parallelizable=*/!serialExecution)
+            .planNode();
+    params.serialExecution = serialExecution;
+    return params;
+  }
+
+  // Drains a cursor through the non-blocking moveNext(future) protocol, waiting
+  // on the returned future whenever the cursor reports it is blocked. Returns
+  // the total number of output rows.
+  static int64_t drainAsync(TaskCursor& cursor) {
+    int64_t rows{0};
+    for (;;) {
+      ContinueFuture future = ContinueFuture::makeEmpty();
+      if (cursor.moveNext(&future)) {
+        rows += cursor.current()->size();
+        continue;
+      }
+      if (!future.valid()) {
+        break;
+      }
+      future.wait();
+    }
+    return rows;
+  }
+
+  static int64_t drainSync(TaskCursor& cursor) {
+    int64_t rows{0};
+    while (cursor.moveNext()) {
+      rows += cursor.current()->size();
+    }
+    return rows;
+  }
+};
+
+// The async drain protocol returns the same data as the blocking drain, for
+// both the parallel (multi-threaded) and serial cursors.
+TEST_F(CursorTest, asyncDrainParallel) {
+  auto cursor = TaskCursor::create(makeParams(/*serialExecution=*/false));
+  EXPECT_EQ(drainAsync(*cursor), 30);
+}
+
+TEST_F(CursorTest, asyncDrainSerial) {
+  auto cursor = TaskCursor::create(makeParams(/*serialExecution=*/true));
+  EXPECT_EQ(drainAsync(*cursor), 30);
+}
+
+TEST_F(CursorTest, asyncMatchesSync) {
+  auto syncCursor = TaskCursor::create(makeParams(/*serialExecution=*/false));
+  const int64_t syncRows = drainSync(*syncCursor);
+
+  auto asyncCursor = TaskCursor::create(makeParams(/*serialExecution=*/false));
+  EXPECT_EQ(drainAsync(*asyncCursor), syncRows);
+}
+
+// After the task is cancelled, the parallel cursor surfaces the error from
+// moveNext() rather than returning data. requestCancel().wait() makes the
+// terminal state deterministic before we pull.
+TEST_F(CursorTest, cancelSurfacesErrorParallel) {
+  auto cursor = TaskCursor::create(makeParams(/*serialExecution=*/false));
+  cursor->start();
+  cursor->task()->requestCancel().wait();
+
+  ContinueFuture future = ContinueFuture::makeEmpty();
+  VELOX_ASSERT_THROW(cursor->moveNext(&future), "Cancelled");
+}
+
+// The serial cursor surfaces the cancellation error too, rather than reporting
+// a terminated task as end-of-stream (false with an invalid future).
+TEST_F(CursorTest, cancelSurfacesErrorSerial) {
+  auto cursor = TaskCursor::create(makeParams(/*serialExecution=*/true));
+  cursor->start();
+  cursor->task()->requestCancel().wait();
+
+  ContinueFuture future = ContinueFuture::makeEmpty();
+  VELOX_ASSERT_THROW(cursor->moveNext(&future), "Cancelled");
+}
+
+} // namespace facebook::velox::exec::test


### PR DESCRIPTION
Summary:

Extends `TaskCursor::moveNext()` with an optional `ContinueFuture*` parameter, mirroring `Task::next(ContinueFuture*)`:

  - `moveNext(nullptr)` (the default) blocks until a batch is available or the task is done — unchanged behavior for all existing callers.
  - `moveNext(&future)` does not block: it returns true with the batch in `current()` if one is ready, otherwise returns false and either sets `*future` to a future realized when the caller should retry (a valid future means "blocked") or leaves it invalid when the task is done.

This lets a caller drive result iteration from a coroutine and compose a deadline / cancellation over the await, without a side thread, and surfaces task cancellation (`requestCancel()`) on the next call.

The polymorphic method is `moveNext(ContinueFuture*)` (no default argument, since Velox style avoids defaults on virtuals); a non-virtual `moveNext()` convenience overload forwards to it so existing callers are unchanged.

`TaskQueue::dequeue()` is replaced by `dequeue(ContinueFuture*)`, which returns the consumer future instead of waiting on it internally; the parallel and serial cursors' `moveNext()` loops build on it (the blocking path waits on the future in-line and is behaviorally unchanged). The interactive debugging cursors ignore the future and block.

The `moveNext` signature change is a breaking API change for any external `TaskCursor` subclass; it follows the existing `Task::next` idiom rather than adding a parallel method.

Reviewed By: xiaoxmeng, mbasmanova

Differential Revision: D109730079


