### PR TITLE
fix(type): Treat custom types as opaque in coercion (#18164)

### DIFF
--- a/velox/type/TypeCoercer.cpp
+++ b/velox/type/TypeCoercer.cpp
@@ -310,6 +310,13 @@ TypePtr TypeCoercer::leastCommonSuperType(const TypePtr& a, const TypePtr& b)
     return nullptr;
   }
 
+  // Custom types do not participate in structural coercion: their
+  // size()/childAt() expose a physical backing, not type parameters, so they
+  // cannot be reconstructed via getType(name, params). Treat them as opaque.
+  if (customTypeExists(a->name())) {
+    return a->equivalent(*b) ? a : nullptr;
+  }
+
   if (a->name() == TypeKindName::toName(TypeKind::ROW)) {
     return leastCommonSuperRowType(*this, a->asRow(), b->asRow());
   }

--- a/velox/type/tests/TypeCoercerTest.cpp
+++ b/velox/type/tests/TypeCoercerTest.cpp
@@ -39,6 +39,59 @@ void testNoCoercion(const TypePtr& fromType, const TypePtr& toType) {
   ASSERT_FALSE(coercion.has_value());
 }
 
+// A ROW-backed custom type registered under a custom name that exposes no type
+// parameters.
+class RowBackedCustomType final : public RowType {
+  RowBackedCustomType() : RowType({"a", "b"}, {BIGINT(), TINYINT()}) {}
+
+ public:
+  static std::shared_ptr<const RowBackedCustomType> get() {
+    static const RowBackedCustomType kInstance;
+    return {std::shared_ptr<const RowBackedCustomType>{}, &kInstance};
+  }
+
+  bool equivalent(const Type& other) const override {
+    // Pointer comparison works since this type is a singleton.
+    return this == &other;
+  }
+
+  const char* name() const override {
+    return "ROW_BACKED_CUSTOM";
+  }
+
+  std::string toString() const override {
+    return name();
+  }
+
+  std::span<const TypeParameter> parameters() const override {
+    return {};
+  }
+
+  folly::dynamic serialize() const override {
+    folly::dynamic obj = folly::dynamic::object;
+    obj["name"] = "Type";
+    obj["type"] = name();
+    return obj;
+  }
+};
+
+class RowBackedCustomTypeFactory : public CustomTypeFactory {
+ public:
+  TypePtr getType(const std::vector<TypeParameter>& parameters) const override {
+    VELOX_CHECK(parameters.empty());
+    return RowBackedCustomType::get();
+  }
+
+  exec::CastOperatorPtr getCastOperator() const override {
+    return nullptr;
+  }
+
+  AbstractInputGeneratorPtr getInputGenerator(
+      const InputGeneratorConfig& /*config*/) const override {
+    return nullptr;
+  }
+};
+
 TEST(TypeCoercerTest, basic) {
   testCoercion(TINYINT(), TINYINT());
   testCoercion(TINYINT(), BIGINT());
@@ -374,6 +427,28 @@ TEST(TypeCoercerTest, leastCommonSuperType) {
   ASSERT_TRUE(
       TypeCoercer::defaults().leastCommonSuperType(
           MAP(INTEGER(), REAL()), ROW({INTEGER(), REAL()})) == nullptr);
+}
+
+TEST(TypeCoercerTest, customType) {
+  registerCustomType(
+      "ROW_BACKED_CUSTOM",
+      std::make_unique<const RowBackedCustomTypeFactory>());
+
+  const auto customType = RowBackedCustomType::get();
+
+  // A custom type is opaque to structural coercion: its common super type with
+  // itself is itself.
+  VELOX_ASSERT_EQ_TYPES(
+      TypeCoercer::defaults().leastCommonSuperType(customType, customType),
+      customType);
+
+  // No common super type between a custom type and an unrelated type.
+  ASSERT_TRUE(
+      TypeCoercer::defaults().leastCommonSuperType(customType, BIGINT()) ==
+      nullptr);
+  ASSERT_TRUE(
+      TypeCoercer::defaults().leastCommonSuperType(
+          customType, ROW({"a", "b"}, {BIGINT(), TINYINT()})) == nullptr);
 }
 
 TEST(TypeCoercerTest, ctorRejectsDuplicateCostForSameSource) {


### PR DESCRIPTION
Summary:

`TypeCoercer::leastCommonSuperType` crashed when reconciling two values of the same custom type. For example, an array constructor over two IPPREFIX values:

    ARRAY[CAST('...' AS ipprefix), CAST('...' AS ipprefix)]

failed during expression resolution with:

    Expression: parameters.empty()

leastCommonSuperType handled any type with children by recursing into them and rebuilding the type via `getType(name, childTypes)`. A custom type reports its physical backing through `size()`/`childAt()`, but those children are not type parameters. IPPREFIX is backed by a row of two fields while its factory takes no parameters, so `getType("IPPREFIX", {...})` tripped the factory's `parameters.empty()` check.

Custom types do not participate in structural coercion: the common super type of a custom type with itself is the type, and with any other type there is none. Return that directly instead of decomposing the type into its physical children.

Reviewed By: amitkdutta, natashasehgal

Differential Revision: D112479257


