### PR TITLE
feat(cuDF): Rebatch before HashJoinProbe to improve compute utilization in large clusters

### DIFF
--- a/velox/experimental/cudf/exec/OperatorAdapters.cpp
+++ b/velox/experimental/cudf/exec/OperatorAdapters.cpp
@@ -433,6 +433,10 @@ class HashJoinProbeAdapter : public CudfHashJoinBaseAdapter {
         std::dynamic_pointer_cast<const core::HashJoinNode>(planNode);
 
     std::vector<std::unique_ptr<exec::Operator>> result;
+    if (CudfConfig::getInstance().concatOptimizationEnabled) {
+      result.push_back(
+          std::make_unique<CudfBatchConcat>(operatorId, ctx, joinPlanNode));
+    }
     result.push_back(
         std::make_unique<CudfHashJoinProbe>(operatorId, ctx, joinPlanNode));
     return result;


### PR DESCRIPTION
When running with Presto in cuDF mode with a large worker count (>30), queries with many back to back joins end up with very small batches in `CudfHashJoinProbe::addInput()` due to hash partitioning before each join. Since CudfHashJoin launches a join kernel for each input, we end up with several small kernel launches an under-utilizing the compute. By re-batching (waiting until we have a decent number of rows before launching kernels), we saw big improvements in compute utilization and performance.

#### Results for some join heavy queries:
tpch SF30k, 32 GPU workers
|Query|Before|After|
|-|-|-|
|Q9|37.7s|15.5s|
|Q21|18.4s|9.9s|

#### NSight Profile screenshots:
Q9 Before(Top) vs After(Bottom)
<img width="1530" height="429" alt="Screenshot 2026-07-17 at 1 29 37 PM" src="https://github.com/user-attachments/assets/87b5f5f5-9556-4c9a-920d-cbd60696d0d2" />

Q21 Before(Top) vs After(Bottom)
<img width="1530" height="485" alt="Screenshot 2026-07-17 at 1 31 48 PM" src="https://github.com/user-attachments/assets/b4764a74-aa44-46e3-9463-366f9488551f" />
