### PR TITLE
fix(spark): Align timestamp to integral cast with Spark overflow semantics under ANSI

### DIFF
--- a/velox/docs/functions/spark/conversion.rst
+++ b/velox/docs/functions/spark/conversion.rst
@@ -152,7 +152,13 @@ Valid examples
 From timestamp
 ^^^^^^^^^^^^^^
 
-Casting timestamp as integral types returns the number of seconds by converting timestamp as microseconds, dividing by the number of microseconds in a second, and then rounding down to the nearest second since the epoch (1970-01-01 00:00:00 UTC).
+*(ANSI compliant)*
+
+Casting timestamp as integral types returns the number of seconds by converting timestamp as microseconds,
+dividing by the number of microseconds in a second, and then rounding down to the nearest second since the
+epoch (1970-01-01 00:00:00 UTC).
+
+In ANSI mode, conversion overflow causes an exception to be thrown; otherwise, returns NULL.
 
 Valid examples
 
@@ -164,8 +170,13 @@ Valid examples
   SELECT cast(cast('2000-01-01 12:21:56' as timestamp) as bigint); -- 946684916
   SELECT cast(cast('2025-02-25 08:00:26.88' as timestamp) as bigint); -- 1740470426
   SELECT cast(cast('2025-02-25 08:00:26.88' as timestamp) as integer); -- 1740470426
