### PR TITLE
fix(exec): Copy LocalExchangeMemoryManager under task lock to avoid teardown race

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -3436,8 +3436,7 @@ Task::getScaleWriterPartitionBalancer(
   return it->second.scaleWriterPartitionBalancer;
 }
 
-const std::shared_ptr<LocalExchangeMemoryManager>&
-Task::getLocalExchangeMemoryManager(
+std::shared_ptr<LocalExchangeMemoryManager> Task::getLocalExchangeMemoryManager(
     uint32_t splitGroupId,
     const core::PlanNodeId& planNodeId) {
   std::lock_guard<std::timed_mutex> l(mutex_);

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -538,8 +538,8 @@ class Task : public std::enable_shared_from_this<Task> {
       uint32_t splitGroupId,
       const core::PlanNodeId& planNodeId);
 
-  const std::shared_ptr<LocalExchangeMemoryManager>&
-  getLocalExchangeMemoryManager(
+  // Returns by copy because the copy must be made under the task lock.
+  std::shared_ptr<LocalExchangeMemoryManager> getLocalExchangeMemoryManager(
       uint32_t splitGroupId,
       const core::PlanNodeId& planNodeId);
 


### PR DESCRIPTION
Summary:
`Task::getLocalExchangeMemoryManager()` returned a `const std::shared_ptr&`
into `splitGroupStates_`. Its caller, `ScaleWriterLocalPartition::initialize()`,
copies that shared_ptr into `memoryManager_` *after* the accessor releases the
task lock. If another driver in the same task fails concurrently, its
`Task::setError()` -> `Task::terminate()` path runs `SplitGroupState::clear()`
(unlocked), destroying the `localExchanges` map entry the returned reference
still points at. The two operations race on the shared_ptr storage, which
ThreadSanitizer reports as a data race in `operator delete`.

This is a teardown-ordering hazard: `terminate()` does not wait for on-thread
drivers to leave, and a driver still in the one-time `initializeOperators()`
has not yet reached a `shouldStop()` checkpoint, so it keeps reading
split-group state while `terminate()` tears it down.

Fix: return the shared_ptr by value so the copy is made while the task lock is
held. Unlike the sibling accessors (`getLocalExchangeQueues`,
`getScaleWriterPartitionBalancer`), which are called from operator constructors
under `createDriversLocked()`'s lock, this accessor is uniquely called from
`initialize()` outside the lock, so the copy must happen inside the accessor.

Differential Revision: D112746954


