### PR TITLE
fix: Prevent VectorFuzzer crash when normalizing encoded map keys

### DIFF
--- a/velox/vector/fuzzer/VectorFuzzer.cpp
+++ b/velox/vector/fuzzer/VectorFuzzer.cpp
@@ -794,6 +794,10 @@ VectorPtr VectorFuzzer::normalizeMapKeys(
   auto rawOffsets = offsets->as<vector_size_t>();
   auto rawSizes = sizes->asMutable<vector_size_t>();
 
+  // Keys may be dictionary/constant/lazy encoded; decode so values can be read
+  // regardless of encoding.
+  DecodedVector decodedKeys(*keys);
+
   // Looks for duplicate key values.
   std::unordered_set<uint64_t> set;
   for (size_t i = 0; i < mapSize; ++i) {
@@ -807,7 +811,7 @@ VectorPtr VectorFuzzer::normalizeMapKeys(
 
     for (size_t j = 0; j < rawSizes[i]; ++j) {
       vector_size_t idx = rawOffsets[i] + j;
-      uint64_t hash = keys->hashValueAt(idx);
+      uint64_t hash = decodedKeys.base()->hashValueAt(decodedKeys.index(idx));
 
       // If we find the same hash (either same key value or hash colision), we
       // cut it short by reducing this element's map size. This should not

--- a/velox/vector/fuzzer/tests/VectorFuzzerTest.cpp
+++ b/velox/vector/fuzzer/tests/VectorFuzzerTest.cpp
@@ -680,6 +680,32 @@ TEST_F(VectorFuzzerTest, mapKeys) {
   }
 }
 
+// Regression test: normalizeMapKeys must read keys through decoding so non-flat
+// encodings work. A dictionary wrapping an unloaded lazy vector has no value
+// accessor until decoded; hashing it directly used to deref null.
+TEST_F(VectorFuzzerTest, normalizeMapKeysEncodedKeys) {
+  VectorFuzzer::Options opts;
+  opts.nullRatio = 0;
+  opts.dictionaryHasNulls = false;
+  opts.normalizeMapKeys = true;
+  VectorFuzzer fuzzer(opts, pool());
+
+  // Build DICTIONARY(LAZY(FLAT)) non-null keys, left unloaded.
+  auto keys = fuzzer.fuzzDictionary(
+      VectorFuzzer::wrapInLazyVector(fuzzer.fuzzFlat(BIGINT(), 1000)));
+  ASSERT_TRUE(VectorEncoding::isDictionary(keys->encoding()));
+  ASSERT_TRUE(isLazyNotLoaded(*keys->valueVector()));
+
+  VectorPtr vector;
+  ASSERT_NO_THROW(
+      vector = fuzzer.fuzzMap(keys, fuzzer.fuzzFlat(BIGINT(), 1000), 10));
+
+  // Materialize the lazy layer so the uniqueness check can read key values,
+  // then verify normalization actually deduplicated keys.
+  vector->as<MapVector>()->mapKeys()->loadedVector();
+  assertMapKeys(vector->as<MapVector>());
+}
+
 TEST_F(VectorFuzzerTest, row) {
   VectorFuzzer::Options opts;
   opts.nullRatio = 0.5;


### PR DESCRIPTION
When fuzzing a map with `opts.normalizeMapKeys` enabled, `VectorFuzzer::fuzzMap` would crash if it was supplied with a dictionary wrapped around an unloaded lazy vector. This can happen if the keys are built by a separate `fuzz()` call and passed to the `fuzzMap(keys, values, size)` overload. The crash occurred because the code directly used `hashValueAt`, which fails when called on such a vector, since it does not ensure the underlying lazy vector is loaded before attempting to access it.

This change fixes this by ensuring the fuzzer correctly handles any encoded vector when normalizing keys.

Differential Revision: D110792214


