### PR TITLE
feat(nimble): Add reader-owned lazy I/O load hook (#17999)

### DIFF
--- a/velox/dwio/common/ColumnLoader.cpp
+++ b/velox/dwio/common/ColumnLoader.cpp
@@ -52,6 +52,9 @@ RowSet read(
     effectiveRows = selectedRows;
   }
 
+  // Load any deferred input streams for this column before decoding. Done on
+  // the reader so it runs regardless of which loader subclass is used.
+  fieldReader->formatData().loadLazyInputStreams();
   structReader->advanceFieldReader(fieldReader, offset);
   fieldReader->scanSpec()->setValueHook(hook);
   fieldReader->readWithTiming(offset, effectiveRows, incomingNulls);

--- a/velox/dwio/common/FormatData.h
+++ b/velox/dwio/common/FormatData.h
@@ -36,6 +36,10 @@ class FormatData {
     return *static_cast<T*>(this);
   }
 
+  /// Loads any deferred input streams for this column before it is decoded.
+  /// The default is a no-op; formats that defer stream loading override it.
+  virtual void loadLazyInputStreams() {}
+
   /// Reads nulls if the format has nulls separate from the encoded
   /// data. If there are no nulls, 'nulls' is set to nullptr, else to
   /// a suitable sized and padded Buffer. 'incomingNulls' may be given


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookincubator/nimble/pull/925

D110095905 fixed the "Fail to read region" crash on Nimble lazy column I/O by
excluding delta-updated columns from lazy I/O (a denylist). That stops the crash
but forces those columns to read eagerly, giving up the lazy-io benefit.

This replaces the denylist with a reader-owned load hook: a no-op
FormatData::loadLazyInputStreams() virtual, called from the shared ColumnLoader
read path and overridden by Nimble to load the deferred lazy clone. Because it
fires from the shared read path, every loader (plain, transform, delta) triggers
it, so deferred streams are loaded before decode and the "streams never loaded"
bug class is structurally impossible.

With the load decoupled from the loader, loader-type selection is left entirely
to the base makeColumnLoader(), independent of laziness: a lazy column gets the
same loader it would eagerly (TransformColumnLoader for extraction transforms,
DeltaUpdateColumnLoader for delta updates on a separate path, TrackedColumnLoader
otherwise). Deferring a column's streams therefore never changes how it decodes,
so delta-updated AND transform columns are lazy-eligible again;
computeLazyIoColumns() now excludes only filter, remaining-filter, and
non-projected columns.

Reviewed By: xiaoxmeng

Differential Revision: D110134101


