### PR TITLE
feat(memory): Add MemoryTier hierarchy value class

### DIFF
--- a/velox/common/memory/CMakeLists.txt
+++ b/velox/common/memory/CMakeLists.txt
@@ -29,6 +29,7 @@ velox_add_library(
   MemoryAllocator.cpp
   MemoryArbitrator.cpp
   MemoryPool.cpp
+  MemoryTier.cpp
   MmapAllocator.cpp
   MmapArena.cpp
   RawVector.cpp
@@ -48,6 +49,7 @@ velox_add_library(
   MemoryAllocator.h
   MemoryArbitrator.h
   MemoryPool.h
+  MemoryTier.h
   MmapAllocator.h
   MmapArena.h
   RawVector.h

--- a/velox/common/memory/MemoryTier.cpp
+++ b/velox/common/memory/MemoryTier.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/memory/MemoryTier.h"
+
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+#include <folly/container/F14Set.h>
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::memory {
+
+MemoryTier::MemoryTier(std::vector<std::vector<std::string>> tiers)
+    : tiers_{std::move(tiers)} {
+  VELOX_CHECK(!tiers_.empty(), "MemoryTier requires at least one tier");
+  folly::F14FastSet<std::string_view> seen;
+  for (const auto& level : tiers_) {
+    VELOX_CHECK(!level.empty(), "MemoryTier level must have at least one tag");
+    for (const auto& tag : level) {
+      VELOX_CHECK(!tag.empty(), "MemoryTier tag must not be empty");
+      VELOX_CHECK(
+          seen.insert(tag).second, "Duplicate tag in MemoryTier: {}", tag);
+    }
+  }
+}
+
+const std::vector<std::string>& MemoryTier::tierAt(size_t level) const {
+  VELOX_CHECK_LT(level, tiers_.size(), "MemoryTier level out of range");
+  return tiers_[level];
+}
+
+std::optional<size_t> MemoryTier::levelOf(std::string_view tag) const {
+  for (size_t level = 0; level < tiers_.size(); ++level) {
+    for (const auto& candidate : tiers_[level]) {
+      if (candidate == tag) {
+        return level;
+      }
+    }
+  }
+  return std::nullopt;
+}
+
+std::string MemoryTier::toString() const {
+  std::vector<std::string> levels;
+  levels.reserve(tiers_.size());
+  for (const auto& level : tiers_) {
+    levels.push_back(fmt::format("[{}]", fmt::join(level, ", ")));
+  }
+  return fmt::format("MemoryTier[{}]", fmt::join(levels, ", "));
+}
+
+} // namespace facebook::velox::memory

--- a/velox/common/memory/MemoryTier.h
+++ b/velox/common/memory/MemoryTier.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace facebook::velox::memory {
+
+/// Key under which a MemoryTier is stored on QueryCtx or OperatorCtx via
+/// setRegistry / registry. Operators use this key to look up the effective
+/// memory-tier hierarchy when choosing a relocation target.
+inline constexpr std::string_view kMemoryTierKey{"memoryTier"};
+
+/// Immutable description of a memory-tier hierarchy. Each level lists the
+/// resource tags considered equivalent at that tier, ordered from fastest
+/// (level 0) to slowest, and within a level from most to least preferred.
+/// Tags name custom memory resources (see CustomMemoryResource) or the default
+/// pool. For a GPU setup, level 0 might be {"rmm"}, level 1 {"pinnedHost"}, and
+/// level 2 {"cxl", "dram"}.
+///
+/// Tags are not validated against any resource registry; a tag with no
+/// registered resource never resolves to a pool during relocation lookup.
+class MemoryTier {
+ public:
+  /// Creates a hierarchy where tiers[level] lists the tags at that level in
+  /// preference order. Throws if 'tiers' is empty, any level is empty, any tag
+  /// is empty, or a tag appears more than once across the hierarchy.
+  explicit MemoryTier(std::vector<std::vector<std::string>> tiers);
+
+  /// Returns the number of tier levels.
+  size_t numTiers() const {
+    return tiers_.size();
+  }
+
+  /// Returns the tags at 'level' in preference order. Throws if 'level' is not
+  /// less than numTiers().
+  const std::vector<std::string>& tierAt(size_t level) const;
+
+  /// Returns the level containing 'tag', or std::nullopt if 'tag' is not part
+  /// of this hierarchy.
+  std::optional<size_t> levelOf(std::string_view tag) const;
+
+  /// Returns a human-readable representation, e.g.
+  /// "MemoryTier[[rmm], [pinnedHost], [cxl, dram]]".
+  std::string toString() const;
+
+ private:
+  const std::vector<std::vector<std::string>> tiers_;
+};
+
+} // namespace facebook::velox::memory

--- a/velox/common/memory/MemoryTier.h
+++ b/velox/common/memory/MemoryTier.h
@@ -23,20 +23,18 @@
 
 namespace facebook::velox::memory {
 
-/// Key under which a MemoryTier is stored on QueryCtx or OperatorCtx via
-/// setRegistry / registry. Operators use this key to look up the effective
-/// memory-tier hierarchy when choosing a relocation target.
+/// Key under which a MemoryTier is stored in the query registry via
+/// setRegistry / registry.
 inline constexpr std::string_view kMemoryTierKey{"memoryTier"};
 
 /// Immutable description of a memory-tier hierarchy. Each level lists the
 /// resource tags considered equivalent at that tier, ordered from fastest
 /// (level 0) to slowest, and within a level from most to least preferred.
-/// Tags name custom memory resources (see CustomMemoryResource) or the default
-/// pool. For a GPU setup, level 0 might be {"rmm"}, level 1 {"pinnedHost"}, and
-/// level 2 {"cxl", "dram"}.
+/// Tags name custom memory resources (see CustomMemoryResource). For a GPU
+/// setup, level 0 might be {"rmm"}, level 1 {"pinnedHost"}, and level 2
+/// {"cxl", "dram"}.
 ///
-/// Tags are not validated against any resource registry; a tag with no
-/// registered resource never resolves to a pool during relocation lookup.
+/// Tags are not validated against any resource registry.
 class MemoryTier {
  public:
   /// Creates a hierarchy where tiers[level] lists the tags at that level in

--- a/velox/common/memory/tests/CMakeLists.txt
+++ b/velox/common/memory/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(
   MemoryCapExceededTest.cpp
   MemoryManagerTest.cpp
   MemoryPoolTest.cpp
+  MemoryTierTest.cpp
   MockSharedArbitratorTest.cpp
   RawVectorTest.cpp
   ScratchTest.cpp

--- a/velox/common/memory/tests/MemoryTierTest.cpp
+++ b/velox/common/memory/tests/MemoryTierTest.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/memory/MemoryTier.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/base/tests/GTestUtils.h"
+
+namespace facebook::velox::memory {
+namespace {
+
+using ::testing::ElementsAre;
+
+TEST(MemoryTierTest, accessors) {
+  MemoryTier tier({{"rmm"}, {"pinnedHost"}, {"cxl", "dram"}});
+  EXPECT_EQ(tier.numTiers(), 3);
+  EXPECT_THAT(tier.tierAt(0), ElementsAre("rmm"));
+  EXPECT_THAT(tier.tierAt(1), ElementsAre("pinnedHost"));
+  EXPECT_THAT(tier.tierAt(2), ElementsAre("cxl", "dram"));
+}
+
+TEST(MemoryTierTest, tierAtOutOfRangeThrows) {
+  MemoryTier tier({{"rmm"}, {"dram"}});
+  VELOX_ASSERT_THROW(tier.tierAt(2), "MemoryTier level out of range");
+}
+
+TEST(MemoryTierTest, emptyHierarchyThrows) {
+  VELOX_ASSERT_THROW(MemoryTier({}), "MemoryTier requires at least one tier");
+}
+
+TEST(MemoryTierTest, emptyLevelThrows) {
+  VELOX_ASSERT_THROW(
+      MemoryTier({{"rmm"}, {}}), "MemoryTier level must have at least one tag");
+}
+
+TEST(MemoryTierTest, emptyTagThrows) {
+  VELOX_ASSERT_THROW(
+      MemoryTier({{"rmm"}, {""}}), "MemoryTier tag must not be empty");
+}
+
+TEST(MemoryTierTest, duplicateTagWithinLevelThrows) {
+  VELOX_ASSERT_THROW(
+      MemoryTier({{"cxl", "cxl"}}), "Duplicate tag in MemoryTier: cxl");
+}
+
+TEST(MemoryTierTest, duplicateTagAcrossLevelsThrows) {
+  VELOX_ASSERT_THROW(
+      MemoryTier({{"dram"}, {"dram"}}), "Duplicate tag in MemoryTier: dram");
+}
+
+TEST(MemoryTierTest, levelOf) {
+  MemoryTier tier({{"rmm"}, {"pinnedHost"}, {"cxl", "dram"}});
+  EXPECT_EQ(tier.levelOf("rmm"), 0);
+  EXPECT_EQ(tier.levelOf("pinnedHost"), 1);
+  EXPECT_EQ(tier.levelOf("cxl"), 2);
+  EXPECT_EQ(tier.levelOf("dram"), 2);
+  EXPECT_EQ(tier.levelOf("unknown"), std::nullopt);
+}
+
+TEST(MemoryTierTest, toString) {
+  MemoryTier tier({{"rmm"}, {"pinnedHost"}, {"cxl", "dram"}});
+  EXPECT_EQ(tier.toString(), "MemoryTier[[rmm], [pinnedHost], [cxl, dram]]");
+}
+
+} // namespace
+} // namespace facebook::velox::memory


### PR DESCRIPTION
Implements the data model of the MemoryTier proposal (#18040).

MemoryTier is an immutable description of a memory-resource hierarchy ordered from fastest tier to slowest. Each level lists the resource tags considered equivalent at that tier — for a GPU setup, level 0 might be `{"rmm"}`, level 1 `{"pinnedHost"}`, and level 2 `{"cxl", "dram"}`.
