### PR TITLE
fix(spark): Fix out-of-bounds write in Spark `map()` when a key repeats 3+ times under LAST_WIN

### DIFF
--- a/velox/functions/sparksql/Map.cpp
+++ b/velox/functions/sparksql/Map.cpp
@@ -136,7 +136,13 @@ class MapFunction : public exec::VectorFunction {
               VELOX_USER_FAIL(
                   "Duplicate map key ({}) was found.", duplicateKey);
             }
+            // The key at position i is superseded by a later occurrence and
+            // will be dropped by setKeysAndValuesResult (LAST_WIN). Count this
+            // occurrence once and stop; otherwise a key repeated N times would
+            // be counted C(N,2) times, under-sizing the result map (0 for N=3,
+            // negative for N>=4) and causing an out-of-bounds write.
             duplicateCnt++;
+            break;
           }
         }
       }

--- a/velox/functions/sparksql/tests/MapTest.cpp
+++ b/velox/functions/sparksql/tests/MapTest.cpp
@@ -136,6 +136,48 @@ TEST_F(MapTest, duplicateMapKey) {
       "Duplicate map key (20) was found.");
 }
 
+TEST_F(MapTest, duplicateMapKeyThreeOrMoreOccurrences) {
+  // Regression test for the case where the same key appears 3+ times in a
+  // single row under the LAST_WIN policy. The result size was computed by
+  // counting duplicate pairs (C(N,2)), while only N-1 occurrences are actually
+  // dropped, so the map was under-sized (0 for N=3, negative for N>=4), leading
+  // to an out-of-bounds write / crash. See fix in Map.cpp.
+  auto key = makeNullableFlatVector<int64_t>({7, 8});
+  auto value1 = makeNullableFlatVector<double>({1.0, 4.0});
+  auto value2 = makeNullableFlatVector<double>({2.0, 5.0});
+  auto value3 = makeNullableFlatVector<double>({3.0, 6.0});
+  auto value4 = makeNullableFlatVector<double>({3.5, 6.5});
+
+  queryCtx_->testingOverrideConfigUnsafe(
+      {{core::QueryConfig::kThrowExceptionOnDuplicateMapKeys, "false"}});
+
+  // Same key 3 times: keep the last value (LAST_WIN).
+  // map(k, v1, k, v2, k, v3) -> {k: v3}
+  const auto expectedThree =
+      makeMapVector<int64_t, double>({{{7, 3.0}}, {{8, 6.0}}});
+  testMap(
+      "map(c0, c1, c0, c2, c0, c3)",
+      {key, value1, value2, value3},
+      expectedThree);
+
+  // Same key 4 times: keep the last value.
+  // map(k, v1, k, v2, k, v3, k, v4) -> {k: v4}
+  const auto expectedFour =
+      makeMapVector<int64_t, double>({{{7, 3.5}}, {{8, 6.5}}});
+  testMap(
+      "map(c0, c1, c0, c2, c0, c3, c0, c4)",
+      {key, value1, value2, value3, value4},
+      expectedFour);
+
+  // EXCEPTION policy is unaffected: still fails on the duplicate key.
+  queryCtx_->testingOverrideConfigUnsafe(
+      {{core::QueryConfig::kThrowExceptionOnDuplicateMapKeys, "true"}});
+  testMapFails(
+      "map(c0, c1, c0, c2, c0, c3)",
+      {key, value1, value2, value3},
+      "Duplicate map key (7) was found.");
+}
+
 TEST_F(MapTest, wide) {
   auto inputVector1 = makeNullableFlatVector<int64_t>({1, 2, 3});
   auto inputVector2 = makeNullableFlatVector<double>({4.0, 5.0, 6.0});


### PR DESCRIPTION
## Summary

The Spark `map()` function (`velox/functions/sparksql/Map.cpp`) under-sizes the result map when the **same key appears three or more times in a single row** with `throw_exception_on_duplicate_map_keys = false` (Spark's
`spark.sql.mapKeyDedupPolicy = LAST_WIN`). The under-allocation causes `setKeysAndValuesResult` to write past the end of the result key/value vectors, corrupting memory and crashing the process (SIGABRT / exit 134).

The result size and the actual writes are computed in two passes that disagree on what "duplicate" means:

- **Size pass** counted duplicate *pairs*: for a key repeated `N` times it added `C(N, 2)` to `duplicateCnt`, so `rawSizes[row] = mapSize - duplicateCnt` becomes `0` for `N = 3` and negative for `N >= 4`.
- **Write pass** (`setKeysAndValuesResult`) keeps only the *last* occurrence of each key, i.e. it drops `N - 1` elements — the correct LAST_WIN semantics.

For `N = 3` the size pass reserves 0 slots while the write pass writes 1 element, hence the overflow. `N = 2` happens to be correct (`C(2,2) = 1 = N - 1`), which is why existing tests — only exercising two duplicates — did not catch it.

The fix makes the size pass count elements to drop instead of pairs: once a key at position `i` is found to be duplicated by a later position, count it once and `break`. This yields `duplicateCnt = N - 1` per group, matching the write pass. The `EXCEPTION` policy is unaffected — it still fails on the first duplicate pair.

Regression introduced by #13183 (which added the LAST_WIN handling).

## Reproduction

Spark SQL on the Velox backend, with the same column repeated three times so the keys are equal at runtime (literal keys are constant-folded away by the planner and never reach Velox):

```sql
SET spark.sql.mapKeyDedupPolicy=LAST_WIN;
SELECT map(id, 'morning', id, 'dawn', id, 'night') FROM range(10);
```

Before: executor crashes with `Exit status: 134` (SIGABRT).
After: returns `{id -> 'night'}` per row (last value wins).

## Test Plan

- Added `MapTest.duplicateMapKeyThreeOrMoreOccurrences` covering:
  - a key repeated 3 times under LAST_WIN → keeps the last value;
  - a key repeated 4 times under LAST_WIN → keeps the last value;
  - the same input under EXCEPTION → still throws `Duplicate map key (...) was found.`
- Existing `MapTest.duplicateMapKey` (2 duplicates, both policies) continues to pass.

```
velox_functions_spark_test --gtest_filter='MapTest.duplicateMapKey*'
```