### PR TITLE
fix(cudf): Fix AzuriteServer.cpp location on Presto builds

### DIFF
--- a/velox/experimental/cudf/tests/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/CMakeLists.txt
@@ -58,7 +58,7 @@ if(VELOX_ENABLE_ABFS)
     SOURCES
       Main.cpp
       AbfsReadTest.cpp
-      ${CMAKE_SOURCE_DIR}/velox/connectors/hive/storage_adapters/abfs/tests/AzuriteServer.cpp
+      ${CMAKE_CURRENT_SOURCE_DIR}/../../../connectors/hive/storage_adapters/abfs/tests/AzuriteServer.cpp
     LIBS
       velox_cudf_exec_test_lib
       velox_cudf_hive_connector


### PR DESCRIPTION
The CMAKE_SOURCE_DIR when building Presto C++ is not the same as when building Velox.

Presto C++ GPU builds are broken when compiling ABFS support.