### PR TITLE
fix(common/base): Add MSVC portability guards

### DIFF
--- a/velox/common/base/BitUtil.h
+++ b/velox/common/base/BitUtil.h
@@ -20,12 +20,24 @@
 
 #include <folly/CPortability.h>
 
+// Provide __builtin_popcount* on MSVC (not compiler builtins)
+#if defined(_MSC_VER)
+#include <folly/portability/Builtins.h>
+#endif
+
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <span>
 #include <string>
+
+#ifndef _MSC_VER
+namespace facebook::velox {
+using int128_t = __int128_t;
+using uint128_t = __uint128_t;
+}
+#endif
 
 #ifdef __BMI2__
 #include <x86intrin.h>
@@ -250,7 +262,7 @@ forEachWord(int32_t begin, int32_t end, PartialWordFunc partialWordFunc) {
   int32_t firstIndex = begin / 64;
   int32_t lastIndex = (roundUp(end, 64) - 64) / 64;
   for (auto index = firstIndex; index <= lastIndex; ++index) {
-    uint64_t mask = ~0UL;
+    uint64_t mask = ~0ULL;
     if (index == firstIndex && begin != firstIndex * 64) {
       // We do not start at 64 bit boundary, and off the bits below start.
       mask = highMask((firstIndex + 1) * 64 - begin);
@@ -279,7 +291,7 @@ void forBatches(
     int32_t begin,
     int32_t end,
     Callable func) {
-  constexpr int64_t unitMask = kWidth == 64 ? ~0UL : lowMask(kWidth);
+  constexpr int64_t unitMask = kWidth == 64 ? ~0ULL : lowMask(kWidth);
   static_assert(kWidth <= 64 && 64 % kWidth == 0);
   bits::forEachWord(begin, end, [&](auto index, uint64_t mask) {
     uint64_t active = bits[index] & mask;
@@ -471,11 +483,58 @@ void forEachBit(
       });
 }
 
+template <typename Callable, typename CallableBatch64>
+void forEachBit(
+    const uint64_t* bits,
+    int32_t begin,
+    int32_t end,
+    bool isSet,
+    Callable func,
+    CallableBatch64 batchFunc) {
+  static constexpr uint64_t kAllSet = -1ULL;
+  forEachWord(
+      begin,
+      end,
+      [isSet, bits, func](int32_t idx, uint64_t mask) {
+        auto word = (isSet ? bits[idx] : ~bits[idx]) & mask;
+        if (!word) {
+          return;
+        }
+        while (word) {
+          func(idx * 64 + __builtin_ctzll(word));
+          word &= word - 1;
+        }
+      },
+      [isSet, bits, func, batchFunc](int32_t idx) {
+        auto word = (isSet ? bits[idx] : ~bits[idx]);
+        if (kAllSet == word) {
+          const size_t start = idx * 64;
+          const size_t end = (idx + 1) * 64;
+          batchFunc(start, end);
+        } else {
+          while (word) {
+            func(idx * 64 + __builtin_ctzll(word));
+            word &= word - 1;
+          }
+        }
+      });
+}
+
 /// Invokes a function for each set bit.
 template <typename Callable>
 inline void
 forEachSetBit(const uint64_t* bits, int32_t begin, int32_t end, Callable func) {
   forEachBit(bits, begin, end, true, func);
+}
+
+template <typename Callable, typename CallableBatch64>
+inline void forEachSetBit(
+    const uint64_t* bits,
+    int32_t begin,
+    int32_t end,
+    Callable func,
+    CallableBatch64 batchFunc) {
+  forEachBit(bits, begin, end, true, func, batchFunc);
 }
 
 /// Invokes a function for each unset bit.
@@ -733,7 +792,13 @@ bool inline hasIntersection(
 
 template <typename T = uint64_t>
 inline int32_t countLeadingZeros(T word) {
-  static_assert(std::is_same_v<T, uint64_t> || std::is_same_v<T, __uint128_t>);
+#ifdef _MSC_VER
+  static_assert(std::is_same_v<T, uint64_t>);
+#else
+  static_assert(
+      std::is_same_v<T, uint64_t> ||
+      std::is_same_v<T, facebook::velox::uint128_t>);
+#endif
   /// Built-in Function: int __builtin_clz (unsigned int x) returns the number
   /// of leading 0-bits in x, starting at the most significant bit position. If
   /// x is 0, the result is undefined.
@@ -743,7 +808,7 @@ inline int32_t countLeadingZeros(T word) {
   if constexpr (std::is_same_v<T, uint64_t>) {
     return __builtin_clzll(word);
   } else {
-    uint64_t hi = word >> 64;
+    uint64_t hi = static_cast<uint64_t>(word >> 64);
     uint64_t lo = static_cast<uint64_t>(word);
     return (hi == 0) ? 64 + __builtin_clzll(lo) : __builtin_clzll(hi);
   }
@@ -826,7 +891,7 @@ inline T loadBits(const uint64_t* source, uint64_t bitOffset, uint8_t numBits) {
     return word >> bit;
   }
   uint8_t lastByte = reinterpret_cast<const uint8_t*>(address)[sizeof(T)];
-  uint64_t lastBits = static_cast<T>(lastByte) << (kBitSize - bit);
+  T lastBits = static_cast<T>(lastByte) << (kBitSize - bit);
   return (word >> bit) | lastBits;
 }
 
@@ -841,7 +906,7 @@ storeBits(uint64_t* target, uint64_t offset, uint64_t word, uint8_t numBits) {
   constexpr int32_t kBitSize = 8 * sizeof(T);
   auto rawAddress = reinterpret_cast<char*>(target) + (offset / 8);
   auto bitOffset = offset & 7;
-  uint64_t mask = (numBits == 64 ? ~0UL : ((1UL << numBits) - 1)) << bitOffset;
+  uint64_t mask = (numBits == 64 ? ~0ULL : ((1ULL << numBits) - 1)) << bitOffset;
   T current;
   std::memcpy(&current, rawAddress, sizeof(T));
   current = (current & ~mask) | (mask & (word << bitOffset));
@@ -986,6 +1051,8 @@ inline void padToAlignment(
 
 /// Returns value with the order of the bytes reversed; for example, 0xaabb
 /// becomes 0xbbaa. Byte here always means exactly 8 bits.
+
+#ifndef _MSC_VER
 inline __int128_t builtin_bswap128(__int128_t value) {
 #if defined __has_builtin
 #if __has_builtin(__builtin_bswap128)
@@ -1000,6 +1067,7 @@ inline __int128_t builtin_bswap128(__int128_t value) {
 #undef VELOX_HAS_BUILTIN_BSWAP_INT128
 #endif
 }
+#endif
 
 /// Store `bits' into the memory region pointed by `byte', at `index' (bit
 /// index).  If `kSize' is 8, we store the whole byte directly; otherwise it

--- a/velox/common/base/CMakeLists.txt
+++ b/velox/common/base/CMakeLists.txt
@@ -83,6 +83,7 @@ velox_add_library(
   SuccinctPrinter.h
   TreeOfLosers.h
   XxHashInline.h
+  windows/BuiltinUtil.h
 )
 
 velox_link_libraries(
@@ -129,3 +130,8 @@ velox_add_library(velox_async_source INTERFACE HEADERS AsyncSource.h)
 velox_add_library(velox_lazy_cpu_thread_pool_executor INTERFACE HEADERS LazyCPUThreadPoolExecutor.h)
 
 velox_add_library(velox_exception_helper INTERFACE HEADERS ExceptionHelper.h)
+
+# Add Windows-specific glog defines
+if(WIN32)
+  velox_compile_definitions(velox_status PRIVATE GLOG_USE_GLOG_EXPORT)
+endif()

--- a/velox/common/base/CheckedArithmetic.h
+++ b/velox/common/base/CheckedArithmetic.h
@@ -21,12 +21,20 @@
 #include "folly/Likely.h"
 #include "velox/common/base/Exceptions.h"
 
+#ifdef _WIN32
+#include "velox/common/base/windows/BuiltinUtil.h"
+#endif
+
 namespace facebook::velox {
 
 template <typename T>
 T checkedPlus(T a, T b, const char* typeName = "integer") {
   T result;
+#ifdef _WIN32
+  bool overflow = facebook::velox::windows::builtin_add_overflow(a, b, &result);
+#else
   bool overflow = __builtin_add_overflow(a, b, &result);
+#endif
   if (UNLIKELY(overflow)) {
     VELOX_ARITHMETIC_ERROR("{} overflow: {} + {}", typeName, a, b);
   }
@@ -36,7 +44,11 @@ T checkedPlus(T a, T b, const char* typeName = "integer") {
 template <typename T>
 T checkedMinus(T a, T b, const char* typeName = "integer") {
   T result;
+#ifdef _WIN32
+  bool overflow = facebook::velox::windows::builtin_sub_overflow(a, b, &result);
+#else
   bool overflow = __builtin_sub_overflow(a, b, &result);
+#endif
   if (UNLIKELY(overflow)) {
     VELOX_ARITHMETIC_ERROR("{} overflow: {} - {}", typeName, a, b);
   }
@@ -46,7 +58,11 @@ T checkedMinus(T a, T b, const char* typeName = "integer") {
 template <typename T>
 T checkedMultiply(T a, T b, const char* typeName = "integer") {
   T result;
+#ifdef _WIN32
+  bool overflow = facebook::velox::windows::builtin_mul_overflow(a, b, &result);
+#else
   bool overflow = __builtin_mul_overflow(a, b, &result);
+#endif
   if (UNLIKELY(overflow)) {
     VELOX_ARITHMETIC_ERROR("{} overflow: {} * {}", typeName, a, b);
   }

--- a/velox/common/base/CountBits.h
+++ b/velox/common/base/CountBits.h
@@ -18,8 +18,38 @@
 
 #include <folly/CPortability.h>
 
+#ifdef _MSC_VER
+#include <type_traits>
+#endif
+
 namespace facebook::velox {
 
+#ifdef _MSC_VER
+template <
+    typename T,
+    typename = std::enable_if_t<std::is_integral_v<T> && (sizeof(T) <= 8)>>
+FOLLY_ALWAYS_INLINE int countDigits(T n) {
+  using Unsigned = std::make_unsigned_t<T>;
+  auto value = static_cast<Unsigned>(n);
+  int count = 1;
+  for (;;) {
+    if (value < 10) {
+      return count;
+    }
+    if (value < 100) {
+      return count + 1;
+    }
+    if (value < 1000) {
+      return count + 2;
+    }
+    if (value < 10000) {
+      return count + 3;
+    }
+    value /= 10000u;
+    count += 4;
+  }
+}
+#else
 // Copied from format.h of fmt.
 FOLLY_ALWAYS_INLINE int countDigits(__uint128_t n) {
   int count = 1;
@@ -40,5 +70,6 @@ FOLLY_ALWAYS_INLINE int countDigits(__uint128_t n) {
     count += 4;
   }
 }
+#endif
 
 } // namespace facebook::velox

--- a/velox/common/base/Fs.cpp
+++ b/velox/common/base/Fs.cpp
@@ -19,6 +19,79 @@
 #include <fmt/format.h>
 #include <glog/logging.h>
 
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <direct.h>
+#include <random>
+
+// Define permission constants for Windows
+#ifndef S_IRUSR
+#define S_IRUSR _S_IREAD
+#endif
+#ifndef S_IWUSR
+#define S_IWUSR _S_IWRITE
+#endif
+
+// Windows implementation of mkstemp
+inline int mkstemp(char* tmpl) {
+  // Find the XXXXXX pattern
+  char* xes = strstr(tmpl, "XXXXXX");
+  if (!xes || strlen(xes) != 6) {
+    return -1;
+  }
+
+  // Generate random suffix
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<> dis(0, 35);
+
+  const char* chars = "0123456789abcdefghijklmnopqrstuvwxyz";
+  for (int attempt = 0; attempt < 100; ++attempt) {
+    for (int i = 0; i < 6; ++i) {
+      xes[i] = chars[dis(gen)];
+    }
+
+    int fd = _open(
+        tmpl,
+        _O_RDWR | _O_CREAT | _O_EXCL | _O_BINARY,
+        _S_IREAD | _S_IWRITE);
+    if (fd != -1) {
+      return fd;
+    }
+  }
+  return -1;
+}
+
+// Windows implementation of mkdtemp
+inline char* mkdtemp(char* tmpl) {
+  // Find the XXXXXX pattern
+  char* xes = strstr(tmpl, "XXXXXX");
+  if (!xes || strlen(xes) != 6) {
+    return nullptr;
+  }
+
+  // Generate random suffix
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<> dis(0, 35);
+
+  const char* chars = "0123456789abcdefghijklmnopqrstuvwxyz";
+  for (int attempt = 0; attempt < 100; ++attempt) {
+    for (int i = 0; i < 6; ++i) {
+      xes[i] = chars[dis(gen)];
+    }
+
+    if (_mkdir(tmpl) == 0) {
+      return tmpl;
+    }
+  }
+  return nullptr;
+}
+#endif // _WIN32
+
 namespace facebook::velox::common {
 
 bool generateFileDirectory(const char* dirPath) {
@@ -38,10 +111,13 @@ std::optional<std::string> generateTempFilePath(
     const char* basePath,
     const char* prefix) {
   auto path = fmt::format("{}/velox_{}_XXXXXX", basePath, prefix);
-  auto fd = mkstemp(path.data());
+  auto fd = ::mkstemp(path.data());
   if (fd == -1) {
     return std::nullopt;
   }
+#ifdef _WIN32
+  _close(fd);
+#endif
   return path;
 }
 
@@ -49,7 +125,7 @@ std::optional<std::string> generateTempFolderPath(
     const char* basePath,
     const char* prefix) {
   auto path = fmt::format("{}/velox_{}_XXXXXX", basePath, prefix);
-  auto createdPath = mkdtemp(path.data());
+  auto createdPath = ::mkdtemp(path.data());
   if (createdPath == nullptr) {
     return std::nullopt;
   }

--- a/velox/common/base/Nulls.h
+++ b/velox/common/base/Nulls.h
@@ -32,7 +32,7 @@ constexpr char kNotNullByte = 0xff;
 
 // Null flags are generally uint64_t for efficient bit counting.
 constexpr uint64_t kNull64 = 0UL;
-constexpr uint64_t kNotNull64 = (~0UL);
+constexpr uint64_t kNotNull64 = (~0ULL);
 
 inline bool isBitNull(const uint64_t* bits, uint32_t index) {
   return isBitSet(bits, index) == kNull;

--- a/velox/common/base/Portability.h
+++ b/velox/common/base/Portability.h
@@ -21,6 +21,36 @@
 #include <cstdint>
 #include <mutex>
 
+#ifdef _MSC_VER
+#include <intrin.h>
+inline size_t count_trailing_zeros(uint64_t x) {
+  if (x == 0) return 64;
+  unsigned long index;
+  _BitScanForward64(&index, x);
+  return static_cast<size_t>(index);
+}
+
+inline size_t count_trailing_zeros_32bits(uint32_t x) {
+  if (x == 0) return 32;
+  unsigned long index;
+  _BitScanForward(&index, x);
+  return static_cast<size_t>(index);
+}
+
+inline size_t count_leading_zeros(uint64_t x) {
+  if (x == 0) return 64;
+  unsigned long index;
+  _BitScanReverse64(&index, x);
+  return 63 - static_cast<size_t>(index);
+}
+
+inline size_t count_leading_zeros_32bits(uint32_t x) {
+  if (x == 0) return 32;
+  unsigned long index;
+  _BitScanReverse(&index, x);
+  return 31 - static_cast<size_t>(index);
+}
+#else
 inline size_t count_trailing_zeros(uint64_t x) {
   return x == 0 ? 64 : __builtin_ctzll(x);
 }
@@ -36,6 +66,7 @@ inline size_t count_leading_zeros(uint64_t x) {
 inline size_t count_leading_zeros_32bits(uint32_t x) {
   return x == 0 ? 32 : __builtin_clz(x);
 }
+#endif
 
 namespace facebook::velox {
 

--- a/velox/common/base/SimdUtil-inl.h
+++ b/velox/common/base/SimdUtil-inl.h
@@ -15,6 +15,9 @@
  */
 
 #include <numeric>
+#ifdef _MSC_VER
+#include <folly/portability/Builtins.h>
+#endif
 
 #if XSIMD_WITH_NEON
 namespace xsimd::types {
@@ -1434,12 +1437,21 @@ struct Crc32<uint64_t, A> {
 
 template <typename T, typename A>
 xsimd::batch<T, A> iota(const A&) {
+#ifdef _MSC_VER
+  static const auto kMemo = [] {
+    constexpr int N = xsimd::batch<T, A>::size;
+    T tmp[N];
+    std::iota(tmp, tmp + N, T{0});
+    return xsimd::load_unaligned(tmp);
+  }();
+#else
   static const auto kMemo = ({
     constexpr int N = xsimd::batch<T, A>::size;
     T tmp[N];
     std::iota(tmp, tmp + N, 0);
     xsimd::load_unaligned(tmp);
   });
+#endif
   return kMemo;
 }
 

--- a/velox/common/base/TreeOfLosers.h
+++ b/velox/common/base/TreeOfLosers.h
@@ -51,6 +51,7 @@ class MergeStream {
   /// TreeOfLosers::nextWithEquals().
   virtual int32_t compare(const MergeStream& /*other*/) const {
     VELOX_UNSUPPORTED();
+    return 0; // Unreachable, but MSVC requires a return statement
   }
 };
 

--- a/velox/common/base/YyFlexLexerShim.cpp
+++ b/velox/common/base/YyFlexLexerShim.cpp
@@ -17,6 +17,13 @@
 
 #include "velox/common/base/Exceptions.h"
 
+#ifdef _MSC_VER
+// These methods are unreachable stubs that always throw via VELOX_FAIL. MSVC
+// does not treat VELOX_FAIL as [[noreturn]] in this context and emits C4716
+// ("must return a value"), which is promoted to an error under /WX.
+#pragma warning(disable : 4716)
+#endif
+
 // Provide a dedicated translation unit for yyFlexLexer so the linker has a
 // single, always-linked home for its vtable and typeinfo. Some builds,
 // especially mono-library builds with sanitizers, can otherwise fail to

--- a/velox/common/base/tests/BitUtilTest.cpp
+++ b/velox/common/base/tests/BitUtilTest.cpp
@@ -804,7 +804,7 @@ TEST_F(BitUtilTest, forBatches) {
       auto bitfield =
           reinterpret_cast<const uint64_t*>(bits)[index / 64] & mask;
       EXPECT_NE(0, bitfield & mask);
-      numSet += __builtin_popcountl(bitfield);
+      numSet += __builtin_popcountll(bitfield);
     });
     EXPECT_EQ(numOnes, numSet);
   };
@@ -850,25 +850,29 @@ TEST_F(BitUtilTest, rotateLeft64) {
   }
 }
 
+#ifndef _MSC_VER
 TEST_F(BitUtilTest, bswap128) {
   EXPECT_EQ(builtin_bswap128(10), HugeInt::build(720575940379279360, 0));
   EXPECT_EQ(
       builtin_bswap128(HugeInt::build(0x08FFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF)),
       -248);
 }
+#endif
 
 TEST_F(BitUtilTest, countLeadingZeros) {
   EXPECT_EQ(countLeadingZeros<uint64_t>(0), 64);
   EXPECT_EQ(countLeadingZeros<uint64_t>(1), 63);
-  EXPECT_EQ(countLeadingZeros<__uint128_t>(0), 128);
-  EXPECT_EQ(countLeadingZeros<__uint128_t>(1), 127);
-  EXPECT_EQ(countLeadingZeros<__uint128_t>(1), 127);
+#ifndef _MSC_VER
+  EXPECT_EQ(countLeadingZeros<uint128_t>(0), 128);
+  EXPECT_EQ(countLeadingZeros<uint128_t>(1), 127);
+  EXPECT_EQ(countLeadingZeros<uint128_t>(1), 127);
   EXPECT_EQ(
-      countLeadingZeros<__uint128_t>(
+      countLeadingZeros<uint128_t>(
           HugeInt::build(0x08FFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF)),
       4);
   EXPECT_EQ(
-      countLeadingZeros<__uint128_t>(HugeInt::build(0x08FFFFFFFFFFFFFF, 0)), 4);
+      countLeadingZeros<uint128_t>(HugeInt::build(0x08FFFFFFFFFFFFFF, 0)), 4);
+#endif
 }
 
 TEST_F(BitUtilTest, storeBitsToByte) {

--- a/velox/common/base/tests/ConcurrentCounterTest.cpp
+++ b/velox/common/base/tests/ConcurrentCounterTest.cpp
@@ -15,6 +15,9 @@
  */
 
 #include "velox/common/base/ConcurrentCounter.h"
+#ifdef _WIN32
+#include "velox/common/base/windows/FollyConcurrencyCompat.h"
+#endif
 
 #include <fmt/format.h>
 #include <folly/Random.h>

--- a/velox/common/base/tests/SplitBlockBloomFilterTest.cpp
+++ b/velox/common/base/tests/SplitBlockBloomFilterTest.cpp
@@ -21,6 +21,7 @@
 #include <gtest/gtest.h>
 
 #include <random>
+#include <cstring>
 
 namespace facebook::velox::test {
 namespace {
@@ -31,7 +32,8 @@ SplitBlockBloomFilter makeFilter(
     const Hasher& hasher,
     std::vector<SplitBlockBloomFilter::Block>& blocks) {
   blocks.resize(SplitBlockBloomFilter::numBlocks(values.size(), 0.01));
-  bzero(blocks.data(), blocks.size() * sizeof(SplitBlockBloomFilter::Block));
+  std::memset(
+      blocks.data(), 0, blocks.size() * sizeof(SplitBlockBloomFilter::Block));
   SplitBlockBloomFilter filter(blocks);
   for (auto& value : values) {
     filter.insert(hasher(value));

--- a/velox/common/base/windows/BuiltinUtil.h
+++ b/velox/common/base/windows/BuiltinUtil.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#ifdef _MSC_VER
+
+#include <limits>
+#include <type_traits>
+
+namespace facebook::velox::windows {
+
+template <typename T>
+inline bool builtin_add_overflow(T a, T b, T* result) {
+  static_assert(std::is_integral_v<T>, "T must be an integral type");
+  using Limits = std::numeric_limits<T>;
+
+  if constexpr (std::is_signed_v<T>) {
+    if ((b > 0 && a > Limits::max() - b) ||
+        (b < 0 && a < Limits::min() - b)) {
+      return true;
+    }
+  } else if (a > Limits::max() - b) {
+    return true;
+  }
+
+  *result = static_cast<T>(a + b);
+  return false;
+}
+
+template <typename T>
+inline bool builtin_sub_overflow(T a, T b, T* result) {
+  static_assert(std::is_integral_v<T>, "T must be an integral type");
+  using Limits = std::numeric_limits<T>;
+
+  if constexpr (std::is_signed_v<T>) {
+    if ((b < 0 && a > Limits::max() + b) ||
+        (b > 0 && a < Limits::min() + b)) {
+      return true;
+    }
+  } else if (a < b) {
+    return true;
+  }
+
+  *result = static_cast<T>(a - b);
+  return false;
+}
+
+template <typename T>
+inline bool builtin_mul_overflow(T a, T b, T* result) {
+  static_assert(std::is_integral_v<T>, "T must be an integral type");
+  using Limits = std::numeric_limits<T>;
+
+  if constexpr (std::is_signed_v<T>) {
+    if (a == 0 || b == 0) {
+      *result = 0;
+      return false;
+    }
+    if ((a == -1 && b == Limits::min()) ||
+        (b == -1 && a == Limits::min())) {
+      return true;
+    }
+    if (a > 0) {
+      if ((b > 0 && a > Limits::max() / b) ||
+          (b < 0 && b < Limits::min() / a)) {
+        return true;
+      }
+    } else if (b > 0) {
+      if (a < Limits::min() / b) {
+        return true;
+      }
+    } else if (b < Limits::max() / a) {
+      return true;
+    }
+  } else if (b != 0 && a > Limits::max() / b) {
+    return true;
+  }
+
+  *result = static_cast<T>(a * b);
+  return false;
+}
+
+} // namespace facebook::velox::windows
+
+#endif // _MSC_VER

--- a/velox/common/base/windows/FollyConcurrencyCompat.h
+++ b/velox/common/base/windows/FollyConcurrencyCompat.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+// Windows build compatibility shim.
+//
+// Velox calls folly::available_concurrency(), a cgroup-aware helper that was
+// added to folly after the folly version pinned by the Windows vcpkg manifest.
+// The pinned folly only provides folly::hardware_concurrency(). Windows has no
+// cgroup CPU accounting, so hardware_concurrency() is an exact substitute.
+//
+// This header is only included on Windows; POSIX builds use folly's real
+// available_concurrency() and never see this shim.
+#ifdef _WIN32
+#include <folly/system/HardwareConcurrency.h>
+
+namespace folly {
+inline unsigned int available_concurrency() noexcept {
+  return hardware_concurrency();
+}
+} // namespace folly
+#endif // _WIN32


### PR DESCRIPTION
## Summary

Make `velox/common/base` more MSVC-portable with narrowly scoped Windows compatibility helpers.

This is split out from the broad Windows/MSVC support PR so the foundational `common/base` changes can be reviewed independently from `velox/type`, generated parsers, source modules, and workflow policy.

## Scope

- Add minimal MSVC helpers for checked arithmetic overflow detection.
- Add Windows temp file/folder helpers used by `Fs.cpp`.
- Use Folly's MSVC builtin compatibility for common bit/SIMD helpers and replace the GNU statement-expression in `simd::iota` on MSVC.
- Keep 128-bit helpers out of the MSVC path until the later `velox/type` PR adds the Windows Int128 shim.
- Add small test portability fixes in `common/base` tests.

## Validation

Reviewed for minimality/correctness. The staged patch applies cleanly on top of the CMake foundation branch (#18092). Local stacked MSVC configure succeeds; direct `velox_common_base` target build is currently blocked earlier by known non-PR gaps in `external/date` endian macros and `common/encode`/glog consumption.

## Context

- Original broad PR: https://github.com/facebookincubator/velox/pull/17897
- Maintainer feedback about encapsulation: https://github.com/facebookincubator/velox/pull/17897#issuecomment-4846635925
- Discussion: https://github.com/facebookincubator/velox/discussions/18005