### PR TITLE
feat(torchwave): Free intermediate tensors at last use (#18119)

### DIFF
--- a/velox/experimental/torchwave/Builtins.cpp
+++ b/velox/experimental/torchwave/Builtins.cpp
@@ -113,6 +113,11 @@ nativert::Node* makeCumsumVariant(NodeCP single, WaveGraph* waveGraph) {
   if (dimAttr) {
     finalNode->addAttribute({dimAttr->name, std::get<int64_t>(dimAttr->value)});
   }
+  // The op input feeds both head and final, and the head counts feed both
+  // add_sizes and final: each is consumed by more than one part of this
+  // expansion, so it must not be freed as a per-op intermediate.
+  waveGraph->declareMultiplyReferencedInput(single->inputs()[0].value);
+  waveGraph->declareMultiplyReferencedInput(headOutput);
   copyOriginalOutputs(finalNode, single, waveGraph);
   return finalNode;
 }
@@ -139,6 +144,10 @@ nativert::Node* makeExclusiveSumVariant(NodeCP single, WaveGraph* waveGraph) {
        {"counts", headOutput},
        {"link", addSizesOutput}});
   finalNode->addAttribute({"dtype", dtypeStr});
+  // Consumed by more than one part of this expansion (input by head+final,
+  // counts by add_sizes+final); keep out of the freeable intermediates.
+  waveGraph->declareMultiplyReferencedInput(single->inputs()[0].value);
+  waveGraph->declareMultiplyReferencedInput(headOutput);
   copyOriginalOutputs(finalNode, single, waveGraph);
   return finalNode;
 }
@@ -164,6 +173,12 @@ nativert::Node* makeMaskedSelectVariant(NodeCP single, WaveGraph* waveGraph) {
        {"mask", single->inputs()[1].value},
        {"counts", headOutput},
        {"total", addSizesOutput}});
+  // input, mask and counts are each consumed by more than one part of this
+  // expansion (input/mask by head+final, counts by add_sizes+final); keep them
+  // out of the freeable intermediates.
+  waveGraph->declareMultiplyReferencedInput(single->inputs()[0].value);
+  waveGraph->declareMultiplyReferencedInput(single->inputs()[1].value);
+  waveGraph->declareMultiplyReferencedInput(headOutput);
   copyOriginalOutputs(finalNode, single, waveGraph);
   return finalNode;
 }

--- a/velox/experimental/torchwave/Compile.cpp
+++ b/velox/experimental/torchwave/Compile.cpp
@@ -2167,11 +2167,19 @@ std::unique_ptr<CompiledNode> CompileCtx::compileNode(ProjectNode& project) {
   }
   auto compositeKernel = std::make_unique<CompositeKernel>(
       std::move(opStorage_), std::move(kernelOpStorage_), includes_);
+  // Values whose last use is in this node (graph outputs already excluded);
+  // WaveConfig::freeIntermediates releases their frame tensors after execute().
+  std::vector<nativert::ValueId> lastUseIds;
+  lastUseIds.reserve(project.lastUse.size());
+  for (auto* value : project.lastUse) {
+    lastUseIds.push_back(value->id());
+  }
   auto invocation = std::make_unique<CompositeInvocation>(
       std::move(compositeKernel),
       std::move(ops_),
       std::move(ivalueStorage_),
-      waveGraph_.nextCompositeInvocationId());
+      waveGraph_.nextCompositeInvocationId(),
+      std::move(lastUseIds));
   placed_.insert(nodes.begin(), nodes.end());
   return std::make_unique<CompiledNode>(std::move(invocation));
 }

--- a/velox/experimental/torchwave/CompiledOp.cpp
+++ b/velox/experimental/torchwave/CompiledOp.cpp
@@ -23,6 +23,7 @@
 #include "velox/experimental/wave/common/KernelFsCache.h"
 
 #include <ATen/ATen.h>
+#include <c10/core/CachingDeviceAllocator.h>
 #include <c10/util/StringUtil.h>
 #include <folly/ScopeGuard.h>
 #include <gflags/gflags.h>
@@ -31,6 +32,7 @@
 #include <iostream>
 #include <sstream>
 #include <type_traits>
+#include <unordered_set>
 
 #include "velox/experimental/wave/common/GpuArena.h"
 
