### PR TITLE
fix: Fix thread-local runtime stat writer leak in SortBufferTest

### DIFF
--- a/velox/exec/tests/SortBufferTest.cpp
+++ b/velox/exec/tests/SortBufferTest.cpp
@@ -63,6 +63,7 @@ class SortBufferTest : public OperatorTestBase,
   }
 
   void TearDown() override {
+    setThreadLocalRunTimeStatWriter(nullptr);
     pool_.reset();
     rootPool_.reset();
     OperatorTestBase::TearDown();


### PR DESCRIPTION
SortBufferTest::SetUp installs a thread-local RuntimeStatWriter via [setThreadLocalRunTimeStatWriter](vscode-file://vscode-app/snap/code/248/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), but TearDown never reset it to nullptr. Because GTest reuses the same thread across test suites, the pointer became dangling after the stat writer object was destroyed, causing a SIGSEGV in unrelated tests that ran afterward on the same thread (e.g. IndexLookupJoinTest) when the DWRF writer tried to log metrics via addThreadLocalRuntimeStat.