### PR TITLE
feat(sparksql): Make unaryminus ANSI-compliant for integer overflow detection

### DIFF
--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -448,9 +448,12 @@ Mathematical Functions
 
     Returns the hyperbolic tangent of ``x``.
 
-.. spark:function:: unaryminus(x) -> [same as x]
+.. spark:function:: unaryminus(x) -> [same as x] (ANSI compliant)
 
-    Returns the negative of `x`.  Corresponds to Spark's operator ``-``.
+    Returns the negative of ``x``. Corresponds to Spark's operator ``-``.
+    When ``x`` is the minimum value of an integral type, returns the same value
+    as ``x`` following the behavior when Spark ANSI mode is disabled, and throws
+    an exception when Spark ANSI mode is enabled.
 
 .. spark:function:: unhex(x) -> varbinary
 

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -165,15 +165,34 @@ struct PModFloatFunction {
 template <typename T>
 struct UnaryMinusFunction {
   template <typename TInput>
-  FOLLY_ALWAYS_INLINE bool call(TInput& result, const TInput a) {
-    if constexpr (std::is_integral_v<TInput>) {
-      // Avoid undefined integer overflow.
-      result = a == std::numeric_limits<TInput>::min() ? a : -a;
-    } else {
-      result = -a;
-    }
-    return true;
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& config,
+      const TInput* /*a*/) {
+    ansiEnabled_ = SparkQueryConfig{config}.ansiEnabled();
   }
+
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE Status call(TInput& result, const TInput a) {
+    if constexpr (std::is_integral_v<TInput>) {
+      if (FOLLY_UNLIKELY(a == std::numeric_limits<TInput>::min())) {
+        if (ansiEnabled_) {
+          if (threadSkipErrorDetails()) {
+            return Status::UserError();
+          }
+          return Status::UserError("Arithmetic overflow: -({})", a);
+        }
+        // In non-ANSI mode, return the minimum value unchanged.
+        result = a;
+        return Status::OK();
+      }
+    }
+    result = -a;
+    return Status::OK();
+  }
+
+ private:
+  bool ansiEnabled_ = false;
 };
 
 template <typename T>

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -334,15 +334,31 @@ TEST_F(ArithmeticTest, UnaryMinus) {
   EXPECT_EQ(unaryminus<double>(6), -6);
 }
 
-TEST_F(ArithmeticTest, UnaryMinusOverflow) {
-  EXPECT_EQ(unaryminus<int8_t>(INT8_MIN), INT8_MIN);
-  EXPECT_EQ(unaryminus<int16_t>(INT16_MIN), INT16_MIN);
-  EXPECT_EQ(unaryminus<int32_t>(INT32_MIN), INT32_MIN);
-  EXPECT_EQ(unaryminus<int64_t>(INT64_MIN), INT64_MIN);
+TEST_F(ArithmeticTest, unaryMinusFloatEdgeCases) {
   EXPECT_EQ(unaryminus<float>(-kInf), kInf);
   EXPECT_TRUE(std::isnan(unaryminus<float>(kNan).value_or(0)));
   EXPECT_EQ(unaryminus<double>(-kInf), kInf);
   EXPECT_TRUE(std::isnan(unaryminus<double>(kNan).value_or(0)));
+}
+
+TEST_F(ArithmeticTest, unaryMinusAnsi) {
+  // Test unaryminus with ANSI off: negating MIN_VALUE returns MIN_VALUE.
+  queryCtx_->testingOverrideConfigUnsafe(
+      {{SparkQueryConfig::qualify(SparkQueryConfig::kAnsiEnabled), "false"}});
+
+  EXPECT_EQ(unaryminus<int8_t>(INT8_MIN), INT8_MIN);
+  EXPECT_EQ(unaryminus<int16_t>(INT16_MIN), INT16_MIN);
+  EXPECT_EQ(unaryminus<int32_t>(INT32_MIN), INT32_MIN);
+  EXPECT_EQ(unaryminus<int64_t>(INT64_MIN), INT64_MIN);
+
+  // Test unaryminus with ANSI on: negating MIN_VALUE throws.
+  queryCtx_->testingOverrideConfigUnsafe(
+      {{SparkQueryConfig::qualify(SparkQueryConfig::kAnsiEnabled), "true"}});
+
+  VELOX_ASSERT_THROW(unaryminus<int8_t>(INT8_MIN), "Arithmetic overflow");
+  VELOX_ASSERT_THROW(unaryminus<int16_t>(INT16_MIN), "Arithmetic overflow");
+  VELOX_ASSERT_THROW(unaryminus<int32_t>(INT32_MIN), "Arithmetic overflow");
+  VELOX_ASSERT_THROW(unaryminus<int64_t>(INT64_MIN), "Arithmetic overflow");
 }
 
 TEST_F(ArithmeticTest, Divide) {


### PR DESCRIPTION
## Summary

Makes `UnaryMinusFunction` ANSI-compliant by reading `ansiEnabled_` from
`SparkQueryConfig` in `initialize()`, following the same pattern as
`AbsFunction` and `RemainderFunction`.

- ANSI mode on: negating the minimum integer value throws
  `"Arithmetic overflow: -(<value>)"`, matching Spark's `ArithmeticException`
- ANSI mode off: returns the minimum value unchanged (existing behavior)

Updates `unaryminus` docs in `math.rst` to flag ANSI compliance and explain
the dual behavior.

Closes #16355