### PR TITLE
fix(expr): Dedup values in tryMergeBigintRanges (#18134)

### DIFF
--- a/velox/expression/ExprToSubfieldFilter.cpp
+++ b/velox/expression/ExprToSubfieldFilter.cpp
@@ -802,6 +802,8 @@ std::unique_ptr<common::Filter> tryMergeBigintRanges(
       values.emplace_back(filter->as<common::BigintRange>()->lower());
     }
 
+    std::sort(values.begin(), values.end());
+    values.erase(std::unique(values.begin(), values.end()), values.end());
     return common::createBigintValues(values, isNullAllowed(disjuncts));
   }
 

--- a/velox/expression/tests/ExprToSubfieldFilterTest.cpp
+++ b/velox/expression/tests/ExprToSubfieldFilterTest.cpp
@@ -403,6 +403,16 @@ TEST_F(ExprToSubfieldFilterTest, makeOrFilterBigint) {
     VELOX_ASSERT_FILTER(expected, makeOr(greaterThan(10), between(12, 100)));
     VELOX_ASSERT_FILTER(expected, makeOr(between(12, 100), greaterThan(10)));
   }
+
+  // a = X or a = X collapses to a = X.
+  {
+    const int64_t kInt64Max = std::numeric_limits<int64_t>::max();
+    VELOX_ASSERT_FILTER(
+        equal(kInt64Max), makeOr(equal(kInt64Max), equal(kInt64Max)));
+    VELOX_ASSERT_FILTER(equal(7), makeOr(equal(7), equal(7)));
+    VELOX_ASSERT_FILTER(
+        in({3, 5}), makeOr(equal(3), equal(5), equal(3), equal(5)));
+  }
 }
 
 TEST_F(ExprToSubfieldFilterTest, makeOrFilterDouble) {

--- a/velox/type/Filter.cpp
+++ b/velox/type/Filter.cpp
@@ -1928,7 +1928,8 @@ std::unique_ptr<Filter> NegatedBigintRange::mergeWith(
         return other->mergeWith(this);
       }
       assert(this->lower() <= otherNegatedRange->lower());
-      if (this->upper() + 1 < otherNegatedRange->lower()) {
+      if (this->upper() < std::numeric_limits<int64_t>::max() &&
+          this->upper() + 1 < otherNegatedRange->lower()) {
         std::vector<std::unique_ptr<common::BigintRange>> outRanges;
         int64_t smallLower = this->lower();
         int64_t smallUpper = this->upper();

--- a/velox/type/tests/FilterTest.cpp
+++ b/velox/type/tests/FilterTest.cpp
@@ -815,6 +815,16 @@ TEST(FilterTest, bigintOrWithBoundaryOverflow) {
   EXPECT_FALSE(filter->testInt64(50));
 }
 
+TEST(FilterTest, negatedBigintRangeMergeWithBoundaryOverflow) {
+  const int64_t kInt64Max = std::numeric_limits<int64_t>::max();
+  auto merged =
+      notBetween(-118, kInt64Max)->mergeWith(notBetween(284, 479).get());
+  ASSERT_EQ(merged->kind(), FilterKind::kNegatedBigintRange);
+  EXPECT_TRUE(merged->testInt64(-119));
+  EXPECT_FALSE(merged->testInt64(-118));
+  EXPECT_FALSE(merged->testInt64(kInt64Max));
+}
+
 TEST(FilterTest, boolValue) {
   auto boolValueTrue = boolEqual(true);
   EXPECT_TRUE(boolValueTrue->testBool(true));
@@ -1795,6 +1805,7 @@ TEST(FilterTest, mergeWithBigint) {
   filters.push_back(notIn({kInt64Min, kInt64Max}));
   filters.push_back(between(kInt64Min, 0));
   filters.push_back(between(0, kInt64Max));
+  filters.push_back(notBetween(-118, kInt64Max));
 
   for (const auto& left : filters) {
     for (const auto& right : filters) {


### PR DESCRIPTION
Summary:

`tryMergeBigintRanges` takes N single-value `BigintRange` disjuncts and hands their `lower()` values to `common::createBigintValues`. When the disjuncts contain duplicates (e.g. `col = X OR col = X`), the `values` vector arrives at `createBigintValuesFilter` with duplicates. The `range + 1 == values.size()` contiguous-range short-circuit fails, control falls into the `BigintValuesUsingBitmask` branch, and `VELOX_CHECK_LT(min, max)` triggers because `min == max == X`.

Example crash: `col >= INT64_MAX OR col = INT64_MAX` — both disjuncts collapse to `BigintRange(INT64_MAX, INT64_MAX)`; the ctor blows up with `min: 9223372036854775807, max: 9223372036854775807`.

Sort + unique the `values` vector before the `createBigintValues` call so the distinct-values invariant that `createBigintValuesFilter` assumes is preserved.

Reviewed By: Yuhta

Differential Revision: D112010149


