### PR TITLE
fix(torchwave): Fix ig pipelines

### DIFF
--- a/velox/experimental/torchwave/Builtins.cpp
+++ b/velox/experimental/torchwave/Builtins.cpp
@@ -777,6 +777,30 @@ void registerBuiltins() {
       .costFunction(divCost)
       .registerOp();
 
+  // In-place (Tensor, Scalar). Same __*_ device functions; the scalar operand
+  // is cast to self's dtype via normalize, and no arithmeticPromotion so the
+  // result keeps self's dtype.
+  MetadataBuilder("torch.ops.aten.add_.Scalar")
+      .elementwiseFunc("__add_")
+      .normalize(castScalarAttrsToInputDtype)
+      .costFunction(arithmeticCost)
+      .registerOp();
+  MetadataBuilder("torch.ops.aten.sub_.Scalar")
+      .elementwiseFunc("__sub_")
+      .normalize(castScalarAttrsToInputDtype)
+      .costFunction(arithmeticCost)
+      .registerOp();
+  MetadataBuilder("torch.ops.aten.mul_.Scalar")
+      .elementwiseFunc("__mul_")
+      .normalize(castScalarAttrsToInputDtype)
+      .costFunction(mulCost)
+      .registerOp();
+  MetadataBuilder("torch.ops.aten.div_.Scalar")
+      .elementwiseFunc("__div_")
+      .normalize(castScalarAttrsToInputDtype)
+      .costFunction(divCost)
+      .registerOp();
+
   // Binary arithmetic (Tensor, Scalar).
   MetadataBuilder("torch.ops.aten.add.Scalar")
       .elementwiseFunc("__add")

--- a/velox/experimental/torchwave/CompiledOp.cpp
+++ b/velox/experimental/torchwave/CompiledOp.cpp
@@ -1515,6 +1515,8 @@ void fillLaunchParams(
       if (returnCounter < static_cast<int32_t>(launch.returnValues.size()) &&
           actualId == launch.returnValues[returnCounter]) {
         launch.returnOffsets.push_back(listOffset);
+        // fillTensorListParam above appended the entry, so back() is safe.
+        TORCH_CHECK(!launch.tensorLists.empty());
         const auto& tlp = launch.tensorLists.back();
         for (auto elemOff : tlp.elementOffsets) {
           if (returnBegin == -1) {
@@ -1990,14 +1992,13 @@ void CompositeInvocation::gatherLaunches(
             if (oi < data.actualOutputTypes.size() &&
                 data.actualOutputTypes[oi] == nativert::Type::Kind::Tensor) {
               const auto& oiv = state.frame->getIValue(data.actualOutputs[oi]);
-              // A None output comes from a later PN.  An empty (0-element)
-              // output means there is nothing to compute and its storage (and
-              // that of any broadcast-to-empty input) may be null -- launching
-              // would fault.  numElements from a kMax sizeExpr ignores the
-              // empty (broadcast-to-0) dimension, so guard on the allocated
-              // output extent explicitly here.
-              if (oiv.isNone() ||
-                  (oiv.isTensor() && oiv.toTensor().numel() == 0)) {
+              // A None output comes from a later PN -- its tensor is not
+              // materialized, so the kernel must not launch yet. An empty
+              // (0-element) output is handled in device code (the elementwise
+              // size head sets size=0 -> 0 iterations), so it does not zero the
+              // whole launch here -- that would wrongly skip the non-empty
+              // lanes of a multi-output kernel.
+              if (oiv.isNone()) {
                 data.numElements = 0;
                 break;
               }
@@ -2749,40 +2750,6 @@ void CompositeInvocation::execute(ExecutionState& state) {
   }
 }
 
-void CompositeInvocation::runDeferredStandalones(ExecutionState& state) {
-  if (prePassStandalones_.empty()) {
-    return;
-  }
-  auto& frame = *state.frame;
-  bool progress = true;
-  while (progress) {
-    progress = false;
-    for (auto& launch : prePassStandalones_) {
-      if (!launch.standalone) {
-        continue;
-      }
-      if (nodeOutputsComputed(launch.standalone, frame)) {
-        continue;
-      }
-      auto kernelIt = state.kernelMap->find(launch.standalone);
-      if (kernelIt == state.kernelMap->end()) {
-        continue;
-      }
-      bool allInputsReady = true;
-      for (const auto& input : launch.standalone->inputs()) {
-        if (isUnreadyNoneDependency(input.value, frame)) {
-          allInputsReady = false;
-          break;
-        }
-      }
-      if (allInputsReady) {
-        executeNode(launch.standalone, kernelIt->second, frame);
-        progress = true;
-      }
-    }
-  }
-}
-
 void CompositeInvocation::launch(
     int32_t numBlocks,
     int32_t blockSize,
@@ -3025,10 +2992,6 @@ std::string CompositeInvocation::toString(Listing mode, int32_t ordinal) const {
 
 void CompiledNode::execute(ExecutionState& state) {
   kernels_->execute(state);
-}
-
-void CompiledNode::runDeferredStandalones(ExecutionState& state) {
-  kernels_->runDeferredStandalones(state);
 }
 
 std::string CompiledNode::toString(Listing mode, int32_t ordinal) const {

--- a/velox/experimental/torchwave/CompiledOp.h
+++ b/velox/experimental/torchwave/CompiledOp.h
@@ -328,11 +328,6 @@ class CompositeInvocation {
   /// copies params to pinned+device memory, and enqueues the H2D transfer.
   void execute(ExecutionState& state);
 
-  /// Runs pre-pass standalones that were skipped during execute() because
-  /// their inputs were None.  Called after all PNs have executed so that
-  /// cross-PN values are available.
-  void runDeferredStandalones(ExecutionState& state);
-
   std::string toString(Listing mode = kExprs, int32_t ordinal = 0) const;
 
   const std::vector<OpInvocation>& ops() const {
@@ -388,10 +383,6 @@ class CompositeInvocation {
   std::deque<c10::IValue> ivalueStorage_;
   int32_t sequenceNumber_;
 
-  // Grid standalones skipped during execute() due to None inputs.
-  // Re-run by runDeferredStandalones() after all PNs execute.
-  std::vector<NodeCP> deferredStandalones_;
-
   // Standalone ops from the maxFusedNodes pre-pass.  Executed at the
   // start of execute() before any kernel step, so their outputs are
   // available for SizeExpr evaluation.
@@ -408,9 +399,6 @@ class CompiledNode {
 
   /// Executes this node using the given execution state.
   void execute(ExecutionState& state);
-
-  /// Runs deferred standalone ops after all PNs have executed.
-  void runDeferredStandalones(ExecutionState& state);
 
   const CompositeInvocation* kernels() const {
     return kernels_.get();

--- a/velox/experimental/torchwave/Executor.cpp
+++ b/velox/experimental/torchwave/Executor.cpp
@@ -26,6 +26,7 @@
 #include <cstdlib>
 #include <iostream>
 #include "velox/experimental/torchwave/NodePrinter.h"
+#include "velox/experimental/torchwave/Registry.h"
 #include "velox/experimental/torchwave/Standalones.h"
 #include "velox/experimental/torchwave/Utils.h"
 #include "velox/experimental/torchwave/WaveConfig.h"
@@ -45,6 +46,23 @@ extern "C" int cudaStreamSynchronize(void* stream);
 namespace torch::wave {
 
 namespace {
+
+// nativert's KernelFactory routes the _operator.* scalar ops by operator, not
+// by the node's output type: the scalar arithmetic ops (add/sub/mul/pow) use
+// ScalarBinaryOpKernel and neg/truediv/sqrt/trunc use SymFloatOpKernel.
+// SymIntOpKernel only implements floordiv/mod/sym_max/sym_min, so choosing a
+// kernel from a SymInt/SymBool output type alone gives the wrong kernel for
+// these (e.g. _operator.sub on a SymInt output -> SymIntOpKernel ->
+// "unsupported operator for SymInt"). Mirror nativert's classification.
+bool isScalarBinaryOp(std::string_view target) {
+  return target == "_operator.add" || target == "_operator.sub" ||
+      target == "_operator.mul" || target == "_operator.pow";
+}
+
+bool isSymFloatOp(std::string_view target) {
+  return target == "_operator.neg" || target == "_operator.truediv" ||
+      target == "torch._sym_sqrt" || target == "math.trunc";
+}
 
 thread_local WaveThreadInfo threadInfo;
 
@@ -245,37 +263,11 @@ void tensorsToHost(
   stream.wait();
 }
 
-namespace {
-
-using SavedValues = std::vector<std::pair<nativert::ValueId, c10::IValue>>;
-
-SavedValues replaceCpuOnlyArgs(
-    const Launch& launch,
-    nativert::ExecutionFrame& frame) {
-  SavedValues saved;
-  for (size_t i = 0; i < launch.argOnCpu.size(); ++i) {
-    auto deviceId = launch.argOnDevice[i]->id();
-    auto& deviceIv = frame.getIValue(deviceId);
-    if (deviceIv.isTensor()) {
-      saved.emplace_back(deviceId, deviceIv);
-      frame.setIValue(deviceId, c10::IValue(deviceIv.toTensor().cpu()));
-    }
-  }
-  return saved;
-}
-
-void restoreCpuOnlyArgs(SavedValues& saved, nativert::ExecutionFrame& frame) {
-  for (auto& [id, iv] : saved) {
-    frame.setIValue(id, std::move(iv));
-  }
-}
-
-} // namespace
-
 void executeNode(
     NodeCP node,
     nativert::OpKernel* kernel,
-    nativert::ExecutionFrame& frame) {
+    nativert::ExecutionFrame& frame,
+    TraceState* traceState) {
   auto trace = WaveConfig::get().trace;
   if (trace & WaveConfig::kLaunches) {
     std::cout << "  node " << standaloneToString(node);
@@ -299,6 +291,41 @@ void executeNode(
       }
     }
   }
+  // Trace requested input values (--trace_values) before the op runs. Done
+  // here so every executeNode caller -- generic standalones, pre-pass,
+  // deferred, and ready-graph nodes -- traces consistently.
+  if (traceState != nullptr && !traceState->empty()) {
+    std::vector<nativert::ValueId> ids;
+    for (const auto& input : node->inputs()) {
+      ids.push_back(input.value->id());
+    }
+    traceFrameValues("input", ids, frame, *traceState);
+  }
+  // Move cpuOnly-flagged tensor args (e.g. tensor_split indices) to CPU before
+  // the op and restore after, for every executeNode caller -- the ready-graph,
+  // deferred, and pre-pass paths call executeNode directly and would otherwise
+  // leave the arg on GPU.
+  std::vector<std::pair<nativert::ValueId, c10::IValue>> savedCpuOnly;
+  if (const auto* meta = Registry::metadata(node->target())) {
+    const auto& nodeInputs = node->inputs();
+    for (size_t i = 0; i < nodeInputs.size() && i < meta->argumentMeta.size();
+         ++i) {
+      if (!meta->argumentMeta[i].cpuOnly) {
+        continue;
+      }
+      auto id = nodeInputs[i].value->id();
+      const auto& iv = frame.getIValue(id);
+      if (iv.isTensor() && iv.toTensor().is_cuda()) {
+        savedCpuOnly.emplace_back(id, iv);
+        frame.setIValue(id, c10::IValue(iv.toTensor().cpu()));
+      }
+    }
+  }
+  SCOPE_EXIT {
+    for (auto& [id, iv] : savedCpuOnly) {
+      frame.setIValue(id, std::move(iv));
+    }
+  };
   try {
     kernel->compute(frame);
   } catch (const std::exception& ex) {
@@ -321,6 +348,16 @@ void executeNode(
   } catch (...) {
     LOG(ERROR) << "Error in node: " << standaloneToString(node);
     throw;
+  }
+  // Trace requested output (produced) values after the op runs.
+  if (traceState != nullptr && !traceState->empty()) {
+    std::vector<nativert::ValueId> ids;
+    for (auto* output : node->outputs()) {
+      if (output) {
+        ids.push_back(output->id());
+      }
+    }
+    traceFrameValues("output", ids, frame, *traceState);
   }
   if (trace & WaveConfig::kTensors) {
     for (auto* output : node->outputs()) {
@@ -349,15 +386,14 @@ void runStandalones(
     const bool metadataOnly =
         data.launch != nullptr && data.launch->metadataOnly;
 
-    // Skip if this node's output is already materialized (e.g. it was computed
-    // by runReadyGraphNodes after the producing composite).  See
+    // Skip if this node's output is already materialized.  See
     // nodeOutputsComputed: re-executing would re-read recycled input buffers.
     if (nodeOutputsComputed(actualNode, *state.frame)) {
       continue;
     }
 
     // Skip standalone ops with None inputs — they depend on values
-    // from later PNs.  runDeferredStandalones will retry them.
+    // from later PNs and are retried by the deferred-standalones pass below.
     bool hasNoneInput = false;
     for (const auto& input : actualNode->inputs()) {
       if (isUnreadyNoneDependency(input.value, *state.frame)) {
@@ -372,12 +408,13 @@ void runStandalones(
       continue;
     }
 
-    SavedValues savedDeviceValues;
-    if (!isShortcut && data.launch && !data.launch->argOnCpu.empty()) {
-      savedDeviceValues = replaceCpuOnlyArgs(*data.launch, *state.frame);
+    // Shortcut ops run via runStandaloneShortcut (not executeNode), so trace
+    // their inputs here; executeNode traces inputs/outputs for the generic
+    // path.
+    if (isShortcut) {
+      traceFrameValues(
+          "input", data.actualInputs, *state.frame, state.traceState);
     }
-    traceFrameValues(
-        "input", data.actualInputs, *state.frame, state.traceState);
 
     // Per-op timing uses the TSC (folly::hardware_timestamp, ~ns) rather than
     // std::chrono, which is backed by a slow kvm-clock here (~tens of us/call)
@@ -393,8 +430,11 @@ void runStandalones(
           kernelIt != kernelMap.end(),
           "No kernel for node ",
           actualNode->target());
-      executeNode(actualNode, kernelIt->second, *state.frame);
-      restoreCpuOnlyArgs(savedDeviceValues, *state.frame);
+      // executeNode moves cpuOnly-flagged args (e.g. tensor_split indices) to
+      // CPU and restores them via a SCOPE_EXIT, so no outer swap is needed
+      // here.
+      executeNode(
+          actualNode, kernelIt->second, *state.frame, &state.traceState);
     }
     if (timing) {
       // A metadata-only op only manipulates host-side tensor metadata and
@@ -423,8 +463,10 @@ void runStandalones(
                   << std::endl;
       }
     }
-    traceFrameValues(
-        "output", data.actualOutputs, *state.frame, state.traceState);
+    if (isShortcut) {
+      traceFrameValues(
+          "output", data.actualOutputs, *state.frame, state.traceState);
+    }
   }
 }
 
@@ -479,6 +521,10 @@ WaveGraphExecutor::WaveGraphExecutor(std::unique_ptr<ModelContext> modelContext)
       kernel = nativert::PrimKernelRegistry()->Create(target, node);
     } else if (c10::starts_with(target, "torch.ops")) {
       kernel = std::make_unique<nativert::C10Kernel>(node);
+    } else if (isScalarBinaryOp(target)) {
+      kernel = std::make_unique<nativert::ScalarBinaryOpKernel>(node);
+    } else if (isSymFloatOp(target)) {
+      kernel = std::make_unique<nativert::SymFloatOpKernel>(node);
     } else {
       bool hasSymIntOutput = false;
       bool hasSymBoolOutput = false;
@@ -713,109 +759,10 @@ void WaveGraphExecutor::executeWave(
 
   std::vector<NodeCP> deferredStandalones;
   state.deferredStandalones = &deferredStandalones;
-  // After each PN execution, run any graph nodes whose outputs are
-  // None but inputs are now ready.  This populates SymInt metadata
-  // (strides, sizes) from _assert_tensor_metadata and other standalone
-  // ops that the serial nativert executor would compute.
-  // Ad-hoc C10 kernels for graph nodes not in kernelMap (e.g.,
-  // sym_size, sym_storage_offset, _local_scalar_dense).
-  std::vector<std::unique_ptr<nativert::OpKernel>> adhocKernels;
-  folly::F14FastMap<NodeCP, nativert::OpKernel*> adhocKernelMap;
-
-  auto runReadyGraphNodes = [&]() {
-    auto& graph = *waveGraph.graph();
-    bool progress = true;
-    while (progress) {
-      progress = false;
-      for (auto& gnode : graph.nodes()) {
-        if (gnode.target() == "prim.Input" || gnode.target() == "prim.Output") {
-          continue;
-        }
-        bool hasNoneOutput = false;
-        for (auto* output : gnode.outputs()) {
-          if (frame.getIValue(output->id()).isNone()) {
-            hasNoneOutput = true;
-            break;
-          }
-        }
-        if (!hasNoneOutput) {
-          continue;
-        }
-        // Look up in both the main kernelMap and ad-hoc map.
-        nativert::OpKernel* kernel = nullptr;
-        auto kernelIt = state.kernelMap->find(&gnode);
-        if (kernelIt != state.kernelMap->end()) {
-          kernel = kernelIt->second;
-        } else {
-          auto adhocIt = adhocKernelMap.find(&gnode);
-          if (adhocIt != adhocKernelMap.end()) {
-            kernel = adhocIt->second;
-          } else {
-            std::string target(gnode.target());
-            std::unique_ptr<nativert::OpKernel> newKernel;
-            if (nativert::PrimKernelRegistry()->Has(target)) {
-              newKernel =
-                  nativert::PrimKernelRegistry()->Create(target, &gnode);
-            } else if (c10::starts_with(target, "torch.ops")) {
-              // Synthetic wave ops (e.g. exclusive_sum) have no real C10
-              // schema and are produced by wave's own lowered kernels, not by
-              // a standalone C10Kernel.  Skip them if no schema exists.
-              try {
-                newKernel = std::make_unique<nativert::C10Kernel>(&gnode);
-              } catch (const std::exception&) {
-                newKernel = nullptr;
-              }
-            } else {
-              bool hasSymIntOutput = false;
-              bool hasSymBoolOutput = false;
-              for (auto* output : gnode.outputs()) {
-                if (output->type().kind() == nativert::Type::Kind::SymInt) {
-                  hasSymIntOutput = true;
-                } else if (
-                    output->type().kind() == nativert::Type::Kind::SymBool) {
-                  hasSymBoolOutput = true;
-                }
-              }
-              if (hasSymIntOutput) {
-                newKernel = std::make_unique<nativert::SymIntOpKernel>(&gnode);
-              } else if (hasSymBoolOutput) {
-                newKernel = std::make_unique<nativert::SymBoolOpKernel>(&gnode);
-              }
-            }
-            if (newKernel) {
-              kernel = newKernel.get();
-              adhocKernelMap[&gnode] = kernel;
-              adhocKernels.push_back(std::move(newKernel));
-            }
-          }
-        }
-        if (!kernel) {
-          continue;
-        }
-        bool inputsReady = true;
-        for (const auto& input : gnode.inputs()) {
-          if (isUnreadyNoneDependency(input.value, frame)) {
-            inputsReady = false;
-            break;
-          }
-        }
-        if (inputsReady) {
-          executeNode(&gnode, kernel, frame);
-          progress = true;
-        }
-      }
-    }
-  };
 
   for (const auto& node : waveGraph.nodes()) {
     node->execute(state);
-    runReadyGraphNodes();
   }
-  // Run deferred standalones whose inputs were produced by later PNs.
-  for (const auto& node : waveGraph.nodes()) {
-    node->runDeferredStandalones(state);
-  }
-
   // Run grid standalones that were skipped due to None inputs.
   {
     bool progress = true;
@@ -838,7 +785,7 @@ void WaveGraphExecutor::executeWave(
           }
         }
         if (allReady) {
-          executeNode(deferredNode, kernelIt->second, frame);
+          executeNode(deferredNode, kernelIt->second, frame, &state.traceState);
           progress = true;
         }
       }

--- a/velox/experimental/torchwave/Executor.h
+++ b/velox/experimental/torchwave/Executor.h
@@ -237,10 +237,13 @@ struct ExecutionState {
 };
 
 /// Executes a single node via its OpKernel with tracing and error logging.
+/// When 'traceState' is non-null, traces the node's input values before the op
+/// and its produced output values after, for any ids in --trace_values.
 void executeNode(
     NodeCP node,
     nativert::OpKernel* kernel,
-    nativert::ExecutionFrame& frame);
+    nativert::ExecutionFrame& frame,
+    TraceState* traceState = nullptr);
 
 /// Runs standalone launches by mapping each formal node to the actual node
 /// via OpInvocation::nodeMap(), executing it via the corresponding OpKernel.


### PR DESCRIPTION
Summary:
Bundles the TorchWave fixes needed to run the IG (roo) preproc pipeline end-to-end through the wave executor, plus a dead-code cleanup.

`Builtins.cpp`: registers the in-place scalar elementwise ops `aten.add_.Scalar`, `sub_.Scalar`, `mul_.Scalar`, and `div_.Scalar`. They reuse the existing `__add_` / `__sub_` / `__mul_` / `__div_` device functions, cast the scalar operand to self's dtype via `castScalarAttrsToInputDtype`, and skip arithmetic promotion so the result keeps self's dtype.

`CompiledOp.cpp`: the standalone-launch empty-output guard now zeroes the launch only when an output is None (produced by a later PN), not when it is an empty (0-element) tensor. An empty output is already handled in device code -- the elementwise size head sets size=0 so the kernel runs zero iterations -- so zeroing the whole launch wrongly skipped the non-empty lanes of a multi-output kernel.

`Executor.{cpp,h}`: `executeNode` now takes a `TraceState*` and traces the requested input values before the op and the produced output values after, so `--trace_values` works uniformly across every caller (generic standalone, shortcut, and deferred paths) rather than only the generic path. `executeNode` also moves `cpuOnly`-flagged tensor args (e.g. `tensor_split` indices) to CPU before the op and restores them after, for every caller instead of only the generic standalone path. Ad-hoc kernel creation for the `_operator.*` scalar ops now classifies them the way the nativert KernelFactory does (`isScalarBinaryOp` -> `ScalarBinaryOpKernel`, `isSymFloatOp` -> `SymFloatOpKernel`) instead of picking a kernel from the SymInt/SymBool output type of the node, which chose the wrong kernel for cases like `_operator.sub` on a SymInt output (SymIntOpKernel -> "unsupported operator for SymInt").

Removes three dead `#if 0` blocks from `Executor.cpp` -- an unused `runReadyGraphNodes` fallback lambda and two disabled call sites -- together with the ad-hoc-kernel scaffolding that only they referenced.

Follow-up cleanup addressing code-review comments: removes the now-orphaned `runDeferredStandalones` methods (on `CompositeInvocation` and `CompiledNode`) plus the unused `deferredStandalones_` member -- their only caller was one of the removed `#if 0` blocks, and deferred standalones are handled by the live `state.deferredStandalones` pass. Consolidates cpuOnly-arg handling into `executeNode`'s `SCOPE_EXIT` and drops the duplicated, exception-unsafe outer `replaceCpuOnlyArgs`/`restoreCpuOnlyArgs` in `runStandalones`. Adds a bounds guard before a `launch.tensorLists.back()` access that clang-tidy flagged.

Differential Revision: D110407886


