### PR TITLE
perf: Optimize right hash joins with probe-only filter pre-evaluation

### DIFF
--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -709,6 +709,7 @@ void HashProbe::addInput(RowVectorPtr input) {
 
   // Reset passingInputRowsInitialized_ as input_ as changed.
   passingInputRowsInitialized_ = false;
+  probeOnlyFilterPreEvaluated_ = false;
 
   const auto numInput = input_->size();
 
@@ -798,6 +799,13 @@ void HashProbe::addInput(RowVectorPtr input) {
     }
     lookup_->hits.resize(lookup_->rows.back() + 1);
     table_->joinProbe(*lookup_);
+  }
+
+  probeOnlyFilterPreEvaluated_ = tryPreEvaluateProbeOnlyFilter();
+
+  if (probeOnlyFilterPreEvaluated_ && isRightSemiFilterJoin(joinType_)) {
+    processRightSemiNoFilter(false);
+    return;
   }
 
   resultIter_->reset(*lookup_);
@@ -1089,6 +1097,46 @@ void HashProbe::processRightSemiNoFilter(bool emptyBuildSide) {
   input_ = nullptr;
 }
 
+bool HashProbe::tryPreEvaluateProbeOnlyFilter() {
+  if (!filter_ || !filterTableProjections_.empty() ||
+      !filter_->expr(0)->isDeterministic()) {
+    return false;
+  }
+
+  if (!isRightJoin(joinType_) && !isFullJoin(joinType_) &&
+      !isRightSemiFilterJoin(joinType_)) {
+    return false;
+  }
+
+  const auto numInput = input_->size();
+  filterInputRows_.resizeFill(numInput, isFullJoin(joinType_));
+
+  if (!isFullJoin(joinType_)) {
+    filterInputRows_.clearAll();
+    for (const auto probeRow : lookup_->rows) {
+      if (lookup_->hits[probeRow] != nullptr) {
+        filterInputRows_.setValid(probeRow, true);
+      }
+    }
+    filterInputRows_.updateBounds();
+  }
+
+  if (filterInputRows_.hasSelections()) {
+    RowVectorPtr filterInput = createProbeOnlyFilterInput(numInput);
+    EvalCtx evalCtx(operatorCtx_->execCtx(), filter_.get(), filterInput.get());
+    filter_->eval(0, 1, true, filterInputRows_, evalCtx, filterResult_);
+    decodedFilterResult_.decode(*filterResult_[0], filterInputRows_);
+  }
+
+  for (const auto probeRow : lookup_->rows) {
+    if (lookup_->hits[probeRow] != nullptr && !filterPassed(probeRow)) {
+      lookup_->hits[probeRow] = nullptr;
+    }
+  }
+
+  return true;
+}
+
 RowVectorPtr HashProbe::getOutputInternal(bool toSpillOutput) {
   if (isFinished()) {
     return nullptr;
@@ -1302,7 +1350,9 @@ RowVectorPtr HashProbe::getOutputInternal(bool toSpillOutput) {
       VELOX_CHECK_NOT_NULL(table_);
     }
 
-    numOut = evalFilter(numOut);
+    if (!probeOnlyFilterPreEvaluated_) {
+      numOut = evalFilter(numOut);
+    }
 
     if (numOut == 0) {
       // The hash probe might get stuck in the output loop if the filter is
@@ -1381,6 +1431,19 @@ RowVectorPtr HashProbe::createFilterInput(vector_size_t size) {
       pool(),
       filterInputType_->children(),
       filterColumns);
+
+  return std::make_shared<RowVector>(
+      pool(), filterInputType_, nullptr, size, std::move(filterColumns));
+}
+
+RowVectorPtr HashProbe::createProbeOnlyFilterInput(vector_size_t size) {
+  std::vector<VectorPtr> filterColumns(filterInputType_->size());
+  for (const auto& projection : filterInputProjections_) {
+    LazyVector::ensureLoadedRows(
+        input_->childAt(projection.inputChannel), filterInputRows_);
+    filterColumns[projection.outputChannel] =
+        input_->childAt(projection.inputChannel);
+  }
 
   return std::make_shared<RowVector>(
       pool(), filterInputType_, nullptr, size, std::move(filterColumns));

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -189,6 +189,10 @@ class HashProbe : public Operator {
   // Returns the number of passing rows.
   vector_size_t evalFilter(vector_size_t numRows);
 
+  // Applies a deterministic probe-only join filter before expanding join
+  // results. Returns true if the filter was applied.
+  bool tryPreEvaluateProbeOnlyFilter();
+
   inline bool filterPassed(vector_size_t row) {
     return filterInputRows_.isValid(row) &&
         !decodedFilterResult_.isNullAt(row) &&
@@ -199,6 +203,9 @@ class HashProbe : public Operator {
   // gets destroyed in case its wrapping an unloaded vector which eventually
   // needs to be wrapped in fillOutput().
   RowVectorPtr createFilterInput(vector_size_t size);
+
+  // Creates filter input directly over the current probe input batch.
+  RowVectorPtr createProbeOnlyFilterInput(vector_size_t size);
 
   // Prepare filter row selectivity for null-aware join. 'numRows'
   // specifies the number of rows in 'filterInputRows_' to process. If
@@ -507,6 +514,10 @@ class HashProbe : public Operator {
 
   // Used to decode a probe side filter input column to check nulls.
   DecodedVector filterInputColumnDecodedVector_;
+
+  // True if 'filter_' has already been applied to 'lookup_->hits' for the
+  // current probe input batch.
+  bool probeOnlyFilterPreEvaluated_{false};
 
   // Rows that have null value in any probe side filter columns to skip the
   // null-propagating filter evaluation. The corresponding probe input rows can

--- a/velox/exec/benchmarks/CMakeLists.txt
+++ b/velox/exec/benchmarks/CMakeLists.txt
@@ -98,6 +98,16 @@ target_link_libraries(
   Folly::follybenchmark
 )
 
+add_executable(velox_hash_join_probe_filter_benchmark HashJoinProbeFilterBenchmark.cpp)
+
+target_link_libraries(
+  velox_hash_join_probe_filter_benchmark
+  velox_exec
+  velox_exec_test_lib
+  velox_vector_test_lib
+  Folly::follybenchmark
+)
+
 add_executable(velox_hash_join_prepare_join_table_benchmark HashJoinPrepareJoinTableBenchmark.cpp)
 
 target_link_libraries(

--- a/velox/exec/benchmarks/HashJoinProbeFilterBenchmark.cpp
+++ b/velox/exec/benchmarks/HashJoinProbeFilterBenchmark.cpp
@@ -1,0 +1,297 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include <algorithm>
+#include <random>
+
+#include "velox/common/memory/Memory.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/parse/TypeResolver.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec::test;
+using namespace facebook::velox::test;
+
+namespace {
+
+struct BenchmarkParams {
+  core::JoinType joinType;
+  int32_t numMatchedKeys;
+  int32_t numBuildOnlyKeys;
+  int32_t numProbeOnlyKeys;
+  int32_t buildDuplicates;
+  int32_t probeDuplicates;
+  int32_t numProbeBatches;
+  std::string filter;
+  std::vector<std::string> outputLayout;
+  std::string title;
+};
+
+struct BenchmarkData {
+  std::vector<RowVectorPtr> buildVectors;
+  std::vector<RowVectorPtr> probeVectors;
+};
+
+struct BenchmarkCase {
+  BenchmarkParams params;
+  BenchmarkData data;
+};
+
+class HashJoinProbedFlagBenchmark : public VectorTestBase {
+ public:
+  BenchmarkData prepareData(const BenchmarkParams& params) {
+    BenchmarkData data;
+
+    auto buildKeys = makeRepeatedKeys(
+        0,
+        params.numMatchedKeys,
+        params.buildDuplicates,
+        31 /*seed for deterministic shuffling*/);
+    appendRepeatedKeys(
+        buildKeys,
+        params.numMatchedKeys,
+        params.numBuildOnlyKeys,
+        1 /*duplicates*/);
+    shuffle(buildKeys, 43);
+
+    auto probeKeys = makeRepeatedKeys(
+        0,
+        params.numMatchedKeys,
+        params.probeDuplicates,
+        97 /*seed for deterministic shuffling*/);
+    appendRepeatedKeys(
+        probeKeys,
+        params.numMatchedKeys + params.numBuildOnlyKeys,
+        params.numProbeOnlyKeys,
+        1 /*duplicates*/);
+    shuffle(probeKeys, 109);
+
+    data.buildVectors = makeBatchesFromKeys(buildKeys, 1, 0);
+    data.probeVectors =
+        makeBatchesFromKeys(probeKeys, params.numProbeBatches, 10'000'000);
+    return data;
+  }
+
+  int64_t run(const BenchmarkParams& params, const BenchmarkData& data) {
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+
+    auto plan = PlanBuilder(planNodeIdGenerator, pool_.get())
+                    .values(data.probeVectors)
+                    .project({"c0 AS t0", "c1 AS t1"})
+                    .hashJoin(
+                        {"t0"},
+                        {"u0"},
+                        PlanBuilder(planNodeIdGenerator, pool_.get())
+                            .values(data.buildVectors)
+                            .project({"c0 AS u0", "c1 AS u1"})
+                            .planNode(),
+                        params.filter,
+                        params.outputLayout,
+                        params.joinType)
+                    .planNode();
+
+    return AssertQueryBuilder(plan).maxDrivers(1).countResults();
+  }
+
+ private:
+  std::vector<int64_t> makeRepeatedKeys(
+      int64_t start,
+      int32_t numKeys,
+      int32_t duplicates,
+      uint32_t seed) {
+    VELOX_CHECK_GE(numKeys, 0);
+    VELOX_CHECK_GT(duplicates, 0);
+
+    std::vector<int64_t> keys;
+    keys.reserve(numKeys * duplicates);
+    appendRepeatedKeys(keys, start, numKeys, duplicates);
+    shuffle(keys, seed);
+    return keys;
+  }
+
+  void appendRepeatedKeys(
+      std::vector<int64_t>& keys,
+      int64_t start,
+      int32_t numKeys,
+      int32_t duplicates) {
+    for (auto i = 0; i < numKeys; ++i) {
+      for (auto j = 0; j < duplicates; ++j) {
+        keys.push_back(start + i);
+      }
+    }
+  }
+
+  void shuffle(std::vector<int64_t>& keys, uint32_t seed) {
+    std::mt19937 random(seed);
+    std::shuffle(keys.begin(), keys.end(), random);
+  }
+
+  std::vector<RowVectorPtr> makeBatchesFromKeys(
+      const std::vector<int64_t>& keys,
+      int32_t numBatches,
+      int64_t payloadBase) {
+    VELOX_CHECK_GT(numBatches, 0);
+
+    std::vector<RowVectorPtr> batches;
+    batches.reserve(numBatches);
+
+    const int32_t totalSize = keys.size();
+    const int32_t batchSize = std::max(1, totalSize / numBatches);
+    int32_t start = 0;
+
+    while (start < totalSize) {
+      const int32_t end = std::min(totalSize, start + batchSize);
+      const int32_t size = end - start;
+
+      std::vector<VectorPtr> children;
+      children.push_back(makeFlatVector<int64_t>(size, [&](vector_size_t row) {
+        return keys[start + row];
+      }));
+      children.push_back(makeFlatVector<int64_t>(size, [&](vector_size_t row) {
+        return payloadBase + static_cast<int64_t>(start + row);
+      }));
+
+      batches.push_back(makeRowVector(children));
+      start = end;
+    }
+
+    return batches;
+  }
+};
+
+} // namespace
+
+int main(int argc, char** argv) {
+  folly::Init init{&argc, &argv};
+  memory::MemoryManager::initialize(memory::MemoryManager::Options{});
+  functions::prestosql::registerAllScalarFunctions();
+  parse::registerTypeResolver();
+
+  auto benchmark = std::make_unique<HashJoinProbedFlagBenchmark>();
+  std::vector<BenchmarkCase> benchmarkCases;
+
+  constexpr int32_t kMatchedKeys = 1'000;
+  constexpr int32_t kBuildDuplicates = 4;
+  constexpr int32_t kProbeDuplicates = 128;
+  constexpr int32_t kOuterOnlyKeys = 1'000;
+  constexpr int32_t kProbeBatches = 8;
+
+  const std::vector<BenchmarkParams> params = {
+      {.joinType = core::JoinType::kRight,
+       .numMatchedKeys = kMatchedKeys,
+       .numBuildOnlyKeys = kOuterOnlyKeys,
+       .numProbeOnlyKeys = 0,
+       .buildDuplicates = kBuildDuplicates,
+       .probeDuplicates = kProbeDuplicates,
+       .numProbeBatches = kProbeBatches,
+       .filter = "",
+       .outputLayout = {"t1", "u1"},
+       .title = "right_outer_dup4x128"},
+      {.joinType = core::JoinType::kRight,
+       .numMatchedKeys = kMatchedKeys,
+       .numBuildOnlyKeys = kOuterOnlyKeys,
+       .numProbeOnlyKeys = 0,
+       .buildDuplicates = kBuildDuplicates,
+       .probeDuplicates = kProbeDuplicates,
+       .numProbeBatches = kProbeBatches,
+       .filter = "t1 >= 0",
+       .outputLayout = {"t1", "u1"},
+       .title = "right_outer_with_filter_dup4x128"},
+      {.joinType = core::JoinType::kRight,
+       .numMatchedKeys = kMatchedKeys,
+       .numBuildOnlyKeys = kOuterOnlyKeys,
+       .numProbeOnlyKeys = 0,
+       .buildDuplicates = kBuildDuplicates,
+       .probeDuplicates = kProbeDuplicates,
+       .numProbeBatches = kProbeBatches,
+       .filter = "t1 % 4 = 0",
+       .outputLayout = {"t1", "u1"},
+       .title = "right_outer_selective_filter_dup4x128"},
+      {.joinType = core::JoinType::kFull,
+       .numMatchedKeys = kMatchedKeys,
+       .numBuildOnlyKeys = kOuterOnlyKeys,
+       .numProbeOnlyKeys = kOuterOnlyKeys,
+       .buildDuplicates = kBuildDuplicates,
+       .probeDuplicates = kProbeDuplicates,
+       .numProbeBatches = kProbeBatches,
+       .filter = "",
+       .outputLayout = {"t1", "u1"},
+       .title = "full_outer_dup4x128"},
+      {.joinType = core::JoinType::kFull,
+       .numMatchedKeys = kMatchedKeys,
+       .numBuildOnlyKeys = kOuterOnlyKeys,
+       .numProbeOnlyKeys = kOuterOnlyKeys,
+       .buildDuplicates = kBuildDuplicates,
+       .probeDuplicates = kProbeDuplicates,
+       .numProbeBatches = kProbeBatches,
+       .filter = "t1 >= 0",
+       .outputLayout = {"t1", "u1"},
+       .title = "full_outer_with_filter_dup4x128"},
+      {.joinType = core::JoinType::kFull,
+       .numMatchedKeys = kMatchedKeys,
+       .numBuildOnlyKeys = kOuterOnlyKeys,
+       .numProbeOnlyKeys = kOuterOnlyKeys,
+       .buildDuplicates = kBuildDuplicates,
+       .probeDuplicates = kProbeDuplicates,
+       .numProbeBatches = kProbeBatches,
+       .filter = "t1 % 4 = 0",
+       .outputLayout = {"t1", "u1"},
+       .title = "full_outer_selective_filter_dup4x128"},
+      {.joinType = core::JoinType::kRightSemiFilter,
+       .numMatchedKeys = kMatchedKeys,
+       .numBuildOnlyKeys = kOuterOnlyKeys,
+       .numProbeOnlyKeys = 0,
+       .buildDuplicates = kBuildDuplicates,
+       .probeDuplicates = kProbeDuplicates,
+       .numProbeBatches = kProbeBatches,
+       .filter = "t1 >= 0",
+       .outputLayout = {"u1"},
+       .title = "right_semi_with_filter_dup4x128"},
+      {.joinType = core::JoinType::kRightSemiFilter,
+       .numMatchedKeys = kMatchedKeys,
+       .numBuildOnlyKeys = kOuterOnlyKeys,
+       .numProbeOnlyKeys = 0,
+       .buildDuplicates = kBuildDuplicates,
+       .probeDuplicates = kProbeDuplicates,
+       .numProbeBatches = kProbeBatches,
+       .filter = "t1 % 4 = 0",
+       .outputLayout = {"u1"},
+       .title = "right_semi_selective_filter_dup4x128"},
+  };
+
+  for (const auto& param : params) {
+    benchmarkCases.push_back({param, benchmark->prepareData(param)});
+  }
+
+  for (const auto& benchmarkCase : benchmarkCases) {
+    folly::addBenchmark(
+        __FILE__, benchmarkCase.params.title, [&benchmark, &benchmarkCase]() {
+          auto outputRows =
+              benchmark->run(benchmarkCase.params, benchmarkCase.data);
+          folly::doNotOptimizeAway(outputRows);
+          return 1;
+        });
+  }
+
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/exec/tests/HashJoinTestExtra.cpp
+++ b/velox/exec/tests/HashJoinTestExtra.cpp
@@ -267,6 +267,55 @@ TEST_P(HashJoinTest, lazyVectorPartiallyLoadedInFilterFullJoin) {
       "SELECT t.c1, t.c2 FROM t FULL OUTER JOIN u ON t.c0 = u.c0 AND (c1 > 0 AND c2 > 0)");
 }
 
+TEST_P(HashJoinTest, probeOnlyFilterRightJoins) {
+  auto makeProbeVectors = [&]() {
+    return std::vector<RowVectorPtr>{makeRowVector({
+        makeFlatVector<int32_t>({1, 1, 2, 3, 5}),
+        makeFlatVector<int32_t>({10, -10, -20, 30, -50}),
+    })};
+  };
+  auto makeBuildVectors = [&]() {
+    return std::vector<RowVectorPtr>{makeRowVector({
+        makeFlatVector<int32_t>({1, 1, 2, 4}),
+        makeFlatVector<int32_t>({100, 101, 200, 400}),
+    })};
+  };
+
+  struct TestData {
+    core::JoinType joinType;
+    std::vector<std::string> outputLayout;
+    std::string referenceQuery;
+  };
+
+  const std::vector<TestData> testData = {
+      {core::JoinType::kRight,
+       {"c0", "c1", "u_c0", "u_c1"},
+       "SELECT t.c0, t.c1, u.c0, u.c1 FROM t RIGHT JOIN u ON t.c0 = u.c0 AND t.c1 > 0"},
+      {core::JoinType::kFull,
+       {"c0", "c1", "u_c0", "u_c1"},
+       "SELECT t.c0, t.c1, u.c0, u.c1 FROM t FULL OUTER JOIN u ON t.c0 = u.c0 AND t.c1 > 0"},
+      {core::JoinType::kRightSemiFilter,
+       {"u_c0", "u_c1"},
+       "SELECT u.c0, u.c1 FROM u WHERE EXISTS (SELECT * FROM t WHERE t.c0 = u.c0 AND t.c1 > 0)"},
+  };
+
+  for (const auto& data : testData) {
+    SCOPED_TRACE(data.referenceQuery);
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+        .numDrivers(numDrivers_)
+        .probeKeys({"c0"})
+        .probeVectors(makeProbeVectors())
+        .buildKeys({"u_c0"})
+        .buildVectors(makeBuildVectors())
+        .buildProjections({"c0 AS u_c0", "c1 AS u_c1"})
+        .joinType(data.joinType)
+        .joinFilter("c1 > 0")
+        .joinOutputLayout(std::vector<std::string>(data.outputLayout))
+        .referenceQuery(data.referenceQuery)
+        .run();
+  }
+}
+
 TEST_P(HashJoinTest, lazyVectorPartiallyLoadedInFilterLeftSemiProject) {
   // Test the case where a filter loads a subset of the rows that will be output
   // from a column on the probe side.


### PR DESCRIPTION
**Background**

Right/full/right-semi joins with an extra filter evaluate the filter after
`listJoinResults()`, which means the filter runs once per expanded join 
pair. Under high duplicate fanout, this can turn a probe-side predicate into 
many repeated evaluations for the same probe row.

**Changes**

This PR adds a fast path in HashProbe for deterministic join filters that 
reference only probe-side columns.The new path evaluates the filter once per 
relevant probe input row after `joinProbe()`, and clears `lookup_->hits[row]` 
for rows that fail the filter before join results are expanded.

This has three effects:
* Right/full joins avoid per-joined-row filter evaluation.
* Selective probe-only filters reduce join fanout before `listJoinResults()`.
* Right semi filter joins can reuse the existing mark-only path after pre-evaluation,
avoiding expanded join result generation entirely.

**Benchmarks** 

Added HashJoinProbedFlagBenchmark to measure end-to-end hash join.

```
right_outer_with_filter_dup4x128             10.69ms -> 7.21ms   1.48x
right_outer_selective_filter_dup4x128         9.36ms -> 2.84ms   3.30x
full_outer_with_filter_dup4x128              11.89ms -> 7.89ms   1.51x
full_outer_selective_filter_dup4x128         10.70ms -> 4.22ms   2.54x
right_semi_with_filter_dup4x128               6.45ms -> 1.02ms   6.32x
right_semi_selective_filter_dup4x128          6.27ms -> 1.13ms   5.55x
```