-  SELECT cast(cast('2025-02-25 08:00:26.88' as timestamp) as smallint); -- 30874
-  SELECT cast(cast('2025-02-25 08:00:26.88' as timestamp) as tinyint); -- -102
+
+Invalid examples
+
+::
+
+  SELECT cast(cast('2025-02-25 08:00:26.88' as timestamp) as smallint); -- NULL (ANSI OFF) / ERROR (ANSI ON)
+  SELECT cast(cast('2025-02-25 08:00:26.88' as timestamp) as tinyint); -- NULL (ANSI OFF) / ERROR (ANSI ON)
 
 Cast to Boolean
 ---------------

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -192,10 +192,6 @@ void CastExpr::applyCastKernel(
          ToKind == TypeKind::INTEGER || ToKind == TypeKind::BIGINT) &&
         FromKind == TypeKind::TIMESTAMP) {
       using To = typename TypeTraits<ToKind>::NativeType;
-      // The hook returns the converted value as int64_t and reports overflow
-      // against the target type 'To' as an error. setResultOrStatus then either
-      // throws (ANSI) or sets NULL (try_cast), and narrows the value to 'To'
-      // when writing to the result vector.
       const auto castResult =
           hooks_->template castTimestampToInt<To>(inputRowValue);
       setResultOrStatus(castResult, row);

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -202,44 +202,18 @@ void CastExpr::applyCastKernel(
         (ToKind == TypeKind::TINYINT || ToKind == TypeKind::SMALLINT ||
          ToKind == TypeKind::INTEGER || ToKind == TypeKind::BIGINT) &&
         FromKind == TypeKind::TIMESTAMP) {
+      using To = typename TypeTraits<ToKind>::NativeType;
       const auto castResult = hooks_->castTimestampToInt(inputRowValue);
-      if (ToKind == TypeKind::BIGINT) {
-        result->set(row, castResult.value());
-        return;
+      const auto value = castResult.value();
+      if (value == static_cast<To>(value)) {
+        result->set(row, static_cast<To>(value));
+      } else {
+        setError(castOverflowErrorMessage(
+            std::to_string(value),
+            input->type()->toString(),
+            result->type()->toString()));
       }
-      if (ToKind == TypeKind::INTEGER) {
-        if (castResult.value() == static_cast<int>(castResult.value())) {
-          result->set(row, castResult.value());
-        } else {
-          setError(castOverflowErrorMessage(
-              std::to_string(castResult.value()),
-              input->type()->toString(),
-              result->type()->toString()));
-        }
-        return;
-      }
-      if (ToKind == TypeKind::SMALLINT) {
-        if (castResult.value() == static_cast<int16_t>(castResult.value())) {
-          result->set(row, castResult.value());
-        } else {
-          setError(castOverflowErrorMessage(
-              std::to_string(castResult.value()),
-              input->type()->toString(),
-              result->type()->toString()));
-        }
-        return;
-      }
-      if (ToKind == TypeKind::TINYINT) {
-        if (castResult.value() == static_cast<int8_t>(castResult.value())) {
-          result->set(row, castResult.value());
-        } else {
-          setError(castOverflowErrorMessage(
-              std::to_string(castResult.value()),
-              input->type()->toString(),
-              result->type()->toString()));
-        }
-        return;
-      }
+      return;
     }
 
     if constexpr (

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -167,17 +167,6 @@ void CastExpr::applyCastKernel(
         wrapException);
   };
 
-  auto castOverflowErrorMessage = [](const std::string& value,
-                                     const std::string& sourceTypeName,
-                                     const std::string& targetTypeName) {
-    return fmt::format(
-        "The value {} of the type \"{}\" cannot be cast to \"{}\" due to an "
-        "overflow. Use `try_cast` to tolerate overflow and return NULL instead.",
-        value,
-        sourceTypeName,
-        targetTypeName);
-  };
-
   try {
     auto inputRowValue = input->valueAt(row);
 
@@ -203,16 +192,13 @@ void CastExpr::applyCastKernel(
          ToKind == TypeKind::INTEGER || ToKind == TypeKind::BIGINT) &&
         FromKind == TypeKind::TIMESTAMP) {
       using To = typename TypeTraits<ToKind>::NativeType;
-      const auto castResult = hooks_->castTimestampToInt(inputRowValue);
-      const auto value = castResult.value();
-      if (value == static_cast<To>(value)) {
-        result->set(row, static_cast<To>(value));
-      } else {
-        setError(castOverflowErrorMessage(
-            std::to_string(value),
-            input->type()->toString(),
-            result->type()->toString()));
-      }
+      // The hook returns the converted value as int64_t and reports overflow
+      // against the target type 'To' as an error. setResultOrStatus then either
+      // throws (ANSI) or sets NULL (try_cast), and narrows the value to 'To'
+      // when writing to the result vector.
+      const auto castResult =
+          hooks_->template castTimestampToInt<To>(inputRowValue);
+      setResultOrStatus(castResult, row);
       return;
     }
 

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -167,6 +167,17 @@ void CastExpr::applyCastKernel(
         wrapException);
   };
 
+  auto castOverflowErrorMessage = [](const std::string& value,
+                                     const std::string& sourceTypeName,
+                                     const std::string& targetTypeName) {
+    return fmt::format(
+        "The value {} of the type \"{}\" cannot be cast to \"{}\" due to an "
+        "overflow. Use `try_cast` to tolerate overflow and return NULL instead.",
+        value,
+        sourceTypeName,
+        targetTypeName);
+  };
+
   try {
     auto inputRowValue = input->valueAt(row);
 
@@ -192,8 +203,43 @@ void CastExpr::applyCastKernel(
          ToKind == TypeKind::INTEGER || ToKind == TypeKind::BIGINT) &&
         FromKind == TypeKind::TIMESTAMP) {
       const auto castResult = hooks_->castTimestampToInt(inputRowValue);
-      setResultOrStatus(castResult, row);
-      return;
+      if (ToKind == TypeKind::BIGINT) {
+        result->set(row, castResult.value());
+        return;
+      }
+      if (ToKind == TypeKind::INTEGER) {
+        if (castResult.value() == static_cast<int>(castResult.value())) {
+          result->set(row, castResult.value());
+        } else {
+          setError(castOverflowErrorMessage(
+              std::to_string(castResult.value()),
+              input->type()->toString(),
+              result->type()->toString()));
+        }
+        return;
+      }
+      if (ToKind == TypeKind::SMALLINT) {
+        if (castResult.value() == static_cast<int16_t>(castResult.value())) {
+          result->set(row, castResult.value());
+        } else {
+          setError(castOverflowErrorMessage(
+              std::to_string(castResult.value()),
+              input->type()->toString(),
+              result->type()->toString()));
+        }
+        return;
+      }
+      if (ToKind == TypeKind::TINYINT) {
+        if (castResult.value() == static_cast<int8_t>(castResult.value())) {
+          result->set(row, castResult.value());
+        } else {
+          setError(castOverflowErrorMessage(
+              std::to_string(castResult.value()),
+              input->type()->toString(),
+              result->type()->toString()));
+        }
+        return;
+      }
     }
 
     if constexpr (

--- a/velox/expression/CastHooks.h
+++ b/velox/expression/CastHooks.h
@@ -52,6 +52,9 @@ class CastHooks {
   virtual Expected<int64_t> castTimestampToBigint(
       Timestamp timestamp) const = 0;
 
+  // Returns the converted value as int64_t and reports overflow against the
+  // target type 'To' as an error. setResultOrStatus then either throws (ANSI)
+  // or sets NULL (try_cast) for the overflow case.
   template <typename T>
   Expected<int64_t> castTimestampToInt(Timestamp timestamp) const {
     auto result = castTimestampToBigint(timestamp);

--- a/velox/expression/CastHooks.h
+++ b/velox/expression/CastHooks.h
@@ -52,9 +52,9 @@ class CastHooks {
   virtual Expected<int64_t> castTimestampToBigint(
       Timestamp timestamp) const = 0;
 
-  // Returns the converted value as int64_t and reports overflow against the
-  // target type 'To' as an error. setResultOrStatus then either throws (ANSI)
-  // or sets NULL (try_cast) for the overflow case.
+  /// Returns the converted value as int64_t and reports overflow against the
+  /// target type 'To' as an error. setResultOrStatus then either throws (ANSI)
+  /// or sets NULL (try_cast) for the overflow case.
   template <typename T>
   Expected<int64_t> castTimestampToInt(Timestamp timestamp) const {
     auto result = castTimestampToBigint(timestamp);

--- a/velox/expression/CastHooks.h
+++ b/velox/expression/CastHooks.h
@@ -16,7 +16,13 @@
 
 #pragma once
 
+#include <type_traits>
+
+#include <folly/Expected.h>
+
+#include "velox/common/base/Status.h"
 #include "velox/expression/StringWriter.h"
+#include "velox/type/CppToType.h"
 #include "velox/type/Timestamp.h"
 #include "velox/type/tz/TimeZoneMap.h"
 
@@ -43,7 +49,29 @@ class CastHooks {
 
   virtual Expected<Timestamp> castIntToTimestamp(int64_t seconds) const = 0;
 
-  virtual Expected<int64_t> castTimestampToInt(Timestamp timestamp) const = 0;
+  virtual Expected<int64_t> castTimestampToBigint(
+      Timestamp timestamp) const = 0;
+
+  template <typename T>
+  Expected<int64_t> castTimestampToInt(Timestamp timestamp) const {
+    auto result = castTimestampToBigint(timestamp);
+    if (result.hasError()) {
+      return result;
+    }
+
+    const int64_t value = result.value();
+    if (value != static_cast<int64_t>(static_cast<T>(value))) {
+      return folly::makeUnexpected(
+          Status::UserError(
+              "The value {} of the type \"{}\" cannot be cast to \"{}\" due to an "
+              "overflow. Use `try_cast` to tolerate overflow and return NULL "
+              "instead.",
+              value,
+              TypeTraits<TypeKind::TIMESTAMP>::name,
+              CppToType<T>::name));
+    }
+    return value;
+  }
 
   virtual Expected<std::optional<Timestamp>> castDoubleToTimestamp(
       double seconds) const = 0;

--- a/velox/expression/PrestoCastHooks.cpp
+++ b/velox/expression/PrestoCastHooks.cpp
@@ -59,7 +59,7 @@ Expected<Timestamp> PrestoCastHooks::castIntToTimestamp(
       Status::UserError("Conversion to Timestamp is not supported"));
 }
 
-Expected<int64_t> PrestoCastHooks::castTimestampToInt(
+Expected<int64_t> PrestoCastHooks::castTimestampToBigint(
     Timestamp /*timestamp*/) const {
   return folly::makeUnexpected(
       Status::UserError("Conversion from Timestamp to Int is not supported"));

--- a/velox/expression/PrestoCastHooks.h
+++ b/velox/expression/PrestoCastHooks.h
@@ -34,7 +34,7 @@ class PrestoCastHooks : public CastHooks {
 
   Expected<Timestamp> castBooleanToTimestamp(bool seconds) const override;
 
-  Expected<int64_t> castTimestampToInt(Timestamp timestamp) const override;
+  Expected<int64_t> castTimestampToBigint(Timestamp timestamp) const override;
 
   Expected<std::optional<Timestamp>> castDoubleToTimestamp(
       double seconds) const override;

--- a/velox/functions/sparksql/specialforms/SparkCastExpr.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastExpr.cpp
@@ -118,6 +118,9 @@ bool SparkCastCallToSpecialForm::isAnsiSupported(
       return true;
     }
   }
+  if (fromType->isTimestamp() && isIntegralType(toType)) {
+    return true;
+  }
 
   return false;
 }

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
@@ -78,7 +78,7 @@ Expected<Timestamp> SparkCastHooks::castIntToTimestamp(int64_t seconds) const {
   return castNumberToTimestamp(seconds);
 }
 
-Expected<int64_t> SparkCastHooks::castTimestampToInt(
+Expected<int64_t> SparkCastHooks::castTimestampToBigint(
     Timestamp timestamp) const {
   auto micros = timestamp.toMicros();
   if (micros < 0) {

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.h
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.h
@@ -36,7 +36,7 @@ class SparkCastHooks : public exec::CastHooks {
   /// number of seconds since the epoch (1970-01-01 00:00:00 UTC).
   Expected<Timestamp> castIntToTimestamp(int64_t seconds) const override;
 
-  Expected<int64_t> castTimestampToInt(Timestamp timestamp) const override;
+  Expected<int64_t> castTimestampToBigint(Timestamp timestamp) const override;
 
   /// When casting double as timestamp, the input is treated as
   /// the number of seconds since the epoch (1970-01-01 00:00:00 UTC).

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -399,8 +399,11 @@ class SparkCastExprTest : public functions::test::CastBaseTest {
         }));
   }
 
+  // Overflow cases for casting timestamp to tinyint/smallint/integer. Under
+  // ANSI OFF (or try_cast), values that do not fit the target type return NULL.
   template <typename T>
-  void testTimestampToIntegralCastOverflow(std::vector<T> expected) {
+  void testTimestampToIntegralCastOverflow(
+      std::vector<std::optional<T>> expected) {
     testCast(
         makeFlatVector<Timestamp>({
             Timestamp(1740470426, 0),
@@ -408,7 +411,7 @@ class SparkCastExprTest : public functions::test::CastBaseTest {
             Timestamp(9223372036854, 775'807'000),
             Timestamp(-9223372036855, 224'192'000),
         }),
-        makeFlatVector<T>(expected));
+        makeNullableFlatVector<T>(expected));
   }
 
   void testTimestampToInt() {
@@ -1158,6 +1161,22 @@ TEST_F(SparkCastExprTestAnsiOn, timestampToInt) {
   testTimestampToInt();
 }
 
+TEST_F(SparkCastExprTestAnsiOn, timestampToIntOverflow) {
+  // Under ANSI ON, values that overflow the target type throw instead of
+  // returning NULL.
+  auto testOverflowThrows = [this](const std::string& type, Timestamp value) {
+    auto input = makeRowVector({makeFlatVector<Timestamp>({value})});
+    VELOX_ASSERT_THROW(
+        (evaluate(fmt::format("cast(c0 as {})", type), input)),
+        "due to an overflow");
+  };
+
+  testOverflowThrows("tinyint", Timestamp(1740470426, 0));
+  testOverflowThrows("smallint", Timestamp(1740470426, 0));
+  testOverflowThrows("integer", Timestamp(9223372036854, 775'807'000));
+  testOverflowThrows("integer", Timestamp(-9223372036855, 224'192'000));
+}
+
 TEST_F(SparkCastExprTestAnsiOn, timestampToString) {
   testTimestampToString();
 }
@@ -1423,23 +1442,24 @@ TEST_F(SparkCastExprTestAnsiOff, timestampToInt) {
   testTimestampToInt();
   testCast<Timestamp, int64_t>(
       "bigint", {Timestamp(9223372036856, 0)}, {std::nullopt});
+  // Values that overflow the target type return NULL when ANSI is off.
   testTimestampToIntegralCastOverflow<int8_t>({
-      -102,
-      -1,
-      -10,
-      9,
+      std::nullopt,
+      std::nullopt,
+      std::nullopt,
+      std::nullopt,
   });
   testTimestampToIntegralCastOverflow<int16_t>({
-      30874,
-      -1,
-      23286,
-      -23287,
+      std::nullopt,
+      std::nullopt,
+      std::nullopt,
+      std::nullopt,
   });
   testTimestampToIntegralCastOverflow<int32_t>({
       1740470426,
       2147483647,
-      2077252342,
-      -2077252343,
+      std::nullopt,
+      std::nullopt,
   });
 }
 


### PR DESCRIPTION
This PR introduces fixes to align with Spark's timestamp-to-integral cast behavior
under ANSI mode. And the error message is mostly aligned with Spark for overflow
cases. Additionally, it has a positive side effect: the cast function now returns NULL
for overflow cases in non-ANSI mode, consistent with Spark 4.0.
Refer to the following Spark patch. https://github.com/apache/spark/commit/f866549a5aa86f379cb71732b97fa547f2c4eb0a
