### PR TITLE
fix(cudf): Handle zero-column inputs in CudfFromVelox

### DIFF
--- a/velox/experimental/cudf/exec/CudfConversion.cpp
+++ b/velox/experimental/cudf/exec/CudfConversion.cpp
@@ -160,7 +160,10 @@ RowVectorPtr CudfFromVelox::doGetOutput() {
   if (input->childrenSize() == 0) {
     auto emptyTable = std::make_unique<cudf::table>();
     return std::make_shared<CudfVector>(
-        input->pool(), outputType_, input->size(), std::move(emptyTable),
+        input->pool(),
+        outputType_,
+        input->size(),
+        std::move(emptyTable),
         stream);
   }
 

--- a/velox/experimental/cudf/exec/CudfConversion.cpp
+++ b/velox/experimental/cudf/exec/CudfConversion.cpp
@@ -153,6 +153,17 @@ RowVectorPtr CudfFromVelox::doGetOutput() {
   // Get a stream from the global stream pool
   auto stream = cudfGlobalStreamPool().get_stream();
 
+  // cuDF tables with zero columns cannot represent a row count, so we
+  // create a CudfVector directly with an empty table, preserving the
+  // logical row count. This mirrors the zero-column handling in
+  // CudfToVelox::doGetOutput().
+  if (input->childrenSize() == 0) {
+    auto emptyTable = std::make_unique<cudf::table>();
+    return std::make_shared<CudfVector>(
+        input->pool(), outputType_, input->size(), std::move(emptyTable),
+        stream);
+  }
+
   // Convert RowVector to cudf table.  toCudfTable synchronizes the stream
   // internally before releasing Arrow host buffers, so no additional sync
   // is needed here.

--- a/velox/experimental/cudf/tests/AggregationTest.cpp
+++ b/velox/experimental/cudf/tests/AggregationTest.cpp
@@ -1702,4 +1702,30 @@ TEST_F(AggregationTest, stddevSampAllNulls) {
   assertQuery(op2, "SELECT c0, stddev_samp(c2) FROM tmp GROUP BY c0");
 }
 
+// Test that zero-column rows flow correctly through CudfFromVelox.
+// project({}) produces zero-column output; localPartitionRoundRobin is a CPU
+// operator that forces CudfFromVelox insertion before the GPU aggregation.
+// Without the zero-column fix in CudfFromVelox, this crashes with:
+//   "Operator::getOutput() must return nullptr or a non-empty vector"
+// because toCudfTable loses the row count for zero-column tables.
+TEST_F(AggregationTest, zeroColumnThroughCudfFromVelox) {
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>({1, 2, 3, 4}),
+  });
+  createDuckDbTable({data});
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .filter("c0 > 0")
+                  .project({})
+                  .localPartitionRoundRobin()
+                  .singleAggregation({}, {"count(*)"})
+                  .planNode();
+
+  AssertQueryBuilder(duckDbQueryRunner_)
+      .config(core::QueryConfig::kMaxLocalExchangePartitionCount, "2")
+      .plan(plan)
+      .assertResults("SELECT count(*) FROM tmp WHERE c0 > 0");
+}
+
 } // namespace facebook::velox::exec::test


### PR DESCRIPTION
`CudfFromVelox::doGetOutput()` converts Velox RowVectors to cuDF tables via `toCudfTable()`. When the input RowVector has zero columns (but non-zero rows), `toCudfTable()` produces a table with zero rows because cuDF tables with zero columns cannot represent a row count. The resulting `CudfVector` with `size==0` violates the Velox Driver invariant that `getOutput()` must return nullptr or a non-empty vector.

This was discovered debugging TPC-DS Q9 at SF1000, where a distributed plan exchanges a zero-column, single-row result through a `CudfFromVelox` operator.

Fix: When the input RowVector has zero children, skip the `toCudfTable` conversion and create a `CudfVector` directly with an empty cuDF table, preserving the logical row count. This mirrors the existing zero-column handling already present in `CudfToVelox::doGetOutput()` and `getConcatenatedCudfVectorsBatched()`.
Testing: Added `zeroColumnThroughCudfFromVelox` test that creates a pipeline where zero-column data flows through a `LocalExchange` into `CudfFromVelox ` before a GPU aggregation.