### PR TITLE
feat(arrow): Add support for large-strings

### DIFF
--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -401,20 +401,22 @@ const char* exportArrowFormatStr(
     case TypeKind::DOUBLE:
       return "g"; // float64
     // We always map VARCHAR and VARBINARY to the "small" version (lower case
-    // format string), which uses 32 bit offsets.
+    // format string).
     case TypeKind::VARCHAR:
       if (options.exportToStringView) {
         return "vu";
       }
-      return "u"; // utf-8 string
+      return options.exportToLargeVarTypes ? "U" : "u"; // utf-8 string
     case TypeKind::VARBINARY:
       if (options.exportVarbinaryAsString) {
-        return "u"; // utf-8 string (binary payload)
+        return options.exportToLargeVarTypes
+            ? "U"
+            : "u"; // utf-8 string (binary payload)
       }
       if (options.exportToStringView) {
         return "vz";
       }
-      return "z"; // binary
+      return options.exportToLargeVarTypes ? "Z" : "z"; // binary
     case TypeKind::UNKNOWN:
       return "n"; // NullType
     case TypeKind::TIMESTAMP:
@@ -991,6 +993,7 @@ void exportViews(
   });
 }
 
+template <typename TOffsets = int32_t>
 void exportStrings(
     const FlatVector<StringView>& vec,
     const Selection& rows,
@@ -1006,10 +1009,10 @@ void exportStrings(
   });
   holder.setBuffer(2, AlignedBuffer::allocate<char>(bufSize, pool));
   char* rawBuffer = holder.getBufferAs<char>(2);
-  VELOX_CHECK_LT(bufSize, std::numeric_limits<int32_t>::max());
+  VELOX_CHECK_LT(bufSize, std::numeric_limits<TOffsets>::max());
   auto offsetLen = checkedPlus<size_t>(out.length, 1);
