### PR TITLE
feat: Introduce VeloxException::properties() for durable context extraction (#18153)

### DIFF
--- a/velox/common/base/VeloxException.cpp
+++ b/velox/common/base/VeloxException.cpp
@@ -101,6 +101,7 @@ VeloxException::VeloxException(
         state.context = getExceptionContext().message(exceptionType);
         state.additionalContext =
             getAdditionalExceptionContextString(exceptionType, state.context);
+        state.properties = getExceptionContext().properties(exceptionType);
         state.isRetriable = isRetriable;
       })) {}
 
@@ -130,6 +131,7 @@ VeloxException::VeloxException(
         state.context = getExceptionContext().message(exceptionType);
         state.additionalContext =
             getAdditionalExceptionContextString(exceptionType, state.context);
+        state.properties = getExceptionContext().properties(exceptionType);
         state.isRetriable = isRetriable;
       })) {}
 
@@ -154,6 +156,7 @@ VeloxException::VeloxException(
         state.context = getExceptionContext().message(exceptionType);
         state.additionalContext =
             getAdditionalExceptionContextString(exceptionType, state.context);
+        state.properties = getExceptionContext().properties(exceptionType);
         state.isRetriable = isRetriable;
         state.wrappedException = e;
       })) {}

--- a/velox/common/base/VeloxException.h
+++ b/velox/common/base/VeloxException.h
@@ -17,10 +17,15 @@
 #pragma once
 
 #include <exception>
+#include <memory>
 #include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
 
 #include <folly/Exception.h>
 #include <folly/FixedString.h>
+#include <folly/ScopeGuard.h>
 #include <folly/String.h>
 #include <folly/synchronization/CallOnce.h>
 #include <gflags/gflags.h>
