### PR TITLE
fix(spark): Name-based column mapping does not fall back to positional for Hive files with all-_col* physical names

### DIFF
--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -747,6 +747,29 @@ std::optional<uint64_t> getStringOrBinaryColumnSize(
   return stats.getRawSize();
 }
 
+// A file whose physical top-level field names are ALL Hive placeholders
+// (_col0, _col1, ...) must be mapped by position even in name mode: such files
+// were written by older Hive without real field names, so the real names live
+// only in the metastore/table schema. Mirrors vanilla Spark's
+// OrcUtils.requestedColumnIds, which switches to positional mapping when
+// `orcFieldNames.forall(_.startsWith("_col"))`.
+bool isAllHivePlaceholderNames(const RowTypePtr& fileSchema) {
+  if (fileSchema == nullptr || fileSchema->size() == 0) {
+    // Empty schema (e.g. SPARK-8501 empty ORC footer): nothing to remap, keep
+    // name mode.
+    return false;
+  }
+  for (auto i = 0; i < fileSchema->size(); ++i) {
+    // Prefix match, equivalent to Java String.startsWith("_col"); like Spark,
+    // we do not require a trailing digit. Any single non-placeholder top-level
+    // name makes `forall` false, so we keep name mode.
+    if (fileSchema->nameOf(i).rfind("_col", 0) != 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
 } // namespace
 
 std::optional<size_t> DwrfRowReader::estimatedRowSizeHelper(
@@ -888,6 +911,12 @@ DwrfReader::DwrfReader(
     if (columnMappingMode == dwio::common::ColumnMappingMode::kFieldId) {
       updateColumnNamesFromFieldIds();
     } else if (columnMappingMode != dwio::common::ColumnMappingMode::kName) {
+      updateColumnNamesFromTableSchema();
+    } else if (isAllHivePlaceholderNames(readerBase_->schema())) {
+      // Name mode, but the file carries only Hive placeholder names
+      // (_col0, ...). Real names exist only in the table schema, so map by
+      // position instead of by name -- otherwise every column would fail to
+      // match and read back as null. Matches vanilla Spark's per-file decision.
       updateColumnNamesFromTableSchema();
     }
   }

--- a/velox/dwio/dwrf/test/E2EWriterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EWriterTest.cpp
@@ -342,6 +342,66 @@ TEST_F(E2EWriterTest, FieldIdMappingRenameReorderDrop) {
   EXPECT_EQ(rowType->nameOf(2), "c2");
 }
 
+// Writes a DWRF file with 'fileSchema', opens it with ColumnMappingMode::kName
+// against 'tableSchema', and returns the reader's row type.
+RowTypePtr readWithColumnNames(
+    memory::MemoryPool* rootPool,
+    memory::MemoryPool* leafPool,
+    const RowTypePtr& fileSchema,
+    const RowTypePtr& tableSchema) {
+  auto sink = std::make_unique<MemorySink>(
+      16 * 1024 * 1024, dwio::common::FileSink::Options{.pool = leafPool});
+  auto* sinkPtr = sink.get();
+
+  dwrf::WriterOptions options;
+  options.config = std::make_shared<dwrf::Config>();
+  options.schema = fileSchema;
+  options.memoryPool = rootPool;
+  dwrf::Writer writer{std::move(sink), options};
+  writer.write(BatchMaker::createBatch(fileSchema, 10, *leafPool, nullptr, 0));
+  writer.close();
+
+  dwio::common::ReaderOptions readerOpts(leafPool);
+  readerOpts.setColumnMappingMode(dwio::common::ColumnMappingMode::kName);
+  readerOpts.setFileSchema(tableSchema);
+  std::string_view data(sinkPtr->data(), sinkPtr->size());
+  auto reader = std::make_unique<dwrf::DwrfReader>(
+      readerOpts,
+      std::make_unique<BufferedInput>(
+          std::make_shared<InMemoryReadFile>(data), readerOpts.memoryPool()));
+  return reader->rowType();
+}
+
+TEST_F(E2EWriterTest, NameMappingPositionalFallbackForHivePlaceholders) {
+  // A file written by old Hive carries only placeholder names (_col0, _col1).
+  // Even in kName mode the reader must map by position, taking the real names
+  // from the table schema -- otherwise name matching finds nothing and every
+  // column reads back as null. Mirrors Spark OrcUtils.requestedColumnIds.
+  auto fileSchema = ROW({"_col0", "_col1"}, {INTEGER(), VARCHAR()});
+  auto tableSchema = ROW({"id", "name"}, {INTEGER(), VARCHAR()});
+  auto rowType = readWithColumnNames(
+      rootPool_.get(), leafPool_.get(), fileSchema, tableSchema);
+
+  // File columns were renamed to the table names by position.
+  ASSERT_EQ(rowType->size(), 2);
+  EXPECT_EQ(rowType->nameOf(0), "id");
+  EXPECT_EQ(rowType->nameOf(1), "name");
+}
+
+TEST_F(E2EWriterTest, NameMappingRealNamesNoPositionalFallback) {
+  // A file with real column names must stay in name mode: no positional rename,
+  // even when the file order differs from the requested table order.
+  auto fileSchema = ROW({"x", "y"}, {INTEGER(), VARCHAR()});
+  auto tableSchema = ROW({"y", "x"}, {VARCHAR(), INTEGER()});
+  auto rowType = readWithColumnNames(
+      rootPool_.get(), leafPool_.get(), fileSchema, tableSchema);
+
+  // Names are untouched (the file schema is preserved); mapping stays by name.
+  ASSERT_EQ(rowType->size(), 2);
+  EXPECT_EQ(rowType->nameOf(0), "x");
+  EXPECT_EQ(rowType->nameOf(1), "y");
+}
+
 TEST_F(E2EWriterTest, FieldIdMappingDropReaddSameName) {
   // File has column c with field id 5; the table dropped it and re-added a new
   // column c with field id 9. The stale file column must NOT bind to the new c.


### PR DESCRIPTION
## Summary

In `ColumnMappingMode::kName`, `DwrfReader` now detects ORC/DWRF files whose physical top-level field names are **all** Hive placeholders (`_col0`, `_col1`, …) and maps those files **by position** instead of by name, reusing the existing `updateColumnNamesFromTableSchema()` path. This mirrors vanilla Spark's per-file decision in `OrcUtils.requestedColumnIds`.

This PR is related to https://github.com/apache/gluten/pull/12438.

Fixes https://github.com/facebookincubator/velox/issues/18020.

## Motivation

A query that reads two ORC tables — one with **real** physical column names, one written by older Hive with **`_col*`** placeholder names — cannot be read correctly with a single column-mapping mode:

- **`kName`** (selected when `hive.orc.use-column-names=true`): the `_col*` file has no real names to match, so every requested column resolves to null → silently wrong/empty results (e.g. a filtered join side becomes empty).
- **`kPosition`**: the real-name file is mapped by ordinal and lands on the wrong column; for a type-incompatible pair this fails with `SCHEMA_MISMATCH` (e.g. `From Kind: INTEGER, To Kind: VARCHAR` in `TypeUtils::checkTypeCompatibility`), or, when a filter is pushed to it, `Filter(BytesValues, ...): testInt64Range() is not supported`.

No single mode value satisfies both tables. Vanilla Spark avoids this by deciding **per file** in `OrcUtils.requestedColumnIds`:

```scala
val orcFieldNames = reader.getSchema.getFieldNames.asScala
if (forcePositionalEvolution || orcFieldNames.forall(_.startsWith("_col"))) {
  // map physical schema -> data schema by INDEX
} else {
  // map by NAME
}
```

The `forcePositionalEvolution` half is already covered (a caller can request `kPosition`). The missing half is `orcFieldNames.forall(_.startsWith("_col"))`: even in name mode, an ORC file whose physical schema is entirely `_col*` must be mapped by position, because those placeholder names carry no identity — the real names live only in the table schema. This matches how Hive itself reads such files.

## Notes for reviewers

- Only the `kName` branch of the `DwrfReader` constructor is touched; `kPosition` and `kFieldId` behavior is unchanged.
- An engine that wants this fall-back to trigger must attach the table schema (`ReaderOptions::setFileSchema`) even when requesting `kName`; without a table schema there is nothing to remap onto and behavior is unchanged.