### PR TITLE
fix(exec): Surface requested cancel as OperationCancelled (#18222)

### DIFF
--- a/velox/exec/Cursor.cpp
+++ b/velox/exec/Cursor.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/exec/Cursor.h"
 
+#include <folly/OperationCancelled.h>
 #include <folly/system/HardwareConcurrency.h>
 #include <filesystem>
 #include <optional>
@@ -499,6 +500,13 @@ class MultiThreadedTaskCursor : public TaskCursorBase {
     // Wait for all task drivers to finish to avoid destroying the executor_
     // before task_ finished using it and causing a crash.
     waitForTaskDriversToFinish(task_.get());
+    // A requested cancellation is not a query failure: surface it as
+    // cooperative cancellation (folly::OperationCancelled) so callers can tell
+    // a user/deadline stop apart from a genuine error. kAborted keeps its
+    // error.
+    if (task_->state() == TaskState::kCanceled) {
+      throw folly::OperationCancelled{};
+    }
     std::rethrow_exception(task_->error());
   }
 
@@ -580,6 +588,11 @@ class SingleThreadedTaskCursor : public TaskCursorBase {
         // an async caller can distinguish a terminated task from end-of-stream
         // (matches the parallel cursor's checkTaskError() behavior).
         if (auto error = task_->error()) {
+          // A requested cancellation surfaces as cooperative cancellation, not
+          // a query failure; kAborted keeps its error.
+          if (task_->state() == TaskState::kCanceled) {
+            throw folly::OperationCancelled{};
+          }
           std::rethrow_exception(error);
         }
         return false;

--- a/velox/exec/tests/CursorTest.cpp
+++ b/velox/exec/tests/CursorTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/exec/Cursor.h"
+#include <folly/OperationCancelled.h>
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
@@ -126,27 +127,29 @@ TEST_F(CursorTest, asyncDrainParallelMultipleProducers) {
   EXPECT_EQ(drainAsync(*cursor), kNumDrivers * kRowsPerDriver);
 }
 
-// After the task is cancelled, the parallel cursor surfaces the error from
-// moveNext() rather than returning data. requestCancel().wait() makes the
-// terminal state deterministic before we pull.
+// After the task is cancelled, the parallel cursor surfaces cooperative
+// cancellation (folly::OperationCancelled) from moveNext() rather than
+// returning data. requestCancel().wait() makes the terminal state deterministic
+// before we pull.
 TEST_F(CursorTest, cancelSurfacesErrorParallel) {
   auto cursor = TaskCursor::create(makeParams(/*serialExecution=*/false));
   cursor->start();
   cursor->task()->requestCancel().wait();
 
   ContinueFuture future = ContinueFuture::makeEmpty();
-  VELOX_ASSERT_THROW(cursor->moveNext(&future), "Cancelled");
+  EXPECT_THROW(cursor->moveNext(&future), folly::OperationCancelled);
 }
 
-// The serial cursor surfaces the cancellation error too, rather than reporting
-// a terminated task as end-of-stream (false with an invalid future).
+// The serial cursor surfaces cancellation as folly::OperationCancelled too,
+// rather than reporting a terminated task as end-of-stream (false with an
+// invalid future).
 TEST_F(CursorTest, cancelSurfacesErrorSerial) {
   auto cursor = TaskCursor::create(makeParams(/*serialExecution=*/true));
   cursor->start();
   cursor->task()->requestCancel().wait();
 
   ContinueFuture future = ContinueFuture::makeEmpty();
-  VELOX_ASSERT_THROW(cursor->moveNext(&future), "Cancelled");
+  EXPECT_THROW(cursor->moveNext(&future), folly::OperationCancelled);
 }
 
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/DriverTest.cpp
+++ b/velox/exec/tests/DriverTest.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <folly/OperationCancelled.h>
 #include <folly/Unit.h>
 #include <folly/init/Init.h>
 #include <velox/exec/Driver.h>
@@ -491,8 +492,9 @@ TEST_F(DriverTest, cancel) {
   try {
     readResults(params, ResultOperation::kCancel, 1'000'000, &numRead);
     FAIL() << "Expected exception";
-  } catch (const VeloxRuntimeError& e) {
-    EXPECT_EQ("Cancelled", e.message());
+  } catch (const folly::OperationCancelled&) {
+    // A requested cancel now surfaces as cooperative cancellation, not a
+    // VeloxRuntimeError.
   }
   EXPECT_GE(numRead, 1'000'000);
   auto& executor = folly::QueuedImmediateExecutor::instance();

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -17,6 +17,7 @@
 #include <shared_mutex>
 
 #include <fmt/ranges.h>
+#include <folly/OperationCancelled.h>
 #include <folly/synchronization/Baton.h>
 #include <folly/synchronization/EventCount.h>
 #include <folly/synchronization/Latch.h>
@@ -6126,11 +6127,11 @@ DEBUG_ONLY_TEST_F(TableScanTest, cancellationToken) {
   std::thread queryThread([&]() {
     auto split = makeHiveConnectorSplit(
         filePath->getPath(), 0, fs::file_size(filePath->getPath()));
-    VELOX_ASSERT_THROW(
+    EXPECT_THROW(
         AssertQueryBuilder(tableScanNode(), duckDbQueryRunner_)
             .split(std::move(split))
             .assertResults("SELECT * FROM tmp"),
-        "Cancelled");
+        folly::OperationCancelled);
     waitForAllTasksToBeDeleted();
   });
 

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/exec/Task.h"
+#include "folly/OperationCancelled.h"
 #include "folly/synchronization/EventCount.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/tests/FaultyFileSystem.h"
@@ -1873,7 +1874,11 @@ class TaskPauseTest : public TaskTest {
       try {
         while (cursor_->moveNext()) {
         };
-      } catch (VeloxRuntimeError&) {
+      } catch (const VeloxRuntimeError&) {
+        // Task errored.
+      } catch (const folly::OperationCancelled&) {
+        // Task cancelled: requestCancel() now surfaces cooperative
+        // cancellation.
       }
     });
 


### PR DESCRIPTION
Summary:

TaskCursor::moveNext() rethrows task_->error() when a task terminates. For a requested cancellation (Task::requestCancel(), which moves the task to kCanceled), Task::terminate() fabricates a VeloxRuntimeError("Cancelled") shaped exactly like a genuine query failure. A caller cannot tell a user or deadline stop apart from a real error without matching on message text.

Surface a requested cancel as folly::OperationCancelled from both cursor paths (the parallel checkTaskError() and the serial moveNext()), so cooperative cancellation is distinguishable by exception type. kAborted keeps its error: it is an external-error abort, not a user cancel.

Reviewed By: xiaoxmeng

Differential Revision: D113099640


