### PR TITLE
fix(core): Validate UnnestNode unnestNames count

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -1410,6 +1410,21 @@ UnnestNode::UnnestNode(
     types.emplace_back(variable->type());
   }
 
+  // Validate that unnestNames provides exactly one name per array (element) and
+  // two per map (key and value) before indexing into it below.
+  size_t expectedUnnestNames{0};
+  for (const auto& variable : unnestVariables_) {
+    if (variable->type()->isArray()) {
+      ++expectedUnnestNames;
+    } else if (variable->type()->isMap()) {
+      expectedUnnestNames += 2;
+    }
+  }
+  VELOX_USER_CHECK_EQ(
+      unnestNames_.size(),
+      expectedUnnestNames,
+      "UnnestNode requires one name per array column and two per map column");
+
   int unnestIndex = 0;
   for (const auto& variable : unnestVariables_) {
     if (variable->type()->isArray()) {

--- a/velox/core/tests/PlanNodeBuilderTest.cpp
+++ b/velox/core/tests/PlanNodeBuilderTest.cpp
@@ -1044,6 +1044,17 @@ TEST_F(PlanNodeBuilderTest, unnestNode) {
 
   const auto node2 = UnnestNode::Builder(*node).build();
   verify(node2);
+
+  // A wrong number of unnest names is rejected: one per array, two per map.
+  VELOX_ASSERT_THROW(
+      UnnestNode::Builder()
+          .id(id)
+          .replicateVariables(replicateVariables)
+          .unnestVariables(unnestVariables)
+          .unnestNames({"b", "extra"})
+          .source(source_)
+          .build(),
+      "one name per array");
 }
 
 TEST_F(PlanNodeBuilderTest, enforceSingleRowNode) {


### PR DESCRIPTION
Summary:
`UnnestNode` reads `unnestNames` positionally: one name per array element, two per map (key then value). It never checked the count, so a wrong count was handled silently. Extra names were ignored, and too few names read past the end of the vector. Constructing an unnest of a single array with two names now fails with:

    UnnestNode requires one name per array column and two per map column

Differential Revision: D110403833


