### PR TITLE
fix(cudf): Fix NLJ mismatch emission when no probe/build columns in output

### DIFF
--- a/velox/experimental/cudf/exec/CudfNestedLoopJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfNestedLoopJoin.cpp
@@ -39,7 +39,6 @@
 #include <cudf/scalar/scalar_factories.hpp>
 #include <cudf/search.hpp>
 #include <cudf/stream_compaction.hpp>
-#include <cudf/unary.hpp>
 
 namespace facebook::velox::cudf_velox {
 
@@ -708,23 +707,16 @@ std::unique_ptr<cudf::table> CudfNestedLoopJoinProbe::emitProbeMismatchRows(
           probeGatherView, stream, get_output_mr());
     }
   } else {
-    auto unmatchedMask = cudf::unary_operation(
-        probeMatchedFlags_->view(),
-        cudf::unary_operator::NOT,
-        stream,
-        get_temp_mr());
+    auto matchedMask = probeMatchedFlags_->view();
     if (!probeColumnIndicesToGather_.empty()) {
       auto probeGatherView = probeTableView.select(probeColumnIndicesToGather_);
-      unmatchedProbe = cudf::apply_boolean_mask(
-          probeGatherView, unmatchedMask->view(), stream, get_output_mr());
+      unmatchedProbe = cudf::apply_deletion_mask(
+          probeGatherView, matchedMask, stream, get_output_mr());
       numUnmatched = static_cast<cudf::size_type>(unmatchedProbe->num_rows());
     } else {
       // No probe columns in output — count unmatched rows from the mask.
-      auto countTable = cudf::apply_boolean_mask(
-          cudf::table_view{{unmatchedMask->view()}},
-          unmatchedMask->view(),
-          stream,
-          get_temp_mr());
+      auto countTable = cudf::apply_deletion_mask(
+          cudf::table_view{{matchedMask}}, matchedMask, stream, get_temp_mr());
       numUnmatched = static_cast<cudf::size_type>(countTable->num_rows());
     }
   }
