### PR TITLE
feat(iceberg): Add IcebergTableHandle class

### DIFF
--- a/velox/connectors/hive/TableHandle.cpp
+++ b/velox/connectors/hive/TableHandle.cpp
@@ -177,11 +177,10 @@ folly::dynamic HiveColumnHandle::serialize() const {
   return obj;
 }
 
-std::string HiveColumnHandle::toString() const {
+std::string HiveColumnHandle::toStringFields() const {
   std::ostringstream out;
   out << fmt::format(
-      "HiveColumnHandle [name: {}, columnType: {}, dataType: {},",
-      name_,
+      "columnType: {}, dataType: {},",
       columnTypeName(columnType_),
       dataType_->toString());
   out << " requiredSubfields: [";
@@ -238,8 +237,12 @@ std::string HiveColumnHandle::toString() const {
     }
     out << "]";
   }
-  out << "]";
   return out.str();
+}
+
+std::string HiveColumnHandle::toString() const {
+  return fmt::format(
+      "HiveColumnHandle [name: {}, {}]", name_, toStringFields());
 }
 
 ColumnHandlePtr HiveColumnHandle::create(const folly::dynamic& obj) {
@@ -380,8 +383,9 @@ std::string HiveTableHandle::toString() const {
   return out.str();
 }
 
-folly::dynamic HiveTableHandle::serialize() const {
-  folly::dynamic obj = ConnectorTableHandle::serializeBase("HiveTableHandle");
+folly::dynamic HiveTableHandle::serializeHiveFields(
+    const std::string& typeName) const {
+  folly::dynamic obj = ConnectorTableHandle::serializeBase(typeName);
   obj["tableName"] = tableName_;
 
   folly::dynamic subfieldFilters = folly::dynamic::array;
@@ -391,8 +395,8 @@ folly::dynamic HiveTableHandle::serialize() const {
     pair["filter"] = filter->serialize();
     subfieldFilters.push_back(pair);
   }
-
   obj["subfieldFilters"] = subfieldFilters;
+
   if (remainingFilter_) {
     obj["remainingFilter"] = remainingFilter_->serialize();
   }
@@ -404,11 +408,13 @@ folly::dynamic HiveTableHandle::serialize() const {
   if (dataColumns_) {
     obj["dataColumns"] = dataColumns_->serialize();
   }
+
   folly::dynamic tableParameters = folly::dynamic::object;
   for (const auto& param : tableParameters_) {
     tableParameters[param.first] = param.second;
   }
   obj["tableParameters"] = tableParameters;
+
   if (!filterColumnHandles_.empty()) {
     folly::dynamic filterColumnHandles = folly::dynamic::array;
     for (const auto& handle : filterColumnHandles_) {
@@ -416,6 +422,7 @@ folly::dynamic HiveTableHandle::serialize() const {
     }
     obj["filterColumnHandles"] = filterColumnHandles;
   }
+
   if (!indexColumns_.empty()) {
     folly::dynamic indexColumns = folly::dynamic::array;
     for (const auto& column : indexColumns_) {
@@ -431,46 +438,53 @@ folly::dynamic HiveTableHandle::serialize() const {
   return obj;
 }
 
-ConnectorTableHandlePtr HiveTableHandle::create(
-    const folly::dynamic& obj,
-    void* context) {
-  auto connectorId = obj["connectorId"].asString();
-  auto tableName = obj["tableName"].asString();
+folly::dynamic HiveTableHandle::serialize() const {
+  return serializeHiveFields("HiveTableHandle");
+}
 
-  core::TypedExprPtr remainingFilter;
+// static
+void HiveTableHandle::deserializeHiveFields(
+    const folly::dynamic& obj,
+    void* context,
+    std::string& connectorId,
+    std::string& tableName,
+    common::SubfieldFilters& subfieldFilters,
+    core::TypedExprPtr& remainingFilter,
+    double& sampleRate,
+    RowTypePtr& dataColumns,
+    std::unordered_map<std::string, std::string>& tableParameters,
+    std::vector<HiveColumnHandlePtr>& filterColumnHandles,
+    std::vector<std::string>& indexColumns,
+    std::string& dbName) {
+  connectorId = obj["connectorId"].asString();
+  tableName = obj["tableName"].asString();
+
   if (auto it = obj.find("remainingFilter"); it != obj.items().end()) {
     remainingFilter =
         ISerializable::deserialize<core::ITypedExpr>(it->second, context);
   }
 
-  common::SubfieldFilters subfieldFilters;
-  folly::dynamic subfieldFiltersObj = obj["subfieldFilters"];
-  for (const auto& subfieldFilter : subfieldFiltersObj) {
-    common::Subfield subfield(subfieldFilter["subfield"].asString());
-    auto filter =
-        ISerializable::deserialize<common::Filter>(subfieldFilter["filter"]);
+  for (const auto& entry : obj["subfieldFilters"]) {
+    common::Subfield subfield(entry["subfield"].asString());
+    auto filter = ISerializable::deserialize<common::Filter>(entry["filter"]);
     subfieldFilters[common::Subfield(std::move(subfield.path()))] =
         filter->clone();
   }
 
-  double sampleRate = 1.0;
+  sampleRate = 1.0;
   if (obj.count("sampleRate")) {
     sampleRate = obj["sampleRate"].asDouble();
   }
 
-  RowTypePtr dataColumns;
   if (auto it = obj.find("dataColumns"); it != obj.items().end()) {
     dataColumns = ISerializable::deserialize<RowType>(it->second, context);
   }
 
-  std::unordered_map<std::string, std::string> tableParameters{};
   const auto& tableParametersObj = obj["tableParameters"];
   for (const auto& key : tableParametersObj.keys()) {
-    const auto& value = tableParametersObj[key];
-    tableParameters.emplace(key.asString(), value.asString());
+    tableParameters.emplace(key.asString(), tableParametersObj[key].asString());
   }
 
-  std::vector<HiveColumnHandlePtr> filterColumnHandles;
   if (auto it = obj.find("filterColumnHandles"); it != obj.items().end()) {
     for (const auto& handle : it->second) {
       filterColumnHandles.push_back(
@@ -478,20 +492,45 @@ ConnectorTableHandlePtr HiveTableHandle::create(
     }
   }
 
-  std::vector<std::string> indexColumns;
   if (auto it = obj.find("indexColumns"); it != obj.items().end()) {
-    for (const auto& column : it->second) {
-      indexColumns.push_back(column.asString());
+    for (const auto& col : it->second) {
+      indexColumns.push_back(col.asString());
     }
   }
 
-  std::string dbName;
   if (auto it = obj.find("dbName"); it != obj.items().end()) {
     dbName = it->second.asString();
   }
+}
+
+ConnectorTableHandlePtr HiveTableHandle::create(
+    const folly::dynamic& obj,
+    void* context) {
+  std::string connectorId, tableName, dbName;
+  common::SubfieldFilters subfieldFilters;
+  core::TypedExprPtr remainingFilter;
+  double sampleRate;
+  RowTypePtr dataColumns;
+  std::unordered_map<std::string, std::string> tableParameters;
+  std::vector<HiveColumnHandlePtr> filterColumnHandles;
+  std::vector<std::string> indexColumns;
+
+  deserializeHiveFields(
+      obj,
+      context,
+      connectorId,
+      tableName,
+      subfieldFilters,
+      remainingFilter,
+      sampleRate,
+      dataColumns,
+      tableParameters,
+      filterColumnHandles,
+      indexColumns,
+      dbName);
 
   return std::make_shared<const HiveTableHandle>(
-      connectorId,
+      std::move(connectorId),
       tableName,
       std::move(subfieldFilters),
       remainingFilter,

--- a/velox/connectors/hive/TableHandle.cpp
+++ b/velox/connectors/hive/TableHandle.cpp
@@ -177,11 +177,10 @@ folly::dynamic HiveColumnHandle::serialize() const {
   return obj;
 }
 
-std::string HiveColumnHandle::toString() const {
+std::string HiveColumnHandle::toStringFields() const {
   std::ostringstream out;
   out << fmt::format(
-      "HiveColumnHandle [name: {}, columnType: {}, dataType: {},",
-      name_,
+      "columnType: {}, dataType: {},",
       columnTypeName(columnType_),
       dataType_->toString());
   out << " requiredSubfields: [";
@@ -238,8 +237,12 @@ std::string HiveColumnHandle::toString() const {
     }
     out << "]";
   }
-  out << "]";
   return out.str();
+}
+
+std::string HiveColumnHandle::toString() const {
+  return fmt::format(
+      "HiveColumnHandle [name: {}, {}]", name_, toStringFields());
 }
 
 ColumnHandlePtr HiveColumnHandle::create(const folly::dynamic& obj) {
@@ -387,8 +390,9 @@ std::string HiveTableHandle::toString() const {
   return out.str();
 }
 
-folly::dynamic HiveTableHandle::serialize() const {
-  folly::dynamic obj = ConnectorTableHandle::serializeBase("HiveTableHandle");
+folly::dynamic HiveTableHandle::serializeHiveFields(
+    const std::string& typeName) const {
+  folly::dynamic obj = ConnectorTableHandle::serializeBase(typeName);
   obj["tableName"] = tableName_;
 
   folly::dynamic subfieldFilters = folly::dynamic::array;
@@ -398,8 +402,8 @@ folly::dynamic HiveTableHandle::serialize() const {
     pair["filter"] = filter->serialize();
     subfieldFilters.push_back(pair);
   }
-
   obj["subfieldFilters"] = subfieldFilters;
+
   if (remainingFilter_) {
     obj["remainingFilter"] = remainingFilter_->serialize();
   }
@@ -411,6 +415,7 @@ folly::dynamic HiveTableHandle::serialize() const {
   if (dataColumns_) {
     obj["dataColumns"] = dataColumns_->serialize();
   }
+
   if (!dataColumnFieldIds_.empty()) {
     folly::dynamic dataColumnFieldIds = folly::dynamic::array;
     for (const auto fieldId : dataColumnFieldIds_) {
@@ -418,11 +423,13 @@ folly::dynamic HiveTableHandle::serialize() const {
     }
     obj["dataColumnFieldIds"] = std::move(dataColumnFieldIds);
   }
+
   folly::dynamic tableParameters = folly::dynamic::object;
   for (const auto& param : tableParameters_) {
     tableParameters[param.first] = param.second;
   }
   obj["tableParameters"] = tableParameters;
+
   if (!filterColumnHandles_.empty()) {
     folly::dynamic filterColumnHandles = folly::dynamic::array;
     for (const auto& handle : filterColumnHandles_) {
@@ -430,6 +437,7 @@ folly::dynamic HiveTableHandle::serialize() const {
     }
     obj["filterColumnHandles"] = filterColumnHandles;
   }
+
   if (!indexColumns_.empty()) {
     folly::dynamic indexColumns = folly::dynamic::array;
     for (const auto& column : indexColumns_) {
@@ -445,39 +453,49 @@ folly::dynamic HiveTableHandle::serialize() const {
   return obj;
 }
 
-ConnectorTableHandlePtr HiveTableHandle::create(
-    const folly::dynamic& obj,
-    void* context) {
-  auto connectorId = obj["connectorId"].asString();
-  auto tableName = obj["tableName"].asString();
+folly::dynamic HiveTableHandle::serialize() const {
+  return serializeHiveFields("HiveTableHandle");
+}
 
-  core::TypedExprPtr remainingFilter;
+// static
+void HiveTableHandle::deserializeHiveFields(
+    const folly::dynamic& obj,
+    void* context,
+    std::string& connectorId,
+    std::string& tableName,
+    common::SubfieldFilters& subfieldFilters,
+    core::TypedExprPtr& remainingFilter,
+    double& sampleRate,
+    RowTypePtr& dataColumns,
+    std::unordered_map<std::string, std::string>& tableParameters,
+    std::vector<HiveColumnHandlePtr>& filterColumnHandles,
+    std::vector<std::string>& indexColumns,
+    std::string& dbName,
+    std::vector<int32_t>& dataColumnFieldIds) {
+  connectorId = obj["connectorId"].asString();
+  tableName = obj["tableName"].asString();
+
   if (auto it = obj.find("remainingFilter"); it != obj.items().end()) {
     remainingFilter =
         ISerializable::deserialize<core::ITypedExpr>(it->second, context);
   }
 
-  common::SubfieldFilters subfieldFilters;
-  folly::dynamic subfieldFiltersObj = obj["subfieldFilters"];
-  for (const auto& subfieldFilter : subfieldFiltersObj) {
-    common::Subfield subfield(subfieldFilter["subfield"].asString());
-    auto filter =
-        ISerializable::deserialize<common::Filter>(subfieldFilter["filter"]);
+  for (const auto& entry : obj["subfieldFilters"]) {
+    common::Subfield subfield(entry["subfield"].asString());
+    auto filter = ISerializable::deserialize<common::Filter>(entry["filter"]);
     subfieldFilters[common::Subfield(std::move(subfield.path()))] =
         filter->clone();
   }
 
-  double sampleRate = 1.0;
+  sampleRate = 1.0;
   if (obj.count("sampleRate")) {
     sampleRate = obj["sampleRate"].asDouble();
   }
 
-  RowTypePtr dataColumns;
   if (auto it = obj.find("dataColumns"); it != obj.items().end()) {
     dataColumns = ISerializable::deserialize<RowType>(it->second, context);
   }
 
-  std::vector<int32_t> dataColumnFieldIds;
   if (auto it = obj.find("dataColumnFieldIds"); it != obj.items().end()) {
     dataColumnFieldIds.reserve(it->second.size());
     for (const auto& fieldId : it->second) {
@@ -485,14 +503,11 @@ ConnectorTableHandlePtr HiveTableHandle::create(
     }
   }
 
-  std::unordered_map<std::string, std::string> tableParameters{};
   const auto& tableParametersObj = obj["tableParameters"];
   for (const auto& key : tableParametersObj.keys()) {
-    const auto& value = tableParametersObj[key];
-    tableParameters.emplace(key.asString(), value.asString());
+    tableParameters.emplace(key.asString(), tableParametersObj[key].asString());
   }
 
-  std::vector<HiveColumnHandlePtr> filterColumnHandles;
   if (auto it = obj.find("filterColumnHandles"); it != obj.items().end()) {
     for (const auto& handle : it->second) {
       filterColumnHandles.push_back(
@@ -500,20 +515,49 @@ ConnectorTableHandlePtr HiveTableHandle::create(
     }
   }
 
-  std::vector<std::string> indexColumns;
   if (auto it = obj.find("indexColumns"); it != obj.items().end()) {
-    for (const auto& column : it->second) {
-      indexColumns.push_back(column.asString());
+    for (const auto& col : it->second) {
+      indexColumns.push_back(col.asString());
     }
   }
 
-  std::string dbName;
   if (auto it = obj.find("dbName"); it != obj.items().end()) {
     dbName = it->second.asString();
   }
+}
+
+ConnectorTableHandlePtr HiveTableHandle::create(
+    const folly::dynamic& obj,
+    void* context) {
+  std::string connectorId;
+  std::string tableName;
+  std::string dbName;
+  common::SubfieldFilters subfieldFilters;
+  core::TypedExprPtr remainingFilter;
+  double sampleRate{1.0};
+  RowTypePtr dataColumns;
+  std::unordered_map<std::string, std::string> tableParameters;
+  std::vector<HiveColumnHandlePtr> filterColumnHandles;
+  std::vector<std::string> indexColumns;
+  std::vector<int32_t> dataColumnFieldIds;
+
+  deserializeHiveFields(
+      obj,
+      context,
+      connectorId,
+      tableName,
+      subfieldFilters,
+      remainingFilter,
+      sampleRate,
+      dataColumns,
+      tableParameters,
+      filterColumnHandles,
+      indexColumns,
+      dbName,
+      dataColumnFieldIds);
 
   return std::make_shared<const HiveTableHandle>(
-      connectorId,
+      std::move(connectorId),
       tableName,
       std::move(subfieldFilters),
       remainingFilter,

--- a/velox/connectors/hive/TableHandle.h
+++ b/velox/connectors/hive/TableHandle.h
@@ -159,6 +159,12 @@ class HiveColumnHandle : public FileColumnHandle {
 
   static void registerSerDe();
 
+ protected:
+  /// Emits the common column fields (columnType, dataType, requiredSubfields,
+  /// extractions) without a class-name prefix. Subclasses use this to build
+  /// their own toString() with the correct class name in the header.
+  std::string toStringFields() const;
+
  private:
   const std::string name_;
   const ColumnType columnType_;
@@ -268,6 +274,31 @@ class HiveTableHandle : public FileTableHandle {
       void* context);
 
   static void registerSerDe();
+
+ protected:
+  /// Serializes the Hive-common fields (tableName, subfieldFilters,
+  /// remainingFilter, sampleRate, dataColumns, tableParameters,
+  /// filterColumnHandles, indexColumns, dbName) into an object whose "name"
+  /// key is set to @p typeName. Subclasses call this instead of duplicating
+  /// the field list, then append their own keys.
+  folly::dynamic serializeHiveFields(const std::string& typeName) const;
+
+  /// Fills the common Hive fields from @p obj into the provided out-parameters.
+  /// Subclasses call this from their own create() and then parse only their
+  /// extra keys on top.
+  static void deserializeHiveFields(
+      const folly::dynamic& obj,
+      void* context,
+      std::string& connectorId,
+      std::string& tableName,
+      common::SubfieldFilters& subfieldFilters,
+      core::TypedExprPtr& remainingFilter,
+      double& sampleRate,
+      RowTypePtr& dataColumns,
+      std::unordered_map<std::string, std::string>& tableParameters,
+      std::vector<HiveColumnHandlePtr>& filterColumnHandles,
+      std::vector<std::string>& indexColumns,
+      std::string& dbName);
 
  private:
   const std::string tableName_;

--- a/velox/connectors/hive/TableHandle.h
+++ b/velox/connectors/hive/TableHandle.h
@@ -159,6 +159,12 @@ class HiveColumnHandle : public FileColumnHandle {
 
   static void registerSerDe();
 
+ protected:
+  // Emits the common column fields (columnType, dataType, requiredSubfields,
+  // extractions) without a class-name prefix. Subclasses use this to build
+  // their own toString() with the correct class name in the header.
+  std::string toStringFields() const;
+
  private:
   const std::string name_;
   const ColumnType columnType_;
@@ -275,6 +281,32 @@ class HiveTableHandle : public FileTableHandle {
       void* context);
 
   static void registerSerDe();
+
+ protected:
+  // Serializes the Hive-common fields (tableName, subfieldFilters,
+  // remainingFilter, sampleRate, dataColumns, tableParameters,
+  // filterColumnHandles, indexColumns, dbName) into an object whose "name"
+  // key is set to @p typeName. Subclasses call this instead of duplicating
+  // the field list, then append their own keys.
+  folly::dynamic serializeHiveFields(const std::string& typeName) const;
+
+  // Fills the common Hive fields from @p obj into the provided out-parameters.
+  // Subclasses call this from their own create() and then parse only their
+  // extra keys on top.
+  static void deserializeHiveFields(
+      const folly::dynamic& obj,
+      void* context,
+      std::string& connectorId,
+      std::string& tableName,
+      common::SubfieldFilters& subfieldFilters,
+      core::TypedExprPtr& remainingFilter,
+      double& sampleRate,
+      RowTypePtr& dataColumns,
+      std::unordered_map<std::string, std::string>& tableParameters,
+      std::vector<HiveColumnHandlePtr>& filterColumnHandles,
+      std::vector<std::string>& indexColumns,
+      std::string& dbName,
+      std::vector<int32_t>& dataColumnFieldIds);
 
  private:
   const std::string tableName_;

--- a/velox/connectors/hive/iceberg/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/CMakeLists.txt
@@ -19,6 +19,7 @@ set(
   IcebergColumnHandle.cpp
   IcebergConfig.cpp
   IcebergConnector.cpp
+  IcebergTableHandle.cpp
   IcebergDataFileStatistics.cpp
   IcebergDataSink.cpp
   IcebergDataSource.cpp
@@ -53,6 +54,7 @@ velox_add_library(
   IcebergColumnHandle.h
   IcebergConfig.h
   IcebergConnector.h
+  IcebergTableHandle.h
   IcebergDataFileStatistics.h
   IcebergDataSink.h
   IcebergDataSource.h

--- a/velox/connectors/hive/iceberg/IcebergColumnHandle.cpp
+++ b/velox/connectors/hive/iceberg/IcebergColumnHandle.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -25,6 +26,111 @@
 #include "velox/type/Type.h"
 
 namespace facebook::velox::connector::hive::iceberg {
+
+namespace {
+
+// Produces a compact string representation of a ParquetFieldId tree.
+// Format: <id> for leaf nodes, <id>[<child0>, <child1>, ...] for nested nodes.
+std::string fieldIdToString(const parquet::ParquetFieldId& fieldId) {
+  std::string result = std::to_string(fieldId.fieldId);
+  if (!fieldId.children.empty()) {
+    result += "[";
+    for (size_t i = 0; i < fieldId.children.size(); ++i) {
+      if (i > 0) {
+        result += ", ";
+      }
+      result += fieldIdToString(fieldId.children[i]);
+    }
+    result += "]";
+  }
+  return result;
+}
+
+// Serializes a ParquetFieldId tree to a folly::dynamic object.
+folly::dynamic serializeFieldId(const parquet::ParquetFieldId& fieldId) {
+  folly::dynamic obj = folly::dynamic::object;
+  obj["fieldId"] = fieldId.fieldId;
+  folly::dynamic children = folly::dynamic::array;
+  for (const auto& child : fieldId.children) {
+    children.push_back(serializeFieldId(child));
+  }
+  obj["children"] = children;
+  return obj;
+}
+
+// Deserializes a ParquetFieldId tree from a folly::dynamic object.
+parquet::ParquetFieldId deserializeFieldId(const folly::dynamic& obj) {
+  parquet::ParquetFieldId fieldId;
+  fieldId.fieldId = static_cast<int32_t>(obj["fieldId"].asInt());
+  for (const auto& child : obj["children"]) {
+    fieldId.children.push_back(deserializeFieldId(child));
+  }
+  return fieldId;
+}
+
+// Serializes an IcebergFieldMetadata node (and its children) to a
+// folly::dynamic object. Only set optional fields are emitted; an all-empty
+// node is serialized as an empty object so that the children array remains
+// parallel to ParquetFieldId::children.
+folly::dynamic serializeFieldMetadata(const IcebergFieldMetadata& meta) {
+  folly::dynamic obj = folly::dynamic::object;
+  if (meta.required.has_value()) {
+    obj["required"] = *meta.required;
+  }
+  if (meta.longType.has_value()) {
+    obj["longType"] = *meta.longType;
+  }
+  if (meta.timestampUnit.has_value()) {
+    obj["timestampUnit"] = *meta.timestampUnit;
+  }
+  if (meta.binaryType.has_value()) {
+    obj["binaryType"] = *meta.binaryType;
+  }
+  if (meta.structType.has_value()) {
+    obj["structType"] = *meta.structType;
+  }
+  if (meta.length.has_value()) {
+    obj["length"] = *meta.length;
+  }
+  folly::dynamic children = folly::dynamic::array;
+  for (const auto& child : meta.children) {
+    children.push_back(serializeFieldMetadata(child));
+  }
+  obj["children"] = children;
+  return obj;
+}
+
+// Deserializes an IcebergFieldMetadata node (and its children) from a
+// folly::dynamic object.
+IcebergFieldMetadata deserializeFieldMetadata(const folly::dynamic& obj) {
+  IcebergFieldMetadata meta;
+  if (auto it = obj.find("required"); it != obj.items().end()) {
+    meta.required = it->second.asBool();
+  }
+  if (auto it = obj.find("longType"); it != obj.items().end()) {
+    meta.longType = it->second.asString();
+  }
+  if (auto it = obj.find("timestampUnit"); it != obj.items().end()) {
+    meta.timestampUnit = it->second.asString();
+  }
+  if (auto it = obj.find("binaryType"); it != obj.items().end()) {
+    meta.binaryType = it->second.asString();
+  }
+  if (auto it = obj.find("structType"); it != obj.items().end()) {
+    meta.structType = it->second.asString();
+  }
+  if (auto it = obj.find("length"); it != obj.items().end()) {
+    meta.length = static_cast<int32_t>(it->second.asInt());
+  }
+  if (auto it = obj.find("children"); it != obj.items().end()) {
+    for (const auto& child : it->second) {
+      meta.children.push_back(deserializeFieldMetadata(child));
+    }
+  }
+  return meta;
+}
+
+} // namespace
 
 IcebergColumnHandle::IcebergColumnHandle(
     const std::string& name,
@@ -50,6 +156,82 @@ IcebergColumnHandle::IcebergColumnHandle(
 
 const parquet::ParquetFieldId& IcebergColumnHandle::field() const {
   return field_;
+}
+
+std::string IcebergColumnHandle::toString() const {
+  std::string fields = HiveColumnHandle::toStringFields();
+  fields += ", field: " + fieldIdToString(field_);
+  if (initialDefaultValue_.has_value()) {
+    fields += ", initialDefaultValue: " + *initialDefaultValue_;
+  }
+  return fmt::format("IcebergColumnHandle [name: {}, {}]", name(), fields);
+}
+
+folly::dynamic IcebergColumnHandle::serialize() const {
+  folly::dynamic obj = ColumnHandle::serializeBase("IcebergColumnHandle");
+  obj["hiveColumnHandleName"] = name();
+  obj["columnType"] = columnTypeName(columnType());
+  obj["dataType"] = dataType()->serialize();
+
+  folly::dynamic requiredSubfieldsArr = folly::dynamic::array;
+  for (const auto& subfield : requiredSubfields()) {
+    requiredSubfieldsArr.push_back(subfield.toString());
+  }
+  obj["requiredSubfields"] = requiredSubfieldsArr;
+
+  obj["field"] = serializeFieldId(field_);
+
+  if (initialDefaultValue_.has_value()) {
+    obj["initialDefaultValue"] = *initialDefaultValue_;
+  }
+
+  // Only serialize icebergMetadata when at least one node carries a set
+  // attribute, to keep the serialized form compact for callers that never
+  // populate V3 metadata.
+  if (!icebergMetadata_.empty() || !icebergMetadata_.children.empty()) {
+    obj["icebergMetadata"] = serializeFieldMetadata(icebergMetadata_);
+  }
+
+  return obj;
+}
+
+// static
+ColumnHandlePtr IcebergColumnHandle::create(const folly::dynamic& obj) {
+  auto name = obj["hiveColumnHandleName"].asString();
+  auto columnType = columnTypeFromName(obj["columnType"].asString());
+  auto dataType = ISerializable::deserialize<Type>(obj["dataType"]);
+
+  std::vector<common::Subfield> requiredSubfields;
+  for (const auto& s : obj["requiredSubfields"]) {
+    requiredSubfields.emplace_back(s.asString());
+  }
+
+  auto field = deserializeFieldId(obj["field"]);
+
+  std::optional<std::string> initialDefaultValue;
+  if (auto it = obj.find("initialDefaultValue"); it != obj.items().end()) {
+    initialDefaultValue = it->second.asString();
+  }
+
+  IcebergFieldMetadata icebergMetadata;
+  if (auto it = obj.find("icebergMetadata"); it != obj.items().end()) {
+    icebergMetadata = deserializeFieldMetadata(it->second);
+  }
+
+  return std::make_shared<IcebergColumnHandle>(
+      name,
+      columnType,
+      std::move(dataType),
+      std::move(field),
+      std::move(requiredSubfields),
+      std::move(initialDefaultValue),
+      std::move(icebergMetadata));
+}
+
+// static
+void IcebergColumnHandle::registerSerDe() {
+  auto& registry = DeserializationRegistryForSharedPtr();
+  registry.Register("IcebergColumnHandle", IcebergColumnHandle::create);
 }
 
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergColumnHandle.cpp
+++ b/velox/connectors/hive/iceberg/IcebergColumnHandle.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -25,6 +26,144 @@
 #include "velox/type/Type.h"
 
 namespace facebook::velox::connector::hive::iceberg {
+
+namespace {
+
+// Produces a compact string of the set attributes in an IcebergFieldMetadata
+// node. Only set fields are emitted; returns an empty string when empty().
+std::string fieldMetadataToString(const IcebergFieldMetadata& meta) {
+  std::ostringstream out;
+  bool first = true;
+  auto append = [&](const std::string& key, const std::string& value) {
+    if (!first) {
+      out << ", ";
+    }
+    out << key << ": " << value;
+    first = false;
+  };
+  if (meta.required.has_value()) {
+    append("required", *meta.required ? "true" : "false");
+  }
+  if (meta.longType.has_value()) {
+    append("longType", *meta.longType);
+  }
+  if (meta.timestampUnit.has_value()) {
+    append("timestampUnit", *meta.timestampUnit);
+  }
+  if (meta.binaryType.has_value()) {
+    append("binaryType", *meta.binaryType);
+  }
+  if (meta.structType.has_value()) {
+    append("structType", *meta.structType);
+  }
+  if (meta.length.has_value()) {
+    append("length", std::to_string(*meta.length));
+  }
+  return out.str();
+}
+
+// Produces a compact string representation of a ParquetFieldId tree.
+// Format: <id> for leaf nodes, <id>[<child0>, <child1>, ...] for nested nodes.
+std::string fieldIdToString(const parquet::ParquetFieldId& fieldId) {
+  std::string result = std::to_string(fieldId.fieldId);
+  if (!fieldId.children.empty()) {
+    result += "[";
+    for (size_t i = 0; i < fieldId.children.size(); ++i) {
+      if (i > 0) {
+        result += ", ";
+      }
+      result += fieldIdToString(fieldId.children[i]);
+    }
+    result += "]";
+  }
+  return result;
+}
+
+// Serializes a ParquetFieldId tree to a folly::dynamic object.
+folly::dynamic serializeFieldId(const parquet::ParquetFieldId& fieldId) {
+  folly::dynamic obj = folly::dynamic::object;
+  obj["fieldId"] = fieldId.fieldId;
+  folly::dynamic children = folly::dynamic::array;
+  for (const auto& child : fieldId.children) {
+    children.push_back(serializeFieldId(child));
+  }
+  obj["children"] = children;
+  return obj;
+}
+
+// Deserializes a ParquetFieldId tree from a folly::dynamic object.
+parquet::ParquetFieldId deserializeFieldId(const folly::dynamic& obj) {
+  parquet::ParquetFieldId fieldId;
+  fieldId.fieldId = static_cast<int32_t>(obj["fieldId"].asInt());
+  for (const auto& child : obj["children"]) {
+    fieldId.children.push_back(deserializeFieldId(child));
+  }
+  return fieldId;
+}
+
+// Serializes an IcebergFieldMetadata node (and its children) to a
+// folly::dynamic object. Only set optional fields are emitted; an all-empty
+// node is serialized as an empty object so that the children array remains
+// parallel to ParquetFieldId::children.
+folly::dynamic serializeFieldMetadata(const IcebergFieldMetadata& meta) {
+  folly::dynamic obj = folly::dynamic::object;
+  if (meta.required.has_value()) {
+    obj["required"] = *meta.required;
+  }
+  if (meta.longType.has_value()) {
+    obj["longType"] = *meta.longType;
+  }
+  if (meta.timestampUnit.has_value()) {
+    obj["timestampUnit"] = *meta.timestampUnit;
+  }
+  if (meta.binaryType.has_value()) {
+    obj["binaryType"] = *meta.binaryType;
+  }
+  if (meta.structType.has_value()) {
+    obj["structType"] = *meta.structType;
+  }
+  if (meta.length.has_value()) {
+    obj["length"] = *meta.length;
+  }
+  folly::dynamic children = folly::dynamic::array;
+  for (const auto& child : meta.children) {
+    children.push_back(serializeFieldMetadata(child));
+  }
+  obj["children"] = children;
+  return obj;
+}
+
+// Deserializes an IcebergFieldMetadata node (and its children) from a
+// folly::dynamic object.
+IcebergFieldMetadata deserializeFieldMetadata(const folly::dynamic& obj) {
+  IcebergFieldMetadata meta;
+  if (auto it = obj.find("required"); it != obj.items().end()) {
+    meta.required = it->second.asBool();
+  }
+  if (auto it = obj.find("longType"); it != obj.items().end()) {
+    meta.longType = it->second.asString();
+  }
+  if (auto it = obj.find("timestampUnit"); it != obj.items().end()) {
+    meta.timestampUnit = it->second.asString();
+  }
+  if (auto it = obj.find("binaryType"); it != obj.items().end()) {
+    meta.binaryType = it->second.asString();
+  }
+  if (auto it = obj.find("structType"); it != obj.items().end()) {
+    meta.structType = it->second.asString();
+  }
+  if (auto it = obj.find("length"); it != obj.items().end()) {
+    meta.length = static_cast<int32_t>(it->second.asInt());
+  }
+  if (auto it = obj.find("children"); it != obj.items().end()) {
+    for (const auto& child : it->second) {
+      meta.children.push_back(deserializeFieldMetadata(child));
+    }
+  }
+  return meta;
+}
+
+} // namespace
 
 IcebergColumnHandle::IcebergColumnHandle(
     const std::string& name,
@@ -50,6 +189,86 @@ IcebergColumnHandle::IcebergColumnHandle(
 
 const parquet::ParquetFieldId& IcebergColumnHandle::field() const {
   return field_;
+}
+
+std::string IcebergColumnHandle::toString() const {
+  std::string fields = HiveColumnHandle::toStringFields();
+  fields += ", field: " + fieldIdToString(field_);
+  if (initialDefaultValue_.has_value()) {
+    fields += ", initialDefaultValue: " + *initialDefaultValue_;
+  }
+  if (!icebergMetadata_.empty()) {
+    fields +=
+        ", icebergMetadata: {" + fieldMetadataToString(icebergMetadata_) + "}";
+  }
+  return fmt::format("IcebergColumnHandle [name: {}, {}]", name(), fields);
+}
+
+folly::dynamic IcebergColumnHandle::serialize() const {
+  folly::dynamic obj = ColumnHandle::serializeBase("IcebergColumnHandle");
+  obj["hiveColumnHandleName"] = name();
+  obj["columnType"] = columnTypeName(columnType());
+  obj["dataType"] = dataType()->serialize();
+
+  folly::dynamic requiredSubfieldsArr = folly::dynamic::array;
+  for (const auto& subfield : requiredSubfields()) {
+    requiredSubfieldsArr.push_back(subfield.toString());
+  }
+  obj["requiredSubfields"] = requiredSubfieldsArr;
+
+  obj["field"] = serializeFieldId(field_);
+
+  if (initialDefaultValue_.has_value()) {
+    obj["initialDefaultValue"] = *initialDefaultValue_;
+  }
+
+  // Only serialize icebergMetadata when at least one node carries a set
+  // attribute, to keep the serialized form compact for callers that never
+  // populate V3 metadata.
+  if (!icebergMetadata_.empty() || !icebergMetadata_.children.empty()) {
+    obj["icebergMetadata"] = serializeFieldMetadata(icebergMetadata_);
+  }
+
+  return obj;
+}
+
+// static
+ColumnHandlePtr IcebergColumnHandle::create(const folly::dynamic& obj) {
+  auto name = obj["hiveColumnHandleName"].asString();
+  auto columnType = columnTypeFromName(obj["columnType"].asString());
+  auto dataType = ISerializable::deserialize<Type>(obj["dataType"]);
+
+  std::vector<common::Subfield> requiredSubfields;
+  for (const auto& s : obj["requiredSubfields"]) {
+    requiredSubfields.emplace_back(s.asString());
+  }
+
+  auto field = deserializeFieldId(obj["field"]);
+
+  std::optional<std::string> initialDefaultValue;
+  if (auto it = obj.find("initialDefaultValue"); it != obj.items().end()) {
+    initialDefaultValue = it->second.asString();
+  }
+
+  IcebergFieldMetadata icebergMetadata;
+  if (auto it = obj.find("icebergMetadata"); it != obj.items().end()) {
+    icebergMetadata = deserializeFieldMetadata(it->second);
+  }
+
+  return std::make_shared<IcebergColumnHandle>(
+      name,
+      columnType,
+      std::move(dataType),
+      std::move(field),
+      std::move(requiredSubfields),
+      std::move(initialDefaultValue),
+      std::move(icebergMetadata));
+}
+
+// static
+void IcebergColumnHandle::registerSerDe() {
+  auto& registry = DeserializationRegistryForSharedPtr();
+  registry.Register("IcebergColumnHandle", IcebergColumnHandle::create);
 }
 
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergColumnHandle.h
+++ b/velox/connectors/hive/iceberg/IcebergColumnHandle.h
@@ -52,6 +52,14 @@ class IcebergColumnHandle : public HiveColumnHandle {
     return initialDefaultValue_;
   }
 
+  std::string toString() const override;
+
+  folly::dynamic serialize() const override;
+
+  static ColumnHandlePtr create(const folly::dynamic& obj);
+
+  static void registerSerDe();
+
  private:
   const parquet::ParquetFieldId field_;
   const std::optional<std::string> initialDefaultValue_;

--- a/velox/connectors/hive/iceberg/IcebergConnector.cpp
+++ b/velox/connectors/hive/iceberg/IcebergConnector.cpp
@@ -26,6 +26,7 @@
 #include "velox/connectors/hive/iceberg/IcebergDeletionVectorSink.h"
 #include "velox/connectors/hive/iceberg/IcebergMergeSink.h"
 #include "velox/connectors/hive/iceberg/IcebergSessionCredentials.h"
+#include "velox/connectors/hive/iceberg/IcebergTableHandle.h"
 
 namespace facebook::velox::connector::hive::iceberg {
 
@@ -164,7 +165,9 @@ std::unique_ptr<DataSink> IcebergConnector::createDataSink(
 }
 
 void IcebergConnector::registerSerDe() {
+  IcebergColumnHandle::registerSerDe();
   IcebergFileNameGenerator::registerSerDe();
+  IcebergTableHandle::registerSerDe();
 }
 
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -724,7 +724,7 @@ IcebergSplitReader::resolveEqualityColumns(
   VELOX_CHECK(
       dataColumns != nullptr,
       "Iceberg equality delete file '{}' cannot be processed because "
-      "table data columns are not available in HiveTableHandle.",
+      "table data columns are not available in IcebergTableHandle.",
       deleteFile.filePath);
   std::unordered_map<int32_t, uint32_t> columnIndexByFieldId;
   if (const auto* hiveTableHandle =

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -669,7 +669,7 @@ IcebergSplitReader::resolveEqualityColumns(
   VELOX_CHECK(
       dataColumns != nullptr,
       "Iceberg equality delete file '{}' cannot be processed because "
-      "table data columns are not available in HiveTableHandle.",
+      "table data columns are not available in IcebergTableHandle.",
       deleteFile.filePath);
   for (const auto& eqFieldId : deleteFile.equalityFieldIds) {
     // Field IDs are 1-based sequential for non-evolved schemas.

--- a/velox/connectors/hive/iceberg/IcebergTableHandle.cpp
+++ b/velox/connectors/hive/iceberg/IcebergTableHandle.cpp
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/IcebergTableHandle.h"
+
+#include <map>
+#include <sstream>
+
+namespace facebook::velox::connector::hive::iceberg {
+
+IcebergTableHandle::IcebergTableHandle(
+    std::string connectorId,
+    const std::string& tableName,
+    common::SubfieldFilters subfieldFilters,
+    const core::TypedExprPtr& remainingFilter,
+    const RowTypePtr& dataColumns,
+    std::vector<std::string> indexColumns,
+    const std::unordered_map<std::string, std::string>& tableParameters,
+    std::vector<IcebergColumnHandlePtr> filterColumnHandles,
+    double sampleRate,
+    std::string dbName,
+    std::vector<int32_t> dataColumnFieldIds,
+    bool isChangelogQuery,
+    std::unordered_map<std::string, IcebergColumnHandlePtr> dataColumnHandles)
+    : HiveTableHandle(
+          std::move(connectorId),
+          tableName,
+          std::move(subfieldFilters),
+          remainingFilter,
+          dataColumns,
+          std::move(indexColumns),
+          tableParameters,
+          std::vector<HiveColumnHandlePtr>(
+              filterColumnHandles.begin(),
+              filterColumnHandles.end()),
+          sampleRate,
+          std::move(dbName),
+          std::move(dataColumnFieldIds)),
+      isChangelogQuery_(isChangelogQuery),
+      dataColumnHandles_(std::move(dataColumnHandles)) {
+  if (isChangelogQuery_) {
+    VELOX_USER_CHECK(
+        !dataColumnHandles_.empty(),
+        "dataColumnHandles must not be empty when isChangelogQuery is true");
+  }
+}
+
+std::string IcebergTableHandle::toString() const {
+  std::ostringstream out;
+  out << HiveTableHandle::toString();
+  if (isChangelogQuery_) {
+    out << ", isChangelogQuery: true";
+  }
+  if (!dataColumnHandles_.empty()) {
+    // Sort by name for deterministic output, mirroring HiveTableHandle's
+    // treatment of subfieldFilters and tableParameters.
+    std::map<std::string, const IcebergColumnHandle*> ordered;
+    for (const auto& [name, handle] : dataColumnHandles_) {
+      ordered[name] = handle.get();
+    }
+    out << ", dataColumnHandles: [";
+    bool first = true;
+    for (const auto& [name, handle] : ordered) {
+      if (!first) {
+        out << ", ";
+      }
+      out << name << ": " << handle->toString();
+      first = false;
+    }
+    out << "]";
+  }
+  return out.str();
+}
+
+folly::dynamic IcebergTableHandle::serialize() const {
+  // Start from the common Hive fields under the "IcebergTableHandle" type name,
+  // then append Iceberg-specific fields.
+  folly::dynamic obj = serializeHiveFields("IcebergTableHandle");
+
+  obj["isChangelogQuery"] = isChangelogQuery_;
+
+  if (!dataColumnHandles_.empty()) {
+    folly::dynamic dataColObj = folly::dynamic::object;
+    for (const auto& [name, handle] : dataColumnHandles_) {
+      dataColObj[name] = handle->serialize();
+    }
+    obj["dataColumnHandles"] = dataColObj;
+  }
+
+  return obj;
+}
+
+// static
+ConnectorTableHandlePtr IcebergTableHandle::create(
+    const folly::dynamic& obj,
+    void* context) {
+  std::string connectorId;
+  std::string tableName;
+  std::string dbName;
+  common::SubfieldFilters subfieldFilters;
+  core::TypedExprPtr remainingFilter;
+  double sampleRate{1.0};
+  RowTypePtr dataColumns;
+  std::unordered_map<std::string, std::string> tableParameters;
+  // deserializeHiveFields dispatches through the SerDe registry using the
+  // "name" key in each handle's JSON.  Because IcebergColumnHandle::serialize()
+  // writes "name":"IcebergColumnHandle", the registry instantiates
+  // IcebergColumnHandle objects, so the dynamic_cast below is always valid.
+  std::vector<HiveColumnHandlePtr> hiveFilterHandles;
+  std::vector<std::string> indexColumns;
+  std::vector<int32_t> dataColumnFieldIds;
+
+  deserializeHiveFields(
+      obj,
+      context,
+      connectorId,
+      tableName,
+      subfieldFilters,
+      remainingFilter,
+      sampleRate,
+      dataColumns,
+      tableParameters,
+      hiveFilterHandles,
+      indexColumns,
+      dbName,
+      dataColumnFieldIds);
+
+  // Cast the already-deserialized handles to their concrete IcebergColumnHandle
+  // type.  The dynamic_cast is guaranteed to succeed (see comment above).
+  std::vector<IcebergColumnHandlePtr> filterColumnHandles;
+  filterColumnHandles.reserve(hiveFilterHandles.size());
+  for (const auto& h : hiveFilterHandles) {
+    auto handle = std::dynamic_pointer_cast<const IcebergColumnHandle>(h);
+    VELOX_CHECK_NOT_NULL(
+        handle,
+        "filterColumnHandle is not an IcebergColumnHandle during deserialization");
+    filterColumnHandles.push_back(std::move(handle));
+  }
+
+  bool isChangelogQuery = false;
+  if (auto it = obj.find("isChangelogQuery"); it != obj.items().end()) {
+    isChangelogQuery = it->second.asBool();
+  }
+
+  std::unordered_map<std::string, IcebergColumnHandlePtr> dataColumnHandles;
+  if (auto it = obj.find("dataColumnHandles"); it != obj.items().end()) {
+    for (const auto& key : it->second.keys()) {
+      auto name = key.asString();
+      auto handle =
+          ISerializable::deserialize<IcebergColumnHandle>(it->second[key]);
+      VELOX_CHECK_NOT_NULL(
+          handle,
+          "dataColumnHandle is not an IcebergColumnHandle during deserialization");
+      dataColumnHandles.emplace(std::move(name), std::move(handle));
+    }
+  }
+
+  return std::make_shared<const IcebergTableHandle>(
+      std::move(connectorId),
+      tableName,
+      std::move(subfieldFilters),
+      remainingFilter,
+      dataColumns,
+      std::move(indexColumns),
+      tableParameters,
+      std::move(filterColumnHandles),
+      sampleRate,
+      std::move(dbName),
+      std::move(dataColumnFieldIds),
+      isChangelogQuery,
+      std::move(dataColumnHandles));
+}
+
+// static
+void IcebergTableHandle::registerSerDe() {
+  auto& registry = DeserializationWithContextRegistryForSharedPtr();
+  registry.Register("IcebergTableHandle", IcebergTableHandle::create);
+}
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergTableHandle.cpp
+++ b/velox/connectors/hive/iceberg/IcebergTableHandle.cpp
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/IcebergTableHandle.h"
+
+#include <map>
+
+namespace facebook::velox::connector::hive::iceberg {
+
+IcebergTableHandle::IcebergTableHandle(
+    std::string connectorId,
+    const std::string& tableName,
+    common::SubfieldFilters subfieldFilters,
+    const core::TypedExprPtr& remainingFilter,
+    const RowTypePtr& dataColumns,
+    std::vector<std::string> indexColumns,
+    const std::unordered_map<std::string, std::string>& tableParameters,
+    std::vector<IcebergColumnHandlePtr> filterColumnHandles,
+    double sampleRate,
+    std::string dbName,
+    bool isChangelogQuery,
+    std::unordered_map<std::string, IcebergColumnHandlePtr> dataColumnHandles)
+    : HiveTableHandle(
+          std::move(connectorId),
+          tableName,
+          std::move(subfieldFilters),
+          remainingFilter,
+          dataColumns,
+          std::move(indexColumns),
+          tableParameters,
+          std::vector<HiveColumnHandlePtr>(
+              filterColumnHandles.begin(),
+              filterColumnHandles.end()),
+          sampleRate,
+          std::move(dbName)),
+      isChangelogQuery_(isChangelogQuery),
+      dataColumnHandles_(std::move(dataColumnHandles)) {
+  if (isChangelogQuery_) {
+    VELOX_USER_CHECK(
+        !dataColumnHandles_.empty(),
+        "dataColumnHandles must not be empty when isChangelogQuery is true");
+  }
+}
+
+std::string IcebergTableHandle::toString() const {
+  std::string base = HiveTableHandle::toString();
+  if (isChangelogQuery_) {
+    base += ", isChangelogQuery: true";
+  }
+  if (!dataColumnHandles_.empty()) {
+    // Sort by name for deterministic output, mirroring HiveTableHandle's
+    // treatment of subfieldFilters and tableParameters.
+    std::map<std::string, const IcebergColumnHandle*> ordered;
+    for (const auto& [name, handle] : dataColumnHandles_) {
+      ordered[name] = handle.get();
+    }
+    base += ", dataColumnHandles: [";
+    bool first = true;
+    for (const auto& [name, handle] : ordered) {
+      if (!first) {
+        base += ", ";
+      }
+      base += name + ": " + handle->toString();
+      first = false;
+    }
+    base += "]";
+  }
+  return base;
+}
+
+folly::dynamic IcebergTableHandle::serialize() const {
+  // Start from the common Hive fields under the "IcebergTableHandle" type name,
+  // then append Iceberg-specific fields.
+  folly::dynamic obj = serializeHiveFields("IcebergTableHandle");
+
+  obj["isChangelogQuery"] = isChangelogQuery_;
+
+  if (!dataColumnHandles_.empty()) {
+    folly::dynamic dataColObj = folly::dynamic::object;
+    for (const auto& [name, handle] : dataColumnHandles_) {
+      dataColObj[name] = handle->serialize();
+    }
+    obj["dataColumnHandles"] = dataColObj;
+  }
+
+  return obj;
+}
+
+// static
+ConnectorTableHandlePtr IcebergTableHandle::create(
+    const folly::dynamic& obj,
+    void* context) {
+  // Declare locals for all common Hive fields; the base helper fills them.
+  // filterColumnHandles is intentionally left empty here — it is parsed below
+  // as IcebergColumnHandlePtr to preserve the concrete type.
+  std::string connectorId, tableName, dbName;
+  common::SubfieldFilters subfieldFilters;
+  core::TypedExprPtr remainingFilter;
+  double sampleRate;
+  RowTypePtr dataColumns;
+  std::unordered_map<std::string, std::string> tableParameters;
+  std::vector<HiveColumnHandlePtr> unusedFilterHandles; // consumed by helper
+  std::vector<std::string> indexColumns;
+
+  deserializeHiveFields(
+      obj,
+      context,
+      connectorId,
+      tableName,
+      subfieldFilters,
+      remainingFilter,
+      sampleRate,
+      dataColumns,
+      tableParameters,
+      unusedFilterHandles,
+      indexColumns,
+      dbName);
+
+  // Re-read filterColumnHandles as IcebergColumnHandlePtr so the concrete
+  // type is preserved and callers never need a dynamic_cast.
+  std::vector<IcebergColumnHandlePtr> filterColumnHandles;
+  if (auto it = obj.find("filterColumnHandles"); it != obj.items().end()) {
+    for (const auto& handle : it->second) {
+      filterColumnHandles.push_back(
+          ISerializable::deserialize<IcebergColumnHandle>(handle));
+    }
+  }
+
+  bool isChangelogQuery = false;
+  if (auto it = obj.find("isChangelogQuery"); it != obj.items().end()) {
+    isChangelogQuery = it->second.asBool();
+  }
+
+  std::unordered_map<std::string, IcebergColumnHandlePtr> dataColumnHandles;
+  if (auto it = obj.find("dataColumnHandles"); it != obj.items().end()) {
+    for (const auto& key : it->second.keys()) {
+      auto name = key.asString();
+      auto handle =
+          ISerializable::deserialize<IcebergColumnHandle>(it->second[key]);
+      dataColumnHandles.emplace(std::move(name), std::move(handle));
+    }
+  }
+
+  return std::make_shared<const IcebergTableHandle>(
+      std::move(connectorId),
+      tableName,
+      std::move(subfieldFilters),
+      remainingFilter,
+      dataColumns,
+      std::move(indexColumns),
+      tableParameters,
+      std::move(filterColumnHandles),
+      sampleRate,
+      std::move(dbName),
+      isChangelogQuery,
+      std::move(dataColumnHandles));
+}
+
+// static
+void IcebergTableHandle::registerSerDe() {
+  auto& registry = DeserializationWithContextRegistryForSharedPtr();
+  registry.Register("IcebergTableHandle", IcebergTableHandle::create);
+}
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergTableHandle.h
+++ b/velox/connectors/hive/iceberg/IcebergTableHandle.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <unordered_map>
+
+#include "velox/connectors/hive/TableHandle.h"
+#include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+/// Iceberg-specific table handle that extends HiveTableHandle.
+///
+/// Carries all fields inherited from HiveTableHandle (subfield filters,
+/// remaining filter, data columns, table parameters, etc.) plus
+/// Iceberg-specific fields:
+///  - isChangelogQuery_: whether this scan is a changelog (CDC) query.
+///  - dataColumnHandles_: column handles keyed by column name, used for
+///    Iceberg-specific column metadata (field IDs, default values, etc.).
+class IcebergTableHandle : public HiveTableHandle {
+ public:
+  IcebergTableHandle(
+      std::string connectorId,
+      const std::string& tableName,
+      common::SubfieldFilters subfieldFilters,
+      const core::TypedExprPtr& remainingFilter,
+      const RowTypePtr& dataColumns = nullptr,
+      std::vector<std::string> indexColumns = {},
+      const std::unordered_map<std::string, std::string>& tableParameters = {},
+      std::vector<IcebergColumnHandlePtr> filterColumnHandles = {},
+      double sampleRate = 1.0,
+      std::string dbName = "",
+      bool isChangelogQuery = false,
+      std::unordered_map<std::string, IcebergColumnHandlePtr>
+          dataColumnHandles = {});
+
+  /// Whether this scan is a changelog (CDC) query over an Iceberg table.
+  bool isChangelogQuery() const {
+    return isChangelogQuery_;
+  }
+
+  /// Column handles keyed by column name, carrying Iceberg-specific metadata
+  /// such as field IDs and initial-default values.
+  const std::unordered_map<std::string, IcebergColumnHandlePtr>&
+  dataColumnHandles() const {
+    return dataColumnHandles_;
+  }
+
+  std::string toString() const override;
+
+  folly::dynamic serialize() const override;
+
+  static ConnectorTableHandlePtr create(
+      const folly::dynamic& obj,
+      void* context);
+
+  static void registerSerDe();
+
+ private:
+  const bool isChangelogQuery_;
+  const std::unordered_map<std::string, IcebergColumnHandlePtr>
+      dataColumnHandles_;
+};
+
+using IcebergTableHandlePtr = std::shared_ptr<const IcebergTableHandle>;
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergTableHandle.h
+++ b/velox/connectors/hive/iceberg/IcebergTableHandle.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <unordered_map>
+
+#include "velox/connectors/hive/TableHandle.h"
+#include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+/// Iceberg-specific table handle that extends HiveTableHandle.
+///
+/// Carries all fields inherited from HiveTableHandle (subfield filters,
+/// remaining filter, data columns, table parameters, etc.) plus
+/// Iceberg-specific fields:
+///  - isChangelogQuery_: whether this scan is a changelog (CDC) query.
+///  - dataColumnHandles_: column handles keyed by column name, used for
+///    Iceberg-specific column metadata (field IDs, default values, etc.).
+class IcebergTableHandle : public HiveTableHandle {
+ public:
+  IcebergTableHandle(
+      std::string connectorId,
+      const std::string& tableName,
+      common::SubfieldFilters subfieldFilters,
+      const core::TypedExprPtr& remainingFilter,
+      const RowTypePtr& dataColumns = nullptr,
+      std::vector<std::string> indexColumns = {},
+      const std::unordered_map<std::string, std::string>& tableParameters = {},
+      std::vector<IcebergColumnHandlePtr> filterColumnHandles = {},
+      double sampleRate = 1.0,
+      std::string dbName = "",
+      std::vector<int32_t> dataColumnFieldIds = {},
+      bool isChangelogQuery = false,
+      std::unordered_map<std::string, IcebergColumnHandlePtr>
+          dataColumnHandles = {});
+
+  /// Whether this scan is a changelog (CDC) query over an Iceberg table.
+  bool isChangelogQuery() const {
+    return isChangelogQuery_;
+  }
+
+  /// Column handles keyed by column name, carrying Iceberg-specific metadata
+  /// such as field IDs and initial-default values.
+  const std::unordered_map<std::string, IcebergColumnHandlePtr>&
+  dataColumnHandles() const {
+    return dataColumnHandles_;
+  }
+
+  std::string toString() const override;
+
+  folly::dynamic serialize() const override;
+
+  static ConnectorTableHandlePtr create(
+      const folly::dynamic& obj,
+      void* context);
+
+  static void registerSerDe();
+
+ private:
+  const bool isChangelogQuery_;
+  const std::unordered_map<std::string, IcebergColumnHandlePtr>
+      dataColumnHandles_;
+};
+
+using IcebergTableHandlePtr = std::shared_ptr<const IcebergTableHandle>;
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/tests/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/tests/CMakeLists.txt
@@ -44,6 +44,7 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
     IcebergPositionalDeleteTest.cpp
     IcebergReadTest.cpp
     IcebergSplitReaderBenchmarkTest.cpp
+    IcebergTableHandleTest.cpp
     IcebergTestBase.cpp
   )
   add_test(velox_hive_iceberg_test velox_hive_iceberg_test)

--- a/velox/connectors/hive/iceberg/tests/IcebergSplitReaderBenchmark.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergSplitReaderBenchmark.cpp
@@ -18,6 +18,7 @@
 #include <filesystem>
 
 #include "velox/connectors/hive/HiveConfig.h"
+#include "velox/connectors/hive/iceberg/IcebergTableHandle.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::dwio;
@@ -282,8 +283,8 @@ void IcebergSplitReaderBenchmark::readSingleColumn(
 
   core::TypedExprPtr remainingFilterExpr;
 
-  std::shared_ptr<HiveTableHandle> hiveTableHandle =
-      std::make_shared<HiveTableHandle>(
+  const std::shared_ptr<IcebergTableHandle> icebergTableHandle =
+      std::make_shared<IcebergTableHandle>(
           "kHiveConnectorId",
           "tableName",
           std::move(filters),
@@ -339,7 +340,7 @@ void IcebergSplitReaderBenchmark::readSingleColumn(
     std::unique_ptr<IcebergSplitReader> icebergSplitReader =
         std::make_unique<IcebergSplitReader>(
             icebergSplit,
-            hiveTableHandle,
+            icebergTableHandle,
             nullptr,
             connectorQueryCtx_.get(),
             hiveConfig,

--- a/velox/connectors/hive/iceberg/tests/IcebergTableHandleTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergTableHandleTest.cpp
@@ -1,0 +1,654 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/IcebergTableHandle.h"
+
+#include <gtest/gtest.h>
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/connectors/hive/TableHandle.h"
+#include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
+#include "velox/dwio/common/ParquetFieldId.h"
+#include "velox/type/Type.h"
+
+// facebook::velox
+using facebook::velox::BIGINT;
+using facebook::velox::DOUBLE;
+using facebook::velox::ISerializable;
+using facebook::velox::ROW;
+using facebook::velox::Type;
+using facebook::velox::TypePtr;
+using facebook::velox::VARCHAR;
+using facebook::velox::dwio::common::ParquetFieldId;
+
+// facebook::velox::common
+using facebook::velox::common::Subfield;
+using facebook::velox::common::SubfieldFilters;
+
+// facebook::velox::connector::hive
+using facebook::velox::connector::hive::FileColumnHandle;
+using facebook::velox::connector::hive::HiveColumnHandle;
+using facebook::velox::connector::hive::HiveTableHandle;
+
+// facebook::velox::connector::hive::iceberg
+using facebook::velox::connector::hive::iceberg::IcebergColumnHandle;
+using facebook::velox::connector::hive::iceberg::IcebergColumnHandlePtr;
+using facebook::velox::connector::hive::iceberg::IcebergFieldMetadata;
+using facebook::velox::connector::hive::iceberg::IcebergTableHandle;
+
+namespace {
+
+// Registers all SerDe entries needed to round-trip IcebergTableHandle and
+// IcebergColumnHandle.
+void registerAll() {
+  Type::registerSerDe();
+  HiveColumnHandle::registerSerDe();
+  IcebergColumnHandle::registerSerDe();
+  HiveTableHandle::registerSerDe();
+  IcebergTableHandle::registerSerDe();
+}
+
+// Builds a minimal IcebergColumnHandle for use in table handle tests.
+IcebergColumnHandlePtr makeIcebergCol(
+    const std::string& name,
+    const TypePtr& type,
+    int32_t fieldId = 1) {
+  return std::make_shared<IcebergColumnHandle>(
+      name,
+      FileColumnHandle::ColumnType::kRegular,
+      type,
+      ParquetFieldId{fieldId, {}});
+}
+
+// Returns a single-entry dataColumnHandles map for the given column.
+std::unordered_map<std::string, IcebergColumnHandlePtr> singleColHandles(
+    const std::string& name,
+    const TypePtr& type,
+    int32_t fieldId = 1) {
+  return {{name, makeIcebergCol(name, type, fieldId)}};
+}
+
+// Builds a minimal IcebergTableHandle with default Iceberg fields.
+std::shared_ptr<IcebergTableHandle> makeMinimal(
+    const std::string& connectorId = "test-iceberg",
+    const std::string& tableName = "test_table") {
+  return std::make_shared<IcebergTableHandle>(
+      connectorId,
+      tableName,
+      /*subfieldFilters=*/SubfieldFilters{},
+      /*remainingFilter=*/nullptr);
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Field accessors
+// ---------------------------------------------------------------------------
+
+TEST(IcebergTableHandleTest, defaultFields) {
+  registerAll();
+
+  auto handle = makeMinimal();
+
+  ASSERT_EQ(handle->tableName(), "test_table");
+  ASSERT_EQ(handle->name(), "test_table");
+  ASSERT_FALSE(handle->isChangelogQuery());
+  ASSERT_TRUE(handle->dataColumnHandles().empty());
+  ASSERT_TRUE(handle->subfieldFilters().empty());
+  ASSERT_EQ(handle->remainingFilter(), nullptr);
+  ASSERT_EQ(handle->sampleRate(), 1.0);
+  ASSERT_EQ(handle->dataColumns(), nullptr);
+  ASSERT_TRUE(handle->dbName().empty());
+}
+
+// isChangelogQuery=true with empty dataColumnHandles must throw.
+TEST(IcebergTableHandleTest, changelogQueryRequiresDataColumnHandles) {
+  registerAll();
+
+  VELOX_ASSERT_THROW(
+      std::make_shared<IcebergTableHandle>(
+          "test-iceberg",
+          "cdc_table",
+          SubfieldFilters{},
+          /*remainingFilter=*/nullptr,
+          /*dataColumns=*/nullptr,
+          /*indexColumns=*/std::vector<std::string>{},
+          /*tableParameters=*/std::unordered_map<std::string, std::string>{},
+          /*filterColumnHandles=*/std::vector<IcebergColumnHandlePtr>{},
+          /*sampleRate=*/1.0,
+          /*dbName=*/"",
+          /*isChangelogQuery=*/true,
+          /*dataColumnHandles=*/
+          std::unordered_map<std::string, IcebergColumnHandlePtr>{}),
+      "dataColumnHandles must not be empty when isChangelogQuery is true");
+}
+
+// ---------------------------------------------------------------------------
+// toString — fully-populated IcebergColumnHandle inside dataColumnHandles.
+// Covers: nested fieldId children, initialDefaultValue, sorted map order.
+// ---------------------------------------------------------------------------
+
+TEST(IcebergTableHandleTest, toString) {
+  registerAll();
+
+  // Two data columns to exercise sorted output ("id" < "payload").
+  // "id": leaf fieldId=3, no default.
+  auto idCol = makeIcebergCol("id", BIGINT(), /*fieldId=*/3);
+
+  // "payload": nested fieldId=10[11, 12], with initialDefaultValue.
+  ParquetFieldId nestedField{
+      10, {ParquetFieldId{11, {}}, ParquetFieldId{12, {}}}};
+  auto payloadCol = std::make_shared<IcebergColumnHandle>(
+      "payload",
+      FileColumnHandle::ColumnType::kRegular,
+      ROW({{"key", BIGINT()}, {"value", VARCHAR()}}),
+      nestedField,
+      /*requiredSubfields=*/std::vector<Subfield>{},
+      /*initialDefaultValue=*/std::optional<std::string>{"{}"}); // default
+                                                                 // empty struct
+
+  std::unordered_map<std::string, IcebergColumnHandlePtr> dataColumnHandles = {
+      {"id", idCol},
+      {"payload", payloadCol},
+  };
+
+  auto dataColumns = ROW({{"c0", BIGINT()}, {"c1", VARCHAR()}});
+  auto handle = std::make_shared<IcebergTableHandle>(
+      "test-iceberg",
+      "cdc_table",
+      SubfieldFilters{},
+      /*remainingFilter=*/nullptr,
+      dataColumns,
+      /*indexColumns=*/std::vector<std::string>{},
+      /*tableParameters=*/
+      std::unordered_map<std::string, std::string>{{"format", "parquet"}},
+      /*filterColumnHandles=*/std::vector<IcebergColumnHandlePtr>{},
+      /*sampleRate=*/0.5,
+      /*dbName=*/"analytics",
+      /*isChangelogQuery=*/true,
+      dataColumnHandles);
+
+  // dataColumnHandles_ is sorted by name: "id" < "payload".
+  ASSERT_EQ(
+      handle->toString(),
+      "table: cdc_table"
+      ", sample rate: 0.5"
+      ", data columns: ROW<c0:BIGINT,c1:VARCHAR>"
+      ", table parameters: [format:parquet]"
+      ", isChangelogQuery: true"
+      ", dataColumnHandles: ["
+      "id: IcebergColumnHandle [name: id, columnType: Regular,"
+      " dataType: BIGINT, requiredSubfields: [ ], field: 3]"
+      ", payload: IcebergColumnHandle [name: payload, columnType: Regular,"
+      " dataType: ROW<key:BIGINT,value:VARCHAR>, requiredSubfields: [ ],"
+      " field: 10[11, 12], initialDefaultValue: {}]"
+      "]");
+}
+
+// ---------------------------------------------------------------------------
+// SerDe round-trip — single fully-populated object, compare clone vs handle
+// ---------------------------------------------------------------------------
+
+TEST(IcebergTableHandleTest, serde) {
+  registerAll();
+
+  auto dataColumns = ROW({{"c0", BIGINT()}, {"c1", VARCHAR()}});
+  auto handle = std::make_shared<IcebergTableHandle>(
+      "test-iceberg",
+      "cdc_table",
+      SubfieldFilters{},
+      /*remainingFilter=*/nullptr,
+      dataColumns,
+      /*indexColumns=*/std::vector<std::string>{},
+      /*tableParameters=*/
+      std::unordered_map<std::string, std::string>{{"format", "parquet"}},
+      /*filterColumnHandles=*/std::vector<IcebergColumnHandlePtr>{},
+      /*sampleRate=*/0.1,
+      /*dbName=*/"analytics",
+      /*isChangelogQuery=*/true,
+      /*dataColumnHandles=*/singleColHandles("id", BIGINT(), /*fieldId=*/7));
+
+  auto obj = handle->serialize();
+  ASSERT_EQ(obj["name"].asString(), "IcebergTableHandle");
+  ASSERT_EQ(obj["connectorId"].asString(), handle->connectorId());
+  ASSERT_EQ(obj["tableName"].asString(), handle->tableName());
+  ASSERT_EQ(obj["isChangelogQuery"].asBool(), handle->isChangelogQuery());
+
+  auto clone =
+      ISerializable::deserialize<IcebergTableHandle>(obj, /*context=*/nullptr);
+
+  ASSERT_EQ(clone->connectorId(), handle->connectorId());
+  ASSERT_EQ(clone->tableName(), handle->tableName());
+  ASSERT_EQ(clone->dbName(), handle->dbName());
+  ASSERT_DOUBLE_EQ(clone->sampleRate(), handle->sampleRate());
+  ASSERT_EQ(clone->tableParameters(), handle->tableParameters());
+  ASSERT_NE(clone->dataColumns(), nullptr);
+  ASSERT_EQ(
+      clone->dataColumns()->toString(), handle->dataColumns()->toString());
+  ASSERT_EQ(clone->isChangelogQuery(), handle->isChangelogQuery());
+  ASSERT_EQ(
+      clone->dataColumnHandles().size(), handle->dataColumnHandles().size());
+  const auto& col = clone->dataColumnHandles().at("id");
+  ASSERT_EQ(col->name(), handle->dataColumnHandles().at("id")->name());
+  ASSERT_EQ(
+      *col->dataType(), *handle->dataColumnHandles().at("id")->dataType());
+  ASSERT_EQ(
+      col->field().fieldId,
+      handle->dataColumnHandles().at("id")->field().fieldId);
+}
+
+// ---------------------------------------------------------------------------
+// SerDe round-trips — targeted field combinations, compare clone vs handle
+// ---------------------------------------------------------------------------
+
+// Minimal handle: only connectorId, tableName, subfieldFilters,
+// remainingFilter. All optional fields must deserialize to their defaults.
+TEST(IcebergTableHandleTest, serdeMinimal) {
+  registerAll();
+
+  auto handle = makeMinimal();
+  auto clone = ISerializable::deserialize<IcebergTableHandle>(
+      handle->serialize(), /*context=*/nullptr);
+
+  ASSERT_EQ(clone->connectorId(), handle->connectorId());
+  ASSERT_EQ(clone->tableName(), handle->tableName());
+  ASSERT_TRUE(clone->subfieldFilters().empty());
+  ASSERT_EQ(clone->remainingFilter(), handle->remainingFilter());
+  ASSERT_EQ(clone->dataColumns(), handle->dataColumns());
+  ASSERT_EQ(clone->indexColumns(), handle->indexColumns());
+  ASSERT_EQ(clone->tableParameters(), handle->tableParameters());
+  ASSERT_DOUBLE_EQ(clone->sampleRate(), handle->sampleRate());
+  ASSERT_EQ(clone->dbName(), handle->dbName());
+  ASSERT_EQ(clone->isChangelogQuery(), handle->isChangelogQuery());
+  ASSERT_EQ(
+      clone->dataColumnHandles().size(), handle->dataColumnHandles().size());
+}
+
+// sampleRate < 1.0 is serialized and round-trips correctly.
+TEST(IcebergTableHandleTest, serdeSampleRate) {
+  registerAll();
+
+  auto handle = std::make_shared<IcebergTableHandle>(
+      "c",
+      "t",
+      SubfieldFilters{},
+      /*remainingFilter=*/nullptr,
+      /*dataColumns=*/nullptr,
+      /*indexColumns=*/std::vector<std::string>{},
+      /*tableParameters=*/std::unordered_map<std::string, std::string>{},
+      /*filterColumnHandles=*/std::vector<IcebergColumnHandlePtr>{},
+      /*sampleRate=*/0.25);
+
+  auto clone = ISerializable::deserialize<IcebergTableHandle>(
+      handle->serialize(), /*context=*/nullptr);
+  ASSERT_DOUBLE_EQ(clone->sampleRate(), handle->sampleRate());
+}
+
+// dbName is serialized only when non-empty and round-trips correctly.
+TEST(IcebergTableHandleTest, serdeDbName) {
+  registerAll();
+
+  auto handle = std::make_shared<IcebergTableHandle>(
+      "c",
+      "t",
+      SubfieldFilters{},
+      /*remainingFilter=*/nullptr,
+      /*dataColumns=*/nullptr,
+      /*indexColumns=*/std::vector<std::string>{},
+      /*tableParameters=*/std::unordered_map<std::string, std::string>{},
+      /*filterColumnHandles=*/std::vector<IcebergColumnHandlePtr>{},
+      /*sampleRate=*/1.0,
+      /*dbName=*/"warehouse");
+
+  auto obj = handle->serialize();
+  ASSERT_TRUE(obj.count("dbName"));
+  ASSERT_EQ(obj["dbName"].asString(), handle->dbName());
+
+  auto clone =
+      ISerializable::deserialize<IcebergTableHandle>(obj, /*context=*/nullptr);
+  ASSERT_EQ(clone->dbName(), handle->dbName());
+
+  // Omitting dbName produces empty string on deserialization.
+  auto minimal = makeMinimal();
+  auto minimalObj = minimal->serialize();
+  ASSERT_EQ(minimalObj.count("dbName"), 0);
+  auto cloneNoDb = ISerializable::deserialize<IcebergTableHandle>(
+      minimalObj, /*context=*/nullptr);
+  ASSERT_EQ(cloneNoDb->dbName(), minimal->dbName());
+}
+
+// tableParameters round-trip with multiple entries.
+TEST(IcebergTableHandleTest, serdeTableParameters) {
+  registerAll();
+
+  const std::unordered_map<std::string, std::string> params = {
+      {"format", "parquet"},
+      {"write.target-file-size-bytes", "134217728"},
+      {"sort-order", "id ASC NULLS LAST"},
+  };
+
+  auto handle = std::make_shared<IcebergTableHandle>(
+      "c",
+      "t",
+      SubfieldFilters{},
+      /*remainingFilter=*/nullptr,
+      /*dataColumns=*/nullptr,
+      /*indexColumns=*/std::vector<std::string>{},
+      /*tableParameters=*/params);
+
+  auto clone = ISerializable::deserialize<IcebergTableHandle>(
+      handle->serialize(), /*context=*/nullptr);
+  ASSERT_EQ(clone->tableParameters(), handle->tableParameters());
+}
+
+// indexColumns non-empty round-trip.
+TEST(IcebergTableHandleTest, serdeIndexColumns) {
+  registerAll();
+
+  const std::vector<std::string> idx = {"id", "event_ts"};
+  auto handle = std::make_shared<IcebergTableHandle>(
+      "c",
+      "t",
+      SubfieldFilters{},
+      /*remainingFilter=*/nullptr,
+      /*dataColumns=*/nullptr,
+      /*indexColumns=*/idx);
+
+  auto clone = ISerializable::deserialize<IcebergTableHandle>(
+      handle->serialize(), /*context=*/nullptr);
+  ASSERT_EQ(clone->indexColumns(), handle->indexColumns());
+}
+
+// dataColumnHandles with nested ParquetFieldId children.
+TEST(IcebergTableHandleTest, serdeDataColumnHandlesNested) {
+  registerAll();
+
+  // A nested field: fieldId=10 with two children (fieldId=11, fieldId=12).
+  const ParquetFieldId nestedField{
+      10,
+      {
+          ParquetFieldId{11, {}},
+          ParquetFieldId{12, {}},
+      }};
+
+  auto col = std::make_shared<IcebergColumnHandle>(
+      "payload",
+      FileColumnHandle::ColumnType::kRegular,
+      ROW({{"key", BIGINT()}, {"value", VARCHAR()}}),
+      nestedField);
+
+  const std::unordered_map<std::string, IcebergColumnHandlePtr>
+      dataColumnHandles = {{"payload", col}};
+
+  auto handle = std::make_shared<IcebergTableHandle>(
+      "c",
+      "t",
+      SubfieldFilters{},
+      /*remainingFilter=*/nullptr,
+      /*dataColumns=*/nullptr,
+      /*indexColumns=*/std::vector<std::string>{},
+      /*tableParameters=*/std::unordered_map<std::string, std::string>{},
+      /*filterColumnHandles=*/std::vector<IcebergColumnHandlePtr>{},
+      /*sampleRate=*/1.0,
+      /*dbName=*/"",
+      /*isChangelogQuery=*/true,
+      dataColumnHandles);
+
+  auto clone = ISerializable::deserialize<IcebergTableHandle>(
+      handle->serialize(), /*context=*/nullptr);
+
+  ASSERT_EQ(
+      clone->dataColumnHandles().size(), handle->dataColumnHandles().size());
+  const auto& src = handle->dataColumnHandles().at("payload");
+  const auto& restored = clone->dataColumnHandles().at("payload");
+  ASSERT_EQ(restored->field().fieldId, src->field().fieldId);
+  ASSERT_EQ(restored->field().children.size(), src->field().children.size());
+  ASSERT_EQ(
+      restored->field().children[0].fieldId, src->field().children[0].fieldId);
+  ASSERT_EQ(
+      restored->field().children[1].fieldId, src->field().children[1].fieldId);
+}
+
+// dataColumnHandles with initialDefaultValue set.
+TEST(IcebergTableHandleTest, serdeDataColumnHandlesInitialDefaultValue) {
+  registerAll();
+
+  auto col = std::make_shared<IcebergColumnHandle>(
+      "status",
+      FileColumnHandle::ColumnType::kRegular,
+      VARCHAR(),
+      ParquetFieldId{20, {}},
+      /*requiredSubfields=*/std::vector<Subfield>{},
+      /*initialDefaultValue=*/std::optional<std::string>{"active"});
+
+  const std::unordered_map<std::string, IcebergColumnHandlePtr>
+      dataColumnHandles = {{"status", col}};
+
+  auto handle = std::make_shared<IcebergTableHandle>(
+      "c",
+      "t",
+      SubfieldFilters{},
+      /*remainingFilter=*/nullptr,
+      /*dataColumns=*/nullptr,
+      /*indexColumns=*/std::vector<std::string>{},
+      /*tableParameters=*/std::unordered_map<std::string, std::string>{},
+      /*filterColumnHandles=*/std::vector<IcebergColumnHandlePtr>{},
+      /*sampleRate=*/1.0,
+      /*dbName=*/"",
+      /*isChangelogQuery=*/true,
+      dataColumnHandles);
+
+  auto clone = ISerializable::deserialize<IcebergTableHandle>(
+      handle->serialize(), /*context=*/nullptr);
+
+  ASSERT_EQ(
+      clone->dataColumnHandles().size(), handle->dataColumnHandles().size());
+  const auto& src = handle->dataColumnHandles().at("status");
+  const auto& restored = clone->dataColumnHandles().at("status");
+  ASSERT_EQ(restored->initialDefaultValue(), src->initialDefaultValue());
+}
+
+// Multiple dataColumnHandles entries — all names and fieldIds survive the trip.
+TEST(IcebergTableHandleTest, serdeDataColumnHandlesMultiple) {
+  registerAll();
+
+  const std::unordered_map<std::string, IcebergColumnHandlePtr>
+      dataColumnHandles = {
+          {"id", makeIcebergCol("id", BIGINT(), 1)},
+          {"name", makeIcebergCol("name", VARCHAR(), 2)},
+          {"score", makeIcebergCol("score", DOUBLE(), 3)},
+      };
+
+  auto handle = std::make_shared<IcebergTableHandle>(
+      "c",
+      "t",
+      SubfieldFilters{},
+      /*remainingFilter=*/nullptr,
+      /*dataColumns=*/nullptr,
+      /*indexColumns=*/std::vector<std::string>{},
+      /*tableParameters=*/std::unordered_map<std::string, std::string>{},
+      /*filterColumnHandles=*/std::vector<IcebergColumnHandlePtr>{},
+      /*sampleRate=*/1.0,
+      /*dbName=*/"",
+      /*isChangelogQuery=*/true,
+      dataColumnHandles);
+
+  auto clone = ISerializable::deserialize<IcebergTableHandle>(
+      handle->serialize(), /*context=*/nullptr);
+
+  ASSERT_EQ(
+      clone->dataColumnHandles().size(), handle->dataColumnHandles().size());
+  for (const auto& [name, srcHandle] : handle->dataColumnHandles()) {
+    ASSERT_EQ(
+        clone->dataColumnHandles().at(name)->field().fieldId,
+        srcHandle->field().fieldId);
+  }
+}
+
+// IcebergColumnHandle icebergMetadata_ round-trip: all V3 attributes and
+// recursive children survive serialization.
+TEST(IcebergTableHandleTest, serdeIcebergMetadata) {
+  registerAll();
+
+  IcebergFieldMetadata childMeta;
+  childMeta.required = false;
+  childMeta.longType = "LONG";
+
+  IcebergFieldMetadata meta;
+  meta.required = true;
+  meta.longType = "LONG";
+  meta.timestampUnit = "MICROS";
+  meta.binaryType = "UUID";
+  meta.structType = "VariantStruct";
+  meta.length = 16;
+  meta.children = {childMeta};
+
+  auto col = std::make_shared<IcebergColumnHandle>(
+      "ts",
+      FileColumnHandle::ColumnType::kRegular,
+      BIGINT(),
+      ParquetFieldId{99, {ParquetFieldId{100, {}}}},
+      /*requiredSubfields=*/std::vector<Subfield>{},
+      /*initialDefaultValue=*/std::nullopt,
+      meta);
+
+  auto obj = col->serialize();
+  ASSERT_TRUE(obj.count("icebergMetadata"));
+
+  auto restored = ISerializable::deserialize<IcebergColumnHandle>(obj);
+  const auto& rm = restored->icebergMetadata();
+
+  ASSERT_EQ(rm.required, meta.required);
+  ASSERT_EQ(rm.longType, meta.longType);
+  ASSERT_EQ(rm.timestampUnit, meta.timestampUnit);
+  ASSERT_EQ(rm.binaryType, meta.binaryType);
+  ASSERT_EQ(rm.structType, meta.structType);
+  ASSERT_EQ(rm.length, meta.length);
+  ASSERT_EQ(rm.children.size(), meta.children.size());
+  ASSERT_EQ(rm.children[0].required, meta.children[0].required);
+  ASSERT_EQ(rm.children[0].longType, meta.children[0].longType);
+}
+
+// Empty icebergMetadata is not written to serialized form.
+TEST(IcebergTableHandleTest, serdeIcebergMetadataOmittedWhenEmpty) {
+  registerAll();
+
+  auto col = makeIcebergCol("id", BIGINT(), /*fieldId=*/1);
+  auto obj = col->serialize();
+  // No V3 metadata was set — the key must be absent.
+  ASSERT_EQ(obj.count("icebergMetadata"), 0);
+
+  auto restored = ISerializable::deserialize<IcebergColumnHandle>(obj);
+  ASSERT_TRUE(restored->icebergMetadata().empty());
+  ASSERT_TRUE(restored->icebergMetadata().children.empty());
+}
+
+// filterColumnHandles round-trip.
+TEST(IcebergTableHandleTest, serdeFilterColumnHandles) {
+  registerAll();
+
+  std::vector<IcebergColumnHandlePtr> filterHandles = {
+      makeIcebergCol("partition_date", VARCHAR(), 5),
+      makeIcebergCol("region_id", BIGINT(), 6),
+  };
+
+  auto handle = std::make_shared<IcebergTableHandle>(
+      "c",
+      "t",
+      SubfieldFilters{},
+      /*remainingFilter=*/nullptr,
+      /*dataColumns=*/nullptr,
+      /*indexColumns=*/std::vector<std::string>{},
+      /*tableParameters=*/std::unordered_map<std::string, std::string>{},
+      /*filterColumnHandles=*/filterHandles);
+
+  auto clone = ISerializable::deserialize<IcebergTableHandle>(
+      handle->serialize(), /*context=*/nullptr);
+
+  // hiveFilterColumnHandles() returns the base vector of HiveColumnHandlePtr;
+  // downcast to IcebergColumnHandle to verify fieldIds.
+  const auto& restored = clone->hiveFilterColumnHandles();
+  ASSERT_EQ(restored.size(), 2);
+
+  const auto* fh0 = dynamic_cast<const IcebergColumnHandle*>(restored[0].get());
+  const auto* fh1 = dynamic_cast<const IcebergColumnHandle*>(restored[1].get());
+  ASSERT_NE(fh0, nullptr);
+  ASSERT_NE(fh1, nullptr);
+
+  // The order from std::vector<IcebergColumnHandlePtr> is preserved.
+  ASSERT_EQ(fh0->name(), "partition_date");
+  ASSERT_EQ(fh0->field().fieldId, 5);
+  ASSERT_EQ(fh1->name(), "region_id");
+  ASSERT_EQ(fh1->field().fieldId, 6);
+}
+
+// ---------------------------------------------------------------------------
+// Negative tests — malformed / missing Iceberg metadata
+// ---------------------------------------------------------------------------
+
+// Deserializing an IcebergTableHandle JSON that is missing the required
+// "tableName" key must throw with a clear diagnostic.
+TEST(IcebergTableHandleTest, deserializeMissingTableName) {
+  registerAll();
+
+  // Build a valid handle, serialize it, then surgically remove "tableName".
+  auto obj = makeMinimal()->serialize();
+  obj.erase("tableName");
+
+  try {
+    ISerializable::deserialize<IcebergTableHandle>(obj, /*context=*/nullptr);
+    FAIL() << "Expected std::out_of_range for missing 'tableName'";
+  } catch (const std::out_of_range& e) {
+    EXPECT_NE(std::string(e.what()).find("tableName"), std::string::npos)
+        << "Exception message was: " << e.what();
+  }
+}
+
+// Deserializing an IcebergColumnHandle JSON that is missing the required
+// "field" key (the ParquetFieldId) must throw with a clear diagnostic.
+TEST(IcebergTableHandleTest, deserializeMissingFieldKey) {
+  registerAll();
+
+  auto col = makeIcebergCol("id", BIGINT(), /*fieldId=*/1);
+  auto obj = col->serialize();
+  obj.erase("field");
+
+  try {
+    ISerializable::deserialize<IcebergColumnHandle>(obj);
+    FAIL() << "Expected std::out_of_range for missing 'field'";
+  } catch (const std::out_of_range& e) {
+    EXPECT_NE(std::string(e.what()).find("field"), std::string::npos)
+        << "Exception message was: " << e.what();
+  }
+}
+
+// Deserializing a ParquetFieldId JSON that is missing the required
+// "fieldId" key inside the "field" object must throw with a clear diagnostic.
+TEST(IcebergTableHandleTest, deserializeMissingFieldId) {
+  registerAll();
+
+  auto col = makeIcebergCol("id", BIGINT(), /*fieldId=*/42);
+  auto obj = col->serialize();
+  // Remove "fieldId" from the nested "field" object.
+  obj["field"].erase("fieldId");
+
+  try {
+    ISerializable::deserialize<IcebergColumnHandle>(obj);
+    FAIL() << "Expected std::out_of_range for missing 'fieldId'";
+  } catch (const std::out_of_range& e) {
+    EXPECT_NE(std::string(e.what()).find("fieldId"), std::string::npos)
+        << "Exception message was: " << e.what();
+  }
+}

--- a/velox/connectors/hive/iceberg/tests/IcebergTableHandleTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergTableHandleTest.cpp
@@ -1,0 +1,472 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/IcebergTableHandle.h"
+
+#include <gtest/gtest.h>
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/connectors/hive/TableHandle.h"
+#include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
+#include "velox/dwio/common/ParquetFieldId.h"
+#include "velox/type/Type.h"
+
+// facebook::velox
+using facebook::velox::BIGINT;
+using facebook::velox::ISerializable;
+using facebook::velox::ROW;
+using facebook::velox::Type;
+using facebook::velox::TypePtr;
+using facebook::velox::VARCHAR;
+using facebook::velox::dwio::common::ParquetFieldId;
+
+// facebook::velox::common
+using facebook::velox::common::Subfield;
+using facebook::velox::common::SubfieldFilters;
+
+// facebook::velox::connector::hive
+using facebook::velox::connector::hive::FileColumnHandle;
+using facebook::velox::connector::hive::HiveColumnHandle;
+using facebook::velox::connector::hive::HiveTableHandle;
+
+// facebook::velox::connector::hive::iceberg
+using facebook::velox::connector::hive::iceberg::IcebergColumnHandle;
+using facebook::velox::connector::hive::iceberg::IcebergColumnHandlePtr;
+using facebook::velox::connector::hive::iceberg::IcebergFieldMetadata;
+using facebook::velox::connector::hive::iceberg::IcebergTableHandle;
+
+namespace {
+
+// Registers all SerDe entries needed to round-trip IcebergTableHandle and
+// IcebergColumnHandle.
+void registerAll() {
+  Type::registerSerDe();
+  HiveColumnHandle::registerSerDe();
+  IcebergColumnHandle::registerSerDe();
+  HiveTableHandle::registerSerDe();
+  IcebergTableHandle::registerSerDe();
+}
+
+// Builds a minimal IcebergColumnHandle for use in table handle tests.
+IcebergColumnHandlePtr makeIcebergCol(
+    const std::string& name,
+    const TypePtr& type,
+    int32_t fieldId = 1) {
+  return std::make_shared<IcebergColumnHandle>(
+      name,
+      FileColumnHandle::ColumnType::kRegular,
+      type,
+      ParquetFieldId{fieldId, {}});
+}
+
+// Builds a minimal IcebergTableHandle with default Iceberg fields.
+std::shared_ptr<IcebergTableHandle> makeMinimal(
+    const std::string& connectorId = "test-iceberg",
+    const std::string& tableName = "test_table") {
+  return std::make_shared<IcebergTableHandle>(
+      connectorId,
+      tableName,
+      /*subfieldFilters=*/SubfieldFilters{},
+      /*remainingFilter=*/nullptr);
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Field accessors
+// ---------------------------------------------------------------------------
+
+TEST(IcebergTableHandleTest, defaultFields) {
+  registerAll();
+
+  auto handle = makeMinimal();
+
+  ASSERT_EQ(handle->tableName(), "test_table");
+  ASSERT_EQ(handle->name(), "test_table");
+  ASSERT_FALSE(handle->isChangelogQuery());
+  ASSERT_TRUE(handle->dataColumnHandles().empty());
+  ASSERT_TRUE(handle->subfieldFilters().empty());
+  ASSERT_EQ(handle->remainingFilter(), nullptr);
+  ASSERT_EQ(handle->sampleRate(), 1.0);
+  ASSERT_EQ(handle->dataColumns(), nullptr);
+  ASSERT_TRUE(handle->dbName().empty());
+}
+
+// isChangelogQuery=true with empty dataColumnHandles must throw.
+TEST(IcebergTableHandleTest, changelogQueryRequiresDataColumnHandles) {
+  registerAll();
+
+  VELOX_ASSERT_THROW(
+      std::make_shared<IcebergTableHandle>(
+          "test-iceberg",
+          "cdc_table",
+          SubfieldFilters{},
+          /*remainingFilter=*/nullptr,
+          /*dataColumns=*/nullptr,
+          /*indexColumns=*/std::vector<std::string>{},
+          /*tableParameters=*/std::unordered_map<std::string, std::string>{},
+          /*filterColumnHandles=*/std::vector<IcebergColumnHandlePtr>{},
+          /*sampleRate=*/1.0,
+          /*dbName=*/"",
+          /*dataColumnFieldIds=*/std::vector<int32_t>{},
+          /*isChangelogQuery=*/true,
+          /*dataColumnHandles=*/
+          std::unordered_map<std::string, IcebergColumnHandlePtr>{}),
+      "dataColumnHandles must not be empty when isChangelogQuery is true");
+}
+
+// ---------------------------------------------------------------------------
+// toString — fully-populated IcebergColumnHandle inside dataColumnHandles.
+// Covers: nested fieldId children, initialDefaultValue, icebergMetadata
+// (empty, partial, fully-populated), sorted map order.
+// ---------------------------------------------------------------------------
+
+TEST(IcebergTableHandleTest, toString) {
+  registerAll();
+
+  // Three data columns to exercise sorted output ("id" < "payload" < "score")
+  // and all three icebergMetadata states: partial, empty, fully-populated.
+
+  // "id": partial icebergMetadata (required + longType only).
+  IcebergFieldMetadata icebergFieldMetadata;
+  icebergFieldMetadata.required = false;
+  icebergFieldMetadata.longType = "LONG";
+  auto idCol = std::make_shared<IcebergColumnHandle>(
+      "id",
+      FileColumnHandle::ColumnType::kRegular,
+      BIGINT(),
+      ParquetFieldId{3, {}},
+      /*requiredSubfields=*/std::vector<Subfield>{},
+      /*initialDefaultValue=*/std::nullopt,
+      icebergFieldMetadata);
+
+  // "payload": nested fieldId=10[11, 12], initialDefaultValue, no metadata.
+  ParquetFieldId nestedField{
+      10, {ParquetFieldId{11, {}}, ParquetFieldId{12, {}}}};
+  auto payloadCol = std::make_shared<IcebergColumnHandle>(
+      "payload",
+      FileColumnHandle::ColumnType::kRegular,
+      ROW({{"key", BIGINT()}, {"value", VARCHAR()}}),
+      nestedField,
+      /*requiredSubfields=*/std::vector<Subfield>{},
+      /*initialDefaultValue=*/std::optional<std::string>{"{}"}); // empty struct
+
+  // "score": fully-populated icebergMetadata, all six attributes set.
+  IcebergFieldMetadata fullMeta;
+  fullMeta.required = true;
+  fullMeta.longType = "LONG";
+  fullMeta.timestampUnit = "MICROS";
+  fullMeta.binaryType = "UUID";
+  fullMeta.structType = "VariantStruct";
+  fullMeta.length = 16;
+  auto scoreCol = std::make_shared<IcebergColumnHandle>(
+      "score",
+      FileColumnHandle::ColumnType::kRegular,
+      BIGINT(),
+      ParquetFieldId{7, {}},
+      /*requiredSubfields=*/std::vector<Subfield>{},
+      /*initialDefaultValue=*/std::nullopt,
+      fullMeta);
+
+  std::unordered_map<std::string, IcebergColumnHandlePtr> dataColumnHandles = {
+      {"id", idCol},
+      {"payload", payloadCol},
+      {"score", scoreCol},
+  };
+
+  auto dataColumns =
+      ROW({{"c0", BIGINT()}, {"c1", VARCHAR()}, {"c2", BIGINT()}});
+  auto handle = std::make_shared<IcebergTableHandle>(
+      "test-iceberg",
+      "cdc_table",
+      SubfieldFilters{},
+      /*remainingFilter=*/nullptr,
+      dataColumns,
+      /*indexColumns=*/std::vector<std::string>{},
+      /*tableParameters=*/
+      std::unordered_map<std::string, std::string>{{"format", "parquet"}},
+      /*filterColumnHandles=*/std::vector<IcebergColumnHandlePtr>{},
+      /*sampleRate=*/0.5,
+      /*dbName=*/"analytics",
+      /*dataColumnFieldIds=*/std::vector<int32_t>{},
+      /*isChangelogQuery=*/true,
+      dataColumnHandles);
+
+  // dataColumnHandles_ is sorted by name: "id" < "payload" < "score".
+  ASSERT_EQ(
+      handle->toString(),
+      "table: cdc_table"
+      ", sample rate: 0.5"
+      ", data columns: ROW<c0:BIGINT,c1:VARCHAR,c2:BIGINT>"
+      ", table parameters: [format:parquet]"
+      ", isChangelogQuery: true"
+      ", dataColumnHandles: ["
+      "id: IcebergColumnHandle [name: id, columnType: Regular,"
+      " dataType: BIGINT, requiredSubfields: [ ], field: 3,"
+      " icebergMetadata: {required: false, longType: LONG}]"
+      ", payload: IcebergColumnHandle [name: payload, columnType: Regular,"
+      " dataType: ROW<key:BIGINT,value:VARCHAR>, requiredSubfields: [ ],"
+      " field: 10[11, 12], initialDefaultValue: {}]"
+      ", score: IcebergColumnHandle [name: score, columnType: Regular,"
+      " dataType: BIGINT, requiredSubfields: [ ], field: 7,"
+      " icebergMetadata: {required: true, longType: LONG,"
+      " timestampUnit: MICROS, binaryType: UUID,"
+      " structType: VariantStruct, length: 16}]"
+      "]");
+}
+
+// ---------------------------------------------------------------------------
+// SerDe round-trips
+// ---------------------------------------------------------------------------
+
+// Minimal handle: only connectorId, tableName, subfieldFilters,
+// remainingFilter. All optional fields must deserialize to their defaults.
+TEST(IcebergTableHandleTest, serdeMinimal) {
+  registerAll();
+
+  auto handle = makeMinimal();
+  auto clone = ISerializable::deserialize<IcebergTableHandle>(
+      handle->serialize(), /*context=*/nullptr);
+
+  ASSERT_EQ(clone->connectorId(), handle->connectorId());
+  ASSERT_EQ(clone->tableName(), handle->tableName());
+  ASSERT_TRUE(clone->subfieldFilters().empty());
+  ASSERT_EQ(clone->remainingFilter(), nullptr);
+  ASSERT_EQ(clone->dataColumns(), nullptr);
+  ASSERT_TRUE(clone->dataColumnFieldIds().empty());
+  ASSERT_TRUE(clone->indexColumns().empty());
+  ASSERT_TRUE(clone->tableParameters().empty());
+  ASSERT_DOUBLE_EQ(clone->sampleRate(), 1.0);
+  ASSERT_TRUE(clone->dbName().empty());
+  ASSERT_FALSE(clone->isChangelogQuery());
+  ASSERT_TRUE(clone->dataColumnHandles().empty());
+  ASSERT_TRUE(clone->hiveFilterColumnHandles().empty());
+}
+
+// Fully-populated round-trip: every serialized field is set to a non-default
+// value and verified to survive the serialize/deserialize cycle.
+TEST(IcebergTableHandleTest, serdeFullyPopulated) {
+  registerAll();
+
+  // dataColumnHandles: leaf + nested field, one with initialDefaultValue.
+  const ParquetFieldId nestedField{
+      10, {ParquetFieldId{11, {}}, ParquetFieldId{12, {}}}};
+  auto payloadCol = std::make_shared<IcebergColumnHandle>(
+      "payload",
+      FileColumnHandle::ColumnType::kRegular,
+      ROW({{"key", BIGINT()}, {"value", VARCHAR()}}),
+      nestedField,
+      /*requiredSubfields=*/std::vector<Subfield>{},
+      /*initialDefaultValue=*/std::optional<std::string>{"active"});
+
+  const std::unordered_map<std::string, IcebergColumnHandlePtr>
+      dataColumnHandles = {
+          {"id", makeIcebergCol("id", BIGINT(), /*fieldId=*/7)},
+          {"payload", payloadCol},
+      };
+
+  // filterColumnHandles: two Iceberg-typed handles.
+  std::vector<IcebergColumnHandlePtr> filterHandles = {
+      makeIcebergCol("partition_date", VARCHAR(), /*fieldId=*/5),
+      makeIcebergCol("region_id", BIGINT(), /*fieldId=*/6),
+  };
+
+  auto dataColumns = ROW({{"c0", BIGINT()}, {"c1", VARCHAR()}});
+  auto handle = std::make_shared<IcebergTableHandle>(
+      "test-iceberg",
+      "cdc_table",
+      SubfieldFilters{},
+      /*remainingFilter=*/nullptr,
+      dataColumns,
+      /*indexColumns=*/std::vector<std::string>{"id", "event_ts"},
+      /*tableParameters=*/
+      std::unordered_map<std::string, std::string>{
+          {"format", "parquet"},
+          {"write.target-file-size-bytes", "134217728"},
+      },
+      /*filterColumnHandles=*/filterHandles,
+      /*sampleRate=*/0.1,
+      /*dbName=*/"warehouse",
+      /*dataColumnFieldIds=*/std::vector<int32_t>{10, 20},
+      /*isChangelogQuery=*/true,
+      dataColumnHandles);
+
+  auto clone = ISerializable::deserialize<IcebergTableHandle>(
+      handle->serialize(), /*context=*/nullptr);
+
+  // HiveTableHandle fields.
+  ASSERT_EQ(clone->connectorId(), handle->connectorId());
+  ASSERT_EQ(clone->tableName(), handle->tableName());
+  ASSERT_EQ(clone->dataColumns()->toString(), dataColumns->toString());
+  ASSERT_EQ(clone->dataColumnFieldIds(), handle->dataColumnFieldIds());
+  ASSERT_EQ(clone->indexColumns(), handle->indexColumns());
+  ASSERT_EQ(clone->tableParameters(), handle->tableParameters());
+  ASSERT_DOUBLE_EQ(clone->sampleRate(), handle->sampleRate());
+  ASSERT_EQ(clone->dbName(), handle->dbName());
+
+  // filterColumnHandles: concrete type survives deserialization.
+  const auto& restoredFilters = clone->hiveFilterColumnHandles();
+  ASSERT_EQ(restoredFilters.size(), 2);
+  const auto* fh0 =
+      dynamic_cast<const IcebergColumnHandle*>(restoredFilters[0].get());
+  const auto* fh1 =
+      dynamic_cast<const IcebergColumnHandle*>(restoredFilters[1].get());
+  ASSERT_NE(fh0, nullptr);
+  ASSERT_NE(fh1, nullptr);
+  ASSERT_EQ(fh0->name(), "partition_date");
+  ASSERT_EQ(fh0->field().fieldId, 5);
+  ASSERT_EQ(fh1->name(), "region_id");
+  ASSERT_EQ(fh1->field().fieldId, 6);
+
+  // Iceberg-specific fields.
+  ASSERT_TRUE(clone->isChangelogQuery());
+  ASSERT_EQ(
+      clone->dataColumnHandles().size(), handle->dataColumnHandles().size());
+
+  // "id": leaf field.
+  const auto& cloneId = clone->dataColumnHandles().at("id");
+  ASSERT_EQ(cloneId->field().fieldId, 7);
+  ASSERT_EQ(*cloneId->dataType(), *BIGINT());
+
+  // "payload": nested field + initialDefaultValue.
+  const auto& clonePayload = clone->dataColumnHandles().at("payload");
+  ASSERT_EQ(clonePayload->field().fieldId, nestedField.fieldId);
+  ASSERT_EQ(clonePayload->field().children.size(), 2);
+  ASSERT_EQ(clonePayload->field().children[0].fieldId, 11);
+  ASSERT_EQ(clonePayload->field().children[1].fieldId, 12);
+  ASSERT_EQ(
+      clonePayload->initialDefaultValue(),
+      std::optional<std::string>{"active"});
+}
+
+// ---------------------------------------------------------------------------
+// IcebergColumnHandle icebergMetadata_ SerDe
+// ---------------------------------------------------------------------------
+
+// All V3 attributes and recursive children survive serialization.
+TEST(IcebergTableHandleTest, serdeIcebergMetadata) {
+  registerAll();
+
+  IcebergFieldMetadata childMeta;
+  childMeta.required = false;
+  childMeta.longType = "LONG";
+
+  IcebergFieldMetadata meta;
+  meta.required = true;
+  meta.longType = "LONG";
+  meta.timestampUnit = "MICROS";
+  meta.binaryType = "UUID";
+  meta.structType = "VariantStruct";
+  meta.length = 16;
+  meta.children = {childMeta};
+
+  auto col = std::make_shared<IcebergColumnHandle>(
+      "ts",
+      FileColumnHandle::ColumnType::kRegular,
+      BIGINT(),
+      ParquetFieldId{99, {ParquetFieldId{100, {}}}},
+      /*requiredSubfields=*/std::vector<Subfield>{},
+      /*initialDefaultValue=*/std::nullopt,
+      meta);
+
+  auto obj = col->serialize();
+  ASSERT_TRUE(obj.count("icebergMetadata"));
+
+  auto restored = ISerializable::deserialize<IcebergColumnHandle>(obj);
+  const auto& rm = restored->icebergMetadata();
+
+  ASSERT_EQ(rm.required, meta.required);
+  ASSERT_EQ(rm.longType, meta.longType);
+  ASSERT_EQ(rm.timestampUnit, meta.timestampUnit);
+  ASSERT_EQ(rm.binaryType, meta.binaryType);
+  ASSERT_EQ(rm.structType, meta.structType);
+  ASSERT_EQ(rm.length, meta.length);
+  ASSERT_EQ(rm.children.size(), meta.children.size());
+  ASSERT_EQ(rm.children[0].required, meta.children[0].required);
+  ASSERT_EQ(rm.children[0].longType, meta.children[0].longType);
+}
+
+// Empty icebergMetadata is not written to serialized form.
+TEST(IcebergTableHandleTest, serdeIcebergMetadataOmittedWhenEmpty) {
+  registerAll();
+
+  auto col = makeIcebergCol("id", BIGINT(), /*fieldId=*/1);
+  auto obj = col->serialize();
+  // No V3 metadata was set — the key must be absent.
+  ASSERT_EQ(obj.count("icebergMetadata"), 0);
+
+  auto restored = ISerializable::deserialize<IcebergColumnHandle>(obj);
+  ASSERT_TRUE(restored->icebergMetadata().empty());
+  ASSERT_TRUE(restored->icebergMetadata().children.empty());
+}
+
+// ---------------------------------------------------------------------------
+// Negative tests — malformed / missing Iceberg metadata
+// ---------------------------------------------------------------------------
+
+// Deserializing an IcebergTableHandle JSON that is missing the required
+// "tableName" key must throw with a clear diagnostic.
+TEST(IcebergTableHandleTest, deserializeMissingTableName) {
+  registerAll();
+
+  // Build a valid handle, serialize it, then surgically remove "tableName".
+  auto obj = makeMinimal()->serialize();
+  obj.erase("tableName");
+
+  try {
+    ISerializable::deserialize<IcebergTableHandle>(obj, /*context=*/nullptr);
+    FAIL() << "Expected std::out_of_range for missing 'tableName'";
+  } catch (const std::out_of_range& e) {
+    EXPECT_NE(std::string(e.what()).find("tableName"), std::string::npos)
+        << "Exception message was: " << e.what();
+  }
+}
+
+// Deserializing an IcebergColumnHandle JSON that is missing the required
+// "field" key (the ParquetFieldId) must throw with a clear diagnostic.
+TEST(IcebergTableHandleTest, deserializeMissingFieldKey) {
+  registerAll();
+
+  auto col = makeIcebergCol("id", BIGINT(), /*fieldId=*/1);
+  auto obj = col->serialize();
+  obj.erase("field");
+
+  try {
+    ISerializable::deserialize<IcebergColumnHandle>(obj);
+    FAIL() << "Expected std::out_of_range for missing 'field'";
+  } catch (const std::out_of_range& e) {
+    EXPECT_NE(std::string(e.what()).find("field"), std::string::npos)
+        << "Exception message was: " << e.what();
+  }
+}
+
+// Deserializing a ParquetFieldId JSON that is missing the required
+// "fieldId" key inside the "field" object must throw with a clear diagnostic.
+TEST(IcebergTableHandleTest, deserializeMissingFieldId) {
+  registerAll();
+
+  auto col = makeIcebergCol("id", BIGINT(), /*fieldId=*/42);
+  auto obj = col->serialize();
+  // Remove "fieldId" from the nested "field" object.
+  obj["field"].erase("fieldId");
+
+  try {
+    ISerializable::deserialize<IcebergColumnHandle>(obj);
+    FAIL() << "Expected std::out_of_range for missing 'fieldId'";
+  } catch (const std::out_of_range& e) {
+    EXPECT_NE(std::string(e.what()).find("fieldId"), std::string::npos)
+        << "Exception message was: " << e.what();
+  }
+}


### PR DESCRIPTION
This PR adds IcebergTableHandle class so that Iceberg specific functionality can be supported. 

1) Iceberg specific table-level metadata has no meaning in Hive. 
2) Serde uses "IcebergTableHandle" instead "HiveTableHandle". 
3) IcebergTableHandle implemented in this PR extends it with the two things that are exclusively Iceberg's: field-ID-bearing column handles and the changelog-query flag (for CDC scans). Reuses all of Hive's scan infrastructure — subfield filters, predicate pushdown, sampling, partition keys — while adding Iceberg semantics on top, in the same pattern already established by IcebergColumnHandle : HiveColumnHandle.

One of the first Iceberg specific features that requires this is the changelog query support in https://github.com/facebookincubator/velox/pull/17801

E2E PR: https://github.com/prestodb/presto/pull/28173 