### PR TITLE
fix(dwio): Fix flaky DirectBufferedInputTest.duplicateRegionsShareCoalescedRead

### DIFF
--- a/velox/dwio/common/tests/DirectBufferedInputTest.cpp
+++ b/velox/dwio/common/tests/DirectBufferedInputTest.cpp
@@ -336,7 +336,6 @@ TEST_F(DirectBufferedInputTest, duplicateRegionsShareCoalescedRead) {
     EXPECT_EQ(dataIoStats_->duplicateReadRegions() - duplicateRegionsBefore, 1);
     EXPECT_EQ(
         dataIoStats_->duplicateReadBytes() - duplicateBytesBefore, regionSize);
-    EXPECT_EQ(readFile->numReads(), 0);
 
     auto next1 = getNext(*stream1);
     ASSERT_TRUE(next1.has_value());


### PR DESCRIPTION
## Summary

`DirectBufferedInputTest.duplicateRegionsShareCoalescedRead` asserts
`readFile->numReads() == 0` immediately after `DirectBufferedInput::load()`.
Because the test constructs the input with an executor, `load()` schedules the
coalesced read asynchronously (`executor_->add(... loadOrFuture ...)`), so the
read can complete before the assertion runs. The check races the prefetch
worker and fails intermittently on loaded CI (observed repeatedly under an
unbounded `ctest -j`).

The other `numReads() == 0` checks in this file are not racy — they assert
before any read is scheduled, or after a synchronous `preload()`. This is the
only one that checks `== 0` after an async `load()`.

The test's intent — two duplicate regions share a single coalesced read — is
still fully covered by the surrounding assertions:
- `testingCoalescedLoads().size() == 1`
- the `duplicateReadRegions` / `duplicateReadBytes` deltas
- `numReads() == 1` after both streams are read (deterministic: `getNext()`
  blocks until the load completes and the coalesced load is idempotent)

So this removes only the racy line.
