### PR TITLE
feat(hashtable): Add hash table serialization and deserialization APIs

### DIFF
--- a/velox/common/serialization/CMakeLists.txt
+++ b/velox/common/serialization/CMakeLists.txt
@@ -17,6 +17,7 @@ velox_add_library(
   DeserializationRegistry.cpp
   HEADERS
   DeserializationRegistry.h
+  NativeSerdeIO.h
   Registry.h
   Serializable.h
 )

--- a/velox/common/serialization/NativeSerdeIO.h
+++ b/velox/common/serialization/NativeSerdeIO.h
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cstring>
+#include <istream>
+#include <ostream>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <vector>
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::common {
+
+class NativeStringWriter {
+ public:
+  explicit NativeStringWriter(std::string& data) : data_(data) {}
+
+  void write(const void* data, size_t size) {
+    data_.append(static_cast<const char*>(data), size);
+  }
+
+  template <typename T>
+  void writeValue(T value) {
+    static_assert(std::is_trivially_copyable_v<T>);
+    write(&value, sizeof(value));
+  }
+
+ private:
+  std::string& data_;
+};
+
+class NativeStringReader {
+ public:
+  explicit NativeStringReader(std::string_view data) : data_(data) {}
+
+  void read(void* out, size_t size) {
+    VELOX_CHECK_LE(offset_ + size, data_.size(), "Corrupted binary data");
+    memcpy(out, data_.data() + offset_, size);
+    offset_ += size;
+  }
+
+  template <typename T>
+  T readValue() {
+    static_assert(std::is_trivially_copyable_v<T>);
+    T value;
+    read(&value, sizeof(value));
+    return value;
+  }
+
+  bool atEnd() const {
+    return offset_ == data_.size();
+  }
+
+ private:
+  std::string_view data_;
+  size_t offset_{0};
+};
+
+class NativeBufferedWriter {
+ public:
+  NativeBufferedWriter(std::ostream& out, size_t bufferSize)
+      : out_(out), buffer_(bufferSize), pos_(0) {}
+
+  ~NativeBufferedWriter() {
+    flush();
+  }
+
+  void write(const void* data, size_t size) {
+    const char* src = static_cast<const char*>(data);
+    while (size > 0) {
+      size_t available = buffer_.size() - pos_;
+      if (available == 0) {
+        flush();
+        available = buffer_.size();
+      }
+
+      const size_t toWrite = std::min(size, available);
+      std::memcpy(buffer_.data() + pos_, src, toWrite);
+      pos_ += toWrite;
+      src += toWrite;
+      size -= toWrite;
+    }
+  }
+
+  template <typename T>
+  void writeValue(T value) {
+    static_assert(std::is_trivially_copyable_v<T>);
+    write(&value, sizeof(value));
+  }
+
+  void flush() {
+    if (pos_ > 0) {
+      out_.write(buffer_.data(), pos_);
+      pos_ = 0;
+    }
+  }
+
+ private:
+  std::ostream& out_;
+  std::vector<char> buffer_;
+  size_t pos_;
+};
+
+class NativeBufferedReader {
+ public:
+  NativeBufferedReader(std::istream& in, size_t bufferSize)
+      : in_(in), buffer_(bufferSize), pos_(0), size_(0) {}
+
+  void read(void* data, size_t size) {
+    char* dest = static_cast<char*>(data);
+    while (size > 0) {
+      if (pos_ >= size_) {
+        refill();
+      }
+
+      const size_t available = size_ - pos_;
+      const size_t toRead = std::min(size, available);
+      std::memcpy(dest, buffer_.data() + pos_, toRead);
+      pos_ += toRead;
+      dest += toRead;
+      size -= toRead;
+    }
+  }
+
+  template <typename T>
+  T readValue() {
+    static_assert(std::is_trivially_copyable_v<T>);
+    T value;
+    read(&value, sizeof(value));
+    return value;
+  }
+
+ private:
+  void refill() {
+    in_.read(buffer_.data(), buffer_.size());
+    size_ = in_.gcount();
+    pos_ = 0;
+    VELOX_CHECK_GT(size_, 0, "Unexpected end of stream");
+  }
+
+  std::istream& in_;
+  std::vector<char> buffer_;
+  size_t pos_;
+  size_t size_;
+};
+
+} // namespace facebook::velox::common

--- a/velox/common/serialization/NativeSerdeIO.h
+++ b/velox/common/serialization/NativeSerdeIO.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstring>
+#include <string>
+#include <string_view>
+#include <type_traits>
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::common {
+
+/// Appends fixed-width values and raw bytes to a std::string in host byte
+/// order. The produced bytes are only portable between processes running the
+/// same binary on the same architecture.
+class NativeStringWriter {
+ public:
+  explicit NativeStringWriter(std::string& data) : data_(data) {}
+
+  void write(const void* data, size_t size) {
+    data_.append(static_cast<const char*>(data), size);
+  }
+
+  template <typename T>
+  void writeValue(T value) {
+    static_assert(std::is_trivially_copyable_v<T>);
+    write(&value, sizeof(value));
+  }
+
+ private:
+  std::string& data_;
+};
+
+/// Reads back the bytes produced by NativeStringWriter.
+class NativeStringReader {
+ public:
+  explicit NativeStringReader(std::string_view data) : data_(data) {}
+
+  void read(void* out, size_t size) {
+    memcpy(out, view(size).data(), size);
+  }
+
+  template <typename T>
+  T readValue() {
+    static_assert(std::is_trivially_copyable_v<T>);
+    T value;
+    read(&value, sizeof(value));
+    return value;
+  }
+
+  /// Returns the next 'size' bytes without copying them and advances past
+  /// them. The returned view is valid for as long as the underlying data is.
+  std::string_view view(size_t size) {
+    VELOX_CHECK_LE(offset_ + size, data_.size(), "Corrupted binary data");
+    const auto result = data_.substr(offset_, size);
+    offset_ += size;
+    return result;
+  }
+
+  /// Advances past the next 'size' bytes without reading them.
+  void skip(size_t size) {
+    VELOX_CHECK_LE(offset_ + size, data_.size(), "Corrupted binary data");
+    offset_ += size;
+  }
+
+  bool atEnd() const {
+    return offset_ == data_.size();
+  }
+
+ private:
+  std::string_view data_;
+  size_t offset_{0};
+};
+
+} // namespace facebook::velox::common

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -236,6 +236,7 @@ velox_link_libraries(
   velox_exec_window
   velox_expression
   velox_file
+  velox_presto_type_parser
   velox_presto_serializer
   velox_trace
   velox_time

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -21,9 +21,14 @@
 #include "velox/common/base/SimdUtil.h"
 #include "velox/common/process/ProcessBase.h"
 #include "velox/common/process/TraceContext.h"
+#include "velox/common/serialization/NativeSerdeIO.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/exec/AdaptivePrefetch.h"
 #include "velox/exec/OperatorUtils.h"
+#include "velox/functions/prestosql/types/parser/TypeParser.h"
+#include "velox/vector/FlatVector.h"
+
+#include <algorithm>
 
 using facebook::velox::common::testutil::TestValue;
 
@@ -2567,5 +2572,627 @@ void HashTable<ignoreNullKeys>::prepareForJoinProbe(
 
   populateLookupRows(rows, lookup.rows);
 }
+namespace {
+
+class CountingWriter {
+ public:
+  void write(const void*, size_t size) {
+    size_ += size;
+  }
+
+  template <typename T>
+  void writeValue(T value) {
+    static_assert(std::is_trivially_copyable_v<T>);
+    write(&value, sizeof(value));
+  }
+
+  void flush() {}
+
+  size_t size() const {
+    return size_;
+  }
+
+ private:
+  size_t size_{0};
+};
+
+class MemoryWriter {
+ public:
+  MemoryWriter(void* data, size_t size)
+      : begin_(static_cast<char*>(data)),
+        current_(static_cast<char*>(data)),
+        end_(begin_ + size) {
+    VELOX_CHECK_NOT_NULL(
+        data, "Serialized hash table destination cannot be null");
+  }
+
+  void write(const void* data, size_t size) {
+    VELOX_CHECK_LE(
+        size,
+        remaining(),
+        "Insufficient space in serialized hash table buffer");
+    std::memcpy(current_, data, size);
+    current_ += size;
+  }
+
+  template <typename T>
+  void writeValue(T value) {
+    static_assert(std::is_trivially_copyable_v<T>);
+    write(&value, sizeof(value));
+  }
+
+  void flush() {}
+
+  size_t writtenSize() const {
+    return static_cast<size_t>(current_ - begin_);
+  }
+
+ private:
+  size_t remaining() const {
+    return static_cast<size_t>(end_ - current_);
+  }
+
+  char* begin_;
+  char* current_;
+  char* end_;
+};
+
+} // namespace
+
+template <bool ignoreNullKeys>
+template <typename Writer>
+void HashTable<ignoreNullKeys>::serializeImpl(Writer& writer) const {
+  VELOX_CHECK(isJoinBuild_, "Only join-build hash tables are supported");
+  uint64_t totalRows = rows_ != nullptr ? rows_->numRows() : 0;
+  for (const auto& other : otherTables_) {
+    if (other->rows() != nullptr) {
+      totalRows += other->rows()->numRows();
+    }
+  }
+  VELOX_CHECK(
+      totalRows == 0 || table_ != nullptr,
+      "Serialization requires a prepared join table");
+
+  LOG(INFO) << "Serializing HashTable: "
+            << const_cast<HashTable<ignoreNullKeys>*>(this)->toString();
+
+  auto writeValue = [&](auto value) { writer.writeValue(value); };
+
+  // Serialize magic and version.
+  writeValue(static_cast<uint32_t>(0x48415348)); // "HASH"
+  writeValue(
+      static_cast<uint32_t>(8)); // Version 8: added constructor parameters for
+                                 // complete reconstruction
+
+  // Serialize base metadata, including all constructor parameters.
+  writeValue(static_cast<bool>(ignoreNullKeys));
+  writeValue(allowDuplicates_);
+  writeValue(isJoinBuild_);
+  writeValue(minTableSizeForParallelJoinBuild_);
+  writeValue(bloomFilterMaxSize_);
+  writeValue(hasDuplicates_.check());
+  writeValue(numDistinct_);
+  writeValue(static_cast<int32_t>(hashMode_));
+
+  // Serialize RowContainer flags.
+  const bool hasProbedFlag = rows_->probedFlagOffset() != 0;
+  const bool hasCountFlag = rows_->countOffset() != 0;
+  writeValue(hasProbedFlag);
+  writeValue(hasCountFlag);
+
+  // Serialize VectorHasher metadata.
+  writeValue(static_cast<uint32_t>(hashers_.size()));
+  for (const auto& hasher : hashers_) {
+    auto typeStr = hasher->type()->toString();
+    writeValue(static_cast<uint32_t>(typeStr.length()));
+    writer.write(typeStr.c_str(), typeStr.length());
+    writeValue(hasher->channel());
+  }
+
+  // Serialize dependentTypes metadata.
+  const auto& allColumnTypes = rows_->columnTypes();
+  const auto numKeyColumns = hashers_.size();
+  const auto numDependentColumns = allColumnTypes.size() > numKeyColumns
+      ? allColumnTypes.size() - numKeyColumns
+      : 0;
+
+  writeValue(static_cast<uint32_t>(numDependentColumns));
+  for (size_t i = numKeyColumns; i < allColumnTypes.size(); ++i) {
+    auto typeStr = allColumnTypes[i]->toString();
+    writeValue(static_cast<uint32_t>(typeStr.length()));
+    writer.write(typeStr.c_str(), typeStr.length());
+  }
+
+  // Serialize row data. For join build, RowContainer stores all build rows,
+  // which can exceed numDistinct_ when duplicate keys exist. Therefore we must
+  // use rows_->numRows() instead of numDistinct_, otherwise listRows() would
+  // not enumerate the full input and validation would fail. We also need to
+  // include rows from otherTables_ because parallel build may spread data
+  // across multiple tables.
+  writeValue(totalRows);
+
+  const bool serializeNormalizedKeys = hashMode_ == HashMode::kNormalizedKey;
+  raw_vector<normalized_key_t> normalizedKeys(0, pool_);
+  if (serializeNormalizedKeys) {
+    normalizedKeys.reserve(totalRows);
+  }
+
+  if (totalRows > 0) {
+    uint32_t numColumns = rows_->columnTypes().size();
+    writeValue(numColumns);
+
+    // Serialize column types.
+    for (int32_t col = 0; col < numColumns; ++col) {
+      auto typeStr = rows_->columnTypes()[col]->toString();
+      writeValue(static_cast<uint32_t>(typeStr.length()));
+      writer.write(typeStr.c_str(), typeStr.length());
+    }
+
+    // Serialize rows for all tables. Keep per-table serialized batches instead
+    // of copying into one large flatSerialized buffer while preserving the
+    // existing "all hashes -> all rows" wire layout.
+    std::vector<VectorPtr> serializedRowBatches;
+    serializedRowBatches.reserve(
+        (rows_ != nullptr ? 1 : 0) + otherTables_.size());
+    raw_vector<uint64_t> allHashes(0, pool_);
+    allHashes.reserve(totalRows);
+    vector_size_t serializedRowCount = 0;
+    auto* self = const_cast<HashTable<ignoreNullKeys>*>(this);
+
+    auto serializeRowsFrom = [&](RowContainer* sourceRows) {
+      if (sourceRows == nullptr || sourceRows->numRows() == 0) {
+        return;
+      }
+
+      const auto numSourceRows = sourceRows->numRows();
+      std::vector<char*> tableRows(numSourceRows);
+      RowContainerIterator iter;
+      const auto listed =
+          sourceRows->listRows(&iter, numSourceRows, tableRows.data());
+      VELOX_CHECK_EQ(listed, numSourceRows, "Failed to list serialized rows");
+
+      auto serializedBatch = BaseVector::create<FlatVector<StringView>>(
+          VARCHAR(), numSourceRows, sourceRows->pool());
+      sourceRows->extractSerializedRows(
+          folly::Range<char**>(tableRows.data(), tableRows.size()),
+          serializedBatch);
+      serializedRowBatches.push_back(serializedBatch);
+      serializedRowCount += numSourceRows;
+      if (serializeNormalizedKeys) {
+        for (auto* row : tableRows) {
+          normalizedKeys.push_back(RowContainer::normalizedKey(row));
+        }
+      }
+
+      raw_vector<uint64_t> tableHashes(numSourceRows, pool_);
+      bool hashSuccess = self->hashRows(
+          folly::Range<char**>(tableRows.data(), tableRows.size()),
+          false,
+          tableHashes);
+
+      // Fall back to full hashes when hashRows fails, e.g. kArray cannot
+      // produce value IDs for the current state.
+      if (!hashSuccess) {
+        for (vector_size_t i = 0; i < numSourceRows; ++i) {
+          sourceRows->hash(
+              0,
+              folly::Range<char**>(tableRows.data() + i, 1),
+              false,
+              &tableHashes[i]);
+          for (int32_t j = 1; j < self->hashers_.size(); ++j) {
+            sourceRows->hash(
+                j,
+                folly::Range<char**>(tableRows.data() + i, 1),
+                true,
+                &tableHashes[i]);
+          }
+        }
+      }
+
+      for (const auto hash : tableHashes) {
+        allHashes.push_back(hash);
+      }
+    };
+
+    serializeRowsFrom(rows_.get());
+    for (const auto& other : otherTables_) {
+      serializeRowsFrom(other->rows());
+    }
+
+    VELOX_CHECK_EQ(serializedRowCount, totalRows, "Total rows mismatch");
+    VELOX_CHECK_EQ(allHashes.size(), totalRows, "Total hashes mismatch");
+    if (serializeNormalizedKeys) {
+      VELOX_CHECK_EQ(
+          normalizedKeys.size(), totalRows, "Total normalized keys mismatch");
+    }
+
+    // Write all hashes.
+    for (uint64_t hash : allHashes) {
+      writeValue(hash);
+    }
+
+    // Write serialized row data batch by batch to avoid copying into one large
+    // intermediate buffer.
+    for (const auto& serializedBatch : serializedRowBatches) {
+      const auto* flatBatch =
+          serializedBatch->template asUnchecked<FlatVector<StringView>>();
+      for (vector_size_t i = 0; i < flatBatch->size(); ++i) {
+        const auto serialized = flatBatch->valueAt(i);
+        writeValue(static_cast<uint32_t>(serialized.size()));
+        if (serialized.size() > 0) {
+          writer.write(serialized.data(), serialized.size());
+        }
+      }
+    }
+  } else {
+    writeValue(static_cast<uint32_t>(0));
+  }
+
+  // Serialize columnHasNulls_.
+  writeValue(static_cast<uint32_t>(columnHasNulls_.size()));
+  for (bool hasNull : columnHasNulls_) {
+    writeValue(hasNull);
+  }
+
+  writeValue(capacity_);
+  writeValue(static_cast<uint32_t>(hashers_.size()));
+  for (const auto& hasher : hashers_) {
+    const auto stateSize = hasher->serializedStateSize();
+    writeValue(stateSize);
+    if (stateSize > 0) {
+      auto state = hasher->serializeState();
+      VELOX_CHECK_EQ(
+          state.size(),
+          stateSize,
+          "Serialized VectorHasher state size mismatch");
+      writer.write(state.data(), state.size());
+    }
+  }
+
+  writeValue(static_cast<bool>(serializeNormalizedKeys));
+  if (serializeNormalizedKeys && totalRows > 0) {
+    for (const auto normalizedKey : normalizedKeys) {
+      writeValue(normalizedKey);
+    }
+  }
+
+  // Flush explicitly so write failures surface at the serialization call site.
+  writer.flush();
+}
+
+template <bool ignoreNullKeys>
+size_t HashTable<ignoreNullKeys>::serializedSize() const {
+  CountingWriter writer;
+  serializeImpl(writer);
+  return writer.size();
+}
+
+template <bool ignoreNullKeys>
+void HashTable<ignoreNullKeys>::serializeTo(void* data, size_t size) const {
+  MemoryWriter writer(data, size);
+  serializeImpl(writer);
+  VELOX_CHECK_EQ(
+      writer.writtenSize(), size, "Hash table serialized size mismatch");
+}
+
+template <bool ignoreNullKeys>
+template <typename Reader>
+std::unique_ptr<HashTable<ignoreNullKeys>> HashTable<
+    ignoreNullKeys>::deserializeImpl(Reader& reader, memory::MemoryPool* pool) {
+  auto readValue = [&]<typename T>() -> T {
+    return reader.template readValue<T>();
+  };
+
+  // Read and validate magic and version.
+  uint32_t magic = readValue.template operator()<uint32_t>();
+  uint32_t version = readValue.template operator()<uint32_t>();
+
+  VELOX_CHECK_EQ(magic, 0x48415348, "Invalid magic number");
+  VELOX_CHECK_EQ(
+      version,
+      8,
+      "Expected version 8, got {}. Version 7 is deprecated due to issues.",
+      version);
+
+  // Read metadata.
+  bool ignoreNulls = readValue.template operator()<bool>();
+  VELOX_CHECK_EQ(ignoreNulls, ignoreNullKeys, "ignoreNullKeys mismatch");
+
+  bool allowDuplicates = readValue.template operator()<bool>();
+  bool isJoinBuild = readValue.template operator()<bool>();
+  uint32_t minTableSizeForParallelJoinBuild =
+      readValue.template operator()<uint32_t>();
+  uint64_t bloomFilterMaxSize = readValue.template operator()<uint64_t>();
+  bool hasDuplicates = readValue.template operator()<bool>();
+
+  int64_t numDistinct = readValue.template operator()<int64_t>();
+  int32_t hashModeInt = readValue.template operator()<int32_t>();
+  VELOX_CHECK(
+      hashModeInt == static_cast<int32_t>(HashMode::kHash) ||
+          hashModeInt == static_cast<int32_t>(HashMode::kArray) ||
+          hashModeInt == static_cast<int32_t>(HashMode::kNormalizedKey),
+      "Invalid hash mode in serialized HashTable: {}",
+      hashModeInt);
+
+  // Read RowContainer flags.
+  bool hasProbedFlag = readValue.template operator()<bool>();
+  bool hasCountFlag = readValue.template operator()<bool>();
+
+  // Read VectorHasher metadata.
+  uint32_t numHashers = readValue.template operator()<uint32_t>();
+  std::vector<std::unique_ptr<VectorHasher>> hashers;
+  std::vector<TypePtr> keyTypes;
+  hashers.reserve(numHashers);
+  keyTypes.reserve(numHashers);
+
+  auto parseType = [](const std::string& typeStr) -> TypePtr {
+    auto normalized = typeStr;
+    std::replace(normalized.begin(), normalized.end(), '<', '(');
+    std::replace(normalized.begin(), normalized.end(), '>', ')');
+    std::replace(normalized.begin(), normalized.end(), ':', ' ');
+    return functions::prestosql::parseType(normalized);
+  };
+
+  for (uint32_t i = 0; i < numHashers; ++i) {
+    uint32_t typeLen = readValue.template operator()<uint32_t>();
+    std::string typeStr(typeLen, '\0');
+    if (typeLen > 0) {
+      reader.read(typeStr.data(), typeLen);
+    }
+
+    column_index_t channel = readValue.template operator()<column_index_t>();
+
+    TypePtr type = parseType(typeStr);
+    keyTypes.push_back(type);
+    hashers.push_back(std::make_unique<VectorHasher>(type, channel));
+  }
+
+  // Read dependentTypes metadata.
+  uint32_t numDependentTypes = readValue.template operator()<uint32_t>();
+  std::vector<TypePtr> dependentTypes;
+  dependentTypes.reserve(numDependentTypes);
+  for (uint32_t i = 0; i < numDependentTypes; ++i) {
+    uint32_t typeLen = readValue.template operator()<uint32_t>();
+    std::string typeStr(typeLen, '\0');
+    if (typeLen > 0) {
+      reader.read(typeStr.data(), typeLen);
+    }
+    dependentTypes.push_back(parseType(typeStr));
+  }
+
+  // Read row data. The serialization format writes numColumns and column types
+  // only when numRows > 0, so deserialization must follow the same condition
+  // to keep the stream position aligned for empty tables.
+  uint64_t numRows = readValue.template operator()<uint64_t>();
+  uint32_t numColumns = 0;
+
+  std::vector<TypePtr> columnTypes;
+  if (numRows > 0) {
+    numColumns = readValue.template operator()<uint32_t>();
+    if (numColumns > 0) {
+      columnTypes.reserve(numColumns);
+      for (uint32_t col = 0; col < numColumns; ++col) {
+        uint32_t typeLen = readValue.template operator()<uint32_t>();
+        std::string typeStr(typeLen, '\0');
+        if (typeLen > 0) {
+          reader.read(typeStr.data(), typeLen);
+        }
+        columnTypes.push_back(parseType(typeStr));
+      }
+    }
+  } else {
+    // When numRows == 0, serialization writes an extra 0 for numColumns.
+    // Consume it here to keep the stream aligned.
+    readValue.template operator()<uint32_t>();
+  }
+
+  // Create the HashTable using all serialized constructor parameters.
+  auto table = std::make_unique<HashTable<ignoreNullKeys>>(
+      std::move(hashers),
+      std::vector<Accumulator>{},
+      dependentTypes,
+      allowDuplicates,
+      isJoinBuild,
+      hasProbedFlag,
+      hasCountFlag,
+      minTableSizeForParallelJoinBuild,
+      pool,
+      bloomFilterMaxSize);
+
+  if (numRows > 0) {
+    const auto expectedNumColumns = keyTypes.size() + dependentTypes.size();
+    VELOX_CHECK_EQ(
+        columnTypes.size(),
+        expectedNumColumns,
+        "Serialized row schema has {} columns, but HashTable expects {}",
+        columnTypes.size(),
+        expectedNumColumns);
+    for (size_t i = 0; i < columnTypes.size(); ++i) {
+      const auto& expectedType = i < keyTypes.size()
+          ? keyTypes[i]
+          : dependentTypes[i - keyTypes.size()];
+      VELOX_CHECK(
+          columnTypes[i]->equivalent(*expectedType),
+          "Serialized row schema mismatch at column {}: got {}, expected {}",
+          i,
+          columnTypes[i]->toString(),
+          expectedType->toString());
+    }
+  }
+
+  // Restore the hasDuplicates flag.
+  if (hasDuplicates) {
+    table->hasDuplicates_.set();
+  }
+
+  std::vector<uint64_t> precomputedHashes;
+  if (numRows > 0) {
+    precomputedHashes.reserve(numRows);
+    for (uint64_t i = 0; i < numRows; ++i) {
+      precomputedHashes.push_back(readValue.template operator()<uint64_t>());
+    }
+  }
+
+  // Restore row data.
+  std::vector<char*> allRows;
+  allRows.reserve(numRows);
+
+  if (numRows > 0) {
+    std::string serializedRowBuffer;
+    for (uint64_t i = 0; i < numRows; ++i) {
+      char* newRow = table->rows_->newRow();
+
+      // Initialize nextRow pointer to nullptr to avoid garbage values
+      // that could cause crashes or incorrect results in listJoinResults.
+      // This must be done before storeSerializedRow because the serialized
+      // data does not include the nextRow pointer (it's an internal hash
+      // table structure), and uninitialized memory may contain random values.
+      if (table->nextOffset_) {
+        *reinterpret_cast<char**>(newRow + table->nextOffset_) = nullptr;
+      }
+
+      uint32_t rowSize = readValue.template operator()<uint32_t>();
+      if (rowSize > 0) {
+        serializedRowBuffer.resize(rowSize);
+        reader.read(serializedRowBuffer.data(), rowSize);
+        table->rows_->storeSerializedRow(
+            std::string_view(serializedRowBuffer.data(), rowSize), newRow);
+      } else {
+        table->rows_->storeSerializedRow(std::string_view{}, newRow);
+      }
+
+      // Initialize probed flag to false (0) if applicable
+      if (hasProbedFlag && table->rows_->probedFlagOffset() != 0) {
+        bits::clearBit(newRow, table->rows_->probedFlagOffset());
+      }
+
+      // Initialize count to 1 for counting joins. Each deserialized row
+      // represents one occurrence of the key. This matches the behavior of
+      // RowContainer::initializeRow() which also sets count to 1.
+      if (hasCountFlag && table->rows_->countOffset() != 0) {
+        *reinterpret_cast<int32_t*>(newRow + table->rows_->countOffset()) = 1;
+      }
+
+      allRows.push_back(newRow);
+    }
+  }
+
+  // Read columnHasNulls_.
+  uint32_t numColumnFlags = readValue.template operator()<uint32_t>();
+  table->columnHasNulls_.resize(numColumnFlags);
+  for (uint32_t i = 0; i < numColumnFlags; ++i) {
+    table->columnHasNulls_[i] = readValue.template operator()<bool>();
+  }
+
+  table->numDistinct_ = numDistinct;
+  const auto serializedCapacity = readValue.template operator()<uint64_t>();
+  const auto serializedHasherCount = readValue.template operator()<uint32_t>();
+  VELOX_CHECK_EQ(
+      serializedHasherCount,
+      table->hashers_.size(),
+      "Serialized VectorHasher count mismatch");
+
+  for (uint32_t i = 0; i < serializedHasherCount; ++i) {
+    const auto stateSize = readValue.template operator()<uint32_t>();
+    std::string state(stateSize, '\0');
+    if (stateSize > 0) {
+      reader.read(state.data(), stateSize);
+    }
+    table->hashers_[i]->deserializeState(state);
+  }
+
+  const bool hasNormalizedKeys = readValue.template operator()<bool>();
+  if (hasNormalizedKeys) {
+    VELOX_CHECK_EQ(
+        hashModeInt,
+        static_cast<int32_t>(HashMode::kNormalizedKey),
+        "Serialized normalized keys require normalized hash mode");
+    for (auto* row : allRows) {
+      RowContainer::normalizedKey(row) =
+          readValue.template operator()<normalized_key_t>();
+    }
+  }
+
+  table->hashMode_ = static_cast<HashMode>(hashModeInt);
+  if (table->hashMode_ == HashMode::kHash) {
+    table->rows_->disableNormalizedKeys();
+  }
+
+  if (!allRows.empty()) {
+    if (table->hashMode_ == HashMode::kArray) {
+      table->capacity_ = serializedCapacity;
+      const auto bytes = table->capacity_ * tableSlotSize();
+      const auto numPages = memory::AllocationTraits::numPages(bytes);
+      table->rows_->pool()->allocateContiguous(
+          numPages, table->tableAllocation_);
+      table->table_ = table->tableAllocation_.template data<char*>();
+      memset(table->table_, 0, bytes);
+    } else {
+      table->allocateTables(serializedCapacity, kNoSpillInputStartPartitionBit);
+    }
+
+    VELOX_CHECK_EQ(
+        precomputedHashes.size(),
+        allRows.size(),
+        "Serialized join-table format requires stored hashes");
+
+    // Recompute value IDs for kArray to match the deserialized VectorHasher
+    // state. This is required because serialized hashes may be full hashes
+    // when hashRows fell back, or value IDs produced from a different
+    // VectorHasher state.
+    if (table->hashMode_ == HashMode::kArray) {
+      raw_vector<uint64_t> valueIds(allRows.size(), pool);
+      bool success = table->hashRows(
+          folly::Range<char**>(allRows.data(), allRows.size()),
+          false,
+          valueIds);
+      VELOX_CHECK(
+          success,
+          "Failed to compute value IDs in kArray mode during deserialization. "
+          "This indicates the data type does not support value IDs.");
+
+      table->insertForJoin(
+          allRows.data(), valueIds.data(), allRows.size(), nullptr);
+    } else {
+      // For kHash and kNormalizedKey, reuse the stored hashes directly.
+      table->insertForJoin(
+          allRows.data(), precomputedHashes.data(), allRows.size(), nullptr);
+    }
+  }
+  table->numDistinct_ = numDistinct;
+  LOG(INFO) << "Deserialized HashTable: " << table->toString();
+
+  return table;
+}
+
+template <bool ignoreNullKeys>
+std::unique_ptr<HashTable<ignoreNullKeys>>
+HashTable<ignoreNullKeys>::deserializeFrom(
+    const void* data,
+    size_t size,
+    memory::MemoryPool* pool) {
+  VELOX_CHECK_NOT_NULL(data, "Serialized hash table data cannot be null");
+  common::NativeStringReader reader(
+      std::string_view(static_cast<const char*>(data), size));
+  auto table = deserializeImpl(reader, pool);
+  VELOX_CHECK(
+      reader.atEnd(), "Trailing bytes after hash table deserialization");
+  return table;
+}
+
+template size_t HashTable<true>::serializedSize() const;
+template size_t HashTable<false>::serializedSize() const;
+
+template void HashTable<true>::serializeTo(void* data, size_t size) const;
+template void HashTable<false>::serializeTo(void* data, size_t size) const;
+
+template std::unique_ptr<HashTable<true>> HashTable<true>::deserializeFrom(
+    const void* data,
+    size_t size,
+    memory::MemoryPool* pool);
+template std::unique_ptr<HashTable<false>> HashTable<false>::deserializeFrom(
+    const void* data,
+    size_t size,
+    memory::MemoryPool* pool);
 
 } // namespace facebook::velox::exec

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -21,9 +21,16 @@
 #include "velox/common/base/SimdUtil.h"
 #include "velox/common/process/ProcessBase.h"
 #include "velox/common/process/TraceContext.h"
