### PR TITLE
refactor: Make AggregateCallExpr::dropAlias overridable (#18151)

### DIFF
--- a/velox/parse/Expressions.cpp
+++ b/velox/parse/Expressions.cpp
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <typeinfo>
+
 #include "velox/parse/Expressions.h"
 
 #include "velox/common/EnumDefine.h"
@@ -130,6 +132,14 @@ std::string CallExpr::toString() const {
 
 bool AggregateCallExpr::operator==(const IExpr& other) const {
   if (!other.is(Kind::kAggregate)) {
+    return false;
+  }
+
+  // Require the exact concrete type so equality stays symmetric with subclasses
+  // that carry extra state. Without this a base AggregateCallExpr could compare
+  // equal to a subclass instance while the subclass's operator== returns false
+  // for the reverse comparison.
+  if (typeid(*this) != typeid(other)) {
     return false;
   }
 

--- a/velox/parse/Expressions.h
+++ b/velox/parse/Expressions.h
@@ -213,7 +213,7 @@ class AggregateCallExpr : public CallExpr {
         name(), inputs(), distinct_, filter_, orderBy_, alias);
   }
 
-  ExprPtr dropAlias() const final {
+  ExprPtr dropAlias() const override {
     return std::make_shared<AggregateCallExpr>(
         name(), inputs(), distinct_, filter_, orderBy_, std::nullopt);
   }


### PR DESCRIPTION
Summary:

`AggregateCallExpr::dropAlias()` was marked `final`, unlike its sibling clone methods `replaceInputs()` and `withAlias()`, which are `override`. That prevented a subclass from returning its own type when an alias is dropped: the `final` version always reconstructs a plain `AggregateCallExpr`, dropping any subclass type and fields. Relax it to `override` so subclasses can preserve their type, consistent with the other clone methods.

Reviewed By: amitkdutta

Differential Revision: D112240433


