### PR TITLE
refactor(cudf): Rework Iceberg schema evolution

### DIFF
--- a/velox/experimental/cudf/connectors/hive/CudfSplitReader.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfSplitReader.cpp
@@ -33,6 +33,7 @@
 #include <cudf/io/datasource.hpp>
 #include <cudf/io/experimental/hybrid_scan.hpp>
 #include <cudf/io/parquet.hpp>
+#include <cudf/io/parquet_metadata.hpp>
 #include <cudf/io/text/byte_range_info.hpp>
 #include <cudf/io/types.hpp>
 #include <cudf/table/table.hpp>
@@ -107,9 +108,8 @@ void CudfSplitReader::prepareSplit(
   // Create a cuDF split reader
   if (useExperimentalCudfReader_) {
     createExperimentalReader();
-    hybridScanState_ = std::make_unique<HybridScanState>();
   } else {
-    createCudfReader(get_output_mr());
+    createCudfReader();
   }
 
   // Update runtime stats
@@ -119,18 +119,14 @@ void CudfSplitReader::prepareSplit(
 std::optional<std::unique_ptr<cudf::table>> CudfSplitReader::next(
     uint64_t /*size*/) {
   VELOX_NVTX_OPERATOR_FUNC_RANGE();
-  VELOX_CHECK(
-      splitReader_ or exptSplitReader_,
-      "No Cudf Split reader present. Call prepareSplit() first.");
 
   // Record start time before reading chunk
   auto startTimeUs = getCurrentTimeMicro();
 
-  auto chunkOpt = readNextChunk(get_output_mr());
+  auto chunkOpt = readNextChunk();
   if (!chunkOpt.has_value()) {
     return std::nullopt;
   }
-  auto cudfTable = std::move(chunkOpt.value());
 
   TotalScanTimeCallbackData* callbackData =
       new TotalScanTimeCallbackData{startTimeUs, ioStatistics_};
@@ -139,11 +135,10 @@ std::optional<std::unique_ptr<cudf::table>> CudfSplitReader::next(
   cudaLaunchHostFunc(
       stream_.value(), &CudfSplitReader::totalScanTimeCalculator, callbackData);
 
-  return cudfTable;
+  return std::move(chunkOpt.value());
 }
 
-std::optional<std::unique_ptr<cudf::table>> CudfSplitReader::readNextChunk(
-    rmm::device_async_resource_ref output_mr) {
+std::optional<std::unique_ptr<cudf::table>> CudfSplitReader::readNextChunk() {
   if (!useExperimentalCudfReader_) {
     // Read table using the regular cudf parquet reader
     VELOX_CHECK_NOT_NULL(splitReader_, "cudf parquet reader not present");
@@ -152,9 +147,10 @@ std::optional<std::unique_ptr<cudf::table>> CudfSplitReader::readNextChunk(
       return std::nullopt;
     }
 
-    auto tableWithMetadata = splitReader_->read_chunk();
-    return std::move(tableWithMetadata.tbl);
+    return std::move(splitReader_->read_chunk().tbl);
   }
+
+  auto output_mr = determineCudfMemoryResource();
 
   // Read table using the experimental parquet reader
   VELOX_CHECK_NOT_NULL(exptSplitReader_, "cuDF hybrid scan reader not present");
@@ -215,8 +211,7 @@ std::optional<std::unique_ptr<cudf::table>> CudfSplitReader::readNextChunk(
     return std::nullopt;
   }
 
-  auto tableWithMetadata = exptSplitReader_->materialize_all_columns_chunk();
-  return std::move(tableWithMetadata.tbl);
+  return std::move(exptSplitReader_->materialize_all_columns_chunk().tbl);
 }
 
 void CudfSplitReader::resetSplit() {
@@ -224,6 +219,11 @@ void CudfSplitReader::resetSplit() {
   exptSplitReader_.reset();
   hybridScanState_.reset();
   dataSource_.reset();
+  fileMetaData_.clear();
+}
+
+cudf::ast::expression const* CudfSplitReader::subfieldFilter() {
+  return subfieldFilterExpr_;
 }
 
 void CudfSplitReader::setupCudfDataSource() {
@@ -344,8 +344,8 @@ void CudfSplitReader::setupReaderOptions() {
     readerOptions_.set_num_bytes(split_->size());
   }
 
-  if (subfieldFilterExpr_ != nullptr) {
-    readerOptions_.set_filter(*subfieldFilterExpr_);
+  if (auto* filter = subfieldFilter(); filter != nullptr) {
+    readerOptions_.set_filter(*filter);
   }
 
   // Set column projection if needed
@@ -354,11 +354,42 @@ void CudfSplitReader::setupReaderOptions() {
   }
 }
 
-void CudfSplitReader::createCudfReader(
-    rmm::device_async_resource_ref output_mr) {
-  // Setup datasource and reader options
+rmm::device_async_resource_ref CudfSplitReader::determineCudfMemoryResource() {
+  return get_output_mr();
+}
+
+void CudfSplitReader::fileMetaDatas() {
+  if (not fileMetaData_.empty()) {
+    return;
+  }
+
+  // Setup the datasource
   setupCudfDataSource();
+
+  // Check that the datasource is set up
+  VELOX_CHECK_NOT_NULL(
+      dataSource_,
+      "CudfSplitReader does not have a datasource. Call setupCudfDataSource() first");
+
+  // Wrap the existing datasource without transferring ownership.
+  std::vector<std::unique_ptr<cudf::io::datasource>> sources;
+  sources.push_back(cudf::io::datasource::create(dataSource_.get()));
+  fileMetaData_ = cudf::io::read_parquet_footers(sources);
+  VELOX_CHECK_GE(
+      fileMetaData_.size(),
+      1,
+      "CudfSplitReader failed to read any parquet metadatas");
+}
+
+void CudfSplitReader::createCudfReader() {
+  // Read file metadatas
+  fileMetaDatas();
+
+  // Setup reader options
   setupReaderOptions();
+
+  std::vector<std::unique_ptr<cudf::io::datasource>> sources;
+  sources.push_back(cudf::io::datasource::create(dataSource_.get()));
 
   // Create a parquet reader
   splitReader_ = std::make_unique<cudf::io::chunked_parquet_reader>(
@@ -366,34 +397,43 @@ void CudfSplitReader::createCudfReader(
           connectorQueryCtx_->sessionProperties()),
       cudfHiveConfig_->maxPassReadLimitSession(
           connectorQueryCtx_->sessionProperties()),
+      std::move(sources),
+      std::move(fileMetaData_),
       readerOptions_,
       stream_,
-      output_mr);
+      determineCudfMemoryResource());
+
+  // Metadata ingested
+  fileMetaData_.clear();
 }
 
 void CudfSplitReader::createExperimentalReader() {
-  // Setup datasource and reader options
-  setupCudfDataSource();
+  // Read file metadatas
+  fileMetaDatas();
+
+  // Setup reader options
   setupReaderOptions();
+
+  VELOX_CHECK_EQ(
+      fileMetaData_.size(),
+      1,
+      "cuDF experimental reader requires exactly one parquet metadata");
 
   // Create a hybrid scan reader
   nvtxRangePush("hybridScanReader");
-  auto const footerBuffer = fetchFooterBytes(dataSource_);
-  auto reader =
-      std::make_unique<CudfHybridScanReader>(*footerBuffer, readerOptions_);
+  auto reader = std::make_unique<CudfHybridScanReader>(
+      std::move(fileMetaData_.front()), readerOptions_);
   nvtxRangePop();
 
-  // Setup page index if available
-  auto const pageIndexByteRange = reader->page_index_byte_range();
-  if (not pageIndexByteRange.is_empty()) {
-    nvtxRangePush("setupPageIndex");
-    auto const pageIndexBuffer =
-        fetchPageIndexBytes(dataSource_, pageIndexByteRange);
-    reader->setup_page_index(*pageIndexBuffer);
-    nvtxRangePop();
-  }
-
   exptSplitReader_ = std::move(reader);
+  hybridScanState_ = std::make_unique<HybridScanState>();
+
+  // Metadata ingested
+  fileMetaData_.clear();
+}
+
+bool CudfSplitReader::useExperimentalCudfReader() const {
+  return useExperimentalCudfReader_;
 }
 
 void CudfSplitReader::totalScanTimeCalculator(void* userData) {

--- a/velox/experimental/cudf/connectors/hive/CudfSplitReader.h
+++ b/velox/experimental/cudf/connectors/hive/CudfSplitReader.h
@@ -32,6 +32,7 @@
 #include <cudf/io/datasource.hpp>
 #include <cudf/io/experimental/hybrid_scan.hpp>
 #include <cudf/io/parquet.hpp>
+#include <cudf/io/parquet_schema.hpp>
 #include <cudf/io/types.hpp>
 
 namespace facebook::velox::cudf_velox::connector::hive {
@@ -77,19 +78,35 @@ class CudfSplitReader : public NvtxHelper {
   }
 
  protected:
-  /// Create the chunked parquet reader.
-  virtual void createCudfReader(rmm::device_async_resource_ref output_mr);
+  // Clear splitReaders and datasources after split has been fully processed.
+  virtual void resetSplit();
 
-  /// Setup the cuDF data source
+  // Return the subfield filter.
+  virtual cudf::ast::expression const* subfieldFilter();
+
+  // Determine the output memory resource for the cuDF reader.
+  virtual rmm::device_async_resource_ref determineCudfMemoryResource();
+
+  // Read the next table chunk from the parquet reader (regular or hybrid).
+  // Returns nullopt when no more data.
+  virtual std::optional<std::unique_ptr<cudf::table>> readNextChunk();
+
+ protected:
+  // Setup the cuDF data source
   void setupCudfDataSource();
 
-  /// Clear splitReaders and datasources after split has been fully processed.
-  void resetSplit();
+  // Read file metadatas.
+  void fileMetaDatas();
 
-  /// Read the next raw chunk from the parquet reader (regular or hybrid).
-  /// Returns nullopt when no more data.
-  virtual std::optional<std::unique_ptr<cudf::table>> readNextChunk(
-      rmm::device_async_resource_ref output_mr);
+  // Create the chunked parquet reader.
+  void createCudfReader();
+
+  // Create the experimental hybrid scan reader.
+  // Requires exactly one footer.
+  void createExperimentalReader();
+
+  // Whether to use the experimental cuDF reader.
+  bool useExperimentalCudfReader() const;
 
   std::shared_ptr<CudfHiveConnectorSplit> split_;
   std::shared_ptr<const ::facebook::velox::connector::hive::HiveTableHandle>
@@ -104,20 +121,20 @@ class CudfSplitReader : public NvtxHelper {
   std::shared_ptr<io::IoStatistics> ioStatistics_;
   std::shared_ptr<IoStats> ioStats_;
 
-  std::shared_ptr<cudf::io::datasource> dataSource_;
   rmm::cuda_stream_view stream_;
 
- private:
-  /// Setup the cuDF reader options
-  void setupReaderOptions();
+  // Parquet metadata(s) for the current split(s).
+  std::vector<cudf::io::parquet::FileMetaData> fileMetaData_;
 
-  /// Create the experimental hybrid scan reader.
-  void createExperimentalReader();
+ private:
+  // Setup the cuDF reader options
+  void setupReaderOptions();
 
   std::shared_ptr<CudfHiveConfig> cudfHiveConfig_;
   memory::MemoryPool* pool_;
 
   // cuDF split reader stuff.
+  std::shared_ptr<cudf::io::datasource> dataSource_;
   cudf::io::parquet_reader_options readerOptions_;
   CudfParquetReaderPtr splitReader_;
   CudfHybridScanReaderPtr exptSplitReader_;
@@ -125,7 +142,6 @@ class CudfSplitReader : public NvtxHelper {
   bool useExperimentalCudfReader_;
 
   dwio::common::ReaderOptions baseReaderOpts_;
-
   cudf::ast::expression const* subfieldFilterExpr_;
 
   struct TotalScanTimeCallbackData {

--- a/velox/experimental/cudf/connectors/hive/CudfSplitReaderHelpers.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfSplitReaderHelpers.cpp
@@ -170,20 +170,6 @@ void BufferedInputDataSource::readContiguous(
   stream->readFully(reinterpret_cast<char*>(dst), size);
 }
 
-std::unique_ptr<cudf::io::datasource::buffer> fetchFooterBytes(
-    std::shared_ptr<cudf::io::datasource> dataSource) {
-  // Using libcudf utility but may have custom implementation in the future
-  return cudf::io::parquet::fetch_footer_to_host(*dataSource);
-}
-
-std::unique_ptr<cudf::io::datasource::buffer> fetchPageIndexBytes(
-    std::shared_ptr<cudf::io::datasource> dataSource,
-    const cudf::io::text::byte_range_info pageIndexBytes) {
-  // Using libcudf utility but may have custom implementation in the future
-  return cudf::io::parquet::fetch_page_index_to_host(
-      *dataSource, pageIndexBytes);
-}
-
 std::tuple<
     std::vector<rmm::device_buffer>,
     std::vector<cudf::device_span<const uint8_t>>,

--- a/velox/experimental/cudf/connectors/hive/CudfSplitReaderHelpers.h
+++ b/velox/experimental/cudf/connectors/hive/CudfSplitReaderHelpers.h
@@ -96,27 +96,6 @@ struct HybridScanState {
 };
 
 /**
- * @brief Fetches a host buffer of Parquet footer bytes from the input data
- * source
- *
- * @param dataSource Input data source
- * @return Host buffer containing footer bytes
- */
-std::unique_ptr<cudf::io::datasource::buffer> fetchFooterBytes(
-    std::shared_ptr<cudf::io::datasource> dataSource);
-
-/**
- * @brief Fetches a host buffer of Parquet page index from the input data source
- *
- * @param dataSource Input datasource
- * @param pageIndexBytes Byte range of page index
- * @return Host buffer containing page index bytes
- */
-std::unique_ptr<cudf::io::datasource::buffer> fetchPageIndexBytes(
-    std::shared_ptr<cudf::io::datasource> dataSource,
-    const cudf::io::text::byte_range_info pageIndexBytes);
-
-/**
  * @brief Fetches a list of byte ranges from a host buffer into device buffers
  *
  * @param dataSource Input datasource

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergConnector.h
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergConnector.h
@@ -18,7 +18,7 @@
 #include "velox/experimental/cudf/connectors/hive/CudfHiveConfig.h"
 
 #include "velox/connectors/hive/HiveConnector.h"
-#include "velox/connectors/hive/iceberg/IcebergConfig.h"
+#include "velox/connectors/hive/iceberg/IcebergConnector.h"
 
 namespace facebook::velox::cudf_velox::connector::hive::iceberg {
 
@@ -67,9 +67,10 @@ class CudfIcebergConnector final
 /// Factory for creating CudfIcebergConnector instances.
 class CudfIcebergConnectorFactory final : public ConnectorFactory {
  public:
-  static constexpr const char* kCudfIcebergConnectorName = "cudf-iceberg";
-
-  CudfIcebergConnectorFactory() : ConnectorFactory(kCudfIcebergConnectorName) {}
+  CudfIcebergConnectorFactory()
+      : ConnectorFactory(
+            ::facebook::velox::connector::hive::iceberg::
+                IcebergConnectorFactory::kIcebergConnectorName) {}
 
   explicit CudfIcebergConnectorFactory(const char* connectorName)
       : ConnectorFactory(connectorName) {}

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergDataSource.h
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergDataSource.h
@@ -37,8 +37,8 @@ namespace velox_iceberg = ::facebook::velox::connector::hive::iceberg;
 /// - Schema evolution with column adaptation (missing/added columns).
 ///
 /// The following features are not yet supported:
-/// - Identity partition columns are limited to VARCHAR, INTEGER, and BIGINT;
-///   other partition types (e.g. BOOLEAN, DATE, TIMESTAMP, DECIMAL, REAL,
+/// - Identity partition columns are limited to VARCHAR, INTEGER, BIGINT, DATE,
+///   and TIMESTAMP; other partition types (e.g. BOOLEAN, DECIMAL, REAL,
 ///   DOUBLE, VARBINARY) are not yet supported.
 /// - Iceberg-specific metadata columns.
 class CudfIcebergDataSource : public ::facebook::velox::cudf_velox::connector::

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergDeletionHelpers.cu
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergDeletionHelpers.cu
@@ -26,6 +26,7 @@
 
 #include <cuda/iterator>
 #include <cuda/std/type_traits>
+#include <thrust/count.h>
 #include <thrust/scatter.h>
 #include <thrust/sequence.h>
 #include <thrust/transform.h>
@@ -60,6 +61,17 @@ void applyBitmapToMask(
       deleteMask.begin<bool>(),
       deleteMask.begin<bool>(),
       IsDeletedRow{bitmap.data()});
+}
+
+cudf::size_type countDeletedRows(
+    cudf::column_view const& deleteMask,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref temp_mr) {
+  return static_cast<cudf::size_type>(thrust::count(
+      rmm::exec_policy_nosync(stream, temp_mr),
+      deleteMask.begin<bool>(),
+      deleteMask.end<bool>(),
+      true));
 }
 
 void scatterDeletesToMask(

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergDeletionHelpers.h
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergDeletionHelpers.h
@@ -40,6 +40,17 @@ void applyBitmapToMask(
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref temp_mr);
 
+/// Counts the number of deleted rows (set to `true`) in the supplied deletion
+/// mask.
+/// @param deleteMask Deletion mask column (row is deleted iff `true`)
+/// @param stream CUDA stream to use
+/// @param temp_mr Memory resource for temporary allocations
+/// @return Number of deleted rows
+cudf::size_type countDeletedRows(
+    cudf::column_view const& deleteMask,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref temp_mr);
+
 /// Scatters deletes to the deletion mask at positions indicated by `indices`
 /// (anti-join semantics).
 /// @param deleteMask Mutable view of deletion mask column

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
@@ -20,21 +20,22 @@
 #include "velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.h"
 #include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
+#include "velox/experimental/cudf/expression/AstUtils.h"
 
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/encode/Base64.h"
+#include "velox/connectors/hive/FileSplitReader.h"
 #include "velox/connectors/hive/iceberg/IcebergMetadataColumns.h"
 #include "velox/dwio/common/BufferUtil.h"
 #include "velox/type/Type.h"
 
 #include <cudf/column/column_factories.hpp>
-#include <cudf/io/parquet.hpp>
-#include <cudf/io/parquet_metadata.hpp>
 #include <cudf/null_mask.hpp>
 #include <cudf/scalar/scalar.hpp>
 #include <cudf/scalar/scalar_factories.hpp>
 #include <cudf/stream_compaction.hpp>
+#include <cudf/transform.hpp>
 #include <cudf/unary.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/span.hpp>
@@ -46,6 +47,7 @@
 #include <folly/lang/Bits.h>
 
 #include <cstring>
+#include <limits>
 #include <unordered_set>
 
 namespace facebook::velox::cudf_velox::connector::hive::iceberg {
@@ -110,66 +112,122 @@ CudfIcebergSplitReader::CudfIcebergSplitReader(
 
 void CudfIcebergSplitReader::prepareSplit(
     dwio::common::RuntimeStatistics& runtimeStats) {
-  // Clear existing delete file readers and other state
+  // Reset the split
+  resetSplit();
+
+  // Get a stream
+  stream_ = cudfGlobalStreamPool().get_stream();
+
+  // Sub-splits are not yet supported.
+  if (split_->start != 0) {
+    VELOX_NYI("cuDF Iceberg reader does not yet support sub-splits");
+  }
+
+  // Read file metadata and cache schema information
+  cacheSchemaFromMetadata();
+
+  // Must setup delete file readers before reader construction so that it
+  // can correctly determine the memory resource to construct the cuDF reader.
+  setupDeleteFileReaders(runtimeStats);
+
+  // Include any extra equality delete key columns that are not already in the
+  // output projection.
+  setupEqualityColumnKeys();
+
+  // Detect info, (Hive-migrated) partition, and schema-evolution columns;
+  // remove them from `readColumnNames_` so the parquet reader skips them, and
+  // record them for post-read injection.
+  adaptColumns();
+
+  // Determine if there are no columns to read.
+  noColumnsToRead_ = readColumnNames_.empty();
+
+  // Defer subfield filter when it cannot evaluate on the physical parquet
+  // table, or when positional deletes are present.
+  deferSubfieldFilter_ = CudfSplitReader::subfieldFilter() != nullptr and
+      (noColumnsToRead_ or injectedColumns_.size() or
+       // TODO(mh): Drop positional/DV deferral when cudf PR #23077 merges.
+       deletionVectorReader_ or positionalDeleteFileReaders_.size());
+
+  if (deferSubfieldFilter_) {
+    VLOG(1) << "Subfield filter is deferred to post table read due to missing "
+               "column references and/or positional deletes.";
+  }
+
+  runtimeStats.processedSplits++;
+
+  // No need to create a cuDF reader for injected-only projection.
+  if (noColumnsToRead_) {
+    return;
+  }
+
+  // Create the cuDF reader
+  if (useExperimentalCudfReader()) {
+    createExperimentalReader();
+  } else {
+    createCudfReader();
+  }
+}
+
+void CudfIcebergSplitReader::resetSplit() {
+  CudfSplitReader::resetSplit();
+
   deletionVectorReader_.reset();
   positionalDeleteFileReaders_.clear();
   equalityDeleteFileReaders_.clear();
   extraEqualityColumns_.clear();
   injectedColumns_.clear();
+  fileColumnNames_.clear();
+  fileRowCount_ = 0;
+  noColumnsToRead_ = false;
+  syntheticTableProduced_ = false;
+  deferSubfieldFilter_ = false;
   baseReadOffset_ = 0;
+  deleteBitmap_ = nullptr;
+  deviceBitmap_.reset();
+  deleteMask_.reset();
+}
 
-  // Must setup delete file readers before calling base `prepareSplit` so
-  // that it can correctly determine the memory resource to construct the cuDF
-  // reader. Pass the DataSource's runtimeStats so delete readers accumulate
-  // stats directly into the DataSource's stats object.
-  setupDeleteFileReaders(runtimeStats);
-
-  // Setup column projection to include any equality delete key columns that
-  // are not already in the output projection. Must be called before base
-  // `prepareSplit`
-  setupColumnProjection();
-
-  // Schema evolution: Detect info columns, partition columns, and
-  // schema-evolution missing columns. Filters them from readColumnNames_ so the
-  // parquet reader doesn't try to read them, and records them for post-read
-  // injection.
-  adaptColumns();
-
-  // Call base to setup stream, datasource, options, and the cudf reader
-  CudfSplitReader::prepareSplit(runtimeStats);
+cudf::ast::expression const* CudfIcebergSplitReader::subfieldFilter() {
+  return deferSubfieldFilter_ ? nullptr : CudfSplitReader::subfieldFilter();
 }
 
 rmm::device_async_resource_ref
 CudfIcebergSplitReader::determineCudfMemoryResource() {
-  // If we will be applying any deletes, use temporary mr to read table chunks
-  // from cuDF readers. Otherwise, use the output mr.
-  return (deletionVectorReader_ or positionalDeleteFileReaders_.size() or
-          equalityDeleteFileReaders_.size())
-      ? get_temp_mr()
-      : get_output_mr();
-}
-
-void CudfIcebergSplitReader::createCudfReader(
-    rmm::device_async_resource_ref output_mr) {
-  CudfSplitReader::createCudfReader(determineCudfMemoryResource());
+  // Use temporary mr when there are filters beyond table read.
+  const auto needsTempMr = deferSubfieldFilter_ or deletionVectorReader_ or
+      positionalDeleteFileReaders_.size() or equalityDeleteFileReaders_.size();
+  return needsTempMr ? get_temp_mr() : get_output_mr();
 }
 
 std::optional<std::unique_ptr<cudf::table>>
-CudfIcebergSplitReader::readNextChunk(
-    rmm::device_async_resource_ref output_mr) {
-  // Determine the memory resource to use for `readNextChunk`
-  auto mr = determineCudfMemoryResource();
-
-  // Read the next table chunk from the cuDF reader
-  auto cudfTable = CudfSplitReader::readNextChunk(mr).value_or(nullptr);
-  if (not cudfTable) {
-    return std::nullopt;
+CudfIcebergSplitReader::readNextChunk() {
+  std::unique_ptr<cudf::table> cudfTable;
+  if (noColumnsToRead_) {
+    if (syntheticTableProduced_) {
+      return std::nullopt;
+    }
+    VELOX_CHECK_LE(
+        fileRowCount_,
+        std::numeric_limits<cudf::size_type>::max(),
+        "File row count exceeds max cudf::size_type value");
+    syntheticTableProduced_ = true;
+    cudfTable = std::make_unique<cudf::table>(
+        std::vector<std::unique_ptr<cudf::column>>{});
+  } else {
+    // Read the next table chunk from the cuDF reader
+    auto chunkOpt = CudfSplitReader::readNextChunk();
+    if (not chunkOpt.has_value()) {
+      return std::nullopt;
+    }
+    cudfTable = std::move(chunkOpt.value());
   }
 
-  // Number of table rows read by cuDF (before any deletes)
-  const auto numRows = cudfTable->num_rows();
+  // Number of table rows before deletes.
+  const auto numRows = noColumnsToRead_
+      ? static_cast<cudf::size_type>(fileRowCount_)
+      : cudfTable->num_rows();
 
-  // Determine if we are applying any deletes
   const auto isApplyingDeletes = numRows > 0 and
       (deletionVectorReader_ or positionalDeleteFileReaders_.size() or
        equalityDeleteFileReaders_.size());
@@ -200,38 +258,67 @@ CudfIcebergSplitReader::readNextChunk(
 
     // Apply deletion vector
     if (deletionVectorReader_) {
-      applyDeletionVector(cudfTable->view());
+      applyDeletionVector(numRows);
     }
     // Apply positional deletes
     if (positionalDeleteFileReaders_.size()) {
-      applyPositionalDeletes(cudfTable->view());
+      applyPositionalDeletes(numRows);
     }
     // Apply equality deletes
     if (equalityDeleteFileReaders_.size()) {
+      VELOX_CHECK_GE(
+          cudfTable->num_columns(),
+          extraEqualityColumns_.size(),
+          "cuDF table must at least contain the extra equality delete key columns");
       applyEqualityDeletes(cudfTable->view());
+      // Drop any extra equality-delete key columns.
+      if (extraEqualityColumns_.size()) {
+        auto columns = cudfTable->release();
+        columns.resize(columns.size() - extraEqualityColumns_.size());
+        cudfTable = std::make_unique<cudf::table>(std::move(columns));
+      }
     }
 
-    cudfTable = cudf::apply_deletion_mask(
-        cudfTable->view(), deleteMaskView_, stream_, get_output_mr());
+    // Apply the delete mask if there are remaining physical columns.
+    if (cudfTable->num_columns() > 0) {
+      const auto deleteMr =
+          deferSubfieldFilter_ ? get_temp_mr() : get_output_mr();
+      cudfTable = cudf::apply_deletion_mask(
+          cudfTable->view(), deleteMaskView_, stream_, deleteMr);
+    }
   }
 
-  // Strip extra equality delete key columns added by
-  // setupColumnProjection()
-  if (not extraEqualityColumns_.empty()) {
-    auto columns = cudfTable->release();
-    VELOX_CHECK_GE(
-        columns.size(),
-        extraEqualityColumns_.size(),
-        "cuDF table has fewer columns than the appended equality delete keys");
-    columns.resize(columns.size() - extraEqualityColumns_.size());
-    cudfTable = std::make_unique<cudf::table>(std::move(columns));
+  // Compute the row count override if there are no remaining physical columns.
+  std::optional<cudf::size_type> rowCountOverride = std::nullopt;
+  if (cudfTable->num_columns() == 0) {
+    if (isApplyingDeletes) {
+      const auto deletedRows = static_cast<std::size_t>(
+          countDeletedRows(deleteMaskView_, stream_, get_temp_mr()));
+      VELOX_CHECK_LE(
+          deletedRows,
+          static_cast<std::size_t>(numRows),
+          "Deleted rows exceed input rows for synthetic table. numRows: {}, deletedRows: {}",
+          numRows,
+          deletedRows);
+      rowCountOverride = numRows - static_cast<cudf::size_type>(deletedRows);
+    } else {
+      rowCountOverride = numRows;
+    }
   }
 
-  // Inject partition columns and schema-evolution NULL columns.
-  // This must run even for 0-row tables so post-delete empty chunks still
-  // have the expected number and order of output columns.
-  if (not injectedColumns_.empty()) {
-    cudfTable = injectMissingColumns(std::move(cudfTable), output_mr);
+  // Build output table by injecting missing columns at appropriate indices
+  const auto injectMr = deferSubfieldFilter_ ? get_temp_mr() : get_output_mr();
+  cudfTable =
+      buildOutputTable(std::move(cudfTable), injectMr, rowCountOverride);
+
+  // Apply the deferred subfield filter.
+  if (deferSubfieldFilter_) {
+    auto* filter = CudfSplitReader::subfieldFilter();
+    VELOX_CHECK_NOT_NULL(filter);
+    auto filterMask = cudf::compute_column(
+        cudfTable->view(), *filter, stream_, get_temp_mr());
+    cudfTable = cudf::apply_boolean_mask(
+        cudfTable->view(), filterMask->view(), stream_, get_output_mr());
   }
 
   // Update the base read offset
@@ -379,16 +466,14 @@ void CudfIcebergSplitReader::setupDeleteFileReaders(
   }
 }
 
-void CudfIcebergSplitReader::applyDeletionVector(cudf::table_view input) {
+void CudfIcebergSplitReader::applyDeletionVector(std::size_t numRows) {
   // Apply deletion vector into the deleteMask_
-  const auto numRows = input.num_rows();
   deletionVectorReader_->applyDeletes(
       deleteMaskView_, baseReadOffset_, numRows, stream_, get_temp_mr());
 }
 
-void CudfIcebergSplitReader::applyPositionalDeletes(cudf::table_view input) {
+void CudfIcebergSplitReader::applyPositionalDeletes(std::size_t numRows) {
   // Apply positional deletes into the deleteMask_
-  const auto numRows = input.num_rows();
 
   // Initialize host and device delete bitmaps
   const auto numWords = cudf::num_bitmask_words(numRows);
@@ -440,15 +525,12 @@ void CudfIcebergSplitReader::applyPositionalDeletes(cudf::table_view input) {
 
 void CudfIcebergSplitReader::applyEqualityDeletes(cudf::table_view input) {
   // Apply equality deletes against the running deleteMask_.
-  const auto numRows = input.num_rows();
-
-  // Iteratively apply equality deletes, if any
   for (auto& reader : equalityDeleteFileReaders_) {
     reader->applyDeletes(input, readColumnNames_, deleteMaskView_, stream_);
   }
 }
 
-void CudfIcebergSplitReader::setupColumnProjection() {
+void CudfIcebergSplitReader::setupEqualityColumnKeys() {
   if (equalityDeleteFileReaders_.empty()) {
     return;
   }
@@ -475,6 +557,13 @@ void CudfIcebergSplitReader::setupColumnProjection() {
               const auto columnIdx = static_cast<uint32_t>(equalityFieldId - 1);
               if (dataColumns and columnIdx < dataColumns->size()) {
                 const auto& columnName = dataColumns->nameOf(columnIdx);
+                if (icebergSplit_->partitionKeys.contains(columnName) or
+                    not fileColumnNames_.contains(columnName)) {
+                  VELOX_NYI(
+                      "Equality deletes on partition columns or columns "
+                      "missing from the data file are not yet supported: {}",
+                      columnName);
+                }
                 // Insert column name into readColumnSet if not already present
                 if (readColumnSet.insert(columnName).second) {
                   extraEqualityColumns_.push_back(columnName);
@@ -491,16 +580,60 @@ void CudfIcebergSplitReader::setupColumnProjection() {
       extraEqualityColumns_.end());
 }
 
+void CudfIcebergSplitReader::cacheSchemaFromMetadata() {
+  // Read file metadatas if not already
+  fileMetaDatas();
+
+  VELOX_CHECK_EQ(
+      fileMetaData_.size(),
+      1,
+      "Expected a single parquet footer for Iceberg data file");
+  const auto& meta = fileMetaData_.front();
+  VELOX_CHECK(not meta.schema.empty(), "Parquet footer schema is empty");
+  VELOX_CHECK_GE(meta.num_rows, 0, "Parquet footer reports negative row count");
+  fileRowCount_ = static_cast<std::size_t>(meta.num_rows);
+
+  const auto& root = meta.schema.front();
+  fileColumnNames_.clear();
+  fileColumnNames_.reserve(root.children_idx.size());
+  for (const auto childIdx : root.children_idx) {
+    VELOX_CHECK_LT(
+        childIdx,
+        meta.schema.size(),
+        "Parquet schema child index out of range");
+    fileColumnNames_.insert(meta.schema[childIdx].name);
+  }
+}
+
 void CudfIcebergSplitReader::adaptColumns() {
-  // Detect info columns and partition columns
+  // Skip trailing equality-delete keys and classify output + filter-only
+  // columns only.
+  VELOX_CHECK_GE(
+      readColumnNames_.size(),
+      extraEqualityColumns_.size(),
+      "Column projection must at least include the equality delete keys");
+  const size_t schemaSize =
+      readColumnNames_.size() - extraEqualityColumns_.size();
+
   std::unordered_set<std::string> injectedNames;
-  for (size_t i = 0; i < outputType_->size(); ++i) {
-    const auto& fieldName = outputType_->nameOf(i);
+  for (size_t i = 0; i < schemaSize; ++i) {
+    const auto& fieldName = readColumnNames_[i];
+    const TypePtr veloxType = [&]() -> TypePtr {
+      if (i < outputType_->size()) {
+        return outputType_->childAt(i);
+      }
+      // Filter-only column beyond the output projection.
+      const auto& dataColumns = tableHandle_->dataColumns();
+      VELOX_CHECK(
+          dataColumns and dataColumns->containsChild(fieldName),
+          "Filter-only column missing from table schema: {}",
+          fieldName);
+      return dataColumns->findChild(fieldName);
+    }();
 
     if (auto iter = split_->infoColumns.find(fieldName);
         iter != split_->infoColumns.end()) {
-      injectedColumns_.push_back(
-          {i, fieldName, iter->second, outputType_->childAt(i)});
+      injectedColumns_.push_back({i, fieldName, iter->second, veloxType});
       injectedNames.insert(fieldName);
     } else if (auto it = icebergSplit_->partitionKeys.find(fieldName);
                it != icebergSplit_->partitionKeys.end()) {
@@ -508,42 +641,13 @@ void CudfIcebergSplitReader::adaptColumns() {
       // files, partition column values are stored in partition metadata
       // rather than in the data file itself, following Hive's
       // partitioning convention.
-      injectedColumns_.push_back(
-          {i, fieldName, it->second, outputType_->childAt(i)});
+      injectedColumns_.push_back({i, fieldName, it->second, veloxType});
       injectedNames.insert(fieldName);
-    }
-  }
-
-  // Detect schema-evolution missing columns by reading the parquet
-  // footer. Only needed if there are output columns not yet accounted for.
-  if (injectedNames.size() < outputType_->size()) {
-    setupCudfDataSource();
-    VELOX_CHECK_NOT_NULL(
-        dataSource_,
-        "CudfIcebergSplitReader failed to setup a cuDF datasource");
-    auto meta = cudf::io::read_parquet_metadata(
-        cudf::io::source_info{dataSource_.get()});
-    const auto& rootSchema = meta.schema().root();
-    std::unordered_set<std::string> fileColumns;
-    fileColumns.reserve(rootSchema.num_children());
-    std::transform(
-        rootSchema.children().begin(),
-        rootSchema.children().end(),
-        std::inserter(fileColumns, fileColumns.end()),
-        [](const auto& col) { return col.name(); });
-
-    for (size_t i = 0; i < outputType_->size(); ++i) {
-      const auto& fieldName = outputType_->nameOf(i);
-      if (injectedNames.contains(fieldName)) {
-        continue;
-      }
-      if (not fileColumns.contains(fieldName)) {
-        // Schema evolution: Column was added after the data file was written
-        // and doesn't exist in older data files.
-        injectedColumns_.push_back(
-            {i, fieldName, std::nullopt, outputType_->childAt(i)});
-        injectedNames.insert(fieldName);
-      }
+    } else if (not fileColumnNames_.contains(fieldName)) {
+      // Schema evolution: Column was added after the data file was written
+      // and doesn't exist in older data files.
+      injectedColumns_.push_back({i, fieldName, std::nullopt, veloxType});
+      injectedNames.insert(fieldName);
     }
   }
 
@@ -552,7 +656,7 @@ void CudfIcebergSplitReader::adaptColumns() {
     std::erase_if(readColumnNames_, [&injectedNames](const auto& name) {
       return injectedNames.contains(name);
     });
-    // Sort injected columns by output index once here
+    // Sort injected columns by assembled-table index once here
     std::sort(
         injectedColumns_.begin(),
         injectedColumns_.end(),
@@ -562,68 +666,47 @@ void CudfIcebergSplitReader::adaptColumns() {
   }
 }
 
-std::unique_ptr<cudf::table> CudfIcebergSplitReader::injectMissingColumns(
+std::unique_ptr<cudf::scalar> CudfIcebergSplitReader::makeInjectedScalar(
+    const InjectedColumn& col) const {
+  const bool readAsLocalTime =
+      hiveConfig_->readTimestampPartitionValueAsLocalTime(
+          connectorQueryCtx_->sessionProperties());
+  try {
+    // DATE values arrive in two format-disjoint encodings: Iceberg-native
+    // days-since-epoch integers (e.g. "20244") or Hive-migrated date strings
+    // (e.g. "2025-06-05"). A bare integer is unambiguously days-since-epoch
+    // (date strings contain '-' separators that fail an integer parse).
+    const bool isDaysSinceEpoch = col.veloxType->isDate() and
+        col.partitionValue.has_value() and
+        folly::tryTo<int32_t>(col.partitionValue.value()).hasValue();
+    const VectorPtr constant = velox::connector::hive::newConstantFromString(
+        col.veloxType,
+        col.partitionValue,
+        connectorQueryCtx_->memoryPool(),
+        readAsLocalTime,
+        isDaysSinceEpoch);
+    return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+        cudf_velox::createCudfScalar, col.veloxType->kind(), constant);
+  } catch (const std::exception& e) {
+    VELOX_USER_FAIL(
+        "Bad partition value. Column: {}, type: {}, value: {}, error: {}",
+        col.name,
+        col.veloxType->toString(),
+        col.partitionValue.value_or("<null>"),
+        e.what());
+  }
+}
+
+std::unique_ptr<cudf::table> CudfIcebergSplitReader::buildOutputTable(
     std::unique_ptr<cudf::table>&& table,
-    rmm::device_async_resource_ref mr) {
-  const auto numRows = table->num_rows();
-  auto columns = table->release();
+    rmm::device_async_resource_ref mr,
+    std::optional<cudf::size_type> rowCountOverride) {
+  const auto numRows = rowCountOverride.value_or(table->num_rows());
+  auto columns = rowCountOverride.has_value()
+      ? std::vector<std::unique_ptr<cudf::column>>{}
+      : table->release();
 
-  // Creates a scalar from a string partition value for the given cudf type.
-  auto makePartitionScalar =
-      [&](const std::string& value,
-          cudf::data_type cudfType,
-          const InjectedColumn& col) -> std::unique_ptr<cudf::scalar> {
-    if (cudfType.id() != cudf::type_id::STRING and
-        cudfType.id() != cudf::type_id::INT32 and
-        cudfType.id() != cudf::type_id::INT64 and
-        cudfType.id() != cudf::type_id::TIMESTAMP_DAYS) {
-      VELOX_NYI(
-          "Identity partition columns are limited to VARCHAR, INTEGER, BIGINT, and DATE only. Other types are not yet supported. Column: '{}', Type: {}",
-          col.name,
-          col.veloxType->toString());
-    }
-    try {
-      switch (cudfType.id()) {
-        case cudf::type_id::STRING:
-          return std::make_unique<cudf::string_scalar>(
-              value, true, stream_, mr);
-        case cudf::type_id::INT32:
-          return std::make_unique<cudf::numeric_scalar<int32_t>>(
-              folly::to<int32_t>(value), true, stream_, mr);
-        case cudf::type_id::INT64:
-          return std::make_unique<cudf::numeric_scalar<int64_t>>(
-              folly::to<int64_t>(value), true, stream_, mr);
-        case cudf::type_id::TIMESTAMP_DAYS: {
-          // DATE partition values arrive either as days-since-epoch (Iceberg
-          // native) or as a date string such as "2025-06-05" (Hive migrated).
-          // The two encodings are disjoint: DATE()->toDays() uses Presto cast
-          // semantics, which reject a bare integer, while a date string always
-          // contains '-' separators that fail integer parsing. So an all-digit
-          // value is unambiguously days-since-epoch, and anything else is
-          // parsed as a date string.
-          const int32_t days = [&] {
-            if (auto parsed = folly::tryTo<int32_t>(value)) {
-              return parsed.value();
-            }
-            return DATE()->toDays(value);
-          }();
-          return std::make_unique<cudf::timestamp_scalar<cudf::timestamp_D>>(
-              days, true, stream_, mr);
-        }
-        default:
-          VELOX_UNREACHABLE();
-      }
-    } catch (const std::exception& e) {
-      VELOX_FAIL(
-          "Bad partition value '{}' for column '{}' (type {}): {}",
-          value,
-          col.name,
-          col.veloxType->toString(),
-          e.what());
-    }
-  };
-
-  // Merge data columns and injected constant columns in output order.
+  // Interleave file columns and injected constants at their outputIndex.
   const auto totalColumns = columns.size() + injectedColumns_.size();
   std::vector<std::unique_ptr<cudf::column>> output;
   output.reserve(totalColumns);
@@ -634,31 +717,23 @@ std::unique_ptr<cudf::table> CudfIcebergSplitReader::injectMissingColumns(
   for (size_t outIdx = 0; outIdx < totalColumns; ++outIdx) {
     if (injectedColIter != injectedColumns_.end() &&
         injectedColIter->outputIndex == outIdx) {
-      const auto& col = *injectedColIter;
-      auto cudfType = cudf_velox::veloxToCudfDataType(col.veloxType);
-
-      std::unique_ptr<cudf::scalar> scalar;
-      if (col.partitionValue.has_value()) {
-        scalar = makePartitionScalar(col.partitionValue.value(), cudfType, col);
-      } else {
-        scalar = cudf::make_default_constructed_scalar(cudfType, stream_, mr);
-        scalar->set_valid_async(false, stream_);
-      }
+      auto scalar = makeInjectedScalar(*injectedColIter++);
       output.push_back(
           cudf::make_column_from_scalar(*scalar, numRows, stream_, mr));
-      injectedColIter++;
     } else {
       VELOX_CHECK(
           dataColIter != columns.end(),
           "Data column index out of range during column injection");
-      output.push_back(std::move(*dataColIter));
-      dataColIter++;
+      output.push_back(std::move(*dataColIter++));
     }
   }
 
   VELOX_CHECK(
       dataColIter == columns.end(),
       "Not all data columns were consumed during column injection");
+  VELOX_CHECK(
+      injectedColIter == injectedColumns_.end(),
+      "Not all injected columns were consumed during column injection");
 
   return std::make_unique<cudf::table>(std::move(output));
 }

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.h
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.h
@@ -26,6 +26,10 @@
 #include "velox/connectors/hive/iceberg/PositionalDeleteFileReader.h"
 
 #include <list>
+#include <optional>
+#include <string>
+#include <unordered_set>
+#include <vector>
 
 namespace facebook::velox::cudf_velox::connector::hive::iceberg {
 
@@ -66,74 +70,94 @@ class CudfIcebergSplitReader : public CudfSplitReader {
   void prepareSplit(dwio::common::RuntimeStatistics& runtimeStats) override;
 
  protected:
-  // Override to create the chunked parquet reader.
-  void createCudfReader(rmm::device_async_resource_ref output_mr) override;
+  // Override to also clear delete readers and column injection
+  void resetSplit() override;
+
+  // Override to return the subfield filter when not deferred.
+  cudf::ast::expression const* subfieldFilter() override;
+
+  // Override to determine the memory resource to construct cuDF reader.
+  rmm::device_async_resource_ref determineCudfMemoryResource() override;
 
   // Override to apply Iceberg deletes after reading a cudf table chunk.
-  std::optional<std::unique_ptr<cudf::table>> readNextChunk(
-      rmm::device_async_resource_ref output_mr) override;
+  std::optional<std::unique_ptr<cudf::table>> readNextChunk() override;
 
  private:
-  // Determine the memory resource to construct the `chunked_parquet_reader`
-  // and when calling `readNextChunk` for the hybrid scan reader.
-  rmm::device_async_resource_ref determineCudfMemoryResource();
-
-  // Setup delete file readers for positional deletes, equality deletes, and
-  // deletion vectors.
-  // @param runtimeStats Reference to the DataSource's runtime statistics,
-  // passed to delete file readers for stats accumulation.
+  // Setup delete file readers for positional and equality deletes,
+  // and deletion vectors.
+  // @param runtimeStats DataSource's runtime statistics, passed to delete
+  // file readers for accumulation.
   void setupDeleteFileReaders(dwio::common::RuntimeStatistics& runtimeStats);
 
-  // Apply deletion vector (V3) to the input cudf table.
-  void applyDeletionVector(cudf::table_view input);
+  // Apply deletion vector (V3).
+  void applyDeletionVector(std::size_t numRows);
 
-  // Apply positional deletes (V2) to the input cudf table.
-  void applyPositionalDeletes(cudf::table_view input);
+  // Apply positional deletes (V2).
+  void applyPositionalDeletes(std::size_t numRows);
 
-  // Apply equality deletes (V2) to the input cudf table.
+  // Apply equality deletes (V2).
   void applyEqualityDeletes(cudf::table_view input);
 
   // Setup column projection to include any equality delete key columns
   // that are not already in the output projection.
-  void setupColumnProjection();
+  void setupEqualityColumnKeys();
+
+  // Read metadata and cache `fileRowCount_` and `fileColumnNames_`
+  void cacheSchemaFromMetadata();
 
   // Adapts the data file schema to match the table schema expected by the
-  // query.
-  //
-  // This method reconciles differences between the physical data file schema
-  // and the logical table schema, handling various scenarios where columns may
-  // be missing, added, or need special treatment.
-  //
-  // Classifies each output column into one of:
+  // query. Classifies each output and filter-only column into one of:
   //
   // 1. Info columns:
-  //    Column is a synthesized info column (e.g., $file_size) from the
-  //    split metadata. Recorded for post-read injection as a constant.
+  //    Synthesized from split metadata (e.g. $file_size). Recorded for
+  //    post-read injection as a constant.
   //
-  // 2. Columns present in File:
-  //    Column exists in the parquet file and will be read normally.
-  //    Type coercion is handled by the cudf parquet reader options.
+  // 2. Partition columns (Hive-migrated tables):
+  //    Value comes from the split's `partitionKeys`, not the data file.
+  //    Recorded for post-read injection as a constant.
   //
-  // 3. Columns missing from File:
-  //    a) Partition columns (Hive-migrated tables):
-  //       Column is a partition key in the Iceberg split. In Hive-written
-  //       Iceberg tables, partition column values are stored in partition
-  //       metadata, not in the data file itself. Recorded for post-read
-  //       injection as a constant.
-  //    b) Schema evolution (newly added columns):
-  //       Column was added to the table schema after this data file was
-  //       written. Recorded for post-read injection as a typed NULL column.
+  // 3. Columns missing from the file (schema evolution):
+  //    Newly added columns absent from `fileColumnNames_`. Recorded for
+  //    post-read injection as a typed NULL.
   //
-  // Columns are recorded in injectedColumns_ and removed from readColumnNames_
-  // so they are injected after reading using `injectMissingColumns()`.
+  // 4. Columns present in the file:
+  //    Left in `readColumnNames_` for the parquet reader.
+  //
+  // Injected names (1-3) are removed from `readColumnNames_`. `outputIndex` is
+  // the column's position in the pre-strip `readColumnNames_` layout (output,
+  // then filter-only), which `buildOutputTable` restores for remaining /
+  // deferred subfield filters.
   void adaptColumns();
 
-  // Inject partition columns and schema-evolution NULL columns into the
-  // cudf table after reading. Returns a new table with all output columns
-  // in the correct order.
-  std::unique_ptr<cudf::table> injectMissingColumns(
+  // Assemble the final output table.
+  //
+  // Interleaves info/partition/schema-evolution constants at their
+  // `outputIndex` among the file columns. Uses `rowCountOverride` when every
+  // projected column is injected (no file columns to size the constants).
+  // @param table Input table
+  // @param mr Memory resource to allocate injected columns
+  // @param rowCountOverride Surviving row count when the input has no physical
+  // columns (injected-only). `nullopt` means use `table->num_rows()`.
+  std::unique_ptr<cudf::table> buildOutputTable(
       std::unique_ptr<cudf::table>&& table,
-      rmm::device_async_resource_ref mr);
+      rmm::device_async_resource_ref mr,
+      std::optional<cudf::size_type> rowCountOverride);
+
+  // Describes a column that must be injected after reading because it is
+  // not present in the parquet file (partition, info, or schema evolution).
+  struct InjectedColumn {
+    // Position in the assembled table / pre-strip `readColumnNames_` layout.
+    size_t outputIndex;
+    std::string name;
+    std::optional<std::string>
+        partitionValue; // nullopt = NULL (schema evolution)
+    TypePtr veloxType;
+  };
+
+  // Builds a cudf scalar for an injected column from its optional string value;
+  // a `nullopt` value yields a typed NULL.
+  std::unique_ptr<cudf::scalar> makeInjectedScalar(
+      const InjectedColumn& col) const;
 
   std::shared_ptr<const velox_iceberg::HiveIcebergSplit> icebergSplit_;
   std::shared_ptr<const velox_hive::HiveConfig> hiveConfig_;
@@ -154,27 +178,30 @@ class CudfIcebergSplitReader : public CudfSplitReader {
   // are not part of the output projection.
   std::vector<std::string> extraEqualityColumns_;
 
-  // Describes a column that must be injected after reading because it is
-  // not present in the parquet file (partition column or schema evolution).
-  struct InjectedColumn {
-    size_t outputIndex; // position in the final output schema
-    std::string name;
-    std::optional<std::string>
-        partitionValue; // nullopt = NULL (schema evolution)
-    TypePtr veloxType;
-  };
-
-  // Columns to inject after reading. Populated by adaptColumns().
+  // Columns to inject after reading.
   std::vector<InjectedColumn> injectedColumns_;
+
+  // Whether every projected column is injected
+  bool noColumnsToRead_{false};
+  bool syntheticTableProduced_{false};
+
+  // Whether the subfield filter is deferred to post table read
+  bool deferSubfieldFilter_{false};
+
+  // Top-level column names and total row count from the file metadata
+  std::unordered_set<std::string> fileColumnNames_;
+  std::size_t fileRowCount_{0};
 
   // Tracks the absolute row offset within the data file. Each chunk advances
   // this by the number of rows read (before deletes).
   uint64_t baseReadOffset_{0};
 
+  // Bitmaps for positional deletes
   BufferPtr deleteBitmap_{nullptr};
   std::shared_ptr<rmm::device_buffer> deviceBitmap_;
+
+  // Deletion mask column updated by each deletion mechanism
   std::unique_ptr<cudf::column> deleteMask_;
-  // Current mutable view into the deleteMask_ column.
   cudf::mutable_column_view deleteMaskView_;
 };
 

--- a/velox/experimental/cudf/tests/iceberg/CudfIcebergGapTests.cpp
+++ b/velox/experimental/cudf/tests/iceberg/CudfIcebergGapTests.cpp
@@ -18,6 +18,7 @@
 #include "velox/experimental/cudf/tests/iceberg/CudfDeletionVectorTestUtils.h"
 #include "velox/experimental/cudf/tests/iceberg/CudfIcebergTestBase.h"
 
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/connectors/hive/iceberg/IcebergMetadataColumns.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
@@ -345,6 +346,51 @@ TEST_F(CudfIcebergGapTests, hivePartitionWithEqualityDelete) {
   });
 
   assertEqualResults({expected}, {result});
+}
+
+TEST_F(CudfIcebergGapTests, equalityDeleteOnPartitionColumnNotSupported) {
+  auto tableType = ROW({"region", "c0"}, {VARCHAR(), BIGINT()});
+
+  auto baseData = makeRowVector({
+      makeFlatVector<int64_t>({1, 2, 3}),
+  });
+  auto dataFile = TempFilePath::create();
+  writeToFile(dataFile->getPath(), baseData);
+
+  auto eqDel = makeRowVector({makeFlatVector<std::string>({"APAC"})});
+  auto eqDelFile = TempFilePath::create();
+  writeDeleteFile(DeleteFileFormat::PARQUET, eqDelFile->getPath(), {eqDel});
+
+  IcebergDeleteFile eqDelete(
+      FileContent::kEqualityDeletes,
+      eqDelFile->getPath(),
+      dwio::common::FileFormat::PARQUET,
+      1,
+      getFileSize(eqDelFile->getPath()),
+      /*equalityFieldIds=*/{1});
+
+  std::unordered_map<std::string, std::optional<std::string>> partitionKeys = {
+      {"region", "APAC"},
+  };
+
+  auto splits =
+      makeIcebergSplits(dataFile->getPath(), {eqDelete}, partitionKeys);
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kCudfIcebergConnectorId)
+                  .outputType(tableType)
+                  .dataColumns(tableType)
+                  .endTableScan()
+                  .planNode();
+
+  const auto runQuery = [&]() {
+    return AssertQueryBuilder(plan).splits(splits).copyResults(pool());
+  };
+  VELOX_ASSERT_THROW(
+      runQuery(),
+      "Equality deletes on partition columns or columns missing from the data "
+      "file are not yet supported: region");
 }
 
 // Schema evolution: file 1 has [c0, c1], file 2 has [c0, c1, c2].

--- a/velox/experimental/cudf/tests/iceberg/CudfIcebergReadTest.cpp
+++ b/velox/experimental/cudf/tests/iceberg/CudfIcebergReadTest.cpp
@@ -22,6 +22,7 @@
 
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/FileSystems.h"
+#include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/connectors/hive/iceberg/IcebergDeleteFile.h"
 #include "velox/connectors/hive/iceberg/IcebergMetadataColumns.h"
@@ -29,6 +30,8 @@
 #include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/type/Timestamp.h"
+#include "velox/type/TimestampConversion.h"
 
 #include <folly/Random.h>
 #include <folly/String.h>
@@ -469,27 +472,6 @@ TEST_F(CudfIcebergReadTest, largerFile) {
   assertQuery(plan, splits, "SELECT * FROM tmp", 0);
 }
 
-/// Read with an empty split (no delete files).
-TEST_F(CudfIcebergReadTest, noDeleteFiles) {
-  auto rowType = ROW({"c0"}, {BIGINT()});
-  auto data = makeRowVector({makeFlatVector<int64_t>({100, 200, 300})});
-
-  auto filePath = TempFilePath::create();
-  writeToFile(filePath->getPath(), data);
-
-  auto splits = makeIcebergSplits(filePath->getPath());
-
-  auto plan = PlanBuilder()
-                  .startTableScan()
-                  .connectorId(kCudfIcebergConnectorId)
-                  .outputType(rowType)
-                  .endTableScan()
-                  .planNode();
-
-  auto expected = makeRowVector({makeFlatVector<int64_t>({100, 200, 300})});
-  AssertQueryBuilder(plan).splits(splits).assertResults({expected});
-}
-
 /// Read with multiple data files (multiple splits).
 TEST_F(CudfIcebergReadTest, multipleSplits) {
   auto rowType = ROW({"c0"}, {BIGINT()});
@@ -520,6 +502,731 @@ TEST_F(CudfIcebergReadTest, multipleSplits) {
                   .planNode();
 
   assertQuery(plan, allSplits, "SELECT * FROM tmp", 0);
+}
+
+/// All  missing (schema evolution) columns
+TEST_F(CudfIcebergReadTest, allSchemaEvolutionColumns) {
+  auto dataVector = makeRowVector(
+      {"old_col"},
+      {
+          makeFlatVector<int64_t>({100, 200, 300}),
+      });
+  auto dataFilePath = TempFilePath::create();
+  writeToFile(dataFilePath->getPath(), dataVector);
+
+  auto newRowType = ROW({"new_col"}, {BIGINT()});
+  auto expected = makeRowVector(
+      {"new_col"},
+      {
+          makeNullConstant(TypeKind::BIGINT, 3),
+      });
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kCudfIcebergConnectorId)
+                  .outputType(newRowType)
+                  .dataColumns(newRowType)
+                  .endTableScan()
+                  .planNode();
+
+  AssertQueryBuilder(plan)
+      .splits(makeIcebergSplits(dataFilePath->getPath()))
+      .assertResults({expected});
+
+  // Filtering a schema-evolution column that is NULL for every row in an old
+  // file must return an empty result (Iceberg NULL semantics).
+  auto filteredPlan = PlanBuilder()
+                          .startTableScan()
+                          .connectorId(kCudfIcebergConnectorId)
+                          .outputType(newRowType)
+                          .dataColumns(newRowType)
+                          .subfieldFilter("new_col = 1")
+                          .endTableScan()
+                          .planNode();
+
+  auto filteredEmptyExpected = makeRowVector(
+      {"new_col"},
+      {
+          makeFlatVector<int64_t>(std::vector<int64_t>{}),
+      });
+
+  AssertQueryBuilder(filteredPlan)
+      .splits(makeIcebergSplits(dataFilePath->getPath()))
+      .assertResults({filteredEmptyExpected});
+
+  // Filter-only evolution col (not in output) with a projected file column.
+  auto mixedType = ROW({"old_col", "new_col"}, {BIGINT(), BIGINT()});
+  auto fileOnlyOutput = ROW({"old_col"}, {BIGINT()});
+  auto filterOnlyPlan = PlanBuilder()
+                            .startTableScan()
+                            .connectorId(kCudfIcebergConnectorId)
+                            .outputType(fileOnlyOutput)
+                            .dataColumns(mixedType)
+                            .subfieldFilter("new_col = 1")
+                            .endTableScan()
+                            .planNode();
+
+  AssertQueryBuilder(filterOnlyPlan)
+      .splits(makeIcebergSplits(dataFilePath->getPath()))
+      .assertResults({makeRowVector(
+          {"old_col"}, {makeFlatVector<int64_t>(std::vector<int64_t>{})})});
+}
+
+/// Column alias: output column `a` -> physical file column `c0`
+TEST_F(CudfIcebergReadTest, columnAliasUsesPhysicalFileName) {
+  auto data = makeRowVector(
+      {"c0"},
+      {
+          makeFlatVector<int64_t>({10, 20, 30}),
+      });
+
+  auto dataFile = TempFilePath::create();
+  writeToFile(dataFile->getPath(), data);
+
+  auto fileType = ROW({"c0"}, {BIGINT()});
+  auto outputType = ROW({"a"}, {BIGINT()});
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kCudfIcebergConnectorId)
+                  .outputType(outputType)
+                  .dataColumns(fileType)
+                  .columnAliases({{"a", "c0"}})
+                  .endTableScan()
+                  .planNode();
+
+  auto expected = makeRowVector(
+      {"a"},
+      {
+          makeFlatVector<int64_t>({10, 20, 30}),
+      });
+
+  AssertQueryBuilder(plan)
+      .splits(makeIcebergSplits(dataFile->getPath()))
+      .assertResults({expected});
+}
+
+/// A nonempty data file in a NULL partition must return one NULL partition
+/// value per row
+TEST_F(CudfIcebergReadTest, nullPartitionColumn) {
+  auto data = makeRowVector(
+      {"c0"},
+      {
+          makeFlatVector<int64_t>({1, 2, 3}),
+      });
+
+  auto dataFile = TempFilePath::create();
+  writeToFile(dataFile->getPath(), data);
+
+  auto tableType = ROW({"c0", "country"}, {BIGINT(), VARCHAR()});
+
+  facebook::velox::connector::ColumnHandleMap assignments;
+  assignments["c0"] = std::make_shared<HiveColumnHandle>(
+      "c0",
+      HiveColumnHandle::ColumnType::kRegular,
+      BIGINT(),
+      BIGINT(),
+      std::vector<common::Subfield>{});
+  assignments["country"] = std::make_shared<HiveColumnHandle>(
+      "country",
+      HiveColumnHandle::ColumnType::kPartitionKey,
+      VARCHAR(),
+      VARCHAR(),
+      std::vector<common::Subfield>{});
+
+  std::unordered_map<std::string, std::optional<std::string>> partitionKeys = {
+      {"country", std::nullopt}};
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kCudfIcebergConnectorId)
+                  .outputType(tableType)
+                  .dataColumns(tableType)
+                  .assignments(assignments)
+                  .endTableScan()
+                  .planNode();
+
+  auto expected = makeRowVector(
+      {"c0", "country"},
+      {
+          data->childAt(0),
+          makeNullConstant(TypeKind::VARCHAR, 3),
+      });
+
+  AssertQueryBuilder(plan)
+      .splits(makeIcebergSplits(dataFile->getPath(), {}, partitionKeys))
+      .assertResults({expected});
+}
+
+/// A projection containing only injected columns. e.g., partition column, leads
+/// to no columns being read from the data file and the output is synthesized
+/// from the injected columns only
+TEST_F(CudfIcebergReadTest, partitionOnlyProjection) {
+  auto data = makeRowVector(
+      {"c0"},
+      {
+          makeFlatVector<int64_t>({1, 2, 3}),
+      });
+
+  auto dataFile = TempFilePath::create();
+  writeToFile(dataFile->getPath(), data);
+
+  auto tableType = ROW({"c0", "country"}, {BIGINT(), VARCHAR()});
+  auto outputType = ROW({"country"}, {VARCHAR()});
+
+  facebook::velox::connector::ColumnHandleMap assignments;
+  assignments["country"] = std::make_shared<HiveColumnHandle>(
+      "country",
+      HiveColumnHandle::ColumnType::kPartitionKey,
+      VARCHAR(),
+      VARCHAR(),
+      std::vector<common::Subfield>{});
+
+  std::unordered_map<std::string, std::optional<std::string>> partitionKeys = {
+      {"country", "US"}};
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kCudfIcebergConnectorId)
+                  .outputType(outputType)
+                  .dataColumns(tableType)
+                  .assignments(assignments)
+                  .endTableScan()
+                  .planNode();
+
+  auto expected = makeRowVector(
+      {"country"},
+      {
+          makeFlatVector<std::string>({"US", "US", "US"}),
+      });
+
+  AssertQueryBuilder(plan)
+      .splits(makeIcebergSplits(dataFile->getPath(), {}, partitionKeys))
+      .assertResults({expected});
+
+  // Filter `country = 'CA'` excludes the partition value 'US', so the output is
+  // an empty table. Reader is bypassed due to no physical columns to read.
+  auto filteredNoMatchPlan = PlanBuilder()
+                                 .startTableScan()
+                                 .connectorId(kCudfIcebergConnectorId)
+                                 .outputType(outputType)
+                                 .dataColumns(tableType)
+                                 .assignments(assignments)
+                                 .subfieldFilter("country = 'CA'")
+                                 .endTableScan()
+                                 .planNode();
+
+  auto emptyExpected =
+      makeRowVector({"country"}, {makeFlatVector<std::string>({})});
+
+  AssertQueryBuilder(filteredNoMatchPlan)
+      .splits(makeIcebergSplits(dataFile->getPath(), {}, partitionKeys))
+      .assertResults({emptyExpected});
+
+  // A matching subfield filter keeps all rows.
+  auto filteredMatchPlan = PlanBuilder()
+                               .startTableScan()
+                               .connectorId(kCudfIcebergConnectorId)
+                               .outputType(outputType)
+                               .dataColumns(tableType)
+                               .assignments(assignments)
+                               .subfieldFilter("country = 'US'")
+                               .endTableScan()
+                               .planNode();
+
+  AssertQueryBuilder(filteredMatchPlan)
+      .splits(makeIcebergSplits(dataFile->getPath(), {}, partitionKeys))
+      .assertResults({expected});
+
+  // Mixed physical + injected projection with a non-matching filter on the
+  // injected partition column must return no rows. The filter cannot be pushed
+  // into the parquet reader because `country` is not a file column.
+  auto mixedAssignments = assignments;
+  mixedAssignments["c0"] = std::make_shared<HiveColumnHandle>(
+      "c0",
+      HiveColumnHandle::ColumnType::kRegular,
+      BIGINT(),
+      BIGINT(),
+      std::vector<common::Subfield>{});
+
+  auto mixedPlan = PlanBuilder()
+                       .startTableScan()
+                       .connectorId(kCudfIcebergConnectorId)
+                       .outputType(tableType)
+                       .dataColumns(tableType)
+                       .assignments(mixedAssignments)
+                       .subfieldFilter("country = 'CA'")
+                       .endTableScan()
+                       .planNode();
+
+  auto mixedEmptyExpected = makeRowVector(
+      {"c0", "country"},
+      {
+          makeFlatVector<int64_t>(std::vector<int64_t>{}),
+          makeFlatVector<std::string>(std::vector<std::string>{}),
+      });
+
+  AssertQueryBuilder(mixedPlan)
+      .splits(makeIcebergSplits(dataFile->getPath(), {}, partitionKeys))
+      .assertResults({mixedEmptyExpected});
+
+  // Matching filter on the injected column with a physical column present.
+  auto mixedMatchPlan = PlanBuilder()
+                            .startTableScan()
+                            .connectorId(kCudfIcebergConnectorId)
+                            .outputType(tableType)
+                            .dataColumns(tableType)
+                            .assignments(mixedAssignments)
+                            .subfieldFilter("country = 'US'")
+                            .endTableScan()
+                            .planNode();
+
+  auto mixedMatchExpected = makeRowVector(
+      {"c0", "country"},
+      {
+          data->childAt(0),
+          makeFlatVector<std::string>({"US", "US", "US"}),
+      });
+
+  AssertQueryBuilder(mixedMatchPlan)
+      .splits(makeIcebergSplits(dataFile->getPath(), {}, partitionKeys))
+      .assertResults({mixedMatchExpected});
+
+  // Filter-only partition (not in output): inject, filter, then strip.
+  auto fileOnlyAssignments = facebook::velox::connector::ColumnHandleMap{};
+  fileOnlyAssignments["c0"] = mixedAssignments["c0"];
+  auto fileOnlyOutput = ROW({"c0"}, {BIGINT()});
+
+  auto filterOnlyMatchPlan = PlanBuilder()
+                                 .startTableScan()
+                                 .connectorId(kCudfIcebergConnectorId)
+                                 .outputType(fileOnlyOutput)
+                                 .dataColumns(tableType)
+                                 .assignments(fileOnlyAssignments)
+                                 .subfieldFilter("country = 'US'")
+                                 .endTableScan()
+                                 .planNode();
+
+  AssertQueryBuilder(filterOnlyMatchPlan)
+      .splits(makeIcebergSplits(dataFile->getPath(), {}, partitionKeys))
+      .assertResults({makeRowVector({"c0"}, {data->childAt(0)})});
+
+  auto filterOnlyNoMatchPlan = PlanBuilder()
+                                   .startTableScan()
+                                   .connectorId(kCudfIcebergConnectorId)
+                                   .outputType(fileOnlyOutput)
+                                   .dataColumns(tableType)
+                                   .assignments(fileOnlyAssignments)
+                                   .subfieldFilter("country = 'CA'")
+                                   .endTableScan()
+                                   .planNode();
+
+  AssertQueryBuilder(filterOnlyNoMatchPlan)
+      .splits(makeIcebergSplits(dataFile->getPath(), {}, partitionKeys))
+      .assertResults({makeRowVector(
+          {"c0"}, {makeFlatVector<int64_t>(std::vector<int64_t>{})})});
+
+  // Experimental hybrid reader must also support injected-only projections.
+  AssertQueryBuilder(plan)
+      .connectorSessionProperty(
+          kCudfIcebergConnectorId,
+          cudf_velox::connector::hive::CudfHiveConfig::
+              kUseExperimentalCudfReaderSession,
+          "true")
+      .splits(makeIcebergSplits(dataFile->getPath(), {}, partitionKeys))
+      .assertResults({expected});
+}
+
+/// A remaining filter on an unprojected column (`c1`) adds `c1` to the
+/// projection for post-scan filtering and removal
+TEST_F(CudfIcebergReadTest, unprojectedRemainingFilterColumn) {
+  auto data = makeRowVector(
+      {"c0", "c1"},
+      {
+          makeFlatVector<int64_t>({10, 20, 30, 40}),
+          makeFlatVector<int64_t>({1, 2, 3, 4}),
+      });
+
+  auto dataFile = TempFilePath::create();
+  writeToFile(dataFile->getPath(), data);
+
+  auto dataType = ROW({"c0", "c1"}, {BIGINT(), BIGINT()});
+  auto outputType = ROW({"c0"}, {BIGINT()});
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kCudfIcebergConnectorId)
+                  .outputType(outputType)
+                  .dataColumns(dataType)
+                  .remainingFilter("c1 % 2 = 0")
+                  .endTableScan()
+                  .planNode();
+
+  auto expected = makeRowVector(
+      {"c0"},
+      {
+          makeFlatVector<int64_t>({20, 40}),
+      });
+
+  AssertQueryBuilder(plan)
+      .splits(makeIcebergSplits(dataFile->getPath()))
+      .assertResults({expected});
+}
+
+/// Remaining filter referencing an injected filter-only partition column and an
+/// unprojected file column.
+TEST_F(CudfIcebergReadTest, remainingFilterOnInjectedColumn) {
+  auto data = makeRowVector(
+      {"c0", "c1"},
+      {
+          makeFlatVector<int64_t>({10, 20, 30, 40}),
+          makeFlatVector<int64_t>({1, 2, 3, 4}),
+      });
+
+  auto dataFile = TempFilePath::create();
+  writeToFile(dataFile->getPath(), data);
+
+  auto tableType =
+      ROW({"c0", "c1", "country"}, {BIGINT(), BIGINT(), VARCHAR()});
+  auto outputType = ROW({"c0"}, {BIGINT()});
+
+  facebook::velox::connector::ColumnHandleMap assignments;
+  assignments["c0"] = std::make_shared<HiveColumnHandle>(
+      "c0",
+      HiveColumnHandle::ColumnType::kRegular,
+      BIGINT(),
+      BIGINT(),
+      std::vector<common::Subfield>{});
+  assignments["c1"] = std::make_shared<HiveColumnHandle>(
+      "c1",
+      HiveColumnHandle::ColumnType::kRegular,
+      BIGINT(),
+      BIGINT(),
+      std::vector<common::Subfield>{});
+  assignments["country"] = std::make_shared<HiveColumnHandle>(
+      "country",
+      HiveColumnHandle::ColumnType::kPartitionKey,
+      VARCHAR(),
+      VARCHAR(),
+      std::vector<common::Subfield>{});
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kCudfIcebergConnectorId)
+                  .outputType(outputType)
+                  .dataColumns(tableType)
+                  .assignments(assignments)
+                  .remainingFilter("country = 'CA' OR c1 % 2 = 0")
+                  .endTableScan()
+                  .planNode();
+
+  // Partition 'US': `country = 'CA'` is false, so the filter reduces to
+  // `c1 % 2 = 0`, keeping c1={2,4} -> c0={20,40}.
+  std::unordered_map<std::string, std::optional<std::string>> usPartition = {
+      {"country", "US"}};
+  AssertQueryBuilder(plan)
+      .splits(makeIcebergSplits(dataFile->getPath(), {}, usPartition))
+      .assertResults(
+          {makeRowVector({"c0"}, {makeFlatVector<int64_t>({20, 40})})});
+
+  // Partition 'CA': `country = 'CA'` is true for every row, so all rows pass.
+  std::unordered_map<std::string, std::optional<std::string>> caPartition = {
+      {"country", "CA"}};
+  AssertQueryBuilder(plan)
+      .splits(makeIcebergSplits(dataFile->getPath(), {}, caPartition))
+      .assertResults(
+          {makeRowVector({"c0"}, {makeFlatVector<int64_t>({10, 20, 30, 40})})});
+}
+
+/// Injected-only projection with positional deletes: surviving row count must
+/// reflect deletes (via rowCountOverride), then deferred partition filter.
+TEST_F(CudfIcebergReadTest, partitionOnlyProjectionWithPositionalDeletes) {
+  auto data = makeRowVector(
+      {"c0"},
+      {
+          makeFlatVector<int64_t>({1, 2, 3, 4}),
+      });
+  auto dataFile = TempFilePath::create();
+  writeToFile(dataFile->getPath(), data);
+
+  auto pathColumn = IcebergMetadataColumn::icebergDeleteFilePathColumn();
+  auto posColumn = IcebergMetadataColumn::icebergDeletePosColumn();
+  auto deleteFilePath = TempFilePath::create();
+  writeDeleteFile(
+      DeleteFileFormat::DWRF,
+      deleteFilePath->getPath(),
+      {makeRowVector(
+          {pathColumn->name, posColumn->name},
+          {
+              makeFlatVector<std::string>(
+                  2, [&](vector_size_t) { return dataFile->getPath(); }),
+              makeFlatVector<int64_t>({0, 2}),
+          })});
+
+  IcebergDeleteFile deleteFile(
+      FileContent::kPositionalDeletes,
+      deleteFilePath->getPath(),
+      dwio::common::FileFormat::DWRF,
+      2,
+      getFileSize(deleteFilePath->getPath()));
+
+  auto tableType = ROW({"c0", "country"}, {BIGINT(), VARCHAR()});
+  auto outputType = ROW({"country"}, {VARCHAR()});
+
+  facebook::velox::connector::ColumnHandleMap assignments;
+  assignments["country"] = std::make_shared<HiveColumnHandle>(
+      "country",
+      HiveColumnHandle::ColumnType::kPartitionKey,
+      VARCHAR(),
+      VARCHAR(),
+      std::vector<common::Subfield>{});
+
+  std::unordered_map<std::string, std::optional<std::string>> partitionKeys = {
+      {"country", "US"}};
+
+  // Delete rows 0 and 2 → 2 surviving "US" rows.
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kCudfIcebergConnectorId)
+                  .outputType(outputType)
+                  .dataColumns(tableType)
+                  .assignments(assignments)
+                  .subfieldFilter("country = 'US'")
+                  .endTableScan()
+                  .planNode();
+
+  auto expected = makeRowVector(
+      {"country"},
+      {
+          makeFlatVector<std::string>({"US", "US"}),
+      });
+
+  AssertQueryBuilder(plan)
+      .splits(
+          makeIcebergSplits(dataFile->getPath(), {deleteFile}, partitionKeys))
+      .assertResults({expected});
+}
+
+// A timezone-less TIMESTAMP partition value is
+// interpreted in the default timezone and converted to UTC when the Hive config
+// is true.
+TEST_F(CudfIcebergReadTest, timestampPartitionHonorsLocalTimeSetting) {
+  auto data = makeRowVector(
+      {"c0"},
+      {
+          makeFlatVector<int64_t>({1, 2, 3}),
+      });
+
+  auto dataFile = TempFilePath::create();
+  writeToFile(dataFile->getPath(), data);
+
+  auto tableType = ROW({"c0", "pkey"}, {BIGINT(), TIMESTAMP()});
+
+  facebook::velox::connector::ColumnHandleMap assignments;
+  assignments["c0"] = std::make_shared<HiveColumnHandle>(
+      "c0",
+      HiveColumnHandle::ColumnType::kRegular,
+      BIGINT(),
+      BIGINT(),
+      std::vector<common::Subfield>{});
+  assignments["pkey"] = std::make_shared<HiveColumnHandle>(
+      "pkey",
+      HiveColumnHandle::ColumnType::kPartitionKey,
+      TIMESTAMP(),
+      TIMESTAMP(),
+      std::vector<common::Subfield>{});
+
+  const std::string partitionValue = "2023-10-14 07:00:00";
+  std::unordered_map<std::string, std::optional<std::string>> partitionKeys = {
+      {"pkey", partitionValue}};
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kCudfIcebergConnectorId)
+                  .outputType(tableType)
+                  .dataColumns(tableType)
+                  .assignments(assignments)
+                  .endTableScan()
+                  .planNode();
+
+  auto utcTimestamp =
+      util::fromTimestampString(
+          StringView(partitionValue), util::TimestampParseMode::kPrestoCast)
+          .value();
+
+  auto localTimestamp = utcTimestamp;
+  localTimestamp.toGMT(Timestamp::defaultTimezone());
+
+  auto assertValue = [&](bool readAsLocalTime, Timestamp expectedTimestamp) {
+    auto expected = makeRowVector(
+        {"c0", "pkey"},
+        {
+            data->childAt(0),
+            makeFlatVector<Timestamp>(
+                {expectedTimestamp, expectedTimestamp, expectedTimestamp}),
+        });
+
+    AssertQueryBuilder(plan)
+        .connectorSessionProperty(
+            kCudfIcebergConnectorId,
+            facebook::velox::connector::hive::HiveConfig::
+                kReadTimestampPartitionValueAsLocalTimeSession,
+            readAsLocalTime ? "true" : "false")
+        .splits(makeIcebergSplits(dataFile->getPath(), {}, partitionKeys))
+        .assertResults({expected});
+  };
+
+  // Interpret the partition string as already being in UTC.
+  assertValue(false, utcTimestamp);
+
+  // Interpret the partition string as local time and convert it to UTC.
+  assertValue(true, localTimestamp);
+}
+
+/// A remaining filter is allowed with positional deletes
+TEST_F(CudfIcebergReadTest, remainingFilterAndPositionalDeletes) {
+  auto data = makeRowVector(
+      {"c0", "c1"},
+      {
+          makeFlatVector<int64_t>({10, 20, 30, 40}),
+          makeFlatVector<int64_t>({1, 2, 3, 4}),
+      });
+
+  auto dataFile = TempFilePath::create();
+  writeToFile(dataFile->getPath(), data);
+
+  // Positional delete file removing row 1 (c0=20, c1=2).
+  auto deleteFilePath = TempFilePath::create();
+  auto pathColumn = IcebergMetadataColumn::icebergDeleteFilePathColumn();
+  auto posColumn = IcebergMetadataColumn::icebergDeletePosColumn();
+  auto deleteVector = makeRowVector(
+      {pathColumn->name, posColumn->name},
+      {
+          makeFlatVector<std::string>(
+              1, [&](vector_size_t) { return dataFile->getPath(); }),
+          makeFlatVector<int64_t>({1}),
+      });
+  writeDeleteFile(
+      DeleteFileFormat::DWRF, deleteFilePath->getPath(), {deleteVector});
+
+  IcebergDeleteFile deleteFile(
+      FileContent::kPositionalDeletes,
+      deleteFilePath->getPath(),
+      dwio::common::FileFormat::DWRF,
+      1,
+      getFileSize(deleteFilePath->getPath()));
+
+  auto dataType = ROW({"c0", "c1"}, {BIGINT(), BIGINT()});
+  auto outputType = ROW({"c0"}, {BIGINT()});
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kCudfIcebergConnectorId)
+                  .outputType(outputType)
+                  .dataColumns(dataType)
+                  .remainingFilter("c1 % 2 = 0")
+                  .endTableScan()
+                  .planNode();
+
+  // Row 1 (c1=2) is deleted; of the remaining c1={1,3,4}, `c1 % 2 = 0` keeps
+  // c1=4, i.e. c0=40.
+  auto expected = makeRowVector(
+      {"c0"},
+      {
+          makeFlatVector<int64_t>({40}),
+      });
+
+  AssertQueryBuilder(plan)
+      .splits(makeIcebergSplits(dataFile->getPath(), {deleteFile}))
+      .assertResults({expected});
+}
+
+// Subfield filter + positional deletes: filter is deferred until after
+// deletes so file positions stay valid.
+TEST_F(CudfIcebergReadTest, subfieldFilterAndPositionalDeletes) {
+  auto data = makeRowVector({makeFlatVector<int64_t>({10, 20, 30, 40})});
+  auto dataFile = TempFilePath::create();
+  writeToFile(dataFile->getPath(), data);
+
+  // Positional delete file removing row 0 (value 10).
+  auto deleteFilePath = TempFilePath::create();
+  auto pathColumn = IcebergMetadataColumn::icebergDeleteFilePathColumn();
+  auto posColumn = IcebergMetadataColumn::icebergDeletePosColumn();
+  auto deleteVector = makeRowVector(
+      {pathColumn->name, posColumn->name},
+      {
+          makeFlatVector<std::string>(
+              1, [&](vector_size_t) { return dataFile->getPath(); }),
+          makeFlatVector<int64_t>({0}),
+      });
+  writeDeleteFile(
+      DeleteFileFormat::DWRF, deleteFilePath->getPath(), {deleteVector});
+
+  IcebergDeleteFile deleteFile(
+      FileContent::kPositionalDeletes,
+      deleteFilePath->getPath(),
+      dwio::common::FileFormat::DWRF,
+      1,
+      getFileSize(deleteFilePath->getPath()));
+
+  // `c0 < 30` is a simple range filter pushed as a subfield filter. With
+  // positional deletes present it is deferred: deletes run first on full
+  // file positions, then the filter. Rows: {10,20,30,40} → delete 10 →
+  // {20,30,40} → filter → {20}.
+  auto dataType = ROW({"c0"}, {BIGINT()});
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kCudfIcebergConnectorId)
+                  .outputType(dataType)
+                  .dataColumns(dataType)
+                  .subfieldFilter("c0 < 30")
+                  .endTableScan()
+                  .planNode();
+
+  auto expected = makeRowVector({makeFlatVector<int64_t>({20})});
+
+  AssertQueryBuilder(plan)
+      .splits(makeIcebergSplits(dataFile->getPath(), {deleteFile}))
+      .assertResults({expected});
+}
+
+// A subfield filter is allowed with equality deletes
+TEST_F(CudfIcebergReadTest, subfieldFilterAndEqualityDeletes) {
+  auto data = makeRowVector({makeFlatVector<int64_t>({10, 20, 30, 40})});
+  auto dataFile = TempFilePath::create();
+  writeToFile(dataFile->getPath(), data);
+
+  // Equality delete file removing rows where c0=20.
+  auto deleteData = makeRowVector({"c0"}, {makeFlatVector<int64_t>({20})});
+  auto eqDeleteFile = TempFilePath::create();
+  writeDeleteFile(
+      DeleteFileFormat::DWRF, eqDeleteFile->getPath(), {deleteData});
+
+  IcebergDeleteFile deleteFile(
+      FileContent::kEqualityDeletes,
+      eqDeleteFile->getPath(),
+      dwio::common::FileFormat::DWRF,
+      1,
+      getFileSize(eqDeleteFile->getPath()),
+      /*equalityFieldIds=*/{1});
+
+  auto dataType = ROW({"c0"}, {BIGINT()});
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kCudfIcebergConnectorId)
+                  .outputType(dataType)
+                  .dataColumns(dataType)
+                  .subfieldFilter("c0 < 35")
+                  .endTableScan()
+                  .planNode();
+
+  // `c0 < 35` keeps {10, 20, 30}; the equality delete then removes c0=20,
+  // leaving {10, 30}.
+  auto expected = makeRowVector({makeFlatVector<int64_t>({10, 30})});
+
+  AssertQueryBuilder(plan)
+      .splits(makeIcebergSplits(dataFile->getPath(), {deleteFile}))
+      .assertResults({expected});
 }
 
 TEST_F(CudfIcebergReadTest, singleBaseFileSinglePositionalDeleteFile) {
@@ -762,6 +1469,133 @@ TEST_F(CudfIcebergReadTest, positionalDeleteSequenceNumberSkipped) {
                   .planNode();
 
   auto expected = makeRowVector({makeFlatVector<int64_t>({0, 1, 2, 3, 4})});
+  AssertQueryBuilder(plan).splits(splits).assertResults({expected});
+}
+
+// Subfield filter + positional delete skipped by sequence-number resolution:
+// no delete readers remain, so the filter can still be pushed into parquet.
+TEST_F(CudfIcebergReadTest, subfieldFilterWithSkippedPositionalDelete) {
+  auto pathColumn = IcebergMetadataColumn::icebergDeleteFilePathColumn();
+  auto posColumn = IcebergMetadataColumn::icebergDeletePosColumn();
+  auto rowType = ROW({"c0"}, {BIGINT()});
+
+  auto dataFilePath = TempFilePath::create();
+  writeToFile(
+      dataFilePath->getPath(),
+      {makeRowVector({makeFlatVector<int64_t>({0, 1, 2, 3, 4})})});
+
+  auto deleteFilePath = TempFilePath::create();
+  auto baseFilePath = dataFilePath->getPath();
+  writeDeleteFile(
+      DeleteFileFormat::DWRF,
+      deleteFilePath->getPath(),
+      {makeRowVector(
+          {pathColumn->name, posColumn->name},
+          {
+              makeFlatVector<std::string>(
+                  2, [&](vector_size_t) { return baseFilePath; }),
+              makeFlatVector<int64_t>({1, 3}),
+          })});
+
+  // Positional delete with dataSequenceNumber (5) < the data file's sequence
+  // number (10), so it is skipped by sequence-number resolution.
+  IcebergDeleteFile deleteFile(
+      FileContent::kPositionalDeletes,
+      deleteFilePath->getPath(),
+      dwio::common::FileFormat::DWRF,
+      2,
+      getFileSize(deleteFilePath->getPath()),
+      {},
+      {},
+      {},
+      /*dataSequenceNumber=*/5);
+
+  auto splits = makeIcebergSplits(
+      baseFilePath,
+      {deleteFile},
+      {},
+      1,
+      /*dataSequenceNumber=*/10);
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kCudfIcebergConnectorId)
+                  .outputType(rowType)
+                  .dataColumns(rowType)
+                  .subfieldFilter("c0 < 4")
+                  .endTableScan()
+                  .planNode();
+
+  // The delete is skipped, so `c0 < 4` simply keeps {0, 1, 2, 3}.
+  auto expected = makeRowVector({makeFlatVector<int64_t>({0, 1, 2, 3})});
+  AssertQueryBuilder(plan).splits(splits).assertResults({expected});
+}
+
+// Subfield filter + positional delete for a different data file. Filter is
+// deferred until cuDF PR #23077 merges.
+TEST_F(
+    CudfIcebergReadTest,
+    subfieldFilterWithPositionalDeleteForDifferentFile) {
+  auto pathColumn = IcebergMetadataColumn::icebergDeleteFilePathColumn();
+  auto posColumn = IcebergMetadataColumn::icebergDeletePosColumn();
+  auto rowType = ROW({"c0"}, {BIGINT()});
+
+  auto dataFilePath = TempFilePath::create();
+  writeToFile(
+      dataFilePath->getPath(),
+      {makeRowVector({makeFlatVector<int64_t>({0, 1, 2, 3, 4})})});
+
+  auto baseFilePath = dataFilePath->getPath();
+  auto otherDataFilePath = TempFilePath::create();
+
+  // The delete file's positions reference a different data file, so its
+  // file_path column statistics exclude `baseFilePath` and `testFilters` prunes
+  // the reader during construction.
+  auto deleteFilePath = TempFilePath::create();
+  writeDeleteFile(
+      DeleteFileFormat::DWRF,
+      deleteFilePath->getPath(),
+      {makeRowVector(
+          {pathColumn->name, posColumn->name},
+          {
+              makeFlatVector<std::string>(
+                  2,
+                  [&](vector_size_t) { return otherDataFilePath->getPath(); }),
+              makeFlatVector<int64_t>({1, 3}),
+          })});
+
+  // Equal sequence numbers make the positional delete applicable, ensuring it
+  // reaches file-path pruning inside `PositionalDeleteFileReader`.
+  IcebergDeleteFile deleteFile(
+      FileContent::kPositionalDeletes,
+      deleteFilePath->getPath(),
+      dwio::common::FileFormat::DWRF,
+      2,
+      getFileSize(deleteFilePath->getPath()),
+      {},
+      {},
+      {},
+      /*dataSequenceNumber=*/10);
+
+  auto splits = makeIcebergSplits(
+      baseFilePath,
+      {deleteFile},
+      {},
+      1,
+      /*dataSequenceNumber=*/10);
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kCudfIcebergConnectorId)
+                  .outputType(rowType)
+                  .dataColumns(rowType)
+                  .subfieldFilter("c0 < 4")
+                  .endTableScan()
+                  .planNode();
+
+  // The positional delete file contains no entries for this data file, so
+  // `c0 < 4` simply keeps {0, 1, 2, 3}.
+  auto expected = makeRowVector({makeFlatVector<int64_t>({0, 1, 2, 3})});
   AssertQueryBuilder(plan).splits(splits).assertResults({expected});
 }
 
@@ -1116,11 +1950,8 @@ TEST_F(CudfIcebergReadTest, schemaEvolutionAddColumns) {
   AssertQueryBuilder(plan).splits(icebergSplits).assertResults({expected});
 }
 
-// Test reading partition columns from Hive-migrated tables.
-// This tests the adaptColumns method handling partition columns that are not
-// stored in the data file but provided via partitionKeys map.
-// This scenario occurs when reading Hive-written data files where partition
-// column values are stored in partition metadata rather than in the data file.
+// Hive-migrated partition columns: values come from the partitionKeys map,
+// not the data file, and are injected by adaptColumns.
 TEST_F(CudfIcebergReadTest, partitionColumnsFromHive) {
   auto fileRowType = ROW({"c0", "c1"}, {BIGINT(), INTEGER()});
   auto tableRowType =


### PR DESCRIPTION
## Description

Redo #17776 + simplified Iceberg schema-evolution corner case handling

Eliminate an extra parquet file footer read to identify schema evolution columns. Allow deferred pushdown filters when positional deletes or missing columns, reuse existing functions for velox -> cudf type conversions and string -> scalar conversion.

## Checklist
- [x] All velox-cudf tests pass
- [x] I am familiar with the contributing guidelines and the code of conduct