### PR TITLE
feat(exec): Add kRightAnti join type (#18138)

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -1573,9 +1573,10 @@ void AbstractJoinNode::validate() const {
     VELOX_CHECK(!rightType->containsChild(name));
   }
 
-  // Output of right semi join cannot include columns from the left side.
-  bool outputMayIncludeLeftColumns =
-      !(isRightSemiFilterJoin() || isRightSemiProjectJoin());
+  // Output of right semi and right anti joins cannot include columns from the
+  // left side.
+  bool outputMayIncludeLeftColumns = !(
+      isRightSemiFilterJoin() || isRightSemiProjectJoin() || isRightAntiJoin());
 
   // Output of left semi and anti joins cannot include columns from the right
   // side.
@@ -1644,6 +1645,7 @@ const auto& joinTypeNames() {
       {JoinType::kAnti, "ANTI"},
       {JoinType::kCountingAnti, "COUNTING ANTI"},
       {JoinType::kCountingLeftSemiFilter, "COUNTING LEFT SEMI (FILTER)"},
+      {JoinType::kRightAnti, "RIGHT ANTI"},
   };
   return kNames;
 }

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -3010,7 +3010,13 @@ enum class JoinType {
   // EXCEPT ALL semantics.
   kCountingAnti = 10,
 
-  kNumJoinTypes = 11,
+  // Opposite of kAnti. Return each row from the right side that has no
+  // left-side match. Output includes only right-side columns. Only regular anti
+  // join (NOT EXISTS) is supported; null-aware (NOT IN) is rejected because it
+  // would require materializing the entire probe side.
+  kRightAnti = 11,
+
+  kNumJoinTypes = 12,
 };
 
 VELOX_DECLARE_ENUM_NAME(JoinType);
