### PR TITLE
fix(dwio): Stabilize exception message templates (#18210)

### DIFF
--- a/velox/dwio/common/DirectInputStream.cpp
+++ b/velox/dwio/common/DirectInputStream.cpp
@@ -156,7 +156,12 @@ void DirectInputStream::loadSync() {
 }
 
 void DirectInputStream::loadPosition() {
-  VELOX_CHECK_LT(offsetInRegion_, region_.length);
+  VELOX_CHECK_LT(
+      offsetInRegion_,
+      region_.length,
+      "Reading past the end of {} in file {}",
+      region_.toString(),
+      fileNum_);
 
   // Fast path: serve from preloaded whole-file data.
   if (bufferedInput_->preloaded()) {

--- a/velox/dwio/common/compression/Compression.cpp
+++ b/velox/dwio/common/compression/Compression.cpp
@@ -54,7 +54,7 @@ ZstdCompressor::compress(const void* src, void* dest, uint64_t length) {
     if (ZSTD_getErrorCode(ret) == ZSTD_ErrorCode::ZSTD_error_dstSize_tooSmall) {
       return length;
     }
-    DWIO_RAISE("ZSTD returned an error: ", ZSTD_getErrorName(ret));
+    DWIO_RAISE_FMT("ZSTD returned an error: {}", ZSTD_getErrorName(ret));
   }
   return ret;
 }
@@ -80,7 +80,7 @@ ZlibCompressor::ZlibCompressor(int32_t level, int32_t windowBits, bool isGzip)
   if (isGzip) {
     windowBits = (windowBits < 0 ? -windowBits : windowBits) | kGzipCodec;
   }
-  DWIO_ENSURE_EQ(
+  DWIO_ENSURE_EQ_FMT(
       deflateInit2(
           &stream_, level_, Z_DEFLATED, windowBits, 8, Z_DEFAULT_STRATEGY),
       Z_OK,
@@ -97,7 +97,7 @@ ZlibCompressor::~ZlibCompressor() {
 uint64_t
 ZlibCompressor::compress(const void* src, void* dest, uint64_t length) {
   isCompressCalled_ = true;
-  DWIO_ENSURE_EQ(deflateReset(&stream_), Z_OK, "Failed to reset deflate.");
+  DWIO_ENSURE_EQ_FMT(deflateReset(&stream_), Z_OK, "Failed to reset deflate.");
 
   stream_.avail_in = static_cast<uint32_t>(length);
   stream_.next_in = reinterpret_cast<unsigned char*>(const_cast<void*>(src));
@@ -110,7 +110,7 @@ ZlibCompressor::compress(const void* src, void* dest, uint64_t length) {
   } else if (ret == Z_OK || ret == Z_BUF_ERROR) {
     // needs more output buffer
   } else {
-    DWIO_RAISE("Failed to deflate input data. error: ", ret);
+    DWIO_RAISE_FMT("Failed to deflate input data. error: {}", ret);
   }
 
   return stream_.total_out;
@@ -134,10 +134,10 @@ class ZlibDecompressor : public Decompressor {
  protected:
   void reset() {
     auto result = inflateReset(&zstream_);
-    DWIO_ENSURE_EQ(
+    DWIO_ENSURE_EQ_FMT(
         result,
         Z_OK,
-        "Bad inflateReset in ZlibDecompressor::reset. error: ",
+        "Bad inflateReset in ZlibDecompressor::reset. error: {}",
         result);
   }
 
@@ -163,12 +163,11 @@ ZlibDecompressor::ZlibDecompressor(
         (zlibWindowBits < 0 ? -zlibWindowBits : zlibWindowBits) | kGzipCodec;
   }
   const auto result = inflateInit2(&zstream_, zlibWindowBits);
-  DWIO_ENSURE_EQ(
+  DWIO_ENSURE_EQ_FMT(
       result,
       Z_OK,
-      "Error from inflateInit2. error: ",
+      "Error from inflateInit2. error: {} Info: {}",
       result,
-      " Info: ",
       streamDebugInfo_);
 }
 
@@ -193,10 +192,10 @@ uint64_t ZlibDecompressor::decompress(
   zstream_.next_out = reinterpret_cast<Bytef*>(const_cast<char*>(dest));
   zstream_.avail_out = folly::to<uInt>(destLength);
   auto result = inflate(&zstream_, Z_FINISH);
-  DWIO_ENSURE_EQ(
+  DWIO_ENSURE_EQ_FMT(
       result,
       Z_STREAM_END,
-      "Error in ZlibDecompressor::decompress. error: ",
+      "Error in ZlibDecompressor::decompress. error: {}",
       result);
   return destLength - zstream_.avail_out;
 }
@@ -250,11 +249,11 @@ uint64_t LzoAndLz4DecompressorCommon::decompress(
   auto uncompressedSize = destLength;
 
   while (compressedSize > 0) {
-    DWIO_ENSURE_GE(
+    DWIO_ENSURE_GE_FMT(
         compressedSize,
         dwio::common::INT_BYTE_SIZE,
+        "{} decompression failed, input len is too small: {}",
         ::facebook::velox::common::compressionKindToString(kind_),
-        " decompression failed, input len is too small: ",
         compressedSize);
 
     uint32_t decompressedBlockSize =
@@ -263,14 +262,13 @@ uint64_t LzoAndLz4DecompressorCommon::decompress(
     compressedSize -= dwio::common::INT_BYTE_SIZE;
     uint32_t remainingOutputSize = uncompressedSize - decompressedTotalSize;
 
-    DWIO_ENSURE_GE(
+    DWIO_ENSURE_GE_FMT(
         remainingOutputSize,
         decompressedBlockSize,
+        "{} decompression failed, remainingOutputSize is less than "
+        "decompressedBlockSize, remainingOutputSize: {}, decompressedBlockSize: {}",
         ::facebook::velox::common::compressionKindToString(kind_),
-        " decompression failed, remainingOutputSize is less than "
-        "decompressedBlockSize, remainingOutputSize: ",
         remainingOutputSize,
-        ", decompressedBlockSize: ",
         decompressedBlockSize);
 
     if (compressedSize <= 0) {
@@ -279,11 +277,11 @@ uint64_t LzoAndLz4DecompressorCommon::decompress(
 
     do {
       // Check that input length should not be negative.
-      DWIO_ENSURE_GE(
+      DWIO_ENSURE_GE_FMT(
           compressedSize,
           dwio::common::INT_BYTE_SIZE,
+          "{} decompression failed, input len is too small: {}",
           ::facebook::velox::common::compressionKindToString(kind_),
-          " decompression failed, input len is too small: ",
           compressedSize);
       // Read the length of the next lz4/lzo compressed block.
       uint32_t compressedBlockSize =
@@ -294,14 +292,13 @@ uint64_t LzoAndLz4DecompressorCommon::decompress(
       if (compressedBlockSize == 0) {
         continue;
       }
-      DWIO_ENSURE_LE(
+      DWIO_ENSURE_LE_FMT(
           compressedBlockSize,
           compressedSize,
+          "{} decompression failed, compressedBlockSize is greater than "
+          "compressedSize, compressedBlockSize: {}, compressedSize: {}",
           ::facebook::velox::common::compressionKindToString(kind_),
-          " decompression failed, compressedBlockSize is greater than "
-          "compressedSize, compressedBlockSize: ",
           compressedBlockSize,
-          ", compressedSize: ",
           compressedSize);
 
       // Decompress this block.
@@ -312,14 +309,13 @@ uint64_t LzoAndLz4DecompressorCommon::decompress(
           outPtr,
           static_cast<int32_t>(remainingOutputSize));
 
-      DWIO_ENSURE_LE(
+      DWIO_ENSURE_LE_FMT(
           decompressedSize,
           remainingOutputSize,
+          "{} decompression failed, decompressedSize is not less than "
+          "or equal to remainingOutputSize, decompressedSize: {}, remainingOutputSize: {}",
           ::facebook::velox::common::compressionKindToString(kind_),
-          " decompression failed, decompressedSize is not less than "
-          "or equal to remainingOutputSize, decompressedSize: ",
           decompressedSize,
-          ", remainingOutputSize: ",
           remainingOutputSize);
 
       outPtr += decompressedSize;
@@ -330,14 +326,13 @@ uint64_t LzoAndLz4DecompressorCommon::decompress(
     } while (decompressedBlockSize > 0);
   }
 
-  DWIO_ENSURE_EQ(
+  DWIO_ENSURE_EQ_FMT(
       decompressedTotalSize,
       uncompressedSize,
+      "{} decompression failed, decompressedTotalSize is not equal to "
+      "uncompressedSize, decompressedTotalSize: {}, uncompressedSize: {}",
       ::facebook::velox::common::compressionKindToString(kind_),
-      " decompression failed, decompressedTotalSize is not equal to "
-      "uncompressedSize, decompressedTotalSize: ",
       decompressedTotalSize,
-      ", uncompressedSize: ",
       uncompressedSize);
 
   return decompressedTotalSize;
@@ -395,8 +390,8 @@ uint64_t Lz4Decompressor::decompressInternal(
       static_cast<int32_t>(srcLength),
       static_cast<int32_t>(destLength));
 
-  DWIO_ENSURE_GE(
-      result, 0, "lz4 failed to decompress. Info: ", streamDebugInfo_);
+  DWIO_ENSURE_GE_FMT(
+      result, 0, "lz4 failed to decompress. Info: {}", streamDebugInfo_);
   return static_cast<uint64_t>(result);
 }
 
@@ -427,11 +422,10 @@ uint64_t ZstdDecompressor::decompress(
   thread_local std::unique_ptr<ZSTD_DCtx, size_t (*)(ZSTD_DCtx*)> ctx{
       ZSTD_createDCtx(), ZSTD_freeDCtx};
   auto ret = ZSTD_decompressDCtx(ctx.get(), dest, destLength, src, srcLength);
-  DWIO_ENSURE(
+  DWIO_ENSURE_FMT(
       !ZSTD_isError(ret),
-      "ZSTD returned an error: ",
+      "ZSTD returned an error: {} Info: {}",
       ZSTD_getErrorName(ret),
-      " Info: ",
       streamDebugInfo_);
   return ret;
 }
@@ -446,10 +440,10 @@ std::pair<int64_t, bool> ZstdDecompressor::getDecompressedLength(
       uncompressedLength == ZSTD_CONTENTSIZE_ERROR) {
     return {blockSize_, false};
   }
-  DWIO_ENSURE_LE(
+  DWIO_ENSURE_LE_FMT(
       uncompressedLength,
       blockSize_,
-      "Insufficient buffer size. Info: ",
+      "Insufficient buffer size. Info: {}",
       streamDebugInfo_);
   return {uncompressedLength, true};
 }
@@ -478,10 +472,10 @@ uint64_t SnappyDecompressor::decompress(
     char* dest,
     uint64_t destLength) {
   auto [length, _] = getDecompressedLength(src, srcLength);
-  DWIO_ENSURE_GE(destLength, length);
-  DWIO_ENSURE(
+  DWIO_ENSURE_GE_FMT(destLength, length, "");
+  DWIO_ENSURE_FMT(
       snappy::RawUncompress(src, srcLength, dest),
-      "Snappy decompress failed. Info: ",
+      "Snappy decompress failed. Info: {}",
       streamDebugInfo_);
   return length;
 }
@@ -495,10 +489,10 @@ std::pair<int64_t, bool> SnappyDecompressor::getDecompressedLength(
   if (!snappy::GetUncompressedLength(src, srcLength, &uncompressedLength)) {
     return {blockSize_, false};
   }
-  DWIO_ENSURE_LE(
+  DWIO_ENSURE_LE_FMT(
       uncompressedLength,
       blockSize_,
-      "Insufficient buffer size. Info: ",
+      "Insufficient buffer size. Info: {}",
       streamDebugInfo_);
   return {uncompressedLength, true};
 }
@@ -561,12 +555,11 @@ bool ZlibDecompressionStream::readOrSkip(const void** data, int32_t* size) {
     inputBufferPtr_ += availSize;
     remainingLength_ -= availSize;
   } else {
-    DWIO_ENSURE_EQ(
-        state_,
-        State::START,
-        "Unknown compression state in ZlibDecompressionStream::Next in ",
+    DWIO_ENSURE_FMT(
+        state_ == State::START,
+        "Unknown compression state {} in ZlibDecompressionStream::Next in {} Info: {}",
+        static_cast<int>(state_),
         getName(),
-        " Info: ",
         ZlibDecompressor::streamDebugInfo_);
     prepareOutputBuffer(
         getDecompressedLength(inputBufferPtr_, availSize).first);
@@ -603,7 +596,7 @@ bool ZlibDecompressionStream::readOrSkip(const void** data, int32_t* size) {
             case Z_MEM_ERROR:
               [[fallthrough]];
             case Z_STREAM_ERROR:
-              DWIO_RAISE("Failed to inflate input data. error: ", result);
+              DWIO_RAISE_FMT("Failed to inflate input data. error: {}", result);
             default:
               *size += static_cast<int32_t>(
                   blockSize_ - static_cast<int64_t>(zstream_.avail_out));
@@ -750,7 +743,7 @@ std::unique_ptr<dwio::common::SeekableInputStream> createDecompressor(
           std::make_unique<ZstdDecompressor>(blockSize, streamDebugInfo);
       break;
     default:
-      DWIO_RAISE("Unknown compression codec ", kind);
+      DWIO_RAISE_FMT("Unknown compression codec {}", kind);
   }
   return std::make_unique<PagedInputStream>(
       std::move(input),

--- a/velox/dwio/common/compression/PagedInputStream.cpp
+++ b/velox/dwio/common/compression/PagedInputStream.cpp
@@ -31,7 +31,7 @@ void PagedInputStream::readBuffer(bool failOnEof) {
   int32_t length;
   if (!input_->Next(
           reinterpret_cast<const void**>(&inputBufferPtr_), &length)) {
-    DWIO_ENSURE(!failOnEof, getName(), ", read past EOF");
+    DWIO_ENSURE_FMT(!failOnEof, "{}, read past EOF", getName());
     state_ = State::END;
     inputBufferStart_ = nullptr;
     inputBufferPtr_ = nullptr;
@@ -179,8 +179,8 @@ bool PagedInputStream::readOrSkip(const void** data, int32_t* size) {
 
   // perform decompression
   if (state_ == State::START) {
-    DWIO_ENSURE_NOT_NULL(decompressor_.get(), "invalid stream state");
-    DWIO_ENSURE_NOT_NULL(input);
+    DWIO_ENSURE_NOT_NULL_FMT(decompressor_.get(), "invalid stream state");
+    DWIO_ENSURE_NOT_NULL_FMT(input, "");
     auto [decompressedLength, exact] =
         decompressor_->getDecompressedLength(input, remainingLength_);
     if (!data && exact && decompressedLength <= pendingSkip_) {
@@ -226,9 +226,9 @@ void PagedInputStream::BackUp(int32_t count) {
       return;
     }
   }
-  DWIO_ENSURE(
+  DWIO_ENSURE_FMT(
       outputBufferPtr_ != nullptr,
-      "Backup without previous Next in ",
+      "Backup without previous Next in {}",
       getName());
   if (state_ == State::ORIGINAL) {
     VELOX_CHECK(

--- a/velox/dwio/common/exception/Exception.h
+++ b/velox/dwio/common/exception/Exception.h
@@ -84,6 +84,31 @@ class LoggedException : public velox::VeloxException {
     logException();
   }
 
+  // Carries an explicit message template, kept distinct from the interpolated
+  // 'errorMessage' so VeloxException::messageTemplate() stays low-cardinality
+  // for error aggregation.
+  LoggedException(
+      const char* file,
+      size_t line,
+      const char* function,
+      const char* expression,
+      const std::string& errorMessage,
+      const std::string& errorSource,
+      const std::string& errorCode,
+      velox::CompileTimeStringLiteral messageTemplate)
+      : VeloxException(
+            file,
+            line,
+            function,
+            expression,
+            errorMessage,
+            errorSource,
+            errorCode,
+            /*isRetriable=*/false,
+            messageTemplate) {
+    logException();
+  }
+
  private:
   void logException() {
     auto logger = getExceptionLogger();
@@ -189,6 +214,29 @@ containing information about the file, line, and function where it happened.
       ::facebook::velox::error_code::kUnknown,                   \
       ##__VA_ARGS__)
 
+// Like DWIO_RAISE, but the first argument is an fmt format string and the rest
+// are interpolated into it. The format string, not the interpolated result,
+// becomes VeloxException::messageTemplate(), so identical failures aggregate
+// together regardless of their interpolated values.
+#define DWIO_RAISE_FMT(fmtString, ...)                               \
+  throw ::facebook::velox::dwio::common::exception::LoggedException( \
+      __FILE__,                                                      \
+      __LINE__,                                                      \
+      __FUNCTION__,                                                  \
+      "",                                                            \
+      ::facebook::velox::errorMessage(fmtString, ##__VA_ARGS__),     \
+      ::facebook::velox::error_source::kErrorSourceExternal,         \
+      ::facebook::velox::error_code::kUnknown,                       \
+      ::facebook::velox::CompileTimeStringLiteral(fmtString))
+
+// DWIO_ENSURE with a stable message template. See DWIO_RAISE_FMT.
+#define DWIO_ENSURE_FMT(expr, fmtString, ...)   \
+  do {                                          \
+    if (!(expr)) {                              \
+      DWIO_RAISE_FMT(fmtString, ##__VA_ARGS__); \
+    }                                           \
+  } while (0)
+
 #define DWIO_ENSURE_NOT_NULL(p, ...) \
   DWIO_ENSURE(p != nullptr, "[Null pointer]: ", ##__VA_ARGS__);
 
@@ -251,5 +299,61 @@ containing information about the file, line, and function where it happened.
       r,                               \
       "]: ",                           \
       ##__VA_ARGS__);
+
+// Template-stable counterparts of the constraint macros above. The compared
+// values are passed as fmt arguments, so 'messageTemplate()' stays constant
+// across failures instead of embedding the runtime values. 'fmtString' is a
+// format literal for extra context and may be "" when none is needed; any
+// following arguments interpolate into it.
+#define DWIO_ENSURE_NOT_NULL_FMT(p, fmtString, ...) \
+  DWIO_ENSURE_FMT((p) != nullptr, "[Null pointer]: " fmtString, ##__VA_ARGS__)
+
+#define DWIO_ENSURE_EQ_FMT(l, r, fmtString, ...)               \
+  DWIO_ENSURE_FMT(                                             \
+      (l) == (r),                                              \
+      "[Equality Constraint Violation: {} == {}]: " fmtString, \
+      (l),                                                     \
+      (r),                                                     \
+      ##__VA_ARGS__)
+
+#define DWIO_ENSURE_NE_FMT(l, r, fmtString, ...)               \
+  DWIO_ENSURE_FMT(                                             \
+      (l) != (r),                                              \
+      "[Equality Constraint Violation: {} != {}]: " fmtString, \
+      (l),                                                     \
+      (r),                                                     \
+      ##__VA_ARGS__)
+
+#define DWIO_ENSURE_LT_FMT(l, r, fmtString, ...)           \
+  DWIO_ENSURE_FMT(                                         \
+      (l) < (r),                                           \
+      "[Range Constraint Violation: {} < {}]: " fmtString, \
+      (l),                                                 \
+      (r),                                                 \
+      ##__VA_ARGS__)
+
+#define DWIO_ENSURE_LE_FMT(l, r, fmtString, ...)            \
+  DWIO_ENSURE_FMT(                                          \
+      (l) <= (r),                                           \
+      "[Range Constraint Violation: {} <= {}]: " fmtString, \
+      (l),                                                  \
+      (r),                                                  \
+      ##__VA_ARGS__)
+
+#define DWIO_ENSURE_GT_FMT(l, r, fmtString, ...)           \
+  DWIO_ENSURE_FMT(                                         \
+      (l) > (r),                                           \
+      "[Range Constraint Violation: {} > {}]: " fmtString, \
+      (l),                                                 \
+      (r),                                                 \
+      ##__VA_ARGS__)
+
+#define DWIO_ENSURE_GE_FMT(l, r, fmtString, ...)            \
+  DWIO_ENSURE_FMT(                                          \
+      (l) >= (r),                                           \
+      "[Range Constraint Violation: {} >= {}]: " fmtString, \
+      (l),                                                  \
+      (r),                                                  \
+      ##__VA_ARGS__)
 
 } // namespace facebook::velox::dwio

--- a/velox/dwio/common/tests/LoggedExceptionTest.cpp
+++ b/velox/dwio/common/tests/LoggedExceptionTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include <folly/Random.h>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "velox/dwio/common/exception/Exception.h"
 
@@ -109,6 +110,45 @@ TEST(LoggedExceptionTest, basic) {
   // Verifier duplicate registration is rejected
   ASSERT_ANY_THROW(
       registerExceptionLogger(std::make_unique<TestExceptionLogger>(counter)));
+}
+
+TEST(LoggedExceptionTest, fmtMessageTemplate) {
+  using ::testing::AllOf;
+  using ::testing::Property;
+  using ::testing::Throws;
+
+  // DWIO_RAISE_FMT keeps the format string as the template while the message
+  // interpolates the runtime value.
+  EXPECT_THAT(
+      [] { DWIO_RAISE_FMT("read past EOF in {}", "stream-7"); },
+      Throws<VeloxException>(AllOf(
+          Property(&VeloxException::messageTemplate, "read past EOF in {}"),
+          Property(&VeloxException::message, "read past EOF in stream-7"),
+          Property(
+              &VeloxException::errorSource,
+              error_source::kErrorSourceExternal))));
+
+  // The compared values are interpolated; the template does not embed them.
+  EXPECT_THAT(
+      [] { DWIO_ENSURE_EQ_FMT(1, 2, "reading col {}", "c0"); },
+      Throws<VeloxException>(AllOf(
+          Property(
+              &VeloxException::messageTemplate,
+              "[Equality Constraint Violation: {} == {}]: reading col {}"),
+          Property(
+              &VeloxException::message,
+              "[Equality Constraint Violation: 1 == 2]: reading col c0"))));
+
+  // An empty context format is allowed.
+  EXPECT_THAT(
+      [] { DWIO_ENSURE_LT_FMT(5, 3, ""); },
+      Throws<VeloxException>(AllOf(
+          Property(
+              &VeloxException::messageTemplate,
+              "[Range Constraint Violation: {} < {}]: "),
+          Property(
+              &VeloxException::message,
+              "[Range Constraint Violation: 5 < 3]: "))));
 }
 
 TEST(LoggedExceptionTest, traceCollectionControlTest) {


### PR DESCRIPTION
Summary:

Error aggregation groups exceptions by `messageTemplate()`. The dwio exception macros build their message by concatenating every value into one string, so the template is the fully-interpolated message — a distinct template per stream, file, or value, which defeats grouping. For example, a corrupt ZSTD block produced this template:

    ZSTD returned an error: Data corruption detected Info: Stripe 0 Stream [id=97, node=3, sequence=0, column=0, kind=1]

Now the template is stable and the per-stream detail stays only in the message:

    ZSTD returned an error: {} Info: {}

`LoggedException` gains a constructor that forwards a message template to `VeloxException`, and each `DWIO_RAISE`/`DWIO_ENSURE` macro gains a `_FMT` counterpart whose first argument is an fmt format string, so the format string rather than the interpolated result becomes the template. The two compression sources are migrated in full; the remaining dwio files can move to the `_FMT` macros incrementally.

Differential Revision: D113031477


