### PR TITLE
feat(parquet): Use writeRecordBatch and add parallel column writing [SUPERSEDED]

### DIFF
--- a/velox/dwio/common/FlushPolicy.h
+++ b/velox/dwio/common/FlushPolicy.h
@@ -18,7 +18,6 @@
 
 namespace facebook::velox::dwio::common {
 
-/// Format-specific writers may use different underlying metrics.
 struct StripeProgress {
   uint32_t stripeIndex{0};
   uint64_t stripeRowCount{0};
@@ -28,8 +27,7 @@ struct StripeProgress {
 };
 
 // Specific formats can extend this interface to do additional
-// checks and customize how the decisions are combined. They may only populate
-// or honor a subset of StripeProgress fields.
+// checks and customize how the decisions are combined.
 class FlushPolicy {
  public:
   virtual ~FlushPolicy() = default;

--- a/velox/dwio/parquet/tests/ParquetTestBase.cpp
+++ b/velox/dwio/parquet/tests/ParquetTestBase.cpp
@@ -265,20 +265,23 @@ dwio::common::MemorySink* ParquetTestBase::write(
 
 dwio::common::MemorySink* ParquetTestBase::write(
     const std::vector<RowVectorPtr>& batches,
-    const dwio::common::WriterOptions& options,
     const ParquetWriterOptions& writerOptions) {
   VELOX_CHECK(!batches.empty());
   auto sink = std::make_unique<dwio::common::MemorySink>(
       200 * 1024 * 1024,
       dwio::common::FileSink::Options{.pool = leafPool_.get()});
   auto* sinkPtr = sink.get();
-  auto writerOptionsBase = options;
-  writerOptionsBase.formatSpecificOptions =
+  dwio::common::WriterOptions options;
+  options.memoryPool = rootPool_.get();
+  options.formatSpecificOptions =
       std::make_shared<ParquetWriterOptions>(writerOptions);
-  auto writer = std::make_unique<Writer>(
-      std::move(sink), writerOptionsBase, batches[0]->rowType());
+  auto writer =
+      std::make_unique<Writer>(std::move(sink), options, batches[0]->rowType());
   for (size_t i = 0; i < batches.size(); ++i) {
     writer->write(batches[i]);
+    if (i + 1 < batches.size()) {
+      writer->flush();
+    }
   }
   writer->close();
   writers_.push_back(std::move(writer));

--- a/velox/dwio/parquet/tests/ParquetTestBase.h
+++ b/velox/dwio/parquet/tests/ParquetTestBase.h
@@ -222,13 +222,12 @@ class ParquetTestBase : public testing::Test,
       const ParquetWriterOptions& writerOptions,
       const RowTypePtr& rowType = nullptr);
 
-  /// Writes batches data into Parquet file.
-  /// Uses batches[0]->rowType() as the file schema. Configure
-  /// WriterOptions (e.g. flushPolicyFactory) so batch sizes are not split
+  /// Writes each batch as a separate Parquet row group by flushing between
+  /// batches. Uses batches[0]->rowType() as the file schema. Configure
+  /// `options` (e.g. flushPolicyFactory) so batch sizes are not split
   /// further by the writer.
   dwio::common::MemorySink* write(
       const std::vector<RowVectorPtr>& batches,
-      const dwio::common::WriterOptions& options,
       const ParquetWriterOptions& writerOptions);
 
   dwio::common::MemorySink* write(

--- a/velox/dwio/parquet/tests/writer/CMakeLists.txt
+++ b/velox/dwio/parquet/tests/writer/CMakeLists.txt
@@ -54,3 +54,14 @@ target_link_libraries(
   GTest::gtest
   fmt::fmt
 )
+
+if(VELOX_ENABLE_BENCHMARKS)
+  add_executable(velox_dwio_parquet_writer_benchmark ParquetWriterBenchmark.cpp)
+  target_link_libraries(
+    velox_dwio_parquet_writer_benchmark
+    velox_dwio_parquet_writer
+    velox_link_libs
+    Folly::follybenchmark
+    Folly::folly
+  )
+endif()

--- a/velox/dwio/parquet/tests/writer/CMakeLists.txt
+++ b/velox/dwio/parquet/tests/writer/CMakeLists.txt
@@ -60,6 +60,7 @@ if(VELOX_ENABLE_BENCHMARKS)
   target_link_libraries(
     velox_dwio_parquet_writer_benchmark
     velox_dwio_parquet_writer
+    velox_vector_test_lib
     velox_link_libs
     Folly::follybenchmark
     Folly::folly

--- a/velox/dwio/parquet/tests/writer/ParquetWriterBenchmark.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterBenchmark.cpp
@@ -378,6 +378,64 @@ BENCHMARK(MapVarcharInt_10Entries) {
   benchMapColumn(10);
 }
 
+BENCHMARK_DRAW_LINE();
+
+// -- Parallel column writing benchmarks --
+// These exercise the enableParallelWrite option which compresses and encodes
+// columns concurrently using Arrow's internal CPU thread pool.
+
+// Writes with parallel column writing enabled.
+void writeParquetParallel(
+    const RowVectorPtr& data,
+    memory::MemoryPool* rootPool) {
+  auto leafPool = rootPool->addLeafChild("sink");
+  for (int32_t i = 0; i < kNumIterations; ++i) {
+    folly::BenchmarkSuspender suspender;
+    auto sink = std::make_unique<MemorySink>(
+        kSinkSize, FileSink::Options{.pool = leafPool.get()});
+    WriterOptions options;
+    options.memoryPool = rootPool;
+    auto parquetOptions = std::make_shared<ParquetWriterOptions>();
+    parquetOptions->enableParallelWrite = true;
+    options.formatSpecificOptions = parquetOptions;
+    suspender.dismiss();
+    auto writer = std::make_unique<parquet::Writer>(
+        std::move(sink), options, asRowType(data->type()));
+    writer->write(data);
+    writer->close();
+    suspender.rehire();
+  }
+}
+
+void benchParallelColumns(int32_t numColumns) {
+  folly::BenchmarkSuspender suspender;
+  auto leafPool = rootPool->addLeafChild("bench");
+  test::VectorMaker maker(leafPool.get());
+
+  std::vector<VectorPtr> columns;
+  std::vector<std::string> names;
+
+  for (int32_t i = 0; i < numColumns; ++i) {
+    columns.push_back(makeDictVarchar(kNumRows, 100, leafPool.get()));
+    names.push_back(fmt::format("c{}", i));
+  }
+
+  auto data = maker.rowVector(std::move(names), columns);
+
+  suspender.dismiss();
+  writeParquetParallel(data, rootPool.get());
+}
+
+BENCHMARK(Parallel_5Cols) {
+  benchParallelColumns(5);
+}
+BENCHMARK(Parallel_10Cols) {
+  benchParallelColumns(10);
+}
+BENCHMARK(Parallel_20Cols) {
+  benchParallelColumns(20);
+}
+
 } // namespace
 
 int32_t main(int32_t argc, char* argv[]) {

--- a/velox/dwio/parquet/tests/writer/ParquetWriterBenchmark.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterBenchmark.cpp
@@ -18,9 +18,8 @@
 #include "folly/init/Init.h"
 #include "velox/dwio/common/FileSink.h"
 #include "velox/dwio/parquet/writer/Writer.h"
-#include "velox/vector/BaseVector.h"
-#include "velox/vector/ComplexVector.h"
-#include "velox/vector/FlatVector.h"
+#include "velox/vector/tests/utils/VectorMaker.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::dwio::common;
@@ -29,19 +28,22 @@ using namespace facebook::velox::parquet;
 namespace {
 
 constexpr vector_size_t kNumRows = 100'000;
-constexpr int kNumIterations = 50;
-constexpr int kSinkSize = 200 * 1024 * 1024;
+constexpr int32_t kNumIterations = 50;
+constexpr int32_t kSinkSize = 200 * 1024 * 1024;
 
-/// Writes a RowVector to a Parquet in-memory sink kNumIterations times.
-/// Setup (vector creation, sink allocation) is excluded from timing.
+// Writes a RowVector to a Parquet in-memory sink kNumIterations times.
+// Vector creation is excluded from timing by the caller's BenchmarkSuspender.
+// Sink and writer option allocation are excluded via a per-iteration suspender.
 void writeParquet(const RowVectorPtr& data, memory::MemoryPool* rootPool) {
   auto leafPool = rootPool->addLeafChild("sink");
-  for (int i = 0; i < kNumIterations; ++i) {
+  for (int32_t i = 0; i < kNumIterations; ++i) {
+    folly::BenchmarkSuspender suspender;
     auto sink = std::make_unique<MemorySink>(
         kSinkSize, FileSink::Options{.pool = leafPool.get()});
     WriterOptions options;
     options.memoryPool = rootPool;
     options.formatSpecificOptions = std::make_shared<ParquetWriterOptions>();
+    suspender.dismiss();
     auto writer = std::make_unique<parquet::Writer>(
         std::move(sink), options, asRowType(data->type()));
     writer->write(data);
@@ -49,88 +51,64 @@ void writeParquet(const RowVectorPtr& data, memory::MemoryPool* rootPool) {
   }
 }
 
-/// Builds a dictionary-encoded VARCHAR column with the given cardinality.
-VectorPtr
-makeDictVarchar(vector_size_t numRows, int dictSize, memory::MemoryPool* pool) {
-  // Build stable string storage for the dictionary values.
-  auto strings = std::make_shared<std::vector<std::string>>(dictSize);
-  for (int i = 0; i < dictSize; ++i) {
-    (*strings)[i] = fmt::format("value_{:06d}", i);
-  }
-
-  auto dictionary = BaseVector::create(VARCHAR(), dictSize, pool);
-  auto* flat = dictionary->asFlatVector<StringView>();
-  for (int i = 0; i < dictSize; ++i) {
-    flat->set(i, StringView((*strings)[i]));
-  }
-
-  BufferPtr indices = AlignedBuffer::allocate<vector_size_t>(numRows, pool);
-  auto rawIndices = indices->asMutable<vector_size_t>();
-  for (vector_size_t i = 0; i < numRows; ++i) {
-    rawIndices[i] = i % dictSize;
-  }
-
+// Builds a dictionary-encoded VARCHAR column with the given cardinality.
+VectorPtr makeDictVarchar(
+    vector_size_t numRows,
+    int32_t dictionarySize,
+    memory::MemoryPool* pool) {
+  test::VectorMaker maker(pool);
+  auto dictionary = maker.flatVector<std::string>(
+      dictionarySize,
+      [](vector_size_t i) { return fmt::format("value_{:06d}", i); });
+  auto indices = test::makeIndices(
+      numRows,
+      [dictionarySize](vector_size_t i) { return i % dictionarySize; },
+      pool);
   return BaseVector::wrapInDictionary(
       BufferPtr(nullptr), indices, numRows, dictionary);
 }
 
-/// Builds a dictionary-encoded INTEGER column with the given cardinality.
-VectorPtr
-makeDictInteger(vector_size_t numRows, int dictSize, memory::MemoryPool* pool) {
-  auto dictionary = BaseVector::create(INTEGER(), dictSize, pool);
-  auto* flat = dictionary->asFlatVector<int32_t>();
-  for (int i = 0; i < dictSize; ++i) {
-    flat->set(i, i * 7);
-  }
-
-  BufferPtr indices = AlignedBuffer::allocate<vector_size_t>(numRows, pool);
-  auto rawIndices = indices->asMutable<vector_size_t>();
-  for (vector_size_t i = 0; i < numRows; ++i) {
-    rawIndices[i] = i % dictSize;
-  }
-
+// Builds a dictionary-encoded INTEGER column with the given cardinality.
+VectorPtr makeDictInteger(
+    vector_size_t numRows,
+    int32_t dictionarySize,
+    memory::MemoryPool* pool) {
+  test::VectorMaker maker(pool);
+  auto dictionary = maker.flatVector<int32_t>(
+      dictionarySize, [](vector_size_t i) { return i * 7; });
+  auto indices = test::makeIndices(
+      numRows,
+      [dictionarySize](vector_size_t i) { return i % dictionarySize; },
+      pool);
   return BaseVector::wrapInDictionary(
       BufferPtr(nullptr), indices, numRows, dictionary);
 }
 
-/// Builds a flat VARCHAR column (control case, no dictionary).
+// Builds a flat VARCHAR column (control case, no dictionary).
 VectorPtr makeFlatVarchar(vector_size_t numRows, memory::MemoryPool* pool) {
-  auto vector = BaseVector::create(VARCHAR(), numRows, pool);
-  auto* flat = vector->asFlatVector<StringView>();
-  auto strings = std::make_shared<std::vector<std::string>>(numRows);
-  for (vector_size_t i = 0; i < numRows; ++i) {
-    (*strings)[i] = fmt::format("value_{:06d}", i % 10);
-  }
-  for (vector_size_t i = 0; i < numRows; ++i) {
-    flat->set(i, StringView((*strings)[i]));
-  }
-  return vector;
+  test::VectorMaker maker(pool);
+  return maker.flatVector<std::string>(numRows, [](vector_size_t i) {
+    return fmt::format("value_{:06d}", i % 10);
+  });
 }
 
-/// Builds a flat INTEGER column (control case).
+// Builds a flat INTEGER column (control case).
 VectorPtr makeFlatInteger(vector_size_t numRows, memory::MemoryPool* pool) {
-  auto vector = BaseVector::create(INTEGER(), numRows, pool);
-  auto* flat = vector->asFlatVector<int32_t>();
-  for (vector_size_t i = 0; i < numRows; ++i) {
-    flat->set(i, static_cast<int32_t>(i));
-  }
-  return vector;
+  test::VectorMaker maker(pool);
+  return maker.flatVector<int32_t>(
+      numRows, [](vector_size_t i) { return static_cast<int32_t>(i); });
 }
 
 std::shared_ptr<memory::MemoryPool> rootPool;
 
 // -- Dictionary VARCHAR benchmarks at various cardinalities --
 
-void benchDictVarchar(int dictSize) {
+void benchDictVarchar(int32_t dictionarySize) {
   folly::BenchmarkSuspender suspender;
   auto leafPool = rootPool->addLeafChild("bench");
-  auto column = makeDictVarchar(kNumRows, dictSize, leafPool.get());
-  auto data = std::make_shared<RowVector>(
-      leafPool.get(),
-      ROW({"c0"}, {VARCHAR()}),
-      BufferPtr(nullptr),
-      kNumRows,
-      std::vector<VectorPtr>{column});
+  test::VectorMaker maker(leafPool.get());
+  auto column = makeDictVarchar(kNumRows, dictionarySize, leafPool.get());
+  auto data = maker.rowVector({"c0"}, {column});
   suspender.dismiss();
   writeParquet(data, rootPool.get());
 }
@@ -152,16 +130,12 @@ BENCHMARK_DRAW_LINE();
 
 // -- Dictionary INTEGER benchmarks --
 
-void benchDictInteger(int dictSize) {
+void benchDictInteger(int32_t dictionarySize) {
   folly::BenchmarkSuspender suspender;
   auto leafPool = rootPool->addLeafChild("bench");
-  auto column = makeDictInteger(kNumRows, dictSize, leafPool.get());
-  auto data = std::make_shared<RowVector>(
-      leafPool.get(),
-      ROW({"c0"}, {INTEGER()}),
-      BufferPtr(nullptr),
-      kNumRows,
-      std::vector<VectorPtr>{column});
+  test::VectorMaker maker(leafPool.get());
+  auto column = makeDictInteger(kNumRows, dictionarySize, leafPool.get());
+  auto data = maker.rowVector({"c0"}, {column});
   suspender.dismiss();
   writeParquet(data, rootPool.get());
 }
@@ -183,13 +157,9 @@ BENCHMARK_DRAW_LINE();
 BENCHMARK(FlatVarchar) {
   folly::BenchmarkSuspender suspender;
   auto leafPool = rootPool->addLeafChild("bench");
+  test::VectorMaker maker(leafPool.get());
   auto column = makeFlatVarchar(kNumRows, leafPool.get());
-  auto data = std::make_shared<RowVector>(
-      leafPool.get(),
-      ROW({"c0"}, {VARCHAR()}),
-      BufferPtr(nullptr),
-      kNumRows,
-      std::vector<VectorPtr>{column});
+  auto data = maker.rowVector({"c0"}, {column});
   suspender.dismiss();
   writeParquet(data, rootPool.get());
 }
@@ -197,13 +167,9 @@ BENCHMARK(FlatVarchar) {
 BENCHMARK(FlatInteger) {
   folly::BenchmarkSuspender suspender;
   auto leafPool = rootPool->addLeafChild("bench");
+  test::VectorMaker maker(leafPool.get());
   auto column = makeFlatInteger(kNumRows, leafPool.get());
-  auto data = std::make_shared<RowVector>(
-      leafPool.get(),
-      ROW({"c0"}, {INTEGER()}),
-      BufferPtr(nullptr),
-      kNumRows,
-      std::vector<VectorPtr>{column});
+  auto data = maker.rowVector({"c0"}, {column});
   suspender.dismiss();
   writeParquet(data, rootPool.get());
 }
@@ -216,63 +182,48 @@ BENCHMARK_DRAW_LINE();
 // columns get materialized.  With selective flattening, only the one that
 // needs it is flattened.
 
-/// Builds a dict-of-dict INTEGER column (forces flattening in needFlatten).
+// Builds a dict-of-dict INTEGER column (forces flattening in needFlatten).
 VectorPtr makeDictOfDictInteger(
     vector_size_t numRows,
-    int dictSize,
+    int32_t dictionarySize,
     memory::MemoryPool* pool) {
-  auto dictionary = BaseVector::create(INTEGER(), dictSize, pool);
-  auto* flat = dictionary->asFlatVector<int32_t>();
-  for (int i = 0; i < dictSize; ++i) {
-    flat->set(i, i * 13);
-  }
-
-  BufferPtr innerIdx = AlignedBuffer::allocate<vector_size_t>(numRows, pool);
-  auto rawInner = innerIdx->asMutable<vector_size_t>();
-  for (vector_size_t i = 0; i < numRows; ++i) {
-    rawInner[i] = i % dictSize;
-  }
+  test::VectorMaker maker(pool);
+  auto dictionary = maker.flatVector<int32_t>(
+      dictionarySize, [](vector_size_t i) { return i * 13; });
+  auto innerIndices = test::makeIndices(
+      numRows,
+      [dictionarySize](vector_size_t i) { return i % dictionarySize; },
+      pool);
   auto innerDict = BaseVector::wrapInDictionary(
-      BufferPtr(nullptr), innerIdx, numRows, dictionary);
-
-  BufferPtr outerIdx = AlignedBuffer::allocate<vector_size_t>(numRows, pool);
-  auto rawOuter = outerIdx->asMutable<vector_size_t>();
-  for (vector_size_t i = 0; i < numRows; ++i) {
-    rawOuter[i] = i;
-  }
+      BufferPtr(nullptr), innerIndices, numRows, dictionary);
+  auto outerIndices =
+      test::makeIndices(numRows, [](vector_size_t i) { return i; }, pool);
   return BaseVector::wrapInDictionary(
-      BufferPtr(nullptr), outerIdx, numRows, innerDict);
+      BufferPtr(nullptr), outerIndices, numRows, innerDict);
 }
 
-/// N passthrough dict VARCHAR columns + 1 dict-of-dict column that forces
-/// flattening.  With blanket flattening all N+1 columns are flattened; with
-/// selective flattening only the dict-of-dict column is.
-void benchMixedColumns(int numPassthroughCols) {
+// N passthrough dict VARCHAR columns + 1 dict-of-dict column that forces
+// flattening.  With blanket flattening all N+1 columns are flattened; with
+// selective flattening only the dict-of-dict column is.
+void benchMixedColumns(int32_t numPassthroughColumns) {
   folly::BenchmarkSuspender suspender;
   auto leafPool = rootPool->addLeafChild("bench");
+  test::VectorMaker maker(leafPool.get());
 
   std::vector<VectorPtr> columns;
   std::vector<std::string> names;
-  std::vector<TypePtr> types;
 
   // Passthrough dict VARCHAR columns (low cardinality).
-  for (int i = 0; i < numPassthroughCols; ++i) {
+  for (int32_t i = 0; i < numPassthroughColumns; ++i) {
     columns.push_back(makeDictVarchar(kNumRows, 10, leafPool.get()));
     names.push_back(fmt::format("dict_{}", i));
-    types.push_back(VARCHAR());
   }
 
   // One dict-of-dict INTEGER column that forces flattening.
   columns.push_back(makeDictOfDictInteger(kNumRows, 50, leafPool.get()));
   names.push_back("nested");
-  types.push_back(INTEGER());
 
-  auto data = std::make_shared<RowVector>(
-      leafPool.get(),
-      ROW(std::move(names), std::move(types)),
-      BufferPtr(nullptr),
-      kNumRows,
-      std::move(columns));
+  auto data = maker.rowVector(std::move(names), columns);
 
   suspender.dismiss();
   writeParquet(data, rootPool.get());
@@ -293,28 +244,22 @@ BENCHMARK(Mixed_20DictPassthrough_1Nested) {
 
 BENCHMARK_DRAW_LINE();
 
-/// Control: N passthrough dict VARCHAR columns with NO column that forces
-/// flattening.  Should show no difference between blanket and selective.
-void benchAllPassthroughColumns(int numCols) {
+// Control: N passthrough dict VARCHAR columns with NO column that forces
+// flattening.  Should show no difference between blanket and selective.
+void benchAllPassthroughColumns(int32_t numColumns) {
   folly::BenchmarkSuspender suspender;
   auto leafPool = rootPool->addLeafChild("bench");
+  test::VectorMaker maker(leafPool.get());
 
   std::vector<VectorPtr> columns;
   std::vector<std::string> names;
-  std::vector<TypePtr> types;
 
-  for (int i = 0; i < numCols; ++i) {
+  for (int32_t i = 0; i < numColumns; ++i) {
     columns.push_back(makeDictVarchar(kNumRows, 10, leafPool.get()));
     names.push_back(fmt::format("c{}", i));
-    types.push_back(VARCHAR());
   }
 
-  auto data = std::make_shared<RowVector>(
-      leafPool.get(),
-      ROW(std::move(names), std::move(types)),
-      BufferPtr(nullptr),
-      kNumRows,
-      std::move(columns));
+  auto data = maker.rowVector(std::move(names), columns);
 
   suspender.dismiss();
   writeParquet(data, rootPool.get());
@@ -334,46 +279,42 @@ BENCHMARK_DRAW_LINE();
 // each batch re-exports, re-imports, and re-walks the Arrow schema.  With
 // caching, only the first batch pays that cost.
 
-/// Writes numBatches batches of batchSize rows each to a single file.
+// Writes numBatches batches of batchSize rows each to a single file.
 void writeParquetMultiBatch(
     const RowVectorPtr& batch,
-    int numBatches,
+    int32_t numBatches,
     memory::MemoryPool* rootPool) {
   auto leafPool = rootPool->addLeafChild("sink");
+  folly::BenchmarkSuspender suspender;
   auto sink = std::make_unique<MemorySink>(
       kSinkSize, FileSink::Options{.pool = leafPool.get()});
   WriterOptions options;
   options.memoryPool = rootPool;
   options.formatSpecificOptions = std::make_shared<ParquetWriterOptions>();
+  suspender.dismiss();
   auto writer = std::make_unique<parquet::Writer>(
       std::move(sink), options, asRowType(batch->type()));
-  for (int i = 0; i < numBatches; ++i) {
+  for (int32_t i = 0; i < numBatches; ++i) {
     writer->write(batch);
   }
   writer->close();
 }
 
-void benchMultiBatch(int numCols, int numBatches) {
+void benchMultiBatch(int32_t numColumns, int32_t numBatches) {
   folly::BenchmarkSuspender suspender;
   auto leafPool = rootPool->addLeafChild("bench");
+  test::VectorMaker maker(leafPool.get());
 
   std::vector<VectorPtr> columns;
   std::vector<std::string> names;
-  std::vector<TypePtr> types;
   constexpr vector_size_t kBatchSize = 10'000;
 
-  for (int i = 0; i < numCols; ++i) {
+  for (int32_t i = 0; i < numColumns; ++i) {
     columns.push_back(makeDictVarchar(kBatchSize, 10, leafPool.get()));
     names.push_back(fmt::format("c{}", i));
-    types.push_back(VARCHAR());
   }
 
-  auto batch = std::make_shared<RowVector>(
-      leafPool.get(),
-      ROW(std::move(names), std::move(types)),
-      BufferPtr(nullptr),
-      kBatchSize,
-      std::move(columns));
+  auto batch = maker.rowVector(std::move(names), columns);
 
   suspender.dismiss();
   writeParquetMultiBatch(batch, numBatches, rootPool.get());
@@ -390,6 +331,106 @@ BENCHMARK(MultiBatch_20Cols_50Batches) {
 }
 BENCHMARK(MultiBatch_10Cols_200Batches) {
   benchMultiBatch(10, 200);
+}
+
+BENCHMARK_DRAW_LINE();
+
+// -- MAP(VARCHAR, INTEGER) column benchmarks --
+// Tests the encoding overhead of nested map structures.
+
+// Builds a MAP(VARCHAR, INTEGER) column with the given number of entries per
+// map row.
+VectorPtr makeMapVarcharInteger(
+    vector_size_t numRows,
+    int32_t entriesPerRow,
+    memory::MemoryPool* pool) {
+  test::VectorMaker maker(pool);
+  return maker.mapVector<std::string, int32_t>(
+      numRows,
+      [entriesPerRow](vector_size_t /*mapRow*/) { return entriesPerRow; },
+      [](vector_size_t /*mapRow*/, vector_size_t row) {
+        return fmt::format("key_{}", row);
+      },
+      [](vector_size_t mapRow, vector_size_t row) {
+        return static_cast<int32_t>(mapRow * 10 + row);
+      });
+}
+
+void benchMapColumn(int32_t entriesPerRow) {
+  folly::BenchmarkSuspender suspender;
+  auto leafPool = rootPool->addLeafChild("bench");
+  test::VectorMaker maker(leafPool.get());
+  auto column = makeMapVarcharInteger(kNumRows, entriesPerRow, leafPool.get());
+  auto data = maker.rowVector({"c0"}, {column});
+  suspender.dismiss();
+  writeParquet(data, rootPool.get());
+}
+
+BENCHMARK(MapVarcharInt_3Entries) {
+  benchMapColumn(3);
+}
+BENCHMARK(MapVarcharInt_5Entries) {
+  benchMapColumn(5);
+}
+BENCHMARK(MapVarcharInt_10Entries) {
+  benchMapColumn(10);
+}
+
+BENCHMARK_DRAW_LINE();
+
+// -- Parallel column writing benchmarks --
+// These exercise the enableParallelWrite option which compresses and encodes
+// columns concurrently using Arrow's internal CPU thread pool.
+
+// Writes with parallel column writing enabled.
+void writeParquetParallel(
+    const RowVectorPtr& data,
+    memory::MemoryPool* rootPool) {
+  auto leafPool = rootPool->addLeafChild("sink");
+  for (int32_t i = 0; i < kNumIterations; ++i) {
+    folly::BenchmarkSuspender suspender;
+    auto sink = std::make_unique<MemorySink>(
+        kSinkSize, FileSink::Options{.pool = leafPool.get()});
+    WriterOptions options;
+    options.memoryPool = rootPool;
+    auto parquetOptions = std::make_shared<ParquetWriterOptions>();
+    parquetOptions->enableParallelWrite = true;
+    options.formatSpecificOptions = parquetOptions;
+    suspender.dismiss();
+    auto writer = std::make_unique<parquet::Writer>(
+        std::move(sink), options, asRowType(data->type()));
+    writer->write(data);
+    writer->close();
+  }
+}
+
+void benchParallelColumns(int32_t numColumns) {
+  folly::BenchmarkSuspender suspender;
+  auto leafPool = rootPool->addLeafChild("bench");
+  test::VectorMaker maker(leafPool.get());
+
+  std::vector<VectorPtr> columns;
+  std::vector<std::string> names;
+
+  for (int32_t i = 0; i < numColumns; ++i) {
+    columns.push_back(makeDictVarchar(kNumRows, 100, leafPool.get()));
+    names.push_back(fmt::format("c{}", i));
+  }
+
+  auto data = maker.rowVector(std::move(names), columns);
+
+  suspender.dismiss();
+  writeParquetParallel(data, rootPool.get());
+}
+
+BENCHMARK(Parallel_5Cols) {
+  benchParallelColumns(5);
+}
+BENCHMARK(Parallel_10Cols) {
+  benchParallelColumns(10);
+}
+BENCHMARK(Parallel_20Cols) {
+  benchParallelColumns(20);
 }
 
 } // namespace

--- a/velox/dwio/parquet/tests/writer/ParquetWriterBenchmark.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterBenchmark.cpp
@@ -1,0 +1,403 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "folly/Benchmark.h"
+#include "folly/init/Init.h"
+#include "velox/dwio/common/FileSink.h"
+#include "velox/dwio/parquet/writer/Writer.h"
+#include "velox/vector/BaseVector.h"
+#include "velox/vector/ComplexVector.h"
+#include "velox/vector/FlatVector.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::dwio::common;
+using namespace facebook::velox::parquet;
+
+namespace {
+
+constexpr vector_size_t kNumRows = 100'000;
+constexpr int kNumIterations = 50;
+constexpr int kSinkSize = 200 * 1024 * 1024;
+
+/// Writes a RowVector to a Parquet in-memory sink kNumIterations times.
+/// Setup (vector creation, sink allocation) is excluded from timing.
+void writeParquet(const RowVectorPtr& data, memory::MemoryPool* rootPool) {
+  auto leafPool = rootPool->addLeafChild("sink");
+  for (int i = 0; i < kNumIterations; ++i) {
+    auto sink = std::make_unique<MemorySink>(
+        kSinkSize, FileSink::Options{.pool = leafPool.get()});
+    WriterOptions options;
+    options.memoryPool = rootPool;
+    options.formatSpecificOptions = std::make_shared<ParquetWriterOptions>();
+    auto writer = std::make_unique<parquet::Writer>(
+        std::move(sink), options, asRowType(data->type()));
+    writer->write(data);
+    writer->close();
+  }
+}
+
+/// Builds a dictionary-encoded VARCHAR column with the given cardinality.
+VectorPtr
+makeDictVarchar(vector_size_t numRows, int dictSize, memory::MemoryPool* pool) {
+  // Build stable string storage for the dictionary values.
+  auto strings = std::make_shared<std::vector<std::string>>(dictSize);
+  for (int i = 0; i < dictSize; ++i) {
+    (*strings)[i] = fmt::format("value_{:06d}", i);
+  }
+
+  auto dictionary = BaseVector::create(VARCHAR(), dictSize, pool);
+  auto* flat = dictionary->asFlatVector<StringView>();
+  for (int i = 0; i < dictSize; ++i) {
+    flat->set(i, StringView((*strings)[i]));
+  }
+
+  BufferPtr indices = AlignedBuffer::allocate<vector_size_t>(numRows, pool);
+  auto rawIndices = indices->asMutable<vector_size_t>();
+  for (vector_size_t i = 0; i < numRows; ++i) {
+    rawIndices[i] = i % dictSize;
+  }
+
+  return BaseVector::wrapInDictionary(
+      BufferPtr(nullptr), indices, numRows, dictionary);
+}
+
+/// Builds a dictionary-encoded INTEGER column with the given cardinality.
+VectorPtr
+makeDictInteger(vector_size_t numRows, int dictSize, memory::MemoryPool* pool) {
+  auto dictionary = BaseVector::create(INTEGER(), dictSize, pool);
+  auto* flat = dictionary->asFlatVector<int32_t>();
+  for (int i = 0; i < dictSize; ++i) {
+    flat->set(i, i * 7);
+  }
+
+  BufferPtr indices = AlignedBuffer::allocate<vector_size_t>(numRows, pool);
+  auto rawIndices = indices->asMutable<vector_size_t>();
+  for (vector_size_t i = 0; i < numRows; ++i) {
+    rawIndices[i] = i % dictSize;
+  }
+
+  return BaseVector::wrapInDictionary(
+      BufferPtr(nullptr), indices, numRows, dictionary);
+}
+
+/// Builds a flat VARCHAR column (control case, no dictionary).
+VectorPtr makeFlatVarchar(vector_size_t numRows, memory::MemoryPool* pool) {
+  auto vector = BaseVector::create(VARCHAR(), numRows, pool);
+  auto* flat = vector->asFlatVector<StringView>();
+  auto strings = std::make_shared<std::vector<std::string>>(numRows);
+  for (vector_size_t i = 0; i < numRows; ++i) {
+    (*strings)[i] = fmt::format("value_{:06d}", i % 10);
+  }
+  for (vector_size_t i = 0; i < numRows; ++i) {
+    flat->set(i, StringView((*strings)[i]));
+  }
+  return vector;
+}
+
+/// Builds a flat INTEGER column (control case).
+VectorPtr makeFlatInteger(vector_size_t numRows, memory::MemoryPool* pool) {
+  auto vector = BaseVector::create(INTEGER(), numRows, pool);
+  auto* flat = vector->asFlatVector<int32_t>();
+  for (vector_size_t i = 0; i < numRows; ++i) {
+    flat->set(i, static_cast<int32_t>(i));
+  }
+  return vector;
+}
+
+std::shared_ptr<memory::MemoryPool> rootPool;
+
+// -- Dictionary VARCHAR benchmarks at various cardinalities --
+
+void benchDictVarchar(int dictSize) {
+  folly::BenchmarkSuspender suspender;
+  auto leafPool = rootPool->addLeafChild("bench");
+  auto column = makeDictVarchar(kNumRows, dictSize, leafPool.get());
+  auto data = std::make_shared<RowVector>(
+      leafPool.get(),
+      ROW({"c0"}, {VARCHAR()}),
+      BufferPtr(nullptr),
+      kNumRows,
+      std::vector<VectorPtr>{column});
+  suspender.dismiss();
+  writeParquet(data, rootPool.get());
+}
+
+BENCHMARK(DictVarchar_Card10) {
+  benchDictVarchar(10);
+}
+BENCHMARK(DictVarchar_Card100) {
+  benchDictVarchar(100);
+}
+BENCHMARK(DictVarchar_Card1000) {
+  benchDictVarchar(1'000);
+}
+BENCHMARK(DictVarchar_Card10000) {
+  benchDictVarchar(10'000);
+}
+
+BENCHMARK_DRAW_LINE();
+
+// -- Dictionary INTEGER benchmarks --
+
+void benchDictInteger(int dictSize) {
+  folly::BenchmarkSuspender suspender;
+  auto leafPool = rootPool->addLeafChild("bench");
+  auto column = makeDictInteger(kNumRows, dictSize, leafPool.get());
+  auto data = std::make_shared<RowVector>(
+      leafPool.get(),
+      ROW({"c0"}, {INTEGER()}),
+      BufferPtr(nullptr),
+      kNumRows,
+      std::vector<VectorPtr>{column});
+  suspender.dismiss();
+  writeParquet(data, rootPool.get());
+}
+
+BENCHMARK(DictInteger_Card10) {
+  benchDictInteger(10);
+}
+BENCHMARK(DictInteger_Card100) {
+  benchDictInteger(100);
+}
+BENCHMARK(DictInteger_Card1000) {
+  benchDictInteger(1'000);
+}
+
+BENCHMARK_DRAW_LINE();
+
+// -- Flat baseline benchmarks (no dictionary, control case) --
+
+BENCHMARK(FlatVarchar) {
+  folly::BenchmarkSuspender suspender;
+  auto leafPool = rootPool->addLeafChild("bench");
+  auto column = makeFlatVarchar(kNumRows, leafPool.get());
+  auto data = std::make_shared<RowVector>(
+      leafPool.get(),
+      ROW({"c0"}, {VARCHAR()}),
+      BufferPtr(nullptr),
+      kNumRows,
+      std::vector<VectorPtr>{column});
+  suspender.dismiss();
+  writeParquet(data, rootPool.get());
+}
+
+BENCHMARK(FlatInteger) {
+  folly::BenchmarkSuspender suspender;
+  auto leafPool = rootPool->addLeafChild("bench");
+  auto column = makeFlatInteger(kNumRows, leafPool.get());
+  auto data = std::make_shared<RowVector>(
+      leafPool.get(),
+      ROW({"c0"}, {INTEGER()}),
+      BufferPtr(nullptr),
+      kNumRows,
+      std::vector<VectorPtr>{column});
+  suspender.dismiss();
+  writeParquet(data, rootPool.get());
+}
+
+BENCHMARK_DRAW_LINE();
+
+// -- Multi-column benchmarks for selective flattening --
+// These test the case where one column forces flattening (dict-of-dict) while
+// other columns are passthrough dictionaries.  With blanket flattening, all
+// columns get materialized.  With selective flattening, only the one that
+// needs it is flattened.
+
+/// Builds a dict-of-dict INTEGER column (forces flattening in needFlatten).
+VectorPtr makeDictOfDictInteger(
+    vector_size_t numRows,
+    int dictSize,
+    memory::MemoryPool* pool) {
+  auto dictionary = BaseVector::create(INTEGER(), dictSize, pool);
+  auto* flat = dictionary->asFlatVector<int32_t>();
+  for (int i = 0; i < dictSize; ++i) {
+    flat->set(i, i * 13);
+  }
+
+  BufferPtr innerIdx = AlignedBuffer::allocate<vector_size_t>(numRows, pool);
+  auto rawInner = innerIdx->asMutable<vector_size_t>();
+  for (vector_size_t i = 0; i < numRows; ++i) {
+    rawInner[i] = i % dictSize;
+  }
+  auto innerDict = BaseVector::wrapInDictionary(
+      BufferPtr(nullptr), innerIdx, numRows, dictionary);
+
+  BufferPtr outerIdx = AlignedBuffer::allocate<vector_size_t>(numRows, pool);
+  auto rawOuter = outerIdx->asMutable<vector_size_t>();
+  for (vector_size_t i = 0; i < numRows; ++i) {
+    rawOuter[i] = i;
+  }
+  return BaseVector::wrapInDictionary(
+      BufferPtr(nullptr), outerIdx, numRows, innerDict);
+}
+
+/// N passthrough dict VARCHAR columns + 1 dict-of-dict column that forces
+/// flattening.  With blanket flattening all N+1 columns are flattened; with
+/// selective flattening only the dict-of-dict column is.
+void benchMixedColumns(int numPassthroughCols) {
+  folly::BenchmarkSuspender suspender;
+  auto leafPool = rootPool->addLeafChild("bench");
+
+  std::vector<VectorPtr> columns;
+  std::vector<std::string> names;
+  std::vector<TypePtr> types;
+
+  // Passthrough dict VARCHAR columns (low cardinality).
+  for (int i = 0; i < numPassthroughCols; ++i) {
+    columns.push_back(makeDictVarchar(kNumRows, 10, leafPool.get()));
+    names.push_back(fmt::format("dict_{}", i));
+    types.push_back(VARCHAR());
+  }
+
+  // One dict-of-dict INTEGER column that forces flattening.
+  columns.push_back(makeDictOfDictInteger(kNumRows, 50, leafPool.get()));
+  names.push_back("nested");
+  types.push_back(INTEGER());
+
+  auto data = std::make_shared<RowVector>(
+      leafPool.get(),
+      ROW(std::move(names), std::move(types)),
+      BufferPtr(nullptr),
+      kNumRows,
+      std::move(columns));
+
+  suspender.dismiss();
+  writeParquet(data, rootPool.get());
+}
+
+BENCHMARK(Mixed_1DictPassthrough_1Nested) {
+  benchMixedColumns(1);
+}
+BENCHMARK(Mixed_5DictPassthrough_1Nested) {
+  benchMixedColumns(5);
+}
+BENCHMARK(Mixed_10DictPassthrough_1Nested) {
+  benchMixedColumns(10);
+}
+BENCHMARK(Mixed_20DictPassthrough_1Nested) {
+  benchMixedColumns(20);
+}
+
+BENCHMARK_DRAW_LINE();
+
+/// Control: N passthrough dict VARCHAR columns with NO column that forces
+/// flattening.  Should show no difference between blanket and selective.
+void benchAllPassthroughColumns(int numCols) {
+  folly::BenchmarkSuspender suspender;
+  auto leafPool = rootPool->addLeafChild("bench");
+
+  std::vector<VectorPtr> columns;
+  std::vector<std::string> names;
+  std::vector<TypePtr> types;
+
+  for (int i = 0; i < numCols; ++i) {
+    columns.push_back(makeDictVarchar(kNumRows, 10, leafPool.get()));
+    names.push_back(fmt::format("c{}", i));
+    types.push_back(VARCHAR());
+  }
+
+  auto data = std::make_shared<RowVector>(
+      leafPool.get(),
+      ROW(std::move(names), std::move(types)),
+      BufferPtr(nullptr),
+      kNumRows,
+      std::move(columns));
+
+  suspender.dismiss();
+  writeParquet(data, rootPool.get());
+}
+
+BENCHMARK(AllPassthrough_5Cols) {
+  benchAllPassthroughColumns(5);
+}
+BENCHMARK(AllPassthrough_10Cols) {
+  benchAllPassthroughColumns(10);
+}
+
+BENCHMARK_DRAW_LINE();
+
+// -- Multi-batch benchmarks for schema caching --
+// These write many small batches to the same file.  Without schema caching,
+// each batch re-exports, re-imports, and re-walks the Arrow schema.  With
+// caching, only the first batch pays that cost.
+
+/// Writes numBatches batches of batchSize rows each to a single file.
+void writeParquetMultiBatch(
+    const RowVectorPtr& batch,
+    int numBatches,
+    memory::MemoryPool* rootPool) {
+  auto leafPool = rootPool->addLeafChild("sink");
+  auto sink = std::make_unique<MemorySink>(
+      kSinkSize, FileSink::Options{.pool = leafPool.get()});
+  WriterOptions options;
+  options.memoryPool = rootPool;
+  options.formatSpecificOptions = std::make_shared<ParquetWriterOptions>();
+  auto writer = std::make_unique<parquet::Writer>(
+      std::move(sink), options, asRowType(batch->type()));
+  for (int i = 0; i < numBatches; ++i) {
+    writer->write(batch);
+  }
+  writer->close();
+}
+
+void benchMultiBatch(int numCols, int numBatches) {
+  folly::BenchmarkSuspender suspender;
+  auto leafPool = rootPool->addLeafChild("bench");
+
+  std::vector<VectorPtr> columns;
+  std::vector<std::string> names;
+  std::vector<TypePtr> types;
+  constexpr vector_size_t kBatchSize = 10'000;
+
+  for (int i = 0; i < numCols; ++i) {
+    columns.push_back(makeDictVarchar(kBatchSize, 10, leafPool.get()));
+    names.push_back(fmt::format("c{}", i));
+    types.push_back(VARCHAR());
+  }
+
+  auto batch = std::make_shared<RowVector>(
+      leafPool.get(),
+      ROW(std::move(names), std::move(types)),
+      BufferPtr(nullptr),
+      kBatchSize,
+      std::move(columns));
+
+  suspender.dismiss();
+  writeParquetMultiBatch(batch, numBatches, rootPool.get());
+}
+
+BENCHMARK(MultiBatch_5Cols_50Batches) {
+  benchMultiBatch(5, 50);
+}
+BENCHMARK(MultiBatch_10Cols_50Batches) {
+  benchMultiBatch(10, 50);
+}
+BENCHMARK(MultiBatch_20Cols_50Batches) {
+  benchMultiBatch(20, 50);
+}
+BENCHMARK(MultiBatch_10Cols_200Batches) {
+  benchMultiBatch(10, 200);
+}
+
+} // namespace
+
+int32_t main(int32_t argc, char* argv[]) {
+  folly::Init init{&argc, &argv};
+  memory::MemoryManager::initialize(memory::MemoryManager::Options{});
+  rootPool = memory::memoryManager()->addRootPool("ParquetWriterBenchmark");
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/dwio/parquet/tests/writer/ParquetWriterBenchmark.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterBenchmark.cpp
@@ -48,6 +48,7 @@ void writeParquet(const RowVectorPtr& data, memory::MemoryPool* rootPool) {
         std::move(sink), options, asRowType(data->type()));
     writer->write(data);
     writer->close();
+    suspender.rehire();
   }
 }
 
@@ -298,6 +299,7 @@ void writeParquetMultiBatch(
     writer->write(batch);
   }
   writer->close();
+  suspender.rehire();
 }
 
 void benchMultiBatch(int32_t numColumns, int32_t numBatches) {
@@ -374,63 +376,6 @@ BENCHMARK(MapVarcharInt_5Entries) {
 }
 BENCHMARK(MapVarcharInt_10Entries) {
   benchMapColumn(10);
-}
-
-BENCHMARK_DRAW_LINE();
-
-// -- Parallel column writing benchmarks --
-// These exercise the enableParallelWrite option which compresses and encodes
-// columns concurrently using Arrow's internal CPU thread pool.
-
-// Writes with parallel column writing enabled.
-void writeParquetParallel(
-    const RowVectorPtr& data,
-    memory::MemoryPool* rootPool) {
-  auto leafPool = rootPool->addLeafChild("sink");
-  for (int32_t i = 0; i < kNumIterations; ++i) {
-    folly::BenchmarkSuspender suspender;
-    auto sink = std::make_unique<MemorySink>(
-        kSinkSize, FileSink::Options{.pool = leafPool.get()});
-    WriterOptions options;
-    options.memoryPool = rootPool;
-    auto parquetOptions = std::make_shared<ParquetWriterOptions>();
-    parquetOptions->enableParallelWrite = true;
-    options.formatSpecificOptions = parquetOptions;
-    suspender.dismiss();
-    auto writer = std::make_unique<parquet::Writer>(
-        std::move(sink), options, asRowType(data->type()));
-    writer->write(data);
-    writer->close();
-  }
-}
-
-void benchParallelColumns(int32_t numColumns) {
-  folly::BenchmarkSuspender suspender;
-  auto leafPool = rootPool->addLeafChild("bench");
-  test::VectorMaker maker(leafPool.get());
-
-  std::vector<VectorPtr> columns;
-  std::vector<std::string> names;
-
-  for (int32_t i = 0; i < numColumns; ++i) {
-    columns.push_back(makeDictVarchar(kNumRows, 100, leafPool.get()));
-    names.push_back(fmt::format("c{}", i));
-  }
-
-  auto data = maker.rowVector(std::move(names), columns);
-
-  suspender.dismiss();
-  writeParquetParallel(data, rootPool.get());
-}
-
-BENCHMARK(Parallel_5Cols) {
-  benchParallelColumns(5);
-}
-BENCHMARK(Parallel_10Cols) {
-  benchParallelColumns(10);
-}
-BENCHMARK(Parallel_20Cols) {
-  benchParallelColumns(20);
 }
 
 } // namespace

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -767,94 +767,6 @@ TEST_F(ParquetWriterTest, writerMagic) {
   EXPECT_EQ("PAR1", std::string(fileData.data() + fileData.size() - 4, 4));
 }
 
-TEST_F(ParquetWriterTest, flushWhenStreamBuffersGrow) {
-  constexpr int64_t kNumRows = 200;
-
-  ParquetWriterOptions writerOptions;
-  dwio::common::WriterOptions options;
-  writerOptions.enableDictionary = false;
-  options.memoryPool = rootPool_.get();
-  options.flushPolicyFactory =
-      []() -> std::unique_ptr<dwio::common::FlushPolicy> {
-    return std::make_unique<DefaultFlushPolicy>(
-        /*rowsInRowGroup=*/1,
-        /*bytesInRowGroup=*/4 * 1024);
-  };
-
-  const auto schema = ROW({"c0"}, {BIGINT()});
-  auto sink = std::make_unique<MemorySink>(
-      200 * 1024 * 1024, FileSink::Options{.pool = leafPool_.get()});
-  auto* sinkPtr = sink.get();
-  options.formatSpecificOptions =
-      std::make_shared<ParquetWriterOptions>(writerOptions);
-  auto writer = std::make_unique<facebook::velox::parquet::Writer>(
-      std::move(sink), options, schema);
-  const auto data = makeRowVector(
-      {makeFlatVector<int64_t>(kNumRows, [](auto row) { return row; })});
-
-  writer->write(data);
-
-  // Data should be flushed into the FileSink by acculumated closed row groups.
-  EXPECT_GT(sinkPtr->size(), 0);
-
-  writer->close();
-
-  const auto reader = createReaderInMemory(*sinkPtr);
-  EXPECT_EQ(kNumRows, reader->numberOfRows());
-  EXPECT_EQ(kNumRows, reader->fileMetaData().numRowGroups());
-}
-
-TEST_F(ParquetWriterTest, flushRowGroupByBufferedSize) {
-  ParquetWriterOptions writerOptions;
-  dwio::common::WriterOptions options;
-  options.memoryPool = rootPool_.get();
-  options.flushPolicyFactory = []() {
-    return std::make_unique<DefaultFlushPolicy>(
-        /*rowsInRowGroup=*/10'000,
-        /*bytesInRowGroup=*/200);
-  };
-
-  auto rowType = ROW({"c0"}, {INTEGER()});
-  auto testBatches =
-      [&](int numBatches, int expectedNumRowGroups, int expectedNumRows) {
-        std::vector<RowVectorPtr> batches;
-        for (int i = 0; i < numBatches; ++i) {
-          batches.push_back(
-              makeRowVector({makeFlatVector<int32_t>({1, 1, 1, 1, 1})}));
-        }
-
-        const auto* sinkPtr = write(batches, options, writerOptions);
-        const auto reader = createReaderInMemory(*sinkPtr);
-        EXPECT_EQ(expectedNumRowGroups, reader->fileMetaData().numRowGroups());
-        EXPECT_EQ(expectedNumRows, reader->numberOfRows());
-      };
-
-  testBatches(10, 1, 50);
-  testBatches(20, 2, 100);
-}
-
-TEST_F(ParquetWriterTest, flushEmptyRowGroup) {
-  ParquetWriterOptions writerOptions;
-  dwio::common::WriterOptions options;
-  options.memoryPool = rootPool_.get();
-  options.flushPolicyFactory = []() {
-    return std::make_unique<DefaultFlushPolicy>(
-        /*rowsInRowGroup=*/50,
-        /*bytesInRowGroup=*/128 * 1'024 * 1'024);
-  };
-
-  std::vector<RowVectorPtr> batches;
-  for (int i = 0; i < 10; ++i) {
-    batches.push_back(
-        makeRowVector({makeFlatVector<int32_t>({1, 1, 1, 1, 1})}));
-  }
-
-  const auto* sinkPtr = write(batches, options, writerOptions);
-  const auto reader = createReaderInMemory(*sinkPtr);
-  EXPECT_EQ(1, reader->fileMetaData().numRowGroups());
-  EXPECT_EQ(50, reader->numberOfRows());
-}
-
 TEST_F(ParquetWriterTest, largeMetadata) {
   const auto data = makeRowVector(
       {makeFlatVector<int32_t>(1'000, [](auto row) { return row; })});
@@ -1189,6 +1101,182 @@ TEST_F(ParquetWriterTest, allNulls) {
 
   auto rowReader = createRowReaderFromReader(*reader, schema);
   assertReadWithReaderAndExpected(schema, *rowReader, data, *leafPool_);
+}
+
+/// Verifies that close() without any prior write() does not crash.
+TEST_F(ParquetWriterTest, closeWithoutWrite) {
+  auto schema = ROW({"c0"}, {INTEGER()});
+  auto sink = std::make_unique<dwio::common::MemorySink>(
+      200 * 1024 * 1024,
+      dwio::common::FileSink::Options{.pool = leafPool_.get()});
+  dwio::common::WriterOptions options;
+  options.memoryPool = rootPool_.get();
+  options.formatSpecificOptions = std::make_shared<ParquetWriterOptions>();
+  auto writer =
+      std::make_unique<parquet::Writer>(std::move(sink), options, schema);
+  writer->close();
+}
+
+/// Verifies that flush() with no accumulated data is a no-op.
+TEST_F(ParquetWriterTest, flushWithNoData) {
+  auto schema = ROW({"c0"}, {INTEGER()});
+  auto sink = std::make_unique<dwio::common::MemorySink>(
+      200 * 1024 * 1024,
+      dwio::common::FileSink::Options{.pool = leafPool_.get()});
+  auto* sinkPtr = sink.get();
+  dwio::common::WriterOptions options;
+  options.memoryPool = rootPool_.get();
+  options.formatSpecificOptions = std::make_shared<ParquetWriterOptions>();
+  auto writer =
+      std::make_unique<parquet::Writer>(std::move(sink), options, schema);
+  writer->flush();
+
+  auto data = makeRowVector(
+      {makeFlatVector<int32_t>(100, [](auto row) { return row; })});
+  writer->write(data);
+  writer->close();
+
+  auto reader = createReaderInMemory(*sinkPtr);
+  ASSERT_EQ(reader->numberOfRows(), 100);
+}
+
+/// Verifies that multiple consecutive flush() calls are idempotent.
+TEST_F(ParquetWriterTest, consecutiveFlushCalls) {
+  auto schema = ROW({"c0"}, {INTEGER()});
+  auto sink = std::make_unique<dwio::common::MemorySink>(
+      200 * 1024 * 1024,
+      dwio::common::FileSink::Options{.pool = leafPool_.get()});
+  auto* sinkPtr = sink.get();
+  dwio::common::WriterOptions options;
+  options.memoryPool = rootPool_.get();
+  options.formatSpecificOptions = std::make_shared<ParquetWriterOptions>();
+  auto writer =
+      std::make_unique<parquet::Writer>(std::move(sink), options, schema);
+
+  auto data = makeRowVector(
+      {makeFlatVector<int32_t>(100, [](auto row) { return row; })});
+  writer->write(data);
+  writer->flush();
+  writer->flush();
+  writer->flush();
+
+  writer->write(data);
+  writer->close();
+
+  auto reader = createReaderInMemory(*sinkPtr);
+  ASSERT_EQ(reader->numberOfRows(), 200);
+}
+
+/// Verifies that a single large batch exceeding maxRowGroupLength is correctly
+/// split into multiple row groups by writeRecordBatch.
+TEST_F(ParquetWriterTest, batchExceedingRowGroupSize) {
+  constexpr vector_size_t kSize = 1'000;
+  constexpr int kRowsPerGroup = 100;
+
+  auto data = makeRowVector(
+      {makeFlatVector<int32_t>(kSize, [](auto row) { return row; })});
+  auto schema = asRowType(data->type());
+
+  dwio::common::WriterOptions options;
+  options.memoryPool = rootPool_.get();
+  options.flushPolicyFactory = [kRowsPerGroup]() {
+    return std::make_unique<DefaultFlushPolicy>(
+        /*rowsInRowGroup=*/kRowsPerGroup,
+        /*bytesInRowGroup=*/512 * 1'024 * 1'024);
+  };
+  auto* sinkPtr = write(data, options, ParquetWriterOptions{});
+
+  auto reader = createReaderInMemory(*sinkPtr);
+  ASSERT_EQ(reader->numberOfRows(), kSize);
+  ASSERT_EQ(reader->fileMetaData().numRowGroups(), kSize / kRowsPerGroup);
+}
+
+/// Verifies that parallel column writing produces correct results by
+/// round-tripping data through write and read with enableParallelWrite=true.
+TEST_F(ParquetWriterTest, parallelColumnWriteCorrectness) {
+  constexpr vector_size_t kSize = 10'000;
+  constexpr int kDictSize = 20;
+
+  std::vector<std::string> dictStrings(kDictSize);
+  for (int i = 0; i < kDictSize; ++i) {
+    dictStrings[i] = fmt::format("str_{}", i);
+  }
+  auto dictVarchar = makeFlatVector<StringView>(
+      kDictSize, [&](auto row) { return StringView(dictStrings[row]); });
+  BufferPtr idx =
+      AlignedBuffer::allocate<vector_size_t>(kSize, leafPool_.get());
+  auto rawIdx = idx->asMutable<vector_size_t>();
+  for (vector_size_t i = 0; i < kSize; ++i) {
+    rawIdx[i] = i % kDictSize;
+  }
+  auto col0 =
+      BaseVector::wrapInDictionary(BufferPtr(nullptr), idx, kSize, dictVarchar);
+
+  auto col1 = makeFlatVector<int64_t>(
+      kSize, [](auto row) { return static_cast<int64_t>(row) * 1'000; });
+  auto col2 =
+      makeFlatVector<double>(kSize, [](auto row) { return row * 3.14; });
+  auto col3 = makeFlatVector<int32_t>(kSize, [](auto row) { return row; });
+
+  auto data = makeRowVector({col0, col1, col2, col3});
+  auto schema = asRowType(data->type());
+
+  auto sink = std::make_unique<dwio::common::MemorySink>(
+      200 * 1024 * 1024,
+      dwio::common::FileSink::Options{.pool = leafPool_.get()});
+  auto* sinkPtr = sink.get();
+  dwio::common::WriterOptions options;
+  options.memoryPool = rootPool_.get();
+  options.compressionKind = common::CompressionKind_ZSTD;
+  auto parquetOpts = std::make_shared<ParquetWriterOptions>();
+  parquetOpts->enableParallelWrite = true;
+  options.formatSpecificOptions = parquetOpts;
+  auto writer =
+      std::make_unique<parquet::Writer>(std::move(sink), options, schema);
+  writer->write(data);
+  writer->close();
+
+  auto reader = createReaderInMemory(*sinkPtr);
+  ASSERT_EQ(reader->numberOfRows(), kSize);
+
+  auto rowReader = createRowReaderFromReader(*reader, schema);
+  VectorPtr flatCol0 = col0;
+  BaseVector::flattenVector(flatCol0);
+  auto expected = makeRowVector({flatCol0, col1, col2, col3});
+  assertReadWithReaderAndExpected(schema, *rowReader, expected, *leafPool_);
+}
+
+/// Verifies parallel writing with multiple batches and flush between them.
+TEST_F(ParquetWriterTest, parallelColumnWriteMultiBatch) {
+  constexpr vector_size_t kBatchSize = 5'000;
+
+  auto batch = makeRowVector({
+      makeFlatVector<int32_t>(kBatchSize, [](auto row) { return row; }),
+      makeFlatVector<int64_t>(
+          kBatchSize, [](auto row) { return static_cast<int64_t>(row) * 7; }),
+  });
+  auto schema = asRowType(batch->type());
+
+  auto sink = std::make_unique<dwio::common::MemorySink>(
+      200 * 1024 * 1024,
+      dwio::common::FileSink::Options{.pool = leafPool_.get()});
+  auto* sinkPtr = sink.get();
+  dwio::common::WriterOptions options;
+  options.memoryPool = rootPool_.get();
+  auto parquetOpts = std::make_shared<ParquetWriterOptions>();
+  parquetOpts->enableParallelWrite = true;
+  options.formatSpecificOptions = parquetOpts;
+  auto writer =
+      std::make_unique<parquet::Writer>(std::move(sink), options, schema);
+
+  writer->write(batch);
+  writer->flush();
+  writer->write(batch);
+  writer->close();
+
+  auto reader = createReaderInMemory(*sinkPtr);
+  ASSERT_EQ(reader->numberOfRows(), kBatchSize * 2);
+  ASSERT_EQ(reader->fileMetaData().numRowGroups(), 2);
 }
 
 } // namespace

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -81,10 +81,6 @@ class ArrowDataBufferSink : public ::arrow::io::OutputStream {
     return bytesFlushed_ + buffer_.size();
   }
 
-  int64_t bufferedBytes() const {
-    return buffer_.size();
-  }
-
   ::arrow::Status Close() override {
     ARROW_RETURN_NOT_OK(Flush());
     sink_->close();
@@ -111,6 +107,8 @@ struct ArrowContext {
   std::unique_ptr<FileWriter> writer;
   std::shared_ptr<::arrow::Schema> schema;
   std::shared_ptr<WriterProperties> properties;
+  uint64_t stagingRows = 0;
+  int64_t stagingBytes = 0;
 };
 
 Compression::type getArrowParquetCompression(
@@ -427,6 +425,7 @@ Writer::Writer(
       getArrowParquetWriterOptions(options, parquetWriterOptions, flushPolicy_);
   setMemoryReclaimers();
   writeInt96AsTimestamp_ = parquetWriterOptions.writeInt96AsTimestamp;
+  enableParallelWrite_ = parquetWriterOptions.enableParallelWrite;
   arrowMemoryPool_ = parquetWriterOptions.arrowMemoryPool;
   parquetFieldIds_ = parquetWriterOptions.parquetFieldIds;
 }
@@ -445,25 +444,45 @@ Writer::Writer(
           std::move(schema)} {}
 
 void Writer::flush() {
-  if (arrowContext_->writer) {
-    PARQUET_THROW_NOT_OK(arrowContext_->writer->finishRowGroup());
+  if (arrowContext_->stagingRows > 0) {
+    if (arrowContext_->writer) {
+      // Complete the current buffered row group so its encoded/compressed
+      // data is written to the stream. This makes the bytes visible to
+      // callers that check raw written bytes for file-rotation decisions.
+      PARQUET_THROW_NOT_OK(arrowContext_->writer->flushBufferedRowGroup());
+    }
+    PARQUET_THROW_NOT_OK(stream_->Flush());
+    arrowContext_->stagingRows = 0;
+    arrowContext_->stagingBytes = 0;
   }
-  PARQUET_THROW_NOT_OK(stream_->Flush());
 }
 
-dwio::common::StripeProgress getStripeProgress(int64_t bufferedBytes) {
-  // Arrow Parquet FileWriter will new row group based on the row number, so
-  // we only check buffered bytes to flush row group here.
-  return dwio::common::StripeProgress{.stripeSizeEstimate = bufferedBytes};
+dwio::common::StripeProgress getStripeProgress(
+    uint64_t stagingRows,
+    int64_t stagingBytes) {
+  return dwio::common::StripeProgress{
+      .stripeRowCount = stagingRows, .stripeSizeEstimate = stagingBytes};
 }
 
 /**
+ * This method would cache input `ColumnarBatch` to make the size of row group
+ * big. It would flush when:
+ * - the cached numRows bigger than `rowsInRowGroup_`
+ * - the cached bytes bigger than `bytesInRowGroup_`
+ *
  * This method assumes each input `ColumnarBatch` have same schema.
  */
 void Writer::write(const VectorPtr& data) {
   VELOX_USER_CHECK(
       data->type()->equivalent(*schema_),
       "The file schema type should be equal with the input rowvector type.");
+
+  // Nothing to write for an empty batch. Avoid creating the FileWriter so
+  // that close() will not produce a file (and commit task) for zero-row
+  // inputs.
+  if (data->size() == 0) {
+    return;
+  }
 
   VectorPtr exportData = data;
   if (needFlatten(exportData)) {
@@ -502,39 +521,49 @@ void Writer::write(const VectorPtr& data) {
       auto recordBatch,
       ::arrow::ImportRecordBatch(&array, arrowContext_->schema));
 
-  if (recordBatch->num_rows() == 0) {
-    return;
+  auto bytes = data->estimateFlatSize();
+  auto numRows = data->size();
+
+  // Check flush policy before writing. Flush closes the current buffered
+  // row group so the next writeRecordBatch starts a new one.
+  if (flushPolicy_->shouldFlush(getStripeProgress(
+          arrowContext_->stagingRows, arrowContext_->stagingBytes))) {
+    flush();
   }
 
+  // Lazily open the FileWriter on the first batch that has data.
   if (!arrowContext_->writer) {
     ArrowWriterProperties::Builder builder;
     if (writeInt96AsTimestamp_) {
       builder.enableDeprecatedInt96Timestamps();
     }
+    if (enableParallelWrite_) {
+      builder.setUseThreads(true);
+    }
     auto arrowProperties = builder.build();
     PARQUET_ASSIGN_OR_THROW(
         arrowContext_->writer,
         FileWriter::open(
-            *recordBatch->schema(),
+            *arrowContext_->schema.get(),
             arrowMemoryPool_.get(),
             stream_,
             arrowContext_->properties,
             arrowProperties));
   }
 
+  // Write the batch directly. The Arrow writer manages buffered row groups
+  // and splits them when maxRowGroupLength is reached.
   PARQUET_THROW_NOT_OK(arrowContext_->writer->writeRecordBatch(*recordBatch));
+
+  arrowContext_->stagingRows += numRows;
+  arrowContext_->stagingBytes += bytes;
 
   // Flush as soon as the current write pushes the staged row group past the
   // policy threshold. Otherwise callers that rotate files based on raw written
   // bytes won't observe the row group until the next write.
   if (flushPolicy_->shouldFlush(getStripeProgress(
-          arrowContext_->writer->currentRowGroupTotalBytes()))) {
+          arrowContext_->stagingRows, arrowContext_->stagingBytes))) {
     flush();
-  } else if (flushPolicy_->bytesInRowGroup() <= stream_->bufferedBytes()) {
-    // Flush the sink separately so completed row groups don't keep accumulating
-    // in the stream buffer when Arrow keeps starting new row groups before the
-    // current one hits the byte threshold.
-    PARQUET_THROW_NOT_OK(stream_->Flush());
   }
 }
 
@@ -543,11 +572,9 @@ bool Writer::isCodecAvailable(common::CompressionKind compression) {
       getArrowParquetCompression(compression));
 }
 
-void Writer::newRowGroup(int32_t numRows) {
-  PARQUET_THROW_NOT_OK(arrowContext_->writer->newRowGroup(numRows));
-}
-
 std::unique_ptr<dwio::common::FileMetadata> Writer::close() {
+  flush();
+
   std::unique_ptr<ParquetFileMetadata> parquetFileMetadata;
   if (arrowContext_->writer) {
     PARQUET_THROW_NOT_OK(arrowContext_->writer->close());

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -427,6 +427,7 @@ Writer::Writer(
       getArrowParquetWriterOptions(options, parquetWriterOptions, flushPolicy_);
   setMemoryReclaimers();
   writeInt96AsTimestamp_ = parquetWriterOptions.writeInt96AsTimestamp;
+  enableParallelWrite_ = parquetWriterOptions.enableParallelWrite;
   arrowMemoryPool_ = parquetWriterOptions.arrowMemoryPool;
   parquetFieldIds_ = parquetWriterOptions.parquetFieldIds;
 }
@@ -510,6 +511,9 @@ void Writer::write(const VectorPtr& data) {
     ArrowWriterProperties::Builder builder;
     if (writeInt96AsTimestamp_) {
       builder.enableDeprecatedInt96Timestamps();
+    }
+    if (enableParallelWrite_) {
+      builder.setUseThreads(true);
     }
     auto arrowProperties = builder.build();
     PARQUET_ASSIGN_OR_THROW(

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -427,7 +427,6 @@ Writer::Writer(
       getArrowParquetWriterOptions(options, parquetWriterOptions, flushPolicy_);
   setMemoryReclaimers();
   writeInt96AsTimestamp_ = parquetWriterOptions.writeInt96AsTimestamp;
-  enableParallelWrite_ = parquetWriterOptions.enableParallelWrite;
   arrowMemoryPool_ = parquetWriterOptions.arrowMemoryPool;
   parquetFieldIds_ = parquetWriterOptions.parquetFieldIds;
 }
@@ -511,9 +510,6 @@ void Writer::write(const VectorPtr& data) {
     ArrowWriterProperties::Builder builder;
     if (writeInt96AsTimestamp_) {
       builder.enableDeprecatedInt96Timestamps();
-    }
-    if (enableParallelWrite_) {
-      builder.setUseThreads(true);
     }
     auto arrowProperties = builder.build();
     PARQUET_ASSIGN_OR_THROW(

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -148,6 +148,12 @@ struct ParquetWriterOptions : public dwio::common::FormatSpecificOptions {
   std::optional<bool> useParquetDataPageV2;
   std::optional<std::string> createdBy;
 
+  /// Write columns in parallel using Arrow's internal thread pool.
+  /// Compression and encoding of different columns proceed concurrently.
+  /// Default is false. Do not enable when writing multiple files in the same
+  /// executor to avoid deadlocks.
+  bool enableParallelWrite = false;
+
   std::shared_ptr<arrow::MemoryPool> arrowMemoryPool;
 
   /// Optional field IDs to assign to columns in the Parquet schema.
@@ -229,6 +235,9 @@ class Writer : public dwio::common::Writer {
 
   // Whether to write Int96 timestamps in Arrow Parquet write.
   bool writeInt96AsTimestamp_;
+
+  // Whether to write columns in parallel.
+  bool enableParallelWrite_;
 };
 
 class ParquetWriterFactory : public dwio::common::WriterFactory {

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -56,12 +56,6 @@ class ParquetFileMetadata : public dwio::common::FileMetadata {
   std::shared_ptr<arrow::FileMetaData> metadata_;
 };
 
-/// Parquet writer enforces the row-count cap via Arrow, and this policy
-/// supplements it with a byte threshold. For Parquet,
-/// - stripeSizeEstimate: the actual compressed bytes of current row group.
-/// - stripeRowCount: remains 0.
-/// Custom Parquet policies should derive from DefaultFlushPolicy to preserve
-/// this contract.
 class DefaultFlushPolicy : public dwio::common::FlushPolicy {
  public:
   DefaultFlushPolicy()
@@ -75,7 +69,8 @@ class DefaultFlushPolicy : public dwio::common::FlushPolicy {
 
   bool shouldFlush(
       const dwio::common::StripeProgress& stripeProgress) override {
-    return stripeProgress.stripeSizeEstimate >= bytesInRowGroup_;
+    return stripeProgress.stripeRowCount >= rowsInRowGroup_ ||
+        stripeProgress.stripeSizeEstimate >= bytesInRowGroup_;
   }
 
   void onClose() override {
@@ -148,6 +143,12 @@ struct ParquetWriterOptions : public dwio::common::FormatSpecificOptions {
   std::optional<bool> useParquetDataPageV2;
   std::optional<std::string> createdBy;
 
+  /// Write columns in parallel using Arrow's internal thread pool.
+  /// Compression and encoding of different columns proceed concurrently.
+  /// Default is false. Do not enable when writing multiple files in the same
+  /// executor to avoid deadlocks.
+  bool enableParallelWrite = false;
+
   std::shared_ptr<arrow::MemoryPool> arrowMemoryPool;
 
   /// Optional field IDs to assign to columns in the Parquet schema.
@@ -161,10 +162,9 @@ struct ParquetWriterOptions : public dwio::common::FormatSpecificOptions {
 class Writer : public dwio::common::Writer {
  public:
   // Constructs a writer with output to 'sink'. 'options' carries common writer
-  // options and Parquet-specific format options. For Parquet,
-  // 'options.flushPolicyFactory' must create a DefaultFlushPolicy (or a
-  // subclass); 'pool' is used for temporary memory. 'schema' specifies the
-  // file's overall schema, and it is always non-null.
+  // options and Parquet-specific format options. 'pool' is used for temporary
+  // memory. 'schema' specifies the file's overall schema, and it is always
+  // non-null.
   Writer(
       std::unique_ptr<dwio::common::FileSink> sink,
       const dwio::common::WriterOptions& options,
@@ -184,9 +184,6 @@ class Writer : public dwio::common::Writer {
   void write(const VectorPtr& data) override;
 
   void flush() override;
-
-  // Forces a row group boundary before the data added by next write().
-  void newRowGroup(int32_t numRows);
 
   bool finish() override {
     return true;
@@ -229,6 +226,9 @@ class Writer : public dwio::common::Writer {
 
   // Whether to write Int96 timestamps in Arrow Parquet write.
   bool writeInt96AsTimestamp_;
+
+  // Whether to write columns in parallel using Arrow's thread pool.
+  bool enableParallelWrite_;
 };
 
 class ParquetWriterFactory : public dwio::common::WriterFactory {

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -148,12 +148,6 @@ struct ParquetWriterOptions : public dwio::common::FormatSpecificOptions {
   std::optional<bool> useParquetDataPageV2;
   std::optional<std::string> createdBy;
 
-  /// Write columns in parallel using Arrow's internal thread pool.
-  /// Compression and encoding of different columns proceed concurrently.
-  /// Default is false. Do not enable when writing multiple files in the same
-  /// executor to avoid deadlocks.
-  bool enableParallelWrite = false;
-
   std::shared_ptr<arrow::MemoryPool> arrowMemoryPool;
 
   /// Optional field IDs to assign to columns in the Parquet schema.
@@ -235,9 +229,6 @@ class Writer : public dwio::common::Writer {
 
   // Whether to write Int96 timestamps in Arrow Parquet write.
   bool writeInt96AsTimestamp_;
-
-  // Whether to write columns in parallel.
-  bool enableParallelWrite_;
 };
 
 class ParquetWriterFactory : public dwio::common::WriterFactory {

--- a/velox/dwio/parquet/writer/arrow/ColumnWriter.cpp
+++ b/velox/dwio/parquet/writer/arrow/ColumnWriter.cpp
@@ -1628,21 +1628,6 @@ class TypedColumnWriterImpl : public ColumnWriterImpl,
     return currentEncoder_->estimatedDataEncodedSize();
   }
 
-  int64_t estimatedBufferedDefLevelBytes() const override {
-    return definitionLevelsSink_.length();
-  }
-
-  int64_t estimatedBufferedRepLevelBytes() const override {
-    return repetitionLevelsSink_.length();
-  }
-
-  int64_t estimatedBufferedDictBytes() const override {
-    if (currentDictEncoder_) {
-      return currentDictEncoder_->dictEncodedSize();
-    }
-    return 0;
-  }
-
  protected:
   std::shared_ptr<Buffer> getValuesBuffer() override {
     return currentEncoder_->flushValues();

--- a/velox/dwio/parquet/writer/arrow/ColumnWriter.h
+++ b/velox/dwio/parquet/writer/arrow/ColumnWriter.h
@@ -194,21 +194,6 @@ class PARQUET_EXPORT ColumnWriter {
   /// totalBytesWritten().
   virtual int64_t totalCompressedBytesWritten() const = 0;
 
-  /// Estimated size of the values that are not written to a page yet.
-  virtual int64_t estimatedBufferedValueBytes() const = 0;
-
-  /// \brief Estimated size of the definition levels that are not written to a
-  /// page yet.
-  virtual int64_t estimatedBufferedDefLevelBytes() const = 0;
-
-  /// \brief Estimated size of the repetition levels that are not written to a
-  /// page yet.
-  virtual int64_t estimatedBufferedRepLevelBytes() const = 0;
-
-  /// \brief Estimated size of the dictionary that are not written to a page
-  /// yet.
-  virtual int64_t estimatedBufferedDictBytes() const = 0;
-
   /// \brief The file-level writer properties.
   virtual const WriterProperties* properties() = 0;
 

--- a/velox/dwio/parquet/writer/arrow/FileWriter.cpp
+++ b/velox/dwio/parquet/writer/arrow/FileWriter.cpp
@@ -73,10 +73,6 @@ int64_t RowGroupWriter::totalCompressedBytesWritten() const {
   return contents_->totalCompressedBytesWritten();
 }
 
-RowGroupWriter::BufferedStats RowGroupWriter::estimatedBufferedStats() const {
-  return contents_->estimatedBufferedStats();
-}
-
 bool RowGroupWriter::buffered() const {
   return contents_->buffered();
 }
@@ -271,22 +267,6 @@ class RowGroupSerializer : public RowGroupWriter::Contents {
     return totalCompressedBytesWritten;
   }
 
-  RowGroupWriter::BufferedStats estimatedBufferedStats() const override {
-    RowGroupWriter::BufferedStats stats;
-    if (closed_) {
-      return stats;
-    }
-    for (const auto& columnWriter : columnWriters_) {
-      if (columnWriter) {
-        stats.defLevelBytes += columnWriter->estimatedBufferedDefLevelBytes();
-        stats.repLevelBytes += columnWriter->estimatedBufferedRepLevelBytes();
-        stats.valueBytes += columnWriter->estimatedBufferedValueBytes();
-        stats.dictBytes += columnWriter->estimatedBufferedDictBytes();
-      }
-    }
-    return stats;
-  }
-
   bool buffered() const override {
     return bufferedRowGroup_;
   }
@@ -436,7 +416,11 @@ class FileSerializer : public ParquetFileWriter::Contents {
       // If any functions here raise an exception, we set isOpen_ to be false
       // so that this does not get called again (possibly causing segfault).
       isOpen_ = false;
-      finishRowGroup();
+      if (rowGroupWriter_) {
+        numRows_ += rowGroupWriter_->numRows();
+        rowGroupWriter_->close();
+      }
+      rowGroupWriter_.reset();
 
       writePageIndex();
 
@@ -468,16 +452,10 @@ class FileSerializer : public ParquetFileWriter::Contents {
     return properties_;
   }
 
-  void finishRowGroup() override {
-    if (rowGroupWriter_) {
-      numRows_ += rowGroupWriter_->numRows();
-      rowGroupWriter_->close();
-      rowGroupWriter_.reset();
-    }
-  }
-
   RowGroupWriter* appendRowGroup(bool bufferedRowGroup) {
-    finishRowGroup();
+    if (rowGroupWriter_) {
+      rowGroupWriter_->close();
+    }
     numRowGroups_++;
     auto rgMetadata = metadata_->appendRowGroup();
     if (pageIndexBuilder_) {
@@ -771,12 +749,6 @@ RowGroupWriter* ParquetFileWriter::appendRowGroup() {
 
 RowGroupWriter* ParquetFileWriter::appendBufferedRowGroup() {
   return contents_->appendBufferedRowGroup();
-}
-
-void ParquetFileWriter::finishRowGroup() {
-  if (contents_) {
-    contents_->finishRowGroup();
-  }
 }
 
 RowGroupWriter* ParquetFileWriter::appendRowGroup(int64_t numRows) {

--- a/velox/dwio/parquet/writer/arrow/FileWriter.h
+++ b/velox/dwio/parquet/writer/arrow/FileWriter.h
@@ -37,15 +37,6 @@ static constexpr uint8_t kParquetEMagic[4] = {'P', 'A', 'R', 'E'};
 
 class PARQUET_EXPORT RowGroupWriter {
  public:
-  /// Estimated uncompressed byte sizes of data buffered by column writers
-  /// that have not yet been serialized into pages.
-  struct BufferedStats {
-    int64_t defLevelBytes = 0;
-    int64_t repLevelBytes = 0;
-    int64_t valueBytes = 0;
-    int64_t dictBytes = 0;
-  };
-
   // Forward declare a virtual class 'Contents' to aid dependency injection and
   // more easily create test fixtures. An implementation of the Contents class
   // is defined in the .cpp file.
@@ -68,9 +59,6 @@ class PARQUET_EXPORT RowGroupWriter {
     virtual int64_t totalCompressedBytes() const = 0;
     /// \brief Total compressed bytes written by the page writer.
     virtual int64_t totalCompressedBytesWritten() const = 0;
-    /// \brief Estimated sizes of buffered data (levels, values, dict) not yet
-    /// written to pages.
-    virtual BufferedStats estimatedBufferedStats() const = 0;
 
     virtual bool buffered() const = 0;
   };
@@ -112,9 +100,6 @@ class PARQUET_EXPORT RowGroupWriter {
   int64_t totalCompressedBytes() const;
   /// \brief Total compressed bytes written by the page writer.
   int64_t totalCompressedBytesWritten() const;
-  /// \brief Estimated sizes of buffered data (levels, values, dict) not yet
-  /// written to pages.
-  BufferedStats estimatedBufferedStats() const;
   /// Returns whether the current RowGroupWriter is in the buffered mode and is
   /// created by calling ParquetFileWriter::appendBufferedRowGroup().
   bool buffered() const;
@@ -173,8 +158,6 @@ class PARQUET_EXPORT ParquetFileWriter {
 
     virtual RowGroupWriter* appendRowGroup() = 0;
     virtual RowGroupWriter* appendBufferedRowGroup() = 0;
-
-    virtual void finishRowGroup() = 0;
 
     virtual int64_t numRows() const = 0;
     virtual int numColumns() const = 0;
@@ -244,12 +227,6 @@ class PARQUET_EXPORT ParquetFileWriter {
   /// only valid until the next call to appendRowGroup() or
   /// appendBufferedRowGroup() or close().
   RowGroupWriter* appendBufferedRowGroup();
-
-  /// Finalize the current row group if one is active. Pages and column
-  /// metadata of the buffered row group are serialized to the underlying
-  /// sink and the active RowGroupWriter is destroyed.
-  /// No-op if there is no active row group.
-  void finishRowGroup();
 
   /// \brief Add key-value metadata to the file.
   /// \param[in] keyValueMetadata The metadata to add.

--- a/velox/dwio/parquet/writer/arrow/Writer.cpp
+++ b/velox/dwio/parquet/writer/arrow/Writer.cpp
@@ -346,16 +346,10 @@ class FileWriterImpl : public FileWriter {
     if (!closed_) {
       // Make idempotent.
       closed_ = true;
-      PARQUET_CATCH_NOT_OK(finishRowGroup());
+      if (rowGroupWriter_ != nullptr) {
+        PARQUET_CATCH_NOT_OK(rowGroupWriter_->close());
+      }
       PARQUET_CATCH_NOT_OK(writer_->close());
-    }
-    return Status::OK();
-  }
-
-  ::arrow::Status finishRowGroup() override {
-    if (rowGroupWriter_ != nullptr) {
-      PARQUET_CATCH_NOT_OK(rowGroupWriter_->close());
-      rowGroupWriter_ = nullptr;
     }
     return Status::OK();
   }
@@ -444,6 +438,14 @@ class FileWriterImpl : public FileWriter {
     return Status::OK();
   }
 
+  Status flushBufferedRowGroup() override {
+    if (rowGroupWriter_ != nullptr) {
+      PARQUET_CATCH_NOT_OK(rowGroupWriter_->close());
+      rowGroupWriter_ = nullptr;
+    }
+    return Status::OK();
+  }
+
   Status writeRecordBatch(const RecordBatch& batch) override {
     if (batch.num_rows() == 0) {
       return Status::OK();
@@ -502,25 +504,14 @@ class FileWriterImpl : public FileWriter {
       RETURN_NOT_OK(writeBatch(offset, batchSize));
       offset += batchSize;
 
-      // Flush current row group if it is full.
+      // Flush current row group if it is full and there is more data to write.
       if (rowGroupWriter_->numRows() >= maxRowGroupLength &&
-          // Avoid leaving an empty row group at the end of the file.
           offset < batch.num_rows()) {
         RETURN_NOT_OK(newBufferedRowGroup());
       }
     }
 
     return Status::OK();
-  }
-
-  int64_t currentRowGroupTotalBytes() const override {
-    if (rowGroupWriter_ == nullptr) {
-      return 0;
-    }
-    auto stats = rowGroupWriter_->estimatedBufferedStats();
-    return stats.defLevelBytes + stats.repLevelBytes + stats.valueBytes +
-        stats.dictBytes + rowGroupWriter_->totalCompressedBytes() +
-        rowGroupWriter_->totalCompressedBytesWritten();
   }
 
   const WriterProperties& properties() const {

--- a/velox/dwio/parquet/writer/arrow/Writer.h
+++ b/velox/dwio/parquet/writer/arrow/Writer.h
@@ -133,6 +133,14 @@ class PARQUET_EXPORT FileWriter {
   /// Returns an error if not all columns have been written.
   virtual ::arrow::Status newBufferedRowGroup() = 0;
 
+  /// \brief Flush the current buffered row group to the output stream
+  /// without starting a new one.
+  ///
+  /// After this call the next writeRecordBatch() will implicitly open a new
+  /// buffered row group. Calling close() after flushBufferedRowGroup() will
+  /// NOT produce a trailing empty row group.
+  virtual ::arrow::Status flushBufferedRowGroup() = 0;
+
   /// \brief Write a RecordBatch into the buffered row group.
   ///
   /// Multiple RecordBatches can be written into the same row group through this
@@ -151,15 +159,6 @@ class PARQUET_EXPORT FileWriter {
   /// option in this case.
   virtual ::arrow::Status writeRecordBatch(
       const ::arrow::RecordBatch& batch) = 0;
-
-  /// \brief Estimated total bytes in the current row group. Including page
-  /// data and buffered data that are not yet written to pages.
-  virtual int64_t currentRowGroupTotalBytes() const = 0;
-
-  /// \brief Finalize the current buffered row group, if any, so that its
-  /// pages and column metadata are serialized to the underlying sink. After
-  /// this call there is no active row group.
-  virtual ::arrow::Status finishRowGroup() = 0;
 
   /// \brief Write the footer and close the file.
   virtual ::arrow::Status close() = 0;


### PR DESCRIPTION
## Superseded

This PR has been fully superseded by upstream changes and PR #17986:

- **writeRecordBatch refactoring**: Merged upstream in the "write batch" PR that landed on main. The staging chunks approach was replaced with direct `writeRecordBatch` calls.
- **Parallel column writing**: The upstream vendored Arrow code already supports `useThreads()` in `writeRecordBatch` (via `ParallelFor` over column writers). PR #17986 enables it with the `enableParallelWrite` option — no vendored Arrow changes needed.
- **Remove unused newRowGroup**: Moved to #17986.
- **Vendored Arrow refactoring** (removing `currentRowGroupTotalBytes`, `finishRowGroup`, `estimatedBufferedStats`; adding `flushBufferedRowGroup`): This was an alternative design. Upstream kept `currentRowGroupTotalBytes()` and `finishRowGroup()`, which #17986 uses. These vendored changes are no longer compatible.

This PR can be closed.

Part of #17988.