@@ -3049,6 +3055,10 @@ inline bool isRightSemiProjectJoin(JoinType joinType) {
 
 inline bool isAntiJoin(JoinType joinType) {
   return joinType == JoinType::kAnti;
+}
+
+inline bool isRightAntiJoin(JoinType joinType) {
+  return joinType == JoinType::kRightAnti;
 }
 
 inline bool isCountingAntiJoin(JoinType joinType) {
@@ -3207,6 +3217,10 @@ class AbstractJoinNode : public PlanNode {
 
   bool isAntiJoin() const {
     return joinType_ == JoinType::kAnti;
+  }
+
+  bool isRightAntiJoin() const {
+    return joinType_ == JoinType::kRightAnti;
   }
 
   bool isCountingAntiJoin() const {

--- a/velox/docs/develop/anti-join.rst
+++ b/velox/docs/develop/anti-join.rst
@@ -9,7 +9,10 @@ implemented by the null aware anti join. NOT EXISTS semantics are implemented
 by the regular anti join.
 
 Velox provides regular anti join via ``JoinType::kAnti`` and null-aware anti
-join via ``JoinType::kNullAwareAnti``.
+join via ``JoinType::kNullAwareAnti``. The build-side mirror, which returns
+build-side rows with no match on the probe side, is provided via
+``JoinType::kRightAnti`` (regular NOT EXISTS semantic only; no null-aware
+variant).
 
 This article explains the differences in semantics between NOT IN and NOT EXISTS
 queries and discusses the implementation of these in the null aware and regular

--- a/velox/docs/develop/joins.rst
+++ b/velox/docs/develop/joins.rst
@@ -3,10 +3,10 @@ Joins
 =====
 
 Velox supports inner, left, right, full outer, left semi filter, left semi
-project, right semi filter, right semi project, anti, and counting hash joins
-using either partitioned or broadcast distribution strategies. Semi project and
-anti joins support additional null-aware flag to distinguish between IN
-(null aware) and EXISTS (regular) semantics. Anti, left semi filter, and
+project, right semi filter, right semi project, anti, right anti, and counting
+hash joins using either partitioned or broadcast distribution strategies. Semi
+project and anti joins support additional null-aware flag to distinguish between
+IN (null aware) and EXISTS (regular) semantics. Anti, left semi filter, and
 counting joins support a null-as-value flag that enables IS NOT DISTINCT FROM
 semantics for join keys (NULL equals NULL), used to implement SQL set operations
 (EXCEPT, INTERSECT, EXCEPT ALL, INTERSECT ALL). Velox also supports cross joins.
@@ -28,7 +28,7 @@ values need to match, and an optional filter to apply to join results.
 
 The join type can be one of kInner, kLeft, kRight, kFull, kLeftSemiFilter,
 kCountingLeftSemiFilter, kLeftSemiProject, kRightSemiFilter, kRightSemiProject,
-kAnti, or kCountingAnti.
+kAnti, kRightAnti, or kCountingAnti.
 
 kLeftSemiProject, kRightSemiProject and kAnti joins support an additional
 nullAware flag to distinguish between IN (null aware) and EXISTS (regular)
@@ -235,6 +235,11 @@ regular anti join is used for queries with NOT EXISTS <subquery> clause.
 Broadly-speaking anti join returns probe-side rows which have no match on
 the build side. However, the exact semantics are a bit tricky. These are
 described in detail in :doc:`Anti joins <anti-join>`.
+
+Right anti join is the build-side mirror of anti join: it returns build-side
+rows which have no match on the probe side. Unlike anti join, right anti join
+supports only the regular (NOT EXISTS) semantic and does not support the
+null-aware flag.
 
 At a high level, null-aware anti join without extra filter behaves as follows:
 

--- a/velox/docs/develop/testing/join-fuzzer.rst
+++ b/velox/docs/develop/testing/join-fuzzer.rst
@@ -28,6 +28,7 @@ The logically equivalent plans are generated as follows:
     - LEFT(a, b) => RIGHT(b, a)
     - LEFT SEMI FILTER(a, b) => RIGHT SEMI FILTER(b, a)
     - LEFT SEMI PROJECT(a, b) => RIGHT SEMI PROJECT(b, a)
+    - ANTI(a, b) => RIGHT ANTI(b, a)
 - Introduce round-robin local exchange before the join:
   Values -> LocalExchange(ROUND_ROBIN) -> HashJoin
 - Replace HashJoin with OrderBy(join keys) + MergeJoin for supported join

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -255,8 +255,9 @@ void HashBuild::setupTable() {
   }
   auto& queryConfig = operatorCtx_->driverCtx()->queryConfig();
   if (joinNode_->isRightJoin() || joinNode_->isFullJoin() ||
-      joinNode_->isRightSemiProjectJoin()) {
-    // Do not ignore null keys.
+      joinNode_->isRightSemiProjectJoin() || joinNode_->isRightAntiJoin()) {
+    // Do not ignore null keys. kRightAnti must retain null keys: a null-keyed
+    // build row never matches and is always returned.
     table_ = HashTable<false>::createForJoin(
         std::move(keyHashers),
         dependentTypes,
@@ -472,8 +473,8 @@ void HashBuild::addInput(RowVectorPtr input) {
   }
 
   if (!isRightJoin(joinType_) && !isFullJoin(joinType_) &&
-      !isRightSemiProjectJoin(joinType_) && !nullAsValue_ &&
-      !isLeftNullAwareJoinWithFilter(joinNode_)) {
+      !isRightSemiProjectJoin(joinType_) && !isRightAntiJoin(joinType_) &&
+      !nullAsValue_ && !isLeftNullAwareJoinWithFilter(joinNode_)) {
     deselectRowsWithNulls(hashers, activeRows_);
     if (nullAware_ && !joinHasNullKeys_ &&
         activeRows_.countSelected() < input->size()) {

--- a/velox/exec/HashJoinBridge.cpp
+++ b/velox/exec/HashJoinBridge.cpp
@@ -466,7 +466,8 @@ bool isHashProbeMemoryPool(const memory::MemoryPool& pool) {
 
 bool needRightSideJoin(core::JoinType joinType) {
   return isRightJoin(joinType) || isFullJoin(joinType) ||
-      isRightSemiFilterJoin(joinType) || isRightSemiProjectJoin(joinType);
+      isRightSemiFilterJoin(joinType) || isRightSemiProjectJoin(joinType) ||
+      isRightAntiJoin(joinType);
 }
 
 RowTypePtr hashJoinTableSpillType(

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -486,7 +486,7 @@ void HashProbe::asyncWaitForHashTable() {
        isCountingLeftSemiFilterJoin(joinType_) ||
        isRightSemiFilterJoin(joinType_) ||
        (isRightSemiProjectJoin(joinType_) && !nullAware_) ||
-       isRightJoin(joinType_)) &&
+       isRightJoin(joinType_) || isRightAntiJoin(joinType_)) &&
       table_->hashMode() != BaseHashTable::HashMode::kHash && !isSpillInput() &&
       operatorCtx_->driverCtx()
           ->queryConfig()
@@ -925,7 +925,7 @@ RowVectorPtr HashProbe::getBuildSideOutput() {
           outputTableRows);
 
     } else {
-      // Must be a right join or full join.
+      // Must be a right, full, or right anti join.
       numOut = table_->listNotProbedRows(
           lastProbeIterator_,
           buildSideOutputRowContainerId_,
@@ -994,7 +994,8 @@ bool HashProbe::needLastProbe() const {
 bool HashProbe::skipProbeOnEmptyBuild() const {
   return isInnerJoin(joinType_) || isLeftSemiFilterJoin(joinType_) ||
       isCountingLeftSemiFilterJoin(joinType_) || isRightJoin(joinType_) ||
-      isRightSemiFilterJoin(joinType_) || isRightSemiProjectJoin(joinType_);
+      isRightSemiFilterJoin(joinType_) || isRightSemiProjectJoin(joinType_) ||
+      isRightAntiJoin(joinType_);
 }
 
 bool HashProbe::canSpill() const {
@@ -1320,9 +1321,10 @@ RowVectorPtr HashProbe::getOutputInternal(bool toSpillOutput) {
       table_->rows()->setProbedFlag(outputTableRows, numOut);
     }
 
-    // Right semi join only returns the build side output when the probe side
-    // is fully complete. Do not return anything here.
-    if (isRightSemiFilterJoin(joinType_) || isRightSemiProjectJoin(joinType_)) {
+    // Right semi and right anti joins only return the build side output when
+    // the probe side is fully complete. Do not return anything here.
+    if (isRightSemiFilterJoin(joinType_) || isRightSemiProjectJoin(joinType_) ||
+        isRightAntiJoin(joinType_)) {
       if (resultIter_->atEnd()) {
         input_ = nullptr;
       }
@@ -2288,14 +2290,15 @@ void HashProbe::spillOutput() {
       outputSpiller->spill(SpillPartitionId(0), output);
       continue;
     }
-    // NOTE: for right semi join types, we need to check if 'input_' has been
-    // cleared or not instead of checking on output. The right semi joins only
-    // producing the output after processing all the probe inputs.
+    // NOTE: for right semi and right anti join types, we need to check if
+    // 'input_' has been cleared or not instead of checking on output. These
+    // joins only produce the output after processing all the probe inputs.
     if (input_ == nullptr) {
       break;
     }
     VELOX_CHECK(
-        isRightSemiFilterJoin(joinType_) || isRightSemiProjectJoin(joinType_));
+        isRightSemiFilterJoin(joinType_) || isRightSemiProjectJoin(joinType_) ||
+        isRightAntiJoin(joinType_));
     VELOX_CHECK((output == nullptr) && (input_ != nullptr));
   }
   VELOX_CHECK_LE(outputSpiller->state().spilledPartitionIdSet().size(), 1);

--- a/velox/exec/fuzzer/JoinFuzzer.cpp
+++ b/velox/exec/fuzzer/JoinFuzzer.cpp
@@ -455,6 +455,10 @@ std::optional<core::JoinType> tryFlipJoinType(core::JoinType joinType) {
       return core::JoinType::kLeftSemiFilter;
     case core::JoinType::kRightSemiProject:
       return core::JoinType::kLeftSemiProject;
+    case core::JoinType::kAnti:
+      return core::JoinType::kRightAnti;
+    case core::JoinType::kRightAnti:
+      return core::JoinType::kAnti;
     default:
       return std::nullopt;
   }

--- a/velox/exec/fuzzer/JoinMaker.cpp
+++ b/velox/exec/fuzzer/JoinMaker.cpp
@@ -132,6 +132,10 @@ std::optional<core::JoinType> tryFlipJoinType(core::JoinType joinType) {
       return core::JoinType::kLeftSemiFilter;
     case core::JoinType::kRightSemiProject:
       return core::JoinType::kLeftSemiProject;
+    case core::JoinType::kAnti:
+      return core::JoinType::kRightAnti;
+    case core::JoinType::kRightAnti:
+      return core::JoinType::kAnti;
     default:
       return std::nullopt;
   }
@@ -571,6 +575,12 @@ bool JoinMaker::supportsFlippingHashJoin() const {
   //  Null-aware right semi project join doesn't support filter.
   if (!filter_.empty() && joinType_ == core::JoinType::kLeftSemiProject &&
       nullAware_) {
+    return false;
+  }
+
+  // Null-aware anti join has no right anti equivalent: kRightAnti rejects
+  // null-aware.
+  if (nullAware_ && joinType_ == core::JoinType::kAnti) {
     return false;
   }
 

--- a/velox/exec/fuzzer/PrestoSql.cpp
+++ b/velox/exec/fuzzer/PrestoSql.cpp
@@ -521,6 +521,12 @@ void PrestoSqlPlanNodeVisitor::visit(
         sql << ")";
       }
       break;
+    case core::JoinType::kRightAnti:
+      // Build-side mirror of kAnti; only the NOT EXISTS form exists.
+      sql << " FROM " << *buildTableName << " WHERE NOT EXISTS (SELECT * FROM "
+          << *probeTableName << " WHERE " << joinConditionAsSql(node);
+      sql << ")";
+      break;
     default:
       VELOX_UNREACHABLE(
           "Unknown join type: {}", static_cast<int>(node.joinType()));

--- a/velox/exec/tests/HashJoinBridgeTest.cpp
+++ b/velox/exec/tests/HashJoinBridgeTest.cpp
@@ -610,7 +610,8 @@ TEST(HashJoinBridgeTest, needRightSideJoin) {
   for (int i = 0; i < static_cast<int>(core::JoinType::kNumJoinTypes); ++i) {
     const core::JoinType joinType = static_cast<core::JoinType>(i);
     if (isRightJoin(joinType) || isFullJoin(joinType) ||
-        isRightSemiFilterJoin(joinType) || isRightSemiProjectJoin(joinType)) {
+        isRightSemiFilterJoin(joinType) || isRightSemiProjectJoin(joinType) ||
+        isRightAntiJoin(joinType)) {
       ASSERT_TRUE(needRightSideJoin(joinType));
     } else {
       ASSERT_FALSE(needRightSideJoin(joinType));

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -905,6 +905,104 @@ TEST_P(MultiThreadedHashJoinTest, rightSemiJoinFilter) {
       .run();
 }
 
+TEST_P(MultiThreadedHashJoinTest, rightAntiJoin) {
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .numDrivers(numDrivers_)
+      .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
+      .probeType(probeType_)
+      .probeVectors(133, 3)
+      .probeKeys({"t_k1"})
+      .buildType(buildType_)
+      .buildVectors(174, 4)
+      .buildKeys({"u_k1"})
+      .joinType(core::JoinType::kRightAnti)
+      .joinOutputLayout({"u_k2"})
+      .referenceQuery(
+          "SELECT u_k2 FROM u WHERE NOT EXISTS (SELECT 1 FROM t WHERE t_k1 = u_k1)")
+      .run();
+}
+
+TEST_P(MultiThreadedHashJoinTest, rightAntiJoinWithEmptyBuild) {
+  const std::vector<bool> finishOnEmptys = {false, true};
+  for (const auto finishOnEmpty : finishOnEmptys) {
+    SCOPED_TRACE(fmt::format("finishOnEmpty: {}", finishOnEmpty));
+
+    std::vector<RowVectorPtr> probeVectors =
+        makeBatches(5, [&](uint32_t /*unused*/) {
+          return makeRowVector(
+              {"t0", "t1"},
+              {makeFlatVector<int32_t>(
+                   431, [](auto row) { return row % 11; }, nullEvery(13)),
+               makeFlatVector<int32_t>(431, [](auto row) { return row; })});
+        });
+
+    std::vector<RowVectorPtr> buildVectors =
+        makeBatches(5, [&](uint32_t /*unused*/) {
+          return makeRowVector(
+              {"u0", "u1"},
+              {
+                  makeFlatVector<int32_t>(
+                      434, [](auto row) { return row % 5; }, nullEvery(7)),
+                  makeFlatVector<int32_t>(434, [](auto row) { return row; }),
+              });
+        });
+
+    // buildFilter empties the build side; right anti over an empty build
+    // produces no rows (every build row is gone).
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+        .hashProbeFinishEarlyOnEmptyBuild(finishOnEmpty)
+        .numDrivers(numDrivers_)
+        .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
+        .probeKeys({"t0"})
+        .probeVectors(std::move(probeVectors))
+        .buildKeys({"u0"})
+        .buildVectors(std::move(buildVectors))
+        .buildFilter("u0 < 0")
+        .joinType(core::JoinType::kRightAnti)
+        .joinOutputLayout({"u1"})
+        .referenceQuery(
+            "SELECT u.u1 FROM u WHERE NOT EXISTS (SELECT 1 FROM t WHERE t0 = u.u0) AND u.u0 < 0")
+        .checkSpillStats(false)
+        .run();
+  }
+}
+
+TEST_P(MultiThreadedHashJoinTest, rightAntiJoinWithExtraFilter) {
+  std::vector<RowVectorPtr> probeVectors =
+      makeBatches(4, [&](uint32_t /*unused*/) {
+        return makeRowVector(
+            {"t0", "t1"},
+            {makeFlatVector<int32_t>(
+                 256, [](auto row) { return row % 11; }, nullEvery(13)),
+             makeFlatVector<int32_t>(256, [](auto row) { return row; })});
+      });
+  std::vector<RowVectorPtr> buildVectors =
+      makeBatches(4, [&](uint32_t /*unused*/) {
+        return makeRowVector(
+            {"u0", "u1"},
+            {makeFlatVector<int32_t>(
+                 234, [](auto row) { return row % 5; }, nullEvery(7)),
+             makeFlatVector<int32_t>(234, [](auto row) { return row; })});
+      });
+
+  // Extra filter references a probe column (t1) even though the output is
+  // build-only: a build row is returned iff no probe row matches key AND
+  // filter.
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .numDrivers(numDrivers_)
+      .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
+      .probeKeys({"t0"})
+      .probeVectors(std::move(probeVectors))
+      .buildKeys({"u0"})
+      .buildVectors(std::move(buildVectors))
+      .joinType(core::JoinType::kRightAnti)
+      .joinFilter("t1 > u1")
+      .joinOutputLayout({"u0", "u1"})
+      .referenceQuery(
+          "SELECT u.u0, u.u1 FROM u WHERE NOT EXISTS (SELECT 1 FROM t WHERE t.t0 = u.u0 AND t.t1 > u.u1)")
+      .run();
+}
+
 TEST_P(MultiThreadedHashJoinTest, rightSemiJoinFilterWithEmptyBuild) {
   const std::vector<bool> finishOnEmptys = {false, true};
   for (const auto finishOnEmpty : finishOnEmptys) {
@@ -1270,6 +1368,30 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoin) {
         .checkSpillStats(false)
         .run();
   }
+}
+
+TEST_P(HashJoinTest, nullAwareRightAntiJoinIsRejected) {
+  // Right anti join supports only the regular (NOT EXISTS) semantic. Requesting
+  // the null-aware flag is rejected at plan construction.
+  auto probeVector = makeRowVector(
+      {"t0"}, {makeFlatVector<int32_t>(10, [](auto row) { return row; })});
+  auto buildVector = makeRowVector(
+      {"u0"}, {makeFlatVector<int32_t>(10, [](auto row) { return row; })});
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  VELOX_ASSERT_THROW(
+      PlanBuilder(planNodeIdGenerator)
+          .values({probeVector})
+          .hashJoin(
+              {"t0"},
+              {"u0"},
+              PlanBuilder(planNodeIdGenerator).values({buildVector}).planNode(),
+              /*filter=*/"",
+              {"u0"},
+              core::JoinType::kRightAnti,
+              /*nullAware=*/true)
+          .planNode(),
+      "Null-aware flag is supported only for semi project and anti joins");
 }
 
 TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoinWithFilter) {

--- a/velox/exec/tests/HashJoinTestExtra.cpp
+++ b/velox/exec/tests/HashJoinTestExtra.cpp
@@ -721,6 +721,49 @@ TEST_P(HashJoinTest, dynamicFilters) {
           })
           .run();
     }
+
+    // Right anti join.
+    op = PlanBuilder(planNodeIdGenerator, pool_.get())
+             .tableScan(probeType)
+             .capturePlanNodeId(probeScanId)
+             .hashJoin(
+                 {"c0"},
+                 {"u_c0"},
+                 buildSide,
+                 "",
+                 {"u_c0", "u_c1"},
+                 core::JoinType::kRightAnti)
+             .capturePlanNodeId(joinId)
+             .project({"u_c0", "u_c1 + 1"})
+             .planNode();
+    {
+      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+          .planNode(std::move(op))
+          .makeInputSplits(makeInputSplits(probeScanId))
+          .referenceQuery(
+              "SELECT u.c0, u.c1 + 1 FROM u WHERE NOT EXISTS (SELECT 1 FROM t WHERE t.c0 = u.c0)")
+          .verifier([&](const std::shared_ptr<Task>& task, bool hasSpill) {
+            SCOPED_TRACE(fmt::format("hasSpill:{}", hasSpill));
+            auto planStats = toPlanStats(task->taskStats());
+            if (hasSpill) {
+              // Dynamic filtering should be disabled with spilling triggered.
+              ASSERT_EQ(0, getFiltersProduced(task, 1).sum);
+              ASSERT_EQ(0, getFiltersAccepted(task, 0).sum);
+              ASSERT_EQ(getReplacedWithFilterRows(task, 1).sum, 0);
+              ASSERT_EQ(getInputPositions(task, 1), numRowsProbe * numSplits);
+              ASSERT_TRUE(planStats.at(probeScanId).dynamicFilterStats.empty());
+            } else {
+              ASSERT_EQ(1, getFiltersProduced(task, 1).sum);
+              ASSERT_EQ(1, getFiltersAccepted(task, 0).sum);
+              ASSERT_EQ(getReplacedWithFilterRows(task, 1).sum, 0);
+              ASSERT_LT(getInputPositions(task, 1), numRowsProbe * numSplits);
+              ASSERT_EQ(
+                  planStats.at(probeScanId).dynamicFilterStats.producerNodeIds,
+                  std::unordered_set<core::PlanNodeId>({joinId}));
+            }
+          })
+          .run();
+    }
   }
 
   // Basic push-down with column names projected out of the table scan

--- a/velox/exec/tests/PlanNodeSerdeTest.cpp
+++ b/velox/exec/tests/PlanNodeSerdeTest.cpp
@@ -567,6 +567,20 @@ TEST_F(PlanNodeSerdeTest, hashJoin) {
              .planNode();
 
   testSerde(plan);
+
+  // Right anti join projects build-side columns only.
+  plan = PlanBuilder(planNodeIdGenerator)
+             .values({probe})
+             .hashJoin(
+                 {"t0"},
+                 {"u0"},
+                 PlanBuilder(planNodeIdGenerator).values({build}).planNode(),
+                 "",
+                 {"u1", "u2"},
+                 core::JoinType::kRightAnti)
+             .planNode();
+
+  testSerde(plan);
 }
 
 TEST_F(PlanNodeSerdeTest, topN) {

--- a/velox/exec/tests/utils/HashJoinTestBase.h
+++ b/velox/exec/tests/utils/HashJoinTestBase.h
@@ -1026,6 +1026,10 @@ class HashJoinTestBase : public HiveConnectorTestBase {
         return core::JoinType::kLeftSemiFilter;
       case core::JoinType::kRightSemiProject:
         return core::JoinType::kLeftSemiProject;
+      case core::JoinType::kAnti:
+        return core::JoinType::kRightAnti;
+      case core::JoinType::kRightAnti:
+        return core::JoinType::kAnti;
       default:
         VELOX_FAIL(
             "Cannot flip join type: {}", core::JoinTypeName::toName(joinType));
@@ -1035,9 +1039,16 @@ class HashJoinTestBase : public HiveConnectorTestBase {
   static core::PlanNodePtr flipJoinSides(const core::PlanNodePtr& plan) {
     auto joinNode = std::dynamic_pointer_cast<const core::HashJoinNode>(plan);
     VELOX_CHECK_NOT_NULL(joinNode);
+    const auto flippedJoinType = flipJoinType(joinNode->joinType());
+    // A null-aware anti join has no right anti equivalent, since kRightAnti has
+    // no null-aware form, so such a plan cannot be flipped.
+    VELOX_CHECK(
+        flippedJoinType != core::JoinType::kRightAnti ||
+            !joinNode->isNullAware(),
+        "Null-aware anti join has no right anti equivalent");
     return std::make_shared<core::HashJoinNode>(
         joinNode->id(),
-        flipJoinType(joinNode->joinType()),
+        flippedJoinType,
         joinNode->isNullAware(),
         joinNode->rightKeys(),
         joinNode->leftKeys(),


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/axiom/pull/1585


Add a `kRightAnti` hash-join type that returns build-side (right) rows with no match on the probe (left) side -- the mirror of `kRightSemiFilter`. This lets an optimizer build the hash table from the smaller input of an anti join: `kAnti(L, R)` (build R) is equivalent to `kRightAnti(R, L)` (build L), a free win when the left side is much smaller than the right.

The implementation reuses the existing unmatched-build-row machinery: `kRightAnti` rides `needRightSideJoin` (probed-flag tracking + spill), HashBuild keeps null keys (a null-keyed build row never matches and so is always returned), and `HashProbe::getBuildSideOutput` emits not-probed rows via `listNotProbedRows` with build-only output (no probe columns). The null-aware (`NOT IN`) variant is rejected by omission from `isNullAwareSupported`, because resolving its three-valued logic for a build row would require materializing the entire streaming probe side.

Implements facebookincubator/velox#17815.

Reviewed By: mbasmanova

Differential Revision: D110210356


