### PR TITLE
feat(DWRF): Complete ORC writer implementation to DWRF writer

### DIFF
--- a/velox/dwio/dwrf/common/FileMetadata.h
+++ b/velox/dwio/dwrf/common/FileMetadata.h
@@ -1640,8 +1640,8 @@ class FooterWriteWrapper : public ProtoWriteWrapperBase {
   }
 
   inline int stripesSize() const {
-    VELOX_CHECK_EQ(format_, DwrfFormat::kDwrf);
-    return dwrfPtr()->stripes_size();
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->stripes_size()
+                                        : orcPtr()->stripes_size();
   }
 
   inline proto::Encryption* mutableEncryption() {
@@ -1833,8 +1833,9 @@ class StreamWriteWrapper : public ProtoWriteWrapperBase {
       : ProtoWriteWrapperBase(DwrfFormat::kOrc, stream) {}
 
   void setOffset(uint64_t offset) {
-    VELOX_CHECK_EQ(format_, DwrfFormat::kDwrf);
-    dwrfPtr()->set_offset(offset);
+    if (format_ == DwrfFormat::kDwrf) {
+      dwrfPtr()->set_offset(offset);
+    }
   }
 
   void setKind(const StreamKind& kind) {
@@ -1854,18 +1855,21 @@ class StreamWriteWrapper : public ProtoWriteWrapperBase {
   }
 
   void setNode(uint32_t node) {
-    VELOX_CHECK_EQ(format_, DwrfFormat::kDwrf);
-    dwrfPtr()->set_node(node);
+    if (format_ == DwrfFormat::kDwrf) {
+      dwrfPtr()->set_node(node);
+    }
   }
 
   void setSequence(uint32_t sequence) {
-    VELOX_CHECK_EQ(format_, DwrfFormat::kDwrf);
-    dwrfPtr()->set_sequence(sequence);
+    if (format_ == DwrfFormat::kDwrf) {
+      dwrfPtr()->set_sequence(sequence);
+    }
   }
 
   void setUseVints(bool useVints) {
-    VELOX_CHECK_EQ(format_, DwrfFormat::kDwrf);
-    dwrfPtr()->set_usevints(useVints);
+    if (format_ == DwrfFormat::kDwrf) {
+      dwrfPtr()->set_usevints(useVints);
+    }
   }
 
  private:

--- a/velox/dwio/dwrf/test/E2EWriterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EWriterTest.cpp
@@ -27,6 +27,7 @@
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
 #include "velox/dwio/common/tests/utils/MapBuilder.h"
 #include "velox/dwio/dwrf/common/Config.h"
+#include "velox/dwio/dwrf/common/wrap/orc-proto-wrapper.h"
 #include "velox/dwio/dwrf/reader/ColumnReader.h"
 #include "velox/dwio/dwrf/reader/DwrfReader.h"
 #include "velox/dwio/dwrf/test/OrcTest.h"
@@ -383,6 +384,206 @@ TEST_F(E2EWriterTest, FieldIdMappingNestedStruct) {
   ASSERT_EQ(nested.size(), 2);
   EXPECT_EQ(nested.nameOf(0), "x");
   EXPECT_EQ(nested.nameOf(1), "y2");
+}
+
+TEST_F(E2EWriterTest, OrcWriterRoundTrip) {
+  constexpr vector_size_t kRowCount = 257;
+  VectorMaker maker{leafPool_.get()};
+  const auto isNullAt = [](vector_size_t row) { return row % 11 == 0; };
+
+  auto batch = maker.rowVector(
+      {"boolean_val",
+       "tinyint_val",
+       "smallint_val",
+       "integer_val",
+       "bigint_val",
+       "string_val",
+       "timestamp_val",
+       "date_val",
+       "short_decimal_val",
+       "long_decimal_val",
+       "array_val",
+       "map_val",
+       "struct_val"},
+      {maker.flatVector<bool>(
+           kRowCount, [](auto row) { return row % 2 == 0; }, isNullAt),
+       maker.flatVector<int8_t>(
+           kRowCount, [](auto row) { return row - 100; }, isNullAt),
+       maker.flatVector<int16_t>(
+           kRowCount, [](auto row) { return row * 7 - 500; }, isNullAt),
+       maker.flatVector<int32_t>(
+           kRowCount,
+           [](auto row) { return row * 10'003 - 1'000'000; },
+           isNullAt),
+       maker.flatVector<int64_t>(
+           kRowCount,
+           [](auto row) { return row * 10'000'000'019L - 2'000'000'000L; },
+           isNullAt),
+       maker.flatVector<std::string>(
+           kRowCount,
+           [](auto row) { return fmt::format("orc-string-{}", row % 17); },
+           isNullAt),
+       maker.flatVector<Timestamp>(
+           kRowCount,
+           [](auto row) {
+             return Timestamp{
+                 1'700'000'000 + row, static_cast<uint64_t>(row) * 1'000};
+           },
+           isNullAt),
+       maker.flatVector<int32_t>(
+           kRowCount, [](auto row) { return row - 10'000; }, isNullAt, DATE()),
+       maker.flatVector<int64_t>(
+           kRowCount,
+           [](auto row) { return row * 123 - 10'000; },
+           isNullAt,
+           DECIMAL(10, 2)),
+       maker.flatVector<int128_t>(
+           kRowCount,
+           [](auto row) { return static_cast<int128_t>(row) * 123'456'789; },
+           isNullAt,
+           DECIMAL(20, 4)),
+       maker.arrayVector<int32_t>(
+           kRowCount,
+           [](auto row) { return row % 4; },
+           [](auto row, auto index) { return row * 10 + index; },
+           isNullAt),
+       maker.mapVector<std::string, int64_t>(
+           kRowCount,
+           [](auto row) { return row % 3; },
+           [](auto row, auto index) {
+             return fmt::format("key-{}-{}", row, index);
+           },
+           [](auto row, auto index) { return row * 100 + index; },
+           isNullAt),
+       maker.rowVector(
+           {"nested_int", "nested_string"},
+           {maker.flatVector<int32_t>(
+                kRowCount, [](auto row) { return -row; }, isNullAt),
+            maker.flatVector<std::string>(
+                kRowCount,
+                [](auto row) { return fmt::format("nested-{}", row); },
+                isNullAt)})});
+
+  auto config = std::make_shared<dwrf::Config>();
+  config->set(
+      dwrf::Config::COMPRESSION, common::CompressionKind::CompressionKind_NONE);
+  config->set(dwrf::Config::ROW_INDEX_STRIDE, uint32_t{1'000});
+  // These DWRF encodings aren't wire-compatible with ORC. Keep the options
+  // enabled to verify that ORC output still selects compatible encodings.
+  config->set(dwrf::Config::INTEGER_DICTIONARY_ENCODING_ENABLED, true);
+  config->set(dwrf::Config::STRING_DICTIONARY_ENCODING_ENABLED, true);
+
+  auto sink = std::make_unique<MemorySink>(
+      4 * 1024 * 1024,
+      dwio::common::FileSink::Options{.pool = leafPool_.get()});
+  auto* sinkPtr = sink.get();
+
+  dwrf::WriterOptions options;
+  options.config = config;
+  options.schema = batch->type();
+  options.memoryPool = rootPool_.get();
+  options.format = dwrf::DwrfFormat::kOrc;
+  dwrf::Writer writer{std::move(sink), options};
+  writer.write(batch);
+  writer.close();
+
+  const std::string_view file{sinkPtr->data(), sinkPtr->size()};
+  constexpr size_t kOrcMagicLength = 3;
+  ASSERT_GT(file.size(), kOrcMagicLength + 1);
+  EXPECT_EQ(file.substr(0, kOrcMagicLength), "ORC");
+
+  const auto postScriptLength = static_cast<uint8_t>(file.back());
+  ASSERT_GT(postScriptLength, 0);
+  ASSERT_LT(postScriptLength + 1, file.size());
+  const auto postScriptOffset = file.size() - postScriptLength - 1;
+  dwrf::proto::orc::PostScript postScript;
+  ASSERT_TRUE(postScript.ParseFromArray(
+      file.data() + postScriptOffset, postScriptLength));
+  ASSERT_EQ(postScript.version_size(), 2);
+  EXPECT_EQ(postScript.version(0), 0);
+  EXPECT_EQ(postScript.version(1), 12);
+  EXPECT_EQ(postScript.compression(), dwrf::proto::orc::CompressionKind::NONE);
+  EXPECT_EQ(postScript.metadatalength(), 0);
+
+  ASSERT_LE(postScript.footerlength(), postScriptOffset);
+  const auto footerOffset = postScriptOffset - postScript.footerlength();
+  dwrf::proto::orc::Footer footer;
+  ASSERT_TRUE(footer.ParseFromArray(
+      file.data() + footerOffset, postScript.footerlength()));
+  EXPECT_EQ(footer.numberofrows(), kRowCount);
+  EXPECT_EQ(footer.writer(), 1);
+  ASSERT_EQ(footer.stripes_size(), 1);
+
+  const auto topLevelTypeId = [&](const std::string& name) {
+    const auto& root = footer.types(0);
+    for (int32_t i = 0; i < root.fieldnames_size(); ++i) {
+      if (root.fieldnames(i) == name) {
+        return root.subtypes(i);
+      }
+    }
+    VELOX_FAIL("Missing field in ORC footer: {}", name);
+  };
+  const auto dateTypeId = topLevelTypeId("date_val");
+  EXPECT_EQ(
+      footer.types(dateTypeId).kind(),
+      dwrf::proto::orc::Type_Kind::Type_Kind_DATE);
+  const auto shortDecimalTypeId = topLevelTypeId("short_decimal_val");
+  EXPECT_EQ(
+      footer.types(shortDecimalTypeId).kind(),
+      dwrf::proto::orc::Type_Kind::Type_Kind_DECIMAL);
+  EXPECT_EQ(footer.types(shortDecimalTypeId).precision(), 10);
+  EXPECT_EQ(footer.types(shortDecimalTypeId).scale(), 2);
+  const auto longDecimalTypeId = topLevelTypeId("long_decimal_val");
+  EXPECT_EQ(
+      footer.types(longDecimalTypeId).kind(),
+      dwrf::proto::orc::Type_Kind::Type_Kind_DECIMAL);
+  EXPECT_EQ(footer.types(longDecimalTypeId).precision(), 20);
+  EXPECT_EQ(footer.types(longDecimalTypeId).scale(), 4);
+
+  const auto& stripe = footer.stripes(0);
+  const auto stripeFooterOffset =
+      stripe.offset() + stripe.indexlength() + stripe.datalength();
+  ASSERT_LE(stripeFooterOffset + stripe.footerlength(), footerOffset);
+  dwrf::proto::orc::StripeFooter stripeFooter;
+  ASSERT_TRUE(stripeFooter.ParseFromArray(
+      file.data() + stripeFooterOffset, stripe.footerlength()));
+  ASSERT_EQ(stripeFooter.columns_size(), footer.types_size());
+  for (const auto& encoding : stripeFooter.columns()) {
+    EXPECT_EQ(encoding.kind(), dwrf::proto::orc::ColumnEncoding_Kind_DIRECT);
+  }
+  uint64_t streamOffset = stripe.offset();
+  size_t rowIndexStreamCount = 0;
+  for (const auto& stream : stripeFooter.streams()) {
+    EXPECT_LT(stream.column(), footer.types_size());
+    if (stream.kind() == dwrf::proto::orc::Stream_Kind_ROW_INDEX) {
+      dwrf::proto::orc::RowIndex rowIndex;
+      ASSERT_TRUE(
+          rowIndex.ParseFromArray(file.data() + streamOffset, stream.length()));
+      EXPECT_GT(rowIndex.entry_size(), 0);
+      ++rowIndexStreamCount;
+    }
+    streamOffset += stream.length();
+  }
+  EXPECT_GT(rowIndexStreamCount, 0);
+  EXPECT_EQ(streamOffset, stripeFooterOffset);
+
+  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+  readerOptions.setFileFormat(FileFormat::ORC);
+  auto reader = createReader(*sinkPtr, readerOptions);
+  EXPECT_EQ(reader->testingReaderBase()->format(), dwrf::DwrfFormat::kOrc);
+
+  auto rowReader = reader->createRowReader({});
+  VectorPtr actual;
+  vector_size_t row = 0;
+  while (rowReader->next(73, actual)) {
+    for (vector_size_t i = 0; i < actual->size(); ++i) {
+      ASSERT_TRUE(batch->equalValueAt(actual.get(), row, i))
+          << "Mismatch at row " << row << ": expected " << batch->toString(row)
+          << ", actual " << actual->toString(i);
+      ++row;
+    }
+  }
+  EXPECT_EQ(row, kRowCount);
 }
 
 // This test can be run to generate test files. Run it with following command

--- a/velox/dwio/dwrf/utils/ProtoUtils.cpp
+++ b/velox/dwio/dwrf/utils/ProtoUtils.cpp
@@ -24,11 +24,21 @@ namespace {
 template <TypeKind T>
 class SchemaType {};
 
+template <TypeKind T>
+class OrcSchemaType {};
+
 #define CREATE_TYPE_TRAIT(Kind, SchemaKind)       \
   template <>                                     \
   struct SchemaType<TypeKind::Kind> {             \
     static constexpr proto::Type_Kind kind =      \
         proto::Type_Kind::Type_Kind_##SchemaKind; \
+  };
+
+#define CREATE_ORC_TYPE_TRAIT(Kind, SchemaKind)        \
+  template <>                                          \
+  struct OrcSchemaType<TypeKind::Kind> {               \
+    static constexpr proto::orc::Type_Kind kind =      \
+        proto::orc::Type_Kind::Type_Kind_##SchemaKind; \
   };
 
 CREATE_TYPE_TRAIT(BOOLEAN, BOOLEAN)
@@ -45,7 +55,22 @@ CREATE_TYPE_TRAIT(ARRAY, LIST)
 CREATE_TYPE_TRAIT(MAP, MAP)
 CREATE_TYPE_TRAIT(ROW, STRUCT)
 
+CREATE_ORC_TYPE_TRAIT(BOOLEAN, BOOLEAN)
+CREATE_ORC_TYPE_TRAIT(TINYINT, BYTE)
+CREATE_ORC_TYPE_TRAIT(SMALLINT, SHORT)
+CREATE_ORC_TYPE_TRAIT(INTEGER, INT)
+CREATE_ORC_TYPE_TRAIT(BIGINT, LONG)
+CREATE_ORC_TYPE_TRAIT(REAL, FLOAT)
+CREATE_ORC_TYPE_TRAIT(DOUBLE, DOUBLE)
+CREATE_ORC_TYPE_TRAIT(VARCHAR, STRING)
+CREATE_ORC_TYPE_TRAIT(VARBINARY, BINARY)
+CREATE_ORC_TYPE_TRAIT(TIMESTAMP, TIMESTAMP)
+CREATE_ORC_TYPE_TRAIT(ARRAY, LIST)
+CREATE_ORC_TYPE_TRAIT(MAP, MAP)
+CREATE_ORC_TYPE_TRAIT(ROW, STRUCT)
+
 #undef CREATE_TYPE_TRAIT
+#undef CREATE_ORC_TYPE_TRAIT
 
 } // namespace
 
@@ -60,10 +85,24 @@ void ProtoUtils::writeType(
     parent->addSubtypes(static_cast<int>(typeId));
   }
 
-  auto kind =
-      VELOX_STATIC_FIELD_DYNAMIC_DISPATCH(SchemaType, kind, type.kind());
-  auto typeKindWrapper = TypeKindWrapper(&kind);
-  self.setKind(typeKindWrapper);
+  if (footer.format() == DwrfFormat::kDwrf) {
+    auto kind =
+        VELOX_STATIC_FIELD_DYNAMIC_DISPATCH(SchemaType, kind, type.kind());
+    self.setKind(TypeKindWrapper(&kind));
+  } else if (type.isDecimal()) {
+    auto kind = proto::orc::Type_Kind::Type_Kind_DECIMAL;
+    self.setKind(TypeKindWrapper(&kind));
+    const auto [precision, scale] = getDecimalPrecisionScale(type);
+    self.setPrecision(precision);
+    self.setScale(scale);
+  } else if (type.isDate()) {
+    auto kind = proto::orc::Type_Kind::Type_Kind_DATE;
+    self.setKind(TypeKindWrapper(&kind));
+  } else {
+    auto kind =
+        VELOX_STATIC_FIELD_DYNAMIC_DISPATCH(OrcSchemaType, kind, type.kind());
+    self.setKind(TypeKindWrapper(&kind));
+  }
 
   // Stamp per-type attributes (e.g. Iceberg field ids) before recursing into
   // children. An empty result keeps the wire format byte-identical to the

--- a/velox/dwio/dwrf/writer/ColumnWriter.cpp
+++ b/velox/dwio/dwrf/writer/ColumnWriter.cpp
@@ -659,6 +659,64 @@ void IntegerColumnWriter<T>::convertToDirectEncoding() {
           std::placeholders::_1));
 }
 
+template <typename T>
+class OrcIntegerColumnWriter : public BaseColumnWriter {
+ public:
+  OrcIntegerColumnWriter(
+      WriterContext& context,
+      const TypeWithId& type,
+      uint32_t sequence,
+      std::function<void(IndexBuilder&)> onRecordPosition)
+      : BaseColumnWriter{context, type, sequence, onRecordPosition},
+        data_{createRleEncoder</* isSigned = */ true>(
+            RleVersion_1,
+            newStream(StreamKind::StreamKind_DATA),
+            context.getConfig(Config::USE_VINTS),
+            sizeof(T))} {
+    reset();
+  }
+
+  uint64_t write(const VectorPtr& slice, const common::Ranges& ranges)
+      override {
+    auto localDecoded = decode(slice, ranges);
+    auto& decodedVector = localDecoded.get();
+    writeNulls(decodedVector, ranges);
+
+    uint64_t count = 0;
+    for (auto pos : ranges) {
+      if (!decodedVector.isNullAt(pos)) {
+        data_->writeValue(decodedVector.template valueAt<T>(pos));
+        ++count;
+      }
+    }
+
+    StatisticsBuilderUtils::addValues<T>(
+        dynamic_cast<IntegerStatisticsBuilder&>(*indexStatsBuilder_),
+        decodedVector,
+        ranges);
+    const auto rawSize =
+        count * sizeof(T) + (ranges.size() - count) * NULL_SIZE;
+    indexStatsBuilder_->increaseRawSize(rawSize);
+    return rawSize;
+  }
+
+  void flush(
+      std::function<ColumnEncodingWriteWrapper(uint32_t)> encodingFactory,
+      std::function<void(ColumnEncodingWriteWrapper&)> encodingOverride)
+      override {
+    BaseColumnWriter::flush(encodingFactory, encodingOverride);
+    data_->flush();
+  }
+
+  void recordPosition() override {
+    BaseColumnWriter::recordPosition();
+    data_->recordPosition(*indexBuilder_);
+  }
+
+ private:
+  std::unique_ptr<IntEncoder<true>> data_;
+};
+
 class TimestampColumnWriter : public BaseColumnWriter {
  public:
   TimestampColumnWriter(
@@ -1176,7 +1234,8 @@ class StringColumnWriter : public BaseColumnWriter {
   }
 
   bool useDictionaryEncoding() const override {
-    return getConfig(Config::STRING_DICTIONARY_ENCODING_ENABLED) &&
+    return context_.format() == DwrfFormat::kDwrf &&
+        getConfig(Config::STRING_DICTIONARY_ENCODING_ENABLED) &&
         (sequence_ == 0 ||
          !getConfig(Config::MAP_FLAT_DISABLE_DICT_ENCODING_STRING)) &&
         !context_.isLowMemoryMode();
@@ -2160,14 +2219,26 @@ std::unique_ptr<BaseColumnWriter> BaseColumnWriter::create(
       return std::make_unique<ByteRleColumnWriter<int8_t>>(
           context, type, sequence, &createByteRleEncoder, onRecordPosition);
     case TypeKind::SMALLINT:
+      if (format == DwrfFormat::kOrc) {
+        return std::make_unique<OrcIntegerColumnWriter<int16_t>>(
+            context, type, sequence, onRecordPosition);
+      }
       return std::make_unique<IntegerColumnWriter<int16_t>>(
           context, type, sequence, onRecordPosition);
     case TypeKind::INTEGER:
+      if (format == DwrfFormat::kOrc) {
+        return std::make_unique<OrcIntegerColumnWriter<int32_t>>(
+            context, type, sequence, onRecordPosition);
+      }
       return std::make_unique<IntegerColumnWriter<int32_t>>(
           context, type, sequence, onRecordPosition);
     case TypeKind::BIGINT: {
       if (format == DwrfFormat::kOrc && type.type()->isDecimal()) {
         return std::make_unique<DecimalColumnWriter>(
+            context, type, sequence, onRecordPosition);
+      }
+      if (format == DwrfFormat::kOrc) {
+        return std::make_unique<OrcIntegerColumnWriter<int64_t>>(
             context, type, sequence, onRecordPosition);
       }
       return std::make_unique<IntegerColumnWriter<int64_t>>(
@@ -2199,7 +2270,8 @@ std::unique_ptr<BaseColumnWriter> BaseColumnWriter::create(
           context, type, sequence, onRecordPosition);
       ret->children_.reserve(type.size());
       for (int32_t i = 0; i < type.size(); ++i) {
-        ret->children_.push_back(create(context, *type.childAt(i), sequence));
+        ret->children_.push_back(
+            create(context, *type.childAt(i), sequence, nullptr, format));
       }
       return ret;
     }
@@ -2215,15 +2287,18 @@ std::unique_ptr<BaseColumnWriter> BaseColumnWriter::create(
       }
       auto ret = std::make_unique<MapColumnWriter>(
           context, type, sequence, onRecordPosition);
-      ret->children_.push_back(create(context, *type.childAt(0), sequence));
-      ret->children_.push_back(create(context, *type.childAt(1), sequence));
+      ret->children_.push_back(
+          create(context, *type.childAt(0), sequence, nullptr, format));
+      ret->children_.push_back(
+          create(context, *type.childAt(1), sequence, nullptr, format));
       return ret;
     }
     case TypeKind::ARRAY: {
       VELOX_CHECK_EQ(type.size(), 1, "Array should have exactly one child");
       auto ret = std::make_unique<ListColumnWriter>(
           context, type, sequence, onRecordPosition);
-      ret->children_.push_back(create(context, *type.childAt(0), sequence));
+      ret->children_.push_back(
+          create(context, *type.childAt(0), sequence, nullptr, format));
       return ret;
     }
     default:

--- a/velox/dwio/dwrf/writer/ColumnWriter.h
+++ b/velox/dwio/dwrf/writer/ColumnWriter.h
@@ -81,9 +81,13 @@ class ColumnWriter {
       : id_{id}, sequence_{sequence}, context_{context} {}
 
   virtual void setEncoding(ColumnEncodingWriteWrapper& columnEncoding) const {
-    auto columnEncodingKind =
-        proto::ColumnEncoding_Kind::ColumnEncoding_Kind_DIRECT;
-    columnEncoding.setKind(ColumnEncodingKindWrapper(&columnEncodingKind));
+    if (columnEncoding.format() == DwrfFormat::kDwrf) {
+      auto kind = proto::ColumnEncoding_Kind::ColumnEncoding_Kind_DIRECT;
+      columnEncoding.setKind(ColumnEncodingKindWrapper(&kind));
+    } else {
+      auto kind = proto::orc::ColumnEncoding_Kind::ColumnEncoding_Kind_DIRECT;
+      columnEncoding.setKind(ColumnEncodingKindWrapper(&kind));
+    }
     columnEncoding.setDictionarySize(0);
     columnEncoding.setNode(id_);
     columnEncoding.setSequence(sequence_);
@@ -271,8 +275,9 @@ class BaseColumnWriter : public ColumnWriter {
   }
 
   virtual bool useDictionaryEncoding() const {
-    return (sequence_ == 0 ||
-            !context_.getConfig(Config::MAP_FLAT_DISABLE_DICT_ENCODING)) &&
+    return context_.format() == DwrfFormat::kDwrf &&
+        (sequence_ == 0 ||
+         !context_.getConfig(Config::MAP_FLAT_DISABLE_DICT_ENCODING)) &&
         !context_.isLowMemoryMode();
   }
 

--- a/velox/dwio/dwrf/writer/IndexBuilder.h
+++ b/velox/dwio/dwrf/writer/IndexBuilder.h
@@ -39,14 +39,20 @@ class IndexBuilder : public PositionRecorder {
  public:
   IndexBuilder(
       std::unique_ptr<BufferedOutputStream> out,
-      dwio::common::FileFormat fileFormat = dwio::common::FileFormat::DWRF)
+      DwrfFormat format = DwrfFormat::kDwrf)
       : out_{std::move(out)},
         arena_(std::make_unique<google::protobuf::Arena>()) {
-    auto rowIndex = ArenaCreate<proto::RowIndex>(arena_.get());
-    auto rowIndexEntry = ArenaCreate<proto::RowIndexEntry>(arena_.get());
-
-    index_ = std::make_unique<RowIndexWriteWrapper>(rowIndex);
-    entry_ = std::make_unique<RowIndexEntryWriteWrapper>(rowIndexEntry);
+    if (format == DwrfFormat::kDwrf) {
+      auto rowIndex = ArenaCreate<proto::RowIndex>(arena_.get());
+      auto rowIndexEntry = ArenaCreate<proto::RowIndexEntry>(arena_.get());
+      index_ = std::make_unique<RowIndexWriteWrapper>(rowIndex);
+      entry_ = std::make_unique<RowIndexEntryWriteWrapper>(rowIndexEntry);
+    } else {
+      auto rowIndex = ArenaCreate<proto::orc::RowIndex>(arena_.get());
+      auto rowIndexEntry = ArenaCreate<proto::orc::RowIndexEntry>(arena_.get());
+      index_ = std::make_unique<RowIndexWriteWrapper>(rowIndex);
+      entry_ = std::make_unique<RowIndexEntryWriteWrapper>(rowIndexEntry);
+    }
   }
 
   virtual ~IndexBuilder() = default;

--- a/velox/dwio/dwrf/writer/LayoutPlanner.cpp
+++ b/velox/dwio/dwrf/writer/LayoutPlanner.cpp
@@ -128,12 +128,21 @@ EncodingIter::pointer EncodingIter::operator->() const {
 }
 
 EncodingManager::EncodingManager(
-    const encryption::EncryptionHandler& encryptionHandler)
+    const encryption::EncryptionHandler& encryptionHandler,
+    DwrfFormat format)
     : encryptionHandler_{encryptionHandler},
       arena_{std::make_unique<google::protobuf::Arena>()} {
   initEncryptionGroups();
-  auto dwrfStripeFooter = ArenaCreate<proto::StripeFooter>(arena_.get());
-  footer_ = std::make_unique<StripeFooterWriteWrapper>(dwrfStripeFooter);
+  if (format == DwrfFormat::kDwrf) {
+    auto dwrfStripeFooter = ArenaCreate<proto::StripeFooter>(arena_.get());
+    footer_ = std::make_unique<StripeFooterWriteWrapper>(dwrfStripeFooter);
+  } else {
+    VELOX_CHECK(
+        !encryptionHandler_.isEncrypted(),
+        "Encryption is not supported by the ORC writer");
+    auto orcStripeFooter = ArenaCreate<proto::orc::StripeFooter>(arena_.get());
+    footer_ = std::make_unique<StripeFooterWriteWrapper>(orcStripeFooter);
+  }
 }
 
 ColumnEncodingWriteWrapper EncodingManager::addEncodingToFooter(
@@ -245,13 +254,17 @@ LayoutPlanner::LayoutPlanner(const dwio::common::TypeWithId& schema) {
 
 LayoutResult LayoutPlanner::plan(
     const EncodingContainer& encoding,
-    StreamList streams) const {
+    StreamList streams,
+    DwrfFormat format) const {
   // place index before data
   auto iter = std::partition(streams.begin(), streams.end(), [](auto& stream) {
     return isIndexStream(stream.first->kind());
   });
   const size_t indexCount = iter - streams.begin();
-  auto flatMapCols = getFlatMapColumns(encoding, nodeToColumnMap_);
+  folly::F14FastSet<uint32_t> flatMapCols;
+  if (format == DwrfFormat::kDwrf) {
+    flatMapCols = getFlatMapColumns(encoding, nodeToColumnMap_);
+  }
 
   // sort streams
   sortBySize(streams.begin(), iter, flatMapCols);

--- a/velox/dwio/dwrf/writer/LayoutPlanner.h
+++ b/velox/dwio/dwrf/writer/LayoutPlanner.h
@@ -86,7 +86,8 @@ class EncodingContainer {
 class EncodingManager : public EncodingContainer {
  public:
   explicit EncodingManager(
-      const encryption::EncryptionHandler& encryptionHandler);
+      const encryption::EncryptionHandler& encryptionHandler,
+      DwrfFormat format = DwrfFormat::kDwrf);
   virtual ~EncodingManager() override = default;
 
   ColumnEncodingWriteWrapper addEncodingToFooter(uint32_t nodeId);
@@ -132,7 +133,8 @@ class LayoutPlanner {
 
   virtual LayoutResult plan(
       const EncodingContainer& encoding,
-      StreamList streamList) const;
+      StreamList streamList,
+      DwrfFormat format = DwrfFormat::kDwrf) const;
 
  protected:
   static void sortBySize(

--- a/velox/dwio/dwrf/writer/Writer.cpp
+++ b/velox/dwio/dwrf/writer/Writer.cpp
@@ -157,7 +157,8 @@ Writer::Writer(
     std::unique_ptr<dwio::common::FileSink> sink,
     const WriterOptions& options,
     std::shared_ptr<memory::MemoryPool> pool)
-    : writerBase_(std::make_unique<WriterBase>(std::move(sink))),
+    : writerBase_(
+          std::make_unique<WriterBase>(std::move(sink), options.format)),
       schema_{dwio::common::TypeWithId::create(options.schema)},
       spillConfig_{options.spillConfig},
       nonReclaimableSection_(options.nonReclaimableSection) {
@@ -202,7 +203,8 @@ Writer::Writer(
   }
 
   if (options.columnWriterFactory == nullptr) {
-    writer_ = BaseColumnWriter::create(writerBase_->getContext(), *schema_);
+    writer_ = BaseColumnWriter::create(
+        writerBase_->getContext(), *schema_, 0, nullptr, options.format);
   } else {
     writer_ = options.columnWriterFactory(writerBase_->getContext(), *schema_);
   }
@@ -522,7 +524,7 @@ void Writer::flushStripe(bool close) {
   TestValue::adjust("facebook::velox::dwrf::Writer::flushStripe", this);
 
   const auto& handler = context.getEncryptionHandler();
-  EncodingManager encodingManager{handler};
+  EncodingManager encodingManager{handler, context.format()};
 
   writer_->flush([&](uint32_t nodeId) -> ColumnEncodingWriteWrapper {
     return encodingManager.addEncodingToFooter(nodeId);
@@ -566,11 +568,16 @@ void Writer::flushStripe(bool close) {
     writerBase_->validateStreamSize(stream, out.size());
 
     s.setKind(stream.kind());
-    s.setNode(nodeId);
-    s.setColumn(stream.column());
-    s.setSequence(stream.encodingKey().sequence());
+    if (context.format() == DwrfFormat::kDwrf) {
+      s.setNode(nodeId);
+      s.setColumn(stream.column());
+      s.setSequence(stream.encodingKey().sequence());
+      s.setUseVints(context.getConfig(Config::USE_VINTS));
+    } else {
+      // ORC identifies streams by the schema node id in its column field.
+      s.setColumn(nodeId);
+    }
     s.setLength(out.size());
-    s.setUseVints(context.getConfig(Config::USE_VINTS));
     offset += out.size();
 
     context.recordPhysicalSize(stream, out.size());
@@ -580,7 +587,8 @@ void Writer::flushStripe(bool close) {
   // deals with streams
   uint64_t indexLength = 0;
   sink.setMode(WriterSink::Mode::Index);
-  auto result = layoutPlanner_->plan(encodingManager, getStreamList(context));
+  auto result = layoutPlanner_->plan(
+      encodingManager, getStreamList(context), context.format());
   result.iterateIndexStreams(
       [&](const DwrfStreamIdentifier& streamId, DataBufferHolder& content) {
         VELOX_CHECK(

--- a/velox/dwio/dwrf/writer/WriterBase.cpp
+++ b/velox/dwio/dwrf/writer/WriterBase.cpp
@@ -28,7 +28,7 @@ void WriterBase::writeFooter(const Type& type) {
 
   // write cache when available
   auto cacheSize = writerSink_->getCacheSize();
-  if (cacheSize > 0) {
+  if (format_ == DwrfFormat::kDwrf && cacheSize > 0) {
     writerSink_->writeCache();
     for (auto& i : writerSink_->getCacheOffsets()) {
       footer_->addStripeCacheOffsets(i);
@@ -60,19 +60,30 @@ void WriterBase::writeFooter(const Type& type) {
     // rawSize.
     footer_->setRawDataSize(context_->fileRawSize());
   }
-  auto* checksum = writerSink_->getChecksum();
-  footer_->setCheckSumAlgorithm(
-      (checksum != nullptr) ? checksum->getType()
-                            : proto::ChecksumAlgorithm::NULL_);
-  writeProto(footer_->getDwrfPtr());
+  std::unique_ptr<PostScriptWriteWrapper> ps;
+  if (format_ == DwrfFormat::kDwrf) {
+    auto* checksum = writerSink_->getChecksum();
+    footer_->setCheckSumAlgorithm(
+        (checksum != nullptr) ? checksum->getType()
+                              : proto::ChecksumAlgorithm::NULL_);
+    writeProto(footer_->getDwrfPtr());
+    auto dwrfPostScript = ArenaCreate<proto::PostScript>(arena_.get());
+    ps = std::make_unique<PostScriptWriteWrapper>(dwrfPostScript);
+    ps->setCacheMode(writerSink_->getCacheMode());
+    ps->setCacheSize(cacheSize);
+  } else {
+    footer_->setWriter(1);
+    writeProto(footer_->getOrcPtr());
+    auto orcPostScript = ArenaCreate<proto::orc::PostScript>(arena_.get());
+    ps = std::make_unique<PostScriptWriteWrapper>(orcPostScript);
+  }
   const auto footerLength = writerSink_->size() - pos;
 
   // write postscript
   pos = writerSink_->size();
-  auto dwrfPostScript = ArenaCreate<proto::PostScript>(arena_.get());
-  std::unique_ptr<PostScriptWriteWrapper> ps =
-      std::make_unique<PostScriptWriteWrapper>(dwrfPostScript);
   ps->setWriterVersion(writerVersion);
+  ps->addVersion(0);
+  ps->addVersion(12);
   ps->setFooterLength(footerLength);
   ps->setCompression(context_->compression());
   if (context_->compression() !=
@@ -80,8 +91,7 @@ void WriterBase::writeFooter(const Type& type) {
     ps->setCompressionBlockSize(context_->compressionBlockSize());
   }
 
-  ps->setCacheMode(writerSink_->getCacheMode());
-  ps->setCacheSize(cacheSize);
+  ps->setMetaDataLength(0);
   writeProto(ps, common::CompressionKind::CompressionKind_NONE);
   auto psLength = writerSink_->size() - pos;
   DWIO_ENSURE_LE(psLength, 0xff, "PostScript is too large: ", psLength);

--- a/velox/dwio/dwrf/writer/WriterBase.h
+++ b/velox/dwio/dwrf/writer/WriterBase.h
@@ -32,8 +32,11 @@ using dwio::common::ArenaCreate;
 
 class WriterBase {
  public:
-  explicit WriterBase(std::unique_ptr<dwio::common::FileSink> sink)
+  explicit WriterBase(
+      std::unique_ptr<dwio::common::FileSink> sink,
+      DwrfFormat format = DwrfFormat::kDwrf)
       : sink_{std::move(sink)},
+        format_{format},
         arena_(std::make_unique<google::protobuf::Arena>()) {
     VELOX_CHECK_NOT_NULL(sink_);
   }
@@ -103,13 +106,20 @@ class WriterBase {
         sessionTimezone,
         adjustTimestampToTimezone,
         std::move(handler),
-        memoryBudget);
+        memoryBudget,
+        format_);
     writerSink_ = std::make_unique<WriterSink>(
         *sink_,
         context_->getMemoryPool(MemoryUsageCategory::OUTPUT_STREAM),
-        context_->getConfigs());
-    auto dwrfFooter_ = ArenaCreate<proto::Footer>(arena_.get());
-    footer_ = std::make_unique<FooterWriteWrapper>(dwrfFooter_);
+        context_->getConfigs(),
+        format_);
+    if (format_ == DwrfFormat::kDwrf) {
+      auto dwrfFooter = ArenaCreate<proto::Footer>(arena_.get());
+      footer_ = std::make_unique<FooterWriteWrapper>(dwrfFooter);
+    } else {
+      auto orcFooter = ArenaCreate<proto::orc::Footer>(arena_.get());
+      footer_ = std::make_unique<FooterWriteWrapper>(orcFooter);
+    }
   }
 
   void initBuffers();
@@ -193,6 +203,7 @@ class WriterBase {
   std::unique_ptr<dwio::common::FileSink> sink_;
   std::unique_ptr<WriterSink> writerSink_;
   std::unique_ptr<FooterWriteWrapper> footer_;
+  const DwrfFormat format_;
   proto::orc::Metadata metadata_;
   std::unordered_map<std::string, std::string> userMetadata_;
   std::unordered_map<uint32_t, std::vector<std::pair<std::string, std::string>>>

--- a/velox/dwio/dwrf/writer/WriterContext.cpp
+++ b/velox/dwio/dwrf/writer/WriterContext.cpp
@@ -30,8 +30,10 @@ WriterContext::WriterContext(
     const tz::TimeZone* sessionTimezone,
     const bool adjustTimestampToTimezone,
     std::unique_ptr<encryption::EncryptionHandler> handler,
-    int64_t memoryBudget)
+    int64_t memoryBudget,
+    DwrfFormat format)
     : config_{config},
+      format_{format},
       pool_{std::move(pool)},
       memoryBudget_{memoryBudget},
       dictionaryPool_{

--- a/velox/dwio/dwrf/writer/WriterContext.h
+++ b/velox/dwio/dwrf/writer/WriterContext.h
@@ -48,7 +48,8 @@ class WriterContext : public CompressionBufferPool {
       const tz::TimeZone* sessionTimezone = nullptr,
       const bool adjustTimestampToTimezone = false,
       std::unique_ptr<encryption::EncryptionHandler> handler = nullptr,
-      int64_t memoryBudget = std::numeric_limits<int64_t>::max());
+      int64_t memoryBudget = std::numeric_limits<int64_t>::max(),
+      DwrfFormat format = DwrfFormat::kDwrf);
 
   ~WriterContext() override;
 
@@ -142,7 +143,7 @@ class WriterContext : public CompressionBufferPool {
       std::unique_ptr<BufferedOutputStream> stream) const {
     return indexBuilderFactory_
         ? indexBuilderFactory_(std::move(stream))
-        : std::make_unique<IndexBuilder>(std::move(stream));
+        : std::make_unique<IndexBuilder>(std::move(stream), format_);
   }
 
   void suppressStream(const DwrfStreamIdentifier& stream) {
@@ -391,6 +392,10 @@ class WriterContext : public CompressionBufferPool {
     return compression_;
   }
 
+  DwrfFormat format() const {
+    return format_;
+  }
+
   uint64_t compressionBlockSize() const {
     return compressionBlockSize_;
   }
@@ -623,6 +628,7 @@ class WriterContext : public CompressionBufferPool {
   }
 
   const std::shared_ptr<const Config> config_;
+  const DwrfFormat format_;
   const std::shared_ptr<memory::MemoryPool> pool_;
   const int64_t memoryBudget_;
   const std::shared_ptr<memory::MemoryPool> dictionaryPool_;

--- a/velox/dwio/dwrf/writer/WriterSink.h
+++ b/velox/dwio/dwrf/writer/WriterSink.h
@@ -39,11 +39,16 @@ class WriterSink {
   WriterSink(
       dwio::common::FileSink& sink,
       memory::MemoryPool& pool,
-      const Config& configs)
+      const Config& configs,
+      DwrfFormat format = DwrfFormat::kDwrf)
       : sink_{&sink},
         checksum_{
-            ChecksumFactory::create(configs.get(Config::CHECKSUM_ALGORITHM))},
-        cacheMode_{configs.get(Config::STRIPE_CACHE_MODE)},
+            format == DwrfFormat::kDwrf ? ChecksumFactory::create(configs.get(
+                                              Config::CHECKSUM_ALGORITHM))
+                                        : nullptr},
+        cacheMode_{
+            format == DwrfFormat::kDwrf ? configs.get(Config::STRIPE_CACHE_MODE)
+                                        : StripeCacheMode::NA},
         shouldBuffer_{!sink_->isBuffered()},
         maxCacheSize_{configs.get(Config::STRIPE_CACHE_SIZE)},
         mode_{Mode::None},


### PR DESCRIPTION
The DWRF writer has most of the ORC implementation, but it was not completed end to end and didn't created standard readable ORC files.
The DWRF Writer options had a kOrc format, but the top level writer ignored it.

- It always created DWRF metadata, and everything else followed dWRF behaviour
- Nested column writers lost oRC settings
- integer columns used DWRF representiation