### PR TITLE
perf: Add zero-copy reinterpret cast

### DIFF
--- a/velox/benchmarks/basic/CastBenchmark.cpp
+++ b/velox/benchmarks/basic/CastBenchmark.cpp
@@ -75,6 +75,13 @@ int main(int argc, char** argv) {
       },
       nullptr,
       DECIMAL(38, 16));
+  auto reinterpretLongDecimalInput = vectorMaker.flatVector<int128_t>(
+      vectorSize,
+      [&](auto j) {
+        return facebook::velox::HugeInt::build(j, 12345 * j + 6789);
+      },
+      nullptr,
+      DECIMAL(20, 4));
   auto largeRealInput = vectorMaker.flatVector<float>(
       vectorSize, [&](auto j) { return 12345678.0 * j; });
   auto smallRealInput = vectorMaker.flatVector<float>(
@@ -92,6 +99,24 @@ int main(int argc, char** argv) {
       [](auto row) { return fmt::format("2024-05-{:02d}", 1 + row % 30); });
   auto invalidDateStrings = vectorMaker.flatVector<std::string>(
       vectorSize, [](auto row) { return fmt::format("2024-05...{}", row); });
+  auto timeInput = vectorMaker.flatVector<int64_t>(
+      vectorSize, [](auto j) { return j % 86'400'000; }, nullptr, TIME());
+
+  benchmarkBuilder
+      .addBenchmarkSet(
+          "cast_reinterpret",
+          vectorMaker.rowVector(
+              {"short_decimal", "long_decimal", "time"},
+              {decimalInput, reinterpretLongDecimalInput, timeInput}))
+      .addExpression(
+          "cast_short_decimal_same_scale_widen_precision",
+          "cast(short_decimal as decimal(18,2))")
+      .addExpression(
+          "cast_long_decimal_same_scale_widen_precision",
+          "cast(long_decimal as decimal(30,4))")
+      .addExpression("cast_time_as_bigint", "cast(time as bigint)")
+      .withIterations(100)
+      .disableTesting();
 
   benchmarkBuilder
       .addBenchmarkSet(

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -18,6 +18,7 @@
 
 #include <fmt/format.h>
 #include <stdexcept>
+#include <type_traits>
 
 #include "velox/common/base/Exceptions.h"
 #include "velox/core/CoreTypeSystem.h"
@@ -27,9 +28,12 @@
 #include "velox/external/tzdb/time_zone.h"
 #include "velox/functions/lib/RowsTranslationUtil.h"
 #include "velox/type/CastRegistry.h"
+#include "velox/type/CppToType.h"
 #include "velox/type/Type.h"
 #include "velox/type/tz/TimeZoneMap.h"
 #include "velox/vector/ComplexVector.h"
+#include "velox/vector/ConstantVector.h"
+#include "velox/vector/FlatVector.h"
 #include "velox/vector/FunctionVector.h"
 #include "velox/vector/LazyVector.h"
 #include "velox/vector/SelectivityVector.h"
@@ -46,6 +50,85 @@ const tz::TimeZone* getTimeZoneFromConfig(const core::QueryConfig& config) {
     }
   }
   return nullptr;
+}
+
+bool isDecimalReinterpretCast(const TypePtr& fromType, const TypePtr& toType) {
+  if (!fromType->isDecimal() || !toType->isDecimal()) {
+    return false;
+  }
+
+  if (fromType->isShortDecimal() != toType->isShortDecimal() ||
+      fromType->isLongDecimal() != toType->isLongDecimal()) {
+    return false;
+  }
+
+  const auto [fromPrecision, fromScale] = getDecimalPrecisionScale(*fromType);
+  const auto [toPrecision, toScale] = getDecimalPrecisionScale(*toType);
+  return fromScale == toScale && toPrecision >= fromPrecision;
+}
+
+template <typename T>
+VectorPtr relabelConstant(
+    const SelectivityVector& rows,
+    const BaseVector& input,
+    exec::EvalCtx& context,
+    const TypePtr& toType) {
+  static_assert(
+      !std::is_same_v<T, StringView>,
+      "Relabeling is only supported for fixed-width types.");
+
+  VELOX_CHECK_EQ(
+      input.type()->kind(),
+      CppToType<T>::typeKind,
+      "Cannot relabel constant unless the input type uses the requested physical C++ representation: {}.",
+      input.type());
+  VELOX_CHECK_EQ(
+      toType->kind(),
+      CppToType<T>::typeKind,
+      "Cannot relabel constant unless the target type uses the requested physical C++ representation: {}.",
+      toType);
+
+  const auto* constantInput = input.as<ConstantVector<T>>();
+  if (constantInput->isNullAt(0)) {
+    return BaseVector::createNullConstant(toType, rows.end(), context.pool());
+  }
+
+  return std::make_shared<ConstantVector<T>>(
+      context.pool(), rows.end(), false, toType, T(constantInput->valueAt(0)));
+}
+
+// Reinterprets a flat vector as 'toType' without changing the underlying value
+// or null buffers. This is valid only when both types have the same fixed-width
+// physical representation T.
+template <typename T>
+VectorPtr reinterpret(const BaseVector& input, const TypePtr& toType) {
+  static_assert(
+      !std::is_same_v<T, StringView>,
+      "Reinterpretation is only supported for fixed-width types.");
+
+  VELOX_CHECK_EQ(
+      input.type()->kind(),
+      CppToType<T>::typeKind,
+      "Cannot reinterpret vector unless the input type uses the requested physical C++ representation: {}.",
+      input.type());
+  VELOX_CHECK_EQ(
+      toType->kind(),
+      CppToType<T>::typeKind,
+      "Cannot reinterpret vector unless the target type uses the requested physical C++ representation: {}.",
+      toType);
+
+  const auto* flatInput = input.asFlatVector<T>();
+  VELOX_CHECK_NOT_NULL(
+      flatInput,
+      "Cannot reinterpret vector unless it has flat encoding: {}.",
+      input.encoding());
+  return std::make_shared<FlatVector<T>>(
+      flatInput->pool(),
+      toType,
+      flatInput->nulls(),
+      flatInput->size(),
+      flatInput->values(),
+      std::vector<BufferPtr>());
 }
 
 } // namespace
