### PR TITLE
build(ci): Update to zizmor 1.26.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,5 +18,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: 'build(ci): '

--- a/.github/workflows/breeze.yml
+++ b/.github/workflows/breeze.yml
@@ -54,7 +54,7 @@ jobs:
         working-directory: velox
     steps:
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           path: velox
           persist-credentials: false
@@ -95,7 +95,7 @@ jobs:
         working-directory: velox
     steps:
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           path: velox
           persist-credentials: false

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -52,7 +52,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
@@ -104,7 +104,7 @@ jobs:
           cat $sizes_file
           echo "::endgroup::"
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           path: ${{ env.sizes_file }}
           name: ${{ matrix.type }}-${{ matrix.link-type }}-sizes

--- a/.github/workflows/ci-failure-comment.yml
+++ b/.github/workflows/ci-failure-comment.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Download failure artifacts
         if: steps.pr.outputs.number
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           github-token: ${{ github.token }}
           run-id: ${{ inputs.run_id || github.event.workflow_run.id }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -187,7 +187,7 @@ jobs:
 
     steps:
       - name: Post unauthorized notice
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             await github.rest.issues.createComment({

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -187,7 +187,7 @@ jobs:
 
     steps:
       - name: Post unauthorized notice
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             await github.rest.issues.createComment({

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -48,14 +48,14 @@ jobs:
     env:
       VELOX_DEPENDENCY_SOURCE: SYSTEM
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           persist-credentials: false
 
       - uses: ./.github/actions/generate-dependency-graph
 
       - name: Upload dependency graph
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: dependency-graph
           path: dependency-graph.json

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -30,7 +30,7 @@ jobs:
   labeler:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml

--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -129,7 +129,7 @@ jobs:
       failed-cases: ${{ steps.retry-tests.outputs.failed-cases }}
       failure-details: ${{ steps.retry-tests.outputs.failure-details }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 2
           persist-credentials: false
@@ -543,7 +543,7 @@ jobs:
         shell: bash
         working-directory: velox
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 2
           path: velox
@@ -584,7 +584,7 @@ jobs:
         run: |
           mkdir -p "$CCACHE_DIR"
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           path: velox
           persist-credentials: false
@@ -775,7 +775,7 @@ jobs:
         shell: bash
         working-directory: velox
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 2
           path: velox
@@ -937,7 +937,7 @@ jobs:
           # Show after
           echo "New available disk space: " $(getAvailableSpace)
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 2
           persist-credentials: false

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -62,7 +62,7 @@ jobs:
       INSTALL_PREFIX: /tmp/deps-install
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/selective-build-comment.yml
+++ b/.github/workflows/selective-build-comment.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Post or update PR comment
         if: steps.pr.outputs.number
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
         with:

--- a/.github/workflows/selective-build-comment.yml
+++ b/.github/workflows/selective-build-comment.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Download comment artifact
         id: download
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: selective-build-comment
           github-token: ${{ github.token }}
@@ -86,7 +86,7 @@ jobs:
 
       - name: Post or update PR comment
         if: steps.pr.outputs.number
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
         with:

--- a/.github/workflows/selective-build-plan.yml
+++ b/.github/workflows/selective-build-plan.yml
@@ -67,7 +67,7 @@ jobs:
       needs_slow_prepare: ${{ steps.final.outputs.needs_slow_prepare }}
       cmake_targets: ${{ steps.read-targets.outputs.cmake_targets }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           persist-credentials: false
           sparse-checkout: .github/scripts
@@ -202,7 +202,7 @@ jobs:
 
       - name: Download cached graph
         if: steps.graph-artifact.outputs.available == 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dependency-graph
           github-token: ${{ github.token }}
@@ -326,7 +326,7 @@ jobs:
           echo "needs_slow_prepare=$needs_slow" >> "$GITHUB_OUTPUT"
 
       - name: Upload comment artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: selective-build-comment
           path: comment.md
@@ -353,7 +353,7 @@ jobs:
       # are non-empty (no override needed).
       mode_override: ${{ steps.read-targets.outputs.cmake_targets == '' && 'full' || '' }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -391,7 +391,7 @@ jobs:
           echo "cmake_targets=$targets" >> "$GITHUB_OUTPUT"
 
       - name: Upload comment artifact (overwrite)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: selective-build-comment
           path: comment.md

--- a/.github/workflows/ubuntu-bundled-deps.yml
+++ b/.github/workflows/ubuntu-bundled-deps.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           mkdir -p "$CCACHE_DIR"
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           path: velox
           persist-credentials: false

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -15,6 +15,9 @@ rules:
   use-trusted-publishing:
     ignore:
       - build_pyvelox.yml
+  adhoc-packages:
+    ignore:
+      - linux-build-base.yml
   dangerous-triggers:
     ignore:
       - selective-build-comment.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -135,7 +135,7 @@ repos:
         exclude: .*\.clang-(tidy|format)
 
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.7.0
+    rev: v1.26.1
     hooks:
       - id: zizmor
 


### PR DESCRIPTION
Proposes updating from `zizmor` 1.7.0 ([May 8, 2025](https://github.com/zizmorcore/zizmor/releases/tag/v1.7.0)) to 1.26.1 ([June 20, 2026](https://github.com/zizmorcore/zizmor/releases/tag/v1.26.1)).

This also fixes the new things it flags:

* GitHub first-party actions in the `actions/` namespace should now also be pinned to commit SHAs
* `dependabot` should be configured with a "cooldown" (minimum age a released dependency must have before dependabot suggests upgrading to it)

Thanks for your time and consideration.