### PR TITLE
refactor(core): Replace AggregationNode::Step name helper with toName

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -1422,23 +1422,7 @@ using AggregationNodePtr = std::shared_ptr<const AggregationNode>;
 inline std::ostream& operator<<(
     std::ostream& out,
     const AggregationNode::Step& step) {
-  switch (step) {
-    case AggregationNode::Step::kFinal:
-      return out << "FINAL";
-    case AggregationNode::Step::kIntermediate:
-      return out << "INTERMEDIATE";
-    case AggregationNode::Step::kPartial:
-      return out << "PARTIAL";
-    case AggregationNode::Step::kSingle:
-      return out << "SINGLE";
-  }
-  VELOX_UNREACHABLE();
-}
-
-inline std::string mapAggregationStepToName(const AggregationNode::Step& step) {
-  std::stringstream ss;
-  ss << step;
-  return ss.str();
+  return out << AggregationNode::toName(step);
 }
 
 /// Specify the column stats collection by aggregation. This is used by table

--- a/velox/exec/tests/HashJoinTestExtra.cpp
+++ b/velox/exec/tests/HashJoinTestExtra.cpp
@@ -1908,7 +1908,7 @@ TEST_P(HashJoinTest, dynamicFiltersPushDownThroughStreamingAgg) {
   for (const auto step :
        {core::AggregationNode::Step::kSingle,
         core::AggregationNode::Step::kPartial}) {
-    SCOPED_TRACE(fmt::format("step {}", core::mapAggregationStepToName(step)));
+    SCOPED_TRACE(fmt::format("step {}", core::AggregationNode::toName(step)));
     auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
     auto buildSide =
         PlanBuilder(planNodeIdGenerator).values(buildVectors).planNode();

--- a/velox/functions/prestosql/aggregates/MinMaxByAggregateBase.h
+++ b/velox/functions/prestosql/aggregates/MinMaxByAggregateBase.h
@@ -1197,7 +1197,7 @@ std::vector<exec::AggregateRegistrationResult> registerMinMaxBy(
         const std::string errorMessage = fmt::format(
             "Unknown input types for {} ({}) aggregation: {}",
             names.front(),
-            mapAggregationStepToName(step),
+            core::AggregationNode::toName(step),
             toString(argTypes));
 
         const bool nAgg = (argTypes.size() == 3) ||

--- a/velox/functions/sparksql/aggregates/MinMaxByAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/MinMaxByAggregate.cpp
@@ -125,7 +125,7 @@ exec::AggregateRegistrationResult registerMinMaxBy(
         const std::string errorMessage = fmt::format(
             "Unknown input types for {} ({}) aggregation: {}",
             name,
-            mapAggregationStepToName(step),
+            core::AggregationNode::toName(step),
             toString(argTypes));
 
         if (isRawInput) {


### PR DESCRIPTION
Summary: `AggregationNode::Step` uses `VELOX_DECLARE_EMBEDDED_ENUM_NAME` / `VELOX_DEFINE_EMBEDDED_ENUM_NAME`, which generate `AggregationNode::toName`. The hand-rolled `mapAggregationStepToName` in `PlanNode.h` is a dead duplicate -- remove it and repoint callers to `toName`. The `operator<<` overload is retained (the embedded-enum macro does not generate one) but simplified to delegate to `toName`. No behavior or serialization change (identical strings).

Reviewed By: mbasmanova

Differential Revision: D109750133


