### PR TITLE
feat(dwio): Add currentStripe() accessor to RowReader (#18146)

### DIFF
--- a/velox/dwio/common/Reader.h
+++ b/velox/dwio/common/Reader.h
@@ -154,6 +154,15 @@ class RowReader {
   }
 
   /**
+   * Returns the index of the currently loaded stripe. Throws an error for
+   * readers without override.
+   */
+  virtual uint32_t currentStripe() const {
+    VELOX_UNSUPPORTED(
+        "RowReader::currentStripe() is not supported by this reader");
+  }
+
+  /**
    * Result of projectColumnsWithSelection. 'output' is the projected
    * RowVector. 'selectedRows' maps each output row back to its input row
    * index: selectedRows[i] is the input row that produced output row i.

--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -85,7 +85,7 @@ class DwrfRowReader : public StrideIndexProvider,
 
   uint64_t skipRows(uint64_t numberOfRowsToSkip);
 
-  uint32_t currentStripe() const {
+  uint32_t currentStripe() const override {
     return currentStripe_;
   }
 

--- a/velox/dwio/dwrf/test/ReaderTest.cpp
+++ b/velox/dwio/dwrf/test/ReaderTest.cpp
@@ -168,6 +168,17 @@ TEST_F(TestReader, testWriterVersions) {
       "future - 99", writerVersionToString(static_cast<WriterVersion>(99)));
 }
 
+TEST_F(TestReader, currentStripe) {
+  dwio::common::ReaderOptions readerOpts{pool()};
+  auto reader = DwrfReader::create(
+      createFileBufferedInput(getFMSmallFile(), readerOpts.memoryPool()),
+      readerOpts);
+  auto rowReader = reader->createRowReader();
+  VectorPtr batch;
+  ASSERT_GT(rowReader->next(1000, batch), 0);
+  EXPECT_LT(rowReader->currentStripe(), reader->getNumberOfStripes());
+}
+
 // This relies on schema and data inside of our fm_small and fm_large orc files,
 // and is not composeable with other schema/datas
 void verifyFlatMapReading(


### PR DESCRIPTION
Summary:

Adds `dwio::common::RowReader::currentStripe()` — a virtual accessor returning the index of the currently loaded stripe. Throws `VELOX_UNSUPPORTED` by default; `DwrfRowReader` provides the override.

Reviewed By: xiaoxmeng

Differential Revision: D111536170


