### PR TITLE
feat(rpc): RPCOperator runtime stats v2 — RTT, congestion, error-kind breakdown (#17943)

### DIFF
--- a/velox/exec/OperatorUtils.cpp
+++ b/velox/exec/OperatorUtils.cpp
@@ -137,7 +137,14 @@ bool shouldAggregateRuntimeMetric(const std::string& name) {
       "ssdCacheReadWallNanos",
       "cacheWaitWallNanos",
       "coalescedSsdLoadWallNanos",
-      "coalescedStorageLoadWallNanos"};
+      "coalescedStorageLoadWallNanos",
+      "rpcCongestionWindowFinal",
+      "rpcPeakInFlight",
+      "rpcBaselineRttNanos",
+      "rpcRttMinWallNanos",
+      "rpcRttMaxWallNanos",
+      "rpcStreamingMode",
+  };
   if (metricNames.contains(name)) {
     return true;
   }

--- a/velox/exec/rpc/CongestionController.cpp
+++ b/velox/exec/rpc/CongestionController.cpp
@@ -22,7 +22,11 @@
 namespace facebook::velox::exec::rpc {
 
 void CongestionController::onError() {
+  const auto prevEffective = effective_;
   effective_ = std::max<int64_t>(effective_ / 2, minWindow_);
+  if (effective_ < prevEffective) {
+    ++numShrinks_;
+  }
   // Drop the in-progress sample window so partial pre-overload samples don't
   // contaminate the next gradient computation. baselineRttNs_ is deliberately
   // preserved (not reset): it represents the unloaded RTT, and keeping it makes
@@ -71,7 +75,11 @@ void CongestionController::onSample(int64_t rttNs) {
       stepCoef_ * std::sqrt(static_cast<double>(effective_));
   const auto newWindow = static_cast<int64_t>(
       static_cast<double>(effective_) * gradient + headroom);
+  const auto prevEffective = effective_;
   effective_ = std::clamp(newWindow, minWindow_, maxWindow_);
+  if (effective_ < prevEffective) {
+    ++numShrinks_;
+  }
 
   // Track the baseline slowly toward the observed RTT so the controller settles
   // at the knee under sustained load instead of shrinking forever.

--- a/velox/exec/rpc/CongestionController.h
+++ b/velox/exec/rpc/CongestionController.h
@@ -89,6 +89,18 @@ class CongestionController {
     return effective_;
   }
 
+  /// Returns the learned baseline RTT (nanos), or 0 before the first full
+  /// sample window.
+  int64_t baselineRttNs() const {
+    return baselineRttNs_;
+  }
+
+  /// Returns the number of window-shrink events (onError halving + gradient
+  /// shrinks) since construction.
+  int64_t numShrinks() const {
+    return numShrinks_;
+  }
+
   /// Halves the window, floored at 1 so dispatch never fully stalls. The fast
   /// overload path (rate limit / timeout).
   void onError();
@@ -118,6 +130,9 @@ class CongestionController {
   // number of samples accumulated in it.
   int64_t windowMinRttNs_{0};
   int64_t numWindowSamples_{0};
+
+  // Count of window-shrink events (onError halving + gradient shrinks).
+  int64_t numShrinks_{0};
 };
 
 } // namespace facebook::velox::exec::rpc

--- a/velox/exec/rpc/RPCOperator.cpp
+++ b/velox/exec/rpc/RPCOperator.cpp
@@ -337,6 +337,7 @@ RowVectorPtr RPCOperator::getOutput() {
       const bool hasError = row.response.hasError();
       if (hasError) {
         numErrors_++;
+        recordErrorKind(row.response.errorKind);
       }
       locations.emplace_back(row.location.batchIndex, row.location.rowIndex);
       // Only successful rows feed the gradient. Errored rows (e.g. null_input,
@@ -385,6 +386,7 @@ RowVectorPtr RPCOperator::getOutput() {
     for (const auto& response : claimedBatch_->responses) {
       if (response.hasError()) {
         numErrors_++;
+        recordErrorKind(response.errorKind);
       }
     }
 
@@ -580,6 +582,24 @@ void RPCOperator::initOutputProjections() {
                  << passthroughProjections_.size();
 }
 
+void RPCOperator::recordErrorKind(velox::rpc::RPCErrorKind kind) {
+  switch (kind) {
+    case velox::rpc::RPCErrorKind::kRateLimited:
+      ++numErrorsRateLimited_;
+      break;
+    case velox::rpc::RPCErrorKind::kTimeout:
+      ++numErrorsTimeout_;
+      break;
+    case velox::rpc::RPCErrorKind::kBackendError:
+      ++numErrorsBackend_;
+      break;
+    case velox::rpc::RPCErrorKind::kNone:
+    case velox::rpc::RPCErrorKind::kNullInput:
+    case velox::rpc::RPCErrorKind::kEmptyResponse:
+      break;
+  }
+}
+
 void RPCOperator::recordRuntimeStats() {
   auto lockedStats = stats_.wlock();
   lockedStats->addRuntimeStat(
@@ -607,6 +627,52 @@ void RPCOperator::recordRuntimeStats() {
         static_cast<uint64_t>(numResponsesReceived_), totalBlockWaitNanos_, 0};
     lockedStats->backgroundTiming.clear();
     lockedStats->backgroundTiming.add(backgroundTiming);
+  }
+
+  if (state_) {
+    auto snapshot = state_->operatorSnapshot();
+    lockedStats->addRuntimeStat(
+        kRpcCongestionWindowFinal, RuntimeCounter(snapshot.windowLimit));
+    lockedStats->addRuntimeStat(
+        kRpcPeakInFlight, RuntimeCounter(snapshot.peakInFlight));
+    if (snapshot.numShrinks > 0) {
+      lockedStats->addRuntimeStat(
+          kRpcCongestionShrinks, RuntimeCounter(snapshot.numShrinks));
+    }
+    if (snapshot.baselineRttNs > 0) {
+      lockedStats->addRuntimeStat(
+          kRpcBaselineRttNanos,
+          RuntimeCounter(snapshot.baselineRttNs, RuntimeCounter::Unit::kNanos));
+    }
+
+    if (snapshot.numRttSamples > 0) {
+      lockedStats->addRuntimeStat(
+          kRpcRttMinWallNanos,
+          RuntimeCounter(snapshot.rttMinNs, RuntimeCounter::Unit::kNanos));
+      lockedStats->addRuntimeStat(
+          kRpcRttMaxWallNanos,
+          RuntimeCounter(snapshot.rttMaxNs, RuntimeCounter::Unit::kNanos));
+      lockedStats->addRuntimeStat(
+          kRpcRttCount, RuntimeCounter(snapshot.numRttSamples));
+    }
+
+    lockedStats->addRuntimeStat(
+        kRpcStreamingMode,
+        RuntimeCounter(
+            snapshot.streamingMode == RPCStreamingMode::kBatch ? 1 : 0));
+  }
+
+  if (numErrorsRateLimited_ > 0) {
+    lockedStats->addRuntimeStat(
+        kRpcErrorKindRateLimited, RuntimeCounter(numErrorsRateLimited_));
+  }
+  if (numErrorsTimeout_ > 0) {
+    lockedStats->addRuntimeStat(
+        kRpcErrorKindTimeout, RuntimeCounter(numErrorsTimeout_));
+  }
+  if (numErrorsBackend_ > 0) {
+    lockedStats->addRuntimeStat(
+        kRpcErrorKindBackendError, RuntimeCounter(numErrorsBackend_));
   }
 }
 

--- a/velox/exec/rpc/RPCOperator.h
+++ b/velox/exec/rpc/RPCOperator.h
@@ -104,6 +104,20 @@ class RPCOperator : public exec::Operator {
   static inline const std::string kRpcWaitWallNanos{"rpcWaitWallNanos"};
   static inline const std::string kRpcBackpressureWaitNanos{
       "rpcBackpressureWaitNanos"};
+  static inline const std::string kRpcCongestionWindowFinal{
+      "rpcCongestionWindowFinal"};
+  static inline const std::string kRpcCongestionShrinks{"rpcCongestionShrinks"};
+  static inline const std::string kRpcBaselineRttNanos{"rpcBaselineRttNanos"};
+  static inline const std::string kRpcPeakInFlight{"rpcPeakInFlight"};
+  static inline const std::string kRpcRttMinWallNanos{"rpcRttMinWallNanos"};
+  static inline const std::string kRpcRttMaxWallNanos{"rpcRttMaxWallNanos"};
+  static inline const std::string kRpcRttCount{"rpcRttCount"};
+  static inline const std::string kRpcStreamingMode{"rpcStreamingMode"};
+  static inline const std::string kRpcErrorKindRateLimited{
+      "rpcErrorKindRateLimited"};
+  static inline const std::string kRpcErrorKindTimeout{"rpcErrorKindTimeout"};
+  static inline const std::string kRpcErrorKindBackendError{
+      "rpcErrorKindBackendError"};
 
  private:
   /// Flush accumulated batch rows via function_->flushBatch().
@@ -123,6 +137,9 @@ class RPCOperator : public exec::Operator {
   /// Called once in initialize() to avoid repeated string lookups in
   /// buildOutputVector().
   void initOutputProjections();
+
+  // Increment the per-error-kind counter for a single response.
+  void recordErrorKind(velox::rpc::RPCErrorKind kind);
 
   /// Record runtime stats into operator stats. Called from close().
   void recordRuntimeStats();
@@ -149,6 +166,10 @@ class RPCOperator : public exec::Operator {
   int64_t numRequestsDispatched_{0};
   int64_t numResponsesReceived_{0};
   int64_t numErrors_{0};
+  // Per-error-kind breakdown of numErrors_, populated by recordErrorKind().
+  int64_t numErrorsRateLimited_{0};
+  int64_t numErrorsTimeout_{0};
+  int64_t numErrorsBackend_{0};
 
   // Global row ID counter for unique IDs across all input batches.
   int64_t globalRowIdCounter_{0};

--- a/velox/exec/rpc/RPCState.cpp
+++ b/velox/exec/rpc/RPCState.cpp
@@ -143,6 +143,7 @@ void RPCState::addPendingRow(
   {
     std::lock_guard<std::mutex> l(mutex_);
     inFlight_++;
+    peakInFlight_ = std::max(peakInFlight_, inFlight_);
     RPC_STATE_VLOG(2) << "addPendingRow: rowId=" << rowId
                       << ", inFlight=" << inFlight_;
   }
@@ -190,6 +191,12 @@ void RPCState::completeRow(
           .response = std::move(response),
           .rttNs = rttNs});
   inFlight_--;
+
+  if (rttNs > 0) {
+    rttMinNs_ = std::min(rttMinNs_, rttNs);
+    rttMaxNs_ = std::max(rttMaxNs_, rttNs);
+    ++numRttSamples_;
+  }
 
   RPC_STATE_VLOG(2) << "Row completed: rowId=" << rowId
                     << ", readyRows=" << readyRows_.size()
@@ -307,6 +314,7 @@ void RPCState::addPendingBatch(
     std::lock_guard<std::mutex> l(mutex_);
     auto batchId = nextBatchId_++;
     inFlight_++;
+    peakInFlight_ = std::max(peakInFlight_, inFlight_);
     pendingBatches_.push_back(
         PendingBatch{
             .batchId = batchId,
@@ -345,6 +353,12 @@ RPCState::ReadyBatch RPCState::extractReadyBatchLocked(
     result.responses = {};
     RPC_STATE_LOG(ERROR) << "extractReadyBatchLocked: batchId="
                          << result.batchId << " failed: " << e.what();
+  }
+
+  if (result.rttNs > 0) {
+    rttMinNs_ = std::min(rttMinNs_, result.rttNs);
+    rttMaxNs_ = std::max(rttMaxNs_, result.rttNs);
+    ++numRttSamples_;
   }
 
   pendingBatches_.erase(it);
@@ -453,6 +467,20 @@ void RPCState::notifyWaitersLocked() {
     promise.setValue();
   }
   promises_.clear();
+}
+
+RPCState::OperatorSnapshot RPCState::operatorSnapshot() const {
+  std::lock_guard<std::mutex> l(mutex_);
+  return OperatorSnapshot{
+      .windowLimit = window_.limit(),
+      .baselineRttNs = window_.baselineRttNs(),
+      .numShrinks = window_.numShrinks(),
+      .peakInFlight = peakInFlight_,
+      .rttMinNs = numRttSamples_ > 0 ? rttMinNs_ : 0,
+      .rttMaxNs = rttMaxNs_,
+      .numRttSamples = numRttSamples_,
+      .streamingMode = streamingMode_,
+  };
 }
 
 } // namespace facebook::velox::exec::rpc

--- a/velox/exec/rpc/RPCState.h
+++ b/velox/exec/rpc/RPCState.h
@@ -18,6 +18,7 @@
 
 #include <atomic>
 #include <deque>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -113,6 +114,22 @@ class RPCState {
     /// Round-trip latency (nanos) from dispatch to completion, used as the
     /// gradient congestion signal on success.
     int64_t rttNs{0};
+  };
+
+  /// Snapshot of all operator-visible state at close() time, captured under a
+  /// single lock acquisition for consistency.
+  struct OperatorSnapshot {
+    // Congestion controller.
+    int64_t windowLimit{0};
+    int64_t baselineRttNs{0};
+    int64_t numShrinks{0};
+    int64_t peakInFlight{0};
+    // Transport RTT.
+    int64_t rttMinNs{0};
+    int64_t rttMaxNs{0};
+    int64_t numRttSamples{0};
+    // Streaming mode.
+    RPCStreamingMode streamingMode{RPCStreamingMode::kPerRow};
   };
 
   RPCState() = default;
@@ -273,6 +290,10 @@ class RPCState {
   /// Thread-safe.
   void onUnitSamples(const std::vector<int64_t>& rttNsList);
 
+  /// Return a consistent snapshot of all operator-visible state under a single
+  /// lock acquisition. Thread-safe.
+  OperatorSnapshot operatorSnapshot() const;
+
  private:
   /// Move a completed row into readyRows_ and notify waiters.
   /// Called from the RPC completion callback (runs on executor thread).
@@ -314,6 +335,14 @@ class RPCState {
   // so exactly one dispatch path feeds this counter. Backpressure compares it
   // against window_.limit().
   int64_t inFlight_{0};
+
+  // High-water mark of inFlight_ across the lifetime of this RPCState.
+  int64_t peakInFlight_{0};
+
+  // Accumulated RTT measurements across all completed units.
+  int64_t rttMinNs_{std::numeric_limits<int64_t>::max()};
+  int64_t rttMaxNs_{0};
+  int64_t numRttSamples_{0};
 
   // Latency-gradient concurrency window, fed RTT via onUnitSample(). Both modes
   // use the same learner; setStreamingMode() only picks the (start, max) pair:


### PR DESCRIPTION
Summary:

Adds 11 new runtime stats to RPCOperator, recorded at `close()` for per-operator visibility into RPC transport behavior.

**Congestion window:**
- `rpcCongestionWindowFinal`: final window limit at close
- `rpcCongestionShrinks`: total shrink events (onError halving + gradient shrinks)
- `rpcBaselineRttNanos`: learned baseline RTT (unloaded)
- `rpcPeakInFlight`: high-water mark of concurrent in-flight units

**Transport RTT:**
- `rpcRttMinWallNanos` / `rpcRttMaxWallNanos`: min/max round-trip across all completed units
- `rpcRttCount`: number of RTT samples

**Error-kind breakdown:**
- `rpcErrorKindRateLimited` / `rpcErrorKindTimeout` / `rpcErrorKindBackendError`: per-kind error counts (complement the existing aggregate `rpcErrorCount`)

**Mode:**
- `rpcStreamingMode`: 0 = PER_ROW, 1 = BATCH

**Aggregation fix:** registers 6 non-additive stats (window, peak, baseline, min/max RTT, mode) in `shouldAggregateRuntimeMetric` so they get `.aggregate()` (count/min/max) instead of being summed across drivers.

**CongestionController accessors:** adds `baselineRttNs()`, `numShrinks()` public accessors and `numShrinks_` private member so `RPCState::operatorSnapshot()` can read the controller state under its own mutex.

**V2 review fixes:** renamed `shrinkCount_` to `numShrinks_` and `rttCount_` to `numRttSamples_` (Velox `numXxx` convention); fixed asymmetric shrink counting in `onError()` (only counts when window actually decreases); extracted duplicated error-kind switch into `recordErrorKind()` helper; listed all `RPCErrorKind` enum values explicitly (fixes `clang-diagnostic-switch-enum`); combined `congestionSnapshot()` + `transportSnapshot()` + `streamingMode()` into a single `operatorSnapshot() const` method (one lock acquisition, consistent snapshot); gated `kRpcRttCount` emission on `numRttSamples > 0` for consistency; added trailing comma in initializer list.

Reviewed By: sebastianopeluso

Differential Revision: D109783970


