### PR TITLE
feat: Iceberg V3 field-id + NIMBLE stats on the Velox Iceberg connector (#18041)

### DIFF
--- a/velox/connectors/hive/iceberg/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/CMakeLists.txt
@@ -70,6 +70,8 @@ velox_add_library(
   TransformEvaluator.h
   TransformExprBuilder.h
   WriterOptionsAdapter.h
+  IcebergFieldId.h
+  IcebergFieldMetadata.h
 )
 
 velox_link_libraries(

--- a/velox/connectors/hive/iceberg/IcebergColumnHandle.cpp
+++ b/velox/connectors/hive/iceberg/IcebergColumnHandle.cpp
@@ -32,7 +32,8 @@ IcebergColumnHandle::IcebergColumnHandle(
     TypePtr dataType,
     parquet::ParquetFieldId icebergField,
     std::vector<common::Subfield> requiredSubfields,
-    std::optional<std::string> initialDefaultValue)
+    std::optional<std::string> initialDefaultValue,
+    IcebergFieldMetadata icebergMetadata)
     : HiveColumnHandle(
           name,
           columnType,
@@ -42,7 +43,8 @@ IcebergColumnHandle::IcebergColumnHandle(
           ColumnParseParameters{ColumnParseParameters::
                                     PartitionDateValueFormat::kDaysSinceEpoch}),
       field_(std::move(icebergField)),
-      initialDefaultValue_(std::move(initialDefaultValue)) {}
+      initialDefaultValue_(std::move(initialDefaultValue)),
+      icebergMetadata_(std::move(icebergMetadata)) {}
 
 const parquet::ParquetFieldId& IcebergColumnHandle::field() const {
   return field_;

--- a/velox/connectors/hive/iceberg/IcebergColumnHandle.h
+++ b/velox/connectors/hive/iceberg/IcebergColumnHandle.h
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "velox/connectors/hive/TableHandle.h"
+#include "velox/connectors/hive/iceberg/IcebergFieldMetadata.h"
 #include "velox/dwio/common/ParquetFieldId.h"
 #include "velox/type/Subfield.h"
 #include "velox/type/Type.h"
@@ -34,9 +35,16 @@ class IcebergColumnHandle : public HiveColumnHandle {
       TypePtr dataType,
       parquet::ParquetFieldId icebergField,
       std::vector<common::Subfield> requiredSubfields = {},
-      std::optional<std::string> initialDefaultValue = std::nullopt);
+      std::optional<std::string> initialDefaultValue = std::nullopt,
+      IcebergFieldMetadata icebergMetadata = {});
 
   const parquet::ParquetFieldId& field() const;
+
+  /// Iceberg V3 type-disambiguation attributes for this column, parallel to
+  /// field(). Empty for callers that do not supply V3 metadata.
+  const IcebergFieldMetadata& icebergMetadata() const {
+    return icebergMetadata_;
+  }
 
   const std::optional<std::string>& initialDefaultValue() const {
     return initialDefaultValue_;
@@ -45,6 +53,7 @@ class IcebergColumnHandle : public HiveColumnHandle {
  private:
   const parquet::ParquetFieldId field_;
   const std::optional<std::string> initialDefaultValue_;
+  const IcebergFieldMetadata icebergMetadata_;
 };
 
 using IcebergColumnHandlePtr = std::shared_ptr<const IcebergColumnHandle>;

--- a/velox/connectors/hive/iceberg/IcebergDataSink.cpp
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.cpp
@@ -31,6 +31,7 @@
 #include "velox/common/testutil/TestValue.h"
 #include "velox/connectors/hive/PartitionIdGenerator.h"
 #include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
+#include "velox/connectors/hive/iceberg/IcebergFieldId.h"
 #include "velox/connectors/hive/iceberg/IcebergStatsCollector.h"
 
 #ifdef VELOX_ENABLE_PARQUET
@@ -452,11 +453,48 @@ std::shared_ptr<dwio::common::WriterOptions>
 IcebergDataSink::createWriterOptions(size_t writerIndex) const {
   auto options = HiveDataSink::createWriterOptions(writerIndex);
 
+  // Build a synthetic top-level IcebergFieldId tree from inputColumns_ to
+  // carry per-column Iceberg field IDs across the adapter boundary. This
+  // matches IcebergParquetStatsCollector's parquetFieldIds() shape: a
+  // root container whose `children` are one entry per input column. The
+  // tree is consumed by the format-specific adapter (NIMBLE today;
+  // others can opt in by overriding applyPostConfigs in their adapter).
+  IcebergFieldId icebergFieldIds{};
+  icebergFieldIds.children.reserve(
+      icebergInsertTableHandle_->inputColumns().size());
+  // Parallel Iceberg V3 type-attribute tree, one child per input column,
+  // drawn from each IcebergColumnHandle::icebergMetadata(). Walked in
+  // lockstep with icebergFieldIds by the NIMBLE adapter.
+  IcebergFieldMetadata icebergMetadata;
+  icebergMetadata.children.reserve(
+      icebergInsertTableHandle_->inputColumns().size());
+  for (const auto& column : icebergInsertTableHandle_->inputColumns()) {
+    const auto& icebergColumn =
+        checkedPointerCast<const IcebergColumnHandle>(column);
+    const auto& srcField = icebergColumn->field();
+    // Convert dwio ParquetFieldId to connector-local IcebergFieldId at
+    // boundary.
+    std::function<IcebergFieldId(const dwio::common::ParquetFieldId&)> convert =
+        [&](const dwio::common::ParquetFieldId& src) -> IcebergFieldId {
+      IcebergFieldId dst{};
+      dst.fieldId = src.fieldId;
+      dst.children.reserve(src.children.size());
+      for (const auto& child : src.children) {
+        dst.children.emplace_back(convert(child));
+      }
+      return dst;
+    };
+    icebergFieldIds.children.emplace_back(convert(srcField));
+    icebergMetadata.children.emplace_back(icebergColumn->icebergMetadata());
+  }
+
   // Dispatch format-specific Iceberg overrides through the adapter so each
   // supported format (Parquet, DWRF, Nimble) gets its pre/post-processConfigs
   // hooks applied uniformly.
-  const auto adapter =
-      createWriterOptionsAdapter(icebergInsertTableHandle_->storageFormat());
+  const auto adapter = createWriterOptionsAdapter(
+      icebergInsertTableHandle_->storageFormat(),
+      std::move(icebergFieldIds),
+      std::move(icebergMetadata));
   if (adapter != nullptr) {
     adapter->applyPreConfigs(*options);
   }

--- a/velox/connectors/hive/iceberg/IcebergDataSink.h
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.h
@@ -27,6 +27,10 @@
 #include "velox/connectors/hive/iceberg/IcebergDataFileStatistics.h"
 #include "velox/connectors/hive/iceberg/IcebergStatsCollector.h"
 
+#ifdef VELOX_ENABLE_NIMBLE
+#include "velox/connectors/hive/iceberg/fb/IcebergNimbleStatsCollector.h"
+#endif
+
 #include "velox/connectors/hive/iceberg/IcebergConfig.h"
 #include "velox/connectors/hive/iceberg/IcebergPartitionName.h"
 #include "velox/connectors/hive/iceberg/PartitionSpec.h"

--- a/velox/connectors/hive/iceberg/IcebergFieldId.h
+++ b/velox/connectors/hive/iceberg/IcebergFieldId.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace facebook::velox::connector::hive::iceberg {
+
+/// Connector-local representation of Iceberg field IDs, decoupled from
+/// dwio::common::ParquetFieldId to avoid exposing Parquet-specific types in
+/// public Iceberg connector APIs. Mirrors the hierarchical structure needed for
+/// nested schema support.
+struct IcebergFieldId {
+  int32_t fieldId{0};
+  std::vector<IcebergFieldId> children;
+};
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergFieldMetadata.h
+++ b/velox/connectors/hive/iceberg/IcebergFieldMetadata.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace facebook::velox::connector::hive::iceberg {
+
+/// Iceberg V3 type-disambiguation attributes for a single schema node,
+/// carried alongside (not folded into) the format-agnostic
+/// dwio::common::ParquetFieldId so the Iceberg V3 vocabulary does not leak
+/// into the 23+ Parquet call sites that consume ParquetFieldId.
+///
+/// Each field is optional and only set when the planner derived it from the
+/// Iceberg schema; an all-empty instance stamps nothing, keeping output
+/// byte-identical to a writer that only emits `iceberg.id`. The `children`
+/// vector parallels `ParquetFieldId::children` so the two trees are walked in
+/// lockstep. Values map to the Iceberg V3 ORC Appendix A attribute keys.
+struct IcebergFieldMetadata {
+  /// Maps to `iceberg.required` ("true"/"false").
+  std::optional<bool> required;
+
+  /// Maps to `iceberg.long-type` (e.g. "LONG").
+  std::optional<std::string> longType;
+
+  /// Maps to `iceberg.timestamp-unit` (e.g. "MICROS"/"NANOS").
+  std::optional<std::string> timestampUnit;
+
+  /// Maps to `iceberg.binary-type` (e.g. "FIXED"/"UUID"/"Variant").
+  std::optional<std::string> binaryType;
+
+  /// Maps to `iceberg.struct-type` (e.g. the Variant struct marker).
+  std::optional<std::string> structType;
+
+  /// Maps to `iceberg.length` (e.g. FixedType length, UUID length 16).
+  std::optional<int32_t> length;
+
+  /// Per-child metadata, parallel to ParquetFieldId::children.
+  std::vector<IcebergFieldMetadata> children;
+
+  /// True when no attribute on this node is set (children are not
+  /// considered).
+  bool empty() const {
+    return !required.has_value() && !longType.has_value() &&
+        !timestampUnit.has_value() && !binaryType.has_value() &&
+        !structType.has_value() && !length.has_value();
+  }
+};
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -188,6 +188,56 @@ void IcebergSplitReader::prepareSplit(
     std::shared_ptr<common::MetadataFilter> metadataFilter,
     dwio::common::RuntimeStatistics& runtimeStats,
     const folly::F14FastMap<std::string, std::string>& fileReadOps) {
+  // For NIMBLE splits, switch the reader to Iceberg field-id-based column
+  // resolution. The NIMBLE per-SchemaNode `attributes` slot carries
+  // `iceberg.id` keys stamped on the write path; the NIMBLE reader uses
+  // them to resolve projected columns under schema evolution (rename /
+  // reorder / add / drop). For other formats this branch is a no-op:
+  // each format-specific reader handles its own column mapping.
+  if (icebergSplit_->fileFormat == dwio::common::FileFormat::NIMBLE &&
+      columnHandles_ != nullptr) {
+    auto fileSchema = baseReaderOpts_.fileSchema();
+    if (fileSchema != nullptr && !fileSchema->names().empty()) {
+      // Build the requested field-id trees, one ParquetFieldId per requested
+      // file-schema column, in file-schema order. Each entry is the
+      // IcebergColumnHandle's field-id tree (per-input-column).
+      // Column handles are keyed by output alias; index them by physical name
+      // to mirror buildFieldIds() and support renamed columns.
+      std::unordered_map<std::string, const IcebergColumnHandle*> handleByName;
+      for (const auto& [outputName, handle] : *columnHandles_) {
+        if (auto* icebergHandle =
+                dynamic_cast<const IcebergColumnHandle*>(handle.get())) {
+          handleByName.emplace(icebergHandle->name(), icebergHandle);
+        }
+      }
+      std::vector<dwio::common::ParquetFieldId> fieldIds;
+      fieldIds.reserve(fileSchema->size());
+      bool allResolved = true;
+      for (size_t i = 0; i < fileSchema->size(); ++i) {
+        const auto& name = fileSchema->nameOf(static_cast<uint32_t>(i));
+        const auto it = handleByName.find(name);
+        if (it == handleByName.end()) {
+          allResolved = false;
+          break;
+        }
+        const auto icebergColumn = it->second;
+        if (icebergColumn == nullptr) {
+          allResolved = false;
+          break;
+        }
+        fieldIds.emplace_back(icebergColumn->field());
+      }
+      if (allResolved) {
+        baseReaderOpts_.setColumnMappingMode(
+            dwio::common::ColumnMappingMode::kFieldId);
+        baseReaderOpts_.setFieldIds(std::move(fieldIds));
+        // The NIMBLE reader resolves columns via the per-type "iceberg.id"
+        // attribute; supply the key here so the reader stays format-agnostic.
+        baseReaderOpts_.setFieldIdAttributeKey("iceberg.id");
+      }
+    }
+  }
+
   // Temporarily extend the file schema with projected row-lineage columns
   // (_row_id, _last_updated_sequence_number) so the reader allocates output
   // slots for them. Scoped to createReader() so getAdaptedRowType() sees the

--- a/velox/connectors/hive/iceberg/WriterOptionsAdapter.cpp
+++ b/velox/connectors/hive/iceberg/WriterOptionsAdapter.cpp
@@ -17,6 +17,9 @@
 #include "velox/connectors/hive/iceberg/WriterOptionsAdapter.h"
 
 #include "velox/common/base/Exceptions.h"
+#ifdef VELOX_ENABLE_NIMBLE
+#include "velox/connectors/hive/iceberg/fb/NimbleWriterOptionsAdapter.h"
+#endif
 #include "velox/dwio/dwrf/writer/Writer.h"
 #include "velox/dwio/parquet/common/ParquetConfig.h"
 
@@ -74,22 +77,12 @@ class DwrfWriterOptionsAdapter : public WriterOptionsAdapter {
   }
 };
 
-class NimbleWriterOptionsAdapter : public WriterOptionsAdapter {
- public:
-  // Reports NIMBLE files as ORC in the manifest so cross-engine readers
-  // (Presto coordinator, catalog) can interpret the commit message. The
-  // actual on-disk format is identified at read time via the file
-  // extension and on-disk magic bytes, not via this string.
-  std::string manifestFormatString() const override {
-    return std::string{kOrcManifestFormat};
-  }
-};
-
 } // namespace
 
 std::unique_ptr<WriterOptionsAdapter> createWriterOptionsAdapter(
-    dwio::common::FileFormat format) {
-  // NOLINTNEXTLINE(clang-diagnostic-switch-enum)
+    dwio::common::FileFormat format,
+    IcebergFieldId icebergFieldIds,
+    IcebergFieldMetadata icebergMetadata) {
   switch (format) {
     case dwio::common::FileFormat::PARQUET:
       return std::make_unique<ParquetWriterOptionsAdapter>();
@@ -101,8 +94,11 @@ std::unique_ptr<WriterOptionsAdapter> createWriterOptionsAdapter(
       // with the Java planner (see FileFormat.DWRF.toIceberg() in
       // presto-facebook-iceberg).
       return std::make_unique<DwrfWriterOptionsAdapter>();
+#ifdef VELOX_ENABLE_NIMBLE
     case dwio::common::FileFormat::NIMBLE:
-      return std::make_unique<NimbleWriterOptionsAdapter>();
+      return createNimbleWriterOptionsAdapter(
+          std::move(icebergFieldIds), std::move(icebergMetadata));
+#endif
     default:
       return nullptr;
   }

--- a/velox/connectors/hive/iceberg/WriterOptionsAdapter.h
+++ b/velox/connectors/hive/iceberg/WriterOptionsAdapter.h
@@ -19,6 +19,8 @@
 #include <memory>
 #include <string>
 
+#include "velox/connectors/hive/iceberg/IcebergFieldId.h"
+#include "velox/connectors/hive/iceberg/IcebergFieldMetadata.h"
 #include "velox/dwio/common/Options.h"
 
 namespace facebook::velox::connector::hive::iceberg {
@@ -52,8 +54,24 @@ class WriterOptionsAdapter {
 /// Returns the adapter for the given file format, or nullptr for
 /// unsupported formats. Single source of truth for which file formats the
 /// Iceberg DataSink supports on the write path.
+///
+/// `icebergFieldIds` carries the per-input-column Iceberg field-id tree.
+/// Honored only by the NIMBLE adapter, which uses it to stamp
+/// `iceberg.id` (and other Iceberg V3 keys) onto each NIMBLE schema node
+/// via `VeloxWriterOptions::attributesByColumn`. Pass an empty
+/// `IcebergFieldId{}` for formats / call sites that have no field-id tree
+/// available (the NIMBLE adapter then produces files without
+/// `iceberg.id` attributes, the same wire shape as a pre-attributes
+/// writer).
+///
+/// `icebergMetadata` carries the parallel Iceberg V3 type-attribute tree
+/// (`iceberg.required`, `iceberg.long-type`, etc.). Also honored only by
+/// the NIMBLE adapter; empty by default so the stamped output is
+/// byte-identical to an `iceberg.id`-only writer.
 std::unique_ptr<WriterOptionsAdapter> createWriterOptionsAdapter(
-    dwio::common::FileFormat format);
+    dwio::common::FileFormat format,
+    IcebergFieldId icebergFieldIds = {},
+    IcebergFieldMetadata icebergMetadata = {});
 
 /// True if the Iceberg DataSink can write the given file format.
 /// Supported formats: PARQUET, ORC, DWRF, NIMBLE. ORC and DWRF share

--- a/velox/connectors/hive/iceberg/tests/WriterOptionsAdapterTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/WriterOptionsAdapterTest.cpp
@@ -17,12 +17,49 @@
 #include "velox/connectors/hive/iceberg/WriterOptionsAdapter.h"
 
 #include <gtest/gtest.h>
+#ifdef VELOX_ENABLE_NIMBLE
+#include "dwio/nimble/velox/writer/fb/NimbleWriter.h"
+#endif
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
 #include "velox/dwio/dwrf/writer/Writer.h"
 #include "velox/dwio/parquet/common/ParquetConfig.h"
+#include "velox/type/Type.h"
 
 namespace facebook::velox::connector::hive::iceberg {
 namespace {
+
+// Verifies IcebergColumnHandle carries the Iceberg V3 metadata supplied at
+// construction and exposes it via icebergMetadata(), and that the default
+// (omitted) metadata is empty for legacy callers.
+TEST(WriterOptionsAdapterTest, icebergColumnHandleCarriesMetadata) {
+  IcebergFieldMetadata metadata;
+  metadata.required = true;
+  metadata.binaryType = "UUID";
+  metadata.length = 16;
+
+  IcebergColumnHandle handle(
+      "u",
+      HiveColumnHandle::ColumnType::kRegular,
+      VARBINARY(),
+      parquet::ParquetFieldId{/*fieldId*/ 5, /*children*/ {}},
+      /*requiredSubfields*/ {},
+      /*initialDefaultValue*/ std::nullopt,
+      metadata);
+
+  const auto& recovered = handle.icebergMetadata();
+  EXPECT_TRUE(recovered.required);
+  EXPECT_EQ(recovered.binaryType, "UUID");
+  EXPECT_EQ(recovered.length, 16);
+
+  // Legacy callers that omit metadata get an empty instance.
+  IcebergColumnHandle legacyHandle(
+      "a",
+      HiveColumnHandle::ColumnType::kRegular,
+      BIGINT(),
+      parquet::ParquetFieldId{/*fieldId*/ 1, /*children*/ {}});
+  EXPECT_TRUE(legacyHandle.icebergMetadata().empty());
+}
 
 // Verifies the dispatch table in createWriterOptionsAdapter():
 // PARQUET, ORC, DWRF, NIMBLE return non-null adapters; everything else
@@ -36,8 +73,10 @@ TEST(WriterOptionsAdapterTest, createWriterOptionsAdapterDispatch) {
   EXPECT_NE(createWriterOptionsAdapter(dwio::common::FileFormat::ORC), nullptr);
   EXPECT_NE(
       createWriterOptionsAdapter(dwio::common::FileFormat::DWRF), nullptr);
+#ifdef VELOX_ENABLE_NIMBLE
   EXPECT_NE(
       createWriterOptionsAdapter(dwio::common::FileFormat::NIMBLE), nullptr);
+#endif
 
   // TEXT, JSON, ALPHA, etc. are intentionally unsupported on the
   // write path until each gets its own end-to-end coverage.
@@ -52,7 +91,9 @@ TEST(WriterOptionsAdapterTest, isSupportedFileFormatMatchesDispatch) {
   EXPECT_TRUE(isSupportedFileFormat(dwio::common::FileFormat::PARQUET));
   EXPECT_TRUE(isSupportedFileFormat(dwio::common::FileFormat::ORC));
   EXPECT_TRUE(isSupportedFileFormat(dwio::common::FileFormat::DWRF));
+#ifdef VELOX_ENABLE_NIMBLE
   EXPECT_TRUE(isSupportedFileFormat(dwio::common::FileFormat::NIMBLE));
+#endif
 
   EXPECT_FALSE(isSupportedFileFormat(dwio::common::FileFormat::TEXT));
   EXPECT_FALSE(isSupportedFileFormat(dwio::common::FileFormat::JSON));
@@ -71,7 +112,9 @@ TEST(WriterOptionsAdapterTest, toManifestFormatString) {
       toManifestFormatString(dwio::common::FileFormat::PARQUET), "PARQUET");
   EXPECT_EQ(toManifestFormatString(dwio::common::FileFormat::ORC), "ORC");
   EXPECT_EQ(toManifestFormatString(dwio::common::FileFormat::DWRF), "ORC");
+#ifdef VELOX_ENABLE_NIMBLE
   EXPECT_EQ(toManifestFormatString(dwio::common::FileFormat::NIMBLE), "ORC");
+#endif
 }
 
 // Verifies the Parquet adapter's pre-config hook installs the Iceberg-spec
@@ -142,6 +185,254 @@ TEST(WriterOptionsAdapterTest, toManifestFormatStringThrowsForUnsupported) {
       toManifestFormatString(dwio::common::FileFormat::JSON),
       "Unsupported file format for Iceberg manifest");
 }
+
+#ifdef VELOX_ENABLE_NIMBLE
+// ---------------------------------------------------------------------------
+// NIMBLE Iceberg V3 attribute stamping.
+//
+// Verifies that IcebergDataSink correctly stamps Iceberg field IDs and V3
+// type attributes onto Nimble writer options via the WriterOptionsAdapter.
+// The adapter converts the IcebergFieldId tree into dotted-path attributes
+// (e.g., "a.b" -> {"iceberg.id":"2", "iceberg.required":"true"}) that survive
+// through NimbleWriterFactory into the Nimble file schema. These tests ensure
+// the writer-side contract is preserved: empty trees are no-ops for backward
+// compatibility, and populated trees produce correct per-column attributes.
+// ---------------------------------------------------------------------------
+
+// Verifies an empty Iceberg field-id tree is a no-op: attributesByColumn
+// stays empty after applyPostConfigs. This is the no-op upgrade path for
+// every existing NIMBLE writer call site -- the on-disk file is
+// byte-identical to pre-stack output.
+TEST(WriterOptionsAdapterTest, nimbleApplyPostConfigsEmptyTreeIsNoOp) {
+  auto adapter = createWriterOptionsAdapter(
+      dwio::common::FileFormat::NIMBLE, IcebergFieldId{});
+  ASSERT_NE(adapter, nullptr);
+
+  velox::nimble::NimbleWriterOptions options;
+  options.schema = ROW({"a"}, {INTEGER()});
+  adapter->applyPostConfigs(options);
+
+  EXPECT_TRUE(options.attributesByColumn.empty());
+}
+
+// Verifies the NIMBLE adapter stamps `iceberg.id` onto top-level columns
+// in the dotted-path keyed map. The walk goes through the schema in
+// lockstep with the field-id tree, so each column gets the right id.
+TEST(WriterOptionsAdapterTest, nimbleApplyPostConfigsStampsTopLevelIcebergIds) {
+  // Build a synthetic top-level wrapper with one child per column,
+  // matching how IcebergDataSink constructs the tree.
+  IcebergFieldId icebergFieldIds;
+  icebergFieldIds.children.emplace_back(
+      IcebergFieldId{/*fieldId*/ 7, /*children*/ {}});
+  icebergFieldIds.children.emplace_back(
+      IcebergFieldId{/*fieldId*/ 12, /*children*/ {}});
+
+  auto adapter = createWriterOptionsAdapter(
+      dwio::common::FileFormat::NIMBLE, std::move(icebergFieldIds));
+  ASSERT_NE(adapter, nullptr);
+
+  velox::nimble::NimbleWriterOptions options;
+  options.schema = ROW({"id", "name"}, {BIGINT(), VARCHAR()});
+
+  adapter->applyPostConfigs(options);
+
+  ASSERT_EQ(options.attributesByColumn.size(), 2u);
+  ASSERT_EQ(options.attributesByColumn.count("id"), 1u);
+  ASSERT_EQ(options.attributesByColumn.count("name"), 1u);
+
+  const std::vector<std::pair<std::string, std::string>> kIdAttrs = {
+      {"iceberg.id", "7"},
+  };
+  const std::vector<std::pair<std::string, std::string>> kNameAttrs = {
+      {"iceberg.id", "12"},
+  };
+  EXPECT_EQ(options.attributesByColumn.at("id"), kIdAttrs);
+  EXPECT_EQ(options.attributesByColumn.at("name"), kNameAttrs);
+}
+
+// Verifies the NIMBLE adapter recurses into nested struct (RowType)
+// children, producing dotted-path keys like "user.name". Diff B's
+// writer-side resolveDottedPath supports this case directly. Array/Map
+// nested field-ids are deferred to a follow-up.
+TEST(WriterOptionsAdapterTest, nimbleApplyPostConfigsStampsNestedStructIds) {
+  IcebergFieldId icebergFieldIds;
+  // Top-level child 0 = column "user" (id 1) with two nested struct
+  // children: "name" (id 2) and "age" (id 3).
+  IcebergFieldId userField;
+  userField.fieldId = 1;
+  userField.children.emplace_back(
+      IcebergFieldId{/*fieldId*/ 2, /*children*/ {}});
+  userField.children.emplace_back(
+      IcebergFieldId{/*fieldId*/ 3, /*children*/ {}});
+  icebergFieldIds.children.emplace_back(std::move(userField));
+
+  auto adapter = createWriterOptionsAdapter(
+      dwio::common::FileFormat::NIMBLE, std::move(icebergFieldIds));
+  ASSERT_NE(adapter, nullptr);
+
+  velox::nimble::NimbleWriterOptions options;
+  options.schema =
+      ROW({"user"}, {ROW({"name", "age"}, {VARCHAR(), INTEGER()})});
+
+  adapter->applyPostConfigs(options);
+
+  // Parent struct + both leaves all annotated with their field-ids.
+  ASSERT_EQ(options.attributesByColumn.size(), 3u);
+  const std::vector<std::pair<std::string, std::string>> kUserAttrs = {
+      {"iceberg.id", "1"},
+  };
+  const std::vector<std::pair<std::string, std::string>> kNameAttrs = {
+      {"iceberg.id", "2"},
+  };
+  const std::vector<std::pair<std::string, std::string>> kAgeAttrs = {
+      {"iceberg.id", "3"},
+  };
+  EXPECT_EQ(options.attributesByColumn.at("user"), kUserAttrs);
+  EXPECT_EQ(options.attributesByColumn.at("user.name"), kNameAttrs);
+  EXPECT_EQ(options.attributesByColumn.at("user.age"), kAgeAttrs);
+}
+
+// Verifies the NIMBLE adapter stamps the Iceberg V3 type attributes carried
+// in the parallel IcebergFieldMetadata tree. The UUID case sets
+// `iceberg.binary-type=UUID` and `iceberg.length=16` together alongside
+// `iceberg.required`, in addition to the always-present `iceberg.id`.
+TEST(WriterOptionsAdapterTest, nimbleApplyPostConfigsStampsV3Attributes) {
+  IcebergFieldId icebergFieldIds;
+  icebergFieldIds.children.emplace_back(
+      IcebergFieldId{/*fieldId*/ 5, /*children*/ {}});
+
+  IcebergFieldMetadata metadata;
+  IcebergFieldMetadata uuidColumn;
+  uuidColumn.required = true;
+  uuidColumn.binaryType = "UUID";
+  uuidColumn.length = 16;
+  metadata.children.push_back(std::move(uuidColumn));
+
+  auto adapter = createWriterOptionsAdapter(
+      dwio::common::FileFormat::NIMBLE,
+      std::move(icebergFieldIds),
+      std::move(metadata));
+  ASSERT_NE(adapter, nullptr);
+
+  velox::nimble::NimbleWriterOptions options;
+  options.schema = ROW({"u"}, {VARBINARY()});
+  adapter->applyPostConfigs(options);
+
+  const std::vector<std::pair<std::string, std::string>> kExpected = {
+      {"iceberg.id", "5"},
+      {"iceberg.required", "true"},
+      {"iceberg.binary-type", "UUID"},
+      {"iceberg.length", "16"},
+  };
+  EXPECT_EQ(options.attributesByColumn.at("u"), kExpected);
+}
+
+// Verifies V3 attributes are stamped only on the columns that supply them;
+// a column with empty metadata keeps the `iceberg.id`-only shape.
+TEST(
+    WriterOptionsAdapterTest,
+    nimbleApplyPostConfigsStampsRequiredOnlyWhenSet) {
+  IcebergFieldId icebergFieldIds;
+  icebergFieldIds.children.emplace_back(
+      IcebergFieldId{/*fieldId*/ 1, /*children*/ {}});
+  icebergFieldIds.children.emplace_back(
+      IcebergFieldId{/*fieldId*/ 2, /*children*/ {}});
+
+  IcebergFieldMetadata metadata;
+  IcebergFieldMetadata requiredColumn;
+  requiredColumn.required = true;
+  metadata.children.push_back(std::move(requiredColumn));
+  // Second column intentionally has empty metadata.
+  metadata.children.emplace_back();
+
+  auto adapter = createWriterOptionsAdapter(
+      dwio::common::FileFormat::NIMBLE,
+      std::move(icebergFieldIds),
+      std::move(metadata));
+  ASSERT_NE(adapter, nullptr);
+
+  velox::nimble::NimbleWriterOptions options;
+  options.schema = ROW({"a", "b"}, {BIGINT(), BIGINT()});
+  adapter->applyPostConfigs(options);
+
+  const std::vector<std::pair<std::string, std::string>> kRequiredAttrs = {
+      {"iceberg.id", "1"},
+      {"iceberg.required", "true"},
+  };
+  const std::vector<std::pair<std::string, std::string>> kPlainAttrs = {
+      {"iceberg.id", "2"},
+  };
+  EXPECT_EQ(options.attributesByColumn.at("a"), kRequiredAttrs);
+  EXPECT_EQ(options.attributesByColumn.at("b"), kPlainAttrs);
+}
+
+// Verifies the V3 attribute tree is walked in lockstep with nested struct
+// children, so each leaf gets its own attributes at the right dotted path.
+TEST(WriterOptionsAdapterTest, nimbleApplyPostConfigsStampsNestedStructV3) {
+  IcebergFieldId icebergFieldIds;
+  IcebergFieldId userField;
+  userField.fieldId = 1;
+  userField.children.emplace_back(
+      IcebergFieldId{/*fieldId*/ 2, /*children*/ {}});
+  userField.children.emplace_back(
+      IcebergFieldId{/*fieldId*/ 3, /*children*/ {}});
+  icebergFieldIds.children.emplace_back(std::move(userField));
+
+  IcebergFieldMetadata metadata;
+  IcebergFieldMetadata userMetadata;
+  IcebergFieldMetadata idMetadata;
+  idMetadata.required = true;
+  idMetadata.longType = "LONG";
+  IcebergFieldMetadata tsMetadata;
+  tsMetadata.timestampUnit = "MICROS";
+  userMetadata.children.push_back(std::move(idMetadata));
+  userMetadata.children.push_back(std::move(tsMetadata));
+  metadata.children.push_back(std::move(userMetadata));
+
+  auto adapter = createWriterOptionsAdapter(
+      dwio::common::FileFormat::NIMBLE,
+      std::move(icebergFieldIds),
+      std::move(metadata));
+  ASSERT_NE(adapter, nullptr);
+
+  velox::nimble::NimbleWriterOptions options;
+  options.schema = ROW({"user"}, {ROW({"id", "ts"}, {BIGINT(), TIMESTAMP()})});
+  adapter->applyPostConfigs(options);
+
+  const std::vector<std::pair<std::string, std::string>> kIdAttrs = {
+      {"iceberg.id", "2"},
+      {"iceberg.required", "true"},
+      {"iceberg.long-type", "LONG"},
+  };
+  const std::vector<std::pair<std::string, std::string>> kTsAttrs = {
+      {"iceberg.id", "3"},
+      {"iceberg.timestamp-unit", "MICROS"},
+  };
+  EXPECT_EQ(options.attributesByColumn.at("user.id"), kIdAttrs);
+  EXPECT_EQ(options.attributesByColumn.at("user.ts"), kTsAttrs);
+}
+
+// Defends against passing a non-NIMBLE WriterOptions to
+// NimbleWriterOptionsAdapter -- e.g. via a wrong dispatch in the factory.
+// The adapter should silently no-op rather than mutate an unrelated
+// options object.
+TEST(WriterOptionsAdapterTest, nimbleApplyPostConfigsIgnoresNonNimbleOptions) {
+  IcebergFieldId icebergFieldIds;
+  icebergFieldIds.children.emplace_back(
+      IcebergFieldId{/*fieldId*/ 1, /*children*/ {}});
+
+  auto adapter = createWriterOptionsAdapter(
+      dwio::common::FileFormat::NIMBLE, std::move(icebergFieldIds));
+  ASSERT_NE(adapter, nullptr);
+
+  // Pass a plain WriterOptions (NOT a NimbleWriterOptions). The
+  // dynamic_cast should fail and the adapter should leave the object
+  // untouched.
+  dwio::common::WriterOptions options;
+  options.schema = ROW({"a"}, {INTEGER()});
+  EXPECT_NO_THROW(adapter->applyPostConfigs(options));
+}
+#endif // VELOX_ENABLE_NIMBLE
 
 } // namespace
 } // namespace facebook::velox::connector::hive::iceberg


### PR DESCRIPTION
Summary:

Velox Hive-Iceberg connector support for Iceberg V3 field-ids / type-attributes and
NIMBLE writer stats. Depends on the FB-internal nimble writer below it
(IcebergNimbleStatsCollector / WriterOptionsAdapter #include writer/fb headers).

- IcebergColumnHandle/IcebergDataSink/IcebergSplitReader: field-id plumbing.
- IcebergFieldMetadata.h, IcebergNimbleStatsCollector: per-column NIMBLE stats.
- WriterOptionsAdapter: bridge writer options to the nimble writer.
- tests: IcebergNimbleStatsTest, WriterOptionsAdapterTest.

Top of the velox/nimble portion of the consolidated Iceberg-V3 stack; split out of the
former combined velox diff D108699499.

Reviewed By: srsuryadev

Differential Revision: D108700352


