### PR TITLE
refactor(dwio): Add context to region bounds check (#18209)

### DIFF
--- a/velox/dwio/common/DirectInputStream.cpp
+++ b/velox/dwio/common/DirectInputStream.cpp
@@ -156,7 +156,12 @@ void DirectInputStream::loadSync() {
 }
 
 void DirectInputStream::loadPosition() {
-  VELOX_CHECK_LT(offsetInRegion_, region_.length);
+  VELOX_CHECK_LT(
+      offsetInRegion_,
+      region_.length,
+      "Reading past the end of {} in file {}",
+      region_.toString(),
+      fileNum_);
 
   // Fast path: serve from preloaded whole-file data.
   if (bufferedInput_->preloaded()) {


### PR DESCRIPTION
Summary:

A read past the end of a scan region failed with an opaque message:

    (0 vs. 0)

The check in `DirectInputStream::loadPosition` now appends the region (offset, length, label) and file number, so the failure points at the offending stream instead of two bare zeros.

Reviewed By: kKPulla

Differential Revision: D113025225


