### PR TITLE
feat: Vectorized hash re-aggregation for HashAggregation spill recovery

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -577,6 +577,20 @@ class QueryConfig {
       true,
       "Enable aggregation spilling. Requires spill_enabled.")
 
+  /// When true, aggregation spilling skips the spill-time sort and recovers
+  /// each spill partition by reading it with an unordered reader and
+  /// re-aggregating it through a hash table (vectorized), instead of the
+  /// row-by-row ordered (sorted) merge. This holds one spill partition in
+  /// memory at a time. Only applies to non-distinct aggregations without
+  /// sorted/distinct aggregates.
+  VELOX_QUERY_CONFIG(
+      kAggregationSpillHashRecoveryEnabled,
+      aggregationSpillHashRecoveryEnabled,
+      "aggregation_spill_hash_recovery_enabled",
+      bool,
+      false,
+      "Enable aggregation spilling hash recovery. Requires spill_enabled.")
+
   /// Join spilling flag, only applies if "spill_enabled" flag is set.
   VELOX_QUERY_CONFIG(
       kJoinSpillEnabled,

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -1085,7 +1085,10 @@ void GroupingSet::ensureOutputFits() {
 }
 
 RowTypePtr GroupingSet::makeSpillType() const {
-  auto rows = table_->rows();
+  return makeSpillType(table_->rows());
+}
+
+RowTypePtr GroupingSet::makeSpillType(const RowContainer* rows) const {
   auto types = rows->keyTypes();
 
   for (const auto& accumulator : rows->accumulators()) {
@@ -1138,7 +1141,11 @@ void GroupingSet::spill() {
                 spillConfig_->numPartitionBits)),
         sortingKeys,
         spillConfig_,
-        spillStats_);
+        spillStats_,
+        // When hash recovery is used, spilled runs do not need to be sorted:
+        // the data is read back unordered and re-aggregated through a hash
+        // table. This removes the spill-time sort.
+        /*needSort=*/!useHashRecovery());
   }
   // Spilling may execute on multiple partitions in parallel, and
   // HashStringAllocator is not thread safe. If any aggregations
@@ -1234,28 +1241,334 @@ bool GroupingSet::getOutputWithSpill(
       return false;
     }
   }
