### PR TITLE
feat(fuzzer): Generate multi-batch adaptively-sized files (#18008)

### DIFF
--- a/velox/exec/tests/TableEvolutionFuzzer.cpp
+++ b/velox/exec/tests/TableEvolutionFuzzer.cpp
@@ -26,9 +26,11 @@
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/exec/tests/utils/QueryAssertions.h"
 #include "velox/expression/fuzzer/ExpressionFuzzer.h"
+#include "velox/expression/fuzzer/FuzzerToolkit.h"
 #include "velox/functions/FunctionRegistry.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 
+#include <algorithm>
 #include <filesystem>
 
 #include <re2/re2.h>
@@ -58,6 +60,40 @@ DEFINE_int32(
     "is enabled with probability 1/N where N is this value. For example, "
     "N=5 means 20% chance, N=2 means 50% chance.");
 
+DEFINE_int32(
+    batches_per_file,
+    8,
+    "Number of independently-fuzzed batches written per file (one writer "
+    "write() call each). A fixed count is sufficient: chunk and stripe flush "
+    "randomness already varies the physical layout across files.");
+
+DEFINE_bool(
+    adaptive_batch_sizing,
+    true,
+    "When true, each written batch is sized adaptively to about "
+    "--batch_target_bytes raw bytes (the per-batch row count is derived from "
+    "the schema's per-row cost, clamped to [--min_adaptive_vector_size, "
+    "--max_adaptive_vector_size]). When false, batches use a fixed row count.");
+
+DEFINE_int64(
+    batch_target_bytes,
+    facebook::velox::exec::test::TableEvolutionFuzzer::kTargetBatchBytes,
+    "Target raw size in bytes for each written batch. The per-batch row count "
+    "is derived from this target so batch bytes stay schema-independent across "
+    "narrow and wide/nested schemas. Only used when --adaptive_batch_sizing.");
+
+DEFINE_int32(
+    min_adaptive_vector_size,
+    facebook::velox::exec::test::TableEvolutionFuzzer::kMinAdaptiveVectorSize,
+    "Lower bound on the adaptive per-batch row count "
+    "(used when --adaptive_batch_sizing).");
+
+DEFINE_int32(
+    max_adaptive_vector_size,
+    facebook::velox::exec::test::TableEvolutionFuzzer::kMaxAdaptiveVectorSize,
+    "Upper bound on the adaptive per-batch row count "
+    "(used when --adaptive_batch_sizing).");
+
 namespace facebook::velox::exec::test {
 using namespace facebook::velox::common::testutil;
 
@@ -72,13 +108,37 @@ std::ostream& operator<<(
 
 namespace {
 
-constexpr int kVectorSize = 101;
+// Default vector size for the fuzzer; the actual per-batch row count is chosen
+// adaptively per setup to hit a byte target (see computeAdaptiveVectorSize).
+constexpr int kDefaultVectorSize = 101;
+
+// Number of rows in the probe batch used to estimate per-row raw size. The
+// per-batch byte target and clamp bounds live on TableEvolutionFuzzer
+// (kTargetBatchBytes / kMinAdaptiveVectorSize / kMaxAdaptiveVectorSize) so the
+// adaptive sizing can be unit tested.
+constexpr int kProbeRows = 64;
+
+// Number of distinct query shapes run against each written set of files. The
+// (now expensive) write happens once per run(); this many shapes amortize it.
+constexpr int kQueryShapesPerFile = 20;
 
 VectorFuzzer::Options makeVectorFuzzerOptions() {
   VectorFuzzer::Options options;
-  options.vectorSize = kVectorSize;
+  options.vectorSize = kDefaultVectorSize;
   options.allowSlice = false;
   return options;
+}
+
+// Estimates the per-row raw byte cost of 'schema' by fuzzing a small probe
+// batch, then returns the adaptive per-batch row count for that cost (see
+// TableEvolutionFuzzer::adaptiveVectorSizeForBytesPerRow).
+int computeAdaptiveVectorSize(
+    VectorFuzzer& vectorFuzzer,
+    const RowTypePtr& schema) {
+  auto probe = vectorFuzzer.fuzzRow(schema, kProbeRows, false);
+  const uint64_t probeRawSize = probe->estimateFlatSize();
+  return TableEvolutionFuzzer::adaptiveVectorSizeForBytesPerRow(
+      static_cast<double>(probeRawSize) / kProbeRows, FLAGS_batch_target_bytes);
 }
 
 template <typename T>
@@ -147,10 +207,29 @@ bool hasEmptyElement(const RowVectorPtr& data, int columnIndex) {
 
 } // namespace
 
+int TableEvolutionFuzzer::adaptiveVectorSizeForBytesPerRow(
+    double bytesPerRow,
+    int64_t targetBatchBytes) {
+  const double safeBytesPerRow = std::max(1.0, bytesPerRow);
+  // Clamp as double before narrowing: a large --batch_target_bytes over a tiny
+  // per-row cost can exceed INT_MAX, and casting that to int before clamping
+  // would be undefined behavior. The clamp bounds are well within int range.
+  const double rows = static_cast<double>(targetBatchBytes) / safeBytesPerRow;
+  return static_cast<int>(std::clamp<double>(
+      rows,
+      static_cast<double>(FLAGS_min_adaptive_vector_size),
+      static_cast<double>(FLAGS_max_adaptive_vector_size)));
+}
+
 TableEvolutionFuzzer::TableEvolutionFuzzer(const Config& config)
     : config_(config), vectorFuzzer_(makeVectorFuzzerOptions(), config.pool) {
   VELOX_CHECK_GT(config_.columnCount, 0);
   VELOX_CHECK_GT(config_.evolutionCount, 0);
+  VELOX_CHECK_GT(FLAGS_batches_per_file, 0);
+  VELOX_CHECK_GT(FLAGS_batch_target_bytes, 0);
+  VELOX_CHECK_GT(FLAGS_min_adaptive_vector_size, 0);
+  VELOX_CHECK_GE(
+      FLAGS_max_adaptive_vector_size, FLAGS_min_adaptive_vector_size);
 }
 
 const std::string& TableEvolutionFuzzer::connectorId() {
@@ -820,7 +899,7 @@ void TableEvolutionFuzzer::run() {
   auto tableOutputRootDir = TempDirectoryPath::create();
   std::vector<std::shared_ptr<TaskCursor>> writeTasks(
       2 * config_.evolutionCount - 1);
-  RowVectorPtr finalExpectedData;
+  std::vector<RowVectorPtr> finalExpectedBatches;
 
   folly::F14FastMap<int, folly::F14FastSet<std::string>> globalMapColumnKeys;
   std::vector<int> globallyConsistentColumnIndexVector;
@@ -830,14 +909,57 @@ void TableEvolutionFuzzer::run() {
       bucketColumnIndices,
       tableOutputRootDir->getPath(),
       writeTasks,
-      finalExpectedData,
+      finalExpectedBatches,
       globalMapColumnKeys,
       globallyConsistentColumnIndexVector);
 
   auto executor = folly::getGlobalCPUExecutor();
   auto writeResults = runTaskCursors(writeTasks, *executor);
 
-  // Step 4: Create scan splits from write results
+  // Merge the final setup's batches into one vector, once, just before the
+  // query-shape loop that uses it to generate subfield filters over every row.
+  const RowVectorPtr finalExpectedData =
+      fuzzer::mergeRowVectors(finalExpectedBatches, config_.pool);
+
+  // Step 4: Amortize the expensive write by running many query shapes over the
+  // same files. Each shape independently draws a fresh query (subfield filters,
+  // remaining-filter application, dropped filter-only columns, aggregation
+  // config, flatmap-as-struct read schema) and rebuilds the scan splits from
+  // the existing write results (no rewrite), then compares the pushdown plan
+  // against the FilterNode reference plan over the SAME files.
+  for (int shape = 0; shape < kQueryShapesPerFile; ++shape) {
+    VLOG(1) << "Running query shape " << shape;
+    runQueryShape(
+        writeResults,
+        testSetups,
+        bucketColumnIndices,
+        finalExpectedData,
+        globalMapColumnKeys,
+        globallyConsistentColumnIndexVector,
+        shouldGenerateRemainingFilters,
+        generatedRemainingFilters,
+        columnNameMapping,
+        *executor);
+  }
+}
+
+void TableEvolutionFuzzer::runQueryShape(
+    const std::vector<std::vector<RowVectorPtr>>& writeResults,
+    const std::vector<Setup>& testSetups,
+    const std::vector<column_index_t>& bucketColumnIndices,
+    const RowVectorPtr& finalExpectedData,
+    const folly::F14FastMap<int, folly::F14FastSet<std::string>>&
+        globalMapColumnKeys,
+    const std::vector<int>& globallyConsistentColumnIndexVector,
+    bool shouldGenerateRemainingFilters,
+    const fuzzer::ExpressionFuzzer::FuzzedExpressionData&
+        generatedRemainingFilters,
+    const std::unordered_map<std::string, std::string>& columnNameMapping,
+    folly::Executor& executor) {
+  // Rebuild the scan splits per shape: makeScanTask moves them, and a fresh
+  // bucket selection lets shapes exercise different buckets. This only
+  // reconstructs Split objects from the existing write results; it does not
+  // rewrite any files.
   std::optional<int32_t> selectedBucket;
   if (!bucketColumnIndices.empty()) {
     selectedBucket =
@@ -846,11 +968,7 @@ void TableEvolutionFuzzer::run() {
   }
 
   auto [actualSplits, expectedSplits] = createScanSplitsFromWriteResults(
-      writeResults,
-      testSetups,
-      bucketColumnIndices,
-      selectedBucket,
-      finalExpectedData);
+      writeResults, testSetups, bucketColumnIndices, selectedBucket);
 
   // Step 5: Setup scan tasks with filters and optional aggregation pushdown
   auto rowType = testSetups.back().schema;
@@ -976,7 +1094,7 @@ void TableEvolutionFuzzer::run() {
   }
 
   // Step 6: Execute scan tasks and verify results
-  auto scanResults = runTaskCursors(scanTasks, *executor);
+  auto scanResults = runTaskCursors(scanTasks, executor);
 
   // Skip result verification when OOM injection is enabled
   if (!FLAGS_enable_oom_injection_write_path &&
@@ -1140,7 +1258,7 @@ std::vector<TableEvolutionFuzzer::Setup> TableEvolutionFuzzer::makeSetups(
 
 std::unique_ptr<TaskCursor> TableEvolutionFuzzer::makeWriteTask(
     const Setup& setup,
-    const RowVectorPtr& data,
+    const std::vector<RowVectorPtr>& dataBatches,
     const std::string& outputDir,
     const std::vector<column_index_t>& bucketColumnIndices,
     FuzzerGenerator& rng,
@@ -1148,7 +1266,10 @@ std::unique_ptr<TaskCursor> TableEvolutionFuzzer::makeWriteTask(
     folly::F14FastMap<int, folly::F14FastSet<std::string>>& globalMapColumnKeys,
     std::vector<int>& globallyCompatibleFlatmapColumns,
     const std::unordered_map<std::string, std::string>& extraSerdeParams) {
-  auto builder = PlanBuilder().values({data});
+  // Emit each batch as its own Values output, so the writer sees multiple
+  // write() calls per file. This drives multiple stripes per file and multiple
+  // chunks per stripe when chunking is enabled.
+  auto builder = PlanBuilder().values(dataBatches);
 
   // Create serdeParameters using proper dwrf::Config for flatmap configuration
   std::unordered_map<std::string, std::string> serdeParameters;
@@ -1159,8 +1280,27 @@ std::unique_ptr<TaskCursor> TableEvolutionFuzzer::makeWriteTask(
 
     for (int i = 0; i < setup.schema->size(); ++i) {
       if (setup.schema->childAt(i)->isMap()) {
-        // Check if this specific map column has any empty elements
-        if (hasEmptyElement(data, i)) {
+        // Check if this specific map column has any empty elements in any
+        // batch. A column is flatmap-compatible only if every batch is free of
+        // empty maps.
+        // TODO: Coverage gap, not a correctness bug. A present-key/null-value
+        // entry (e.g. {k: null}) is NOT excluded here -- it still contributes
+        // key k -- yet under flatmap-as-struct read it collapses to the same
+        // null child as an absent key. That collapse is symmetric across both
+        // compared plans (both read flatmap-as-struct), so it does not diverge
+        // the oracle; it only leaves the present-null-vs-absent case
+        // unexercised. Empty/null maps are excluded for a different, real
+        // reason: an all-empty/all-null column collects zero keys, and
+        // buildFlatmapAsStructSchema would then build a zero-field struct that
+        // the flatmap-as-struct reader rejects.
+        bool anyEmptyElement = false;
+        for (const auto& batch : dataBatches) {
+          if (hasEmptyElement(batch, i)) {
+            anyEmptyElement = true;
+            break;
+          }
+        }
+        if (anyEmptyElement) {
           removeFromVector(globallyCompatibleFlatmapColumns, i);
           continue;
         }
@@ -1172,64 +1312,68 @@ std::unique_ptr<TaskCursor> TableEvolutionFuzzer::makeWriteTask(
             VLOG(1) << "Write column " << setup.schema->nameOf(i)
                     << " as flatmap";
 
-            // Extract actual keys from the map data and collect directly into
-            // global set
-            SelectivityVector allRows(data->childAt(i)->size());
-            DecodedVector decodedMap(*data->childAt(i), allRows);
-            auto* mapVector = decodedMap.base()->asChecked<MapVector>();
-            if (mapVector->size() > 0) {
+            // Collect keys directly into the global set
+            auto& uniqueKeys = globalMapColumnKeys[static_cast<int>(i)];
+
+            // Extract actual keys from every batch's map data and collect
+            // directly into the global set.
+            for (const auto& batch : dataBatches) {
+              SelectivityVector allRows(batch->childAt(i)->size());
+              DecodedVector decodedMap(*batch->childAt(i), allRows);
+              auto* mapVector = decodedMap.base()->asChecked<MapVector>();
+              if (mapVector->size() == 0) {
+                continue;
+              }
               auto keys = mapVector->mapKeys();
+              if (!keys) {
+                continue;
+              }
 
-              if (keys) {
-                // Collect keys directly into the global set
-                auto& uniqueKeys = globalMapColumnKeys[static_cast<int>(i)];
+              // Iterate through the decoded rows, not the raw mapVector
+              // indices
+              for (vector_size_t row = 0; row < batch->childAt(i)->size();
+                   ++row) {
+                auto decodedIndex = decodedMap.index(row);
+                if (!decodedMap.isNullAt(row) &&
+                    !mapVector->isNullAt(decodedIndex)) {
+                  // Get the map entry for this decoded row
+                  auto mapOffset = mapVector->offsetAt(decodedIndex);
+                  auto mapSize = mapVector->sizeAt(decodedIndex);
 
-                // Iterate through the decoded rows, not the raw mapVector
-                // indices
-                for (vector_size_t row = 0; row < data->childAt(i)->size();
-                     ++row) {
-                  auto decodedIndex = decodedMap.index(row);
-                  if (!decodedMap.isNullAt(row) &&
-                      !mapVector->isNullAt(decodedIndex)) {
-                    // Get the map entry for this decoded row
-                    auto mapOffset = mapVector->offsetAt(decodedIndex);
-                    auto mapSize = mapVector->sizeAt(decodedIndex);
-
-                    // Process all keys in this map entry
-                    for (vector_size_t keyIdx = 0; keyIdx < mapSize; ++keyIdx) {
-                      auto keyPosition = mapOffset + keyIdx;
-                      if (!keys->isNullAt(keyPosition)) {
-                        std::string keyStr;
-                        if (keys->type()->isVarchar() ||
-                            keys->type()->isVarbinary()) {
-                          auto* keyVector = keys->asFlatVector<StringView>();
-                          auto keyView = keyVector->valueAt(keyPosition);
-                          keyStr = std::string(keyView);
-                        } else if (keys->type()->isInteger()) {
-                          auto* keyVector = keys->asFlatVector<int32_t>();
-                          auto keyVal = keyVector->valueAt(keyPosition);
-                          keyStr = std::to_string(keyVal);
-                        } else if (keys->type()->isBigint()) {
-                          auto* keyVector = keys->asFlatVector<int64_t>();
-                          auto keyVal = keyVector->valueAt(keyPosition);
-                          keyStr = std::to_string(keyVal);
-                        } else if (keys->type()->isSmallint()) {
-                          auto* keyVector = keys->asFlatVector<int16_t>();
-                          auto keyVal = keyVector->valueAt(keyPosition);
-                          keyStr = std::to_string(keyVal);
-                        } else if (keys->type()->isTinyint()) {
-                          auto* keyVector = keys->asFlatVector<int8_t>();
-                          auto keyVal = keyVector->valueAt(keyPosition);
-                          keyStr = std::to_string(keyVal);
-                        } else {
-                          // This should not be reached since
-                          // hasUnsupportedMapKey filters out unsupported types
-                          VELOX_UNREACHABLE(
-                              "Unsupported map key type: {}",
-                              keys->type()->toString());
-                        }
-                        uniqueKeys.insert(keyStr);
+                  // Process all keys in this map entry
+                  for (vector_size_t keyIdx = 0; keyIdx < mapSize; ++keyIdx) {
+                    auto keyPosition = mapOffset + keyIdx;
+                    if (!keys->isNullAt(keyPosition)) {
+                      std::string keyStr;
+                      if (keys->type()->isVarchar() ||
+                          keys->type()->isVarbinary()) {
+                        auto* keyVector = keys->asFlatVector<StringView>();
+                        auto keyView = keyVector->valueAt(keyPosition);
+                        keyStr = std::string(keyView);
+                      } else if (keys->type()->isInteger()) {
+                        auto* keyVector = keys->asFlatVector<int32_t>();
+                        auto keyVal = keyVector->valueAt(keyPosition);
+                        keyStr = std::to_string(keyVal);
+                      } else if (keys->type()->isBigint()) {
+                        auto* keyVector = keys->asFlatVector<int64_t>();
+                        auto keyVal = keyVector->valueAt(keyPosition);
+                        keyStr = std::to_string(keyVal);
+                      } else if (keys->type()->isSmallint()) {
+                        auto* keyVector = keys->asFlatVector<int16_t>();
+                        auto keyVal = keyVector->valueAt(keyPosition);
+                        keyStr = std::to_string(keyVal);
+                      } else if (keys->type()->isTinyint()) {
+                        auto* keyVector = keys->asFlatVector<int8_t>();
+                        auto keyVal = keyVector->valueAt(keyPosition);
+                        keyStr = std::to_string(keyVal);
+                      } else {
+                        // This should not be reached since
+                        // hasUnsupportedMapKey filters out unsupported types
+                        VELOX_UNREACHABLE(
+                            "Unsupported map key type: {}",
+                            keys->type()->toString());
                       }
+                      uniqueKeys.insert(keyStr);
                     }
                   }
                 }
@@ -1506,8 +1650,7 @@ TableEvolutionFuzzer::createScanSplitsFromWriteResults(
     const std::vector<std::vector<RowVectorPtr>>& writeResults,
     const std::vector<Setup>& testSetups,
     const std::vector<column_index_t>& bucketColumnIndices,
-    std::optional<int32_t> selectedBucket,
-    const RowVectorPtr& finalExpectedData) {
+    std::optional<int32_t> selectedBucket) {
   std::vector<Split> actualSplits, expectedSplits;
 
   for (int i = 0; i < config_.evolutionCount; ++i) {
@@ -1544,7 +1687,7 @@ void TableEvolutionFuzzer::createWriteTasks(
     const std::vector<column_index_t>& bucketColumnIndices,
     const std::string& tableOutputRootDirPath,
     std::vector<std::shared_ptr<TaskCursor>>& writeTasks,
-    RowVectorPtr& finalExpectedData,
+    std::vector<RowVectorPtr>& finalExpectedBatches,
     folly::F14FastMap<int, folly::F14FastSet<std::string>>& globalMapColumnKeys,
     std::vector<int>& globallyConsistentColumnIndexVector) {
   // Initialize globallyConsistentColumnIndexVector with all map column indices
@@ -1560,10 +1703,26 @@ void TableEvolutionFuzzer::createWriteTasks(
 
   // Generate data and create write tasks in a single loop
   for (int i = 0; i < config_.evolutionCount; ++i) {
-    // Generate fresh data for each evolution step independently
-    auto data = vectorFuzzer_.fuzzRow(testSetups[i].schema, kVectorSize, false);
-    for (auto& child : data->children()) {
-      BaseVector::flattenVector(child);
+    // Write several independently fuzzed batches per file (one writer write()
+    // call each) to drive multiple stripes per file and multiple chunks per
+    // stripe. A fixed count suffices: chunk and stripe flush randomness already
+    // varies the physical layout across files.
+    const int numBatches = FLAGS_batches_per_file;
+    // Size each batch to a byte target so file/stripe sizes are stable across
+    // wildly different schema widths, unless adaptive sizing is disabled via
+    // --adaptive_batch_sizing, in which case use a fixed per-batch row count.
+    const int vectorSize = FLAGS_adaptive_batch_sizing
+        ? computeAdaptiveVectorSize(vectorFuzzer_, testSetups[i].schema)
+        : kDefaultVectorSize;
+    std::vector<RowVectorPtr> dataBatches;
+    dataBatches.reserve(numBatches);
+    for (int batch = 0; batch < numBatches; ++batch) {
+      auto data =
+          vectorFuzzer_.fuzzRow(testSetups[i].schema, vectorSize, false);
+      for (auto& child : data->children()) {
+        BaseVector::flattenVector(child);
+      }
+      dataBatches.push_back(std::move(data));
     }
 
     auto actualDir = fmt::format("{}/actual_{}", tableOutputRootDirPath, i);
@@ -1572,7 +1731,7 @@ void TableEvolutionFuzzer::createWriteTasks(
     // Pass globally consistent columns to restrict flatmap usage
     writeTasks[2 * i] = makeWriteTask(
         testSetups[i],
-        data,
+        dataBatches,
         actualDir,
         bucketColumnIndices,
         rng_,
@@ -1584,17 +1743,28 @@ void TableEvolutionFuzzer::createWriteTasks(
             : std::unordered_map<std::string, std::string>{});
 
     if (i == config_.evolutionCount - 1) {
-      finalExpectedData = std::move(data);
+      // The final setup has no separate expected file; its actual file is the
+      // oracle. Keep its batches for subfield-filter generation; the caller
+      // merges them into one vector just before use.
+      finalExpectedBatches = std::move(dataBatches);
       continue;
     }
     auto expectedDir = fmt::format("{}/expected_{}", tableOutputRootDirPath, i);
     VELOX_CHECK(std::filesystem::create_directory(expectedDir));
-    auto expectedData = std::static_pointer_cast<RowVector>(
-        liftToType(data, testSetups.back().schema));
+
+    // Write the same batches lifted to the final schema, so the expected file
+    // holds the identical logical rows as the actual file and the oracle holds.
+    std::vector<RowVectorPtr> expectedBatches;
+    expectedBatches.reserve(dataBatches.size());
+    for (const auto& data : dataBatches) {
+      expectedBatches.push_back(
+          std::static_pointer_cast<RowVector>(
+              liftToType(data, testSetups.back().schema)));
+    }
 
     writeTasks[2 * i + 1] = makeWriteTask(
         testSetups.back(),
-        expectedData,
+        expectedBatches,
         expectedDir,
         bucketColumnIndices,
         rng_,

--- a/velox/exec/tests/TableEvolutionFuzzer.cpp
+++ b/velox/exec/tests/TableEvolutionFuzzer.cpp
@@ -15,9 +15,11 @@
  */
 
 #include "velox/exec/tests/TableEvolutionFuzzer.h"
+#include "velox/common/config/Config.h"
 #include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/connectors/hive/TableHandle.h"
+#include "velox/core/QueryCtx.h"
 #include "velox/dwio/common/tests/utils/FilterGenerator.h"
 #include "velox/dwio/dwrf/common/Config.h"
 #include "velox/exec/Cursor.h"
@@ -1305,6 +1307,17 @@ std::unique_ptr<TaskCursor> TableEvolutionFuzzer::makeWriteTask(
   CursorParameters params;
   params.serialExecution = true;
   params.planNode = builder.planNode();
+  // A bucketed write opens one writer per bucket, and generated setups can
+  // reach 2^8 buckets -- past the Hive connector's default 128 open-writer cap.
+  // Raise the cap so high-bucket-count setups exercise bucket conversion
+  // instead of failing with "Exceeded open writer limit".
+  params.queryCtx = core::QueryCtx::create(
+      /*executor=*/nullptr,
+      core::QueryConfig{{}},
+      {{std::string(PlanBuilder::kHiveDefaultConnectorId),
+        std::make_shared<config::ConfigBase>(
+            std::unordered_map<std::string, std::string>{
+                {"max_partitions_per_writers", "1024"}})}});
   return TaskCursor::create(params);
 }
 

--- a/velox/exec/tests/TableEvolutionFuzzer.h
+++ b/velox/exec/tests/TableEvolutionFuzzer.h
@@ -23,6 +23,8 @@
 #include <folly/init/Init.h>
 #include <gflags/gflags.h>
 #include <gtest/gtest.h>
+#include <algorithm>
+#include <cstdint>
 #include <functional>
 #include <unordered_map>
 #include <unordered_set>
@@ -48,6 +50,23 @@ class TableEvolutionFuzzer {
         FuzzerGenerator&)>
         extraWriteSerdeParams;
   };
+
+  /// Per-batch raw-byte target and clamp bounds for adaptive batch sizing. A
+  /// batch is sized to about kTargetBatchBytes raw bytes regardless of schema
+  /// width: narrow schemas get many rows, wide/nested schemas get few. Public
+  /// so the adaptive sizing can be unit tested.
+  static constexpr int64_t kTargetBatchBytes = 768 * 1024L;
+  static constexpr int kMinAdaptiveVectorSize = 16;
+  static constexpr int kMaxAdaptiveVectorSize = 50'000;
+
+  /// Maps an estimated per-row raw byte cost to a per-batch row count
+  /// (~targetBatchBytes per batch), clamped to [FLAGS_min_adaptive_vector_size,
+  /// FLAGS_max_adaptive_vector_size] (which default to kMinAdaptiveVectorSize /
+  /// kMaxAdaptiveVectorSize). A per-row cost below 1 byte is treated as 1.
+  /// Defined in the .cpp so it can read the clamp-bound gflags.
+  static int adaptiveVectorSizeForBytesPerRow(
+      double bytesPerRow,
+      int64_t targetBatchBytes = kTargetBatchBytes);
 
   explicit TableEvolutionFuzzer(const Config& config);
 
@@ -138,7 +157,7 @@ class TableEvolutionFuzzer {
 
   static std::unique_ptr<TaskCursor> makeWriteTask(
       const Setup& setup,
-      const RowVectorPtr& data,
+      const std::vector<RowVectorPtr>& dataBatches,
       const std::string& outputDir,
       const std::vector<column_index_t>& bucketColumnIndices,
       FuzzerGenerator& rng,
@@ -183,14 +202,14 @@ class TableEvolutionFuzzer {
 
   /// Creates write tasks for all evolution steps.
   /// Generates test data and creates TaskCursor objects for writing data
-  /// to temporary directories. Populates the writeTasks vector and sets
-  /// finalExpectedData to the data from the last evolution step.
+  /// to temporary directories. Populates the writeTasks vector and collects the
+  /// last evolution step's batches into finalExpectedBatches.
   void createWriteTasks(
       const std::vector<Setup>& testSetups,
       const std::vector<column_index_t>& bucketColumnIndices,
       const std::string& tableOutputRootDirPath,
       std::vector<std::shared_ptr<TaskCursor>>& writeTasks,
-      RowVectorPtr& finalExpectedData,
+      std::vector<RowVectorPtr>& finalExpectedBatches,
       folly::F14FastMap<int, folly::F14FastSet<std::string>>&
           globalMapColumnKeys,
       std::vector<int>& globallyConsistentColumnIndexVector);
@@ -203,8 +222,7 @@ class TableEvolutionFuzzer {
       const std::vector<std::vector<RowVectorPtr>>& writeResults,
       const std::vector<Setup>& testSetups,
       const std::vector<column_index_t>& bucketColumnIndices,
-      std::optional<int32_t> selectedBucket,
-      const RowVectorPtr& finalExpectedData);
+      std::optional<int32_t> selectedBucket);
 
   /// Applies remaining filters with updated column names.
   /// Updates filter expressions to use evolved column names based on the
@@ -215,6 +233,26 @@ class TableEvolutionFuzzer {
       const std::unordered_map<std::string, std::string>& columnNameMapping,
       PushdownConfig& pushdownConfig,
       const std::unordered_set<std::string>& subfieldFilteredFields);
+
+  /// Generates a single fresh query shape over the already-written files and
+  /// verifies the pushdown plan against the FilterNode reference plan. Draws
+  /// subfield filters, remaining-filter application, dropped filter-only
+  /// columns, aggregation config, and the flatmap-as-struct read schema, then
+  /// rebuilds the scan splits (no rewrite) and runs both scan tasks. Called
+  /// once per query shape so a single write amortizes many shapes.
+  void runQueryShape(
+      const std::vector<std::vector<RowVectorPtr>>& writeResults,
+      const std::vector<Setup>& testSetups,
+      const std::vector<column_index_t>& bucketColumnIndices,
+      const RowVectorPtr& finalExpectedData,
+      const folly::F14FastMap<int, folly::F14FastSet<std::string>>&
+          globalMapColumnKeys,
+      const std::vector<int>& globallyConsistentColumnIndexVector,
+      bool shouldGenerateRemainingFilters,
+      const fuzzer::ExpressionFuzzer::FuzzedExpressionData&
+          generatedRemainingFilters,
+      const std::unordered_map<std::string, std::string>& columnNameMapping,
+      folly::Executor& executor);
 
   const Config config_;
   VectorFuzzer vectorFuzzer_;

--- a/velox/exec/tests/TableEvolutionFuzzerTest.cpp
+++ b/velox/exec/tests/TableEvolutionFuzzerTest.cpp
@@ -33,6 +33,11 @@ DEFINE_int32(table_evolution_fuzzer_duration_sec, 30, "");
 DEFINE_int32(column_count, 5, "");
 DEFINE_int32(evolution_count, 5, "");
 
+// Defined in TableEvolutionFuzzer.cpp; declared here for the flag-validation
+// test below.
+DECLARE_int32(batches_per_file);
+DECLARE_int64(batch_target_bytes);
+
 namespace facebook::velox::exec::test {
 
 namespace {
@@ -79,6 +84,27 @@ TEST(TableEvolutionFuzzerTest, constructorEvolutionCountBoundary) {
   EXPECT_THROW(
       { TableEvolutionFuzzer fuzzer(makeDwrfConfig(pool.get(), 0)); },
       VeloxException);
+}
+
+// The constructor validates the batch-shaping gflags: a non-positive
+// batches_per_file or batch_target_bytes must throw.
+TEST(TableEvolutionFuzzerTest, constructorRejectsNonPositiveBatchFlags) {
+  auto pool = memory::memoryManager()->addLeafPool("TableEvolutionFuzzer");
+
+  {
+    gflags::FlagSaver flagSaver;
+    FLAGS_batches_per_file = 0;
+    EXPECT_THROW(
+        { TableEvolutionFuzzer fuzzer(makeDwrfConfig(pool.get(), 1)); },
+        VeloxException);
+  }
+  {
+    gflags::FlagSaver flagSaver;
+    FLAGS_batch_target_bytes = 0;
+    EXPECT_THROW(
+        { TableEvolutionFuzzer fuzzer(makeDwrfConfig(pool.get(), 1)); },
+        VeloxException);
+  }
 }
 
 // Runs the fuzzer in no-evolution mode (evolutionCount == 1) for a small,
@@ -174,6 +200,90 @@ TEST(TableEvolutionFuzzerTest, selectFilterOnlyColumns) {
     everDroppedScalar |= dropped.count("c_scalar") > 0;
   }
   EXPECT_TRUE(everDroppedScalar);
+}
+// Runs the fuzzer in evolution mode (evolutionCount > 1) for a small, fixed
+// number of deterministic iterations, exercising the
+// multiple-batches-per-file write path together with schema evolution. Each
+// file holds batches_per_file independently fuzzed batches; the actual file and
+// the lifted expected file are written from the SAME batches, and the caller
+// merges the final setup's batches for filter generation, so this covers the
+// multi-batch write + liftToType + merge path across evolving schemas, which
+// the single-schema noEvolutionBoundedRun does not. The pushdown-vs-FilterNode
+// oracle inside run() is the assertion.
+TEST(TableEvolutionFuzzerTest, multiBatchEvolutionBoundedRun) {
+  auto pool = memory::memoryManager()->addLeafPool("TableEvolutionFuzzer");
+  TableEvolutionFuzzer fuzzer(makeDwrfConfig(pool.get(), 3));
+  fuzzer.setSeed(20260629);
+  constexpr int kIterations = 4;
+  for (int i = 0; i < kIterations; ++i) {
+    LOG(INFO) << "multiBatchEvolutionBoundedRun iteration " << i
+              << ", seed=" << fuzzer.seed();
+    EXPECT_NO_THROW(fuzzer.run());
+    fuzzer.reSeed();
+  }
+}
+
+// Exercises the pure adaptive batch-size clamp: narrow rows (few bytes each)
+// saturate at the max row count, very wide rows floor at the min, and in the
+// unclamped band the row count is kTargetBatchBytes / bytesPerRow and is
+// monotonically non-increasing in bytesPerRow.
+TEST(TableEvolutionFuzzerTest, adaptiveVectorSizeClampsToByteTarget) {
+  using Fuzzer = TableEvolutionFuzzer;
+
+  // Narrow rows -> many rows, capped at the max. A sub-byte estimate is treated
+  // as 1 byte/row, so it also saturates at the cap.
+  EXPECT_EQ(
+      Fuzzer::adaptiveVectorSizeForBytesPerRow(1.0),
+      Fuzzer::kMaxAdaptiveVectorSize);
+  EXPECT_EQ(
+      Fuzzer::adaptiveVectorSizeForBytesPerRow(0.0),
+      Fuzzer::kMaxAdaptiveVectorSize);
+
+  // Very wide rows -> few rows, floored at the min.
+  EXPECT_EQ(
+      Fuzzer::adaptiveVectorSizeForBytesPerRow(Fuzzer::kTargetBatchBytes),
+      Fuzzer::kMinAdaptiveVectorSize);
+  EXPECT_EQ(
+      Fuzzer::adaptiveVectorSizeForBytesPerRow(1e12),
+      Fuzzer::kMinAdaptiveVectorSize);
+
+  // In the unclamped band, rows == kTargetBatchBytes / bytesPerRow.
+  constexpr double kBytesPerRow = 1024.0;
+  const int expected =
+      static_cast<int>(Fuzzer::kTargetBatchBytes / kBytesPerRow);
+  EXPECT_EQ(Fuzzer::adaptiveVectorSizeForBytesPerRow(kBytesPerRow), expected);
+  EXPECT_GT(expected, Fuzzer::kMinAdaptiveVectorSize);
+  EXPECT_LT(expected, Fuzzer::kMaxAdaptiveVectorSize);
+
+  // Monotonic non-increasing: wider rows never yield more rows.
+  EXPECT_GE(
+      Fuzzer::adaptiveVectorSizeForBytesPerRow(512.0),
+      Fuzzer::adaptiveVectorSizeForBytesPerRow(4096.0));
+}
+
+// The byte target (the batch_target_bytes gflag, passed as the second arg)
+// scales the per-batch row count: in the unclamped band the count is
+// targetBatchBytes / bytesPerRow, so doubling the target doubles the rows. The
+// one-arg form defaults to kTargetBatchBytes.
+TEST(TableEvolutionFuzzerTest, adaptiveVectorSizeScalesWithByteTarget) {
+  using Fuzzer = TableEvolutionFuzzer;
+  constexpr double kBytesPerRow = 512.0;
+
+  EXPECT_EQ(
+      Fuzzer::adaptiveVectorSizeForBytesPerRow(kBytesPerRow),
+      Fuzzer::adaptiveVectorSizeForBytesPerRow(
+          kBytesPerRow, Fuzzer::kTargetBatchBytes));
+
+  const int base =
+      Fuzzer::adaptiveVectorSizeForBytesPerRow(kBytesPerRow, 4LL << 20);
+  const int doubled =
+      Fuzzer::adaptiveVectorSizeForBytesPerRow(kBytesPerRow, 8LL << 20);
+
+  // Both land in the unclamped band, and the larger target yields exactly twice
+  // the rows.
+  EXPECT_GT(base, Fuzzer::kMinAdaptiveVectorSize);
+  EXPECT_LT(doubled, Fuzzer::kMaxAdaptiveVectorSize);
+  EXPECT_EQ(doubled, 2 * base);
 }
 
 TEST(TableEvolutionFuzzerTest, run) {


### PR DESCRIPTION
Summary:

Grows each generated Nimble file from a single 101-row batch into several independently-fuzzed, adaptively-sized batches, and amortizes the now-expensive write by running many query shapes over each file. Together these exercise the chunked write/read paths at realistic file sizes: multiple chunks per stream/stripe, multiple stripes per file, and many distinct read queries per written file.

Multiple batches per file: each file writes `batches_per_file` batches (gflag, default 8), each emitted as a separate writer `write()` call. Streams accumulate across writes and cross the chunk-size floor, producing many chunks per stripe; combined with the stateful random flush policy from the base of this stack, files also reach multiple stripes. A fixed batch count suffices because chunk and stripe flush randomness already varies the physical layout across files. `makeWriteTask` takes a batch vector; `createWriteTasks` generates the batches per setup and writes both the actual file (setup schema) and the lifted expected file (final schema, via `liftToType`) from the SAME batches, preserving the actual/expected oracle. The final setup's batches are merged once (in `run()`, just before the query-shape loop) into a single vector for subfield-filter generation so the filters reflect every written row.

Adaptive batch sizing: each batch is sized to a raw-byte target (`batch_target_bytes` gflag, default 768KB) rather than a fixed row count. Per setup it probes the schema's per-row raw cost (`getRawSizeFromVector` on a small probe) and picks `vectorSize = clamp(batch_target_bytes / bytesPerRow, kMinAdaptiveVectorSize, kMaxAdaptiveVectorSize)`, so batch bytes stay schema-independent: narrow schemas get many rows, wide/nested schemas few. The pure clamp is factored into `TableEvolutionFuzzer::adaptiveVectorSizeForBytesPerRow` and unit tested.

N query shapes per file: `run()` writes the file set ONCE, then runs `kQueryShapesPerFile` independent query shapes against it via `runQueryShape()`. Each shape redraws subfield/remaining filters, dropped filter-only columns, aggregation config, and the flatmap-as-struct read schema, and rebuilds the scan splits from the existing write results (no rewrite), comparing the pushdown plan against the FilterNode reference plan. This keeps query-shape throughput high now that writes are large.

Bucketing, flatmap, filters, and no-evolution mode are preserved.

Reviewed By: xiaoxmeng

Differential Revision: D110052627


