### PR TITLE
feat(exec): Fire stateChangeFuture on scan split queue drain (#17998)

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -2164,13 +2164,27 @@ BlockingReason Task::getSplitOrFuture(
     const ConnectorSplitPreloadFunc& preload,
     exec::Split& split,
     ContinueFuture& future) {
-  std::lock_guard<std::timed_mutex> l(mutex_);
-  auto& splitsState = getPlanNodeSplitsStateLocked(planNodeId);
-  auto* splitsStore = getOrCreateSplitsStoreLocked(splitsState, splitGroupId);
-  return splitsStore->nextSplit(
-             driverId, maxPreloadSplits, preload, split, future)
-      ? BlockingReason::kNotBlocked
-      : BlockingReason::kWaitForSplit;
+  EventCompletionNotifier stateChangeNotifier;
+  bool notBlocked{false};
+  {
+    std::lock_guard<std::timed_mutex> l(mutex_);
+    auto& splitsState = getPlanNodeSplitsStateLocked(planNodeId);
+    auto* splitsStore = getOrCreateSplitsStoreLocked(splitsState, splitGroupId);
+    const auto numQueuedBefore = taskStats_.numQueuedTableScanSplits;
+    notBlocked = splitsStore->nextSplit(
+        driverId, maxPreloadSplits, preload, split, future);
+    // Wake status waiters when the scan split queue drains while more splits
+    // may still arrive, so a coordinator can refill before the task starves.
+    // Once noMoreSplits has been signaled there is nothing left to refill, so
+    // the drain carries no actionable signal and is skipped.
+    if (numQueuedBefore > 0 && taskStats_.numQueuedTableScanSplits == 0 &&
+        !splitsState.noMoreSplits) {
+      stateChangeNotifier.activate(std::move(stateChangePromises_));
+    }
+  }
+  stateChangeNotifier.notify();
+  return notBlocked ? BlockingReason::kNotBlocked
+                    : BlockingReason::kWaitForSplit;
 }
 
 bool Task::testingHasDriverWaitForSplit() const {

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -625,6 +625,84 @@ TEST_F(TaskTest, createdCount) {
   ASSERT_EQ(Task::numCreatedTasks(), createdCount + 1);
 }
 
+TEST_F(TaskTest, stateChangeFutureOnSplitQueueDrain) {
+  // Draining the scan split queue while more splits may still arrive resolves
+  // stateChangeFuture, so a coordinator's status poll can refill the queue
+  // before the task starves. Serial next() requires noMoreSplits up front,
+  // which would gate the notification, so exercise the consume path directly.
+  auto data = makeRowVector({makeFlatVector<int32_t>({1, 2, 3})});
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->getPath(), {data});
+  auto task = Task::create(
+      "task-1",
+      PlanBuilder().tableScan(asRowType(data->type())).planFragment(),
+      0,
+      core::QueryCtx::create(),
+      Task::ExecutionMode::kSerial,
+      exec::Consumer{});
+  task->addSplit("0", exec::Split(makeHiveConnectorSplit(filePath->getPath())));
+  ASSERT_EQ(task->taskStats().numQueuedTableScanSplits, 1);
+
+  auto future = task->stateChangeFuture(0);
+  EXPECT_FALSE(future.isReady());
+
+  exec::Split split;
+  ContinueFuture splitFuture = ContinueFuture::makeEmpty();
+  EXPECT_EQ(
+      task->getSplitOrFuture(
+          /*driverId=*/0,
+          kUngroupedGroupId,
+          "0",
+          /*maxPreloadSplits=*/0,
+          /*preload=*/nullptr,
+          split,
+          splitFuture),
+      BlockingReason::kNotBlocked);
+  EXPECT_EQ(task->taskStats().numQueuedTableScanSplits, 0);
+  EXPECT_TRUE(future.isReady());
+
+  task->requestCancel().wait();
+}
+
+TEST_F(TaskTest, stateChangeFutureNotFiredWhenNoMoreSplits) {
+  // After noMoreSplits there is nothing left to refill, so draining the scan
+  // split queue carries no actionable signal and does not resolve
+  // stateChangeFuture.
+  auto data = makeRowVector({makeFlatVector<int32_t>({1, 2, 3})});
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->getPath(), {data});
+  auto task = Task::create(
+      "task-1",
+      PlanBuilder().tableScan(asRowType(data->type())).planFragment(),
+      0,
+      core::QueryCtx::create(),
+      Task::ExecutionMode::kSerial,
+      exec::Consumer{});
+  task->addSplit("0", exec::Split(makeHiveConnectorSplit(filePath->getPath())));
+  task->noMoreSplits("0");
+  ASSERT_EQ(task->taskStats().numQueuedTableScanSplits, 1);
+
+  auto future = task->stateChangeFuture(0);
+  EXPECT_FALSE(future.isReady());
+
+  exec::Split split;
+  ContinueFuture splitFuture = ContinueFuture::makeEmpty();
+  EXPECT_EQ(
+      task->getSplitOrFuture(
+          /*driverId=*/0,
+          kUngroupedGroupId,
+          "0",
+          /*maxPreloadSplits=*/0,
+          /*preload=*/nullptr,
+          split,
+          splitFuture),
+      BlockingReason::kNotBlocked);
+  EXPECT_EQ(task->taskStats().numQueuedTableScanSplits, 0);
+  EXPECT_FALSE(future.isReady());
+
+  task->requestCancel().wait();
+}
+
 TEST_F(TaskTest, wrongPlanNodeForSplit) {
   auto connectorSplit = std::make_shared<connector::hive::HiveConnectorSplit>(
       "test",


### PR DESCRIPTION
Summary:

`Task::stateChangeFuture` already resolves on important task state changes (a split group finishing, the task terminating). Make it also resolve when the scan split queue drains, so a coordinator that long-polls task status via `stateChangeFuture` wakes as soon as a worker has split-queue space instead of waiting out a fixed poll interval. Velox previously exposed no consume-side signal for this.

The notification fires from the existing consume path in `getSplitOrFuture` when the last queued table scan split is handed out, and is delivered after releasing `mutex_` so continuations do not run under the lock.

Differential Revision: D110222389


