### PR TITLE
fix(json): Collapse duplicate keys in json_parse (keep last) (#18212)

### DIFF
--- a/velox/docs/functions/presto/json.rst
+++ b/velox/docs/functions/presto/json.rst
@@ -196,6 +196,11 @@ JSON Functions
         SELECT json_parse('[1, 2, 3]'); -- JSON '[1,2,3]'
         SELECT json_parse('"abc"'); -- JSON '"abc"'
 
+    In the result, object keys are sorted and exact-duplicate keys are
+    collapsed, keeping the value of the last occurrence. Keys that become
+    equal only after decoding a control-character escape (for example
+    ``\n`` and its ``\uXXXX`` form) are not collapsed.
+
     .. _RFC 7159: https://datatracker.ietf.org/doc/html/rfc7159.html
 
 .. function:: json_size(json, value) -> bigint

--- a/velox/functions/prestosql/JsonFunctions.cpp
+++ b/velox/functions/prestosql/JsonFunctions.cpp
@@ -187,6 +187,23 @@ class JsonFormatFunction : public exec::VectorFunction {
   }
 };
 
+// Returns whether two json_parse object keys are equal, given that 'later'
+// sorts at-or-after 'earlier' in the key ordering. The caller only compares an
+// element against an earlier element of the sorted permutation, so a single
+// direction suffices on the normalized path. On the fast/plain path equal keys
+// are byte-identical (normalization runs before parsing), so a raw comparison
+// is correct.
+template <bool kNeedNormalize>
+bool keyEqualToSortedPredecessor(
+    std::string_view earlier,
+    std::string_view later) {
+  if constexpr (kNeedNormalize) {
+    return !lessThanForJsonParse(earlier, later);
+  } else {
+    return earlier == later;
+  }
+}
+
 // A performant json parsing implementation. Does not handle null rows. This is
 // also leveraged by json functions other than json_parse that need to parse a
 // varchar input. If `nullOnError` is true, the result will have null values for
@@ -490,14 +507,35 @@ class JsonParseImpl {
       sortIndices(
           [&](int32_t i, int32_t j) { return fields[i].key < fields[j].key; });
     }
