### PR TITLE
fix: Prevent cancelled direct coalesced loads from exposing partial data

### DIFF
--- a/velox/dwio/common/DirectBufferedInput.cpp
+++ b/velox/dwio/common/DirectBufferedInput.cpp
@@ -451,6 +451,11 @@ int32_t DirectCoalescedLoad::getData(
     int64_t offset,
     memory::Allocation& data,
     std::string& tinyData) {
+  // A failed read may have partially filled the request buffers. Only publish
+  // them after the complete coalesced load has succeeded.
+  if (state() != CoalescedLoad::State::kLoaded) {
+    return 0;
+  }
   auto it = std::lower_bound(
       requests_.begin(), requests_.end(), offset, [](auto& x, auto offset) {
         return x.region.offset < offset;

--- a/velox/dwio/dwrf/test/DirectBufferedInputTest.cpp
+++ b/velox/dwio/dwrf/test/DirectBufferedInputTest.cpp
@@ -18,13 +18,19 @@
 #include <folly/Random.h>
 #include <folly/container/F14Map.h>
 #include <folly/executors/IOThreadPoolExecutor.h>
+#include <deque>
+#include <exception>
+#include <fstream>
+#include "velox/common/file/LocalFile.h"
 #include "velox/common/io/IoStatistics.h"
 #include "velox/common/memory/MmapAllocator.h"
+#include "velox/common/testutil/TempFilePath.h"
 #include "velox/dwio/common/Options.h"
 #include "velox/dwio/dwrf/common/Common.h"
 #include "velox/dwio/dwrf/test/TestReadFile.h"
 
 #include <gtest/gtest.h>
+#include <unistd.h>
 
 using namespace facebook::velox;
 using namespace facebook::velox::dwio;
@@ -41,6 +47,42 @@ struct TestRegion {
   int32_t length;
   bool read = true;
 };
+
+class QueuedExecutor final : public folly::Executor {
+ public:
+  void add(folly::Func func) override {
+    functions_.push_back(std::move(func));
+  }
+
+  size_t size() const {
+    return functions_.size();
+  }
+
+  std::exception_ptr runNext() {
+    VELOX_CHECK(!functions_.empty());
+    auto func = std::move(functions_.front());
+    functions_.pop_front();
+    try {
+      func();
+      return nullptr;
+    } catch (...) {
+      return std::current_exception();
+    }
+  }
+
+ private:
+  std::deque<folly::Func> functions_;
+};
+
+std::string readAll(SeekableInputStream& stream) {
+  std::string result;
+  const void* buffer;
+  int32_t size;
+  while (stream.Next(&buffer, &size)) {
+    result.append(static_cast<const char*>(buffer), size);
+  }
+  return result;
+}
 
 class DirectBufferedInputTest : public testing::Test {
  protected:
@@ -225,4 +267,56 @@ TEST_F(DirectBufferedInputTest, ioStatsLifeTimeTest) {
     testLoads({{1000, 9000000}, {9010000, 1000000}}, 3, stats);
     t.join();
   }
+}
+
+TEST_F(DirectBufferedInputTest, cancelledLocalLoadFallsBackToSyncRead) {
+  constexpr int32_t kRegionSize = 1024;
+  std::string content(4 * kRegionSize, 0);
+  for (size_t i = 0; i < content.size(); ++i) {
+    content[i] = 'a' + (i % 26);
+  }
+
+  auto tempFile = facebook::velox::common::testutil::TempFilePath::create();
+  tempFile->append(content);
+  auto localFile = std::make_shared<LocalReadFile>(tempFile->getPath());
+  QueuedExecutor executor;
+  auto input = std::make_unique<DirectBufferedInput>(
+      localFile,
+      dwio::common::MetricsLog::voidLog(),
+      StringIdLease{},
+      tracker_,
+      StringIdLease{},
+      ioStatistics_,
+      ioStats_,
+      &executor,
+      *opts_);
+
+  auto first = input->enqueue({0, kRegionSize}, nullptr);
+  auto second = input->enqueue({kRegionSize, kRegionSize}, nullptr);
+  input->load(LogType::FILE);
+  ASSERT_EQ(executor.size(), 1);
+
+  // Keep the size cached by LocalReadFile, but truncate the backing file so
+  // preadv fills the first region and half of the second before returning a
+  // short read. ReadFileInputStream turns the short read into an exception and
+  // the coalesced load becomes cancelled.
+  ASSERT_EQ(
+      ::truncate(tempFile->getPath().c_str(), kRegionSize + kRegionSize / 2),
+      0);
+  ASSERT_NE(executor.runNext(), nullptr);
+
+  // Restore the file so the foreground synchronous fallback can succeed.
+  {
+    std::ofstream output(
+        tempFile->getPath(), std::ios::binary | std::ios::trunc);
+    ASSERT_TRUE(output.good());
+    output.write(content.data(), content.size());
+    output.close();
+    ASSERT_TRUE(output.good());
+  }
+
+  EXPECT_EQ(readAll(*first), content.substr(0, kRegionSize));
+  EXPECT_EQ(readAll(*second), content.substr(kRegionSize, kRegionSize));
+  EXPECT_EQ(ioStatistics_->read().count(), 2);
+  EXPECT_EQ(ioStatistics_->read().sum(), 2 * kRegionSize);
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Prevent a cancelled `DirectCoalescedLoad` from publishing buffers that may have been only partially filled before an asynchronous read failed, and add local-file regression coverage for the synchronous recovery path.

1. **Guard cancelled coalesced loads**: `DirectCoalescedLoad::loadData()` allocates each request buffer and records a non-zero `loadSize` before issuing the underlying read. If the read writes part of the requested data and then throws, `CoalescedLoad::loadOrFuture()` transitions the load to `kCancelled`. Previously, `DirectCoalescedLoad::getData()` did not inspect this state: it moved the partially filled buffer into the waiting `DirectInputStream` and returned the precomputed `loadSize`. Because `loadedRegion_.length` was non-zero, `DirectInputStream::loadPosition()` skipped `loadSync()` and could expose incomplete or uninitialized bytes. `getData()` now returns zero unless the coalesced load reached `kLoaded`, which activates the existing synchronous fallback and rereads the requested region safely.

2. **Local-file regression test**: cache a `LocalReadFile` size, truncate the backing file after the asynchronous load is queued, and make `preadv` fill the first region plus half of the second before reporting a short read. The file is restored before the foreground streams are consumed. Without the state guard, the second stream contains the partial prefix followed by zero-filled bytes and no synchronous reads are recorded. With the guard, both streams return the original content and the two foreground reads are recorded.

3. **Cached path is unaffected**: `CachedBufferedInput`'s `DwioCoalescedLoad` / `SsdLoad` write into `AsyncDataCacheEntry` pins that are only transitioned from exclusive to shared after `loadData()` succeeds (see `CoalescedLoad::loadOrFuture` in `AsyncDataCache.cpp`). A cancelled cached load leaves the entry in the exclusive state; the pin is evicted when it goes out of scope, and `CacheInputStream::loadSync` re-reads the region through a fresh `findOrCreate`. Partial data is never published to shared readers, so no analogous guard is needed there.

The asynchronous exception itself still follows the existing prefetch behavior. This patch changes only whether data from that failed load is considered usable; successful `kLoaded` coalesced loads, including duplicate-region handling, are unchanged.

## How was this patch tested?

- `./_build/release/velox/dwio/dwrf/test/velox_dwio_cache_test '--gtest_filter=DirectBufferedInputTest.*'`: all 5 tests passed, including `cancelledLocalLoadFallsBackToSyncRead`.
- Before/after regression check: removing the new state guard makes `cancelledLocalLoadFallsBackToSyncRead` fail with a partially correct, partially zero-filled second region and zero synchronous-read metrics; restoring the guard makes it pass.
- `git diff --check`: passed.

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)
