### PR TITLE
fix(dict): Initialize sparse null buffer more rigorously (#17940)

### DIFF
--- a/velox/dwio/common/SelectiveColumnReader.cpp
+++ b/velox/dwio/common/SelectiveColumnReader.cpp
@@ -120,7 +120,7 @@ void SelectiveColumnReader::seekTo(int64_t offset, bool readsNullsOnly) {
   }
 }
 
-void SelectiveColumnReader::initReturnReaderNulls(const RowSet& rows) {
+void SelectiveColumnReader::setReturnNullsMode(const RowSet& rows) {
   if (useBulkPath() && !scanSpec_->hasFilter()) {
     anyNulls_ = nullsInReadRange_ != nullptr;
     const bool isDense = rows.back() == rows.size() - 1;
@@ -139,7 +139,7 @@ void SelectiveColumnReader::prepareNulls(
     return;
   }
 
-  initReturnReaderNulls(rows);
+  setReturnNullsMode(rows);
   if (returnReaderNulls_) {
     // No need for null flags if fast path.
     return;

--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -283,7 +283,14 @@ class SelectiveColumnReader {
     return returnReaderNulls_;
   }
 
-  void initReturnReaderNulls(const RowSet& rows);
+  /// Resolves which buffer resultNulls() returns for this read, by setting the
+  /// returnReaderNulls_ flag (and anyNulls_). Sets it true on the fast path --
+  /// bulk read, no filter, dense rows, and nulls present -- so the nulls
+  /// decoded into nullsInReadRange_ can be returned directly; otherwise false,
+  /// so resultNulls() returns the separately-built, output-aligned
+  /// resultNulls_. Resolves the flag only; allocates no buffer. Call after the
+  /// read-range nulls are decoded.
+  void setReturnNullsMode(const RowSet& rows);
 
   void setNumValues(vector_size_t size) {
     numValues_ = size;


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookincubator/nimble/pull/911

Hardens the dictionary visitor read path against cross-chunk null-handling bugs surfaced by multi-chunk fuzzing, plus a clarity rename of one helper and an aarch64 build fix. Sits on top of D108709293 (RLEFix) in the dictionary vector stack.

## Bug fix: stale result-null bits leak across buffer-reused reads

When a chunk is nullable and the output row set is sparse/compacted (`returnReaderNulls_ == false`), the dictionary-index read path cleared `resultNulls_` only lazily -- it touched the buffer only when it actually emitted a null. A read whose surviving rows are all non-null therefore never cleared `resultNulls_`, so a stale null bit left over from a prior (buffer-reused) read leaked into the result vector and corrupted the output.

Fix: prepare the result-null buffer eagerly in the sparse dictionary-index reader instead of on the first emitted null. `readSparseMaterializedIndices` now clears `resultNulls_` up front whenever the read range carries nulls (`rawNulls != nullptr`), so an all-non-null read still starts from a clean buffer.

The prep lives in the reader that sees `rawNulls`, not in a single `NullableEncoding` chokepoint, because output nulls have two sources: the encoding's own nulls (via `NullableEncoding`) and incoming/inMap nulls on a non-nullable column nested under a nullable parent (e.g. a flat-map dict child with inMap nulls). The latter has no `NullableEncoding` in its read path, so a chokepoint there would never run for it; `rawNulls` is set for both, matching how the dense and filtered index readers already prepare their buffers.

## Rename: `initReturnReaderNulls` -> `setReturnNullsMode`

The helper only sets which buffer `resultNulls()` returns for the read -- it sets the `returnReaderNulls_` flag (and `anyNulls_`) and allocates nothing. The old name implied buffer initialization/allocation. Renamed across the Velox `SelectiveColumnReader` API and all Nimble call sites (legacy and non-legacy `NullableEncoding`, `ChunkedDecoder`, the `ReadWithVisitorParams` field in `Encoding.h`, `ReadWithVisitorTest`, `EncodingBench`).

## Build fix: bucket_benchmark on aarch64

`dwio/nimble/encodings/tests:bucket_benchmark` hardcoded x86-only tuning flags (`-mavx`, `-mavx2`, `-mbmi`, `-mbmi2`, `-mclzero`, `-mlzcnt`) in `compiler_flags`, which clang rejects for `aarch64-redhat-linux-gnu`, so the target failed to build on aarch64. The benchmark source uses no raw x86 intrinsics, so the flags are now arch-gated with `select()` (applied only on `ovr_config//cpu:x86_64`) and the portable source builds on aarch64 without them. Pre-existing breakage surfaced by this diff rebuilding the shared encoding headers.

## Test coverage: exercise cross-chunk resume paths

`E2EFilterTest` previously wrote a single chunk per stream, so the cross-chunk reader resume paths (where the above bug lives) were never exercised by standalone tests. Added two helpers and applied them across the dictionary / mainly-constant / RLE / nullable / fuzz cases:
- `applyMultiChunkOptions(VeloxWriterOptions&)` -- enable chunking, zero `minStreamChunkRawSize`, and a flush policy that never flushes the stripe but chunks at every `write()` boundary.
- `writeInChunks(writer, batch, numChunks=3)` -- slice a batch into N row-slices so each emits its own chunk (a single `write()` yields only one chunk).

Note: touches Velox-owned `velox/dwio/common/SelectiveColumnReader.{h,cpp}` (rename only) -- needs Velox-owner sign-off before landing.

Reviewed By: xiaoxmeng

Differential Revision: D108873522


