### PR TITLE
docs: Add MarkSortedNode to the operators reference

### DIFF
--- a/velox/docs/develop/operators.rst
+++ b/velox/docs/develop/operators.rst
@@ -39,6 +39,7 @@ ProjectNode                 FilterProject
 AggregationNode             HashAggregation or StreamingAggregation
 GroupIdNode                 GroupId
 MarkDistinctNode            MarkDistinct
+MarkSortedNode              MarkSorted
 HashJoinNode                HashProbe and HashBuild
 MergeJoinNode               MergeJoin
 NestedLoopJoinNode          NestedLoopJoinProbe and NestedLoopJoinBuild
@@ -1042,6 +1043,33 @@ table and restored together. Disabled by default; enable with `mark_distinct_spi
     - Names of grouping keys.
   * - masks
     - List of boolean mask column references. Empty when only the no-mask marker is needed.
+
+MarkSortedNode
+~~~~~~~~~~~~~~
+
+The MarkSorted operator appends a boolean marker column, named 'markerName', at the end of
+the input columns. For each row, the marker indicates whether the row maintains sort order
+relative to the preceding row, based on 'sortingKeys' and 'sortingOrders'. Rows with equal
+sorting keys are considered sorted.
+
+The operator runs in streaming mode and preserves the order of its input. The comparison
+carries across batches, so only the first row of the entire input is unconditionally marked
+true; the first row of each later batch is compared against the last row of the previous
+batch.
+
+.. list-table::
+  :widths: 10 30
+  :align: left
+  :header-rows: 1
+
+  * - Property
+    - Description
+  * - markerName
+    - Name of the output boolean marker column, appended after all input columns.
+  * - sortingKeys
+    - Columns to check for sorted order. Must not be empty.
+  * - sortingOrders
+    - Sorting order for each sorting key above. The supported sort orders are asc nulls first, asc nulls last, desc nulls first and desc nulls last.
 
 MixedUnionNode
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
Summary:
The MarkSorted operator (added in #16652) and its plan node MarkSortedNode were missing from the operators reference (`velox/docs/develop/operators.rst`), which documents every other plan node with a row in the top-of-file table and a dedicated section. This adds both.

Fixes #18176.

Differential Revision: D112861076


