### PR TITLE
fix: Fix heap-buffer-overflow reads in Parquet reader (#18105)

### DIFF
--- a/velox/dwio/common/SeekableInputStream.cpp
+++ b/velox/dwio/common/SeekableInputStream.cpp
@@ -54,6 +54,7 @@ void SeekableInputStream::readFully(char* buffer, size_t bufferSize) {
     const void* chunk;
     int32_t length;
     VELOX_CHECK(Next(&chunk, &length), "bad read in readFully");
+    VELOX_CHECK_GE(length, 0, "Negative chunk length in readFully: {}", length);
     readLength = static_cast<size_t>(length);
     bytesToCopy = std::min(readLength, bufferSize - pos);
     auto* bytes = reinterpret_cast<const char*>(chunk);

--- a/velox/dwio/parquet/reader/PageReader.cpp
+++ b/velox/dwio/parquet/reader/PageReader.cpp
@@ -44,6 +44,18 @@ struct __attribute__((__packed__)) Int96Timestamp {
   uint64_t nanos;
 };
 
+namespace {
+// Validates a signed 32-bit Parquet PageHeader size field and narrows it to
+// uint32_t. These sizes are attacker-controlled; a negative value would promote
+// to a huge unsigned value in the page-size arithmetic and drive an
+// out-of-bounds read. Zero is valid (e.g. an empty page). Enforced before any
+// page path consumes the size.
+uint32_t checkedPageSize(int32_t size, const char* name) {
+  VELOX_CHECK_GE(size, 0, "Negative {}: {}", name, size);
+  return static_cast<uint32_t>(size);
+}
+} // namespace
+
 void PageReader::seekToPage(int64_t row) {
   defineDecoder_.reset();
   repeatDecoder_.reset();
@@ -57,7 +69,9 @@ void PageReader::seekToPage(int64_t row) {
       break;
     }
     PageHeader pageHeader = readPageHeader();
-    pageStart_ = pageDataStart_ + *pageHeader.compressed_page_size();
+    const uint32_t compressedPageSize = checkedPageSize(
+        *pageHeader.compressed_page_size(), "compressed page size");
+    pageStart_ = pageDataStart_ + compressedPageSize;
 
     switch (*pageHeader.type()) {
       case thrift::PageType::DATA_PAGE:
@@ -69,7 +83,7 @@ void PageReader::seekToPage(int64_t row) {
       case thrift::PageType::DICTIONARY_PAGE:
         if (row == kRepDefOnly) {
           skipBytes(
-              *pageHeader.compressed_page_size(),
+              static_cast<int32_t>(compressedPageSize),
               inputStream_.get(),
               bufferStart_,
               bufferEnd_);
@@ -262,24 +276,26 @@ void PageReader::prepareDataPageV1(const PageHeader& pageHeader, int64_t row) {
       *pageHeader.type() == thrift::PageType::DATA_PAGE &&
       pageHeader.data_page_header());
   numRepDefsInPage_ = *pageHeader.data_page_header()->num_values();
+  const uint32_t compressedPageSize = checkedPageSize(
+      *pageHeader.compressed_page_size(), "compressed page size");
+  const uint32_t uncompressedPageSize = checkedPageSize(
+      *pageHeader.uncompressed_page_size(), "uncompressed page size");
   setPageRowInfo(row == kRepDefOnly);
   if (row != kRepDefOnly && numRowsInPage_ != kRowsUnknown &&
       numRowsInPage_ + rowOfPage_ <= row) {
     dwio::common::skipBytes(
-        *pageHeader.compressed_page_size(),
+        static_cast<int32_t>(compressedPageSize),
         inputStream_.get(),
         bufferStart_,
         bufferEnd_);
 
     return;
   }
-  pageData_ = readBytes(*pageHeader.compressed_page_size(), pageBuffer_);
-  pageData_ = decompressData(
-      pageData_,
-      *pageHeader.compressed_page_size(),
-      *pageHeader.uncompressed_page_size());
-  auto pageEnd = pageData_ + *pageHeader.uncompressed_page_size();
-  auto remainingBytes = *pageHeader.uncompressed_page_size();
+  pageData_ = readBytes(static_cast<int32_t>(compressedPageSize), pageBuffer_);
+  pageData_ =
+      decompressData(pageData_, compressedPageSize, uncompressedPageSize);
+  auto pageEnd = pageData_ + uncompressedPageSize;
+  auto remainingBytes = uncompressedPageSize;
   if (maxRepeat_ > 0) {
     VELOX_CHECK_GE(
         remainingBytes,
@@ -342,14 +358,16 @@ void PageReader::prepareDataPageV1(const PageHeader& pageHeader, int64_t row) {
 void PageReader::prepareDataPageV2(const PageHeader& pageHeader, int64_t row) {
   VELOX_CHECK(pageHeader.data_page_header_v2().has_value());
   numRepDefsInPage_ = *pageHeader.data_page_header_v2()->num_values();
+
+  const uint32_t compressedPageSize = checkedPageSize(
+      *pageHeader.compressed_page_size(), "compressed page size");
+  const uint32_t uncompressedPageSize = checkedPageSize(
+      *pageHeader.uncompressed_page_size(), "uncompressed page size");
+
   setPageRowInfo(row == kRepDefOnly);
   if (row != kRepDefOnly && numRowsInPage_ != kRowsUnknown &&
       numRowsInPage_ + rowOfPage_ <= row) {
-    skipBytes(
-        *pageHeader.compressed_page_size(),
-        inputStream_.get(),
-        bufferStart_,
-        bufferEnd_);
+    skipBytes(compressedPageSize, inputStream_.get(), bufferStart_, bufferEnd_);
     return;
   }
 
@@ -357,15 +375,24 @@ void PageReader::prepareDataPageV2(const PageHeader& pageHeader, int64_t row) {
       *pageHeader.data_page_header_v2()->definition_levels_byte_length();
   uint32_t repeatLength =
       *pageHeader.data_page_header_v2()->repetition_levels_byte_length();
+  auto levelsSizeRaw = static_cast<uint64_t>(repeatLength) + defineLength;
 
-  auto bytes = *pageHeader.compressed_page_size();
   VELOX_CHECK_LE(
-      static_cast<uint64_t>(repeatLength) + defineLength,
-      bytes,
+      levelsSizeRaw,
+      compressedPageSize,
       "Repetition and definition level lengths ({} + {}) exceed compressed page size {} (corrupt data page?)",
       repeatLength,
       defineLength,
-      bytes);
+      compressedPageSize);
+  VELOX_CHECK_LE(
+      levelsSizeRaw,
+      uncompressedPageSize,
+      "Repetition and definition level lengths ({} + {}) exceed uncompressed page size {} (corrupt data page?)",
+      repeatLength,
+      defineLength,
+      uncompressedPageSize);
+  auto levelsSize = static_cast<uint32_t>(levelsSizeRaw);
+  const auto bytes = static_cast<int32_t>(compressedPageSize);
   pageData_ = readBytes(bytes, pageBuffer_);
 
   if (repeatLength) {
@@ -379,7 +406,7 @@ void PageReader::prepareDataPageV2(const PageHeader& pageHeader, int64_t row) {
     if (maxDefine_ == 1) {
       defineDecoder_ = std::make_unique<RleBpDecoder>(
           pageData_ + repeatLength,
-          pageData_ + repeatLength + defineLength,
+          pageData_ + levelsSize,
           ::arrow::bit_util::NumRequiredBits(maxDefine_));
     }
     wideDefineDecoder_ = std::make_unique<RleDecoder>(
@@ -387,7 +414,6 @@ void PageReader::prepareDataPageV2(const PageHeader& pageHeader, int64_t row) {
         defineLength,
         ::arrow::bit_util::NumRequiredBits(maxDefine_));
   }
-  auto levelsSize = repeatLength + defineLength;
   pageData_ += levelsSize;
   // parquet.thrift uses "7: optional bool is_compressed = true;" but
   // FBThrift doesn't support "optional" and default value. The problem is
@@ -397,18 +423,18 @@ void PageReader::prepareDataPageV2(const PageHeader& pageHeader, int64_t row) {
   // We are changing the behavior and an absent is_compressed now assumes
   // compression is used matching the parquet definition.
   if (pageHeader.data_page_header_v2()->is_compressed().value_or(true) &&
-      (*pageHeader.compressed_page_size() - levelsSize > 0)) {
+      (compressedPageSize - levelsSize > 0)) {
     pageData_ = decompressData(
         pageData_,
-        *pageHeader.compressed_page_size() - levelsSize,
-        *pageHeader.uncompressed_page_size() - levelsSize);
+        compressedPageSize - levelsSize,
+        uncompressedPageSize - levelsSize);
   }
   if (row == kRepDefOnly) {
     skipBytes(bytes, inputStream_.get(), bufferStart_, bufferEnd_);
     return;
   }
 
-  encodedDataSize_ = *pageHeader.uncompressed_page_size() - levelsSize;
+  encodedDataSize_ = static_cast<int32_t>(uncompressedPageSize - levelsSize);
   encoding_ = *pageHeader.data_page_header_v2()->encoding();
   if (numRowsInPage_ == kRowsUnknown) {
     readPageDefLevels();
@@ -427,12 +453,15 @@ void PageReader::prepareDictionary(const PageHeader& pageHeader) {
       dictionaryEncoding_ == Encoding::PLAIN_DICTIONARY ||
       dictionaryEncoding_ == Encoding::PLAIN);
 
+  const uint32_t uncompressedPageSize = checkedPageSize(
+      *pageHeader.uncompressed_page_size(), "uncompressed page size");
   if (codec_ != common::CompressionKind::CompressionKind_NONE) {
-    pageData_ = readBytes(*pageHeader.compressed_page_size(), pageBuffer_);
-    pageData_ = decompressData(
-        pageData_,
-        *pageHeader.compressed_page_size(),
-        *pageHeader.uncompressed_page_size());
+    const uint32_t compressedPageSize = checkedPageSize(
+        *pageHeader.compressed_page_size(), "compressed page size");
+    pageData_ =
+        readBytes(static_cast<int32_t>(compressedPageSize), pageBuffer_);
+    pageData_ =
+        decompressData(pageData_, compressedPageSize, uncompressedPageSize);
   }
 
   auto parquetType = type_->parquetType_.value();
@@ -532,7 +561,7 @@ void PageReader::prepareDictionary(const PageHeader& pageHeader) {
     case thrift::Type::BYTE_ARRAY: {
       dictionary_.values =
           AlignedBuffer::allocate<StringView>(dictionary_.numValues, &pool_);
-      auto numBytes = *pageHeader.uncompressed_page_size();
+      auto numBytes = uncompressedPageSize;
       auto values = dictionary_.values->asMutable<StringView>();
       dictionary_.strings = AlignedBuffer::allocate<char>(numBytes, &pool_);
       auto strings = dictionary_.strings->asMutable<char>();

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -390,7 +390,12 @@ void ReaderBase::loadFileMetaData() {
 
   uint32_t footerLength;
   std::memcpy(&footerLength, copy.data() + readSize - 8, sizeof(uint32_t));
-  VELOX_CHECK_LE(footerLength + 12, fileLength_);
+  VELOX_CHECK_LE(
+      static_cast<uint64_t>(footerLength) + 12,
+      fileLength_,
+      "Parquet file footer length is inconsistent with file length: footer length {}, file length {}",
+      footerLength,
+      fileLength_);
   int32_t footerOffsetInBuffer = readSize - 8 - footerLength;
   if (footerLength > readSize - 8) {
     footerOffsetInBuffer = 0;

--- a/velox/dwio/parquet/tests/reader/ParquetPageReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetPageReaderTest.cpp
@@ -554,6 +554,127 @@ TEST_F(ParquetPageReaderTest, corruptRepeatLengthOnlyV2) {
       "Repetition and definition level lengths (2147483632 + 0) exceed");
 }
 
+// Test that prepareDataPageV2 rejects pages where the uncompressed page size is
+// smaller than the repetition + definition level lengths. Without the check the
+// subtraction (uncompressed_page_size - levelsSize) underflows to a huge
+// unsigned value that drives an out-of-bounds read while decompressing.
+TEST_F(ParquetPageReaderTest, corruptUncompressedSizeSmallerThanLevelsV2) {
+  // Level lengths fit within the compressed page size (so the existing
+  // levels-vs-compressed check passes) but exceed the uncompressed page size.
+  constexpr int32_t kCompressedSize = 100;
+  constexpr int32_t kUncompressedSize = 20;
+  constexpr int32_t kDefineLength = 40;
+  constexpr int32_t kRepeatLength = 40;
+  auto pageHeader = createDataPageV2Header(
+      kUncompressedSize, kCompressedSize, 100, kDefineLength, kRepeatLength);
+  std::string headerBytes = serializePageHeader(pageHeader);
+
+  // Page data large enough to satisfy the compressed-size read.
+  std::string pageData(kCompressedSize, '\0');
+
+  std::string fullData = headerBytes + pageData;
+
+  auto inputStream = std::make_unique<SeekableArrayInputStream>(
+      fullData.data(), fullData.size());
+
+  dwio::common::ColumnReaderStatistics stats;
+  auto pageReader = std::make_unique<PageReader>(
+      std::move(inputStream),
+      *leafPool_,
+      common::CompressionKind::CompressionKind_NONE,
+      fullData.size(),
+      stats,
+      nullptr,
+      1,
+      1);
+
+  // Calling skip(1) triggers seekToPage() which calls prepareDataPageV2().
+  // The bounds check should throw when the level lengths exceed the
+  // uncompressed page size.
+  VELOX_ASSERT_THROW(
+      pageReader->skip(1),
+      "Repetition and definition level lengths (40 + 40) exceed uncompressed page size 20");
+}
+
+// Test that prepareDataPageV2 rejects pages with a negative uncompressed page
+// size. The size is a signed 32-bit thrift field; a negative value would
+// promote to a huge unsigned value in the decompression sizing and drive an
+// out-of-bounds read in SeekableInputStream::readFully.
+TEST_F(ParquetPageReaderTest, corruptNegativeUncompressedSizeV2) {
+  // -139 is the reproducer value (0xFFFFFF75); with no level bytes the
+  // decompressor would be asked to produce ~4 GiB from a tiny page body.
+  constexpr int32_t kCompressedSize = 100;
+  constexpr int32_t kNegativeUncompressedSize = -139;
+  auto pageHeader = createDataPageV2Header(
+      kNegativeUncompressedSize,
+      kCompressedSize,
+      100,
+      /*definitionLevelsByteLength=*/0,
+      /*repetitionLevelsByteLength=*/0);
+  // The reproducer page is compressed, so exercise the decompression path.
+  pageHeader.data_page_header_v2()->is_compressed() = true;
+  std::string headerBytes = serializePageHeader(pageHeader);
+
+  std::string pageData(kCompressedSize, '\0');
+
+  std::string fullData = headerBytes + pageData;
+
+  auto inputStream = std::make_unique<SeekableArrayInputStream>(
+      fullData.data(), fullData.size());
+
+  dwio::common::ColumnReaderStatistics stats;
+  auto pageReader = std::make_unique<PageReader>(
+      std::move(inputStream),
+      *leafPool_,
+      common::CompressionKind::CompressionKind_GZIP,
+      fullData.size(),
+      stats,
+      nullptr,
+      1,
+      1);
+
+  VELOX_ASSERT_THROW(
+      pageReader->skip(1), "Negative uncompressed page size: -139");
+}
+
+// Test that seekToPage rejects pages with a negative compressed page size. The
+// size is a signed 32-bit thrift field validated by the shared
+// checkedPageSize() guard at the top of seekToPage() before any
+// page-type-specific handling runs; a negative value would promote to a huge
+// unsigned value in the page-start arithmetic and drive an out-of-bounds read.
+// Exercised on a V1 data page to cover the common guard rather than a V2-only
+// path.
+TEST_F(ParquetPageReaderTest, corruptNegativeCompressedSizeV1) {
+  constexpr int32_t kUncompressedSize = 20;
+  constexpr int32_t kNegativeCompressedSize = -139;
+  auto pageHeader = createDataPageV1Header(
+      kUncompressedSize, kNegativeCompressedSize, /*numValues=*/100);
+  std::string headerBytes = serializePageHeader(pageHeader);
+
+  std::string pageData(kUncompressedSize, '\0');
+
+  std::string fullData = headerBytes + pageData;
+
+  auto inputStream = std::make_unique<SeekableArrayInputStream>(
+      fullData.data(), fullData.size());
+
+  dwio::common::ColumnReaderStatistics stats;
+  auto pageReader = std::make_unique<PageReader>(
+      std::move(inputStream),
+      *leafPool_,
+      common::CompressionKind::CompressionKind_NONE,
+      fullData.size(),
+      stats,
+      nullptr,
+      1,
+      1);
+
+  // Calling skip(1) triggers seekToPage(), whose checkedPageSize() guard runs
+  // for every page type before dispatching to prepareDataPageV1().
+  VELOX_ASSERT_THROW(
+      pageReader->skip(1), "Negative compressed page size: -139");
+}
+
 // Reads two consecutive page headers from a stream whose underlying chunks
 // are small enough that the FBThrift deserializer's refiller has to coalesce
 // several chunks to satisfy a single header. Exercises the post-deserialize

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -1657,6 +1657,31 @@ TEST_F(ParquetReaderTest, readerWithSchema) {
   EXPECT_EQ(reader.rowType()->toString(), schema->toString());
 }
 
+// Test that loadFileMetaData rejects a Parquet trailer whose 4-byte
+// footerLength is near UINT32_MAX. The validation footerLength + 12 must be
+// computed in 64-bit; a 32-bit computation wraps to a tiny value that passes
+// the file-length check and drives an out-of-bounds read while reassembling
+// the footer.
+TEST_F(ParquetReaderTest, corruptFooterLengthWraps) {
+  // Trailer layout: [padding][4-byte footerLength][PAR1]. Choosing a
+  // footerLength close to UINT32_MAX makes footerLength + 12 wrap to 4 in
+  // 32-bit arithmetic, which trivially satisfies the wrapped guard.
+  std::string dataBuf(8, '\0');
+  const uint32_t corruptFooterLength = 0xFFFFFFF8;
+  dataBuf.append(
+      reinterpret_cast<const char*>(&corruptFooterLength), sizeof(uint32_t));
+  dataBuf.append("PAR1");
+
+  auto readerOptions = makeDefaultReaderOptions();
+  auto file = std::make_shared<InMemoryReadFile>(std::move(dataBuf));
+  auto buffer = std::make_unique<dwio::common::BufferedInput>(
+      file, readerOptions.memoryPool());
+
+  VELOX_ASSERT_THROW(
+      ParquetReader(std::move(buffer), readerOptions),
+      "is inconsistent with file length");
+}
+
 TEST_F(ParquetReaderTest, columnStatistics) {
   auto data = makeRowVector(
       {"a", "b", "c"},


### PR DESCRIPTION
Summary:

Two agentic-fuzzing findings in the Velox Parquet reader let a crafted file drive an out-of-bounds read from attacker-controlled size fields:

  - `PageReader::prepareDataPageV2` trusted the signed 32-bit `compressed_page_size`/`uncompressed_page_size` page-header fields. A negative value (repro: `uncompressed_page_size = -139`) promoted to a huge unsigned size, so `decompressData` asked the decompressor to produce ~4 GiB and `SeekableInputStream::readFully` over-read the page buffer. Added a `checkAndCast()` helper that rejects non-positive sizes and narrows to `uint32_t` before any size arithmetic, plus a defense-in-depth check in `readFully` that rejects a negative chunk length instead of sign-extending it into a huge copy.
  - `ReaderBase::loadFileMetaData` validated the footer with `footerLength + 12` in 32-bit arithmetic, which wraps for a `footerLength` near `UINT32_MAX` and slips an inconsistent length through to the footer-extension read. Promoted the addition to 64-bit.

Differential Revision: D111157778
