### PR TITLE
refactor: Add Velox common Bloom filter for Nimble hash index (#17951)

### DIFF
--- a/velox/common/base/SplitBlockBloomFilter.cpp
+++ b/velox/common/base/SplitBlockBloomFilter.cpp
@@ -19,17 +19,44 @@
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/base/Exceptions.h"
 
+#include <algorithm>
 #include <bit>
+#include <cmath>
 #include <sstream>
 
 namespace facebook::velox {
+
+namespace {
+
+constexpr uint32_t kBitIndexShift{32 - 5};
+
+// Keep this order aligned with the legacy Nimble hash index layout. It is
+// intentionally different from SplitBlockBloomFilter's SIMD salts.
+constexpr uint32_t kSalts[ModuloSplitBlockBloomFilter::kNumWords] = {
+    0x47b6137bU,
+    0x44974d91U,
+    0x8824ad5bU,
+    0xa2b7289dU,
+    0x705495c7U,
+    0x2df1424bU,
+    0x9efc4947U,
+    0x5c6bfb31U,
+};
+
+uint32_t wordMask(uint32_t hash, uint32_t wordIndex) {
+  const uint32_t bitIndex = (hash * kSalts[wordIndex]) >> kBitIndexShift;
+  return uint32_t{1} << bitIndex;
+}
+
+} // namespace
 
 int64_t SplitBlockBloomFilter::numBlocks(
     int64_t numElements,
     double falsePositive) {
   constexpr int K = xsimd::batch<uint32_t>::size;
-  int64_t numBits = std::ceil(
-      -K * numElements / std::log(1 - std::pow(falsePositive, 1.0 / K)));
+  int64_t numBits = static_cast<int64_t>(std::ceil(
+      -static_cast<double>(K) * static_cast<double>(numElements) /
+      std::log(1 - std::pow(falsePositive, 1.0 / K))));
   return bits::divRoundUp(numBits, 8 * sizeof(Block));
 }
 
@@ -61,6 +88,41 @@ std::string SplitBlockBloomFilter::debugString() const {
     out << "Bit " << i << ": " << byBitPosition[i] << '\n';
   }
   return out.str();
+}
+
+ModuloSplitBlockBloomFilter::ModuloSplitBlockBloomFilter(
+    const std::span<Block>& blocks)
+    : blocks_(blocks) {
+  VELOX_CHECK_GT(blocks_.size(), 0);
+}
+
+uint32_t ModuloSplitBlockBloomFilter::numBlocks(
+    uint64_t numEntries,
+    float bitsPerKey) {
+  const uint64_t totalBits = std::max(
+      static_cast<uint64_t>(numEntries * bitsPerKey), uint64_t{kBlockSizeBits});
+  return std::max(
+      static_cast<uint32_t>(bits::divRoundUp(totalBits, kBlockSizeBits)),
+      uint32_t{1});
+}
+
+void ModuloSplitBlockBloomFilter::insert(uint64_t hash) {
+  auto& block = blocks_[blockIndex(hash)];
+  const auto key = static_cast<uint32_t>(hash);
+  for (uint32_t wordIndex = 0; wordIndex < kNumWords; ++wordIndex) {
+    block.data[wordIndex] |= wordMask(key, wordIndex);
+  }
+}
+
+bool ModuloSplitBlockBloomFilter::mayContain(uint64_t hash) const {
+  const auto& block = blocks_[blockIndex(hash)];
+  const auto key = static_cast<uint32_t>(hash);
+  for (uint32_t wordIndex = 0; wordIndex < kNumWords; ++wordIndex) {
+    if ((block.data[wordIndex] & wordMask(key, wordIndex)) == 0) {
+      return false;
+    }
+  }
+  return true;
 }
 
 } // namespace facebook::velox

--- a/velox/common/base/SplitBlockBloomFilter.h
+++ b/velox/common/base/SplitBlockBloomFilter.h
@@ -16,10 +16,11 @@
 
 #pragma once
 
-#include "velox/common/base/SimdUtil.h"
-
 #include <cstdint>
 #include <span>
