### PR TITLE
fix(row): Add MSVC portability casts

### DIFF
--- a/velox/row/CompactRow.cpp
+++ b/velox/row/CompactRow.cpp
@@ -281,10 +281,10 @@ void CompactRow::initialize(const TypePtr& type) {
 namespace {
 std::optional<int32_t> fixedValueSize(const TypePtr& type) {
   if (type->isTimestamp()) {
-    return sizeof(int64_t);
+    return static_cast<int32_t>(sizeof(int64_t));
   }
   if (type->isFixedWidth()) {
-    return type->cppSizeInBytes();
+    return static_cast<int32_t>(type->cppSizeInBytes());
   }
   return std::nullopt;
 }
@@ -304,7 +304,7 @@ std::optional<int32_t> CompactRow::fixedRowSize(const RowTypePtr& rowType) {
     }
   }
 
-  return size;
+  return static_cast<int32_t>(size);
 }
 
 int32_t CompactRow::rowSize(vector_size_t index) const {

--- a/velox/row/UnsafeRowFast.cpp
+++ b/velox/row/UnsafeRowFast.cpp
@@ -46,7 +46,7 @@ std::optional<int32_t> UnsafeRowFast::fixedRowSize(const RowTypePtr& rowType) {
   const size_t numFields = rowType->size();
   const size_t nullLength = alignBits(numFields);
 
-  return nullLength + numFields * kFieldWidth;
+  return static_cast<int32_t>(nullLength + numFields * kFieldWidth);
 }
 
 UnsafeRowFast::UnsafeRowFast(const RowVectorPtr& vector)


### PR DESCRIPTION
## Summary

Make `velox/row` serialization helpers compile under MSVC by adding explicit casts where `int32_t` return values are computed from `size_t` intermediates.

This is a standalone subfolder split from the broader Windows/MSVC support work.

## Scope

- `velox/row/CompactRow.cpp`
- `velox/row/UnsafeRowFast.cpp`

No CMake, workflow, platform shim, generated parser, or `velox/type` changes are included.

## Validation

Reviewed for minimality/correctness. The diff is limited to explicit casts and does not change non-Windows behavior.

## Context

- Original broad PR: https://github.com/facebookincubator/velox/pull/17897
- Maintainer feedback about encapsulation: https://github.com/facebookincubator/velox/pull/17897#issuecomment-4846635925
- Discussion: https://github.com/facebookincubator/velox/discussions/18005