### PR TITLE
fix(ci): Publish the require-fbcode-import gate as a commit status (#17971)

### DIFF
--- a/.github/workflows/detect-approval.yml
+++ b/.github/workflows/detect-approval.yml
@@ -1,0 +1,46 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Detect Approval -- step 1 of the require-fbcode-import approval hop.
+#
+# pull_request_review on a fork pull request runs with a read-only token, so it
+# cannot publish the gate status directly. This workflow does nothing but fire a
+# workflow_run that the require-fbcode-import gate consumes in the base-repo
+# context (full token) to re-evaluate and publish the status. pull_request_review
+# runs the workflow file from the default branch, so this is not
+# fork-controllable, and it emits no pull-request-controlled output -- the gate
+# re-derives the pull request identity from the GitHub-set workflow_run head SHA.
+
+name: Detect Approval
+
+# zizmor:disable:dangerous-triggers -- pull_request_review runs in fork context
+# with a read-only token; no pull-request-provided code is executed. This
+# workflow only fires a workflow_run for the gate, which re-derives identity from
+# the GitHub-set workflow_run head SHA, not from anything emitted here.
+on:
+  pull_request_review:
+    types: [submitted, dismissed]
+
+permissions:
+  contents: read
+
+jobs:
+  detect:
+    # Fire on review submissions and dismissals -- the changes that can flip the
+    # review decision the gate keys on.
+    if: github.event.action == 'submitted' || github.event.action == 'dismissed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Signal the gate to re-evaluate
+        run: echo "Review change detected; the require-fbcode-import gate re-evaluates via workflow_run."

--- a/.github/workflows/require-fbcode-import.yml
+++ b/.github/workflows/require-fbcode-import.yml
@@ -14,142 +14,169 @@
 
 # Require-fbcode-import gate
 #
-# Once a pull request is APPROVED, it must not be mergeable until the change
-# exists in fbcode. Before approval the gate is not applicable and reports
-# success (approval itself is enforced by branch protection). Once APPROVED the
-# gate reports success only on a positive in-fbcode signal:
+# Once a pull request is APPROVED it must not be mergeable until the change is in
+# fbcode. Before approval the gate is not applicable and reports success
+# (approval itself is enforced by the Require approvals rule). Once APPROVED the
+# gate reports success only on a positive, NON-FORGEABLE in-fbcode signal:
 #
-#   * fbcode-originated PRs carry a "Differential Revision" trailer in the body.
-#   * Imported PRs are detected by the comment that Meta CodeSync
-#     (meta-codesync[bot]) posts on import, which links the imported diff. To
-#     keep this per-commit-correct, the comment counts only if it was posted
-#     after the current head commit; pushing a new commit re-blocks the gate
-#     until the new commit is imported.
+#   * fbcode-originated PRs carry the "meta-exported" label, which Meta CodeSync
+#     applies on export. (A pull request author cannot add labels to a base-repo
+#     PR, so this is not forgeable; the "Differential Revision" trailer in the
+#     PR body is NOT used because the author controls the body.)
+#   * Imported PRs are detected by the comment Meta CodeSync (meta-codesync[bot])
+#     posts on import. It counts only if newer than the current head commit, so
+#     pushing a new commit re-blocks the gate until that commit is imported.
 #
-# Reporting the result:
-#   * On pull_request and pull_request_review the run is associated with the PR
-#     head commit, so the job exit code (0/1) is recorded as the check on the
-#     right commit. No API write and no write token are needed, which is why
-#     this works for fork pull requests (whose token is read-only).
-#   * On issue_comment the run is associated with the default branch, not the PR
-#     head, so the exit code would land on the wrong commit. There we explicitly
-#     publish the result to the PR head SHA via the Checks API. issue_comment
-#     runs in the base-repo context and so has a write token even for fork PRs.
-# When several check runs share the name "gate" on a commit, GitHub uses the
-# latest, so the issue_comment result supersedes an earlier pull_request result.
+# The result is published as the "gate" commit STATUS on the pull request head.
+# A commit status is deduplicated by context, so the latest "gate" replaces any
+# previous one and it transitions red<->green cleanly with no stale entry.
+#
+# Triggers and tokens (publishing a status needs a write token, which fork
+# pull_request runs do not get):
+#   * pull_request_target -- PR open/push/label; grants a write token on fork PRs.
+#   * issue_comment -- reacts to the import comment; base-repo context, write token.
+#   * workflow_run (from "Detect Approval") -- reacts to approval/dismissal, which
+#     pull_request_review cannot publish from directly (read-only token on forks).
+#     Identity is re-derived from the GitHub-set workflow_run head SHA.
 
 name: Require fbcode Import
 
+# zizmor:disable:dangerous-triggers -- pull_request_target, issue_comment, and
+# workflow_run are required so the job has a write token to publish the gate
+# status on fork PRs. This workflow does NOT check out or run any
+# pull-request-provided code, and does not interpolate untrusted pull-request
+# fields into the shell, so the privilege-escalation ("pwn request") risk does
+# not apply. The workflow_run input is the trivial Detect Approval workflow; the
+# pull request identity is re-derived from the GitHub-set workflow_run head SHA.
 on:
-  pull_request:
-    types: [opened, reopened, synchronize]
-  pull_request_review:
-    types: [submitted, dismissed]
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
   issue_comment:
     types: [created]
+  workflow_run:
+    workflows: [Detect Approval]
+    types: [completed]
 
 permissions:
   contents: read
   pull-requests: read
   issues: read
-  # Used only by the issue_comment path, to publish the result on the PR head.
-  checks: write
+  # Required to publish the "gate" commit status on the pull request head.
+  statuses: write
 
 jobs:
-  gate:
-    name: gate
+  evaluate:
+    name: evaluate-import-gate
     runs-on: ubuntu-latest
-    # Always run for PR activity and reviews. For comments, run only for the
-    # CodeSync bot's import comment, so the job is skipped (no runner) for
-    # ordinary comments.
+    # Run for PR activity and the approval hop; for comments, run only for the
+    # CodeSync bot's import comment so the job is skipped (no runner allocated)
+    # for ordinary comments.
     if: >-
       github.event_name != 'issue_comment' ||
       (github.event.issue.pull_request != null &&
        github.event.comment.user.login == 'meta-codesync[bot]')
     steps:
-      - name: Evaluate the import gate
+      - name: Evaluate the import gate and publish the "gate" commit status
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           EVENT_NAME: ${{ github.event_name }}
-          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          # PR number is present on pull_request_target and issue_comment events;
+          # workflow_run carries none, so it is derived below from the head SHA.
+          ENV_PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          WORKFLOW_RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
           # The GitHub App account that Meta CodeSync comments as on import.
           CODESYNC_BOT: meta-codesync[bot]
-          # The check name enforced by branch protection (the required context).
-          CHECK_NAME: gate
+          # The label Meta CodeSync applies to fbcode-originated (exported) PRs.
+          EXPORTED_LABEL: meta-exported
+          # The status context enforced by branch protection.
+          CONTEXT: gate
         run: |
           set -uo pipefail
 
+          # Resolve the PR number. For the workflow_run hop the event carries no
+          # PR number, so derive it from the GitHub-set head SHA.
+          PR_NUMBER="${ENV_PR_NUMBER}"
+          if [ "${EVENT_NAME}" = "workflow_run" ]; then
+            if [ "${WORKFLOW_RUN_CONCLUSION}" != "success" ]; then
+              echo "::notice::Detect Approval run did not succeed; nothing to do."
+              exit 0
+            fi
+            PR_NUMBER="$(gh api "repos/${REPO}/commits/${WORKFLOW_RUN_HEAD_SHA}/pulls" \
+              --jq '[.[] | select(.state=="open")][0].number' 2>/dev/null || echo '')"
+          fi
           if [ -z "${PR_NUMBER}" ] || [ "${PR_NUMBER}" = "null" ]; then
-            echo "::notice::No pull request on this event; nothing to do."
+            echo "::notice::No pull request resolved for this event; nothing to do."
             exit 0
           fi
 
-          PR_JSON="$(gh pr view "${PR_NUMBER}" --repo "${REPO}" --json headRefOid,reviewDecision,body)"
+          PR_JSON="$(gh pr view "${PR_NUMBER}" --repo "${REPO}" --json headRefOid,reviewDecision,labels)"
           HEAD_SHA="$(printf '%s' "${PR_JSON}" | jq -r '.headRefOid')"
           DECISION="$(printf '%s' "${PR_JSON}" | jq -r '.reviewDecision // ""')"
-          PR_BODY="$(printf '%s' "${PR_JSON}" | jq -r '.body // ""')"
-          echo "PR #${PR_NUMBER} head=${HEAD_SHA} reviewDecision=${DECISION:-<none>} event=${EVENT_NAME}"
+          LABELS="$(printf '%s' "${PR_JSON}" | jq -r '[.labels[].name] | join(",")')"
+          echo "PR #${PR_NUMBER} head=${HEAD_SHA} reviewDecision=${DECISION:-<none>} labels=[${LABELS}] event=${EVENT_NAME}"
 
-          CONCLUSION=""
-          TITLE=""
-          SUMMARY=""
-          result() { CONCLUSION="$1"; TITLE="$2"; SUMMARY="$3"; }
+          # Could not resolve the head: leave the gate unset (fail closed -- a
+          # required check stays unsatisfied rather than going green on error).
+          if [ -z "${HEAD_SHA}" ] || [ "${HEAD_SHA}" = "null" ]; then
+            echo "::notice::Could not resolve PR head SHA; nothing published."
+            exit 0
+          fi
 
+          has_label() { printf ',%s,' "${LABELS}" | grep -q ",$1,"; }
+
+          # Publish the gate result as a commit status on the PR head. A status is
+          # deduplicated by context, so the latest one always wins. pull_request_target
+          # and workflow_run run against the base SHA, so the head SHA must be
+          # targeted explicitly.
+          publish() {
+            gh api -X POST "repos/${REPO}/statuses/${HEAD_SHA}" \
+              -f state="$1" \
+              -f context="${CONTEXT}" \
+              -f description="$2" >/dev/null
+            echo "${CONTEXT} -> $1 on ${HEAD_SHA}: $2"
+          }
+
+          # Before approval the gate is not applicable.
           if [ "${DECISION}" != "APPROVED" ]; then
-            # Before approval the gate is not applicable; re-evaluated when the
-            # review decision changes.
-            result "success" "Not applicable until approved" \
-              "Approval is enforced separately by branch protection. This gate engages once the PR is APPROVED."
-          elif printf '%s' "${PR_BODY}" | grep -Eq 'Differential Revision:.*D[0-9]+'; then
-            result "success" "fbcode-originated" \
-              "PR carries a Differential Revision trailer; the change already exists in fbcode."
-          else
-            # Meta CodeSync posts an imported-diff comment on import. The comment
-            # must be authored by ${CODESYNC_BOT}, and must be newer than the
-            # current head commit so a new commit re-blocks the gate.
-            BOT_TSV="$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
-              --jq ".[] | select(.user.login==\"${CODESYNC_BOT}\") | [.created_at, (.body | gsub(\"[\\n\\r]\"; \" \"))] | @tsv" 2>/dev/null || true)"
-            IMPORT_TS="$(printf '%s\n' "${BOT_TSV}" | grep -E 'you can view this in \[D[0-9]+\]' | cut -f1 | sort | tail -1)"
+            publish "success" "Not applicable until approved"
+            exit 0
+          fi
 
