### PR TITLE
refactor(exec): Rename OutputBufferManager to DefaultOutputBufferManager

### DIFF
--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -72,7 +72,7 @@ velox_add_library(
   OperatorUtils.cpp
   OrderBy.cpp
   OutputBuffer.cpp
-  OutputBufferManager.cpp
+  DefaultOutputBufferManager.cpp
   ParallelProject.cpp
   PartitionFunction.cpp
   PartitionedOutput.cpp
@@ -172,7 +172,7 @@ velox_add_library(
   OperatorUtils.h
   OrderBy.h
   OutputBuffer.h
-  OutputBufferManager.h
+  DefaultOutputBufferManager.h
   ParallelProject.h
   PartitionFunction.h
   PartitionedOutput.h

--- a/velox/exec/DefaultOutputBufferManager.cpp
+++ b/velox/exec/DefaultOutputBufferManager.cpp
@@ -13,26 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/exec/OutputBufferManager.h"
+#include "velox/exec/DefaultOutputBufferManager.h"
 #include "velox/exec/Task.h"
 
 namespace facebook::velox::exec {
 
 // static
-const std::shared_ptr<OutputBufferManager>&
-OutputBufferManager::getInstanceRef() {
+const std::shared_ptr<DefaultOutputBufferManager>&
+DefaultOutputBufferManager::getInstanceRef() {
   return getInstanceRef(Options());
 }
 
 // static
-const std::shared_ptr<OutputBufferManager>& OutputBufferManager::getInstanceRef(
-    const Options& options) {
-  static const std::shared_ptr<OutputBufferManager> instance =
-      std::make_shared<OutputBufferManager>(options);
+const std::shared_ptr<DefaultOutputBufferManager>&
+DefaultOutputBufferManager::getInstanceRef(const Options& options) {
+  static const std::shared_ptr<DefaultOutputBufferManager> instance =
+      std::make_shared<DefaultOutputBufferManager>(options);
   return instance;
 }
 
-std::shared_ptr<OutputBuffer> OutputBufferManager::getBuffer(
+std::shared_ptr<OutputBuffer> DefaultOutputBufferManager::getBuffer(
     const std::string& taskId) {
   return buffers_.withLock([&](auto& buffers) {
     auto it = buffers.find(taskId);
@@ -42,7 +42,7 @@ std::shared_ptr<OutputBuffer> OutputBufferManager::getBuffer(
   });
 }
 
-std::shared_ptr<OutputBuffer> OutputBufferManager::getBufferIfExists(
+std::shared_ptr<OutputBuffer> DefaultOutputBufferManager::getBufferIfExists(
     const std::string& taskId) {
   return buffers_.withLock([&](auto& buffers) {
     auto it = buffers.find(taskId);
@@ -50,11 +50,11 @@ std::shared_ptr<OutputBuffer> OutputBufferManager::getBufferIfExists(
   });
 }
 
-uint64_t OutputBufferManager::numBuffers() const {
+uint64_t DefaultOutputBufferManager::numBuffers() const {
   return buffers_.lock()->size();
 }
 
-bool OutputBufferManager::enqueue(
+bool DefaultOutputBufferManager::enqueue(
     const std::string& taskId,
     int destination,
     std::unique_ptr<SerializedPageBase> data,
@@ -62,15 +62,15 @@ bool OutputBufferManager::enqueue(
   return getBuffer(taskId)->enqueue(destination, std::move(data), future);
 }
 
-void OutputBufferManager::noMoreData(const std::string& taskId) {
+void DefaultOutputBufferManager::noMoreData(const std::string& taskId) {
   getBuffer(taskId)->noMoreData();
 }
 
-bool OutputBufferManager::isFinished(const std::string& taskId) {
+bool DefaultOutputBufferManager::isFinished(const std::string& taskId) {
   return getBuffer(taskId)->isFinished();
 }
 
-void OutputBufferManager::acknowledge(
+void DefaultOutputBufferManager::acknowledge(
     const std::string& taskId,
     int destination,
     int64_t sequence) {
@@ -89,7 +89,7 @@ void OutputBufferManager::acknowledge(
   }
 }
 
-void OutputBufferManager::deleteResults(
+void DefaultOutputBufferManager::deleteResults(
     const std::string& taskId,
     int destination) {
   if (auto buffer = getBufferIfExists(taskId)) {
@@ -97,7 +97,7 @@ void OutputBufferManager::deleteResults(
   }
 }
 
-bool OutputBufferManager::getData(
+bool DefaultOutputBufferManager::getData(
     const std::string& taskId,
     int destination,
     uint64_t maxBytes,
@@ -111,7 +111,7 @@ bool OutputBufferManager::getData(
   return false;
 }
 
-void OutputBufferManager::initializeTask(
+void DefaultOutputBufferManager::initializeTask(
     std::shared_ptr<Task> task,
     core::PartitionedOutputNode::Kind kind,
     int numDestinations,
@@ -130,7 +130,7 @@ void OutputBufferManager::initializeTask(
   });
 }
 
-bool OutputBufferManager::updateOutputBuffers(
+bool DefaultOutputBufferManager::updateOutputBuffers(
     const std::string& taskId,
     int numBuffers,
     bool noMoreBuffers) {
@@ -141,7 +141,7 @@ bool OutputBufferManager::updateOutputBuffers(
   return false;
 }
 
-bool OutputBufferManager::updateNumDrivers(
+bool DefaultOutputBufferManager::updateNumDrivers(
     const std::string& taskId,
     uint32_t newNumDrivers) {
   if (auto buffer = getBufferIfExists(taskId)) {
@@ -151,7 +151,7 @@ bool OutputBufferManager::updateNumDrivers(
   return false;
 }
 
-void OutputBufferManager::removeTask(const std::string& taskId) {
+void DefaultOutputBufferManager::removeTask(const std::string& taskId) {
   auto buffer =
       buffers_.withLock([&](auto& buffers) -> std::shared_ptr<OutputBuffer> {
         auto it = buffers.find(taskId);
@@ -168,7 +168,7 @@ void OutputBufferManager::removeTask(const std::string& taskId) {
   }
 }
 
-std::string OutputBufferManager::toString() {
+std::string DefaultOutputBufferManager::toString() {
   return buffers_.withLock([](const auto& buffers) {
     std::stringstream out;
     out << "[BufferManager:" << std::endl;
@@ -180,7 +180,7 @@ std::string OutputBufferManager::toString() {
   });
 }
 
-double OutputBufferManager::getUtilization(const std::string& taskId) {
+double DefaultOutputBufferManager::getUtilization(const std::string& taskId) {
   auto buffer = getBufferIfExists(taskId);
   if (buffer != nullptr) {
     return buffer->getUtilization();
@@ -188,7 +188,7 @@ double OutputBufferManager::getUtilization(const std::string& taskId) {
   return 0;
 }
 
-bool OutputBufferManager::isOverutilized(const std::string& taskId) {
+bool DefaultOutputBufferManager::isOverutilized(const std::string& taskId) {
   auto buffer = getBufferIfExists(taskId);
   if (buffer != nullptr) {
     return buffer->isOverutilized();
@@ -196,7 +196,7 @@ bool OutputBufferManager::isOverutilized(const std::string& taskId) {
   return false;
 }
 
-std::optional<OutputBuffer::Stats> OutputBufferManager::stats(
+std::optional<OutputBuffer::Stats> DefaultOutputBufferManager::stats(
     const std::string& taskId) {
   auto buffer = getBufferIfExists(taskId);
   if (buffer != nullptr) {

--- a/velox/exec/DefaultOutputBufferManager.h
+++ b/velox/exec/DefaultOutputBufferManager.h
@@ -19,7 +19,7 @@
 
 namespace facebook::velox::exec {
 
-class OutputBufferManager {
+class DefaultOutputBufferManager {
  public:
   /// Options for shuffle. This is initialized once and affects both
   /// PartitionedOutput and Exchange. This can be used for controlling
@@ -27,7 +27,7 @@ class OutputBufferManager {
   /// agree.
   struct Options {};
 
-  explicit OutputBufferManager(Options) {}
+  explicit DefaultOutputBufferManager(Options) {}
 
   void initializeTask(
       std::shared_ptr<Task> task,
@@ -94,9 +94,9 @@ class OutputBufferManager {
 
   void removeTask(const std::string& taskId);
 
-  static const std::shared_ptr<OutputBufferManager>& getInstanceRef();
+  static const std::shared_ptr<DefaultOutputBufferManager>& getInstanceRef();
 
-  static const std::shared_ptr<OutputBufferManager>& getInstanceRef(
+  static const std::shared_ptr<DefaultOutputBufferManager>& getInstanceRef(
       const Options& options);
 
   uint64_t numBuffers() const;

--- a/velox/exec/Exchange.h
+++ b/velox/exec/Exchange.h
@@ -17,10 +17,10 @@
 
 #include <random>
 
+#include "velox/exec/DefaultOutputBufferManager.h"
 #include "velox/exec/ExchangeClient.h"
 #include "velox/exec/Operator.h"
 #include "velox/exec/OperatorType.h"
-#include "velox/exec/OutputBufferManager.h"
 #include "velox/serializers/PrestoSerializer.h"
 #include "velox/serializers/RowSerializer.h"
 

--- a/velox/exec/PartitionedOutput.cpp
+++ b/velox/exec/PartitionedOutput.cpp
@@ -15,9 +15,9 @@
  */
 
 #include "velox/exec/PartitionedOutput.h"
+#include "velox/exec/DefaultOutputBufferManager.h"
 #include "velox/exec/OperatorType.h"
 #include "velox/exec/OperatorUtils.h"
-#include "velox/exec/OutputBufferManager.h"
 #include "velox/exec/Task.h"
 
 namespace facebook::velox::exec {
@@ -48,7 +48,7 @@ BlockingReason Destination::advance(
     const RowVectorPtr& output,
     const row::CompactRow* outputCompactRow,
     const row::UnsafeRowFast* outputUnsafeRow,
-    OutputBufferManager& bufferManager,
+    DefaultOutputBufferManager& bufferManager,
     const std::function<void()>& bufferReleaseFn,
     bool* atEnd,
     ContinueFuture* future,
@@ -121,7 +121,7 @@ void Destination::clearVectorStreamGroup() {
 }
 
 BlockingReason Destination::flush(
-    OutputBufferManager& bufferManager,
+    DefaultOutputBufferManager& bufferManager,
     const std::function<void()>& bufferReleaseFn,
     ContinueFuture* future) {
   if (!current_ || rowsInCurrent_ == 0) {
@@ -215,7 +215,7 @@ PartitionedOutput::PartitionedOutput(
           planNode->inputType(),
           planNode->outputType(),
           planNode->outputType())),
-      bufferManager_(OutputBufferManager::getInstanceRef()),
+      bufferManager_(DefaultOutputBufferManager::getInstanceRef()),
       // NOTE: 'bufferReleaseFn_' holds a reference on the associated task to
       // prevent it from deleting while there are output buffers being accessed
       // out of the partitioned output buffer manager such as in Prestissimo,
@@ -429,7 +429,7 @@ RowVectorPtr PartitionedOutput::getOutput() {
   detail::Destination* blockedDestination = nullptr;
   auto bufferManager = bufferManager_.lock();
   VELOX_CHECK_NOT_NULL(
-      bufferManager, "OutputBufferManager was already destructed");
+      bufferManager, "DefaultOutputBufferManager was already destructed");
 
   // Limit serialized pages to 1MB.
   static const uint64_t kMaxPageSize = 1 << 20;

--- a/velox/exec/PartitionedOutput.h
+++ b/velox/exec/PartitionedOutput.h
@@ -16,8 +16,8 @@
 #pragma once
 
 #include <folly/Random.h>
+#include "velox/exec/DefaultOutputBufferManager.h"
 #include "velox/exec/Operator.h"
-#include "velox/exec/OutputBufferManager.h"
 #include "velox/row/CompactRow.h"
 #include "velox/row/UnsafeRowFast.h"
 #include "velox/vector/VectorStream.h"
@@ -28,7 +28,7 @@ namespace detail {
 class Destination {
  public:
   /// @param recordEnqueued Should be called to record each call to
-  /// OutputBufferManager::enqueue. Takes number of bytes and rows.
+  /// DefaultOutputBufferManager::enqueue. Takes number of bytes and rows.
   Destination(
       const std::string& taskId,
       int destination,
@@ -62,14 +62,14 @@ class Destination {
       const RowVectorPtr& output,
       const row::CompactRow* outputCompactRow,
       const row::UnsafeRowFast* outputUnsafeRow,
-      OutputBufferManager& bufferManager,
+      DefaultOutputBufferManager& bufferManager,
       const std::function<void()>& bufferReleaseFn,
       bool* atEnd,
       ContinueFuture* future,
       Scratch& scratch);
 
   BlockingReason flush(
-      OutputBufferManager& bufferManager,
+      DefaultOutputBufferManager& bufferManager,
       const std::function<void()>& bufferReleaseFn,
       ContinueFuture* future);
 
@@ -234,7 +234,7 @@ class PartitionedOutput : public Operator {
   std::unique_ptr<core::PartitionFunction> partitionFunction_;
   // Empty if column order in the output is exactly the same as in input.
   const std::vector<column_index_t> outputChannels_;
-  const std::weak_ptr<exec::OutputBufferManager> bufferManager_;
+  const std::weak_ptr<exec::DefaultOutputBufferManager> bufferManager_;
   const std::function<void()> bufferReleaseFn_;
   const int64_t maxBufferedBytes_;
   const bool eagerFlush_;

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -27,6 +27,7 @@
 #include "velox/common/memory/CustomMemoryResourceRegistry.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/common/time/Timer.h"
+#include "velox/exec/DefaultOutputBufferManager.h"
 #include "velox/exec/Exchange.h"
 #include "velox/exec/HashJoinBridge.h"
 #include "velox/exec/IndexLookupJoinBridge.h"
@@ -36,7 +37,6 @@
 #include "velox/exec/OperatorTraceCtx.h"
 #include "velox/exec/OperatorType.h"
 #include "velox/exec/OperatorUtils.h"
-#include "velox/exec/OutputBufferManager.h"
 #include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/SpatialJoinBuild.h"
 #include "velox/exec/TableScan.h"
@@ -439,7 +439,7 @@ Task::Task(
       consumerSupplier_(std::move(consumerSupplier)),
       onError_(std::move(onError)),
       splitsStates_(buildSplitStates(planFragment_.planNode)),
-      bufferManager_(OutputBufferManager::getInstanceRef()) {
+      bufferManager_(DefaultOutputBufferManager::getInstanceRef()) {
   ++numCreatedTasks_;
   // Validate that any per-node transport type annotations refer to the right
   // kind of plan node before they are used to select exchange transports.
@@ -2328,7 +2328,7 @@ bool Task::updateOutputBuffers(int numBuffers, bool noMoreBuffers) {
   VELOX_CHECK_NOT_NULL(
       bufferManager,
       "Unable to initialize task. "
-      "OutputBufferManager was already destructed");
+      "DefaultOutputBufferManager was already destructed");
   {
     std::lock_guard<std::timed_mutex> l(mutex_);
     if (noMoreOutputBuffers_) {

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -32,7 +32,7 @@
 
 namespace facebook::velox::exec {
 
-class OutputBufferManager;
+class DefaultOutputBufferManager;
 
 class HashJoinBridge;
 class IndexLookupJoinBridge;
@@ -802,7 +802,7 @@ class Task : public std::enable_shared_from_this<Task> {
   /// folder could not be created.
   const std::string& getOrCreateSpillDirectory();
 
-  /// True if produces output via OutputBufferManager.
+  /// True if produces output via DefaultOutputBufferManager.
   bool hasPartitionedOutput() const {
     return numDriversInPartitionedOutput_ > 0;
   }
@@ -1276,7 +1276,7 @@ class Task : public std::enable_shared_from_this<Task> {
   // default hierarchy is unchanged.
   std::vector<std::shared_ptr<memory::MemoryPool>> customChildPools_;
 
-  // Set to true by OutputBufferManager when all output is
+  // Set to true by DefaultOutputBufferManager when all output is
   // acknowledged. If this happens before Drivers are at end, the last
   // Driver to finish will set state_ to kFinished. If Drivers have
   // finished then setting this to true will also set state_ to
@@ -1470,7 +1470,7 @@ class Task : public std::enable_shared_from_this<Task> {
   // ungrouped execution we use the [0] entry in this vector.
   std::unordered_map<uint32_t, SplitGroupState> splitGroupStates_;
 
-  std::weak_ptr<OutputBufferManager> bufferManager_;
+  std::weak_ptr<DefaultOutputBufferManager> bufferManager_;
 
   // Boolean indicating that we have already received no-more-output-buffers
   // message. Subsequent messages will be ignored.

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -49,8 +49,9 @@ target_link_libraries(
 #   IndexLookupJoinTest 783s, MultiFragmentTest 599s,
 #   HashJoinTestExtra ~585s, SpillerTest 584s, HashJoinTest ~575s,
 #   TableWriterTest 225s, TableScanTest 189s, IndexLookupJoinTestExtra 188s,
-#   MergeJoinTest 111s, AggregationTest 105s, OutputBufferManagerTest 98s,
-#   ScaleWriterLocalPartitionTest 96s, OrderByTest 71s, TopNRowNumberTest 64s,
+#   MergeJoinTest 111s, AggregationTest 105s,
+#   DefaultOutputBufferManagerTest 98s, ScaleWriterLocalPartitionTest 96s,
+#   OrderByTest 71s, TopNRowNumberTest 64s,
 #   HashTableTest 60s, StreamingAggregationTest 58s, ExchangeClientTest 54s,
 #   RowNumberTest 42s.
 #
@@ -112,10 +113,10 @@ set(
   ProbeOperatorStateTest.cpp
   MarkDistinctTest.cpp
   MergeTest.cpp
-  # group5 (~445s): TableWriterTest 225 + OutputBufMgr 98
+  # group5 (~445s): TableWriterTest 225 + DefaultOutputBufMgr 98
   # + TopNRowNumber 64 + StreamingAgg 58
   TableWriterTest.cpp
-  OutputBufferManagerTest.cpp
+  DefaultOutputBufferManagerTest.cpp
   TopNRowNumberTest.cpp
   StreamingAggregationTest.cpp
   ContainerRowSerdeTest.cpp

--- a/velox/exec/tests/DefaultOutputBufferManagerTest.cpp
+++ b/velox/exec/tests/DefaultOutputBufferManagerTest.cpp
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/exec/OutputBufferManager.h"
+#include "velox/exec/DefaultOutputBufferManager.h"
 #include <folly/system/HardwareConcurrency.h>
 #include <gtest/gtest.h>
 #include "folly/synchronization/EventCount.h"
@@ -44,15 +44,15 @@ inline void PrintTo(const TestParam& param, std::ostream* os) {
   *os << fmt::format("{}_{}", param.outputKind, param.serdeKind);
 }
 
-class OutputBufferManagerTest : public testing::Test {
+class DefaultOutputBufferManagerTest : public testing::Test {
  protected:
-  OutputBufferManagerTest() : serdeKind_("Presto") {
+  DefaultOutputBufferManagerTest() : serdeKind_("Presto") {
     std::vector<std::string> names = {"c0", "c1"};
     std::vector<TypePtr> types = {BIGINT(), VARCHAR()};
     rowType_ = ROW(std::move(names), std::move(types));
   }
 
-  explicit OutputBufferManagerTest(std::string serdeKind)
+  explicit DefaultOutputBufferManagerTest(std::string serdeKind)
       : serdeKind_(serdeKind) {
     std::vector<std::string> names = {"c0", "c1"};
     std::vector<TypePtr> types = {BIGINT(), VARCHAR()};
@@ -65,7 +65,7 @@ class OutputBufferManagerTest : public testing::Test {
 
   void SetUp() override {
     pool_ = facebook::velox::memory::memoryManager()->addLeafPool();
-    bufferManager_ = OutputBufferManager::getInstanceRef();
+    bufferManager_ = DefaultOutputBufferManager::getInstanceRef();
     if (!isRegisteredVectorSerde()) {
       facebook::velox::serializer::presto::PrestoVectorSerde::
           registerVectorSerde();
@@ -442,12 +442,12 @@ class OutputBufferManagerTest : public testing::Test {
       std::make_shared<folly::CPUThreadPoolExecutor>(
           folly::available_concurrency())};
   std::shared_ptr<facebook::velox::memory::MemoryPool> pool_;
-  std::shared_ptr<OutputBufferManager> bufferManager_;
+  std::shared_ptr<DefaultOutputBufferManager> bufferManager_;
   RowTypePtr rowType_;
 };
 
-class OutputBufferManagerWithDifferentSerdeKindsTest
-    : public OutputBufferManagerTest,
+class DefaultOutputBufferManagerWithDifferentSerdeKindsTest
+    : public DefaultOutputBufferManagerTest,
       public testing::WithParamInterface<std::string> {
  public:
   static std::vector<std::string> getTestParams() {
@@ -457,8 +457,8 @@ class OutputBufferManagerWithDifferentSerdeKindsTest
   }
 };
 
-class AllOutputBufferManagerTest
-    : public OutputBufferManagerTest,
+class AllDefaultOutputBufferManagerTest
+    : public DefaultOutputBufferManagerTest,
       public testing::WithParamInterface<TestParam> {
  public:
   static std::vector<TestParam> getTestParams() {
@@ -475,15 +475,15 @@ class AllOutputBufferManagerTest
     return params;
   }
 
-  AllOutputBufferManagerTest()
-      : OutputBufferManagerTest(GetParam().serdeKind),
+  AllDefaultOutputBufferManagerTest()
+      : DefaultOutputBufferManagerTest(GetParam().serdeKind),
         outputKind_(GetParam().outputKind) {}
 
  protected:
   const PartitionedOutputNode::Kind outputKind_;
 };
 
-TEST_P(OutputBufferManagerWithDifferentSerdeKindsTest, arbitrayBuffer) {
+TEST_P(DefaultOutputBufferManagerWithDifferentSerdeKindsTest, arbitrayBuffer) {
   {
     ArbitraryBuffer buffer;
     ASSERT_TRUE(buffer.empty());
@@ -560,12 +560,13 @@ TEST_P(OutputBufferManagerWithDifferentSerdeKindsTest, arbitrayBuffer) {
 }
 
 VELOX_INSTANTIATE_TEST_SUITE_P(
-    OutputBufferManagerWithDifferentSerdeKindsTest,
-    OutputBufferManagerWithDifferentSerdeKindsTest,
+    DefaultOutputBufferManagerWithDifferentSerdeKindsTest,
+    DefaultOutputBufferManagerWithDifferentSerdeKindsTest,
     testing::ValuesIn(
-        OutputBufferManagerWithDifferentSerdeKindsTest::getTestParams()));
+        DefaultOutputBufferManagerWithDifferentSerdeKindsTest::
+            getTestParams()));
 
-TEST_F(OutputBufferManagerTest, outputType) {
+TEST_F(DefaultOutputBufferManagerTest, outputType) {
   ASSERT_EQ(
       PartitionedOutputNode::toName(PartitionedOutputNode::Kind::kPartitioned),
       "PARTITIONED");
@@ -581,7 +582,9 @@ TEST_F(OutputBufferManagerTest, outputType) {
       "Invalid enum value: 100");
 }
 
-TEST_P(OutputBufferManagerWithDifferentSerdeKindsTest, destinationBuffer) {
+TEST_P(
+    DefaultOutputBufferManagerWithDifferentSerdeKindsTest,
+    destinationBuffer) {
   {
     ArbitraryBuffer buffer;
     DestinationBuffer destinationBuffer;
@@ -770,7 +773,9 @@ TEST_P(OutputBufferManagerWithDifferentSerdeKindsTest, destinationBuffer) {
   }
 }
 
-TEST_P(OutputBufferManagerWithDifferentSerdeKindsTest, basicPartitioned) {
+TEST_P(
+    DefaultOutputBufferManagerWithDifferentSerdeKindsTest,
+    basicPartitioned) {
   vector_size_t size = 100;
   std::string taskId = "t0";
   auto task = initializeTask(
@@ -850,7 +855,7 @@ TEST_P(OutputBufferManagerWithDifferentSerdeKindsTest, basicPartitioned) {
   EXPECT_TRUE(task->isFinished());
 }
 
-TEST_P(OutputBufferManagerWithDifferentSerdeKindsTest, basicBroadcast) {
+TEST_P(DefaultOutputBufferManagerWithDifferentSerdeKindsTest, basicBroadcast) {
   vector_size_t size = 100;
 
   std::string taskId = "t0";
@@ -921,7 +926,7 @@ TEST_P(OutputBufferManagerWithDifferentSerdeKindsTest, basicBroadcast) {
   EXPECT_TRUE(task->isFinished());
 }
 
-TEST_P(OutputBufferManagerWithDifferentSerdeKindsTest, basicArbitrary) {
+TEST_P(DefaultOutputBufferManagerWithDifferentSerdeKindsTest, basicArbitrary) {
   const vector_size_t size = 100;
   int numDestinations = 5;
   const std::string taskId = "t0";
@@ -1005,7 +1010,7 @@ TEST_P(OutputBufferManagerWithDifferentSerdeKindsTest, basicArbitrary) {
 }
 
 TEST_P(
-    OutputBufferManagerWithDifferentSerdeKindsTest,
+    DefaultOutputBufferManagerWithDifferentSerdeKindsTest,
     inactiveDestinationBuffer) {
   const vector_size_t dataSize = 1'000;
   const int maxBytes = 1;
@@ -1144,7 +1149,7 @@ TEST_P(
 }
 
 TEST_P(
-    OutputBufferManagerWithDifferentSerdeKindsTest,
+    DefaultOutputBufferManagerWithDifferentSerdeKindsTest,
     broadcastWithDynamicAddedDestination) {
   vector_size_t size = 100;
 
@@ -1190,7 +1195,7 @@ TEST_P(
 }
 
 TEST_P(
-    OutputBufferManagerWithDifferentSerdeKindsTest,
+    DefaultOutputBufferManagerWithDifferentSerdeKindsTest,
     arbitraryWithDynamicAddedDestination) {
   const vector_size_t size = 100;
   int numDestinations = 5;
@@ -1247,7 +1252,7 @@ TEST_P(
   EXPECT_TRUE(task->isFinished());
 }
 
-TEST_P(AllOutputBufferManagerTest, maxBytes) {
+TEST_P(AllDefaultOutputBufferManagerTest, maxBytes) {
   const vector_size_t size = 100;
   const std::string taskId = "t0";
   initializeTask(taskId, rowType_, outputKind_, 1, 1);
@@ -1273,7 +1278,7 @@ TEST_P(AllOutputBufferManagerTest, maxBytes) {
   bufferManager_->removeTask(taskId);
 }
 
-TEST_P(AllOutputBufferManagerTest, outputBufferUtilization) {
+TEST_P(AllDefaultOutputBufferManagerTest, outputBufferUtilization) {
   const std::string taskId = std::to_string(rand());
   const auto destination = 0;
   auto task = initializeTask(taskId, rowType_, outputKind_, 1, 1);
@@ -1317,7 +1322,7 @@ TEST_P(AllOutputBufferManagerTest, outputBufferUtilization) {
   verifyOutputBuffer(task, OutputBufferStatus::kFinished);
 }
 
-TEST_P(AllOutputBufferManagerTest, outputBufferStats) {
+TEST_P(AllDefaultOutputBufferManagerTest, outputBufferStats) {
   const vector_size_t vectorSize = 100;
   const std::string taskId = std::to_string(folly::Random::rand32());
   initializeTask(taskId, rowType_, outputKind_, 1, 1);
@@ -1413,7 +1418,7 @@ TEST_P(AllOutputBufferManagerTest, outputBufferStats) {
   ASSERT_FALSE(bufferManager_->stats(taskId).has_value());
 }
 
-TEST_P(OutputBufferManagerWithDifferentSerdeKindsTest, outOfOrderAcks) {
+TEST_P(DefaultOutputBufferManagerWithDifferentSerdeKindsTest, outOfOrderAcks) {
   const vector_size_t size = 100;
   const std::string taskId = "t0";
   auto task = initializeTask(
@@ -1444,7 +1449,7 @@ TEST_P(OutputBufferManagerWithDifferentSerdeKindsTest, outOfOrderAcks) {
   bufferManager_->removeTask(taskId);
 }
 
-TEST_F(OutputBufferManagerTest, errorInQueue) {
+TEST_F(DefaultOutputBufferManagerTest, errorInQueue) {
   auto queue = std::make_shared<ExchangeQueue>(1, 0);
   queue->setError("Forced failure");
 
@@ -1458,7 +1463,7 @@ TEST_F(OutputBufferManagerTest, errorInQueue) {
 }
 
 TEST_P(
-    OutputBufferManagerWithDifferentSerdeKindsTest,
+    DefaultOutputBufferManagerWithDifferentSerdeKindsTest,
     setQueueErrorWithPendingPages) {
   const uint64_t kBufferSize = 128;
   auto iobuf = folly::IOBuf::create(kBufferSize);
@@ -1488,7 +1493,9 @@ TEST_P(
       "Forced failure");
 }
 
-TEST_P(OutputBufferManagerWithDifferentSerdeKindsTest, getDataOnFailedTask) {
+TEST_P(
+    DefaultOutputBufferManagerWithDifferentSerdeKindsTest,
+    getDataOnFailedTask) {
   // Fetching data on a task which was either never initialized in the buffer
   // manager or was removed by a parallel thread must return false. The
   // `notify` callback must not be registered.
@@ -1506,7 +1513,7 @@ TEST_P(OutputBufferManagerWithDifferentSerdeKindsTest, getDataOnFailedTask) {
 }
 
 TEST_P(
-    OutputBufferManagerWithDifferentSerdeKindsTest,
+    DefaultOutputBufferManagerWithDifferentSerdeKindsTest,
     updateBrodcastBufferOnFailedTask) {
   // Updating broadcast buffer count in the buffer manager for a given unknown
   // task must not throw exception, instead must return FALSE.
@@ -1516,7 +1523,7 @@ TEST_P(
       false));
 }
 
-TEST_P(AllOutputBufferManagerTest, multiFetchers) {
+TEST_P(AllDefaultOutputBufferManagerTest, multiFetchers) {
   const std::vector<bool> earlyTerminations = {false, true};
   for (const auto earlyTermination : earlyTerminations) {
     SCOPED_TRACE(fmt::format("earlyTermination {}", earlyTermination));
@@ -1608,6 +1615,6 @@ TEST_P(AllOutputBufferManagerTest, multiFetchers) {
 }
 
 VELOX_INSTANTIATE_TEST_SUITE_P(
-    AllOutputBufferManagerTestSuite,
-    AllOutputBufferManagerTest,
-    testing::ValuesIn(AllOutputBufferManagerTest::getTestParams()));
+    AllDefaultOutputBufferManagerTestSuite,
+    AllDefaultOutputBufferManagerTest,
+    testing::ValuesIn(AllDefaultOutputBufferManagerTest::getTestParams()));

--- a/velox/exec/tests/ExchangeClientTest.cpp
+++ b/velox/exec/tests/ExchangeClientTest.cpp
@@ -19,7 +19,7 @@
 #include <atomic>
 #include <thread>
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/exec/OutputBufferManager.h"
+#include "velox/exec/DefaultOutputBufferManager.h"
 #include "velox/exec/Task.h"
 #include "velox/exec/tests/utils/LocalExchangeSource.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
@@ -62,7 +62,7 @@ class ExchangeClientTest : public testing::Test,
     if (!isRegisteredVectorSerde()) {
       velox::serializer::presto::PrestoVectorSerde::registerVectorSerde();
     }
-    bufferManager_ = OutputBufferManager::getInstanceRef();
+    bufferManager_ = DefaultOutputBufferManager::getInstanceRef();
 
     common::testutil::TestValue::enable();
   }
@@ -163,7 +163,7 @@ class ExchangeClientTest : public testing::Test,
 
   std::string serdeKind_;
   std::unique_ptr<folly::CPUThreadPoolExecutor> executor_;
-  std::shared_ptr<OutputBufferManager> bufferManager_;
+  std::shared_ptr<DefaultOutputBufferManager> bufferManager_;
 };
 
 TEST_P(ExchangeClientTest, nonVeloxCreateExchangeSourceException) {

--- a/velox/exec/tests/GroupedExecutionTest.cpp
+++ b/velox/exec/tests/GroupedExecutionTest.cpp
@@ -20,7 +20,7 @@
 #include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/common/testutil/TempFilePath.h"
 #include "velox/exec/Cursor.h"
-#include "velox/exec/OutputBufferManager.h"
+#include "velox/exec/DefaultOutputBufferManager.h"
 #include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
@@ -290,7 +290,7 @@ TEST_F(GroupedExecutionTest, groupedExecutionWithOutputBuffer) {
 
   // 'Delete results' from output buffer triggers 'set all output consumed',
   // which should finish the task.
-  auto outputBufferManager = exec::OutputBufferManager::getInstanceRef();
+  auto outputBufferManager = exec::DefaultOutputBufferManager::getInstanceRef();
   outputBufferManager->deleteResults(task->taskId(), 0);
 
   // Task must be finished at this stage.
@@ -492,7 +492,8 @@ TEST_F(GroupedExecutionTest, hashJoinWithMixedGroupedExecution) {
         task->noMoreSplits(probeScanNodeId);
       }
 
-      auto outputBufferManager = exec::OutputBufferManager::getInstanceRef();
+      auto outputBufferManager =
+          exec::DefaultOutputBufferManager::getInstanceRef();
       outputBufferManager->deleteResults(task->taskId(), 0);
 
       waitForTaskCompletion(task.get());
@@ -737,7 +738,8 @@ DEBUG_ONLY_TEST_F(
 
     // 'Delete results' from output buffer triggers 'set all output consumed',
     // which should finish the task.
-    auto outputBufferManager = exec::OutputBufferManager::getInstanceRef();
+    auto outputBufferManager =
+        exec::DefaultOutputBufferManager::getInstanceRef();
     outputBufferManager->deleteResults(task->taskId(), 0);
 
     // Task must be finished at this stage.
@@ -871,7 +873,7 @@ DEBUG_ONLY_TEST_F(
 
   // 'Delete results' from output buffer triggers 'set all output consumed',
   // which should finish the task.
-  auto outputBufferManager = exec::OutputBufferManager::getInstanceRef();
+  auto outputBufferManager = exec::DefaultOutputBufferManager::getInstanceRef();
   outputBufferManager->deleteResults(task->taskId(), 0);
 
   // Task is at running state because the build side is lingering.
@@ -1030,7 +1032,8 @@ TEST_F(GroupedExecutionTest, groupedExecutionWithHashAndNestedLoopJoin) {
 
     // 'Delete results' from output buffer triggers 'set all output consumed',
     // which should finish the task.
-    auto outputBufferManager = exec::OutputBufferManager::getInstanceRef();
+    auto outputBufferManager =
+        exec::DefaultOutputBufferManager::getInstanceRef();
     outputBufferManager->deleteResults(task->taskId(), 0);
 
     // Task must be finished at this stage.

--- a/velox/exec/tests/IndexLookupJoinTestExtra.cpp
+++ b/velox/exec/tests/IndexLookupJoinTestExtra.cpp
@@ -23,8 +23,8 @@
 #include "velox/connectors/Connector.h"
 #include "velox/connectors/ConnectorRegistry.h"
 #include "velox/core/PlanNode.h"
+#include "velox/exec/DefaultOutputBufferManager.h"
 #include "velox/exec/IndexLookupJoin.h"
-#include "velox/exec/OutputBufferManager.h"
 #include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
@@ -1987,8 +1987,9 @@ TEST_P(IndexLookupJoinTest, groupedExecution) {
       task->noMoreSplitsForGroup(indexScanNodeId_, group);
     }
 
-    // Consume output via OutputBufferManager.
-    auto outputBufferManager = exec::OutputBufferManager::getInstanceRef();
+    // Consume output via DefaultOutputBufferManager.
+    auto outputBufferManager =
+        exec::DefaultOutputBufferManager::getInstanceRef();
     outputBufferManager->deleteResults(task->taskId(), 0);
 
     waitForTaskCompletion(task.get());
@@ -2102,7 +2103,8 @@ TEST_P(IndexLookupJoinTest, groupedExecutionWithEmptyIndexSplits) {
     task->noMoreSplitsForGroup(indexScanNodeId_, 1);
     task->noMoreSplitsForGroup(indexScanNodeId_, 2);
 
-    auto outputBufferManager = exec::OutputBufferManager::getInstanceRef();
+    auto outputBufferManager =
+        exec::DefaultOutputBufferManager::getInstanceRef();
     outputBufferManager->deleteResults(task->taskId(), 0);
 
     waitForTaskCompletion(task.get());

--- a/velox/exec/tests/LimitTest.cpp
+++ b/velox/exec/tests/LimitTest.cpp
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/exec/OutputBufferManager.h"
+#include "velox/exec/DefaultOutputBufferManager.h"
 #include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
@@ -126,7 +126,7 @@ TEST_F(LimitTest, partialLimitEagerFlush) {
     params.planNode = builder.partitionedOutput({}, 1).planNode();
     auto cursor = TaskCursor::create(params);
     ASSERT_FALSE(cursor->moveNext());
-    auto bufferManager = exec::OutputBufferManager::getInstanceRef();
+    auto bufferManager = exec::DefaultOutputBufferManager::getInstanceRef();
     auto [numPagesPromise, numPagesFuture] = folly::makePromiseContract<int>();
     ASSERT_TRUE(bufferManager->getData(
         cursor->task()->taskId(),

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -20,8 +20,8 @@
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
+#include "velox/exec/DefaultOutputBufferManager.h"
 #include "velox/exec/Exchange.h"
-#include "velox/exec/OutputBufferManager.h"
 #include "velox/exec/PartitionedOutput.h"
 #include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/RoundRobinPartitionFunction.h"
@@ -262,8 +262,8 @@ class MultiFragmentTest : public HiveConnectorTestBase,
   std::unordered_map<std::string, std::string> configSettings_;
   std::vector<std::shared_ptr<TempFilePath>> filePaths_;
   std::vector<RowVectorPtr> vectors_;
-  std::shared_ptr<OutputBufferManager> bufferManager_{
-      OutputBufferManager::getInstanceRef()};
+  std::shared_ptr<DefaultOutputBufferManager> bufferManager_{
+      DefaultOutputBufferManager::getInstanceRef()};
 };
 
 TEST_P(MultiFragmentTest, aggregationSingleKey) {
@@ -2648,8 +2648,8 @@ class DataFetcher {
   /// Used to notify DataFetcher that one of the above bool flags has been set.
   folly::EventCount bufferFullOrDoneWait_;
 
-  std::shared_ptr<OutputBufferManager> bufferManager_{
-      OutputBufferManager::getInstanceRef()};
+  std::shared_ptr<DefaultOutputBufferManager> bufferManager_{
+      DefaultOutputBufferManager::getInstanceRef()};
 };
 
 /// Verify that POBM::getData() honors maxBytes parameter roughly at 1MB

--- a/velox/exec/tests/PartitionedOutputTest.cpp
+++ b/velox/exec/tests/PartitionedOutputTest.cpp
@@ -86,8 +86,8 @@ class PartitionedOutputTest : public OperatorTestBase,
   }
 
  private:
-  const std::shared_ptr<OutputBufferManager> bufferManager_{
-      OutputBufferManager::getInstanceRef()};
+  const std::shared_ptr<DefaultOutputBufferManager> bufferManager_{
+      DefaultOutputBufferManager::getInstanceRef()};
 };
 
 TEST_P(PartitionedOutputTest, flush) {

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -26,7 +26,7 @@
 #include "velox/common/testutil/TestValue.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/exec/Cursor.h"
-#include "velox/exec/OutputBufferManager.h"
+#include "velox/exec/DefaultOutputBufferManager.h"
 #include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/Values.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
@@ -1357,7 +1357,7 @@ TEST_F(TaskTest, updateBroadCastOutputBuffers) {
                   .project({"c0 % 10"})
                   .partitionedOutputBroadcast({})
                   .planFragment();
-  auto bufferManager = OutputBufferManager::getInstanceRef();
+  auto bufferManager = DefaultOutputBufferManager::getInstanceRef();
   {
     auto task = Task::create(
         "t0",

--- a/velox/exec/tests/utils/LocalExchangeSource.cpp
+++ b/velox/exec/tests/utils/LocalExchangeSource.cpp
@@ -17,8 +17,8 @@
 #include <folly/executors/IOThreadPoolExecutor.h>
 #include <atomic>
 #include "velox/common/testutil/TestValue.h"
+#include "velox/exec/DefaultOutputBufferManager.h"
 #include "velox/exec/Operator.h"
-#include "velox/exec/OutputBufferManager.h"
 
 namespace facebook::velox::exec::test {
 namespace {
@@ -55,8 +55,8 @@ class LocalExchangeSource : public exec::ExchangeSource {
       promise_ = std::move(promise);
     }
 
-    auto buffers = OutputBufferManager::getInstanceRef();
-    VELOX_CHECK_NOT_NULL(buffers, "invalid OutputBufferManager");
+    auto buffers = DefaultOutputBufferManager::getInstanceRef();
+    VELOX_CHECK_NOT_NULL(buffers, "invalid DefaultOutputBufferManager");
     VELOX_CHECK(requestPending_);
     auto requestedSequence = sequence_;
     auto self = shared_from_this();
@@ -169,8 +169,8 @@ class LocalExchangeSource : public exec::ExchangeSource {
   void pause() override {
     common::testutil::TestValue::adjust(
         "facebook::velox::exec::test::LocalExchangeSource::pause", nullptr);
-    auto buffers = OutputBufferManager::getInstanceRef();
-    VELOX_CHECK_NOT_NULL(buffers, "invalid OutputBufferManager");
+    auto buffers = DefaultOutputBufferManager::getInstanceRef();
+    VELOX_CHECK_NOT_NULL(buffers, "invalid DefaultOutputBufferManager");
     int64_t ackSequence;
     {
       std::lock_guard<std::mutex> l(queue_->mutex());
@@ -182,7 +182,7 @@ class LocalExchangeSource : public exec::ExchangeSource {
   void close() override {
     checkSetRequestPromise();
 
-    auto buffers = OutputBufferManager::getInstanceRef();
+    auto buffers = DefaultOutputBufferManager::getInstanceRef();
     buffers->deleteResults(remoteTaskId_, destination_);
   }
 

--- a/velox/exec/tests/utils/LocalExchangeSource.h
+++ b/velox/exec/tests/utils/LocalExchangeSource.h
@@ -20,7 +20,7 @@
 namespace facebook::velox::exec::test {
 
 /// Given taskId that starts with local:// returns an instance of ExchangeSource
-/// that fetches data from local OutputBufferManager.
+/// that fetches data from local DefaultOutputBufferManager.
 std::unique_ptr<exec::ExchangeSource> createLocalExchangeSource(
     const std::string& taskId,
     int destination,

--- a/velox/exec/tests/utils/SerializedPageUtil.cpp
+++ b/velox/exec/tests/utils/SerializedPageUtil.cpp
@@ -23,7 +23,7 @@ namespace facebook::velox::exec::test {
 std::unique_ptr<SerializedPageBase> toSerializedPage(
     const RowVectorPtr& vector,
     std::string serdeKind,
-    const std::shared_ptr<OutputBufferManager>& bufferManager,
+    const std::shared_ptr<DefaultOutputBufferManager>& bufferManager,
     memory::MemoryPool* pool) {
   auto data =
       std::make_unique<VectorStreamGroup>(pool, getNamedVectorSerde(serdeKind));

--- a/velox/exec/tests/utils/SerializedPageUtil.h
+++ b/velox/exec/tests/utils/SerializedPageUtil.h
@@ -15,8 +15,8 @@
  */
 #pragma once
 
+#include "velox/exec/DefaultOutputBufferManager.h"
 #include "velox/exec/ExchangeQueue.h"
-#include "velox/exec/OutputBufferManager.h"
 #include "velox/vector/ComplexVector.h"
 // #include "velox/vector/VectorStream.h"
 
@@ -26,7 +26,7 @@ namespace facebook::velox::exec::test {
 std::unique_ptr<SerializedPageBase> toSerializedPage(
     const RowVectorPtr& vector,
     std::string serdeKind,
-    const std::shared_ptr<OutputBufferManager>& bufferManager,
+    const std::shared_ptr<DefaultOutputBufferManager>& bufferManager,
     memory::MemoryPool* pool);
 
 } // namespace facebook::velox::exec::test

--- a/velox/experimental/cudf/tests/LimitTest.cpp
+++ b/velox/experimental/cudf/tests/LimitTest.cpp
@@ -16,7 +16,6 @@
 
 #include "velox/experimental/cudf/exec/ToCudf.h"
 
-#include "velox/exec/OutputBufferManager.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 

--- a/velox/tool/trace/PartitionedOutputReplayer.cpp
+++ b/velox/tool/trace/PartitionedOutputReplayer.cpp
@@ -36,7 +36,7 @@ std::shared_ptr<core::QueryCtx> createQueryContext(
 }
 
 std::vector<std::unique_ptr<folly::IOBuf>> getData(
-    const std::shared_ptr<exec::OutputBufferManager>& bufferManager,
+    const std::shared_ptr<exec::DefaultOutputBufferManager>& bufferManager,
     const std::string& taskId,
     int destination,
     int64_t sequence,
@@ -64,7 +64,7 @@ std::vector<std::unique_ptr<folly::IOBuf>> getData(
 } // namespace
 
 void consumeAllData(
-    const std::shared_ptr<exec::OutputBufferManager>& bufferManager,
+    const std::shared_ptr<exec::DefaultOutputBufferManager>& bufferManager,
     const std::string& taskId,
     uint32_t numPartitions,
     folly::Executor* driverExecutor,

--- a/velox/tool/trace/PartitionedOutputReplayer.h
+++ b/velox/tool/trace/PartitionedOutputReplayer.h
@@ -20,7 +20,7 @@
 #include <utility>
 
 #include "velox/core/PlanNode.h"
-#include "velox/exec/OutputBufferManager.h"
+#include "velox/exec/DefaultOutputBufferManager.h"
 #include "velox/tool/trace/OperatorReplayerBase.h"
 
 namespace facebook::velox::tool::trace {
@@ -28,7 +28,7 @@ namespace facebook::velox::tool::trace {
 /// Concurrently gets all partitioned buffer content (vec<IOBuf>) for every
 /// partition.
 void consumeAllData(
-    const std::shared_ptr<exec::OutputBufferManager>& bufferManager,
+    const std::shared_ptr<exec::DefaultOutputBufferManager>& bufferManager,
     const std::string& taskId,
     uint32_t numPartitions,
     folly::Executor* executor,
@@ -63,8 +63,8 @@ class PartitionedOutputReplayer final : public OperatorReplayerBase {
 
   const core::PartitionedOutputNode* const originalNode_;
   const std::string serdeKind_;
-  const std::shared_ptr<exec::OutputBufferManager> bufferManager_{
-      exec::OutputBufferManager::getInstanceRef()};
+  const std::shared_ptr<exec::DefaultOutputBufferManager> bufferManager_{
+      exec::DefaultOutputBufferManager::getInstanceRef()};
   const std::unique_ptr<folly::Executor> executor_{
       std::make_unique<folly::CPUThreadPoolExecutor>(
           folly::available_concurrency(),

--- a/velox/tool/trace/tests/PartitionedOutputReplayerTest.cpp
+++ b/velox/tool/trace/tests/PartitionedOutputReplayerTest.cpp
@@ -117,8 +117,8 @@ class PartitionedOutputReplayerTest
     return task;
   }
 
-  const std::shared_ptr<OutputBufferManager> bufferManager_{
-      exec::OutputBufferManager::getInstanceRef()};
+  const std::shared_ptr<DefaultOutputBufferManager> bufferManager_{
+      exec::DefaultOutputBufferManager::getInstanceRef()};
 };
 
 TEST_P(PartitionedOutputReplayerTest, defaultConsumer) {


### PR DESCRIPTION
## Summary

Rename the concrete `OutputBufferManager` class and its
`OutputBufferManager.{h,cpp}` files to `DefaultOutputBufferManager`, including
the `OutputBufferManagerTest*` fixtures and the `OutputBufferManagerTest.cpp`
file, and update all references, includes, and CMake source entries.

This is a pure mechanical rename with no behavior change. `clang-format`
reflowed a few lines that exceeded 80 columns after the longer name and hoisted
the renamed main-header include to the top of its test file. The unused
`OutputBufferManager` include in `velox/experimental/cudf/tests/LimitTest.cpp`
is removed rather than renamed.

## Motivation

This frees the `OutputBufferManager` name so a follow-up (#16980) can introduce
an abstract output-buffer-manager interface — with `DefaultOutputBufferManager`
as the in-memory implementation — without burying that design change under a
large mechanical rename. Splitting the rename out keeps the design PR focused
and reviewable.