@@ -38,6 +43,28 @@ DECLARE_int32(velox_exception_system_stacktrace_rate_limit_ms);
 
 namespace facebook {
 namespace velox {
+
+/// Base class for typed, structured context attached to a VeloxException via
+/// ExceptionContext::propertiesFunc (see VeloxException::properties()).
+/// Consumers dynamic_cast to the concrete subtype they understand, so different
+/// producers can attach distinct typed context without the key collisions a
+/// shared string map would risk.
+class ExceptionContextProperties {
+ public:
+  virtual ~ExceptionContextProperties() = default;
+};
+
+/// Structured context for an error thrown while evaluating an expression: the
+/// function owner (empty when the function has no registered owner), the
+/// function name, and the expression string.
+struct ExpressionExceptionProperties : public ExceptionContextProperties {
+  /// The owner registered for the failing function; empty when none.
+  std::string owner;
+  /// The name of the failing function (Expr::name()), e.g. the UDF name.
+  std::string functionName;
+  /// The string form of the expression that threw (Expr::toString()).
+  std::string expression;
+};
 
 namespace error_source {
 using namespace folly::string_literals;
@@ -261,6 +288,15 @@ class VeloxException : public std::exception {
     return state_->additionalContext;
   }
 
+  /// Typed, structured context propagated onto the exception (e.g. an
+  /// ExpressionExceptionProperties for an expression-evaluation error),
+  /// collected from ExceptionContext::propertiesFunc. Consumers dynamic_cast to
+  /// the concrete type to read structured attribution without parsing the
+  /// formatted context string. Null when no context in the chain provided one.
+  const std::shared_ptr<const ExceptionContextProperties>& properties() const {
+    return state_->properties;
+  }
+
   const std::exception_ptr& wrappedException() const {
     return state_->wrappedException;
   }
@@ -285,6 +321,8 @@ class VeloxException : public std::exception {
     std::string context;
     // The top-level ancestor of the current exception context.
     std::string additionalContext;
+    // Typed, structured context collected from the exception context chain.
+    std::shared_ptr<const ExceptionContextProperties> properties;
     bool isRetriable;
     // The original std::exception.
     std::exception_ptr wrappedException;
@@ -471,6 +509,10 @@ class ScopedThreadSkipErrorDetails {
 struct ExceptionContext {
   using MessageFunction =
       std::string (*)(VeloxException::Type exceptionType, void* arg);
+  using PropertiesFunction =
+      std::shared_ptr<const ExceptionContextProperties> (*)(
+          VeloxException::Type exceptionType,
+          void* arg);
 
   /// Function to call in case of an exception to get additional context.
   MessageFunction messageFunc{nullptr};
@@ -481,6 +523,13 @@ struct ExceptionContext {
   /// If true, then the addition context in 'this' is always included when there
   /// are hierarchical exception contexts.
   bool isEssential{false};
+
+  /// Optional structured counterpart to `messageFunc`: returns typed context
+  /// (e.g. ExpressionExceptionProperties) collected onto
+  /// VeloxException::properties() at throw time. Called with the same `arg` as
+  /// `messageFunc`. Declared after the fields above to preserve positional
+  /// aggregate initialization of the leading members.
+  PropertiesFunction propertiesFunc{nullptr};
 
   /// Pointer to the parent context when there are hierarchical exception
   /// contexts.
@@ -493,18 +542,47 @@ struct ExceptionContext {
       return "";
     }
 
-    std::string theMessage;
+    // `suspended` gates re-entry: while messageFunc runs, a VeloxException it
+    // throws would re-invoke it via this same context. The guard restores the
+    // flag on every exit (normal or throw), so a failure never leaves the
+    // context stuck-suspended.
+    suspended = true;
+    auto guard = folly::makeGuard([this] { suspended = false; });
 
     try {
-      // Make sure not to call messageFunc again in case it throws.
-      suspended = true;
-      theMessage = messageFunc(exceptionType, arg);
-      suspended = false;
+      return messageFunc(exceptionType, arg);
     } catch (...) {
       return "Failed to produce additional context.";
     }
+  }
 
-    return theMessage;
+  /// Walks the context chain from this context outward and returns the
+  /// inner-most typed properties (the first context that provides them), or
+  /// null if none do. Structured counterpart to message() (which returns only
+  /// this context's string); the string chain is aggregated separately by
+  /// getAdditionalExceptionContextString().
+  std::shared_ptr<const ExceptionContextProperties> properties(
+      VeloxException::Type exceptionType) {
+    for (auto* context = this; context != nullptr; context = context->parent) {
+      if (context->propertiesFunc == nullptr || context->suspended) {
+        continue;
+      }
+      // `suspended` gates re-entry: while propertiesFunc runs, a VeloxException
+      // it throws would re-walk this chain; mark the context so the nested walk
+      // skips it. The guard restores the flag on every exit (normal or throw),
+      // mirroring message().
+      context->suspended = true;
+      auto guard = folly::makeGuard([context] { context->suspended = false; });
+      try {
+        if (auto properties =
+                context->propertiesFunc(exceptionType, context->arg)) {
+          return properties;
+        }
+      } catch (...) {
+        // Best effort; never mask the real error.
+      }
+    }
+    return nullptr;
   }
 
   bool suspended{false};

--- a/velox/common/base/tests/ExceptionTest.cpp
+++ b/velox/common/base/tests/ExceptionTest.cpp
@@ -992,6 +992,141 @@ TEST(ExceptionTest, wrappedExceptionWithContext) {
   }
 }
 
+TEST(ExceptionTest, properties) {
+  using facebook::velox::ExceptionContextProperties;
+  using facebook::velox::ExpressionExceptionProperties;
+
+  auto makeProperties =
+      [](facebook::velox::VeloxException::Type /*exceptionType*/,
+         void* untypedArg)
+      -> std::shared_ptr<const ExceptionContextProperties> {
+    auto properties = std::make_shared<ExpressionExceptionProperties>();
+    properties->owner = static_cast<const char*>(untypedArg);
+    properties->functionName = "expr";
+    properties->expression = "expr(c0)";
+    return properties;
+  };
+
+  // No properties context: properties() is null.
+  try {
+    throw std::invalid_argument("boom");
+  } catch (const std::exception& e) {
+    VeloxUserError ve(std::current_exception(), e.what(), false);
+    EXPECT_EQ(ve.properties(), nullptr);
+  }
+
+  const char* outer = "outer-team";
+  facebook::velox::ExceptionContextSetter outerContext(
+      {.arg = (void*)outer, .propertiesFunc = makeProperties});
+  try {
+    throw std::invalid_argument("boom");
+  } catch (const std::exception& e) {
+    VeloxUserError ve(std::current_exception(), e.what(), false);
+    auto properties =
+        std::dynamic_pointer_cast<const ExpressionExceptionProperties>(
+            ve.properties());
+    ASSERT_NE(properties, nullptr);
+    EXPECT_EQ(properties->owner, "outer-team");
+    EXPECT_EQ(properties->functionName, "expr");
+    EXPECT_EQ(properties->expression, "expr(c0)");
+  }
+
+  // The inner-most context's properties win.
+  auto makeInnerProperties =
+      [](facebook::velox::VeloxException::Type /*exceptionType*/,
+         void* /*untypedArg*/)
+      -> std::shared_ptr<const ExceptionContextProperties> {
+    auto properties = std::make_shared<ExpressionExceptionProperties>();
+    properties->owner = "inner-team";
+    properties->functionName = "innerExpr";
+    properties->expression = "expr(c1)";
+    return properties;
+  };
+  facebook::velox::ExceptionContextSetter innerContext(
+      {.arg = nullptr, .propertiesFunc = makeInnerProperties});
+  try {
+    throw std::invalid_argument("boom");
+  } catch (const std::exception& e) {
+    VeloxUserError ve(std::current_exception(), e.what(), false);
+    auto properties =
+        std::dynamic_pointer_cast<const ExpressionExceptionProperties>(
+            ve.properties());
+    ASSERT_NE(properties, nullptr);
+    EXPECT_EQ(properties->owner, "inner-team");
+    EXPECT_EQ(properties->functionName, "innerExpr");
+    EXPECT_EQ(properties->expression, "expr(c1)");
+  }
+}
+
+// A propertiesFunc that itself throws must (1) not be re-invoked by the nested
+// VeloxException it throws (re-entrancy guard), and (2) not leave the context
+// suspended, so a later exception invokes it again.
+TEST(ExceptionTest, propertiesReentrancyAndRestore) {
+  int callCount = 0;
+  auto throwingProperties =
+      [](facebook::velox::VeloxException::Type /*exceptionType*/, void* arg)
+      -> std::shared_ptr<const facebook::velox::ExceptionContextProperties> {
+    ++(*static_cast<int*>(arg));
+    VELOX_FAIL("props boom");
+  };
+  facebook::velox::ExceptionContextSetter context(
+      {.arg = &callCount, .propertiesFunc = throwingProperties});
+
+  // propertiesFunc runs once and throws; the nested VeloxException from
+  // VELOX_FAIL must not re-invoke it, so callCount stays 1 (not infinite).
+  try {
+    throw std::invalid_argument("boom");
+  } catch (const std::exception& e) {
+    VeloxUserError ve(std::current_exception(), e.what(), false);
+    EXPECT_EQ(ve.properties(), nullptr);
+  }
+  EXPECT_EQ(callCount, 1);
+
+  // The context must not be left suspended: propertiesFunc runs again. With the
+  // pre-guard code this would stay 1 (the context stayed suspended).
+  try {
+    throw std::invalid_argument("boom");
+  } catch (const std::exception& e) {
+    VeloxUserError ve(std::current_exception(), e.what(), false);
+    EXPECT_EQ(ve.properties(), nullptr);
+  }
+  EXPECT_EQ(callCount, 2);
+}
+
+// Same guarantee for messageFunc: a throwing messageFunc falls back and does
+// not leave the context suspended, so a later exception invokes it again.
+TEST(ExceptionTest, messageReentrancyAndRestore) {
+  int callCount = 0;
+  auto throwingMessage =
+      [](facebook::velox::VeloxException::Type /*exceptionType*/,
+         void* arg) -> std::string {
+    ++(*static_cast<int*>(arg));
+    VELOX_FAIL("message boom");
+  };
+  facebook::velox::ExceptionContextSetter context(
+      {.messageFunc = throwingMessage, .arg = &callCount});
+
+  try {
+    throw std::invalid_argument("boom");
+  } catch (const std::exception& e) {
+    VeloxUserError ve(std::current_exception(), e.what(), false);
+    EXPECT_THAT(
+        ve.context(),
+        testing::HasSubstr("Failed to produce additional context."));
+  }
+  EXPECT_EQ(callCount, 1);
+
+  try {
+    throw std::invalid_argument("boom");
+  } catch (const std::exception& e) {
+    VeloxUserError ve(std::current_exception(), e.what(), false);
+    EXPECT_THAT(
+        ve.context(),
+        testing::HasSubstr("Failed to produce additional context."));
+  }
+  EXPECT_EQ(callCount, 2);
+}
+
 TEST(ExceptionTest, exceptionMacroInlining) {
   // Verify that the right formatting method is inlined when using _VELOX_THROW
   // macro. This test can be removed if fmt::vformat changes behavior and starts

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -746,6 +746,36 @@ std::string onException(VeloxException::Type /*exceptionType*/, void* arg) {
   }
   return fmt::format("Owner: {}. Expression: {}", owner, expr->toString());
 }
+
+// Returns typed expression error context: the owner (if any), the function
+// name, and the expression.
+std::shared_ptr<const ExceptionContextProperties> makeExprExceptionProperties(
+    const Expr* expr) {
+  if (expr == nullptr) {
+    return nullptr;
+  }
+  auto properties = std::make_shared<ExpressionExceptionProperties>();
+  properties->owner = expr->vectorFunctionMetadata().owner;
+  properties->functionName = expr->name();
+  properties->expression = expr->toString();
+  return properties;
+}
+
+// Structured counterpart to onTopLevelException (arg is an
+// ExprExceptionContext).
+std::shared_ptr<const ExceptionContextProperties> onTopLevelExceptionProperties(
+    VeloxException::Type /*exceptionType*/,
+    void* arg) {
+  return makeExprExceptionProperties(
+      static_cast<ExprExceptionContext*>(arg)->expr());
+}
+
+// Structured counterpart to onException (arg is an Expr).
+std::shared_ptr<const ExceptionContextProperties> onExceptionProperties(
+    VeloxException::Type /*exceptionType*/,
+    void* arg) {
+  return makeExprExceptionProperties(static_cast<Expr*>(arg));
+}
 } // namespace
 
 void Expr::evalFlatNoNulls(
@@ -777,7 +807,9 @@ void Expr::evalFlatNoNullsImpl(
   ExceptionContextSetter exceptionContext(
       {.messageFunc = parentExprSet ? onTopLevelException : onException,
        .arg = parentExprSet ? (void*)&exprExceptionContext : this,
-       .isEssential = parentExprSet != nullptr});
+       .isEssential = parentExprSet != nullptr,
+       .propertiesFunc = parentExprSet ? onTopLevelExceptionProperties
+                                       : onExceptionProperties});
   auto releaseInputsGuard =
       folly::makeGuard([&]() { releaseInputValues(context); });
   if (!rows.hasSelections()) {
@@ -832,7 +864,9 @@ void Expr::eval(
   ExceptionContextSetter exceptionContext(
       {.messageFunc = parentExprSet ? onTopLevelException : onException,
        .arg = parentExprSet ? (void*)&exprExceptionContext : this,
-       .isEssential = parentExprSet != nullptr});
+       .isEssential = parentExprSet != nullptr,
+       .propertiesFunc = parentExprSet ? onTopLevelExceptionProperties
+                                       : onExceptionProperties});
 
   if (!rows.hasSelections()) {
     checkOrSetEmptyResult(type(), context.pool(), result);


### PR DESCRIPTION
Summary:

D89347702 added function ownership info but only rendered it into the exception message string, forcing consumers to parse human-readable text to extract attribution. This diff introduces structured, typed properties on exceptions: a polymorphic `ExceptionContextProperties` base plus a concrete `ExpressionExceptionProperties` (owner + expression), exposed via `VeloxException::properties()` and populated at throw through `ExceptionContext::propertiesFunc`. Downstream systems (like error translation) `dynamic_cast` to the type they understand and read attribution directly, without fragile string parsing.

A typed class is used instead of a generic `string`->`string` map: string keys risk collision across producers (e.g. a future operator's `owner` would be semantically distinct from a UDF's), and typed fields are checked at compile time rather than looked up by string key.

Reviewed By: kevinwilfong

Differential Revision: D112041191


