### PR TITLE
fix(fuzzer): Fix out-of-range pad size in Spark expression fuzzer

### DIFF
--- a/velox/expression/fuzzer/SparkExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/SparkExpressionFuzzerTest.cpp
@@ -31,12 +31,14 @@
 #include "velox/functions/sparksql/fuzzer/DivideArgTypesGenerator.h"
 #include "velox/functions/sparksql/fuzzer/MakeTimestampArgTypesGenerator.h"
 #include "velox/functions/sparksql/fuzzer/MultiplyArgTypesGenerator.h"
+#include "velox/functions/sparksql/fuzzer/PadArgValuesGenerator.h"
 #include "velox/functions/sparksql/fuzzer/UnscaledValueArgTypesGenerator.h"
 #include "velox/functions/sparksql/registration/Register.h"
 
 using namespace facebook::velox::functions::sparksql::fuzzer;
 using facebook::velox::functions::sparksql::SparkQueryConfig;
 using facebook::velox::fuzzer::ArgTypesGenerator;
+using facebook::velox::fuzzer::ArgValuesGenerator;
 using facebook::velox::test::ReferenceQueryRunner;
 
 DEFINE_int64(
@@ -123,6 +125,11 @@ int main(int argc, char** argv) {
           {"make_timestamp",
            std::make_shared<MakeTimestampArgTypesGenerator>()}};
 
+  std::unordered_map<std::string, std::shared_ptr<ArgValuesGenerator>>
+      argValuesGenerators = {
+          {"lpad", std::make_shared<PadArgValuesGenerator>()},
+          {"rpad", std::make_shared<PadArgValuesGenerator>()}};
+
   std::shared_ptr<ReferenceQueryRunner> referenceQueryRunner{nullptr};
   return FuzzerRunner::run(
       FLAGS_seed,
@@ -130,7 +137,7 @@ int main(int argc, char** argv) {
       {{}},
       queryConfigs,
       argTypesGenerators,
-      {{}},
+      argValuesGenerators,
       referenceQueryRunner,
       std::make_shared<
           facebook::velox::fuzzer::SparkSpecialFormSignatureGenerator>());

--- a/velox/functions/sparksql/fuzzer/CMakeLists.txt
+++ b/velox/functions/sparksql/fuzzer/CMakeLists.txt
@@ -131,5 +131,6 @@ velox_add_library(
   DivideArgTypesGenerator.h
   MakeTimestampArgTypesGenerator.h
   MultiplyArgTypesGenerator.h
+  PadArgValuesGenerator.h
   UnscaledValueArgTypesGenerator.h
 )

--- a/velox/functions/sparksql/fuzzer/PadArgValuesGenerator.h
+++ b/velox/functions/sparksql/fuzzer/PadArgValuesGenerator.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "velox/common/fuzzer/ConstrainedGenerators.h"
+#include "velox/core/Expressions.h"
+#include "velox/expression/fuzzer/FuzzerToolkit.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+namespace facebook::velox::functions::sparksql::fuzzer {
+
+class PadArgValuesGenerator : public velox::fuzzer::ArgValuesGenerator {
+ public:
+  std::vector<core::TypedExprPtr> generate(
+      const velox::fuzzer::CallableSignature& signature,
+      const VectorFuzzer::Options& options,
+      velox::fuzzer::FuzzerGenerator& rng,
+      velox::fuzzer::ExpressionFuzzerState& state) override {
+    VELOX_CHECK(signature.args.size() == 2 || signature.args.size() == 3);
+    VELOX_CHECK_EQ(signature.args[0]->kind(), TypeKind::VARCHAR);
+    VELOX_CHECK_EQ(signature.args[1]->kind(), TypeKind::INTEGER);
+    if (signature.args.size() == 3) {
+      VELOX_CHECK_EQ(signature.args[2]->kind(), TypeKind::VARCHAR);
+    }
+
+    populateInputTypesAndNames(signature, state);
+
+    std::vector<core::TypedExprPtr> inputExpressions;
+    inputExpressions.reserve(signature.args.size());
+    const auto firstInputIndex =
+        state.inputRowNames_.size() - signature.args.size();
+    const auto nullRatio = options.nullRatio;
+    const auto stringLength = std::max<size_t>(1, options.stringLength);
+    constexpr int32_t kMaxPadSize = 1024 * 1024;
+
+    for (size_t i = 0; i < signature.args.size(); ++i) {
+      const auto seed = velox::fuzzer::rand<uint32_t>(rng);
+      if (i == 1) {
+        state.customInputGenerators_.emplace_back(
+            std::make_shared<velox::fuzzer::RangeConstrainedGenerator<int32_t>>(
+                seed, signature.args[i], nullRatio, 0, kMaxPadSize));
+      } else if (i == 2) {
+        state.customInputGenerators_.emplace_back(
+            std::make_shared<velox::fuzzer::NotEqualConstrainedGenerator>(
+                seed,
+                signature.args[i],
+                variant(std::string("")),
+                std::make_unique<
+                    velox::fuzzer::RandomInputGenerator<StringView>>(
+                    seed, signature.args[i], nullRatio, stringLength)));
+      } else {
+        state.customInputGenerators_.emplace_back(nullptr);
+      }
+
+      inputExpressions.emplace_back(
+          std::make_shared<core::FieldAccessTypedExpr>(
+              signature.args[i], state.inputRowNames_[firstInputIndex + i]));
+    }
+
+    return inputExpressions;
+  }
+};
+
+} // namespace facebook::velox::functions::sparksql::fuzzer


### PR DESCRIPTION
This PR adds a Spark expression fuzzer argument generator for lpad and rpad.
The string padding helper rejects pad sizes outside `[0, 1024 * 1024]` and 
empty pad strings. Spark itself does not impose the same size bound, but 
generating strings larger than 1MB per row is not a practical input.

Fixes https://github.com/facebookincubator/velox/issues/15582.