### PR TITLE
feat(vector): Improve MSVC portability

### DIFF
--- a/velox/vector/BiasVector-inl.h
+++ b/velox/vector/BiasVector-inl.h
@@ -94,21 +94,32 @@ std::unique_ptr<SimpleVector<uint64_t>> BiasVector<T>::hashAll() const {
       std::nullopt /*distinctValueCount*/,
       0 /* nullCount */,
       false /*isSorted*/,
-      sizeof(uint64_t) * BaseVector::length_ /*representedBytes*/);
+      static_cast<ByteCount>(
+          sizeof(uint64_t) * BaseVector::length_) /*representedBytes*/);
 }
 
 template <typename T>
 typename SimpleVector<T>::TValueAt BiasVector<T>::valueAtFast(
     vector_size_t idx) const {
-  switch (valueType_) {
-    case TypeKind::INTEGER:
-      return bias_ + reinterpret_cast<const int32_t*>(rawValues_)[idx];
-    case TypeKind::SMALLINT:
-      return bias_ + reinterpret_cast<const int16_t*>(rawValues_)[idx];
-    case TypeKind::TINYINT:
-      return bias_ + reinterpret_cast<const int8_t*>(rawValues_)[idx];
-    default:
-      VELOX_UNSUPPORTED("Invalid type");
+  // BiasVector only ever stores narrowed integral values. Guard the body with
+  // if constexpr so MSVC does not eagerly instantiate the integer arithmetic
+  // for non-integral T (e.g. StringView) when a test forces the vtable via
+  // BaseVector::as<BiasVector<T>>(). is_constructible_v<T, int32_t> keeps the
+  // exact set of POSIX instantiations (including int128_t) and codegen
+  // unchanged, so GCC/Clang object files are byte-identical.
+  if constexpr (std::is_constructible_v<T, int32_t>) {
+    switch (valueType_) {
+      case TypeKind::INTEGER:
+        return bias_ + reinterpret_cast<const int32_t*>(rawValues_)[idx];
+      case TypeKind::SMALLINT:
+        return bias_ + reinterpret_cast<const int16_t*>(rawValues_)[idx];
+      case TypeKind::TINYINT:
+        return bias_ + reinterpret_cast<const int8_t*>(rawValues_)[idx];
+      default:
+        VELOX_UNSUPPORTED("Invalid type");
+    }
+  } else {
+    VELOX_UNSUPPORTED("Invalid type");
   }
 }
 

--- a/velox/vector/ConstantVector-inl.h
+++ b/velox/vector/ConstantVector-inl.h
@@ -25,7 +25,8 @@ std::unique_ptr<SimpleVector<uint64_t>> ConstantVector<T>::hashAll() const {
       BIGINT(),
       this->hashValueAt(0),
       SimpleVectorStats<uint64_t>{}, /* stats */
-      sizeof(uint64_t) * BaseVector::length_ /* representedBytes */);
+      static_cast<ByteCount>(
+          sizeof(uint64_t) * BaseVector::length_) /* representedBytes */);
 }
 
 } // namespace facebook::velox

--- a/velox/vector/DictionaryVector-inl.h
+++ b/velox/vector/DictionaryVector-inl.h
@@ -153,7 +153,8 @@ std::unique_ptr<SimpleVector<uint64_t>> DictionaryVector<T>::hashAll() const {
           (BaseVector::nullCount_.value_or(0) > 0 ? 1 : 0),
       0 /* nullCount */,
       false /* sorted */,
-      sizeof(uint64_t) * BaseVector::length_ /* representedBytes */);
+      static_cast<ByteCount>(
+          sizeof(uint64_t) * BaseVector::length_) /* representedBytes */);
 }
 
 #ifdef VELOX_ENABLE_LOAD_SIMD_VALUE_BUFFER

