### PR TITLE
refactor: Allow registering collect_list under arbitrary names (#18132)

### DIFF
--- a/velox/functions/sparksql/aggregates/CollectListAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/CollectListAggregate.cpp
@@ -118,8 +118,10 @@ class CollectListAggregate {
   };
 };
 
-AggregateRegistrationResult registerCollectList(
-    const std::string& name,
+} // namespace
+
+void registerCollectListAggregate(
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
@@ -129,14 +131,15 @@ AggregateRegistrationResult registerCollectList(
           .intermediateType("array(E)")
           .argumentType("E")
           .build()};
-  return exec::registerAggregateFunction(
-      name,
+  exec::registerAggregateFunction(
+      names,
       std::move(signatures),
-      [name](
+      [names](
           core::AggregationNode::Step step,
           const std::vector<TypePtr>& argTypes,
           const TypePtr& resultType,
           const core::QueryConfig& config) -> std::unique_ptr<exec::Aggregate> {
+        const std::string& name = names.front();
         VELOX_CHECK_EQ(
             argTypes.size(), 1, "{} takes at most one argument", name);
         return std::make_unique<SimpleAggregateAdapter<CollectListAggregate>>(
@@ -144,14 +147,5 @@ AggregateRegistrationResult registerCollectList(
       },
       withCompanionFunctions,
       overwrite);
-}
-} // namespace
-
-void registerCollectListAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite) {
-  registerCollectList(
-      prefix + "collect_list", withCompanionFunctions, overwrite);
 }
 } // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/CollectListAggregate.h
+++ b/velox/functions/sparksql/aggregates/CollectListAggregate.h
@@ -17,11 +17,17 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::functions::aggregate::sparksql {
 
+/// Register collect_list aggregate function.
+/// @param names Names to use for the aggregate function.
+/// @param withCompanionFunctions Also register companion functions.
+/// @param overwrite Whether to overwrite existing entry in the function
+/// registry.
 void registerCollectListAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 

--- a/velox/functions/sparksql/aggregates/Register.cpp
+++ b/velox/functions/sparksql/aggregates/Register.cpp
@@ -70,7 +70,8 @@ void registerAggregateFunctions(
   registerSum(prefix + "sum", withCompanionFunctions, overwrite);
   registerCentralMomentsAggregate(prefix, withCompanionFunctions, overwrite);
   registerCollectSetAggAggregate(prefix, withCompanionFunctions, overwrite);
-  registerCollectListAggregate(prefix, withCompanionFunctions, overwrite);
+  registerCollectListAggregate(
+      {prefix + "collect_list"}, withCompanionFunctions, overwrite);
   registerRegrReplacementAggregate(prefix, withCompanionFunctions, overwrite);
   registerModeAggregate(prefix, withCompanionFunctions, overwrite);
   registerVarianceAggregate(prefix, withCompanionFunctions, overwrite);


### PR DESCRIPTION
Summary:

The collect_list aggregate hardcodes the name it registers under. A caller that wants to reuse the implementation under a different name has to register it once and then copy the factory to the new name. This changes registerCollectListAggregate to accept a list of names instead of a fixed prefix, letting any caller register collect_list under the names it needs. This mirrors the pattern already used for the prestosql aggregates.

Reviewed By: kevinwilfong

Differential Revision: D112007150


