### PR TITLE
feat(nimble): Wire nimble string reader optimization flags from session config

### DIFF
--- a/velox/connectors/hive/FileConnectorUtil.cpp
+++ b/velox/connectors/hive/FileConnectorUtil.cpp
@@ -201,6 +201,10 @@ void configureRowReaderOptions(
         fileConfig->nimbleLazyColumnIo(sessionProperties));
     rowReaderOptions.setCollectColumnCpuMetrics(
         fileConfig->readerCollectColumnCpuMetrics(sessionProperties));
+    rowReaderOptions.setStringDecoderZeroCopy(
+        fileConfig->nimbleStringDecoderZeroCopy(sessionProperties));
+    rowReaderOptions.setNimblePreserveDictionaryEncoding(
+        fileConfig->nimblePreserveDictionaryEncoding(sessionProperties));
   }
 }
 

--- a/velox/connectors/hive/tests/FileConnectorUtilTest.cpp
+++ b/velox/connectors/hive/tests/FileConnectorUtilTest.cpp
@@ -318,6 +318,53 @@ TEST_F(FileConnectorUtilTest, configureRowReaderOptions) {
   EXPECT_EQ(rowReaderOptions.length(), std::numeric_limits<uint64_t>::max());
 }
 
+TEST_F(FileConnectorUtilTest, configureRowReaderOptionsNimbleDictVectorFlags) {
+  auto fileConfig = makeFileConfig();
+  auto split = makeSplit(dwio::common::FileFormat::NIMBLE);
+  auto scanSpec = std::make_shared<common::ScanSpec>("<root>");
+  auto rowType = ROW({"c0"}, {BIGINT()});
+
+  // Both session flags enabled => both RowReaderOptions flags true.
+  {
+    auto holder = makeConnectorQueryCtx(
+        {{hive::FileConfig::kNimbleStringDecoderZeroCopySession, "true"},
+         {hive::FileConfig::kNimblePreserveDictionaryEncodingSession, "true"}});
+    dwio::common::RowReaderOptions rowReaderOptions;
+    hive::configureRowReaderOptions(
+        /*tableParameters=*/{},
+        scanSpec,
+        /*metadataFilter=*/nullptr,
+        rowType,
+        split,
+        fileConfig,
+        holder.ctx->sessionProperties(),
+        /*ioExecutor=*/nullptr,
+        rowReaderOptions);
+
+    EXPECT_TRUE(rowReaderOptions.stringDecoderZeroCopy());
+    EXPECT_TRUE(rowReaderOptions.nimblePreserveDictionaryEncoding());
+  }
+
+  // Keys absent => both flags fall back to their default (false).
+  {
+    auto holder = makeConnectorQueryCtx();
+    dwio::common::RowReaderOptions rowReaderOptions;
+    hive::configureRowReaderOptions(
+        /*tableParameters=*/{},
+        scanSpec,
+        /*metadataFilter=*/nullptr,
+        rowType,
+        split,
+        fileConfig,
+        holder.ctx->sessionProperties(),
+        /*ioExecutor=*/nullptr,
+        rowReaderOptions);
+
+    EXPECT_FALSE(rowReaderOptions.stringDecoderZeroCopy());
+    EXPECT_FALSE(rowReaderOptions.nimblePreserveDictionaryEncoding());
+  }
+}
+
 TEST_F(FileConnectorUtilTest, configureRowReaderOptionsSkipRows) {
   auto holder = makeConnectorQueryCtx();
   auto fileConfig = makeFileConfig();


### PR DESCRIPTION
Summary:
The Hive connector's configureRowReaderOptions (velox/connectors/hive/FileConnectorUtil.cpp) now consumes the two Nimble dictionary-vector session/connector config keys and applies them to RowReaderOptions, alongside the existing sibling flags (preserveFlatMapsInMemory, nimbleLazyColumnIo, indexEnabled):

- nimble.string-decoder-zero-copy (session: nimble_string_decoder_zero_copy) -> RowReaderOptions::setStringDecoderZeroCopy
- nimble.preserve-dictionary-encoding (session: nimble_preserve_dictionary_encoding) -> RowReaderOptions::setNimblePreserveDictionaryEncoding

These config keys (FileConfig.h) and the RowReaderOptions setters (velox/dwio/common/Options.h) already existed, but configureRowReaderOptions did not read them, so the Nimble selective reader's dictionary-vector read path (returning DictionaryVector for dictionary-encoded string columns) could not be enabled through session/connector config. This wires them up so the path can be turned on per query.

Motivation: unblocks fuzzing the Nimble dictionary-vector read stack via the TableEvolutionFuzzer --nimble_dict_vector_stack flag (D110052629), which emits these two keys into the connector session config; without this wiring the keys were silently ignored on the read path.

Differential Revision: D110105262


