### PR TITLE
refactor(core): Make UnnestNode output names std::optional (#18213)

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -408,6 +408,20 @@ std::vector<std::string> deserializeStrings(const folly::dynamic& array) {
   return ISerializable::deserialize<std::vector<std::string>>(array);
 }
 
+std::vector<std::optional<std::string>> deserializeOptionalStrings(
+    const folly::dynamic& array) {
+  std::vector<std::optional<std::string>> names;
+  names.reserve(array.size());
+  for (const auto& name : array) {
+    if (name.isNull()) {
+      names.emplace_back(std::nullopt);
+    } else {
+      names.emplace_back(name.asString());
+    }
+  }
+  return names;
+}
+
 RowTypePtr deserializeRowType(const folly::dynamic& obj) {
   return ISerializable::deserialize<RowType>(obj);
 }
@@ -1369,7 +1383,7 @@ UnnestNode::UnnestNode(
     const PlanNodeId& id,
     std::vector<FieldAccessTypedExprPtr> replicateVariables,
     std::vector<FieldAccessTypedExprPtr> unnestVariables,
-    std::vector<std::string> unnestNames,
+    std::vector<std::optional<std::string>> unnestNames,
     std::optional<std::string> ordinalityName,
     std::optional<std::string> markerName,
     const PlanNodePtr& source)
@@ -1387,7 +1401,7 @@ UnnestNode::UnnestNode(
     const PlanNodeId& id,
     std::vector<FieldAccessTypedExprPtr> replicateVariables,
     std::vector<FieldAccessTypedExprPtr> unnestVariables,
-    std::vector<std::string> unnestNames,
+    std::vector<std::optional<std::string>> unnestNames,
     std::optional<std::string> ordinalityName,
     std::optional<std::string> markerName,
     std::optional<bool> splitOutput,
@@ -1428,15 +1442,15 @@ UnnestNode::UnnestNode(
   int unnestIndex = 0;
   for (const auto& variable : unnestVariables_) {
     if (variable->type()->isArray()) {
-      names.emplace_back(unnestNames_[unnestIndex++]);
+      names.emplace_back(unnestNames_[unnestIndex++].value());
       types.emplace_back(variable->type()->asArray().elementType());
     } else if (variable->type()->isMap()) {
       const auto& mapType = variable->type()->asMap();
 
-      names.emplace_back(unnestNames_[unnestIndex++]);
+      names.emplace_back(unnestNames_[unnestIndex++].value());
       types.emplace_back(mapType.keyType());
 
-      names.emplace_back(unnestNames_[unnestIndex++]);
+      names.emplace_back(unnestNames_[unnestIndex++].value());
       types.emplace_back(mapType.valueType());
     } else {
       VELOX_FAIL(
@@ -1466,7 +1480,13 @@ folly::dynamic UnnestNode::serialize() const {
   auto obj = PlanNode::serialize();
   obj["replicateVariables"] = ISerializable::serialize(replicateVariables_);
   obj["unnestVariables"] = ISerializable::serialize(unnestVariables_);
-  obj["unnestNames"] = ISerializable::serialize(unnestNames_);
+  folly::dynamic unnestNames = folly::dynamic::array;
+  for (const auto& name : unnestNames_) {
+    unnestNames.push_back(
+        name.has_value() ? folly::dynamic(name.value())
+                         : folly::dynamic(nullptr));
+  }
+  obj["unnestNames"] = std::move(unnestNames);
 
   if (ordinalityName_.has_value()) {
     obj["ordinalityName"] = ordinalityName_.value();
@@ -1492,7 +1512,7 @@ PlanNodePtr UnnestNode::create(const folly::dynamic& obj, void* context) {
   auto replicateVariables =
       deserializeFields(obj["replicateVariables"], context);
   auto unnestVariables = deserializeFields(obj["unnestVariables"], context);
-  auto unnestNames = deserializeStrings(obj["unnestNames"]);
+  auto unnestNames = deserializeOptionalStrings(obj["unnestNames"]);
   std::optional<std::string> ordinalityName = std::nullopt;
   if (obj.count("ordinalityName")) {
     ordinalityName = obj["ordinalityName"].asString();

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -4881,7 +4881,7 @@ class UnnestNode : public PlanNode {
       const PlanNodeId& id,
       std::vector<FieldAccessTypedExprPtr> replicateVariables,
       std::vector<FieldAccessTypedExprPtr> unnestVariables,
-      std::vector<std::string> unnestNames,
+      std::vector<std::optional<std::string>> unnestNames,
       std::optional<std::string> ordinalityName,
       std::optional<std::string> markerName,
       const PlanNodePtr& source);
@@ -4890,11 +4890,34 @@ class UnnestNode : public PlanNode {
       const PlanNodeId& id,
       std::vector<FieldAccessTypedExprPtr> replicateVariables,
       std::vector<FieldAccessTypedExprPtr> unnestVariables,
-      std::vector<std::string> unnestNames,
+      std::vector<std::optional<std::string>> unnestNames,
       std::optional<std::string> ordinalityName,
       std::optional<std::string> markerName,
       std::optional<bool> splitOutput,
       const PlanNodePtr& source);
+
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+  /// Deprecated. Use the std::vector<std::optional<std::string>> overload.
+  UnnestNode(
+      const PlanNodeId& id,
+      std::vector<FieldAccessTypedExprPtr> replicateVariables,
+      std::vector<FieldAccessTypedExprPtr> unnestVariables,
+      std::vector<std::string> unnestNames,
+      std::optional<std::string> ordinalityName,
+      std::optional<std::string> markerName,
+      const PlanNodePtr& source)
+      : UnnestNode(
+            id,
+            std::move(replicateVariables),
+            std::move(unnestVariables),
+            std::vector<std::optional<std::string>>(
+                unnestNames.begin(),
+                unnestNames.end()),
+            std::move(ordinalityName),
+            std::move(markerName),
+            std::nullopt,
+            source) {}
+#endif
 
   class Builder {
    public:
@@ -4929,7 +4952,7 @@ class UnnestNode : public PlanNode {
       return *this;
     }
 
-    Builder& unnestNames(std::vector<std::string> unnestNames) {
+    Builder& unnestNames(std::vector<std::optional<std::string>> unnestNames) {
       unnestNames_ = std::move(unnestNames);
       return *this;
     }
@@ -4981,7 +5004,7 @@ class UnnestNode : public PlanNode {
     std::optional<PlanNodeId> id_;
     std::optional<std::vector<FieldAccessTypedExprPtr>> replicateVariables_;
     std::optional<std::vector<FieldAccessTypedExprPtr>> unnestVariables_;
-    std::optional<std::vector<std::string>> unnestNames_;
+    std::optional<std::vector<std::optional<std::string>>> unnestNames_;
     std::optional<std::string> ordinalityName_;
     std::optional<std::string> markerName_;
     std::optional<PlanNodePtr> source_;
@@ -5014,7 +5037,7 @@ class UnnestNode : public PlanNode {
     return unnestVariables_;
   }
 
-  const std::vector<std::string>& unnestNames() const {
+  const std::vector<std::optional<std::string>>& unnestNames() const {
     return unnestNames_;
   }
 
@@ -5051,7 +5074,7 @@ class UnnestNode : public PlanNode {
 
   const std::vector<FieldAccessTypedExprPtr> replicateVariables_;
   const std::vector<FieldAccessTypedExprPtr> unnestVariables_;
-  const std::vector<std::string> unnestNames_;
+  const std::vector<std::optional<std::string>> unnestNames_;
   const std::optional<std::string> ordinalityName_;
   const std::optional<std::string> markerName_;
   const std::optional<bool> splitOutput_;

--- a/velox/core/tests/PlanNodeBuilderTest.cpp
+++ b/velox/core/tests/PlanNodeBuilderTest.cpp
@@ -1010,7 +1010,7 @@ TEST_F(PlanNodeBuilderTest, unnestNode) {
       std::make_shared<FieldAccessTypedExpr>(BIGINT(), "a")};
   std::vector<FieldAccessTypedExprPtr> unnestVariables{
       std::make_shared<FieldAccessTypedExpr>(ARRAY(BIGINT()), "b")};
-  std::vector<std::string> unnestNames{"b"};
+  std::vector<std::optional<std::string>> unnestNames{"b"};
   std::optional<std::string> ordinalityName =
       std::make_optional<std::string>("ord");
   std::optional<bool> splitOutput = false;
@@ -1033,7 +1033,7 @@ TEST_F(PlanNodeBuilderTest, unnestNode) {
       expectedNames.push_back(variable->name());
     }
     for (const auto& name : unnestNames) {
-      expectedNames.push_back(name);
+      expectedNames.push_back(name.value());
     }
     if (ordinalityName.has_value()) {
       expectedNames.push_back(ordinalityName.value());

--- a/velox/exec/tests/UnnestTest.cpp
+++ b/velox/exec/tests/UnnestTest.cpp
@@ -1046,7 +1046,7 @@ TEST_P(UnnestTest, splitOutputNodeOverride) {
         planNodeIdGenerator->next(),
         std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>>{},
         unnestFields,
-        std::vector<std::string>{"s_e"},
+        std::vector<std::optional<std::string>>{"s_e"},
         std::nullopt,
         std::nullopt,
         testData.nodeSplitOutput,

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -2272,14 +2272,14 @@ PlanBuilder& PlanBuilder::unnest(
     unnestFields.emplace_back(field(name));
   }
 
-  std::vector<std::string> unnestNames;
+  std::vector<std::optional<std::string>> unnestNames;
   for (const auto& name : unnestColumns) {
     auto input = planNode_->outputType()->findChild(name);
     if (input->isArray()) {
-      unnestNames.push_back(name + "_e");
+      unnestNames.emplace_back(name + "_e");
     } else if (input->isMap()) {
-      unnestNames.push_back(name + "_k");
-      unnestNames.push_back(name + "_v");
+      unnestNames.emplace_back(name + "_k");
+      unnestNames.emplace_back(name + "_v");
     } else {
       VELOX_NYI(
           "Unsupported type of unnest variable. Expected ARRAY or MAP, but got {}.",

--- a/velox/parse/QueryPlanner.cpp
+++ b/velox/parse/QueryPlanner.cpp
@@ -140,7 +140,7 @@ PlanNodePtr toVeloxPlan(
             std::make_shared<FieldAccessTypedExpr>(
                 sources[0]->outputType()->childAt(0),
                 sources[0]->outputType()->asRow().nameOf(0))},
-        std::vector<std::string>{"a"},
+        std::vector<std::optional<std::string>>{"a"},
         /*ordinalityName=*/std::nullopt,
         /*emptyUnnestValueName=*/std::nullopt,
         std::move(sources[0]));


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/axiom/pull/1622


Migrate `UnnestNode::unnestNames` from `std::vector<std::string>` to `std::vector<std::optional<std::string>>`. This is a no-functional-change refactor: every entry remains present and behavior is unchanged. It is the enabling type migration for #17678 (allow `UnnestNode` to skip unused output columns); a follow-up gives `std::nullopt` its pruning meaning in the operator.

The previous `std::vector<std::string>` constructor is retained behind `VELOX_ENABLE_BACKWARD_COMPATIBILITY` so backward-compatibility consumers continue to build unchanged; all other call sites move to the new API. Optional names are serialized with an explicit null-tolerant encoding.

Part of #17678.

Reviewed By: stellameta, xiaoxmeng

Differential Revision: D112583571


