### PR TITLE
test(torchwave): Synthetic-data end-to-end test for the ROO preproc graph (#18025)

### DIFF
--- a/velox/experimental/torchwave/Builtins.cpp
+++ b/velox/experimental/torchwave/Builtins.cpp
@@ -777,6 +777,30 @@ void registerBuiltins() {
       .costFunction(divCost)
       .registerOp();
 
+  // In-place (Tensor, Scalar). Same __*_ device functions; the scalar operand
+  // is cast to self's dtype via normalize, and no arithmeticPromotion so the
+  // result keeps self's dtype.
+  MetadataBuilder("torch.ops.aten.add_.Scalar")
+      .elementwiseFunc("__add_")
+      .normalize(castScalarAttrsToInputDtype)
+      .costFunction(arithmeticCost)
+      .registerOp();
+  MetadataBuilder("torch.ops.aten.sub_.Scalar")
+      .elementwiseFunc("__sub_")
+      .normalize(castScalarAttrsToInputDtype)
+      .costFunction(arithmeticCost)
+      .registerOp();
+  MetadataBuilder("torch.ops.aten.mul_.Scalar")
+      .elementwiseFunc("__mul_")
+      .normalize(castScalarAttrsToInputDtype)
+      .costFunction(mulCost)
+      .registerOp();
+  MetadataBuilder("torch.ops.aten.div_.Scalar")
+      .elementwiseFunc("__div_")
+      .normalize(castScalarAttrsToInputDtype)
+      .costFunction(divCost)
+      .registerOp();
+
   // Binary arithmetic (Tensor, Scalar).
   MetadataBuilder("torch.ops.aten.add.Scalar")
       .elementwiseFunc("__add")

--- a/velox/experimental/torchwave/CompiledOp.cpp
+++ b/velox/experimental/torchwave/CompiledOp.cpp
@@ -1515,6 +1515,8 @@ void fillLaunchParams(
       if (returnCounter < static_cast<int32_t>(launch.returnValues.size()) &&
           actualId == launch.returnValues[returnCounter]) {
         launch.returnOffsets.push_back(listOffset);
+        // fillTensorListParam above appended the entry, so back() is safe.
+        TORCH_CHECK(!launch.tensorLists.empty());
         const auto& tlp = launch.tensorLists.back();
         for (auto elemOff : tlp.elementOffsets) {
           if (returnBegin == -1) {
@@ -1990,14 +1992,13 @@ void CompositeInvocation::gatherLaunches(
             if (oi < data.actualOutputTypes.size() &&
                 data.actualOutputTypes[oi] == nativert::Type::Kind::Tensor) {
               const auto& oiv = state.frame->getIValue(data.actualOutputs[oi]);
-              // A None output comes from a later PN.  An empty (0-element)
-              // output means there is nothing to compute and its storage (and
-              // that of any broadcast-to-empty input) may be null -- launching
-              // would fault.  numElements from a kMax sizeExpr ignores the
-              // empty (broadcast-to-0) dimension, so guard on the allocated
-              // output extent explicitly here.
-              if (oiv.isNone() ||
-                  (oiv.isTensor() && oiv.toTensor().numel() == 0)) {
+              // A None output comes from a later PN -- its tensor is not
+              // materialized, so the kernel must not launch yet. An empty
+              // (0-element) output is handled in device code (the elementwise
+              // size head sets size=0 -> 0 iterations), so it does not zero the
+              // whole launch here -- that would wrongly skip the non-empty
+              // lanes of a multi-output kernel.
+              if (oiv.isNone()) {
                 data.numElements = 0;
                 break;
               }
@@ -2749,40 +2750,6 @@ void CompositeInvocation::execute(ExecutionState& state) {
   }
 }
 
-void CompositeInvocation::runDeferredStandalones(ExecutionState& state) {
-  if (prePassStandalones_.empty()) {
-    return;
-  }
-  auto& frame = *state.frame;
-  bool progress = true;
-  while (progress) {
-    progress = false;
-    for (auto& launch : prePassStandalones_) {
-      if (!launch.standalone) {
-        continue;
-      }
-      if (nodeOutputsComputed(launch.standalone, frame)) {
-        continue;
-      }
-      auto kernelIt = state.kernelMap->find(launch.standalone);
-      if (kernelIt == state.kernelMap->end()) {
-        continue;
-      }
-      bool allInputsReady = true;
-      for (const auto& input : launch.standalone->inputs()) {
-        if (isUnreadyNoneDependency(input.value, frame)) {
-          allInputsReady = false;
-          break;
-        }
-      }
-      if (allInputsReady) {
-        executeNode(launch.standalone, kernelIt->second, frame);
-        progress = true;
-      }
-    }
-  }
-}
-
 void CompositeInvocation::launch(
     int32_t numBlocks,
     int32_t blockSize,
@@ -3025,10 +2992,6 @@ std::string CompositeInvocation::toString(Listing mode, int32_t ordinal) const {
 
 void CompiledNode::execute(ExecutionState& state) {
   kernels_->execute(state);
-}
-
-void CompiledNode::runDeferredStandalones(ExecutionState& state) {
-  kernels_->runDeferredStandalones(state);
 }
 
 std::string CompiledNode::toString(Listing mode, int32_t ordinal) const {

--- a/velox/experimental/torchwave/CompiledOp.h
+++ b/velox/experimental/torchwave/CompiledOp.h
@@ -328,11 +328,6 @@ class CompositeInvocation {
   /// copies params to pinned+device memory, and enqueues the H2D transfer.
   void execute(ExecutionState& state);
 
-  /// Runs pre-pass standalones that were skipped during execute() because
-  /// their inputs were None.  Called after all PNs have executed so that
-  /// cross-PN values are available.
-  void runDeferredStandalones(ExecutionState& state);
-
   std::string toString(Listing mode = kExprs, int32_t ordinal = 0) const;
 
   const std::vector<OpInvocation>& ops() const {
@@ -388,10 +383,6 @@ class CompositeInvocation {
   std::deque<c10::IValue> ivalueStorage_;
   int32_t sequenceNumber_;
 
-  // Grid standalones skipped during execute() due to None inputs.
-  // Re-run by runDeferredStandalones() after all PNs execute.
-  std::vector<NodeCP> deferredStandalones_;
-
   // Standalone ops from the maxFusedNodes pre-pass.  Executed at the
   // start of execute() before any kernel step, so their outputs are
   // available for SizeExpr evaluation.
@@ -408,9 +399,6 @@ class CompiledNode {
 
   /// Executes this node using the given execution state.
   void execute(ExecutionState& state);
-
-  /// Runs deferred standalone ops after all PNs have executed.
-  void runDeferredStandalones(ExecutionState& state);
 
   const CompositeInvocation* kernels() const {
     return kernels_.get();

--- a/velox/experimental/torchwave/Executor.cpp
+++ b/velox/experimental/torchwave/Executor.cpp
@@ -26,6 +26,7 @@
 #include <cstdlib>
 #include <iostream>
 #include "velox/experimental/torchwave/NodePrinter.h"
+#include "velox/experimental/torchwave/Registry.h"
 #include "velox/experimental/torchwave/Standalones.h"
 #include "velox/experimental/torchwave/Utils.h"
 #include "velox/experimental/torchwave/WaveConfig.h"
@@ -45,6 +46,23 @@ extern "C" int cudaStreamSynchronize(void* stream);
 namespace torch::wave {
 
 namespace {
+
+// nativert's KernelFactory routes the _operator.* scalar ops by operator, not
+// by the node's output type: the scalar arithmetic ops (add/sub/mul/pow) use
+// ScalarBinaryOpKernel and neg/truediv/sqrt/trunc use SymFloatOpKernel.
+// SymIntOpKernel only implements floordiv/mod/sym_max/sym_min, so choosing a
+// kernel from a SymInt/SymBool output type alone gives the wrong kernel for
+// these (e.g. _operator.sub on a SymInt output -> SymIntOpKernel ->
+// "unsupported operator for SymInt"). Mirror nativert's classification.
+bool isScalarBinaryOp(std::string_view target) {
+  return target == "_operator.add" || target == "_operator.sub" ||
+      target == "_operator.mul" || target == "_operator.pow";
+}
+
+bool isSymFloatOp(std::string_view target) {
+  return target == "_operator.neg" || target == "_operator.truediv" ||
+      target == "torch._sym_sqrt" || target == "math.trunc";
+}
 
 thread_local WaveThreadInfo threadInfo;
 
@@ -245,37 +263,11 @@ void tensorsToHost(
   stream.wait();
 }
 
-namespace {
-
-using SavedValues = std::vector<std::pair<nativert::ValueId, c10::IValue>>;
-
-SavedValues replaceCpuOnlyArgs(
-    const Launch& launch,
-    nativert::ExecutionFrame& frame) {
-  SavedValues saved;
-  for (size_t i = 0; i < launch.argOnCpu.size(); ++i) {
-    auto deviceId = launch.argOnDevice[i]->id();
-    auto& deviceIv = frame.getIValue(deviceId);
-    if (deviceIv.isTensor()) {
-      saved.emplace_back(deviceId, deviceIv);
-      frame.setIValue(deviceId, c10::IValue(deviceIv.toTensor().cpu()));
-    }
-  }
-  return saved;
-}
-
-void restoreCpuOnlyArgs(SavedValues& saved, nativert::ExecutionFrame& frame) {
-  for (auto& [id, iv] : saved) {
-    frame.setIValue(id, std::move(iv));
-  }
-}
-
-} // namespace
-
 void executeNode(
     NodeCP node,
     nativert::OpKernel* kernel,
-    nativert::ExecutionFrame& frame) {
+    nativert::ExecutionFrame& frame,
+    TraceState* traceState) {
   auto trace = WaveConfig::get().trace;
   if (trace & WaveConfig::kLaunches) {
     std::cout << "  node " << standaloneToString(node);
@@ -299,6 +291,41 @@ void executeNode(
       }
     }
   }
+  // Trace requested input values (--trace_values) before the op runs. Done
+  // here so every executeNode caller -- generic standalones, pre-pass,
+  // deferred, and ready-graph nodes -- traces consistently.
+  if (traceState != nullptr && !traceState->empty()) {
+    std::vector<nativert::ValueId> ids;
+    for (const auto& input : node->inputs()) {
+      ids.push_back(input.value->id());
+    }
+    traceFrameValues("input", ids, frame, *traceState);
+  }
+  // Move cpuOnly-flagged tensor args (e.g. tensor_split indices) to CPU before
+  // the op and restore after, for every executeNode caller -- the ready-graph,
+  // deferred, and pre-pass paths call executeNode directly and would otherwise
+  // leave the arg on GPU.
+  std::vector<std::pair<nativert::ValueId, c10::IValue>> savedCpuOnly;
+  if (const auto* meta = Registry::metadata(node->target())) {
+    const auto& nodeInputs = node->inputs();
+    for (size_t i = 0; i < nodeInputs.size() && i < meta->argumentMeta.size();
+         ++i) {
+      if (!meta->argumentMeta[i].cpuOnly) {
+        continue;
+      }
+      auto id = nodeInputs[i].value->id();
+      const auto& iv = frame.getIValue(id);
+      if (iv.isTensor() && iv.toTensor().is_cuda()) {
+        savedCpuOnly.emplace_back(id, iv);
+        frame.setIValue(id, c10::IValue(iv.toTensor().cpu()));
+      }
+    }
+  }
+  SCOPE_EXIT {
+    for (auto& [id, iv] : savedCpuOnly) {
+      frame.setIValue(id, std::move(iv));
+    }
+  };
   try {
     kernel->compute(frame);
   } catch (const std::exception& ex) {
@@ -321,6 +348,16 @@ void executeNode(
   } catch (...) {
     LOG(ERROR) << "Error in node: " << standaloneToString(node);
     throw;
+  }
+  // Trace requested output (produced) values after the op runs.
+  if (traceState != nullptr && !traceState->empty()) {
+    std::vector<nativert::ValueId> ids;
+    for (auto* output : node->outputs()) {
+      if (output) {
+        ids.push_back(output->id());
+      }
+    }
+    traceFrameValues("output", ids, frame, *traceState);
   }
   if (trace & WaveConfig::kTensors) {
     for (auto* output : node->outputs()) {
@@ -349,15 +386,14 @@ void runStandalones(
     const bool metadataOnly =
         data.launch != nullptr && data.launch->metadataOnly;
 
-    // Skip if this node's output is already materialized (e.g. it was computed
-    // by runReadyGraphNodes after the producing composite).  See
+    // Skip if this node's output is already materialized.  See
     // nodeOutputsComputed: re-executing would re-read recycled input buffers.
     if (nodeOutputsComputed(actualNode, *state.frame)) {
       continue;
     }
 
     // Skip standalone ops with None inputs — they depend on values
-    // from later PNs.  runDeferredStandalones will retry them.
+    // from later PNs and are retried by the deferred-standalones pass below.
     bool hasNoneInput = false;
     for (const auto& input : actualNode->inputs()) {
       if (isUnreadyNoneDependency(input.value, *state.frame)) {
@@ -372,12 +408,13 @@ void runStandalones(
       continue;
     }
 
-    SavedValues savedDeviceValues;
-    if (!isShortcut && data.launch && !data.launch->argOnCpu.empty()) {
-      savedDeviceValues = replaceCpuOnlyArgs(*data.launch, *state.frame);
+    // Shortcut ops run via runStandaloneShortcut (not executeNode), so trace
+    // their inputs here; executeNode traces inputs/outputs for the generic
+    // path.
+    if (isShortcut) {
+      traceFrameValues(
+          "input", data.actualInputs, *state.frame, state.traceState);
     }
-    traceFrameValues(
-        "input", data.actualInputs, *state.frame, state.traceState);
 
     // Per-op timing uses the TSC (folly::hardware_timestamp, ~ns) rather than
     // std::chrono, which is backed by a slow kvm-clock here (~tens of us/call)
@@ -393,8 +430,11 @@ void runStandalones(
           kernelIt != kernelMap.end(),
           "No kernel for node ",
           actualNode->target());
-      executeNode(actualNode, kernelIt->second, *state.frame);
-      restoreCpuOnlyArgs(savedDeviceValues, *state.frame);
+      // executeNode moves cpuOnly-flagged args (e.g. tensor_split indices) to
+      // CPU and restores them via a SCOPE_EXIT, so no outer swap is needed
+      // here.
+      executeNode(
+          actualNode, kernelIt->second, *state.frame, &state.traceState);
     }
     if (timing) {
       // A metadata-only op only manipulates host-side tensor metadata and
@@ -423,8 +463,10 @@ void runStandalones(
                   << std::endl;
       }
     }
-    traceFrameValues(
-        "output", data.actualOutputs, *state.frame, state.traceState);
+    if (isShortcut) {
+      traceFrameValues(
+          "output", data.actualOutputs, *state.frame, state.traceState);
+    }
   }
 }
 
@@ -479,6 +521,10 @@ WaveGraphExecutor::WaveGraphExecutor(std::unique_ptr<ModelContext> modelContext)
       kernel = nativert::PrimKernelRegistry()->Create(target, node);
     } else if (c10::starts_with(target, "torch.ops")) {
       kernel = std::make_unique<nativert::C10Kernel>(node);
+    } else if (isScalarBinaryOp(target)) {
+      kernel = std::make_unique<nativert::ScalarBinaryOpKernel>(node);
+    } else if (isSymFloatOp(target)) {
+      kernel = std::make_unique<nativert::SymFloatOpKernel>(node);
     } else {
       bool hasSymIntOutput = false;
       bool hasSymBoolOutput = false;
@@ -713,109 +759,10 @@ void WaveGraphExecutor::executeWave(
 
   std::vector<NodeCP> deferredStandalones;
   state.deferredStandalones = &deferredStandalones;
-  // After each PN execution, run any graph nodes whose outputs are
-  // None but inputs are now ready.  This populates SymInt metadata
-  // (strides, sizes) from _assert_tensor_metadata and other standalone
-  // ops that the serial nativert executor would compute.
-  // Ad-hoc C10 kernels for graph nodes not in kernelMap (e.g.,
-  // sym_size, sym_storage_offset, _local_scalar_dense).
-  std::vector<std::unique_ptr<nativert::OpKernel>> adhocKernels;
-  folly::F14FastMap<NodeCP, nativert::OpKernel*> adhocKernelMap;
-
-  auto runReadyGraphNodes = [&]() {
-    auto& graph = *waveGraph.graph();
-    bool progress = true;
-    while (progress) {
-      progress = false;
-      for (auto& gnode : graph.nodes()) {
-        if (gnode.target() == "prim.Input" || gnode.target() == "prim.Output") {
-          continue;
-        }
-        bool hasNoneOutput = false;
-        for (auto* output : gnode.outputs()) {
-          if (frame.getIValue(output->id()).isNone()) {
-            hasNoneOutput = true;
-            break;
-          }
-        }
-        if (!hasNoneOutput) {
-          continue;
-        }
-        // Look up in both the main kernelMap and ad-hoc map.
-        nativert::OpKernel* kernel = nullptr;
-        auto kernelIt = state.kernelMap->find(&gnode);
-        if (kernelIt != state.kernelMap->end()) {
-          kernel = kernelIt->second;
-        } else {
-          auto adhocIt = adhocKernelMap.find(&gnode);
-          if (adhocIt != adhocKernelMap.end()) {
-            kernel = adhocIt->second;
-          } else {
-            std::string target(gnode.target());
-            std::unique_ptr<nativert::OpKernel> newKernel;
-            if (nativert::PrimKernelRegistry()->Has(target)) {
-              newKernel =
-                  nativert::PrimKernelRegistry()->Create(target, &gnode);
-            } else if (c10::starts_with(target, "torch.ops")) {
-              // Synthetic wave ops (e.g. exclusive_sum) have no real C10
-              // schema and are produced by wave's own lowered kernels, not by
-              // a standalone C10Kernel.  Skip them if no schema exists.
-              try {
-                newKernel = std::make_unique<nativert::C10Kernel>(&gnode);
-              } catch (const std::exception&) {
-                newKernel = nullptr;
-              }
-            } else {
-              bool hasSymIntOutput = false;
-              bool hasSymBoolOutput = false;
-              for (auto* output : gnode.outputs()) {
-                if (output->type().kind() == nativert::Type::Kind::SymInt) {
-                  hasSymIntOutput = true;
-                } else if (
-                    output->type().kind() == nativert::Type::Kind::SymBool) {
-                  hasSymBoolOutput = true;
-                }
-              }
-              if (hasSymIntOutput) {
-                newKernel = std::make_unique<nativert::SymIntOpKernel>(&gnode);
-              } else if (hasSymBoolOutput) {
-                newKernel = std::make_unique<nativert::SymBoolOpKernel>(&gnode);
-              }
-            }
-            if (newKernel) {
-              kernel = newKernel.get();
-              adhocKernelMap[&gnode] = kernel;
-              adhocKernels.push_back(std::move(newKernel));
-            }
-          }
-        }
-        if (!kernel) {
-          continue;
-        }
-        bool inputsReady = true;
-        for (const auto& input : gnode.inputs()) {
-          if (isUnreadyNoneDependency(input.value, frame)) {
-            inputsReady = false;
-            break;
-          }
-        }
-        if (inputsReady) {
-          executeNode(&gnode, kernel, frame);
-          progress = true;
-        }
-      }
-    }
-  };
 
   for (const auto& node : waveGraph.nodes()) {
     node->execute(state);
-    runReadyGraphNodes();
   }
-  // Run deferred standalones whose inputs were produced by later PNs.
-  for (const auto& node : waveGraph.nodes()) {
-    node->runDeferredStandalones(state);
-  }
-
   // Run grid standalones that were skipped due to None inputs.
   {
     bool progress = true;
@@ -838,7 +785,7 @@ void WaveGraphExecutor::executeWave(
           }
         }
         if (allReady) {
-          executeNode(deferredNode, kernelIt->second, frame);
+          executeNode(deferredNode, kernelIt->second, frame, &state.traceState);
           progress = true;
         }
       }

--- a/velox/experimental/torchwave/Executor.h
+++ b/velox/experimental/torchwave/Executor.h
@@ -237,10 +237,13 @@ struct ExecutionState {
 };
 
 /// Executes a single node via its OpKernel with tracing and error logging.
+/// When 'traceState' is non-null, traces the node's input values before the op
+/// and its produced output values after, for any ids in --trace_values.
 void executeNode(
     NodeCP node,
     nativert::OpKernel* kernel,
-    nativert::ExecutionFrame& frame);
+    nativert::ExecutionFrame& frame,
+    TraceState* traceState = nullptr);
 
 /// Runs standalone launches by mapping each formal node to the actual node
 /// via OpInvocation::nodeMap(), executing it via the corresponding OpKernel.

--- a/velox/experimental/torchwave/tests/DataGen.cpp
+++ b/velox/experimental/torchwave/tests/DataGen.cpp
@@ -1,0 +1,548 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/torchwave/tests/DataGen.h"
+
+#include <algorithm>
+#include <cmath>
+#include <fstream>
+#include <sstream>
+#include <unordered_map>
+#include <unordered_set>
+
+#include <c10/core/ScalarType.h>
+#include <folly/dynamic.h>
+#include <folly/json.h>
+#include <glog/logging.h>
+
+#include <torch/nativert/graph/GraphSignature.h>
+
+namespace torch::wave {
+namespace {
+
+// Cap for recording all values of a small tensor and for the distinct-value
+// pool used at generation time. Tensors below this element count keep their
+// exact values in the spec.
+constexpr int64_t kListValuesCap = 256;
+
+// Cap on the distinct-value set built during analysis (bounds memory) and on
+// the pool used at generation time.
+constexpr int64_t kDistinctCap = 1 << 20;
+
+// Fraction by which an ascending int tensor's last value may differ from a
+// candidate tensor's element count and still be treated as offsets.
+constexpr double kOffsetsTolerance = 0.05;
+
+std::string readWholeFile(const std::string& path) {
+  std::ifstream in(path, std::ios::binary);
+  TORCH_CHECK(in.is_open(), "Cannot open spec file: ", path);
+  std::ostringstream ss;
+  ss << in.rdbuf();
+  return ss.str();
+}
+
+void writeWholeFile(const std::string& path, const std::string& contents) {
+  std::ofstream out(path, std::ios::binary | std::ios::trunc);
+  TORCH_CHECK(out.is_open(), "Cannot write spec file: ", path);
+  out << contents;
+}
+
+c10::ScalarType scalarTypeFromString(const std::string& name) {
+  static const std::unordered_map<std::string, c10::ScalarType> kMap = {
+      {"Float", at::kFloat},
+      {"Double", at::kDouble},
+      {"Half", at::kHalf},
+      {"BFloat16", at::kBFloat16},
+      {"Long", at::kLong},
+      {"Int", at::kInt},
+      {"Short", at::kShort},
+      {"Char", at::kChar},
+      {"Byte", at::kByte},
+      {"Bool", at::kBool},
+  };
+  auto it = kMap.find(name);
+  if (it != kMap.end()) {
+    return it->second;
+  }
+  LOG(WARNING) << "DataGen: unknown dtype '" << name
+               << "', defaulting to Float";
+  return at::kFloat;
+}
+
+int64_t product(const std::vector<int64_t>& dims) {
+  int64_t n = 1;
+  for (auto d : dims) {
+    n *= d;
+  }
+  return n;
+}
+
+// Fills the numeric statistics (min/max/sum/distinctCount) and, when the tensor
+// is small or looks like offsets, the exact values, into 'spec'. 'allNumels'
+// holds every leaf tensor's element count for the offsets heuristic.
+void analyzeTensor(
+    const at::Tensor& tensor,
+    const std::vector<int64_t>& allNumels,
+    LeafSpec& spec) {
+  spec.dtype = c10::toString(tensor.scalar_type());
+  spec.dims = tensor.sizes().vec();
+  spec.strides = tensor.strides().vec();
+
+  auto cpu = tensor.to(at::kCPU).contiguous();
+  int64_t n = cpu.numel();
+  if (n == 0) {
+    return;
+  }
+
+  bool isInt = c10::isIntegralType(tensor.scalar_type(), /*includeBool=*/false);
+
+  auto asDouble = cpu.to(at::kDouble).contiguous();
+  const double* p = asDouble.data_ptr<double>();
+  double minVal = p[0];
+  double maxVal = p[0];
+  double sum = 0;
+  bool ascending = true;
+  std::unordered_set<double> distinct;
+  for (int64_t i = 0; i < n; ++i) {
+    double v = p[i];
+    minVal = std::min(minVal, v);
+    maxVal = std::max(maxVal, v);
+    sum += v;
+    if (i > 0 && v < p[i - 1]) {
+      ascending = false;
+    }
+    if (static_cast<int64_t>(distinct.size()) < kDistinctCap) {
+      distinct.insert(v);
+    }
+  }
+  spec.minVal = minVal;
+  spec.maxVal = maxVal;
+  spec.sum = sum;
+  spec.distinctCount = static_cast<int64_t>(distinct.size());
+
+  // Offsets heuristic: an ascending int tensor whose last element is within a
+  // few percent of some leaf's element count is a jagged offsets array.
+  if (isInt && n > 1 && ascending) {
+    double last = p[n - 1];
+    for (int64_t m : allNumels) {
+      if (m <= 0) {
+        continue;
+      }
+      if (std::abs(last - static_cast<double>(m)) <=
+          kOffsetsTolerance * static_cast<double>(m)) {
+        spec.isOffsets = true;
+        break;
+      }
+    }
+  }
+
+  // Lengths heuristic: an int tensor whose element sum is within a few percent
+  // of some leaf's element count is a jagged lengths array (sum of lengths ==
+  // number of values). Sparse ops (e.g. batch_flip_and_truncate /
+  // GroupLengthGuardSparse) memcpy each group by length, so an inconsistent
+  // lengths/values pair reads out of bounds. Record such tensors exactly so the
+  // sum-of-lengths invariant -- and the resulting data cardinalities -- are
+  // preserved. Feature-value tensors (hashes) have astronomically large sums
+  // that match no size, so they are never mistaken for lengths.
+  bool isLengths = false;
+  if (isInt && !spec.isOffsets) {
+    for (int64_t m : allNumels) {
+      if (m <= 0) {
+        continue;
+      }
+      if (std::abs(sum - static_cast<double>(m)) <=
+          kOffsetsTolerance * static_cast<double>(m)) {
+        isLengths = true;
+        break;
+      }
+    }
+  }
+
+  // Record exact values for offsets, lengths, and small tensors so generation
+  // reproduces their structure.
+  if (spec.isOffsets || isLengths || n <= kListValuesCap) {
+    spec.hasValues = true;
+    spec.values.assign(p, p + n);
+  }
+}
+
+LeafSpec analyzeScalar(const c10::IValue& iv) {
+  LeafSpec spec;
+  spec.kind = LeafKind::kUserInputScalar;
+  if (iv.isInt()) {
+    spec.scalarType = "int";
+    spec.scalarValue = static_cast<double>(iv.toInt());
+  } else if (iv.isDouble()) {
+    spec.scalarType = "float";
+    spec.scalarValue = iv.toDouble();
+  } else if (iv.isBool()) {
+    spec.scalarType = "bool";
+    spec.scalarValue = iv.toBool() ? 1.0 : 0.0;
+  } else {
+    // None or an unsupported input type: reproduce as None.
+    spec.scalarType = "none";
+  }
+  return spec;
+}
+
+folly::dynamic leafToDynamic(const LeafSpec& leaf) {
+  folly::dynamic o = folly::dynamic::object;
+  o["kind"] = static_cast<int>(leaf.kind);
+  o["valueId"] = leaf.valueId;
+  o["name"] = leaf.name;
+  o["inputIndex"] = leaf.inputIndex;
+  o["dtype"] = leaf.dtype;
+  folly::dynamic dims = folly::dynamic::array;
+  for (auto d : leaf.dims) {
+    dims.push_back(d);
+  }
+  o["dims"] = dims;
+  folly::dynamic strides = folly::dynamic::array;
+  for (auto s : leaf.strides) {
+    strides.push_back(s);
+  }
+  o["strides"] = strides;
+  o["min"] = leaf.minVal;
+  o["max"] = leaf.maxVal;
+  o["distinctCount"] = leaf.distinctCount;
+  o["sum"] = leaf.sum;
+  o["isOffsets"] = leaf.isOffsets;
+  o["hasValues"] = leaf.hasValues;
+  if (leaf.hasValues) {
+    folly::dynamic values = folly::dynamic::array;
+    for (auto v : leaf.values) {
+      values.push_back(v);
+    }
+    o["values"] = values;
+  }
+  if (leaf.kind == LeafKind::kUserInputScalar) {
+    o["scalarType"] = leaf.scalarType;
+    o["scalarValue"] = leaf.scalarValue;
+  }
+  return o;
+}
+
+LeafSpec leafFromDynamic(const folly::dynamic& o) {
+  LeafSpec leaf;
+  leaf.kind = static_cast<LeafKind>(o["kind"].asInt());
+  leaf.valueId = static_cast<int32_t>(o["valueId"].asInt());
+  leaf.name = o["name"].asString();
+  leaf.inputIndex = static_cast<int32_t>(o["inputIndex"].asInt());
+  leaf.dtype = o["dtype"].asString();
+  for (const auto& d : o["dims"]) {
+    leaf.dims.push_back(d.asInt());
+  }
+  for (const auto& s : o["strides"]) {
+    leaf.strides.push_back(s.asInt());
+  }
+  leaf.minVal = o["min"].asDouble();
+  leaf.maxVal = o["max"].asDouble();
+  leaf.distinctCount = o["distinctCount"].asInt();
+  leaf.sum = o["sum"].asDouble();
+  leaf.isOffsets = o["isOffsets"].asBool();
+  leaf.hasValues = o["hasValues"].asBool();
+  if (leaf.hasValues && o.count("values")) {
+    for (const auto& v : o["values"]) {
+      leaf.values.push_back(v.asDouble());
+    }
+  }
+  if (leaf.kind == LeafKind::kUserInputScalar) {
+    leaf.scalarType = o["scalarType"].asString();
+    leaf.scalarValue = o["scalarValue"].asDouble();
+  }
+  return leaf;
+}
+
+// Builds a CPU tensor for one leaf spec. Uses the global RNG (seed set by the
+// caller). Reproduces exact values when recorded, otherwise draws random values
+// matching the recorded range and distinct-value count.
+at::Tensor generateTensor(const LeafSpec& leaf) {
+  auto stype = scalarTypeFromString(leaf.dtype);
+  auto opts = at::TensorOptions().dtype(stype).device(at::kCPU);
+  int64_t n = product(leaf.dims);
+
+  if (leaf.hasValues) {
+    auto flat =
+        at::empty({static_cast<int64_t>(leaf.values.size())}, at::kDouble);
+    double* d = flat.data_ptr<double>();
+    std::copy(leaf.values.begin(), leaf.values.end(), d);
+    if (static_cast<int64_t>(leaf.values.size()) != n) {
+      // Fall back to the recorded 1-D values if they do not match dims.
+      return flat.to(stype);
+    }
+    return flat.reshape(leaf.dims).to(stype);
+  }
+
+  if (n == 0) {
+    return at::empty(leaf.dims, opts);
+  }
+
+  bool isInt = c10::isIntegralType(stype, /*includeBool=*/false);
+  bool usePool = leaf.distinctCount > 0 && leaf.distinctCount <= kDistinctCap &&
+      leaf.distinctCount < n;
+
+  if (stype == at::kBool) {
+    return at::randint(0, 2, leaf.dims, opts);
+  }
+
+  if (usePool) {
+    int64_t poolSize = leaf.distinctCount;
+    at::Tensor pool;
+    if (isInt) {
+      int64_t lo = static_cast<int64_t>(std::llround(leaf.minVal));
+      int64_t hi = static_cast<int64_t>(std::llround(leaf.maxVal));
+      pool = at::randint(lo, hi + 1, {poolSize}, opts);
+    } else {
+      pool = at::rand({poolSize}, at::TensorOptions().dtype(stype)) *
+              (leaf.maxVal - leaf.minVal) +
+          leaf.minVal;
+    }
+    auto idx = at::randint(
+        0,
+        poolSize,
+        {n},
+        at::TensorOptions().dtype(at::kLong).device(at::kCPU));
+    return pool.index_select(0, idx).reshape(leaf.dims);
+  }
+
+  if (isInt) {
+    int64_t lo = static_cast<int64_t>(std::llround(leaf.minVal));
+    int64_t hi = static_cast<int64_t>(std::llround(leaf.maxVal));
+    return at::randint(lo, hi + 1, leaf.dims, opts);
+  }
+
+  return (at::rand(leaf.dims, at::TensorOptions().dtype(stype)) *
+              (leaf.maxVal - leaf.minVal) +
+          leaf.minVal)
+      .to(stype);
+}
+
+c10::IValue generateScalar(const LeafSpec& leaf) {
+  if (leaf.scalarType == "int") {
+    return c10::IValue(static_cast<int64_t>(std::llround(leaf.scalarValue)));
+  }
+  if (leaf.scalarType == "float") {
+    return c10::IValue(leaf.scalarValue);
+  }
+  if (leaf.scalarType == "bool") {
+    return c10::IValue(leaf.scalarValue != 0.0);
+  }
+  return c10::IValue();
+}
+
+} // namespace
+
+void makeDatasetSpec(
+    const nativert::Graph& graph,
+    const nativert::Weights& weights,
+    const std::vector<c10::IValue>& userInputs,
+    const std::string& specPath) {
+  DatasetSpec spec;
+
+  // Collect every leaf tensor's element count first (needed for the offsets
+  // heuristic), then analyze.
+  std::vector<int64_t> allNumels;
+  for (const auto& iv : userInputs) {
+    if (iv.isTensor()) {
+      allNumels.push_back(iv.toTensor().numel());
+    }
+  }
+  auto collectNumels =
+      [&](const std::unordered_map<std::string, at::Tensor>& m) {
+        for (const auto& [name, t] : m) {
+          allNumels.push_back(t.numel());
+        }
+      };
+  auto params = weights.parameters();
+  auto buffers = weights.buffers();
+  auto constants = weights.attributes();
+  collectNumels(params);
+  collectNumels(buffers);
+  collectNumels(constants);
+
+  // Map weight FQN -> graph value id (best effort; informational only).
+  std::unordered_map<std::string, int32_t> fqnToId;
+  {
+    std::unordered_map<std::string, int32_t> inputNameToId;
+    for (const auto* v : graph.weightValues()) {
+      inputNameToId[std::string(v->name())] = v->id();
+    }
+    for (const auto& [inputName, fqn] : graph.signature().inputsToWeights()) {
+      auto it = inputNameToId.find(inputName);
+      if (it != inputNameToId.end()) {
+        fqnToId[fqn] = it->second;
+      }
+    }
+  }
+
+  // User inputs (positional, matching graph.userInputs()).
+  const auto& inputValues = graph.userInputs();
+  const auto& inputNames = graph.signature().userInputs();
+  for (size_t i = 0; i < userInputs.size(); ++i) {
+    const auto& iv = userInputs[i];
+    if (iv.isTensor()) {
+      LeafSpec leaf;
+      leaf.kind = LeafKind::kUserInput;
+      leaf.inputIndex = static_cast<int32_t>(i);
+      if (i < inputValues.size() && inputValues[i]) {
+        leaf.valueId = inputValues[i]->id();
+      }
+      if (i < inputNames.size()) {
+        leaf.name = inputNames[i];
+      }
+      analyzeTensor(iv.toTensor(), allNumels, leaf);
+      spec.leaves.push_back(std::move(leaf));
+    } else {
+      LeafSpec leaf = analyzeScalar(iv);
+      leaf.inputIndex = static_cast<int32_t>(i);
+      if (i < inputValues.size() && inputValues[i]) {
+        leaf.valueId = inputValues[i]->id();
+      }
+      if (i < inputNames.size()) {
+        leaf.name = inputNames[i];
+      }
+      spec.leaves.push_back(std::move(leaf));
+    }
+  }
+
+  // Weights: parameters, buffers, constants (keyed by FQN).
+  auto addWeights = [&](const std::unordered_map<std::string, at::Tensor>& m,
+                        LeafKind kind) {
+    for (const auto& [name, t] : m) {
+      LeafSpec leaf;
+      leaf.kind = kind;
+      leaf.name = name;
+      auto it = fqnToId.find(name);
+      leaf.valueId = it != fqnToId.end() ? it->second : -1;
+      analyzeTensor(t, allNumels, leaf);
+      spec.leaves.push_back(std::move(leaf));
+    }
+  };
+  addWeights(params, LeafKind::kParameter);
+  addWeights(buffers, LeafKind::kBuffer);
+  addWeights(constants, LeafKind::kConstant);
+
+  folly::dynamic root = folly::dynamic::object;
+  root["seed"] = static_cast<int64_t>(spec.seed);
+  folly::dynamic arr = folly::dynamic::array;
+  for (const auto& leaf : spec.leaves) {
+    arr.push_back(leafToDynamic(leaf));
+  }
+  root["leaves"] = arr;
+  writeWholeFile(specPath, folly::toPrettyJson(root));
+  LOG(INFO) << "DataGen: wrote spec with " << spec.leaves.size()
+            << " leaves to " << specPath;
+}
+
+DatasetSpec loadDatasetSpec(const std::string& specPath) {
+  auto contents = readWholeFile(specPath);
+  auto root = folly::parseJson(contents);
+  DatasetSpec spec;
+  if (root.count("seed")) {
+    spec.seed = static_cast<uint64_t>(root["seed"].asInt());
+  }
+  for (const auto& o : root["leaves"]) {
+    spec.leaves.push_back(leafFromDynamic(o));
+  }
+  return spec;
+}
+
+GeneratedData generateFromSpec(
+    const nativert::Graph& graph,
+    const std::string& specPath,
+    std::optional<uint64_t> seed,
+    c10::Device weightDevice) {
+  DatasetSpec spec = loadDatasetSpec(specPath);
+  uint64_t actualSeed = seed.has_value() ? *seed : spec.seed;
+  at::manual_seed(actualSeed);
+
+  GeneratedData out;
+
+  // Count user inputs to size the positional output vector.
+  int32_t maxInputIndex = -1;
+  for (const auto& leaf : spec.leaves) {
+    if (leaf.kind == LeafKind::kUserInput ||
+        leaf.kind == LeafKind::kUserInputScalar) {
+      maxInputIndex = std::max(maxInputIndex, leaf.inputIndex);
+    }
+  }
+  out.userInputs.resize(maxInputIndex + 1);
+
+  std::unordered_map<std::string, c10::IValue> stateDict;
+  std::unordered_map<std::string, c10::IValue> constants;
+
+  // A weight's shape and dtype must match the graph's weightsMeta exactly (the
+  // Weights ctor validates them), so generate weights to the meta rather than
+  // the recorded spec dims in case the two ever diverge.
+  const auto& weightsMeta = graph.weightsMeta();
+  auto generateWeight = [&](const LeafSpec& leaf) -> at::Tensor {
+    at::Tensor t;
+    auto it = weightsMeta.find(leaf.name);
+    if (it == weightsMeta.end() || it->second.hasSymbolicShape()) {
+      t = generateTensor(leaf);
+    } else {
+      LeafSpec adjusted = leaf;
+      adjusted.dims = it->second.sizes().vec();
+      adjusted.dtype = c10::toString(it->second.dtype());
+      if (adjusted.hasValues &&
+          static_cast<int64_t>(adjusted.values.size()) !=
+              product(adjusted.dims)) {
+        adjusted.hasValues = false;
+        adjusted.values.clear();
+      }
+      t = generateTensor(adjusted);
+    }
+    return weightDevice.is_cpu() ? t : t.to(weightDevice);
+  };
+
+  for (const auto& leaf : spec.leaves) {
+    switch (leaf.kind) {
+      case LeafKind::kUserInput:
+        if (leaf.inputIndex >= 0) {
+          out.userInputs[leaf.inputIndex] = generateTensor(leaf);
+        }
+        break;
+      case LeafKind::kUserInputScalar:
+        if (leaf.inputIndex >= 0) {
+          out.userInputs[leaf.inputIndex] = generateScalar(leaf);
+        }
+        break;
+      case LeafKind::kParameter:
+      case LeafKind::kBuffer:
+        stateDict[leaf.name] = generateWeight(leaf);
+        break;
+      case LeafKind::kConstant:
+        constants[leaf.name] = generateWeight(leaf);
+        break;
+    }
+  }
+
+  out.weights = std::make_shared<nativert::Weights>(
+      &graph,
+      stateDict.empty()
+          ? std::nullopt
+          : std::optional<std::unordered_map<std::string, c10::IValue>>(
+                std::move(stateDict)),
+      constants.empty()
+          ? std::nullopt
+          : std::optional<std::unordered_map<std::string, c10::IValue>>(
+                std::move(constants)));
+  LOG(INFO) << "DataGen: generated data for " << spec.leaves.size()
+            << " leaves (seed " << actualSeed << ")";
+  return out;
+}
+
+} // namespace torch::wave

--- a/velox/experimental/torchwave/tests/DataGen.h
+++ b/velox/experimental/torchwave/tests/DataGen.h
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <ATen/ATen.h>
+#include <torch/nativert/executor/Weights.h>
+#include <torch/nativert/graph/Graph.h>
+
+namespace torch::wave {
+
+/// Where a leaf value comes from in the graph. User inputs are supplied per
+/// run; the rest are persistent weights (Weights, keyed by name).
+enum class LeafKind {
+  kUserInput = 0, ///< A user-supplied graph input tensor.
+  kUserInputScalar =
+      1, ///< A user-supplied graph input scalar (int/float/bool).
+  kParameter = 2, ///< A model parameter (Weights).
+  kBuffer = 3, ///< A model buffer (Weights).
+  kConstant = 4, ///< A tensor constant (Weights).
+};
+
+/// Statistical description of one leaf tensor (or scalar) of a model, produced
+/// by analyzing a real dataset. It captures enough to regenerate synthetic data
+/// in the same general range and with a similar number of distinct values,
+/// without keeping the original (possibly private) data. Small tensors and
+/// detected offset arrays keep their exact values.
+struct LeafSpec {
+  LeafKind kind{LeafKind::kUserInput};
+
+  /// Graph value id (informational; weights are matched by name, user inputs by
+  /// position).
+  int32_t valueId{-1};
+  /// Weight FQN (empty for user inputs).
+  std::string name;
+  /// Position in graph.userInputs() (only for user inputs; -1 otherwise).
+  int32_t inputIndex{-1};
+
+  /// c10::ScalarType name (e.g. "Float", "Long"). Empty for non-tensor scalars,
+  /// which use 'scalarValue' instead.
+  std::string dtype;
+  std::vector<int64_t> dims;
+  std::vector<int64_t> strides;
+
+  double minVal{0};
+  double maxVal{0};
+  int64_t distinctCount{0};
+  double sum{0};
+
+  /// True when this int/long tensor looks like a jagged offsets array
+  /// (ascending, last element within 5% of some other leaf's element count).
+  bool isOffsets{false};
+
+  /// When true, 'values' lists every element (offsets, or small tensors); the
+  /// generator reproduces them exactly.
+  bool hasValues{false};
+  std::vector<double> values;
+
+  /// For a scalar user input (kUserInputScalar): the exact value, reproduced
+  /// as-is.
+  double scalarValue{0};
+  /// "int" | "float" | "bool" for a scalar user input.
+  std::string scalarType;
+};
+
+/// A full dataset specification: one entry per leaf value of the model.
+struct DatasetSpec {
+  std::vector<LeafSpec> leaves;
+  /// Optional seed used at generation time (0 means unset / caller-provided).
+  uint64_t seed{0};
+};
+
+/// Analyzes the real leaf values of a model and writes a DatasetSpec as JSON to
+/// 'specPath'. 'userInputs' are the actual user inputs (positional, matching
+/// graph.userInputs()); the weights are read from 'weights'. This is the
+/// analysis half of the synthesizer -- its input is the actual dataset, its
+/// output is a per-tensor specification.
+void makeDatasetSpec(
+    const nativert::Graph& graph,
+    const nativert::Weights& weights,
+    const std::vector<c10::IValue>& userInputs,
+    const std::string& specPath);
+
+/// Parses a DatasetSpec JSON file (does not generate any tensors).
+DatasetSpec loadDatasetSpec(const std::string& specPath);
+
+/// Result of generating synthetic data from a DatasetSpec: freshly built
+/// Weights bound to 'graph' plus the positional user inputs (CPU tensors /
+/// scalars).
+struct GeneratedData {
+  std::shared_ptr<nativert::Weights> weights;
+  std::vector<c10::IValue> userInputs;
+};
+
+/// Reads the spec at 'specPath' and generates pseudorandom synthetic data for
+/// 'graph': a Weights object with all parameters/buffers/constants filled, and
+/// the positional user inputs. Values are drawn to match each leaf's recorded
+/// range and distinct-value count; offsets and small tensors are reproduced
+/// exactly. If 'seed' is set it overrides the spec's seed; generation is
+/// deterministic for a given seed. User-input tensors are created on CPU;
+/// weights are placed on 'weightDevice' (default CPU) so a GPU reference run
+/// gets device-resident weights consistent with a device-placed graph.
+GeneratedData generateFromSpec(
+    const nativert::Graph& graph,
+    const std::string& specPath,
+    std::optional<uint64_t> seed = std::nullopt,
+    c10::Device weightDevice = c10::kCPU);
+
+} // namespace torch::wave

--- a/velox/experimental/torchwave/tests/ExecutorTest.cpp
+++ b/velox/experimental/torchwave/tests/ExecutorTest.cpp
@@ -29,6 +29,21 @@ DEFINE_string(
     custom,
     "",
     "Custom test model base name (without .pt2/.pt extension)");
+DEFINE_string(
+    save_model,
+    "",
+    "With --custom: save the graph as <save_model>.pt2 and a synthetic-data "
+    "spec as <save_model>.spec");
+DEFINE_string(
+    run_synthetic,
+    "",
+    "Load the graph from <run_synthetic>.pt2 and the spec from "
+    "<run_synthetic>.spec, generate synthetic data, and run nativert-GPU "
+    "reference vs wave");
+DEFINE_int64(
+    synthetic_seed,
+    0,
+    "Seed for --run_synthetic data generation (deterministic)");
 DECLARE_string(reference_frame);
 
 namespace torch::wave {
@@ -453,6 +468,34 @@ TEST_F(ExecutorTest, custom) {
     return;
   }
   runTest(FLAGS_custom + ".pt2", FLAGS_custom + "_results.pt");
+}
+
+// Saves the --custom graph as <save_model>.pt2 and a synthetic-data spec as
+// <save_model>.spec. The spec is analyzed from the model's sample inputs and
+// weights so a later --run_synthetic can reproduce a same-shape dataset.
+TEST_F(ExecutorTest, saveModel) {
+  if (FLAGS_save_model.empty()) {
+    return;
+  }
+  ASSERT_FALSE(FLAGS_custom.empty()) << "--save_model requires --custom";
+  auto pt2Path = FLAGS_custom.front() == '/'
+      ? FLAGS_custom + ".pt2"
+      : getDataFilePath(dataDir(), FLAGS_custom + ".pt2");
+  auto fixture = ModelFixture::load(pt2Path);
+  ASSERT_NE(fixture, nullptr);
+  auto inputs = loadSampleInputs(*fixture);
+  saveSyntheticModel(*fixture, inputs, FLAGS_save_model);
+}
+
+// Loads a saved graph + spec, generates synthetic data, and checks wave against
+// the nativert-GPU reference (outputs and reference frame).
+TEST_F(ExecutorTest, runSynthetic) {
+  if (FLAGS_run_synthetic.empty()) {
+    return;
+  }
+  runSynthetic(
+      FLAGS_run_synthetic,
+      std::optional<uint64_t>(static_cast<uint64_t>(FLAGS_synthetic_seed)));
 }
 
 // Per-fix isolating tests for the ads-preproc torchwave fixes (each fails when

--- a/velox/experimental/torchwave/tests/ExecutorTestBase.cpp
+++ b/velox/experimental/torchwave/tests/ExecutorTestBase.cpp
@@ -16,16 +16,21 @@
 
 #include "velox/experimental/torchwave/tests/ExecutorTestBase.h"
 
+#include <unistd.h>
+
 #include <algorithm>
 #include <chrono>
+#include <cstdio>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <map>
+#include <unordered_map>
 #include <unordered_set>
 
 #include <ATen/cuda/CUDAContext.h>
 #include <cuda_runtime.h> // @manual
+#include <folly/compression/Compression.h>
 #include <glog/logging.h>
 #include <torch/csrc/export/pt2_archive_constants.h>
 #include <torch/csrc/jit/serialization/pickle.h>
@@ -240,6 +245,71 @@ void fillFrameInputs(
       frame.setIValue(value->id(), std::move(flat[flatIdx++]));
     }
   }
+}
+
+// Fill a frame from inputs already aligned 1:1 with graph.userInputs(), e.g.
+// synthetic data generated per user input. Unlike fillFrameInputs this does not
+// re-flatten and keys off graph.userInputs() rather than the signature's
+// userInputs: for models like the ROO preproc the two lists differ in length
+// (graph.userInputs() includes the optional/None leaves the signature omits),
+// and only graph.userInputs() aligns positionally with the generated data.
+void fillFrameFromUserInputs(
+    const nativert::Graph& graph,
+    nativert::ExecutionFrame& frame,
+    const std::vector<c10::IValue>& inputs) {
+  const auto& userInputs = graph.userInputs();
+  for (size_t i = 0; i < userInputs.size() && i < inputs.size(); ++i) {
+    if (userInputs[i] && !inputs[i].isNone()) {
+      if (inputs[i].isTensor()) {
+        frame.setIValue(
+            userInputs[i]->id(), c10::IValue(inputs[i].toTensor().clone()));
+      } else {
+        frame.setIValue(userInputs[i]->id(), inputs[i]);
+      }
+    }
+  }
+}
+
+// Removes aten._assert_async runtime data-validation nodes from the graph.
+// These guard real-data invariants (e.g. "num_candidates must be all True",
+// "labels must equal label presences") that random synthetic data does not
+// satisfy, so they fire spurious device-side asserts on a synthetic run. Their
+// outputs are unused, so removal is safe; mirrors nativert's RemoveDetach pass.
+void stripDataAsserts(nativert::Graph& graph) {
+  std::vector<nativert::Node*> toDrop;
+  for (auto& node : graph.nodes()) {
+    if (node.target() == "torch.ops.aten._assert_async.msg") {
+      toDrop.push_back(&node);
+    }
+  }
+  if (toDrop.empty()) {
+    return;
+  }
+  for (auto* node : toDrop) {
+    node->destroy();
+  }
+  graph.renumberValues();
+  graph.finalize();
+  graph.lint();
+  LOG(INFO) << "stripDataAsserts: removed " << toDrop.size()
+            << " _assert_async node(s)";
+}
+
+// Decompresses a gzipped file to a fresh temp file and returns its path. The
+// committed synthetic-graph archives are stored as <name>.pt2.gz because the
+// raw graph JSON is far over the repo's per-file size limit; this restores a
+// plain .pt2 the PyTorchStreamReader can open. Caller removes the temp file.
+std::string decompressGzToTemp(const std::string& gzPath) {
+  auto data = readFile(gzPath);
+  auto codec =
+      folly::compression::getCodec(folly::compression::CodecType::GZIP);
+  std::string out =
+      codec->uncompress(folly::StringPiece(data.data(), data.size()));
+  std::string tmp = "/tmp/torchwave_synth_" + std::to_string(getpid()) + ".pt2";
+  std::ofstream o(tmp, std::ios::binary | std::ios::trunc);
+  TORCH_CHECK(o.is_open(), "Cannot write temp pt2: ", tmp);
+  o.write(out.data(), static_cast<std::streamsize>(out.size()));
+  return tmp;
 }
 
 } // namespace
@@ -1213,6 +1283,205 @@ void ExecutorTestBase::verifyOutputs(
       ADD_FAILURE() << fullLabel << " output " << i
                     << " unsupported expected type: " << exp.tagKind();
     }
+  }
+}
+
+void saveModelArchive(
+    caffe2::serialize::PyTorchStreamReader& reader,
+    const std::string& outPath) {
+  caffe2::serialize::PyTorchStreamWriter writer(outPath);
+  for (const auto& name : reader.getAllRecords()) {
+    // Drop the data sections (data/weights, data/constants,
+    // data/sample_inputs): the real tensors may contain user data that must not
+    // be checked in, and omitting them keeps the test archive small. Synthetic
+    // weights and inputs are regenerated from the .spec by --run_synthetic.
+    // Only the graph serialization (models/...) and archive metadata are kept.
+    if (name.rfind("data/", 0) == 0) {
+      continue;
+    }
+    auto [dataPtr, size] = reader.getRecord(name);
+    writer.writeRecord(name, dataPtr.get(), size);
+  }
+  writer.writeEndOfFile();
+}
+
+std::unique_ptr<ModelFixture> ExecutorTestBase::loadSyntheticFixture(
+    const std::string& pt2Path) {
+  // Graph-only load: the saved archive has empty data sections, so weights are
+  // not read from it -- they are generated from the spec and assigned by the
+  // caller.
+  auto fixture = std::make_unique<ModelFixture>();
+  fixture->pt2Path = pt2Path;
+  fixture->reader = std::make_shared<caffe2::serialize::PyTorchStreamReader>(
+      std::make_unique<caffe2::serialize::FileAdapter>(pt2Path));
+  auto modelNames = getModelNames(*fixture->reader);
+  if (modelNames.empty()) {
+    return nullptr;
+  }
+  fixture->model = loadPt2Model(fixture->reader, modelNames[0]);
+  ModelFixture::prepareGraph(fixture->model.graph.get());
+  return fixture;
+}
+
+void ExecutorTestBase::saveSyntheticModel(
+    ModelFixture& fixture,
+    const std::vector<c10::IValue>& inputs,
+    const std::string& path) {
+  makeDatasetSpec(
+      *fixture.model.graph, *fixture.weights, inputs, path + ".spec");
+  saveModelArchive(*fixture.reader, path + ".pt2");
+  LOG(INFO) << "Saved synthetic model to " << path << ".pt2 and " << path
+            << ".spec";
+}
+
+std::vector<c10::IValue> ExecutorTestBase::runNativertReferenceWithInputs(
+    ModelFixture& fixture,
+    std::vector<c10::IValue> inputs,
+    const std::string& refFramePath) {
+  auto& graph = *fixture.model.graph;
+  // Match wave's graph before running: drop runtime data-validation asserts
+  // that synthetic data cannot satisfy, apply the subclass rewrites (e.g.
+  // merge_and_dedup -> _tw) so both use the same kernel, then place on GPU and
+  // insert the cpuOnly copies the generic nativert executor needs. The weights
+  // are already GPU-resident (see runSynthetic), so ops that mix weights with
+  // device inputs stay on one device -- the piece a CPU-weight reference got
+  // wrong (isin / _assert_tensor_metadata device mismatches).
+  stripDataAsserts(graph);
+  applySyntheticGraphRewrites(graph);
+  setGraphDevice(&graph, true);
+  rewriteGpuIncompatibleOps(graph);
+  insertCpuOnlyCopies(graph);
+
+  nativert::SerialGraphExecutor executor(
+      graph, fixture.makeKernels(), fixture.config);
+  auto frame = std::make_unique<nativert::ExecutionFrame>(
+      graph, *fixture.weights, fixture.config);
+
+  auto [deviceInputs, dataMovUs] = inputsToDevice(inputs);
+  auto* waveDevice = facebook::velox::wave::currentDevice();
+  if (!waveDevice) {
+    waveDevice = facebook::velox::wave::getDevice();
+  }
+  at::cuda::set_device(static_cast<c10::DeviceIndex>(waveDevice->deviceId));
+
+  fillFrameFromUserInputs(graph, *frame, deviceInputs);
+  auto outputs = executor.executeWithPrefilledFrame(*frame);
+  if (!refFramePath.empty()) {
+    saveReferenceFrame(*frame, graph, refFramePath);
+  }
+  return outputsToHost(outputs, "synthetic-ref");
+}
+
+void ExecutorTestBase::runWaveWithInputs(
+    ModelFixture& fixture,
+    std::vector<c10::IValue> inputs,
+    const std::vector<c10::IValue>& expected,
+    const std::string& refFramePath) {
+  std::unordered_map<int32_t, c10::IValue> refFrame;
+  if (!refFramePath.empty()) {
+    refFrame = loadReferenceFrame(refFramePath);
+    WaveConfig::get().referenceFrame = &refFrame;
+  }
+
+  WaveGraphExecutor waveExec(fixture.makeModelContext());
+  auto& graph = waveExec.graph();
+  auto pooledFrame = waveExec.getFrame();
+
+  auto [deviceInputs, dataMovUs] = inputsToDevice(inputs);
+  fillFrameFromUserInputs(graph, *pooledFrame, deviceInputs);
+  auto waveOutputs = waveExec.executeWithPrefilledFrame(*pooledFrame);
+  waveExec.returnFrame(std::move(pooledFrame));
+
+  lastRefTensorsChecked_ = waveExec.numRefTensorsChecked();
+  lastRefNodesChecked_ = waveExec.numRefNodesChecked();
+  WaveConfig::get().referenceFrame = nullptr;
+  if (!refFramePath.empty()) {
+    LOG(INFO) << "synthetic-wave reference frame: checked "
+              << lastRefTensorsChecked_ << " tensors, " << lastRefNodesChecked_
+              << " nodes";
+  }
+
+  auto hostOutputs = outputsToHost(waveOutputs, "synthetic-wave");
+
+  // Compare wave outputs against the nativert reference the way the sigmoid
+  // [refout] check does: tensors only, non-fatal, counting mismatches. Some
+  // final outputs are legitimately None in wave (unmaterialized), so a strict
+  // verifyOutputs would spuriously fail; the per-intermediate reference-frame
+  // check above is the strict correctness gate.
+  size_t numToCheck = std::min(hostOutputs.size(), expected.size());
+  int compared = 0, mismatched = 0, skipped = 0;
+  for (size_t i = 0; i < numToCheck; ++i) {
+    if (!expected[i].isTensor() || !hostOutputs[i].isTensor()) {
+      ++skipped;
+      continue;
+    }
+    ++compared;
+    auto actual = hostOutputs[i].toTensor();
+    auto exp = expected[i].toTensor();
+    if (actual.sizes() != exp.sizes() || !tensorsMatch(actual, exp)) {
+      ++mismatched;
+      LOG(ERROR) << "synthetic-wave output " << i
+                 << " differs from reference: " << firstDifference(actual, exp);
+    }
+  }
+  LOG(INFO) << "synthetic-wave: " << compared << " outputs compared, "
+            << mismatched << " mismatched, " << skipped
+            << " skipped (non-tensor)";
+  EXPECT_EQ(mismatched, 0) << "synthetic-wave: " << mismatched
+                           << " output(s) differ from the nativert reference";
+}
+
+void ExecutorTestBase::runSynthetic(
+    const std::string& path,
+    std::optional<uint64_t> seed) {
+  std::string pt2Path = path + ".pt2";
+  const std::string specPath = path + ".spec";
+
+  // Committed graph archives are gzipped (<path>.pt2.gz) to stay under the repo
+  // per-file size limit. When the plain .pt2 is absent, decompress to a temp
+  // file and load that.
+  std::string tempPt2;
+  if (!std::filesystem::exists(pt2Path) &&
+      std::filesystem::exists(pt2Path + ".gz")) {
+    tempPt2 = decompressGzToTemp(pt2Path + ".gz");
+    pt2Path = tempPt2;
+  }
+
+  // Weights are placed on the wave GPU so the GPU reference (and wave) run with
+  // device-resident weights that match the device-placed graphs.
+  auto* waveDevice = facebook::velox::wave::currentDevice();
+  if (!waveDevice) {
+    waveDevice = facebook::velox::wave::getDevice();
+  }
+  c10::Device weightDevice(
+      c10::kCUDA, static_cast<c10::DeviceIndex>(waveDevice->deviceId));
+
+  // Reference run: a fresh graph with generated data on the nativert GPU
+  // executor produces the reference outputs and a reference frame.
+  auto refFixture = loadSyntheticFixture(pt2Path);
+  ASSERT_NE(refFixture, nullptr);
+  auto generated =
+      generateFromSpec(*refFixture->model.graph, specPath, seed, weightDevice);
+  refFixture->weights = generated.weights;
+
+  const std::string refFramePath =
+      "/tmp/torchwave_synthetic_ref_" + std::to_string(getpid()) + ".pt";
+  auto expected = runNativertReferenceWithInputs(
+      *refFixture, generated.userInputs, refFramePath);
+
+  // Wave run: another fresh graph, the same generated weights and inputs,
+  // verified against the reference outputs and the reference frame.
+  auto waveFixture = loadSyntheticFixture(pt2Path);
+  ASSERT_NE(waveFixture, nullptr);
+  waveFixture->weights = generated.weights;
+  stripDataAsserts(*waveFixture->model.graph);
+  applySyntheticGraphRewrites(*waveFixture->model.graph);
+  setGraphDevice(waveFixture->model.graph.get(), true);
+  runWaveWithInputs(*waveFixture, generated.userInputs, expected, refFramePath);
+
+  std::remove(refFramePath.c_str());
+  if (!tempPt2.empty()) {
+    std::remove(tempPt2.c_str());
   }
 }
 

--- a/velox/experimental/torchwave/tests/ExecutorTestBase.h
+++ b/velox/experimental/torchwave/tests/ExecutorTestBase.h
@@ -20,6 +20,7 @@
 
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -31,6 +32,7 @@
 
 #include "velox/experimental/torchwave/Executor.h"
 #include "velox/experimental/torchwave/Pt2Load.h"
+#include "velox/experimental/torchwave/tests/DataGen.h"
 
 namespace torch::wave {
 
@@ -132,6 +134,16 @@ std::vector<c10::IValue> outputsToHost(
 /// time first. Each node is serialized as in Launch::toString.
 void standaloneReport(WaveGraphExecutor& executor);
 
+/// Copies 'reader's records into a fresh archive at 'outPath', dropping the
+/// data sections (data/weights, data/constants, data/sample_inputs) so the
+/// result carries only the graph serialization and archive metadata. Used by
+/// --save_model to write a small, data-free graph archive (a .pt2 for a .pt2
+/// source, or the sigmoid graph for a sigmoid source) that --run_synthetic
+/// loads and pairs with synthetic weights and inputs from the spec.
+void saveModelArchive(
+    caffe2::serialize::PyTorchStreamReader& reader,
+    const std::string& outPath);
+
 /// Base test fixture for running .pt2 models through serial and wave executors.
 class ExecutorTestBase : public ::testing::Test {
  protected:
@@ -198,6 +210,56 @@ class ExecutorTestBase : public ::testing::Test {
   virtual std::string dataDir() const {
     return "velox/experimental/torchwave/tests";
   }
+
+  /// Loads the graph archive for --run_synthetic. The base loads a standard
+  /// .pt2 (JSON). The meta harness overrides this to also accept a sigmoid
+  /// (thrift) archive.
+  virtual std::unique_ptr<ModelFixture> loadSyntheticFixture(
+      const std::string& pt2Path);
+
+  /// Subclass hook applied to both the reference and wave graphs in
+  /// runSynthetic, before device placement, so the two runs use the same
+  /// kernels. The meta harness overrides this to rewrite
+  /// fused_datafm_merge_and_dedup_by_reference to its _tw variant (the
+  /// reference and _tw dedup implementations differ, so comparing them directly
+  /// produces spurious mismatches). Default: no-op.
+  virtual void applySyntheticGraphRewrites(nativert::Graph& /*graph*/) {}
+
+  /// --save_model: writes 'path.spec' (a DatasetSpec analyzed from 'inputs' and
+  /// the fixture's weights) and 'path.pt2' (a copy of the source archive).
+  void saveSyntheticModel(
+      ModelFixture& fixture,
+      const std::vector<c10::IValue>& inputs,
+      const std::string& path);
+
+  /// --run_synthetic: loads 'path.pt2' and 'path.spec', generates synthetic
+  /// data, runs the nativert GPU reference to produce reference outputs (and a
+  /// reference frame), then runs wave on the same data and verifies it against
+  /// both. 'seed' is optional; when unset the spec's seed is used.
+  void runSynthetic(
+      const std::string& path,
+      std::optional<uint64_t> seed = std::nullopt);
+
+  /// Runs 'fixture' through the nativert serial executor on GPU with explicit
+  /// 'inputs' (not loadSampleInputs). Applies applySyntheticGraphRewrites, then
+  /// GPU placement (setGraphDevice / rewriteGpuIncompatibleOps /
+  /// insertCpuOnlyCopies) so the reference runs on the same device and kernels
+  /// as wave. The fixture's weights must already be GPU-resident. Returns the
+  /// host outputs and, if 'refFramePath' is non-empty, saves the post-run frame
+  /// there as a reference frame.
+  std::vector<c10::IValue> runNativertReferenceWithInputs(
+      ModelFixture& fixture,
+      std::vector<c10::IValue> inputs,
+      const std::string& refFramePath);
+
+  /// Runs 'fixture' through the wave executor with explicit 'inputs' and
+  /// verifies against 'expected'. If 'refFramePath' is non-empty it is loaded
+  /// as the reference frame so wave checks intermediates too.
+  void runWaveWithInputs(
+      ModelFixture& fixture,
+      std::vector<c10::IValue> inputs,
+      const std::vector<c10::IValue>& expected,
+      const std::string& refFramePath);
 
   /// Counters copied from WaveGraphExecutor after runWave.
   int64_t lastRefTensorsChecked_{0};


### PR DESCRIPTION
Summary:

Adds a synthetic-dataset generator plus end-to-end tests that run the ROO preproc graphs on generated data, so we can exercise the full preproc pipeline (including the data-dependent sparse ops) without checking in real, possibly user-derived, data.

New `DataGen` (`velox/experimental/torchwave/tests/DataGen.{h,cpp}`) has two halves. `makeDatasetSpec` analyzes a real dataset into a per-leaf JSON spec: for each user input and weight it records dtype, dims, strides, value range, distinct-value count, and sum -- but not the raw values, except for structural integer tensors it must reproduce exactly. `generateFromSpec` reads a spec and regenerates pseudorandom data (deterministic per seed): values are drawn to match the recorded range and distinct-value count, and weights are placed on the target device.

Two structural-tensor heuristics keep the regenerated data self-consistent so the graph's data-dependent ops stay in bounds: an offsets array (ascending int tensor whose last element is within 5% of some tensor's element count) and a lengths array (int tensor whose element sum is within 5% of some tensor's element count) are both recorded and reproduced exactly. Without the lengths heuristic the sparse ops (`GroupLengthGuardSparse` / batch_flip, merge_and_dedup) memcpy each group past the values buffer and segfault.

`ExecutorTestBase::stripDataAsserts` removes `aten._assert_async` runtime data-validation nodes before running. These guard real-data invariants (e.g. "num_candidates must be all True", "labels must equal label presences") that random synthetic data cannot satisfy; their outputs are unused so removal is safe (mirrors nativert's RemoveDetach pass).

The harness (`ExecutorTestBase::runSynthetic`) loads a data-free graph archive plus its spec, generates data, runs the nativert GPU reference, and verifies wave against it -- both the final outputs and the per-intermediate reference frame. Two subtleties worth calling out: (1) synthetic inputs are aligned to `graph.userInputs()` (e.g. 590 leaves for the ROO preproc), not `graph.signature().userInputs()` (298, which omits the optional/None leaves), so the frame is filled positionally over `graph.userInputs()` via `fillFrameFromUserInputs`; (2) the reference and wave graphs both rewrite `fused_datafm_merge_and_dedup_by_reference` to its `_tw` variant (via the `applySyntheticGraphRewrites` hook) so they run the same dedup kernel -- the by_reference and `_tw` implementations dedup differently and would otherwise disagree.

Flags `--save_model <path>` (writes `<path>.pt2` with data sections emptied plus `<path>.spec`) and `--run_synthetic <path>` drive it manually. Two committed tests run at a fixed seed: `syntheticRooPreproc` on `data/roo_synth.*` (the ROO preproc graph) and `syntheticRooTrainPreproc` on `data/roo_train_synth.*` (the larger ROO train-preproc graph, whose `_assert_async` guards are stripped). Both are gated behind `--run_heavy_synthetic` and skipped by default: cold-compiling the ~11k-node graph with no kernel cache is ~3.5 min each, which would risk CI timeouts, so they run on demand only (the cheap tests in the target stay on per-diff CI).

The committed graph archives are gzipped (`data/*.pt2.gz`, ~0.5-0.65 MB each vs 11-17 MB raw) to stay under the repo's 5 MB per-file commit hook; `runSynthetic` decompresses `<path>.pt2.gz` to a temp `.pt2` at load time (`decompressGzToTemp`, folly GZIP codec).

Verified the regenerated data has cardinalities comparable to real data on the data-dependent ops. For the train-preproc graph the `grouped_masked_select_jagged_1d` input matches exactly (4,429,726 in both, since it is driven by the recorded lengths), while the `merge_and_dedup` deduped output is ~19.7% larger (11.51M vs 9.61M) -- expected, since randomly drawn synthetic values collide/dedup less than naturally clustered real data.

Differential Revision: D110518376