-  VELOX_CHECK_NOT_NULL(merge_);
+  // Spill output may already be fully produced (e.g. a redundant getOutput()
+  // call after completion). Guard against re-entering the merge with no active
+  // partition.
+  if (merge_ == nullptr && !currentPartitionHashRecovery_) {
+    return false;
+  }
   return mergeNext(maxOutputRows, maxOutputBytes, result);
 }
 
 bool GroupingSet::prepareNextSpillPartitionOutput() {
-  VELOX_CHECK_EQ(merge_ == nullptr, outputSpillPartition_ == -1);
   merge_ = nullptr;
-  if (spillPartitionSet_.empty()) {
+  currentPartitionHashRecovery_ = false;
+
+  // Process recursively re-spilled sub-partitions (deeper levels) first so the
+  // working set of open spill files stays small.
+  if (!recoveryWorkStack_.empty()) {
+    auto item = std::move(recoveryWorkStack_.back());
+    recoveryWorkStack_.pop_back();
+    outputSpillPartition_ = item.partition->id().partitionNumber();
+    startHashRecovery(*item.partition, item.respillStartBit);
+    return true;
+  }
+
+  while (!spillPartitionSet_.empty()) {
+    auto it = spillPartitionSet_.begin();
+    outputSpillPartition_ = it->first.partitionNumber();
+    if (useHashRecovery()) {
+      // Top-level partitions written by the input spiller are partitioned with
+      // bits [startPartitionBit, startPartitionBit + numPartitionBits), so a
+      // recursive re-spill must advance past them. The output spiller writes a
+      // single, unpartitioned partition and therefore re-spills from the base
+      // bit.
+      const uint8_t respillStartBit = inputSpiller_ != nullptr
+          ? static_cast<uint8_t>(
+                spillConfig_->startPartitionBit +
+                spillConfig_->numPartitionBits)
+          : spillConfig_->startPartitionBit;
+      startHashRecovery(*it->second, respillStartBit);
+      spillPartitionSet_.erase(it);
+      return true;
+    }
+    merge_ = it->second->createOrderedReader(*spillConfig_, pool_, spillStats_);
+    spillPartitionSet_.erase(it);
+    // 'createOrderedReader' returns null for an empty partition (no spill
+    // files). Skip it and move on to keep the postcondition: when this returns
+    // true, exactly one of 'merge_' / 'currentPartitionHashRecovery_' is set.
+    if (merge_ != nullptr) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool GroupingSet::useHashRecovery() const {
+  if (!queryConfig_->aggregationSpillHashRecoveryEnabled()) {
     return false;
   }
-  auto it = spillPartitionSet_.begin();
-  VELOX_CHECK_NE(outputSpillPartition_, it->first.partitionNumber());
-  outputSpillPartition_ = it->first.partitionNumber();
-  merge_ = it->second->createOrderedReader(*spillConfig_, pool_, spillStats_);
-  spillPartitionSet_.erase(it);
+  // Hash recovery only supports plain group-by aggregates. Distinct hash
+  // aggregation, and sorted/distinct aggregates, rely on the ordered merge to
+  // collocate equal keys, so they stay on the existing sorted path.
+  if (isDistinct() || sortedAggregations_ != nullptr) {
+    return false;
+  }
+  for (const auto& distinctAgg : distinctAggregations_) {
+    if (distinctAgg != nullptr) {
+      return false;
+    }
+  }
   return true;
+}
+
+void GroupingSet::startHashRecovery(
+    SpillPartition& partition,
+    uint8_t respillStartBit) {
+  // Build hashers over the spilled key columns, which occupy channels
+  // [0, numKeys) of the spill row (see makeSpillType()).
+  const auto& keyTypes = mergeRows_->keyTypes();
+  std::vector<std::unique_ptr<VectorHasher>> hashers;
+  hashers.reserve(keyTypes.size());
+  for (column_index_t i = 0; i < keyTypes.size(); ++i) {
+    hashers.push_back(VectorHasher::create(keyTypes[i], i));
+  }
+  if (ignoreNullKeys_) {
+    recoveryTable_ = HashTable<true>::createForAggregation(
+        std::move(hashers), accumulators(false), pool_);
+  } else {
+    recoveryTable_ = HashTable<false>::createForAggregation(
+        std::move(hashers), accumulators(false), pool_);
+  }
+  initializeAggregates(aggregates_, *recoveryTable_->rows(), false);
+  recoveryLookup_ =
+      std::make_unique<HashLookup>(recoveryTable_->hashers(), pool_);
+
+  recoveryReader_ = partition.createUnorderedReader(
+      spillConfig_->readBufferSize, pool_, spillStats_);
+  recoveryResultIterator_ = RowContainerIterator{};
+  hashRecoveryDrained_ = false;
+  currentPartitionHashRecovery_ = true;
+  currentRespillStartBit_ = respillStartBit;
+  recoverySpiller_.reset();
+  recoveryRespilling_ = false;
+}
+
+void GroupingSet::addSpillBatchToHashRecovery(const RowVectorPtr& batch) {
+  const auto numRows = batch->size();
+  if (numRows == 0) {
+    return;
+  }
+  activeRows_.resize(numRows);
+  activeRows_.setAll();
+
+  recoveryTable_->prepareForGroupProbe(
+      *recoveryLookup_,
+      batch,
+      activeRows_,
+      BaseHashTable::kNoSpillInputStartPartitionBit);
+  recoveryTable_->groupProbe(
+      *recoveryLookup_, BaseHashTable::kNoSpillInputStartPartitionBit);
+
+  auto* groups = recoveryLookup_->hits.data();
+  const auto& newGroups = recoveryLookup_->newGroups;
+  const auto numKeys = mergeRows_->keyTypes().size();
+
+  std::vector<VectorPtr> args(1);
+  for (auto i = 0; i < aggregates_.size(); ++i) {
+    auto& function = aggregates_[i].function;
+    if (!newGroups.empty()) {
+      function->initializeNewGroups(groups, newGroups);
+    }
+    args[0] = batch->childAt(i + numKeys);
+    function->addIntermediateResults(groups, activeRows_, args, false);
+  }
+}
+
+bool GroupingSet::mergeNextWithHashRecovery(
+    int32_t maxOutputRows,
+    int32_t maxOutputBytes,
+    const RowVectorPtr& result) {
+  for (;;) {
+    VELOX_CHECK(currentPartitionHashRecovery_);
+    if (!hashRecoveryDrained_) {
+      RowVectorPtr batch;
+      while (recoveryReader_->nextBatch(batch)) {
+        // Re-spill the partially built recovery table when it no longer fits in
+        // memory, so the partition is processed recursively at a finer
+        // granularity instead of risking an OOM during output.
+        if (recoveryShouldRespill(batch)) {
+          respillRecoveryTable();
+        }
+        addSpillBatchToHashRecovery(batch);
+      }
+      hashRecoveryDrained_ = true;
+      recoveryResultIterator_ = RowContainerIterator{};
+
+      if (recoveryRespilling_) {
+        // This partition was recursively re-spilled into sub-partitions and
+        // produces no direct output. Finalize the sub-partitions, release the
+        // partition state, and advance to process them (or the next partition).
+        finalizeRecoveryRespill();
+        finishHashRecoveryPartition();
+        if (!prepareNextSpillPartitionOutput()) {
+          return false;
+        }
+        return mergeNext(maxOutputRows, maxOutputBytes, result);
+      }
+    }
+
+    // @lint-ignore CLANGTIDY
+    std::vector<char*> groups(maxOutputRows);
+    const int32_t numGroups = recoveryTable_->rows()->listRows(
+        &recoveryResultIterator_, maxOutputRows, maxOutputBytes, groups.data());
+    if (numGroups > 0) {
+      extractGroups(
+          recoveryTable_->rows(),
+          folly::Range<char**>(groups.data(), numGroups),
+          result);
+      return true;
+    }
+
+    // Current partition is fully extracted; release it and advance.
+    finishHashRecoveryPartition();
+    if (!prepareNextSpillPartitionOutput()) {
+      return false;
+    }
+    // The next partition may use ordered merge or hash recovery; dispatch
+    // centrally so the right reader is used.
+    return mergeNext(maxOutputRows, maxOutputBytes, result);
+  }
+}
+
+void GroupingSet::finishHashRecoveryPartition() {
+  recoveryReader_.reset();
+  recoveryLookup_.reset();
+  if (recoveryTable_ != nullptr) {
+    recoveryTable_->clear(/*freeTable=*/true);
+    recoveryTable_.reset();
+  }
+  recoverySpiller_.reset();
+  recoveryRespilling_ = false;
+  recoveryResultIterator_ = RowContainerIterator{};
+  hashRecoveryDrained_ = false;
+  currentPartitionHashRecovery_ = false;
+  // Return any memory freed by clearing the recovery table back to the
+  // arbitrator.
+  pool_->release();
+}
+
+bool GroupingSet::recoveryShouldRespill(const RowVectorPtr& batch) {
+  VELOX_CHECK_NOT_NULL(recoveryTable_);
+  if (recoveryTable_->numDistinct() == 0) {
+    return false;
+  }
+  // Cannot descend below the configured spill level limit. Keep accumulating in
+  // memory (best effort) to preserve correctness; this matches HashBuild which
+  // also disables further spilling at the deepest level.
+  if (spillConfig_->exceedSpillLevelLimit(currentRespillStartBit_)) {
+    return false;
+  }
+
+  // Test-only deterministic re-spill trigger.
+  if (testingTriggerSpill(pool_->name())) {
+    return true;
+  }
+
+  // The decision below mirrors ensureInputFits(): try to reserve enough memory
+  // to absorb 'batch'; if the reservation cannot be grown, re-spill instead of
+  // risking an OOM during output (where reclaim is a no-op).
+  auto* rows = recoveryTable_->rows();
+  const auto [freeRows, outOfLineFreeBytes] = rows->freeSpace();
+  const auto outOfLineBytes =
+      rows->stringAllocator().retainedSize() - outOfLineFreeBytes;
+  const int64_t flatBytes = batch->estimateFlatSize();
+
+  const auto currentUsage = pool_->usedBytes();
+  const auto minReservationBytes =
+      currentUsage * spillConfig_->minSpillableReservationPct / 100;
+  const auto availableReservationBytes = pool_->availableReservation();
+  const auto tableIncrementBytes =
+      recoveryTable_->hashTableSizeIncrease(batch->size());
+  const auto incrementBytes =
+      rows->sizeIncrement(batch->size(), outOfLineBytes ? flatBytes * 2 : 0) +
+      tableIncrementBytes;
+
+  if (availableReservationBytes >= minReservationBytes) {
+    if ((tableIncrementBytes == 0) && (freeRows > batch->size()) &&
+        (outOfLineBytes == 0 || outOfLineFreeBytes >= flatBytes * 2)) {
+      return false;
+    }
+    if (availableReservationBytes > 2 * incrementBytes) {
+      return false;
+    }
+  }
+
+  const auto targetIncrementBytes = std::max<int64_t>(
+      incrementBytes * 2,
+      currentUsage * spillConfig_->spillableReservationGrowthPct / 100);
+  {
+    memory::ReclaimableSectionGuard guard(nonReclaimableSection_);
+    if (pool_->maybeReserve(targetIncrementBytes)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+void GroupingSet::respillRecoveryTable() {
+  VELOX_CHECK_NOT_NULL(recoveryTable_);
+  auto* rows = recoveryTable_->rows();
+  if (rows->numRows() == 0) {
+    return;
+  }
+  if (recoverySpiller_ == nullptr) {
+    const auto numBits = spillConfig_->numPartitionBits;
+    const auto sortingKeys = SpillState::makeSortingKeys(
+        std::vector<CompareFlags>(rows->keyTypes().size()));
+    recoverySpiller_ = std::make_unique<AggregationInputSpiller>(
+        rows,
+        makeSpillType(rows),
+        HashBitRange(
+            currentRespillStartBit_,
+            static_cast<uint8_t>(currentRespillStartBit_ + numBits)),
+        sortingKeys,
+        spillConfig_,
+        spillStats_,
+        /*needSort=*/false);
+  }
+  rows->stringAllocator().freezeAndExecute(
+      [&]() { recoverySpiller_->spill(); });
+  recoveryTable_->clear(/*freeTable=*/true);
+  recoveryRespilling_ = true;
+  // Return the memory freed by clearing the table so subsequent draining can
+  // reuse it.
+  pool_->release();
+}
+
+void GroupingSet::finalizeRecoveryRespill() {
+  VELOX_CHECK(recoveryRespilling_);
+  VELOX_CHECK_NOT_NULL(recoverySpiller_);
+
+  // Spill rows accumulated since the last re-spill so the entire partition ends
+  // up in the sub-partitions and no key is split between memory and disk.
+  if (recoveryTable_ != nullptr && recoveryTable_->rows()->numRows() > 0) {
+    auto* rows = recoveryTable_->rows();
+    rows->stringAllocator().freezeAndExecute(
+        [&]() { recoverySpiller_->spill(); });
+    recoveryTable_->clear(/*freeTable=*/true);
+  }
+
+  SpillPartitionSet subPartitions;
+  recoverySpiller_->finishSpill(subPartitions);
+  removeEmptyPartitions(subPartitions);
+
+  const auto childRespillStartBit = static_cast<uint8_t>(
+      currentRespillStartBit_ + spillConfig_->numPartitionBits);
+  for (auto& [id, partition] : subPartitions) {
+    recoveryWorkStack_.push_back(
+        RecoveryPartition{std::move(partition), childRespillStartBit});
+  }
+  recoverySpiller_.reset();
 }
 
 bool GroupingSet::mergeNext(
     int32_t maxOutputRows,
     int32_t maxOutputBytes,
     const RowVectorPtr& result) {
+  if (currentPartitionHashRecovery_) {
+    return mergeNextWithHashRecovery(maxOutputRows, maxOutputBytes, result);
+  }
   if (isDistinct()) {
     return mergeNextWithoutAggregates(maxOutputRows, result);
   } else {
@@ -1285,8 +1598,9 @@ bool GroupingSet::mergeNextWithAggregates(
         VELOX_CHECK_NULL(merge_);
         return false;
       }
-      VELOX_CHECK_NOT_NULL(merge_);
-      continue;
+      // The next partition may use ordered merge or hash recovery; dispatch
+      // centrally so the right reader is used.
+      return mergeNext(maxOutputRows, maxOutputBytes, result);
     }
     if (!nextKeyIsEqual) {
       mergeState_ = mergeRows_->newRow();
@@ -1685,7 +1999,8 @@ AggregationInputSpiller::AggregationInputSpiller(
     const HashBitRange& hashBitRange,
     const std::vector<SpillSortKey>& sortingKeys,
     const common::SpillConfig* spillConfig,
-    exec::SpillStats* spillStats)
+    exec::SpillStats* spillStats,
+    bool needSort)
     : SpillerBase(
           container,
           std::move(rowType),
@@ -1695,7 +2010,8 @@ AggregationInputSpiller::AggregationInputSpiller(
           spillConfig->maxSpillRunRows,
           std::nullopt,
           spillConfig,
-          spillStats) {}
+          spillStats),
+      needSort_(needSort) {}
 
 AggregationOutputSpiller::AggregationOutputSpiller(
     RowContainer* container,

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -23,6 +23,7 @@
 #include "velox/exec/HashTable.h"
 #include "velox/exec/SortedAggregations.h"
 #include "velox/exec/Spiller.h"
+#include "velox/exec/UnorderedStreamReader.h"
 #include "velox/exec/VectorHasher.h"
 
 namespace facebook::velox::exec {
@@ -278,6 +279,54 @@ class GroupingSet {
   // spilled partitions have been processed.
   bool prepareNextSpillPartitionOutput();
 
+  // Returns true if spilled aggregation data is recovered through hash
+  // re-aggregation (vectorized, unsorted spill) instead of the row-by-row
+  // ordered (sorted) merge. This is a stable, query-lifetime decision based on
+  // the 'aggregation_spill_hash_recovery_enabled' config and the aggregate
+  // shape: only plain group-by aggregates without sorted/distinct aggregates
+  // are supported. The same predicate drives both the spill-time sort decision
+  // and the read-time recovery path, so they always agree.
+  bool useHashRecovery() const;
+
+  // Starts hash-based recovery for 'partition': sets up 'recoveryTable_' and
+  // 'recoveryReader_' and marks 'currentPartitionHashRecovery_'.
+  // 'respillStartBit' is the partition bit offset to use if the partition has
+  // to be recursively re-spilled because it does not fit in memory.
+  void startHashRecovery(SpillPartition& partition, uint8_t respillStartBit);
+
+  // Returns true if the recovery hash table cannot accommodate 'batch' within
+  // the available memory and the partition should be recursively re-spilled
+  // (provided the spill level limit is not exceeded). Mirrors the reservation
+  // logic of ensureInputFits().
+  bool recoveryShouldRespill(const RowVectorPtr& batch);
+
+  // Spills the current contents of 'recoveryTable_' into 'recoverySpiller_'
+  // (creating it on first use) and clears the table, so draining can continue
+  // into a fresh table. Marks 'recoveryRespilling_'.
+  void respillRecoveryTable();
+
+  // Finalizes recursive re-spill of the current partition: spills any remaining
+  // recovery rows, finishes 'recoverySpiller_' and pushes the resulting
+  // sub-partitions onto 'recoveryWorkStack_' for later processing.
+  void finalizeRecoveryRespill();
+
+  // Re-aggregates one batch of spilled intermediate rows into
+  // 'recoveryTable_'. The batch layout is [keys..., intermediate accumulators].
+  void addSpillBatchToHashRecovery(const RowVectorPtr& batch);
+
+  // Reads spilled rows for the current partition via hash-based recovery: on
+  // the first call it fully drains the partition into 'recoveryTable_', then
+  // returns the re-aggregated groups in 'maxOutputRows'/'maxOutputBytes' sized
+  // chunks. Advances to the next partition when the current one is exhausted.
+  bool mergeNextWithHashRecovery(
+      int32_t maxOutputRows,
+      int32_t maxOutputBytes,
+      const RowVectorPtr& result);
+
+  // Releases the hash-recovery state for the current partition and returns any
+  // unused memory reservation back to the pool.
+  void finishHashRecoveryPartition();
+
   // Reads from spilled rows until producing a batch of final results in
   // 'result'. Returns false and leaves 'result' empty when the spilled data is
   // fully read. 'maxOutputRows' and 'maxOutputBytes' specify the max number of
@@ -317,8 +366,12 @@ class GroupingSet {
   // 'keys'. This is called for each row received from a merge of spilled data.
   void updateRow(SpillMergeStream& keys, char* row);
 
-  // Returns a RowType of the spilled data.
+  // Returns a RowType of the spilled data for the main hash table.
   RowTypePtr makeSpillType() const;
+
+  // Returns a RowType of the spilled data for an arbitrary aggregation row
+  // container (e.g. the recovery hash table during recursive re-spill).
+  RowTypePtr makeSpillType(const RowContainer* rows) const;
 
   // Copies the finalized state from 'mergeRows' to 'result' and clears
   // 'mergeRows'. Used for producing a batch of results when aggregating spilled
@@ -470,6 +523,54 @@ class GroupingSet {
   // Temporary for case where an aggregate in toIntermediate() outputs post-init
   // state of aggregate for all rows.
   std::vector<char*> firstGroup_;
+
+  // Hash-based spill recovery state (alternative to the ordered merge in
+  // 'merge_'). Only one of 'merge_' / 'recoveryTable_' is active per spill
+  // partition. See useHashRecovery() and startHashRecovery().
+  //
+  // True if the current spill partition is being recovered via a hash table
+  // rather than the ordered merge.
+  bool currentPartitionHashRecovery_{false};
+
+  // True once the current partition has been fully drained into
+  // 'recoveryTable_' and we are extracting its groups.
+  bool hashRecoveryDrained_{false};
+
+  // Unordered reader over the current spill partition's files.
+  std::unique_ptr<UnorderedStreamReader<BatchStream>> recoveryReader_;
+
+  // Hash table holding the re-aggregated groups of the current spill partition.
+  std::unique_ptr<BaseHashTable> recoveryTable_;
+
+  std::unique_ptr<HashLookup> recoveryLookup_;
+
+  // Iterator over 'recoveryTable_' rows while extracting output in chunks.
+  RowContainerIterator recoveryResultIterator_;
+
+  // A spill partition pending hash recovery together with the partition bit
+  // offset to use if it has to be recursively re-spilled.
+  struct RecoveryPartition {
+    std::unique_ptr<SpillPartition> partition;
+    uint8_t respillStartBit;
+  };
+
+  // Sub-partitions produced by recursive re-spill of a recovery partition that
+  // did not fit in memory. Processed (depth-first) before the next top-level
+  // spill partition.
+  std::vector<RecoveryPartition> recoveryWorkStack_;
+
+  // Spiller used to recursively re-spill the current recovery partition when it
+  // does not fit in memory. Partitions the (intermediate) aggregation state by
+  // 'currentRespillStartBit_'.
+  std::unique_ptr<AggregationInputSpiller> recoverySpiller_;
+
+  // True once the current recovery partition has started recursive re-spill, in
+  // which case it produces no direct output and is fully routed to
+  // 'recoverySpiller_'.
+  bool recoveryRespilling_{false};
+
+  // Partition bit offset used to re-spill the current recovery partition.
+  uint8_t currentRespillStartBit_{0};
 };
 
 class AggregationInputSpiller : public SpillerBase {
@@ -482,7 +583,8 @@ class AggregationInputSpiller : public SpillerBase {
       const HashBitRange& hashBitRange,
       const std::vector<SpillSortKey>& sortingKeys,
       const common::SpillConfig* spillConfig,
-      exec::SpillStats* spillStats);
+      exec::SpillStats* spillStats,
+      bool needSort = true);
 
   void spill();
 
@@ -492,8 +594,13 @@ class AggregationInputSpiller : public SpillerBase {
   }
 
   bool needSort() const override {
-    return true;
+    return needSort_;
   }
+
+  // When false, spilled runs are not sorted. This is used when the spilled data
+  // is recovered through hash re-aggregation (see GroupingSet hash recovery)
+  // instead of the ordered (sorted) merge, which removes the spill-time sort.
+  const bool needSort_;
 };
 
 class AggregationOutputSpiller : public SpillerBase {

--- a/velox/exec/benchmarks/CMakeLists.txt
+++ b/velox/exec/benchmarks/CMakeLists.txt
@@ -201,6 +201,20 @@ target_link_libraries(
   Folly::follybenchmark
 )
 
+add_executable(velox_hash_recovery_aggregation_benchmark HashRecoveryAggregationBenchmark.cpp)
+
+target_link_libraries(
+  velox_hash_recovery_aggregation_benchmark
+  velox_memory
+  velox_aggregates
+  velox_exec
+  velox_exec_test_lib
+  velox_vector_fuzzer
+  velox_vector_test_lib
+  velox_presto_serializer
+  Folly::follybenchmark
+)
+
 add_executable(velox_exec_bm_duplicate_project DuplicateProjectBenchmark.cpp)
 
 target_link_libraries(

--- a/velox/exec/benchmarks/HashRecoveryAggregationBenchmark.cpp
+++ b/velox/exec/benchmarks/HashRecoveryAggregationBenchmark.cpp
@@ -1,0 +1,312 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include <iostream>
+
+#include "velox/common/file/FileSystems.h"
+#include "velox/common/memory/SharedArbitrator.h"
+#include "velox/common/testutil/TempDirectoryPath.h"
+#include "velox/exec/MemoryReclaimer.h"
+#include "velox/exec/PlanNodeStats.h"
+#include "velox/exec/Spill.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/exec/tests/utils/QueryAssertions.h"
+#include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
+#include "velox/serializers/PrestoSerializer.h"
+#include "velox/vector/VectorStream.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+DEFINE_bool(
+    bm_verbose_stats,
+    false,
+    "Print per-iteration spill stats for hash recovery aggregation benchmark.");
+
+DECLARE_bool(velox_enable_memory_usage_track_in_default_memory_pool);
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+using namespace facebook::velox::test;
+
+namespace facebook::velox::exec {
+namespace {
+
+class HashRecoveryAggregationBenchmark;
+
+constexpr int64_t kAllocatorCapacityBytes = 8L << 30;
+constexpr int64_t kArbitratorCapacityBytes = 6L << 30;
+constexpr int64_t kQueryCapacityBytes = 6L << 30;
+
+void initializeBenchmarkMemory() {
+  // Align with OperatorTestBase::setupMemory so TestScopedSpillInjection can
+  // trigger arbitration reclaim on operators with small working sets.
+  FLAGS_velox_enable_memory_usage_track_in_default_memory_pool = true;
+  memory::SharedArbitrator::registerFactory();
+
+  memory::MemoryManager::Options options;
+  options.allocatorCapacity = kAllocatorCapacityBytes;
+  options.arbitratorCapacity = kArbitratorCapacityBytes;
+  options.arbitratorKind = "SHARED";
+  options.checkUsageLeak = false;
+  options.arbitrationStateCheckCb = memoryArbitrationStateCheck;
+
+  using ExtraConfig = memory::SharedArbitrator::ExtraConfig;
+  options.extraArbitratorConfigs = {
+      {std::string(ExtraConfig::kMemoryPoolInitialCapacity), "512MB"},
+      {std::string(ExtraConfig::kMemoryPoolMinReclaimBytes), "0B"},
+      {std::string(ExtraConfig::kMemoryPoolMinReclaimPct), "0"},
+      {std::string(ExtraConfig::kGlobalArbitrationEnabled), "true"},
+  };
+  memory::MemoryManager::initialize(options);
+}
+
+void registerBenchmarkSerde() {
+  if (!isRegisteredVectorSerde()) {
+    serializer::presto::PrestoVectorSerde::registerVectorSerde();
+  }
+  if (!isRegisteredNamedVectorSerde("Presto")) {
+    serializer::presto::PrestoVectorSerde::registerNamedVectorSerde();
+  }
+}
+
+struct BenchmarkCase {
+  vector_size_t vectorSize;
+  int32_t numVectors;
+  int32_t numPartitionBits;
+  // When true, each row gets a globally unique grouping key to model
+  // high-cardinality final aggregation workloads.
+  bool uniqueKeys;
+};
+
+struct RunStats {
+  uint64_t totalUs{0};
+  uint64_t inputNs{0};
+  uint64_t outputNs{0};
+  uint64_t finishNs{0};
+  uint64_t spillSortNs{0};
+  uint64_t spilledRows{0};
+  uint64_t spilledBytes{0};
+  uint64_t spillRuns{0};
+};
+
+HashRecoveryAggregationBenchmark& benchmarkInstance();
+
+struct BenchmarkPlan {
+  core::PlanNodePtr plan;
+  core::PlanNodeId aggNodeId;
+};
+
+class HashRecoveryAggregationBenchmark : public VectorTestBase {
+ public:
+  void addBenchmarks(const BenchmarkCase& testCase) {
+    addBenchmark(testCase, /*hashRecovery=*/false);
+    addBenchmark(testCase, /*hashRecovery=*/true);
+    BENCHMARK_DRAW_LINE();
+  }
+
+  // Release data-generation pools after benchmarks finish so the arbitrator can
+  // tear down cleanly.
+  void tearDown() {
+    pool_.reset();
+    rootPool_.reset();
+    executor_.reset();
+  }
+
+  uint64_t runIteration(const BenchmarkCase& testCase, bool hashRecovery) {
+    folly::BenchmarkSuspender suspender;
+    const auto benchmarkPlan = makeBenchmarkPlan(testCase);
+    suspender.dismiss();
+
+    RunStats stats;
+    run(testCase, hashRecovery, benchmarkPlan, stats);
+    if (FLAGS_bm_verbose_stats) {
+      std::cout << "Total " << succinctMicros(stats.totalUs) << " Input "
+                << succinctNanos(stats.inputNs) << " Output "
+                << succinctNanos(stats.outputNs) << " Finish "
+                << succinctNanos(stats.finishNs) << " SpillSort "
+                << succinctNanos(stats.spillSortNs) << " SpilledRows "
+                << stats.spilledRows << " SpilledBytes "
+                << succinctBytes(stats.spilledBytes) << " SpillRuns "
+                << stats.spillRuns << std::endl;
+    }
+    return 1;
+  }
+
+ private:
+  void addBenchmark(const BenchmarkCase& testCase, bool hashRecovery) {
+    const auto totalRows =
+        static_cast<int64_t>(testCase.vectorSize) * testCase.numVectors;
+    const auto name = fmt::format(
+        "{}_rows{}_vectors{}_parts{}_{}",
+        hashRecovery ? "hash_recovery" : "sorted_merge",
+        totalRows,
+        testCase.numVectors,
+        testCase.numPartitionBits,
+        testCase.uniqueKeys ? "unique_keys" : "low_cardinality");
+
+    folly::addBenchmark(__FILE__, name, [testCase, hashRecovery]() {
+      return benchmarkInstance().runIteration(testCase, hashRecovery);
+    });
+  }
+
+  std::vector<RowVectorPtr> makeData(const BenchmarkCase& testCase) {
+    const auto rowType =
+        ROW({"c0", "c1", "c2", "c3", "c4", "c5"},
+            {BIGINT(), INTEGER(), BIGINT(), REAL(), DOUBLE(), VARCHAR()});
+
+    VectorFuzzer::Options opts;
+    opts.vectorSize = testCase.vectorSize;
+    opts.nullRatio = 0;
+    VectorFuzzer fuzzer(opts, pool());
+
+    std::vector<RowVectorPtr> vectors;
+    vectors.reserve(testCase.numVectors);
+    for (auto i = 0; i < testCase.numVectors; ++i) {
+      const auto rowOffset = static_cast<int64_t>(i) * testCase.vectorSize;
+      std::vector<VectorPtr> children;
+      children.push_back(
+          makeFlatVector<int64_t>(testCase.vectorSize, [&](auto row) {
+            const auto globalRow = rowOffset + row;
+            return testCase.uniqueKeys ? globalRow : globalRow % 128;
+          }));
+      children.push_back(fuzzer.fuzzFlat(INTEGER()));
+      children.push_back(fuzzer.fuzzFlat(BIGINT()));
+      children.push_back(fuzzer.fuzzFlat(REAL()));
+      children.push_back(fuzzer.fuzzFlat(DOUBLE()));
+      children.push_back(fuzzer.fuzzFlat(VARCHAR()));
+      vectors.push_back(makeRowVector(rowType->names(), children));
+    }
+    return vectors;
+  }
+
+  BenchmarkPlan makeBenchmarkPlan(const BenchmarkCase& testCase) {
+    const auto data = makeData(testCase);
+    core::PlanNodeId aggNodeId;
+    const auto plan =
+        PlanBuilder()
+            .values(data)
+            .singleAggregation(
+                {"c0"}, {"sum(c2)", "max(c4)", "min(c5)", "count(c1)"})
+            .capturePlanNodeId(aggNodeId)
+            .planNode();
+    return {plan, aggNodeId};
+  }
+
+  void run(
+      const BenchmarkCase& testCase,
+      bool hashRecovery,
+      const BenchmarkPlan& benchmarkPlan,
+      RunStats& stats) {
+    const auto spillDir =
+        common::testutil::TempDirectoryPath::create()->getPath();
+
+    TestScopedSpillInjection scopedSpillInjection(100);
+    const auto startUs = getCurrentTimeMicro();
+    std::shared_ptr<Task> task;
+    AssertQueryBuilder(benchmarkPlan.plan)
+        .spillDirectory(spillDir)
+        .maxDrivers(1)
+        .maxQueryCapacity(kQueryCapacityBytes)
+        .serialExecution(true)
+        .config(core::QueryConfig::kSpillEnabled, true)
+        .config(core::QueryConfig::kAggregationSpillEnabled, true)
+        .config(
+            core::QueryConfig::kAggregationSpillHashRecoveryEnabled,
+            hashRecovery)
+        .config(
+            core::QueryConfig::kSpillNumPartitionBits,
+            std::to_string(testCase.numPartitionBits))
+        .config(core::QueryConfig::kMaxSpillLevel, "0")
+        .countResults(task);
+    stats.totalUs = getCurrentTimeMicro() - startUs;
+
+    const auto planStats = toPlanStats(task->taskStats());
+    const auto& aggStats = planStats.at(benchmarkPlan.aggNodeId);
+    stats.inputNs = aggStats.addInputTiming.wallNanos;
+    stats.outputNs = aggStats.getOutputTiming.wallNanos;
+    stats.finishNs = aggStats.finishTiming.wallNanos;
+    stats.spilledRows = aggStats.spilledRows;
+    stats.spilledBytes = aggStats.spilledBytes;
+    const auto spillRunsIt =
+        aggStats.customStats.find(std::string(Operator::kSpillRuns));
+    if (spillRunsIt != aggStats.customStats.end()) {
+      stats.spillRuns = spillRunsIt->second.sum;
+    }
+    const auto spillSortIt =
+        aggStats.customStats.find(std::string(Operator::kSpillSortTime));
+    if (spillSortIt != aggStats.customStats.end()) {
+      stats.spillSortNs = spillSortIt->second.sum;
+    }
+
+    VELOX_CHECK_GT(
+        stats.spilledBytes,
+        0,
+        "Expected forced spill in benchmark run '{}'",
+        hashRecovery ? "hash_recovery" : "sorted_merge");
+    VELOX_CHECK_GT(
+        stats.spillRuns, 0, "Expected at least one spill run in benchmark");
+  }
+};
+
+HashRecoveryAggregationBenchmark& benchmarkInstance() {
+  static HashRecoveryAggregationBenchmark instance;
+  return instance;
+}
+
+} // namespace
+
+HashRecoveryAggregationBenchmark& hashRecoveryAggregationBenchmark() {
+  return benchmarkInstance();
+}
+
+} // namespace facebook::velox::exec
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+  initializeBenchmarkMemory();
+  registerBenchmarkSerde();
+  aggregate::prestosql::registerAllAggregateFunctions();
+  filesystems::registerLocalFileSystem();
+
+  auto& benchmark = facebook::velox::exec::hashRecoveryAggregationBenchmark();
+  // High-cardinality workloads with forced spill. Each case runs both the
+  // sorted-merge recovery path and the hash-recovery path for comparison.
+  benchmark.addBenchmarks(
+      {.vectorSize = 4'096,
+       .numVectors = 32,
+       .numPartitionBits = 2,
+       .uniqueKeys = true});
+  benchmark.addBenchmarks(
+      {.vectorSize = 8'192,
+       .numVectors = 32,
+       .numPartitionBits = 3,
+       .uniqueKeys = true});
+  benchmark.addBenchmarks(
+      {.vectorSize = 4'096,
+       .numVectors = 16,
+       .numPartitionBits = 2,
+       .uniqueKeys = false});
+
+  folly::runBenchmarks();
+  exec::test::waitForAllTasksToBeDeleted();
+  benchmark.tearDown();
+  memory::SharedArbitrator::unregisterFactory();
+  return 0;
+}

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -1270,6 +1270,94 @@ TEST_F(AggregationTest, spillAll) {
   }
 }
 
+// Verifies the vectorized hash-recovery spill-merge path (recovering spilled
+// aggregation state by re-aggregating through a hash table instead of the
+// row-by-row sorted merge) produces results identical to the in-memory plan,
+// without recursive re-spill (spill level limited to the input level).
+TEST_F(AggregationTest, hashRecoverySpill) {
+  auto inputs = makeVectors(rowType_, 200, 8);
+
+  auto plan = PlanBuilder()
+                  .values(inputs)
+                  .singleAggregation({"c0"}, {"sum(c2)", "max(c4)", "min(c5)"})
+                  .planNode();
+  auto expected = AssertQueryBuilder(plan).copyResults(pool_.get());
+
+  for (int numPartitionBits : {1, 2, 3}) {
+    SCOPED_TRACE(fmt::format("numPartitionBits {}", numPartitionBits));
+    auto tempDirectory = exec::test::TempDirectoryPath::create();
+    TestScopedSpillInjection scopedSpillInjection(100);
+    auto task =
+        AssertQueryBuilder(plan)
+            .spillDirectory(tempDirectory->getPath())
+            .config(QueryConfig::kSpillEnabled, true)
+            .config(QueryConfig::kAggregationSpillEnabled, true)
+            .config(QueryConfig::kAggregationSpillHashRecoveryEnabled, true)
+            // Disable recursive re-spill: only the input-level spill happens,
+            // so this isolates the basic (non-recursive) hash-recovery path.
+            .config(QueryConfig::kMaxSpillLevel, "0")
+            .config(
+                QueryConfig::kSpillNumPartitionBits,
+                std::to_string(numPartitionBits))
+            .maxDrivers(1)
+            .assertResults(expected);
+
+    auto stats = task->taskStats().pipelineStats;
+    ASSERT_LT(
+        0,
+        stats[0]
+            .operatorStats[1]
+            .runtimeStats[std::string(Operator::kSpillRuns)]
+            .count);
+    ASSERT_LT(0, stats[0].operatorStats[1].spilledBytes);
+    OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
+  }
+}
+
+// Verifies recursive re-spill during hash recovery: when a recovered partition
+// does not fit in memory it is re-partitioned with finer bits and processed
+// recursively. The deterministic re-spill trigger (TestScopedSpillInjection)
+// forces re-spill on every recovered batch, exercising the recursion down to
+// the configured spill level limit. Results must still match the in-memory
+// plan.
+TEST_F(AggregationTest, hashRecoveryRecursiveRespill) {
+  auto inputs = makeVectors(rowType_, 200, 8);
+
+  auto plan = PlanBuilder()
+                  .values(inputs)
+                  .singleAggregation({"c0"}, {"sum(c2)", "count(1)", "max(c4)"})
+                  .planNode();
+  auto expected = AssertQueryBuilder(plan).copyResults(pool_.get());
+
+  for (int maxSpillLevel : {1, 2, 3}) {
+    SCOPED_TRACE(fmt::format("maxSpillLevel {}", maxSpillLevel));
+    auto tempDirectory = exec::test::TempDirectoryPath::create();
+    // 100% injection forces both the input spill and (via the recovery
+    // re-spill trigger) recursive re-spill of every recovered partition.
+    TestScopedSpillInjection scopedSpillInjection(100);
+    auto task =
+        AssertQueryBuilder(plan)
+            .spillDirectory(tempDirectory->getPath())
+            .config(QueryConfig::kSpillEnabled, true)
+            .config(QueryConfig::kAggregationSpillEnabled, true)
+            .config(QueryConfig::kAggregationSpillHashRecoveryEnabled, true)
+            .config(QueryConfig::kSpillNumPartitionBits, "2")
+            .config(QueryConfig::kMaxSpillLevel, std::to_string(maxSpillLevel))
+            .maxDrivers(1)
+            .assertResults(expected);
+
+    auto stats = task->taskStats().pipelineStats;
+    ASSERT_LT(
+        0,
+        stats[0]
+            .operatorStats[1]
+            .runtimeStats[std::string(Operator::kSpillRuns)]
+            .count);
+    ASSERT_LT(0, stats[0].operatorStats[1].spilledBytes);
+    OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
+  }
+}
+
 // Verify number of memory allocations in the HashAggregation operator.
 TEST_F(AggregationTest, memoryAllocations) {
   vector_size_t size = 1'024;


### PR DESCRIPTION
## Background
`HashAggregation` (final/single aggregation) recovers spilled data through an
**ordered (sorted) merge**: spilled runs are sorted on the grouping keys at
spill time, and on read `GroupingSet::mergeNextWithAggregates()` walks the
merged stream **row by row**, calling `initializeRow()` / `updateRow()` for
every spilled row to rebuild the merge `RowContainer` before re-aggregating.
## Problem
For high-cardinality final aggregations that spill across multiple rounds, this
recovery path is a major bottleneck:
- **Spill-time sort overhead.** Every spilled run is sorted, even though final
  aggregation only needs equal keys to be *collocated*, not *ordered*.
- **Row-by-row column→row conversion on read.** The merge deserializes each
  spilled row individually (tens of millions of `initializeRow`/`updateRow`
  calls), which dominates the spill-merge phase.
In a production Gluten/Velox workload, a single high-cardinality aggregation
task spent the majority of its spill-recovery time in this row-by-row
column→row conversion, with a non-trivial additional cost in the spill-time
sort.
## Proposed solution
Add an optional **hash-based spill recovery** path for plain group-by final/
single aggregation:
1. **Skip the spill-time sort.** When hash recovery is enabled, the
   `AggregationInputSpiller` writes **unsorted** runs (`needSort = false`).
2. **Vectorized re-aggregation on read.** Each spill partition is read back
   through an `UnorderedStreamReader` and re-aggregated into a fresh hash table
   using the existing **vectorized** `groupProbe()` + `addIntermediateResults()`
   APIs, instead of the per-row ordered merge. The recovered groups are then
   extracted in output-sized chunks.
3. **Recursive re-spill for memory safety.** If a recovered partition does not
   fit in memory, it is re-partitioned with finer hash bits and processed
   recursively (depth-first), bounded by `max_spill_level`. Because the memory
   arbitrator cannot reclaim from an operator during output processing
   (`HashAggregation::reclaim()` is a no-op once `noMoreInput_ && hasSpilled()`),
   the re-spill decision is made **proactively** at batch boundaries, mirroring
   the reservation logic of `GroupingSet::ensureInputFits()`. A key always hashes
   to the same sub-partition across re-spill rounds, so equal keys are always
   recombined correctly.
The same predicate (`useHashRecovery()`) drives both the spill-time sort
decision and the read-time recovery path, so they can never disagree.

## Configuration
- `aggregation_spill_hash_recovery_enabled` (`QueryConfig`),
  default `false`.
## Benefit
<img width="538" height="197" alt="image" src="https://github.com/user-attachments/assets/a10329e9-1e11-46f7-9d2a-00ad9ada6175" />

<img width="430" height="217" alt="image" src="https://github.com/user-attachments/assets/f290cb2c-7219-4f3f-afd4-32e30f86566e" />

Comparison before and after optimization, all task cpu time cost for whole stage trigger spill reduce by 45.48%, from 93core*hour to 50.7 core*hour