### PR TITLE
feat(cudf): Lazy gather and batched output for CudfHashJoinProbe

### DIFF
--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -26,6 +26,8 @@
 
 #include "velox/common/testutil/TestValue.h"
 #include "velox/core/PlanNode.h"
+
+#include <limits>
 #include "velox/exec/Task.h" // NOLINT(misc-unused-headers)
 #include "velox/type/TypeUtil.h"
 
@@ -539,7 +541,8 @@ bool CudfHashJoinProbe::needsInput() const {
   if (joinNode_->isRightSemiFilterJoin()) {
     return !noMoreInput_;
   }
-  return !noMoreInput_ && !finished_ && input_ == nullptr;
+  return !noMoreInput_ && !finished_ && input_ == nullptr &&
+      outputQueue_.empty() && pendingIndices_.empty();
 }
 
 void CudfHashJoinProbe::doAddInput(RowVectorPtr input) {
@@ -826,68 +829,123 @@ CudfHashJoinProbe::JoinOutput CudfHashJoinProbe::filteredOutputIndices(
       stream);
 }
 
-std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::innerJoin(
+void CudfHashJoinProbe::enqueuePendingIndices(
+    std::unique_ptr<rmm::device_uvector<cudf::size_type>> leftIndices,
+    std::unique_ptr<rmm::device_uvector<cudf::size_type>> rightIndices,
+    size_t buildChunkIndex) {
+  pendingIndices_.push(
+      {std::move(leftIndices), std::move(rightIndices), 0, buildChunkIndex});
+}
+
+RowVectorPtr CudfHashJoinProbe::gatherPendingBatch(
+    rmm::cuda_stream_view stream) {
+  VELOX_CHECK(!pendingIndices_.empty());
+  VELOX_CHECK_NOT_NULL(input_);
+  auto cudfInput = std::dynamic_pointer_cast<CudfVector>(input_);
+  VELOX_CHECK_NOT_NULL(cudfInput);
+  auto const maxRows = maxBatchRows();
+  auto& rightTables = hashObject_.value().first;
+  auto leftTableView = cudfInput->getTableView();
+
+  // Gather sub-chunks from the front of pendingIndices_ until we fill a batch.
+  std::vector<JoinOutput> gathered;
+  size_t rows = 0;
+  while (!pendingIndices_.empty() && rows < maxRows) {
+    auto& entry = pendingIndices_.front();
+    auto const chunkSize = std::min(maxRows - rows, entry.remaining());
+
+    auto leftSpan = cudf::device_span<cudf::size_type const>{
+        entry.leftIndices->data() + entry.offset, chunkSize};
+    auto rightSpan = cudf::device_span<cudf::size_type const>{
+        entry.rightIndices->data() + entry.offset, chunkSize};
+    auto leftIndicesCol = cudf::column_view{leftSpan};
+    auto rightIndicesCol = cudf::column_view{rightSpan};
+    auto rightTableView = rightTables[entry.buildChunkIndex]->view();
+
+    gathered.push_back(unfilteredOutput(
+        leftTableView,
+        leftIndicesCol,
+        rightTableView,
+        rightIndicesCol,
+        stream));
+    rows += chunkSize;
+    entry.offset += chunkSize;
+
+    // Pop entry if fully consumed.
+    if (entry.remaining() == 0) {
+      pendingIndices_.pop();
+    }
+  }
+
+  // If pendingIndices_ is now empty, release probe input.
+  if (pendingIndices_.empty()) {
+    input_.reset();
+    finished_ =
+        noMoreInput_ && !joinNode_->isRightJoin() && !joinNode_->isFullJoin();
+  }
+
+  if (gathered.empty()) {
+    return nullptr;
+  }
+
+  // Concatenate gathered chunks.
+  if (gathered.size() == 1) {
+    auto const size = static_cast<cudf::size_type>(gathered[0].numRows);
+    if (size == 0) {
+      return nullptr;
+    }
+    return std::make_shared<CudfVector>(
+        pool(), outputType_, size, std::move(gathered[0].table), stream);
+  }
+
+  std::vector<std::unique_ptr<cudf::table>> tables;
+  tables.reserve(gathered.size());
+  for (auto& g : gathered) {
+    tables.push_back(std::move(g.table));
+  }
+  auto result = concatenateTables(std::move(tables), stream, get_output_mr());
+  auto const size = static_cast<cudf::size_type>(result->num_rows());
+  if (size == 0) {
+    return nullptr;
+  }
+  return std::make_shared<CudfVector>(
+      pool(), outputType_, size, std::move(result), stream);
+}
+
+void CudfHashJoinProbe::innerJoin(
     cudf::table_view leftTableView,
     rmm::cuda_stream_view stream) {
-  std::vector<JoinOutput> cudfOutputs;
-
   auto& rightTables = hashObject_.value().first;
   auto& hbs = hashObject_.value().second;
 
-  // Precompute left (probe) table columns if needed (once, outside loop)
-  std::vector<ColumnOrView> leftPrecomputed;
-  cudf::table_view extendedLeftView = leftTableView;
-  if (joinNode_->filter() && useAstFilter_ &&
-      !leftPrecomputeInstructions_.empty()) {
-    auto leftColumnViews = tableViewToColumnViews(leftTableView);
-    leftPrecomputed = precomputeSubexpressions(
-        leftColumnViews,
-        leftPrecomputeInstructions_,
-        scalars_,
-        probeType_,
-        stream);
-    extendedLeftView = createExtendedTableView(leftTableView, leftPrecomputed);
-  }
-
-  for (auto i = 0; i < rightTables.size(); i++) {
-    auto rightTableView = rightTables[i]->view();
-    auto& hb = hbs[i];
-
-    // Use cached precomputed columns for right (build) table
-    cudf::table_view extendedRightView =
-        (joinNode_->filter() && useAstFilter_ &&
-         !rightPrecomputeInstructions_.empty())
-        ? cachedExtendedRightViews_[i]
-        : rightTableView;
-
-    // left = probe, right = build
-    VELOX_CHECK_NOT_NULL(hb);
-    auto [leftJoinIndices, rightJoinIndices] = hb->inner_join(
-        leftTableView.select(leftKeyIndices_),
-        std::nullopt,
-        stream,
-        get_temp_mr());
-
-    auto leftIndicesSpan =
-        cudf::device_span<cudf::size_type const>{*leftJoinIndices};
-    auto rightIndicesSpan =
-        cudf::device_span<cudf::size_type const>{*rightJoinIndices};
-    auto leftIndicesCol = cudf::column_view{leftIndicesSpan};
-    auto rightIndicesCol = cudf::column_view{rightIndicesSpan};
-    std::vector<std::unique_ptr<cudf::column>> joinedCols;
-
-    if (joinNode_->filter()) {
-      if (useAstFilter_) {
-        cudfOutputs.push_back(filteredOutputIndices(
-            leftTableView,
-            leftIndicesCol,
-            rightTableView,
-            rightIndicesCol,
-            extendedLeftView,
-            extendedRightView,
-            cudf::join_kind::INNER_JOIN,
-            stream));
-      } else {
+  // Non-AST filter path: eagerly gather and push to outputQueue_.
+  if (joinNode_->filter() && !useAstFilter_) {
+    for (size_t i = 0; i < rightTables.size(); i++) {
+      auto rightTableView = rightTables[i]->view();
+      auto& hb = hbs[i];
+      VELOX_CHECK_NOT_NULL(hb);
+      auto [leftJoinIndices, rightJoinIndices] = hb->inner_join(
+          leftTableView.select(leftKeyIndices_),
+          std::nullopt,
+          stream,
+          get_temp_mr());
+      auto leftIndicesSpan =
+          cudf::device_span<cudf::size_type const>{*leftJoinIndices};
+      auto rightIndicesSpan =
+          cudf::device_span<cudf::size_type const>{*rightJoinIndices};
+      VLOG(1) << "CudfHashJoinProbe[" << planNodeId()
+              << "] innerJoin (non-AST filter) chunk " << i
+              << ": joinResultRows=" << leftIndicesSpan.size();
+      // For non-AST filter, gather eagerly (filter needs materialized data).
+      // Split oversized spans into sub-maxBatchRows chunks.
+      auto const maxRows = maxBatchRows();
+      auto const totalRows = leftIndicesSpan.size();
+      for (size_t offset = 0; offset < totalRows; offset += maxRows) {
+        auto const chunkSize = std::min(maxRows, totalRows - offset);
+        auto leftChunk = leftIndicesSpan.subspan(offset, chunkSize);
+        auto rightChunk = rightIndicesSpan.subspan(offset, chunkSize);
+        auto leftIndicesCol = cudf::column_view{leftChunk};
+        auto rightIndicesCol = cudf::column_view{rightChunk};
         auto filterFunc =
             [stream](
                 std::vector<std::unique_ptr<cudf::column>>&& joinedCols,
@@ -898,124 +956,225 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::innerJoin(
                   *filterTable, filterColumn, stream, get_output_mr());
               return filteredTable->release();
             };
-        cudfOutputs.push_back(filteredOutput(
+        auto output = filteredOutput(
             leftTableView,
             leftIndicesCol,
             rightTableView,
             rightIndicesCol,
             filterFunc,
-            stream));
+            stream);
+        if (output.numRows > 0) {
+          outputQueue_.push(std::make_shared<CudfVector>(
+              pool(), outputType_, output.numRows,
+              std::move(output.table), stream));
+        }
+      }
+    }
+    return;
+  }
+
+  // AST filter or no filter: populate pendingIndices_ for lazy gather.
+  for (size_t i = 0; i < rightTables.size(); i++) {
+    auto rightTableView = rightTables[i]->view();
+    auto& hb = hbs[i];
+    VELOX_CHECK_NOT_NULL(hb);
+    auto [leftJoinIndices, rightJoinIndices] = hb->inner_join(
+        leftTableView.select(leftKeyIndices_),
+        std::nullopt,
+        stream,
+        get_temp_mr());
+    VLOG(1) << "CudfHashJoinProbe[" << planNodeId() << "] innerJoin chunk "
+            << i << ": joinResultRows=" << leftJoinIndices->size()
+            << ", leftProbeRows=" << leftTableView.num_rows()
+            << ", rightBuildRows=" << rightTableView.num_rows();
+
+    if (joinNode_->filter()) {
+      // AST filter: eagerly apply filter_join_indices to reduce index count.
+      auto leftIndicesSpan =
+          cudf::device_span<cudf::size_type const>{*leftJoinIndices};
+      auto rightIndicesSpan =
+          cudf::device_span<cudf::size_type const>{*rightJoinIndices};
+
+      // Precompute left columns for AST filter if needed.
+      cudf::table_view extendedLeftView = leftTableView;
+      std::vector<ColumnOrView> leftPrecomputed;
+      if (!leftPrecomputeInstructions_.empty()) {
+        auto leftColumnViews = tableViewToColumnViews(leftTableView);
+        leftPrecomputed = precomputeSubexpressions(
+            leftColumnViews,
+            leftPrecomputeInstructions_,
+            scalars_,
+            probeType_,
+            stream);
+        extendedLeftView =
+            createExtendedTableView(leftTableView, leftPrecomputed);
+      }
+      cudf::table_view extendedRightView =
+          (!rightPrecomputeInstructions_.empty())
+          ? cachedExtendedRightViews_[i]
+          : rightTableView;
+
+      // Split into sub-maxBatchRows spans for filter_join_indices.
+      auto const maxRows = maxBatchRows();
+      auto const totalRows = leftIndicesSpan.size();
+      for (size_t offset = 0; offset < totalRows; offset += maxRows) {
+        auto const chunkSize = std::min(maxRows, totalRows - offset);
+        auto leftChunk = leftIndicesSpan.subspan(offset, chunkSize);
+        auto rightChunk = rightIndicesSpan.subspan(offset, chunkSize);
+        auto leftIndicesCol = cudf::column_view{leftChunk};
+        auto rightIndicesCol = cudf::column_view{rightChunk};
+        auto [filteredLeft, filteredRight] = cudf::filter_join_indices(
+            extendedLeftView,
+            extendedRightView,
+            leftIndicesCol,
+            rightIndicesCol,
+            tree_.back(),
+            cudf::join_kind::INNER_JOIN,
+            stream,
+            get_temp_mr());
+        // Enqueue the filtered (smaller) indices for lazy gather.
+        enqueuePendingIndices(
+            std::move(filteredLeft), std::move(filteredRight), i);
       }
     } else {
-      cudfOutputs.push_back(unfilteredOutput(
-          leftTableView,
-          leftIndicesCol,
-          rightTableView,
-          rightIndicesCol,
-          stream));
+      // No filter: enqueue raw indices for lazy gather.
+      enqueuePendingIndices(
+          std::move(leftJoinIndices), std::move(rightJoinIndices), i);
     }
   }
-  return cudfOutputs;
 }
 
-std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::leftJoin(
+void CudfHashJoinProbe::leftJoin(
     cudf::table_view leftTableView,
     rmm::cuda_stream_view stream) {
-  std::vector<JoinOutput> cudfOutputs;
-
   auto& rightTables = hashObject_.value().first;
   auto& hbs = hashObject_.value().second;
 
-  // Precompute left (probe) table columns if needed (once, outside loop)
-  std::vector<ColumnOrView> leftPrecomputed;
-  cudf::table_view extendedLeftView = leftTableView;
-  if (joinNode_->filter() && !leftPrecomputeInstructions_.empty()) {
-    auto leftColumnViews = tableViewToColumnViews(leftTableView);
-    leftPrecomputed = precomputeSubexpressions(
-        leftColumnViews,
-        leftPrecomputeInstructions_,
-        scalars_,
-        probeType_,
-        stream);
-    extendedLeftView = createExtendedTableView(leftTableView, leftPrecomputed);
+  // Non-AST filter path: eagerly gather and push to outputQueue_.
+  if (joinNode_->filter() && !useAstFilter_) {
+    for (size_t i = 0; i < rightTables.size(); i++) {
+      auto rightTableView = rightTables[i]->view();
+      auto& hb = hbs[i];
+      VELOX_CHECK_NOT_NULL(hb);
+      auto [leftJoinIndices, rightJoinIndices] = hb->left_join(
+          leftTableView.select(leftKeyIndices_),
+          std::nullopt,
+          stream,
+          get_temp_mr());
+      auto leftIndicesSpan =
+          cudf::device_span<cudf::size_type const>{*leftJoinIndices};
+      auto rightIndicesSpan =
+          cudf::device_span<cudf::size_type const>{*rightJoinIndices};
+      auto const maxRows = maxBatchRows();
+      auto const totalRows = leftIndicesSpan.size();
+      for (size_t offset = 0; offset < totalRows; offset += maxRows) {
+        auto const chunkSize = std::min(maxRows, totalRows - offset);
+        auto leftChunk = leftIndicesSpan.subspan(offset, chunkSize);
+        auto rightChunk = rightIndicesSpan.subspan(offset, chunkSize);
+        auto leftIndicesCol = cudf::column_view{leftChunk};
+        auto rightIndicesCol = cudf::column_view{rightChunk};
+        auto filterFunc =
+            [stream](
+                std::vector<std::unique_ptr<cudf::column>>&& joinedCols,
+                cudf::column_view filterColumn) {
+              auto filterTable =
+                  std::make_unique<cudf::table>(std::move(joinedCols));
+              auto filteredTable = cudf::apply_boolean_mask(
+                  *filterTable, filterColumn, stream, get_output_mr());
+              return filteredTable->release();
+            };
+        auto output = filteredOutput(
+            leftTableView,
+            leftIndicesCol,
+            rightTableView,
+            rightIndicesCol,
+            filterFunc,
+            stream);
+        if (output.numRows > 0) {
+          outputQueue_.push(std::make_shared<CudfVector>(
+              pool(), outputType_, output.numRows,
+              std::move(output.table), stream));
+        }
+      }
+    }
+    return;
   }
 
-  for (auto i = 0; i < rightTables.size(); i++) {
+  // AST filter or no filter: populate pendingIndices_ for lazy gather.
+  for (size_t i = 0; i < rightTables.size(); i++) {
     auto rightTableView = rightTables[i]->view();
     auto& hb = hbs[i];
-
-    // Use cached precomputed columns for right (build) table
-    cudf::table_view extendedRightView =
-        (joinNode_->filter() && !rightPrecomputeInstructions_.empty())
-        ? cachedExtendedRightViews_[i]
-        : rightTableView;
-
     VELOX_CHECK_NOT_NULL(hb);
     auto [leftJoinIndices, rightJoinIndices] = hb->left_join(
         leftTableView.select(leftKeyIndices_),
         std::nullopt,
         stream,
         get_temp_mr());
-
-    auto leftIndicesSpan =
-        cudf::device_span<cudf::size_type const>{*leftJoinIndices};
-    auto rightIndicesSpan =
-        cudf::device_span<cudf::size_type const>{*rightJoinIndices};
-    auto leftIndicesCol = cudf::column_view{leftIndicesSpan};
-    auto rightIndicesCol = cudf::column_view{rightIndicesSpan};
-    std::vector<std::unique_ptr<cudf::column>> joinedCols;
+    VLOG(1) << "CudfHashJoinProbe[" << planNodeId() << "] leftJoin chunk "
+            << i << ": joinResultRows=" << leftJoinIndices->size()
+            << ", leftProbeRows=" << leftTableView.num_rows()
+            << ", rightBuildRows=" << rightTableView.num_rows();
 
     if (joinNode_->filter()) {
-      if (useAstFilter_) {
-        cudfOutputs.push_back(filteredOutputIndices(
-            leftTableView,
-            leftIndicesCol,
-            rightTableView,
-            rightIndicesCol,
+      // AST filter: eagerly apply filter_join_indices to reduce index count.
+      auto leftIndicesSpan =
+          cudf::device_span<cudf::size_type const>{*leftJoinIndices};
+      auto rightIndicesSpan =
+          cudf::device_span<cudf::size_type const>{*rightJoinIndices};
+
+      cudf::table_view extendedLeftView = leftTableView;
+      std::vector<ColumnOrView> leftPrecomputed;
+      if (!leftPrecomputeInstructions_.empty()) {
+        auto leftColumnViews = tableViewToColumnViews(leftTableView);
+        leftPrecomputed = precomputeSubexpressions(
+            leftColumnViews,
+            leftPrecomputeInstructions_,
+            scalars_,
+            probeType_,
+            stream);
+        extendedLeftView =
+            createExtendedTableView(leftTableView, leftPrecomputed);
+      }
+      cudf::table_view extendedRightView =
+          (!rightPrecomputeInstructions_.empty())
+          ? cachedExtendedRightViews_[i]
+          : rightTableView;
+
+      auto const maxRows = maxBatchRows();
+      auto const totalRows = leftIndicesSpan.size();
+      for (size_t offset = 0; offset < totalRows; offset += maxRows) {
+        auto const chunkSize = std::min(maxRows, totalRows - offset);
+        auto leftChunk = leftIndicesSpan.subspan(offset, chunkSize);
+        auto rightChunk = rightIndicesSpan.subspan(offset, chunkSize);
+        auto leftIndicesCol = cudf::column_view{leftChunk};
+        auto rightIndicesCol = cudf::column_view{rightChunk};
+        auto [filteredLeft, filteredRight] = cudf::filter_join_indices(
             extendedLeftView,
             extendedRightView,
-            cudf::join_kind::LEFT_JOIN,
-            stream));
-      } else {
-        auto filterFunc =
-            [stream](
-                std::vector<std::unique_ptr<cudf::column>>&& joinedCols,
-                cudf::column_view filterColumn) {
-              auto filterTable =
-                  std::make_unique<cudf::table>(std::move(joinedCols));
-              auto filteredTable = cudf::apply_boolean_mask(
-                  *filterTable, filterColumn, stream, get_output_mr());
-              return filteredTable->release();
-            };
-        cudfOutputs.push_back(filteredOutput(
-            leftTableView,
             leftIndicesCol,
-            rightTableView,
             rightIndicesCol,
-            filterFunc,
-            stream));
+            tree_.back(),
+            cudf::join_kind::LEFT_JOIN,
+            stream,
+            get_temp_mr());
+        enqueuePendingIndices(
+            std::move(filteredLeft), std::move(filteredRight), i);
       }
     } else {
-      cudfOutputs.push_back(unfilteredOutput(
-          leftTableView,
-          leftIndicesCol,
-          rightTableView,
-          rightIndicesCol,
-          stream));
+      // No filter: enqueue raw indices for lazy gather.
+      enqueuePendingIndices(
+          std::move(leftJoinIndices), std::move(rightJoinIndices), i);
     }
   }
-  return cudfOutputs;
 }
 
-std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::rightJoin(
+void CudfHashJoinProbe::rightJoin(
     cudf::table_view leftTableView,
     rmm::cuda_stream_view stream) {
-  std::vector<JoinOutput> cudfOutputs;
-
   auto& rightTables = hashObject_.value().first;
   auto& hbs = hashObject_.value().second;
 
-  for (auto i = 0; i < rightTables.size(); i++) {
+  for (size_t i = 0; i < rightTables.size(); i++) {
     auto rightTableView = rightTables[i]->view();
     auto& hb = hbs[i];
 
@@ -1025,65 +1184,41 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::rightJoin(
         std::nullopt,
         stream,
         get_temp_mr());
-    if (!joinNode_->filter()) {
-      // Mark matched build rows by checking which row indices appear in
-      // rightJoinIndices. Use contains to avoid scatter with duplicate indices.
-      auto rightIdxCol = cudf::column_view{
-          cudf::device_span<cudf::size_type const>{*rightJoinIndices}};
 
-      // Create sequence [0, 1, ..., n-1] for build table row indices
-      auto n = rightTableView.num_rows();
-      auto rowIndices = cudf::sequence(
-          n,
-          cudf::numeric_scalar<cudf::size_type>(0, true, stream, get_temp_mr()),
-          cudf::numeric_scalar<cudf::size_type>(1, true, stream, get_temp_mr()),
-          stream,
-          get_temp_mr());
+    VELOX_CHECK_LE(
+        leftJoinIndices->size(),
+        static_cast<size_t>(std::numeric_limits<cudf::size_type>::max()),
+        "Right join output exceeds cudf::size_type row limit ({} rows). "
+        "Consider using multi-GPU partitioning to reduce join fanout.",
+        leftJoinIndices->size());
 
-      // Check which build row indices are present in the join result
-      auto matchedInBatch = cudf::contains(
-          rightIdxCol, rowIndices->view(), stream, get_temp_mr());
-
-      // OR with existing flags to accumulate matches across batches
-      auto updatedFlags = cudf::binary_operation(
-          rightMatchedFlags_[i]->view(),
-          matchedInBatch->view(),
-          cudf::binary_operator::BITWISE_OR,
-          cudf::data_type{cudf::type_id::BOOL8},
-          stream,
-          get_temp_mr());
-      // binary_operation is async on `stream`; the old column destructs via
-      // cudaFreeAsync on its allocation stream (not `stream`), so the free
-      // can race the kernel. Drain `stream` before the move-assign.
-      stream.synchronize();
-      rightMatchedFlags_[i] = std::move(updatedFlags);
-    }
-
-    auto leftIndicesSpan =
-        cudf::device_span<cudf::size_type const>{*leftJoinIndices};
-    auto rightIndicesSpan =
-        cudf::device_span<cudf::size_type const>{*rightJoinIndices};
-    auto leftIndicesCol = cudf::column_view{leftIndicesSpan};
-    auto rightIndicesCol = cudf::column_view{rightIndicesSpan};
-    std::vector<std::unique_ptr<cudf::column>> joinedCols;
+    VLOG(1) << "CudfHashJoinProbe[" << planNodeId() << "] rightJoin chunk "
+              << i << ": joinResultRows=" << leftJoinIndices->size()
+              << ", leftProbeRows=" << leftTableView.num_rows()
+              << ", rightBuildRows=" << rightTableView.num_rows();
 
     if (joinNode_->filter()) {
+      // Filtered right join: eagerly gather and update rightMatchedFlags_
+      // in the filter callback. Push result to outputQueue_.
+      auto leftIndicesSpan =
+          cudf::device_span<cudf::size_type const>{*leftJoinIndices};
+      auto rightIndicesSpan =
+          cudf::device_span<cudf::size_type const>{*rightJoinIndices};
+      auto leftIndicesCol = cudf::column_view{leftIndicesSpan};
+      auto rightIndicesCol = cudf::column_view{rightIndicesSpan};
+
       auto& rightMatchedFlags = rightMatchedFlags_[i];
       auto numBuildRows = rightTableView.num_rows();
       auto filterFunc =
           [&rightMatchedFlags, rightIndicesSpan, numBuildRows, stream](
               std::vector<std::unique_ptr<cudf::column>>&& joinedCols,
               cudf::column_view filterColumn) {
-            // apply the filter
             auto filterTable =
                 std::make_unique<cudf::table>(std::move(joinedCols));
             auto filteredTable = cudf::apply_boolean_mask(
                 *filterTable, filterColumn, stream, get_output_mr());
             joinedCols = filteredTable->release();
 
-            // For streaming right join, after applying filter, we record
-            // matched right indices filter rightJoinIndices with the same mask
-            // to update matched flags
             auto rightIdxCol = cudf::column_view{rightIndicesSpan};
             auto filteredIdxTable = cudf::apply_boolean_mask(
                 cudf::table_view{std::vector<cudf::column_view>{rightIdxCol}},
@@ -1093,7 +1228,6 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::rightJoin(
             auto filteredCols = filteredIdxTable->release();
             auto filteredRightIdxCol = std::move(filteredCols[0]);
 
-            // Use contains to check which build row indices passed the filter
             auto rowIndices = cudf::sequence(
                 numBuildRows,
                 cudf::numeric_scalar<cudf::size_type>(
@@ -1109,7 +1243,6 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::rightJoin(
                 stream,
                 get_temp_mr());
 
-            // OR with existing flags to accumulate matches across batches
             auto updatedFlags = cudf::binary_operation(
                 rightMatchedFlags->view(),
                 matchedInBatch->view(),
@@ -1124,58 +1257,24 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::rightJoin(
             rightMatchedFlags = std::move(updatedFlags);
             return std::move(joinedCols);
           };
-      cudfOutputs.push_back(filteredOutput(
+      auto output = filteredOutput(
           leftTableView,
           leftIndicesCol,
           rightTableView,
           rightIndicesCol,
           filterFunc,
-          stream));
+          stream);
+      if (output.numRows > 0) {
+        outputQueue_.push(std::make_shared<CudfVector>(
+            pool(), outputType_, output.numRows,
+            std::move(output.table), stream));
+      }
     } else {
-      cudfOutputs.push_back(unfilteredOutput(
-          leftTableView,
-          leftIndicesCol,
-          rightTableView,
-          rightIndicesCol,
-          stream));
-    }
-  }
-  return cudfOutputs;
-}
-
-std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::fullJoin(
-    cudf::table_view leftTableView,
-    rmm::cuda_stream_view stream) {
-  std::vector<JoinOutput> cudfOutputs;
-
-  auto& rightTables = hashObject_.value().first;
-  auto& hbs = hashObject_.value().second;
-
-  // For now, AST support is necessary to filter join output
-  if (joinNode_->filter() && !useAstFilter_) {
-    VELOX_NYI("Full join requires AST support for filtering");
-  }
-
-  for (auto i = 0; i < rightTables.size(); i++) {
-    auto rightTableView = rightTables[i]->view();
-    auto& hb = hbs[i];
-
-    VELOX_CHECK_NOT_NULL(hb);
-    // Use left_join to get all probe rows (matched + unmatched).
-    // Track matched build rows in rightMatchedFlags_ for last driver to emit
-    // unmatched build rows at the end.
-    auto [leftJoinIndices, rightJoinIndices] = hb->left_join(
-        leftTableView.select(leftKeyIndices_),
-        std::nullopt,
-        stream,
-        get_temp_mr());
-    if (!joinNode_->filter()) {
-      // Mark matched build rows by checking which row indices appear in
-      // rightJoinIndices. Use contains to avoid scatter with duplicate indices.
+      // No filter: update rightMatchedFlags_ eagerly, then enqueue indices
+      // for lazy gather.
       auto rightIdxCol = cudf::column_view{
           cudf::device_span<cudf::size_type const>{*rightJoinIndices}};
 
-      // Create sequence [0, 1, ..., n-1] for build table row indices
       auto n = rightTableView.num_rows();
       auto rowIndices = cudf::sequence(
           n,
@@ -1184,11 +1283,9 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::fullJoin(
           stream,
           get_temp_mr());
 
-      // Check which build row indices are present in the join result
       auto matchedInBatch = cudf::contains(
           rightIdxCol, rowIndices->view(), stream, get_temp_mr());
 
-      // OR with existing flags to accumulate matches across batches
       auto updatedFlags = cudf::binary_operation(
           rightMatchedFlags_[i]->view(),
           matchedInBatch->view(),
@@ -1201,19 +1298,58 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::fullJoin(
       // can race the kernel. Drain `stream` before the move-assign.
       stream.synchronize();
       rightMatchedFlags_[i] = std::move(updatedFlags);
-    }
 
-    auto leftIndicesSpan =
-        cudf::device_span<cudf::size_type const>{*leftJoinIndices};
-    auto rightIndicesSpan =
-        cudf::device_span<cudf::size_type const>{*rightJoinIndices};
-    auto leftIndicesCol = cudf::column_view{leftIndicesSpan};
-    auto rightIndicesCol = cudf::column_view{rightIndicesSpan};
+      enqueuePendingIndices(
+          std::move(leftJoinIndices), std::move(rightJoinIndices), i);
+    }
+  }
+}
+
+void CudfHashJoinProbe::fullJoin(
+    cudf::table_view leftTableView,
+    rmm::cuda_stream_view stream) {
+  auto& rightTables = hashObject_.value().first;
+  auto& hbs = hashObject_.value().second;
+
+  // Non-AST filter not supported for full join.
+  if (joinNode_->filter() && !useAstFilter_) {
+    VELOX_NYI("Full join requires AST support for filtering");
+  }
+
+  for (size_t i = 0; i < rightTables.size(); i++) {
+    auto rightTableView = rightTables[i]->view();
+    auto& hb = hbs[i];
+
+    VELOX_CHECK_NOT_NULL(hb);
+    // Use left_join to get all probe rows (matched + unmatched).
+    auto [leftJoinIndices, rightJoinIndices] = hb->left_join(
+        leftTableView.select(leftKeyIndices_),
+        std::nullopt,
+        stream,
+        get_temp_mr());
+
+    VELOX_CHECK_LE(
+        leftJoinIndices->size(),
+        static_cast<size_t>(std::numeric_limits<cudf::size_type>::max()),
+        "Full join output exceeds cudf::size_type row limit ({} rows). "
+        "Consider using multi-GPU partitioning to reduce join fanout.",
+        leftJoinIndices->size());
+
+    VLOG(1) << "CudfHashJoinProbe[" << planNodeId() << "] fullJoin chunk "
+              << i << ": joinResultRows=" << leftJoinIndices->size()
+              << ", leftProbeRows=" << leftTableView.num_rows()
+              << ", rightBuildRows=" << rightTableView.num_rows();
 
     if (joinNode_->filter()) {
-      // Use filter_join_indices with LEFT_JOIN to get proper full join probe
-      // semantics: all probe rows are kept, build columns are NULL when filter
-      // fails or no match.
+      // AST filter: eagerly apply filter_join_indices, update
+      // rightMatchedFlags_, then enqueue filtered indices for lazy gather.
+      auto leftIndicesSpan =
+          cudf::device_span<cudf::size_type const>{*leftJoinIndices};
+      auto rightIndicesSpan =
+          cudf::device_span<cudf::size_type const>{*rightJoinIndices};
+      auto leftIndicesCol = cudf::column_view{leftIndicesSpan};
+      auto rightIndicesCol = cudf::column_view{rightIndicesSpan};
+
       auto [filteredLeftJoinIndices, filteredRightJoinIndices] =
           cudf::filter_join_indices(
               leftTableView,
@@ -1226,13 +1362,11 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::fullJoin(
               get_temp_mr());
 
       // Track matched build rows for unmatched row emission at end.
-      // Use contains to check which build row indices passed the filter.
       auto& rightMatchedFlags = rightMatchedFlags_[i];
       auto filteredRightIndicesSpan =
           cudf::device_span<cudf::size_type const>{*filteredRightJoinIndices};
       auto filteredRightIdxCol = cudf::column_view{filteredRightIndicesSpan};
 
-      // Create sequence [0, 1, ..., n-1] for build table row indices
       auto n = rightTableView.num_rows();
       auto rowIndices = cudf::sequence(
           n,
@@ -1241,11 +1375,9 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::fullJoin(
           stream,
           get_temp_mr());
 
-      // Check which build row indices are present in the filtered join result
       auto matchedInBatch = cudf::contains(
           filteredRightIdxCol, rowIndices->view(), stream, get_temp_mr());
 
-      // OR with existing flags to accumulate matches across batches
       auto updatedFlags = cudf::binary_operation(
           rightMatchedFlags->view(),
           matchedInBatch->view(),
@@ -1259,39 +1391,52 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::fullJoin(
       stream.synchronize();
       rightMatchedFlags = std::move(updatedFlags);
 
-      // Build output using filtered indices
-      auto filteredLeftIndicesSpan =
-          cudf::device_span<cudf::size_type const>{*filteredLeftJoinIndices};
-      auto filteredLeftIndicesCol = cudf::column_view{filteredLeftIndicesSpan};
-      auto filteredRightIndicesCol =
-          cudf::column_view{filteredRightIndicesSpan};
-      cudfOutputs.push_back(unfilteredOutput(
-          leftTableView,
-          filteredLeftIndicesCol,
-          rightTableView,
-          filteredRightIndicesCol,
-          stream));
+      // Enqueue filtered indices for lazy gather.
+      enqueuePendingIndices(
+          std::move(filteredLeftJoinIndices),
+          std::move(filteredRightJoinIndices), i);
     } else {
-      cudfOutputs.push_back(unfilteredOutput(
-          leftTableView,
-          leftIndicesCol,
-          rightTableView,
-          rightIndicesCol,
-          stream));
+      // No filter: update rightMatchedFlags_ eagerly, then enqueue indices
+      // for lazy gather.
+      auto rightIdxCol = cudf::column_view{
+          cudf::device_span<cudf::size_type const>{*rightJoinIndices}};
+
+      auto n = rightTableView.num_rows();
+      auto rowIndices = cudf::sequence(
+          n,
+          cudf::numeric_scalar<cudf::size_type>(0, true, stream, get_temp_mr()),
+          cudf::numeric_scalar<cudf::size_type>(1, true, stream, get_temp_mr()),
+          stream,
+          get_temp_mr());
+
+      auto matchedInBatch = cudf::contains(
+          rightIdxCol, rowIndices->view(), stream, get_temp_mr());
+
+      auto updatedFlags = cudf::binary_operation(
+          rightMatchedFlags_[i]->view(),
+          matchedInBatch->view(),
+          cudf::binary_operator::BITWISE_OR,
+          cudf::data_type{cudf::type_id::BOOL8},
+          stream,
+          get_temp_mr());
+      // binary_operation is async on `stream`; the old column destructs via
+      // cudaFreeAsync on its allocation stream (not `stream`), so the free
+      // can race the kernel. Drain `stream` before the move-assign.
+      stream.synchronize();
+      rightMatchedFlags_[i] = std::move(updatedFlags);
+
+      enqueuePendingIndices(
+          std::move(leftJoinIndices), std::move(rightJoinIndices), i);
     }
   }
-  return cudfOutputs;
 }
 
-std::vector<CudfHashJoinProbe::JoinOutput>
-CudfHashJoinProbe::leftSemiFilterJoin(
+void CudfHashJoinProbe::leftSemiFilterJoin(
     cudf::table_view leftTableView,
     rmm::cuda_stream_view stream) {
-  std::vector<JoinOutput> cudfOutputs;
-
   auto& rightTables = hashObject_.value().first;
 
-  for (auto i = 0; i < rightTables.size(); i++) {
+  for (size_t i = 0; i < rightTables.size(); i++) {
     auto rightTableView = rightTables[i]->view();
     std::unique_ptr<rmm::device_uvector<cudf::size_type>> leftJoinIndices;
 
@@ -1319,14 +1464,18 @@ CudfHashJoinProbe::leftSemiFilterJoin(
     auto leftIndicesCol = cudf::column_view{leftIndicesSpan};
     auto rightIndicesCol = cudf::empty_like(leftIndicesCol);
 
-    cudfOutputs.push_back(unfilteredOutput(
+    auto output = unfilteredOutput(
         leftTableView,
         leftIndicesCol,
         rightTableView,
         rightIndicesCol->view(),
-        stream));
+        stream);
+    if (output.numRows > 0) {
+      outputQueue_.push(std::make_shared<CudfVector>(
+          pool(), outputType_, output.numRows,
+          std::move(output.table), stream));
+    }
   }
-  return cudfOutputs;
 }
 
 namespace {
@@ -1450,12 +1599,9 @@ createCrossProductIndices(
 // 5. For null-aware mode (without filter): apply null mask based on probe key
 //    nullity and build side null keys presence
 // 6. Output: all probe columns + match column
-std::vector<CudfHashJoinProbe::JoinOutput>
-CudfHashJoinProbe::leftSemiProjectJoin(
+void CudfHashJoinProbe::leftSemiProjectJoin(
     cudf::table_view leftTableView,
     rmm::cuda_stream_view stream) {
-  std::vector<JoinOutput> cudfOutputs;
-
   // For now, AST support is necessary to filter join output
   if (joinNode_->filter() && !useAstFilter_) {
     VELOX_NYI("Left semi project join requires AST support for filtering");
@@ -1841,17 +1987,16 @@ CudfHashJoinProbe::leftSemiProjectJoin(
   stream.synchronize();
 
   auto output = std::make_unique<cudf::table>(std::move(outputCols));
-  cudfOutputs.push_back(
-      {std::move(output), static_cast<vector_size_t>(numProbeRows)});
-  return cudfOutputs;
+  if (numProbeRows > 0) {
+    outputQueue_.push(std::make_shared<CudfVector>(
+        pool(), outputType_, static_cast<cudf::size_type>(numProbeRows),
+        std::move(output), stream));
+  }
 }
 
-std::vector<CudfHashJoinProbe::JoinOutput>
-CudfHashJoinProbe::rightSemiFilterJoin(
+void CudfHashJoinProbe::rightSemiFilterJoin(
     cudf::table_view leftTableView,
     rmm::cuda_stream_view stream) {
-  std::vector<JoinOutput> cudfOutputs;
-
   auto& rightTables = hashObject_.value().first;
   auto rightTableView = rightTables[0]->view();
 
@@ -1884,20 +2029,22 @@ CudfHashJoinProbe::rightSemiFilterJoin(
       cudf::device_span<cudf::size_type const>{*rightJoinIndices};
   auto rightIndicesCol = cudf::column_view{rightIndicesSpan};
   auto leftIndicesCol = cudf::empty_like(rightIndicesCol);
-  cudfOutputs.push_back(unfilteredOutput(
+  auto output = unfilteredOutput(
       leftTableView,
       leftIndicesCol->view(),
       rightTableView,
       rightIndicesCol,
-      stream));
-
-  return cudfOutputs;
+      stream);
+  if (output.numRows > 0) {
+    outputQueue_.push(std::make_shared<CudfVector>(
+        pool(), outputType_, output.numRows,
+        std::move(output.table), stream));
+  }
 }
 
-std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::antiJoin(
+void CudfHashJoinProbe::antiJoin(
     cudf::table_view leftTableViewParam,
     rmm::cuda_stream_view stream) {
-  std::vector<JoinOutput> cudfOutputs;
   auto& rightTables = hashObject_.value().first;
 
   VELOX_CHECK_EQ(
@@ -1960,17 +2107,37 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::antiJoin(
       cudf::device_span<cudf::size_type const>{*leftJoinIndices};
   auto leftIndicesCol = cudf::column_view{leftIndicesSpan};
   auto rightIndicesCol = cudf::empty_like(leftIndicesCol);
-  cudfOutputs.push_back(unfilteredOutput(
+  auto output = unfilteredOutput(
       leftTableView,
       leftIndicesCol,
       rightTableView,
       rightIndicesCol->view(),
-      stream));
-
-  return cudfOutputs;
+      stream);
+  if (output.numRows > 0) {
+    outputQueue_.push(std::make_shared<CudfVector>(
+        pool(), outputType_, output.numRows,
+        std::move(output.table), stream));
+  }
 }
 
 RowVectorPtr CudfHashJoinProbe::doGetOutput() {
+  // Drain queued materialized output batches (non-AST filter, semi/anti,
+  // unmatched-right).
+  if (!outputQueue_.empty()) {
+    auto output = std::move(outputQueue_.front());
+    outputQueue_.pop();
+    return output;
+  }
+
+  // Lazily gather from pending index pairs (inner/left join, no filter or AST
+  // filter).
+  if (!pendingIndices_.empty()) {
+    auto cudfInput = std::dynamic_pointer_cast<CudfVector>(input_);
+    VELOX_CHECK_NOT_NULL(cudfInput);
+    auto stream = cudfInput->stream();
+    return gatherPendingBatch(stream);
+  }
+
   if (finished_ or !hashObject_.has_value()) {
     return nullptr;
   }
@@ -2036,20 +2203,36 @@ RowVectorPtr CudfHashJoinProbe::doGetOutput() {
         }
         toConcat.push_back(std::make_unique<cudf::table>(std::move(outCols)));
       }
-      // TODO (dm): We build multiple right chunks only when they are too large
-      // to fit in cudf::size_type. In case of a right join which doesn't have a
-      // lot of matches we'll get outCols of similar size. This concatenation
-      // will overflow. Try emitting result of one right chunk at a time.
       if (!toConcat.empty()) {
-        auto out =
-            concatenateTables(std::move(toConcat), stream, get_output_mr());
+        VLOG(1) << "CudfHashJoinProbe[" << planNodeId()
+                << "] unmatched-right: " << toConcat.size()
+                << " chunks, unmatchedRows=" << unmatchedRows;
+        auto outputBatches = concatenateTablesBatched(
+            std::move(toConcat), stream, get_output_mr());
+
+        bool const isZeroColumn = (outputType_->size() == 0);
+
+        // Queue all-but-first batch for subsequent doGetOutput() calls.
+        for (size_t i = 1; i < outputBatches.size(); ++i) {
+          auto batchSize = isZeroColumn
+              ? vector_size_t{0}
+              : static_cast<vector_size_t>(outputBatches[i]->num_rows());
+          if (batchSize > 0) {
+            outputQueue_.push(std::make_shared<CudfVector>(
+                pool(), outputType_, batchSize,
+                std::move(outputBatches[i]), stream));
+          }
+        }
+
         finished_ = true;
-        auto size = outputType_->size() == 0 ? unmatchedRows : out->num_rows();
+        auto size = isZeroColumn
+            ? unmatchedRows
+            : static_cast<vector_size_t>(outputBatches[0]->num_rows());
         if (size == 0) {
           return nullptr;
         }
         return std::make_shared<CudfVector>(
-            pool(), outputType_, size, std::move(out), stream);
+            pool(), outputType_, size, std::move(outputBatches[0]), stream);
       }
       finished_ = true;
     }
@@ -2084,31 +2267,32 @@ RowVectorPtr CudfHashJoinProbe::doGetOutput() {
     }
   }
 
-  std::vector<JoinOutput> cudfOutputs;
+  // Dispatch to join method. All join methods populate pendingIndices_
+  // and/or outputQueue_ directly.
   switch (joinNode_->joinType()) {
     case core::JoinType::kInner:
-      cudfOutputs = innerJoin(leftTableView, stream);
+      innerJoin(leftTableView, stream);
       break;
     case core::JoinType::kLeft:
-      cudfOutputs = leftJoin(leftTableView, stream);
+      leftJoin(leftTableView, stream);
       break;
     case core::JoinType::kRight:
-      cudfOutputs = rightJoin(leftTableView, stream);
-      break;
-    case core::JoinType::kLeftSemiFilter:
-      cudfOutputs = leftSemiFilterJoin(leftTableView, stream);
-      break;
-    case core::JoinType::kLeftSemiProject:
-      cudfOutputs = leftSemiProjectJoin(leftTableView, stream);
-      break;
-    case core::JoinType::kRightSemiFilter:
-      cudfOutputs = rightSemiFilterJoin(leftTableView, stream);
-      break;
-    case core::JoinType::kAnti:
-      cudfOutputs = antiJoin(leftTableView, stream);
+      rightJoin(leftTableView, stream);
       break;
     case core::JoinType::kFull:
-      cudfOutputs = fullJoin(leftTableView, stream);
+      fullJoin(leftTableView, stream);
+      break;
+    case core::JoinType::kLeftSemiFilter:
+      leftSemiFilterJoin(leftTableView, stream);
+      break;
+    case core::JoinType::kLeftSemiProject:
+      leftSemiProjectJoin(leftTableView, stream);
+      break;
+    case core::JoinType::kRightSemiFilter:
+      rightSemiFilterJoin(leftTableView, stream);
+      break;
+    case core::JoinType::kAnti:
+      antiJoin(leftTableView, stream);
       break;
     default:
       VELOX_FAIL("Unsupported join type: ", joinNode_->joinType());
@@ -2119,32 +2303,24 @@ RowVectorPtr CudfHashJoinProbe::doGetOutput() {
     lastProbeStream_ = stream;
   }
 
-  // Release input CudfVector to free GPU memory before creating output.
-  // This reduces peak memory from (input + output) to max(input, output).
-  // cudfInput must be released first since input_.reset() only decrements
-  // the refcount while cudfInput still holds a reference.
+  // Lazy gather path: pendingIndices_ was populated.
+  if (!pendingIndices_.empty()) {
+    // Don't reset input_ -- gatherPendingBatch will do it when drained.
+    return gatherPendingBatch(stream);
+  }
+
+  // Eager path (non-AST filter, semi/anti) or zero-match: outputQueue_ may
+  // have been populated. Release probe input immediately.
   cudfInput.reset();
   input_.reset();
   finished_ =
       noMoreInput_ && !joinNode_->isRightJoin() && !joinNode_->isFullJoin();
-
-  vector_size_t zeroColumnOutputRows = 0;
-  std::vector<std::unique_ptr<cudf::table>> cudfOutputTables;
-  cudfOutputTables.reserve(cudfOutputs.size());
-  for (auto& output : cudfOutputs) {
-    zeroColumnOutputRows += output.numRows;
-    cudfOutputTables.push_back(std::move(output.table));
+  if (!outputQueue_.empty()) {
+    auto output = std::move(outputQueue_.front());
+    outputQueue_.pop();
+    return output;
   }
-
-  auto cudfOutput =
-      concatenateTables(std::move(cudfOutputTables), stream, get_output_mr());
-  auto const size =
-      outputType_->size() == 0 ? zeroColumnOutputRows : cudfOutput->num_rows();
-  if (size == 0) {
-    return nullptr;
-  }
-  return std::make_shared<CudfVector>(
-      pool(), outputType_, size, std::move(cudfOutput), stream);
+  return nullptr;
 }
 
 bool CudfHashJoinProbe::skipProbeOnEmptyBuild() const {
@@ -2275,7 +2451,8 @@ exec::BlockingReason CudfHashJoinProbe::isBlocked(ContinueFuture* future) {
 }
 
 bool CudfHashJoinProbe::isFinished() {
-  auto const isFinished = finished_ || (noMoreInput_ && input_ == nullptr);
+  auto const isFinished = outputQueue_.empty() && pendingIndices_.empty() &&
+      (finished_ || (noMoreInput_ && input_ == nullptr));
 
   // Release hashObject_ if finished
   if (isFinished) {

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -837,6 +837,132 @@ void CudfHashJoinProbe::enqueuePendingIndices(
       {std::move(leftIndices), std::move(rightIndices), 0, buildChunkIndex});
 }
 
+void CudfHashJoinProbe::updateRightMatchedFlags(
+    size_t chunkIndex,
+    cudf::column_view rightIndicesCol,
+    cudf::size_type numBuildRows,
+    rmm::cuda_stream_view stream) {
+  auto rowIndices = cudf::sequence(
+      numBuildRows,
+      cudf::numeric_scalar<cudf::size_type>(0, true, stream, get_temp_mr()),
+      cudf::numeric_scalar<cudf::size_type>(1, true, stream, get_temp_mr()),
+      stream,
+      get_temp_mr());
+
+  auto matchedInBatch = cudf::contains(
+      rightIndicesCol, rowIndices->view(), stream, get_temp_mr());
+
+  auto updatedFlags = cudf::binary_operation(
+      rightMatchedFlags_[chunkIndex]->view(),
+      matchedInBatch->view(),
+      cudf::binary_operator::BITWISE_OR,
+      cudf::data_type{cudf::type_id::BOOL8},
+      stream,
+      get_temp_mr());
+  // binary_operation is async on `stream`; the old column destructs via
+  // cudaFreeAsync on its allocation stream (not `stream`), so the free
+  // can race the kernel. Drain `stream` before the move-assign.
+  stream.synchronize();
+  rightMatchedFlags_[chunkIndex] = std::move(updatedFlags);
+}
+
+void CudfHashJoinProbe::filterAndEnqueueAstIndices(
+    cudf::table_view leftTableView,
+    size_t rightTableIndex,
+    rmm::device_uvector<cudf::size_type>& leftJoinIndices,
+    rmm::device_uvector<cudf::size_type>& rightJoinIndices,
+    cudf::join_kind joinKind,
+    rmm::cuda_stream_view stream) {
+  auto leftIndicesSpan =
+      cudf::device_span<cudf::size_type const>{leftJoinIndices};
+  auto rightIndicesSpan =
+      cudf::device_span<cudf::size_type const>{rightJoinIndices};
+
+  cudf::table_view extendedLeftView = leftTableView;
+  std::vector<ColumnOrView> leftPrecomputed;
+  if (!leftPrecomputeInstructions_.empty()) {
+    auto leftColumnViews = tableViewToColumnViews(leftTableView);
+    leftPrecomputed = precomputeSubexpressions(
+        leftColumnViews,
+        leftPrecomputeInstructions_,
+        scalars_,
+        probeType_,
+        stream);
+    extendedLeftView =
+        createExtendedTableView(leftTableView, leftPrecomputed);
+  }
+  auto& rightTables = hashObject_.value().first;
+  auto rightTableView = rightTables[rightTableIndex]->view();
+  cudf::table_view extendedRightView =
+      (!rightPrecomputeInstructions_.empty())
+      ? cachedExtendedRightViews_[rightTableIndex]
+      : rightTableView;
+
+  auto const maxRows = maxBatchRows();
+  auto const totalRows = leftIndicesSpan.size();
+  for (size_t offset = 0; offset < totalRows; offset += maxRows) {
+    auto const chunkSize = std::min(maxRows, totalRows - offset);
+    auto leftChunk = leftIndicesSpan.subspan(offset, chunkSize);
+    auto rightChunk = rightIndicesSpan.subspan(offset, chunkSize);
+    auto leftIndicesCol = cudf::column_view{leftChunk};
+    auto rightIndicesCol = cudf::column_view{rightChunk};
+    auto [filteredLeft, filteredRight] = cudf::filter_join_indices(
+        extendedLeftView,
+        extendedRightView,
+        leftIndicesCol,
+        rightIndicesCol,
+        tree_.back(),
+        joinKind,
+        stream,
+        get_temp_mr());
+    enqueuePendingIndices(
+        std::move(filteredLeft), std::move(filteredRight), rightTableIndex);
+  }
+}
+
+void CudfHashJoinProbe::gatherFilterAndEnqueue(
+    cudf::table_view leftTableView,
+    cudf::table_view rightTableView,
+    rmm::device_uvector<cudf::size_type>& leftJoinIndices,
+    rmm::device_uvector<cudf::size_type>& rightJoinIndices,
+    rmm::cuda_stream_view stream) {
+  auto leftIndicesSpan =
+      cudf::device_span<cudf::size_type const>{leftJoinIndices};
+  auto rightIndicesSpan =
+      cudf::device_span<cudf::size_type const>{rightJoinIndices};
+  auto const maxRows = maxBatchRows();
+  auto const totalRows = leftIndicesSpan.size();
+  for (size_t offset = 0; offset < totalRows; offset += maxRows) {
+    auto const chunkSize = std::min(maxRows, totalRows - offset);
+    auto leftChunk = leftIndicesSpan.subspan(offset, chunkSize);
+    auto rightChunk = rightIndicesSpan.subspan(offset, chunkSize);
+    auto leftIndicesCol = cudf::column_view{leftChunk};
+    auto rightIndicesCol = cudf::column_view{rightChunk};
+    auto filterFunc =
+        [stream](
+            std::vector<std::unique_ptr<cudf::column>>&& joinedCols,
+            cudf::column_view filterColumn) {
+          auto filterTable =
+              std::make_unique<cudf::table>(std::move(joinedCols));
+          auto filteredTable = cudf::apply_boolean_mask(
+              *filterTable, filterColumn, stream, get_output_mr());
+          return filteredTable->release();
+        };
+    auto output = filteredOutput(
+        leftTableView,
+        leftIndicesCol,
+        rightTableView,
+        rightIndicesCol,
+        filterFunc,
+        stream);
+    if (output.numRows > 0) {
+      outputQueue_.push(std::make_shared<CudfVector>(
+          pool(), outputType_, output.numRows,
+          std::move(output.table), stream));
+    }
+  }
+}
+
 RowVectorPtr CudfHashJoinProbe::gatherPendingBatch(
     rmm::cuda_stream_view stream) {
   VELOX_CHECK(!pendingIndices_.empty());
@@ -929,46 +1055,12 @@ void CudfHashJoinProbe::innerJoin(
           std::nullopt,
           stream,
           get_temp_mr());
-      auto leftIndicesSpan =
-          cudf::device_span<cudf::size_type const>{*leftJoinIndices};
-      auto rightIndicesSpan =
-          cudf::device_span<cudf::size_type const>{*rightJoinIndices};
       VLOG(1) << "CudfHashJoinProbe[" << planNodeId()
               << "] innerJoin (non-AST filter) chunk " << i
-              << ": joinResultRows=" << leftIndicesSpan.size();
-      // For non-AST filter, gather eagerly (filter needs materialized data).
-      // Split oversized spans into sub-maxBatchRows chunks.
-      auto const maxRows = maxBatchRows();
-      auto const totalRows = leftIndicesSpan.size();
-      for (size_t offset = 0; offset < totalRows; offset += maxRows) {
-        auto const chunkSize = std::min(maxRows, totalRows - offset);
-        auto leftChunk = leftIndicesSpan.subspan(offset, chunkSize);
-        auto rightChunk = rightIndicesSpan.subspan(offset, chunkSize);
-        auto leftIndicesCol = cudf::column_view{leftChunk};
-        auto rightIndicesCol = cudf::column_view{rightChunk};
-        auto filterFunc =
-            [stream](
-                std::vector<std::unique_ptr<cudf::column>>&& joinedCols,
-                cudf::column_view filterColumn) {
-              auto filterTable =
-                  std::make_unique<cudf::table>(std::move(joinedCols));
-              auto filteredTable = cudf::apply_boolean_mask(
-                  *filterTable, filterColumn, stream, get_output_mr());
-              return filteredTable->release();
-            };
-        auto output = filteredOutput(
-            leftTableView,
-            leftIndicesCol,
-            rightTableView,
-            rightIndicesCol,
-            filterFunc,
-            stream);
-        if (output.numRows > 0) {
-          outputQueue_.push(std::make_shared<CudfVector>(
-              pool(), outputType_, output.numRows,
-              std::move(output.table), stream));
-        }
-      }
+              << ": joinResultRows=" << leftJoinIndices->size();
+      gatherFilterAndEnqueue(
+          leftTableView, rightTableView,
+          *leftJoinIndices, *rightJoinIndices, stream);
     }
     return;
   }
@@ -990,52 +1082,10 @@ void CudfHashJoinProbe::innerJoin(
 
     if (joinNode_->filter()) {
       // AST filter: eagerly apply filter_join_indices to reduce index count.
-      auto leftIndicesSpan =
-          cudf::device_span<cudf::size_type const>{*leftJoinIndices};
-      auto rightIndicesSpan =
-          cudf::device_span<cudf::size_type const>{*rightJoinIndices};
-
-      // Precompute left columns for AST filter if needed.
-      cudf::table_view extendedLeftView = leftTableView;
-      std::vector<ColumnOrView> leftPrecomputed;
-      if (!leftPrecomputeInstructions_.empty()) {
-        auto leftColumnViews = tableViewToColumnViews(leftTableView);
-        leftPrecomputed = precomputeSubexpressions(
-            leftColumnViews,
-            leftPrecomputeInstructions_,
-            scalars_,
-            probeType_,
-            stream);
-        extendedLeftView =
-            createExtendedTableView(leftTableView, leftPrecomputed);
-      }
-      cudf::table_view extendedRightView =
-          (!rightPrecomputeInstructions_.empty())
-          ? cachedExtendedRightViews_[i]
-          : rightTableView;
-
-      // Split into sub-maxBatchRows spans for filter_join_indices.
-      auto const maxRows = maxBatchRows();
-      auto const totalRows = leftIndicesSpan.size();
-      for (size_t offset = 0; offset < totalRows; offset += maxRows) {
-        auto const chunkSize = std::min(maxRows, totalRows - offset);
-        auto leftChunk = leftIndicesSpan.subspan(offset, chunkSize);
-        auto rightChunk = rightIndicesSpan.subspan(offset, chunkSize);
-        auto leftIndicesCol = cudf::column_view{leftChunk};
-        auto rightIndicesCol = cudf::column_view{rightChunk};
-        auto [filteredLeft, filteredRight] = cudf::filter_join_indices(
-            extendedLeftView,
-            extendedRightView,
-            leftIndicesCol,
-            rightIndicesCol,
-            tree_.back(),
-            cudf::join_kind::INNER_JOIN,
-            stream,
-            get_temp_mr());
-        // Enqueue the filtered (smaller) indices for lazy gather.
-        enqueuePendingIndices(
-            std::move(filteredLeft), std::move(filteredRight), i);
-      }
+      filterAndEnqueueAstIndices(
+          leftTableView, i,
+          *leftJoinIndices, *rightJoinIndices,
+          cudf::join_kind::INNER_JOIN, stream);
     } else {
       // No filter: enqueue raw indices for lazy gather.
       enqueuePendingIndices(
@@ -1061,41 +1111,12 @@ void CudfHashJoinProbe::leftJoin(
           std::nullopt,
           stream,
           get_temp_mr());
-      auto leftIndicesSpan =
-          cudf::device_span<cudf::size_type const>{*leftJoinIndices};
-      auto rightIndicesSpan =
-          cudf::device_span<cudf::size_type const>{*rightJoinIndices};
-      auto const maxRows = maxBatchRows();
-      auto const totalRows = leftIndicesSpan.size();
-      for (size_t offset = 0; offset < totalRows; offset += maxRows) {
-        auto const chunkSize = std::min(maxRows, totalRows - offset);
-        auto leftChunk = leftIndicesSpan.subspan(offset, chunkSize);
-        auto rightChunk = rightIndicesSpan.subspan(offset, chunkSize);
-        auto leftIndicesCol = cudf::column_view{leftChunk};
-        auto rightIndicesCol = cudf::column_view{rightChunk};
-        auto filterFunc =
-            [stream](
-                std::vector<std::unique_ptr<cudf::column>>&& joinedCols,
-                cudf::column_view filterColumn) {
-              auto filterTable =
-                  std::make_unique<cudf::table>(std::move(joinedCols));
-              auto filteredTable = cudf::apply_boolean_mask(
-                  *filterTable, filterColumn, stream, get_output_mr());
-              return filteredTable->release();
-            };
-        auto output = filteredOutput(
-            leftTableView,
-            leftIndicesCol,
-            rightTableView,
-            rightIndicesCol,
-            filterFunc,
-            stream);
-        if (output.numRows > 0) {
-          outputQueue_.push(std::make_shared<CudfVector>(
-              pool(), outputType_, output.numRows,
-              std::move(output.table), stream));
-        }
-      }
+      VLOG(1) << "CudfHashJoinProbe[" << planNodeId()
+              << "] leftJoin (non-AST filter) chunk " << i
+              << ": joinResultRows=" << leftJoinIndices->size();
+      gatherFilterAndEnqueue(
+          leftTableView, rightTableView,
+          *leftJoinIndices, *rightJoinIndices, stream);
     }
     return;
   }
@@ -1117,49 +1138,10 @@ void CudfHashJoinProbe::leftJoin(
 
     if (joinNode_->filter()) {
       // AST filter: eagerly apply filter_join_indices to reduce index count.
-      auto leftIndicesSpan =
-          cudf::device_span<cudf::size_type const>{*leftJoinIndices};
-      auto rightIndicesSpan =
-          cudf::device_span<cudf::size_type const>{*rightJoinIndices};
-
-      cudf::table_view extendedLeftView = leftTableView;
-      std::vector<ColumnOrView> leftPrecomputed;
-      if (!leftPrecomputeInstructions_.empty()) {
-        auto leftColumnViews = tableViewToColumnViews(leftTableView);
-        leftPrecomputed = precomputeSubexpressions(
-            leftColumnViews,
-            leftPrecomputeInstructions_,
-            scalars_,
-            probeType_,
-            stream);
-        extendedLeftView =
-            createExtendedTableView(leftTableView, leftPrecomputed);
-      }
-      cudf::table_view extendedRightView =
-          (!rightPrecomputeInstructions_.empty())
-          ? cachedExtendedRightViews_[i]
-          : rightTableView;
-
-      auto const maxRows = maxBatchRows();
-      auto const totalRows = leftIndicesSpan.size();
-      for (size_t offset = 0; offset < totalRows; offset += maxRows) {
-        auto const chunkSize = std::min(maxRows, totalRows - offset);
-        auto leftChunk = leftIndicesSpan.subspan(offset, chunkSize);
-        auto rightChunk = rightIndicesSpan.subspan(offset, chunkSize);
-        auto leftIndicesCol = cudf::column_view{leftChunk};
-        auto rightIndicesCol = cudf::column_view{rightChunk};
-        auto [filteredLeft, filteredRight] = cudf::filter_join_indices(
-            extendedLeftView,
-            extendedRightView,
-            leftIndicesCol,
-            rightIndicesCol,
-            tree_.back(),
-            cudf::join_kind::LEFT_JOIN,
-            stream,
-            get_temp_mr());
-        enqueuePendingIndices(
-            std::move(filteredLeft), std::move(filteredRight), i);
-      }
+      filterAndEnqueueAstIndices(
+          leftTableView, i,
+          *leftJoinIndices, *rightJoinIndices,
+          cudf::join_kind::LEFT_JOIN, stream);
     } else {
       // No filter: enqueue raw indices for lazy gather.
       enqueuePendingIndices(
@@ -1185,21 +1167,26 @@ void CudfHashJoinProbe::rightJoin(
         stream,
         get_temp_mr());
 
+    // TODO: Chunk oversized right join output like innerJoin/leftJoin do,
+    // by splitting the index spans and updating rightMatchedFlags_ per chunk.
     VELOX_CHECK_LE(
         leftJoinIndices->size(),
         static_cast<size_t>(std::numeric_limits<cudf::size_type>::max()),
         "Right join output exceeds cudf::size_type row limit ({} rows). "
-        "Consider using multi-GPU partitioning to reduce join fanout.",
+        "Chunking for right join is not yet implemented.",
         leftJoinIndices->size());
 
     VLOG(1) << "CudfHashJoinProbe[" << planNodeId() << "] rightJoin chunk "
-              << i << ": joinResultRows=" << leftJoinIndices->size()
-              << ", leftProbeRows=" << leftTableView.num_rows()
-              << ", rightBuildRows=" << rightTableView.num_rows();
+            << i << ": joinResultRows=" << leftJoinIndices->size()
+            << ", leftProbeRows=" << leftTableView.num_rows()
+            << ", rightBuildRows=" << rightTableView.num_rows();
 
     if (joinNode_->filter()) {
       // Filtered right join: eagerly gather and update rightMatchedFlags_
       // in the filter callback. Push result to outputQueue_.
+      // TODO: When chunking is added for right join (removing the
+      // VELOX_CHECK_LE above), this path will also need to split oversized
+      // index spans into sub-maxBatchRows chunks.
       auto leftIndicesSpan =
           cudf::device_span<cudf::size_type const>{*leftJoinIndices};
       auto rightIndicesSpan =
@@ -1274,30 +1261,8 @@ void CudfHashJoinProbe::rightJoin(
       // for lazy gather.
       auto rightIdxCol = cudf::column_view{
           cudf::device_span<cudf::size_type const>{*rightJoinIndices}};
-
-      auto n = rightTableView.num_rows();
-      auto rowIndices = cudf::sequence(
-          n,
-          cudf::numeric_scalar<cudf::size_type>(0, true, stream, get_temp_mr()),
-          cudf::numeric_scalar<cudf::size_type>(1, true, stream, get_temp_mr()),
-          stream,
-          get_temp_mr());
-
-      auto matchedInBatch = cudf::contains(
-          rightIdxCol, rowIndices->view(), stream, get_temp_mr());
-
-      auto updatedFlags = cudf::binary_operation(
-          rightMatchedFlags_[i]->view(),
-          matchedInBatch->view(),
-          cudf::binary_operator::BITWISE_OR,
-          cudf::data_type{cudf::type_id::BOOL8},
-          stream,
-          get_temp_mr());
-      // binary_operation is async on `stream`; the old column destructs via
-      // cudaFreeAsync on its allocation stream (not `stream`), so the free
-      // can race the kernel. Drain `stream` before the move-assign.
-      stream.synchronize();
-      rightMatchedFlags_[i] = std::move(updatedFlags);
+      updateRightMatchedFlags(
+          i, rightIdxCol, rightTableView.num_rows(), stream);
 
       enqueuePendingIndices(
           std::move(leftJoinIndices), std::move(rightJoinIndices), i);
@@ -1328,17 +1293,19 @@ void CudfHashJoinProbe::fullJoin(
         stream,
         get_temp_mr());
 
+    // TODO: Chunk oversized full join output like innerJoin/leftJoin do,
+    // by splitting the index spans and updating rightMatchedFlags_ per chunk.
     VELOX_CHECK_LE(
         leftJoinIndices->size(),
         static_cast<size_t>(std::numeric_limits<cudf::size_type>::max()),
         "Full join output exceeds cudf::size_type row limit ({} rows). "
-        "Consider using multi-GPU partitioning to reduce join fanout.",
+        "Chunking for full join is not yet implemented.",
         leftJoinIndices->size());
 
     VLOG(1) << "CudfHashJoinProbe[" << planNodeId() << "] fullJoin chunk "
-              << i << ": joinResultRows=" << leftJoinIndices->size()
-              << ", leftProbeRows=" << leftTableView.num_rows()
-              << ", rightBuildRows=" << rightTableView.num_rows();
+            << i << ": joinResultRows=" << leftJoinIndices->size()
+            << ", leftProbeRows=" << leftTableView.num_rows()
+            << ", rightBuildRows=" << rightTableView.num_rows();
 
     if (joinNode_->filter()) {
       // AST filter: eagerly apply filter_join_indices, update
@@ -1362,34 +1329,11 @@ void CudfHashJoinProbe::fullJoin(
               get_temp_mr());
 
       // Track matched build rows for unmatched row emission at end.
-      auto& rightMatchedFlags = rightMatchedFlags_[i];
       auto filteredRightIndicesSpan =
           cudf::device_span<cudf::size_type const>{*filteredRightJoinIndices};
       auto filteredRightIdxCol = cudf::column_view{filteredRightIndicesSpan};
-
-      auto n = rightTableView.num_rows();
-      auto rowIndices = cudf::sequence(
-          n,
-          cudf::numeric_scalar<cudf::size_type>(0, true, stream, get_temp_mr()),
-          cudf::numeric_scalar<cudf::size_type>(1, true, stream, get_temp_mr()),
-          stream,
-          get_temp_mr());
-
-      auto matchedInBatch = cudf::contains(
-          filteredRightIdxCol, rowIndices->view(), stream, get_temp_mr());
-
-      auto updatedFlags = cudf::binary_operation(
-          rightMatchedFlags->view(),
-          matchedInBatch->view(),
-          cudf::binary_operator::BITWISE_OR,
-          cudf::data_type{cudf::type_id::BOOL8},
-          stream,
-          get_temp_mr());
-      // binary_operation is async on `stream`; the old column destructs via
-      // cudaFreeAsync on its allocation stream (not `stream`), so the free
-      // can race the kernel. Drain `stream` before the move-assign.
-      stream.synchronize();
-      rightMatchedFlags = std::move(updatedFlags);
+      updateRightMatchedFlags(
+          i, filteredRightIdxCol, rightTableView.num_rows(), stream);
 
       // Enqueue filtered indices for lazy gather.
       enqueuePendingIndices(
@@ -1400,30 +1344,8 @@ void CudfHashJoinProbe::fullJoin(
       // for lazy gather.
       auto rightIdxCol = cudf::column_view{
           cudf::device_span<cudf::size_type const>{*rightJoinIndices}};
-
-      auto n = rightTableView.num_rows();
-      auto rowIndices = cudf::sequence(
-          n,
-          cudf::numeric_scalar<cudf::size_type>(0, true, stream, get_temp_mr()),
-          cudf::numeric_scalar<cudf::size_type>(1, true, stream, get_temp_mr()),
-          stream,
-          get_temp_mr());
-
-      auto matchedInBatch = cudf::contains(
-          rightIdxCol, rowIndices->view(), stream, get_temp_mr());
-
-      auto updatedFlags = cudf::binary_operation(
-          rightMatchedFlags_[i]->view(),
-          matchedInBatch->view(),
-          cudf::binary_operator::BITWISE_OR,
-          cudf::data_type{cudf::type_id::BOOL8},
-          stream,
-          get_temp_mr());
-      // binary_operation is async on `stream`; the old column destructs via
-      // cudaFreeAsync on its allocation stream (not `stream`), so the free
-      // can race the kernel. Drain `stream` before the move-assign.
-      stream.synchronize();
-      rightMatchedFlags_[i] = std::move(updatedFlags);
+      updateRightMatchedFlags(
+          i, rightIdxCol, rightTableView.num_rows(), stream);
 
       enqueuePendingIndices(
           std::move(leftJoinIndices), std::move(rightJoinIndices), i);
@@ -2207,16 +2129,38 @@ RowVectorPtr CudfHashJoinProbe::doGetOutput() {
         VLOG(1) << "CudfHashJoinProbe[" << planNodeId()
                 << "] unmatched-right: " << toConcat.size()
                 << " chunks, unmatchedRows=" << unmatchedRows;
+
+        finished_ = true;
+
+        if (outputType_->size() == 0) {
+          // Zero-column tables: cudf::table::num_rows() is always 0, so
+          // concatenateTablesBatched cannot track logical row counts. Emit
+          // batches manually with the correct logical row count.
+          auto const maxRows = maxBatchRows();
+          auto remaining = static_cast<size_t>(unmatchedRows);
+          while (remaining > 0) {
+            auto const chunkRows =
+                static_cast<vector_size_t>(std::min(remaining, maxRows));
+            outputQueue_.push(std::make_shared<CudfVector>(
+                pool(), outputType_, chunkRows,
+                std::make_unique<cudf::table>(), stream));
+            remaining -= chunkRows;
+          }
+          if (!outputQueue_.empty()) {
+            auto output = std::move(outputQueue_.front());
+            outputQueue_.pop();
+            return output;
+          }
+          return nullptr;
+        }
+
         auto outputBatches = concatenateTablesBatched(
             std::move(toConcat), stream, get_output_mr());
 
-        bool const isZeroColumn = (outputType_->size() == 0);
-
         // Queue all-but-first batch for subsequent doGetOutput() calls.
         for (size_t i = 1; i < outputBatches.size(); ++i) {
-          auto batchSize = isZeroColumn
-              ? vector_size_t{0}
-              : static_cast<vector_size_t>(outputBatches[i]->num_rows());
+          auto batchSize =
+              static_cast<vector_size_t>(outputBatches[i]->num_rows());
           if (batchSize > 0) {
             outputQueue_.push(std::make_shared<CudfVector>(
                 pool(), outputType_, batchSize,
@@ -2224,10 +2168,8 @@ RowVectorPtr CudfHashJoinProbe::doGetOutput() {
           }
         }
 
-        finished_ = true;
-        auto size = isZeroColumn
-            ? unmatchedRows
-            : static_cast<vector_size_t>(outputBatches[0]->num_rows());
+        auto size =
+            static_cast<vector_size_t>(outputBatches[0]->num_rows());
         if (size == 0) {
           return nullptr;
         }
@@ -2253,7 +2195,7 @@ RowVectorPtr CudfHashJoinProbe::doGetOutput() {
 
   auto& rightTables = hashObject_.value().first;
   auto& hbs = hashObject_.value().second;
-  for (auto i = 0; i < rightTables.size(); i++) {
+  for (size_t i = 0; i < rightTables.size(); i++) {
     auto& rightTable = rightTables[i];
     auto& hb = hbs[i];
     VELOX_CHECK_NOT_NULL(rightTable);

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -26,8 +26,6 @@
 
 #include "velox/common/testutil/TestValue.h"
 #include "velox/core/PlanNode.h"
-
-#include <limits>
 #include "velox/exec/Task.h" // NOLINT(misc-unused-headers)
 #include "velox/type/TypeUtil.h"
 
@@ -58,6 +56,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <limits>
 
 namespace facebook::velox::cudf_velox {
 
@@ -888,13 +887,11 @@ void CudfHashJoinProbe::filterAndEnqueueAstIndices(
         scalars_,
         probeType_,
         stream);
-    extendedLeftView =
-        createExtendedTableView(leftTableView, leftPrecomputed);
+    extendedLeftView = createExtendedTableView(leftTableView, leftPrecomputed);
   }
   auto& rightTables = hashObject_.value().first;
   auto rightTableView = rightTables[rightTableIndex]->view();
-  cudf::table_view extendedRightView =
-      (!rightPrecomputeInstructions_.empty())
+  cudf::table_view extendedRightView = (!rightPrecomputeInstructions_.empty())
       ? cachedExtendedRightViews_[rightTableIndex]
       : rightTableView;
 
@@ -956,9 +953,13 @@ void CudfHashJoinProbe::gatherFilterAndEnqueue(
         filterFunc,
         stream);
     if (output.numRows > 0) {
-      outputQueue_.push(std::make_shared<CudfVector>(
-          pool(), outputType_, output.numRows,
-          std::move(output.table), stream));
+      outputQueue_.push(
+          std::make_shared<CudfVector>(
+              pool(),
+              outputType_,
+              output.numRows,
+              std::move(output.table),
+              stream));
     }
   }
 }
@@ -1059,8 +1060,11 @@ void CudfHashJoinProbe::innerJoin(
               << "] innerJoin (non-AST filter) chunk " << i
               << ": joinResultRows=" << leftJoinIndices->size();
       gatherFilterAndEnqueue(
-          leftTableView, rightTableView,
-          *leftJoinIndices, *rightJoinIndices, stream);
+          leftTableView,
+          rightTableView,
+          *leftJoinIndices,
+          *rightJoinIndices,
+          stream);
     }
     return;
   }
@@ -1075,17 +1079,20 @@ void CudfHashJoinProbe::innerJoin(
         std::nullopt,
         stream,
         get_temp_mr());
-    VLOG(1) << "CudfHashJoinProbe[" << planNodeId() << "] innerJoin chunk "
-            << i << ": joinResultRows=" << leftJoinIndices->size()
+    VLOG(1) << "CudfHashJoinProbe[" << planNodeId() << "] innerJoin chunk " << i
+            << ": joinResultRows=" << leftJoinIndices->size()
             << ", leftProbeRows=" << leftTableView.num_rows()
             << ", rightBuildRows=" << rightTableView.num_rows();
 
     if (joinNode_->filter()) {
       // AST filter: eagerly apply filter_join_indices to reduce index count.
       filterAndEnqueueAstIndices(
-          leftTableView, i,
-          *leftJoinIndices, *rightJoinIndices,
-          cudf::join_kind::INNER_JOIN, stream);
+          leftTableView,
+          i,
+          *leftJoinIndices,
+          *rightJoinIndices,
+          cudf::join_kind::INNER_JOIN,
+          stream);
     } else {
       // No filter: enqueue raw indices for lazy gather.
       enqueuePendingIndices(
@@ -1115,8 +1122,11 @@ void CudfHashJoinProbe::leftJoin(
               << "] leftJoin (non-AST filter) chunk " << i
               << ": joinResultRows=" << leftJoinIndices->size();
       gatherFilterAndEnqueue(
-          leftTableView, rightTableView,
-          *leftJoinIndices, *rightJoinIndices, stream);
+          leftTableView,
+          rightTableView,
+          *leftJoinIndices,
+          *rightJoinIndices,
+          stream);
     }
     return;
   }
@@ -1131,17 +1141,20 @@ void CudfHashJoinProbe::leftJoin(
         std::nullopt,
         stream,
         get_temp_mr());
-    VLOG(1) << "CudfHashJoinProbe[" << planNodeId() << "] leftJoin chunk "
-            << i << ": joinResultRows=" << leftJoinIndices->size()
+    VLOG(1) << "CudfHashJoinProbe[" << planNodeId() << "] leftJoin chunk " << i
+            << ": joinResultRows=" << leftJoinIndices->size()
             << ", leftProbeRows=" << leftTableView.num_rows()
             << ", rightBuildRows=" << rightTableView.num_rows();
 
     if (joinNode_->filter()) {
       // AST filter: eagerly apply filter_join_indices to reduce index count.
       filterAndEnqueueAstIndices(
-          leftTableView, i,
-          *leftJoinIndices, *rightJoinIndices,
-          cudf::join_kind::LEFT_JOIN, stream);
+          leftTableView,
+          i,
+          *leftJoinIndices,
+          *rightJoinIndices,
+          cudf::join_kind::LEFT_JOIN,
+          stream);
     } else {
       // No filter: enqueue raw indices for lazy gather.
       enqueuePendingIndices(
@@ -1176,8 +1189,8 @@ void CudfHashJoinProbe::rightJoin(
         "Chunking for right join is not yet implemented.",
         leftJoinIndices->size());
 
-    VLOG(1) << "CudfHashJoinProbe[" << planNodeId() << "] rightJoin chunk "
-            << i << ": joinResultRows=" << leftJoinIndices->size()
+    VLOG(1) << "CudfHashJoinProbe[" << planNodeId() << "] rightJoin chunk " << i
+            << ": joinResultRows=" << leftJoinIndices->size()
             << ", leftProbeRows=" << leftTableView.num_rows()
             << ", rightBuildRows=" << rightTableView.num_rows();
 
@@ -1252,9 +1265,13 @@ void CudfHashJoinProbe::rightJoin(
           filterFunc,
           stream);
       if (output.numRows > 0) {
-        outputQueue_.push(std::make_shared<CudfVector>(
-            pool(), outputType_, output.numRows,
-            std::move(output.table), stream));
+        outputQueue_.push(
+            std::make_shared<CudfVector>(
+                pool(),
+                outputType_,
+                output.numRows,
+                std::move(output.table),
+                stream));
       }
     } else {
       // No filter: update rightMatchedFlags_ eagerly, then enqueue indices
@@ -1302,8 +1319,8 @@ void CudfHashJoinProbe::fullJoin(
         "Chunking for full join is not yet implemented.",
         leftJoinIndices->size());
 
-    VLOG(1) << "CudfHashJoinProbe[" << planNodeId() << "] fullJoin chunk "
-            << i << ": joinResultRows=" << leftJoinIndices->size()
+    VLOG(1) << "CudfHashJoinProbe[" << planNodeId() << "] fullJoin chunk " << i
+            << ": joinResultRows=" << leftJoinIndices->size()
             << ", leftProbeRows=" << leftTableView.num_rows()
             << ", rightBuildRows=" << rightTableView.num_rows();
 
@@ -1338,7 +1355,8 @@ void CudfHashJoinProbe::fullJoin(
       // Enqueue filtered indices for lazy gather.
       enqueuePendingIndices(
           std::move(filteredLeftJoinIndices),
-          std::move(filteredRightJoinIndices), i);
+          std::move(filteredRightJoinIndices),
+          i);
     } else {
       // No filter: update rightMatchedFlags_ eagerly, then enqueue indices
       // for lazy gather.
@@ -1393,9 +1411,13 @@ void CudfHashJoinProbe::leftSemiFilterJoin(
         rightIndicesCol->view(),
         stream);
     if (output.numRows > 0) {
-      outputQueue_.push(std::make_shared<CudfVector>(
-          pool(), outputType_, output.numRows,
-          std::move(output.table), stream));
+      outputQueue_.push(
+          std::make_shared<CudfVector>(
+              pool(),
+              outputType_,
+              output.numRows,
+              std::move(output.table),
+              stream));
     }
   }
 }
@@ -1910,9 +1932,13 @@ void CudfHashJoinProbe::leftSemiProjectJoin(
 
   auto output = std::make_unique<cudf::table>(std::move(outputCols));
   if (numProbeRows > 0) {
-    outputQueue_.push(std::make_shared<CudfVector>(
-        pool(), outputType_, static_cast<cudf::size_type>(numProbeRows),
-        std::move(output), stream));
+    outputQueue_.push(
+        std::make_shared<CudfVector>(
+            pool(),
+            outputType_,
+            static_cast<cudf::size_type>(numProbeRows),
+            std::move(output),
+            stream));
   }
 }
 
@@ -1958,9 +1984,13 @@ void CudfHashJoinProbe::rightSemiFilterJoin(
       rightIndicesCol,
       stream);
   if (output.numRows > 0) {
-    outputQueue_.push(std::make_shared<CudfVector>(
-        pool(), outputType_, output.numRows,
-        std::move(output.table), stream));
+    outputQueue_.push(
+        std::make_shared<CudfVector>(
+            pool(),
+            outputType_,
+            output.numRows,
+            std::move(output.table),
+            stream));
   }
 }
 
@@ -2036,9 +2066,13 @@ void CudfHashJoinProbe::antiJoin(
       rightIndicesCol->view(),
       stream);
   if (output.numRows > 0) {
-    outputQueue_.push(std::make_shared<CudfVector>(
-        pool(), outputType_, output.numRows,
-        std::move(output.table), stream));
+    outputQueue_.push(
+        std::make_shared<CudfVector>(
+            pool(),
+            outputType_,
+            output.numRows,
+            std::move(output.table),
+            stream));
   }
 }
 
@@ -2141,9 +2175,13 @@ RowVectorPtr CudfHashJoinProbe::doGetOutput() {
           while (remaining > 0) {
             auto const chunkRows =
                 static_cast<vector_size_t>(std::min(remaining, maxRows));
-            outputQueue_.push(std::make_shared<CudfVector>(
-                pool(), outputType_, chunkRows,
-                std::make_unique<cudf::table>(), stream));
+            outputQueue_.push(
+                std::make_shared<CudfVector>(
+                    pool(),
+                    outputType_,
+                    chunkRows,
+                    std::make_unique<cudf::table>(),
+                    stream));
             remaining -= chunkRows;
           }
           if (!outputQueue_.empty()) {
@@ -2162,14 +2200,17 @@ RowVectorPtr CudfHashJoinProbe::doGetOutput() {
           auto batchSize =
               static_cast<vector_size_t>(outputBatches[i]->num_rows());
           if (batchSize > 0) {
-            outputQueue_.push(std::make_shared<CudfVector>(
-                pool(), outputType_, batchSize,
-                std::move(outputBatches[i]), stream));
+            outputQueue_.push(
+                std::make_shared<CudfVector>(
+                    pool(),
+                    outputType_,
+                    batchSize,
+                    std::move(outputBatches[i]),
+                    stream));
           }
         }
 
-        auto size =
-            static_cast<vector_size_t>(outputBatches[0]->num_rows());
+        auto size = static_cast<vector_size_t>(outputBatches[0]->num_rows());
         if (size == 0) {
           return nullptr;
         }

--- a/velox/experimental/cudf/exec/CudfHashJoin.h
+++ b/velox/experimental/cudf/exec/CudfHashJoin.h
@@ -29,8 +29,8 @@
 #include <cudf/ast/expressions.hpp>
 #include <cudf/copying.hpp>
 #include <cudf/join/hash_join.hpp>
-#include <cudf/utilities/span.hpp>
 #include <cudf/table/table.hpp>
+#include <cudf/utilities/span.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -287,7 +287,9 @@ class CudfHashJoinProbe : public CudfOperatorBase {
     std::unique_ptr<rmm::device_uvector<cudf::size_type>> rightIndices;
     size_t offset{0};
     size_t buildChunkIndex;
-    size_t remaining() const { return leftIndices->size() - offset; }
+    size_t remaining() const {
+      return leftIndices->size() - offset;
+    }
   };
 
   /// Queue of deferred index pairs awaiting gather in doGetOutput().
@@ -297,32 +299,24 @@ class CudfHashJoinProbe : public CudfOperatorBase {
    * @brief Performs inner join between probe table and all build tables.
    * Populates pendingIndices_ (lazy gather) or outputQueue_ (non-AST filter).
    */
-  void innerJoin(
-      cudf::table_view leftTableView,
-      rmm::cuda_stream_view stream);
+  void innerJoin(cudf::table_view leftTableView, rmm::cuda_stream_view stream);
   /**
    * @brief Performs left join between probe table and all build tables.
    * Populates pendingIndices_ (lazy gather) or outputQueue_ (non-AST filter).
    */
-  void leftJoin(
-      cudf::table_view leftTableView,
-      rmm::cuda_stream_view stream);
+  void leftJoin(cudf::table_view leftTableView, rmm::cuda_stream_view stream);
   /**
    * @brief Performs right join between probe table and all build tables.
    * Populates pendingIndices_ for matched rows. Updates rightMatchedFlags_
    * eagerly. Uses outputQueue_ for non-AST filtered right joins.
    */
-  void rightJoin(
-      cudf::table_view leftTableView,
-      rmm::cuda_stream_view stream);
+  void rightJoin(cudf::table_view leftTableView, rmm::cuda_stream_view stream);
   /**
    * @brief Performs full outer join between probe table and all build tables.
    * Populates pendingIndices_ for matched rows. Updates rightMatchedFlags_
    * eagerly. Full join requires AST filter support.
    */
-  void fullJoin(
-      cudf::table_view leftTableView,
-      rmm::cuda_stream_view stream);
+  void fullJoin(cudf::table_view leftTableView, rmm::cuda_stream_view stream);
   /**
    * @brief Performs left semi filter join. Pushes results to outputQueue_.
    */
@@ -344,9 +338,7 @@ class CudfHashJoinProbe : public CudfOperatorBase {
   /**
    * @brief Performs anti join. Pushes results to outputQueue_.
    */
-  void antiJoin(
-      cudf::table_view leftTableView,
-      rmm::cuda_stream_view stream);
+  void antiJoin(cudf::table_view leftTableView, rmm::cuda_stream_view stream);
   /**
    * @brief Constructs join output table without applying filter conditions.
    * @param leftTableView Input probe table view

--- a/velox/experimental/cudf/exec/CudfHashJoin.h
+++ b/velox/experimental/cudf/exec/CudfHashJoin.h
@@ -29,11 +29,13 @@
 #include <cudf/ast/expressions.hpp>
 #include <cudf/copying.hpp>
 #include <cudf/join/hash_join.hpp>
+#include <cudf/utilities/span.hpp>
 #include <cudf/table/table.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
 #include <memory>
+#include <queue>
 
 namespace facebook::velox::cudf_velox {
 
@@ -221,6 +223,10 @@ class CudfHashJoinProbe : public CudfOperatorBase {
   std::vector<size_t> rightColumnOutputIndices_;
   bool finished_{false};
 
+  /// Queue of output batches when a single probe produces results exceeding
+  /// cudf::size_type limits. Drained before accepting new input.
+  std::queue<CudfVectorPtr> outputQueue_;
+
   /// True if any build table has NULL values in join key columns.
   /// Used for null-aware LEFT SEMI PROJECT to determine match column
   /// nullability.
@@ -274,80 +280,71 @@ class CudfHashJoinProbe : public CudfOperatorBase {
     vector_size_t numRows;
   };
 
+  /// Deferred join index pair for lazy gather in doGetOutput().
+  /// gatherPendingBatch advances offset and pops the entry when fully consumed.
+  struct PendingIndices {
+    std::unique_ptr<rmm::device_uvector<cudf::size_type>> leftIndices;
+    std::unique_ptr<rmm::device_uvector<cudf::size_type>> rightIndices;
+    size_t offset{0};
+    size_t buildChunkIndex;
+    size_t remaining() const { return leftIndices->size() - offset; }
+  };
+
+  /// Queue of deferred index pairs awaiting gather in doGetOutput().
+  std::queue<PendingIndices> pendingIndices_;
+
   /**
    * @brief Performs inner join between probe table and all build tables.
-   * @param leftTable Probe-side table to join
-   * @param stream CUDA stream for operations
-   * @return Vector of result tables (multiple if build data was batched)
+   * Populates pendingIndices_ (lazy gather) or outputQueue_ (non-AST filter).
    */
-  std::vector<JoinOutput> innerJoin(
+  void innerJoin(
       cudf::table_view leftTableView,
       rmm::cuda_stream_view stream);
   /**
    * @brief Performs left join between probe table and all build tables.
-   * @param leftTableView Probe-side table view to join
-   * @param stream CUDA stream for operations
-   * @return Vector of result tables (multiple if build data was batched)
+   * Populates pendingIndices_ (lazy gather) or outputQueue_ (non-AST filter).
    */
-  std::vector<JoinOutput> leftJoin(
+  void leftJoin(
       cudf::table_view leftTableView,
       rmm::cuda_stream_view stream);
   /**
    * @brief Performs right join between probe table and all build tables.
-   * @param leftTableView Probe-side table view to join
-   * @param stream CUDA stream for operations
-   * @return Vector of result tables (multiple if build data was batched)
+   * Populates pendingIndices_ for matched rows. Updates rightMatchedFlags_
+   * eagerly. Uses outputQueue_ for non-AST filtered right joins.
    */
-  std::vector<JoinOutput> rightJoin(
+  void rightJoin(
       cudf::table_view leftTableView,
       rmm::cuda_stream_view stream);
   /**
    * @brief Performs full outer join between probe table and all build tables.
-   * @param leftTableView Probe-side table view to join
-   * @param stream CUDA stream for operations
-   * @return Vector of result tables (multiple if build data was batched)
+   * Populates pendingIndices_ for matched rows. Updates rightMatchedFlags_
+   * eagerly. Full join requires AST filter support.
    */
-  std::vector<JoinOutput> fullJoin(
+  void fullJoin(
       cudf::table_view leftTableView,
       rmm::cuda_stream_view stream);
   /**
-   * @brief Performs left semi filter join between probe table and all build
-   * tables.
-   * @param leftTableView Probe-side table view to join
-   * @param stream CUDA stream for operations
-   * @return Vector of result tables (multiple if build data was batched)
+   * @brief Performs left semi filter join. Pushes results to outputQueue_.
    */
-  std::vector<JoinOutput> leftSemiFilterJoin(
+  void leftSemiFilterJoin(
       cudf::table_view leftTableView,
       rmm::cuda_stream_view stream);
   /**
-   * @brief Performs left semi project join between probe table and all build
-   * tables. Returns all probe rows with a boolean match column indicating
-   * whether each row has a match on the build side.
-   * @param leftTableView Probe-side table view to join
-   * @param stream CUDA stream for operations
-   * @return Vector of result tables (multiple if build data was batched)
+   * @brief Performs left semi project join. Pushes results to outputQueue_.
    */
-  std::vector<JoinOutput> leftSemiProjectJoin(
+  void leftSemiProjectJoin(
       cudf::table_view leftTableView,
       rmm::cuda_stream_view stream);
   /**
-   * @brief Performs right semi filter join between probe table and all build
-   * tables.
-   * @param leftTableView Probe-side table view to join
-   * @param stream CUDA stream for operations
-   * @return Vector of result tables (multiple if build data was batched)
+   * @brief Performs right semi filter join. Pushes results to outputQueue_.
    */
-  std::vector<JoinOutput> rightSemiFilterJoin(
+  void rightSemiFilterJoin(
       cudf::table_view leftTableView,
       rmm::cuda_stream_view stream);
   /**
-   * @brief Performs anti join between probe table and all build tables.
-   * @param leftTableView Probe-side table view to join
-   * @param stream CUDA stream for operations
-   * @return Vector of result tables (multiple if build data was batched)
+   * @brief Performs anti join. Pushes results to outputQueue_.
    */
-  std::vector<JoinOutput> antiJoin(
+  void antiJoin(
       cudf::table_view leftTableView,
       rmm::cuda_stream_view stream);
   /**
@@ -394,6 +391,16 @@ class CudfHashJoinProbe : public CudfOperatorBase {
       cudf::table_view extendedRightView,
       cudf::join_kind joinKind,
       rmm::cuda_stream_view stream);
+
+  /// Enqueues a pair of join index vectors into pendingIndices_ for lazy
+  /// gather. Sub-chunking is handled in gatherPendingBatch via offset.
+  void enqueuePendingIndices(
+      std::unique_ptr<rmm::device_uvector<cudf::size_type>> leftIndices,
+      std::unique_ptr<rmm::device_uvector<cudf::size_type>> rightIndices,
+      size_t buildChunkIndex);
+
+  /// Gather one batch from pendingIndices_ and return as CudfVector.
+  RowVectorPtr gatherPendingBatch(rmm::cuda_stream_view stream);
 };
 
 /**

--- a/velox/experimental/cudf/exec/CudfHashJoin.h
+++ b/velox/experimental/cudf/exec/CudfHashJoin.h
@@ -401,6 +401,34 @@ class CudfHashJoinProbe : public CudfOperatorBase {
 
   /// Gather one batch from pendingIndices_ and return as CudfVector.
   RowVectorPtr gatherPendingBatch(rmm::cuda_stream_view stream);
+
+  /// Updates rightMatchedFlags_[chunkIndex] by OR-ing in which build rows
+  /// appear in rightIndicesCol. Synchronizes the stream before move-assigning
+  /// the updated flags to avoid a race with cudaFreeAsync.
+  void updateRightMatchedFlags(
+      size_t chunkIndex,
+      cudf::column_view rightIndicesCol,
+      cudf::size_type numBuildRows,
+      rmm::cuda_stream_view stream);
+
+  /// Applies AST filter_join_indices to join index pairs in sub-maxBatchRows
+  /// chunks and enqueues the filtered results into pendingIndices_.
+  void filterAndEnqueueAstIndices(
+      cudf::table_view leftTableView,
+      size_t rightTableIndex,
+      rmm::device_uvector<cudf::size_type>& leftJoinIndices,
+      rmm::device_uvector<cudf::size_type>& rightJoinIndices,
+      cudf::join_kind joinKind,
+      rmm::cuda_stream_view stream);
+
+  /// Eagerly gathers, applies non-AST filter, and pushes results to
+  /// outputQueue_. Splits oversized index spans into sub-maxBatchRows chunks.
+  void gatherFilterAndEnqueue(
+      cudf::table_view leftTableView,
+      cudf::table_view rightTableView,
+      rmm::device_uvector<cudf::size_type>& leftJoinIndices,
+      rmm::device_uvector<cudf::size_type>& rightJoinIndices,
+      rmm::cuda_stream_view stream);
 };
 
 /**

--- a/velox/experimental/cudf/exec/Utilities.cpp
+++ b/velox/experimental/cudf/exec/Utilities.cpp
@@ -60,18 +60,6 @@ CudaEvent& eventForThread() {
   return *events[deviceIndex];
 }
 
-size_t maxBatchRows() {
-  const auto& cudfConfig = CudfConfig::getInstance();
-  if (cudfConfig.batchSizeMaxThreshold) {
-    VELOX_CHECK_GT(
-        cudfConfig.batchSizeMaxThreshold.value(),
-        0,
-        "cuDF max batch size must be positive");
-    return static_cast<size_t>(cudfConfig.batchSizeMaxThreshold.value());
-  }
-  return static_cast<size_t>(std::numeric_limits<cudf::size_type>::max());
-}
-
 vector_size_t checkedVectorSize(size_t rowCount) {
   VELOX_CHECK_LE(
       rowCount,
@@ -81,24 +69,95 @@ vector_size_t checkedVectorSize(size_t rowCount) {
 }
 } // namespace
 
+size_t maxBatchRows() {
+  const auto& cudfConfig = CudfConfig::getInstance();
+  if (cudfConfig.batchSizeMaxThreshold) {
+    VELOX_CHECK_GT(
+        cudfConfig.batchSizeMaxThreshold.value(),
+        0,
+        "cuDF max batch size must be positive");
+    return static_cast<size_t>(cudfConfig.batchSizeMaxThreshold.value());
+  }
+  return static_cast<size_t>(std::numeric_limits<cudf::size_type>::max()) - 1;
+}
+
+// Concatenate a vector of table views into a single table.
+std::unique_ptr<cudf::table> concatenateViews(
+    std::vector<cudf::table_view> const& views,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  VELOX_CHECK_GT(views.size(), 0);
+  return cudf::concatenate(views, stream, mr);
+}
+
+// Concatenate table views into batches that respect maxBatchRows().
+std::vector<std::unique_ptr<cudf::table>> concatenateViewsBatched(
+    std::vector<cudf::table_view> const& views,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  VELOX_CHECK_GT(views.size(), 0);
+  std::vector<std::unique_ptr<cudf::table>> output;
+  auto const maxRows = maxBatchRows();
+  size_t startpos = 0;
+  size_t runningRows = 0;
+  for (size_t i = 0; i < views.size(); ++i) {
+    auto const numRows = static_cast<size_t>(views[i].num_rows());
+    // If adding this view would exceed the limit, flush current batch
+    // [startpos, i).
+    if (runningRows > 0 && runningRows + numRows > maxRows) {
+      output.push_back(cudf::concatenate(
+          std::vector<cudf::table_view>(
+              views.begin() + startpos, views.begin() + i),
+          stream,
+          mr));
+      startpos = i;
+      runningRows = 0;
+    }
+    runningRows += numRows;
+  }
+  // Flush the final batch [startpos, end).
+  if (startpos < views.size()) {
+    output.push_back(cudf::concatenate(
+        std::vector<cudf::table_view>(
+            views.begin() + startpos, views.end()),
+        stream,
+        mr));
+  }
+  return output;
+}
+
 std::unique_ptr<cudf::table> concatenateTables(
     std::vector<std::unique_ptr<cudf::table>> tables,
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr) {
-  // Check for empty vector
   VELOX_CHECK_GT(tables.size(), 0);
-
   if (tables.size() == 1) {
     return std::move(tables[0]);
   }
-  std::vector<cudf::table_view> tableViews;
-  tableViews.reserve(tables.size());
-  std::transform(
-      tables.begin(),
-      tables.end(),
-      std::back_inserter(tableViews),
-      [&](const auto& tbl) { return tbl->view(); });
-  return cudf::concatenate(tableViews, stream, mr);
+  std::vector<cudf::table_view> views;
+  views.reserve(tables.size());
+  for (const auto& tbl : tables) {
+    views.push_back(tbl->view());
+  }
+  return concatenateViews(views, stream, mr);
+}
+
+std::vector<std::unique_ptr<cudf::table>> concatenateTablesBatched(
+    std::vector<std::unique_ptr<cudf::table>> tables,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  VELOX_CHECK_GT(tables.size(), 0);
+  if (tables.size() == 1) {
+    std::vector<std::unique_ptr<cudf::table>> result;
+    result.push_back(std::move(tables[0]));
+    return result;
+  }
+  std::vector<cudf::table_view> views;
+  views.reserve(tables.size());
+  for (const auto& tbl : tables) {
+    views.push_back(tbl->view());
+  }
+  return concatenateViewsBatched(views, stream, mr);
 }
 
 std::unique_ptr<cudf::table> makeEmptyTable(TypePtr const& inputType) {
@@ -152,7 +211,7 @@ std::unique_ptr<cudf::table> getConcatenatedTable(
   // release in-place: the output is owned by `stream` but the input buffer was
   // allocated on a different stream, so releasing it would bind deallocation to
   // the wrong stream.
-  auto output = cudf::concatenate(tableViews, stream, mr);
+  auto output = concatenateViews(tableViews, stream, mr);
 
   orderCudfVectorDeallocationsAfterStream(tables, inputStreams, stream);
   // Input tables are deallocated here when 'tables' goes out of scope.
@@ -185,35 +244,8 @@ std::vector<std::unique_ptr<cudf::table>> getConcatenatedTableBatched(
 
   cudf::detail::join_streams(inputStreams, stream);
 
-  std::vector<std::unique_ptr<cudf::table>> outputTables;
-  auto const maxRows = maxBatchRows();
-  size_t startpos = 0;
-  size_t runningRows = 0;
-  for (size_t i = 0; i < tableViews.size(); ++i) {
-    auto const numRows = static_cast<size_t>(tableViews[i].num_rows());
-    // If adding this table would exceed the limit, flush current batch
-    // [startpos, i).
-    if (runningRows > 0 && runningRows + numRows > maxRows) {
-      outputTables.push_back(
-          cudf::concatenate(
-              std::vector<cudf::table_view>(
-                  tableViews.begin() + startpos, tableViews.begin() + i),
-              stream,
-              mr));
-      startpos = i;
-      runningRows = 0;
-    }
-    runningRows += numRows;
-  }
-  // Flush the final batch [startpos, end).
-  if (startpos < tableViews.size()) {
-    outputTables.push_back(
-        cudf::concatenate(
-            std::vector<cudf::table_view>(
-                tableViews.begin() + startpos, tableViews.end()),
-            stream,
-            mr));
-  }
+  auto outputTables = concatenateViewsBatched(tableViews, stream, mr);
+
   orderCudfVectorDeallocationsAfterStream(tables, inputStreams, stream);
 
   // Input tables are deallocated here when 'tables' goes out of scope.

--- a/velox/experimental/cudf/exec/Utilities.cpp
+++ b/velox/experimental/cudf/exec/Utilities.cpp
@@ -78,16 +78,7 @@ size_t maxBatchRows() {
         "cuDF max batch size must be positive");
     return static_cast<size_t>(cudfConfig.batchSizeMaxThreshold.value());
   }
-  return static_cast<size_t>(std::numeric_limits<cudf::size_type>::max()) - 1;
-}
-
-// Concatenate a vector of table views into a single table.
-std::unique_ptr<cudf::table> concatenateViews(
-    std::vector<cudf::table_view> const& views,
-    rmm::cuda_stream_view stream,
-    rmm::device_async_resource_ref mr) {
-  VELOX_CHECK_GT(views.size(), 0);
-  return cudf::concatenate(views, stream, mr);
+  return static_cast<size_t>(std::numeric_limits<cudf::size_type>::max());
 }
 
 // Concatenate table views into batches that respect maxBatchRows().
@@ -139,7 +130,7 @@ std::unique_ptr<cudf::table> concatenateTables(
   for (const auto& tbl : tables) {
     views.push_back(tbl->view());
   }
-  return concatenateViews(views, stream, mr);
+  return cudf::concatenate(views, stream, mr);
 }
 
 std::vector<std::unique_ptr<cudf::table>> concatenateTablesBatched(
@@ -211,7 +202,7 @@ std::unique_ptr<cudf::table> getConcatenatedTable(
   // release in-place: the output is owned by `stream` but the input buffer was
   // allocated on a different stream, so releasing it would bind deallocation to
   // the wrong stream.
-  auto output = concatenateViews(tableViews, stream, mr);
+  auto output = cudf::concatenate(tableViews, stream, mr);
 
   orderCudfVectorDeallocationsAfterStream(tables, inputStreams, stream);
   // Input tables are deallocated here when 'tables' goes out of scope.

--- a/velox/experimental/cudf/exec/Utilities.cpp
+++ b/velox/experimental/cudf/exec/Utilities.cpp
@@ -82,6 +82,8 @@ size_t maxBatchRows() {
 }
 
 // Concatenate table views into batches that respect maxBatchRows().
+// A single view whose row count exceeds maxBatchRows() is emitted as-is
+// (table views cannot be split).
 std::vector<std::unique_ptr<cudf::table>> concatenateViewsBatched(
     std::vector<cudf::table_view> const& views,
     rmm::cuda_stream_view stream,

--- a/velox/experimental/cudf/exec/Utilities.cpp
+++ b/velox/experimental/cudf/exec/Utilities.cpp
@@ -98,11 +98,12 @@ std::vector<std::unique_ptr<cudf::table>> concatenateViewsBatched(
     // If adding this view would exceed the limit, flush current batch
     // [startpos, i).
     if (runningRows > 0 && runningRows + numRows > maxRows) {
-      output.push_back(cudf::concatenate(
-          std::vector<cudf::table_view>(
-              views.begin() + startpos, views.begin() + i),
-          stream,
-          mr));
+      output.push_back(
+          cudf::concatenate(
+              std::vector<cudf::table_view>(
+                  views.begin() + startpos, views.begin() + i),
+              stream,
+              mr));
       startpos = i;
       runningRows = 0;
     }
@@ -110,11 +111,12 @@ std::vector<std::unique_ptr<cudf::table>> concatenateViewsBatched(
   }
   // Flush the final batch [startpos, end).
   if (startpos < views.size()) {
-    output.push_back(cudf::concatenate(
-        std::vector<cudf::table_view>(
-            views.begin() + startpos, views.end()),
-        stream,
-        mr));
+    output.push_back(
+        cudf::concatenate(
+            std::vector<cudf::table_view>(
+                views.begin() + startpos, views.end()),
+            stream,
+            mr));
   }
   return output;
 }

--- a/velox/experimental/cudf/exec/Utilities.h
+++ b/velox/experimental/cudf/exec/Utilities.h
@@ -27,8 +27,21 @@
 
 namespace facebook::velox::cudf_velox {
 
+/// Returns the maximum number of rows allowed in a single cudf table.
+/// Defaults to cudf::size_type max (~2.1B); overridable via
+/// CudfConfig::batchSizeMaxThreshold.
+size_t maxBatchRows();
+
 // Concatenate a vector of cuDF tables into a single table
 [[nodiscard]] std::unique_ptr<cudf::table> concatenateTables(
+    std::vector<std::unique_ptr<cudf::table>> tables,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr);
+
+/// Batched variant of concatenateTables that splits output to respect
+/// cudf::size_type row limits. All input tables must be on the same stream.
+[[nodiscard]] std::vector<std::unique_ptr<cudf::table>>
+concatenateTablesBatched(
     std::vector<std::unique_ptr<cudf::table>> tables,
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr);

--- a/velox/experimental/cudf/tests/HashJoinTest.cpp
+++ b/velox/experimental/cudf/tests/HashJoinTest.cpp
@@ -9105,4 +9105,127 @@ TEST_F(HashJoinTest, emptyBuildWithDebugEnabled) {
       .run();
 }
 
+// Verifies that inner join output exceeding batchSizeMaxThreshold is correctly
+// split into multiple batches and emitted via the output queue.
+TEST_F(HashJoinTest, innerJoinOutputBatching) {
+  // Set a low threshold to force multiple output batches.
+  auto& config = cudf_velox::CudfConfig::getInstance();
+  config.batchSizeMaxThreshold = 10;
+  SCOPE_EXIT {
+    config.batchSizeMaxThreshold = std::nullopt;
+  };
+
+  // 50 probe rows with keys 0..49, 50 build rows with keys 0..49.
+  // Each probe row matches exactly one build row -> 50 output rows total,
+  // split into batches of at most 10.
+  auto probeVectors = makeBatches(1, [&](int32_t /*unused*/) {
+    return makeRowVector(
+        {"c0", "c1"},
+        {makeFlatVector<int32_t>(50, [](auto row) { return row; }),
+         makeFlatVector<int32_t>(50, [](auto row) { return row * 10; })});
+  });
+  auto buildVectors = makeBatches(1, [&](int32_t /*unused*/) {
+    return makeRowVector(
+        {"c0", "c1"},
+        {makeFlatVector<int32_t>(50, [](auto row) { return row; }),
+         makeFlatVector<int32_t>(50, [](auto row) { return row * 100; })});
+  });
+
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .numDrivers(1)
+      .injectSpill(false)
+      .probeKeys({"c0"})
+      .probeVectors(std::move(probeVectors))
+      .buildKeys({"u_c0"})
+      .buildVectors(std::move(buildVectors))
+      .buildProjections({"c0 AS u_c0", "c1 AS u_c1"})
+      .joinType(core::JoinType::kInner)
+      .joinOutputLayout({"c0", "c1", "u_c1"})
+      .referenceQuery(
+          "SELECT t.c0, t.c1, u.c1 FROM t INNER JOIN u ON t.c0 = u.c0")
+      .run();
+}
+
+// Verifies that right join unmatched-right output exceeding
+// batchSizeMaxThreshold is correctly split and emitted via the output queue.
+TEST_F(HashJoinTest, rightJoinOutputBatching) {
+  // Set a low threshold to force multiple output batches.
+  auto& config = cudf_velox::CudfConfig::getInstance();
+  config.batchSizeMaxThreshold = 10;
+  SCOPE_EXIT {
+    config.batchSizeMaxThreshold = std::nullopt;
+  };
+
+  // Probe keys are 0..9. Build keys are 0..49.
+  // Only build rows with keys 0..9 match; build rows 10..49 are unmatched
+  // and emitted via the unmatched-right path (40 rows, split at threshold 10).
+  auto probeVectors = makeBatches(1, [&](int32_t /*unused*/) {
+    return makeRowVector(
+        {"c0", "c1"},
+        {makeFlatVector<int32_t>(10, [](auto row) { return row; }),
+         makeFlatVector<int32_t>(10, [](auto row) { return row * 10; })});
+  });
+  auto buildVectors = makeBatches(1, [&](int32_t /*unused*/) {
+    return makeRowVector(
+        {"c0", "c1"},
+        {makeFlatVector<int32_t>(50, [](auto row) { return row; }),
+         makeFlatVector<int32_t>(50, [](auto row) { return row * 100; })});
+  });
+
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .numDrivers(1)
+      .injectSpill(false)
+      .probeKeys({"c0"})
+      .probeVectors(std::move(probeVectors))
+      .buildKeys({"u_c0"})
+      .buildVectors(std::move(buildVectors))
+      .buildProjections({"c0 AS u_c0", "c1 AS u_c1"})
+      .joinType(core::JoinType::kRight)
+      .joinOutputLayout({"c0", "c1", "u_c1"})
+      .referenceQuery(
+          "SELECT t.c0, t.c1, u.c1 FROM t RIGHT JOIN u ON t.c0 = u.c0")
+      .run();
+}
+
+// Verifies that a single inner join chunk exceeding batchSizeMaxThreshold
+// is correctly split via chunkedJoinOutput (Scenario 1).
+TEST_F(HashJoinTest, innerJoinSingleChunkExceedsRowLimit) {
+  // Set a low threshold so a single join result exceeds the limit.
+  auto& config = cudf_velox::CudfConfig::getInstance();
+  config.batchSizeMaxThreshold = 10;
+  SCOPE_EXIT {
+    config.batchSizeMaxThreshold = std::nullopt;
+  };
+
+  // Many-to-many join: 10 probe rows all with key=1, 10 build rows all with
+  // key=1. The single inner_join call produces 10*10=100 output rows, well
+  // above the threshold of 10.
+  auto probeVectors = makeBatches(1, [&](int32_t /*unused*/) {
+    return makeRowVector(
+        {"c0", "c1"},
+        {makeFlatVector<int32_t>(10, [](auto /*row*/) { return 1; }),
+         makeFlatVector<int32_t>(10, [](auto row) { return row; })});
+  });
+  auto buildVectors = makeBatches(1, [&](int32_t /*unused*/) {
+    return makeRowVector(
+        {"c0", "c1"},
+        {makeFlatVector<int32_t>(10, [](auto /*row*/) { return 1; }),
+         makeFlatVector<int32_t>(10, [](auto row) { return row * 100; })});
+  });
+
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .numDrivers(1)
+      .injectSpill(false)
+      .probeKeys({"c0"})
+      .probeVectors(std::move(probeVectors))
+      .buildKeys({"u_c0"})
+      .buildVectors(std::move(buildVectors))
+      .buildProjections({"c0 AS u_c0", "c1 AS u_c1"})
+      .joinType(core::JoinType::kInner)
+      .joinOutputLayout({"c0", "c1", "u_c1"})
+      .referenceQuery(
+          "SELECT t.c0, t.c1, u.c1 FROM t INNER JOIN u ON t.c0 = u.c0")
+      .run();
+}
+
 } // namespace

--- a/velox/experimental/cudf/tests/HashJoinTest.cpp
+++ b/velox/experimental/cudf/tests/HashJoinTest.cpp
@@ -9188,7 +9188,7 @@ TEST_F(HashJoinTest, rightJoinOutputBatching) {
 }
 
 // Verifies that a single inner join chunk exceeding batchSizeMaxThreshold
-// is correctly split via chunkedJoinOutput (Scenario 1).
+// is correctly split via pendingIndices_ and gatherPendingBatch.
 TEST_F(HashJoinTest, innerJoinSingleChunkExceedsRowLimit) {
   // Set a low threshold so a single join result exceeds the limit.
   auto& config = cudf_velox::CudfConfig::getInstance();


### PR DESCRIPTION
## Summary

- Add lazy gather for inner/left joins to reduce peak GPU memory to the `maxBatchRows` per `doGetOutput()` call
- Handle join output with number of rows exceeding integer row limit (~2.1B rows) for inner/left joins by splitting index spans into sub-batches
- Batch unmatched-right output for right/full joins to respect row limits

This PR addresses the crash in TPC-DS Q23 at SF1000 on a single B200 where `CudfHashJoinProbe::doGetOutput()` fails because the join fanout produces more than integer limit rows. Additionally, even when the row count stays within int32 range, the eager gather approach materializes all join output in GPU memory at once (probe input + all gathered chunks + concatenated result), causing OOM on high-fanout joins.

## Design

### Lazy gather of indices in a queue

Inner and left join methods no longer call `cudf::gather`. Instead they push raw join index pairs into a `pendingIndices_` queue. `doGetOutput()` gathers only up to `maxBatchRows()` indices per call using an offset-based cursor to incrementally consume each index pair entry without pre-splitting.
For AST-filtered joins, the indices are filtered eagerly (reducing index count before queuing). For non-AST-filtered joins, the gather is eager since the filter needs materialized data — results are pushed to a output queue instead.

### Queue selection by join type

| Join type | Queue | Reason |
|-----------|-------|--------|
| Inner/Left (no filter or AST) | `pendingIndices_` | Lazy gather |
| Inner/Left (non-AST filter) | `outputQueue_` | Filter needs materialized data |
| Right/Full (matched rows) | `pendingIndices_` | Lazy gather |
| Right/Full (unmatched-right) | `outputQueue_` | Sequential after probe phase |
| Semi/Anti | `outputQueue_` | Output ≤ probe cardinality |

### Oversized join output

- **Inner/Left joins**: Index spans exceeding `maxBatchRows()` are split into sub-batches transparently.
- **Right/Full joins**: A `VELOX_CHECK_LE` guards against overflow (chunking requires splitting `rightMatchedFlags_` updates and is left as future work).