### PR TITLE
feat(selective): Wire nimble_compact_dictionary_across_chunks session property

### DIFF
--- a/velox/connectors/hive/FileConfig.h
+++ b/velox/connectors/hive/FileConfig.h
@@ -117,6 +117,16 @@ class FileConfig {
       "Preserve dictionary encoding for Nimble string column reads.")
 
   VELOX_HIVE_CONFIG_LEGACY(
+      kNimbleCompactDictionaryAcrossChunksSession,
+      kNimbleCompactDictionaryAcrossChunks,
+      nimbleCompactDictionaryAcrossChunks,
+      "nimble_compact_dictionary_across_chunks",
+      "nimble.compact-dictionary-across-chunks",
+      bool,
+      false,
+      "Deduplicate dictionary entries when merging alphabets across chunks.")
+
+  VELOX_HIVE_CONFIG_LEGACY(
       kNimbleLazyColumnIoSession,
       kNimbleLazyColumnIo,
       nimbleLazyColumnIo,

--- a/velox/connectors/hive/FileSplitReader.cpp
+++ b/velox/connectors/hive/FileSplitReader.cpp
@@ -383,6 +383,9 @@ void FileSplitReader::createRowReader(
   baseRowReaderOpts_.setNimblePreserveDictionaryEncoding(
       fileConfig_->nimblePreserveDictionaryEncoding(
           connectorQueryCtx_->sessionProperties()));
+  baseRowReaderOpts_.setNimbleCompactDictionaryAcrossChunks(
+      fileConfig_->nimbleCompactDictionaryAcrossChunks(
+          connectorQueryCtx_->sessionProperties()));
   baseRowReaderOpts_.setTrackRowSize(
       rowSizeTrackingEnabled.has_value()
           ? *rowSizeTrackingEnabled

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -567,6 +567,14 @@ class RowReaderOptions {
     nimblePreserveDictionaryEncoding_ = value;
   }
 
+  bool nimbleCompactDictionaryAcrossChunks() const {
+    return nimbleCompactDictionaryAcrossChunks_;
+  }
+
+  void setNimbleCompactDictionaryAcrossChunks(bool value) {
+    nimbleCompactDictionaryAcrossChunks_ = value;
+  }
+
   bool lazyColumnIo() const {
     return lazyColumnIo_;
   }
@@ -665,6 +673,9 @@ class RowReaderOptions {
   // Controls whether dictionary-encoded Nimble string columns return
   // DictionaryVector instead of FlatVector.
   bool nimblePreserveDictionaryEncoding_{false};
+  // Deduplicates dictionary entries when merging alphabets across chunks,
+  // reducing DictionaryVector memory at the cost of a dedup map lookup.
+  bool nimbleCompactDictionaryAcrossChunks_{false};
   // Defers I/O for projected columns without pushdown or remaining filters.
   bool lazyColumnIo_{false};
   folly::F14FastSet<std::string> remainingFilterColumns_;


### PR DESCRIPTION
Summary:
Add the `nimble_compact_dictionary_across_chunks` / `nimble.compact-dictionary-across-chunks` session property and its `RowReaderOptions` plumbing, so cross-chunk dictionary deduplication in the Nimble selective reader can be toggled per query (default off).

This diff is the plumbing layer: `FileConfig.h` registers the session property, `FileSplitReader.cpp` reads it from the session and calls `RowReaderOptions::setNimbleCompactDictionaryAcrossChunks`, and `Options.h` defines the `RowReaderOptions` getter/setter/member.

The read-path logic that consumes the option (deduplicating merged dictionary alphabets in `StringColumnReader`) lands in the child D101228445.

Differential Revision: D110593187


