### PR TITLE
build(cxl): Add the VELOX_ENABLE_CXL build flag

### DIFF
--- a/.github/scripts/cmake-flags.sh
+++ b/.github/scripts/cmake-flags.sh
@@ -96,6 +96,11 @@ ubuntu-debug | ubuntu-bundled-deps)
   if [[ ${USE_CLANG:-false} != "true" ]]; then
     CMAKE_FLAGS+=(-DVELOX_ENABLE_FAISS=ON)
   fi
+  if [[ $BUILD_PROFILE == "ubuntu-debug" ]]; then
+    # libnuma is baked into the velox-dev:ubuntu-22.04 image. ubuntu-bundled-deps
+    # runs on a bare runner that doesn't install it, so it can't enable CXL.
+    CMAKE_FLAGS+=(-DVELOX_ENABLE_CXL=ON)
+  fi
   if [[ $BUILD_PROFILE == "ubuntu-debug" && ${USE_CLANG:-false} != "true" ]]; then
     # REMOTE_FUNCTIONS pulls in fbthrift / fizz / wangle / mvfst, which
     # velox doesn't bundle. ubuntu-debug runs in the velox-dev container
@@ -111,6 +116,8 @@ fedora-debug)
     -DVELOX_ENABLE_PARQUET=ON
     -DVELOX_ENABLE_EXAMPLES=ON
     -DVELOX_ENABLE_FAISS=ON
+    # libnuma is baked into the velox-dev:fedora image.
+    -DVELOX_ENABLE_CXL=ON
   )
   ;;
 

--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -594,6 +594,7 @@ jobs:
           source scripts/setup-ubuntu.sh
           install_apt_deps
           install_faiss_deps
+          install_cxl_deps
           # We can remove them once we bundle FBThrift.
           install_fmt
           install_boost
@@ -820,6 +821,11 @@ jobs:
       - name: Clear CCache Statistics
         run: |
           ccache -sz
+
+      - name: Install CXL Dependencies
+        run: |
+          source scripts/setup-fedora.sh
+          install_cxl_deps
 
       - name: Make Debug Build
         id: build

