### PR TITLE
fix(cudf): Preserve probe schema for right semi join input

### DIFF
--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -740,7 +740,7 @@ void CudfHashJoinProbe::doNoMoreInput() {
   // Using output_mr here to allow spilling queued up large tables
   auto tbl = getConcatenatedTable(
       std::exchange(inputs_, {}),
-      joinNode_->sources()[1]->outputType(),
+      probeType_,
       stream,
       get_output_mr());
 
@@ -751,10 +751,11 @@ void CudfHashJoinProbe::doNoMoreInput() {
     VLOG(1) << "Probe table number of rows: " << tbl->num_rows();
   }
 
-  // Store the concatenated table in input_
+  // This intermediate is still the complete probe input. The right-semi
+  // output schema applies only after rightSemiFilterJoin gathers build rows.
   input_ = std::make_shared<CudfVector>(
       operatorCtx_->pool(),
-      joinNode_->outputType(),
+      probeType_,
       tbl->num_rows(),
       std::move(tbl),
       stream);

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -751,8 +751,7 @@ void CudfHashJoinProbe::doNoMoreInput() {
     VLOG(1) << "Probe table number of rows: " << tbl->num_rows();
   }
 
-  // This intermediate is still the complete probe input. The right-semi
-  // output schema applies only after rightSemiFilterJoin gathers build rows.
+  // Store the concatenated probe table in input_.
   input_ = std::make_shared<CudfVector>(
       operatorCtx_->pool(),
       probeType_,

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -751,7 +751,7 @@ void CudfHashJoinProbe::doNoMoreInput() {
     VLOG(1) << "Probe table number of rows: " << tbl->num_rows();
   }
 
-  // Store the concatenated probe table in input_.
+  // Store the concatenated table in input_
   input_ = std::make_shared<CudfVector>(
       operatorCtx_->pool(),
       probeType_,

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -739,10 +739,7 @@ void CudfHashJoinProbe::doNoMoreInput() {
   auto stream = cudfGlobalStreamPool().get_stream();
   // Using output_mr here to allow spilling queued up large tables
   auto tbl = getConcatenatedTable(
-      std::exchange(inputs_, {}),
-      probeType_,
-      stream,
-      get_output_mr());
+      std::exchange(inputs_, {}), probeType_, stream, get_output_mr());
 
   VELOX_CHECK_NOT_NULL(tbl);
 

--- a/velox/experimental/cudf/tests/HashJoinTest.cpp
+++ b/velox/experimental/cudf/tests/HashJoinTest.cpp
@@ -869,6 +869,67 @@ TEST_P(MultiThreadedHashJoinTest, rightSemiJoinFilter) {
       .run();
 }
 
+TEST_P(
+    MultiThreadedHashJoinTest,
+    rightSemiJoinFilterWithAsymmetricSchemas) {
+  auto probeVectors = makeBatches(3, [&](int32_t batch) {
+    return makeRowVector(
+        {"t0", "t1", "t2"},
+        {makeFlatVector<int32_t>(
+             32, [batch](auto row) { return batch * 16 + row; }),
+         makeFlatVector<int64_t>(
+             32, [batch](auto row) { return batch * 1'000 + row; }),
+         makeFlatVector<double>(
+             32, [batch](auto row) { return batch + row / 10.0; })});
+  });
+  auto buildVectors = makeBatches(2, [&](int32_t batch) {
+    return makeRowVector(
+        {"u0", "u1"},
+        {makeFlatVector<int32_t>(
+             32, [batch](auto row) { return batch * 24 + row; }),
+         makeFlatVector<int64_t>(
+             32, [batch](auto row) { return batch * 10'000 + row; })});
+  });
+
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .injectSpill(false)
+      .numDrivers(numDrivers_)
+      .probeKeys({"t0"})
+      .probeVectors(std::move(probeVectors))
+      .buildKeys({"u0"})
+      .buildVectors(std::move(buildVectors))
+      .joinType(core::JoinType::kRightSemiFilter)
+      .joinOutputLayout({"u1"})
+      .referenceQuery("SELECT u.u1 FROM u WHERE u.u0 IN (SELECT t.t0 FROM t)")
+      .run();
+}
+
+TEST_P(MultiThreadedHashJoinTest, rightSemiJoinFilterWithEmptyProbe) {
+  auto probeType = ROW(
+      {{"t0", INTEGER()}, {"t1", BIGINT()}, {"t2", DOUBLE()}});
+  auto buildVectors = makeBatches(2, [&](int32_t batch) {
+    return makeRowVector(
+        {"u0", "u1"},
+        {makeFlatVector<int32_t>(
+             32, [batch](auto row) { return batch * 32 + row; }),
+         makeFlatVector<int64_t>(
+             32, [batch](auto row) { return batch * 1'000 + row; })});
+  });
+
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .injectSpill(false)
+      .numDrivers(numDrivers_)
+      .probeType(probeType)
+      .probeVectors(0, 3)
+      .probeKeys({"t0"})
+      .buildKeys({"u0"})
+      .buildVectors(std::move(buildVectors))
+      .joinType(core::JoinType::kRightSemiFilter)
+      .joinOutputLayout({"u1"})
+      .referenceQuery("SELECT u.u1 FROM u WHERE u.u0 IN (SELECT t.t0 FROM t)")
+      .run();
+}
+
 TEST_P(MultiThreadedHashJoinTest, rightSemiJoinFilterWithEmptyBuild) {
   const std::vector<bool> finishOnEmptys = {false, true};
   for (const auto finishOnEmpty : finishOnEmptys) {

--- a/velox/experimental/cudf/tests/HashJoinTest.cpp
+++ b/velox/experimental/cudf/tests/HashJoinTest.cpp
@@ -904,9 +904,14 @@ TEST_P(
       .run();
 }
 
+// Regression test for #18124: an empty right-semi probe must be materialized
+// with the probe schema, not the build/output schema. The probe key sits at
+// ordinal 2, past the build side's column count (2). If doNoMoreInput builds a
+// build-shaped empty table, selecting the key column throws an out-of-range
+// error; a probe-shaped empty table has the column and the join returns empty.
 TEST_P(MultiThreadedHashJoinTest, rightSemiJoinFilterWithEmptyProbe) {
-  auto probeType = ROW(
-      {{"t0", INTEGER()}, {"t1", BIGINT()}, {"t2", DOUBLE()}});
+  auto probeType =
+      ROW({{"t0", BIGINT()}, {"t1", DOUBLE()}, {"t2", INTEGER()}});
   auto buildVectors = makeBatches(2, [&](int32_t batch) {
     return makeRowVector(
         {"u0", "u1"},
@@ -921,12 +926,12 @@ TEST_P(MultiThreadedHashJoinTest, rightSemiJoinFilterWithEmptyProbe) {
       .numDrivers(numDrivers_)
       .probeType(probeType)
       .probeVectors(0, 3)
-      .probeKeys({"t0"})
+      .probeKeys({"t2"})
       .buildKeys({"u0"})
       .buildVectors(std::move(buildVectors))
       .joinType(core::JoinType::kRightSemiFilter)
       .joinOutputLayout({"u1"})
-      .referenceQuery("SELECT u.u1 FROM u WHERE u.u0 IN (SELECT t.t0 FROM t)")
+      .referenceQuery("SELECT u.u1 FROM u WHERE u.u0 IN (SELECT t.t2 FROM t)")
       .run();
 }
 

--- a/velox/experimental/cudf/tests/HashJoinTest.cpp
+++ b/velox/experimental/cudf/tests/HashJoinTest.cpp
@@ -869,9 +869,7 @@ TEST_P(MultiThreadedHashJoinTest, rightSemiJoinFilter) {
       .run();
 }
 
-TEST_P(
-    MultiThreadedHashJoinTest,
-    rightSemiJoinFilterWithAsymmetricSchemas) {
+TEST_P(MultiThreadedHashJoinTest, rightSemiJoinFilterWithAsymmetricSchemas) {
   auto probeVectors = makeBatches(3, [&](int32_t batch) {
     return makeRowVector(
         {"t0", "t1", "t2"},
@@ -910,8 +908,7 @@ TEST_P(
 // build-shaped empty table, selecting the key column throws an out-of-range
 // error; a probe-shaped empty table has the column and the join returns empty.
 TEST_P(MultiThreadedHashJoinTest, rightSemiJoinFilterWithEmptyProbe) {
-  auto probeType =
-      ROW({{"t0", BIGINT()}, {"t1", DOUBLE()}, {"t2", INTEGER()}});
+  auto probeType = ROW({{"t0", BIGINT()}, {"t1", DOUBLE()}, {"t2", INTEGER()}});
   auto buildVectors = makeBatches(2, [&](int32_t batch) {
     return makeRowVector(
         {"u0", "u1"},


### PR DESCRIPTION
## Summary

- Preserve `probeType_` while concatenating and wrapping queued probe input for right-semi filter joins.
- Apply the final output schema only after `rightSemiFilterJoin()` gathers matching build rows.
- Add regression coverage for asymmetric probe/build/output schemas and empty probe input with one and three drivers.

## Problem

`CudfHashJoinProbe::doNoMoreInput()` collects complete probe-side tables at the driver barrier. The existing code passes the build-side schema to `getConcatenatedTable()` and the final join output schema to the temporary `CudfVector`, even though `rightSemiFilterJoin()` has not run yet.

For a three-column probe and one-column output, this describes a three-column physical cuDF table using a one-column `RowType`. For empty probe input, it asks `getConcatenatedTable()` to synthesize a build-shaped empty table instead of a probe-shaped table.

This change corrects only the metadata contract; it does not unpack or copy GPU columns.

## Testing

```text
velox_cudf_hash_join_test
  *rightSemiJoinFilterWithAsymmetricSchemas*
  *rightSemiJoinFilterWithEmptyProbe*

4/4 passed (one and three drivers for each case)
```

The same focused selection failed 4/4 on unmodified upstream `main` with reproduction-only contract checks and passed 4/4 after applying this fix.

Fixes #18124
