### PR TITLE
fix(memory): Record real exception message templates

### DIFF
--- a/velox/common/memory/MemoryArbitrator.h
+++ b/velox/common/memory/MemoryArbitrator.h
@@ -30,32 +30,29 @@ namespace facebook::velox::memory {
 class MemoryPool;
 class ArbitrationOperation;
 
-#define VELOX_MEM_POOL_CAP_EXCEEDED(errorMessage)                   \
+#define VELOX_MEM_POOL_CAP_EXCEEDED(...)                            \
   _VELOX_THROW(                                                     \
       ::facebook::velox::VeloxRuntimeError,                         \
       ::facebook::velox::error_source::kErrorSourceRuntime.c_str(), \
       ::facebook::velox::error_code::kMemCapExceeded.c_str(),       \
       /* isRetriable */ true,                                       \
-      "{}",                                                         \
-      errorMessage);
+      ##__VA_ARGS__);
 
-#define VELOX_MEM_ARBITRATION_FAILED(errorMessage)                   \
+#define VELOX_MEM_ARBITRATION_FAILED(...)                            \
   _VELOX_THROW(                                                      \
       ::facebook::velox::VeloxRuntimeError,                          \
       ::facebook::velox::error_source::kErrorSourceRuntime.c_str(),  \
       ::facebook::velox::error_code::kMemArbitrationFailure.c_str(), \
       /* isRetriable */ true,                                        \
-      "{}",                                                          \
-      errorMessage);
+      ##__VA_ARGS__);
 
-#define VELOX_MEM_POOL_ABORTED(errorMessage)                        \
+#define VELOX_MEM_POOL_ABORTED(...)                                 \
   _VELOX_THROW(                                                     \
       ::facebook::velox::VeloxRuntimeError,                         \
       ::facebook::velox::error_source::kErrorSourceRuntime.c_str(), \
       ::facebook::velox::error_code::kMemAborted.c_str(),           \
       /* isRetriable */ true,                                       \
-      "{}",                                                         \
-      errorMessage);
+      ##__VA_ARGS__);
 
 using MemoryArbitrationStateCheckCB = std::function<void(MemoryPool&)>;
 

--- a/velox/common/memory/SharedArbitrator.cpp
+++ b/velox/common/memory/SharedArbitrator.cpp
@@ -31,56 +31,7 @@ using facebook::velox::common::testutil::TestValue;
 
 namespace facebook::velox::memory {
 
-using namespace facebook::velox::memory;
-
 namespace {
-#define RETURN_IF_TRUE(func) \
-  {                          \
-    const bool ret = func;   \
-    if (ret) {               \
-      return;                \
-    }                        \
-  }
-
-#define RETURN_TRUE_IF_TRUE(func) \
-  {                               \
-    const bool ret = func;        \
-    if (ret) {                    \
-      return true;                \
-    }                             \
-  }
-
-#define CHECKED_GROW(pool, growBytes, reservationBytes) \
-  try {                                                 \
-    checkedGrow(pool, growBytes, reservationBytes);     \
-  } catch (const VeloxRuntimeError&) {                  \
-    freeCapacity(growBytes);                            \
-    throw;                                              \
-  }
-
-#define MEM_POOL_CAP_EXCEEDED(errorMessage, requestPool) \
-  VELOX_MEM_POOL_CAP_EXCEEDED(                           \
-      fmt::format(                                       \
-          "Exceeded memory pool capacity. {}\n{}\n\n{}", \
-          errorMessage,                                  \
-          this->toString(),                              \
-          requestPool->toString(true)));
-
-#define LOCAL_MEM_ARBITRATION_FAILED(errorMessage, requestPool) \
-  VELOX_MEM_ARBITRATION_FAILED(                                 \
-      fmt::format(                                              \
-          "Local arbitration failure. {}\n{}\n\n{}",            \
-          errorMessage,                                         \
-          this->toString(),                                     \
-          requestPool->toString(true)));
-
-#define GLOBAL_MEM_ARBITRATION_FAILED(errorMessage, requestPool) \
-  VELOX_MEM_ARBITRATION_FAILED(                                  \
-      fmt::format(                                               \
-          "Global arbitration failure. {}\n{}\n\n{}",            \
-          errorMessage,                                          \
-          this->toString(),                                      \
-          requestPool->toString(true)));
 
 template <typename T>
 T getConfig(
@@ -894,11 +845,14 @@ void SharedArbitrator::growCapacity(ArbitrationOperation& op) {
   checkIfAborted(op);
   checkIfTimeout(op);
 
-  RETURN_IF_TRUE(maybeGrowFromSelf(op));
+  if (maybeGrowFromSelf(op)) {
+    return;
+  }
 
   if (!ensureCapacity(op)) {
     const auto maxCapacity = op.participant()->maxCapacity();
-    MEM_POOL_CAP_EXCEEDED(
+    VELOX_MEM_POOL_CAP_EXCEEDED(
+        "Exceeded memory pool capacity. {}\n{}\n\n{}",
         fmt::format(
             "Can't grow {} capacity with {}. This will exceed its {} "
             "{}, current capacity {}.",
@@ -908,23 +862,37 @@ void SharedArbitrator::growCapacity(ArbitrationOperation& op) {
                                     : "memory pool capacity",
             succinctBytes(std::min(capacity_, maxCapacity)),
             succinctBytes(op.participant()->capacity())),
-        op.participant()->pool());
+        toString(),
+        op.participant()->pool()->toString(true));
   }
 
   checkIfAborted(op);
 
-  RETURN_IF_TRUE(maybeGrowFromSelf(op));
+  if (maybeGrowFromSelf(op)) {
+    return;
+  }
 
   op.setGrowTargets();
-  RETURN_IF_TRUE(growWithFreeCapacity(op));
+  if (growWithFreeCapacity(op)) {
+    return;
+  }
 
   reclaimUnusedCapacity();
-  RETURN_IF_TRUE(growWithFreeCapacity(op));
+  if (growWithFreeCapacity(op)) {
+    return;
+  }
+
+#define VELOX_LOCAL_MEM_ARBITRATION_FAILED(errorMessage, requestPool) \
+  VELOX_MEM_ARBITRATION_FAILED(                                       \
+      "Local arbitration failure. {}\n{}\n\n{}",                      \
+      errorMessage,                                                   \
+      this->toString(),                                               \
+      requestPool->toString(true));
 
   if (!globalArbitrationEnabled_) {
     if (op.participant()->reclaimableUsedCapacity() <
         participantConfig_.minReclaimBytes) {
-      LOCAL_MEM_ARBITRATION_FAILED(
+      VELOX_LOCAL_MEM_ARBITRATION_FAILED(
           fmt::format(
               "Reclaimable used capacity {} is less than min reclaim bytes {}",
               succinctBytes(op.participant()->reclaimableUsedCapacity()),
@@ -944,9 +912,11 @@ void SharedArbitrator::growCapacity(ArbitrationOperation& op) {
         op.timeoutNs(),
         /*localArbitration=*/true);
     checkIfAborted(op);
-    RETURN_IF_TRUE(maybeGrowFromSelf(op));
+    if (maybeGrowFromSelf(op)) {
+      return;
+    }
     if (!growWithFreeCapacity(op)) {
-      LOCAL_MEM_ARBITRATION_FAILED(
+      VELOX_LOCAL_MEM_ARBITRATION_FAILED(
           fmt::format(
               "Failed to arbitrate enough memory for requestor {} with {} "
               "request bytes due to insufficient global memory resources.",
@@ -957,6 +927,8 @@ void SharedArbitrator::growCapacity(ArbitrationOperation& op) {
     return;
   }
   startAndWaitGlobalArbitration(op);
+
+#undef VELOX_LOCAL_MEM_ARBITRATION_FAILED
 }
 
 void SharedArbitrator::startAndWaitGlobalArbitration(ArbitrationOperation& op) {
@@ -1016,17 +988,19 @@ void SharedArbitrator::startAndWaitGlobalArbitration(ArbitrationOperation& op) {
     if (allocatedBytes == 0) {
       checkIfAborted(op);
       checkIfTimeout(op);
-      GLOBAL_MEM_ARBITRATION_FAILED(
+      VELOX_MEM_ARBITRATION_FAILED(
+          "Global arbitration failure. {}\n{}\n\n{}",
           fmt::format(
               "Failed to arbitrate enough memory for requestor {} with {} "
               "request bytes due to insufficient global memory resources.",
               op.participant()->name(),
               succinctBytes(op.requestBytes())),
-          op.participant()->pool());
+          toString(),
+          op.participant()->pool()->toString(true));
     }
   }
   VELOX_CHECK_GE(allocatedBytes, op.requestBytes());
-  CHECKED_GROW(op.participant(), allocatedBytes, op.requestBytes());
+  checkedGrowOrFree(op.participant(), allocatedBytes, op.requestBytes());
 }
 
 void SharedArbitrator::updateGlobalArbitrationStats(
@@ -1139,8 +1113,7 @@ uint64_t SharedArbitrator::getGlobalArbitrationTarget() {
 
 void SharedArbitrator::checkIfAborted(ArbitrationOperation& op) {
   if (op.participant()->aborted()) {
-    VELOX_MEM_POOL_ABORTED(
-        fmt::format("Memory pool {} aborted", op.participant()->name()));
+    VELOX_MEM_POOL_ABORTED("Memory pool {} aborted", op.participant()->name());
   }
 }
 
@@ -1166,7 +1139,7 @@ bool SharedArbitrator::growWithFreeCapacity(ArbitrationOperation& op) {
       op.minGrowBytes());
   if (allocatedBytes > 0) {
     VELOX_CHECK_GE(allocatedBytes, op.requestBytes());
-    CHECKED_GROW(op.participant(), allocatedBytes, op.requestBytes());
+    checkedGrowOrFree(op.participant(), allocatedBytes, op.requestBytes());
     return true;
   }
   return false;
@@ -1193,11 +1166,15 @@ bool SharedArbitrator::ensureCapacity(ArbitrationOperation& op) {
     return false;
   }
 
-  RETURN_TRUE_IF_TRUE(checkCapacityGrowth(op));
+  if (checkCapacityGrowth(op)) {
+    return true;
+  }
 
   shrink(op.participant(), /*reclaimAll=*/true);
 
-  RETURN_TRUE_IF_TRUE(checkCapacityGrowth(op));
+  if (checkCapacityGrowth(op)) {
+    return true;
+  }
 
   reclaim(
       op.participant(),
@@ -1207,7 +1184,9 @@ bool SharedArbitrator::ensureCapacity(ArbitrationOperation& op) {
   // Checks if the requestor has been aborted in reclaim above.
   checkIfAborted(op);
 
-  RETURN_TRUE_IF_TRUE(checkCapacityGrowth(op));
+  if (checkCapacityGrowth(op)) {
+    return true;
+  }
 
   shrink(op.participant(), /*reclaimAll=*/true);
   return checkCapacityGrowth(op);
@@ -1226,6 +1205,18 @@ void SharedArbitrator::checkedGrow(
         succinctBytes(reservationBytes),
         participant->pool()->toString(),
         participant->pool()->treeMemoryUsage());
+  }
+}
+
+void SharedArbitrator::checkedGrowOrFree(
+    const ScopedArbitrationParticipant& participant,
+    uint64_t growBytes,
+    uint64_t reservationBytes) {
+  try {
+    checkedGrow(participant, growBytes, reservationBytes);
+  } catch (const VeloxRuntimeError&) {
+    freeCapacity(growBytes);
+    throw;
   }
 }
 
@@ -1363,14 +1354,13 @@ uint64_t SharedArbitrator::reclaimUsedMemoryByAbort(bool force) {
   const auto currentCapacity = victim.participant->pool()->capacity();
   try {
     VELOX_MEM_POOL_ABORTED(
-        fmt::format(
-            "Memory pool aborted to reclaim used memory, current capacity {}, "
-            "requesting capacity from global arbitration {} memory pool "
-            "stats:\n{}\n{}",
-            succinctBytes(currentCapacity),
-            succinctBytes(victim.participant->globalArbitrationGrowCapacity()),
-            victim.participant->pool()->toString(),
-            victim.participant->pool()->treeMemoryUsage()));
+        "Memory pool aborted to reclaim used memory, current capacity {}, "
+        "requesting capacity from global arbitration {} memory pool "
+        "stats:\n{}\n{}",
+        succinctBytes(currentCapacity),
+        succinctBytes(victim.participant->globalArbitrationGrowCapacity()),
+        victim.participant->pool()->toString(),
+        victim.participant->pool()->treeMemoryUsage());
   } catch (VeloxRuntimeError&) {
     abort(victim.participant, std::current_exception());
     return currentCapacity;
@@ -1625,4 +1615,5 @@ void SharedArbitrator::incrementLocalArbitrationCount() {
   addThreadLocalRuntimeStat(
       kLocalArbitrationCount, RuntimeCounter(1, RuntimeCounter::Unit::kNone));
 }
+
 } // namespace facebook::velox::memory

--- a/velox/common/memory/SharedArbitrator.h
+++ b/velox/common/memory/SharedArbitrator.h
@@ -543,6 +543,13 @@ class SharedArbitrator : public memory::MemoryArbitrator {
       uint64_t growBytes,
       uint64_t reservationBytes);
 
+  // Grows 'participant' capacity like checkedGrow(), but frees 'growBytes' back
+  // to the arbitrator before rethrowing if the growth fails.
+  void checkedGrowOrFree(
+      const ScopedArbitrationParticipant& participant,
+      uint64_t growBytes,
+      uint64_t reservationBytes);
+
   // Invoked to reclaim used memory from 'participant' with specified
   // 'targetBytes'. The function returns the actually freed capacity.
   // 'localArbitration' is true when the reclaim attempt is for a local

--- a/velox/common/memory/tests/MemoryArbitratorTest.cpp
+++ b/velox/common/memory/tests/MemoryArbitratorTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <deque>
@@ -47,6 +48,53 @@ class MemoryArbitrationTest : public testing::Test {
     SharedArbitrator::unregisterFactory();
   }
 };
+
+TEST_F(MemoryArbitrationTest, errorMessageTemplate) {
+  // The memory throw macros must record the format string as the exception's
+  // message template (not "{}") so similar failures group together in
+  // downstream monitoring instead of collapsing to a single "{}" template.
+  auto arbitrationFailed = []() {
+    VELOX_MEM_ARBITRATION_FAILED("Local arbitration failure. {}", 42);
+  };
+  EXPECT_THAT(
+      arbitrationFailed,
+      Throws<VeloxRuntimeError>(AllOf(
+          Property(
+              &VeloxException::messageTemplate,
+              StrEq("Local arbitration failure. {}")),
+          Property(
+              &VeloxException::message, StrEq("Local arbitration failure. 42")),
+          Property(
+              &VeloxException::errorCode,
+              Eq(error_code::kMemArbitrationFailure)))));
+
+  auto capExceeded = []() {
+    VELOX_MEM_POOL_CAP_EXCEEDED("Exceeded memory pool capacity. {}", 7);
+  };
+  EXPECT_THAT(
+      capExceeded,
+      Throws<VeloxRuntimeError>(AllOf(
+          Property(
+              &VeloxException::messageTemplate,
+              StrEq("Exceeded memory pool capacity. {}")),
+          Property(
+              &VeloxException::message,
+              StrEq("Exceeded memory pool capacity. 7")),
+          Property(
+              &VeloxException::errorCode, Eq(error_code::kMemCapExceeded)))));
+
+  auto poolAborted = []() {
+    VELOX_MEM_POOL_ABORTED("Memory pool aborted: {}", "p0");
+  };
+  EXPECT_THAT(
+      poolAborted,
+      Throws<VeloxRuntimeError>(AllOf(
+          Property(
+              &VeloxException::messageTemplate,
+              StrEq("Memory pool aborted: {}")),
+          Property(&VeloxException::message, StrEq("Memory pool aborted: p0")),
+          Property(&VeloxException::errorCode, Eq(error_code::kMemAborted)))));
+}
 
 TEST_F(MemoryArbitrationTest, stats) {
   MemoryArbitrator::Stats stats;


### PR DESCRIPTION
Summary:
Memory errors raised by the arbitrator recorded `{}` as their `VeloxException` message template. Every failure kind collapsed into a single `{}` group in monitoring instead of grouping by kind. They now carry the real format string. A local arbitration failure reports a template starting `Local arbitration failure. {}` rather than `{}`; the specific values stay in the rendered message.

`VELOX_MEM_POOL_CAP_EXCEEDED`, `VELOX_MEM_ARBITRATION_FAILED`, and `VELOX_MEM_POOL_ABORTED` hardcoded `"{}"` as the fmt format string and took a single pre-rendered message, so the exception stored `{}` as the template. They are now variadic like `VELOX_FAIL`. Callers pass a static format string plus arguments, so the template keeps the static text while the brace-bearing dynamic values remain `{}` arguments.

This also removes obsolete file-local macros and a redundant using-directive in `SharedArbitrator.cpp`.

Differential Revision: D112722259