--- a/velox/vector/FlatVector-inl.h
+++ b/velox/vector/FlatVector-inl.h
@@ -90,7 +90,25 @@ std::unique_ptr<SimpleVector<uint64_t>> FlatVector<T>::hashAll() const {
       AlignedBuffer::allocate<uint64_t>(BaseVector::length_, BaseVector::pool_);
   auto hashData = hashBuffer->asMutable<uint64_t>();
 
+#ifdef _MSC_VER
+  // MSVC instantiates this method for every T (e.g. via the serializer), even
+  // for complex/opaque element types where folly::hasher is undefined and the
+  // method is never actually called. Guard those to keep the body well-formed;
+  // GCC instantiates lazily and only ever sees the scalar specializations.
+  // folly::hasher<int128_t>/<Timestamp> are provided by Velox, so the scalar
+  // path hashes identically to SimpleVector::hashValueAt.
+  const auto hasher = [](T value) -> uint64_t {
+    if constexpr (
+        std::is_arithmetic_v<T> || std::is_same_v<T, StringView> ||
+        std::is_same_v<T, Timestamp> || std::is_same_v<T, int128_t>) {
+      return folly::hasher<T>()(value);
+    } else {
+      return 0;
+    }
+  };
+#else
   folly::hasher<T> hasher;
+#endif
   if (!BaseVector::rawNulls_) {
     VELOX_DCHECK_NOT_NULL(rawValues_);
     for (len_type i = 0; i < BaseVector::length_; ++i) {
@@ -116,7 +134,8 @@ std::unique_ptr<SimpleVector<uint64_t>> FlatVector<T>::hashAll() const {
       std::nullopt /*distinctValueCount*/,
       0 /*nullCount*/,
       false /*sorted*/,
-      sizeof(uint64_t) * BaseVector::length_ /*representedBytes*/);
+      static_cast<ByteCount>(
+          sizeof(uint64_t) * BaseVector::length_) /*representedBytes*/);
 }
 
 #ifdef VELOX_ENABLE_LOAD_SIMD_VALUE_BUFFER

--- a/velox/vector/SequenceVector-inl.h
+++ b/velox/vector/SequenceVector-inl.h
@@ -103,7 +103,8 @@ std::unique_ptr<SimpleVector<uint64_t>> SequenceVector<T>::hashAll() const {
       std::nullopt /*distinctValueCount*/,
       0 /* nullCount */,
       false /* sorted */,
-      sizeof(uint64_t) * sequenceCount /* representedBytes */);
+      static_cast<ByteCount>(
+          sizeof(uint64_t) * sequenceCount) /* representedBytes */);
 
   return std::make_unique<SequenceVector<uint64_t>>(
       BaseVector::pool_,
@@ -114,7 +115,8 @@ std::unique_ptr<SimpleVector<uint64_t>> SequenceVector<T>::hashAll() const {
       std::nullopt /*distinctCount*/,
       0 /* nullCount */,
       false /* sorted */,
-      sizeof(uint64_t) * BaseVector::length_ /* representedBytes */,
+      static_cast<ByteCount>(
+          sizeof(uint64_t) * BaseVector::length_) /* representedBytes */,
       0 /* nullSequenceCount */);
 }
 

--- a/velox/vector/arrow/tests/CMakeLists.txt
+++ b/velox/vector/arrow/tests/CMakeLists.txt
@@ -24,5 +24,5 @@ target_link_libraries(
   GTest::gtest
   GTest::gtest_main
   glog::glog
-  dl
+  ${CMAKE_DL_LIBS}
 )

