### PR TITLE
feat(rpc): Add kInvalidRequest error kind for non-retryable failures (#18095)

### DIFF
--- a/velox/common/rpc/RPCTypes.h
+++ b/velox/common/rpc/RPCTypes.h
@@ -116,6 +116,10 @@ enum class RPCErrorKind {
   kBackendError,
   /// Backend returned successfully but with no usable result.
   kEmptyResponse,
+  /// Backend rejected the request as invalid (e.g. malformed args, bad model).
+  /// Non-retryable: the same request will fail again, so the transport fails
+  /// fast rather than spending its retry budget.
+  kInvalidRequest,
 };
 
 /// Generic response structure from RPC calls.

--- a/velox/exec/rpc/RPCOperator.cpp
+++ b/velox/exec/rpc/RPCOperator.cpp
@@ -756,6 +756,10 @@ void RPCOperator::recordErrorKind(velox::rpc::RPCErrorKind kind) {
     case velox::rpc::RPCErrorKind::kNone:
     case velox::rpc::RPCErrorKind::kNullInput:
     case velox::rpc::RPCErrorKind::kEmptyResponse:
+    // A rejected request is a permanent client-side error, not a congestion
+    // signal, so it is not counted among the overload kinds above (it is
+    // tracked separately via a dedicated invalid-request counter).
+    case velox::rpc::RPCErrorKind::kInvalidRequest:
       break;
   }
 }


### PR DESCRIPTION
Summary:

Adds a generic, non-retryable `RPCErrorKind::kInvalidRequest` and classifies it end-to-end, so a request rejection is distinct from an overload/backend error and can be failed fast instead of retried.

- OSS (velox core): the enum in `RPCTypes.h` and its handling in `RPCOperator::recordErrorKind` — a rejected request is a permanent client-side error, not a congestion signal, so it is excluded from the overload kinds (rate-limited / timeout / backend).
- Meta (facebook/): the `velox.rpc.<backend>.<mode>.errors_invalid_request` ODS counter in `RpcMetrics` + unit coverage.

Why one diff: the enum value and EVERY exhaustive switch over `RPCErrorKind` (the OSS `RPCOperator` switch and the Meta `RpcMetrics` switch, both `-Werror,-Wswitch`) must change together, or the intermediate stack state fails to compile. ShipIt exports only the velox-core files (`RPCTypes.h`, `RPCOperator.cpp`) to OSS; the `facebook/` files stay internal. No behavior change on its own — the transports that use `kInvalidRequest` to fail fast are the next diff in the stack.

Reviewed By: zacw7

Differential Revision: D111523082


