### PR TITLE
perf(vector): Accumulate consecutive copy ranges in locals in copyRangesImpl 

### DIFF
--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -590,6 +590,11 @@ void ArrayVectorBase::copyRangesImpl(
           }
         });
     outRanges.reserve(totalCount);
+    // Current run of consecutive source rows, appended to 'outRanges' only when
+    // the run breaks.  Deliberately a local, not 'outRanges.back()', so it
+    // stays register-resident in the hot loop; do not simplify back to
+    // '.back()'.
+    CopyRange run{};
     applyToEachRow(ranges, [&](auto targetIndex, auto sourceIndex) {
       if (source->isNullAt(sourceIndex)) {
         setNull(targetIndex, true);
@@ -605,12 +610,13 @@ void ArrayVectorBase::copyRangesImpl(
 
           // If we're copying two adjacent ranges, merge them.  This only
           // works if they're consecutive.
-          if (!outRanges.empty() &&
-              (outRanges.back().sourceIndex + outRanges.back().count ==
-               copyOffset)) {
-            outRanges.back().count += copySize;
+          if (run.count != 0 && run.sourceIndex + run.count == copyOffset) {
+            run.count += copySize;
           } else {
-            outRanges.push_back({copyOffset, childSize, copySize});
+            if (run.count != 0) {
+              outRanges.push_back(run);
+            }
+            run = {copyOffset, childSize, copySize};
           }
         }
 
@@ -619,6 +625,10 @@ void ArrayVectorBase::copyRangesImpl(
         childSize = checkedPlus<vector_size_t>(childSize, copySize);
       }
     });
+
+    if (run.count != 0) {
+      outRanges.push_back(run);
+    }
 
     targetValues->get()->resize(childSize);
     targetValues->get()->copyRanges(sourceValues, outRanges);


### PR DESCRIPTION
The multi-range element-copy path of ArrayVectorBase::copyRangesImpl previously
tracked the current mergeable copy range by inspecting and mutating
outRanges.back() -- a heap-resident std::vector element -- on every source row.
This replaces that with a single local CopyRange that accumulates a run of
source-consecutive copies, appending to outRanges only when the run breaks, with
a final flush after the loop.

This removes the per-row store-to-load memory dependency on
outRanges.back().count and the per-row push_back bookkeeping from the hot loop,
while producing byte-for-byte identical outRanges, offsets, sizes, and final
childSize.

Summary: Pull Request resolved: https://github.com/facebookincubator/velox/pull/18200

Reviewed By: mbasmanova

Differential Revision: D112263282


