### PR TITLE
fix(fuzzer): Handle zero selected rows in ExpressionVerifier

### DIFF
--- a/velox/expression/tests/ExpressionVerifier.cpp
+++ b/velox/expression/tests/ExpressionVerifier.cpp
@@ -114,11 +114,16 @@ RowVectorPtr reduceToSelectedRows(
   if (rows.isAllSelected()) {
     return rowVector;
   }
+  // The fuzzer can generate a test case whose active rows select nothing.
+  // Return an empty RowVector so callers compare zero rows.
+  if (!rows.hasSelections()) {
+    return std::dynamic_pointer_cast<RowVector>(
+        BaseVector::create(rowVector->type(), 0, rowVector->pool()));
+  }
   BufferPtr indices = allocateIndices(rows.end(), rowVector->pool());
   auto rawIndices = indices->asMutable<vector_size_t>();
   vector_size_t cnt = 0;
   rows.applyToSelected([&](vector_size_t row) { rawIndices[cnt++] = row; });
-  VELOX_CHECK_GT(cnt, 0);
   indices->setSize(cnt * sizeof(vector_size_t));
   // Top level row vector is not expected to be encoded, therefore we copy
   // instead of wrapping in the indices.

--- a/velox/expression/tests/ExpressionVerifierUnitTest.cpp
+++ b/velox/expression/tests/ExpressionVerifierUnitTest.cpp
@@ -22,6 +22,7 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/FileSystems.h"
 #include "velox/common/testutil/TempDirectoryPath.h"
+#include "velox/exec/fuzzer/DuckQueryRunner.h"
 #include "velox/functions/Registerer.h"
 #include "velox/parse/ExpressionsParser.h"
 #include "velox/parse/TypeResolver.h"
@@ -155,6 +156,31 @@ TEST_F(ExpressionVerifierUnitTest, subsetOfRowsToVerify) {
     rows.updateBounds();
     verifier.verify({plan}, {{data, rows}}, nullptr, false);
   }
+}
+
+TEST_F(ExpressionVerifierUnitTest, emptyActiveRowsWithReferenceRunner) {
+  // When no rows are selected, the reference-runner path reduces both the input
+  // and the result to zero rows and verifies the empty result against the
+  // reference DB.
+  auto referenceRunner =
+      std::make_shared<exec::test::DuckQueryRunner>(pool_.get());
+  ExpressionVerifierOptions options;
+  ExpressionVerifier verifier{&execCtx_, options, referenceRunner};
+
+  auto data = makeRowVector({makeFlatVector<int32_t>({1, 2, 3})});
+  auto plan = parseExpression("c0", asRowType(data->type()));
+
+  SelectivityVector emptyRows(data->size());
+  emptyRows.clearAll();
+  ASSERT_FALSE(emptyRows.hasSelections());
+
+  auto states =
+      verifier.verify({plan}, {{data, emptyRows}}, nullptr, /*canThrow=*/false)
+          .second;
+  ASSERT_EQ(states.size(), 1);
+  EXPECT_EQ(
+      states[0],
+      ExpressionVerifier::VerificationState::kVerifiedAgainstReference);
 }
 
 } // namespace facebook::velox::test


### PR DESCRIPTION
Summary:
The expression fuzzer aborts when a test case selects no active rows.
`ExpressionFuzzerVerifier` randomly deselects input rows, so it can hand
the verifier a selection that is not all-selected yet has nothing selected. On
the reference-runner path the verifier reduces the input to its selected
rows via `reduceToSelectedRows`, which required at least one selected
row and aborted with:

    Expression: cnt > 0 (0 vs. 0), Function: reduceToSelectedRows, Source: RUNTIME

E.g., https://github.com/facebookincubator/velox/actions/runs/27915037882/job/82600203113?pr=17860

`reduceToSelectedRows` now returns an empty `RowVector` when no
rows are selected. The input and the result both reduce to zero rows and
verify as empty against the reference DB instead of crashing.

Reviewed By: bikramSingh91

Differential Revision: D109389034


