### PR TITLE
feat(exec): Add spill support to NestedLoopJoin

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -4023,6 +4023,10 @@ class NestedLoopJoinNode : public PlanNode {
     return "NestedLoopJoin";
   }
 
+  bool canSpill(const QueryConfig& queryConfig) const override {
+    return queryConfig.joinSpillEnabled();
+  }
+
   const TypedExprPtr& joinCondition() const {
     return joinCondition_;
   }

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -4188,6 +4188,10 @@ class NestedLoopJoinNode : public PlanNode {
     return "NestedLoopJoin";
   }
 
+  bool canSpill(const QueryConfig& queryConfig) const override {
+    return queryConfig.joinSpillEnabled();
+  }
+
   const TypedExprPtr& joinCondition() const {
     return joinCondition_;
   }

--- a/velox/core/tests/PlanNodeTest.cpp
+++ b/velox/core/tests/PlanNodeTest.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/core/Expressions.h"
+#include "velox/core/QueryConfig.h"
 #include "velox/parse/PlanNodeIdGenerator.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
@@ -237,6 +238,15 @@ TEST_F(PlanNodeTest, nestedLoopJoin) {
       std::make_shared<NestedLoopJoinNode>(
           nextId(), leftValues, rightValues, ROW({"a"}, VARCHAR())),
       "Join output column type must match the input type: VARCHAR vs. INTEGER");
