### PR TITLE
fix(cudf): Gate Hive remaining filters for GPU scans

### DIFF
--- a/velox/experimental/cudf/connectors/hive/CudfHiveConnector.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveConnector.cpp
@@ -44,7 +44,8 @@ std::unique_ptr<DataSource> CudfHiveConnector::createDataSource(
   // TODO (dm): Make this ^^^ happen
   // Problem: this information is in split, not table handle
 
-  if (cudfIsRegistered()) {
+  if (cudfIsRegistered() &&
+      isCudfHiveDataSourceSupported(tableHandle, connectorQueryCtx)) {
     return std::make_unique<CudfHiveDataSource>(
         outputType,
         tableHandle,

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
@@ -41,6 +41,28 @@ namespace facebook::velox::cudf_velox::connector::hive {
 using namespace facebook::velox::connector;
 using namespace facebook::velox::connector::hive;
 
+bool isCudfHiveDataSourceSupported(
+    const ConnectorTableHandlePtr& tableHandle,
+    const ConnectorQueryCtx* connectorQueryCtx) {
+  VELOX_CHECK_NOT_NULL(connectorQueryCtx);
+
+  auto hiveTableHandle =
+      std::dynamic_pointer_cast<const HiveTableHandle>(tableHandle);
+  if (!hiveTableHandle) {
+    return false;
+  }
+
+  const auto& remainingFilter = hiveTableHandle->remainingFilter();
+  if (!remainingFilter) {
+    return true;
+  }
+
+  auto exprSet =
+      connectorQueryCtx->expressionEvaluator()->compile(remainingFilter);
+  return facebook::velox::cudf_velox::canBeEvaluatedByCudf(
+      exprSet->exprs(), connectorQueryCtx->adjustTimestampToTimezone());
+}
+
 CudfHiveDataSource::CudfHiveDataSource(
     const RowTypePtr& outputType,
     const ConnectorTableHandlePtr& tableHandle,

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.h
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.h
@@ -40,6 +40,13 @@ namespace facebook::velox::cudf_velox::connector::hive {
 
 using namespace facebook::velox::connector;
 
+/// Returns whether the table handle's remaining filter can be evaluated by the
+/// cuDF data source under the connector query's semantic configuration.
+/// Returns false for non-Hive table handles.
+bool isCudfHiveDataSourceSupported(
+    const ConnectorTableHandlePtr& tableHandle,
+    const ConnectorQueryCtx* connectorQueryCtx);
+
 class CudfHiveDataSource : public DataSource, public NvtxHelper {
  public:
   CudfHiveDataSource(

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergConnector.cpp
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergConnector.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/experimental/cudf/CudfNoDefaults.h"
+#include "velox/experimental/cudf/connectors/hive/CudfHiveDataSource.h"
 #include "velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergConnector.h"
 #include "velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergDataSource.h"
 #include "velox/experimental/cudf/exec/ToCudf.h"
@@ -61,7 +62,8 @@ std::unique_ptr<DataSource> CudfIcebergConnector::createDataSource(
     const ConnectorTableHandlePtr& tableHandle,
     const ColumnHandleMap& columnHandles,
     ConnectorQueryCtx* connectorQueryCtx) {
-  if (cudfIsRegistered()) {
+  if (cudfIsRegistered() &&
+      isCudfHiveDataSourceSupported(tableHandle, connectorQueryCtx)) {
     return std::make_unique<CudfIcebergDataSource>(
         outputType,
         tableHandle,

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergConnector.h
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergConnector.h
@@ -36,8 +36,9 @@ class CudfIcebergConnector final
       std::shared_ptr<const ConfigBase> config,
       folly::Executor* executor);
 
-  /// Creates a CudfIcebergDataSource when reading from Iceberg tables when cudf
-  /// is registered, otherwise falls back to the base IcebergDataSource.
+  /// Creates a CudfIcebergDataSource when cuDF is registered and the remaining
+  /// filter is eligible for cuDF evaluation. Otherwise, falls back to the base
+  /// IcebergDataSource.
   ///
   /// @param outputType The schema of the output data to read.
   /// @param tableHandle The table handle containing table metadata.

--- a/velox/experimental/cudf/exec/CudfFilterProject.cpp
+++ b/velox/experimental/cudf/exec/CudfFilterProject.cpp
@@ -20,7 +20,6 @@
 #include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/exec/Validation.h"
 #include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
-#include "velox/experimental/cudf/expression/DateTruncFunction.h"
 #include "velox/experimental/cudf/vector/CudfVector.h"
 
 #include "velox/common/memory/Memory.h"
@@ -51,28 +50,6 @@ void debugPrintTree(
   for (auto& input : expr->inputs()) {
     debugPrintTree(input, indent + 2, os);
   }
-}
-
-bool isTimezoneSensitiveDateTrunc(
-    const std::shared_ptr<velox::exec::Expr>& expr) {
-  const auto dateTruncName =
-      CudfConfig::getInstance().functionNamePrefix + "date_trunc";
-  return expr->name() == dateTruncName &&
-      DateTruncFunction::isTimezoneSensitive(expr);
-}
-
-bool containsTimezoneSensitiveDateTrunc(
-    const std::shared_ptr<velox::exec::Expr>& expr) {
-  if (isTimezoneSensitiveDateTrunc(expr)) {
-    return true;
-  }
-
-  for (const auto& input : expr->inputs()) {
-    if (containsTimezoneSensitiveDateTrunc(input)) {
-      return true;
-    }
-  }
-  return false;
 }
 
 bool checkAddIdentityProjection(
@@ -151,18 +128,7 @@ bool canBeEvaluatedByCudf(
   const bool adjustTimestampToTimezone =
       queryConfig.adjustTimestampToTimezone();
 
-  for (const auto& e : exprSet->exprs()) {
-    if (adjustTimestampToTimezone && containsTimezoneSensitiveDateTrunc(e)) {
-      LOG_FALLBACK(
-          "date_trunc(timestamp) requires CPU evaluation when "
-          "adjust_timestamp_to_session_timezone is enabled");
-      return false;
-    }
-    if (!canBeEvaluatedByCudf(e)) {
-      return false;
-    }
-  }
-  return true;
+  return canBeEvaluatedByCudf(exprSet->exprs(), adjustTimestampToTimezone);
 }
 
 CudfFilterProject::CudfFilterProject(

--- a/velox/experimental/cudf/exec/OperatorAdapters.cpp
+++ b/velox/experimental/cudf/exec/OperatorAdapters.cpp
@@ -40,6 +40,7 @@
 #include "velox/experimental/cudf/expression/ExpressionEvaluator.h"
 
 #include "velox/connectors/ConnectorRegistry.h"
+#include "velox/connectors/hive/TableHandle.h"
 #include "velox/exec/AssignUniqueId.h"
 #include "velox/exec/CallbackSink.h"
 #include "velox/exec/EnforceSingleRow.h"
@@ -107,7 +108,7 @@ class TableScanAdapter : public OperatorAdapter {
   bool canRunOnGPU(
       const exec::Operator* op,
       const core::PlanNodePtr& planNode,
-      exec::DriverCtx* /*ctx*/) const override {
+      exec::DriverCtx* ctx) const override {
     auto tableScanNode =
         std::dynamic_pointer_cast<const core::TableScanNode>(planNode);
     if (!tableScanNode) {
@@ -125,16 +126,33 @@ class TableScanAdapter : public OperatorAdapter {
         std::dynamic_pointer_cast<facebook::velox::cudf_velox::connector::hive::
                                       iceberg::CudfIcebergConnector>(connector);
 
-    bool canRunOnGPU =
-        cudfHiveConnector != nullptr or cudfIcebergConnector != nullptr;
-
-    if (!canRunOnGPU) {
+    if (cudfHiveConnector == nullptr && cudfIcebergConnector == nullptr) {
       LOG_FALLBACK(
           "TableScan connector is not CudfHiveConnector or CudfIcebergConnector, PlanNode id: {}",
           planNode->id());
+      return false;
     }
 
-    return canRunOnGPU;
+    auto hiveTableHandle = std::dynamic_pointer_cast<
+        const facebook::velox::connector::hive::HiveTableHandle>(
+        tableScanNode->tableHandle());
+    if (!hiveTableHandle) {
+      LOG_FALLBACK(
+          "TableScan table handle is not HiveTableHandle, PlanNode id: {}",
+          planNode->id());
+      return false;
+    }
+
+    const auto& remainingFilter = hiveTableHandle->remainingFilter();
+    if (remainingFilter &&
+        !canBeEvaluatedByCudf({remainingFilter}, ctx->task->queryCtx().get())) {
+      LOG_FALLBACK(
+          "TableScan remaining filter cannot be evaluated by cuDF, PlanNode id: {}",
+          planNode->id());
+      return false;
+    }
+
+    return true;
   }
 
   bool acceptsGpuInput() const override {

--- a/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
@@ -13,9 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/exec/Validation.h"
 #include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
 #include "velox/experimental/cudf/expression/AstUtils.h"
+#include "velox/experimental/cudf/expression/DateTruncFunction.h"
 #include "velox/experimental/cudf/expression/DecimalExpressionKernels.h"
 #include "velox/experimental/cudf/expression/ExpressionEvaluator.h"
 #include "velox/experimental/cudf/expression/NullMask.h"
@@ -2887,6 +2889,44 @@ bool canBeEvaluatedByCudf(std::shared_ptr<velox::exec::Expr> expr, bool deep) {
     }
   }
 
+  return true;
+}
+
+namespace {
+
+bool containsTimezoneSensitiveDateTrunc(
+    const std::shared_ptr<velox::exec::Expr>& expr) {
+  const auto dateTruncName =
+      CudfConfig::getInstance().functionNamePrefix + "date_trunc";
+  if (expr->name() == dateTruncName &&
+      DateTruncFunction::isTimezoneSensitive(expr)) {
+    return true;
+  }
+
+  for (const auto& input : expr->inputs()) {
+    if (containsTimezoneSensitiveDateTrunc(input)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+} // namespace
+
+bool canBeEvaluatedByCudf(
+    const std::vector<std::shared_ptr<velox::exec::Expr>>& exprs,
+    bool adjustTimestampToTimezone) {
+  for (const auto& expr : exprs) {
+    if (adjustTimestampToTimezone && containsTimezoneSensitiveDateTrunc(expr)) {
+      LOG_FALLBACK(
+          "date_trunc(timestamp) requires CPU evaluation when "
+          "adjust_timestamp_to_session_timezone is enabled");
+      return false;
+    }
+    if (!canBeEvaluatedByCudf(expr)) {
+      return false;
+    }
+  }
   return true;
 }
 

--- a/velox/experimental/cudf/expression/ExpressionEvaluator.h
+++ b/velox/experimental/cudf/expression/ExpressionEvaluator.h
@@ -208,4 +208,15 @@ bool canBeEvaluatedByCudf(
     std::shared_ptr<velox::exec::Expr> expr,
     bool deep = true);
 
+/// Checks a group of compiled expressions for cuDF evaluator support and
+/// query-dependent semantic restrictions.
+///
+/// @param exprs Expressions to check.
+/// @param adjustTimestampToTimezone Whether timestamps are adjusted to the
+/// session timezone. Timezone-sensitive expressions that cuDF evaluates in UTC
+/// are rejected when this is true.
+bool canBeEvaluatedByCudf(
+    const std::vector<std::shared_ptr<velox::exec::Expr>>& exprs,
+    bool adjustTimestampToTimezone);
+
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/tests/TableScanTest.cpp
+++ b/velox/experimental/cudf/tests/TableScanTest.cpp
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
+#include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/connectors/hive/CudfHiveConfig.h"
 #include "velox/experimental/cudf/connectors/hive/CudfHiveConnector.h"
 #include "velox/experimental/cudf/connectors/hive/CudfHiveConnectorSplit.h"
 #include "velox/experimental/cudf/connectors/hive/CudfHiveDataSource.h"
 #include "velox/experimental/cudf/connectors/hive/CudfHiveTableHandle.h"
+#include "velox/experimental/cudf/expression/PrestoFunctions.h"
 #include "velox/experimental/cudf/expression/SubfieldFiltersToAst.h"
 #include "velox/experimental/cudf/tests/utils/CudfHiveConnectorTestBase.h"
 
@@ -32,6 +34,7 @@
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/dwio/common/tests/utils/DataFiles.h"
+#include "velox/dwio/parquet/RegisterParquetReader.h"
 #include "velox/exec/Exchange.h"
 #include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/TableScan.h"
@@ -94,6 +97,9 @@ class TableScanTest : public virtual CudfHiveConnectorTestBase {
  protected:
   void SetUp() override {
     CudfHiveConnectorTestBase::SetUp();
+    cudf_velox::registerPrestoFunctions(
+        cudf_velox::CudfConfig::getInstance().functionNamePrefix);
+    parquet::registerParquetReaderFactory();
     ExchangeSource::factories().clear();
     ExchangeSource::registerFactory(createLocalExchangeSource);
   }
@@ -167,6 +173,14 @@ class TableScanTest : public virtual CudfHiveConnectorTestBase {
   static PlanNodeStats getTableScanStats(const std::shared_ptr<Task>& task) {
     auto planStats = toPlanStats(task->taskStats());
     return std::move(planStats.at("0"));
+  }
+
+  static bool wasCudfToVeloxUsed(
+      const std::shared_ptr<Task>& task,
+      const core::PlanNodeId& planNodeId) {
+    const auto planStats = toPlanStats(task->taskStats());
+    const auto& scanStats = planStats.at(planNodeId);
+    return scanStats.operatorStats.count("CudfToVelox") > 0;
   }
 
   static std::unordered_map<std::string, RuntimeMetric>
@@ -745,6 +759,130 @@ TEST_F(TableScanTest, remainingFilterExtraction) {
   ASSERT_NE(it, scanStats.customStats.end());
   EXPECT_EQ(it->second.sum, 0)
       << "Expected no remaining filter time when filter is fully extracted";
+}
+
+TEST_F(TableScanTest, remainingFilterEligibility) {
+  auto rowType = ROW({"c0"}, {BIGINT()});
+  auto data = makeRowVector({"c0"}, {makeFlatVector<int64_t>({1, 2, 3, 4})});
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->getPath(), data);
+
+  const auto assignments =
+      facebook::velox::exec::test::HiveConnectorTestBase::allRegularColumns(
+          rowType);
+
+  auto testFilter = [&](const std::string& filter, bool expectCudfScan) {
+    SCOPED_TRACE(filter);
+
+    auto referencePlan =
+        PlanBuilder(pool_.get()).values({data}).filter(filter).planNode();
+    auto expected = AssertQueryBuilder(referencePlan)
+                        .config(CudfConfig::kCudfEnabled, false)
+                        .copyResults(pool());
+
+    auto scanPlan = PlanBuilder(pool_.get())
+                        .startTableScan()
+                        .connectorId(kCudfHiveConnectorId)
+                        .outputType(rowType)
+                        .dataColumns(rowType)
+                        .assignments(assignments)
+                        .remainingFilter(filter)
+                        .endTableScan()
+                        .planNode();
+
+    std::shared_ptr<Task> task;
+    auto actual = AssertQueryBuilder(scanPlan)
+                      .config(CudfConfig::kCudfEnabled, true)
+                      .splits(makeCudfHiveConnectorSplits({filePath}))
+                      .copyResults(pool(), task);
+
+    assertEqualResults({expected}, {actual});
+    EXPECT_EQ(wasCudfToVeloxUsed(task, scanPlan->id()), expectCudfScan);
+  };
+
+  // A supported, non-extractable remaining filter keeps the scan on GPU.
+  testFilter("c0 % 2 = 0", true);
+
+  // An unsupported nested function falls back to the CPU Hive data source.
+  testFilter(
+      "to_big_endian_64(c0) = to_big_endian_64(CAST(1 AS BIGINT))", false);
+}
+
+TEST_F(TableScanTest, remainingFilterTimestampTimezoneEligibility) {
+  auto rowType = ROW({"event_ts"}, {TIMESTAMP()});
+  auto data = makeRowVector(
+      {"event_ts"},
+      {makeFlatVector<Timestamp>(
+          {
+              Timestamp(1767297600, 0), // 2026-01-01 20:00:00 UTC.
+              Timestamp(1767258000, 0), // 2026-01-01 09:00:00 UTC.
+          },
+          TIMESTAMP())});
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->getPath(), data);
+
+  const auto assignments =
+      facebook::velox::exec::test::HiveConnectorTestBase::allRegularColumns(
+          rowType);
+
+  auto testFilter = [&](const std::string& filter,
+                        bool adjustTimestampToTimezone,
+                        bool expectCudfScan) {
+    SCOPED_TRACE(filter);
+
+    auto referencePlan =
+        PlanBuilder(pool_.get()).values({data}).filter(filter).planNode();
+    auto expected = AssertQueryBuilder(referencePlan)
+                        .config(CudfConfig::kCudfEnabled, false)
+                        .config(QueryConfig::kSessionTimezone, "Asia/Kolkata")
+                        .config(
+                            QueryConfig::kAdjustTimestampToTimezone,
+                            adjustTimestampToTimezone ? "true" : "false")
+                        .copyResults(pool());
+
+    auto scanPlan = PlanBuilder(pool_.get())
+                        .startTableScan()
+                        .connectorId(kCudfHiveConnectorId)
+                        .outputType(rowType)
+                        .dataColumns(rowType)
+                        .assignments(assignments)
+                        .remainingFilter(filter)
+                        .endTableScan()
+                        .planNode();
+
+    std::shared_ptr<Task> task;
+    auto actual = AssertQueryBuilder(scanPlan)
+                      .config(CudfConfig::kCudfEnabled, true)
+                      .config(QueryConfig::kSessionTimezone, "Asia/Kolkata")
+                      .config(
+                          QueryConfig::kAdjustTimestampToTimezone,
+                          adjustTimestampToTimezone ? "true" : "false")
+                      .splits(makeCudfHiveConnectorSplits({filePath}))
+                      .copyResults(pool(), task);
+
+    assertEqualResults({expected}, {actual});
+    EXPECT_EQ(wasCudfToVeloxUsed(task, scanPlan->id()), expectCudfScan);
+  };
+
+  // Without session-timezone adjustment, day truncation is safe on GPU.
+  testFilter(
+      "date_trunc('day', event_ts) = TIMESTAMP '2026-01-01 00:00:00'",
+      false,
+      true);
+
+  // Day truncation must use CPU session-timezone semantics when adjustment is
+  // enabled. 20:00 UTC is 01:30 the next day in Asia/Kolkata, whose truncated
+  // value is 18:30 UTC on the previous day.
+  testFilter(
+      "date_trunc('day', event_ts) = TIMESTAMP '2026-01-01 18:30:00'",
+      true,
+      false);
+
+  // Minute truncation is timezone-insensitive and remains eligible.
+  testFilter(
+      "date_trunc('minute', event_ts) = TIMESTAMP '2026-01-01 20:00:00'",
+      true,
+      true);
 }
 
 TEST_F(TableScanTest, decimalSubfieldFilter) {


### PR DESCRIPTION
- Apply cuDF evaluator support and query-semantic checks to Hive and Iceberg remaining filters before selecting a GPU data source.
- Keep the TableScan adapter output-format decision aligned with connector CPU fallback.
- Share the timezone-sensitive date_trunc gate with CudfFilterProject.
- Add end-to-end coverage for supported, unsupported, and timezone-sensitive remaining filters.

This addresses the remaining-filter eligibility item tracked in https://github.com/facebookincubator/velox/issues/17410#issuecomment-4919379077.
