### PR TITLE
feat: Make Spark avg aggregate ANSI-compliant via config-based pattern

### DIFF
--- a/velox/functions/sparksql/aggregates/AverageAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/AverageAggregate.cpp
@@ -16,9 +16,11 @@
 
 #include "velox/functions/sparksql/aggregates/AverageAggregate.h"
 #include "velox/functions/lib/aggregates/AverageAggregateBase.h"
+#include "velox/functions/sparksql/SparkQueryConfig.h"
 #include "velox/functions/sparksql/aggregates/DecimalAverageAggregate.h"
 
 using namespace facebook::velox::functions::aggregate;
+using facebook::velox::functions::sparksql::SparkQueryConfig;
 
 namespace facebook::velox::functions::aggregate::sparksql {
 namespace {
@@ -85,6 +87,7 @@ TypePtr getAvgResultType(const TypePtr& rawInputType) {
       std::min<uint8_t>(LongDecimalType::kMaxPrecision, s + 4));
 }
 
+template <bool throwOnOverflow = false>
 std::unique_ptr<exec::Aggregate> getDecimalAverageAggregate(
     core::AggregationNode::Step step,
     const std::vector<TypePtr>& argTypes,
@@ -95,15 +98,16 @@ std::unique_ptr<exec::Aggregate> getDecimalAverageAggregate(
   if (inputType->isShortDecimal()) {
     if (avgType->isShortDecimal()) {
       return std::make_unique<exec::SimpleAggregateAdapter<
-          DecimalAverageAggregate<int64_t, int64_t>>>(
+          DecimalAverageAggregate<int64_t, int64_t, throwOnOverflow>>>(
           step, argTypes, resultType);
     }
     return std::make_unique<exec::SimpleAggregateAdapter<
-        DecimalAverageAggregate<int64_t, int128_t>>>(
+        DecimalAverageAggregate<int64_t, int128_t, throwOnOverflow>>>(
         step, argTypes, resultType);
   }
   return std::make_unique<exec::SimpleAggregateAdapter<
-      DecimalAverageAggregate<int128_t, int128_t>>>(step, argTypes, resultType);
+      DecimalAverageAggregate<int128_t, int128_t, throwOnOverflow>>>(
+      step, argTypes, resultType);
 }
 
 } // namespace
@@ -151,11 +155,14 @@ exec::AggregateRegistrationResult registerAverage(
           core::AggregationNode::Step step,
           const std::vector<TypePtr>& argTypes,
           const TypePtr& resultType,
-          const core::QueryConfig& /*config*/)
-          -> std::unique_ptr<exec::Aggregate> {
+          const core::QueryConfig& config) -> std::unique_ptr<exec::Aggregate> {
         VELOX_CHECK_LE(
             argTypes.size(), 1, "{} takes at most one argument", name);
         const auto& inputType = argTypes[0];
+        // When Spark ANSI mode is enabled, decimal AVG throws on overflow
+        // instead of returning null. Only the decimal paths can overflow;
+        // integer/floating-point AVG widens to DOUBLE and cannot overflow.
+        const bool ansiEnabled = SparkQueryConfig{config}.ansiEnabled();
         if (exec::isRawInput(step)) {
           switch (inputType->kind()) {
             case TypeKind::SMALLINT:
@@ -178,14 +185,20 @@ exec::AggregateRegistrationResult registerAverage(
                 // will always be a long decimal. We can directly assume that
                 // the physical type of the intermediate sum is int128_t.
                 VELOX_USER_CHECK_GT(precision, 11);
-                return getDecimalAverageAggregate(step, argTypes, resultType);
+                return ansiEnabled ? getDecimalAverageAggregate<true>(
+                                         step, argTypes, resultType)
+                                   : getDecimalAverageAggregate<false>(
+                                         step, argTypes, resultType);
               }
               return std::make_unique<
                   AverageAggregate<int64_t, double, double>>(resultType);
             }
             case TypeKind::HUGEINT: {
               if (inputType->isLongDecimal()) {
-                return getDecimalAverageAggregate(step, argTypes, resultType);
+                return ansiEnabled ? getDecimalAverageAggregate<true>(
+                                         step, argTypes, resultType)
+                                   : getDecimalAverageAggregate<false>(
+                                         step, argTypes, resultType);
               }
               VELOX_NYI();
             }
@@ -210,6 +223,13 @@ exec::AggregateRegistrationResult registerAverage(
             case TypeKind::DOUBLE:
             case TypeKind::ROW:
               if (inputType->childAt(0)->isDecimal()) {
+                if (ansiEnabled) {
+                  return std::make_unique<
+                      exec::SimpleAggregateAdapter<DecimalAverageAggregate<
+                          int128_t /*unused*/,
+                          int128_t /*unused*/,
+                          true>>>(step, argTypes, resultType);
+                }
                 return std::make_unique<
                     exec::SimpleAggregateAdapter<DecimalAverageAggregate<
                         int128_t /*unused*/,
@@ -219,11 +239,25 @@ exec::AggregateRegistrationResult registerAverage(
                   AverageAggregate<int64_t, double, double>>(resultType);
             case TypeKind::BIGINT:
               VELOX_USER_CHECK(resultType->isShortDecimal());
+              if (ansiEnabled) {
+                return std::make_unique<
+                    exec::SimpleAggregateAdapter<DecimalAverageAggregate<
+                        int64_t /*unused*/,
+                        int64_t,
+                        true>>>(step, argTypes, resultType);
+              }
               return std::make_unique<exec::SimpleAggregateAdapter<
                   DecimalAverageAggregate<int64_t /*unused*/, int64_t>>>(
                   step, argTypes, resultType);
             case TypeKind::HUGEINT:
               VELOX_USER_CHECK(resultType->isLongDecimal());
+              if (ansiEnabled) {
+                return std::make_unique<
+                    exec::SimpleAggregateAdapter<DecimalAverageAggregate<
+                        int128_t /*unused*/,
+                        int128_t,
+                        true>>>(step, argTypes, resultType);
+              }
               return std::make_unique<exec::SimpleAggregateAdapter<
                   DecimalAverageAggregate<int128_t /*unused*/, int128_t>>>(
                   step, argTypes, resultType);

--- a/velox/functions/sparksql/aggregates/tests/AverageAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/AverageAggregationTest.cpp
@@ -15,12 +15,17 @@
  */
 #include <folly/init/Init.h>
 
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
+#include "velox/functions/sparksql/SparkQueryConfig.h"
 #include "velox/functions/sparksql/aggregates/Register.h"
+#include "velox/type/DecimalUtil.h"
 
 using namespace facebook::velox::exec::test;
 using namespace facebook::velox::functions::aggregate::test;
+using facebook::velox::functions::sparksql::SparkQueryConfig;
 
 namespace facebook::velox::functions::aggregate::sparksql::test {
 
@@ -356,6 +361,53 @@ TEST_F(AverageAggregationTest, avgDecimalCompanionMergeExtract) {
   auto expected = makeRowVector(
       {makeFlatVector<int64_t>(std::vector<int64_t>{2000000}, DECIMAL(16, 5))});
   AssertQueryBuilder(plan).assertResults(expected);
+}
+
+// Decimal avg with ANSI mode enabled throws on overflow instead of NULL.
+TEST_F(AverageAggregationTest, decimalAvgOverflowAnsi) {
+  std::vector<int128_t> rawVector;
+  for (int i = 0; i < 10; ++i) {
+    rawVector.push_back(DecimalUtil::kLongDecimalMax);
+  }
+  auto input =
+      makeRowVector({makeFlatVector<int128_t>(rawVector, DECIMAL(38, 0))});
+  auto plan = PlanBuilder()
+                  .values({input})
+                  .singleAggregation({}, {"spark_avg(c0)"})
+                  .planNode();
+
+  // ANSI enabled: throws.
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan)
+          .config(
+              SparkQueryConfig::qualify(SparkQueryConfig::kAnsiEnabled), "true")
+          .copyResults(pool()),
+      "Decimal overflow in average");
+
+  // ANSI disabled (default): returns NULL on overflow.
+  auto expectedNull = makeRowVector({makeNullableFlatVector(
+      std::vector<std::optional<int128_t>>{std::nullopt}, DECIMAL(38, 4))});
+  AssertQueryBuilder(plan)
+      .config(
+          SparkQueryConfig::qualify(SparkQueryConfig::kAnsiEnabled), "false")
+      .assertResults({expectedNull});
+}
+
+// Decimal avg with normal values produces the same result regardless of ANSI.
+TEST_F(AverageAggregationTest, decimalAvgNormalAnsi) {
+  auto input =
+      makeRowVector({makeFlatVector<int64_t>({100, 200, 300}, DECIMAL(12, 1))});
+  int64_t kRescale = 10000;
+  auto expected =
+      makeRowVector({makeConstant<int64_t>(200 * kRescale, 1, DECIMAL(16, 5))});
+  auto plan = PlanBuilder()
+                  .values({input})
+                  .singleAggregation({}, {"spark_avg(c0)"})
+                  .planNode();
+  // ANSI on: normal values are unchanged.
+  AssertQueryBuilder(plan)
+      .config(SparkQueryConfig::qualify(SparkQueryConfig::kAnsiEnabled), "true")
+      .assertResults({expected});
 }
 
 } // namespace


### PR DESCRIPTION
Adopt the same config-based pattern used for Spark abs (#14346), unaryminus (#16672), and remainder (#17885) instead of introducing a separate checked_avg aggregate function:

- registerAverage lambda now reads SparkQueryConfig{config}.ansiEnabled() and dispatches to DecimalAverageAggregate<..., throwOnOverflow=true> when ANSI is on, or <..., throwOnOverflow=false> otherwise.
- The throwOnOverflow template parameter on DecimalAverageAggregate controls whether writeFinalResult throws via VELOX_USER_FAIL ("Decimal overflow in average") or returns false (NULL) on overflow.

Only decimal AVG paths can overflow; integer/floating-point AVG widens to DOUBLE and never throws, so the ANSI check is scoped to the decimal dispatches only.

Removes the separate registerCheckedAverage function and the "checked_avg" registration. Replaces the checked_avg tests with config-driven tests on the unified avg function (decimalAvgOverflowAnsi exercises both modes; decimalAvgNormalAnsi verifies no false-positives with ANSI on).

Addresses review feedback on #16439 from @rui-mo (same pattern as applied for remainder in #17885).