### PR TITLE
fix(cudf): Correct left/full join with multiple build batches

### DIFF
--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -130,10 +130,9 @@ class ProbeMatchTracker {
       cudf::size_type numProbeRows,
       rmm::cuda_stream_view stream,
       rmm::device_async_resource_ref mr) {
-    auto falseScalar =
-        cudf::numeric_scalar<bool>(false, true, stream, mr);
-    matchCol_ = cudf::make_column_from_scalar(
-        falseScalar, numProbeRows, stream, mr);
+    auto falseScalar = cudf::numeric_scalar<bool>(false, true, stream, mr);
+    matchCol_ =
+        cudf::make_column_from_scalar(falseScalar, numProbeRows, stream, mr);
     probeRowIndices_ = cudf::sequence(
         numProbeRows,
         cudf::numeric_scalar<cudf::size_type>(0, true, stream, mr),
@@ -147,8 +146,8 @@ class ProbeMatchTracker {
       cudf::column_view matchedLeftIndices,
       rmm::cuda_stream_view stream,
       rmm::device_async_resource_ref mr) {
-    auto matchedInBatch =
-        cudf::contains(matchedLeftIndices, probeRowIndices_->view(), stream, mr);
+    auto matchedInBatch = cudf::contains(
+        matchedLeftIndices, probeRowIndices_->view(), stream, mr);
     auto updatedMatch = cudf::binary_operation(
         matchCol_->view(),
         matchedInBatch->view(),
@@ -1050,7 +1049,7 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::leftJoin(
           auto filteredLeftCol = cudf::column_view{filteredLeftSpan};
           auto filteredRightCol = cudf::column_view{filteredRightSpan};
 
-probeTracker.update(filteredLeftCol, stream, get_temp_mr());
+          probeTracker.update(filteredLeftCol, stream, get_temp_mr());
 
           cudfOutputs.push_back(unfilteredOutput(
               leftTableView,
@@ -1076,8 +1075,7 @@ probeTracker.update(filteredLeftCol, stream, get_temp_mr());
               // probe rows passed the filter.
               auto leftIdxCol = cudf::column_view{leftIndicesSpanCopy};
               auto filteredIdxTable = cudf::apply_boolean_mask(
-                  cudf::table_view{
-                      std::vector<cudf::column_view>{leftIdxCol}},
+                  cudf::table_view{std::vector<cudf::column_view>{leftIdxCol}},
                   filterColumn,
                   stream,
                   get_temp_mr());
@@ -1849,8 +1847,8 @@ CudfHashJoinProbe::leftSemiProjectJoin(
 
         // Type B: Null probe keys × all build rows
         if (probeHasNulls) {
-          auto nullProbeIndices =
-              getRetainedIndices(probeKeyNullMask->view(), stream, get_temp_mr());
+          auto nullProbeIndices = getRetainedIndices(
+              probeKeyNullMask->view(), stream, get_temp_mr());
           auto allBuildIndices = cudf::sequence(
               numBuildRows,
               cudf::numeric_scalar<cudf::size_type>(
@@ -1891,8 +1889,8 @@ CudfHashJoinProbe::leftSemiProjectJoin(
               getRetainedIndices(typeAMask->view(), stream, get_temp_mr());
           auto buildKeyNullMask =
               createProbeKeyNullMask(buildKeyView, stream, get_temp_mr());
-          auto nullBuildIndices =
-              getRetainedIndices(buildKeyNullMask->view(), stream, get_temp_mr());
+          auto nullBuildIndices = getRetainedIndices(
+              buildKeyNullMask->view(), stream, get_temp_mr());
 
           accumulateIndeterminate(
               typeAProbeIndices->view(),

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -103,7 +103,7 @@ vector_size_t filteredOutputNumRows(
           ->value(stream));
 }
 
-/// Returns row indices where mask is true as a column of size_type.
+// Returns row indices where mask is true as a column of size_type.
 std::unique_ptr<cudf::column> getRetainedIndices(
     cudf::column_view mask,
     rmm::cuda_stream_view stream,
@@ -121,9 +121,9 @@ std::unique_ptr<cudf::column> getRetainedIndices(
   return std::move(indicesTable->release().front());
 }
 
-/// Tracks which probe rows have been matched across multiple build batches.
-/// Maintains a boolean column that accumulates matches via cudf::contains +
-/// BITWISE_OR, and provides a method to retrieve unmatched probe row indices.
+// Tracks which probe rows have been matched across multiple build batches.
+// Maintains a boolean column that accumulates matches via cudf::contains +
+// BITWISE_OR, and provides a method to retrieve unmatched probe row indices.
 class ProbeMatchTracker {
  public:
   ProbeMatchTracker(
@@ -141,7 +141,7 @@ class ProbeMatchTracker {
         mr);
   }
 
-  /// Mark probe rows present in matchedLeftIndices as matched.
+  // Mark probe rows present in matchedLeftIndices as matched.
   void update(
       cudf::column_view matchedLeftIndices,
       rmm::cuda_stream_view stream,
@@ -159,7 +159,7 @@ class ProbeMatchTracker {
     matchCol_ = std::move(updatedMatch);
   }
 
-  /// Returns indices of probe rows that were never matched.
+  // Returns indices of probe rows that were never matched.
   std::unique_ptr<cudf::column> getUnmatchedIndices(
       rmm::cuda_stream_view stream,
       rmm::device_async_resource_ref mr) {
@@ -1425,16 +1425,8 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::fullJoin(
         sentinelScalar, unmatchedIndices->size(), stream, get_temp_mr());
     auto unmatchedRightCol = unmatchedRightIndices->view();
 
-    // Emit unmatched rows directly via unfilteredOutput for two reasons:
-    // (1) We cannot use filteredOutputIndices with LEFT_JOIN here because
-    //     filter_join_indices(LEFT_JOIN) ensures every row in the left *table*
-    //     appears at least once. Since our left indices are a subset of probe
-    //     rows (only the unmatched ones), LEFT_JOIN would re-add all the
-    //     matched probe rows that are absent from this subset.
-    // (2) Using unfilteredOutput is safe because all right indices are
-    //     JoinNoMatch. Per filter_join_indices semantics, input pairs with
-    //     JoinNoMatch in either position pass through unchanged (the predicate
-    //     cannot be evaluated), so filtering would be a no-op anyway.
+    // Use unfilteredOutput directly — see the matching comment in leftJoin()
+    // for why filteredOutputIndices cannot be used here.
     cudfOutputs.push_back(unfilteredOutput(
         leftTableView,
         unmatchedLeftCol,

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -103,6 +103,27 @@ vector_size_t filteredOutputNumRows(
           ->value(stream));
 }
 
+/// Get row indices where mask is true.
+/// Returns a column of size_type indices.
+std::unique_ptr<cudf::column> getIndicesWhere(
+    cudf::column_view mask,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  // Create sequence [0, 1, 2, ..., mask.size()-1]
+  auto seq = cudf::sequence(
+      mask.size(),
+      cudf::numeric_scalar<cudf::size_type>(0, true, stream, mr),
+      cudf::numeric_scalar<cudf::size_type>(1, true, stream, mr),
+      stream,
+      mr);
+
+  // Filter to keep only indices where mask is true
+  auto indicesTable = cudf::apply_boolean_mask(
+      cudf::table_view{{seq->view()}}, mask, stream, mr);
+
+  return std::move(indicesTable->release()[0]);
+}
+
 } // namespace
 
 void CudfHashJoinProbe::doClose() {
@@ -925,6 +946,36 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::leftJoin(
 
   auto& rightTables = hashObject_.value().first;
   auto& hbs = hashObject_.value().second;
+  auto numProbeRows = leftTableView.num_rows();
+
+  // Track which probe rows matched in any build batch so that unmatched probe
+  // rows can be emitted with NULL build columns after the loop.
+  auto falseScalar =
+      cudf::numeric_scalar<bool>(false, true, stream, get_temp_mr());
+  auto matchCol = cudf::make_column_from_scalar(
+      falseScalar, numProbeRows, stream, get_temp_mr());
+  auto probeRowIndices = cudf::sequence(
+      numProbeRows,
+      cudf::numeric_scalar<cudf::size_type>(0, true, stream, get_temp_mr()),
+      cudf::numeric_scalar<cudf::size_type>(1, true, stream, get_temp_mr()),
+      stream,
+      get_temp_mr());
+
+  // Helper to accumulate probe-side match flags from a column of matched
+  // probe indices.
+  auto updateMatchCol = [&](cudf::column_view matchedLeftIndices) {
+    auto matchedInBatch = cudf::contains(
+        matchedLeftIndices, probeRowIndices->view(), stream, get_temp_mr());
+    auto updatedMatch = cudf::binary_operation(
+        matchCol->view(),
+        matchedInBatch->view(),
+        cudf::binary_operator::BITWISE_OR,
+        cudf::data_type{cudf::type_id::BOOL8},
+        stream,
+        get_temp_mr());
+    stream.synchronize();
+    matchCol = std::move(updatedMatch);
+  };
 
   // Precompute left (probe) table columns if needed (once, outside loop)
   std::vector<ColumnOrView> leftPrecomputed;
@@ -940,52 +991,77 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::leftJoin(
     extendedLeftView = createExtendedTableView(leftTableView, leftPrecomputed);
   }
 
-  for (auto i = 0; i < rightTables.size(); i++) {
-    auto rightTableView = rightTables[i]->view();
-    auto& hb = hbs[i];
-
-    // Use cached precomputed columns for right (build) table
-    cudf::table_view extendedRightView =
-        (joinNode_->filter() && !rightPrecomputeInstructions_.empty())
-        ? cachedExtendedRightViews_[i]
-        : rightTableView;
-
-    VELOX_CHECK_NOT_NULL(hb);
-    auto [leftJoinIndices, rightJoinIndices] = hb->left_join(
-        leftTableView.select(leftKeyIndices_),
-        std::nullopt,
-        stream,
-        get_temp_mr());
-
-    auto leftIndicesSpan =
-        cudf::device_span<cudf::size_type const>{*leftJoinIndices};
-    auto rightIndicesSpan =
-        cudf::device_span<cudf::size_type const>{*rightJoinIndices};
-    auto leftIndicesCol = cudf::column_view{leftIndicesSpan};
-    auto rightIndicesCol = cudf::column_view{rightIndicesSpan};
-    std::vector<std::unique_ptr<cudf::column>> joinedCols;
-
+  // Processes a build batch of join indices: applies the filter (if any),
+  // updates matchCol from post-filter left indices, and appends the result to
+  // cudfOutputs.
+  auto processBatch = [&](cudf::column_view leftIndicesCol,
+                          cudf::column_view rightIndicesCol,
+                          cudf::table_view rightTableView,
+                          size_t buildBatchIdx) {
     if (joinNode_->filter()) {
+      cudf::table_view extendedRightView =
+          !rightPrecomputeInstructions_.empty()
+          ? cachedExtendedRightViews_[buildBatchIdx]
+          : rightTableView;
+
       if (useAstFilter_) {
-        cudfOutputs.push_back(filteredOutputIndices(
-            leftTableView,
-            leftIndicesCol,
-            rightTableView,
-            rightIndicesCol,
-            extendedLeftView,
-            extendedRightView,
-            cudf::join_kind::LEFT_JOIN,
-            stream));
+        // Inline filter_join_indices so we can access post-filter left indices
+        // for match tracking.
+        auto [filteredLeftJoinIndices, filteredRightJoinIndices] =
+            cudf::filter_join_indices(
+                extendedLeftView,
+                extendedRightView,
+                leftIndicesCol,
+                rightIndicesCol,
+                tree_.back(),
+                cudf::join_kind::INNER_JOIN,
+                stream,
+                get_temp_mr());
+
+        if (filteredLeftJoinIndices->size() > 0) {
+          auto filteredLeftSpan = cudf::device_span<cudf::size_type const>{
+              *filteredLeftJoinIndices};
+          auto filteredRightSpan = cudf::device_span<cudf::size_type const>{
+              *filteredRightJoinIndices};
+          auto filteredLeftCol = cudf::column_view{filteredLeftSpan};
+          auto filteredRightCol = cudf::column_view{filteredRightSpan};
+
+          updateMatchCol(filteredLeftCol);
+
+          cudfOutputs.push_back(unfilteredOutput(
+              leftTableView,
+              filteredLeftCol,
+              rightTableView,
+              filteredRightCol,
+              stream));
+        }
       } else {
+        auto leftIndicesSpanCopy =
+            cudf::device_span<cudf::size_type const>(leftIndicesCol);
         auto filterFunc =
-            [stream](
+            [&updateMatchCol, leftIndicesSpanCopy, stream](
                 std::vector<std::unique_ptr<cudf::column>>&& joinedCols,
                 cudf::column_view filterColumn) {
               auto filterTable =
                   std::make_unique<cudf::table>(std::move(joinedCols));
               auto filteredTable = cudf::apply_boolean_mask(
                   *filterTable, filterColumn, stream, get_output_mr());
-              return filteredTable->release();
+              joinedCols = filteredTable->release();
+
+              // Filter left join indices with the same mask to track which
+              // probe rows passed the filter.
+              auto leftIdxCol = cudf::column_view{leftIndicesSpanCopy};
+              auto filteredIdxTable = cudf::apply_boolean_mask(
+                  cudf::table_view{
+                      std::vector<cudf::column_view>{leftIdxCol}},
+                  filterColumn,
+                  stream,
+                  get_temp_mr());
+              auto filteredLeftIdxCol =
+                  std::move(filteredIdxTable->release()[0]);
+              updateMatchCol(filteredLeftIdxCol->view());
+
+              return std::move(joinedCols);
             };
         cudfOutputs.push_back(filteredOutput(
             leftTableView,
@@ -996,6 +1072,7 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::leftJoin(
             stream));
       }
     } else {
+      updateMatchCol(leftIndicesCol);
       cudfOutputs.push_back(unfilteredOutput(
           leftTableView,
           leftIndicesCol,
@@ -1003,7 +1080,75 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::leftJoin(
           rightIndicesCol,
           stream));
     }
+  };
+
+  for (auto i = 0; i < rightTables.size(); i++) {
+    auto rightTableView = rightTables[i]->view();
+    auto& hb = hbs[i];
+
+    // Use inner_join to get only real matched pairs. Unmatched probe rows are
+    // emitted separately after the loop.
+    VELOX_CHECK_NOT_NULL(hb);
+    auto [leftJoinIndices, rightJoinIndices] = hb->inner_join(
+        leftTableView.select(leftKeyIndices_),
+        std::nullopt,
+        stream,
+        get_temp_mr());
+
+    if (leftJoinIndices->size() == 0) {
+      continue;
+    }
+
+    auto leftIndicesSpan =
+        cudf::device_span<cudf::size_type const>{*leftJoinIndices};
+    auto rightIndicesSpan =
+        cudf::device_span<cudf::size_type const>{*rightJoinIndices};
+    auto leftIndicesCol = cudf::column_view{leftIndicesSpan};
+    auto rightIndicesCol = cudf::column_view{rightIndicesSpan};
+
+    processBatch(leftIndicesCol, rightIndicesCol, rightTableView, i);
   }
+
+  // Emit unmatched probe rows. Build a synthetic batch where left indices are
+  // the unmatched probe row indices and right indices are all -1 (out of
+  // bounds), so the gather with NULLIFY produces NULL build columns. This also
+  // correctly applies any filter to the unmatched rows.
+  auto unmatchedMask = cudf::unary_operation(
+      matchCol->view(), cudf::unary_operator::NOT, stream, get_temp_mr());
+  auto unmatchedIndices =
+      getIndicesWhere(unmatchedMask->view(), stream, get_temp_mr());
+
+  if (unmatchedIndices->size() > 0) {
+    auto unmatchedLeftCol = unmatchedIndices->view();
+    // Create right indices filled with cudf::JoinNoMatch so that gather with
+    // NULLIFY produces NULL build columns.
+    auto sentinelScalar = cudf::numeric_scalar<cudf::size_type>(
+        cudf::JoinNoMatch, true, stream, get_temp_mr());
+    auto unmatchedRightIndices = cudf::make_column_from_scalar(
+        sentinelScalar,
+        unmatchedIndices->size(),
+        stream,
+        get_temp_mr());
+    auto unmatchedRightCol = unmatchedRightIndices->view();
+
+    // Emit unmatched rows directly via unfilteredOutput for two reasons:
+    // (1) We cannot use filteredOutputIndices with LEFT_JOIN here because
+    //     filter_join_indices(LEFT_JOIN) ensures every row in the left *table*
+    //     appears at least once. Since our left indices are a subset of probe
+    //     rows (only the unmatched ones), LEFT_JOIN would re-add all the
+    //     matched probe rows that are absent from this subset.
+    // (2) Using unfilteredOutput is safe because all right indices are
+    //     JoinNoMatch. Per filter_join_indices semantics, input pairs with
+    //     JoinNoMatch in either position pass through unchanged (the predicate
+    //     cannot be evaluated), so filtering would be a no-op anyway.
+    cudfOutputs.push_back(unfilteredOutput(
+        leftTableView,
+        unmatchedLeftCol,
+        rightTables[0]->view(),
+        unmatchedRightCol,
+        stream));
+  }
+
   return cudfOutputs;
 }
 
@@ -1150,57 +1295,86 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::fullJoin(
 
   auto& rightTables = hashObject_.value().first;
   auto& hbs = hashObject_.value().second;
+  auto numProbeRows = leftTableView.num_rows();
 
   // For now, AST support is necessary to filter join output
   if (joinNode_->filter() && !useAstFilter_) {
     VELOX_NYI("Full join requires AST support for filtering");
   }
 
+  // Track which probe rows matched in any build batch so that unmatched probe
+  // rows can be emitted with NULL build columns after the loop.
+  auto falseScalar =
+      cudf::numeric_scalar<bool>(false, true, stream, get_temp_mr());
+  auto probeMatchCol = cudf::make_column_from_scalar(
+      falseScalar, numProbeRows, stream, get_temp_mr());
+  auto probeRowIndices = cudf::sequence(
+      numProbeRows,
+      cudf::numeric_scalar<cudf::size_type>(0, true, stream, get_temp_mr()),
+      cudf::numeric_scalar<cudf::size_type>(1, true, stream, get_temp_mr()),
+      stream,
+      get_temp_mr());
+
+  // Helper to accumulate probe-side match flags from a column of matched
+  // probe indices.
+  auto updateProbeMatchCol = [&](cudf::column_view matchedLeftIndices) {
+    auto matchedInBatch = cudf::contains(
+        matchedLeftIndices, probeRowIndices->view(), stream, get_temp_mr());
+    auto updatedMatch = cudf::binary_operation(
+        probeMatchCol->view(),
+        matchedInBatch->view(),
+        cudf::binary_operator::BITWISE_OR,
+        cudf::data_type{cudf::type_id::BOOL8},
+        stream,
+        get_temp_mr());
+    stream.synchronize();
+    probeMatchCol = std::move(updatedMatch);
+  };
+
+  // Helper to accumulate build-side (right) match flags for a build batch.
+  auto updateRightMatchedFlags =
+      [&](size_t batchIdx, cudf::column_view matchedRightIndices,
+          cudf::size_type numBuildRows) {
+        auto buildRowIndices = cudf::sequence(
+            numBuildRows,
+            cudf::numeric_scalar<cudf::size_type>(
+                0, true, stream, get_temp_mr()),
+            cudf::numeric_scalar<cudf::size_type>(
+                1, true, stream, get_temp_mr()),
+            stream,
+            get_temp_mr());
+        auto matchedInBatch = cudf::contains(
+            matchedRightIndices,
+            buildRowIndices->view(),
+            stream,
+            get_temp_mr());
+        auto updatedFlags = cudf::binary_operation(
+            rightMatchedFlags_[batchIdx]->view(),
+            matchedInBatch->view(),
+            cudf::binary_operator::BITWISE_OR,
+            cudf::data_type{cudf::type_id::BOOL8},
+            stream,
+            get_temp_mr());
+        stream.synchronize();
+        rightMatchedFlags_[batchIdx] = std::move(updatedFlags);
+      };
+
   for (auto i = 0; i < rightTables.size(); i++) {
     auto rightTableView = rightTables[i]->view();
     auto& hb = hbs[i];
 
+    // Use inner_join to get only real matched pairs. Unmatched probe rows are
+    // emitted separately after the loop. Unmatched build rows are emitted in
+    // doGetOutput via rightMatchedFlags_.
     VELOX_CHECK_NOT_NULL(hb);
-    // Use left_join to get all probe rows (matched + unmatched).
-    // Track matched build rows in rightMatchedFlags_ for last driver to emit
-    // unmatched build rows at the end.
-    auto [leftJoinIndices, rightJoinIndices] = hb->left_join(
+    auto [leftJoinIndices, rightJoinIndices] = hb->inner_join(
         leftTableView.select(leftKeyIndices_),
         std::nullopt,
         stream,
         get_temp_mr());
-    if (!joinNode_->filter()) {
-      // Mark matched build rows by checking which row indices appear in
-      // rightJoinIndices. Use contains to avoid scatter with duplicate indices.
-      auto rightIdxCol = cudf::column_view{
-          cudf::device_span<cudf::size_type const>{*rightJoinIndices}};
 
-      // Create sequence [0, 1, ..., n-1] for build table row indices
-      auto n = rightTableView.num_rows();
-      auto rowIndices = cudf::sequence(
-          n,
-          cudf::numeric_scalar<cudf::size_type>(0, true, stream, get_temp_mr()),
-          cudf::numeric_scalar<cudf::size_type>(1, true, stream, get_temp_mr()),
-          stream,
-          get_temp_mr());
-
-      // Check which build row indices are present in the join result
-      auto matchedInBatch = cudf::contains(
-          rightIdxCol, rowIndices->view(), stream, get_temp_mr());
-
-      // OR with existing flags to accumulate matches across batches
-      auto updatedFlags = cudf::binary_operation(
-          rightMatchedFlags_[i]->view(),
-          matchedInBatch->view(),
-          cudf::binary_operator::BITWISE_OR,
-          cudf::data_type{cudf::type_id::BOOL8},
-          stream,
-          get_temp_mr());
-      // binary_operation is async on `stream`; the old column destructs via
-      // cudaFreeAsync on its allocation stream (not `stream`), so the free
-      // can race the kernel. Drain `stream` before the move-assign.
-      stream.synchronize();
-      rightMatchedFlags_[i] = std::move(updatedFlags);
+    if (leftJoinIndices->size() == 0) {
+      continue;
     }
 
     auto leftIndicesSpan =
@@ -1211,9 +1385,7 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::fullJoin(
     auto rightIndicesCol = cudf::column_view{rightIndicesSpan};
 
     if (joinNode_->filter()) {
-      // Use filter_join_indices with LEFT_JOIN to get proper full join probe
-      // semantics: all probe rows are kept, build columns are NULL when filter
-      // fails or no match.
+      // Apply filter and keep only pairs where the predicate passes.
       auto [filteredLeftJoinIndices, filteredRightJoinIndices] =
           cudf::filter_join_indices(
               leftTableView,
@@ -1221,57 +1393,34 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::fullJoin(
               leftIndicesCol,
               rightIndicesCol,
               tree_.back(),
-              cudf::join_kind::LEFT_JOIN,
+              cudf::join_kind::INNER_JOIN,
               stream,
               get_temp_mr());
 
-      // Track matched build rows for unmatched row emission at end.
-      // Use contains to check which build row indices passed the filter.
-      auto& rightMatchedFlags = rightMatchedFlags_[i];
-      auto filteredRightIndicesSpan =
-          cudf::device_span<cudf::size_type const>{*filteredRightJoinIndices};
-      auto filteredRightIdxCol = cudf::column_view{filteredRightIndicesSpan};
+      if (filteredLeftJoinIndices->size() > 0) {
+        auto filteredLeftSpan = cudf::device_span<cudf::size_type const>{
+            *filteredLeftJoinIndices};
+        auto filteredRightSpan = cudf::device_span<cudf::size_type const>{
+            *filteredRightJoinIndices};
+        auto filteredLeftCol = cudf::column_view{filteredLeftSpan};
+        auto filteredRightCol = cudf::column_view{filteredRightSpan};
 
-      // Create sequence [0, 1, ..., n-1] for build table row indices
-      auto n = rightTableView.num_rows();
-      auto rowIndices = cudf::sequence(
-          n,
-          cudf::numeric_scalar<cudf::size_type>(0, true, stream, get_temp_mr()),
-          cudf::numeric_scalar<cudf::size_type>(1, true, stream, get_temp_mr()),
-          stream,
-          get_temp_mr());
+        updateProbeMatchCol(filteredLeftCol);
+        updateRightMatchedFlags(
+            i, filteredRightCol, rightTableView.num_rows());
 
-      // Check which build row indices are present in the filtered join result
-      auto matchedInBatch = cudf::contains(
-          filteredRightIdxCol, rowIndices->view(), stream, get_temp_mr());
-
-      // OR with existing flags to accumulate matches across batches
-      auto updatedFlags = cudf::binary_operation(
-          rightMatchedFlags->view(),
-          matchedInBatch->view(),
-          cudf::binary_operator::BITWISE_OR,
-          cudf::data_type{cudf::type_id::BOOL8},
-          stream,
-          get_temp_mr());
-      // binary_operation is async on `stream`; the old column destructs via
-      // cudaFreeAsync on its allocation stream (not `stream`), so the free
-      // can race the kernel. Drain `stream` before the move-assign.
-      stream.synchronize();
-      rightMatchedFlags = std::move(updatedFlags);
-
-      // Build output using filtered indices
-      auto filteredLeftIndicesSpan =
-          cudf::device_span<cudf::size_type const>{*filteredLeftJoinIndices};
-      auto filteredLeftIndicesCol = cudf::column_view{filteredLeftIndicesSpan};
-      auto filteredRightIndicesCol =
-          cudf::column_view{filteredRightIndicesSpan};
-      cudfOutputs.push_back(unfilteredOutput(
-          leftTableView,
-          filteredLeftIndicesCol,
-          rightTableView,
-          filteredRightIndicesCol,
-          stream));
+        cudfOutputs.push_back(unfilteredOutput(
+            leftTableView,
+            filteredLeftCol,
+            rightTableView,
+            filteredRightCol,
+            stream));
+      }
     } else {
+      updateProbeMatchCol(leftIndicesCol);
+      updateRightMatchedFlags(
+          i, rightIndicesCol, rightTableView.num_rows());
+
       cudfOutputs.push_back(unfilteredOutput(
           leftTableView,
           leftIndicesCol,
@@ -1280,6 +1429,47 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::fullJoin(
           stream));
     }
   }
+
+  // Emit unmatched probe rows. Build a synthetic batch where left indices are
+  // the unmatched probe row indices and right indices are all -1 (out of
+  // bounds), so the gather with NULLIFY produces NULL build columns.
+  auto unmatchedMask = cudf::unary_operation(
+      probeMatchCol->view(),
+      cudf::unary_operator::NOT,
+      stream,
+      get_temp_mr());
+  auto unmatchedIndices =
+      getIndicesWhere(unmatchedMask->view(), stream, get_temp_mr());
+
+  if (unmatchedIndices->size() > 0) {
+    auto unmatchedLeftCol = unmatchedIndices->view();
+    auto sentinelScalar = cudf::numeric_scalar<cudf::size_type>(
+        cudf::JoinNoMatch, true, stream, get_temp_mr());
+    auto unmatchedRightIndices = cudf::make_column_from_scalar(
+        sentinelScalar,
+        unmatchedIndices->size(),
+        stream,
+        get_temp_mr());
+    auto unmatchedRightCol = unmatchedRightIndices->view();
+
+    // Emit unmatched rows directly via unfilteredOutput for two reasons:
+    // (1) We cannot use filteredOutputIndices with LEFT_JOIN here because
+    //     filter_join_indices(LEFT_JOIN) ensures every row in the left *table*
+    //     appears at least once. Since our left indices are a subset of probe
+    //     rows (only the unmatched ones), LEFT_JOIN would re-add all the
+    //     matched probe rows that are absent from this subset.
+    // (2) Using unfilteredOutput is safe because all right indices are
+    //     JoinNoMatch. Per filter_join_indices semantics, input pairs with
+    //     JoinNoMatch in either position pass through unchanged (the predicate
+    //     cannot be evaluated), so filtering would be a no-op anyway.
+    cudfOutputs.push_back(unfilteredOutput(
+        leftTableView,
+        unmatchedLeftCol,
+        rightTables[0]->view(),
+        unmatchedRightCol,
+        stream));
+  }
+
   return cudfOutputs;
 }
 
@@ -1374,27 +1564,6 @@ std::unique_ptr<cudf::column> applyNullMask(
   // copy_if_else: where nullMask is true, use nullScalar (NULL); else use col
   // value
   return cudf::copy_if_else(nullScalar, col, nullMask, stream, mr);
-}
-
-/// Get row indices where mask is true.
-/// Returns a column of size_type indices.
-std::unique_ptr<cudf::column> getIndicesWhere(
-    cudf::column_view mask,
-    rmm::cuda_stream_view stream,
-    rmm::device_async_resource_ref mr) {
-  // Create sequence [0, 1, 2, ..., mask.size()-1]
-  auto seq = cudf::sequence(
-      mask.size(),
-      cudf::numeric_scalar<cudf::size_type>(0, true, stream, mr),
-      cudf::numeric_scalar<cudf::size_type>(1, true, stream, mr),
-      stream,
-      mr);
-
-  // Filter to keep only indices where mask is true
-  auto indicesTable = cudf::apply_boolean_mask(
-      cudf::table_view{{seq->view()}}, mask, stream, mr);
-
-  return std::move(indicesTable->release()[0]);
 }
 
 /// Create cross-product of two index columns.

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -999,8 +999,7 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::leftJoin(
                           cudf::table_view rightTableView,
                           size_t buildBatchIdx) {
     if (joinNode_->filter()) {
-      cudf::table_view extendedRightView =
-          !rightPrecomputeInstructions_.empty()
+      cudf::table_view extendedRightView = !rightPrecomputeInstructions_.empty()
           ? cachedExtendedRightViews_[buildBatchIdx]
           : rightTableView;
 
@@ -1052,8 +1051,7 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::leftJoin(
               // probe rows passed the filter.
               auto leftIdxCol = cudf::column_view{leftIndicesSpanCopy};
               auto filteredIdxTable = cudf::apply_boolean_mask(
-                  cudf::table_view{
-                      std::vector<cudf::column_view>{leftIdxCol}},
+                  cudf::table_view{std::vector<cudf::column_view>{leftIdxCol}},
                   filterColumn,
                   stream,
                   get_temp_mr());
@@ -1125,10 +1123,7 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::leftJoin(
     auto sentinelScalar = cudf::numeric_scalar<cudf::size_type>(
         cudf::JoinNoMatch, true, stream, get_temp_mr());
     auto unmatchedRightIndices = cudf::make_column_from_scalar(
-        sentinelScalar,
-        unmatchedIndices->size(),
-        stream,
-        get_temp_mr());
+        sentinelScalar, unmatchedIndices->size(), stream, get_temp_mr());
     auto unmatchedRightCol = unmatchedRightIndices->view();
 
     // Emit unmatched rows directly via unfilteredOutput for two reasons:
@@ -1332,32 +1327,27 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::fullJoin(
   };
 
   // Helper to accumulate build-side (right) match flags for a build batch.
-  auto updateRightMatchedFlags =
-      [&](size_t batchIdx, cudf::column_view matchedRightIndices,
-          cudf::size_type numBuildRows) {
-        auto buildRowIndices = cudf::sequence(
-            numBuildRows,
-            cudf::numeric_scalar<cudf::size_type>(
-                0, true, stream, get_temp_mr()),
-            cudf::numeric_scalar<cudf::size_type>(
-                1, true, stream, get_temp_mr()),
-            stream,
-            get_temp_mr());
-        auto matchedInBatch = cudf::contains(
-            matchedRightIndices,
-            buildRowIndices->view(),
-            stream,
-            get_temp_mr());
-        auto updatedFlags = cudf::binary_operation(
-            rightMatchedFlags_[batchIdx]->view(),
-            matchedInBatch->view(),
-            cudf::binary_operator::BITWISE_OR,
-            cudf::data_type{cudf::type_id::BOOL8},
-            stream,
-            get_temp_mr());
-        stream.synchronize();
-        rightMatchedFlags_[batchIdx] = std::move(updatedFlags);
-      };
+  auto updateRightMatchedFlags = [&](size_t batchIdx,
+                                     cudf::column_view matchedRightIndices,
+                                     cudf::size_type numBuildRows) {
+    auto buildRowIndices = cudf::sequence(
+        numBuildRows,
+        cudf::numeric_scalar<cudf::size_type>(0, true, stream, get_temp_mr()),
+        cudf::numeric_scalar<cudf::size_type>(1, true, stream, get_temp_mr()),
+        stream,
+        get_temp_mr());
+    auto matchedInBatch = cudf::contains(
+        matchedRightIndices, buildRowIndices->view(), stream, get_temp_mr());
+    auto updatedFlags = cudf::binary_operation(
+        rightMatchedFlags_[batchIdx]->view(),
+        matchedInBatch->view(),
+        cudf::binary_operator::BITWISE_OR,
+        cudf::data_type{cudf::type_id::BOOL8},
+        stream,
+        get_temp_mr());
+    stream.synchronize();
+    rightMatchedFlags_[batchIdx] = std::move(updatedFlags);
+  };
 
   for (auto i = 0; i < rightTables.size(); i++) {
     auto rightTableView = rightTables[i]->view();
@@ -1398,16 +1388,15 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::fullJoin(
               get_temp_mr());
 
       if (filteredLeftJoinIndices->size() > 0) {
-        auto filteredLeftSpan = cudf::device_span<cudf::size_type const>{
-            *filteredLeftJoinIndices};
-        auto filteredRightSpan = cudf::device_span<cudf::size_type const>{
-            *filteredRightJoinIndices};
+        auto filteredLeftSpan =
+            cudf::device_span<cudf::size_type const>{*filteredLeftJoinIndices};
+        auto filteredRightSpan =
+            cudf::device_span<cudf::size_type const>{*filteredRightJoinIndices};
         auto filteredLeftCol = cudf::column_view{filteredLeftSpan};
         auto filteredRightCol = cudf::column_view{filteredRightSpan};
 
         updateProbeMatchCol(filteredLeftCol);
-        updateRightMatchedFlags(
-            i, filteredRightCol, rightTableView.num_rows());
+        updateRightMatchedFlags(i, filteredRightCol, rightTableView.num_rows());
 
         cudfOutputs.push_back(unfilteredOutput(
             leftTableView,
@@ -1418,8 +1407,7 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::fullJoin(
       }
     } else {
       updateProbeMatchCol(leftIndicesCol);
-      updateRightMatchedFlags(
-          i, rightIndicesCol, rightTableView.num_rows());
+      updateRightMatchedFlags(i, rightIndicesCol, rightTableView.num_rows());
 
       cudfOutputs.push_back(unfilteredOutput(
           leftTableView,
@@ -1434,10 +1422,7 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::fullJoin(
   // the unmatched probe row indices and right indices are all -1 (out of
   // bounds), so the gather with NULLIFY produces NULL build columns.
   auto unmatchedMask = cudf::unary_operation(
-      probeMatchCol->view(),
-      cudf::unary_operator::NOT,
-      stream,
-      get_temp_mr());
+      probeMatchCol->view(), cudf::unary_operator::NOT, stream, get_temp_mr());
   auto unmatchedIndices =
       getIndicesWhere(unmatchedMask->view(), stream, get_temp_mr());
 
@@ -1446,10 +1431,7 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::fullJoin(
     auto sentinelScalar = cudf::numeric_scalar<cudf::size_type>(
         cudf::JoinNoMatch, true, stream, get_temp_mr());
     auto unmatchedRightIndices = cudf::make_column_from_scalar(
-        sentinelScalar,
-        unmatchedIndices->size(),
-        stream,
-        get_temp_mr());
+        sentinelScalar, unmatchedIndices->size(), stream, get_temp_mr());
     auto unmatchedRightCol = unmatchedRightIndices->view();
 
     // Emit unmatched rows directly via unfilteredOutput for two reasons:

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -103,13 +103,11 @@ vector_size_t filteredOutputNumRows(
           ->value(stream));
 }
 
-/// Get row indices where mask is true.
-/// Returns a column of size_type indices.
-std::unique_ptr<cudf::column> getIndicesWhere(
+/// Returns row indices where mask is true as a column of size_type.
+std::unique_ptr<cudf::column> getRetainedIndices(
     cudf::column_view mask,
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr) {
-  // Create sequence [0, 1, 2, ..., mask.size()-1]
   auto seq = cudf::sequence(
       mask.size(),
       cudf::numeric_scalar<cudf::size_type>(0, true, stream, mr),
@@ -117,12 +115,64 @@ std::unique_ptr<cudf::column> getIndicesWhere(
       stream,
       mr);
 
-  // Filter to keep only indices where mask is true
   auto indicesTable = cudf::apply_boolean_mask(
       cudf::table_view{{seq->view()}}, mask, stream, mr);
 
-  return std::move(indicesTable->release()[0]);
+  return std::move(indicesTable->release().front());
 }
+
+/// Tracks which probe rows have been matched across multiple build batches.
+/// Maintains a boolean column that accumulates matches via cudf::contains +
+/// BITWISE_OR, and provides a method to retrieve unmatched probe row indices.
+class ProbeMatchTracker {
+ public:
+  ProbeMatchTracker(
+      cudf::size_type numProbeRows,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) {
+    auto falseScalar =
+        cudf::numeric_scalar<bool>(false, true, stream, mr);
+    matchCol_ = cudf::make_column_from_scalar(
+        falseScalar, numProbeRows, stream, mr);
+    probeRowIndices_ = cudf::sequence(
+        numProbeRows,
+        cudf::numeric_scalar<cudf::size_type>(0, true, stream, mr),
+        cudf::numeric_scalar<cudf::size_type>(1, true, stream, mr),
+        stream,
+        mr);
+  }
+
+  /// Mark probe rows present in matchedLeftIndices as matched.
+  void update(
+      cudf::column_view matchedLeftIndices,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) {
+    auto matchedInBatch =
+        cudf::contains(matchedLeftIndices, probeRowIndices_->view(), stream, mr);
+    auto updatedMatch = cudf::binary_operation(
+        matchCol_->view(),
+        matchedInBatch->view(),
+        cudf::binary_operator::BITWISE_OR,
+        cudf::data_type{cudf::type_id::BOOL8},
+        stream,
+        mr);
+    stream.synchronize();
+    matchCol_ = std::move(updatedMatch);
+  }
+
+  /// Returns indices of probe rows that were never matched.
+  std::unique_ptr<cudf::column> getUnmatchedIndices(
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) {
+    auto unmatchedMask = cudf::unary_operation(
+        matchCol_->view(), cudf::unary_operator::NOT, stream, mr);
+    return getRetainedIndices(unmatchedMask->view(), stream, mr);
+  }
+
+ private:
+  std::unique_ptr<cudf::column> matchCol_;
+  std::unique_ptr<cudf::column> probeRowIndices_;
+};
 
 } // namespace
 
@@ -950,32 +1000,7 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::leftJoin(
 
   // Track which probe rows matched in any build batch so that unmatched probe
   // rows can be emitted with NULL build columns after the loop.
-  auto falseScalar =
-      cudf::numeric_scalar<bool>(false, true, stream, get_temp_mr());
-  auto matchCol = cudf::make_column_from_scalar(
-      falseScalar, numProbeRows, stream, get_temp_mr());
-  auto probeRowIndices = cudf::sequence(
-      numProbeRows,
-      cudf::numeric_scalar<cudf::size_type>(0, true, stream, get_temp_mr()),
-      cudf::numeric_scalar<cudf::size_type>(1, true, stream, get_temp_mr()),
-      stream,
-      get_temp_mr());
-
-  // Helper to accumulate probe-side match flags from a column of matched
-  // probe indices.
-  auto updateMatchCol = [&](cudf::column_view matchedLeftIndices) {
-    auto matchedInBatch = cudf::contains(
-        matchedLeftIndices, probeRowIndices->view(), stream, get_temp_mr());
-    auto updatedMatch = cudf::binary_operation(
-        matchCol->view(),
-        matchedInBatch->view(),
-        cudf::binary_operator::BITWISE_OR,
-        cudf::data_type{cudf::type_id::BOOL8},
-        stream,
-        get_temp_mr());
-    stream.synchronize();
-    matchCol = std::move(updatedMatch);
-  };
+  ProbeMatchTracker probeTracker(numProbeRows, stream, get_temp_mr());
 
   // Precompute left (probe) table columns if needed (once, outside loop)
   std::vector<ColumnOrView> leftPrecomputed;
@@ -992,8 +1017,8 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::leftJoin(
   }
 
   // Processes a build batch of join indices: applies the filter (if any),
-  // updates matchCol from post-filter left indices, and appends the result to
-  // cudfOutputs.
+  // updates probeTracker from post-filter left indices, and appends the result
+  // to cudfOutputs.
   auto processBatch = [&](cudf::column_view leftIndicesCol,
                           cudf::column_view rightIndicesCol,
                           cudf::table_view rightTableView,
@@ -1025,7 +1050,7 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::leftJoin(
           auto filteredLeftCol = cudf::column_view{filteredLeftSpan};
           auto filteredRightCol = cudf::column_view{filteredRightSpan};
 
-          updateMatchCol(filteredLeftCol);
+probeTracker.update(filteredLeftCol, stream, get_temp_mr());
 
           cudfOutputs.push_back(unfilteredOutput(
               leftTableView,
@@ -1038,7 +1063,7 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::leftJoin(
         auto leftIndicesSpanCopy =
             cudf::device_span<cudf::size_type const>(leftIndicesCol);
         auto filterFunc =
-            [&updateMatchCol, leftIndicesSpanCopy, stream](
+            [&probeTracker, leftIndicesSpanCopy, stream](
                 std::vector<std::unique_ptr<cudf::column>>&& joinedCols,
                 cudf::column_view filterColumn) {
               auto filterTable =
@@ -1051,13 +1076,15 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::leftJoin(
               // probe rows passed the filter.
               auto leftIdxCol = cudf::column_view{leftIndicesSpanCopy};
               auto filteredIdxTable = cudf::apply_boolean_mask(
-                  cudf::table_view{std::vector<cudf::column_view>{leftIdxCol}},
+                  cudf::table_view{
+                      std::vector<cudf::column_view>{leftIdxCol}},
                   filterColumn,
                   stream,
                   get_temp_mr());
               auto filteredLeftIdxCol =
                   std::move(filteredIdxTable->release()[0]);
-              updateMatchCol(filteredLeftIdxCol->view());
+              probeTracker.update(
+                  filteredLeftIdxCol->view(), stream, get_temp_mr());
 
               return std::move(joinedCols);
             };
@@ -1070,7 +1097,7 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::leftJoin(
             stream));
       }
     } else {
-      updateMatchCol(leftIndicesCol);
+      probeTracker.update(leftIndicesCol, stream, get_temp_mr());
       cudfOutputs.push_back(unfilteredOutput(
           leftTableView,
           leftIndicesCol,
@@ -1107,19 +1134,13 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::leftJoin(
     processBatch(leftIndicesCol, rightIndicesCol, rightTableView, i);
   }
 
-  // Emit unmatched probe rows. Build a synthetic batch where left indices are
-  // the unmatched probe row indices and right indices are all -1 (out of
-  // bounds), so the gather with NULLIFY produces NULL build columns. This also
-  // correctly applies any filter to the unmatched rows.
-  auto unmatchedMask = cudf::unary_operation(
-      matchCol->view(), cudf::unary_operator::NOT, stream, get_temp_mr());
+  // Emit unmatched probe rows with JoinNoMatch right indices so that gather
+  // with NULLIFY produces NULL build columns.
   auto unmatchedIndices =
-      getIndicesWhere(unmatchedMask->view(), stream, get_temp_mr());
+      probeTracker.getUnmatchedIndices(stream, get_temp_mr());
 
   if (unmatchedIndices->size() > 0) {
     auto unmatchedLeftCol = unmatchedIndices->view();
-    // Create right indices filled with cudf::JoinNoMatch so that gather with
-    // NULLIFY produces NULL build columns.
     auto sentinelScalar = cudf::numeric_scalar<cudf::size_type>(
         cudf::JoinNoMatch, true, stream, get_temp_mr());
     auto unmatchedRightIndices = cudf::make_column_from_scalar(
@@ -1299,32 +1320,7 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::fullJoin(
 
   // Track which probe rows matched in any build batch so that unmatched probe
   // rows can be emitted with NULL build columns after the loop.
-  auto falseScalar =
-      cudf::numeric_scalar<bool>(false, true, stream, get_temp_mr());
-  auto probeMatchCol = cudf::make_column_from_scalar(
-      falseScalar, numProbeRows, stream, get_temp_mr());
-  auto probeRowIndices = cudf::sequence(
-      numProbeRows,
-      cudf::numeric_scalar<cudf::size_type>(0, true, stream, get_temp_mr()),
-      cudf::numeric_scalar<cudf::size_type>(1, true, stream, get_temp_mr()),
-      stream,
-      get_temp_mr());
-
-  // Helper to accumulate probe-side match flags from a column of matched
-  // probe indices.
-  auto updateProbeMatchCol = [&](cudf::column_view matchedLeftIndices) {
-    auto matchedInBatch = cudf::contains(
-        matchedLeftIndices, probeRowIndices->view(), stream, get_temp_mr());
-    auto updatedMatch = cudf::binary_operation(
-        probeMatchCol->view(),
-        matchedInBatch->view(),
-        cudf::binary_operator::BITWISE_OR,
-        cudf::data_type{cudf::type_id::BOOL8},
-        stream,
-        get_temp_mr());
-    stream.synchronize();
-    probeMatchCol = std::move(updatedMatch);
-  };
+  ProbeMatchTracker probeTracker(numProbeRows, stream, get_temp_mr());
 
   // Helper to accumulate build-side (right) match flags for a build batch.
   auto updateRightMatchedFlags = [&](size_t batchIdx,
@@ -1395,7 +1391,7 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::fullJoin(
         auto filteredLeftCol = cudf::column_view{filteredLeftSpan};
         auto filteredRightCol = cudf::column_view{filteredRightSpan};
 
-        updateProbeMatchCol(filteredLeftCol);
+        probeTracker.update(filteredLeftCol, stream, get_temp_mr());
         updateRightMatchedFlags(i, filteredRightCol, rightTableView.num_rows());
 
         cudfOutputs.push_back(unfilteredOutput(
@@ -1406,7 +1402,7 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::fullJoin(
             stream));
       }
     } else {
-      updateProbeMatchCol(leftIndicesCol);
+      probeTracker.update(leftIndicesCol, stream, get_temp_mr());
       updateRightMatchedFlags(i, rightIndicesCol, rightTableView.num_rows());
 
       cudfOutputs.push_back(unfilteredOutput(
@@ -1418,13 +1414,10 @@ std::vector<CudfHashJoinProbe::JoinOutput> CudfHashJoinProbe::fullJoin(
     }
   }
 
-  // Emit unmatched probe rows. Build a synthetic batch where left indices are
-  // the unmatched probe row indices and right indices are all -1 (out of
-  // bounds), so the gather with NULLIFY produces NULL build columns.
-  auto unmatchedMask = cudf::unary_operation(
-      probeMatchCol->view(), cudf::unary_operator::NOT, stream, get_temp_mr());
+  // Emit unmatched probe rows with JoinNoMatch right indices so that gather
+  // with NULLIFY produces NULL build columns.
   auto unmatchedIndices =
-      getIndicesWhere(unmatchedMask->view(), stream, get_temp_mr());
+      probeTracker.getUnmatchedIndices(stream, get_temp_mr());
 
   if (unmatchedIndices->size() > 0) {
     auto unmatchedLeftCol = unmatchedIndices->view();
@@ -1857,7 +1850,7 @@ CudfHashJoinProbe::leftSemiProjectJoin(
         // Type B: Null probe keys × all build rows
         if (probeHasNulls) {
           auto nullProbeIndices =
-              getIndicesWhere(probeKeyNullMask->view(), stream, get_temp_mr());
+              getRetainedIndices(probeKeyNullMask->view(), stream, get_temp_mr());
           auto allBuildIndices = cudf::sequence(
               numBuildRows,
               cudf::numeric_scalar<cudf::size_type>(
@@ -1895,11 +1888,11 @@ CudfHashJoinProbe::leftSemiProjectJoin(
               get_temp_mr());
 
           auto typeAProbeIndices =
-              getIndicesWhere(typeAMask->view(), stream, get_temp_mr());
+              getRetainedIndices(typeAMask->view(), stream, get_temp_mr());
           auto buildKeyNullMask =
               createProbeKeyNullMask(buildKeyView, stream, get_temp_mr());
           auto nullBuildIndices =
-              getIndicesWhere(buildKeyNullMask->view(), stream, get_temp_mr());
+              getRetainedIndices(buildKeyNullMask->view(), stream, get_temp_mr());
 
           accumulateIndeterminate(
               typeAProbeIndices->view(),

--- a/velox/experimental/cudf/tests/HashJoinTest.cpp
+++ b/velox/experimental/cudf/tests/HashJoinTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/experimental/cudf/CudfConfig.h"
+#include "velox/experimental/cudf/exec/CudfConversion.h"
 #include "velox/experimental/cudf/exec/ToCudf.h"
 #include "velox/experimental/cudf/expression/PrestoFunctions.h"
 
@@ -1749,6 +1750,330 @@ TEST_P(MultiThreadedHashJoinTest, leftJoin) {
         ASSERT_EQ(nullJoinBuildKeyCount, 33 * GetParam().numDrivers);
         ASSERT_EQ(nullJoinProbeKeyCount, 34 * GetParam().numDrivers);
       })
+      .run();
+}
+
+TEST_P(MultiThreadedHashJoinTest, leftJoinBatchedBuild) {
+  // Build side has 3 input vectors of 10 rows each. With batch size max = 10,
+  // each becomes a separate build batch. Only the last batch has keys matching
+  // the probe side. Probe side includes matched keys [0..4], unmatched keys
+  // [100..102], and a null key — testing matched, unmatched, and null-key paths
+  // across multiple build batches.
+  auto& cudfConfig = cudf_velox::CudfConfig::getInstance();
+  cudfConfig.batchSizeMinThreshold = 10;
+  cudfConfig.batchSizeMaxThreshold = 10;
+
+  std::vector<RowVectorPtr> probeVectors = {makeRowVector(
+      {"c0", "c1", "row_number"},
+      {
+          makeNullableFlatVector<int32_t>(
+              {0, 1, 2, 3, 4, 100, 101, 102, std::nullopt}),
+          makeFlatVector<int32_t>({10, 11, 12, 13, 14, 15, 16, 17, 18}),
+          makeFlatVector<int32_t>({0, 1, 2, 3, 4, 5, 6, 7, 8}),
+      })};
+
+  // Build side: 3 batches of 10 rows each. First two batches have keys
+  // [200..219] (no probe match), last batch has keys [0..9] (keys 0-4 match
+  // probe).
+  std::vector<RowVectorPtr> buildVectors =
+      makeBatches(3, [&](int32_t batchIdx) {
+        return makeRowVector({
+            makeFlatVector<int32_t>(10, [batchIdx](auto row) {
+              return batchIdx < 2 ? 200 + batchIdx * 10 + row : row;
+            }),
+            makeFlatVector<int32_t>(
+                10, [batchIdx](auto row) { return batchIdx * 100 + row; }),
+        });
+      });
+
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .injectSpill(false)
+      .numDrivers(numDrivers_)
+      .probeKeys({"c0"})
+      .probeVectors(std::move(probeVectors))
+      .buildKeys({"u_c0"})
+      .buildVectors(std::move(buildVectors))
+      .buildProjections({"c0 AS u_c0", "c1 AS u_c1"})
+      .joinType(core::JoinType::kLeft)
+      .joinOutputLayout({"row_number", "c0", "c1", "u_c0"})
+      .referenceQuery(
+          "SELECT t.row_number, t.c0, t.c1, u.c0 FROM t LEFT JOIN u ON t.c0 = u.c0")
+      .config(cudf_velox::CudfFromVelox::kGpuBatchSizeRows, "10")
+      .run();
+}
+
+// Probe rows match in different build batches, testing that matchCol
+// accumulates correctly via BITWISE_OR across batches.
+TEST_P(MultiThreadedHashJoinTest, leftJoinBatchedBuildMatchesAcrossBatches) {
+  auto& cudfConfig = cudf_velox::CudfConfig::getInstance();
+  cudfConfig.batchSizeMinThreshold = 10;
+  cudfConfig.batchSizeMaxThreshold = 10;
+
+  // Probe keys [0..9]. Even keys match batch 0, odd keys match batch 1.
+  std::vector<RowVectorPtr> probeVectors = {makeRowVector(
+      {"c0", "c1"},
+      {
+          makeFlatVector<int32_t>(10, [](auto row) { return row; }),
+          makeFlatVector<int32_t>(10, [](auto row) { return row * 10; }),
+      })};
+
+  // Build batch 0: even keys [0, 2, 4, 6, 8, 200..204]
+  // Build batch 1: odd keys [1, 3, 5, 7, 9, 300..304]
+  std::vector<RowVectorPtr> buildVectors =
+      makeBatches(2, [&](int32_t batchIdx) {
+        return makeRowVector({
+            makeFlatVector<int32_t>(10, [batchIdx](auto row) {
+              return row < 5 ? batchIdx + row * 2
+                             : (batchIdx + 2) * 100 + row;
+            }),
+            makeFlatVector<int32_t>(
+                10, [batchIdx](auto row) { return batchIdx * 100 + row; }),
+        });
+      });
+
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .injectSpill(false)
+      .numDrivers(numDrivers_)
+      .probeKeys({"c0"})
+      .probeVectors(std::move(probeVectors))
+      .buildKeys({"u_c0"})
+      .buildVectors(std::move(buildVectors))
+      .buildProjections({"c0 AS u_c0", "c1 AS u_c1"})
+      .joinType(core::JoinType::kLeft)
+      .joinOutputLayout({"c0", "c1", "u_c0", "u_c1"})
+      .referenceQuery(
+          "SELECT t.c0, t.c1, u.c0, u.c1 FROM t LEFT JOIN u ON t.c0 = u.c0")
+      .config(cudf_velox::CudfFromVelox::kGpuBatchSizeRows, "10")
+      .run();
+}
+
+// A single probe key matches rows in multiple build batches. Verifies that
+// all matched pairs appear and no spurious unmatched-with-NULL row is emitted.
+TEST_P(MultiThreadedHashJoinTest, leftJoinBatchedBuildDuplicateMatches) {
+  auto& cudfConfig = cudf_velox::CudfConfig::getInstance();
+  cudfConfig.batchSizeMinThreshold = 10;
+  cudfConfig.batchSizeMaxThreshold = 10;
+
+  // Probe has a single key=1.
+  std::vector<RowVectorPtr> probeVectors = {makeRowVector(
+      {"c0", "c1"},
+      {
+          makeFlatVector<int32_t>({1}),
+          makeFlatVector<int32_t>({10}),
+      })};
+
+  // Both build batches contain key=1 (among others).
+  std::vector<RowVectorPtr> buildVectors =
+      makeBatches(2, [&](int32_t batchIdx) {
+        return makeRowVector({
+            makeFlatVector<int32_t>(10, [](auto row) { return row; }),
+            makeFlatVector<int32_t>(
+                10, [batchIdx](auto row) { return batchIdx * 100 + row; }),
+        });
+      });
+
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .injectSpill(false)
+      .numDrivers(numDrivers_)
+      .probeKeys({"c0"})
+      .probeVectors(std::move(probeVectors))
+      .buildKeys({"u_c0"})
+      .buildVectors(std::move(buildVectors))
+      .buildProjections({"c0 AS u_c0", "c1 AS u_c1"})
+      .joinType(core::JoinType::kLeft)
+      .joinOutputLayout({"c0", "c1", "u_c0", "u_c1"})
+      .referenceQuery(
+          "SELECT t.c0, t.c1, u.c0, u.c1 FROM t LEFT JOIN u ON t.c0 = u.c0")
+      .config(cudf_velox::CudfFromVelox::kGpuBatchSizeRows, "10")
+      .run();
+}
+
+// Left join with an AST-compatible filter and multiple build batches.
+TEST_P(MultiThreadedHashJoinTest, leftJoinBatchedBuildWithFilter) {
+  auto& cudfConfig = cudf_velox::CudfConfig::getInstance();
+  cudfConfig.batchSizeMinThreshold = 10;
+  cudfConfig.batchSizeMaxThreshold = 10;
+
+  // Probe keys [0..9] with c1 values.
+  std::vector<RowVectorPtr> probeVectors = {makeRowVector(
+      {"c0", "c1"},
+      {
+          makeFlatVector<int32_t>(10, [](auto row) { return row; }),
+          makeFlatVector<int32_t>(10, [](auto row) { return row; }),
+      })};
+
+  // Build: 3 batches of 10 rows. All batches have keys [0..9] so every
+  // probe row has key matches in every batch. The filter will select only
+  // some of the matched pairs.
+  std::vector<RowVectorPtr> buildVectors =
+      makeBatches(3, [&](int32_t batchIdx) {
+        return makeRowVector({
+            makeFlatVector<int32_t>(10, [](auto row) { return row; }),
+            makeFlatVector<int32_t>(
+                10, [batchIdx](auto row) { return batchIdx * 10 + row; }),
+        });
+      });
+
+  // Filter: (c1 + u_c1) % 2 = 1. Some probe rows will have matches that
+  // pass, some won't. Probe rows whose matches all fail should appear with
+  // NULL build columns.
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .injectSpill(false)
+      .numDrivers(numDrivers_)
+      .probeKeys({"c0"})
+      .probeVectors(std::move(probeVectors))
+      .buildKeys({"u_c0"})
+      .buildVectors(std::move(buildVectors))
+      .buildProjections({"c0 AS u_c0", "c1 AS u_c1"})
+      .joinType(core::JoinType::kLeft)
+      .joinFilter("(c1 + u_c1) % 2 = 1")
+      .joinOutputLayout({"c0", "c1", "u_c1"})
+      .referenceQuery(
+          "SELECT t.c0, t.c1, u.c1 FROM t LEFT JOIN u ON t.c0 = u.c0 "
+          "AND (t.c1 + u.c1) % 2 = 1")
+      .config(cudf_velox::CudfFromVelox::kGpuBatchSizeRows, "10")
+      .run();
+}
+
+// Left join with a non-AST filter (lower() is not supported by cuDF AST)
+// and multiple build batches. Tests the filterFunc lambda match tracking path.
+TEST_P(MultiThreadedHashJoinTest, leftJoinBatchedBuildWithNonAstFilter) {
+  auto& cudfConfig = cudf_velox::CudfConfig::getInstance();
+  cudfConfig.batchSizeMinThreshold = 10;
+  cudfConfig.batchSizeMaxThreshold = 10;
+
+  std::vector<RowVectorPtr> probeVectors = {makeRowVector(
+      {"t0", "t1"},
+      {
+          makeFlatVector<int64_t>(10, [](auto row) { return row; }),
+          makeFlatVector<std::string>(
+              10, [](auto row) { return row % 2 == 0 ? "HELLO" : "world"; }),
+      })};
+
+  // Build: 2 batches. Batch 0 has keys [0..9] with "hello", batch 1 has
+  // keys [0..9] with "WORLD". lower(t1)=lower(u1) matches "HELLO"/"hello"
+  // for even probe rows in batch 0, and "world"/"WORLD" for odd probe rows
+  // in batch 1.
+  std::vector<RowVectorPtr> buildVectors =
+      makeBatches(2, [&](int32_t batchIdx) {
+        return makeRowVector(
+            {"u0", "u1"},
+            {
+                makeFlatVector<int64_t>(10, [](auto row) { return row; }),
+                makeFlatVector<std::string>(10, [batchIdx](auto /*row*/) {
+                  return batchIdx == 0 ? "hello" : "WORLD";
+                }),
+            });
+      });
+
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .injectSpill(false)
+      .numDrivers(numDrivers_)
+      .probeKeys({"t0"})
+      .probeVectors(std::move(probeVectors))
+      .buildKeys({"u0"})
+      .buildVectors(std::move(buildVectors))
+      .joinType(core::JoinType::kLeft)
+      .joinFilter("lower(t1) = lower(u1)")
+      .joinOutputLayout({"t0", "t1", "u0", "u1"})
+      .referenceQuery(
+          "SELECT t.t0, t.t1, u.u0, u.u1 FROM t LEFT JOIN u "
+          "ON t.t0 = u.u0 AND lower(t.t1) = lower(u.u1)")
+      .config(cudf_velox::CudfFromVelox::kGpuBatchSizeRows, "10")
+      .run();
+}
+
+// Full join with multiple build batches. Tests both probe-side and build-side
+// unmatched row emission.
+TEST_P(MultiThreadedHashJoinTest, fullJoinBatchedBuild) {
+  auto& cudfConfig = cudf_velox::CudfConfig::getInstance();
+  cudfConfig.batchSizeMinThreshold = 10;
+  cudfConfig.batchSizeMaxThreshold = 10;
+
+  // Probe keys [0..4, 100..102]. Keys 0-4 match build, 100-102 don't.
+  std::vector<RowVectorPtr> probeVectors = {makeRowVector(
+      {"c0", "c1"},
+      {
+          makeFlatVector<int32_t>({0, 1, 2, 3, 4, 100, 101, 102}),
+          makeFlatVector<int32_t>({10, 11, 12, 13, 14, 15, 16, 17}),
+      })};
+
+  // Build: 3 batches of 10 rows. Batch 0 has keys [200..209] (no probe
+  // match), batch 1 has keys [0..9] (keys 0-4 match probe, 5-9 don't),
+  // batch 2 has keys [300..309] (no probe match). Build keys 5-9, 200-209,
+  // 300-309 are unmatched and should appear with NULL probe columns.
+  std::vector<RowVectorPtr> buildVectors =
+      makeBatches(3, [&](int32_t batchIdx) {
+        return makeRowVector({
+            makeFlatVector<int32_t>(10, [batchIdx](auto row) {
+              if (batchIdx == 1) {
+                return static_cast<int32_t>(row);
+              }
+              return static_cast<int32_t>(
+                  (batchIdx == 0 ? 200 : 300) + row);
+            }),
+            makeFlatVector<int32_t>(
+                10, [batchIdx](auto row) { return batchIdx * 100 + row; }),
+        });
+      });
+
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .injectSpill(false)
+      .numDrivers(numDrivers_)
+      .probeKeys({"c0"})
+      .probeVectors(std::move(probeVectors))
+      .buildKeys({"u_c0"})
+      .buildVectors(std::move(buildVectors))
+      .buildProjections({"c0 AS u_c0", "c1 AS u_c1"})
+      .joinType(core::JoinType::kFull)
+      .joinOutputLayout({"c0", "c1", "u_c0", "u_c1"})
+      .referenceQuery(
+          "SELECT t.c0, t.c1, u.c0, u.c1 FROM t FULL OUTER JOIN u "
+          "ON t.c0 = u.c0")
+      .config(cudf_velox::CudfFromVelox::kGpuBatchSizeRows, "10")
+      .run();
+}
+
+// Full join with AST filter and multiple build batches.
+TEST_P(MultiThreadedHashJoinTest, fullJoinBatchedBuildWithFilter) {
+  auto& cudfConfig = cudf_velox::CudfConfig::getInstance();
+  cudfConfig.batchSizeMinThreshold = 10;
+  cudfConfig.batchSizeMaxThreshold = 10;
+
+  // Probe keys [0..7].
+  std::vector<RowVectorPtr> probeVectors = {makeRowVector(
+      {"c0", "c1"},
+      {
+          makeFlatVector<int32_t>(8, [](auto row) { return row; }),
+          makeFlatVector<int32_t>(8, [](auto row) { return row; }),
+      })};
+
+  // Build: 2 batches of 10 rows each. Both have keys [0..9]. The filter
+  // will select only some pairs.
+  std::vector<RowVectorPtr> buildVectors =
+      makeBatches(2, [&](int32_t batchIdx) {
+        return makeRowVector({
+            makeFlatVector<int32_t>(10, [](auto row) { return row; }),
+            makeFlatVector<int32_t>(
+                10, [batchIdx](auto row) { return batchIdx * 10 + row; }),
+        });
+      });
+
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .injectSpill(false)
+      .numDrivers(numDrivers_)
+      .probeKeys({"c0"})
+      .probeVectors(std::move(probeVectors))
+      .buildKeys({"u_c0"})
+      .buildVectors(std::move(buildVectors))
+      .buildProjections({"c0 AS u_c0", "c1 AS u_c1"})
+      .joinType(core::JoinType::kFull)
+      .joinFilter("(c1 + u_c1) % 2 = 1")
+      .joinOutputLayout({"c0", "c1", "u_c1"})
+      .referenceQuery(
+          "SELECT t.c0, t.c1, u.c1 FROM t FULL OUTER JOIN u ON t.c0 = u.c0 "
+          "AND (t.c1 + u.c1) % 2 = 1")
+      .config(cudf_velox::CudfFromVelox::kGpuBatchSizeRows, "10")
       .run();
 }
 

--- a/velox/experimental/cudf/tests/HashJoinTest.cpp
+++ b/velox/experimental/cudf/tests/HashJoinTest.cpp
@@ -1760,8 +1760,14 @@ TEST_P(MultiThreadedHashJoinTest, leftJoinBatchedBuild) {
   // [100..102], and a null key — testing matched, unmatched, and null-key paths
   // across multiple build batches.
   auto& cudfConfig = cudf_velox::CudfConfig::getInstance();
+  auto savedMin = cudfConfig.batchSizeMinThreshold;
+  auto savedMax = cudfConfig.batchSizeMaxThreshold;
   cudfConfig.batchSizeMinThreshold = 10;
   cudfConfig.batchSizeMaxThreshold = 10;
+  SCOPE_EXIT {
+    cudfConfig.batchSizeMinThreshold = savedMin;
+    cudfConfig.batchSizeMaxThreshold = savedMax;
+  };
 
   std::vector<RowVectorPtr> probeVectors = {makeRowVector(
       {"c0", "c1", "row_number"},
@@ -1808,8 +1814,14 @@ TEST_P(MultiThreadedHashJoinTest, leftJoinBatchedBuild) {
 // accumulates correctly via BITWISE_OR across batches.
 TEST_P(MultiThreadedHashJoinTest, leftJoinBatchedBuildMatchesAcrossBatches) {
   auto& cudfConfig = cudf_velox::CudfConfig::getInstance();
+  auto savedMin = cudfConfig.batchSizeMinThreshold;
+  auto savedMax = cudfConfig.batchSizeMaxThreshold;
   cudfConfig.batchSizeMinThreshold = 10;
   cudfConfig.batchSizeMaxThreshold = 10;
+  SCOPE_EXIT {
+    cudfConfig.batchSizeMinThreshold = savedMin;
+    cudfConfig.batchSizeMaxThreshold = savedMax;
+  };
 
   // Probe keys [0..9]. Even keys match batch 0, odd keys match batch 1.
   std::vector<RowVectorPtr> probeVectors = {makeRowVector(
@@ -1855,8 +1867,14 @@ TEST_P(MultiThreadedHashJoinTest, leftJoinBatchedBuildMatchesAcrossBatches) {
 // all matched pairs appear and no spurious unmatched-with-NULL row is emitted.
 TEST_P(MultiThreadedHashJoinTest, leftJoinBatchedBuildDuplicateMatches) {
   auto& cudfConfig = cudf_velox::CudfConfig::getInstance();
+  auto savedMin = cudfConfig.batchSizeMinThreshold;
+  auto savedMax = cudfConfig.batchSizeMaxThreshold;
   cudfConfig.batchSizeMinThreshold = 10;
   cudfConfig.batchSizeMaxThreshold = 10;
+  SCOPE_EXIT {
+    cudfConfig.batchSizeMinThreshold = savedMin;
+    cudfConfig.batchSizeMaxThreshold = savedMax;
+  };
 
   // Probe has a single key=1.
   std::vector<RowVectorPtr> probeVectors = {makeRowVector(
@@ -1895,8 +1913,14 @@ TEST_P(MultiThreadedHashJoinTest, leftJoinBatchedBuildDuplicateMatches) {
 // Left join with an AST-compatible filter and multiple build batches.
 TEST_P(MultiThreadedHashJoinTest, leftJoinBatchedBuildWithFilter) {
   auto& cudfConfig = cudf_velox::CudfConfig::getInstance();
+  auto savedMin = cudfConfig.batchSizeMinThreshold;
+  auto savedMax = cudfConfig.batchSizeMaxThreshold;
   cudfConfig.batchSizeMinThreshold = 10;
   cudfConfig.batchSizeMaxThreshold = 10;
+  SCOPE_EXIT {
+    cudfConfig.batchSizeMinThreshold = savedMin;
+    cudfConfig.batchSizeMaxThreshold = savedMax;
+  };
 
   // Probe keys [0..9] with c1 values.
   std::vector<RowVectorPtr> probeVectors = {makeRowVector(
@@ -1943,8 +1967,14 @@ TEST_P(MultiThreadedHashJoinTest, leftJoinBatchedBuildWithFilter) {
 // and multiple build batches. Tests the filterFunc lambda match tracking path.
 TEST_P(MultiThreadedHashJoinTest, leftJoinBatchedBuildWithNonAstFilter) {
   auto& cudfConfig = cudf_velox::CudfConfig::getInstance();
+  auto savedMin = cudfConfig.batchSizeMinThreshold;
+  auto savedMax = cudfConfig.batchSizeMaxThreshold;
   cudfConfig.batchSizeMinThreshold = 10;
   cudfConfig.batchSizeMaxThreshold = 10;
+  SCOPE_EXIT {
+    cudfConfig.batchSizeMinThreshold = savedMin;
+    cudfConfig.batchSizeMaxThreshold = savedMax;
+  };
 
   std::vector<RowVectorPtr> probeVectors = {makeRowVector(
       {"t0", "t1"},
@@ -1993,8 +2023,14 @@ TEST_P(MultiThreadedHashJoinTest, leftJoinBatchedBuildWithNonAstFilter) {
 // unmatched row emission.
 TEST_P(MultiThreadedHashJoinTest, fullJoinBatchedBuild) {
   auto& cudfConfig = cudf_velox::CudfConfig::getInstance();
+  auto savedMin = cudfConfig.batchSizeMinThreshold;
+  auto savedMax = cudfConfig.batchSizeMaxThreshold;
   cudfConfig.batchSizeMinThreshold = 10;
   cudfConfig.batchSizeMaxThreshold = 10;
+  SCOPE_EXIT {
+    cudfConfig.batchSizeMinThreshold = savedMin;
+    cudfConfig.batchSizeMaxThreshold = savedMax;
+  };
 
   // Probe keys [0..4, 100..102]. Keys 0-4 match build, 100-102 don't.
   std::vector<RowVectorPtr> probeVectors = {makeRowVector(
@@ -2045,8 +2081,14 @@ TEST_P(MultiThreadedHashJoinTest, fullJoinBatchedBuild) {
 // Full join with AST filter and multiple build batches.
 TEST_P(MultiThreadedHashJoinTest, fullJoinBatchedBuildWithFilter) {
   auto& cudfConfig = cudf_velox::CudfConfig::getInstance();
+  auto savedMin = cudfConfig.batchSizeMinThreshold;
+  auto savedMax = cudfConfig.batchSizeMaxThreshold;
   cudfConfig.batchSizeMinThreshold = 10;
   cudfConfig.batchSizeMaxThreshold = 10;
+  SCOPE_EXIT {
+    cudfConfig.batchSizeMinThreshold = savedMin;
+    cudfConfig.batchSizeMaxThreshold = savedMax;
+  };
 
   // Probe keys [0..7].
   std::vector<RowVectorPtr> probeVectors = {makeRowVector(

--- a/velox/experimental/cudf/tests/HashJoinTest.cpp
+++ b/velox/experimental/cudf/tests/HashJoinTest.cpp
@@ -1778,9 +1778,11 @@ TEST_P(MultiThreadedHashJoinTest, leftJoinBatchedBuild) {
   std::vector<RowVectorPtr> buildVectors =
       makeBatches(3, [&](int32_t batchIdx) {
         return makeRowVector({
-            makeFlatVector<int32_t>(10, [batchIdx](auto row) {
-              return batchIdx < 2 ? 200 + batchIdx * 10 + row : row;
-            }),
+            makeFlatVector<int32_t>(
+                10,
+                [batchIdx](auto row) {
+                  return batchIdx < 2 ? 200 + batchIdx * 10 + row : row;
+                }),
             makeFlatVector<int32_t>(
                 10, [batchIdx](auto row) { return batchIdx * 100 + row; }),
         });
@@ -1822,10 +1824,12 @@ TEST_P(MultiThreadedHashJoinTest, leftJoinBatchedBuildMatchesAcrossBatches) {
   std::vector<RowVectorPtr> buildVectors =
       makeBatches(2, [&](int32_t batchIdx) {
         return makeRowVector({
-            makeFlatVector<int32_t>(10, [batchIdx](auto row) {
-              return row < 5 ? batchIdx + row * 2
-                             : (batchIdx + 2) * 100 + row;
-            }),
+            makeFlatVector<int32_t>(
+                10,
+                [batchIdx](auto row) {
+                  return row < 5 ? batchIdx + row * 2
+                                 : (batchIdx + 2) * 100 + row;
+                }),
             makeFlatVector<int32_t>(
                 10, [batchIdx](auto row) { return batchIdx * 100 + row; }),
         });
@@ -1960,9 +1964,11 @@ TEST_P(MultiThreadedHashJoinTest, leftJoinBatchedBuildWithNonAstFilter) {
             {"u0", "u1"},
             {
                 makeFlatVector<int64_t>(10, [](auto row) { return row; }),
-                makeFlatVector<std::string>(10, [batchIdx](auto /*row*/) {
-                  return batchIdx == 0 ? "hello" : "WORLD";
-                }),
+                makeFlatVector<std::string>(
+                    10,
+                    [batchIdx](auto /*row*/) {
+                      return batchIdx == 0 ? "hello" : "WORLD";
+                    }),
             });
       });
 
@@ -2005,13 +2011,15 @@ TEST_P(MultiThreadedHashJoinTest, fullJoinBatchedBuild) {
   std::vector<RowVectorPtr> buildVectors =
       makeBatches(3, [&](int32_t batchIdx) {
         return makeRowVector({
-            makeFlatVector<int32_t>(10, [batchIdx](auto row) {
-              if (batchIdx == 1) {
-                return static_cast<int32_t>(row);
-              }
-              return static_cast<int32_t>(
-                  (batchIdx == 0 ? 200 : 300) + row);
-            }),
+            makeFlatVector<int32_t>(
+                10,
+                [batchIdx](auto row) {
+                  if (batchIdx == 1) {
+                    return static_cast<int32_t>(row);
+                  }
+                  return static_cast<int32_t>(
+                      (batchIdx == 0 ? 200 : 300) + row);
+                }),
             makeFlatVector<int32_t>(
                 10, [batchIdx](auto row) { return batchIdx * 100 + row; }),
         });


### PR DESCRIPTION
### Summary

When there are multiple build-side batches, and we perform a left-join or a full-join, the current implementation incorrectly inserts a probe row for each build batch. That is, with N build batches, a probe row matching only in the last batch would incorrectly produce N output rows (N-1 spurious null-build rows + 1 correct match), instead of just the 1 correct match.

### Implementation idea

The fix follows the pattern already used by right joins (for build-side match tracking) and left semi-project joins (for probe-side match tracking):
1. Use inner join per batch to first produce only matched pairs
2. Track which probe rows matched in any batch in a single vector that is updated after each batch is processed
3. For filtered joins, track the matched probe rows from post-filter indices 
4. Finally, emit unmatched probe rows with the cuDF `JoinNoMatch` sentinel for right indices