### PR TITLE
feat: NIMBLE Iceberg field-id end-to-end write+read test

### DIFF
--- a/velox/connectors/hive/iceberg/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/CMakeLists.txt
@@ -70,6 +70,8 @@ velox_add_library(
   TransformEvaluator.h
   TransformExprBuilder.h
   WriterOptionsAdapter.h
+  IcebergFieldId.h
+  IcebergFieldMetadata.h
 )
 
 velox_link_libraries(

--- a/velox/connectors/hive/iceberg/IcebergColumnHandle.cpp
+++ b/velox/connectors/hive/iceberg/IcebergColumnHandle.cpp
@@ -32,7 +32,8 @@ IcebergColumnHandle::IcebergColumnHandle(
     TypePtr dataType,
     parquet::ParquetFieldId icebergField,
     std::vector<common::Subfield> requiredSubfields,
-    std::optional<std::string> initialDefaultValue)
+    std::optional<std::string> initialDefaultValue,
+    IcebergFieldMetadata icebergMetadata)
     : HiveColumnHandle(
           name,
           columnType,
@@ -42,7 +43,8 @@ IcebergColumnHandle::IcebergColumnHandle(
           ColumnParseParameters{ColumnParseParameters::
                                     PartitionDateValueFormat::kDaysSinceEpoch}),
       field_(std::move(icebergField)),
-      initialDefaultValue_(std::move(initialDefaultValue)) {}
+      initialDefaultValue_(std::move(initialDefaultValue)),
+      icebergMetadata_(std::move(icebergMetadata)) {}
 
 const parquet::ParquetFieldId& IcebergColumnHandle::field() const {
   return field_;

--- a/velox/connectors/hive/iceberg/IcebergColumnHandle.h
+++ b/velox/connectors/hive/iceberg/IcebergColumnHandle.h
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "velox/connectors/hive/TableHandle.h"
+#include "velox/connectors/hive/iceberg/IcebergFieldMetadata.h"
 #include "velox/dwio/common/ParquetFieldId.h"
 #include "velox/type/Subfield.h"
 #include "velox/type/Type.h"
@@ -34,9 +35,16 @@ class IcebergColumnHandle : public HiveColumnHandle {
       TypePtr dataType,
       parquet::ParquetFieldId icebergField,
       std::vector<common::Subfield> requiredSubfields = {},
-      std::optional<std::string> initialDefaultValue = std::nullopt);
+      std::optional<std::string> initialDefaultValue = std::nullopt,
+      IcebergFieldMetadata icebergMetadata = {});
 
   const parquet::ParquetFieldId& field() const;
+
+  /// Iceberg V3 type-disambiguation attributes for this column, parallel to
+  /// field(). Empty for callers that do not supply V3 metadata.
+  const IcebergFieldMetadata& icebergMetadata() const {
+    return icebergMetadata_;
+  }
 
   const std::optional<std::string>& initialDefaultValue() const {
     return initialDefaultValue_;
@@ -45,6 +53,7 @@ class IcebergColumnHandle : public HiveColumnHandle {
  private:
   const parquet::ParquetFieldId field_;
   const std::optional<std::string> initialDefaultValue_;
+  const IcebergFieldMetadata icebergMetadata_;
 };
 
 using IcebergColumnHandlePtr = std::shared_ptr<const IcebergColumnHandle>;

--- a/velox/connectors/hive/iceberg/IcebergDataSink.cpp
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.cpp
@@ -31,6 +31,7 @@
 #include "velox/common/testutil/TestValue.h"
 #include "velox/connectors/hive/PartitionIdGenerator.h"
 #include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
+#include "velox/connectors/hive/iceberg/IcebergFieldId.h"
 #include "velox/connectors/hive/iceberg/IcebergStatsCollector.h"
 
 #ifdef VELOX_ENABLE_PARQUET
@@ -452,11 +453,48 @@ std::shared_ptr<dwio::common::WriterOptions>
 IcebergDataSink::createWriterOptions(size_t writerIndex) const {
   auto options = HiveDataSink::createWriterOptions(writerIndex);
 
+  // Build a synthetic top-level IcebergFieldId tree from inputColumns_ to
+  // carry per-column Iceberg field IDs across the adapter boundary. This
+  // matches IcebergParquetStatsCollector's parquetFieldIds() shape: a
+  // root container whose `children` are one entry per input column. The
+  // tree is consumed by the format-specific adapter (NIMBLE today;
+  // others can opt in by overriding applyPostConfigs in their adapter).
+  IcebergFieldId icebergFieldIds{};
+  icebergFieldIds.children.reserve(
+      icebergInsertTableHandle_->inputColumns().size());
+  // Parallel Iceberg V3 type-attribute tree, one child per input column,
+  // drawn from each IcebergColumnHandle::icebergMetadata(). Walked in
+  // lockstep with icebergFieldIds by the NIMBLE adapter.
+  IcebergFieldMetadata icebergMetadata;
+  icebergMetadata.children.reserve(
+      icebergInsertTableHandle_->inputColumns().size());
+  for (const auto& column : icebergInsertTableHandle_->inputColumns()) {
+    const auto& icebergColumn =
+        checkedPointerCast<const IcebergColumnHandle>(column);
+    const auto& srcField = icebergColumn->field();
+    // Convert dwio ParquetFieldId to connector-local IcebergFieldId at
+    // boundary.
+    std::function<IcebergFieldId(const dwio::common::ParquetFieldId&)> convert =
+        [&](const dwio::common::ParquetFieldId& src) -> IcebergFieldId {
+      IcebergFieldId dst{};
+      dst.fieldId = src.fieldId;
+      dst.children.reserve(src.children.size());
+      for (const auto& child : src.children) {
+        dst.children.emplace_back(convert(child));
+      }
+      return dst;
+    };
+    icebergFieldIds.children.emplace_back(convert(srcField));
+    icebergMetadata.children.emplace_back(icebergColumn->icebergMetadata());
+  }
+
   // Dispatch format-specific Iceberg overrides through the adapter so each
   // supported format (Parquet, DWRF, Nimble) gets its pre/post-processConfigs
   // hooks applied uniformly.
-  const auto adapter =
-      createWriterOptionsAdapter(icebergInsertTableHandle_->storageFormat());
+  const auto adapter = createWriterOptionsAdapter(
+      icebergInsertTableHandle_->storageFormat(),
+      std::move(icebergFieldIds),
+      std::move(icebergMetadata));
   if (adapter != nullptr) {
     adapter->applyPreConfigs(*options);
   }

--- a/velox/connectors/hive/iceberg/IcebergDataSink.h
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.h
@@ -27,6 +27,10 @@
 #include "velox/connectors/hive/iceberg/IcebergDataFileStatistics.h"
 #include "velox/connectors/hive/iceberg/IcebergStatsCollector.h"
 
+#ifdef VELOX_ENABLE_NIMBLE
+#include "velox/connectors/hive/iceberg/fb/IcebergNimbleStatsCollector.h"
+#endif
+
 #include "velox/connectors/hive/iceberg/IcebergConfig.h"
 #include "velox/connectors/hive/iceberg/IcebergPartitionName.h"
 #include "velox/connectors/hive/iceberg/PartitionSpec.h"

--- a/velox/connectors/hive/iceberg/IcebergFieldId.h
+++ b/velox/connectors/hive/iceberg/IcebergFieldId.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace facebook::velox::connector::hive::iceberg {
+
+/// Connector-local representation of Iceberg field IDs, decoupled from
+/// dwio::common::ParquetFieldId to avoid exposing Parquet-specific types in
+/// public Iceberg connector APIs. Mirrors the hierarchical structure needed for
+/// nested schema support.
+struct IcebergFieldId {
+  int32_t fieldId{0};
+  std::vector<IcebergFieldId> children;
+};
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergFieldMetadata.h
+++ b/velox/connectors/hive/iceberg/IcebergFieldMetadata.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace facebook::velox::connector::hive::iceberg {
+
+/// Iceberg V3 type-disambiguation attributes for a single schema node,
+/// carried alongside (not folded into) the format-agnostic
+/// dwio::common::ParquetFieldId so the Iceberg V3 vocabulary does not leak
+/// into the 23+ Parquet call sites that consume ParquetFieldId.
+///
+/// Each field is optional and only set when the planner derived it from the
+/// Iceberg schema; an all-empty instance stamps nothing, keeping output
+/// byte-identical to a writer that only emits `iceberg.id`. The `children`
+/// vector parallels `ParquetFieldId::children` so the two trees are walked in
+/// lockstep. Values map to the Iceberg V3 ORC Appendix A attribute keys.
+struct IcebergFieldMetadata {
+  /// Maps to `iceberg.required` ("true"/"false").
+  std::optional<bool> required;
+
+  /// Maps to `iceberg.long-type` (e.g. "LONG").
+  std::optional<std::string> longType;
+
+  /// Maps to `iceberg.timestamp-unit` (e.g. "MICROS"/"NANOS").
+  std::optional<std::string> timestampUnit;
+
+  /// Maps to `iceberg.binary-type` (e.g. "FIXED"/"UUID"/"Variant").
+  std::optional<std::string> binaryType;
+
+  /// Maps to `iceberg.struct-type` (e.g. the Variant struct marker).
+  std::optional<std::string> structType;
+
+  /// Maps to `iceberg.length` (e.g. FixedType length, UUID length 16).
+  std::optional<int32_t> length;
+
+  /// Per-child metadata, parallel to ParquetFieldId::children.
+  std::vector<IcebergFieldMetadata> children;
+
+  /// True when no attribute on this node is set (children are not
+  /// considered).
+  bool empty() const {
+    return !required.has_value() && !longType.has_value() &&
+        !timestampUnit.has_value() && !binaryType.has_value() &&
+        !structType.has_value() && !length.has_value();
+  }
+};
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -188,6 +188,56 @@ void IcebergSplitReader::prepareSplit(
     std::shared_ptr<common::MetadataFilter> metadataFilter,
     dwio::common::RuntimeStatistics& runtimeStats,
     const folly::F14FastMap<std::string, std::string>& fileReadOps) {
+  // For NIMBLE splits, switch the reader to Iceberg field-id-based column
+  // resolution. The NIMBLE per-SchemaNode `attributes` slot carries
+  // `iceberg.id` keys stamped on the write path; the NIMBLE reader uses
+  // them to resolve projected columns under schema evolution (rename /
+  // reorder / add / drop). For other formats this branch is a no-op:
+  // each format-specific reader handles its own column mapping.
+  if (icebergSplit_->fileFormat == dwio::common::FileFormat::NIMBLE &&
+      columnHandles_ != nullptr) {
+    auto fileSchema = baseReaderOpts_.fileSchema();
+    if (fileSchema != nullptr && !fileSchema->names().empty()) {
+      // Build the requested field-id trees, one ParquetFieldId per requested
+      // file-schema column, in file-schema order. Each entry is the
+      // IcebergColumnHandle's field-id tree (per-input-column).
+      // Column handles are keyed by output alias; index them by physical name
+      // to mirror buildFieldIds() and support renamed columns.
+      std::unordered_map<std::string, const IcebergColumnHandle*> handleByName;
+      for (const auto& [outputName, handle] : *columnHandles_) {
+        if (auto* icebergHandle =
+                dynamic_cast<const IcebergColumnHandle*>(handle.get())) {
+          handleByName.emplace(icebergHandle->name(), icebergHandle);
+        }
+      }
+      std::vector<dwio::common::ParquetFieldId> fieldIds;
+      fieldIds.reserve(fileSchema->size());
+      bool allResolved = true;
+      for (size_t i = 0; i < fileSchema->size(); ++i) {
+        const auto& name = fileSchema->nameOf(static_cast<uint32_t>(i));
+        const auto it = handleByName.find(name);
+        if (it == handleByName.end()) {
+          allResolved = false;
+          break;
+        }
+        const auto icebergColumn = it->second;
+        if (icebergColumn == nullptr) {
+          allResolved = false;
+          break;
+        }
+        fieldIds.emplace_back(icebergColumn->field());
+      }
+      if (allResolved) {
+        baseReaderOpts_.setColumnMappingMode(
+            dwio::common::ColumnMappingMode::kFieldId);
+        baseReaderOpts_.setFieldIds(std::move(fieldIds));
+        // The NIMBLE reader resolves columns via the per-type "iceberg.id"
+        // attribute; supply the key here so the reader stays format-agnostic.
+        baseReaderOpts_.setFieldIdAttributeKey("iceberg.id");
+      }
+    }
+  }
+
   // Temporarily extend the file schema with projected row-lineage columns
   // (_row_id, _last_updated_sequence_number) so the reader allocates output
   // slots for them. Scoped to createReader() so getAdaptedRowType() sees the

--- a/velox/connectors/hive/iceberg/WriterOptionsAdapter.cpp
+++ b/velox/connectors/hive/iceberg/WriterOptionsAdapter.cpp
@@ -17,6 +17,9 @@
 #include "velox/connectors/hive/iceberg/WriterOptionsAdapter.h"
 
 #include "velox/common/base/Exceptions.h"
+#ifdef VELOX_ENABLE_NIMBLE
+#include "velox/connectors/hive/iceberg/fb/NimbleWriterOptionsAdapter.h"
+#endif
 #include "velox/dwio/dwrf/writer/Writer.h"
 #include "velox/dwio/parquet/common/ParquetConfig.h"
 
@@ -74,22 +77,12 @@ class DwrfWriterOptionsAdapter : public WriterOptionsAdapter {
   }
 };
 
-class NimbleWriterOptionsAdapter : public WriterOptionsAdapter {
- public:
-  // Reports NIMBLE files as ORC in the manifest so cross-engine readers
-  // (Presto coordinator, catalog) can interpret the commit message. The
-  // actual on-disk format is identified at read time via the file
-  // extension and on-disk magic bytes, not via this string.
-  std::string manifestFormatString() const override {
-    return std::string{kOrcManifestFormat};
-  }
-};
-
 } // namespace
 
 std::unique_ptr<WriterOptionsAdapter> createWriterOptionsAdapter(
-    dwio::common::FileFormat format) {
-  // NOLINTNEXTLINE(clang-diagnostic-switch-enum)
+    dwio::common::FileFormat format,
+    IcebergFieldId icebergFieldIds,
+    IcebergFieldMetadata icebergMetadata) {
   switch (format) {
     case dwio::common::FileFormat::PARQUET:
       return std::make_unique<ParquetWriterOptionsAdapter>();
@@ -101,8 +94,11 @@ std::unique_ptr<WriterOptionsAdapter> createWriterOptionsAdapter(
       // with the Java planner (see FileFormat.DWRF.toIceberg() in
       // presto-facebook-iceberg).
       return std::make_unique<DwrfWriterOptionsAdapter>();
+#ifdef VELOX_ENABLE_NIMBLE
     case dwio::common::FileFormat::NIMBLE:
-      return std::make_unique<NimbleWriterOptionsAdapter>();
+      return createNimbleWriterOptionsAdapter(
+          std::move(icebergFieldIds), std::move(icebergMetadata));
+#endif
     default:
       return nullptr;
   }

--- a/velox/connectors/hive/iceberg/WriterOptionsAdapter.h
+++ b/velox/connectors/hive/iceberg/WriterOptionsAdapter.h
@@ -19,6 +19,8 @@
 #include <memory>
 #include <string>
 
+#include "velox/connectors/hive/iceberg/IcebergFieldId.h"
+#include "velox/connectors/hive/iceberg/IcebergFieldMetadata.h"
 #include "velox/dwio/common/Options.h"
 
 namespace facebook::velox::connector::hive::iceberg {
@@ -52,8 +54,24 @@ class WriterOptionsAdapter {
 /// Returns the adapter for the given file format, or nullptr for
 /// unsupported formats. Single source of truth for which file formats the
 /// Iceberg DataSink supports on the write path.
+///
+/// `icebergFieldIds` carries the per-input-column Iceberg field-id tree.
+/// Honored only by the NIMBLE adapter, which uses it to stamp
+/// `iceberg.id` (and other Iceberg V3 keys) onto each NIMBLE schema node
+/// via `VeloxWriterOptions::attributesByColumn`. Pass an empty
+/// `IcebergFieldId{}` for formats / call sites that have no field-id tree
+/// available (the NIMBLE adapter then produces files without
+/// `iceberg.id` attributes, the same wire shape as a pre-attributes
+/// writer).
+///
+/// `icebergMetadata` carries the parallel Iceberg V3 type-attribute tree
+/// (`iceberg.required`, `iceberg.long-type`, etc.). Also honored only by
+/// the NIMBLE adapter; empty by default so the stamped output is
+/// byte-identical to an `iceberg.id`-only writer.
 std::unique_ptr<WriterOptionsAdapter> createWriterOptionsAdapter(
-    dwio::common::FileFormat format);
+    dwio::common::FileFormat format,
+    IcebergFieldId icebergFieldIds = {},
+    IcebergFieldMetadata icebergMetadata = {});
 
 /// True if the Iceberg DataSink can write the given file format.
 /// Supported formats: PARQUET, ORC, DWRF, NIMBLE. ORC and DWRF share

--- a/velox/connectors/hive/iceberg/tests/IcebergNimbleInsertTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergNimbleInsertTest.cpp
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/velox/reader/fb/NimbleReader.h"
+#include "dwio/nimble/velox/writer/fb/NimbleWriter.h"
+#include "velox/connectors/hive/HiveConfig.h"
+#include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
+#include "velox/connectors/hive/iceberg/tests/IcebergTestBase.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+using namespace facebook::velox::common::testutil;
+
+namespace facebook::velox::connector::hive::iceberg {
+namespace {
+
+// Iceberg field-id column resolution under schema evolution only runs in the
+// batch NimbleReader, not the selective reader. The connector session property
+// "selective_nimble_reader_enabled" defaults to true, so the field-id read
+// queries below set it to false to exercise the batch path.
+constexpr const char* kSelectiveNimbleReaderEnabled{
+    "selective_nimble_reader_enabled"};
+
+/// End-to-end tests for writing and reading Iceberg tables using the NIMBLE
+/// file format, mirroring IcebergDwrfInsertTest. Exercises the full write path
+/// (IcebergDataSink -> NIMBLE writer, which stamps iceberg.id attributes via
+/// NimbleWriterOptionsAdapter) and the full read path (IcebergSplitReader ->
+/// batch NimbleReader, which resolves columns by Iceberg field id and null-
+/// fills added columns).
+class IcebergNimbleInsertTest : public test::IcebergTestBase {
+ protected:
+  void SetUp() override {
+    IcebergTestBase::SetUp();
+    nimble::registerNimbleReaderFactory();
+    nimble::registerNimbleWriterFactory();
+    fileFormat_ = dwio::common::FileFormat::NIMBLE;
+  }
+
+  void TearDown() override {
+    nimble::unregisterNimbleReaderFactory();
+    nimble::unregisterNimbleWriterFactory();
+    IcebergTestBase::TearDown();
+  }
+
+  /// Write test data using NIMBLE format, then read it back and verify results.
+  void test(const RowTypePtr& rowType, double nullRatio = 0.0) {
+    const auto outputDirectory = TempDirectoryPath::create();
+    const auto dataPath = outputDirectory->getPath();
+    constexpr int32_t numBatches = 10;
+    constexpr int32_t vectorSize = 5'000;
+    const auto vectors =
+        createTestData(rowType, numBatches, vectorSize, nullRatio);
+    const auto dataSink = createDataSinkAndAppendData(vectors, dataPath);
+    const auto commitTasks = dataSink->close();
+
+    auto splits = createSplitsForDirectory(dataPath);
+    ASSERT_EQ(splits.size(), commitTasks.size());
+    auto plan = exec::test::PlanBuilder()
+                    .startTableScan()
+                    .connectorId(test::kIcebergConnectorId)
+                    .outputType(rowType)
+                    .endTableScan()
+                    .planNode();
+    exec::test::AssertQueryBuilder(plan).splits(splits).assertResults(vectors);
+  }
+};
+
+// No schema evolution: write and read the same schema. Sanity check for the
+// NIMBLE connector write+read path and iceberg.id stamping.
+TEST_F(IcebergNimbleInsertTest, roundTrip) {
+  auto rowType =
+      ROW({"c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8"},
+          {BIGINT(),
+           INTEGER(),
+           SMALLINT(),
+           BOOLEAN(),
+           REAL(),
+           VARCHAR(),
+           VARBINARY(),
+           DOUBLE()});
+  test(rowType, 0.2);
+}
+
+// Builds an Iceberg column handle with an explicit field-id tree, used to drive
+// reads whose requested schema differs from the written schema.
+std::shared_ptr<const connector::ColumnHandle> makeIcebergColumnHandle(
+    const std::string& name,
+    const TypePtr& type,
+    const parquet::ParquetFieldId& field) {
+  return std::make_shared<const IcebergColumnHandle>(
+      name, FileColumnHandle::ColumnType::kRegular, type, field);
+}
+
+// Schema evolution: a top-level column is renamed (c -> c2, id 3) and
+// reordered, another is dropped from the projection (b, id 2), and a new column
+// is added (d, id 9) that is absent from the file. Field-id resolution must
+// read c2/a from the file by id and null-fill d.
+TEST_F(IcebergNimbleInsertTest, fieldIdRenameReorderDropAdd) {
+  auto writeVector = makeRowVector(
+      {"a", "b", "c"},
+      {makeFlatVector<int64_t>({1, 2, 3}),
+       makeFlatVector<int32_t>({10, 20, 30}),
+       makeFlatVector<std::string>({"x", "y", "z"})});
+
+  const auto dir = TempDirectoryPath::create();
+  const auto path = dir->getPath();
+  createDataSinkAndAppendData({writeVector}, path)->close();
+  auto splits = createSplitsForDirectory(path);
+
+  // Written field ids (assigned depth-first from 1): a=1, b=2, c=3.
+  auto readSchema = ROW({"c2", "a", "d"}, {VARCHAR(), BIGINT(), INTEGER()});
+  std::
+      unordered_map<std::string, std::shared_ptr<const connector::ColumnHandle>>
+          assignments{
+              {"c2", makeIcebergColumnHandle("c2", VARCHAR(), {3, {}})},
+              {"a", makeIcebergColumnHandle("a", BIGINT(), {1, {}})},
+              {"d", makeIcebergColumnHandle("d", INTEGER(), {9, {}})}};
+
+  auto plan = exec::test::PlanBuilder()
+                  .startTableScan()
+                  .connectorId(test::kIcebergConnectorId)
+                  .outputType(readSchema)
+                  .dataColumns(readSchema)
+                  .assignments(assignments)
+                  .endTableScan()
+                  .planNode();
+
+  auto expected = makeRowVector(
+      {"c2", "a", "d"},
+      {makeFlatVector<std::string>({"x", "y", "z"}),
+       makeFlatVector<int64_t>({1, 2, 3}),
+       makeNullConstant(TypeKind::INTEGER, 3)});
+  exec::test::AssertQueryBuilder(plan)
+      .connectorSessionProperty(
+          test::kIcebergConnectorId, kSelectiveNimbleReaderEnabled, "false")
+      .splits(splits)
+      .assertResults({expected});
+}
+
+// Schema evolution: column c (id 1) is dropped and a new column with the same
+// name c (id 9) is added. The stale file column must NOT bind to the new c by
+// name; the new c must read as null. The resolver renames the retained-dropped
+// file column to a non-colliding sentinel so the connector's by-name null-fill
+// correctly null-fills the re-added column instead of binding to stale data.
+TEST_F(IcebergNimbleInsertTest, fieldIdDropReaddSameName) {
+  auto writeVector = makeRowVector({"c"}, {makeFlatVector<int32_t>({1, 2, 3})});
+
+  const auto dir = TempDirectoryPath::create();
+  const auto path = dir->getPath();
+  createDataSinkAndAppendData({writeVector}, path)->close();
+  auto splits = createSplitsForDirectory(path);
+
+  // Written field id: c=1. The re-added c has id 9.
+  auto readSchema = ROW({"c"}, {INTEGER()});
+  std::
+      unordered_map<std::string, std::shared_ptr<const connector::ColumnHandle>>
+          assignments{{"c", makeIcebergColumnHandle("c", INTEGER(), {9, {}})}};
+
+  auto plan = exec::test::PlanBuilder()
+                  .startTableScan()
+                  .connectorId(test::kIcebergConnectorId)
+                  .outputType(readSchema)
+                  .dataColumns(readSchema)
+                  .assignments(assignments)
+                  .endTableScan()
+                  .planNode();
+
+  auto expected =
+      makeRowVector({"c"}, {makeNullConstant(TypeKind::INTEGER, 3)});
+  exec::test::AssertQueryBuilder(plan)
+      .connectorSessionProperty(
+          test::kIcebergConnectorId, kSelectiveNimbleReaderEnabled, "false")
+      .splits(splits)
+      .assertResults({expected});
+}
+
+// Schema evolution inside a struct: a nested field is dropped (y) and the
+// remaining nested fields are reordered (z before x). Field-id resolution must
+// match nested columns by id, not position. The batch NimbleReader reshapes
+// nested struct columns to the requested (table) field order/selection (see
+// projectStructToSpec in NimbleReader.cpp), so the struct comes back as the
+// requested ROW<z,x> rather than the file-order ROW<x,y,z>.
+TEST_F(IcebergNimbleInsertTest, fieldIdNestedStructReorderDrop) {
+  auto writeVector = makeRowVector(
+      {"s"},
+      {makeRowVector(
+          {"x", "y", "z"},
+          {makeFlatVector<int32_t>({1, 2, 3}),
+           makeFlatVector<int32_t>({4, 5, 6}),
+           makeFlatVector<int32_t>({7, 8, 9})})});
+
+  const auto dir = TempDirectoryPath::create();
+  const auto path = dir->getPath();
+  createDataSinkAndAppendData({writeVector}, path)->close();
+  auto splits = createSplitsForDirectory(path);
+
+  // Written field ids (depth-first): s=1, x=2, y=3, z=4.
+  auto readSchema = ROW({"s"}, {ROW({"z", "x"}, {INTEGER(), INTEGER()})});
+  std::
+      unordered_map<std::string, std::shared_ptr<const connector::ColumnHandle>>
+          assignments{
+              {"s",
+               makeIcebergColumnHandle(
+                   "s",
+                   ROW({"z", "x"}, {INTEGER(), INTEGER()}),
+                   {1, {{4, {}}, {2, {}}}})}};
+
+  auto plan = exec::test::PlanBuilder()
+                  .startTableScan()
+                  .connectorId(test::kIcebergConnectorId)
+                  .outputType(readSchema)
+                  .dataColumns(readSchema)
+                  .assignments(assignments)
+                  .endTableScan()
+                  .planNode();
+
+  auto expected = makeRowVector(
+      {"s"},
+      {makeRowVector(
+          {"z", "x"},
+          {makeFlatVector<int32_t>({7, 8, 9}),
+           makeFlatVector<int32_t>({1, 2, 3})})});
+  exec::test::AssertQueryBuilder(plan)
+      .connectorSessionProperty(
+          test::kIcebergConnectorId, kSelectiveNimbleReaderEnabled, "false")
+      .splits(splits)
+      .assertResults({expected});
+}
+
+} // namespace
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/tests/WriterOptionsAdapterTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/WriterOptionsAdapterTest.cpp
@@ -17,12 +17,49 @@
 #include "velox/connectors/hive/iceberg/WriterOptionsAdapter.h"
 
 #include <gtest/gtest.h>
+#ifdef VELOX_ENABLE_NIMBLE
+#include "dwio/nimble/velox/writer/fb/NimbleWriter.h"
+#endif
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
 #include "velox/dwio/dwrf/writer/Writer.h"
 #include "velox/dwio/parquet/common/ParquetConfig.h"
+#include "velox/type/Type.h"
 
 namespace facebook::velox::connector::hive::iceberg {
 namespace {
+
+// Verifies IcebergColumnHandle carries the Iceberg V3 metadata supplied at
+// construction and exposes it via icebergMetadata(), and that the default
+// (omitted) metadata is empty for legacy callers.
+TEST(WriterOptionsAdapterTest, icebergColumnHandleCarriesMetadata) {
+  IcebergFieldMetadata metadata;
+  metadata.required = true;
+  metadata.binaryType = "UUID";
+  metadata.length = 16;
+
+  IcebergColumnHandle handle(
+      "u",
+      HiveColumnHandle::ColumnType::kRegular,
+      VARBINARY(),
+      parquet::ParquetFieldId{/*fieldId*/ 5, /*children*/ {}},
+      /*requiredSubfields*/ {},
+      /*initialDefaultValue*/ std::nullopt,
+      metadata);
+
+  const auto& recovered = handle.icebergMetadata();
+  EXPECT_TRUE(recovered.required);
+  EXPECT_EQ(recovered.binaryType, "UUID");
+  EXPECT_EQ(recovered.length, 16);
+
+  // Legacy callers that omit metadata get an empty instance.
+  IcebergColumnHandle legacyHandle(
+      "a",
+      HiveColumnHandle::ColumnType::kRegular,
+      BIGINT(),
+      parquet::ParquetFieldId{/*fieldId*/ 1, /*children*/ {}});
+  EXPECT_TRUE(legacyHandle.icebergMetadata().empty());
+}
 
 // Verifies the dispatch table in createWriterOptionsAdapter():
 // PARQUET, ORC, DWRF, NIMBLE return non-null adapters; everything else
@@ -36,8 +73,10 @@ TEST(WriterOptionsAdapterTest, createWriterOptionsAdapterDispatch) {
   EXPECT_NE(createWriterOptionsAdapter(dwio::common::FileFormat::ORC), nullptr);
   EXPECT_NE(
       createWriterOptionsAdapter(dwio::common::FileFormat::DWRF), nullptr);
+#ifdef VELOX_ENABLE_NIMBLE
   EXPECT_NE(
       createWriterOptionsAdapter(dwio::common::FileFormat::NIMBLE), nullptr);
+#endif
 
   // TEXT, JSON, ALPHA, etc. are intentionally unsupported on the
   // write path until each gets its own end-to-end coverage.
@@ -52,7 +91,9 @@ TEST(WriterOptionsAdapterTest, isSupportedFileFormatMatchesDispatch) {
   EXPECT_TRUE(isSupportedFileFormat(dwio::common::FileFormat::PARQUET));
   EXPECT_TRUE(isSupportedFileFormat(dwio::common::FileFormat::ORC));
   EXPECT_TRUE(isSupportedFileFormat(dwio::common::FileFormat::DWRF));
+#ifdef VELOX_ENABLE_NIMBLE
   EXPECT_TRUE(isSupportedFileFormat(dwio::common::FileFormat::NIMBLE));
+#endif
 
   EXPECT_FALSE(isSupportedFileFormat(dwio::common::FileFormat::TEXT));
   EXPECT_FALSE(isSupportedFileFormat(dwio::common::FileFormat::JSON));
@@ -142,6 +183,254 @@ TEST(WriterOptionsAdapterTest, toManifestFormatStringThrowsForUnsupported) {
       toManifestFormatString(dwio::common::FileFormat::JSON),
       "Unsupported file format for Iceberg manifest");
 }
+
+#ifdef VELOX_ENABLE_NIMBLE
+// ---------------------------------------------------------------------------
+// NIMBLE Iceberg V3 attribute stamping.
+//
+// Verifies that IcebergDataSink correctly stamps Iceberg field IDs and V3
+// type attributes onto Nimble writer options via the WriterOptionsAdapter.
+// The adapter converts the IcebergFieldId tree into dotted-path attributes
+// (e.g., "a.b" -> {"iceberg.id":"2", "iceberg.required":"true"}) that survive
+// through NimbleWriterFactory into the Nimble file schema. These tests ensure
+// the writer-side contract is preserved: empty trees are no-ops for backward
+// compatibility, and populated trees produce correct per-column attributes.
+// ---------------------------------------------------------------------------
+
+// Verifies an empty Iceberg field-id tree is a no-op: attributesByColumn
+// stays empty after applyPostConfigs. This is the no-op upgrade path for
+// every existing NIMBLE writer call site -- the on-disk file is
+// byte-identical to pre-stack output.
+TEST(WriterOptionsAdapterTest, nimbleApplyPostConfigsEmptyTreeIsNoOp) {
+  auto adapter = createWriterOptionsAdapter(
+      dwio::common::FileFormat::NIMBLE, IcebergFieldId{});
+  ASSERT_NE(adapter, nullptr);
+
+  velox::nimble::NimbleWriterOptions options;
+  options.schema = ROW({"a"}, {INTEGER()});
+  adapter->applyPostConfigs(options);
+
+  EXPECT_TRUE(options.attributesByColumn.empty());
+}
+
+// Verifies the NIMBLE adapter stamps `iceberg.id` onto top-level columns
+// in the dotted-path keyed map. The walk goes through the schema in
+// lockstep with the field-id tree, so each column gets the right id.
+TEST(WriterOptionsAdapterTest, nimbleApplyPostConfigsStampsTopLevelIcebergIds) {
+  // Build a synthetic top-level wrapper with one child per column,
+  // matching how IcebergDataSink constructs the tree.
+  IcebergFieldId icebergFieldIds;
+  icebergFieldIds.children.emplace_back(
+      IcebergFieldId{/*fieldId*/ 7, /*children*/ {}});
+  icebergFieldIds.children.emplace_back(
+      IcebergFieldId{/*fieldId*/ 12, /*children*/ {}});
+
+  auto adapter = createWriterOptionsAdapter(
+      dwio::common::FileFormat::NIMBLE, std::move(icebergFieldIds));
+  ASSERT_NE(adapter, nullptr);
+
+  velox::nimble::NimbleWriterOptions options;
+  options.schema = ROW({"id", "name"}, {BIGINT(), VARCHAR()});
+
+  adapter->applyPostConfigs(options);
+
+  ASSERT_EQ(options.attributesByColumn.size(), 2u);
+  ASSERT_EQ(options.attributesByColumn.count("id"), 1u);
+  ASSERT_EQ(options.attributesByColumn.count("name"), 1u);
+
+  const std::vector<std::pair<std::string, std::string>> kIdAttrs = {
+      {"iceberg.id", "7"},
+  };
+  const std::vector<std::pair<std::string, std::string>> kNameAttrs = {
+      {"iceberg.id", "12"},
+  };
+  EXPECT_EQ(options.attributesByColumn.at("id"), kIdAttrs);
+  EXPECT_EQ(options.attributesByColumn.at("name"), kNameAttrs);
+}
+
+// Verifies the NIMBLE adapter recurses into nested struct (RowType)
+// children, producing dotted-path keys like "user.name". Diff B's
+// writer-side resolveDottedPath supports this case directly. Array/Map
+// nested field-ids are deferred to a follow-up.
+TEST(WriterOptionsAdapterTest, nimbleApplyPostConfigsStampsNestedStructIds) {
+  IcebergFieldId icebergFieldIds;
+  // Top-level child 0 = column "user" (id 1) with two nested struct
+  // children: "name" (id 2) and "age" (id 3).
+  IcebergFieldId userField;
+  userField.fieldId = 1;
+  userField.children.emplace_back(
+      IcebergFieldId{/*fieldId*/ 2, /*children*/ {}});
+  userField.children.emplace_back(
+      IcebergFieldId{/*fieldId*/ 3, /*children*/ {}});
+  icebergFieldIds.children.emplace_back(std::move(userField));
+
+  auto adapter = createWriterOptionsAdapter(
+      dwio::common::FileFormat::NIMBLE, std::move(icebergFieldIds));
+  ASSERT_NE(adapter, nullptr);
+
+  velox::nimble::NimbleWriterOptions options;
+  options.schema =
+      ROW({"user"}, {ROW({"name", "age"}, {VARCHAR(), INTEGER()})});
+
+  adapter->applyPostConfigs(options);
+
+  // Parent struct + both leaves all annotated with their field-ids.
+  ASSERT_EQ(options.attributesByColumn.size(), 3u);
+  const std::vector<std::pair<std::string, std::string>> kUserAttrs = {
+      {"iceberg.id", "1"},
+  };
+  const std::vector<std::pair<std::string, std::string>> kNameAttrs = {
+      {"iceberg.id", "2"},
+  };
+  const std::vector<std::pair<std::string, std::string>> kAgeAttrs = {
+      {"iceberg.id", "3"},
+  };
+  EXPECT_EQ(options.attributesByColumn.at("user"), kUserAttrs);
+  EXPECT_EQ(options.attributesByColumn.at("user.name"), kNameAttrs);
+  EXPECT_EQ(options.attributesByColumn.at("user.age"), kAgeAttrs);
+}
+
+// Verifies the NIMBLE adapter stamps the Iceberg V3 type attributes carried
+// in the parallel IcebergFieldMetadata tree. The UUID case sets
+// `iceberg.binary-type=UUID` and `iceberg.length=16` together alongside
+// `iceberg.required`, in addition to the always-present `iceberg.id`.
+TEST(WriterOptionsAdapterTest, nimbleApplyPostConfigsStampsV3Attributes) {
+  IcebergFieldId icebergFieldIds;
+  icebergFieldIds.children.emplace_back(
+      IcebergFieldId{/*fieldId*/ 5, /*children*/ {}});
+
+  IcebergFieldMetadata metadata;
+  IcebergFieldMetadata uuidColumn;
+  uuidColumn.required = true;
+  uuidColumn.binaryType = "UUID";
+  uuidColumn.length = 16;
+  metadata.children.push_back(std::move(uuidColumn));
+
+  auto adapter = createWriterOptionsAdapter(
+      dwio::common::FileFormat::NIMBLE,
+      std::move(icebergFieldIds),
+      std::move(metadata));
+  ASSERT_NE(adapter, nullptr);
+
+  velox::nimble::NimbleWriterOptions options;
+  options.schema = ROW({"u"}, {VARBINARY()});
+  adapter->applyPostConfigs(options);
+
+  const std::vector<std::pair<std::string, std::string>> kExpected = {
+      {"iceberg.id", "5"},
+      {"iceberg.required", "true"},
+      {"iceberg.binary-type", "UUID"},
+      {"iceberg.length", "16"},
+  };
+  EXPECT_EQ(options.attributesByColumn.at("u"), kExpected);
+}
+
+// Verifies V3 attributes are stamped only on the columns that supply them;
+// a column with empty metadata keeps the `iceberg.id`-only shape.
+TEST(
+    WriterOptionsAdapterTest,
+    nimbleApplyPostConfigsStampsRequiredOnlyWhenSet) {
+  IcebergFieldId icebergFieldIds;
+  icebergFieldIds.children.emplace_back(
+      IcebergFieldId{/*fieldId*/ 1, /*children*/ {}});
+  icebergFieldIds.children.emplace_back(
+      IcebergFieldId{/*fieldId*/ 2, /*children*/ {}});
+
+  IcebergFieldMetadata metadata;
+  IcebergFieldMetadata requiredColumn;
+  requiredColumn.required = true;
+  metadata.children.push_back(std::move(requiredColumn));
+  // Second column intentionally has empty metadata.
+  metadata.children.emplace_back();
+
+  auto adapter = createWriterOptionsAdapter(
+      dwio::common::FileFormat::NIMBLE,
+      std::move(icebergFieldIds),
+      std::move(metadata));
+  ASSERT_NE(adapter, nullptr);
+
+  velox::nimble::NimbleWriterOptions options;
+  options.schema = ROW({"a", "b"}, {BIGINT(), BIGINT()});
+  adapter->applyPostConfigs(options);
+
+  const std::vector<std::pair<std::string, std::string>> kRequiredAttrs = {
+      {"iceberg.id", "1"},
+      {"iceberg.required", "true"},
+  };
+  const std::vector<std::pair<std::string, std::string>> kPlainAttrs = {
+      {"iceberg.id", "2"},
+  };
+  EXPECT_EQ(options.attributesByColumn.at("a"), kRequiredAttrs);
+  EXPECT_EQ(options.attributesByColumn.at("b"), kPlainAttrs);
+}
+
+// Verifies the V3 attribute tree is walked in lockstep with nested struct
+// children, so each leaf gets its own attributes at the right dotted path.
+TEST(WriterOptionsAdapterTest, nimbleApplyPostConfigsStampsNestedStructV3) {
+  IcebergFieldId icebergFieldIds;
+  IcebergFieldId userField;
+  userField.fieldId = 1;
+  userField.children.emplace_back(
+      IcebergFieldId{/*fieldId*/ 2, /*children*/ {}});
+  userField.children.emplace_back(
+      IcebergFieldId{/*fieldId*/ 3, /*children*/ {}});
+  icebergFieldIds.children.emplace_back(std::move(userField));
+
+  IcebergFieldMetadata metadata;
+  IcebergFieldMetadata userMetadata;
+  IcebergFieldMetadata idMetadata;
+  idMetadata.required = true;
+  idMetadata.longType = "LONG";
+  IcebergFieldMetadata tsMetadata;
+  tsMetadata.timestampUnit = "MICROS";
+  userMetadata.children.push_back(std::move(idMetadata));
+  userMetadata.children.push_back(std::move(tsMetadata));
+  metadata.children.push_back(std::move(userMetadata));
+
+  auto adapter = createWriterOptionsAdapter(
+      dwio::common::FileFormat::NIMBLE,
+      std::move(icebergFieldIds),
+      std::move(metadata));
+  ASSERT_NE(adapter, nullptr);
+
+  velox::nimble::NimbleWriterOptions options;
+  options.schema = ROW({"user"}, {ROW({"id", "ts"}, {BIGINT(), TIMESTAMP()})});
+  adapter->applyPostConfigs(options);
+
+  const std::vector<std::pair<std::string, std::string>> kIdAttrs = {
+      {"iceberg.id", "2"},
+      {"iceberg.required", "true"},
+      {"iceberg.long-type", "LONG"},
+  };
+  const std::vector<std::pair<std::string, std::string>> kTsAttrs = {
+      {"iceberg.id", "3"},
+      {"iceberg.timestamp-unit", "MICROS"},
+  };
+  EXPECT_EQ(options.attributesByColumn.at("user.id"), kIdAttrs);
+  EXPECT_EQ(options.attributesByColumn.at("user.ts"), kTsAttrs);
+}
+
+// Defends against passing a non-NIMBLE WriterOptions to
+// NimbleWriterOptionsAdapter -- e.g. via a wrong dispatch in the factory.
+// The adapter should silently no-op rather than mutate an unrelated
+// options object.
+TEST(WriterOptionsAdapterTest, nimbleApplyPostConfigsIgnoresNonNimbleOptions) {
+  IcebergFieldId icebergFieldIds;
+  icebergFieldIds.children.emplace_back(
+      IcebergFieldId{/*fieldId*/ 1, /*children*/ {}});
+
+  auto adapter = createWriterOptionsAdapter(
+      dwio::common::FileFormat::NIMBLE, std::move(icebergFieldIds));
+  ASSERT_NE(adapter, nullptr);
+
+  // Pass a plain WriterOptions (NOT a NimbleWriterOptions). The
+  // dynamic_cast should fail and the adapter should leave the object
+  // untouched.
+  dwio::common::WriterOptions options;
+  options.schema = ROW({"a"}, {INTEGER()});
+  EXPECT_NO_THROW(adapter->applyPostConfigs(options));
+}
+#endif // VELOX_ENABLE_NIMBLE
 
 } // namespace
 } // namespace facebook::velox::connector::hive::iceberg


### PR DESCRIPTION
Summary:
Adds the NIMBLE analog of IcebergDwrfInsertTest, exercising the real
write -> serialize -> read -> null-fill chain through the Iceberg connector
for NIMBLE files (write side stamps iceberg.id via NimbleWriterOptionsAdapter;
read side resolves columns by Iceberg field id in the batch NimbleReader).

- New IcebergNimbleInsertTest.cpp with roundTrip and
  fieldIdRenameReorderDropAdd (top-level rename + reorder + drop +
  null-fill-added, the primary parity target). Field-id reads set
  selective_nimble_reader_enabled=false so the batch NimbleReader (where the
  field-id resolver lives) is exercised.
- Two further evolution cases (fieldIdDropReaddSameName,
  fieldIdNestedStructReorderDrop) are committed as DISABLED_ with detailed
  comments: they need deeper NIMBLE support (connector/resolver
  disambiguation of retained-dropped columns; nested struct-field projection
  in the batch reader) and are out of scope here, mirroring the
  type-promotion exclusion.
- Implements nextRowNumber()/nextReadSize() on the batch NimbleRowReader
  (previously VELOX_NYI), which IcebergSplitReader::prepareSplit/next require;
  computed from VeloxReader::getRowNumber() and TabletReader stripe metadata.
- Adds the iceberg_nimble_insert_test cpp_unittest target.

Reviewed By: srsuryadev

Differential Revision: D108760899


