### PR TITLE
fix: RowSerializer should use chain length during serialization

### DIFF
--- a/velox/serializers/RowSerializer.h
+++ b/velox/serializers/RowSerializer.h
@@ -147,7 +147,7 @@ class RowSerializer : public IterativeVectorSerializer {
       // Compress the buffer if satisfied condition.
       const auto toCompress = toIOBuf(buffers_);
       const auto compressedBuffer = codec_->compress(toCompress.get());
-      const int32_t compressedSize = compressedBuffer->length();
+      const int32_t compressedSize = compressedBuffer->computeChainDataLength();
       stats_.compressionInputBytes += size;
       stats_.compressedBytes += compressedSize;
       if (compressedSize > options_.minCompressionRatio * size) {

--- a/velox/serializers/tests/UnsafeRowSerializerTest.cpp
+++ b/velox/serializers/tests/UnsafeRowSerializerTest.cpp
@@ -628,6 +628,19 @@ TEST_P(UnsafeRowSerializerTest, multiPage) {
   test::assertEqualVectors(deserialized, expected);
 }
 
+TEST_P(UnsafeRowSerializerTest, basicLarge) {
+#ifndef NDEBUG
+  constexpr vector_size_t kNumRows = 60'000;
+#else
+  constexpr vector_size_t kNumRows = 600'000;
+#endif
+  auto rowVector = makeRowVector(
+      {makeFlatVector<int64_t>(kNumRows, [](vector_size_t row) { return row; }),
+       makeFlatVector<std::string>(
+           kNumRows, [](vector_size_t) { return std::string(2048, 'x'); })});
+  testRoundTrip(std::move(rowVector));
+}
+
 VELOX_INSTANTIATE_TEST_SUITE_P(
     UnsafeRowSerializerTest,
     UnsafeRowSerializerTest,


### PR DESCRIPTION
This change is a follow up of https://github.com/facebookincubator/velox/pull/12784, `RowSerializer` should also use chain length duration serialization.

Add a test with large size 60'000/600'000 to cover this case, before this change it failed with:
```bash
[ RUN      ] UnsafeRowSerializerTest/UnsafeRowSerializerTest.basicLarge/zlib_append_batchDeserialize
unknown file: Failure
C++ exception with description "Codec: no forward progress made" thrown in the test body.

[  FAILED  ] UnsafeRowSerializerTest/UnsafeRowSerializerTest.basicLarge/zlib_append_batchDeserialize, where GetParam() = 16-byte object <01-00 00-00 00-00 00-00 01-00 49-35 86-55 00-00> (15593 ms)
```