### PR TITLE
refactor(memory): Remove unused capacityToString helper

### DIFF
--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -157,10 +157,6 @@ void treeMemoryUsageVisitor(
   });
 }
 
-std::string capacityToString(int64_t capacity) {
-  return capacity == kMaxMemory ? "UNLIMITED" : succinctBytes(capacity);
-}
-
 #define DEBUG_RECORD_ALLOC(pool, ...)         \
   if (FOLLY_UNLIKELY(pool->debugEnabled())) { \
     pool->recordAllocDbg(__VA_ARGS__);        \


### PR DESCRIPTION
The `capacityToString()` free function in MemoryPool.cpp no longer has any
callers. Remove the dead code.

No functional change.