### PR TITLE
build: Add ColumnReaderStatisticsTests.cpp to cmake

### DIFF
--- a/velox/dwio/common/tests/CMakeLists.txt
+++ b/velox/dwio/common/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(
   BitConcatenationTest.cpp
   BitPackDecoderTest.cpp
   ChainedBufferTests.cpp
+  ColumnReaderStatisticsTests.cpp
   ColumnSelectorTests.cpp
   DataBufferTests.cpp
   DecoderUtilTest.cpp


### PR DESCRIPTION
The test `ColumnReaderStatisticsTests.cpp` is not included in any CMake target so was not running. The patch fixes the issue.