@@ -50,6 +52,18 @@ DEFINE_bool(
 // binary. PyTorch dispatches eager standalone ops to the default stream.
 extern "C" int cudaStreamSynchronize(void* stream);
 
+// Forward-declared (not via <c10/cuda/...>) for the same reason as
+// cudaStreamSynchronize above: this TU is CPU-configured and has no CUDA
+// headers. current_device() is a non-inline C10_CUDA_API symbol resolved at
+// final link. Allocator stats go through the CPU-safe, device-agnostic
+// c10::getDeviceAllocator(CUDA) base interface
+// (<c10/core/CachingDeviceAllocator.h>), whose getDeviceStats is a virtual
+// dispatched to libc10_cuda's registered allocator, so no CUDA-header (or new
+// build) dependency is needed.
+namespace c10::cuda {
+c10::DeviceIndex current_device();
+} // namespace c10::cuda
+
 namespace torch::wave {
 
 namespace {
@@ -59,6 +73,17 @@ namespace {
 // composite invocation returns.
 void syncTorchDefaultStream() {
   cudaStreamSynchronize(nullptr);
+}
+
+// Bytes currently held in live tensors by the torch CUDA caching allocator on
+// the active device. Sampled per step for the kTiming trace's "GPU RAM" field.
+int64_t currentAllocatedBytes() {
+  auto* allocator = c10::getDeviceAllocator(c10::DeviceType::CUDA);
+  auto stats = allocator->getDeviceStats(c10::cuda::current_device());
+  return stats
+      .allocated_bytes[static_cast<size_t>(
+          c10::CachingAllocator::StatType::AGGREGATE)]
+      .current;
 }
 
 facebook::velox::wave::CompiledKernel& patchOpcodesKernel() {
@@ -239,6 +264,16 @@ at::Tensor paramTensor(
       "Input value %",
       value->id(),
       " not found in FormalToActual map");
+  const auto& iv = frame.getIValue(it->second);
+  TORCH_CHECK(
+      iv.isTensor(),
+      "paramTensor: actual value %",
+      it->second,
+      " (formal %",
+      value->id(),
+      ") is not a tensor (tag=",
+      iv.tagKind(),
+      ") -- freed while still needed?");
   return frame.getTensor(it->second);
 }
 
@@ -701,11 +736,15 @@ CompositeInvocation::CompositeInvocation(
     std::unique_ptr<CompositeKernel> kernel,
     std::vector<OpInvocation> ops,
     std::deque<c10::IValue> ivalueStorage,
-    int32_t sequenceNumber)
+    int32_t sequenceNumber,
+    std::vector<nativert::ValueId> lastUseIds,
+    std::vector<Launch> prePassStandalones)
     : kernel_(std::move(kernel)),
       ops_(std::move(ops)),
       ivalueStorage_(std::move(ivalueStorage)),
-      sequenceNumber_(sequenceNumber) {}
+      sequenceNumber_(sequenceNumber),
+      lastUseIds_(std::move(lastUseIds)),
+      prePassStandalones_(std::move(prePassStandalones)) {}
 
 namespace {
 
@@ -1366,8 +1405,19 @@ void fillTensorListParam(
     tlp.elementOffsets.push_back(elemOffset);
     tlp.elementIds.push_back(actualId);
     if (filledOffsets.insert(elemOffset).second) {
-      fillTensorParam(
-          frame.getIValue(actualId).toTensor(), paramBase + elemOffset);
+      const auto& elemIv = frame.getIValue(actualId);
+      TORCH_CHECK(
+          elemIv.isTensor(),
+          "fillTensorListParam: list %",
+          listValue->id(),
+          " element actual %",
+          actualId,
+          " (formal %",
+          elemId,
+          ") is not a tensor (tag=",
+          elemIv.tagKind(),
+          ") -- freed while still needed?");
+      fillTensorParam(elemIv.toTensor(), paramBase + elemOffset);
       launch.tensorsInFrame.push_back(actualId);
       launch.tensorOffsets.push_back(elemOffset);
     }
@@ -2113,7 +2163,7 @@ void verifyAgainstReference(
   // This checks both fused outputs (produced on the wave stream) and standalone
   // outputs (produced by eager ops on the default stream), so sync both: the
   // wave stream and the default stream where eager standalones run.
-  state.stream->wait();
+  syncWaveStream(state);
   syncTorchDefaultStream();
   // The reference stores scalars and scalar lists as 1-D tensors; fold the
   // actual frame value into a tensor the same way so it can be compared
@@ -2431,6 +2481,7 @@ void CompositeInvocation::execute(ExecutionState& state) {
   bool ranStandalones = false;
 
   int32_t blockSize;
+  int32_t lastExecStep = -1;
   for (int32_t stepIdx = 0;; ++stepIdx) {
     auto& sv = getStepVectors(state.stepVectors, sequenceNumber_, stepIdx);
     // Re-fetch since the resize above may have invalidated the reference.
@@ -2459,6 +2510,7 @@ void CompositeInvocation::execute(ExecutionState& state) {
         sv.shortcutStandalones.empty()) {
       break;
     }
+    lastExecStep = stepIdx;
 
     if (sv.kernels.empty()) {
       if (WaveConfig::get().trace &
@@ -2477,7 +2529,7 @@ void CompositeInvocation::execute(ExecutionState& state) {
       // unordered. Shortcut ops only touch host-side tensor metadata, so they
       // need no sync.
       if (sv.hasGpuStandalones) {
-        state.stream->wait();
+        syncWaveStream(state);
       }
       auto tStandalone = doTiming ? Clock::now() : Clock::time_point{};
       runStandalones(
@@ -2489,6 +2541,7 @@ void CompositeInvocation::execute(ExecutionState& state) {
           doTiming);
       if (doTiming) {
         sv.standaloneUs = elapsed(tStandalone);
+        sv.currentBytes = currentAllocatedBytes();
       }
       ranStandalones = true;
       state.launchDebugInfos.push_back(
@@ -2498,7 +2551,7 @@ void CompositeInvocation::execute(ExecutionState& state) {
         // belongs in e2e); time only the device-to-host copy and comparison.
         bool timeRefCheck = doTiming && WaveConfig::get().referenceFrame;
         if (timeRefCheck) {
-          state.stream->wait();
+          syncWaveStream(state);
           syncTorchDefaultStream();
         }
         auto tRefCheck = timeRefCheck ? Clock::now() : Clock::time_point{};
@@ -2508,6 +2561,9 @@ void CompositeInvocation::execute(ExecutionState& state) {
           sv.refCheckUs += elapsed(tRefCheck);
         }
       }
+      // Standalone-only step issued; the next wave-stream wait advances it to
+      // kSynced (and frees its lastUseIds if freeIntermediates is on).
+      sv.executionStage = ExecutionStage::kAllocated;
       continue;
     }
 
@@ -2684,7 +2740,7 @@ void CompositeInvocation::execute(ExecutionState& state) {
     // unordered. Shortcut standalones only touch host-side tensor metadata, so
     // they need no sync.
     if (sv.hasGpuStandalones) {
-      state.stream->wait();
+      syncWaveStream(state);
     }
 
     {
@@ -2711,12 +2767,13 @@ void CompositeInvocation::execute(ExecutionState& state) {
         sv.standaloneUs = standaloneElapsed;
         sv.standaloneBound = standaloneElapsed > sv.kernelUs;
         sv.noDtoH = (returnBegin < 0);
+        sv.currentBytes = currentAllocatedBytes();
       }
     }
 
     // Trace outputs of kernel launches after execution.
     if (!state.traceState.empty()) {
-      state.stream->wait();
+      syncWaveStream(state);
       for (const auto& launch : sv.kernels) {
         traceFrameValues(
             "output", launch.actualOutputs, frame, state.traceState);
@@ -2734,7 +2791,7 @@ void CompositeInvocation::execute(ExecutionState& state) {
       // only the device-to-host copy and comparison.
       bool timeRefCheck = doTiming && WaveConfig::get().referenceFrame;
       if (timeRefCheck) {
-        state.stream->wait();
+        syncWaveStream(state);
         syncTorchDefaultStream();
       }
       auto tRefCheck = timeRefCheck ? Clock::now() : Clock::time_point{};
@@ -2745,6 +2802,9 @@ void CompositeInvocation::execute(ExecutionState& state) {
         sv.refCheckUs += elapsed(tRefCheck);
       }
     }
+    // Kernel launched and its outputs allocated; the next wave-stream wait
+    // advances this step to kSynced.
+    sv.executionStage = ExecutionStage::kAllocated;
   }
 
   // If any eager standalone op ran, synchronize the default CUDA stream before
@@ -2760,6 +2820,15 @@ void CompositeInvocation::execute(ExecutionState& state) {
     // async tail to the first standalone step and over-reported standalone time
     // past e2e.
     syncTorchDefaultStream();
+  }
+
+  // Stamp this node's last-use values onto its last executed step so they are
+  // released by the wave-stream sync that advances that step to kSynced, with
+  // no dedicated sync of their own. advanceSyncedStages performs the release.
+  if (WaveConfig::get().freeIntermediates && lastExecStep >= 0 &&
+      !lastUseIds_.empty()) {
+    getStepVectors(state.stepVectors, sequenceNumber_, lastExecStep)
+        .lastUseIds = lastUseIds_;
   }
 }
 

--- a/velox/experimental/torchwave/CompiledOp.h
+++ b/velox/experimental/torchwave/CompiledOp.h
@@ -321,7 +321,9 @@ class CompositeInvocation {
       std::unique_ptr<CompositeKernel> kernel,
       std::vector<OpInvocation> ops,
       std::deque<c10::IValue> ivalueStorage,
-      int32_t sequenceNumber);
+      int32_t sequenceNumber,
+      std::vector<nativert::ValueId> lastUseIds,
+      std::vector<Launch> prePassStandalones = {});
 
   /// Executes this composite invocation: allocates outputs, builds the grid,
   /// copies params to pinned+device memory, and enqueues the H2D transfer.
@@ -381,6 +383,16 @@ class CompositeInvocation {
   std::vector<OpInvocation> ops_;
   std::deque<c10::IValue> ivalueStorage_;
   int32_t sequenceNumber_;
+
+  // Frame value ids whose last use across the graph is in this node (graph
+  // outputs excluded). When WaveConfig::freeIntermediates is set, their frame
+  // tensors are released at the end of execute().
+  std::vector<nativert::ValueId> lastUseIds_;
+
+  // Standalone ops from the maxFusedNodes pre-pass.  Executed at the
+  // start of execute() before any kernel step, so their outputs are
+  // available for SizeExpr evaluation.
+  std::vector<Launch> prePassStandalones_;
 };
 
 /// Represents a single ProjectNode in a stack of ProjectNodes. Contains a graph

--- a/velox/experimental/torchwave/Executor.cpp
+++ b/velox/experimental/torchwave/Executor.cpp
@@ -17,6 +17,7 @@
 #include "velox/experimental/torchwave/Executor.h"
 
 #include <ATen/ATen.h>
+#include <c10/core/CachingDeviceAllocator.h>
 #include <folly/ScopeGuard.h>
 #include <folly/chrono/Hardware.h>
 #include <gflags/gflags.h>
@@ -24,7 +25,10 @@
 #include <atomic>
 #include <chrono>
 #include <cstdlib>
+#include <cstring>
 #include <iostream>
+#include <unordered_set>
+#include "velox/common/base/SuccinctPrinter.h"
 #include "velox/experimental/torchwave/NodePrinter.h"
 #include "velox/experimental/torchwave/Registry.h"
 #include "velox/experimental/torchwave/Standalones.h"
@@ -42,6 +46,15 @@
 // CUDA headers; the symbol resolves from the CUDA runtime linked into the final
 // binary. PyTorch dispatches eager standalone ops to the default stream.
 extern "C" int cudaStreamSynchronize(void* stream);
+
+// current_device() is a non-inline C10_CUDA_API symbol resolved at final link
+// (same rationale as cudaStreamSynchronize: this TU has no CUDA headers).
+// Allocator peak stats are read/reset through the CPU-safe, device-agnostic
+// c10::getDeviceAllocator(CUDA) interface
+// (<c10/core/CachingDeviceAllocator.h>).
+namespace c10::cuda {
+c10::DeviceIndex current_device();
+} // namespace c10::cuda
 
 namespace torch::wave {
 
@@ -70,6 +83,25 @@ thread_local WaveThreadInfo threadInfo;
 // ops are dispatched, so they are complete before executeWave returns.
 void syncTorchDefaultStream() {
   cudaStreamSynchronize(nullptr);
+}
+
+// Resets the torch CUDA caching allocator's peak stats on the active device so
+// the peak read back after a run reflects only that run.
+void resetPeakAllocatedBytes() {
+  c10::getDeviceAllocator(c10::DeviceType::CUDA)
+      ->resetPeakStats(c10::cuda::current_device());
+}
+
+// Peak bytes allocated by the torch CUDA caching allocator since the last
+// resetPeakStats, on the active device. Captures the transient intra-run
+// high-water mark, not just per-step samples.
+int64_t peakAllocatedBytes() {
+  auto* allocator = c10::getDeviceAllocator(c10::DeviceType::CUDA);
+  auto stats = allocator->getDeviceStats(c10::cuda::current_device());
+  return stats
+      .allocated_bytes[static_cast<size_t>(
+          c10::CachingAllocator::StatType::AGGREGATE)]
+      .peak;
 }
 
 // TSC ticks per microsecond, calibrated once. folly::hardware_timestamp()
@@ -663,11 +695,11 @@ std::vector<c10::IValue> WaveGraphExecutor::executeWithPrefilledFrame(
   }
 
   // tryMoveUserOutputs moves the output IValues out of the frame, decoupling
-  // them so the frame can be safely returned to the pool. However, it does
-  // not move outputs whose graph-level default is Constant(None) — in that
-  // case the result slot stays None even though the frame has a computed
-  // tensor (e.g. dynamic-shape outputs computed on device). The loop below
-  // copies these non-moved outputs from the frame into the results.
+  // them so the frame can be safely returned to the pool. However, it does not
+  // move outputs whose graph-level default is Constant(None) -- in that case
+  // the result slot stays None even though the frame has a computed tensor
+  // (e.g. dynamic-shape outputs computed on device). The loop below copies
+  // these non-moved outputs from the frame into the results.
   auto results = frame.tryMoveUserOutputs();
   auto outputValues = graph_.outputs();
   for (size_t i = 0; i < results.size() && i < outputValues.size(); ++i) {
@@ -679,7 +711,215 @@ std::vector<c10::IValue> WaveGraphExecutor::executeWithPrefilledFrame(
       }
     }
   }
+
+  // A user output can still be None here when it is an elided no-op /
+  // metadata-only view (e.g. view(x, [-1]) of an already-contiguous tensor):
+  // wave aliases such a view to its input and never writes the view's own
+  // value, so a graph-output view stays None even though its input tensor is
+  // present. The loop above cannot reach these when userOutputs() is longer
+  // than the output-node operand list (graph_.outputs()), so recover them here
+  // directly from the flattened user-output list, materializing the view from
+  // its input.
+  const auto& userOutputs = graph_.userOutputs();
+  for (size_t i = 0; i < results.size() && i < userOutputs.size(); ++i) {
+    if (!results.at(i).isNone()) {
+      continue;
+    }
+    const auto* valuePtr = std::get_if<nativert::Value*>(&userOutputs[i]);
+    if (valuePtr == nullptr || *valuePtr == nullptr) {
+      continue;
+    }
+    const nativert::Value* v = *valuePtr;
+    const auto& iv = frame.getIValue(v->id());
+    if (!iv.isNone()) {
+      results.at(i) = iv;
+      continue;
+    }
+    const auto* prod = v->producer();
+    if (prod == nullptr || prod->inputs().empty()) {
+      continue;
+    }
+    const auto tgt = prod->target();
+    bool viewLike = tgt.find("view") != std::string_view::npos ||
+        tgt.find("reshape") != std::string_view::npos ||
+        tgt.find("flatten") != std::string_view::npos;
+    if (!viewLike) {
+      continue;
+    }
+    const auto* inputVal = prod->inputs()[0].value;
+    if (inputVal == nullptr) {
+      continue;
+    }
+    const auto& inIv = frame.getIValue(inputVal->id());
+    if (inIv.isTensor() && inIv.toTensor().defined()) {
+      // Observed elided views are all view(x, [-1]) (flatten); reshape(-1)
+      // reproduces them and is a no-op when the input is already 1-D.
+      results.at(i) = inIv.toTensor().reshape(-1);
+      LOG(WARNING) << "Recovered elided view output %" << v->id()
+                   << " (producer " << tgt << ") from input %"
+                   << inputVal->id();
+    }
+  }
   return results;
+}
+
+// Releases a frame value. Under debug_single_ops, if this frame slot is the
+// sole owner of the tensor's storage (no live view/alias references it), the
+// whole storage -- not just this tensor's possibly-partial view -- is filled
+// with 0xdd before it is dropped, so any use-after-free of a released buffer
+// reads an obvious poison pattern instead of stale-but-valid data.
+void freeFrameValue(
+    nativert::ExecutionFrame& frame,
+    nativert::ValueId id,
+    facebook::velox::wave::Stream* stream) {
+  if (WaveConfig::get().debugSingleOps) {
+    const auto& iv = frame.getIValue(id);
+    if (iv.isTensor()) {
+      const at::Tensor& t = iv.toTensor();
+      // Poison only if this frame slot is the sole owner: no other frame slot
+      // holds the same TensorImpl (use_count==1 -- in-place/aliasing ops like
+      // index_put/masked_put put the same tensor in the result slot too), and
+      // no other tensor references the storage (a view would keep
+      // storage.use_count > 1 while TensorImpl.use_count stays 1). Both must
+      // hold, else a live value still sees this storage.
+      if (t.defined() && t.has_storage() && t.use_count() == 1 &&
+          t.storage().use_count() == 1) {
+        const auto& storage = t.storage();
+        void* ptr = storage.mutable_data();
+        auto nbytes = static_cast<size_t>(storage.nbytes());
+        if (ptr != nullptr && nbytes > 0) {
+          if (t.is_cuda() && stream != nullptr) {
+            // Enqueue the poison on the wave stream: it is ordered after the
+            // kernels that used this buffer and before any later wave op that
+            // reuses it, so it can't race buffer reuse (a default-stream memset
+            // would). A genuine use-after-free on the wave stream still reads
+            // 0xdd; a legitimate reuse overwrites the poison first.
+            stream->memset(ptr, 0xdd, nbytes);
+          } else {
+            std::memset(ptr, 0xdd, nbytes);
+          }
+        }
+      }
+    }
+  }
+  frame.setIValue(id, c10::IValue());
+}
+
+// If a reference frame is loaded, compares the current contents of frame value
+// 'id' against the recorded reference just before it is freed. A mismatch means
+// the value was already corrupted (a stray write, or an aliased premature free
+// of an overlapping buffer) BEFORE this free -- pinpointing which value went
+// bad and at which free point, to compare against its intended last use.
+void checkValueBeforeFree(
+    nativert::ExecutionFrame& frame,
+    nativert::ValueId id) {
+  auto* ref = WaveConfig::get().referenceFrame;
+  if (ref == nullptr) {
+    return;
+  }
+  auto it = ref->find(id);
+  if (it == ref->end() || !it->second.isTensor()) {
+    return;
+  }
+  const auto& iv = frame.getIValue(id);
+  std::optional<at::Tensor> actual = iv.isTensor()
+      ? std::optional<at::Tensor>(iv.toTensor())
+      : scalarLikeToTensor(iv);
+  if (!actual || !actual->defined() || actual->numel() == 0) {
+    return;
+  }
+  const auto& refTensor = it->second.toTensor();
+  if (!tensorsMatch(*actual, refTensor)) {
+    auto limit = WaveConfig::get().tensorPrintElementLimit;
+    LOG(ERROR) << "REF-BEFORE-FREE mismatch value %" << id << "\n  "
+               << firstDifference(*actual, refTensor)
+               << "\n  expected: " << tensorDebugString(refTensor, limit)
+               << "\n  actual:   " << tensorDebugString(*actual, limit);
+  }
+}
+
+void advanceSyncedStages(ExecutionState& state) {
+  // Stage tracking exists only to bundle intermediate freeing with syncs, so
+  // there is nothing to do (and no cost to pay) when freeing is off.
+  if (!WaveConfig::get().freeIntermediates) {
+    return;
+  }
+  auto& frame = *state.frame;
+
+  // In debug_single_ops mode (or when a reference frame is loaded for the
+  // before-free check), sync BOTH the wave stream and the default stream (eager
+  // standalones run there) before freeing, so all kernels that could read a
+  // buffer have finished. Any later access to a freed buffer is then a genuine
+  // use-after-free, the poison memset cannot race an in-flight kernel, and the
+  // before-free reference check reads settled data.
+  if (WaveConfig::get().debugSingleOps ||
+      WaveConfig::get().referenceFrame != nullptr) {
+    if (state.stream != nullptr) {
+      state.stream->wait();
+    }
+    cudaStreamSynchronize(nullptr);
+  }
+
+  // kFrame trace: collect the graph-output value ids (outputNode's inputs), so
+  // the free trace can flag if any of them is ever freed -- they must not be.
+  const bool traceFrame = (WaveConfig::get().trace & WaveConfig::kFrame) != 0;
+  std::unordered_set<nativert::ValueId> graphOutputs;
+  if (traceFrame && state.waveGraph != nullptr) {
+    if (auto* outputNode = state.waveGraph->graph()->outputNode()) {
+      for (const auto& input : outputNode->inputs()) {
+        if (input.value != nullptr) {
+          graphOutputs.insert(input.value->id());
+        }
+      }
+    }
+  }
+  auto traceFree =
+      [&](nativert::ValueId id, const char* kind, size_t seq, size_t step) {
+        if (!traceFrame) {
+          return;
+        }
+        const auto& iv = frame.getIValue(id);
+        int64_t useCount = -1;
+        uintptr_t storagePtr = 0;
+        int64_t storageBytes = 0;
+        if (iv.isTensor() && iv.toTensor().defined() &&
+            iv.toTensor().has_storage()) {
+          const auto& st = iv.toTensor().storage();
+          useCount = st.use_count();
+          storagePtr = reinterpret_cast<uintptr_t>(st.data());
+          storageBytes = static_cast<int64_t>(st.nbytes());
+        }
+        LOG(INFO) << "TWFREE " << kind << " %" << id << " storage=0x"
+                  << std::hex << storagePtr << std::dec
+                  << " size=" << storageBytes << " node=" << seq
+                  << " step=" << step << " use_count=" << useCount
+                  << (graphOutputs.count(id) != 0 ? "  <-- GRAPH OUTPUT" : "");
+      };
+
+  for (size_t seq = 0; seq < state.stepVectors.size(); ++seq) {
+    auto& steps = state.stepVectors[seq];
+    for (size_t step = 0; step < steps.size(); ++step) {
+      auto& sv = steps[step];
+      if (sv.executionStage != ExecutionStage::kAllocated) {
+        continue;
+      }
+      // The wave stream was just waited on, so this step's kernels are done and
+      // its freeable buffers can be released.
+      sv.executionStage = ExecutionStage::kSynced;
+      // The node's last-use tensors were stamped onto its last step; they go
+      // free in this same sync (no dedicated sync of their own).
+      for (auto id : sv.lastUseIds) {
+        traceFree(id, "lastUse", seq, step);
+        checkValueBeforeFree(frame, id);
+        freeFrameValue(frame, id, state.stream.get());
+      }
+    }
+  }
+}
+
+void syncWaveStream(ExecutionState& state) {
+  state.stream->wait();
+  advanceSyncedStages(state);
 }
 
 void WaveGraphExecutor::executeWave(
@@ -765,6 +1005,23 @@ void WaveGraphExecutor::executeWave(
   state.deferredStandalones = &deferredStandalones;
   state.numStandalonesRun = 0;
   state.numShortcutsRun = 0;
+
+  // Reset the allocator's peak so the peak read back after the run reflects
+  // only this run's transient high-water mark.
+  if (WaveConfig::get().trace & WaveConfig::kTiming) {
+    resetPeakAllocatedBytes();
+  }
+
+  // Reset per-step lifecycle stages (step vectors are pooled across runs) so
+  // freeIntermediates freeing only ever fires for this run's steps.
+  if (WaveConfig::get().freeIntermediates) {
+    for (auto& steps : state.stepVectors) {
+      for (auto& sv : steps) {
+        sv.executionStage = ExecutionStage::kNotStarted;
+        sv.lastUseIds.clear();
+      }
+    }
+  }
   for (const auto& node : waveGraph.nodes()) {
     node->execute(state);
   }
@@ -832,7 +1089,7 @@ void WaveGraphExecutor::executeWave(
   // the two are otherwise unordered. Both must complete before executeWave
   // returns so all results this invocation produced are visible to the
   // caller.
-  state.stream->wait();
+  syncWaveStream(state);
   syncTorchDefaultStream();
   auto wallUs = std::chrono::duration_cast<std::chrono::microseconds>(
                     std::chrono::high_resolution_clock::now() - wallStart)
@@ -844,6 +1101,10 @@ void WaveGraphExecutor::executeWave(
     }
     threadInfo.errors = errorString();
     if (WaveConfig::get().trace & WaveConfig::kTiming) {
+      // Peak allocated GPU memory over this run, from the allocator's own
+      // high-water mark (reset at the start of the run above), so it captures
+      // transient intra-step peaks rather than just the per-step samples.
+      threadInfo.peakBytes = peakAllocatedBytes();
       threadInfo.perfReport = makePerfReport(state, wallUs);
     }
     if (WaveConfig::get().throwOnError && !threadInfo.errors.empty()) {
@@ -903,6 +1164,7 @@ void WaveGraphExecutor::collectDebugInfo(ExecutionState& state) {
         meta.noDtoH = sv.noDtoH;
         meta.inputBytes = sv.inputBytes;
         meta.outputBytes = sv.outputBytes;
+        meta.currentBytes = sv.currentBytes;
         meta.refCheckUs = sv.refCheckUs;
       }
     }
@@ -1116,6 +1378,8 @@ std::string WaveGraphExecutor::makePerfReport(
         dataGBs,
         totalDataBytes / 1e6);
   }
+  ss << fmt::format(
+      "Peak GPU RAM: {}\n", facebook::velox::succinctBytes(info.peakBytes));
 
   // Time split across all steps: kernel (GPU), standalone (eager ATen on the
   // default stream), and interpretation (gather + grid + alloc + fill = the
@@ -1238,9 +1502,10 @@ std::string WaveGraphExecutor::makePerfReport(
               state.stepVectors[seq][step].shortcutStandalones.size());
         }
         ss << fmt::format(
-            "  step {}: {} standalones  {} us",
+            "  step {}: {} standalones  GPU RAM={}  {} us",
             m.stepIdx,
             numStandalones,
+            facebook::velox::succinctBytes(m.currentBytes),
             m.standaloneUs);
         ss << standaloneBreakdown(m.sequenceNumber, m.stepIdx) << "\n";
         continue;
@@ -1249,10 +1514,11 @@ std::string WaveGraphExecutor::makePerfReport(
       double bytesTotal = m.inputBytes + m.outputBytes;
       double gbps = m.kernelUs > 0 ? bytesTotal / (m.kernelUs * 1e3) : 0.0;
       ss << fmt::format(
-          "  step {}: {} us  blocks={}  in={:.1f}KB out={:.1f}KB  {:.1f} GB/s",
+          "  step {}: {} us  blocks={}  GPU RAM={}  in={:.1f}KB out={:.1f}KB  {:.1f} GB/s",
           m.stepIdx,
           stepUs,
           m.numBlocks,
+          facebook::velox::succinctBytes(m.currentBytes),
           m.inputBytes / 1024.0,
           m.outputBytes / 1024.0,
           gbps);

--- a/velox/experimental/torchwave/Executor.h
+++ b/velox/experimental/torchwave/Executor.h
@@ -82,6 +82,7 @@ struct LaunchMeta {
   bool noDtoH{false};
   int64_t inputBytes{0};
   int64_t outputBytes{0};
+  int64_t currentBytes{0};
   // Time spent on reference-frame device-to-host copy and comparison for this
   // step (debug-only; excluded from the reported e2e time).
   int64_t refCheckUs{0};
@@ -100,12 +101,29 @@ struct WaveThreadInfo {
   std::vector<std::string> standaloneLabels;
   /// Operator target string for each standalone, parallel to standaloneTimes.
   std::vector<std::string> standaloneTargets;
+  /// Peak torch CUDA caching-allocator allocated bytes reached over the covered
+  /// run, read from the allocator's high-water mark (peak stats are reset at
+  /// the start of the run), so it captures transient intra-step peaks. Filled
+  /// when trace kTiming is on.
+  int64_t peakBytes{0};
   /// Performance report, filled when trace kTiming is on.
   std::string perfReport;
 };
 
 /// Returns the thread-local WaveThreadInfo for the current thread.
 const WaveThreadInfo& waveThreadInfo();
+
+/// Lifecycle of a step's kernel outputs, used to bundle intermediate freeing
+/// with wave-stream syncs (see WaveConfig::freeIntermediates).
+enum class ExecutionStage {
+  /// Reset state at the start of executeWave; nothing allocated yet.
+  kNotStarted,
+  /// The step's kernel op outputs have been allocated (kernels launched).
+  kAllocated,
+  /// A wave-stream wait has completed since kAllocated, so this step's kernels
+  /// are known to be done; its freeable buffers may be released.
+  kSynced,
+};
 
 /// Preallocated vectors reused across executions for a given
 /// (compositeInvocation, stepIdx) pair.  Avoids per-step heap allocation
@@ -179,9 +197,24 @@ struct StepVectors {
   bool noDtoH{false};
   int64_t inputBytes{0};
   int64_t outputBytes{0};
+  // Torch CUDA caching allocator's currently-allocated bytes, sampled right
+  // after this step's kernel and standalones ran (kTiming trace only).
+  int64_t currentBytes{0};
   // Time spent on reference-frame device-to-host copy and comparison for this
   // step (debug-only; excluded from the reported e2e time).
   int64_t refCheckUs{0};
+
+  // Lifecycle stage for bundling frees with wave-stream syncs. Reset to
+  // kNotStarted at the start of executeWave, set to kAllocated once this step's
+  // kernel outputs are allocated, and advanced to kSynced by the first
+  // wave-stream wait thereafter (see advanceSyncedStages).
+  ExecutionStage executionStage{ExecutionStage::kNotStarted};
+
+  // Frame value ids to release when this step reaches kSynced (and
+  // WaveConfig::freeIntermediates is on). Set on a node's last executed step to
+  // that node's ProjectNode::lastUse values, so the node's last-use tensors are
+  // freed by the sync that advances this step to kSynced -- no extra sync.
+  std::vector<nativert::ValueId> lastUseIds;
 };
 
 /// Holds runtime state for executing a WaveGraph.  Pooled by WaveGraph
@@ -242,6 +275,18 @@ struct ExecutionState {
   /// to signal that launch caches are stale.
   uint64_t lastFrameGeneration{0};
 };
+
+/// Advances every step vector currently in kAllocated to kSynced (call right
+/// after a wave-stream wait, when those steps' kernels are known complete).
+/// When WaveConfig::freeIntermediates is on, releases each newly-synced step's
+/// lastUseIds from the frame, bundling that freeing into the sync that just
+/// happened rather than adding a dedicated one.
+void advanceSyncedStages(ExecutionState& state);
+
+/// Waits on the wave stream and then advances synced stages (see
+/// advanceSyncedStages). Used everywhere the wave stream is drained so freeing
+/// is bundled with the wait.
+void syncWaveStream(ExecutionState& state);
 
 /// Executes a single node via its OpKernel with tracing and error logging.
 /// When 'traceState' is non-null, traces the node's input values before the op

--- a/velox/experimental/torchwave/KernelOperation.cpp
+++ b/velox/experimental/torchwave/KernelOperation.cpp
@@ -972,6 +972,9 @@ void mergeOutputDesc(OutputDesc& dst, OutputDesc&& src) {
   if (src.isList) {
     dst.isList = true;
   }
+  if (src.nonRootOutput) {
+    dst.nonRootOutput = true;
+  }
   if (src.byLargestInput) {
     dst.byLargestInput = true;
   }
@@ -1008,6 +1011,10 @@ bool addOrUpdateOutput(
         OutputDesc elemDesc;
         elemDesc.delegated = true;
         elemDesc.shapeSetOnDevice = desc.shapeSetOnDevice;
+        // Propagate nonRootOutput so a list result of a split root op (e.g.
+        // tw.group_length_guard_head) keeps its unpacked elements out of the
+        // freeable intermediates list as well, not just the list value.
+        elemDesc.nonRootOutput = desc.nonRootOutput;
         outputValues.push_back(elem);
         outputDescs.push_back(std::move(elemDesc));
       }
@@ -1025,6 +1032,7 @@ OutputDesc KernelOperation::makeOutputDesc(
   OutputDesc desc;
   desc.shapeSetOnDevice = returnMeta.shapeSetOnDevice;
   desc.neededOnHost = returnMeta.neededOnHost;
+  desc.nonRootOutput = returnMeta.nonRootOutput;
   desc.sizeExpr.op = returnMeta.sizeShortcut;
 
   // Expand sizeArgs ordinals to ValueIds from the node's inputs.
@@ -1060,6 +1068,17 @@ OutputDesc KernelOperation::makeOutputDesc(
   }
 
   return desc;
+}
+
+bool KernelOperation::isMultiUseInput(nativert::ValueId id) const {
+  // Read from the WaveGraph (persists to execution), not compileCtx_, which is
+  // a stack temporary destroyed after compilation. LaunchData calls this while
+  // gathering launches at execution time.
+  return waveGraph_ != nullptr && waveGraph_->isMultiUseInput(id);
+}
+
+bool KernelOperation::isGraphOutput(nativert::ValueId id) const {
+  return waveGraph_ != nullptr && waveGraph_->isGraphOutput(id);
 }
 
 void KernelOperation::setOutputs(

--- a/velox/experimental/torchwave/KernelOperation.h
+++ b/velox/experimental/torchwave/KernelOperation.h
@@ -132,6 +132,14 @@ struct OutputDesc {
   /// can set the output shape by that.
   bool byLargestInput{false};
 
+  /// Propagated from ArgumentMeta::nonRootOutput: this output belongs to a
+  /// non-last part of a split root op and is a real output of the original op,
+  /// so it is excluded from the freeable intermediates list (LaunchData::
+  /// intermediates). Flagged statically at registration, not from downstream
+  /// uses, because a shared ProjectOperation may or may not reference the value
+  /// externally per actual use.
+  bool nonRootOutput{false};
+
   SizeExpr sizeExpr;
 
   bool isList{false};
@@ -229,6 +237,17 @@ class KernelOperation {
   NodeCP expr() const {
     return expr_;
   }
+
+  /// True if the actual value 'id' is fed to more than one part of a multipart
+  /// expansion (WaveGraph::multiUseInputs). Such values are produced in one
+  /// part's kernel op but read by another, so they must not be freed as per-op
+  /// intermediates.
+  bool isMultiUseInput(nativert::ValueId id) const;
+
+  /// True if the actual value 'id' is a graph output (or a list-output
+  /// element), which escapes the graph and must not be freed as a per-op
+  /// intermediate.
+  bool isGraphOutput(nativert::ValueId id) const;
 
   int32_t numInputs() const {
     return numInputs_;

--- a/velox/experimental/torchwave/NodePrinter.cpp
+++ b/velox/experimental/torchwave/NodePrinter.cpp
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 
+#include "velox/experimental/torchwave/Project.h"
 #include "velox/experimental/torchwave/Utils.h"
 #include "velox/experimental/torchwave/WaveGraph.h"
 
@@ -231,6 +232,13 @@ void NodePrinter::printValueRef(std::stringstream& ss, ValueCP value) const {
   }
   if (options_.showTypes && options_.valueTypes) {
     formatTypeAnnotation(ss, value, *options_.valueTypes);
+  }
+  // Mark a reusable last use: the operand is a boundary input of only one expr
+  // in this ProjectNode and never read again (directly or via alias), so its
+  // buffer is free to mutate in place.
+  if (options_.projectNode != nullptr &&
+      options_.projectNode->isReusableInput(value)) {
+    ss << "& ";
   }
   if (options_.useGraphNames && options_.graph) {
     ss << leafValueString(value->name(), *options_.graph);

--- a/velox/experimental/torchwave/NodePrinter.h
+++ b/velox/experimental/torchwave/NodePrinter.h
@@ -26,6 +26,8 @@
 
 namespace torch::wave {
 
+class ProjectNode;
+
 /// Controls formatting, recursion depth, and name style for NodePrinter output.
 struct PrintOptions {
   // --- Value reference format ---
@@ -113,6 +115,11 @@ struct PrintOptions {
 
   /// If set, map formal value IDs to actual value IDs when printing.
   const FormalToActual* formalToActual = nullptr;
+
+  /// If set, operands that are a reusable input of this ProjectNode (a boundary
+  /// input of only one expr, dead after here directly and via alias) are
+  /// prefixed with '&' to flag that the value's buffer is mutable in place.
+  const ProjectNode* projectNode = nullptr;
 };
 
 /// Renders nativert graph nodes as human-readable expression strings.

--- a/velox/experimental/torchwave/ParallelExpr.cpp
+++ b/velox/experimental/torchwave/ParallelExpr.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <functional>
 #include <limits>
 #include <memory>
 #include <ranges>
@@ -28,9 +29,11 @@
 
 #include <fmt/format.h>
 #include <folly/ScopeGuard.h>
+#include <folly/container/F14Map.h>
 
 #include "velox/experimental/torchwave/ParallelExpr.h"
 #include "velox/experimental/torchwave/Utils.h"
+#include "velox/experimental/torchwave/WaveConfig.h"
 
 namespace torch::wave {
 
@@ -451,6 +454,309 @@ ProjectNode* ParallelNodes::makeParallelProject(
   return result;
 }
 
+namespace {
+
+// True if 'v' is a list-typed value. getListElements() asserts on non-list
+// values, so callers must gate on this.
+bool isListValue(ValueCP v) {
+  switch (v->type().kind()) {
+    case nativert::Type::Kind::TensorList:
+    case nativert::Type::Kind::NestedTensorList:
+    case nativert::Type::Kind::OptionalTensorList:
+      return true;
+    default:
+      return false;
+  }
+}
+
+// Distinct boundary input values read by one top-level expr, stopping at the
+// layer boundary (same boundary rule as countBoundaryAccesses).
+void collectExprBoundaryInputs(
+    NodeCP exprRoot,
+    const std::unordered_set<NodeCP>& boundary,
+    std::unordered_set<ValueCP>& inputs) {
+  NodeSet visited;
+  std::vector<NodeCP> stack{exprRoot};
+  while (!stack.empty()) {
+    NodeCP n = stack.back();
+    stack.pop_back();
+    if (!visited.insert(n).second) {
+      continue;
+    }
+    for (const auto& in : n->inputs()) {
+      ValueCP v = in.value;
+      if (v == nullptr) {
+        continue;
+      }
+      NodeCP producer = v->producer();
+      if (producer == nullptr || boundary.count(producer) > 0) {
+        inputs.insert(v);
+      } else {
+        stack.push_back(producer);
+      }
+    }
+  }
+}
+
+// The layer's internal (non-boundary) nodes, in program order. Value ids are
+// assigned in creation order, so the first-output id sorts nodes into program
+// order; the alias analysis below depends on this so consumption is seen after
+// the corresponding production.
+std::vector<NodeCP> layerNodesInOrder(const ProjectNode* pn) {
+  const auto& boundary = pn->inputs();
+  NodeSet visited;
+  std::vector<NodeCP> stack;
+  for (auto* n : pn->nodes()) {
+    if (boundary.count(n) == 0) {
+      stack.push_back(n);
+    }
+  }
+  std::vector<NodeCP> result;
+  while (!stack.empty()) {
+    NodeCP n = stack.back();
+    stack.pop_back();
+    if (!visited.insert(n).second) {
+      continue;
+    }
+    result.push_back(n);
+    for (const auto& in : n->inputs()) {
+      ValueCP v = in.value;
+      if (v == nullptr) {
+        continue;
+      }
+      NodeCP producer = v->producer();
+      if (producer != nullptr && boundary.count(producer) == 0) {
+        stack.push_back(producer);
+      }
+    }
+  }
+  std::sort(result.begin(), result.end(), [](NodeCP a, NodeCP b) {
+    auto idOf = [](NodeCP e) {
+      return e->outputs().empty() ? 0 : e->outputs()[0]->id();
+    };
+    return idOf(a) < idOf(b);
+  });
+  return result;
+}
+
+} // namespace
+
+void ParallelNodes::computeLastUse(const nativert::Graph& graph) {
+  // Values that leave the graph must never be reused or released, so exclude
+  // them from the last-use sets even if no later layer reads them.
+  // Graph outputs (and elements of list-typed outputs) escape the graph and
+  // must never be freed -- nor may any value that shares their storage.
+  std::unordered_set<ValueCP> graphOutputs;
+  if (NodeCP outputNode = graph.outputNode()) {
+    std::function<void(ValueCP)> addOut = [&](ValueCP v) {
+      if (v == nullptr || !graphOutputs.insert(v).second) {
+        return;
+      }
+      if (isListValue(v)) {
+        for (auto* e : v->getListElements()) {
+          addOut(e);
+        }
+      }
+    };
+    for (const auto& output : outputNode->inputs()) {
+      addOut(output.value);
+    }
+  }
+
+  // User inputs, weights, and constants are externally managed frame values
+  // that must persist across runs (the frame is reused; they are refilled, not
+  // reproduced). They must never appear in a freeable list -- even if the
+  // optimized graph gives them a producer node. Exclude them explicitly.
+  std::unordered_set<ValueCP> frameInputs;
+  for (auto* v : graph.userInputs()) {
+    frameInputs.insert(v);
+  }
+  for (auto* v : graph.weightValues()) {
+    frameInputs.insert(v);
+  }
+
+  // Last use of EVERY assigned value -- not just the values returned by a
+  // layer's top-level exprs, but also the intra-layer intermediates of fused
+  // elementwise chains. Those intermediates are never separately allocated, so
+  // listing them as "freeable" costs nothing, but tracking them here (then
+  // extending lifetimes through list membership and storage aliasing below)
+  // frees a shared buffer only after its last reader, and makes the separate
+  // kernel-op intermediate free mechanism unnecessary. A value's raw last use
+  // is the highest project node that directly reads it; id() equals the index
+  // in projectNodes_.
+  std::unordered_map<NodeCP, int32_t> nodeToPn;
+  for (auto& pnPtr : projectNodes_) {
+    for (NodeCP n : layerNodesInOrder(pnPtr.get())) {
+      nodeToPn[n] = pnPtr->id();
+    }
+  }
+  folly::F14FastMap<ValueCP, int32_t> lastNode;
+  for (auto* value : graph.values()) {
+    if (value == nullptr) {
+      continue;
+    }
+    int32_t last = -1;
+    for (auto* user : value->users()) {
+      auto it = nodeToPn.find(user);
+      if (it != nodeToPn.end()) {
+        last = std::max(last, it->second);
+      }
+    }
+    if (last >= 0) {
+      lastNode[value] = last;
+    }
+  }
+
+  // Extend lifetimes through prim.ListPack membership: an element is read
+  // whenever the list containing it is read, so its last use is at least the
+  // list's -- recursively for lists of lists. Iterate to a fixpoint.
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    for (auto* value : graph.values()) {
+      if (value == nullptr || !isListValue(value)) {
+        continue;
+      }
+      auto lit = lastNode.find(value);
+      if (lit == lastNode.end()) {
+        continue;
+      }
+      int32_t listLast = lit->second;
+      for (auto* e : value->getListElements()) {
+        if (e == nullptr) {
+          continue;
+        }
+        auto& el = lastNode[e];
+        if (el < listLast) {
+          el = listLast;
+          changed = true;
+        }
+      }
+    }
+  }
+
+  // Extend lifetimes through storage aliasing: a view and its base share one
+  // buffer, so the buffer lives until the last read of ANY value in the storage
+  // group. Group by viewStorageBase and lift every member to the group's max
+  // last use. If any member is a graph output, the group's storage escapes and
+  // must never be freed.
+  folly::F14FastMap<ValueCP, ValueCP> baseOf;
+  folly::F14FastMap<ValueCP, int32_t> baseLast;
+  std::unordered_set<ValueCP> nonFreeableBase;
+  for (auto* v : graphOutputs) {
+    nonFreeableBase.insert(viewStorageBase(v));
+  }
+  for (const auto& [value, ln] : lastNode) {
+    ValueCP b = viewStorageBase(value);
+    baseOf[value] = b;
+    auto it = baseLast.find(b);
+    if (it == baseLast.end() || it->second < ln) {
+      baseLast[b] = ln;
+    }
+  }
+
+  // Assign each value to its storage group's last-use layer. Leaves -- graph
+  // inputs, weights, constants -- are externally managed and persist across
+  // runs, so they are never freed. A leaf is a value whose producer is not a
+  // graph computation node (it is null, or the graph input/constant node, which
+  // is not in nodeToPn). Leaves still contribute their last read to baseLast
+  // above so that views over them are freed at the right layer.
+  for (const auto& [value, ln] : lastNode) {
+    ValueCP b = baseOf[value];
+    bool isLeaf =
+        value->producer() == nullptr || nodeToPn.count(value->producer()) == 0;
+    if (graphOutputs.count(value) > 0 || nonFreeableBase.count(b) > 0 ||
+        isLeaf || frameInputs.count(value) > 0 || frameInputs.count(b) > 0) {
+      continue;
+    }
+    projectNodes_[baseLast[b]]->lastUse.insert(value);
+  }
+
+  // Distinct boundary inputs of each top-level expr (for the reusable-input
+  // third pass below).
+  std::vector<std::vector<std::unordered_set<ValueCP>>> exprInputs(
+      projectNodes_.size());
+  for (auto& pnPtr : projectNodes_) {
+    ProjectNode* pn = pnPtr.get();
+    auto& perExpr = exprInputs[pn->id()];
+    perExpr.resize(pn->nodes().size());
+    for (size_t i = 0; i < pn->nodes().size(); ++i) {
+      collectExprBoundaryInputs(pn->nodes()[i], pn->inputs(), perExpr[i]);
+    }
+  }
+
+  // Third pass: a (now alias-corrected) lastUse value that is a boundary input
+  // of exactly one top-level expr in its layer can be reused in place by that
+  // expr's kernel op.
+  for (auto& pnPtr : projectNodes_) {
+    ProjectNode* pn = pnPtr.get();
+    const auto& perExpr = exprInputs[pn->id()];
+    pn->reusableValues_.assign(pn->nodes().size(), {});
+    for (ValueCP v : pn->lastUse) {
+      int32_t onlyExpr = -1;
+      int32_t count = 0;
+      for (size_t i = 0; i < perExpr.size(); ++i) {
+        if (perExpr[i].count(v) > 0) {
+          ++count;
+          onlyExpr = static_cast<int32_t>(i);
+          if (count > 1) {
+            break;
+          }
+        }
+      }
+      if (count == 1) {
+        pn->reusableValues_[onlyExpr].push_back(v);
+      }
+    }
+  }
+
+  // Diagnostic (kFrame): validate the (alias-corrected) lastUse against
+  // viewStorageBase ground truth. A value freed in a layer whose storage is
+  // still read by a later layer -- directly or through any storage alias -- is
+  // a premature free. Reports which later use was missed so the alias tracking
+  // can be fixed.
+  if (WaveConfig::get().trace & WaveConfig::kFrame) {
+    auto userMaxNode = [&](ValueCP v) -> int32_t {
+      int32_t m = -1;
+      for (auto* u : v->users()) {
+        auto it = nodeToPn.find(u);
+        if (it != nodeToPn.end()) {
+          m = std::max(m, it->second);
+        }
+      }
+      return m;
+    };
+    // storage base -> latest layer that reads any value sharing that storage.
+    std::unordered_map<ValueCP, int32_t> baseTrueLast;
+    for (auto* v : graph.values()) {
+      if (v == nullptr) {
+        continue;
+      }
+      ValueCP b = viewStorageBase(v);
+      int32_t mu = userMaxNode(v);
+      auto it = baseTrueLast.find(b);
+      if (it == baseTrueLast.end() || it->second < mu) {
+        baseTrueLast[b] = mu;
+      }
+    }
+    for (auto& pnPtr : projectNodes_) {
+      ProjectNode* pn = pnPtr.get();
+      for (ValueCP v : pn->lastUse) {
+        ValueCP b = viewStorageBase(v);
+        auto it = baseTrueLast.find(b);
+        int32_t trueLast = it != baseTrueLast.end() ? it->second : -1;
+        if (trueLast > pn->id()) {
+          LOG(INFO) << "LASTUSE-TOO-EARLY %" << v->id() << " freed at node "
+                    << pn->id() << " but storage base %" << b->id()
+                    << " (producer "
+                    << (b->producer() ? b->producer()->target() : "<none>")
+                    << ") is read through node " << trueLast;
+        }
+      }
+    }
+  }
+}
+
 ProjectNode* ParallelNodes::makeParallelNodes(const nativert::Graph& graph) {
   // Side-effect analysis: extra ordering edges for in-place mutations. Computed
   // from the raw graph (gExtraArgs is still null here), then installed so the
@@ -531,6 +837,10 @@ ProjectNode* ParallelNodes::makeParallelNodes(const nativert::Graph& graph) {
     TORCH_CHECK(false, "makeParallelProject returned null");
   }
   current = project;
+
+  // All layers are now built in execution order; annotate each with its
+  // last-use / reusable-last-use values.
+  computeLastUse(graph);
 
   return current;
 }

--- a/velox/experimental/torchwave/ParallelExpr.h
+++ b/velox/experimental/torchwave/ParallelExpr.h
@@ -41,6 +41,11 @@ class ParallelNodes {
       const NodeSet& topExprs,
       std::vector<NodeCP> orderedExprs = {});
 
+  /// After the graph is split into layers, fills each ProjectNode's lastUse
+  /// (alias-corrected) and reusableValues_ sets by scanning every layer's
+  /// boundary-value accesses and view/list aliases in execution order.
+  void computeLastUse(const nativert::Graph& graph);
+
   std::vector<std::unique_ptr<ProjectNode>> projectNodes_;
   int32_t nextId_{0};
 };

--- a/velox/experimental/torchwave/Project.cpp
+++ b/velox/experimental/torchwave/Project.cpp
@@ -45,6 +45,8 @@ std::string ProjectNode::toString(
   opts.graph = &graph;
   opts.valueTypes = valueTypes;
   opts.showTypes = valueTypes != nullptr;
+  // Drives the '&' annotation on operands that are a reusable last use here.
+  opts.projectNode = this;
   NodePrinter printer(opts);
 
   std::stringstream ss;
@@ -60,6 +62,23 @@ std::string ProjectNode::toString(
       printer.printOutputIds(ss, nodes_[i]);
       ss << " = " << printer.print(nodes_[i]) << "\n";
     }
+  }
+  // Values whose last use is in this node but that are not exclusively consumed
+  // by a single expr: their buffers may be released after the node runs, but
+  // cannot be reused in place by one op (unlike reusableValues_, flagged '&').
+  std::vector<int32_t> releasable;
+  for (auto* value : lastUse) {
+    if (value != nullptr && !isReusableInput(value)) {
+      releasable.push_back(value->id());
+    }
+  }
+  if (!releasable.empty()) {
+    std::sort(releasable.begin(), releasable.end());
+    ss << "  May release ";
+    for (size_t i = 0; i < releasable.size(); ++i) {
+      ss << (i > 0 ? ", " : "") << "%" << releasable[i];
+    }
+    ss << "\n";
   }
   if (input_ != nullptr) {
     ss << fmt::format("  input: ProjectNode {}\n", input_->id());

--- a/velox/experimental/torchwave/Project.h
+++ b/velox/experimental/torchwave/Project.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
 #include <string>
 #include <unordered_map>
@@ -68,6 +69,30 @@ class ProjectNode {
 
   void distinctFunctions(
       std::unordered_map<std::string, int32_t>& counts) const;
+
+  /// Values whose last access across all ProjectNodes happens in this node, so
+  /// their buffers may be released after this node executes. Graph outputs are
+  /// excluded (they escape the graph). Alias-corrected: a value kept alive by a
+  /// view or by membership in a prim.ListPack is not listed until its last
+  /// alias dies. Populated by ParallelNodes::computeLastUse.
+  std::unordered_set<ValueCP> lastUse;
+
+  /// For each top-level expr (parallel to nodes()), the lastUse values that are
+  /// a boundary input of only that expr in this layer. A kernel op for the expr
+  /// may reuse such a value's buffer in place, since nothing else reads it here
+  /// or later (directly or via any alias). Populated by
+  /// ParallelNodes::computeLastUse.
+  std::vector<std::vector<ValueCP>> reusableValues_;
+
+  /// True if 'value' is a reusable input of any expr in this node.
+  bool isReusableInput(ValueCP value) const {
+    for (const auto& perExpr : reusableValues_) {
+      if (std::find(perExpr.begin(), perExpr.end(), value) != perExpr.end()) {
+        return true;
+      }
+    }
+    return false;
+  }
 
  private:
   std::vector<NodeCP> nodes_;

--- a/velox/experimental/torchwave/Registry.h
+++ b/velox/experimental/torchwave/Registry.h
@@ -133,6 +133,18 @@ struct ArgumentMeta {
   /// on device side results from another.
   bool linkOnly{false};
 
+  /// Set for an output produced by a non-last part of a root op that was split
+  /// into several kernel ops (e.g. tw.group_length_guard_head, whose length
+  /// outputs are consumed by tw.group_length_guard_final). Such an output is a
+  /// real output of the original op, so it must never be released as a per-op
+  /// freeable intermediate, even though its producing node is not the kernel
+  /// op's root expr. We flag this statically at registration rather than
+  /// deciding from downstream uses on purpose: a ProjectOperation is
+  /// deduplicated and reused across actual subgraphs, some of which reference
+  /// this value externally and some of which do not, so a use-based decision
+  /// would be wrong for the shared op.
+  bool nonRootOutput{false};
+
   /// Marks that for an elementwise operation, we want the whole tensor as
   /// opposed to its element for this lane.
   bool wholeTensor{false};

--- a/velox/experimental/torchwave/Standalones.cpp
+++ b/velox/experimental/torchwave/Standalones.cpp
@@ -30,7 +30,19 @@ void runStandaloneShortcut(
 
   // Reads operand 'i' as a tensor from the frame.
   auto tensorAt = [&](size_t i) -> at::Tensor {
-    return frame.getIValue(args[i]->id()).toTensor();
+    const auto& iv = frame.getIValue(args[i]->id());
+    TORCH_CHECK(
+        iv.isTensor(),
+        "runStandaloneShortcut: shortcut ",
+        static_cast<int>(data.launch->standaloneShortcut),
+        " operand ",
+        i,
+        " value %",
+        args[i]->id(),
+        " is not a tensor (tag=",
+        static_cast<int>(iv.tag),
+        ")");
+    return iv.toTensor();
   };
   // Reads operand 'i' as an integer: a dynamic value (args[i] set) is read from
   // the frame; a constant comes from intArgs.
@@ -89,7 +101,15 @@ void runStandaloneShortcut(
       c10::List<at::Tensor> list;
       list.reserve(args.size());
       for (auto* value : args) {
-        list.push_back(frame.getIValue(value->id()).toTensor());
+        const auto& iv = frame.getIValue(value->id());
+        TORCH_CHECK(
+            iv.isTensor(),
+            "runStandaloneShortcut: kListPack element %",
+            value->id(),
+            " is not a tensor (tag=",
+            static_cast<int>(iv.tag),
+            ")");
+        list.push_back(iv.toTensor());
       }
       setOutput(c10::IValue(std::move(list)));
       break;

--- a/velox/experimental/torchwave/Utils.cpp
+++ b/velox/experimental/torchwave/Utils.cpp
@@ -939,6 +939,23 @@ void saveTensorList(
   out.write(data.data(), static_cast<std::streamsize>(data.size()));
 }
 
+void saveIValueList(
+    const std::vector<c10::IValue>& values,
+    const std::string& path) {
+  // A tuple (not a typed list) so pickling emits no element type tag: a
+  // heterogeneous List[Any] fails pickleLoadWithTypes, but a tuple unpickles
+  // generically and loadReferenceValues flattens it back to these elements.
+  std::vector<c10::IValue> elems;
+  elems.reserve(values.size());
+  for (const auto& v : values) {
+    elems.push_back(v.isTensor() ? c10::IValue(v.toTensor().cpu()) : v);
+  }
+  auto data = torch::jit::pickle_save(
+      c10::IValue(c10::ivalue::Tuple::create(std::move(elems))));
+  std::ofstream out(path, std::ios::binary);
+  out.write(data.data(), static_cast<std::streamsize>(data.size()));
+}
+
 std::vector<at::Tensor> loadTensorList(const std::string& path) {
   std::ifstream in(path, std::ios::binary | std::ios::ate);
   if (!in.good()) {
@@ -1126,58 +1143,64 @@ bool aliasSetsIntersect(const c10::AliasInfo& a, const c10::AliasInfo& b) {
 }
 } // namespace
 
+ValueCP schemaAliasedInput(NodeCP node, ValueCP output) {
+  // The c10 FunctionSchema tells whether an output aliases (shares storage
+  // with) an input: a view annotates both as the same alias set 'a'
+  // (Tensor(a) self -> Tensor(a)), an in-place op as 'a!' (Tensor(a!) self ->
+  // Tensor(a!)). Return the aliased input value, or nullptr if the output is
+  // fresh (its return has no alias set, or no input shares it).
+  const auto* schema = findFunctionSchema(node->target());
+  if (schema == nullptr) {
+    return nullptr;
+  }
+  const auto& outputs = node->outputs();
+  int32_t outIdx = -1;
+  for (size_t i = 0; i < outputs.size(); ++i) {
+    if (outputs[i] == output) {
+      outIdx = static_cast<int32_t>(i);
+      break;
+    }
+  }
+  if (outIdx < 0 || static_cast<size_t>(outIdx) >= schema->returns().size()) {
+    return nullptr;
+  }
+  const auto* outAlias = schema->returns()[outIdx].alias_info();
+  if (outAlias == nullptr) {
+    return nullptr;
+  }
+  const auto& args = schema->arguments();
+  const auto& inputs = node->inputs();
+  for (size_t j = 0; j < inputs.size() && j < args.size(); ++j) {
+    const auto* inAlias = args[j].alias_info();
+    if (inAlias != nullptr && aliasSetsIntersect(*inAlias, *outAlias)) {
+      return inputs[j].value;
+    }
+  }
+  return nullptr;
+}
+
 ValueCP viewStorageBase(ValueCP value) {
-  // Follow storage-aliasing edges from a value to its base. Two kinds of edge
-  // alias an output to an input: a view (output is a view of input 'viewOfArg')
-  // and an in-place op (the FunctionSchema gives the output and the mutated
-  // self the same alias set, e.g. add_/clamp_ Tensor(a!) -> Tensor(a!)). Both
-  // must be followed so that a, a.view(), and a.add_(...) all resolve to the
-  // same base. Bounded by the graph's acyclicity.
+  // Follow storage-aliasing edges from a value to its base. An output aliases
+  // an input when they share a c10 alias set -- a view (Tensor(a) self ->
+  // Tensor(a)) or an in-place op (Tensor(a!) self -> Tensor(a!)). Prefer the
+  // c10 schema (authoritative), and fall back to the torchwave viewOfArg
+  // metadata for tw.* ops that have no c10 alias annotations. Follow so that a,
+  // a.view(), and a.add_(...) all resolve to the same base; bounded by graph
+  // acyclicity.
   while (value != nullptr) {
     auto* producer = value->producer();
     if (producer == nullptr) {
       break;
     }
-    ValueCP next = nullptr;
+    ValueCP next = schemaAliasedInput(producer, value);
 
-    // 1. torchwave view metadata (static op property, no thread WaveGraph
-    // needed, so this works in GraphTool too).
-    const auto* meta = Registry::metadata(producer->target());
-    if (meta != nullptr && meta->viewOfArg.has_value()) {
-      auto ordinal = *meta->viewOfArg;
-      if (ordinal >= 0 &&
-          static_cast<size_t>(ordinal) < producer->inputs().size()) {
-        next = producer->inputs()[ordinal].value;
-      }
-    }
-
-    // 2. Schema alias: the output 'value' shares an alias set with an input.
     if (next == nullptr) {
-      const auto* schema = findFunctionSchema(producer->target());
-      if (schema != nullptr) {
-        const auto& outputs = producer->outputs();
-        int32_t outIdx = -1;
-        for (size_t i = 0; i < outputs.size(); ++i) {
-          if (outputs[i] == value) {
-            outIdx = static_cast<int32_t>(i);
-            break;
-          }
-        }
-        if (outIdx >= 0 &&
-            static_cast<size_t>(outIdx) < schema->returns().size()) {
-          const auto* outAlias = schema->returns()[outIdx].alias_info();
-          if (outAlias != nullptr) {
-            const auto& args = schema->arguments();
-            const auto& inputs = producer->inputs();
-            for (size_t j = 0; j < inputs.size() && j < args.size(); ++j) {
-              const auto* inAlias = args[j].alias_info();
-              if (inAlias != nullptr &&
-                  aliasSetsIntersect(*inAlias, *outAlias)) {
-                next = inputs[j].value;
-                break;
-              }
-            }
-          }
+      const auto* meta = Registry::metadata(producer->target());
+      if (meta != nullptr && meta->viewOfArg.has_value()) {
+        auto ordinal = *meta->viewOfArg;
+        if (ordinal >= 0 &&
+            static_cast<size_t>(ordinal) < producer->inputs().size()) {
+          next = producer->inputs()[ordinal].value;
         }
       }
     }
@@ -1294,11 +1317,14 @@ void traceFrameValues(
       continue;
     }
     const auto& iv = frame.getIValue(id);
-    if (iv.isNone()) {
-      continue;
-    }
     traceState.markTraced(id);
-    if (iv.isTensor()) {
+    if (iv.isNone()) {
+      // Print a marker rather than skipping: an unset/freed value is exactly
+      // what we want to see when tracing (e.g. a user input read as null on a
+      // second run of a reused frame).
+      std::cout << "  trace " << label << " %" << id << ": <none/unset>"
+                << std::endl;
+    } else if (iv.isTensor()) {
       std::cout << "  trace " << label << " %" << id << ": "
                 << tensorDebugString(iv.toTensor(), maxElements) << std::endl;
     } else {

--- a/velox/experimental/torchwave/Utils.h
+++ b/velox/experimental/torchwave/Utils.h
@@ -362,9 +362,16 @@ std::string standaloneToString(NodeCP node);
 /// 'value'. Falls back to checking for "_." in the target name.
 bool isInPlaceMutation(NodeCP node, ValueCP value);
 
-/// Resolves 'value' to its underlying storage base by following view chains
-/// (the viewOfArg metadata). Views-on-views collapse to the ultimate base; a
-/// value with no view producer is its own base.
+/// If 'output' (an output of 'node') aliases one of 'node's inputs per the c10
+/// FunctionSchema alias sets (a view Tensor(a) or an in-place op Tensor(a!)),
+/// returns that input value; nullptr if the output is fresh or there is no
+/// schema. Authoritative alias source, preferred over the viewOfArg metadata.
+ValueCP schemaAliasedInput(NodeCP node, ValueCP output);
+
+/// Resolves 'value' to its underlying storage base by following alias chains
+/// (c10 schema alias sets, falling back to the viewOfArg metadata). Views-on-
+/// views collapse to the ultimate base; a value with no aliasing producer is
+/// its own base.
 ValueCP viewStorageBase(ValueCP value);
 
 /// Returns the input values that 'node' mutates in place (writes their
@@ -461,6 +468,14 @@ void saveTensorList(
 /// Loads a list of tensors saved by saveTensorList. Returns an empty vector if
 /// the file does not exist.
 std::vector<at::Tensor> loadTensorList(const std::string& path);
+
+/// Saves a full list of output IValues to a .pt file (pickled list),
+/// preserving non-tensor entries (scalars, None) in place. Tensors are moved to
+/// CPU. Unlike saveTensorList (which drops non-tensors), this keeps positions
+/// so the file is loadable as a golden reference via loadReferenceValues.
+void saveIValueList(
+    const std::vector<c10::IValue>& values,
+    const std::string& path);
 
 /// Loads a reference frame from a .pt file into a map keyed by ValueId.
 std::unordered_map<int32_t, c10::IValue> loadReferenceFrame(

--- a/velox/experimental/torchwave/WaveConfig.h
+++ b/velox/experimental/torchwave/WaveConfig.h
@@ -130,6 +130,11 @@ struct WaveConfig {
   // correctness fix); the race harness flips it off for the racy A/B arm.
   bool scanOutputReturnBarrier{true};
 
+  // If true, release the frame tensors of each ProjectNode's last-use values
+  // right after that node's composite invocation executes, instead of keeping
+  // them until the whole graph finishes. Off by default.
+  bool freeIntermediates{false};
+
   /// Not thread-safe. All mutations must happen before concurrent reads.
   FOLLY_EXPORT static WaveConfig& get() {
     static WaveConfig instance;

--- a/velox/experimental/torchwave/WaveGraph.cpp
+++ b/velox/experimental/torchwave/WaveGraph.cpp
@@ -26,6 +26,7 @@
 
 #include <c10/util/StringUtil.h>
 #include <folly/ScopeGuard.h>
+#include <functional>
 #include <sstream>
 
 #include "velox/experimental/wave/common/Cuda.h"
@@ -186,6 +187,35 @@ WaveGraph::WaveGraph(ModelContext* modelContext)
   optimizer_ = std::make_unique<Optimizer>(*this);
   optimizer_->optimizeGraph(graph_);
   createdValueDtypes_.clear();
+
+  // Graph outputs (and, for list-typed outputs, their elements) escape the
+  // graph, so LaunchData must never release them as per-op intermediates.
+  graphOutputIds_.clear();
+  if (auto* outNode = graph_->outputNode()) {
+    std::function<void(ValueCP)> addOut = [&](ValueCP v) {
+      if (v == nullptr || !graphOutputIds_.insert(v->id()).second) {
+        return;
+      }
+      // A graph output that is a view keeps its base's storage live, so protect
+      // the storage base too -- freeing the base as a per-op intermediate would
+      // corrupt the surviving output.
+      if (auto* base = viewStorageBase(v); base != nullptr) {
+        graphOutputIds_.insert(base->id());
+      }
+      auto k = v->type().kind();
+      if (k == nativert::Type::Kind::TensorList ||
+          k == nativert::Type::Kind::NestedTensorList ||
+          k == nativert::Type::Kind::OptionalTensorList) {
+        for (auto* e : v->getListElements()) {
+          addOut(e);
+        }
+      }
+    };
+    for (const auto& in : outNode->inputs()) {
+      addOut(in.value);
+    }
+  }
+
   ParallelNodes parallelNodes;
   auto* lastProjectNode = parallelNodes.makeParallelNodes(*graph_);
 
@@ -427,6 +457,16 @@ nativert::Value* WaveGraph::newListValue(
 
 bool WaveGraph::isCreatedValue(ValueCP value) const {
   return createdValueDtypes_.count(value->id()) > 0;
+}
+
+void WaveGraph::declareMultiplyReferencedInput(const nativert::Value* value) {
+  if (value != nullptr) {
+    multiUseInputs_.insert(value->id());
+    if (WaveConfig::get().trace & WaveConfig::kFrame) {
+      LOG(INFO) << "declareMultiplyReferencedInput %" << value->id() << " ("
+                << value->name() << ")";
+    }
+  }
 }
 
 nativert::Value* WaveGraph::duplicateValue(ValueCP original) {

--- a/velox/experimental/torchwave/WaveGraph.h
+++ b/velox/experimental/torchwave/WaveGraph.h
@@ -292,6 +292,25 @@ class WaveGraph {
     return compileCtx_;
   }
 
+  /// Records that 'value' is consumed by more than one part of a multipart op
+  /// expansion (e.g. the shared input of cumsum_head and cumsum_final), so it
+  /// must not be released as a per-op freeable intermediate. Called by the
+  /// split / variant lowerings while generating the parts. The set lives here
+  /// (not on the transient CompileCtx) because it is consulted at execution
+  /// time, when LaunchData decides which kernel outputs are freeable.
+  void declareMultiplyReferencedInput(const nativert::Value* value);
+
+  bool isMultiUseInput(nativert::ValueId id) const {
+    return multiUseInputs_.count(id) != 0;
+  }
+
+  /// True if 'id' is a graph output value (or an element of a list-typed graph
+  /// output). Such values escape the graph and must never be released as a
+  /// per-op freeable intermediate.
+  bool isGraphOutput(nativert::ValueId id) const {
+    return graphOutputIds_.count(id) != 0;
+  }
+
   /// Returns the ModelContext, or nullptr if none was provided.
   ModelContext* modelContext() const {
     return modelContext_;
@@ -378,6 +397,16 @@ class WaveGraph {
 
   // Set during construction, cleared after.
   CompileCtx* compileCtx_{nullptr};
+
+  // Values consumed by more than one part of a multipart op expansion; they
+  // must never be freed as per-op intermediates. Populated at compile time via
+  // declareMultiplyReferencedInput, read at execution time by LaunchData.
+  std::unordered_set<nativert::ValueId> multiUseInputs_;
+
+  // Graph output value ids (plus elements of list-typed outputs). Escaping
+  // values that must never be freed as per-op intermediates. Populated at the
+  // start of compile, read at execution time by LaunchData.
+  std::unordered_set<nativert::ValueId> graphOutputIds_;
 
   // Alive during construction only. Retains visited set so multikernel
   // variant nodes reuse the main-graph pass.

--- a/velox/experimental/torchwave/tests/ExecutorTestBase.cpp
+++ b/velox/experimental/torchwave/tests/ExecutorTestBase.cpp
@@ -148,6 +148,10 @@ DEFINE_bool(
     enable_reuse,
     false,
     "Reuse a value's buffer in place when an op is its unique last use (turn copying ops into in-place ops)");
+DEFINE_bool(
+    free_intermediates,
+    false,
+    "Release each ProjectNode's last-use value tensors right after its composite invocation executes, instead of at end-of-graph");
 
 namespace torch::wave {
 
@@ -644,6 +648,7 @@ void ExecutorTestBase::SetUpTestSuite() {
   WaveConfig::get().debugSingleOps = FLAGS_debug_single_ops;
   WaveConfig::get().autoAdjustCost = FLAGS_auto_adjust_cost;
   WaveConfig::get().enableReuse = FLAGS_enable_reuse;
+  WaveConfig::get().freeIntermediates = FLAGS_free_intermediates;
   if (!FLAGS_print_options.empty()) {
     NodePrinter::setDefaults(
         NodePrinter::parsePrintOptions(FLAGS_print_options));
@@ -695,12 +700,18 @@ std::vector<c10::IValue> ExecutorTestBase::executeSerialWithTrace(
       if (output) {
         // Capture a deep copy of each output the instant its node ran, so a
         // later in-place overwrite of its storage cannot corrupt the reference.
-        // Skip scratch self-args of index_put (see inPlaceSelfIds above).
+        // Copy straight to CPU: on a GPU nativert run this keeps the whole
+        // reference frame off the GPU, so capturing every intermediate does not
+        // exhaust GPU memory (a full-graph frame at large batch otherwise
+        // OOMs). copy=true forces a fresh tensor even when the value is already
+        // on CPU. Skip scratch self-args of index_put (see inPlaceSelfIds
+        // above).
         if (!FLAGS_save_reference_frame.empty() &&
             !inPlaceSelfIds.count(output->id())) {
           const auto& iv = frame.getIValue(output->id());
           if (iv.isTensor() && iv.toTensor().numel() > 0) {
-            capturedRefOutputs_[output->id()] = iv.toTensor().detach().clone();
+            capturedRefOutputs_[output->id()] = iv.toTensor().detach().to(
+                at::kCPU, /*non_blocking=*/false, /*copy=*/true);
           }
         }
         std::vector<nativert::ValueId> ids = {output->id()};
@@ -777,7 +788,10 @@ RunTiming ExecutorTestBase::runSerial(
             << " non-none slots of " << graph.numValues();
 
   if (!FLAGS_save_reference_frame.empty()) {
-    saveReferenceFrame(*frame, graph, FLAGS_save_reference_frame);
+    // Prefer the per-node CPU copies (capturedRefOutputs_) over the live frame,
+    // so a GPU serial run never has to hold every intermediate on the device.
+    saveReferenceFrame(
+        *frame, graph, capturedRefOutputs_, FLAGS_save_reference_frame);
     LOG(INFO) << "Saved reference frame to " << FLAGS_save_reference_frame;
   }
 


### PR DESCRIPTION
Summary:

With `--free_intermediates` (off by default via `WaveConfig::freeIntermediates`), wave releases a tensor's frame slot as soon as the last ProjectNode layer that reads it has executed, instead of holding every intermediate until the whole graph finishes. A large sparse intermediate produced early in the ROO preproc graph is freed right after its last reader, lowering the transient GPU high-water mark of a run.

Lifetime tracking lives in `ParallelNodes::computeLastUse`. It assigns every value -- including the intra-layer intermediates of fused elementwise chains -- to the highest layer that reads it. Two extensions make that assignment safe to free on. A `prim.ListPack` element is read whenever its list is read, so its lifetime is lifted to the list's. A view and its base share one buffer, so all values in a storage group (found via `viewStorageBase`) are lifted to the group's last reader. Values that leave the graph are excluded and never freed: graph outputs, every value sharing a graph output's storage, and the externally-managed frame values (user inputs, weights, constants) that persist across runs.

Releasing is bundled into syncs that already occur, so freeing adds no dedicated synchronization. Each step advances `kNotStarted` -> `kAllocated` -> `kSynced`. A wave-stream wait drives `advanceSyncedStages`, which releases every newly-synced step's freeable buffers. A node's last-use tensors are stamped onto its last executed step, so they are released in that same sync.

Differential Revision: D110704400


