### PR TITLE
Disambiguate `optional<int32_t>` comparison in BaseVector::sortIndices

### DIFF
--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -348,7 +348,12 @@ class BaseVector {
         indices.begin(),
         indices.end(),
         [&](vector_size_t left, vector_size_t right) {
-          return compare(this, left, right, flags) < 0;
+          // An empty result (null encountered) sorts as less, matching the
+          // pre-C++20 std::optional relational semantics; dereferencing avoids
+          // libc++'s ambiguous optional<=> comparison.
+          const std::optional<int32_t> result =
+              compare(this, left, right, flags);
+          return !result.has_value() || result.value() < 0;
         });
   }
 
@@ -362,7 +367,12 @@ class BaseVector {
         indices.begin(),
         indices.end(),
         [&](vector_size_t left, vector_size_t right) {
-          return compare(this, mapping[left], mapping[right], flags) < 0;
+          // An empty result (null encountered) sorts as less, matching the
+          // pre-C++20 std::optional relational semantics; dereferencing avoids
+          // libc++'s ambiguous optional<=> comparison.
+          const std::optional<int32_t> result =
+              compare(this, mapping[left], mapping[right], flags);
+          return !result.has_value() || result.value() < 0;
         });
   }
 


### PR DESCRIPTION
Summary:
`velox/vector/BaseVector.h` `sortIndices()` compares the result of `compare(...)` (a `std::optional<int32_t>`) directly against `0` with `<` inside its `std::sort` comparator. Under libc++17 this is ambiguous -- libc++'s heterogeneous `operator<=>(const optional<T>&, const U&)` collides with the pre-C++20 relational comparison -- and the ill-formed comparator then cascades into `std::__partial_sort` / `__sort3` "no matching function" errors. libstdc++ compiled it fine.

This blocks building `velox` under libc++, which cascades to the unicorn ML/training/import targets that depend on velox (via `multifeed/datafm` and `admarket/training_data/udf/koski`) once unicorn enables libc++ at the top of this stack.

Fix: dereference the optional before comparing, preserving the pre-C++20 `std::optional` relational semantics -- an empty result (a null encountered under non-`NullAsValue` handling) sorts as "less" -- so the operands are `int32_t` vs `int`, unambiguous under both standard libraries and behavior-identical.

Note: `velox/vector/BaseVector.h` is a governed OSS header; this carry-in-stack fix should get velox-owner review before publishing.

Differential Revision: D109463680


