### PR TITLE
feat: Replace (union) an existing deletion vector on repeated mutation (#18117)

### DIFF
--- a/velox/connectors/hive/iceberg/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/CMakeLists.txt
@@ -45,6 +45,7 @@ velox_add_library(
   velox_hive_iceberg_splitreader
   ${ICEBERG_SOURCES}
   HEADERS
+  DeletionVectorFormat.h
   DeletionVectorReader.h
   DeletionVectorWriter.h
   EqualityDeleteFileReader.h

--- a/velox/connectors/hive/iceberg/DeletionVectorFormat.h
+++ b/velox/connectors/hive/iceberg/DeletionVectorFormat.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstddef>
+
+namespace facebook::velox::connector::hive::iceberg {
+
+/// Iceberg deletion-vector-v1 blob frame constants (Iceberg V3 spec), shared by
+/// DeletionVectorWriter and DeletionVectorReader so the on-disk value can never
+/// drift between the write and read paths. On disk a deletion vector blob is:
+///   [length: 4B big-endian][magic][roaring bitmap][CRC-32: 4B big-endian]
+/// where 'length' and the CRC-32 cover the magic bytes + bitmap. The magic is
+/// Iceberg's MAGIC_NUMBER 0x6439D3D1 written little-endian, i.e. the on-disk
+/// bytes D1 D3 39 64 (org.apache.iceberg.deletes.BitmapPositionDeleteIndex).
+inline constexpr char kDeletionVectorMagic[] = {'\xD1', '\xD3', '\x39', '\x64'};
+inline constexpr size_t kDeletionVectorMagicSize = 4;
+
+// Sizes of the big-endian length prefix and trailing CRC-32 that bracket the
+// magic + bitmap in the deletion-vector-v1 frame.
+inline constexpr size_t kDeletionVectorLengthSize = 4;
+inline constexpr size_t kDeletionVectorCrcSize = 4;
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/DeletionVectorReader.cpp
+++ b/velox/connectors/hive/iceberg/DeletionVectorReader.cpp
@@ -16,7 +16,13 @@
 
 #include "velox/connectors/hive/iceberg/DeletionVectorReader.h"
 
+#include "velox/connectors/hive/iceberg/DeletionVectorFormat.h"
+
+#include <folly/hash/Checksum.h>
 #include <folly/lang/Bits.h>
+
+#include <cstring>
+#include <string_view>
 
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/base/Exceptions.h"
@@ -28,13 +34,60 @@ namespace {
 static constexpr uint32_t kSerialCookieNoRun = 12'346;
 static constexpr uint32_t kSerialCookie = 12'347;
 static constexpr uint32_t kRunContainersNoOffsetThreshold = 4;
+
+uint32_t readBigEndian32(const char* data) {
+  uint32_t value;
+  std::memcpy(&value, data, sizeof(value));
+  return folly::Endian::big(value);
+}
+
+// Unwraps the Iceberg deletion-vector-v1 blob frame
+// ([length: 4B BE][magic][bitmap][CRC-32: 4B BE]), validating the magic and
+// CRC-32, and returns a view of the inner roaring bitmap. If 'blob' is not
+// framed (legacy raw roaring bitmap), returns it unchanged.
+std::string_view unframeDeletionVector(const std::string& blob) {
+  constexpr size_t kLengthSize = kDeletionVectorLengthSize;
+  constexpr size_t kCrcSize = kDeletionVectorCrcSize;
+  constexpr size_t kHeaderSize = kLengthSize + kDeletionVectorMagicSize;
+  if (blob.size() < kHeaderSize ||
+      std::memcmp(
+          blob.data() + kLengthSize,
+          kDeletionVectorMagic,
+          kDeletionVectorMagicSize) != 0) {
+    return blob;
+  }
+
+  const uint32_t magicAndVectorLength = readBigEndian32(blob.data());
+  VELOX_CHECK_GE(
+      magicAndVectorLength,
+      kDeletionVectorMagicSize,
+      "Deletion-vector-v1 length too small: {}.",
+      magicAndVectorLength);
+  VELOX_CHECK_EQ(
+      blob.size(),
+      kLengthSize + magicAndVectorLength + kCrcSize,
+      "Deletion-vector-v1 blob size mismatch.");
+
+  const uint32_t storedCrc =
+      readBigEndian32(blob.data() + kLengthSize + magicAndVectorLength);
+  const uint32_t computedCrc = folly::crc32(
+      reinterpret_cast<const uint8_t*>(blob.data() + kLengthSize),
+      magicAndVectorLength);
+  VELOX_CHECK_EQ(storedCrc, computedCrc, "Deletion-vector-v1 CRC-32 mismatch.");
+
+  return std::string_view(blob).substr(
+      kHeaderSize, magicAndVectorLength - kDeletionVectorMagicSize);
+}
 } // namespace
 
 DeletionVectorReader::DeletionVectorReader(
     const IcebergDeleteFile& dvFile,
     uint64_t splitOffset,
-    memory::MemoryPool* /*pool*/)
-    : dvFile_(dvFile), splitOffset_(splitOffset) {
+    memory::MemoryPool* /*pool*/,
+    std::shared_ptr<const config::ConfigBase> connectorConfig)
+    : dvFile_(dvFile),
+      splitOffset_(splitOffset),
+      connectorConfig_(std::move(connectorConfig)) {
   VELOX_CHECK(
       dvFile_.content == FileContent::kDeletionVector,
       "Expected deletion vector file but got content type: {}",
@@ -84,8 +137,18 @@ void DeletionVectorReader::loadBitmap() {
     }
   }
 
-  auto fs = filesystems::getFileSystem(dvFile_.filePath, nullptr);
+  // Pass the connector config (e.g. hive.manifold.* credentials) so
+  // config-requiring filesystems like Manifold resolve a properly-configured
+  // client for the Puffin read. Passing nullptr here previously left the
+  // Manifold client unconfigured and segfaulted in openFileForRead.
+  auto fs = filesystems::getFileSystem(dvFile_.filePath, connectorConfig_);
+  VELOX_CHECK_NOT_NULL(
+      fs,
+      "No filesystem registered for deletion vector file: {}",
+      dvFile_.filePath);
   auto readFile = fs->openFileForRead(dvFile_.filePath);
+  VELOX_CHECK_NOT_NULL(
+      readFile, "Failed to open deletion vector file: {}", dvFile_.filePath);
 
   auto fileSize = readFile->size();
   VELOX_CHECK_LE(
@@ -105,16 +168,14 @@ void DeletionVectorReader::loadBitmap() {
   std::string blobData(blobLength, '\0');
   readFile->pread(blobOffset, blobLength, blobData.data());
 
-  // Detect format: 64-bit Roaring64Bitmap vs 32-bit RoaringBitmap.
-  // 64-bit format starts with [numGroups: uint64]. If the first 4 bytes
-  // match a 32-bit cookie (12346 or 12347), it's a legacy 32-bit bitmap.
-  // Otherwise, interpret as 64-bit format.
-  deserializeRoaring64Bitmap(blobData);
+  // Unwrap the Iceberg deletion-vector-v1 frame (validates magic + CRC-32),
+  // then parse the inner roaring bitmap. Legacy unframed blobs pass through.
+  deserializeRoaring64Bitmap(unframeDeletionVector(blobData));
 
   std::sort(deletedPositions_.begin(), deletedPositions_.end());
 }
 
-void DeletionVectorReader::deserializeRoaring64Bitmap(const std::string& data) {
+void DeletionVectorReader::deserializeRoaring64Bitmap(std::string_view data) {
   if (data.size() < 8) {
     VELOX_FAIL(
         "Deletion vector blob too small: {} bytes, expected at least 8.",
@@ -438,6 +499,11 @@ void DeletionVectorReader::readDeletePositions(
 
 bool DeletionVectorReader::noMoreData() const {
   return loaded_ && positionIndex_ >= deletedPositions_.size();
+}
+
+const std::vector<int64_t>& DeletionVectorReader::deletedPositions() {
+  loadBitmap();
+  return deletedPositions_;
 }
 
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/DeletionVectorReader.h
+++ b/velox/connectors/hive/iceberg/DeletionVectorReader.h
@@ -16,9 +16,15 @@
 
 #pragma once
 
+#include <memory>
+#include <string_view>
 #include <vector>
 
 #include "velox/connectors/hive/iceberg/IcebergDeleteFile.h"
+
+namespace facebook::velox::config {
+class ConfigBase;
+}
 
 namespace facebook::velox::connector::hive::iceberg {
 
@@ -40,10 +46,14 @@ class DeletionVectorReader {
   ///        blob offset, and blob length.
   /// @param splitOffset File position of the first row in the split.
   /// @param pool Memory pool for internal allocations.
+  /// @param connectorConfig Connector configuration used to resolve the
+  ///        filesystem for the Puffin file (e.g. Manifold client credentials).
+  ///        Passing nullptr leaves config-requiring filesystems unconfigured.
   DeletionVectorReader(
       const IcebergDeleteFile& dvFile,
       uint64_t splitOffset,
-      memory::MemoryPool* pool);
+      memory::MemoryPool* pool,
+      std::shared_ptr<const config::ConfigBase> connectorConfig);
 
   /// Reads deleted positions from the DV and sets corresponding bits in the
   /// deleteBitmap for the current batch range.
@@ -55,6 +65,11 @@ class DeletionVectorReader {
   /// Returns true when there is no more data.
   bool noMoreData() const;
 
+  /// Loads the deletion vector (if not already loaded) and returns the sorted,
+  /// absolute file-level deleted positions. Used to seed a DeletionVectorWriter
+  /// when replacing an existing DV with the union of old and new positions.
+  const std::vector<int64_t>& deletedPositions();
+
   static constexpr int32_t kDvOffsetFieldId = 100;
   static constexpr int32_t kDvLengthFieldId = 101;
 
@@ -62,7 +77,7 @@ class DeletionVectorReader {
   void loadBitmap();
 
   // Deserializes a 64-bit roaring bitmap (Roaring64Bitmap format).
-  void deserializeRoaring64Bitmap(const std::string& data);
+  void deserializeRoaring64Bitmap(std::string_view data);
 
   // Deserializes a 32-bit roaring bitmap from portable binary format.
   // Positions are offset by highBitsOffset (upper 32 bits for 64-bit mode,
@@ -77,6 +92,9 @@ class DeletionVectorReader {
 
   // Base offset of the split within the data file (for position mapping).
   const uint64_t splitOffset_;
+
+  // Connector configuration for resolving the Puffin file's filesystem.
+  const std::shared_ptr<const config::ConfigBase> connectorConfig_;
 
   // Sorted list of deleted row positions (absolute, file-level positions).
   std::vector<int64_t> deletedPositions_;

--- a/velox/connectors/hive/iceberg/DeletionVectorWriter.cpp
+++ b/velox/connectors/hive/iceberg/DeletionVectorWriter.cpp
@@ -16,8 +16,11 @@
 
 #include "velox/connectors/hive/iceberg/DeletionVectorWriter.h"
 
+#include "velox/connectors/hive/iceberg/DeletionVectorFormat.h"
+
 #include <algorithm>
 
+#include <folly/hash/Checksum.h>
 #include <folly/json.h>
 #include <folly/lang/Bits.h>
 
@@ -36,8 +39,8 @@ constexpr uint32_t kMaxArrayContainerCardinality = 4'096;
 constexpr size_t kBitmapContainerBytes = 8'192;
 constexpr size_t kBitmapContainerWords = 1'024;
 
-// Puffin file format constants (per Iceberg spec).
-constexpr char kPuffinMagic[] = {'\x50', '\x55', '\x46', '\x31'};
+// Puffin file format constants (per Iceberg spec). Magic is "PFA1".
+constexpr char kPuffinMagic[] = {'\x50', '\x46', '\x41', '\x31'};
 constexpr size_t kPuffinMagicSize = 4;
 constexpr uint32_t kPuffinFooterFlags = 0;
 
@@ -60,6 +63,34 @@ void writeLittleEndian(std::string& out, uint32_t val) {
 void writeLittleEndian(std::string& out, uint64_t val) {
   val = folly::Endian::little(val);
   out.append(reinterpret_cast<const char*>(&val), sizeof(val));
+}
+
+void writeBigEndian(std::string& out, uint32_t val) {
+  val = folly::Endian::big(val);
+  out.append(reinterpret_cast<const char*>(&val), sizeof(val));
+}
+
+// Wraps the serialized roaring bitmap in the Iceberg deletion-vector-v1 blob
+// frame: [length: 4B BE][magic: D1 D3 39 64][bitmap][CRC-32: 4B BE], where
+// 'length' and the CRC-32 cover magic + bitmap. This is the on-disk layout
+// Iceberg's BitmapPositionDeleteIndex produces, so the blob is readable by
+// spec-compliant Iceberg engines and vice versa.
+std::string frameDeletionVector(const std::string& bitmap) {
+  std::string magicAndVector;
+  magicAndVector.reserve(kDeletionVectorMagicSize + bitmap.size());
+  magicAndVector.append(kDeletionVectorMagic, kDeletionVectorMagicSize);
+  magicAndVector.append(bitmap);
+
+  const uint32_t crc = folly::crc32(
+      reinterpret_cast<const uint8_t*>(magicAndVector.data()),
+      magicAndVector.size());
+
+  std::string framed;
+  framed.reserve(sizeof(uint32_t) + magicAndVector.size() + sizeof(uint32_t));
+  writeBigEndian(framed, static_cast<uint32_t>(magicAndVector.size()));
+  framed.append(magicAndVector);
+  writeBigEndian(framed, crc);
+  return framed;
 }
 
 // Serializes the key-cardinality header for a 32-bit Roaring Bitmap.
@@ -131,6 +162,13 @@ void DeletionVectorWriter::addDeletedPositions(
   for (auto pos : positions) {
     addDeletedPosition(pos);
   }
+}
+
+size_t DeletionVectorWriter::numDistinctPositions() const {
+  std::vector<int64_t> sorted = positions_;
+  std::sort(sorted.begin(), sorted.end());
+  return static_cast<size_t>(
+      std::unique(sorted.begin(), sorted.end()) - sorted.begin());
 }
 
 std::string DeletionVectorWriter::serialize32(
@@ -206,9 +244,13 @@ std::pair<uint64_t, uint64_t> writePuffinFile(
     dwio::common::FileSink& sink,
     memory::MemoryPool& pool,
     const std::string& blobData,
-    const std::string& referencedDataFile) {
+    const std::string& referencedDataFile,
+    int64_t cardinality) {
+  // Wrap the raw roaring bitmap in the Iceberg deletion-vector-v1 frame so the
+  // blob is interoperable with spec-compliant Iceberg readers.
+  const std::string framedBlob = frameDeletionVector(blobData);
   uint64_t blobOffset = kPuffinMagicSize;
-  uint64_t blobLength = blobData.size();
+  uint64_t blobLength = framedBlob.size();
 
   folly::dynamic blobMeta = folly::dynamic::object(
       "type", kDeletionVectorBlobType)(
@@ -221,6 +263,9 @@ std::pair<uint64_t, uint64_t> writePuffinFile(
 
   folly::dynamic properties = folly::dynamic::object;
   properties["referenced-data-file"] = referencedDataFile;
+  // Iceberg V3 requires the deletion-vector-v1 blob to carry its cardinality
+  // (the number of deleted positions).
+  properties["cardinality"] = std::to_string(cardinality);
   blobMeta["properties"] = properties;
 
   folly::dynamic footer = folly::dynamic::object;
@@ -232,7 +277,9 @@ std::pair<uint64_t, uint64_t> writePuffinFile(
 
   std::string fileContent;
   fileContent.append(kPuffinMagic, kPuffinMagicSize);
-  fileContent.append(blobData);
+  fileContent.append(framedBlob);
+  // Footer = Magic FooterPayload FooterPayloadSize Flags Magic (Puffin spec).
+  fileContent.append(kPuffinMagic, kPuffinMagicSize);
   fileContent.append(footerJson);
   uint32_t littleEndianSize = folly::Endian::little(footerPayloadSize);
   fileContent.append(

--- a/velox/connectors/hive/iceberg/DeletionVectorWriter.h
+++ b/velox/connectors/hive/iceberg/DeletionVectorWriter.h
@@ -60,10 +60,18 @@ class DeletionVectorWriter {
   /// Adds multiple deleted row positions.
   void addDeletedPositions(const std::vector<int64_t>& positions);
 
-  /// Returns the number of deleted positions collected so far.
+  /// Returns the number of deleted positions collected so far, including any
+  /// duplicates. Prefer numDistinctPositions() for the DV blob cardinality.
   size_t numPositions() const {
     return positions_.size();
   }
+
+  /// Returns the number of distinct deleted positions, i.e. the cardinality of
+  /// the bitmap that serialize() emits (which sorts and de-duplicates). Use
+  /// this for the Iceberg deletion-vector-v1 'cardinality' property and the
+  /// commit-message record count, since seeding an existing DV and then adding
+  /// overlapping new deletes can make positions_ contain duplicates.
+  size_t numDistinctPositions() const;
 
   /// Serializes collected positions into a 64-bit roaring bitmap.
   ///
@@ -94,9 +102,10 @@ class DeletionVectorWriter {
 /// provided file sink.
 ///
 /// The Puffin file format consists of:
-///   - 4-byte magic: "PUF1"
-///   - Blob data (the serialized roaring bitmap)
-///   - Footer: blob metadata + footer payload size + magic
+///   - 4-byte magic: "PFA1"
+///   - Blob data: the deletion-vector-v1 frame
+///     [length: 4B BE][magic: D1 D3 39 64][roaring bitmap][CRC-32: 4B BE]
+///   - Footer: magic + blob metadata JSON + footer payload size + flags + magic
 ///
 /// The caller owns 'sink' and is responsible for opening it before this call
 /// and closing it after. Routing the bytes through 'sink' lets the puffin
@@ -106,13 +115,16 @@ class DeletionVectorWriter {
 ///
 /// @param sink Opened file sink to write the Puffin bytes into.
 /// @param pool Memory pool used to allocate the in-memory staging buffer.
-/// @param blobData Serialized roaring bitmap bytes.
+/// @param blobData Serialized roaring bitmap bytes (unframed).
 /// @param referencedDataFile Path of the data file this DV applies to.
-/// @return Pair of (blobOffset, blobLength) within the written file.
+/// @param cardinality Number of deleted positions in the vector.
+/// @return Pair of (blobOffset, blobLength) within the written file, where
+///   blobLength is the length of the framed deletion-vector-v1 blob.
 std::pair<uint64_t, uint64_t> writePuffinFile(
     dwio::common::FileSink& sink,
     memory::MemoryPool& pool,
     const std::string& blobData,
-    const std::string& referencedDataFile);
+    const std::string& referencedDataFile,
+    int64_t cardinality);
 
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergDataSink.cpp
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.cpp
@@ -137,6 +137,8 @@ IcebergInsertTableHandle::IcebergInsertTableHandle(
     std::optional<common::CompressionKind> compressionKind,
     const std::unordered_map<std::string, std::string>& serdeParameters,
     WriteKind writeKind,
+    std::unordered_map<std::string, ExistingDeletionVector>
+        existingDeletionVectors,
     std::shared_ptr<const FileNameGenerator> fileNameGenerator)
     : HiveInsertTableHandle(
           std::vector<HiveColumnHandlePtr>(
@@ -151,7 +153,8 @@ IcebergInsertTableHandle::IcebergInsertTableHandle(
           false,
           std::move(fileNameGenerator)),
       partitionSpec_(partitionSpec),
-      writeKind_(writeKind) {
+      writeKind_(writeKind),
+      existingDeletionVectors_(std::move(existingDeletionVectors)) {
   // Data-file writes and merge writes both require the input row type to
   // have inputColumns populated (the data file sub-sink consumes them and
   // the merge sink projects them into a narrow data batch). The

--- a/velox/connectors/hive/iceberg/IcebergDataSink.h
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.h
@@ -64,6 +64,25 @@ class IcebergFileNameGenerator : public FileNameGenerator {
 /// Represents a request for Iceberg write.
 class IcebergInsertTableHandle final : public HiveInsertTableHandle {
  public:
+  /// Descriptor for a deletion vector that already exists for a data file at
+  /// plan time. Used by IcebergDeletionVectorSink to seed a new DV's roaring
+  /// bitmap with the prior DV's positions so the emitted Puffin holds the
+  /// union of old and newly-deleted positions. Iceberg V3 allows at most one
+  /// DV per data file, so a repeated mutation of a data file that already has
+  /// a DV must replace it with the union rather than add a second DV.
+  struct ExistingDeletionVector {
+    /// Path of the Puffin file holding the existing DV blob.
+    std::string puffinPath;
+    /// Byte offset of the DV blob within the Puffin file.
+    int64_t contentOffset{0};
+    /// Length in bytes of the DV blob within the Puffin file.
+    int64_t contentLength{0};
+    /// Number of deleted positions encoded in the existing DV blob.
+    int64_t recordCount{0};
+    /// Total size in bytes of the Puffin file.
+    int64_t fileSizeInBytes{0};
+  };
+
   /// Identifies which kind of file the sink should produce. Used by
   /// IcebergConnector::createDataSink to dispatch between:
   ///  - the data-file IcebergDataSink (kData, INSERT and UPDATE-insert
@@ -108,6 +127,11 @@ class IcebergInsertTableHandle final : public HiveInsertTableHandle {
   /// semantics.
   /// @param fileNameGenerator File name generator for generating unique file
   /// names for data files. Defaults to IcebergFileNameGenerator.
+  /// @param existingDeletionVectors Map from referenced data-file path to the
+  /// descriptor of a deletion vector that already exists for it. Empty for
+  /// INSERT and for first-time mutations; populated by the coordinator for a
+  /// V3 repeated mutation so the deletion-vector sink seeds the new DV with
+  /// the prior DV's positions.
   IcebergInsertTableHandle(
       std::vector<IcebergColumnHandlePtr> inputColumns,
       LocationHandlePtr locationHandle,
@@ -116,6 +140,8 @@ class IcebergInsertTableHandle final : public HiveInsertTableHandle {
       std::optional<common::CompressionKind> compressionKind = {},
       const std::unordered_map<std::string, std::string>& serdeParameters = {},
       WriteKind writeKind = WriteKind::kData,
+      std::unordered_map<std::string, ExistingDeletionVector>
+          existingDeletionVectors = {},
       std::shared_ptr<const FileNameGenerator> fileNameGenerator =
           std::make_shared<const IcebergFileNameGenerator>());
 
@@ -131,9 +157,19 @@ class IcebergInsertTableHandle final : public HiveInsertTableHandle {
     return writeKind_;
   }
 
+  /// Returns the map from referenced data-file path to the descriptor of the
+  /// deletion vector that already exists for it. Empty unless this is a V3
+  /// repeated mutation that must union with a prior DV.
+  const std::unordered_map<std::string, ExistingDeletionVector>&
+  existingDeletionVectors() const {
+    return existingDeletionVectors_;
+  }
+
  private:
   const IcebergPartitionSpecPtr partitionSpec_;
   const WriteKind writeKind_;
+  const std::unordered_map<std::string, ExistingDeletionVector>
+      existingDeletionVectors_;
 };
 
 using IcebergInsertTableHandlePtr =

--- a/velox/connectors/hive/iceberg/IcebergDeletionVectorSink.cpp
+++ b/velox/connectors/hive/iceberg/IcebergDeletionVectorSink.cpp
@@ -23,6 +23,8 @@
 
 #include "velox/common/base/Exceptions.h"
 #include "velox/connectors/hive/HiveConfig.h"
+#include "velox/connectors/hive/iceberg/DeletionVectorReader.h"
+#include "velox/connectors/hive/iceberg/IcebergDeleteFile.h"
 #include "velox/dwio/common/FileSink.h"
 
 namespace facebook::velox::connector::hive::iceberg {
@@ -80,10 +82,40 @@ IcebergDeletionVectorSink::IcebergDeletionVectorSink(
   VELOX_USER_CHECK_NOT_NULL(
       hiveConfig_,
       "IcebergDeletionVectorSink requires a non-null hive config.");
-  VELOX_USER_CHECK_EQ(
-      static_cast<int32_t>(inputType_->size()),
-      kExpectedChannelCount,
-      "IcebergDeletionVectorSink expects a 2-column input (file_path, pos)");
+  // The V3 DELETE plan delivers the row-id as a synthesized
+  // ROW<file_path VARCHAR, pos BIGINT, ...> column (getDeleteRowIdColumn),
+  // and may prepend passthrough columns (e.g. a data/partition column), so the
+  // input can be ROW<id, $row_id:ROW<...>> — not a bare 2-column page. Detect
+  // the row-id by locating the ROW-typed column whose first two fields are
+  // (VARCHAR file_path, BIGINT pos). Fall back to the legacy two flat columns
+  // (file_path, pos) produced by IcebergMergeSink::makeDeleteBatch.
+  const auto isRowIdStruct = [](const TypePtr& type) {
+    return type->isRow() && type->asRow().size() >= kExpectedChannelCount &&
+        type->asRow().childAt(kFilePathChannel)->isVarchar() &&
+        type->asRow().childAt(kPositionChannel)->isBigint();
+  };
+  const auto numColumns = static_cast<int32_t>(inputType_->size());
+  bool found = false;
+  for (int32_t channel = 0; channel < numColumns; ++channel) {
+    if (isRowIdStruct(inputType_->childAt(channel))) {
+      rowIdAsStruct_ = true;
+      rowIdChannel_ = channel;
+      found = true;
+      break;
+    }
+  }
+  if (!found) {
+    if (numColumns == kExpectedChannelCount &&
+        inputType_->childAt(kFilePathChannel)->isVarchar() &&
+        inputType_->childAt(kPositionChannel)->isBigint()) {
+      rowIdAsStruct_ = false;
+    } else {
+      VELOX_USER_FAIL(
+          "IcebergDeletionVectorSink expects a two-column (file_path, pos) "
+          "input or a ROW<file_path, pos, ...> row-id column, got {}",
+          inputType_->toString());
+    }
+  }
 }
 
 void IcebergDeletionVectorSink::appendData(RowVectorPtr input) {
@@ -92,27 +124,60 @@ void IcebergDeletionVectorSink::appendData(RowVectorPtr input) {
   if (input == nullptr || input->size() == 0) {
     return;
   }
+
+  const auto numRows = input->size();
+  const SelectivityVector allRows(numRows);
+
+  if (rowIdAsStruct_) {
+    // The row-id is a synthesized ROW<file_path, pos, ...> column (at
+    // 'rowIdChannel_') that may be dictionary-encoded (the delete operator
+    // selects deleted rows via a dictionary over the row-id). Decode the ROW
+    // column to peel the outer encoding, then read file_path/pos from the base
+    // ROW's fields through the decoded indices. Reading the base children
+    // directly (ignoring the dictionary) mis-indexes and can read out of
+    // bounds.
+    DecodedVector decodedRowId(*input->childAt(rowIdChannel_), allRows);
+    const auto* rowId = decodedRowId.base()->as<RowVector>();
+    VELOX_USER_CHECK_NOT_NULL(rowId, "row-id column must be a ROW vector");
+    VELOX_USER_CHECK_GE(
+        rowId->childrenSize(),
+        kExpectedChannelCount,
+        "row-id ROW must have at least 2 fields (file_path, pos), got {}",
+        rowId->childrenSize());
+    const SelectivityVector baseRows(rowId->size());
+    DecodedVector decodedFilePath(*rowId->childAt(kFilePathChannel), baseRows);
+    DecodedVector decodedPosition(*rowId->childAt(kPositionChannel), baseRows);
+    for (vector_size_t i = 0; i < numRows; ++i) {
+      if (decodedRowId.isNullAt(i)) {
+        continue;
+      }
+      const auto row = decodedRowId.index(i);
+      VELOX_USER_CHECK(
+          !decodedFilePath.isNullAt(row), "Null file_path in DELETE input row");
+      VELOX_USER_CHECK(
+          !decodedPosition.isNullAt(row), "Null pos in DELETE input row");
+      const auto pathSlice = decodedFilePath.valueAt<StringView>(row);
+      PerFileState& state =
+          findOrCreatePerFile(std::string(pathSlice.data(), pathSlice.size()));
+      state.writer.addDeletedPosition(decodedPosition.valueAt<int64_t>(row));
+    }
+    return;
+  }
+
   VELOX_USER_CHECK_EQ(
       static_cast<int32_t>(input->childrenSize()),
       kExpectedChannelCount,
       "IcebergDeletionVectorSink expects 2-column input pages");
-
-  const auto* filePathVector = input->childAt(kFilePathChannel)->loadedVector();
-  const auto* positionVector = input->childAt(kPositionChannel)->loadedVector();
-
-  DecodedVector decodedFilePath(
-      *filePathVector, SelectivityVector(input->size()));
-  DecodedVector decodedPosition(
-      *positionVector, SelectivityVector(input->size()));
-
-  for (vector_size_t i = 0; i < input->size(); ++i) {
+  DecodedVector decodedFilePath(*input->childAt(kFilePathChannel), allRows);
+  DecodedVector decodedPosition(*input->childAt(kPositionChannel), allRows);
+  for (vector_size_t i = 0; i < numRows; ++i) {
     VELOX_USER_CHECK(
         !decodedFilePath.isNullAt(i), "Null file_path in DELETE input row");
     VELOX_USER_CHECK(
         !decodedPosition.isNullAt(i), "Null pos in DELETE input row");
     const auto pathSlice = decodedFilePath.valueAt<StringView>(i);
-    const std::string path(pathSlice.data(), pathSlice.size());
-    PerFileState& state = findOrCreatePerFile(path);
+    PerFileState& state =
+        findOrCreatePerFile(std::string(pathSlice.data(), pathSlice.size()));
     state.writer.addDeletedPosition(decodedPosition.valueAt<int64_t>(i));
   }
 }
@@ -125,7 +190,41 @@ IcebergDeletionVectorSink::findOrCreatePerFile(const std::string& path) {
   const size_t index = perFile_.size();
   perFile_.emplace_back(path, PerFileState{});
   perFileIndex_.emplace(path, index);
-  return perFile_.back().second;
+  PerFileState& state = perFile_.back().second;
+  seedFromExistingDeletionVector(state, path);
+  return state;
+}
+
+void IcebergDeletionVectorSink::seedFromExistingDeletionVector(
+    PerFileState& state,
+    const std::string& dataFile) {
+  const auto& existing = insertTableHandle_->existingDeletionVectors();
+  const auto it = existing.find(dataFile);
+  if (it == existing.end()) {
+    return;
+  }
+  const auto& descriptor = it->second;
+
+  // Reconstruct the existing DV as an IcebergDeleteFile and read its positions
+  // through the same DeletionVectorReader used on the read path. The reader
+  // ignores the memory pool argument, so nullptr is safe; the connector config
+  // resolves the (possibly warm-storage / Manifold) filesystem for the Puffin.
+  const IcebergDeleteFile dvFile(
+      FileContent::kDeletionVector,
+      descriptor.puffinPath,
+      dwio::common::FileFormat::PUFFIN,
+      static_cast<uint64_t>(descriptor.recordCount),
+      static_cast<uint64_t>(descriptor.fileSizeInBytes),
+      /*equalityFieldIds=*/{},
+      /*lowerBounds=*/{},
+      /*upperBounds=*/{},
+      /*dataSequenceNumber=*/0,
+      descriptor.contentOffset,
+      descriptor.contentLength,
+      dataFile);
+  DeletionVectorReader reader(
+      dvFile, /*splitOffset=*/0, /*pool=*/nullptr, hiveConfig_->config());
+  state.writer.addDeletedPositions(reader.deletedPositions());
 }
 
 bool IcebergDeletionVectorSink::finish() {
@@ -175,8 +274,14 @@ bool IcebergDeletionVectorSink::finish() {
     VELOX_CHECK_NOT_NULL(
         sink, "Failed to create file sink for Puffin file: {}", puffinPath);
 
-    const auto [offset, length] =
-        writePuffinFile(*sink, *pool, blob, entry.first);
+    // Iceberg V3 treats the DV blob's cardinality as authoritative, so it must
+    // match the de-duplicated bitmap that serialize() emits — not the raw
+    // insertion count (seeding an existing DV plus overlapping new deletes can
+    // introduce duplicates).
+    const size_t cardinality = entry.second.writer.numDistinctPositions();
+
+    const auto [offset, length] = writePuffinFile(
+        *sink, *pool, blob, entry.first, static_cast<int64_t>(cardinality));
     const uint64_t fileSize = sink->size();
     sink->close();
 
@@ -192,7 +297,7 @@ bool IcebergDeletionVectorSink::finish() {
     commitMessages_.push_back(buildDeletionVectorCommitMessage(
         puffinPath,
         fileSize,
-        entry.second.writer.numPositions(),
+        cardinality,
         partitionSpecId,
         entry.first,
         offset,

--- a/velox/connectors/hive/iceberg/IcebergDeletionVectorSink.h
+++ b/velox/connectors/hive/iceberg/IcebergDeletionVectorSink.h
@@ -91,8 +91,17 @@ class IcebergDeletionVectorSink : public DataSink {
   // Returns the accumulator for 'path', creating it on first use. Lookups are
   // O(1) via 'perFileIndex_'; new entries are appended to 'perFile_' so the
   // overall insertion order (and hence commit-message order) stays
-  // deterministic.
+  // deterministic. On first creation, if the insert handle carries an existing
+  // deletion vector for 'path', seeds the writer with its positions so the
+  // emitted DV is the union of old and newly-deleted positions.
   PerFileState& findOrCreatePerFile(const std::string& path);
+
+  // Reads the existing deletion vector for 'dataFile' (as described by the
+  // insert handle) and adds its positions to 'state.writer' exactly once.
+  // No-op when the handle has no existing DV for 'dataFile'.
+  void seedFromExistingDeletionVector(
+      PerFileState& state,
+      const std::string& dataFile);
 
   const RowTypePtr inputType_;
   const IcebergInsertTableHandlePtr insertTableHandle_;
@@ -117,6 +126,19 @@ class IcebergDeletionVectorSink : public DataSink {
 
   bool finished_{false};
   bool aborted_{false};
+
+  // True when the coordinator delivers the row-id as a synthesized
+  // ROW<file_path, pos, ...> column (Presto's getDeleteRowIdColumn for V3),
+  // possibly alongside other passthrough columns (e.g. a leading data/partition
+  // column). In that case appendData unwraps the ROW's first two fields. When
+  // false, the input is the legacy two flat (file_path, pos) columns produced
+  // by IcebergMergeSink::makeDeleteBatch.
+  bool rowIdAsStruct_{false};
+
+  // Index of the row-id ROW column in the input when 'rowIdAsStruct_' is true.
+  // The V3 DELETE plan may prepend other columns, so the ROW is not always at
+  // channel 0. Unused when 'rowIdAsStruct_' is false.
+  int32_t rowIdChannel_{0};
 
   // Cumulative stats for the Stats() accessor.
   uint64_t numWrittenBytes_{0};

--- a/velox/connectors/hive/iceberg/IcebergMergeSink.cpp
+++ b/velox/connectors/hive/iceberg/IcebergMergeSink.cpp
@@ -98,6 +98,11 @@ IcebergInsertTableHandlePtr IcebergMergeSink::cloneHandleWithKind(
     icebergInputs.emplace_back(
         checkedPointerCast<const IcebergColumnHandle>(col));
   }
+  // Propagate the existing deletion-vector map so the kDeletionVector sub-sink
+  // seeds each new DV with the prior DV's positions on an UPDATE/MERGE that
+  // re-touches a data file already carrying a DV. The kData sub-sink ignores
+  // the map. Preserve the original file-name generator too (the default here
+  // would otherwise drop a custom generator).
   return std::make_shared<const IcebergInsertTableHandle>(
       std::move(icebergInputs),
       original.locationHandle(),
@@ -105,7 +110,9 @@ IcebergInsertTableHandlePtr IcebergMergeSink::cloneHandleWithKind(
       original.partitionSpec(),
       original.compressionKind(),
       original.serdeParameters(),
-      kind);
+      kind,
+      original.existingDeletionVectors(),
+      original.fileNameGenerator());
 }
 
 RowTypePtr IcebergMergeSink::projectDataInputType(

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -494,7 +494,10 @@ void IcebergSplitReader::prepareSplit(
 
         deletionVectorReaders_.push_back(
             std::make_unique<DeletionVectorReader>(
-                deleteFile, splitOffset_, connectorQueryCtx_->memoryPool()));
+                deleteFile,
+                splitOffset_,
+                connectorQueryCtx_->memoryPool(),
+                fileConfig_->config()));
       }
     } else {
       VELOX_NYI(

--- a/velox/connectors/hive/iceberg/tests/DeletionVectorReaderTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/DeletionVectorReaderTest.cpp
@@ -263,7 +263,7 @@ TEST_F(DeletionVectorReaderTest, basicArrayContainer) {
   auto dvFile =
       makeDvDeleteFile(tempFile->getPath(), positions.size(), fileSize);
 
-  DeletionVectorReader reader(dvFile, 0, pool_.get());
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
   EXPECT_FALSE(reader.noMoreData());
 
   auto bitmap = allocateBitmap(100);
@@ -284,7 +284,7 @@ TEST_F(DeletionVectorReaderTest, batchRangeFiltering) {
   auto dvFile =
       makeDvDeleteFile(tempFile->getPath(), positions.size(), fileSize);
 
-  DeletionVectorReader reader(dvFile, 0, pool_.get());
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
 
   // First batch: rows 0-24 (should contain positions 10, 20).
   auto bitmap1 = allocateBitmap(25);
@@ -319,7 +319,7 @@ TEST_F(DeletionVectorReaderTest, splitOffset) {
       makeDvDeleteFile(tempFile->getPath(), positions.size(), fileSize);
 
   // Split starts at row 100.
-  DeletionVectorReader reader(dvFile, 100, pool_.get());
+  DeletionVectorReader reader(dvFile, 100, pool_.get(), nullptr);
 
   auto bitmap = allocateBitmap(20);
   reader.readDeletePositions(0, 20, bitmap);
@@ -342,7 +342,7 @@ TEST_F(DeletionVectorReaderTest, splitOffsetWithBaseReadOffset) {
       makeDvDeleteFile(tempFile->getPath(), positions.size(), fileSize);
 
   // Split starts at row 100.
-  DeletionVectorReader reader(dvFile, 100, pool_.get());
+  DeletionVectorReader reader(dvFile, 100, pool_.get(), nullptr);
 
   // First batch: baseReadOffset=100, so file positions [200, 300).
   // Positions 200, 210, 220 are all in range.
@@ -364,7 +364,7 @@ TEST_F(DeletionVectorReaderTest, noDeletesInRange) {
   auto dvFile =
       makeDvDeleteFile(tempFile->getPath(), positions.size(), fileSize);
 
-  DeletionVectorReader reader(dvFile, 0, pool_.get());
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
 
   // Batch covers rows 0-99, no deletions in this range.
   auto bitmap = allocateBitmap(100);
@@ -389,7 +389,7 @@ TEST_F(DeletionVectorReaderTest, runContainers) {
   auto dvFile =
       makeDvDeleteFile(tempFile->getPath(), expected.size(), fileSize);
 
-  DeletionVectorReader reader(dvFile, 0, pool_.get());
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
 
   auto bitmap = allocateBitmap(100);
   reader.readDeletePositions(0, 100, bitmap);
@@ -415,7 +415,7 @@ TEST_F(DeletionVectorReaderTest, runContainersWithOffsetHeader) {
   auto dvFile =
       makeDvDeleteFile(tempFile->getPath(), expected.size(), fileSize);
 
-  DeletionVectorReader reader(dvFile, 0, pool_.get());
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
 
   const uint64_t numRows = 200'000;
   auto bitmap = allocateBitmap(numRows);
@@ -437,7 +437,7 @@ TEST_F(DeletionVectorReaderTest, largePositionsMultipleContainers) {
   auto dvFile =
       makeDvDeleteFile(tempFile->getPath(), positions.size(), fileSize);
 
-  DeletionVectorReader reader(dvFile, 0, pool_.get());
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
 
   // Read a batch covering all positions.
   auto bitmap = allocateBitmap(66000);
@@ -463,7 +463,7 @@ TEST_F(DeletionVectorReaderTest, blobOffset) {
   auto dvFile = makeDvDeleteFile(
       tempFile->getPath(), positions.size(), fileSize, 64, bitmapData.size());
 
-  DeletionVectorReader reader(dvFile, 0, pool_.get());
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
 
   auto bitmap = allocateBitmap(20);
   reader.readDeletePositions(0, 20, bitmap);
@@ -488,7 +488,7 @@ TEST_F(DeletionVectorReaderTest, constructorRejectsWrongContentType) {
       5);
 
   VELOX_ASSERT_THROW(
-      DeletionVectorReader(badFile, 0, pool_.get()),
+      DeletionVectorReader(badFile, 0, pool_.get(), nullptr),
       "Expected deletion vector file");
 }
 
@@ -507,7 +507,8 @@ TEST_F(DeletionVectorReaderTest, constructorRejectsEmptyDv) {
       5);
 
   VELOX_ASSERT_THROW(
-      DeletionVectorReader(emptyDv, 0, pool_.get()), "Empty deletion vector");
+      DeletionVectorReader(emptyDv, 0, pool_.get(), nullptr),
+      "Empty deletion vector");
 }
 
 TEST_F(DeletionVectorReaderTest, noMoreDataAfterAllConsumed) {
@@ -519,7 +520,7 @@ TEST_F(DeletionVectorReaderTest, noMoreDataAfterAllConsumed) {
   auto dvFile =
       makeDvDeleteFile(tempFile->getPath(), positions.size(), fileSize);
 
-  DeletionVectorReader reader(dvFile, 0, pool_.get());
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
   EXPECT_FALSE(reader.noMoreData());
 
   auto bitmap = allocateBitmap(10);
@@ -543,7 +544,7 @@ TEST_F(DeletionVectorReaderTest, singlePosition) {
   auto dvFile =
       makeDvDeleteFile(tempFile->getPath(), positions.size(), fileSize);
 
-  DeletionVectorReader reader(dvFile, 0, pool_.get());
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
 
   auto bitmap = allocateBitmap(100);
   reader.readDeletePositions(0, 100, bitmap);
@@ -566,7 +567,7 @@ TEST_F(DeletionVectorReaderTest, consecutivePositions) {
   auto dvFile =
       makeDvDeleteFile(tempFile->getPath(), positions.size(), fileSize);
 
-  DeletionVectorReader reader(dvFile, 0, pool_.get());
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
 
   auto bitmap = allocateBitmap(100);
   reader.readDeletePositions(0, 100, bitmap);
@@ -587,7 +588,7 @@ TEST_F(DeletionVectorReaderTest, invalidBitmapTooSmall) {
 
   auto dvFile = makeDvDeleteFile(tempFile->getPath(), 1, tinyData.size());
 
-  DeletionVectorReader reader(dvFile, 0, pool_.get());
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
 
   auto bitmap = allocateBitmap(10);
   VELOX_ASSERT_THROW(reader.readDeletePositions(0, 10, bitmap), "too small");
@@ -604,7 +605,7 @@ TEST_F(DeletionVectorReaderTest, invalidBitmapBadCookie) {
 
   auto dvFile = makeDvDeleteFile(tempFile->getPath(), 1, badData.size());
 
-  DeletionVectorReader reader(dvFile, 0, pool_.get());
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
 
   auto bitmap = allocateBitmap(10);
   VELOX_ASSERT_THROW(

--- a/velox/connectors/hive/iceberg/tests/DeletionVectorWriterTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/DeletionVectorWriterTest.cpp
@@ -18,7 +18,11 @@
 
 #include <fstream>
 
+#include <folly/hash/Checksum.h>
+#include <folly/lang/Bits.h>
 #include <gtest/gtest.h>
+
+#include <cstring>
 
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/base/tests/GTestUtils.h"
@@ -107,7 +111,7 @@ class DeletionVectorWriterTest : public ::testing::Test {
         lowerBounds,
         upperBounds);
 
-    DeletionVectorReader reader(dvFile, 0, pool_.get());
+    DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
 
     // Collect all set bits across batches.
     std::vector<uint64_t> allSetBits;
@@ -216,7 +220,7 @@ TEST_F(DeletionVectorWriterTest, duplicatePositions) {
       lowerBounds,
       upperBounds);
 
-  DeletionVectorReader reader(dvFile, 0, pool_.get());
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
 
   auto bitmap = allocateBitmap(20);
   reader.readDeletePositions(0, 20, bitmap);
@@ -267,12 +271,18 @@ TEST_F(DeletionVectorWriterTest, puffinFileRoundTrip) {
   auto sink = dwio::common::FileSink::create(
       "file:" + puffinPath, {.pool = pool_.get()});
   VELOX_CHECK_NOT_NULL(sink);
-  auto [blobOffset, blobLength] =
-      writePuffinFile(*sink, *pool_, blobData, "/data/test-data-file.parquet");
+  auto [blobOffset, blobLength] = writePuffinFile(
+      *sink,
+      *pool_,
+      blobData,
+      "/data/test-data-file.parquet",
+      /*cardinality=*/4);
   sink->close();
 
-  EXPECT_EQ(blobOffset, 4); // After "PUF1" magic.
-  EXPECT_EQ(blobLength, blobData.size());
+  EXPECT_EQ(blobOffset, 4); // After "PFA1" magic.
+  // blobLength is the framed deletion-vector-v1 blob: 4B length + 4B magic +
+  // bitmap + 4B CRC-32.
+  EXPECT_EQ(blobLength, blobData.size() + 12);
 
   // Read the blob back from the Puffin file using DeletionVectorReader.
   std::unordered_map<int32_t, std::string> lowerBounds;
@@ -296,13 +306,65 @@ TEST_F(DeletionVectorWriterTest, puffinFileRoundTrip) {
       lowerBounds,
       upperBounds);
 
-  DeletionVectorReader reader(dvFile, 0, pool_.get());
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
 
   auto bitmap = allocateBitmap(200);
   reader.readDeletePositions(0, 200, bitmap);
 
   auto setBits = getSetBits(bitmap, 200);
   EXPECT_EQ(setBits, (std::vector<uint64_t>{3, 7, 42, 100}));
+}
+
+// Verifies the on-disk deletion-vector-v1 blob matches the Iceberg V3 spec
+// frame: [length: 4B BE][magic D1 D3 39 64][bitmap][CRC-32: 4B BE], where the
+// length and CRC-32 cover the magic + bitmap. This is what makes the DV
+// interoperable with spec-compliant Iceberg engines.
+TEST_F(DeletionVectorWriterTest, deletionVectorV1FrameLayout) {
+  DeletionVectorWriter writer;
+  writer.addDeletedPositions({3, 7, 42, 100});
+  const auto bitmap = writer.serialize();
+
+  auto tempDir = TempDirectoryPath::create();
+  const std::string puffinPath =
+      std::string(tempDir->getPath()) + "/frame.puffin";
+  auto sink = dwio::common::FileSink::create(
+      "file:" + puffinPath, {.pool = pool_.get()});
+  const auto [blobOffset, blobLength] = writePuffinFile(
+      *sink, *pool_, bitmap, "/data/f.parquet", /*cardinality=*/4);
+  sink->close();
+
+  std::ifstream in(puffinPath, std::ios::binary);
+  const std::string bytes((std::istreambuf_iterator<char>(in)), {});
+
+  // File starts with the Puffin magic "PFA1".
+  EXPECT_EQ(bytes.substr(0, 4), std::string("PFA1"));
+
+  const std::string blob = bytes.substr(blobOffset, blobLength);
+  ASSERT_EQ(blob.size(), bitmap.size() + 12);
+
+  auto readBigEndian = [](const char* p) {
+    uint32_t value;
+    std::memcpy(&value, p, sizeof(value));
+    return folly::Endian::big(value);
+  };
+
+  // [length: 4B BE] covers magic (4) + bitmap.
+  const uint32_t magicAndVectorLength = readBigEndian(blob.data());
+  EXPECT_EQ(magicAndVectorLength, bitmap.size() + 4);
+
+  // [magic: D1 D3 39 64].
+  const std::string magic = blob.substr(4, 4);
+  EXPECT_EQ(magic, std::string({'\xD1', '\xD3', '\x39', '\x64'}));
+
+  // [bitmap] matches the writer's serialize() output.
+  EXPECT_EQ(blob.substr(8, bitmap.size()), bitmap);
+
+  // [CRC-32: 4B BE] over magic + bitmap.
+  const uint32_t storedCrc =
+      readBigEndian(blob.data() + 4 + magicAndVectorLength);
+  const uint32_t expectedCrc = folly::crc32(
+      reinterpret_cast<const uint8_t*>(blob.data() + 4), magicAndVectorLength);
+  EXPECT_EQ(storedCrc, expectedCrc);
 }
 
 /// Verifies 64-bit positions (>4 billion) serialize and deserialize correctly.

--- a/velox/connectors/hive/iceberg/tests/IcebergDeletionVectorSinkTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergDeletionVectorSinkTest.cpp
@@ -58,6 +58,30 @@ IcebergInsertTableHandlePtr makeDeletionVectorHandle(
       IcebergInsertTableHandle::WriteKind::kDeletionVector);
 }
 
+// Like makeDeletionVectorHandle but carries a map of existing deletion vectors
+// (data-file path -> descriptor) so the sink seeds each new DV with the prior
+// DV's positions.
+IcebergInsertTableHandlePtr makeDeletionVectorHandleWithExisting(
+    const std::string& outputDirectory,
+    std::unordered_map<
+        std::string,
+        IcebergInsertTableHandle::ExistingDeletionVector>
+        existingDeletionVectors) {
+  auto locationHandle = std::make_shared<connector::hive::LocationHandle>(
+      outputDirectory,
+      outputDirectory,
+      connector::hive::LocationHandle::TableType::kExisting);
+  return std::make_shared<const IcebergInsertTableHandle>(
+      /*inputColumns=*/std::vector<IcebergColumnHandlePtr>{},
+      locationHandle,
+      /*tableStorageFormat=*/dwio::common::FileFormat::PARQUET,
+      /*partitionSpec=*/nullptr,
+      /*compressionKind=*/std::nullopt,
+      /*serdeParameters=*/std::unordered_map<std::string, std::string>{},
+      IcebergInsertTableHandle::WriteKind::kDeletionVector,
+      std::move(existingDeletionVectors));
+}
+
 // Allocates a bit-packed buffer big enough to hold 'numBits' bits, zeroed.
 BufferPtr allocateBitmap(uint64_t numBits, memory::MemoryPool* pool) {
   return AlignedBuffer::allocate<uint8_t>(bits::nbytes(numBits), pool, 0);
@@ -99,7 +123,7 @@ std::vector<uint64_t> readBackDeletedPositions(
       lowerBounds,
       upperBounds);
 
-  DeletionVectorReader reader(dvFile, 0, pool);
+  DeletionVectorReader reader(dvFile, 0, pool, /*connectorConfig=*/nullptr);
   const uint64_t batchSize = 1024;
   const uint64_t totalRows = maxPos + batchSize;
 
@@ -172,6 +196,59 @@ class IcebergDeletionVectorSinkTest : public ::testing::Test {
         {"file_path", "pos"}, {filePathVector, positionVector});
   }
 
+  // Builds an input page whose row-id is a 4-field
+  // ROW<file_path, pos, spec_id, partition> (the shape Presto's V3
+  // getMergeTargetTableRowIdColumnHandle produces), dictionary-wrapped to
+  // 'selected' base rows. This mirrors the delete operator, which selects the
+  // deleted rows via a dictionary over the row-id column rather than
+  // materializing a compact page. 'filePathConstant' toggles whether file_path
+  // is a constant vector (single-file DELETE) or a flat per-row vector.
+  // When 'withLeadingIdColumn' is true, a passthrough BIGINT column is placed
+  // before the row-id ROW (the real V3 DELETE layout ROW<id,
+  // $row_id:ROW<...>>).
+  RowVectorPtr makeRowIdStructDeletePage(
+      const std::string& dataFile,
+      const std::vector<int64_t>& allPositions,
+      const std::vector<vector_size_t>& selected,
+      bool filePathConstant,
+      bool withLeadingIdColumn = false) {
+    const auto baseSize = static_cast<vector_size_t>(allPositions.size());
+    VectorPtr filePathVector;
+    if (filePathConstant) {
+      filePathVector = BaseVector::createConstant(
+          VARCHAR(), variant(dataFile), baseSize, pool_.get());
+    } else {
+      filePathVector = vectorMaker_->flatVector<StringView>(
+          baseSize, [&](vector_size_t /*i*/) { return StringView(dataFile); });
+    }
+    auto positionVector = vectorMaker_->flatVector<int64_t>(allPositions);
+    auto specIdVector = vectorMaker_->flatVector<int32_t>(
+        baseSize, [](vector_size_t /*i*/) { return 0; });
+    auto partitionVector = vectorMaker_->flatVector<StringView>(
+        baseSize, [](vector_size_t /*i*/) { return StringView(""); });
+    auto rowId = vectorMaker_->rowVector(
+        {"_file", "_pos", "_spec_id", "partition_data"},
+        {filePathVector, positionVector, specIdVector, partitionVector});
+
+    const auto selectedSize = static_cast<vector_size_t>(selected.size());
+    auto indices =
+        AlignedBuffer::allocate<vector_size_t>(selectedSize, pool_.get());
+    auto* rawIndices = indices->asMutable<vector_size_t>();
+    for (vector_size_t i = 0; i < selectedSize; ++i) {
+      rawIndices[i] = selected[i];
+    }
+    auto wrappedRowId = BaseVector::wrapInDictionary(
+        /*nulls=*/nullptr, indices, selectedSize, rowId);
+
+    if (!withLeadingIdColumn) {
+      return vectorMaker_->rowVector({"$row_id"}, {wrappedRowId});
+    }
+    // Leading passthrough column aligned to the selected (top-level) rows.
+    auto idVector = vectorMaker_->flatVector<int64_t>(
+        selectedSize, [](vector_size_t i) { return i; });
+    return vectorMaker_->rowVector({"id", "$row_id"}, {idVector, wrappedRowId});
+  }
+
   std::shared_ptr<memory::MemoryPool> pool_;
   std::shared_ptr<memory::MemoryPool> connectorPool_;
   std::shared_ptr<config::ConfigBase> sessionProperties_;
@@ -205,9 +282,9 @@ TEST_F(IcebergDeletionVectorSinkTest, singleFileSinglePosition) {
   EXPECT_EQ(parsed["fileFormat"].asString(), "PUFFIN");
   EXPECT_EQ(parsed["referencedDataFile"].asString(), dataFile);
   EXPECT_EQ(parsed["metrics"]["recordCount"].asInt(), 1);
-  ASSERT_TRUE(parsed.find("path") != parsed.items().end());
-  ASSERT_TRUE(parsed.find("contentOffset") != parsed.items().end());
-  ASSERT_TRUE(parsed.find("contentSizeInBytes") != parsed.items().end());
+  ASSERT_NE(parsed.find("path"), parsed.items().end());
+  ASSERT_NE(parsed.find("contentOffset"), parsed.items().end());
+  ASSERT_NE(parsed.find("contentSizeInBytes"), parsed.items().end());
 
   // Verify the emitted Puffin file is readable by DeletionVectorReader and
   // round-trips the position we wrote.
@@ -220,6 +297,108 @@ TEST_F(IcebergDeletionVectorSinkTest, singleFileSinglePosition) {
   auto deleted = readBackDeletedPositions(
       puffinPath, offset, length, recordCount, /*maxPos=*/42, pool_.get());
   EXPECT_EQ(deleted, std::vector<uint64_t>{42});
+}
+
+// Writes a first DV for a data file, then runs a second sink that DELETEs a
+// different position for the SAME data file while carrying the first DV as an
+// existing DV. The emitted DV must be the union of the prior and new
+// positions (Iceberg V3 allows at most one DV per data file).
+TEST_F(IcebergDeletionVectorSinkTest, seedFromExistingDeletionVectorUnions) {
+  auto tempDir = TempDirectoryPath::create();
+  const std::string dataFile = tempDir->getPath() + "/data-file.parquet";
+
+  // First mutation: DELETE positions {1, 3}.
+  folly::dynamic firstCommit;
+  {
+    auto handle = makeDeletionVectorHandle(tempDir->getPath());
+    IcebergDeletionVectorSink sink(
+        ROW({"file_path", "pos"}, {VARCHAR(), BIGINT()}),
+        handle,
+        connectorQueryCtx_.get(),
+        connector::CommitStrategy::kNoCommit,
+        hiveConfig_);
+    sink.appendData(makePositionDeleteRows({dataFile, dataFile}, {1, 3}));
+    EXPECT_TRUE(sink.finish());
+    auto messages = sink.close();
+    ASSERT_EQ(messages.size(), 1);
+    firstCommit = folly::parseJson(messages[0]);
+  }
+
+  // Build the existing-DV descriptor from the first commit message.
+  IcebergInsertTableHandle::ExistingDeletionVector existing;
+  existing.puffinPath = firstCommit["path"].asString();
+  existing.contentOffset = firstCommit["contentOffset"].asInt();
+  existing.contentLength = firstCommit["contentSizeInBytes"].asInt();
+  existing.recordCount = firstCommit["metrics"]["recordCount"].asInt();
+  existing.fileSizeInBytes = firstCommit["fileSizeInBytes"].asInt();
+
+  // Second mutation: DELETE position {5} for the same data file, seeded with
+  // the existing DV.
+  auto handle = makeDeletionVectorHandleWithExisting(
+      tempDir->getPath(), {{dataFile, existing}});
+  IcebergDeletionVectorSink sink(
+      ROW({"file_path", "pos"}, {VARCHAR(), BIGINT()}),
+      handle,
+      connectorQueryCtx_.get(),
+      connector::CommitStrategy::kNoCommit,
+      hiveConfig_);
+  sink.appendData(makePositionDeleteRows({dataFile}, {5}));
+  EXPECT_TRUE(sink.finish());
+  auto messages = sink.close();
+  ASSERT_EQ(messages.size(), 1);
+  auto parsed = folly::parseJson(messages[0]);
+
+  // The emitted DV holds the union {1, 3, 5}.
+  EXPECT_EQ(parsed["metrics"]["recordCount"].asInt(), 3);
+  auto deleted = readBackDeletedPositions(
+      parsed["path"].asString(),
+      static_cast<uint64_t>(parsed["contentOffset"].asInt()),
+      static_cast<uint64_t>(parsed["contentSizeInBytes"].asInt()),
+      static_cast<uint64_t>(parsed["metrics"]["recordCount"].asInt()),
+      /*maxPos=*/5,
+      pool_.get());
+  EXPECT_EQ(deleted, (std::vector<uint64_t>{1, 3, 5}));
+}
+
+// Verifies the DeletionVectorReader::deletedPositions() accessor returns the
+// sorted positions of a known Puffin file (used by the sink to seed a new DV).
+TEST_F(
+    IcebergDeletionVectorSinkTest,
+    deletionVectorReaderExposesSortedPositions) {
+  auto tempDir = TempDirectoryPath::create();
+  const std::string dataFile = tempDir->getPath() + "/data-file.parquet";
+
+  auto handle = makeDeletionVectorHandle(tempDir->getPath());
+  IcebergDeletionVectorSink sink(
+      ROW({"file_path", "pos"}, {VARCHAR(), BIGINT()}),
+      handle,
+      connectorQueryCtx_.get(),
+      connector::CommitStrategy::kNoCommit,
+      hiveConfig_);
+  // Append out of order to confirm the accessor returns sorted positions.
+  sink.appendData(
+      makePositionDeleteRows({dataFile, dataFile, dataFile}, {7, 2, 4}));
+  EXPECT_TRUE(sink.finish());
+  auto messages = sink.close();
+  ASSERT_EQ(messages.size(), 1);
+  auto parsed = folly::parseJson(messages[0]);
+
+  IcebergDeleteFile dvFile(
+      FileContent::kDeletionVector,
+      parsed["path"].asString(),
+      dwio::common::FileFormat::PARQUET,
+      static_cast<uint64_t>(parsed["metrics"]["recordCount"].asInt()),
+      static_cast<uint64_t>(parsed["fileSizeInBytes"].asInt()),
+      /*equalityFieldIds=*/{},
+      /*lowerBounds=*/{},
+      /*upperBounds=*/{},
+      /*dataSequenceNumber=*/0,
+      parsed["contentOffset"].asInt(),
+      parsed["contentSizeInBytes"].asInt(),
+      dataFile);
+  DeletionVectorReader reader(
+      dvFile, /*splitOffset=*/0, pool_.get(), hiveConfig_->config());
+  EXPECT_EQ(reader.deletedPositions(), (std::vector<int64_t>{2, 4, 7}));
 }
 
 TEST_F(IcebergDeletionVectorSinkTest, multipleFilesDemultiplexed) {
@@ -377,4 +556,131 @@ TEST_F(IcebergDeletionVectorSinkTest, writesThroughRegisteredFileSinkFactory) {
   auto deleted = readBackDeletedPositions(
       localPuffinPath, offset, length, recordCount, /*maxPos=*/21, pool_.get());
   EXPECT_EQ(deleted, (std::vector<uint64_t>{7, 13, 21}));
+}
+
+// Reproduces the pure-DELETE (non-merge) path: the row-id arrives as a single
+// 4-field ROW column, dictionary-wrapped to the deleted rows. Regression guard
+// for a worker SIGSEGV where appendData read the base ROW's children ignoring
+// the outer dictionary. A single-file DELETE delivers file_path as a CONSTANT
+// vector inside the ROW.
+TEST_F(
+    IcebergDeletionVectorSinkTest,
+    dictionaryWrappedRowIdStructConstantPath) {
+  auto tempDir = TempDirectoryPath::create();
+  auto handle = makeDeletionVectorHandle(tempDir->getPath());
+
+  IcebergDeletionVectorSink sink(
+      ROW({"$row_id"},
+          {ROW(
+              {"file_path", "pos", "spec_id", "partition"},
+              {VARCHAR(), BIGINT(), INTEGER(), VARCHAR()})}),
+      handle,
+      connectorQueryCtx_.get(),
+      connector::CommitStrategy::kNoCommit,
+      hiveConfig_);
+
+  const std::string dataFile = tempDir->getPath() + "/data-file.parquet";
+  // Table had rows at positions 0..4; DELETE removed ids 2 and 4 -> positions
+  // 1 and 3. The delete operator wraps the full row-id in a dictionary that
+  // selects only those two base rows.
+  sink.appendData(makeRowIdStructDeletePage(
+      dataFile,
+      /*allPositions=*/{0, 1, 2, 3, 4},
+      /*selected=*/{1, 3},
+      /*filePathConstant=*/true));
+  EXPECT_TRUE(sink.finish());
+  auto commitMessages = sink.close();
+
+  ASSERT_EQ(commitMessages.size(), 1);
+  auto parsed = folly::parseJson(commitMessages[0]);
+  EXPECT_EQ(parsed["referencedDataFile"].asString(), dataFile);
+  EXPECT_EQ(parsed["metrics"]["recordCount"].asInt(), 2);
+
+  auto deleted = readBackDeletedPositions(
+      parsed["path"].asString(),
+      static_cast<uint64_t>(parsed["contentOffset"].asInt()),
+      static_cast<uint64_t>(parsed["contentSizeInBytes"].asInt()),
+      static_cast<uint64_t>(parsed["metrics"]["recordCount"].asInt()),
+      /*maxPos=*/4,
+      pool_.get());
+  EXPECT_EQ(deleted, (std::vector<uint64_t>{1, 3}));
+}
+
+// Reproduces the exact production V3 DELETE layout captured from the worker:
+// the sink input is ROW<id:BIGINT, $row_id:ROW<_file, _pos, _spec_id,
+// partition_data>> — a passthrough data column PLUS the row-id ROW. Regression
+// guard for a worker SIGSEGV where the sink counted 2 columns and mis-took the
+// page for the legacy flat (file_path, pos) layout, then read the ROW column
+// as BIGINT positions.
+TEST_F(IcebergDeletionVectorSinkTest, rowIdStructWithLeadingDataColumn) {
+  auto tempDir = TempDirectoryPath::create();
+  auto handle = makeDeletionVectorHandle(tempDir->getPath());
+
+  IcebergDeletionVectorSink sink(
+      ROW({"id", "$row_id"},
+          {BIGINT(),
+           ROW({"_file", "_pos", "_spec_id", "partition_data"},
+               {VARCHAR(), BIGINT(), INTEGER(), VARCHAR()})}),
+      handle,
+      connectorQueryCtx_.get(),
+      connector::CommitStrategy::kNoCommit,
+      hiveConfig_);
+
+  const std::string dataFile = tempDir->getPath() + "/data-file.parquet";
+  sink.appendData(makeRowIdStructDeletePage(
+      dataFile,
+      /*allPositions=*/{0, 1, 2, 3, 4},
+      /*selected=*/{1, 3},
+      /*filePathConstant=*/true,
+      /*withLeadingIdColumn=*/true));
+  EXPECT_TRUE(sink.finish());
+  auto commitMessages = sink.close();
+
+  ASSERT_EQ(commitMessages.size(), 1);
+  auto parsed = folly::parseJson(commitMessages[0]);
+  EXPECT_EQ(parsed["referencedDataFile"].asString(), dataFile);
+  EXPECT_EQ(parsed["metrics"]["recordCount"].asInt(), 2);
+
+  auto deleted = readBackDeletedPositions(
+      parsed["path"].asString(),
+      static_cast<uint64_t>(parsed["contentOffset"].asInt()),
+      static_cast<uint64_t>(parsed["contentSizeInBytes"].asInt()),
+      static_cast<uint64_t>(parsed["metrics"]["recordCount"].asInt()),
+      /*maxPos=*/4,
+      pool_.get());
+  EXPECT_EQ(deleted, (std::vector<uint64_t>{1, 3}));
+}
+TEST_F(IcebergDeletionVectorSinkTest, dictionaryWrappedRowIdStructFlatPath) {
+  auto tempDir = TempDirectoryPath::create();
+  auto handle = makeDeletionVectorHandle(tempDir->getPath());
+
+  IcebergDeletionVectorSink sink(
+      ROW({"$row_id"},
+          {ROW(
+              {"file_path", "pos", "spec_id", "partition"},
+              {VARCHAR(), BIGINT(), INTEGER(), VARCHAR()})}),
+      handle,
+      connectorQueryCtx_.get(),
+      connector::CommitStrategy::kNoCommit,
+      hiveConfig_);
+
+  const std::string dataFile = tempDir->getPath() + "/data-file.parquet";
+  sink.appendData(makeRowIdStructDeletePage(
+      dataFile,
+      /*allPositions=*/{0, 1, 2, 3, 4},
+      /*selected=*/{1, 3},
+      /*filePathConstant=*/false));
+  EXPECT_TRUE(sink.finish());
+  auto commitMessages = sink.close();
+
+  ASSERT_EQ(commitMessages.size(), 1);
+  auto parsed = folly::parseJson(commitMessages[0]);
+  auto deleted = readBackDeletedPositions(
+      parsed["path"].asString(),
+      static_cast<uint64_t>(parsed["contentOffset"].asInt()),
+      static_cast<uint64_t>(parsed["contentSizeInBytes"].asInt()),
+      static_cast<uint64_t>(parsed["metrics"]["recordCount"].asInt()),
+      /*maxPos=*/4,
+      pool_.get());
+  EXPECT_EQ(deleted, (std::vector<uint64_t>{1, 3}));
 }


### PR DESCRIPTION
Summary:

Iceberg V3 allows at most one deletion vector (DV) per data file
(MergingSnapshotProducer.validateAddedDVs). A second mutation that touches a
data file which already has a DV (e.g. UPDATE grp='a' then DELETE id=3 in the
same file) previously failed at commit with "Found concurrently added DV",
because Presto's commit path was add-only and never removed/replaced the prior
DV, and the DELETE path never bounded the added-DV conflict check.

This implements the worker-seed approach (option A), matching Iceberg OSS's own
BaseDVFileWriter + SparkPositionDeltaWrite DV-replacement pattern:

- Coordinator (plan): IcebergAbstractMetadata enumerates the existing DVs for
  the read snapshot at beginDelete/beginMerge (V3-gated) and attaches them,
  keyed by referenced data file, to IcebergDeleteTableHandle and the inner
  IcebergInsertTableHandle.
- Prestissimo bridge + protocol: the existing-DV map is threaded through the
  generated protocol structs (via the special/*.inc overrides) and
  IcebergPrestoToVeloxConnector into the Velox IcebergInsertTableHandle.
- Velox worker (seed): IcebergDeletionVectorSink seeds each new DV's roaring
  bitmap with the prior DV's positions (read via a new
  DeletionVectorReader::deletedPositions() accessor) so the emitted Puffin is
  the union of old and newly-deleted positions. IcebergMergeSink propagates the
  map to its kDeletionVector sub-sink.
- Coordinator (commit): finishDeleteWithOutput / finishWrite remove the prior
  DV in the same RowDelta (RowDelta.removeDeletes) and call
  validateFromSnapshot(readSnapshot) so validateAddedDVs is bounded to
  genuinely-concurrent snapshots. Result: exactly one DV per data file with
  removed-dvs/added-dvs = 1/1.

Reviewed By: srsuryadev

Differential Revision: D111582329


