### PR TITLE
refactor(test): Build DuckDbQueryRunner's database lazily (#17939)

### DIFF
--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -840,6 +840,13 @@ std::vector<MaterializedRow> materialize(const RowVectorPtr& vector) {
   return rows;
 }
 
+::duckdb::DuckDB& DuckDbQueryRunner::database() {
+  if (db_ == nullptr) {
+    db_ = std::make_shared<::duckdb::DuckDB>(nullptr);
+  }
+  return *db_;
+}
+
 void DuckDbQueryRunner::createTable(
     const std::string& name,
     const std::vector<RowVectorPtr>& data) {
@@ -847,7 +854,7 @@ void DuckDbQueryRunner::createTable(
   execute(query);
 
   auto& rowType = data[0]->type()->as<TypeKind::ROW>();
-  ::duckdb::Connection con(db_);
+  ::duckdb::Connection con(database());
   auto sql = duckdb::makeCreateTableSql(name, rowType);
   auto res = con.Query(sql);
   verifyDuckDBResult(res, sql);
@@ -888,7 +895,7 @@ void DuckDbQueryRunner::createTable(
 }
 
 DuckDBQueryResult DuckDbQueryRunner::execute(const std::string& sql) {
-  ::duckdb::Connection con(db_);
+  ::duckdb::Connection con(database());
   // Changing the default null order of NULLS FIRST used by DuckDB. Velox uses
   // NULLS LAST.
   con.Query("PRAGMA default_null_order='NULLS LAST'");

--- a/velox/exec/tests/utils/QueryAssertions.h
+++ b/velox/exec/tests/utils/QueryAssertions.h
@@ -41,9 +41,12 @@ std::vector<MaterializedRow> materialize(const RowVectorPtr& vector);
 /// Converts a list of 'RowVector's into 'MaterializedRowMultiset'.
 MaterializedRowMultiset materialize(const std::vector<RowVectorPtr>& vectors);
 
+/// Runs SQL queries against an in-memory DuckDB to compute expected results in
+/// tests. Not thread-safe: a single instance must be accessed from one thread
+/// at a time.
 class DuckDbQueryRunner {
  public:
-  DuckDbQueryRunner() : db_(nullptr) {}
+  DuckDbQueryRunner() = default;
 
   void createTable(
       const std::string& name,
@@ -79,7 +82,13 @@ class DuckDbQueryRunner {
   }
 
  private:
-  ::duckdb::DuckDB db_;
+  // Returns the in-memory DuckDB, building it on the first call. Construction
+  // is expensive, so it is deferred until the first query.
+  ::duckdb::DuckDB& database();
+
+  // shared_ptr (not unique_ptr) keeps DuckDbQueryRunner copyable; some callers
+  // hold it by value and rely on copy semantics.
+  std::shared_ptr<::duckdb::DuckDB> db_;
 
   void execute(
       const std::string& sql,


### PR DESCRIPTION
Summary:

DuckDbQueryRunner built an in-memory DuckDB in its constructor, costing ~52ms even for a runner that never issues a DuckDB query. Many tests deriving from OperatorTestBase check results with AssertQueryBuilder against expected RowVectors and never touch DuckDB, so they paid that cost for nothing. The database is now created on first use, so an unused runner costs nothing.

bypass-github-export-checks

Reviewed By: srsuryadev

Differential Revision: D109811214