@@ -212,13 +295,13 @@ VectorPtr CastExpr::castFromTime(
     const BaseVector& input,
     exec::EvalCtx& context,
     const TypePtr& toType) {
-  VectorPtr castResult;
-  context.ensureWritable(rows, toType, castResult);
-  (*castResult).clearNulls(rows);
-
-  auto* inputFlatVector = input.as<SimpleVector<int64_t>>();
   switch (toType->kind()) {
     case TypeKind::VARCHAR: {
+      VectorPtr castResult;
+      context.ensureWritable(rows, toType, castResult);
+      (*castResult).clearNulls(rows);
+      auto* inputFlatVector = input.as<SimpleVector<int64_t>>();
+
       // Get session timezone
       const auto* timeZone =
           getTimeZoneFromConfig(context.execCtx()->queryCtx()->queryConfig());
@@ -273,31 +356,17 @@ VectorPtr CastExpr::castFromTime(
       return castResult;
     }
     case TypeKind::BIGINT: {
-      // if input is constant, create a constant output vector
       if (input.isConstantEncoding()) {
-        auto constantInput = input.as<ConstantVector<int64_t>>();
-        if (constantInput->isNullAt(0)) {
-          return BaseVector::createNullConstant(
-              toType, rows.end(), context.pool());
-        } else {
-          auto constantValue = constantInput->valueAt(0);
-          return std::make_shared<ConstantVector<int64_t>>(
-              context.pool(),
-              rows.end(),
-              false, // isNull
-              toType,
-              std::move(constantValue));
-        }
+        return relabelConstant<int64_t>(rows, input, context, toType);
       }
-
-      // fallback to element-wise copy for non-constant inputs
-      auto* resultFlatVector = castResult->as<FlatVector<int64_t>>();
-      applyToSelectedNoThrowLocal(context, rows, castResult, [&](int row) {
-        resultFlatVector->set(row, inputFlatVector->valueAt(row));
-      });
-      return castResult;
+      return reinterpret<int64_t>(input, toType);
     }
     case TypeKind::TIMESTAMP: {
+      VectorPtr castResult;
+      context.ensureWritable(rows, toType, castResult);
+      (*castResult).clearNulls(rows);
+      auto* inputFlatVector = input.as<SimpleVector<int64_t>>();
+
       VELOX_DCHECK(toType->equivalent(*TIMESTAMP()));
       // if input is constant, create a constant output vector
       if (input.isConstantEncoding()) {
@@ -708,6 +777,19 @@ VectorPtr CastExpr::applyDecimal(
     exec::EvalCtx& context,
     const TypePtr& fromType,
     const TypePtr& toType) {
+  if (isDecimalReinterpretCast(fromType, toType)) {
+    if (toType->isShortDecimal()) {
+      if (input.isConstantEncoding()) {
+        return relabelConstant<int64_t>(rows, input, context, toType);
+      }
+      return reinterpret<int64_t>(input, toType);
+    }
+    if (input.isConstantEncoding()) {
+      return relabelConstant<int128_t>(rows, input, context, toType);
+    }
+    return reinterpret<int128_t>(input, toType);
+  }
+
   VectorPtr castResult;
   context.ensureWritable(rows, toType, castResult);
   (*castResult).clearNulls(rows);
@@ -1037,6 +1119,23 @@ VectorPtr CastExpr::applyTimestampTimestampUtcCast(
     const SelectivityVector& rows,
     exec::EvalCtx& context,
     const BaseVector& input) {
+  const auto* sessionTimeZone =
+      getTimeZoneFromConfig(context.execCtx()->queryCtx()->queryConfig());
+  if (!sessionTimeZone) {
+    if constexpr (kToUtc) {
+      if (input.isConstantEncoding()) {
+        return relabelConstant<Timestamp>(
+            rows, input, context, TIMESTAMP_UTC());
+      }
+      return reinterpret<Timestamp>(input, TIMESTAMP_UTC());
+    } else {
+      if (input.isConstantEncoding()) {
+        return relabelConstant<Timestamp>(rows, input, context, TIMESTAMP());
+      }
+      return reinterpret<Timestamp>(input, TIMESTAMP());
+    }
+  }
+
   VectorPtr result;
   if constexpr (kToUtc) {
     context.ensureWritable(rows, TIMESTAMP_UTC(), result);
@@ -1046,18 +1145,14 @@ VectorPtr CastExpr::applyTimestampTimestampUtcCast(
   (*result).clearNulls(rows);
   auto* resultVector = result->asFlatVector<Timestamp>();
   const auto& inputVector = *input.as<SimpleVector<Timestamp>>();
-  const auto* sessionTimeZone =
-      getTimeZoneFromConfig(context.execCtx()->queryCtx()->queryConfig());
   applyToSelectedNoThrowLocal(context, rows, result, [&](vector_size_t row) {
     Timestamp ts = inputVector.valueAt(row);
-    if (sessionTimeZone) {
-      if constexpr (kToUtc) {
-        ts.toTimezone(*sessionTimeZone);
-      } else {
-        // Convert from local timestamp representation to UTC, applying DST gap
-        // correction for spring-forward transitions.
-        hooks_->castDateTimestampToGMT(ts, *sessionTimeZone);
-      }
+    if constexpr (kToUtc) {
+      ts.toTimezone(*sessionTimeZone);
+    } else {
+      // Convert from local timestamp representation to UTC, applying DST gap
+      // correction for spring-forward transitions.
+      hooks_->castDateTimestampToGMT(ts, *sessionTimeZone);
     }
     resultVector->set(row, ts);
   });

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -1839,6 +1839,14 @@ TEST_F(CastExprTest, decimalToDecimal) {
            72'000'000'000},
           DECIMAL(20, 11)));
 
+  // Reinterpret when scale is unchanged.
+  testCast(
+      shortFlat,
+      makeFlatVector<int64_t>({-3, -2, -1, 0, 55, 69, 72}, DECIMAL(18, 2)));
+  testCast(
+      longFlat,
+      makeFlatVector<int128_t>({-201, -109, 0, 105, 208}, DECIMAL(38, 2)));
+
   // short to long, scale down.
   testCast(
       makeFlatVector<int64_t>({-20'500, -190, 12'345, 19'999}, DECIMAL(6, 4)),
@@ -3172,106 +3180,11 @@ TEST_F(CastExprTest, timeToVarcharCast) {
 }
 
 TEST_F(CastExprTest, timeToBigintCast) {
-  {
-    // Test casting TIME to BIGINT
-
-    // Test various TIME values (milliseconds since midnight)
-    // 0 = 00:00:00.000
-    // 3661000 = 01:01:01.000
-    // 43200000 = 12:00:00.000 (noon)
-    // 86399999 = 23:59:59.999
-    auto timeVector =
-        makeFlatVector<int64_t>({0, 3661000, 43200000, 86399999}, TIME());
-
-    auto result = evaluate<FlatVector<int64_t>>(
-        "cast(c0 as bigint)", makeRowVector({timeVector}));
-
-    // Should return the same values since TIME is already stored as int64_t
-    // milliseconds
-    auto expected = makeFlatVector<int64_t>({0, 3661000, 43200000, 86399999});
-
-    assertEqualVectors(expected, result);
-  }
-
-  {
-    // Test casting TIME to BIGINT with nulls
-    auto timeVector = makeNullableFlatVector<int64_t>(
-        {0, std::nullopt, 43200000, std::nullopt}, TIME());
-
-    auto result = evaluate<FlatVector<int64_t>>(
-        "cast(c0 as bigint)", makeRowVector({timeVector}));
-
-    auto expected = makeNullableFlatVector<int64_t>(
-        {0, std::nullopt, 43200000, std::nullopt});
-
-    assertEqualVectors(expected, result);
-  }
-
-  {
-    // Test try_cast for TIME to BIGINT
-    auto timeVector = makeFlatVector<int64_t>({0, 43200000}, TIME());
-
-    auto result = evaluate<FlatVector<int64_t>>(
-        "try_cast(c0 as bigint)", makeRowVector({timeVector}));
-
-    auto expected = makeFlatVector<int64_t>({0, 43200000});
-
-    assertEqualVectors(expected, result);
-  }
-
-  {
-    // Test constant TIME vector cast to BIGINT (non-null)
-    // This tests the optimization path for constant vectors
-    auto constantTimeVector = BaseVector::wrapInConstant(
-        1000, 0, makeFlatVector<int64_t>({43200000}, TIME()));
-
-    auto result =
-        evaluate("cast(c0 as bigint)", makeRowVector({constantTimeVector}));
-
-    // Should return a constant vector with the same value
-    auto expected = BaseVector::wrapInConstant(
-        1000, 0, makeFlatVector<int64_t>({43200000}));
-
-    assertEqualVectors(expected, result);
-    // Verify the result is actually constant-encoded (optimization worked)
-    ASSERT_TRUE(result->isConstantEncoding());
-  }
-
-  {
-    // Test constant TIME vector cast to BIGINT (null)
-    // This tests the optimization path for null constant vectors
-    auto nullTimeVector = BaseVector::createNullConstant(TIME(), 500, pool());
-
-    auto result =
-        evaluate("cast(c0 as bigint)", makeRowVector({nullTimeVector}));
-
-    // Should return a null constant vector
-    auto expected = BaseVector::createNullConstant(BIGINT(), 500, pool());
-
-    assertEqualVectors(expected, result);
-    // Verify the result is actually constant-encoded (optimization worked)
-    ASSERT_TRUE(result->isConstantEncoding());
-    ASSERT_TRUE(result->isNullAt(0));
-  }
-
-  {
-    // Test constant TIME vector cast to BIGINT with different sizes
-    // This ensures the optimization correctly handles different vector sizes
-    for (auto size : {1, 10, 100, 1000}) {
-      auto constantTimeVector = BaseVector::wrapInConstant(
-          size, 0, makeFlatVector<int64_t>({86399999}, TIME()));
-
-      auto result =
-          evaluate("cast(c0 as bigint)", makeRowVector({constantTimeVector}));
-
-      auto expected = BaseVector::wrapInConstant(
-          size, 0, makeFlatVector<int64_t>({86399999}));
-
-      assertEqualVectors(expected, result);
-      ASSERT_TRUE(result->isConstantEncoding());
-      ASSERT_EQ(result->size(), size);
-    }
-  }
+  testCast<int64_t, int64_t>(
+      TIME(),
+      BIGINT(),
+      {0, 3'661'000, 43'200'000, 86'399'999, std::nullopt},
+      {0, 3'661'000, 43'200'000, 86'399'999, std::nullopt});
 }
 
 TEST_F(CastExprTest, varcharToTimeCast) {

--- a/velox/functions/sparksql/benchmarks/CastBenchmark.cpp
+++ b/velox/functions/sparksql/benchmarks/CastBenchmark.cpp
@@ -18,18 +18,66 @@
 #include <folly/init/Init.h>
 
 #include "velox/benchmarks/ExpressionBenchmarkBuilder.h"
+#include "velox/core/Expressions.h"
+#include "velox/core/QueryCtx.h"
 #include "velox/functions/sparksql/registration/Register.h"
 
 using namespace facebook;
 
 using namespace facebook::velox;
 
+namespace {
+
+core::TypedExprPtr makeCastExpr(
+    const TypePtr& fromType,
+    const std::string& fieldName,
+    const TypePtr& toType) {
+  auto input =
+      std::make_shared<const core::FieldAccessTypedExpr>(fromType, fieldName);
+  return std::make_shared<const core::CastTypedExpr>(
+      toType, std::move(input), false);
+}
+
+// Add a benchmark for a cast expression. The benchmark will evaluate the cast
+// expression on the input row vector for a number of iterations.
+// This is used when 'DuckSqlExpressionsParser' cannot be used to parse the
+// expression, e.g. when the input type is TIMESTAMP_UTC.
+void addTypedCastBenchmark(
+    const std::string& name,
+    const RowVectorPtr& input,
+    core::TypedExprPtr castExpr,
+    core::ExecCtx& execCtx,
+    int32_t iterations) {
+  auto exprSet = std::make_shared<exec::ExprSet>(
+      std::vector<core::TypedExprPtr>{std::move(castExpr)}, &execCtx);
+  folly::addBenchmark(__FILE__, name, [input, exprSet, &execCtx, iterations]() {
+    exec::EvalCtx evalCtx(&execCtx, exprSet.get(), input.get());
+    SelectivityVector rows(input->size());
+    std::vector<VectorPtr> results(1);
+
+    int64_t count = 0;
+    for (auto i = 0; i < iterations; ++i) {
+      exprSet->eval(rows, evalCtx, results);
+      BaseVector::flattenVector(results[0]);
+      results[0]->prepareForReuse();
+      count += results[0]->size();
+    }
+    folly::doNotOptimizeAway(count);
+    return 1;
+  });
+}
+
+} // namespace
+
 int main(int argc, char** argv) {
   folly::Init init(&argc, &argv);
   memory::MemoryManager::initialize(memory::MemoryManager::Options{});
-  functions::sparksql::registerFunctions("");
 
   ExpressionBenchmarkBuilder benchmarkBuilder;
+  // 'ExpressionBenchmarkBuilder' registers the default special forms through
+  // 'FunctionBenchmarkBase'. Register SparkSQL functions afterward so the
+  // benchmarks use Spark cast implementations.
+  functions::sparksql::registerFunctions("");
   const vector_size_t vectorSize = 1000;
   auto vectorMaker = benchmarkBuilder.vectorMaker();
   auto decimalInput = vectorMaker.flatVector<int64_t>(
@@ -52,9 +100,28 @@ int main(int argc, char** argv) {
       nullptr,
       DECIMAL(38, 16));
 
+  auto timestampInput = vectorMaker.rowVector(
+      {"timestamp", "timestamp_utc"},
+      {vectorMaker.flatVector<Timestamp>(
+           vectorSize,
+           [](auto j) {
+             return Timestamp(1'600'000'000 + j, j % 1'000'000'000);
+           },
+           nullptr,
+           TIMESTAMP()),
+       vectorMaker.flatVector<Timestamp>(
+           vectorSize,
+           [](auto j) {
+             return Timestamp(1'600'000'000 + j, j % 1'000'000'000);
+           },
+           nullptr,
+           TIMESTAMP_UTC())});
+
+  const std::string setName = "spark cast";
+  const int iterations = 100;
   benchmarkBuilder
       .addBenchmarkSet(
-          "cast_decimal_as_varchar",
+          setName,
           vectorMaker.rowVector(
               {"decimal", "short_decimal", "small_decimal", "long_decimal"},
               {
@@ -68,8 +135,23 @@ int main(int argc, char** argv) {
       .addExpression("cast_short_decimal", "cast (short_decimal as varchar)")
       .addExpression("cast_small_decimal", "cast (small_decimal as varchar)")
       .addExpression("cast_long_decimal", "cast (long_decimal as varchar)")
-      .withIterations(100)
+      .withIterations(iterations)
       .disableTesting();
+
+  auto queryCtx = core::QueryCtx::create();
+  core::ExecCtx execCtx(benchmarkBuilder.pool(), queryCtx.get());
+  addTypedCastBenchmark(
+      setName + "##cast_timestamp_as_timestamp_utc",
+      timestampInput,
+      makeCastExpr(TIMESTAMP(), "timestamp", TIMESTAMP_UTC()),
+      execCtx,
+      iterations);
+  addTypedCastBenchmark(
+      setName + "##cast_timestamp_utc_as_timestamp",
+      timestampInput,
+      makeCastExpr(TIMESTAMP_UTC(), "timestamp_utc", TIMESTAMP()),
+      execCtx,
+      iterations);
 
   benchmarkBuilder.registerBenchmarks();
   folly::runBenchmarks();

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -2004,10 +2004,12 @@ TEST_F(SparkCastExprTestAnsiOn, dateToTimestampTimezoneGap) {
 TEST_F(SparkCastExprTestAnsiOff, timestampToTimestampUtc) {
   // No session timezone: identity cast.
   testCast(
-      makeFlatVector<Timestamp>(
-          {Timestamp(0, 0), Timestamp(1'000'000'000, 123)}, TIMESTAMP()),
-      makeFlatVector<Timestamp>(
-          {Timestamp(0, 0), Timestamp(1'000'000'000, 123)}, TIMESTAMP_UTC()));
+      makeNullableFlatVector<Timestamp>(
+          {Timestamp(0, 0), Timestamp(1'000'000'000, 123), std::nullopt},
+          TIMESTAMP()),
+      makeNullableFlatVector<Timestamp>(
+          {Timestamp(0, 0), Timestamp(1'000'000'000, 123), std::nullopt},
+          TIMESTAMP_UTC()));
 
   // America/Los_Angeles (PST = UTC-8): 2020-01-01 00:00:00 UTC
   // → local 2019-12-31 16:00:00 → stored as epoch 1577808000.
@@ -2044,10 +2046,12 @@ TEST_F(SparkCastExprTestAnsiOn, timestampToTimestampUtc) {
 TEST_F(SparkCastExprTestAnsiOff, timestampUtcToTimestamp) {
   // No session timezone: identity cast.
   testCast(
-      makeFlatVector<Timestamp>(
-          {Timestamp(0, 0), Timestamp(1'000'000'000, 123)}, TIMESTAMP_UTC()),
-      makeFlatVector<Timestamp>(
-          {Timestamp(0, 0), Timestamp(1'000'000'000, 123)}, TIMESTAMP()));
+      makeNullableFlatVector<Timestamp>(
+          {Timestamp(0, 0), Timestamp(1'000'000'000, 123), std::nullopt},
+          TIMESTAMP_UTC()),
+      makeNullableFlatVector<Timestamp>(
+          {Timestamp(0, 0), Timestamp(1'000'000'000, 123), std::nullopt},
+          TIMESTAMP()));
 
   // America/Los_Angeles (PST = UTC-8): stored epoch 1577808000
   // → local 2019-12-31 16:00:00 → UTC 2020-01-01 00:00:00 = epoch 1577836800.


### PR DESCRIPTION
This PR adds fast paths for casts where the logical type changes but the 
underlying raw value and nulls can be reused directly.

**Covered cases**

- Decimal casts with the same scale and compatible physical storage.
- TIME -> BIGINT, both backed by int64_t.
- TIMESTAMP <-> TIMESTAMP_UTC when no timezone conversion is required.

For these casts, the result vector reuses the input value buffer and nulls, only 
updating the output type, avoiding the existing per-row cast path.

**Benchmark Results**

```
cast_short_decimal_:              404.88us -> 43.74us   (~9.3x faster)
cast_long_decimal_s:              431.88us -> 96.90us   (~4.5x faster)
cast_time_as_bigint:              128.51us -> 20.70us   (~6.2x faster)

spark timestamp -> timestamp utc: 191.54us -> 61.89us   (~3.1x faster)
spark timestamp utc -> timestamp: 202.62us -> 58.48us   (~3.5x faster)
```

The speedup grows with larger inputs. At 10'000 rows, the old row-by-row path 
reaches millisecond-level, while the new buffer-reuse path stays nearly flat.