### PR TITLE
refactor(velox): Extract shared HiveHash primitives into functions/lib/HiveHash.h (#18193)

### DIFF
--- a/velox/connectors/hive/CMakeLists.txt
+++ b/velox/connectors/hive/CMakeLists.txt
@@ -97,7 +97,7 @@ endif()
 
 velox_add_library(velox_hive_partition_function HivePartitionFunction.cpp)
 
-velox_link_libraries(velox_hive_partition_function velox_core velox_exec)
+velox_link_libraries(velox_hive_partition_function velox_core velox_exec velox_hive_hash)
 
 add_subdirectory(storage_adapters)
 

--- a/velox/connectors/hive/CMakeLists.txt
+++ b/velox/connectors/hive/CMakeLists.txt
@@ -99,7 +99,7 @@ endif()
 
 velox_add_library(velox_hive_partition_function HivePartitionFunction.cpp)
 
-velox_link_libraries(velox_hive_partition_function velox_core velox_exec)
+velox_link_libraries(velox_hive_partition_function velox_core velox_exec velox_hive_hash)
 
 add_subdirectory(storage_adapters)
 

--- a/velox/connectors/hive/HivePartitionFunction.cpp
+++ b/velox/connectors/hive/HivePartitionFunction.cpp
@@ -17,128 +17,12 @@
 
 #include <utility>
 
+#include "velox/functions/lib/HiveHash.h"
+
 namespace facebook::velox::connector::hive {
 
 namespace {
-void mergeHash(bool mix, uint32_t oneHash, uint32_t& aggregateHash) {
-  aggregateHash = mix ? aggregateHash * 31 + oneHash : oneHash;
-}
-
-int32_t hashInt64(int64_t value) {
-  return ((*reinterpret_cast<uint64_t*>(&value)) >> 32) ^ value;
-}
-
-#if defined(__has_feature)
-#if __has_feature(__address_sanitizer__)
-__attribute__((no_sanitize("integer")))
-#endif
-#endif
-uint32_t hashBytes(StringView bytes, int32_t initialValue) {
-  uint32_t hash = initialValue;
-  auto* data = bytes.data();
-  for (auto i = 0; i < bytes.size(); ++i) {
-    hash = hash * 31 + *reinterpret_cast<const int8_t*>(data + i);
-  }
-  return hash;
-}
-
-int32_t hashTimestamp(const Timestamp& ts) {
-  return hashInt64((ts.getSeconds() << 30) | ts.getNanos());
-}
-
-template <TypeKind kind>
-inline uint32_t hashOne(typename TypeTraits<kind>::NativeType /* value */) {
-  VELOX_UNSUPPORTED(
-      "Hive partitioning function doesn't support {} type",
-      TypeTraits<kind>::name);
-  return 0; // Make compiler happy.
-}
-
-template <>
-inline uint32_t hashOne<TypeKind::BOOLEAN>(bool value) {
-  return value ? 1 : 0;
-}
-
-template <>
-inline uint32_t hashOne<TypeKind::TINYINT>(int8_t value) {
-  return static_cast<uint32_t>(value);
-}
-
-template <>
-inline uint32_t hashOne<TypeKind::SMALLINT>(int16_t value) {
-  return static_cast<uint32_t>(value);
-}
-
-template <>
-inline uint32_t hashOne<TypeKind::INTEGER>(int32_t value) {
-  return static_cast<uint32_t>(value);
-}
-
-template <>
-inline uint32_t hashOne<TypeKind::REAL>(float value) {
-  return static_cast<uint32_t>(*reinterpret_cast<const int32_t*>(&value));
-}
-
-template <>
-inline uint32_t hashOne<TypeKind::BIGINT>(int64_t value) {
-  return hashInt64(value);
-}
-
-template <>
-inline uint32_t hashOne<TypeKind::DOUBLE>(double value) {
-  return hashInt64(*reinterpret_cast<const int64_t*>(&value));
-}
-
-template <>
-inline uint32_t hashOne<TypeKind::VARCHAR>(StringView value) {
-  return hashBytes(value, 0);
-}
-
-template <>
-inline uint32_t hashOne<TypeKind::VARBINARY>(StringView value) {
-  return hashBytes(value, 0);
-}
-
-template <>
-inline uint32_t hashOne<TypeKind::TIMESTAMP>(Timestamp value) {
-  return hashTimestamp(value);
-}
-
-template <>
-inline uint32_t hashOne<TypeKind::UNKNOWN>(UnknownValue /*value*/) {
-  VELOX_FAIL("Unknown values cannot be non-NULL");
-}
-
-template <TypeKind kind>
-void hashPrimitive(
-    const DecodedVector& values,
-    const SelectivityVector& rows,
-    bool mix,
-    std::vector<uint32_t>& hashes) {
-  if (rows.isAllSelected()) {
-    // The compiler seems to be a little fickle with optimizations.
-    // Although rows.applyToSelected should do roughly the same thing, doing
-    // this here along with assigning rows.size() to a variable seems to help
-    // the compiler to inline hashOne showing a 50% performance improvement in
-    // benchmarks.
-    vector_size_t numRows = rows.size();
-    for (auto i = 0; i < numRows; ++i) {
-      const uint32_t hash = values.isNullAt(i)
-          ? 0
-          : hashOne<kind>(
-                values.valueAt<typename TypeTraits<kind>::NativeType>(i));
-      mergeHash(mix, hash, hashes[i]);
-    }
-  } else {
-    rows.applyToSelected([&](auto row) INLINE_LAMBDA {
-      const uint32_t hash = values.isNullAt(row)
-          ? 0
-          : hashOne<kind>(
-                values.valueAt<typename TypeTraits<kind>::NativeType>(row));
-      mergeHash(mix, hash, hashes[row]);
-    });
-  }
-}
+using facebook::velox::functions::HiveHash;
 
 void hashPrecomputed(
     uint32_t precomputedHash,
@@ -158,7 +42,7 @@ void HivePartitionFunction::hashTyped<TypeKind::BOOLEAN>(
     bool mix,
     std::vector<uint32_t>& hashes,
     size_t /* poolIndex */) {
-  hashPrimitive<TypeKind::BOOLEAN>(values, rows, mix, hashes);
+  HiveHash::hashPrimitive<TypeKind::BOOLEAN>(values, rows, mix, hashes);
 }
 
 template <>
@@ -168,7 +52,7 @@ void HivePartitionFunction::hashTyped<TypeKind::TINYINT>(
     bool mix,
     std::vector<uint32_t>& hashes,
     size_t /* poolIndex */) {
-  hashPrimitive<TypeKind::TINYINT>(values, rows, mix, hashes);
+  HiveHash::hashPrimitive<TypeKind::TINYINT>(values, rows, mix, hashes);
 }
 
 template <>
@@ -178,7 +62,7 @@ void HivePartitionFunction::hashTyped<TypeKind::SMALLINT>(
     bool mix,
     std::vector<uint32_t>& hashes,
     size_t /* poolIndex */) {
-  hashPrimitive<TypeKind::SMALLINT>(values, rows, mix, hashes);
+  HiveHash::hashPrimitive<TypeKind::SMALLINT>(values, rows, mix, hashes);
 }
 
 template <>
@@ -188,7 +72,7 @@ void HivePartitionFunction::hashTyped<TypeKind::INTEGER>(
     bool mix,
     std::vector<uint32_t>& hashes,
     size_t /* poolIndex */) {
-  hashPrimitive<TypeKind::INTEGER>(values, rows, mix, hashes);
+  HiveHash::hashPrimitive<TypeKind::INTEGER>(values, rows, mix, hashes);
 }
 
 template <>
@@ -198,7 +82,7 @@ void HivePartitionFunction::hashTyped<TypeKind::REAL>(
     bool mix,
     std::vector<uint32_t>& hashes,
     size_t /* poolIndex */) {
-  hashPrimitive<TypeKind::REAL>(values, rows, mix, hashes);
+  HiveHash::hashPrimitive<TypeKind::REAL>(values, rows, mix, hashes);
 }
 
 template <>
@@ -208,7 +92,7 @@ void HivePartitionFunction::hashTyped<TypeKind::BIGINT>(
     bool mix,
     std::vector<uint32_t>& hashes,
     size_t /* poolIndex */) {
-  hashPrimitive<TypeKind::BIGINT>(values, rows, mix, hashes);
+  HiveHash::hashPrimitive<TypeKind::BIGINT>(values, rows, mix, hashes);
 }
 
 template <>
@@ -218,7 +102,7 @@ void HivePartitionFunction::hashTyped<TypeKind::DOUBLE>(
     bool mix,
     std::vector<uint32_t>& hashes,
     size_t /* poolIndex */) {
-  hashPrimitive<TypeKind::DOUBLE>(values, rows, mix, hashes);
+  HiveHash::hashPrimitive<TypeKind::DOUBLE>(values, rows, mix, hashes);
 }
 
 template <>
@@ -228,7 +112,7 @@ void HivePartitionFunction::hashTyped<TypeKind::VARCHAR>(
     bool mix,
     std::vector<uint32_t>& hashes,
     size_t /* poolIndex */) {
-  hashPrimitive<TypeKind::VARCHAR>(values, rows, mix, hashes);
+  HiveHash::hashPrimitive<TypeKind::VARCHAR>(values, rows, mix, hashes);
 }
 
 template <>
@@ -238,7 +122,7 @@ void HivePartitionFunction::hashTyped<TypeKind::VARBINARY>(
     bool mix,
     std::vector<uint32_t>& hashes,
     size_t /* poolIndex */) {
-  hashPrimitive<TypeKind::VARBINARY>(values, rows, mix, hashes);
+  HiveHash::hashPrimitive<TypeKind::VARBINARY>(values, rows, mix, hashes);
 }
 
 template <>
@@ -248,7 +132,7 @@ void HivePartitionFunction::hashTyped<TypeKind::TIMESTAMP>(
     bool mix,
     std::vector<uint32_t>& hashes,
     size_t /* poolIndex */) {
-  hashPrimitive<TypeKind::TIMESTAMP>(values, rows, mix, hashes);
+  HiveHash::hashPrimitive<TypeKind::TIMESTAMP>(values, rows, mix, hashes);
 }
 
 template <>
@@ -258,7 +142,7 @@ void HivePartitionFunction::hashTyped<TypeKind::UNKNOWN>(
     bool mix,
     std::vector<uint32_t>& hashes,
     size_t /* poolIndex */) {
-  hashPrimitive<TypeKind::UNKNOWN>(values, rows, mix, hashes);
+  HiveHash::hashPrimitive<TypeKind::UNKNOWN>(values, rows, mix, hashes);
 }
 
 template <>
@@ -318,11 +202,11 @@ void HivePartitionFunction::hashTyped<TypeKind::ARRAY>(
       const auto length = arrayVector->sizeAt(index);
 
       for (size_t i = offset; i < offset + length; ++i) {
-        mergeHash(true, elementsHashes[i], hash);
+        HiveHash::mergeHash(true, elementsHashes[i], hash);
       }
     }
 
-    mergeHash(mix, hash, hashes[row]);
+    HiveHash::mergeHash(mix, hash, hashes[row]);
   });
 }
 
@@ -389,7 +273,7 @@ void HivePartitionFunction::hashTyped<TypeKind::MAP>(
       }
     }
 
