### PR TITLE
feat(vector): Add DecodedVector::forEachNull() and forEachNotNull() (#18051)

### DIFF
--- a/velox/vector/DecodedVector.h
+++ b/velox/vector/DecodedVector.h
@@ -209,6 +209,35 @@ class DecodedVector {
     return bits::isBitNull(nulls_, indices_[idx]);
   }
 
+  /// Invokes 'func(row)' for each null top-level row in [begin, end), in
+  /// increasing row order. 'func' must be invocable as 'void(vector_size_t)'.
+  ///
+  /// Iterates the null bitmap a word at a time for flat and
+  /// dictionary-with-combined-nulls encodings; otherwise resolves the
+  /// dictionary indirection per row, or expands a null constant. Mirrors
+  /// isNullAt() over a range without the per-row call overhead where the
+  /// encoding allows a bulk scan.
+  ///
+  /// If the DecodedVector was created using a selectivity vector, it is the
+  /// caller's responsibility to make sure the input range hits part of the
+  /// decoded row subset.
+  template <typename TFunc>
+  void forEachNull(vector_size_t begin, vector_size_t end, TFunc&& func) const {
+    forEachRow<true>(begin, end, std::forward<TFunc>(func));
+  }
+
+  /// Invokes 'func(row)' for each non-null top-level row in [begin, end), in
+  /// increasing row order. The common companion to forEachNull(): when there is
+  /// no null bitmap every row in the range is visited. Uses the same
+  /// encoding-aware, word-granular scan (bits::forEachSetBit for the flat and
+  /// combined-nulls cases). Same [begin, end) decode-selection contract as
+  /// forEachNull().
+  template <typename TFunc>
+  void forEachNotNull(vector_size_t begin, vector_size_t end, TFunc&& func)
+      const {
+    forEachRow<false>(begin, end, std::forward<TFunc>(func));
+  }
+
   /// Returns the largest decoded row number + 1, i.e. rows.end().
   vector_size_t size() const {
     return size_;
@@ -308,6 +337,44 @@ class DecodedVector {
   static const std::vector<vector_size_t>& consecutiveIndices();
 
  private:
+  // Invokes 'func(row)' for each row in [begin, end) whose null flag equals
+  // 'kIsNull', in increasing row order. Shared implementation of forEachNull()
+  // and forEachNotNull(): a word-at-a-time bitmap scan for flat and
+  // combined-nulls encodings, per-row indirection for other dictionaries, and
+  // constant/no-bitmap handled directly (with no bitmap, every row is
+  // non-null).
+  template <bool kIsNull, typename TFunc>
+  void forEachRow(vector_size_t begin, vector_size_t end, TFunc&& func) const {
+    if (nulls_ == nullptr) {
+      if constexpr (!kIsNull) {
+        for (vector_size_t row = begin; row < end; ++row) {
+          func(row);
+        }
+      }
+      return;
+    }
+    if (isIdentityMapping_ || hasExtraNulls_) {
+      if constexpr (kIsNull) {
+        bits::forEachUnsetBit(nulls_, begin, end, std::forward<TFunc>(func));
+      } else {
+        bits::forEachSetBit(nulls_, begin, end, std::forward<TFunc>(func));
+      }
+    } else if (isConstantMapping_) {
+      if (bits::isBitNull(nulls_, 0) == kIsNull) {
+        for (vector_size_t row = begin; row < end; ++row) {
+          func(row);
+        }
+      }
+    } else {
+      VELOX_DCHECK(indices_);
+      for (vector_size_t row = begin; row < end; ++row) {
+        if (bits::isBitNull(nulls_, indices_[row]) == kIsNull) {
+          func(row);
+        }
+      }
+    }
+  }
+
   DecodedVector(
       const BaseVector& vector,
       const SelectivityVector* rows,

--- a/velox/vector/tests/DecodedVectorTest.cpp
+++ b/velox/vector/tests/DecodedVectorTest.cpp
@@ -1434,6 +1434,76 @@ TEST_F(DecodedVectorTest, dictionaryOverFlatNulls) {
   decodeAndCheckNulls(dict);
 }
 
+TEST_F(DecodedVectorTest, forEachNullNotNull) {
+  // forEachNull/forEachNotNull must visit exactly the null / non-null rows in
+  // [begin, end), in order. Cross-check against isNullAt for every encoding so
+  // the assertion holds regardless of which internal branch (bulk scan vs
+  // per-row) is taken.
+  auto verify = [&](const VectorPtr& vector) {
+    SelectivityVector rows(vector->size());
+    DecodedVector decoded(*vector, rows);
+
+    auto collect = [&](bool wantNull, vector_size_t begin, vector_size_t end) {
+      std::vector<vector_size_t> visited;
+      auto push = [&](vector_size_t row) { visited.push_back(row); };
+      if (wantNull) {
+        decoded.forEachNull(begin, end, push);
+      } else {
+        decoded.forEachNotNull(begin, end, push);
+      }
+      return visited;
+    };
+    auto expected = [&](bool wantNull, vector_size_t begin, vector_size_t end) {
+      std::vector<vector_size_t> result;
+      for (vector_size_t row = begin; row < end; ++row) {
+        if (decoded.isNullAt(row) == wantNull) {
+          result.push_back(row);
+        }
+      }
+      return result;
+    };
+    auto check = [&](vector_size_t begin, vector_size_t end) {
+      EXPECT_EQ(collect(true, begin, end), expected(true, begin, end));
+      EXPECT_EQ(collect(false, begin, end), expected(false, begin, end));
+    };
+
+    const auto size = vector->size();
+    check(0, size);
+    // Interior sub-range: only rows inside [begin, end), nothing outside.
+    ASSERT_GE(size, 4);
+    check(1, size - 1);
+  };
+
+  auto identity = [](auto row) { return row; };
+
+  // Flat: some nulls, no nulls, all null.
+  verify(makeFlatVector<int64_t>(64, identity, nullEvery(7)));
+  verify(makeFlatVector<int64_t>(64, identity));
+  verify(makeFlatVector<int64_t>(64, identity, nullEvery(1)));
+
+  // Dictionary inheriting base nulls through indirection (per-row index path).
+  // Reverse indices ensure the scan must translate indices_[row] rather than
+  // iterating top-level row numbers (which would give the wrong null bits).
+  {
+    auto base = makeFlatVector<int64_t>(64, identity, nullEvery(5));
+    auto indices = makeIndicesInReverse(64);
+    verify(BaseVector::wrapInDictionary(nullptr, indices, 64, base));
+  }
+
+  // Dictionary adding its own nulls over a null-free base (combined-nulls
+  // path).
+  {
+    auto base = makeFlatVector<int64_t>(64, identity);
+    auto indices = makeIndices(64, identity);
+    auto nulls = makeNulls(64, nullEvery(3));
+    verify(BaseVector::wrapInDictionary(nulls, indices, 64, base));
+  }
+
+  // Constant: null and non-null.
+  verify(makeNullConstant(TypeKind::BIGINT, 16));
+  verify(makeConstant<int64_t>(42, 16));
+}
+
 TEST_F(DecodedVectorTest, dictionaryWrapping) {
   constexpr vector_size_t baseVectorSize{100};
   constexpr vector_size_t innerDictSize{30};


### PR DESCRIPTION
Summary:

Adds a complementary pair of const, encoding-aware row iterators:

    template <typename TFunc>
    void forEachNull(vector_size_t begin, vector_size_t end, TFunc&& func) const;
    template <typename TFunc>
    void forEachNotNull(vector_size_t begin, vector_size_t end, TFunc&& func) const;

Both invoke 'func(row)' for the matching top-level rows in [begin, end), in increasing order, and share one private implementation (forEachRow<kIsNull>). They hide the encoding dispatch: for flat/identity and dictionary-with-combined-nulls encodings the null bitmap is scanned a word at a time (bits::forEachUnsetBit / forEachSetBit, skipping whole words); other dictionaries resolve the indirection per row; a constant expands to all-or-nothing; and with no null bitmap every row is non-null (so forEachNotNull visits the whole range, forEachNull visits nothing).

This lets callers do null-aware bulk work -- zeroing/masking null positions, or processing valid values -- without branching on the encoding themselves or paying a per-row isNullAt() call on the common flat case. Both stay const, unlike nulls(), which lazily materializes and caches a combined bitmap; so they are usable on a const DecodedVector&. forEachNotNull is the common direction (iterate valid rows); forEachNull its counterpart.

Reviewed By: MnO2

Differential Revision: D110926017


