### PR TITLE
fix(ci): Use official velox-dev image for adapters jobs

### DIFF
--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -105,7 +105,7 @@ jobs:
     # check prevents errors when forks fast-forward their main branch.
     if: ${{ github.repository == 'facebookincubator/velox' }}
     runs-on: 32-core-ubuntu
-    container: ghcr.io/czentgr/czentgr-test:thrift-deps
+    container: ghcr.io/facebookincubator/velox-dev:adapters
     defaults:
       run:
         shell: bash
@@ -892,7 +892,7 @@ jobs:
     if: ${{ inputs.is-full-mode && github.repository == 'facebookincubator/velox' }}
     runs-on: 32-core-ubuntu
     container:
-      image: ghcr.io/czentgr/czentgr-test:thrift-deps
+      image: ghcr.io/facebookincubator/velox-dev:adapters
       volumes:
         - /usr:/host_usr
         - /opt:/host_opt


### PR DESCRIPTION
Summary:
The `adapters` and `asan-ubsan-adapters` jobs in `linux-build-base.yml` were running against a personal container image, `ghcr.io/czentgr/czentgr-test:thrift-deps`, rather than the official `ghcr.io/facebookincubator/velox-dev:adapters`. The personal image was introduced in #16019 to validate the Apache Thrift to FBThrift migration and was never reverted after that PR merged.

Because the personal image is not built by the "Build & Push Docker Images" pipeline, it never picked up changes baked into the official image, such as the CMake 4.3.2 bump from #17637. The adapters builds have therefore been running on a stale toolchain. The official `velox-dev:adapters` image is rebuilt by the docker pipeline and already carries FBThrift support, so both jobs are pointed back at it.

Issue #18226 only calls out the `adapters` job; this change also fixes the same personal image reference in the `asan-ubsan-adapters` job.

Fixes #18226: https://github.com/facebookincubator/velox/issues/18226

Differential Revision: D113252797