+#include "velox/common/serialization/NativeSerdeIO.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/exec/AdaptivePrefetch.h"
 #include "velox/exec/OperatorUtils.h"
+#include "velox/vector/FlatVector.h"
+
+#include <folly/json.h>
+#include <folly/synchronization/CallOnce.h>
+
+#include <algorithm>
 
 using facebook::velox::common::testutil::TestValue;
 
@@ -739,6 +746,12 @@ void HashTable<ignoreNullKeys>::allocateTables(
   sizeBits_ = __builtin_popcountll(sizeMask_);
   checkHashBitsOverlap(spillInputStartPartitionBit);
   bucketOffsetMask_ = sizeMask_ & ~(kBucketSize - 1);
+  if (buildForSerializationOnly_) {
+    // Keep every derived size field, since 'capacity_' goes on the wire and the
+    // reading side sizes its own slot array from it, but do not back it with
+    // memory: nothing probes this table. See setBuildForSerializationOnly().
+    return;
+  }
   // The total size is 8 bytes per slot, in groups of 16 slots with 16 bytes of
   // tags and 16 * 6 bytes of pointers and a padding of 16 bytes to round up the
   // cache line.
@@ -987,6 +1000,11 @@ bool HashTable<false>::bloomFilterSupported() const {
 template <bool ignoreNullKeys>
 bool HashTable<ignoreNullKeys>::canApplyParallelJoinBuild() const {
   if (!isJoinBuild_ || buildExecutor_ == nullptr) {
+    return false;
+  }
+  if (buildForSerializationOnly_) {
+    // parallelJoinBuild() partitions the table's slot array and inserts into
+    // it, which is exactly the work this mode exists to skip.
     return false;
   }
   if (hashMode_ == HashMode::kArray) {
@@ -1315,6 +1333,11 @@ bool HashTable<ignoreNullKeys>::insertBatch(
   if (!hashRows(folly::Range(groups, numGroups), initNormalizedKeys, hashes)) {
     return false;
   }
+  if (buildForSerializationOnly_) {
+    // hashRows() above produced everything that gets serialized. There is no
+    // slot array to insert into. See setBuildForSerializationOnly().
+    return true;
+  }
   if (isJoinBuild_) {
     insertForJoin(groups, hashes.data(), numGroups, nullptr);
   } else {
@@ -1546,6 +1569,17 @@ void HashTable<ignoreNullKeys>::rehash(
     parallelJoinBuild();
     return;
   }
+  // A serialize-only build has no slot array to insert into, so in kHash mode a
+  // rehash produces nothing that is kept: the hashes it computes are thrown
+  // away and serializeImpl() computes the ones it writes itself. The other
+  // modes do keep something, namely the value ids that insertBatch() settles
+  // and, in kNormalizedKey mode, the normalized keys it writes into the rows.
+  // Bloom filters are the other thing a rehash produces, and they are
+  // serialized as part of the VectorHasher state.
+  if (buildForSerializationOnly_ && hashMode_ == HashMode::kHash &&
+      !bloomFilterSupported()) {
+    return;
+  }
   raw_vector<uint64_t> hashes(pool_);
   hashes.resize(kHashBatchSize);
   char* groups[kHashBatchSize];
@@ -1603,12 +1637,17 @@ void HashTable<ignoreNullKeys>::setHashMode(
   VELOX_CHECK_NE(hashMode_, HashMode::kHash);
   TestValue::adjust("facebook::velox::exec::HashTable::setHashMode", &mode);
   if (mode == HashMode::kArray) {
-    const auto bytes = capacity_ * tableSlotSize();
-    const auto numPages = memory::AllocationTraits::numPages(bytes);
-    rows_->pool()->allocateContiguous(numPages, tableAllocation_);
-    table_ = tableAllocation_.data<char*>();
-    memset(table_, 0, bytes);
+    if (!buildForSerializationOnly_) {
+      const auto bytes = capacity_ * tableSlotSize();
+      const auto numPages = memory::AllocationTraits::numPages(bytes);
+      rows_->pool()->allocateContiguous(numPages, tableAllocation_);
+      table_ = tableAllocation_.data<char*>();
+      memset(table_, 0, bytes);
+    }
     hashMode_ = HashMode::kArray;
+    // Still rehashes: that is what computes the value ids and, in
+    // kNormalizedKey mode, writes the normalized keys into the rows, both of
+    // which are serialized. Only the insertion into the slot array is skipped.
     rehash(true, spillInputStartPartitionBit);
   } else if (mode == HashMode::kHash) {
     hashMode_ = HashMode::kHash;
@@ -1905,7 +1944,8 @@ std::string HashTable<ignoreNullKeys>::toString() {
     // Each bucket has 16 slots. Hence, the number of non-empty slots is
     // between 0 and 16 (17 possible values).
     int64_t numBuckets[sizeof(TagVector) + 1] = {};
-    for (int64_t bucketOffset = 0; bucketOffset < sizeMask_;
+    for (int64_t bucketOffset = 0;
+         table_ != nullptr && bucketOffset < sizeMask_;
          bucketOffset += kBucketSize) {
       auto tags = loadTags(bucketOffset);
       auto filled = simd::toBitMask(tags != TagVector::broadcast(0));
@@ -2710,5 +2750,904 @@ void HashTable<ignoreNullKeys>::prepareForJoinProbe(
 
   populateLookupRows(rows, lookup.rows);
 }
+namespace {
+
+// Wire format identity of a serialized HashTable. The format holds host-native
+// fixed-width values and is only readable by the same binary on the same
+// architecture.
+constexpr uint32_t kSerializedTableMagic = 0x48415348; // "HASH"
+// Bumped whenever the layout below changes. deserializeFrom() accepts only an
+// exact match: there is no compatibility window, since a serialized table is
+// only readable by the binary that wrote it to begin with.
+constexpr uint32_t kSerializedTableVersion = 1;
+
+// Target number of build rows per serialized section. Sections are decoded
+// independently, each into its own RowContainer, so this is what bounds the
+// parallelism available to deserializeFrom(). Small enough that a build side
+// of a few million rows splits into more sections than a host has cores, large
+// enough that the per-section RowContainer overhead stays irrelevant.
+constexpr uint64_t kSerializedSectionRows = 256 * 1024;
+
+// Caps the number of sections, and with it the number of RowContainers the
+// reading side creates, for a very large build side.
+constexpr uint64_t kMaxSerializedSections = 128;
+
+// Counts the bytes a serialization produces without materializing them.
+// 'kSizeOnly' lets serializeImpl() skip the row extraction and hashing, which
+// affect only the content and not the size of the output.
+class SizeCountingWriter {
+ public:
+  static constexpr bool kSizeOnly = true;
+
+  void write(const void* /*data*/, size_t size) {
+    size_ += size;
+  }
+
+  template <typename T>
+  void writeValue(T /*value*/) {
+    static_assert(std::is_trivially_copyable_v<T>);
+    size_ += sizeof(T);
+  }
+
+  // Accounts for 'size' bytes whose content this pass does not produce.
+  char* reserve(size_t size) {
+    size_ += size;
+    return nullptr;
+  }
+
+  void flush() {}
+
+  size_t size() const {
+    return size_;
+  }
+
+ private:
+  size_t size_{0};
+};
+
+// Writes into a caller-provided contiguous buffer.
+class MemoryWriter {
+ public:
+  static constexpr bool kSizeOnly = false;
+
+  MemoryWriter(void* data, size_t size)
+      : begin_(static_cast<char*>(data)),
+        current_(begin_),
+        end_(begin_ + size) {
+    VELOX_CHECK_NOT_NULL(
+        data, "Serialized hash table destination cannot be null");
+  }
+
+  void write(const void* data, size_t size) {
+    ::memcpy(reserve(size), data, size);
+  }
+
+  template <typename T>
+  void writeValue(T value) {
+    static_assert(std::is_trivially_copyable_v<T>);
+    write(&value, sizeof(value));
+  }
+
+  // Returns a pointer to the next 'size' bytes of the destination and advances
+  // past them, so callers can produce large sections in place instead of
+  // staging them in a temporary buffer.
+  char* reserve(size_t size) {
+    VELOX_CHECK_LE(
+        size,
+        static_cast<size_t>(end_ - current_),
+        "Insufficient space in serialized hash table buffer");
+    auto* result = current_;
+    current_ += size;
+    return result;
+  }
+
+  void flush() {}
+
+  size_t writtenSize() const {
+    return static_cast<size_t>(current_ - begin_);
+  }
+
+ private:
+  char* const begin_;
+  char* current_;
+  char* const end_;
+};
+
+// Types go on the wire in the ISerializable form, the only representation Type
+// guarantees a round trip for. Type::toString() is a debug representation and
+// reconstructing a type from it takes a parser that only the Presto dialect
+// has.
+std::string serializeType(const Type& type) {
+  return folly::toJson(type.serialize());
+}
+
+TypePtr deserializeType(std::string_view serialized) {
+  // The Type deserializers live in a process-wide registry that an embedder
+  // reading a hash table has no other reason to have populated, and a missing
+  // registration silently yields a null type rather than an error. Registering
+  // is idempotent and thread safe.
+  static folly::once_flag registered;
+  folly::call_once(registered, []() { Type::registerSerDe(); });
+  auto type = ISerializable::deserialize<Type>(folly::parseJson(serialized));
+  VELOX_CHECK_NOT_NULL(type, "Unknown type in serialized HashTable");
+  return type;
+}
+
+// Runs 'work(i)' for every i in [0, numItems) on 'executor', keeping the last
+// item on the calling thread rather than leaving it idle. Falls back to running
+// everything inline when there is no executor or nothing to overlap. All items
+// are synced before returning, including when one of them throws, since they
+// hold references to the caller's frame; the first error is rethrown.
+template <typename Work>
+void runParallel(folly::Executor* executor, size_t numItems, Work work) {
+  if (numItems == 0) {
+    return;
+  }
+  if (executor == nullptr || numItems == 1) {
+    for (size_t i = 0; i < numItems; ++i) {
+      work(i);
+    }
+    return;
+  }
+
+  std::vector<std::shared_ptr<AsyncSource<bool>>> steps;
+  steps.reserve(numItems - 1);
+  // Runs on the unwinding path if 'work' throws before the sync loop below is
+  // reached, so it must not throw itself.
+  auto sync = folly::makeGuard([&]() {
+    for (auto& step : steps) {
+      try {
+        step->move();
+      } catch (const std::exception& e) {
+        LOG(ERROR) << "Error in async hash table work: " << e.what();
+      }
+    }
+  });
+
+  // Passing the driver context explicitly, since the worker threads have no
+  // thread local one of their own.
+  const DriverCtx* driverCtx{nullptr};
+  if (const auto* driverThreadCtx = driverThreadContext()) {
+    driverCtx = driverThreadCtx->driverCtx();
+  }
+
+  for (size_t i = 0; i + 1 < numItems; ++i) {
+    auto step = std::make_shared<AsyncSource<bool>>([i, &work]() {
+      work(i);
+      return std::make_unique<bool>(true);
+    });
+    steps.push_back(step);
+    executor->add([driverCtx, step]() {
+      ScopedDriverThreadContext scopedDriverThreadContext(driverCtx);
+      step->prepare();
+    });
+  }
+  work(numItems - 1);
+
+  std::exception_ptr error;
+  for (auto& step : steps) {
+    try {
+      step->move();
+    } catch (const std::exception&) {
+      if (error == nullptr) {
+        error = std::current_exception();
+      }
+    }
+  }
+  // Everything has been synced, so keep the guard from doing it again.
+  steps.clear();
+  if (error != nullptr) {
+    std::rethrow_exception(error);
+  }
+}
+
+// Number of bucket range partitions to insert 'numSections' row sections with.
+// Mirrors the constraints parallelJoinBuild() works under: the partition index
+// has to fit in a uint8_t, and a partition must cover more than
+// 'minTableSizeForParallelJoinBuild' entries for the partitioning to pay off.
+int32_t numInsertPartitions(
+    uint64_t capacity,
+    uint32_t minTableSizeForParallelJoinBuild,
+    size_t numSections) {
+  auto numPartitions = static_cast<int32_t>(
+      std::min<size_t>(numSections, std::numeric_limits<uint8_t>::max()));
+  while (numPartitions > 1 &&
+         capacity / numPartitions <= minTableSizeForParallelJoinBuild) {
+    --numPartitions;
+  }
+  return numPartitions;
+}
+
+// Everything the serialized form carries ahead of the build rows, i.e. what it
+// takes to create the table the rows are then read into.
+struct SerializedTableHeader {
+  // Constructor parameters of the table that was written.
+  bool allowDuplicates;
+  bool isJoinBuild;
+  uint32_t minTableSizeForParallelJoinBuild;
+  uint64_t bloomFilterMaxSize;
+  // State that the insertion below does not reproduce on its own.
+  bool hasDuplicates;
+  int64_t numDistinct;
+  BaseHashTable::HashMode hashMode;
+  uint64_t capacity;
+  bool hasProbedFlag;
+  // The key types and the input channels they come from, 1:1.
+  std::vector<TypePtr> keyTypes;
+  std::vector<column_index_t> keyChannels;
+  // The non-key columns of the build rows, in RowContainer order.
+  std::vector<TypePtr> dependentTypes;
+  std::vector<bool> columnHasNulls;
+  // Views into the buffer being read, one per key, applied to the hashers once
+  // they belong to a table.
+  std::vector<std::string_view> hasherStates;
+};
+
+// 'ignoreNullKeys' is the reading side's own setting, which the writing side
+// has to agree with: it decides whether the rows have null flags for the keys.
+SerializedTableHeader readTableHeader(
+    common::NativeStringReader& reader,
+    bool ignoreNullKeys) {
+  VELOX_CHECK_EQ(
+      reader.readValue<uint32_t>(),
+      kSerializedTableMagic,
+      "Invalid magic number");
+  const auto version = reader.readValue<uint32_t>();
+  VELOX_CHECK_EQ(
+      version,
+      kSerializedTableVersion,
+      "Unsupported serialized HashTable version: {}",
+      version);
+
+  VELOX_CHECK_EQ(
+      reader.readValue<bool>(), ignoreNullKeys, "ignoreNullKeys mismatch");
+
+  SerializedTableHeader header;
+  header.allowDuplicates = reader.readValue<bool>();
+  header.isJoinBuild = reader.readValue<bool>();
+  header.minTableSizeForParallelJoinBuild = reader.readValue<uint32_t>();
+  header.bloomFilterMaxSize = reader.readValue<uint64_t>();
+  header.hasDuplicates = reader.readValue<bool>();
+  header.numDistinct = reader.readValue<int64_t>();
+
+  const auto hashMode = reader.readValue<int32_t>();
+  VELOX_CHECK(
+      hashMode == static_cast<int32_t>(BaseHashTable::HashMode::kHash) ||
+          hashMode == static_cast<int32_t>(BaseHashTable::HashMode::kArray) ||
+          hashMode ==
+              static_cast<int32_t>(BaseHashTable::HashMode::kNormalizedKey),
+      "Invalid hash mode in serialized HashTable: {}",
+      hashMode);
+  header.hashMode = static_cast<BaseHashTable::HashMode>(hashMode);
+
+  header.capacity = reader.readValue<uint64_t>();
+  header.hasProbedFlag = reader.readValue<bool>();
+
+  auto readType = [&]() {
+    const auto length = reader.readValue<uint32_t>();
+    return deserializeType(reader.view(length));
+  };
+
+  const auto numKeys = reader.readValue<uint32_t>();
+  header.keyTypes.reserve(numKeys);
+  header.keyChannels.reserve(numKeys);
+  for (uint32_t i = 0; i < numKeys; ++i) {
+    header.keyTypes.push_back(readType());
+    header.keyChannels.push_back(reader.readValue<column_index_t>());
+  }
+
+  const auto numDependentTypes = reader.readValue<uint32_t>();
+  header.dependentTypes.reserve(numDependentTypes);
+  for (uint32_t i = 0; i < numDependentTypes; ++i) {
+    header.dependentTypes.push_back(readType());
+  }
+
+  const auto numColumnHasNulls = reader.readValue<uint32_t>();
+  const auto columnNullFlags = reader.view(numColumnHasNulls);
+  header.columnHasNulls.resize(numColumnHasNulls);
+  for (uint32_t i = 0; i < numColumnHasNulls; ++i) {
+    header.columnHasNulls[i] = columnNullFlags[i] != 0;
+  }
+
+  header.hasherStates.resize(numKeys);
+  for (uint32_t i = 0; i < numKeys; ++i) {
+    header.hasherStates[i] = reader.view(reader.readValue<uint32_t>());
+  }
+
+  return header;
+}
+
+// A fresh set of hashers for a table holding deserialized rows. The extra
+// tables that take the row sections decoded in parallel need their own.
+std::vector<std::unique_ptr<VectorHasher>> makeHashers(
+    const SerializedTableHeader& header) {
+  std::vector<std::unique_ptr<VectorHasher>> hashers;
+  hashers.reserve(header.keyTypes.size());
+  for (auto i = 0; i < header.keyTypes.size(); ++i) {
+    hashers.push_back(
+        std::make_unique<VectorHasher>(
+            header.keyTypes[i], header.keyChannels[i]));
+  }
+  return hashers;
+}
+
+// Creates an empty table shaped like the serialized one. Accumulators and
+// per-row counts have no serialized form; serializeImpl() rejects the tables
+// that have them.
+template <bool ignoreNullKeys>
+std::unique_ptr<HashTable<ignoreNullKeys>> makeDeserializedTable(
+    const SerializedTableHeader& header,
+    memory::MemoryPool* pool) {
+  return std::make_unique<HashTable<ignoreNullKeys>>(
+      makeHashers(header),
+      std::vector<Accumulator>{},
+      header.dependentTypes,
+      header.allowDuplicates,
+      header.isJoinBuild,
+      header.hasProbedFlag,
+      /*hasCountFlag=*/false,
+      header.minTableSizeForParallelJoinBuild,
+      pool,
+      header.bloomFilterMaxSize);
+}
+
+} // namespace
+
+template <bool ignoreNullKeys>
+void HashTable<ignoreNullKeys>::insertForJoinParallel(
+    char** allRows,
+    const uint64_t* hashes,
+    uint64_t numRows,
+    folly::Executor* executor,
+    int32_t numPartitions) {
+  VELOX_CHECK_GT(numPartitions, 0);
+  VELOX_CHECK_NE(
+      hashMode_,
+      HashMode::kArray,
+      "kArray mode inserts by value id and cannot be partitioned by bucket");
+
+  const auto insertRange = [&](char** rows,
+                               const uint64_t* rowHashes,
+                               uint64_t count,
+                               TableInsertPartitionInfo* partitionInfo) {
+    for (uint64_t offset = 0; offset < count; offset += kHashBatchSize) {
+      const auto batch = static_cast<int32_t>(
+          std::min<uint64_t>(kHashBatchSize, count - offset));
+      insertForJoin(rows + offset, rowHashes + offset, batch, partitionInfo);
+    }
+  };
+
+  if (numPartitions == 1 || executor == nullptr) {
+    insertRange(allRows, hashes, numRows, nullptr);
+    return;
+  }
+
+  // Same bucket range partitioning as parallelJoinBuild(): a row's home bucket
+  // determines its partition, so two partitions never write the same bucket.
+  // The bounds are cache line aligned, and the tail is the whole table.
+  std::vector<PartitionBoundIndexType> bounds(numPartitions + 1);
+  for (int32_t i = 0; i < numPartitions; ++i) {
+    bounds[i] =
+        bits::roundUp(((sizeMask_ + 1) / numPartitions) * i, kBucketSize);
+    VELOX_CHECK_GE(
+        bounds[i],
+        0,
+        "Turn on VELOX_ENABLE_INT64_BUILD_PARTITION_BOUND to avoid integer overflow in partition bounds");
+  }
+  bounds[numPartitions] = sizeMask_ + 1;
+
+  std::vector<std::vector<char*>> overflows(numPartitions);
+  std::vector<std::vector<uint64_t>> overflowHashes(numPartitions);
+
+  runParallel(executor, numPartitions, [&](size_t partition) {
+    TableInsertPartitionInfo partitionInfo{
+        bounds[partition],
+        bounds[partition + 1],
+        overflows[partition],
+        overflowHashes[partition]};
+    // Each worker scans all the hashes and keeps the rows that are its own.
+    // Rescanning the hash array per partition costs a sequential read of 8
+    // bytes per row, which is cheaper than materializing per-partition row
+    // lists and needs no shared state.
+    raw_vector<char*> batchRows(kHashBatchSize, pool_);
+    raw_vector<uint64_t> batchHashes(kHashBatchSize, pool_);
+    int32_t numBatched{0};
+    for (uint64_t i = 0; i < numRows; ++i) {
+      const auto index = bucketOffset(hashes[i]);
+      if (!partitionInfo.inRange(index)) {
+        continue;
+      }
+      batchRows[numBatched] = allRows[i];
+      batchHashes[numBatched] = hashes[i];
+      if (++numBatched == kHashBatchSize) {
+        insertForJoin(
+            batchRows.data(), batchHashes.data(), numBatched, &partitionInfo);
+        numBatched = 0;
+      }
+    }
+    if (numBatched > 0) {
+      insertForJoin(
+          batchRows.data(), batchHashes.data(), numBatched, &partitionInfo);
+    }
+  });
+
+  // Serially re-insert the rows that probed past the end of their partition.
+  // Their hashes were kept, so this does not re-hash.
+  for (int32_t i = 0; i < numPartitions; ++i) {
+    VELOX_CHECK_EQ(overflows[i].size(), overflowHashes[i].size());
+    insertRange(
+        overflows[i].data(),
+        overflowHashes[i].data(),
+        overflows[i].size(),
+        nullptr);
+  }
+}
+
+template <bool ignoreNullKeys>
+const typename HashTable<ignoreNullKeys>::SerializationPlan&
+HashTable<ignoreNullKeys>::ensureSerializationPlan() const {
+  // A join build RowContainer holds all build rows, which exceeds
+  // 'numDistinct_' when duplicate keys exist, and parallel build spreads the
+  // rows over 'otherTables_'. All of them have to be serialized.
+  std::vector<RowContainer*> containers;
+  containers.reserve(1 + otherTables_.size());
+  if (rows_ != nullptr && rows_->numRows() > 0) {
+    containers.push_back(rows_.get());
+  }
+  for (const auto& other : otherTables_) {
+    if (other->rows() != nullptr && other->rows()->numRows() > 0) {
+      containers.push_back(other->rows());
+    }
+  }
+
+  uint64_t totalRows{0};
+  for (const auto* container : containers) {
+    totalRows += container->numRows();
+  }
+
+  if (serializationPlan_ != nullptr &&
+      serializationPlan_->totalRows == totalRows) {
+    return *serializationPlan_;
+  }
+
+  auto plan = std::make_unique<SerializationPlan>(pool_);
+  plan->totalRows = totalRows;
+
+  // The types and the hasher states go on the wire verbatim, so both passes
+  // write the same bytes. Producing them is not free - a hasher state carries
+  // one entry per distinct key value - so they are built here instead of in
+  // each pass.
+  plan->keyTypes.reserve(hashers_.size());
+  plan->hasherStates.reserve(hashers_.size());
+  for (const auto& hasher : hashers_) {
+    plan->keyTypes.push_back(serializeType(*hasher->type()));
+    plan->hasherStates.push_back(hasher->serializeState());
+  }
+
+  // The key columns come first in the RowContainer, so the remaining ones are
+  // the dependent columns.
+  const auto& columnTypes = rows_->columnTypes();
+  VELOX_CHECK_GE(columnTypes.size(), hashers_.size());
+  plan->dependentTypes.reserve(columnTypes.size() - hashers_.size());
+  for (auto i = hashers_.size(); i < columnTypes.size(); ++i) {
+    plan->dependentTypes.push_back(serializeType(*columnTypes[i]));
+  }
+
+  if (totalRows == 0) {
+    serializationPlan_ = std::move(plan);
+    return *serializationPlan_;
+  }
+
+  // The rows, hashes and normalized keys sections share one row order, so list
+  // the build rows once.
+  plan->rows.resize(totalRows);
+  uint64_t numListed{0};
+  for (auto* container : containers) {
+    RowContainerIterator iter;
+    const auto listed = container->listRows(
+        &iter, container->numRows(), plan->rows.data() + numListed);
+    VELOX_CHECK_EQ(listed, container->numRows(), "Failed to list build rows");
+    numListed += listed;
+  }
+  VELOX_CHECK_EQ(numListed, totalRows, "Build row count mismatch");
+
+  // Chop the rows into sections. A section never spans containers, since the
+  // reading side fills each one from a single RowContainer, and a container
+  // holding many rows is split further so that the reading side can use all
+  // its threads even when the writing side built the table with few
+  // containers.
+  const auto rowsPerSection = std::max<uint64_t>(
+      kSerializedSectionRows,
+      (totalRows + kMaxSerializedSections - 1) / kMaxSerializedSections);
+  uint64_t firstRow{0};
+  for (auto* container : containers) {
+    const uint64_t containerRows = container->numRows();
+    for (uint64_t offset = 0; offset < containerRows;
+         offset += rowsPerSection) {
+      const auto numRows = std::min(rowsPerSection, containerRows - offset);
+      const auto numBytes = container->serializedRowsSize(
+          folly::Range<char**>(plan->rows.data() + firstRow + offset, numRows));
+      plan->sections.push_back(
+          SerializedSection{firstRow + offset, numRows, numBytes});
+      plan->sectionContainers.push_back(container);
+      plan->rowBytes += numBytes;
+    }
+    firstRow += containerRows;
+  }
+  VELOX_CHECK_EQ(firstRow, totalRows);
+
+  serializationPlan_ = std::move(plan);
+  return *serializationPlan_;
+}
+
+template <bool ignoreNullKeys>
+template <typename Writer>
+void HashTable<ignoreNullKeys>::serializeImpl(
+    Writer& writer,
+    const SerializationPlan& plan) const {
+  VELOX_CHECK(isJoinBuild_, "Only join-build hash tables are supported");
+  // Everything the format does not carry has to be rejected here rather than
+  // silently dropped. Accumulators have no serialized form, and per-row counts
+  // cannot be restored by replaying the insert: a counting build leaves the
+  // rows it folded into another row in the RowContainer, so re-inserting all
+  // of them would count them twice.
+  VELOX_CHECK(
+      rows_->accumulators().empty(),
+      "Serializing a hash table with accumulators is not supported");
+  VELOX_CHECK_EQ(
+      rows_->countOffset(),
+      0,
+      "Serializing a counting join build side is not supported");
+
+  const auto totalRows = plan.totalRows;
+  // The slot array is not part of the serialized form, so a table built with
+  // setBuildForSerializationOnly() legitimately has none. What is required is
+  // that the hash mode and the VectorHasher state have been settled, i.e. that
+  // prepareJoinTable() has run, which is what 'capacity_' witnesses.
+  VELOX_CHECK(
+      totalRows == 0 || table_ != nullptr || buildForSerializationOnly_,
+      "Serialization requires a prepared join table");
+  VELOX_CHECK(
+      totalRows == 0 || capacity_ > 0,
+      "Serialization requires a prepared join table");
+
+  VLOG(1) << "Serializing HashTable: "
+          << const_cast<HashTable<ignoreNullKeys>*>(this)->toString();
+
+  auto writeValue = [&](auto value) { writer.writeValue(value); };
+  auto writeString = [&](const std::string& value) {
+    writeValue(static_cast<uint32_t>(value.size()));
+    writer.write(value.data(), value.size());
+  };
+
+  writeValue(kSerializedTableMagic);
+  writeValue(kSerializedTableVersion);
+
+  // Serialize base metadata, including all constructor parameters.
+  writeValue(static_cast<bool>(ignoreNullKeys));
+  writeValue(allowDuplicates_);
+  writeValue(isJoinBuild_);
+  writeValue(minTableSizeForParallelJoinBuild_);
+  writeValue(bloomFilterMaxSize_);
+  writeValue(hasDuplicates_.check());
+  writeValue(numDistinct_);
+  writeValue(static_cast<int32_t>(hashMode_));
+  writeValue(capacity_);
+  writeValue(rows_->probedFlagOffset() != 0);
+
+  // Serialize the key types and their input channels.
+  writeValue(static_cast<uint32_t>(plan.keyTypes.size()));
+  for (auto i = 0; i < plan.keyTypes.size(); ++i) {
+    writeString(plan.keyTypes[i]);
+    writeValue(hashers_[i]->channel());
+  }
+
+  // Serialize the dependent column types.
+  writeValue(static_cast<uint32_t>(plan.dependentTypes.size()));
+  for (const auto& type : plan.dependentTypes) {
+    writeString(type);
+  }
+
+  // 'columnHasNulls_' is a bit-packed std::vector<bool> with no contiguous
+  // storage to write from, so it goes on the wire as one byte per column.
+  writeValue(static_cast<uint32_t>(columnHasNulls_.size()));
+  if constexpr (Writer::kSizeOnly) {
+    writer.reserve(columnHasNulls_.size());
+  } else {
+    auto* destination = writer.reserve(columnHasNulls_.size());
+    for (auto i = 0; i < columnHasNulls_.size(); ++i) {
+      destination[i] = columnHasNulls_[i] ? 1 : 0;
+    }
+  }
+
+  // Serialize the VectorHasher value id state, which the probe side needs in
+  // order to map probe keys to the same value ids as the build side.
+  for (const auto& state : plan.hasherStates) {
+    writeString(state);
+  }
+
+  writeValue(totalRows);
+  if (totalRows == 0) {
+    writer.flush();
+    return;
+  }
+
+  // The row blob is chopped into sections that the reading side can decode in
+  // parallel. Neither a section's row count nor its byte count can be derived
+  // from the bytes without walking them, so both go on the wire;
+  // storeSerializedRow() consumes exactly one row's bytes, so per-row lengths
+  // stay off it.
+  const auto& sections = plan.sections;
+  writeValue(static_cast<uint32_t>(sections.size()));
+  for (const auto& section : sections) {
+    writeValue(section.numRows);
+    writeValue(section.numBytes);
+  }
+
+  writeValue(plan.rowBytes);
+  if constexpr (Writer::kSizeOnly) {
+    writer.reserve(plan.rowBytes);
+  } else {
+    auto* destination = writer.reserve(plan.rowBytes);
+    size_t written{0};
+    for (size_t i = 0; i < sections.size(); ++i) {
+      const auto& section = sections[i];
+      const auto sectionBytes = plan.sectionContainers[i]->serializeRows(
+          folly::Range<char**>(
+              plan.rows.data() + section.firstRow, section.numRows),
+          destination + written,
+          nullptr);
+      VELOX_CHECK_EQ(
+          sectionBytes, section.numBytes, "Serialized section size mismatch");
+      written += sectionBytes;
+    }
+    VELOX_CHECK_EQ(written, plan.rowBytes, "Serialized row size mismatch");
+  }
+
+  // The hashes only go on the wire in kHash mode. In kNormalizedKey mode they
+  // are mixNormalizedKey() of the normalized keys written below, which the
+  // reading side recomputes for a fraction of the cost of shipping another 8
+  // bytes per row; in kArray mode deserialization recomputes the value ids
+  // from the restored VectorHasher state.
+  if (hashMode_ == HashMode::kHash) {
+    const auto hashBytes = totalRows * sizeof(uint64_t);
+    if constexpr (Writer::kSizeOnly) {
+      writer.reserve(hashBytes);
+    } else {
+      raw_vector<uint64_t> hashes(totalRows, pool_);
+      // hashRows() only fails when it cannot produce value ids, which happens
+      // in kArray mode alone.
+      VELOX_CHECK(
+          const_cast<HashTable<ignoreNullKeys>*>(this)->hashRows(
+              folly::Range<char**>(plan.rows.data(), totalRows), false, hashes),
+          "Failed to hash build rows for serialization");
+      writer.write(hashes.data(), hashBytes);
+    }
+  }
+
+  // Normalized keys live below the row start and are not part of the
+  // serialized row bytes.
+  if (hashMode_ == HashMode::kNormalizedKey) {
+    const auto keyBytes = totalRows * sizeof(normalized_key_t);
+    if constexpr (Writer::kSizeOnly) {
+      writer.reserve(keyBytes);
+    } else {
+      auto* destination = writer.reserve(keyBytes);
+      for (uint64_t i = 0; i < totalRows; ++i) {
+        const auto key = RowContainer::normalizedKey(plan.rows[i]);
+        ::memcpy(destination + i * sizeof(key), &key, sizeof(key));
+      }
+    }
+  }
+
+  // Flush explicitly so write failures surface at the serialization call site.
+  writer.flush();
+}
+
+template <bool ignoreNullKeys>
+size_t HashTable<ignoreNullKeys>::serializedSize() const {
+  SizeCountingWriter writer;
+  serializeImpl(writer, ensureSerializationPlan());
+  return writer.size();
+}
+
+template <bool ignoreNullKeys>
+void HashTable<ignoreNullKeys>::serializeTo(void* data, size_t size) const {
+  MemoryWriter writer(data, size);
+  serializeImpl(writer, ensureSerializationPlan());
+  VELOX_CHECK_EQ(
+      writer.writtenSize(), size, "Hash table serialized size mismatch");
+  // The plan pins one pointer per build row plus the measured section sizes,
+  // which are only valid while the table is unchanged. Drop them now that they
+  // have been consumed instead of holding tens of MB for the table's lifetime.
+  serializationPlan_.reset();
+}
+
+template <bool ignoreNullKeys>
+std::unique_ptr<HashTable<ignoreNullKeys>>
+HashTable<ignoreNullKeys>::deserializeFrom(
+    const void* data,
+    size_t size,
+    memory::MemoryPool* pool,
+    folly::Executor* executor) {
+  VELOX_CHECK_NOT_NULL(data, "Serialized hash table data cannot be null");
+  common::NativeStringReader reader(
+      std::string_view(static_cast<const char*>(data), size));
+
+  const auto header = readTableHeader(reader, ignoreNullKeys);
+  const auto hashMode = header.hashMode;
+  const auto capacity = header.capacity;
+
+  auto table = makeDeserializedTable<ignoreNullKeys>(header, pool);
+  if (header.hasDuplicates) {
+    table->hasDuplicates_.set();
+  }
+  table->columnHasNulls_ = header.columnHasNulls;
+  for (auto i = 0; i < header.hasherStates.size(); ++i) {
+    table->hashers_[i]->deserializeState(header.hasherStates[i]);
+  }
+
+  // The mode drives the probe path. Setting it here is safe because the rows
+  // below are decoded through RowContainer, which does not consult it, whereas
+  // disableNormalizedKeys() has to wait until the rows exist.
+  table->hashMode_ = hashMode;
+
+  const auto totalRows = reader.readValue<uint64_t>();
+  if (totalRows > 0) {
+    raw_vector<char*> rows(totalRows, pool);
+    raw_vector<uint64_t> hashes(pool);
+    // Row sections beyond the first are decoded into tables of their own,
+    // which is what lets the decode run in parallel: a RowContainer cannot be
+    // appended to from several threads. This is the same shape a parallel join
+    // build leaves behind, so the probe side handles it as usual.
+    std::vector<std::unique_ptr<HashTable<ignoreNullKeys>>> extraTables;
+    std::vector<SerializedSection> sections;
+
+    const auto numSections = reader.readValue<uint32_t>();
+    VELOX_CHECK_GT(
+        numSections, 0, "Serialized hash table has rows but no row sections");
+    sections.resize(numSections);
+    uint64_t firstRow{0};
+    uint64_t sectionBytes{0};
+    for (uint32_t i = 0; i < numSections; ++i) {
+      sections[i].firstRow = firstRow;
+      sections[i].numRows = reader.readValue<uint64_t>();
+      sections[i].numBytes = reader.readValue<uint64_t>();
+      VELOX_CHECK_LE(
+          sections[i].numRows,
+          std::numeric_limits<vector_size_t>::max(),
+          "Serialized row section is too large");
+      firstRow += sections[i].numRows;
+      sectionBytes += sections[i].numBytes;
+    }
+    VELOX_CHECK_EQ(
+        firstRow, totalRows, "Serialized section row counts do not add up");
+
+    const auto rowBytes = reader.readValue<uint64_t>();
+    VELOX_CHECK_EQ(
+        sectionBytes, rowBytes, "Serialized section byte counts do not add up");
+    const auto rowData = reader.view(rowBytes);
+
+    std::vector<RowContainer*> sectionRows(numSections);
+    sectionRows[0] = table->rows_.get();
+    extraTables.reserve(numSections - 1);
+    for (uint32_t i = 1; i < numSections; ++i) {
+      auto sectionTable = makeDeserializedTable<ignoreNullKeys>(header, pool);
+      sectionRows[i] = sectionTable->rows_.get();
+      extraTables.push_back(std::move(sectionTable));
+    }
+
+    uint64_t byteOffset{0};
+    std::vector<uint64_t> sectionByteOffsets(numSections);
+    for (uint32_t i = 0; i < numSections; ++i) {
+      sectionByteOffsets[i] = byteOffset;
+      byteOffset += sections[i].numBytes;
+    }
+
+    runParallel(executor, numSections, [&](size_t i) {
+      const auto& section = sections[i];
+      const auto consumed = sectionRows[i]->storeSerializedRows(
+          std::string_view(
+              rowData.data() + sectionByteOffsets[i], section.numBytes),
+          static_cast<vector_size_t>(section.numRows),
+          rows.data() + section.firstRow);
+      VELOX_CHECK_EQ(
+          consumed, section.numBytes, "Serialized row data size mismatch");
+    });
+
+    std::string_view normalizedKeys;
+    if (hashMode == HashMode::kHash) {
+      hashes.resize(totalRows);
+      reader.read(hashes.data(), totalRows * sizeof(uint64_t));
+      // The rows are in place, so the normalized key prefix this mode has no
+      // use for can be dropped now.
+      table->rows_->disableNormalizedKeys();
+      for (auto& extra : extraTables) {
+        extra->rows()->disableNormalizedKeys();
+      }
+    } else if (hashMode == HashMode::kNormalizedKey) {
+      normalizedKeys = reader.view(totalRows * sizeof(normalized_key_t));
+    }
+    table->otherTables_ = std::move(extraTables);
+
+    if (hashMode == HashMode::kArray) {
+      table->capacity_ = capacity;
+      const auto bytes = table->capacity_ * tableSlotSize();
+      const auto numPages = memory::AllocationTraits::numPages(bytes);
+      table->rows_->pool()->allocateContiguous(
+          numPages, table->tableAllocation_);
+      table->table_ = table->tableAllocation_.template data<char*>();
+      memset(table->table_, 0, bytes);
+
+      // Recompute the value ids from the restored VectorHasher state. The
+      // array slot is the value id itself, so this cannot be partitioned by
+      // bucket range the way the other modes are.
+      raw_vector<uint64_t> valueIds(totalRows, pool);
+      VELOX_CHECK(
+          table->hashRows(
+              folly::Range<char**>(rows.data(), totalRows), false, valueIds),
+          "Failed to compute value ids in kArray mode during deserialization");
+      table->insertForJoin(rows.data(), valueIds.data(), totalRows, nullptr);
+    } else {
+      table->allocateTables(capacity, kNoSpillInputStartPartitionBit);
+
+      if (hashMode == HashMode::kNormalizedKey) {
+        // Restore the normalized keys and derive the hashes from them. This
+        // needs 'sizeBits_', hence the allocateTables() above; the writing
+        // side derived the serialized hashes the same way from the same
+        // 'capacity_'.
+        hashes.resize(totalRows);
+        runParallel(executor, sections.size(), [&](size_t i) {
+          const auto& section = sections[i];
+          for (uint64_t row = section.firstRow;
+               row < section.firstRow + section.numRows;
+               ++row) {
+            normalized_key_t key;
+            ::memcpy(
+                &key, normalizedKeys.data() + row * sizeof(key), sizeof(key));
+            RowContainer::normalizedKey(rows[row]) = key;
+            hashes[row] = mixNormalizedKey(key, table->sizeBits_);
+          }
+        });
+      }
+
+      table->insertForJoinParallel(
+          rows.data(),
+          hashes.data(),
+          totalRows,
+          executor,
+          numInsertPartitions(
+              capacity,
+              header.minTableSizeForParallelJoinBuild,
+              sections.size()));
+    }
+  }
+
+  VELOX_CHECK(
+      reader.atEnd(), "Trailing bytes after hash table deserialization");
+
+  // insertForJoin() does not maintain 'numDistinct_'.
+  table->numDistinct_ = header.numDistinct;
+  VLOG(1) << "Deserialized HashTable: " << table->toString();
+
+  return table;
+}
+
+template size_t HashTable<true>::serializedSize() const;
+template size_t HashTable<false>::serializedSize() const;
+
+template void HashTable<true>::serializeTo(void* data, size_t size) const;
+template void HashTable<false>::serializeTo(void* data, size_t size) const;
+
+template std::unique_ptr<HashTable<true>> HashTable<true>::deserializeFrom(
+    const void* data,
+    size_t size,
+    memory::MemoryPool* pool,
+    folly::Executor* executor);
+template std::unique_ptr<HashTable<false>> HashTable<false>::deserializeFrom(
+    const void* data,
+    size_t size,
+    memory::MemoryPool* pool,
+    folly::Executor* executor);
 
 } // namespace facebook::velox::exec

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -780,6 +780,23 @@ class HashTable : public BaseHashTable {
   /// are left till the end of the table.
   std::string toString(int64_t startBucket, int64_t numBuckets = 1) const;
 
+  /// Returns the exact serialized size in bytes for the current hash table.
+  size_t serializedSize() const;
+
+  /// Serializes the hash table directly to a caller-provided memory buffer.
+  /// @param data Destination buffer
+  /// @param size Size of destination buffer in bytes. Must equal
+  /// serializedSize().
+  void serializeTo(void* data, size_t size) const;
+
+  /// Deserializes the hash table directly from a contiguous memory buffer.
+  /// @param data Serialized hash table bytes
+  /// @param size Serialized hash table size in bytes
+  /// @param pool Memory pool for allocating deserialized data
+  /// @return A new HashTable instance with deserialized data
+  static std::unique_ptr<HashTable<ignoreNullKeys>>
+  deserializeFrom(const void* data, size_t size, memory::MemoryPool* pool);
+
   /// Invoked to check the consistency of the internal state. The function scans
   /// all the table slots to check if the relevant slot counting are correct
   /// such as the number of used slots ('numDistinct_') and the number of
@@ -814,6 +831,14 @@ class HashTable : public BaseHashTable {
   }
 
  private:
+  template <typename Writer>
+  void serializeImpl(Writer& writer) const;
+
+  template <typename Reader>
+  static std::unique_ptr<HashTable<ignoreNullKeys>> deserializeImpl(
+      Reader& reader,
+      memory::MemoryPool* pool);
+
   // Enables debug stats for collisions for debug build.
 #ifdef NDEBUG
   static constexpr bool kTrackLoads = false;

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -447,6 +447,28 @@ class BaseHashTable {
   /// be deduplicated, but it will not impact the containing row container.
   virtual void setAllowDuplicates(bool allowDuplicates) = 0;
 
+  /// Marks this table as being built only in order to be serialized with
+  /// serializeTo(), never probed in this process. Must be set before
+  /// prepareJoinTable().
+  ///
+  /// serializeTo() does not write the slot array: it holds absolute pointers
+  /// into the row container, which are meaningless in the process that reads
+  /// the table back, so deserializeFrom() allocates the slot array and inserts
+  /// the build rows into it itself. Building the slot array here as well is
+  /// therefore pure duplicated work, and for a large build side it is a
+  /// substantial part of both the build time and the peak memory.
+  ///
+  /// Everything that does go on the wire is still produced: the hash mode
+  /// decision, the VectorHasher value id state, the normalized keys written
+  /// into the rows, and the bloom filters.
+  void setBuildForSerializationOnly(bool value) {
+    buildForSerializationOnly_ = value;
+  }
+
+  bool buildForSerializationOnly() const {
+    return buildForSerializationOnly_;
+  }
+
   /// Returns the memory footprint in bytes for any data structures
   /// owned by 'this'.
   virtual int64_t allocatedBytes() const = 0;
@@ -591,6 +613,9 @@ class BaseHashTable {
 
   std::vector<std::unique_ptr<VectorHasher>> hashers_;
   std::unique_ptr<RowContainer> rows_;
+
+  // See setBuildForSerializationOnly().
+  bool buildForSerializationOnly_{false};
 
   ParallelJoinBuildStats parallelJoinBuildStats_;
   CpuWallTiming vectorHasherMergeTiming_;
@@ -848,6 +873,39 @@ class HashTable : public BaseHashTable {
   /// are left till the end of the table.
   std::string toString(int64_t startBucket, int64_t numBuckets = 1) const;
 
+  /// Returns the exact serialized size in bytes for the current hash table.
+  ///
+  /// Listing the build rows, measuring their variable-width columns and
+  /// producing the VectorHasher state is the bulk of the cost and is the same
+  /// work serializeTo() needs, so the result is cached and reused by a
+  /// following serializeTo(), which then drops it.
+  ///
+  /// The table must not change in between: the cache is keyed on the row
+  /// count, which catches rows being added or removed but not rows being
+  /// replaced.
+  size_t serializedSize() const;
+
+  /// Serializes the hash table directly to a caller-provided memory buffer.
+  /// @param data Destination buffer
+  /// @param size Size of destination buffer in bytes. Must equal
+  /// serializedSize().
+  void serializeTo(void* data, size_t size) const;
+
+  /// Deserializes the hash table directly from a contiguous memory buffer.
+  /// @param data Serialized hash table bytes
+  /// @param size Serialized hash table size in bytes
+  /// @param pool Memory pool for allocating deserialized data
+  /// @param executor If given, the build rows are decoded and inserted into
+  /// the slot array on this executor rather than on the calling thread. The
+  /// serialized form carries the rows in independent sections precisely so
+  /// that this can be done in parallel; see kSerializedTableVersion.
+  /// @return A new HashTable instance with deserialized data
+  static std::unique_ptr<HashTable<ignoreNullKeys>> deserializeFrom(
+      const void* data,
+      size_t size,
+      memory::MemoryPool* pool,
+      folly::Executor* executor = nullptr);
+
   /// Invoked to check the consistency of the internal state. The function scans
   /// all the table slots to check if the relevant slot counting are correct
   /// such as the number of used slots ('numDistinct_') and the number of
@@ -882,6 +940,61 @@ class HashTable : public BaseHashTable {
   }
 
  private:
+  // One independently decodable run of build rows in the serialized form. The
+  // reading side gives each section its own RowContainer so that the sections
+  // can be decoded in parallel, which is why a section records both its row
+  // count and its byte count: neither can be derived from the row bytes
+  // without walking them.
+  struct SerializedSection {
+    // Index of the first row of this section in SerializationPlan::rows.
+    uint64_t firstRow;
+    uint64_t numRows;
+    uint64_t numBytes;
+  };
+
+  // Everything serializeImpl() needs that is not a plain member read, shared
+  // by the size-counting and the buffer-filling pass. See serializedSize().
+  struct SerializationPlan {
+    explicit SerializationPlan(memory::MemoryPool* pool) : rows(pool) {}
+
+    // The key types and the non-key column types in their serialized form.
+    std::vector<std::string> keyTypes;
+    std::vector<std::string> dependentTypes;
+    // The VectorHasher value id state, one per key. Producing it walks every
+    // distinct key value, so it is built here rather than in each pass.
+    std::vector<std::string> hasherStates;
+    // The build rows of all containers, section by section.
+    raw_vector<char*> rows;
+    // The container each section's rows live in, 1:1 with 'sections'.
+    std::vector<RowContainer*> sectionContainers;
+    std::vector<SerializedSection> sections;
+    uint64_t totalRows{0};
+    uint64_t rowBytes{0};
+  };
+
+  // Returns the cached serialization plan, computing it if absent or stale.
+  const SerializationPlan& ensureSerializationPlan() const;
+
+  // Writes the serialized form to 'writer'. 'Writer' is either a writer that
+  // only counts the bytes, for serializedSize(), or one that fills in a
+  // destination buffer, for serializeTo().
+  template <typename Writer>
+  void serializeImpl(Writer& writer, const SerializationPlan& plan) const;
+
+  // Inserts 'numRows' rows with the given precomputed 'hashes' into the slot
+  // array using 'executor'. Each worker owns a disjoint range of bucket
+  // offsets and picks the rows whose home bucket falls in its range, so no two
+  // workers touch the same bucket; the few rows that probe past the end of
+  // their range are collected and re-inserted serially at the end. This is the
+  // same partitioning parallelJoinBuild() uses, but driven off flat row and
+  // hash arrays, which is what deserializeFrom() has.
+  void insertForJoinParallel(
+      char** rows,
+      const uint64_t* hashes,
+      uint64_t numRows,
+      folly::Executor* executor,
+      int32_t numPartitions);
+
   // Enables debug stats for collisions for debug build.
 #ifdef NDEBUG
   static constexpr bool kTrackLoads = false;
@@ -1357,6 +1470,10 @@ class HashTable : public BaseHashTable {
 
   //  Counts parallel build rows. Used for consistency check.
   std::atomic<int64_t> numParallelBuildRows_{0};
+
+  // Cached result of the row-listing and row-measuring work shared by
+  // serializedSize() and serializeTo(). See serializedSize().
+  mutable std::unique_ptr<SerializationPlan> serializationPlan_;
 
   // If true, avoids using VectorHasher value ranges with kArray hash mode.
   bool disableRangeArrayHash_{false};

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -735,7 +735,9 @@ void RowContainer::extractSerializedRows(
     size_t offset = 0;
 
     // Copy nulls and other flags.
-    ::memcpy(rawBuffer + offset, row + rowColumns_[0].nullByte(), flagBytes_);
+    const auto flagsOffset =
+        nullOffsets_.empty() ? freeFlagOffset_ / 8 : nullByte(nullOffsets_[0]);
+    ::memcpy(rawBuffer + offset, row + flagsOffset, flagBytes_);
     offset += flagBytes_;
 
     // Copy values.
@@ -765,9 +767,16 @@ void RowContainer::storeSerializedRow(
     char* row) {
   VELOX_CHECK(!vector.isNullAt(index));
   const auto serialized = vector.valueAt(index);
+  storeSerializedRow(
+      std::string_view(serialized.data(), serialized.size()), row);
+}
+
+void RowContainer::storeSerializedRow(std::string_view serialized, char* row) {
   size_t offset = 0;
 
-  ::memcpy(row + rowColumns_[0].nullByte(), serialized.data(), flagBytes_);
+  const auto flagsOffset =
+      nullOffsets_.empty() ? freeFlagOffset_ / 8 : nullByte(nullOffsets_[0]);
+  ::memcpy(row + flagsOffset, serialized.data(), flagBytes_);
   offset += flagBytes_;
 
   RowSizeTracker tracker(row[rowSizeOffset_], *stringAllocator_);
@@ -783,6 +792,10 @@ void RowContainer::storeSerializedRow(
     }
     updateColumnStats(row, i);
   }
+  VELOX_CHECK_EQ(
+      offset,
+      serialized.size(),
+      "Serialized row size mismatch while storing RowContainer row");
 }
 
 void RowContainer::extractString(

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -506,6 +506,11 @@ void RowContainer::updateColumnStats(
 }
 
 void RowContainer::updateColumnStats(char* row, int32_t columnIndex) {
+  if (rowColumnsStats_.empty()) {
+    // Column stats have been invalidated.
+    return;
+  }
+
   const bool nullColumn = isNullAt(row, rowColumns_[columnIndex]);
 
   auto& columnStats = rowColumnsStats_[columnIndex];
@@ -688,6 +693,89 @@ int32_t RowContainer::storeVariableSizeAt(
   return 4 + size;
 }
 
+std::optional<size_t> RowContainer::fixedSerializedRowSize() const {
+  size_t rowSize = flagBytes_;
+  for (const auto& type : types_) {
+    if (!type->isFixedWidth()) {
+      return std::nullopt;
+    }
+    rowSize += typeKindSize(type->kind());
+  }
+  return rowSize;
+}
+
+size_t RowContainer::serializedRowsSize(folly::Range<char**> rows) const {
+  if (const auto rowSize = fixedSerializedRowSize()) {
+    return rowSize.value() * rows.size();
+  }
+
+  size_t fixedWidthRowSize = flagBytes_;
+  std::vector<column_index_t> variableWidthColumns;
+  for (auto i = 0; i < types_.size(); ++i) {
+    if (types_[i]->isFixedWidth()) {
+      fixedWidthRowSize += typeKindSize(types_[i]->kind());
+    } else {
+      variableWidthColumns.push_back(i);
+    }
+  }
+
+  size_t totalBytes = fixedWidthRowSize * rows.size();
+  for (const char* row : rows) {
+    for (const auto column : variableWidthColumns) {
+      // 4 bytes for size + N bytes for data.
+      totalBytes += 4 + variableSizeAt(row, column);
+    }
+  }
+  return totalBytes;
+}
+
+std::vector<RowContainer::SerializedColumn> RowContainer::serializedColumns()
+    const {
+  std::vector<SerializedColumn> layout;
+  layout.reserve(types_.size());
+  for (auto i = 0; i < types_.size(); ++i) {
+    layout.push_back(
+        {rowColumns_[i].offset(),
+         types_[i]->isFixedWidth()
+             ? static_cast<int32_t>(typeKindSize(types_[i]->kind()))
+             : 0});
+  }
+  return layout;
+}
+
+size_t RowContainer::serializeRows(
+    folly::Range<char**> rows,
+    char* destination,
+    vector_size_t* rowSizes) const {
+  const auto layout = serializedColumns();
+  auto* current = destination;
+  for (auto i = 0; i < rows.size(); ++i) {
+    const auto* row = rows[i];
+    auto* rowStart = current;
+
+    // Copy nulls and other flags.
+    ::memcpy(current, row + flagsByteOffset_, flagBytes_);
+    current += flagBytes_;
+
+    // Copy values.
+    for (auto column = 0; column < layout.size(); ++column) {
+      if (layout[column].fixedSize != 0) {
+        ::memcpy(
+            current, row + layout[column].offset, layout[column].fixedSize);
+        current += layout[column].fixedSize;
+      } else {
+        current += extractVariableSizeAt(row, column, current);
+      }
+    }
+
+    if (rowSizes != nullptr) {
+      rowSizes[i] = static_cast<vector_size_t>(current - rowStart);
+    }
+  }
+
+  return static_cast<size_t>(current - destination);
+}
+
 void RowContainer::extractSerializedRows(
     folly::Range<char**> rows,
     const VectorPtr& result) const {
@@ -695,68 +783,20 @@ void RowContainer::extractSerializedRows(
   // dependent columns. Fixed-width columns are serialized into fixed number of
   // bytes (see typeKindSize). Variable-width columns are serialized as 4 bytes
   // of size followed by that many bytes.
+  const auto totalBytes = serializedRowsSize(rows);
 
-  // First, calculate total number of bytes needed to serialize all rows.
-
-  size_t fixedWidthRowSize = 0;
-  bool hasVariableWidth = false;
-  for (auto i = 0; i < types_.size(); ++i) {
-    const auto& type = types_[i];
-    if (type->isFixedWidth()) {
-      fixedWidthRowSize += typeKindSize(type->kind());
-    } else {
-      hasVariableWidth = true;
-    }
-  }
-
-  size_t totalBytes =
-      flagBytes_ * rows.size() + fixedWidthRowSize * rows.size();
-  if (hasVariableWidth) {
-    for (const char* row : rows) {
-      for (auto i = 0; i < types_.size(); ++i) {
-        const auto& type = types_[i];
-        if (!type->isFixedWidth()) {
-          // 4 bytes for size + N bytes for data.
-          totalBytes += 4 + variableSizeAt(row, i);
-        }
-      }
-    }
-  }
-
-  // Allocate sufficient buffer.
   auto* flatResult = result->as<FlatVector<StringView>>();
   flatResult->resize(rows.size());
   auto* rawBuffer = flatResult->getRawStringBufferWithSpace(totalBytes, true);
 
-  // Write serialized data.
-  size_t totalWritten = 0;
-  for (auto i = 0; i < rows.size(); ++i) {
-    auto* row = rows[i];
-    size_t offset = 0;
-
-    // Copy nulls and other flags.
-    ::memcpy(rawBuffer + offset, row + flagsByteOffset_, flagBytes_);
-    offset += flagBytes_;
-
-    // Copy values.
-    for (auto j = 0; j < types_.size(); ++j) {
-      const auto& type = types_[j];
-      if (type->isFixedWidth()) {
-        const auto size = typeKindSize(type->kind());
-        ::memcpy(rawBuffer + offset, row + rowColumns_[j].offset(), size);
-        offset += size;
-      } else {
-        auto size = extractVariableSizeAt(row, j, rawBuffer + offset);
-        offset += size;
-      }
-    }
-
-    flatResult->setNoCopy(i, StringView(rawBuffer, offset));
-    rawBuffer += offset;
-    totalWritten += offset;
-  }
-
+  std::vector<vector_size_t> rowSizes(rows.size());
+  const auto totalWritten = serializeRows(rows, rawBuffer, rowSizes.data());
   VELOX_CHECK_EQ(totalWritten, totalBytes);
+
+  for (auto i = 0; i < rows.size(); ++i) {
+    flatResult->setNoCopy(i, StringView(rawBuffer, rowSizes[i]));
+    rawBuffer += rowSizes[i];
+  }
 }
 
 void RowContainer::storeSerializedRow(
@@ -765,6 +805,17 @@ void RowContainer::storeSerializedRow(
     char* row) {
   VELOX_CHECK(!vector.isNullAt(index));
   const auto serialized = vector.valueAt(index);
+  const auto consumed = storeSerializedRow(
+      std::string_view(serialized.data(), serialized.size()), row);
+  VELOX_CHECK_EQ(
+      consumed,
+      serialized.size(),
+      "Serialized row size mismatch while storing RowContainer row");
+}
+
+size_t RowContainer::storeSerializedRow(
+    std::string_view serialized,
+    char* row) {
   size_t offset = 0;
 
   ::memcpy(row + flagsByteOffset_, serialized.data(), flagBytes_);
@@ -783,6 +834,74 @@ void RowContainer::storeSerializedRow(
     }
     updateColumnStats(row, i);
   }
+  VELOX_CHECK_LE(
+      offset, serialized.size(), "Truncated serialized RowContainer row");
+  return offset;
+}
+
+size_t RowContainer::storeSerializedRows(
+    std::string_view serialized,
+    vector_size_t numRows,
+    char** rows) {
+  const auto layout = serializedColumns();
+  // Column stats are gone once they have been invalidated.
+  const bool updateStats = !rowColumnsStats_.empty();
+
+  size_t offset{0};
+  for (vector_size_t i = 0; i < numRows; ++i) {
+    char* row = newRow();
+    rows[i] = row;
+
+    // The serialized bytes do not include the next-row pointer, which belongs
+    // to the hash table rather than to the row. Clear it so that nothing
+    // follows uninitialized memory.
+    if (nextOffset_ != 0) {
+      *reinterpret_cast<char**>(row + nextOffset_) = nullptr;
+    }
+
+    VELOX_CHECK_LE(
+        offset + flagBytes_, serialized.size(), "Truncated serialized rows");
+    ::memcpy(row + flagsByteOffset_, serialized.data() + offset, flagBytes_);
+    offset += flagBytes_;
+
+    RowSizeTracker tracker(row[rowSizeOffset_], *stringAllocator_);
+    for (auto column = 0; column < layout.size(); ++column) {
+      int32_t valueSize;
+      if (layout[column].fixedSize != 0) {
+        valueSize = layout[column].fixedSize;
+        ::memcpy(
+            row + layout[column].offset, serialized.data() + offset, valueSize);
+        offset += valueSize;
+      } else {
+        const auto consumed =
+            storeVariableSizeAt(serialized.data() + offset, row, column);
+        // The leading 4 bytes hold the size and are not part of the value.
+        valueSize = consumed - 4;
+        offset += consumed;
+      }
+
+      if (updateStats) {
+        auto& columnStats = rowColumnsStats_[column];
+        if (isNullAt(row, rowColumns_[column])) {
+          columnStats.addNullCell();
+        } else {
+          columnStats.addCellSize(valueSize);
+        }
+      }
+    }
+    VELOX_CHECK_LE(offset, serialized.size(), "Truncated serialized rows");
+
+    // The flag bytes carry the source container's join flags. Reset them so
+    // that every row reads back as unprobed and as a single occurrence.
+    if (probedFlagOffset_ != 0) {
+      bits::clearBit(row, probedFlagOffset_);
+    }
+    if (countOffset_ != 0) {
+      countRef(row) = 1;
+    }
+  }
+
+  return offset;
 }
 
 void RowContainer::extractString(

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -23,6 +23,8 @@
 #include "velox/vector/FlatVector.h"
 #include "velox/vector/VectorTypeUtils.h"
 
+#include <string_view>
+
 namespace facebook::velox::exec {
 namespace test {
 class RowContainerTestHelper;
@@ -428,6 +430,10 @@ class RowContainer {
       const FlatVector<StringView>& vector,
       vector_size_t index,
       char* row);
+
+  /// Copies serialized row bytes produced by 'extractSerializedRows' into the
+  /// container.
+  void storeSerializedRow(std::string_view serialized, char* row);
 
   /// Copies the values at 'col' into 'result' (starting at 'resultOffset')
   /// for the 'numRows' rows pointed to by 'rows'. If a 'row' is null, sets

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -23,6 +23,8 @@
 #include "velox/vector/FlatVector.h"
 #include "velox/vector/VectorTypeUtils.h"
 
+#include <string_view>
+
 namespace facebook::velox::exec {
 namespace test {
 class RowContainerTestHelper;
@@ -422,12 +424,41 @@ class RowContainer {
   void extractSerializedRows(folly::Range<char**> rows, const VectorPtr& result)
       const;
 
+  /// Returns the number of bytes 'serializeRows' writes for 'rows'. Reads the
+  /// rows only when the container has variable-width columns.
+  size_t serializedRowsSize(folly::Range<char**> rows) const;
+
+  /// Serializes 'rows' back to back into 'destination', which must have room
+  /// for 'serializedRowsSize(rows)' bytes. Produces the same per-row bytes as
+  /// 'extractSerializedRows', letting callers serialize straight into their own
+  /// buffer instead of going through a vector. If 'rowSizes' is not null, fills
+  /// it with the per-row byte counts. Returns the number of bytes written.
+  size_t serializeRows(
+      folly::Range<char**> rows,
+      char* destination,
+      vector_size_t* rowSizes) const;
+
   /// Copies serialized row produced by 'extractSerializedRow' into the
   /// container.
   void storeSerializedRow(
       const FlatVector<StringView>& vector,
       vector_size_t index,
       char* row);
+
+  /// Copies the first serialized row of 'serialized' into the container.
+  /// 'serialized' may hold more than one row, as produced by 'serializeRows'.
+  /// Returns the number of bytes consumed.
+  size_t storeSerializedRow(std::string_view serialized, char* row);
+
+  /// Creates 'numRows' rows and fills them from 'serialized', which holds that
+  /// many rows back to back as produced by 'serializeRows'. Writes the new row
+  /// pointers to 'rows'. Resets the probed flag and the duplicate count, which
+  /// the serialized bytes carry over from the source container. Returns the
+  /// number of bytes consumed.
+  size_t storeSerializedRows(
+      std::string_view serialized,
+      vector_size_t numRows,
+      char** rows);
 
   /// Copies the values at 'col' into 'result' (starting at 'resultOffset')
   /// for the 'numRows' rows pointed to by 'rows'. If a 'row' is null, sets
@@ -1006,6 +1037,21 @@ class RowContainer {
   // bytes.
   int32_t
   storeVariableSizeAt(const char* data, char* row, column_index_t column);
+
+  // Returns the serialized size of one row when it does not depend on the row's
+  // content, i.e. when all columns are fixed width, and std::nullopt otherwise.
+  std::optional<size_t> fixedSerializedRowSize() const;
+
+  // Per-column offset and, for fixed-width columns, value size. 'fixedSize' is
+  // zero for variable-width columns.
+  struct SerializedColumn {
+    int32_t offset;
+    int32_t fixedSize;
+  };
+
+  // Precomputes the column layout so that serializing or storing a batch of
+  // rows does not repeat the type dispatch for every row.
+  std::vector<SerializedColumn> serializedColumns() const;
 
   template <TypeKind Kind>
   static void extractColumnTyped(

--- a/velox/exec/VectorHasher.cpp
+++ b/velox/exec/VectorHasher.cpp
@@ -19,9 +19,17 @@
 #include "velox/common/base/Portability.h"
 #include "velox/common/base/SimdUtil.h"
 #include "velox/common/memory/HashStringAllocator.h"
+#include "velox/common/serialization/NativeSerdeIO.h"
 #include "velox/type/FloatingPointUtil.h"
 
 namespace facebook::velox::exec {
+
+namespace {
+
+constexpr uint32_t kVectorHasherStateMagic = 0x56485331; // VHS1
+constexpr uint32_t kVectorHasherStateVersion = 3;
+
+} // namespace
 
 #define VALUE_ID_TYPE_DISPATCH(TEMPLATE_FUNC, typeKind, ...)                \
   [&]() {                                                                   \
@@ -932,6 +940,243 @@ void VectorHasher::merge(const VectorHasher& other, size_t maxNumDistinct) {
       break;
     }
   }
+}
+
+std::string VectorHasher::serializeState() const {
+  const common::BigintValuesUsingBloomFilter* bloomFilter = nullptr;
+  std::string bloomFilterData;
+  if (bloomFilter_) {
+    VELOX_CHECK(
+        supportsBloomFilter(),
+        "Unexpected bloom filter for VectorHasher type {}",
+        type_->toString());
+    bloomFilter = dynamic_cast<const common::BigintValuesUsingBloomFilter*>(
+        bloomFilter_.get());
+    VELOX_CHECK_NOT_NULL(
+        bloomFilter, "Unexpected bloom filter implementation in VectorHasher");
+    bloomFilterData.reserve(16 + bloomFilter->blocksByteSize());
+    bloomFilter->serializeBinary(bloomFilterData);
+  }
+
+  std::vector<const UniqueValue*> valuesById;
+  if (!distinctOverflow_) {
+    valuesById.resize(uniqueValues_.size(), nullptr);
+    for (const auto& value : uniqueValues_) {
+      VELOX_CHECK_GE(value.id(), 1);
+      VELOX_CHECK_LE(value.id(), valuesById.size());
+      valuesById[value.id() - 1] = &value;
+    }
+  }
+
+  std::string data;
+  data.reserve(serializedStateSize());
+  common::NativeStringWriter writer(data);
+
+  writer.writeValue<uint32_t>(kVectorHasherStateMagic);
+  writer.writeValue<uint32_t>(kVectorHasherStateVersion);
+  writer.writeValue<uint32_t>(static_cast<uint32_t>(typeKind_));
+  writer.writeValue<bool>(typeProvidesCustomComparison_);
+  writer.writeValue<uint64_t>(rangeSize_);
+  writer.writeValue<uint64_t>(multiplier_);
+  writer.writeValue<bool>(isRange_);
+  writer.writeValue<bool>(hasRange_);
+  writer.writeValue<bool>(rangeOverflow_);
+  writer.writeValue<bool>(distinctOverflow_);
+  writer.writeValue<int64_t>(min_);
+  writer.writeValue<int64_t>(max_);
+
+  writer.writeValue<bool>(bloomFilter != nullptr);
+  if (bloomFilter != nullptr) {
+    writer.writeValue<uint32_t>(bloomFilterData.size());
+    if (!bloomFilterData.empty()) {
+      writer.write(bloomFilterData.data(), bloomFilterData.size());
+    }
+  }
+
+  if (distinctOverflow_) {
+    writer.writeValue<uint32_t>(0);
+    return data;
+  }
+
+  writer.writeValue<uint32_t>(valuesById.size());
+  for (const auto* value : valuesById) {
+    VELOX_CHECK_NOT_NULL(value, "Missing unique value for serialized id range");
+    const auto bytes = value->bytesView();
+    writer.writeValue<uint32_t>(bytes.size());
+    if (!bytes.empty()) {
+      writer.write(bytes.data(), bytes.size());
+    }
+  }
+
+  return data;
+}
+
+uint32_t VectorHasher::serializedStateSize() const {
+  uint32_t size = sizeof(kVectorHasherStateMagic) +
+      sizeof(kVectorHasherStateVersion) + sizeof(uint32_t) + sizeof(bool) +
+      sizeof(rangeSize_) + sizeof(multiplier_) + sizeof(isRange_) +
+      sizeof(hasRange_) + sizeof(rangeOverflow_) + sizeof(distinctOverflow_) +
+      sizeof(min_) + sizeof(max_) + sizeof(bool) + sizeof(uint32_t);
+
+  if (bloomFilter_) {
+    VELOX_CHECK(
+        supportsBloomFilter(),
+        "Unexpected bloom filter for VectorHasher type {}",
+        type_->toString());
+    auto* bloomFilter =
+        dynamic_cast<const common::BigintValuesUsingBloomFilter*>(
+            bloomFilter_.get());
+    VELOX_CHECK_NOT_NULL(
+        bloomFilter, "Unexpected bloom filter implementation in VectorHasher");
+    size += sizeof(bool) + 3 * sizeof(uint32_t) + bloomFilter->blocksByteSize();
+  }
+
+  if (!distinctOverflow_) {
+    for (const auto& value : uniqueValues_) {
+      size += sizeof(uint32_t) + value.size();
+    }
+  }
+
+  return size;
+}
+
+void VectorHasher::serializeState(common::NativeBufferedWriter& writer) const {
+  const common::BigintValuesUsingBloomFilter* bloomFilter = nullptr;
+  std::string bloomFilterData;
+  if (bloomFilter_) {
+    VELOX_CHECK(
+        supportsBloomFilter(),
+        "Unexpected bloom filter for VectorHasher type {}",
+        type_->toString());
+    bloomFilter = dynamic_cast<const common::BigintValuesUsingBloomFilter*>(
+        bloomFilter_.get());
+    VELOX_CHECK_NOT_NULL(
+        bloomFilter, "Unexpected bloom filter implementation in VectorHasher");
+    bloomFilterData.reserve(16 + bloomFilter->blocksByteSize());
+    bloomFilter->serializeBinary(bloomFilterData);
+  }
+
+  std::vector<const UniqueValue*> valuesById;
+  if (!distinctOverflow_) {
+    valuesById.resize(uniqueValues_.size(), nullptr);
+    for (const auto& value : uniqueValues_) {
+      VELOX_CHECK_GE(value.id(), 1);
+      VELOX_CHECK_LE(value.id(), valuesById.size());
+      valuesById[value.id() - 1] = &value;
+    }
+  }
+
+  writer.writeValue<uint32_t>(kVectorHasherStateMagic);
+  writer.writeValue<uint32_t>(kVectorHasherStateVersion);
+  writer.writeValue<uint32_t>(static_cast<uint32_t>(typeKind_));
+  writer.writeValue<bool>(typeProvidesCustomComparison_);
+  writer.writeValue<uint64_t>(rangeSize_);
+  writer.writeValue<uint64_t>(multiplier_);
+  writer.writeValue<bool>(isRange_);
+  writer.writeValue<bool>(hasRange_);
+  writer.writeValue<bool>(rangeOverflow_);
+  writer.writeValue<bool>(distinctOverflow_);
+  writer.writeValue<int64_t>(min_);
+  writer.writeValue<int64_t>(max_);
+
+  writer.writeValue<bool>(bloomFilter != nullptr);
+  if (bloomFilter != nullptr) {
+    writer.writeValue<uint32_t>(bloomFilterData.size());
+    if (!bloomFilterData.empty()) {
+      writer.write(bloomFilterData.data(), bloomFilterData.size());
+    }
+  }
+
+  if (distinctOverflow_) {
+    writer.writeValue<uint32_t>(0);
+    return;
+  }
+
+  writer.writeValue<uint32_t>(valuesById.size());
+  for (const auto* value : valuesById) {
+    VELOX_CHECK_NOT_NULL(value, "Missing unique value for serialized id range");
+    const auto bytes = value->bytesView();
+    writer.writeValue<uint32_t>(bytes.size());
+    if (!bytes.empty()) {
+      writer.write(bytes.data(), bytes.size());
+    }
+  }
+}
+
+void VectorHasher::deserializeState(std::string_view data) {
+  common::NativeStringReader reader(data);
+  const auto magic = reader.readValue<uint32_t>();
+  const auto version = reader.readValue<uint32_t>();
+  VELOX_CHECK_EQ(magic, kVectorHasherStateMagic, "Invalid VectorHasher state");
+  VELOX_CHECK_EQ(
+      version,
+      kVectorHasherStateVersion,
+      "Unsupported VectorHasher state version: {}",
+      version);
+
+  const auto typeKind = static_cast<TypeKind>(reader.readValue<uint32_t>());
+  const auto hasCustomComparison = reader.readValue<bool>();
+  VELOX_CHECK_EQ(typeKind, typeKind_, "VectorHasher type kind mismatch");
+  VELOX_CHECK_EQ(
+      hasCustomComparison,
+      typeProvidesCustomComparison_,
+      "VectorHasher comparison mode mismatch");
+
+  rangeSize_ = reader.readValue<uint64_t>();
+  multiplier_ = reader.readValue<uint64_t>();
+  isRange_ = reader.readValue<bool>();
+  hasRange_ = reader.readValue<bool>();
+  rangeOverflow_ = reader.readValue<bool>();
+  distinctOverflow_ = reader.readValue<bool>();
+  min_ = reader.readValue<int64_t>();
+  max_ = reader.readValue<int64_t>();
+
+  bloomFilter_.reset();
+  const bool hasBloomFilter = reader.readValue<bool>();
+  if (hasBloomFilter) {
+    VELOX_CHECK(
+        supportsBloomFilter(),
+        "Unexpected bloom filter for VectorHasher type {}",
+        type_->toString());
+    const auto bloomFilterSize = reader.readValue<uint32_t>();
+    std::string bloomFilterData(bloomFilterSize, '\0');
+    if (bloomFilterSize > 0) {
+      reader.read(bloomFilterData.data(), bloomFilterSize);
+    }
+    bloomFilter_ = common::BigintValuesUsingBloomFilter::deserializeBinary(
+        bloomFilterData);
+  }
+
+  uniqueValues_.clear();
+  uniqueValuesStorage_.clear();
+  distinctStringsBytes_ = 0;
+
+  const auto numUniqueValues = reader.readValue<uint32_t>();
+  if (!distinctOverflow_) {
+    for (uint32_t id = 1; id <= numUniqueValues; ++id) {
+      const auto size = reader.readValue<uint32_t>();
+      std::string value(size, '\0');
+      if (size > 0) {
+        reader.read(value.data(), size);
+      }
+
+      UniqueValue unique(value.data(), size);
+      unique.setId(id);
+      auto [iter, inserted] = uniqueValues_.insert(unique);
+      VELOX_CHECK(inserted, "Duplicate value in VectorHasher state");
+      copyStringToLocal(&*iter);
+    }
+  } else {
+    for (uint32_t i = 0; i < numUniqueValues; ++i) {
+      const auto size = reader.readValue<uint32_t>();
+      if (size > 0) {
+        std::string skip(size, '\0');
+        reader.read(skip.data(), size);
+      }
+    }
+  }
+
+  VELOX_CHECK(reader.atEnd(), "Trailing bytes in VectorHasher state");
 }
 
 std::string VectorHasher::toString() const {

--- a/velox/exec/VectorHasher.cpp
+++ b/velox/exec/VectorHasher.cpp
@@ -19,9 +19,17 @@
 #include "velox/common/base/Portability.h"
 #include "velox/common/base/SimdUtil.h"
 #include "velox/common/memory/HashStringAllocator.h"
+#include "velox/common/serialization/NativeSerdeIO.h"
 #include "velox/type/FloatingPointUtil.h"
 
 namespace facebook::velox::exec {
+
+namespace {
+
+constexpr uint32_t kVectorHasherStateMagic = 0x56485331; // VHS1
+constexpr uint32_t kVectorHasherStateVersion = 3;
+
+} // namespace
 
 #define VALUE_ID_TYPE_DISPATCH(TEMPLATE_FUNC, typeKind, ...)                \
   [&]() {                                                                   \
@@ -1006,6 +1014,173 @@ void VectorHasher::merge(const VectorHasher& other, size_t maxNumDistinct) {
       break;
     }
   }
+}
+
+const common::BigintValuesUsingBloomFilter* VectorHasher::bloomFilterState()
+    const {
+  if (!bloomFilter_) {
+    return nullptr;
+  }
+  VELOX_CHECK(
+      supportsBloomFilter(),
+      "Unexpected bloom filter for VectorHasher type {}",
+      type_->toString());
+  auto* bloomFilter = dynamic_cast<const common::BigintValuesUsingBloomFilter*>(
+      bloomFilter_.get());
+  VELOX_CHECK_NOT_NULL(
+      bloomFilter, "Unexpected bloom filter implementation in VectorHasher");
+  return bloomFilter;
+}
+
+std::string VectorHasher::serializeState() const {
+  const auto* bloomFilter = bloomFilterState();
+  std::string bloomFilterData;
+  if (bloomFilter != nullptr) {
+    bloomFilter->serializeBinary(bloomFilterData);
+  }
+
+  std::vector<const UniqueValue*> valuesById;
+  if (!distinctOverflow_) {
+    valuesById.resize(uniqueValues_.size(), nullptr);
+    for (const auto& value : uniqueValues_) {
+      VELOX_CHECK_GE(value.id(), 1);
+      VELOX_CHECK_LE(value.id(), valuesById.size());
+      valuesById[value.id() - 1] = &value;
+    }
+  }
+
+  std::string data;
+  data.reserve(serializedStateSize());
+  common::NativeStringWriter writer(data);
+
+  writer.writeValue<uint32_t>(kVectorHasherStateMagic);
+  writer.writeValue<uint32_t>(kVectorHasherStateVersion);
+  writer.writeValue<uint32_t>(static_cast<uint32_t>(typeKind_));
+  writer.writeValue<bool>(typeProvidesCustomComparison_);
+  writer.writeValue<uint64_t>(rangeSize_);
+  writer.writeValue<uint64_t>(multiplier_);
+  writer.writeValue<bool>(isRange_);
+  writer.writeValue<bool>(hasRange_);
+  writer.writeValue<bool>(rangeOverflow_);
+  writer.writeValue<bool>(distinctOverflow_);
+  writer.writeValue<int64_t>(min_);
+  writer.writeValue<int64_t>(max_);
+
+  writer.writeValue<bool>(bloomFilter != nullptr);
+  if (bloomFilter != nullptr) {
+    writer.writeValue<uint32_t>(bloomFilterData.size());
+    if (!bloomFilterData.empty()) {
+      writer.write(bloomFilterData.data(), bloomFilterData.size());
+    }
+  }
+
+  if (distinctOverflow_) {
+    writer.writeValue<uint32_t>(0);
+    return data;
+  }
+
+  writer.writeValue<uint32_t>(valuesById.size());
+  for (const auto* value : valuesById) {
+    VELOX_CHECK_NOT_NULL(value, "Missing unique value for serialized id range");
+    const auto bytes = value->bytesView();
+    writer.writeValue<uint32_t>(bytes.size());
+    if (!bytes.empty()) {
+      writer.write(bytes.data(), bytes.size());
+    }
+  }
+
+  return data;
+}
+
+uint32_t VectorHasher::serializedStateSize() const {
+  // Fixed part: magic, version, type kind, custom comparison flag, range and
+  // distinct state, the bloom filter presence flag and the unique value count.
+  uint32_t size = sizeof(kVectorHasherStateMagic) +
+      sizeof(kVectorHasherStateVersion) + sizeof(uint32_t) + sizeof(bool) +
+      sizeof(rangeSize_) + sizeof(multiplier_) + sizeof(isRange_) +
+      sizeof(hasRange_) + sizeof(rangeOverflow_) + sizeof(distinctOverflow_) +
+      sizeof(min_) + sizeof(max_) + sizeof(bool) + sizeof(uint32_t);
+
+  if (const auto* bloomFilter = bloomFilterState()) {
+    // Length prefix plus the bloom filter's own binary form.
+    size += sizeof(uint32_t) + bloomFilter->serializedBinarySize();
+  }
+
+  if (!distinctOverflow_) {
+    for (const auto& value : uniqueValues_) {
+      size += sizeof(uint32_t) + value.size();
+    }
+  }
+
+  return size;
+}
+
+void VectorHasher::deserializeState(std::string_view data) {
+  common::NativeStringReader reader(data);
+  const auto magic = reader.readValue<uint32_t>();
+  const auto version = reader.readValue<uint32_t>();
+  VELOX_CHECK_EQ(magic, kVectorHasherStateMagic, "Invalid VectorHasher state");
+  VELOX_CHECK_EQ(
+      version,
+      kVectorHasherStateVersion,
+      "Unsupported VectorHasher state version: {}",
+      version);
+
+  const auto typeKind = static_cast<TypeKind>(reader.readValue<uint32_t>());
+  const auto hasCustomComparison = reader.readValue<bool>();
+  VELOX_CHECK_EQ(typeKind, typeKind_, "VectorHasher type kind mismatch");
+  VELOX_CHECK_EQ(
+      hasCustomComparison,
+      typeProvidesCustomComparison_,
+      "VectorHasher comparison mode mismatch");
+
+  rangeSize_ = reader.readValue<uint64_t>();
+  multiplier_ = reader.readValue<uint64_t>();
+  isRange_ = reader.readValue<bool>();
+  hasRange_ = reader.readValue<bool>();
+  rangeOverflow_ = reader.readValue<bool>();
+  distinctOverflow_ = reader.readValue<bool>();
+  min_ = reader.readValue<int64_t>();
+  max_ = reader.readValue<int64_t>();
+
+  bloomFilter_.reset();
+  const bool hasBloomFilter = reader.readValue<bool>();
+  if (hasBloomFilter) {
+    VELOX_CHECK(
+        supportsBloomFilter(),
+        "Unexpected bloom filter for VectorHasher type {}",
+        type_->toString());
+    const auto bloomFilterSize = reader.readValue<uint32_t>();
+    bloomFilter_ = common::BigintValuesUsingBloomFilter::deserializeBinary(
+        reader.view(bloomFilterSize));
+  }
+
+  uniqueValues_.clear();
+  uniqueValuesStorage_.clear();
+  distinctStringsBytes_ = 0;
+
+  const auto numUniqueValues = reader.readValue<uint32_t>();
+  if (!distinctOverflow_) {
+    uniqueValues_.reserve(numUniqueValues);
+    for (uint32_t id = 1; id <= numUniqueValues; ++id) {
+      const auto size = reader.readValue<uint32_t>();
+      const auto value = reader.view(size);
+
+      // 'value' points into 'data'; copyStringToLocal() moves out-of-line
+      // values into 'uniqueValuesStorage_'.
+      UniqueValue unique(value.data(), size);
+      unique.setId(id);
+      auto [iter, inserted] = uniqueValues_.insert(unique);
+      VELOX_CHECK(inserted, "Duplicate value in VectorHasher state");
+      copyStringToLocal(&*iter);
+    }
+  } else {
+    for (uint32_t i = 0; i < numUniqueValues; ++i) {
+      reader.skip(reader.readValue<uint32_t>());
+    }
+  }
+
+  VELOX_CHECK(reader.atEnd(), "Trailing bytes in VectorHasher state");
 }
 
 std::string VectorHasher::toString() const {

--- a/velox/exec/VectorHasher.h
+++ b/velox/exec/VectorHasher.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <string_view>
+
 #include <folly/container/F14Set.h>
 
 #include <velox/type/Filter.h>
@@ -22,6 +24,10 @@
 #include "velox/exec/Operator.h"
 #include "velox/vector/FlatVector.h"
 #include "velox/vector/VectorTypeUtils.h"
+
+namespace facebook::velox::common {
+class NativeBufferedWriter;
+}
 
 namespace facebook::velox::exec {
 
@@ -68,6 +74,15 @@ class UniqueValue {
     }
     // String is stored as a pointer in data_.
     return std::string{reinterpret_cast<const char*>(data_), size_};
+  }
+
+  std::string_view bytesView() const {
+    if (size_ <= sizeof(int64_t)) {
+      return std::string_view{
+          reinterpret_cast<const char*>(&data_), static_cast<size_t>(size_)};
+    }
+    return std::string_view{
+        reinterpret_cast<const char*>(data_), static_cast<size_t>(size_)};
   }
 
   void setData(int64_t data) {
@@ -354,6 +369,17 @@ class VectorHasher {
   }
 
   std::string toString() const;
+
+  // Serializes the value-id / range state needed to preserve non-kHash join
+  // probe behavior across process boundaries.
+  std::string serializeState() const;
+
+  uint32_t serializedStateSize() const;
+
+  void serializeState(common::NativeBufferedWriter& writer) const;
+
+  // Restores state produced by serializeState().
+  void deserializeState(std::string_view data);
 
   size_t numUniqueValues() const {
     return uniqueValues_.size();

--- a/velox/exec/VectorHasher.h
+++ b/velox/exec/VectorHasher.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <string_view>
+
 #include <folly/container/F14Map.h>
 #include <folly/container/F14Set.h>
 
@@ -71,6 +73,15 @@ class UniqueValue {
     }
     // String is stored as a pointer in data_.
     return std::string{reinterpret_cast<const char*>(data_), size_};
+  }
+
+  std::string_view bytesView() const {
+    if (size_ <= sizeof(int64_t)) {
+      return std::string_view{
+          reinterpret_cast<const char*>(&data_), static_cast<size_t>(size_)};
+    }
+    return std::string_view{
+        reinterpret_cast<const char*>(data_), static_cast<size_t>(size_)};
   }
 
   void setData(int64_t data) {
@@ -369,6 +380,13 @@ class VectorHasher {
 
   std::string toString() const;
 
+  /// Serializes the value-id / range state needed to preserve non-kHash join
+  /// probe behavior across process boundaries.
+  std::string serializeState() const;
+
+  /// Restores state produced by serializeState().
+  void deserializeState(std::string_view data);
+
   size_t numUniqueValues() const {
     return numDistinct();
   }
@@ -377,6 +395,14 @@ class VectorHasher {
   static constexpr uint32_t kStringASRangeMaxSize = 7;
   static constexpr uint32_t kStringBufferUnitSize = 1024;
   static constexpr uint64_t kMaxDistinctStringsBytes = 1 << 20;
+
+  // Returns 'bloomFilter_' as the only implementation that serializeState()
+  // supports, or null if there is no bloom filter.
+  const common::BigintValuesUsingBloomFilter* bloomFilterState() const;
+
+  // Returns the number of bytes serializeState() produces, which it uses to
+  // size its destination up front.
+  uint32_t serializedStateSize() const;
 
   // Maps a binary string of up to 7 bytes to int64_t. Each size maps
   // to a different numeric range, so leading zeros are considered.

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -136,6 +136,7 @@ set(
   UnnestTest.cpp
   PlanNodeSerdeTest.cpp
   HashJoinBridgeTest.cpp
+  HashTableSerializationTest.cpp
   SortBufferTest.cpp
   VectorHasherTest.cpp
   # group7 (~449s): IndexLookupJoinTestExtra 188

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -137,6 +137,7 @@ set(
   UnnestTest.cpp
   PlanNodeSerdeTest.cpp
   HashJoinBridgeTest.cpp
+  HashTableSerializationTest.cpp
   SortBufferTest.cpp
   VectorHasherTest.cpp
   # group7 (~449s): IndexLookupJoinTestExtra 188

--- a/velox/exec/tests/HashTableSerializationTest.cpp
+++ b/velox/exec/tests/HashTableSerializationTest.cpp
@@ -1,0 +1,627 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/HashTable.h"
+#include "velox/exec/VectorHasher.h"
+#include "velox/exec/tests/utils/TempDirectoryPath.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+#include <gtest/gtest.h>
+
+#include <sys/wait.h>
+#include <unistd.h>
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::test;
+
+namespace facebook::velox::exec::test {
+
+namespace {
+std::string readFile(const std::string& path) {
+  std::ifstream in(path, std::ios::binary);
+  if (!in.good()) {
+    return "";
+  }
+  in.seekg(0, std::ios::end);
+  const auto end = in.tellg();
+  if (end <= 0) {
+    return "";
+  }
+  const auto size = static_cast<size_t>(end);
+  in.seekg(0, std::ios::beg);
+  std::string data;
+  data.resize(size);
+  in.read(data.data(), data.size());
+  return data;
+}
+
+void writeFile(const std::string& path, const std::string& data) {
+  std::ofstream out(path, std::ios::binary);
+  out.write(data.data(), data.size());
+}
+} // namespace
+
+class HashTableSerializationTest : public testing::Test, public VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  std::string serialize(const HashTable<true>& table) const {
+    std::string data;
+    data.resize(table.serializedSize());
+    table.serializeTo(data.data(), data.size());
+    return data;
+  }
+
+  std::unique_ptr<HashTable<true>> deserialize(
+      const std::string& data,
+      memory::MemoryPool* pool) const {
+    return HashTable<true>::deserializeFrom(data.data(), data.size(), pool);
+  }
+
+  void SetUp() override {
+    pool_ = memory::memoryManager()->addLeafPool();
+    tempDir_ = exec::test::TempDirectoryPath::create();
+  }
+
+  void TearDown() override {
+    pool_.reset();
+  }
+
+  std::unique_ptr<HashTable<true>> createTestHashTable(
+      const std::vector<TypePtr>& keyTypes,
+      const std::vector<TypePtr>& dependentTypes,
+      bool allowDuplicates = false) {
+    std::vector<std::unique_ptr<VectorHasher>> hashers;
+    for (int i = 0; i < keyTypes.size(); ++i) {
+      hashers.push_back(std::make_unique<VectorHasher>(keyTypes[i], i));
+    }
+
+    return std::make_unique<HashTable<true>>(
+        std::move(hashers),
+        std::vector<Accumulator>{},
+        dependentTypes,
+        allowDuplicates,
+        true, // isJoinBuild
+        false, // hasProbedFlag
+        false, // hasCountFlag
+        0, // minTableSizeForParallelJoinBuild
+        pool_.get());
+  }
+
+  void insertData(
+      HashTable<true>* table,
+      const RowVectorPtr& data,
+      const std::vector<column_index_t>& /*keyChannels*/) {
+    SelectivityVector allRows(data->size());
+
+    std::vector<char*> inserted(data->size());
+    const auto nextOffset = table->rows()->nextOffset();
+    for (int i = 0; i < data->size(); ++i) {
+      inserted[i] = table->rows()->newRow();
+      if (nextOffset > 0) {
+        *reinterpret_cast<char**>(inserted[i] + nextOffset) = nullptr;
+      }
+    }
+
+    for (int col = 0; col < data->childrenSize(); ++col) {
+      DecodedVector decoded(*data->childAt(col), allRows);
+      for (int row = 0; row < data->size(); ++row) {
+        table->rows()->store(decoded, row, inserted[row], col);
+      }
+    }
+  }
+
+  void verifyHashTablesEqual(
+      HashTable<true>* original,
+      HashTable<true>* restored) {
+    EXPECT_EQ(original->numDistinct(), restored->numDistinct());
+    EXPECT_EQ(original->hashMode(), restored->hashMode());
+
+    auto* origRows = original->rows();
+    auto* restRows = restored->rows();
+
+    ASSERT_EQ(origRows->numRows(), restRows->numRows());
+    ASSERT_EQ(origRows->columnTypes().size(), restRows->columnTypes().size());
+
+    std::vector<char*> origRowPtrs;
+    std::vector<char*> restRowPtrs;
+
+    RowContainerIterator origIter;
+    RowContainerIterator restIter;
+
+    std::vector<char*> buffer(1000);
+
+    while (true) {
+      auto numRows = origRows->listRows(
+          &origIter, buffer.size(), RowContainer::kUnlimited, buffer.data());
+      if (numRows == 0)
+        break;
+      origRowPtrs.insert(
+          origRowPtrs.end(), buffer.begin(), buffer.begin() + numRows);
+    }
+
+    while (true) {
+      auto numRows = restRows->listRows(
+          &restIter, buffer.size(), RowContainer::kUnlimited, buffer.data());
+      if (numRows == 0)
+        break;
+      restRowPtrs.insert(
+          restRowPtrs.end(), buffer.begin(), buffer.begin() + numRows);
+    }
+
+    ASSERT_EQ(origRowPtrs.size(), restRowPtrs.size());
+
+    auto encodeRows = [](RowContainer* rows,
+                         const std::vector<char*>& rowPtrs) {
+      std::vector<std::string> encodedRows;
+      encodedRows.reserve(rowPtrs.size());
+      for (auto* rowPtr : rowPtrs) {
+        std::string encoded;
+        for (int col = 0; col < rows->columnTypes().size(); ++col) {
+          const auto column = rows->columnAt(col);
+          const bool isNull = RowContainer::isNullAt(rowPtr, column);
+          encoded += isNull ? "NULL:" : "VAL:";
+          if (!isNull) {
+            const auto& type = rows->columnTypes()[col];
+            switch (type->kind()) {
+              case TypeKind::BIGINT:
+                encoded += std::to_string(*reinterpret_cast<const int64_t*>(
+                    rowPtr + column.offset()));
+                break;
+              case TypeKind::INTEGER:
+                encoded += std::to_string(*reinterpret_cast<const int32_t*>(
+                    rowPtr + column.offset()));
+                break;
+              case TypeKind::DOUBLE:
+                encoded += std::to_string(
+                    *reinterpret_cast<const double*>(rowPtr + column.offset()));
+                break;
+              case TypeKind::BOOLEAN:
+                encoded +=
+                    *reinterpret_cast<const bool*>(rowPtr + column.offset())
+                    ? "true"
+                    : "false";
+                break;
+              case TypeKind::VARCHAR: {
+                const auto* str = reinterpret_cast<const StringView*>(
+                    rowPtr + column.offset());
+                encoded.append(str->data(), str->size());
+                break;
+              }
+              default:
+                VELOX_FAIL(
+                    "Unsupported type in HashTableSerializationTest comparison: {}",
+                    type->toString());
+            }
+          }
+          encoded += "|";
+        }
+        encodedRows.push_back(std::move(encoded));
+      }
+      std::sort(encodedRows.begin(), encodedRows.end());
+      return encodedRows;
+    };
+
+    EXPECT_EQ(
+        encodeRows(origRows, origRowPtrs), encodeRows(restRows, restRowPtrs));
+  }
+
+  void verifyJoinProbe(
+      HashTable<true>* table,
+      const RowVectorPtr& probe,
+      int32_t expectedHits) {
+    HashLookup lookup(table->hashers(), pool_.get());
+    SelectivityVector rows(probe->size());
+    rows.setAll();
+
+    table->prepareForJoinProbe(lookup, probe, rows, true);
+    table->joinProbe(lookup);
+
+    int32_t hitCount = 0;
+    for (int32_t row = 0; row < probe->size(); ++row) {
+      if (lookup.hits[row] != nullptr) {
+        ++hitCount;
+      }
+    }
+    EXPECT_EQ(hitCount, expectedHits);
+  }
+
+  std::shared_ptr<memory::MemoryPool> pool_;
+  std::shared_ptr<TempDirectoryPath> tempDir_;
+};
+
+TEST_F(HashTableSerializationTest, BasicSerializationDefault) {
+  auto table = createTestHashTable({BIGINT()}, {VARCHAR()}, false);
+
+  auto data = makeRowVector(
+      {makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+       makeFlatVector<std::string>({"a", "b", "c", "d", "e"})});
+
+  insertData(table.get(), data, {0});
+  table->prepareJoinTable(
+      {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+
+  const auto serialized = serialize(*table);
+  auto restored = deserialize(serialized, pool_.get());
+
+  verifyHashTablesEqual(table.get(), restored.get());
+}
+
+TEST_F(HashTableSerializationTest, BasicSerializationJoinProbe) {
+  auto table = createTestHashTable({BIGINT()}, {VARCHAR()}, false);
+
+  auto data = makeRowVector(
+      {makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+       makeFlatVector<std::string>({"a", "b", "c", "d", "e"})});
+
+  insertData(table.get(), data, {0});
+  table->prepareJoinTable(
+      {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+
+  const auto serialized = serialize(*table);
+  auto restored = deserialize(serialized, pool_.get());
+
+  verifyHashTablesEqual(table.get(), restored.get());
+  verifyJoinProbe(restored.get(), data, data->size());
+}
+
+TEST_F(HashTableSerializationTest, MultipleDataTypes) {
+  auto table = createTestHashTable(
+      {BIGINT(), INTEGER(), VARCHAR()}, {DOUBLE(), BOOLEAN()}, false);
+
+  auto data = makeRowVector(
+      {makeFlatVector<int64_t>({1, 2, 3}),
+       makeFlatVector<int32_t>({10, 20, 30}),
+       makeFlatVector<std::string>({"key1", "key2", "key3"}),
+       makeFlatVector<double>({1.1, 2.2, 3.3}),
+       makeFlatVector<bool>({true, false, true})});
+
+  insertData(table.get(), data, {0, 1, 2});
+  table->prepareJoinTable(
+      {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+
+  const auto serialized = serialize(*table);
+  auto restored = deserialize(serialized, pool_.get());
+
+  verifyHashTablesEqual(table.get(), restored.get());
+}
+
+TEST_F(HashTableSerializationTest, NullValues) {
+  auto table = createTestHashTable({BIGINT()}, {VARCHAR()}, false);
+
+  auto data = makeRowVector(
+      {makeNullableFlatVector<int64_t>({1, std::nullopt, 3, std::nullopt, 5}),
+       makeNullableFlatVector<std::string>(
+           {"a", std::nullopt, "c", "d", std::nullopt})});
+
+  insertData(table.get(), data, {0});
+  table->prepareJoinTable(
+      {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+
+  const auto serialized = serialize(*table);
+  auto restored = deserialize(serialized, pool_.get());
+
+  verifyHashTablesEqual(table.get(), restored.get());
+}
+
+TEST_F(HashTableSerializationTest, LargeDataSet) {
+  auto table = createTestHashTable({BIGINT()}, {VARCHAR()}, false);
+
+  std::vector<int64_t> keys;
+  std::vector<std::string> values;
+  for (int i = 0; i < 10000; ++i) {
+    keys.push_back(i);
+    values.push_back("value_" + std::to_string(i));
+  }
+
+  auto data = makeRowVector({makeFlatVector(keys), makeFlatVector(values)});
+
+  insertData(table.get(), data, {0});
+  table->prepareJoinTable(
+      {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+
+  const auto serialized = serialize(*table);
+  auto restored = deserialize(serialized, pool_.get());
+
+  verifyHashTablesEqual(table.get(), restored.get());
+}
+
+TEST_F(HashTableSerializationTest, LongStrings) {
+  auto table = createTestHashTable({BIGINT()}, {VARCHAR()}, false);
+
+  std::vector<std::string> values = {
+      "short",
+      "this is a very long string that exceeds 12 bytes",
+      "medium",
+      std::string(1000, 'x'),
+      ""};
+
+  auto data = makeRowVector(
+      {makeFlatVector<int64_t>({1, 2, 3, 4, 5}), makeFlatVector(values)});
+
+  insertData(table.get(), data, {0});
+  table->prepareJoinTable(
+      {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+
+  const auto serialized = serialize(*table);
+  auto restored = deserialize(serialized, pool_.get());
+
+  verifyHashTablesEqual(table.get(), restored.get());
+}
+
+TEST_F(HashTableSerializationTest, AllowDuplicates) {
+  auto table = createTestHashTable({BIGINT()}, {VARCHAR()}, true);
+
+  auto data = makeRowVector(
+      {makeFlatVector<int64_t>({1, 1, 2, 2, 3}),
+       makeFlatVector<std::string>({"a1", "a2", "b1", "b2", "c"})});
+
+  insertData(table.get(), data, {0});
+  table->prepareJoinTable(
+      {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+
+  const auto serialized = serialize(*table);
+  auto restored = deserialize(serialized, pool_.get());
+
+  verifyHashTablesEqual(table.get(), restored.get());
+}
+
+TEST_F(HashTableSerializationTest, CrossProcessSerialization) {
+  std::string tempFile = tempDir_->getPath() + "/hashtable_cross_process.bin";
+
+  pid_t pid = fork();
+
+  if (pid == 0) {
+    auto childPool = memory::memoryManager()->addLeafPool();
+    pool_ = childPool;
+    auto table = createTestHashTable({BIGINT()}, {VARCHAR()}, false);
+
+    auto data = makeRowVector(
+        {makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+         makeFlatVector<std::string>(
+             {"child1", "child2", "child3", "child4", "child5"})});
+
+    insertData(table.get(), data, {0});
+    table->prepareJoinTable(
+        {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+
+    const auto serialized = serialize(*table);
+    writeFile(tempFile, serialized);
+
+    exit(0);
+  } else {
+    int status;
+    waitpid(pid, &status, 0);
+    ASSERT_EQ(WEXITSTATUS(status), 0) << "Child process failed";
+
+    const auto serialized = readFile(tempFile);
+    ASSERT_GT(serialized.size(), 0) << "Failed to read serialized file";
+    auto restored = deserialize(serialized, pool_.get());
+
+    EXPECT_EQ(restored->numDistinct(), 5);
+    EXPECT_EQ(restored->rows()->numRows(), 5);
+
+    std::remove(tempFile.c_str());
+  }
+}
+
+TEST_F(HashTableSerializationTest, MultiProcessConcurrentSerialization) {
+  const int numProcesses = 4;
+  std::vector<std::string> tempFiles;
+
+  for (int i = 0; i < numProcesses; ++i) {
+    std::string tempFile = tempDir_->getPath() + "/hashtable_process_" +
+        std::to_string(i) + ".bin";
+    tempFiles.push_back(tempFile);
+
+    pid_t pid = fork();
+
+    if (pid == 0) {
+      auto childPool = memory::memoryManager()->addLeafPool();
+      pool_ = childPool;
+      auto table = createTestHashTable({BIGINT()}, {VARCHAR()}, false);
+
+      int start = i * 1000;
+      int end = start + 1000;
+
+      std::vector<int64_t> keys;
+      std::vector<std::string> values;
+      for (int j = start; j < end; ++j) {
+        keys.push_back(j);
+        values.push_back(
+            "process_" + std::to_string(i) + "_value_" + std::to_string(j));
+      }
+
+      auto data = makeRowVector({makeFlatVector(keys), makeFlatVector(values)});
+
+      insertData(table.get(), data, {0});
+      table->prepareJoinTable(
+          {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+
+      const auto serialized = serialize(*table);
+      writeFile(tempFile, serialized);
+
+      exit(0);
+    }
+  }
+
+  for (int i = 0; i < numProcesses; ++i) {
+    int status;
+    wait(&status);
+    ASSERT_EQ(WEXITSTATUS(status), 0) << "Child process " << i << " failed";
+  }
+
+  for (int i = 0; i < numProcesses; ++i) {
+    const auto serialized = readFile(tempFiles[i]);
+    ASSERT_GT(serialized.size(), 0) << "Failed to read file from process " << i;
+    auto restored = deserialize(serialized, pool_.get());
+
+    EXPECT_EQ(restored->numDistinct(), 1000)
+        << "Process " << i << " data mismatch";
+
+    std::remove(tempFiles[i].c_str());
+  }
+}
+
+TEST_F(HashTableSerializationTest, CrossProcessDataMerge) {
+  const int numPartitions = 3;
+  std::vector<std::string> partitionFiles;
+
+  for (int i = 0; i < numPartitions; ++i) {
+    std::string tempFile =
+        tempDir_->getPath() + "/partition_" + std::to_string(i) + ".bin";
+    partitionFiles.push_back(tempFile);
+
+    pid_t pid = fork();
+
+    if (pid == 0) {
+      auto childPool = memory::memoryManager()->addLeafPool();
+      pool_ = childPool;
+      auto table = createTestHashTable({BIGINT()}, {VARCHAR()}, false);
+
+      std::vector<int64_t> keys;
+      std::vector<std::string> values;
+
+      for (int64_t key = 0; key < 1000; ++key) {
+        if (key % numPartitions == i) {
+          keys.push_back(key);
+          values.push_back(
+              "partition_" + std::to_string(i) + "_key_" + std::to_string(key));
+        }
+      }
+
+      auto data = makeRowVector({makeFlatVector(keys), makeFlatVector(values)});
+
+      insertData(table.get(), data, {0});
+      table->prepareJoinTable(
+          {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+
+      const auto serialized = serialize(*table);
+      writeFile(tempFile, serialized);
+
+      exit(0);
+    }
+  }
+
+  for (int i = 0; i < numPartitions; ++i) {
+    int status;
+    wait(&status);
+    ASSERT_EQ(WEXITSTATUS(status), 0);
+  }
+
+  int totalRows = 0;
+  for (int i = 0; i < numPartitions; ++i) {
+    const auto serialized = readFile(partitionFiles[i]);
+    ASSERT_GT(serialized.size(), 0) << "Failed to read partition file " << i;
+    auto partition = deserialize(serialized, pool_.get());
+
+    totalRows += partition->numDistinct();
+
+    std::remove(partitionFiles[i].c_str());
+  }
+
+  EXPECT_EQ(totalRows, 1000) << "Merged data count mismatch";
+}
+
+TEST_F(HashTableSerializationTest, PerformanceBenchmark) {
+  const int numRows = 100000;
+
+  auto table = createTestHashTable({BIGINT()}, {VARCHAR()}, false);
+
+  std::vector<int64_t> keys;
+  std::vector<std::string> values;
+  for (int i = 0; i < numRows; ++i) {
+    keys.push_back(i);
+    values.push_back("benchmark_value_" + std::to_string(i));
+  }
+
+  auto data = makeRowVector({makeFlatVector(keys), makeFlatVector(values)});
+
+  insertData(table.get(), data, {0});
+  table->prepareJoinTable(
+      {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+
+  {
+    auto start = std::chrono::high_resolution_clock::now();
+
+    const auto serialized = serialize(*table);
+
+    auto serEnd = std::chrono::high_resolution_clock::now();
+
+    auto restored = deserialize(serialized, pool_.get());
+
+    auto deserEnd = std::chrono::high_resolution_clock::now();
+
+    auto serTime =
+        std::chrono::duration_cast<std::chrono::milliseconds>(serEnd - start)
+            .count();
+    auto deserTime =
+        std::chrono::duration_cast<std::chrono::milliseconds>(deserEnd - serEnd)
+            .count();
+
+    LOG(INFO) << "Default Serialization Performance (" << numRows << " rows):";
+    LOG(INFO) << "  Serialization: " << serTime << " ms";
+    LOG(INFO) << "  Deserialization: " << deserTime << " ms";
+    LOG(INFO) << "  Total: " << (serTime + deserTime) << " ms";
+  }
+}
+
+TEST_F(HashTableSerializationTest, InvalidMagicNumber) {
+  uint32_t invalidMagic = 0x12345678;
+  std::string data(sizeof(invalidMagic), '\0');
+  std::memcpy(data.data(), &invalidMagic, sizeof(invalidMagic));
+  EXPECT_THROW(deserialize(data, pool_.get()), VeloxException);
+}
+
+TEST_F(HashTableSerializationTest, UnsupportedVersion) {
+  uint32_t magic = 0x48415348;
+  uint32_t version = 999;
+  std::string data(sizeof(magic) + sizeof(version), '\0');
+  std::memcpy(data.data(), &magic, sizeof(magic));
+  std::memcpy(data.data() + sizeof(magic), &version, sizeof(version));
+  EXPECT_THROW(deserialize(data, pool_.get()), VeloxException);
+}
+
+TEST_F(HashTableSerializationTest, CorruptedData) {
+  auto table = createTestHashTable({BIGINT()}, {VARCHAR()}, false);
+
+  auto data = makeRowVector(
+      {makeFlatVector<int64_t>({1, 2, 3}),
+       makeFlatVector<std::string>({"a", "b", "c"})});
+
+  insertData(table.get(), data, {0});
+  table->prepareJoinTable(
+      {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+
+  auto serialized = serialize(*table);
+  ASSERT_GT(serialized.size(), 8);
+  serialized.resize(serialized.size() - 8);
+  EXPECT_THROW(deserialize(serialized, pool_.get()), VeloxException);
+}
+
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/HashTableSerializationTest.cpp
+++ b/velox/exec/tests/HashTableSerializationTest.cpp
@@ -1,0 +1,934 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/HashTable.h"
+#include "velox/exec/VectorHasher.h"
+#include "velox/exec/tests/utils/TempDirectoryPath.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+#include <folly/executors/CPUThreadPoolExecutor.h>
+#include <gtest/gtest.h>
+
+#include <sys/wait.h>
+#include <unistd.h>
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::test;
+
+namespace facebook::velox::exec::test {
+
+namespace {
+std::string readFile(const std::string& path) {
+  std::ifstream in(path, std::ios::binary);
+  if (!in.good()) {
+    return "";
+  }
+  in.seekg(0, std::ios::end);
+  const auto end = in.tellg();
+  if (end <= 0) {
+    return "";
+  }
+  const auto size = static_cast<size_t>(end);
+  in.seekg(0, std::ios::beg);
+  std::string data;
+  data.resize(size);
+  in.read(data.data(), data.size());
+  return data;
+}
+
+void writeFile(const std::string& path, const std::string& data) {
+  std::ofstream out(path, std::ios::binary);
+  out.write(data.data(), data.size());
+}
+} // namespace
+
+class HashTableSerializationTest : public testing::Test, public VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  std::string serialize(const HashTable<true>& table) const {
+    std::string data;
+    data.resize(table.serializedSize());
+    table.serializeTo(data.data(), data.size());
+    return data;
+  }
+
+  std::unique_ptr<HashTable<true>> deserialize(
+      const std::string& data,
+      memory::MemoryPool* pool,
+      folly::Executor* executor = nullptr) const {
+    return HashTable<true>::deserializeFrom(
+        data.data(), data.size(), pool, executor);
+  }
+
+  void SetUp() override {
+    pool_ = memory::memoryManager()->addLeafPool();
+    tempDir_ = exec::test::TempDirectoryPath::create();
+  }
+
+  void TearDown() override {
+    pool_.reset();
+  }
+
+  std::unique_ptr<HashTable<true>> createTestHashTable(
+      const std::vector<TypePtr>& keyTypes,
+      const std::vector<TypePtr>& dependentTypes,
+      bool allowDuplicates = false) {
+    std::vector<std::unique_ptr<VectorHasher>> hashers;
+    for (int i = 0; i < keyTypes.size(); ++i) {
+      hashers.push_back(std::make_unique<VectorHasher>(keyTypes[i], i));
+    }
+
+    return std::make_unique<HashTable<true>>(
+        std::move(hashers),
+        std::vector<Accumulator>{},
+        dependentTypes,
+        allowDuplicates,
+        true, // isJoinBuild
+        false, // hasProbedFlag
+        false, // hasCountFlag
+        0, // minTableSizeForParallelJoinBuild
+        pool_.get());
+  }
+
+  void insertData(
+      HashTable<true>* table,
+      const RowVectorPtr& data,
+      const std::vector<column_index_t>& /*keyChannels*/) {
+    SelectivityVector allRows(data->size());
+
+    std::vector<char*> inserted(data->size());
+    const auto nextOffset = table->rows()->nextOffset();
+    for (int i = 0; i < data->size(); ++i) {
+      inserted[i] = table->rows()->newRow();
+      if (nextOffset > 0) {
+        *reinterpret_cast<char**>(inserted[i] + nextOffset) = nullptr;
+      }
+    }
+
+    for (int col = 0; col < data->childrenSize(); ++col) {
+      DecodedVector decoded(*data->childAt(col), allRows);
+      for (int row = 0; row < data->size(); ++row) {
+        table->rows()->store(decoded, row, inserted[row], col);
+      }
+    }
+  }
+
+  // Inserts 'data' and also feeds the key columns to the VectorHashers the way
+  // a real join build does, so that prepareJoinTable() can settle on a value id
+  // based hash mode instead of falling back to kHash.
+  void insertDataWithValueIds(
+      HashTable<true>* table,
+      const RowVectorPtr& data) {
+    insertData(table, data, {});
+
+    const SelectivityVector allRows(data->size());
+    raw_vector<uint64_t> valueIds(data->size());
+    for (const auto& hasher : table->hashers()) {
+      hasher->decode(*data->childAt(hasher->channel()), allRows);
+      // A false return only means the ids do not fit the hasher's current
+      // range; prepareJoinTable() settles the mode from the observed values.
+      hasher->computeValueIds(allRows, valueIds);
+    }
+  }
+
+  void verifyHashTablesEqual(
+      HashTable<true>* original,
+      HashTable<true>* restored) {
+    EXPECT_EQ(original->numDistinct(), restored->numDistinct());
+    EXPECT_EQ(original->hashMode(), restored->hashMode());
+
+    auto* origRows = original->rows();
+    auto* restRows = restored->rows();
+    ASSERT_EQ(origRows->columnTypes().size(), restRows->columnTypes().size());
+
+    // The rows of either side may be spread over several containers: a
+    // parallel build leaves one per build thread behind, and deserializeFrom()
+    // gives each serialized row section one of its own so that the sections
+    // can be decoded in parallel. Gather them all.
+    auto listAll = [](HashTable<true>* table) {
+      std::vector<char*> rowPtrs;
+      std::vector<char*> buffer(1000);
+      for (auto* container : table->allRows()) {
+        RowContainerIterator iter;
+        while (true) {
+          auto numRows = container->listRows(
+              &iter, buffer.size(), RowContainer::kUnlimited, buffer.data());
+          if (numRows == 0) {
+            break;
+          }
+          rowPtrs.insert(
+              rowPtrs.end(), buffer.begin(), buffer.begin() + numRows);
+        }
+      }
+      return rowPtrs;
+    };
+
+    const auto origRowPtrs = listAll(original);
+    const auto restRowPtrs = listAll(restored);
+    ASSERT_EQ(origRowPtrs.size(), restRowPtrs.size());
+
+    // Extract through RowContainer so that strings spread over several
+    // HashStringAllocator blocks are read correctly, then compare the rows as
+    // sets since the two containers enumerate them in different orders.
+    auto encodeRows =
+        [this](RowContainer* rows, const std::vector<char*>& rowPtrs) {
+          std::vector<VectorPtr> columns;
+          for (auto col = 0; col < rows->columnTypes().size(); ++col) {
+            auto column = BaseVector::create(
+                rows->columnTypes()[col], rowPtrs.size(), pool_.get());
+            RowContainer::extractColumn(
+                rowPtrs.data(),
+                rowPtrs.size(),
+                rows->columnAt(col),
+                /*columnHasNulls=*/true,
+                column);
+            columns.push_back(std::move(column));
+          }
+
+          auto rowVector = makeRowVector(columns);
+          std::vector<std::string> encodedRows;
+          encodedRows.reserve(rowPtrs.size());
+          for (vector_size_t i = 0; i < rowVector->size(); ++i) {
+            encodedRows.push_back(rowVector->toString(i));
+          }
+          std::sort(encodedRows.begin(), encodedRows.end());
+          return encodedRows;
+        };
+
+    EXPECT_EQ(
+        encodeRows(origRows, origRowPtrs), encodeRows(restRows, restRowPtrs));
+  }
+
+  void verifyJoinProbe(
+      HashTable<true>* table,
+      const RowVectorPtr& probe,
+      int32_t expectedHits) {
+    HashLookup lookup(table->hashers(), pool_.get());
+    SelectivityVector rows(probe->size());
+    rows.setAll();
+
+    table->prepareForJoinProbe(lookup, probe, rows, true);
+    table->joinProbe(lookup);
+
+    int32_t hitCount = 0;
+    for (int32_t row = 0; row < probe->size(); ++row) {
+      if (lookup.hits[row] != nullptr) {
+        ++hitCount;
+      }
+    }
+    EXPECT_EQ(hitCount, expectedHits);
+  }
+
+  std::shared_ptr<memory::MemoryPool> pool_;
+  std::shared_ptr<TempDirectoryPath> tempDir_;
+};
+
+TEST_F(HashTableSerializationTest, BasicSerializationDefault) {
+  auto table = createTestHashTable({BIGINT()}, {VARCHAR()}, false);
+
+  auto data = makeRowVector(
+      {makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+       makeFlatVector<std::string>({"a", "b", "c", "d", "e"})});
+
+  insertData(table.get(), data, {0});
+  table->prepareJoinTable(
+      {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+
+  const auto serialized = serialize(*table);
+  auto restored = deserialize(serialized, pool_.get());
+
+  verifyHashTablesEqual(table.get(), restored.get());
+}
+
+TEST_F(HashTableSerializationTest, BasicSerializationJoinProbe) {
+  auto table = createTestHashTable({BIGINT()}, {VARCHAR()}, false);
+
+  auto data = makeRowVector(
+      {makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+       makeFlatVector<std::string>({"a", "b", "c", "d", "e"})});
+
+  insertData(table.get(), data, {0});
+  table->prepareJoinTable(
+      {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+
+  const auto serialized = serialize(*table);
+  auto restored = deserialize(serialized, pool_.get());
+
+  verifyHashTablesEqual(table.get(), restored.get());
+  verifyJoinProbe(restored.get(), data, data->size());
+}
+
+TEST_F(HashTableSerializationTest, arrayHashMode) {
+  auto table = createTestHashTable({BIGINT()}, {VARCHAR()}, false);
+
+  auto data = makeRowVector(
+      {makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+       makeFlatVector<std::string>({"a", "b", "c", "d", "e"})});
+
+  insertDataWithValueIds(table.get(), data);
+  table->prepareJoinTable(
+      {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+  ASSERT_EQ(table->hashMode(), BaseHashTable::HashMode::kArray);
+
+  const auto serialized = serialize(*table);
+  auto restored = deserialize(serialized, pool_.get());
+
+  ASSERT_EQ(restored->hashMode(), BaseHashTable::HashMode::kArray);
+  verifyHashTablesEqual(table.get(), restored.get());
+  verifyJoinProbe(restored.get(), data, data->size());
+}
+
+TEST_F(HashTableSerializationTest, normalizedKeyHashMode) {
+  auto table = createTestHashTable({BIGINT(), BIGINT()}, {VARCHAR()}, false);
+
+  // Two wide key ranges do not fit an array, but their concatenation fits in 64
+  // bits, which is what kNormalizedKey requires.
+  const vector_size_t numRows = 1'000;
+  auto data = makeRowVector(
+      {makeFlatVector<int64_t>(
+           numRows, [](auto row) { return row * 1'000'000; }),
+       makeFlatVector<int64_t>(
+           numRows, [](auto row) { return row * 2'000'000; }),
+       makeFlatVector<std::string>(
+           numRows, [](auto row) { return fmt::format("value_{}", row); })});
+
+  insertDataWithValueIds(table.get(), data);
+  table->prepareJoinTable(
+      {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+  ASSERT_EQ(table->hashMode(), BaseHashTable::HashMode::kNormalizedKey);
+
+  const auto serialized = serialize(*table);
+  auto restored = deserialize(serialized, pool_.get());
+
+  ASSERT_EQ(restored->hashMode(), BaseHashTable::HashMode::kNormalizedKey);
+  verifyHashTablesEqual(table.get(), restored.get());
+  verifyJoinProbe(restored.get(), data, data->size());
+}
+
+TEST_F(HashTableSerializationTest, MultipleDataTypes) {
+  auto table = createTestHashTable(
+      {BIGINT(), INTEGER(), VARCHAR()}, {DOUBLE(), BOOLEAN()}, false);
+
+  auto data = makeRowVector(
+      {makeFlatVector<int64_t>({1, 2, 3}),
+       makeFlatVector<int32_t>({10, 20, 30}),
+       makeFlatVector<std::string>({"key1", "key2", "key3"}),
+       makeFlatVector<double>({1.1, 2.2, 3.3}),
+       makeFlatVector<bool>({true, false, true})});
+
+  insertData(table.get(), data, {0, 1, 2});
+  table->prepareJoinTable(
+      {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+
+  const auto serialized = serialize(*table);
+  auto restored = deserialize(serialized, pool_.get());
+
+  verifyHashTablesEqual(table.get(), restored.get());
+}
+
+TEST_F(HashTableSerializationTest, NullValues) {
+  auto table = createTestHashTable({BIGINT()}, {VARCHAR()}, false);
+
+  auto data = makeRowVector(
+      {makeNullableFlatVector<int64_t>({1, std::nullopt, 3, std::nullopt, 5}),
+       makeNullableFlatVector<std::string>(
+           {"a", std::nullopt, "c", "d", std::nullopt})});
+
+  insertData(table.get(), data, {0});
+  table->prepareJoinTable(
+      {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+
+  const auto serialized = serialize(*table);
+  auto restored = deserialize(serialized, pool_.get());
+
+  verifyHashTablesEqual(table.get(), restored.get());
+}
+
+TEST_F(HashTableSerializationTest, LargeDataSet) {
+  auto table = createTestHashTable({BIGINT()}, {VARCHAR()}, false);
+
+  std::vector<int64_t> keys;
+  std::vector<std::string> values;
+  for (int i = 0; i < 10000; ++i) {
+    keys.push_back(i);
+    values.push_back("value_" + std::to_string(i));
+  }
+
+  auto data = makeRowVector({makeFlatVector(keys), makeFlatVector(values)});
+
+  insertData(table.get(), data, {0});
+  table->prepareJoinTable(
+      {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+
+  const auto serialized = serialize(*table);
+  auto restored = deserialize(serialized, pool_.get());
+
+  verifyHashTablesEqual(table.get(), restored.get());
+}
+
+TEST_F(HashTableSerializationTest, LongStrings) {
+  auto table = createTestHashTable({BIGINT()}, {VARCHAR()}, false);
+
+  std::vector<std::string> values = {
+      "short",
+      "this is a very long string that exceeds 12 bytes",
+      "medium",
+      std::string(1000, 'x'),
+      ""};
+
+  auto data = makeRowVector(
+      {makeFlatVector<int64_t>({1, 2, 3, 4, 5}), makeFlatVector(values)});
+
+  insertData(table.get(), data, {0});
+  table->prepareJoinTable(
+      {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+
+  const auto serialized = serialize(*table);
+  auto restored = deserialize(serialized, pool_.get());
+
+  verifyHashTablesEqual(table.get(), restored.get());
+}
+
+TEST_F(HashTableSerializationTest, AllowDuplicates) {
+  auto table = createTestHashTable({BIGINT()}, {VARCHAR()}, true);
+
+  auto data = makeRowVector(
+      {makeFlatVector<int64_t>({1, 1, 2, 2, 3}),
+       makeFlatVector<std::string>({"a1", "a2", "b1", "b2", "c"})});
+
+  insertData(table.get(), data, {0});
+  table->prepareJoinTable(
+      {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+
+  const auto serialized = serialize(*table);
+  auto restored = deserialize(serialized, pool_.get());
+
+  verifyHashTablesEqual(table.get(), restored.get());
+}
+
+TEST_F(HashTableSerializationTest, buildForSerializationOnly) {
+  // A table built with setBuildForSerializationOnly() skips allocating and
+  // populating the slot array, since that is not part of the serialized form
+  // and deserializeFrom() rebuilds it. The wire form must come out identical to
+  // that of a fully built table.
+  struct TestCase {
+    std::string name;
+    std::vector<TypePtr> keyTypes;
+    bool withValueIds;
+    BaseHashTable::HashMode expectedMode;
+    std::function<RowVectorPtr()> makeData;
+  };
+
+  const vector_size_t numRows = 1'000;
+  const std::vector<TestCase> testCases = {
+      {"kHash",
+       {BIGINT()},
+       false,
+       BaseHashTable::HashMode::kHash,
+       [&]() {
+         return makeRowVector(
+             {makeFlatVector<int64_t>(numRows, [](auto row) { return row; }),
+              makeFlatVector<std::string>(
+                  numRows, [](auto row) { return fmt::format("v_{}", row); })});
+       }},
+      {"kArray",
+       {BIGINT()},
+       true,
+       BaseHashTable::HashMode::kArray,
+       [&]() {
+         return makeRowVector(
+             {makeFlatVector<int64_t>(numRows, [](auto row) { return row; }),
+              makeFlatVector<std::string>(
+                  numRows, [](auto row) { return fmt::format("v_{}", row); })});
+       }},
+      {"kNormalizedKey",
+       {BIGINT(), BIGINT()},
+       true,
+       BaseHashTable::HashMode::kNormalizedKey,
+       [&]() {
+         return makeRowVector(
+             {makeFlatVector<int64_t>(
+                  numRows, [](auto row) { return row * 1'000'000; }),
+              makeFlatVector<int64_t>(
+                  numRows, [](auto row) { return row * 2'000'000; }),
+              makeFlatVector<std::string>(
+                  numRows, [](auto row) { return fmt::format("v_{}", row); })});
+       }},
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.name);
+    const auto data = testCase.makeData();
+
+    auto build = [&](bool serializeOnly) {
+      auto table = createTestHashTable(testCase.keyTypes, {VARCHAR()}, false);
+      table->setBuildForSerializationOnly(serializeOnly);
+      if (testCase.withValueIds) {
+        insertDataWithValueIds(table.get(), data);
+      } else {
+        insertData(table.get(), data, {});
+      }
+      table->prepareJoinTable(
+          {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+      return table;
+    };
+
+    auto full = build(false);
+    auto serializeOnly = build(true);
+
+    ASSERT_EQ(full->hashMode(), testCase.expectedMode);
+    EXPECT_EQ(serializeOnly->hashMode(), full->hashMode());
+    EXPECT_EQ(serializeOnly->capacity(), full->capacity());
+    EXPECT_EQ(serializeOnly->numDistinct(), full->numDistinct());
+
+    // The point of the mode: no slot array was built here.
+    EXPECT_EQ(serializeOnly->testingTable(), nullptr);
+    EXPECT_NE(full->testingTable(), nullptr);
+
+    // Identical bytes on the wire is the strongest statement that skipping the
+    // insertion changed nothing an executor can observe.
+    EXPECT_EQ(serialize(*serializeOnly), serialize(*full));
+
+    auto restored = deserialize(serialize(*serializeOnly), pool_.get());
+    EXPECT_EQ(restored->hashMode(), testCase.expectedMode);
+    EXPECT_NE(restored->testingTable(), nullptr);
+    verifyHashTablesEqual(full.get(), restored.get());
+    verifyJoinProbe(restored.get(), data, data->size());
+  }
+}
+
+TEST_F(HashTableSerializationTest, buildForSerializationOnlyWithDuplicates) {
+  // With duplicate keys the two builds differ in exactly one serialized field:
+  // 'hasDuplicates_' is set while inserting, which this mode does not do. The
+  // reading side sets it during its own insertion, so the restored table must
+  // still report duplicates and probe correctly.
+  auto data = makeRowVector(
+      {makeFlatVector<int64_t>({1, 1, 2, 2, 3}),
+       makeFlatVector<std::string>({"a1", "a2", "b1", "b2", "c"})});
+
+  auto build = [&](bool serializeOnly) {
+    auto table = createTestHashTable({BIGINT()}, {VARCHAR()}, true);
+    table->setBuildForSerializationOnly(serializeOnly);
+    insertData(table.get(), data, {});
+    table->prepareJoinTable(
+        {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+    return table;
+  };
+
+  auto full = build(false);
+  auto serializeOnly = build(true);
+
+  ASSERT_TRUE(full->hasDuplicateKeys());
+  ASSERT_FALSE(serializeOnly->hasDuplicateKeys());
+  EXPECT_EQ(serializeOnly->testingTable(), nullptr);
+
+  auto restored = deserialize(serialize(*serializeOnly), pool_.get());
+  EXPECT_TRUE(restored->hasDuplicateKeys());
+  verifyHashTablesEqual(full.get(), restored.get());
+  verifyJoinProbe(restored.get(), data, data->size());
+}
+
+TEST_F(HashTableSerializationTest, parallelDeserialize) {
+  // The serialized form splits the build rows into independently decodable
+  // sections so that deserializeFrom() can fill several RowContainers and the
+  // slot array at once. The result must not depend on whether it does.
+  struct TestCase {
+    std::string name;
+    bool withValueIds;
+    std::function<int64_t(vector_size_t)> key;
+    BaseHashTable::HashMode expectedMode;
+  };
+
+  // Enough rows to cross the section size, so that the parallel path really has
+  // more than one section to work with.
+  const vector_size_t numRows = 600'000;
+  const std::vector<TestCase> testCases = {
+      {"kHash",
+       false,
+       [](auto row) { return row; },
+       BaseHashTable::HashMode::kHash},
+      {"kArray",
+       true,
+       [](auto row) { return row; },
+       BaseHashTable::HashMode::kArray},
+      {"kNormalizedKey",
+       true,
+       [](auto row) { return static_cast<int64_t>(row) * 1'000'003; },
+       BaseHashTable::HashMode::kNormalizedKey},
+  };
+
+  folly::CPUThreadPoolExecutor executor(8);
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.name);
+    auto data = makeRowVector(
+        {makeFlatVector<int64_t>(numRows, testCase.key),
+         makeFlatVector<std::string>(numRows, [](auto row) {
+           return fmt::format("parallel_value_{}", row);
+         })});
+
+    auto table = createTestHashTable({BIGINT()}, {VARCHAR()}, false);
+    if (testCase.withValueIds) {
+      insertDataWithValueIds(table.get(), data);
+    } else {
+      insertData(table.get(), data, {0});
+    }
+    table->prepareJoinTable(
+        {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+    ASSERT_EQ(table->hashMode(), testCase.expectedMode);
+
+    const auto serialized = serialize(*table);
+    auto serial = deserialize(serialized, pool_.get());
+    auto parallel = deserialize(serialized, pool_.get(), &executor);
+
+    // More than one section, or the parallel path would be untested.
+    EXPECT_GT(parallel->testingOtherTables().size(), 0);
+
+    for (auto* restored : {serial.get(), parallel.get()}) {
+      verifyHashTablesEqual(table.get(), restored);
+      verifyJoinProbe(restored, data, data->size());
+      // A valid slot array: every used and tombstone slot accounted for.
+      restored->checkConsistency();
+      // The wire form must survive a round trip through either path.
+      EXPECT_EQ(serialize(*restored), serialized);
+    }
+  }
+}
+
+TEST_F(HashTableSerializationTest, normalizedKeysCarryTheHashes) {
+  // In kNormalizedKey mode the hashes are mixNormalizedKey() of the normalized
+  // keys, which are on the wire regardless, so they are not serialized
+  // separately. Guard the 8 bytes per row that buys.
+  //
+  // Two keys, since a single key with this many distinct values goes to kArray
+  // instead. Both ranges are too wide for an array while their value id
+  // concatenation fits in 64 bits, which is what kNormalizedKey requires.
+  const vector_size_t numRows = 10'000;
+  auto data = makeRowVector(
+      {makeFlatVector<int64_t>(
+           numRows,
+           [](auto row) { return static_cast<int64_t>(row) * 1'000'003; }),
+       makeFlatVector<int64_t>(
+           numRows,
+           [](auto row) { return static_cast<int64_t>(row) * 2'000'003; }),
+       makeFlatVector<std::string>(
+           numRows, [](auto row) { return fmt::format("v_{}", row); })});
+
+  auto table = createTestHashTable({BIGINT(), BIGINT()}, {VARCHAR()}, false);
+  insertDataWithValueIds(table.get(), data);
+  table->prepareJoinTable(
+      {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+  ASSERT_EQ(table->hashMode(), BaseHashTable::HashMode::kNormalizedKey);
+
+  const auto serialized = serialize(*table);
+  auto restored = deserialize(serialized, pool_.get());
+  verifyJoinProbe(restored.get(), data, data->size());
+
+  auto hashTable =
+      createTestHashTable({BIGINT(), BIGINT()}, {VARCHAR()}, false);
+  insertData(hashTable.get(), data, {0, 1});
+  hashTable->prepareJoinTable(
+      {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+  ASSERT_EQ(hashTable->hashMode(), BaseHashTable::HashMode::kHash);
+
+  // Same rows either way, and each mode writes exactly one 8 byte per row side
+  // table: normalized keys for one, hashes for the other. The only other
+  // difference is the value id state of the hashers, which kHash mode does not
+  // build. Account for that and the two wire forms come out the same size, so
+  // neither mode pays for both side tables.
+  const auto hashSerialized = serialize(*hashTable);
+  size_t valueIdStateBytes{0};
+  for (const auto& hasher : table->hashers()) {
+    valueIdStateBytes += hasher->serializeState().size();
+  }
+  for (const auto& hasher : hashTable->hashers()) {
+    valueIdStateBytes -= hasher->serializeState().size();
+  }
+  EXPECT_GT(valueIdStateBytes, 0);
+  EXPECT_EQ(serialized.size(), hashSerialized.size() + valueIdStateBytes);
+}
+
+TEST_F(HashTableSerializationTest, CrossProcessSerialization) {
+  std::string tempFile = tempDir_->getPath() + "/hashtable_cross_process.bin";
+
+  pid_t pid = fork();
+
+  if (pid == 0) {
+    auto childPool = memory::memoryManager()->addLeafPool();
+    pool_ = childPool;
+    auto table = createTestHashTable({BIGINT()}, {VARCHAR()}, false);
+
+    auto data = makeRowVector(
+        {makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+         makeFlatVector<std::string>(
+             {"child1", "child2", "child3", "child4", "child5"})});
+
+    insertData(table.get(), data, {0});
+    table->prepareJoinTable(
+        {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+
+    const auto serialized = serialize(*table);
+    writeFile(tempFile, serialized);
+
+    exit(0);
+  } else {
+    int status;
+    waitpid(pid, &status, 0);
+    ASSERT_EQ(WEXITSTATUS(status), 0) << "Child process failed";
+
+    const auto serialized = readFile(tempFile);
+    ASSERT_GT(serialized.size(), 0) << "Failed to read serialized file";
+    auto restored = deserialize(serialized, pool_.get());
+
+    EXPECT_EQ(restored->numDistinct(), 5);
+    EXPECT_EQ(restored->rows()->numRows(), 5);
+
+    std::remove(tempFile.c_str());
+  }
+}
+
+TEST_F(HashTableSerializationTest, MultiProcessConcurrentSerialization) {
+  const int numProcesses = 4;
+  std::vector<std::string> tempFiles;
+
+  for (int i = 0; i < numProcesses; ++i) {
+    std::string tempFile = tempDir_->getPath() + "/hashtable_process_" +
+        std::to_string(i) + ".bin";
+    tempFiles.push_back(tempFile);
+
+    pid_t pid = fork();
+
+    if (pid == 0) {
+      auto childPool = memory::memoryManager()->addLeafPool();
+      pool_ = childPool;
+      auto table = createTestHashTable({BIGINT()}, {VARCHAR()}, false);
+
+      int start = i * 1000;
+      int end = start + 1000;
+
+      std::vector<int64_t> keys;
+      std::vector<std::string> values;
+      for (int j = start; j < end; ++j) {
+        keys.push_back(j);
+        values.push_back(
+            "process_" + std::to_string(i) + "_value_" + std::to_string(j));
+      }
+
+      auto data = makeRowVector({makeFlatVector(keys), makeFlatVector(values)});
+
+      insertData(table.get(), data, {0});
+      table->prepareJoinTable(
+          {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+
+      const auto serialized = serialize(*table);
+      writeFile(tempFile, serialized);
+
+      exit(0);
+    }
+  }
+
+  for (int i = 0; i < numProcesses; ++i) {
+    int status;
+    wait(&status);
+    ASSERT_EQ(WEXITSTATUS(status), 0) << "Child process " << i << " failed";
+  }
+
+  for (int i = 0; i < numProcesses; ++i) {
+    const auto serialized = readFile(tempFiles[i]);
+    ASSERT_GT(serialized.size(), 0) << "Failed to read file from process " << i;
+    auto restored = deserialize(serialized, pool_.get());
+
+    EXPECT_EQ(restored->numDistinct(), 1000)
+        << "Process " << i << " data mismatch";
+
+    std::remove(tempFiles[i].c_str());
+  }
+}
+
+TEST_F(HashTableSerializationTest, CrossProcessDataMerge) {
+  const int numPartitions = 3;
+  std::vector<std::string> partitionFiles;
+
+  for (int i = 0; i < numPartitions; ++i) {
+    std::string tempFile =
+        tempDir_->getPath() + "/partition_" + std::to_string(i) + ".bin";
+    partitionFiles.push_back(tempFile);
+
+    pid_t pid = fork();
+
+    if (pid == 0) {
+      auto childPool = memory::memoryManager()->addLeafPool();
+      pool_ = childPool;
+      auto table = createTestHashTable({BIGINT()}, {VARCHAR()}, false);
+
+      std::vector<int64_t> keys;
+      std::vector<std::string> values;
+
+      for (int64_t key = 0; key < 1000; ++key) {
+        if (key % numPartitions == i) {
+          keys.push_back(key);
+          values.push_back(
+              "partition_" + std::to_string(i) + "_key_" + std::to_string(key));
+        }
+      }
+
+      auto data = makeRowVector({makeFlatVector(keys), makeFlatVector(values)});
+
+      insertData(table.get(), data, {0});
+      table->prepareJoinTable(
+          {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+
+      const auto serialized = serialize(*table);
+      writeFile(tempFile, serialized);
+
+      exit(0);
+    }
+  }
+
+  for (int i = 0; i < numPartitions; ++i) {
+    int status;
+    wait(&status);
+    ASSERT_EQ(WEXITSTATUS(status), 0);
+  }
+
+  int totalRows = 0;
+  for (int i = 0; i < numPartitions; ++i) {
+    const auto serialized = readFile(partitionFiles[i]);
+    ASSERT_GT(serialized.size(), 0) << "Failed to read partition file " << i;
+    auto partition = deserialize(serialized, pool_.get());
+
+    totalRows += partition->numDistinct();
+
+    std::remove(partitionFiles[i].c_str());
+  }
+
+  EXPECT_EQ(totalRows, 1000) << "Merged data count mismatch";
+}
+
+TEST_F(HashTableSerializationTest, PerformanceBenchmark) {
+  const int32_t numRows = 100'000;
+
+  auto table = createTestHashTable({BIGINT()}, {VARCHAR()}, false);
+
+  auto data = makeRowVector(
+      {makeFlatVector<int64_t>(numRows, [](auto row) { return row; }),
+       makeFlatVector<std::string>(numRows, [](auto row) {
+         return fmt::format("benchmark_value_{}", row);
+       })});
+
+  insertData(table.get(), data, {0});
+  table->prepareJoinTable(
+      {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+
+  using Clock = std::chrono::steady_clock;
+  auto micros = [](Clock::time_point begin, Clock::time_point end) {
+    return std::chrono::duration_cast<std::chrono::microseconds>(end - begin)
+        .count();
+  };
+
+  const auto beforeSize = Clock::now();
+  std::string serialized;
+  serialized.resize(table->serializedSize());
+  const auto beforeSerialize = Clock::now();
+  table->serializeTo(serialized.data(), serialized.size());
+  const auto beforeDeserialize = Clock::now();
+  auto restored = deserialize(serialized, pool_.get());
+  const auto end = Clock::now();
+
+  LOG(INFO) << "Serialization performance (" << numRows << " rows, "
+            << serialized.size() << " bytes):";
+  LOG(INFO) << "  serializedSize: " << micros(beforeSize, beforeSerialize)
+            << " us";
+  LOG(INFO) << "  serializeTo: " << micros(beforeSerialize, beforeDeserialize)
+            << " us";
+  LOG(INFO) << "  deserializeFrom: " << micros(beforeDeserialize, end) << " us";
+
+  verifyHashTablesEqual(table.get(), restored.get());
+}
+
+TEST_F(HashTableSerializationTest, InvalidMagicNumber) {
+  uint32_t invalidMagic = 0x12345678;
+  std::string data(sizeof(invalidMagic), '\0');
+  std::memcpy(data.data(), &invalidMagic, sizeof(invalidMagic));
+  EXPECT_THROW(deserialize(data, pool_.get()), VeloxException);
+}
+
+TEST_F(HashTableSerializationTest, UnsupportedVersion) {
+  uint32_t magic = 0x48415348;
+  uint32_t version = 999;
+  std::string data(sizeof(magic) + sizeof(version), '\0');
+  std::memcpy(data.data(), &magic, sizeof(magic));
+  std::memcpy(data.data() + sizeof(magic), &version, sizeof(version));
+  EXPECT_THROW(deserialize(data, pool_.get()), VeloxException);
+}
+
+TEST_F(HashTableSerializationTest, countingJoinIsRejected) {
+  // A counting build folds a duplicate row into the row it matched and leaves
+  // the folded row in the RowContainer, so replaying the insert on the reading
+  // side would count it twice. Serialization has to refuse rather than drop
+  // the counts silently.
+  std::vector<std::unique_ptr<VectorHasher>> hashers;
+  hashers.push_back(std::make_unique<VectorHasher>(BIGINT(), 0));
+  auto table = std::make_unique<HashTable<true>>(
+      std::move(hashers),
+      std::vector<Accumulator>{},
+      std::vector<TypePtr>{},
+      false, // allowDuplicates
+      true, // isJoinBuild
+      false, // hasProbedFlag
+      true, // hasCountFlag
+      0, // minTableSizeForParallelJoinBuild
+      pool_.get());
+
+  auto data = makeRowVector({makeFlatVector<int64_t>({1, 2, 3})});
+  insertData(table.get(), data, {0});
+  table->prepareJoinTable(
+      {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+
+  VELOX_ASSERT_THROW(
+      table->serializedSize(), "Serializing a counting join build side");
+}
+
+TEST_F(HashTableSerializationTest, CorruptedData) {
+  auto table = createTestHashTable({BIGINT()}, {VARCHAR()}, false);
+
+  auto data = makeRowVector(
+      {makeFlatVector<int64_t>({1, 2, 3}),
+       makeFlatVector<std::string>({"a", "b", "c"})});
+
+  insertData(table.get(), data, {0});
+  table->prepareJoinTable(
+      {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
+
+  auto serialized = serialize(*table);
+  ASSERT_GT(serialized.size(), 8);
+  serialized.resize(serialized.size() - 8);
+  EXPECT_THROW(deserialize(serialized, pool_.get()), VeloxException);
+}
+
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/VectorHasherTest.cpp
+++ b/velox/exec/tests/VectorHasherTest.cpp
@@ -1413,6 +1413,76 @@ TEST_F(VectorHasherTest, stringFilterDistinctOverflow) {
   ASSERT_TRUE(filter == nullptr);
 }
 
+TEST_F(VectorHasherTest, serializeStateRoundTripStringDistinctValues) {
+  std::vector<std::string> strings = {
+      "short",
+      "this is a long string value",
+      "medium",
+      "another long string value",
+      "short"};
+
+  auto vector = makeFlatVector<StringView>(
+      strings.size(),
+      [&strings](vector_size_t row) { return StringView(strings[row]); });
+
+  auto hasher = exec::VectorHasher::create(VARCHAR(), 0);
+  SelectivityVector rows(vector->size());
+  raw_vector<uint64_t> hashes(vector->size());
+  hasher->decode(*vector, rows);
+  hasher->computeValueIds(rows, hashes);
+  hasher->enableValueIds(1, 0);
+
+  auto serialized = hasher->serializeState();
+
+  auto restored = exec::VectorHasher::create(VARCHAR(), 0);
+  restored->deserializeState(serialized);
+
+  EXPECT_EQ(restored->numUniqueValues(), 4);
+
+  auto filter = restored->getFilter(false);
+  ASSERT_NE(filter, nullptr);
+  auto bytesValues = dynamic_cast<common::BytesValues*>(filter.get());
+  ASSERT_NE(bytesValues, nullptr);
+  EXPECT_TRUE(bytesValues->testBytes(strings[0].data(), strings[0].size()));
+  EXPECT_TRUE(bytesValues->testBytes(strings[1].data(), strings[1].size()));
+  EXPECT_TRUE(bytesValues->testBytes(strings[2].data(), strings[2].size()));
+  EXPECT_TRUE(bytesValues->testBytes(strings[3].data(), strings[3].size()));
+  EXPECT_FALSE(bytesValues->testBytes("missing", 7));
+}
+
+TEST_F(VectorHasherTest, serializeStateRoundTripBloomFilter) {
+  auto hasher = exec::VectorHasher::create(BIGINT(), 0);
+
+  constexpr uint32_t numRows = 10'000;
+  constexpr int numBatches = 15;
+  SelectivityVector rows(numRows);
+  raw_vector<uint64_t> hashes(numRows);
+  for (int batch = 0; batch < numBatches; ++batch) {
+    auto vector = makeFlatVector<int64_t>(
+        numRows, [batch](vector_size_t row) { return batch * numRows + row; });
+    hasher->decode(*vector, rows);
+    hasher->computeValueIds(rows, hashes);
+  }
+
+  ASSERT_TRUE(hasher->supportsBloomFilter());
+
+  auto filter = std::make_shared<common::BigintValuesUsingBloomFilter>(
+      numRows * numBatches, false);
+  for (int64_t value : {1, 17, 1024, 65536}) {
+    filter->insert(value);
+  }
+  hasher->setBloomFilter(filter);
+
+  auto serialized = hasher->serializeState();
+
+  auto restored = exec::VectorHasher::create(BIGINT(), 0);
+  restored->deserializeState(serialized);
+
+  auto restoredFilter = restored->getBloomFilter();
+  ASSERT_NE(restoredFilter, nullptr);
+  EXPECT_TRUE(restoredFilter->testingEquals(*filter));
+}
+
 DEBUG_ONLY_TEST_F(VectorHasherTest, customComparisonNoValueIds) {
   // Test that custom comparison types cannot use value IDs for optimization.
   auto data = makeRowVector({makeNullableFlatVector<int64_t>(

--- a/velox/exec/tests/VectorHasherTest.cpp
+++ b/velox/exec/tests/VectorHasherTest.cpp
@@ -1683,6 +1683,76 @@ TEST_F(VectorHasherTest, stringFilterDistinctOverflow) {
   ASSERT_TRUE(filter == nullptr);
 }
 
+TEST_F(VectorHasherTest, serializeStateRoundTripStringDistinctValues) {
+  std::vector<std::string> strings = {
+      "short",
+      "this is a long string value",
+      "medium",
+      "another long string value",
+      "short"};
+
+  auto vector = makeFlatVector<StringView>(
+      strings.size(),
+      [&strings](vector_size_t row) { return StringView(strings[row]); });
+
+  auto hasher = exec::VectorHasher::create(VARCHAR(), 0);
+  SelectivityVector rows(vector->size());
+  raw_vector<uint64_t> hashes(vector->size());
+  hasher->decode(*vector, rows);
+  hasher->computeValueIds(rows, hashes);
+  hasher->enableValueIds(1, 0);
+
+  auto serialized = hasher->serializeState();
+
+  auto restored = exec::VectorHasher::create(VARCHAR(), 0);
+  restored->deserializeState(serialized);
+
+  EXPECT_EQ(restored->numUniqueValues(), 4);
+
+  auto filter = restored->getFilter(false);
+  ASSERT_NE(filter, nullptr);
+  auto bytesValues = dynamic_cast<common::BytesValues*>(filter.get());
+  ASSERT_NE(bytesValues, nullptr);
+  EXPECT_TRUE(bytesValues->testBytes(strings[0].data(), strings[0].size()));
+  EXPECT_TRUE(bytesValues->testBytes(strings[1].data(), strings[1].size()));
+  EXPECT_TRUE(bytesValues->testBytes(strings[2].data(), strings[2].size()));
+  EXPECT_TRUE(bytesValues->testBytes(strings[3].data(), strings[3].size()));
+  EXPECT_FALSE(bytesValues->testBytes("missing", 7));
+}
+
+TEST_F(VectorHasherTest, serializeStateRoundTripBloomFilter) {
+  auto hasher = exec::VectorHasher::create(BIGINT(), 0);
+
+  constexpr uint32_t numRows = 10'000;
+  constexpr int numBatches = 15;
+  SelectivityVector rows(numRows);
+  raw_vector<uint64_t> hashes(numRows);
+  for (int batch = 0; batch < numBatches; ++batch) {
+    auto vector = makeFlatVector<int64_t>(
+        numRows, [batch](vector_size_t row) { return batch * numRows + row; });
+    hasher->decode(*vector, rows);
+    hasher->computeValueIds(rows, hashes);
+  }
+
+  ASSERT_TRUE(hasher->supportsBloomFilter());
+
+  auto filter = std::make_shared<common::BigintValuesUsingBloomFilter>(
+      numRows * numBatches, false);
+  for (int64_t value : {1, 17, 1024, 65536}) {
+    filter->insert(value);
+  }
+  hasher->setBloomFilter(filter);
+
+  auto serialized = hasher->serializeState();
+
+  auto restored = exec::VectorHasher::create(BIGINT(), 0);
+  restored->deserializeState(serialized);
+
+  auto restoredFilter = restored->getBloomFilter();
+  ASSERT_NE(restoredFilter, nullptr);
+  EXPECT_TRUE(restoredFilter->testingEquals(*filter));
+}
+
 DEBUG_ONLY_TEST_F(VectorHasherTest, customComparisonNoValueIds) {
   // Test that custom comparison types cannot use value IDs for optimization.
   auto data = makeRowVector({makeNullableFlatVector<int64_t>(

--- a/velox/type/Filter.cpp
+++ b/velox/type/Filter.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <cstring>
 #include <limits>
 #include <memory>
 #include <optional>
@@ -23,6 +24,7 @@
 #include "velox/type/Filter.h"
 
 #include "velox/common/EnumDefine.h"
+#include "velox/common/serialization/NativeSerdeIO.h"
 
 namespace facebook::velox::common {
 
@@ -415,6 +417,41 @@ std::unique_ptr<Filter> BigintValuesUsingBloomFilter::create(
       i = 0;
     }
   }
+  return std::unique_ptr<BigintValuesUsingBloomFilter>(
+      new BigintValuesUsingBloomFilter(nullAllowed, std::move(blocks)));
+}
+
+void BigintValuesUsingBloomFilter::serializeBinary(std::string& out) const {
+  common::NativeStringWriter writer(out);
+  writer.writeValue<bool>(nullAllowed());
+  writer.writeValue<uint32_t>(xsimd::batch<uint32_t>::size);
+  writer.writeValue<uint32_t>(blocks_.size());
+  for (const auto& block : blocks_) {
+    for (auto word : block.data) {
+      writer.writeValue<uint32_t>(word);
+    }
+  }
+}
+
+std::unique_ptr<Filter> BigintValuesUsingBloomFilter::deserializeBinary(
+    std::string_view data) {
+  common::NativeStringReader reader(data);
+  const auto nullAllowed = reader.readValue<bool>();
+  const auto simdWidth = reader.readValue<uint32_t>();
+  VELOX_USER_CHECK_EQ(
+      simdWidth,
+      xsimd::batch<uint32_t>::size,
+      "Cannot deserialize BigintValuesUsingBloomFilter serialized on hardware with different SIMD length");
+  const auto numBlocks = reader.readValue<uint32_t>();
+  std::vector<SplitBlockBloomFilter::Block> blocks(numBlocks);
+  for (auto& block : blocks) {
+    for (auto& word : block.data) {
+      word = reader.readValue<uint32_t>();
+    }
+  }
+  VELOX_USER_CHECK(
+      reader.atEnd(),
+      "Trailing bytes in BigintValuesUsingBloomFilter binary data");
   return std::unique_ptr<BigintValuesUsingBloomFilter>(
       new BigintValuesUsingBloomFilter(nullAllowed, std::move(blocks)));
 }

--- a/velox/type/Filter.cpp
+++ b/velox/type/Filter.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <cstring>
 #include <limits>
 #include <memory>
 #include <optional>
@@ -23,6 +24,7 @@
 #include "velox/type/Filter.h"
 
 #include "velox/common/EnumDefine.h"
+#include "velox/common/serialization/NativeSerdeIO.h"
 
 namespace facebook::velox::common {
 
@@ -415,6 +417,43 @@ std::unique_ptr<Filter> BigintValuesUsingBloomFilter::create(
       i = 0;
     }
   }
+  return std::unique_ptr<BigintValuesUsingBloomFilter>(
+      new BigintValuesUsingBloomFilter(nullAllowed, std::move(blocks)));
+}
+
+void BigintValuesUsingBloomFilter::serializeBinary(std::string& out) const {
+  out.reserve(out.size() + serializedBinarySize());
+  common::NativeStringWriter writer(out);
+  writer.writeValue<bool>(nullAllowed());
+  writer.writeValue<uint32_t>(xsimd::batch<uint32_t>::size);
+  writer.writeValue<uint32_t>(blocks_.size());
+  writer.write(blocks_.data(), blocks_.size() * sizeof(blocks_[0]));
+}
+
+size_t BigintValuesUsingBloomFilter::serializedBinarySize() const {
+  return sizeof(bool) + 2 * sizeof(uint32_t) +
+      blocks_.size() * sizeof(blocks_[0]);
+}
+
+std::unique_ptr<Filter> BigintValuesUsingBloomFilter::deserializeBinary(
+    std::string_view data) {
+  common::NativeStringReader reader(data);
+  const auto nullAllowed = reader.readValue<bool>();
+  const auto simdWidth = reader.readValue<uint32_t>();
+  VELOX_USER_CHECK_EQ(
+      simdWidth,
+      xsimd::batch<uint32_t>::size,
+      "Cannot deserialize BigintValuesUsingBloomFilter serialized on hardware with different SIMD length");
+  const auto numBlocks = reader.readValue<uint32_t>();
+  std::vector<SplitBlockBloomFilter::Block> blocks(numBlocks);
+  for (auto& block : blocks) {
+    for (auto& word : block.data) {
+      word = reader.readValue<uint32_t>();
+    }
+  }
+  VELOX_USER_CHECK(
+      reader.atEnd(),
+      "Trailing bytes in BigintValuesUsingBloomFilter binary data");
   return std::unique_ptr<BigintValuesUsingBloomFilter>(
       new BigintValuesUsingBloomFilter(nullAllowed, std::move(blocks)));
 }

--- a/velox/type/Filter.h
+++ b/velox/type/Filter.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <string_view>
+
 #include <folly/Range.h>
 #include <folly/container/F14Set.h>
 #include <xsimd/xsimd.hpp>
@@ -1332,6 +1334,10 @@ class BigintValuesUsingBloomFilter final : public Filter {
   folly::dynamic serialize() const override;
 
   static std::unique_ptr<Filter> create(const folly::dynamic& obj);
+
+  void serializeBinary(std::string& out) const;
+
+  static std::unique_ptr<Filter> deserializeBinary(std::string_view data);
 
   bool testingEquals(const Filter& other) const override;
 

--- a/velox/type/Filter.h
+++ b/velox/type/Filter.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <string_view>
+
 #include <folly/Range.h>
 #include <folly/container/F14Set.h>
 #include <xsimd/xsimd.hpp>
@@ -1337,6 +1339,15 @@ class BigintValuesUsingBloomFilter final : public Filter {
   folly::dynamic serialize() const override;
 
   static std::unique_ptr<Filter> create(const folly::dynamic& obj);
+
+  /// Appends the filter to 'out' in a host-native binary form that is only
+  /// readable by the same binary on the same architecture.
+  void serializeBinary(std::string& out) const;
+
+  /// Returns the number of bytes 'serializeBinary' appends.
+  size_t serializedBinarySize() const;
+
+  static std::unique_ptr<Filter> deserializeBinary(std::string_view data);
 
   bool testingEquals(const Filter& other) const override;
 


### PR DESCRIPTION
Adds `HashTable::serializedSize() / serializeTo() / deserializeFrom()`, so a join build side can be built once, handed to another process as bytes, and probed there without being rebuilt.

### What it is for

Broadcast hash joins. Today every task that probes a broadcast build side builds its own copy of the hash table from the same input: decode the keys, analyze them, decide the hash mode, hash the rows, insert them into the slot array. With these APIs the table is built once, serialized, and each consumer deserializes it, which also makes the build cost independent of the number of consumers. 

Deserialization is parallel: the build rows go on the wire in independently decodable sections, and deserializeFrom() takes an optional executor to decode them and insert them into the slot array concurrently. That is the same shape a parallel join build leaves behind (one RowContainer per worker, reachable through otherTables_), so the probe side handles it as usual.

For a producer that only ever serializes the table, `setBuildForSerializationOnly()` skips building the slot array during prepareJoinTable(). The slot array is not on the wire — it holds absolute pointers into the row container, which mean nothing in the reading process — so building it on the producer is pure duplicated work, and for a large build side it is a substantial part of both build time and peak memory. Everything that does go on the wire is still produced: the hash mode decision, the VectorHasher value id state, the normalized keys written into the rows, and the bloom
filters.

### What is on the wire

- The table metadata and the constructor parameters needed to recreate it: hash mode, capacity, numDistinct_, hasDuplicates_, allowDuplicates,  isJoinBuild, hasProbedFlag, minTableSizeForParallelJoinBuild, bloomFilterMaxSize, columnHasNulls_.
- The key types (through `Type::serialize()`) and their input channels, plus the dependent column types.
- The VectorHasher value id state per key: range, unique values, and the bloom filter. The probe side needs this to map probe keys to the same value ids the build side used; without it, it cannot use the kArray or kNormalizedKey probe paths at all.
- The build rows as row images (`RowContainer::serializeRows()`), chopped into sections, including the null and probed flag bytes.
- The hashes, in kHash mode only. In `kNormalizedKey` mode they are `mixNormalizedKey() `of the normalized keys, which are on the wire anyway, and in kArray mode the value ids are recomputed from the restored hasher state — so in both of those modes the reading side derives them instead of shipping 8 more bytes per row.

### Limitations

The format is host-native: fixed-width values are written raw, and the row images follow the producer's RowContainer layout. A serialized table is only readable by the same binary on the same architecture — it is a way to move a table between processes of one deployment, not a storage or an interchange format. There is no compatibility window: kSerializedTableVersion is checked for an exact match, and it is at 1 because nothing has ever read this format.

Anything the format does not carry is rejected at serialization time rather than dropped silently (serializeImpl()):

- Join build tables only (isJoinBuild_). Aggregation, RowNumber and TopNRowNumber tables are out.
- No accumulators.
- No counting joins (RowContainer::countOffset() != 0). A counting build folds a duplicate row into the row it matched and leaves the folded row in the RowContainer, so replaying the insert on the reading side would count it twice. Supporting it means shipping only the rows the slot array points at; a follow-up if a use case shows up.

Within join builds, all three hash modes and both duplicate settings round trip and are covered by tests. The probed flags are part of the serialized rows, so a table built with hasProbedFlag round trips as well, but the outer-join paths that write those flags during the probe are not exercised by the tests in this PR.


### Supporting changes

- RowContainer::serializeRows() / storeSerializedRows(): batch versions of the existing per-row extractSerializedRows() / storeSerializedRow() (already used by SortedAggregations), so a whole section is written or stored in one call.
- VectorHasher::serializeState() / deserializeState() for the value id state.
- BigintValuesUsingBloomFilter::serializeBinary() / deserializeBinary(), used by the above for the key bloom filters.

### Testing

velox/exec/tests/HashTableSerializationTest.cpp: round trips per hash mode (kArray / kNormalizedKey / kHash), multiple key and dependent column types, nulls, long strings, duplicate keys, a large build side, setBuildForSerializationOnly(), parallel deserialization, and probe-result equivalence against the original table via verifyJoinProbe(). Cross-process coverage forks a child that reads a table written by the parent. Failure paths: bad magic, unsupported version, truncated data, and a counting join build being rejected. VectorHasherTest covers the hasher state round trip.