-    for (auto i = 0; i < numFields; ++i) {
-      if (i > 0) {
+    // Emit one field per run of equal keys, keeping the last occurrence in the
+    // document. Equal keys are adjacent because the permutation is sorted by
+    // key; the sort is not stable, so within a run keep the field with the
+    // greatest original index (= the last occurrence). Duplicates are rare, so
+    // the inner scan is a single iteration on the common no-duplicate path.
+    bool first{true};
+    for (int i = 0; i < numFields;) {
+      int32_t lastOccurrence = sortIndices_[i];
+      int runEnd = i;
+      while (runEnd + 1 < numFields &&
+             keyEqualToSortedPredecessor<kNeedNormalize>(
+                 fields[sortIndices_[i]].key,
+                 fields[sortIndices_[runEnd + 1]].key)) {
+        ++runEnd;
+        lastOccurrence = std::max(lastOccurrence, sortIndices_[runEnd]);
+      }
+      // A collapsed run is byte-equal on every path (normalization makes
+      // comparator-equal keys byte-identical); guards against a future fastSort
+      // or normalization change grouping distinct keys.
+      VELOX_DCHECK_EQ(fields[sortIndices_[i]].key, fields[lastOccurrence].key);
+      if (!first) {
         addOrMergeChar(views_, kSeparator);
       }
-      auto& field = fields[sortIndices_[i]];
+      first = false;
+      const auto& field = fields[lastOccurrence];
       for (int j = 0; j < field.size; ++j) {
         views_.push_back(views_[field.offset + j]);
       }
+      i = runEnd + 1;
     }
     auto numNewViews = views_.size() - sortedBegin;
     static_assert(std::is_trivially_copyable_v<std::string_view>);

--- a/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
@@ -287,7 +287,55 @@ TEST_F(JsonFunctionsTest, jsonParse) {
   EXPECT_EQ(jsonParse(R"(["k1", "v1"])"), R"(["k1","v1"])");
   testJsonParse(R"({ "abc" : "\/"})", R"({"abc":"/"})");
   testJsonParse(R"({ "abc" : "\\/"})", R"({"abc":"\\/"})");
-  testJsonParse("{\"\\\\\":null, \"\\\\\":null}", R"({"\\":null,"\\":null})");
+  // Exact-duplicate object keys collapse, keeping the last value (matches
+  // Presto). The backslash key forces the normalized path; differing values
+  // prove keep-LAST.
+  testJsonParse(R"({"\\":1,"\\":2})", R"({"\\":2})");
+  testJsonParse(R"({"\\":1,"\\":2,"\\":3})", R"({"\\":3})");
+  testJsonParse(R"({"a":1,"a":2})", R"({"a":2})");
+  testJsonParse(R"({"a":1,"a":2,"a":3})", R"({"a":3})");
+  // Case-sensitive: 'a' and 'A' are distinct, both kept, sorted (A < a).
+  testJsonParse(R"({"a":1,"A":2})", R"({"A":2,"a":1})");
+  // Dedup interleaved with sort, and two separate duplicate groups.
+  testJsonParse(R"({"b":1,"a":2,"a":3})", R"({"a":3,"b":1})");
+  testJsonParse(R"({"a":1,"a":2,"b":3,"b":4})", R"({"a":2,"b":4})");
+  // Last value wins even when null or a different shape.
+  testJsonParse(R"({"a":1,"a":null})", R"({"a":null})");
+  testJsonParse(R"({"a":1,"a":[1,2]})", R"({"a":[1,2]})");
+  // Empty-key duplicate.
+  testJsonParse(R"({"":1,"":2})", R"({"":2})");
+  // Nested object and object-in-array collapse via recursion.
+  testJsonParse(R"({"x":{"a":1,"a":2}})", R"({"x":{"a":2}})");
+  testJsonParse(R"([{"a":1,"a":2},{"b":1,"b":2}])", R"([{"a":2},{"b":2}])");
+  // Fast/plain-path key-length boundaries (differing values); the last key
+  // (>24B) exercises the plain path, the rest the fastSort chunk/tail handling.
+  testJsonParse(R"({"1234567":1,"1234567":2})", R"({"1234567":2})");
+  testJsonParse(R"({"12345678":1,"12345678":2})", R"({"12345678":2})");
+  testJsonParse(R"({"123456789":1,"123456789":2})", R"({"123456789":2})");
+  testJsonParse(
+      R"({"123456789012345":1,"123456789012345":2})",
+      R"({"123456789012345":2})");
+  testJsonParse(
+      R"({"1234567890123456":1,"1234567890123456":2})",
+      R"({"1234567890123456":2})");
+  testJsonParse(
+      R"({"12345678901234567":1,"12345678901234567":2})",
+      R"({"12345678901234567":2})");
+  testJsonParse(
+      R"({"123456789012345678901234":1,"123456789012345678901234":2})",
+      R"({"123456789012345678901234":2})");
+  testJsonParse(
+      R"({"1234567890123456789012345":1,"1234567890123456789012345":2})",
+      R"({"1234567890123456789012345":2})");
+  // Escaped vs literal decode-equal key (\/ normalizes to /) -> collapse
+  // keep-last.
+  testJsonParse(R"({"\/":1,"/":2})", R"({"/":2})");
+  // Multibyte-UTF-8 duplicate key, differing values (normalized path).
+  testJsonParse(R"({"信":1,"信":2})", R"({"信":2})");
+  // Known-divergence lock (Masha Q4): "\n" and "\u000A" both
+  // decode to U+000A, but the comparator byte-length tiebreak ranks them
+  // distinct, so they are NOT collapsed (both kept). Documents the scope.
+  testJsonParse(R"({"\n":1,"\u000A":2})", R"({"\n":1,"\u000A":2})");
   testJsonParse(R"({ "abc" : [1, 2, 3, 4    ]})", R"({"abc":[1,2,3,4]})");
   // Test out with unicodes and empty keys.
   testJsonParse(


### PR DESCRIPTION
Summary:

`json_parse` sorts object keys but keeps exact-duplicate keys, whereas Presto
canonicalizes objects through a map round-trip so duplicates collapse to the
last value:

    json_parse('{"a":1,"a":2}')

returns `{"a":1,"a":2}` in Velox and `{"a":2}` in Presto. The same expression
can return two different results inside one query: a constant argument is
folded on the Java coordinator and collapses, while a non-constant one runs
on the Velox worker and does not. `CAST(json_parse(...) AS ROW(...))` succeeds
for the folded form and throws `Duplicate field` for the other.

Collapse runs of equal keys in `sortFields`, keeping the value of the last
occurrence. The grouping happens in the loop that already emits sorted fields,
so there is no extra pass over the data.

`json_extract` and `json_array_get` canonicalize their result through the same
code when the input is a varchar, so an extracted object with duplicate keys
collapses as well.

Keys that become equal only after decoding a control-character escape, such as
`\n` and its `\uXXXX` form, are not collapsed. The key comparator ranks the two
escape forms as distinct, and closing that gap needs decode-canonicalized key
equality.

Fixes #18066.

Reviewed By: amitkdutta, kevinwilfong

Differential Revision: D112879325