--- a/CMake/FindNuma.cmake
+++ b/CMake/FindNuma.cmake
@@ -1,0 +1,39 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# - Try to find libnuma
+# Once done, this will define
+#
+# Numa_FOUND - system has libnuma
+# Numa::numa - imported target for the numa library and headers
+
+include(FindPackageHandleStandardArgs)
+
+find_library(NUMA_LIBRARY numa PATHS ${NUMA_LIBRARYDIR})
+find_path(NUMA_INCLUDE_DIR numa.h PATHS ${NUMA_INCLUDEDIR})
+
+find_package_handle_standard_args(Numa DEFAULT_MSG NUMA_LIBRARY NUMA_INCLUDE_DIR)
+
+mark_as_advanced(NUMA_LIBRARY NUMA_INCLUDE_DIR)
+
+if(Numa_FOUND AND NOT TARGET Numa::numa)
+  add_library(Numa::numa UNKNOWN IMPORTED)
+  set_target_properties(
+    Numa::numa
+    PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${NUMA_INCLUDE_DIR}"
+      IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+      IMPORTED_LOCATION "${NUMA_LIBRARY}"
+  )
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,7 @@ option(
 option(VELOX_SIMDJSON_SKIPUTF8VALIDATION "Skip simdjson utf8 validation in JSON parsing" OFF)
 option(VELOX_ENABLE_FAISS "Build faiss vector search support" OFF)
 option(VELOX_ENABLE_TORCHWAVE "Build TorchWave experimental subsystem." OFF)
+option(VELOX_ENABLE_CXL "Build CXL experimental memory subsystem (Linux only)." OFF)
 
 # Explicitly force compilers to generate colored output. Compilers usually do
 # this by default if they detect the output is a terminal, but this assumption
@@ -334,6 +335,15 @@ if(VELOX_ENABLE_S3)
   endif()
   find_package(AWSSDK 1.11.654 REQUIRED COMPONENTS s3;identity-management)
   add_definitions(-DVELOX_ENABLE_S3)
+endif()
+
+if(VELOX_ENABLE_CXL AND NOT (UNIX AND NOT APPLE))
+  # libnuma's numa_tonode_memory page binding is unavailable off Linux.
+  message(STATUS "VELOX_ENABLE_CXL is only supported on Linux; forcing OFF.")
+  set(VELOX_ENABLE_CXL OFF)
+endif()
+if(VELOX_ENABLE_CXL)
+  add_compile_definitions(VELOX_ENABLE_CXL)
 endif()
 
 if(VELOX_ENABLE_ABFS)

--- a/scripts/setup-centos9.sh
+++ b/scripts/setup-centos9.sh
@@ -73,7 +73,7 @@ function install_velox_deps_from_dnf {
   dnf_install libevent-devel \
     openssl-devel re2-devel libzstd-devel lz4-devel double-conversion-devel \
     libdwarf-devel elfutils-libelf-devel curl-devel libicu-devel bison flex \
-    libsodium-devel zlib-devel gtest-devel gmock-devel xxhash-devel numactl-devel
+    libsodium-devel zlib-devel gtest-devel gmock-devel xxhash-devel
 
   install_faiss_deps
 }
@@ -96,6 +96,10 @@ function install_gflags {
 
 function install_faiss_deps {
   dnf_install openblas-devel libomp
+}
+
+function install_cxl_deps {
+  dnf_install numactl-devel
 }
 
 function install_velox_deps {

--- a/scripts/setup-fedora.sh
+++ b/scripts/setup-fedora.sh
@@ -61,8 +61,7 @@ function install_velox_deps_from_dnf {
     elfutils-libelf-devel flex gflags-devel glog-devel gmock-devel \
     gtest-devel libdwarf-devel libevent-devel libicu-devel \
     libsodium-devel libzstd-devel lz4-devel openssl-devel-engine \
-    re2-devel snappy-devel xxhash-devel zlib-devel grpc-devel grpc-plugins \
-    numactl-devel
+    re2-devel snappy-devel xxhash-devel zlib-devel grpc-devel grpc-plugins
 
   install_faiss_deps
 }

--- a/scripts/setup-manylinux.sh
+++ b/scripts/setup-manylinux.sh
@@ -68,7 +68,11 @@ function install_velox_deps_from_dnf {
   dnf_install libevent-devel \
     openssl-devel re2-devel libzstd-devel lz4-devel double-conversion-devel \
     libdwarf-devel elfutils-libelf-devel curl-devel libicu-devel bison flex \
-    libsodium-devel zlib-devel gtest-devel gmock-devel xxhash-devel numactl-devel
+    libsodium-devel zlib-devel gtest-devel gmock-devel xxhash-devel
+}
+
+function install_cxl_deps {
+  dnf_install numactl-devel
 }
 
 function install_conda {

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -126,7 +126,6 @@ function install_velox_deps_from_apt {
     flex \
     libfl-dev \
     tzdata \
-    libnuma-dev \
     libxxhash-dev
 }
 
@@ -228,6 +227,10 @@ function install_adapters {
 
 function install_faiss_deps {
   ${SUDO} apt-get install -y libopenblas-dev libomp-dev
+}
+
+function install_cxl_deps {
+  ${SUDO} apt install -y libnuma-dev
 }
 
 function install_velox_deps {

--- a/velox/CMakeLists.txt
+++ b/velox/CMakeLists.txt
@@ -82,6 +82,10 @@ if(VELOX_ENABLE_TORCHWAVE)
   add_subdirectory(experimental/torchwave)
 endif()
 
+if(VELOX_ENABLE_CXL)
+  add_subdirectory(experimental/cxl)
+endif()
+
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tool)
 endif()

--- a/velox/experimental/cxl/CMakeLists.txt
+++ b/velox/experimental/cxl/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# CXL experimental memory subsystem.
+# This validates that libnuma is discoverable when VELOX_ENABLE_CXL is enabled.
+find_package(Numa REQUIRED)
+
+velox_add_library(velox_experimental_cxl INTERFACE HEADERS CxlMemoryResource.h)

--- a/velox/experimental/cxl/CxlMemoryResource.h
+++ b/velox/experimental/cxl/CxlMemoryResource.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace facebook::velox::cxl {
+
+// Placeholder for the CXL memory resource.
+
+} // namespace facebook::velox::cxl


### PR DESCRIPTION
Second of the four PRs splitting #17856 (see #17908 for the overall plan).

Adds the `VELOX_ENABLE_CXL` CMake flag (off by default, Linux only) that gates the experimental CXL memory subsystem under `velox/experimental/cxl`. A new `CMake/FindNuma.cmake` locates libnuma, and `find_package(Numa)` validates it is available at configure time when the flag is on. The subsystem is header-only for now, so nothing links libnuma yet.

Per the review on #17909, libnuma is no longer a core dependency: `numactl-devel` / `libnuma-dev` move out of the default installer lists into an on-demand `install_cxl_deps`, installed only where CXL is built. The `ubuntu-debug` and `fedora-debug` CI jobs enable the flag and install libnuma at job time, keeping it out of the shared dev images and the Python wheels.

The allocator and the libnuma link follow in later PRs.

cc @kgpai