### PR TITLE
build: Fix double building of abseil on Macs and forced reinstalls of abseil and fbthrift

### DIFF
--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -91,7 +91,9 @@ function install_fbthrift {
   fi
   (
     cd "$DEPENDENCY_DIR"/fbthrift || exit 1
-    git apply "${VELOX_FBTHRIFT_CMAKE_PATCH}" || exit 1
+    # Skip applying the patch if it is already applied.
+    git apply --reverse --check "${VELOX_FBTHRIFT_CMAKE_PATCH}" 2>/dev/null ||
+      git apply "${VELOX_FBTHRIFT_CMAKE_PATCH}" || exit 1
   )
 
   # Apple Clang's libc++ no longer defines _LIBCPP_HAS_NO_ASAN (renamed to
@@ -168,6 +170,14 @@ function install_ranges_v3 {
 }
 
 function install_abseil {
+  # Abseil is a dependency of multiple libraries, so install_abseil can be
+  # invoked more than once per run. Build it only on the first call within a
+  # run.
+  if [ -n "${VELOX_ABSEIL_INSTALLED:-}" ]; then
+    echo "Abseil already installed in this run, skipping."
+    return 0
+  fi
+  VELOX_ABSEIL_INSTALLED=1
   wget_and_untar https://github.com/abseil/abseil-cpp/archive/refs/tags/"${ABSEIL_VERSION}".tar.gz abseil-cpp
   local OS
   OS=$(uname)
@@ -175,7 +185,10 @@ function install_abseil {
     ABSOLUTE_SCRIPTDIR=$(realpath "$SCRIPT_DIR")
     (
       cd "${DEPENDENCY_DIR}/abseil-cpp" || exit 1
-      git apply $ABSOLUTE_SCRIPTDIR/../CMake/resolve_dependency_modules/absl/absl-macos.patch
+      PATCH_FILE="$ABSOLUTE_SCRIPTDIR/../CMake/resolve_dependency_modules/absl/absl-macos.patch"
+      # Skip applying the patch if it is already applied.
+      git apply --reverse --check "$PATCH_FILE" 2>/dev/null ||
+        git apply "$PATCH_FILE"
     )
   fi
   cmake_install_dir abseil-cpp \


### PR DESCRIPTION
Today, when setting up dependencies on Macs, we end up installing abseil twice, once because it's a transitive dependency of protobuf and once because it's a transitive dependency of re2. Worse we need to patch abseil, and the patch fails when it's already been applied, so we need to delete it, redownload it, and rebuild it both times.

This PR fixes both issues:
1) install_abseil uses a variable to keep track if it's already been called, so if we call it twice, it only runs the first time.
2) when patching abseil, we first check if the patch has already been applied,  and only patch it if not (I applied the same fix to install_fbthrift which applies a patch similarly)

I ran setup-macos.sh with a clean checkout and verified it only installed abseil once, and both abseil and fbthrift had the patches applied. I then ran it again and verified it checked if the patches were applied and did not attempt to reapply.

In both cases I verified a make debug succeeded aftwerwards.