### PR TITLE
feat: Support kAnti and kLeftSemiFilter in NestedLoopJoin (#18161)

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -2177,7 +2177,9 @@ bool NestedLoopJoinNode::isSupported(JoinType joinType) {
     case JoinType::kLeft:
     case JoinType::kRight:
     case JoinType::kFull:
+    case JoinType::kLeftSemiFilter:
     case JoinType::kLeftSemiProject:
+    case JoinType::kAnti:
       return true;
 
     default:

--- a/velox/exec/NestedLoopJoinProbe.cpp
+++ b/velox/exec/NestedLoopJoinProbe.cpp
@@ -25,7 +25,7 @@ namespace {
 
 bool needsProbeMismatch(core::JoinType joinType) {
   return isLeftJoin(joinType) || isFullJoin(joinType) ||
-      isLeftSemiProjectJoin(joinType);
+      isLeftSemiProjectJoin(joinType) || isAntiJoin(joinType);
 }
 
 bool needsBuildMismatch(core::JoinType joinType) {
@@ -322,11 +322,22 @@ bool NestedLoopJoinProbe::advanceProbe() {
   return false;
 }
 
-void NestedLoopJoinProbe::handleLeftSemiProjectNoCondition() {
+void NestedLoopJoinProbe::handleProbeOnlyNoCondition() {
+  // Reached only with a non-empty build vector, so every probe row matches.
+  if (isAntiJoin(joinType_)) {
+    // Anti join emits nothing when the probe row matches.
+    buildIndex_ = buildVectors_.value().size();
+    filterResultRow_ = 0;
+    return;
+  }
+
+  // Left semi filter and left semi project emit the probe row once.
   rawProbeOutputIndices_[numOutputRows_++] = probeRow_;
-  output_->childAt(outputType_->size() - 1)
-      ->asFlatVector<bool>()
-      ->set(numOutputRows_ - 1, true);
+  if (isLeftSemiProjectJoin(joinType_)) {
+    output_->childAt(outputType_->size() - 1)
+        ->asFlatVector<bool>()
+        ->set(numOutputRows_ - 1, true);
+  }
   buildIndex_ = buildVectors_.value().size();
   filterResultRow_ = 0;
 }
@@ -365,6 +376,13 @@ bool NestedLoopJoinProbe::addFilteredOutput(
         continue;
       }
     } else if (handleMatchedFilterRow(i, buildRowCount, singleProbeRow)) {
+      // The emit-once short-circuit (left semi filter/project) advances the
+      // probe state past the batch-boundary check below. Honor that boundary
+      // here so a full batch is produced instead of overflowing output_.
+      if (numOutputRows_ == outputBatchSize_) {
+        copyBuildValues(buildVector);
+        return false;
+      }
       return true;
     }
 
@@ -402,18 +420,41 @@ bool NestedLoopJoinProbe::handleMatchedFilterRow(
   if (needsBuildMismatch(joinType_)) {
     buildMatched_[buildIndex_].setValid(buildRow_, true);
   }
+
+  // Anti join: a match disqualifies the probe row, so emit nothing and stop
+  // scanning the build for this probe row.
+  if (isAntiJoin(joinType_)) {
+    probeRowHasMatch_ = true;
+    shortCircuitProbeRow(filterResultRow, buildRowCount, singleProbeRow);
+    return true;
+  }
+
   addOutputRow();
   ++numOutputRows_;
   probeRowHasMatch_ = true;
+
+  // Left semi filter: emit the probe row once and stop scanning the build.
+  if (isLeftSemiFilterJoin(joinType_)) {
+    shortCircuitProbeRow(filterResultRow, buildRowCount, singleProbeRow);
+    return true;
+  }
 
   if (!isLeftSemiProjectJoin(joinType_)) {
     return false;
   }
 
+  // Left semi project: set the match column and stop scanning the build.
   output_->childAt(outputType_->size() - 1)
       ->asFlatVector<bool>()
       ->set(numOutputRows_ - 1, true);
+  shortCircuitProbeRow(filterResultRow, buildRowCount, singleProbeRow);
+  return true;
+}
 
+void NestedLoopJoinProbe::shortCircuitProbeRow(
+    vector_size_t filterResultRow,
+    vector_size_t buildRowCount,
+    bool singleProbeRow) {
   if (singleProbeRow) {
     buildIndex_ = buildVectors_.value().size();
     filterResultRow_ = 0;
@@ -424,7 +465,6 @@ bool NestedLoopJoinProbe::handleMatchedFilterRow(
     buildRow_ = 0;
     probeRowHasMatch_ = false;
   }
-  return true;
 }
 
 // Main join loop.
@@ -464,10 +504,10 @@ bool NestedLoopJoinProbe::addToOutput() {
       return false;
     }
 
-    // Handle LeftSemiProjectJoin with no join condition before evaluating the
-    // filter.
-    if (isLeftSemiProjectNoCondition()) {
-      handleLeftSemiProjectNoCondition();
+    // Handle probe-only joins (left semi filter/project, anti) with no join
+    // condition before evaluating the filter (there is no filter to evaluate).
+    if (isProbeOnlyNoCondition()) {
+      handleProbeOnlyNoCondition();
       return true;
     }
 

--- a/velox/exec/NestedLoopJoinProbe.h
+++ b/velox/exec/NestedLoopJoinProbe.h
@@ -23,7 +23,7 @@ namespace facebook::velox::exec {
 
 /// Implements a Nested Loop Join (NLJ) between records from the probe (input_)
 /// and build (NestedLoopJoinBridge) sides. It supports inner, left, right and
-/// full outer joins.
+/// full outer joins, as well as left semi (filter and project) and anti joins.
 ///
 /// This class is generally useful to evaluate non-equi-joins (e.g. "k1 >= k2"),
 /// when join conditions may need to be evaluated against a full cross product
@@ -179,6 +179,14 @@ class NestedLoopJoinProbe : public Operator {
       vector_size_t buildRowCount,
       bool singleProbeRow);
 
+  // Skips the remaining build rows for the current probe row after an
+  // emit-once match (left semi filter/project) or an anti-join match. Shared
+  // by all three probe-only short-circuits.
+  void shortCircuitProbeRow(
+      vector_size_t filterResultRow,
+      vector_size_t buildRowCount,
+      bool singleProbeRow);
+
   // Generates the next batch of a cross product between probe and build. It
   // should be used as the entry point, and will internally delegate to one of
   // the three functions below.
@@ -271,7 +279,7 @@ class NestedLoopJoinProbe : public Operator {
 
   // Cross joins are translated into NLJ's without a join conditition.
   bool isCrossJoin() const {
-    return joinCondition_ == nullptr && !isLeftSemiProjectJoin(joinType_);
+    return joinCondition_ == nullptr && !isProbeOnlyJoin(joinType_);
   }
 
   // If build has a single vector, we can wrap probe and build batches into
@@ -292,13 +300,16 @@ class NestedLoopJoinProbe : public Operator {
     return isSingleBuildVector() && buildVectors_->front()->size() == 1;
   }
 
-  // Check if this is a LeftSemiProjectJoin with no join condition.
-  bool isLeftSemiProjectNoCondition() const {
-    return joinCondition_ == nullptr && isLeftSemiProjectJoin(joinType_);
+  // Check if this is a probe-only join (left semi filter/project, anti) with
+  // no join condition. Every probe row then trivially matches a non-empty
+  // build side.
+  bool isProbeOnlyNoCondition() const {
+    return joinCondition_ == nullptr && isProbeOnlyJoin(joinType_);
   }
 
-  // Handles LeftSemiProjectJoin with no join condition
-  void handleLeftSemiProjectNoCondition();
+  // Handles a probe-only join (left semi filter/project, anti) with no join
+  // condition.
+  void handleProbeOnlyNoCondition();
 
   // Wraps rows of 'data' that are not selected in 'matched' and projects
   // to the output according to 'projections'. 'nullProjections' is used to

--- a/velox/exec/tests/NestedLoopJoinTest.cpp
+++ b/velox/exec/tests/NestedLoopJoinTest.cpp
@@ -769,6 +769,202 @@ TEST_F(NestedLoopJoinTest, smallBuildSideJoins) {
   assertLeftSemiProject(singleRowBuild, "u_single_row");
 }
 
+TEST_F(NestedLoopJoinTest, antiAndLeftSemiFilter) {
+  // kAnti (NOT EXISTS) and kLeftSemiFilter (EXISTS) both output the probe
+  // columns only (no build columns, no match column). Cross-check the full
+  // correctness matrix against DuckDB across the {=, <, <=, <>} comparison set:
+  // matching / non-matching probe rows, NULLs in the join keys, empty build,
+  // empty probe and no join condition. Mirrors the createPlan /
+  // assertLeftSemiProject helpers in smallBuildSideJoins but parameterizes
+  // probe, build and condition so one pair of helpers drives the whole matrix.
+  const auto createProbeOnlyPlan = [&](const RowVectorPtr& probeVector,
+                                       const RowVectorPtr& buildVector,
+                                       const std::string& joinCondition,
+                                       core::JoinType joinType) {
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+    return PlanBuilder(planNodeIdGenerator)
+        .values({probeVector})
+        .nestedLoopJoin(
+            PlanBuilder(planNodeIdGenerator).values({buildVector}).planNode(),
+            joinCondition,
+            {"t0", "t1"},
+            joinType)
+        .planNode();
+  };
+
+  // Left-semi-filter emits each probe row matching >= 1 build row. Oracle: the
+  // probe rows for which a satisfying build row EXISTS.
+  const auto assertLeftSemiFilter = [&](const RowVectorPtr& probeVector,
+                                        const RowVectorPtr& buildVector,
+                                        const std::string& comparison) {
+    createDuckDbTable("t", {probeVector});
+    createDuckDbTable("u", {buildVector});
+    AssertQueryBuilder(
+        createProbeOnlyPlan(
+            probeVector,
+            buildVector,
+            fmt::format("t0 {} u0", comparison),
+            core::JoinType::kLeftSemiFilter),
+        duckDbQueryRunner_)
+        .assertResults(
+            fmt::format(
+                "SELECT t0, t1 FROM t WHERE EXISTS "
+                "(SELECT 1 FROM u WHERE t0 {} u0)",
+                comparison));
+  };
+
+  // Anti emits each probe row matching no build row (a NULL condition is a
+  // non-match). Oracle: the probe rows for which no satisfying build row
+  // EXISTS.
+  const auto assertAnti = [&](const RowVectorPtr& probeVector,
+                              const RowVectorPtr& buildVector,
+                              const std::string& comparison) {
+    createDuckDbTable("t", {probeVector});
+    createDuckDbTable("u", {buildVector});
+    AssertQueryBuilder(
+        createProbeOnlyPlan(
+            probeVector,
+            buildVector,
+            fmt::format("t0 {} u0", comparison),
+            core::JoinType::kAnti),
+        duckDbQueryRunner_)
+        .assertResults(
+            fmt::format(
+                "SELECT t0, t1 FROM t WHERE NOT EXISTS "
+                "(SELECT 1 FROM u WHERE t0 {} u0)",
+                comparison));
+  };
+
+  // Probe rows with matches, non-matches and a NULL join key.
+  const auto probe = makeRowVector(
+      {"t0", "t1"},
+      {
+          makeNullableFlatVector<int64_t>({1, 8, 6, std::nullopt, 7, 4}),
+          makeFlatVector<StringView>({"a", "b", "c", "d", "e", "f"}),
+      });
+  // Build with matches for some probe rows and a NULL join key.
+  const auto build = makeRowVector(
+      {"u0", "u1"},
+      {
+          makeNullableFlatVector<int64_t>({4, 6, std::nullopt}),
+          makeFlatVector<StringView>({"z", "x", "y"}),
+      });
+  // Build whose keys are all NULL, so the condition is NULL for every build
+  // row.
+  const auto allNullBuild = makeRowVector(
+      {"u0", "u1"},
+      {
+          makeNullableFlatVector<int64_t>({std::nullopt, std::nullopt}),
+          makeFlatVector<StringView>({"z", "x"}),
+      });
+  const auto emptyBuild = makeRowVector(
+      {"u0", "u1"},
+      {makeFlatVector<int64_t>({}), makeFlatVector<StringView>({})});
+  const auto emptyProbe = makeRowVector(
+      {"t0", "t1"},
+      {makeFlatVector<int64_t>({}), makeFlatVector<StringView>({})});
+
+  for (const auto& comparison : comparisons_) {
+    SCOPED_TRACE(fmt::format("comparison: {}", comparison));
+
+    // Probe rows that match / don't match, including a NULL probe key.
+    assertLeftSemiFilter(probe, build, comparison);
+    assertAnti(probe, build, comparison);
+
+    // Condition is NULL for every build row: left-semi-filter emits none, anti
+    // emits every probe row.
+    assertLeftSemiFilter(probe, allNullBuild, comparison);
+    assertAnti(probe, allNullBuild, comparison);
+
+    // Empty build: left-semi-filter emits none, anti emits all probe rows.
+    assertLeftSemiFilter(probe, emptyBuild, comparison);
+    assertAnti(probe, emptyBuild, comparison);
+
+    // Empty probe: both emit nothing.
+    assertLeftSemiFilter(emptyProbe, build, comparison);
+    assertAnti(emptyProbe, build, comparison);
+  }
+
+  // No join condition. With a non-empty build every probe row trivially
+  // matches, so left-semi-filter emits all probe rows and anti emits none; with
+  // an empty build the two are reversed.
+  const auto assertNoConditionLeftSemiFilter =
+      [&](const RowVectorPtr& buildVector) {
+        createDuckDbTable("t", {probe});
+        createDuckDbTable("u", {buildVector});
+        AssertQueryBuilder(
+            createProbeOnlyPlan(
+                probe, buildVector, "", core::JoinType::kLeftSemiFilter),
+            duckDbQueryRunner_)
+            .assertResults(
+                "SELECT t0, t1 FROM t WHERE EXISTS (SELECT 1 FROM u)");
+      };
+  const auto assertNoConditionAnti = [&](const RowVectorPtr& buildVector) {
+    createDuckDbTable("t", {probe});
+    createDuckDbTable("u", {buildVector});
+    AssertQueryBuilder(
+        createProbeOnlyPlan(probe, buildVector, "", core::JoinType::kAnti),
+        duckDbQueryRunner_)
+        .assertResults(
+            "SELECT t0, t1 FROM t WHERE NOT EXISTS (SELECT 1 FROM u)");
+  };
+
+  assertNoConditionLeftSemiFilter(build);
+  assertNoConditionAnti(build);
+  assertNoConditionLeftSemiFilter(emptyBuild);
+  assertNoConditionAnti(emptyBuild);
+}
+
+TEST_F(NestedLoopJoinTest, leftSemiFilterAndProjectEmitOnceOverflow) {
+  // C1 regression: with a single build row, probeRowCount_ equals the probe
+  // batch size, so a probe batch whose matching-row count exceeds the output
+  // batch size drives the emit-once short-circuit (kLeftSemiFilter /
+  // kLeftSemiProject) past the output-batch boundary. Guards against
+  // rawProbeOutputIndices_ overflowing its outputBatchSize_ capacity.
+  const vector_size_t numProbeRows = 2'048;
+  const auto probeVector = makeRowVector(
+      {"t0"},
+      {makeFlatVector<int64_t>(numProbeRows, [](auto row) { return row; })});
+  // Single build row for which every probe row matches (t0 < u0), so the whole
+  // probe batch is emitted in one short-circuited pass.
+  const auto buildVector =
+      makeRowVector({"u0"}, {makeFlatVector<int64_t>({numProbeRows})});
+
+  createDuckDbTable("t", {probeVector});
+  createDuckDbTable("u", {buildVector});
+
+  const auto assertEmitOnce = [&](const std::vector<std::string>& outputLayout,
+                                  core::JoinType joinType,
+                                  const std::string& duckDbSql) {
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+    auto plan = PlanBuilder(planNodeIdGenerator)
+                    .values({probeVector})
+                    .nestedLoopJoin(
+                        PlanBuilder(planNodeIdGenerator)
+                            .values({buildVector})
+                            .planNode(),
+                        "t0 < u0",
+                        outputLayout,
+                        joinType)
+                    .planNode();
+    // Output batch far smaller than the probe batch forces the single
+    // short-circuited pass to span multiple output batches.
+    AssertQueryBuilder(plan, duckDbQueryRunner_)
+        .config(core::QueryConfig::kPreferredOutputBatchRows, "128")
+        .config(core::QueryConfig::kMaxOutputBatchRows, "128")
+        .assertResults(duckDbSql);
+  };
+
+  assertEmitOnce(
+      {"t0"},
+      core::JoinType::kLeftSemiFilter,
+      "SELECT t0 FROM t WHERE EXISTS (SELECT 1 FROM u WHERE t0 < u0)");
+  assertEmitOnce(
+      {"t0", "match"},
+      core::JoinType::kLeftSemiProject,
+      "SELECT t0, EXISTS(SELECT 1 FROM u WHERE t0 < u0) AS match FROM t");
+}
+
 TEST_F(NestedLoopJoinTest, mergeBuildVectors) {
   const std::vector<RowVectorPtr> buildVectors = {
       makeRowVector({makeFlatVector<int64_t>({1, 2})}),


### PR DESCRIPTION
Summary:

NestedLoopJoin is the operator Velox uses for cross joins and non-equi joins. Until now it rejected the anti and left-semi-filter join types: building such a plan failed with `The join type is not supported by nested loop join: ANTI`. This adds regular `kAnti` (`NOT EXISTS`) and `kLeftSemiFilter` (`EXISTS`). An optimizer targeting Velox can now plan a non-equi anti or left-semi-filter join directly, instead of downgrading to `kLeftSemiProject` plus a filter on the mark column. Part of #17650.

Both types are new emission decisions on the per-probe-row match state that `kLeftSemiProject` already tracks. `kLeftSemiFilter` emits a probe row once when it matches at least one build row. `kAnti` emits a probe row when it matches none. Both output the probe columns only; the build side and the cross-product scan are unchanged.

This also fixes a latent overflow in the emit-once short-circuit shared with `kLeftSemiProject`. When a single build row matches more probe rows than fit in one output batch, the short-circuit returned before the batch-size check and could write past the output vector. It now produces a full batch and resumes.

Null-aware anti (`NOT IN`) is out of scope. `NestedLoopJoinNode` has no null-aware flag, so anti is regular only, matching `MergeJoinNode`.

Reviewed By: mbasmanova

Differential Revision: D112283617


