### PR TITLE
feat(sparksql): Add casts between DATE and TIMESTAMP UTC

### DIFF
--- a/velox/docs/functions/spark/conversion.rst
+++ b/velox/docs/functions/spark/conversion.rst
@@ -374,6 +374,28 @@ Invalid examples
   SELECT cast('2012/10/23' as date); -- NULL // Invalid argument
   SELECT cast('2012.10.23' as date); -- NULL // Invalid argument
 
+From TIMESTAMP_UTC
+^^^^^^^^^^^^^^^^^^
+
+*(ANSI compliant)*
+
+Casting a timestamp_utc to date extracts the date from the stored timestamp
+fields without applying the session timezone.
+
+``cast`` throws when the value is too far from the epoch to fit in a date
+(regardless of ANSI mode); ``try_cast`` returns NULL instead.
+
+Valid examples
+
+::
+
+  SELECT cast(TIMESTAMP_NTZ '2020-01-01 15:30:00' as date); -- 2020-01-01
+  SELECT cast(TIMESTAMP_NTZ '2020-01-01 00:00:00' as date); -- 2020-01-01
+
+Under session timezone ``America/Los_Angeles`` (UTC-8): ::
+
+  SELECT cast(TIMESTAMP_NTZ '2020-01-01 00:00:00' as date); -- 2020-01-01
+
 Cast to Time
 ------------
 
@@ -768,3 +790,26 @@ Valid examples
   SELECT cast('2015-03-18 12:03:17.123' as timestamp_ntz); -- 2015-03-18 12:03:17.123
   SELECT cast('1970-01-01 00:00:00-08:00' as timestamp_ntz); -- 1970-01-01 00:00:00
   SELECT cast('2015-03-18T12:03:17Z' as timestamp_ntz); -- 2015-03-18 12:03:17
+
+From DATE
+^^^^^^^^^
+
+*(ANSI compliant)*
+
+Casting a date to timestamp_utc returns midnight of the given date, not
+subject to the session timezone.
+
+``cast`` throws when the date is too far from the epoch to fit in a
+timestamp_utc (regardless of ANSI mode); ``try_cast`` returns NULL instead.
+
+Valid examples
+
+Under session timezone UTC: ::
+
+  SELECT cast(DATE '2020-01-01' as timestamp_ntz); -- 2020-01-01 00:00:00
+  SELECT cast(DATE '1970-01-01' as timestamp_ntz); -- 1970-01-01 00:00:00
+
+Under session timezone ``America/Los_Angeles`` (UTC-8): ::
+
+  SELECT cast(DATE '2020-01-01' as timestamp_ntz); -- 2020-01-01 00:00:00
+  SELECT cast(DATE '1970-01-01' as timestamp_ntz); -- 1970-01-01 00:00:00

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -17,6 +17,7 @@
 #include "velox/expression/CastExpr.h"
 
 #include <fmt/format.h>
+#include <folly/Likely.h>
 #include <stdexcept>
 #include <type_traits>
 
