### PR TITLE
fix(sparksql): Enable ANSI-compliant cast from INTEGRAL to DECIMAL

### DIFF
--- a/velox/docs/functions/spark/conversion.rst
+++ b/velox/docs/functions/spark/conversion.rst
@@ -340,10 +340,16 @@ Cast to Decimal
 From varchar
 ^^^^^^^^^^^^
 
+*(ANSI compliant)*
+
 Casting varchar to a decimal of given precision and scale is allowed.
 The behavior is similar with Presto except Spark allows leading and trailing white-spaces in input varchars.
 
-Valid example
+When ANSI mode is enabled, casting from an invalid input value or a value that
+overflows the target precision and scale throws an error. Otherwise, such casts
+return NULL.
+
+Valid examples
 
 ::
 
@@ -353,6 +359,44 @@ Valid example
   SELECT cast(' -3E+2' as decimal(12, 2)); -- -300.00
   SELECT cast('-3E+2 ' as decimal(12, 2)); -- -300.00
   SELECT cast('  -3E+2  ' as decimal(12, 2)); -- -300.00
+
+Invalid examples
+
+::
+
+  SELECT cast('0.0444a' as decimal(38, 0)); -- NULL (ANSI OFF) / ERROR (ANSI ON) // Value is not a number
+  SELECT cast('' as decimal(38, 0)); -- NULL (ANSI OFF) / ERROR (ANSI ON) // Value is not a number
+  SELECT cast('1. 23' as decimal(38, 0)); -- NULL (ANSI OFF) / ERROR (ANSI ON) // Interior whitespace is invalid
+  SELECT cast('1.23e67' as decimal(38, 0)); -- NULL (ANSI OFF) / ERROR (ANSI ON) // Value too large
+  SELECT cast('111111111111111111.23' as decimal(38, 38)); -- NULL (ANSI OFF) / ERROR (ANSI ON) // Value too large
+
+From integral types
+^^^^^^^^^^^^^^^^^^^
+
+*(ANSI compliant)*
+
+Casting an integral value to a decimal of given precision and scale is allowed.
+Supported types are tinyint, smallint, integer and bigint.
+
+When ANSI mode is enabled, casting a value that overflows the target precision
+and scale throws an error. Otherwise, such casts return NULL.
+
+Valid examples
+
+::
+
+  SELECT cast(cast(55 as tinyint) as decimal(6, 2)); -- 55.00
+  SELECT cast(cast(-3 as smallint) as decimal(6, 2)); -- -3.00
+  SELECT cast(cast(72 as integer) as decimal(20, 10)); -- 72.0000000000
+  SELECT cast(cast(0 as bigint) as decimal(6, 2)); -- 0.00
+
+Invalid examples
+
+::
+
+  SELECT cast(cast(-128 as tinyint) as decimal(3, 1)); -- NULL (ANSI OFF) / ERROR (ANSI ON) // Value too large
+  SELECT cast(cast(100 as integer) as decimal(17, 16)); -- NULL (ANSI OFF) / ERROR (ANSI ON) // Value too large
+  SELECT cast(cast(-100 as bigint) as decimal(17, 16)); -- NULL (ANSI OFF) / ERROR (ANSI ON) // Value too large
 
 Cast to Varbinary
 -----------------

--- a/velox/functions/sparksql/specialforms/SparkCastExpr.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastExpr.cpp
@@ -121,6 +121,10 @@ bool SparkCastCallToSpecialForm::isAnsiSupported(
     return true;
   }
 
+  if (isIntegralType(fromType) && toType->isDecimal()) {
+    return true;
+  }
+
   return false;
 }
 

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -1242,45 +1242,6 @@ class SparkCastExprTest : public functions::test::CastBaseTest {
              720'000'000'000},
             DECIMAL(20, 10)));
   }
