### PR TITLE
fix(ci): Use Velox-owned fuzzer images

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -95,7 +95,7 @@ jobs:
     # prevent errors when forks ff their main branch
     if: ${{ github.repository == 'facebookincubator/velox' }}
     runs-on: 32-core-ubuntu
-    container: ghcr.io/czentgr/czentgr-test:thrift-deps
+    container: ghcr.io/facebookincubator/velox-dev:centos9
     timeout-minutes: 120
     env:
       CCACHE_DIR: ${{ github.workspace }}/ccache
@@ -684,7 +684,7 @@ jobs:
     name: Spark Aggregate Fuzzer
     if: ${{ needs.compile.outputs.spark_aggregate_bias  != 'true' }}
     runs-on: 4-core-ubuntu
-    container: ghcr.io/czentgr/czentgr-test:spark-server
+    container: ghcr.io/facebookincubator/velox-dev:spark-server
     needs: compile
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
Summary:
Fuzzer jobs built binaries in an older thrift-deps container but ran them in Velox dev images. This allowed the compile job to link against a different `gflags` ABI; Spark fuzzer jobs then failed before startup with `libgflags.so.2.2: cannot open shared object file`.

Use the matching Velox-owned CentOS image for the fuzzer compile job and the Velox-owned Spark server image for the Spark aggregate fuzzer job.

Differential Revision: D112267846


