### PR TITLE
feat(fuzzer): Add random chunking mode in fuzzer (#17970)

### DIFF
--- a/velox/exec/tests/TableEvolutionFuzzer.cpp
+++ b/velox/exec/tests/TableEvolutionFuzzer.cpp
@@ -1004,7 +1004,8 @@ std::unique_ptr<TaskCursor> TableEvolutionFuzzer::makeWriteTask(
     FuzzerGenerator& rng,
     bool enableFlatMap,
     folly::F14FastMap<int, folly::F14FastSet<std::string>>& globalMapColumnKeys,
-    std::vector<int>& globallyCompatibleFlatmapColumns) {
+    std::vector<int>& globallyCompatibleFlatmapColumns,
+    const std::unordered_map<std::string, std::string>& extraSerdeParams) {
   auto builder = PlanBuilder().values({data});
 
   // Create serdeParameters using proper dwrf::Config for flatmap configuration
@@ -1112,6 +1113,11 @@ std::unique_ptr<TaskCursor> TableEvolutionFuzzer::makeWriteTask(
       auto configParams = config->toSerdeParams();
       serdeParameters.insert(configParams.begin(), configParams.end());
     }
+  }
+
+  // Driver-injected, format-specific overrides win over the defaults above.
+  for (const auto& [key, value] : extraSerdeParams) {
+    serdeParameters.insert_or_assign(key, value);
   }
 
   if (bucketColumnIndices.empty()) {
@@ -1374,7 +1380,10 @@ void TableEvolutionFuzzer::createWriteTasks(
         rng_,
         true,
         globalMapColumnKeys,
-        globallyConsistentColumnIndexVector);
+        globallyConsistentColumnIndexVector,
+        config_.extraWriteSerdeParams
+            ? config_.extraWriteSerdeParams(testSetups[i].fileFormat, rng_)
+            : std::unordered_map<std::string, std::string>{});
 
     if (i == config_.evolutionCount - 1) {
       finalExpectedData = std::move(data);
@@ -1393,7 +1402,10 @@ void TableEvolutionFuzzer::createWriteTasks(
         rng_,
         true,
         globalMapColumnKeys,
-        globallyConsistentColumnIndexVector);
+        globallyConsistentColumnIndexVector,
+        config_.extraWriteSerdeParams
+            ? config_.extraWriteSerdeParams(testSetups.back().fileFormat, rng_)
+            : std::unordered_map<std::string, std::string>{});
   }
 }
 

--- a/velox/exec/tests/TableEvolutionFuzzer.h
+++ b/velox/exec/tests/TableEvolutionFuzzer.h
@@ -23,6 +23,8 @@
 #include <folly/init/Init.h>
 #include <gflags/gflags.h>
 #include <gtest/gtest.h>
+#include <functional>
+#include <unordered_map>
 #include <unordered_set>
 #include "velox/expression/fuzzer/ExpressionFuzzer.h"
 
@@ -35,6 +37,16 @@ class TableEvolutionFuzzer {
     int evolutionCount;
     std::vector<dwio::common::FileFormat> formats;
     memory::MemoryPool* pool;
+
+    /// Returns extra writer serde params to merge for one file, or none when
+    /// unset. Called once per written file with the file's format and the
+    /// fuzzer rng, so a driver can exercise format-specific write options,
+    /// randomized yet reproducible from the seed. The core stays
+    /// format-agnostic.
+    std::function<std::unordered_map<std::string, std::string>(
+        dwio::common::FileFormat,
+        FuzzerGenerator&)>
+        extraWriteSerdeParams;
   };
 
   explicit TableEvolutionFuzzer(const Config& config);
@@ -108,7 +120,8 @@ class TableEvolutionFuzzer {
       bool enableFlatMap,
       folly::F14FastMap<int, folly::F14FastSet<std::string>>&
           globalMapColumnKeys,
-      std::vector<int>& globallyCompatibleFlatmapColumns);
+      std::vector<int>& globallyCompatibleFlatmapColumns,
+      const std::unordered_map<std::string, std::string>& extraSerdeParams);
 
   template <typename To, typename From>
   VectorPtr liftToPrimitiveType(


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/nimble/pull/919


The `TableEvolutionFuzzer` writes single-chunk Nimble files, so Nimble's chunked write/read paths go unexercised. This wires randomized chunk/stripe flush behavior into the fuzzer, porting the idea from the (removed) Vader validation-service flush policy (D89336482).

What it adds:
- `nimble::TestFlushPolicy` (`dwio/nimble/velox/FlushPolicy.{h,cpp}`) — a seeded, test-only flush policy. `shouldChunk` cuts a chunk with probability `flushChunkProbability` (default 1/3); `shouldFlush` flushes with probability `flushStripeProbability` (default 1/20) plus an encoded-stripe-size guard (`maxStripePhysicalSize` default 128MB, using `estimatedCompressionFactor` default 3.7 before any data is encoded). Tunables live in a nested `TestFlushPolicy::Options`, range-checked in the constructor. The RNG lives in a shared `TestFlushState` that the policy borrows via a raw, non-owning pointer: `VeloxWriter` rebuilds the flush policy from its factory on every `write()`, so an RNG owned by the policy would reseed identically each call; holding it in state that outlives the per-`write()` policy instances lets decisions vary across writes while staying reproducible from the seed. The `TestFlushState` is owned by the factory closure (a `std::shared_ptr`, since a `std::function` target must be copyable) and each policy takes a raw pointer.
- `nimble::FlushPolicyFactoryFactory` (`dwio/nimble/velox/FlushPolicyFactory.{h,cpp}`) — builds a flush-policy factory from a `nimble.flush_policy_config` string of the form `type:<t>,key:value,...`. The leading `type` selects the policy and dispatches to a per-type parser (`parseRandomConfig` / `parsePerBatchConfig`), each returning a `TestFlushPolicy::Options`; `makeRandom` wraps it in a factory whose produced policies share one `TestFlushState`. `random` uses the parsed tuning as-is; `per_batch` pins `flushChunkProbability` to 1.0 (cuts a chunk every batch, ignoring any value in the spec). `type:default` (or an absent key) returns `std::nullopt`, so the caller keeps the size-based policy. Byte sizes go through `velox::config::toCapacity` (case-insensitive `KB`/`MB`/`GB`); a malformed entry, unknown key, unparseable/out-of-range value, or unknown type fails fast as `NimbleUserError`.
- A single `nimble::Config` key `FLUSH_POLICY_CONFIG` (`nimble.flush_policy_config`). `NimbleWriterOptionBuilder::withSerdeParams` consults `FlushPolicyFactoryFactory::create` first (it takes precedence over the size-based paths); when it returns a factory, chunking is forced on and `minStreamChunkRawSize` is set to 0 so even small inputs chunk. A throttled tripwire logs when a test policy is installed.
- A generic, format-agnostic `Config::extraWriteSerdeParams` hook on the OSS-core `velox/exec/tests/TableEvolutionFuzzer` (no Nimble coupling in OSS). The Meta `fb_velox` driver sets it to choose default / `per_batch` / `random` ~1/3 each per written file, seeded from `FLAGS_seed` for reproducibility.

The `per_batch` and `random` types are test-only; production writes are unaffected (the `nimble.flush_policy_config` key is never set in production).

Differential Revision: D109997547


