### PR TITLE
fix(dwio): Fix dictionary filter cache-mask extraction on ARM NEON

### DIFF
--- a/velox/dwio/common/ColumnVisitors.h
+++ b/velox/dwio/common/ColumnVisitors.h
@@ -991,20 +991,10 @@ class DictionaryColumnVisitor
           dictMask,
           reinterpret_cast<const int32_t*>(filterCache() - 3),
           indices);
-#ifdef SVE_BITS
       auto unknowns = simd::toBitMask(
-          simd::reinterpretBatch<uint32_t>((cache & (kUnknown << 24)) << 1) !=
-          xsimd::batch<uint32_t>(0));
-      auto passed = simd::toBitMask(
-          (simd::reinterpretBatch<uint32_t>(cache) &
-           xsimd::batch<uint32_t>(1)) != xsimd::batch<uint32_t>(0));
-#else
-      auto unknowns = simd::toBitMask(
-          xsimd::batch_bool<int32_t>(simd::reinterpretBatch<uint32_t>(
-              (cache & (kUnknown << 24)) << 1)));
-      auto passed = simd::toBitMask(
-          xsimd::batch_bool<int32_t>(simd::reinterpretBatch<uint32_t>(cache)));
-#endif
+          (cache & xsimd::batch<int32_t>(kUnknown << 24)) !=
+          xsimd::batch<int32_t>(0));
+      auto passed = simd::toBitMask(cache < xsimd::batch<int32_t>(0));
       if (UNLIKELY(unknowns)) {
         uint16_t bits = unknowns;
         // Ranges only over inputs that are in dictionary, the not in dictionary
@@ -1405,20 +1395,10 @@ class StringDictionaryColumnVisitor
       } else {
         cache = simd::gather<int32_t, int32_t, 1>(base, indices);
       }
-#ifdef SVE_BITS
       auto unknowns = simd::toBitMask(
-          simd::reinterpretBatch<uint32_t>((cache & (kUnknown << 24)) << 1) !=
-          xsimd::batch<uint32_t>(0));
-      auto passed = simd::toBitMask(
-          (simd::reinterpretBatch<uint32_t>(cache) &
-           xsimd::batch<uint32_t>(1)) != xsimd::batch<uint32_t>(0));
-#else
-      auto unknowns = simd::toBitMask(
-          xsimd::batch_bool<int32_t>(simd::reinterpretBatch<uint32_t>(
-              (cache & (kUnknown << 24)) << 1)));
-      auto passed = simd::toBitMask(
-          xsimd::batch_bool<int32_t>(simd::reinterpretBatch<uint32_t>(cache)));
-#endif
+          (cache & xsimd::batch<int32_t>(kUnknown << 24)) !=
+          xsimd::batch<int32_t>(0));
+      auto passed = simd::toBitMask(cache < xsimd::batch<int32_t>(0));
       if (UNLIKELY(unknowns)) {
         uint16_t bits = unknowns;
         while (bits) {

--- a/velox/dwio/common/DecoderUtil.h
+++ b/velox/dwio/common/DecoderUtil.h
@@ -95,20 +95,13 @@ int32_t filterDictionaryRunSimd(
     } else {
       cache = simd::gather<int32_t, int32_t, 1>(base, indices);
     }
-#ifdef SVE_BITS
+    // The cache byte ends up in the high byte (bits 24-31) of each
+    // gathered int32.  Extract unknowns via bit 30 (kUnknown 0x40) and
+    // passed via the sign bit (kSuccess 0x80).
     auto unknowns = simd::toBitMask(
-        simd::reinterpretBatch<uint32_t>((cache & (kUnknown << 24)) << 1) !=
-        xsimd::batch<uint32_t>(0));
-    auto passed = simd::toBitMask(
-        (simd::reinterpretBatch<uint32_t>(cache) & xsimd::batch<uint32_t>(1)) !=
-        xsimd::batch<uint32_t>(0));
-#else
-    auto unknowns = simd::toBitMask(
-        xsimd::batch_bool<int32_t>(
-            simd::reinterpretBatch<uint32_t>((cache & (kUnknown << 24)) << 1)));
-    auto passed = simd::toBitMask(
-        xsimd::batch_bool<int32_t>(simd::reinterpretBatch<uint32_t>(cache)));
-#endif
+        (cache & xsimd::batch<int32_t>(kUnknown << 24)) !=
+        xsimd::batch<int32_t>(0));
+    auto passed = simd::toBitMask(cache < xsimd::batch<int32_t>(0));
     if (UNLIKELY(unknowns)) {
       uint16_t bits = unknowns;
       while (bits) {


### PR DESCRIPTION
## Summary

The SIMD dictionary filter kernel (`filterDictionaryRunSimd` in `DecoderUtil.h`, two inline copies in `ColumnVisitors.h`) gathers each `filterCache` byte as the high byte of an int32 via a misaligned load at `filterCache + index - 3`. It then extracts `unknowns` (kUnknown 0x40 → bit 30) and `passed` (kSuccess 0x80 → bit 31) masks from the gathered values.

**NEON bug:** The `#else` path constructed `batch_bool<int32_t>` directly from the raw gathered values. On x86 this worked because `_mm256_movemask_ps` extracts bit 31. On NEON, `toBitMask` requires all-ones/all-zeros boolean lanes — the raw values produced zero for both masks, silently returning empty results and never updating the cache.

**SVE bug:** The `#ifdef SVE_BITS` path used `& 1 != 0` for the `passed` check. Bit 0 of the gathered int32 comes from `filterCache[index - 3]` (a neighboring entry), not `filterCache[index]`. This caused warm-cache successes to be silently dropped.

**Fix:** Replace both branches with portable comparisons that produce proper `batch_bool` values on all architectures: `(cache & batch(kUnknown << 24)) != batch(0)` for unknowns, `cache < batch(0)` for passed. The generated SVE assembly (`cmpne`/`cmplt` on `z` registers) uses equal or fewer instructions than the original `#ifdef SVE_BITS` path.

Fixes first bug in #18086 (Dictionary SIMD — 12 cases)

## Validated on arm64

| Build | Config | Old code | With fix |
|---|---|---|---|
| `arm64-cpu-ci-release` | NEON (`-march=armv8-a+crc+crypto`) | 12 tests fail — all dictionary SIMD tests return empty results | 306/306 pass |
| `arm64-sve128-dictionary-probe` | SVE 128-bit (`-march=armv8-a+crc+crypto+sve -msve-vector-bits=128 -DSVE_BITS=128`) | 2 tests fail — `warmCacheShortCircuitsTestIndex`, `repeatedIndexAcrossBatchesHitsCache` (warm-cache hits dropped) | 306/306 pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)