### PR TITLE
fix(dwio): Correct flat-map prefetch eligibility (#18038)

### DIFF
--- a/velox/common/caching/ScanTracker.cpp
+++ b/velox/common/caching/ScanTracker.cpp
@@ -34,7 +34,12 @@ void ScanTracker::recordReference(
   std::lock_guard<std::mutex> l(mutex_);
   auto& data = data_[id];
   data.referencedBytes += bytes;
-  data.lastReferencedBytes = bytes;
+  // Accumulate, rather than overwrite, the bytes referenced since the last
+  // read. A single load unit (e.g. a stripe) can reference the same trackingId
+  // many times -- a flat map's per-key value streams intentionally share one
+  // trackingId -- and adjustedReadPct() must be able to exclude all of those
+  // references until the bytes are actually read.
+  data.lastReferencedBytes += static_cast<double>(bytes);
   sum_.referencedBytes += bytes;
 }
 
@@ -49,6 +54,10 @@ void ScanTracker::recordRead(
   std::lock_guard<std::mutex> l(mutex_);
   auto& data = data_[id];
   data.readBytes += bytes;
+  // The bytes referenced since the last read are now being read, so they are no
+  // longer "referenced but not yet read". Reset the counter; references from
+  // the next load unit re-accumulate it.
+  data.lastReferencedBytes = 0;
   sum_.readBytes += bytes;
 }
 

--- a/velox/common/caching/ScanTracker.h
+++ b/velox/common/caching/ScanTracker.h
@@ -74,6 +74,14 @@ class FileGroupStats;
 /// Records references and actual uses of a stream.
 struct TrackingData {
   double referencedBytes{};
+  /// All bytes referenced since the last read, i.e. by the current,
+  /// not-yet-read load unit (e.g. a stripe): accumulated by every
+  /// recordReference() and reset to 0 on the next recordRead().
+  /// adjustedReadPct() subtracts it so the read percentage counts only bytes
+  /// that have already had a chance to be read. Accumulating, rather than
+  /// tracking just the last reference, keeps the percentage correct when many
+  /// streams share one trackingId -- e.g. a flat map's per-key value streams --
+  /// where a single load unit produces many references.
   double lastReferencedBytes{};
   double readBytes{};
 };

--- a/velox/dwio/common/BufferedInput.h
+++ b/velox/dwio/common/BufferedInput.h
@@ -242,9 +242,12 @@ class BufferedInput {
 
  protected:
   static int adjustedReadPct(const cache::TrackingData& trackingData) {
-    // When this method is called, there is one more reference that is already
-    // counted, but the corresponding read (if exists) has not happened yet.  So
-    // we must count one fewer reference at this point.
+    // Exclude the references made since the last read (lastReferencedBytes) so
+    // the percentage counts only bytes that have already had a chance to be
+    // read. Because lastReferencedBytes accumulates every reference in the
+    // current load unit and resets on the next read, this stays correct even
+    // when many streams share one trackingId -- e.g. a flat map's per-key value
+    // streams -- and a single unit produces many references.
     const auto referencedBytes =
         trackingData.referencedBytes - trackingData.lastReferencedBytes;
     if (referencedBytes == 0) {

--- a/velox/dwio/common/tests/BufferedInputTest.cpp
+++ b/velox/dwio/common/tests/BufferedInputTest.cpp
@@ -842,3 +842,45 @@ TEST_F(BufferedInputTest, readGapTracking) {
     EXPECT_EQ(ioStats->readGap().max(), testCase.expectedGapMax);
   }
 }
+
+namespace {
+// Exposes BufferedInput's protected static adjustedReadPct() for testing
+// (no friend declaration needed).
+class AdjustedReadPctAccessor : public BufferedInput {
+ public:
+  using BufferedInput::adjustedReadPct;
+};
+} // namespace
+
+// A flat map's per-key value streams all share one trackingId, so reading a
+// single stripe records many references under that id. adjustedReadPct() must
+// exclude the whole current (not-yet-read) stripe -- not just the last
+// reference -- so a fully-read column scores ~100% (and is eligible for
+// prefetch) instead of roughly half.
+TEST(BufferedInputAdjustedReadPctTest, ExcludesWholeCurrentStripe) {
+  cache::ScanTracker tracker(
+      "test", /*unregisterer=*/nullptr, /*loadQuantum=*/1 << 20);
+  const cache::TrackingId id(1);
+  constexpr uint64_t kStreamBytes = 100;
+  constexpr int kKeysPerStripe = 5;
+
+  // Stripe 1: reference every per-key value stream under the shared id, then
+  // read all.
+  for (int i = 0; i < kKeysPerStripe; ++i) {
+    tracker.recordReference(id, kStreamBytes, /*fileId=*/0, /*groupId=*/0);
+  }
+  tracker.recordRead(
+      id, kStreamBytes * kKeysPerStripe, /*fileId=*/0, /*groupId=*/0);
+
+  // Stripe 2: reference every per-key value stream again (recorded, not yet
+  // read).
+  for (int i = 0; i < kKeysPerStripe; ++i) {
+    tracker.recordReference(id, kStreamBytes, /*fileId=*/0, /*groupId=*/0);
+  }
+
+  // referencedBytes = 1000, readBytes = 500, current-stripe references = 500.
+  //   Correct: 500 / (1000 - 500) = 100%.
+  //   Buggy (subtracts only the last reference): 500 / (1000 - 100) = 55%.
+  EXPECT_EQ(
+      AdjustedReadPctAccessor::adjustedReadPct(tracker.trackingData(id)), 100);
+}


### PR DESCRIPTION
Summary:

DirectBufferedInput decides whether to prefetch a stream from the read
percentage tracked per TrackingData:
  readBytes / (referencedBytes - <current unit's references>).
The current unit's references were held in lastReferencedBytes, overwritten
on every recordReference (it assumed one reference per unit).

Flat-map columns map all per-key streams of a (node, kind) to one
TrackingData, so a single stripe produces many references under that
TrackingData but only the last one was subtracted. Such a column scored
~50% and was never prefetched even though it was read ~100%.

Make lastReferencedBytes accumulate every reference since the last read
(reset to 0 on the next recordRead) instead of overwriting. adjustedReadPct
now excludes the whole current, not-yet-read unit, so streams that share a
TrackingData (flat-map per-key streams) are scored correctly. Behaviour is
unchanged for the common single-reference-per-unit case.

Reviewed By: Yuhta

Differential Revision: D110111997