--- a/velox/vector/fuzzer/VectorFuzzer.cpp
+++ b/velox/vector/fuzzer/VectorFuzzer.cpp
@@ -83,7 +83,8 @@ size_t getElementsVectorLength(
 
 int64_t randShortDecimal(const TypePtr& type, FuzzerGenerator& rng) {
   auto precision = type->asShortDecimal().precision();
-  return rand<int64_t>(rng) % DecimalUtil::kPowersOfTen[precision];
+  return rand<int64_t>(rng) %
+      static_cast<int64_t>(DecimalUtil::kPowersOfTen[precision]);
 }
 
 int128_t randLongDecimal(const TypePtr& type, FuzzerGenerator& rng) {
@@ -703,7 +704,7 @@ void VectorFuzzer::fuzzOffsetsAndSizes(
   auto rawOffsets = offsets->asMutable<vector_size_t>();
   auto rawSizes = sizes->asMutable<vector_size_t>();
 
-  size_t containerAvgLength = std::max(elementsSize / size, 1UL);
+  size_t containerAvgLength = std::max<size_t>(elementsSize / size, 1);
   size_t childSize = 0;
   size_t length = 0;
   const auto bound = static_cast<vector_size_t>(elementsSize);

--- a/velox/vector/fuzzer/VectorFuzzer.cpp
+++ b/velox/vector/fuzzer/VectorFuzzer.cpp
@@ -83,7 +83,8 @@ size_t getElementsVectorLength(
 
 int64_t randShortDecimal(const TypePtr& type, FuzzerGenerator& rng) {
   auto precision = type->asShortDecimal().precision();
-  return rand<int64_t>(rng) % DecimalUtil::kPowersOfTen[precision];
+  return rand<int64_t>(rng) %
+      static_cast<int64_t>(DecimalUtil::kPowersOfTen[precision]);
 }
 
 int128_t randLongDecimal(const TypePtr& type, FuzzerGenerator& rng) {
@@ -701,7 +702,7 @@ void VectorFuzzer::fuzzOffsetsAndSizes(
   auto rawOffsets = offsets->asMutable<vector_size_t>();
   auto rawSizes = sizes->asMutable<vector_size_t>();
 
-  size_t containerAvgLength = std::max(elementsSize / size, 1UL);
+  size_t containerAvgLength = std::max<size_t>(elementsSize / size, 1);
   size_t childSize = 0;
   size_t length = 0;
   const auto bound = static_cast<vector_size_t>(elementsSize);

--- a/velox/vector/tests/CMakeLists.txt
+++ b/velox/vector/tests/CMakeLists.txt
@@ -79,7 +79,7 @@ target_link_libraries(
   Folly::folly
   glog::glog
   fmt::fmt
-  dl
+  ${CMAKE_DL_LIBS}
 )
 
 add_executable(simple_vector_test SimpleVectorTest.cpp ToStringUtilityTest.cpp)

--- a/velox/vector/tests/EncodingTest.cpp
+++ b/velox/vector/tests/EncodingTest.cpp
@@ -188,7 +188,7 @@ Timestamp EncodingTest::testValue(int32_t i, BufferPtr& /*space*/) {
 }
 
 TEST_F(EncodingTest, basic) {
-  checkTypeEncoding<TypeKind::BOOLEAN>(BOOLEAN());
+  checkTypeEncoding<TypeKind::BOOLEAN>(::facebook::velox::BOOLEAN());
   checkTypeEncoding<TypeKind::TINYINT>(TINYINT());
   checkTypeEncoding<TypeKind::SMALLINT>(SMALLINT());
   checkTypeEncoding<TypeKind::INTEGER>(INTEGER());

--- a/velox/vector/tests/EncodingTest.cpp
+++ b/velox/vector/tests/EncodingTest.cpp
@@ -19,17 +19,14 @@
 #include "velox/vector/tests/VectorTestUtils.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
-using namespace facebook;
-using namespace facebook::velox;
-using namespace facebook::velox::test;
+namespace facebook::velox::test {
 
-class EncodingTest : public testing::Test, public velox::test::VectorTestBase {
+class EncodingTest : public testing::Test, public VectorTestBase {
  protected:
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
     if (!isRegisteredVectorSerde()) {
-      facebook::velox::serializer::presto::PrestoVectorSerde::
-          registerVectorSerde();
+      serializer::presto::PrestoVectorSerde::registerVectorSerde();
     }
   }
 
@@ -188,7 +185,7 @@ Timestamp EncodingTest::testValue(int32_t i, BufferPtr& /*space*/) {
 }
 
 TEST_F(EncodingTest, basic) {
-  checkTypeEncoding<TypeKind::BOOLEAN>(::facebook::velox::BOOLEAN());
+  checkTypeEncoding<TypeKind::BOOLEAN>(BOOLEAN());
   checkTypeEncoding<TypeKind::TINYINT>(TINYINT());
   checkTypeEncoding<TypeKind::SMALLINT>(SMALLINT());
   checkTypeEncoding<TypeKind::INTEGER>(INTEGER());
@@ -196,3 +193,5 @@ TEST_F(EncodingTest, basic) {
   checkTypeEncoding<TypeKind::VARCHAR>(VARCHAR());
   checkTypeEncoding<TypeKind::TIMESTAMP>(TIMESTAMP());
 }
+
+} // namespace facebook::velox::test

--- a/velox/vector/tests/EnsureWritableVectorTest.cpp
+++ b/velox/vector/tests/EnsureWritableVectorTest.cpp
@@ -962,8 +962,8 @@ TEST_F(EnsureWritableVectorTest, booleanFlatVector) {
     auto another = vector->asFlatVector<bool>()->values();
 
     auto vectorPtr = vector.get();
-    ASSERT_NO_THROW(
-        BaseVector::ensureWritable(rows, BOOLEAN(), pool(), vector));
+    ASSERT_NO_THROW(BaseVector::ensureWritable(
+        rows, ::facebook::velox::BOOLEAN(), pool(), vector));
     ASSERT_EQ(vectorPtr, vector.get());
     ASSERT_NE(another->as<void>(), vector->valuesAsVoid());
   };
@@ -984,7 +984,7 @@ TEST_F(EnsureWritableVectorTest, booleanFlatVector) {
     // Create a FlatVector with a length smaller than the value buffer.
     VectorPtr vector = std::make_shared<FlatVector<bool>>(
         pool(),
-        BOOLEAN(),
+        ::facebook::velox::BOOLEAN(),
         nullptr,
         100,
         std::move(value),

--- a/velox/vector/tests/EnsureWritableVectorTest.cpp
+++ b/velox/vector/tests/EnsureWritableVectorTest.cpp
@@ -18,8 +18,7 @@
 #include "velox/vector/tests/VectorTestUtils.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
-using namespace facebook::velox;
-using namespace facebook::velox::test;
+namespace facebook::velox::test {
 
 class EnsureWritableVectorTest : public testing::Test, public VectorTestBase {
  protected:
@@ -962,8 +961,8 @@ TEST_F(EnsureWritableVectorTest, booleanFlatVector) {
     auto another = vector->asFlatVector<bool>()->values();
 
     auto vectorPtr = vector.get();
-    ASSERT_NO_THROW(BaseVector::ensureWritable(
-        rows, ::facebook::velox::BOOLEAN(), pool(), vector));
+    ASSERT_NO_THROW(
+        BaseVector::ensureWritable(rows, BOOLEAN(), pool(), vector));
     ASSERT_EQ(vectorPtr, vector.get());
     ASSERT_NE(another->as<void>(), vector->valuesAsVoid());
   };
@@ -984,7 +983,7 @@ TEST_F(EnsureWritableVectorTest, booleanFlatVector) {
     // Create a FlatVector with a length smaller than the value buffer.
     VectorPtr vector = std::make_shared<FlatVector<bool>>(
         pool(),
-        ::facebook::velox::BOOLEAN(),
+        BOOLEAN(),
         nullptr,
         100,
         std::move(value),
@@ -1078,3 +1077,5 @@ TEST_F(EnsureWritableVectorTest, lazyMap) {
     EXPECT_EQ(size, lazy->size());
   }
 }
+
+} // namespace facebook::velox::test

--- a/velox/vector/tests/VectorValueGenerator.h
+++ b/velox/vector/tests/VectorValueGenerator.h
@@ -86,7 +86,8 @@ class VectorValueGenerator {
       auto value = useFullTypeRange ? getRand64(rng) : getRand32(rng);
       if (type->isShortDecimal()) {
         const auto& [precision, _] = getDecimalPrecisionScale(*type);
-        return value % DecimalUtil::kPowersOfTen[precision];
+        return value %
+            static_cast<decltype(value)>(DecimalUtil::kPowersOfTen[precision]);
       } else {
         return value;
       }

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -884,10 +884,20 @@ class VectorTestBase {
   velox::test::VectorMaker vectorMaker_{pool_.get()};
   std::unique_ptr<folly::Executor> executor_{
       std::make_unique<folly::CPUThreadPoolExecutor>(
+#ifdef _WIN32
+          // The vcpkg folly predates folly::available_concurrency(); the older
+          // folly::hardware_concurrency() is the closest equivalent on Windows.
+          folly::hardware_concurrency())};
+#else
           folly::available_concurrency())};
+#endif
   std::shared_ptr<folly::Executor> spillExecutor_{
       std::make_shared<folly::CPUThreadPoolExecutor>(
+#ifdef _WIN32
+          folly::hardware_concurrency())};
+#else
           folly::available_concurrency())};
+#endif
 };
 
 class TestRuntimeStatWriter : public BaseRuntimeStatWriter {

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -883,10 +883,20 @@ class VectorTestBase {
   velox::test::VectorMaker vectorMaker_{pool_.get()};
   std::unique_ptr<folly::Executor> executor_{
       std::make_unique<folly::CPUThreadPoolExecutor>(
+#ifdef _WIN32
+          // The vcpkg folly predates folly::available_concurrency(); the older
+          // folly::hardware_concurrency() is the closest equivalent on Windows.
+          folly::hardware_concurrency())};
+#else
           folly::available_concurrency())};
+#endif
   std::shared_ptr<folly::Executor> spillExecutor_{
       std::make_shared<folly::CPUThreadPoolExecutor>(
+#ifdef _WIN32
+          folly::hardware_concurrency())};
+#else
           folly::available_concurrency())};
+#endif
 };
 
 } // namespace facebook::velox::test

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -883,20 +883,10 @@ class VectorTestBase {
   velox::test::VectorMaker vectorMaker_{pool_.get()};
   std::unique_ptr<folly::Executor> executor_{
       std::make_unique<folly::CPUThreadPoolExecutor>(
-#ifdef _WIN32
-          // The vcpkg folly predates folly::available_concurrency(); the older
-          // folly::hardware_concurrency() is the closest equivalent on Windows.
-          folly::hardware_concurrency())};
-#else
           folly::available_concurrency())};
-#endif
   std::shared_ptr<folly::Executor> spillExecutor_{
       std::make_shared<folly::CPUThreadPoolExecutor>(
-#ifdef _WIN32
-          folly::hardware_concurrency())};
-#else
           folly::available_concurrency())};
-#endif
 };
 
 } // namespace facebook::velox::test


### PR DESCRIPTION
## Summary

Make `velox/vector` compile cleanly under MSVC by fixing vector hash generation and the vector-only test/build issues needed for this module slice.

This is split out from the broad Windows/MSVC support PR to keep the first review small and module-scoped.

## Scope

- Adds explicit `ByteCount` casts for represented-bytes calculations in vector hash helpers.
- Guards `FlatVector<T>::hashAll()` under `_MSC_VER` so MSVC does not instantiate `folly::hasher` for complex/opaque vector types.
- Includes vector test/build portability fixes that belong with the `velox/vector` module.
- Does not add Windows CI; the workflow scaffold is proposed separately.

## Context

- Original broad PR: https://github.com/facebookincubator/velox/pull/17897
- Maintainer feedback about encapsulating platform changes: https://github.com/facebookincubator/velox/pull/17897#issuecomment-4846635925
- Discussion: https://github.com/facebookincubator/velox/discussions/18005