@@ -168,14 +169,30 @@ VectorPtr CastExpr::castFromDate(
       return castResult;
     }
     case TypeKind::TIMESTAMP: {
-      VELOX_DCHECK(toType->equivalent(*TIMESTAMP()));
-      static const int64_t kMillisPerDay{86'400'000};
+      auto* resultFlatVector = castResult->as<FlatVector<Timestamp>>();
+      if (toType->equivalent(*TIMESTAMP_UTC())) {
+        // Use applyToSelected to retain the exception even when isTryCast_ is
+        // enabled.
+        rows.applyToSelected([&](vector_size_t row) {
+          const auto date = inputFlatVector->valueAt(row);
+          if (FOLLY_UNLIKELY(hooks_->isDateOverflowForTimestampUtc(date))) {
+            if (hooks_->truncate()) {
+              VELOX_USER_FAIL(
+                  makeErrorMessage(input, row, toType) +
+                  " Date value is out of range for TIMESTAMP_UTC.");
+            }
+            resultFlatVector->setNull(row, true);
+            return;
+          }
+          resultFlatVector->set(row, Timestamp::fromDate(date));
+        });
+        return castResult;
+      }
+
       const auto* timeZone =
           getTimeZoneFromConfig(context.execCtx()->queryCtx()->queryConfig());
-      auto* resultFlatVector = castResult->as<FlatVector<Timestamp>>();
       applyToSelectedNoThrowLocal(context, rows, castResult, [&](int row) {
-        auto timestamp = Timestamp::fromMillis(
-            inputFlatVector->valueAt(row) * kMillisPerDay);
+        auto timestamp = Timestamp::fromDate(inputFlatVector->valueAt(row));
         if (timeZone) {
           hooks_->castDateTimestampToGMT(timestamp, *timeZone);
         }
@@ -231,8 +248,27 @@ VectorPtr CastExpr::castToDate(
       return castResult;
     }
     case TypeKind::TIMESTAMP: {
-      VELOX_DCHECK(fromType->equivalent(*TIMESTAMP()));
       auto* inputVector = input.as<SimpleVector<Timestamp>>();
+      if (fromType->equivalent(*TIMESTAMP_UTC())) {
+        // See castFromDate: use applyToSelected to retain the exception even
+        // when isTryCast_ is enabled.
+        rows.applyToSelected([&](vector_size_t row) {
+          const auto& timestamp = inputVector->valueAt(row);
+          const auto days = timestamp.getSeconds() / 86'400;
+          if (FOLLY_UNLIKELY(hooks_->isDateOverflowForTimestampUtc(days))) {
+            if (hooks_->truncate()) {
+              VELOX_USER_FAIL(
+                  makeErrorMessage(input, row, DATE()) +
+                  " Date value is out of range for TIMESTAMP_UTC.");
+            }
+            resultFlatVector->setNull(row, true);
+            return;
+          }
+          resultFlatVector->set(row, util::toDate(timestamp, nullptr));
+        });
+        return castResult;
+      }
+
       const auto* timeZone =
           getTimeZoneFromConfig(context.execCtx()->queryCtx()->queryConfig());
       applyToSelectedNoThrowLocal(context, rows, castResult, [&](int row) {
@@ -245,6 +281,61 @@ VectorPtr CastExpr::castToDate(
       VELOX_UNSUPPORTED(
           "Cast from {} to DATE is not supported", fromType->toString());
   }
+}
+
+VectorPtr CastExpr::castToTimestampUTC(
+    const SelectivityVector& rows,
+    const BaseVector& input,
+    exec::EvalCtx& context,
+    const TypePtr& fromType) {
+  VELOX_USER_CHECK(
+      hooks_->supportsTimestampUtc(),
+      "Cast from {} to {} is not supported",
+      fromType->toString(),
+      TIMESTAMP_UTC()->toString());
+  if (fromType->equivalent(*TIMESTAMP())) {
+    return applyTimestampTimestampUtcCast<true>(rows, context, input);
+  }
+  if (fromType->isDate()) {
+    return castFromDate(rows, input, context, TIMESTAMP_UTC());
+  }
+  if (fromType->kind() == TypeKind::VARCHAR) {
+    VectorPtr result;
+    applyCastPrimitivesDispatch<TypeKind::TIMESTAMP>(
+        fromType, TIMESTAMP_UTC(), rows, context, input, result);
+    return result;
+  }
+  VELOX_UNSUPPORTED(
+      "Cast from {} to {} is not supported",
+      fromType->toString(),
+      TIMESTAMP_UTC()->toString());
+}
+
+VectorPtr CastExpr::castFromTimestampUTC(
+    const SelectivityVector& rows,
+    const BaseVector& input,
+    exec::EvalCtx& context,
+    const TypePtr& toType) {
+  VELOX_USER_CHECK(
+      hooks_->supportsTimestampUtc(),
+      "Cast from {} to {} is not supported",
+      TIMESTAMP_UTC()->toString(),
+      toType->toString());
+  if (toType->equivalent(*TIMESTAMP())) {
+    return applyTimestampTimestampUtcCast<false>(rows, context, input);
+  }
+  if (toType->isDate()) {
+    return castToDate(rows, input, context, TIMESTAMP_UTC());
+  }
+  if (toType->kind() == TypeKind::VARCHAR ||
+      toType->kind() == TypeKind::VARBINARY) {
+    return applyTimestampToVarcharCast(
+        toType, rows, context, input, hooks_->timestampUtcToStringOptions());
+  }
+  VELOX_UNSUPPORTED(
+      "Cast from {} to {} is not supported",
+      TIMESTAMP_UTC()->toString(),
+      toType->toString());
 }
 
 VectorPtr CastExpr::castFromIntervalDayTime(
@@ -927,6 +1018,10 @@ void CastExpr::applyPeeled(
     } else {
       applyCustomCast();
     }
+  } else if (toType->equivalent(*TIMESTAMP_UTC())) {
+    result = castToTimestampUTC(rows, input, context, fromType);
+  } else if (fromType->equivalent(*TIMESTAMP_UTC())) {
+    result = castFromTimestampUTC(rows, input, context, toType);
   } else if (fromType->isDate()) {
     result = castFromDate(rows, input, context, toType);
   } else if (toType->isDate()) {
@@ -967,47 +1062,6 @@ void CastExpr::applyPeeled(
             context,
             fromType,
             toType);
-    }
-  } else if (toType->equivalent(*TIMESTAMP_UTC())) {
-    if (fromType->equivalent(*TIMESTAMP())) {
-      VELOX_USER_CHECK(
-          hooks_->supportsTimestampUtc(),
-          "Cast from {} to {} is not supported",
-          fromType->toString(),
-          toType->toString());
-      result = applyTimestampTimestampUtcCast<true>(rows, context, input);
-    } else if (fromType->kind() == TypeKind::VARCHAR) {
-      applyCastPrimitivesDispatch<TypeKind::TIMESTAMP>(
-          fromType, toType, rows, context, input, result);
-    } else {
-      VELOX_UNSUPPORTED(
-          "Cast from {} to {} is not supported",
-          fromType->toString(),
-          toType->toString());
-    }
-  } else if (fromType->equivalent(*TIMESTAMP_UTC())) {
-    if (toType->equivalent(*TIMESTAMP())) {
-      VELOX_USER_CHECK(
-          hooks_->supportsTimestampUtc(),
-          "Cast from {} to {} is not supported",
-          fromType->toString(),
-          toType->toString());
-      result = applyTimestampTimestampUtcCast<false>(rows, context, input);
-    } else if (
-        toType->kind() == TypeKind::VARCHAR ||
-        toType->kind() == TypeKind::VARBINARY) {
-      VELOX_USER_CHECK(
-          hooks_->supportsTimestampUtc(),
-          "Cast from {} to {} is not supported",
-          fromType->toString(),
-          toType->toString());
-      result = applyTimestampToVarcharCast(
-          toType, rows, context, input, hooks_->timestampUtcToStringOptions());
-    } else {
-      VELOX_UNSUPPORTED(
-          "Cast from {} to {} is not supported",
-          fromType->toString(),
-          toType->toString());
     }
   } else if (
       fromType->kind() == TypeKind::TIMESTAMP &&

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -185,6 +185,18 @@ class CastExpr : public SpecialForm {
       exec::EvalCtx& context,
       const TypePtr& fromType);
 
+  VectorPtr castToTimestampUTC(
+      const SelectivityVector& rows,
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const TypePtr& fromType);
+
+  VectorPtr castFromTimestampUTC(
+      const SelectivityVector& rows,
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const TypePtr& toType);
+
   VectorPtr castFromIntervalDayTime(
       const SelectivityVector& rows,
       const BaseVector& input,

--- a/velox/expression/CastHooks.h
+++ b/velox/expression/CastHooks.h
@@ -142,6 +142,12 @@ class CastHooks {
   /// Spark supports them; Presto does not.
   virtual bool supportsTimestampUtc() const = 0;
 
+  /// True if 'days' is out of range for TIMESTAMP_UTC. Default never
+  /// overflows.
+  virtual bool isDateOverflowForTimestampUtc(int64_t days) const {
+    return false;
+  }
+
   /// Converts boolean to timestamp type.
   virtual Expected<Timestamp> castBooleanToTimestamp(bool seconds) const = 0;
 

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
@@ -29,6 +29,14 @@
 
 namespace facebook::velox::functions::sparksql {
 
+namespace {
+
+// Max DATE magnitude before TIMESTAMP_NTZ's microseconds-since-epoch range
+// overflows. Spark throws here unconditionally, ANSI or not.
+constexpr int64_t kMaxTimestampUtcDays = 106'751'991;
+
+} // namespace
+
 SparkCastHooks::SparkCastHooks(
     const velox::core::QueryConfig& config,
     bool allowOverflow)
@@ -195,6 +203,10 @@ void SparkCastHooks::castDateTimestampToGMT(
     Timestamp& timestamp,
     const tz::TimeZone& timeZone) const {
   toGMTWithGapCorrection(timestamp, timeZone);
+}
+
+bool SparkCastHooks::isDateOverflowForTimestampUtc(int64_t days) const {
+  return days > kMaxTimestampUtcDays || days < -kMaxTimestampUtcDays;
 }
 
 exec::PolicyType SparkCastHooks::getPolicy() const {

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.h
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.h
@@ -105,6 +105,8 @@ class SparkCastHooks : public exec::CastHooks {
       Timestamp& timestamp,
       const tz::TimeZone& timeZone) const override;
 
+  bool isDateOverflowForTimestampUtc(int64_t days) const override;
+
   bool isScientific() const override {
     return true;
   }

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -577,6 +577,118 @@ class SparkCastExprTest : public functions::test::CastBaseTest {
             {"1970-01-01 00:00:00", "2000-01-01 12:21:56"}, VARCHAR()));
   }
 
+  void testDateToTimestampUtc() {
+    // Day 0 = 1970-01-01.
+    testCast(
+        makeFlatVector<int32_t>({0}, DATE()),
+        makeFlatVector<Timestamp>({Timestamp(0, 0)}, TIMESTAMP_UTC()));
+    // Day 18262 = 2020-01-01.
+    testCast(
+        makeFlatVector<int32_t>({18262}, DATE()),
+        makeFlatVector<Timestamp>({Timestamp(1577836800, 0)}, TIMESTAMP_UTC()));
+
+    // Timezone must not affect the result.
+    SCOPE_EXIT {
+      setTimezone("");
+    };
+    setTimezone("America/Los_Angeles");
+    testCast(
+        makeFlatVector<int32_t>({18262}, DATE()),
+        makeFlatVector<Timestamp>({Timestamp(1577836800, 0)}, TIMESTAMP_UTC()));
+  }
+
+  void testTimestampUtcToDate() {
+    // 2020-01-01 → day 18262.
+    testCast(
+        makeFlatVector<Timestamp>({Timestamp(1577836800, 0)}, TIMESTAMP_UTC()),
+        makeFlatVector<int32_t>({18262}, DATE()));
+    // Epoch → 1970-01-01 (day 0).
+    testCast(
+        makeFlatVector<Timestamp>({Timestamp(0, 0)}, TIMESTAMP_UTC()),
+        makeFlatVector<int32_t>({0}, DATE()));
+
+    // Kolkata (UTC+5:30) would shift -19800s to day 0; UTC gives day -1.
+    SCOPE_EXIT {
+      setTimezone("");
+    };
+    setTimezone("Asia/Kolkata");
+    testCast(
+        makeFlatVector<Timestamp>({Timestamp(-19800, 0)}, TIMESTAMP_UTC()),
+        makeFlatVector<int32_t>({-1}, DATE()));
+    testCast(
+        makeFlatVector<Timestamp>({Timestamp(1577836800, 0)}, TIMESTAMP_UTC()),
+        makeFlatVector<int32_t>({18262}, DATE()));
+  }
+
+  // See CastExpr.cpp's overflow check for the derivation of this bound.
+  static constexpr int64_t kMaxTimestampUtcDays = 106'751'991;
+
+  void testDateToTimestampUtcOverflow() {
+    testCast(
+        makeFlatVector<int32_t>({kMaxTimestampUtcDays}, DATE()),
+        makeFlatVector<Timestamp>(
+            {Timestamp(kMaxTimestampUtcDays * 86'400, 0)}, TIMESTAMP_UTC()));
+    testCast(
+        makeFlatVector<int32_t>({-kMaxTimestampUtcDays}, DATE()),
+        makeFlatVector<Timestamp>(
+            {Timestamp(-kMaxTimestampUtcDays * 86'400, 0)}, TIMESTAMP_UTC()));
+
+    testThrow<int32_t>(
+        DATE(),
+        TIMESTAMP_UTC(),
+        {kMaxTimestampUtcDays + 1},
+        "is out of range for TIMESTAMP_UTC");
+    testThrow<int32_t>(
+        DATE(),
+        TIMESTAMP_UTC(),
+        {-kMaxTimestampUtcDays - 1},
+        "is out of range for TIMESTAMP_UTC");
+
+    testCast(
+        makeFlatVector<int32_t>({kMaxTimestampUtcDays + 1}, DATE()),
+        makeNullableFlatVector<Timestamp>({std::nullopt}, TIMESTAMP_UTC()),
+        /*isTryCast=*/true);
+    testCast(
+        makeFlatVector<int32_t>({-kMaxTimestampUtcDays - 1}, DATE()),
+        makeNullableFlatVector<Timestamp>({std::nullopt}, TIMESTAMP_UTC()),
+        /*isTryCast=*/true);
+  }
+
+  void testTimestampUtcToDateOverflow() {
+    testCast(
+        makeFlatVector<Timestamp>(
+            {Timestamp(kMaxTimestampUtcDays * 86'400, 0)}, TIMESTAMP_UTC()),
+        makeFlatVector<int32_t>({kMaxTimestampUtcDays}, DATE()));
+    testCast(
+        makeFlatVector<Timestamp>(
+            {Timestamp(-kMaxTimestampUtcDays * 86'400, 0)}, TIMESTAMP_UTC()),
+        makeFlatVector<int32_t>({-kMaxTimestampUtcDays}, DATE()));
+
+    testThrow<Timestamp>(
+        TIMESTAMP_UTC(),
+        DATE(),
+        {Timestamp((kMaxTimestampUtcDays + 1) * 86'400, 0)},
+        "is out of range for TIMESTAMP_UTC");
+    testThrow<Timestamp>(
+        TIMESTAMP_UTC(),
+        DATE(),
+        {Timestamp((-kMaxTimestampUtcDays - 1) * 86'400, 0)},
+        "is out of range for TIMESTAMP_UTC");
+
+    testCast(
+        makeFlatVector<Timestamp>(
+            {Timestamp((kMaxTimestampUtcDays + 1) * 86'400, 0)},
+            TIMESTAMP_UTC()),
+        makeNullableFlatVector<int32_t>({std::nullopt}, DATE()),
+        /*isTryCast=*/true);
+    testCast(
+        makeFlatVector<Timestamp>(
+            {Timestamp((-kMaxTimestampUtcDays - 1) * 86'400, 0)},
+            TIMESTAMP_UTC()),
+        makeNullableFlatVector<int32_t>({std::nullopt}, DATE()),
+        /*isTryCast=*/true);
+  }
+
   void testInvalidDate() {
     testInvalidCast<int8_t>(
         "date", {12}, "Cast from TINYINT to DATE is not supported", TINYINT());
@@ -2717,6 +2829,38 @@ TEST_F(SparkCastExprTestAnsiOff, overflow) {
 
 TEST_F(SparkCastExprTestAnsiOff, recursiveTryCast) {
   testRecursiveTryCast();
+}
+
+TEST_F(SparkCastExprTestAnsiOff, dateToTimestampUtc) {
+  testDateToTimestampUtc();
+}
+
+TEST_F(SparkCastExprTestAnsiOn, dateToTimestampUtc) {
+  testDateToTimestampUtc();
+}
+
+TEST_F(SparkCastExprTestAnsiOff, timestampUtcToDate) {
+  testTimestampUtcToDate();
+}
+
+TEST_F(SparkCastExprTestAnsiOn, timestampUtcToDate) {
+  testTimestampUtcToDate();
+}
+
+TEST_F(SparkCastExprTestAnsiOff, dateToTimestampUtcOverflow) {
+  testDateToTimestampUtcOverflow();
+}
+
+TEST_F(SparkCastExprTestAnsiOn, dateToTimestampUtcOverflow) {
+  testDateToTimestampUtcOverflow();
+}
+
+TEST_F(SparkCastExprTestAnsiOff, timestampUtcToDateOverflow) {
+  testTimestampUtcToDateOverflow();
+}
+
+TEST_F(SparkCastExprTestAnsiOn, timestampUtcToDateOverflow) {
+  testTimestampUtcToDateOverflow();
 }
 
 // Verify that casting DATE to TIMESTAMP in a timezone where midnight falls in


### PR DESCRIPTION
This PR adds support for casting between DATE and TIMESTAMP UTC (TIMESTAMP_NTZ in Spark) in CastExpr.

DATE to TIMESTAMP_UTC: returns midnight of the given date as a UTC epoch, not subject to the session timezone.
TIMESTAMP_UTC to DATE: extracts the date from the stored timestamp fields without applying the session timezone.
