### PR TITLE
feat(exec): Enforce NOT NULL constraints on table writes

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -3076,7 +3076,8 @@ TableWriteNode::TableWriteNode(
     bool hasPartitioningScheme,
     RowTypePtr outputType,
     connector::CommitStrategy commitStrategy,
-    const PlanNodePtr& source)
+    const PlanNodePtr& source,
+    std::optional<std::vector<std::string>> notNullColumnNames)
     : PlanNode(id),
       sources_{source},
       columns_{columns},
@@ -3085,7 +3086,8 @@ TableWriteNode::TableWriteNode(
       insertTableHandle_(std::move(insertTableHandle)),
       hasPartitioningScheme_(hasPartitioningScheme),
       outputType_(std::move(outputType)),
-      commitStrategy_(commitStrategy) {
+      commitStrategy_(commitStrategy),
+      notNullColumnNames_(std::move(notNullColumnNames)) {
   VELOX_USER_CHECK_NOT_NULL(sources_[0]);
   VELOX_USER_CHECK_NOT_NULL(insertTableHandle_);
   VELOX_USER_CHECK_EQ(columns_->size(), columnNames_.size());
@@ -3094,6 +3096,16 @@ TableWriteNode::TableWriteNode(
         sources_[0]->outputType()->containsChild(column),
         "Column not found in TableWrite input: {}",
         column);
+  }
+  if (notNullColumnNames_.has_value()) {
+    const folly::F14FastSet<std::string> columnNameSet(
+        columnNames_.begin(), columnNames_.end());
+    for (const auto& name : notNullColumnNames_.value()) {
+      VELOX_USER_CHECK(
+          columnNameSet.count(name) > 0,
+          "NOT NULL column is not in the table schema: {}",
+          name);
+    }
   }
   if (columnStatsSpec_.has_value()) {
     VELOX_USER_CHECK(
@@ -3149,6 +3161,10 @@ void TableWriteNode::addDetails(std::stringstream& stream) const {
   if (columnStatsSpec_.has_value()) {
     stream << ", ";
     addStatsSpecDetails(stream, columnStatsSpec_);
+  }
+  if (notNullColumnNames_.has_value()) {
+    stream << ", notNullColumns: ["
+           << folly::join(", ", notNullColumnNames_.value()) << "]";
   }
 }
 
@@ -3225,6 +3241,10 @@ folly::dynamic TableWriteNode::serialize() const {
   obj["outputType"] = outputType_->serialize();
   obj["commitStrategy"] =
       std::string(connector::CommitStrategyName::toName(commitStrategy_));
+  if (notNullColumnNames_.has_value()) {
+    obj["notNullColumnNames"] =
+        ISerializable::serialize(notNullColumnNames_.value());
+  }
   return obj;
 }
 
@@ -3252,6 +3272,11 @@ PlanNodePtr TableWriteNode::create(const folly::dynamic& obj, void* context) {
   if (obj.count("columnStatsSpec") != 0) {
     columnStatsSpec = ColumnStatsSpec::create(obj["columnStatsSpec"], context);
   }
+  std::optional<std::vector<std::string>> notNullColumnNames;
+  if (obj.count("notNullColumnNames") != 0) {
+    notNullColumnNames = ISerializable::deserialize<std::vector<std::string>>(
+        obj["notNullColumnNames"]);
+  }
   return std::make_shared<TableWriteNode>(
       id,
       columns,
@@ -3262,7 +3287,8 @@ PlanNodePtr TableWriteNode::create(const folly::dynamic& obj, void* context) {
       hasPartitioningScheme,
       outputType,
       commitStrategy,
-      deserializeSingleSource(obj, context));
+      deserializeSingleSource(obj, context),
+      std::move(notNullColumnNames));
 }
 
 TableWriteMergeNode::TableWriteMergeNode(

--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -3076,8 +3076,7 @@ TableWriteNode::TableWriteNode(
     bool hasPartitioningScheme,
     RowTypePtr outputType,
     connector::CommitStrategy commitStrategy,
-    const PlanNodePtr& source,
-    std::optional<std::vector<std::string>> notNullColumnNames)
+    const PlanNodePtr& source)
     : PlanNode(id),
       sources_{source},
       columns_{columns},
@@ -3086,8 +3085,7 @@ TableWriteNode::TableWriteNode(
       insertTableHandle_(std::move(insertTableHandle)),
       hasPartitioningScheme_(hasPartitioningScheme),
       outputType_(std::move(outputType)),
-      commitStrategy_(commitStrategy),
-      notNullColumnNames_(std::move(notNullColumnNames)) {
+      commitStrategy_(commitStrategy) {
   VELOX_USER_CHECK_NOT_NULL(sources_[0]);
   VELOX_USER_CHECK_NOT_NULL(insertTableHandle_);
   VELOX_USER_CHECK_EQ(columns_->size(), columnNames_.size());
@@ -3097,10 +3095,11 @@ TableWriteNode::TableWriteNode(
         "Column not found in TableWrite input: {}",
         column);
   }
-  if (notNullColumnNames_.has_value()) {
+  const auto& notNullColumnNames = insertTableHandle_->notNullColumnNames();
+  if (!notNullColumnNames.empty()) {
     const folly::F14FastSet<std::string> columnNameSet(
         columnNames_.begin(), columnNames_.end());
-    for (const auto& name : notNullColumnNames_.value()) {
+    for (const auto& name : notNullColumnNames) {
       VELOX_USER_CHECK(
           columnNameSet.count(name) > 0,
           "NOT NULL column is not in the table schema: {}",
@@ -3162,9 +3161,10 @@ void TableWriteNode::addDetails(std::stringstream& stream) const {
     stream << ", ";
     addStatsSpecDetails(stream, columnStatsSpec_);
   }
-  if (notNullColumnNames_.has_value()) {
-    stream << ", notNullColumns: ["
-           << folly::join(", ", notNullColumnNames_.value()) << "]";
+  const auto& notNullColumnNames = insertTableHandle_->notNullColumnNames();
+  if (!notNullColumnNames.empty()) {
+    stream << ", notNullColumns: [" << folly::join(", ", notNullColumnNames)
+           << "]";
   }
 }
 
@@ -3241,9 +3241,9 @@ folly::dynamic TableWriteNode::serialize() const {
   obj["outputType"] = outputType_->serialize();
   obj["commitStrategy"] =
       std::string(connector::CommitStrategyName::toName(commitStrategy_));
-  if (notNullColumnNames_.has_value()) {
+  if (!insertTableHandle_->notNullColumnNames().empty()) {
     obj["notNullColumnNames"] =
-        ISerializable::serialize(notNullColumnNames_.value());
+        ISerializable::serialize(insertTableHandle_->notNullColumnNames());
   }
   return obj;
 }
@@ -3272,7 +3272,7 @@ PlanNodePtr TableWriteNode::create(const folly::dynamic& obj, void* context) {
   if (obj.count("columnStatsSpec") != 0) {
     columnStatsSpec = ColumnStatsSpec::create(obj["columnStatsSpec"], context);
   }
-  std::optional<std::vector<std::string>> notNullColumnNames;
+  std::vector<std::string> notNullColumnNames;
   if (obj.count("notNullColumnNames") != 0) {
     notNullColumnNames = ISerializable::deserialize<std::vector<std::string>>(
         obj["notNullColumnNames"]);
@@ -3283,12 +3283,13 @@ PlanNodePtr TableWriteNode::create(const folly::dynamic& obj, void* context) {
       columnNames,
       std::move(columnStatsSpec),
       std::make_shared<InsertTableHandle>(
-          connectorId, connectorInsertTableHandle),
+          connectorId,
+          connectorInsertTableHandle,
+          std::move(notNullColumnNames)),
       hasPartitioningScheme,
       outputType,
       commitStrategy,
-      deserializeSingleSource(obj, context),
-      std::move(notNullColumnNames));
+      deserializeSingleSource(obj, context));
 }
 
 TableWriteMergeNode::TableWriteMergeNode(

--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -3098,7 +3098,8 @@ TableWriteNode::TableWriteNode(
     bool hasPartitioningScheme,
     RowTypePtr outputType,
     connector::CommitStrategy commitStrategy,
-    const PlanNodePtr& source)
+    const PlanNodePtr& source,
+    std::optional<std::vector<std::string>> notNullColumnNames)
     : PlanNode(id),
       sources_{source},
       columns_{columns},
@@ -3107,7 +3108,8 @@ TableWriteNode::TableWriteNode(
       insertTableHandle_(std::move(insertTableHandle)),
       hasPartitioningScheme_(hasPartitioningScheme),
       outputType_(std::move(outputType)),
-      commitStrategy_(commitStrategy) {
+      commitStrategy_(commitStrategy),
+      notNullColumnNames_(std::move(notNullColumnNames)) {
   VELOX_USER_CHECK_NOT_NULL(sources_[0]);
   VELOX_USER_CHECK_NOT_NULL(insertTableHandle_);
   VELOX_USER_CHECK_EQ(columns_->size(), columnNames_.size());
@@ -3116,6 +3118,16 @@ TableWriteNode::TableWriteNode(
         sources_[0]->outputType()->containsChild(column),
         "Column not found in TableWrite input: {}",
         column);
+  }
+  if (notNullColumnNames_.has_value()) {
+    const folly::F14FastSet<std::string> columnNameSet(
+        columnNames_.begin(), columnNames_.end());
+    for (const auto& name : notNullColumnNames_.value()) {
+      VELOX_USER_CHECK(
+          columnNameSet.count(name) > 0,
+          "NOT NULL column is not in the table schema: {}",
+          name);
+    }
   }
   if (columnStatsSpec_.has_value()) {
     VELOX_USER_CHECK(
@@ -3171,6 +3183,10 @@ void TableWriteNode::addDetails(std::stringstream& stream) const {
   if (columnStatsSpec_.has_value()) {
     stream << ", ";
     addStatsSpecDetails(stream, columnStatsSpec_);
+  }
+  if (notNullColumnNames_.has_value()) {
+    stream << ", notNullColumns: ["
+           << folly::join(", ", notNullColumnNames_.value()) << "]";
   }
 }
 
@@ -3247,6 +3263,10 @@ folly::dynamic TableWriteNode::serialize() const {
   obj["outputType"] = outputType_->serialize();
   obj["commitStrategy"] =
       std::string(connector::CommitStrategyName::toName(commitStrategy_));
+  if (notNullColumnNames_.has_value()) {
+    obj["notNullColumnNames"] =
+        ISerializable::serialize(notNullColumnNames_.value());
+  }
   return obj;
 }
 
@@ -3274,6 +3294,11 @@ PlanNodePtr TableWriteNode::create(const folly::dynamic& obj, void* context) {
   if (obj.count("columnStatsSpec") != 0) {
     columnStatsSpec = ColumnStatsSpec::create(obj["columnStatsSpec"], context);
   }
+  std::optional<std::vector<std::string>> notNullColumnNames;
+  if (obj.count("notNullColumnNames") != 0) {
+    notNullColumnNames = ISerializable::deserialize<std::vector<std::string>>(
+        obj["notNullColumnNames"]);
+  }
   return std::make_shared<TableWriteNode>(
       id,
       columns,
@@ -3284,7 +3309,8 @@ PlanNodePtr TableWriteNode::create(const folly::dynamic& obj, void* context) {
       hasPartitioningScheme,
       outputType,
       commitStrategy,
-      deserializeSingleSource(obj, context));
+      deserializeSingleSource(obj, context),
+      std::move(notNullColumnNames));
 }
 
 TableWriteMergeNode::TableWriteMergeNode(

--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -3089,6 +3089,21 @@ void validateGroupingKeys(
 }
 } // namespace
 
+InsertTableHandle::InsertTableHandle(
+    const std::string& connectorId,
+    const connector::ConnectorInsertTableHandlePtr& connectorInsertTableHandle,
+    std::vector<std::string> notNullColumns)
+    : connectorId_(connectorId),
+      connectorInsertTableHandle_(connectorInsertTableHandle),
+      notNullColumns_(std::move(notNullColumns)) {
+  folly::F14FastSet<std::string> seenColumns;
+  seenColumns.reserve(notNullColumns_.size());
+  for (const auto& name : notNullColumns_) {
+    VELOX_USER_CHECK(
+        seenColumns.insert(name).second, "Duplicate NOT NULL column: {}", name);
+  }
+}
+
 TableWriteNode::TableWriteNode(
     const PlanNodeId& id,
     const RowTypePtr& columns,
@@ -3117,13 +3132,13 @@ TableWriteNode::TableWriteNode(
         "Column not found in TableWrite input: {}",
         column);
   }
-  const auto& notNullColumnNames = insertTableHandle_->notNullColumnNames();
-  if (!notNullColumnNames.empty()) {
+  const auto& notNullColumns = insertTableHandle_->notNullColumns();
+  if (!notNullColumns.empty()) {
     const folly::F14FastSet<std::string> columnNameSet(
         columnNames_.begin(), columnNames_.end());
-    for (const auto& name : notNullColumnNames) {
+    for (const auto& name : notNullColumns) {
       VELOX_USER_CHECK(
-          columnNameSet.count(name) > 0,
+          columnNameSet.contains(name),
           "NOT NULL column is not in the table schema: {}",
           name);
     }
@@ -3183,10 +3198,9 @@ void TableWriteNode::addDetails(std::stringstream& stream) const {
     stream << ", ";
     addStatsSpecDetails(stream, columnStatsSpec_);
   }
-  const auto& notNullColumnNames = insertTableHandle_->notNullColumnNames();
-  if (!notNullColumnNames.empty()) {
-    stream << ", notNullColumns: [" << folly::join(", ", notNullColumnNames)
-           << "]";
+  const auto& notNullColumns = insertTableHandle_->notNullColumns();
+  if (!notNullColumns.empty()) {
+    stream << ", notNullColumns: [" << folly::join(", ", notNullColumns) << "]";
   }
 }
 
@@ -3263,9 +3277,9 @@ folly::dynamic TableWriteNode::serialize() const {
   obj["outputType"] = outputType_->serialize();
   obj["commitStrategy"] =
       std::string(connector::CommitStrategyName::toName(commitStrategy_));
-  if (!insertTableHandle_->notNullColumnNames().empty()) {
-    obj["notNullColumnNames"] =
-        ISerializable::serialize(insertTableHandle_->notNullColumnNames());
+  if (!insertTableHandle_->notNullColumns().empty()) {
+    obj["notNullColumns"] =
+        ISerializable::serialize(insertTableHandle_->notNullColumns());
   }
   return obj;
 }
@@ -3294,10 +3308,10 @@ PlanNodePtr TableWriteNode::create(const folly::dynamic& obj, void* context) {
   if (obj.count("columnStatsSpec") != 0) {
     columnStatsSpec = ColumnStatsSpec::create(obj["columnStatsSpec"], context);
   }
-  std::vector<std::string> notNullColumnNames;
-  if (obj.count("notNullColumnNames") != 0) {
-    notNullColumnNames = ISerializable::deserialize<std::vector<std::string>>(
-        obj["notNullColumnNames"]);
+  std::vector<std::string> notNullColumns;
+  if (obj.count("notNullColumns") != 0) {
+    notNullColumns = ISerializable::deserialize<std::vector<std::string>>(
+        obj["notNullColumns"]);
   }
   return std::make_shared<TableWriteNode>(
       id,
@@ -3305,9 +3319,7 @@ PlanNodePtr TableWriteNode::create(const folly::dynamic& obj, void* context) {
       columnNames,
       std::move(columnStatsSpec),
       std::make_shared<InsertTableHandle>(
-          connectorId,
-          connectorInsertTableHandle,
-          std::move(notNullColumnNames)),
+          connectorId, connectorInsertTableHandle, std::move(notNullColumns)),
       hasPartitioningScheme,
       outputType,
       commitStrategy,

--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -3092,15 +3092,12 @@ void validateGroupingKeys(
 InsertTableHandle::InsertTableHandle(
     const std::string& connectorId,
     const connector::ConnectorInsertTableHandlePtr& connectorInsertTableHandle,
-    std::vector<std::string> notNullColumns)
+    folly::F14FastSet<std::string> notNullColumns)
     : connectorId_(connectorId),
       connectorInsertTableHandle_(connectorInsertTableHandle),
       notNullColumns_(std::move(notNullColumns)) {
-  folly::F14FastSet<std::string> seenColumns;
-  seenColumns.reserve(notNullColumns_.size());
   for (const auto& name : notNullColumns_) {
-    VELOX_USER_CHECK(
-        seenColumns.insert(name).second, "Duplicate NOT NULL column: {}", name);
+    VELOX_USER_CHECK(!name.empty(), "NOT NULL column name must not be empty");
   }
 }
 
@@ -3192,15 +3189,17 @@ void addStatsSpecDetails(
 } // namespace
 
 void TableWriteNode::addDetails(std::stringstream& stream) const {
-  stream << insertTableHandle_->connectorId() << ", "
-         << folly::join(", ", columnNames_);
+  stream << insertTableHandle_->connectorId();
+  const auto& notNullColumns = insertTableHandle_->notNullColumns();
+  for (const auto& columnName : columnNames_) {
+    stream << ", " << columnName;
+    if (notNullColumns.contains(columnName)) {
+      stream << " not null";
+    }
+  }
   if (columnStatsSpec_.has_value()) {
     stream << ", ";
     addStatsSpecDetails(stream, columnStatsSpec_);
-  }
-  const auto& notNullColumns = insertTableHandle_->notNullColumns();
-  if (!notNullColumns.empty()) {
-    stream << ", notNullColumns: [" << folly::join(", ", notNullColumns) << "]";
   }
 }
 
@@ -3277,9 +3276,13 @@ folly::dynamic TableWriteNode::serialize() const {
   obj["outputType"] = outputType_->serialize();
   obj["commitStrategy"] =
       std::string(connector::CommitStrategyName::toName(commitStrategy_));
-  if (!insertTableHandle_->notNullColumns().empty()) {
-    obj["notNullColumns"] =
-        ISerializable::serialize(insertTableHandle_->notNullColumns());
+  const auto& notNullColumns = insertTableHandle_->notNullColumns();
+  if (!notNullColumns.empty()) {
+    // Sorted to keep the serialized form stable across runs.
+    std::vector<std::string> sortedNotNullColumns(
+        notNullColumns.begin(), notNullColumns.end());
+    std::sort(sortedNotNullColumns.begin(), sortedNotNullColumns.end());
+    obj["notNullColumns"] = ISerializable::serialize(sortedNotNullColumns);
   }
   return obj;
 }
@@ -3308,10 +3311,11 @@ PlanNodePtr TableWriteNode::create(const folly::dynamic& obj, void* context) {
   if (obj.count("columnStatsSpec") != 0) {
     columnStatsSpec = ColumnStatsSpec::create(obj["columnStatsSpec"], context);
   }
-  std::vector<std::string> notNullColumns;
+  folly::F14FastSet<std::string> notNullColumns;
   if (obj.count("notNullColumns") != 0) {
-    notNullColumns = ISerializable::deserialize<std::vector<std::string>>(
+    const auto names = ISerializable::deserialize<std::vector<std::string>>(
         obj["notNullColumns"]);
+    notNullColumns.insert(names.begin(), names.end());
   }
   return std::make_shared<TableWriteNode>(
       id,

--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -3098,8 +3098,7 @@ TableWriteNode::TableWriteNode(
     bool hasPartitioningScheme,
     RowTypePtr outputType,
     connector::CommitStrategy commitStrategy,
-    const PlanNodePtr& source,
-    std::optional<std::vector<std::string>> notNullColumnNames)
+    const PlanNodePtr& source)
     : PlanNode(id),
       sources_{source},
       columns_{columns},
@@ -3108,8 +3107,7 @@ TableWriteNode::TableWriteNode(
       insertTableHandle_(std::move(insertTableHandle)),
       hasPartitioningScheme_(hasPartitioningScheme),
       outputType_(std::move(outputType)),
-      commitStrategy_(commitStrategy),
-      notNullColumnNames_(std::move(notNullColumnNames)) {
+      commitStrategy_(commitStrategy) {
   VELOX_USER_CHECK_NOT_NULL(sources_[0]);
   VELOX_USER_CHECK_NOT_NULL(insertTableHandle_);
   VELOX_USER_CHECK_EQ(columns_->size(), columnNames_.size());
@@ -3119,10 +3117,11 @@ TableWriteNode::TableWriteNode(
         "Column not found in TableWrite input: {}",
         column);
   }
-  if (notNullColumnNames_.has_value()) {
+  const auto& notNullColumnNames = insertTableHandle_->notNullColumnNames();
+  if (!notNullColumnNames.empty()) {
     const folly::F14FastSet<std::string> columnNameSet(
         columnNames_.begin(), columnNames_.end());
-    for (const auto& name : notNullColumnNames_.value()) {
+    for (const auto& name : notNullColumnNames) {
       VELOX_USER_CHECK(
           columnNameSet.count(name) > 0,
           "NOT NULL column is not in the table schema: {}",
@@ -3184,9 +3183,10 @@ void TableWriteNode::addDetails(std::stringstream& stream) const {
     stream << ", ";
     addStatsSpecDetails(stream, columnStatsSpec_);
   }
-  if (notNullColumnNames_.has_value()) {
-    stream << ", notNullColumns: ["
-           << folly::join(", ", notNullColumnNames_.value()) << "]";
+  const auto& notNullColumnNames = insertTableHandle_->notNullColumnNames();
+  if (!notNullColumnNames.empty()) {
+    stream << ", notNullColumns: [" << folly::join(", ", notNullColumnNames)
+           << "]";
   }
 }
 
@@ -3263,9 +3263,9 @@ folly::dynamic TableWriteNode::serialize() const {
   obj["outputType"] = outputType_->serialize();
   obj["commitStrategy"] =
       std::string(connector::CommitStrategyName::toName(commitStrategy_));
-  if (notNullColumnNames_.has_value()) {
+  if (!insertTableHandle_->notNullColumnNames().empty()) {
     obj["notNullColumnNames"] =
-        ISerializable::serialize(notNullColumnNames_.value());
+        ISerializable::serialize(insertTableHandle_->notNullColumnNames());
   }
   return obj;
 }
@@ -3294,7 +3294,7 @@ PlanNodePtr TableWriteNode::create(const folly::dynamic& obj, void* context) {
   if (obj.count("columnStatsSpec") != 0) {
     columnStatsSpec = ColumnStatsSpec::create(obj["columnStatsSpec"], context);
   }
-  std::optional<std::vector<std::string>> notNullColumnNames;
+  std::vector<std::string> notNullColumnNames;
   if (obj.count("notNullColumnNames") != 0) {
     notNullColumnNames = ISerializable::deserialize<std::vector<std::string>>(
         obj["notNullColumnNames"]);
@@ -3305,12 +3305,13 @@ PlanNodePtr TableWriteNode::create(const folly::dynamic& obj, void* context) {
       columnNames,
       std::move(columnStatsSpec),
       std::make_shared<InsertTableHandle>(
-          connectorId, connectorInsertTableHandle),
+          connectorId,
+          connectorInsertTableHandle,
+          std::move(notNullColumnNames)),
       hasPartitioningScheme,
       outputType,
       commitStrategy,
-      deserializeSingleSource(obj, context),
-      std::move(notNullColumnNames));
+      deserializeSingleSource(obj, context));
 }
 
 TableWriteMergeNode::TableWriteMergeNode(

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -1569,6 +1569,8 @@ class TableWriteNode : public PlanNode {
   /// single-column BIGINT type with no columnStatsSpec.
   /// @param commitStrategy Commit strategy for the write operation.
   /// @param source Input plan node providing rows to write.
+  /// @param notNullColumnNames If set, 'columnNames' entries that must not
+  /// contain nulls; the operator throws a user error otherwise.
   TableWriteNode(
       const PlanNodeId& id,
       const RowTypePtr& columns,
@@ -1578,7 +1580,8 @@ class TableWriteNode : public PlanNode {
       bool hasPartitioningScheme,
       RowTypePtr outputType,
       connector::CommitStrategy commitStrategy,
-      const PlanNodePtr& source);
+      const PlanNodePtr& source,
+      std::optional<std::vector<std::string>> notNullColumnNames);
 
   class Builder {
    public:
@@ -1593,6 +1596,7 @@ class TableWriteNode : public PlanNode {
       hasPartitioningScheme_ = other.hasPartitioningScheme();
       outputType_ = other.outputType();
       commitStrategy_ = other.commitStrategy();
+      notNullColumnNames_ = other.notNullColumnNames();
       VELOX_CHECK_EQ(other.sources().size(), 1);
       source_ = other.sources()[0];
     }
@@ -1638,6 +1642,11 @@ class TableWriteNode : public PlanNode {
       return *this;
     }
 
+    Builder& notNullColumnNames(std::vector<std::string> notNullColumnNames) {
+      notNullColumnNames_ = std::move(notNullColumnNames);
+      return *this;
+    }
+
     Builder& source(PlanNodePtr source) {
       source_ = std::move(source);
       return *this;
@@ -1671,7 +1680,8 @@ class TableWriteNode : public PlanNode {
           hasPartitioningScheme_.value(),
           outputType_.value(),
           commitStrategy_.value(),
-          source_.value());
+          source_.value(),
+          notNullColumnNames_);
     }
 
    private:
@@ -1683,6 +1693,7 @@ class TableWriteNode : public PlanNode {
     std::optional<bool> hasPartitioningScheme_;
     std::optional<RowTypePtr> outputType_;
     std::optional<connector::CommitStrategy> commitStrategy_;
+    std::optional<std::vector<std::string>> notNullColumnNames_;
     std::optional<PlanNodePtr> source_;
   };
 
@@ -1733,6 +1744,11 @@ class TableWriteNode : public PlanNode {
     return columnStatsSpec_;
   }
 
+  /// Columns that must not contain nulls, or std::nullopt if unconstrained.
+  const std::optional<std::vector<std::string>>& notNullColumnNames() const {
+    return notNullColumnNames_;
+  }
+
   bool requiresSingleThread() const override {
     return !insertTableHandle_->connectorInsertTableHandle()
                 ->supportsMultiThreading();
@@ -1761,6 +1777,8 @@ class TableWriteNode : public PlanNode {
   const bool hasPartitioningScheme_;
   const RowTypePtr outputType_;
   const connector::CommitStrategy commitStrategy_;
+  // NOT NULL column names, or std::nullopt if unconstrained.
+  const std::optional<std::vector<std::string>> notNullColumnNames_;
 };
 
 using TableWriteNodePtr = std::shared_ptr<const TableWriteNode>;

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -60,9 +60,11 @@ struct InsertTableHandle {
   InsertTableHandle(
       const std::string& connectorId,
       const connector::ConnectorInsertTableHandlePtr&
-          connectorInsertTableHandle)
+          connectorInsertTableHandle,
+      std::vector<std::string> notNullColumnNames = {})
       : connectorId_(connectorId),
-        connectorInsertTableHandle_(connectorInsertTableHandle) {}
+        connectorInsertTableHandle_(connectorInsertTableHandle),
+        notNullColumnNames_(std::move(notNullColumnNames)) {}
 
   const std::string& connectorId() const {
     return connectorId_;
@@ -73,12 +75,20 @@ struct InsertTableHandle {
     return connectorInsertTableHandle_;
   }
 
+  /// Target columns that must not contain nulls; empty if unconstrained.
+  const std::vector<std::string>& notNullColumnNames() const {
+    return notNullColumnNames_;
+  }
+
  private:
   // Connector ID
   const std::string connectorId_;
 
   // Write request to a DataSink of that connector type
   const connector::ConnectorInsertTableHandlePtr connectorInsertTableHandle_;
+
+  // Target columns that must not contain nulls; empty if unconstrained.
+  const std::vector<std::string> notNullColumnNames_;
 };
 
 class SortOrder {
@@ -1559,7 +1569,9 @@ class TableWriteNode : public PlanNode {
   ///   - grouping keys must be a subset of 'columns' (partition columns).
   ///   - grouping keys must not contain duplicates.
   /// @param insertTableHandle Connector-specific handle identifying the
-  /// target table and write operation.
+  /// target table and write operation. If its notNullColumnNames() is set,
+  /// those 'columnNames' entries must not contain nulls; the operator throws
+  /// a user error otherwise.
   /// @param hasPartitioningScheme Whether a partitioning scheme is configured
   /// for shuffles. Controls which query config determines the number of
   /// writer operator instances: 'task_partitioned_writer_count' if true,
@@ -1569,8 +1581,6 @@ class TableWriteNode : public PlanNode {
   /// single-column BIGINT type with no columnStatsSpec.
   /// @param commitStrategy Commit strategy for the write operation.
   /// @param source Input plan node providing rows to write.
-  /// @param notNullColumnNames If set, 'columnNames' entries that must not
-  /// contain nulls; the operator throws a user error otherwise.
   TableWriteNode(
       const PlanNodeId& id,
       const RowTypePtr& columns,
@@ -1580,8 +1590,7 @@ class TableWriteNode : public PlanNode {
       bool hasPartitioningScheme,
       RowTypePtr outputType,
       connector::CommitStrategy commitStrategy,
-      const PlanNodePtr& source,
-      std::optional<std::vector<std::string>> notNullColumnNames);
+      const PlanNodePtr& source);
 
   class Builder {
    public:
@@ -1596,7 +1605,6 @@ class TableWriteNode : public PlanNode {
       hasPartitioningScheme_ = other.hasPartitioningScheme();
       outputType_ = other.outputType();
       commitStrategy_ = other.commitStrategy();
-      notNullColumnNames_ = other.notNullColumnNames();
       VELOX_CHECK_EQ(other.sources().size(), 1);
       source_ = other.sources()[0];
     }
@@ -1642,11 +1650,6 @@ class TableWriteNode : public PlanNode {
       return *this;
     }
 
-    Builder& notNullColumnNames(std::vector<std::string> notNullColumnNames) {
-      notNullColumnNames_ = std::move(notNullColumnNames);
-      return *this;
-    }
-
     Builder& source(PlanNodePtr source) {
       source_ = std::move(source);
       return *this;
@@ -1680,8 +1683,7 @@ class TableWriteNode : public PlanNode {
           hasPartitioningScheme_.value(),
           outputType_.value(),
           commitStrategy_.value(),
-          source_.value(),
-          notNullColumnNames_);
+          source_.value());
     }
 
    private:
@@ -1693,7 +1695,6 @@ class TableWriteNode : public PlanNode {
     std::optional<bool> hasPartitioningScheme_;
     std::optional<RowTypePtr> outputType_;
     std::optional<connector::CommitStrategy> commitStrategy_;
-    std::optional<std::vector<std::string>> notNullColumnNames_;
     std::optional<PlanNodePtr> source_;
   };
 
@@ -1744,11 +1745,6 @@ class TableWriteNode : public PlanNode {
     return columnStatsSpec_;
   }
 
-  /// Columns that must not contain nulls, or std::nullopt if unconstrained.
-  const std::optional<std::vector<std::string>>& notNullColumnNames() const {
-    return notNullColumnNames_;
-  }
-
   bool requiresSingleThread() const override {
     return !insertTableHandle_->connectorInsertTableHandle()
                 ->supportsMultiThreading();
@@ -1777,8 +1773,6 @@ class TableWriteNode : public PlanNode {
   const bool hasPartitioningScheme_;
   const RowTypePtr outputType_;
   const connector::CommitStrategy commitStrategy_;
-  // NOT NULL column names, or std::nullopt if unconstrained.
-  const std::optional<std::vector<std::string>> notNullColumnNames_;
 };
 
 using TableWriteNodePtr = std::shared_ptr<const TableWriteNode>;

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -1566,6 +1566,8 @@ class TableWriteNode : public PlanNode {
   /// single-column BIGINT type with no columnStatsSpec.
   /// @param commitStrategy Commit strategy for the write operation.
   /// @param source Input plan node providing rows to write.
+  /// @param notNullColumnNames If set, 'columnNames' entries that must not
+  /// contain nulls; the operator throws a user error otherwise.
   TableWriteNode(
       const PlanNodeId& id,
       const RowTypePtr& columns,
@@ -1575,7 +1577,8 @@ class TableWriteNode : public PlanNode {
       bool hasPartitioningScheme,
       RowTypePtr outputType,
       connector::CommitStrategy commitStrategy,
-      const PlanNodePtr& source);
+      const PlanNodePtr& source,
+      std::optional<std::vector<std::string>> notNullColumnNames);
 
   class Builder {
    public:
@@ -1590,6 +1593,7 @@ class TableWriteNode : public PlanNode {
       hasPartitioningScheme_ = other.hasPartitioningScheme();
       outputType_ = other.outputType();
       commitStrategy_ = other.commitStrategy();
+      notNullColumnNames_ = other.notNullColumnNames();
       VELOX_CHECK_EQ(other.sources().size(), 1);
       source_ = other.sources()[0];
     }
@@ -1635,6 +1639,11 @@ class TableWriteNode : public PlanNode {
       return *this;
     }
 
+    Builder& notNullColumnNames(std::vector<std::string> notNullColumnNames) {
+      notNullColumnNames_ = std::move(notNullColumnNames);
+      return *this;
+    }
+
     Builder& source(PlanNodePtr source) {
       source_ = std::move(source);
       return *this;
@@ -1668,7 +1677,8 @@ class TableWriteNode : public PlanNode {
           hasPartitioningScheme_.value(),
           outputType_.value(),
           commitStrategy_.value(),
-          source_.value());
+          source_.value(),
+          notNullColumnNames_);
     }
 
    private:
@@ -1680,6 +1690,7 @@ class TableWriteNode : public PlanNode {
     std::optional<bool> hasPartitioningScheme_;
     std::optional<RowTypePtr> outputType_;
     std::optional<connector::CommitStrategy> commitStrategy_;
+    std::optional<std::vector<std::string>> notNullColumnNames_;
     std::optional<PlanNodePtr> source_;
   };
 
@@ -1730,6 +1741,11 @@ class TableWriteNode : public PlanNode {
     return columnStatsSpec_;
   }
 
+  /// Columns that must not contain nulls, or std::nullopt if unconstrained.
+  const std::optional<std::vector<std::string>>& notNullColumnNames() const {
+    return notNullColumnNames_;
+  }
+
   bool requiresSingleThread() const override {
     return !insertTableHandle_->connectorInsertTableHandle()
                 ->supportsMultiThreading();
@@ -1758,6 +1774,8 @@ class TableWriteNode : public PlanNode {
   const bool hasPartitioningScheme_;
   const RowTypePtr outputType_;
   const connector::CommitStrategy commitStrategy_;
+  // NOT NULL column names, or std::nullopt if unconstrained.
+  const std::optional<std::vector<std::string>> notNullColumnNames_;
 };
 
 using TableWriteNodePtr = std::shared_ptr<const TableWriteNode>;

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -65,6 +65,16 @@ struct InsertTableHandle {
           connectorInsertTableHandle,
       folly::F14FastSet<std::string> notNullColumns);
 
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+  /// Legacy constructor. Prefer the overload above, which takes the NOT NULL
+  /// columns. Removed once all callers have migrated.
+  InsertTableHandle(
+      const std::string& connectorId,
+      const connector::ConnectorInsertTableHandlePtr&
+          connectorInsertTableHandle)
+      : InsertTableHandle(connectorId, connectorInsertTableHandle, {}) {}
+#endif // VELOX_ENABLE_BACKWARD_COMPATIBILITY
+
   const std::string& connectorId() const {
     return connectorId_;
   }

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -57,14 +57,12 @@ struct TransportKind {
 /// Generic representation of InsertTable
 struct InsertTableHandle {
  public:
+  /// @param notNullColumns Throws a user error if it contains duplicates.
   InsertTableHandle(
       const std::string& connectorId,
       const connector::ConnectorInsertTableHandlePtr&
           connectorInsertTableHandle,
-      std::vector<std::string> notNullColumnNames = {})
-      : connectorId_(connectorId),
-        connectorInsertTableHandle_(connectorInsertTableHandle),
-        notNullColumnNames_(std::move(notNullColumnNames)) {}
+      std::vector<std::string> notNullColumns);
 
   const std::string& connectorId() const {
     return connectorId_;
@@ -75,9 +73,10 @@ struct InsertTableHandle {
     return connectorInsertTableHandle_;
   }
 
-  /// Target columns that must not contain nulls; empty if unconstrained.
-  const std::vector<std::string>& notNullColumnNames() const {
-    return notNullColumnNames_;
+  /// Unique target columns that must not contain nulls. Empty if
+  /// unconstrained.
+  const std::vector<std::string>& notNullColumns() const {
+    return notNullColumns_;
   }
 
  private:
@@ -87,8 +86,7 @@ struct InsertTableHandle {
   // Write request to a DataSink of that connector type
   const connector::ConnectorInsertTableHandlePtr connectorInsertTableHandle_;
 
-  // Target columns that must not contain nulls; empty if unconstrained.
-  const std::vector<std::string> notNullColumnNames_;
+  const std::vector<std::string> notNullColumns_;
 };
 
 class SortOrder {
@@ -1569,9 +1567,8 @@ class TableWriteNode : public PlanNode {
   ///   - grouping keys must be a subset of 'columns' (partition columns).
   ///   - grouping keys must not contain duplicates.
   /// @param insertTableHandle Connector-specific handle identifying the
-  /// target table and write operation. If its notNullColumnNames() is set,
-  /// those 'columnNames' entries must not contain nulls; the operator throws
-  /// a user error otherwise.
+  /// target table and write operation. Its notNullColumns() must be a subset
+  /// of 'columnNames'.
   /// @param hasPartitioningScheme Whether a partitioning scheme is configured
   /// for shuffles. Controls which query config determines the number of
   /// writer operator instances: 'task_partitioned_writer_count' if true,

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -57,9 +57,11 @@ struct InsertTableHandle {
   InsertTableHandle(
       const std::string& connectorId,
       const connector::ConnectorInsertTableHandlePtr&
-          connectorInsertTableHandle)
+          connectorInsertTableHandle,
+      std::vector<std::string> notNullColumnNames = {})
       : connectorId_(connectorId),
-        connectorInsertTableHandle_(connectorInsertTableHandle) {}
+        connectorInsertTableHandle_(connectorInsertTableHandle),
+        notNullColumnNames_(std::move(notNullColumnNames)) {}
 
   const std::string& connectorId() const {
     return connectorId_;
@@ -70,12 +72,20 @@ struct InsertTableHandle {
     return connectorInsertTableHandle_;
   }
 
+  /// Target columns that must not contain nulls; empty if unconstrained.
+  const std::vector<std::string>& notNullColumnNames() const {
+    return notNullColumnNames_;
+  }
+
  private:
   // Connector ID
   const std::string connectorId_;
 
   // Write request to a DataSink of that connector type
   const connector::ConnectorInsertTableHandlePtr connectorInsertTableHandle_;
+
+  // Target columns that must not contain nulls; empty if unconstrained.
+  const std::vector<std::string> notNullColumnNames_;
 };
 
 class SortOrder {
@@ -1556,7 +1566,9 @@ class TableWriteNode : public PlanNode {
   ///   - grouping keys must be a subset of 'columns' (partition columns).
   ///   - grouping keys must not contain duplicates.
   /// @param insertTableHandle Connector-specific handle identifying the
-  /// target table and write operation.
+  /// target table and write operation. If its notNullColumnNames() is set,
+  /// those 'columnNames' entries must not contain nulls; the operator throws
+  /// a user error otherwise.
   /// @param hasPartitioningScheme Whether a partitioning scheme is configured
   /// for shuffles. Controls which query config determines the number of
   /// writer operator instances: 'task_partitioned_writer_count' if true,
@@ -1566,8 +1578,6 @@ class TableWriteNode : public PlanNode {
   /// single-column BIGINT type with no columnStatsSpec.
   /// @param commitStrategy Commit strategy for the write operation.
   /// @param source Input plan node providing rows to write.
-  /// @param notNullColumnNames If set, 'columnNames' entries that must not
-  /// contain nulls; the operator throws a user error otherwise.
   TableWriteNode(
       const PlanNodeId& id,
       const RowTypePtr& columns,
@@ -1577,8 +1587,7 @@ class TableWriteNode : public PlanNode {
       bool hasPartitioningScheme,
       RowTypePtr outputType,
       connector::CommitStrategy commitStrategy,
-      const PlanNodePtr& source,
-      std::optional<std::vector<std::string>> notNullColumnNames);
+      const PlanNodePtr& source);
 
   class Builder {
    public:
@@ -1593,7 +1602,6 @@ class TableWriteNode : public PlanNode {
       hasPartitioningScheme_ = other.hasPartitioningScheme();
       outputType_ = other.outputType();
       commitStrategy_ = other.commitStrategy();
-      notNullColumnNames_ = other.notNullColumnNames();
       VELOX_CHECK_EQ(other.sources().size(), 1);
       source_ = other.sources()[0];
     }
@@ -1639,11 +1647,6 @@ class TableWriteNode : public PlanNode {
       return *this;
     }
 
-    Builder& notNullColumnNames(std::vector<std::string> notNullColumnNames) {
-      notNullColumnNames_ = std::move(notNullColumnNames);
-      return *this;
-    }
-
     Builder& source(PlanNodePtr source) {
       source_ = std::move(source);
       return *this;
@@ -1677,8 +1680,7 @@ class TableWriteNode : public PlanNode {
           hasPartitioningScheme_.value(),
           outputType_.value(),
           commitStrategy_.value(),
-          source_.value(),
-          notNullColumnNames_);
+          source_.value());
     }
 
    private:
@@ -1690,7 +1692,6 @@ class TableWriteNode : public PlanNode {
     std::optional<bool> hasPartitioningScheme_;
     std::optional<RowTypePtr> outputType_;
     std::optional<connector::CommitStrategy> commitStrategy_;
-    std::optional<std::vector<std::string>> notNullColumnNames_;
     std::optional<PlanNodePtr> source_;
   };
 
@@ -1741,11 +1742,6 @@ class TableWriteNode : public PlanNode {
     return columnStatsSpec_;
   }
 
-  /// Columns that must not contain nulls, or std::nullopt if unconstrained.
-  const std::optional<std::vector<std::string>>& notNullColumnNames() const {
-    return notNullColumnNames_;
-  }
-
   bool requiresSingleThread() const override {
     return !insertTableHandle_->connectorInsertTableHandle()
                 ->supportsMultiThreading();
@@ -1774,8 +1770,6 @@ class TableWriteNode : public PlanNode {
   const bool hasPartitioningScheme_;
   const RowTypePtr outputType_;
   const connector::CommitStrategy commitStrategy_;
-  // NOT NULL column names, or std::nullopt if unconstrained.
-  const std::optional<std::vector<std::string>> notNullColumnNames_;
 };
 
 using TableWriteNodePtr = std::shared_ptr<const TableWriteNode>;

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <fmt/format.h>
+#include <folly/container/F14Set.h>
 
 #include <utility>
 
@@ -57,12 +58,12 @@ struct TransportKind {
 /// Generic representation of InsertTable
 struct InsertTableHandle {
  public:
-  /// @param notNullColumns Throws a user error if it contains duplicates.
+  /// @param notNullColumns Throws a user error if any name is empty.
   InsertTableHandle(
       const std::string& connectorId,
       const connector::ConnectorInsertTableHandlePtr&
           connectorInsertTableHandle,
-      std::vector<std::string> notNullColumns);
+      folly::F14FastSet<std::string> notNullColumns);
 
   const std::string& connectorId() const {
     return connectorId_;
@@ -73,9 +74,8 @@ struct InsertTableHandle {
     return connectorInsertTableHandle_;
   }
 
-  /// Unique target columns that must not contain nulls. Empty if
-  /// unconstrained.
-  const std::vector<std::string>& notNullColumns() const {
+  /// Target columns that must not contain nulls. Empty if unconstrained.
+  const folly::F14FastSet<std::string>& notNullColumns() const {
     return notNullColumns_;
   }
 
@@ -86,7 +86,7 @@ struct InsertTableHandle {
   // Write request to a DataSink of that connector type
   const connector::ConnectorInsertTableHandlePtr connectorInsertTableHandle_;
 
-  const std::vector<std::string> notNullColumns_;
+  const folly::F14FastSet<std::string> notNullColumns_;
 };
 
 class SortOrder {

--- a/velox/core/tests/PlanNodeBuilderTest.cpp
+++ b/velox/core/tests/PlanNodeBuilderTest.cpp
@@ -370,8 +370,8 @@ TEST_F(PlanNodeBuilderTest, tableWriteNode) {
       std::vector<std::string>{"sum(c0)"});
   const auto outputType = TableWriteTraits::outputType(statsSpec);
 
-  const auto insertTableHandle =
-      std::make_shared<InsertTableHandle>("connector_id", nullptr);
+  const auto insertTableHandle = std::make_shared<InsertTableHandle>(
+      "connector_id", nullptr, /*notNullColumns=*/std::vector<std::string>{});
 
   const auto verify = [&](const std::shared_ptr<const TableWriteNode>& node) {
     EXPECT_EQ(node->id(), id);

--- a/velox/core/tests/PlanNodeBuilderTest.cpp
+++ b/velox/core/tests/PlanNodeBuilderTest.cpp
@@ -371,7 +371,9 @@ TEST_F(PlanNodeBuilderTest, tableWriteNode) {
   const auto outputType = TableWriteTraits::outputType(statsSpec);
 
   const auto insertTableHandle = std::make_shared<InsertTableHandle>(
-      "connector_id", nullptr, /*notNullColumns=*/std::vector<std::string>{});
+      "connector_id",
+      nullptr,
+      /*notNullColumns=*/folly::F14FastSet<std::string>{});
 
   const auto verify = [&](const std::shared_ptr<const TableWriteNode>& node) {
     EXPECT_EQ(node->id(), id);
@@ -400,6 +402,31 @@ TEST_F(PlanNodeBuilderTest, tableWriteNode) {
 
   const auto node2 = TableWriteNode::Builder(*node).build();
   verify(node2);
+}
+
+TEST_F(PlanNodeBuilderTest, tableWriteNodeEmptyNotNullColumn) {
+  VELOX_ASSERT_USER_THROW(
+      std::make_shared<InsertTableHandle>(
+          "connector_id", nullptr, folly::F14FastSet<std::string>{""}),
+      "NOT NULL column name must not be empty");
+}
+
+TEST_F(PlanNodeBuilderTest, tableWriteNodeNotNullColumnOutsideSchema) {
+  const auto insertTableHandle = std::make_shared<InsertTableHandle>(
+      "connector_id", nullptr, folly::F14FastSet<std::string>{"c1"});
+
+  VELOX_ASSERT_USER_THROW(
+      TableWriteNode::Builder()
+          .id("test_id")
+          .columns(ROW({"c0"}, {INTEGER()}))
+          .columnNames({"c0"})
+          .insertTableHandle(insertTableHandle)
+          .hasPartitioningScheme(false)
+          .outputType(TableWriteTraits::outputType(std::nullopt))
+          .commitStrategy(connector::CommitStrategy::kNoCommit)
+          .source(source_)
+          .build(),
+      "NOT NULL column is not in the table schema: c1");
 }
 
 TEST_F(PlanNodeBuilderTest, tableWriteMergeNode) {

--- a/velox/core/tests/PlanNodeBuilderTest.cpp
+++ b/velox/core/tests/PlanNodeBuilderTest.cpp
@@ -404,13 +404,6 @@ TEST_F(PlanNodeBuilderTest, tableWriteNode) {
   verify(node2);
 }
 
-TEST_F(PlanNodeBuilderTest, tableWriteNodeEmptyNotNullColumn) {
-  VELOX_ASSERT_USER_THROW(
-      std::make_shared<InsertTableHandle>(
-          "connector_id", nullptr, folly::F14FastSet<std::string>{""}),
-      "NOT NULL column name must not be empty");
-}
-
 TEST_F(PlanNodeBuilderTest, tableWriteNodeNotNullColumnOutsideSchema) {
   const auto insertTableHandle = std::make_shared<InsertTableHandle>(
       "connector_id", nullptr, folly::F14FastSet<std::string>{"c1"});

--- a/velox/docs/develop/operators.rst
+++ b/velox/docs/develop/operators.rst
@@ -709,7 +709,7 @@ the written file paths on storage and the collected column stats.
    * - aggregationNode
      - Optional Aggregation plan node used to collect column stats for the data written to storage.
    * - insertTableHandle
-     - Connector-specific description of the destination table. Its notNullColumns is a unique subset of columnNames; writing a null into one of them fails the query.
+     - Connector-specific description of the destination table. Its notNullColumns is a subset of columnNames; writing a null into one of them fails the query.
    * - outputType
      - A list of output columns containing the metadata of the data written storage.
 

--- a/velox/docs/develop/operators.rst
+++ b/velox/docs/develop/operators.rst
@@ -709,7 +709,7 @@ the written file paths on storage and the collected column stats.
    * - aggregationNode
      - Optional Aggregation plan node used to collect column stats for the data written to storage.
    * - insertTableHandle
-     - Connector-specific description of the destination table.
+     - Connector-specific description of the destination table. Its notNullColumns is a unique subset of columnNames; writing a null into one of them fails the query.
    * - outputType
      - A list of output columns containing the metadata of the data written storage.
 

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -15,9 +15,15 @@
  */
 
 #include "velox/exec/TableWriter.h"
+
+#include <folly/container/F14Set.h>
+
+#include "velox/common/base/Nulls.h"
 #include "velox/connectors/ConnectorRegistry.h"
 #include "velox/exec/OperatorType.h"
 #include "velox/exec/Task.h"
+#include "velox/vector/DecodedVector.h"
+#include "velox/vector/SelectivityVector.h"
 
 namespace facebook::velox::exec {
 
@@ -96,6 +102,18 @@ void TableWriter::setTypeMappings(
 
   mappedOutputType_ = ROW(folly::copy(outputNames), std::move(outputTypes));
   mappedInputType_ = ROW(std::move(outputNames), std::move(inputTypes));
+
+  const auto& notNullNames = tableWriteNode->notNullColumnNames();
+  if (notNullNames.has_value()) {
+    const folly::F14FastSet<std::string> notNullSet(
+        notNullNames->begin(), notNullNames->end());
+    const auto& targetNames = tableWriteNode->columnNames();
+    for (size_t i = 0; i < targetNames.size(); ++i) {
+      if (notNullSet.count(targetNames[i]) > 0) {
+        notNullChannels_.emplace_back(inputMapping_[i], targetNames[i]);
+      }
+    }
+  }
 }
 
 void TableWriter::initialize() {
@@ -146,6 +164,29 @@ bool TableWriter::finishDataSink() {
 void TableWriter::addInput(RowVectorPtr input) {
   if (input->size() == 0) {
     return;
+  }
+
+  // Flat vectors use rawNulls() directly; other encodings are decoded
+  // since rawNulls() misses nulls behind dictionary or constant wrapping.
+  if (!notNullChannels_.empty()) {
+    notNullRows_.resizeFill(input->size());
+    for (const auto& [channel, name] : notNullChannels_) {
+      const auto& column = input->childAt(channel);
+      bool hasNulls = false;
+      if (column->mayHaveNullsRecursive()) {
+        if (column->isFlatEncoding()) {
+          const auto* rawNulls = column->rawNulls();
+          hasNulls = rawNulls != nullptr &&
+              bits::countNulls(rawNulls, 0, input->size()) > 0;
+        } else {
+          notNullDecodedVector_.decode(*column, notNullRows_);
+          hasNulls = notNullDecodedVector_.hasNulls();
+        }
+      }
+      if (hasNulls) {
+        VELOX_USER_FAIL("NULL value not allowed for NOT NULL column: {}", name);
+      }
+    }
   }
 
   std::vector<VectorPtr> mappedChildren;

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -166,24 +166,26 @@ void TableWriter::addInput(RowVectorPtr input) {
     return;
   }
 
-  // Enforce NOT NULL constraints. Flat vectors use their nulls buffer; other
-  // encodings are decoded, since rawNulls() misses nulls behind dictionary or
-  // constant wrapping.
-  for (const auto& [channel, name] : notNullChannels_) {
-    const auto& column = input->childAt(channel);
-    bool hasNulls = false;
-    if (column->mayHaveNullsRecursive()) {
-      if (column->isFlatEncoding()) {
-        const auto* rawNulls = column->rawNulls();
-        hasNulls = rawNulls != nullptr &&
-            bits::countNulls(rawNulls, 0, input->size()) > 0;
-      } else {
-        DecodedVector decoded(*column, SelectivityVector(input->size()));
-        hasNulls = decoded.hasNulls();
+  // Flat vectors use rawNulls() directly; other encodings are decoded
+  // since rawNulls() misses nulls behind dictionary or constant wrapping.
+  if (!notNullChannels_.empty()) {
+    notNullRows_.resizeFill(input->size());
+    for (const auto& [channel, name] : notNullChannels_) {
+      const auto& column = input->childAt(channel);
+      bool hasNulls = false;
+      if (column->mayHaveNullsRecursive()) {
+        if (column->isFlatEncoding()) {
+          const auto* rawNulls = column->rawNulls();
+          hasNulls = rawNulls != nullptr &&
+              bits::countNulls(rawNulls, 0, input->size()) > 0;
+        } else {
+          notNullDecodedVector_.decode(*column, notNullRows_);
+          hasNulls = notNullDecodedVector_.hasNulls();
+        }
       }
-    }
-    if (hasNulls) {
-      VELOX_USER_FAIL("NULL value not allowed for NOT NULL column: {}", name);
+      if (hasNulls) {
+        VELOX_USER_FAIL("NULL value not allowed for NOT NULL column: {}", name);
+      }
     }
   }
 

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -15,9 +15,15 @@
  */
 
 #include "velox/exec/TableWriter.h"
+
+#include <folly/container/F14Set.h>
+
+#include "velox/common/base/Nulls.h"
 #include "velox/connectors/ConnectorRegistry.h"
 #include "velox/exec/OperatorType.h"
 #include "velox/exec/Task.h"
+#include "velox/vector/DecodedVector.h"
+#include "velox/vector/SelectivityVector.h"
 
 namespace facebook::velox::exec {
 
@@ -96,6 +102,18 @@ void TableWriter::setTypeMappings(
 
   mappedOutputType_ = ROW(folly::copy(outputNames), std::move(outputTypes));
   mappedInputType_ = ROW(std::move(outputNames), std::move(inputTypes));
+
+  const auto& notNullNames = tableWriteNode->notNullColumnNames();
+  if (notNullNames.has_value()) {
+    const folly::F14FastSet<std::string> notNullSet(
+        notNullNames->begin(), notNullNames->end());
+    const auto& targetNames = tableWriteNode->columnNames();
+    for (size_t i = 0; i < targetNames.size(); ++i) {
+      if (notNullSet.count(targetNames[i]) > 0) {
+        notNullChannels_.emplace_back(inputMapping_[i], targetNames[i]);
+      }
+    }
+  }
 }
 
 void TableWriter::initialize() {
@@ -146,6 +164,27 @@ bool TableWriter::finishDataSink() {
 void TableWriter::addInput(RowVectorPtr input) {
   if (input->size() == 0) {
     return;
+  }
+
+  // Enforce NOT NULL constraints. Flat vectors use their nulls buffer; other
+  // encodings are decoded, since rawNulls() misses nulls behind dictionary or
+  // constant wrapping.
+  for (const auto& [channel, name] : notNullChannels_) {
+    const auto& column = input->childAt(channel);
+    bool hasNulls = false;
+    if (column->mayHaveNullsRecursive()) {
+      if (column->isFlatEncoding()) {
+        const auto* rawNulls = column->rawNulls();
+        hasNulls = rawNulls != nullptr &&
+            bits::countNulls(rawNulls, 0, input->size()) > 0;
+      } else {
+        DecodedVector decoded(*column, SelectivityVector(input->size()));
+        hasNulls = decoded.hasNulls();
+      }
+    }
+    if (hasNulls) {
+      VELOX_USER_FAIL("NULL value not allowed for NOT NULL column: {}", name);
+    }
   }
 
   std::vector<VectorPtr> mappedChildren;

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -18,7 +18,6 @@
 
 #include <folly/container/F14Set.h>
 
-#include "velox/common/base/Nulls.h"
 #include "velox/connectors/ConnectorRegistry.h"
 #include "velox/exec/OperatorType.h"
 #include "velox/exec/Task.h"
@@ -103,10 +102,11 @@ void TableWriter::setTypeMappings(
   mappedOutputType_ = ROW(folly::copy(outputNames), std::move(outputTypes));
   mappedInputType_ = ROW(std::move(outputNames), std::move(inputTypes));
 
-  const auto& notNullNames = tableWriteNode->notNullColumnNames();
-  if (notNullNames.has_value()) {
+  const auto& notNullNames =
+      tableWriteNode->insertTableHandle()->notNullColumnNames();
+  if (!notNullNames.empty()) {
     const folly::F14FastSet<std::string> notNullSet(
-        notNullNames->begin(), notNullNames->end());
+        notNullNames.begin(), notNullNames.end());
     const auto& targetNames = tableWriteNode->columnNames();
     for (size_t i = 0; i < targetNames.size(); ++i) {
       if (notNullSet.count(targetNames[i]) > 0) {
@@ -161,32 +161,30 @@ bool TableWriter::finishDataSink() {
   return dataSink_->finish();
 }
 
+void TableWriter::checkNotNullConstraints(const RowVectorPtr& input) {
+  for (const auto& [channel, name] : notNullChannels_) {
+    const auto& column = input->childAt(channel);
+    if (!column->mayHaveNullsRecursive()) {
+      continue;
+    }
+    // Decode to catch nulls behind dictionary or constant wrapping, restricting
+    // the scan to the batch's rows. hasNulls() fast-paths identity (flat)
+    // mappings, so no separate flat branch is needed.
+    notNullRows_.resizeFill(input->size());
+    notNullDecodedVector_.decode(*column, notNullRows_);
+    if (notNullDecodedVector_.hasNulls()) {
+      VELOX_USER_FAIL("NULL value not allowed for NOT NULL column: {}", name);
+    }
+  }
+}
+
 void TableWriter::addInput(RowVectorPtr input) {
   if (input->size() == 0) {
     return;
   }
 
-  // Flat vectors use rawNulls() directly; other encodings are decoded
-  // since rawNulls() misses nulls behind dictionary or constant wrapping.
   if (!notNullChannels_.empty()) {
-    notNullRows_.resizeFill(input->size());
-    for (const auto& [channel, name] : notNullChannels_) {
-      const auto& column = input->childAt(channel);
-      bool hasNulls = false;
-      if (column->mayHaveNullsRecursive()) {
-        if (column->isFlatEncoding()) {
-          const auto* rawNulls = column->rawNulls();
-          hasNulls = rawNulls != nullptr &&
-              bits::countNulls(rawNulls, 0, input->size()) > 0;
-        } else {
-          notNullDecodedVector_.decode(*column, notNullRows_);
-          hasNulls = notNullDecodedVector_.hasNulls();
-        }
-      }
-      if (hasNulls) {
-        VELOX_USER_FAIL("NULL value not allowed for NOT NULL column: {}", name);
-      }
-    }
+    checkNotNullConstraints(input);
   }
 
   std::vector<VectorPtr> mappedChildren;

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -21,8 +21,6 @@
 #include "velox/connectors/ConnectorRegistry.h"
 #include "velox/exec/OperatorType.h"
 #include "velox/exec/Task.h"
-#include "velox/vector/DecodedVector.h"
-#include "velox/vector/SelectivityVector.h"
 
 namespace facebook::velox::exec {
 
@@ -77,6 +75,7 @@ TableWriter::TableWriter(
       connectorPool_,
       spillConfig_.has_value() ? &(spillConfig_.value()) : nullptr);
   setTypeMappings(tableWriteNode);
+  setNotNullChannels(tableWriteNode);
 }
 
 void TableWriter::setTypeMappings(
@@ -101,17 +100,22 @@ void TableWriter::setTypeMappings(
 
   mappedOutputType_ = ROW(folly::copy(outputNames), std::move(outputTypes));
   mappedInputType_ = ROW(std::move(outputNames), std::move(inputTypes));
+}
 
-  const auto& notNullNames =
-      tableWriteNode->insertTableHandle()->notNullColumnNames();
-  if (!notNullNames.empty()) {
-    const folly::F14FastSet<std::string> notNullSet(
-        notNullNames.begin(), notNullNames.end());
-    const auto& targetNames = tableWriteNode->columnNames();
-    for (size_t i = 0; i < targetNames.size(); ++i) {
-      if (notNullSet.count(targetNames[i]) > 0) {
-        notNullChannels_.emplace_back(inputMapping_[i], targetNames[i]);
-      }
+void TableWriter::setNotNullChannels(
+    const core::TableWriteNodePtr& tableWriteNode) {
+  const auto& notNullColumns =
+      tableWriteNode->insertTableHandle()->notNullColumns();
+  if (notNullColumns.empty()) {
+    return;
+  }
+
+  const folly::F14FastSet<std::string> notNullColumnSet(
+      notNullColumns.begin(), notNullColumns.end());
+  const auto& targetNames = tableWriteNode->columnNames();
+  for (auto i = 0; i < targetNames.size(); ++i) {
+    if (notNullColumnSet.contains(targetNames[i])) {
+      notNullChannels_.emplace_back(inputMapping_[i], targetNames[i]);
     }
   }
 }
@@ -162,19 +166,29 @@ bool TableWriter::finishDataSink() {
 }
 
 void TableWriter::checkNotNullConstraints(const RowVectorPtr& input) {
+  if (notNullChannels_.empty()) {
+    return;
+  }
+
+  // Decoding catches nulls behind dictionary or constant wrapping. The scan is
+  // bounded to the batch's rows because a child may be longer than 'input'.
+  notNullRows_.resizeFill(input->size());
+
+  // A null row of 'input' is null in every column, and addInput() forwards it
+  // to the data sink as such, but the children do not reflect it. Every
+  // constrained column is violated, so report the first.
+  notNullDecodedVector_.decode(*input, notNullRows_);
+  VELOX_USER_CHECK(
+      !notNullDecodedVector_.hasNulls(),
+      "NULL value not allowed for NOT NULL column: {}",
+      notNullChannels_.front().second);
+
   for (const auto& [channel, name] : notNullChannels_) {
-    const auto& column = input->childAt(channel);
-    if (!column->mayHaveNullsRecursive()) {
-      continue;
-    }
-    // Decode to catch nulls behind dictionary or constant wrapping, restricting
-    // the scan to the batch's rows. hasNulls() fast-paths identity (flat)
-    // mappings, so no separate flat branch is needed.
-    notNullRows_.resizeFill(input->size());
-    notNullDecodedVector_.decode(*column, notNullRows_);
-    if (notNullDecodedVector_.hasNulls()) {
-      VELOX_USER_FAIL("NULL value not allowed for NOT NULL column: {}", name);
-    }
+    notNullDecodedVector_.decode(*input->childAt(channel), notNullRows_);
+    VELOX_USER_CHECK(
+        !notNullDecodedVector_.hasNulls(),
+        "NULL value not allowed for NOT NULL column: {}",
+        name);
   }
 }
 
@@ -183,9 +197,7 @@ void TableWriter::addInput(RowVectorPtr input) {
     return;
   }
 
-  if (!notNullChannels_.empty()) {
-    checkNotNullConstraints(input);
-  }
+  checkNotNullConstraints(input);
 
   std::vector<VectorPtr> mappedChildren;
   mappedChildren.reserve(inputMapping_.size());

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -16,8 +16,6 @@
 
 #include "velox/exec/TableWriter.h"
 
-#include <folly/container/F14Set.h>
-
 #include "velox/connectors/ConnectorRegistry.h"
 #include "velox/exec/OperatorType.h"
 #include "velox/exec/Task.h"
@@ -110,11 +108,9 @@ void TableWriter::setNotNullChannels(
     return;
   }
 
-  const folly::F14FastSet<std::string> notNullColumnSet(
-      notNullColumns.begin(), notNullColumns.end());
   const auto& targetNames = tableWriteNode->columnNames();
   for (auto i = 0; i < targetNames.size(); ++i) {
-    if (notNullColumnSet.contains(targetNames[i])) {
+    if (notNullColumns.contains(targetNames[i])) {
       notNullChannels_.emplace_back(inputMapping_[i], targetNames[i]);
     }
   }
@@ -170,18 +166,8 @@ void TableWriter::checkNotNullConstraints(const RowVectorPtr& input) {
     return;
   }
 
-  // Decoding catches nulls behind dictionary or constant wrapping. The scan is
-  // bounded to the batch's rows because a child may be longer than 'input'.
+  // Bounded to the batch's rows because a child may be longer than 'input'.
   notNullRows_.resizeFill(input->size());
-
-  // A null row of 'input' is null in every column, and addInput() forwards it
-  // to the data sink as such, but the children do not reflect it. Every
-  // constrained column is violated, so report the first.
-  notNullDecodedVector_.decode(*input, notNullRows_);
-  VELOX_USER_CHECK(
-      !notNullDecodedVector_.hasNulls(),
-      "NULL value not allowed for NOT NULL column: {}",
-      notNullChannels_.front().second);
 
   for (const auto& [channel, name] : notNullChannels_) {
     notNullDecodedVector_.decode(*input->childAt(channel), notNullRows_);

--- a/velox/exec/TableWriter.h
+++ b/velox/exec/TableWriter.h
@@ -21,6 +21,8 @@
 #include "velox/exec/ColumnStatsCollector.h"
 #include "velox/exec/MemoryReclaimer.h"
 #include "velox/exec/Operator.h"
+#include "velox/vector/DecodedVector.h"
+#include "velox/vector/SelectivityVector.h"
 
 namespace facebook::velox::exec {
 
@@ -171,6 +173,14 @@ class TableWriter : public Operator {
 
   // Contains the mappings between input and output columns.
   std::vector<column_index_t> inputMapping_;
+
+  // (channel, target name) pairs enforced as NOT NULL; set in
+  // setTypeMappings().
+  std::vector<std::pair<column_index_t, std::string>> notNullChannels_;
+
+  // Reused across addInput() calls to avoid reallocating per batch.
+  SelectivityVector notNullRows_;
+  DecodedVector notNullDecodedVector_;
 
   // Stores the mapped input and output types. Note that input types must have
   // the same types as the types receing in addInput(), but they may be in a

--- a/velox/exec/TableWriter.h
+++ b/velox/exec/TableWriter.h
@@ -172,6 +172,10 @@ class TableWriter : public Operator {
   // Contains the mappings between input and output columns.
   std::vector<column_index_t> inputMapping_;
 
+  // (channel, target name) pairs enforced as NOT NULL; set in
+  // setTypeMappings().
+  std::vector<std::pair<column_index_t, std::string>> notNullChannels_;
+
   // Stores the mapped input and output types. Note that input types must have
   // the same types as the types receing in addInput(), but they may be in a
   // different order. Output type may have different types to allow the writer

--- a/velox/exec/TableWriter.h
+++ b/velox/exec/TableWriter.h
@@ -21,6 +21,8 @@
 #include "velox/exec/ColumnStatsCollector.h"
 #include "velox/exec/MemoryReclaimer.h"
 #include "velox/exec/Operator.h"
+#include "velox/vector/DecodedVector.h"
+#include "velox/vector/SelectivityVector.h"
 
 namespace facebook::velox::exec {
 
@@ -175,6 +177,10 @@ class TableWriter : public Operator {
   // (channel, target name) pairs enforced as NOT NULL; set in
   // setTypeMappings().
   std::vector<std::pair<column_index_t, std::string>> notNullChannels_;
+
+  // Reused across addInput() calls to avoid reallocating per batch.
+  SelectivityVector notNullRows_;
+  DecodedVector notNullDecodedVector_;
 
   // Stores the mapped input and output types. Note that input types must have
   // the same types as the types receing in addInput(), but they may be in a

--- a/velox/exec/TableWriter.h
+++ b/velox/exec/TableWriter.h
@@ -153,6 +153,10 @@ class TableWriter : public Operator {
   // `mappedOutputType_`.
   void setTypeMappings(const core::TableWriteNodePtr& tableWriteNode);
 
+  // Throws a user error if 'input' has a null value in any of the
+  // 'notNullChannels_' columns.
+  void checkNotNullConstraints(const RowVectorPtr& input);
+
   std::string createTableCommitContext(bool lastOutput);
 
   void setConnectorMemoryReclaimer();

--- a/velox/exec/TableWriter.h
+++ b/velox/exec/TableWriter.h
@@ -153,8 +153,11 @@ class TableWriter : public Operator {
   // `mappedOutputType_`.
   void setTypeMappings(const core::TableWriteNodePtr& tableWriteNode);
 
-  // Throws a user error if 'input' has a null value in any of the
-  // 'notNullChannels_' columns.
+  // Fills 'notNullChannels_'. Must run after setTypeMappings(), which fills
+  // 'inputMapping_'.
+  void setNotNullChannels(const core::TableWriteNodePtr& tableWriteNode);
+
+  // Throws a user error if 'input' has a null in a NOT NULL column.
   void checkNotNullConstraints(const RowVectorPtr& input);
 
   std::string createTableCommitContext(bool lastOutput);
@@ -178,8 +181,8 @@ class TableWriter : public Operator {
   // Contains the mappings between input and output columns.
   std::vector<column_index_t> inputMapping_;
 
-  // (channel, target name) pairs enforced as NOT NULL; set in
-  // setTypeMappings().
+  // Input channels of the NOT NULL columns, each with the target column name
+  // to report in the error.
   std::vector<std::pair<column_index_t, std::string>> notNullChannels_;
 
   // Reused across addInput() calls to avoid reallocating per batch.

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -116,6 +116,7 @@ set(
   # group5 (~445s): TableWriterTest 225 + DefaultOutputBufMgr 98
   # + TopNRowNumber 64 + StreamingAgg 58
   TableWriterTest.cpp
+  TableWriterNotNullTest.cpp
   DefaultOutputBufferManagerTest.cpp
   TopNRowNumberTest.cpp
   StreamingAggregationTest.cpp

--- a/velox/exec/tests/PlanBuilderTest.cpp
+++ b/velox/exec/tests/PlanBuilderTest.cpp
@@ -470,7 +470,9 @@ TEST_F(PlanBuilderTest, insertTableHandleParameter) {
           connector::hive::LocationHandle::TableType::kNew));
 
   auto insertHandle = std::make_shared<core::InsertTableHandle>(
-      std::string(PlanBuilder::kHiveDefaultConnectorId), hiveHandle);
+      std::string(PlanBuilder::kHiveDefaultConnectorId),
+      hiveHandle,
+      /*notNullColumns=*/std::vector<std::string>{});
   testInsertTableHandle(insertHandle);
 }
 

--- a/velox/exec/tests/PlanBuilderTest.cpp
+++ b/velox/exec/tests/PlanBuilderTest.cpp
@@ -428,36 +428,6 @@ TEST_F(PlanBuilderTest, insertTableHandleParameter) {
   auto data = makeRowVector({makeFlatVector<int64_t>(10, folly::identity)});
   auto directory = "/some/test/directory";
 
-  // Lambda to create a plan with given insertableHandle and verify it
-  auto testInsertTableHandle =
-      [&](std::shared_ptr<core::InsertTableHandle> insertTableHandle) {
-        // Create a plan with insertTableHandle
-        auto planBuilder = PlanBuilder().values({data}).tableWrite(
-            directory,
-            {},
-            0,
-            {},
-            {},
-            dwio::common::FileFormat::DWRF,
-            {},
-            PlanBuilder::kHiveDefaultConnectorId,
-            {},
-            nullptr,
-            "",
-            common::CompressionKind_NONE,
-            nullptr,
-            false,
-            connector::CommitStrategy::kNoCommit,
-            insertTableHandle);
-
-        // Verify the plan node has the correct insert Table Handle.
-        auto tableWriteNode =
-            std::dynamic_pointer_cast<const core::TableWriteNode>(
-                planBuilder.planNode());
-        ASSERT_NE(tableWriteNode, nullptr);
-        ASSERT_EQ(tableWriteNode->insertTableHandle(), insertTableHandle);
-      };
-
   auto rowType = ROW({"c0", "c1", "c2"}, {BIGINT(), INTEGER(), SMALLINT()});
   auto hiveHandle = HiveConnectorTestBase::makeHiveInsertTableHandle(
       rowType->names(),
@@ -469,11 +439,30 @@ TEST_F(PlanBuilderTest, insertTableHandleParameter) {
           std::nullopt,
           connector::hive::LocationHandle::TableType::kNew));
 
-  auto insertHandle = std::make_shared<core::InsertTableHandle>(
-      std::string(PlanBuilder::kHiveDefaultConnectorId),
-      hiveHandle,
-      /*notNullColumns=*/std::vector<std::string>{});
-  testInsertTableHandle(insertHandle);
+  auto planBuilder = PlanBuilder().values({data}).tableWrite(
+      directory,
+      {},
+      0,
+      {},
+      {},
+      dwio::common::FileFormat::DWRF,
+      {},
+      PlanBuilder::kHiveDefaultConnectorId,
+      {},
+      nullptr,
+      "",
+      common::CompressionKind_NONE,
+      nullptr,
+      false,
+      connector::CommitStrategy::kNoCommit,
+      hiveHandle);
+
+  auto tableWriteNode = std::dynamic_pointer_cast<const core::TableWriteNode>(
+      planBuilder.planNode());
+  ASSERT_NE(tableWriteNode, nullptr);
+  ASSERT_EQ(
+      tableWriteNode->insertTableHandle()->connectorInsertTableHandle(),
+      hiveHandle);
 }
 
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/PlanNodeSerdeTest.cpp
+++ b/velox/exec/tests/PlanNodeSerdeTest.cpp
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <gmock/gmock-matchers.h>
+
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/core/FixedPointPlanNodes.h"
@@ -778,6 +780,58 @@ TEST_F(PlanNodeSerdeTest, write) {
              .tableWrite("targetDirectory")
              .planNode();
   testSerde(plan);
+}
+
+TEST_F(PlanNodeSerdeTest, writeWithNotNullConstraints) {
+  auto plan = PlanBuilder(pool_.get())
+                  .values(data_)
+                  .tableWrite("targetDirectory")
+                  .planNode();
+
+  auto* writeNode = dynamic_cast<const core::TableWriteNode*>(plan.get());
+  ASSERT_NE(writeNode, nullptr);
+
+  auto planWithConstraints = core::TableWriteNode::Builder(*writeNode)
+                                 .notNullColumnNames({"c0", "c2"})
+                                 .build();
+
+  EXPECT_THAT(
+      planWithConstraints->toString(true, true),
+      testing::HasSubstr("notNullColumns: [c0, c2]"));
+  EXPECT_THAT(
+      plan->toString(true, true),
+      testing::Not(testing::HasSubstr("notNullColumns")));
+
+  const auto serialized = planWithConstraints->serialize();
+  const auto copy =
+      velox::ISerializable::deserialize<core::PlanNode>(serialized, pool());
+  const auto* copyWrite = dynamic_cast<const core::TableWriteNode*>(copy.get());
+  ASSERT_NE(copyWrite, nullptr);
+  ASSERT_TRUE(copyWrite->notNullColumnNames().has_value());
+  EXPECT_EQ(
+      *copyWrite->notNullColumnNames(), (std::vector<std::string>{"c0", "c2"}));
+
+  const auto serializedNone = plan->serialize();
+  const auto copyNone =
+      velox::ISerializable::deserialize<core::PlanNode>(serializedNone, pool());
+  const auto* copyWriteNone =
+      dynamic_cast<const core::TableWriteNode*>(copyNone.get());
+  ASSERT_NE(copyWriteNone, nullptr);
+  EXPECT_FALSE(copyWriteNone->notNullColumnNames().has_value());
+
+  // Empty list vs. std::nullopt must remain distinguishable after serde.
+  auto planWithEmptyConstraints =
+      core::TableWriteNode::Builder(*writeNode)
+          .notNullColumnNames(std::vector<std::string>{})
+          .build();
+  const auto serializedEmpty = planWithEmptyConstraints->serialize();
+  const auto copyEmpty = velox::ISerializable::deserialize<core::PlanNode>(
+      serializedEmpty, pool());
+  const auto* copyWriteEmpty =
+      dynamic_cast<const core::TableWriteNode*>(copyEmpty.get());
+  ASSERT_NE(copyWriteEmpty, nullptr);
+  ASSERT_TRUE(copyWriteEmpty->notNullColumnNames().has_value());
+  EXPECT_TRUE(copyWriteEmpty->notNullColumnNames()->empty());
 }
 
 TEST_F(PlanNodeSerdeTest, tableWriteMerge) {

--- a/velox/exec/tests/PlanNodeSerdeTest.cpp
+++ b/velox/exec/tests/PlanNodeSerdeTest.cpp
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <gmock/gmock.h>
-
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/core/FixedPointPlanNodes.h"
@@ -782,46 +780,15 @@ TEST_F(PlanNodeSerdeTest, write) {
   testSerde(plan);
 }
 
-TEST_F(PlanNodeSerdeTest, writeWithNotNullConstraints) {
+TEST_F(PlanNodeSerdeTest, writeWithNotNullColumns) {
   auto plan = PlanBuilder(pool_.get())
                   .values(data_)
-                  .tableWrite("targetDirectory")
+                  .startTableWriter()
+                  .outputDirectoryPath("targetDirectory")
+                  .notNullColumns({"c0", "c2"})
+                  .endTableWriter()
                   .planNode();
-
-  auto* writeNode = dynamic_cast<const core::TableWriteNode*>(plan.get());
-  ASSERT_NE(writeNode, nullptr);
-
-  auto insertHandleWithConstraints = std::make_shared<core::InsertTableHandle>(
-      writeNode->insertTableHandle()->connectorId(),
-      writeNode->insertTableHandle()->connectorInsertTableHandle(),
-      std::vector<std::string>{"c0", "c2"});
-  auto planWithConstraints = core::TableWriteNode::Builder(*writeNode)
-                                 .insertTableHandle(insertHandleWithConstraints)
-                                 .build();
-
-  EXPECT_THAT(
-      planWithConstraints->toString(true, true),
-      testing::HasSubstr("notNullColumns: [c0, c2]"));
-  EXPECT_THAT(
-      plan->toString(true, true),
-      testing::Not(testing::HasSubstr("notNullColumns")));
-
-  const auto serialized = planWithConstraints->serialize();
-  const auto copy =
-      velox::ISerializable::deserialize<core::PlanNode>(serialized, pool());
-  const auto* copyWrite = dynamic_cast<const core::TableWriteNode*>(copy.get());
-  ASSERT_NE(copyWrite, nullptr);
-  EXPECT_EQ(
-      copyWrite->insertTableHandle()->notNullColumnNames(),
-      (std::vector<std::string>{"c0", "c2"}));
-
-  const auto serializedNone = plan->serialize();
-  const auto copyNone =
-      velox::ISerializable::deserialize<core::PlanNode>(serializedNone, pool());
-  const auto* copyWriteNone =
-      dynamic_cast<const core::TableWriteNode*>(copyNone.get());
-  ASSERT_NE(copyWriteNone, nullptr);
-  EXPECT_TRUE(copyWriteNone->insertTableHandle()->notNullColumnNames().empty());
+  testSerde(plan);
 }
 
 TEST_F(PlanNodeSerdeTest, tableWriteMerge) {

--- a/velox/exec/tests/PlanNodeSerdeTest.cpp
+++ b/velox/exec/tests/PlanNodeSerdeTest.cpp
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <gmock/gmock-matchers.h>
+#include <gmock/gmock.h>
 
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/connectors/hive/HiveConnector.h"
@@ -791,8 +791,12 @@ TEST_F(PlanNodeSerdeTest, writeWithNotNullConstraints) {
   auto* writeNode = dynamic_cast<const core::TableWriteNode*>(plan.get());
   ASSERT_NE(writeNode, nullptr);
 
+  auto insertHandleWithConstraints = std::make_shared<core::InsertTableHandle>(
+      writeNode->insertTableHandle()->connectorId(),
+      writeNode->insertTableHandle()->connectorInsertTableHandle(),
+      std::vector<std::string>{"c0", "c2"});
   auto planWithConstraints = core::TableWriteNode::Builder(*writeNode)
-                                 .notNullColumnNames({"c0", "c2"})
+                                 .insertTableHandle(insertHandleWithConstraints)
                                  .build();
 
   EXPECT_THAT(
@@ -807,9 +811,9 @@ TEST_F(PlanNodeSerdeTest, writeWithNotNullConstraints) {
       velox::ISerializable::deserialize<core::PlanNode>(serialized, pool());
   const auto* copyWrite = dynamic_cast<const core::TableWriteNode*>(copy.get());
   ASSERT_NE(copyWrite, nullptr);
-  ASSERT_TRUE(copyWrite->notNullColumnNames().has_value());
   EXPECT_EQ(
-      *copyWrite->notNullColumnNames(), (std::vector<std::string>{"c0", "c2"}));
+      copyWrite->insertTableHandle()->notNullColumnNames(),
+      (std::vector<std::string>{"c0", "c2"}));
 
   const auto serializedNone = plan->serialize();
   const auto copyNone =
@@ -817,21 +821,7 @@ TEST_F(PlanNodeSerdeTest, writeWithNotNullConstraints) {
   const auto* copyWriteNone =
       dynamic_cast<const core::TableWriteNode*>(copyNone.get());
   ASSERT_NE(copyWriteNone, nullptr);
-  EXPECT_FALSE(copyWriteNone->notNullColumnNames().has_value());
-
-  // Empty list vs. std::nullopt must remain distinguishable after serde.
-  auto planWithEmptyConstraints =
-      core::TableWriteNode::Builder(*writeNode)
-          .notNullColumnNames(std::vector<std::string>{})
-          .build();
-  const auto serializedEmpty = planWithEmptyConstraints->serialize();
-  const auto copyEmpty = velox::ISerializable::deserialize<core::PlanNode>(
-      serializedEmpty, pool());
-  const auto* copyWriteEmpty =
-      dynamic_cast<const core::TableWriteNode*>(copyEmpty.get());
-  ASSERT_NE(copyWriteEmpty, nullptr);
-  ASSERT_TRUE(copyWriteEmpty->notNullColumnNames().has_value());
-  EXPECT_TRUE(copyWriteEmpty->notNullColumnNames()->empty());
+  EXPECT_TRUE(copyWriteNone->insertTableHandle()->notNullColumnNames().empty());
 }
 
 TEST_F(PlanNodeSerdeTest, tableWriteMerge) {

--- a/velox/exec/tests/PlanNodeSerdeTest.cpp
+++ b/velox/exec/tests/PlanNodeSerdeTest.cpp
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <gmock/gmock-matchers.h>
+
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/core/FixedPointPlanNodes.h"
@@ -777,6 +779,58 @@ TEST_F(PlanNodeSerdeTest, write) {
              .tableWrite("targetDirectory")
              .planNode();
   testSerde(plan);
+}
+
+TEST_F(PlanNodeSerdeTest, writeWithNotNullConstraints) {
+  auto plan = PlanBuilder(pool_.get())
+                  .values(data_)
+                  .tableWrite("targetDirectory")
+                  .planNode();
+
+  auto* writeNode = dynamic_cast<const core::TableWriteNode*>(plan.get());
+  ASSERT_NE(writeNode, nullptr);
+
+  auto planWithConstraints = core::TableWriteNode::Builder(*writeNode)
+                                 .notNullColumnNames({"c0", "c2"})
+                                 .build();
+
+  EXPECT_THAT(
+      planWithConstraints->toString(true, true),
+      testing::HasSubstr("notNullColumns: [c0, c2]"));
+  EXPECT_THAT(
+      plan->toString(true, true),
+      testing::Not(testing::HasSubstr("notNullColumns")));
+
+  const auto serialized = planWithConstraints->serialize();
+  const auto copy =
+      velox::ISerializable::deserialize<core::PlanNode>(serialized, pool());
+  const auto* copyWrite = dynamic_cast<const core::TableWriteNode*>(copy.get());
+  ASSERT_NE(copyWrite, nullptr);
+  ASSERT_TRUE(copyWrite->notNullColumnNames().has_value());
+  EXPECT_EQ(
+      *copyWrite->notNullColumnNames(), (std::vector<std::string>{"c0", "c2"}));
+
+  const auto serializedNone = plan->serialize();
+  const auto copyNone =
+      velox::ISerializable::deserialize<core::PlanNode>(serializedNone, pool());
+  const auto* copyWriteNone =
+      dynamic_cast<const core::TableWriteNode*>(copyNone.get());
+  ASSERT_NE(copyWriteNone, nullptr);
+  EXPECT_FALSE(copyWriteNone->notNullColumnNames().has_value());
+
+  // Empty list vs. std::nullopt must remain distinguishable after serde.
+  auto planWithEmptyConstraints =
+      core::TableWriteNode::Builder(*writeNode)
+          .notNullColumnNames(std::vector<std::string>{})
+          .build();
+  const auto serializedEmpty = planWithEmptyConstraints->serialize();
+  const auto copyEmpty = velox::ISerializable::deserialize<core::PlanNode>(
+      serializedEmpty, pool());
+  const auto* copyWriteEmpty =
+      dynamic_cast<const core::TableWriteNode*>(copyEmpty.get());
+  ASSERT_NE(copyWriteEmpty, nullptr);
+  ASSERT_TRUE(copyWriteEmpty->notNullColumnNames().has_value());
+  EXPECT_TRUE(copyWriteEmpty->notNullColumnNames()->empty());
 }
 
 TEST_F(PlanNodeSerdeTest, tableWriteMerge) {

--- a/velox/exec/tests/PlanNodeSerdeTest.cpp
+++ b/velox/exec/tests/PlanNodeSerdeTest.cpp
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <gmock/gmock-matchers.h>
+#include <gmock/gmock.h>
 
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/connectors/hive/HiveConnector.h"
@@ -790,8 +790,12 @@ TEST_F(PlanNodeSerdeTest, writeWithNotNullConstraints) {
   auto* writeNode = dynamic_cast<const core::TableWriteNode*>(plan.get());
   ASSERT_NE(writeNode, nullptr);
 
+  auto insertHandleWithConstraints = std::make_shared<core::InsertTableHandle>(
+      writeNode->insertTableHandle()->connectorId(),
+      writeNode->insertTableHandle()->connectorInsertTableHandle(),
+      std::vector<std::string>{"c0", "c2"});
   auto planWithConstraints = core::TableWriteNode::Builder(*writeNode)
-                                 .notNullColumnNames({"c0", "c2"})
+                                 .insertTableHandle(insertHandleWithConstraints)
                                  .build();
 
   EXPECT_THAT(
@@ -806,9 +810,9 @@ TEST_F(PlanNodeSerdeTest, writeWithNotNullConstraints) {
       velox::ISerializable::deserialize<core::PlanNode>(serialized, pool());
   const auto* copyWrite = dynamic_cast<const core::TableWriteNode*>(copy.get());
   ASSERT_NE(copyWrite, nullptr);
-  ASSERT_TRUE(copyWrite->notNullColumnNames().has_value());
   EXPECT_EQ(
-      *copyWrite->notNullColumnNames(), (std::vector<std::string>{"c0", "c2"}));
+      copyWrite->insertTableHandle()->notNullColumnNames(),
+      (std::vector<std::string>{"c0", "c2"}));
 
   const auto serializedNone = plan->serialize();
   const auto copyNone =
@@ -816,21 +820,7 @@ TEST_F(PlanNodeSerdeTest, writeWithNotNullConstraints) {
   const auto* copyWriteNone =
       dynamic_cast<const core::TableWriteNode*>(copyNone.get());
   ASSERT_NE(copyWriteNone, nullptr);
-  EXPECT_FALSE(copyWriteNone->notNullColumnNames().has_value());
-
-  // Empty list vs. std::nullopt must remain distinguishable after serde.
-  auto planWithEmptyConstraints =
-      core::TableWriteNode::Builder(*writeNode)
-          .notNullColumnNames(std::vector<std::string>{})
-          .build();
-  const auto serializedEmpty = planWithEmptyConstraints->serialize();
-  const auto copyEmpty = velox::ISerializable::deserialize<core::PlanNode>(
-      serializedEmpty, pool());
-  const auto* copyWriteEmpty =
-      dynamic_cast<const core::TableWriteNode*>(copyEmpty.get());
-  ASSERT_NE(copyWriteEmpty, nullptr);
-  ASSERT_TRUE(copyWriteEmpty->notNullColumnNames().has_value());
-  EXPECT_TRUE(copyWriteEmpty->notNullColumnNames()->empty());
+  EXPECT_TRUE(copyWriteNone->insertTableHandle()->notNullColumnNames().empty());
 }
 
 TEST_F(PlanNodeSerdeTest, tableWriteMerge) {

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -1046,6 +1046,21 @@ TEST_F(PlanNodeToStringTest, tableWrite) {
         plan->toString(true, false));
   }
 
+  // TableWrite with NOT NULL columns.
+  {
+    auto plan = PlanBuilder()
+                    .values({data_})
+                    .startTableWriter()
+                    .outputDirectoryPath(outputDir->getPath())
+                    .notNullColumns({"c0", "c2"})
+                    .endTableWriter()
+                    .planNode();
+    ASSERT_EQ("-- TableWrite[1]\n", plan->toString());
+    ASSERT_EQ(
+        "-- TableWrite[1][test-hive, c0, c1, c2, notNullColumns: [c0, c2]] -> rows:BIGINT, fragments:VARBINARY, commitcontext:VARBINARY\n",
+        plan->toString(true, false));
+  }
+
   // TableWrite with stats (no grouping keys) and TableWriteMerge.
   {
     core::TableWriteNodePtr writeNode;

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -1057,7 +1057,7 @@ TEST_F(PlanNodeToStringTest, tableWrite) {
                     .planNode();
     ASSERT_EQ("-- TableWrite[1]\n", plan->toString());
     ASSERT_EQ(
-        "-- TableWrite[1][test-hive, c0, c1, c2, notNullColumns: [c0, c2]] -> rows:BIGINT, fragments:VARBINARY, commitcontext:VARBINARY\n",
+        "-- TableWrite[1][test-hive, c0 not null, c1, c2 not null] -> rows:BIGINT, fragments:VARBINARY, commitcontext:VARBINARY\n",
         plan->toString(true, false));
   }
 

--- a/velox/exec/tests/TableWriterNotNullTest.cpp
+++ b/velox/exec/tests/TableWriterNotNullTest.cpp
@@ -21,32 +21,29 @@
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 
-namespace facebook::velox::exec::test {
+using namespace facebook::velox::exec::test;
 
+namespace facebook::velox::exec {
 using namespace facebook::velox::common::testutil;
+namespace {
 
 // Writes data through a TableWriter whose target columns carry a NOT NULL
 // constraint, and checks which nulls the operator rejects and which it lets
 // through.
 class TableWriterNotNullTest : public HiveConnectorTestBase {
  protected:
-  // Plans a write of 'input' into a fresh directory. 'targetColumns', when set,
-  // selects and reorders the written columns.
+  // Plans a write of 'input' into a fresh directory.
   core::PlanNodePtr writePlan(
       const std::vector<RowVectorPtr>& input,
-      const folly::F14FastSet<std::string>& notNullColumns,
-      const RowTypePtr& targetColumns = nullptr) {
+      const folly::F14FastSet<std::string>& notNullColumns) {
     directories_.push_back(TempDirectoryPath::create());
-    PlanBuilder planBuilder;
-    auto& writerBuilder =
-        planBuilder.values(input)
-            .startTableWriter()
-            .outputDirectoryPath(directories_.back()->getPath())
-            .notNullColumns(notNullColumns);
-    if (targetColumns != nullptr) {
-      writerBuilder.targetColumns(targetColumns);
-    }
-    return writerBuilder.endTableWriter().planNode();
+    return PlanBuilder()
+        .values(input)
+        .startTableWriter()
+        .outputDirectoryPath(directories_.back()->getPath())
+        .notNullColumns(notNullColumns)
+        .endTableWriter()
+        .planNode();
   }
 
   int64_t writtenRows(const core::PlanNodePtr& plan) {
@@ -62,99 +59,87 @@ class TableWriterNotNullTest : public HiveConnectorTestBase {
 };
 
 TEST_F(TableWriterNotNullTest, enforcement) {
-  const vector_size_t size = 100;
-  auto nonNulls = makeFlatVector<int32_t>(size, [](auto row) { return row; });
-  auto values =
-      makeFlatVector<int32_t>(size, [](auto row) { return row; }, nullEvery(3));
-  auto indices = makeIndices(size, [](auto row) { return row; });
-  // The same nulls presented flat, dictionary- and constant-wrapped, and as a
-  // struct that is itself null.
-  const std::vector<VectorPtr> nullColumns = {
-      values,
-      wrapInDictionary(indices, size, values),
-      makeNullConstant(TypeKind::INTEGER, size),
-      makeRowVector({nonNulls}, nullEvery(3)),
-  };
+  auto data = makeRowVector(
+      {"c0", "c1"},
+      {
+          makeFlatVector<int32_t>({0, 1, 2}),
+          makeNullableFlatVector<int32_t>({0, std::nullopt, 2}),
+      });
 
-  for (const auto& nullColumn : nullColumns) {
-    SCOPED_TRACE(nullColumn->toString());
-    auto data = makeRowVector({"c0", "c1"}, {nonNulls, nullColumn});
+  VELOX_ASSERT_USER_THROW(
+      AssertQueryBuilder(writePlan({data}, {"c0", "c1"})).countResults(),
+      "NULL value not allowed for NOT NULL column: c1");
 
-    // Constraining c0 leaves the nulls in c1 alone.
-    ASSERT_EQ(writtenRows(writePlan({data}, {"c0"})), size);
-
-    VELOX_ASSERT_USER_THROW(
-        AssertQueryBuilder(writePlan({data}, {"c0", "c1"})).countResults(),
-        "NULL value not allowed for NOT NULL column: c1");
-  }
+  ASSERT_EQ(writtenRows(writePlan({data}, {"c0"})), data->size());
 }
 
-// Nulls inside a struct's fields are the fields' nulls, not the column's.
-TEST_F(TableWriterNotNullTest, nullsInsideStruct) {
-  const vector_size_t size = 10;
-  auto data = makeRowVector(
-      {"c0"},
-      {makeRowVector({makeFlatVector<int32_t>(
-          size, [](auto row) { return row; }, nullEvery(3))})});
+// A dictionary wrap decides the column's nulls: it may add nulls the base does
+// not have, and hide nulls the base does have.
+TEST_F(TableWriterNotNullTest, dictionaryEncoding) {
+  auto nullFree = makeFlatVector<int32_t>({0, 1, 2});
+  auto withNulls = makeNullableFlatVector<int32_t>({0, std::nullopt, 2});
 
-  ASSERT_EQ(writtenRows(writePlan({data}, {"c0"})), size);
+  // The wrap adds a null over a null-free base.
+  auto addsNulls = makeRowVector(
+      {"c0"},
+      {BaseVector::wrapInDictionary(
+          makeNulls({false, true, false}),
+          makeIndices({0, 1, 2}),
+          3,
+          nullFree)});
+  VELOX_ASSERT_USER_THROW(
+      AssertQueryBuilder(writePlan({addsNulls}, {"c0"})).countResults(),
+      "NULL value not allowed for NOT NULL column: c0");
+
+  // The wrap selects only the base's non-null rows.
+  auto hidesNulls =
+      makeRowVector({"c0"}, {wrapInDictionary(makeIndices({2, 0}), withNulls)});
+  ASSERT_EQ(writtenRows(writePlan({hidesNulls}, {"c0"})), 2);
+
+  // The wrap selects some of the base's rows, one of them null.
+  auto keepsNull =
+      makeRowVector({"c0"}, {wrapInDictionary(makeIndices({2, 1}), withNulls)});
+  VELOX_ASSERT_USER_THROW(
+      AssertQueryBuilder(writePlan({keepsNull}, {"c0"})).countResults(),
+      "NULL value not allowed for NOT NULL column: c0");
+}
+
+TEST_F(TableWriterNotNullTest, constantNull) {
+  auto data = makeRowVector({"c0"}, {makeNullConstant(TypeKind::INTEGER, 3)});
+
+  VELOX_ASSERT_USER_THROW(
+      AssertQueryBuilder(writePlan({data}, {"c0"})).countResults(),
+      "NULL value not allowed for NOT NULL column: c0");
 }
 
 // A RowVector may be shorter than its children, as in Limit's output. Nulls
 // past its size are not part of the batch.
 TEST_F(TableWriterNotNullTest, ignoresNullsBeyondBatchSize) {
-  const vector_size_t childSize = 10;
-  const vector_size_t batchSize = 4;
-  auto indices = makeIndices(childSize, [](auto row) { return row; });
-  auto base = makeFlatVector<int32_t>(
-      childSize,
-      [](auto row) { return row; },
-      [batchSize](auto row) { return row >= batchSize; });
+  const vector_size_t batchSize = 2;
   auto data = std::make_shared<RowVector>(
       pool(),
-      ROW({"c0"}, {INTEGER()}),
+      ROW("c0", INTEGER()),
       nullptr,
       batchSize,
-      std::vector<VectorPtr>{wrapInDictionary(indices, childSize, base)});
+      std::vector<VectorPtr>{
+          makeNullableFlatVector<int32_t>({0, 1, std::nullopt})});
 
   ASSERT_EQ(writtenRows(writePlan({data}, {"c0"})), batchSize);
 }
 
-// The constraint names target table columns, which may be a reordered subset
-// of the input columns.
-TEST_F(TableWriterNotNullTest, reorderedColumns) {
-  const vector_size_t size = 10;
-  auto data = makeRowVector(
-      {"c0", "c1", "c2"},
-      {
-          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
-          makeFlatVector<int32_t>(size, [](auto row) { return row * 2; }),
-          makeFlatVector<int32_t>(
-              size, [](auto row) { return row * 3; }, nullEvery(3)),
-      });
-  auto targetColumns = ROW({"c2", "c0"}, {INTEGER(), INTEGER()});
-
-  ASSERT_EQ(writtenRows(writePlan({data}, {"c0"}, targetColumns)), size);
-
-  VELOX_ASSERT_USER_THROW(
-      AssertQueryBuilder(writePlan({data}, {"c2"}, targetColumns))
-          .countResults(),
-      "NULL value not allowed for NOT NULL column: c2");
-}
-
-// The constraint names the table's columns, which may differ from the input's.
-// PlanBuilder always writes under the input names, so build the node directly.
+// The constraint names the table's columns, which may be renamed and reordered
+// relative to the input's. PlanBuilder writes under the input names, so build
+// the node directly.
 TEST_F(TableWriterNotNullTest, renamedColumns) {
-  const vector_size_t size = 10;
   auto data = makeRowVector(
       {"c0", "c1"},
       {
-          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
-          makeFlatVector<int32_t>(
-              size, [](auto row) { return row; }, nullEvery(3)),
+          makeFlatVector<int32_t>({0, 1, 2}),
+          makeNullableFlatVector<int32_t>({0, std::nullopt, 2}),
       });
-  const auto inputColumns = asRowType(data->type());
-  const std::vector<std::string> tableColumnNames = {"key", "value"};
+  // 'value' is input column c1, 'key' is c0.
+  const auto targetColumns = ROW({"c1", "c0"}, INTEGER());
+  const std::vector<std::string> tableColumnNames = {"value", "key"};
 
   auto directory = TempDirectoryPath::create();
   auto writePlan = [&](const folly::F14FastSet<std::string>& notNullColumns) {
@@ -162,7 +147,7 @@ TEST_F(TableWriterNotNullTest, renamedColumns) {
         kHiveConnectorId,
         makeHiveInsertTableHandle(
             tableColumnNames,
-            inputColumns->children(),
+            targetColumns->children(),
             /*partitionedBy=*/{},
             makeLocationHandle(directory->getPath())),
         notNullColumns);
@@ -171,7 +156,7 @@ TEST_F(TableWriterNotNullTest, renamedColumns) {
         .addNode([&](const core::PlanNodeId& nodeId, core::PlanNodePtr source) {
           return std::make_shared<core::TableWriteNode>(
               nodeId,
-              inputColumns,
+              targetColumns,
               tableColumnNames,
               /*columnStatsSpec=*/std::nullopt,
               insertHandle,
@@ -183,45 +168,30 @@ TEST_F(TableWriterNotNullTest, renamedColumns) {
         .planNode();
   };
 
-  // 'key' maps to input column c0, which has no nulls.
-  ASSERT_EQ(writtenRows(writePlan({"key"})), size);
+  ASSERT_EQ(writtenRows(writePlan({"key"})), data->size());
 
   VELOX_ASSERT_USER_THROW(
       AssertQueryBuilder(writePlan({"value"})).countResults(),
       "NULL value not allowed for NOT NULL column: value");
 }
 
-// The reused DecodedVector must not break on a change of size or encoding, nor
-// mask a null in a later batch.
+// The reused DecodedVector must not break on a change of batch size or
+// encoding, nor mask a null in a later batch.
 TEST_F(TableWriterNotNullTest, multipleBatches) {
-  auto makeBatch = [&](vector_size_t size, bool dictionary, bool hasNulls) {
-    std::function<bool(vector_size_t)> isNullAt;
-    if (hasNulls) {
-      isNullAt = nullEvery(3);
-    }
-    auto values =
-        makeFlatVector<int32_t>(size, [](auto row) { return row; }, isNullAt);
-    if (!dictionary) {
-      return makeRowVector({"c0"}, {values});
-    }
-    auto indices = makeIndices(size, [](auto row) { return row; });
-    return makeRowVector({"c0"}, {wrapInDictionary(indices, size, values)});
-  };
+  auto flat = makeRowVector({"c0"}, {makeFlatVector<int32_t>({0, 1, 2})});
+  auto dictionary = makeRowVector(
+      {"c0"},
+      {wrapInDictionary(makeIndices({1, 0}), makeFlatVector<int32_t>({0, 1}))});
+  auto withNull =
+      makeRowVector({"c0"}, {makeNullableFlatVector<int32_t>({std::nullopt})});
 
-  ASSERT_EQ(
-      writtenRows(writePlan(
-          {makeBatch(10, false, false),
-           makeBatch(50, true, false),
-           makeBatch(1, true, false)},
-          {"c0"})),
-      61);
+  ASSERT_EQ(writtenRows(writePlan({flat, dictionary}, {"c0"})), 5);
 
   VELOX_ASSERT_USER_THROW(
-      AssertQueryBuilder(
-          writePlan(
-              {makeBatch(10, false, false), makeBatch(5, true, true)}, {"c0"}))
+      AssertQueryBuilder(writePlan({flat, dictionary, withNull}, {"c0"}))
           .countResults(),
       "NULL value not allowed for NOT NULL column: c0");
 }
 
-} // namespace facebook::velox::exec::test
+} // namespace
+} // namespace facebook::velox::exec

--- a/velox/exec/tests/TableWriterNotNullTest.cpp
+++ b/velox/exec/tests/TableWriterNotNullTest.cpp
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/testutil/TempDirectoryPath.h"
+#include "velox/exec/TableWriter.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+namespace facebook::velox::exec::test {
+
+using namespace facebook::velox::common::testutil;
+
+// Writes data through a TableWriter whose target columns carry a NOT NULL
+// constraint, and checks which nulls the operator rejects and which it lets
+// through.
+class TableWriterNotNullTest : public HiveConnectorTestBase {
+ protected:
+  // Plans a write of 'input' into a fresh directory. 'targetColumns', when set,
+  // selects and reorders the written columns.
+  core::PlanNodePtr writePlan(
+      const std::vector<RowVectorPtr>& input,
+      const folly::F14FastSet<std::string>& notNullColumns,
+      const RowTypePtr& targetColumns = nullptr) {
+    directories_.push_back(TempDirectoryPath::create());
+    PlanBuilder planBuilder;
+    auto& writerBuilder =
+        planBuilder.values(input)
+            .startTableWriter()
+            .outputDirectoryPath(directories_.back()->getPath())
+            .notNullColumns(notNullColumns);
+    if (targetColumns != nullptr) {
+      writerBuilder.targetColumns(targetColumns);
+    }
+    return writerBuilder.endTableWriter().planNode();
+  }
+
+  int64_t writtenRows(const core::PlanNodePtr& plan) {
+    const auto results = AssertQueryBuilder(plan).copyResults(pool());
+    const auto* rowCount = results->childAt(TableWriteTraits::kRowCountChannel)
+                               ->as<FlatVector<int64_t>>();
+    VELOX_CHECK(!rowCount->isNullAt(0));
+    return rowCount->valueAt(0);
+  }
+
+  // Keeps the plans' output directories alive.
+  std::vector<std::shared_ptr<TempDirectoryPath>> directories_;
+};
+
+TEST_F(TableWriterNotNullTest, enforcement) {
+  const vector_size_t size = 100;
+  auto nonNulls = makeFlatVector<int32_t>(size, [](auto row) { return row; });
+  auto values =
+      makeFlatVector<int32_t>(size, [](auto row) { return row; }, nullEvery(3));
+  auto indices = makeIndices(size, [](auto row) { return row; });
+  // The same nulls presented flat, dictionary- and constant-wrapped, and as a
+  // struct that is itself null.
+  const std::vector<VectorPtr> nullColumns = {
+      values,
+      wrapInDictionary(indices, size, values),
+      makeNullConstant(TypeKind::INTEGER, size),
+      makeRowVector({nonNulls}, nullEvery(3)),
+  };
+
+  for (const auto& nullColumn : nullColumns) {
+    SCOPED_TRACE(nullColumn->toString());
+    auto data = makeRowVector({"c0", "c1"}, {nonNulls, nullColumn});
+
+    // Constraining c0 leaves the nulls in c1 alone.
+    ASSERT_EQ(writtenRows(writePlan({data}, {"c0"})), size);
+
+    VELOX_ASSERT_USER_THROW(
+        AssertQueryBuilder(writePlan({data}, {"c0", "c1"})).countResults(),
+        "NULL value not allowed for NOT NULL column: c1");
+  }
+}
+
+// Nulls inside a struct's fields are the fields' nulls, not the column's.
+TEST_F(TableWriterNotNullTest, nullsInsideStruct) {
+  const vector_size_t size = 10;
+  auto data = makeRowVector(
+      {"c0"},
+      {makeRowVector({makeFlatVector<int32_t>(
+          size, [](auto row) { return row; }, nullEvery(3))})});
+
+  ASSERT_EQ(writtenRows(writePlan({data}, {"c0"})), size);
+}
+
+// A RowVector may be shorter than its children, as in Limit's output. Nulls
+// past its size are not part of the batch.
+TEST_F(TableWriterNotNullTest, ignoresNullsBeyondBatchSize) {
+  const vector_size_t childSize = 10;
+  const vector_size_t batchSize = 4;
+  auto indices = makeIndices(childSize, [](auto row) { return row; });
+  auto base = makeFlatVector<int32_t>(
+      childSize,
+      [](auto row) { return row; },
+      [batchSize](auto row) { return row >= batchSize; });
+  auto data = std::make_shared<RowVector>(
+      pool(),
+      ROW({"c0"}, {INTEGER()}),
+      nullptr,
+      batchSize,
+      std::vector<VectorPtr>{wrapInDictionary(indices, childSize, base)});
+
+  ASSERT_EQ(writtenRows(writePlan({data}, {"c0"})), batchSize);
+}
+
+// The constraint names target table columns, which may be a reordered subset
+// of the input columns.
+TEST_F(TableWriterNotNullTest, reorderedColumns) {
+  const vector_size_t size = 10;
+  auto data = makeRowVector(
+      {"c0", "c1", "c2"},
+      {
+          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+          makeFlatVector<int32_t>(size, [](auto row) { return row * 2; }),
+          makeFlatVector<int32_t>(
+              size, [](auto row) { return row * 3; }, nullEvery(3)),
+      });
+  auto targetColumns = ROW({"c2", "c0"}, {INTEGER(), INTEGER()});
+
+  ASSERT_EQ(writtenRows(writePlan({data}, {"c0"}, targetColumns)), size);
+
+  VELOX_ASSERT_USER_THROW(
+      AssertQueryBuilder(writePlan({data}, {"c2"}, targetColumns))
+          .countResults(),
+      "NULL value not allowed for NOT NULL column: c2");
+}
+
+// The constraint names the table's columns, which may differ from the input's.
+// PlanBuilder always writes under the input names, so build the node directly.
+TEST_F(TableWriterNotNullTest, renamedColumns) {
+  const vector_size_t size = 10;
+  auto data = makeRowVector(
+      {"c0", "c1"},
+      {
+          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+          makeFlatVector<int32_t>(
+              size, [](auto row) { return row; }, nullEvery(3)),
+      });
+  const auto inputColumns = asRowType(data->type());
+  const std::vector<std::string> tableColumnNames = {"key", "value"};
+
+  auto directory = TempDirectoryPath::create();
+  auto writePlan = [&](const folly::F14FastSet<std::string>& notNullColumns) {
+    auto insertHandle = std::make_shared<core::InsertTableHandle>(
+        kHiveConnectorId,
+        makeHiveInsertTableHandle(
+            tableColumnNames,
+            inputColumns->children(),
+            /*partitionedBy=*/{},
+            makeLocationHandle(directory->getPath())),
+        notNullColumns);
+    return PlanBuilder()
+        .values({data})
+        .addNode([&](const core::PlanNodeId& nodeId, core::PlanNodePtr source) {
+          return std::make_shared<core::TableWriteNode>(
+              nodeId,
+              inputColumns,
+              tableColumnNames,
+              /*columnStatsSpec=*/std::nullopt,
+              insertHandle,
+              /*hasPartitioningScheme=*/false,
+              TableWriteTraits::outputType(std::nullopt),
+              connector::CommitStrategy::kNoCommit,
+              std::move(source));
+        })
+        .planNode();
+  };
+
+  // 'key' maps to input column c0, which has no nulls.
+  ASSERT_EQ(writtenRows(writePlan({"key"})), size);
+
+  VELOX_ASSERT_USER_THROW(
+      AssertQueryBuilder(writePlan({"value"})).countResults(),
+      "NULL value not allowed for NOT NULL column: value");
+}
+
+// The reused DecodedVector must not break on a change of size or encoding, nor
+// mask a null in a later batch.
+TEST_F(TableWriterNotNullTest, multipleBatches) {
+  auto makeBatch = [&](vector_size_t size, bool dictionary, bool hasNulls) {
+    std::function<bool(vector_size_t)> isNullAt;
+    if (hasNulls) {
+      isNullAt = nullEvery(3);
+    }
+    auto values =
+        makeFlatVector<int32_t>(size, [](auto row) { return row; }, isNullAt);
+    if (!dictionary) {
+      return makeRowVector({"c0"}, {values});
+    }
+    auto indices = makeIndices(size, [](auto row) { return row; });
+    return makeRowVector({"c0"}, {wrapInDictionary(indices, size, values)});
+  };
+
+  ASSERT_EQ(
+      writtenRows(writePlan(
+          {makeBatch(10, false, false),
+           makeBatch(50, true, false),
+           makeBatch(1, true, false)},
+          {"c0"})),
+      61);
+
+  VELOX_ASSERT_USER_THROW(
+      AssertQueryBuilder(
+          writePlan(
+              {makeBatch(10, false, false), makeBatch(5, true, true)}, {"c0"}))
+          .countResults(),
+      "NULL value not allowed for NOT NULL column: c0");
+}
+
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/TableWriterTest.cpp
+++ b/velox/exec/tests/TableWriterTest.cpp
@@ -105,6 +105,288 @@ TEST_F(BasicTableWriterTest, roundTrip) {
   assertEqualResults({data}, {copy});
 }
 
+TEST_F(BasicTableWriterTest, notNullConstraintPasses) {
+  const vector_size_t size = 100;
+  auto data = makeRowVector(
+      {"c0", "c1"},
+      {
+          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+          makeFlatVector<int32_t>(size, [](auto row) { return row * 2; }),
+      });
+
+  auto directory = TempDirectoryPath::create();
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .startTableWriter()
+                  .outputDirectoryPath(directory->getPath())
+                  .notNullColumnNames({"c0", "c1"})
+                  .endTableWriter()
+                  .planNode();
+
+  auto results = AssertQueryBuilder(plan).copyResults(pool());
+  auto rowCount = results->childAt(TableWriteTraits::kRowCountChannel)
+                      ->as<FlatVector<int64_t>>();
+  ASSERT_FALSE(rowCount->isNullAt(0));
+  ASSERT_EQ(size, rowCount->valueAt(0));
+}
+
+TEST_F(BasicTableWriterTest, notNullConstraintInvalidColumnThrows) {
+  const vector_size_t size = 10;
+  auto data = makeRowVector(
+      {"c0", "c1"},
+      {
+          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+          makeFlatVector<int32_t>(size, [](auto row) { return row * 2; }),
+      });
+
+  auto directory = TempDirectoryPath::create();
+
+  VELOX_ASSERT_USER_THROW(
+      PlanBuilder()
+          .values({data})
+          .startTableWriter()
+          .outputDirectoryPath(directory->getPath())
+          .notNullColumnNames({"c99"})
+          .endTableWriter(),
+      "NOT NULL column is not in the table schema: c99");
+}
+
+TEST_F(BasicTableWriterTest, notNullConstraintThrowsOnNull) {
+  const vector_size_t size = 10;
+  auto data = makeRowVector(
+      {"c0", "c1"},
+      {
+          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+          makeFlatVector<int32_t>(
+              size, [](auto row) { return row; }, nullEvery(3)),
+      });
+
+  auto directory = TempDirectoryPath::create();
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .startTableWriter()
+                  .outputDirectoryPath(directory->getPath())
+                  .notNullColumnNames({"c1"})
+                  .endTableWriter()
+                  .planNode();
+
+  VELOX_ASSERT_USER_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()),
+      "NULL value not allowed for NOT NULL column: c1");
+}
+
+TEST_F(BasicTableWriterTest, notNullConstraintThrowsOnDictionaryEncodedNull) {
+  // Dictionary wrapping hides nulls: no top-level nulls buffer.
+  const vector_size_t size = 10;
+  auto base =
+      makeFlatVector<int32_t>(size, [](auto row) { return row; }, nullEvery(3));
+  auto indices = makeIndices(size, [](auto row) { return row; });
+  auto data = makeRowVector(
+      {"c0", "c1"},
+      {
+          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+          wrapInDictionary(indices, size, base),
+      });
+
+  auto directory = TempDirectoryPath::create();
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .startTableWriter()
+                  .outputDirectoryPath(directory->getPath())
+                  .notNullColumnNames({"c1"})
+                  .endTableWriter()
+                  .planNode();
+
+  VELOX_ASSERT_USER_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()),
+      "NULL value not allowed for NOT NULL column: c1");
+}
+
+TEST_F(BasicTableWriterTest, notNullConstraintThrowsOnConstantNull) {
+  // Large batch confirms enforcement isn't limited to the first rows.
+  const vector_size_t size = 1'000;
+  auto data = makeRowVector(
+      {"c0", "c1"},
+      {
+          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+          makeNullConstant(TypeKind::INTEGER, size),
+      });
+
+  auto directory = TempDirectoryPath::create();
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .startTableWriter()
+                  .outputDirectoryPath(directory->getPath())
+                  .notNullColumnNames({"c1"})
+                  .endTableWriter()
+                  .planNode();
+
+  VELOX_ASSERT_USER_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()),
+      "NULL value not allowed for NOT NULL column: c1");
+}
+
+TEST_F(BasicTableWriterTest, notNullConstraintIgnoresNullsBeyondBatchSize) {
+  // Like Limit's output: RowVector size smaller than its children's.
+  const vector_size_t childSize = 10;
+  const vector_size_t batchSize = 4;
+  auto indices = makeIndices(childSize, [](auto row) { return row; });
+  auto base = makeFlatVector<int32_t>(
+      childSize,
+      [](auto row) { return row; },
+      [batchSize](auto row) { return row >= batchSize; });
+  auto data = std::make_shared<RowVector>(
+      pool(),
+      ROW({"c0", "c1"}, {INTEGER(), INTEGER()}),
+      nullptr,
+      batchSize,
+      std::vector<VectorPtr>{
+          makeFlatVector<int32_t>(childSize, [](auto row) { return row; }),
+          wrapInDictionary(indices, childSize, base),
+      });
+
+  auto directory = TempDirectoryPath::create();
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .startTableWriter()
+                  .outputDirectoryPath(directory->getPath())
+                  .notNullColumnNames({"c1"})
+                  .endTableWriter()
+                  .planNode();
+
+  auto results = AssertQueryBuilder(plan).copyResults(pool());
+  auto rowCount = results->childAt(TableWriteTraits::kRowCountChannel)
+                      ->as<FlatVector<int64_t>>();
+  ASSERT_FALSE(rowCount->isNullAt(0));
+  ASSERT_EQ(batchSize, rowCount->valueAt(0));
+}
+
+TEST_F(BasicTableWriterTest, notNullConstraintNulloptAllowsNulls) {
+  const vector_size_t size = 20;
+  auto data = makeRowVector(
+      {"c0"},
+      {makeFlatVector<int32_t>(
+          size, [](auto row) { return row; }, nullEvery(5))});
+
+  auto directory = TempDirectoryPath::create();
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .startTableWriter()
+                  .outputDirectoryPath(directory->getPath())
+                  .endTableWriter()
+                  .planNode();
+
+  auto results = AssertQueryBuilder(plan).copyResults(pool());
+  auto rowCount = results->childAt(TableWriteTraits::kRowCountChannel)
+                      ->as<FlatVector<int64_t>>();
+  ASSERT_FALSE(rowCount->isNullAt(0));
+  ASSERT_EQ(size, rowCount->valueAt(0));
+}
+
+TEST_F(BasicTableWriterTest, notNullConstraintEmptyListAllowsNulls) {
+  const vector_size_t size = 20;
+  auto data = makeRowVector(
+      {"c0"},
+      {makeFlatVector<int32_t>(
+          size, [](auto row) { return row; }, nullEvery(5))});
+
+  auto directory = TempDirectoryPath::create();
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .startTableWriter()
+                  .outputDirectoryPath(directory->getPath())
+                  .notNullColumnNames({})
+                  .endTableWriter()
+                  .planNode();
+
+  auto results = AssertQueryBuilder(plan).copyResults(pool());
+  auto rowCount = results->childAt(TableWriteTraits::kRowCountChannel)
+                      ->as<FlatVector<int64_t>>();
+  ASSERT_FALSE(rowCount->isNullAt(0));
+  ASSERT_EQ(size, rowCount->valueAt(0));
+}
+
+TEST_F(BasicTableWriterTest, notNullConstraintWithReorderedColumns) {
+  // Non-identity 'inputMapping_': write targets c2, c0 in that order.
+  const vector_size_t size = 10;
+  auto data = makeRowVector(
+      {"c0", "c1", "c2"},
+      {
+          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+          makeFlatVector<int32_t>(size, [](auto row) { return row * 2; }),
+          makeFlatVector<int32_t>(
+              size, [](auto row) { return row * 3; }, nullEvery(3)),
+      });
+
+  auto directory = TempDirectoryPath::create();
+  auto columns = ROW({"c2", "c0"}, {INTEGER(), INTEGER()});
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .startTableWriter()
+                  .outputDirectoryPath(directory->getPath())
+                  .outputType(columns)
+                  .notNullColumnNames({"c2"})
+                  .endTableWriter()
+                  .planNode();
+
+  VELOX_ASSERT_USER_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()),
+      "NULL value not allowed for NOT NULL column: c2");
+}
+
+TEST_F(BasicTableWriterTest, notNullConstraintAcrossMultipleBatches) {
+  // Reused member state must survive flat-to-dictionary encoding changes
+  // and growing-then-shrinking batch sizes.
+  auto makeBatch = [&](vector_size_t size, bool dictionary) {
+    auto values = makeFlatVector<int32_t>(size, [](auto row) { return row; });
+    if (!dictionary) {
+      return makeRowVector({"c0"}, {values});
+    }
+    auto indices = makeIndices(size, [](auto row) { return row; });
+    return makeRowVector({"c0"}, {wrapInDictionary(indices, size, values)});
+  };
+
+  auto directory = TempDirectoryPath::create();
+  auto plan =
+      PlanBuilder()
+          .values(
+              {makeBatch(10, false), makeBatch(50, true), makeBatch(1, true)})
+          .startTableWriter()
+          .outputDirectoryPath(directory->getPath())
+          .notNullColumnNames({"c0"})
+          .endTableWriter()
+          .planNode();
+
+  auto results = AssertQueryBuilder(plan).copyResults(pool());
+  auto rowCount = results->childAt(TableWriteTraits::kRowCountChannel)
+                      ->as<FlatVector<int64_t>>();
+  ASSERT_FALSE(rowCount->isNullAt(0));
+  ASSERT_EQ(61, rowCount->valueAt(0));
+}
+
+TEST_F(BasicTableWriterTest, notNullConstraintThrowsOnLaterBatch) {
+  // Reused member state must not mask a null introduced in a later batch.
+  auto batch1 = makeRowVector(
+      {"c0"}, {makeFlatVector<int32_t>(10, [](auto row) { return row; })});
+  auto base =
+      makeFlatVector<int32_t>(5, [](auto row) { return row; }, nullEvery(3));
+  auto indices = makeIndices(5, [](auto row) { return row; });
+  auto batch2 = makeRowVector({"c0"}, {wrapInDictionary(indices, 5, base)});
+
+  auto directory = TempDirectoryPath::create();
+  auto plan = PlanBuilder()
+                  .values({batch1, batch2})
+                  .startTableWriter()
+                  .outputDirectoryPath(directory->getPath())
+                  .notNullColumnNames({"c0"})
+                  .endTableWriter()
+                  .planNode();
+
+  VELOX_ASSERT_USER_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()),
+      "NULL value not allowed for NOT NULL column: c0");
+}
+
 // Generates a struct (row), write it as a flap map, and check that it is read
 // back as a map.
 TEST_F(BasicTableWriterTest, structAsMap) {

--- a/velox/exec/tests/TableWriterTest.cpp
+++ b/velox/exec/tests/TableWriterTest.cpp
@@ -176,8 +176,7 @@ TEST_F(BasicTableWriterTest, notNullConstraintThrowsOnNull) {
 }
 
 TEST_F(BasicTableWriterTest, notNullConstraintThrowsOnDictionaryEncodedNull) {
-  // Dictionary wrapping can hide nulls in the base vector with no
-  // top-level nulls buffer.
+  // Dictionary wrapping hides nulls: no top-level nulls buffer.
   const vector_size_t size = 10;
   auto base =
       makeFlatVector<int32_t>(size, [](auto row) { return row; }, nullEvery(3));
@@ -228,8 +227,7 @@ TEST_F(BasicTableWriterTest, notNullConstraintThrowsOnConstantNull) {
 }
 
 TEST_F(BasicTableWriterTest, notNullConstraintIgnoresNullsBeyondBatchSize) {
-  // Like Limit's output: RowVector size smaller than its children's. The NOT
-  // NULL check must ignore nulls past the batch's own rows.
+  // Like Limit's output: RowVector size smaller than its children's.
   const vector_size_t childSize = 10;
   const vector_size_t batchSize = 4;
   auto indices = makeIndices(childSize, [](auto row) { return row; });
@@ -286,8 +284,6 @@ TEST_F(BasicTableWriterTest, notNullConstraintNulloptAllowsNulls) {
 }
 
 TEST_F(BasicTableWriterTest, notNullConstraintEmptyListAllowsNulls) {
-  // An explicit empty list behaves like std::nullopt: no constraints
-  // enforced.
   const vector_size_t size = 20;
   auto data = makeRowVector(
       {"c0"},
@@ -336,6 +332,59 @@ TEST_F(BasicTableWriterTest, notNullConstraintWithReorderedColumns) {
   VELOX_ASSERT_USER_THROW(
       AssertQueryBuilder(plan).copyResults(pool()),
       "NULL value not allowed for NOT NULL column: c2");
+}
+
+TEST_F(BasicTableWriterTest, notNullConstraintAcrossMultipleBatches) {
+  // Reused member state must survive flat-to-dictionary encoding changes
+  // and growing-then-shrinking batch sizes.
+  auto makeBatch = [&](vector_size_t size, bool dictionary) {
+    auto values = makeFlatVector<int32_t>(size, [](auto row) { return row; });
+    if (!dictionary) {
+      return makeRowVector({"c0"}, {values});
+    }
+    auto indices = makeIndices(size, [](auto row) { return row; });
+    return makeRowVector({"c0"}, {wrapInDictionary(indices, size, values)});
+  };
+
+  auto directory = TempDirectoryPath::create();
+  auto plan =
+      PlanBuilder()
+          .values(
+              {makeBatch(10, false), makeBatch(50, true), makeBatch(1, true)})
+          .startTableWriter()
+          .outputDirectoryPath(directory->getPath())
+          .notNullColumnNames({"c0"})
+          .endTableWriter()
+          .planNode();
+
+  auto results = AssertQueryBuilder(plan).copyResults(pool());
+  auto rowCount = results->childAt(TableWriteTraits::kRowCountChannel)
+                      ->as<FlatVector<int64_t>>();
+  ASSERT_FALSE(rowCount->isNullAt(0));
+  ASSERT_EQ(61, rowCount->valueAt(0));
+}
+
+TEST_F(BasicTableWriterTest, notNullConstraintThrowsOnLaterBatch) {
+  // Reused member state must not mask a null introduced in a later batch.
+  auto batch1 = makeRowVector(
+      {"c0"}, {makeFlatVector<int32_t>(10, [](auto row) { return row; })});
+  auto base =
+      makeFlatVector<int32_t>(5, [](auto row) { return row; }, nullEvery(3));
+  auto indices = makeIndices(5, [](auto row) { return row; });
+  auto batch2 = makeRowVector({"c0"}, {wrapInDictionary(indices, 5, base)});
+
+  auto directory = TempDirectoryPath::create();
+  auto plan = PlanBuilder()
+                  .values({batch1, batch2})
+                  .startTableWriter()
+                  .outputDirectoryPath(directory->getPath())
+                  .notNullColumnNames({"c0"})
+                  .endTableWriter()
+                  .planNode();
+
+  VELOX_ASSERT_USER_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()),
+      "NULL value not allowed for NOT NULL column: c0");
 }
 
 // Generates a struct (row), write it as a flap map, and check that it is read

--- a/velox/exec/tests/TableWriterTest.cpp
+++ b/velox/exec/tests/TableWriterTest.cpp
@@ -105,6 +105,239 @@ TEST_F(BasicTableWriterTest, roundTrip) {
   assertEqualResults({data}, {copy});
 }
 
+TEST_F(BasicTableWriterTest, notNullConstraintPasses) {
+  const vector_size_t size = 100;
+  auto data = makeRowVector(
+      {"c0", "c1"},
+      {
+          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+          makeFlatVector<int32_t>(size, [](auto row) { return row * 2; }),
+      });
+
+  auto directory = TempDirectoryPath::create();
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .startTableWriter()
+                  .outputDirectoryPath(directory->getPath())
+                  .notNullColumnNames({"c0", "c1"})
+                  .endTableWriter()
+                  .planNode();
+
+  auto results = AssertQueryBuilder(plan).copyResults(pool());
+  auto rowCount = results->childAt(TableWriteTraits::kRowCountChannel)
+                      ->as<FlatVector<int64_t>>();
+  ASSERT_FALSE(rowCount->isNullAt(0));
+  ASSERT_EQ(size, rowCount->valueAt(0));
+}
+
+TEST_F(BasicTableWriterTest, notNullConstraintInvalidColumnThrows) {
+  const vector_size_t size = 10;
+  auto data = makeRowVector(
+      {"c0", "c1"},
+      {
+          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+          makeFlatVector<int32_t>(size, [](auto row) { return row * 2; }),
+      });
+
+  auto directory = TempDirectoryPath::create();
+
+  VELOX_ASSERT_USER_THROW(
+      PlanBuilder()
+          .values({data})
+          .startTableWriter()
+          .outputDirectoryPath(directory->getPath())
+          .notNullColumnNames({"c99"})
+          .endTableWriter(),
+      "NOT NULL column is not in the table schema: c99");
+}
+
+TEST_F(BasicTableWriterTest, notNullConstraintThrowsOnNull) {
+  const vector_size_t size = 10;
+  auto data = makeRowVector(
+      {"c0", "c1"},
+      {
+          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+          makeFlatVector<int32_t>(
+              size, [](auto row) { return row; }, nullEvery(3)),
+      });
+
+  auto directory = TempDirectoryPath::create();
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .startTableWriter()
+                  .outputDirectoryPath(directory->getPath())
+                  .notNullColumnNames({"c1"})
+                  .endTableWriter()
+                  .planNode();
+
+  VELOX_ASSERT_USER_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()),
+      "NULL value not allowed for NOT NULL column: c1");
+}
+
+TEST_F(BasicTableWriterTest, notNullConstraintThrowsOnDictionaryEncodedNull) {
+  // Dictionary wrapping can hide nulls in the base vector with no
+  // top-level nulls buffer.
+  const vector_size_t size = 10;
+  auto base =
+      makeFlatVector<int32_t>(size, [](auto row) { return row; }, nullEvery(3));
+  auto indices = makeIndices(size, [](auto row) { return row; });
+  auto data = makeRowVector(
+      {"c0", "c1"},
+      {
+          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+          wrapInDictionary(indices, size, base),
+      });
+
+  auto directory = TempDirectoryPath::create();
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .startTableWriter()
+                  .outputDirectoryPath(directory->getPath())
+                  .notNullColumnNames({"c1"})
+                  .endTableWriter()
+                  .planNode();
+
+  VELOX_ASSERT_USER_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()),
+      "NULL value not allowed for NOT NULL column: c1");
+}
+
+TEST_F(BasicTableWriterTest, notNullConstraintThrowsOnConstantNull) {
+  // Large batch confirms enforcement isn't limited to the first rows.
+  const vector_size_t size = 1'000;
+  auto data = makeRowVector(
+      {"c0", "c1"},
+      {
+          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+          makeNullConstant(TypeKind::INTEGER, size),
+      });
+
+  auto directory = TempDirectoryPath::create();
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .startTableWriter()
+                  .outputDirectoryPath(directory->getPath())
+                  .notNullColumnNames({"c1"})
+                  .endTableWriter()
+                  .planNode();
+
+  VELOX_ASSERT_USER_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()),
+      "NULL value not allowed for NOT NULL column: c1");
+}
+
+TEST_F(BasicTableWriterTest, notNullConstraintIgnoresNullsBeyondBatchSize) {
+  // Like Limit's output: RowVector size smaller than its children's. The NOT
+  // NULL check must ignore nulls past the batch's own rows.
+  const vector_size_t childSize = 10;
+  const vector_size_t batchSize = 4;
+  auto indices = makeIndices(childSize, [](auto row) { return row; });
+  auto base = makeFlatVector<int32_t>(
+      childSize,
+      [](auto row) { return row; },
+      [batchSize](auto row) { return row >= batchSize; });
+  auto data = std::make_shared<RowVector>(
+      pool(),
+      ROW({"c0", "c1"}, {INTEGER(), INTEGER()}),
+      nullptr,
+      batchSize,
+      std::vector<VectorPtr>{
+          makeFlatVector<int32_t>(childSize, [](auto row) { return row; }),
+          wrapInDictionary(indices, childSize, base),
+      });
+
+  auto directory = TempDirectoryPath::create();
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .startTableWriter()
+                  .outputDirectoryPath(directory->getPath())
+                  .notNullColumnNames({"c1"})
+                  .endTableWriter()
+                  .planNode();
+
+  auto results = AssertQueryBuilder(plan).copyResults(pool());
+  auto rowCount = results->childAt(TableWriteTraits::kRowCountChannel)
+                      ->as<FlatVector<int64_t>>();
+  ASSERT_FALSE(rowCount->isNullAt(0));
+  ASSERT_EQ(batchSize, rowCount->valueAt(0));
+}
+
+TEST_F(BasicTableWriterTest, notNullConstraintNulloptAllowsNulls) {
+  const vector_size_t size = 20;
+  auto data = makeRowVector(
+      {"c0"},
+      {makeFlatVector<int32_t>(
+          size, [](auto row) { return row; }, nullEvery(5))});
+
+  auto directory = TempDirectoryPath::create();
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .startTableWriter()
+                  .outputDirectoryPath(directory->getPath())
+                  .endTableWriter()
+                  .planNode();
+
+  auto results = AssertQueryBuilder(plan).copyResults(pool());
+  auto rowCount = results->childAt(TableWriteTraits::kRowCountChannel)
+                      ->as<FlatVector<int64_t>>();
+  ASSERT_FALSE(rowCount->isNullAt(0));
+  ASSERT_EQ(size, rowCount->valueAt(0));
+}
+
+TEST_F(BasicTableWriterTest, notNullConstraintEmptyListAllowsNulls) {
+  // An explicit empty list behaves like std::nullopt: no constraints
+  // enforced.
+  const vector_size_t size = 20;
+  auto data = makeRowVector(
+      {"c0"},
+      {makeFlatVector<int32_t>(
+          size, [](auto row) { return row; }, nullEvery(5))});
+
+  auto directory = TempDirectoryPath::create();
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .startTableWriter()
+                  .outputDirectoryPath(directory->getPath())
+                  .notNullColumnNames({})
+                  .endTableWriter()
+                  .planNode();
+
+  auto results = AssertQueryBuilder(plan).copyResults(pool());
+  auto rowCount = results->childAt(TableWriteTraits::kRowCountChannel)
+                      ->as<FlatVector<int64_t>>();
+  ASSERT_FALSE(rowCount->isNullAt(0));
+  ASSERT_EQ(size, rowCount->valueAt(0));
+}
+
+TEST_F(BasicTableWriterTest, notNullConstraintWithReorderedColumns) {
+  // Non-identity 'inputMapping_': write targets c2, c0 in that order.
+  const vector_size_t size = 10;
+  auto data = makeRowVector(
+      {"c0", "c1", "c2"},
+      {
+          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+          makeFlatVector<int32_t>(size, [](auto row) { return row * 2; }),
+          makeFlatVector<int32_t>(
+              size, [](auto row) { return row * 3; }, nullEvery(3)),
+      });
+
+  auto directory = TempDirectoryPath::create();
+  auto columns = ROW({"c2", "c0"}, {INTEGER(), INTEGER()});
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .startTableWriter()
+                  .outputDirectoryPath(directory->getPath())
+                  .outputType(columns)
+                  .notNullColumnNames({"c2"})
+                  .endTableWriter()
+                  .planNode();
+
+  VELOX_ASSERT_USER_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()),
+      "NULL value not allowed for NOT NULL column: c2");
+}
+
 // Generates a struct (row), write it as a flap map, and check that it is read
 // back as a map.
 TEST_F(BasicTableWriterTest, structAsMap) {

--- a/velox/exec/tests/TableWriterTest.cpp
+++ b/velox/exec/tests/TableWriterTest.cpp
@@ -261,7 +261,7 @@ TEST_F(BasicTableWriterTest, notNullConstraintIgnoresNullsBeyondBatchSize) {
   ASSERT_EQ(batchSize, rowCount->valueAt(0));
 }
 
-TEST_F(BasicTableWriterTest, notNullConstraintNulloptAllowsNulls) {
+TEST_F(BasicTableWriterTest, notNullConstraintUnsetAllowsNulls) {
   const vector_size_t size = 20;
   auto data = makeRowVector(
       {"c0"},

--- a/velox/exec/tests/TableWriterTest.cpp
+++ b/velox/exec/tests/TableWriterTest.cpp
@@ -264,7 +264,7 @@ class TableWriterNotNullTest : public HiveConnectorTestBase {
             .outputDirectoryPath(directories_.back()->getPath())
             .notNullColumns(notNullColumns);
     if (targetColumns != nullptr) {
-      writerBuilder.outputType(targetColumns);
+      writerBuilder.targetColumns(targetColumns);
     }
     return writerBuilder.endTableWriter().planNode();
   }

--- a/velox/exec/tests/TableWriterTest.cpp
+++ b/velox/exec/tests/TableWriterTest.cpp
@@ -247,248 +247,6 @@ TEST_F(BasicTableWriterTest, writerRuntimeStatsReachOperatorStats) {
       kInjectedNanos);
 }
 
-// Covers InsertTableHandle::notNullColumns() enforcement.
-class TableWriterNotNullTest : public HiveConnectorTestBase {
- protected:
-  // Plans a write of 'input' into a fresh directory. 'targetColumns', when set,
-  // selects and reorders the written columns.
-  core::PlanNodePtr writePlan(
-      const std::vector<RowVectorPtr>& input,
-      const std::vector<std::string>& notNullColumns,
-      const RowTypePtr& targetColumns = nullptr) {
-    directories_.push_back(TempDirectoryPath::create());
-    PlanBuilder planBuilder;
-    auto& writerBuilder =
-        planBuilder.values(input)
-            .startTableWriter()
-            .outputDirectoryPath(directories_.back()->getPath())
-            .notNullColumns(notNullColumns);
-    if (targetColumns != nullptr) {
-      writerBuilder.targetColumns(targetColumns);
-    }
-    return writerBuilder.endTableWriter().planNode();
-  }
-
-  int64_t writtenRows(const core::PlanNodePtr& plan) {
-    const auto results = AssertQueryBuilder(plan).copyResults(pool());
-    const auto* rowCount = results->childAt(TableWriteTraits::kRowCountChannel)
-                               ->as<FlatVector<int64_t>>();
-    VELOX_CHECK(!rowCount->isNullAt(0));
-    return rowCount->valueAt(0);
-  }
-
-  // Keeps the plans' output directories alive.
-  std::vector<std::shared_ptr<TempDirectoryPath>> directories_;
-};
-
-TEST_F(TableWriterNotNullTest, unconstrainedAllowsNulls) {
-  const vector_size_t size = 20;
-  auto data = makeRowVector(
-      {"c0"},
-      {makeFlatVector<int32_t>(
-          size, [](auto row) { return row; }, nullEvery(5))});
-
-  ASSERT_EQ(writtenRows(writePlan({data}, {})), size);
-}
-
-TEST_F(TableWriterNotNullTest, enforcement) {
-  const vector_size_t size = 100;
-  auto nonNulls = makeFlatVector<int32_t>(size, [](auto row) { return row; });
-  auto values =
-      makeFlatVector<int32_t>(size, [](auto row) { return row; }, nullEvery(3));
-  auto indices = makeIndices(size, [](auto row) { return row; });
-  // The same nulls presented flat, dictionary- and constant-wrapped, and as a
-  // struct that is itself null.
-  const std::vector<VectorPtr> nullColumns = {
-      values,
-      wrapInDictionary(indices, size, values),
-      makeNullConstant(TypeKind::INTEGER, size),
-      makeRowVector({nonNulls}, nullEvery(3)),
-  };
-
-  for (const auto& nullColumn : nullColumns) {
-    SCOPED_TRACE(nullColumn->toString());
-    auto data = makeRowVector({"c0", "c1"}, {nonNulls, nullColumn});
-
-    // Constraining c0 leaves the nulls in c1 alone.
-    ASSERT_EQ(writtenRows(writePlan({data}, {"c0"})), size);
-
-    VELOX_ASSERT_USER_THROW(
-        AssertQueryBuilder(writePlan({data}, {"c0", "c1"})).countResults(),
-        "NULL value not allowed for NOT NULL column: c1");
-  }
-}
-
-// A null row in the batch itself makes every column null in that row, which
-// the children do not reflect.
-TEST_F(TableWriterNotNullTest, nullBatchRows) {
-  const vector_size_t size = 10;
-  auto data = makeRowVector(
-      {makeFlatVector<int32_t>(size, [](auto row) { return row; })},
-      nullEvery(3));
-
-  ASSERT_EQ(writtenRows(writePlan({data}, {})), size);
-
-  VELOX_ASSERT_USER_THROW(
-      AssertQueryBuilder(writePlan({data}, {"c0"})).countResults(),
-      "NULL value not allowed for NOT NULL column: c0");
-}
-
-// Nulls inside a struct's fields are the fields' nulls, not the column's.
-TEST_F(TableWriterNotNullTest, nullsInsideStruct) {
-  const vector_size_t size = 10;
-  auto data = makeRowVector(
-      {"c0"},
-      {makeRowVector({makeFlatVector<int32_t>(
-          size, [](auto row) { return row; }, nullEvery(3))})});
-
-  ASSERT_EQ(writtenRows(writePlan({data}, {"c0"})), size);
-}
-
-// A RowVector may be shorter than its children, as in Limit's output. Nulls
-// past its size are not part of the batch.
-TEST_F(TableWriterNotNullTest, ignoresNullsBeyondBatchSize) {
-  const vector_size_t childSize = 10;
-  const vector_size_t batchSize = 4;
-  auto indices = makeIndices(childSize, [](auto row) { return row; });
-  auto base = makeFlatVector<int32_t>(
-      childSize,
-      [](auto row) { return row; },
-      [batchSize](auto row) { return row >= batchSize; });
-  auto data = std::make_shared<RowVector>(
-      pool(),
-      ROW({"c0"}, {INTEGER()}),
-      nullptr,
-      batchSize,
-      std::vector<VectorPtr>{wrapInDictionary(indices, childSize, base)});
-
-  ASSERT_EQ(writtenRows(writePlan({data}, {"c0"})), batchSize);
-}
-
-// The constraint names target table columns, which may be a reordered subset
-// of the input columns.
-TEST_F(TableWriterNotNullTest, reorderedColumns) {
-  const vector_size_t size = 10;
-  auto data = makeRowVector(
-      {"c0", "c1", "c2"},
-      {
-          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
-          makeFlatVector<int32_t>(size, [](auto row) { return row * 2; }),
-          makeFlatVector<int32_t>(
-              size, [](auto row) { return row * 3; }, nullEvery(3)),
-      });
-  auto targetColumns = ROW({"c2", "c0"}, {INTEGER(), INTEGER()});
-
-  ASSERT_EQ(writtenRows(writePlan({data}, {"c0"}, targetColumns)), size);
-
-  VELOX_ASSERT_USER_THROW(
-      AssertQueryBuilder(writePlan({data}, {"c2"}, targetColumns))
-          .countResults(),
-      "NULL value not allowed for NOT NULL column: c2");
-}
-
-// The constraint names the table's columns, which may differ from the input's.
-// PlanBuilder always writes under the input names, so build the node directly.
-TEST_F(TableWriterNotNullTest, renamedColumns) {
-  const vector_size_t size = 10;
-  auto data = makeRowVector(
-      {"c0", "c1"},
-      {
-          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
-          makeFlatVector<int32_t>(
-              size, [](auto row) { return row; }, nullEvery(3)),
-      });
-  const auto inputColumns = asRowType(data->type());
-  const std::vector<std::string> tableColumnNames = {"key", "value"};
-
-  auto directory = TempDirectoryPath::create();
-  auto writePlan = [&](const std::vector<std::string>& notNullColumns) {
-    auto insertHandle = std::make_shared<core::InsertTableHandle>(
-        kHiveConnectorId,
-        makeHiveInsertTableHandle(
-            tableColumnNames,
-            inputColumns->children(),
-            /*partitionedBy=*/{},
-            makeLocationHandle(directory->getPath())),
-        notNullColumns);
-    return PlanBuilder()
-        .values({data})
-        .addNode([&](const core::PlanNodeId& nodeId, core::PlanNodePtr source) {
-          return std::make_shared<core::TableWriteNode>(
-              nodeId,
-              inputColumns,
-              tableColumnNames,
-              /*columnStatsSpec=*/std::nullopt,
-              insertHandle,
-              /*hasPartitioningScheme=*/false,
-              TableWriteTraits::outputType(std::nullopt),
-              connector::CommitStrategy::kNoCommit,
-              std::move(source));
-        })
-        .planNode();
-  };
-
-  // 'key' maps to input column c0, which has no nulls.
-  ASSERT_EQ(writtenRows(writePlan({"key"})), size);
-
-  VELOX_ASSERT_USER_THROW(
-      AssertQueryBuilder(writePlan({"value"})).countResults(),
-      "NULL value not allowed for NOT NULL column: value");
-
-  VELOX_ASSERT_USER_THROW(
-      writePlan({"c1"}), "NOT NULL column is not in the table schema: c1");
-}
-
-// The reused DecodedVector must not break on a change of size or encoding, nor
-// mask a null in a later batch.
-TEST_F(TableWriterNotNullTest, multipleBatches) {
-  auto makeBatch = [&](vector_size_t size, bool dictionary, bool hasNulls) {
-    std::function<bool(vector_size_t)> isNullAt;
-    if (hasNulls) {
-      isNullAt = nullEvery(3);
-    }
-    auto values =
-        makeFlatVector<int32_t>(size, [](auto row) { return row; }, isNullAt);
-    if (!dictionary) {
-      return makeRowVector({"c0"}, {values});
-    }
-    auto indices = makeIndices(size, [](auto row) { return row; });
-    return makeRowVector({"c0"}, {wrapInDictionary(indices, size, values)});
-  };
-
-  ASSERT_EQ(
-      writtenRows(writePlan(
-          {makeBatch(10, false, false),
-           makeBatch(50, true, false),
-           makeBatch(1, true, false)},
-          {"c0"})),
-      61);
-
-  VELOX_ASSERT_USER_THROW(
-      AssertQueryBuilder(
-          writePlan(
-              {makeBatch(10, false, false), makeBatch(5, true, true)}, {"c0"}))
-          .countResults(),
-      "NULL value not allowed for NOT NULL column: c0");
-}
-
-TEST_F(TableWriterNotNullTest, invalidConstraint) {
-  const vector_size_t size = 10;
-  auto data = makeRowVector(
-      {"c0", "c1"},
-      {
-          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
-          makeFlatVector<int32_t>(size, [](auto row) { return row * 2; }),
-      });
-
-  VELOX_ASSERT_USER_THROW(
-      writePlan({data}, {"c99"}),
-      "NOT NULL column is not in the table schema: c99");
-
-  VELOX_ASSERT_USER_THROW(
-      writePlan({data}, {"c0", "c0"}), "Duplicate NOT NULL column: c0");
-}
-
 class PartitionedTableWriterTest
     : public TableWriterTestBase,
       public testing::WithParamInterface<uint64_t> {
@@ -2358,7 +2116,7 @@ TEST_P(AllTableWriterTest, columnStatsDataTypes) {
                               partitionedBy_,
                               nullptr,
                               makeLocationHandle(outputDirectory->getPath())),
-                          /*notNullColumns=*/std::vector<std::string>{}),
+                          /*notNullColumns=*/folly::F14FastSet<std::string>{}),
                       false,
                       CommitStrategy::kNoCommit))
                   .planNode();
@@ -2443,7 +2201,7 @@ TEST_P(AllTableWriterTest, columnStats) {
                               partitionedBy_,
                               bucketProperty_,
                               makeLocationHandle(outputDirectory->getPath())),
-                          /*notNullColumns=*/std::vector<std::string>{}),
+                          /*notNullColumns=*/folly::F14FastSet<std::string>{}),
                       false,
                       commitStrategy_))
                   .planNode();
@@ -2538,7 +2296,7 @@ TEST_P(AllTableWriterTest, columnStatsWithTableWriteMerge) {
               partitionedBy_,
               bucketProperty_,
               makeLocationHandle(outputDirectory->getPath())),
-          /*notNullColumns=*/std::vector<std::string>{}),
+          /*notNullColumns=*/folly::F14FastSet<std::string>{}),
       false,
       commitStrategy_));
 

--- a/velox/exec/tests/TableWriterTest.cpp
+++ b/velox/exec/tests/TableWriterTest.cpp
@@ -105,288 +105,6 @@ TEST_F(BasicTableWriterTest, roundTrip) {
   assertEqualResults({data}, {copy});
 }
 
-TEST_F(BasicTableWriterTest, notNullConstraintPasses) {
-  const vector_size_t size = 100;
-  auto data = makeRowVector(
-      {"c0", "c1"},
-      {
-          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
-          makeFlatVector<int32_t>(size, [](auto row) { return row * 2; }),
-      });
-
-  auto directory = TempDirectoryPath::create();
-  auto plan = PlanBuilder()
-                  .values({data})
-                  .startTableWriter()
-                  .outputDirectoryPath(directory->getPath())
-                  .notNullColumnNames({"c0", "c1"})
-                  .endTableWriter()
-                  .planNode();
-
-  auto results = AssertQueryBuilder(plan).copyResults(pool());
-  auto rowCount = results->childAt(TableWriteTraits::kRowCountChannel)
-                      ->as<FlatVector<int64_t>>();
-  ASSERT_FALSE(rowCount->isNullAt(0));
-  ASSERT_EQ(size, rowCount->valueAt(0));
-}
-
-TEST_F(BasicTableWriterTest, notNullConstraintInvalidColumnThrows) {
-  const vector_size_t size = 10;
-  auto data = makeRowVector(
-      {"c0", "c1"},
-      {
-          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
-          makeFlatVector<int32_t>(size, [](auto row) { return row * 2; }),
-      });
-
-  auto directory = TempDirectoryPath::create();
-
-  VELOX_ASSERT_USER_THROW(
-      PlanBuilder()
-          .values({data})
-          .startTableWriter()
-          .outputDirectoryPath(directory->getPath())
-          .notNullColumnNames({"c99"})
-          .endTableWriter(),
-      "NOT NULL column is not in the table schema: c99");
-}
-
-TEST_F(BasicTableWriterTest, notNullConstraintThrowsOnNull) {
-  const vector_size_t size = 10;
-  auto data = makeRowVector(
-      {"c0", "c1"},
-      {
-          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
-          makeFlatVector<int32_t>(
-              size, [](auto row) { return row; }, nullEvery(3)),
-      });
-
-  auto directory = TempDirectoryPath::create();
-  auto plan = PlanBuilder()
-                  .values({data})
-                  .startTableWriter()
-                  .outputDirectoryPath(directory->getPath())
-                  .notNullColumnNames({"c1"})
-                  .endTableWriter()
-                  .planNode();
-
-  VELOX_ASSERT_USER_THROW(
-      AssertQueryBuilder(plan).copyResults(pool()),
-      "NULL value not allowed for NOT NULL column: c1");
-}
-
-TEST_F(BasicTableWriterTest, notNullConstraintThrowsOnDictionaryEncodedNull) {
-  // Dictionary wrapping hides nulls: no top-level nulls buffer.
-  const vector_size_t size = 10;
-  auto base =
-      makeFlatVector<int32_t>(size, [](auto row) { return row; }, nullEvery(3));
-  auto indices = makeIndices(size, [](auto row) { return row; });
-  auto data = makeRowVector(
-      {"c0", "c1"},
-      {
-          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
-          wrapInDictionary(indices, size, base),
-      });
-
-  auto directory = TempDirectoryPath::create();
-  auto plan = PlanBuilder()
-                  .values({data})
-                  .startTableWriter()
-                  .outputDirectoryPath(directory->getPath())
-                  .notNullColumnNames({"c1"})
-                  .endTableWriter()
-                  .planNode();
-
-  VELOX_ASSERT_USER_THROW(
-      AssertQueryBuilder(plan).copyResults(pool()),
-      "NULL value not allowed for NOT NULL column: c1");
-}
-
-TEST_F(BasicTableWriterTest, notNullConstraintThrowsOnConstantNull) {
-  // Large batch confirms enforcement isn't limited to the first rows.
-  const vector_size_t size = 1'000;
-  auto data = makeRowVector(
-      {"c0", "c1"},
-      {
-          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
-          makeNullConstant(TypeKind::INTEGER, size),
-      });
-
-  auto directory = TempDirectoryPath::create();
-  auto plan = PlanBuilder()
-                  .values({data})
-                  .startTableWriter()
-                  .outputDirectoryPath(directory->getPath())
-                  .notNullColumnNames({"c1"})
-                  .endTableWriter()
-                  .planNode();
-
-  VELOX_ASSERT_USER_THROW(
-      AssertQueryBuilder(plan).copyResults(pool()),
-      "NULL value not allowed for NOT NULL column: c1");
-}
-
-TEST_F(BasicTableWriterTest, notNullConstraintIgnoresNullsBeyondBatchSize) {
-  // Like Limit's output: RowVector size smaller than its children's.
-  const vector_size_t childSize = 10;
-  const vector_size_t batchSize = 4;
-  auto indices = makeIndices(childSize, [](auto row) { return row; });
-  auto base = makeFlatVector<int32_t>(
-      childSize,
-      [](auto row) { return row; },
-      [batchSize](auto row) { return row >= batchSize; });
-  auto data = std::make_shared<RowVector>(
-      pool(),
-      ROW({"c0", "c1"}, {INTEGER(), INTEGER()}),
-      nullptr,
-      batchSize,
-      std::vector<VectorPtr>{
-          makeFlatVector<int32_t>(childSize, [](auto row) { return row; }),
-          wrapInDictionary(indices, childSize, base),
-      });
-
-  auto directory = TempDirectoryPath::create();
-  auto plan = PlanBuilder()
-                  .values({data})
-                  .startTableWriter()
-                  .outputDirectoryPath(directory->getPath())
-                  .notNullColumnNames({"c1"})
-                  .endTableWriter()
-                  .planNode();
-
-  auto results = AssertQueryBuilder(plan).copyResults(pool());
-  auto rowCount = results->childAt(TableWriteTraits::kRowCountChannel)
-                      ->as<FlatVector<int64_t>>();
-  ASSERT_FALSE(rowCount->isNullAt(0));
-  ASSERT_EQ(batchSize, rowCount->valueAt(0));
-}
-
-TEST_F(BasicTableWriterTest, notNullConstraintUnsetAllowsNulls) {
-  const vector_size_t size = 20;
-  auto data = makeRowVector(
-      {"c0"},
-      {makeFlatVector<int32_t>(
-          size, [](auto row) { return row; }, nullEvery(5))});
-
-  auto directory = TempDirectoryPath::create();
-  auto plan = PlanBuilder()
-                  .values({data})
-                  .startTableWriter()
-                  .outputDirectoryPath(directory->getPath())
-                  .endTableWriter()
-                  .planNode();
-
-  auto results = AssertQueryBuilder(plan).copyResults(pool());
-  auto rowCount = results->childAt(TableWriteTraits::kRowCountChannel)
-                      ->as<FlatVector<int64_t>>();
-  ASSERT_FALSE(rowCount->isNullAt(0));
-  ASSERT_EQ(size, rowCount->valueAt(0));
-}
-
-TEST_F(BasicTableWriterTest, notNullConstraintEmptyListAllowsNulls) {
-  const vector_size_t size = 20;
-  auto data = makeRowVector(
-      {"c0"},
-      {makeFlatVector<int32_t>(
-          size, [](auto row) { return row; }, nullEvery(5))});
-
-  auto directory = TempDirectoryPath::create();
-  auto plan = PlanBuilder()
-                  .values({data})
-                  .startTableWriter()
-                  .outputDirectoryPath(directory->getPath())
-                  .notNullColumnNames({})
-                  .endTableWriter()
-                  .planNode();
-
-  auto results = AssertQueryBuilder(plan).copyResults(pool());
-  auto rowCount = results->childAt(TableWriteTraits::kRowCountChannel)
-                      ->as<FlatVector<int64_t>>();
-  ASSERT_FALSE(rowCount->isNullAt(0));
-  ASSERT_EQ(size, rowCount->valueAt(0));
-}
-
-TEST_F(BasicTableWriterTest, notNullConstraintWithReorderedColumns) {
-  // Non-identity 'inputMapping_': write targets c2, c0 in that order.
-  const vector_size_t size = 10;
-  auto data = makeRowVector(
-      {"c0", "c1", "c2"},
-      {
-          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
-          makeFlatVector<int32_t>(size, [](auto row) { return row * 2; }),
-          makeFlatVector<int32_t>(
-              size, [](auto row) { return row * 3; }, nullEvery(3)),
-      });
-
-  auto directory = TempDirectoryPath::create();
-  auto columns = ROW({"c2", "c0"}, {INTEGER(), INTEGER()});
-  auto plan = PlanBuilder()
-                  .values({data})
-                  .startTableWriter()
-                  .outputDirectoryPath(directory->getPath())
-                  .outputType(columns)
-                  .notNullColumnNames({"c2"})
-                  .endTableWriter()
-                  .planNode();
-
-  VELOX_ASSERT_USER_THROW(
-      AssertQueryBuilder(plan).copyResults(pool()),
-      "NULL value not allowed for NOT NULL column: c2");
-}
-
-TEST_F(BasicTableWriterTest, notNullConstraintAcrossMultipleBatches) {
-  // Reused member state must survive flat-to-dictionary encoding changes
-  // and growing-then-shrinking batch sizes.
-  auto makeBatch = [&](vector_size_t size, bool dictionary) {
-    auto values = makeFlatVector<int32_t>(size, [](auto row) { return row; });
-    if (!dictionary) {
-      return makeRowVector({"c0"}, {values});
-    }
-    auto indices = makeIndices(size, [](auto row) { return row; });
-    return makeRowVector({"c0"}, {wrapInDictionary(indices, size, values)});
-  };
-
-  auto directory = TempDirectoryPath::create();
-  auto plan =
-      PlanBuilder()
-          .values(
-              {makeBatch(10, false), makeBatch(50, true), makeBatch(1, true)})
-          .startTableWriter()
-          .outputDirectoryPath(directory->getPath())
-          .notNullColumnNames({"c0"})
-          .endTableWriter()
-          .planNode();
-
-  auto results = AssertQueryBuilder(plan).copyResults(pool());
-  auto rowCount = results->childAt(TableWriteTraits::kRowCountChannel)
-                      ->as<FlatVector<int64_t>>();
-  ASSERT_FALSE(rowCount->isNullAt(0));
-  ASSERT_EQ(61, rowCount->valueAt(0));
-}
-
-TEST_F(BasicTableWriterTest, notNullConstraintThrowsOnLaterBatch) {
-  // Reused member state must not mask a null introduced in a later batch.
-  auto batch1 = makeRowVector(
-      {"c0"}, {makeFlatVector<int32_t>(10, [](auto row) { return row; })});
-  auto base =
-      makeFlatVector<int32_t>(5, [](auto row) { return row; }, nullEvery(3));
-  auto indices = makeIndices(5, [](auto row) { return row; });
-  auto batch2 = makeRowVector({"c0"}, {wrapInDictionary(indices, 5, base)});
-
-  auto directory = TempDirectoryPath::create();
-  auto plan = PlanBuilder()
-                  .values({batch1, batch2})
-                  .startTableWriter()
-                  .outputDirectoryPath(directory->getPath())
-                  .notNullColumnNames({"c0"})
-                  .endTableWriter()
-                  .planNode();
-
-  VELOX_ASSERT_USER_THROW(
-      AssertQueryBuilder(plan).copyResults(pool()),
-      "NULL value not allowed for NOT NULL column: c0");
-}
-
 // Generates a struct (row), write it as a flap map, and check that it is read
 // back as a map.
 TEST_F(BasicTableWriterTest, structAsMap) {
@@ -527,6 +245,248 @@ TEST_F(BasicTableWriterTest, writerRuntimeStatsReachOperatorStats) {
           .at(std::string{Operator::kBackgroundCpuTimeNanos})
           .sum,
       kInjectedNanos);
+}
+
+// Covers InsertTableHandle::notNullColumns() enforcement.
+class TableWriterNotNullTest : public HiveConnectorTestBase {
+ protected:
+  // Plans a write of 'input' into a fresh directory. 'targetColumns', when set,
+  // selects and reorders the written columns.
+  core::PlanNodePtr writePlan(
+      const std::vector<RowVectorPtr>& input,
+      const std::vector<std::string>& notNullColumns,
+      const RowTypePtr& targetColumns = nullptr) {
+    directories_.push_back(TempDirectoryPath::create());
+    PlanBuilder planBuilder;
+    auto& writerBuilder =
+        planBuilder.values(input)
+            .startTableWriter()
+            .outputDirectoryPath(directories_.back()->getPath())
+            .notNullColumns(notNullColumns);
+    if (targetColumns != nullptr) {
+      writerBuilder.outputType(targetColumns);
+    }
+    return writerBuilder.endTableWriter().planNode();
+  }
+
+  int64_t writtenRows(const core::PlanNodePtr& plan) {
+    const auto results = AssertQueryBuilder(plan).copyResults(pool());
+    const auto* rowCount = results->childAt(TableWriteTraits::kRowCountChannel)
+                               ->as<FlatVector<int64_t>>();
+    VELOX_CHECK(!rowCount->isNullAt(0));
+    return rowCount->valueAt(0);
+  }
+
+  // Keeps the plans' output directories alive.
+  std::vector<std::shared_ptr<TempDirectoryPath>> directories_;
+};
+
+TEST_F(TableWriterNotNullTest, unconstrainedAllowsNulls) {
+  const vector_size_t size = 20;
+  auto data = makeRowVector(
+      {"c0"},
+      {makeFlatVector<int32_t>(
+          size, [](auto row) { return row; }, nullEvery(5))});
+
+  ASSERT_EQ(writtenRows(writePlan({data}, {})), size);
+}
+
+TEST_F(TableWriterNotNullTest, enforcement) {
+  const vector_size_t size = 100;
+  auto nonNulls = makeFlatVector<int32_t>(size, [](auto row) { return row; });
+  auto values =
+      makeFlatVector<int32_t>(size, [](auto row) { return row; }, nullEvery(3));
+  auto indices = makeIndices(size, [](auto row) { return row; });
+  // The same nulls presented flat, dictionary- and constant-wrapped, and as a
+  // struct that is itself null.
+  const std::vector<VectorPtr> nullColumns = {
+      values,
+      wrapInDictionary(indices, size, values),
+      makeNullConstant(TypeKind::INTEGER, size),
+      makeRowVector({nonNulls}, nullEvery(3)),
+  };
+
+  for (const auto& nullColumn : nullColumns) {
+    SCOPED_TRACE(nullColumn->toString());
+    auto data = makeRowVector({"c0", "c1"}, {nonNulls, nullColumn});
+
+    // Constraining c0 leaves the nulls in c1 alone.
+    ASSERT_EQ(writtenRows(writePlan({data}, {"c0"})), size);
+
+    VELOX_ASSERT_USER_THROW(
+        AssertQueryBuilder(writePlan({data}, {"c0", "c1"})).countResults(),
+        "NULL value not allowed for NOT NULL column: c1");
+  }
+}
+
+// A null row in the batch itself makes every column null in that row, which
+// the children do not reflect.
+TEST_F(TableWriterNotNullTest, nullBatchRows) {
+  const vector_size_t size = 10;
+  auto data = makeRowVector(
+      {makeFlatVector<int32_t>(size, [](auto row) { return row; })},
+      nullEvery(3));
+
+  ASSERT_EQ(writtenRows(writePlan({data}, {})), size);
+
+  VELOX_ASSERT_USER_THROW(
+      AssertQueryBuilder(writePlan({data}, {"c0"})).countResults(),
+      "NULL value not allowed for NOT NULL column: c0");
+}
+
+// Nulls inside a struct's fields are the fields' nulls, not the column's.
+TEST_F(TableWriterNotNullTest, nullsInsideStruct) {
+  const vector_size_t size = 10;
+  auto data = makeRowVector(
+      {"c0"},
+      {makeRowVector({makeFlatVector<int32_t>(
+          size, [](auto row) { return row; }, nullEvery(3))})});
+
+  ASSERT_EQ(writtenRows(writePlan({data}, {"c0"})), size);
+}
+
+// A RowVector may be shorter than its children, as in Limit's output. Nulls
+// past its size are not part of the batch.
+TEST_F(TableWriterNotNullTest, ignoresNullsBeyondBatchSize) {
+  const vector_size_t childSize = 10;
+  const vector_size_t batchSize = 4;
+  auto indices = makeIndices(childSize, [](auto row) { return row; });
+  auto base = makeFlatVector<int32_t>(
+      childSize,
+      [](auto row) { return row; },
+      [batchSize](auto row) { return row >= batchSize; });
+  auto data = std::make_shared<RowVector>(
+      pool(),
+      ROW({"c0"}, {INTEGER()}),
+      nullptr,
+      batchSize,
+      std::vector<VectorPtr>{wrapInDictionary(indices, childSize, base)});
+
+  ASSERT_EQ(writtenRows(writePlan({data}, {"c0"})), batchSize);
+}
+
+// The constraint names target table columns, which may be a reordered subset
+// of the input columns.
+TEST_F(TableWriterNotNullTest, reorderedColumns) {
+  const vector_size_t size = 10;
+  auto data = makeRowVector(
+      {"c0", "c1", "c2"},
+      {
+          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+          makeFlatVector<int32_t>(size, [](auto row) { return row * 2; }),
+          makeFlatVector<int32_t>(
+              size, [](auto row) { return row * 3; }, nullEvery(3)),
+      });
+  auto targetColumns = ROW({"c2", "c0"}, {INTEGER(), INTEGER()});
+
+  ASSERT_EQ(writtenRows(writePlan({data}, {"c0"}, targetColumns)), size);
+
+  VELOX_ASSERT_USER_THROW(
+      AssertQueryBuilder(writePlan({data}, {"c2"}, targetColumns))
+          .countResults(),
+      "NULL value not allowed for NOT NULL column: c2");
+}
+
+// The constraint names the table's columns, which may differ from the input's.
+// PlanBuilder always writes under the input names, so build the node directly.
+TEST_F(TableWriterNotNullTest, renamedColumns) {
+  const vector_size_t size = 10;
+  auto data = makeRowVector(
+      {"c0", "c1"},
+      {
+          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+          makeFlatVector<int32_t>(
+              size, [](auto row) { return row; }, nullEvery(3)),
+      });
+  const auto inputColumns = asRowType(data->type());
+  const std::vector<std::string> tableColumnNames = {"key", "value"};
+
+  auto directory = TempDirectoryPath::create();
+  auto writePlan = [&](const std::vector<std::string>& notNullColumns) {
+    auto insertHandle = std::make_shared<core::InsertTableHandle>(
+        kHiveConnectorId,
+        makeHiveInsertTableHandle(
+            tableColumnNames,
+            inputColumns->children(),
+            /*partitionedBy=*/{},
+            makeLocationHandle(directory->getPath())),
+        notNullColumns);
+    return PlanBuilder()
+        .values({data})
+        .addNode([&](const core::PlanNodeId& nodeId, core::PlanNodePtr source) {
+          return std::make_shared<core::TableWriteNode>(
+              nodeId,
+              inputColumns,
+              tableColumnNames,
+              /*columnStatsSpec=*/std::nullopt,
+              insertHandle,
+              /*hasPartitioningScheme=*/false,
+              TableWriteTraits::outputType(std::nullopt),
+              connector::CommitStrategy::kNoCommit,
+              std::move(source));
+        })
+        .planNode();
+  };
+
+  // 'key' maps to input column c0, which has no nulls.
+  ASSERT_EQ(writtenRows(writePlan({"key"})), size);
+
+  VELOX_ASSERT_USER_THROW(
+      AssertQueryBuilder(writePlan({"value"})).countResults(),
+      "NULL value not allowed for NOT NULL column: value");
+
+  VELOX_ASSERT_USER_THROW(
+      writePlan({"c1"}), "NOT NULL column is not in the table schema: c1");
+}
+
+// The reused DecodedVector must not break on a change of size or encoding, nor
+// mask a null in a later batch.
+TEST_F(TableWriterNotNullTest, multipleBatches) {
+  auto makeBatch = [&](vector_size_t size, bool dictionary, bool hasNulls) {
+    std::function<bool(vector_size_t)> isNullAt;
+    if (hasNulls) {
+      isNullAt = nullEvery(3);
+    }
+    auto values =
+        makeFlatVector<int32_t>(size, [](auto row) { return row; }, isNullAt);
+    if (!dictionary) {
+      return makeRowVector({"c0"}, {values});
+    }
+    auto indices = makeIndices(size, [](auto row) { return row; });
+    return makeRowVector({"c0"}, {wrapInDictionary(indices, size, values)});
+  };
+
+  ASSERT_EQ(
+      writtenRows(writePlan(
+          {makeBatch(10, false, false),
+           makeBatch(50, true, false),
+           makeBatch(1, true, false)},
+          {"c0"})),
+      61);
+
+  VELOX_ASSERT_USER_THROW(
+      AssertQueryBuilder(
+          writePlan(
+              {makeBatch(10, false, false), makeBatch(5, true, true)}, {"c0"}))
+          .countResults(),
+      "NULL value not allowed for NOT NULL column: c0");
+}
+
+TEST_F(TableWriterNotNullTest, invalidConstraint) {
+  const vector_size_t size = 10;
+  auto data = makeRowVector(
+      {"c0", "c1"},
+      {
+          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+          makeFlatVector<int32_t>(size, [](auto row) { return row * 2; }),
+      });
+
+  VELOX_ASSERT_USER_THROW(
+      writePlan({data}, {"c99"}),
+      "NOT NULL column is not in the table schema: c99");
+
+  VELOX_ASSERT_USER_THROW(
+      writePlan({data}, {"c0", "c0"}), "Duplicate NOT NULL column: c0");
 }
 
 class PartitionedTableWriterTest
@@ -2397,7 +2357,8 @@ TEST_P(AllTableWriterTest, columnStatsDataTypes) {
                               rowType_->children(),
                               partitionedBy_,
                               nullptr,
-                              makeLocationHandle(outputDirectory->getPath()))),
+                              makeLocationHandle(outputDirectory->getPath())),
+                          /*notNullColumns=*/std::vector<std::string>{}),
                       false,
                       CommitStrategy::kNoCommit))
                   .planNode();
@@ -2481,7 +2442,8 @@ TEST_P(AllTableWriterTest, columnStats) {
                               rowType_->children(),
                               partitionedBy_,
                               bucketProperty_,
-                              makeLocationHandle(outputDirectory->getPath()))),
+                              makeLocationHandle(outputDirectory->getPath())),
+                          /*notNullColumns=*/std::vector<std::string>{}),
                       false,
                       commitStrategy_))
                   .planNode();
@@ -2575,7 +2537,8 @@ TEST_P(AllTableWriterTest, columnStatsWithTableWriteMerge) {
               rowType_->children(),
               partitionedBy_,
               bucketProperty_,
-              makeLocationHandle(outputDirectory->getPath()))),
+              makeLocationHandle(outputDirectory->getPath())),
+          /*notNullColumns=*/std::vector<std::string>{}),
       false,
       commitStrategy_));
 

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -485,7 +485,8 @@ core::PlanNodePtr PlanBuilder::TableWriterBuilder::build(core::PlanNodeId id) {
       false,
       TableWriteTraits::outputType(columnStatsSpec),
       commitStrategy_,
-      upstreamNode);
+      upstreamNode,
+      notNullColumnNames_);
   VELOX_CHECK(!writeNode->supportsBarrier());
   return writeNode;
 }

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -455,8 +455,13 @@ core::PlanNodePtr PlanBuilder::TableWriterBuilder::build(core::PlanNodeId id) {
         options_,
         ensureFiles_);
 
-    insertHandle_ =
-        std::make_shared<core::InsertTableHandle>(connectorId_, hiveHandle);
+    insertHandle_ = std::make_shared<core::InsertTableHandle>(
+        connectorId_, hiveHandle, notNullColumnNames_);
+  } else if (!notNullColumnNames_.empty()) {
+    insertHandle_ = std::make_shared<core::InsertTableHandle>(
+        insertHandle_->connectorId(),
+        insertHandle_->connectorInsertTableHandle(),
+        notNullColumnNames_);
   }
 
   std::optional<core::ColumnStatsSpec> columnStatsSpec;
@@ -485,8 +490,7 @@ core::PlanNodePtr PlanBuilder::TableWriterBuilder::build(core::PlanNodeId id) {
       false,
       TableWriteTraits::outputType(columnStatsSpec),
       commitStrategy_,
-      upstreamNode,
-      notNullColumnNames_);
+      upstreamNode);
   VELOX_CHECK(!writeNode->supportsBarrier());
   return writeNode;
 }

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -418,7 +418,7 @@ core::PlanNodePtr PlanBuilder::TableWriterBuilder::build(core::PlanNodeId id) {
 
   // If insertHandle_ is not specified, build a HiveInsertTableHandle along with
   // columnHandles, bucketProperty and locationHandle.
-  if (!insertHandle_) {
+  if (insertHandle_ == nullptr) {
     // Create column handles.
     std::vector<std::shared_ptr<const connector::hive::HiveColumnHandle>>
         columnHandles;
@@ -449,7 +449,7 @@ core::PlanNodePtr PlanBuilder::TableWriterBuilder::build(core::PlanNodeId id) {
           targetColumns, bucketCount_, bucketedBy_, sortBy_);
     }
 
-    auto hiveHandle = std::make_shared<connector::hive::HiveInsertTableHandle>(
+    insertHandle_ = std::make_shared<connector::hive::HiveInsertTableHandle>(
         columnHandles,
         locationHandle,
         fileFormat_,
@@ -462,15 +462,9 @@ core::PlanNodePtr PlanBuilder::TableWriterBuilder::build(core::PlanNodeId id) {
         // follows it positionally, can be passed.
         std::make_shared<const connector::hive::HiveInsertFileNameGenerator>(),
         storageParameters_);
-
-    insertHandle_ = std::make_shared<core::InsertTableHandle>(
-        connectorId_, hiveHandle, notNullColumns_);
-  } else if (!notNullColumns_.empty()) {
-    insertHandle_ = std::make_shared<core::InsertTableHandle>(
-        insertHandle_->connectorId(),
-        insertHandle_->connectorInsertTableHandle(),
-        notNullColumns_);
   }
+  const auto insertTableHandle = std::make_shared<core::InsertTableHandle>(
+      connectorId_, insertHandle_, notNullColumns_);
 
   std::optional<core::ColumnStatsSpec> columnStatsSpec;
   if (!aggregates_.empty()) {
@@ -494,7 +488,7 @@ core::PlanNodePtr PlanBuilder::TableWriterBuilder::build(core::PlanNodeId id) {
       targetColumns,
       targetColumns->names(),
       columnStatsSpec,
-      insertHandle_,
+      insertTableHandle,
       false,
       TableWriteTraits::outputType(columnStatsSpec),
       commitStrategy_,
@@ -815,7 +809,7 @@ PlanBuilder& PlanBuilder::tableWrite(
     const RowTypePtr& schema,
     const bool ensureFiles,
     const connector::CommitStrategy commitStrategy,
-    std::shared_ptr<core::InsertTableHandle> insertTableHandle,
+    connector::ConnectorInsertTableHandlePtr insertTableHandle,
     const std::unordered_map<std::string, std::string>& storageParameters) {
   return TableWriterBuilder(*this)
       .outputDirectoryPath(outputDirectoryPath)

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -493,7 +493,8 @@ core::PlanNodePtr PlanBuilder::TableWriterBuilder::build(core::PlanNodeId id) {
       false,
       TableWriteTraits::outputType(columnStatsSpec),
       commitStrategy_,
-      upstreamNode);
+      upstreamNode,
+      notNullColumnNames_);
   VELOX_CHECK(!writeNode->supportsBarrier());
   return writeNode;
 }

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -464,12 +464,12 @@ core::PlanNodePtr PlanBuilder::TableWriterBuilder::build(core::PlanNodeId id) {
         storageParameters_);
 
     insertHandle_ = std::make_shared<core::InsertTableHandle>(
-        connectorId_, hiveHandle, notNullColumnNames_);
-  } else if (!notNullColumnNames_.empty()) {
+        connectorId_, hiveHandle, notNullColumns_);
+  } else if (!notNullColumns_.empty()) {
     insertHandle_ = std::make_shared<core::InsertTableHandle>(
         insertHandle_->connectorId(),
         insertHandle_->connectorInsertTableHandle(),
-        notNullColumnNames_);
+        notNullColumns_);
   }
 
   std::optional<core::ColumnStatsSpec> columnStatsSpec;

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -463,8 +463,13 @@ core::PlanNodePtr PlanBuilder::TableWriterBuilder::build(core::PlanNodeId id) {
         std::make_shared<const connector::hive::HiveInsertFileNameGenerator>(),
         storageParameters_);
 
-    insertHandle_ =
-        std::make_shared<core::InsertTableHandle>(connectorId_, hiveHandle);
+    insertHandle_ = std::make_shared<core::InsertTableHandle>(
+        connectorId_, hiveHandle, notNullColumnNames_);
+  } else if (!notNullColumnNames_.empty()) {
+    insertHandle_ = std::make_shared<core::InsertTableHandle>(
+        insertHandle_->connectorId(),
+        insertHandle_->connectorInsertTableHandle(),
+        notNullColumnNames_);
   }
 
   std::optional<core::ColumnStatsSpec> columnStatsSpec;
@@ -493,8 +498,7 @@ core::PlanNodePtr PlanBuilder::TableWriterBuilder::build(core::PlanNodeId id) {
       false,
       TableWriteTraits::outputType(columnStatsSpec),
       commitStrategy_,
-      upstreamNode,
-      notNullColumnNames_);
+      upstreamNode);
   VELOX_CHECK(!writeNode->supportsBarrier());
   return writeNode;
 }

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -618,6 +618,13 @@ class PlanBuilder {
       return *this;
     }
 
+    /// @param notNullColumnNames Columns that must not contain nulls.
+    TableWriterBuilder& notNullColumnNames(
+        std::vector<std::string> notNullColumnNames) {
+      notNullColumnNames_ = std::move(notNullColumnNames);
+      return *this;
+    }
+
     /// Stop the TableWriterBuilder.
     PlanBuilder& endTableWriter() {
       planBuilder_.planNode_ = build(planBuilder_.nextPlanNodeId());
@@ -651,6 +658,7 @@ class PlanBuilder {
     bool ensureFiles_{false};
     connector::CommitStrategy commitStrategy_{
         connector::CommitStrategy::kNoCommit};
+    std::optional<std::vector<std::string>> notNullColumnNames_;
   };
 
   /// Start a TableWriterBuilder.

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -658,7 +658,7 @@ class PlanBuilder {
     bool ensureFiles_{false};
     connector::CommitStrategy commitStrategy_{
         connector::CommitStrategy::kNoCommit};
-    std::optional<std::vector<std::string>> notNullColumnNames_;
+    std::vector<std::string> notNullColumnNames_;
   };
 
   /// Start a TableWriterBuilder.

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -681,7 +681,7 @@ class PlanBuilder {
     bool ensureFiles_{false};
     connector::CommitStrategy commitStrategy_{
         connector::CommitStrategy::kNoCommit};
-    std::optional<std::vector<std::string>> notNullColumnNames_;
+    std::vector<std::string> notNullColumnNames_;
   };
 
   /// Start a TableWriterBuilder.

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -545,11 +545,11 @@ class PlanBuilder {
       return *this;
     }
 
-    /// @param insertHandle TableInsertHandle (optional). Other builder
-    /// arguments such as the `connectorId`, `outputDirectoryPath`, `fileFormat`
-    /// and so on will be ignored.
+    /// @param insertHandle Connector-specific write request (optional). Other
+    /// builder arguments describing it, such as `outputDirectoryPath`,
+    /// `fileFormat` and so on, will be ignored.
     TableWriterBuilder& insertHandle(
-        std::shared_ptr<core::InsertTableHandle> insertHandle) {
+        connector::ConnectorInsertTableHandlePtr insertHandle) {
       insertHandle_ = std::move(insertHandle);
       return *this;
     }
@@ -640,9 +640,9 @@ class PlanBuilder {
       return *this;
     }
 
-    /// Unique target columns that must not contain nulls.
+    /// @param notNullColumns Target columns that must not contain nulls.
     TableWriterBuilder& notNullColumns(
-        std::vector<std::string> notNullColumns) {
+        folly::F14FastSet<std::string> notNullColumns) {
       notNullColumns_ = std::move(notNullColumns);
       return *this;
     }
@@ -662,7 +662,7 @@ class PlanBuilder {
     std::string outputDirectoryPath_;
     std::string outputFileName_;
     std::string connectorId_{kHiveDefaultConnectorId};
-    std::shared_ptr<core::InsertTableHandle> insertHandle_;
+    connector::ConnectorInsertTableHandlePtr insertHandle_;
 
     std::vector<std::string> partitionBy_;
     int32_t bucketCount_{0};
@@ -681,7 +681,7 @@ class PlanBuilder {
     bool ensureFiles_{false};
     connector::CommitStrategy commitStrategy_{
         connector::CommitStrategy::kNoCommit};
-    std::vector<std::string> notNullColumns_;
+    folly::F14FastSet<std::string> notNullColumns_;
   };
 
   /// Start a TableWriterBuilder.
@@ -909,10 +909,9 @@ class PlanBuilder {
   /// create a file even if there is no data.
   /// @param commitStrategy The commit strategy to use for the table write
   /// operation, default is kNoCommit.
-  /// @param insertTableHandle Encapsulates information needed to write data
-  /// to a table through a connector. If not specified, tableWrite will build
-  /// a HiveInsertTableHandle with columnHandles, bucketProperty and
-  /// locationHandle.
+  /// @param insertTableHandle Connector-specific write request. If not
+  /// specified, tableWrite will build a HiveInsertTableHandle with
+  /// columnHandles, bucketProperty and locationHandle.
   /// @param storageParameters Physical storage properties of the written
   /// objects, as opposed to the byte layout inside them. Consumed by the file
   /// sink rather than the format writer.
@@ -935,7 +934,7 @@ class PlanBuilder {
       const bool ensureFiles = false,
       const connector::CommitStrategy commitStrategy =
           connector::CommitStrategy::kNoCommit,
-      std::shared_ptr<core::InsertTableHandle> insertTableHandle = nullptr,
+      connector::ConnectorInsertTableHandlePtr insertTableHandle = nullptr,
       const std::unordered_map<std::string, std::string>& storageParameters =
           {});
 

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -640,6 +640,13 @@ class PlanBuilder {
       return *this;
     }
 
+    /// @param notNullColumnNames Columns that must not contain nulls.
+    TableWriterBuilder& notNullColumnNames(
+        std::vector<std::string> notNullColumnNames) {
+      notNullColumnNames_ = std::move(notNullColumnNames);
+      return *this;
+    }
+
     /// Stop the TableWriterBuilder.
     PlanBuilder& endTableWriter() {
       planBuilder_.planNode_ = build(planBuilder_.nextPlanNodeId());
@@ -674,6 +681,7 @@ class PlanBuilder {
     bool ensureFiles_{false};
     connector::CommitStrategy commitStrategy_{
         connector::CommitStrategy::kNoCommit};
+    std::optional<std::vector<std::string>> notNullColumnNames_;
   };
 
   /// Start a TableWriterBuilder.

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -640,10 +640,10 @@ class PlanBuilder {
       return *this;
     }
 
-    /// @param notNullColumnNames Columns that must not contain nulls.
-    TableWriterBuilder& notNullColumnNames(
-        std::vector<std::string> notNullColumnNames) {
-      notNullColumnNames_ = std::move(notNullColumnNames);
+    /// Unique target columns that must not contain nulls.
+    TableWriterBuilder& notNullColumns(
+        std::vector<std::string> notNullColumns) {
+      notNullColumns_ = std::move(notNullColumns);
       return *this;
     }
 
@@ -681,7 +681,7 @@ class PlanBuilder {
     bool ensureFiles_{false};
     connector::CommitStrategy commitStrategy_{
         connector::CommitStrategy::kNoCommit};
-    std::vector<std::string> notNullColumnNames_;
+    std::vector<std::string> notNullColumns_;
   };
 
   /// Start a TableWriterBuilder.

--- a/velox/exec/tests/utils/TableWriterTestBase.cpp
+++ b/velox/exec/tests/utils/TableWriterTestBase.cpp
@@ -134,7 +134,8 @@ TableWriterTestBase::addTableWriter(
         hasPartitioningScheme,
         TableWriteTraits::outputType(columnStatsSpec),
         commitStrategy,
-        std::move(source));
+        std::move(source),
+        std::nullopt);
   };
 }
 

--- a/velox/exec/tests/utils/TableWriterTestBase.cpp
+++ b/velox/exec/tests/utils/TableWriterTestBase.cpp
@@ -134,8 +134,7 @@ TableWriterTestBase::addTableWriter(
         hasPartitioningScheme,
         TableWriteTraits::outputType(columnStatsSpec),
         commitStrategy,
-        std::move(source),
-        std::nullopt);
+        std::move(source));
   };
 }
 

--- a/velox/exec/tests/utils/TableWriterTestBase.cpp
+++ b/velox/exec/tests/utils/TableWriterTestBase.cpp
@@ -529,7 +529,8 @@ TableWriterTestBase::createInsertTableHandle(
           makeLocationHandle(
               outputDirectoryPath, std::nullopt, outputTableType),
           fileFormat_,
-          compressionKind));
+          compressionKind),
+      /*notNullColumns=*/std::vector<std::string>{});
 }
 
 // Returns a table insert plan node.

--- a/velox/exec/tests/utils/TableWriterTestBase.cpp
+++ b/velox/exec/tests/utils/TableWriterTestBase.cpp
@@ -530,7 +530,7 @@ TableWriterTestBase::createInsertTableHandle(
               outputDirectoryPath, std::nullopt, outputTableType),
           fileFormat_,
           compressionKind),
-      /*notNullColumns=*/std::vector<std::string>{});
+      /*notNullColumns=*/folly::F14FastSet<std::string>{});
 }
 
 // Returns a table insert plan node.

--- a/velox/exec/trace/TraceUtil.cpp
+++ b/velox/exec/trace/TraceUtil.cpp
@@ -409,8 +409,7 @@ core::PlanNodePtr getTraceNode(
         core::TableWriteTraits::outputType(tableWriteNode->columnStatsSpec()),
         tableWriteNode->commitStrategy(),
         std::make_shared<DummySourceNode>(
-            tableWriteNode->sources().front()->outputType()),
-        tableWriteNode->notNullColumnNames());
+            tableWriteNode->sources().front()->outputType()));
   }
 
   if (const auto* unnestNode =

--- a/velox/exec/trace/TraceUtil.cpp
+++ b/velox/exec/trace/TraceUtil.cpp
@@ -409,7 +409,8 @@ core::PlanNodePtr getTraceNode(
         core::TableWriteTraits::outputType(tableWriteNode->columnStatsSpec()),
         tableWriteNode->commitStrategy(),
         std::make_shared<DummySourceNode>(
-            tableWriteNode->sources().front()->outputType()));
+            tableWriteNode->sources().front()->outputType()),
+        tableWriteNode->notNullColumnNames());
   }
 
   if (const auto* unnestNode =

--- a/velox/experimental/cudf/tests/TableWriteTest.cpp
+++ b/velox/experimental/cudf/tests/TableWriteTest.cpp
@@ -373,7 +373,8 @@ class TableWriteTest : public CudfHiveConnectorTestBase {
             outputRowType->names(),
             outputRowType->children(),
             makeLocationHandle(outputDirectoryPath, outputTableType),
-            compressionKind));
+            compressionKind),
+        /*notNullColumns=*/std::vector<std::string>{});
   }
 
   // Returns a table insert plan node.

--- a/velox/experimental/cudf/tests/TableWriteTest.cpp
+++ b/velox/experimental/cudf/tests/TableWriteTest.cpp
@@ -374,7 +374,7 @@ class TableWriteTest : public CudfHiveConnectorTestBase {
             outputRowType->children(),
             makeLocationHandle(outputDirectoryPath, outputTableType),
             compressionKind),
-        /*notNullColumns=*/std::vector<std::string>{});
+        /*notNullColumns=*/folly::F14FastSet<std::string>{});
   }
 
   // Returns a table insert plan node.

--- a/velox/experimental/cudf/tests/utils/CudfPlanBuilder.cpp
+++ b/velox/experimental/cudf/tests/utils/CudfPlanBuilder.cpp
@@ -39,7 +39,8 @@ std::function<PlanNodePtr(std::string, PlanNodePtr)> addCudfTableWriter(
         false,
         TableWriteTraits::outputType(columnStatsSpec),
         commitStrategy,
-        std::move(source));
+        std::move(source),
+        std::nullopt);
   };
 }
 
@@ -92,7 +93,8 @@ std::function<PlanNodePtr(std::string, PlanNodePtr)> cudfTableWrite(
         false,
         TableWriteTraits::outputType(columnStatsSpec),
         facebook::velox::connector::CommitStrategy::kNoCommit,
-        std::move(source));
+        std::move(source),
+        std::nullopt);
   };
 }
 

--- a/velox/experimental/cudf/tests/utils/CudfPlanBuilder.cpp
+++ b/velox/experimental/cudf/tests/utils/CudfPlanBuilder.cpp
@@ -39,8 +39,7 @@ std::function<PlanNodePtr(std::string, PlanNodePtr)> addCudfTableWriter(
         false,
         TableWriteTraits::outputType(columnStatsSpec),
         commitStrategy,
-        std::move(source),
-        std::nullopt);
+        std::move(source));
   };
 }
 
@@ -93,8 +92,7 @@ std::function<PlanNodePtr(std::string, PlanNodePtr)> cudfTableWrite(
         false,
         TableWriteTraits::outputType(columnStatsSpec),
         facebook::velox::connector::CommitStrategy::kNoCommit,
-        std::move(source),
-        std::nullopt);
+        std::move(source));
   };
 }
 

--- a/velox/experimental/cudf/tests/utils/CudfPlanBuilder.cpp
+++ b/velox/experimental/cudf/tests/utils/CudfPlanBuilder.cpp
@@ -81,7 +81,9 @@ std::function<PlanNodePtr(std::string, PlanNodePtr)> cudfTableWrite(
         CudfHiveConnectorTestBase::makeCudfHiveInsertTableHandle(
             rowType->names(), rowType->children(), locationHandle, compression);
     auto insertHandle = std::make_shared<core::InsertTableHandle>(
-        std::string(connectorId), parquetHandle);
+        std::string(connectorId),
+        parquetHandle,
+        /*notNullColumns=*/std::vector<std::string>{});
 
     return std::make_shared<core::TableWriteNode>(
         nodeId,

--- a/velox/experimental/cudf/tests/utils/CudfPlanBuilder.cpp
+++ b/velox/experimental/cudf/tests/utils/CudfPlanBuilder.cpp
@@ -83,7 +83,7 @@ std::function<PlanNodePtr(std::string, PlanNodePtr)> cudfTableWrite(
     auto insertHandle = std::make_shared<core::InsertTableHandle>(
         std::string(connectorId),
         parquetHandle,
-        /*notNullColumns=*/std::vector<std::string>{});
+        /*notNullColumns=*/folly::F14FastSet<std::string>{});
 
     return std::make_shared<core::TableWriteNode>(
         nodeId,

--- a/velox/tool/trace/TableWriterReplayer.cpp
+++ b/velox/tool/trace/TableWriterReplayer.cpp
@@ -99,6 +99,7 @@ core::PlanNodePtr TableWriterReplayer::createPlanNode(
       tableWriterNode->hasPartitioningScheme(),
       TableWriteTraits::outputType(tableWriterNode->columnStatsSpec()),
       tableWriterNode->commitStrategy(),
-      source);
+      source,
+      tableWriterNode->notNullColumnNames());
 }
 } // namespace facebook::velox::tool::trace

--- a/velox/tool/trace/TableWriterReplayer.cpp
+++ b/velox/tool/trace/TableWriterReplayer.cpp
@@ -80,7 +80,7 @@ std::shared_ptr<core::InsertTableHandle> createInsertTableHanlde(
   return std::make_shared<core::InsertTableHandle>(
       connectorId,
       makeHiveInsertTableHandle(node, std::move(targetDir)),
-      node->insertTableHandle()->notNullColumnNames());
+      node->insertTableHandle()->notNullColumns());
 }
 } // namespace
 

--- a/velox/tool/trace/TableWriterReplayer.cpp
+++ b/velox/tool/trace/TableWriterReplayer.cpp
@@ -78,7 +78,9 @@ std::shared_ptr<core::InsertTableHandle> createInsertTableHanlde(
     const core::TableWriteNode* node,
     std::string targetDir) {
   return std::make_shared<core::InsertTableHandle>(
-      connectorId, makeHiveInsertTableHandle(node, std::move(targetDir)));
+      connectorId,
+      makeHiveInsertTableHandle(node, std::move(targetDir)),
+      node->insertTableHandle()->notNullColumnNames());
 }
 } // namespace
 
@@ -99,7 +101,6 @@ core::PlanNodePtr TableWriterReplayer::createPlanNode(
       tableWriterNode->hasPartitioningScheme(),
       TableWriteTraits::outputType(tableWriterNode->columnStatsSpec()),
       tableWriterNode->commitStrategy(),
-      source,
-      tableWriterNode->notNullColumnNames());
+      source);
 }
 } // namespace facebook::velox::tool::trace

--- a/velox/tool/trace/tests/TableWriterReplayerTest.cpp
+++ b/velox/tool/trace/tests/TableWriterReplayerTest.cpp
@@ -155,7 +155,9 @@ class TableWriterReplayerTest : public HiveConnectorTestBase {
       const std::shared_ptr<core::InsertTableHandle>& insertHandle,
       bool hasPartitioningScheme,
       connector::CommitStrategy commitStrategy =
-          connector::CommitStrategy::kNoCommit) {
+          connector::CommitStrategy::kNoCommit,
+      std::optional<std::vector<std::string>> notNullColumnNames =
+          std::nullopt) {
     return [=](core::PlanNodeId nodeId,
                core::PlanNodePtr source) -> core::PlanNodePtr {
       return std::make_shared<core::TableWriteNode>(
@@ -167,7 +169,8 @@ class TableWriterReplayerTest : public HiveConnectorTestBase {
           hasPartitioningScheme,
           TableWriteTraits::outputType(statsSpec),
           commitStrategy,
-          source);
+          source,
+          notNullColumnNames);
     };
   }
 
@@ -486,6 +489,72 @@ TEST_F(TableWriterReplayerTest, serdeParametersPreserved) {
     ASSERT_EQ(tracedSerdeParams.count(key), 1);
     ASSERT_EQ(tracedSerdeParams.at(key), value);
   }
+}
+
+TEST_F(TableWriterReplayerTest, notNullConstraintPreserved) {
+  vector_size_t size = 1'000;
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+      makeFlatVector<int32_t>(size, [](auto row) { return row * 2; }),
+  });
+  auto sourceFilePath = TempFilePath::create();
+  writeToFile(sourceFilePath->getPath(), data);
+
+  auto rowType = asRowType(data->type());
+  auto targetDirectoryPath = TempDirectoryPath::create();
+  const std::vector<std::string> notNullColumnNames = {"c1"};
+
+  std::string traceNodeId;
+  auto plan =
+      PlanBuilder()
+          .tableScan(rowType)
+          .addNode(addTableWriter(
+              rowType,
+              rowType->names(),
+              std::nullopt,
+              createInsertTableHandle(
+                  rowType,
+                  connector::hive::LocationHandle::TableType::kNew,
+                  targetDirectoryPath->getPath(),
+                  {},
+                  nullptr),
+              false,
+              connector::CommitStrategy::kNoCommit,
+              notNullColumnNames))
+          .capturePlanNodeId(traceNodeId)
+          .project({TableWriteTraits::rowCountColumnName()})
+          .singleAggregation(
+              {},
+              {fmt::format("sum({})", TableWriteTraits::rowCountColumnName())})
+          .planNode();
+
+  const auto testDir = TempDirectoryPath::create();
+  const auto traceRoot = fmt::format("{}/{}", testDir->getPath(), "traceRoot");
+  std::shared_ptr<Task> task;
+  AssertQueryBuilder(plan)
+      .config(core::QueryConfig::kQueryTraceEnabled, true)
+      .config(core::QueryConfig::kQueryTraceDir, traceRoot)
+      .config(core::QueryConfig::kQueryTraceMaxBytes, 100UL << 30)
+      .config(core::QueryConfig::kQueryTraceTaskRegExp, ".*")
+      .config(core::QueryConfig::kQueryTraceNodeId, traceNodeId)
+      .split(makeHiveConnectorSplit(sourceFilePath->getPath()))
+      .copyResults(pool(), task);
+
+  // createPlanNode() forwards notNullColumnNames() verbatim from this node.
+  const auto taskTraceDir = exec::trace::getTaskTraceDirectory(
+      traceRoot, task->queryCtx()->queryId(), task->taskId());
+  const auto taskMetaReader =
+      exec::trace::TaskTraceMetadataReader(taskTraceDir, pool());
+  const auto queryPlan = taskMetaReader.queryPlan();
+  const auto* replayNode = core::PlanNode::findFirstNode(
+      queryPlan.get(),
+      [&](const auto* node) { return node->id() == traceNodeId; });
+  ASSERT_NE(replayNode, nullptr);
+  const auto* tableWriteNode =
+      dynamic_cast<const core::TableWriteNode*>(replayNode);
+  ASSERT_NE(tableWriteNode, nullptr);
+  ASSERT_TRUE(tableWriteNode->notNullColumnNames().has_value());
+  ASSERT_EQ(*tableWriteNode->notNullColumnNames(), notNullColumnNames);
 }
 
 TEST_F(TableWriterReplayerTest, partitionWrite) {

--- a/velox/tool/trace/tests/TableWriterReplayerTest.cpp
+++ b/velox/tool/trace/tests/TableWriterReplayerTest.cpp
@@ -156,8 +156,13 @@ class TableWriterReplayerTest : public HiveConnectorTestBase {
       bool hasPartitioningScheme,
       connector::CommitStrategy commitStrategy =
           connector::CommitStrategy::kNoCommit,
-      std::optional<std::vector<std::string>> notNullColumnNames =
-          std::nullopt) {
+      std::vector<std::string> notNullColumnNames = {}) {
+    const auto handle = !notNullColumnNames.empty()
+        ? std::make_shared<core::InsertTableHandle>(
+              insertHandle->connectorId(),
+              insertHandle->connectorInsertTableHandle(),
+              notNullColumnNames)
+        : insertHandle;
     return [=](core::PlanNodeId nodeId,
                core::PlanNodePtr source) -> core::PlanNodePtr {
       return std::make_shared<core::TableWriteNode>(
@@ -165,12 +170,11 @@ class TableWriterReplayerTest : public HiveConnectorTestBase {
           inputColumns,
           tableColumnNames,
           statsSpec,
-          insertHandle,
+          handle,
           hasPartitioningScheme,
           TableWriteTraits::outputType(statsSpec),
           commitStrategy,
-          source,
-          notNullColumnNames);
+          source);
     };
   }
 
@@ -540,7 +544,8 @@ TEST_F(TableWriterReplayerTest, notNullConstraintPreserved) {
       .split(makeHiveConnectorSplit(sourceFilePath->getPath()))
       .copyResults(pool(), task);
 
-  // createPlanNode() forwards notNullColumnNames() verbatim from this node.
+  // createPlanNode() forwards insertTableHandle()->notNullColumnNames()
+  // verbatim from this node.
   const auto taskTraceDir = exec::trace::getTaskTraceDirectory(
       traceRoot, task->queryCtx()->queryId(), task->taskId());
   const auto taskMetaReader =
@@ -553,8 +558,9 @@ TEST_F(TableWriterReplayerTest, notNullConstraintPreserved) {
   const auto* tableWriteNode =
       dynamic_cast<const core::TableWriteNode*>(replayNode);
   ASSERT_NE(tableWriteNode, nullptr);
-  ASSERT_TRUE(tableWriteNode->notNullColumnNames().has_value());
-  ASSERT_EQ(*tableWriteNode->notNullColumnNames(), notNullColumnNames);
+  const auto& tracedNotNullColumnNames =
+      tableWriteNode->insertTableHandle()->notNullColumnNames();
+  ASSERT_EQ(tracedNotNullColumnNames, notNullColumnNames);
 }
 
 TEST_F(TableWriterReplayerTest, partitionWrite) {

--- a/velox/tool/trace/tests/TableWriterReplayerTest.cpp
+++ b/velox/tool/trace/tests/TableWriterReplayerTest.cpp
@@ -98,7 +98,7 @@ class TableWriterReplayerTest : public HiveConnectorTestBase {
       const std::vector<std::string>& partitionedBy,
       const std::shared_ptr<HiveBucketProperty> bucketProperty,
       const std::optional<CompressionKind> compressionKind = {},
-      std::vector<std::string> notNullColumns = {}) {
+      folly::F14FastSet<std::string> notNullColumns = {}) {
     return std::make_shared<core::InsertTableHandle>(
         kHiveConnectorId,
         makeHiveInsertTableHandle(
@@ -428,7 +428,7 @@ TEST_F(TableWriterReplayerTest, serdeParametersPreserved) {
           fileFormat_,
           std::nullopt,
           serdeParams),
-      /*notNullColumns=*/std::vector<std::string>{});
+      /*notNullColumns=*/folly::F14FastSet<std::string>{});
 
   std::string traceNodeId;
   auto plan =
@@ -507,7 +507,7 @@ TEST_F(TableWriterReplayerTest, notNullConstraintPreserved) {
 
   auto rowType = asRowType(data->type());
   auto targetDirectoryPath = TempDirectoryPath::create();
-  const std::vector<std::string> notNullColumns = {"c1"};
+  const folly::F14FastSet<std::string> notNullColumns = {"c1"};
   constexpr std::string_view kErrorMessage =
       "NULL value not allowed for NOT NULL column: c1";
 

--- a/velox/tool/trace/tests/TableWriterReplayerTest.cpp
+++ b/velox/tool/trace/tests/TableWriterReplayerTest.cpp
@@ -22,6 +22,7 @@
 
 #include "folly/dynamic.h"
 #include "velox/common/base/Fs.h"
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/FileSystems.h"
 #include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/connectors/hive/HiveConnector.h"
@@ -96,7 +97,8 @@ class TableWriterReplayerTest : public HiveConnectorTestBase {
       const std::string& outputDirectoryPath,
       const std::vector<std::string>& partitionedBy,
       const std::shared_ptr<HiveBucketProperty> bucketProperty,
-      const std::optional<CompressionKind> compressionKind = {}) {
+      const std::optional<CompressionKind> compressionKind = {},
+      std::vector<std::string> notNullColumns = {}) {
     return std::make_shared<core::InsertTableHandle>(
         kHiveConnectorId,
         makeHiveInsertTableHandle(
@@ -107,7 +109,8 @@ class TableWriterReplayerTest : public HiveConnectorTestBase {
             makeLocationHandle(
                 outputDirectoryPath, std::nullopt, outputTableType),
             fileFormat_,
-            compressionKind));
+            compressionKind),
+        std::move(notNullColumns));
   }
 
   // Returns a table insert plan node.
@@ -155,14 +158,7 @@ class TableWriterReplayerTest : public HiveConnectorTestBase {
       const std::shared_ptr<core::InsertTableHandle>& insertHandle,
       bool hasPartitioningScheme,
       connector::CommitStrategy commitStrategy =
-          connector::CommitStrategy::kNoCommit,
-      std::vector<std::string> notNullColumnNames = {}) {
-    const auto handle = !notNullColumnNames.empty()
-        ? std::make_shared<core::InsertTableHandle>(
-              insertHandle->connectorId(),
-              insertHandle->connectorInsertTableHandle(),
-              notNullColumnNames)
-        : insertHandle;
+          connector::CommitStrategy::kNoCommit) {
     return [=](core::PlanNodeId nodeId,
                core::PlanNodePtr source) -> core::PlanNodePtr {
       return std::make_shared<core::TableWriteNode>(
@@ -170,7 +166,7 @@ class TableWriterReplayerTest : public HiveConnectorTestBase {
           inputColumns,
           tableColumnNames,
           statsSpec,
-          handle,
+          insertHandle,
           hasPartitioningScheme,
           TableWriteTraits::outputType(statsSpec),
           commitStrategy,
@@ -431,7 +427,8 @@ TEST_F(TableWriterReplayerTest, serdeParametersPreserved) {
               connector::hive::LocationHandle::TableType::kNew),
           fileFormat_,
           std::nullopt,
-          serdeParams));
+          serdeParams),
+      /*notNullColumns=*/std::vector<std::string>{});
 
   std::string traceNodeId;
   auto plan =
@@ -495,18 +492,24 @@ TEST_F(TableWriterReplayerTest, serdeParametersPreserved) {
   }
 }
 
+// Replay rebuilds the insert handle around a new target directory. The
+// constraint must survive that rebuild, so a trace whose input violates it
+// fails on replay too.
 TEST_F(TableWriterReplayerTest, notNullConstraintPreserved) {
   vector_size_t size = 1'000;
   auto data = makeRowVector({
       makeFlatVector<int32_t>(size, [](auto row) { return row; }),
-      makeFlatVector<int32_t>(size, [](auto row) { return row * 2; }),
+      makeFlatVector<int32_t>(
+          size, [](auto row) { return row * 2; }, nullEvery(7)),
   });
   auto sourceFilePath = TempFilePath::create();
   writeToFile(sourceFilePath->getPath(), data);
 
   auto rowType = asRowType(data->type());
   auto targetDirectoryPath = TempDirectoryPath::create();
-  const std::vector<std::string> notNullColumnNames = {"c1"};
+  const std::vector<std::string> notNullColumns = {"c1"};
+  constexpr std::string_view kErrorMessage =
+      "NULL value not allowed for NOT NULL column: c1";
 
   std::string traceNodeId;
   auto plan =
@@ -521,10 +524,10 @@ TEST_F(TableWriterReplayerTest, notNullConstraintPreserved) {
                   connector::hive::LocationHandle::TableType::kNew,
                   targetDirectoryPath->getPath(),
                   {},
-                  nullptr),
-              false,
-              connector::CommitStrategy::kNoCommit,
-              notNullColumnNames))
+                  nullptr,
+                  /*compressionKind=*/{},
+                  notNullColumns),
+              false))
           .capturePlanNodeId(traceNodeId)
           .project({TableWriteTraits::rowCountColumnName()})
           .singleAggregation(
@@ -534,33 +537,39 @@ TEST_F(TableWriterReplayerTest, notNullConstraintPreserved) {
 
   const auto testDir = TempDirectoryPath::create();
   const auto traceRoot = fmt::format("{}/{}", testDir->getPath(), "traceRoot");
-  std::shared_ptr<Task> task;
-  AssertQueryBuilder(plan)
-      .config(core::QueryConfig::kQueryTraceEnabled, true)
-      .config(core::QueryConfig::kQueryTraceDir, traceRoot)
-      .config(core::QueryConfig::kQueryTraceMaxBytes, 100UL << 30)
-      .config(core::QueryConfig::kQueryTraceTaskRegExp, ".*")
-      .config(core::QueryConfig::kQueryTraceNodeId, traceNodeId)
-      .split(makeHiveConnectorSplit(sourceFilePath->getPath()))
-      .copyResults(pool(), task);
+  std::string queryId;
+  std::string taskId;
+  // The input is traced before the operator sees it, so the failed query still
+  // leaves a replayable trace.
+  VELOX_ASSERT_USER_THROW(
+      AssertQueryBuilder(plan)
+          .config(core::QueryConfig::kQueryTraceEnabled, true)
+          .config(core::QueryConfig::kQueryTraceDir, traceRoot)
+          .config(core::QueryConfig::kQueryTraceMaxBytes, 100UL << 30)
+          .config(core::QueryConfig::kQueryTraceTaskRegExp, ".*")
+          .config(core::QueryConfig::kQueryTraceNodeId, traceNodeId)
+          .beforeTaskStart([&](Task& task) {
+            queryId = task.queryCtx()->queryId();
+            taskId = task.taskId();
+          })
+          .split(makeHiveConnectorSplit(sourceFilePath->getPath()))
+          .copyResults(pool()),
+      kErrorMessage);
 
-  // createPlanNode() forwards insertTableHandle()->notNullColumnNames()
-  // verbatim from this node.
-  const auto taskTraceDir = exec::trace::getTaskTraceDirectory(
-      traceRoot, task->queryCtx()->queryId(), task->taskId());
-  const auto taskMetaReader =
-      exec::trace::TaskTraceMetadataReader(taskTraceDir, pool());
-  const auto queryPlan = taskMetaReader.queryPlan();
-  const auto* replayNode = core::PlanNode::findFirstNode(
-      queryPlan.get(),
-      [&](const auto* node) { return node->id() == traceNodeId; });
-  ASSERT_NE(replayNode, nullptr);
-  const auto* tableWriteNode =
-      dynamic_cast<const core::TableWriteNode*>(replayNode);
-  ASSERT_NE(tableWriteNode, nullptr);
-  const auto& tracedNotNullColumnNames =
-      tableWriteNode->insertTableHandle()->notNullColumnNames();
-  ASSERT_EQ(tracedNotNullColumnNames, notNullColumnNames);
+  const auto replayOutputDir = TempDirectoryPath::create();
+  VELOX_ASSERT_USER_THROW(
+      TableWriterReplayer(
+          traceRoot,
+          queryId,
+          taskId,
+          traceNodeId,
+          "TableWriter",
+          "",
+          0,
+          executor_.get(),
+          replayOutputDir->getPath())
+          .run(),
+      kErrorMessage);
 }
 
 TEST_F(TableWriterReplayerTest, partitionWrite) {


### PR DESCRIPTION
## Why

The native (Prestissimo) worker currently accepts NULLs into NOT NULL columns
silently, while the Java engine rejects them in `TableWriterOperator` before any
file is written — a data-integrity and Java-parity gap
(https://github.com/prestodb/presto/issues/28156).

## What

Table writes can now enforce NOT NULL constraints on selected columns. Writing a
null into a column marked NOT NULL fails with, for example:
`NULL value not allowed for NOT NULL column: c1`.

`InsertTableHandle` carries the list of NOT NULL column names (empty means
unconstrained), so the constraint travels with the write-request descriptor and
round-trips through plan serialization. `TableWriteNode` validates at
construction that each name exists in the target schema. `TableWriter` maps each
constrained column to its input column and checks it with
`DecodedVector::hasNulls()`, which catches nulls behind dictionary or constant
encoding as well as flat vectors. The check is opt-in and only scans the listed
columns.

Part of https://github.com/prestodb/presto/issues/28156. E2E protocol changes:
https://github.com/prestodb/presto/pull/28040.
