### PR TITLE
fix: Handle nested leaf columns by dotted path (#17979)

### DIFF
--- a/velox/dwio/parquet/reader/Metadata.cpp
+++ b/velox/dwio/parquet/reader/Metadata.cpp
@@ -450,6 +450,11 @@ std::vector<thrift::Encoding> ColumnChunkMetaDataPtr::encodings() const {
       thriftColumnChunkPtr(ptr_)->meta_data()->encodings());
 }
 
+std::vector<std::string> ColumnChunkMetaDataPtr::pathInSchema() const {
+  return *apache::thrift::can_throw(
+      thriftColumnChunkPtr(ptr_)->meta_data()->path_in_schema());
+}
+
 int64_t ColumnChunkMetaDataPtr::totalUncompressedSize() const {
   return apache::thrift::can_throw(
       *apache::thrift::can_throw(thriftColumnChunkPtr(ptr_)->meta_data())

--- a/velox/dwio/parquet/reader/Metadata.h
+++ b/velox/dwio/parquet/reader/Metadata.h
@@ -68,6 +68,12 @@ class ColumnChunkMetaDataPtr {
   /// Returns the list of encodings used for all pages in this column chunk.
   std::vector<thrift::Encoding> encodings() const;
 
+  /// Returns the column's physical path in the file schema as ordered segments,
+  /// e.g. {"tags", "list", "element"} or {"lookup", "key_value", "key"}. Unlike
+  /// the logical row type, this includes the synthetic repeated-group levels
+  /// ("list", "key_value") that Parquet inserts for arrays and maps.
+  std::vector<std::string> pathInSchema() const;
+
   /// Total byte size of all the compressed (and potentially encrypted)
   /// column data in this row group.
   /// This information is optional and may be 0 if omitted.


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookincubator/axiom/pull/1525

Fixes how column names show up for nested fields (structs, lists, maps) when you inspect a Parquet file's per-column details. Now each nested column is labeled by its real path inside the file.

Example:
```
  SELECT column_id, path, encodings
  FROM file."parquet"."nested.parquet$column_chunks" ORDER BY column_id;

   column_id | path                      | encodings
  -----------+---------------------------+-----------------------
   0         | [id]                      | [RLE, PLAIN]
   3         | [address, city]           | [RLE, PLAIN]
   5         | [tags, list, element]     | [RLE, RLE_DICTIONARY]
   6         | [lookup, key_value, key]  | [RLE, RLE_DICTIONARY]
```

Reviewed By: mbasmanova

Differential Revision: D109186690
