### PR TITLE
fix(cudf): Register Presto functions in TPCH GPU benchmark

### DIFF
--- a/velox/experimental/cudf/benchmarks/CudfTpchBenchmark.cpp
+++ b/velox/experimental/cudf/benchmarks/CudfTpchBenchmark.cpp
@@ -20,6 +20,7 @@
 #include "velox/experimental/cudf/connectors/hive/CudfHiveTableHandle.h"
 #include "velox/experimental/cudf/exec/CudfConversion.h"
 #include "velox/experimental/cudf/exec/ToCudf.h"
+#include "velox/experimental/cudf/expression/PrestoFunctions.h"
 #include "velox/experimental/cudf/tests/utils/CudfHiveConnectorTestBase.h"
 
 #include "velox/connectors/ConnectorRegistry.h"
@@ -97,6 +98,8 @@ void CudfTpchBenchmark::initialize() {
   }
 
   cudf_velox::registerCudf();
+  cudf_velox::registerPrestoFunctions(
+      cudf_velox::CudfConfig::getInstance().functionNamePrefix);
 
   queryConfigs_[facebook::velox::cudf_velox::CudfFromVelox::kGpuBatchSizeRows] =
       std::to_string(FLAGS_cudf_gpu_batch_size_rows);

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -41,8 +41,6 @@
 
 #include <cuda.h>
 
-#include <experimental/cudf/expression/PrestoFunctions.h>
-
 #include <iostream>
 
 static const std::string kCudfAdapterName = "cuDF";
@@ -312,7 +310,6 @@ void registerCudf() {
 
   auto prefix = CudfConfig::getInstance().functionNamePrefix;
   registerBuiltinFunctions(prefix);
-  registerPrestoFunctions(prefix);
   registerPrestoAggregateFunctions(prefix);
 
   CUDF_FUNC_RANGE();

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -41,6 +41,8 @@
 
 #include <cuda.h>
 
+#include <experimental/cudf/expression/PrestoFunctions.h>
+
 #include <iostream>
 
 static const std::string kCudfAdapterName = "cuDF";
@@ -310,6 +312,7 @@ void registerCudf() {
 
   auto prefix = CudfConfig::getInstance().functionNamePrefix;
   registerBuiltinFunctions(prefix);
+  registerPrestoFunctions(prefix);
   registerPrestoAggregateFunctions(prefix);
 
   CUDF_FUNC_RANGE();


### PR DESCRIPTION
**Summary:**

TPCH Q22 GPU benchmarks fail with `Unsupported expression: substr` because `registerCudf()` only registers builtin and aggregate functions after #16960.  
Register Presto scalar functions in the benchmark so queries like `Q22` that use `substr()` in table-scan filters and projections succeed, while keeping the engine function separation.