@@ -770,29 +762,20 @@ RowVectorPtr CudfNestedLoopJoinProbe::emitBuildMismatchRows(
   auto& buildTable = buildData_.value();
   auto numOutputColumns = outputType_->size();
 
-  // Invert flags: unmatched = NOT(matched).
-  auto unmatchedMask = cudf::unary_operation(
-      buildMatchedFlags_->view(),
-      cudf::unary_operator::NOT,
-      stream,
-      get_temp_mr());
-
-  // Select unmatched build rows.
+  // Select unmatched build rows (deletion mask removes matched rows).
+  auto matchedMask = buildMatchedFlags_->view();
   cudf::size_type numUnmatched;
   std::unique_ptr<cudf::table> unmatchedBuild;
   if (!buildColumnIndicesToGather_.empty()) {
     auto buildGatherView =
         buildTable->view().select(buildColumnIndicesToGather_);
-    unmatchedBuild = cudf::apply_boolean_mask(
-        buildGatherView, unmatchedMask->view(), stream, get_output_mr());
+    unmatchedBuild = cudf::apply_deletion_mask(
+        buildGatherView, matchedMask, stream, get_output_mr());
     numUnmatched = static_cast<cudf::size_type>(unmatchedBuild->num_rows());
   } else {
     // No build columns in output — count unmatched rows from the mask.
-    auto countTable = cudf::apply_boolean_mask(
-        cudf::table_view{{unmatchedMask->view()}},
-        unmatchedMask->view(),
-        stream,
-        get_temp_mr());
+    auto countTable = cudf::apply_deletion_mask(
+        cudf::table_view{{matchedMask}}, matchedMask, stream, get_temp_mr());
     numUnmatched = static_cast<cudf::size_type>(countTable->num_rows());
   }
 

--- a/velox/experimental/cudf/exec/CudfNestedLoopJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfNestedLoopJoin.cpp
@@ -696,24 +696,43 @@ std::unique_ptr<cudf::table> CudfNestedLoopJoinProbe::joinWithBuildBatch(
 std::unique_ptr<cudf::table> CudfNestedLoopJoinProbe::emitProbeMismatchRows(
     cudf::table_view probeTableView,
     rmm::cuda_stream_view stream) {
-  auto probeGatherView = probeTableView.select(probeColumnIndicesToGather_);
-
+  cudf::size_type numUnmatched;
   std::unique_ptr<cudf::table> unmatchedProbe;
+
   if (!probeMatchedFlags_) {
     // No flags means all probe rows are unmatched (empty build case).
-    unmatchedProbe =
-        std::make_unique<cudf::table>(probeGatherView, stream, get_output_mr());
+    numUnmatched = static_cast<cudf::size_type>(probeTableView.num_rows());
+    if (!probeColumnIndicesToGather_.empty()) {
+      auto probeGatherView =
+          probeTableView.select(probeColumnIndicesToGather_);
+      unmatchedProbe = std::make_unique<cudf::table>(
+          probeGatherView, stream, get_output_mr());
+    }
   } else {
     auto unmatchedMask = cudf::unary_operation(
         probeMatchedFlags_->view(),
         cudf::unary_operator::NOT,
         stream,
         get_temp_mr());
-    unmatchedProbe = cudf::apply_boolean_mask(
-        probeGatherView, unmatchedMask->view(), stream, get_output_mr());
+    if (!probeColumnIndicesToGather_.empty()) {
+      auto probeGatherView =
+          probeTableView.select(probeColumnIndicesToGather_);
+      unmatchedProbe = cudf::apply_boolean_mask(
+          probeGatherView, unmatchedMask->view(), stream, get_output_mr());
+      numUnmatched =
+          static_cast<cudf::size_type>(unmatchedProbe->num_rows());
+    } else {
+      // No probe columns in output — count unmatched rows from the mask.
+      auto countTable = cudf::apply_boolean_mask(
+          cudf::table_view{{unmatchedMask->view()}},
+          unmatchedMask->view(),
+          stream,
+          get_temp_mr());
+      numUnmatched =
+          static_cast<cudf::size_type>(countTable->num_rows());
+    }
   }
 
-  auto numUnmatched = static_cast<cudf::size_type>(unmatchedProbe->num_rows());
   if (numUnmatched == 0) {
     return nullptr;
   }
@@ -722,9 +741,11 @@ std::unique_ptr<cudf::table> CudfNestedLoopJoinProbe::emitProbeMismatchRows(
   std::vector<std::unique_ptr<cudf::column>> outCols(numOutputColumns);
 
   // Place unmatched probe columns at their output positions.
-  auto probeCols = unmatchedProbe->release();
-  for (size_t i = 0; i < probeColumnOutputIndices_.size(); ++i) {
-    outCols[probeColumnOutputIndices_[i]] = std::move(probeCols[i]);
+  if (unmatchedProbe) {
+    auto probeCols = unmatchedProbe->release();
+    for (size_t i = 0; i < probeColumnOutputIndices_.size(); ++i) {
+      outCols[probeColumnOutputIndices_[i]] = std::move(probeCols[i]);
+    }
   }
 
   // Create all-null columns for the build side.
@@ -761,10 +782,25 @@ RowVectorPtr CudfNestedLoopJoinProbe::emitBuildMismatchRows(
       get_temp_mr());
 
   // Select unmatched build rows.
-  auto buildGatherView = buildTable->view().select(buildColumnIndicesToGather_);
-  auto unmatchedBuild = cudf::apply_boolean_mask(
-      buildGatherView, unmatchedMask->view(), stream, get_output_mr());
-  auto numUnmatched = static_cast<cudf::size_type>(unmatchedBuild->num_rows());
+  cudf::size_type numUnmatched;
+  std::unique_ptr<cudf::table> unmatchedBuild;
+  if (!buildColumnIndicesToGather_.empty()) {
+    auto buildGatherView =
+        buildTable->view().select(buildColumnIndicesToGather_);
+    unmatchedBuild = cudf::apply_boolean_mask(
+        buildGatherView, unmatchedMask->view(), stream, get_output_mr());
+    numUnmatched =
+        static_cast<cudf::size_type>(unmatchedBuild->num_rows());
+  } else {
+    // No build columns in output — count unmatched rows from the mask.
+    auto countTable = cudf::apply_boolean_mask(
+        cudf::table_view{{unmatchedMask->view()}},
+        unmatchedMask->view(),
+        stream,
+        get_temp_mr());
+    numUnmatched =
+        static_cast<cudf::size_type>(countTable->num_rows());
+  }
 
   finished_ = true;
   if (numUnmatched == 0) {
@@ -786,9 +822,11 @@ RowVectorPtr CudfNestedLoopJoinProbe::emitBuildMismatchRows(
   }
 
   // Place unmatched build columns at their output positions.
-  auto buildCols = unmatchedBuild->release();
-  for (size_t ri = 0; ri < buildColumnOutputIndices_.size(); ++ri) {
-    outCols[buildColumnOutputIndices_[ri]] = std::move(buildCols[ri]);
+  if (unmatchedBuild) {
+    auto buildCols = unmatchedBuild->release();
+    for (size_t ri = 0; ri < buildColumnOutputIndices_.size(); ++ri) {
+      outCols[buildColumnOutputIndices_[ri]] = std::move(buildCols[ri]);
+    }
   }
 
   auto out = std::make_unique<cudf::table>(std::move(outCols));

--- a/velox/experimental/cudf/exec/CudfNestedLoopJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfNestedLoopJoin.cpp
@@ -703,8 +703,7 @@ std::unique_ptr<cudf::table> CudfNestedLoopJoinProbe::emitProbeMismatchRows(
     // No flags means all probe rows are unmatched (empty build case).
     numUnmatched = static_cast<cudf::size_type>(probeTableView.num_rows());
     if (!probeColumnIndicesToGather_.empty()) {
-      auto probeGatherView =
-          probeTableView.select(probeColumnIndicesToGather_);
+      auto probeGatherView = probeTableView.select(probeColumnIndicesToGather_);
       unmatchedProbe = std::make_unique<cudf::table>(
           probeGatherView, stream, get_output_mr());
     }
@@ -715,12 +714,10 @@ std::unique_ptr<cudf::table> CudfNestedLoopJoinProbe::emitProbeMismatchRows(
         stream,
         get_temp_mr());
     if (!probeColumnIndicesToGather_.empty()) {
-      auto probeGatherView =
-          probeTableView.select(probeColumnIndicesToGather_);
+      auto probeGatherView = probeTableView.select(probeColumnIndicesToGather_);
       unmatchedProbe = cudf::apply_boolean_mask(
           probeGatherView, unmatchedMask->view(), stream, get_output_mr());
-      numUnmatched =
-          static_cast<cudf::size_type>(unmatchedProbe->num_rows());
+      numUnmatched = static_cast<cudf::size_type>(unmatchedProbe->num_rows());
     } else {
       // No probe columns in output — count unmatched rows from the mask.
       auto countTable = cudf::apply_boolean_mask(
@@ -728,8 +725,7 @@ std::unique_ptr<cudf::table> CudfNestedLoopJoinProbe::emitProbeMismatchRows(
           unmatchedMask->view(),
           stream,
           get_temp_mr());
-      numUnmatched =
-          static_cast<cudf::size_type>(countTable->num_rows());
+      numUnmatched = static_cast<cudf::size_type>(countTable->num_rows());
     }
   }
 
@@ -789,8 +785,7 @@ RowVectorPtr CudfNestedLoopJoinProbe::emitBuildMismatchRows(
         buildTable->view().select(buildColumnIndicesToGather_);
     unmatchedBuild = cudf::apply_boolean_mask(
         buildGatherView, unmatchedMask->view(), stream, get_output_mr());
-    numUnmatched =
-        static_cast<cudf::size_type>(unmatchedBuild->num_rows());
+    numUnmatched = static_cast<cudf::size_type>(unmatchedBuild->num_rows());
   } else {
     // No build columns in output — count unmatched rows from the mask.
     auto countTable = cudf::apply_boolean_mask(
@@ -798,8 +793,7 @@ RowVectorPtr CudfNestedLoopJoinProbe::emitBuildMismatchRows(
         unmatchedMask->view(),
         stream,
         get_temp_mr());
-    numUnmatched =
-        static_cast<cudf::size_type>(countTable->num_rows());
+    numUnmatched = static_cast<cudf::size_type>(countTable->num_rows());
   }
 
   finished_ = true;

--- a/velox/experimental/cudf/tests/NestedLoopJoinTest.cpp
+++ b/velox/experimental/cudf/tests/NestedLoopJoinTest.cpp
@@ -1335,11 +1335,12 @@ TEST_F(CudfNestedLoopJoinTest, fullJoinMultiDriver) {
 // zero-column table returned 0 rows, silently dropping mismatch rows.
 TEST_F(CudfNestedLoopJoinTest, fullJoinOneSidedOutput) {
   auto probeVectors = makeRowVector(
-      {"p0", "p1"}, {makeFlatVector<int32_t>({1, 2, 3}),
-                      makeFlatVector<int32_t>({10, 20, 30})});
+      {"p0", "p1"},
+      {makeFlatVector<int32_t>({1, 2, 3}),
+       makeFlatVector<int32_t>({10, 20, 30})});
   auto buildVectors = makeRowVector(
-      {"b0", "b1"}, {makeFlatVector<int32_t>({2, 4}),
-                      makeFlatVector<int32_t>({200, 400})});
+      {"b0", "b1"},
+      {makeFlatVector<int32_t>({2, 4}), makeFlatVector<int32_t>({200, 400})});
 
   createDuckDbTable("t", {probeVectors});
   createDuckDbTable("u", {buildVectors});
@@ -1348,17 +1349,16 @@ TEST_F(CudfNestedLoopJoinTest, fullJoinOneSidedOutput) {
 
   // Output only probe columns — build mismatch rows should still appear
   // with null values for the probe columns.
-  auto probeOnlyPlan =
-      PlanBuilder(planNodeIdGenerator)
-          .values({probeVectors})
-          .nestedLoopJoin(
-              PlanBuilder(planNodeIdGenerator)
-                  .values({buildVectors})
-                  .planNode(),
-              "p0 = b0",
-              {"p0", "p1"},
-              core::JoinType::kFull)
-          .planNode();
+  auto probeOnlyPlan = PlanBuilder(planNodeIdGenerator)
+                           .values({probeVectors})
+                           .nestedLoopJoin(
+                               PlanBuilder(planNodeIdGenerator)
+                                   .values({buildVectors})
+                                   .planNode(),
+                               "p0 = b0",
+                               {"p0", "p1"},
+                               core::JoinType::kFull)
+                           .planNode();
 
   assertQuery(
       probeOnlyPlan,
@@ -1368,17 +1368,16 @@ TEST_F(CudfNestedLoopJoinTest, fullJoinOneSidedOutput) {
 
   // Output only build columns — probe mismatch rows should still appear
   // with null values for the build columns.
-  auto buildOnlyPlan =
-      PlanBuilder(planNodeIdGenerator)
-          .values({probeVectors})
-          .nestedLoopJoin(
-              PlanBuilder(planNodeIdGenerator)
-                  .values({buildVectors})
-                  .planNode(),
-              "p0 = b0",
-              {"b0", "b1"},
-              core::JoinType::kFull)
-          .planNode();
+  auto buildOnlyPlan = PlanBuilder(planNodeIdGenerator)
+                           .values({probeVectors})
+                           .nestedLoopJoin(
+                               PlanBuilder(planNodeIdGenerator)
+                                   .values({buildVectors})
+                                   .planNode(),
+                               "p0 = b0",
+                               {"b0", "b1"},
+                               core::JoinType::kFull)
+                           .planNode();
 
   assertQuery(
       buildOnlyPlan,

--- a/velox/experimental/cudf/tests/NestedLoopJoinTest.cpp
+++ b/velox/experimental/cudf/tests/NestedLoopJoinTest.cpp
@@ -1329,6 +1329,62 @@ TEST_F(CudfNestedLoopJoinTest, fullJoinMultiDriver) {
       "ON t.c0 < u.c0");
 }
 
+// Full join with output columns from only one side: exercises the mismatch
+// emission path when probeColumnIndicesToGather_ or
+// buildColumnIndicesToGather_ is empty. Previously, apply_boolean_mask on a
+// zero-column table returned 0 rows, silently dropping mismatch rows.
+TEST_F(CudfNestedLoopJoinTest, fullJoinOneSidedOutput) {
+  auto probeVectors = makeRowVector(
+      {"p0", "p1"}, {makeFlatVector<int32_t>({1, 2, 3}),
+                      makeFlatVector<int32_t>({10, 20, 30})});
+  auto buildVectors = makeRowVector(
+      {"b0", "b1"}, {makeFlatVector<int32_t>({2, 4}),
+                      makeFlatVector<int32_t>({200, 400})});
+
+  createDuckDbTable("t", {probeVectors});
+  createDuckDbTable("u", {buildVectors});
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+
+  // Output only probe columns — build mismatch rows should still appear
+  // with null values for the probe columns.
+  auto probeOnlyPlan =
+      PlanBuilder(planNodeIdGenerator)
+          .values({probeVectors})
+          .nestedLoopJoin(
+              PlanBuilder(planNodeIdGenerator)
+                  .values({buildVectors})
+                  .planNode(),
+              "p0 = b0",
+              {"p0", "p1"},
+              core::JoinType::kFull)
+          .planNode();
+
+  assertQuery(
+      probeOnlyPlan,
+      "SELECT t.p0, t.p1 FROM t FULL OUTER JOIN u ON t.p0 = u.b0");
+
+  planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+
+  // Output only build columns — probe mismatch rows should still appear
+  // with null values for the build columns.
+  auto buildOnlyPlan =
+      PlanBuilder(planNodeIdGenerator)
+          .values({probeVectors})
+          .nestedLoopJoin(
+              PlanBuilder(planNodeIdGenerator)
+                  .values({buildVectors})
+                  .planNode(),
+              "p0 = b0",
+              {"b0", "b1"},
+              core::JoinType::kFull)
+          .planNode();
+
+  assertQuery(
+      buildOnlyPlan,
+      "SELECT u.b0, u.b1 FROM t FULL OUTER JOIN u ON t.p0 = u.b0");
+}
+
 // --- LeftSemiProject join tests ---
 
 // LeftSemiProject with filter: probe rows + boolean match column.


### PR DESCRIPTION
### Summary
Fixes a bug in `CudfNestedLoopJoinProbe` where mismatch rows were silently dropped in left/right/full nested loop joins when the output projection included columns from only one side of the join.

### Problem
When mismatched rows in the build and probe tables are emitted, a boolean mask is applied on the gathered columns to both filter unmatched rows and determine the unmatched row count. When no probe (or build) columns appeared in the join output, the gather produced a zero-column table, and `apply_boolean_mask` on a zero-column table returned 0 rows — causing all mismatch rows to be silently dropped.
For example, a FULL OUTER JOIN outputting only build-side columns would lose all probe mismatch rows (which should appear as null-filled rows).

### Fix
Compute the unmatched row count from the boolean mask itself when the gather column set is empty, and guard column placement behind a null check on the gathered table.

### Test
Adds fullJoinOneSidedOutput test covering both directions:
- Output only probe columns — verifies build mismatch rows appear with null probe values
- Output only build columns — verifies probe mismatch rows appear with null build values