### PR TITLE
fix(spark): Support VARBINARY type in to_json function

### DIFF
--- a/velox/docs/functions/spark/json.rst
+++ b/velox/docs/functions/spark/json.rst
@@ -107,7 +107,11 @@ JSON Functions
 
 .. spark:function:: to_json(jsonObject) -> jsonString
 
-    Converts a Json object (ROW, ARRAY or MAP) into a JSON string. ::
+    Converts a JSON object (ROW, ARRAY, or MAP) into a JSON string.
+
+    Supported primitive types are: BOOLEAN, TINYINT, SMALLINT, INTEGER, BIGINT,
+    REAL, DOUBLE, DECIMAL, DATE, TIMESTAMP, VARCHAR, and VARBINARY. ROW, ARRAY,
+    and MAP can be nested. ::
 
         SELECT to_json(named_struct('c0', 1, 'c1', 'a')); -- {"c0":1,"c1":"a"}
         SELECT to_json(ARRAY(1, 2, 3)); -- [1,2,3]

--- a/velox/functions/sparksql/ToJson.h
+++ b/velox/functions/sparksql/ToJson.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <vector>
+#include "velox/common/encode/Base64.h"
 #include "velox/expression/ComplexViewTypes.h"
 #include "velox/functions/lib/DateTimeFormatter.h"
 #include "velox/functions/lib/TimeUtils.h"
@@ -201,6 +202,28 @@ inline void toJson<TypeKind::VARCHAR>(
     std::string quotedString;
     folly::json::escapeString(std::string_view(value), quotedString, {});
     result.append(quotedString.substr(1, quotedString.size() - 2));
+  }
+}
+
+template <>
+inline void toJson<TypeKind::VARBINARY>(
+    const exec::GenericView& input,
+    std::string& result,
+    const JsonOptions& /*options*/,
+    bool isMapKey) {
+  auto value = input.castTo<Varbinary>();
+  const auto encodedSize = encoding::Base64::calculateEncodedSize(value.size());
+  const auto originalSize = result.size();
+  const auto quoteSize = isMapKey ? 0 : 2;
+  result.resize(originalSize + quoteSize + encodedSize);
+
+  auto* output = result.data() + originalSize;
+  if (!isMapKey) {
+    *output++ = '\"';
+  }
+  encoding::Base64::encode(value.data(), value.size(), output);
+  if (!isMapKey) {
+    output[encodedSize] = '\"';
   }
 }
 

--- a/velox/functions/sparksql/ToJson.h
+++ b/velox/functions/sparksql/ToJson.h
@@ -18,6 +18,7 @@
 #include <vector>
 #include "velox/common/encode/Base64.h"
 #include "velox/expression/ComplexViewTypes.h"
+#include "velox/expression/VectorReaders.h"
 #include "velox/functions/lib/DateTimeFormatter.h"
 #include "velox/functions/lib/TimeUtils.h"
 #include "velox/functions/sparksql/SparkQueryConfig.h"

--- a/velox/functions/sparksql/tests/ToJsonTest.cpp
+++ b/velox/functions/sparksql/tests/ToJsonTest.cpp
@@ -92,6 +92,22 @@ TEST_F(ToJsonTest, basicMap) {
        R"({})",
        R"({"1":"a","2":null})"});
   testToJson(input, expected);
+
+  // MAP(VARBINARY, BIGINT)
+  input = makeNullableMapVector<std::string, int64_t>(
+      {std::vector<std::pair<std::string, std::optional<int64_t>>>{
+           {"Man", 1}, {"", 2}, {std::string("\x01", 1), 3}},
+       common::testutil::optionalEmpty,
+       std::nullopt,
+       std::vector<std::pair<std::string, std::optional<int64_t>>>{
+           {std::string("\xff\xee", 2), std::nullopt}}},
+      MAP(VARBINARY(), BIGINT()));
+  expected = makeNullableFlatVector<std::string>(
+      {R"({"TWFu":1,"":2,"AQ==":3})",
+       R"({})",
+       std::nullopt,
+       R"({"/+4=":null})"});
+  testToJson(input, expected);
 }
 
 TEST_F(ToJsonTest, basicBool) {

--- a/velox/functions/sparksql/tests/ToJsonTest.cpp
+++ b/velox/functions/sparksql/tests/ToJsonTest.cpp
@@ -118,6 +118,29 @@ TEST_F(ToJsonTest, basicString) {
   testToJson(input, expected);
 }
 
+TEST_F(ToJsonTest, basicBinary) {
+  disableJsonIgnoreNullFields();
+  auto data = makeNullableFlatVector<std::string>(
+      {"Man",
+       "",
+       std::string("\x01", 1),
+       std::string("\xff\xee", 2),
+       "Spark SQL",
+       std::string(58, 'A'),
+       std::nullopt},
+      VARBINARY());
+  auto input = makeRowVector({"a"}, {data});
+  auto expected = makeFlatVector<std::string>(
+      {R"({"a":"TWFu"})",
+       R"({"a":""})",
+       R"({"a":"AQ=="})",
+       R"({"a":"/+4="})",
+       R"({"a":"U3BhcmsgU1FM"})",
+       R"({"a":"QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQQ=="})",
+       R"({"a":null})"});
+  testToJson(input, expected);
+}
+
 TEST_F(ToJsonTest, basicTinyInt) {
   auto data =
       makeNullableFlatVector<int8_t>({0, 127, 128, -128, -129, std::nullopt});


### PR DESCRIPTION
Add support for VARBINARY in the Spark to_json function.

To match Spark's behavior, binary values are serialized as Base64-encoded strings, following Jackson Core's implementation used by Spark:
https://github.com/FasterXML/jackson-core/blob/fc1bc9382c4405c789b7757dc2dae19c9c3b2317/src/main/java/com/fasterxml/jackson/core/JsonGenerator.java#L1610-L1612