+#include <string>
+
+#include <xsimd/xsimd.hpp>
 
 namespace facebook::velox {
 
@@ -65,11 +66,13 @@ class SplitBlockBloomFilter {
   SplitBlockBloomFilter& operator=(const SplitBlockBloomFilter&) = delete;
 
   SplitBlockBloomFilter(SplitBlockBloomFilter&&) = default;
+  SplitBlockBloomFilter& operator=(SplitBlockBloomFilter&&) = delete;
+  ~SplitBlockBloomFilter() = default;
 
   /// Insert a hash into the bloom filter.  The function used to generate this
   /// hash should be avalanching.
   void insert(uint64_t hash) {
-    auto mask = makeMask(hash);
+    auto mask = makeMask(static_cast<uint32_t>(hash));
     auto* block = blocks_[blockIndex(hash)].data;
     (xsimd::load_aligned(block) | mask).store_aligned(block);
   }
@@ -78,7 +81,7 @@ class SplitBlockBloomFilter {
   /// has not been inserted.  Never return false when the hash has been
   /// inserted.
   bool mayContain(uint64_t hash) const {
-    auto mask = makeMask(hash);
+    auto mask = makeMask(static_cast<uint32_t>(hash));
     auto block = xsimd::load_aligned(blocks_[blockIndex(hash)].data);
 #if XSIMD_WITH_AVX
     return _mm256_testc_si256(block, mask);
@@ -133,5 +136,61 @@ class SplitBlockBloomFilter {
 
   std::span<Block> const blocks_;
 };
+
+/// Provides a fixed 32-byte split-block Bloom filter with modulo block
+/// selection.
+///
+/// Leaves memory management and hashing to callers.
+/// Preserves formats that store an arbitrary number of 32-byte blocks and
+/// map hashes to blocks using modulo arithmetic.
+class ModuloSplitBlockBloomFilter {
+ public:
+  static constexpr uint32_t kNumWords{8};
+
+  /// Stores eight 32-bit words, one per probe.
+  struct Block {
+    uint32_t data[kNumWords]{};
+  };
+
+  static constexpr uint32_t kBlockSizeBytes{sizeof(Block)};
+  static constexpr uint32_t kBlockSizeBits{kBlockSizeBytes * 8};
+
+  /// Calculates the number of blocks needed for the entry count and target
+  /// bits per key.
+  static uint32_t numBlocks(uint64_t numEntries, float bitsPerKey);
+
+  /// Constructs the Bloom filter using caller-owned block memory.
+  explicit ModuloSplitBlockBloomFilter(const std::span<Block>& blocks);
+
+  ModuloSplitBlockBloomFilter(const ModuloSplitBlockBloomFilter&) = delete;
+  ModuloSplitBlockBloomFilter& operator=(const ModuloSplitBlockBloomFilter&) =
+      delete;
+
+  ModuloSplitBlockBloomFilter(ModuloSplitBlockBloomFilter&&) = default;
+  ModuloSplitBlockBloomFilter& operator=(ModuloSplitBlockBloomFilter&&) =
+      delete;
+  ~ModuloSplitBlockBloomFilter() = default;
+
+  /// Inserts an avalanching hash into the Bloom filter.
+  void insert(uint64_t hash);
+
+  /// Checks whether an avalanching hash may have been inserted.
+  bool mayContain(uint64_t hash) const;
+
+  /// Returns the number of 32-byte blocks.
+  uint32_t numBlocks() const {
+    return static_cast<uint32_t>(blocks_.size());
+  }
+
+ private:
+  uint32_t blockIndex(uint64_t hash) const {
+    return static_cast<uint32_t>((hash >> 32) % blocks_.size());
+  }
+
+  // Points to caller-owned Bloom filter blocks.
+  std::span<Block> const blocks_;
+};
+
+static_assert(sizeof(ModuloSplitBlockBloomFilter::Block) == 32);
 
 } // namespace facebook::velox

--- a/velox/common/base/benchmarks/SplitBlockBloomFilterBenchmark.cpp
+++ b/velox/common/base/benchmarks/SplitBlockBloomFilterBenchmark.cpp
@@ -18,6 +18,7 @@
 
 #include <folly/Benchmark.h>
 #include <folly/Random.h>
+#include <folly/hash/Hash.h>
 #include <folly/init/Init.h>
 
 #define VELOX_BENCHMARK(_make, _name, ...) \

--- a/velox/common/base/tests/SplitBlockBloomFilterTest.cpp
+++ b/velox/common/base/tests/SplitBlockBloomFilterTest.cpp
@@ -20,6 +20,7 @@
 #include <folly/container/F14Set.h>
 #include <gtest/gtest.h>
 
+#include <cstring>
 #include <random>
 
 namespace facebook::velox::test {
@@ -30,7 +31,9 @@ SplitBlockBloomFilter makeFilter(
     const folly::F14FastSet<int64_t>& values,
     const Hasher& hasher,
     std::vector<SplitBlockBloomFilter::Block>& blocks) {
-  blocks.resize(SplitBlockBloomFilter::numBlocks(values.size(), 0.01));
+  blocks.resize(
+      SplitBlockBloomFilter::numBlocks(
+          static_cast<int64_t>(values.size()), 0.01));
   bzero(blocks.data(), blocks.size() * sizeof(SplitBlockBloomFilter::Block));
   SplitBlockBloomFilter filter(blocks);
   for (auto& value : values) {
@@ -116,6 +119,65 @@ TEST(SplitBlockBloomFilterTest, random) {
     SCOPED_TRACE("Multiplication");
     test([](auto x) { return x * 0xc6a4a7935bd1e995L; });
   }
+}
+
+TEST(ModuloSplitBlockBloomFilterTest, supportsArbitraryBlockCounts) {
+  std::vector<ModuloSplitBlockBloomFilter::Block> blocks(
+      37, ModuloSplitBlockBloomFilter::Block{});
+  ModuloSplitBlockBloomFilter filter(blocks);
+
+  EXPECT_EQ(ModuloSplitBlockBloomFilter::numBlocks(0, 10.0f), 1);
+  EXPECT_EQ(ModuloSplitBlockBloomFilter::numBlocks(1'000, 10.0f), 40);
+  for (int i = 0; i < 1'000; ++i) {
+    filter.insert(folly::hasher<int64_t>()(i));
+  }
+
+  EXPECT_EQ(filter.numBlocks(), 37);
+  for (int i = 0; i < 1'000; ++i) {
+    ASSERT_TRUE(filter.mayContain(folly::hasher<int64_t>()(i)));
+  }
+}
+
+TEST(ModuloSplitBlockBloomFilterTest, preservesLegacyBlockLayout) {
+  constexpr uint32_t kNumBlocks{3};
+  constexpr uint32_t kSalts[] = {
+      0x47b6137bU,
+      0x44974d91U,
+      0x8824ad5bU,
+      0xa2b7289dU,
+      0x705495c7U,
+      0x2df1424bU,
+      0x9efc4947U,
+      0x5c6bfb31U,
+  };
+
+  std::vector<ModuloSplitBlockBloomFilter::Block> blocks(
+      kNumBlocks, ModuloSplitBlockBloomFilter::Block{});
+  std::vector<ModuloSplitBlockBloomFilter::Block> expectedBlocks(
+      kNumBlocks, ModuloSplitBlockBloomFilter::Block{});
+
+  const auto insertLegacyHash = [&](uint64_t hash) {
+    auto& block = expectedBlocks[(hash >> 32) % kNumBlocks];
+    const auto key = static_cast<uint32_t>(hash);
+    for (uint32_t wordIndex = 0; wordIndex < std::size(kSalts); ++wordIndex) {
+      const uint32_t bitIndex = (key * kSalts[wordIndex]) >> 27;
+      block.data[wordIndex] |= (uint32_t{1} << bitIndex);
+    }
+  };
+
+  ModuloSplitBlockBloomFilter filter(blocks);
+  for (const auto hash :
+       {0x12345678abcdef01ULL, 0xfedcba9876543210ULL, 0x0000000200000001ULL}) {
+    filter.insert(hash);
+    insertLegacyHash(hash);
+  }
+
+  EXPECT_EQ(
+      std::memcmp(
+          blocks.data(),
+          expectedBlocks.data(),
+          blocks.size() * sizeof(ModuloSplitBlockBloomFilter::Block)),
+      0);
 }
 
 } // namespace


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookincubator/nimble/pull/913

Move Nimble hash index Bloom filter logic into Velox common as ModuloSplitBlockBloomFilter

Differential Revision: D109859927


