### PR TITLE
fix: Restore Clang-15 nightly (scheduled Fuzzer Jobs) build (#18081)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -57,6 +57,16 @@ HeaderFilterRegex: '.*'
 
 WarningsAsErrors: 'bugprone-use-after-move'
 
+# clang-tidy parses the GCC compile commands with its Clang frontend, which
+# emits -Wnullability-completeness on core headers when nullability qualifiers
+# leak into a translation unit. The GCC compile commands lack the
+# -Wno-nullability-completeness that CMakeLists.txt sets only for Clang builds,
+# so under -Werror the warning becomes an error. Disabling the check in Checks
+# only filters warning-level output, not an error, so pass the suppression as a
+# real compiler flag here.
+ExtraArgs:
+  - '-Wno-nullability-completeness'
+
 CheckOptions:
   # Naming conventions as explicitly stated in CODING_STYLE.md.
   - key: readability-identifier-naming.ClassCase

--- a/.github/scripts/cmake-flags.sh
+++ b/.github/scripts/cmake-flags.sh
@@ -74,10 +74,11 @@ adapters | dep-graph)
   if [[ $BUILD_PROFILE == "adapters" ]]; then
     # WAVE / CUDF gate code under velox/experimental/, which the
     # planner short-circuits to full mode via FULL_BUILD_PREFIXES,
-    # so dep-graph doesn't need their targets. CUDF is GCC-only.
-    CMAKE_FLAGS+=(-DVELOX_ENABLE_WAVE=ON)
+    # so dep-graph doesn't need their targets. Both are CUDA (nvcc)
+    # builds and nvcc with a Clang host trips on fmt's _BitInt usage,
+    # so keep WAVE and CUDF GCC-only.
     if [[ ${USE_CLANG:-false} != "true" ]]; then
-      CMAKE_FLAGS+=(-DVELOX_ENABLE_CUDF=ON)
+      CMAKE_FLAGS+=(-DVELOX_ENABLE_WAVE=ON -DVELOX_ENABLE_CUDF=ON)
     fi
   fi
   ;;

--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -599,7 +599,16 @@ jobs:
           install_fmt
           install_boost
           install_fast_float
-          install_folly
+          # Build folly (and its gflags) shared under Clang so it matches the
+          # shared libvelox.so. A static folly links gflags statically, which
+          # then collides with the shared gflags velox links
+          # (VELOX_GFLAGS_TYPE=shared), registering gflags' flags twice and
+          # aborting every test at startup.
+          if [[ "${USE_CLANG}" = "true" ]]; then
+            VELOX_BUILD_SHARED=ON install_folly
+          else
+            install_folly
+          fi
           install_fizz
           install_wangle
           install_mvfst
@@ -638,6 +647,11 @@ jobs:
           BUILD_PROFILE=ubuntu-debug USE_CLANG="${USE_CLANG}" source .github/scripts/cmake-flags.sh
           if [[ "${USE_CLANG}" = "true" ]]; then
              export CC=/usr/bin/clang-15; export CXX=/usr/bin/clang++-15;
+             # folly is now built shared (linking the system libgflags.so), so
+             # resolve gflags from SYSTEM here too. This keeps a single shared
+             # libgflags.so across folly, glog and velox instead of mixing a
+             # BUNDLED gflags into libvelox.so alongside the system one.
+             export gflags_SOURCE=SYSTEM;
           fi
           export EXTRA_CMAKE_FLAGS="${CMAKE_FLAGS[*]}"
           make debug 2>&1 | tee /tmp/build-output.log

--- a/CMake/VeloxUtils.cmake
+++ b/CMake/VeloxUtils.cmake
@@ -352,6 +352,20 @@ function(velox_configure_clang_atomic_linker_flags)
     return()
   endif()
 
