### PR TITLE
refactor: Migrate folly::format to fmt::format in velox (#18198)

### DIFF
--- a/velox/dwio/dwrf/common/IntEncoder.h
+++ b/velox/dwio/dwrf/common/IntEncoder.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <fmt/format.h>
 #include <folly/Varint.h>
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/base/GTestMacros.h"
@@ -342,7 +343,7 @@ template <bool isSigned>
       return writeVarint<1>(value, buffer);
   }
   DWIO_RAISE(
-      folly::sformat(
+      fmt::format(
           "Unexpected leading zeros {} for value {}", leadingZeros, value));
 }
 


### PR DESCRIPTION
Summary:

Automated migration of `folly::format` / `folly::sformat` to `fmt::format` in
`fbcode/velox`, generated with the `folly-to-fmt-format` clang codemod.
`folly::format` is deprecated in favor of `{fmt}`; this is a mechanical,
no-runtime-effect change (adds `#include <fmt/format.h>` and rewrites call sites).

Reviewed By: vitaut

Differential Revision: D112506323


