### PR TITLE
Migrate `folly::bit_cast` callers to C++20 `std::bit_cast`

### DIFF
--- a/velox/dwio/parquet/thrift/CompactV1ProtocolReaderWithRefill.h
+++ b/velox/dwio/parquet/thrift/CompactV1ProtocolReaderWithRefill.h
@@ -18,6 +18,7 @@
 
 #include <thrift/lib/cpp2/protocol/CompactV1Protocol.h>
 #include <thrift/lib/cpp2/protocol/ProtocolReaderWithRefill.h>
+#include <bit>
 
 namespace apache::thrift {
 
@@ -32,7 +33,7 @@ class CompactV1ProtocolReaderWithRefill
     static_assert(std::numeric_limits<double>::is_iec559);
     ensureBuffer(sizeof(double));
     uint64_t bits = readLEFromBuffer<int64_t>();
-    dub = folly::bit_cast<double>(bits);
+    dub = std::bit_cast<double>(bits);
   }
 };
 


### PR DESCRIPTION
Summary:
`folly::bit_cast` (in `folly/lang/Bits.h`) was `using std::bit_cast;` under `#if defined(__cpp_lib_bit_cast)` with a memcpy fallback for pre-C++20 toolchains. C++20 `std::bit_cast` (`<bit>`) is now available in both libstdc++ and libc++, so the shim is redundant. This migrates every caller to `std::bit_cast`, adding `#include <bit>` where needed. The `folly::bit_cast` definition itself is removed in the follow-up D112153971.

The migration is a pure drop-in: on every toolchain that defined `__cpp_lib_bit_cast`, `folly::bit_cast` already *was* `std::bit_cast`.

Reviewed By: ot, praihan, iahs

Differential Revision: D111982636