-    mergeHash(mix, hash, hashes[row]);
+    HiveHash::mergeHash(mix, hash, hashes[row]);
   });
 }
 
@@ -429,7 +313,7 @@ void HivePartitionFunction::hashTyped<TypeKind::ROW>(
   }
 
   rows.applyToSelected([&](auto row) {
-    mergeHash(
+    HiveHash::mergeHash(
         mix,
         values.isNullAt(row) ? 0 : childHashes[values.index(row)],
         hashes[row]);

--- a/velox/functions/lib/CMakeLists.txt
+++ b/velox/functions/lib/CMakeLists.txt
@@ -133,3 +133,7 @@ velox_add_library(velox_tdigest INTERFACE HEADERS TDigest.h)
 velox_add_library(velox_quantile_digest INTERFACE HEADERS QuantileDigest.h)
 
 velox_add_library(velox_setdigest INTERFACE HEADERS SetDigest.h SetDigestImpl.h)
+
+velox_add_library(velox_hive_hash INTERFACE HEADERS HiveHash.h)
+
+velox_link_libraries(velox_hive_hash INTERFACE velox_vector velox_type velox_common_base)

--- a/velox/functions/lib/HiveHash.h
+++ b/velox/functions/lib/HiveHash.h
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/base/Portability.h"
+#include "velox/type/StringView.h"
+#include "velox/type/Timestamp.h"
+#include "velox/type/Type.h"
+#include "velox/vector/DecodedVector.h"
+#include "velox/vector/SelectivityVector.h"
+
+namespace facebook::velox::functions {
+
+/// Hive-compatible hash primitives, mirroring the hashCode implementation in
+/// Hive's ObjectInspectorUtils (HIVE-12025). Shared between the Hive
+/// connector's partition function and Spark's `hive_hash` scalar function so
+/// both produce bit-identical bucket assignments.
+class HiveHash {
+ public:
+  /// Folds 'oneHash' into 'aggregateHash'. When 'mix' is false the aggregate is
+  /// replaced (used for the first column); otherwise it is combined as
+  /// 31 * aggregateHash + oneHash (Hive's field-folding rule).
+  static void mergeHash(bool mix, uint32_t oneHash, uint32_t& aggregateHash) {
+    aggregateHash = mix ? aggregateHash * 31 + oneHash : oneHash;
+  }
+
+  /// Hashes a 64-bit value by xoring its high and low 32-bit words, matching
+  /// Hive's LongWritable hashCode.
+  static int32_t hashInt64(int64_t value) {
+    return ((*reinterpret_cast<uint64_t*>(&value)) >> 32) ^ value;
+  }
+
+#if defined(__has_feature)
+#if __has_feature(__address_sanitizer__)
+  __attribute__((no_sanitize("integer")))
+#endif
+#endif
+  static uint32_t hashBytes(StringView bytes, int32_t initialValue) {
+    uint32_t hash = initialValue;
+    auto* data = bytes.data();
+    for (auto i = 0; i < bytes.size(); ++i) {
+      hash = hash * 31 + *reinterpret_cast<const int8_t*>(data + i);
+    }
+    return hash;
+  }
+
+  /// Hashes a timestamp using Hive's (seconds << 30 | nanos) packing.
+  static int32_t hashTimestamp(const Timestamp& ts) {
+    return hashInt64((ts.getSeconds() << 30) | ts.getNanos());
+  }
+
+  /// Computes the Hive hash of a single non-null value of the given 'kind'.
+  /// Throws VELOX_UNSUPPORTED for kinds outside the supported primitive set.
+  template <TypeKind kind>
+  static uint32_t hashOne(typename TypeTraits<kind>::NativeType value);
+
+  /// Folds the Hive hash of every selected row of 'values' into 'hashes',
+  /// treating nulls as hash 0. When 'mix' is false the per-row hash replaces
+  /// the accumulator (first column); otherwise it is combined via mergeHash.
+  template <TypeKind kind>
+  static void hashPrimitive(
+      const DecodedVector& values,
+      const SelectivityVector& rows,
+      bool mix,
+      std::vector<uint32_t>& hashes);
+};
+
+template <TypeKind kind>
+inline uint32_t HiveHash::hashOne(
+    typename TypeTraits<kind>::NativeType /* value */) {
+  VELOX_UNSUPPORTED(
+      "Hive hash doesn't support {} type", TypeTraits<kind>::name);
+  return 0; // Make compiler happy.
+}
+
+template <>
+inline uint32_t HiveHash::hashOne<TypeKind::BOOLEAN>(bool value) {
+  return value ? 1 : 0;
+}
+
+template <>
+inline uint32_t HiveHash::hashOne<TypeKind::TINYINT>(int8_t value) {
+  return static_cast<uint32_t>(value);
+}
+
+template <>
+inline uint32_t HiveHash::hashOne<TypeKind::SMALLINT>(int16_t value) {
+  return static_cast<uint32_t>(value);
+}
+
+template <>
+inline uint32_t HiveHash::hashOne<TypeKind::INTEGER>(int32_t value) {
+  return static_cast<uint32_t>(value);
+}
+
+template <>
+inline uint32_t HiveHash::hashOne<TypeKind::REAL>(float value) {
+  return static_cast<uint32_t>(*reinterpret_cast<const int32_t*>(&value));
+}
+
+template <>
+inline uint32_t HiveHash::hashOne<TypeKind::BIGINT>(int64_t value) {
+  return hashInt64(value);
+}
+
+template <>
+inline uint32_t HiveHash::hashOne<TypeKind::DOUBLE>(double value) {
+  return hashInt64(*reinterpret_cast<const int64_t*>(&value));
+}
+
+template <>
+inline uint32_t HiveHash::hashOne<TypeKind::VARCHAR>(StringView value) {
+  return hashBytes(value, 0);
+}
+
+template <>
+inline uint32_t HiveHash::hashOne<TypeKind::VARBINARY>(StringView value) {
+  return hashBytes(value, 0);
+}
+
+template <>
+inline uint32_t HiveHash::hashOne<TypeKind::TIMESTAMP>(Timestamp value) {
+  return hashTimestamp(value);
+}
+
+template <>
+inline uint32_t HiveHash::hashOne<TypeKind::UNKNOWN>(UnknownValue /*value*/) {
+  VELOX_FAIL("Unknown values cannot be non-NULL");
+}
+
+template <TypeKind kind>
+inline void HiveHash::hashPrimitive(
+    const DecodedVector& values,
+    const SelectivityVector& rows,
+    bool mix,
+    std::vector<uint32_t>& hashes) {
+  if (rows.isAllSelected()) {
+    // The compiler seems to be a little fickle with optimizations.
+    // Although rows.applyToSelected should do roughly the same thing, doing
+    // this here along with assigning rows.size() to a variable seems to help
+    // the compiler to inline hashOne showing a 50% performance improvement in
+    // benchmarks.
+    vector_size_t numRows = rows.size();
+    for (auto i = 0; i < numRows; ++i) {
+      const uint32_t hash = values.isNullAt(i)
+          ? 0
+          : hashOne<kind>(
+                values.valueAt<typename TypeTraits<kind>::NativeType>(i));
+      mergeHash(mix, hash, hashes[i]);
+    }
+  } else {
+    rows.applyToSelected([&](auto row) INLINE_LAMBDA {
+      const uint32_t hash = values.isNullAt(row)
+          ? 0
+          : hashOne<kind>(
+                values.valueAt<typename TypeTraits<kind>::NativeType>(row));
+      mergeHash(mix, hash, hashes[row]);
+    });
+  }
+}
+
+} // namespace facebook::velox::functions

--- a/velox/functions/lib/HiveHash.h
+++ b/velox/functions/lib/HiveHash.h
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/base/Portability.h"
+#include "velox/type/StringView.h"
+#include "velox/type/Timestamp.h"
+#include "velox/type/Type.h"
+#include "velox/vector/DecodedVector.h"
+#include "velox/vector/SelectivityVector.h"
+
+namespace facebook::velox::functions {
+
+/// Hive-compatible hash primitives, mirroring the hashCode implementation in
+/// Hive's ObjectInspectorUtils (HIVE-12025). Shared between the Hive
+/// connector's partition function and Spark's `hive_hash` scalar function so
+/// both produce bit-identical bucket assignments.
+class HiveHash {
+ public:
+  /// Folds 'oneHash' into 'aggregateHash'. When 'mix' is false the aggregate is
+  /// replaced (used for the first column); otherwise it is combined as
+  /// 31 * aggregateHash + oneHash (Hive's field-folding rule).
+  static void mergeHash(bool mix, uint32_t oneHash, uint32_t& aggregateHash) {
+    aggregateHash = mix ? aggregateHash * 31 + oneHash : oneHash;
+  }
+
+  /// Hashes a 64-bit value by xoring its high and low 32-bit words, matching
+  /// Hive's LongWritable hashCode.
+  static int32_t hashInt64(int64_t value) {
+    return ((*reinterpret_cast<uint64_t*>(&value)) >> 32) ^ value;
+  }
+
+  /// Hashes the bytes of 'bytes' as 31 * hash + byte starting from
+  /// 'initialValue', matching Hive's Text/BytesWritable hashCode. Bytes are
+  /// interpreted as signed, as in Java.
+#if defined(__has_feature)
+#if __has_feature(__address_sanitizer__)
+  __attribute__((no_sanitize("integer")))
+#endif
+#endif
+  static uint32_t hashBytes(StringView bytes, int32_t initialValue) {
+    uint32_t hash = initialValue;
+    auto* data = bytes.data();
+    for (auto i = 0; i < bytes.size(); ++i) {
+      hash = hash * 31 + *reinterpret_cast<const int8_t*>(data + i);
+    }
+    return hash;
+  }
+
+  /// Hashes a timestamp using Hive's (seconds << 30 | nanos) packing.
+  static int32_t hashTimestamp(const Timestamp& ts) {
+    return hashInt64((ts.getSeconds() << 30) | ts.getNanos());
+  }
+
+  /// Computes the Hive hash of a single non-null value of the given 'kind'.
+  /// Throws VELOX_UNSUPPORTED for kinds outside the supported primitive set.
+  template <TypeKind kind>
+  static uint32_t hashOne(typename TypeTraits<kind>::NativeType value);
+
+  /// Folds the Hive hash of every selected row of 'values' into 'hashes',
+  /// treating nulls as hash 0. When 'mix' is false the per-row hash replaces
+  /// the accumulator (first column); otherwise it is combined via mergeHash.
+  template <TypeKind kind>
+  static void hashPrimitive(
+      const DecodedVector& values,
+      const SelectivityVector& rows,
+      bool mix,
+      std::vector<uint32_t>& hashes);
+};
+
+template <TypeKind kind>
+inline uint32_t HiveHash::hashOne(
+    typename TypeTraits<kind>::NativeType /* value */) {
+  VELOX_UNSUPPORTED(
+      "Hive hash doesn't support {} type", TypeTraits<kind>::name);
+  return 0; // Make compiler happy.
+}
+
+template <>
+inline uint32_t HiveHash::hashOne<TypeKind::BOOLEAN>(bool value) {
+  return value ? 1 : 0;
+}
+
+template <>
+inline uint32_t HiveHash::hashOne<TypeKind::TINYINT>(int8_t value) {
+  return static_cast<uint32_t>(value);
+}
+
+template <>
+inline uint32_t HiveHash::hashOne<TypeKind::SMALLINT>(int16_t value) {
+  return static_cast<uint32_t>(value);
+}
+
+template <>
+inline uint32_t HiveHash::hashOne<TypeKind::INTEGER>(int32_t value) {
+  return static_cast<uint32_t>(value);
+}
+
+template <>
+inline uint32_t HiveHash::hashOne<TypeKind::REAL>(float value) {
+  return static_cast<uint32_t>(*reinterpret_cast<const int32_t*>(&value));
+}
+
+template <>
+inline uint32_t HiveHash::hashOne<TypeKind::BIGINT>(int64_t value) {
+  return hashInt64(value);
+}
+
+template <>
+inline uint32_t HiveHash::hashOne<TypeKind::DOUBLE>(double value) {
+  return hashInt64(*reinterpret_cast<const int64_t*>(&value));
+}
+
+template <>
+inline uint32_t HiveHash::hashOne<TypeKind::VARCHAR>(StringView value) {
+  return hashBytes(value, 0);
+}
+
+template <>
+inline uint32_t HiveHash::hashOne<TypeKind::VARBINARY>(StringView value) {
+  return hashBytes(value, 0);
+}
+
+template <>
+inline uint32_t HiveHash::hashOne<TypeKind::TIMESTAMP>(Timestamp value) {
+  return hashTimestamp(value);
+}
+
+template <>
+inline uint32_t HiveHash::hashOne<TypeKind::UNKNOWN>(UnknownValue /*value*/) {
+  VELOX_FAIL("Unknown values cannot be non-NULL");
+}
+
+template <TypeKind kind>
+inline void HiveHash::hashPrimitive(
+    const DecodedVector& values,
+    const SelectivityVector& rows,
+    bool mix,
+    std::vector<uint32_t>& hashes) {
+  if (rows.isAllSelected()) {
+    // The compiler seems to be a little fickle with optimizations.
+    // Although rows.applyToSelected should do roughly the same thing, doing
+    // this here along with assigning rows.size() to a variable seems to help
+    // the compiler to inline hashOne showing a 50% performance improvement in
+    // benchmarks.
+    vector_size_t numRows = rows.size();
+    for (auto i = 0; i < numRows; ++i) {
+      const uint32_t hash = values.isNullAt(i)
+          ? 0
+          : hashOne<kind>(
+                values.valueAt<typename TypeTraits<kind>::NativeType>(i));
+      mergeHash(mix, hash, hashes[i]);
+    }
+  } else {
+    rows.applyToSelected([&](auto row) INLINE_LAMBDA {
+      const uint32_t hash = values.isNullAt(row)
+          ? 0
+          : hashOne<kind>(
+                values.valueAt<typename TypeTraits<kind>::NativeType>(row));
+      mergeHash(mix, hash, hashes[row]);
+    });
+  }
+}
+
+} // namespace facebook::velox::functions


### PR DESCRIPTION
Summary:

The Hive-compatible hash primitives (mergeHash, hashInt64, hashBytes,
hashTimestamp, hashOne<kind>, hashPrimitive<kind>) that mirror Hive's
ObjectInspectorUtils.hashCode (HIVE-12025) lived in an anonymous namespace
inside HivePartitionFunction.cpp. Anonymous-namespace symbols have internal
linkage, so no other translation unit could reuse them -- any consumer had to
copy the frozen algorithm and keep it bit-identical by hand.

Move the primitives into a header-only velox/functions/lib/HiveHash.h as static
methods on a HiveHash class (namespace facebook::velox::functions), and have
HivePartitionFunction.cpp include it. This is a pure refactor with no behavior
change: the hashing logic and the folding rule (31 * hash + field, seed 0, nulls
contribute 0) are byte-for-byte identical to the previous code.

The motivation is de-duplication: the native Cosco shuffle needs to evaluate
Hive bucketing as a Velox scalar expression (Spark's hive_hash), which the
downstream Gluten diff registers. Sharing this header makes the frozen Hive
spec a single source of truth so that function and the Hive connector's
partition function cannot drift apart, instead of maintaining two hand-synced
copies.

Reviewed By: kevinwilfong

Differential Revision: D112642006


