### PR TITLE
feat(fuzzer): Add no-evolution mode and fix test flatmap column consistency (#17975)

### DIFF
--- a/velox/exec/tests/TableEvolutionFuzzer.cpp
+++ b/velox/exec/tests/TableEvolutionFuzzer.cpp
@@ -147,7 +147,7 @@ bool hasEmptyElement(const RowVectorPtr& data, int columnIndex) {
 TableEvolutionFuzzer::TableEvolutionFuzzer(const Config& config)
     : config_(config), vectorFuzzer_(makeVectorFuzzerOptions(), config.pool) {
   VELOX_CHECK_GT(config_.columnCount, 0);
-  VELOX_CHECK_GT(config_.evolutionCount, 1);
+  VELOX_CHECK_GT(config_.evolutionCount, 0);
 }
 
 const std::string& TableEvolutionFuzzer::connectorId() {
@@ -802,6 +802,13 @@ void TableEvolutionFuzzer::run() {
     }
   }
 
+  // Decide the flatmap-as-struct read schema once and share it across both scan
+  // plans. buildFlatmapAsStructSchema draws an rng coin per compatible map
+  // column; computing it separately per plan would make the two plans disagree
+  // on a column's read mode (MAP vs struct).
+  RowTypePtr fullOutSchema = buildFlatmapAsStructSchema(
+      rowType, globalMapColumnKeys, globallyConsistentColumnIndexVector);
+
   std::vector<std::shared_ptr<TaskCursor>> scanTasks(2);
   // actual: TableScan -> Aggregation (allows pushdown)
   pushdownConfig.aggregationConfig = aggConfig;
@@ -811,8 +818,7 @@ void TableEvolutionFuzzer::run() {
       pushdownConfig,
       false,
       false, // insertProjectToBlockPushdown
-      globalMapColumnKeys,
-      globallyConsistentColumnIndexVector);
+      fullOutSchema);
 
   // expected: TableScan -> Project -> Aggregation (blocks pushdown)
   // Insert a Project node to prevent aggregation pushdown
@@ -823,8 +829,7 @@ void TableEvolutionFuzzer::run() {
       pushdownConfig,
       true,
       true, // insertProjectToBlockPushdown
-      globalMapColumnKeys,
-      globallyConsistentColumnIndexVector);
+      fullOutSchema);
 
   ScopedOOMInjector oomInjectorReadPath(
       [this]() -> bool { return folly::Random::oneIn(10, rng_); },
@@ -1241,33 +1246,22 @@ std::unique_ptr<TaskCursor> TableEvolutionFuzzer::makeScanTask(
     const PushdownConfig& pushdownConfig,
     bool useFiltersAsNode,
     bool insertProjectToBlockPushdown,
-    const folly::F14FastMap<int, folly::F14FastSet<std::string>>&
-        globalMapColumnKeys,
-    const std::vector<int>& globallyCompatibleFlatmapColumns) {
-  // Build schema for flatmap as struct reading
-  RowTypePtr newSchemaUsingStructReadingFlatMap = buildFlatmapAsStructSchema(
-      tableSchema, globalMapColumnKeys, globallyCompatibleFlatmapColumns);
-
+    const RowTypePtr& fullOutSchema) {
   CursorParameters params;
   params.serialExecution = true;
 
   auto builder = PlanBuilder()
                      .filtersAsNode(useFiltersAsNode)
                      .tableScanWithPushDown(
-                         newSchemaUsingStructReadingFlatMap, // Use struct
-                                                             // schema for
-                                                             // flatmap reading
+                         fullOutSchema,
                          /*pushdownConfig=*/pushdownConfig,
-                         tableSchema, // Original schema as dataColumns
+                         tableSchema,
                          {});
 
-  // If insertProjectToBlockPushdown is set, insert an identity Project node
-  // to prevent Driver::mayPushdownAggregation() from allowing pushdown
   if (insertProjectToBlockPushdown &&
       pushdownConfig.aggregationConfig.has_value()) {
-    // Create identity projection: simply pass through all columns
     std::vector<std::string> projectExprs;
-    for (const auto& name : newSchemaUsingStructReadingFlatMap->names()) {
+    for (const auto& name : fullOutSchema->names()) {
       projectExprs.push_back(name);
     }
     builder.project(projectExprs);

--- a/velox/exec/tests/TableEvolutionFuzzer.h
+++ b/velox/exec/tests/TableEvolutionFuzzer.h
@@ -136,9 +136,7 @@ class TableEvolutionFuzzer {
       const PushdownConfig& pushdownConfig,
       bool useFiltersAsNode,
       bool insertProjectToBlockPushdown,
-      const folly::F14FastMap<int, folly::F14FastSet<std::string>>&
-          globalMapColumnKeys = {},
-      const std::vector<int>& globallyCompatibleFlatmapColumns = {});
+      const RowTypePtr& fullOutSchema);
 
   /// Builds schema for flatmap as struct reading by converting selected map
   /// columns to struct types.

--- a/velox/exec/tests/TableEvolutionFuzzerTest.cpp
+++ b/velox/exec/tests/TableEvolutionFuzzerTest.cpp
@@ -53,6 +53,52 @@ void registerFactories(folly::Executor* ioExecutor) {
   dwrf::registerDwrfWriterFactory();
 }
 
+TableEvolutionFuzzer::Config makeDwrfConfig(
+    memory::MemoryPool* pool,
+    int evolutionCount) {
+  TableEvolutionFuzzer::Config config;
+  config.pool = pool;
+  config.columnCount = 5;
+  config.evolutionCount = evolutionCount;
+  config.formats = TableEvolutionFuzzer::parseFileFormats("dwrf");
+  return config;
+}
+
+// Constructs the fuzzer with various evolutionCount values to pin the relaxed
+// constructor assert (VELOX_CHECK_GT(evolutionCount, 0)). evolutionCount == 1
+// is the no-evolution mode (single setup, no schema evolution) and must
+// construct cleanly; evolutionCount == 0 must throw.
+TEST(TableEvolutionFuzzerTest, constructorEvolutionCountBoundary) {
+  auto pool = memory::memoryManager()->addLeafPool("TableEvolutionFuzzer");
+
+  EXPECT_NO_THROW(
+      { TableEvolutionFuzzer fuzzer(makeDwrfConfig(pool.get(), 1)); });
+  EXPECT_NO_THROW(
+      { TableEvolutionFuzzer fuzzer(makeDwrfConfig(pool.get(), 2)); });
+
+  EXPECT_THROW(
+      { TableEvolutionFuzzer fuzzer(makeDwrfConfig(pool.get(), 0)); },
+      VeloxException);
+}
+
+// Runs the fuzzer in no-evolution mode (evolutionCount == 1) for a small,
+// fixed number of deterministic iterations. This exercises the no-evolution
+// path together with filter-no-project (dropped filter-only columns) and the
+// shared flatmap-as-struct read schema end to end; the fuzzer's internal
+// pushdown-vs-FilterNode oracle is the assertion (run() throws on divergence).
+TEST(TableEvolutionFuzzerTest, noEvolutionBoundedRun) {
+  auto pool = memory::memoryManager()->addLeafPool("TableEvolutionFuzzer");
+  TableEvolutionFuzzer fuzzer(makeDwrfConfig(pool.get(), 1));
+  fuzzer.setSeed(20260629);
+  constexpr int kIterations = 4;
+  for (int i = 0; i < kIterations; ++i) {
+    LOG(INFO) << "noEvolutionBoundedRun iteration " << i
+              << ", seed=" << fuzzer.seed();
+    EXPECT_NO_THROW(fuzzer.run());
+    fuzzer.reSeed();
+  }
+}
+
 TEST(TableEvolutionFuzzerTest, run) {
   auto pool = memory::memoryManager()->addLeafPool("TableEvolutionFuzzer");
   exec::test::TableEvolutionFuzzer::Config config;


### PR DESCRIPTION
Summary:

Two related TableEvolutionFuzzer changes: a no-evolution run mode, and the latent flatmap-as-struct read bug that mode immediately surfaced.

No-evolution mode: the fb_velox `--table_evolution_fuzzer_no_evolution` flag sets `evolutionCount=1`, and the core constructor assert is relaxed from `> 1` to `> 0` to allow a single un-evolved setup. A single setup maximizes filter-only coverage with no type promotion.

Test flatmap column consistenty fix: `run()` now computes the flatmap-as-struct read schema ONCE (`buildFlatmapAsStructSchema`) and passes it to both scan plans (the pushdown "actual" plan and the FilterNode "reference" plan), instead of each `makeScanTask` call recomputing it. `buildFlatmapAsStructSchema` draws an rng coin per globally-compatible flatmap column to decide read-as-MAP vs read-as-struct; computing it independently per plan let the two plans pick different read modes for the same column, yielding a column typed MAP in one plan and ROW (struct) in the other -- a spurious type mismatch in `checkResultsEqual`. The bug was latent in evolution mode because the globally-compatible set is almost always empty there (a column survives only if written as a clean flatmap in every setup's write -- stringent removal-only attrition); no-evolution mode (a single setup) makes the set non-empty often enough that the divergence surfaces immediately, which is how it was found.

Reviewed By: kewang1024, xiaoxmeng

Differential Revision: D110145989