-
-  template <typename T>
-  void testIntegralToDecimalOverflowThrow() {
-    // The value does not fit in the allowed integer digits (precision - scale)
-    // of the target.
-    testThrow<T>(
-        CppToType<T>::create(),
-        DECIMAL(3, 1),
-        {std::numeric_limits<T>::min()},
-        fmt::format(
-            "Cannot cast {} '{}' to DECIMAL(3, 1)",
-            CppToType<T>::name,
-            std::to_string(std::numeric_limits<T>::min())));
-    testThrow<T>(
-        CppToType<T>::create(),
-        DECIMAL(17, 16),
-        {-100},
-        fmt::format(
-            "Cannot cast {} '-100' to DECIMAL(17, 16)", CppToType<T>::name));
-    testThrow<T>(
-        CppToType<T>::create(),
-        DECIMAL(17, 16),
-        {100},
-        fmt::format(
-            "Cannot cast {} '100' to DECIMAL(17, 16)", CppToType<T>::name));
-  }
-
-  template <typename T>
-  void testIntegralToDecimalOverflowNull() {
-    testCast<T, int64_t>(
-        CppToType<T>::create(),
-        DECIMAL(3, 1),
-        {std::numeric_limits<T>::min()},
-        {std::nullopt});
-    testCast<T, int64_t>(
-        CppToType<T>::create(), DECIMAL(17, 16), {-100}, {std::nullopt});
-    testCast<T, int64_t>(
-        CppToType<T>::create(), DECIMAL(17, 16), {100}, {std::nullopt});
-  }
 };
 
 class SparkCastExprTestAnsiOn : public SparkCastExprTest {
@@ -2152,10 +2113,34 @@ TEST_F(SparkCastExprTestAnsiOn, integralToDecimal) {
   testIntegralToDecimal<int64_t>();
 
   // Under ANSI ON, inputs that overflow the target precision/scale throw.
-  testIntegralToDecimalOverflowThrow<int8_t>();
-  testIntegralToDecimalOverflowThrow<int16_t>();
-  testIntegralToDecimalOverflowThrow<int32_t>();
-  testIntegralToDecimalOverflowThrow<int64_t>();
+  // The value does not fit in the allowed integer digits (precision - scale)
+  // of the target.
+  auto testOverflowThrow = [&]<typename T>() {
+    testThrow<T>(
+        CppToType<T>::create(),
+        DECIMAL(3, 1),
+        {std::numeric_limits<T>::min()},
+        fmt::format(
+            "Cannot cast {} '{}' to DECIMAL(3, 1)",
+            CppToType<T>::name,
+            std::to_string(std::numeric_limits<T>::min())));
+    testThrow<T>(
+        CppToType<T>::create(),
+        DECIMAL(17, 16),
+        {-100},
+        fmt::format(
+            "Cannot cast {} '-100' to DECIMAL(17, 16)", CppToType<T>::name));
+    testThrow<T>(
+        CppToType<T>::create(),
+        DECIMAL(17, 16),
+        {100},
+        fmt::format(
+            "Cannot cast {} '100' to DECIMAL(17, 16)", CppToType<T>::name));
+  };
+  testOverflowThrow.operator()<int8_t>();
+  testOverflowThrow.operator()<int16_t>();
+  testOverflowThrow.operator()<int32_t>();
+  testOverflowThrow.operator()<int64_t>();
 }
 
 TEST_F(SparkCastExprTestAnsiOff, varcharToDecimal) {
@@ -2255,10 +2240,21 @@ TEST_F(SparkCastExprTestAnsiOff, integralToDecimal) {
 
   // Under ANSI OFF, the same overflowing inputs return NULL instead of
   // throwing.
-  testIntegralToDecimalOverflowNull<int8_t>();
-  testIntegralToDecimalOverflowNull<int16_t>();
-  testIntegralToDecimalOverflowNull<int32_t>();
-  testIntegralToDecimalOverflowNull<int64_t>();
+  auto testOverflowNull = [&]<typename T>() {
+    testCast<T, int64_t>(
+        CppToType<T>::create(),
+        DECIMAL(3, 1),
+        {std::numeric_limits<T>::min()},
+        {std::nullopt});
+    testCast<T, int64_t>(
+        CppToType<T>::create(), DECIMAL(17, 16), {-100}, {std::nullopt});
+    testCast<T, int64_t>(
+        CppToType<T>::create(), DECIMAL(17, 16), {100}, {std::nullopt});
+  };
+  testOverflowNull.operator()<int8_t>();
+  testOverflowNull.operator()<int16_t>();
+  testOverflowNull.operator()<int32_t>();
+  testOverflowNull.operator()<int64_t>();
 }
 
 } // namespace

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -1219,6 +1219,68 @@ class SparkCastExprTest : public functions::test::CastBaseTest {
     testCast<std::string, int64_t>(
         "decimal(12, 2)", {" -3E+2"}, {-30000}, VARCHAR(), DECIMAL(12, 2));
   }
+
+  template <typename T>
+  void testIntegralToDecimal() {
+    // Integral to short decimal.
+    auto input = makeFlatVector<T>({-3, -2, -1, 0, 55, 69, 72});
+    testCast(
+        input,
+        makeFlatVector<int64_t>(
+            {-300, -200, -100, 0, 5'500, 6'900, 7'200}, DECIMAL(6, 2)));
+
+    // Integral to long decimal.
+    testCast(
+        input,
+        makeFlatVector<int128_t>(
+            {-30'000'000'000,
+             -20'000'000'000,
+             -10'000'000'000,
+             0,
+             550'000'000'000,
+             690'000'000'000,
+             720'000'000'000},
+            DECIMAL(20, 10)));
+  }
+
+  template <typename T>
+  void testIntegralToDecimalOverflowThrow() {
+    // The value does not fit in the allowed integer digits (precision - scale)
+    // of the target.
+    testThrow<T>(
+        CppToType<T>::create(),
+        DECIMAL(3, 1),
+        {std::numeric_limits<T>::min()},
+        fmt::format(
+            "Cannot cast {} '{}' to DECIMAL(3, 1)",
+            CppToType<T>::name,
+            std::to_string(std::numeric_limits<T>::min())));
+    testThrow<T>(
+        CppToType<T>::create(),
+        DECIMAL(17, 16),
+        {-100},
+        fmt::format(
+            "Cannot cast {} '-100' to DECIMAL(17, 16)", CppToType<T>::name));
+    testThrow<T>(
+        CppToType<T>::create(),
+        DECIMAL(17, 16),
+        {100},
+        fmt::format(
+            "Cannot cast {} '100' to DECIMAL(17, 16)", CppToType<T>::name));
+  }
+
+  template <typename T>
+  void testIntegralToDecimalOverflowNull() {
+    testCast<T, int64_t>(
+        CppToType<T>::create(),
+        DECIMAL(3, 1),
+        {std::numeric_limits<T>::min()},
+        {std::nullopt});
+    testCast<T, int64_t>(
+        CppToType<T>::create(), DECIMAL(17, 16), {-100}, {std::nullopt});
+    testCast<T, int64_t>(
+        CppToType<T>::create(), DECIMAL(17, 16), {100}, {std::nullopt});
+  }
 };
 
 class SparkCastExprTestAnsiOn : public SparkCastExprTest {
@@ -2082,6 +2144,20 @@ TEST_F(SparkCastExprTestAnsiOn, varcharToDecimal) {
       "Cannot cast VARCHAR '09{xi+yD' to DECIMAL(12, 2). Value is not a number. Chars are invalid.");
 }
 
+TEST_F(SparkCastExprTestAnsiOn, integralToDecimal) {
+  // Regular cases produce the same results regardless of ANSI mode.
+  testIntegralToDecimal<int8_t>();
+  testIntegralToDecimal<int16_t>();
+  testIntegralToDecimal<int32_t>();
+  testIntegralToDecimal<int64_t>();
+
+  // Under ANSI ON, inputs that overflow the target precision/scale throw.
+  testIntegralToDecimalOverflowThrow<int8_t>();
+  testIntegralToDecimalOverflowThrow<int16_t>();
+  testIntegralToDecimalOverflowThrow<int32_t>();
+  testIntegralToDecimalOverflowThrow<int64_t>();
+}
+
 TEST_F(SparkCastExprTestAnsiOff, varcharToDecimal) {
   // Regular cases produce the same results regardless of ANSI mode.
   testVarcharToDecimal();
@@ -2168,6 +2244,21 @@ TEST_F(SparkCastExprTestAnsiOff, varcharToDecimal) {
       {std::nullopt},
       VARCHAR(),
       DECIMAL(12, 2));
+}
+
+TEST_F(SparkCastExprTestAnsiOff, integralToDecimal) {
+  // Regular cases produce the same results regardless of ANSI mode.
+  testIntegralToDecimal<int8_t>();
+  testIntegralToDecimal<int16_t>();
+  testIntegralToDecimal<int32_t>();
+  testIntegralToDecimal<int64_t>();
+
+  // Under ANSI OFF, the same overflowing inputs return NULL instead of
+  // throwing.
+  testIntegralToDecimalOverflowNull<int8_t>();
+  testIntegralToDecimalOverflowNull<int16_t>();
+  testIntegralToDecimalOverflowNull<int32_t>();
+  testIntegralToDecimalOverflowNull<int64_t>();
 }
 
 } // namespace


### PR DESCRIPTION
Adds ANSI mode support for casting integral types to DECIMAL in Spark SQL functions, aligning Velox with Spark: when ANSI mode is on, values that overflow the target precision/scale throw; when ANSI mode is off (or for try_cast), they return NULL. This matches Spark, whose ANSI decimal cast path throws on overflow while the non-ANSI path returns NULL.

Update docs for this support and for cast from varchar to decimal.

#### Tests

Ported from CastExprTest.cpp (Presto cast behavior). Shared valid cases live in testIntegralToDecimal(); overflow cases are split between the ANSI-on test (expects a throw) and the ANSI-off test (expects NULL).