### PR TITLE
fix: Stop reading ahead past a back-pressured operator to prevent stale LazyVector loads (#18139)

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -782,6 +782,18 @@ StopReason Driver::runInternal(
                 break;
               }
             }
+          } else {
+            // Transitive back-pressure. 'nextOp' is full
+            // (needsInput()==false) and already confirmed kNotBlocked above, so
+            // nothing upstream can flow past it. Stop the upstream production
+            // walk instead of filling/advancing operators above this
+            // bottleneck: reading ahead strands an unloaded scan LazyVector in
+            // an intermediate operator while the source reader advances,
+            // tripping the "Loading LazyVector after the enclosing reader has
+            // moved" check on a later load. 'nextOp' drains at its own
+            // already-visited position; the outer loop re-descends to make
+            // progress.
+            break;
           }
         } else {
           // A sink (last) operator, after getting unblocked, gets

--- a/velox/exec/rpc/RPCOperator.cpp
+++ b/velox/exec/rpc/RPCOperator.cpp
@@ -133,6 +133,8 @@ bool RPCOperator::needsInput() const {
 
   // Check per-state backpressure.
   if (state_->isUnderBackpressure()) {
+    // NOTE: in BATCH mode this back-pressure is not paired with a blocking
+    // isBlocked() future -- see the TODO in isBlocked().
     return false;
   }
 
@@ -633,6 +635,18 @@ exec::BlockingReason RPCOperator::isBlocked(ContinueFuture* future) {
   } else {
     // BATCH mode
     if (!noMoreInput_ && !isDraining()) {
+      // TODO: back-pressure contract gap. needsInput() returns
+      // false under pending-batch back-pressure
+      // (state_->isUnderBackpressure()), but this mid-stream path polls without
+      // registering a waiter and returns kNotBlocked below even when no batch
+      // is ready -- i.e. "full but not blocked". The standard Velox contract
+      // (cf. PartitionedOutput / LocalPartition) signals fullness via
+      // isBlocked() returning a future. A driver that stops its upstream walk
+      // at a full operator (transitive back-pressure) can therefore busy-spin
+      // here until an in-flight batch completes instead of parking off-thread.
+      // Fix: when under back-pressure with no ready batch, return kWaitForRPC
+      // on the oldest pending batch (route through a promise-registering poll
+      // like tryPollBatchOrWait) rather than tryPollReady + kNotBlocked.
       auto readyBatch = state_->tryPollReady();
       if (readyBatch) {
         if (readyBatch->error.has_value()) {

--- a/velox/exec/tests/IndexLookupJoinTest.cpp
+++ b/velox/exec/tests/IndexLookupJoinTest.cpp
@@ -26,6 +26,7 @@
 #include "velox/core/PlanNode.h"
 #include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/BackpressureTestNode.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/IndexLookupJoinTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
@@ -150,6 +151,149 @@ class IndexLookupJoinTest : public IndexLookupJoinTestBase,
   const std::unique_ptr<folly::CPUThreadPoolExecutor> connectorCpuExecutor_{
       std::make_unique<folly::CPUThreadPoolExecutor>(128)};
 };
+
+class LazyStaleAcrossBatchTest : public IndexLookupJoinTestBase {
+ protected:
+  void SetUp() override {
+    HiveConnectorTestBase::SetUp();
+    TestIndexConnectorFactory::registerConnector(connectorCpuExecutor_.get());
+    Operator::registerOperator(std::make_unique<BackpressureTranslator>());
+    keyType_ = ROW({"u0"}, {BIGINT()});
+    valueType_ = ROW({"u1"}, {BIGINT()});
+    tableType_ = concat(keyType_, valueType_);
+    probeType_ = ROW({"t0", "t1"}, {BIGINT(), BIGINT()});
+  }
+
+  void TearDown() override {
+    Operator::unregisterAllOperators();
+    connector::ConnectorRegistry::global().erase(kTestIndexConnectorName);
+    HiveConnectorTestBase::TearDown();
+  }
+
+  static std::shared_ptr<TestIndexTableHandle> makeIndexTableHandle(
+      const std::shared_ptr<TestIndexTable>& indexTable,
+      bool asyncLookup) {
+    return std::make_shared<TestIndexTableHandle>(
+        kTestIndexConnectorName, indexTable, asyncLookup, false);
+  }
+
+  static connector::ColumnHandleMap makeIndexColumnHandles(
+      const std::vector<std::string>& names) {
+    connector::ColumnHandleMap handles;
+    for (const auto& name : names) {
+      handles.emplace(name, std::make_shared<TestIndexColumnHandle>(name));
+    }
+    return handles;
+  }
+
+  const std::unique_ptr<folly::CPUThreadPoolExecutor> connectorCpuExecutor_{
+      std::make_unique<folly::CPUThreadPoolExecutor>(128)};
+};
+
+// Reproduces the Driver-level bug where the TableScan reader advances past a
+// passthrough LazyVector that the IndexLookupJoin still holds unloaded
+// downstream, surfacing as "Loading LazyVector after the enclosing reader has
+// moved". See BackpressureTestNode.h for how the back-pressuring sink forces
+// the driver to race the scan ahead while a probe batch is draining. The bug is
+// operator-neutral; NestedLoopJoinTest has the same regression with a
+// cross-product join. This test passes once the Driver fix is in place.
+TEST_F(LazyStaleAcrossBatchTest, lazyVectorStaleUnderBackpressure) {
+  IndexTableData tableData;
+  generateIndexTableData(/*keyCardinalities=*/{100}, tableData, pool_);
+
+  // One large probe input -> one file -> one split whose reader yields many
+  // (10k-row) batches (~9). The join drains each batch over multiple
+  // getOutput() calls, so while one batch is draining the driver advances the
+  // scan to read later batches -- this is what lets the reader move past a
+  // batch whose scan lazy is still unloaded downstream.
+  auto probeVectors = generateProbeInput(
+      /*numBatches=*/1,
+      /*batchSize=*/90'000,
+      /*numDuplicateProbeRows=*/1,
+      tableData,
+      pool_,
+      /*probeJoinKeys=*/{"t0"},
+      /*hasNullKeys=*/false,
+      /*inColumns=*/{},
+      /*betweenColumns=*/{},
+      /*equalMatchPct=*/100);
+  auto probeFiles = createProbeFiles(probeVectors);
+
+  auto indexTable = TestIndexTable::create(
+      /*numEqualJoinKeys=*/1,
+      tableData.keyVectors,
+      tableData.valueVectors,
+      *pool());
+  // Synchronous lookups: isBlocked never blocks the join, so the join drains
+  // each batch itself while the driver races the scan ahead.
+  auto indexTableHandle =
+      makeIndexTableHandle(indexTable, /*asyncLookup=*/false);
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto indexScanNode = makeIndexScanNode(
+      planNodeIdGenerator,
+      indexTableHandle,
+      makeScanOutputType({"u0", "u1"}),
+      makeIndexColumnHandles({"u0", "u1"}));
+
+  // Project[1] loads t1 and passes t0 through as an unloaded scan LazyVector;
+  // Project[2] loads t0 to form the join key.
+  auto plan = PlanBuilder(planNodeIdGenerator, pool_.get())
+                  .startTableScan()
+                  .outputType(probeType_)
+                  .endTableScan()
+                  .captureScanNodeId(probeScanNodeId_)
+                  .project({"t1 + 0 AS t1", "t0"})
+                  .project({"t0 + 0 AS t0", "t1"})
+                  .startIndexLookupJoin()
+                  .leftKeys({"t0"})
+                  .rightKeys({"u0"})
+                  .indexSource(indexScanNode)
+                  .outputLayout({"t0", "t1", "u1"})
+                  .joinType(core::JoinType::kInner)
+                  .endIndexLookupJoin()
+                  .capturePlanNodeId(joinNodeId_)
+                  // Downstream projects: the join drains each probe batch into
+                  // them over multiple driver iterations, during which the
+                  // driver fills the scan + upstream projects ahead of
+                  // Project[2].
+                  .project({"t0 + 0 AS t0", "t1", "u1"})
+                  .project({"t0", "t1 + 0 AS t1", "u1"})
+                  .addNode([](const std::string& id, core::PlanNodePtr input) {
+                    return std::make_shared<BackpressureNode>(
+                        id, /*delayCycles=*/20, std::move(input));
+                  })
+                  .planNode();
+
+  // No prefetch (maxNumInputBatches_ == 1). The join holds a single probe batch
+  // and drains it into the downstream projects over many getOutput() calls
+  // because its output is chunked at outputBatchSize_ (1024) while a scan read
+  // is 10000 rows. Throughout that multi-call drain numInputBatches()==1==max
+  // so the join refuses input; the driver, unable to feed it, instead advances
+  // the scan->Project[1]->Project[2] chain via per-pair back-pressure:
+  // Project[1] forwards the next batch (with t0 still an unloaded scan lazy)
+  // into the empty Project[2], then the scan reads one more batch. When the
+  // join finishes the current batch and finally pulls Project[2], Project[2]
+  // loads that stranded t0 lazy against a reader that has already moved ->
+  // stale version crash. Parallel (non-serial) execution: the sink does not
+  // block the driver per output chunk. In serial cursor mode the driver returns
+  // kWaitForConsumer after every chunk and resumes from the sink, so it
+  // re-drains the join (which still holds the batch) without ever walking up to
+  // the scan -- the reader never advances during the drain and the bug is
+  // masked. With a non-blocking sink the driver continues the loop up to the
+  // scan between chunks, advancing the reader while Project[2] still holds an
+  // unloaded lazy.
+  auto result =
+      AssertQueryBuilder(plan)
+          .serialExecution(false)
+          .splits(probeScanNodeId_, makeHiveConnectorSplits(probeFiles))
+          .copyResults(pool_.get());
+  // With the bug, copyResults() above throws the lazy-vector "reader has moved"
+  // error before reaching here. After the fix, the inner join produces exactly
+  // one output row per probe row: equalMatchPct=100 so every probe key matches,
+  // and the index keys are unique (keyCardinalities={100}) so each match fans
+  // out to a single row.
+  ASSERT_EQ(result->size(), probeVectors[0]->size());
+}
 
 TEST_F(IndexLookupJoinTest, joinCondition) {
   const auto rowType =

--- a/velox/exec/tests/NestedLoopJoinTest.cpp
+++ b/velox/exec/tests/NestedLoopJoinTest.cpp
@@ -17,6 +17,7 @@
 #include "velox/core/PlanNode.h"
 #include "velox/exec/NestedLoopJoinBuild.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/BackpressureTestNode.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/exec/tests/utils/VectorTestUtil.h"
@@ -1004,6 +1005,67 @@ DEBUG_ONLY_TEST_F(NestedLoopJoinTest, longBatchDurationYield) {
   }
   ASSERT_LT(
       testSettings[0].numGetOutputCalls, testSettings[1].numGetOutputCalls);
+}
+
+// Reproduces the operator-neutral Driver-level bug where the TableScan reader
+// advances past a passthrough LazyVector that an intermediate operator still
+// holds unloaded, surfacing as "Loading LazyVector after the enclosing reader
+// has moved". Here the amplifying operator is a cross-product NestedLoopJoin:
+// it holds one probe batch and drains it over many chunked getOutput() calls
+// while needsInput() == false. A back-pressuring sink (see
+// BackpressureTestNode.h) forces the driver to race the scan ahead during that
+// drain, stranding the unloaded scan lazy that Project[1] forwarded. This test
+// passes once the Driver fix is in place.
+TEST_F(NestedLoopJoinTest, lazyVectorStaleUnderBackpressure) {
+  Operator::registerOperator(std::make_unique<BackpressureTranslator>());
+
+  // One large probe input -> one file -> one split whose reader yields many
+  // (10k-row) batches. t0 cycles through 100 distinct values; t1 is a unique
+  // row ordinal.
+  auto probeVector = makeRowVector(
+      {"t0", "t1"},
+      {makeFlatVector<int64_t>(90'000, [](auto i) { return i % 100; }),
+       makeFlatVector<int64_t>(90'000, [](auto i) { return i; })});
+  auto probeFile = TempFilePath::create();
+  writeToFile(probeFile->getPath(), {probeVector});
+
+  // Small build side: the cross product multiplies each 10k-row probe batch by
+  // these rows, so one probe batch yields many output chunks -> a long drain
+  // window during which the scan reader advances.
+  auto buildVector = makeRowVector(
+      {"u0"}, {makeFlatVector<int64_t>(std::vector<int64_t>{0, 1, 2, 3})});
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  core::PlanNodeId scanNodeId;
+  // Project[1] loads t1 and forwards t0 as an unloaded scan LazyVector;
+  // Project[2] loads t0.
+  auto plan = PlanBuilder(planNodeIdGenerator, pool_.get())
+                  .tableScan(ROW({"t0", "t1"}, {BIGINT(), BIGINT()}))
+                  .captureScanNodeId(scanNodeId)
+                  .project({"t1 + 0 AS t1", "t0"})
+                  .project({"t0 + 0 AS t0", "t1"})
+                  .nestedLoopJoin(
+                      PlanBuilder(planNodeIdGenerator, pool_.get())
+                          .values({buildVector})
+                          .planNode(),
+                      {"t0", "t1", "u0"},
+                      core::JoinType::kInner)
+                  .project({"t0 + 0 AS t0", "t1", "u0"})
+                  .project({"t0", "t1 + 0 AS t1", "u0"})
+                  .addNode([](const std::string& id, core::PlanNodePtr input) {
+                    return std::make_shared<BackpressureNode>(
+                        id, /*delayCycles=*/20, std::move(input));
+                  })
+                  .planNode();
+
+  auto result = AssertQueryBuilder(plan)
+                    .serialExecution(false)
+                    .splits(scanNodeId, makeHiveConnectorSplits({probeFile}))
+                    .copyResults(pool());
+  // Cross product of every probe row with every build row.
+  ASSERT_EQ(result->size(), probeVector->size() * buildVector->size());
+
+  Operator::unregisterAllOperators();
 }
 
 } // namespace

--- a/velox/exec/tests/utils/BackpressureTestNode.h
+++ b/velox/exec/tests/utils/BackpressureTestNode.h
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/core/PlanNode.h"
+#include "velox/exec/Operator.h"
+
+namespace facebook::velox::exec::test {
+
+/// Pass-through sink that emulates a slow downstream consumer by applying
+/// back-pressure: after accepting a chunk it refuses further input
+/// (needsInput() == false) for 'delayCycles' driver iterations while returning
+/// null from getOutput(). During that window the driver, unable to push the
+/// upstream operator's output down, descends to the TableScan and advances its
+/// reader.
+///
+/// This is used to deterministically reproduce the Driver-level bug where the
+/// scan reader advances past a passthrough LazyVector that an intermediate
+/// operator still holds unloaded, surfacing as "Loading LazyVector after the
+/// enclosing reader has moved". The bug is operator-neutral: any operator that
+/// emits one input batch over multiple chunked getOutput() calls while
+/// needsInput() == false (e.g. IndexLookupJoin or a cross-product
+/// NestedLoopJoin), sitting downstream of a project-forwarded unloaded scan
+/// LazyVector, can strand that lazy. Without such back-pressure the test cursor
+/// consumes every chunk instantly and the pipeline runs lock-step, so the
+/// reader never advances mid-drain and the bug is masked.
+class BackpressureNode : public core::PlanNode {
+ public:
+  BackpressureNode(
+      const core::PlanNodeId& id,
+      int32_t delayCycles,
+      core::PlanNodePtr source)
+      : PlanNode(id), delayCycles_(delayCycles), sources_{std::move(source)} {}
+
+  const RowTypePtr& outputType() const override {
+    return sources_[0]->outputType();
+  }
+
+  const std::vector<core::PlanNodePtr>& sources() const override {
+    return sources_;
+  }
+
+  std::string_view name() const override {
+    return "Backpressure";
+  }
+
+  int32_t delayCycles() const {
+    return delayCycles_;
+  }
+
+ private:
+  void addDetails(std::stringstream& /*stream*/) const override {}
+
+  const int32_t delayCycles_;
+  const std::vector<core::PlanNodePtr> sources_;
+};
+
+class BackpressureOperator : public Operator {
+ public:
+  BackpressureOperator(
+      int32_t operatorId,
+      DriverCtx* driverCtx,
+      const std::shared_ptr<const BackpressureNode>& node)
+      : Operator(
+            driverCtx,
+            node->outputType(),
+            operatorId,
+            node->id(),
+            "Backpressure"),
+        delayCycles_(node->delayCycles()) {}
+
+  bool needsInput() const override {
+    return !noMoreInput_ && input_ == nullptr;
+  }
+
+  void addInput(RowVectorPtr input) override {
+    input_ = std::move(input);
+    cyclesLeft_ = delayCycles_;
+  }
+
+  RowVectorPtr getOutput() override {
+    if (input_ == nullptr) {
+      return nullptr;
+    }
+    if (cyclesLeft_ > 0) {
+      --cyclesLeft_;
+      return nullptr;
+    }
+    return std::move(input_);
+  }
+
+  BlockingReason isBlocked(ContinueFuture* /*future*/) override {
+    return BlockingReason::kNotBlocked;
+  }
+
+  bool isFinished() override {
+    return noMoreInput_ && input_ == nullptr;
+  }
+
+ private:
+  const int32_t delayCycles_;
+  int32_t cyclesLeft_{0};
+};
+
+class BackpressureTranslator : public Operator::PlanNodeTranslator {
+ public:
+  std::unique_ptr<Operator> toOperator(
+      DriverCtx* ctx,
+      int32_t id,
+      const core::PlanNodePtr& node) override {
+    if (auto castedNode =
+            std::dynamic_pointer_cast<const BackpressureNode>(node)) {
+      return std::make_unique<BackpressureOperator>(id, ctx, castedNode);
+    }
+    return nullptr;
+  }
+};
+
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/utils/CMakeLists.txt
+++ b/velox/exec/tests/utils/CMakeLists.txt
@@ -40,6 +40,7 @@ velox_add_test_headers(
   AggregationResolver.h
   ArbitratorTestUtil.h
   AssertQueryBuilder.h
+  BackpressureTestNode.h
   ExpressionBuilder.h
   FilterToExpression.h
   HashJoinTestBase.h


### PR DESCRIPTION
Summary:

Under back-pressure from a slow downstream sink (e.g. a `TableWrite` stalling on storage), the `Driver::runInternal` sink->source descend loop would walk past a full operator (`needsInput()==false`) and keep filling empty upstream operators -- i.e. read ahead. With a non-blocking sink this advances the `TableScan` reader past a probe-side passthrough `LazyVector` that is still held unloaded in an intermediate operator (e.g. a `FilterProject` feeding an `IndexLookupJoin`/`NestedLoopJoin` that drains one input batch over many chunked `getOutput()` calls). When that lazy is finally loaded, its captured reader version no longer matches the advanced `numReads`, tripping `VELOX_CHECK(version == structReader->numReads())` -- "Loading LazyVector after the enclosing reader has moved" (`ColumnLoader`).

This was first seen in an internal production ETL job and is reproduced here via two new deterministic unit tests -- one with `IndexLookupJoin`, one with `NestedLoopJoin` -- confirming it is the general class of an amplifying/buffering operator downstream of a forwarded scan lazy (the same family as the 2024 MergeJoin fix D66169184), not specific to one operator.

Fix: make the per-adjacent-pair back-pressure transitive. When the descend loop finds a non-last operator whose successor is full (`needsInput()==false`) and not blocked, stop the upstream production walk instead of filling/advancing operators above the bottleneck. The bottleneck still drains (it is visited earlier in the same descent) and the outer loop re-descends to make progress. This only changes behavior under back-pressure -- the common case is already lock-step -- so read-ahead is preserved when consumers keep up.

This change also adds a code comment in `RPCOperator` documenting a pre-existing BATCH-mode back-pressure contract gap (it reports `needsInput()==false` without a blocking `isBlocked()` future) that this fix can expose as a narrow, self-recovering CPU spin; the `RPCOperator` fix itself is left as a follow-up for its owners.

Reviewed By: kKPulla, xiaoxmeng

Differential Revision: D109961803


