### PR TITLE
perf: Pack DirectCoalescedLoad buffers into one shared allocation (#17949)

### DIFF
--- a/velox/common/io/Options.h
+++ b/velox/common/io/Options.h
@@ -107,6 +107,13 @@ class ReaderOptions {
     return *this;
   }
 
+  /// Modifies whether a coalesced direct read packs its buffers into one
+  /// shared allocation.
+  ReaderOptions& setDirectBufferedInputSharedAllocation(bool enabled) {
+    directBufferedInputSharedAllocation_ = enabled;
+    return *this;
+  }
+
   /// Modifies the maximum load coalesce distance.
   ReaderOptions& setMaxCoalesceDistance(int32_t distance) {
     maxCoalesceDistance_ = distance;
@@ -140,6 +147,10 @@ class ReaderOptions {
 
   int32_t loadQuantum() const {
     return loadQuantum_;
+  }
+
+  bool directBufferedInputSharedAllocation() const {
+    return directBufferedInputSharedAllocation_;
   }
 
   int32_t maxCoalesceDistance() const {
@@ -197,6 +208,7 @@ class ReaderOptions {
   uint64_t autoPreloadLength_{DEFAULT_AUTO_PRELOAD_SIZE};
   PrefetchMode prefetchMode_{PrefetchMode::PREFETCH};
   int32_t loadQuantum_{kDefaultLoadQuantum};
+  bool directBufferedInputSharedAllocation_{false};
   int32_t maxCoalesceDistance_{kDefaultCoalesceDistance};
   int64_t maxCoalesceBytes_{kDefaultCoalesceBytes};
   int32_t prefetchRowGroups_{kDefaultPrefetchRowGroups};

--- a/velox/connectors/hive/FileConfig.cpp
+++ b/velox/connectors/hive/FileConfig.cpp
@@ -45,6 +45,7 @@ const std::vector<config::ConfigProperty>& FileConfig::registeredProperties() {
     VELOX_HIVE_CONFIG_REGISTER(kCacheIndexSession);
     VELOX_HIVE_CONFIG_REGISTER(kPinIndexSession);
     VELOX_HIVE_CONFIG_REGISTER(kSelectiveNimbleReaderEnabledSession);
+    VELOX_HIVE_CONFIG_REGISTER(kDirectBufferedInputSharedAllocationSession);
     VELOX_HIVE_CONFIG_REGISTER(kMaxCoalescedDistanceSession);
     VELOX_HIVE_CONFIG_REGISTER(kParallelUnitLoadCountSession);
     VELOX_HIVE_CONFIG_REGISTER(kReadTimestampUnitSession);

--- a/velox/connectors/hive/FileConfig.h
+++ b/velox/connectors/hive/FileConfig.h
@@ -106,6 +106,21 @@ class FileConfig {
       false,
       "Preserve dictionary encoding for Nimble string column reads.")
 
+  // TODO: Deprecate this gate and pack unconditionally once the shared
+  // allocation has run in production for a while.
+  VELOX_HIVE_CONFIG_LEGACY(
+      kDirectBufferedInputSharedAllocationSession,
+      kDirectBufferedInputSharedAllocation,
+      directBufferedInputSharedAllocation,
+      "reader.direct_buffered_input_shared_allocation",
+      "reader.direct-buffered-input-shared-allocation",
+      bool,
+      false,
+      "Pack a coalesced direct read's buffers into a single shared allocation "
+      "instead of one page-rounded allocation per request. Opt-in: off by "
+      "default, enable per cluster to roll out. Affects which bytes are "
+      "allocated, never which bytes are read.")
+
   VELOX_HIVE_CONFIG_LEGACY(
       kNimbleLazyColumnIoSession,
       kNimbleLazyColumnIo,
@@ -240,6 +255,7 @@ class FileConfig {
       "quantum per stream is always issued; subsequent quanta are loaded on "
       "demand. Small streams that fit in one quantum see no reduction. "
       "Streams coalesced with eager columns may also be loaded early.")
+
   // --- VELOX_HIVE_CONFIG_PROPERTY properties ---
 
   VELOX_HIVE_CONFIG_PROPERTY(

--- a/velox/connectors/hive/FileConnectorUtil.cpp
+++ b/velox/connectors/hive/FileConnectorUtil.cpp
@@ -79,6 +79,8 @@ void configureReaderOptions(
   auto sessionProperties = connectorQueryCtx->sessionProperties();
   VELOX_CHECK_NOT_NULL(sessionProperties, "Session properties are null");
   readerOptions.setLoadQuantum(fileConfig->loadQuantum(sessionProperties));
+  readerOptions.setDirectBufferedInputSharedAllocation(
+      fileConfig->directBufferedInputSharedAllocation(sessionProperties));
   readerOptions.setMaxCoalesceBytes(
       fileConfig->maxCoalescedBytes(sessionProperties));
   readerOptions.setMaxCoalesceDistance(

--- a/velox/connectors/hive/tests/FileConfigTest.cpp
+++ b/velox/connectors/hive/tests/FileConfigTest.cpp
@@ -56,6 +56,7 @@ TEST(FileConfigTest, defaultConfig) {
   EXPECT_FALSE(config.nimbleStringDecoderZeroCopy(emptySession.get()));
   EXPECT_FALSE(config.nimblePreserveDictionaryEncoding(emptySession.get()));
   EXPECT_FALSE(config.nimbleLazyColumnIo(emptySession.get()));
+  EXPECT_FALSE(config.directBufferedInputSharedAllocation(emptySession.get()));
 }
 
 TEST(FileConfigTest, overrideConfig) {
@@ -79,6 +80,7 @@ TEST(FileConfigTest, overrideConfig) {
       {FileConfig::kNimbleStringDecoderZeroCopy, "true"},
       {FileConfig::kNimblePreserveDictionaryEncoding, "true"},
       {FileConfig::kNimbleLazyColumnIo, "true"},
+      {FileConfig::kDirectBufferedInputSharedAllocation, "true"},
   };
   FileConfig config(
       std::make_shared<config::ConfigBase>(std::move(configFromFile)), "hive.");
@@ -105,6 +107,10 @@ TEST(FileConfigTest, overrideConfig) {
   EXPECT_TRUE(config.nimbleStringDecoderZeroCopy(emptySession.get()));
   EXPECT_TRUE(config.nimblePreserveDictionaryEncoding(emptySession.get()));
   EXPECT_TRUE(config.nimbleLazyColumnIo(emptySession.get()));
+  // The catalog key is the only way this gate can be enabled in production: the
+  // session key contains a dot, so the Presto CLI cannot parse it, and there is
+  // no HiveSessionProperties.java entry for it.
+  EXPECT_TRUE(config.directBufferedInputSharedAllocation(emptySession.get()));
 }
 
 TEST(FileConfigTest, connectorScopedReaderOptions) {
@@ -144,6 +150,7 @@ TEST(FileConfigTest, overrideSession) {
       {FileConfig::kNimbleStringDecoderZeroCopySession, "true"},
       {FileConfig::kNimblePreserveDictionaryEncodingSession, "true"},
       {FileConfig::kNimbleLazyColumnIoSession, "true"},
+      {FileConfig::kDirectBufferedInputSharedAllocationSession, "true"},
   };
   const auto session =
       std::make_unique<config::ConfigBase>(std::move(sessionOverride));
@@ -165,6 +172,7 @@ TEST(FileConfigTest, overrideSession) {
   EXPECT_TRUE(config.nimbleStringDecoderZeroCopy(session.get()));
   EXPECT_TRUE(config.nimblePreserveDictionaryEncoding(session.get()));
   EXPECT_TRUE(config.nimbleLazyColumnIo(session.get()));
+  EXPECT_TRUE(config.directBufferedInputSharedAllocation(session.get()));
 }
 
 TEST(FileConfigTest, nullConfig) {

--- a/velox/dwio/common/DirectBufferedInput.cpp
+++ b/velox/dwio/common/DirectBufferedInput.cpp
@@ -296,16 +296,20 @@ void copyDuplicateRegion(
     const LoadRequest& source,
     LoadRequest& duplicate,
     memory::MemoryPool* pool) {
-  VELOX_CHECK_EQ(source.loadSize, duplicate.loadSize);
-  if (source.data.numPages() > 0) {
+  VELOX_CHECK_EQ(source.buffer.numBytes, duplicate.buffer.numBytes);
+  if (source.buffer.ownedData.numPages() > 0) {
     const auto numPages =
-        memory::AllocationTraits::numPages(duplicate.loadSize);
-    pool->allocateNonContiguous(numPages, duplicate.data);
-    memory::Allocation::copy(source.data, duplicate.data, duplicate.loadSize);
+        memory::AllocationTraits::numPages(duplicate.buffer.numBytes);
+    pool->allocateNonContiguous(numPages, duplicate.buffer.ownedData);
+    memory::Allocation::copy(
+        source.buffer.ownedData,
+        duplicate.buffer.ownedData,
+        duplicate.buffer.numBytes);
   } else {
     VELOX_CHECK(
-        !source.tinyData.empty(), "Duplicate tiny region source is empty");
-    duplicate.tinyData = source.tinyData;
+        !source.buffer.tinyData.empty(),
+        "Duplicate tiny region source is empty");
+    duplicate.buffer.tinyData = source.buffer.tinyData;
   }
 }
 } // namespace
@@ -375,50 +379,18 @@ std::unique_ptr<SeekableInputStream> DirectBufferedInput::read(
 }
 
 std::vector<cache::CachePin> DirectCoalescedLoad::loadData(bool prefetch) {
-  std::vector<folly::Range<char*>> buffers;
-  int64_t lastEnd = requests_[0].region.offset;
+  const int64_t baselineWaste = computeLoadSizes();
+
+  // Use the arena only when per-request page-rounding would waste more than the
+  // arena's minimum run; below that its own floor would over-reserve.
+  constexpr int64_t kArenaMinSavingsBytes =
+      static_cast<int64_t>(memory::AllocationPool::kMinPages) *
+      static_cast<int64_t>(memory::AllocationTraits::kPageSize);
+  const bool useArena = baselineWaste > kArenaMinSavingsBytes;
+
   int64_t size = 0;
   int64_t overread = 0;
-
-  for (size_t i = 0; i < requests_.size(); ++i) {
-    auto& request = requests_[i];
-    const auto& region = request.region;
-    if (i > 0 && duplicateRegion(requests_[i - 1], request)) {
-      const auto& prev = requests_[i - 1];
-      request.loadSize = prev.loadSize;
-      continue;
-    }
-
-    if (region.offset > lastEnd) {
-      buffers.push_back(
-          folly::Range<char*>(
-              nullptr,
-              reinterpret_cast<char*>(
-                  static_cast<uint64_t>(region.offset - lastEnd))));
-      overread += buffers.back().size();
-    }
-
-    if (region.length > DirectBufferedInput::kTinySize) {
-      if (&request != &requests_.back()) {
-        // Case where request is a little over quantum but is followed by
-        // another within the max distance. Coalesces and allows reading the
-        // region of max quantum + max distance in one piece.
-        request.loadSize = region.length;
-      } else {
-        request.loadSize = std::min<int32_t>(region.length, loadQuantum_);
-      }
-      const auto numPages =
-          memory::AllocationTraits::numPages(request.loadSize);
-      pool_->allocateNonContiguous(numPages, request.data);
-      appendRanges(request.data, request.loadSize, buffers);
-    } else {
-      request.loadSize = region.length;
-      request.tinyData.resize(region.length);
-      buffers.push_back(folly::Range(request.tinyData.data(), region.length));
-    }
-    lastEnd = region.offset + request.loadSize;
-    size += request.loadSize;
-  }
+  const auto buffers = buildReadRanges(useArena, size, overread);
 
   uint64_t usecs = 0;
   {
@@ -428,49 +400,133 @@ std::vector<cache::CachePin> DirectCoalescedLoad::loadData(bool prefetch) {
 
   ioStatistics_->read().increment(size + overread);
   ioStatistics_->incRawBytesRead(size);
-  ioStatistics_->incTotalScanTimeNs(usecs * 1'000);
+  ioStatistics_->incTotalScanTimeNs(static_cast<int64_t>(usecs * 1'000));
   ioStatistics_->queryThreadIoLatencyUs().increment(usecs);
   ioStatistics_->storageReadLatencyUs().increment(usecs);
   ioStatistics_->incRawOverreadBytes(overread);
   if (prefetch) {
     ioStatistics_->prefetch().increment(size + overread);
   }
-  for (size_t i = 0; i < requests_.size(); ++i) {
-    auto& request = requests_[i];
-    if (i == 0 || !duplicateRegion(requests_[i - 1], request)) {
-      continue;
-    }
-    copyDuplicateRegion(requests_[i - 1], request, pool_);
-  }
+
+  fillDuplicates(useArena);
+
   TestValue::adjust(
       "facebook::velox::cache::DirectCoalescedLoad::loadData", this);
   return {};
 }
 
-int32_t DirectCoalescedLoad::getData(
-    int64_t offset,
-    memory::Allocation& data,
-    std::string& tinyData) {
-  auto it = std::lower_bound(
-      requests_.begin(), requests_.end(), offset, [](auto& x, auto offset) {
-        return x.region.offset < offset;
-      });
-  if (it == requests_.cend() || it->region.offset != offset) {
-    return 0;
+int64_t DirectCoalescedLoad::computeLoadSizes() {
+  int64_t baselineWaste = 0;
+  for (size_t i = 0; i < requests_.size(); ++i) {
+    auto& request = requests_[i];
+    const auto& region = request.region;
+    if (i > 0 && duplicateRegion(requests_[i - 1], request)) {
+      request.buffer.numBytes = requests_[i - 1].buffer.numBytes;
+      continue;
+    }
+    if (region.length > DirectBufferedInput::kTinySize) {
+      if (&request != &requests_.back()) {
+        // Request is a little over quantum but is followed by another within
+        // the max distance. Coalesce and read the whole region in one piece.
+        request.buffer.numBytes = static_cast<int32_t>(region.length);
+      } else {
+        request.buffer.numBytes = static_cast<int32_t>(
+            std::min<uint64_t>(region.length, loadQuantum_));
+      }
+      const auto paddedBytes =
+          memory::AllocationTraits::roundUpPageBytes(request.buffer.numBytes);
+      baselineWaste +=
+          static_cast<int64_t>(paddedBytes) - request.buffer.numBytes;
+    } else {
+      request.buffer.numBytes = static_cast<int32_t>(region.length);
+    }
   }
-  // Duplicate regions have the same offset. Skip buffers already handed to
-  // earlier streams so each duplicate stream gets its own copied buffer.
+  return baselineWaste;
+}
+
+std::vector<folly::Range<char*>> DirectCoalescedLoad::buildReadRanges(
+    bool useArena,
+    int64_t& size,
+    int64_t& overread) {
+  std::vector<folly::Range<char*>> buffers;
+  uint64_t lastEnd = requests_[0].region.offset;
+  for (size_t i = 0; i < requests_.size(); ++i) {
+    auto& request = requests_[i];
+    const auto& region = request.region;
+    if (i > 0 && duplicateRegion(requests_[i - 1], request)) {
+      // Shares the source's buffer; filled by fillDuplicates() after the read.
+      continue;
+    }
+    if (region.offset > lastEnd) {
+      buffers.emplace_back(
+          nullptr,
+          // NOLINTNEXTLINE(performance-no-int-to-ptr)
+          reinterpret_cast<char*>(
+              static_cast<uint64_t>(region.offset - lastEnd)));
+      overread += static_cast<int64_t>(buffers.back().size());
+    }
+
+    if (region.length <= DirectBufferedInput::kTinySize) {
+      request.buffer.tinyData.resize(region.length);
+      buffers.emplace_back(request.buffer.tinyData.data(), region.length);
+    } else if (useArena) {
+      request.buffer.arenaData = arena_.allocateFixed(request.buffer.numBytes);
+      buffers.emplace_back(request.buffer.arenaData, request.buffer.numBytes);
+    } else {
+      const auto numPages =
+          memory::AllocationTraits::numPages(request.buffer.numBytes);
+      pool_->allocateNonContiguous(numPages, request.buffer.ownedData);
+      appendRanges(request.buffer.ownedData, request.buffer.numBytes, buffers);
+    }
+    lastEnd = region.offset + request.buffer.numBytes;
+    size += request.buffer.numBytes;
+  }
+  return buffers;
+}
+
+void DirectCoalescedLoad::fillDuplicates(bool useArena) {
+  for (size_t i = 0; i < requests_.size(); ++i) {
+    auto& request = requests_[i];
+    if (i == 0 || !duplicateRegion(requests_[i - 1], request)) {
+      continue;
+    }
+    // Arena duplicates share the source's slice (no copy); tiny and non-arena
+    // duplicates own a copy. Gate on 'useArena', not the predecessor's
+    // 'arenaData', so a 3+ duplicate chain still copies correctly.
+    if (request.region.length <= DirectBufferedInput::kTinySize || !useArena) {
+      copyDuplicateRegion(requests_[i - 1], request, pool_);
+    }
+  }
+}
+
+LoadedBuffer DirectCoalescedLoad::getData(uint64_t offset) {
+  auto it = std::lower_bound(
+      requests_.begin(),
+      requests_.end(),
+      offset,
+      [](const auto& request, uint64_t targetOffset) {
+        return request.region.offset < targetOffset;
+      });
+  if (it == requests_.end() || it->region.offset != offset) {
+    return {};
+  }
+  if (it->buffer.arenaData != nullptr) {
+    // Arena duplicates share one read-only slice; nothing is moved.
+    return LoadedBuffer{
+        .arenaData = it->buffer.arenaData,
+        .numBytes = it->buffer.numBytes,
+    };
+  }
+  // Skip buffers already handed to earlier duplicate streams.
   while (it != requests_.end() && it->region.offset == offset &&
          it->bufferConsumed) {
     ++it;
   }
-  if (it == requests_.cend() || it->region.offset != offset) {
-    return 0;
+  if (it == requests_.end() || it->region.offset != offset) {
+    return {};
   }
-  data = std::move(it->data);
-  tinyData = std::move(it->tinyData);
   it->bufferConsumed = true;
-  return it->loadSize;
+  return std::move(it->buffer);
 }
 
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/DirectBufferedInput.cpp
+++ b/velox/dwio/common/DirectBufferedInput.cpp
@@ -202,7 +202,8 @@ void DirectBufferedInput::readRegion(
       groupId_.id(),
       requests,
       pool_,
-      options_.loadQuantum());
+      options_.loadQuantum(),
+      options_.directBufferedInputSharedAllocation());
   coalescedLoads_.push_back(load);
   streamToCoalescedLoad_.withWLock([&](auto& loads) {
     for (auto& request : requests) {
@@ -292,20 +293,37 @@ bool duplicateRegion(const LoadRequest& source, const LoadRequest& duplicate) {
       duplicate.region.length == source.region.length;
 }
 
-void copyDuplicateRegion(
+// Gives 'duplicate' its own copy of the source's bytes, unless it can share the
+// source's slice of the shared allocation. Duplicates left uncopied resolve to
+// the source's slice in getData(), which finds the first request at the offset.
+// Gates on 'useSharedAllocation' rather than the source's 'sharedData' so a 3+
+// duplicate chain still copies correctly.
+void maybeCopyDuplicateRegion(
     const LoadRequest& source,
     LoadRequest& duplicate,
-    memory::MemoryPool* pool) {
-  VELOX_CHECK_EQ(source.loadSize, duplicate.loadSize);
-  if (source.data.numPages() > 0) {
+    memory::MemoryPool* pool,
+    bool useSharedAllocation) {
+  if (useSharedAllocation &&
+      duplicate.region.length > DirectBufferedInput::kTinySize) {
+    return;
+  }
+  VELOX_CHECK_EQ(source.buffer.requestBytes, duplicate.buffer.requestBytes);
+  VELOX_CHECK(!source.buffer.empty(), "Duplicate region source is empty");
+  VELOX_CHECK(
+      duplicate.buffer.empty(), "Duplicate region destination is already set");
+  if (source.buffer.ownedData.numPages() > 0) {
     const auto numPages =
-        memory::AllocationTraits::numPages(duplicate.loadSize);
-    pool->allocateNonContiguous(numPages, duplicate.data);
-    memory::Allocation::copy(source.data, duplicate.data, duplicate.loadSize);
+        memory::AllocationTraits::numPages(duplicate.buffer.requestBytes);
+    pool->allocateNonContiguous(numPages, duplicate.buffer.ownedData);
+    memory::Allocation::copy(
+        source.buffer.ownedData,
+        duplicate.buffer.ownedData,
+        duplicate.buffer.requestBytes);
   } else {
     VELOX_CHECK(
-        !source.tinyData.empty(), "Duplicate tiny region source is empty");
-    duplicate.tinyData = source.tinyData;
+        !source.buffer.tinyData.empty(),
+        "Duplicate tiny region source is empty");
+    duplicate.buffer.tinyData = source.buffer.tinyData;
   }
 }
 } // namespace
@@ -375,52 +393,22 @@ std::unique_ptr<SeekableInputStream> DirectBufferedInput::read(
 }
 
 std::vector<cache::CachePin> DirectCoalescedLoad::loadData(bool prefetch) {
-  std::vector<folly::Range<char*>> buffers;
-  int64_t lastEnd = requests_[0].region.offset;
+  const int64_t overAllocatedBytes = computeLoadSizes();
+
+  // Use the shared allocation only when per-request page-rounding would
+  // over-allocate more than its minimum run; below that its own floor would
+  // over-reserve.
+  constexpr int64_t kMinPaddingBytesToUseSharedAllocation =
+      static_cast<int64_t>(memory::AllocationPool::kMinPages) *
+      static_cast<int64_t>(memory::AllocationTraits::kPageSize);
+  const bool useSharedAllocation = sharedAllocationEnabled_ &&
+      overAllocatedBytes > kMinPaddingBytesToUseSharedAllocation;
+
   int64_t size = 0;
   int64_t overread = 0;
+  const auto buffers = buildReadRanges(useSharedAllocation, size, overread);
 
-  for (size_t i = 0; i < requests_.size(); ++i) {
-    auto& request = requests_[i];
-    const auto& region = request.region;
-    if (i > 0 && duplicateRegion(requests_[i - 1], request)) {
-      const auto& prev = requests_[i - 1];
-      request.loadSize = prev.loadSize;
-      continue;
-    }
-
-    if (region.offset > lastEnd) {
-      buffers.push_back(
-          folly::Range<char*>(
-              nullptr,
-              reinterpret_cast<char*>(
-                  static_cast<uint64_t>(region.offset - lastEnd))));
-      overread += buffers.back().size();
-    }
-
-    if (region.length > DirectBufferedInput::kTinySize) {
-      if (&request != &requests_.back()) {
-        // Case where request is a little over quantum but is followed by
-        // another within the max distance. Coalesces and allows reading the
-        // region of max quantum + max distance in one piece.
-        request.loadSize = region.length;
-      } else {
-        request.loadSize = std::min<int32_t>(region.length, loadQuantum_);
-      }
-      const auto numPages =
-          memory::AllocationTraits::numPages(request.loadSize);
-      pool_->allocateNonContiguous(numPages, request.data);
-      appendRanges(request.data, request.loadSize, buffers);
-    } else {
-      request.loadSize = region.length;
-      request.tinyData.resize(region.length);
-      buffers.push_back(folly::Range(request.tinyData.data(), region.length));
-    }
-    lastEnd = region.offset + request.loadSize;
-    size += request.loadSize;
-  }
-
-  uint64_t usecs = 0;
+  uint64_t usecs{0};
   {
     MicrosecondWallTimer timer(&usecs);
     input_->read(buffers, requests_[0].region.offset, LogType::FILE);
@@ -428,54 +416,147 @@ std::vector<cache::CachePin> DirectCoalescedLoad::loadData(bool prefetch) {
 
   ioStatistics_->read().increment(size + overread);
   ioStatistics_->incRawBytesRead(size);
-  ioStatistics_->incTotalScanTimeNs(usecs * 1'000);
+  ioStatistics_->incTotalScanTimeNs(static_cast<int64_t>(usecs * 1'000));
   ioStatistics_->queryThreadIoLatencyUs().increment(usecs);
   ioStatistics_->storageReadLatencyUs().increment(usecs);
   ioStatistics_->incRawOverreadBytes(overread);
   if (prefetch) {
     ioStatistics_->prefetch().increment(size + overread);
   }
-  for (size_t i = 0; i < requests_.size(); ++i) {
-    auto& request = requests_[i];
-    if (i == 0 || !duplicateRegion(requests_[i - 1], request)) {
-      continue;
-    }
-    copyDuplicateRegion(requests_[i - 1], request, pool_);
-  }
+
+  fillDuplicates(useSharedAllocation);
+
   TestValue::adjust(
       "facebook::velox::cache::DirectCoalescedLoad::loadData", this);
   return {};
 }
 
-int32_t DirectCoalescedLoad::getData(
-    int64_t offset,
-    memory::Allocation& data,
-    std::string& tinyData) {
+int64_t DirectCoalescedLoad::computeLoadSizes() {
+  int64_t overAllocatedBytes{0};
+  for (size_t i = 0; i < requests_.size(); ++i) {
+    auto& request = requests_[i];
+    const auto& region = request.region;
+    if (i > 0 && duplicateRegion(requests_[i - 1], request)) {
+      request.buffer.requestBytes = requests_[i - 1].buffer.requestBytes;
+      continue;
+    }
+    if (region.length > DirectBufferedInput::kTinySize) {
+      if (&request != &requests_.back()) {
+        // Request is a little over quantum but is followed by another within
+        // the max distance. Coalesce and read the whole region in one piece.
+        // This is the only path that does not clamp to 'loadQuantum_', so it is
+        // the only one where an oversized region could overflow the int32_t
+        // 'requestBytes'. Fail loudly instead of truncating: a wrapped value
+        // makes buildReadRanges() read fewer bytes than the region and hand the
+        // stream silently wrong data.
+        VELOX_CHECK_LE(
+            region.length,
+            static_cast<uint64_t>(std::numeric_limits<int32_t>::max()),
+            "Coalesced region is too large to read in one piece");
+        request.buffer.requestBytes = static_cast<int32_t>(region.length);
+      } else {
+        request.buffer.requestBytes = static_cast<int32_t>(
+            std::min<uint64_t>(region.length, loadQuantum_));
+      }
+      const auto paddedBytes = memory::AllocationTraits::roundUpPageBytes(
+          request.buffer.requestBytes);
+      overAllocatedBytes +=
+          static_cast<int64_t>(paddedBytes) - request.buffer.requestBytes;
+    } else {
+      request.buffer.requestBytes = static_cast<int32_t>(region.length);
+    }
+  }
+  return overAllocatedBytes;
+}
+
+std::vector<folly::Range<char*>> DirectCoalescedLoad::buildReadRanges(
+    bool useSharedAllocation,
+    int64_t& size,
+    int64_t& overread) {
+  std::vector<folly::Range<char*>> buffers;
+  uint64_t lastEnd = requests_[0].region.offset;
+  for (size_t i = 0; i < requests_.size(); ++i) {
+    auto& request = requests_[i];
+    const auto& region = request.region;
+    if (i > 0 && duplicateRegion(requests_[i - 1], request)) {
+      // Shares the source's buffer; filled by fillDuplicates() after the read.
+      continue;
+    }
+    if (region.offset > lastEnd) {
+      buffers.emplace_back(
+          nullptr,
+          // NOLINTNEXTLINE(performance-no-int-to-ptr)
+          reinterpret_cast<char*>(
+              static_cast<uint64_t>(region.offset - lastEnd)));
+      overread += static_cast<int64_t>(buffers.back().size());
+    }
+
+    if (region.length <= DirectBufferedInput::kTinySize) {
+      request.buffer.tinyData.resize(region.length);
+      buffers.emplace_back(request.buffer.tinyData.data(), region.length);
+    } else if (useSharedAllocation) {
+      request.buffer.sharedData =
+          sharedAllocation_.allocateFixed(request.buffer.requestBytes);
+      buffers.emplace_back(
+          request.buffer.sharedData, request.buffer.requestBytes);
+    } else {
+      const auto numPages =
+          memory::AllocationTraits::numPages(request.buffer.requestBytes);
+      pool_->allocateNonContiguous(numPages, request.buffer.ownedData);
+      appendRanges(
+          request.buffer.ownedData, request.buffer.requestBytes, buffers);
+    }
+    lastEnd = region.offset + request.buffer.requestBytes;
+    size += request.buffer.requestBytes;
+  }
+  return buffers;
+}
+
+void DirectCoalescedLoad::fillDuplicates(bool useSharedAllocation) {
+  for (size_t i = 0; i < requests_.size(); ++i) {
+    auto& request = requests_[i];
+    if (i == 0 || !duplicateRegion(requests_[i - 1], request)) {
+      continue;
+    }
+    maybeCopyDuplicateRegion(
+        requests_[i - 1], request, pool_, useSharedAllocation);
+  }
+}
+
+LoadedBuffer DirectCoalescedLoad::getData(uint64_t offset) {
   // A failed read may have partially filled the request buffers. Only publish
   // them after the complete coalesced load has succeeded.
   if (state() != CoalescedLoad::State::kLoaded) {
-    return 0;
+    return {};
   }
   auto it = std::lower_bound(
-      requests_.begin(), requests_.end(), offset, [](auto& x, auto offset) {
-        return x.region.offset < offset;
+      requests_.begin(),
+      requests_.end(),
+      offset,
+      [](const auto& request, uint64_t targetOffset) {
+        return request.region.offset < targetOffset;
       });
-  if (it == requests_.cend() || it->region.offset != offset) {
-    return 0;
+  if (it == requests_.end() || it->region.offset != offset) {
+    return {};
   }
-  // Duplicate regions have the same offset. Skip buffers already handed to
-  // earlier streams so each duplicate stream gets its own copied buffer.
+  if (it->buffer.sharedData != nullptr) {
+    // Duplicates backed by the shared allocation share one read-only slice;
+    // nothing is moved.
+    return LoadedBuffer{
+        .requestBytes = it->buffer.requestBytes,
+        .sharedData = it->buffer.sharedData,
+    };
+  }
+  // Skip buffers already handed to earlier duplicate streams.
   while (it != requests_.end() && it->region.offset == offset &&
          it->bufferConsumed) {
     ++it;
   }
-  if (it == requests_.cend() || it->region.offset != offset) {
-    return 0;
+  if (it == requests_.end() || it->region.offset != offset) {
+    return {};
   }
-  data = std::move(it->data);
-  tinyData = std::move(it->tinyData);
   it->bufferConsumed = true;
-  return it->loadSize;
+  return std::move(it->buffer);
 }
 
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/DirectBufferedInput.h
+++ b/velox/dwio/common/DirectBufferedInput.h
@@ -24,11 +24,25 @@
 #include "velox/common/caching/ScanTracker.h"
 #include "velox/common/io/IoStatistics.h"
 #include "velox/common/io/Options.h"
+#include "velox/common/memory/AllocationPool.h"
 #include "velox/dwio/common/BufferedInput.h"
 #include "velox/dwio/common/CacheInputStream.h"
 #include "velox/dwio/common/InputStream.h"
 
 namespace facebook::velox::dwio::common {
+
+/// Loaded bytes for one region; exactly one representation is live.
+struct LoadedBuffer {
+  /// Borrowed read-only slice in the load's arena. The consumer keeps the
+  /// load alive while reading it.
+  char* arenaData{nullptr};
+  /// Owned non-contiguous allocation, moved to the consumer.
+  memory::Allocation ownedData{};
+  /// Owned bytes for a tiny region, moved to the consumer.
+  std::string tinyData{};
+  /// Number of valid bytes, or 0 if the region was not found.
+  int32_t numBytes{0};
+};
 
 struct LoadRequest {
   LoadRequest() = default;
@@ -46,14 +60,10 @@ struct LoadRequest {
 
   const SeekableInputStream* stream;
 
-  /// Buffers to be handed to 'stream' after load.
-  memory::Allocation data;
-  std::string tinyData;
-  /// Number of bytes in 'data/tinyData'.
-  int32_t loadSize{0};
-  // Set after getData() moves 'data/tinyData' to the owning stream. Duplicate
-  // regions share an offset, so getData() skips consumed buffers to find the
-  // next duplicate buffer.
+  /// Loaded bytes for this request; see LoadedBuffer.
+  LoadedBuffer buffer;
+
+  /// Set once getData() moved 'buffer' out; lets it skip consumed duplicates.
   bool bufferConsumed{false};
 };
 
@@ -73,7 +83,8 @@ class DirectCoalescedLoad : public cache::CoalescedLoad {
         ioStats_(ioStats),
         input_(std::move(input)),
         loadQuantum_(loadQuantum),
-        pool_(pool) {
+        pool_(pool),
+        arena_(pool) {
     VELOX_DCHECK_NOT_NULL(pool_);
     VELOX_DCHECK(
         std::is_sorted(
@@ -96,10 +107,9 @@ class DirectCoalescedLoad : public cache::CoalescedLoad {
     return false;
   }
 
-  /// Returns the buffer for 'region' in either 'data' or 'tinyData'. 'region'
-  /// must match a region given to DirectBufferedInput::enqueue().
-  int32_t
-  getData(int64_t offset, memory::Allocation& data, std::string& tinyData);
+  /// Returns the loaded buffer for the request at 'offset'. 'offset' must match
+  /// a region given to DirectBufferedInput::enqueue().
+  LoadedBuffer getData(uint64_t offset);
 
   const std::vector<LoadRequest>& requests() {
     return requests_;
@@ -114,11 +124,29 @@ class DirectCoalescedLoad : public cache::CoalescedLoad {
   }
 
  private:
+  // Sets each request's 'buffer.numBytes' and returns the bytes the baseline
+  // (one page-rounded allocation per request) would waste on page padding.
+  int64_t computeLoadSizes();
+
+  // Allocates each non-duplicate request's buffer and returns the file-ordered
+  // ranges for the coalesced read. Adds read bytes to 'size', gap bytes to
+  // 'overread'; uses the arena for non-tiny buffers when 'useArena' is set.
+  std::vector<folly::Range<char*>>
+  buildReadRanges(bool useArena, int64_t& size, int64_t& overread);
+
+  // Gives each duplicate region its buffer after the read: a copy of the source
+  // for tiny and non-arena duplicates; arena duplicates share the source's
+  // slice and are left untouched.
+  void fillDuplicates(bool useArena);
+
   const std::shared_ptr<IoStatistics> ioStatistics_;
   const std::shared_ptr<velox::IoStats> ioStats_;
   const std::shared_ptr<ReadFileInputStream> input_;
   const int32_t loadQuantum_;
   memory::MemoryPool* const pool_;
+  // Arena backing all non-tiny request buffers; bump-packs them into a few
+  // allocations, freed as a unit on destruction.
+  memory::AllocationPool arena_;
   std::vector<LoadRequest> requests_;
 };
 

--- a/velox/dwio/common/DirectBufferedInput.h
+++ b/velox/dwio/common/DirectBufferedInput.h
@@ -24,11 +24,34 @@
 #include "velox/common/caching/ScanTracker.h"
 #include "velox/common/io/IoStatistics.h"
 #include "velox/common/io/Options.h"
+#include "velox/common/memory/AllocationPool.h"
 #include "velox/dwio/common/BufferedInput.h"
 #include "velox/dwio/common/CacheInputStream.h"
 #include "velox/dwio/common/InputStream.h"
 
 namespace facebook::velox::dwio::common {
+
+/// Loaded bytes for one region. At most one of the three representations
+/// below -- 'sharedData', 'ownedData', 'tinyData' -- is ever set; all three are
+/// unset until the region is loaded.
+struct LoadedBuffer {
+  /// Number of request bytes, or 0 if the region was not found.
+  int32_t requestBytes{0};
+  /// Borrowed read-only slice in the load's shared allocation. The consumer
+  /// keeps the load alive while reading it.
+  char* sharedData{nullptr};
+  /// Owned non-contiguous allocation, moved to the consumer.
+  memory::Allocation ownedData{};
+  /// Owned bytes for a tiny region, moved to the consumer.
+  std::string tinyData{};
+
+  /// True when no representation holds bytes, i.e. nothing has been loaded for
+  /// this region yet.
+  bool empty() const {
+    return sharedData == nullptr && ownedData.numPages() == 0 &&
+        tinyData.empty();
+  }
+};
 
 struct LoadRequest {
   LoadRequest() = default;
@@ -46,14 +69,10 @@ struct LoadRequest {
 
   const SeekableInputStream* stream;
 
-  /// Buffers to be handed to 'stream' after load.
-  memory::Allocation data;
-  std::string tinyData;
-  /// Number of bytes in 'data/tinyData'.
-  int32_t loadSize{0};
-  // Set after getData() moves 'data/tinyData' to the owning stream. Duplicate
-  // regions share an offset, so getData() skips consumed buffers to find the
-  // next duplicate buffer.
+  /// Loaded bytes for this request; see LoadedBuffer.
+  LoadedBuffer buffer;
+
+  /// Set once getData() moved 'buffer' out; lets it skip consumed duplicates.
   bool bufferConsumed{false};
 };
 
@@ -67,13 +86,16 @@ class DirectCoalescedLoad : public cache::CoalescedLoad {
       uint64_t /* groupId */,
       const std::vector<LoadRequest*>& requests,
       memory::MemoryPool* pool,
-      int32_t loadQuantum)
+      int32_t loadQuantum,
+      bool sharedAllocationEnabled)
       : CoalescedLoad({}, {}),
         ioStatistics_(ioStatistics),
         ioStats_(ioStats),
         input_(std::move(input)),
         loadQuantum_(loadQuantum),
-        pool_(pool) {
+        sharedAllocationEnabled_(sharedAllocationEnabled),
+        pool_(pool),
+        sharedAllocation_(pool) {
     VELOX_DCHECK_NOT_NULL(pool_);
     VELOX_DCHECK(
         std::is_sorted(
@@ -96,10 +118,9 @@ class DirectCoalescedLoad : public cache::CoalescedLoad {
     return false;
   }
 
-  /// Returns the buffer for 'region' in either 'data' or 'tinyData'. 'region'
-  /// must match a region given to DirectBufferedInput::enqueue().
-  int32_t
-  getData(int64_t offset, memory::Allocation& data, std::string& tinyData);
+  /// Returns the loaded buffer for the request at 'offset'. 'offset' must match
+  /// a region given to DirectBufferedInput::enqueue().
+  LoadedBuffer getData(uint64_t offset);
 
   const std::vector<LoadRequest>& requests() {
     return requests_;
@@ -114,11 +135,33 @@ class DirectCoalescedLoad : public cache::CoalescedLoad {
   }
 
  private:
+  // Sets each request's 'buffer.requestBytes' and returns the total
+  // page-padding bytes that per-request allocations would over-allocate.
+  int64_t computeLoadSizes();
+
+  // Allocates each non-duplicate request's buffer and returns the file-ordered
+  // ranges for the coalesced read. Adds read bytes to 'size', gap bytes to
+  // 'overread'; serves non-tiny buffers from the shared allocation when
+  // 'useSharedAllocation' is set.
+  std::vector<folly::Range<char*>>
+  buildReadRanges(bool useSharedAllocation, int64_t& size, int64_t& overread);
+
+  // Gives each duplicate region its buffer after the read: a copy of the source
+  // for tiny duplicates and for per-request allocations; duplicates backed by
+  // the shared allocation share the source's slice and are left untouched.
+  void fillDuplicates(bool useSharedAllocation);
+
   const std::shared_ptr<IoStatistics> ioStatistics_;
   const std::shared_ptr<velox::IoStats> ioStats_;
   const std::shared_ptr<ReadFileInputStream> input_;
   const int32_t loadQuantum_;
+  // Whether the shared allocation may back this load's buffers at all. When
+  // false, every request keeps its own page-rounded allocation.
+  const bool sharedAllocationEnabled_;
   memory::MemoryPool* const pool_;
+  // Shared allocation backing all non-tiny request buffers; bump-packs them
+  // into a few allocations, freed as a unit on destruction.
+  memory::AllocationPool sharedAllocation_;
   std::vector<LoadRequest> requests_;
 };
 

--- a/velox/dwio/common/DirectInputStream.cpp
+++ b/velox/dwio/common/DirectInputStream.cpp
@@ -186,7 +186,13 @@ void DirectInputStream::loadPosition() {
           waitFuture.wait();
         }
         loadedRegion_.offset = region_.offset;
-        loadedRegion_.length = load->getData(region_.offset, data_, tinyData_);
+        auto loaded = load->getData(region_.offset);
+        loadedRegion_.length = loaded.numBytes;
+        data_ = std::move(loaded.ownedData);
+        tinyData_ = std::move(loaded.tinyData);
+        if (loaded.arenaData != nullptr) {
+          arena_ = {loaded.arenaData, load};
+        }
       }
       ioStats_->queryThreadIoLatencyUs().increment(loadUs);
       // DirectCoalescedLoad always reads from remote storage, not SSD.
@@ -203,6 +209,9 @@ void DirectInputStream::loadPosition() {
       region_.offset + offsetInRegion_ < loadedRegion_.offset ||
       region_.offset + offsetInRegion_ >=
           loadedRegion_.offset + loadedRegion_.length) {
+    // Outside the loaded range: drop the arena buffer; loadSync() reloads
+    // below.
+    arena_.reset();
     loadedRegion_.offset = region_.offset + offsetInRegion_;
     loadedRegion_.length = (offsetInRegion_ + loadQuantum_ <= region_.length)
         ? loadQuantum_
@@ -213,9 +222,23 @@ void DirectInputStream::loadPosition() {
     loadSync();
   }
 
+  // Priority dispatch below would mask a double-set; assert at most one is
+  // live.
+  VELOX_DCHECK_LE(
+      static_cast<int>(arena_.data != nullptr) +
+          static_cast<int>(data_.numPages() > 0) +
+          static_cast<int>(!tinyData_.empty()),
+      1,
+      "DirectInputStream has multiple live buffer representations");
+
   const auto offsetInData =
       offsetInRegion_ - (loadedRegion_.offset - region_.offset);
-  if (data_.numPages() == 0) {
+  if (arena_) {
+    run_ = reinterpret_cast<uint8_t*>(const_cast<char*>(arena_.data));
+    runSize_ = static_cast<uint32_t>(loadedRegion_.length);
+    offsetInRun_ = static_cast<int>(offsetInData);
+    offsetOfRun_ = 0;
+  } else if (data_.numPages() == 0) {
     run_ = reinterpret_cast<uint8_t*>(tinyData_.data());
     runSize_ = tinyData_.size();
     offsetInRun_ = offsetInData;

--- a/velox/dwio/common/DirectInputStream.cpp
+++ b/velox/dwio/common/DirectInputStream.cpp
@@ -130,20 +130,59 @@ makeRanges(size_t size, memory::Allocation& data, std::string& tinyData) {
 }
 } // namespace
 
+void DirectInputStream::LoadedData::set(
+    LoadedBuffer&& loaded,
+    std::shared_ptr<void> load) {
+  // 'owned' must be empty; loadPosition() reaches set() once per stream under
+  // 'loaded_'. Allocation's move assignment rebinds the runs without
+  // returning the old ones to the pool, so overwriting a live allocation
+  // loses its pages while the pool keeps counting them until teardown.
+  // valid() below does not catch that: it counts live representations, and a
+  // dropped one still reads as valid. Hard check, not a DCHECK, because the
+  // failure is a silent leak; not repaired by freeing here, because a second
+  // set() on one stream means the load lifecycle changed and needs review.
+  VELOX_CHECK_EQ(owned.numPages(), 0, "set() would drop a live allocation");
+
+  // Drop any previous slice first. Adopting 'loaded' must not leave a stale
+  // borrowed pointer live alongside the new representation, since
+  // loadPosition() dispatches on the shared slice ahead of the owned ones.
+  resetShared();
+  owned = std::move(loaded.ownedData);
+  tiny = std::move(loaded.tinyData);
+  if (loaded.sharedData != nullptr) {
+    sharedPtr = loaded.sharedData;
+    sharedHolder = std::move(load);
+  }
+  VELOX_CHECK(valid(), "Loaded data has multiple live representations");
+}
+
+bool DirectInputStream::LoadedData::valid() const {
+  return (static_cast<int>(sharedPtr != nullptr) +
+          static_cast<int>(owned.numPages() > 0) +
+          static_cast<int>(!tiny.empty())) <= 1;
+}
+
+void DirectInputStream::LoadedData::resetShared() {
+  sharedPtr = nullptr;
+  sharedHolder.reset();
+}
+
 void DirectInputStream::loadSync() {
   if (region_.length < DirectBufferedInput::kTinySize &&
-      data_.numPages() == 0) {
-    tinyData_.resize(region_.length);
+      loadedData_.owned.numPages() == 0) {
+    loadedData_.tiny.resize(region_.length);
   } else {
     const auto numPages =
         memory::AllocationTraits::numPages(loadedRegion_.length);
-    if (numPages > data_.numPages()) {
-      bufferedInput_->pool()->allocateNonContiguous(numPages, data_);
+    if (numPages > loadedData_.owned.numPages()) {
+      bufferedInput_->pool()->allocateNonContiguous(
+          numPages, loadedData_.owned);
     }
   }
 
   ioStats_->incRawBytesRead(loadedRegion_.length);
-  auto ranges = makeRanges(loadedRegion_.length, data_, tinyData_);
+  auto ranges =
+      makeRanges(loadedRegion_.length, loadedData_.owned, loadedData_.tiny);
   uint64_t usecs = 0;
   {
     MicrosecondWallTimer timer(&usecs);
@@ -186,7 +225,9 @@ void DirectInputStream::loadPosition() {
           waitFuture.wait();
         }
         loadedRegion_.offset = region_.offset;
-        loadedRegion_.length = load->getData(region_.offset, data_, tinyData_);
+        auto loaded = load->getData(region_.offset);
+        loadedRegion_.length = loaded.requestBytes;
+        loadedData_.set(std::move(loaded), load);
       }
       ioStats_->queryThreadIoLatencyUs().increment(loadUs);
       // DirectCoalescedLoad always reads from remote storage, not SSD.
@@ -203,6 +244,9 @@ void DirectInputStream::loadPosition() {
       region_.offset + offsetInRegion_ < loadedRegion_.offset ||
       region_.offset + offsetInRegion_ >=
           loadedRegion_.offset + loadedRegion_.length) {
+    // Outside the loaded range: drop the borrowed slice; loadSync() reloads
+    // below.
+    loadedData_.resetShared();
     loadedRegion_.offset = region_.offset + offsetInRegion_;
     loadedRegion_.length = (offsetInRegion_ + loadQuantum_ <= region_.length)
         ? loadQuantum_
@@ -213,17 +257,26 @@ void DirectInputStream::loadPosition() {
     loadSync();
   }
 
+  VELOX_DCHECK(
+      loadedData_.valid(),
+      "DirectInputStream has multiple live buffer representations");
+
   const auto offsetInData =
       offsetInRegion_ - (loadedRegion_.offset - region_.offset);
-  if (data_.numPages() == 0) {
-    run_ = reinterpret_cast<uint8_t*>(tinyData_.data());
-    runSize_ = tinyData_.size();
+  if (loadedData_.hasShared()) {
+    run_ = reinterpret_cast<uint8_t*>(const_cast<char*>(loadedData_.sharedPtr));
+    runSize_ = static_cast<uint32_t>(loadedRegion_.length);
+    offsetInRun_ = static_cast<int>(offsetInData);
+    offsetOfRun_ = 0;
+  } else if (loadedData_.owned.numPages() == 0) {
+    run_ = reinterpret_cast<uint8_t*>(loadedData_.tiny.data());
+    runSize_ = static_cast<uint32_t>(loadedData_.tiny.size());
     offsetInRun_ = offsetInData;
     offsetOfRun_ = 0;
   } else {
-    data_.findRun(offsetInData, &runIndex_, &offsetInRun_);
+    loadedData_.owned.findRun(offsetInData, &runIndex_, &offsetInRun_);
     offsetOfRun_ = offsetInData - offsetInRun_;
-    auto run = data_.runAt(runIndex_);
+    auto run = loadedData_.owned.runAt(runIndex_);
     run_ = run.data();
     runSize_ = memory::AllocationTraits::pageBytes(run.numPages());
     if (offsetOfRun_ + runSize_ > loadedRegion_.length) {

--- a/velox/dwio/common/DirectInputStream.h
+++ b/velox/dwio/common/DirectInputStream.h
@@ -91,6 +91,21 @@ class DirectInputStream : public SeekableInputStream {
   // Contains the data if the range is too small for Allocation.
   std::string tinyData_;
 
+  // Borrowed arena slice plus a hold on the owning load, bundled so the pointer
+  // and keep-alive can never desync. Empty when not arena-backed.
+  struct ArenaBuffer {
+    const char* data{nullptr};
+    std::shared_ptr<void> hold;
+    explicit operator bool() const {
+      return data != nullptr;
+    }
+    void reset() {
+      data = nullptr;
+      hold.reset();
+    }
+  };
+  ArenaBuffer arena_;
+
   // Pointer to start of current run in 'entry->nonContiguousData()' or
   // 'entry->contiguousData()'.
   uint8_t* run_{nullptr};

--- a/velox/dwio/common/DirectInputStream.h
+++ b/velox/dwio/common/DirectInputStream.h
@@ -25,6 +25,7 @@
 namespace facebook::velox::dwio::common {
 
 class DirectBufferedInput;
+struct LoadedBuffer;
 
 /// An input stream over possibly coalesced loads. Created by
 /// DirectBufferedInput. Similar to CacheInputStream but does not use cache.
@@ -56,15 +57,15 @@ class DirectInputStream : public SeekableInputStream {
       memory::Allocation*& data,
       std::string*& tinyData) {
     loadedRegion = loadedRegion_;
-    data = &data_;
-    tinyData = &tinyData_;
+    data = &loadedData_.owned;
+    tinyData = &loadedData_.tiny;
   }
 
  private:
-  // Ensures that the current position is covered by 'data_'.
+  // Ensures that the current position is covered by 'loadedData_'.
   void loadPosition();
 
-  // Synchronously sets 'data_' to cover loadedRegion_'.
+  // Synchronously sets 'loadedData_' to cover 'loadedRegion_'.
   void loadSync();
 
   DirectBufferedInput* const bufferedInput_;
@@ -80,28 +81,59 @@ class DirectInputStream : public SeekableInputStream {
   // Maximum number of bytes read from 'input' at a time.
   const int32_t loadQuantum_;
 
-  // The part of 'region_' that is loaded into 'data_'/'tinyData_'. Relative to
-  // file start.
+  // The part of 'region_' that is loaded into 'loadedData_'. Relative to file
+  // start.
   velox::common::Region loadedRegion_;
 
-  // Allocation with loaded data. Has space for region.length or loadQuantum_
-  // bytes, whichever is less.
-  memory::Allocation data_;
+  // The loaded bytes for 'loadedRegion_', held in exactly one of three
+  // representations.
+  struct LoadedData {
+    // Allocation with loaded data. Has space for region.length or loadQuantum_
+    // bytes, whichever is less.
+    memory::Allocation owned;
 
-  // Contains the data if the range is too small for Allocation.
-  std::string tinyData_;
+    // Contains the data if the range is too small for Allocation.
+    std::string tiny;
+
+    // Borrowed slice of the load's shared allocation plus a hold on the owning
+    // load, bundled so the pointer and keep-alive can never desync. Null when
+    // the bytes are not backed by the shared allocation.
+    const char* sharedPtr{nullptr};
+    std::shared_ptr<void> sharedHolder;
+
+    // Adopts the buffers of a completed coalesced load. 'load' is retained only
+    // when the bytes are a borrowed slice of that load's shared allocation, so
+    // the slice cannot outlive its owner.
+    void set(LoadedBuffer&& loaded, std::shared_ptr<void> load);
+
+    // True when at most one representation holds bytes. The priority dispatch
+    // in loadPosition() picks the first live one, so a double-set would be
+    // silently masked rather than caught.
+    bool valid() const;
+
+    // Drops the borrowed slice. 'owned' is deliberately left in place: an
+    // Allocation is only freeable through its pool, and loadSync() reuses it
+    // whenever it is already large enough, so clearing it here would force a
+    // fresh allocation on every quantum advance.
+    void resetShared();
+
+    bool hasShared() const {
+      return sharedPtr != nullptr;
+    }
+  };
+  LoadedData loadedData_;
 
   // Pointer to start of current run in 'entry->nonContiguousData()' or
   // 'entry->contiguousData()'.
   uint8_t* run_{nullptr};
 
-  // Offset of current run from start of 'data_'
+  // Offset of current run from start of 'loadedData_.owned'
   uint64_t offsetOfRun_;
 
   // Position of stream relative to 'run_'.
   int offsetInRun_{0};
 
-  // Index of run in 'data_'
+  // Index of run in 'loadedData_.owned'
   int runIndex_ = -1;
 
   // Number of valid bytes starting at 'run_'

--- a/velox/dwio/common/tests/DirectBufferedInputTest.cpp
+++ b/velox/dwio/common/tests/DirectBufferedInputTest.cpp
@@ -349,6 +349,309 @@ TEST_F(DirectBufferedInputTest, duplicateRegionsShareCoalescedRead) {
   }
 }
 
+// Arena path with a duplicate region: each region is read once and the
+// duplicate shares the source's arena slice.
+TEST_F(DirectBufferedInputTest, duplicateRegionsShareArenaRead) {
+  constexpr int32_t kContentSize = 4 << 20; // 4MB
+  std::string content;
+  content.resize(kContentSize);
+  for (int32_t i = 0; i < kContentSize; ++i) {
+    content[i] = static_cast<char>(i % 251);
+  }
+
+  // 32 regions just over a page each waste ~128KB total, over the arena floor.
+  constexpr int32_t kNumRegions = 32;
+  constexpr int32_t kRegionSize = 4'097;
+
+  auto readFile = std::make_shared<tests::utils::CountingReadFile>(content);
+
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
+  readerOptions.setLoadQuantum(1 << 20);
+
+  auto& ids = fileIds();
+  StringIdLease fileId(ids, "arenaDup");
+  StringIdLease groupId(ids, "arenaDupGroup");
+
+  DirectBufferedInput input(
+      readFile,
+      MetricsLog::voidLog(),
+      std::move(fileId),
+      tracker_,
+      std::move(groupId),
+      dataIoStats_,
+      nullptr,
+      executor_.get(),
+      readerOptions);
+
+  // Adjacent distinct regions, then a duplicate of region 0.
+  std::vector<std::unique_ptr<SeekableInputStream>> streams;
+  streams.reserve(kNumRegions);
+  for (int32_t k = 0; k < kNumRegions; ++k) {
+    streams.push_back(input.enqueue(
+        common::Region{static_cast<uint64_t>(k) * kRegionSize, kRegionSize},
+        nullptr));
+    ASSERT_NE(streams.back(), nullptr);
+  }
+  auto dupStream = input.enqueue(common::Region{0, kRegionSize}, nullptr);
+  ASSERT_NE(dupStream, nullptr);
+  // Second duplicate of region 0: a 3-chain exercising the intermediate
+  // duplicate (its predecessor is itself a duplicate).
+  auto dupStream2 = input.enqueue(common::Region{0, kRegionSize}, nullptr);
+  ASSERT_NE(dupStream2, nullptr);
+
+  input.load(LogType::TEST);
+  EXPECT_EQ(input.testingCoalescedLoads().size(), 1);
+
+  // Source and its duplicates return the same bytes, read once.
+  auto src = getNext(*streams[0]);
+  ASSERT_TRUE(src.has_value());
+  EXPECT_EQ(src.value(), content.substr(0, kRegionSize));
+  auto dup = getNext(*dupStream);
+  ASSERT_TRUE(dup.has_value());
+  EXPECT_EQ(dup.value(), content.substr(0, kRegionSize));
+  auto dup2 = getNext(*dupStream2);
+  ASSERT_TRUE(dup2.has_value());
+  EXPECT_EQ(dup2.value(), content.substr(0, kRegionSize));
+  // Only the distinct regions are read; duplicates add none.
+  EXPECT_EQ(readFile->numReads(), kNumRegions);
+
+  // A non-duplicate arena stream still reads its own bytes.
+  auto mid = getNext(*streams[5]);
+  ASSERT_TRUE(mid.has_value());
+  EXPECT_EQ(mid.value(), content.substr(5 * kRegionSize, kRegionSize));
+  EXPECT_EQ(readFile->numReads(), kNumRegions);
+}
+
+// An arena stream whose region exceeds loadQuantum reads the first quantum from
+// the arena and the rest into its own buffer, reproducing the region intact.
+TEST_F(DirectBufferedInputTest, arenaStreamCrossesQuantum) {
+  constexpr int32_t kContentSize = 4 << 20; // 4MB
+  std::string content;
+  content.resize(kContentSize);
+  for (int32_t i = 0; i < kContentSize; ++i) {
+    content[i] = static_cast<char>(i % 251);
+  }
+
+  // 32 non-tiny regions push baselineWaste over the 64KB floor -> useArena.
+  constexpr int32_t kNumSmall = 32;
+  constexpr int32_t kSmallSize = 4'097;
+  constexpr uint64_t kLoadQuantum = 1 << 20; // 1MB
+  const uint64_t bigOffset = static_cast<uint64_t>(kNumSmall) * kSmallSize;
+  constexpr uint64_t kBigSize = (1 << 20) + (512 << 10); // 1.5MB > quantum
+
+  auto readFile = std::make_shared<tests::utils::CountingReadFile>(content);
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
+  readerOptions.setLoadQuantum(kLoadQuantum);
+
+  auto& ids = fileIds();
+  StringIdLease fileId(ids, "arenaQuantum");
+  StringIdLease groupId(ids, "arenaQuantumGroup");
+  DirectBufferedInput input(
+      readFile,
+      MetricsLog::voidLog(),
+      std::move(fileId),
+      tracker_,
+      std::move(groupId),
+      dataIoStats_,
+      nullptr,
+      executor_.get(),
+      readerOptions);
+
+  std::vector<std::unique_ptr<SeekableInputStream>> streams;
+  streams.reserve(kNumSmall);
+  for (int32_t k = 0; k < kNumSmall; ++k) {
+    streams.push_back(input.enqueue(
+        common::Region{static_cast<uint64_t>(k) * kSmallSize, kSmallSize},
+        nullptr));
+  }
+  auto bigStream = input.enqueue(common::Region{bigOffset, kBigSize}, nullptr);
+  ASSERT_NE(bigStream, nullptr);
+
+  input.load(LogType::TEST);
+  ASSERT_EQ(input.testingCoalescedLoads().size(), 1);
+
+  // Read the whole region across the quantum boundary.
+  std::string got;
+  while (auto chunk = getNext(*bigStream)) {
+    got += chunk.value();
+  }
+  EXPECT_EQ(got, content.substr(bigOffset, kBigSize));
+}
+
+// In an arena load, a tiny request is still served from its own 'tinyData' and
+// a tiny duplicate gets its own copy.
+TEST_F(DirectBufferedInputTest, arenaLoadServesTinyAndDuplicates) {
+  constexpr int32_t kContentSize = 4 << 20; // 4MB
+  std::string content;
+  content.resize(kContentSize);
+  for (int32_t i = 0; i < kContentSize; ++i) {
+    content[i] = static_cast<char>(i % 251);
+  }
+
+  constexpr int32_t kNumSmall = 32;
+  constexpr int32_t kSmallSize = 4'097; // non-tiny, drives useArena
+  constexpr int32_t kTinyLen = 100; // <= kTinySize
+  const uint64_t tinyOffset = static_cast<uint64_t>(kNumSmall) * kSmallSize;
+
+  auto readFile = std::make_shared<tests::utils::CountingReadFile>(content);
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
+  readerOptions.setLoadQuantum(1 << 20);
+
+  auto& ids = fileIds();
+  StringIdLease fileId(ids, "arenaTiny");
+  StringIdLease groupId(ids, "arenaTinyGroup");
+  DirectBufferedInput input(
+      readFile,
+      MetricsLog::voidLog(),
+      std::move(fileId),
+      tracker_,
+      std::move(groupId),
+      dataIoStats_,
+      nullptr,
+      executor_.get(),
+      readerOptions);
+
+  std::vector<std::unique_ptr<SeekableInputStream>> streams;
+  streams.reserve(kNumSmall);
+  for (int32_t k = 0; k < kNumSmall; ++k) {
+    streams.push_back(input.enqueue(
+        common::Region{static_cast<uint64_t>(k) * kSmallSize, kSmallSize},
+        nullptr));
+  }
+  // A tiny region plus a tiny duplicate of it, inside the arena load.
+  auto tinyStream =
+      input.enqueue(common::Region{tinyOffset, kTinyLen}, nullptr);
+  auto tinyDupStream =
+      input.enqueue(common::Region{tinyOffset, kTinyLen}, nullptr);
+  ASSERT_NE(tinyStream, nullptr);
+  ASSERT_NE(tinyDupStream, nullptr);
+
+  input.load(LogType::TEST);
+  ASSERT_EQ(input.testingCoalescedLoads().size(), 1);
+
+  // Non-tiny request reads from the arena correctly.
+  auto big = getNext(*streams[7]);
+  ASSERT_TRUE(big.has_value());
+  EXPECT_EQ(big.value(), content.substr(7 * kSmallSize, kSmallSize));
+
+  // Tiny request and its duplicate both read the correct bytes from 'tinyData'.
+  auto tiny = getNext(*tinyStream);
+  ASSERT_TRUE(tiny.has_value());
+  EXPECT_EQ(tiny.value(), content.substr(tinyOffset, kTinyLen));
+  auto tinyDup = getNext(*tinyDupStream);
+  ASSERT_TRUE(tinyDup.has_value());
+  EXPECT_EQ(tinyDup.value(), content.substr(tinyOffset, kTinyLen));
+
+  // Each distinct region is read once; the tiny duplicate shares its read.
+  EXPECT_EQ(readFile->numReads(), kNumSmall + 1);
+}
+
+// 'useArena' engages only when per-request page padding would waste more than
+// the arena floor (kMinPages * kPageSize = 64KB). A 4097B region rounds to two
+// pages, wasting ~4095B; ~16 such regions reach the floor.
+TEST_F(DirectBufferedInputTest, useArenaThreshold) {
+  constexpr int32_t kContentSize = 4 << 20; // 4MB
+  std::string content;
+  content.resize(kContentSize);
+  for (int32_t i = 0; i < kContentSize; ++i) {
+    content[i] = static_cast<char>(i % 251);
+  }
+  constexpr int32_t kRegionSize = 4'097; // non-tiny; ~4095B padding each
+
+  auto firstRequestArenaBacked = [&](int32_t numRegions) {
+    auto readFile = std::make_shared<tests::utils::CountingReadFile>(content);
+    io::ReaderOptions readerOptions(pool_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
+    readerOptions.setLoadQuantum(1 << 20);
+    auto& ids = fileIds();
+    StringIdLease fileId(ids, fmt::format("arenaFloor{}", numRegions));
+    StringIdLease groupId(ids, fmt::format("arenaFloorGroup{}", numRegions));
+    DirectBufferedInput input(
+        readFile,
+        MetricsLog::voidLog(),
+        std::move(fileId),
+        tracker_,
+        std::move(groupId),
+        dataIoStats_,
+        nullptr,
+        executor_.get(),
+        readerOptions);
+    std::vector<std::unique_ptr<SeekableInputStream>> streams;
+    streams.reserve(numRegions);
+    for (int32_t k = 0; k < numRegions; ++k) {
+      streams.push_back(input.enqueue(
+          common::Region{static_cast<uint64_t>(k) * kRegionSize, kRegionSize},
+          nullptr));
+    }
+    input.load(LogType::TEST);
+    // Buffers are allocated on first access; touch a stream to force it.
+    EXPECT_TRUE(getNext(*streams[0]).has_value());
+    auto* load = dynamic_cast<DirectCoalescedLoad*>(
+        input.testingCoalescedLoads()[0].get());
+    EXPECT_NE(load, nullptr);
+    return load->requests()[0].buffer.arenaData != nullptr;
+  };
+
+  EXPECT_FALSE(firstRequestArenaBacked(10)); // ~41KB waste -> per-request
+  EXPECT_TRUE(firstRequestArenaBacked(32)); // ~131KB waste -> arena
+}
+
+// A wide group bump-packs its non-tiny buffers into one arena, costing far
+// fewer pool allocations than one per request.
+TEST_F(DirectBufferedInputTest, arenaReducesAllocations) {
+  constexpr int32_t kContentSize = 4 << 20; // 4MB
+  std::string content;
+  content.resize(kContentSize);
+  for (int32_t i = 0; i < kContentSize; ++i) {
+    content[i] = static_cast<char>(i % 251);
+  }
+  constexpr int32_t kNumRegions = 32; // > arena floor -> useArena
+  constexpr int32_t kRegionSize = 4'097;
+
+  auto readFile = std::make_shared<tests::utils::CountingReadFile>(content);
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
+  readerOptions.setLoadQuantum(1 << 20);
+  auto& ids = fileIds();
+  StringIdLease fileId(ids, "arenaAllocs");
+  StringIdLease groupId(ids, "arenaAllocsGroup");
+  DirectBufferedInput input(
+      readFile,
+      MetricsLog::voidLog(),
+      std::move(fileId),
+      tracker_,
+      std::move(groupId),
+      dataIoStats_,
+      nullptr,
+      executor_.get(),
+      readerOptions);
+
+  std::vector<std::unique_ptr<SeekableInputStream>> streams;
+  streams.reserve(kNumRegions);
+  for (int32_t k = 0; k < kNumRegions; ++k) {
+    streams.push_back(input.enqueue(
+        common::Region{static_cast<uint64_t>(k) * kRegionSize, kRegionSize},
+        nullptr));
+  }
+
+  const auto allocsBefore = pool_->stats().numAllocs;
+  input.load(LogType::TEST);
+  for (auto& stream : streams) {
+    EXPECT_TRUE(getNext(*stream).has_value());
+  }
+  const auto allocsDelta = pool_->stats().numAllocs - allocsBefore;
+  // 32 requests share one arena -> far fewer than one allocation each.
+  EXPECT_LT(allocsDelta, static_cast<uint64_t>(kNumRegions));
+}
+
 DEBUG_ONLY_TEST_F(DirectBufferedInputTest, resetInputWithBeforeLoading) {
   constexpr int32_t kContentSize = 4 << 20; // 4MB
   std::string content;

--- a/velox/dwio/common/tests/DirectBufferedInputTest.cpp
+++ b/velox/dwio/common/tests/DirectBufferedInputTest.cpp
@@ -349,6 +349,385 @@ TEST_F(DirectBufferedInputTest, duplicateRegionsShareCoalescedRead) {
   }
 }
 
+// Shared-allocation path with a duplicate region: each region is read once and
+// the duplicate shares the source's slice.
+TEST_F(DirectBufferedInputTest, duplicateRegionsShareAllocationRead) {
+  constexpr int32_t kContentSize = 4 << 20; // 4MB
+  std::string content;
+  content.resize(kContentSize);
+  for (int32_t i = 0; i < kContentSize; ++i) {
+    content[i] = static_cast<char>(i % 251);
+  }
+
+  // 32 regions just over a page each over-allocate ~128KB total, above the
+  // shared-allocation floor.
+  constexpr int32_t kNumRegions = 32;
+  constexpr int32_t kRegionSize = 4'097;
+
+  auto readFile = std::make_shared<tests::utils::CountingReadFile>(content);
+
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
+  readerOptions.setLoadQuantum(1 << 20);
+  readerOptions.setDirectBufferedInputSharedAllocation(true);
+
+  auto& ids = fileIds();
+  StringIdLease fileId(ids, "sharedAllocDup");
+  StringIdLease groupId(ids, "sharedAllocDupGroup");
+
+  DirectBufferedInput input(
+      readFile,
+      MetricsLog::voidLog(),
+      std::move(fileId),
+      tracker_,
+      std::move(groupId),
+      dataIoStats_,
+      nullptr,
+      executor_.get(),
+      readerOptions);
+
+  // Adjacent distinct regions, then a duplicate of region 0.
+  std::vector<std::unique_ptr<SeekableInputStream>> streams;
+  streams.reserve(kNumRegions);
+  for (int32_t k = 0; k < kNumRegions; ++k) {
+    streams.push_back(input.enqueue(
+        common::Region{static_cast<uint64_t>(k) * kRegionSize, kRegionSize},
+        nullptr));
+    ASSERT_NE(streams.back(), nullptr);
+  }
+  auto dupStream = input.enqueue(common::Region{0, kRegionSize}, nullptr);
+  ASSERT_NE(dupStream, nullptr);
+  // Second duplicate of region 0: a 3-chain exercising the intermediate
+  // duplicate (its predecessor is itself a duplicate).
+  auto dupStream2 = input.enqueue(common::Region{0, kRegionSize}, nullptr);
+  ASSERT_NE(dupStream2, nullptr);
+
+  input.load(LogType::TEST);
+  EXPECT_EQ(input.testingCoalescedLoads().size(), 1);
+
+  // Source and its duplicates return the same bytes, read once.
+  auto src = getNext(*streams[0]);
+  ASSERT_TRUE(src.has_value());
+  EXPECT_EQ(src.value(), content.substr(0, kRegionSize));
+  auto dup = getNext(*dupStream);
+  ASSERT_TRUE(dup.has_value());
+  EXPECT_EQ(dup.value(), content.substr(0, kRegionSize));
+  auto dup2 = getNext(*dupStream2);
+  ASSERT_TRUE(dup2.has_value());
+  EXPECT_EQ(dup2.value(), content.substr(0, kRegionSize));
+  // Only the distinct regions are read; duplicates add none.
+  EXPECT_EQ(readFile->numReads(), kNumRegions);
+
+  // A non-duplicate shared-allocation stream still reads its own bytes.
+  auto mid = getNext(*streams[5]);
+  ASSERT_TRUE(mid.has_value());
+  EXPECT_EQ(mid.value(), content.substr(5 * kRegionSize, kRegionSize));
+  EXPECT_EQ(readFile->numReads(), kNumRegions);
+}
+
+// A shared-allocation stream whose region exceeds loadQuantum reads the first
+// quantum from the shared allocation and the rest into its own buffer,
+// reproducing the region intact.
+TEST_F(DirectBufferedInputTest, sharedAllocationStreamCrossesQuantum) {
+  constexpr int32_t kContentSize = 4 << 20; // 4MB
+  std::string content;
+  content.resize(kContentSize);
+  for (int32_t i = 0; i < kContentSize; ++i) {
+    content[i] = static_cast<char>(i % 251);
+  }
+
+  // 32 non-tiny regions push overAllocatedBytes over the 64KB floor ->
+  // useSharedAllocation.
+  constexpr int32_t kNumSmall = 32;
+  constexpr int32_t kSmallSize = 4'097;
+  constexpr uint64_t kLoadQuantum = 1 << 20; // 1MB
+  const uint64_t bigOffset = static_cast<uint64_t>(kNumSmall) * kSmallSize;
+  constexpr uint64_t kBigSize = (1 << 20) + (512 << 10); // 1.5MB > quantum
+
+  auto readFile = std::make_shared<tests::utils::CountingReadFile>(content);
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
+  readerOptions.setLoadQuantum(kLoadQuantum);
+  readerOptions.setDirectBufferedInputSharedAllocation(true);
+
+  auto& ids = fileIds();
+  StringIdLease fileId(ids, "sharedAllocQuantum");
+  StringIdLease groupId(ids, "sharedAllocQuantumGroup");
+  DirectBufferedInput input(
+      readFile,
+      MetricsLog::voidLog(),
+      std::move(fileId),
+      tracker_,
+      std::move(groupId),
+      dataIoStats_,
+      nullptr,
+      executor_.get(),
+      readerOptions);
+
+  std::vector<std::unique_ptr<SeekableInputStream>> streams;
+  streams.reserve(kNumSmall);
+  for (int32_t k = 0; k < kNumSmall; ++k) {
+    streams.push_back(input.enqueue(
+        common::Region{static_cast<uint64_t>(k) * kSmallSize, kSmallSize},
+        nullptr));
+  }
+  auto bigStream = input.enqueue(common::Region{bigOffset, kBigSize}, nullptr);
+  ASSERT_NE(bigStream, nullptr);
+
+  input.load(LogType::TEST);
+  ASSERT_EQ(input.testingCoalescedLoads().size(), 1);
+
+  // Read the whole region across the quantum boundary.
+  std::string got;
+  while (auto chunk = getNext(*bigStream)) {
+    got += chunk.value();
+  }
+  EXPECT_EQ(got, content.substr(bigOffset, kBigSize));
+}
+
+// In a shared-allocation load, a tiny request is still served from its own
+// 'tinyData' and a tiny duplicate gets its own copy.
+TEST_F(DirectBufferedInputTest, sharedAllocationLoadServesTinyAndDuplicates) {
+  constexpr int32_t kContentSize = 4 << 20; // 4MB
+  std::string content;
+  content.resize(kContentSize);
+  for (int32_t i = 0; i < kContentSize; ++i) {
+    content[i] = static_cast<char>(i % 251);
+  }
+
+  constexpr int32_t kNumSmall = 32;
+  constexpr int32_t kSmallSize = 4'097; // non-tiny, drives useSharedAllocation
+  constexpr int32_t kTinyLen = 100; // <= kTinySize
+  const uint64_t tinyOffset = static_cast<uint64_t>(kNumSmall) * kSmallSize;
+
+  auto readFile = std::make_shared<tests::utils::CountingReadFile>(content);
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
+  readerOptions.setLoadQuantum(1 << 20);
+  readerOptions.setDirectBufferedInputSharedAllocation(true);
+
+  auto& ids = fileIds();
+  StringIdLease fileId(ids, "sharedAllocTiny");
+  StringIdLease groupId(ids, "sharedAllocTinyGroup");
+  DirectBufferedInput input(
+      readFile,
+      MetricsLog::voidLog(),
+      std::move(fileId),
+      tracker_,
+      std::move(groupId),
+      dataIoStats_,
+      nullptr,
+      executor_.get(),
+      readerOptions);
+
+  std::vector<std::unique_ptr<SeekableInputStream>> streams;
+  streams.reserve(kNumSmall);
+  for (int32_t k = 0; k < kNumSmall; ++k) {
+    streams.push_back(input.enqueue(
+        common::Region{static_cast<uint64_t>(k) * kSmallSize, kSmallSize},
+        nullptr));
+  }
+  // A tiny region plus a tiny duplicate of it, inside the shared-allocation
+  // load.
+  auto tinyStream =
+      input.enqueue(common::Region{tinyOffset, kTinyLen}, nullptr);
+  auto tinyDupStream =
+      input.enqueue(common::Region{tinyOffset, kTinyLen}, nullptr);
+  ASSERT_NE(tinyStream, nullptr);
+  ASSERT_NE(tinyDupStream, nullptr);
+
+  input.load(LogType::TEST);
+  ASSERT_EQ(input.testingCoalescedLoads().size(), 1);
+
+  // Non-tiny request reads from the shared allocation correctly.
+  auto big = getNext(*streams[7]);
+  ASSERT_TRUE(big.has_value());
+  EXPECT_EQ(big.value(), content.substr(7 * kSmallSize, kSmallSize));
+
+  // Tiny request and its duplicate both read the correct bytes from 'tinyData'.
+  auto tiny = getNext(*tinyStream);
+  ASSERT_TRUE(tiny.has_value());
+  EXPECT_EQ(tiny.value(), content.substr(tinyOffset, kTinyLen));
+  auto tinyDup = getNext(*tinyDupStream);
+  ASSERT_TRUE(tinyDup.has_value());
+  EXPECT_EQ(tinyDup.value(), content.substr(tinyOffset, kTinyLen));
+
+  // Each distinct region is read once; the tiny duplicate shares its read.
+  EXPECT_EQ(readFile->numReads(), kNumSmall + 1);
+}
+
+// With the shared allocation off (the default), a load whose padding would
+// otherwise clear the floor still serves every request from its own allocation
+// and returns identical bytes. Same 32-region load that
+// useSharedAllocationThreshold shows is shared-backed once enabled.
+TEST_F(DirectBufferedInputTest, sharedAllocationDisabled) {
+  constexpr int32_t kContentSize = 4 << 20; // 4MB
+  std::string content;
+  content.resize(kContentSize);
+  for (int32_t i = 0; i < kContentSize; ++i) {
+    content[i] = static_cast<char>(i % 251);
+  }
+  constexpr int32_t kRegionSize = 4'097;
+  constexpr int32_t kNumRegions = 32; // clears the floor when enabled
+
+  auto readFile = std::make_shared<tests::utils::CountingReadFile>(content);
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
+  readerOptions.setLoadQuantum(1 << 20);
+  // Already the default; set explicitly so the test states its intent.
+  readerOptions.setDirectBufferedInputSharedAllocation(false);
+  auto& ids = fileIds();
+  StringIdLease fileId(ids, "sharedAllocOff");
+  StringIdLease groupId(ids, "sharedAllocOffGroup");
+  DirectBufferedInput input(
+      readFile,
+      MetricsLog::voidLog(),
+      std::move(fileId),
+      tracker_,
+      std::move(groupId),
+      dataIoStats_,
+      nullptr,
+      executor_.get(),
+      readerOptions);
+  std::vector<std::unique_ptr<SeekableInputStream>> streams;
+  streams.reserve(kNumRegions);
+  for (int32_t k = 0; k < kNumRegions; ++k) {
+    streams.push_back(input.enqueue(
+        common::Region{static_cast<uint64_t>(k) * kRegionSize, kRegionSize},
+        nullptr));
+  }
+  input.load(LogType::TEST);
+
+  // Buffers are allocated on first access, so read every stream before
+  // inspecting the load. Bytes must be unchanged by the layout.
+  for (int32_t k = 0; k < kNumRegions; ++k) {
+    auto bytes = getNext(*streams[k]);
+    ASSERT_TRUE(bytes.has_value()) << "stream " << k;
+    EXPECT_EQ(
+        bytes.value(),
+        content.substr(
+            static_cast<size_t>(k) * kRegionSize,
+            static_cast<size_t>(kRegionSize)));
+  }
+
+  auto* load = dynamic_cast<DirectCoalescedLoad*>(
+      input.testingCoalescedLoads()[0].get());
+  ASSERT_NE(load, nullptr);
+  // No request is served from the shared allocation.
+  for (const auto& request : load->requests()) {
+    EXPECT_EQ(request.buffer.sharedData, nullptr);
+  }
+}
+
+// 'useSharedAllocation' engages only when per-request page padding would waste
+// more than the shared-allocation floor (kMinPages * kPageSize = 64KB). A 4097B
+// region rounds to two pages, wasting ~4095B; ~16 such regions reach the floor.
+TEST_F(DirectBufferedInputTest, useSharedAllocationThreshold) {
+  constexpr int32_t kContentSize = 4 << 20; // 4MB
+  std::string content;
+  content.resize(kContentSize);
+  for (int32_t i = 0; i < kContentSize; ++i) {
+    content[i] = static_cast<char>(i % 251);
+  }
+  constexpr int32_t kRegionSize = 4'097; // non-tiny; ~4095B padding each
+
+  auto firstRequestSharedAllocationBacked = [&](int32_t numRegions) {
+    auto readFile = std::make_shared<tests::utils::CountingReadFile>(content);
+    io::ReaderOptions readerOptions(pool_.get());
+    readerOptions.setDataIoStats(dataIoStats_);
+    readerOptions.setMetadataIoStats(metadataIoStats_);
+    readerOptions.setLoadQuantum(1 << 20);
+    readerOptions.setDirectBufferedInputSharedAllocation(true);
+    auto& ids = fileIds();
+    StringIdLease fileId(ids, fmt::format("sharedAllocFloor{}", numRegions));
+    StringIdLease groupId(
+        ids, fmt::format("sharedAllocFloorGroup{}", numRegions));
+    DirectBufferedInput input(
+        readFile,
+        MetricsLog::voidLog(),
+        std::move(fileId),
+        tracker_,
+        std::move(groupId),
+        dataIoStats_,
+        nullptr,
+        executor_.get(),
+        readerOptions);
+    std::vector<std::unique_ptr<SeekableInputStream>> streams;
+    streams.reserve(numRegions);
+    for (int32_t k = 0; k < numRegions; ++k) {
+      streams.push_back(input.enqueue(
+          common::Region{static_cast<uint64_t>(k) * kRegionSize, kRegionSize},
+          nullptr));
+    }
+    input.load(LogType::TEST);
+    // Buffers are allocated on first access; touch a stream to force it.
+    EXPECT_TRUE(getNext(*streams[0]).has_value());
+    auto* load = dynamic_cast<DirectCoalescedLoad*>(
+        input.testingCoalescedLoads()[0].get());
+    EXPECT_NE(load, nullptr);
+    return load->requests()[0].buffer.sharedData != nullptr;
+  };
+
+  EXPECT_FALSE(firstRequestSharedAllocationBacked(
+      10)); // ~41KB over-allocated -> per-request
+  EXPECT_TRUE(firstRequestSharedAllocationBacked(
+      32)); // ~131KB over-allocated -> shared allocation
+}
+
+// A wide group bump-packs its non-tiny buffers into one shared allocation,
+// costing far fewer pool allocations than one per request.
+TEST_F(DirectBufferedInputTest, sharedAllocationReducesAllocations) {
+  constexpr int32_t kContentSize = 4 << 20; // 4MB
+  std::string content;
+  content.resize(kContentSize);
+  for (int32_t i = 0; i < kContentSize; ++i) {
+    content[i] = static_cast<char>(i % 251);
+  }
+  constexpr int32_t kNumRegions = 32; // > shared-allocation floor
+  constexpr int32_t kRegionSize = 4'097;
+
+  auto readFile = std::make_shared<tests::utils::CountingReadFile>(content);
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
+  readerOptions.setLoadQuantum(1 << 20);
+  readerOptions.setDirectBufferedInputSharedAllocation(true);
+  auto& ids = fileIds();
+  StringIdLease fileId(ids, "sharedAllocs");
+  StringIdLease groupId(ids, "sharedAllocsGroup");
+  DirectBufferedInput input(
+      readFile,
+      MetricsLog::voidLog(),
+      std::move(fileId),
+      tracker_,
+      std::move(groupId),
+      dataIoStats_,
+      nullptr,
+      executor_.get(),
+      readerOptions);
+
+  std::vector<std::unique_ptr<SeekableInputStream>> streams;
+  streams.reserve(kNumRegions);
+  for (int32_t k = 0; k < kNumRegions; ++k) {
+    streams.push_back(input.enqueue(
+        common::Region{static_cast<uint64_t>(k) * kRegionSize, kRegionSize},
+        nullptr));
+  }
+
+  const auto allocsBefore = pool_->stats().numAllocs;
+  input.load(LogType::TEST);
+  for (auto& stream : streams) {
+    EXPECT_TRUE(getNext(*stream).has_value());
+  }
+  const auto allocsDelta = pool_->stats().numAllocs - allocsBefore;
+  // 32 requests share one allocation -> far fewer than one allocation each.
+  EXPECT_LT(allocsDelta, static_cast<uint64_t>(kNumRegions));
+}
+
 DEBUG_ONLY_TEST_F(DirectBufferedInputTest, resetInputWithBeforeLoading) {
   constexpr int32_t kContentSize = 4 << 20; // 4MB
   std::string content;


### PR DESCRIPTION
Summary:

## Context

Routing Nimble through DirectBufferedInput (parent D106424768) allocated one
page-rounded buffer per request in a coalesced read, so a wide load (many column
streams) wasted sub-page padding on every buffer and held them all allocated at
once.

## Details

- Pack a coalesced load's buffers into a single shared allocation instead of one
  allocation per request: byte-packed (no per-buffer page padding) and freed
  together.
- Streams read directly out of that allocation, with no per-stream copy.
- Used only when per-request page rounding would waste more than
  AllocationPool::kMinPages * kPageSize (64KB); otherwise the per-request path
  is unchanged.
- DirectBufferedInput also backs DWRF and other non-cache reads, so they get the
  same treatment.
- No change to which bytes are read or how reads are coalesced -- an
  allocation-layout change only.

## What this does and does not buy, measured

An earlier revision of this summary claimed the change "cuts peak memory and
allocation churn on wide reads". Production measurement does not support that,
so it is corrected here.

At the shipped 64KB threshold the feature is close to inert: it engages on 0.50%
of DWRF coalesced loads and 0.00% of Nimble ones. Forced to full engagement it
is performance-neutral on DWRF (peak memory 1.0071 total / 1.0129 per-node at
95% engagement). The one real win is heavy Nimble reads, >100GB scanned, at
0.7565 peak memory -- and the shipped threshold never reaches it.

Two earlier regression reports (+17.5% dkl1, +11.8% cross-build) do NOT
reproduce under a controlled A/B; both were confounded (one sequential on a
single cluster at an 8MB footer, one cross-region and cross-binary).

So this lands as a safe, correct, gated no-op. It is worth having for the Nimble
case, but the threshold needs recalibrating before that benefit is reachable,
and that should be a separate change with its own measurement.

## Rollout

Gated on reader.direct-buffered-input-shared-allocation, defaulting to FALSE, so
landing this is a no-op until a cluster opts in. Enable per cluster to roll out,
the same way nimble.lazy-column-io was. Declared with VELOX_HIVE_CONFIG_LEGACY
so it gets an explicit catalog config key alongside the session name; the
catalog key is what makes per-cluster and per-region rollout possible. A session
property would additionally need an entry in HiveSessionProperties.java to be
settable from SQL, which is not included here since rollout is per cluster
rather than per query.

The gate ships with the change rather than as a follow-up: landing them
separately would leave a window where the shared allocation is on for every DWRF
read with no way to turn it off.

D116738714 turns it on for the test and verifier clusters.

Reviewed By: xiaoxmeng

Differential Revision: D107779205


