### PR TITLE
feat(cudf): Experimental Support for Presto DECIMAL32 as in TPC-DS

### DIFF
--- a/.cursor/plans/decimal32-to-decimal64-widening.plan.md
+++ b/.cursor/plans/decimal32-to-decimal64-widening.plan.md
@@ -1,0 +1,202 @@
+# DECIMAL32-to-DECIMAL64 Widening Plan
+
+**Status: COMPLETE** (phases 1–5 implemented on branch `simoneves/support_presto_decimal32`)
+
+| Phase | Commit | Summary |
+|-------|--------|---------|
+| 1/5 | `65a6525d2` | Shared widening helpers + agg input defense |
+| 2/5 | `e77a98c64` | Scan-boundary alignment in `CudfHiveDataSource::next` |
+| 3/5 | `f4a4ab056` | Arrow bridge `d:p,s,32` import + tests |
+| 4/5 | `cb866d623` | Expression evaluator / divide kernel defense |
+| 5/5 | `f34da3ed5` | Unit, interop, scan, and expression tests |
+
+---
+
+## Problem (original)
+
+cuDF's Parquet reader can materialize small-precision decimals as native `cudf::type_id::DECIMAL32` (physical INT32, precision 1–9). The Velox+CUDF stack assumes short Velox decimals map to **`DECIMAL64`** via [`veloxToCudfDataType`](velox/experimental/cudf/exec/VeloxCudfInterop.cpp) and did not handle `DECIMAL32` in compute paths.
+
+**Gap (resolved):** Parquet `DECIMAL(7,2)` (e.g. [`decimal_dict.parquet`](velox/dwio/parquet/tests/examples/decimal_dict.parquet)) read through `CudfSplitReader` could arrive as `DECIMAL32`, then flow into remaining filters, GPU expressions, aggregations, or `toVeloxColumn` (Arrow bridge) without widening — causing failures or silent incompatibility.
+
+```mermaid
+flowchart TD
+  PQ["Parquet INT32 DECIMAL p le 9"]
+  CR["CudfSplitReader.readNextChunk"]
+  D32["cudf DECIMAL32"]
+  Align["alignTableColumnsToOutputType in CudfHiveDataSource::next"]
+  D64["cudf DECIMAL64 / DECIMAL128"]
+  Filter["remainingFilter eval"]
+  Ops["GPU expr / agg / join"]
+  Arrow["toVeloxColumn / Arrow import d:p,s,32"]
+  Velox["Velox ShortDecimalType int64"]
+
+  PQ --> CR --> D32 --> Align --> D64
+  D64 --> Filter
+  D64 --> Ops
+  D32 -.->|"defense in depth"| Ops
+  D64 --> Arrow --> Velox
+```
+
+Velox CPU Parquet already widens INT32 → `int64` at read time ([`PageReader.cpp`](velox/dwio/parquet/reader/PageReader.cpp) ~477–485). This plan closed the equivalent gap on the **CUDF + Arrow bridge** side.
+
+---
+
+## Design principles
+
+1. **Widen once, early:** Align column storage width immediately after Parquet chunk read and **before** `remainingFilter` evaluation in [`CudfHiveDataSource::next`](velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp) (~228–250).
+2. **Mirror existing patterns:** Follow [`castDecimal64InputToDecimal128`](velox/experimental/cudf/exec/DecimalAggregationHostOps.cpp) — thin wrapper around `cudf::cast` preserving `numeric::scale_type`.
+3. **Target type from Velox schema:** Use `veloxToCudfDataType(outputType->childAt(i))` as the authoritative expected cuDF type (`DECIMAL64` for short decimal, `DECIMAL128` for long).
+4. **Minimal surface area:** A single shared alignment helper at scan boundary; secondary defense at aggregation inputs, Arrow import, and expression evaluation.
+5. **No Velox type change:** Velox continues to represent short decimals as `int64` (`ShortDecimalType`). No new `DECIMAL32` in Velox.
+
+---
+
+## Implementation phases
+
+### Phase 1 — Shared widening utilities (foundation) ✅
+
+**Commit:** `65a6525d2`
+
+**Files:**
+- [`velox/experimental/cudf/exec/DecimalAggregationHostOps.h`](velox/experimental/cudf/exec/DecimalAggregationHostOps.h)
+- [`velox/experimental/cudf/exec/DecimalAggregationHostOps.cpp`](velox/experimental/cudf/exec/DecimalAggregationHostOps.cpp)
+- [`velox/experimental/cudf/exec/CudfGroupby.cpp`](velox/experimental/cudf/exec/CudfGroupby.cpp)
+- [`velox/experimental/cudf/exec/CudfReduce.cpp`](velox/experimental/cudf/exec/CudfReduce.cpp)
+- [`velox/experimental/cudf/exec/CudfWindow.cpp`](velox/experimental/cudf/exec/CudfWindow.cpp)
+
+**Implemented:**
+- `castDecimal32InputToDecimal64`, `castDecimalColumnIfNeeded`, `alignTableColumnsToOutputType`
+- Chained `castDecimal32InputToDecimal64` before `castDecimal64InputToDecimal128` in decimal SUM paths (groupby, reduce, window)
+
+**Deferred (unchanged from v1):** Nested LIST/STRUCT decimal alignment in `alignTableColumnsToOutputType` — not needed for flat Parquet scan columns.
+
+---
+
+### Phase 2 — Scan boundary (primary fix) ✅
+
+**Commit:** `e77a98c64`
+
+**File:** [`velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp`](velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp)
+
+**Implemented in `next()` (~236–237):**
+
+```
+chunkOpt = readNextChunk()
+cudfTable = move(chunkOpt)
+cudfTable = alignTableColumnsToOutputType(
+    move(cudfTable), getTableRowType(), stream, get_output_mr())  // before filter
+if (remainingFilterExprSet_) { ... }
+```
+
+**Note:** Uses `getTableRowType()` (not `outputType_`) so filter-only columns in `readColumnNames_` are widened too. Iceberg and equality-delete paths inherit this `next()` flow.
+
+---
+
+### Phase 3 — Arrow bridge import (Velox fallback path) ✅
+
+**Commit:** `f4a4ab056`
+
+**File:** [`velox/vector/arrow/Bridge.cpp`](velox/vector/arrow/Bridge.cpp)
+
+**Implemented:**
+- `parseDecimalFormat` accepts `bitWidth == 32` → `ShortDecimalType`
+- Short-decimal array import for `bitWidth == 32` via `createShortDecimalVectorFromInt32Decimals` (int32 sign-extension to int64)
+- Tests in [`ArrowBridgeSchemaTest.cpp`](velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp) (`d:7,2,32`, `d:9,1,32`) and [`ArrowBridgeArrayTest.cpp`](velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp)
+
+**Export unchanged:** Velox short decimals still export as `d:p,s,64` with `useDecimalTypeWidth=true`.
+
+---
+
+### Phase 4 — Expression / kernel defense (secondary) ✅
+
+**Commit:** `cb866d623`
+
+**Files:**
+- [`velox/experimental/cudf/expression/ExpressionEvaluator.cpp`](velox/experimental/cudf/expression/ExpressionEvaluator.cpp)
+- [`velox/experimental/cudf/expression/DecimalExpressionKernels.cpp`](velox/experimental/cudf/expression/DecimalExpressionKernels.cpp)
+
+**Implemented (beyond the original “simpler alternative” sketch):**
+
+| Area | Change |
+|------|--------|
+| Scalar helpers | `decimalScalarIsZero`, `hasDecimalZero`, `castDecimalScalar` — `DECIMAL32` via `numeric::decimal32` |
+| Divide prep | New `prepareDecimalDivideColumn` — chains `castDecimal32InputToDecimal64`, then `DECIMAL64→DECIMAL128` when output requires it; scalar operands aligned to widened column type |
+| MUL | `!= DECIMAL128` promotion (covers `DECIMAL32` + `DECIMAL64`); DECIMAL64-output MUL casts operands to result type |
+| Kernels | `getDecimalScalarValue` reads `DECIMAL32`; `checkDecimalDivideTypes` rejects unwidened `DECIMAL32` with explicit message |
+
+**Unchanged (as planned):**
+- [`AstUtils.h`](velox/experimental/cudf/expression/AstUtils.h) — already emits `DECIMAL64` for short-decimal literals
+- [`DecimalExpressionKernelsGpu.cu`](velox/experimental/cudf/expression/DecimalExpressionKernelsGpu.cu) — no int32 divide dispatch; inputs widened upstream
+- ADD/SUB/MOD/CMP — already used `cudf::cast` when operand types differ
+
+---
+
+### Phase 5 — Tests ✅
+
+**Commit:** `f34da3ed5`
+
+| Item | Status | Location |
+|------|--------|----------|
+| 5a. Widening helper unit tests | ✅ | [`DecimalWideningTest.cpp`](velox/experimental/cudf/tests/DecimalWideningTest.cpp) — target `velox_cudf_decimal_widening_test` |
+| 5b. Interop round-trip | ✅ | [`InteropTest.cpp`](velox/experimental/cudf/tests/InteropTest.cpp) — `DECIMAL(5,2)`, `DECIMAL(9,2)`, nulls, DECIMAL32 widen → Velox |
+| 5c. Parquet e2e scan | ✅ | [`TableScanTest.cpp`](velox/experimental/cudf/tests/TableScanTest.cpp) — `decimalDictParquetInt32Physical` reads `decimal_dict.parquet` |
+| 5d. Low-precision expressions | ✅ | [`DecimalExpressionTest.cpp`](velox/experimental/cudf/tests/DecimalExpressionTest.cpp) — `DECIMAL(7,2)` and `DECIMAL(9,2)` arithmetic |
+| 5e. Arrow bridge 32-bit | ✅ | Phase 3 (`ArrowBridgeSchemaTest`, `ArrowBridgeArrayTest`) |
+
+**Not implemented (optional in original plan):**
+- [`decimal.parquet`](velox/dwio/parquet/tests/examples/decimal.parquet) `DECIMAL(5,2)` e2e scan
+- Low-precision decimal **aggregation** tests (expression tests only; agg paths covered indirectly via Phase 1 wiring)
+- Re-enabling `DISABLED_decimalFilterPushdown` / `DISABLED_decimalStatsFilterIoPruning` in TableScanTest
+
+---
+
+## File change summary
+
+| Priority | File | Action | Status |
+|----------|------|--------|--------|
+| P0 | `DecimalAggregationHostOps.h/.cpp` | Widening + table alignment helpers | ✅ |
+| P0 | `CudfHiveDataSource.cpp` | `alignTableColumnsToOutputType` after read, before filter | ✅ |
+| P1 | `Bridge.cpp` | Accept/import `bitWidth=32` | ✅ |
+| P1 | `CudfGroupby.cpp`, `CudfReduce.cpp`, `CudfWindow.cpp` | Chain 32→64 before 64→128 | ✅ |
+| P2 | `ExpressionEvaluator.cpp`, `DecimalExpressionKernels.cpp` | DECIMAL32 operand defense | ✅ |
+| P2 | Test files listed above | New coverage | ✅ |
+
+**No changes needed (confirmed):**
+- [`veloxToCudfDataType`](velox/experimental/cudf/exec/VeloxCudfInterop.cpp) — maps short decimal → `DECIMAL64`
+- Velox CPU Parquet reader — widens INT32 → int64
+- [`toCudfTable`](velox/experimental/cudf/exec/VeloxCudfInterop.cpp) export — emits 64-bit width
+- [`AstUtils.h`](velox/experimental/cudf/expression/AstUtils.h) — short-decimal literals already `DECIMAL64`
+
+---
+
+## Risks and validation
+
+| Risk | Mitigation / status |
+|------|---------------------|
+| `cudf::cast(DECIMAL32, DECIMAL64)` unsupported | `DecimalWideningTest` and `InteropTest` gate on `cudf::is_supported_cast` |
+| Scale sign convention (Velox +, cuDF −) | Widening preserves `inputCol.type().scale()` unchanged |
+| Filter pushdown with DECIMAL32 predicates | **Still open** — `DISABLED_decimalFilterPushdown` remains disabled pending cuDF fix |
+| Performance (one cast per decimal column per chunk) | Accepted; preferable to per-operator casts |
+
+---
+
+## Actual commit breakdown (branch `simoneves/support_presto_decimal32`)
+
+One commit per phase (5 total), suitable for a single PR or cherry-pick review:
+
+1. `65a6525d2` — helpers + agg defense
+2. `e77a98c64` — scan boundary
+3. `f4a4ab056` — Arrow bridge
+4. `cb866d623` — expression defense
+5. `f34da3ed5` — tests
+
+---
+
+## Implementation todos
+
+- [x] Add `castDecimal32InputToDecimal64`, `castDecimalColumnIfNeeded`, and `alignTableColumnsToOutputType` in `DecimalAggregationHostOps.h/.cpp`
+- [x] Call `alignTableColumnsToOutputType` in `CudfHiveDataSource::next()` after `readNextChunk`, before remainingFilter eval (use `getTableRowType` for filter columns)
+- [x] Extend `Bridge.cpp` `parseDecimalFormat` and short-decimal import for `bitWidth=32` with int32 sign-extension
+- [x] Chain DECIMAL32 widening before `castDecimal64InputToDecimal128` in `CudfGroupby`, `CudfReduce`, `CudfWindow`
+- [x] Pre-cast DECIMAL32 operands in `ExpressionEvaluator` binary/divide/multiply paths
+- [x] Add `DecimalWideningTest`, `InteropTest` decimal cases, `TableScanTest` with `decimal_dict.parquet`, ArrowBridge 32-bit import tests (phase 3)

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
@@ -19,6 +19,7 @@
 #include "velox/experimental/cudf/connectors/hive/CudfHiveConnectorSplit.h"
 #include "velox/experimental/cudf/connectors/hive/CudfHiveDataSource.h"
 #include "velox/experimental/cudf/connectors/hive/CudfHiveTableHandle.h"
