### PR TITLE
build(cmake): Fix `velox_install_library_headers` build portability

### DIFF
--- a/CMake/VeloxUtils.cmake
+++ b/CMake/VeloxUtils.cmake
@@ -51,7 +51,7 @@ function(velox_install_library_headers)
     cmake_path(
       RELATIVE_PATH
       CMAKE_CURRENT_SOURCE_DIR
-      BASE_DIRECTORY "${CMAKE_SOURCE_DIR}"
+      BASE_DIRECTORY "${PROJECT_SOURCE_DIR}"
       OUTPUT_VARIABLE _hdr_dir
     )
     install(FILES ${_hdrs} DESTINATION include/${_hdr_dir})


### PR DESCRIPTION
This is to address https://github.com/facebookincubator/velox/pull/17797#pullrequestreview-4573500561.

In function `velox_install_library_headers`, `_hdr_dir` is wrong when Velox is a CMake subproject.

The patch fixes the issue.

Before:

<img width="1966" height="400" alt="image" src="https://github.com/user-attachments/assets/17c85705-cd5e-44ed-9e21-e65d01b16418" />

After:

<img width="1966" height="400" alt="image" src="https://github.com/user-attachments/assets/8b0cfbae-f66b-4844-a76e-83d7627db494" />
