### PR TITLE
fix(spill): Register named Presto serde in spill benchmarks (#18223)

### DIFF
--- a/velox/exec/tests/AggregateSpillBenchmarkBase.h
+++ b/velox/exec/tests/AggregateSpillBenchmarkBase.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#pragma once
+
 #include "velox/exec/tests/SpillerBenchmarkBase.h"
 
 namespace facebook::velox::exec::test {

--- a/velox/exec/tests/JoinSpillInputBenchmarkBase.h
+++ b/velox/exec/tests/JoinSpillInputBenchmarkBase.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#pragma once
+
 #include "velox/exec/tests/SpillerBenchmarkBase.h"
 
 namespace facebook::velox::exec::test {

--- a/velox/exec/tests/SpillBenchmarkSmokeTest.cpp
+++ b/velox/exec/tests/SpillBenchmarkSmokeTest.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gflags/gflags.h>
+#include <gtest/gtest.h>
+
+#include "velox/common/file/FileSystems.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/exec/GroupingSet.h"
+#include "velox/exec/tests/AggregateSpillBenchmarkBase.h"
+#include "velox/exec/tests/JoinSpillInputBenchmarkBase.h"
+
+// The spiller_benchmark_* flags set below are declared in
+// SpillerBenchmarkBase.h (included transitively) and defined in
+// SpillerBenchmarkBase.cpp.
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec::test;
+
+namespace {
+
+// Smoke test that exercises the spill benchmarks' code path end to end with a
+// tiny workload so they are built and run in CI. The benchmarks themselves are
+// cpp_binary targets CI never builds, so a regression in the spill path -- most
+// notably the named-serde registration (getNamedVectorSerde("Presto") in
+// SpillWriter/SpillReadFile) -- would otherwise only surface on a manual run.
+//
+// Crucially this fixture does NOT derive from OperatorTestBase: that base
+// registers the named Presto serde itself in SetUp(), which would mask a
+// regression in SpillerBenchmarkBase::registerSerde() and make this test pass
+// even if the fix were reverted. Instead we register serdes through the exact
+// same shared entry point the benchmark mains use, so dropping the named-serde
+// registration fails this test.
+class SpillBenchmarkSmokeTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    if (!memory::MemoryManager::testInstance()) {
+      memory::MemoryManager::initialize(memory::MemoryManager::Options{});
+    }
+    filesystems::registerLocalFileSystem();
+    SpillerBenchmarkBase::registerSerde();
+  }
+
+  void SetUp() override {
+    FLAGS_spiller_benchmark_num_spill_vectors = 4;
+    FLAGS_spiller_benchmark_spill_vector_size = 16;
+    FLAGS_spiller_benchmark_spill_executor_size = 1;
+  }
+};
+
+TEST_F(SpillBenchmarkSmokeTest, aggregateInput) {
+  const std::string spillerType{exec::AggregationInputSpiller::kType};
+  AggregateSpillBenchmarkBase benchmark(spillerType);
+  // The whole point is that the spill path runs without throwing (in particular
+  // the named-serde lookup in SpillWriter); assert it explicitly.
+  ASSERT_NO_THROW(benchmark.setUp());
+  ASSERT_NO_THROW(benchmark.run());
+  ASSERT_NO_THROW(benchmark.cleanup());
+}
+
+TEST_F(SpillBenchmarkSmokeTest, joinInput) {
+  JoinSpillInputBenchmarkBase benchmark;
+  ASSERT_NO_THROW(benchmark.setUp());
+  ASSERT_NO_THROW(benchmark.run());
+  ASSERT_NO_THROW(benchmark.cleanup());
+}
+
+} // namespace

--- a/velox/exec/tests/SpillerAggregateBenchmarkTest.cpp
+++ b/velox/exec/tests/SpillerAggregateBenchmarkTest.cpp
@@ -16,7 +16,6 @@
 
 #include "velox/exec/GroupingSet.h"
 #include "velox/exec/tests/AggregateSpillBenchmarkBase.h"
-#include "velox/serializers/PrestoSerializer.h"
 
 #include <gflags/gflags.h>
 
@@ -26,7 +25,7 @@ using namespace facebook::velox::exec;
 int main(int argc, char* argv[]) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   memory::MemoryManager::initialize(memory::MemoryManager::Options{});
-  serializer::presto::PrestoVectorSerde::registerVectorSerde();
+  exec::test::SpillerBenchmarkBase::registerSerde();
   filesystems::registerLocalFileSystem();
 
   auto spillerType = FLAGS_spiller_benchmark_spiller_type;

--- a/velox/exec/tests/SpillerBenchmarkBase.cpp
+++ b/velox/exec/tests/SpillerBenchmarkBase.cpp
@@ -27,6 +27,8 @@
 #include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/exec/Spiller.h"
 #include "velox/exec/tests/SpillerBenchmarkBase.h"
+#include "velox/serializers/PrestoSerializer.h"
+#include "velox/vector/VectorStream.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 
 DEFINE_string(
@@ -80,6 +82,18 @@ using namespace facebook::velox::memory;
 
 namespace facebook::velox::exec::test {
 using namespace facebook::velox::common::testutil;
+
+// static. See header for the rationale (the named serde is what the spill path
+// looks up); keep both registrations here so a revert is caught by the smoke
+// test.
+void SpillerBenchmarkBase::registerSerde() {
+  if (!isRegisteredVectorSerde()) {
+    serializer::presto::PrestoVectorSerde::registerVectorSerde();
+  }
+  if (!isRegisteredNamedVectorSerde("Presto")) {
+    serializer::presto::PrestoVectorSerde::registerNamedVectorSerde();
+  }
+}
 
 void SpillerBenchmarkBase::setUp() {
   rootPool_ =

--- a/velox/exec/tests/SpillerBenchmarkBase.h
+++ b/velox/exec/tests/SpillerBenchmarkBase.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#pragma once
+
 #include <gflags/gflags.h>
 
 #include <folly/executors/IOThreadPoolExecutor.h>
@@ -45,6 +47,14 @@ class SpillerBenchmarkBase {
   SpillerBenchmarkBase() = default;
 
   virtual ~SpillerBenchmarkBase() = default;
+
+  /// Registers the vector serdes the spill path depends on: the global default
+  /// Presto serde and, critically, the *named* "Presto" serde that
+  /// SpillWriter/SpillReadFile look up via getNamedVectorSerde(). Both the
+  /// benchmark mains and the CI smoke test call this so the registration is
+  /// exercised in CI and a regression fails a test instead of a manual run.
+  /// Idempotent: safe to call more than once.
+  static void registerSerde();
 
   /// Sets up the test.
   virtual void setUp() = 0;

--- a/velox/exec/tests/SpillerJoinInputBenchmarkTest.cpp
+++ b/velox/exec/tests/SpillerJoinInputBenchmarkTest.cpp
@@ -15,7 +15,6 @@
  */
 
 #include <gflags/gflags.h>
-#include "velox/serializers/PrestoSerializer.h"
 
 #include "velox/exec/tests/JoinSpillInputBenchmarkBase.h"
 
@@ -24,7 +23,7 @@ using namespace facebook::velox;
 int main(int argc, char* argv[]) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   memory::MemoryManager::initialize(memory::MemoryManager::Options{});
-  serializer::presto::PrestoVectorSerde::registerVectorSerde();
+  exec::test::SpillerBenchmarkBase::registerSerde();
   filesystems::registerLocalFileSystem();
   auto test = std::make_unique<exec::test::JoinSpillInputBenchmarkBase>();
   test->setUp();


### PR DESCRIPTION
Summary:

The spill benchmarks (spiller_aggregation_benchmark, spiller_join_input_benchmark)
crash immediately with "Named vector serde 'Presto' is not registered." Their
mains call PrestoVectorSerde::registerVectorSerde() (the global default serde),
but the spill path (SpillFile.cpp SpillWriter/SpillReadFile) looks the serde up
via getNamedVectorSerde("Presto"), which requires the NAMED registry. Add
registerNamedVectorSerde() to both benchmark mains so they run.

Reviewed By: Yuhta

Differential Revision: D113139096


