### PR TITLE
fix(StreamingAggregation): Do not drop input batches under downstream back-pressure (#17941)

### DIFF
--- a/velox/exec/StreamingAggregation.cpp
+++ b/velox/exec/StreamingAggregation.cpp
@@ -126,6 +126,11 @@ void StreamingAggregation::close() {
 }
 
 void StreamingAggregation::addInput(RowVectorPtr input) {
+  // needsInput() returns false while input_ is set, so the driver must drain
+  // the previous batch via getOutput() before feeding another. Fail loudly if
+  // that contract is violated rather than silently overwriting and dropping
+  // input_.
+  VELOX_CHECK_NULL(input_);
   input_ = std::move(input);
 }
 

--- a/velox/exec/StreamingAggregation.h
+++ b/velox/exec/StreamingAggregation.h
@@ -41,8 +41,10 @@ class StreamingAggregation : public Operator {
 
   bool needsInput() const override {
     // We don't need input if the first group is ready to output which has mixed
-    // input sources across streaming input batches.
-    return !outputFirstGroup_;
+    // input sources across streaming input batches, nor while we are still
+    // holding an unconsumed input batch -- otherwise the next addInput() would
+    // overwrite (and silently drop) the pending input_.
+    return !outputFirstGroup_ && input_ == nullptr;
   }
 
   bool startDrain() override;

--- a/velox/exec/tests/StreamingAggregationTest.cpp
+++ b/velox/exec/tests/StreamingAggregationTest.cpp
@@ -1588,5 +1588,143 @@ DEBUG_ONLY_TEST_P(StreamingAggregationTest, singleAggregationCleansState) {
   EXPECT_EQ(NonPODInt64::constructed, NonPODInt64::destructed);
 }
 
+// Minimal plan node + operator for a back-pressuring downstream. This mirrors
+// the helper in RowNumberTest, which is a regression test for the same class of
+// bug (an operator's needsInput() not checking input_ == nullptr). The operator
+// passes input through but refuses it most of the time, keeping the upstream
+// StreamingAggregation holding a buffered batch. Before the needsInput() fix
+// this made the Driver re-feed the aggregation and overwrite its undrained
+// input_, silently dropping rows.
+class BackpressureNode : public core::PlanNode {
+ public:
+  BackpressureNode(const core::PlanNodeId& id, core::PlanNodePtr input)
+      : PlanNode(id), sources_{std::move(input)} {}
+
+  const RowTypePtr& outputType() const override {
+    return sources_[0]->outputType();
+  }
+
+  const std::vector<core::PlanNodePtr>& sources() const override {
+    return sources_;
+  }
+
+  std::string_view name() const override {
+    return "Backpressure";
+  }
+
+ private:
+  void addDetails(std::stringstream& /* stream */) const override {}
+
+  std::vector<core::PlanNodePtr> sources_;
+};
+
+class BackpressureOperator : public Operator {
+ public:
+  BackpressureOperator(
+      DriverCtx* ctx,
+      int32_t id,
+      const std::shared_ptr<const BackpressureNode>& node)
+      : Operator(ctx, node->outputType(), id, node->id(), "Backpressure") {}
+
+  bool needsInput() const override {
+    if (noMoreInput_ || input_ != nullptr) {
+      return false;
+    }
+    // Accept input only every 4th poll. The rejected polls are when the Driver
+    // would re-feed (and, before the fix, overwrite) the upstream aggregation.
+    return (++polls_ % 4) == 0;
+  }
+
+  void addInput(RowVectorPtr input) override {
+    input_ = std::move(input);
+  }
+
+  RowVectorPtr getOutput() override {
+    return std::move(input_);
+  }
+
+  BlockingReason isBlocked(ContinueFuture* /* future */) override {
+    return BlockingReason::kNotBlocked;
+  }
+
+  bool isFinished() override {
+    return noMoreInput_ && input_ == nullptr;
+  }
+
+ private:
+  mutable int32_t polls_{0};
+};
+
+class BackpressureNodeFactory : public Operator::PlanNodeTranslator {
+ public:
+  std::unique_ptr<Operator> toOperator(
+      DriverCtx* ctx,
+      int32_t id,
+      const core::PlanNodePtr& node) override {
+    if (auto bpNode = std::dynamic_pointer_cast<const BackpressureNode>(node)) {
+      return std::make_unique<BackpressureOperator>(ctx, id, bpNode);
+    }
+    return nullptr;
+  }
+
+  std::optional<uint32_t> maxDrivers(const core::PlanNodePtr& node) override {
+    if (std::dynamic_pointer_cast<const BackpressureNode>(node)) {
+      return 1;
+    }
+    return std::nullopt;
+  }
+};
+
+// Regression test: a StreamingAggregation feeding a back-pressuring downstream
+// must not drop rows. Before the fix, StreamingAggregation::needsInput() did
+// not check input_ == nullptr, so when the downstream returned
+// needsInput()=false the Driver re-fed the aggregation and addInput() overwrote
+// the undrained batch, silently dropping rows (seen in production with
+// streaming aggregations fed through async IndexLookupJoins). One distinct,
+// clustered key per row makes the aggregation a pass-through, so output rows
+// must equal input rows.
+TEST_P(StreamingAggregationTest, noRowLossWithBackpressuringDownstream) {
+  static folly::once_flag registerFlag;
+  folly::call_once(registerFlag, [] {
+    Operator::registerOperator(std::make_unique<BackpressureNodeFactory>());
+  });
+
+  // Many small batches so the Driver repeatedly feeds the aggregation while the
+  // downstream refuses input.
+  const int32_t numBatches = 200;
+  const int32_t rowsPerBatch = 100;
+  const vector_size_t totalRows = numBatches * rowsPerBatch;
+  std::vector<RowVectorPtr> batches;
+  batches.reserve(numBatches);
+  for (int32_t i = 0; i < numBatches; ++i) {
+    // One distinct, globally-increasing (hence clustered) key per row, so a
+    // correct streaming aggregation emits exactly one group per input row.
+    batches.push_back(makeRowVector(
+        {makeFlatVector<int64_t>(
+             rowsPerBatch, [&](auto row) { return i * rowsPerBatch + row; }),
+         makeFlatVector<int64_t>(
+             rowsPerBatch, [&](auto row) { return i * rowsPerBatch + row; })}));
+  }
+
+  auto plan =
+      PlanBuilder()
+          .values(batches)
+          .streamingAggregation(
+              {"c0"},
+              {"arbitrary(c1)"},
+              {},
+              core::AggregationNode::Step::kSingle,
+              false)
+          .addNode([](const std::string& id, core::PlanNodePtr input) {
+            return std::make_shared<BackpressureNode>(id, std::move(input));
+          })
+          .planNode();
+
+  // Single driver so the aggregation and the back-pressuring downstream share a
+  // pipeline.
+  auto result = AssertQueryBuilder(plan).maxDrivers(1).copyResults(pool());
+  EXPECT_EQ(result->size(), totalRows);
+}
+
 } // namespace
 } // namespace facebook::velox::exec


