### PR TITLE
refactor: Decouple Parquet row-group byte targeting from writer.max-target-file-size

### DIFF
--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -639,7 +639,8 @@ std::shared_ptr<dwio::common::WriterOptions> HiveDataSink::createWriterOptions(
   options->sessionTimezoneName = connectorQueryCtx_->sessionTimezone();
   options->adjustTimestampToTimezone =
       connectorQueryCtx_->adjustTimestampToTimezone();
-  options->maxTargetFileSizeBytes = maxTargetFileBytes_;
+  options->maxTargetFileSizeBytes =
+      (isBucketed() || sortWrite()) ? 0 : maxTargetFileBytes_;
   if (options->formatSpecificOptions == nullptr) {
     auto formatScopedConfigs = makeFormatScopedConfigs(
         *hiveConfig_,

--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -1200,20 +1200,23 @@ TEST_F(
     maxTargetFileSizeDoesNotAffectBucketedParquetRowGroups) {
   connectorSessionProperties_->set(
       HiveConfig::kParquetMaxTargetFileSizeSession, "8KB");
+  constexpr uint64_t kMaxTargetFileSizeBytes = 8 * 1024;
 
   auto writeOptions = std::make_shared<dwio::common::WriterOptions>();
   writeOptions->compressionKind = CompressionKind::CompressionKind_NONE;
 
+  auto rowType = ROW("payload", VARCHAR());
+
   auto bucketProperty = std::make_shared<HiveBucketProperty>(
       HiveBucketProperty::Kind::kHiveCompatible,
       1,
-      std::vector<std::string>{"c0"},
-      std::vector<TypePtr>{BIGINT()},
+      std::vector<std::string>{"payload"},
+      std::vector<TypePtr>{VARCHAR()},
       std::vector<std::shared_ptr<const HiveSortingColumn>>{});
 
   const auto outputDirectory = TempDirectoryPath::create();
   auto dataSink = createDataSink(
-      rowType_,
+      rowType,
       outputDirectory->getPath(),
       dwio::common::FileFormat::PARQUET,
       {},
@@ -1221,23 +1224,16 @@ TEST_F(
       writeOptions);
 
   constexpr int32_t kNumRows = 500;
+  constexpr int32_t kNumBatches = 5;
   const std::string payload(512, 'x');
-  const auto makeBatch = [&]() {
-    return makeRowVector({
-        makeFlatVector<int64_t>(kNumRows, folly::identity),
-        makeFlatVector<int32_t>(kNumRows, [](auto row) { return row * 2; }),
-        makeFlatVector<int16_t>(kNumRows, [](auto row) { return row % 100; }),
-        makeFlatVector<float>(kNumRows, [](auto row) { return row * 1.0f; }),
-        makeFlatVector<double>(kNumRows, [](auto row) { return row * 1.0; }),
-        makeFlatVector<StringView>(
-            kNumRows, [&](auto /*row*/) { return StringView(payload); }),
-        makeFlatVector<bool>(kNumRows, [](auto row) { return row % 2 == 0; }),
-    });
-  };
+  auto batch = makeRowVector({makeFlatVector<std::string>(
+      kNumRows, [&](auto /*row*/) { return payload; })});
 
-  const int numBatches = 5;
-  for (int i = 0; i < numBatches; ++i) {
-    dataSink->appendData(makeBatch());
+  // About 2500 * 512B = 1.3MB is written here: far above the 8KB file-size
+  // target. Bucketed writes do not rotate, so row-group sizing must ignore the
+  // file-size target and keep all rows in one default-sized row group.
+  for (int i = 0; i < kNumBatches; ++i) {
+    dataSink->appendData(batch);
   }
   ASSERT_TRUE(dataSink->finish());
   dataSink->close();
@@ -1254,8 +1250,9 @@ TEST_F(
   auto reader = std::make_unique<facebook::velox::parquet::ParquetReader>(
       std::move(bufferedInput), readerOpts);
   auto fileMeta = reader->fileMetaData();
-  EXPECT_EQ(fileMeta.numRowGroups(), 1);
-  EXPECT_EQ(fileMeta.rowGroup(0).numRows(), kNumRows * numBatches);
+  EXPECT_GT(kNumRows * kNumBatches * payload.size(), kMaxTargetFileSizeBytes);
+  EXPECT_EQ(1, fileMeta.numRowGroups());
+  EXPECT_EQ(kNumRows * kNumBatches, fileMeta.rowGroup(0).numRows());
 }
 #endif
 

--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -1194,6 +1194,69 @@ TEST_F(HiveDataSinkTest, flushPolicyWithParquet) {
   EXPECT_EQ(fileMeta.numRowGroups(), 10);
   EXPECT_EQ(fileMeta.rowGroup(0).numRows(), 500);
 }
+
+TEST_F(
+    HiveDataSinkTest,
+    maxTargetFileSizeDoesNotAffectBucketedParquetRowGroups) {
+  connectorSessionProperties_->set(
+      HiveConfig::kParquetMaxTargetFileSizeSession, "8KB");
+
+  auto writeOptions = std::make_shared<dwio::common::WriterOptions>();
+  writeOptions->compressionKind = CompressionKind::CompressionKind_NONE;
+
+  auto bucketProperty = std::make_shared<HiveBucketProperty>(
+      HiveBucketProperty::Kind::kHiveCompatible,
+      1,
+      std::vector<std::string>{"c0"},
+      std::vector<TypePtr>{BIGINT()},
+      std::vector<std::shared_ptr<const HiveSortingColumn>>{});
+
+  const auto outputDirectory = TempDirectoryPath::create();
+  auto dataSink = createDataSink(
+      rowType_,
+      outputDirectory->getPath(),
+      dwio::common::FileFormat::PARQUET,
+      {},
+      bucketProperty,
+      writeOptions);
+
+  constexpr int32_t kNumRows = 500;
+  const std::string payload(512, 'x');
+  const auto makeBatch = [&]() {
+    return makeRowVector({
+        makeFlatVector<int64_t>(kNumRows, folly::identity),
+        makeFlatVector<int32_t>(kNumRows, [](auto row) { return row * 2; }),
+        makeFlatVector<int16_t>(kNumRows, [](auto row) { return row % 100; }),
+        makeFlatVector<float>(kNumRows, [](auto row) { return row * 1.0f; }),
+        makeFlatVector<double>(kNumRows, [](auto row) { return row * 1.0; }),
+        makeFlatVector<StringView>(
+            kNumRows, [&](auto /*row*/) { return StringView(payload); }),
+        makeFlatVector<bool>(kNumRows, [](auto row) { return row % 2 == 0; }),
+    });
+  };
+
+  const int numBatches = 5;
+  for (int i = 0; i < numBatches; ++i) {
+    dataSink->appendData(makeBatch());
+  }
+  ASSERT_TRUE(dataSink->finish());
+  dataSink->close();
+
+  dwio::common::ReaderOptions readerOpts(pool_.get());
+  readerOpts.setDataIoStats(dataIoStats_);
+  readerOpts.setMetadataIoStats(metadataIoStats_);
+  const std::vector<std::string> filePaths =
+      listFiles(outputDirectory->getPath());
+  ASSERT_EQ(filePaths.size(), 1);
+
+  auto bufferedInput = std::make_unique<dwio::common::BufferedInput>(
+      std::make_shared<LocalReadFile>(filePaths[0]), readerOpts.memoryPool());
+  auto reader = std::make_unique<facebook::velox::parquet::ParquetReader>(
+      std::move(bufferedInput), readerOpts);
+  auto fileMeta = reader->fileMetaData();
+  EXPECT_EQ(fileMeta.numRowGroups(), 1);
+  EXPECT_EQ(fileMeta.rowGroup(0).numRows(), kNumRows * numBatches);
+}
 #endif
 
 TEST_F(HiveDataSinkTest, flushPolicyWithDWRF) {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -1069,16 +1069,19 @@ Parquet Options (prefix ``hive.parquet.``)
        "1GB". Zero means no limit (default). File rotation is not supported for bucketed tables or
        sorted writes.
 
-       Parquet tracks row-group bytes and target file size independently. The
-       row-group byte target comes from ``WriterOptions.flushPolicyFactory`` if
-       provided, or falls back to the default 128MB. When this setting is
-       configured, the writer may also flush the current row group early so the
-       file size is visible to the caller and file rotation can happen once the
-       current file reaches ``writer.max-target-file-size``.
+      Parquet tracks row-group limits and target file size independently.
+      ``writer.max-target-file-size`` is configurable and controls file
+      rotation. Row-group limits are fixed and not user-configurable: a row
+      group is bounded by a soft byte target of about 128MB and a hard row
+      count cap of about 1M rows.
 
-       For Parquet, this row-group byte threshold is a soft target, not a hard bound: row groups may
-       exceed it slightly because the writer flushes after buffered bytes reach or exceed the target,
-       while Arrow enforces the row-count cap separately. Session:
+      When this setting is configured, the writer may also flush the current
+      row group early so the file size is visible to the caller and file
+      rotation can happen once the current file reaches
+      ``writer.max-target-file-size``. For Parquet, the row-group byte
+      threshold is a soft target, not a hard bound: row groups may exceed it
+      slightly because the writer flushes after buffered bytes reach or exceed
+      the target. The row-count cap is enforced as a hard bound. Session:
        ``parquet_writer_max_target_file_size``.
    * - ``writer.enable-dictionary``
      - bool

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -1067,7 +1067,19 @@ Parquet Options (prefix ``hive.parquet.``)
      - Maximum target file size for Parquet writers. When a file exceeds this size during writing, the writer
        closes the current file and starts writing to a new file. Accepts human-readable values like
        "1GB". Zero means no limit (default). File rotation is not supported for bucketed tables or
-       sorted writes. Session: ``parquet_writer_max_target_file_size``.
+       sorted writes.
+
+       Parquet tracks row-group bytes and target file size independently. The
+       row-group byte target comes from ``WriterOptions.flushPolicyFactory`` if
+       provided, or falls back to the default 128MB. When this setting is
+       configured, the writer may also flush the current row group early so the
+       file size is visible to the caller and file rotation can happen once the
+       current file reaches ``writer.max-target-file-size``.
+
+       For Parquet, this row-group byte threshold is a soft target, not a hard bound: row groups may
+       exceed it slightly because the writer flushes after buffered bytes reach or exceed the target,
+       while Arrow enforces the row-count cap separately. Session:
+       ``parquet_writer_max_target_file_size``.
    * - ``writer.enable-dictionary``
      - bool
      - true

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -1069,20 +1069,14 @@ Parquet Options (prefix ``hive.parquet.``)
        "1GB". Zero means no limit (default). File rotation is not supported for bucketed tables or
        sorted writes.
 
-      Parquet tracks row-group limits and target file size independently.
-      ``writer.max-target-file-size`` is configurable and controls file
-      rotation. Row-group limits are fixed and not user-configurable: a row
-      group is bounded by a soft byte target of about 128MB and a hard row
-      count cap of about 1M rows.
+      Session: ``parquet_writer_max_target_file_size``.
 
-      When this setting is configured, the writer may also flush the current
-      row group early so the file size is visible to the caller and file
-      rotation can happen once the current file reaches
-      ``writer.max-target-file-size``. For Parquet, the row-group byte
-      threshold is a soft target, not a hard bound: row groups may exceed it
-      slightly because the writer flushes after buffered bytes reach or exceed
-      the target. The row-count cap is enforced as a hard bound. Session:
-       ``parquet_writer_max_target_file_size``.
+      Row-group sizing is independent of this setting and is not user-configurable: a row group is
+      flushed at a 128MB byte target or 1,048,576 rows, whichever comes first. The byte target is
+      soft - a row group may slightly exceed it, since the writer flushes only after buffered bytes
+      reach the target; the row count is a hard cap. When ``writer.max-target-file-size`` is set,
+      the writer may flush the current row group early so the accumulated file size is visible and
+      rotation can occur.
    * - ``writer.enable-dictionary``
      - bool
      - true

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -912,41 +912,36 @@ TEST_F(ParquetWriterTest, flushRowGroupByBufferedSize) {
 
 TEST_F(ParquetWriterTest, flushRowGroupByMaxTargetFileSize) {
   constexpr int64_t kNumRows = 64;
-  const std::string payload(512, 'x');
+  constexpr uint64_t kMaxTargetFileSizeBytes = 8 * 1024;
 
   dwio::common::WriterOptions options;
   options.memoryPool = rootPool_.get();
   options.compressionKind = CompressionKind::CompressionKind_NONE;
-  options.maxTargetFileSizeBytes = 8 * 1024;
-  options.flushPolicyFactory = []() {
-    return std::make_unique<DefaultFlushPolicy>(
-        /*rowsInRowGroup=*/1'024 * 1'024,
-        /*bytesInRowGroup=*/128 * 1'024 * 1'024);
-  };
+  options.maxTargetFileSizeBytes = kMaxTargetFileSizeBytes;
 
-  const auto schema = ROW({"payload"}, {VARCHAR()});
+  const auto schema = ROW("payload", VARCHAR());
   ParquetWriterOptions writerOptions;
   writerOptions.enableDictionary = false;
   auto writerWithSink = makeWriterWithSink(schema, options, writerOptions);
 
-  const auto makeBatch = [&]() {
-    return makeRowVector({makeFlatVector<StringView>(
-        kNumRows, [&](auto /*row*/) { return StringView(payload); })});
-  };
+  const std::string payload(512, 'x');
+  auto batch = makeRowVector({makeFlatVector<std::string>(
+      kNumRows, [&](auto /*row*/) { return payload; })});
 
-  writerWithSink.writer->write(makeBatch());
+  // Verify that maxTargetFileSizeBytes, not the default 128MB row-group
+  // target, closes the current row group so callers can observe file size.
+  // Each batch is roughly 64 * 512B = 32KB: well above the 8KB file-size
+  // target, but far below the default row-group byte target.
+  writerWithSink.writer->write(batch);
 
-  // The writer should flush the current row group early so file-size-based
-  // rotation can observe written bytes even though the row-group target is
-  // much larger than maxTargetFileSizeBytes.
-  EXPECT_GT(writerWithSink.sink->size(), options.maxTargetFileSizeBytes);
+  EXPECT_GT(writerWithSink.sink->size(), kMaxTargetFileSizeBytes);
 
-  writerWithSink.writer->write(makeBatch());
+  writerWithSink.writer->write(batch);
   writerWithSink.writer->close();
 
   const auto reader = createReaderInMemory(*writerWithSink.sink);
   EXPECT_EQ(2 * kNumRows, reader->numberOfRows());
-  EXPECT_EQ(reader->fileMetaData().numRowGroups(), 2);
+  EXPECT_EQ(2, reader->fileMetaData().numRowGroups());
 }
 
 TEST_F(ParquetWriterTest, flushEmptyRowGroup) {

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -901,9 +901,6 @@ TEST_F(ParquetWriterTest, flushRowGroupByMaxTargetFileSize) {
   constexpr int64_t kNumRows = 64;
   const std::string payload(512, 'x');
 
-  ParquetWriterOptions writerOptions;
-  writerOptions.enableDictionary = false;
-
   dwio::common::WriterOptions options;
   options.memoryPool = rootPool_.get();
   options.compressionKind = CompressionKind::CompressionKind_NONE;
@@ -918,6 +915,9 @@ TEST_F(ParquetWriterTest, flushRowGroupByMaxTargetFileSize) {
   auto sink = std::make_unique<MemorySink>(
       200 * 1024 * 1024, FileSink::Options{.pool = leafPool_.get()});
   auto* sinkPtr = sink.get();
+
+  ParquetWriterOptions writerOptions;
+  writerOptions.enableDictionary = false;
   options.formatSpecificOptions =
       std::make_shared<ParquetWriterOptions>(writerOptions);
   auto writer = std::make_unique<facebook::velox::parquet::Writer>(
@@ -935,14 +935,14 @@ TEST_F(ParquetWriterTest, flushRowGroupByMaxTargetFileSize) {
   // The writer should flush the current row group early so file-size-based
   // rotation can observe written bytes even though the row-group target is
   // much larger than maxTargetFileSizeBytes.
-  EXPECT_GT(sinkPtr->size(), 0);
+  EXPECT_GT(sinkPtr->size(), options.maxTargetFileSizeBytes);
 
   writer->write(makeBatch());
   writer->close();
 
   const auto reader = createReaderInMemory(*sinkPtr);
   EXPECT_EQ(2 * kNumRows, reader->numberOfRows());
-  EXPECT_GE(reader->fileMetaData().numRowGroups(), 2);
+  EXPECT_EQ(reader->fileMetaData().numRowGroups(), 2);
 }
 
 TEST_F(ParquetWriterTest, flushEmptyRowGroup) {

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -897,6 +897,54 @@ TEST_F(ParquetWriterTest, flushRowGroupByBufferedSize) {
   testBatches(20, 2, 100);
 }
 
+TEST_F(ParquetWriterTest, flushRowGroupByMaxTargetFileSize) {
+  constexpr int64_t kNumRows = 64;
+  const std::string payload(512, 'x');
+
+  ParquetWriterOptions writerOptions;
+  writerOptions.enableDictionary = false;
+
+  dwio::common::WriterOptions options;
+  options.memoryPool = rootPool_.get();
+  options.compressionKind = CompressionKind::CompressionKind_NONE;
+  options.maxTargetFileSizeBytes = 8 * 1024;
+  options.flushPolicyFactory = []() {
+    return std::make_unique<DefaultFlushPolicy>(
+        /*rowsInRowGroup=*/1'024 * 1'024,
+        /*bytesInRowGroup=*/128 * 1'024 * 1'024);
+  };
+
+  const auto schema = ROW({"id", "payload"}, {BIGINT(), VARCHAR()});
+  auto sink = std::make_unique<MemorySink>(
+      200 * 1024 * 1024, FileSink::Options{.pool = leafPool_.get()});
+  auto* sinkPtr = sink.get();
+  options.formatSpecificOptions =
+      std::make_shared<ParquetWriterOptions>(writerOptions);
+  auto writer = std::make_unique<facebook::velox::parquet::Writer>(
+      std::move(sink), options, schema);
+
+  const auto makeBatch = [&]() {
+    return makeRowVector(
+        {makeFlatVector<int64_t>(kNumRows, [](auto row) { return row; }),
+         makeFlatVector<StringView>(
+             kNumRows, [&](auto /*row*/) { return StringView(payload); })});
+  };
+
+  writer->write(makeBatch());
+
+  // The writer should flush the current row group early so file-size-based
+  // rotation can observe written bytes even though the row-group target is
+  // much larger than maxTargetFileSizeBytes.
+  EXPECT_GT(sinkPtr->size(), 0);
+
+  writer->write(makeBatch());
+  writer->close();
+
+  const auto reader = createReaderInMemory(*sinkPtr);
+  EXPECT_EQ(2 * kNumRows, reader->numberOfRows());
+  EXPECT_GE(reader->fileMetaData().numRowGroups(), 2);
+}
+
 TEST_F(ParquetWriterTest, flushEmptyRowGroup) {
   ParquetWriterOptions writerOptions;
   dwio::common::WriterOptions options;

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -109,6 +109,25 @@ class ParquetWriterTest : public ParquetTestBase {
 
   inline static const std::string kHiveConnectorId = "test-hive";
   dwio::common::ColumnReaderStatistics stats;
+
+  struct WriterWithSink {
+    std::unique_ptr<facebook::velox::parquet::Writer> writer;
+    MemorySink* sink;
+  };
+
+  WriterWithSink makeWriterWithSink(
+      const RowTypePtr& schema,
+      dwio::common::WriterOptions options,
+      const ParquetWriterOptions& writerOptions) {
+    auto sink = std::make_unique<MemorySink>(
+        200 * 1024 * 1024, FileSink::Options{.pool = leafPool_.get()});
+    auto* sinkPtr = sink.get();
+    options.formatSpecificOptions =
+        std::make_shared<ParquetWriterOptions>(writerOptions);
+    auto writer = std::make_unique<facebook::velox::parquet::Writer>(
+        std::move(sink), options, schema);
+    return WriterWithSink{std::move(writer), sinkPtr};
+  }
 };
 
 class ArrowMemoryPool final : public ::arrow::MemoryPool {
@@ -846,24 +865,18 @@ TEST_F(ParquetWriterTest, flushWhenStreamBuffersGrow) {
   };
 
   const auto schema = ROW({"c0"}, {BIGINT()});
-  auto sink = std::make_unique<MemorySink>(
-      200 * 1024 * 1024, FileSink::Options{.pool = leafPool_.get()});
-  auto* sinkPtr = sink.get();
-  options.formatSpecificOptions =
-      std::make_shared<ParquetWriterOptions>(writerOptions);
-  auto writer = std::make_unique<facebook::velox::parquet::Writer>(
-      std::move(sink), options, schema);
+  auto writerWithSink = makeWriterWithSink(schema, options, writerOptions);
   const auto data = makeRowVector(
       {makeFlatVector<int64_t>(kNumRows, [](auto row) { return row; })});
 
-  writer->write(data);
+  writerWithSink.writer->write(data);
 
   // Data should be flushed into the FileSink by acculumated closed row groups.
-  EXPECT_GT(sinkPtr->size(), 0);
+  EXPECT_GT(writerWithSink.sink->size(), 0);
 
-  writer->close();
+  writerWithSink.writer->close();
 
-  const auto reader = createReaderInMemory(*sinkPtr);
+  const auto reader = createReaderInMemory(*writerWithSink.sink);
   EXPECT_EQ(kNumRows, reader->numberOfRows());
   EXPECT_EQ(kNumRows, reader->fileMetaData().numRowGroups());
 }
@@ -911,36 +924,27 @@ TEST_F(ParquetWriterTest, flushRowGroupByMaxTargetFileSize) {
         /*bytesInRowGroup=*/128 * 1'024 * 1'024);
   };
 
-  const auto schema = ROW({"id", "payload"}, {BIGINT(), VARCHAR()});
-  auto sink = std::make_unique<MemorySink>(
-      200 * 1024 * 1024, FileSink::Options{.pool = leafPool_.get()});
-  auto* sinkPtr = sink.get();
-
+  const auto schema = ROW({"payload"}, {VARCHAR()});
   ParquetWriterOptions writerOptions;
   writerOptions.enableDictionary = false;
-  options.formatSpecificOptions =
-      std::make_shared<ParquetWriterOptions>(writerOptions);
-  auto writer = std::make_unique<facebook::velox::parquet::Writer>(
-      std::move(sink), options, schema);
+  auto writerWithSink = makeWriterWithSink(schema, options, writerOptions);
 
   const auto makeBatch = [&]() {
-    return makeRowVector(
-        {makeFlatVector<int64_t>(kNumRows, [](auto row) { return row; }),
-         makeFlatVector<StringView>(
-             kNumRows, [&](auto /*row*/) { return StringView(payload); })});
+    return makeRowVector({makeFlatVector<StringView>(
+        kNumRows, [&](auto /*row*/) { return StringView(payload); })});
   };
 
-  writer->write(makeBatch());
+  writerWithSink.writer->write(makeBatch());
 
   // The writer should flush the current row group early so file-size-based
   // rotation can observe written bytes even though the row-group target is
   // much larger than maxTargetFileSizeBytes.
-  EXPECT_GT(sinkPtr->size(), options.maxTargetFileSizeBytes);
+  EXPECT_GT(writerWithSink.sink->size(), options.maxTargetFileSizeBytes);
 
-  writer->write(makeBatch());
-  writer->close();
+  writerWithSink.writer->write(makeBatch());
+  writerWithSink.writer->close();
 
-  const auto reader = createReaderInMemory(*sinkPtr);
+  const auto reader = createReaderInMemory(*writerWithSink.sink);
   EXPECT_EQ(2 * kNumRows, reader->numberOfRows());
   EXPECT_EQ(reader->fileMetaData().numRowGroups(), 2);
 }

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -384,6 +384,7 @@ Writer::Writer(
               *generalPool_,
               getFormatOptions(options).bufferGrowRatio)),
       arrowContext_(std::make_shared<ArrowContext>()),
+      maxTargetFileSizeBytes_(options.maxTargetFileSizeBytes),
       schema_(std::move(schema)) {
   const auto& parquetWriterOptions = getFormatOptions(options);
   validateSchemaRecursive(schema_, parquetWriterOptions.parquetFieldIds);
@@ -411,12 +412,6 @@ Writer::Writer(
 
   if (options.flushPolicyFactory) {
     castUniquePointer(options.flushPolicyFactory(), flushPolicy_);
-  } else if (options.maxTargetFileSizeBytes > 0) {
-    auto bytesInRowGroup = static_cast<int64_t>(std::min<uint64_t>(
-        DefaultFlushPolicy::kDefaultBytesInRowGroup,
-        options.maxTargetFileSizeBytes));
-    flushPolicy_ = std::make_unique<DefaultFlushPolicy>(
-        DefaultFlushPolicy::kDefaultRowsInGroup, bytesInRowGroup);
   } else {
     flushPolicy_ = std::make_unique<DefaultFlushPolicy>();
   }
@@ -457,6 +452,14 @@ dwio::common::StripeProgress getStripeProgress(int64_t bufferedBytes) {
   // Arrow Parquet FileWriter will new row group based on the row number, so
   // we only check buffered bytes to flush row group here.
   return dwio::common::StripeProgress{.stripeSizeEstimate = bufferedBytes};
+}
+
+bool shouldFlushForTargetFileSize(
+    uint64_t maxTargetFileSizeBytes,
+    int64_t streamBytes,
+    int64_t currentRowGroupBytes) {
+  return maxTargetFileSizeBytes > 0 && currentRowGroupBytes > 0 &&
+      streamBytes + currentRowGroupBytes >= maxTargetFileSizeBytes;
 }
 
 /**
@@ -526,11 +529,17 @@ void Writer::write(const VectorPtr& data) {
 
   PARQUET_THROW_NOT_OK(arrowContext_->writer->writeRecordBatch(*recordBatch));
 
+  const auto currentRowGroupBytes =
+      arrowContext_->writer->currentRowGroupTotalBytes();
+  PARQUET_ASSIGN_OR_THROW(const auto streamBytes, stream_->Tell());
+
   // Flush as soon as the current write pushes the staged row group past the
-  // policy threshold. Otherwise callers that rotate files based on raw written
-  // bytes won't observe the row group until the next write.
-  if (flushPolicy_->shouldFlush(getStripeProgress(
-          arrowContext_->writer->currentRowGroupTotalBytes()))) {
+  // row-group target or the file-size target. Otherwise callers that rotate
+  // files based on raw written bytes won't observe the row group until the
+  // next write.
+  if (flushPolicy_->shouldFlush(getStripeProgress(currentRowGroupBytes)) ||
+      shouldFlushForTargetFileSize(
+          maxTargetFileSizeBytes_, streamBytes, currentRowGroupBytes)) {
     flush();
   } else if (flushPolicy_->bytesInRowGroup() <= stream_->bufferedBytes()) {
     // Flush the sink separately so completed row groups don't keep accumulating

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -454,7 +454,7 @@ dwio::common::StripeProgress getStripeProgress(int64_t bufferedBytes) {
   return dwio::common::StripeProgress{.stripeSizeEstimate = bufferedBytes};
 }
 
-bool shouldFlushForTargetFileSize(
+bool stagedBytesReachTargetFileSize(
     uint64_t maxTargetFileSizeBytes,
     int64_t streamBytes,
     int64_t currentRowGroupBytes) {
@@ -538,7 +538,7 @@ void Writer::write(const VectorPtr& data) {
   // files based on raw written bytes won't observe the row group until the
   // next write.
   if (flushPolicy_->shouldFlush(getStripeProgress(currentRowGroupBytes)) ||
-      shouldFlushForTargetFileSize(
+      stagedBytesReachTargetFileSize(
           maxTargetFileSizeBytes_, streamBytes, currentRowGroupBytes)) {
     flush();
   } else if (flushPolicy_->bytesInRowGroup() <= stream_->bufferedBytes()) {

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -162,12 +162,14 @@ class Writer : public dwio::common::Writer {
  public:
   // Constructs a writer with output to 'sink'. 'options' carries common writer
   // options and Parquet-specific format options. For Parquet,
-  // 'options.flushPolicyFactory' must create a DefaultFlushPolicy (or a
-  // subclass). If not provided, the writer uses the default 128MB row-group
-  // byte target. 'options.maxTargetFileSizeBytes' is tracked independently so
-  // the writer can flush the current row group early and make file rotation
-  // visible to the caller. 'pool' is used for temporary memory. 'schema'
-  // specifies the file's overall schema, and it is always non-null.
+  // 'options.flushPolicyFactory' is a programmatic C++ hook and must create a
+  // DefaultFlushPolicy (or a subclass). If not provided, the writer uses its
+  // built-in row-group limits: a soft 128MB byte target and a hard row-count
+  // cap of DefaultFlushPolicy::kDefaultRowsInGroup (~1M rows).
+  // 'options.maxTargetFileSizeBytes' is tracked independently so the writer
+  // can flush the current row group early and make file rotation visible to
+  // the caller. 'pool' is used for temporary memory. 'schema' specifies the
+  // file's overall schema, and it is always non-null.
   Writer(
       std::unique_ptr<dwio::common::FileSink> sink,
       const dwio::common::WriterOptions& options,

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -57,7 +57,7 @@ class ParquetFileMetadata : public dwio::common::FileMetadata {
 };
 
 /// Parquet writer enforces the row-count cap via Arrow, and this policy
-/// supplements it with a byte threshold. For Parquet,
+/// supplements it with a soft row-group byte target. For Parquet,
 /// - stripeSizeEstimate: the actual compressed bytes of current row group.
 /// - stripeRowCount: remains 0.
 /// Custom Parquet policies should derive from DefaultFlushPolicy to preserve
@@ -163,8 +163,11 @@ class Writer : public dwio::common::Writer {
   // Constructs a writer with output to 'sink'. 'options' carries common writer
   // options and Parquet-specific format options. For Parquet,
   // 'options.flushPolicyFactory' must create a DefaultFlushPolicy (or a
-  // subclass); 'pool' is used for temporary memory. 'schema' specifies the
-  // file's overall schema, and it is always non-null.
+  // subclass). If not provided, the writer uses the default 128MB row-group
+  // byte target. 'options.maxTargetFileSizeBytes' is tracked independently so
+  // the writer can flush the current row group early and make file rotation
+  // visible to the caller. 'pool' is used for temporary memory. 'schema'
+  // specifies the file's overall schema, and it is always non-null.
   Writer(
       std::unique_ptr<dwio::common::FileSink> sink,
       const dwio::common::WriterOptions& options,
@@ -222,6 +225,7 @@ class Writer : public dwio::common::Writer {
   std::vector<ParquetFieldId> parquetFieldIds_;
 
   std::unique_ptr<DefaultFlushPolicy> flushPolicy_;
+  const uint64_t maxTargetFileSizeBytes_{0};
 
   const RowTypePtr schema_;
 


### PR DESCRIPTION
## Summary

Decouple Parquet row-group byte targeting from `writer.max-target-file-size`.

Previously, when `flushPolicyFactory` was not provided, the Parquet writer derived the effective row-group byte threshold as:

- `min(128MB, writer.max-target-file-size)`

This made `writer.max-target-file-size` implicitly lower the row-group byte target.

With this change, Parquet tracks the row-group byte target and the target file size independently:

- `bytesInRowGroup` continues to come from `flushPolicyFactory` when provided, or defaults to 128MB,
- `writer.max-target-file-size` is checked separately to make file-size-based rotation observable to the caller.

## Problem

`writer.max-target-file-size` is a file-rotation setting, but it was also implicitly changing Parquet row-group byte sizing through:

- `bytesInRowGroup = min(128MB, writer.max-target-file-size)`

This made two different concepts share a single threshold:

- row-group byte targeting
- file-size targeting

That coupling was especially confusing when a custom `flushPolicyFactory` was provided, because row-group sizing and file-size behavior were no longer clearly separated.

## Change

This PR updates the Parquet writer so that:

1. `flushPolicyFactory` continues to define the row-group byte target when provided.
2. If no custom flush policy is provided, the row-group byte target remains the default 128MB.
3. `writer.max-target-file-size` is tracked independently.
4. After each write, the writer flushes the current row group if either:
   - the row-group byte target is reached, or
   - the current staged file size plus the active row group size reaches `writer.max-target-file-size`.

This keeps the row-group byte policy separate from file-size targeting, while still allowing file rotation to observe actual written bytes in time.

## Semantics

This does **not** make Parquet row-group bytes a hard bound.

The row-group byte threshold remains a **soft target**:
- row groups may still slightly exceed the configured byte target,
- Arrow continues to enforce the row-count cap separately.

## Documentation

Updated the Parquet config documentation to clarify that:

- row-group bytes and target file size are tracked independently,
- `flushPolicyFactory` controls the row-group byte target when present,
- `writer.max-target-file-size` may trigger an early row-group flush to make file rotation visible,
- Parquet row-group byte sizing is a soft target, not a hard bound.

## Testing

Added a unit test covering the case where:

- a custom flush policy uses a large `bytesInRowGroup`,
- `writer.max-target-file-size` is much smaller,

and verifies that the writer flushes the current row group early so file-size-based rotation can observe written bytes.