### PR TITLE
feat(core): Allow UnnestNode to skip unused output columns (#18214)

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -1442,16 +1442,25 @@ UnnestNode::UnnestNode(
   int unnestIndex = 0;
   for (const auto& variable : unnestVariables_) {
     if (variable->type()->isArray()) {
-      names.emplace_back(unnestNames_[unnestIndex++].value());
-      types.emplace_back(variable->type()->asArray().elementType());
+      if (unnestNames_[unnestIndex].has_value()) {
+        names.emplace_back(unnestNames_[unnestIndex].value());
+        types.emplace_back(variable->type()->asArray().elementType());
+      }
+      ++unnestIndex;
     } else if (variable->type()->isMap()) {
       const auto& mapType = variable->type()->asMap();
 
-      names.emplace_back(unnestNames_[unnestIndex++].value());
-      types.emplace_back(mapType.keyType());
+      if (unnestNames_[unnestIndex].has_value()) {
+        names.emplace_back(unnestNames_[unnestIndex].value());
+        types.emplace_back(mapType.keyType());
+      }
+      ++unnestIndex;
 
-      names.emplace_back(unnestNames_[unnestIndex++].value());
-      types.emplace_back(mapType.valueType());
+      if (unnestNames_[unnestIndex].has_value()) {
+        names.emplace_back(unnestNames_[unnestIndex].value());
+        types.emplace_back(mapType.valueType());
+      }
+      ++unnestIndex;
     } else {
       VELOX_FAIL(
           "Unexpected type of unnest variable. Expected ARRAY or MAP, but got {}.",

--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -408,6 +408,20 @@ std::vector<std::string> deserializeStrings(const folly::dynamic& array) {
   return ISerializable::deserialize<std::vector<std::string>>(array);
 }
 
+std::vector<std::optional<std::string>> deserializeOptionalStrings(
+    const folly::dynamic& array) {
+  std::vector<std::optional<std::string>> names;
+  names.reserve(array.size());
+  for (const auto& name : array) {
+    if (name.isNull()) {
+      names.emplace_back(std::nullopt);
+    } else {
+      names.emplace_back(name.asString());
+    }
+  }
+  return names;
+}
+
 RowTypePtr deserializeRowType(const folly::dynamic& obj) {
   return ISerializable::deserialize<RowType>(obj);
 }
@@ -1369,7 +1383,7 @@ UnnestNode::UnnestNode(
     const PlanNodeId& id,
     std::vector<FieldAccessTypedExprPtr> replicateVariables,
     std::vector<FieldAccessTypedExprPtr> unnestVariables,
-    std::vector<std::string> unnestNames,
+    std::vector<std::optional<std::string>> unnestNames,
     std::optional<std::string> ordinalityName,
     std::optional<std::string> markerName,
     const PlanNodePtr& source)
@@ -1387,7 +1401,7 @@ UnnestNode::UnnestNode(
     const PlanNodeId& id,
     std::vector<FieldAccessTypedExprPtr> replicateVariables,
     std::vector<FieldAccessTypedExprPtr> unnestVariables,
-    std::vector<std::string> unnestNames,
+    std::vector<std::optional<std::string>> unnestNames,
     std::optional<std::string> ordinalityName,
     std::optional<std::string> markerName,
     std::optional<bool> splitOutput,
@@ -1428,15 +1442,15 @@ UnnestNode::UnnestNode(
   int unnestIndex = 0;
   for (const auto& variable : unnestVariables_) {
     if (variable->type()->isArray()) {
-      names.emplace_back(unnestNames_[unnestIndex++]);
+      names.emplace_back(unnestNames_[unnestIndex++].value());
       types.emplace_back(variable->type()->asArray().elementType());
     } else if (variable->type()->isMap()) {
       const auto& mapType = variable->type()->asMap();
 
-      names.emplace_back(unnestNames_[unnestIndex++]);
+      names.emplace_back(unnestNames_[unnestIndex++].value());
       types.emplace_back(mapType.keyType());
 
-      names.emplace_back(unnestNames_[unnestIndex++]);
+      names.emplace_back(unnestNames_[unnestIndex++].value());
       types.emplace_back(mapType.valueType());
     } else {
       VELOX_FAIL(
@@ -1466,7 +1480,13 @@ folly::dynamic UnnestNode::serialize() const {
   auto obj = PlanNode::serialize();
   obj["replicateVariables"] = ISerializable::serialize(replicateVariables_);
   obj["unnestVariables"] = ISerializable::serialize(unnestVariables_);
-  obj["unnestNames"] = ISerializable::serialize(unnestNames_);
+  folly::dynamic unnestNames = folly::dynamic::array;
+  for (const auto& name : unnestNames_) {
+    unnestNames.push_back(
+        name.has_value() ? folly::dynamic(name.value())
+                         : folly::dynamic(nullptr));
+  }
+  obj["unnestNames"] = std::move(unnestNames);
 
   if (ordinalityName_.has_value()) {
     obj["ordinalityName"] = ordinalityName_.value();
@@ -1492,7 +1512,7 @@ PlanNodePtr UnnestNode::create(const folly::dynamic& obj, void* context) {
   auto replicateVariables =
       deserializeFields(obj["replicateVariables"], context);
   auto unnestVariables = deserializeFields(obj["unnestVariables"], context);
-  auto unnestNames = deserializeStrings(obj["unnestNames"]);
+  auto unnestNames = deserializeOptionalStrings(obj["unnestNames"]);
   std::optional<std::string> ordinalityName = std::nullopt;
   if (obj.count("ordinalityName")) {
     ordinalityName = obj["ordinalityName"].asString();

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -4881,7 +4881,7 @@ class UnnestNode : public PlanNode {
       const PlanNodeId& id,
       std::vector<FieldAccessTypedExprPtr> replicateVariables,
       std::vector<FieldAccessTypedExprPtr> unnestVariables,
-      std::vector<std::string> unnestNames,
+      std::vector<std::optional<std::string>> unnestNames,
       std::optional<std::string> ordinalityName,
       std::optional<std::string> markerName,
       const PlanNodePtr& source);
@@ -4890,11 +4890,34 @@ class UnnestNode : public PlanNode {
       const PlanNodeId& id,
       std::vector<FieldAccessTypedExprPtr> replicateVariables,
       std::vector<FieldAccessTypedExprPtr> unnestVariables,
-      std::vector<std::string> unnestNames,
+      std::vector<std::optional<std::string>> unnestNames,
       std::optional<std::string> ordinalityName,
       std::optional<std::string> markerName,
       std::optional<bool> splitOutput,
       const PlanNodePtr& source);
+
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+  /// Deprecated. Use the std::vector<std::optional<std::string>> overload.
+  UnnestNode(
+      const PlanNodeId& id,
+      std::vector<FieldAccessTypedExprPtr> replicateVariables,
+      std::vector<FieldAccessTypedExprPtr> unnestVariables,
+      std::vector<std::string> unnestNames,
+      std::optional<std::string> ordinalityName,
+      std::optional<std::string> markerName,
+      const PlanNodePtr& source)
+      : UnnestNode(
+            id,
+            std::move(replicateVariables),
+            std::move(unnestVariables),
+            std::vector<std::optional<std::string>>(
+                unnestNames.begin(),
+                unnestNames.end()),
+            std::move(ordinalityName),
+            std::move(markerName),
+            std::nullopt,
+            source) {}
+#endif
 
   class Builder {
    public:
@@ -4929,7 +4952,7 @@ class UnnestNode : public PlanNode {
       return *this;
     }
 
-    Builder& unnestNames(std::vector<std::string> unnestNames) {
+    Builder& unnestNames(std::vector<std::optional<std::string>> unnestNames) {
       unnestNames_ = std::move(unnestNames);
       return *this;
     }
@@ -4981,7 +5004,7 @@ class UnnestNode : public PlanNode {
     std::optional<PlanNodeId> id_;
     std::optional<std::vector<FieldAccessTypedExprPtr>> replicateVariables_;
     std::optional<std::vector<FieldAccessTypedExprPtr>> unnestVariables_;
-    std::optional<std::vector<std::string>> unnestNames_;
+    std::optional<std::vector<std::optional<std::string>>> unnestNames_;
     std::optional<std::string> ordinalityName_;
     std::optional<std::string> markerName_;
     std::optional<PlanNodePtr> source_;
@@ -5014,7 +5037,7 @@ class UnnestNode : public PlanNode {
     return unnestVariables_;
   }
 
-  const std::vector<std::string>& unnestNames() const {
+  const std::vector<std::optional<std::string>>& unnestNames() const {
     return unnestNames_;
   }
 
@@ -5051,7 +5074,7 @@ class UnnestNode : public PlanNode {
 
   const std::vector<FieldAccessTypedExprPtr> replicateVariables_;
   const std::vector<FieldAccessTypedExprPtr> unnestVariables_;
-  const std::vector<std::string> unnestNames_;
+  const std::vector<std::optional<std::string>> unnestNames_;
   const std::optional<std::string> ordinalityName_;
   const std::optional<std::string> markerName_;
   const std::optional<bool> splitOutput_;

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -4864,7 +4864,9 @@ class UnnestNode : public PlanNode {
   /// or MAP.
   /// @param unnestNames Names to use for unnested outputs: one name for each
   /// array (element); two names for each map (key and value). The output
-  /// names must appear in the same order as unnestVariables.
+  /// names must appear in the same order as unnestVariables. A std::nullopt
+  /// entry prunes the corresponding output column (not emitted, not
+  /// materialized).
   /// @param ordinalityName Optional name for the ordinality columns. If not
   /// present, ordinality column is not produced.
   /// @param markerName Optional name for column which indicates whether an

--- a/velox/core/tests/PlanNodeBuilderTest.cpp
+++ b/velox/core/tests/PlanNodeBuilderTest.cpp
@@ -1010,7 +1010,7 @@ TEST_F(PlanNodeBuilderTest, unnestNode) {
       std::make_shared<FieldAccessTypedExpr>(BIGINT(), "a")};
   std::vector<FieldAccessTypedExprPtr> unnestVariables{
       std::make_shared<FieldAccessTypedExpr>(ARRAY(BIGINT()), "b")};
-  std::vector<std::string> unnestNames{"b"};
+  std::vector<std::optional<std::string>> unnestNames{"b"};
   std::optional<std::string> ordinalityName =
       std::make_optional<std::string>("ord");
   std::optional<bool> splitOutput = false;
@@ -1033,7 +1033,7 @@ TEST_F(PlanNodeBuilderTest, unnestNode) {
       expectedNames.push_back(variable->name());
     }
     for (const auto& name : unnestNames) {
-      expectedNames.push_back(name);
+      expectedNames.push_back(name.value());
     }
     if (ordinalityName.has_value()) {
       expectedNames.push_back(ordinalityName.value());

--- a/velox/docs/develop/operators.rst
+++ b/velox/docs/develop/operators.rst
@@ -678,7 +678,7 @@ output rows with empty unnest values are not produced.
    * - unnestVariables
      - Input columns of type array or map to expand.
    * - unnestNames
-     - Names to use for expanded columns. One name per array column. Two names per map column.
+     - Names to use for expanded columns. One name per array column. Two names per map column. A name may be absent (null) to prune the corresponding expanded column, which is then neither emitted nor materialized.
    * - ordinalityName
      - Optional name for the ordinality column.
    * - emptyUnnestValueName

--- a/velox/exec/Unnest.cpp
+++ b/velox/exec/Unnest.cpp
@@ -55,13 +55,27 @@ Unnest::Unnest(
               : std::numeric_limits<vector_size_t>::max()) {
   const auto& inputType = unnestNode->sources()[0]->outputType();
   const auto& unnestVariables = unnestNode->unnestVariables();
-  for (const auto& variable : unnestVariables) {
+  const auto& unnestNames = unnestNode->unnestNames();
+  size_t nameIndex{0};
+  for (column_index_t channel = 0; channel < unnestVariables.size();
+       ++channel) {
+    const auto& variable = unnestVariables[channel];
     if (!variable->type()->isArray() && !variable->type()->isMap()) {
       VELOX_UNSUPPORTED(
           "Unnest operator supports only ARRAY and MAP types, the actual type is {}",
           variable->type()->toString());
     }
     unnestChannels_.push_back(inputType->getChildIdx(variable->name()));
+    // Emit each expansion column whose name is present; a std::nullopt name
+    // prunes it (neither materialized nor emitted). An ARRAY expands into one
+    // column (the element), a MAP into two (the key, then the value).
+    const uint32_t numExpansionColumns = variable->type()->isArray() ? 1 : 2;
+    for (uint32_t sourceChildIndex = 0; sourceChildIndex < numExpansionColumns;
+         ++sourceChildIndex) {
+      if (unnestNames[nameIndex++].has_value()) {
+        unnestOutputColumns_.push_back({channel, sourceChildIndex});
+      }
+    }
   }
   unnestDecoded_.resize(unnestVariables.size());
 
@@ -419,28 +433,34 @@ RowVectorPtr Unnest::generateOutput(const RowRange& range) {
   std::vector<VectorPtr> outputs(outputType_->size());
   generateRepeatedColumns(range, outputs);
 
-  // Create unnest columns.
-  column_index_t outputColumnIndex = identityProjections_.size();
-  for (auto channel = 0; channel < unnestChannels_.size(); ++channel) {
-    const auto unnestChannelEncoding =
-        generateEncodingForChannel(channel, range);
-
-    const auto& currentDecoded = unnestDecoded_[channel];
-    if (currentDecoded.base()->typeKind() == TypeKind::ARRAY) {
-      // Construct unnest column using Array elements wrapped using above
-      // created dictionary.
-      const auto* unnestBaseArray = currentDecoded.base()->as<ArrayVector>();
-      outputs[outputColumnIndex++] = unnestChannelEncoding.wrap(
-          unnestBaseArray->elements(), range.numInnerRows);
-    } else {
-      // Construct two unnest columns for Map keys and values vectors wrapped
-      // using above created dictionary.
-      const auto* unnestBaseMap = currentDecoded.base()->as<MapVector>();
-      outputs[outputColumnIndex++] = unnestChannelEncoding.wrap(
-          unnestBaseMap->mapKeys(), range.numInnerRows);
-      outputs[outputColumnIndex++] = unnestChannelEncoding.wrap(
-          unnestBaseMap->mapValues(), range.numInnerRows);
+  // Create unnest columns, one per emitted output column. Pruned columns are
+  // absent from 'unnestOutputColumns_', so a fully pruned channel builds no
+  // encoding and copies nothing. A channel's encoding is shared across its
+  // emitted columns and built once, when the channel first appears.
+  const auto unnestChild =
+      [this](column_index_t channel, uint32_t sourceChildIndex) -> VectorPtr {
+    const auto* base = unnestDecoded_[channel].base();
+    if (base->typeKind() == TypeKind::ARRAY) {
+      return base->as<ArrayVector>()->elements();
     }
+    const auto* mapVector = base->as<MapVector>();
+    return sourceChildIndex == 0 ? mapVector->mapKeys()
+                                 : mapVector->mapValues();
+  };
+
+  column_index_t outputColumnIndex = identityProjections_.size();
+  std::optional<column_index_t> encodedChannel;
+  std::optional<UnnestChannelEncoding> encoding;
+  for (const auto& outputColumn : unnestOutputColumns_) {
+    if (encodedChannel != outputColumn.channel) {
+      encoding = generateEncodingForChannel(outputColumn.channel, range);
+      encodedChannel = outputColumn.channel;
+    }
+    VELOX_CHECK(encodedChannel.has_value());
+    VELOX_CHECK(encoding.has_value());
+    outputs[outputColumnIndex++] = encoding->wrap(
+        unnestChild(outputColumn.channel, outputColumn.sourceChildIndex),
+        range.numInnerRows);
   }
 
   // 'Ordinality' and 'EmptyUnnestValue' columns are always at the end.

--- a/velox/exec/Unnest.h
+++ b/velox/exec/Unnest.h
@@ -148,6 +148,17 @@ class Unnest : public Operator {
 
   std::vector<column_index_t> unnestChannels_;
 
+  // The unnest output columns to emit, in output order; pruned columns are
+  // absent. Each points at a source sub-vector of an unnest channel:
+  //   ARRAY -> sourceChildIndex 0 (element)
+  //   MAP   -> sourceChildIndex 0 (key), 1 (value)
+  // Analogous to identityProjections_ for the replicated columns.
+  struct UnnestOutputColumn {
+    column_index_t channel;
+    uint32_t sourceChildIndex;
+  };
+  std::vector<UnnestOutputColumn> unnestOutputColumns_;
+
   std::vector<DecodedVector> unnestDecoded_;
 
   BufferPtr maxSizes_;

--- a/velox/exec/tests/PlanNodeSerdeTest.cpp
+++ b/velox/exec/tests/PlanNodeSerdeTest.cpp
@@ -635,6 +635,19 @@ TEST_F(PlanNodeSerdeTest, unnest) {
              .unnest({"c0"}, {"c1"}, "ordinal", "emptyUnnestValue")
              .planNode();
   testSerde(plan);
+
+  // A std::nullopt unnest name (pruned column) must round-trip through serde:
+  // prune the array element and the map value, keep the map key.
+  plan = PlanBuilder()
+             .values({data})
+             .unnest(
+                 {"c0"},
+                 {"c1", "c2"},
+                 std::vector<std::optional<std::string>>{
+                     std::nullopt, "c2_k", std::nullopt},
+                 "ordinal")
+             .planNode();
+  testSerde(plan);
 }
 
 TEST_F(PlanNodeSerdeTest, values) {

--- a/velox/exec/tests/UnnestTest.cpp
+++ b/velox/exec/tests/UnnestTest.cpp
@@ -71,6 +71,220 @@ TEST_P(UnnestTest, basicArray) {
   assertQuery(params, "SELECT c0, UNNEST(c1) FROM tmp WHERE c0 % 7 > 0");
 }
 
+TEST_P(UnnestTest, skipArrayElement) {
+  auto vector = makeRowVector({
+      makeFlatVector<int64_t>({1, 2}),
+      makeArrayVector<int32_t>({{10, 11, 12}, {20, 21}}),
+  });
+
+  // Prune the array element: only the replicated column is emitted, one row per
+  // array element.
+  auto plan = PlanBuilder()
+                  .values({vector})
+                  .unnest(
+                      {"c0"},
+                      {"c1"},
+                      std::vector<std::optional<std::string>>{std::nullopt})
+                  .planNode();
+
+  auto expected =
+      makeRowVector({"c0"}, {makeFlatVector<int64_t>({1, 1, 1, 2, 2})});
+  AssertQueryBuilder(plan)
+      .config(
+          core::QueryConfig::kPreferredOutputBatchRows,
+          std::to_string(batchSize_))
+      .assertResults(expected);
+}
+
+TEST_P(UnnestTest, skipMapValue) {
+  auto vector = makeRowVector({
+      makeFlatVector<int64_t>({1, 2}),
+      makeMapVector<int32_t, double>({{{10, 1.5}, {11, 2.5}}, {{20, 3.5}}}),
+  });
+
+  // Keep only the map key; prune the value.
+  auto plan =
+      PlanBuilder()
+          .values({vector})
+          .unnest(
+              {"c0"},
+              {"c1"},
+              std::vector<std::optional<std::string>>{"c1_k", std::nullopt})
+          .planNode();
+
+  auto expected = makeRowVector(
+      {"c0", "c1_k"},
+      {makeFlatVector<int64_t>({1, 1, 2}),
+       makeFlatVector<int32_t>({10, 11, 20})});
+  AssertQueryBuilder(plan)
+      .config(
+          core::QueryConfig::kPreferredOutputBatchRows,
+          std::to_string(batchSize_))
+      .assertResults(expected);
+}
+
+TEST_P(UnnestTest, skipMapKey) {
+  auto vector = makeRowVector({
+      makeFlatVector<int64_t>({1, 2}),
+      makeMapVector<int32_t, double>({{{10, 1.5}, {11, 2.5}}, {{20, 3.5}}}),
+  });
+
+  // Keep only the map value; prune the key.
+  auto plan =
+      PlanBuilder()
+          .values({vector})
+          .unnest(
+              {"c0"},
+              {"c1"},
+              std::vector<std::optional<std::string>>{std::nullopt, "c1_v"})
+          .planNode();
+
+  auto expected = makeRowVector(
+      {"c0", "c1_v"},
+      {makeFlatVector<int64_t>({1, 1, 2}),
+       makeFlatVector<double>({1.5, 2.5, 3.5})});
+  AssertQueryBuilder(plan)
+      .config(
+          core::QueryConfig::kPreferredOutputBatchRows,
+          std::to_string(batchSize_))
+      .assertResults(expected);
+}
+
+TEST_P(UnnestTest, skipMixedArrayAndMap) {
+  auto vector = makeRowVector({
+      makeFlatVector<int64_t>({1, 2}),
+      makeArrayVector<int32_t>({{10, 11}, {20}}),
+      makeMapVector<int32_t, double>({{{100, 1.5}, {101, 2.5}}, {{200, 3.5}}}),
+  });
+
+  // Prune the array element and the map value; keep only the map key.
+  auto plan = PlanBuilder()
+                  .values({vector})
+                  .unnest(
+                      {"c0"},
+                      {"c1", "c2"},
+                      std::vector<std::optional<std::string>>{
+                          std::nullopt, "c2_k", std::nullopt})
+                  .planNode();
+
+  auto expected = makeRowVector(
+      {"c0", "c2_k"},
+      {makeFlatVector<int64_t>({1, 1, 2}),
+       makeFlatVector<int32_t>({100, 101, 200})});
+  AssertQueryBuilder(plan)
+      .config(
+          core::QueryConfig::kPreferredOutputBatchRows,
+          std::to_string(batchSize_))
+      .assertResults(expected);
+}
+
+TEST_P(UnnestTest, skipAllArrayToCount) {
+  auto vector = makeRowVector({
+      makeArrayVector<int32_t>({{10, 11, 12}, {20, 21}, {}}),
+  });
+
+  // Prune the only output column with no replicated/ordinality/marker columns:
+  // the unnest output type is empty, but cardinality is preserved. count(1)
+  // over it must equal the total number of array elements.
+  auto plan =
+      PlanBuilder()
+          .values({vector})
+          .unnest(
+              {}, {"c0"}, std::vector<std::optional<std::string>>{std::nullopt})
+          .singleAggregation({}, {"count(1)"})
+          .planNode();
+
+  auto expected =
+      makeRowVector({makeFlatVector<int64_t>(std::vector<int64_t>{5})});
+  AssertQueryBuilder(plan)
+      .config(
+          core::QueryConfig::kPreferredOutputBatchRows,
+          std::to_string(batchSize_))
+      .assertResults(expected);
+}
+
+TEST_P(UnnestTest, skipMapKeyWithOrdinalityAndMarker) {
+  auto vector = makeRowVector({
+      makeFlatVector<int64_t>({1, 2}),
+      makeMapVector<int32_t, double>({{{10, 1.5}, {11, 2.5}}, {{20, 3.5}}}),
+  });
+
+  // Prune the map key while emitting the value, ordinality and marker columns.
+  // Exercises output-column index bookkeeping when a map column is partially
+  // pruned but trailing ordinality/marker columns remain.
+  auto plan =
+      PlanBuilder()
+          .values({vector})
+          .unnest(
+              {"c0"},
+              {"c1"},
+              std::vector<std::optional<std::string>>{std::nullopt, "c1_v"},
+              "ord",
+              "marker")
+          .planNode();
+
+  auto expected = makeRowVector(
+      {"c0", "c1_v", "ord", "marker"},
+      {makeFlatVector<int64_t>({1, 1, 2}),
+       makeFlatVector<double>({1.5, 2.5, 3.5}),
+       makeFlatVector<int64_t>({1, 2, 1}),
+       makeFlatVector<bool>({true, true, true})});
+  AssertQueryBuilder(plan)
+      .config(
+          core::QueryConfig::kPreferredOutputBatchRows,
+          std::to_string(batchSize_))
+      .assertResults(expected);
+}
+
+TEST_P(UnnestTest, skipArrayOfRowElement) {
+  // ARRAY(ROW(...)) unnests to a single ROW-typed column. Keeping the name
+  // emits that column; a nullopt name prunes it while preserving cardinality.
+  auto elements = makeRowVector({
+      makeFlatVector<int64_t>({10, 20, 30, 40, 50}),
+      makeFlatVector<std::string>({"x", "y", "z", "p", "q"}),
+  });
+  auto vector = makeRowVector({
+      makeFlatVector<int64_t>({1, 2}),
+      makeArrayVector({0, 3}, elements),
+  });
+
+  // Keep: the ROW element is emitted as one ROW(BIGINT, VARCHAR) column.
+  auto keepPlan =
+      PlanBuilder()
+          .values({vector})
+          .unnest({"c0"}, {"c1"}, std::vector<std::optional<std::string>>{"e"})
+          .planNode();
+  auto keepExpected = makeRowVector(
+      {"c0", "e"},
+      {makeFlatVector<int64_t>({1, 1, 1, 2, 2}),
+       makeRowVector({
+           makeFlatVector<int64_t>({10, 20, 30, 40, 50}),
+           makeFlatVector<std::string>({"x", "y", "z", "p", "q"}),
+       })});
+  AssertQueryBuilder(keepPlan)
+      .config(
+          core::QueryConfig::kPreferredOutputBatchRows,
+          std::to_string(batchSize_))
+      .assertResults(keepExpected);
+
+  // Prune: the ROW column is dropped entirely; only the replicated column
+  // remains, with cardinality preserved.
+  auto skipPlan = PlanBuilder()
+                      .values({vector})
+                      .unnest(
+                          {"c0"},
+                          {"c1"},
+                          std::vector<std::optional<std::string>>{std::nullopt})
+                      .planNode();
+  auto skipExpected =
+      makeRowVector({"c0"}, {makeFlatVector<int64_t>({1, 1, 1, 2, 2})});
+  AssertQueryBuilder(skipPlan)
+      .config(
+          core::QueryConfig::kPreferredOutputBatchRows,
+          std::to_string(batchSize_))
+      .assertResults(skipExpected);
+}
+
 TEST_P(UnnestTest, arrayWithIdentityMap) {
   struct {
     int32_t vectorSize;

--- a/velox/exec/tests/UnnestTest.cpp
+++ b/velox/exec/tests/UnnestTest.cpp
@@ -1046,7 +1046,7 @@ TEST_P(UnnestTest, splitOutputNodeOverride) {
         planNodeIdGenerator->next(),
         std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>>{},
         unnestFields,
-        std::vector<std::string>{"s_e"},
+        std::vector<std::optional<std::string>>{"s_e"},
         std::nullopt,
         std::nullopt,
         testData.nodeSplitOutput,

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -2259,19 +2259,6 @@ PlanBuilder& PlanBuilder::unnest(
     const std::optional<std::string>& ordinalColumn,
     const std::optional<std::string>& markerName) {
   VELOX_CHECK_NOT_NULL(planNode_, "Unnest cannot be the source node");
-  std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>>
-      replicateFields;
-  replicateFields.reserve(replicateColumns.size());
-  for (const auto& name : replicateColumns) {
-    replicateFields.emplace_back(field(name));
-  }
-
-  std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>> unnestFields;
-  unnestFields.reserve(unnestColumns.size());
-  for (const auto& name : unnestColumns) {
-    unnestFields.emplace_back(field(name));
-  }
-
   std::vector<std::optional<std::string>> unnestNames;
   for (const auto& name : unnestColumns) {
     auto input = planNode_->outputType()->findChild(name);
@@ -2285,6 +2272,29 @@ PlanBuilder& PlanBuilder::unnest(
           "Unsupported type of unnest variable. Expected ARRAY or MAP, but got {}.",
           input->toString());
     }
+  }
+  return unnest(
+      replicateColumns, unnestColumns, unnestNames, ordinalColumn, markerName);
+}
+
+PlanBuilder& PlanBuilder::unnest(
+    const std::vector<std::string>& replicateColumns,
+    const std::vector<std::string>& unnestColumns,
+    const std::vector<std::optional<std::string>>& unnestNames,
+    const std::optional<std::string>& ordinalColumn,
+    const std::optional<std::string>& markerName) {
+  VELOX_CHECK_NOT_NULL(planNode_, "Unnest cannot be the source node");
+  std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>>
+      replicateFields;
+  replicateFields.reserve(replicateColumns.size());
+  for (const auto& name : replicateColumns) {
+    replicateFields.emplace_back(field(name));
+  }
+
+  std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>> unnestFields;
+  unnestFields.reserve(unnestColumns.size());
+  for (const auto& name : unnestColumns) {
+    unnestFields.emplace_back(field(name));
   }
 
   planNode_ = std::make_shared<core::UnnestNode>(

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -2272,14 +2272,14 @@ PlanBuilder& PlanBuilder::unnest(
     unnestFields.emplace_back(field(name));
   }
 
-  std::vector<std::string> unnestNames;
+  std::vector<std::optional<std::string>> unnestNames;
   for (const auto& name : unnestColumns) {
     auto input = planNode_->outputType()->findChild(name);
     if (input->isArray()) {
-      unnestNames.push_back(name + "_e");
+      unnestNames.emplace_back(name + "_e");
     } else if (input->isMap()) {
-      unnestNames.push_back(name + "_k");
-      unnestNames.push_back(name + "_v");
+      unnestNames.emplace_back(name + "_k");
+      unnestNames.emplace_back(name + "_v");
     } else {
       VELOX_NYI(
           "Unsupported type of unnest variable. Expected ARRAY or MAP, but got {}.",

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -1528,6 +1528,16 @@ class PlanBuilder {
       const std::optional<std::string>& ordinalColumn = std::nullopt,
       const std::optional<std::string>& markerName = std::nullopt);
 
+  /// Same as above, but with caller-provided unnest output names: one per array
+  /// column, two per map column (key then value), in the same order as
+  /// 'unnestColumns'. A std::nullopt name prunes that output column.
+  PlanBuilder& unnest(
+      const std::vector<std::string>& replicateColumns,
+      const std::vector<std::string>& unnestColumns,
+      const std::vector<std::optional<std::string>>& unnestNames,
+      const std::optional<std::string>& ordinalColumn = std::nullopt,
+      const std::optional<std::string>& markerName = std::nullopt);
+
   /// Add a WindowNode to compute one or more windowFunctions.
   /// @param windowFunctions A list of one or more window function SQL like
   /// strings to be computed by this windowNode.

--- a/velox/parse/QueryPlanner.cpp
+++ b/velox/parse/QueryPlanner.cpp
@@ -140,7 +140,7 @@ PlanNodePtr toVeloxPlan(
             std::make_shared<FieldAccessTypedExpr>(
                 sources[0]->outputType()->childAt(0),
                 sources[0]->outputType()->asRow().nameOf(0))},
-        std::vector<std::string>{"a"},
+        std::vector<std::optional<std::string>>{"a"},
         /*ordinalityName=*/std::nullopt,
         /*emptyUnnestValueName=*/std::nullopt,
         std::move(sources[0]));


### PR DESCRIPTION
Summary:

Extend UnnestNode to prune expansion output columns the consumer does not
need. A `std::nullopt` entry in `unnestNames` drops the corresponding
expanded column: it is neither emitted nor materialized (its element, key,
or value vector is never copied).

Builds on the preceding refactor that made `unnestNames` a
`std::vector<std::optional<std::string>>`. Column selection is positional
and element-type-agnostic:

  - ARRAY -> one expansion column (the element)
  - MAP   -> two expansion columns (key, value), prunable independently

Skipping is at expansion-column granularity, so an ARRAY(ROW(...)) column
(delivered as a single ROW-typed column, not flattened) is kept or pruned
as a whole.

Part of #17678.

Reviewed By: xiaoxmeng

Differential Revision: D112878138


