### PR TITLE
refactor(cursor): Pass TaskQueue future out-params by reference

### DIFF
--- a/velox/exec/Cursor.cpp
+++ b/velox/exec/Cursor.cpp
@@ -49,18 +49,17 @@ class TaskQueue {
 
   // Adds a batch of rows to the queue and returns kNotBlocked if the
   // producer may continue. Returns kWaitForConsumer if the queue is
-  // full after the addition and sets '*future' to a future that is
+  // full after the addition and sets 'future' to a future that is
   // realized when the producer may continue.
   exec::BlockingReason
-  enqueue(RowVectorPtr vector, bool drained, velox::ContinueFuture* future);
+  enqueue(RowVectorPtr vector, bool drained, velox::ContinueFuture& future);
 
   // Returns the next batch if one is available. Otherwise returns nullptr and,
-  // if more output may still arrive, sets '*future' to a future realized when
+  // if more output may still arrive, sets 'future' to a future realized when
   // the consumer should retry; when all producers are at end (or the queue is
-  // closed) returns nullptr and leaves '*future' untouched. The caller
-  // distinguishes "blocked" from "done" by whether '*future' is valid.
-  // 'future' must be non-null.
-  RowVectorPtr dequeue(velox::ContinueFuture* future);
+  // closed) returns nullptr and leaves 'future' untouched. The caller
+  // distinguishes "blocked" from "done" by whether 'future' is valid.
+  RowVectorPtr dequeue(velox::ContinueFuture& future);
 
   void close();
 
@@ -77,22 +76,22 @@ class TaskQueue {
   // Owns the vectors in 'queue_', hence must be declared first.
   std::shared_ptr<velox::memory::MemoryPool> pool_;
   std::deque<TaskQueueEntry> queue_;
-  int32_t producersFinished_ = 0;
-  uint64_t totalBytes_ = 0;
+  int32_t producersFinished_{0};
+  uint64_t totalBytes_{0};
   // Blocks the producer if 'totalBytes' exceeds 'maxBytes' after
   // adding the result.
   uint64_t maxBytes_;
   std::mutex mutex_;
   std::vector<ContinuePromise> producerUnblockPromises_;
-  bool consumerBlocked_ = false;
+  bool consumerBlocked_{false};
   ContinuePromise consumerPromise_{ContinuePromise::makeEmpty()};
-  bool closed_ = false;
+  bool closed_{false};
 };
 
 exec::BlockingReason TaskQueue::enqueue(
     RowVectorPtr vector,
     bool drained,
-    velox::ContinueFuture* future) {
+    velox::ContinueFuture& future) {
   if (!vector) {
     std::lock_guard<std::mutex> l(mutex_);
     if (drained) {
@@ -125,14 +124,13 @@ exec::BlockingReason TaskQueue::enqueue(
     auto [unblockPromise, unblockFuture] =
         makeVeloxContinuePromiseContract("TaskQueue::enqueue");
     producerUnblockPromises_.emplace_back(std::move(unblockPromise));
-    *future = std::move(unblockFuture);
+    future = std::move(unblockFuture);
     return exec::BlockingReason::kWaitForConsumer;
   }
   return exec::BlockingReason::kNotBlocked;
 }
 
-RowVectorPtr TaskQueue::dequeue(velox::ContinueFuture* future) {
-  VELOX_CHECK_NOT_NULL(future);
+RowVectorPtr TaskQueue::dequeue(velox::ContinueFuture& future) {
   RowVectorPtr vector;
   std::vector<ContinuePromise> mayContinue;
   {
@@ -165,7 +163,7 @@ RowVectorPtr TaskQueue::dequeue(velox::ContinueFuture* future) {
       VELOX_CHECK(!consumerBlocked_);
       consumerBlocked_ = true;
       consumerPromise_ = ContinuePromise("TaskQueue::dequeue");
-      *future = consumerPromise_.getFuture();
+      future = consumerPromise_.getFuture();
     }
   }
   // outside of 'mutex_'
@@ -252,8 +250,8 @@ class TaskCursorBase : public TaskCursor {
         try {
           fileSystem->mkdir(taskSpillDirectory_);
         } catch (...) {
-          LOG(ERROR) << "Faield to create task spill directory "
-                     << taskSpillDirectory_ << " base director "
+          LOG(ERROR) << "Failed to create task spill directory "
+                     << taskSpillDirectory_ << " base directory "
                      << params.spillDirectory << " exists["
                      << std::filesystem::exists(taskSpillDirectory_) << "]";
 
@@ -323,14 +321,14 @@ class MultiThreadedTaskCursor : public TaskCursorBase {
           }
 
           if (!vector || !copyResult) {
-            return queue->enqueue(vector, drained, future);
+            return queue->enqueue(vector, drained, *future);
           }
           VectorPtr copy = encodedVectorCopy(
               {.pool = queue->pool(), .reuseSource = false}, vector);
           return queue->enqueue(
               std::static_pointer_cast<RowVector>(std::move(copy)),
               drained,
-              future);
+              *future);
         },
         0,
         std::move(spillDiskOpts),
@@ -388,7 +386,7 @@ class MultiThreadedTaskCursor : public TaskCursorBase {
       // Task might be aborted before start.
       ContinueFuture waitFuture = ContinueFuture::makeEmpty();
       checkTaskError();
-      current_ = queue_->dequeue(&waitFuture);
+      current_ = queue_->dequeue(waitFuture);
       checkTaskError();
 
       if (current_) {
@@ -458,7 +456,7 @@ class MultiThreadedTaskCursor : public TaskCursorBase {
     if (!task_->error()) {
       return;
     }
-    // Wait for the task to finish (there's' a small period of time between
+    // Wait for the task to finish (there's a small period of time between
     // when the error is set on the Task and terminate is called).
     task_->taskCompletionFuture()
         .within(std::chrono::microseconds(5'000'000))
@@ -666,9 +664,8 @@ class TaskDebuggerCursorBase : public TaskCursorBase {
  protected:
   // Internal state for coordinating between the tracer and cursor.
   //
-  // This struct manages the synchronization between the trace writer
-  // (which produces intermediate results) and the cursor (which consumes
-  // them).
+  // Manages the synchronization between the trace writer (which produces
+  // intermediate results) and the cursor (which consumes them).
   struct TraceDriverState {
     // Promise used to signal the tracer to continue after a partial result
     // has been consumed.
@@ -695,8 +692,8 @@ class TaskDebuggerCursorBase : public TaskCursorBase {
 
   // Custom trace context implementation for the debugger.
   //
-  // This trace context pauses execution at traced operators by blocking
-  // the trace writer until the cursor consumes the intermediate result.
+  // Pauses execution at traced operators by blocking the trace writer until
+  // the cursor consumes the intermediate result.
   class TaskDebuggerTraceCtx : public trace::TraceCtx {
    public:
     // Constructs a trace context for the specified plan nodes.

--- a/velox/exec/Cursor.h
+++ b/velox/exec/Cursor.h
@@ -64,21 +64,21 @@ struct CursorParameters {
 
   /// Spilling directory, if not empty, then the task's spilling directory
   /// would be built from it.
-  std::string spillDirectory = "";
+  std::string spillDirectory{};
 
   /// Callback function to dynamically create or determine the spill directory
   /// path at runtime. If provided, this callback is invoked when spilling is
   /// needed and must return a valid directory path. This allows for dynamic
   /// spill directory creation or path resolution based on runtime conditions.
-  std::function<std::string()> spillDirectoryCallback = nullptr;
+  std::function<std::string()> spillDirectoryCallback{nullptr};
 
-  bool copyResult = true;
+  bool copyResult{true};
 
   /// If true, use serial execution mode. Use parallel execution mode
   /// otherwise.
-  bool serialExecution = false;
+  bool serialExecution{false};
 
-  bool barrierExecution = false;
+  bool barrierExecution{false};
 
   /// Per-task unique id used by AssignUniqueId operators. See
   /// core::PlanFragment::taskUniqueId.
@@ -126,9 +126,9 @@ struct CursorParameters {
 /// Example usage:
 /// @code
 ///
-///   auto cursor = TaskCursor:create({
+///   auto cursor = TaskCursor::create({
 ///     .planNode = node,
-///   );
+///   });
 ///
 ///   // Run through every output.
 ///   while (cursor->moveNext()) {
@@ -194,7 +194,7 @@ class TaskCursor {
   /// (unblocked) automatically. When empty (the default), stops at the next
   /// breakpoint regardless of plan node ID.
   ///
-  /// @return Returns false is the task is done producing output.
+  /// @return Returns false if the task is done producing output.
   virtual bool moveStep(const core::PlanNodeId& planId = "") = 0;
 
   /// Returns the vector the cursor is currently on.
@@ -248,8 +248,8 @@ class RowCursor {
   std::unique_ptr<TaskCursor> cursor_;
   std::vector<std::unique_ptr<DecodedVector>> decoded_;
   SelectivityVector allRows_;
-  vector_size_t currentRow_ = 0;
-  vector_size_t numRows_ = 0;
+  vector_size_t currentRow_{0};
+  vector_size_t numRows_{0};
 };
 
 /// Wait up to maxWaitMicros for all the task drivers to finish. The function


### PR DESCRIPTION
Summary:
Cleanup to `Cursor.{h,cpp}`.

API: `TaskQueue::dequeue` and `TaskQueue::enqueue` take their future out-parameter by `ContinueFuture&` instead of a pointer. Both are always called with a valid future: `dequeue` from `MultiThreadedTaskCursor::moveNext`, and `enqueue` from the task consumer callback, which Velox always invokes with a non-null `&future_` (see `CallbackSink.cpp`). The reference encodes that precondition in the type system and drops the runtime `VELOX_CHECK_NOT_NULL` from `dequeue`. No behavior change.

Style:
- Use uniform initialization (`x{0}`) for member declarations that still used copy-init (`x = 0`), matching the dominant convention in the file and the rest of velox/exec.
- Fix typos: a broken `code` example (`TaskCursor:create` -> `TaskCursor::create`, missing `}`), "Returns false is" -> "if", "Faield" -> "Failed", "base director" -> "base directory", a stray apostrophe in "there's'", and start two trace-struct comments with active verbs.

Differential Revision: D109865075


