### PR TITLE
fbcode/velox/common/base: add missing <fmt/format.h> include to CompareFlags.h for fmt 12.2.0 (#18203)

### DIFF
--- a/velox/common/base/CompareFlags.h
+++ b/velox/common/base/CompareFlags.h
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include <fmt/core.h>
+#include <fmt/format.h>
 #include <optional>
 #include <sstream>
 #include <string>


### PR DESCRIPTION
Summary:

CompareFlags.h calls fmt::format() but only includes <fmt/core.h>. Under
fmt 9.1.0, format() was declared directly in core.h; fmt 12.2.0 moved that
declaration to fmt/format.h, breaking velox_functions_prestosql_impl and
downstream targets like velox_tpch_speed_test.

Differential Revision: D112756593


