### PR TITLE
Use notEqual for integer != filters

### DIFF
--- a/velox/expression/ExprToSubfieldFilter.cpp
+++ b/velox/expression/ExprToSubfieldFilter.cpp
@@ -318,6 +318,20 @@ std::unique_ptr<common::Filter> ExprToSubfieldFilterParser::makeNotEqualFilter(
     return std::make_unique<common::AlwaysFalse>();
   }
 
+  const auto typeKind = value->typeKind();
+  switch (typeKind) {
+    case TypeKind::TINYINT:
+      return notEqual(singleValue<int8_t>(value));
+    case TypeKind::SMALLINT:
+      return notEqual(singleValue<int16_t>(value));
+    case TypeKind::INTEGER:
+      return notEqual(singleValue<int32_t>(value));
+    case TypeKind::BIGINT:
+      return notEqual(singleValue<int64_t>(value));
+    default:
+      break;
+  }
+
   auto lessThanFilter = makeLessThanFilter(valueExpr, evaluator);
   if (!lessThanFilter) {
     return nullptr;
@@ -326,26 +340,6 @@ std::unique_ptr<common::Filter> ExprToSubfieldFilterParser::makeNotEqualFilter(
   auto greaterThanFilter = makeGreaterThanFilter(valueExpr, evaluator);
   if (!greaterThanFilter) {
     return nullptr;
-  }
-
-  const auto typeKind = value->typeKind();
-
-  if (typeKind == TypeKind::TINYINT || typeKind == TypeKind::SMALLINT ||
-      typeKind == TypeKind::INTEGER || typeKind == TypeKind::BIGINT) {
-    if (lessThanFilter->kind() == common::FilterKind::kAlwaysFalse) {
-      return greaterThanFilter;
-    }
-    if (greaterThanFilter->kind() == common::FilterKind::kAlwaysFalse) {
-      return lessThanFilter;
-    }
-    VELOX_CHECK(isBigintRange(lessThanFilter));
-    VELOX_CHECK(isBigintRange(greaterThanFilter));
-
-    std::vector<std::unique_ptr<common::BigintRange>> filters;
-    filters.emplace_back(asBigintRange(lessThanFilter));
-    filters.emplace_back(asBigintRange(greaterThanFilter));
-    return std::make_unique<common::BigintMultiRange>(
-        std::move(filters), false);
   }
 
   if (typeKind == TypeKind::HUGEINT) {

--- a/velox/expression/tests/ExprToSubfieldFilterTest.cpp
+++ b/velox/expression/tests/ExprToSubfieldFilterTest.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/expression/ExprToSubfieldFilter.h"
 #include <gtest/gtest.h>
+#include <limits>
 #include "velox/expression/Expr.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/parse/ExpressionsParser.h"
@@ -131,8 +132,7 @@ TEST_F(ExprToSubfieldFilterTest, neq) {
   ASSERT_TRUE(filter);
   validateSubfield(subfield, {"a"});
 
-  // TODO Optimize to notEqual(42).
-  VELOX_ASSERT_FILTER(bigintOr(lessThan(42), greaterThan(42)), filter);
+  VELOX_ASSERT_FILTER(notEqual(42), filter);
 }
 
 TEST_F(ExprToSubfieldFilterTest, neqBoundary) {
@@ -143,7 +143,8 @@ TEST_F(ExprToSubfieldFilterTest, neqBoundary) {
     ASSERT_TRUE(filter);
     validateSubfield(subfield, {"a"});
 
-    VELOX_ASSERT_FILTER(lessThan(std::numeric_limits<int64_t>::max()), filter);
+    VELOX_ASSERT_FILTER(
+        notEqual(std::numeric_limits<int64_t>::max()), filter);
   }
 
   {
@@ -155,7 +156,7 @@ TEST_F(ExprToSubfieldFilterTest, neqBoundary) {
     validateSubfield(subfield, {"a"});
 
     VELOX_ASSERT_FILTER(
-        greaterThan(std::numeric_limits<int64_t>::min()), filter);
+        notEqual(std::numeric_limits<int64_t>::min()), filter);
   }
 }
 


### PR DESCRIPTION
Integer != filters were built as x < v OR x > v via BigintMultiRange. That predates NegatedBigintRange and works for most values, but breaks at INT64_MAX: the x > v side computes v + 1, overflows, and produces overlapping bigint ranges. 