+#include "velox/experimental/cudf/exec/DecimalAggregationHostOps.h"
 #include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/exec/ToCudf.h"
 #include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
@@ -232,6 +233,9 @@ std::optional<RowVectorPtr> CudfHiveDataSource::next(
   auto cudfTable = std::move(chunkOpt.value());
   auto stream = cudfSplitReader_->stream();
 
+  cudfTable = alignTableColumnsToOutputType(
+      std::move(cudfTable), getTableRowType(), stream, get_output_mr());
+
   uint64_t filterTimeUs{0};
   if (remainingFilterExprSet_) {
     MicrosecondWallTimer filterTimer(&filterTimeUs);
@@ -306,13 +310,27 @@ const RowTypePtr CudfHiveDataSource::getTableRowType() {
   if (cachedTableRowType_) {
     return cachedTableRowType_;
   }
-  if (tableHandle_->dataColumns()) {
+  const auto& dataColumns = tableHandle_->dataColumns();
+  if (dataColumns) {
     std::vector<std::string> names;
     std::vector<TypePtr> types;
+    names.reserve(readColumnNames_.size());
+    types.reserve(readColumnNames_.size());
     for (const auto& name : readColumnNames_) {
-      auto parsedType = tableHandle_->dataColumns()->findChild(name);
-      names.emplace_back(std::move(name));
-      types.push_back(parsedType);
+      TypePtr columnType;
+      if (dataColumns->containsChild(name)) {
+        columnType = dataColumns->findChild(name);
+      } else if (outputType_->containsChild(name)) {
+        // Partition, info, and schema-evolution columns are projected in
+        // outputType but omitted from dataColumns (file schema only).
+        columnType = outputType_->findChild(name);
+      } else {
+        VELOX_USER_FAIL(
+            "Column {} is missing from dataColumns and outputType",
+            name);
+      }
+      names.emplace_back(name);
+      types.push_back(std::move(columnType));
     }
     cachedTableRowType_ = ROW(std::move(names), std::move(types));
     return cachedTableRowType_;

--- a/velox/experimental/cudf/exec/CudfGroupby.cpp
+++ b/velox/experimental/cudf/exec/CudfGroupby.cpp
@@ -41,6 +41,7 @@
 namespace {
 
 using namespace facebook::velox;
+using cudf_velox::castDecimal32InputToDecimal64;
 using cudf_velox::castDecimal64InputToDecimal128;
 using cudf_velox::CountInputKind;
 using cudf_velox::finalizeDecimalAverage;
@@ -187,8 +188,11 @@ void addDecimalRawPartialSingleSumRequest(
     rmm::cuda_stream_view stream,
     uint32_t& sumIdx,
     std::unique_ptr<cudf::column>& castedInput) {
-  auto inputView = castDecimal64InputToDecimal128(
-      tbl.column(inputIndex), castedInput, stream);
+  std::unique_ptr<cudf::column> castedDecimal32;
+  auto inputView = castDecimal32InputToDecimal64(
+      tbl.column(inputIndex), castedDecimal32, stream);
+  inputView = castDecimal64InputToDecimal128(
+      inputView, castedInput, stream);
   auto& request = requests.emplace_back();
   sumIdx = requests.size() - 1;
   request.values = inputView;

--- a/velox/experimental/cudf/exec/CudfReduce.cpp
+++ b/velox/experimental/cudf/exec/CudfReduce.cpp
@@ -42,6 +42,7 @@
 namespace {
 
 using namespace facebook::velox;
+using facebook::velox::cudf_velox::castDecimal32InputToDecimal64;
 using facebook::velox::cudf_velox::castDecimal64InputToDecimal128;
 using facebook::velox::cudf_velox::CountInputKind;
 using facebook::velox::cudf_velox::finalizeDecimalAverage;
@@ -268,7 +269,9 @@ std::unique_ptr<cudf::column> partialDecimalSumCountToSerializedString(
     cudf::column_view inputCol,
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr) {
+  std::unique_ptr<cudf::column> castedDecimal32;
   std::unique_ptr<cudf::column> castedInput;
+  inputCol = castDecimal32InputToDecimal64(inputCol, castedDecimal32, stream);
   inputCol = castDecimal64InputToDecimal128(inputCol, castedInput, stream);
   auto const sumAgg = cudf::make_sum_aggregation<cudf::reduce_aggregation>();
   auto sumScalar =
@@ -340,7 +343,9 @@ std::unique_ptr<cudf::column> singleDecimalAvgFromRawColumn(
     TypePtr const& resultType,
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr) {
+  std::unique_ptr<cudf::column> castedDecimal32;
   std::unique_ptr<cudf::column> castedInput;
+  inputCol = castDecimal32InputToDecimal64(inputCol, castedDecimal32, stream);
   inputCol = castDecimal64InputToDecimal128(inputCol, castedInput, stream);
   auto const sumAgg = cudf::make_sum_aggregation<cudf::reduce_aggregation>();
   auto sumScalar =

--- a/velox/experimental/cudf/exec/CudfWindow.cpp
+++ b/velox/experimental/cudf/exec/CudfWindow.cpp
@@ -1136,8 +1136,11 @@ RowVectorPtr CudfWindow::doGetOutput() {
           : sortedView.column(*inputColIdx);
       if (baseName == "sum" &&
           func.functionCall->inputs()[0]->type()->isDecimal()) {
+        std::unique_ptr<cudf::column> castedDecimal32;
+        auto widened = castDecimal32InputToDecimal64(
+            inputCol, castedDecimal32, stream_);
         inputCol = castDecimal64InputToDecimal128(
-            inputCol, decimalSumInputOwners[funcIndex], stream_);
+            widened, decimalSumInputOwners[funcIndex], stream_);
       }
       const bool isFullPartition =
           isFullPartitionFrame(func, !sortKeyIndices_.empty());

--- a/velox/experimental/cudf/exec/DecimalAggregationHostOps.cpp
+++ b/velox/experimental/cudf/exec/DecimalAggregationHostOps.cpp
@@ -22,9 +22,25 @@
 
 #include "velox/common/base/Exceptions.h"
 
+#include <cudf/dictionary/dictionary_column_view.hpp>
+#include <cudf/dictionary/encode.hpp>
+#include <cudf/fixed_point/fixed_point.hpp>
+#include <cudf/table/table.hpp>
 #include <cudf/unary.hpp>
+#include <cudf/utilities/traits.hpp>
 
 namespace facebook::velox::cudf_velox {
+
+namespace {
+
+cudf::data_type physicalColumnType(cudf::column_view column) {
+  if (cudf::is_dictionary(column.type())) {
+    return cudf::dictionary_column_view{column}.keys().type();
+  }
+  return column.type();
+}
+
+} // namespace
 
 void validateIntermediateColumnType(cudf::column_view const& column) {
   // fmt does not understand cudf::type_id enum class
@@ -34,6 +50,21 @@ void validateIntermediateColumnType(cudf::column_view const& column) {
       static_cast<int>(cudf::type_id::STRING),
       "Expected serialized decimal aggregation state: Velox VARBINARY represented as cuDF STRING (got type {})",
       colType);
+}
+
+cudf::column_view castDecimal32InputToDecimal64(
+    cudf::column_view inputCol,
+    std::unique_ptr<cudf::column>& holder,
+    rmm::cuda_stream_view stream) {
+  if (inputCol.type().id() != cudf::type_id::DECIMAL32) {
+    return inputCol;
+  }
+  holder = cudf::cast(
+      inputCol,
+      cudf::data_type{cudf::type_id::DECIMAL64, inputCol.type().scale()},
+      stream,
+      get_temp_mr());
+  return holder->view();
 }
 
 cudf::column_view castDecimal64InputToDecimal128(
@@ -49,6 +80,73 @@ cudf::column_view castDecimal64InputToDecimal128(
       stream,
       get_temp_mr());
   return holder->view();
+}
+
+std::unique_ptr<cudf::column> castDecimalColumnIfNeeded(
+    cudf::column_view inputCol,
+    cudf::data_type expectedType,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  cudf::column_view valueCol = inputCol;
+  std::unique_ptr<cudf::column> decoded;
+  if (cudf::is_dictionary(inputCol.type())) {
+    decoded = cudf::dictionary::decode(
+        cudf::dictionary_column_view{inputCol}, stream, mr);
+    valueCol = decoded->view();
+  }
+
+  if (valueCol.type() == expectedType) {
+    return decoded;
+  }
+  if (!cudf::is_fixed_point(valueCol.type()) &&
+      !cudf::is_fixed_point(expectedType)) {
+    return decoded;
+  }
+  return cudf::cast(valueCol, expectedType, stream, mr);
+}
+
+std::unique_ptr<cudf::table> alignTableColumnsToOutputType(
+    std::unique_ptr<cudf::table> table,
+    const RowTypePtr& outputType,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  auto columns = table->release();
+  const auto numColumns = columns.size();
+  const auto numOutputColumns =
+      std::min(numColumns, static_cast<size_t>(outputType->size()));
+
+  bool needsRebuild = false;
+  for (size_t i = 0; i < numOutputColumns; ++i) {
+    const auto columnView = columns[i]->view();
+    const auto expectedType = veloxToCudfDataType(outputType->childAt(i));
+    const auto actualType = physicalColumnType(columnView);
+    if (cudf::is_dictionary(columnView.type()) ||
+        (actualType != expectedType &&
+         (cudf::is_fixed_point(actualType) ||
+          cudf::is_fixed_point(expectedType)))) {
+      needsRebuild = true;
+      break;
+    }
+  }
+
+  if (!needsRebuild) {
+    return std::make_unique<cudf::table>(std::move(columns));
+  }
+
+  std::vector<std::unique_ptr<cudf::column>> alignedColumns;
+  alignedColumns.reserve(numColumns);
+  for (size_t i = 0; i < numColumns; ++i) {
+    if (i < numOutputColumns) {
+      const auto expectedType = veloxToCudfDataType(outputType->childAt(i));
+      if (auto casted = castDecimalColumnIfNeeded(
+              columns[i]->view(), expectedType, stream, mr)) {
+        alignedColumns.push_back(std::move(casted));
+        continue;
+      }
+    }
+    alignedColumns.push_back(std::move(columns[i]));
+  }
+  return std::make_unique<cudf::table>(std::move(alignedColumns));
 }
 
 std::unique_ptr<cudf::column> castCountColumnToInt64(

--- a/velox/experimental/cudf/exec/DecimalAggregationHostOps.h
+++ b/velox/experimental/cudf/exec/DecimalAggregationHostOps.h
@@ -19,6 +19,7 @@
 
 #include <cudf/column/column.hpp>
 #include <cudf/column/column_view.hpp>
+#include <cudf/table/table.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -38,6 +39,22 @@ namespace facebook::velox::cudf_velox {
 void validateIntermediateColumnType(cudf::column_view const& column);
 
 /**
+ * Casts a DECIMAL32 column up to DECIMAL64 (scale preserved). Allocates the
+ * casted column from the temporary memory resource into holder and returns its
+ * view. Lifetime stays valid only while holder is alive.
+ *
+ * @param inputCol DECIMAL32 input column.
+ * @param holder receives ownership of the casted column when inputCol is
+ *        DECIMAL32; unchanged otherwise.
+ * @param stream CUDA stream for device work.
+ * @return view of inputCol or of the column stored in holder.
+ */
+cudf::column_view castDecimal32InputToDecimal64(
+    cudf::column_view inputCol,
+    std::unique_ptr<cudf::column>& holder,
+    rmm::cuda_stream_view stream);
+
+/**
  * Casts a DECIMAL64 column up to DECIMAL128 (scale preserved) so a subsequent
  * SUM accumulates in 128 bits instead of wrapping. Allocates the casted column
  * from the temporary memory resource into holder and returns its view. Lifetime
@@ -53,6 +70,41 @@ cudf::column_view castDecimal64InputToDecimal128(
     cudf::column_view inputCol,
     std::unique_ptr<cudf::column>& holder,
     rmm::cuda_stream_view stream);
+
+/**
+ * Materializes dictionary-encoded fixed-point columns and casts them to the
+ * expected cuDF decimal type when the storage width differs (e.g. DECIMAL32 to
+ * DECIMAL64). Returns nullptr when the input column can be used as-is.
+ *
+ * @param inputCol input column.
+ * @param expectedType target cuDF type from veloxToCudfDataType.
+ * @param stream CUDA stream for device work.
+ * @param mr memory resource for allocated columns.
+ * @return casted column, or nullptr if inputCol already matches expectedType
+ *         or the types are not fixed-point decimals.
+ */
+std::unique_ptr<cudf::column> castDecimalColumnIfNeeded(
+    cudf::column_view inputCol,
+    cudf::data_type expectedType,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr);
+
+/**
+ * Aligns each table column's cuDF decimal storage width to the Velox output
+ * schema. Preserves scale and only casts when the actual type differs from
+ * veloxToCudfDataType for the corresponding output column.
+ *
+ * @param table input table (may be moved from).
+ * @param outputType Velox row type describing expected column types.
+ * @param stream CUDA stream for device work.
+ * @param mr memory resource for allocated columns.
+ * @return table with decimal columns widened as needed.
+ */
+std::unique_ptr<cudf::table> alignTableColumnsToOutputType(
+    std::unique_ptr<cudf::table> table,
+    const RowTypePtr& outputType,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr);
 
 /**
  * Ensures the partial-row count column is INT64, casting with the temporary

--- a/velox/experimental/cudf/exec/VeloxCudfInterop.cpp
+++ b/velox/experimental/cudf/exec/VeloxCudfInterop.cpp
@@ -37,6 +37,9 @@
 
 #include <cstdlib>
 #include <cstring>
+#include <string>
+
+#include <fmt/format.h>
 
 namespace facebook::velox::cudf_velox {
 
@@ -179,14 +182,16 @@ std::unique_ptr<cudf::table> toCudfTable(
 
 namespace {
 
-void setArrowFormatBackToVarbinary(ArrowSchema* schema, const TypePtr& type) {
+void overrideArrowSchemaFromVeloxType(
+    ArrowSchema* schema,
+    const TypePtr& type) {
   switch (type->kind()) {
     case TypeKind::ROW: {
       if (schema->n_children != static_cast<int64_t>(type->size())) {
         break;
       }
       for (size_t i = 0; i < type->size(); ++i) {
-        setArrowFormatBackToVarbinary(schema->children[i], type->childAt(i));
+        overrideArrowSchemaFromVeloxType(schema->children[i], type->childAt(i));
       }
       break;
     }
@@ -201,6 +206,28 @@ void setArrowFormatBackToVarbinary(ArrowSchema* schema, const TypePtr& type) {
       auto* buffer = static_cast<char*>(std::malloc(bufferLen));
       VELOX_CHECK_NOT_NULL(buffer);
       std::memcpy(buffer, kVarbinaryArrowFormat, bufferLen);
+      schema->format = buffer;
+      break;
+    }
+    case TypeKind::BIGINT:
+    case TypeKind::HUGEINT: {
+      if (!type->isDecimal()) {
+        break;
+      }
+      // cuDF DECIMAL64/128 Arrow export uses libcudf default precision (e.g.
+      // d:18,s,64). Restore the Velox logical precision before import.
+      const auto [precision, scale] = getDecimalPrecisionScale(*type);
+      const int bitWidth = type->isShortDecimal() ? 64 : 128;
+      const auto formatStr =
+          fmt::format("d:{},{},{}", precision, scale, bitWidth);
+      if (schema->format != nullptr) {
+        std::free(const_cast<char*>(schema->format));
+        schema->format = nullptr;
+      }
+      const size_t bufferLen = formatStr.size() + 1;
+      auto* buffer = static_cast<char*>(std::malloc(bufferLen));
+      VELOX_CHECK_NOT_NULL(buffer);
+      std::memcpy(buffer, formatStr.c_str(), bufferLen);
       schema->format = buffer;
       break;
     }
@@ -235,14 +262,11 @@ RowVectorPtr toVeloxColumn(
   ArrowSchema schemaCopy = *arrowSchema;
   arrowSchema->release = nullptr;
 
-  // Override schema type recursively with outputType if provided. This is
-  // needed for some types like VARBINARY which are exported as STRING (the
-  // format is overridden to "z" when the exportVarbinaryAsString option is set
-  // to true in the exportToArrow() call) because cuDF does not have a VARBINARY
-  // type. This code implements the other side of the conversion, to change the
-  // format back to "z" so that the data re-imports as VARBINARY.
+  // Override schema types recursively with outputType when provided. Needed
+  // for VARBINARY (cuDF STRING export) and for decimals where cuDF Arrow
+  // export uses libcudf default precision instead of the Velox logical type.
   if (outputType) {
-    setArrowFormatBackToVarbinary(&schemaCopy, *outputType);
+    overrideArrowSchemaFromVeloxType(&schemaCopy, *outputType);
   }
 
   auto veloxTable = importFromArrowAsOwner(schemaCopy, arrayCopy, pool);

--- a/velox/experimental/cudf/expression/DecimalExpressionKernels.cpp
+++ b/velox/experimental/cudf/expression/DecimalExpressionKernels.cpp
@@ -32,6 +32,11 @@ namespace {
 __int128_t getDecimalScalarValue(
     const cudf::scalar& s,
     rmm::cuda_stream_view stream) {
+  if (s.type().id() == cudf::type_id::DECIMAL32) {
+    auto const& dec =
+        static_cast<cudf::fixed_point_scalar<numeric::decimal32> const&>(s);
+    return static_cast<__int128_t>(static_cast<int64_t>(dec.value(stream)));
+  }
   if (s.type().id() == cudf::type_id::DECIMAL64) {
     auto const& dec =
         static_cast<cudf::fixed_point_scalar<numeric::decimal64> const&>(s);
@@ -56,7 +61,8 @@ std::unique_ptr<cudf::column> makeAllNullDecimalColumn(
 void checkDecimalDivideTypes(cudf::type_id inType, cudf::type_id outType) {
   VELOX_CHECK(
       inType == cudf::type_id::DECIMAL64 || inType == cudf::type_id::DECIMAL128,
-      "Unsupported input type for decimal divide");
+      "Unsupported input type for decimal divide; DECIMAL32 operands must be "
+      "widened before calling decimalDivide");
   if (inType == cudf::type_id::DECIMAL64) {
     VELOX_CHECK(
         outType == cudf::type_id::DECIMAL64 ||

--- a/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/experimental/cudf/exec/DecimalAggregationHostOps.h"
 #include "velox/experimental/cudf/exec/Validation.h"
 #include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
 #include "velox/experimental/cudf/expression/AstUtils.h"
@@ -95,6 +96,12 @@ bool decimalScalarIsZero(
   if (!scalar.is_valid(stream)) {
     return false;
   }
+  if (scalar.type().id() == cudf::type_id::DECIMAL32) {
+    auto const& dec =
+        static_cast<cudf::fixed_point_scalar<numeric::decimal32> const&>(
+            scalar);
+    return dec.value(stream) == 0;
+  }
   if (scalar.type().id() == cudf::type_id::DECIMAL64) {
     auto const& dec =
         static_cast<cudf::fixed_point_scalar<numeric::decimal64> const&>(
@@ -119,7 +126,10 @@ bool hasDecimalZero(
   }
   std::unique_ptr<cudf::scalar> zero;
   auto scale = numeric::scale_type{col.type().scale()};
-  if (col.type().id() == cudf::type_id::DECIMAL64) {
+  if (col.type().id() == cudf::type_id::DECIMAL32) {
+    zero =
+        cudf::make_fixed_point_scalar<numeric::decimal32>(0, scale, stream, mr);
+  } else if (col.type().id() == cudf::type_id::DECIMAL64) {
     zero =
         cudf::make_fixed_point_scalar<numeric::decimal64>(0, scale, stream, mr);
   } else if (col.type().id() == cudf::type_id::DECIMAL128) {
@@ -167,7 +177,11 @@ std::unique_ptr<cudf::scalar> castDecimalScalar(
   }
 
   __int128_t rep;
-  if (src.type().id() == cudf::type_id::DECIMAL64) {
+  if (src.type().id() == cudf::type_id::DECIMAL32) {
+    auto const& dec =
+        static_cast<cudf::fixed_point_scalar<numeric::decimal32> const&>(src);
+    rep = static_cast<int64_t>(dec.value(stream));
+  } else if (src.type().id() == cudf::type_id::DECIMAL64) {
     auto const& dec =
         static_cast<cudf::fixed_point_scalar<numeric::decimal64> const&>(src);
     rep = static_cast<int64_t>(dec.value(stream));
@@ -197,6 +211,26 @@ std::unique_ptr<cudf::scalar> castDecimalScalar(
       numeric::scale_type{targetType.scale()},
       stream,
       mr);
+}
+
+cudf::column_view prepareDecimalDivideColumn(
+    cudf::column_view col,
+    cudf::data_type outputType,
+    std::unique_ptr<cudf::column>& holder,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  holder.reset();
+  col = castDecimal32InputToDecimal64(col, holder, stream);
+  if (outputType.id() == cudf::type_id::DECIMAL128 &&
+      col.type().id() != cudf::type_id::DECIMAL128) {
+    holder = cudf::cast(
+        col,
+        cudf::data_type{cudf::type_id::DECIMAL128, col.type().scale()},
+        stream,
+        mr);
+    col = holder->view();
+  }
+  return col;
 }
 
 struct CudfExpressionEvaluatorEntry {
@@ -557,24 +591,12 @@ class BinaryFunction : public CudfFunction {
     };
     if (left_ == nullptr && right_ == nullptr) {
       if (op_ == cudf::binary_operator::DIV && cudf::is_fixed_point(type_)) {
-        auto lhsView = asView(inputColumns[0]);
-        auto rhsView = asView(inputColumns[1]);
-        std::unique_ptr<cudf::column> lhsCast;
-        std::unique_ptr<cudf::column> rhsCast;
-        if (type_.id() == cudf::type_id::DECIMAL128) {
-          if (lhsView.type().id() == cudf::type_id::DECIMAL64) {
-            auto castType = cudf::data_type{
-                cudf::type_id::DECIMAL128, lhsView.type().scale()};
-            lhsCast = cudf::cast(lhsView, castType, stream, mr);
-            lhsView = lhsCast->view();
-          }
-          if (rhsView.type().id() == cudf::type_id::DECIMAL64) {
-            auto castType = cudf::data_type{
-                cudf::type_id::DECIMAL128, rhsView.type().scale()};
-            rhsCast = cudf::cast(rhsView, castType, stream, mr);
-            rhsView = rhsCast->view();
-          }
-        }
+        std::unique_ptr<cudf::column> lhsHolder;
+        std::unique_ptr<cudf::column> rhsHolder;
+        auto lhsView = prepareDecimalDivideColumn(
+            asView(inputColumns[0]), type_, lhsHolder, stream, mr);
+        auto rhsView = prepareDecimalDivideColumn(
+            asView(inputColumns[1]), type_, rhsHolder, stream, mr);
         auto lhsScale = -lhsView.type().scale();
         auto rhsScale = -rhsView.type().scale();
         auto outScale = -type_.scale();
@@ -629,16 +651,25 @@ class BinaryFunction : public CudfFunction {
           std::unique_ptr<cudf::column> lhsCast;
           std::unique_ptr<cudf::column> rhsCast;
           if (type_.id() == cudf::type_id::DECIMAL128) {
-            if (lhsView.type().id() == cudf::type_id::DECIMAL64) {
+            if (lhsView.type().id() != cudf::type_id::DECIMAL128) {
               auto castType = cudf::data_type{
                   cudf::type_id::DECIMAL128, lhsView.type().scale()};
               lhsCast = cudf::cast(lhsView, castType, stream, mr);
               lhsView = lhsCast->view();
             }
-            if (rhsView.type().id() == cudf::type_id::DECIMAL64) {
+            if (rhsView.type().id() != cudf::type_id::DECIMAL128) {
               auto castType = cudf::data_type{
                   cudf::type_id::DECIMAL128, rhsView.type().scale()};
               rhsCast = cudf::cast(rhsView, castType, stream, mr);
+              rhsView = rhsCast->view();
+            }
+          } else {
+            if (lhsView.type() != type_) {
+              lhsCast = cudf::cast(lhsView, type_, stream, mr);
+              lhsView = lhsCast->view();
+            }
+            if (rhsView.type() != type_) {
+              rhsCast = cudf::cast(rhsView, type_, stream, mr);
               rhsView = rhsCast->view();
             }
           }
@@ -654,12 +685,20 @@ class BinaryFunction : public CudfFunction {
         if (decimalScalarIsZero(*right_, stream)) {
           VELOX_USER_FAIL("Division by zero");
         }
-        auto lhsView = asView(inputColumns[0]);
+        std::unique_ptr<cudf::column> lhsHolder;
+        auto lhsView = prepareDecimalDivideColumn(
+            asView(inputColumns[0]), type_, lhsHolder, stream, mr);
+        std::unique_ptr<cudf::scalar> rhsScalar;
+        const cudf::scalar* rhs = right_.get();
+        if (right_->type().id() != lhsView.type().id()) {
+          rhsScalar = castDecimalScalar(*right_, lhsView.type(), stream, mr);
+          rhs = rhsScalar.get();
+        }
         auto lhsScale = -lhsView.type().scale();
-        auto rhsScale = -right_->type().scale();
+        auto rhsScale = -rhs->type().scale();
         auto outScale = -type_.scale();
         auto aRescale = outScale - lhsScale + rhsScale;
-        return decimalDivide(lhsView, *right_, type_, aRescale, stream, mr);
+        return decimalDivide(lhsView, *rhs, type_, aRescale, stream, mr);
       }
       auto lhsView = asView(inputColumns[0]);
       if (isComparisonOp(op_) && cudf::is_fixed_point(lhsView.type()) &&
@@ -706,16 +745,24 @@ class BinaryFunction : public CudfFunction {
           std::unique_ptr<cudf::column> lhsCast;
           std::unique_ptr<cudf::scalar> rhsScalar;
           if (type_.id() == cudf::type_id::DECIMAL128) {
-            if (lhsView.type().id() == cudf::type_id::DECIMAL64) {
+            if (lhsView.type().id() != cudf::type_id::DECIMAL128) {
               auto castType = cudf::data_type{
                   cudf::type_id::DECIMAL128, lhsView.type().scale()};
               lhsCast = cudf::cast(lhsView, castType, stream, mr);
               lhsView = lhsCast->view();
             }
-            if (right_->type().id() == cudf::type_id::DECIMAL64) {
+            if (right_->type().id() != cudf::type_id::DECIMAL128) {
               auto castType = cudf::data_type{
                   cudf::type_id::DECIMAL128, right_->type().scale()};
               rhsScalar = castDecimalScalar(*right_, castType, stream, mr);
+            }
+          } else {
+            if (lhsView.type() != type_) {
+              lhsCast = cudf::cast(lhsView, type_, stream, mr);
+              lhsView = lhsCast->view();
+            }
+            if (right_->type() != type_) {
+              rhsScalar = castDecimalScalar(*right_, type_, stream, mr);
             }
           }
           return cudf::binary_operation(
@@ -731,12 +778,20 @@ class BinaryFunction : public CudfFunction {
           asView(inputColumns[0]), *right_, op_, type_, stream, mr);
     }
     if (op_ == cudf::binary_operator::DIV && cudf::is_fixed_point(type_)) {
-      auto rhsView = asView(inputColumns[0]);
-      auto lhsScale = -left_->type().scale();
+      std::unique_ptr<cudf::column> rhsHolder;
+      auto rhsView = prepareDecimalDivideColumn(
+          asView(inputColumns[0]), type_, rhsHolder, stream, mr);
+      std::unique_ptr<cudf::scalar> lhsScalar;
+      const cudf::scalar* lhs = left_.get();
+      if (left_->type().id() != rhsView.type().id()) {
+        lhsScalar = castDecimalScalar(*left_, rhsView.type(), stream, mr);
+        lhs = lhsScalar.get();
+      }
+      auto lhsScale = -lhs->type().scale();
       auto rhsScale = -rhsView.type().scale();
       auto outScale = -type_.scale();
       auto aRescale = outScale - lhsScale + rhsScale;
-      return decimalDivide(*left_, rhsView, type_, aRescale, stream, mr);
+      return decimalDivide(*lhs, rhsView, type_, aRescale, stream, mr);
     }
     auto rhsView = asView(inputColumns[0]);
     if (isComparisonOp(op_) && cudf::is_fixed_point(left_->type()) &&
@@ -782,16 +837,24 @@ class BinaryFunction : public CudfFunction {
         std::unique_ptr<cudf::column> rhsCast;
         std::unique_ptr<cudf::scalar> lhsScalar;
         if (type_.id() == cudf::type_id::DECIMAL128) {
-          if (rhsView.type().id() == cudf::type_id::DECIMAL64) {
+          if (rhsView.type().id() != cudf::type_id::DECIMAL128) {
             auto castType = cudf::data_type{
                 cudf::type_id::DECIMAL128, rhsView.type().scale()};
             rhsCast = cudf::cast(rhsView, castType, stream, mr);
             rhsView = rhsCast->view();
           }
-          if (left_->type().id() == cudf::type_id::DECIMAL64) {
+          if (left_->type().id() != cudf::type_id::DECIMAL128) {
             auto castType = cudf::data_type{
                 cudf::type_id::DECIMAL128, left_->type().scale()};
             lhsScalar = castDecimalScalar(*left_, castType, stream, mr);
+          }
+        } else {
+          if (rhsView.type() != type_) {
+            rhsCast = cudf::cast(rhsView, type_, stream, mr);
+            rhsView = rhsCast->view();
+          }
+          if (left_->type() != type_) {
+            lhsScalar = castDecimalScalar(*left_, type_, stream, mr);
           }
         }
         return cudf::binary_operation(

--- a/velox/experimental/cudf/tests/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/CMakeLists.txt
@@ -115,6 +115,12 @@ velox_add_cudf_test(
 )
 
 velox_add_cudf_test(
+  NAME velox_cudf_decimal_widening_test
+  SOURCES Main.cpp DecimalWideningTest.cpp
+  LIBS ${CUDF_TEST_DEFAULT_LIBS}
+)
+
+velox_add_cudf_test(
   NAME velox_cudf_vector_test
   SOURCES Main.cpp CudfVectorTest.cpp
   LIBS velox_cudf_vector velox_vector_test_lib cudf::cudf

--- a/velox/experimental/cudf/tests/DecimalExpressionTest.cpp
+++ b/velox/experimental/cudf/tests/DecimalExpressionTest.cpp
@@ -1580,5 +1580,64 @@ TEST_F(CudfDecimalTest, decimalCoalesceStopsAtFirstLiteral) {
   facebook::velox::test::assertEqualVectors(cpuResult, gpuResult);
 }
 
+TEST_F(CudfDecimalTest, lowPrecisionDecimal7p2Arithmetic) {
+  auto input = makeRowVector(
+      {"a", "b"},
+      {
+          makeFlatVector<int64_t>({1111, 2222, -3333, 0}, DECIMAL(7, 2)),
+          makeFlatVector<int64_t>({100, 50, 200, 1}, DECIMAL(7, 2)),
+      });
+  std::vector<RowVectorPtr> vectors = {input};
+
+  auto plan = exec::test::PlanBuilder()
+                  .values(vectors)
+                  .project({
+                      "a + b AS sum72",
+                      "a - b AS diff72",
+                      "a * b AS mul72",
+                      "a / b AS div72",
+                      "a > b AS gt72",
+                  })
+                  .planNode();
+
+  unregisterCudf();
+  auto cpuResult =
+      facebook::velox::exec::test::AssertQueryBuilder(plan).copyResults(pool());
+  registerCudf();
+  auto gpuResult =
+      facebook::velox::exec::test::AssertQueryBuilder(plan).copyResults(pool());
+
+  facebook::velox::test::assertEqualVectors(cpuResult, gpuResult);
+}
+
+TEST_F(CudfDecimalTest, lowPrecisionDecimal9p2Arithmetic) {
+  auto input = makeRowVector(
+      {"a", "b"},
+      {
+          makeFlatVector<int64_t>(
+              {1'000'000, 2'500'000, -100}, DECIMAL(9, 2)),
+          makeFlatVector<int64_t>({250'000, 500'000, 4}, DECIMAL(9, 2)),
+      });
+  std::vector<RowVectorPtr> vectors = {input};
+
+  auto plan = exec::test::PlanBuilder()
+                  .values(vectors)
+                  .project({
+                      "a + b AS sum92",
+                      "a - b AS diff92",
+                      "a * CAST(2 AS DECIMAL(9, 2)) AS dbl92",
+                  })
+                  .planNode();
+
+  unregisterCudf();
+  auto cpuResult =
+      facebook::velox::exec::test::AssertQueryBuilder(plan).copyResults(pool());
+  registerCudf();
+  auto gpuResult =
+      facebook::velox::exec::test::AssertQueryBuilder(plan).copyResults(pool());
+
+  facebook::velox::test::assertEqualVectors(cpuResult, gpuResult);
+}
+
 } // namespace
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/tests/DecimalWideningTest.cpp
+++ b/velox/experimental/cudf/tests/DecimalWideningTest.cpp
@@ -1,0 +1,343 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/cudf/exec/DecimalAggregationHostOps.h"
+#include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+#include <cudf/column/column_factories.hpp>
+#include <cudf/dictionary/encode.hpp>
+#include <cudf/null_mask.hpp>
+#include <cudf/unary.hpp>
+#include <cudf/utilities/default_stream.hpp>
+
+#include <cuda_runtime_api.h>
+
+#include <limits>
+#include <vector>
+
+namespace facebook::velox::cudf_velox {
+namespace {
+
+constexpr int kBitsPerWord = 8 * sizeof(cudf::bitmask_type);
+
+std::pair<rmm::device_buffer, cudf::size_type> makeNullMask(
+    const std::vector<bool>& valid,
+    rmm::cuda_stream_view stream) {
+  auto numBits = static_cast<cudf::size_type>(valid.size());
+  if (numBits == 0) {
+    return {rmm::device_buffer{}, 0};
+  }
+  auto maskBytes = cudf::bitmask_allocation_size_bytes(numBits);
+  auto numWords = maskBytes / sizeof(cudf::bitmask_type);
+  std::vector<cudf::bitmask_type> host(numWords, 0);
+  cudf::size_type nullCount = 0;
+  for (cudf::size_type i = 0; i < numBits; ++i) {
+    if (valid[i]) {
+      auto word = i / kBitsPerWord;
+      auto bit = i % kBitsPerWord;
+      host[word] |= (cudf::bitmask_type{1} << bit);
+    } else {
+      ++nullCount;
+    }
+  }
+  rmm::device_buffer mask(maskBytes, stream);
+  if (!host.empty()) {
+    auto status = cudaMemcpyAsync(
+        mask.data(),
+        host.data(),
+        host.size() * sizeof(cudf::bitmask_type),
+        cudaMemcpyHostToDevice,
+        stream.value());
+    VELOX_CHECK_EQ(0, static_cast<int>(status));
+    stream.synchronize();
+  }
+  return {std::move(mask), nullCount};
+}
+
+template <typename T>
+std::unique_ptr<cudf::column> makeFixedWidthColumn(
+    cudf::data_type type,
+    const std::vector<T>& values,
+    const std::vector<bool>* valid,
+    rmm::cuda_stream_view stream) {
+  auto col = cudf::make_fixed_width_column(
+      type,
+      static_cast<cudf::size_type>(values.size()),
+      cudf::mask_state::UNALLOCATED,
+      stream);
+  if (!values.empty()) {
+    auto status = cudaMemcpyAsync(
+        col->mutable_view().data<T>(),
+        values.data(),
+        values.size() * sizeof(T),
+        cudaMemcpyHostToDevice,
+        stream.value());
+    VELOX_CHECK_EQ(0, static_cast<int>(status));
+    stream.synchronize();
+  }
+  if (valid) {
+    auto [mask, nullCount] = makeNullMask(*valid, stream);
+    col->set_null_mask(std::move(mask), nullCount);
+  }
+  return col;
+}
+
+std::unique_ptr<cudf::column> makeDecimal32Column(
+    const std::vector<int32_t>& values,
+    int32_t scale,
+    const std::vector<bool>* valid,
+    rmm::cuda_stream_view stream) {
+  cudf::data_type type{cudf::type_id::DECIMAL32, -scale};
+  return makeFixedWidthColumn(type, values, valid, stream);
+}
+
+template <typename T>
+std::vector<T> copyColumnData(
+    const cudf::column_view& view,
+    rmm::cuda_stream_view stream) {
+  std::vector<T> host(view.size());
+  if (view.size() == 0) {
+    return host;
+  }
+  auto status = cudaMemcpyAsync(
+      host.data(),
+      view.data<T>(),
+      view.size() * sizeof(T),
+      cudaMemcpyDeviceToHost,
+      stream.value());
+  VELOX_CHECK_EQ(0, static_cast<int>(status));
+  stream.synchronize();
+  return host;
+}
+
+std::vector<cudf::bitmask_type> copyNullMask(
+    const cudf::column_view& view,
+    rmm::cuda_stream_view stream) {
+  auto numWords = cudf::num_bitmask_words(view.size());
+  std::vector<cudf::bitmask_type> host(numWords, 0);
+  if (!view.nullable() || numWords == 0) {
+    return host;
+  }
+  auto status = cudaMemcpyAsync(
+      host.data(),
+      view.null_mask(),
+      host.size() * sizeof(cudf::bitmask_type),
+      cudaMemcpyDeviceToHost,
+      stream.value());
+  VELOX_CHECK_EQ(0, static_cast<int>(status));
+  stream.synchronize();
+  return host;
+}
+
+bool isValidAt(const std::vector<cudf::bitmask_type>& mask, size_t idx) {
+  if (mask.empty()) {
+    return true;
+  }
+  auto word = idx / kBitsPerWord;
+  auto bit = idx % kBitsPerWord;
+  return (mask[word] >> bit) & 1;
+}
+
+void skipIfDecimal32To64CastUnsupported(int32_t scale) {
+  const cudf::data_type src{cudf::type_id::DECIMAL32, -scale};
+  const cudf::data_type dst{cudf::type_id::DECIMAL64, -scale};
+  if (!cudf::is_supported_cast(src, dst)) {
+    GTEST_SKIP() << "libcudf does not support DECIMAL32 to DECIMAL64 cast";
+  }
+}
+
+class DecimalWideningTest : public ::testing::Test,
+                            public facebook::velox::test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  void SetUp() override {
+    int deviceCount = 0;
+    auto status = cudaGetDeviceCount(&deviceCount);
+    if (status != cudaSuccess) {
+      GTEST_SKIP() << "cudaGetDeviceCount failed: " << static_cast<int>(status)
+                   << " (" << cudaGetErrorString(status) << ")";
+    }
+    if (deviceCount == 0) {
+      GTEST_SKIP() << "No CUDA devices visible (check CUDA_VISIBLE_DEVICES)";
+    }
+    VELOX_CHECK_EQ(0, static_cast<int>(cudaSetDevice(0)));
+    VELOX_CHECK_EQ(0, static_cast<int>(cudaFree(nullptr)));
+  }
+};
+
+TEST_F(DecimalWideningTest, castDecimal32InputToDecimal64PreservesValues) {
+  skipIfDecimal32To64CastUnsupported(2);
+
+  auto stream = cudf::get_default_stream();
+  const std::vector<int32_t> inputValues = {
+      1111, -2222, 0, 99999, std::numeric_limits<int32_t>::min()};
+  const std::vector<bool> valid = {true, true, true, true, false};
+  auto inputCol =
+      makeDecimal32Column(inputValues, 2, &valid, stream);
+
+  std::unique_ptr<cudf::column> holder;
+  auto widened =
+      castDecimal32InputToDecimal64(inputCol->view(), holder, stream);
+  ASSERT_NE(holder, nullptr);
+  EXPECT_EQ(widened.type().id(), cudf::type_id::DECIMAL64);
+  EXPECT_EQ(widened.type().scale(), inputCol->type().scale());
+
+  auto outputValues = copyColumnData<int64_t>(widened, stream);
+  auto outputMask = copyNullMask(widened, stream);
+  ASSERT_EQ(outputValues.size(), inputValues.size());
+  for (size_t i = 0; i < inputValues.size(); ++i) {
+    if (!isValidAt(outputMask, i)) {
+      continue;
+    }
+    EXPECT_EQ(outputValues[i], static_cast<int64_t>(inputValues[i])) << "at " << i;
+  }
+}
+
+TEST_F(DecimalWideningTest, castDecimal32InputToDecimal64NoOpForDecimal64) {
+  auto stream = cudf::get_default_stream();
+  const std::vector<int64_t> values = {100, -200};
+  cudf::data_type type{cudf::type_id::DECIMAL64, -2};
+  auto inputCol = makeFixedWidthColumn(type, values, nullptr, stream);
+
+  std::unique_ptr<cudf::column> holder;
+  auto result = castDecimal32InputToDecimal64(inputCol->view(), holder, stream);
+  EXPECT_EQ(holder, nullptr);
+  EXPECT_EQ(result.type().id(), cudf::type_id::DECIMAL64);
+  EXPECT_EQ(copyColumnData<int64_t>(result, stream), values);
+}
+
+TEST_F(DecimalWideningTest, alignTableColumnsToOutputTypeWidensDecimal32) {
+  skipIfDecimal32To64CastUnsupported(2);
+
+  auto stream = cudf::get_default_stream();
+  auto mr = cudf::get_current_device_resource_ref();
+
+  const std::vector<int32_t> decimalValues = {1111, 2222, 3333};
+  const std::vector<int64_t> bigintValues = {10, 20, 30};
+  auto decimalCol = makeDecimal32Column(decimalValues, 2, nullptr, stream);
+  auto bigintCol = makeFixedWidthColumn(
+      cudf::data_type{cudf::type_id::INT64}, bigintValues, nullptr, stream);
+
+  std::vector<std::unique_ptr<cudf::column>> columns;
+  columns.push_back(std::move(decimalCol));
+  columns.push_back(std::move(bigintCol));
+  auto table = std::make_unique<cudf::table>(std::move(columns));
+
+  auto outputType = ROW({"a", "b"}, {DECIMAL(7, 2), BIGINT()});
+  auto aligned =
+      alignTableColumnsToOutputType(std::move(table), outputType, stream, mr);
+  ASSERT_EQ(aligned->num_columns(), 2);
+  EXPECT_EQ(aligned->view().column(0).type().id(), cudf::type_id::DECIMAL64);
+  EXPECT_EQ(aligned->view().column(1).type().id(), cudf::type_id::INT64);
+
+  auto widenedValues =
+      copyColumnData<int64_t>(aligned->view().column(0), stream);
+  ASSERT_EQ(widenedValues.size(), decimalValues.size());
+  for (size_t i = 0; i < decimalValues.size(); ++i) {
+    EXPECT_EQ(widenedValues[i], static_cast<int64_t>(decimalValues[i]));
+  }
+
+  auto bigintOut =
+      copyColumnData<int64_t>(aligned->view().column(1), stream);
+  EXPECT_EQ(bigintOut, bigintValues);
+}
+
+TEST_F(DecimalWideningTest, alignTableColumnsToOutputTypeNoOpWhenAlreadyAligned) {
+  auto stream = cudf::get_default_stream();
+  auto mr = cudf::get_current_device_resource_ref();
+
+  const std::vector<int64_t> values = {100, 200};
+  cudf::data_type type{cudf::type_id::DECIMAL64, -2};
+  auto col = makeFixedWidthColumn(type, values, nullptr, stream);
+  auto* rawData = col->view().data<int64_t>();
+
+  std::vector<std::unique_ptr<cudf::column>> columns;
+  columns.push_back(std::move(col));
+  auto table = std::make_unique<cudf::table>(std::move(columns));
+
+  auto outputType = ROW({"a"}, {DECIMAL(5, 2)});
+  auto aligned =
+      alignTableColumnsToOutputType(std::move(table), outputType, stream, mr);
+  ASSERT_EQ(aligned->num_columns(), 1);
+  EXPECT_EQ(aligned->view().column(0).type().id(), cudf::type_id::DECIMAL64);
+  EXPECT_EQ(aligned->view().column(0).data<int64_t>(), rawData);
+}
+
+TEST_F(DecimalWideningTest, alignedDecimal32RoundTripsToVelox) {
+  skipIfDecimal32To64CastUnsupported(2);
+
+  auto stream = cudf::get_default_stream();
+  auto mr = cudf::get_current_device_resource_ref();
+
+  const std::vector<int32_t> values = {1111, -1111, 0};
+  const std::vector<bool> valid = {true, true, false};
+  auto decimalCol = makeDecimal32Column(values, 2, &valid, stream);
+
+  std::vector<std::unique_ptr<cudf::column>> columns;
+  columns.push_back(std::move(decimalCol));
+  auto table = std::make_unique<cudf::table>(std::move(columns));
+
+  auto outputType = ROW({"a"}, {DECIMAL(7, 2)});
+  auto aligned =
+      alignTableColumnsToOutputType(std::move(table), outputType, stream, mr);
+
+  auto expected = makeRowVector(
+      {"a"},
+      {makeNullableFlatVector<int64_t>(
+          {1111, -1111, std::nullopt}, DECIMAL(7, 2))});
+  auto result = with_arrow::toVeloxColumn(
+      aligned->view(), pool_.get(), outputType, stream, mr);
+  stream.synchronize();
+  facebook::velox::test::assertEqualVectors(expected, result);
+}
+
+TEST_F(DecimalWideningTest, alignTableColumnsToOutputTypeWidensDictionaryDecimal32) {
+  skipIfDecimal32To64CastUnsupported(2);
+
+  auto stream = cudf::get_default_stream();
+  auto mr = cudf::get_current_device_resource_ref();
+
+  const std::vector<int32_t> values = {1111, 1111, 2222, 2222, 3333, 3333};
+  auto decimalCol = makeDecimal32Column(values, 2, nullptr, stream);
+  auto dictionaryCol = cudf::dictionary::encode(
+      decimalCol->view(), cudf::data_type{cudf::type_id::INT32}, stream, mr);
+  VELOX_CHECK(cudf::is_dictionary(dictionaryCol->type()));
+
+  std::vector<std::unique_ptr<cudf::column>> columns;
+  columns.push_back(std::move(dictionaryCol));
+  auto table = std::make_unique<cudf::table>(std::move(columns));
+
+  auto outputType = ROW({"a"}, {DECIMAL(7, 2)});
+  auto aligned =
+      alignTableColumnsToOutputType(std::move(table), outputType, stream, mr);
+  ASSERT_EQ(aligned->num_columns(), 1);
+  EXPECT_EQ(aligned->view().column(0).type().id(), cudf::type_id::DECIMAL64);
+
+  const std::vector<int64_t> expectedValues = {
+      1111, 1111, 2222, 2222, 3333, 3333};
+  auto widenedValues =
+      copyColumnData<int64_t>(aligned->view().column(0), stream);
+  EXPECT_EQ(widenedValues, expectedValues);
+}
+
+} // namespace
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/tests/InteropTest.cpp
+++ b/velox/experimental/cudf/tests/InteropTest.cpp
@@ -14,9 +14,19 @@
  * limitations under the License.
  */
 
+#include "velox/experimental/cudf/exec/DecimalAggregationHostOps.h"
 #include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
 
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
+
+#include <cudf/column/column_factories.hpp>
+#include <cudf/unary.hpp>
+#include <cudf/utilities/default_stream.hpp>
+
+#include <cuda_runtime_api.h>
+
+#include <vector>
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
@@ -449,6 +459,84 @@ TEST_F(InteropTest, constant) {
   auto child = makeConstant<int64_t>(10, 5);
   auto input = makeRowVector({child});
   roundTrip(input);
+}
+
+// ========== Decimal types ==========
+
+TEST_F(InteropTest, shortDecimal5p2) {
+  auto input = makeRowVector(
+      {"c0"},
+      {makeFlatVector<int64_t>(
+          {100, -250, 0, 12345, -9999}, DECIMAL(5, 2))});
+  roundTrip(input);
+}
+
+TEST_F(InteropTest, shortDecimal9p2) {
+  auto input = makeRowVector(
+      {"c0"},
+      {makeFlatVector<int64_t>(
+          {1'111'111'111,
+           -2'222'222'222,
+           0,
+           9'999'999'999,
+           -9'999'999'999},
+          DECIMAL(9, 2))});
+  roundTrip(input);
+}
+
+TEST_F(InteropTest, shortDecimalWithNulls) {
+  auto input = makeRowVector(
+      {"c0"},
+      {makeNullableFlatVector<int64_t>(
+          {100, std::nullopt, -250, std::nullopt, 0}, DECIMAL(5, 2))});
+  roundTrip(input);
+}
+
+TEST_F(InteropTest, decimal32WidenedToVeloxShortDecimal) {
+  int deviceCount = 0;
+  if (cudaGetDeviceCount(&deviceCount) != cudaSuccess || deviceCount == 0) {
+    GTEST_SKIP() << "CUDA device required";
+  }
+  VELOX_CHECK_EQ(0, static_cast<int>(cudaSetDevice(0)));
+
+  const cudf::data_type srcType{cudf::type_id::DECIMAL32, -2};
+  const cudf::data_type dstType{cudf::type_id::DECIMAL64, -2};
+  if (!cudf::is_supported_cast(srcType, dstType)) {
+    GTEST_SKIP() << "libcudf does not support DECIMAL32 to DECIMAL64 cast";
+  }
+
+  auto stream = cudf::get_default_stream();
+  auto mr = cudf::get_current_device_resource_ref();
+
+  const std::vector<int32_t> hostValues = {500, -700, 1234};
+  auto col = cudf::make_fixed_width_column(
+      srcType,
+      static_cast<cudf::size_type>(hostValues.size()),
+      cudf::mask_state::UNALLOCATED,
+      stream);
+  auto status = cudaMemcpyAsync(
+      col->mutable_view().data<int32_t>(),
+      hostValues.data(),
+      hostValues.size() * sizeof(int32_t),
+      cudaMemcpyHostToDevice,
+      stream.value());
+  VELOX_CHECK_EQ(0, static_cast<int>(status));
+  stream.synchronize();
+
+  std::vector<std::unique_ptr<cudf::column>> columns;
+  columns.push_back(std::move(col));
+  auto table = std::make_unique<cudf::table>(std::move(columns));
+
+  auto outputType = ROW({"c0"}, {DECIMAL(5, 2)});
+  auto aligned =
+      alignTableColumnsToOutputType(std::move(table), outputType, stream, mr);
+
+  auto expected = makeRowVector(
+      {"c0"}, {makeFlatVector<int64_t>({500, -700, 1234}, DECIMAL(5, 2))});
+  auto result = with_arrow::toVeloxColumn(
+      aligned->view(), pool_.get(), outputType, stream, mr);
+  stream.synchronize();
+  test::assertEqualVectors(expected, result);
 }
 
 } // namespace

--- a/velox/experimental/cudf/tests/TableScanTest.cpp
+++ b/velox/experimental/cudf/tests/TableScanTest.cpp
@@ -45,6 +45,7 @@
 
 #include <cudf/io/parquet.hpp>
 
+#include <filesystem>
 #include <fmt/ranges.h>
 
 using namespace facebook::velox;
@@ -87,6 +88,19 @@ StatsFilterMetrics readParquetWithStatsFilter(
       result.metadata.num_input_row_groups,
       result.metadata.num_row_groups_after_stats_filter,
       result.tbl->num_rows()};
+}
+
+std::string getExampleParquetPath(const std::string& fileName) {
+  const std::string relativePath =
+      "../../../dwio/parquet/tests/examples/" + fileName;
+  auto path = facebook::velox::test::getDataFilePath(
+      "velox/experimental/cudf/tests", relativePath);
+  if (std::filesystem::exists(path)) {
+    return path;
+  }
+  return (std::filesystem::current_path() / relativePath)
+      .lexically_normal()
+      .string();
 }
 } // namespace
 
@@ -785,6 +799,41 @@ TEST_F(TableScanTest, decimalSubfieldFilter) {
       plan,
       {filePath},
       "SELECT c0, c1 FROM tmp WHERE c0 = CAST('-5.00' AS DECIMAL(5, 2))");
+}
+
+TEST_F(TableScanTest, decimalDictParquetInt32Physical) {
+  const auto filePath = getExampleParquetPath("decimal_dict.parquet");
+  if (!std::filesystem::exists(filePath)) {
+    GTEST_SKIP() << "Missing fixture: " << filePath;
+  }
+
+  auto rowType = ROW({"a", "b"}, {DECIMAL(7, 2), DECIMAL(14, 2)});
+  auto expected = makeRowVector(
+      {"a", "b"},
+      {
+          makeFlatVector<int64_t>(
+              {1111, 1111, 2222, 2222, 3333, 3333}, DECIMAL(7, 2)),
+          makeFlatVector<int64_t>(
+              {1111, 1111, 2222, 2222, 3333, 3333}, DECIMAL(14, 2)),
+      });
+
+  auto tableHandle = makeTableHandle("parquet_table", rowType, {}, nullptr);
+  auto assignments =
+      facebook::velox::exec::test::HiveConnectorTestBase::allRegularColumns(
+          rowType);
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .outputType(rowType)
+                  .tableHandle(tableHandle)
+                  .assignments(assignments)
+                  .endTableScan()
+                  .planNode();
+
+  // DuckDB's appender crashes on DECIMAL(7, 2); compare against fixture values.
+  AssertQueryBuilder(plan)
+      .splits({makeCudfHiveSplit(filePath)})
+      .assertResults(expected);
 }
 
 TEST_F(TableScanTest, decimalRemainingFilter) {

--- a/velox/experimental/cudf/vector/CudfVector.cpp
+++ b/velox/experimental/cudf/vector/CudfVector.cpp
@@ -29,72 +29,17 @@
 namespace facebook::velox::cudf_velox {
 namespace {
 
-/// Calculates the total memory size in bytes of a cudf column and reconstructs
-/// it.
-///
-/// This function disassembles a cudf column to access its underlying memory
-/// buffers, calculates the total size including children columns (for nested
-/// types), and then reassembles the column.
-///
-/// @return A pair containing the total size in bytes and the reconstructed
-/// column
-std::pair<uint64_t, std::unique_ptr<cudf::column>> getColumnSize(
-    std::unique_ptr<cudf::column> column) {
-  // Store column metadata (type, null count, and size) before releasing it,
-  // as the release() operation transfers ownership of the underlying buffers
-  // and invalidates access to these properties.
-  auto type = column->type();
-  auto nullCount = column->null_count();
-  auto size = column->size();
-
-  auto contents = column->release();
-  auto bytes = contents.data->size() + contents.null_mask->size();
-
-  // Recursively get the size of the children columns.
-  std::vector<std::unique_ptr<cudf::column>> children;
-  for (auto& child : contents.children) {
-    auto [childBytes, childColumn] = getColumnSize(std::move(child));
-    bytes += childBytes;
-    children.push_back(std::move(childColumn));
-  }
-
-  // Reassemble the column with the original metadata.
-  auto reconstitutedColumn = std::make_unique<cudf::column>(
-      type,
-      size,
-      std::move(*contents.data.release()),
-      std::move(*contents.null_mask.release()),
-      nullCount,
-      std::move(children));
-
-  return std::make_pair(bytes, std::move(reconstitutedColumn));
-}
-
-/// Calculates the total memory size in bytes of a cudf table and reconstructs
-/// it.
-///
-/// This function disassembles a cudf table to access its underlying columns,
-/// calculates the total size, and then reassembles the table.
-///
-/// @note This is a workaround because cudf::table doesn't have an API to get
-/// this information without involving estimation and d->h copies.
-/// @see https://github.com/rapidsai/cudf/issues/18462
-///
-/// @return A pair containing the total size in bytes and the reconstructed
-/// table
-std::pair<uint64_t, std::unique_ptr<cudf::table>> getTableSize(
-    std::unique_ptr<cudf::table>&& table) {
+/// Returns total device allocation bytes for a table without disassembling
+/// columns. The previous release/reconstitute path corrupted dictionary columns
+/// (e.g. dictionary-encoded decimals from Parquet) and could segfault.
+uint64_t tableAllocSize(std::unique_ptr<cudf::table>& table) {
   auto columns = table->release();
-  std::vector<std::unique_ptr<cudf::column>> columnsOut;
   uint64_t totalBytes = 0;
-
   for (auto& column : columns) {
-    auto [bytes, columnOut] = getColumnSize(std::move(column));
-    totalBytes += bytes;
-    columnsOut.push_back(std::move(columnOut));
+    totalBytes += column->alloc_size();
   }
-  return std::make_pair(
-      totalBytes, std::make_unique<cudf::table>(std::move(columnsOut)));
+  table = std::make_unique<cudf::table>(std::move(columns));
+  return totalBytes;
 }
 
 void logDefaultStreamIfNeeded(
@@ -127,9 +72,7 @@ CudfVector::CudfVector(
       stream_{stream} {
   logDefaultStreamIfNeeded(stream_, "CudfVector(table)");
   auto& tablePtr = std::get<std::unique_ptr<cudf::table>>(tableStorage_);
-  auto [bytes, tableOut] = getTableSize(std::move(tablePtr));
-  flatSize_ = bytes;
-  tablePtr = std::move(tableOut);
+  flatSize_ = tableAllocSize(tablePtr);
   tabView_ = tablePtr->view();
 }
 

--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -1396,7 +1396,7 @@ void exportToArrowImpl(
 
 // Parses the velox decimal format from the given arrow format.
 // The input format string should be in the form "d:precision,scale<,bitWidth>".
-// bitWidth is optional and may be 64 or 128 if provided.
+// bitWidth is optional and may be 32, 64, or 128 if provided.
 
 int32_t parseDecimalBitWidthOrDefault(const std::string_view format) {
   auto firstCommaIdx = format.find(',', 2);
@@ -1431,16 +1431,16 @@ TypePtr parseDecimalFormat(const std::string_view format) {
     int precision = std::stoi(&format[2], &sz);
     int scale = std::stoi(&format[firstCommaIdx + 1], &sz);
     if (secondCommaIdx != std::string_view::npos) {
-      // BitWidth is provided. We only support 64 or 128.
+      // BitWidth is provided. We support 32, 64, or 128.
       int bitWidth = std::stoi(&format[secondCommaIdx + 1], &sz);
       // Return type depends on bitWidth.
-      if (bitWidth == 64) {
+      if (bitWidth == 32 || bitWidth == 64) {
         return std::make_shared<ShortDecimalType>(precision, scale);
       } else if (bitWidth == 128) {
         return std::make_shared<LongDecimalType>(precision, scale);
       }
       VELOX_USER_FAIL(
-          "Conversion failed for '{}'. Only 64-bit and 128-bit decimal types are supported.",
+          "Conversion failed for '{}'. Only 32-bit, 64-bit, and 128-bit decimal types are supported.",
           format);
     }
     // Otherwise return type depends on precision.
@@ -2258,6 +2258,23 @@ VectorPtr createShortDecimalVectorFromLongDecimals(
       pool, type, std::move(nulls), length, values, nullCount);
 }
 
+VectorPtr createShortDecimalVectorFromInt32Decimals(
+    memory::MemoryPool* pool,
+    const TypePtr& type,
+    BufferPtr nulls,
+    const int32_t* input,
+    vector_size_t length,
+    int64_t nullCount) {
+  auto values = AlignedBuffer::allocate<int64_t>(length, pool);
+  auto rawValues = values->asMutable<int64_t>();
+  for (size_t i = 0; i < length; ++i) {
+    rawValues[i] = static_cast<int64_t>(input[i]);
+  }
+
+  return createFlatVector<TypeKind::BIGINT>(
+      pool, type, std::move(nulls), length, values, nullCount);
+}
+
 // Arrow uses two uint64_t values to represent a 128-bit decimal value. The
 // memory allocated by Arrow might not be 16-byte aligned, so we need to copy
 // the values to a new buffer to ensure 16-byte alignment.
@@ -2408,6 +2425,15 @@ VectorPtr importFromArrowImpl(
   } else if (type->isShortDecimal()) {
     // Validate the format bitWidth.
     const auto bitWidth = parseDecimalBitWidthOrDefault(arrowSchema.format);
+    if (bitWidth == 32) {
+      return createShortDecimalVectorFromInt32Decimals(
+          pool,
+          type,
+          nulls,
+          static_cast<const int32_t*>(arrowArray.buffers[1]),
+          arrowArray.length,
+          arrowArray.null_count);
+    }
     if (bitWidth == 64) {
       return createShortDecimalVector(
           pool,
@@ -2418,7 +2444,7 @@ VectorPtr importFromArrowImpl(
           arrowArray.null_count,
           wrapInBufferView);
     }
-    // Otherwise convert to 128.
+    // Otherwise convert from 128-bit storage.
     VELOX_USER_CHECK_EQ(
         bitWidth,
         128,

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -1281,6 +1281,13 @@ class ArrowBridgeArrayImportTest : public ArrowBridgeArrayExportTest {
       if (format[0] == 't' && format[1] == 't') {
         assertTimeVectorContent(
             inputValues, output, arrowArray.null_count, format);
+      } else if (format[0] == 'd') {
+        if constexpr (std::is_same_v<TInput, int32_t>) {
+          assertShortDecimalVectorContentFromInt32(
+              inputValues, output, arrowArray.null_count);
+        } else {
+          assertVectorContent(inputValues, output, arrowArray.null_count);
+        }
       } else {
         assertVectorContent(inputValues, output, arrowArray.null_count);
       }
@@ -1393,6 +1400,18 @@ class ArrowBridgeArrayImportTest : public ArrowBridgeArrayExportTest {
 
     testArrowImport<int64_t, int128_t>(
         "d:5,2", {1, -1, 0, 12345, -12345, std::nullopt});
+    testArrowImport<int64_t, int32_t>(
+        "d:7,2,32", {1, -1, 0, 12345, -12345, std::nullopt});
+    testArrowImport<int64_t, int32_t>(
+        "d:9,1,32",
+        {10,
+         -10,
+         0,
+         123456789,
+         -123456789,
+         std::numeric_limits<int32_t>::max(),
+         std::numeric_limits<int32_t>::min(),
+         std::nullopt});
     testArrowImport<int128_t, int128_t>(
         "d:36,2",
         {HugeInt::parse("20000000000000000"),
@@ -1624,6 +1643,22 @@ class ArrowBridgeArrayImportTest : public ArrowBridgeArrayExportTest {
   // with the expected values.
   void assertShortDecimalVectorContent(
       const std::vector<std::optional<int128_t>>& expectedValues,
+      const VectorPtr& actual,
+      size_t nullCount) {
+    std::vector<std::optional<int64_t>> decValues;
+    decValues.reserve(expectedValues.size());
+    for (const auto& value : expectedValues) {
+      if (value) {
+        decValues.emplace_back(static_cast<int64_t>(*value));
+      } else {
+        decValues.emplace_back(std::nullopt);
+      }
+    }
+    assertVectorContent(decValues, actual, nullCount);
+  }
+
+  void assertShortDecimalVectorContentFromInt32(
+      const std::vector<std::optional<int32_t>>& expectedValues,
       const VectorPtr& actual,
       size_t nullCount) {
     std::vector<std::optional<int64_t>> decValues;

--- a/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
@@ -509,10 +509,12 @@ TEST_F(ArrowBridgeSchemaImportTest, scalar) {
       *testSchemaImport("d2,15"),
       "Unable to convert 'd2,15' ArrowSchema decimal format to Velox decimal");
   EXPECT_EQ(*DECIMAL(10, 4), *testSchemaImport("d:10,4,64"));
+  EXPECT_EQ(*DECIMAL(7, 2), *testSchemaImport("d:7,2,32"));
+  EXPECT_EQ(*DECIMAL(9, 1), *testSchemaImport("d:9,1,32"));
   EXPECT_EQ(*DECIMAL(20, 15), *testSchemaImport("d:20,15,128"));
   VELOX_ASSERT_THROW(
       *testSchemaImport("d:10,4,256"),
-      "Conversion failed for 'd:10,4,256'. Only 64-bit and 128-bit decimal types are supported.");
+      "Conversion failed for 'd:10,4,256'. Only 32-bit, 64-bit, and 128-bit decimal types are supported.");
   VELOX_ASSERT_THROW(
       *testSchemaImport("d:10,4,"),
       "Unable to convert 'd:10,4,' ArrowSchema decimal format to Velox decimal");


### PR DESCRIPTION
Speculative changes to support decimal variants that would normally be DECIMAL32 in Presto and CUDF, but not in Velox which does not natively support that type. Such data is widened to DECIMAL64 in order to be processed.

This may be partial or complete BS, and should not be reviewed seriously any time soon, so everyone except maybe for @bdice please ignore for now.