### PR TITLE
perf(parquet): Dictionary passthrough and selective flattening in Parquet writer

### DIFF
--- a/velox/dwio/parquet/tests/writer/ParquetWriterBenchmark.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterBenchmark.cpp
@@ -378,63 +378,6 @@ BENCHMARK(MapVarcharInt_10Entries) {
   benchMapColumn(10);
 }
 
-BENCHMARK_DRAW_LINE();
-
-// -- Parallel column writing benchmarks --
-// These exercise the enableParallelWrite option which compresses and encodes
-// columns concurrently using Arrow's internal CPU thread pool.
-
-// Writes with parallel column writing enabled.
-void writeParquetParallel(
-    const RowVectorPtr& data,
-    memory::MemoryPool* rootPool) {
-  auto leafPool = rootPool->addLeafChild("sink");
-  for (int32_t i = 0; i < kNumIterations; ++i) {
-    folly::BenchmarkSuspender suspender;
-    auto sink = std::make_unique<MemorySink>(
-        kSinkSize, FileSink::Options{.pool = leafPool.get()});
-    WriterOptions options;
-    options.memoryPool = rootPool;
-    auto parquetOptions = std::make_shared<ParquetWriterOptions>();
-    parquetOptions->enableParallelWrite = true;
-    options.formatSpecificOptions = parquetOptions;
-    suspender.dismiss();
-    auto writer = std::make_unique<parquet::Writer>(
-        std::move(sink), options, asRowType(data->type()));
-    writer->write(data);
-    writer->close();
-  }
-}
-
-void benchParallelColumns(int32_t numColumns) {
-  folly::BenchmarkSuspender suspender;
-  auto leafPool = rootPool->addLeafChild("bench");
-  test::VectorMaker maker(leafPool.get());
-
-  std::vector<VectorPtr> columns;
-  std::vector<std::string> names;
-
-  for (int32_t i = 0; i < numColumns; ++i) {
-    columns.push_back(makeDictVarchar(kNumRows, 100, leafPool.get()));
-    names.push_back(fmt::format("c{}", i));
-  }
-
-  auto data = maker.rowVector(std::move(names), columns);
-
-  suspender.dismiss();
-  writeParquetParallel(data, rootPool.get());
-}
-
-BENCHMARK(Parallel_5Cols) {
-  benchParallelColumns(5);
-}
-BENCHMARK(Parallel_10Cols) {
-  benchParallelColumns(10);
-}
-BENCHMARK(Parallel_20Cols) {
-  benchParallelColumns(20);
-}
-
 } // namespace
 
 int32_t main(int32_t argc, char* argv[]) {

--- a/velox/dwio/parquet/tests/writer/ParquetWriterBenchmark.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterBenchmark.cpp
@@ -58,9 +58,10 @@ VectorPtr makeDictVarchar(
     int32_t dictionarySize,
     memory::MemoryPool* pool) {
   test::VectorMaker maker(pool);
-  auto dictionary = maker.flatVector<std::string>(
-      dictionarySize,
-      [](vector_size_t i) { return fmt::format("value_{:06d}", i); });
+  auto dictionary =
+      maker.flatVector<std::string>(dictionarySize, [](vector_size_t i) {
+        return fmt::format("val_{}{}", i, std::string(i % 47, 'x'));
+      });
   auto indices = test::makeIndices(
       numRows,
       [dictionarySize](vector_size_t i) { return i % dictionarySize; },
@@ -89,7 +90,7 @@ VectorPtr makeDictInteger(
 VectorPtr makeFlatVarchar(vector_size_t numRows, memory::MemoryPool* pool) {
   test::VectorMaker maker(pool);
   return maker.flatVector<std::string>(numRows, [](vector_size_t i) {
-    return fmt::format("value_{:06d}", i % 10);
+    return fmt::format("val_{}{}", i, std::string(i % 47, 'x'));
   });
 }
 
@@ -376,6 +377,114 @@ BENCHMARK(MapVarcharInt_5Entries) {
 }
 BENCHMARK(MapVarcharInt_10Entries) {
   benchMapColumn(10);
+}
+
+BENCHMARK_DRAW_LINE();
+
+// -- Parallel column writing benchmarks --
+// Compare serial vs parallel writing with ZSTD compression.
+
+void writeParquetWithOptions(
+    const RowVectorPtr& data,
+    memory::MemoryPool* rootPool,
+    bool parallel,
+    common::CompressionKind compression) {
+  auto leafPool = rootPool->addLeafChild("sink");
+  auto sink = std::make_unique<MemorySink>(
+      kSinkSize, FileSink::Options{.pool = leafPool.get()});
+  WriterOptions options;
+  options.memoryPool = rootPool;
+  options.compressionKind = compression;
+  auto parquetOpts = std::make_shared<ParquetWriterOptions>();
+  parquetOpts->enableParallelWrite = parallel;
+  options.formatSpecificOptions = parquetOpts;
+  auto writer = std::make_unique<parquet::Writer>(
+      std::move(sink), options, asRowType(data->type()));
+  writer->write(data);
+  writer->close();
+}
+
+void benchParallelWrite(int32_t numCols, bool parallel) {
+  folly::BenchmarkSuspender suspender;
+  auto leafPool = rootPool->addLeafChild("bench");
+  test::VectorMaker maker(leafPool.get());
+  constexpr vector_size_t kParBatchSize = 100'000;
+
+  std::vector<VectorPtr> columns;
+  std::vector<std::string> names;
+
+  for (int32_t i = 0; i < numCols; ++i) {
+    columns.push_back(makeDictVarchar(kParBatchSize, 100, leafPool.get()));
+    names.push_back(fmt::format("c{}", i));
+  }
+
+  auto data = maker.rowVector(std::move(names), columns);
+
+  suspender.dismiss();
+  writeParquetWithOptions(
+      data, rootPool.get(), parallel, common::CompressionKind_ZSTD);
+}
+
+BENCHMARK(Serial_10Cols_Zstd) {
+  benchParallelWrite(10, false);
+}
+BENCHMARK(Parallel_10Cols_Zstd) {
+  benchParallelWrite(10, true);
+}
+BENCHMARK(Serial_20Cols_Zstd) {
+  benchParallelWrite(20, false);
+}
+BENCHMARK(Parallel_20Cols_Zstd) {
+  benchParallelWrite(20, true);
+}
+
+BENCHMARK_DRAW_LINE();
+
+// -- Flush estimation benchmarks --
+// These write many batches of dictionary data with a size-based flush policy.
+// With accurate size estimation, fewer row groups are created, meaning less
+// flush overhead and better compression.
+
+void benchFlushEstimation(int32_t numBatches) {
+  folly::BenchmarkSuspender suspender;
+  auto leafPool = rootPool->addLeafChild("bench");
+  test::VectorMaker maker(leafPool.get());
+  constexpr vector_size_t kBatchSize = 10'000;
+  constexpr int kDictSize = 10;
+
+  // Each batch: 10K rows of dict VARCHAR (retained ~40KB, flat estimate ~600KB)
+  auto dict = makeDictVarchar(kBatchSize, kDictSize, leafPool.get());
+  auto batch = maker.rowVector({"c0"}, {dict});
+
+  suspender.dismiss();
+
+  auto sinkPool = rootPool->addLeafChild("sink");
+  auto sink = std::make_unique<MemorySink>(
+      kSinkSize, FileSink::Options{.pool = sinkPool.get()});
+  WriterOptions options;
+  options.memoryPool = rootPool.get();
+  // 512KB byte threshold -- with flat estimate each 10K batch looks like
+  // ~600KB (exceeds threshold every batch). With retained size each batch
+  // is ~40KB so ~12 batches fit per row group.
+  options.flushPolicyFactory = []() {
+    return std::make_unique<DefaultFlushPolicy>(
+        /*rowsInRowGroup=*/1'000'000,
+        /*bytesInRowGroup=*/512 * 1'024);
+  };
+  options.formatSpecificOptions = std::make_shared<ParquetWriterOptions>();
+  auto writer = std::make_unique<parquet::Writer>(
+      std::move(sink), options, asRowType(batch->type()));
+  for (int32_t i = 0; i < numBatches; ++i) {
+    writer->write(batch);
+  }
+  writer->close();
+}
+
+BENCHMARK(FlushEstimation_50Batches) {
+  benchFlushEstimation(50);
+}
+BENCHMARK(FlushEstimation_200Batches) {
+  benchFlushEstimation(200);
 }
 
 } // namespace

--- a/velox/dwio/parquet/tests/writer/ParquetWriterBenchmark.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterBenchmark.cpp
@@ -378,6 +378,63 @@ BENCHMARK(MapVarcharInt_10Entries) {
   benchMapColumn(10);
 }
 
+BENCHMARK_DRAW_LINE();
+
+// -- Parallel column writing benchmarks --
+// These exercise the enableParallelWrite option which compresses and encodes
+// columns concurrently using Arrow's internal CPU thread pool.
+
+// Writes with parallel column writing enabled.
+void writeParquetParallel(
+    const RowVectorPtr& data,
+    memory::MemoryPool* rootPool) {
+  auto leafPool = rootPool->addLeafChild("sink");
+  for (int32_t i = 0; i < kNumIterations; ++i) {
+    folly::BenchmarkSuspender suspender;
+    auto sink = std::make_unique<MemorySink>(
+        kSinkSize, FileSink::Options{.pool = leafPool.get()});
+    WriterOptions options;
+    options.memoryPool = rootPool;
+    auto parquetOptions = std::make_shared<ParquetWriterOptions>();
+    parquetOptions->enableParallelWrite = true;
+    options.formatSpecificOptions = parquetOptions;
+    suspender.dismiss();
+    auto writer = std::make_unique<parquet::Writer>(
+        std::move(sink), options, asRowType(data->type()));
+    writer->write(data);
+    writer->close();
+  }
+}
+
+void benchParallelColumns(int32_t numColumns) {
+  folly::BenchmarkSuspender suspender;
+  auto leafPool = rootPool->addLeafChild("bench");
+  test::VectorMaker maker(leafPool.get());
+
+  std::vector<VectorPtr> columns;
+  std::vector<std::string> names;
+
+  for (int32_t i = 0; i < numColumns; ++i) {
+    columns.push_back(makeDictVarchar(kNumRows, 100, leafPool.get()));
+    names.push_back(fmt::format("c{}", i));
+  }
+
+  auto data = maker.rowVector(std::move(names), columns);
+
+  suspender.dismiss();
+  writeParquetParallel(data, rootPool.get());
+}
+
+BENCHMARK(Parallel_5Cols) {
+  benchParallelColumns(5);
+}
+BENCHMARK(Parallel_10Cols) {
+  benchParallelColumns(10);
+}
+BENCHMARK(Parallel_20Cols) {
+  benchParallelColumns(20);
+}
+
 } // namespace
 
 int32_t main(int32_t argc, char* argv[]) {

--- a/velox/dwio/parquet/tests/writer/ParquetWriterBenchmark.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterBenchmark.cpp
@@ -381,65 +381,6 @@ BENCHMARK(MapVarcharInt_10Entries) {
 
 BENCHMARK_DRAW_LINE();
 
-// -- Parallel column writing benchmarks --
-// Compare serial vs parallel writing with ZSTD compression.
-
-void writeParquetWithOptions(
-    const RowVectorPtr& data,
-    memory::MemoryPool* rootPool,
-    bool parallel,
-    common::CompressionKind compression) {
-  auto leafPool = rootPool->addLeafChild("sink");
-  auto sink = std::make_unique<MemorySink>(
-      kSinkSize, FileSink::Options{.pool = leafPool.get()});
-  WriterOptions options;
-  options.memoryPool = rootPool;
-  options.compressionKind = compression;
-  auto parquetOpts = std::make_shared<ParquetWriterOptions>();
-  parquetOpts->enableParallelWrite = parallel;
-  options.formatSpecificOptions = parquetOpts;
-  auto writer = std::make_unique<parquet::Writer>(
-      std::move(sink), options, asRowType(data->type()));
-  writer->write(data);
-  writer->close();
-}
-
-void benchParallelWrite(int32_t numCols, bool parallel) {
-  folly::BenchmarkSuspender suspender;
-  auto leafPool = rootPool->addLeafChild("bench");
-  test::VectorMaker maker(leafPool.get());
-  constexpr vector_size_t kParBatchSize = 100'000;
-
-  std::vector<VectorPtr> columns;
-  std::vector<std::string> names;
-
-  for (int32_t i = 0; i < numCols; ++i) {
-    columns.push_back(makeDictVarchar(kParBatchSize, 100, leafPool.get()));
-    names.push_back(fmt::format("c{}", i));
-  }
-
-  auto data = maker.rowVector(std::move(names), columns);
-
-  suspender.dismiss();
-  writeParquetWithOptions(
-      data, rootPool.get(), parallel, common::CompressionKind_ZSTD);
-}
-
-BENCHMARK(Serial_10Cols_Zstd) {
-  benchParallelWrite(10, false);
-}
-BENCHMARK(Parallel_10Cols_Zstd) {
-  benchParallelWrite(10, true);
-}
-BENCHMARK(Serial_20Cols_Zstd) {
-  benchParallelWrite(20, false);
-}
-BENCHMARK(Parallel_20Cols_Zstd) {
-  benchParallelWrite(20, true);
-}
-
-BENCHMARK_DRAW_LINE();
-
 // -- Flush estimation benchmarks --
 // These write many batches of dictionary data with a size-based flush policy.
 // With accurate size estimation, fewer row groups are created, meaning less

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -2108,6 +2108,94 @@ TEST_F(ParquetWriterTest, batchExceedingRowGroupSize) {
   ASSERT_EQ(reader->fileMetaData().numRowGroups(), kSize / kRowsPerGroup);
 }
 
+/// Verifies that parallel column writing produces correct results by
+/// round-tripping data through write and read with enableParallelWrite=true.
+TEST_F(ParquetWriterTest, parallelColumnWriteCorrectness) {
+  constexpr vector_size_t kSize = 10'000;
+  constexpr int kDictSize = 20;
+
+  std::vector<std::string> dictStrings(kDictSize);
+  for (int i = 0; i < kDictSize; ++i) {
+    dictStrings[i] = fmt::format("str_{}", i);
+  }
+  auto dictVarchar = makeFlatVector<StringView>(
+      kDictSize, [&](auto row) { return StringView(dictStrings[row]); });
+  BufferPtr idx =
+      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
+  auto rawIdx = idx->asMutable<vector_size_t>();
+  for (vector_size_t i = 0; i < kSize; ++i) {
+    rawIdx[i] = i % kDictSize;
+  }
+  auto col0 =
+      BaseVector::wrapInDictionary(BufferPtr(nullptr), idx, kSize, dictVarchar);
+
+  auto col1 = makeFlatVector<int64_t>(
+      kSize, [](auto row) { return static_cast<int64_t>(row) * 1'000; });
+  auto col2 =
+      makeFlatVector<double>(kSize, [](auto row) { return row * 3.14; });
+  auto col3 = makeFlatVector<int32_t>(kSize, [](auto row) { return row; });
+
+  auto data = makeRowVector({col0, col1, col2, col3});
+  auto schema = asRowType(data->type());
+
+  auto sink = std::make_unique<dwio::common::MemorySink>(
+      200 * 1024 * 1024,
+      dwio::common::FileSink::Options{.pool = leafPool_.get()});
+  auto* sinkPtr = sink.get();
+  dwio::common::WriterOptions options;
+  options.memoryPool = rootPool_.get();
+  options.compressionKind = common::CompressionKind_ZSTD;
+  auto parquetOpts = std::make_shared<ParquetWriterOptions>();
+  parquetOpts->enableParallelWrite = true;
+  options.formatSpecificOptions = parquetOpts;
+  auto writer =
+      std::make_unique<parquet::Writer>(std::move(sink), options, schema);
+  writer->write(data);
+  writer->close();
+
+  auto reader = createReaderInMemory(*sinkPtr);
+  ASSERT_EQ(reader->numberOfRows(), kSize);
+
+  auto rowReader = createRowReaderFromReader(*reader, schema);
+  VectorPtr flatCol0 = col0;
+  BaseVector::flattenVector(flatCol0);
+  auto expected = makeRowVector({flatCol0, col1, col2, col3});
+  assertReadWithReaderAndExpected(schema, *rowReader, expected, *leafPool_);
+}
+
+/// Verifies parallel writing with multiple batches and flush between them.
+TEST_F(ParquetWriterTest, parallelColumnWriteMultiBatch) {
+  constexpr vector_size_t kBatchSize = 5'000;
+
+  auto batch = makeRowVector({
+      makeFlatVector<int32_t>(kBatchSize, [](auto row) { return row; }),
+      makeFlatVector<int64_t>(
+          kBatchSize, [](auto row) { return static_cast<int64_t>(row) * 7; }),
+  });
+  auto schema = asRowType(batch->type());
+
+  auto sink = std::make_unique<dwio::common::MemorySink>(
+      200 * 1024 * 1024,
+      dwio::common::FileSink::Options{.pool = leafPool_.get()});
+  auto* sinkPtr = sink.get();
+  dwio::common::WriterOptions options;
+  options.memoryPool = rootPool_.get();
+  auto parquetOpts = std::make_shared<ParquetWriterOptions>();
+  parquetOpts->enableParallelWrite = true;
+  options.formatSpecificOptions = parquetOpts;
+  auto writer =
+      std::make_unique<parquet::Writer>(std::move(sink), options, schema);
+
+  writer->write(batch);
+  writer->flush();
+  writer->write(batch);
+  writer->close();
+
+  auto reader = createReaderInMemory(*sinkPtr);
+  ASSERT_EQ(reader->numberOfRows(), kBatchSize * 2);
+  ASSERT_EQ(reader->fileMetaData().numRowGroups(), 2);
+}
+
 } // namespace
 
 int main(int argc, char** argv) {

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -1372,6 +1372,43 @@ TEST_F(ParquetWriterTest, dictionaryPassthroughWithoutArrowMemoryPool) {
   assertRoundTrip(data, expected, writerOptions);
 }
 
+// Verifies round-trip correctness when the VARCHAR dictionary alphabet contains
+// duplicate values. Duplicates force the Arrow Parquet writer to abandon
+// dictionary encoding (numEntries() != dictionary->length()) and fall back to
+// PLAIN, but it still flushes a dictionary page first. The page must be sized
+// from the de-duplicated entries, otherwise the reader's exact-consumption
+// check in PageReader::prepareDictionary fails.
+TEST_F(ParquetWriterTest, dictionaryPassthroughVarcharDuplicateValues) {
+  constexpr vector_size_t kSize = 10'000;
+  constexpr int kDictSize = 12;
+
+  // Dictionary alphabet with intentional duplicates: several entries share the
+  // same string value, so numEntries() (distinct) < kDictSize (total).
+  const std::vector<std::string> dictStrings = {
+      "apple",
+      "apple",
+      "banana",
+      "cherry",
+      "cherry",
+      "cherry",
+      "date",
+      "elderberry",
+      "elderberry",
+      "fig",
+      "grape",
+      "grape",
+  };
+  ASSERT_EQ(dictStrings.size(), kDictSize);
+  auto dictionary = makeFlatVector<StringView>(
+      kDictSize, [&](auto row) { return StringView(dictStrings[row]); });
+
+  auto dictVector = makeDictionaryColumn(
+      kSize, dictionary, [](auto row) { return row % kDictSize; });
+  ASSERT_EQ(dictVector->encoding(), VectorEncoding::Simple::DICTIONARY);
+
+  assertFlattenedRoundTrip(makeRowVector({dictVector}));
+}
+
 // Verifies round-trip correctness with high-cardinality VARCHAR dictionary
 // (all unique values).  The Arrow Parquet writer may abandon dictionary
 // encoding and fall back to PLAIN.

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -81,6 +81,49 @@ class ParquetWriterTest : public ParquetTestBase {
     return data;
   }
 
+  // Builds a dictionary column of 'size' rows over 'values', mapping each row
+  // to values[indexAt(row)], optionally applying a null buffer.
+  VectorPtr makeDictionaryColumn(
+      vector_size_t size,
+      const VectorPtr& values,
+      std::function<vector_size_t(vector_size_t)> indexAt,
+      BufferPtr nulls = nullptr) {
+    return BaseVector::wrapInDictionary(
+        std::move(nulls), makeIndices(size, std::move(indexAt)), size, values);
+  }
+
+  // Returns a flattened copy of 'vector'. Parquet always reads back flat, so
+  // the flattened input is the expected round-trip output.
+  static VectorPtr flatten(const VectorPtr& vector) {
+    VectorPtr flat = vector;
+    BaseVector::flattenVector(flat);
+    return flat;
+  }
+
+  // Writes single-batch 'data' and verifies it round-trips to 'expected'.
+  void assertRoundTrip(
+      const RowVectorPtr& data,
+      const RowVectorPtr& expected,
+      const ParquetWriterOptions& writerOptions = {}) {
+    auto schema = asRowType(data->type());
+    auto* sinkPtr = write(data, writerOptions);
+    auto reader = createReaderInMemory(*sinkPtr);
+    ASSERT_EQ(reader->numberOfRows(), data->size());
+    auto rowReader = createRowReaderFromReader(*reader, schema);
+    assertReadWithReaderAndExpected(schema, *rowReader, expected, *leafPool_);
+  }
+
+  // Writes 'data' and verifies it round-trips, using the flattened form of each
+  // column as the expected output.
+  void assertFlattenedRoundTrip(const RowVectorPtr& data) {
+    std::vector<VectorPtr> expectedChildren;
+    expectedChildren.reserve(data->children().size());
+    for (const auto& child : data->children()) {
+      expectedChildren.push_back(flatten(child));
+    }
+    assertRoundTrip(data, makeRowVector(expectedChildren));
+  }
+
   thrift::PageHeader readPageHeader(
       MemorySink* sinkPtr,
       int64_t offsetFromDataPage) {
@@ -203,6 +246,7 @@ TEST_F(ParquetWriterTest, createFormatOptions) {
       {"hive.parquet.writer.enable-dictionary", "true"},
       {"hive.parquet.writer.page-size", "2KB"},
       {"hive.parquet.writer.created-by", "test-writer"},
+      {"hive.parquet.writer.enable-parallel-write", "true"},
       {"iceberg.parquet.writer.page-size", "4KB"},
   });
   config::ConfigBase session({
@@ -224,6 +268,7 @@ TEST_F(ParquetWriterTest, createFormatOptions) {
   EXPECT_EQ(parquetOptions->dataPageSize.value(), 2 * 1024);
   EXPECT_EQ(parquetOptions->batchSize.value(), 97);
   EXPECT_EQ(parquetOptions->createdBy.value(), "test-writer");
+  EXPECT_TRUE(parquetOptions->enableParallelWrite);
 
   config::ConfigBase icebergConnectorConfig(
       rawConnectorConfig.rawConfigsWithPrefix("iceberg.parquet."));
@@ -1293,32 +1338,11 @@ TEST_F(ParquetWriterTest, dictionaryPassthroughVarcharLowCardinality) {
   auto dictionary = makeFlatVector<StringView>(
       kDictSize, [&](auto row) { return StringView(dictStrings[row]); });
 
-  // Index buffer pointing into the dictionary.
-  BufferPtr indices =
-      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
-  auto rawIndices = indices->asMutable<vector_size_t>();
-  for (vector_size_t i = 0; i < kSize; ++i) {
-    rawIndices[i] = i % kDictSize;
-  }
-
-  auto dictVector = BaseVector::wrapInDictionary(
-      BufferPtr(nullptr), indices, kSize, dictionary);
+  auto dictVector = makeDictionaryColumn(
+      kSize, dictionary, [](auto row) { return row % kDictSize; });
   ASSERT_EQ(dictVector->encoding(), VectorEncoding::Simple::DICTIONARY);
 
-  auto data = makeRowVector({dictVector});
-  auto schema = asRowType(data->type());
-
-  auto* sinkPtr = write(data, ParquetWriterOptions{});
-
-  auto reader = createReaderInMemory(*sinkPtr);
-  ASSERT_EQ(reader->numberOfRows(), kSize);
-
-  auto rowReader = createRowReaderFromReader(*reader, schema);
-  // Build expected output as a flat vector (Parquet always reads back flat).
-  VectorPtr flatDict = dictVector;
-  BaseVector::flattenVector(flatDict);
-  auto expected = makeRowVector({flatDict});
-  assertReadWithReaderAndExpected(schema, *rowReader, expected, *leafPool_);
+  assertFlattenedRoundTrip(makeRowVector({dictVector}));
 }
 
 /// Verifies round-trip correctness with high-cardinality VARCHAR dictionary
@@ -1335,101 +1359,37 @@ TEST_F(ParquetWriterTest, dictionaryPassthroughVarcharHighCardinality) {
   auto dictionary = makeFlatVector<StringView>(
       kSize, [&](auto row) { return StringView(dictStrings[row]); });
 
-  BufferPtr indices =
-      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
-  auto rawIndices = indices->asMutable<vector_size_t>();
-  for (vector_size_t i = 0; i < kSize; ++i) {
-    rawIndices[i] = i;
-  }
+  auto dictVector =
+      makeDictionaryColumn(kSize, dictionary, [](auto row) { return row; });
 
-  auto dictVector = BaseVector::wrapInDictionary(
-      BufferPtr(nullptr), indices, kSize, dictionary);
-
-  auto data = makeRowVector({dictVector});
-  auto schema = asRowType(data->type());
-
-  auto* sinkPtr = write(data, ParquetWriterOptions{});
-
-  auto reader = createReaderInMemory(*sinkPtr);
-  ASSERT_EQ(reader->numberOfRows(), kSize);
-
-  auto rowReader = createRowReaderFromReader(*reader, schema);
-  VectorPtr flatDict = dictVector;
-  BaseVector::flattenVector(flatDict);
-  auto expected = makeRowVector({flatDict});
-  assertReadWithReaderAndExpected(schema, *rowReader, expected, *leafPool_);
+  assertFlattenedRoundTrip(makeRowVector({dictVector}));
 }
 
-/// Verifies that DictionaryVector<INTEGER> (non-string type) round-trips
-/// correctly.  The Arrow Parquet writer's dictionaryDirectWriteSupported()
-/// only supports binary-like types for direct dict write, so integer
-/// dictionaries should fall back to dense encoding internally.
-TEST_F(ParquetWriterTest, dictionaryPassthroughInteger) {
+/// Verifies that dictionary-encoded non-string primitive columns (INTEGER,
+/// BIGINT, DOUBLE, BOOLEAN) round-trip correctly. These share the same
+/// non-VARCHAR/VARBINARY path: childNeedsFlatten() forces flattening because
+/// Arrow's Parquet writer only supports dictionary passthrough for binary-like
+/// scalar types.
+TEST_F(ParquetWriterTest, dictionaryNonStringPrimitivesFlatten) {
   constexpr vector_size_t kSize = 10'000;
-  constexpr int kDictSize = 50;
 
-  auto dictionary =
-      makeFlatVector<int32_t>(kDictSize, [](auto row) { return row * 7; });
+  auto intDict = makeFlatVector<int32_t>(50, [](auto row) { return row * 7; });
+  auto bigintDict = makeFlatVector<int64_t>(
+      100, [](auto row) { return static_cast<int64_t>(row) * 1'000'000; });
+  auto doubleDict =
+      makeFlatVector<double>(10, [](auto row) { return row * 1.5; });
+  auto boolDict = makeFlatVector<bool>(2, [](auto row) { return row == 1; });
 
-  BufferPtr indices =
-      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
-  auto rawIndices = indices->asMutable<vector_size_t>();
-  for (vector_size_t i = 0; i < kSize; ++i) {
-    rawIndices[i] = i % kDictSize;
-  }
-
-  auto dictVector = BaseVector::wrapInDictionary(
-      BufferPtr(nullptr), indices, kSize, dictionary);
-
-  auto data = makeRowVector({dictVector});
-  auto schema = asRowType(data->type());
-
-  auto* sinkPtr = write(data, ParquetWriterOptions{});
-
-  auto reader = createReaderInMemory(*sinkPtr);
-  ASSERT_EQ(reader->numberOfRows(), kSize);
-
-  auto rowReader = createRowReaderFromReader(*reader, schema);
-  VectorPtr flatDict = dictVector;
-  BaseVector::flattenVector(flatDict);
-  auto expected = makeRowVector({flatDict});
-  assertReadWithReaderAndExpected(schema, *rowReader, expected, *leafPool_);
-}
-
-/// Verifies that DictionaryVector<BIGINT> round-trips correctly and that the
-/// data is identical whether dictionary encoding or plain encoding is used in
-/// the Parquet file.
-TEST_F(ParquetWriterTest, dictionaryPassthroughBigint) {
-  constexpr vector_size_t kSize = 5'000;
-  constexpr int kDictSize = 100;
-
-  auto dictionary = makeFlatVector<int64_t>(kDictSize, [](auto row) {
-    return static_cast<int64_t>(row) * 1'000'000;
+  auto data = makeRowVector({
+      makeDictionaryColumn(kSize, intDict, [](auto row) { return row % 50; }),
+      makeDictionaryColumn(
+          kSize, bigintDict, [](auto row) { return row % 100; }),
+      makeDictionaryColumn(
+          kSize, doubleDict, [](auto row) { return row % 10; }),
+      makeDictionaryColumn(kSize, boolDict, [](auto row) { return row % 2; }),
   });
 
-  BufferPtr indices =
-      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
-  auto rawIndices = indices->asMutable<vector_size_t>();
-  for (vector_size_t i = 0; i < kSize; ++i) {
-    rawIndices[i] = i % kDictSize;
-  }
-
-  auto dictVector = BaseVector::wrapInDictionary(
-      BufferPtr(nullptr), indices, kSize, dictionary);
-
-  auto data = makeRowVector({dictVector});
-  auto schema = asRowType(data->type());
-
-  auto* sinkPtr = write(data, ParquetWriterOptions{});
-
-  auto reader = createReaderInMemory(*sinkPtr);
-  ASSERT_EQ(reader->numberOfRows(), kSize);
-
-  auto rowReader = createRowReaderFromReader(*reader, schema);
-  VectorPtr flatDict = dictVector;
-  BaseVector::flattenVector(flatDict);
-  auto expected = makeRowVector({flatDict});
-  assertReadWithReaderAndExpected(schema, *rowReader, expected, *leafPool_);
+  assertFlattenedRoundTrip(data);
 }
 
 /// Verifies that writing multiple batches with changing dictionaries works
@@ -1450,15 +1410,8 @@ TEST_F(ParquetWriterTest, dictionaryPassthroughMultipleBatches) {
     auto dictionary = makeFlatVector<StringView>(
         kDictSize, [&](auto row) { return StringView(dictStrings[row]); });
 
-    BufferPtr indices =
-        AlignedBuffer::allocate<vector_size_t>(kBatchSize, leafPool_.get());
-    auto rawIndices = indices->asMutable<vector_size_t>();
-    for (vector_size_t i = 0; i < kBatchSize; ++i) {
-      rawIndices[i] = i % kDictSize;
-    }
-
-    auto dictVector = BaseVector::wrapInDictionary(
-        BufferPtr(nullptr), indices, kBatchSize, dictionary);
+    auto dictVector = makeDictionaryColumn(
+        kBatchSize, dictionary, [](auto row) { return row % kDictSize; });
     batches.push_back(makeRowVector({dictVector}));
   }
 
@@ -1501,33 +1454,15 @@ TEST_F(ParquetWriterTest, dictionaryPassthroughWithNulls) {
   auto dictionary = makeFlatVector<StringView>(
       kDictSize, [&](auto row) { return StringView(dictStrings[row]); });
 
-  BufferPtr indices =
-      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
-  auto rawIndices = indices->asMutable<vector_size_t>();
-  for (vector_size_t i = 0; i < kSize; ++i) {
-    rawIndices[i] = i % kDictSize;
-  }
-
   // Every 3rd element is null.
-  auto nulls = makeNulls(kSize, [](auto row) { return row % 3 == 0; });
-
-  auto dictVector =
-      BaseVector::wrapInDictionary(nulls, indices, kSize, dictionary);
+  auto dictVector = makeDictionaryColumn(
+      kSize,
+      dictionary,
+      [](auto row) { return row % kDictSize; },
+      makeNulls(kSize, [](auto row) { return row % 3 == 0; }));
   ASSERT_EQ(dictVector->encoding(), VectorEncoding::Simple::DICTIONARY);
 
-  auto data = makeRowVector({dictVector});
-  auto schema = asRowType(data->type());
-
-  auto* sinkPtr = write(data, ParquetWriterOptions{});
-
-  auto reader = createReaderInMemory(*sinkPtr);
-  ASSERT_EQ(reader->numberOfRows(), kSize);
-
-  auto rowReader = createRowReaderFromReader(*reader, schema);
-  VectorPtr flatDict = dictVector;
-  BaseVector::flattenVector(flatDict);
-  auto expected = makeRowVector({flatDict});
-  assertReadWithReaderAndExpected(schema, *rowReader, expected, *leafPool_);
+  assertFlattenedRoundTrip(makeRowVector({dictVector}));
 }
 
 /// Verifies that complex types (MAP, ARRAY, ROW) are written correctly without
@@ -1555,15 +1490,8 @@ TEST_F(ParquetWriterTest, complexTypesWithoutFlattening) {
       [](auto row) { return static_cast<int64_t>(row * 100); });
 
   auto data = makeRowVector({mapVector, arrayVector});
-  auto schema = asRowType(data->type());
 
-  auto* sinkPtr = write(data, ParquetWriterOptions{});
-
-  auto reader = createReaderInMemory(*sinkPtr);
-  ASSERT_EQ(reader->numberOfRows(), kSize);
-
-  auto rowReader = createRowReaderFromReader(*reader, schema);
-  assertReadWithReaderAndExpected(schema, *rowReader, data, *leafPool_);
+  assertFlattenedRoundTrip(data);
 }
 
 /// Verifies that a mix of dictionary-encoded scalar columns and flat complex
@@ -1581,14 +1509,8 @@ TEST_F(ParquetWriterTest, mixedDictionaryAndComplexTypes) {
   }
   auto dictionary = makeFlatVector<StringView>(
       kDictSize, [&](auto row) { return StringView(dictStrings[row]); });
-  BufferPtr indices =
-      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
-  auto rawIndices = indices->asMutable<vector_size_t>();
-  for (vector_size_t i = 0; i < kSize; ++i) {
-    rawIndices[i] = i % kDictSize;
-  }
-  auto dictColumn = BaseVector::wrapInDictionary(
-      BufferPtr(nullptr), indices, kSize, dictionary);
+  auto dictColumn = makeDictionaryColumn(
+      kSize, dictionary, [](auto row) { return row % kDictSize; });
 
   // Flat ARRAY column.
   auto arrayColumn = makeArrayVector<int32_t>(
@@ -1599,20 +1521,7 @@ TEST_F(ParquetWriterTest, mixedDictionaryAndComplexTypes) {
   // Flat INTEGER column.
   auto intColumn = makeFlatVector<int32_t>(kSize, [](auto row) { return row; });
 
-  auto data = makeRowVector({dictColumn, arrayColumn, intColumn});
-  auto schema = asRowType(data->type());
-
-  auto* sinkPtr = write(data, ParquetWriterOptions{});
-
-  auto reader = createReaderInMemory(*sinkPtr);
-  ASSERT_EQ(reader->numberOfRows(), kSize);
-
-  auto rowReader = createRowReaderFromReader(*reader, schema);
-  // Expected: flatten the dictionary column, keep complex and flat as-is.
-  VectorPtr flatDictCol = dictColumn;
-  BaseVector::flattenVector(flatDictCol);
-  auto expected = makeRowVector({flatDictCol, arrayColumn, intColumn});
-  assertReadWithReaderAndExpected(schema, *rowReader, expected, *leafPool_);
+  assertFlattenedRoundTrip(makeRowVector({dictColumn, arrayColumn, intColumn}));
 }
 
 /// Verifies that dictionary wrapping a complex type (ARRAY) is correctly
@@ -1626,30 +1535,13 @@ TEST_F(ParquetWriterTest, dictionaryWrappingComplexTypeFlattens) {
       [](auto row) { return row % 3 + 1; },
       [](auto row) { return static_cast<int32_t>(row); });
 
-  BufferPtr indices =
-      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
-  auto rawIndices = indices->asMutable<vector_size_t>();
-  for (vector_size_t i = 0; i < kSize; ++i) {
-    rawIndices[i] = i;
-  }
-
-  auto dictOfArray = BaseVector::wrapInDictionary(
-      BufferPtr(nullptr), indices, kSize, arrayVector);
+  auto dictOfArray =
+      makeDictionaryColumn(kSize, arrayVector, [](auto row) { return row; });
   ASSERT_EQ(dictOfArray->encoding(), VectorEncoding::Simple::DICTIONARY);
 
-  auto data = makeRowVector({dictOfArray});
-  auto schema = asRowType(data->type());
-
-  auto* sinkPtr = write(data, ParquetWriterOptions{});
-
-  auto reader = createReaderInMemory(*sinkPtr);
-  ASSERT_EQ(reader->numberOfRows(), kSize);
-
-  auto rowReader = createRowReaderFromReader(*reader, schema);
   // Expected output is the original unwrapped array (flattening removes the
   // identity dictionary wrapping).
-  auto expected = makeRowVector({arrayVector});
-  assertReadWithReaderAndExpected(schema, *rowReader, expected, *leafPool_);
+  assertRoundTrip(makeRowVector({dictOfArray}), makeRowVector({arrayVector}));
 }
 
 /// Verifies that dictionary-of-dictionary (nested wrapping) is correctly
@@ -1661,61 +1553,36 @@ TEST_F(ParquetWriterTest, dictionaryOfDictionaryFlattens) {
   auto dictionary =
       makeFlatVector<int32_t>(kDictSize, [](auto row) { return row * 11; });
 
-  BufferPtr innerIndices =
-      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
-  auto rawInner = innerIndices->asMutable<vector_size_t>();
-  for (vector_size_t i = 0; i < kSize; ++i) {
-    rawInner[i] = i % kDictSize;
-  }
-
-  auto innerDict = BaseVector::wrapInDictionary(
-      BufferPtr(nullptr), innerIndices, kSize, dictionary);
-
+  auto innerDict = makeDictionaryColumn(
+      kSize, dictionary, [](auto row) { return row % kDictSize; });
   // Wrap the dictionary in another dictionary layer.
-  BufferPtr outerIndices =
-      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
-  auto rawOuter = outerIndices->asMutable<vector_size_t>();
-  for (vector_size_t i = 0; i < kSize; ++i) {
-    rawOuter[i] = i;
-  }
-  auto dictOfDict = BaseVector::wrapInDictionary(
-      BufferPtr(nullptr), outerIndices, kSize, innerDict);
+  auto dictOfDict =
+      makeDictionaryColumn(kSize, innerDict, [](auto row) { return row; });
 
-  auto data = makeRowVector({dictOfDict});
-  auto schema = asRowType(data->type());
-
-  auto* sinkPtr = write(data, ParquetWriterOptions{});
-
-  auto reader = createReaderInMemory(*sinkPtr);
-  ASSERT_EQ(reader->numberOfRows(), kSize);
-
-  auto rowReader = createRowReaderFromReader(*reader, schema);
-  VectorPtr flatExpected = dictOfDict;
-  BaseVector::flattenVector(flatExpected);
-  auto expected = makeRowVector({flatExpected});
-  assertReadWithReaderAndExpected(schema, *rowReader, expected, *leafPool_);
+  assertFlattenedRoundTrip(makeRowVector({dictOfDict}));
 }
 
-/// Verifies that a constant vector wrapping a dictionary is correctly
-/// flattened.  This exercises the CONSTANT branch in needFlatten().
+/// Verifies that a constant wrapping a dictionary is correctly flattened.
+/// wrapInConstant peels the scalar dictionary layers, so to keep a non-flat
+/// wrapped vector the dictionary wraps a complex (ARRAY) type. This exercises
+/// the CONSTANT branch in childNeedsFlatten(), which flattens a constant whose
+/// wrapped vector is not flat.
 TEST_F(ParquetWriterTest, constantWrappingDictionaryFlattens) {
   constexpr vector_size_t kSize = 500;
+  constexpr int kDictSize = 10;
 
-  auto constantInt = makeConstant(static_cast<int32_t>(42), kSize);
+  auto arrayVector = makeArrayVector<int32_t>(
+      kDictSize,
+      [](auto row) { return row % 3 + 1; },
+      [](auto row) { return static_cast<int32_t>(row); });
+  // Dictionary over the ARRAY, then wrap a single entry as a constant.
+  auto dictOfArray = makeDictionaryColumn(
+      kDictSize, arrayVector, [](auto row) { return row; });
+  auto constColumn = BaseVector::wrapInConstant(kSize, 0, dictOfArray);
+  ASSERT_EQ(constColumn->encoding(), VectorEncoding::Simple::CONSTANT);
+  ASSERT_FALSE(constColumn->wrappedVector()->isFlatEncoding());
 
-  auto data = makeRowVector({constantInt});
-  auto schema = asRowType(data->type());
-
-  auto* sinkPtr = write(data, ParquetWriterOptions{});
-
-  auto reader = createReaderInMemory(*sinkPtr);
-  ASSERT_EQ(reader->numberOfRows(), kSize);
-
-  auto rowReader = createRowReaderFromReader(*reader, schema);
-  VectorPtr flatExpected = constantInt;
-  BaseVector::flattenVector(flatExpected);
-  auto expected = makeRowVector({flatExpected});
-  assertReadWithReaderAndExpected(schema, *rowReader, expected, *leafPool_);
+  assertFlattenedRoundTrip(makeRowVector({constColumn}));
 }
 
 /// Verifies that an empty dictionary vector (0 rows) can be written without
@@ -1732,46 +1599,13 @@ TEST_F(ParquetWriterTest, dictionaryPassthroughEmptyVector) {
   auto dictionary = makeFlatVector<StringView>(
       kDictSize, [&](auto row) { return StringView(dictStrings[row]); });
 
-  BufferPtr indices =
-      AlignedBuffer::allocate<vector_size_t>(0, leafPool_.get());
-
-  auto dictVector = BaseVector::wrapInDictionary(
-      BufferPtr(nullptr), indices, kSize, dictionary);
+  auto dictVector =
+      makeDictionaryColumn(kSize, dictionary, [](auto row) { return row; });
 
   auto data = makeRowVector({dictVector});
 
   // Write should succeed without crashing.
   write(data, ParquetWriterOptions{});
-}
-
-/// Verifies that a single-row dictionary vector round-trips correctly.
-TEST_F(ParquetWriterTest, dictionaryPassthroughSingleRow) {
-  constexpr vector_size_t kSize = 1;
-
-  std::vector<std::string> dictStrings = {"only_value"};
-  auto dictionary = makeFlatVector<StringView>(
-      1, [&](auto row) { return StringView(dictStrings[row]); });
-
-  BufferPtr indices =
-      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
-  indices->asMutable<vector_size_t>()[0] = 0;
-
-  auto dictVector = BaseVector::wrapInDictionary(
-      BufferPtr(nullptr), indices, kSize, dictionary);
-
-  auto data = makeRowVector({dictVector});
-  auto schema = asRowType(data->type());
-
-  auto* sinkPtr = write(data, ParquetWriterOptions{});
-
-  auto reader = createReaderInMemory(*sinkPtr);
-  ASSERT_EQ(reader->numberOfRows(), kSize);
-
-  auto rowReader = createRowReaderFromReader(*reader, schema);
-  VectorPtr flatDict = dictVector;
-  BaseVector::flattenVector(flatDict);
-  auto expected = makeRowVector({flatDict});
-  assertReadWithReaderAndExpected(schema, *rowReader, expected, *leafPool_);
 }
 
 /// Verifies that a dictionary vector where every element is null round-trips.
@@ -1786,149 +1620,49 @@ TEST_F(ParquetWriterTest, dictionaryPassthroughAllNulls) {
   auto dictionary = makeFlatVector<StringView>(
       kDictSize, [&](auto row) { return StringView(dictStrings[row]); });
 
-  BufferPtr indices =
-      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
-  auto rawIndices = indices->asMutable<vector_size_t>();
-  for (vector_size_t i = 0; i < kSize; ++i) {
-    rawIndices[i] = i % kDictSize;
-  }
-
   // Every element is null.
-  auto nulls = makeNulls(kSize, [](auto /*row*/) { return true; });
+  auto dictVector = makeDictionaryColumn(
+      kSize,
+      dictionary,
+      [](auto row) { return row % kDictSize; },
+      makeNulls(kSize, [](auto /*row*/) { return true; }));
 
-  auto dictVector =
-      BaseVector::wrapInDictionary(nulls, indices, kSize, dictionary);
-
-  auto data = makeRowVector({dictVector});
-  auto schema = asRowType(data->type());
-
-  auto* sinkPtr = write(data, ParquetWriterOptions{});
-
-  auto reader = createReaderInMemory(*sinkPtr);
-  ASSERT_EQ(reader->numberOfRows(), kSize);
-
-  auto rowReader = createRowReaderFromReader(*reader, schema);
-  VectorPtr flatDict = dictVector;
-  BaseVector::flattenVector(flatDict);
-  auto expected = makeRowVector({flatDict});
-  assertReadWithReaderAndExpected(schema, *rowReader, expected, *leafPool_);
+  assertFlattenedRoundTrip(makeRowVector({dictVector}));
 }
 
-/// Verifies that multiple dictionary-encoded columns in the same RowVector all
-/// pass through correctly.
-TEST_F(ParquetWriterTest, dictionaryPassthroughMultipleColumns) {
-  constexpr vector_size_t kSize = 2'000;
+/// Verifies that a complex column that is flat at the top level but contains a
+/// dictionary-encoded descendant is flattened before Arrow export. Dictionary
+/// passthrough is only safe for top-level scalar VARCHAR/VARBINARY columns, so
+/// childNeedsFlatten() recurses into ARRAY/MAP/ROW children to catch nested
+/// dictionaries the bridge would otherwise export as DictionaryArrays.
+TEST_F(ParquetWriterTest, flatComplexWithEncodedDescendantFlattens) {
+  constexpr vector_size_t kSize = 1'000;
+  constexpr int kDictSize = 10;
 
-  // First dict column: VARCHAR, cardinality 5.
-  constexpr int kDictSize1 = 5;
-  std::vector<std::string> strings1(kDictSize1);
-  for (int i = 0; i < kDictSize1; ++i) {
-    strings1[i] = fmt::format("a_{}", i);
+  std::vector<std::string> dictStrings(kDictSize);
+  for (int i = 0; i < kDictSize; ++i) {
+    dictStrings[i] = fmt::format("val_{}", i);
   }
-  auto dict1 = makeFlatVector<StringView>(
-      kDictSize1, [&](auto row) { return StringView(strings1[row]); });
-  BufferPtr idx1 =
-      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
-  auto raw1 = idx1->asMutable<vector_size_t>();
+  auto dictionary = makeFlatVector<StringView>(
+      kDictSize, [&](auto row) { return StringView(dictStrings[row]); });
+
+  // ROW column: flat at the top level, with a dictionary-encoded child.
+  auto structColumn = makeRowVector({makeDictionaryColumn(
+      kSize, dictionary, [](auto row) { return row % kDictSize; })});
+  ASSERT_EQ(structColumn->encoding(), VectorEncoding::Simple::ROW);
+
+  // ARRAY column: flat at the top level, with dictionary-encoded elements.
+  // Each row holds two consecutive dictionary entries.
+  auto elements = makeDictionaryColumn(
+      kSize * 2, dictionary, [](auto row) { return row % kDictSize; });
+  std::vector<vector_size_t> offsets(kSize);
   for (vector_size_t i = 0; i < kSize; ++i) {
-    raw1[i] = i % kDictSize1;
+    offsets[i] = i * 2;
   }
-  auto col1 =
-      BaseVector::wrapInDictionary(BufferPtr(nullptr), idx1, kSize, dict1);
+  auto arrayColumn = makeArrayVector(offsets, elements);
+  ASSERT_EQ(arrayColumn->encoding(), VectorEncoding::Simple::ARRAY);
 
-  // Second dict column: VARCHAR, cardinality 20.
-  constexpr int kDictSize2 = 20;
-  std::vector<std::string> strings2(kDictSize2);
-  for (int i = 0; i < kDictSize2; ++i) {
-    strings2[i] = fmt::format("b_{}", i);
-  }
-  auto dict2 = makeFlatVector<StringView>(
-      kDictSize2, [&](auto row) { return StringView(strings2[row]); });
-  BufferPtr idx2 =
-      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
-  auto raw2 = idx2->asMutable<vector_size_t>();
-  for (vector_size_t i = 0; i < kSize; ++i) {
-    raw2[i] = i % kDictSize2;
-  }
-  auto col2 =
-      BaseVector::wrapInDictionary(BufferPtr(nullptr), idx2, kSize, dict2);
-
-  // Third dict column: INTEGER, cardinality 50.
-  constexpr int kDictSize3 = 50;
-  auto dict3 =
-      makeFlatVector<int32_t>(kDictSize3, [](auto row) { return row * 3; });
-  BufferPtr idx3 =
-      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
-  auto raw3 = idx3->asMutable<vector_size_t>();
-  for (vector_size_t i = 0; i < kSize; ++i) {
-    raw3[i] = i % kDictSize3;
-  }
-  auto col3 =
-      BaseVector::wrapInDictionary(BufferPtr(nullptr), idx3, kSize, dict3);
-
-  auto data = makeRowVector({col1, col2, col3});
-  auto schema = asRowType(data->type());
-
-  auto* sinkPtr = write(data, ParquetWriterOptions{});
-
-  auto reader = createReaderInMemory(*sinkPtr);
-  ASSERT_EQ(reader->numberOfRows(), kSize);
-
-  auto rowReader = createRowReaderFromReader(*reader, schema);
-  VectorPtr flat1 = col1;
-  BaseVector::flattenVector(flat1);
-  VectorPtr flat2 = col2;
-  BaseVector::flattenVector(flat2);
-  VectorPtr flat3 = col3;
-  BaseVector::flattenVector(flat3);
-  auto expected = makeRowVector({flat1, flat2, flat3});
-  assertReadWithReaderAndExpected(schema, *rowReader, expected, *leafPool_);
-}
-
-/// Verifies dictionary passthrough for DOUBLE and BOOLEAN types.
-TEST_F(ParquetWriterTest, dictionaryPassthroughOtherPrimitiveTypes) {
-  constexpr vector_size_t kSize = 2'000;
-
-  // Dictionary DOUBLE column.
-  constexpr int kDoubleDictSize = 10;
-  auto doubleDictionary = makeFlatVector<double>(
-      kDoubleDictSize, [](auto row) { return row * 1.5; });
-  BufferPtr doubleIndices =
-      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
-  auto rawDoubleIdx = doubleIndices->asMutable<vector_size_t>();
-  for (vector_size_t i = 0; i < kSize; ++i) {
-    rawDoubleIdx[i] = i % kDoubleDictSize;
-  }
-  auto dictDouble = BaseVector::wrapInDictionary(
-      BufferPtr(nullptr), doubleIndices, kSize, doubleDictionary);
-
-  // Dictionary BOOLEAN column.
-  auto boolDictionary =
-      makeFlatVector<bool>(2, [](auto row) { return row == 1; });
-  BufferPtr boolIndices =
-      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
-  auto rawBoolIdx = boolIndices->asMutable<vector_size_t>();
-  for (vector_size_t i = 0; i < kSize; ++i) {
-    rawBoolIdx[i] = i % 2;
-  }
-  auto dictBool = BaseVector::wrapInDictionary(
-      BufferPtr(nullptr), boolIndices, kSize, boolDictionary);
-
-  auto data = makeRowVector({dictDouble, dictBool});
-  auto schema = asRowType(data->type());
-
-  auto* sinkPtr = write(data, ParquetWriterOptions{});
-
-  auto reader = createReaderInMemory(*sinkPtr);
-  ASSERT_EQ(reader->numberOfRows(), kSize);
-
-  auto rowReader = createRowReaderFromReader(*reader, schema);
-  VectorPtr flatDouble = dictDouble;
-  BaseVector::flattenVector(flatDouble);
-  VectorPtr flatBool = dictBool;
-  BaseVector::flattenVector(flatBool);
-  auto expected = makeRowVector({flatDouble, flatBool});
-  assertReadWithReaderAndExpected(schema, *rowReader, expected, *leafPool_);
+  assertFlattenedRoundTrip(makeRowVector({structColumn, arrayColumn}));
 }
 
 /// Verifies selective per-column flattening: a dict-of-dict column (must
@@ -1947,51 +1681,19 @@ TEST_F(ParquetWriterTest, selectiveFlatteningMixedEncodings) {
   }
   auto dict = makeFlatVector<StringView>(
       kDictSize, [&](auto row) { return StringView(dictStrings[row]); });
-  BufferPtr idx =
-      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
-  auto rawIdx = idx->asMutable<vector_size_t>();
-  for (vector_size_t i = 0; i < kSize; ++i) {
-    rawIdx[i] = i % kDictSize;
-  }
-  auto passthroughCol =
-      BaseVector::wrapInDictionary(BufferPtr(nullptr), idx, kSize, dict);
+  auto passthroughCol = makeDictionaryColumn(
+      kSize, dict, [](auto row) { return row % kDictSize; });
 
   // Column 1: dict-of-dict INTEGER (must flatten).
   constexpr int kInnerDictSize = 20;
   auto innerDict =
       makeFlatVector<int32_t>(kInnerDictSize, [](auto row) { return row * 5; });
-  BufferPtr innerIdx =
-      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
-  auto rawInner = innerIdx->asMutable<vector_size_t>();
-  for (vector_size_t i = 0; i < kSize; ++i) {
-    rawInner[i] = i % kInnerDictSize;
-  }
-  auto innerDictVec = BaseVector::wrapInDictionary(
-      BufferPtr(nullptr), innerIdx, kSize, innerDict);
-  BufferPtr outerIdx =
-      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
-  auto rawOuter = outerIdx->asMutable<vector_size_t>();
-  for (vector_size_t i = 0; i < kSize; ++i) {
-    rawOuter[i] = i;
-  }
-  auto nestedDictCol = BaseVector::wrapInDictionary(
-      BufferPtr(nullptr), outerIdx, kSize, innerDictVec);
+  auto innerDictVec = makeDictionaryColumn(
+      kSize, innerDict, [](auto row) { return row % kInnerDictSize; });
+  auto nestedDictCol =
+      makeDictionaryColumn(kSize, innerDictVec, [](auto row) { return row; });
 
-  auto data = makeRowVector({passthroughCol, nestedDictCol});
-  auto schema = asRowType(data->type());
-
-  auto* sinkPtr = write(data, ParquetWriterOptions{});
-
-  auto reader = createReaderInMemory(*sinkPtr);
-  ASSERT_EQ(reader->numberOfRows(), kSize);
-
-  auto rowReader = createRowReaderFromReader(*reader, schema);
-  VectorPtr flatPassthrough = passthroughCol;
-  BaseVector::flattenVector(flatPassthrough);
-  VectorPtr flatNested = nestedDictCol;
-  BaseVector::flattenVector(flatNested);
-  auto expected = makeRowVector({flatPassthrough, flatNested});
-  assertReadWithReaderAndExpected(schema, *rowReader, expected, *leafPool_);
+  assertFlattenedRoundTrip(makeRowVector({passthroughCol, nestedDictCol}));
 }
 
 TEST_F(ParquetWriterTest, allNulls) {

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -1277,6 +1277,657 @@ TEST_F(ParquetWriterTest, dictionaryEncodedVector) {
   write(data);
 }
 
+/// Verifies round-trip correctness when writing DictionaryVector<VARCHAR> with
+/// low cardinality.  With flattenDictionary=false the bridge exports a
+/// DictionaryArray that the Arrow Parquet writer encodes directly via
+/// writeArrowDictionary().
+TEST_F(ParquetWriterTest, dictionaryPassthroughVarcharLowCardinality) {
+  constexpr vector_size_t kSize = 10'000;
+  constexpr int kDictSize = 10;
+
+  // Build a dictionary of 10 strings.
+  std::vector<std::string> dictStrings(kDictSize);
+  for (int i = 0; i < kDictSize; ++i) {
+    dictStrings[i] = fmt::format("val_{}", i);
+  }
+  auto dictionary = makeFlatVector<StringView>(
+      kDictSize, [&](auto row) { return StringView(dictStrings[row]); });
+
+  // Index buffer pointing into the dictionary.
+  BufferPtr indices =
+      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
+  auto rawIndices = indices->asMutable<vector_size_t>();
+  for (vector_size_t i = 0; i < kSize; ++i) {
+    rawIndices[i] = i % kDictSize;
+  }
+
+  auto dictVector = BaseVector::wrapInDictionary(
+      BufferPtr(nullptr), indices, kSize, dictionary);
+  ASSERT_EQ(dictVector->encoding(), VectorEncoding::Simple::DICTIONARY);
+
+  auto data = makeRowVector({dictVector});
+  auto schema = asRowType(data->type());
+
+  auto* sinkPtr = write(data, ParquetWriterOptions{});
+
+  auto reader = createReaderInMemory(*sinkPtr);
+  ASSERT_EQ(reader->numberOfRows(), kSize);
+
+  auto rowReader = createRowReaderFromReader(*reader, schema);
+  // Build expected output as a flat vector (Parquet always reads back flat).
+  VectorPtr flatDict = dictVector;
+  BaseVector::flattenVector(flatDict);
+  auto expected = makeRowVector({flatDict});
+  assertReadWithReaderAndExpected(schema, *rowReader, expected, *leafPool_);
+}
+
+/// Verifies round-trip correctness with high-cardinality VARCHAR dictionary
+/// (all unique values).  The Arrow Parquet writer may abandon dictionary
+/// encoding and fall back to PLAIN.
+TEST_F(ParquetWriterTest, dictionaryPassthroughVarcharHighCardinality) {
+  constexpr vector_size_t kSize = 10'000;
+
+  // All-unique dictionary (size == kSize).
+  std::vector<std::string> dictStrings(kSize);
+  for (vector_size_t i = 0; i < kSize; ++i) {
+    dictStrings[i] = fmt::format("unique_{}", i);
+  }
+  auto dictionary = makeFlatVector<StringView>(
+      kSize, [&](auto row) { return StringView(dictStrings[row]); });
+
+  BufferPtr indices =
+      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
+  auto rawIndices = indices->asMutable<vector_size_t>();
+  for (vector_size_t i = 0; i < kSize; ++i) {
+    rawIndices[i] = i;
+  }
+
+  auto dictVector = BaseVector::wrapInDictionary(
+      BufferPtr(nullptr), indices, kSize, dictionary);
+
+  auto data = makeRowVector({dictVector});
+  auto schema = asRowType(data->type());
+
+  auto* sinkPtr = write(data, ParquetWriterOptions{});
+
+  auto reader = createReaderInMemory(*sinkPtr);
+  ASSERT_EQ(reader->numberOfRows(), kSize);
+
+  auto rowReader = createRowReaderFromReader(*reader, schema);
+  VectorPtr flatDict = dictVector;
+  BaseVector::flattenVector(flatDict);
+  auto expected = makeRowVector({flatDict});
+  assertReadWithReaderAndExpected(schema, *rowReader, expected, *leafPool_);
+}
+
+/// Verifies that DictionaryVector<INTEGER> (non-string type) round-trips
+/// correctly.  The Arrow Parquet writer's dictionaryDirectWriteSupported()
+/// only supports binary-like types for direct dict write, so integer
+/// dictionaries should fall back to dense encoding internally.
+TEST_F(ParquetWriterTest, dictionaryPassthroughInteger) {
+  constexpr vector_size_t kSize = 10'000;
+  constexpr int kDictSize = 50;
+
+  auto dictionary =
+      makeFlatVector<int32_t>(kDictSize, [](auto row) { return row * 7; });
+
+  BufferPtr indices =
+      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
+  auto rawIndices = indices->asMutable<vector_size_t>();
+  for (vector_size_t i = 0; i < kSize; ++i) {
+    rawIndices[i] = i % kDictSize;
+  }
+
+  auto dictVector = BaseVector::wrapInDictionary(
+      BufferPtr(nullptr), indices, kSize, dictionary);
+
+  auto data = makeRowVector({dictVector});
+  auto schema = asRowType(data->type());
+
+  auto* sinkPtr = write(data, ParquetWriterOptions{});
+
+  auto reader = createReaderInMemory(*sinkPtr);
+  ASSERT_EQ(reader->numberOfRows(), kSize);
+
+  auto rowReader = createRowReaderFromReader(*reader, schema);
+  VectorPtr flatDict = dictVector;
+  BaseVector::flattenVector(flatDict);
+  auto expected = makeRowVector({flatDict});
+  assertReadWithReaderAndExpected(schema, *rowReader, expected, *leafPool_);
+}
+
+/// Verifies that DictionaryVector<BIGINT> round-trips correctly and that the
+/// data is identical whether dictionary encoding or plain encoding is used in
+/// the Parquet file.
+TEST_F(ParquetWriterTest, dictionaryPassthroughBigint) {
+  constexpr vector_size_t kSize = 5'000;
+  constexpr int kDictSize = 100;
+
+  auto dictionary = makeFlatVector<int64_t>(kDictSize, [](auto row) {
+    return static_cast<int64_t>(row) * 1'000'000;
+  });
+
+  BufferPtr indices =
+      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
+  auto rawIndices = indices->asMutable<vector_size_t>();
+  for (vector_size_t i = 0; i < kSize; ++i) {
+    rawIndices[i] = i % kDictSize;
+  }
+
+  auto dictVector = BaseVector::wrapInDictionary(
+      BufferPtr(nullptr), indices, kSize, dictionary);
+
+  auto data = makeRowVector({dictVector});
+  auto schema = asRowType(data->type());
+
+  auto* sinkPtr = write(data, ParquetWriterOptions{});
+
+  auto reader = createReaderInMemory(*sinkPtr);
+  ASSERT_EQ(reader->numberOfRows(), kSize);
+
+  auto rowReader = createRowReaderFromReader(*reader, schema);
+  VectorPtr flatDict = dictVector;
+  BaseVector::flattenVector(flatDict);
+  auto expected = makeRowVector({flatDict});
+  assertReadWithReaderAndExpected(schema, *rowReader, expected, *leafPool_);
+}
+
+/// Verifies that writing multiple batches with changing dictionaries works
+/// correctly.  Each batch has a different dictionary, testing that the Arrow
+/// Parquet writer handles dictionary transitions across write() calls.
+TEST_F(ParquetWriterTest, dictionaryPassthroughMultipleBatches) {
+  constexpr vector_size_t kBatchSize = 2'000;
+  constexpr int kDictSize = 5;
+
+  auto schema = ROW({"c0"}, {VARCHAR()});
+
+  std::vector<RowVectorPtr> batches;
+  for (int batchIdx = 0; batchIdx < 3; ++batchIdx) {
+    std::vector<std::string> dictStrings(kDictSize);
+    for (int i = 0; i < kDictSize; ++i) {
+      dictStrings[i] = fmt::format("batch{}_{}", batchIdx, i);
+    }
+    auto dictionary = makeFlatVector<StringView>(
+        kDictSize, [&](auto row) { return StringView(dictStrings[row]); });
+
+    BufferPtr indices =
+        AlignedBuffer::allocate<vector_size_t>(kBatchSize, leafPool_.get());
+    auto rawIndices = indices->asMutable<vector_size_t>();
+    for (vector_size_t i = 0; i < kBatchSize; ++i) {
+      rawIndices[i] = i % kDictSize;
+    }
+
+    auto dictVector = BaseVector::wrapInDictionary(
+        BufferPtr(nullptr), indices, kBatchSize, dictionary);
+    batches.push_back(makeRowVector({dictVector}));
+  }
+
+  ParquetWriterOptions writerOptions;
+  auto* sinkPtr = write(batches, writerOptions);
+
+  auto reader = createReaderInMemory(*sinkPtr);
+  ASSERT_EQ(
+      reader->numberOfRows(),
+      static_cast<uint64_t>(kBatchSize) * batches.size());
+
+  // Build expected flat output by concatenating all batches.
+  auto totalSize = kBatchSize * batches.size();
+  std::vector<std::string> expectedStrings(totalSize);
+  for (size_t i = 0; i < totalSize; ++i) {
+    int batchIdx = i / kBatchSize;
+    int localIdx = i % kBatchSize;
+    expectedStrings[i] =
+        fmt::format("batch{}_{}", batchIdx, localIdx % kDictSize);
+  }
+  auto expected = makeRowVector({makeFlatVector<StringView>(
+      totalSize, [&](auto row) { return StringView(expectedStrings[row]); })});
+
+  auto rowReader = createRowReaderFromReader(*reader, schema);
+  assertReadWithReaderAndExpected(schema, *rowReader, expected, *leafPool_);
+}
+
+/// Verifies that DictionaryVector with nulls round-trips correctly.
+TEST_F(ParquetWriterTest, dictionaryPassthroughWithNulls) {
+  constexpr vector_size_t kSize = 5'000;
+  constexpr int kDictSize = 20;
+
+  std::vector<std::string> dictStrings(kDictSize);
+  for (int i = 0; i < kDictSize; ++i) {
+    dictStrings[i] = fmt::format("v_{}", i);
+  }
+  auto dictionary = makeFlatVector<StringView>(
+      kDictSize, [&](auto row) { return StringView(dictStrings[row]); });
+
+  BufferPtr indices =
+      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
+  auto rawIndices = indices->asMutable<vector_size_t>();
+  for (vector_size_t i = 0; i < kSize; ++i) {
+    rawIndices[i] = i % kDictSize;
+  }
+
+  // Every 3rd element is null.
+  auto nulls = makeNulls(kSize, [](auto row) { return row % 3 == 0; });
+
+  auto dictVector =
+      BaseVector::wrapInDictionary(nulls, indices, kSize, dictionary);
+  ASSERT_EQ(dictVector->encoding(), VectorEncoding::Simple::DICTIONARY);
+
+  auto data = makeRowVector({dictVector});
+  auto schema = asRowType(data->type());
+
+  auto* sinkPtr = write(data, ParquetWriterOptions{});
+
+  auto reader = createReaderInMemory(*sinkPtr);
+  ASSERT_EQ(reader->numberOfRows(), kSize);
+
+  auto rowReader = createRowReaderFromReader(*reader, schema);
+  VectorPtr flatDict = dictVector;
+  BaseVector::flattenVector(flatDict);
+  auto expected = makeRowVector({flatDict});
+  assertReadWithReaderAndExpected(schema, *rowReader, expected, *leafPool_);
+}
+
+/// Verifies that complex types (MAP, ARRAY, ROW) are written correctly without
+/// flattening when they are not wrapped in dictionary encoding.  This tests O2:
+/// the removal of the overly conservative isComplex check in needFlatten().
+TEST_F(ParquetWriterTest, complexTypesWithoutFlattening) {
+  constexpr vector_size_t kSize = 1'000;
+
+  // Pre-generate key strings for the map.
+  std::vector<std::string> keyStrings(kSize * 3);
+  for (vector_size_t i = 0; i < static_cast<vector_size_t>(keyStrings.size());
+       ++i) {
+    keyStrings[i] = fmt::format("key_{}", i);
+  }
+
+  auto mapVector = makeMapVector<StringView, int32_t>(
+      kSize,
+      [](auto row) { return row % 3 + 1; },
+      [&](auto row) { return StringView(keyStrings[row]); },
+      [](auto row) { return static_cast<int32_t>(row * 10); });
+
+  auto arrayVector = makeArrayVector<int64_t>(
+      kSize,
+      [](auto row) { return row % 4 + 1; },
+      [](auto row) { return static_cast<int64_t>(row * 100); });
+
+  auto data = makeRowVector({mapVector, arrayVector});
+  auto schema = asRowType(data->type());
+
+  auto* sinkPtr = write(data, ParquetWriterOptions{});
+
+  auto reader = createReaderInMemory(*sinkPtr);
+  ASSERT_EQ(reader->numberOfRows(), kSize);
+
+  auto rowReader = createRowReaderFromReader(*reader, schema);
+  assertReadWithReaderAndExpected(schema, *rowReader, data, *leafPool_);
+}
+
+/// Verifies that a mix of dictionary-encoded scalar columns and flat complex
+/// type columns in the same RowVector round-trips correctly.  This exercises
+/// the interaction between O1 (dictionary passthrough for scalars) and O2
+/// (no flattening for complex types).
+TEST_F(ParquetWriterTest, mixedDictionaryAndComplexTypes) {
+  constexpr vector_size_t kSize = 2'000;
+  constexpr int kDictSize = 15;
+
+  // Dictionary-encoded VARCHAR column.
+  std::vector<std::string> dictStrings(kDictSize);
+  for (int i = 0; i < kDictSize; ++i) {
+    dictStrings[i] = fmt::format("cat_{}", i);
+  }
+  auto dictionary = makeFlatVector<StringView>(
+      kDictSize, [&](auto row) { return StringView(dictStrings[row]); });
+  BufferPtr indices =
+      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
+  auto rawIndices = indices->asMutable<vector_size_t>();
+  for (vector_size_t i = 0; i < kSize; ++i) {
+    rawIndices[i] = i % kDictSize;
+  }
+  auto dictColumn = BaseVector::wrapInDictionary(
+      BufferPtr(nullptr), indices, kSize, dictionary);
+
+  // Flat ARRAY column.
+  auto arrayColumn = makeArrayVector<int32_t>(
+      kSize,
+      [](auto row) { return row % 3 + 1; },
+      [](auto row) { return static_cast<int32_t>(row); });
+
+  // Flat INTEGER column.
+  auto intColumn = makeFlatVector<int32_t>(kSize, [](auto row) { return row; });
+
+  auto data = makeRowVector({dictColumn, arrayColumn, intColumn});
+  auto schema = asRowType(data->type());
+
+  auto* sinkPtr = write(data, ParquetWriterOptions{});
+
+  auto reader = createReaderInMemory(*sinkPtr);
+  ASSERT_EQ(reader->numberOfRows(), kSize);
+
+  auto rowReader = createRowReaderFromReader(*reader, schema);
+  // Expected: flatten the dictionary column, keep complex and flat as-is.
+  VectorPtr flatDictCol = dictColumn;
+  BaseVector::flattenVector(flatDictCol);
+  auto expected = makeRowVector({flatDictCol, arrayColumn, intColumn});
+  assertReadWithReaderAndExpected(schema, *rowReader, expected, *leafPool_);
+}
+
+/// Verifies that dictionary wrapping a complex type (ARRAY) is correctly
+/// flattened before writing.  This exercises the isPrimitiveType() guard in
+/// needFlatten() — Arrow cannot handle DictionaryArray of complex types.
+TEST_F(ParquetWriterTest, dictionaryWrappingComplexTypeFlattens) {
+  constexpr vector_size_t kSize = 1'000;
+
+  auto arrayVector = makeArrayVector<int32_t>(
+      kSize,
+      [](auto row) { return row % 3 + 1; },
+      [](auto row) { return static_cast<int32_t>(row); });
+
+  BufferPtr indices =
+      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
+  auto rawIndices = indices->asMutable<vector_size_t>();
+  for (vector_size_t i = 0; i < kSize; ++i) {
+    rawIndices[i] = i;
+  }
+
+  auto dictOfArray = BaseVector::wrapInDictionary(
+      BufferPtr(nullptr), indices, kSize, arrayVector);
+  ASSERT_EQ(dictOfArray->encoding(), VectorEncoding::Simple::DICTIONARY);
+
+  auto data = makeRowVector({dictOfArray});
+  auto schema = asRowType(data->type());
+
+  auto* sinkPtr = write(data, ParquetWriterOptions{});
+
+  auto reader = createReaderInMemory(*sinkPtr);
+  ASSERT_EQ(reader->numberOfRows(), kSize);
+
+  auto rowReader = createRowReaderFromReader(*reader, schema);
+  // Expected output is the original unwrapped array (flattening removes the
+  // identity dictionary wrapping).
+  auto expected = makeRowVector({arrayVector});
+  assertReadWithReaderAndExpected(schema, *rowReader, expected, *leafPool_);
+}
+
+/// Verifies that dictionary-of-dictionary (nested wrapping) is correctly
+/// flattened.  This exercises the isFlatEncoding() guard in needFlatten().
+TEST_F(ParquetWriterTest, dictionaryOfDictionaryFlattens) {
+  constexpr vector_size_t kSize = 1'000;
+  constexpr int kDictSize = 10;
+
+  auto dictionary =
+      makeFlatVector<int32_t>(kDictSize, [](auto row) { return row * 11; });
+
+  BufferPtr innerIndices =
+      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
+  auto rawInner = innerIndices->asMutable<vector_size_t>();
+  for (vector_size_t i = 0; i < kSize; ++i) {
+    rawInner[i] = i % kDictSize;
+  }
+
+  auto innerDict = BaseVector::wrapInDictionary(
+      BufferPtr(nullptr), innerIndices, kSize, dictionary);
+
+  // Wrap the dictionary in another dictionary layer.
+  BufferPtr outerIndices =
+      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
+  auto rawOuter = outerIndices->asMutable<vector_size_t>();
+  for (vector_size_t i = 0; i < kSize; ++i) {
+    rawOuter[i] = i;
+  }
+  auto dictOfDict = BaseVector::wrapInDictionary(
+      BufferPtr(nullptr), outerIndices, kSize, innerDict);
+
+  auto data = makeRowVector({dictOfDict});
+  auto schema = asRowType(data->type());
+
+  auto* sinkPtr = write(data, ParquetWriterOptions{});
+
+  auto reader = createReaderInMemory(*sinkPtr);
+  ASSERT_EQ(reader->numberOfRows(), kSize);
+
+  auto rowReader = createRowReaderFromReader(*reader, schema);
+  VectorPtr flatExpected = dictOfDict;
+  BaseVector::flattenVector(flatExpected);
+  auto expected = makeRowVector({flatExpected});
+  assertReadWithReaderAndExpected(schema, *rowReader, expected, *leafPool_);
+}
+
+/// Verifies that a constant vector wrapping a dictionary is correctly
+/// flattened.  This exercises the CONSTANT branch in needFlatten().
+TEST_F(ParquetWriterTest, constantWrappingDictionaryFlattens) {
+  constexpr vector_size_t kSize = 500;
+
+  auto constantInt = makeConstant(static_cast<int32_t>(42), kSize);
+
+  auto data = makeRowVector({constantInt});
+  auto schema = asRowType(data->type());
+
+  auto* sinkPtr = write(data, ParquetWriterOptions{});
+
+  auto reader = createReaderInMemory(*sinkPtr);
+  ASSERT_EQ(reader->numberOfRows(), kSize);
+
+  auto rowReader = createRowReaderFromReader(*reader, schema);
+  VectorPtr flatExpected = constantInt;
+  BaseVector::flattenVector(flatExpected);
+  auto expected = makeRowVector({flatExpected});
+  assertReadWithReaderAndExpected(schema, *rowReader, expected, *leafPool_);
+}
+
+/// Verifies that an empty dictionary vector (0 rows) can be written without
+/// crashing.  The Parquet reader rejects empty files, so this test only
+/// verifies the write path.
+TEST_F(ParquetWriterTest, dictionaryPassthroughEmptyVector) {
+  constexpr vector_size_t kSize = 0;
+  constexpr int kDictSize = 5;
+
+  std::vector<std::string> dictStrings(kDictSize);
+  for (int i = 0; i < kDictSize; ++i) {
+    dictStrings[i] = fmt::format("v_{}", i);
+  }
+  auto dictionary = makeFlatVector<StringView>(
+      kDictSize, [&](auto row) { return StringView(dictStrings[row]); });
+
+  BufferPtr indices =
+      AlignedBuffer::allocate<vector_size_t>(0, leafPool_.get());
+
+  auto dictVector = BaseVector::wrapInDictionary(
+      BufferPtr(nullptr), indices, kSize, dictionary);
+
+  auto data = makeRowVector({dictVector});
+
+  // Write should succeed without crashing.
+  write(data, ParquetWriterOptions{});
+}
+
+/// Verifies that a single-row dictionary vector round-trips correctly.
+TEST_F(ParquetWriterTest, dictionaryPassthroughSingleRow) {
+  constexpr vector_size_t kSize = 1;
+
+  std::vector<std::string> dictStrings = {"only_value"};
+  auto dictionary = makeFlatVector<StringView>(
+      1, [&](auto row) { return StringView(dictStrings[row]); });
+
+  BufferPtr indices =
+      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
+  indices->asMutable<vector_size_t>()[0] = 0;
+
+  auto dictVector = BaseVector::wrapInDictionary(
+      BufferPtr(nullptr), indices, kSize, dictionary);
+
+  auto data = makeRowVector({dictVector});
+  auto schema = asRowType(data->type());
+
+  auto* sinkPtr = write(data, ParquetWriterOptions{});
+
+  auto reader = createReaderInMemory(*sinkPtr);
+  ASSERT_EQ(reader->numberOfRows(), kSize);
+
+  auto rowReader = createRowReaderFromReader(*reader, schema);
+  VectorPtr flatDict = dictVector;
+  BaseVector::flattenVector(flatDict);
+  auto expected = makeRowVector({flatDict});
+  assertReadWithReaderAndExpected(schema, *rowReader, expected, *leafPool_);
+}
+
+/// Verifies that a dictionary vector where every element is null round-trips.
+TEST_F(ParquetWriterTest, dictionaryPassthroughAllNulls) {
+  constexpr vector_size_t kSize = 1'000;
+  constexpr int kDictSize = 5;
+
+  std::vector<std::string> dictStrings(kDictSize);
+  for (int i = 0; i < kDictSize; ++i) {
+    dictStrings[i] = fmt::format("v_{}", i);
+  }
+  auto dictionary = makeFlatVector<StringView>(
+      kDictSize, [&](auto row) { return StringView(dictStrings[row]); });
+
+  BufferPtr indices =
+      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
+  auto rawIndices = indices->asMutable<vector_size_t>();
+  for (vector_size_t i = 0; i < kSize; ++i) {
+    rawIndices[i] = i % kDictSize;
+  }
+
+  // Every element is null.
+  auto nulls = makeNulls(kSize, [](auto /*row*/) { return true; });
+
+  auto dictVector =
+      BaseVector::wrapInDictionary(nulls, indices, kSize, dictionary);
+
+  auto data = makeRowVector({dictVector});
+  auto schema = asRowType(data->type());
+
+  auto* sinkPtr = write(data, ParquetWriterOptions{});
+
+  auto reader = createReaderInMemory(*sinkPtr);
+  ASSERT_EQ(reader->numberOfRows(), kSize);
+
+  auto rowReader = createRowReaderFromReader(*reader, schema);
+  VectorPtr flatDict = dictVector;
+  BaseVector::flattenVector(flatDict);
+  auto expected = makeRowVector({flatDict});
+  assertReadWithReaderAndExpected(schema, *rowReader, expected, *leafPool_);
+}
+
+/// Verifies that multiple dictionary-encoded columns in the same RowVector all
+/// pass through correctly.
+TEST_F(ParquetWriterTest, dictionaryPassthroughMultipleColumns) {
+  constexpr vector_size_t kSize = 2'000;
+
+  // First dict column: VARCHAR, cardinality 5.
+  constexpr int kDictSize1 = 5;
+  std::vector<std::string> strings1(kDictSize1);
+  for (int i = 0; i < kDictSize1; ++i) {
+    strings1[i] = fmt::format("a_{}", i);
+  }
+  auto dict1 = makeFlatVector<StringView>(
+      kDictSize1, [&](auto row) { return StringView(strings1[row]); });
+  BufferPtr idx1 =
+      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
+  auto raw1 = idx1->asMutable<vector_size_t>();
+  for (vector_size_t i = 0; i < kSize; ++i) {
+    raw1[i] = i % kDictSize1;
+  }
+  auto col1 =
+      BaseVector::wrapInDictionary(BufferPtr(nullptr), idx1, kSize, dict1);
+
+  // Second dict column: VARCHAR, cardinality 20.
+  constexpr int kDictSize2 = 20;
+  std::vector<std::string> strings2(kDictSize2);
+  for (int i = 0; i < kDictSize2; ++i) {
+    strings2[i] = fmt::format("b_{}", i);
+  }
+  auto dict2 = makeFlatVector<StringView>(
+      kDictSize2, [&](auto row) { return StringView(strings2[row]); });
+  BufferPtr idx2 =
+      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
+  auto raw2 = idx2->asMutable<vector_size_t>();
+  for (vector_size_t i = 0; i < kSize; ++i) {
+    raw2[i] = i % kDictSize2;
+  }
+  auto col2 =
+      BaseVector::wrapInDictionary(BufferPtr(nullptr), idx2, kSize, dict2);
+
+  // Third dict column: INTEGER, cardinality 50.
+  constexpr int kDictSize3 = 50;
+  auto dict3 =
+      makeFlatVector<int32_t>(kDictSize3, [](auto row) { return row * 3; });
+  BufferPtr idx3 =
+      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
+  auto raw3 = idx3->asMutable<vector_size_t>();
+  for (vector_size_t i = 0; i < kSize; ++i) {
+    raw3[i] = i % kDictSize3;
+  }
+  auto col3 =
+      BaseVector::wrapInDictionary(BufferPtr(nullptr), idx3, kSize, dict3);
+
+  auto data = makeRowVector({col1, col2, col3});
+  auto schema = asRowType(data->type());
+
+  auto* sinkPtr = write(data, ParquetWriterOptions{});
+
+  auto reader = createReaderInMemory(*sinkPtr);
+  ASSERT_EQ(reader->numberOfRows(), kSize);
+
+  auto rowReader = createRowReaderFromReader(*reader, schema);
+  VectorPtr flat1 = col1;
+  BaseVector::flattenVector(flat1);
+  VectorPtr flat2 = col2;
+  BaseVector::flattenVector(flat2);
+  VectorPtr flat3 = col3;
+  BaseVector::flattenVector(flat3);
+  auto expected = makeRowVector({flat1, flat2, flat3});
+  assertReadWithReaderAndExpected(schema, *rowReader, expected, *leafPool_);
+}
+
+/// Verifies dictionary passthrough for DOUBLE and BOOLEAN types.
+TEST_F(ParquetWriterTest, dictionaryPassthroughOtherPrimitiveTypes) {
+  constexpr vector_size_t kSize = 2'000;
+
+  // Dictionary DOUBLE column.
+  constexpr int kDoubleDictSize = 10;
+  auto doubleDictionary = makeFlatVector<double>(
+      kDoubleDictSize, [](auto row) { return row * 1.5; });
+  BufferPtr doubleIndices =
+      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
+  auto rawDoubleIdx = doubleIndices->asMutable<vector_size_t>();
+  for (vector_size_t i = 0; i < kSize; ++i) {
+    rawDoubleIdx[i] = i % kDoubleDictSize;
+  }
+  auto dictDouble = BaseVector::wrapInDictionary(
+      BufferPtr(nullptr), doubleIndices, kSize, doubleDictionary);
+
+  // Dictionary BOOLEAN column.
+  auto boolDictionary =
+      makeFlatVector<bool>(2, [](auto row) { return row == 1; });
+  BufferPtr boolIndices =
+      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
+  auto rawBoolIdx = boolIndices->asMutable<vector_size_t>();
+  for (vector_size_t i = 0; i < kSize; ++i) {
+    rawBoolIdx[i] = i % 2;
+  }
+  auto dictBool = BaseVector::wrapInDictionary(
+      BufferPtr(nullptr), boolIndices, kSize, boolDictionary);
+
+  auto data = makeRowVector({dictDouble, dictBool});
+  auto schema = asRowType(data->type());
+
+  auto* sinkPtr = write(data, ParquetWriterOptions{});
+
+  auto reader = createReaderInMemory(*sinkPtr);
+  ASSERT_EQ(reader->numberOfRows(), kSize);
+
+  auto rowReader = createRowReaderFromReader(*reader, schema);
+  VectorPtr flatDouble = dictDouble;
+  BaseVector::flattenVector(flatDouble);
+  VectorPtr flatBool = dictBool;
+  BaseVector::flattenVector(flatBool);
+  auto expected = makeRowVector({flatDouble, flatBool});
+  assertReadWithReaderAndExpected(schema, *rowReader, expected, *leafPool_);
+}
+
 TEST_F(ParquetWriterTest, allNulls) {
   auto schema = ROW({"c0"}, {INTEGER()});
   const int64_t kRows = 4096;

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -1463,7 +1463,10 @@ TEST_F(ParquetWriterTest, dictionaryPassthroughMultipleBatches) {
   }
 
   ParquetWriterOptions writerOptions;
-  auto* sinkPtr = write(batches, writerOptions);
+  dwio::common::WriterOptions options;
+  options.memoryPool = rootPool_.get();
+  options.schema = schema;
+  auto* sinkPtr = write(batches, options, writerOptions);
 
   auto reader = createReaderInMemory(*sinkPtr);
   ASSERT_EQ(
@@ -2015,6 +2018,94 @@ TEST_F(ParquetWriterTest, allNulls) {
 
   auto rowReader = createRowReaderFromReader(*reader, schema);
   assertReadWithReaderAndExpected(schema, *rowReader, data, *leafPool_);
+}
+
+/// Verifies that close() without any prior write() does not crash.
+TEST_F(ParquetWriterTest, closeWithoutWrite) {
+  auto schema = ROW({"c0"}, {INTEGER()});
+  auto sink = std::make_unique<dwio::common::MemorySink>(
+      200 * 1024 * 1024,
+      dwio::common::FileSink::Options{.pool = leafPool_.get()});
+  dwio::common::WriterOptions options;
+  options.memoryPool = rootPool_.get();
+  options.formatSpecificOptions = std::make_shared<ParquetWriterOptions>();
+  auto writer =
+      std::make_unique<parquet::Writer>(std::move(sink), options, schema);
+  writer->close();
+}
+
+/// Verifies that flush() with no accumulated data is a no-op.
+TEST_F(ParquetWriterTest, flushWithNoData) {
+  auto schema = ROW({"c0"}, {INTEGER()});
+  auto sink = std::make_unique<dwio::common::MemorySink>(
+      200 * 1024 * 1024,
+      dwio::common::FileSink::Options{.pool = leafPool_.get()});
+  auto* sinkPtr = sink.get();
+  dwio::common::WriterOptions options;
+  options.memoryPool = rootPool_.get();
+  options.formatSpecificOptions = std::make_shared<ParquetWriterOptions>();
+  auto writer =
+      std::make_unique<parquet::Writer>(std::move(sink), options, schema);
+  writer->flush();
+
+  auto data = makeRowVector(
+      {makeFlatVector<int32_t>(100, [](auto row) { return row; })});
+  writer->write(data);
+  writer->close();
+
+  auto reader = createReaderInMemory(*sinkPtr);
+  ASSERT_EQ(reader->numberOfRows(), 100);
+}
+
+/// Verifies that multiple consecutive flush() calls are idempotent.
+TEST_F(ParquetWriterTest, consecutiveFlushCalls) {
+  auto schema = ROW({"c0"}, {INTEGER()});
+  auto sink = std::make_unique<dwio::common::MemorySink>(
+      200 * 1024 * 1024,
+      dwio::common::FileSink::Options{.pool = leafPool_.get()});
+  auto* sinkPtr = sink.get();
+  dwio::common::WriterOptions options;
+  options.memoryPool = rootPool_.get();
+  options.formatSpecificOptions = std::make_shared<ParquetWriterOptions>();
+  auto writer =
+      std::make_unique<parquet::Writer>(std::move(sink), options, schema);
+
+  auto data = makeRowVector(
+      {makeFlatVector<int32_t>(100, [](auto row) { return row; })});
+  writer->write(data);
+  writer->flush();
+  writer->flush();
+  writer->flush();
+
+  writer->write(data);
+  writer->close();
+
+  auto reader = createReaderInMemory(*sinkPtr);
+  ASSERT_EQ(reader->numberOfRows(), 200);
+}
+
+/// Verifies that a single large batch exceeding maxRowGroupLength is correctly
+/// split into multiple row groups by writeRecordBatch.
+TEST_F(ParquetWriterTest, batchExceedingRowGroupSize) {
+  constexpr vector_size_t kSize = 1'000;
+  constexpr int kRowsPerGroup = 100;
+
+  auto data = makeRowVector(
+      {makeFlatVector<int32_t>(kSize, [](auto row) { return row; })});
+  auto schema = asRowType(data->type());
+
+  dwio::common::WriterOptions options;
+  options.memoryPool = rootPool_.get();
+  options.flushPolicyFactory = [kRowsPerGroup]() {
+    return std::make_unique<DefaultFlushPolicy>(
+        /*rowsInRowGroup=*/kRowsPerGroup,
+        /*bytesInRowGroup=*/512 * 1'024 * 1'024);
+  };
+  auto* sinkPtr = write(data, options, ParquetWriterOptions{});
+
+  auto reader = createReaderInMemory(*sinkPtr);
+  ASSERT_EQ(reader->numberOfRows(), kSize);
+  ASSERT_EQ(reader->fileMetaData().numRowGroups(), kSize / kRowsPerGroup);
 }
 
 } // namespace

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -2196,6 +2196,98 @@ TEST_F(ParquetWriterTest, parallelColumnWriteMultiBatch) {
   ASSERT_EQ(reader->fileMetaData().numRowGroups(), 2);
 }
 
+/// Verifies that the flush policy uses actual retained size, not flat estimate,
+/// for dictionary columns. With estimateFlatSize() the 100K-row dictionary
+/// column would appear to be ~6MB (100K * 60-byte strings), exceeding a 2MB
+/// bytesInRowGroup threshold and causing multiple row groups. With
+/// retainedSize() the actual footprint is ~500KB (dictionary + indices),
+/// fitting in a single row group.
+TEST_F(ParquetWriterTest, flushEstimationDictionaryAware) {
+  constexpr vector_size_t kSize = 100'000;
+  constexpr int kDictSize = 10;
+
+  // Dictionary of 10 strings, each ~60 bytes. estimateFlatSize would report
+  // 100K * 60 = 6MB. retainedSize reports ~600 bytes + 400KB indices = ~400KB.
+  std::vector<std::string> dictStrings(kDictSize);
+  for (int i = 0; i < kDictSize; ++i) {
+    dictStrings[i] =
+        fmt::format("this_is_a_longer_dictionary_value_for_testing_{:04d}", i);
+  }
+  auto dictionary = makeFlatVector<StringView>(
+      kDictSize, [&](auto row) { return StringView(dictStrings[row]); });
+
+  BufferPtr indices =
+      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
+  auto rawIndices = indices->asMutable<vector_size_t>();
+  for (vector_size_t i = 0; i < kSize; ++i) {
+    rawIndices[i] = i % kDictSize;
+  }
+  auto dictVector = BaseVector::wrapInDictionary(
+      BufferPtr(nullptr), indices, kSize, dictionary);
+
+  auto data = makeRowVector({dictVector});
+  auto schema = asRowType(data->type());
+
+  // Set bytesInRowGroup to 2MB. With estimateFlatSize (~6MB), this would
+  // produce multiple row groups. With retainedSize (~400KB), it fits in one.
+  dwio::common::WriterOptions options;
+  options.memoryPool = rootPool_.get();
+  options.flushPolicyFactory = []() {
+    return std::make_unique<DefaultFlushPolicy>(
+        /*rowsInRowGroup=*/1'000'000,
+        /*bytesInRowGroup=*/2 * 1'024 * 1'024);
+  };
+  auto* sinkPtr = write(data, options, ParquetWriterOptions{});
+
+  auto reader = createReaderInMemory(*sinkPtr);
+  ASSERT_EQ(reader->numberOfRows(), kSize);
+  // Should be a single row group because the actual data size is well under
+  // the 2MB threshold.
+  ASSERT_EQ(reader->fileMetaData().numRowGroups(), 1);
+}
+
+/// Verifies that flat columns still trigger flush at the correct threshold.
+/// This ensures retainedSize() doesn't under-report for non-dictionary data.
+TEST_F(ParquetWriterTest, flushEstimationFlatColumns) {
+  // Write 50K rows of int32 (200KB) + 50K rows of int64 (400KB) = 600KB.
+  // With bytesInRowGroup=500KB, the first batch should trigger a flush before
+  // the second batch.
+  constexpr vector_size_t kBatchSize = 50'000;
+
+  auto batch = makeRowVector({
+      makeFlatVector<int32_t>(kBatchSize, [](auto row) { return row; }),
+      makeFlatVector<int64_t>(
+          kBatchSize, [](auto row) { return static_cast<int64_t>(row); }),
+  });
+  auto schema = asRowType(batch->type());
+
+  auto sink = std::make_unique<dwio::common::MemorySink>(
+      200 * 1024 * 1024,
+      dwio::common::FileSink::Options{.pool = leafPool_.get()});
+  auto* sinkPtr = sink.get();
+  dwio::common::WriterOptions options;
+  options.memoryPool = rootPool_.get();
+  options.flushPolicyFactory = []() {
+    return std::make_unique<DefaultFlushPolicy>(
+        /*rowsInRowGroup=*/1'000'000,
+        /*bytesInRowGroup=*/500 * 1'024);
+  };
+  auto parquetOpts = std::make_shared<ParquetWriterOptions>();
+  options.formatSpecificOptions = parquetOpts;
+  auto writer =
+      std::make_unique<parquet::Writer>(std::move(sink), options, schema);
+
+  writer->write(batch);
+  writer->write(batch);
+  writer->close();
+
+  auto reader = createReaderInMemory(*sinkPtr);
+  ASSERT_EQ(reader->numberOfRows(), kBatchSize * 2);
+  // The second write triggers a flush because the first batch (~600KB)
+  // exceeds the 500KB threshold.
+  ASSERT_EQ(reader->fileMetaData().numRowGroups(), 2);
+}
+
 } // namespace
 
 int main(int argc, char** argv) {

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -1928,6 +1928,69 @@ TEST_F(ParquetWriterTest, dictionaryPassthroughOtherPrimitiveTypes) {
   assertReadWithReaderAndExpected(schema, *rowReader, expected, *leafPool_);
 }
 
+/// Verifies selective per-column flattening: a dict-of-dict column (must
+/// flatten) alongside a passthrough dictionary column (must NOT flatten).
+/// With blanket flattening, both would be materialized. With selective
+/// flattening, only the nested-dict column is flattened while the simple
+/// dictionary passes through to Arrow.
+TEST_F(ParquetWriterTest, selectiveFlatteningMixedEncodings) {
+  constexpr vector_size_t kSize = 2'000;
+
+  // Column 0: simple dictionary VARCHAR (should pass through).
+  constexpr int kDictSize = 10;
+  std::vector<std::string> dictStrings(kDictSize);
+  for (int i = 0; i < kDictSize; ++i) {
+    dictStrings[i] = fmt::format("pass_{}", i);
+  }
+  auto dict = makeFlatVector<StringView>(
+      kDictSize, [&](auto row) { return StringView(dictStrings[row]); });
+  BufferPtr idx =
+      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
+  auto rawIdx = idx->asMutable<vector_size_t>();
+  for (vector_size_t i = 0; i < kSize; ++i) {
+    rawIdx[i] = i % kDictSize;
+  }
+  auto passthroughCol =
+      BaseVector::wrapInDictionary(BufferPtr(nullptr), idx, kSize, dict);
+
+  // Column 1: dict-of-dict INTEGER (must flatten).
+  constexpr int kInnerDictSize = 20;
+  auto innerDict =
+      makeFlatVector<int32_t>(kInnerDictSize, [](auto row) { return row * 5; });
+  BufferPtr innerIdx =
+      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
+  auto rawInner = innerIdx->asMutable<vector_size_t>();
+  for (vector_size_t i = 0; i < kSize; ++i) {
+    rawInner[i] = i % kInnerDictSize;
+  }
+  auto innerDictVec = BaseVector::wrapInDictionary(
+      BufferPtr(nullptr), innerIdx, kSize, innerDict);
+  BufferPtr outerIdx =
+      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
+  auto rawOuter = outerIdx->asMutable<vector_size_t>();
+  for (vector_size_t i = 0; i < kSize; ++i) {
+    rawOuter[i] = i;
+  }
+  auto nestedDictCol = BaseVector::wrapInDictionary(
+      BufferPtr(nullptr), outerIdx, kSize, innerDictVec);
+
+  auto data = makeRowVector({passthroughCol, nestedDictCol});
+  auto schema = asRowType(data->type());
+
+  auto* sinkPtr = write(data, ParquetWriterOptions{});
+
+  auto reader = createReaderInMemory(*sinkPtr);
+  ASSERT_EQ(reader->numberOfRows(), kSize);
+
+  auto rowReader = createRowReaderFromReader(*reader, schema);
+  VectorPtr flatPassthrough = passthroughCol;
+  BaseVector::flattenVector(flatPassthrough);
+  VectorPtr flatNested = nestedDictCol;
+  BaseVector::flattenVector(flatNested);
+  auto expected = makeRowVector({flatPassthrough, flatNested});
+  assertReadWithReaderAndExpected(schema, *rowReader, expected, *leafPool_);
+}
+
 TEST_F(ParquetWriterTest, allNulls) {
   auto schema = ROW({"c0"}, {INTEGER()});
   const int64_t kRows = 4096;

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -246,7 +246,6 @@ TEST_F(ParquetWriterTest, createFormatOptions) {
       {"hive.parquet.writer.enable-dictionary", "true"},
       {"hive.parquet.writer.page-size", "2KB"},
       {"hive.parquet.writer.created-by", "test-writer"},
-      {"hive.parquet.writer.enable-parallel-write", "true"},
       {"iceberg.parquet.writer.page-size", "4KB"},
   });
   config::ConfigBase session({
@@ -268,7 +267,6 @@ TEST_F(ParquetWriterTest, createFormatOptions) {
   EXPECT_EQ(parquetOptions->dataPageSize.value(), 2 * 1024);
   EXPECT_EQ(parquetOptions->batchSize.value(), 97);
   EXPECT_EQ(parquetOptions->createdBy.value(), "test-writer");
-  EXPECT_TRUE(parquetOptions->enableParallelWrite);
 
   config::ConfigBase icebergConnectorConfig(
       rawConnectorConfig.rawConfigsWithPrefix("iceberg.parquet."));
@@ -1322,10 +1320,10 @@ TEST_F(ParquetWriterTest, dictionaryEncodedVector) {
   write(data);
 }
 
-/// Verifies round-trip correctness when writing DictionaryVector<VARCHAR> with
-/// low cardinality.  With flattenDictionary=false the bridge exports a
-/// DictionaryArray that the Arrow Parquet writer encodes directly via
-/// writeArrowDictionary().
+// Verifies round-trip correctness when writing DictionaryVector<VARCHAR> with
+// low cardinality.  With flattenDictionary=false the bridge exports a
+// DictionaryArray that the Arrow Parquet writer encodes directly via
+// writeArrowDictionary().
 TEST_F(ParquetWriterTest, dictionaryPassthroughVarcharLowCardinality) {
   constexpr vector_size_t kSize = 10'000;
   constexpr int kDictSize = 10;
@@ -1345,9 +1343,9 @@ TEST_F(ParquetWriterTest, dictionaryPassthroughVarcharLowCardinality) {
   assertFlattenedRoundTrip(makeRowVector({dictVector}));
 }
 
-/// Verifies round-trip correctness with high-cardinality VARCHAR dictionary
-/// (all unique values).  The Arrow Parquet writer may abandon dictionary
-/// encoding and fall back to PLAIN.
+// Verifies round-trip correctness with high-cardinality VARCHAR dictionary
+// (all unique values).  The Arrow Parquet writer may abandon dictionary
+// encoding and fall back to PLAIN.
 TEST_F(ParquetWriterTest, dictionaryPassthroughVarcharHighCardinality) {
   constexpr vector_size_t kSize = 10'000;
 
@@ -1365,11 +1363,11 @@ TEST_F(ParquetWriterTest, dictionaryPassthroughVarcharHighCardinality) {
   assertFlattenedRoundTrip(makeRowVector({dictVector}));
 }
 
-/// Verifies that dictionary-encoded non-string primitive columns (INTEGER,
-/// BIGINT, DOUBLE, BOOLEAN) round-trip correctly. These share the same
-/// non-VARCHAR/VARBINARY path: childNeedsFlatten() forces flattening because
-/// Arrow's Parquet writer only supports dictionary passthrough for binary-like
-/// scalar types.
+// Verifies that dictionary-encoded non-string primitive columns (INTEGER,
+// BIGINT, DOUBLE, BOOLEAN) round-trip correctly. These share the same
+// non-VARCHAR/VARBINARY path: childNeedsFlatten() forces flattening because
+// Arrow's Parquet writer only supports dictionary passthrough for binary-like
+// scalar types.
 TEST_F(ParquetWriterTest, dictionaryNonStringPrimitivesFlatten) {
   constexpr vector_size_t kSize = 10'000;
 
@@ -1392,9 +1390,9 @@ TEST_F(ParquetWriterTest, dictionaryNonStringPrimitivesFlatten) {
   assertFlattenedRoundTrip(data);
 }
 
-/// Verifies that writing multiple batches with changing dictionaries works
-/// correctly.  Each batch has a different dictionary, testing that the Arrow
-/// Parquet writer handles dictionary transitions across write() calls.
+// Verifies that writing multiple batches with changing dictionaries works
+// correctly.  Each batch has a different dictionary, testing that the Arrow
+// Parquet writer handles dictionary transitions across write() calls.
 TEST_F(ParquetWriterTest, dictionaryPassthroughMultipleBatches) {
   constexpr vector_size_t kBatchSize = 2'000;
   constexpr int kDictSize = 5;
@@ -1442,7 +1440,7 @@ TEST_F(ParquetWriterTest, dictionaryPassthroughMultipleBatches) {
   assertReadWithReaderAndExpected(schema, *rowReader, expected, *leafPool_);
 }
 
-/// Verifies that DictionaryVector with nulls round-trips correctly.
+// Verifies that DictionaryVector with nulls round-trips correctly.
 TEST_F(ParquetWriterTest, dictionaryPassthroughWithNulls) {
   constexpr vector_size_t kSize = 5'000;
   constexpr int kDictSize = 20;
@@ -1465,9 +1463,9 @@ TEST_F(ParquetWriterTest, dictionaryPassthroughWithNulls) {
   assertFlattenedRoundTrip(makeRowVector({dictVector}));
 }
 
-/// Verifies that complex types (MAP, ARRAY, ROW) are written correctly without
-/// flattening when they are not wrapped in dictionary encoding.  This tests O2:
-/// the removal of the overly conservative isComplex check in needFlatten().
+// Verifies that complex types (MAP, ARRAY, ROW) are written correctly without
+// flattening when they are not wrapped in dictionary encoding.  This tests O2:
+// the removal of the overly conservative isComplex check in needFlatten().
 TEST_F(ParquetWriterTest, complexTypesWithoutFlattening) {
   constexpr vector_size_t kSize = 1'000;
 
@@ -1494,10 +1492,10 @@ TEST_F(ParquetWriterTest, complexTypesWithoutFlattening) {
   assertFlattenedRoundTrip(data);
 }
 
-/// Verifies that a mix of dictionary-encoded scalar columns and flat complex
-/// type columns in the same RowVector round-trips correctly.  This exercises
-/// the interaction between O1 (dictionary passthrough for scalars) and O2
-/// (no flattening for complex types).
+// Verifies that a mix of dictionary-encoded scalar columns and flat complex
+// type columns in the same RowVector round-trips correctly.  This exercises
+// the interaction between O1 (dictionary passthrough for scalars) and O2
+// (no flattening for complex types).
 TEST_F(ParquetWriterTest, mixedDictionaryAndComplexTypes) {
   constexpr vector_size_t kSize = 2'000;
   constexpr int kDictSize = 15;
@@ -1524,9 +1522,9 @@ TEST_F(ParquetWriterTest, mixedDictionaryAndComplexTypes) {
   assertFlattenedRoundTrip(makeRowVector({dictColumn, arrayColumn, intColumn}));
 }
 
-/// Verifies that dictionary wrapping a complex type (ARRAY) is correctly
-/// flattened before writing.  This exercises the isPrimitiveType() guard in
-/// needFlatten() — Arrow cannot handle DictionaryArray of complex types.
+// Verifies that dictionary wrapping a complex type (ARRAY) is correctly
+// flattened before writing.  This exercises the isPrimitiveType() guard in
+// needFlatten() — Arrow cannot handle DictionaryArray of complex types.
 TEST_F(ParquetWriterTest, dictionaryWrappingComplexTypeFlattens) {
   constexpr vector_size_t kSize = 1'000;
 
@@ -1544,8 +1542,8 @@ TEST_F(ParquetWriterTest, dictionaryWrappingComplexTypeFlattens) {
   assertRoundTrip(makeRowVector({dictOfArray}), makeRowVector({arrayVector}));
 }
 
-/// Verifies that dictionary-of-dictionary (nested wrapping) is correctly
-/// flattened.  This exercises the isFlatEncoding() guard in needFlatten().
+// Verifies that dictionary-of-dictionary (nested wrapping) is correctly
+// flattened.  This exercises the isFlatEncoding() guard in needFlatten().
 TEST_F(ParquetWriterTest, dictionaryOfDictionaryFlattens) {
   constexpr vector_size_t kSize = 1'000;
   constexpr int kDictSize = 10;
@@ -1562,11 +1560,11 @@ TEST_F(ParquetWriterTest, dictionaryOfDictionaryFlattens) {
   assertFlattenedRoundTrip(makeRowVector({dictOfDict}));
 }
 
-/// Verifies that a constant wrapping a dictionary is correctly flattened.
-/// wrapInConstant peels the scalar dictionary layers, so to keep a non-flat
-/// wrapped vector the dictionary wraps a complex (ARRAY) type. This exercises
-/// the CONSTANT branch in childNeedsFlatten(), which flattens a constant whose
-/// wrapped vector is not flat.
+// Verifies that a constant wrapping a dictionary is correctly flattened.
+// wrapInConstant peels the scalar dictionary layers, so to keep a non-flat
+// wrapped vector the dictionary wraps a complex (ARRAY) type. This exercises
+// the CONSTANT branch in childNeedsFlatten(), which flattens a constant whose
+// wrapped vector is not flat.
 TEST_F(ParquetWriterTest, constantWrappingDictionaryFlattens) {
   constexpr vector_size_t kSize = 500;
   constexpr int kDictSize = 10;
@@ -1585,9 +1583,9 @@ TEST_F(ParquetWriterTest, constantWrappingDictionaryFlattens) {
   assertFlattenedRoundTrip(makeRowVector({constColumn}));
 }
 
-/// Verifies that an empty dictionary vector (0 rows) can be written without
-/// crashing.  The Parquet reader rejects empty files, so this test only
-/// verifies the write path.
+// Verifies that an empty dictionary vector (0 rows) can be written without
+// crashing.  The Parquet reader rejects empty files, so this test only
+// verifies the write path.
 TEST_F(ParquetWriterTest, dictionaryPassthroughEmptyVector) {
   constexpr vector_size_t kSize = 0;
   constexpr int kDictSize = 5;
@@ -1608,7 +1606,7 @@ TEST_F(ParquetWriterTest, dictionaryPassthroughEmptyVector) {
   write(data, ParquetWriterOptions{});
 }
 
-/// Verifies that a dictionary vector where every element is null round-trips.
+// Verifies that a dictionary vector where every element is null round-trips.
 TEST_F(ParquetWriterTest, dictionaryPassthroughAllNulls) {
   constexpr vector_size_t kSize = 1'000;
   constexpr int kDictSize = 5;
@@ -1630,11 +1628,11 @@ TEST_F(ParquetWriterTest, dictionaryPassthroughAllNulls) {
   assertFlattenedRoundTrip(makeRowVector({dictVector}));
 }
 
-/// Verifies that a complex column that is flat at the top level but contains a
-/// dictionary-encoded descendant is flattened before Arrow export. Dictionary
-/// passthrough is only safe for top-level scalar VARCHAR/VARBINARY columns, so
-/// childNeedsFlatten() recurses into ARRAY/MAP/ROW children to catch nested
-/// dictionaries the bridge would otherwise export as DictionaryArrays.
+// Verifies that a complex column that is flat at the top level but contains a
+// dictionary-encoded descendant is flattened before Arrow export. Dictionary
+// passthrough is only safe for top-level scalar VARCHAR/VARBINARY columns, so
+// childNeedsFlatten() recurses into ARRAY/MAP/ROW children to catch nested
+// dictionaries the bridge would otherwise export as DictionaryArrays.
 TEST_F(ParquetWriterTest, flatComplexWithEncodedDescendantFlattens) {
   constexpr vector_size_t kSize = 1'000;
   constexpr int kDictSize = 10;
@@ -1665,11 +1663,11 @@ TEST_F(ParquetWriterTest, flatComplexWithEncodedDescendantFlattens) {
   assertFlattenedRoundTrip(makeRowVector({structColumn, arrayColumn}));
 }
 
-/// Verifies selective per-column flattening: a dict-of-dict column (must
-/// flatten) alongside a passthrough dictionary column (must NOT flatten).
-/// With blanket flattening, both would be materialized. With selective
-/// flattening, only the nested-dict column is flattened while the simple
-/// dictionary passes through to Arrow.
+// Verifies selective per-column flattening: a dict-of-dict column (must
+// flatten) alongside a passthrough dictionary column (must NOT flatten).
+// With blanket flattening, both would be materialized. With selective
+// flattening, only the nested-dict column is flattened while the simple
+// dictionary passes through to Arrow.
 TEST_F(ParquetWriterTest, selectiveFlatteningMixedEncodings) {
   constexpr vector_size_t kSize = 2'000;
 
@@ -1722,7 +1720,7 @@ TEST_F(ParquetWriterTest, allNulls) {
   assertReadWithReaderAndExpected(schema, *rowReader, data, *leafPool_);
 }
 
-/// Verifies that close() without any prior write() does not crash.
+// Verifies that close() without any prior write() does not crash.
 TEST_F(ParquetWriterTest, closeWithoutWrite) {
   auto schema = ROW({"c0"}, {INTEGER()});
   auto sink = std::make_unique<dwio::common::MemorySink>(
@@ -1736,7 +1734,7 @@ TEST_F(ParquetWriterTest, closeWithoutWrite) {
   writer->close();
 }
 
-/// Verifies that flush() with no accumulated data is a no-op.
+// Verifies that flush() with no accumulated data is a no-op.
 TEST_F(ParquetWriterTest, flushWithNoData) {
   auto schema = ROW({"c0"}, {INTEGER()});
   auto sink = std::make_unique<dwio::common::MemorySink>(
@@ -1759,7 +1757,7 @@ TEST_F(ParquetWriterTest, flushWithNoData) {
   ASSERT_EQ(reader->numberOfRows(), 100);
 }
 
-/// Verifies that multiple consecutive flush() calls are idempotent.
+// Verifies that multiple consecutive flush() calls are idempotent.
 TEST_F(ParquetWriterTest, consecutiveFlushCalls) {
   auto schema = ROW({"c0"}, {INTEGER()});
   auto sink = std::make_unique<dwio::common::MemorySink>(
@@ -1786,8 +1784,8 @@ TEST_F(ParquetWriterTest, consecutiveFlushCalls) {
   ASSERT_EQ(reader->numberOfRows(), 200);
 }
 
-/// Verifies that a single large batch exceeding maxRowGroupLength is correctly
-/// split into multiple row groups by writeRecordBatch.
+// Verifies that a single large batch exceeding maxRowGroupLength is correctly
+// split into multiple row groups by writeRecordBatch.
 TEST_F(ParquetWriterTest, batchExceedingRowGroupSize) {
   constexpr vector_size_t kSize = 1'000;
   constexpr int kRowsPerGroup = 100;
@@ -1810,100 +1808,12 @@ TEST_F(ParquetWriterTest, batchExceedingRowGroupSize) {
   ASSERT_EQ(reader->fileMetaData().numRowGroups(), kSize / kRowsPerGroup);
 }
 
-/// Verifies that parallel column writing produces correct results by
-/// round-tripping data through write and read with enableParallelWrite=true.
-TEST_F(ParquetWriterTest, parallelColumnWriteCorrectness) {
-  constexpr vector_size_t kSize = 10'000;
-  constexpr int kDictSize = 20;
-
-  std::vector<std::string> dictStrings(kDictSize);
-  for (int i = 0; i < kDictSize; ++i) {
-    dictStrings[i] = fmt::format("str_{}", i);
-  }
-  auto dictVarchar = makeFlatVector<StringView>(
-      kDictSize, [&](auto row) { return StringView(dictStrings[row]); });
-  BufferPtr idx =
-      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
-  auto rawIdx = idx->asMutable<vector_size_t>();
-  for (vector_size_t i = 0; i < kSize; ++i) {
-    rawIdx[i] = i % kDictSize;
-  }
-  auto col0 =
-      BaseVector::wrapInDictionary(BufferPtr(nullptr), idx, kSize, dictVarchar);
-
-  auto col1 = makeFlatVector<int64_t>(
-      kSize, [](auto row) { return static_cast<int64_t>(row) * 1'000; });
-  auto col2 =
-      makeFlatVector<double>(kSize, [](auto row) { return row * 3.14; });
-  auto col3 = makeFlatVector<int32_t>(kSize, [](auto row) { return row; });
-
-  auto data = makeRowVector({col0, col1, col2, col3});
-  auto schema = asRowType(data->type());
-
-  auto sink = std::make_unique<dwio::common::MemorySink>(
-      200 * 1024 * 1024,
-      dwio::common::FileSink::Options{.pool = leafPool_.get()});
-  auto* sinkPtr = sink.get();
-  dwio::common::WriterOptions options;
-  options.memoryPool = rootPool_.get();
-  options.compressionKind = common::CompressionKind_ZSTD;
-  auto parquetOpts = std::make_shared<ParquetWriterOptions>();
-  parquetOpts->enableParallelWrite = true;
-  options.formatSpecificOptions = parquetOpts;
-  auto writer =
-      std::make_unique<parquet::Writer>(std::move(sink), options, schema);
-  writer->write(data);
-  writer->close();
-
-  auto reader = createReaderInMemory(*sinkPtr);
-  ASSERT_EQ(reader->numberOfRows(), kSize);
-
-  auto rowReader = createRowReaderFromReader(*reader, schema);
-  VectorPtr flatCol0 = col0;
-  BaseVector::flattenVector(flatCol0);
-  auto expected = makeRowVector({flatCol0, col1, col2, col3});
-  assertReadWithReaderAndExpected(schema, *rowReader, expected, *leafPool_);
-}
-
-/// Verifies parallel writing with multiple batches and flush between them.
-TEST_F(ParquetWriterTest, parallelColumnWriteMultiBatch) {
-  constexpr vector_size_t kBatchSize = 5'000;
-
-  auto batch = makeRowVector({
-      makeFlatVector<int32_t>(kBatchSize, [](auto row) { return row; }),
-      makeFlatVector<int64_t>(
-          kBatchSize, [](auto row) { return static_cast<int64_t>(row) * 7; }),
-  });
-  auto schema = asRowType(batch->type());
-
-  auto sink = std::make_unique<dwio::common::MemorySink>(
-      200 * 1024 * 1024,
-      dwio::common::FileSink::Options{.pool = leafPool_.get()});
-  auto* sinkPtr = sink.get();
-  dwio::common::WriterOptions options;
-  options.memoryPool = rootPool_.get();
-  auto parquetOpts = std::make_shared<ParquetWriterOptions>();
-  parquetOpts->enableParallelWrite = true;
-  options.formatSpecificOptions = parquetOpts;
-  auto writer =
-      std::make_unique<parquet::Writer>(std::move(sink), options, schema);
-
-  writer->write(batch);
-  writer->flush();
-  writer->write(batch);
-  writer->close();
-
-  auto reader = createReaderInMemory(*sinkPtr);
-  ASSERT_EQ(reader->numberOfRows(), kBatchSize * 2);
-  ASSERT_EQ(reader->fileMetaData().numRowGroups(), 2);
-}
-
-/// Verifies that the flush policy uses actual retained size, not flat estimate,
-/// for dictionary columns. With estimateFlatSize() the 100K-row dictionary
-/// column would appear to be ~6MB (100K * 60-byte strings), exceeding a 2MB
-/// bytesInRowGroup threshold and causing multiple row groups. With
-/// retainedSize() the actual footprint is ~500KB (dictionary + indices),
-/// fitting in a single row group.
+// Verifies that the flush policy uses actual retained size, not flat estimate,
+// for dictionary columns. With estimateFlatSize() the 100K-row dictionary
+// column would appear to be ~6MB (100K * 60-byte strings), exceeding a 2MB
+// bytesInRowGroup threshold and causing multiple row groups. With
+// retainedSize() the actual footprint is ~500KB (dictionary + indices),
+// fitting in a single row group.
 TEST_F(ParquetWriterTest, flushEstimationDictionaryAware) {
   constexpr vector_size_t kSize = 100'000;
   constexpr int kDictSize = 10;
@@ -1948,8 +1858,8 @@ TEST_F(ParquetWriterTest, flushEstimationDictionaryAware) {
   ASSERT_EQ(reader->fileMetaData().numRowGroups(), 1);
 }
 
-/// Verifies that flat columns still trigger flush at the correct threshold.
-/// This ensures retainedSize() doesn't under-report for non-dictionary data.
+// Verifies that flat columns still trigger flush at the correct threshold.
+// This ensures retainedSize() doesn't under-report for non-dictionary data.
 TEST_F(ParquetWriterTest, flushEstimationFlatColumns) {
   // Write 50K rows of int32 (200KB) + 50K rows of int64 (400KB) = 600KB.
   // With bytesInRowGroup=500KB, the first batch should trigger a flush before

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -1440,6 +1440,113 @@ TEST_F(ParquetWriterTest, dictionaryPassthroughMultipleBatches) {
   assertReadWithReaderAndExpected(schema, *rowReader, expected, *leafPool_);
 }
 
+// Verifies a multi-batch write where a passthrough VARCHAR dictionary batch is
+// followed by a flat VARCHAR batch. The first batch caches a DictionaryType
+// Arrow schema; flattenIfNeeded() must rewrite the cached field to the value
+// type so the flat second batch imports and writes correctly (a dictionary
+// field expects 2 buffers while flat string data produces 3).
+TEST_F(ParquetWriterTest, multiBatchDictionaryThenFlat) {
+  constexpr vector_size_t kBatchSize = 2'000;
+  constexpr int kDictSize = 8;
+  auto schema = ROW({"c0"}, {VARCHAR()});
+
+  std::vector<std::string> dictStrings(kDictSize);
+  for (int i = 0; i < kDictSize; ++i) {
+    dictStrings[i] = fmt::format("dict_{}", i);
+  }
+  auto dictionary = makeFlatVector<StringView>(
+      kDictSize, [&](auto row) { return StringView(dictStrings[row]); });
+
+  // Batch 0: passthrough dictionary.
+  auto dictBatch = makeRowVector({makeDictionaryColumn(
+      kBatchSize, dictionary, [](auto row) { return row % kDictSize; })});
+  ASSERT_EQ(
+      dictBatch->childAt(0)->encoding(), VectorEncoding::Simple::DICTIONARY);
+
+  // Batch 1: flat.
+  std::vector<std::string> flatStrings(kBatchSize);
+  for (int i = 0; i < kBatchSize; ++i) {
+    flatStrings[i] = fmt::format("flat_{}", i);
+  }
+  auto flatBatch = makeRowVector({makeFlatVector<StringView>(
+      kBatchSize, [&](auto row) { return StringView(flatStrings[row]); })});
+  ASSERT_EQ(flatBatch->childAt(0)->encoding(), VectorEncoding::Simple::FLAT);
+
+  dwio::common::WriterOptions options;
+  options.memoryPool = rootPool_.get();
+  options.schema = schema;
+  auto* sinkPtr =
+      write({dictBatch, flatBatch}, options, ParquetWriterOptions{});
+
+  auto reader = createReaderInMemory(*sinkPtr);
+  ASSERT_EQ(reader->numberOfRows(), static_cast<uint64_t>(kBatchSize) * 2);
+
+  const auto total = kBatchSize * 2;
+  auto expected =
+      makeRowVector({makeFlatVector<StringView>(total, [&](auto row) {
+        return row < kBatchSize ? StringView(dictStrings[row % kDictSize])
+                                : StringView(flatStrings[row - kBatchSize]);
+      })});
+  auto rowReader = createRowReaderFromReader(*reader, schema);
+  assertReadWithReaderAndExpected(schema, *rowReader, expected, *leafPool_);
+}
+
+// Verifies a multi-batch write where a passthrough VARCHAR dictionary batch is
+// followed by a dictionary batch that must be force-flattened (dict-of-dict).
+// The second batch is still DICTIONARY-encoded at the top level, so the reverse
+// schema fixup (which only fires for non-dictionary input) does not apply on
+// its own; flattenIfNeeded() must still rewrite the cached DictionaryType field
+// to the value type because the column is flattened before export. Otherwise
+// ImportRecordBatch() would receive flat buffers described by a dictionary
+// schema.
+TEST_F(ParquetWriterTest, multiBatchDictionaryThenForcedFlattenDictionary) {
+  constexpr vector_size_t kBatchSize = 2'000;
+  constexpr int kDictSize = 8;
+  auto schema = ROW({"c0"}, {VARCHAR()});
+
+  std::vector<std::string> dictStrings(kDictSize);
+  for (int i = 0; i < kDictSize; ++i) {
+    dictStrings[i] = fmt::format("dict_{}", i);
+  }
+  auto dictionary = makeFlatVector<StringView>(
+      kDictSize, [&](auto row) { return StringView(dictStrings[row]); });
+
+  // Batch 0: passthrough dictionary.
+  auto dictBatch = makeRowVector({makeDictionaryColumn(
+      kBatchSize, dictionary, [](auto row) { return row % kDictSize; })});
+  ASSERT_EQ(
+      dictBatch->childAt(0)->encoding(), VectorEncoding::Simple::DICTIONARY);
+
+  // Batch 1: dictionary-of-dictionary. Top-level encoding is DICTIONARY but the
+  // inner vector is not flat, so childNeedsFlatten() forces a flatten while the
+  // top-level encoding stays DICTIONARY.
+  auto innerDict = makeDictionaryColumn(
+      kBatchSize, dictionary, [](auto row) { return row % kDictSize; });
+  auto nestedDict =
+      makeDictionaryColumn(kBatchSize, innerDict, [](auto row) { return row; });
+  auto nestedBatch = makeRowVector({nestedDict});
+  ASSERT_EQ(
+      nestedBatch->childAt(0)->encoding(), VectorEncoding::Simple::DICTIONARY);
+
+  dwio::common::WriterOptions options;
+  options.memoryPool = rootPool_.get();
+  options.schema = schema;
+  auto* sinkPtr =
+      write({dictBatch, nestedBatch}, options, ParquetWriterOptions{});
+
+  auto reader = createReaderInMemory(*sinkPtr);
+  ASSERT_EQ(reader->numberOfRows(), static_cast<uint64_t>(kBatchSize) * 2);
+
+  // Both batches resolve to dictStrings[row % kDictSize].
+  const auto total = kBatchSize * 2;
+  auto expected =
+      makeRowVector({makeFlatVector<StringView>(total, [&](auto row) {
+        return StringView(dictStrings[(row % kBatchSize) % kDictSize]);
+      })});
+  auto rowReader = createRowReaderFromReader(*reader, schema);
+  assertReadWithReaderAndExpected(schema, *rowReader, expected, *leafPool_);
+}
+
 // Verifies that DictionaryVector with nulls round-trips correctly.
 TEST_F(ParquetWriterTest, dictionaryPassthroughWithNulls) {
   constexpr vector_size_t kSize = 5'000;

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -1343,6 +1343,35 @@ TEST_F(ParquetWriterTest, dictionaryPassthroughVarcharLowCardinality) {
   assertFlattenedRoundTrip(makeRowVector({dictVector}));
 }
 
+// Dictionary passthrough must not require the caller to supply an Arrow memory
+// pool. writeArrowDictionary() runs arrow::compute (Unique/Take) to compute
+// page statistics, and those kernels dereference the write context's pool. When
+// no pool is provided the writer must fall back to a valid default; otherwise a
+// null pool aborts in arrow/util/hashing.h ("Check failed: (pool) != nullptr").
+// Uses a low-cardinality dictionary so the writer keeps dictionary encoding
+// active and takes the passthrough path rather than falling back to dense.
+TEST_F(ParquetWriterTest, dictionaryPassthroughWithoutArrowMemoryPool) {
+  constexpr vector_size_t kSize = 10'000;
+  constexpr int kDictSize = 10;
+
+  std::vector<std::string> dictStrings(kDictSize);
+  for (int i = 0; i < kDictSize; ++i) {
+    dictStrings[i] = fmt::format("val_{}", i);
+  }
+  auto dictionary = makeFlatVector<StringView>(
+      kDictSize, [&](auto row) { return StringView(dictStrings[row]); });
+  auto dictVector = makeDictionaryColumn(
+      kSize, dictionary, [](auto row) { return row % kDictSize; });
+
+  // Explicitly leave ParquetWriterOptions::arrowMemoryPool unset (nullptr).
+  ParquetWriterOptions writerOptions;
+  ASSERT_EQ(writerOptions.arrowMemoryPool, nullptr);
+
+  auto data = makeRowVector({dictVector});
+  auto expected = makeRowVector({flatten(dictVector)});
+  assertRoundTrip(data, expected, writerOptions);
+}
+
 // Verifies round-trip correctness with high-cardinality VARCHAR dictionary
 // (all unique values).  The Arrow Parquet writer may abandon dictionary
 // encoding and fall back to PLAIN.

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -621,7 +621,41 @@ void Writer::setMemoryReclaimers() {
 
 namespace {
 
-/// Returns true if a single column requires flattening before Arrow export.
+// Returns true if 'vector' or any of its descendants is dictionary-encoded.
+// Used to detect dictionary encoding nested inside a top-level complex column
+// (ARRAY/MAP/ROW). Constant descendants are exported densely by the Arrow
+// bridge (flattenConstant=true) and therefore do not need to be checked here.
+bool hasDictionaryDescendant(const VectorPtr& vector) {
+  if (vector == nullptr) {
+    return false;
+  }
+  switch (vector->encoding()) {
+    case VectorEncoding::Simple::DICTIONARY:
+      return true;
+    case VectorEncoding::Simple::ROW: {
+      const auto* row = vector->asUnchecked<RowVector>();
+      for (const auto& child : row->children()) {
+        if (hasDictionaryDescendant(child)) {
+          return true;
+        }
+      }
+      return false;
+    }
+    case VectorEncoding::Simple::ARRAY:
+      return hasDictionaryDescendant(
+          vector->asUnchecked<ArrayVector>()->elements());
+    case VectorEncoding::Simple::MAP: {
+      const auto* map = vector->asUnchecked<MapVector>();
+      return hasDictionaryDescendant(map->mapKeys()) ||
+          hasDictionaryDescendant(map->mapValues());
+    }
+    default:
+      return false;
+  }
+}
+
+// Returns true if a single top-level column requires flattening before Arrow
+// export.
 bool childNeedsFlatten(const VectorPtr& child) {
   auto encoding = child->encoding();
   if (encoding == VectorEncoding::Simple::DICTIONARY) {
@@ -663,6 +697,13 @@ bool childNeedsFlatten(const VectorPtr& child) {
     if (child->valueVector() && !child->wrappedVector()->isFlatEncoding()) {
       return true;
     }
+  } else if (!child->type()->isPrimitiveType()) {
+    // A flat complex column (ARRAY/MAP/ROW) is not itself flattened, but the
+    // Velox-to-Arrow bridge exports dictionary-encoded descendants as Arrow
+    // DictionaryArrays (flattenDictionary=false). Dictionary passthrough is
+    // only safe for top-level scalar VARCHAR/VARBINARY columns, so flatten the
+    // whole column if any descendant is dictionary-encoded.
+    return hasDictionaryDescendant(child);
   }
   return false;
 }
@@ -784,6 +825,11 @@ ParquetWriterFactory::createFormatOptions(
   parquetOptions->batchSize = toParquetBatchSize(
       ParquetConfig::writerBatchSize(connectorConfig, session));
   parquetOptions->createdBy = ParquetConfig::writerCreatedBy(connectorConfig);
+  parquetOptions->enableParallelWrite =
+      toBoolConfigValue(
+          ParquetConfig::writerEnableParallelWrite(connectorConfig, session),
+          "enable parallel write")
+          .value_or(false);
   return parquetOptions;
 }
 

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -640,6 +640,22 @@ bool childNeedsFlatten(const VectorPtr& child) {
       if (!innerVector->isFlatEncoding()) {
         return true;
       }
+      // Only VARCHAR and VARBINARY benefit from dictionary passthrough in
+      // Parquet. Arrow's Parquet writer converts non-binary-like dictionary
+      // arrays back to dense anyway, and passing them through as dictionaries
+      // causes schema inconsistency across batches (the cached schema from the
+      // first batch may not match the encoding of subsequent batches).
+      auto typeKind = innerVector->typeKind();
+      if (typeKind != TypeKind::VARCHAR && typeKind != TypeKind::VARBINARY) {
+        return true;
+      }
+      // Arrow's Parquet writer does not support writing DictionaryArray when
+      // the dictionary values contain nulls. Flatten to avoid the
+      // "NotImplemented: Writing DictionaryArray with null encoded in
+      // dictionary type not yet supported" error.
+      if (innerVector->mayHaveNulls()) {
+        return true;
+      }
     }
   } else if (encoding == VectorEncoding::Simple::CONSTANT) {
     // Flatten constant wrapping a non-flat inner vector
@@ -660,8 +676,18 @@ VectorPtr Writer::flattenIfNeeded(const VectorPtr& data) const {
 
   const auto& children = rowVector->children();
   bool anyNeedsFlatten = false;
-  for (const auto& child : children) {
-    if (childNeedsFlatten(child)) {
+  for (size_t i = 0; i < children.size(); ++i) {
+    if (childNeedsFlatten(children[i])) {
+      anyNeedsFlatten = true;
+      break;
+    }
+    // Schema consistency: if the schema is already cached and expects a
+    // non-dictionary type for this column, flatten any dictionary vector
+    // to avoid import errors from schema/data encoding mismatch across batches.
+    if (arrowContext_->schema &&
+        children[i]->encoding() == VectorEncoding::Simple::DICTIONARY &&
+        arrowContext_->schema->field(i)->type()->id() !=
+            ::arrow::Type::DICTIONARY) {
       anyNeedsFlatten = true;
       break;
     }
@@ -674,7 +700,16 @@ VectorPtr Writer::flattenIfNeeded(const VectorPtr& data) const {
   // Selectively flatten only the columns that need it.
   std::vector<VectorPtr> newChildren(children.size());
   for (size_t i = 0; i < children.size(); ++i) {
-    if (childNeedsFlatten(children[i])) {
+    bool needsFlatten = childNeedsFlatten(children[i]);
+    // Also flatten if the cached schema does not expect a dictionary for this
+    // column (prevents schema/data mismatch on subsequent batches).
+    if (!needsFlatten && arrowContext_->schema &&
+        children[i]->encoding() == VectorEncoding::Simple::DICTIONARY &&
+        arrowContext_->schema->field(i)->type()->id() !=
+            ::arrow::Type::DICTIONARY) {
+      needsFlatten = true;
+    }
+    if (needsFlatten) {
       newChildren[i] = children[i];
       BaseVector::flattenVector(newChildren[i]);
     } else {

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -713,14 +713,43 @@ VectorPtr Writer::flattenIfNeeded(const VectorPtr& data) const {
 
   const auto& children = rowVector->children();
 
-  // Reverse schema consistency: if the cached schema expects a dictionary
-  // type for a column but the current data is not dictionary-encoded, update
-  // the cached schema field to use the dictionary's value type. This prevents
-  // import errors when buffer counts don't match (dict schema expects 2
-  // buffers but flat data produces 3).
+  // Decide per-column whether it must be flattened before Arrow export. A
+  // column is flattened when childNeedsFlatten() requires it, or when the
+  // cached schema from an earlier batch expects a non-dictionary type but the
+  // current column is dictionary-encoded (the encoding changed across batches).
+  std::vector<bool> needsFlatten(children.size(), false);
+  bool anyNeedsFlatten = false;
+  for (size_t i = 0; i < children.size(); ++i) {
+    bool flatten = childNeedsFlatten(children[i]);
+    // Schema consistency: if the schema is already cached and expects a
+    // non-dictionary type for this column, flatten any dictionary vector to
+    // avoid import errors from schema/data encoding mismatch across batches.
+    if (!flatten && arrowContext_->schema &&
+        children[i]->encoding() == VectorEncoding::Simple::DICTIONARY &&
+        arrowContext_->schema->field(i)->type()->id() !=
+            ::arrow::Type::DICTIONARY) {
+      flatten = true;
+    }
+    needsFlatten[i] = flatten;
+    anyNeedsFlatten |= flatten;
+  }
+
+  // Reconcile the cached schema with the encoding that will actually be
+  // exported. A column is exported as an Arrow DictionaryArray only when it is
+  // dictionary-encoded AND is not being flattened. For every column that will
+  // NOT be a dictionary but whose cached schema field is still DictionaryType,
+  // rewrite the cached field to the dictionary value type. This covers both a
+  // later batch arriving flat and a later batch arriving as a dictionary that
+  // must be flattened (e.g. dict values gained nulls). Without this,
+  // ImportRecordBatch() would receive flat buffers described by a dictionary
+  // schema (buffer-count mismatch: a dictionary field expects 2 buffers but
+  // flat string data produces 3).
   if (arrowContext_->schema) {
     for (size_t i = 0; i < children.size(); ++i) {
-      if (children[i]->encoding() != VectorEncoding::Simple::DICTIONARY &&
+      const bool exportsAsDictionary =
+          children[i]->encoding() == VectorEncoding::Simple::DICTIONARY &&
+          !needsFlatten[i];
+      if (!exportsAsDictionary &&
           arrowContext_->schema->field(i)->type()->id() ==
               ::arrow::Type::DICTIONARY) {
         auto dictType = std::static_pointer_cast<::arrow::DictionaryType>(
@@ -736,24 +765,6 @@ VectorPtr Writer::flattenIfNeeded(const VectorPtr& data) const {
     }
   }
 
-  bool anyNeedsFlatten = false;
-  for (size_t i = 0; i < children.size(); ++i) {
-    if (childNeedsFlatten(children[i])) {
-      anyNeedsFlatten = true;
-      break;
-    }
-    // Schema consistency: if the schema is already cached and expects a
-    // non-dictionary type for this column, flatten any dictionary vector
-    // to avoid import errors from schema/data encoding mismatch across batches.
-    if (arrowContext_->schema &&
-        children[i]->encoding() == VectorEncoding::Simple::DICTIONARY &&
-        arrowContext_->schema->field(i)->type()->id() !=
-            ::arrow::Type::DICTIONARY) {
-      anyNeedsFlatten = true;
-      break;
-    }
-  }
-
   if (!anyNeedsFlatten) {
     return data;
   }
@@ -761,20 +772,9 @@ VectorPtr Writer::flattenIfNeeded(const VectorPtr& data) const {
   // Selectively flatten only the columns that need it.
   std::vector<VectorPtr> newChildren(children.size());
   for (size_t i = 0; i < children.size(); ++i) {
-    bool needsFlatten = childNeedsFlatten(children[i]);
-    // Also flatten if the cached schema does not expect a dictionary for this
-    // column (prevents schema/data mismatch on subsequent batches).
-    if (!needsFlatten && arrowContext_->schema &&
-        children[i]->encoding() == VectorEncoding::Simple::DICTIONARY &&
-        arrowContext_->schema->field(i)->type()->id() !=
-            ::arrow::Type::DICTIONARY) {
-      needsFlatten = true;
-    }
-    if (needsFlatten) {
-      newChildren[i] = children[i];
+    newChildren[i] = children[i];
+    if (needsFlatten[i]) {
       BaseVector::flattenVector(newChildren[i]);
-    } else {
-      newChildren[i] = children[i];
     }
   }
 

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -629,12 +629,32 @@ bool Writer::needFlatten(const VectorPtr& data) const {
 
   const auto& children = rowVector->children();
   return std::any_of(children.begin(), children.end(), [](const auto& child) {
-    bool isNestedWrapped =
-        (child->encoding() == VectorEncoding::Simple::DICTIONARY ||
-         child->encoding() == VectorEncoding::Simple::CONSTANT) &&
-        child->valueVector() && !child->wrappedVector()->isFlatEncoding();
-    bool isComplex = !child->isScalar();
-    return isNestedWrapped || isComplex;
+    auto encoding = child->encoding();
+    if (encoding == VectorEncoding::Simple::DICTIONARY) {
+      auto* innerVector = child->valueVector().get();
+      if (innerVector != nullptr) {
+        // Flatten dictionary wrapping a complex (non-primitive) type. The Arrow
+        // Parquet writer only supports dictionary passthrough for binary-like
+        // scalar types, and updateFieldNameAndIdRecursive cannot traverse
+        // DictionaryType wrapping complex Arrow types.
+        if (!innerVector->type()->isPrimitiveType()) {
+          return true;
+        }
+        // Flatten nested wrapping (e.g., dictionary-of-dictionary,
+        // dictionary-of-constant). Only a dictionary directly wrapping a flat
+        // vector can be exported as an Arrow DictionaryArray.
+        if (!innerVector->isFlatEncoding()) {
+          return true;
+        }
+      }
+    } else if (encoding == VectorEncoding::Simple::CONSTANT) {
+      // Flatten constant wrapping a non-flat inner vector
+      // (e.g., constant-of-dictionary).
+      if (child->valueVector() && !child->wrappedVector()->isFlatEncoding()) {
+        return true;
+      }
+    }
+    return false;
   });
 }
 

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -583,10 +583,6 @@ bool Writer::isCodecAvailable(common::CompressionKind compression) {
       getArrowParquetCompression(compression));
 }
 
-void Writer::newRowGroup(int32_t numRows) {
-  PARQUET_THROW_NOT_OK(arrowContext_->writer->newRowGroup(numRows));
-}
-
 std::unique_ptr<dwio::common::FileMetadata> Writer::close() {
   std::unique_ptr<ParquetFileMetadata> parquetFileMetadata;
   if (arrowContext_->writer) {

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -452,6 +452,7 @@ Writer::Writer(
       getArrowParquetWriterOptions(options, parquetWriterOptions, flushPolicy_);
   setMemoryReclaimers();
   writeInt96AsTimestamp_ = parquetWriterOptions.writeInt96AsTimestamp;
+  enableParallelWrite_ = parquetWriterOptions.enableParallelWrite;
   arrowMemoryPool_ = parquetWriterOptions.arrowMemoryPool;
   parquetFieldIds_ = parquetWriterOptions.parquetFieldIds;
 }
@@ -540,6 +541,9 @@ void Writer::write(const VectorPtr& data) {
     ArrowWriterProperties::Builder builder;
     if (writeInt96AsTimestamp_) {
       builder.enableDeprecatedInt96Timestamps();
+    }
+    if (enableParallelWrite_) {
+      builder.setUseThreads(true);
     }
     auto arrowProperties = builder.build();
     PARQUET_ASSIGN_OR_THROW(

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -452,6 +452,7 @@ Writer::Writer(
       getArrowParquetWriterOptions(options, parquetWriterOptions, flushPolicy_);
   setMemoryReclaimers();
   writeInt96AsTimestamp_ = parquetWriterOptions.writeInt96AsTimestamp;
+  enableParallelWrite_ = parquetWriterOptions.enableParallelWrite;
   arrowMemoryPool_ = parquetWriterOptions.arrowMemoryPool;
   parquetFieldIds_ = parquetWriterOptions.parquetFieldIds;
 }
@@ -543,6 +544,9 @@ void Writer::write(const VectorPtr& data) {
     ArrowWriterProperties::Builder builder;
     if (writeInt96AsTimestamp_) {
       builder.enableDeprecatedInt96Timestamps();
+    }
+    if (enableParallelWrite_) {
+      builder.setUseThreads(true);
     }
     auto arrowProperties = builder.build();
     PARQUET_ASSIGN_OR_THROW(

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -452,7 +452,6 @@ Writer::Writer(
       getArrowParquetWriterOptions(options, parquetWriterOptions, flushPolicy_);
   setMemoryReclaimers();
   writeInt96AsTimestamp_ = parquetWriterOptions.writeInt96AsTimestamp;
-  enableParallelWrite_ = parquetWriterOptions.enableParallelWrite;
   arrowMemoryPool_ = parquetWriterOptions.arrowMemoryPool;
   parquetFieldIds_ = parquetWriterOptions.parquetFieldIds;
 }
@@ -541,9 +540,6 @@ void Writer::write(const VectorPtr& data) {
     ArrowWriterProperties::Builder builder;
     if (writeInt96AsTimestamp_) {
       builder.enableDeprecatedInt96Timestamps();
-    }
-    if (enableParallelWrite_) {
-      builder.setUseThreads(true);
     }
     auto arrowProperties = builder.build();
     PARQUET_ASSIGN_OR_THROW(
@@ -825,11 +821,6 @@ ParquetWriterFactory::createFormatOptions(
   parquetOptions->batchSize = toParquetBatchSize(
       ParquetConfig::writerBatchSize(connectorConfig, session));
   parquetOptions->createdBy = ParquetConfig::writerCreatedBy(connectorConfig);
-  parquetOptions->enableParallelWrite =
-      toBoolConfigValue(
-          ParquetConfig::writerEnableParallelWrite(connectorConfig, session),
-          "enable parallel write")
-          .value_or(false);
   return parquetOptions;
 }
 

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -452,7 +452,6 @@ Writer::Writer(
       getArrowParquetWriterOptions(options, parquetWriterOptions, flushPolicy_);
   setMemoryReclaimers();
   writeInt96AsTimestamp_ = parquetWriterOptions.writeInt96AsTimestamp;
-  enableParallelWrite_ = parquetWriterOptions.enableParallelWrite;
   arrowMemoryPool_ = parquetWriterOptions.arrowMemoryPool;
   parquetFieldIds_ = parquetWriterOptions.parquetFieldIds;
 }
@@ -544,9 +543,6 @@ void Writer::write(const VectorPtr& data) {
     ArrowWriterProperties::Builder builder;
     if (writeInt96AsTimestamp_) {
       builder.enableDeprecatedInt96Timestamps();
-    }
-    if (enableParallelWrite_) {
-      builder.setUseThreads(true);
     }
     auto arrowProperties = builder.build();
     PARQUET_ASSIGN_OR_THROW(

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -498,10 +498,7 @@ void Writer::write(const VectorPtr& data) {
       data->type()->equivalent(*schema_),
       "The file schema type should be equal with the input rowvector type.");
 
-  VectorPtr exportData = data;
-  if (needFlatten(exportData)) {
-    BaseVector::flattenVector(exportData);
-  }
+  VectorPtr exportData = flattenIfNeeded(data);
 
   ArrowArray array;
   exportToArrow(exportData, array, generalPool_.get(), options_);
@@ -622,40 +619,75 @@ void Writer::setMemoryReclaimers() {
   generalPool_->setReclaimer(exec::MemoryReclaimer::create());
 }
 
-bool Writer::needFlatten(const VectorPtr& data) const {
+namespace {
+
+/// Returns true if a single column requires flattening before Arrow export.
+bool childNeedsFlatten(const VectorPtr& child) {
+  auto encoding = child->encoding();
+  if (encoding == VectorEncoding::Simple::DICTIONARY) {
+    auto* innerVector = child->valueVector().get();
+    if (innerVector != nullptr) {
+      // Flatten dictionary wrapping a complex (non-primitive) type. The Arrow
+      // Parquet writer only supports dictionary passthrough for binary-like
+      // scalar types, and updateFieldNameAndIdRecursive cannot traverse
+      // DictionaryType wrapping complex Arrow types.
+      if (!innerVector->type()->isPrimitiveType()) {
+        return true;
+      }
+      // Flatten nested wrapping (e.g., dictionary-of-dictionary,
+      // dictionary-of-constant). Only a dictionary directly wrapping a flat
+      // vector can be exported as an Arrow DictionaryArray.
+      if (!innerVector->isFlatEncoding()) {
+        return true;
+      }
+    }
+  } else if (encoding == VectorEncoding::Simple::CONSTANT) {
+    // Flatten constant wrapping a non-flat inner vector
+    // (e.g., constant-of-dictionary).
+    if (child->valueVector() && !child->wrappedVector()->isFlatEncoding()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+} // namespace
+
+VectorPtr Writer::flattenIfNeeded(const VectorPtr& data) const {
   auto rowVector = std::dynamic_pointer_cast<RowVector>(data);
   VELOX_CHECK_NOT_NULL(
       rowVector, "Arrow export expects a RowVector as input data.");
 
   const auto& children = rowVector->children();
-  return std::any_of(children.begin(), children.end(), [](const auto& child) {
-    auto encoding = child->encoding();
-    if (encoding == VectorEncoding::Simple::DICTIONARY) {
-      auto* innerVector = child->valueVector().get();
-      if (innerVector != nullptr) {
-        // Flatten dictionary wrapping a complex (non-primitive) type. The Arrow
-        // Parquet writer only supports dictionary passthrough for binary-like
-        // scalar types, and updateFieldNameAndIdRecursive cannot traverse
-        // DictionaryType wrapping complex Arrow types.
-        if (!innerVector->type()->isPrimitiveType()) {
-          return true;
-        }
-        // Flatten nested wrapping (e.g., dictionary-of-dictionary,
-        // dictionary-of-constant). Only a dictionary directly wrapping a flat
-        // vector can be exported as an Arrow DictionaryArray.
-        if (!innerVector->isFlatEncoding()) {
-          return true;
-        }
-      }
-    } else if (encoding == VectorEncoding::Simple::CONSTANT) {
-      // Flatten constant wrapping a non-flat inner vector
-      // (e.g., constant-of-dictionary).
-      if (child->valueVector() && !child->wrappedVector()->isFlatEncoding()) {
-        return true;
-      }
+  bool anyNeedsFlatten = false;
+  for (const auto& child : children) {
+    if (childNeedsFlatten(child)) {
+      anyNeedsFlatten = true;
+      break;
     }
-    return false;
-  });
+  }
+
+  if (!anyNeedsFlatten) {
+    return data;
+  }
+
+  // Selectively flatten only the columns that need it.
+  std::vector<VectorPtr> newChildren(children.size());
+  for (size_t i = 0; i < children.size(); ++i) {
+    if (childNeedsFlatten(children[i])) {
+      newChildren[i] = children[i];
+      BaseVector::flattenVector(newChildren[i]);
+    } else {
+      newChildren[i] = children[i];
+    }
+  }
+
+  return std::make_shared<RowVector>(
+      rowVector->pool(),
+      rowVector->type(),
+      rowVector->nulls(),
+      rowVector->size(),
+      std::move(newChildren));
 }
 
 std::unique_ptr<dwio::common::Writer> ParquetWriterFactory::createWriter(

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -453,6 +453,15 @@ Writer::Writer(
   setMemoryReclaimers();
   writeInt96AsTimestamp_ = parquetWriterOptions.writeInt96AsTimestamp;
   arrowMemoryPool_ = parquetWriterOptions.arrowMemoryPool;
+  // The Arrow memory pool is optional. When it is not provided, fall back to
+  // Arrow's default pool so the Arrow write path always has a valid allocator.
+  // Dictionary passthrough relies on arrow::compute (Unique/Take) while
+  // computing page statistics, and those kernels dereference the pool; a null
+  // pool aborts in arrow/util/hashing.h ("Check failed: (pool) != (nullptr)").
+  if (arrowMemoryPool_ == nullptr) {
+    arrowMemoryPool_ = std::shared_ptr<::arrow::MemoryPool>(
+        ::arrow::default_memory_pool(), [](::arrow::MemoryPool*) {});
+  }
   parquetFieldIds_ = parquetWriterOptions.parquetFieldIds;
 }
 

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -675,6 +675,30 @@ VectorPtr Writer::flattenIfNeeded(const VectorPtr& data) const {
       rowVector, "Arrow export expects a RowVector as input data.");
 
   const auto& children = rowVector->children();
+
+  // Reverse schema consistency: if the cached schema expects a dictionary
+  // type for a column but the current data is not dictionary-encoded, update
+  // the cached schema field to use the dictionary's value type. This prevents
+  // import errors when buffer counts don't match (dict schema expects 2
+  // buffers but flat data produces 3).
+  if (arrowContext_->schema) {
+    for (size_t i = 0; i < children.size(); ++i) {
+      if (children[i]->encoding() != VectorEncoding::Simple::DICTIONARY &&
+          arrowContext_->schema->field(i)->type()->id() ==
+              ::arrow::Type::DICTIONARY) {
+        auto dictType = std::static_pointer_cast<::arrow::DictionaryType>(
+            arrowContext_->schema->field(i)->type());
+        arrowContext_->schema =
+            arrowContext_->schema
+                ->SetField(
+                    i,
+                    arrowContext_->schema->field(i)->WithType(
+                        dictType->value_type()))
+                .ValueOrDie();
+      }
+    }
+  }
+
   bool anyNeedsFlatten = false;
   for (size_t i = 0; i < children.size(); ++i) {
     if (childNeedsFlatten(children[i])) {

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -152,12 +152,6 @@ struct ParquetWriterOptions : public dwio::common::FormatSpecificOptions {
   std::optional<bool> useParquetDataPageV2;
   std::optional<std::string> createdBy;
 
-  /// Write columns in parallel using Arrow's internal thread pool.
-  /// Compression and encoding of different columns proceed concurrently.
-  /// Default is false. Do not enable when writing multiple files in the same
-  /// executor to avoid deadlocks.
-  bool enableParallelWrite = false;
-
   std::shared_ptr<arrow::MemoryPool> arrowMemoryPool;
 
   /// Optional field IDs to assign to columns in the Parquet schema.
@@ -245,9 +239,6 @@ class Writer : public dwio::common::Writer {
 
   // Whether to write Int96 timestamps in Arrow Parquet write.
   bool writeInt96AsTimestamp_;
-
-  // Whether to write columns in parallel.
-  bool enableParallelWrite_;
 };
 
 class ParquetWriterFactory : public dwio::common::WriterFactory {

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -152,12 +152,6 @@ struct ParquetWriterOptions : public dwio::common::FormatSpecificOptions {
   std::optional<bool> useParquetDataPageV2;
   std::optional<std::string> createdBy;
 
-  /// Write columns in parallel using Arrow's internal thread pool.
-  /// Compression and encoding of different columns proceed concurrently.
-  /// Default is false. Do not enable when writing multiple files in the same
-  /// executor to avoid deadlocks.
-  bool enableParallelWrite = false;
-
   std::shared_ptr<arrow::MemoryPool> arrowMemoryPool;
 
   /// Optional field IDs to assign to columns in the Parquet schema.
@@ -259,9 +253,6 @@ class Writer : public dwio::common::Writer {
 
   // Whether to write Int96 timestamps in Arrow Parquet write.
   bool writeInt96AsTimestamp_;
-
-  // Whether to write columns in parallel using Arrow's thread pool.
-  bool enableParallelWrite_;
 };
 
 class ParquetWriterFactory : public dwio::common::WriterFactory {

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -152,6 +152,12 @@ struct ParquetWriterOptions : public dwio::common::FormatSpecificOptions {
   std::optional<bool> useParquetDataPageV2;
   std::optional<std::string> createdBy;
 
+  /// Write columns in parallel using Arrow's internal thread pool.
+  /// Compression and encoding of different columns proceed concurrently.
+  /// Default is false. Do not enable when writing multiple files in the same
+  /// executor to avoid deadlocks.
+  bool enableParallelWrite = false;
+
   std::shared_ptr<arrow::MemoryPool> arrowMemoryPool;
 
   /// Optional field IDs to assign to columns in the Parquet schema.
@@ -239,6 +245,9 @@ class Writer : public dwio::common::Writer {
 
   // Whether to write Int96 timestamps in Arrow Parquet write.
   bool writeInt96AsTimestamp_;
+
+  // Whether to write columns in parallel.
+  bool enableParallelWrite_;
 };
 
 class ParquetWriterFactory : public dwio::common::WriterFactory {

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -228,6 +228,11 @@ class Writer : public dwio::common::Writer {
   // Only VARCHAR/VARBINARY dictionary vectors with null-free values are
   // passed through as Arrow DictionaryArrays for zero-copy Parquet writing.
   //
+  // Also handles the reverse schema mismatch: if the cached schema expects a
+  // dictionary type but the current data is flat, the cached schema is updated
+  // to use the dictionary's value type so ImportRecordBatch buffer counts
+  // match.
+  //
   // When flattening is needed, only the columns that require it are flattened.
   // Columns that can be passed through are left unchanged, avoiding
   // unnecessary materialization.

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -152,6 +152,12 @@ struct ParquetWriterOptions : public dwio::common::FormatSpecificOptions {
   std::optional<bool> useParquetDataPageV2;
   std::optional<std::string> createdBy;
 
+  /// Write columns in parallel using Arrow's internal thread pool.
+  /// Compression and encoding of different columns proceed concurrently.
+  /// Default is false. Do not enable when writing multiple files in the same
+  /// executor to avoid deadlocks.
+  bool enableParallelWrite = false;
+
   std::shared_ptr<arrow::MemoryPool> arrowMemoryPool;
 
   /// Optional field IDs to assign to columns in the Parquet schema.
@@ -247,6 +253,9 @@ class Writer : public dwio::common::Writer {
 
   // Whether to write Int96 timestamps in Arrow Parquet write.
   bool writeInt96AsTimestamp_;
+
+  // Whether to write columns in parallel using Arrow's thread pool.
+  bool enableParallelWrite_;
 };
 
 class ParquetWriterFactory : public dwio::common::WriterFactory {

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -220,7 +220,11 @@ class Writer : public dwio::common::Writer {
   //  - Constant wrapping a non-flat inner vector (e.g., constant-of-dict).
   // Returns false for scalar dictionary vectors (passthrough to Arrow Parquet
   // writer) and flat complex types (handled natively by the Arrow bridge).
-  bool needFlatten(const VectorPtr& data) const;
+  //
+  // When flattening is needed, only the columns that require it are flattened.
+  // Columns that can be passed through (e.g., scalar dictionaries) are left
+  // unchanged, avoiding unnecessary materialization.
+  VectorPtr flattenIfNeeded(const VectorPtr& data) const;
 
   // Pool for 'stream_'.
   std::shared_ptr<memory::MemoryPool> pool_;

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -200,9 +200,6 @@ class Writer : public dwio::common::Writer {
 
   void flush() override;
 
-  // Forces a row group boundary before the data added by next write().
-  void newRowGroup(int32_t numRows);
-
   bool finish() override {
     return true;
   }

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -213,9 +213,13 @@ class Writer : public dwio::common::Writer {
   // Sets the memory reclaimers for all the memory pools used by this writer.
   void setMemoryReclaimers();
 
-  // Checks if the input data contains a nested wrapped vector or complex
-  // vector. If so, flatten the input to make it compatible with
-  // 'exportFlattenedVector' in Arrow export.
+  // Checks if the input data requires flattening before Arrow export.
+  // Returns true for:
+  //  - Dictionary wrapping a complex (non-primitive) type.
+  //  - Dictionary wrapping a non-flat inner vector (e.g., dict-of-dict).
+  //  - Constant wrapping a non-flat inner vector (e.g., constant-of-dict).
+  // Returns false for scalar dictionary vectors (passthrough to Arrow Parquet
+  // writer) and flat complex types (handled natively by the Arrow bridge).
   bool needFlatten(const VectorPtr& data) const;
 
   // Pool for 'stream_'.
@@ -235,7 +239,7 @@ class Writer : public dwio::common::Writer {
 
   const RowTypePtr schema_;
 
-  ArrowOptions options_{.flattenDictionary = true, .flattenConstant = true};
+  ArrowOptions options_{.flattenDictionary = false, .flattenConstant = true};
 
   // Whether to write Int96 timestamps in Arrow Parquet write.
   bool writeInt96AsTimestamp_;

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -216,17 +216,21 @@ class Writer : public dwio::common::Writer {
   // Sets the memory reclaimers for all the memory pools used by this writer.
   void setMemoryReclaimers();
 
-  // Checks if the input data requires flattening before Arrow export.
-  // Returns true for:
+  // Selectively flattens columns that cannot be exported as-is to Arrow.
+  // Flattens:
   //  - Dictionary wrapping a complex (non-primitive) type.
   //  - Dictionary wrapping a non-flat inner vector (e.g., dict-of-dict).
+  //  - Dictionary of a non-string/binary type (no benefit in Parquet).
+  //  - Dictionary whose values contain nulls (unsupported by Arrow writer).
+  //  - Dictionary when cached schema expects a non-dictionary type (schema
+  //    consistency across batches).
   //  - Constant wrapping a non-flat inner vector (e.g., constant-of-dict).
-  // Returns false for scalar dictionary vectors (passthrough to Arrow Parquet
-  // writer) and flat complex types (handled natively by the Arrow bridge).
+  // Only VARCHAR/VARBINARY dictionary vectors with null-free values are
+  // passed through as Arrow DictionaryArrays for zero-copy Parquet writing.
   //
   // When flattening is needed, only the columns that require it are flattened.
-  // Columns that can be passed through (e.g., scalar dictionaries) are left
-  // unchanged, avoiding unnecessary materialization.
+  // Columns that can be passed through are left unchanged, avoiding
+  // unnecessary materialization.
   VectorPtr flattenIfNeeded(const VectorPtr& data) const;
 
   // Pool for 'stream_'.

--- a/velox/dwio/parquet/writer/arrow/Encoding.cpp
+++ b/velox/dwio/parquet/writer/arrow/Encoding.cpp
@@ -663,16 +663,30 @@ class DictEncoderImpl : public EncoderImpl, virtual public DictEncoder<DType> {
   template <typename ArrayType>
   void putBinaryDictionaryArray(const ArrayType& array) {
     VELOX_DCHECK_EQ(array.null_count(), 0);
+    auto onFound = [](int32_t memoIndex) {};
     for (int64_t i = 0; i < array.length(); i++) {
       auto v = array.GetView(i);
       if (ARROW_PREDICT_FALSE(v.size() > kMaxByteArraySize)) {
         throw ParquetException(
             "Parquet cannot store strings with size 2GB or more");
       }
-      dictEncodedSize_ += static_cast<int>(v.size() + sizeof(uint32_t));
+      // Only charge the dictionary size for distinct values. The dictionary
+      // alphabet may contain duplicates; charging every element (rather than
+      // only newly inserted ones) over-counts dictEncodedSize_ relative to the
+      // de-duplicated entries actually serialized by writeDict(). That mismatch
+      // sizes the flushed dictionary page from the inflated count, leaving
+      // trailing uninitialized bytes and tripping the reader's
+      // exact-consumption check in PageReader::prepareDictionary.
+      auto onNotFound = [this, &v](int32_t memoIndex) {
+        dictEncodedSize_ += static_cast<int>(v.size() + sizeof(uint32_t));
+      };
       int32_t unusedMemoIndex;
       PARQUET_THROW_NOT_OK(memoTable_.getOrInsert(
-          v.data(), static_cast<int32_t>(v.size()), &unusedMemoIndex));
+          v.data(),
+          static_cast<int32_t>(v.size()),
+          onFound,
+          onNotFound,
+          &unusedMemoIndex));
     }
   }
 


### PR DESCRIPTION
The Parquet writer previously flattened every dictionary-encoded column into a flat vector before exporting to Arrow, even when Arrow's Parquet writer can encode dictionaries natively. For low-cardinality VARCHAR columns (common for categories, status codes, country codes), this materialized the full string for every row from a small dictionary — pure overhead.

> **Depends on #18052** (Add Parquet writer benchmark). This PR is stacked on top of that branch.

## Changes

**1. Dictionary passthrough** (`flattenDictionary=false`)

Set `flattenDictionary` to false in `ArrowOptions` so the Velox-to-Arrow bridge exports dictionary vectors as Arrow DictionaryArrays. The Arrow Parquet writer encodes them natively via `writeArrowDictionary()`, avoiding materialization.

**2. Selective per-column flattening**

Replace the old blanket `needFlatten()` + full-vector flatten with `flattenIfNeeded()` that inspects each column individually. Only columns that actually need flattening are materialized:
- Dictionary wrapping a complex (non-primitive) type
- Nested wrapping (dict-of-dict, dict-of-constant)
- Constant wrapping a non-flat inner vector
- Flat complex column (ARRAY/MAP/ROW) with a dictionary-encoded descendant

Columns that can pass through (scalar VARCHAR/VARBINARY dictionaries, flat vectors) are left untouched. Previously a single column requiring flattening would flatten the entire RowVector. The cached Arrow schema is reconciled across batches against the encoding that is actually exported, so mixed dictionary/flat batches for the same column round-trip correctly.

**3. Remove unused `newRowGroup` method**

Drop the now-unused `Writer::newRowGroup()` public method. Upstream's `writeRecordBatch` manages row groups internally via `finishRowGroup()`.

**4. Tests for writeRecordBatch and flush behavior**

Add tests validating correct round-trip behavior with dictionary passthrough, multiple batches with changing dictionaries, mixed dictionary/flat and dictionary/forced-flatten transitions across batches, and flush policy thresholds with both dictionary and flat columns.

## Benchmark Results

100K rows, 50 iterations. Dictionary values use variable-length strings (5-50+ bytes).

| Benchmark | Baseline | Passthrough | Speedup |
|-----------|----------|-------------|---------|
| DictVarchar_Card10 | 159.87ms | 52.25ms | **3.1x** |
| DictVarchar_Card100 | 161.37ms | 66.52ms | **2.4x** |
| DictVarchar_Card1000 | 149.26ms | 141.34ms | ~1.06x |
| DictInteger_Card10 | 33.02ms | 32.66ms | ~1.0x |
| Mixed_1Dict_1Nested | 154.38ms | 71.72ms | **2.2x** |
| Mixed_5Dict_1Nested | 668.24ms | 207.37ms | **3.2x** |
| Mixed_10Dict_1Nested | 1.51s | 574.04ms | **2.6x** |
| AllPassthrough_5Cols | 642.15ms | 150.51ms | **4.3x** |
| AllPassthrough_10Cols | 1.35s | 415.81ms | **3.2x** |
| FlatVarchar (control) | 99.01ms | 151.04ms | 0.66x * |
| FlatInteger (control) | 80.84ms | 72.35ms | **1.12x** |

\* **FlatVarchar** shows overhead from the first-batch schema export when no dictionary passthrough is used. In production multi-batch writes, flat-only batches after the first reuse the cached schema with zero overhead.

**2.4-4.3x faster** for dictionary VARCHAR at low-to-medium cardinality. Multi-column mixed workloads show 2.2-3.2x improvement from selective flattening.

Part of #17988.
