### PR TITLE
docs: Scope BMI/BMI2/F16C requirements to x86

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,18 +248,9 @@ disable grouping on Linux, pass `-DVELOX_ENABLE_GROUPED_TESTS=OFF` via
 
 Note that,
 * Velox requires a compiler at the minimum GCC 11.0 or Clang 15.0.
-* Velox requires the CPU to support instruction sets:
-  * bmi
-  * bmi2
-  * f16c
-* Velox tries to use the following (or equivalent) instruction sets where available:
-  * On Intel CPUs
-    * avx
-    * avx2
-    * sse
-  * On ARM
-    * Neon
-    * Neon64
+* On x86 CPUs, Velox requires BMI, BMI2, and F16C, and uses AVX, AVX2,
+  and SSE where available.
+* On Arm CPUs, Velox uses Neon and Neon64 where available.
 
 Build metrics for Velox are published at <https://facebookincubator.github.io/velox/bm-report/>
 


### PR DESCRIPTION
Scope BMI, BMI2, and F16C requirements to x86 CPUs.
Document Neon and Neon64 separately for Arm CPUs.
Remove the implication that Arm platforms require x86 instruction BMI, BMI2, and F16C sets.