### PR TITLE
build(ci): Install CMake 4.3.2 for adapters job

### DIFF
--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -165,6 +165,12 @@ jobs:
             rm -rf /tmp/build # cleanup to avoid issues with disk space
           fi
 
+      # TODO: Remove after the thrift-deps image includes CMake 4.3.2.
+      - name: Install Required CMake Version
+        run: |
+          UV_TOOL_BIN_DIR=/usr/local/bin uv tool install --force cmake@4.3.2
+          cmake --version
+
       - uses: apache/infrastructure-actions/stash/restore@3354c1565d4b0e335b78a76aedd82153a9e144d4
         with:
           path: ${{ env.CCACHE_DIR }}


### PR DESCRIPTION
## Summary

The adapters CI job uses a thrift-deps image containing CMake 3.31.1, while bundled cuDF now requires CMake 4.0 or newer. Install CMake 4.3.2 before the adapters build as a temporary workaround until the image is rebuilt.