### PR TITLE
docs: Add blog post on the extensible file connector (#18088)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ of available functions [can be found here.](https://facebookincubator.github.io/
 
 Recent blog posts ([all posts](https://velox-lib.io/blog)):
 
+- [Everything is a File: A Pluggable SQL Interface for Universal File Inspection](https://velox-lib.io/blog/file-connector) (2026-07-10)
 - [Making OpenZL Available in Nimble OSS](https://velox-lib.io/blog/openzl-in-nimble-oss) (2026-07-05)
 - [Why RIGHT SEMI JOIN Can Be Slower Than LEFT SEMI JOIN in Velox](https://velox-lib.io/blog/right-semi-join-performance) (2026-06-26)
-- [From copyBits to SIMD: Accelerating Parquet DELTA Decoding in Velox](https://velox-lib.io/blog/parquet-delta-decoding) (2026-06-17)
 
 ## Community
 

--- a/website/blog/2026-07-10-file-connector.mdx
+++ b/website/blog/2026-07-10-file-connector.mdx
@@ -1,0 +1,100 @@
+---
+slug: file-connector
+title: "Everything is a File: A Pluggable SQL Interface for Universal File Inspection"
+date: 2026-07-10
+authors: [srsuryadev, mbasmanova, PingLiuPing]
+tags: [tech-blog]
+description: "An extensible Axiom connector that makes SQL the universal file inspector: query any file — Parquet, Nimble, CSV, tensors, images — by path alone, with no catalog, metastore, or registration."
+---
+
+We present an extensible connector for the [Axiom](https://github.com/facebookincubator/axiom) SQL engine that lets users query any file — Parquet, Nimble, CSV, tensors, images — by path alone. No catalog, no metastore, no registration. A minimal `FileHandler` interface encapsulates all format-specific logic; adding a new modality requires implementing two methods without touching the core. Synthetic `$`-suffixed metadata tables expose file internals as first-class SQL relations.
+
+<!-- truncate -->
+
+## Introduction
+
+Unix made one decision that shaped fifty years of systems design: everything is a file. Devices, pipes, and sockets are all accessed through `open`/`read`/`close`. [Plan 9](https://www.usenix.org/legacy/publications/compsystems/1995/sum_pike.pdf) pushed further, so that network connections and process state became files too. The payoff was composability: programs written for text files worked, unmodified, on device output and network streams.
+
+Modern data engineering has no equivalent for file inspection. A team working with Parquet, Nimble, tensors, and images needs four tools, four output formats, and four mental models. The tools do not compose. The outputs do not join. An operation as natural as "compare the compression of file A with the schema of file B" requires leaving SQL entirely.
+
+We restore the Unix principle at the data layer. Our connector makes SQL the universal file inspector: point a query at a path, get back rows. The design rests on three ideas:
+
+1. **Zero-registration addressing.** The filesystem path *is* the table name.
+2. **Handler-registry separation.** The core never interprets bytes; format logic lives behind a two-method interface.
+3. **Synthetic metadata tables.** File internals (row groups, encodings, statistics) are queryable relations.
+
+## Architecture
+
+<figure style={{textAlign: 'center'}}>
+  <img src="/img/file-connector-architecture.svg" alt="Layered architecture: SQL to FileConnector to Handler Registry to Format DataSources to Storage" width="100%" />
+</figure>
+
+*Figure 1. Layered architecture: SQL → FileConnector → Handler Registry → Format DataSources → Storage.*
+
+Separating high-level orchestration from file-specific storage details keeps the core engine lightweight, stable, and format-neutral. The real work happens in how format-specific logic is managed. Instead of overloading the core with custom code for every file type, we isolate that complexity behind the `FileHandler` interface. Each handler is a specialist that teaches the core how to read its format: how to pull out the schema, how to stream the data, and what metadata to expose.
+
+This gives a distinct advantage: support for a new file format can be added at any time without touching the core. The design also makes the connector a universal gateway. Because it is not tied to SQL, it works with any Axiom tool, from the SQL interface to the dataframe APIs. The result is efficient, schema-aware access to individual files or directories through streamable, column-projected reads and synthetic metadata inspection.
+
+**FileHandler interface.** Each file format implements a single abstract class. The interface is deliberately minimal — a schema, a stream, and optional metadata tables:
+
+```cpp
+class FileHandler {
+ public:
+  virtual ~FileHandler() = default;
+
+  // Returns the schema of the file (or directory) at 'path'.
+  virtual RowTypePtr schema(std::string_view path) = 0;
+
+  // Creates a streaming, column-projected reader for 'path'.
+  virtual std::unique_ptr<DataSource> createDataSource(
+      std::string_view path,
+      const RowTypePtr& outputType) = 0;
+
+  // Optional: synthetic metadata tables (e.g. $row_groups) for 'path'.
+  virtual std::vector<MetadataTable> metadataTables(std::string_view path) {
+    return {};
+  }
+};
+```
+
+Handlers register once at startup, guarded by `std::call_once`:
+
+```cpp
+registerHandler("parquet", std::make_shared<ParquetFileHandler>());
+```
+
+See the `FileHandler` interface in [FileHandler.h](https://github.com/facebookincubator/axiom/blob/main/axiom/connectors/file/FileHandler.h) for how to add a new format. Table names are file paths: a trailing `/` scans an entire folder as one dataset, and a `$` suffix opens a metadata view of the file. Because folder scans combine many files, per-file identifiers (such as row-group ids) reset for each file, so track the file identity when it matters.
+
+## Querying and Metadata
+
+**Reading row data.** Users interact with files directly through standard SQL by naming the format and path. There is no catalog to manage and no table to pre-register.
+
+```sql
+-- Read all rows from a Parquet file.
+SELECT * FROM parquet."/data/events.parquet";
+
+-- Project specific columns.
+SELECT user_id, ts FROM parquet."/data/events.parquet" LIMIT 100;
+```
+
+**Directory scans.** When the path points to a folder rather than a file, the connector treats the whole directory as one logical dataset — useful for partitioned data or logs spread across many objects. The engine aggregates every file of the given format into a single result set.
+
+```sql
+-- Scan an entire directory of Parquet files as one dataset.
+SELECT count(*) FROM parquet."/data/events/";
+```
+
+**Inspecting metadata.** Synthetic metadata tables expose the physical layout and internal statistics of a file. They are addressed by appending a `$`-suffixed name to the path, surfacing details that are normally hidden — handy for debugging performance and data distribution without a separate tool.
+
+```sql
+-- Inspect row groups of a Parquet file.
+SELECT * FROM parquet."/data/events.parquet$row_groups";
+```
+
+## Toward multi-modal inspection
+
+The `FileHandler` interface makes no assumption about byte layout — it asks only for a schema and a stream. That generality extends directly to non-tabular modalities such as tensors and images, so the same SQL surface can grow to inspect them. You can read more about the technical details in the [connector README](https://github.com/facebookincubator/axiom/blob/main/axiom/connectors/file/README.md).
+
+## Acknowledgements
+
+Thanks to <a href="https://github.com/mbasmanova">Masha Basmanova</a>, <a href="https://github.com/zzhao0">Zhenyuan Zhao</a>, <a href="https://github.com/pedroerp">Pedro Eugenio Rocha Pedreira</a>, Rohit Jain, Jimmy Lu, and <a href="https://github.com/xiaoxmeng">Xiaoxuan Meng</a> for brainstorming and discussion.

--- a/website/static/img/file-connector-architecture.svg
+++ b/website/static/img/file-connector-architecture.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="640" viewBox="0 0 900 640" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L7,3 L0,6 Z" fill="#000"/>
+    </marker>
+  </defs>
+
+  <rect x="0" y="0" width="900" height="640" fill="#ffffff"/>
+
+  <!-- Layer 1: SQL -->
+  <rect x="230" y="30" width="440" height="70" rx="10" fill="#ffffff" stroke="#000" stroke-width="2"/>
+  <text x="450" y="60" text-anchor="middle" font-size="20" font-weight="bold" fill="#000">SQL / Dataframe API</text>
+  <text x="450" y="85" text-anchor="middle" font-size="14" fill="#000" font-family="monospace">SELECT * FROM parquet."/data/events.parquet"</text>
+
+  <line x1="450" y1="100" x2="450" y2="135" stroke="#000" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <!-- Layer 2: FileConnector -->
+  <rect x="230" y="140" width="440" height="70" rx="10" fill="#ffffff" stroke="#000" stroke-width="2"/>
+  <text x="450" y="170" text-anchor="middle" font-size="20" font-weight="bold" fill="#000">FileConnector</text>
+  <text x="450" y="194" text-anchor="middle" font-size="14" fill="#000">path parsing · schema · splits · column-projected streaming</text>
+
+  <line x1="450" y1="210" x2="450" y2="245" stroke="#000" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <!-- Layer 3: Handler Registry -->
+  <rect x="230" y="250" width="440" height="70" rx="10" fill="#ffffff" stroke="#000" stroke-width="2"/>
+  <text x="450" y="280" text-anchor="middle" font-size="20" font-weight="bold" fill="#000">Handler Registry</text>
+  <text x="450" y="304" text-anchor="middle" font-size="14" fill="#000" font-family="monospace">registerHandler("parquet", handler)</text>
+
+  <!-- fan-out arrows to handlers -->
+  <line x1="330" y1="320" x2="150" y2="365" stroke="#000" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="410" y1="320" x2="355" y2="365" stroke="#000" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="490" y1="320" x2="545" y2="365" stroke="#000" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="570" y1="320" x2="750" y2="365" stroke="#000" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <!-- Layer 4: Format DataSources (pluggable FileHandlers) -->
+  <text x="450" y="360" text-anchor="middle" font-size="13" fill="#000">pluggable FileHandlers (two methods each)</text>
+  <g font-size="15" fill="#000">
+    <rect x="60"  y="370" width="150" height="55" rx="8" fill="#ffffff" stroke="#000" stroke-width="1.8" stroke-dasharray="2 4"/>
+    <text x="135" y="403" text-anchor="middle" font-weight="bold">Parquet</text>
+    <rect x="280" y="370" width="150" height="55" rx="8" fill="#ffffff" stroke="#000" stroke-width="1.8" stroke-dasharray="2 4"/>
+    <text x="355" y="403" text-anchor="middle" font-weight="bold">Nimble</text>
+    <rect x="470" y="370" width="150" height="55" rx="8" fill="#ffffff" stroke="#000" stroke-width="1.8" stroke-dasharray="2 4"/>
+    <text x="545" y="403" text-anchor="middle" font-weight="bold">CSV</text>
+    <rect x="680" y="370" width="160" height="55" rx="8" fill="#ffffff" stroke="#000" stroke-width="1.8" stroke-dasharray="2 4"/>
+    <text x="760" y="403" text-anchor="middle" font-weight="bold">Tensor · Image</text>
+  </g>
+
+  <!-- arrows to storage -->
+  <line x1="135" y1="425" x2="300" y2="500" stroke="#000" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="355" y1="425" x2="420" y2="500" stroke="#000" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="545" y1="425" x2="480" y2="500" stroke="#000" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="760" y1="425" x2="600" y2="500" stroke="#000" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <!-- Layer 5: Storage -->
+  <rect x="230" y="505" width="440" height="70" rx="10" fill="#ffffff" stroke="#000" stroke-width="2"/>
+  <text x="450" y="548" text-anchor="middle" font-size="20" font-weight="bold" fill="#000">Storage</text>
+
+  <text x="450" y="612" text-anchor="middle" font-size="13" fill="#000">The core never interprets bytes; each format lives behind the FileHandler interface.</text>
+</svg>


### PR DESCRIPTION
Summary:

Add a blog post, "Everything is a File", introducing a pluggable Axiom connector that turns SQL into a universal file inspector.

Differential Revision: D111453933
