### PR TITLE
fix(core): Handle shared expression DAGs in linear time (#18169)

### DIFF
--- a/velox/core/Expressions.cpp
+++ b/velox/core/Expressions.cpp
@@ -443,18 +443,20 @@ size_t ConstantTypedExpr::localHash() const {
 }
 
 std::string CallTypedExpr::toString() const {
-  std::string str{};
-  str += name();
-  str += "(";
+  return toStringWithSharing();
+}
+
+void CallTypedExpr::appendToString(std::string& out, ExprToStringContext& ctx)
+    const {
+  out += name();
+  out += "(";
   for (size_t i = 0; i < inputs().size(); ++i) {
-    auto& input = inputs().at(i);
     if (i != 0) {
-      str += ",";
+      out += ",";
     }
-    str += input->toString();
+    inputs().at(i)->appendWithSharing(out, ctx);
   }
-  str += ")";
-  return str;
+  out += ")";
 }
 
 void CallTypedExpr::accept(
@@ -506,13 +508,23 @@ TypedExprPtr FieldAccessTypedExpr::rewriteInputNames(
 }
 
 std::string FieldAccessTypedExpr::toString() const {
+  return toStringWithSharing();
+}
+
+void FieldAccessTypedExpr::appendToString(
+    std::string& out,
+    ExprToStringContext& ctx) const {
   std::stringstream ss;
   ss << std::quoted(name(), '"', '"');
   if (inputs().empty()) {
-    return fmt::format("{}", ss.str());
+    out += ss.str();
+    return;
   }
 
-  return fmt::format("{}[{}]", inputs()[0]->toString(), ss.str());
+  inputs()[0]->appendWithSharing(out, ctx);
+  out += "[";
+  out += ss.str();
+  out += "]";
 }
 
 void FieldAccessTypedExpr::accept(
@@ -592,17 +604,19 @@ ConcatTypedExpr::ConcatTypedExpr(
     : ITypedExpr{ExprKind::kConcat, toRowType(names, inputs), inputs} {}
 
 std::string ConcatTypedExpr::toString() const {
-  std::string str{};
-  str += "CONCAT(";
+  return toStringWithSharing();
+}
+
+void ConcatTypedExpr::appendToString(std::string& out, ExprToStringContext& ctx)
+    const {
+  out += "CONCAT(";
   for (size_t i = 0; i < inputs().size(); ++i) {
-    auto& input = inputs().at(i);
     if (i != 0) {
-      str += ",";
+      out += ",";
     }
-    str += input->toString();
+    inputs().at(i)->appendWithSharing(out, ctx);
   }
-  str += ")";
-  return str;
+  out += ")";
 }
 
 void ConcatTypedExpr::accept(
@@ -658,13 +672,14 @@ TypedExprPtr LambdaTypedExpr::create(const folly::dynamic& obj, void* context) {
 }
 
 std::string CastTypedExpr::toString() const {
-  if (isTryCast_) {
-    return fmt::format(
-        "try_cast({} as {})", inputs()[0]->toString(), type()->toString());
-  } else {
-    return fmt::format(
-        "cast({} as {})", inputs()[0]->toString(), type()->toString());
-  }
+  return toStringWithSharing();
+}
+
+void CastTypedExpr::appendToString(std::string& out, ExprToStringContext& ctx)
+    const {
+  out += isTryCast_ ? "try_cast(" : "cast(";
+  inputs()[0]->appendWithSharing(out, ctx);
+  out += fmt::format(" as {})", type()->toString());
 }
 
 void CastTypedExpr::accept(
@@ -720,8 +735,16 @@ bool NullIfTypedExpr::operator==(const ITypedExpr& other) const {
 }
 
 std::string NullIfTypedExpr::toString() const {
-  return fmt::format(
-      "nullif({}, {})", inputs()[0]->toString(), inputs()[1]->toString());
+  return toStringWithSharing();
+}
+
+void NullIfTypedExpr::appendToString(std::string& out, ExprToStringContext& ctx)
+    const {
+  out += "nullif(";
+  inputs()[0]->appendWithSharing(out, ctx);
+  out += ", ";
+  inputs()[1]->appendWithSharing(out, ctx);
+  out += ")";
 }
 
 void NullIfTypedExpr::accept(

--- a/velox/core/Expressions.h
+++ b/velox/core/Expressions.h
@@ -228,6 +228,9 @@ class CallTypedExpr : public ITypedExpr {
 
   std::string toString() const override;
 
+  void appendToString(std::string& out, ExprToStringContext& ctx)
+      const override;
+
   size_t localHash() const override {
     static const size_t kBaseHash =
         folly::hasher<std::string_view>()("CallTypedExpr");
@@ -296,6 +299,9 @@ class FieldAccessTypedExpr : public ITypedExpr {
       const override;
 
   std::string toString() const override;
+
+  void appendToString(std::string& out, ExprToStringContext& ctx)
+      const override;
 
   size_t localHash() const override {
     static const size_t kBaseHash =
@@ -377,11 +383,18 @@ class DereferenceTypedExpr : public ITypedExpr {
   }
 
   std::string toString() const override {
+    return toStringWithSharing();
+  }
+
+  void appendToString(std::string& out, ExprToStringContext& ctx)
+      const override {
+    inputs()[0]->appendWithSharing(out, ctx);
     const auto& fieldName = name();
     if (fieldName.empty()) {
-      return fmt::format("{}[{}]", inputs()[0]->toString(), index_);
+      out += fmt::format("[{}]", index_);
+    } else {
+      out += fmt::format("[{}]", fieldName);
     }
-    return fmt::format("{}[{}]", inputs()[0]->toString(), fieldName);
   }
 
   size_t localHash() const override {
@@ -439,6 +452,9 @@ class ConcatTypedExpr : public ITypedExpr {
   }
 
   std::string toString() const override;
+
+  void appendToString(std::string& out, ExprToStringContext& ctx)
+      const override;
 
   size_t localHash() const override {
     static const size_t kBaseHash =
@@ -501,8 +517,13 @@ class LambdaTypedExpr : public ITypedExpr {
       const override;
 
   std::string toString() const override {
-    return fmt::format(
-        "lambda {} -> {}", signature_->toString(), body_->toString());
+    return toStringWithSharing();
+  }
+
+  void appendToString(std::string& out, ExprToStringContext& ctx)
+      const override {
+    out += fmt::format("lambda {} -> ", signature_->toString());
+    body_->appendWithSharing(out, ctx);
   }
 
   size_t localHash() const override {
@@ -570,6 +591,9 @@ class CastTypedExpr : public ITypedExpr {
 
   std::string toString() const override;
 
+  void appendToString(std::string& out, ExprToStringContext& ctx)
+      const override;
+
   size_t localHash() const override {
     static const size_t kBaseHash =
         folly::hasher<std::string_view>()("CastTypedExpr");
@@ -636,6 +660,9 @@ class NullIfTypedExpr : public ITypedExpr {
       const override;
 
   std::string toString() const override;
+
+  void appendToString(std::string& out, ExprToStringContext& ctx)
+      const override;
 
   size_t localHash() const override;
 

--- a/velox/core/ITypedExpr.cpp
+++ b/velox/core/ITypedExpr.cpp
@@ -38,6 +38,59 @@ const auto& exprKindNames() {
 
 VELOX_DEFINE_ENUM_NAME(ExprKind, exprKindNames);
 
+namespace {
+void countReferences(
+    const ITypedExpr& expr,
+    folly::F14FastMap<const ITypedExpr*, uint32_t>& refCounts) {
+  auto [it, inserted] = refCounts.emplace(&expr, 1);
+  if (!inserted) {
+    // Already visited this node's subtree; just record the extra reference.
+    ++it->second;
+    return;
+  }
+  for (const auto& input : expr.inputs()) {
+    countReferences(*input, refCounts);
+  }
+}
+} // namespace
+
+void ITypedExpr::appendToString(std::string& out, ExprToStringContext& /*ctx*/)
+    const {
+  out += toString();
+}
+
+void ITypedExpr::appendWithSharing(std::string& out, ExprToStringContext& ctx)
+    const {
+  if (auto it = ctx.labels.find(this); it != ctx.labels.end()) {
+    out += '#';
+    out += std::to_string(it->second);
+    return;
+  }
+
+  appendToString(out, ctx);
+
+  // Label a shared non-leaf node the first time it is printed, so later
+  // occurrences reference it by "#N" instead of re-expanding it. Leaves are
+  // cheap to reprint, so they are left unlabeled to avoid noise.
+  if (!inputs().empty()) {
+    if (auto it = ctx.refCounts.find(this);
+        it != ctx.refCounts.end() && it->second > 1) {
+      const uint32_t id = ctx.nextLabel++;
+      ctx.labels.emplace(this, id);
+      out += " as #";
+      out += std::to_string(id);
+    }
+  }
+}
+
+std::string ITypedExpr::toStringWithSharing() const {
+  ExprToStringContext ctx;
+  countReferences(*this, ctx.refCounts);
+  std::string out;
+  appendWithSharing(out, ctx);
+  return out;
+}
+
 size_t ITypedExprHasher::operator()(const ITypedExpr* expr) const {
   return expr->hash();
 }

--- a/velox/core/ITypedExpr.h
+++ b/velox/core/ITypedExpr.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <folly/container/F14Map.h>
+
 #include "velox/type/Type.h"
 
 namespace facebook::velox::core {
@@ -45,6 +47,22 @@ struct ITypedExprHasher {
 
 struct ITypedExprComparer {
   bool operator()(const ITypedExpr* lhs, const ITypedExpr* rhs) const;
+};
+
+/// State threaded through sharing-aware expression printing. Expressions form a
+/// DAG: a shared subexpression is one node reached from several parents.
+/// Printing such a DAG as a tree takes time and space exponential in its depth.
+/// With this context each shared subexpression is written out once, followed by
+/// an "as #N" label, and every later occurrence prints just "#N".
+struct ExprToStringContext {
+  /// Number of times each node is reached in the DAG rooted at the expression
+  /// being printed. A node reached more than once is shared.
+  folly::F14FastMap<const ITypedExpr*, uint32_t> refCounts;
+
+  /// Labels assigned to shared nodes that have already been printed in full.
+  folly::F14FastMap<const ITypedExpr*, uint32_t> labels;
+
+  uint32_t nextLabel{1};
 };
 
 /// Strongly-typed expression, e.g. literal, function call, etc.
@@ -128,6 +146,12 @@ class ITypedExpr : public ISerializable {
 
   virtual std::string toString() const = 0;
 
+  /// Appends this expression to 'out', reusing 'ctx' so that a shared
+  /// subexpression is printed once with an "as #N" label and every later
+  /// occurrence is printed as just "#N". This prints an expression DAG in
+  /// linear size, unlike toString() which expands it as a tree.
+  void appendWithSharing(std::string& out, ExprToStringContext& ctx) const;
+
   /// Returns a hash value for this expression node only, not including inputs.
   /// Implementations must use a stable hash like folly::hasher to ensure
   /// stable hashing across processes and builds.
@@ -152,6 +176,24 @@ class ITypedExpr : public ISerializable {
   static void registerSerDe();
 
  protected:
+  // Appends this node's own textual form to 'out', recursing into inputs via
+  // appendWithSharing so that sharing is preserved. The default prints the node
+  // via toString() and is used by leaves and by subclasses that do not opt into
+  // sharing-aware printing.
+  //
+  // Invariant: a subclass that recurses into inputs must EITHER leave both this
+  // and toString() at their defaults, OR override this AND make toString()
+  // return toStringWithSharing() - the two go together. Overriding only
+  // toString() to call toStringWithSharing() without also overriding this loops
+  // forever (the default appendToString() calls toString() calls
+  // toStringWithSharing() calls the default appendToString()).
+  virtual void appendToString(std::string& out, ExprToStringContext& ctx) const;
+
+  // Builds a fresh context and prints this expression sharing-aware. Recursive
+  // subclasses call this from toString(); see the invariant on
+  // appendToString().
+  std::string toStringWithSharing() const;
+
   folly::dynamic serializeBase(std::string_view name) const;
 
   std::vector<TypedExprPtr> rewriteInputsRecursive(

--- a/velox/core/PlanConsistencyChecker.cpp
+++ b/velox/core/PlanConsistencyChecker.cpp
@@ -315,9 +315,26 @@ class Checker : public PlanNodeVisitor {
     }
   }
 
+  using TypedExprCache = folly::F14FastSet<const ITypedExpr*>;
+
   static void checkInputs(
       const core::TypedExprPtr& expr,
       const RowTypePtr& rowType) {
+    TypedExprCache visited;
+    checkInputs(expr, rowType, visited);
+  }
+
+  static void checkInputs(
+      const core::TypedExprPtr& expr,
+      const RowTypePtr& rowType,
+      TypedExprCache& visited) {
+    // A TypedExpr is a DAG: a shared subexpression is reached from many
+    // parents. Check each node once, so a heavily-shared expression is
+    // validated in linear rather than exponential time.
+    if (!visited.insert(expr.get()).second) {
+      return;
+    }
+
     if (expr->isFieldAccessKind()) {
       auto fieldAccess = expr->asUnchecked<core::FieldAccessTypedExpr>();
       if (fieldAccess->isInputColumn()) {
@@ -337,11 +354,12 @@ class Checker : public PlanNodeVisitor {
 
     if (expr->isLambdaKind()) {
       const auto& lambda = expr->asUnchecked<core::LambdaTypedExpr>();
-      checkInputs(lambda->body(), lambda->signature()->unionWith(rowType));
+      checkInputs(
+          lambda->body(), lambda->signature()->unionWith(rowType), visited);
     }
 
     for (const auto& input : expr->inputs()) {
-      checkInputs(input, rowType);
+      checkInputs(input, rowType, visited);
     }
   }
 

--- a/velox/core/tests/CMakeLists.txt
+++ b/velox/core/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(
   StringTest.cpp
   TypeAnalysisTest.cpp
   TypedExprSerdeTest.cpp
+  TypedExprToStringTest.cpp
 )
 
 add_test(velox_core_test velox_core_test)

--- a/velox/core/tests/PlanConsistencyCheckerTest.cpp
+++ b/velox/core/tests/PlanConsistencyCheckerTest.cpp
@@ -261,6 +261,35 @@ TEST_F(PlanConsistencyCheckerTest, aggregation) {
   }
 }
 
+TEST_F(PlanConsistencyCheckerTest, sharedSubexpressionDag) {
+  auto valuesNode =
+      std::make_shared<ValuesNode>(nextId(), std::vector<RowVectorPtr>{});
+
+  auto sourceNode = std::make_shared<ProjectNode>(
+      nextId(),
+      std::vector<std::string>{"x"},
+      std::vector<TypedExprPtr>{Lit(int64_t{1})},
+      valuesNode);
+
+  // Each level squares the one below by referencing it twice, so the expression
+  // is a DAG whose expansion as a tree has 2^depth nodes. The checker must
+  // visit each node once; otherwise validating this is exponential.
+  constexpr int kDepth = 40;
+  TypedExprPtr expr = Col(BIGINT(), "x");
+  for (int i = 0; i < kDepth; ++i) {
+    expr = std::make_shared<CallTypedExpr>(
+        BIGINT(), std::vector<TypedExprPtr>{expr, expr}, "multiply");
+  }
+
+  auto projectNode = std::make_shared<ProjectNode>(
+      nextId(),
+      std::vector<std::string>{"y"},
+      std::vector<TypedExprPtr>{expr},
+      sourceNode);
+
+  ASSERT_NO_THROW(PlanConsistencyChecker::check(projectNode));
+}
+
 TEST_F(PlanConsistencyCheckerTest, hashJoin) {
   auto leftValuesNode =
       std::make_shared<ValuesNode>(nextId(), std::vector<RowVectorPtr>{});

--- a/velox/core/tests/TypedExprToStringTest.cpp
+++ b/velox/core/tests/TypedExprToStringTest.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/core/Expressions.h"
+
+#include <gtest/gtest.h>
+
+namespace facebook::velox::core {
+namespace {
+
+FieldAccessTypedExprPtr field(const std::string& name) {
+  return std::make_shared<FieldAccessTypedExpr>(BIGINT(), name);
+}
+
+CallTypedExprPtr call(std::vector<TypedExprPtr> inputs) {
+  return std::make_shared<CallTypedExpr>(
+      BIGINT(), std::move(inputs), "multiply");
+}
+
+// An expression with no shared subexpressions prints exactly as before: no
+// labels are introduced.
+TEST(TypedExprToStringTest, noSharing) {
+  auto expr = call({field("a"), field("b")});
+  EXPECT_EQ(expr->toString(), "multiply(\"a\",\"b\")");
+}
+
+// A subexpression reached from more than one parent is printed once, tagged
+// with "as #N", and referenced by "#N" thereafter.
+TEST(TypedExprToStringTest, sharedSubexpression) {
+  auto shared = call({field("x"), field("x")});
+  auto expr = call({shared, shared});
+  EXPECT_EQ(expr->toString(), "multiply(multiply(\"x\",\"x\") as #1,#1)");
+}
+
+// A leaf reached from more than one parent is cheap to reprint, so it is not
+// labeled.
+TEST(TypedExprToStringTest, sharedLeafNotLabeled) {
+  auto x = field("x");
+  auto expr = call({x, x});
+  EXPECT_EQ(expr->toString(), "multiply(\"x\",\"x\")");
+}
+
+// A deeply shared DAG (each level squares the one below) would expand to a
+// tree of 2^depth nodes. Sharing-aware printing keeps it linear, so this
+// returns quickly and stays small.
+TEST(TypedExprToStringTest, deeplySharedDagIsLinear) {
+  constexpr int kDepth = 40;
+  TypedExprPtr expr = field("x");
+  for (int i = 0; i < kDepth; ++i) {
+    expr = call({expr, expr});
+  }
+
+  const auto text = expr->toString();
+  // Each level contributes one full "multiply(...)" plus one "#N"
+  // back-reference, so the output is O(depth), nowhere near 2^depth.
+  EXPECT_LT(text.size(), 2000);
+  EXPECT_NE(text.find(" as #"), std::string::npos);
+}
+
+} // namespace
+} // namespace facebook::velox::core


### PR DESCRIPTION
Summary:

Expressions can share subexpressions, forming a DAG rather than a tree: one node is reached from several parents. Printing a plan in detail or validating it walked that DAG as a tree and revisited each shared node once per path. For a deeply shared expression this took time and space exponential in its depth, so planning the query never finished.

Such an expression arises when projections that reuse a column are inlined. A chain where each step squares the previous column,

    x1 = x0 * x0, x2 = x1 * x1, ..., xN = x(N-1) * x(N-1)

collapses into one expression whose tree form has 2^N nodes but whose DAG has only N.

`PlanNode::toString(detailed=true)`, through each expression's `toString()`, and `PlanConsistencyChecker` now track nodes by pointer identity and process each once. A shared subexpression is printed once and tagged `as #N`; every later occurrence prints just `#N`. An expression with no sharing prints exactly as before.

Reviewed By: amitkdutta

Differential Revision: D112540299