### PR DESCRIPTION
Summary:

`StreamingAggregation` could silently drop input batches, producing far fewer output rows than input rows, when a downstream operator back-pressures. Surviving rows are individually correct, so the output looks valid but is incomplete.

**Root cause:** `needsInput()` returned `!outputFirstGroup_` without checking for an unconsumed `input_`. Since `addInput()` does `input_ = std::move(input)`, two `addInput()` calls with no intervening `getOutput()` overwrite and lose the first batch. The driver feeds an operator when its `needsInput()` is true, but drains it via `getOutput()` only when its consumer's `needsInput()` is true -- so when the downstream stops producing while holding its input across driver passes (e.g. an async `IndexLookupJoin` waiting on remote lookups), this repeats:

1. downstream `needsInput()` is false, so the aggregation's `getOutput()` is skipped and `input_` is not drained;
2. the aggregation's `needsInput()` still returns true (the bug), so the driver calls `addInput()` again;
3. `input_ = std::move(input)` overwrites the undrained batch, dropping it.

(A downstream that drains within the same pass, e.g. a plain `Unnest`, is unaffected.)

**Fix:** gate `needsInput()` on `input_ == nullptr` -- the single-buffer guard `Expand`, `MarkDistinct`, `Unnest`, and `AssignUniqueId` already use; `StreamingAggregation` was another single-input-buffer operator still missing it. `addInput()` also gets a `VELOX_CHECK_NULL(input_)` so any future regression fails loudly instead of silently dropping rows. This is the same bug and fix as D107271793 / https://github.com/facebookincubator/velox/pull/17702 (fix(RowNumber): Preserve rows under backpressure).

**Impact:** found in a production nested-array pipeline (streaming aggregations fed through async `IndexLookupJoin`s) where ~96% of rows were dropped (4.4M source rows down to ~165K); with the fix all rows are preserved.

Reviewed By: Yuhta

Differential Revision: D109836205


