### PR TITLE
fix(gcs): Improve GCS error diagnostics

### DIFF
--- a/velox/connectors/hive/storage_adapters/gcs/GcsUtil.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/GcsUtil.cpp
@@ -38,46 +38,7 @@ bool isRetryableGcsStatus(google::cloud::StatusCode code) {
 } // namespace
 
 std::string getErrorStringFromGcsError(const google::cloud::StatusCode& code) {
-  using ::google::cloud::StatusCode;
-
-  switch (code) {
-    case StatusCode::kOk:
-      return "No error";
-    case StatusCode::kCancelled:
-      return "Request cancelled";
-    case StatusCode::kUnknown:
-      return "Unknown error";
-    case StatusCode::kInvalidArgument:
-      return "Invalid argument";
-    case StatusCode::kDeadlineExceeded:
-      return "Deadline exceeded";
-    case StatusCode::kNotFound:
-      return "Resource not found";
-    case StatusCode::kAlreadyExists:
-      return "Resource already exists";
-    case StatusCode::kPermissionDenied:
-      return "Access denied";
-    case StatusCode::kResourceExhausted:
-      return "Resource exhausted";
-    case StatusCode::kFailedPrecondition:
-      return "Failed precondition";
-    case StatusCode::kAborted:
-      return "Request aborted";
-    case StatusCode::kOutOfRange:
-      return "Out of range";
-    case StatusCode::kUnimplemented:
-      return "Operation not implemented";
-    case StatusCode::kInternal:
-      return "Internal error";
-    case StatusCode::kUnavailable:
-      return "Service unavailable";
-    case StatusCode::kDataLoss:
-      return "Data loss";
-    case StatusCode::kUnauthenticated:
-      return "Unauthenticated";
-    default:
-      return google::cloud::StatusCodeToString(code);
-  }
+  return google::cloud::StatusCodeToString(code);
 }
 
 void checkGcsStatus(

--- a/velox/connectors/hive/storage_adapters/gcs/GcsUtil.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/GcsUtil.cpp
@@ -37,10 +37,6 @@ bool isRetryableGcsStatus(google::cloud::StatusCode code) {
 
 } // namespace
 
-std::string getErrorStringFromGcsError(const google::cloud::StatusCode& code) {
-  return google::cloud::StatusCodeToString(code);
-}
-
 void checkGcsStatus(
     const google::cloud::Status outcome,
     const std::string_view& errorMsgPrefix,
@@ -51,7 +47,7 @@ void checkGcsStatus(
         "{} due to: Path:'{}', GCS Status Code:{}, Error Domain:'{}', Error Reason:'{}', Message:'{}'",
         errorMsgPrefix,
         gcsURI(bucket, key),
-        getErrorStringFromGcsError(outcome.code()),
+        google::cloud::StatusCodeToString(outcome.code()),
         outcome.error_info().domain(),
         outcome.error_info().reason(),
         outcome.message());

--- a/velox/connectors/hive/storage_adapters/gcs/GcsUtil.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/GcsUtil.cpp
@@ -18,19 +18,65 @@
 
 namespace facebook::velox {
 
+namespace {
+
+// Returns true for status codes treated as transient by the GCS retry policy.
+bool isRetryableGcsStatus(google::cloud::StatusCode code) {
+  using ::google::cloud::StatusCode;
+
+  switch (code) {
+    case StatusCode::kDeadlineExceeded:
+    case StatusCode::kInternal:
+    case StatusCode::kResourceExhausted:
+    case StatusCode::kUnavailable:
+      return true;
+    default:
+      return false;
+  }
+}
+
+} // namespace
+
 std::string getErrorStringFromGcsError(const google::cloud::StatusCode& code) {
   using ::google::cloud::StatusCode;
 
   switch (code) {
+    case StatusCode::kOk:
+      return "No error";
+    case StatusCode::kCancelled:
+      return "Request cancelled";
+    case StatusCode::kUnknown:
+      return "Unknown error";
+    case StatusCode::kInvalidArgument:
+      return "Invalid argument";
+    case StatusCode::kDeadlineExceeded:
+      return "Deadline exceeded";
     case StatusCode::kNotFound:
       return "Resource not found";
+    case StatusCode::kAlreadyExists:
+      return "Resource already exists";
     case StatusCode::kPermissionDenied:
       return "Access denied";
+    case StatusCode::kResourceExhausted:
+      return "Resource exhausted";
+    case StatusCode::kFailedPrecondition:
+      return "Failed precondition";
+    case StatusCode::kAborted:
+      return "Request aborted";
+    case StatusCode::kOutOfRange:
+      return "Out of range";
+    case StatusCode::kUnimplemented:
+      return "Operation not implemented";
+    case StatusCode::kInternal:
+      return "Internal error";
     case StatusCode::kUnavailable:
       return "Service unavailable";
-
+    case StatusCode::kDataLoss:
+      return "Data loss";
+    case StatusCode::kUnauthenticated:
+      return "Unauthenticated";
     default:
-      return "Unknown error";
+      return google::cloud::StatusCodeToString(code);
   }
 }
 
@@ -40,17 +86,23 @@ void checkGcsStatus(
     const std::string& bucket,
     const std::string& key) {
   if (!outcome.ok()) {
-    const auto errMsg = fmt::format(
-        "{} due to: Path:'{}', SDK Error Type:{}, GCS Status Code:{},  Message:'{}'",
+    auto errorMessage = fmt::format(
+        "{} due to: Path:'{}', GCS Status Code:{}, Error Domain:'{}', Error Reason:'{}', Message:'{}'",
         errorMsgPrefix,
         gcsURI(bucket, key),
-        outcome.error_info().domain(),
         getErrorStringFromGcsError(outcome.code()),
+        outcome.error_info().domain(),
+        outcome.error_info().reason(),
         outcome.message());
-    if (outcome.code() == google::cloud::StatusCode::kNotFound) {
-      VELOX_FILE_NOT_FOUND_ERROR(errMsg);
+    if (isRetryableGcsStatus(outcome.code())) {
+      errorMessage.append(
+          " This GCS error is transient. Consider increasing "
+          "'hive.gcs.max-retry-count' or 'hive.gcs.max-retry-time'.");
     }
-    VELOX_FAIL(errMsg);
+    if (outcome.code() == google::cloud::StatusCode::kNotFound) {
+      VELOX_FILE_NOT_FOUND_ERROR(errorMessage);
+    }
+    VELOX_FAIL(errorMessage);
   }
 }
 

--- a/velox/connectors/hive/storage_adapters/gcs/GcsUtil.h
+++ b/velox/connectors/hive/storage_adapters/gcs/GcsUtil.h
@@ -38,8 +38,6 @@ constexpr std::string_view kGcsScheme{"gs://"};
 
 } // namespace
 
-std::string getErrorStringFromGcsError(const google::cloud::StatusCode& error);
-
 inline bool isGcsFile(const std::string_view filename) {
   return (filename.substr(0, kGcsScheme.size()) == kGcsScheme);
 }

--- a/velox/connectors/hive/storage_adapters/gcs/tests/GcsUtilTest.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/tests/GcsUtilTest.cpp
@@ -20,6 +20,8 @@
 #include <utility>
 #include <vector>
 
+#include "velox/common/base/tests/GTestUtils.h"
+
 #include "gtest/gtest.h"
 
 using namespace facebook::velox;

--- a/velox/connectors/hive/storage_adapters/gcs/tests/GcsUtilTest.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/tests/GcsUtilTest.cpp
@@ -16,6 +16,10 @@
 
 #include "velox/connectors/hive/storage_adapters/gcs/GcsUtil.h"
 
+#include <string>
+#include <utility>
+#include <vector>
+
 #include "gtest/gtest.h"
 
 using namespace facebook::velox;
@@ -33,4 +37,51 @@ TEST(GcsUtilTest, setBucketAndKeyFromGcsPath) {
   setBucketAndKeyFromGcsPath(path, bucket, key);
   EXPECT_EQ(bucket, "bucket");
   EXPECT_EQ(key, "file.txt");
+}
+
+TEST(GcsUtilTest, errorString) {
+  using google::cloud::StatusCode;
+
+  const std::vector<std::pair<StatusCode, std::string>> testCases{
+      {StatusCode::kOk, "No error"},
+      {StatusCode::kCancelled, "Request cancelled"},
+      {StatusCode::kUnknown, "Unknown error"},
+      {StatusCode::kInvalidArgument, "Invalid argument"},
+      {StatusCode::kDeadlineExceeded, "Deadline exceeded"},
+      {StatusCode::kNotFound, "Resource not found"},
+      {StatusCode::kAlreadyExists, "Resource already exists"},
+      {StatusCode::kPermissionDenied, "Access denied"},
+      {StatusCode::kResourceExhausted, "Resource exhausted"},
+      {StatusCode::kFailedPrecondition, "Failed precondition"},
+      {StatusCode::kAborted, "Request aborted"},
+      {StatusCode::kOutOfRange, "Out of range"},
+      {StatusCode::kUnimplemented, "Operation not implemented"},
+      {StatusCode::kInternal, "Internal error"},
+      {StatusCode::kUnavailable, "Service unavailable"},
+      {StatusCode::kDataLoss, "Data loss"},
+      {StatusCode::kUnauthenticated, "Unauthenticated"},
+  };
+
+  for (const auto& [statusCode, expectedMessage] : testCases) {
+    EXPECT_EQ(getErrorStringFromGcsError(statusCode), expectedMessage);
+  }
+
+  EXPECT_EQ(
+      getErrorStringFromGcsError(static_cast<StatusCode>(123)),
+      "UNEXPECTED_STATUS_CODE=123");
+}
+
+TEST(GcsUtilTest, statusError) {
+  const google::cloud::Status status{
+      google::cloud::StatusCode::kResourceExhausted,
+      "Quota exceeded",
+      google::cloud::ErrorInfo{
+          "RATE_LIMIT_EXCEEDED",
+          "storage.googleapis.com",
+          {},
+      }};
+
+  VELOX_ASSERT_THROW(
+      checkGcsStatus(status, "Failed to read GCS object", "bucket", "key"),
+      "Failed to read GCS object due to: Path:'gs://bucket/key', GCS Status Code:Resource exhausted, Error Domain:'storage.googleapis.com', Error Reason:'RATE_LIMIT_EXCEEDED', Message:'Quota exceeded' This GCS error is transient. Consider increasing 'hive.gcs.max-retry-count' or 'hive.gcs.max-retry-time'.");
 }

--- a/velox/connectors/hive/storage_adapters/gcs/tests/GcsUtilTest.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/tests/GcsUtilTest.cpp
@@ -17,8 +17,6 @@
 #include "velox/connectors/hive/storage_adapters/gcs/GcsUtil.h"
 
 #include <string>
-#include <utility>
-#include <vector>
 
 #include "velox/common/base/tests/GTestUtils.h"
 
@@ -41,38 +39,6 @@ TEST(GcsUtilTest, setBucketAndKeyFromGcsPath) {
   EXPECT_EQ(key, "file.txt");
 }
 
-TEST(GcsUtilTest, errorString) {
-  using google::cloud::StatusCode;
-
-  const std::vector<std::pair<StatusCode, std::string>> testCases{
-      {StatusCode::kOk, "No error"},
-      {StatusCode::kCancelled, "Request cancelled"},
-      {StatusCode::kUnknown, "Unknown error"},
-      {StatusCode::kInvalidArgument, "Invalid argument"},
-      {StatusCode::kDeadlineExceeded, "Deadline exceeded"},
-      {StatusCode::kNotFound, "Resource not found"},
-      {StatusCode::kAlreadyExists, "Resource already exists"},
-      {StatusCode::kPermissionDenied, "Access denied"},
-      {StatusCode::kResourceExhausted, "Resource exhausted"},
-      {StatusCode::kFailedPrecondition, "Failed precondition"},
-      {StatusCode::kAborted, "Request aborted"},
-      {StatusCode::kOutOfRange, "Out of range"},
-      {StatusCode::kUnimplemented, "Operation not implemented"},
-      {StatusCode::kInternal, "Internal error"},
-      {StatusCode::kUnavailable, "Service unavailable"},
-      {StatusCode::kDataLoss, "Data loss"},
-      {StatusCode::kUnauthenticated, "Unauthenticated"},
-  };
-
-  for (const auto& [statusCode, expectedMessage] : testCases) {
-    EXPECT_EQ(getErrorStringFromGcsError(statusCode), expectedMessage);
-  }
-
-  EXPECT_EQ(
-      getErrorStringFromGcsError(static_cast<StatusCode>(123)),
-      "UNEXPECTED_STATUS_CODE=123");
-}
-
 TEST(GcsUtilTest, statusError) {
   const google::cloud::Status status{
       google::cloud::StatusCode::kResourceExhausted,
@@ -85,5 +51,5 @@ TEST(GcsUtilTest, statusError) {
 
   VELOX_ASSERT_THROW(
       checkGcsStatus(status, "Failed to read GCS object", "bucket", "key"),
-      "Failed to read GCS object due to: Path:'gs://bucket/key', GCS Status Code:Resource exhausted, Error Domain:'storage.googleapis.com', Error Reason:'RATE_LIMIT_EXCEEDED', Message:'Quota exceeded' This GCS error is transient. Consider increasing 'hive.gcs.max-retry-count' or 'hive.gcs.max-retry-time'.");
+      "Failed to read GCS object due to: Path:'gs://bucket/key', GCS Status Code:RESOURCE_EXHAUSTED, Error Domain:'storage.googleapis.com', Error Reason:'RATE_LIMIT_EXCEEDED', Message:'Quota exceeded' This GCS error is transient. Consider increasing 'hive.gcs.max-retry-count' or 'hive.gcs.max-retry-time'.");
 }


### PR DESCRIPTION
## Summary

Improve GCS failure diagnostics by replacing generic unknown-error labels with
descriptive status messages and surfacing the structured error domain and reason.

For status codes classified as transient by the google-cloud-cpp Storage retry
policy, point users to the existing GCS retry configuration options. This makes
failures more actionable while preserving file-not-found handling.