### PR TITLE
fix(iceberg): Support nested primitive equality-delete fields

### DIFF
--- a/velox/connectors/hive/iceberg/EqualityDeleteFileReader.cpp
+++ b/velox/connectors/hive/iceberg/EqualityDeleteFileReader.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/connectors/hive/iceberg/EqualityDeleteFileReader.h"
 
+#include <folly/container/F14Map.h>
+
 #include "velox/common/base/BitUtil.h"
 #include "velox/connectors/hive/BufferedInputBuilder.h"
 #include "velox/connectors/hive/HiveConnectorUtil.h"
@@ -26,119 +28,42 @@ namespace facebook::velox::connector::hive::iceberg {
 
 namespace {
 
-// Hashes a single value from a vector at the given index.
-// Handles lazy vectors via loadedVector(). Returns 0 for null values.
-uint64_t hashValue(const VectorPtr& vectorPtr, vector_size_t index) {
-  const auto* vector = vectorPtr->loadedVector();
-  if (vector->isNullAt(index)) {
-    return 0;
+std::optional<std::pair<const BaseVector*, vector_size_t>> valueAtSubfield(
+    const RowVectorPtr& row,
+    vector_size_t index,
+    const common::Subfield& subfield) {
+  const BaseVector* current = row.get();
+  auto currentIndex = index;
+
+  for (const auto& element : subfield.path()) {
+    current = current->loadedVector();
+    if (current->isNullAt(currentIndex)) {
+      return std::nullopt;
+    }
+
+    const auto wrappedIndex = current->wrappedIndex(currentIndex);
+    const auto* rowVector = current->wrappedVector()->asChecked<RowVector>();
+    const auto* nestedField =
+        element->asChecked<common::Subfield::NestedField>();
+    const auto childIndex =
+        rowVector->type()->asRow().getChildIdx(nestedField->name());
+    current = rowVector->childAt(childIndex).get();
+    currentIndex = wrappedIndex;
   }
 
-  auto type = vector->type();
-  switch (type->kind()) { // NOLINT(clang-diagnostic-switch-enum)
-    case TypeKind::BOOLEAN:
-      return std::hash<bool>{}(
-          vector->as<SimpleVector<bool>>()->valueAt(index));
-    case TypeKind::TINYINT:
-      return std::hash<int8_t>{}(
-          vector->as<SimpleVector<int8_t>>()->valueAt(index));
-    case TypeKind::SMALLINT:
-      return std::hash<int16_t>{}(
-          vector->as<SimpleVector<int16_t>>()->valueAt(index));
-    case TypeKind::INTEGER:
-      return std::hash<int32_t>{}(
-          vector->as<SimpleVector<int32_t>>()->valueAt(index));
-    case TypeKind::BIGINT:
-      return std::hash<int64_t>{}(
-          vector->as<SimpleVector<int64_t>>()->valueAt(index));
-    case TypeKind::REAL:
-      return std::hash<float>{}(
-          vector->as<SimpleVector<float>>()->valueAt(index));
-    case TypeKind::DOUBLE:
-      return std::hash<double>{}(
-          vector->as<SimpleVector<double>>()->valueAt(index));
-    case TypeKind::VARCHAR:
-    case TypeKind::VARBINARY: {
-      auto stringView = vector->as<SimpleVector<StringView>>()->valueAt(index);
-      return folly::hasher<std::string_view>{}(
-          std::string_view(stringView.data(), stringView.size()));
-    }
-    case TypeKind::TIMESTAMP: {
-      auto ts = vector->as<SimpleVector<Timestamp>>()->valueAt(index);
-      return std::hash<int64_t>{}(ts.toNanos());
-    }
-    default:
-      VELOX_NYI(
-          "Equality delete hash not implemented for type: {}",
-          type->toString());
+  current = current->loadedVector();
+  if (current->isNullAt(currentIndex)) {
+    return std::nullopt;
   }
-}
-
-// Compares two values from vectors at given indices.
-// Handles lazy vectors via loadedVector().
-bool compareValues(
-    const VectorPtr& leftPtr,
-    vector_size_t leftIndex,
-    const VectorPtr& rightPtr,
-    vector_size_t rightIndex) {
-  const auto* left = leftPtr->loadedVector();
-  const auto* right = rightPtr->loadedVector();
-  bool leftNull = left->isNullAt(leftIndex);
-  bool rightNull = right->isNullAt(rightIndex);
-  if (leftNull && rightNull) {
-    return true;
-  }
-  if (leftNull || rightNull) {
-    return false;
-  }
-
-  auto type = left->type();
-  switch (type->kind()) { // NOLINT(clang-diagnostic-switch-enum)
-    case TypeKind::BOOLEAN:
-      return left->as<SimpleVector<bool>>()->valueAt(leftIndex) ==
-          right->as<SimpleVector<bool>>()->valueAt(rightIndex);
-    case TypeKind::TINYINT:
-      return left->as<SimpleVector<int8_t>>()->valueAt(leftIndex) ==
-          right->as<SimpleVector<int8_t>>()->valueAt(rightIndex);
-    case TypeKind::SMALLINT:
-      return left->as<SimpleVector<int16_t>>()->valueAt(leftIndex) ==
-          right->as<SimpleVector<int16_t>>()->valueAt(rightIndex);
-    case TypeKind::INTEGER:
-      return left->as<SimpleVector<int32_t>>()->valueAt(leftIndex) ==
-          right->as<SimpleVector<int32_t>>()->valueAt(rightIndex);
-    case TypeKind::BIGINT:
-      return left->as<SimpleVector<int64_t>>()->valueAt(leftIndex) ==
-          right->as<SimpleVector<int64_t>>()->valueAt(rightIndex);
-    case TypeKind::REAL:
-      return left->as<SimpleVector<float>>()->valueAt(leftIndex) ==
-          right->as<SimpleVector<float>>()->valueAt(rightIndex);
-    case TypeKind::DOUBLE:
-      return left->as<SimpleVector<double>>()->valueAt(leftIndex) ==
-          right->as<SimpleVector<double>>()->valueAt(rightIndex);
-    case TypeKind::VARCHAR:
-    case TypeKind::VARBINARY: {
-      auto leftValue = left->as<SimpleVector<StringView>>()->valueAt(leftIndex);
-      auto rightValue =
-          right->as<SimpleVector<StringView>>()->valueAt(rightIndex);
-      return std::string_view(leftValue.data(), leftValue.size()) ==
-          std::string_view(rightValue.data(), rightValue.size());
-    }
-    case TypeKind::TIMESTAMP:
-      return left->as<SimpleVector<Timestamp>>()->valueAt(leftIndex) ==
-          right->as<SimpleVector<Timestamp>>()->valueAt(rightIndex);
-    default:
-      VELOX_NYI(
-          "Equality delete comparison not implemented for type: {}",
-          type->toString());
-  }
+  return std::pair{current, currentIndex};
 }
 
 } // namespace
 
 EqualityDeleteFileReader::EqualityDeleteFileReader(
     const IcebergDeleteFile& deleteFile,
-    const std::vector<std::string>& equalityColumnNames,
-    const std::vector<TypePtr>& equalityColumnTypes,
+    const RowTypePtr& tableSchema,
+    const std::vector<common::Subfield>& equalityFields,
     const std::string& /*baseFilePath*/,
     FileHandleFactory* fileHandleFactory,
     const ConnectorQueryCtx* connectorQueryCtx,
@@ -148,32 +73,45 @@ EqualityDeleteFileReader::EqualityDeleteFileReader(
     const std::shared_ptr<IoStats>& ioStats,
     dwio::common::RuntimeStats& runtimeStats,
     const std::string& connectorId)
-    : equalityColumnNames_(equalityColumnNames),
-      equalityColumnTypes_(equalityColumnTypes),
-      pool_(connectorQueryCtx->memoryPool()) {
+    : pool_(connectorQueryCtx->memoryPool()) {
+  equalityFields_.reserve(equalityFields.size());
+  for (const auto& field : equalityFields) {
+    equalityFields_.push_back(field.clone());
+  }
+
   VELOX_CHECK(
       deleteFile.content == FileContent::kEqualityDeletes,
       "Expected equality delete file but got content type: {}",
       static_cast<int>(deleteFile.content));
   VELOX_CHECK_GT(deleteFile.recordCount, 0, "Empty equality delete file.");
   VELOX_CHECK(
-      !equalityColumnNames_.empty(),
-      "Equality delete file must specify at least one column.");
-  VELOX_CHECK_EQ(
-      equalityColumnNames_.size(),
-      equalityColumnTypes_.size(),
-      "Equality column names and types must have the same size.");
+      !equalityFields_.empty(),
+      "Equality delete file must specify at least one field.");
 
-  // Build the file schema for the equality delete columns only.
-  auto deleteFileSchema =
-      ROW(std::vector<std::string>(equalityColumnNames_),
-          std::vector<TypePtr>(equalityColumnTypes_));
-
-  // Create a ScanSpec that reads only the equality delete columns.
-  auto scanSpec = std::make_shared<common::ScanSpec>("<root>");
-  for (size_t i = 0; i < equalityColumnNames_.size(); ++i) {
-    scanSpec->addField(equalityColumnNames_[i], static_cast<int>(i));
+  std::vector<std::string> deleteColumnNames;
+  std::vector<TypePtr> deleteColumnTypes;
+  folly::F14FastMap<std::string, std::vector<const common::Subfield*>>
+      equalitySubfields;
+  for (const auto& field : equalityFields_) {
+    auto& subfields = equalitySubfields[field.baseName()];
+    if (subfields.empty()) {
+      deleteColumnNames.push_back(field.baseName());
+      deleteColumnTypes.push_back(tableSchema->findChild(field.baseName()));
+    }
+    subfields.push_back(&field);
   }
+  auto deleteFileSchema =
+      ROW(std::move(deleteColumnNames), std::move(deleteColumnTypes));
+  auto scanSpec = makeScanSpec(
+      deleteFileSchema,
+      equalitySubfields,
+      /*subfieldFilters=*/{},
+      /*dataColumns=*/tableSchema,
+      /*partitionKeys=*/{},
+      /*infoColumns=*/{},
+      /*specialColumns=*/{},
+      /*disableStatsBasedFilterReorder=*/false,
+      pool_);
 
   auto deleteSplit = std::make_shared<HiveConnectorSplit>(
       connectorId,
@@ -259,17 +197,9 @@ EqualityDeleteFileReader::EqualityDeleteFileReader(
     size_t batchIndex = deleteRows_.size();
     deleteRows_.push_back(rowOutput);
 
-    // Resolve column indices on the first batch.
-    if (deleteColumnIndices_.empty()) {
-      for (const auto& colName : equalityColumnNames_) {
-        auto idx = rowOutput->type()->as<TypeKind::ROW>().getChildIdx(colName);
-        deleteColumnIndices_.push_back(static_cast<column_index_t>(idx));
-      }
-    }
-
     // Hash each row and insert into the multimap.
     for (vector_size_t i = 0; i < numRows; ++i) {
-      uint64_t hash = hashRow(rowOutput, i, deleteColumnIndices_);
+      uint64_t hash = hashRow(rowOutput, i);
       deleteKeyHashes_.emplace(hash, DeleteKeyEntry{batchIndex, i});
     }
 
@@ -294,7 +224,7 @@ void EqualityDeleteFileReader::applyDeletes(
       continue;
     }
 
-    uint64_t hash = hashRow(output, i, resolveOutputColumnIndices(output));
+    uint64_t hash = hashRow(output, i);
     auto range = deleteKeyHashes_.equal_range(hash);
 
     for (auto it = range.first; it != range.second; ++it) {
@@ -307,32 +237,16 @@ void EqualityDeleteFileReader::applyDeletes(
   }
 }
 
-const std::vector<column_index_t>&
-EqualityDeleteFileReader::resolveOutputColumnIndices(
-    const RowVectorPtr& row) const {
-  if (outputColumnIndices_.empty()) {
-    const auto& rowType = row->type()->asRow();
-    outputColumnIndices_.reserve(equalityColumnNames_.size());
-    for (const auto& colName : equalityColumnNames_) {
-      auto colIdx = rowType.getChildIdxIfExists(colName);
-      VELOX_CHECK(
-          colIdx.has_value(),
-          "Equality delete column not found in the output columns: {}",
-          colName);
-      outputColumnIndices_.push_back(static_cast<column_index_t>(*colIdx));
-    }
-  }
-  return outputColumnIndices_;
-}
-
 uint64_t EqualityDeleteFileReader::hashRow(
     const RowVectorPtr& row,
-    vector_size_t index,
-    const std::vector<column_index_t>& colIndices) const {
+    vector_size_t index) const {
   uint64_t hash = 0;
 
-  for (auto colIdx : colIndices) {
-    auto colHash = hashValue(row->childAt(colIdx), index);
+  for (const auto& field : equalityFields_) {
+    const auto value = valueAtSubfield(row, index, field);
+    const auto colHash = value.has_value()
+        ? value->first->hashValueAt(value->second)
+        : BaseVector::kNullHash;
     hash ^= colHash + 0x9e3779b97f4a7c15ULL + (hash << 6) + (hash >> 2);
   }
   return hash;
@@ -343,14 +257,15 @@ bool EqualityDeleteFileReader::equalRows(
     vector_size_t leftIndex,
     const RowVectorPtr& right,
     vector_size_t rightIndex) const {
-  const auto& leftColIndices = resolveOutputColumnIndices(left);
-
-  for (size_t i = 0; i < leftColIndices.size(); ++i) {
-    if (!compareValues(
-            left->childAt(leftColIndices[i]),
-            leftIndex,
-            right->childAt(deleteColumnIndices_[i]),
-            rightIndex)) {
+  for (const auto& field : equalityFields_) {
+    const auto leftValue = valueAtSubfield(left, leftIndex, field);
+    const auto rightValue = valueAtSubfield(right, rightIndex, field);
+    if (leftValue.has_value() != rightValue.has_value()) {
+      return false;
+    }
+    if (leftValue.has_value() &&
+        !leftValue->first->equalValueAt(
+            rightValue->first, leftValue->second, rightValue->second)) {
       return false;
     }
   }

--- a/velox/connectors/hive/iceberg/EqualityDeleteFileReader.cpp
+++ b/velox/connectors/hive/iceberg/EqualityDeleteFileReader.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/connectors/hive/iceberg/EqualityDeleteFileReader.h"
 
+#include <folly/container/F14Map.h>
+
 #include "velox/common/base/BitUtil.h"
 #include "velox/connectors/hive/BufferedInputBuilder.h"
 #include "velox/connectors/hive/HiveConnectorUtil.h"
@@ -26,119 +28,42 @@ namespace facebook::velox::connector::hive::iceberg {
 
 namespace {
 
-// Hashes a single value from a vector at the given index.
-// Handles lazy vectors via loadedVector(). Returns 0 for null values.
-uint64_t hashValue(const VectorPtr& vectorPtr, vector_size_t index) {
-  const auto* vector = vectorPtr->loadedVector();
-  if (vector->isNullAt(index)) {
-    return 0;
+std::optional<std::pair<const BaseVector*, vector_size_t>> valueAtSubfield(
+    const RowVectorPtr& row,
+    vector_size_t index,
+    const common::Subfield& subfield) {
+  const BaseVector* current = row.get();
+  auto currentIndex = index;
+
+  for (const auto& element : subfield.path()) {
+    current = current->loadedVector();
+    if (current->isNullAt(currentIndex)) {
+      return std::nullopt;
+    }
+
+    const auto wrappedIndex = current->wrappedIndex(currentIndex);
+    const auto* rowVector = current->wrappedVector()->asChecked<RowVector>();
+    const auto* nestedField =
+        element->asChecked<common::Subfield::NestedField>();
+    const auto childIndex =
+        rowVector->type()->asRow().getChildIdx(nestedField->name());
+    current = rowVector->childAt(childIndex).get();
+    currentIndex = wrappedIndex;
   }
 
-  auto type = vector->type();
-  switch (type->kind()) { // NOLINT(clang-diagnostic-switch-enum)
-    case TypeKind::BOOLEAN:
-      return std::hash<bool>{}(
-          vector->as<SimpleVector<bool>>()->valueAt(index));
-    case TypeKind::TINYINT:
-      return std::hash<int8_t>{}(
-          vector->as<SimpleVector<int8_t>>()->valueAt(index));
-    case TypeKind::SMALLINT:
-      return std::hash<int16_t>{}(
-          vector->as<SimpleVector<int16_t>>()->valueAt(index));
-    case TypeKind::INTEGER:
-      return std::hash<int32_t>{}(
-          vector->as<SimpleVector<int32_t>>()->valueAt(index));
-    case TypeKind::BIGINT:
-      return std::hash<int64_t>{}(
-          vector->as<SimpleVector<int64_t>>()->valueAt(index));
-    case TypeKind::REAL:
-      return std::hash<float>{}(
-          vector->as<SimpleVector<float>>()->valueAt(index));
-    case TypeKind::DOUBLE:
-      return std::hash<double>{}(
-          vector->as<SimpleVector<double>>()->valueAt(index));
-    case TypeKind::VARCHAR:
-    case TypeKind::VARBINARY: {
-      auto stringView = vector->as<SimpleVector<StringView>>()->valueAt(index);
-      return folly::hasher<std::string_view>{}(
-          std::string_view(stringView.data(), stringView.size()));
-    }
-    case TypeKind::TIMESTAMP: {
-      auto ts = vector->as<SimpleVector<Timestamp>>()->valueAt(index);
-      return std::hash<int64_t>{}(ts.toNanos());
-    }
-    default:
-      VELOX_NYI(
-          "Equality delete hash not implemented for type: {}",
-          type->toString());
+  current = current->loadedVector();
+  if (current->isNullAt(currentIndex)) {
+    return std::nullopt;
   }
-}
-
-// Compares two values from vectors at given indices.
-// Handles lazy vectors via loadedVector().
-bool compareValues(
-    const VectorPtr& leftPtr,
-    vector_size_t leftIndex,
-    const VectorPtr& rightPtr,
-    vector_size_t rightIndex) {
-  const auto* left = leftPtr->loadedVector();
-  const auto* right = rightPtr->loadedVector();
-  bool leftNull = left->isNullAt(leftIndex);
-  bool rightNull = right->isNullAt(rightIndex);
-  if (leftNull && rightNull) {
-    return true;
-  }
-  if (leftNull || rightNull) {
-    return false;
-  }
-
-  auto type = left->type();
-  switch (type->kind()) { // NOLINT(clang-diagnostic-switch-enum)
-    case TypeKind::BOOLEAN:
-      return left->as<SimpleVector<bool>>()->valueAt(leftIndex) ==
-          right->as<SimpleVector<bool>>()->valueAt(rightIndex);
-    case TypeKind::TINYINT:
-      return left->as<SimpleVector<int8_t>>()->valueAt(leftIndex) ==
-          right->as<SimpleVector<int8_t>>()->valueAt(rightIndex);
-    case TypeKind::SMALLINT:
-      return left->as<SimpleVector<int16_t>>()->valueAt(leftIndex) ==
-          right->as<SimpleVector<int16_t>>()->valueAt(rightIndex);
-    case TypeKind::INTEGER:
-      return left->as<SimpleVector<int32_t>>()->valueAt(leftIndex) ==
-          right->as<SimpleVector<int32_t>>()->valueAt(rightIndex);
-    case TypeKind::BIGINT:
-      return left->as<SimpleVector<int64_t>>()->valueAt(leftIndex) ==
-          right->as<SimpleVector<int64_t>>()->valueAt(rightIndex);
-    case TypeKind::REAL:
-      return left->as<SimpleVector<float>>()->valueAt(leftIndex) ==
-          right->as<SimpleVector<float>>()->valueAt(rightIndex);
-    case TypeKind::DOUBLE:
-      return left->as<SimpleVector<double>>()->valueAt(leftIndex) ==
-          right->as<SimpleVector<double>>()->valueAt(rightIndex);
-    case TypeKind::VARCHAR:
-    case TypeKind::VARBINARY: {
-      auto leftValue = left->as<SimpleVector<StringView>>()->valueAt(leftIndex);
-      auto rightValue =
-          right->as<SimpleVector<StringView>>()->valueAt(rightIndex);
-      return std::string_view(leftValue.data(), leftValue.size()) ==
-          std::string_view(rightValue.data(), rightValue.size());
-    }
-    case TypeKind::TIMESTAMP:
-      return left->as<SimpleVector<Timestamp>>()->valueAt(leftIndex) ==
-          right->as<SimpleVector<Timestamp>>()->valueAt(rightIndex);
-    default:
-      VELOX_NYI(
-          "Equality delete comparison not implemented for type: {}",
-          type->toString());
-  }
+  return std::pair{current, currentIndex};
 }
 
 } // namespace
 
 EqualityDeleteFileReader::EqualityDeleteFileReader(
     const IcebergDeleteFile& deleteFile,
-    const std::vector<std::string>& equalityColumnNames,
-    const std::vector<TypePtr>& equalityColumnTypes,
+    const RowTypePtr& tableSchema,
+    const std::vector<common::Subfield>& equalityFields,
     const std::string& /*baseFilePath*/,
     FileHandleFactory* fileHandleFactory,
     const ConnectorQueryCtx* connectorQueryCtx,
@@ -148,32 +73,45 @@ EqualityDeleteFileReader::EqualityDeleteFileReader(
     const std::shared_ptr<IoStats>& ioStats,
     dwio::common::RuntimeStatistics& runtimeStats,
     const std::string& connectorId)
-    : equalityColumnNames_(equalityColumnNames),
-      equalityColumnTypes_(equalityColumnTypes),
-      pool_(connectorQueryCtx->memoryPool()) {
+    : pool_(connectorQueryCtx->memoryPool()) {
+  equalityFields_.reserve(equalityFields.size());
+  for (const auto& field : equalityFields) {
+    equalityFields_.push_back(field.clone());
+  }
+
   VELOX_CHECK(
       deleteFile.content == FileContent::kEqualityDeletes,
       "Expected equality delete file but got content type: {}",
       static_cast<int>(deleteFile.content));
   VELOX_CHECK_GT(deleteFile.recordCount, 0, "Empty equality delete file.");
   VELOX_CHECK(
-      !equalityColumnNames_.empty(),
-      "Equality delete file must specify at least one column.");
-  VELOX_CHECK_EQ(
-      equalityColumnNames_.size(),
-      equalityColumnTypes_.size(),
-      "Equality column names and types must have the same size.");
+      !equalityFields_.empty(),
+      "Equality delete file must specify at least one field.");
 
-  // Build the file schema for the equality delete columns only.
-  auto deleteFileSchema =
-      ROW(std::vector<std::string>(equalityColumnNames_),
-          std::vector<TypePtr>(equalityColumnTypes_));
-
-  // Create a ScanSpec that reads only the equality delete columns.
-  auto scanSpec = std::make_shared<common::ScanSpec>("<root>");
-  for (size_t i = 0; i < equalityColumnNames_.size(); ++i) {
-    scanSpec->addField(equalityColumnNames_[i], static_cast<int>(i));
+  std::vector<std::string> deleteColumnNames;
+  std::vector<TypePtr> deleteColumnTypes;
+  folly::F14FastMap<std::string, std::vector<const common::Subfield*>>
+      equalitySubfields;
+  for (const auto& field : equalityFields_) {
+    auto& subfields = equalitySubfields[field.baseName()];
+    if (subfields.empty()) {
+      deleteColumnNames.push_back(field.baseName());
+      deleteColumnTypes.push_back(tableSchema->findChild(field.baseName()));
+    }
+    subfields.push_back(&field);
   }
+  auto deleteFileSchema =
+      ROW(std::move(deleteColumnNames), std::move(deleteColumnTypes));
+  auto scanSpec = makeScanSpec(
+      deleteFileSchema,
+      equalitySubfields,
+      /*subfieldFilters=*/{},
+      /*dataColumns=*/tableSchema,
+      /*partitionKeys=*/{},
+      /*infoColumns=*/{},
+      /*specialColumns=*/{},
+      /*disableStatsBasedFilterReorder=*/false,
+      pool_);
 
   auto deleteSplit = std::make_shared<HiveConnectorSplit>(
       connectorId,
@@ -259,17 +197,9 @@ EqualityDeleteFileReader::EqualityDeleteFileReader(
     size_t batchIndex = deleteRows_.size();
     deleteRows_.push_back(rowOutput);
 
-    // Resolve column indices on the first batch.
-    if (deleteColumnIndices_.empty()) {
-      for (const auto& colName : equalityColumnNames_) {
-        auto idx = rowOutput->type()->as<TypeKind::ROW>().getChildIdx(colName);
-        deleteColumnIndices_.push_back(static_cast<column_index_t>(idx));
-      }
-    }
-
     // Hash each row and insert into the multimap.
     for (vector_size_t i = 0; i < numRows; ++i) {
-      uint64_t hash = hashRow(rowOutput, i, deleteColumnIndices_);
+      uint64_t hash = hashRow(rowOutput, i);
       deleteKeyHashes_.emplace(hash, DeleteKeyEntry{batchIndex, i});
     }
 
@@ -294,7 +224,7 @@ void EqualityDeleteFileReader::applyDeletes(
       continue;
     }
 
-    uint64_t hash = hashRow(output, i, resolveOutputColumnIndices(output));
+    uint64_t hash = hashRow(output, i);
     auto range = deleteKeyHashes_.equal_range(hash);
 
     for (auto it = range.first; it != range.second; ++it) {
@@ -307,32 +237,16 @@ void EqualityDeleteFileReader::applyDeletes(
   }
 }
 
-const std::vector<column_index_t>&
-EqualityDeleteFileReader::resolveOutputColumnIndices(
-    const RowVectorPtr& row) const {
-  if (outputColumnIndices_.empty()) {
-    const auto& rowType = row->type()->asRow();
-    outputColumnIndices_.reserve(equalityColumnNames_.size());
-    for (const auto& colName : equalityColumnNames_) {
-      auto colIdx = rowType.getChildIdxIfExists(colName);
-      VELOX_CHECK(
-          colIdx.has_value(),
-          "Equality delete column not found in the output columns: {}",
-          colName);
-      outputColumnIndices_.push_back(static_cast<column_index_t>(*colIdx));
-    }
-  }
-  return outputColumnIndices_;
-}
-
 uint64_t EqualityDeleteFileReader::hashRow(
     const RowVectorPtr& row,
-    vector_size_t index,
-    const std::vector<column_index_t>& colIndices) const {
+    vector_size_t index) const {
   uint64_t hash = 0;
 
-  for (auto colIdx : colIndices) {
-    auto colHash = hashValue(row->childAt(colIdx), index);
+  for (const auto& field : equalityFields_) {
+    const auto value = valueAtSubfield(row, index, field);
+    const auto colHash = value.has_value()
+        ? value->first->hashValueAt(value->second)
+        : BaseVector::kNullHash;
     hash ^= colHash + 0x9e3779b97f4a7c15ULL + (hash << 6) + (hash >> 2);
   }
   return hash;
@@ -343,14 +257,15 @@ bool EqualityDeleteFileReader::equalRows(
     vector_size_t leftIndex,
     const RowVectorPtr& right,
     vector_size_t rightIndex) const {
-  const auto& leftColIndices = resolveOutputColumnIndices(left);
-
-  for (size_t i = 0; i < leftColIndices.size(); ++i) {
-    if (!compareValues(
-            left->childAt(leftColIndices[i]),
-            leftIndex,
-            right->childAt(deleteColumnIndices_[i]),
-            rightIndex)) {
+  for (const auto& field : equalityFields_) {
+    const auto leftValue = valueAtSubfield(left, leftIndex, field);
+    const auto rightValue = valueAtSubfield(right, rightIndex, field);
+    if (leftValue.has_value() != rightValue.has_value()) {
+      return false;
+    }
+    if (leftValue.has_value() &&
+        !leftValue->first->equalValueAt(
+            rightValue->first, leftValue->second, rightValue->second)) {
       return false;
     }
   }

--- a/velox/connectors/hive/iceberg/EqualityDeleteFileReader.h
+++ b/velox/connectors/hive/iceberg/EqualityDeleteFileReader.h
@@ -26,6 +26,7 @@
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/connectors/hive/iceberg/IcebergDeleteFile.h"
 #include "velox/dwio/common/Reader.h"
+#include "velox/type/Subfield.h"
 
 namespace facebook::velox::connector::hive::iceberg {
 
@@ -40,9 +41,6 @@ namespace facebook::velox::connector::hive::iceberg {
 /// require reading the base data first, then probing each row against the
 /// delete set. The reader eagerly loads all delete key tuples from the file
 /// into an in-memory hash set during construction.
-///
-/// The equality delete column names are resolved from equalityFieldIds via
-/// the table schema provided by the caller.
 class EqualityDeleteFileReader {
  public:
   /// Constructs a reader for a single equality delete file.
@@ -54,10 +52,9 @@ class EqualityDeleteFileReader {
   /// @param deleteFile Metadata about the equality delete file. Must have
   ///   content == FileContent::kEqualityDeletes and non-empty
   ///   equalityFieldIds.
-  /// @param equalityColumnNames Ordered column names corresponding to
+  /// @param tableSchema Iceberg table schema containing the equality fields.
+  /// @param equalityFields Ordered Subfields corresponding to
   ///   equalityFieldIds, resolved by the caller from the table schema.
-  /// @param equalityColumnTypes Ordered column types corresponding to
-  ///   equalityFieldIds.
   /// @param baseFilePath Path of the base data file being read.
   /// @param fileHandleFactory Factory for creating file handles.
   /// @param connectorQueryCtx Query context for memory and config.
@@ -69,8 +66,8 @@ class EqualityDeleteFileReader {
   /// @param connectorId Connector identifier.
   EqualityDeleteFileReader(
       const IcebergDeleteFile& deleteFile,
-      const std::vector<std::string>& equalityColumnNames,
-      const std::vector<TypePtr>& equalityColumnTypes,
+      const RowTypePtr& tableSchema,
+      const std::vector<common::Subfield>& equalityFields,
       const std::string& baseFilePath,
       FileHandleFactory* fileHandleFactory,
       const ConnectorQueryCtx* connectorQueryCtx,
@@ -103,16 +100,8 @@ class EqualityDeleteFileReader {
   }
 
  private:
-  // Resolves column indices for the given row type, caching the result in
-  // outputColumnIndices_ for reuse across rows.
-  const std::vector<column_index_t>& resolveOutputColumnIndices(
-      const RowVectorPtr& row) const;
-
   // Hashes a single row's equality delete columns into a uint64_t key.
-  uint64_t hashRow(
-      const RowVectorPtr& row,
-      vector_size_t index,
-      const std::vector<column_index_t>& colIndices) const;
+  uint64_t hashRow(const RowVectorPtr& row, vector_size_t index) const;
 
   // Checks whether two rows are equal on all equality delete columns.
   bool equalRows(
@@ -121,16 +110,7 @@ class EqualityDeleteFileReader {
       const RowVectorPtr& right,
       vector_size_t rightIndex) const;
 
-  // Column names and types for equality delete comparison.
-  std::vector<std::string> equalityColumnNames_;
-  std::vector<TypePtr> equalityColumnTypes_;
-
-  // Column indices in the delete file output vector.
-  std::vector<column_index_t> deleteColumnIndices_;
-
-  // Cached column indices for the output (probe) row type. Resolved lazily
-  // on first applyDeletes() call to avoid repeated name lookups per row.
-  mutable std::vector<column_index_t> outputColumnIndices_;
+  std::vector<common::Subfield> equalityFields_;
 
   // All rows read from the equality delete file, stored for equality
   // comparison during probing.

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -127,6 +127,40 @@ bool shouldSkipBySequenceNumber(
                           : (deleteFileSeqNum < dataSeqNum);
 }
 
+std::optional<common::Subfield> findEqualityField(
+    int32_t targetFieldId,
+    const TypePtr& type,
+    const dwio::common::ParquetFieldId& field,
+    std::vector<std::string>& path) {
+  if (field.fieldId == targetFieldId) {
+    VELOX_CHECK(
+        type->isPrimitiveType() && !type->isReal() && !type->isDouble(),
+        "Invalid Iceberg equality field ID {}.",
+        targetFieldId);
+    std::vector<std::unique_ptr<common::Subfield::PathElement>> elements;
+    elements.reserve(path.size());
+    for (const auto& name : path) {
+      elements.push_back(std::make_unique<common::Subfield::NestedField>(name));
+    }
+    return common::Subfield(std::move(elements));
+  }
+
+  if (!type->isRow()) {
+    return std::nullopt;
+  }
+
+  VELOX_CHECK_EQ(field.children.size(), type->size());
+  for (size_t i = 0; i < field.children.size(); ++i) {
+    path.push_back(type->asRow().nameOf(i));
+    if (auto resolved = findEqualityField(
+            targetFieldId, type->childAt(i), field.children[i], path)) {
+      return resolved;
+    }
+    path.pop_back();
+  }
+  return std::nullopt;
+}
+
 } // namespace
 
 IcebergSplitReader::IcebergSplitReader(
@@ -212,11 +246,10 @@ std::vector<dwio::common::ParquetFieldId> IcebergSplitReader::buildFieldIds()
   }
 
   // Equality-delete columns absent from the user's projection have no
-  // IcebergColumnHandle and would otherwise get a sentinel field ID. Collect
-  // their real Iceberg field IDs via resolveEqualityColumns() — the single
-  // authoritative path for field-ID→name resolution — so the Parquet reader
-  // can locate those columns physically. This is purely additive: it only
-  // fills slots where handleByName has no entry.
+  // IcebergColumnHandle and would otherwise get a sentinel field ID. Resolve
+  // their base columns and retain the base column's field ID so the file
+  // reader can locate the complete top-level value. This is purely additive:
+  // it only fills slots where handleByName has no entry.
   std::unordered_map<std::string, int32_t> equalityFieldIdByName;
   for (const auto& deleteFile : icebergSplit_->deleteFiles) {
     if (deleteFile.content != FileContent::kEqualityDeletes ||
@@ -230,9 +263,16 @@ std::vector<dwio::common::ParquetFieldId> IcebergSplitReader::buildFieldIds()
       continue;
     }
 
-    auto [names, types] = resolveEqualityColumns(deleteFile);
-    for (size_t i = 0; i < names.size(); ++i) {
-      equalityFieldIdByName.emplace(names[i], deleteFile.equalityFieldIds[i]);
+    const auto equalityFields = resolveEqualityFields(deleteFile);
+    for (size_t i = 0; i < equalityFields.size(); ++i) {
+      const auto& name = equalityFields[i].baseName();
+      const auto columnIndex = dataColumns->getChildIdx(name);
+      if (dataColumnFieldIds != nullptr && !dataColumnFieldIds->empty()) {
+        equalityFieldIdByName.emplace(
+            name, dataColumnFieldIds->at(columnIndex));
+      } else if (equalityFields[i].path().size() == 1) {
+        equalityFieldIdByName.emplace(name, deleteFile.equalityFieldIds[i]);
+      }
     }
   }
 
@@ -488,7 +528,9 @@ void IcebergSplitReader::prepareSplit(
   equalityDeleteFileReaders_.clear();
 
   const auto& deleteFiles = icebergSplit_->deleteFiles;
-  for (const auto& deleteFile : deleteFiles) {
+  for (size_t deleteFileIndex = 0; deleteFileIndex < deleteFiles.size();
+       ++deleteFileIndex) {
+    const auto& deleteFile = deleteFiles[deleteFileIndex];
     if (deleteFile.content == FileContent::kPositionalDeletes) {
       if (deleteFile.recordCount > 0) {
         if (shouldSkipBySequenceNumber(
@@ -540,15 +582,15 @@ void IcebergSplitReader::prepareSplit(
           continue;
         }
 
-        auto [equalityColumnNames, equalityColumnTypes] =
-            resolveEqualityColumns(deleteFile);
+        const auto& equalityFields =
+            equalityFieldsByDeleteFile_[deleteFileIndex];
 
-        if (!equalityColumnNames.empty()) {
+        if (!equalityFields.empty()) {
           equalityDeleteFileReaders_.push_back(
               std::make_unique<EqualityDeleteFileReader>(
                   deleteFile,
-                  equalityColumnNames,
-                  equalityColumnTypes,
+                  tableHandle_->dataColumns(),
+                  equalityFields,
                   fileSplit_->filePath,
                   fileHandleFactory_,
                   connectorQueryCtx_,
@@ -585,12 +627,11 @@ void IcebergSplitReader::prepareSplit(
               << fileSplit_->filePath << "'";
         }
 
-        deletionVectorReaders_.push_back(
-            std::make_unique<DeletionVectorReader>(
-                deleteFile,
-                splitOffset_,
-                connectorQueryCtx_->memoryPool(),
-                fileConfig_->config()));
+        deletionVectorReaders_.push_back(std::make_unique<DeletionVectorReader>(
+            deleteFile,
+            splitOffset_,
+            connectorQueryCtx_->memoryPool(),
+            fileConfig_->config()));
       }
     } else {
       VELOX_NYI(
@@ -604,13 +645,17 @@ void IcebergSplitReader::configureEqualityDeleteColumns() {
   // Reset partition-column tracking from any prior split before re-augmenting.
   equalityAugmentedPartitionColumns_.clear();
 
-  std::vector<std::string> extraEqualityColumns;
   std::vector<std::string> extraNames;
   std::vector<TypePtr> extraTypes;
   const auto& deleteFiles = icebergSplit_->deleteFiles;
   const auto& identityPartitionKeys = icebergSplit_->identityPartitionKeys;
+  const auto& dataColumns = tableHandle_->dataColumns();
 
-  for (const auto& deleteFile : deleteFiles) {
+  equalityFieldsByDeleteFile_.clear();
+  equalityFieldsByDeleteFile_.resize(deleteFiles.size());
+  for (size_t deleteFileIndex = 0; deleteFileIndex < deleteFiles.size();
+       ++deleteFileIndex) {
+    const auto& deleteFile = deleteFiles[deleteFileIndex];
     if (deleteFile.content != FileContent::kEqualityDeletes ||
         deleteFile.recordCount == 0 || deleteFile.equalityFieldIds.empty()) {
       continue;
@@ -622,37 +667,43 @@ void IcebergSplitReader::configureEqualityDeleteColumns() {
       continue;
     }
 
-    auto [equalityColumnNames, equalityColumnTypes] =
-        resolveEqualityColumns(deleteFile);
-    for (size_t i = 0; i < equalityColumnNames.size(); ++i) {
-      const auto& name = equalityColumnNames[i];
-      // Skip if this column was already added by a previous delete file.
-      if (std::find(
-              extraEqualityColumns.begin(), extraEqualityColumns.end(), name) !=
-          extraEqualityColumns.end()) {
+    auto& equalityFields = equalityFieldsByDeleteFile_[deleteFileIndex];
+    equalityFields = resolveEqualityFields(deleteFile);
+    for (size_t i = 0; i < equalityFields.size(); ++i) {
+      const auto& field = equalityFields[i];
+      const auto& name = field.baseName();
+      const auto dataColumnIndex = dataColumns->getChildIdx(name);
+      const auto& equalityColumnType = dataColumns->childAt(dataColumnIndex);
+
+      const auto outputIndex = readerOutputType_->getChildIdxIfExists(name);
+      auto extraIt = std::find(extraNames.begin(), extraNames.end(), name);
+      const bool isNewExtra =
+          !outputIndex.has_value() && extraIt == extraNames.end();
+      const auto channel = outputIndex.has_value()
+          ? static_cast<column_index_t>(*outputIndex)
+          : static_cast<column_index_t>(
+                readerOutputType_->size() +
+                (isNewExtra ? extraNames.size()
+                            : std::distance(extraNames.begin(), extraIt)));
+
+      scanSpec_->getOrCreateChild(field);
+      auto* fieldSpec = scanSpec_.get();
+      const Type* currentType = dataColumns.get();
+      for (size_t depth = 0; depth < field.path().size(); ++depth) {
+        const auto* nestedField =
+            field.path()[depth]->asChecked<common::Subfield::NestedField>();
+        const auto& rowType = currentType->asRow();
+        const auto childIndex = rowType.getChildIdx(nestedField->name());
+        fieldSpec = fieldSpec->childByName(nestedField->name());
+        fieldSpec->setProjectOut(true);
+        fieldSpec->setChannel(
+            depth == 0 ? channel : static_cast<column_index_t>(childIndex));
+        currentType = rowType.childAt(childIndex).get();
+      }
+
+      if (!isNewExtra) {
         continue;
       }
-      auto* fieldSpec = scanSpec_->childByName(name);
-      const bool alreadyInOutput =
-          readerOutputType_->getChildIdxIfExists(name).has_value();
-      if (fieldSpec != nullptr && fieldSpec->projectOut() && alreadyInOutput) {
-        // Already projected by the user (or a previous augmentation) AND
-        // present in the output type by name. The equality-delete reader can
-        // probe it directly.
-        continue;
-      }
-      // Either no spec exists, or one exists but is filter-only, or the
-      // scan-spec child is projected but the column is missing from
-      // 'readerOutputType_'. In all cases ensure the column ends up in
-      // 'readerOutputType_' AND has a projected scan-spec child with a
-      // non-conflicting channel.
-      if (fieldSpec == nullptr) {
-        fieldSpec = scanSpec_->getOrCreateChild(name);
-      }
-      fieldSpec->setProjectOut(true);
-      fieldSpec->setChannel(
-          static_cast<column_index_t>(
-              readerOutputType_->size() + extraEqualityColumns.size()));
 
       // Substitute the partition value for the source column only when the
       // Iceberg partition spec explicitly marks this equality field's source
@@ -668,7 +719,8 @@ void IcebergSplitReader::configureEqualityDeleteColumns() {
       // constant installed, so the column is read from the data file.
       const auto identityIt =
           identityPartitionKeys.find(deleteFile.equalityFieldIds[i]);
-      if (identityIt != identityPartitionKeys.end()) {
+      if (field.path().size() == 1 &&
+          identityIt != identityPartitionKeys.end()) {
         // Iceberg encodes DATE partition values as the integer number of
         // days since the Unix epoch (e.g. "19345"). The standard
         // 'setPartitionValue' helper learns this from the planner-supplied
@@ -676,15 +728,15 @@ void IcebergSplitReader::configureEqualityDeleteColumns() {
         // ColumnHandle is available here when the partition column is not
         // in the user's projection. Derive the flag from the column type
         // instead — Iceberg always uses days-since-epoch for DATE.
-        const bool isDaysSinceEpoch = equalityColumnTypes[i]->isDate();
+        const bool isDaysSinceEpoch = equalityColumnType->isDate();
         auto constant = newConstantFromString(
-            equalityColumnTypes[i],
+            equalityColumnType,
             identityIt->second,
             connectorQueryCtx_->memoryPool(),
             fileConfig_->readTimestampPartitionValueAsLocalTime(
                 connectorQueryCtx_->sessionProperties()),
             isDaysSinceEpoch);
-        fieldSpec->setConstantValue(constant);
+        scanSpec_->childByName(name)->setConstantValue(constant);
         // Mirror Java's PARTITION_KEY column-type marking: this column's
         // value MUST come from the partition metadata, never from the file
         // body. Track it so 'adaptColumns' Branch 1 does not later wipe the
@@ -692,13 +744,12 @@ void IcebergSplitReader::configureEqualityDeleteColumns() {
         equalityAugmentedPartitionColumns_.insert(name);
       }
 
-      extraEqualityColumns.push_back(name);
       extraNames.push_back(name);
-      extraTypes.push_back(equalityColumnTypes[i]);
+      extraTypes.push_back(equalityColumnType);
     }
   }
 
-  if (extraEqualityColumns.empty()) {
+  if (extraNames.empty()) {
     return;
   }
 
@@ -714,18 +765,15 @@ void IcebergSplitReader::configureEqualityDeleteColumns() {
   readerOutputType_ = ROW(std::move(names), std::move(types));
 }
 
-std::pair<std::vector<std::string>, std::vector<TypePtr>>
-IcebergSplitReader::resolveEqualityColumns(
+std::vector<common::Subfield> IcebergSplitReader::resolveEqualityFields(
     const IcebergDeleteFile& deleteFile) const {
-  std::vector<std::string> equalityColumnNames;
-  std::vector<TypePtr> equalityColumnTypes;
-
   const auto& dataColumns = tableHandle_->dataColumns();
   VELOX_CHECK(
       dataColumns != nullptr,
       "Iceberg equality delete file '{}' cannot be processed because "
       "table data columns are not available in IcebergTableHandle.",
       deleteFile.filePath);
+
   std::unordered_map<int32_t, uint32_t> columnIndexByFieldId;
   if (const auto* hiveTableHandle =
           dynamic_cast<const HiveTableHandle*>(tableHandle_.get())) {
@@ -736,27 +784,55 @@ IcebergSplitReader::resolveEqualityColumns(
     }
   }
 
-  for (const auto& equalityFieldId : deleteFile.equalityFieldIds) {
+  const auto handleByName =
+      buildIcebergHandleByName(columnHandles_.get(), tableHandle_.get());
+
+  std::vector<common::Subfield> equalityFields;
+  equalityFields.reserve(deleteFile.equalityFieldIds.size());
+  for (const auto equalityFieldId : deleteFile.equalityFieldIds) {
     VELOX_CHECK_GT(
         equalityFieldId,
         0,
         "Equality delete field ID must be positive: {}",
         equalityFieldId);
-    const auto fieldIdIt = columnIndexByFieldId.find(equalityFieldId);
-    // Older plans and tests may not carry full-schema field IDs. Preserve the
-    // legacy ordinal lookup when metadata is unavailable or incomplete.
-    const auto columnIndex = fieldIdIt != columnIndexByFieldId.end()
-        ? fieldIdIt->second
-        : static_cast<uint32_t>(equalityFieldId - 1);
-    VELOX_CHECK_LT(
-        columnIndex,
-        dataColumns->size(),
-        "Equality delete field ID cannot be resolved against table columns: {}",
-        equalityFieldId);
-    equalityColumnNames.push_back(dataColumns->nameOf(columnIndex));
-    equalityColumnTypes.push_back(dataColumns->childAt(columnIndex));
+    std::optional<common::Subfield> resolvedField;
+
+    for (size_t i = 0; i < dataColumns->size() && !resolvedField; ++i) {
+      const auto& name = dataColumns->nameOf(i);
+      const auto handleIt = handleByName.find(name);
+      if (handleIt == handleByName.end()) {
+        continue;
+      }
+      std::vector<std::string> path{name};
+      resolvedField = findEqualityField(
+          equalityFieldId,
+          dataColumns->childAt(i),
+          handleIt->second->field(),
+          path);
+    }
+
+    if (!resolvedField.has_value()) {
+      const auto fieldIdIt = columnIndexByFieldId.find(equalityFieldId);
+      // Older plans and tests may not carry full-schema field IDs. Preserve
+      // the legacy ordinal lookup when metadata is unavailable or incomplete.
+      const auto columnIndex = fieldIdIt != columnIndexByFieldId.end()
+          ? fieldIdIt->second
+          : static_cast<uint32_t>(equalityFieldId - 1);
+      VELOX_CHECK_LT(
+          columnIndex,
+          dataColumns->size(),
+          "Iceberg equality field ID {} is missing from the table schema.",
+          equalityFieldId);
+      std::vector<std::unique_ptr<common::Subfield::PathElement>> elements;
+      elements.push_back(std::make_unique<common::Subfield::NestedField>(
+          dataColumns->nameOf(columnIndex)));
+      resolvedField = common::Subfield(std::move(elements));
+    }
+
+    equalityFields.push_back(std::move(*resolvedField));
   }
-  return {std::move(equalityColumnNames), std::move(equalityColumnTypes)};
+
+  return equalityFields;
 }
 
 uint64_t IcebergSplitReader::next(uint64_t size, VectorPtr& output) {
@@ -1035,9 +1111,8 @@ std::vector<TypePtr> IcebergSplitReader::adaptColumns(
              fieldName ==
                  IcebergMetadataColumn::kLastUpdatedSequenceNumberColumnName)) {
           // Null first_row_id: spec requires null for both lineage columns.
-          childSpec->setConstantValue(
-              BaseVector::createNullConstant(
-                  BIGINT(), 1, connectorQueryCtx_->memoryPool()));
+          childSpec->setConstantValue(BaseVector::createNullConstant(
+              BIGINT(), 1, connectorQueryCtx_->memoryPool()));
           continue;
         }
         childSpec->setConstantValue(nullptr);
@@ -1088,16 +1163,14 @@ std::vector<TypePtr> IcebergSplitReader::adaptColumns(
                     BIGINT(),
                     static_cast<int64_t>(*dataSequenceNumber_)));
           } else {
-            childSpec->setConstantValue(
-                BaseVector::createNullConstant(
-                    BIGINT(), 1, connectorQueryCtx_->memoryPool()));
+            childSpec->setConstantValue(BaseVector::createNullConstant(
+                BIGINT(), 1, connectorQueryCtx_->memoryPool()));
           }
         } else if (fieldName == IcebergMetadataColumn::kRowIdColumnName) {
           // Column absent from file. next() fills nulls with first_row_id +
           // _pos when first_row_id is present.
-          childSpec->setConstantValue(
-              BaseVector::createNullConstant(
-                  BIGINT(), 1, connectorQueryCtx_->memoryPool()));
+          childSpec->setConstantValue(BaseVector::createNullConstant(
+              BIGINT(), 1, connectorQueryCtx_->memoryPool()));
         } else if (
             fieldName == IcebergMetadataColumn::kTargetTableRowIdColumnName) {
           // Synthesized Iceberg MERGE row-id column. Install a null
@@ -1112,9 +1185,8 @@ std::vector<TypePtr> IcebergSplitReader::adaptColumns(
           VELOX_CHECK_NOT_NULL(
               columnType,
               "$target_table_row_id type missing from readerOutputType");
-          childSpec->setConstantValue(
-              BaseVector::createNullConstant(
-                  columnType, 1, connectorQueryCtx_->memoryPool()));
+          childSpec->setConstantValue(BaseVector::createNullConstant(
+              columnType, 1, connectorQueryCtx_->memoryPool()));
         } else if (childSpec->isConstant()) {
           // Constant already set (equality-delete partition column, or set on
           // a previous prepareSplit call for the same scanSpec). Nothing to do.
@@ -1140,9 +1212,8 @@ std::vector<TypePtr> IcebergSplitReader::adaptColumns(
             // Fall back to NULL if no default value.
             VELOX_CHECK_NOT_NULL(
                 columnType, "Column '{}' not found in table schema", fieldName);
-            childSpec->setConstantValue(
-                BaseVector::createNullConstant(
-                    columnType, 1, connectorQueryCtx_->memoryPool()));
+            childSpec->setConstantValue(BaseVector::createNullConstant(
+                columnType, 1, connectorQueryCtx_->memoryPool()));
           }
         }
       }

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -98,6 +98,40 @@ bool shouldSkipBySequenceNumber(
                           : (deleteFileSeqNum < dataSeqNum);
 }
 
+std::optional<common::Subfield> findEqualityField(
+    int32_t targetFieldId,
+    const TypePtr& type,
+    const dwio::common::ParquetFieldId& field,
+    std::vector<std::string>& path) {
+  if (field.fieldId == targetFieldId) {
+    VELOX_CHECK(
+        type->isPrimitiveType() && !type->isReal() && !type->isDouble(),
+        "Invalid Iceberg equality field ID {}.",
+        targetFieldId);
+    std::vector<std::unique_ptr<common::Subfield::PathElement>> elements;
+    elements.reserve(path.size());
+    for (const auto& name : path) {
+      elements.push_back(std::make_unique<common::Subfield::NestedField>(name));
+    }
+    return common::Subfield(std::move(elements));
+  }
+
+  if (!type->isRow()) {
+    return std::nullopt;
+  }
+
+  VELOX_CHECK_EQ(field.children.size(), type->size());
+  for (size_t i = 0; i < field.children.size(); ++i) {
+    path.push_back(type->asRow().nameOf(i));
+    if (auto resolved = findEqualityField(
+            targetFieldId, type->childAt(i), field.children[i], path)) {
+      return resolved;
+    }
+    path.pop_back();
+  }
+  return std::nullopt;
+}
+
 } // namespace
 
 IcebergSplitReader::IcebergSplitReader(
@@ -395,7 +429,9 @@ void IcebergSplitReader::prepareSplit(
   equalityDeleteFileReaders_.clear();
 
   const auto& deleteFiles = icebergSplit_->deleteFiles;
-  for (const auto& deleteFile : deleteFiles) {
+  for (size_t deleteFileIndex = 0; deleteFileIndex < deleteFiles.size();
+       ++deleteFileIndex) {
+    const auto& deleteFile = deleteFiles[deleteFileIndex];
     if (deleteFile.content == FileContent::kPositionalDeletes) {
       if (deleteFile.recordCount > 0) {
         if (shouldSkipBySequenceNumber(
@@ -447,15 +483,15 @@ void IcebergSplitReader::prepareSplit(
           continue;
         }
 
-        auto [equalityColumnNames, equalityColumnTypes] =
-            resolveEqualityColumns(deleteFile);
+        const auto& equalityFields =
+            equalityFieldsByDeleteFile_[deleteFileIndex];
 
-        if (!equalityColumnNames.empty()) {
+        if (!equalityFields.empty()) {
           equalityDeleteFileReaders_.push_back(
               std::make_unique<EqualityDeleteFileReader>(
                   deleteFile,
-                  equalityColumnNames,
-                  equalityColumnTypes,
+                  tableHandle_->dataColumns(),
+                  equalityFields,
                   fileSplit_->filePath,
                   fileHandleFactory_,
                   connectorQueryCtx_,
@@ -511,13 +547,17 @@ void IcebergSplitReader::configureEqualityDeleteColumns() {
   // Reset partition-column tracking from any prior split before re-augmenting.
   equalityAugmentedPartitionColumns_.clear();
 
-  std::vector<std::string> extraEqualityColumns;
   std::vector<std::string> extraNames;
   std::vector<TypePtr> extraTypes;
   const auto& deleteFiles = icebergSplit_->deleteFiles;
   const auto& splitPartitionKeys = icebergSplit_->partitionKeys;
+  const auto& dataColumns = tableHandle_->dataColumns();
 
-  for (const auto& deleteFile : deleteFiles) {
+  equalityFieldsByDeleteFile_.clear();
+  equalityFieldsByDeleteFile_.resize(deleteFiles.size());
+  for (size_t deleteFileIndex = 0; deleteFileIndex < deleteFiles.size();
+       ++deleteFileIndex) {
+    const auto& deleteFile = deleteFiles[deleteFileIndex];
     if (deleteFile.content != FileContent::kEqualityDeletes ||
         deleteFile.recordCount == 0 || deleteFile.equalityFieldIds.empty()) {
       continue;
@@ -529,37 +569,42 @@ void IcebergSplitReader::configureEqualityDeleteColumns() {
       continue;
     }
 
-    auto [equalityColumnNames, equalityColumnTypes] =
-        resolveEqualityColumns(deleteFile);
-    for (size_t i = 0; i < equalityColumnNames.size(); ++i) {
-      const auto& name = equalityColumnNames[i];
-      // Skip if this column was already added by a previous delete file.
-      if (std::find(
-              extraEqualityColumns.begin(), extraEqualityColumns.end(), name) !=
-          extraEqualityColumns.end()) {
+    auto& equalityFields = equalityFieldsByDeleteFile_[deleteFileIndex];
+    equalityFields = resolveEqualityFields(deleteFile);
+    for (const auto& field : equalityFields) {
+      const auto& name = field.baseName();
+      const auto dataColumnIndex = dataColumns->getChildIdx(name);
+      const auto& equalityColumnType = dataColumns->childAt(dataColumnIndex);
+
+      const auto outputIndex = readerOutputType_->getChildIdxIfExists(name);
+      auto extraIt = std::find(extraNames.begin(), extraNames.end(), name);
+      const bool isNewExtra =
+          !outputIndex.has_value() && extraIt == extraNames.end();
+      const auto channel = outputIndex.has_value()
+          ? static_cast<column_index_t>(*outputIndex)
+          : static_cast<column_index_t>(
+                readerOutputType_->size() +
+                (isNewExtra ? extraNames.size()
+                            : std::distance(extraNames.begin(), extraIt)));
+
+      scanSpec_->getOrCreateChild(field);
+      auto* fieldSpec = scanSpec_.get();
+      const Type* currentType = dataColumns.get();
+      for (size_t depth = 0; depth < field.path().size(); ++depth) {
+        const auto* nestedField =
+            field.path()[depth]->asChecked<common::Subfield::NestedField>();
+        const auto& rowType = currentType->asRow();
+        const auto childIndex = rowType.getChildIdx(nestedField->name());
+        fieldSpec = fieldSpec->childByName(nestedField->name());
+        fieldSpec->setProjectOut(true);
+        fieldSpec->setChannel(
+            depth == 0 ? channel : static_cast<column_index_t>(childIndex));
+        currentType = rowType.childAt(childIndex).get();
+      }
+
+      if (!isNewExtra) {
         continue;
       }
-      auto* fieldSpec = scanSpec_->childByName(name);
-      const bool alreadyInOutput =
-          readerOutputType_->getChildIdxIfExists(name).has_value();
-      if (fieldSpec != nullptr && fieldSpec->projectOut() && alreadyInOutput) {
-        // Already projected by the user (or a previous augmentation) AND
-        // present in the output type by name. The equality-delete reader can
-        // probe it directly.
-        continue;
-      }
-      // Either no spec exists, or one exists but is filter-only, or the
-      // scan-spec child is projected but the column is missing from
-      // 'readerOutputType_'. In all cases ensure the column ends up in
-      // 'readerOutputType_' AND has a projected scan-spec child with a
-      // non-conflicting channel.
-      if (fieldSpec == nullptr) {
-        fieldSpec = scanSpec_->getOrCreateChild(name);
-      }
-      fieldSpec->setProjectOut(true);
-      fieldSpec->setChannel(
-          static_cast<column_index_t>(
-              readerOutputType_->size() + extraEqualityColumns.size()));
 
       // For partition columns set the partition value directly as a constant
       // on the scan-spec child. This is independent of whether the data file
@@ -576,15 +621,15 @@ void IcebergSplitReader::configureEqualityDeleteColumns() {
         // ColumnHandle is available here when the partition column is not
         // in the user's projection. Derive the flag from the column type
         // instead — Iceberg always uses days-since-epoch for DATE.
-        const bool isDaysSinceEpoch = equalityColumnTypes[i]->isDate();
+        const bool isDaysSinceEpoch = equalityColumnType->isDate();
         auto constant = newConstantFromString(
-            equalityColumnTypes[i],
+            equalityColumnType,
             partitionIt->second,
             connectorQueryCtx_->memoryPool(),
             fileConfig_->readTimestampPartitionValueAsLocalTime(
                 connectorQueryCtx_->sessionProperties()),
             isDaysSinceEpoch);
-        fieldSpec->setConstantValue(constant);
+        scanSpec_->childByName(name)->setConstantValue(constant);
         // Mirror Java's PARTITION_KEY column-type marking: this column's
         // value MUST come from the partition metadata, never from the file
         // body. Track it so 'adaptColumns' Branch 1 does not later wipe the
@@ -592,13 +637,12 @@ void IcebergSplitReader::configureEqualityDeleteColumns() {
         equalityAugmentedPartitionColumns_.insert(name);
       }
 
-      extraEqualityColumns.push_back(name);
       extraNames.push_back(name);
-      extraTypes.push_back(equalityColumnTypes[i]);
+      extraTypes.push_back(equalityColumnType);
     }
   }
 
-  if (extraEqualityColumns.empty()) {
+  if (extraNames.empty()) {
     return;
   }
 
@@ -614,32 +658,52 @@ void IcebergSplitReader::configureEqualityDeleteColumns() {
   readerOutputType_ = ROW(std::move(names), std::move(types));
 }
 
-std::pair<std::vector<std::string>, std::vector<TypePtr>>
-IcebergSplitReader::resolveEqualityColumns(
+std::vector<common::Subfield> IcebergSplitReader::resolveEqualityFields(
     const IcebergDeleteFile& deleteFile) const {
-  std::vector<std::string> equalityColumnNames;
-  std::vector<TypePtr> equalityColumnTypes;
-
   const auto& dataColumns = tableHandle_->dataColumns();
   VELOX_CHECK(
       dataColumns != nullptr,
       "Iceberg equality delete file '{}' cannot be processed because "
       "table data columns are not available in HiveTableHandle.",
       deleteFile.filePath);
-  for (const auto& eqFieldId : deleteFile.equalityFieldIds) {
-    // Field IDs are 1-based sequential for non-evolved schemas.
-    auto colIdx = static_cast<uint32_t>(eqFieldId - 1);
-    VELOX_CHECK_LT(
-        colIdx,
-        dataColumns->size(),
-        "Equality delete field ID {} out of range. This may indicate "
-        "schema evolution with non-sequential field IDs, which is "
-        "not yet supported.",
-        eqFieldId);
-    equalityColumnNames.push_back(dataColumns->nameOf(colIdx));
-    equalityColumnTypes.push_back(dataColumns->childAt(colIdx));
+
+  std::unordered_map<std::string, const IcebergColumnHandle*> handleByName;
+  if (columnHandles_ != nullptr) {
+    for (const auto& [outputName, handle] : *columnHandles_) {
+      if (auto* icebergHandle =
+              dynamic_cast<const IcebergColumnHandle*>(handle.get())) {
+        handleByName.emplace(icebergHandle->name(), icebergHandle);
+      }
+    }
   }
-  return {std::move(equalityColumnNames), std::move(equalityColumnTypes)};
+
+  std::vector<common::Subfield> equalityFields;
+  equalityFields.reserve(deleteFile.equalityFieldIds.size());
+  for (const auto equalityFieldId : deleteFile.equalityFieldIds) {
+    std::optional<common::Subfield> resolvedField;
+
+    for (size_t i = 0; i < dataColumns->size() && !resolvedField; ++i) {
+      const auto& name = dataColumns->nameOf(i);
+      const auto handleIt = handleByName.find(name);
+      if (handleIt == handleByName.end()) {
+        continue;
+      }
+      std::vector<std::string> path{name};
+      resolvedField = findEqualityField(
+          equalityFieldId,
+          dataColumns->childAt(i),
+          handleIt->second->field(),
+          path);
+    }
+
+    VELOX_CHECK(
+        resolvedField.has_value(),
+        "Iceberg equality field ID {} is missing from the table schema.",
+        equalityFieldId);
+    equalityFields.push_back(std::move(*resolvedField));
+  }
+
+  return equalityFields;
 }
 
 uint64_t IcebergSplitReader::next(uint64_t size, VectorPtr& output) {

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.h
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.h
@@ -131,11 +131,11 @@ class IcebergSplitReader : public FileSplitReader {
       const RowTypePtr& fileType,
       const RowTypePtr& tableSchema) const override;
 
-  // Resolves equality-delete field IDs to column names and types using the
-  // table handle's full-schema field IDs. Falls back to the legacy one-based
-  // ordinal mapping when those IDs are unavailable or incomplete.
-  std::pair<std::vector<std::string>, std::vector<TypePtr>>
-  resolveEqualityColumns(const IcebergDeleteFile& deleteFile) const;
+  // Resolves equality-delete field IDs to primitive subfields using Iceberg
+  // column metadata. Top-level fields fall back to the table handle's
+  // full-schema field IDs, or to legacy one-based ordinals when unavailable.
+  std::vector<common::Subfield> resolveEqualityFields(
+      const IcebergDeleteFile& deleteFile) const;
 
   // Discovers equality-delete columns that are not in the user's projection
   // and augments 'scanSpec_' and 'readerOutputType_' so they are physically
@@ -209,6 +209,9 @@ class IcebergSplitReader : public FileSplitReader {
   /// Readers for equality delete files.
   std::list<std::unique_ptr<EqualityDeleteFileReader>>
       equalityDeleteFileReaders_;
+
+  // Resolved equality fields indexed by delete-file position.
+  std::vector<std::vector<common::Subfield>> equalityFieldsByDeleteFile_;
 
   /// Column handles map shared with IcebergDataSource.
   /// Used for accessing column metadata including initial-default values.

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.h
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.h
@@ -129,12 +129,8 @@ class IcebergSplitReader : public FileSplitReader {
       const RowTypePtr& fileType,
       const RowTypePtr& tableSchema) const override;
 
-  // Resolves the equality field IDs of an equality-delete file to the
-  // corresponding column names and types in the table schema. In Iceberg,
-  // field IDs for top-level columns are assigned sequentially starting from
-  // 1, matching the column order in the table schema.
-  std::pair<std::vector<std::string>, std::vector<TypePtr>>
-  resolveEqualityColumns(const IcebergDeleteFile& deleteFile) const;
+  std::vector<common::Subfield> resolveEqualityFields(
+      const IcebergDeleteFile& deleteFile) const;
 
   // Discovers equality-delete columns that are not in the user's projection
   // and augments 'scanSpec_' and 'readerOutputType_' so they are physically
@@ -205,6 +201,9 @@ class IcebergSplitReader : public FileSplitReader {
   /// Readers for equality delete files.
   std::list<std::unique_ptr<EqualityDeleteFileReader>>
       equalityDeleteFileReaders_;
+
+  // Resolved equality fields indexed by delete-file position.
+  std::vector<std::vector<common::Subfield>> equalityFieldsByDeleteFile_;
 
   /// Column handles map shared with IcebergDataSource.
   /// Used for accessing column metadata including initial-default values.

--- a/velox/connectors/hive/iceberg/tests/EqualityDeleteFileReaderTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/EqualityDeleteFileReaderTest.cpp
@@ -19,6 +19,7 @@
 #include "velox/common/file/FileSystems.h"
 #include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/connectors/ConnectorRegistry.h"
+#include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
 #include "velox/connectors/hive/iceberg/IcebergConnector.h"
 #include "velox/connectors/hive/iceberg/IcebergDeleteFile.h"
 #include "velox/connectors/hive/iceberg/IcebergSplit.h"
@@ -132,10 +133,30 @@ class EqualityDeleteFileReaderTest : public HiveConnectorTestBase {
   core::PlanNodePtr makeTableScanPlan(
       const RowTypePtr& outputType,
       const RowTypePtr& dataColumns) {
+    connector::ColumnHandleMap assignments;
+    for (size_t i = 0; i < dataColumns->size(); ++i) {
+      const auto& name = dataColumns->nameOf(i);
+      const auto& type = dataColumns->childAt(i);
+      assignments.emplace(
+          name,
+          std::make_shared<const IcebergColumnHandle>(
+              name,
+              FileColumnHandle::ColumnType::kRegular,
+              type,
+              parquet::ParquetFieldId{static_cast<int32_t>(i + 1), {}}));
+    }
+    return makeTableScanPlan(outputType, dataColumns, std::move(assignments));
+  }
+
+  core::PlanNodePtr makeTableScanPlan(
+      const RowTypePtr& outputType,
+      const RowTypePtr& dataColumns,
+      connector::ColumnHandleMap assignments) {
     return PlanBuilder()
         .startTableScan(kIcebergConnectorId)
         .outputType(outputType)
         .dataColumns(dataColumns)
+        .assignments(std::move(assignments))
         .endTableScan()
         .planNode();
   }
@@ -602,10 +623,24 @@ TEST_F(EqualityDeleteFileReaderTest, equalityFilterOnlyColumnNotInProjection) {
   // WHERE id >= 3 keeps rows {3,4,5,6,7,8,9} from the file; the equality
   // delete then removes id=4 and id=8, leaving values {d->skipped} no, we
   // expect surviving values for ids {3,5,6,7,9}, projected as 'value' only.
+  connector::ColumnHandleMap assignments{
+      {"id",
+       std::make_shared<const IcebergColumnHandle>(
+           "id",
+           FileColumnHandle::ColumnType::kRegular,
+           BIGINT(),
+           parquet::ParquetFieldId{1, {}})},
+      {"value",
+       std::make_shared<const IcebergColumnHandle>(
+           "value",
+           FileColumnHandle::ColumnType::kRegular,
+           VARCHAR(),
+           parquet::ParquetFieldId{2, {}})}};
   auto plan = PlanBuilder()
                   .startTableScan(kIcebergConnectorId)
                   .outputType(outputType)
                   .dataColumns(tableType)
+                  .assignments(std::move(assignments))
                   .subfieldFilter("id >= 3")
                   .endTableScan()
                   .planNode();
@@ -860,6 +895,83 @@ TEST_F(EqualityDeleteFileReaderTest, stringColumnDelete) {
       {
           makeFlatVector<std::string>({"alice", "charlie"}),
           makeFlatVector<int32_t>({25, 35}),
+      });
+
+  assertEqualResults({expected}, {result});
+}
+
+TEST_F(EqualityDeleteFileReaderTest, nestedPrimitiveColumnDelete) {
+  auto detailsType = ROW({"code", "label"}, {INTEGER(), VARCHAR()});
+  auto rowType = ROW({"id", "details"}, {BIGINT(), detailsType});
+
+  auto baseDetails = makeRowVector(
+      {"code", "label"},
+      {
+          makeNullableFlatVector<int32_t>({10, 20, 10, 40, std::nullopt, 60}),
+          makeFlatVector<std::string>({"a", "b", "c", "d", "e", "f"}),
+      },
+      [](vector_size_t row) { return row == 5; });
+  auto baseData = makeRowVector(
+      {"id", "details"},
+      {
+          makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6}),
+          baseDetails,
+      });
+  auto dataFile = writeDataFile({baseData});
+
+  auto deleteDetails = makeRowVector(
+      {"code"},
+      {
+          makeNullableFlatVector<int32_t>({10, std::nullopt}),
+      },
+      [](vector_size_t row) { return row == 1; });
+  auto deleteData = makeRowVector(
+      {"details"},
+      {
+          deleteDetails,
+      });
+  auto eqDeleteFile = writeEqDeleteFile({deleteData});
+
+  const IcebergDeleteFile icebergDeleteFile(
+      FileContent::kEqualityDeletes,
+      eqDeleteFile->getPath(),
+      dwio::common::FileFormat::DWRF,
+      2,
+      getFileSize(eqDeleteFile->getPath()),
+      /*equalityFieldIds=*/{17});
+
+  auto splits = makeSplits(dataFile->getPath(), {icebergDeleteFile});
+  // Non-sequential IDs verify that field 17 resolves to details.code through
+  // Iceberg metadata rather than an ordinal.
+  connector::ColumnHandleMap assignments{
+      {"id",
+       std::make_shared<const IcebergColumnHandle>(
+           "id",
+           FileColumnHandle::ColumnType::kRegular,
+           BIGINT(),
+           parquet::ParquetFieldId{101, {}})},
+      {"details",
+       std::make_shared<const IcebergColumnHandle>(
+           "details",
+           FileColumnHandle::ColumnType::kRegular,
+           detailsType,
+           parquet::ParquetFieldId{
+               102,
+               {
+                   parquet::ParquetFieldId{17, {}},
+                   parquet::ParquetFieldId{18, {}},
+               }})}};
+  auto plan = makeTableScanPlan(rowType, rowType, std::move(assignments));
+  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
+
+  auto expected = makeRowVector(
+      {"id", "details"},
+      {
+          makeFlatVector<int64_t>({2, 4}),
+          makeRowVector(
+              {"code", "label"},
+              {makeFlatVector<int32_t>({20, 40}),
+               makeFlatVector<std::string>({"b", "d"})}),
       });
 
   assertEqualResults({expected}, {result});

--- a/velox/connectors/hive/iceberg/tests/EqualityDeleteFileReaderTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/EqualityDeleteFileReaderTest.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
 #include "velox/connectors/hive/iceberg/tests/IcebergTestBase.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 
@@ -1168,6 +1169,94 @@ TEST_F(
           makeFlatVector<std::string>({"1009"}),
           makeNullableFlatVector<std::string>({std::nullopt}),
       });
+  assertEqualResults({expected}, {result});
+}
+
+TEST_F(EqualityDeleteFileReaderTest, nestedPrimitiveColumnDelete) {
+  auto detailsType = ROW({"code", "label"}, {INTEGER(), VARCHAR()});
+  auto rowType = ROW({"id", "details"}, {BIGINT(), detailsType});
+
+  auto baseDetails = makeRowVector(
+      {"code", "label"},
+      {
+          makeNullableFlatVector<int32_t>({10, 20, 10, 40, std::nullopt, 60}),
+          makeFlatVector<std::string>({"a", "b", "c", "d", "e", "f"}),
+      },
+      [](vector_size_t row) { return row == 5; });
+  auto baseData = makeRowVector(
+      {"id", "details"},
+      {
+          makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6}),
+          baseDetails,
+      });
+  auto dataFile = writeDataFile({baseData});
+
+  auto deleteDetails = makeRowVector(
+      {"code"},
+      {
+          makeNullableFlatVector<int32_t>({10, std::nullopt}),
+      },
+      [](vector_size_t row) { return row == 1; });
+  auto deleteData = makeRowVector(
+      {"details"},
+      {
+          deleteDetails,
+      });
+  auto eqDeleteFile = writeDataFile({deleteData});
+
+  const IcebergDeleteFile icebergDeleteFile(
+      FileContent::kEqualityDeletes,
+      eqDeleteFile->getPath(),
+      dwio::common::FileFormat::DWRF,
+      2,
+      getFileSize(eqDeleteFile->getPath()),
+      /*equalityFieldIds=*/{17});
+
+  auto splits = makeSplits(
+      dataFile->getPath(),
+      /*partitionKeys=*/{},
+      {dwio::common::FileFormat::DWRF, false},
+      {icebergDeleteFile});
+  // Non-sequential IDs verify that field 17 resolves to details.code through
+  // Iceberg metadata rather than an ordinal.
+  connector::ColumnHandleMap assignments{
+      {"id",
+       std::make_shared<const IcebergColumnHandle>(
+           "id",
+           FileColumnHandle::ColumnType::kRegular,
+           BIGINT(),
+           parquet::ParquetFieldId{101, {}})},
+      {"details",
+       std::make_shared<const IcebergColumnHandle>(
+           "details",
+           FileColumnHandle::ColumnType::kRegular,
+           detailsType,
+           parquet::ParquetFieldId{
+               102,
+               {
+                   parquet::ParquetFieldId{17, {}},
+                   parquet::ParquetFieldId{18, {}},
+               }})}};
+  auto plan = exec::test::PlanBuilder()
+                  .startTableScan(kIcebergConnectorId)
+                  .outputType(rowType)
+                  .dataColumns(rowType)
+                  .dataColumnFieldIds({101, 102})
+                  .assignments(std::move(assignments))
+                  .endTableScan()
+                  .planNode();
+  auto result = AssertQueryBuilder(plan).splits(splits).copyResults(pool());
+
+  auto expected = makeRowVector(
+      {"id", "details"},
+      {
+          makeFlatVector<int64_t>({2, 4}),
+          makeRowVector(
+              {"code", "label"},
+              {makeFlatVector<int32_t>({20, 40}),
+               makeFlatVector<std::string>({"b", "d"})}),
+      });
+
   assertEqualResults({expected}, {result});
 }
 


### PR DESCRIPTION
## Background

The equality-delete reader previously assumed that `equality_ids` mapped to top-level column ordinals and used a manual type switch for hashing and comparison. This misses a valid Iceberg case: an equality field may be an optional primitive nested through one or more structs. The delete-file scan spec also did not materialize nested children.

## Changes

- Resolve equality field IDs to primitive field paths, using planner-provided Iceberg field-ID trees when available and a depth-first fallback for legacy non-evolved schemas.

## Impact

This adds support for spec-compliant nested primitive equality deletes.

Specification: https://iceberg.apache.org/spec/#equality-delete-files