-            if [ -n "${IMPORT_TS}" ]; then
-              HEAD_TS="$(gh api "repos/${REPO}/commits/${HEAD_SHA}" --jq '.commit.committer.date' 2>/dev/null || echo '')"
-              IMPORT_EPOCH="$(date -d "${IMPORT_TS}" +%s 2>/dev/null || echo 0)"
-              HEAD_EPOCH="$(date -d "${HEAD_TS}" +%s 2>/dev/null || echo 0)"
-              echo "import comment=${IMPORT_TS} (${IMPORT_EPOCH}) head commit=${HEAD_TS} (${HEAD_EPOCH})"
-              if [ "${IMPORT_EPOCH}" -gt "${HEAD_EPOCH}" ]; then
-                result "success" "Imported into fbcode" \
-                  "Meta CodeSync (${CODESYNC_BOT}) imported this PR; the current head exists in fbcode."
-              else
-                result "failure" "Head not yet imported into fbcode" \
-                  "The latest import predates the current head commit. Import the new commit; once Meta CodeSync (${CODESYNC_BOT}) posts the imported-diff comment, this check turns green automatically."
-              fi
-            else
-              result "failure" "Approved PR not yet imported into fbcode" \
-                "Import this PR into fbcode. Once Meta CodeSync (${CODESYNC_BOT}) posts the imported-diff comment, this check turns green automatically."
+          # fbcode-originated: the bot applies the meta-exported label on export.
+          # Non-forgeable (a fork cannot add labels to a base-repo PR).
+          if has_label "${EXPORTED_LABEL}"; then
+            publish "success" "fbcode-originated; already in fbcode"
+            exit 0
+          fi
+
+          # Imported: the bot posts an imported-diff comment on import. Require it
+          # to be authored by ${CODESYNC_BOT} and newer than the current head, so a
+          # new commit re-blocks the gate.
+          BOT_TSV="$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+            --jq ".[] | select(.user.login==\"${CODESYNC_BOT}\") | [.created_at, (.body | gsub(\"[\\n\\r]\"; \" \"))] | @tsv" 2>/dev/null || true)"
+          IMPORT_TS="$(printf '%s\n' "${BOT_TSV}" | grep -E 'you can view this in \[D[0-9]+\]' | cut -f1 | sort | tail -1)"
+
+          if [ -n "${IMPORT_TS}" ]; then
+            HEAD_TS="$(gh api "repos/${REPO}/commits/${HEAD_SHA}" --jq '.commit.committer.date' 2>/dev/null || echo '')"
+            IMPORT_EPOCH="$(date -d "${IMPORT_TS}" +%s 2>/dev/null || echo 0)"
+            HEAD_EPOCH="$(date -d "${HEAD_TS}" +%s 2>/dev/null || echo 0)"
+            echo "import comment=${IMPORT_TS} (${IMPORT_EPOCH}) head commit=${HEAD_TS} (${HEAD_EPOCH})"
+            # If either timestamp could not be parsed (transient API/parse error),
+            # fail closed rather than risk a false success.
+            if [ "${IMPORT_EPOCH}" -eq 0 ] || [ "${HEAD_EPOCH}" -eq 0 ]; then
+              publish "failure" "Could not verify the import is newer than the head"
+              exit 0
             fi