+  # Clang 15 ships compiler-rt builtins that do not provide
+  # __atomic_is_lock_free, so the compiler-rt heuristic below wrongly skips
+  # libatomic and linking libvelox.so fails with an undefined reference. Force
+  # libatomic (executables and shared libraries) on Clang 15.
+  if(
+    CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 15
+    AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 16
+  )
+    message(STATUS "Clang 15 detected, forcing libatomic linking")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -latomic" PARENT_SCOPE)
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -latomic" PARENT_SCOPE)
+    return()
+  endif()
+
   set(COMPILER_RT_FOUND FALSE)
 
   # Get Clang's resource directory

--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -73,7 +73,7 @@ class IcebergReadTest : public test::IcebergTestBase {
         name,
         HiveColumnHandle::ColumnType::kRegular,
         type,
-        parquet::ParquetFieldId(fieldId),
+        parquet::ParquetFieldId{fieldId, {}},
         std::vector<common::Subfield>{},
         defaultValue);
   }


### PR DESCRIPTION
Summary:
The scheduled nightly **Fuzzer Jobs** (`scheduled.yml` → `linux-clang`, clang-15) have been failing **every night for a month+** (13/13 in the last two weeks, red at least back to 2026-06-15). Because the Clang build gates the fuzzer stages, the entire nightly fuzzer suite has effectively not been running.

The nightly had rotted across several independent layers, each masking the next (the build stopped at the first error, so nobody saw the rest). This PR fixes all of them so the clang-15 build, link, and tests pass.

Fixes https://github.com/facebookincubator/velox/issues/18077. Related: https://github.com/facebookincubator/velox/issues/16008.

## Root causes and fixes

1. **Compile — C++20 P0960 (parenthesized aggregate init):** clang-15 doesn't implement P0960 (GCC 10+/clang 16+ do), so `make_shared<Aggregate>(args)` fails.
   - `velox/type/tests/OpaqueCustomTypesTest.cpp`: give `TestCustomType` explicit constructors.
   - `velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp`: brace-initialize `ParquetFieldId{fieldId, {}}` (both fields, avoiding `-Wmissing-field-initializers`).

2. **Link — `libatomic` not linked under clang-15:** `std::atomic<T>::is_lock_free()` emits `__atomic_is_lock_free`, which lives in libatomic. The existing `velox_configure_clang_atomic_linker_flags()` heuristic skipped it because compiler-rt builtins were detected (they don't provide that symbol) and only touched `CMAKE_EXE_LINKER_FLAGS`. Force `-latomic` for both executables and shared libraries on clang-15 (`CMake/VeloxUtils.cmake`).

3. **Runtime — gflags linked both statically and dynamically:** the clang path rebuilds folly **static** with static gflags baked in, while velox is built shared with `VELOX_GFLAGS_TYPE=shared`, so `libvelox.so` pulled in static gflags (via static folly) *and* shared `libgflags.so` → the flag registry initialized twice → every test aborted at startup (`something wrong with flag 'flagfile' ... linked both statically and dynamically`). Build folly (and gflags) **shared** under Clang and resolve gflags from SYSTEM so folly, glog, and velox share one `libgflags.so` (`.github/workflows/linux-build-base.yml`).

4. **CUDA — nvcc + Clang host trips on fmt `_BitInt`:** the WAVE CUDA (`.cu`) build fails under a Clang host (`fmt/base.h: identifier "_BitInt" is undefined`). Keep WAVE GCC-only, matching how CUDF is already gated (`.github/scripts/cmake-flags.sh`).


Test Plan:
Validated by manually dispatching `scheduled.yml` on this branch (the `linux-clang` job only runs on `schedule`/`workflow_dispatch`, not on PRs). All Clang jobs pass:

- `Build with Clang / Ubuntu debug with system dependencies` — BUILD + TEST ✅
- `Build with Clang / Linux release with adapters` — BUILD + TEST ✅
- `Build with Clang / Linux ASAN/UBSAN with system dependencies` — BUILD + TEST ✅
- `Build with Clang / Fedora debug` ✅

Green run: https://github.com/facebookincubator/velox/actions/runs/29065344634

Reviewers can re-validate by running the `Fuzzer Jobs` workflow via `workflow_dispatch` on this branch.

Differential Revision: D114095766

Pulled By: kgpai


