### PR TITLE
fix(rpc): Degrade whole-batch RPC failures to per-row errors instead of failing the query (#18049)

### DIFF
--- a/velox/exec/rpc/RPCOperator.cpp
+++ b/velox/exec/rpc/RPCOperator.cpp
@@ -314,18 +314,51 @@ void RPCOperator::flushBatchRequests(int32_t maxRows) {
   auto token = std::make_shared<RPCRateLimiter::Token>(
       RPCRateLimiter::acquire(tierKey_));
 
-  // Scatter responses into batch-position order using each response's
-  // function-assigned rowId (its position within the batch), then stamp
-  // the global rowIds. Functions may return results out of order (e.g.,
-  // MetaGen's batchDialogCompletion streams results in arbitrary order).
-  // Without this, responses[i] would be paired with rowLocations[i] in
-  // buildOutputFromReadyBatch, silently mis-mapping results to wrong
-  // passthrough rows.
+  // Share rowIds across both continuations. Order matters: deferError runs
+  // BEFORE deferValue, so a whole-batch backend failure is first converted into
+  // one errored response per row (in batch-position order), and then flows
+  // through the same scatter as real responses. This keeps the scatter's
+  // invariant checks (below) FATAL for genuine function-contract violations
+  // (wrong response count / duplicate / out-of-range rowId) — those must still
+  // hard-fail the query, not be silently degraded to NULL rows.
+  auto rowIdsPtr = std::make_shared<std::vector<int64_t>>(std::move(rowIds));
   auto wrapped =
       std::move(future)
           .within(kBatchRpcTimeout)
-          .deferValue([rowIds = std::move(rowIds),
-                       token](std::vector<RPCResponse> resps) {
+          .deferError([rowIdsPtr, token](folly::exception_wrapper ew) {
+            // A whole-batch failure (e.g. an operator-level batch/RPC timeout)
+            // degrades to per-row errored responses so the per-row error policy
+            // (meta_ai_on_error) applies downstream, instead of hard-failing
+            // the whole query. Mirrors the client-layer fan-out, but covers all
+            // backends and the operator-level timeout uniformly. Both AIMD
+            // controllers still back off via evaluateCongestion (a batch
+            // failure is overload). Responses carry batch-position rowId
+            // (0..N-1) so the scatter below stamps global rowIds identically to
+            // the success path.
+            const auto& rowIds = *rowIdsPtr;
+            RPC_OP_LOG(ERROR)
+                << "RPC batch failed, " << rowIds.size()
+                << " rows will carry a per-row error: " << ew.what();
+            std::vector<RPCResponse> errResponses(rowIds.size());
+            for (size_t i = 0; i < rowIds.size(); ++i) {
+              errResponses[i].rowId = static_cast<int64_t>(i);
+              errResponses[i].error = std::string("[RPC_BATCH] batch error: ") +
+                  ew.what().toStdString();
+              errResponses[i].errorKind =
+                  velox::rpc::RPCErrorKind::kBackendError;
+            }
+            return errResponses;
+          })
+          // Scatter responses into batch-position order using each response's
+          // function-assigned rowId (its position within the batch), then stamp
+          // the global rowIds. Functions may return results out of order (e.g.,
+          // MetaGen's batchDialogCompletion streams results in arbitrary
+          // order). Without this, responses[i] would be paired with
+          // rowLocations[i] in buildOutputFromReadyBatch, silently mis-mapping
+          // results to wrong passthrough rows. Invariant violations here are
+          // fatal by design.
+          .deferValue([rowIdsPtr, token](std::vector<RPCResponse> resps) {
+            const auto& rowIds = *rowIdsPtr;
             VELOX_CHECK_EQ(
                 resps.size(),
                 rowIds.size(),
@@ -352,11 +385,6 @@ void RPCOperator::flushBatchRequests(int32_t maxRows) {
               sorted[static_cast<size_t>(batchIdx)] = std::move(resp);
             }
             return sorted;
-          })
-          .deferError([token](folly::exception_wrapper ew) {
-            RPC_OP_LOG(ERROR) << "RPC batch failed: " << ew.what();
-            return folly::makeSemiFuture<std::vector<RPCResponse>>(
-                std::move(ew));
           });
 
   state_->addPendingBatch(state_, std::move(wrapped), std::move(rowLocations));

--- a/velox/exec/rpc/tests/DemoBatchRPCFunction.cpp
+++ b/velox/exec/rpc/tests/DemoBatchRPCFunction.cpp
@@ -22,8 +22,28 @@ namespace facebook::velox::exec::rpc {
 
 DemoBatchRPCFunction::DemoBatchRPCFunction(
     ResponseOrder order,
-    std::unordered_set<int32_t> failingRowIndices)
-    : responseOrder_(order), failingRowIndices_(std::move(failingRowIndices)) {}
+    std::unordered_set<int32_t> failingRowIndices,
+    bool failWholeBatch,
+    bool failOnError,
+    bool dropOneResponse)
+    : responseOrder_(order),
+      failingRowIndices_(std::move(failingRowIndices)),
+      failWholeBatch_(failWholeBatch),
+      failOnError_(failOnError),
+      dropOneResponse_(dropOneResponse) {}
+
+VectorPtr DemoBatchRPCFunction::buildOutput(
+    const std::vector<RPCResponse>& responses,
+    memory::MemoryPool* pool) const {
+  if (failOnError_) {
+    for (const auto& r : responses) {
+      if (r.hasError()) {
+        VELOX_USER_FAIL("RPC call failed for row");
+      }
+    }
+  }
+  return AsyncRPCFunction::buildOutput(responses, pool);
+}
 
 void DemoBatchRPCFunction::initialize(
     const core::QueryConfig& /*queryConfig*/,
@@ -76,6 +96,15 @@ folly::SemiFuture<std::vector<RPCResponse>> DemoBatchRPCFunction::flushBatch(
       pendingRows_.begin(), pendingRows_.begin() + flushCount);
   pendingRows_.erase(pendingRows_.begin(), pendingRows_.begin() + flushCount);
 
+  // Simulate an operator-level batch failure (e.g. an RPC/batch timeout): the
+  // whole flush future fails rather than returning per-row responses. Rows are
+  // still consumed above so pendingBatchSize() drains and noMoreInput()
+  // terminates.
+  if (failWholeBatch_) {
+    return folly::makeSemiFuture<std::vector<RPCResponse>>(
+        std::runtime_error("simulated batch timeout"));
+  }
+
   std::vector<RPCResponse> responses;
   responses.reserve(toFlush.size());
 
@@ -101,6 +130,12 @@ folly::SemiFuture<std::vector<RPCResponse>> DemoBatchRPCFunction::flushBatch(
 
   if (responseOrder_ == ResponseOrder::kReversed) {
     std::reverse(responses.begin(), responses.end());
+  }
+
+  // Simulate a function-contract violation: return fewer responses than rows.
+  // The operator's scatter must hard-fail on the count mismatch (not degrade).
+  if (dropOneResponse_ && !responses.empty()) {
+    responses.pop_back();
   }
 
   return folly::makeSemiFuture(std::move(responses));

--- a/velox/exec/rpc/tests/DemoBatchRPCFunction.h
+++ b/velox/exec/rpc/tests/DemoBatchRPCFunction.h
@@ -30,10 +30,13 @@ namespace facebook::velox::exec::rpc {
 ///   - In-order responses (default, happy path)
 ///   - Reversed responses (simulates backend returning out of order)
 ///   - Per-row failures (simulates partial batch failure)
+///   - Whole-batch failure (simulates an operator-level batch timeout / RPC
+///     error where the flush future itself fails, not individual rows)
 ///
 /// Returns "Batch response for: <prompt>" for each non-null, non-failing row.
 /// Null inputs produce RPCResponse{.error = "null_input"}.
 /// Failing rows produce RPCResponse{.error = "simulated_failure"}.
+/// With failWholeBatch=true, flushBatch() returns a FAILED future instead.
 class DemoBatchRPCFunction : public AsyncRPCFunction {
  public:
   enum class ResponseOrder {
@@ -43,7 +46,10 @@ class DemoBatchRPCFunction : public AsyncRPCFunction {
 
   explicit DemoBatchRPCFunction(
       ResponseOrder order = ResponseOrder::kInOrder,
-      std::unordered_set<int32_t> failingRowIndices = {});
+      std::unordered_set<int32_t> failingRowIndices = {},
+      bool failWholeBatch = false,
+      bool failOnError = false,
+      bool dropOneResponse = false);
 
   void initialize(
       const core::QueryConfig& queryConfig,
@@ -57,6 +63,13 @@ class DemoBatchRPCFunction : public AsyncRPCFunction {
   TypePtr resultType() const override {
     return VARCHAR();
   }
+
+  /// With failOnError=true, mimics the meta_ai_on_error='fail' policy: any
+  /// errored response hard-fails the query (VELOX_USER_FAIL) instead of NULLing
+  /// the row. Otherwise defers to the base (errors -> NULL).
+  VectorPtr buildOutput(
+      const std::vector<RPCResponse>& responses,
+      memory::MemoryPool* pool) const override;
 
   std::vector<std::pair<vector_size_t, folly::SemiFuture<RPCResponse>>>
   dispatchPerRow(
@@ -83,6 +96,9 @@ class DemoBatchRPCFunction : public AsyncRPCFunction {
   std::vector<PendingRow> pendingRows_;
   ResponseOrder responseOrder_;
   std::unordered_set<int32_t> failingRowIndices_;
+  bool failWholeBatch_{false};
+  bool failOnError_{false};
+  bool dropOneResponse_{false};
   int32_t totalAccumulatedCount_{0};
 };
 

--- a/velox/exec/rpc/tests/RPCOperatorTest.cpp
+++ b/velox/exec/rpc/tests/RPCOperatorTest.cpp
@@ -22,6 +22,7 @@
 
 #include <gtest/gtest.h>
 
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/exec/rpc/RPCPlanNodeTranslator.h"
 #include "velox/exec/rpc/RPCRateLimiter.h"
 #include "velox/exec/rpc/tests/DemoBatchRPCFunction.h"
@@ -54,6 +55,34 @@ class RPCOperatorTest : public OperatorTestBase {
           return std::make_shared<DemoBatchRPCFunction>(
               DemoBatchRPCFunction::ResponseOrder::kInOrder,
               std::unordered_set<int32_t>{1, 3});
+        });
+    AsyncRPCFunctionRegistry::registerFunction(
+        "demo_batch_rpc_whole_fail", []() {
+          return std::make_shared<DemoBatchRPCFunction>(
+              DemoBatchRPCFunction::ResponseOrder::kInOrder,
+              std::unordered_set<int32_t>{},
+              /*failWholeBatch=*/true);
+        });
+    // Whole-batch failure AND a fail-on-error policy (mimics
+    // meta_ai_on_error='fail'): the query must still hard-fail, not degrade.
+    AsyncRPCFunctionRegistry::registerFunction(
+        "demo_batch_rpc_whole_fail_strict", []() {
+          return std::make_shared<DemoBatchRPCFunction>(
+              DemoBatchRPCFunction::ResponseOrder::kInOrder,
+              std::unordered_set<int32_t>{},
+              /*failWholeBatch=*/true,
+              /*failOnError=*/true);
+        });
+    // Returns fewer responses than rows (function-contract violation): the
+    // operator's scatter must hard-fail on the count mismatch.
+    AsyncRPCFunctionRegistry::registerFunction(
+        "demo_batch_rpc_wrong_count", []() {
+          return std::make_shared<DemoBatchRPCFunction>(
+              DemoBatchRPCFunction::ResponseOrder::kInOrder,
+              std::unordered_set<int32_t>{},
+              /*failWholeBatch=*/false,
+              /*failOnError=*/false,
+              /*dropOneResponse=*/true);
         });
   }
 
@@ -337,6 +366,69 @@ TEST_F(RPCOperatorTest, batchPartialFailure) {
   EXPECT_FALSE(results->isNullAt(rowIndex["row2"]));
   EXPECT_TRUE(results->isNullAt(rowIndex["row3_fail"]));
   EXPECT_FALSE(results->isNullAt(rowIndex["row4"]));
+}
+
+// Whole-batch failure (e.g. an operator-level batch/RPC timeout) should DEGRADE
+// to per-row errored responses (-> NULL under the return-null policy), NOT
+// hard-fail the entire query. This is the repro for the batch-timeout bug:
+// today RPCOperator::getOutput VELOX_FAILs on claimedBatch_->error, bypassing
+// the per-row error policy, so this test currently fails with "RPC batch
+// failed: simulated batch timeout". After routing the operator's deferError
+// through a per-row fan-out, all rows should come back NULL and the query
+// should complete.
+TEST_F(RPCOperatorTest, batchWholeBatchFailureDegradesToNull) {
+  auto input =
+      makeRowVector({"prompt"}, {makeFlatVector<StringView>({"a", "b", "c"})});
+
+  auto plan = makeBatchRPCNode(
+      PlanBuilder().values({input}).planNode(),
+      {"prompt"},
+      "demo_batch_rpc_whole_fail");
+
+  auto result = AssertQueryBuilder(plan).maxDrivers(1).copyResults(pool());
+
+  ASSERT_EQ(result->size(), 3);
+  auto* results = result->childAt(1)->asFlatVector<StringView>();
+  for (vector_size_t i = 0; i < result->size(); ++i) {
+    EXPECT_TRUE(results->isNullAt(i))
+        << "row " << i << " should degrade to NULL on whole-batch failure";
+  }
+}
+
+// With a fail-on-error policy (meta_ai_on_error='fail'), a whole-batch failure
+// must still HARD-FAIL the query — the degrade-to-per-row change must not
+// silently turn a 'fail' request into all-NULL. The per-row errors produced by
+// the operator flow to the function's buildOutput, which fails the query.
+TEST_F(RPCOperatorTest, batchWholeBatchFailureWithFailPolicyThrows) {
+  auto input =
+      makeRowVector({"prompt"}, {makeFlatVector<StringView>({"a", "b", "c"})});
+
+  auto plan = makeBatchRPCNode(
+      PlanBuilder().values({input}).planNode(),
+      {"prompt"},
+      "demo_batch_rpc_whole_fail_strict");
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan).maxDrivers(1).copyResults(pool()),
+      "RPC call failed for row");
+}
+
+// A function that returns fewer responses than rows violates the batch
+// contract. After moving deferError before deferValue, the scatter's
+// count-mismatch check must STILL hard-fail the query (not be swallowed and
+// degraded to NULL rows).
+TEST_F(RPCOperatorTest, batchWrongResponseCountHardFails) {
+  auto input =
+      makeRowVector({"prompt"}, {makeFlatVector<StringView>({"a", "b", "c"})});
+
+  auto plan = makeBatchRPCNode(
+      PlanBuilder().values({input}).planNode(),
+      {"prompt"},
+      "demo_batch_rpc_wrong_count");
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan).maxDrivers(1).copyResults(pool()),
+      "does not match row count");
 }
 
 // Null inputs in batch mode produce null results.


### PR DESCRIPTION
Summary:

In BATCH streaming mode, the RPC operator wraps each batch dispatch future with a deadline (within(kBatchRpcTimeout)). When the whole batch future failed — e.g. it timed out, or the backend returned a transport-level error — the operator's deferError re-threw, which surfaced as claimedBatch_->error and caused getOutput to VELOX_FAIL("RPC batch failed: ..."). That aborted the entire query and bypassed the function's per-row error policy, so a single transient backend hiccup could kill a long-running batch job even when the caller asked for failed rows to be tolerated.

This routes the operator's deferError through a per-row fan-out: on a whole-batch failure it now produces one errored RPCResponse per row (errorKind kBackendError) instead of propagating the exception. Those flow through the normal per-row path, so the function's buildOutput applies its error policy (return-null / error-message / fail) per row, and both AIMD congestion controllers still back off because evaluateCongestion classifies an all-errored batch as overload. rowIds are shared between deferValue and deferError via a shared_ptr so both continuations can stamp them.

This mirrors the existing client-layer fan-out but at the operator level, so it covers every backend and the operator-level deadline uniformly. The last-resort VELOX_FAIL on claimedBatch_->error remains as a backstop for genuinely unexpected states.

Reviewed By: zacw7, sebastianopeluso

Differential Revision: D110951878


