### PR TITLE
fix(cursor): Wake the cursor only on the terminal producer signal (#17995)

### DIFF
--- a/velox/exec/Cursor.cpp
+++ b/velox/exec/Cursor.cpp
@@ -93,15 +93,33 @@ exec::BlockingReason TaskQueue::enqueue(
     bool drained,
     velox::ContinueFuture& future) {
   if (!vector) {
-    std::lock_guard<std::mutex> l(mutex_);
-    if (drained) {
-      ++numDrainedProducers_;
-    } else {
-      ++producersFinished_;
+    // Fulfilled after releasing 'mutex_': setValue() may resume a coroutine
+    // consumer inline, which would re-enter the queue and deadlock on 'mutex_'.
+    ContinuePromise wakeConsumer{ContinuePromise::makeEmpty()};
+    {
+      std::lock_guard<std::mutex> l(mutex_);
+      if (drained) {
+        ++numDrainedProducers_;
+      } else {
+        ++producersFinished_;
+      }
+      // Only wake a blocked consumer once all producers have finished or all
+      // have drained. A producer-done signal from just one of several producers
+      // leaves data still potentially arriving from the others, so waking here
+      // would hand the consumer an empty queue and force it to re-wait. Data
+      // enqueues wake the consumer on their own. When the consumer is blocked,
+      // numProducers_ is already set (dequeue runs after start()'s
+      // setNumProducers()), so a missing count cannot hide this signal.
+      const bool allFinishedOrDrained = numProducers_.has_value() &&
+          (producersFinished_ == numProducers_.value() ||
+           numDrainedProducers_ == numProducers_.value());
+      if (consumerBlocked_ && allFinishedOrDrained) {
+        consumerBlocked_ = false;
+        wakeConsumer = std::move(consumerPromise_);
+      }
     }
-    if (consumerBlocked_) {
-      consumerBlocked_ = false;
-      consumerPromise_.setValue();
+    if (wakeConsumer.valid()) {
+      wakeConsumer.setValue();
     }
     return exec::BlockingReason::kNotBlocked;
   }
@@ -109,25 +127,33 @@ exec::BlockingReason TaskQueue::enqueue(
   auto bytes = vector->retainedSize();
   TaskQueueEntry entry{std::move(vector), bytes};
 
-  std::lock_guard<std::mutex> l(mutex_);
-  // Check inside 'mutex_'
-  if (closed_) {
-    throw std::runtime_error("Consumer cursor is closed");
+  // Fulfilled after releasing 'mutex_' for the same reason as above.
+  ContinuePromise wakeConsumer{ContinuePromise::makeEmpty()};
+  exec::BlockingReason reason{exec::BlockingReason::kNotBlocked};
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    // Check inside 'mutex_'
+    if (closed_) {
+      throw std::runtime_error("Consumer cursor is closed");
+    }
+    queue_.push_back(std::move(entry));
+    totalBytes_ += bytes;
+    if (consumerBlocked_) {
+      consumerBlocked_ = false;
+      wakeConsumer = std::move(consumerPromise_);
+    }
+    if (totalBytes_ > maxBytes_) {
+      auto [unblockPromise, unblockFuture] =
+          makeVeloxContinuePromiseContract("TaskQueue::enqueue");
+      producerUnblockPromises_.emplace_back(std::move(unblockPromise));
+      future = std::move(unblockFuture);
+      reason = exec::BlockingReason::kWaitForConsumer;
+    }
   }
-  queue_.push_back(std::move(entry));
-  totalBytes_ += bytes;
-  if (consumerBlocked_) {
-    consumerBlocked_ = false;
-    consumerPromise_.setValue();
+  if (wakeConsumer.valid()) {
+    wakeConsumer.setValue();
   }
-  if (totalBytes_ > maxBytes_) {
-    auto [unblockPromise, unblockFuture] =
-        makeVeloxContinuePromiseContract("TaskQueue::enqueue");
-    producerUnblockPromises_.emplace_back(std::move(unblockPromise));
-    future = std::move(unblockFuture);
-    return exec::BlockingReason::kWaitForConsumer;
-  }
-  return exec::BlockingReason::kNotBlocked;
+  return reason;
 }
 
 RowVectorPtr TaskQueue::dequeue(velox::ContinueFuture& future) {
@@ -174,18 +200,26 @@ RowVectorPtr TaskQueue::dequeue(velox::ContinueFuture& future) {
 }
 
 void TaskQueue::close() {
-  std::lock_guard<std::mutex> l(mutex_);
-  closed_ = true;
-  // Unblock producers.
-  for (auto& promise : producerUnblockPromises_) {
-    promise.setValue();
-  }
-  producerUnblockPromises_.clear();
+  // Fulfilled after releasing 'mutex_': setValue() may resume a coroutine
+  // consumer inline, which would re-enter the queue and deadlock on 'mutex_'.
+  ContinuePromise wakeConsumer{ContinuePromise::makeEmpty()};
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    closed_ = true;
+    // Unblock producers.
+    for (auto& promise : producerUnblockPromises_) {
+      promise.setValue();
+    }
+    producerUnblockPromises_.clear();
 
-  // Unblock consumers.
-  if (consumerBlocked_) {
-    consumerBlocked_ = false;
-    consumerPromise_.setValue();
+    // Unblock the consumer.
+    if (consumerBlocked_) {
+      consumerBlocked_ = false;
+      wakeConsumer = std::move(consumerPromise_);
+    }
+  }
+  if (wakeConsumer.valid()) {
+    wakeConsumer.setValue();
   }
 }
 

--- a/velox/exec/tests/CursorTest.cpp
+++ b/velox/exec/tests/CursorTest.cpp
@@ -99,6 +99,33 @@ TEST_F(CursorTest, asyncMatchesSync) {
   EXPECT_EQ(drainAsync(*asyncCursor), syncRows);
 }
 
+// With multiple output drivers (producers), a blocked async consumer must still
+// be woken and drain to completion. Exercises terminal-only consumer signaling:
+// a non-terminal producer finishing must not be relied on to wake the consumer,
+// and the terminal one must — a missed wakeup here would hang the drain.
+TEST_F(CursorTest, asyncDrainParallelMultipleProducers) {
+  constexpr int32_t kNumDrivers = 4;
+  // input_ holds 10 rows; the plan emits 3 copies and, being parallelizable,
+  // replicates that full 30-row set on each driver.
+  constexpr int64_t kRowsPerDriver = 3 * 10;
+
+  CursorParameters params;
+  params.planNode =
+      PlanBuilder()
+          .values({input_, input_, input_}, /*parallelizable=*/true)
+          .planNode();
+  params.serialExecution = false;
+  params.maxDrivers = kNumDrivers;
+
+  auto cursor = TaskCursor::create(params);
+  cursor->start();
+  // The driver count is fixed by maxDrivers at task creation (not timing), so
+  // pin it exactly: a regression that ran a single producer would both miss the
+  // multi-producer wakeup path and fail here loudly.
+  EXPECT_EQ(cursor->task()->numOutputDrivers(), kNumDrivers);
+  EXPECT_EQ(drainAsync(*cursor), kNumDrivers * kRowsPerDriver);
+}
+
 // After the task is cancelled, the parallel cursor surfaces the error from
 // moveNext() rather than returning data. requestCancel().wait() makes the
 // terminal state deterministic before we pull.


### PR DESCRIPTION
Summary:

TaskQueue::enqueue(nullptr, ...) (a producer signaling completion) fulfilled the consumer promise on every producer finishing, not just the last. With multiple producers the consumer woke while the queue was still empty and other producers were running; dequeue then found no data, not-all-finished, and handed out another future. So a resolved wait-future did not imply the next call yields data, which is the only reason TaskCursor::moveNext (and downstream coroutine pulls) needed an unbounded retry loop instead of a single wait.

Now the producer-done path wakes a blocked consumer only when the signal is terminal (all producers finished or all drained); data enqueues already wake it. A resolved future therefore always yields data-or-terminal on the next dequeue.

Differential Revision: D110217977
