### PR TITLE
fix(window): Fail gracefully on oversized window partitions (#18102)

### DIFF
--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 #include "velox/exec/Window.h"
+
+#include <limits>
+
+#include "velox/common/testutil/TestValue.h"
 #include "velox/exec/OperatorType.h"
 #include "velox/exec/OperatorUtils.h"
 #include "velox/exec/Task.h"
@@ -264,6 +268,22 @@ bool Window::supportRowsStreaming() {
 }
 
 void Window::addInput(RowVectorPtr input) {
+  common::testutil::TestValue::adjust(
+      "facebook::velox::exec::Window::addInput", &numRows_);
+
+  // numRows_ is a vector_size_t (int32) that drives isFinished() / getOutput()
+  // accounting. Guard it before delegating to the build: this bounds the total
+  // row count, which in turn bounds every per-build int32 counter that only
+  // counts a subset of the fed rows. In particular RowsStreamingWindowBuild's
+  // pendingRowCount_ increments inside windowBuild_->addInput() and, for a
+  // RANGE frame with one huge peer group, never flushes - so guarding after
+  // delegation would be too late to keep it from overflowing.
+  VELOX_USER_CHECK_LE(
+      static_cast<int64_t>(numRows_) + input->size(),
+      std::numeric_limits<vector_size_t>::max(),
+      "Window operator cannot process more than {} rows",
+      std::numeric_limits<vector_size_t>::max());
+
   windowBuild_->addInput(input);
   numRows_ += input->size();
 }

--- a/velox/exec/tests/WindowTest.cpp
+++ b/velox/exec/tests/WindowTest.cpp
@@ -377,6 +377,92 @@ DEBUG_ONLY_TEST_F(WindowTest, aggWindowResultMismatch) {
   ASSERT_TRUE(isStreamCreated.load());
 }
 
+DEBUG_ONLY_TEST_F(WindowTest, singlePartitionRowCountLimit) {
+  // A single window partition is limited to vector_size_t (int32) rows. Inject
+  // a count at the limit so the next row append would overflow, and verify the
+  // operator fails with a catchable user error rather than overflowing and
+  // aborting the process.
+  auto data = makeRowVector({"c0"}, {makeFlatVector<int64_t>({1, 2, 3, 4, 5})});
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .window({"sum(c0) over (order by c0)"})
+                  .planNode();
+
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::exec::window::SortWindowBuild::addDecodedInputRow",
+      std::function<void(vector_size_t*)>([](vector_size_t* numRows) {
+        *numRows = std::numeric_limits<vector_size_t>::max();
+      }));
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()),
+      "Window operator cannot process more than");
+}
+
+DEBUG_ONLY_TEST_F(WindowTest, subPartitionedRowCountLimit) {
+  // The same limit applies to SubPartitionedSortWindowBuild, whose own counter
+  // aggregates all sub-partitions. Force sub-partitioning and inject a count at
+  // the limit; the next batch must fail cleanly rather than overflow.
+  auto data = makeRowVector({"c0"}, {makeFlatVector<int64_t>({1, 2, 3, 4, 5})});
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .window({"sum(c0) over (order by c0)"})
+                  .planNode();
+
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::exec::window::SubPartitionedSortWindowBuild::addInput",
+      std::function<void(vector_size_t*)>([](vector_size_t* numRows) {
+        *numRows = std::numeric_limits<vector_size_t>::max();
+      }));
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan)
+          .config(core::QueryConfig::kWindowNumSubPartitions, "4")
+          .copyResults(pool()),
+      "Window operator cannot process more than");
+}
+
+DEBUG_ONLY_TEST_F(WindowTest, operatorRowCountLimit) {
+  // The Window operator keeps its own vector_size_t (int32) row counter that
+  // feeds isFinished()/getOutput() accounting and bounds every per-build int32
+  // counter (e.g. RowsStreamingWindowBuild::pendingRowCount_). The guard runs
+  // before delegating to the build, so inject a count at the limit and verify
+  // the batch is rejected before it reaches the streaming build.
+  auto data = makeRowVector({"c0"}, {makeFlatVector<int64_t>({1, 2, 3, 4, 5})});
+
+  // orderBy() + streamingWindow() selects RowsStreamingWindowBuild, the path
+  // where the operator counter is the only guard.
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .orderBy({"c0"}, false)
+                  .streamingWindow(
+                      {"rank() over (order by c0 rows unbounded preceding)"})
+                  .planNode();
+
+  std::atomic_bool isStreamCreated{false};
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::exec::window::RowsStreamingWindowBuild::RowsStreamingWindowBuild",
+      std::function<void(window::RowsStreamingWindowBuild*)>(
+          [&](window::RowsStreamingWindowBuild*) {
+            isStreamCreated.store(true);
+          }));
+
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::exec::Window::addInput",
+      std::function<void(vector_size_t*)>([](vector_size_t* numRows) {
+        *numRows = std::numeric_limits<vector_size_t>::max();
+      }));
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()),
+      "Window operator cannot process more than");
+
+  // The guard must have fired on the rows-streaming path, not a sort build.
+  ASSERT_TRUE(isStreamCreated.load());
+}
+
 DEBUG_ONLY_TEST_F(WindowTest, rankRowStreamingWindowBuild) {
   auto data = makeRowVector(
       {"c1"},

--- a/velox/exec/window/SortWindowBuild.cpp
+++ b/velox/exec/window/SortWindowBuild.cpp
@@ -15,6 +15,10 @@
  */
 
 #include "velox/exec/window/SortWindowBuild.h"
+
+#include <limits>
+
+#include "velox/common/testutil/TestValue.h"
 #include "velox/exec/MemoryReclaimer.h"
 #include "velox/exec/Window.h"
 
@@ -85,6 +89,22 @@ void SortWindowBuild::addInput(RowVectorPtr input) {
 void SortWindowBuild::addDecodedInputRow(
     std::vector<DecodedVector>& decodedInputVectors,
     vector_size_t row) {
+  common::testutil::TestValue::adjust(
+      "facebook::velox::exec::window::SortWindowBuild::addDecodedInputRow",
+      &numRows_);
+
+  // sortPartitions() indexes every buffered row with a vector_size_t (int32),
+  // so a sort-based build cannot hold more than that many rows. Enforce the
+  // limit here, the one path every row append goes through (including
+  // SubPartitionedSortWindowBuild, which calls it directly), so numRows_ cannot
+  // overflow. Otherwise sortPartitions() would resize sortedRows_ to a huge
+  // size, throw std::length_error, and abort the whole process.
+  VELOX_USER_CHECK_LT(
+      numRows_,
+      std::numeric_limits<vector_size_t>::max(),
+      "Window operator cannot process more than {} rows",
+      std::numeric_limits<vector_size_t>::max());
+
   char* newRow = data_->newRow();
 
   for (auto col = 0; col < inputChannels_.size(); ++col) {

--- a/velox/exec/window/SubPartitionedSortWindowBuild.cpp
+++ b/velox/exec/window/SubPartitionedSortWindowBuild.cpp
@@ -15,6 +15,10 @@
  */
 
 #include "velox/exec/window/SubPartitionedSortWindowBuild.h"
+
+#include <limits>
+
+#include "velox/common/testutil/TestValue.h"
 #include "velox/exec/MemoryReclaimer.h"
 
 namespace facebook::velox::exec::window {
@@ -57,6 +61,18 @@ SubPartitionedSortWindowBuild::SubPartitionedSortWindowBuild(
 
 void SubPartitionedSortWindowBuild::addInput(RowVectorPtr input) {
   VELOX_CHECK_LT(currentSubPartition_, 0);
+
+  common::testutil::TestValue::adjust(
+      "facebook::velox::exec::window::SubPartitionedSortWindowBuild::addInput",
+      &numRows_);
+
+  // numRows_ (a vector_size_t / int32) counts all rows across sub-partitions.
+  // Fail before it overflows.
+  VELOX_USER_CHECK_LE(
+      static_cast<int64_t>(numRows_) + input->size(),
+      std::numeric_limits<vector_size_t>::max(),
+      "Window operator cannot process more than {} rows",
+      std::numeric_limits<vector_size_t>::max());
 
   subPartitionIdsBuffer_.resize(input->size());
   subPartitioningFunction_->partition(*input, subPartitionIdsBuffer_);


### PR DESCRIPTION
Summary:

A window with no `PARTITION BY` puts every input row into a single partition, gathered into one `SortWindowBuild`. A minimal shape is:

    SELECT sum(x) OVER () FROM t

When that single partition holds more than 2^31 rows, the operator aborts the whole worker (killing every query running on it) with:

    terminate called after throwing an instance of 'std::length_error'
      what():  vector::_M_default_append

Why it happens: `SortWindowBuild` counts rows in `numRows_`, a `vector_size_t` (int32), incremented once per row. Past 2^31 rows `numRows_` overflows to a negative value. At end of input `sortPartitions()` calls `sortedRows_.resize(numRows_)`. `sortedRows_` is a `std::vector<char*>`, so the negative count converts to a huge `size_t`, exceeds the vector's `max_size()`, and `resize` throws `std::length_error`. Nothing catches it, so `std::terminate` aborts the process.

Several `vector_size_t` (int32) row counters are at risk. The window build's own counter feeds `sortedRows_.resize()` (the crash above). The `Window` operator keeps a separate counter that drives `isFinished()` / `getOutput()` accounting, and the streaming builds keep their own per-build counters (e.g. `RowsStreamingWindowBuild::pendingRowCount_`, which for a RANGE frame with one huge peer group never flushes and increments once per row). The fix adds a `VELOX_USER_CHECK` before each can overflow: in `SortWindowBuild::addDecodedInputRow` — the single path every row goes through, including the calls from `SubPartitionedSortWindowBuild` — on `SubPartitionedSortWindowBuild`'s own counter, which aggregates all sub-partitions, and in `Window::addInput` on the operator counter, placed *before* delegating to the build. Guarding the operator total before delegation bounds the total row count, which in turn bounds every per-build counter (each only ever counts a subset of the fed rows), so none of them — including `pendingRowCount_`, which increments inside the build — can overflow. The offending query fails cleanly and the worker survives. Actually processing more than 2^31 rows in one partition would require widening the window build's row indexing to 64-bit and is left as a follow-up.

Differential Revision: D111577883


