### PR TITLE
feat: Enhance KLL memory allocation for sparse merges

### DIFF
--- a/velox/functions/lib/KllSketch-inl.h
+++ b/velox/functions/lib/KllSketch-inl.h
@@ -333,8 +333,12 @@ uint32_t KllSketch<T, A, C>::insertPosition() {
               detail::computeTotalCapacity(k_, numLevels()) - items_.size();
           delta > 0) {
         // Level zero must be under-populated (otherwise `findLevelToCompact()`
-        // would return 0), just grow it.
-        shiftItems(delta);
+        // would return 0). Grow geometrically instead of materializing the
+        // entire theoretical capacity. This keeps sparse, compacted sketches
+        // small while preserving amortized linear growth.
+        const auto growth =
+            std::min<uint32_t>(delta, std::max<uint32_t>(items_.size(), 1));
+        shiftItems(growth);
         return --levels_[0];
       }
       // It is important to add the new top level right here. Be aware
@@ -679,16 +683,12 @@ void KllSketch<T, A, C>::mergeViews(
         randomBit_);
     VELOX_DCHECK_LE(result.finalNumLevels, ub);
     // Now we need to transfer the results back into "this" sketch.
-    items_.resize(result.finalCapacity);
-    const auto freeSpaceAtBottom = result.finalCapacity - result.finalNumItems;
-    std::move(
-        workbuf.data() + outlevels[0],
-        workbuf.data() + outlevels[0] + result.finalNumItems,
-        items_.data() + freeSpaceAtBottom);
+    VELOX_DCHECK_EQ(outlevels[0], 0);
+    workbuf.resize(result.finalNumItems);
+    items_.swap(workbuf);
     levels_.resize(result.finalNumLevels + 1);
-    const auto offset = freeSpaceAtBottom - outlevels[0];
     for (unsigned lvl = 0; lvl < levels_.size(); ++lvl) {
-      levels_[lvl] = outlevels[lvl] + offset;
+      levels_[lvl] = outlevels[lvl];
     }
   }
   n_ = newN;

--- a/velox/functions/lib/KllSketch-inl.h
+++ b/velox/functions/lib/KllSketch-inl.h
@@ -684,8 +684,11 @@ void KllSketch<T, A, C>::mergeViews(
     VELOX_DCHECK_LE(result.finalNumLevels, ub);
     // Now we need to transfer the results back into "this" sketch.
     VELOX_DCHECK_EQ(outlevels[0], 0);
-    workbuf.resize(result.finalNumItems);
-    items_.swap(workbuf);
+    std::vector<T, A> packed(
+        std::make_move_iterator(workbuf.begin()),
+        std::make_move_iterator(workbuf.begin() + result.finalNumItems),
+        allocator_);
+    items_.swap(packed);
     levels_.resize(result.finalNumLevels + 1);
     for (unsigned lvl = 0; lvl < levels_.size(); ++lvl) {
       levels_[lvl] = outlevels[lvl];

--- a/velox/functions/lib/tests/KllSketchTest.cpp
+++ b/velox/functions/lib/tests/KllSketchTest.cpp
@@ -323,6 +323,25 @@ TEST_F(KllSketchTest, growCompacted) {
   }
 }
 
+TEST_F(KllSketchTest, mergeSparseSketchWithLargeK) {
+  constexpr uint32_t k = 326408;
+
+  auto input = KllSketch<int64_t>::fromRepeatedValue(11, 2, k, {}, 0);
+  KllSketch<int64_t> result(k, {}, 0);
+  result.merge(input);
+
+  EXPECT_LT(result.serializedByteSize(), 1024);
+
+  result.insert(13);
+  result.merge(KllSketch<int64_t>::fromRepeatedValue(17, 4, k, {}, 0));
+
+  EXPECT_EQ(result.totalCount(), 7);
+  EXPECT_LT(result.serializedByteSize(), 1024);
+  result.finish();
+  EXPECT_EQ(result.estimateQuantile(0), 11);
+  EXPECT_EQ(result.estimateQuantile(1), 17);
+}
+
 TEST_F(KllSketchTest, fromRepeatedValue) {
   constexpr int N = 1000;
   constexpr int kTotal = (1 + N) * N / 2;

--- a/velox/functions/lib/tests/KllSketchTest.cpp
+++ b/velox/functions/lib/tests/KllSketchTest.cpp
@@ -324,7 +324,7 @@ TEST_F(KllSketchTest, growCompacted) {
 }
 
 TEST_F(KllSketchTest, mergeSparseSketchWithLargeK) {
-  constexpr uint32_t k = 326408;
+  constexpr uint32_t k = 326'408;
 
   auto input = KllSketch<int64_t>::fromRepeatedValue(11, 2, k, {}, 0);
   KllSketch<int64_t> result(k, {}, 0);


### PR DESCRIPTION
Current KLL implementation's merge path resized `items_` to `finalCapacity`, even when only a few items were retained. This differs from the initial insert path, which intentionally avoids allocating all `k` elements for small groups.

## Changes
- Keep the compressed merge result packed in `workbuf` and swap it into `items_`.
- Avoid allocating unused space up to `finalCapacity`.
- Grow packed sketches geometrically when additional level-zero space is required, capped by the remaining theoretical capacity.

Fix https://github.com/facebookincubator/velox/issues/18129.