-          fi
-
-          echo "verdict: ${CONCLUSION} — ${TITLE}"
-
-          # On issue_comment the run is not tied to the PR head, so publish the
-          # result to the head SHA via the Checks API (write token available in
-          # the base-repo context). Otherwise the job exit code is recorded on
-          # the head commit directly.
-          if [ "${EVENT_NAME}" = "issue_comment" ]; then
-            gh api -X POST "repos/${REPO}/check-runs" \
-              -f name="${CHECK_NAME}" \
-              -f head_sha="${HEAD_SHA}" \
-              -f status="completed" \
-              -f conclusion="${CONCLUSION}" \
-              -f "output[title]=${TITLE}" \
-              -f "output[summary]=${SUMMARY}" >/dev/null
-            echo "published ${CHECK_NAME}=${CONCLUSION} on ${HEAD_SHA}"
+            if [ "${IMPORT_EPOCH}" -gt "${HEAD_EPOCH}" ]; then
+              publish "success" "Imported into fbcode"
+              exit 0
+            fi
+            publish "failure" "Head not yet imported into fbcode"
             exit 0
           fi
 
-          if [ "${CONCLUSION}" = "success" ]; then
-            exit 0
-          fi
-          echo "::error title=${TITLE}::${SUMMARY}"
-          exit 1
+          # Approved + not in fbcode: fail closed.
+          publish "failure" "Approved PR not yet imported into fbcode"
+          exit 0

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -23,3 +23,5 @@ rules:
       - detect-force-full.yml
       - rerun-on-force-full.yml
       - force-full-on-comment.yml
