### PR TITLE
fix(exec): LocalExchangeSource use-after-free at teardown (#18157)

### DIFF
--- a/velox/exec/tests/utils/LocalExchangeSource.cpp
+++ b/velox/exec/tests/utils/LocalExchangeSource.cpp
@@ -182,6 +182,15 @@ class LocalExchangeSource : public exec::ExchangeSource {
   void close() override {
     checkSetRequestPromise();
 
+    {
+      // Deregister any pending timeout. A source closed with an in-flight
+      // request (e.g. when its query is cancelled) would otherwise linger in
+      // the static 'timeouts_' map until atexit, where stop() destroys it after
+      // the MemoryManager is already gone -- a use-after-free on its pool.
+      std::lock_guard<std::mutex> l(mutex_);
+      timeouts_.erase(shared_from_this());
+    }
+
     auto buffers = DefaultOutputBufferManager::getInstanceRef();
     buffers->deleteResults(remoteTaskId_, destination_);
   }


### PR DESCRIPTION
Summary:

A query cancelled while a `LocalExchangeSource` request is in flight crashes the process at teardown with a heap-use-after-free. `LocalExchangeSource` (a test util) registers each outstanding request in a `static timeouts_` map keyed by `shared_ptr<ExchangeSource>`, and installs an `atexit` handler that runs `stop()` -> `timeouts_.clear()`. An entry is removed when the request's result or timeout callback fires, but `close()` -- the cancellation path -- did not remove its entry. The closed source therefore lives until process exit, where `atexit` destroys it after the `MemoryManager` singleton is already gone, so `~MemoryPool` -> `MemoryManager::dropPool()` reads freed memory.

Erase the pending timeout in `close()`, mirroring the erase the result callback already does. The erase is a no-op once the entry was already removed, and `shared_from_this()` is safe because `close()` always runs on a live `shared_ptr` (from `ExchangeClient::close()`), never during destruction.

Reviewed By: mbasmanova

Differential Revision: D112268344


