### PR TITLE
fix(vector): Keep resized dictionaries valid over empty bases

### DIFF
--- a/velox/vector/DictionaryVector.h
+++ b/velox/vector/DictionaryVector.h
@@ -209,23 +209,21 @@ class DictionaryVector : public SimpleVector<T> {
     setInternalState();
   }
 
-  /// Resizes the vector to be of size 'size'. If setNotNull is true
-  /// the newly added elements point to the value at the 0th index.
+  /// Resizes the vector to be of size 'size'. If setNotNull is true, the
+  /// newly added elements point to the value at the 0th index, or are null if
+  /// the base vector is empty.
   /// If setNotNull is false then the values and isNull is undefined.
   void resize(vector_size_t size, bool setNotNull = true) override {
-    if (size > BaseVector::length_) {
+    const auto oldSize = BaseVector::length_;
+    if (size > oldSize) {
       BaseVector::resizeIndices(
-          BaseVector::length_,
-          size,
-          BaseVector::pool(),
-          indices_,
-          &rawIndices_);
+          oldSize, size, BaseVector::pool(), indices_, &rawIndices_);
     }
 
-    // TODO Fix the case when base vector is empty.
-    // https://github.com/facebookincubator/velox/issues/7828
-
     BaseVector::resize(size, setNotNull);
+    if (setNotNull && size > oldSize && dictionaryValues_->size() == 0) {
+      bits::fillBits(BaseVector::mutableRawNulls(), oldSize, size, bits::kNull);
+    }
   }
 
   VectorPtr slice(vector_size_t offset, vector_size_t length) const override;

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -2354,6 +2354,21 @@ TEST_F(VectorTest, dictionaryResize) {
       EXPECT_EQ(rawIndices[i], 3);
     }
   }
+
+  {
+    SCOPED_TRACE("empty base");
+    auto emptyBase = BaseVector::create(INTEGER(), 0, pool());
+    auto allNullDictionary = BaseVector::wrapInDictionary(
+        makeNulls(size, nullEvery(1)),
+        allocateIndices(size, pool()),
+        size,
+        emptyBase);
+    allNullDictionary->resize(size * 2);
+    allNullDictionary->validate();
+    for (auto i = 0; i < allNullDictionary->size(); ++i) {
+      EXPECT_TRUE(allNullDictionary->isNullAt(i));
+    }
+  }
 }
 
 TEST_F(VectorTest, acquireSharedStringBuffers) {


### PR DESCRIPTION
Summary:

`DictionaryVector::resize` initializes new dictionary indices to zero and
marks the rows non-null. This is invalid when the base vector is empty because
index zero does not exist.

Keep newly added rows null when an empty base cannot supply a valid value. Add
a regression case to `dictionaryResize` that validates the resized vector.

Validation:

```bash
pre-commit run --files \
  velox/vector/DictionaryVector.h \
  velox/vector/tests/VectorTest.cpp
```

Fixes #7828
