### PR TITLE
fix(type): Guard NegatedBigintRange::mergeWith overflow (#18133)

### DIFF
--- a/velox/type/Filter.cpp
+++ b/velox/type/Filter.cpp
@@ -1928,7 +1928,8 @@ std::unique_ptr<Filter> NegatedBigintRange::mergeWith(
         return other->mergeWith(this);
       }
       assert(this->lower() <= otherNegatedRange->lower());
-      if (this->upper() + 1 < otherNegatedRange->lower()) {
+      if (this->upper() < std::numeric_limits<int64_t>::max() &&
+          this->upper() + 1 < otherNegatedRange->lower()) {
         std::vector<std::unique_ptr<common::BigintRange>> outRanges;
         int64_t smallLower = this->lower();
         int64_t smallUpper = this->upper();

--- a/velox/type/tests/FilterTest.cpp
+++ b/velox/type/tests/FilterTest.cpp
@@ -815,6 +815,16 @@ TEST(FilterTest, bigintOrWithBoundaryOverflow) {
   EXPECT_FALSE(filter->testInt64(50));
 }
 
+TEST(FilterTest, negatedBigintRangeMergeWithBoundaryOverflow) {
+  const int64_t kInt64Max = std::numeric_limits<int64_t>::max();
+  auto merged =
+      notBetween(-118, kInt64Max)->mergeWith(notBetween(284, 479).get());
+  ASSERT_EQ(merged->kind(), FilterKind::kNegatedBigintRange);
+  EXPECT_TRUE(merged->testInt64(-119));
+  EXPECT_FALSE(merged->testInt64(-118));
+  EXPECT_FALSE(merged->testInt64(kInt64Max));
+}
+
 TEST(FilterTest, boolValue) {
   auto boolValueTrue = boolEqual(true);
   EXPECT_TRUE(boolValueTrue->testBool(true));
@@ -1795,6 +1805,7 @@ TEST(FilterTest, mergeWithBigint) {
   filters.push_back(notIn({kInt64Min, kInt64Max}));
   filters.push_back(between(kInt64Min, 0));
   filters.push_back(between(0, kInt64Max));
+  filters.push_back(notBetween(-118, kInt64Max));
 
   for (const auto& left : filters) {
     for (const auto& right : filters) {


### PR DESCRIPTION
Summary:

`NegatedBigintRange::mergeWith` computes `this->upper() + 1 < otherNegatedRange->lower()` to detect the disjoint case. When `this->upper() == INT64_MAX`, `+1` wraps to `INT64_MIN`, the comparison is spuriously true, and the merge takes the disjoint branch — emitting `col < smallLower OR col > bigUpper` instead of `col < smallLower`.

Example: merging `NOT BETWEEN -118 AND INT64_MAX` with `NOT BETWEEN 284 AND 479` produces `BigintMultiRange: [[INT64_MIN, -119], [480, INT64_MAX]]` instead of the correct `col < -118`.

Guard the disjoint-branch test with an explicit `this->upper() < INT64_MAX` check.

Reviewed By: Yuhta

Differential Revision: D112010147