+      - require-fbcode-import.yml
+      - detect-approval.yml


### PR DESCRIPTION
Summary:

Reworks the require-fbcode-import gate so it is correct, non-forgeable, and works for fork pull requests.

Problems with the previous version: it reported the result through a mix of a workflow-job check run and a Checks-API check run (two different sources for the same check name, which GitHub does not reconcile, leaving a stale failing entry under a later passing one), and it trusted a `Differential Revision` trailer in the pull request body, which the author controls and can therefore forge to bypass the gate.

This version:
- Publishes a single commit STATUS named `gate` on the pull request head. A commit status is deduplicated by context, so the latest result always wins and no stale entry remains.
- Trusts only non-forgeable, bot-authored signals: the `meta-exported` label Meta CodeSync applies to fbcode-originated PRs (a fork cannot add labels to a base-repo PR), and the Meta CodeSync (meta-codesync[bot]) import comment for imported PRs (counted only when newer than the current head commit, so a new commit re-blocks the gate). The PR body trailer is no longer trusted.
- Gates on approval: not approved gives success (not applicable); approved and in fbcode gives success; approved and not in fbcode gives failure. Approval itself stays enforced by the Require approvals rule.
- Triggers on pull_request_target (PR open/push/label) and issue_comment (import comment), both of which grant a write token on fork PRs. Approval and dismissal are caught via a small detect-approval.yml on pull_request_review (which is read-only on forks) that fires a workflow_run the gate consumes in the base-repo context with a write token; the gate re-derives the PR from the GitHub-set workflow_run head SHA.
- Adds both workflows to .github/zizmor.yml dangerous-triggers ignore, matching the repo's other pull_request_target, issue_comment, and workflow_run workflows.

Reviewed By: bikramSingh91

Differential Revision: D110130799