-  holder.setBuffer(1, AlignedBuffer::allocate<int32_t>(offsetLen, pool));
-  auto* rawOffsets = holder.getBufferAs<int32_t>(1);
+  holder.setBuffer(1, AlignedBuffer::allocate<TOffsets>(offsetLen, pool));
+  auto* rawOffsets = holder.getBufferAs<TOffsets>(1);
   *rawOffsets = 0;
   rows.apply([&](vector_size_t i) {
     auto newOffset = *rawOffsets;
@@ -1058,13 +1061,21 @@ void exportFlat(
             out,
             pool,
             holder);
-      } else
+      } else if (options.exportToLargeVarTypes) {
+        exportStrings<int64_t>(
+            *vec.asUnchecked<FlatVector<StringView>>(),
+            rows,
+            out,
+            pool,
+            holder);
+      } else {
         exportStrings(
             *vec.asUnchecked<FlatVector<StringView>>(),
             rows,
             out,
             pool,
             holder);
+      }
       break;
     default:
       VELOX_NYI(

--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -400,23 +400,24 @@ const char* exportArrowFormatStr(
       return "f"; // float32
     case TypeKind::DOUBLE:
       return "g"; // float64
-    // We always map VARCHAR and VARBINARY to the "small" version (lower case
-    // format string).
     case TypeKind::VARCHAR:
-      if (options.exportToStringView) {
-        return "vu";
+      switch (options.varTypeLayout) {
+        case VarTypeLayout::kDefault:
+          return "u";
+        case VarTypeLayout::kStringView:
+          return "vu";
+        case VarTypeLayout::kLargeVarTypes:
+          return "U";
       }
-      return options.exportToLargeVarTypes ? "U" : "u"; // utf-8 string
     case TypeKind::VARBINARY:
-      if (options.exportVarbinaryAsString) {
-        return options.exportToLargeVarTypes
-            ? "U"
-            : "u"; // utf-8 string (binary payload)
+      switch (options.varTypeLayout) {
+        case VarTypeLayout::kDefault:
+          return options.exportVarbinaryAsString ? "u" : "z";
+        case VarTypeLayout::kStringView:
+          return options.exportVarbinaryAsString ? "vu" : "vz";
+        case VarTypeLayout::kLargeVarTypes:
+          return options.exportVarbinaryAsString ? "U" : "Z";
       }
-      if (options.exportToStringView) {
-        return "vz";
-      }
-      return options.exportToLargeVarTypes ? "Z" : "z"; // binary
     case TypeKind::UNKNOWN:
       return "n"; // NullType
     case TypeKind::TIMESTAMP:
@@ -1054,28 +1055,31 @@ void exportFlat(
       break;
     case TypeKind::VARCHAR:
     case TypeKind::VARBINARY:
-      if (options.exportToStringView) {
-        exportValues(vec, rows, options, out, pool, holder);
-        exportViews(
-            *vec.asUnchecked<FlatVector<StringView>>(),
-            rows,
-            out,
-            pool,
-            holder);
-      } else if (options.exportToLargeVarTypes) {
-        exportStrings<int64_t>(
-            *vec.asUnchecked<FlatVector<StringView>>(),
-            rows,
-            out,
-            pool,
-            holder);
-      } else {
-        exportStrings(
-            *vec.asUnchecked<FlatVector<StringView>>(),
-            rows,
-            out,
-            pool,
-            holder);
+      switch (options.varTypeLayout) {
+        case VarTypeLayout::kDefault:
+          exportStrings(
+              *vec.asUnchecked<FlatVector<StringView>>(),
+              rows,
+              out,
+              pool,
+              holder);
+          break;
+        case VarTypeLayout::kStringView:
+          exportValues(vec, rows, options, out, pool, holder);
+          exportViews(
+              *vec.asUnchecked<FlatVector<StringView>>(),
+              rows,
+              out,
+              pool,
+              holder);
+          break;
+        case VarTypeLayout::kLargeVarTypes:
+          exportStrings<int64_t>(
+              *vec.asUnchecked<FlatVector<StringView>>(),
+              rows,
+              out,
+              pool,
+              holder);
       }
       break;
     default:

--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -401,20 +401,22 @@ const char* exportArrowFormatStr(
     case TypeKind::DOUBLE:
       return "g"; // float64
     // We always map VARCHAR and VARBINARY to the "small" version (lower case
-    // format string), which uses 32 bit offsets.
+    // format string).
     case TypeKind::VARCHAR:
       if (options.exportToStringView) {
         return "vu";
       }
-      return "u"; // utf-8 string
+      return options.exportToLargeVarTypes ? "U" : "u"; // utf-8 string
     case TypeKind::VARBINARY:
       if (options.exportVarbinaryAsString) {
-        return "u"; // utf-8 string (binary payload)
+        return options.exportToLargeVarTypes
+            ? "U"
+            : "u"; // utf-8 string (binary payload)
       }
       if (options.exportToStringView) {
         return "vz";
       }
-      return "z"; // binary
+      return options.exportToLargeVarTypes ? "Z" : "z"; // binary
     case TypeKind::UNKNOWN:
       return "n"; // NullType
     case TypeKind::TIMESTAMP:
@@ -992,6 +994,7 @@ void exportViews(
   });
 }
 
+template <typename TOffsets = int32_t>
 void exportStrings(
     const FlatVector<StringView>& vec,
     const Selection& rows,
@@ -1007,10 +1010,10 @@ void exportStrings(
   });
   holder.setBuffer(2, AlignedBuffer::allocate<char>(bufSize, pool));
   char* rawBuffer = holder.getBufferAs<char>(2);
-  VELOX_CHECK_LT(bufSize, std::numeric_limits<int32_t>::max());
+  VELOX_CHECK_LT(bufSize, std::numeric_limits<TOffsets>::max());
   auto offsetLen = checkedPlus<size_t>(out.length, 1);
-  holder.setBuffer(1, AlignedBuffer::allocate<int32_t>(offsetLen, pool));
-  auto* rawOffsets = holder.getBufferAs<int32_t>(1);
+  holder.setBuffer(1, AlignedBuffer::allocate<TOffsets>(offsetLen, pool));
+  auto* rawOffsets = holder.getBufferAs<TOffsets>(1);
   *rawOffsets = 0;
   rows.apply([&](vector_size_t i) {
     auto newOffset = *rawOffsets;
@@ -1059,13 +1062,21 @@ void exportFlat(
             out,
             pool,
             holder);
-      } else
+      } else if (options.exportToLargeVarTypes) {
+        exportStrings<int64_t>(
+            *vec.asUnchecked<FlatVector<StringView>>(),
+            rows,
+            out,
+            pool,
+            holder);
+      } else {
         exportStrings(
             *vec.asUnchecked<FlatVector<StringView>>(),
             rows,
             out,
             pool,
             holder);
+      }
       break;
     default:
       VELOX_NYI(

--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -19,6 +19,7 @@
 #include <cstring>
 
 #include "velox/buffer/Buffer.h"
+#include "velox/common/EnumDefine.h"
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/base/CheckedArithmetic.h"
 #include "velox/common/base/Exceptions.h"
@@ -27,6 +28,22 @@
 #include "velox/vector/FlatVector.h"
 #include "velox/vector/VectorTypeUtils.h"
 #include "velox/vector/arrow/Abi.h"
+
+namespace {
+
+const auto& varTypeLayoutNames() {
+  static const folly::F14FastMap<ArrowOptions::VarTypeLayout, std::string_view>
+      kNames = {
+          {ArrowOptions::VarTypeLayout::kDefault, "Default"},
+          {ArrowOptions::VarTypeLayout::kStringView, "StringView"},
+          {ArrowOptions::VarTypeLayout::kLarge, "Large"},
+      };
+  return kNames;
+}
+
+} // namespace
+
+VELOX_DEFINE_EMBEDDED_ENUM_NAME(ArrowOptions, VarTypeLayout, varTypeLayoutNames)
 
 namespace facebook::velox {
 
@@ -401,23 +418,19 @@ const char* exportArrowFormatStr(
     case TypeKind::DOUBLE:
       return "g"; // float64
     case TypeKind::VARCHAR:
+    case TypeKind::VARBINARY: {
+      const bool asString =
+          type->kind() == TypeKind::VARCHAR || options.exportVarbinaryAsString;
       switch (options.varTypeLayout) {
-        case VarTypeLayout::kDefault:
-          return "u";
-        case VarTypeLayout::kStringView:
-          return "vu";
-        case VarTypeLayout::kLargeVarTypes:
-          return "U";
+        case ArrowOptions::VarTypeLayout::kDefault:
+          return asString ? "u" : "z";
+        case ArrowOptions::VarTypeLayout::kStringView:
+          return asString ? "vu" : "vz";
+        case ArrowOptions::VarTypeLayout::kLarge:
+          return asString ? "U" : "Z";
       }
-    case TypeKind::VARBINARY:
-      switch (options.varTypeLayout) {
-        case VarTypeLayout::kDefault:
-          return options.exportVarbinaryAsString ? "u" : "z";
-        case VarTypeLayout::kStringView:
-          return options.exportVarbinaryAsString ? "vu" : "vz";
-        case VarTypeLayout::kLargeVarTypes:
-          return options.exportVarbinaryAsString ? "U" : "Z";
-      }
+      VELOX_UNREACHABLE();
+    }
     case TypeKind::UNKNOWN:
       return "n"; // NullType
     case TypeKind::TIMESTAMP:
@@ -1054,34 +1067,22 @@ void exportFlat(
       // Keep out.n_children = 0 for UNKNOWN type.
       break;
     case TypeKind::VARCHAR:
-    case TypeKind::VARBINARY:
+    case TypeKind::VARBINARY: {
+      const auto& stringVector = *vec.asUnchecked<FlatVector<StringView>>();
       switch (options.varTypeLayout) {
-        case VarTypeLayout::kDefault:
-          exportStrings(
-              *vec.asUnchecked<FlatVector<StringView>>(),
-              rows,
-              out,
-              pool,
-              holder);
+        case ArrowOptions::VarTypeLayout::kDefault:
+          exportStrings(stringVector, rows, out, pool, holder);
           break;
-        case VarTypeLayout::kStringView:
+        case ArrowOptions::VarTypeLayout::kStringView:
           exportValues(vec, rows, options, out, pool, holder);
-          exportViews(
-              *vec.asUnchecked<FlatVector<StringView>>(),
-              rows,
-              out,
-              pool,
-              holder);
+          exportViews(stringVector, rows, out, pool, holder);
           break;
-        case VarTypeLayout::kLargeVarTypes:
-          exportStrings<int64_t>(
-              *vec.asUnchecked<FlatVector<StringView>>(),
-              rows,
-              out,
-              pool,
-              holder);
+        case ArrowOptions::VarTypeLayout::kLarge:
+          exportStrings<int64_t>(stringVector, rows, out, pool, holder);
+          break;
       }
       break;
+    }
     default:
       VELOX_NYI(
           "Conversion of FlatVector of {} is not supported yet.",

--- a/velox/vector/arrow/Bridge.h
+++ b/velox/vector/arrow/Bridge.h
@@ -40,7 +40,8 @@ struct ArrowOptions {
   std::optional<std::string> timestampTimeZone{std::nullopt};
   // Export VARCHAR and VARBINARY to Arrow 15 StringView format
   bool exportToStringView = false;
-  // Export VARCHAR and VARBINARY with 64-bit offsets (Arrow LargeUtf8/LargeBinary).
+  // Export VARCHAR and VARBINARY with 64-bit offsets (Arrow
+  // LargeUtf8/LargeBinary).
   bool exportToLargeVarTypes = false;
   // Export VARBINARY as UTF-8 string (for consumers that lack binary support).
   bool exportVarbinaryAsString = false;

--- a/velox/vector/arrow/Bridge.h
+++ b/velox/vector/arrow/Bridge.h
@@ -40,6 +40,8 @@ struct ArrowOptions {
   std::optional<std::string> timestampTimeZone{std::nullopt};
   // Export VARCHAR and VARBINARY to Arrow 15 StringView format
   bool exportToStringView = false;
+  // Export VARCHAR and VARBINARY with 64-bit offsets (Arrow LargeUtf8/LargeBinary).
+  bool exportToLargeVarTypes = false;
   // Export VARBINARY as UTF-8 string (for consumers that lack binary support).
   bool exportVarbinaryAsString = false;
   /// Respect the width component of decimal type format string on export.

--- a/velox/vector/arrow/Bridge.h
+++ b/velox/vector/arrow/Bridge.h
@@ -36,9 +36,12 @@ enum class TimestampUnit : uint8_t {
 struct ArrowOptions {
   /// Physical layout used to export variable-width values to Arrow.
   enum class VarTypeLayout : uint8_t {
-    kDefault, // 32-bit offsets (Arrow String/Binary)
-    kStringView, // Arrow StringView
-    kLarge // 64-bit offsets (Arrow LargeString/LargeBinary)
+    /// 32-bit offsets (Arrow String/Binary).
+    kDefault,
+    /// Arrow StringView.
+    kStringView,
+    /// 64-bit offsets (Arrow LargeString/LargeBinary).
+    kLarge,
   };
 
   VELOX_DECLARE_EMBEDDED_ENUM_NAME(VarTypeLayout);

--- a/velox/vector/arrow/Bridge.h
+++ b/velox/vector/arrow/Bridge.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "velox/common/EnumDeclare.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/vector/BaseVector.h"
 
@@ -32,14 +33,16 @@ enum class TimestampUnit : uint8_t {
   kNano = 9 /*10^9 nanoseconds are equal to 1 second*/
 };
 
-/// Physical layout used to export variable-width values to Arrow.
-enum class VarTypeLayout : uint8_t {
-  kDefault, // 32-bit offsets (Arrow String/Binary)
-  kStringView, // Arrow StringView
-  kLargeVarTypes // 64-bit offsets (Arrow LargeString/LargeBinary)
-};
-
 struct ArrowOptions {
+  /// Physical layout used to export variable-width values to Arrow.
+  enum class VarTypeLayout : uint8_t {
+    kDefault, // 32-bit offsets (Arrow String/Binary)
+    kStringView, // Arrow StringView
+    kLarge // 64-bit offsets (Arrow LargeString/LargeBinary)
+  };
+
+  VELOX_DECLARE_EMBEDDED_ENUM_NAME(VarTypeLayout);
+
   bool flattenDictionary{false};
   // NOTE: flattenConstant is only supported for scalar types.
   bool flattenConstant{false};

--- a/velox/vector/arrow/Bridge.h
+++ b/velox/vector/arrow/Bridge.h
@@ -32,17 +32,21 @@ enum class TimestampUnit : uint8_t {
   kNano = 9 /*10^9 nanoseconds are equal to 1 second*/
 };
 
+/// Physical layout used to export variable-width values to Arrow.
+enum class VarTypeLayout : uint8_t {
+  kDefault, // 32-bit offsets (Arrow String/Binary)
+  kStringView, // Arrow StringView
+  kLargeVarTypes // 64-bit offsets (Arrow LargeString/LargeBinary)
+};
+
 struct ArrowOptions {
   bool flattenDictionary{false};
   // NOTE: flattenConstant is only supported for scalar types.
   bool flattenConstant{false};
   TimestampUnit timestampUnit = TimestampUnit::kNano;
   std::optional<std::string> timestampTimeZone{std::nullopt};
-  // Export VARCHAR and VARBINARY to Arrow 15 StringView format
-  bool exportToStringView = false;
-  // Export VARCHAR and VARBINARY with 64-bit offsets (Arrow
-  // LargeUtf8/LargeBinary).
-  bool exportToLargeVarTypes = false;
+  // Layout used for VARCHAR and VARBINARY.
+  VarTypeLayout varTypeLayout{VarTypeLayout::kDefault};
   // Export VARBINARY as UTF-8 string (for consumers that lack binary support).
   bool exportVarbinaryAsString = false;
   /// Respect the width component of decimal type format string on export.

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -49,7 +49,7 @@ class ArrowBridgeArrayExportTest : public testing::Test {
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
   }
 
-  template <typename T>
+  template <typename T, typename TOffsets = int32_t>
   void testFlatVector(
       const std::vector<std::optional<T>>& inputData,
       const TypePtr& type = CppToType<T>::create()) {
@@ -57,7 +57,7 @@ class ArrowBridgeArrayExportTest : public testing::Test {
     ArrowArray arrowArray;
     velox::exportToArrow(flatVector, arrowArray, pool_.get(), options_);
 
-    validateArray(inputData, arrowArray);
+    validateArray<T, TOffsets>(inputData, arrowArray);
 
     arrowArray.release(&arrowArray);
     EXPECT_EQ(nullptr, arrowArray.release);
@@ -135,7 +135,7 @@ class ArrowBridgeArrayExportTest : public testing::Test {
 
   // Helper functions for verification.
 
-  template <typename T>
+  template <typename T, typename TOffsets = int32_t>
   void validateArray(
       const std::vector<std::optional<T>>& inputData,
       const ArrowArray& arrowArray) {
@@ -155,7 +155,7 @@ class ArrowBridgeArrayExportTest : public testing::Test {
 
     // Validate array contents.
     if constexpr (isString) {
-      validateStringArray(inputData, arrowArray);
+      validateStringArray<T, TOffsets>(inputData, arrowArray);
     } else if constexpr (isUnknownType) {
       validateNullArray(arrowArray);
     } else {
@@ -206,7 +206,7 @@ class ArrowBridgeArrayExportTest : public testing::Test {
     }
   }
 
-  template <typename T>
+  template <typename T, typename TOffsets = int32_t>
   void validateStringArray(
       const std::vector<std::optional<T>>& inputData,
       const ArrowArray& arrowArray) {
@@ -215,7 +215,8 @@ class ArrowBridgeArrayExportTest : public testing::Test {
 
     const uint64_t* nulls = static_cast<const uint64_t*>(arrowArray.buffers[0]);
     const char* values = static_cast<const char*>(arrowArray.buffers[2]);
-    const int32_t* offsets = static_cast<const int32_t*>(arrowArray.buffers[1]);
+    const TOffsets* offsets =
+        static_cast<const TOffsets*>(arrowArray.buffers[1]);
 
     EXPECT_NE(values, nullptr);
     EXPECT_NE(offsets, nullptr);
@@ -610,7 +611,7 @@ TEST_F(ArrowBridgeArrayExportTest, flatTime) {
 }
 
 TEST_F(ArrowBridgeArrayExportTest, flatString) {
-  testFlatVector<std::string>({
+  const std::vector<std::optional<std::string>> inputData = {
       "my string",
       "another slightly longer string",
       std::nullopt,
@@ -620,10 +621,19 @@ TEST_F(ArrowBridgeArrayExportTest, flatString) {
       "a",
       "another even longer string to ensure it's for sure not stored inline!!!",
       std::nullopt,
-  });
+  };
+
+  testFlatVector<std::string, int32_t>(inputData);
+
+  options_.exportToLargeVarTypes = true;
+  testFlatVector<std::string, int64_t>(inputData);
 
   // Empty vector.
-  testFlatVector<std::string>({});
+  options_.exportToLargeVarTypes = false;
+  testFlatVector<std::string, int32_t>({});
+
+  options_.exportToLargeVarTypes = true;
+  testFlatVector<std::string, int64_t>({});
 }
 
 TEST_F(ArrowBridgeArrayExportTest, rowVector) {

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -49,7 +49,7 @@ class ArrowBridgeArrayExportTest : public testing::Test {
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
   }
 
-  template <typename T, typename TOffsets = int32_t>
+  template <typename T>
   void testFlatVector(
       const std::vector<std::optional<T>>& inputData,
       const TypePtr& type = CppToType<T>::create()) {
@@ -57,7 +57,7 @@ class ArrowBridgeArrayExportTest : public testing::Test {
     ArrowArray arrowArray;
     velox::exportToArrow(flatVector, arrowArray, pool_.get(), options_);
 
-    validateArray<T, TOffsets>(inputData, arrowArray);
+    validateArray(inputData, arrowArray);
 
     arrowArray.release(&arrowArray);
     EXPECT_EQ(nullptr, arrowArray.release);
@@ -135,7 +135,7 @@ class ArrowBridgeArrayExportTest : public testing::Test {
 
   // Helper functions for verification.
 
-  template <typename T, typename TOffsets = int32_t>
+  template <typename T>
   void validateArray(
       const std::vector<std::optional<T>>& inputData,
       const ArrowArray& arrowArray) {
@@ -155,7 +155,11 @@ class ArrowBridgeArrayExportTest : public testing::Test {
 
     // Validate array contents.
     if constexpr (isString) {
-      validateStringArray<T, TOffsets>(inputData, arrowArray);
+      if (options_.varTypeLayout == VarTypeLayout::kLargeVarTypes) {
+        validateStringArray<T, int64_t>(inputData, arrowArray);
+      } else {
+        validateStringArray<T, int32_t>(inputData, arrowArray);
+      }
     } else if constexpr (isUnknownType) {
       validateNullArray(arrowArray);
     } else {
@@ -623,17 +627,17 @@ TEST_F(ArrowBridgeArrayExportTest, flatString) {
       std::nullopt,
   };
 
-  testFlatVector<std::string, int32_t>(inputData);
+  testFlatVector(inputData);
 
-  options_.exportToLargeVarTypes = true;
-  testFlatVector<std::string, int64_t>(inputData);
+  options_.varTypeLayout = VarTypeLayout::kLargeVarTypes;
+  testFlatVector(inputData);
 
   // Empty vector.
-  options_.exportToLargeVarTypes = false;
-  testFlatVector<std::string, int32_t>({});
+  options_.varTypeLayout = VarTypeLayout::kDefault;
+  testFlatVector<std::string>({});
 
-  options_.exportToLargeVarTypes = true;
-  testFlatVector<std::string, int64_t>({});
+  options_.varTypeLayout = VarTypeLayout::kLargeVarTypes;
+  testFlatVector<std::string>({});
 }
 
 TEST_F(ArrowBridgeArrayExportTest, rowVector) {
@@ -1950,7 +1954,7 @@ class ArrowBridgeArrayImportTest : public ArrowBridgeArrayExportTest {
           ASSERT_EQ(*vec.type(), *VARCHAR());
           EXPECT_EQ(vec.size(), 12);
         },
-        ArrowOptions{.exportToStringView = true});
+        ArrowOptions{.varTypeLayout = VarTypeLayout::kStringView});
   }
 
   void testImportREE() {

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -155,7 +155,7 @@ class ArrowBridgeArrayExportTest : public testing::Test {
 
     // Validate array contents.
     if constexpr (isString) {
-      if (options_.varTypeLayout == VarTypeLayout::kLargeVarTypes) {
+      if (options_.varTypeLayout == ArrowOptions::VarTypeLayout::kLarge) {
         validateStringArray<T, int64_t>(inputData, arrowArray);
       } else {
         validateStringArray<T, int32_t>(inputData, arrowArray);
@@ -627,17 +627,15 @@ TEST_F(ArrowBridgeArrayExportTest, flatString) {
       std::nullopt,
   };
 
-  testFlatVector(inputData);
+  for (auto layout :
+       {ArrowOptions::VarTypeLayout::kDefault,
+        ArrowOptions::VarTypeLayout::kLarge}) {
+    options_.varTypeLayout = layout;
+    testFlatVector(inputData);
 
-  options_.varTypeLayout = VarTypeLayout::kLargeVarTypes;
-  testFlatVector(inputData);
-
-  // Empty vector.
-  options_.varTypeLayout = VarTypeLayout::kDefault;
-  testFlatVector<std::string>({});
-
-  options_.varTypeLayout = VarTypeLayout::kLargeVarTypes;
-  testFlatVector<std::string>({});
+    // Empty vector.
+    testFlatVector<std::string>({});
+  }
 }
 
 TEST_F(ArrowBridgeArrayExportTest, rowVector) {
@@ -1954,7 +1952,8 @@ class ArrowBridgeArrayImportTest : public ArrowBridgeArrayExportTest {
           ASSERT_EQ(*vec.type(), *VARCHAR());
           EXPECT_EQ(vec.size(), 12);
         },
-        ArrowOptions{.varTypeLayout = VarTypeLayout::kStringView});
+        ArrowOptions{
+            .varTypeLayout = ArrowOptions::VarTypeLayout::kStringView});
   }
 
   void testImportREE() {

--- a/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
@@ -209,6 +209,8 @@ TEST_F(ArrowBridgeSchemaExportTest, scalar) {
 
   testScalarType(VARCHAR(), "u");
   testScalarType(VARBINARY(), "z");
+  testScalarType(VARCHAR(), "U", {.exportToLargeVarTypes = true});
+  testScalarType(VARBINARY(), "Z", {.exportToLargeVarTypes = true});
 
   testScalarType(VARCHAR(), "vu", {.exportToStringView = true});
   testScalarType(VARBINARY(), "vz", {.exportToStringView = true});

--- a/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
@@ -209,12 +209,27 @@ TEST_F(ArrowBridgeSchemaExportTest, scalar) {
 
   testScalarType(VARCHAR(), "u");
   testScalarType(VARBINARY(), "z");
-  testScalarType(VARCHAR(), "U", {.exportToLargeVarTypes = true});
-  testScalarType(VARBINARY(), "Z", {.exportToLargeVarTypes = true});
+  testScalarType(
+      VARCHAR(), "U", {.varTypeLayout = VarTypeLayout::kLargeVarTypes});
+  testScalarType(
+      VARBINARY(), "Z", {.varTypeLayout = VarTypeLayout::kLargeVarTypes});
 
-  testScalarType(VARCHAR(), "vu", {.exportToStringView = true});
-  testScalarType(VARBINARY(), "vz", {.exportToStringView = true});
+  testScalarType(
+      VARCHAR(), "vu", {.varTypeLayout = VarTypeLayout::kStringView});
+  testScalarType(
+      VARBINARY(), "vz", {.varTypeLayout = VarTypeLayout::kStringView});
 
+  testScalarType(VARBINARY(), "u", {.exportVarbinaryAsString = true});
+  testScalarType(
+      VARBINARY(),
+      "U",
+      {.varTypeLayout = VarTypeLayout::kLargeVarTypes,
+       .exportVarbinaryAsString = true});
+  testScalarType(
+      VARBINARY(),
+      "vu",
+      {.varTypeLayout = VarTypeLayout::kStringView,
+       .exportVarbinaryAsString = true});
   {
     struct TimestampCase {
       TimestampUnit unit;
@@ -323,7 +338,7 @@ TEST_F(ArrowBridgeSchemaExportTest, constant) {
   testConstant(BOOLEAN(), "b");
   testConstant(DOUBLE(), "g");
   testConstant(VARCHAR(), "u");
-  testConstant(VARCHAR(), "vu", {.exportToStringView = true});
+  testConstant(VARCHAR(), "vu", {.varTypeLayout = VarTypeLayout::kStringView});
   testConstant(DATE(), "tdD");
   testConstant(INTERVAL_YEAR_MONTH(), "tiM");
   testConstant(UNKNOWN(), "n");
@@ -612,7 +627,7 @@ class ArrowBridgeSchemaTest : public testing::Test {
 TEST_F(ArrowBridgeSchemaTest, roundtrip) {
   roundtripTest(BOOLEAN());
   roundtripTest(VARCHAR());
-  roundtripTest(VARCHAR(), {.exportToStringView = true});
+  roundtripTest(VARCHAR(), {.varTypeLayout = VarTypeLayout::kStringView});
   roundtripTest(REAL());
   roundtripTest(TIMESTAMP());
   roundtripTest(TIMESTAMP_UTC());
@@ -657,7 +672,8 @@ TEST_F(ArrowBridgeSchemaTest, validateInArrow) {
             << ta->ToString();
     ArrowSchema schema;
     ta == arrow::utf8_view()
-        ? exportToArrow(tv, schema, {.exportToStringView = true})
+        ? exportToArrow(
+              tv, schema, {.varTypeLayout = VarTypeLayout::kStringView})
         : exportToArrow(tv, schema);
     ASSERT_OK_AND_ASSIGN(auto actual, arrow::ImportType(&schema));
     ASSERT_FALSE(schema.release);

--- a/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
@@ -210,25 +210,29 @@ TEST_F(ArrowBridgeSchemaExportTest, scalar) {
   testScalarType(VARCHAR(), "u");
   testScalarType(VARBINARY(), "z");
   testScalarType(
-      VARCHAR(), "U", {.varTypeLayout = VarTypeLayout::kLargeVarTypes});
+      VARCHAR(), "U", {.varTypeLayout = ArrowOptions::VarTypeLayout::kLarge});
   testScalarType(
-      VARBINARY(), "Z", {.varTypeLayout = VarTypeLayout::kLargeVarTypes});
+      VARBINARY(), "Z", {.varTypeLayout = ArrowOptions::VarTypeLayout::kLarge});
 
   testScalarType(
-      VARCHAR(), "vu", {.varTypeLayout = VarTypeLayout::kStringView});
+      VARCHAR(),
+      "vu",
+      {.varTypeLayout = ArrowOptions::VarTypeLayout::kStringView});
   testScalarType(
-      VARBINARY(), "vz", {.varTypeLayout = VarTypeLayout::kStringView});
+      VARBINARY(),
+      "vz",
+      {.varTypeLayout = ArrowOptions::VarTypeLayout::kStringView});
 
   testScalarType(VARBINARY(), "u", {.exportVarbinaryAsString = true});
   testScalarType(
       VARBINARY(),
       "U",
-      {.varTypeLayout = VarTypeLayout::kLargeVarTypes,
+      {.varTypeLayout = ArrowOptions::VarTypeLayout::kLarge,
        .exportVarbinaryAsString = true});
   testScalarType(
       VARBINARY(),
       "vu",
-      {.varTypeLayout = VarTypeLayout::kStringView,
+      {.varTypeLayout = ArrowOptions::VarTypeLayout::kStringView,
        .exportVarbinaryAsString = true});
   {
     struct TimestampCase {
@@ -338,7 +342,10 @@ TEST_F(ArrowBridgeSchemaExportTest, constant) {
   testConstant(BOOLEAN(), "b");
   testConstant(DOUBLE(), "g");
   testConstant(VARCHAR(), "u");
-  testConstant(VARCHAR(), "vu", {.varTypeLayout = VarTypeLayout::kStringView});
+  testConstant(
+      VARCHAR(),
+      "vu",
+      {.varTypeLayout = ArrowOptions::VarTypeLayout::kStringView});
   testConstant(DATE(), "tdD");
   testConstant(INTERVAL_YEAR_MONTH(), "tiM");
   testConstant(UNKNOWN(), "n");
@@ -627,7 +634,10 @@ class ArrowBridgeSchemaTest : public testing::Test {
 TEST_F(ArrowBridgeSchemaTest, roundtrip) {
   roundtripTest(BOOLEAN());
   roundtripTest(VARCHAR());
-  roundtripTest(VARCHAR(), {.varTypeLayout = VarTypeLayout::kStringView});
+  roundtripTest(
+      VARCHAR(), {.varTypeLayout = ArrowOptions::VarTypeLayout::kStringView});
+  roundtripTest(
+      VARCHAR(), {.varTypeLayout = ArrowOptions::VarTypeLayout::kLarge});
   roundtripTest(REAL());
   roundtripTest(TIMESTAMP());
   roundtripTest(TIMESTAMP_UTC());
@@ -651,6 +661,7 @@ TEST_F(ArrowBridgeSchemaTest, validateInArrow) {
       {BOOLEAN(), arrow::boolean()},
       {VARCHAR(), arrow::utf8()},
       {VARCHAR(), arrow::utf8_view()},
+      {VARCHAR(), arrow::large_utf8()},
 #if ARROW_VERSION_MAJOR >= 18
       // Type arrow::decimal is deprecated, use arrow::decimal128.
       {DECIMAL(10, 4), arrow::decimal128(10, 4)},
@@ -671,10 +682,17 @@ TEST_F(ArrowBridgeSchemaTest, validateInArrow) {
     VLOG(1) << "Validating conversion between " << tv->toString() << " and "
             << ta->ToString();
     ArrowSchema schema;
-    ta == arrow::utf8_view()
-        ? exportToArrow(
-              tv, schema, {.varTypeLayout = VarTypeLayout::kStringView})
-        : exportToArrow(tv, schema);
+    if (ta == arrow::utf8_view()) {
+      exportToArrow(
+          tv,
+          schema,
+          {.varTypeLayout = ArrowOptions::VarTypeLayout::kStringView});
+    } else if (ta == arrow::large_utf8()) {
+      exportToArrow(
+          tv, schema, {.varTypeLayout = ArrowOptions::VarTypeLayout::kLarge});
+    } else {
+      exportToArrow(tv, schema);
+    }
     ASSERT_OK_AND_ASSIGN(auto actual, arrow::ImportType(&schema));
     ASSERT_FALSE(schema.release);
     EXPECT_EQ(*actual, *ta);


### PR DESCRIPTION
Add support for exporting Velox `VARCHAR` and `VARBINARY` vectors to Arrow large variable-width types.
- Add enum `VarTypeLayout`:
  - `kDefault`: 32-bit offsets (Arrow String/Binary)
  - `kStringView`: Arrow StringView
  - `kLarge`: 64-bit offsets (Arrow LargeString/LargeBinary)
- Replace `ArrowOptions::exportToStringView` with `ArrowOptions::varTypeLayout` (**Breaking Change**)
- Use `int64_t` offsets for large var types

This PR complements https://github.com/facebookincubator/velox/pull/14359 and is required for https://github.com/apache/gluten/pull/12448.