### PR TITLE
fix(exec): Suspend table scan driver while it awaits a split preload or coalesced load (#18118)

### DIFF
--- a/velox/dwio/common/DirectInputStream.cpp
+++ b/velox/dwio/common/DirectInputStream.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <folly/ScopeGuard.h>
 #include <folly/executors/QueuedImmediateExecutor.h>
 
 #include "velox/common/time/Timer.h"
@@ -178,6 +179,20 @@ void DirectInputStream::loadPosition() {
       {
         MicrosecondWallTimer timer(&loadUs);
         if (!load->loadOrFuture(&waitFuture)) {
+          // The driver parks here on-thread waiting for a prefetch running on
+          // another thread. Suspend it (via the operator pool's reclaimer) so a
+          // concurrent memory-arbitration reclaim can pause this task instead
+          // of dead-locking on numThreads_ > 0. No-op off a driver thread or
+          // when the pool has no suspending reclaimer.
+          auto* reclaimer = bufferedInput_->pool()->reclaimer();
+          if (reclaimer != nullptr) {
+            reclaimer->enterArbitration();
+          }
+          auto leaveGuard = folly::makeGuard([reclaimer]() {
+            if (reclaimer != nullptr) {
+              reclaimer->leaveArbitration();
+            }
+          });
           waitFuture.wait();
         }
         loadedRegion_.offset = region_.offset;

--- a/velox/dwio/common/tests/DirectBufferedInputTest.cpp
+++ b/velox/dwio/common/tests/DirectBufferedInputTest.cpp
@@ -20,6 +20,7 @@
 #include <folly/executors/CPUThreadPoolExecutor.h>
 #include <folly/synchronization/Baton.h>
 #include <gtest/gtest.h>
+#include <atomic>
 #include <thread>
 
 #include "velox/common/base/tests/GTestUtils.h"
@@ -47,6 +48,33 @@ std::optional<std::string> getNext(SeekableInputStream& input) {
     return std::nullopt;
   }
 }
+
+// Records enterArbitration()/leaveArbitration() so a test can verify that a
+// blocking coalesced load wait suspends the calling driver via the operator
+// pool's reclaimer.
+class CountingReclaimer : public MemoryReclaimer {
+ public:
+  CountingReclaimer() : MemoryReclaimer(0) {}
+
+  static std::unique_ptr<MemoryReclaimer> create() {
+    return std::make_unique<CountingReclaimer>();
+  }
+
+  void enterArbitration() override {
+    ++numEntered;
+    entered.post();
+  }
+
+  void leaveArbitration() noexcept override {
+    ++numLeft;
+  }
+
+  std::atomic_int32_t numEntered{0};
+  std::atomic_int32_t numLeft{0};
+  // Posted the first time enterArbitration() is called so a test can wait for
+  // the suspending wait to begin without polling.
+  folly::Baton<> entered;
+};
 
 class DirectBufferedInputTest : public testing::Test {
  protected:
@@ -562,6 +590,106 @@ DEBUG_ONLY_TEST_F(DirectBufferedInputTest, resetInputWithAfterLoading) {
       std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
   }
+}
+
+DEBUG_ONLY_TEST_F(DirectBufferedInputTest, coalescedLoadWaitEntersArbitration) {
+  // When a stream needs data that a prefetch is still producing on another
+  // thread, the on-thread wait must suspend the calling driver via the operator
+  // pool's reclaimer, otherwise the task's thread count stays nonzero and a
+  // concurrent memory-arbitration reclaim dead-locks. This test has no real
+  // driver, so it installs a reclaimer that counts enterArbitration()/
+  // leaveArbitration() and asserts the wait invokes them once.
+  auto rootPool = memoryManager()->addRootPool(
+      "coalescedLoadWaitRoot", kMaxMemory, MemoryReclaimer::create());
+  auto leafReclaimer = CountingReclaimer::create();
+  auto* countingReclaimer =
+      static_cast<CountingReclaimer*>(leafReclaimer.get());
+  auto pool = rootPool->addLeafChild(
+      "coalescedLoadWaitLeaf", true, std::move(leafReclaimer));
+
+  constexpr int32_t kContentSize = 4 << 20; // 4MB
+  std::string content;
+  content.resize(kContentSize);
+  for (int32_t i = 0; i < kContentSize; ++i) {
+    content[i] = static_cast<char>('a' + (i % 26));
+  }
+  const uint64_t regionSize = DirectBufferedInput::kTinySize + 1000;
+  auto readFile = std::make_shared<InMemoryReadFile>(content);
+
+  io::ReaderOptions readerOptions(pool.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
+  readerOptions.setLoadQuantum(1 << 20);
+
+  auto& ids = fileIds();
+  StringIdLease fileId(ids, "coalescedLoadWaitFile");
+  StringIdLease groupId(ids, "coalescedLoadWaitGroup");
+
+  DirectBufferedInput input(
+      readFile,
+      MetricsLog::voidLog(),
+      std::move(fileId),
+      tracker_,
+      std::move(groupId),
+      dataIoStats_,
+      nullptr,
+      executor_.get(),
+      readerOptions);
+
+  // Block the prefetch after it enters the kLoading state so a concurrent
+  // reader parks on the wait future rather than loading inline.
+  folly::Baton<> loadStarted;
+  folly::Baton<> loadAllowed;
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::cache::CoalescedLoad::loadOrFuture::loading",
+      std::function<void(const CoalescedLoad*)>(
+          [&](const CoalescedLoad* /*load*/) {
+            loadStarted.post();
+            loadAllowed.wait();
+          }));
+
+  auto stream1 = input.enqueue(common::Region{0, regionSize}, nullptr);
+  auto stream2 = input.enqueue(common::Region{regionSize, regionSize}, nullptr);
+  ASSERT_NE(stream1, nullptr);
+  ASSERT_NE(stream2, nullptr);
+
+  input.load(LogType::TEST);
+
+  // Wait until the prefetch is loading (and blocked on 'loadAllowed').
+  loadStarted.wait();
+
+  // Read on another thread; it parks in the coalesced load wait because the
+  // prefetch is still loading.
+  std::atomic_bool consumerDone{false};
+  std::optional<std::string> consumed;
+  std::thread consumer([&]() {
+    consumed = getNext(*stream1);
+    consumerDone = true;
+  });
+
+  // The reader must enter arbitration (suspend) before its wait returns. Wait
+  // for the reclaimer's baton; without the fix it is never posted and this
+  // times out.
+  ASSERT_TRUE(
+      countingReclaimer->entered.try_wait_for(std::chrono::seconds(30)));
+  EXPECT_EQ(countingReclaimer->numEntered.load(), 1);
+  EXPECT_FALSE(consumerDone.load());
+
+  // Unblock the prefetch; the reader's wait returns and it leaves arbitration.
+  loadAllowed.post();
+  consumer.join();
+
+  EXPECT_EQ(countingReclaimer->numLeft.load(), 1);
+  ASSERT_TRUE(consumed.has_value());
+  EXPECT_EQ(consumed.value(), content.substr(0, regionSize));
+
+  stream1.reset();
+  stream2.reset();
+  input.reset();
+  // Drain the prefetch executor so the background load fully unwinds and drops
+  // its reference to the coalesced load before the pool is checked/destroyed.
+  executor_->join();
+  EXPECT_EQ(pool->usedBytes(), 0);
 }
 
 TEST_F(DirectBufferedInputTest, preloadCalledTwice) {

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -13,11 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/exec/TableScan.h"
+#include <folly/ScopeGuard.h>
+
 #include "velox/common/testutil/TestValue.h"
 #include "velox/common/time/Timer.h"
 #include "velox/connectors/ConnectorRegistry.h"
 #include "velox/exec/OperatorType.h"
+#include "velox/exec/TableScan.h"
 #include "velox/exec/Task.h"
 
 using facebook::velox::common::testutil::TestValue;
@@ -395,7 +397,24 @@ bool TableScan::getSplit() {
     // will be nullptr if there was a cancellation.
     numReadyPreloadedSplits_ += connectorSplit->dataSource->hasValue();
     auto startTimeNs = getCurrentTimeNano();
-    auto preparedDataSource = connectorSplit->dataSource->move();
+    std::unique_ptr<connector::DataSource> preparedDataSource;
+    {
+      // The driver parks here on-thread waiting for a split preload prepared on
+      // another thread. Suspend it (via the operator pool's reclaimer) so a
+      // concurrent memory-arbitration reclaim can pause this task instead of
+      // dead-locking on numThreads_ > 0. No-op off a driver thread or when the
+      // pool has no suspending reclaimer.
+      auto* reclaimer = pool()->reclaimer();
+      if (reclaimer != nullptr) {
+        reclaimer->enterArbitration();
+      }
+      auto leaveGuard = folly::makeGuard([reclaimer]() {
+        if (reclaimer != nullptr) {
+          reclaimer->leaveArbitration();
+        }
+      });
+      preparedDataSource = connectorSplit->dataSource->move();
+    }
     auto endTimeNs = getCurrentTimeNano();
     stats_.wlock()->addRuntimeStat(
         std::string(TableScan::kWaitForPreloadSplitNanos),

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -5917,6 +5917,100 @@ TEST_F(TableScanTest, bloomFilterPushdown) {
   }
 }
 
+// A table scan driver that blocks on-thread awaiting a split preload (or a
+// coalesced load) prepared on another thread must suspend itself, otherwise a
+// concurrent memory-arbitration reclaim can never pause the task and the query
+// dead-locks. Here the second split's read is blocked on the faulty file system
+// so a scan driver parks on the preload wait; the task must still be pausable.
+DEBUG_ONLY_TEST_F(TableScanTest, tableScanPausableWhileAwaitingSplitPreload) {
+  const size_t numFiles{2};
+  std::vector<std::shared_ptr<TempFilePath>> filePaths;
+  std::vector<RowVectorPtr> vectors;
+  for (auto i = 0; i < numFiles; ++i) {
+    auto batch = makeVectors(1, 1'000);
+    filePaths.emplace_back(TempFilePath::create(true));
+    writeToFile(filePaths.back()->tempFilePath(), batch);
+    vectors.push_back(batch[0]);
+  }
+  createDuckDbTable(vectors);
+
+  // Block the read of the second file so its background split preload never
+  // completes, parking a scan driver on the preload wait. 'secondReadBlocked'
+  // is set once that read is entered and stays blocked until the test releases
+  // it, so the scan driver's wait on this split is durable (not transient).
+  std::atomic_bool secondReadBlocked{false};
+  std::atomic_bool readResumeFlag{true};
+  folly::EventCount readResume;
+  auto faultyFs = faultyFileSystem();
+  std::atomic_bool blockOnce{true};
+  faultyFs->setFileInjectionHook([&](FaultFileOperation* op) {
+    if (op->path != filePaths.back()->getPath()) {
+      return;
+    }
+    if (!blockOnce.exchange(false)) {
+      return;
+    }
+    secondReadBlocked = true;
+    readResume.await([&]() { return !readResumeFlag.load(); });
+  });
+
+  // Fires on the driver thread when it parks on a split preload wait. Only act
+  // on the wait for the durably-blocked second split (after its read is
+  // entered); by this point driver suspension (if present) has already taken
+  // effect.
+  std::atomic_bool driverWaitingFlag{true};
+  folly::EventCount driverWaiting;
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::AsyncSource::makeWait",
+      std::function<void(void*)>([&](void*) {
+        if (!secondReadBlocked.load()) {
+          return;
+        }
+        driverWaitingFlag = false;
+        driverWaiting.notifyAll();
+      }));
+
+  auto plan = tableScanNode();
+  const auto scanNodeId = plan->id();
+  std::shared_ptr<Task> task;
+  folly::Baton<> taskReady;
+  std::thread queryThread([&]() {
+    bool splitsAdded{false};
+    ::assertQuery(
+        plan,
+        [&](TaskCursor* cursor) {
+          if (splitsAdded) {
+            return;
+          }
+          splitsAdded = true;
+          task = cursor->task();
+          for (const auto& filePath : filePaths) {
+            cursor->task()->addSplit(
+                scanNodeId, makeHiveSplit(filePath->getPath()));
+          }
+          cursor->task()->noMoreSplits(scanNodeId);
+          cursor->setNoMoreSplits();
+          taskReady.post();
+        },
+        "SELECT * FROM tmp",
+        duckDbQueryRunner_);
+  });
+
+  taskReady.wait();
+  driverWaiting.await([&]() { return !driverWaitingFlag.load(); });
+
+  // The parked driver must have suspended so the task can pause. Without driver
+  // suspension for table scan, requestPause() never completes and this times
+  // out.
+  EXPECT_TRUE(task->requestPause().wait(std::chrono::seconds(60)));
+  Task::resume(task);
+
+  // Unblock the read and let the query run to completion.
+  readResumeFlag = false;
+  readResume.notifyAll();
+  queryThread.join();
+}
+
 // TODO: re-enable this test once we add back driver suspension support for
 // table scan.
 TEST_F(TableScanTest, DISABLED_memoryArbitrationWithSlowTableScan) {


### PR DESCRIPTION
Summary:

When a `TableScan` driver needs data that a prefetch is producing on another thread, it blocks on-thread in a synchronous wait that is not integrated with the Driver loop: either `AsyncSource::move()` for a preloaded split (`TableScan::getSplit`) or `folly::SemiFuture::wait()` for a coalesced load (`DirectInputStream::loadPosition`). Because the driver never returns control to the Driver loop, the `Task`'s `numThreads_` stays greater than zero, so a concurrent memory-arbitration reclaim's `Task::requestPause()` never completes. When an external memory arbitrator drives the reclaim from another thread while holding a lock that the blocked driver also needs to make progress, the task can dead-lock until the reclaim wait times out.

Suspend the driver for the duration of those two blocking waits via the operator pool's reclaimer (`enterArbitration()` / `leaveArbitration()`, which call `Task::enterSuspended` / `Task::leaveSuspended`). While suspended the driver is off-thread, so a concurrent reclaim can pause the task, reclaim memory, and resume it; the driver then finishes its wait and proceeds. The wrap is a no-op when not on a driver thread (for example the prefetch thread itself) or when the pool has no suspending reclaimer.

This narrowly re-adds driver suspension for table scan, which was previously removed. The earlier version wrapped the entire `TableScan::getOutput()` in a `SuspendedSection` and was reverted for two reasons: (1) `leaveSuspended` does an on-thread sleep while a pause is in flight, causing high driver-queue latency when applied to all of `getOutput()`, including its CPU work; and (2) a task-terminate race. This change limits suspension to the two actual blocking I/O waits (never the CPU portions of `getOutput()`), so (1) is negligible; `enterArbitration()` throws if the task is already terminated when the driver enters the wait, and the Driver loop's post-operator terminate check handles a terminate that happens while suspended.

Limitation: this does not restore driver suspension for a fully synchronous (non-preloaded) read. The pre-existing `DISABLED_memoryArbitrationWithSlowTableScan` and `DISABLED_memoryArbitrationByTableScanAllocation` tests were written against the whole-`getOutput()` suspension and remain disabled.

Differential Revision: D111518924


