### PR TITLE
feat(exec): Add operator-scoped registry to OperatorCtx

### DIFF
--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -46,6 +46,10 @@ memory::MemoryPool* OperatorCtx::customPool(std::string_view tag) const {
   return it == customPools_.end() ? nullptr : it->second;
 }
 
+core::QueryCtx* OperatorCtx::queryCtx() const {
+  return driverCtx_->task->queryCtx().get();
+}
+
 core::ExecCtx* OperatorCtx::execCtx() const {
   if (!execCtx_) {
     execCtx_ = std::make_unique<core::ExecCtx>(

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -16,7 +16,9 @@
 #pragma once
 
 #include <folly/Synchronized.h>
+#include <folly/container/F14Map.h>
 #include <string_view>
+#include <typeindex>
 #include <unordered_map>
 #include "velox/core/PlanNode.h"
 #include "velox/core/QueryCtx.h"
@@ -70,6 +72,58 @@ class OperatorCtx {
   /// 'tag', or nullptr if no such custom root is registered on this query.
   velox::memory::MemoryPool* customPool(std::string_view tag) const;
 
+  /// Stores a per-operator registry override, shadowing any query-level entry
+  /// under the same key. Each subsystem defines its own key; the value is
+  /// stored type-erased and callers must use the same type T for setRegistry
+  /// and registry with the same key. Returns true if the key was newly
+  /// inserted. Throws if the key already exists unless 'overwrite' is true, in
+  /// which case the existing entry is replaced and false is returned. Intended
+  /// to be called before the driver starts running, e.g. by a DriverAdapter on
+  /// a replacement operator.
+  template <typename T>
+  bool setRegistry(
+      std::string_view key,
+      std::shared_ptr<T> registry,
+      bool overwrite = false) {
+    return registries_.withWLock([&](auto& map) {
+      auto it = map.find(std::string(key));
+      if (it != map.end()) {
+        VELOX_CHECK(overwrite, "Registry already set: {}", key);
+        it->second = {std::move(registry), std::type_index(typeid(T))};
+        return false;
+      }
+      map.emplace(
+          std::string(key),
+          RegistryEntry{std::move(registry), std::type_index(typeid(T))});
+      return true;
+    });
+  }
+
+  /// Retrieves a registry entry, checking the operator scope first and falling
+  /// through to the query scope. Returns nullptr if neither scope has an entry
+  /// for 'key'. Asserts that the stored type matches T.
+  template <typename T>
+  std::shared_ptr<T> registry(std::string_view key) const {
+    auto local =
+        registries_.withRLock([&](const auto& map) -> std::shared_ptr<T> {
+          auto it = map.find(std::string(key));
+          if (it == map.end()) {
+            return nullptr;
+          }
+          VELOX_CHECK(
+              it->second.type == std::type_index(typeid(T)),
+              "Registry type mismatch for key '{}': expected {}, got {}",
+              key,
+              typeid(T).name(),
+              it->second.type.name());
+          return std::static_pointer_cast<T>(it->second.ptr);
+        });
+    if (local) {
+      return local;
+    }
+    return queryCtx()->registry<T>(key);
+  }
+
   const core::PlanNodeId& planNodeId() const {
     return planNodeId_;
   }
@@ -101,6 +155,11 @@ class OperatorCtx {
       const common::SpillConfig* spillConfig = nullptr) const;
 
  private:
+  // Returns the query context of the task running this operator. Defined
+  // out-of-line because Task is incomplete in this header; used by registry()
+  // to fall through to the query-level registries.
+  core::QueryCtx* queryCtx() const;
+
   DriverCtx* const driverCtx_;
   const core::PlanNodeId planNodeId_;
   int32_t operatorId_;
@@ -111,6 +170,17 @@ class OperatorCtx {
   // custom root pool. Empty when no custom pools are registered.
   const std::unordered_map<std::string, velox::memory::MemoryPool*>
       customPools_;
+
+  // Type-erased registry entry for per-operator overrides.
+  struct RegistryEntry {
+    std::shared_ptr<void> ptr;
+    std::type_index type;
+  };
+
+  // Per-operator registry overrides keyed by subsystem name. Checked before
+  // falling through to the query-level registries on QueryCtx.
+  folly::Synchronized<folly::F14FastMap<std::string, RegistryEntry>>
+      registries_;
 
   // These members are created on demand.
   mutable std::unique_ptr<core::ExecCtx> execCtx_;
@@ -392,6 +462,25 @@ class Operator : public BaseRuntimeStatWriter {
   /// 'tag', or nullptr if no such custom root is registered.
   velox::memory::MemoryPool* customPool(std::string_view tag) const {
     return operatorCtx_->customPool(tag);
+  }
+
+  /// Stores a per-operator registry override on this operator's context. May
+  /// be called by a DriverAdapter on a replacement operator before execution
+  /// starts. See OperatorCtx::setRegistry.
+  template <typename T>
+  bool setRegistry(
+      std::string_view key,
+      std::shared_ptr<T> registry,
+      bool overwrite = false) {
+    return operatorCtx_->setRegistry<T>(key, std::move(registry), overwrite);
+  }
+
+  /// Retrieves a registry entry visible to this operator, checking the
+  /// operator scope first and falling through to the query scope. See
+  /// OperatorCtx::registry.
+  template <typename T>
+  std::shared_ptr<T> registry(std::string_view key) const {
+    return operatorCtx_->registry<T>(key);
   }
 
   /// Returns true if the operator is reclaimable. Currently, we only support

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -454,6 +454,15 @@ add_test(
 
 target_link_libraries(velox_driver_test velox_exec velox_exec_test_lib GTest::gtest)
 
+add_executable(velox_operator_registry_test OperatorRegistryTest.cpp Main.cpp)
+add_test(
+  NAME velox_operator_registry_test
+  COMMAND velox_operator_registry_test
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_link_libraries(velox_operator_registry_test velox_exec velox_exec_test_lib GTest::gtest)
+
 add_executable(velox_adaptive_prefetch_test AdaptivePrefetchTest.cpp)
 add_test(
   NAME velox_adaptive_prefetch_test

--- a/velox/exec/tests/OperatorRegistryTest.cpp
+++ b/velox/exec/tests/OperatorRegistryTest.cpp
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include <gtest/gtest.h>
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/exec/Driver.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+namespace facebook::velox::exec::test {
+namespace {
+
+// Stand-in registry value; the operator-scoped registry stores arbitrary
+// types keyed by subsystem name.
+struct TierConfig {
+  std::string name;
+};
+
+constexpr std::string_view kTestKey{"testKey"};
+
+// Observational DriverAdapter: runs the test-provided hook against the driver
+// during adaptation and does not replace any operators.
+using DriverHook = std::function<void(exec::Driver&)>;
+DriverHook* gDriverHook{nullptr};
+
+bool testAdapter(const exec::DriverFactory& /*factory*/, exec::Driver& driver) {
+  if (gDriverHook != nullptr && *gDriverHook) {
+    (*gDriverHook)(driver);
+  }
+  return false;
+}
+
+class OperatorRegistryTest : public OperatorTestBase {
+ protected:
+  void SetUp() override {
+    OperatorTestBase::SetUp();
+    savedAdapters_ = DriverFactory::adapters;
+    DriverFactory::adapters.clear();
+    DriverFactory::registerAdapter(
+        exec::DriverAdapter{"operatorRegistryTest", {}, testAdapter});
+  }
+
+  void TearDown() override {
+    DriverFactory::adapters = savedAdapters_;
+    gDriverHook = nullptr;
+    OperatorTestBase::TearDown();
+  }
+
+  // Runs a two-operator (Values -> FilterProject) single-driver plan with
+  // 'hook' installed as the adapter body and 'ctx' as the query context.
+  void run(DriverHook hook, const std::shared_ptr<core::QueryCtx>& ctx) {
+    gDriverHook = &hook;
+    auto data = makeRowVector(
+        {makeFlatVector<int32_t>(10, [](auto row) { return row; })});
+    auto plan = PlanBuilder().values({data}).filter("c0 >= 0").planNode();
+    AssertQueryBuilder(plan).queryCtx(ctx).maxDrivers(1).copyResults(pool());
+    gDriverHook = nullptr;
+  }
+
+  std::shared_ptr<core::QueryCtx> makeQueryCtx() {
+    return core::QueryCtx::create(driverExecutor_.get());
+  }
+
+  std::vector<DriverAdapter> savedAdapters_;
+};
+
+TEST_F(OperatorRegistryTest, queryLevelEntryVisibleToOperator) {
+  auto ctx = makeQueryCtx();
+  auto queryValue = std::make_shared<TierConfig>(TierConfig{"query"});
+  ctx->setRegistry<TierConfig>(kTestKey, queryValue);
+
+  std::shared_ptr<TierConfig> seen;
+  run(
+      [&](exec::Driver& driver) {
+        auto operators = driver.operators();
+        ASSERT_GE(operators.size(), 1);
+        seen = operators[0]->registry<TierConfig>(kTestKey);
+      },
+      ctx);
+
+  EXPECT_EQ(seen, queryValue);
+}
+
+TEST_F(OperatorRegistryTest, operatorLevelOverrideShadowsQueryLevel) {
+  auto ctx = makeQueryCtx();
+  auto queryValue = std::make_shared<TierConfig>(TierConfig{"query"});
+  ctx->setRegistry<TierConfig>(kTestKey, queryValue);
+  auto operatorValue = std::make_shared<TierConfig>(TierConfig{"operator"});
+
+  std::shared_ptr<TierConfig> overridden;
+  std::shared_ptr<TierConfig> sibling;
+  run(
+      [&](exec::Driver& driver) {
+        auto operators = driver.operators();
+        ASSERT_GE(operators.size(), 2);
+        operators[0]->setRegistry<TierConfig>(kTestKey, operatorValue);
+        overridden = operators[0]->registry<TierConfig>(kTestKey);
+        sibling = operators[1]->registry<TierConfig>(kTestKey);
+      },
+      ctx);
+
+  EXPECT_EQ(overridden, operatorValue);
+  EXPECT_EQ(sibling, queryValue);
+}
+
+TEST_F(OperatorRegistryTest, missingEntryReturnsNullptr) {
+  auto ctx = makeQueryCtx();
+
+  std::shared_ptr<TierConfig> seen{std::make_shared<TierConfig>()};
+  run(
+      [&](exec::Driver& driver) {
+        auto operators = driver.operators();
+        ASSERT_GE(operators.size(), 1);
+        seen = operators[0]->registry<TierConfig>(kTestKey);
+      },
+      ctx);
+
+  EXPECT_EQ(seen, nullptr);
+}
+
+TEST_F(OperatorRegistryTest, typeMismatchOnFallThroughThrows) {
+  auto ctx = makeQueryCtx();
+  ctx->setRegistry<std::string>(
+      kTestKey, std::make_shared<std::string>("value"));
+
+  std::string error;
+  run(
+      [&](exec::Driver& driver) {
+        auto operators = driver.operators();
+        ASSERT_GE(operators.size(), 1);
+        try {
+          operators[0]->registry<TierConfig>(kTestKey);
+        } catch (const VeloxException& e) {
+          error = e.message();
+        }
+      },
+      ctx);
+
+  EXPECT_NE(
+      error.find("Registry type mismatch for key 'testKey'"),
+      std::string::npos);
+}
+
+TEST_F(OperatorRegistryTest, operatorScopeDuplicateThrowsUnlessOverwrite) {
+  auto ctx = makeQueryCtx();
+  auto first = std::make_shared<TierConfig>(TierConfig{"first"});
+  auto second = std::make_shared<TierConfig>(TierConfig{"second"});
+
+  std::string error;
+  std::shared_ptr<TierConfig> afterOverwrite;
+  run(
+      [&](exec::Driver& driver) {
+        auto operators = driver.operators();
+        ASSERT_GE(operators.size(), 1);
+        operators[0]->setRegistry<TierConfig>(kTestKey, first);
+        try {
+          operators[0]->setRegistry<TierConfig>(kTestKey, second);
+        } catch (const VeloxException& e) {
+          error = e.message();
+        }
+        operators[0]->setRegistry<TierConfig>(
+            kTestKey, second, /*overwrite=*/true);
+        afterOverwrite = operators[0]->registry<TierConfig>(kTestKey);
+      },
+      ctx);
+
+  EXPECT_NE(error.find("Registry already set: testKey"), std::string::npos);
+  EXPECT_EQ(afterOverwrite, second);
+}
+
+} // namespace
+} // namespace facebook::velox::exec::test


### PR DESCRIPTION
Implements the first half of the MemoryTier proposal (#18040).

Extensions that replace operators through a DriverAdapter need per-operator configuration that can differ from the query-wide setting, but OperatorCtx had no place to store it. This PR adds the ScopedRegistry introduced in QueryCtx to OperatorCtx as well. A lookup checks the operator scope first and falls through to the query scope, and so on.