### PR TITLE
fix(dwrf): Bound PATCHED_BASE gap chain to avoid OOB read (#18106)

### DIFF
--- a/velox/dwio/dwrf/common/RLEv2.cpp
+++ b/velox/dwio/dwrf/common/RLEv2.cpp
@@ -393,7 +393,7 @@ uint64_t RleDecoderV2<isSigned>::nextPatched(
     VELOX_CHECK_NE(
         pl,
         0,
-        "Corrupt PATCHED_BASE encoded data (pl==0)! ",
+        "Patch list length is zero: {}",
         dwio::common::IntDecoder<isSigned>::inputStream_->getName());
 
     // read the next base width number of bytes to extract base value
@@ -420,7 +420,9 @@ uint64_t RleDecoderV2<isSigned>::nextPatched(
     VELOX_CHECK_LE(
         (patchBitSize_ + pgw),
         64,
-        "Corrupt PATCHED_BASE encoded data (patchBitSize + pgw > 64)! ",
+        "Patch width ({}) plus patch gap width ({}) exceeds 64 bits: {}",
+        patchBitSize_,
+        pgw,
         dwio::common::IntDecoder<isSigned>::inputStream_->getName());
     uint32_t cfb = getClosestFixedBits(patchBitSize_ + pgw);
     readLongs(unpackedPatch_.data(), 0, pl, cfb);

--- a/velox/dwio/dwrf/common/RLEv2.h
+++ b/velox/dwio/dwrf/common/RLEv2.h
@@ -111,6 +111,13 @@ class RleDecoderV2 : public dwio::common::IntDecoder<isSigned> {
     while (curGap_ == 255 && curPatch_ == 0) {
       actualGap_ += 255;
       ++patchIdx_;
+      // A gap==255/patch==0 entry promises a continuation entry follows; a
+      // corrupt patch list may end on one, so bound the chain before reading.
+      VELOX_CHECK_LT(
+          patchIdx_,
+          unpackedPatch_.size(),
+          "Patch gap chain runs past patch list: {}",
+          dwio::common::IntDecoder<isSigned>::inputStream_->getName());
       curGap_ =
           static_cast<uint64_t>(unpackedPatch_[patchIdx_]) >> patchBitSize_;
       curPatch_ = unpackedPatch_[patchIdx_] & patchMask_;
@@ -140,7 +147,7 @@ class RleDecoderV2 : public dwio::common::IntDecoder<isSigned> {
           &bufferPointer, &bufferLength);
       VELOX_CHECK(
           ret,
-          "bad read in RleDecoderV2::readByte, ",
+          "bad read in RleDecoderV2::readByte: {}",
           dwio::common::IntDecoder<isSigned>::inputStream_->getName());
       dwio::common::IntDecoder<isSigned>::bufferStart_ =
           static_cast<const char*>(bufferPointer);

--- a/velox/dwio/dwrf/test/TestRle.cpp
+++ b/velox/dwio/dwrf/test/TestRle.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 
 #include "velox/common/base/Nulls.h"
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/dwio/common/IntDecoder.h"
 #include "velox/dwio/common/SeekableInputStream.h"
 #include "velox/dwio/dwrf/common/DecoderUtil.h"
@@ -454,6 +455,26 @@ TEST_F(RLEv2Test, basicPatched0) {
       values,
       decodeRLEv2(bytes, l, values.size(), values.size()),
       values.size());
+};
+
+// Regression test for a heap-buffer-overflow read in
+// RleDecoderV2::adjustGapAndPatch(). A crafted PATCHED_BASE run whose patch
+// list ends in a gap-continuation entry (gap == 255, patch == 0) used to walk
+// patchIdx_ past the end of the patch list; decoding must now fail cleanly.
+TEST_F(RLEv2Test, patchedBaseGapChainOutOfBounds) {
+  // Single-entry PATCHED_BASE patch list that is itself a continuation marker:
+  //   0x80 firstByte  -> PATCHED_BASE, fixed width 1 bit, runLength high bit 0
+  //   0x00 runLength   -> runLength = 1
+  //   0x07 thirdByte   -> base width 1 byte, patch width 8 bits
+  //   0xe1 fourthByte  -> patch gap width 8 bits, patch list length 1
+  //   0x00 base value
+  //   0x00 unpacked value
+  //   0xff 0x00 patch  -> gap = 255, patch = 0 (continuation marker)
+  const unsigned char bytes[] = {
+      0x80, 0x00, 0x07, 0xe1, 0x00, 0x00, 0xff, 0x00};
+  VELOX_ASSERT_THROW(
+      decodeRLEv2(bytes, sizeof(bytes), 1, 1),
+      "Patch gap chain runs past patch list");
 };
 
 TEST_F(RLEv2Test, basicPatched1) {


### PR DESCRIPTION
Summary:

A crafted ORC file with a PATCHED_BASE integer run whose patch list ends in a gap-continuation entry (gap == 255, patch == 0) made `RleDecoderV2::adjustGapAndPatch()` advance `patchIdx_` past the end of the patch list. The decoder then read past the `unpackedPatch_` buffer and fed the out-of-bounds values into the decoded column. Add a bounds check on `patchIdx_` inside the gap-chaining loop so a corrupt patch list fails with a clear decode error instead of reading out of bounds.

Reviewed By: HuamengJiang

Differential Revision: D111666151


