### PR TITLE
feat: Add HUGEINT support to VectorHasher's distinct value-id path

### DIFF
--- a/velox/exec/VectorHasher.cpp
+++ b/velox/exec/VectorHasher.cpp
@@ -41,6 +41,9 @@ namespace facebook::velox::exec {
       case TypeKind::BIGINT: {                                              \
         return TEMPLATE_FUNC<TypeKind::BIGINT>(__VA_ARGS__);                \
       }                                                                     \
+      case TypeKind::HUGEINT: {                                             \
+        return TEMPLATE_FUNC<TypeKind::HUGEINT>(__VA_ARGS__);               \
+      }                                                                     \
       case TypeKind::VARCHAR:                                               \
       case TypeKind::VARBINARY: {                                           \
         return TEMPLATE_FUNC<TypeKind::VARCHAR>(__VA_ARGS__);               \
@@ -620,6 +623,47 @@ void VectorHasher::analyze(
       analyzeTyped, typeKind_, groups, numGroups, offset, nullByte, nullMask);
 }
 
+uint64_t VectorHasher::valueId(int128_t value) {
+  if (isRange_) {
+    return kUnmappable;
+  }
+
+  auto nextId = uniqueHugeintValues_.size() + 1;
+  auto [iterator, inserted] = uniqueHugeintValues_.emplace(value, nextId);
+  if (!inserted) {
+    return iterator->second;
+  }
+
+  hasHugeintValue_ = true;
+  if (uniqueHugeintValues_.size() >= rangeSize_) {
+    return kUnmappable;
+  }
+  return iterator->second;
+}
+
+uint64_t VectorHasher::lookupValueId(int128_t value) const {
+  if (isRange_) {
+    return kUnmappable;
+  }
+
+  auto iterator = uniqueHugeintValues_.find(value);
+  if (iterator != uniqueHugeintValues_.end()) {
+    return iterator->second;
+  }
+  return kUnmappable;
+}
+
+void VectorHasher::analyzeValue(int128_t value) {
+  hasHugeintValue_ = true;
+  if (!distinctOverflow_) {
+    auto nextId = uniqueHugeintValues_.size() + 1;
+    if (uniqueHugeintValues_.emplace(value, nextId).second &&
+        uniqueHugeintValues_.size() > kMaxDistinct) {
+      setDistinctOverflow();
+    }
+  }
+}
+
 template <>
 void VectorHasher::analyzeValue(StringView value) {
   int size = value.size();
@@ -676,9 +720,7 @@ void VectorHasher::copyStringToLocal(const UniqueValue* unique) {
 
 void VectorHasher::setDistinctOverflow() {
   distinctOverflow_ = true;
-  uniqueValues_.clear();
-  uniqueValuesStorage_.clear();
-  distinctStringsBytes_ = 0;
+  clearDistinctValues();
 }
 
 void VectorHasher::setRangeOverflow() {
@@ -702,7 +744,7 @@ std::unique_ptr<common::Filter> VectorHasher::getFilter(
     case TypeKind::BIGINT:
       if (!distinctOverflow_) {
         std::vector<int64_t> values;
-        values.reserve(uniqueValues_.size());
+        values.reserve(numDistinct());
         for (const auto& value : uniqueValues_) {
           values.emplace_back(value.data());
         }
@@ -710,12 +752,22 @@ std::unique_ptr<common::Filter> VectorHasher::getFilter(
         return common::createBigintValues(values, nullAllowed);
       }
       [[fallthrough]];
+    case TypeKind::HUGEINT:
+      if (!distinctOverflow_) {
+        std::vector<int128_t> values;
+        values.reserve(numDistinct());
+        for (const auto& entry : uniqueHugeintValues_) {
+          values.emplace_back(entry.first);
+        }
+        return common::createHugeintValues(values, nullAllowed);
+      }
+      [[fallthrough]];
     case TypeKind::VARCHAR:
       [[fallthrough]];
     case TypeKind::VARBINARY:
       if (!distinctOverflow_) {
         std::vector<std::string> values;
-        values.reserve(uniqueValues_.size());
+        values.reserve(numDistinct());
         for (const auto& value : uniqueValues_) {
           values.emplace_back(value.asString());
         }
@@ -814,6 +866,13 @@ void VectorHasher::cardinality(
     asDistincts = 3;
     return;
   }
+  if (typeKind_ == TypeKind::HUGEINT) {
+    asRange = kRangeTooLarge;
+    asDistincts = distinctOverflow_
+        ? kRangeTooLarge
+        : addIdReserve(numDistinct(), reservePct) + 1;
+    return;
+  }
   int64_t signedRange;
   if (!hasRange_ || rangeOverflow_) {
     asRange = kRangeTooLarge;
@@ -841,7 +900,7 @@ void VectorHasher::cardinality(
     return;
   }
   // Padded count of values + 1 for null.
-  asDistincts = addIdReserve(uniqueValues_.size(), reservePct) + 1;
+  asDistincts = addIdReserve(numDistinct(), reservePct) + 1;
 }
 
 uint64_t VectorHasher::enableValueIds(uint64_t multiplier, int32_t reservePct) {
@@ -852,7 +911,7 @@ uint64_t VectorHasher::enableValueIds(uint64_t multiplier, int32_t reservePct) {
   checkTypeSupportsValueIds();
 
   multiplier_ = multiplier;
-  rangeSize_ = addIdReserve(uniqueValues_.size(), reservePct) + 1;
+  rangeSize_ = addIdReserve(numDistinct(), reservePct) + 1;
   isRange_ = false;
   uint64_t result;
   if (__builtin_mul_overflow(multiplier_, rangeSize_, &result)) {
@@ -886,12 +945,14 @@ uint64_t VectorHasher::enableValueRange(
 
 void VectorHasher::copyStatsFrom(const VectorHasher& other) {
   hasRange_ = other.hasRange_;
+  hasHugeintValue_ = other.hasHugeintValue_;
   rangeOverflow_ = other.rangeOverflow_;
   distinctOverflow_ = other.distinctOverflow_;
 
   min_ = other.min_;
   max_ = other.max_;
   uniqueValues_ = other.uniqueValues_;
+  uniqueHugeintValues_ = other.uniqueHugeintValues_;
 }
 
 void VectorHasher::merge(const VectorHasher& other, size_t maxNumDistinct) {
@@ -919,6 +980,19 @@ void VectorHasher::merge(const VectorHasher& other, size_t maxNumDistinct) {
     setDistinctOverflow();
     return;
   }
+  if (typeKind_ == TypeKind::HUGEINT) {
+    hasHugeintValue_ |= other.hasHugeintValue_;
+
+    for (const auto& entry : other.uniqueHugeintValues_) {
+      auto nextId = uniqueHugeintValues_.size() + 1;
+      if (uniqueHugeintValues_.emplace(entry.first, nextId).second &&
+          uniqueHugeintValues_.size() > maxNumDistinct) {
+        setDistinctOverflow();
+        break;
+      }
+    }
+    return;
+  }
   // Unique values can be merged without dispatch on type. All the
   // merged hashers must stay live for string type columns.
   for (UniqueValue value : other.uniqueValues_) {
@@ -942,7 +1016,7 @@ std::string VectorHasher::toString() const {
     out << " range size " << rangeSize_ << ": [" << min_ << ", " << max_ << "]";
   }
   if (!distinctOverflow_) {
-    out << " numDistinct: " << uniqueValues_.size();
+    out << " numDistinct: " << numDistinct();
   }
   return out.str();
 }

--- a/velox/exec/VectorHasher.cpp
+++ b/velox/exec/VectorHasher.cpp
@@ -41,6 +41,9 @@ namespace facebook::velox::exec {
       case TypeKind::BIGINT: {                                              \
         return TEMPLATE_FUNC<TypeKind::BIGINT>(__VA_ARGS__);                \
       }                                                                     \
+      case TypeKind::HUGEINT: {                                             \
+        return TEMPLATE_FUNC<TypeKind::HUGEINT>(__VA_ARGS__);               \
+      }                                                                     \
       case TypeKind::VARCHAR:                                               \
       case TypeKind::VARBINARY: {                                           \
         return TEMPLATE_FUNC<TypeKind::VARCHAR>(__VA_ARGS__);               \
@@ -620,6 +623,47 @@ void VectorHasher::analyze(
       analyzeTyped, typeKind_, groups, numGroups, offset, nullByte, nullMask);
 }
 
+uint64_t VectorHasher::valueId(int128_t value) {
+  if (isRange_) {
+    return kUnmappable;
+  }
+
+  auto nextId = uniqueHugeintValues_.size() + 1;
+  auto [iterator, inserted] = uniqueHugeintValues_.emplace(value, nextId);
+  if (!inserted) {
+    return iterator->second;
+  }
+
+  hasHugeintValue_ = true;
+  if (uniqueHugeintValues_.size() >= rangeSize_) {
+    return kUnmappable;
+  }
+  return iterator->second;
+}
+
+uint64_t VectorHasher::lookupValueId(int128_t value) const {
+  if (isRange_) {
+    return kUnmappable;
+  }
+
+  auto iterator = uniqueHugeintValues_.find(value);
+  if (iterator != uniqueHugeintValues_.end()) {
+    return iterator->second;
+  }
+  return kUnmappable;
+}
+
+void VectorHasher::analyzeValue(int128_t value) {
+  hasHugeintValue_ = true;
+  if (!distinctOverflow_) {
+    auto nextId = uniqueHugeintValues_.size() + 1;
+    if (uniqueHugeintValues_.emplace(value, nextId).second &&
+        uniqueHugeintValues_.size() > kMaxDistinct) {
+      setDistinctOverflow();
+    }
+  }
+}
+
 template <>
 void VectorHasher::analyzeValue(StringView value) {
   int size = value.size();
@@ -677,6 +721,7 @@ void VectorHasher::copyStringToLocal(const UniqueValue* unique) {
 void VectorHasher::setDistinctOverflow() {
   distinctOverflow_ = true;
   uniqueValues_.clear();
+  uniqueHugeintValues_.clear();
   uniqueValuesStorage_.clear();
   distinctStringsBytes_ = 0;
 }
@@ -708,6 +753,16 @@ std::unique_ptr<common::Filter> VectorHasher::getFilter(
         }
 
         return common::createBigintValues(values, nullAllowed);
+      }
+      [[fallthrough]];
+    case TypeKind::HUGEINT:
+      if (!distinctOverflow_) {
+        std::vector<int128_t> values;
+        values.reserve(uniqueHugeintValues_.size());
+        for (const auto& entry : uniqueHugeintValues_) {
+          values.emplace_back(entry.first);
+        }
+        return common::createHugeintValues(values, nullAllowed);
       }
       [[fallthrough]];
     case TypeKind::VARCHAR:
@@ -814,6 +869,13 @@ void VectorHasher::cardinality(
     asDistincts = 3;
     return;
   }
+  if (typeKind_ == TypeKind::HUGEINT) {
+    asRange = kRangeTooLarge;
+    asDistincts = distinctOverflow_
+        ? kRangeTooLarge
+        : addIdReserve(uniqueHugeintValues_.size(), reservePct) + 1;
+    return;
+  }
   int64_t signedRange;
   if (!hasRange_ || rangeOverflow_) {
     asRange = kRangeTooLarge;
@@ -852,7 +914,11 @@ uint64_t VectorHasher::enableValueIds(uint64_t multiplier, int32_t reservePct) {
   checkTypeSupportsValueIds();
 
   multiplier_ = multiplier;
-  rangeSize_ = addIdReserve(uniqueValues_.size(), reservePct) + 1;
+  rangeSize_ = addIdReserve(
+                   typeKind_ == TypeKind::HUGEINT ? uniqueHugeintValues_.size()
+                                                  : uniqueValues_.size(),
+                   reservePct) +
+      1;
   isRange_ = false;
   uint64_t result;
   if (__builtin_mul_overflow(multiplier_, rangeSize_, &result)) {
@@ -886,12 +952,14 @@ uint64_t VectorHasher::enableValueRange(
 
 void VectorHasher::copyStatsFrom(const VectorHasher& other) {
   hasRange_ = other.hasRange_;
+  hasHugeintValue_ = other.hasHugeintValue_;
   rangeOverflow_ = other.rangeOverflow_;
   distinctOverflow_ = other.distinctOverflow_;
 
   min_ = other.min_;
   max_ = other.max_;
   uniqueValues_ = other.uniqueValues_;
+  uniqueHugeintValues_ = other.uniqueHugeintValues_;
 }
 
 void VectorHasher::merge(const VectorHasher& other, size_t maxNumDistinct) {
@@ -919,6 +987,19 @@ void VectorHasher::merge(const VectorHasher& other, size_t maxNumDistinct) {
     setDistinctOverflow();
     return;
   }
+  if (typeKind_ == TypeKind::HUGEINT) {
+    hasHugeintValue_ |= other.hasHugeintValue_;
+
+    for (const auto& entry : other.uniqueHugeintValues_) {
+      auto nextId = uniqueHugeintValues_.size() + 1;
+      if (uniqueHugeintValues_.emplace(entry.first, nextId).second &&
+          uniqueHugeintValues_.size() > maxNumDistinct) {
+        setDistinctOverflow();
+        break;
+      }
+    }
+    return;
+  }
   // Unique values can be merged without dispatch on type. All the
   // merged hashers must stay live for string type columns.
   for (UniqueValue value : other.uniqueValues_) {
@@ -942,7 +1023,9 @@ std::string VectorHasher::toString() const {
     out << " range size " << rangeSize_ << ": [" << min_ << ", " << max_ << "]";
   }
   if (!distinctOverflow_) {
-    out << " numDistinct: " << uniqueValues_.size();
+    out << " numDistinct: "
+        << (typeKind_ == TypeKind::HUGEINT ? uniqueHugeintValues_.size()
+                                           : uniqueValues_.size());
   }
   return out.str();
 }

--- a/velox/exec/VectorHasher.h
+++ b/velox/exec/VectorHasher.h
@@ -15,7 +15,10 @@
  */
 #pragma once
 
+#include <folly/container/F14Map.h>
 #include <folly/container/F14Set.h>
+
+#include <type_traits>
 
 #include <velox/type/Filter.h>
 #include "velox/common/memory/RawVector.h"
@@ -154,6 +157,9 @@ class VectorHasher {
       hasRange_ = true;
       min_ = 0;
       max_ = 1;
+    } else if (typeKind_ == TypeKind::HUGEINT) {
+      // We do not support range based hashing for hugeint.
+      setRangeOverflow();
     }
   }
 
@@ -270,6 +276,11 @@ class VectorHasher {
       case TypeKind::INTEGER:
       case TypeKind::BIGINT:
         return distinctOverflow_;
+      case TypeKind::HUGEINT:
+        // TODO: Add 128-bit bloom filter support. HUGEINT dynamic filters are
+        // limited to exact value sets, so no dynamic filter is produced after
+        // distinct values overflow.
+        return false;
       default:
         return false;
     }
@@ -286,7 +297,9 @@ class VectorHasher {
 
   void resetStats() {
     uniqueValues_.clear();
+    uniqueHugeintValues_.clear();
     uniqueValuesStorage_.clear();
+    hasHugeintValue_ = false;
   }
 
   // Sets 'this' to range mode and adds 'reservePct' values to the
@@ -335,6 +348,7 @@ class VectorHasher {
       case TypeKind::SMALLINT:
       case TypeKind::INTEGER:
       case TypeKind::BIGINT:
+      case TypeKind::HUGEINT:
       case TypeKind::VARCHAR:
       case TypeKind::VARBINARY:
       case TypeKind::TIMESTAMP:
@@ -350,6 +364,9 @@ class VectorHasher {
 
   // true if no values have been added.
   bool empty() const {
+    if (typeKind_ == TypeKind::HUGEINT) {
+      return !hasHugeintValue_ && uniqueHugeintValues_.empty();
+    }
     return !hasRange_ && uniqueValues_.empty();
   }
 
@@ -374,6 +391,10 @@ class VectorHasher {
 
   template <typename T>
   inline int64_t toInt64(T value) const {
+    static_assert(
+        !std::is_same_v<std::remove_cvref_t<T>, int128_t>,
+        "HUGEINT values must use the int128_t overloads instead of narrowing "
+        "to int64_t.");
     return value;
   }
 
@@ -422,7 +443,7 @@ class VectorHasher {
           result[i] = 0;
         }
       } else {
-        auto id = valueId<T>(valueAt<T>(groups[i], offset));
+        auto id = valueId(valueAt<T>(groups[i], offset));
         if (id == kUnmappable) {
           return false;
         }
@@ -481,6 +502,8 @@ class VectorHasher {
     }
   }
 
+  void analyzeValue(int128_t value);
+
   template <typename T>
   bool tryMapToRangeSimd(
       const T* values,
@@ -496,28 +519,32 @@ class VectorHasher {
     if (!isRange_) {
       return false;
     }
-
-    if constexpr (
-        std::is_same_v<T, std::int64_t> || std::is_same_v<T, std::int32_t> ||
-        std::is_same_v<T, std::int16_t>) {
-      if (rows.isAllSelected() && multiplier_ == 1) {
-        return tryMapToRangeSimd(values, rows, result);
+    if constexpr (std::is_same_v<std::remove_cvref_t<T>, int128_t>) {
+      return false;
+    } else {
+      if constexpr (
+          std::is_same_v<T, std::int64_t> || std::is_same_v<T, std::int32_t> ||
+          std::is_same_v<T, std::int16_t>) {
+        if (rows.isAllSelected() && multiplier_ == 1) {
+          return tryMapToRangeSimd(values, rows, result);
+        }
       }
+
+      bool inRange = true;
+      rows.testSelected([&](vector_size_t row) {
+        auto int64Value = toInt64(values[row]);
+        if (int64Value > max_ || int64Value < min_) {
+          inRange = false;
+          return false;
+        }
+        auto hash = int64Value - min_ + 1;
+        result[row] =
+            multiplier_ == 1 ? hash : result[row] + multiplier_ * hash;
+        return true;
+      });
+
+      return inRange;
     }
-
-    bool inRange = true;
-    rows.testSelected([&](vector_size_t row) {
-      auto int64Value = toInt64(values[row]);
-      if (int64Value > max_ || int64Value < min_) {
-        inRange = false;
-        return false;
-      }
-      auto hash = int64Value - min_ + 1;
-      result[row] = multiplier_ == 1 ? hash : result[row] + multiplier_ * hash;
-      return true;
-    });
-
-    return inRange;
   }
 
   template <typename T>
@@ -543,6 +570,8 @@ class VectorHasher {
     return unique.id();
   }
 
+  uint64_t valueId(int128_t value);
+
   template <typename T>
   uint64_t lookupValueId(T value) const {
     auto int64Value = toInt64(value);
@@ -559,6 +588,8 @@ class VectorHasher {
     }
     return kUnmappable;
   }
+
+  uint64_t lookupValueId(int128_t value) const;
 
   void updateRange(int64_t value) {
     if (hasRange_) {
@@ -625,6 +656,10 @@ class VectorHasher {
   // True if 'min_' and 'max_' are initialized.
   bool hasRange_ = false;
 
+  // True if at least one HUGEINT value has been observed. This stays true even
+  // after distinct values overflow and uniqueHugeintValues_ is cleared.
+  bool hasHugeintValue_ = false;
+
   // True when range or distinct mapping is not possible or practical.
   bool rangeOverflow_ = false;
   bool distinctOverflow_ = false;
@@ -632,9 +667,13 @@ class VectorHasher {
   // Bounds of the range if 'isRange_' is true.
   int64_t min_ = 1;
   int64_t max_ = 0;
+
   // Table for mapping distinct values to small ints.
   folly::F14FastSet<UniqueValue, UniqueValueHasher, UniqueValueComparer>
       uniqueValues_;
+
+  // Table for mapping distinct hugeint values to small ints.
+  folly::F14FastMap<int128_t, uint32_t> uniqueHugeintValues_;
 
   // Memory for unique string values.
   std::vector<std::string> uniqueValuesStorage_;

--- a/velox/exec/VectorHasher.h
+++ b/velox/exec/VectorHasher.h
@@ -15,7 +15,10 @@
  */
 #pragma once
 
+#include <folly/container/F14Map.h>
 #include <folly/container/F14Set.h>
+
+#include <type_traits>
 
 #include <velox/type/Filter.h>
 #include "velox/common/memory/RawVector.h"
@@ -154,6 +157,9 @@ class VectorHasher {
       hasRange_ = true;
       min_ = 0;
       max_ = 1;
+    } else if (typeKind_ == TypeKind::HUGEINT) {
+      // We do not support range based hashing for hugeint.
+      setRangeOverflow();
     }
   }
 
@@ -270,6 +276,11 @@ class VectorHasher {
       case TypeKind::INTEGER:
       case TypeKind::BIGINT:
         return distinctOverflow_;
+      case TypeKind::HUGEINT:
+        // TODO: Add 128-bit bloom filter support. HUGEINT dynamic filters are
+        // limited to exact value sets, so no dynamic filter is produced after
+        // distinct values overflow.
+        return false;
       default:
         return false;
     }
@@ -285,8 +296,8 @@ class VectorHasher {
   }
 
   void resetStats() {
-    uniqueValues_.clear();
-    uniqueValuesStorage_.clear();
+    clearDistinctValues();
+    hasHugeintValue_ = false;
   }
 
   // Sets 'this' to range mode and adds 'reservePct' values to the
@@ -335,6 +346,7 @@ class VectorHasher {
       case TypeKind::SMALLINT:
       case TypeKind::INTEGER:
       case TypeKind::BIGINT:
+      case TypeKind::HUGEINT:
       case TypeKind::VARCHAR:
       case TypeKind::VARBINARY:
       case TypeKind::TIMESTAMP:
@@ -350,13 +362,15 @@ class VectorHasher {
 
   // true if no values have been added.
   bool empty() const {
-    return !hasRange_ && uniqueValues_.empty();
+    const bool hasSeenValue =
+        typeKind_ == TypeKind::HUGEINT ? hasHugeintValue_ : hasRange_;
+    return !hasSeenValue && numDistinct() == 0;
   }
 
   std::string toString() const;
 
   size_t numUniqueValues() const {
-    return uniqueValues_.size();
+    return numDistinct();
   }
 
  private:
@@ -372,8 +386,24 @@ class VectorHasher {
     return size == 0 ? word : word + (1L << (size * 8));
   }
 
+  size_t numDistinct() const {
+    return typeKind_ == TypeKind::HUGEINT ? uniqueHugeintValues_.size()
+                                          : uniqueValues_.size();
+  }
+
+  void clearDistinctValues() {
+    uniqueValues_.clear();
+    uniqueHugeintValues_.clear();
+    uniqueValuesStorage_.clear();
+    distinctStringsBytes_ = 0;
+  }
+
   template <typename T>
   inline int64_t toInt64(T value) const {
+    static_assert(
+        !std::is_same_v<std::remove_cvref_t<T>, int128_t>,
+        "HUGEINT values must use the int128_t overloads instead of narrowing "
+        "to int64_t.");
     return value;
   }
 
@@ -422,7 +452,7 @@ class VectorHasher {
           result[i] = 0;
         }
       } else {
-        auto id = valueId<T>(valueAt<T>(groups[i], offset));
+        auto id = valueId(valueAt<T>(groups[i], offset));
         if (id == kUnmappable) {
           return false;
         }
@@ -481,6 +511,8 @@ class VectorHasher {
     }
   }
 
+  void analyzeValue(int128_t value);
+
   template <typename T>
   bool tryMapToRangeSimd(
       const T* values,
@@ -496,28 +528,32 @@ class VectorHasher {
     if (!isRange_) {
       return false;
     }
-
-    if constexpr (
-        std::is_same_v<T, std::int64_t> || std::is_same_v<T, std::int32_t> ||
-        std::is_same_v<T, std::int16_t>) {
-      if (rows.isAllSelected() && multiplier_ == 1) {
-        return tryMapToRangeSimd(values, rows, result);
+    if constexpr (std::is_same_v<std::remove_cvref_t<T>, int128_t>) {
+      return false;
+    } else {
+      if constexpr (
+          std::is_same_v<T, std::int64_t> || std::is_same_v<T, std::int32_t> ||
+          std::is_same_v<T, std::int16_t>) {
+        if (rows.isAllSelected() && multiplier_ == 1) {
+          return tryMapToRangeSimd(values, rows, result);
+        }
       }
+
+      bool inRange = true;
+      rows.testSelected([&](vector_size_t row) {
+        auto int64Value = toInt64(values[row]);
+        if (int64Value > max_ || int64Value < min_) {
+          inRange = false;
+          return false;
+        }
+        auto hash = int64Value - min_ + 1;
+        result[row] =
+            multiplier_ == 1 ? hash : result[row] + multiplier_ * hash;
+        return true;
+      });
+
+      return inRange;
     }
-
-    bool inRange = true;
-    rows.testSelected([&](vector_size_t row) {
-      auto int64Value = toInt64(values[row]);
-      if (int64Value > max_ || int64Value < min_) {
-        inRange = false;
-        return false;
-      }
-      auto hash = int64Value - min_ + 1;
-      result[row] = multiplier_ == 1 ? hash : result[row] + multiplier_ * hash;
-      return true;
-    });
-
-    return inRange;
   }
 
   template <typename T>
@@ -543,6 +579,8 @@ class VectorHasher {
     return unique.id();
   }
 
+  uint64_t valueId(int128_t value);
+
   template <typename T>
   uint64_t lookupValueId(T value) const {
     auto int64Value = toInt64(value);
@@ -559,6 +597,8 @@ class VectorHasher {
     }
     return kUnmappable;
   }
+
+  uint64_t lookupValueId(int128_t value) const;
 
   void updateRange(int64_t value) {
     if (hasRange_) {
@@ -625,6 +665,10 @@ class VectorHasher {
   // True if 'min_' and 'max_' are initialized.
   bool hasRange_ = false;
 
+  // True if at least one HUGEINT value has been observed. This stays true even
+  // after distinct values overflow and uniqueHugeintValues_ is cleared.
+  bool hasHugeintValue_ = false;
+
   // True when range or distinct mapping is not possible or practical.
   bool rangeOverflow_ = false;
   bool distinctOverflow_ = false;
@@ -632,9 +676,13 @@ class VectorHasher {
   // Bounds of the range if 'isRange_' is true.
   int64_t min_ = 1;
   int64_t max_ = 0;
+
   // Table for mapping distinct values to small ints.
   folly::F14FastSet<UniqueValue, UniqueValueHasher, UniqueValueComparer>
       uniqueValues_;
+
+  // Table for mapping distinct hugeint values to small ints.
+  folly::F14FastMap<int128_t, uint32_t> uniqueHugeintValues_;
 
   // Memory for unique string values.
   std::vector<std::string> uniqueValuesStorage_;

--- a/velox/exec/tests/VectorHasherTest.cpp
+++ b/velox/exec/tests/VectorHasherTest.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/exec/VectorHasher.h"
 #include <gtest/gtest.h>
+#include <array>
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/type/Type.h"
 #include "velox/type/tests/utils/CustomTypesForTesting.h"
@@ -760,9 +761,261 @@ TEST_F(VectorHasherTest, mergeMaxNumDistinct) {
   EXPECT_EQ(numDistinct, VectorHasher::kRangeTooLarge);
 }
 
+TEST_F(VectorHasherTest, mergeHugeint) {
+  constexpr vector_size_t kSize = 10;
+  const auto type = DECIMAL(38, 0);
+  auto makeValue = [](uint64_t highBits) {
+    return HugeInt::build(highBits, 42);
+  };
+  auto makeValues = [&](uint64_t firstHighBit) {
+    std::vector<int128_t> values;
+    values.reserve(kSize);
+    for (auto i = 0; i < kSize; ++i) {
+      values.push_back(makeValue(firstHighBit + i));
+    }
+    return values;
+  };
+
+  auto vector1 = makeFlatVector<int128_t>(makeValues(0), type);
+  auto vector2 = makeFlatVector<int128_t>(makeValues(5), type);
+
+  SelectivityVector rows(kSize);
+  raw_vector<uint64_t> hashes(kSize);
+
+  VectorHasher hasher1(type, 0);
+  hasher1.decode(*vector1, rows);
+  hasher1.computeValueIds(rows, hashes);
+
+  VectorHasher hasher2(type, 0);
+  hasher2.decode(*vector2, rows);
+  hasher2.computeValueIds(rows, hashes);
+
+  hasher1.merge(hasher2, kSize * 2);
+
+  uint64_t numRange;
+  uint64_t numDistinct;
+  hasher1.cardinality(0, numRange, numDistinct);
+  EXPECT_EQ(numRange, VectorHasher::kRangeTooLarge);
+  EXPECT_EQ(numDistinct, 16);
+
+  auto filter = hasher1.getFilter(false);
+  ASSERT_NE(filter, nullptr);
+  auto* hugeintValues =
+      dynamic_cast<common::HugeintValuesUsingHashTable*>(filter.get());
+  ASSERT_NE(hugeintValues, nullptr);
+  EXPECT_TRUE(hugeintValues->testInt128(makeValue(0)));
+  EXPECT_TRUE(hugeintValues->testInt128(makeValue(9)));
+  EXPECT_TRUE(hugeintValues->testInt128(makeValue(14)));
+  EXPECT_FALSE(hugeintValues->testInt128(makeValue(15)));
+
+  VectorHasher overflowHasher1(type, 0);
+  overflowHasher1.decode(*vector1, rows);
+  overflowHasher1.computeValueIds(rows, hashes);
+
+  auto vector3 = makeFlatVector<int128_t>(makeValues(100), type);
+  VectorHasher overflowHasher2(type, 0);
+  overflowHasher2.decode(*vector3, rows);
+  overflowHasher2.computeValueIds(rows, hashes);
+
+  overflowHasher1.merge(overflowHasher2, kSize + 5);
+  overflowHasher1.cardinality(0, numRange, numDistinct);
+  EXPECT_EQ(numRange, VectorHasher::kRangeTooLarge);
+  EXPECT_EQ(numDistinct, VectorHasher::kRangeTooLarge);
+  EXPECT_EQ(nullptr, overflowHasher1.getFilter(false));
+}
+
 TEST_F(VectorHasherTest, computeValueIdsBigint) {
   testComputeValueIds<int64_t>(false);
   testComputeValueIds<int64_t>(true);
+}
+
+TEST_F(VectorHasherTest, computeValueIdsHugeint) {
+  const auto valueWithLowBits = HugeInt::build(1, 42);
+  const auto anotherValueWithSameLowBits = HugeInt::build(2, 42);
+  const auto negativeValueWithSameLowBits =
+      HugeInt::build(std::numeric_limits<uint64_t>::max(), 42);
+  const auto newValue = HugeInt::build(3, 42);
+
+  auto vector = makeNullableFlatVector<int128_t>(
+      {std::nullopt,
+       valueWithLowBits,
+       anotherValueWithSameLowBits,
+       valueWithLowBits,
+       negativeValueWithSameLowBits,
+       anotherValueWithSameLowBits},
+      DECIMAL(38, 0));
+
+  auto hasher = exec::VectorHasher::create(vector->type(), 0);
+  SelectivityVector rows(vector->size());
+  raw_vector<uint64_t> result(vector->size());
+  std::fill(result.begin(), result.end(), 0);
+
+  hasher->decode(*vector, rows);
+  ASSERT_FALSE(hasher->computeValueIds(rows, result));
+
+  uint64_t rangeSize;
+  uint64_t distinctSize;
+  hasher->cardinality(0, rangeSize, distinctSize);
+  ASSERT_EQ(VectorHasher::kRangeTooLarge, rangeSize);
+  ASSERT_EQ(4, distinctSize);
+
+  ASSERT_EQ(4, hasher->enableValueIds(1, 0));
+
+  hasher->decode(*vector, rows);
+  ASSERT_TRUE(hasher->computeValueIds(rows, result));
+  EXPECT_EQ(0, result[0]);
+  EXPECT_EQ(result[1], result[3]);
+  EXPECT_EQ(result[2], result[5]);
+  EXPECT_NE(result[1], result[2]);
+  EXPECT_NE(result[1], result[4]);
+  EXPECT_NE(result[2], result[4]);
+
+  auto outOfRangeVector = makeFlatVector<int128_t>(
+      {valueWithLowBits,
+       anotherValueWithSameLowBits,
+       negativeValueWithSameLowBits,
+       newValue},
+      DECIMAL(38, 0));
+  SelectivityVector outOfRangeRows(outOfRangeVector->size());
+  result.resize(outOfRangeVector->size());
+  std::fill(result.begin(), result.end(), 0);
+  hasher->decode(*outOfRangeVector, outOfRangeRows);
+  ASSERT_FALSE(hasher->computeValueIds(outOfRangeRows, result));
+}
+
+TEST_F(VectorHasherTest, lookupValueIdsHugeint) {
+  const auto first = HugeInt::build(1, 42);
+  const auto second = HugeInt::build(2, 42);
+  const auto third = HugeInt::build(3, 42);
+  const auto missing = HugeInt::build(4, 42);
+  const auto type = DECIMAL(38, 0);
+
+  auto vector = makeFlatVector<int128_t>({first, second, third}, type);
+  auto hasher = exec::VectorHasher::create(type, 0);
+  SelectivityVector rows(vector->size());
+  raw_vector<uint64_t> result(vector->size());
+
+  hasher->decode(*vector, rows);
+  hasher->computeValueIds(rows, result);
+  hasher->enableValueIds(1, 0);
+
+  auto probe = makeFlatVector<int128_t>({first, missing, second, third}, type);
+  SelectivityVector probeRows(probe->size());
+  result.resize(probe->size());
+  std::fill(result.begin(), result.end(), 0);
+
+  VectorHasher::ScratchMemory scratch;
+  hasher->lookupValueIds(*probe, probeRows, scratch, result);
+
+  EXPECT_TRUE(probeRows.isValid(0));
+  EXPECT_FALSE(probeRows.isValid(1));
+  EXPECT_TRUE(probeRows.isValid(2));
+  EXPECT_TRUE(probeRows.isValid(3));
+  EXPECT_EQ(probeRows.countSelected(), 3);
+  EXPECT_EQ(result[0], 1);
+  EXPECT_EQ(result[1], 0);
+  EXPECT_EQ(result[2], 2);
+  EXPECT_EQ(result[3], 3);
+}
+
+TEST_F(VectorHasherTest, hugeintFilter) {
+  const auto first = HugeInt::build(1, 42);
+  const auto second = HugeInt::build(2, 42);
+  const auto third = HugeInt::build(3, 42);
+  const auto missing = HugeInt::build(4, 42);
+
+  auto vector =
+      makeFlatVector<int128_t>({first, second, first, third}, DECIMAL(38, 0));
+
+  auto hasher = exec::VectorHasher::create(vector->type(), 0);
+  SelectivityVector rows(vector->size());
+  raw_vector<uint64_t> hashes(vector->size());
+
+  hasher->decode(*vector, rows);
+  hasher->computeValueIds(rows, hashes);
+
+  auto filter = hasher->getFilter(false);
+  ASSERT_NE(nullptr, filter);
+
+  auto* hugeintValues =
+      dynamic_cast<common::HugeintValuesUsingHashTable*>(filter.get());
+  ASSERT_NE(nullptr, hugeintValues);
+  ASSERT_FALSE(hugeintValues->testNull());
+  EXPECT_TRUE(hugeintValues->testInt128(first));
+  EXPECT_TRUE(hugeintValues->testInt128(second));
+  EXPECT_TRUE(hugeintValues->testInt128(third));
+  EXPECT_FALSE(hugeintValues->testInt128(missing));
+
+  auto filterWithNull = hasher->getFilter(true);
+  ASSERT_TRUE(filterWithNull->testNull());
+  EXPECT_TRUE(filterWithNull->testInt128(first));
+  EXPECT_FALSE(filterWithNull->testInt128(missing));
+}
+
+TEST_F(VectorHasherTest, int128BoundaryCollisions) {
+  vector_size_t size = 100;
+  auto vector = makeFlatVector<int128_t>(size, [](vector_size_t row) {
+    int64_t baseValue = row % 10;
+    int128_t highBits = static_cast<int128_t>(row / 10) << 64;
+    return highBits + baseValue;
+  });
+
+  auto hasher = exec::VectorHasher::create(HUGEINT(), 0);
+  SelectivityVector allRows(size);
+  raw_vector<uint64_t> result(size);
+
+  // Verify decoded vector path keeps the high bits when collecting distincts.
+  hasher->decode(*vector, allRows);
+  hasher->computeValueIds(allRows, result);
+
+  uint64_t asRange;
+  uint64_t asDistinct;
+  hasher->cardinality(0, asRange, asDistinct);
+  ASSERT_EQ(size + 1, asDistinct)
+      << "Expected " << (size + 1)
+      << " distinct values (100 values + 1 for null), but got " << asDistinct
+      << ". This indicates hash collisions for int128_t values that differ "
+         "only in high bits.";
+}
+
+TEST_F(VectorHasherTest, int128BoundaryCollisionsForRows) {
+  constexpr int32_t kNumGroups = 100;
+  constexpr int32_t kValueOffset = 0;
+  constexpr int32_t kNullByte = sizeof(int128_t);
+  constexpr int32_t kRowSize = sizeof(int128_t) + 1;
+  constexpr uint8_t kNullMask = 1;
+
+  std::vector<std::array<char, kRowSize>> rowData(kNumGroups);
+  std::vector<char*> groups(kNumGroups);
+  for (auto row = 0; row < kNumGroups; ++row) {
+    rowData[row].fill(0);
+    groups[row] = rowData[row].data();
+
+    int64_t baseValue = row % 10;
+    int128_t highBits = static_cast<int128_t>(row / 10) << 64;
+    HugeInt::serialize(highBits + baseValue, groups[row] + kValueOffset);
+  }
+
+  auto rowHasher = exec::VectorHasher::create(HUGEINT(), 0);
+  raw_vector<uint64_t> rowResult(kNumGroups);
+
+  // Verify row-wise path used by hash table modes maps 128-bit values exactly.
+  rowHasher->analyze(
+      groups.data(), kNumGroups, kValueOffset, kNullByte, kNullMask);
+  rowHasher->enableValueIds(1, 0);
+  ASSERT_TRUE(rowHasher->computeValueIdsForRows(
+      groups.data(),
+      kNumGroups,
+      kValueOffset,
+      kNullByte,
+      kNullMask,
+      rowResult));
+
+  for (auto row = 0; row < kNumGroups; ++row) {
+    ASSERT_EQ(row + 1, rowResult[row])
+        << "Expected a distinct value id for an int128_t value that differs "
+           "only in high bits.";
+  }
 }
 
 TEST_F(VectorHasherTest, computeValueIdsInteger) {

--- a/velox/exec/tests/VectorHasherTest.cpp
+++ b/velox/exec/tests/VectorHasherTest.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/exec/VectorHasher.h"
 #include <gtest/gtest.h>
+#include <array>
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/type/Type.h"
 #include "velox/type/tests/utils/CustomTypesForTesting.h"
@@ -503,6 +504,7 @@ TEST_F(VectorHasherTest, integerIds) {
   SelectivityVector rows(ints->size());
   hasher->decode(*vector, rows);
   EXPECT_FALSE(hasher->computeValueIds(rows, hashes));
+  EXPECT_EQ(hasher->numUniqueValues(), 99);
   hasher->enableValueRange(1, 50);
   hasher->decode(*vector, rows);
   EXPECT_TRUE(hasher->computeValueIds(rows, hashes));
@@ -532,6 +534,10 @@ TEST_F(VectorHasherTest, integerIds) {
   ASSERT_TRUE(bigintValues->testInt64(kMin + 100));
   ASSERT_FALSE(bigintValues->testInt64(kMin + 101));
   ASSERT_FALSE(bigintValues->testInt64(0));
+
+  hasher->resetStats();
+  EXPECT_TRUE(hasher->empty());
+  EXPECT_EQ(hasher->numUniqueValues(), 0);
 
   hasher = exec::VectorHasher::create(BIGINT(), 1);
   hasher->enableValueIds(1, VectorHasher::kNoLimit);
@@ -760,9 +766,269 @@ TEST_F(VectorHasherTest, mergeMaxNumDistinct) {
   EXPECT_EQ(numDistinct, VectorHasher::kRangeTooLarge);
 }
 
+TEST_F(VectorHasherTest, mergeHugeint) {
+  constexpr vector_size_t kSize = 10;
+  const auto type = DECIMAL(38, 0);
+  auto makeValue = [](uint64_t highBits) {
+    return HugeInt::build(highBits, 42);
+  };
+  auto makeValues = [&](uint64_t firstHighBit) {
+    std::vector<int128_t> values;
+    values.reserve(kSize);
+    for (auto i = 0; i < kSize; ++i) {
+      values.push_back(makeValue(firstHighBit + i));
+    }
+    return values;
+  };
+
+  auto vector1 = makeFlatVector<int128_t>(makeValues(0), type);
+  auto vector2 = makeFlatVector<int128_t>(makeValues(5), type);
+
+  SelectivityVector rows(kSize);
+  raw_vector<uint64_t> hashes(kSize);
+
+  VectorHasher hasher1(type, 0);
+  hasher1.decode(*vector1, rows);
+  hasher1.computeValueIds(rows, hashes);
+
+  VectorHasher hasher2(type, 0);
+  hasher2.decode(*vector2, rows);
+  hasher2.computeValueIds(rows, hashes);
+
+  hasher1.merge(hasher2, kSize * 2);
+
+  uint64_t numRange;
+  uint64_t numDistinct;
+  hasher1.cardinality(0, numRange, numDistinct);
+  EXPECT_EQ(numRange, VectorHasher::kRangeTooLarge);
+  EXPECT_EQ(numDistinct, 16);
+  EXPECT_EQ(hasher1.numUniqueValues(), 15);
+
+  auto filter = hasher1.getFilter(false);
+  ASSERT_NE(filter, nullptr);
+  auto* hugeintValues =
+      dynamic_cast<common::HugeintValuesUsingHashTable*>(filter.get());
+  ASSERT_NE(hugeintValues, nullptr);
+  EXPECT_TRUE(hugeintValues->testInt128(makeValue(0)));
+  EXPECT_TRUE(hugeintValues->testInt128(makeValue(9)));
+  EXPECT_TRUE(hugeintValues->testInt128(makeValue(14)));
+  EXPECT_FALSE(hugeintValues->testInt128(makeValue(15)));
+
+  VectorHasher overflowHasher1(type, 0);
+  overflowHasher1.decode(*vector1, rows);
+  overflowHasher1.computeValueIds(rows, hashes);
+
+  auto vector3 = makeFlatVector<int128_t>(makeValues(100), type);
+  VectorHasher overflowHasher2(type, 0);
+  overflowHasher2.decode(*vector3, rows);
+  overflowHasher2.computeValueIds(rows, hashes);
+
+  overflowHasher1.merge(overflowHasher2, kSize + 5);
+  overflowHasher1.cardinality(0, numRange, numDistinct);
+  EXPECT_EQ(numRange, VectorHasher::kRangeTooLarge);
+  EXPECT_EQ(numDistinct, VectorHasher::kRangeTooLarge);
+  EXPECT_FALSE(overflowHasher1.empty());
+  EXPECT_EQ(overflowHasher1.numUniqueValues(), 0);
+  EXPECT_EQ(nullptr, overflowHasher1.getFilter(false));
+}
+
 TEST_F(VectorHasherTest, computeValueIdsBigint) {
   testComputeValueIds<int64_t>(false);
   testComputeValueIds<int64_t>(true);
+}
+
+TEST_F(VectorHasherTest, computeValueIdsHugeint) {
+  const auto valueWithLowBits = HugeInt::build(1, 42);
+  const auto anotherValueWithSameLowBits = HugeInt::build(2, 42);
+  const auto negativeValueWithSameLowBits =
+      HugeInt::build(std::numeric_limits<uint64_t>::max(), 42);
+  const auto newValue = HugeInt::build(3, 42);
+
+  auto vector = makeNullableFlatVector<int128_t>(
+      {std::nullopt,
+       valueWithLowBits,
+       anotherValueWithSameLowBits,
+       valueWithLowBits,
+       negativeValueWithSameLowBits,
+       anotherValueWithSameLowBits},
+      DECIMAL(38, 0));
+
+  auto hasher = exec::VectorHasher::create(vector->type(), 0);
+  SelectivityVector rows(vector->size());
+  raw_vector<uint64_t> result(vector->size());
+  std::fill(result.begin(), result.end(), 0);
+
+  hasher->decode(*vector, rows);
+  ASSERT_FALSE(hasher->computeValueIds(rows, result));
+
+  uint64_t rangeSize;
+  uint64_t distinctSize;
+  hasher->cardinality(0, rangeSize, distinctSize);
+  ASSERT_EQ(VectorHasher::kRangeTooLarge, rangeSize);
+  ASSERT_EQ(4, distinctSize);
+
+  ASSERT_EQ(4, hasher->enableValueIds(1, 0));
+
+  hasher->decode(*vector, rows);
+  ASSERT_TRUE(hasher->computeValueIds(rows, result));
+  EXPECT_EQ(0, result[0]);
+  EXPECT_EQ(result[1], result[3]);
+  EXPECT_EQ(result[2], result[5]);
+  EXPECT_NE(result[1], result[2]);
+  EXPECT_NE(result[1], result[4]);
+  EXPECT_NE(result[2], result[4]);
+
+  auto outOfRangeVector = makeFlatVector<int128_t>(
+      {valueWithLowBits,
+       anotherValueWithSameLowBits,
+       negativeValueWithSameLowBits,
+       newValue},
+      DECIMAL(38, 0));
+  SelectivityVector outOfRangeRows(outOfRangeVector->size());
+  result.resize(outOfRangeVector->size());
+  std::fill(result.begin(), result.end(), 0);
+  hasher->decode(*outOfRangeVector, outOfRangeRows);
+  ASSERT_FALSE(hasher->computeValueIds(outOfRangeRows, result));
+}
+
+TEST_F(VectorHasherTest, lookupValueIdsHugeint) {
+  const auto first = HugeInt::build(1, 42);
+  const auto second = HugeInt::build(2, 42);
+  const auto third = HugeInt::build(3, 42);
+  const auto missing = HugeInt::build(4, 42);
+  const auto type = DECIMAL(38, 0);
+
+  auto vector = makeFlatVector<int128_t>({first, second, third}, type);
+  auto hasher = exec::VectorHasher::create(type, 0);
+  SelectivityVector rows(vector->size());
+  raw_vector<uint64_t> result(vector->size());
+
+  hasher->decode(*vector, rows);
+  hasher->computeValueIds(rows, result);
+  hasher->enableValueIds(1, 0);
+
+  auto probe = makeFlatVector<int128_t>({first, missing, second, third}, type);
+  SelectivityVector probeRows(probe->size());
+  result.resize(probe->size());
+  std::fill(result.begin(), result.end(), 0);
+
+  VectorHasher::ScratchMemory scratch;
+  hasher->lookupValueIds(*probe, probeRows, scratch, result);
+
+  EXPECT_TRUE(probeRows.isValid(0));
+  EXPECT_FALSE(probeRows.isValid(1));
+  EXPECT_TRUE(probeRows.isValid(2));
+  EXPECT_TRUE(probeRows.isValid(3));
+  EXPECT_EQ(probeRows.countSelected(), 3);
+  EXPECT_EQ(result[0], 1);
+  EXPECT_EQ(result[1], 0);
+  EXPECT_EQ(result[2], 2);
+  EXPECT_EQ(result[3], 3);
+}
+
+TEST_F(VectorHasherTest, hugeintFilter) {
+  const auto first = HugeInt::build(1, 42);
+  const auto second = HugeInt::build(2, 42);
+  const auto third = HugeInt::build(3, 42);
+  const auto missing = HugeInt::build(4, 42);
+
+  auto vector =
+      makeFlatVector<int128_t>({first, second, first, third}, DECIMAL(38, 0));
+
+  auto hasher = exec::VectorHasher::create(vector->type(), 0);
+  SelectivityVector rows(vector->size());
+  raw_vector<uint64_t> hashes(vector->size());
+
+  hasher->decode(*vector, rows);
+  hasher->computeValueIds(rows, hashes);
+  EXPECT_EQ(hasher->numUniqueValues(), 3);
+
+  auto filter = hasher->getFilter(false);
+  ASSERT_NE(nullptr, filter);
+
+  auto* hugeintValues =
+      dynamic_cast<common::HugeintValuesUsingHashTable*>(filter.get());
+  ASSERT_NE(nullptr, hugeintValues);
+  ASSERT_FALSE(hugeintValues->testNull());
+  EXPECT_TRUE(hugeintValues->testInt128(first));
+  EXPECT_TRUE(hugeintValues->testInt128(second));
+  EXPECT_TRUE(hugeintValues->testInt128(third));
+  EXPECT_FALSE(hugeintValues->testInt128(missing));
+
+  auto filterWithNull = hasher->getFilter(true);
+  ASSERT_TRUE(filterWithNull->testNull());
+  EXPECT_TRUE(filterWithNull->testInt128(first));
+  EXPECT_FALSE(filterWithNull->testInt128(missing));
+
+  hasher->resetStats();
+  EXPECT_TRUE(hasher->empty());
+  EXPECT_EQ(hasher->numUniqueValues(), 0);
+}
+
+TEST_F(VectorHasherTest, int128BoundaryCollisions) {
+  vector_size_t size = 100;
+  auto vector = makeFlatVector<int128_t>(size, [](vector_size_t row) {
+    int64_t baseValue = row % 10;
+    int128_t highBits = static_cast<int128_t>(row / 10) << 64;
+    return highBits + baseValue;
+  });
+
+  auto hasher = exec::VectorHasher::create(HUGEINT(), 0);
+  SelectivityVector allRows(size);
+  raw_vector<uint64_t> result(size);
+
+  // Verify decoded vector path keeps the high bits when collecting distincts.
+  hasher->decode(*vector, allRows);
+  hasher->computeValueIds(allRows, result);
+
+  uint64_t asRange;
+  uint64_t asDistinct;
+  hasher->cardinality(0, asRange, asDistinct);
+  ASSERT_EQ(size + 1, asDistinct)
+      << "Expected " << (size + 1)
+      << " distinct values (100 values + 1 for null), but got " << asDistinct
+      << ". This indicates hash collisions for int128_t values that differ "
+         "only in high bits.";
+}
+
+TEST_F(VectorHasherTest, int128BoundaryCollisionsForRows) {
+  constexpr int32_t kNumGroups = 100;
+  constexpr int32_t kValueOffset = 0;
+  constexpr int32_t kNullByte = sizeof(int128_t);
+  constexpr int32_t kRowSize = sizeof(int128_t) + 1;
+  constexpr uint8_t kNullMask = 1;
+
+  std::vector<std::array<char, kRowSize>> rowData(kNumGroups);
+  std::vector<char*> groups(kNumGroups);
+  for (auto row = 0; row < kNumGroups; ++row) {
+    rowData[row].fill(0);
+    groups[row] = rowData[row].data();
+
+    int64_t baseValue = row % 10;
+    int128_t highBits = static_cast<int128_t>(row / 10) << 64;
+    HugeInt::serialize(highBits + baseValue, groups[row] + kValueOffset);
+  }
+
+  auto rowHasher = exec::VectorHasher::create(HUGEINT(), 0);
+  raw_vector<uint64_t> rowResult(kNumGroups);
+
+  // Verify row-wise path used by hash table modes maps 128-bit values exactly.
+  rowHasher->analyze(
+      groups.data(), kNumGroups, kValueOffset, kNullByte, kNullMask);
+  rowHasher->enableValueIds(1, 0);
+  ASSERT_TRUE(rowHasher->computeValueIdsForRows(
+      groups.data(),
+      kNumGroups,
+      kValueOffset,
+      kNullByte,
+      kNullMask,
+      rowResult));
+
+  for (auto row = 0; row < kNumGroups; ++row) {
+    ASSERT_EQ(row + 1, rowResult[row])
+        << "Expected a distinct value id for an int128_t value that differs "
+           "only in high bits.";
+  }
 }
 
 TEST_F(VectorHasherTest, computeValueIdsInteger) {
@@ -1377,6 +1643,10 @@ TEST_F(VectorHasherTest, stringFilterWithLongStrings) {
   // Test rejection of non-existent strings.
   ASSERT_FALSE(bytesValues->testBytes("not in the set", 14));
   ASSERT_FALSE(bytesValues->testBytes("different", 9));
+
+  hasher->resetStats();
+  EXPECT_TRUE(hasher->empty());
+  EXPECT_EQ(hasher->numUniqueValues(), 0);
 }
 
 TEST_F(VectorHasherTest, stringFilterDistinctOverflow) {

--- a/velox/type/Filter.cpp
+++ b/velox/type/Filter.cpp
@@ -1116,6 +1116,13 @@ std::unique_ptr<Filter> createBigintValues(
 std::unique_ptr<Filter> createHugeintValues(
     const std::vector<int128_t>& values,
     bool nullAllowed) {
+  if (values.empty()) {
+    if (nullAllowed) {
+      return std::make_unique<IsNull>();
+    }
+    return std::make_unique<AlwaysFalse>();
+  }
+
   int128_t min = *std::min_element(values.begin(), values.end());
   int128_t max = *std::max_element(values.begin(), values.end());
 

--- a/velox/type/tests/FilterTest.cpp
+++ b/velox/type/tests/FilterTest.cpp
@@ -258,6 +258,18 @@ TEST(FilterTest, hugeintRangeBoundaryOverflow) {
   EXPECT_FALSE(filter->testInt128(0));
 }
 
+TEST(FilterTest, createHugeintValuesEmpty) {
+  auto filter = createHugeintValues({}, false);
+  EXPECT_EQ(filter->kind(), common::FilterKind::kAlwaysFalse);
+  EXPECT_FALSE(filter->testNull());
+  EXPECT_FALSE(filter->testInt128(0));
+
+  filter = createHugeintValues({}, true);
+  EXPECT_EQ(filter->kind(), common::FilterKind::kIsNull);
+  EXPECT_TRUE(filter->testNull());
+  EXPECT_FALSE(filter->testInt128(0));
+}
+
 TEST(FilterTest, negatedBigintRange) {
   auto filter = notEqual(1, false);
   EXPECT_FALSE(filter->testNull());

--- a/velox/type/tests/FilterTest.cpp
+++ b/velox/type/tests/FilterTest.cpp
@@ -259,6 +259,18 @@ TEST(FilterTest, hugeintRangeBoundaryOverflow) {
   EXPECT_FALSE(filter->testInt128(0));
 }
 
+TEST(FilterTest, createHugeintValuesEmpty) {
+  auto filter = createHugeintValues({}, false);
+  EXPECT_EQ(filter->kind(), common::FilterKind::kAlwaysFalse);
+  EXPECT_FALSE(filter->testNull());
+  EXPECT_FALSE(filter->testInt128(0));
+
+  filter = createHugeintValues({}, true);
+  EXPECT_EQ(filter->kind(), common::FilterKind::kIsNull);
+  EXPECT_TRUE(filter->testNull());
+  EXPECT_FALSE(filter->testInt128(0));
+}
+
 TEST(FilterTest, negatedBigintRange) {
   auto filter = notEqual(1, false);
   EXPECT_FALSE(filter->testNull());


### PR DESCRIPTION
Support dense value IDs and filters for HUGEINT in VectorHasher.

**Details**
VectorHasher now tracks `int128_t` values for HUGEINT / long decimal keys, 
avoiding collisions between values that share the same low 64 bits. Range-based 
hashing remains disabled for HUGEINT.

This also enables `VectorHasher::getFilter()` to produce HUGEINT value filters 
via `common::createHugeintValues()`.

Added tests for HUGEINT value IDs, dynamic filter creation, and high-bit
`int128_t` collision cases.

**Impact**
This adds the VectorHasher utility needed for long decimal dynamic filter 
pushdown and decimal Hive partition keys.

Related issue: https://github.com/facebookincubator/velox/issues/15309

