### PR TITLE
perf: Use DirectBufferedInput for Nimble (enable loadQuantum) (#17948)

### DIFF
--- a/velox/connectors/hive/FileConfig.h
+++ b/velox/connectors/hive/FileConfig.h
@@ -231,6 +231,17 @@ class FileConfig {
       true,
       "Enable selective Nimble reader.")
 
+  VELOX_HIVE_CONFIG(
+      kNimbleDirectBufferedInputEnabledSession,
+      nimbleDirectBufferedInputEnabled,
+      "nimble_direct_buffered_input_enabled",
+      bool,
+      false,
+      "Use DirectBufferedInput for Nimble reads. Loads streams in quanta "
+      "(loadQuantum-sized chunks) instead of full-stream reads. The first "
+      "quantum per stream is always issued; subsequent quanta are loaded on "
+      "demand. Small streams that fit in one quantum see no reduction. "
+      "Streams coalesced with eager columns may also be loaded early.")
   // --- VELOX_HIVE_CONFIG_PROPERTY properties ---
 
   VELOX_HIVE_CONFIG_PROPERTY(

--- a/velox/connectors/hive/FileConnectorUtil.cpp
+++ b/velox/connectors/hive/FileConnectorUtil.cpp
@@ -116,6 +116,8 @@ void configureReaderOptions(
     readerOptions.setSelectiveNimbleReaderEnabled(
         connectorQueryCtx->selectiveNimbleReaderEnabled());
   }
+  readerOptions.setNimbleDirectBufferedInputEnabled(
+      fileConfig->nimbleDirectBufferedInputEnabled(sessionProperties));
   readerOptions.setCacheMetadata(
       fileConfig->cacheMetadata(sessionProperties) && fileSplit->cacheable);
   readerOptions.setPinMetadata(fileConfig->pinMetadata(sessionProperties));

--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -673,11 +673,8 @@ std::unique_ptr<dwio::common::BufferedInput> createBufferedInput(
         readerOpts,
         fileReadOps);
   }
-  if (readerOpts.fileFormat() == dwio::common::FileFormat::NIMBLE) {
-    // Nimble streams (in case of single chunk) are compressed as whole and need
-    // to be fully fetched in order to do decompression, so there is no point to
-    // fetch them by quanta.  Just use BufferedInput to fetch streams as whole
-    // to reduce memory footprint.
+  if (readerOpts.fileFormat() == dwio::common::FileFormat::NIMBLE &&
+      !readerOpts.nimbleDirectBufferedInputEnabled()) {
     return std::make_unique<dwio::common::BufferedInput>(
         fileHandle.file,
         readerOpts.memoryPool(),

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -878,6 +878,18 @@ class ReaderOptions : public io::ReaderOptions {
     selectiveNimbleReaderEnabled_ = value;
   }
 
+  /// If true, Nimble reads use DirectBufferedInput, which loads each stream
+  /// quantum-by-quantum (loadQuantum-sized) on demand instead of fetching the
+  /// whole stream up front. When false, Nimble uses BufferedInput and fetches
+  /// each stream in one piece.
+  bool nimbleDirectBufferedInputEnabled() const {
+    return nimbleDirectBufferedInputEnabled_;
+  }
+
+  void setNimbleDirectBufferedInputEnabled(bool value) {
+    nimbleDirectBufferedInputEnabled_ = value;
+  }
+
   /// Whether to cache file metadata (footer, stripes, index) in the
   /// process-wide AsyncDataCache. When enabled, the first reader performs a
   /// speculative tail read and populates the cache; subsequent readers on the
@@ -1020,6 +1032,7 @@ class ReaderOptions : public io::ReaderOptions {
   const tz::TimeZone* sessionTimezone_{nullptr};
   bool adjustTimestampToTimezone_{false};
   bool selectiveNimbleReaderEnabled_{false};
+  bool nimbleDirectBufferedInputEnabled_{false};
   bool cacheMetadata_{false};
   bool pinMetadata_{false};
   bool cacheIndex_{false};


### PR DESCRIPTION
Summary:

Gate Nimble reader to use DirectBufferedInput with configurable
loadQuantum via session property nimble_direct_buffered_input_enabled.
When enabled, streams are loaded lazily quantum-by-quantum instead of
all-at-once, enabling deferred I/O for lazy columns.

Reviewed By: xiaoxmeng

Differential Revision: D106424768


