### PR TITLE
refactor: Refactor cast error handling to build error message lazily

### DIFF
--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -141,14 +141,9 @@ void CastExpr::applyCastKernel(
     FlatVector<typename TypeTraits<ToKind>::NativeType>* result) {
   bool wrapException = true;
   auto setError = [&](const std::string& details) INLINE_LAMBDA {
-    if (setNullInResultAtError()) {
-      setCastError(row, context, result, wrapException);
-      return;
-    }
-    const auto errorDetails = context.captureErrorDetails()
-        ? makeErrorMessage(*input, row, result->type(), details)
-        : std::string{};
-    setCastError(row, context, result, wrapException, errorDetails);
+    setCastError(row, context, result, wrapException, [&] {
+      return makeErrorMessage(*input, row, result->type(), details);
+    });
   };
 
   // If castResult has an error, set the error in context. Otherwise, set the

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -327,28 +327,39 @@ class CastExpr : public SpecialForm {
   /// @param result The result vector to update
   /// @param wrapException Output parameter indicating if exception should be
   /// wrapped
-  /// @param details Optional error details message
-  template <typename TResult>
+  /// @param makeErrorDetails Callable returning the error details string. It is
+  /// invoked lazily and only when the error details are actually needed.
+  template <typename TResult, typename TMakeErrorDetails>
   void setCastError(
       vector_size_t row,
       EvalCtx& context,
       TResult* result,
       bool& wrapException,
-      const std::string& details = "") const {
+      TMakeErrorDetails makeErrorDetails) const {
     if (setNullInResultAtError()) {
       result->setNull(row, true);
-    } else {
-      wrapException = false;
-      if (context.captureErrorDetails()) {
-        if (!details.empty()) {
-          context.setStatus(row, Status::UserError("{}", details));
-        } else {
-          context.setStatus(row, Status::UserError());
-        }
-      } else {
-        context.setStatus(row, Status::UserError());
+      return;
+    }
+    wrapException = false;
+    if (context.captureErrorDetails()) {
+      const std::string details = makeErrorDetails();
+      if (!details.empty()) {
+        context.setStatus(row, Status::UserError("{}", details));
+        return;
       }
     }
+    context.setStatus(row, Status::UserError());
+  }
+
+  /// Overload for cases where no error details are available.
+  template <typename TResult>
+  void setCastError(
+      vector_size_t row,
+      EvalCtx& context,
+      TResult* result,
+      bool& wrapException) const {
+    setCastError(
+        row, context, result, wrapException, [] { return std::string{}; });
   }
 
   /// Helper to set result or error from Expected<T> cast result.
@@ -371,14 +382,9 @@ class CastExpr : public SpecialForm {
       TResult* result,
       bool& wrapException) const {
     if (castResult.hasError()) {
-      if (setNullInResultAtError()) {
-        setCastError(row, context, result, wrapException);
-        return;
-      }
-      const auto errorDetails = context.captureErrorDetails()
-          ? makeErrorDetails(castResult.error().message())
-          : std::string{};
-      setCastError(row, context, result, wrapException, errorDetails);
+      setCastError(row, context, result, wrapException, [&] {
+        return makeErrorDetails(castResult.error().message());
+      });
     } else {
       result->set(row, castResult.value());
     }


### PR DESCRIPTION
Callers of setCastError checked setNullInResultAtError() before invoking it,
and setCastError then checked the same condition again internally. This
redundant check was duplicated across every call site.

This PR removes the redundant checks by having setCastError accept a
makeErrorDetails callable that is invoked lazily, only when the error message
is actually needed. This preserves the optimization of not building unused
error messages while consolidating the logic in one place, making setCastError
cleaner and the call sites simpler.

