### PR TITLE
build(ci): Reject personal container images in workflows

### DIFF
--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -105,7 +105,7 @@ jobs:
     # check prevents errors when forks fast-forward their main branch.
     if: ${{ github.repository == 'facebookincubator/velox' }}
     runs-on: 32-core-ubuntu
-    container: ghcr.io/czentgr/czentgr-test:thrift-deps
+    container: ghcr.io/facebookincubator/velox-dev:adapters
     defaults:
       run:
         shell: bash
@@ -892,7 +892,7 @@ jobs:
     if: ${{ inputs.is-full-mode && github.repository == 'facebookincubator/velox' }}
     runs-on: 32-core-ubuntu
     container:
-      image: ghcr.io/czentgr/czentgr-test:thrift-deps
+      image: ghcr.io/facebookincubator/velox-dev:adapters
       volumes:
         - /usr:/host_usr
         - /opt:/host_opt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,6 +66,15 @@ repos:
         files: ^(README\.md|website/blog/.*)$
         pass_filenames: false
 
+      - id: check-workflow-images
+        name: check-workflow-images
+        description: >-
+          Workflow container images must use the official Velox namespace
+          (ghcr.io/facebookincubator/...), not personal or test images.
+        language: pygrep
+        files: ^\.github/workflows/.*\.yml$
+        entry: ^[ \t]*(?:container|image):[ \t]*["']?(?!\$\{\{)(?!ghcr\.io/facebookincubator/)\S
+
       - id: license-header
         name: license-header
         description: Add missing license headers.


### PR DESCRIPTION
Summary:
CI now fails if a GitHub Actions workflow references a container image outside the official Velox namespace (`ghcr.io/facebookincubator/`). This guards against regressions like the personal `ghcr.io/czentgr/czentgr-test:thrift-deps` image, which ran the adapters builds on a stale toolchain because it is not rebuilt by the "Build & Push Docker Images" pipeline.

The check is a `repo: local` pre-commit hook, `check-workflow-images`, using pre-commit's built-in `pygrep` language. Its regex flags any `container:`/`image:` value in `.github/workflows/*.yml` that is not under `ghcr.io/facebookincubator/`, while skipping the map-form `container:` parent and GitHub Actions expressions (`${{ ... }}`). It runs locally on commit and in CI through the existing pre-commit job in `preliminary_checks.yml`.

Related to https://github.com/facebookincubator/velox/issues/18226, which is fixed by the parent diff that restores the official image.

Differential Revision: D113259510


