### PR TITLE
feat(parquet): Support reading DELTA_BYTE_ARRAY encoded Parquet decimals

### DIFF
--- a/velox/dwio/parquet/reader/DeltaByteArrayDecoder.h
+++ b/velox/dwio/parquet/reader/DeltaByteArrayDecoder.h
@@ -16,13 +16,53 @@
 
 #pragma once
 
+#include <cstring>
 #include <optional>
+#include <string_view>
+#include <type_traits>
 
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/base/Nulls.h"
 #include "velox/dwio/parquet/reader/DeltaBpDecoder.h"
 
 namespace facebook::velox::parquet {
+namespace detail {
+
+template <typename T>
+FOLLY_ALWAYS_INLINE T fromBigEndianBytes(std::string_view bytes) {
+  static_assert(
+      std::is_same_v<T, int128_t> || std::is_same_v<T, int64_t> ||
+          std::is_same_v<T, int32_t>,
+      "Only integer types are supported.");
+
+  VELOX_CHECK_LE(
+      bytes.size(),
+      sizeof(T),
+      "Length of byte array passed to fromBigEndianBytes is too large");
+
+  if (bytes.empty()) {
+    return {};
+  }
+
+  const auto* rawBytes = reinterpret_cast<const uint8_t*>(bytes.data());
+  T result = (rawBytes[0] & 0x80) != 0 ? -1 : 0;
+  memcpy(
+      reinterpret_cast<uint8_t*>(&result) + sizeof(T) - bytes.size(),
+      rawBytes,
+      bytes.size());
+
+  if constexpr (std::is_same_v<T, int128_t>) {
+    return bits::builtin_bswap128(result);
+  } else if constexpr (std::is_same_v<T, int64_t>) {
+    return __builtin_bswap64(result);
+  } else if constexpr (std::is_same_v<T, int32_t>) {
+    return __builtin_bswap32(result);
+  } else {
+    VELOX_UNREACHABLE();
+  }
+}
+
+} // namespace detail
 
 // DeltaLengthByteArrayDecoder is adapted from Apache Arrow:
 // https://github.com/apache/arrow/blob/apache-arrow-15.0.0/cpp/src/parquet/encoding.cc#L2758-L2889
@@ -204,7 +244,15 @@ class DeltaByteArrayDecoder {
         }
 
         // We are at a non-null value on a row to visit.
-        toSkip = visitor.process(readString(), atEnd);
+        using T = typename Visitor::DataType;
+        if constexpr (
+            std::is_same_v<T, int128_t> || std::is_same_v<T, int64_t> ||
+            std::is_same_v<T, int32_t>) {
+          toSkip = visitor.process(
+              detail::fromBigEndianBytes<T>(readString()), atEnd);
+        } else {
+          toSkip = visitor.process(readString(), atEnd);
+        }
       }
       ++current;
       if (toSkip) {

--- a/velox/dwio/parquet/reader/PageReader.cpp
+++ b/velox/dwio/parquet/reader/PageReader.cpp
@@ -861,7 +861,8 @@ void PageReader::makeDecoder() {
       }
       break;
     case Encoding::DELTA_BYTE_ARRAY:
-      if (parquetType == thrift::Type::BYTE_ARRAY) {
+      if (parquetType == thrift::Type::BYTE_ARRAY ||
+          parquetType == thrift::Type::FIXED_LEN_BYTE_ARRAY) {
         if (!deltaByteArrDecoder_) {
           deltaByteArrDecoder_ = std::make_unique<DeltaByteArrayDecoder>();
         }

--- a/velox/dwio/parquet/reader/PageReader.h
+++ b/velox/dwio/parquet/reader/PageReader.h
@@ -307,6 +307,17 @@ class PageReader {
       } else if (encoding_ == thrift::Encoding::DELTA_BINARY_PACKED) {
         nullsFromFastPath = false;
         deltaBpDecoder_->readWithVisitor<true>(nulls, visitor);
+      } else if (encoding_ == thrift::Encoding::DELTA_BYTE_ARRAY) {
+        if constexpr (
+            std::is_same_v<typename Visitor::DataType, int128_t> ||
+            std::is_same_v<typename Visitor::DataType, int64_t> ||
+            std::is_same_v<typename Visitor::DataType, int32_t>) {
+          nullsFromFastPath = false;
+          deltaByteArrDecoder_->readWithVisitor<true>(nulls, visitor);
+        } else {
+          VELOX_UNSUPPORTED(
+              "DELTA_BYTE_ARRAY decoder for non-string values only supports decimal type.");
+        }
       } else {
         directDecoder_->readWithVisitor<true>(
             nulls, visitor, nullsFromFastPath);
@@ -317,6 +328,16 @@ class PageReader {
         dictionaryIdDecoder_->readWithVisitor<false>(nullptr, dictVisitor);
       } else if (encoding_ == thrift::Encoding::DELTA_BINARY_PACKED) {
         deltaBpDecoder_->readWithVisitor<false>(nulls, visitor);
+      } else if (encoding_ == thrift::Encoding::DELTA_BYTE_ARRAY) {
+        if constexpr (
+            std::is_same_v<typename Visitor::DataType, int128_t> ||
+            std::is_same_v<typename Visitor::DataType, int64_t> ||
+            std::is_same_v<typename Visitor::DataType, int32_t>) {
+          deltaByteArrDecoder_->readWithVisitor<false>(nulls, visitor);
+        } else {
+          VELOX_UNSUPPORTED(
+              "DELTA_BYTE_ARRAY decoder for non-string values only supports decimal type.");
+        }
       } else {
         directDecoder_->readWithVisitor<false>(
             nulls, visitor, !this->type_->type()->isShortDecimal());

--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -512,6 +512,55 @@ TEST_F(E2EFilterTest, longDecimalDirect) {
       20);
 }
 
+TEST_F(E2EFilterTest, decimalDeltaByteArray) {
+  options_.enableDictionary = false;
+  options_.encoding =
+      facebook::velox::parquet::arrow::Encoding::kDeltaByteArray;
+  options_.enableStoreDecimalAsInteger = false;
+  const auto expectedEncoding = options_.encoding;
+
+  testWithTypes(
+      "shortdecimal_val:decimal(10, 5)",
+      [&]() {
+        makeIntDistribution<int64_t>(
+            "shortdecimal_val",
+            10, // min
+            100, // max
+            22, // repeats
+            19, // rareFrequency
+            -40'000'000, // rareMin
+            40'000'000, // rareMax
+            true);
+      },
+      false,
+      {"shortdecimal_val"},
+      20);
+  EXPECT_TRUE(columnChunkUsesEncoding(expectedEncoding));
+
+  // decimal(30, 10) maps to 13 bytes FLBA in Parquet.
+  // decimal(37, 15) maps to 16 bytes FLBA in Parquet.
+  for (const auto& type :
+       {"longdecimal_val:decimal(30, 10)", "longdecimal_val:decimal(37, 15)"}) {
+    testWithTypes(
+        type,
+        [&]() {
+          makeIntDistribution<int128_t>(
+              "longdecimal_val",
+              10, // min
+              100, // max
+              22, // repeats
+              19, // rareFrequency
+              -999, // rareMin
+              30'000, // rareMax
+              true);
+        },
+        false,
+        {"longdecimal_val"},
+        20);
+    EXPECT_TRUE(columnChunkUsesEncoding(expectedEncoding));
+  }
+}
+
 TEST_F(E2EFilterTest, stringDirect) {
   options_.enableDictionary = false;
   options_.dataPageSize = 4 * 1024;


### PR DESCRIPTION
This PR adds support for reading Parquet decimal columns encoded with 
`DELTA_BYTE_ARRAY`. Parquet decimals may be physically represented as
`BYTE_ARRAY` or `FIXED_LEN_BYTE_ARRAY`, and these byte-array physical
types may use `DELTA_BYTE_ARRAY` encoding.

Add an E2E Parquet reader test covering short and long decimals written as 
`FIXED_LEN_BYTE_ARRAY` with `DELTA_BYTE_ARRAY` encoding.

Based on the original PR: https://github.com/oap-project/velox/pull/1037.