### PR TITLE
fix(fuzzer): Raise open-writer cap in TableEvolutionFuzzer write tasks (#18237)

### DIFF
--- a/velox/exec/tests/TableEvolutionFuzzer.cpp
+++ b/velox/exec/tests/TableEvolutionFuzzer.cpp
@@ -15,9 +15,11 @@
  */
 
 #include "velox/exec/tests/TableEvolutionFuzzer.h"
+#include "velox/common/config/Config.h"
 #include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/connectors/hive/TableHandle.h"
+#include "velox/core/QueryCtx.h"
 #include "velox/dwio/common/tests/utils/FilterGenerator.h"
 #include "velox/dwio/dwrf/common/Config.h"
 #include "velox/exec/Cursor.h"
@@ -1305,6 +1307,17 @@ std::unique_ptr<TaskCursor> TableEvolutionFuzzer::makeWriteTask(
   CursorParameters params;
   params.serialExecution = true;
   params.planNode = builder.planNode();
+  // A bucketed write opens one writer per bucket, and generated setups can
+  // reach 2^8 buckets -- past the Hive connector's default 128 open-writer cap.
+  // Raise the cap so high-bucket-count setups exercise bucket conversion
+  // instead of failing with "Exceeded open writer limit".
+  params.queryCtx = core::QueryCtx::create(
+      /*executor=*/nullptr,
+      core::QueryConfig{{}},
+      {{std::string(PlanBuilder::kHiveDefaultConnectorId),
+        std::make_shared<config::ConfigBase>(
+            std::unordered_map<std::string, std::string>{
+                {"max_partitions_per_writers", "1024"}})}});
   return TaskCursor::create(params);
 }
 


### PR DESCRIPTION
Summary:

Bucketed writes open one writer per bucket, and generated setups can reach
2^8 = 256 buckets, exceeding the Hive connector's default 128 open-writer cap
(`max_partitions_per_writers`). Certain seeds (e.g. `1164430764`) therefore
failed with `VeloxUserError: Exceeded open writer limit (129 vs. 128)`.

Set `max_partitions_per_writers` to 1024 on the write task's `QueryCtx` so
high-bucket-count setups exercise bucket conversion instead of erroring. This
preserves large-bucket-count coverage (vs. clamping the generated count).

Reviewed By: xiaoxmeng

Differential Revision: D112782374