+
+  auto join = std::make_shared<NestedLoopJoinNode>(
+      nextId(), leftValues, rightValues, ROW({"a"}, {INTEGER()}));
+  ASSERT_FALSE(join->canSpill(QueryConfig(
+      std::unordered_map<std::string, std::string>{
+          {QueryConfig::kJoinSpillEnabled, "false"}})));
+  ASSERT_TRUE(join->canSpill(QueryConfig(
+      std::unordered_map<std::string, std::string>{
+          {QueryConfig::kJoinSpillEnabled, "true"}})));
 }
 
 TEST_F(PlanNodeTest, indexLookupJoin) {

--- a/velox/core/tests/PlanNodeTest.cpp
+++ b/velox/core/tests/PlanNodeTest.cpp
@@ -18,6 +18,7 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/core/Expressions.h"
 #include "velox/core/FixedPointPlanNodes.h"
+#include "velox/core/QueryConfig.h"
 #include "velox/parse/PlanNodeIdGenerator.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
@@ -238,6 +239,15 @@ TEST_F(PlanNodeTest, nestedLoopJoin) {
       std::make_shared<NestedLoopJoinNode>(
           nextId(), leftValues, rightValues, ROW({"a"}, VARCHAR())),
       "Join output column type must match the input type: VARCHAR vs. INTEGER");
+
+  auto join = std::make_shared<NestedLoopJoinNode>(
+      nextId(), leftValues, rightValues, ROW({"a"}, {INTEGER()}));
+  ASSERT_FALSE(join->canSpill(QueryConfig(
+      std::unordered_map<std::string, std::string>{
+          {QueryConfig::kJoinSpillEnabled, "false"}})));
+  ASSERT_TRUE(join->canSpill(QueryConfig(
+      std::unordered_map<std::string, std::string>{
+          {QueryConfig::kJoinSpillEnabled, "true"}})));
 }
 
 TEST_F(PlanNodeTest, indexLookupJoin) {

--- a/velox/exec/NestedLoopJoinBuild.cpp
+++ b/velox/exec/NestedLoopJoinBuild.cpp
@@ -17,29 +17,52 @@
 #include "velox/exec/OperatorType.h"
 #include "velox/exec/Task.h"
 
-namespace facebook::velox::exec {
+#include <algorithm>
 
-void NestedLoopJoinBridge::setData(std::vector<RowVectorPtr> buildVectors) {
+namespace facebook::velox::exec {
+namespace {
+const SpillPartitionId kNestedLoopJoinSpillPartitionId{0};
+} // namespace
+
+std::shared_ptr<const NestedLoopJoinBuildData>
+NestedLoopJoinBuildData::createInMemory(std::vector<RowVectorPtr> vectors) {
+  auto data = std::make_shared<NestedLoopJoinBuildData>();
+  data->vectors = std::move(vectors);
+  return data;
+}
+
+std::shared_ptr<const NestedLoopJoinBuildData>
+NestedLoopJoinBuildData::createSpilled(RowTypePtr type, SpillFiles files) {
+  auto data = std::make_shared<NestedLoopJoinBuildData>();
+  data->spilled = true;
+  data->type = std::move(type);
+  data->spillFiles = std::move(files);
+  return data;
+}
+
+void NestedLoopJoinBridge::setData(
+    std::shared_ptr<const NestedLoopJoinBuildData> buildData) {
   std::vector<ContinuePromise> promises;
   {
     std::lock_guard<std::mutex> l(mutex_);
-    VELOX_CHECK(!buildVectors_.has_value(), "setData must be called only once");
-    buildVectors_ = std::move(buildVectors);
+    VELOX_CHECK_NULL(buildData_, "setData must be called only once");
+    buildData_ = std::move(buildData);
     promises = std::move(promises_);
   }
   notify(std::move(promises));
 }
 
-std::optional<std::vector<RowVectorPtr>> NestedLoopJoinBridge::dataOrFuture(
+std::shared_ptr<const NestedLoopJoinBuildData>
+NestedLoopJoinBridge::dataOrFuture(
     ContinueFuture* future) {
   std::lock_guard<std::mutex> l(mutex_);
   VELOX_CHECK(!cancelled_, "Getting data after the build side is aborted");
-  if (buildVectors_.has_value()) {
-    return buildVectors_;
+  if (buildData_ != nullptr) {
+    return buildData_;
   }
   promises_.emplace_back("NestedLoopJoinBridge::tableOrFuture");
   *future = promises_.back().getSemiFuture();
-  return std::nullopt;
+  return nullptr;
 }
 
 NestedLoopJoinBuild::NestedLoopJoinBuild(
@@ -51,13 +74,31 @@ NestedLoopJoinBuild::NestedLoopJoinBuild(
           nullptr,
           operatorId,
           joinNode->id(),
-          OperatorType::kNestedLoopJoinBuild) {}
+          OperatorType::kNestedLoopJoinBuild,
+          joinNode->canSpill(driverCtx->queryConfig())
+              ? driverCtx->makeSpillConfig(
+                    operatorId,
+                    OperatorType::kNestedLoopJoinBuild)
+              : std::nullopt),
+      buildType_(joinNode->sources()[1]->outputType()) {}
 
 void NestedLoopJoinBuild::addInput(RowVectorPtr input) {
   if (input->size() > 0) {
-    // Load lazy vectors before storing.
-    for (auto& child : input->children()) {
-      child->loadedVector();
+    {
+      Operator::ReclaimableSectionGuard guard(this);
+      // Load lazy vectors before storing or spilling.
+      for (auto& child : input->children()) {
+        child->loadedVector();
+      }
+      if (canSpill()) {
+        input = copyToOperatorPool(input);
+      }
+    }
+
+    if (spilled_) {
+      spillVector(std::move(input));
+      pool()->release();
+      return;
     }
     dataVectors_.emplace_back(std::move(input));
   }
@@ -104,6 +145,63 @@ std::vector<RowVectorPtr> NestedLoopJoinBuild::mergeDataVectors() const {
   return merged;
 }
 
+void NestedLoopJoinBuild::ensureSpiller() {
+  VELOX_CHECK(canSpill());
+  if (spiller_ != nullptr) {
+    return;
+  }
+  spiller_ = std::make_unique<NoRowContainerSpiller>(
+      buildType_,
+      std::nullopt,
+      HashBitRange{},
+      spillConfig(),
+      spillStats_.get());
+}
+
+void NestedLoopJoinBuild::spillVector(RowVectorPtr vector) {
+  if (vector == nullptr || vector->size() == 0) {
+    return;
+  }
+  ensureSpiller();
+  spiller_->spill(kNestedLoopJoinSpillPartitionId, vector);
+  spilled_ = true;
+}
+
+void NestedLoopJoinBuild::spillBufferedVectors() {
+  if (dataVectors_.empty()) {
+    return;
+  }
+  for (auto& vector : dataVectors_) {
+    spillVector(std::move(vector));
+  }
+  dataVectors_.clear();
+  pool()->release();
+}
+
+void NestedLoopJoinBuild::finishSpill(SpillPartitionSet& spillPartitions) {
+  if (spiller_ == nullptr) {
+    return;
+  }
+  spiller_->finishSpill(spillPartitions);
+  spiller_.reset();
+}
+
+RowVectorPtr NestedLoopJoinBuild::copyToOperatorPool(
+    const RowVectorPtr& input) {
+  auto copy =
+      BaseVector::create<RowVector>(input->type(), input->size(), pool());
+  copy->copy(input.get(), 0, 0, input->size());
+  return copy;
+}
+
+void NestedLoopJoinBuild::reclaim(
+    uint64_t /*targetBytes*/,
+    memory::MemoryReclaimer::Stats& /*stats*/) {
+  VELOX_CHECK(canSpill());
+  VELOX_CHECK(!nonReclaimableSection_);
+  spillBufferedVectors();
+}
+
 void NestedLoopJoinBuild::noMoreInput() {
   Operator::noMoreInput();
   std::vector<ContinuePromise> promises;
@@ -128,6 +226,40 @@ void NestedLoopJoinBuild::noMoreInput() {
       }
     });
 
+    std::vector<NestedLoopJoinBuild*> builds{this};
+    for (auto& peer : peers) {
+      auto op = peer->findOperator(planNodeId());
+      auto* build = dynamic_cast<NestedLoopJoinBuild*>(op);
+      VELOX_CHECK_NOT_NULL(build);
+      builds.push_back(build);
+    }
+
+    const bool anySpilled =
+        std::any_of(builds.begin(), builds.end(), [](auto* build) {
+          return build->spilled_;
+        });
+
+    if (anySpilled) {
+      SpillPartitionSet spillPartitions;
+      for (auto* build : builds) {
+        build->spillBufferedVectors();
+        build->finishSpill(spillPartitions);
+      }
+
+      SpillFiles spillFiles;
+      auto it = spillPartitions.find(kNestedLoopJoinSpillPartitionId);
+      if (it != spillPartitions.end()) {
+        spillFiles = it->second->files();
+      }
+
+      operatorCtx_->task()
+          ->getNestedLoopJoinBridge(
+              operatorCtx_->driverCtx()->splitGroupId, planNodeId())
+          ->setData(NestedLoopJoinBuildData::createSpilled(
+              buildType_, std::move(spillFiles)));
+      return;
+    }
+
     for (auto& peer : peers) {
       auto op = peer->findOperator(planNodeId());
       auto* build = dynamic_cast<NestedLoopJoinBuild*>(op);
@@ -143,7 +275,8 @@ void NestedLoopJoinBuild::noMoreInput() {
   operatorCtx_->task()
       ->getNestedLoopJoinBridge(
           operatorCtx_->driverCtx()->splitGroupId, planNodeId())
-      ->setData(std::move(dataVectors_));
+      ->setData(NestedLoopJoinBuildData::createInMemory(
+          std::move(dataVectors_)));
 }
 
 bool NestedLoopJoinBuild::isFinished() {

--- a/velox/exec/NestedLoopJoinBuild.h
+++ b/velox/exec/NestedLoopJoinBuild.h
@@ -17,17 +17,33 @@
 
 #include "velox/exec/JoinBridge.h"
 #include "velox/exec/Operator.h"
+#include "velox/exec/Spiller.h"
 
 namespace facebook::velox::exec {
 
+struct NestedLoopJoinBuildData {
+  static std::shared_ptr<const NestedLoopJoinBuildData> createInMemory(
+      std::vector<RowVectorPtr> vectors);
+
+  static std::shared_ptr<const NestedLoopJoinBuildData> createSpilled(
+      RowTypePtr type,
+      SpillFiles files);
+
+  bool spilled{false};
+  std::vector<RowVectorPtr> vectors;
+  RowTypePtr type;
+  SpillFiles spillFiles;
+};
+
 class NestedLoopJoinBridge : public JoinBridge {
  public:
-  void setData(std::vector<RowVectorPtr> buildVectors);
+  void setData(std::shared_ptr<const NestedLoopJoinBuildData> buildData);
 
-  std::optional<std::vector<RowVectorPtr>> dataOrFuture(ContinueFuture* future);
+  std::shared_ptr<const NestedLoopJoinBuildData> dataOrFuture(
+      ContinueFuture* future);
 
  private:
-  std::optional<std::vector<RowVectorPtr>> buildVectors_;
+  std::shared_ptr<const NestedLoopJoinBuildData> buildData_;
 };
 
 class NestedLoopJoinBuild : public Operator {
@@ -53,15 +69,39 @@ class NestedLoopJoinBuild : public Operator {
 
   bool isFinished() override;
 
+  bool canReclaim() const override {
+    return canSpill() && !dataVectors_.empty();
+  }
+
+  void reclaim(uint64_t targetBytes, memory::MemoryReclaimer::Stats& stats)
+      override;
+
   void close() override {
     dataVectors_.clear();
+    spiller_.reset();
     Operator::close();
   }
 
   std::vector<RowVectorPtr> mergeDataVectors() const;
 
  private:
+  void ensureSpiller();
+
+  void spillVector(RowVectorPtr vector);
+
+  void spillBufferedVectors();
+
+  void finishSpill(SpillPartitionSet& spillPartitions);
+
+  RowVectorPtr copyToOperatorPool(const RowVectorPtr& input);
+
+  const RowTypePtr buildType_;
+
   std::vector<RowVectorPtr> dataVectors_;
+
+  std::unique_ptr<NoRowContainerSpiller> spiller_;
+
+  bool spilled_{false};
 
   // Future for synchronizing with other Drivers of the same pipeline. All build
   // Drivers must be completed before making data available for the probe side.

--- a/velox/exec/NestedLoopJoinProbe.cpp
+++ b/velox/exec/NestedLoopJoinProbe.cpp
@@ -57,7 +57,12 @@ NestedLoopJoinProbe::NestedLoopJoinProbe(
           joinNode->outputType(),
           operatorId,
           joinNode->id(),
-          OperatorType::kNestedLoopJoinProbe),
+          OperatorType::kNestedLoopJoinProbe,
+          joinNode->canSpill(driverCtx->queryConfig())
+              ? driverCtx->makeSpillConfig(
+                    operatorId,
+                    OperatorType::kNestedLoopJoinProbe)
+              : std::nullopt),
       joinType_(joinNode->joinType()),
       outputBatchSize_{outputBatchRows()},
       joinNode_(joinNode) {
@@ -125,6 +130,139 @@ void NestedLoopJoinProbe::initializeFilter(
   filterInputType_ = ROW(std::move(names), std::move(types));
 }
 
+bool NestedLoopJoinProbe::hasProbedAllBuildData() const {
+  if (isBuildDataSpilled()) {
+    return spilledBuildVector_ == nullptr;
+  }
+  return buildIndex_ >= buildVectors_.value().size();
+}
+
+bool NestedLoopJoinProbe::isLastBuildIndex() const {
+  if (isBuildDataSpilled()) {
+    return false;
+  }
+  return buildIndex_ + 1 >= buildVectors_.value().size();
+}
+
+bool NestedLoopJoinProbe::isBuildSideEmpty() const {
+  if (isBuildDataSpilled()) {
+    return buildData_->spillFiles.empty();
+  }
+  return buildVectors_->empty();
+}
+
+const RowVectorPtr& NestedLoopJoinProbe::currentBuildVector() const {
+  if (isBuildDataSpilled()) {
+    VELOX_CHECK_NOT_NULL(spilledBuildVector_);
+    return spilledBuildVector_;
+  }
+  return buildVectors_.value()[buildIndex_];
+}
+
+void NestedLoopJoinProbe::advanceBuildVector() {
+  if (!isBuildDataSpilled()) {
+    ++buildIndex_;
+    return;
+  }
+
+  ++buildIndex_;
+  spilledBuildVector_.reset();
+  loadNextSpilledBuildVector();
+}
+
+void NestedLoopJoinProbe::resetBuildCursor() {
+  buildIndex_ = 0;
+  if (!isBuildDataSpilled()) {
+    return;
+  }
+
+  spillReader_.reset();
+  spilledBuildVector_.reset();
+  if (buildData_->spillFiles.empty()) {
+    return;
+  }
+
+  VELOX_CHECK_NOT_NULL(spillConfig());
+  SpillPartition spillPartition(
+      SpillPartitionId{0}, SpillFiles(buildData_->spillFiles));
+  spillReader_ = spillPartition.createUnorderedReader(
+      spillConfig()->readBufferSize, pool(), spillStats_.get());
+  loadNextSpilledBuildVector();
+}
+
+void NestedLoopJoinProbe::clearBuildCursor() {
+  buildIndex_ = 0;
+  spillReader_.reset();
+  spilledBuildVector_.reset();
+}
+
+bool NestedLoopJoinProbe::loadNextSpilledBuildVector() {
+  VELOX_CHECK(isBuildDataSpilled());
+  if (spillReader_ == nullptr) {
+    return false;
+  }
+
+  RowVectorPtr batch;
+  while (spillReader_->nextBatch(batch)) {
+    if (batch->size() > 0) {
+      spilledBuildVector_ = std::move(batch);
+      return true;
+    }
+    batch.reset();
+  }
+
+  spillReader_.reset();
+  return false;
+}
+
+void NestedLoopJoinProbe::finishBuildCursor() {
+  if (!isBuildDataSpilled()) {
+    buildIndex_ = buildVectors_.value().size();
+    return;
+  }
+  spillReader_.reset();
+  spilledBuildVector_.reset();
+}
+
+SelectivityVector& NestedLoopJoinProbe::buildMatched(vector_size_t size) {
+  VELOX_CHECK(needsBuildMismatch(joinType_));
+  if (buildMatched_.size() <= buildIndex_) {
+    buildMatched_.resize(buildIndex_ + 1);
+  }
+  auto& matched = buildMatched_[buildIndex_];
+  if (matched.size() == 0) {
+    matched.resizeFill(size, false);
+  } else {
+    VELOX_CHECK_EQ(matched.size(), size);
+  }
+  return matched;
+}
+
+const SelectivityVector& NestedLoopJoinProbe::buildMatchedForOutput(
+    const RowVectorPtr& data) {
+  return buildMatched(data->size());
+}
+
+void NestedLoopJoinProbe::mergeBuildMatched(
+    const NestedLoopJoinProbe& peer) {
+  if (buildMatched_.size() < peer.buildMatched_.size()) {
+    buildMatched_.resize(peer.buildMatched_.size());
+  }
+  for (auto i = 0; i < peer.buildMatched_.size(); ++i) {
+    const auto& peerMatched = peer.buildMatched_[i];
+    if (peerMatched.size() == 0) {
+      continue;
+    }
+    auto& localMatched = buildMatched_[i];
+    if (localMatched.size() == 0) {
+      localMatched.resizeFill(peerMatched.size(), false);
+    } else {
+      VELOX_CHECK_EQ(localMatched.size(), peerMatched.size());
+    }
+    localMatched.select(peerMatched);
+  }
+}
+
 BlockingReason NestedLoopJoinProbe::isBlocked(ContinueFuture* future) {
   switch (state_) {
     case ProbeOperatorState::kRunning:
@@ -139,16 +277,17 @@ BlockingReason NestedLoopJoinProbe::isBlocked(ContinueFuture* future) {
       setState(ProbeOperatorState::kFinish);
       return BlockingReason::kNotBlocked;
     case ProbeOperatorState::kWaitForBuild: {
-      VELOX_CHECK(!buildVectors_.has_value());
+      VELOX_CHECK_NULL(buildData_);
       if (!getBuildData(future)) {
         return BlockingReason::kWaitForJoinBuild;
       }
-      VELOX_CHECK(buildVectors_.has_value());
+      VELOX_CHECK_NOT_NULL(buildData_);
 
       // If we just got build data, check if this is a right or full join where
       // we need to hit track of hits on build records. If it is, initialize the
-      // selectivity vectors that do so.
-      if (needsBuildMismatch(joinType_)) {
+      // selectivity vectors that do so. Spilled build data initializes these
+      // lazily as files are replayed.
+      if (needsBuildMismatch(joinType_) && !isBuildDataSpilled()) {
         buildMatched_.resize(buildVectors_->size());
         for (auto i = 0; i < buildVectors_->size(); ++i) {
           buildMatched_[i].resizeFill(buildVectors_.value()[i]->size(), false);
@@ -167,6 +306,8 @@ void NestedLoopJoinProbe::close() {
   if (joinCondition_ != nullptr) {
     joinCondition_->clear();
   }
+  clearBuildCursor();
+  buildData_.reset();
   buildVectors_.reset();
   Operator::close();
 }
@@ -185,6 +326,9 @@ void NestedLoopJoinProbe::addInput(RowVectorPtr input) {
     probeSideEmpty_ = false;
   }
   VELOX_CHECK_EQ(buildIndex_, 0);
+  if (isBuildDataSpilled()) {
+    resetBuildCursor();
+  }
 }
 
 void NestedLoopJoinProbe::noMoreInput() {
@@ -200,18 +344,21 @@ void NestedLoopJoinProbe::noMoreInput() {
 }
 
 bool NestedLoopJoinProbe::getBuildData(ContinueFuture* future) {
-  VELOX_CHECK(!buildVectors_.has_value());
+  VELOX_CHECK_NULL(buildData_);
 
   auto buildData =
       operatorCtx_->task()
           ->getNestedLoopJoinBridge(
               operatorCtx_->driverCtx()->splitGroupId, planNodeId())
           ->dataOrFuture(future);
-  if (!buildData.has_value()) {
+  if (buildData == nullptr) {
     return false;
   }
 
-  buildVectors_ = std::move(buildData);
+  buildData_ = std::move(buildData);
+  if (!isBuildDataSpilled()) {
+    buildVectors_ = buildData_->vectors;
+  }
   return true;
 }
 
@@ -230,13 +377,14 @@ RowVectorPtr NestedLoopJoinProbe::getOutput() {
       // Scans build input producing build mismatches by wrapping dictionaries
       // to build input, and null constant to probe projections.
       while (output == nullptr && !hasProbedAllBuildData()) {
+        const auto& buildVector = currentBuildVector();
         output = getBuildMismatchedOutput(
-            buildVectors_.value()[buildIndex_],
-            buildMatched_[buildIndex_],
+            buildVector,
+            buildMatchedForOutput(buildVector),
             buildOutMapping_,
             buildProjections_,
             identityProjections_);
-        ++buildIndex_;
+        advanceBuildVector();
       }
       if (hasProbedAllBuildData()) {
         setState(ProbeOperatorState::kFinish);
@@ -312,12 +460,12 @@ bool NestedLoopJoinProbe::advanceProbe() {
   if (hasProbedAllBuildData()) {
     probeRow_ += probeRowCount_;
     probeRowHasMatch_ = false;
-    buildIndex_ = 0;
 
     // If we finished processing the probe side.
     if (probeRow_ >= input_->size()) {
       return true;
     }
+    resetBuildCursor();
   }
   return false;
 }
@@ -327,7 +475,7 @@ void NestedLoopJoinProbe::handleLeftSemiProjectNoCondition() {
   output_->childAt(outputType_->size() - 1)
       ->asFlatVector<bool>()
       ->set(numOutputRows_ - 1, true);
-  buildIndex_ = buildVectors_.value().size();
+  finishBuildCursor();
   filterResultRow_ = 0;
 }
 
@@ -385,7 +533,7 @@ bool NestedLoopJoinProbe::addFilteredOutput(
   }
 
   copyBuildValues(buildVector);
-  ++buildIndex_;
+  advanceBuildVector();
   filterResultRow_ = 0;
   buildRow_ = 0;
   if (!singleProbeRow) {
@@ -400,7 +548,7 @@ bool NestedLoopJoinProbe::handleMatchedFilterRow(
     vector_size_t buildRowCount,
     bool singleProbeRow) {
   if (needsBuildMismatch(joinType_)) {
-    buildMatched_[buildIndex_].setValid(buildRow_, true);
+    buildMatched(buildRowCount).setValid(buildRow_, true);
   }
   addOutputRow();
   ++numOutputRows_;
@@ -415,7 +563,7 @@ bool NestedLoopJoinProbe::handleMatchedFilterRow(
       ->set(numOutputRows_ - 1, true);
 
   if (singleProbeRow) {
-    buildIndex_ = buildVectors_.value().size();
+    finishBuildCursor();
     filterResultRow_ = 0;
     buildRow_ = 0;
   } else {
@@ -442,11 +590,11 @@ bool NestedLoopJoinProbe::addToOutput() {
   }
 
   while (!hasProbedAllBuildData()) {
-    const auto& currentBuild = buildVectors_.value()[buildIndex_];
+    const auto& currentBuild = currentBuildVector();
 
     // Empty build vector; move to the next.
     if (currentBuild->size() == 0) {
-      ++buildIndex_;
+      advanceBuildVector();
       filterResultRow_ = 0;
       continue;
     }
@@ -459,7 +607,7 @@ bool NestedLoopJoinProbe::addToOutput() {
           currentBuild, outputType_, identityProjections_, buildProjections_);
       numOutputRows_ = output_->size();
       probeRowHasMatch_ = true;
-      ++buildIndex_;
+      advanceBuildVector();
       filterResultRow_ = 0;
       return false;
     }
@@ -493,6 +641,8 @@ bool NestedLoopJoinProbe::addToOutput() {
   // If build side is empty, need to add mismatch row (for left, left semi and
   // full outer joins)
   if (isBuildSideEmpty()) {
+    checkProbeMismatchRow();
+  } else if (isBuildDataSpilled()) {
     checkProbeMismatchRow();
   }
   // Signals that all input has been generated for the probeRow and build
@@ -734,7 +884,8 @@ bool NestedLoopJoinProbe::checkProbeMismatchRow() {
   // If we are processing the last batch of the build side, check if we need
   // to add a probe mismatch record.
   if (needsProbeMismatch(joinType_) && !probeRowHasMatch_ &&
-      isLastBuildIndex()) {
+      (isLastBuildIndex() ||
+       (isBuildDataSpilled() && hasProbedAllBuildData()))) {
     prepareOutput();
     addProbeMismatchRow();
     ++numOutputRows_;
@@ -746,7 +897,7 @@ bool NestedLoopJoinProbe::checkProbeMismatchRow() {
 void NestedLoopJoinProbe::finishProbeInput() {
   VELOX_CHECK_NOT_NULL(input_);
   input_.reset();
-  buildIndex_ = 0;
+  clearBuildCursor();
   probeRow_ = 0;
 
   if (!noMoreInput_) {
@@ -787,18 +938,19 @@ void NestedLoopJoinProbe::beginBuildMismatch() {
     auto* op = peer->findOperator(planNodeId());
     auto* probe = dynamic_cast<NestedLoopJoinProbe*>(op);
     VELOX_CHECK_NOT_NULL(probe);
-    for (auto i = 0; i < buildMatched_.size(); ++i) {
-      buildMatched_[i].select(probe->buildMatched_[i]);
-      probeSideEmpty_ &= probe->probeSideEmpty_;
-    }
+    mergeBuildMatched(*probe);
+    probeSideEmpty_ &= probe->probeSideEmpty_;
   }
   peers.clear();
   for (auto& matched : buildMatched_) {
-    matched.updateBounds();
+    if (matched.size() > 0) {
+      matched.updateBounds();
+    }
   }
   for (auto& promise : promises) {
     promise.setValue();
   }
+  resetBuildCursor();
 }
 
 RowVectorPtr NestedLoopJoinProbe::getBuildMismatchedOutput(

--- a/velox/exec/NestedLoopJoinProbe.cpp
+++ b/velox/exec/NestedLoopJoinProbe.cpp
@@ -57,7 +57,12 @@ NestedLoopJoinProbe::NestedLoopJoinProbe(
           joinNode->outputType(),
           operatorId,
           joinNode->id(),
-          OperatorType::kNestedLoopJoinProbe),
+          OperatorType::kNestedLoopJoinProbe,
+          joinNode->canSpill(driverCtx->queryConfig())
+              ? driverCtx->makeSpillConfig(
+                    operatorId,
+                    OperatorType::kNestedLoopJoinProbe)
+              : std::nullopt),
       joinType_(joinNode->joinType()),
       outputBatchSize_{outputBatchRows()},
       joinNode_(joinNode) {
@@ -125,6 +130,139 @@ void NestedLoopJoinProbe::initializeFilter(
   filterInputType_ = ROW(std::move(names), std::move(types));
 }
 
+bool NestedLoopJoinProbe::hasProbedAllBuildData() const {
+  if (isBuildDataSpilled()) {
+    return spilledBuildVector_ == nullptr;
+  }
+  return buildIndex_ >= buildVectors_.value().size();
+}
+
+bool NestedLoopJoinProbe::isLastBuildIndex() const {
+  if (isBuildDataSpilled()) {
+    return false;
+  }
+  return buildIndex_ + 1 >= buildVectors_.value().size();
+}
+
+bool NestedLoopJoinProbe::isBuildSideEmpty() const {
+  if (isBuildDataSpilled()) {
+    return buildData_->spillFiles.empty();
+  }
+  return buildVectors_->empty();
+}
+
+const RowVectorPtr& NestedLoopJoinProbe::currentBuildVector() const {
+  if (isBuildDataSpilled()) {
+    VELOX_CHECK_NOT_NULL(spilledBuildVector_);
+    return spilledBuildVector_;
+  }
+  return buildVectors_.value()[buildIndex_];
+}
+
+void NestedLoopJoinProbe::advanceBuildVector() {
+  if (!isBuildDataSpilled()) {
+    ++buildIndex_;
+    return;
+  }
+
+  ++buildIndex_;
+  spilledBuildVector_.reset();
+  loadNextSpilledBuildVector();
+}
+
+void NestedLoopJoinProbe::resetBuildCursor() {
+  buildIndex_ = 0;
+  if (!isBuildDataSpilled()) {
+    return;
+  }
+
+  spillReader_.reset();
+  spilledBuildVector_.reset();
+  if (buildData_->spillFiles.empty()) {
+    return;
+  }
+
+  VELOX_CHECK_NOT_NULL(spillConfig());
+  SpillPartition spillPartition(
+      SpillPartitionId{0}, SpillFiles(buildData_->spillFiles));
+  spillReader_ = spillPartition.createUnorderedReader(
+      spillConfig()->readBufferSize, pool(), spillStats_.get());
+  loadNextSpilledBuildVector();
+}
+
+void NestedLoopJoinProbe::clearBuildCursor() {
+  buildIndex_ = 0;
+  spillReader_.reset();
+  spilledBuildVector_.reset();
+}
+
+bool NestedLoopJoinProbe::loadNextSpilledBuildVector() {
+  VELOX_CHECK(isBuildDataSpilled());
+  if (spillReader_ == nullptr) {
+    return false;
+  }
+
+  RowVectorPtr batch;
+  while (spillReader_->nextBatch(batch)) {
+    if (batch->size() > 0) {
+      spilledBuildVector_ = std::move(batch);
+      return true;
+    }
+    batch.reset();
+  }
+
+  spillReader_.reset();
+  return false;
+}
+
+void NestedLoopJoinProbe::finishBuildCursor() {
+  if (!isBuildDataSpilled()) {
+    buildIndex_ = buildVectors_.value().size();
+    return;
+  }
+  spillReader_.reset();
+  spilledBuildVector_.reset();
+}
+
+SelectivityVector& NestedLoopJoinProbe::buildMatched(vector_size_t size) {
+  VELOX_CHECK(needsBuildMismatch(joinType_));
+  if (buildMatched_.size() <= buildIndex_) {
+    buildMatched_.resize(buildIndex_ + 1);
+  }
+  auto& matched = buildMatched_[buildIndex_];
+  if (matched.size() == 0) {
+    matched.resizeFill(size, false);
+  } else {
+    VELOX_CHECK_EQ(matched.size(), size);
+  }
+  return matched;
+}
+
+const SelectivityVector& NestedLoopJoinProbe::buildMatchedForOutput(
+    const RowVectorPtr& data) {
+  return buildMatched(data->size());
+}
+
+void NestedLoopJoinProbe::mergeBuildMatched(
+    const NestedLoopJoinProbe& peer) {
+  if (buildMatched_.size() < peer.buildMatched_.size()) {
+    buildMatched_.resize(peer.buildMatched_.size());
+  }
+  for (auto i = 0; i < peer.buildMatched_.size(); ++i) {
+    const auto& peerMatched = peer.buildMatched_[i];
+    if (peerMatched.size() == 0) {
+      continue;
+    }
+    auto& localMatched = buildMatched_[i];
+    if (localMatched.size() == 0) {
+      localMatched.resizeFill(peerMatched.size(), false);
+    } else {
+      VELOX_CHECK_EQ(localMatched.size(), peerMatched.size());
+    }
+    localMatched.select(peerMatched);
+  }
+}
+
 BlockingReason NestedLoopJoinProbe::isBlocked(ContinueFuture* future) {
   switch (state_) {
     case ProbeOperatorState::kRunning:
@@ -139,16 +277,17 @@ BlockingReason NestedLoopJoinProbe::isBlocked(ContinueFuture* future) {
       setState(ProbeOperatorState::kFinish);
       return BlockingReason::kNotBlocked;
     case ProbeOperatorState::kWaitForBuild: {
-      VELOX_CHECK(!buildVectors_.has_value());
+      VELOX_CHECK_NULL(buildData_);
       if (!getBuildData(future)) {
         return BlockingReason::kWaitForJoinBuild;
       }
-      VELOX_CHECK(buildVectors_.has_value());
+      VELOX_CHECK_NOT_NULL(buildData_);
 
       // If we just got build data, check if this is a right or full join where
       // we need to hit track of hits on build records. If it is, initialize the
-      // selectivity vectors that do so.
-      if (needsBuildMismatch(joinType_)) {
+      // selectivity vectors that do so. Spilled build data initializes these
+      // lazily as files are replayed.
+      if (needsBuildMismatch(joinType_) && !isBuildDataSpilled()) {
         buildMatched_.resize(buildVectors_->size());
         for (auto i = 0; i < buildVectors_->size(); ++i) {
           buildMatched_[i].resizeFill(buildVectors_.value()[i]->size(), false);
@@ -167,6 +306,8 @@ void NestedLoopJoinProbe::close() {
   if (joinCondition_ != nullptr) {
     joinCondition_->clear();
   }
+  clearBuildCursor();
+  buildData_.reset();
   buildVectors_.reset();
   Operator::close();
 }
@@ -185,6 +326,9 @@ void NestedLoopJoinProbe::addInput(RowVectorPtr input) {
     probeSideEmpty_ = false;
   }
   VELOX_CHECK_EQ(buildIndex_, 0);
+  if (isBuildDataSpilled()) {
+    resetBuildCursor();
+  }
 }
 
 void NestedLoopJoinProbe::noMoreInput() {
@@ -200,18 +344,21 @@ void NestedLoopJoinProbe::noMoreInput() {
 }
 
 bool NestedLoopJoinProbe::getBuildData(ContinueFuture* future) {
-  VELOX_CHECK(!buildVectors_.has_value());
+  VELOX_CHECK_NULL(buildData_);
 
   auto buildData =
       operatorCtx_->task()
           ->getNestedLoopJoinBridge(
               operatorCtx_->driverCtx()->splitGroupId, planNodeId())
           ->dataOrFuture(future);
-  if (!buildData.has_value()) {
+  if (buildData == nullptr) {
     return false;
   }
 
-  buildVectors_ = std::move(buildData);
+  buildData_ = std::move(buildData);
+  if (!isBuildDataSpilled()) {
+    buildVectors_ = buildData_->vectors;
+  }
   return true;
 }
 
@@ -230,13 +377,14 @@ RowVectorPtr NestedLoopJoinProbe::getOutput() {
       // Scans build input producing build mismatches by wrapping dictionaries
       // to build input, and null constant to probe projections.
       while (output == nullptr && !hasProbedAllBuildData()) {
+        const auto& buildVector = currentBuildVector();
         output = getBuildMismatchedOutput(
-            buildVectors_.value()[buildIndex_],
-            buildMatched_[buildIndex_],
+            buildVector,
+            buildMatchedForOutput(buildVector),
             buildOutMapping_,
             buildProjections_,
             identityProjections_);
-        ++buildIndex_;
+        advanceBuildVector();
       }
       if (hasProbedAllBuildData()) {
         setState(ProbeOperatorState::kFinish);
@@ -312,12 +460,12 @@ bool NestedLoopJoinProbe::advanceProbe() {
   if (hasProbedAllBuildData()) {
     probeRow_ += probeRowCount_;
     probeRowHasMatch_ = false;
-    buildIndex_ = 0;
 
     // If we finished processing the probe side.
     if (probeRow_ >= input_->size()) {
       return true;
     }
+    resetBuildCursor();
   }
   return false;
 }
@@ -326,7 +474,7 @@ void NestedLoopJoinProbe::handleProbeOnlyNoCondition() {
   // Reached only with a non-empty build vector, so every probe row matches.
   if (isAntiJoin(joinType_)) {
     // Anti join emits nothing when the probe row matches.
-    buildIndex_ = buildVectors_.value().size();
+    finishBuildCursor();
     filterResultRow_ = 0;
     return;
   }
@@ -338,7 +486,7 @@ void NestedLoopJoinProbe::handleProbeOnlyNoCondition() {
         ->asFlatVector<bool>()
         ->set(numOutputRows_ - 1, true);
   }
-  buildIndex_ = buildVectors_.value().size();
+  finishBuildCursor();
   filterResultRow_ = 0;
 }
 
@@ -403,7 +551,7 @@ bool NestedLoopJoinProbe::addFilteredOutput(
   }
 
   copyBuildValues(buildVector);
-  ++buildIndex_;
+  advanceBuildVector();
   filterResultRow_ = 0;
   buildRow_ = 0;
   if (!singleProbeRow) {
@@ -418,7 +566,7 @@ bool NestedLoopJoinProbe::handleMatchedFilterRow(
     vector_size_t buildRowCount,
     bool singleProbeRow) {
   if (needsBuildMismatch(joinType_)) {
-    buildMatched_[buildIndex_].setValid(buildRow_, true);
+    buildMatched(buildRowCount).setValid(buildRow_, true);
   }
 
   // Anti join: a match disqualifies the probe row, so emit nothing and stop
@@ -456,7 +604,7 @@ void NestedLoopJoinProbe::shortCircuitProbeRow(
     vector_size_t buildRowCount,
     bool singleProbeRow) {
   if (singleProbeRow) {
-    buildIndex_ = buildVectors_.value().size();
+    finishBuildCursor();
     filterResultRow_ = 0;
     buildRow_ = 0;
   } else {
@@ -482,11 +630,11 @@ bool NestedLoopJoinProbe::addToOutput() {
   }
 
   while (!hasProbedAllBuildData()) {
-    const auto& currentBuild = buildVectors_.value()[buildIndex_];
+    const auto& currentBuild = currentBuildVector();
 
     // Empty build vector; move to the next.
     if (currentBuild->size() == 0) {
-      ++buildIndex_;
+      advanceBuildVector();
       filterResultRow_ = 0;
       continue;
     }
@@ -499,7 +647,7 @@ bool NestedLoopJoinProbe::addToOutput() {
           currentBuild, outputType_, identityProjections_, buildProjections_);
       numOutputRows_ = output_->size();
       probeRowHasMatch_ = true;
-      ++buildIndex_;
+      advanceBuildVector();
       filterResultRow_ = 0;
       return false;
     }
@@ -533,6 +681,8 @@ bool NestedLoopJoinProbe::addToOutput() {
   // If build side is empty, need to add mismatch row (for left, left semi and
   // full outer joins)
   if (isBuildSideEmpty()) {
+    checkProbeMismatchRow();
+  } else if (isBuildDataSpilled()) {
     checkProbeMismatchRow();
   }
   // Signals that all input has been generated for the probeRow and build
@@ -774,7 +924,8 @@ bool NestedLoopJoinProbe::checkProbeMismatchRow() {
   // If we are processing the last batch of the build side, check if we need
   // to add a probe mismatch record.
   if (needsProbeMismatch(joinType_) && !probeRowHasMatch_ &&
-      isLastBuildIndex()) {
+      (isLastBuildIndex() ||
+       (isBuildDataSpilled() && hasProbedAllBuildData()))) {
     prepareOutput();
     addProbeMismatchRow();
     ++numOutputRows_;
@@ -786,7 +937,7 @@ bool NestedLoopJoinProbe::checkProbeMismatchRow() {
 void NestedLoopJoinProbe::finishProbeInput() {
   VELOX_CHECK_NOT_NULL(input_);
   input_.reset();
-  buildIndex_ = 0;
+  clearBuildCursor();
   probeRow_ = 0;
 
   if (!noMoreInput_) {
@@ -827,18 +978,19 @@ void NestedLoopJoinProbe::beginBuildMismatch() {
     auto* op = peer->findOperator(planNodeId());
     auto* probe = dynamic_cast<NestedLoopJoinProbe*>(op);
     VELOX_CHECK_NOT_NULL(probe);
-    for (auto i = 0; i < buildMatched_.size(); ++i) {
-      buildMatched_[i].select(probe->buildMatched_[i]);
-      probeSideEmpty_ &= probe->probeSideEmpty_;
-    }
+    mergeBuildMatched(*probe);
+    probeSideEmpty_ &= probe->probeSideEmpty_;
   }
   peers.clear();
   for (auto& matched : buildMatched_) {
-    matched.updateBounds();
+    if (matched.size() > 0) {
+      matched.updateBounds();
+    }
   }
   for (auto& promise : promises) {
     promise.setValue();
   }
+  resetBuildCursor();
 }
 
 RowVectorPtr NestedLoopJoinProbe::getBuildMismatchedOutput(

--- a/velox/exec/NestedLoopJoinProbe.h
+++ b/velox/exec/NestedLoopJoinProbe.h
@@ -18,6 +18,7 @@
 #include "velox/exec/NestedLoopJoinBuild.h"
 #include "velox/exec/Operator.h"
 #include "velox/exec/ProbeOperatorState.h"
+#include "velox/exec/UnorderedStreamReader.h"
 
 namespace facebook::velox::exec {
 
@@ -31,8 +32,8 @@ namespace facebook::velox::exec {
 /// nullptr.
 ///
 /// The output follows the order of the probe side rows (for inner and left
-/// joins). All build vectors are materialized upfront (check buildVectors_),
-/// but probe batches are processed one-by-one as a stream.
+/// joins). Build data is either kept in buildVectors_ or replayed from spill
+/// files, while probe batches are processed one-by-one as a stream.
 ///
 /// To produce output, the operator processes each probe record from probe
 /// input, using the following steps:
@@ -91,6 +92,10 @@ class NestedLoopJoinProbe : public Operator {
     return state_ == ProbeOperatorState::kFinish;
   }
 
+  bool canReclaim() const override {
+    return false;
+  }
+
   void close() override;
 
  private:
@@ -101,10 +106,9 @@ class NestedLoopJoinProbe : public Operator {
       const RowTypePtr& leftType,
       const RowTypePtr& rightType);
 
-  // Materializes build data from nested loop join bridge into `buildVectors_`.
-  // Returns whether the data has been materialized and is ready for use. Nested
-  // loop join requires all build data to be materialized and available in
-  // `buildVectors_` before it can produce output.
+  // Gets build data from nested loop join bridge. Returns whether the data is
+  // ready for use. Nested loop join requires the build side to be complete
+  // before it can produce output.
   bool getBuildData(ContinueFuture* future);
 
   // Generates output from join matches between probe and build sides, as well
@@ -257,17 +261,17 @@ class NestedLoopJoinProbe : public Operator {
         noMoreInput_;
   }
 
+  bool isBuildDataSpilled() const {
+    return buildData_ != nullptr && buildData_->spilled;
+  }
+
   // Whether we have processed all build data for the current probe row (based
   // on buildIndex_'s value).
-  bool hasProbedAllBuildData() const {
-    return (buildIndex_ >= buildVectors_.value().size());
-  }
+  bool hasProbedAllBuildData() const;
 
   // Whether processing last batch of build data or processed all build data for
   // the current probe row (based on buildIndex_'s value).
-  bool isLastBuildIndex() const {
-    return buildIndex_ + 1 >= buildVectors_.value().size();
-  }
+  bool isLastBuildIndex() const;
 
   // Cross joins are translated into NLJ's without a join conditition.
   bool isCrossJoin() const {
@@ -278,13 +282,14 @@ class NestedLoopJoinProbe : public Operator {
   // dictionaries and produce as many combinations of probe and build rows,
   // until `numOutputRows_` is filled.
   bool isSingleBuildVector() const {
+    if (isBuildDataSpilled()) {
+      return false;
+    }
     return buildVectors_->size() == 1;
   }
 
   // If there are no incoming records in the build side.
-  bool isBuildSideEmpty() const {
-    return buildVectors_->empty();
-  }
+  bool isBuildSideEmpty() const;
 
   // If build has a single row, we can simply add it as a constant to probe
   // batches.
@@ -299,6 +304,24 @@ class NestedLoopJoinProbe : public Operator {
 
   // Handles LeftSemiProjectJoin with no join condition
   void handleLeftSemiProjectNoCondition();
+
+  const RowVectorPtr& currentBuildVector() const;
+
+  void advanceBuildVector();
+
+  void resetBuildCursor();
+
+  void clearBuildCursor();
+
+  bool loadNextSpilledBuildVector();
+
+  void finishBuildCursor();
+
+  SelectivityVector& buildMatched(vector_size_t size);
+
+  const SelectivityVector& buildMatchedForOutput(const RowVectorPtr& data);
+
+  void mergeBuildMatched(const NestedLoopJoinProbe& peer);
 
   // Wraps rows of 'data' that are not selected in 'matched' and projects
   // to the output according to 'projections'. 'nullProjections' is used to
@@ -385,8 +408,14 @@ class NestedLoopJoinProbe : public Operator {
 
   // Build side state.
 
+  std::shared_ptr<const NestedLoopJoinBuildData> buildData_;
+
   // Stores the data for build vectors (right side of the join).
   std::optional<std::vector<RowVectorPtr>> buildVectors_;
+
+  std::unique_ptr<UnorderedStreamReader<BatchStream>> spillReader_;
+
+  RowVectorPtr spilledBuildVector_;
 
   // Index into `buildVectors_` for the build vector being currently processed.
   size_t buildIndex_{0};

--- a/velox/exec/NestedLoopJoinProbe.h
+++ b/velox/exec/NestedLoopJoinProbe.h
@@ -18,6 +18,7 @@
 #include "velox/exec/NestedLoopJoinBuild.h"
 #include "velox/exec/Operator.h"
 #include "velox/exec/ProbeOperatorState.h"
+#include "velox/exec/UnorderedStreamReader.h"
 
 namespace facebook::velox::exec {
 
@@ -31,8 +32,8 @@ namespace facebook::velox::exec {
 /// nullptr.
 ///
 /// The output follows the order of the probe side rows (for inner and left
-/// joins). All build vectors are materialized upfront (check buildVectors_),
-/// but probe batches are processed one-by-one as a stream.
+/// joins). Build data is either kept in buildVectors_ or replayed from spill
+/// files, while probe batches are processed one-by-one as a stream.
 ///
 /// To produce output, the operator processes each probe record from probe
 /// input, using the following steps:
@@ -91,6 +92,10 @@ class NestedLoopJoinProbe : public Operator {
     return state_ == ProbeOperatorState::kFinish;
   }
 
+  bool canReclaim() const override {
+    return false;
+  }
+
   void close() override;
 
  private:
@@ -101,10 +106,9 @@ class NestedLoopJoinProbe : public Operator {
       const RowTypePtr& leftType,
       const RowTypePtr& rightType);
 
-  // Materializes build data from nested loop join bridge into `buildVectors_`.
-  // Returns whether the data has been materialized and is ready for use. Nested
-  // loop join requires all build data to be materialized and available in
-  // `buildVectors_` before it can produce output.
+  // Gets build data from nested loop join bridge. Returns whether the data is
+  // ready for use. Nested loop join requires the build side to be complete
+  // before it can produce output.
   bool getBuildData(ContinueFuture* future);
 
   // Generates output from join matches between probe and build sides, as well
@@ -265,17 +269,17 @@ class NestedLoopJoinProbe : public Operator {
         noMoreInput_;
   }
 
+  bool isBuildDataSpilled() const {
+    return buildData_ != nullptr && buildData_->spilled;
+  }
+
   // Whether we have processed all build data for the current probe row (based
   // on buildIndex_'s value).
-  bool hasProbedAllBuildData() const {
-    return (buildIndex_ >= buildVectors_.value().size());
-  }
+  bool hasProbedAllBuildData() const;
 
   // Whether processing last batch of build data or processed all build data for
   // the current probe row (based on buildIndex_'s value).
-  bool isLastBuildIndex() const {
-    return buildIndex_ + 1 >= buildVectors_.value().size();
-  }
+  bool isLastBuildIndex() const;
 
   // Cross joins are translated into NLJ's without a join conditition.
   bool isCrossJoin() const {
@@ -286,13 +290,14 @@ class NestedLoopJoinProbe : public Operator {
   // dictionaries and produce as many combinations of probe and build rows,
   // until `numOutputRows_` is filled.
   bool isSingleBuildVector() const {
+    if (isBuildDataSpilled()) {
+      return false;
+    }
     return buildVectors_->size() == 1;
   }
 
   // If there are no incoming records in the build side.
-  bool isBuildSideEmpty() const {
-    return buildVectors_->empty();
-  }
+  bool isBuildSideEmpty() const;
 
   // If build has a single row, we can simply add it as a constant to probe
   // batches.
@@ -310,6 +315,24 @@ class NestedLoopJoinProbe : public Operator {
   // Handles a probe-only join (left semi filter/project, anti) with no join
   // condition.
   void handleProbeOnlyNoCondition();
+
+  const RowVectorPtr& currentBuildVector() const;
+
+  void advanceBuildVector();
+
+  void resetBuildCursor();
+
+  void clearBuildCursor();
+
+  bool loadNextSpilledBuildVector();
+
+  void finishBuildCursor();
+
+  SelectivityVector& buildMatched(vector_size_t size);
+
+  const SelectivityVector& buildMatchedForOutput(const RowVectorPtr& data);
+
+  void mergeBuildMatched(const NestedLoopJoinProbe& peer);
 
   // Wraps rows of 'data' that are not selected in 'matched' and projects
   // to the output according to 'projections'. 'nullProjections' is used to
@@ -396,8 +419,14 @@ class NestedLoopJoinProbe : public Operator {
 
   // Build side state.
 
+  std::shared_ptr<const NestedLoopJoinBuildData> buildData_;
+
   // Stores the data for build vectors (right side of the join).
   std::optional<std::vector<RowVectorPtr>> buildVectors_;
+
+  std::unique_ptr<UnorderedStreamReader<BatchStream>> spillReader_;
+
+  RowVectorPtr spilledBuildVector_;
 
   // Index into `buildVectors_` for the build vector being currently processed.
   size_t buildIndex_{0};

--- a/velox/exec/tests/NestedLoopJoinTest.cpp
+++ b/velox/exec/tests/NestedLoopJoinTest.cpp
@@ -14,8 +14,12 @@
  * limitations under the License.
  */
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/testutil/TempDirectoryPath.h"
+#include "velox/common/testutil/TestValue.h"
 #include "velox/core/PlanNode.h"
 #include "velox/exec/NestedLoopJoinBuild.h"
+#include "velox/exec/Operator.h"
+#include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
@@ -26,6 +30,7 @@ namespace facebook::velox::exec::test {
 namespace {
 
 using facebook::velox::test::assertEqualVectors;
+using facebook::velox::common::testutil::TempDirectoryPath;
 
 class NestedLoopJoinTest : public HiveConnectorTestBase {
  protected:
@@ -55,6 +60,139 @@ class NestedLoopJoinTest : public HiveConnectorTestBase {
 
   void setJoinTypes(std::vector<core::JoinType> joinTypes) {
     joinTypes_ = std::move(joinTypes);
+  }
+
+  std::vector<RowVectorPtr> makeSpillProbeVectors() {
+    return {
+        makeRowVector(
+            {"t0"},
+            {makeFlatVector<int64_t>({0, 1, 2, 3})}),
+        makeRowVector(
+            {"t0"},
+            {makeFlatVector<int64_t>({4, 5, 9})})};
+  }
+
+  std::vector<RowVectorPtr> makeSpillBuildVectors() {
+    return {
+        makeRowVector(
+            {"u0"},
+            {makeFlatVector<int64_t>({-1, 0})}),
+        makeRowVector(
+            {"u0"},
+            {makeFlatVector<int64_t>({2, 4})}),
+        makeRowVector(
+            {"u0"},
+            {makeFlatVector<int64_t>({6, 8})}),
+        makeRowVector(
+            {"u0"},
+            {makeFlatVector<int64_t>({9, 10})})};
+  }
+
+  core::PlanNodePtr makeSpillJoinPlan(
+      const std::vector<RowVectorPtr>& probeVectors,
+      const std::vector<RowVectorPtr>& buildVectors,
+      const std::string& joinCondition,
+      const std::vector<std::string>& outputLayout,
+      core::JoinType joinType) {
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+    auto buildPlan = PlanBuilder(planNodeIdGenerator)
+                         .values(buildVectors)
+                         .localPartition({buildKeyName_})
+                         .planNode();
+
+    auto probePlan =
+        PlanBuilder(planNodeIdGenerator)
+            .values(probeVectors)
+            .localPartition({probeKeyName_});
+    if (joinCondition.empty()) {
+      return probePlan.nestedLoopJoin(buildPlan, outputLayout, joinType)
+          .planNode();
+    }
+    return probePlan
+        .nestedLoopJoin(buildPlan, joinCondition, outputLayout, joinType)
+        .planNode();
+  }
+
+  int64_t runtimeStatSum(
+      const OperatorStats& stats,
+      std::string_view name) const {
+    auto it = stats.runtimeStats.find(std::string(name));
+    return it == stats.runtimeStats.end() ? 0 : it->second.sum;
+  }
+
+  void verifyNestedLoopJoinSpillStats(
+      const std::shared_ptr<Task>& task,
+      bool expectSpill,
+      bool expectRead) const {
+    auto opStats = toOperatorStats(task->taskStats());
+    const auto& buildStats = opStats.at("NestedLoopJoinBuild");
+    const auto& probeStats = opStats.at("NestedLoopJoinProbe");
+
+    if (expectSpill) {
+      ASSERT_GT(buildStats.spilledBytes, 0);
+      ASSERT_GT(buildStats.spilledRows, 0);
+      ASSERT_GT(
+          runtimeStatSum(buildStats, Operator::kSpillWrites),
+          0);
+      if (expectRead) {
+        ASSERT_GT(runtimeStatSum(probeStats, Operator::kSpillReads), 0);
+      }
+    } else {
+      ASSERT_EQ(buildStats.spilledBytes, 0);
+      ASSERT_EQ(buildStats.spilledRows, 0);
+      ASSERT_EQ(runtimeStatSum(buildStats, Operator::kSpillWrites), 0);
+      ASSERT_EQ(runtimeStatSum(probeStats, Operator::kSpillReads), 0);
+    }
+  }
+
+  void assertSpillQuery(
+      const core::PlanNodePtr& plan,
+      const std::string& duckDbSql,
+      bool joinSpillEnabled = true,
+      bool expectSpill = true,
+      bool expectRead = true,
+      int32_t maxInjectedReclaims =
+          std::numeric_limits<int32_t>::max(),
+      int32_t* actualInjectedReclaims = nullptr) {
+    const auto spillDirectory = TempDirectoryPath::create();
+    std::atomic<int32_t> injectedReclaims{0};
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::Driver::runInternal::addInput",
+        std::function<void(Operator*)>([&](Operator* op) {
+          if (op->operatorType() != "NestedLoopJoinBuild" ||
+              !op->canReclaim()) {
+            return;
+          }
+
+          auto current = injectedReclaims.load();
+          while (current < maxInjectedReclaims) {
+            if (injectedReclaims.compare_exchange_weak(
+                    current, current + 1)) {
+              memory::MemoryReclaimer::Stats stats;
+              Operator::ReclaimableSectionGuard guard(op);
+              op->reclaim(0, stats);
+              return;
+            }
+          }
+        }));
+
+    auto task =
+        AssertQueryBuilder(plan, duckDbQueryRunner_)
+            .spillDirectory(spillDirectory->getPath())
+            .config(core::QueryConfig::kSpillEnabled, true)
+            .config(core::QueryConfig::kJoinSpillEnabled, joinSpillEnabled)
+            .config(core::QueryConfig::kMaxOutputBatchRows, "4")
+            .config(core::QueryConfig::kPreferredOutputBatchRows, "4")
+            .maxDrivers(4)
+            .maxQueryCapacity(64 << 20)
+            .assertResults(duckDbSql);
+
+    verifyNestedLoopJoinSpillStats(task, expectSpill, expectRead);
+    if (actualInjectedReclaims != nullptr) {
+      *actualInjectedReclaims = injectedReclaims.load();
+    }
+    task.reset();
+    waitForAllTasksToBeDeleted();
   }
 
   RowVectorPtr makeOutputOrderProbeVector() {
@@ -879,6 +1017,173 @@ TEST_F(NestedLoopJoinTest, leftSemiJoinWithNullsAndFilter) {
   auto result = builder.copyResults(pool());
 
   assertEqualVectors(expected, result);
+}
+
+TEST_F(NestedLoopJoinTest, spillInnerCrossAndLeftJoins) {
+  const auto probeVectors = makeSpillProbeVectors();
+  const auto buildVectors = makeSpillBuildVectors();
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", buildVectors);
+
+  struct {
+    std::string name;
+    std::string joinCondition;
+    core::JoinType joinType;
+    std::string duckDbSql;
+  } testSettings[] = {
+      {"inner",
+       "t0 < u0 AND u0 < 8",
+       core::JoinType::kInner,
+       "SELECT t0, u0 FROM t JOIN u ON t.t0 < u.u0 AND u.u0 < 8"},
+      {"cross",
+       "",
+       core::JoinType::kInner,
+       "SELECT t0, u0 FROM t, u"},
+      {"left",
+       "t0 = u0",
+       core::JoinType::kLeft,
+       "SELECT t0, u0 FROM t LEFT JOIN u ON t.t0 = u.u0"}};
+
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.name);
+    assertSpillQuery(
+        makeSpillJoinPlan(
+            probeVectors,
+            buildVectors,
+            testData.joinCondition,
+            {"t0", "u0"},
+            testData.joinType),
+        testData.duckDbSql);
+  }
+}
+
+TEST_F(NestedLoopJoinTest, spillRightFullAndLeftSemiProjectJoins) {
+  const auto probeVectors = makeSpillProbeVectors();
+  const auto buildVectors = makeSpillBuildVectors();
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", buildVectors);
+
+  struct {
+    std::string name;
+    std::string joinCondition;
+    std::vector<std::string> outputLayout;
+    core::JoinType joinType;
+    std::string duckDbSql;
+  } testSettings[] = {
+      {"right",
+       "t0 = u0",
+       {"t0", "u0"},
+       core::JoinType::kRight,
+       "SELECT t0, u0 FROM t RIGHT JOIN u ON t.t0 = u.u0"},
+      {"full",
+       "t0 = u0",
+       {"t0", "u0"},
+       core::JoinType::kFull,
+       "SELECT t0, u0 FROM t FULL JOIN u ON t.t0 = u.u0"},
+      {"left-semi-project",
+       "t0 = u0",
+       {"t0", "match"},
+       core::JoinType::kLeftSemiProject,
+       "SELECT t0, EXISTS(SELECT 1 FROM u WHERE t.t0 = u.u0) AS match FROM t"}};
+
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.name);
+    assertSpillQuery(
+        makeSpillJoinPlan(
+            probeVectors,
+            buildVectors,
+            testData.joinCondition,
+            testData.outputLayout,
+            testData.joinType),
+        testData.duckDbSql);
+  }
+}
+
+TEST_F(NestedLoopJoinTest, spillEmptyBuildAndProbe) {
+  {
+    SCOPED_TRACE("empty build");
+    const auto probeVectors = makeSpillProbeVectors();
+    const std::vector<RowVectorPtr> buildVectors = {
+        makeRowVector({"u0"}, {makeFlatVector<int64_t>({})})};
+    createDuckDbTable("t", probeVectors);
+    createDuckDbTable("u", buildVectors);
+
+    assertSpillQuery(
+        makeSpillJoinPlan(
+            probeVectors,
+            buildVectors,
+            "t0 = u0",
+            {"t0", "u0"},
+            core::JoinType::kLeft),
+        "SELECT t0, u0 FROM t LEFT JOIN u ON t.t0 = u.u0",
+        true,
+        false,
+        false);
+  }
+
+  {
+    SCOPED_TRACE("empty probe");
+    const std::vector<RowVectorPtr> probeVectors = {
+        makeRowVector({"t0"}, {makeFlatVector<int64_t>({})})};
+    const auto buildVectors = makeSpillBuildVectors();
+    createDuckDbTable("t", probeVectors);
+    createDuckDbTable("u", buildVectors);
+
+    assertSpillQuery(
+        makeSpillJoinPlan(
+            probeVectors,
+            buildVectors,
+            "t0 = u0",
+            {"t0", "u0"},
+            core::JoinType::kRight),
+        "SELECT t0, u0 FROM t RIGHT JOIN u ON t.t0 = u.u0");
+  }
+}
+
+TEST_F(NestedLoopJoinTest, spillForcedAtBuildBarrier) {
+  const auto probeVectors = makeSpillProbeVectors();
+  const auto buildVectors = makeSpillBuildVectors();
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", buildVectors);
+
+  int32_t injectedReclaims = 0;
+  assertSpillQuery(
+      makeSpillJoinPlan(
+          probeVectors,
+          buildVectors,
+          "t0 = u0",
+          {"t0", "u0"},
+          core::JoinType::kFull),
+      "SELECT t0, u0 FROM t FULL JOIN u ON t.t0 = u.u0",
+      true,
+      true,
+      true,
+      1,
+      &injectedReclaims);
+  ASSERT_EQ(injectedReclaims, 1);
+}
+
+TEST_F(NestedLoopJoinTest, spillDisabledWhenJoinSpillDisabled) {
+  const auto probeVectors = makeSpillProbeVectors();
+  const auto buildVectors = makeSpillBuildVectors();
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", buildVectors);
+
+  int32_t injectedReclaims = 0;
+  assertSpillQuery(
+      makeSpillJoinPlan(
+          probeVectors,
+          buildVectors,
+          "t0 = u0",
+          {"t0", "u0"},
+          core::JoinType::kInner),
+      "SELECT t0, u0 FROM t JOIN u ON t.t0 = u.u0",
+      false,
+      false,
+      false,
+      std::numeric_limits<int32_t>::max(),
+      &injectedReclaims);
+  ASSERT_EQ(injectedReclaims, 0);
 }
 
 TEST_F(NestedLoopJoinTest, mergeBuildVectorsOverflow) {

--- a/velox/exec/tests/NestedLoopJoinTest.cpp
+++ b/velox/exec/tests/NestedLoopJoinTest.cpp
@@ -14,8 +14,12 @@
  * limitations under the License.
  */
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/testutil/TempDirectoryPath.h"
+#include "velox/common/testutil/TestValue.h"
 #include "velox/core/PlanNode.h"
 #include "velox/exec/NestedLoopJoinBuild.h"
+#include "velox/exec/Operator.h"
+#include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/BackpressureTestNode.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
@@ -27,6 +31,7 @@ namespace facebook::velox::exec::test {
 namespace {
 
 using facebook::velox::test::assertEqualVectors;
+using facebook::velox::common::testutil::TempDirectoryPath;
 
 class NestedLoopJoinTest : public HiveConnectorTestBase {
  protected:
@@ -56,6 +61,139 @@ class NestedLoopJoinTest : public HiveConnectorTestBase {
 
   void setJoinTypes(std::vector<core::JoinType> joinTypes) {
     joinTypes_ = std::move(joinTypes);
+  }
+
+  std::vector<RowVectorPtr> makeSpillProbeVectors() {
+    return {
+        makeRowVector(
+            {"t0"},
+            {makeFlatVector<int64_t>({0, 1, 2, 3})}),
+        makeRowVector(
+            {"t0"},
+            {makeFlatVector<int64_t>({4, 5, 9})})};
+  }
+
+  std::vector<RowVectorPtr> makeSpillBuildVectors() {
+    return {
+        makeRowVector(
+            {"u0"},
+            {makeFlatVector<int64_t>({-1, 0})}),
+        makeRowVector(
+            {"u0"},
+            {makeFlatVector<int64_t>({2, 4})}),
+        makeRowVector(
+            {"u0"},
+            {makeFlatVector<int64_t>({6, 8})}),
+        makeRowVector(
+            {"u0"},
+            {makeFlatVector<int64_t>({9, 10})})};
+  }
+
+  core::PlanNodePtr makeSpillJoinPlan(
+      const std::vector<RowVectorPtr>& probeVectors,
+      const std::vector<RowVectorPtr>& buildVectors,
+      const std::string& joinCondition,
+      const std::vector<std::string>& outputLayout,
+      core::JoinType joinType) {
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+    auto buildPlan = PlanBuilder(planNodeIdGenerator)
+                         .values(buildVectors)
+                         .localPartition({buildKeyName_})
+                         .planNode();
+
+    auto probePlan =
+        PlanBuilder(planNodeIdGenerator)
+            .values(probeVectors)
+            .localPartition({probeKeyName_});
+    if (joinCondition.empty()) {
+      return probePlan.nestedLoopJoin(buildPlan, outputLayout, joinType)
+          .planNode();
+    }
+    return probePlan
+        .nestedLoopJoin(buildPlan, joinCondition, outputLayout, joinType)
+        .planNode();
+  }
+
+  int64_t runtimeStatSum(
+      const OperatorStats& stats,
+      std::string_view name) const {
+    auto it = stats.runtimeStats.find(std::string(name));
+    return it == stats.runtimeStats.end() ? 0 : it->second.sum;
+  }
+
+  void verifyNestedLoopJoinSpillStats(
+      const std::shared_ptr<Task>& task,
+      bool expectSpill,
+      bool expectRead) const {
+    auto opStats = toOperatorStats(task->taskStats());
+    const auto& buildStats = opStats.at("NestedLoopJoinBuild");
+    const auto& probeStats = opStats.at("NestedLoopJoinProbe");
+
+    if (expectSpill) {
+      ASSERT_GT(buildStats.spilledBytes, 0);
+      ASSERT_GT(buildStats.spilledRows, 0);
+      ASSERT_GT(
+          runtimeStatSum(buildStats, Operator::kSpillWrites),
+          0);
+      if (expectRead) {
+        ASSERT_GT(runtimeStatSum(probeStats, Operator::kSpillReads), 0);
+      }
+    } else {
+      ASSERT_EQ(buildStats.spilledBytes, 0);
+      ASSERT_EQ(buildStats.spilledRows, 0);
+      ASSERT_EQ(runtimeStatSum(buildStats, Operator::kSpillWrites), 0);
+      ASSERT_EQ(runtimeStatSum(probeStats, Operator::kSpillReads), 0);
+    }
+  }
+
+  void assertSpillQuery(
+      const core::PlanNodePtr& plan,
+      const std::string& duckDbSql,
+      bool joinSpillEnabled = true,
+      bool expectSpill = true,
+      bool expectRead = true,
+      int32_t maxInjectedReclaims =
+          std::numeric_limits<int32_t>::max(),
+      int32_t* actualInjectedReclaims = nullptr) {
+    const auto spillDirectory = TempDirectoryPath::create();
+    std::atomic<int32_t> injectedReclaims{0};
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::Driver::runInternal::addInput",
+        std::function<void(Operator*)>([&](Operator* op) {
+          if (op->operatorType() != "NestedLoopJoinBuild" ||
+              !op->canReclaim()) {
+            return;
+          }
+
+          auto current = injectedReclaims.load();
+          while (current < maxInjectedReclaims) {
+            if (injectedReclaims.compare_exchange_weak(
+                    current, current + 1)) {
+              memory::MemoryReclaimer::Stats stats;
+              Operator::ReclaimableSectionGuard guard(op);
+              op->reclaim(0, stats);
+              return;
+            }
+          }
+        }));
+
+    auto task =
+        AssertQueryBuilder(plan, duckDbQueryRunner_)
+            .spillDirectory(spillDirectory->getPath())
+            .config(core::QueryConfig::kSpillEnabled, true)
+            .config(core::QueryConfig::kJoinSpillEnabled, joinSpillEnabled)
+            .config(core::QueryConfig::kMaxOutputBatchRows, "4")
+            .config(core::QueryConfig::kPreferredOutputBatchRows, "4")
+            .maxDrivers(4)
+            .maxQueryCapacity(64 << 20)
+            .assertResults(duckDbSql);
+
+    verifyNestedLoopJoinSpillStats(task, expectSpill, expectRead);
+    if (actualInjectedReclaims != nullptr) {
+      *actualInjectedReclaims = injectedReclaims.load();
+    }
+    task.reset();
+    waitForAllTasksToBeDeleted();
   }
 
   RowVectorPtr makeOutputOrderProbeVector() {
@@ -1076,6 +1214,173 @@ TEST_F(NestedLoopJoinTest, leftSemiJoinWithNullsAndFilter) {
   auto result = builder.copyResults(pool());
 
   assertEqualVectors(expected, result);
+}
+
+TEST_F(NestedLoopJoinTest, spillInnerCrossAndLeftJoins) {
+  const auto probeVectors = makeSpillProbeVectors();
+  const auto buildVectors = makeSpillBuildVectors();
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", buildVectors);
+
+  struct {
+    std::string name;
+    std::string joinCondition;
+    core::JoinType joinType;
+    std::string duckDbSql;
+  } testSettings[] = {
+      {"inner",
+       "t0 < u0 AND u0 < 8",
+       core::JoinType::kInner,
+       "SELECT t0, u0 FROM t JOIN u ON t.t0 < u.u0 AND u.u0 < 8"},
+      {"cross",
+       "",
+       core::JoinType::kInner,
+       "SELECT t0, u0 FROM t, u"},
+      {"left",
+       "t0 = u0",
+       core::JoinType::kLeft,
+       "SELECT t0, u0 FROM t LEFT JOIN u ON t.t0 = u.u0"}};
+
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.name);
+    assertSpillQuery(
+        makeSpillJoinPlan(
+            probeVectors,
+            buildVectors,
+            testData.joinCondition,
+            {"t0", "u0"},
+            testData.joinType),
+        testData.duckDbSql);
+  }
+}
+
+TEST_F(NestedLoopJoinTest, spillRightFullAndLeftSemiProjectJoins) {
+  const auto probeVectors = makeSpillProbeVectors();
+  const auto buildVectors = makeSpillBuildVectors();
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", buildVectors);
+
+  struct {
+    std::string name;
+    std::string joinCondition;
+    std::vector<std::string> outputLayout;
+    core::JoinType joinType;
+    std::string duckDbSql;
+  } testSettings[] = {
+      {"right",
+       "t0 = u0",
+       {"t0", "u0"},
+       core::JoinType::kRight,
+       "SELECT t0, u0 FROM t RIGHT JOIN u ON t.t0 = u.u0"},
+      {"full",
+       "t0 = u0",
+       {"t0", "u0"},
+       core::JoinType::kFull,
+       "SELECT t0, u0 FROM t FULL JOIN u ON t.t0 = u.u0"},
+      {"left-semi-project",
+       "t0 = u0",
+       {"t0", "match"},
+       core::JoinType::kLeftSemiProject,
+       "SELECT t0, EXISTS(SELECT 1 FROM u WHERE t.t0 = u.u0) AS match FROM t"}};
+
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.name);
+    assertSpillQuery(
+        makeSpillJoinPlan(
+            probeVectors,
+            buildVectors,
+            testData.joinCondition,
+            testData.outputLayout,
+            testData.joinType),
+        testData.duckDbSql);
+  }
+}
+
+TEST_F(NestedLoopJoinTest, spillEmptyBuildAndProbe) {
+  {
+    SCOPED_TRACE("empty build");
+    const auto probeVectors = makeSpillProbeVectors();
+    const std::vector<RowVectorPtr> buildVectors = {
+        makeRowVector({"u0"}, {makeFlatVector<int64_t>({})})};
+    createDuckDbTable("t", probeVectors);
+    createDuckDbTable("u", buildVectors);
+
+    assertSpillQuery(
+        makeSpillJoinPlan(
+            probeVectors,
+            buildVectors,
+            "t0 = u0",
+            {"t0", "u0"},
+            core::JoinType::kLeft),
+        "SELECT t0, u0 FROM t LEFT JOIN u ON t.t0 = u.u0",
+        true,
+        false,
+        false);
+  }
+
+  {
+    SCOPED_TRACE("empty probe");
+    const std::vector<RowVectorPtr> probeVectors = {
+        makeRowVector({"t0"}, {makeFlatVector<int64_t>({})})};
+    const auto buildVectors = makeSpillBuildVectors();
+    createDuckDbTable("t", probeVectors);
+    createDuckDbTable("u", buildVectors);
+
+    assertSpillQuery(
+        makeSpillJoinPlan(
+            probeVectors,
+            buildVectors,
+            "t0 = u0",
+            {"t0", "u0"},
+            core::JoinType::kRight),
+        "SELECT t0, u0 FROM t RIGHT JOIN u ON t.t0 = u.u0");
+  }
+}
+
+TEST_F(NestedLoopJoinTest, spillForcedAtBuildBarrier) {
+  const auto probeVectors = makeSpillProbeVectors();
+  const auto buildVectors = makeSpillBuildVectors();
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", buildVectors);
+
+  int32_t injectedReclaims = 0;
+  assertSpillQuery(
+      makeSpillJoinPlan(
+          probeVectors,
+          buildVectors,
+          "t0 = u0",
+          {"t0", "u0"},
+          core::JoinType::kFull),
+      "SELECT t0, u0 FROM t FULL JOIN u ON t.t0 = u.u0",
+      true,
+      true,
+      true,
+      1,
+      &injectedReclaims);
+  ASSERT_EQ(injectedReclaims, 1);
+}
+
+TEST_F(NestedLoopJoinTest, spillDisabledWhenJoinSpillDisabled) {
+  const auto probeVectors = makeSpillProbeVectors();
+  const auto buildVectors = makeSpillBuildVectors();
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", buildVectors);
+
+  int32_t injectedReclaims = 0;
+  assertSpillQuery(
+      makeSpillJoinPlan(
+          probeVectors,
+          buildVectors,
+          "t0 = u0",
+          {"t0", "u0"},
+          core::JoinType::kInner),
+      "SELECT t0, u0 FROM t JOIN u ON t.t0 = u.u0",
+      false,
+      false,
+      false,
+      std::numeric_limits<int32_t>::max(),
+      &injectedReclaims);
+  ASSERT_EQ(injectedReclaims, 0);
 }
 
 TEST_F(NestedLoopJoinTest, mergeBuildVectorsOverflow) {


### PR DESCRIPTION
## Summary

Add build-side spill support for `NestedLoopJoin` using Velox's existing spill framework and the existing `spill_enabled` and `join_spill_enabled` configuration knobs. The build bridge now publishes either in-memory build vectors or immutable spill-file metadata.

The probe side can replay spilled build batches for each probe row and for right/full outer unmatched-build output. This covers inner, cross, left, right, full, and left semi project nested-loop joins without adding a new NestedLoopJoin-specific spill configuration.

## Tests

```bash
ninja -C _build/debug -j16 velox_exec_test_group7 velox_core_test
_build/debug/velox/exec/tests/velox_exec_test_group7 '--gtest_filter=NestedLoopJoinTest.*'
_build/debug/velox/core/tests/velox_core_test '--gtest_filter=PlanNodeTest.*NestedLoopJoin*:QueryConfigTest.*'
_build/debug/velox/core/tests/velox_core_test '--gtest_filter=PlanNodeTest.nestedLoopJoin'
git diff --check
```

Fixes #17955
