### PR TITLE
perf(parquet): Cache Arrow schema across write() calls

### DIFF
--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -513,39 +513,41 @@ void Writer::write(const VectorPtr& data) {
   }
 
   ArrowArray array;
-  ArrowSchema schema;
   exportToArrow(exportData, array, generalPool_.get(), options_);
-  exportToArrow(exportData, schema, options_);
 
-  // Convert the arrow schema to Schema and then update the column names based
-  // on schema_.
-  auto arrowSchema = ::arrow::ImportSchema(&schema).ValueOrDie();
-  common::testutil::TestValue::adjust(
-      "facebook::velox::parquet::Writer::write", arrowSchema.get());
-  std::vector<std::shared_ptr<::arrow::Field>> newFields;
-  auto childSize = schema_->size();
-  if (!parquetFieldIds_.empty()) {
-    VELOX_CHECK(childSize == parquetFieldIds_.size());
-  }
-  for (auto i = 0; i < childSize; i++) {
-    newFields.push_back(updateFieldNameAndIdRecursive(
-        arrowSchema->fields()[i],
-        *schema_->childAt(i),
-        !parquetFieldIds_.empty() ? &parquetFieldIds_.at(i) : nullptr,
-        schema_->nameOf(i)));
-  }
-
-  PARQUET_ASSIGN_OR_THROW(
-      auto recordBatch,
-      ::arrow::ImportRecordBatch(&array, ::arrow::schema(newFields)));
   if (!arrowContext_->schema) {
-    arrowContext_->schema = recordBatch->schema();
+    // First batch: export and fix up the Arrow schema, then cache it.
+    ArrowSchema schema;
+    exportToArrow(exportData, schema, options_);
+
+    auto arrowSchema = ::arrow::ImportSchema(&schema).ValueOrDie();
+    common::testutil::TestValue::adjust(
+        "facebook::velox::parquet::Writer::write", arrowSchema.get());
+    std::vector<std::shared_ptr<::arrow::Field>> newFields;
+    auto childSize = schema_->size();
+    if (!parquetFieldIds_.empty()) {
+      VELOX_CHECK(childSize == parquetFieldIds_.size());
+    }
+    for (auto i = 0; i < childSize; i++) {
+      newFields.push_back(updateFieldNameAndIdRecursive(
+          arrowSchema->fields()[i],
+          *schema_->childAt(i),
+          !parquetFieldIds_.empty() ? &parquetFieldIds_.at(i) : nullptr,
+          schema_->nameOf(i)));
+    }
+
+    arrowContext_->schema = ::arrow::schema(newFields);
     for (int colIdx = 0; colIdx < arrowContext_->schema->num_fields();
          colIdx++) {
       arrowContext_->stagingChunks.push_back(
           std::vector<std::shared_ptr<::arrow::Array>>());
     }
   }
+
+  // Import the data array using the cached schema.
+  PARQUET_ASSIGN_OR_THROW(
+      auto recordBatch,
+      ::arrow::ImportRecordBatch(&array, arrowContext_->schema));
 
   auto bytes = data->estimateFlatSize();
   auto numRows = data->size();


### PR DESCRIPTION
Every `write()` call previously exported the Velox schema to an Arrow C struct, imported it back into an Arrow C++ Schema, then walked the full type tree in `updateFieldNameAndIdRecursive()` to fix field names and IDs. The schema never changes between batches — it is validated to be equivalent at the top of `write()`.

Compute the Arrow schema once on the first `write()` and cache it in `arrowContext_->schema`. Subsequent calls skip the schema export, import, and recursive fixup entirely, importing only the data array using the cached schema via the `ImportRecordBatch(array, schema)` overload.

**Benchmark results** (10K rows/batch, dict VARCHAR columns, debug build):

| Scenario | Before | After | Speedup |
|---|---|---|---|
| 5 cols, 50 batches | 148ms | 123ms | 1.21x |
| 10 cols, 50 batches | 277ms | 238ms | 1.16x |
| 20 cols, 50 batches | 603ms | 500ms | 1.21x |
| 10 cols, 200 batches | 1.13s | 1.02s | 1.11x |

Part of #17988.
