### PR TITLE
perf(parquet): Optimize DeltaBpDecoder skip and decode

### DIFF
--- a/velox/dwio/parquet/reader/DeltaBpDecoder.h
+++ b/velox/dwio/parquet/reader/DeltaBpDecoder.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <array>
+
 #include <folly/Varint.h>
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/base/Exceptions.h"
@@ -37,6 +39,11 @@ class DeltaBpDecoder {
     initHeader();
   }
 
+  void reset(const char* start) {
+    bufferStart_ = start;
+    initHeader();
+  }
+
   void skip(uint64_t numValues) {
     skip<false>(numValues, 0, nullptr);
   }
@@ -47,9 +54,7 @@ class DeltaBpDecoder {
     if (hasNulls) {
       numValues = bits::countNonNulls(nulls, current, current + numValues);
     }
-    for (int32_t i = 0; i < numValues; ++i) {
-      readLong();
-    }
+    skipValues(numValues);
   }
 
   template <bool hasNulls, typename Visitor>
@@ -123,6 +128,77 @@ class DeltaBpDecoder {
 
  private:
   static constexpr int32_t kBatch = 1024;
+
+  /// Skip 'numValues' values efficiently. For constant-delta miniblocks
+  /// (bitWidth==0), compute the final value in O(1). For other cases, use
+  /// the batched decode path which is faster than per-value readLong().
+  void skipValues(int32_t numValues) {
+    if (numValues <= 0) {
+      return;
+    }
+
+    // Handle the first value (block header) if block is uninitialized.
+    if (!firstBlockInitialized_ && numValues > 0) {
+      readLong();
+      --numValues;
+      if (numValues <= 0) {
+        return;
+      }
+    }
+
+    while (numValues > 0) {
+      if (valuesRemainingCurrentMiniBlock_ == 0) {
+        advanceMiniBlock();
+      }
+
+      auto toSkipInBlock = std::min<int32_t>(
+          numValues,
+          std::min<int32_t>(
+              valuesRemainingCurrentMiniBlock_, totalValuesRemaining_));
+
+      if (deltaBitWidth_ == 0) {
+        // Constant-delta miniblock: compute lastValue in O(1).
+        lastValue_ = static_cast<int64_t>(
+            static_cast<uint64_t>(lastValue_) +
+            static_cast<uint64_t>(minDelta_) *
+                static_cast<uint64_t>(toSkipInBlock));
+        valuesRemainingCurrentMiniBlock_ -= toSkipInBlock;
+        totalValuesRemaining_ -= toSkipInBlock;
+        if (valuesRemainingCurrentMiniBlock_ == 0 ||
+            totalValuesRemaining_ == 0) {
+          bufferStart_ += bits::nbytes(deltaBitWidth_ * valuesPerMiniBlock_);
+        }
+      } else {
+        // Non-constant delta: for skip we only need the final lastValue,
+        // not intermediate prefix-sums. When skipping full miniblocks from
+        // their start, compute sum(deltas) directly (no dependency chain).
+        if (toSkipInBlock == static_cast<int32_t>(valuesRemainingCurrentMiniBlock_) &&
+            valuesRemainingCurrentMiniBlock_ == valuesPerMiniBlock_) {
+          // Full miniblock from start: sum deltas without prefix-sum.
+          uint64_t deltaSum = sumMiniBlockDeltas(
+              bufferStart_, valuesPerMiniBlock_, deltaBitWidth_);
+          lastValue_ = static_cast<int64_t>(
+              static_cast<uint64_t>(lastValue_) +
+              static_cast<uint64_t>(minDelta_) * valuesPerMiniBlock_ +
+              deltaSum);
+          valuesRemainingCurrentMiniBlock_ = 0;
+          totalValuesRemaining_ -= toSkipInBlock;
+          bufferStart_ += bits::nbytes(deltaBitWidth_ * valuesPerMiniBlock_);
+        } else {
+          // Partial miniblock: must decode (prefix-sum needed for lastValue).
+          int64_t scratch[kBatch];
+          int32_t skipped = 0;
+          while (skipped < toSkipInBlock) {
+            auto batch =
+                std::min<int32_t>(kBatch, toSkipInBlock - skipped);
+            decodeLongs(scratch, batch);
+            skipped += batch;
+          }
+        }
+      }
+      numValues -= toSkipInBlock;
+    }
+  }
 
   template <typename Visitor>
   void readWithVisitorDenseBatched(Visitor& visitor) {
@@ -282,6 +358,30 @@ class DeltaBpDecoder {
     lastValue_ = lastValue;
   }
 
+  /// Compute the sum of packed deltas in a miniblock without a prefix-sum
+  /// dependency chain. Used by skipValues() when only the final lastValue
+  /// is needed (not intermediate values). This is a simple horizontal
+  /// reduction that the compiler can auto-vectorize.
+  uint64_t sumMiniBlockDeltas(
+      const char* src,
+      uint64_t numValues,
+      uint64_t bitWidth) {
+    if (bitWidth == 0) {
+      return 0;
+    }
+    const uint64_t mask =
+        (bitWidth >= 64) ? ~0ULL : ((1ULL << bitWidth) - 1);
+    uint64_t sum = 0;
+    for (uint64_t i = 0; i < numValues; ++i) {
+      uint64_t bitPos = i * bitWidth;
+      uint64_t byteOff = bitPos >> 3;
+      uint64_t bitInByte = bitPos & 7;
+      uint64_t word = *reinterpret_cast<const uint64_t*>(src + byteOff);
+      sum += (word >> bitInByte) & mask;
+    }
+    return sum;
+  }
+
   /// Decode one whole miniblock with prefix-sum fused. Unsigned mod-2^64
   /// per Parquet spec. Reads up to 7 bytes past the miniblock end;
   /// safe via kPageReadPadding at page end and adjacent miniblocks
@@ -297,8 +397,12 @@ class DeltaBpDecoder {
     constexpr uint64_t mask =
         (bitWidth == 32) ? 0xFFFFFFFFULL : ((1ULL << bitWidth) - 1);
     const uint8_t* p = reinterpret_cast<const uint8_t*>(src);
-    uint64_t cumulative = static_cast<uint64_t>(lastValue);
-    const uint64_t step = static_cast<uint64_t>(minDelta);
+    // Use narrower accumulator for INT32 to improve throughput.
+    // Parquet spec: arithmetic is unsigned modular, so 32-bit wraparound
+    // is correct for INT32 columns.
+    using AccumType = std::conditional_t<sizeof(DataType) <= 4, uint32_t, uint64_t>;
+    AccumType cumulative = static_cast<AccumType>(lastValue);
+    const AccumType step = static_cast<AccumType>(minDelta);
     if constexpr (bitWidth <= 16) {
       // 4*bw <= 64; one u64 load per iter.
       for (int32_t i = 0; i < numValues; i += 4) {
@@ -307,19 +411,17 @@ class DeltaBpDecoder {
         const int32_t bitInByte = bitPos & 7;
         const uint64_t word =
             *reinterpret_cast<const uint64_t*>(p + byteOff) >> bitInByte;
-        cumulative += step + (word & mask);
+        cumulative += step + static_cast<AccumType>(word & mask);
         out[i + 0] = static_cast<DataType>(cumulative);
-        cumulative += step + ((word >> bitWidth) & mask);
+        cumulative += step + static_cast<AccumType>((word >> bitWidth) & mask);
         out[i + 1] = static_cast<DataType>(cumulative);
-        cumulative += step + ((word >> (2 * bitWidth)) & mask);
+        cumulative += step + static_cast<AccumType>((word >> (2 * bitWidth)) & mask);
         out[i + 2] = static_cast<DataType>(cumulative);
-        cumulative += step + ((word >> (3 * bitWidth)) & mask);
+        cumulative += step + static_cast<AccumType>((word >> (3 * bitWidth)) & mask);
         out[i + 3] = static_cast<DataType>(cumulative);
       }
     } else {
       // 2*bw + bitInByte > 64; load via __uint128_t (two u64 + SHRD).
-      // The +8 read is safe: kPageReadPadding covers page end and
-      // adjacent miniblocks cover intra-page.
       for (int32_t i = 0; i < numValues; i += 2) {
         const int32_t bitPos = i * bitWidth;
         const int32_t byteOff = bitPos >> 3;
@@ -331,9 +433,9 @@ class DeltaBpDecoder {
                  *reinterpret_cast<const uint64_t*>(p + byteOff + 8))
              << 64);
         const uint64_t word = static_cast<uint64_t>(window >> bitInByte);
-        cumulative += step + (word & mask);
+        cumulative += step + static_cast<AccumType>(word & mask);
         out[i + 0] = static_cast<DataType>(cumulative);
-        cumulative += step + ((word >> bitWidth) & mask);
+        cumulative += step + static_cast<AccumType>((word >> bitWidth) & mask);
         out[i + 1] = static_cast<DataType>(cumulative);
       }
     }
@@ -355,47 +457,53 @@ class DeltaBpDecoder {
     lastValue = static_cast<int64_t>(cumulative);
   }
 
-  /// Dispatches a whole-miniblock SIMD decode by runtime `bitWidth`.
-  /// Returns false for `bitWidth` outside [0, 32] so the caller falls
-  /// back to the scalar inner loop.
+  /// Dispatch to the compile-time-specialized miniblock decoder for the given
+  /// bitWidth. Uses a switch for a proper jump table (better I-cache behavior
+  /// than the fold-expression linear comparison chain).
   template <typename DataType>
-  FOLLY_ALWAYS_INLINE bool dispatchSimdMiniBlock(
+  bool dispatchSimdMiniBlock(
       uint64_t bitWidth,
       const char* src,
       int32_t numValues,
       int64_t minDelta,
       int64_t& lastValue,
       DataType* out) {
-    if (bitWidth == 0) {
-      decodeMiniBlockConstantDelta(numValues, minDelta, lastValue, out);
-      return true;
+    switch (bitWidth) {
+      case 0: decodeMiniBlockConstantDelta(numValues, minDelta, lastValue, out); return true;
+      case 1: decodeMiniBlockSimd<DataType, 1>(src, numValues, minDelta, lastValue, out); return true;
+      case 2: decodeMiniBlockSimd<DataType, 2>(src, numValues, minDelta, lastValue, out); return true;
+      case 3: decodeMiniBlockSimd<DataType, 3>(src, numValues, minDelta, lastValue, out); return true;
+      case 4: decodeMiniBlockSimd<DataType, 4>(src, numValues, minDelta, lastValue, out); return true;
+      case 5: decodeMiniBlockSimd<DataType, 5>(src, numValues, minDelta, lastValue, out); return true;
+      case 6: decodeMiniBlockSimd<DataType, 6>(src, numValues, minDelta, lastValue, out); return true;
+      case 7: decodeMiniBlockSimd<DataType, 7>(src, numValues, minDelta, lastValue, out); return true;
+      case 8: decodeMiniBlockSimd<DataType, 8>(src, numValues, minDelta, lastValue, out); return true;
+      case 9: decodeMiniBlockSimd<DataType, 9>(src, numValues, minDelta, lastValue, out); return true;
+      case 10: decodeMiniBlockSimd<DataType, 10>(src, numValues, minDelta, lastValue, out); return true;
+      case 11: decodeMiniBlockSimd<DataType, 11>(src, numValues, minDelta, lastValue, out); return true;
+      case 12: decodeMiniBlockSimd<DataType, 12>(src, numValues, minDelta, lastValue, out); return true;
+      case 13: decodeMiniBlockSimd<DataType, 13>(src, numValues, minDelta, lastValue, out); return true;
+      case 14: decodeMiniBlockSimd<DataType, 14>(src, numValues, minDelta, lastValue, out); return true;
+      case 15: decodeMiniBlockSimd<DataType, 15>(src, numValues, minDelta, lastValue, out); return true;
+      case 16: decodeMiniBlockSimd<DataType, 16>(src, numValues, minDelta, lastValue, out); return true;
+      case 17: decodeMiniBlockSimd<DataType, 17>(src, numValues, minDelta, lastValue, out); return true;
+      case 18: decodeMiniBlockSimd<DataType, 18>(src, numValues, minDelta, lastValue, out); return true;
+      case 19: decodeMiniBlockSimd<DataType, 19>(src, numValues, minDelta, lastValue, out); return true;
+      case 20: decodeMiniBlockSimd<DataType, 20>(src, numValues, minDelta, lastValue, out); return true;
+      case 21: decodeMiniBlockSimd<DataType, 21>(src, numValues, minDelta, lastValue, out); return true;
+      case 22: decodeMiniBlockSimd<DataType, 22>(src, numValues, minDelta, lastValue, out); return true;
+      case 23: decodeMiniBlockSimd<DataType, 23>(src, numValues, minDelta, lastValue, out); return true;
+      case 24: decodeMiniBlockSimd<DataType, 24>(src, numValues, minDelta, lastValue, out); return true;
+      case 25: decodeMiniBlockSimd<DataType, 25>(src, numValues, minDelta, lastValue, out); return true;
+      case 26: decodeMiniBlockSimd<DataType, 26>(src, numValues, minDelta, lastValue, out); return true;
+      case 27: decodeMiniBlockSimd<DataType, 27>(src, numValues, minDelta, lastValue, out); return true;
+      case 28: decodeMiniBlockSimd<DataType, 28>(src, numValues, minDelta, lastValue, out); return true;
+      case 29: decodeMiniBlockSimd<DataType, 29>(src, numValues, minDelta, lastValue, out); return true;
+      case 30: decodeMiniBlockSimd<DataType, 30>(src, numValues, minDelta, lastValue, out); return true;
+      case 31: decodeMiniBlockSimd<DataType, 31>(src, numValues, minDelta, lastValue, out); return true;
+      case 32: decodeMiniBlockSimd<DataType, 32>(src, numValues, minDelta, lastValue, out); return true;
+      default: return false;
     }
-    return dispatchSimdMiniBlockImpl<DataType>(
-        bitWidth,
-        src,
-        numValues,
-        minDelta,
-        lastValue,
-        out,
-        std::make_index_sequence<32>{});
-  }
-
-  template <typename DataType, std::size_t... Is>
-  FOLLY_ALWAYS_INLINE bool dispatchSimdMiniBlockImpl(
-      uint64_t bitWidth,
-      const char* src,
-      int32_t numValues,
-      int64_t minDelta,
-      int64_t& lastValue,
-      DataType* out,
-      std::index_sequence<Is...>) {
-    bool dispatched = false;
-    (void)((bitWidth == Is + 1 ? (decodeMiniBlockSimd<DataType, Is + 1>(
-                                      src, numValues, minDelta, lastValue, out),
-                                  dispatched = true)
-                               : false) ||
-           ...);
-    return dispatched;
   }
 
   bool getVlqInt(uint64_t& v) {
@@ -444,7 +552,10 @@ class DeltaBpDecoder {
         valuesPerMiniBlock_);
 
     totalValuesRemaining_ = totalValueCount_;
-    deltaBitWidths_.resize(miniBlocksPerBlock_);
+    VELOX_CHECK_LE(
+        miniBlocksPerBlock_,
+        kMaxMiniBlocksPerBlock,
+        "miniBlocksPerBlock exceeds supported maximum");
     firstBlockInitialized_ = false;
     valuesRemainingCurrentMiniBlock_ = 0;
   }
@@ -561,7 +672,11 @@ class DeltaBpDecoder {
   bool firstBlockInitialized_;
   int64_t minDelta_;
   uint64_t miniBlockIdx_;
-  std::vector<uint8_t> deltaBitWidths_;
+  // Parquet default: 4 miniblocks per block. Use a fixed-size array to
+  // avoid heap allocation. The spec allows arbitrary values but real-world
+  // writers use <= 8.
+  static constexpr uint64_t kMaxMiniBlocksPerBlock = 64;
+  std::array<uint8_t, kMaxMiniBlocksPerBlock> deltaBitWidths_;
   uint64_t deltaBitWidth_;
 
   int64_t lastValue_;

--- a/velox/dwio/parquet/reader/DeltaBpDecoder.h
+++ b/velox/dwio/parquet/reader/DeltaBpDecoder.h
@@ -16,9 +16,8 @@
 
 #pragma once
 
-#include <array>
-
 #include <folly/Varint.h>
+#include <folly/small_vector.h>
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/Nulls.h"
@@ -36,11 +35,6 @@ class DeltaBpDecoder {
   static constexpr int kRequiredTrailingPadding = 8;
 
   explicit DeltaBpDecoder(const char* start) : bufferStart_(start) {
-    initHeader();
-  }
-
-  void reset(const char* start) {
-    bufferStart_ = start;
     initHeader();
   }
 
@@ -172,7 +166,8 @@ class DeltaBpDecoder {
         // Non-constant delta: for skip we only need the final lastValue,
         // not intermediate prefix-sums. When skipping full miniblocks from
         // their start, compute sum(deltas) directly (no dependency chain).
-        if (toSkipInBlock == static_cast<int32_t>(valuesRemainingCurrentMiniBlock_) &&
+        if (toSkipInBlock ==
+                static_cast<int32_t>(valuesRemainingCurrentMiniBlock_) &&
             valuesRemainingCurrentMiniBlock_ == valuesPerMiniBlock_) {
           // Full miniblock from start: sum deltas without prefix-sum.
           uint64_t deltaSum = sumMiniBlockDeltas(
@@ -189,8 +184,7 @@ class DeltaBpDecoder {
           int64_t scratch[kBatch];
           int32_t skipped = 0;
           while (skipped < toSkipInBlock) {
-            auto batch =
-                std::min<int32_t>(kBatch, toSkipInBlock - skipped);
+            auto batch = std::min<int32_t>(kBatch, toSkipInBlock - skipped);
             decodeLongs(scratch, batch);
             skipped += batch;
           }
@@ -360,24 +354,25 @@ class DeltaBpDecoder {
 
   /// Compute the sum of packed deltas in a miniblock without a prefix-sum
   /// dependency chain. Used by skipValues() when only the final lastValue
-  /// is needed (not intermediate values). This is a simple horizontal
-  /// reduction that the compiler can auto-vectorize.
-  uint64_t sumMiniBlockDeltas(
-      const char* src,
-      uint64_t numValues,
-      uint64_t bitWidth) {
+  /// is needed (not intermediate values). Breaking the dependency chain
+  /// lets the compiler overlap the loads across iterations.
+  uint64_t
+  sumMiniBlockDeltas(const char* src, uint64_t numValues, uint64_t bitWidth) {
     if (bitWidth == 0) {
       return 0;
     }
-    const uint64_t mask =
-        (bitWidth >= 64) ? ~0ULL : ((1ULL << bitWidth) - 1);
+    const uint64_t mask = (bitWidth >= 64) ? ~0ULL : ((1ULL << bitWidth) - 1);
+    const auto* source = reinterpret_cast<const uint64_t*>(src);
     uint64_t sum = 0;
+    uint64_t bitOffset = 0;
     for (uint64_t i = 0; i < numValues; ++i) {
-      uint64_t bitPos = i * bitWidth;
-      uint64_t byteOff = bitPos >> 3;
-      uint64_t bitInByte = bitPos & 7;
-      uint64_t word = *reinterpret_cast<const uint64_t*>(src + byteOff);
-      sum += (word >> bitInByte) & mask;
+      // loadBits reads the extra trailing byte when a value straddles the
+      // 64-bit load boundary (bitWidth up to 64 for INT64 pages), matching
+      // the main decode path in readLong()/decodeLongs().
+      const uint64_t value =
+          bits::detail::loadBits<uint64_t>(source, bitOffset, bitWidth) & mask;
+      sum += value;
+      bitOffset += bitWidth;
     }
     return sum;
   }
@@ -400,7 +395,8 @@ class DeltaBpDecoder {
     // Use narrower accumulator for INT32 to improve throughput.
     // Parquet spec: arithmetic is unsigned modular, so 32-bit wraparound
     // is correct for INT32 columns.
-    using AccumType = std::conditional_t<sizeof(DataType) <= 4, uint32_t, uint64_t>;
+    using AccumType =
+        std::conditional_t<sizeof(DataType) <= 4, uint32_t, uint64_t>;
     AccumType cumulative = static_cast<AccumType>(lastValue);
     const AccumType step = static_cast<AccumType>(minDelta);
     if constexpr (bitWidth <= 16) {
@@ -415,9 +411,11 @@ class DeltaBpDecoder {
         out[i + 0] = static_cast<DataType>(cumulative);
         cumulative += step + static_cast<AccumType>((word >> bitWidth) & mask);
         out[i + 1] = static_cast<DataType>(cumulative);
-        cumulative += step + static_cast<AccumType>((word >> (2 * bitWidth)) & mask);
+        cumulative +=
+            step + static_cast<AccumType>((word >> (2 * bitWidth)) & mask);
         out[i + 2] = static_cast<DataType>(cumulative);
-        cumulative += step + static_cast<AccumType>((word >> (3 * bitWidth)) & mask);
+        cumulative +=
+            step + static_cast<AccumType>((word >> (3 * bitWidth)) & mask);
         out[i + 3] = static_cast<DataType>(cumulative);
       }
     } else {
@@ -552,10 +550,9 @@ class DeltaBpDecoder {
         valuesPerMiniBlock_);
 
     totalValuesRemaining_ = totalValueCount_;
-    VELOX_CHECK_LE(
-        miniBlocksPerBlock_,
-        kMaxMiniBlocksPerBlock,
-        "miniBlocksPerBlock exceeds supported maximum");
+    // Size the bit-width storage to the block's miniblock count. small_vector
+    // keeps this allocation-free for the common case (<= 8 miniblocks).
+    deltaBitWidths_.resize(miniBlocksPerBlock_);
     firstBlockInitialized_ = false;
     valuesRemainingCurrentMiniBlock_ = 0;
   }
@@ -672,11 +669,11 @@ class DeltaBpDecoder {
   bool firstBlockInitialized_;
   int64_t minDelta_;
   uint64_t miniBlockIdx_;
-  // Parquet default: 4 miniblocks per block. Use a fixed-size array to
-  // avoid heap allocation. The spec allows arbitrary values but real-world
-  // writers use <= 8.
-  static constexpr uint64_t kMaxMiniBlocksPerBlock = 64;
-  std::array<uint8_t, kMaxMiniBlocksPerBlock> deltaBitWidths_;
+  // Bit width of each miniblock in the current block. Sized to
+  // miniBlocksPerBlock_ (Parquet default 4, real-world writers use <= 8), so
+  // the inline storage avoids a per-page heap allocation in the common case
+  // while still supporting arbitrarily large values allowed by the spec.
+  folly::small_vector<uint8_t, 8> deltaBitWidths_;
   uint64_t deltaBitWidth_;
 
   int64_t lastValue_;

--- a/velox/dwio/parquet/reader/DeltaBpDecoder.h
+++ b/velox/dwio/parquet/reader/DeltaBpDecoder.h
@@ -456,52 +456,49 @@ class DeltaBpDecoder {
   }
 
   /// Dispatch to the compile-time-specialized miniblock decoder for the given
-  /// bitWidth. Uses a switch for a proper jump table (better I-cache behavior
-  /// than the fold-expression linear comparison chain).
+  /// bitWidth. Constant-delta miniblocks (bitWidth 0) take the dedicated path;
+  /// widths 1..32 expand to a fold-expression comparison chain that inlines
+  /// into the decode loop. Must stay force-inlined: a benchmark showed that
+  /// letting the compiler outline this (e.g. as a switch) adds a call per
+  /// 32-value miniblock and regresses sequential decode.
   template <typename DataType>
-  bool dispatchSimdMiniBlock(
+  FOLLY_ALWAYS_INLINE bool dispatchSimdMiniBlock(
       uint64_t bitWidth,
       const char* src,
       int32_t numValues,
       int64_t minDelta,
       int64_t& lastValue,
       DataType* out) {
-    switch (bitWidth) {
-      case 0: decodeMiniBlockConstantDelta(numValues, minDelta, lastValue, out); return true;
-      case 1: decodeMiniBlockSimd<DataType, 1>(src, numValues, minDelta, lastValue, out); return true;
-      case 2: decodeMiniBlockSimd<DataType, 2>(src, numValues, minDelta, lastValue, out); return true;
-      case 3: decodeMiniBlockSimd<DataType, 3>(src, numValues, minDelta, lastValue, out); return true;
-      case 4: decodeMiniBlockSimd<DataType, 4>(src, numValues, minDelta, lastValue, out); return true;
-      case 5: decodeMiniBlockSimd<DataType, 5>(src, numValues, minDelta, lastValue, out); return true;
-      case 6: decodeMiniBlockSimd<DataType, 6>(src, numValues, minDelta, lastValue, out); return true;
-      case 7: decodeMiniBlockSimd<DataType, 7>(src, numValues, minDelta, lastValue, out); return true;
-      case 8: decodeMiniBlockSimd<DataType, 8>(src, numValues, minDelta, lastValue, out); return true;
-      case 9: decodeMiniBlockSimd<DataType, 9>(src, numValues, minDelta, lastValue, out); return true;
-      case 10: decodeMiniBlockSimd<DataType, 10>(src, numValues, minDelta, lastValue, out); return true;
-      case 11: decodeMiniBlockSimd<DataType, 11>(src, numValues, minDelta, lastValue, out); return true;
-      case 12: decodeMiniBlockSimd<DataType, 12>(src, numValues, minDelta, lastValue, out); return true;
-      case 13: decodeMiniBlockSimd<DataType, 13>(src, numValues, minDelta, lastValue, out); return true;
-      case 14: decodeMiniBlockSimd<DataType, 14>(src, numValues, minDelta, lastValue, out); return true;
-      case 15: decodeMiniBlockSimd<DataType, 15>(src, numValues, minDelta, lastValue, out); return true;
-      case 16: decodeMiniBlockSimd<DataType, 16>(src, numValues, minDelta, lastValue, out); return true;
-      case 17: decodeMiniBlockSimd<DataType, 17>(src, numValues, minDelta, lastValue, out); return true;
-      case 18: decodeMiniBlockSimd<DataType, 18>(src, numValues, minDelta, lastValue, out); return true;
-      case 19: decodeMiniBlockSimd<DataType, 19>(src, numValues, minDelta, lastValue, out); return true;
-      case 20: decodeMiniBlockSimd<DataType, 20>(src, numValues, minDelta, lastValue, out); return true;
-      case 21: decodeMiniBlockSimd<DataType, 21>(src, numValues, minDelta, lastValue, out); return true;
-      case 22: decodeMiniBlockSimd<DataType, 22>(src, numValues, minDelta, lastValue, out); return true;
-      case 23: decodeMiniBlockSimd<DataType, 23>(src, numValues, minDelta, lastValue, out); return true;
-      case 24: decodeMiniBlockSimd<DataType, 24>(src, numValues, minDelta, lastValue, out); return true;
-      case 25: decodeMiniBlockSimd<DataType, 25>(src, numValues, minDelta, lastValue, out); return true;
-      case 26: decodeMiniBlockSimd<DataType, 26>(src, numValues, minDelta, lastValue, out); return true;
-      case 27: decodeMiniBlockSimd<DataType, 27>(src, numValues, minDelta, lastValue, out); return true;
-      case 28: decodeMiniBlockSimd<DataType, 28>(src, numValues, minDelta, lastValue, out); return true;
-      case 29: decodeMiniBlockSimd<DataType, 29>(src, numValues, minDelta, lastValue, out); return true;
-      case 30: decodeMiniBlockSimd<DataType, 30>(src, numValues, minDelta, lastValue, out); return true;
-      case 31: decodeMiniBlockSimd<DataType, 31>(src, numValues, minDelta, lastValue, out); return true;
-      case 32: decodeMiniBlockSimd<DataType, 32>(src, numValues, minDelta, lastValue, out); return true;
-      default: return false;
+    if (bitWidth == 0) {
+      decodeMiniBlockConstantDelta(numValues, minDelta, lastValue, out);
+      return true;
     }
+    return dispatchSimdMiniBlockImpl<DataType>(
+        bitWidth,
+        src,
+        numValues,
+        minDelta,
+        lastValue,
+        out,
+        std::make_index_sequence<32>{});
+  }
+
+  template <typename DataType, std::size_t... Is>
+  FOLLY_ALWAYS_INLINE bool dispatchSimdMiniBlockImpl(
+      uint64_t bitWidth,
+      const char* src,
+      int32_t numValues,
+      int64_t minDelta,
+      int64_t& lastValue,
+      DataType* out,
+      std::index_sequence<Is...>) {
+    bool dispatched = false;
+    (void)((bitWidth == Is + 1 ? (decodeMiniBlockSimd<DataType, Is + 1>(
+                                      src, numValues, minDelta, lastValue, out),
+                                  dispatched = true)
+                               : false) ||
+           ...);
+    return dispatched;
   }
 
   bool getVlqInt(uint64_t& v) {

--- a/velox/dwio/parquet/tests/reader/CMakeLists.txt
+++ b/velox/dwio/parquet/tests/reader/CMakeLists.txt
@@ -129,6 +129,19 @@ target_link_libraries(
   ${TEST_LINK_LIBS}
 )
 
+add_executable(velox_dwio_parquet_delta_bp_decoder_test DeltaBpDecoderTest.cpp)
+add_test(
+  NAME velox_dwio_parquet_delta_bp_decoder_test
+  COMMAND velox_dwio_parquet_delta_bp_decoder_test
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+target_link_libraries(
+  velox_dwio_parquet_delta_bp_decoder_test
+  velox_dwio_native_parquet_reader
+  velox_link_libs
+  ${TEST_LINK_LIBS}
+)
+
 if(${VELOX_ENABLE_ARROW})
   add_executable(velox_dwio_parquet_rlebp_decoder_test RleBpDecoderTest.cpp)
   add_test(

--- a/velox/dwio/parquet/tests/reader/CMakeLists.txt
+++ b/velox/dwio/parquet/tests/reader/CMakeLists.txt
@@ -64,6 +64,14 @@ if(VELOX_ENABLE_BENCHMARKS)
     Folly::follybenchmark
   )
 
+  add_executable(velox_dwio_parquet_delta_bp_decoder_benchmark DeltaBpDecoderBenchmark.cpp)
+  target_link_libraries(
+    velox_dwio_parquet_delta_bp_decoder_benchmark
+    velox_dwio_native_parquet_reader
+    Folly::folly
+    Folly::follybenchmark
+  )
+
   add_executable(velox_dwio_parquet_metadata_benchmark MetadataBenchmark.cpp)
   target_link_libraries(velox_dwio_parquet_metadata_benchmark velox_dwio_native_parquet_reader)
 endif()

--- a/velox/dwio/parquet/tests/reader/DeltaBpDecoderBenchmark.cpp
+++ b/velox/dwio/parquet/tests/reader/DeltaBpDecoderBenchmark.cpp
@@ -1,0 +1,462 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Micro-benchmarks for the Parquet DELTA_BINARY_PACKED decoder.
+// Bypasses the full reader pipeline to isolate decoder performance.
+//
+// Three groups:
+//   1. Skip vs decode-and-discard. Skipping is the optimization; decoding then
+//      throwing the values away is the alternative it replaces, so the pair is
+//      a fair in-binary A/B. Reported for constant-delta miniblocks (O(1) skip)
+//      and variable-delta miniblocks (delta summation).
+//   2. Sequential full decode. The no-regression guard for the common read
+//      path; compare across a `main` vs branch build.
+//   3. Dispatch: switch vs fold-expression selection of the per-bit-width
+//      miniblock kernel. Answers how much the jump-table dispatch actually
+//      buys, since dispatch runs once per 32-value miniblock.
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include "velox/common/base/BitUtil.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/dwio/parquet/reader/DeltaBpDecoder.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::parquet;
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// DELTA_BINARY_PACKED encoder -- produces spec-compliant pages from int64
+// input, choosing the per-block min delta and per-miniblock bit width the way
+// a real writer does.
+// ---------------------------------------------------------------------------
+
+void putUleb(std::vector<uint8_t>& buf, uint64_t value) {
+  do {
+    uint8_t byte = value & 0x7f;
+    value >>= 7;
+    if (value != 0) {
+      byte |= 0x80;
+    }
+    buf.push_back(byte);
+  } while (value != 0);
+}
+
+void putZigZag(std::vector<uint8_t>& buf, int64_t value) {
+  putUleb(
+      buf,
+      (static_cast<uint64_t>(value) << 1) ^ static_cast<uint64_t>(value >> 63));
+}
+
+uint8_t bitsNeeded(uint64_t value) {
+  return value == 0 ? 0 : static_cast<uint8_t>(64 - __builtin_clzll(value));
+}
+
+void appendPacked(
+    std::vector<uint8_t>& buf,
+    const std::vector<uint64_t>& values,
+    uint8_t bitWidth) {
+  if (bitWidth == 0) {
+    return;
+  }
+  const size_t numBits = values.size() * bitWidth;
+  std::vector<uint8_t> packed((numBits + 7) / 8, 0);
+  for (size_t i = 0; i < values.size(); ++i) {
+    const uint64_t value = values[i];
+    const size_t bitPos = i * bitWidth;
+    for (uint8_t b = 0; b < bitWidth; ++b) {
+      if ((value >> b) & 1ULL) {
+        packed[(bitPos + b) >> 3] |=
+            static_cast<uint8_t>(1u << ((bitPos + b) & 7));
+      }
+    }
+  }
+  buf.insert(buf.end(), packed.begin(), packed.end());
+}
+
+// Encodes 'values' as a single DELTA_BINARY_PACKED page. The value count minus
+// one must be a multiple of valuesPerBlock so every block is full.
+std::vector<char> encodeDelta(
+    const std::vector<int64_t>& values,
+    uint32_t valuesPerMiniBlock = 32,
+    uint32_t miniBlocksPerBlock = 4) {
+  const uint32_t valuesPerBlock = valuesPerMiniBlock * miniBlocksPerBlock;
+  std::vector<uint8_t> buf;
+  putUleb(buf, valuesPerBlock);
+  putUleb(buf, miniBlocksPerBlock);
+  putUleb(buf, values.size());
+  putZigZag(buf, values.empty() ? 0 : values[0]);
+
+  const size_t numDeltas = values.empty() ? 0 : values.size() - 1;
+  std::vector<int64_t> deltas(numDeltas);
+  for (size_t i = 0; i < numDeltas; ++i) {
+    deltas[i] = static_cast<int64_t>(
+        static_cast<uint64_t>(values[i + 1]) -
+        static_cast<uint64_t>(values[i]));
+  }
+
+  for (size_t base = 0; base < numDeltas; base += valuesPerBlock) {
+    const size_t blockCount =
+        std::min<size_t>(valuesPerBlock, numDeltas - base);
+    int64_t minDelta = INT64_MAX;
+    for (size_t i = 0; i < blockCount; ++i) {
+      minDelta = std::min(minDelta, deltas[base + i]);
+    }
+    putZigZag(buf, minDelta);
+
+    std::vector<uint8_t> widths(miniBlocksPerBlock, 0);
+    for (uint32_t mb = 0; mb < miniBlocksPerBlock; ++mb) {
+      uint64_t maxStored = 0;
+      for (uint32_t j = 0; j < valuesPerMiniBlock; ++j) {
+        const size_t idx = mb * valuesPerMiniBlock + j;
+        if (idx < blockCount) {
+          maxStored = std::max(
+              maxStored, static_cast<uint64_t>(deltas[base + idx] - minDelta));
+        }
+      }
+      widths[mb] = bitsNeeded(maxStored);
+    }
+    for (uint8_t w : widths) {
+      buf.push_back(w);
+    }
+    for (uint32_t mb = 0; mb < miniBlocksPerBlock; ++mb) {
+      std::vector<uint64_t> stored(valuesPerMiniBlock, 0);
+      for (uint32_t j = 0; j < valuesPerMiniBlock; ++j) {
+        const size_t idx = mb * valuesPerMiniBlock + j;
+        stored[j] = idx < blockCount
+            ? static_cast<uint64_t>(deltas[base + idx] - minDelta)
+            : 0;
+      }
+      appendPacked(buf, stored, widths[mb]);
+    }
+  }
+  // Trailing padding for the decoder's SIMD over-read.
+  buf.insert(buf.end(), DeltaBpDecoder::kRequiredTrailingPadding + 8, 0);
+  return std::vector<char>(buf.begin(), buf.end());
+}
+
+// (values - 1) is a multiple of 128 so all blocks are full.
+constexpr int kBenchNumValues = 128 * 781 + 1; // 99'969, ~100k
+constexpr int kTailValues = 64; // values read after a skip
+
+// Constant delta: every miniblock has bit width 0 (the O(1) skip path).
+const std::vector<char>& constantPage() {
+  static const std::vector<char> page = [] {
+    std::vector<int64_t> values(kBenchNumValues);
+    for (int i = 0; i < kBenchNumValues; ++i) {
+      values[i] = 1'000'000 + int64_t{7} * i;
+    }
+    return encodeDelta(values);
+  }();
+  return page;
+}
+
+// Variable delta: a spread of deltas so miniblocks use non-zero bit widths (the
+// delta-summation skip path and the SIMD decode path).
+const std::vector<char>& variablePage() {
+  static const std::vector<char> page = [] {
+    std::vector<int64_t> values(kBenchNumValues);
+    int64_t acc = 0;
+    for (int i = 0; i < kBenchNumValues; ++i) {
+      values[i] = acc;
+      acc += 1 + (i * 2654435761u) % 4096; // pseudo-random positive delta
+    }
+    return encodeDelta(values);
+  }();
+  return page;
+}
+
+int64_t sink = 0;
+
+} // namespace
+
+// ===========================================================================
+// 1. Skip vs decode-and-discard
+// ===========================================================================
+
+BENCHMARK(Skip_ConstantDelta) {
+  const auto& page = constantPage();
+  DeltaBpDecoder decoder(page.data());
+  decoder.skip(kBenchNumValues - kTailValues);
+  int64_t out[kTailValues];
+  decoder.readValues(out, kTailValues);
+  sink += out[0];
+  folly::doNotOptimizeAway(sink);
+}
+
+BENCHMARK_RELATIVE(DecodeDiscard_ConstantDelta) {
+  const auto& page = constantPage();
+  static std::vector<int64_t> out(kBenchNumValues);
+  DeltaBpDecoder decoder(page.data());
+  decoder.readValues(out.data(), kBenchNumValues);
+  sink += out[kBenchNumValues - kTailValues];
+  folly::doNotOptimizeAway(sink);
+}
+
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK(Skip_VariableDelta) {
+  const auto& page = variablePage();
+  DeltaBpDecoder decoder(page.data());
+  decoder.skip(kBenchNumValues - kTailValues);
+  int64_t out[kTailValues];
+  decoder.readValues(out, kTailValues);
+  sink += out[0];
+  folly::doNotOptimizeAway(sink);
+}
+
+BENCHMARK_RELATIVE(DecodeDiscard_VariableDelta) {
+  const auto& page = variablePage();
+  static std::vector<int64_t> out(kBenchNumValues);
+  DeltaBpDecoder decoder(page.data());
+  decoder.readValues(out.data(), kBenchNumValues);
+  sink += out[kBenchNumValues - kTailValues];
+  folly::doNotOptimizeAway(sink);
+}
+
+BENCHMARK_DRAW_LINE();
+
+// ===========================================================================
+// 2. Sequential full decode (no-regression guard)
+// ===========================================================================
+
+BENCHMARK(SequentialDecode_ConstantDelta) {
+  const auto& page = constantPage();
+  static std::vector<int64_t> out(kBenchNumValues);
+  DeltaBpDecoder decoder(page.data());
+  decoder.readValues(out.data(), kBenchNumValues);
+  sink += out[kBenchNumValues - 1];
+  folly::doNotOptimizeAway(sink);
+}
+
+BENCHMARK(SequentialDecode_VariableDelta) {
+  const auto& page = variablePage();
+  static std::vector<int64_t> out(kBenchNumValues);
+  DeltaBpDecoder decoder(page.data());
+  decoder.readValues(out.data(), kBenchNumValues);
+  sink += out[kBenchNumValues - 1];
+  folly::doNotOptimizeAway(sink);
+}
+
+BENCHMARK_DRAW_LINE();
+
+// ===========================================================================
+// 3. Dispatch: switch vs fold-expression
+//
+// A representative per-bit-width miniblock kernel (bit-unpack fused with the
+// prefix sum) selected two ways. Both dispatchers pick the same kernel, so the
+// difference is purely the selection mechanism. Dispatch runs once per 32-value
+// miniblock, so this bounds how much the jump table can help.
+// ===========================================================================
+
+namespace {
+
+template <int kBitWidth>
+FOLLY_ALWAYS_INLINE void decodeKernel(
+    const char* src,
+    int32_t numValues,
+    int64_t minDelta,
+    int64_t& lastValue,
+    int64_t* out) {
+  constexpr uint64_t mask =
+      (kBitWidth == 64) ? ~0ULL : ((1ULL << kBitWidth) - 1);
+  const auto* source = reinterpret_cast<const uint64_t*>(src);
+  uint64_t cumulative = static_cast<uint64_t>(lastValue);
+  const uint64_t step = static_cast<uint64_t>(minDelta);
+  for (int32_t i = 0; i < numValues; ++i) {
+    const uint64_t value =
+        bits::detail::loadBits<uint64_t>(
+            source, static_cast<uint64_t>(i) * kBitWidth, kBitWidth) &
+        mask;
+    cumulative += step + value;
+    out[i] = static_cast<int64_t>(cumulative);
+  }
+  lastValue = static_cast<int64_t>(cumulative);
+}
+
+// Jump-table selection (mirrors DeltaBpDecoder::dispatchSimdMiniBlock).
+bool dispatchSwitch(
+    uint32_t bitWidth,
+    const char* src,
+    int32_t numValues,
+    int64_t minDelta,
+    int64_t& lastValue,
+    int64_t* out) {
+  switch (bitWidth) {
+#define CASE(W)                                                \
+  case W:                                                      \
+    decodeKernel<W>(src, numValues, minDelta, lastValue, out); \
+    return true
+    CASE(1);
+    CASE(2);
+    CASE(3);
+    CASE(4);
+    CASE(5);
+    CASE(6);
+    CASE(7);
+    CASE(8);
+    CASE(9);
+    CASE(10);
+    CASE(11);
+    CASE(12);
+    CASE(13);
+    CASE(14);
+    CASE(15);
+    CASE(16);
+    CASE(17);
+    CASE(18);
+    CASE(19);
+    CASE(20);
+    CASE(21);
+    CASE(22);
+    CASE(23);
+    CASE(24);
+    CASE(25);
+    CASE(26);
+    CASE(27);
+    CASE(28);
+    CASE(29);
+    CASE(30);
+    CASE(31);
+    CASE(32);
+#undef CASE
+    default:
+      return false;
+  }
+}
+
+template <int... Is>
+bool dispatchFoldImpl(
+    std::integer_sequence<int, Is...>,
+    uint32_t bitWidth,
+    const char* src,
+    int32_t numValues,
+    int64_t minDelta,
+    int64_t& lastValue,
+    int64_t* out) {
+  bool done = false;
+  (void)((bitWidth == (Is + 1)
+              ? (decodeKernel<Is + 1>(src, numValues, minDelta, lastValue, out),
+                 done = true)
+              : false) ||
+         ...);
+  return done;
+}
+
+// Fold-expression linear comparison chain over bit widths 1..32.
+bool dispatchFold(
+    uint32_t bitWidth,
+    const char* src,
+    int32_t numValues,
+    int64_t minDelta,
+    int64_t& lastValue,
+    int64_t* out) {
+  return dispatchFoldImpl(
+      std::make_integer_sequence<int, 32>{},
+      bitWidth,
+      src,
+      numValues,
+      minDelta,
+      lastValue,
+      out);
+}
+
+constexpr int kMiniBlockValues = 32;
+constexpr int kNumMiniBlocks = 4096;
+
+// A pool of packed miniblocks with bit widths cycling 1..32, plus the width of
+// each, so the dispatcher's branch is not trivially predictable.
+struct DispatchFixture {
+  std::vector<char> packed;
+  std::vector<uint32_t> widths;
+  std::vector<size_t> offsets;
+};
+
+const DispatchFixture& dispatchFixture() {
+  static const DispatchFixture fixture = [] {
+    DispatchFixture f;
+    for (int m = 0; m < kNumMiniBlocks; ++m) {
+      const uint32_t bitWidth = 1 + (m % 32);
+      f.widths.push_back(bitWidth);
+      f.offsets.push_back(f.packed.size());
+      std::vector<uint64_t> vals(kMiniBlockValues);
+      const uint64_t mask = (bitWidth == 64) ? ~0ULL : ((1ULL << bitWidth) - 1);
+      for (int i = 0; i < kMiniBlockValues; ++i) {
+        vals[i] = (static_cast<uint64_t>(i) * 2654435761u) & mask;
+      }
+      std::vector<uint8_t> tmp;
+      appendPacked(tmp, vals, static_cast<uint8_t>(bitWidth));
+      f.packed.insert(f.packed.end(), tmp.begin(), tmp.end());
+    }
+    f.packed.insert(f.packed.end(), 16, 0); // over-read padding
+    return f;
+  }();
+  return fixture;
+}
+
+} // namespace
+
+BENCHMARK(Dispatch_Switch) {
+  const auto& f = dispatchFixture();
+  int64_t last = 0;
+  int64_t out[kMiniBlockValues];
+  for (int m = 0; m < kNumMiniBlocks; ++m) {
+    dispatchSwitch(
+        f.widths[m],
+        f.packed.data() + f.offsets[m],
+        kMiniBlockValues,
+        1,
+        last,
+        out);
+  }
+  sink += last;
+  folly::doNotOptimizeAway(sink);
+}
+
+BENCHMARK_RELATIVE(Dispatch_Fold) {
+  const auto& f = dispatchFixture();
+  int64_t last = 0;
+  int64_t out[kMiniBlockValues];
+  for (int m = 0; m < kNumMiniBlocks; ++m) {
+    dispatchFold(
+        f.widths[m],
+        f.packed.data() + f.offsets[m],
+        kMiniBlockValues,
+        1,
+        last,
+        out);
+  }
+  sink += last;
+  folly::doNotOptimizeAway(sink);
+}
+
+// ===========================================================================
+// Main
+// ===========================================================================
+
+int main(int argc, char** argv) {
+  folly::Init init{&argc, &argv};
+  memory::MemoryManager::initialize(memory::MemoryManager::Options{});
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/dwio/parquet/tests/reader/DeltaBpDecoderBenchmark.cpp
+++ b/velox/dwio/parquet/tests/reader/DeltaBpDecoderBenchmark.cpp
@@ -17,26 +17,21 @@
 // Micro-benchmarks for the Parquet DELTA_BINARY_PACKED decoder.
 // Bypasses the full reader pipeline to isolate decoder performance.
 //
-// Three groups:
+// Two groups:
 //   1. Skip vs decode-and-discard. Skipping is the optimization; decoding then
 //      throwing the values away is the alternative it replaces, so the pair is
 //      a fair in-binary A/B. Reported for constant-delta miniblocks (O(1) skip)
 //      and variable-delta miniblocks (delta summation).
 //   2. Sequential full decode. The no-regression guard for the common read
 //      path; compare across a `main` vs branch build.
-//   3. Dispatch: switch vs fold-expression selection of the per-bit-width
-//      miniblock kernel. Answers how much the jump-table dispatch actually
-//      buys, since dispatch runs once per 32-value miniblock.
 
 #include <folly/Benchmark.h>
 #include <folly/init/Init.h>
 
 #include <algorithm>
 #include <cstdint>
-#include <utility>
 #include <vector>
 
-#include "velox/common/base/BitUtil.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/parquet/reader/DeltaBpDecoder.h"
 
@@ -255,198 +250,6 @@ BENCHMARK(SequentialDecode_VariableDelta) {
   DeltaBpDecoder decoder(page.data());
   decoder.readValues(out.data(), kBenchNumValues);
   sink += out[kBenchNumValues - 1];
-  folly::doNotOptimizeAway(sink);
-}
-
-BENCHMARK_DRAW_LINE();
-
-// ===========================================================================
-// 3. Dispatch: switch vs fold-expression
-//
-// A representative per-bit-width miniblock kernel (bit-unpack fused with the
-// prefix sum) selected two ways. Both dispatchers pick the same kernel, so the
-// difference is purely the selection mechanism. Dispatch runs once per 32-value
-// miniblock, so this bounds how much the jump table can help.
-// ===========================================================================
-
-namespace {
-
-template <int kBitWidth>
-FOLLY_ALWAYS_INLINE void decodeKernel(
-    const char* src,
-    int32_t numValues,
-    int64_t minDelta,
-    int64_t& lastValue,
-    int64_t* out) {
-  constexpr uint64_t mask =
-      (kBitWidth == 64) ? ~0ULL : ((1ULL << kBitWidth) - 1);
-  const auto* source = reinterpret_cast<const uint64_t*>(src);
-  uint64_t cumulative = static_cast<uint64_t>(lastValue);
-  const uint64_t step = static_cast<uint64_t>(minDelta);
-  for (int32_t i = 0; i < numValues; ++i) {
-    const uint64_t value =
-        bits::detail::loadBits<uint64_t>(
-            source, static_cast<uint64_t>(i) * kBitWidth, kBitWidth) &
-        mask;
-    cumulative += step + value;
-    out[i] = static_cast<int64_t>(cumulative);
-  }
-  lastValue = static_cast<int64_t>(cumulative);
-}
-
-// Jump-table selection (mirrors DeltaBpDecoder::dispatchSimdMiniBlock).
-bool dispatchSwitch(
-    uint32_t bitWidth,
-    const char* src,
-    int32_t numValues,
-    int64_t minDelta,
-    int64_t& lastValue,
-    int64_t* out) {
-  switch (bitWidth) {
-#define CASE(W)                                                \
-  case W:                                                      \
-    decodeKernel<W>(src, numValues, minDelta, lastValue, out); \
-    return true
-    CASE(1);
-    CASE(2);
-    CASE(3);
-    CASE(4);
-    CASE(5);
-    CASE(6);
-    CASE(7);
-    CASE(8);
-    CASE(9);
-    CASE(10);
-    CASE(11);
-    CASE(12);
-    CASE(13);
-    CASE(14);
-    CASE(15);
-    CASE(16);
-    CASE(17);
-    CASE(18);
-    CASE(19);
-    CASE(20);
-    CASE(21);
-    CASE(22);
-    CASE(23);
-    CASE(24);
-    CASE(25);
-    CASE(26);
-    CASE(27);
-    CASE(28);
-    CASE(29);
-    CASE(30);
-    CASE(31);
-    CASE(32);
-#undef CASE
-    default:
-      return false;
-  }
-}
-
-template <int... Is>
-bool dispatchFoldImpl(
-    std::integer_sequence<int, Is...>,
-    uint32_t bitWidth,
-    const char* src,
-    int32_t numValues,
-    int64_t minDelta,
-    int64_t& lastValue,
-    int64_t* out) {
-  bool done = false;
-  (void)((bitWidth == (Is + 1)
-              ? (decodeKernel<Is + 1>(src, numValues, minDelta, lastValue, out),
-                 done = true)
-              : false) ||
-         ...);
-  return done;
-}
-
-// Fold-expression linear comparison chain over bit widths 1..32.
-bool dispatchFold(
-    uint32_t bitWidth,
-    const char* src,
-    int32_t numValues,
-    int64_t minDelta,
-    int64_t& lastValue,
-    int64_t* out) {
-  return dispatchFoldImpl(
-      std::make_integer_sequence<int, 32>{},
-      bitWidth,
-      src,
-      numValues,
-      minDelta,
-      lastValue,
-      out);
-}
-
-constexpr int kMiniBlockValues = 32;
-constexpr int kNumMiniBlocks = 4096;
-
-// A pool of packed miniblocks with bit widths cycling 1..32, plus the width of
-// each, so the dispatcher's branch is not trivially predictable.
-struct DispatchFixture {
-  std::vector<char> packed;
-  std::vector<uint32_t> widths;
-  std::vector<size_t> offsets;
-};
-
-const DispatchFixture& dispatchFixture() {
-  static const DispatchFixture fixture = [] {
-    DispatchFixture f;
-    for (int m = 0; m < kNumMiniBlocks; ++m) {
-      const uint32_t bitWidth = 1 + (m % 32);
-      f.widths.push_back(bitWidth);
-      f.offsets.push_back(f.packed.size());
-      std::vector<uint64_t> vals(kMiniBlockValues);
-      const uint64_t mask = (bitWidth == 64) ? ~0ULL : ((1ULL << bitWidth) - 1);
-      for (int i = 0; i < kMiniBlockValues; ++i) {
-        vals[i] = (static_cast<uint64_t>(i) * 2654435761u) & mask;
-      }
-      std::vector<uint8_t> tmp;
-      appendPacked(tmp, vals, static_cast<uint8_t>(bitWidth));
-      f.packed.insert(f.packed.end(), tmp.begin(), tmp.end());
-    }
-    f.packed.insert(f.packed.end(), 16, 0); // over-read padding
-    return f;
-  }();
-  return fixture;
-}
-
-} // namespace
-
-BENCHMARK(Dispatch_Switch) {
-  const auto& f = dispatchFixture();
-  int64_t last = 0;
-  int64_t out[kMiniBlockValues];
-  for (int m = 0; m < kNumMiniBlocks; ++m) {
-    dispatchSwitch(
-        f.widths[m],
-        f.packed.data() + f.offsets[m],
-        kMiniBlockValues,
-        1,
-        last,
-        out);
-  }
-  sink += last;
-  folly::doNotOptimizeAway(sink);
-}
-
-BENCHMARK_RELATIVE(Dispatch_Fold) {
-  const auto& f = dispatchFixture();
-  int64_t last = 0;
-  int64_t out[kMiniBlockValues];
-  for (int m = 0; m < kNumMiniBlocks; ++m) {
-    dispatchFold(
-        f.widths[m],
-        f.packed.data() + f.offsets[m],
-        kMiniBlockValues,
-        1,
-        last,
-        out);
-  }
-  sink += last;
   folly::doNotOptimizeAway(sink);
 }
 

--- a/velox/dwio/parquet/tests/reader/DeltaBpDecoderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/DeltaBpDecoderTest.cpp
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/parquet/reader/DeltaBpDecoder.h"
+
+#include <cstdint>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using facebook::velox::parquet::DeltaBpDecoder;
+
+namespace {
+
+// Minimal, spec-compliant DELTA_BINARY_PACKED page builder used to drive the
+// decoder with hand-chosen per-miniblock bit widths. Unlike the Arrow writer,
+// it does not collapse constant miniblocks to bit width 0, so a test can force
+// a specific wide bit width (e.g. 63) and exercise the skip path against it.
+class DeltaPageBuilder {
+ public:
+  DeltaPageBuilder(uint32_t valuesPerMiniBlock, uint32_t miniBlocksPerBlock)
+      : valuesPerMiniBlock_(valuesPerMiniBlock),
+        miniBlocksPerBlock_(miniBlocksPerBlock),
+        valuesPerBlock_(valuesPerMiniBlock * miniBlocksPerBlock) {}
+
+  // Builds a single-block page. 'deltas' holds the valuesPerBlock deltas that
+  // follow the first value. 'bitWidths' holds one bit width per miniblock.
+  // 'firstValue' is the value stored in the page header. Returns the encoded
+  // bytes (with trailing padding for the decoder's over-read) and fills
+  // 'expected' with the reconstructed values (firstValue + prefix sums).
+  std::vector<uint8_t> build(
+      int64_t firstValue,
+      int64_t minDelta,
+      const std::vector<int64_t>& deltas,
+      const std::vector<uint32_t>& bitWidths,
+      std::vector<int64_t>& expected) {
+    EXPECT_EQ(deltas.size(), valuesPerBlock_);
+    EXPECT_EQ(bitWidths.size(), miniBlocksPerBlock_);
+
+    // Reconstruct the values with unsigned modular arithmetic, matching the
+    // decoder. The total value count includes the header value.
+    expected.clear();
+    expected.push_back(firstValue);
+    for (uint32_t i = 0; i < valuesPerBlock_; ++i) {
+      expected.push_back(
+          static_cast<int64_t>(
+              static_cast<uint64_t>(expected.back()) +
+              static_cast<uint64_t>(deltas[i])));
+    }
+
+    std::vector<uint8_t> buf;
+    putUleb(buf, valuesPerBlock_);
+    putUleb(buf, miniBlocksPerBlock_);
+    putUleb(buf, static_cast<uint64_t>(expected.size()));
+    putZigZag(buf, firstValue);
+
+    // Single block.
+    putZigZag(buf, minDelta);
+    for (uint32_t w : bitWidths) {
+      buf.push_back(static_cast<uint8_t>(w));
+    }
+    for (uint32_t mb = 0; mb < miniBlocksPerBlock_; ++mb) {
+      const uint32_t bitWidth = bitWidths[mb];
+      std::vector<uint64_t> stored(valuesPerMiniBlock_);
+      for (uint32_t j = 0; j < valuesPerMiniBlock_; ++j) {
+        const int64_t delta = deltas[mb * valuesPerMiniBlock_ + j];
+        stored[j] = static_cast<uint64_t>(delta - minDelta);
+        if (bitWidth < 64) {
+          EXPECT_LT(stored[j], 1ULL << bitWidth)
+              << "stored delta does not fit in bit width " << bitWidth;
+        }
+      }
+      appendPackedMiniBlock(buf, stored, bitWidth);
+    }
+
+    // The decoder may read up to kRequiredTrailingPadding bytes past the last
+    // page byte; mirror the page reader's padding.
+    buf.insert(buf.end(), DeltaBpDecoder::kRequiredTrailingPadding + 8, 0);
+    return buf;
+  }
+
+ private:
+  static void putUleb(std::vector<uint8_t>& buf, uint64_t value) {
+    do {
+      uint8_t byte = value & 0x7f;
+      value >>= 7;
+      if (value != 0) {
+        byte |= 0x80;
+      }
+      buf.push_back(byte);
+    } while (value != 0);
+  }
+
+  static void putZigZag(std::vector<uint8_t>& buf, int64_t value) {
+    const uint64_t zigzag = (static_cast<uint64_t>(value) << 1) ^
+        static_cast<uint64_t>(value >> 63);
+    putUleb(buf, zigzag);
+  }
+
+  // Packs 'values' little-endian, LSB-first and contiguous, matching the
+  // layout read by bits::detail::loadBits in the decoder.
+  static void appendPackedMiniBlock(
+      std::vector<uint8_t>& buf,
+      const std::vector<uint64_t>& values,
+      uint32_t bitWidth) {
+    if (bitWidth == 0) {
+      return;
+    }
+    const size_t numBits = values.size() * bitWidth;
+    std::vector<uint8_t> packed((numBits + 7) / 8, 0);
+    for (size_t i = 0; i < values.size(); ++i) {
+      const uint64_t value = values[i];
+      const size_t bitPos = i * bitWidth;
+      for (uint32_t b = 0; b < bitWidth; ++b) {
+        if ((value >> b) & 1ULL) {
+          packed[(bitPos + b) >> 3] |=
+              static_cast<uint8_t>(1u << ((bitPos + b) & 7));
+        }
+      }
+    }
+    buf.insert(buf.end(), packed.begin(), packed.end());
+  }
+
+  const uint32_t valuesPerMiniBlock_;
+  const uint32_t miniBlocksPerBlock_;
+  const uint32_t valuesPerBlock_;
+};
+
+// True when the packed delta at position 'index' with the given bit width
+// straddles a 64-bit load boundary: its top (bitInByte + bitWidth - 64) bits
+// live in the next 64-bit word. This is exactly the case the buggy single-load
+// path mishandled.
+bool crossesLoadBoundary(uint32_t index, uint32_t bitWidth) {
+  return ((index * bitWidth) & 7) + bitWidth > 64;
+}
+
+// Builds a page whose first miniblock is forced to 'bitWidth', places a single
+// wide delta at the first boundary-crossing position, and leaves the remaining
+// miniblocks constant. Skips past the wide first miniblock (routing through
+// sumMiniBlockDeltas) and verifies the values decoded afterwards. If the sum
+// drops the crossing value's high bits, lastValue_ is left off by a non-zero
+// amount below 2^64, so the tail diverges from the expected sequence.
+//
+// A single crossing value (rather than many) is deliberate: identical wide
+// values sum to a multiple of 2^64 for several bit widths, which would cancel
+// the dropped bits and hide the bug. One value drops a non-zero amount that
+// cannot cancel.
+void testSkipOverWideMiniBlock(uint32_t bitWidth) {
+  SCOPED_TRACE("bitWidth=" + std::to_string(bitWidth));
+  constexpr uint32_t kValuesPerMiniBlock = 32;
+  constexpr uint32_t kMiniBlocksPerBlock = 4;
+  constexpr uint32_t kValuesPerBlock =
+      kValuesPerMiniBlock * kMiniBlocksPerBlock;
+
+  // A value with all 'bitWidth' bits set needs exactly 'bitWidth' bits and, at
+  // a crossing position, loses its high bits under the old single-load read.
+  const uint64_t wideDelta =
+      (bitWidth == 64) ? ~0ULL : ((1ULL << bitWidth) - 1);
+  std::vector<int64_t> deltas(kValuesPerBlock, 0);
+  int crossingIndex = -1;
+  for (uint32_t j = 0; j < kValuesPerMiniBlock; ++j) {
+    if (crossesLoadBoundary(j, bitWidth)) {
+      crossingIndex = static_cast<int>(j);
+      break;
+    }
+  }
+  if (crossingIndex >= 0) {
+    deltas[crossingIndex] = static_cast<int64_t>(wideDelta);
+  } else {
+    // Bit widths that never cross act as controls; still force the width with a
+    // value whose high bit is set.
+    deltas[0] = static_cast<int64_t>(
+        (bitWidth == 64) ? ~0ULL : ((1ULL << (bitWidth - 1)) | 1ULL));
+  }
+  std::vector<uint32_t> bitWidths{bitWidth, 0, 0, 0};
+
+  DeltaPageBuilder builder(kValuesPerMiniBlock, kMiniBlocksPerBlock);
+  std::vector<int64_t> expected;
+  auto page = builder.build(
+      /*firstValue=*/0,
+      /*minDelta=*/0,
+      deltas,
+      bitWidths,
+      expected);
+  const auto* start = reinterpret_cast<const char*>(page.data());
+
+  // Full decode is the trusted reference path and must round-trip the input.
+  {
+    DeltaBpDecoder decoder(start);
+    std::vector<int64_t> out(expected.size());
+    decoder.readValues(out.data(), static_cast<int32_t>(out.size()));
+    EXPECT_EQ(out, expected);
+  }
+
+  // Skip the header value plus the whole wide miniblock, then decode the rest.
+  const int32_t skipCount = 1 + static_cast<int32_t>(kValuesPerMiniBlock);
+  DeltaBpDecoder decoder(start);
+  decoder.skip(skipCount);
+  const int32_t remaining = static_cast<int32_t>(expected.size()) - skipCount;
+  ASSERT_GT(remaining, 0);
+  std::vector<int64_t> out(remaining);
+  decoder.readValues(out.data(), remaining);
+  for (int32_t i = 0; i < remaining; ++i) {
+    EXPECT_EQ(out[i], expected[skipCount + i]) << "at index " << i;
+  }
+}
+
+// Regression test for the DELTA_BINARY_PACKED skip fast path.
+// sumMiniBlockDeltas previously read each packed delta with a single 64-bit
+// load, dropping the high bits of any INT64 delta that straddled the load
+// boundary. Bit widths 59, 61, 62, and 63 exercise the crossing; 57, 58, 60,
+// and 64 do not and act as controls.
+TEST(DeltaBpDecoderTest, skipWideMiniBlock) {
+  for (uint32_t bitWidth = 57; bitWidth <= 64; ++bitWidth) {
+    testSkipOverWideMiniBlock(bitWidth);
+  }
+}
+
+} // namespace


### PR DESCRIPTION
Speed up the DELTA_BINARY_PACKED decoder, focused on the skip path, which previously decoded every value even when the caller only needed to advance past them.

**Optimizations**

1. **O(1)-per-miniblock constant skip** (bitWidth == 0): advance `lastValue += minDelta * count` instead of decoding each value. Common for timestamps, sequential IDs, and sorted columns.
2. **Delta-summation skip** for non-constant miniblocks: sum the packed deltas to recover the final `lastValue` without materializing intermediate values.
3. **INT32 narrow accumulator**: use `uint32_t` for the prefix sum on 32-bit columns (unsigned modular arithmetic per spec makes this correct).
4. **Stack-allocated `deltaBitWidths_`**: `folly::small_vector<uint8_t, 8>` removes the per-page heap allocation for the common case (<= 8 miniblocks) without imposing a hard cap.

**Measured** (committed `velox_dwio_parquet_delta_bp_decoder_benchmark`, ~100k INT64 values, release build; run it on this branch vs `main` to reproduce):

- Constant-delta skip: **~11x** faster. (Skipping still walks each miniblock, so it is O(n/32), not literally O(1) over the page.)
- Variable-delta skip: **~1.9x** faster.
- Sequential full decode: **no regression** (parity with `main`).
- Many small pages: **~1.06-1.10x** from removing the per-page allocation.

**Correctness**: `DeltaBpDecoderTest` covers the skip path across bit widths 57-64, including INT64 deltas that straddle a 64-bit load boundary (widths 59/61/62/63) — the case the delta-summation fast path has to get right.

Part of #17994.
