### PR TITLE
fix(cudf): Fix DecimalSumState size mismatch

### DIFF
--- a/velox/experimental/cudf/exec/DecimalAggregationState.cpp
+++ b/velox/experimental/cudf/exec/DecimalAggregationState.cpp
@@ -26,9 +26,47 @@
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/strings/utilities.hpp>
 
+#include <cuda_runtime_api.h>
+
 #include <limits>
 
 namespace facebook::velox::cudf_velox {
+namespace {
+
+int64_t readLastStringOffset(
+    cudf::column_view offsetsView,
+    cudf::size_type numRows,
+    rmm::cuda_stream_view stream) {
+  if (offsetsView.type().id() == cudf::type_id::INT32) {
+    int32_t last{};
+    auto status = cudaMemcpyAsync(
+        &last,
+        offsetsView.data<int32_t>() + numRows,
+        sizeof(int32_t),
+        cudaMemcpyDeviceToHost,
+        stream.value());
+    VELOX_CHECK_EQ(0, static_cast<int>(status));
+    stream.synchronize();
+    return last;
+  }
+  if (offsetsView.type().id() == cudf::type_id::INT64) {
+    int64_t last{};
+    auto status = cudaMemcpyAsync(
+        &last,
+        offsetsView.data<int64_t>() + numRows,
+        sizeof(int64_t),
+        cudaMemcpyDeviceToHost,
+        stream.value());
+    VELOX_CHECK_EQ(0, static_cast<int>(status));
+    stream.synchronize();
+    return last;
+  }
+  VELOX_FAIL(
+      "Decimal sum state requires INT32 or INT64 offsets (offset type is {})",
+      cudf::type_to_name(offsetsView.type()));
+}
+
+} // namespace
 
 DecimalSumStateColumns deserializeDecimalSumState(
     const cudf::column_view& stateCol,
@@ -80,16 +118,24 @@ DecimalSumStateColumns deserializeDecimalSumState(
 
   cudf::strings_column_view strings(stateCol);
 
+  auto offsetsView = strings.offsets();
   auto const payloadSize = strings.chars_size(stream);
   auto const expectedPayloadSize =
-      static_cast<int64_t>(numRows) * detail::kDecimalSumStateSize;
-  VELOX_CHECK(
-      payloadSize == expectedPayloadSize,
+      readLastStringOffset(offsetsView, numRows, stream);
+  VELOX_CHECK_EQ(
+      payloadSize,
+      expectedPayloadSize,
       "Decimal sum state requires payload size {} (got {})",
       expectedPayloadSize,
       payloadSize);
+  VELOX_CHECK_LE(
+      expectedPayloadSize,
+      static_cast<int64_t>(numRows) * detail::kDecimalSumStateSize,
+      "Decimal sum state payload size {} exceeds max {} for {} rows",
+      expectedPayloadSize,
+      static_cast<int64_t>(numRows) * detail::kDecimalSumStateSize,
+      numRows);
 
-  auto offsetsView = strings.offsets();
   auto charsPtr = reinterpret_cast<const uint8_t*>(strings.chars_begin(stream));
 
   auto sumCol = cudf::make_fixed_width_column(
@@ -110,11 +156,6 @@ DecimalSumStateColumns deserializeDecimalSumState(
 
   // numRows is guaranteed positive here
   auto const offsetsType = offsetsView.type().id();
-  VELOX_CHECK(
-      offsetsType == cudf::type_id::INT32 ||
-          offsetsType == cudf::type_id::INT64,
-      "Decimal sum state requires INT32 or INT64 offsets (offset type is {})",
-      cudf::type_to_name(offsetsView.type()));
   detail::unpackDecimalSumState(
       offsetsType, offsetsView, charsPtr, sumView, countView, numRows, stream);
 

--- a/velox/experimental/cudf/tests/DecimalAggregationTest.cpp
+++ b/velox/experimental/cudf/tests/DecimalAggregationTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/experimental/cudf/CudfConfig.h"
+#include "velox/experimental/cudf/exec/DecimalAggregationDevice.h"
 #include "velox/experimental/cudf/exec/DecimalAggregationState.h"
 #include "velox/experimental/cudf/exec/ToCudf.h"
 #include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
@@ -1088,6 +1089,46 @@ TEST_F(CudfDecimalTest, decimalDeserializeSumStateDecimal64) {
       serializeDecimalSumState(sumCol->view(), countCol->view(), stream, mr);
   auto sumAndCount = deserializeDecimalSumState(stateCol->view(), 2, stream);
   auto stateMask = copyNullMask(stateCol->view(), stream);
+  auto sumMask = copyNullMask(sumAndCount.sum->view(), stream);
+  EXPECT_EQ(stateMask, sumMask);
+
+  auto outSum = copyColumnData<__int128_t>(sumAndCount.sum->view(), stream);
+  for (size_t i = 0; i < sums.size(); ++i) {
+    bool expectedValid = sumValid[i] && countValid[i] && counts[i] != 0;
+    EXPECT_EQ(isValidAt(sumMask, i), expectedValid);
+    if (expectedValid) {
+      EXPECT_EQ(outSum[i], static_cast<__int128_t>(sums[i]));
+    }
+  }
+}
+
+TEST_F(CudfDecimalTest, decimalDeserializeSumStateAfterVarbinaryRoundTrip) {
+  auto stream = cudf::get_default_stream();
+  auto mr = cudf::get_current_device_resource_ref();
+  std::vector<int64_t> sums = {100, -200, 300, 400};
+  std::vector<int64_t> counts = {1, 0, 2, 3};
+  std::vector<bool> sumValid = {true, true, false, true};
+  std::vector<bool> countValid = {true, true, true, false};
+
+  auto sumCol = makeDecimalColumn<int64_t>(sums, 2, &sumValid, stream);
+  auto countCol = makeInt64Column(counts, &countValid, stream);
+  auto stateCol =
+      serializeDecimalSumState(sumCol->view(), countCol->view(), stream, mr);
+
+  auto rowType = ROW({{"state", VARBINARY()}});
+  cudf::table_view stateTable({stateCol->view()});
+  auto velox = with_arrow::toVeloxColumn(
+      stateTable, pool(), rowType, "rt_", stream, mr);
+  auto cudfAgain = with_arrow::toCudfTable(velox, pool(), stream, mr);
+
+  cudf::strings_column_view strings(cudfAgain->view().column(0));
+  EXPECT_LT(
+      strings.chars_size(stream),
+      static_cast<int64_t>(sums.size()) * detail::kDecimalSumStateSize);
+
+  auto sumAndCount =
+      deserializeDecimalSumState(cudfAgain->view().column(0), 2, stream);
+  auto stateMask = copyNullMask(cudfAgain->view().column(0), stream);
   auto sumMask = copyNullMask(sumAndCount.sum->view(), stream);
   EXPECT_EQ(stateMask, sumMask);
 

--- a/velox/experimental/cudf/tests/DecimalAggregationTest.cpp
+++ b/velox/experimental/cudf/tests/DecimalAggregationTest.cpp
@@ -1117,8 +1117,8 @@ TEST_F(CudfDecimalTest, decimalDeserializeSumStateAfterVarbinaryRoundTrip) {
 
   auto rowType = ROW({{"state", VARBINARY()}});
   cudf::table_view stateTable({stateCol->view()});
-  auto velox = with_arrow::toVeloxColumn(
-      stateTable, pool(), rowType, "rt_", stream, mr);
+  auto velox =
+      with_arrow::toVeloxColumn(stateTable, pool(), rowType, "rt_", stream, mr);
   auto cudfAgain = with_arrow::toCudfTable(velox, pool(), stream, mr);
 
   cudf::strings_column_view strings(cudfAgain->view().column(0));


### PR DESCRIPTION
TPC-DS Q2 fails in `CudfGroupbyFINAL` when merging partial decimal SUM state that crossed a Velox exchange:

    Decimal sum state requires payload size 4480 (got 4448)
    Operator: CudfGroupbyFINAL[51]

GPU partial serialization packs each row into a fixed 32-byte payload and still advances string offsets for invalid rows (`count == 0`), so a column with 140 rows normally has `chars_size == 140 × 32 == 4480`. After the state is exported as Velox `VARBINARY`, shuffled, and re-imported as cuDF `STRING`, null rows become empty strings and no longer contribute bytes to the chars buffer. The column still has 140 rows, but `chars_size` drops to `139 × 32 == 4448`. `deserializeDecimalSumState()` compared `chars_size` to `numRows × 32`, so FINAL aggregation rejected otherwise valid exchanged state.

Validate payload size against the string offset table (`offsets[numRows]`) instead of assuming every row occupies 32 bytes. Keep an upper bound of `numRows × 32` so corrupted buffers are still rejected. Unpack behavior is unchanged: null rows stay null via the source null mask.

Test plan: `DecimalAggregationTest.decimalDeserializeSumStateAfterVarbinaryRoundTrip` — serialize partial SUM state, round-trip through Velox `VARBINARY` via Arrow, re-import to cuDF `STRING`, and deserialize the sum/count columns.

(cherry picked from commit 575df6252dbe910dfaa254c23be0b8e8129ae6b6)