### PR TITLE
fix(type): Add explicit constructor to TestCustomType for libstdc++ 12 (#18175)

### DIFF
--- a/velox/type/tests/OpaqueCustomTypesTest.cpp
+++ b/velox/type/tests/OpaqueCustomTypesTest.cpp
@@ -33,6 +33,8 @@ class OpaqueCustomTypeTest : public testing::Test {
   struct TestCustomType {
     std::string name;
 
+    explicit TestCustomType(std::string name) : name(std::move(name)) {}
+
     bool operator==(const TestCustomType& other) const {
       return name == other.name;
     }


### PR DESCRIPTION
Summary:

The `Build with Clang / Ubuntu debug with system dependencies` OSS CI job (GCC-12
system libstdc++) fails to compile `velox/type/tests/OpaqueCustomTypesTest.cpp`:

  error: no matching constructor for initialization of 'TestCustomType'
  (via std::construct_at, _Args = <std::string> / <const char[5]>)

`TestCustomType` was an aggregate with no constructor, and the test builds it via
`std::make_shared<TestCustomType>(name)`. `make_shared` constructs through
`std::construct_at`, and libstdc++ 12 does not support C++20 parenthesized
aggregate initialization there, so that toolchain rejects it. Other toolchains
(incl. fbcode platform010) accept it, which is why only that one OSS build config
was red.

Add an explicit `TestCustomType(std::string)` constructor so construction no
longer depends on parenthesized aggregate init and compiles on every toolchain.

Origin: this test and the aggregate + `make_shared` pattern were introduced by
#15843 ("refactor: Implement one step type registration and
serialization/deserialization for OpaqueCustomType"), and have been latent on the
libstdc++ 12 build since then.

Fixes this OSS CI failure (velox nightly, "Build with Clang / Ubuntu debug with system dependencies" -- OpaqueCustomTypesTest.cpp fails to compile): 

https://github.com/facebookincubator/velox/actions/runs/29629734207/job/88040912650

Differential Revision: D112701505


