### PR TITLE
feat(vector): Add DecodedVector::hasNulls() (#18054)

### DIFF
--- a/velox/vector/DecodedVector.h
+++ b/velox/vector/DecodedVector.h
@@ -209,6 +209,51 @@ class DecodedVector {
     return bits::isBitNull(nulls_, indices_[idx]);
   }
 
+  /// Returns whether any decoded row is actually null, scanning the bitmap for
+  /// a definitive answer. mayHaveNulls() is only indeterminate: it is true
+  /// whenever a null buffer is present, even if no bit in it is set.
+  ///
+  /// Side effect (so it is non-const, like nulls()): the first call that finds
+  /// no nulls normalizes this view -- drops the null buffer pointer, clears
+  /// mayHaveNulls()/hasExtraNulls(), and invalidates the nulls() cache -- so
+  /// later null checks take the no-null fast path and repeated calls are O(1).
+  /// Only this decoded view is touched, never the base vector; a view that has
+  /// nulls is left unchanged.
+  ///
+  /// Scans only when a null buffer is present: bulk for flat and combined-nulls
+  /// encodings, O(1) for constants, O(size()) for a dictionary (nulls indexed
+  /// indirectly).
+  bool hasNulls() {
+    if (!mayHaveNulls_) {
+      return false;
+    }
+    bool anyNull = false;
+    if (nulls_ != nullptr) {
+      if (isIdentityMapping_ || hasExtraNulls_) {
+        // Bitmap is indexed directly by decoded row over [0, size()).
+        anyNull = !bits::isAllSet(nulls_, 0, size_);
+      } else if (isConstantMapping_) {
+        anyNull = bits::isBitNull(nulls_, 0);
+      } else {
+        // Dictionary without extra nulls: resolve each row's base index.
+        VELOX_DCHECK(indices_);
+        for (vector_size_t i = 0; i < size_; ++i) {
+          if (bits::isBitNull(nulls_, indices_[i])) {
+            anyNull = true;
+            break;
+          }
+        }
+      }
+    }
+    if (!anyNull) {
+      nulls_ = nullptr;
+      mayHaveNulls_ = false;
+      hasExtraNulls_ = false;
+      allNulls_.reset();
+    }
+    return anyNull;
+  }
+
   /// Invokes 'func(row)' for each null top-level row in [begin, end), in
   /// increasing row order. 'func' must be invocable as 'void(vector_size_t)'.
   ///

--- a/velox/vector/tests/DecodedVectorTest.cpp
+++ b/velox/vector/tests/DecodedVectorTest.cpp
@@ -1504,6 +1504,105 @@ TEST_F(DecodedVectorTest, forEachNullNotNull) {
   verify(makeConstant<int64_t>(42, 16));
 }
 
+TEST_F(DecodedVectorTest, hasNulls) {
+  auto identity = [](auto row) { return row; };
+
+  // Flat, null buffer present but every bit set (no row null): hasNulls() is
+  // false and normalizes away the null view; values are untouched.
+  {
+    auto flat = makeFlatVector<int64_t>(64, identity);
+    flat->mutableRawNulls(); // Allocate an all-non-null (all-set) null buffer.
+    DecodedVector decoded(*flat);
+    ASSERT_TRUE(decoded.mayHaveNulls());
+    EXPECT_FALSE(decoded.hasNulls());
+    EXPECT_FALSE(decoded.mayHaveNulls()); // Side effect: cleared.
+    for (vector_size_t i = 0; i < 64; ++i) {
+      EXPECT_FALSE(decoded.isNullAt(i));
+      EXPECT_EQ(decoded.valueAt<int64_t>(i), i);
+    }
+  }
+
+  // Same, but nulls() is materialized first: hasNulls() must invalidate the
+  // cached combined bitmap so a later nulls() does not return a stale one.
+  {
+    auto flat = makeFlatVector<int64_t>(64, identity);
+    flat->mutableRawNulls();
+    DecodedVector decoded(*flat);
+    ASSERT_NE(decoded.nulls(), nullptr); // Populate the allNulls_ cache.
+    EXPECT_FALSE(decoded.hasNulls());
+    EXPECT_EQ(decoded.nulls(), nullptr);
+  }
+
+  // Flat with real nulls: hasNulls() is true and the null view is preserved.
+  {
+    auto flat = makeFlatVector<int64_t>(64, identity, nullEvery(7));
+    DecodedVector decoded(*flat);
+    EXPECT_TRUE(decoded.hasNulls());
+    EXPECT_TRUE(decoded.mayHaveNulls());
+    for (vector_size_t i = 0; i < 64; ++i) {
+      EXPECT_EQ(decoded.isNullAt(i), (i % 7) == 0);
+    }
+  }
+
+  // No null buffer at all: false, no-op.
+  {
+    auto flat = makeFlatVector<int64_t>(64, identity);
+    DecodedVector decoded(*flat);
+    EXPECT_FALSE(decoded.hasNulls());
+    EXPECT_FALSE(decoded.mayHaveNulls());
+  }
+
+  // Combined-nulls (hasExtraNulls) dictionary with every bit set: bulk-scanned,
+  // false, and normalized (the combined bitmap is indexed by decoded row).
+  {
+    auto base = makeFlatVector<int64_t>(64, identity);
+    auto indices = makeIndices(64, identity);
+    auto nulls =
+        makeNulls(64, [](auto) { return false; }); // All-set, no nulls.
+    auto dict = BaseVector::wrapInDictionary(nulls, indices, 64, base);
+    DecodedVector decoded(*dict);
+    ASSERT_TRUE(decoded.hasExtraNulls());
+    EXPECT_FALSE(decoded.hasNulls());
+    EXPECT_FALSE(decoded.mayHaveNulls());
+    EXPECT_FALSE(decoded.hasExtraNulls());
+    for (vector_size_t i = 0; i < 64; ++i) {
+      EXPECT_FALSE(decoded.isNullAt(i));
+    }
+  }
+
+  // Dictionary without extra nulls over an all-set base (per-row confirm path):
+  // hasNulls() resolves each index, finds none, and normalizes.
+  {
+    auto base = makeFlatVector<int64_t>(64, identity);
+    base->mutableRawNulls(); // All-set base null buffer.
+    auto indices = makeIndicesInReverse(64);
+    auto dict = BaseVector::wrapInDictionary(nullptr, indices, 64, base);
+    DecodedVector decoded(*dict);
+    ASSERT_FALSE(decoded.isIdentityMapping());
+    ASSERT_TRUE(decoded.mayHaveNulls());
+    EXPECT_FALSE(decoded.hasNulls());
+    EXPECT_FALSE(decoded.mayHaveNulls());
+    for (vector_size_t i = 0; i < 64; ++i) {
+      EXPECT_FALSE(decoded.isNullAt(i));
+    }
+  }
+
+  // Dictionary without extra nulls over a base that has nulls (per-row confirm
+  // path finds one): hasNulls() is true and the view is preserved.
+  {
+    auto base = makeFlatVector<int64_t>(64, identity, nullEvery(5));
+    auto indices = makeIndicesInReverse(64);
+    auto dict = BaseVector::wrapInDictionary(nullptr, indices, 64, base);
+    DecodedVector decoded(*dict);
+    ASSERT_FALSE(decoded.isIdentityMapping());
+    EXPECT_TRUE(decoded.hasNulls());
+    EXPECT_TRUE(decoded.mayHaveNulls());
+    for (vector_size_t i = 0; i < 64; ++i) {
+      EXPECT_EQ(decoded.isNullAt(i), ((64 - i - 1) % 5) == 0);
+    }
+  }
+}
+
 TEST_F(DecodedVectorTest, dictionaryWrapping) {
   constexpr vector_size_t baseVectorSize{100};
   constexpr vector_size_t innerDictSize{30};


### PR DESCRIPTION
Summary:

Adds a definitive-nullness query to DecodedVector:

    bool hasNulls();

mayHaveNulls() is only indeterminate -- it is true whenever a null buffer is present, even if no bit in it is set (a shape production readers often emit). hasNulls() scans the bitmap and reports whether any decoded row is actually null.

As a side effect, the first call that finds no nulls normalizes the view: it drops the null buffer pointer, clears mayHaveNulls()/hasExtraNulls(), and invalidates the bitmap cached by nulls(). Afterwards mayHaveNulls()/isNullAt() report no nulls (callers take their null-free fast paths) and repeated calls are O(1). It only mutates this decoded view -- never the base vector -- so it is non-const, mirroring nulls(), which is likewise non-const because it lazily materializes derived null state. A view that has nulls is left unchanged.

Scans only when a null buffer is present: bulk bits::isAllSet for flat and combined-nulls encodings, O(1) for constants, O(size) for a dictionary without extra nulls (its bitmap is indexed indirectly, so each row's index is resolved to confirm).

Differential Revision: D110978844
