### PR TITLE
fix(core): Preserve markerName in UnnestNode::Builder

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -1410,6 +1410,21 @@ UnnestNode::UnnestNode(
     types.emplace_back(variable->type());
   }
 
+  // Validate that unnestNames provides exactly one name per array (element) and
+  // two per map (key and value) before indexing into it below.
+  size_t expectedUnnestNames{0};
+  for (const auto& variable : unnestVariables_) {
+    if (variable->type()->isArray()) {
+      ++expectedUnnestNames;
+    } else if (variable->type()->isMap()) {
+      expectedUnnestNames += 2;
+    }
+  }
+  VELOX_USER_CHECK_EQ(
+      unnestNames_.size(),
+      expectedUnnestNames,
+      "UnnestNode requires one name per array column and two per map column");
+
   int unnestIndex = 0;
   for (const auto& variable : unnestVariables_) {
     if (variable->type()->isArray()) {

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -4746,6 +4746,7 @@ class UnnestNode : public PlanNode {
       unnestVariables_ = other.unnestVariables();
       unnestNames_ = other.unnestNames_;
       ordinalityName_ = other.ordinalityName_;
+      markerName_ = other.markerName_;
       splitOutput_ = other.splitOutput_;
       VELOX_CHECK_EQ(other.sources().size(), 1);
       source_ = other.sources()[0];

--- a/velox/core/tests/PlanNodeBuilderTest.cpp
+++ b/velox/core/tests/PlanNodeBuilderTest.cpp
@@ -1044,6 +1044,17 @@ TEST_F(PlanNodeBuilderTest, unnestNode) {
 
   const auto node2 = UnnestNode::Builder(*node).build();
   verify(node2);
+
+  // A wrong number of unnest names is rejected: one per array, two per map.
+  VELOX_ASSERT_THROW(
+      UnnestNode::Builder()
+          .id(id)
+          .replicateVariables(replicateVariables)
+          .unnestVariables(unnestVariables)
+          .unnestNames({"b", "extra"})
+          .source(source_)
+          .build(),
+      "one name per array");
 }
 
 TEST_F(PlanNodeBuilderTest, enforceSingleRowNode) {

--- a/velox/core/tests/PlanNodeBuilderTest.cpp
+++ b/velox/core/tests/PlanNodeBuilderTest.cpp
@@ -1008,6 +1008,8 @@ TEST_F(PlanNodeBuilderTest, unnestNode) {
   std::optional<std::string> ordinalityName =
       std::make_optional<std::string>("ord");
   std::optional<bool> splitOutput = false;
+  std::optional<std::string> markerName =
+      std::make_optional<std::string>("marker");
 
   const auto verify = [&](const std::shared_ptr<const UnnestNode>& node) {
     EXPECT_EQ(node->id(), id);
@@ -1016,19 +1018,24 @@ TEST_F(PlanNodeBuilderTest, unnestNode) {
     EXPECT_TRUE(node->hasOrdinality());
     EXPECT_EQ(node->sources()[0], source_);
     EXPECT_EQ(node->splitOutput(), splitOutput);
+    EXPECT_EQ(node->markerName(), markerName);
 
-    for (int i = 0; i < node->outputType()->size(); ++i) {
-      if (i < replicateVariables.size()) {
-        EXPECT_EQ(node->outputType()->nameOf(i), replicateVariables[i]->name());
-      } else if (i < replicateVariables.size() + unnestVariables.size()) {
-        EXPECT_EQ(
-            node->outputType()->nameOf(i),
-            unnestVariables[i - replicateVariables.size()]->name());
-      } else {
-        EXPECT_EQ(i, node->outputType()->size() - 1);
-        EXPECT_EQ(node->outputType()->nameOf(i), ordinalityName.value());
-      }
+    // Output columns: replicate columns, then the unnest names, then the
+    // optional ordinality and marker columns.
+    std::vector<std::string> expectedNames;
+    for (const auto& variable : replicateVariables) {
+      expectedNames.push_back(variable->name());
     }
+    for (const auto& name : unnestNames) {
+      expectedNames.push_back(name);
+    }
+    if (ordinalityName.has_value()) {
+      expectedNames.push_back(ordinalityName.value());
+    }
+    if (markerName.has_value()) {
+      expectedNames.push_back(markerName.value());
+    }
+    EXPECT_EQ(node->outputType()->names(), expectedNames);
   };
 
   const auto node = UnnestNode::Builder()
@@ -1037,6 +1044,7 @@ TEST_F(PlanNodeBuilderTest, unnestNode) {
                         .unnestVariables(unnestVariables)
                         .unnestNames(unnestNames)
                         .ordinalityName(ordinalityName)
+                        .markerName(markerName)
                         .source(source_)
                         .splitOutput(splitOutput)
                         .build();


### PR DESCRIPTION
Summary: `UnnestNode::Builder`'s copy constructor rebuilds a node from an existing one, but it never copied `markerName_`. `UnnestNode::Builder(node).build()` therefore silently dropped the marker column (the boolean `emptyUnnestValue` output) from the rebuilt node. Copy `markerName_` alongside the other fields.

Differential Revision: D110403834


