### PR TITLE
docs: Improve description of building requirement on CPUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,9 +248,12 @@ disable grouping on Linux, pass `-DVELOX_ENABLE_GROUPED_TESTS=OFF` via
 
 Note that,
 * Velox requires a compiler at the minimum GCC 11.0 or Clang 15.0.
-* On x86 CPUs, Velox requires BMI, BMI2, and F16C, and uses AVX, AVX2,
-  and SSE where available.
-* On Arm CPUs, Velox uses Neon and Neon64 where available.
+* On x86 CPUs, Velox requires at least SSE4.2. By default, Velox builds for
+  `CPU_TARGET=avx` on AVX-capable hosts, which requires AVX, AVX2, FMA, F16C,
+  LZCNT, and BMI2. To build for the minimum x86 baseline, set
+  `CPU_TARGET=sse`.
+* On Arm CPUs, Velox supports Apple Silicon with `CPU_TARGET=arm64` and Linux
+  AArch64 with `CPU_TARGET=aarch64`.
 
 Build metrics for Velox are published at <https://facebookincubator.github.io/velox/bm-report/>
 


### PR DESCRIPTION
The current doc says that x86 CPUs require BMI, BMI2, and F16C, which is too broad for Velox’s minimum supported x86 build. This updates that the minimum x86 requirement is SSE4.2, and documents that the default `CPU_TARGET=avx` build requires AVX, AVX2, FMA, F16C, LZCNT, and BMI2. And points users to `CPU_TARGET=sse`for the minimum x86 baseline.

The current Arm wording describes runtime SIMD usage, not the build requirement. Updated to describe the supported build targets: `CPU_TARGET=arm64` for Apple Silicon and `CPU_TARGET=aarch64` for Linux AArch64. 