### PR TITLE
Make connectors MSVC-portable

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -187,6 +187,9 @@ class ConnectorInsertTableHandle : public ISerializable {
 
   folly::dynamic serialize() const override {
     VELOX_NYI();
+#ifdef _MSC_VER
+    return nullptr; // Unreachable; MSVC C4716 requires a return value.
+#endif
   }
 };
 
@@ -342,6 +345,9 @@ class DataSource {
   /// stay live until after the destruction of the delegate.
   virtual std::shared_ptr<wave::WaveDataSource> toWaveDataSource() {
     VELOX_UNSUPPORTED();
+#ifdef _MSC_VER
+    return nullptr; // Unreachable; MSVC C4716 requires a return value.
+#endif
   }
 
   /// Invoked by table scan close to cancel any inflight async operations
@@ -434,6 +440,9 @@ class IndexSource {
         vector_size_t size,
         velox::ContinueFuture& future) {
       VELOX_UNSUPPORTED();
+#ifdef _MSC_VER
+      return std::nullopt; // Unreachable; MSVC C4716 requires a return value.
+#endif
     }
   };
 

--- a/velox/connectors/tpch/TpchConnector.h
+++ b/velox/connectors/tpch/TpchConnector.h
@@ -230,6 +230,9 @@ class TpchConnector final : public Connector {
       ConnectorQueryCtx* /*connectorQueryCtx*/,
       CommitStrategy /*commitStrategy*/) override final {
     VELOX_NYI("TpchConnector does not support data sink.");
+#ifdef _MSC_VER
+    return nullptr; // Unreachable, but MSVC requires a return statement.
+#endif
   }
 
   static void registerSerDe() {


### PR DESCRIPTION
## Summary

Make `velox/connectors` MSVC-portable by adding MSVC-only unreachable returns after methods that always throw via Velox unsupported/not-yet-implemented helpers.

This is a standalone subfolder split from the broader Windows/MSVC support work.

## Scope

- `velox/connectors/Connector.h`
- `velox/connectors/tpch/TpchConnector.h`

No CMake, workflow, platform shim, generated parser, vector, common/base, or type changes are included.

## Validation

Reviewed for minimality/correctness. The diff is `_MSC_VER`-guarded and does not change non-Windows behavior.

## Context

- Original broad PR: https://github.com/facebookincubator/velox/pull/17897
- Maintainer feedback about encapsulation: https://github.com/facebookincubator/velox/pull/17897#issuecomment-4846635925
- Discussion: https://github.com/facebookincubator/velox/discussions/18005