### PR TITLE
fix(hive): Wire file-handle-expiration-duration-ms to SimpleLRUCache

### DIFF
--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -40,7 +40,8 @@ HiveConnector::HiveConnector(
       fileHandleFactory_(
           hiveConfig_->isFileHandleCacheEnabled()
               ? std::make_unique<SimpleLRUCache<FileHandleKey, FileHandle>>(
-                    hiveConfig_->numCacheFileHandles())
+                    hiveConfig_->numCacheFileHandles(),
+                    hiveConfig_->fileHandleExpirationDurationMs())
               : nullptr,
           std::make_unique<FileHandleGenerator>(hiveConfig_->config())),
       ioExecutor_(ioExecutor) {


### PR DESCRIPTION
## Summary

The `file-handle-expiration-duration-ms` config exists in `HiveConfig` and is already logged at connector creation time, but it was never actually passed to the `SimpleLRUCache` constructor. This meant cached file handles were never evicted by TTL, causing stale handles to accumulate indefinitely (e.g., expired HDFS leases, closed remote connections on long-running executors).

## Fix

Pass `hiveConfig_->fileHandleExpirationDurationMs()` as the second argument to `SimpleLRUCache`'s constructor, which already supports an `expireDurationMs` parameter (defaulting to 0 / no eviction).

## Testing

Existing tests pass. The `SimpleLRUCache` TTL eviction logic is already tested in `SimpleLRUCacheTest.cpp`. This change just wires the config value that was previously dead code.

## Context

Discovered while working on Apache Gluten ([PR #12400](https://github.com/apache/gluten/pull/12400)) which enables file handle caching by default and needs TTL-based eviction to prevent stale handle accumulation on remote filesystems.

Was this patch authored or co-authored using generative AI tooling? Generated-by: Claude claude-opus-4.6