### PR TITLE
feat(selective): SIMD filterCache evaluation for dictionary index reading with filters

### DIFF
--- a/velox/dwio/common/ColumnVisitors.h
+++ b/velox/dwio/common/ColumnVisitors.h
@@ -617,8 +617,6 @@ ColumnVisitor<T, TFilter, ExtractValues, isDense, hasBulkPath>::addOutputRow(
   reader_->addOutputRow(row);
 }
 
-enum FilterResult { kUnknown = 0x40, kSuccess = 0x80, kFailure = 0 };
-
 namespace detail {
 
 template <typename T, typename A>
@@ -1387,6 +1385,11 @@ class StringDictionaryColumnVisitor
     }
     constexpr bool filterOnly =
         std::is_same_v<typename super::Extract, DropValues>;
+    // TODO: This inline SIMD loop duplicates the shared
+    // filterDictionaryRunSimd() free function in DecoderUtil.h; rewire
+    // processRun to call it in a follow-up diff. The dedup is split out to keep
+    // this DWRF change separate from the Nimble post-hoc dictionary filter
+    // feature.
     constexpr int32_t kWidth = xsimd::batch<int32_t>::size;
     for (auto i = 0; i < numInput; i += kWidth) {
       auto indices = xsimd::load_unaligned(input + i);

--- a/velox/dwio/common/DecoderUtil.h
+++ b/velox/dwio/common/DecoderUtil.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <algorithm>
+#include "velox/common/base/Portability.h"
 #include "velox/common/memory/RawVector.h"
 #include "velox/common/process/ProcessBase.h"
 #include "velox/dwio/common/StreamUtil.h"
@@ -32,6 +33,115 @@ static bool applyFilter(TFilter& filter, T value);
 } // namespace facebook::velox
 
 namespace facebook::velox::dwio::common {
+
+// Per-dictionary-index verdict cached by the dictionary filter path. The byte
+// values are chosen so the SIMD kernel below tests them from the gathered
+// int32: bit 7 (kSuccess) is the sign bit and bit 6 (kUnknown) selects
+// unknowns.
+enum FilterResult { kUnknown = 0x40, kSuccess = 0x80, kFailure = 0 };
+
+/// SIMD dictionary-filter kernel shared by the DWRF framework
+/// StringDictionaryColumnVisitor and the Nimble dictionary filter path. Reads a
+/// run of materialized dictionary indices, consults the per-index 'filterCache'
+/// to skip indices already known to pass or fail, resolves cache-unknown
+/// indices by invoking 'testIndex' (which the kernel then records into
+/// 'filterCache' as kSuccess/kFailure), and compacts the passing entries. For
+/// each passing entry the corresponding 'rows' value is appended to
+/// 'filterHits'; unless 'kFilterOnly' is set, the passing dictionary index is
+/// also appended to 'values'. The caller supplies 'rows' already offset to the
+/// current position. Returns the updated number of output values.
+///
+/// Caller-side buffer contracts -- the kernel reads and writes a full SIMD
+/// width at the tail and gathers the cache through a misaligned load, none of
+/// which is bounds-checked:
+///  - 'input' and 'rows' must each have at least kWidth
+///    (= xsimd::batch<int32_t>::size) readable elements beyond 'numInput'.
+///  - 'filterHits', and unless 'kFilterOnly' also 'values', must have room for
+///    at least 'numValues' + 'numInput' + kWidth entries.
+///  - 'filterCache' must have >= 3 bytes of valid leading padding, because each
+///    verdict is gathered via 'filterCache + index - 3'. The Nimble and Velox
+///    callers satisfy this with raw_vector<uint8_t>, whose data() is offset by
+///    velox::simd::kPadding (>= 16).
+template <bool kFilterOnly, typename TestIndex>
+int32_t filterDictionaryRunSimd(
+    const int32_t* input,
+    int32_t numInput,
+    const int32_t* rows,
+    uint8_t* filterCache,
+    int32_t* filterHits,
+    int32_t* values,
+    int32_t numValues,
+    TestIndex&& testIndex) {
+  constexpr int32_t kWidth = xsimd::batch<int32_t>::size;
+  for (auto i = 0; i < numInput; i += kWidth) {
+    auto indices = xsimd::load_unaligned(input + i);
+    xsimd::batch<int32_t> cache;
+    // The gather reads each cache byte as the high byte of an int32 via a
+    // misaligned load at 'filterCache + index - 3', so for index 0 it touches
+    // up to 3 bytes before 'filterCache'. The param is a raw uint8_t*, so this
+    // is a caller contract: 'filterCache' must point into a buffer with >= 3
+    // bytes of valid leading padding. Both callers satisfy it with
+    // raw_vector<uint8_t> (Nimble's DictionaryState::filterCache and velox's
+    // ScanState::filterCache), whose data() is always offset by
+    // velox::simd::kPadding (>= 16). Mirrors the StringDictionaryColumnVisitor
+    // filterCache() - 3 idiom in ColumnVisitors.h.
+    auto base = reinterpret_cast<const int32_t*>(filterCache - 3);
+    if (i + kWidth > numInput) {
+      cache = simd::maskGather<int32_t, int32_t, 1>(
+          xsimd::broadcast<int32_t>(0),
+          simd::leadingMask<int32_t>(numInput - i),
+          base,
+          indices);
+    } else {
+      cache = simd::gather<int32_t, int32_t, 1>(base, indices);
+    }
+#ifdef SVE_BITS
+    auto unknowns = simd::toBitMask(
+        simd::reinterpretBatch<uint32_t>((cache & (kUnknown << 24)) << 1) !=
+        xsimd::batch<uint32_t>(0));
+    auto passed = simd::toBitMask(
+        (simd::reinterpretBatch<uint32_t>(cache) & xsimd::batch<uint32_t>(1)) !=
+        xsimd::batch<uint32_t>(0));
+#else
+    auto unknowns = simd::toBitMask(
+        xsimd::batch_bool<int32_t>(
+            simd::reinterpretBatch<uint32_t>((cache & (kUnknown << 24)) << 1)));
+    auto passed = simd::toBitMask(
+        xsimd::batch_bool<int32_t>(simd::reinterpretBatch<uint32_t>(cache)));
+#endif
+    if (UNLIKELY(unknowns)) {
+      uint16_t bits = unknowns;
+      while (bits) {
+        int index = bits::getAndClearLastSetBit(bits);
+        int32_t value = input[i + index];
+        if (testIndex(value)) {
+          filterCache[value] = FilterResult::kSuccess;
+          passed |= 1 << index;
+        } else {
+          filterCache[value] = FilterResult::kFailure;
+        }
+      }
+    }
+    if (!passed) {
+      continue;
+    } else if (passed == (1 << kWidth) - 1) {
+      xsimd::load_unaligned(rows + i).store_unaligned(filterHits + numValues);
+      if (!kFilterOnly) {
+        indices.store_unaligned(values + numValues);
+      }
+      numValues += kWidth;
+    } else {
+      const int32_t numBits = __builtin_popcount(passed);
+      simd::filter(xsimd::load_unaligned(rows + i), passed)
+          .store_unaligned(filterHits + numValues);
+      if (!kFilterOnly) {
+        simd::filter(indices, passed).store_unaligned(values + numValues);
+      }
+      numValues += numBits;
+    }
+  }
+  return numValues;
+}
 
 inline int32_t firstNullIndex(const uint64_t* nulls, int32_t numRows) {
   int32_t first = -1;

--- a/velox/dwio/common/tests/DecoderUtilTest.cpp
+++ b/velox/dwio/common/tests/DecoderUtilTest.cpp
@@ -20,7 +20,11 @@
 #include "velox/dwio/common/SelectiveColumnReader.h"
 #include "velox/type/Filter.h"
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
+#include <algorithm>
+#include <functional>
 
 using namespace facebook::velox;
 using namespace facebook::velox::dwio::common;
@@ -255,3 +259,289 @@ TEST_F(DecoderUtilTest, fixedWidthScanMemcpyFastPath) {
   }
   ASSERT_EQ(numValues, kSize);
 }
+
+namespace {
+
+using ::testing::ElementsAre;
+using ::testing::ElementsAreArray;
+using ::testing::IsEmpty;
+
+// Number of int32 lanes per SIMD batch on this build's architecture. The kernel
+// processes the input one batch at a time, so the tests parameterize sizes off
+// this to exercise both full and masked-tail batches regardless of arch.
+constexpr int32_t kSimdWidth = xsimd::batch<int32_t>::size;
+
+// Distinctive value pre-filled into the output buffers so a test can tell which
+// slots filterDictionaryRunSimd actually wrote.
+constexpr int32_t kSentinel = -7;
+
+// filterDictionaryRunSimd gathers each cache byte via a misaligned load at
+// 'filterCache + index - 3', so for index 0 it reads up to 3 bytes before the
+// pointer. This holds the cache in a std::vector with that much leading slack
+// (the real callers satisfy the same contract with raw_vector, whose data() is
+// offset by simd::kPadding). The pad value is irrelevant: only bits 6/7 of the
+// byte at 'index' drive the kernel's unknown/success masks.
+constexpr int32_t kLeadingPad = 16;
+
+class FilterCache {
+ public:
+  FilterCache(int32_t numIndices, uint8_t fill)
+      : storage_(kLeadingPad + numIndices + kLeadingPad, fill) {}
+
+  // Pointer to dictionary index 0, with kLeadingPad valid bytes before it.
+  uint8_t* data() {
+    return storage_.data() + kLeadingPad;
+  }
+
+  uint8_t& operator[](int32_t index) {
+    return data()[index];
+  }
+
+ private:
+  std::vector<uint8_t> storage_;
+};
+
+FilterCache makeFilterCache(
+    int32_t numIndices,
+    uint8_t fill = FilterResult::kUnknown) {
+  return FilterCache(numIndices, fill);
+}
+
+// Outputs of one filterDictionaryRunSimd call, sliced to just the entries this
+// call produced (i.e. [startNumValues, returnedNumValues)) so tests assert
+// against independently constructed expectations.
+struct FilterRunResult {
+  std::vector<int32_t> hits; // passing rows, in input order
+  std::vector<int32_t>
+      values; // passing dict indices (sentinel-filled if kFilterOnly)
+  int32_t returnedNumValues{0};
+  std::vector<int32_t>
+      testedIndices; // indices handed to testIndex, in call order
+};
+
+// Drives filterDictionaryRunSimd against constructed input. 'input' and 'rows'
+// are passed by value so this can grow them by one SIMD width -- the kernel
+// loads a full batch at the tail, reading past the logical end, so the read
+// (input/rows) and write (hits/values) buffers all need that much slack.
+template <bool kFilterOnly>
+FilterRunResult runFilterRun(
+    std::vector<int32_t> input,
+    std::vector<int32_t> rows,
+    FilterCache& filterCache,
+    const std::function<bool(int32_t)>& predicate,
+    int32_t startNumValues = 0) {
+  const int32_t numInput = static_cast<int32_t>(input.size());
+  input.resize(numInput + kSimdWidth, 0);
+  rows.resize(numInput + kSimdWidth, 0);
+
+  std::vector<int32_t> hits(startNumValues + numInput + kSimdWidth, kSentinel);
+  std::vector<int32_t> values(
+      startNumValues + numInput + kSimdWidth, kSentinel);
+
+  std::vector<int32_t> testedIndices;
+  auto testIndex = [&](int32_t dictionaryIndex) {
+    testedIndices.push_back(dictionaryIndex);
+    return predicate(dictionaryIndex);
+  };
+
+  const int32_t returnedNumValues = filterDictionaryRunSimd<kFilterOnly>(
+      input.data(),
+      numInput,
+      rows.data(),
+      filterCache.data(),
+      hits.data(),
+      values.data(),
+      startNumValues,
+      testIndex);
+
+  FilterRunResult result;
+  result.returnedNumValues = returnedNumValues;
+  result.testedIndices = std::move(testedIndices);
+  result.hits.assign(
+      hits.begin() + startNumValues, hits.begin() + returnedNumValues);
+  result.values.assign(
+      values.begin() + startNumValues, values.begin() + returnedNumValues);
+  return result;
+}
+
+// Every entry passes on a cold cache: all rows/indices flow through and each
+// distinct index is recorded as kSuccess.
+TEST(FilterDictionaryRunSimdTest, allPassColdCache) {
+  auto cache = makeFilterCache(/*numIndices=*/10);
+  auto result = runFilterRun</*kFilterOnly=*/false>(
+      /*input=*/{3, 1, 4, 1, 5},
+      /*rows=*/{100, 101, 102, 103, 104},
+      cache,
+      /*predicate=*/[](int32_t) { return true; });
+
+  EXPECT_EQ(result.returnedNumValues, 5);
+  EXPECT_THAT(result.hits, ElementsAre(100, 101, 102, 103, 104));
+  EXPECT_THAT(result.values, ElementsAre(3, 1, 4, 1, 5));
+  EXPECT_EQ(cache[3], FilterResult::kSuccess);
+  EXPECT_EQ(cache[1], FilterResult::kSuccess);
+  EXPECT_EQ(cache[4], FilterResult::kSuccess);
+  EXPECT_EQ(cache[5], FilterResult::kSuccess);
+}
+
+// Every entry fails on a cold cache: no output, each distinct index recorded as
+// kFailure.
+TEST(FilterDictionaryRunSimdTest, allFailColdCache) {
+  auto cache = makeFilterCache(10);
+  auto result = runFilterRun<false>(
+      {3, 1, 4, 1, 5}, {100, 101, 102, 103, 104}, cache, [](int32_t) {
+        return false;
+      });
+
+  EXPECT_EQ(result.returnedNumValues, 0);
+  EXPECT_THAT(result.hits, IsEmpty());
+  EXPECT_THAT(result.values, IsEmpty());
+  EXPECT_EQ(cache[3], FilterResult::kFailure);
+  EXPECT_EQ(cache[1], FilterResult::kFailure);
+  EXPECT_EQ(cache[4], FilterResult::kFailure);
+  EXPECT_EQ(cache[5], FilterResult::kFailure);
+}
+
+// A mix of passing/failing indices compacts to just the survivors (preserving
+// order) and records the right verdict per index.
+TEST(FilterDictionaryRunSimdTest, mixedColdCacheCompactsAndRecords) {
+  auto cache = makeFilterCache(10);
+  auto result = runFilterRun<false>(
+      /*input=*/{2, 4, 5, 6, 7},
+      /*rows=*/{10, 11, 12, 13, 14},
+      cache,
+      /*predicate=*/[](int32_t index) { return index % 2 == 0; });
+
+  EXPECT_EQ(result.returnedNumValues, 3);
+  EXPECT_THAT(result.hits, ElementsAre(10, 11, 13)); // rows of 2, 4, 6
+  EXPECT_THAT(result.values, ElementsAre(2, 4, 6));
+  EXPECT_EQ(cache[2], FilterResult::kSuccess);
+  EXPECT_EQ(cache[4], FilterResult::kSuccess);
+  EXPECT_EQ(cache[6], FilterResult::kSuccess);
+  EXPECT_EQ(cache[5], FilterResult::kFailure);
+  EXPECT_EQ(cache[7], FilterResult::kFailure);
+}
+
+// A warm cache short-circuits: testIndex is only invoked for cache-unknown
+// indices; pre-recorded kSuccess/kFailure verdicts are honored without calling
+// it.
+TEST(FilterDictionaryRunSimdTest, warmCacheShortCircuitsTestIndex) {
+  auto cache = makeFilterCache(10);
+  cache[2] = FilterResult::kSuccess;
+  cache[5] = FilterResult::kFailure;
+  // Index 7 stays kUnknown, so only it should reach testIndex.
+
+  auto result = runFilterRun<false>(
+      {2, 5, 7}, {10, 11, 12}, cache, [](int32_t) { return true; });
+
+  EXPECT_EQ(result.returnedNumValues, 2); // 2 (warm pass) + 7 (cold pass)
+  EXPECT_THAT(result.hits, ElementsAre(10, 12));
+  EXPECT_THAT(result.values, ElementsAre(2, 7));
+  EXPECT_THAT(result.testedIndices, ElementsAre(7));
+  EXPECT_EQ(cache[7], FilterResult::kSuccess);
+}
+
+// With kFilterOnly the values (dict index) buffer is left untouched; only the
+// row hits are emitted.
+TEST(FilterDictionaryRunSimdTest, filterOnlyLeavesValuesBufferUntouched) {
+  auto cache = makeFilterCache(10);
+  auto result = runFilterRun</*kFilterOnly=*/true>(
+      {2, 4, 5, 6, 7}, {10, 11, 12, 13, 14}, cache, [](int32_t index) {
+        return index % 2 == 0;
+      });
+
+  EXPECT_EQ(result.returnedNumValues, 3);
+  EXPECT_THAT(result.hits, ElementsAre(10, 11, 13));
+  // The values buffer slice is still the pre-filled sentinel -> not written.
+  EXPECT_THAT(result.values, ElementsAre(kSentinel, kSentinel, kSentinel));
+}
+
+// Output is appended at the supplied starting numValues offset, not overwritten
+// from zero, and the returned count reflects the offset.
+TEST(FilterDictionaryRunSimdTest, appendsAtStartingNumValues) {
+  auto cache = makeFilterCache(10);
+  auto result = runFilterRun<false>(
+      {2, 5, 4},
+      {10, 11, 12},
+      cache,
+      [](int32_t index) { return index % 2 == 0; },
+      /*startNumValues=*/4);
+
+  // 2 and 4 pass, 5 fails -> 2 appended after offset 4 -> returns 6.
+  EXPECT_EQ(result.returnedNumValues, 6);
+  EXPECT_THAT(result.hits, ElementsAre(10, 12));
+  EXPECT_THAT(result.values, ElementsAre(2, 4));
+}
+
+// The same index appearing in a later batch hits the verdict cached by the
+// earlier batch, so testIndex runs exactly once for it.
+TEST(FilterDictionaryRunSimdTest, repeatedIndexAcrossBatchesHitsCache) {
+  constexpr int32_t kRepeatedIndex = 2;
+  const int32_t numInput = kSimdWidth + 1;
+  std::vector<int32_t> input(numInput);
+  std::vector<int32_t> rows(numInput);
+  for (int32_t i = 0; i < numInput; ++i) {
+    input[i] = 100 + i; // distinct, all != kRepeatedIndex
+    rows[i] = i;
+  }
+  // Same index in batch 0 (pos 0) and batch 1 (pos kSimdWidth).
+  input[0] = kRepeatedIndex;
+  input[kSimdWidth] = kRepeatedIndex;
+
+  auto cache = makeFilterCache(/*numIndices=*/200);
+  auto result =
+      runFilterRun<false>(input, rows, cache, [](int32_t) { return true; });
+
+  const int32_t timesTested = static_cast<int32_t>(std::count(
+      result.testedIndices.begin(),
+      result.testedIndices.end(),
+      kRepeatedIndex));
+  EXPECT_EQ(timesTested, 1);
+  EXPECT_EQ(cache[kRepeatedIndex], FilterResult::kSuccess);
+  EXPECT_EQ(result.returnedNumValues, numInput);
+}
+
+// Exercises full and masked-tail batches across a range of input sizes; the
+// expected survivors are computed independently from the same predicate.
+class FilterDictionaryRunSimdSizeTest : public testing::TestWithParam<int32_t> {
+};
+
+TEST_P(FilterDictionaryRunSimdSizeTest, fullAndPartialBatches) {
+  const int32_t numInput = GetParam();
+  std::vector<int32_t> input(numInput);
+  std::vector<int32_t> rows(numInput);
+  for (int32_t i = 0; i < numInput; ++i) {
+    input[i] = i;
+    rows[i] = 1000 + i;
+  }
+  const auto predicate = [](int32_t index) { return index % 3 != 0; };
+
+  std::vector<int32_t> expectedHits;
+  std::vector<int32_t> expectedValues;
+  for (int32_t i = 0; i < numInput; ++i) {
+    if (predicate(i)) {
+      expectedHits.push_back(1000 + i);
+      expectedValues.push_back(i);
+    }
+  }
+
+  auto cache = makeFilterCache(numInput + 1);
+  auto result = runFilterRun<false>(input, rows, cache, predicate);
+
+  EXPECT_EQ(
+      result.returnedNumValues, static_cast<int32_t>(expectedValues.size()));
+  EXPECT_THAT(result.hits, ElementsAreArray(expectedHits));
+  EXPECT_THAT(result.values, ElementsAreArray(expectedValues));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Sizes,
+    FilterDictionaryRunSimdSizeTest,
+    testing::Values(
+        1,
+        kSimdWidth - 1,
+        kSimdWidth,
+        kSimdWidth + 1,
+        2 * kSimdWidth,
+        3 * kSimdWidth + 3));
+
+} // namespace


### PR DESCRIPTION
Summary:
Dictionary-encoded string columns in the selective Nimble reader emit a `DictionaryVector` backed by a single alphabet merged across all chunks of a read range. A filter pushed down on such a column cannot be evaluated inside the encoding's per-row decode: the merged alphabet (and therefore the per-alphabet-index `filterCache`) is not known until every chunk has been read, and the inner encoding's `bulkScan` would apply a string filter directly to raw `int32` dictionary indices. The filter is therefore suppressed during the bulk `materializeIndices` read and applied post-hoc on the merged alphabet.

This diff replaces the previous in-encoding (`populateScanState` / framework `StringDictionaryColumnVisitor`) filter evaluation with that post-hoc path, makes it SIMD-accelerated, and removes the now-dead in-encoding code:

- Shared SIMD kernel. Add a free function `filterDictionaryRunSimd<kFilterOnly>(...)` in `velox/dwio/common/ColumnVisitors.h` that gathers each index's cached verdict from `filterCache`, resolves cache misses through the filter (recording the result back), and SIMD-compacts the passing rows (and, unless `kFilterOnly`, the passing indices). Nimble's `filterByCache` calls it directly. DWRF's `StringDictionaryColumnVisitor::processRun` is left unchanged; it still holds an equivalent inline loop, marked with a TODO to adopt the shared kernel in a follow-up diff (kept separate to isolate the DWRF change from this Nimble feature).
- Post-hoc filter in `StringColumnReader`. `readWithDictionary` saves and clears the scan-spec filter so the bulk index read runs, then `filterDictionaryIndices` applies the filter on the merged alphabet via `filterByCache`, compacting `rawValues_`/`outputRows_` to the passing rows. `ensureFilterCache` lazily sizes the per-alphabet-index cache, which grows and clears together with the alphabet.
- Output-layout null realignment. Pre-compacting `rawValues_`/`outputRows_` makes the framework's `compactScalarValues` a no-op (`rows.size() == numValues_`), which skips its null move, so `filterDictionaryIndices` realigns the result nulls itself in three cases: (1) no nulls — filter in place; (2) value filter rejects nulls — filter in place and mark the compacted output all-non-null; (3) IS NULL accepts nulls — merge null rows with the passing non-null rows in row order. `ensureWritableResultNulls` mirrors the framework's `shouldMoveNulls` by switching off the dense `returnReaderNulls_` fast path and allocating an output-indexed null bitmap.
- Delete dead code. With `StringColumnReader` the sole owner of dictionary filtering, the per-encoding `kHasFilter` branches and the `prepareResultNullsForDenseFilter` helper in `encodings/common/Encoding.h` (and their call sites in the `Constant`, `Dictionary`, `MainlyConstant`, and `RLE` encodings) are unreachable and removed, along with `StringColumnReader::populateScanState`.

Performance. On a simulated filter workload (`parallel_reader` over a dictionary-encoded string column, `l_returnflag='R'`, opt mode, `batch_size=1024`, concurrency 16, `read_count=500`, P50), the SIMD `filterCache` path reads at ~52 ms, versus ~70 ms for the parent diff's scalar per-row filter (−26%) and 130 ms for a no-dictionary flat read (−60%). The gain comes from evaluating the byte filter once per distinct dictionary value (`filterCache` memoization) and SIMD-gathering/compacting survivors, instead of testing the filter per row. (Parent/flat figures are from the 2026-06-05 A/B; the SIMD figure was reconfirmed on the current stack on 2026-06-13: P50 wall 52/52/54 ms across 3 runs.)

No behavior change for non-dictionary columns or for dictionary columns read without a pushed-down filter.

Reviewed By: Yuhta

Differential Revision: D102273283


