### PR TITLE
feat(fuzzer): Selectively project columns (#17976)

### DIFF
--- a/velox/exec/tests/TableEvolutionFuzzer.cpp
+++ b/velox/exec/tests/TableEvolutionFuzzer.cpp
@@ -17,6 +17,7 @@
 #include "velox/exec/tests/TableEvolutionFuzzer.h"
 #include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
+#include "velox/connectors/hive/TableHandle.h"
 #include "velox/dwio/common/tests/utils/FilterGenerator.h"
 #include "velox/dwio/dwrf/common/Config.h"
 #include "velox/exec/Cursor.h"
@@ -646,6 +647,116 @@ VectorPtr TableEvolutionFuzzer::liftToType(
   }
 }
 
+namespace {
+// Returns true when 'name' occurs in 'expr' as a complete identifier token
+// rather than as a substring of a longer identifier. Aggregate expressions look
+// like "func(name)" and column names are plain identifiers, so this avoids
+// false positives such as column "name_4" matching aggregate "min(name_42)".
+// Mirrors the word-boundary check in applyRemainingFilters.
+bool containsIdentifier(const std::string& expr, const std::string& name) {
+  const auto isIdentChar = [](char c) {
+    return std::isalnum(static_cast<unsigned char>(c)) != 0 || c == '_';
+  };
+  size_t pos = 0;
+  while ((pos = expr.find(name, pos)) != std::string::npos) {
+    const bool boundedLeft = pos == 0 || !isIdentChar(expr[pos - 1]);
+    const size_t end = pos + name.size();
+    const bool boundedRight = end >= expr.size() || !isIdentChar(expr[end]);
+    if (boundedLeft && boundedRight) {
+      return true;
+    }
+    pos += name.size();
+  }
+  return false;
+}
+} // namespace
+
+bool TableEvolutionFuzzer::isColumnUsedByAggregation(
+    const std::string& columnName,
+    const AggregationConfig& aggregationConfig) {
+  for (const auto& groupingKey : aggregationConfig.groupingKeys) {
+    if (groupingKey == columnName) {
+      return true;
+    }
+  }
+  for (const auto& aggregate : aggregationConfig.aggregates) {
+    if (containsIdentifier(aggregate, columnName)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+folly::F14FastSet<std::string> TableEvolutionFuzzer::selectFilterOnlyColumns(
+    const RowTypePtr& schema,
+    const std::unordered_set<std::string>& filteredColumns,
+    const std::vector<column_index_t>& bucketColumnIndices,
+    const std::vector<RowTypePtr>& perEvolutionSchemas,
+    const std::optional<AggregationConfig>& aggregationConfig,
+    FuzzerGenerator& rng) {
+  folly::F14FastSet<std::string> bucketColumnNames;
+  for (const auto bucketColumnIndex : bucketColumnIndices) {
+    bucketColumnNames.insert(schema->nameOf(bucketColumnIndex));
+  }
+  folly::F14FastSet<std::string> droppedColumns;
+  for (int i = 0; i < schema->size(); ++i) {
+    const auto& name = schema->nameOf(i);
+    if (filteredColumns.count(name) == 0) {
+      continue;
+    }
+    // Skip map columns: a filtered map column is read in flatmap-as-struct mode
+    // (buildFlatmapAsStructSchema swaps its type to a struct in the output
+    // schema) and its filter is a map key/value subfield filter. Dropping it
+    // filter-only makes the two oracle plans read it through divergent paths --
+    // the pushdown plan pushes the subfield filter onto the struct-read column,
+    // while the FilterNode plan realizes the filter as a node and then projects
+    // the column away -- so their results can disagree.
+    if (schema->childAt(i)->isMap()) {
+      continue;
+    }
+    if (bucketColumnNames.count(name) > 0) {
+      continue;
+    }
+    // Columns evolve positionally; index 'i' in the final schema corresponds to
+    // index 'i' in every earlier setup that has that position. Skip columns
+    // whose type differs across setups: the selective reader applies coercion
+    // for evolved columns differently when a column is filter-only versus also
+    // projected, which would make the pushdown-vs-FilterNode oracle diverge.
+    bool typeStableAcrossSetups = true;
+    for (const auto& evolutionSchema : perEvolutionSchemas) {
+      if (i >= evolutionSchema->size() ||
+          !evolutionSchema->childAt(i)->equivalent(*schema->childAt(i))) {
+        typeStableAcrossSetups = false;
+        break;
+      }
+    }
+    if (!typeStableAcrossSetups) {
+      continue;
+    }
+    if (aggregationConfig.has_value() &&
+        isColumnUsedByAggregation(name, *aggregationConfig)) {
+      continue;
+    }
+    if (folly::Random::oneIn(2, rng)) {
+      droppedColumns.insert(name);
+    }
+  }
+  return droppedColumns;
+}
+
+std::vector<std::string> TableEvolutionFuzzer::projectedColumnNames(
+    const RowTypePtr& schema,
+    const folly::F14FastSet<std::string>& droppedColumns) {
+  std::vector<std::string> outputColumnNames;
+  for (int i = 0; i < schema->size(); ++i) {
+    const auto& name = schema->nameOf(i);
+    if (droppedColumns.count(name) == 0) {
+      outputColumnNames.push_back(name);
+    }
+  }
+  return outputColumnNames;
+}
+
 void TableEvolutionFuzzer::run() {
   ScopedOOMInjector oomInjectorWritePath(
       [this]() -> bool { return folly::Random::oneIn(10, rng_); },
@@ -802,10 +913,32 @@ void TableEvolutionFuzzer::run() {
     }
   }
 
-  // Decide the flatmap-as-struct read schema once and share it across both scan
+  // Read a random subset of the filtered columns filter-only (drop them from
+  // the scan output while still filtering on them) to exercise the selective
+  // reader's filter-only column path.
+  std::vector<RowTypePtr> perEvolutionSchemas;
+  perEvolutionSchemas.reserve(testSetups.size());
+  for (const auto& setup : testSetups) {
+    perEvolutionSchemas.emplace_back(setup.schema);
+  }
+  const folly::F14FastSet<std::string> droppedColumns = selectFilterOnlyColumns(
+      rowType,
+      allFilteredColumns,
+      bucketColumnIndices,
+      perEvolutionSchemas,
+      aggConfig,
+      rng_);
+  if (!droppedColumns.empty()) {
+    VLOG(1) << "Dropping filter-only columns from scan output: ["
+            << folly::join(", ", droppedColumns) << "]";
+  }
+  const std::vector<std::string> outputColumnNames =
+      projectedColumnNames(rowType, droppedColumns);
+
+  // Decide the flatmap-as-struct read schema once and share it across both
   // plans. buildFlatmapAsStructSchema draws an rng coin per compatible map
-  // column; computing it separately per plan would make the two plans disagree
-  // on a column's read mode (MAP vs struct).
+  // column; computing it separately per plan could make the pushdown and
+  // FilterNode plans disagree on a column's read mode (MAP vs struct).
   RowTypePtr fullOutSchema = buildFlatmapAsStructSchema(
       rowType, globalMapColumnKeys, globallyConsistentColumnIndexVector);
 
@@ -818,7 +951,8 @@ void TableEvolutionFuzzer::run() {
       pushdownConfig,
       false,
       false, // insertProjectToBlockPushdown
-      fullOutSchema);
+      fullOutSchema,
+      outputColumnNames);
 
   // expected: TableScan -> Project -> Aggregation (blocks pushdown)
   // Insert a Project node to prevent aggregation pushdown
@@ -829,7 +963,8 @@ void TableEvolutionFuzzer::run() {
       pushdownConfig,
       true,
       true, // insertProjectToBlockPushdown
-      fullOutSchema);
+      fullOutSchema,
+      outputColumnNames);
 
   ScopedOOMInjector oomInjectorReadPath(
       [this]() -> bool { return folly::Random::oneIn(10, rng_); },
@@ -1246,25 +1381,81 @@ std::unique_ptr<TaskCursor> TableEvolutionFuzzer::makeScanTask(
     const PushdownConfig& pushdownConfig,
     bool useFiltersAsNode,
     bool insertProjectToBlockPushdown,
-    const RowTypePtr& fullOutSchema) {
+    const RowTypePtr& fullOutSchema,
+    const std::vector<std::string>& outputColumnNames) {
+  // 'insertProjectToBlockPushdown' only takes effect on the reference plan,
+  // where the Project below is what blocks aggregation pushdown; it is
+  // meaningless (and never applied) on the pushdown plan. Enforce the pairing
+  // so a caller that sets it without 'useFiltersAsNode' fails loudly instead of
+  // silently skipping the intended Project.
+  VELOX_CHECK(
+      !insertProjectToBlockPushdown || useFiltersAsNode,
+      "insertProjectToBlockPushdown requires useFiltersAsNode");
+  // Build the projected output schema by keeping only the columns named in
+  // 'outputColumnNames', preserving the order of 'fullOutSchema'. An empty
+  // 'outputColumnNames' means no pruning, i.e. project the full schema.
+  std::unordered_set<std::string> outputColumnNameSet(
+      outputColumnNames.begin(), outputColumnNames.end());
+  std::vector<std::string> projectedNames;
+  std::vector<TypePtr> projectedTypes;
+  for (uint32_t i = 0; i < fullOutSchema->size(); ++i) {
+    const auto& name = fullOutSchema->nameOf(i);
+    if (outputColumnNames.empty() || outputColumnNameSet.count(name) > 0) {
+      projectedNames.push_back(name);
+      projectedTypes.push_back(fullOutSchema->childAt(i));
+    }
+  }
+  RowTypePtr projectedSchema =
+      ROW(std::move(projectedNames), std::move(projectedTypes));
+  const bool isPruned = projectedSchema->size() < fullOutSchema->size();
+
   CursorParameters params;
   params.serialExecution = true;
 
-  auto builder = PlanBuilder()
-                     .filtersAsNode(useFiltersAsNode)
-                     .tableScanWithPushDown(
-                         fullOutSchema,
-                         /*pushdownConfig=*/pushdownConfig,
-                         tableSchema,
-                         {});
-
-  if (insertProjectToBlockPushdown &&
-      pushdownConfig.aggregationConfig.has_value()) {
-    std::vector<std::string> projectExprs;
-    for (const auto& name : fullOutSchema->names()) {
-      projectExprs.push_back(name);
+  PlanBuilder builder;
+  builder.filtersAsNode(useFiltersAsNode);
+  if (!useFiltersAsNode && isPruned) {
+    // Pushdown path with pruning: output only the projected columns while
+    // still reading every column so the dropped columns can be used for
+    // pushed-down filters. The assignments map covers all columns of the full
+    // output schema; the extra columns (not in 'projectedSchema') are read
+    // for filters but not output, exercising the filter-only-column path.
+    connector::ColumnHandleMap assignments;
+    for (uint32_t i = 0; i < fullOutSchema->size(); ++i) {
+      const auto& name = fullOutSchema->nameOf(i);
+      const auto& type = fullOutSchema->childAt(i);
+      assignments.emplace(
+          name,
+          std::make_shared<connector::hive::HiveColumnHandle>(
+              name,
+              connector::hive::FileColumnHandle::ColumnType::kRegular,
+              type,
+              type));
     }
-    builder.project(projectExprs);
+    builder.tableScanWithPushDown(
+        projectedSchema,
+        /*pushdownConfig=*/pushdownConfig,
+        tableSchema, // Original schema as dataColumns
+        assignments);
+  } else {
+    builder.tableScanWithPushDown(
+        fullOutSchema, // Use struct schema for flatmap reading
+        /*pushdownConfig=*/pushdownConfig,
+        tableSchema, // Original schema as dataColumns
+        {});
+  }
+
+  // Reference path: when filters are realized as a FilterNode, the filtered
+  // columns must be output by the scan so the FilterNode can reference them.
+  // Add a Project to drop the filter-only columns and emit the same projected
+  // schema as the pushdown path. Projecting also blocks aggregation pushdown,
+  // so the identity-project case for aggregation is preserved when not pruned.
+  if (useFiltersAsNode &&
+      (isPruned ||
+       (insertProjectToBlockPushdown &&
+        pushdownConfig.aggregationConfig.has_value()))) {
+    builder.project(
+        isPruned ? projectedSchema->names() : fullOutSchema->names());
   }
 
   // Add aggregation if enabled in pushdown config

--- a/velox/exec/tests/TableEvolutionFuzzer.h
+++ b/velox/exec/tests/TableEvolutionFuzzer.h
@@ -65,6 +65,31 @@ class TableEvolutionFuzzer {
   static const std::vector<dwio::common::FileFormat> parseFileFormats(
       std::string input);
 
+  /// Returns true if 'columnName' is referenced by 'aggregationConfig's
+  /// grouping keys or aggregate expressions.
+  static bool isColumnUsedByAggregation(
+      const std::string& columnName,
+      const AggregationConfig& aggregationConfig);
+
+  /// Selects a random subset of 'filteredColumns' to read filter-only (filtered
+  /// but dropped from the scan output), exercising the selective reader's
+  /// filter-only column path. A column is eligible only when it is a top-level,
+  /// non-map, non-bucket column whose type is identical across all
+  /// 'perEvolutionSchemas', and, when 'aggregationConfig' is set, is not used
+  /// by the aggregation. Each eligible column is dropped with probability 1/2.
+  static folly::F14FastSet<std::string> selectFilterOnlyColumns(
+      const RowTypePtr& schema,
+      const std::unordered_set<std::string>& filteredColumns,
+      const std::vector<column_index_t>& bucketColumnIndices,
+      const std::vector<RowTypePtr>& perEvolutionSchemas,
+      const std::optional<AggregationConfig>& aggregationConfig,
+      FuzzerGenerator& rng);
+
+  /// Returns the column names in 'schema' order, excluding 'droppedColumns'.
+  static std::vector<std::string> projectedColumnNames(
+      const RowTypePtr& schema,
+      const folly::F14FastSet<std::string>& droppedColumns);
+
   void run();
 
   virtual ~TableEvolutionFuzzer() = default;
@@ -130,13 +155,18 @@ class TableEvolutionFuzzer {
 
   VectorPtr liftToType(const VectorPtr& input, const TypePtr& type);
 
+  /// Builds a TableScan TaskCursor for one setup. When 'useFiltersAsNode' is
+  /// true the filters are realized as a separate FilterNode above the scan (the
+  /// reference plan that the pushdown plan is validated against); when false
+  /// the filters are pushed down into the TableScan (the plan under test).
   std::unique_ptr<TaskCursor> makeScanTask(
       const RowTypePtr& tableSchema,
       std::vector<Split> splits,
       const PushdownConfig& pushdownConfig,
       bool useFiltersAsNode,
       bool insertProjectToBlockPushdown,
-      const RowTypePtr& fullOutSchema);
+      const RowTypePtr& fullOutSchema,
+      const std::vector<std::string>& outputColumnNames);
 
   /// Builds schema for flatmap as struct reading by converting selected map
   /// columns to struct types.

--- a/velox/exec/tests/TableEvolutionFuzzerTest.cpp
+++ b/velox/exec/tests/TableEvolutionFuzzerTest.cpp
@@ -99,6 +99,83 @@ TEST(TableEvolutionFuzzerTest, noEvolutionBoundedRun) {
   }
 }
 
+// A column is "used by aggregation" if it is a grouping key or appears in an
+// aggregate expression.
+TEST(TableEvolutionFuzzerTest, isColumnUsedByAggregation) {
+  AggregationConfig aggConfig;
+  aggConfig.groupingKeys = {"g0", "g1"};
+  aggConfig.aggregates = {"sum(a0)", "max(a1)"};
+
+  EXPECT_TRUE(TableEvolutionFuzzer::isColumnUsedByAggregation("g0", aggConfig));
+  EXPECT_TRUE(TableEvolutionFuzzer::isColumnUsedByAggregation("g1", aggConfig));
+  EXPECT_TRUE(TableEvolutionFuzzer::isColumnUsedByAggregation("a0", aggConfig));
+  EXPECT_TRUE(TableEvolutionFuzzer::isColumnUsedByAggregation("a1", aggConfig));
+  EXPECT_FALSE(
+      TableEvolutionFuzzer::isColumnUsedByAggregation("c0", aggConfig));
+}
+
+// projectedColumnNames returns the schema's columns in order, minus the dropped
+// set; names not present in the schema are ignored.
+TEST(TableEvolutionFuzzerTest, projectedColumnNames) {
+  auto schema = ROW({{"c0", INTEGER()}, {"c1", BIGINT()}, {"c2", VARCHAR()}});
+
+  EXPECT_EQ(
+      TableEvolutionFuzzer::projectedColumnNames(schema, {"c1"}),
+      (std::vector<std::string>{"c0", "c2"}));
+  EXPECT_EQ(
+      TableEvolutionFuzzer::projectedColumnNames(schema, {}),
+      (std::vector<std::string>{"c0", "c1", "c2"}));
+  EXPECT_EQ(
+      TableEvolutionFuzzer::projectedColumnNames(schema, {"absent"}),
+      (std::vector<std::string>{"c0", "c1", "c2"}));
+}
+
+// Only a top-level, non-map, non-bucket, type-stable, non-aggregation filtered
+// column is eligible to be dropped filter-only; everything else is always
+// projected. Across many seeds the eligible column is sometimes dropped and the
+// ineligible ones never are.
+TEST(TableEvolutionFuzzerTest, selectFilterOnlyColumns) {
+  auto schema = ROW({
+      {"c_scalar", INTEGER()}, // eligible
+      {"c_map", MAP(VARCHAR(), INTEGER())}, // map -> excluded
+      {"c_bucket", INTEGER()}, // bucket column -> excluded
+      {"c_unstable", DOUBLE()}, // differs from an earlier setup -> excluded
+      {"c_agg", INTEGER()}, // used by the aggregation -> excluded
+      {"c_unfiltered", INTEGER()}, // not filtered -> excluded
+  });
+  // An earlier setup where c_unstable (positional index 3) was REAL.
+  auto earlierSetup = ROW({
+      {"c_scalar", INTEGER()},
+      {"c_map", MAP(VARCHAR(), INTEGER())},
+      {"c_bucket", INTEGER()},
+      {"c_unstable", REAL()},
+      {"c_agg", INTEGER()},
+      {"c_unfiltered", INTEGER()},
+  });
+  const std::unordered_set<std::string> filtered = {
+      "c_scalar", "c_map", "c_bucket", "c_unstable", "c_agg"};
+  const std::vector<column_index_t> bucketColumnIndices = {2}; // c_bucket
+  AggregationConfig aggConfig;
+  aggConfig.aggregates = {"sum(c_agg)"};
+
+  bool everDroppedScalar = false;
+  for (uint32_t seed = 0; seed < 50; ++seed) {
+    FuzzerGenerator rng(seed);
+    const auto dropped = TableEvolutionFuzzer::selectFilterOnlyColumns(
+        schema,
+        filtered,
+        bucketColumnIndices,
+        {schema, earlierSetup},
+        aggConfig,
+        rng);
+    for (const auto& name : dropped) {
+      EXPECT_EQ(name, "c_scalar") << "unexpectedly dropped: " << name;
+    }
+    everDroppedScalar |= dropped.count("c_scalar") > 0;
+  }
+  EXPECT_TRUE(everDroppedScalar);
+}
+
 TEST(TableEvolutionFuzzerTest, run) {
   auto pool = memory::memoryManager()->addLeafPool("TableEvolutionFuzzer");
   exec::test::TableEvolutionFuzzer::Config config;


### PR DESCRIPTION
Summary:

Adds filter-no-project coverage to TableEvolutionFuzzer: run() drops a random subset of filtered columns from the scan projection (eligible = filtered AND type-stable across setups AND not a map/bucket/aggregation column), and makeScanTask reads those columns for their pushed-down filters but does not project them (pushdown plan: all-column assignments with a pruned outputType; reference plan: a Project that drops them). This is the first coverage of the selective reader's filter-only column path, which the validation service never exercised (it always projects the filter columns).

The eligibility logic is factored into small static helpers on TableEvolutionFuzzer -- selectFilterOnlyDroppedColumns, isColumnUsedByAggregation, and projectedColumnNames -- which are unit-tested directly.

The type-stability gate is intentional: it keeps the dropped filter-only columns type-stable, sidestepping a separate real connector bug (filter-only promoted columns read wrong via adaptColumns -- out of scope here), documented in-code. A reader-level repro of that connector bug lives in the separate "Add repro for filter-only schema-evolution wrong-results bug" diff.

Builds on the no-evolution mode + flatmap-as-struct double-draw fix in the parent diff (which the no-evolution mode is what surfaced).

Reviewed By: xiaoxmeng

Differential Revision: D110052631


