### PR TITLE
Disambiguate optional comparison in BaseVector::sortIndices

### DIFF
--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -357,7 +357,7 @@ class BaseVector {
         indices.begin(),
         indices.end(),
         [&](vector_size_t left, vector_size_t right) {
-          return compare(this, left, right, flags) < 0;
+          return compare(this, left, right, flags).value() < 0;
         });
   }
 
@@ -371,7 +371,8 @@ class BaseVector {
         indices.begin(),
         indices.end(),
         [&](vector_size_t left, vector_size_t right) {
-          return compare(this, mapping[left], mapping[right], flags) < 0;
+          return compare(this, mapping[left], mapping[right], flags).value() <
+              0;
         });
   }
 


### PR DESCRIPTION
Summary:
## Context

fbcode is migrating from libstdc++ to libc++ for better performance, access to newer C++ features, and stronger safety guarantees. Some code that compiled under libstdc++ relies on non-standard extensions, implicit conversions, or header inclusion side effects that libc++ does not provide.

## Problem

`BaseVector::compare(...)` returns `std::optional<int32_t>`. The `sortIndices` comparator lambdas compared the result directly against `0` (`compare(...) < 0`). Under libc++ with C++20, comparing `std::optional<T>` with a bare value `T` is ambiguous: the heterogeneous `operator<=>(const optional<_Tp>&, const _Up&)` candidate collides with the synthesized reversed candidates, producing `error: use of overloaded operator '<' is ambiguous`. This also cascaded into `__sort3`/`__partial_sort_impl` "no matching function" errors because the comparator lambda no longer yielded a valid `bool`.

## Fix

Dereference the optional with `.value()` before comparing, mirroring the existing non-optional `compare()` overload in the same file (which already does `.value()`). The default `CompareFlags` used by these sort paths always produce a value, so `.value()` is safe and preserves the engaged-value semantics.

Reviewed By: yuxuanchen1997

Differential Revision: D109311719


