### PR TITLE
fix(ci): Isolate main sanitizer builds per commit

### DIFF
--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -919,7 +919,7 @@ jobs:
       failed-cases: ${{ steps.tests.outputs.failed-cases }}
       failure-details: ${{ steps.tests.outputs.failure-details }}
     concurrency:
-      group: ${{ github.workflow }}-asan-ubsan-adapters-${{ github.event.pull_request.number }}
+      group: ${{ github.workflow }}-asan-ubsan-adapters-${{ github.head_ref || github.sha }}
       cancel-in-progress: true
     steps:
       - name: Free Disk Space


### PR DESCRIPTION
Summary:
On pushes to main, the ASAN/UBSAN "adapters" build shared one concurrency group across every commit, so each new merge cancelled the previous merge's still-running build. The group key ended in `${{ github.event.pull_request.number }}`, which is empty outside a pull request, so on push it collapsed to the constant string `Linux Build using GCC-asan-ubsan-adapters-`. With `cancel-in-progress: true` that made a single shared group for all of main. The build takes ~90 minutes and merges land more often than that during busy periods, so most commits never finished it, and the dependent `BUILD: Linux sanitizers` and `TEST: Linux sanitizers` gate jobs read the cancelled build's outcome and reported a false red on otherwise-green commits:

    Linux ASAN/UBSAN with system dependencies build failed. Do not land this PR until the build is fixed.

Keying the group on `${{ github.head_ref || github.sha }}` gives each pushed commit its own group, so main builds run to completion and stop cancelling each other. This matches the pattern every other Velox workflow already uses: `benchmark`, `docker`, `docs`, `macos`, `linux-build`, and the rest all key on `github.head_ref || github.sha`. The ASAN/UBSAN adapters job was the only concurrency group keyed on the PR number, and the only one missing a fallback. Pull request behavior is unchanged: `github.head_ref` is set on pull-request runs, so a new push to a PR still cancels that PR's in-flight build.

Reviewed By: kKPulla

Differential Revision: D111133208


