### PR TITLE
fix: Spark from_json failure on scalar input for array of rows

### DIFF
--- a/velox/functions/sparksql/specialforms/FromJson.cpp
+++ b/velox/functions/sparksql/specialforms/FromJson.cpp
@@ -270,7 +270,9 @@ struct ExtractJsonTypeImpl {
                 nodeIndex + 1));
           }
         }
-      } else if (elementType->kind() == TypeKind::ROW && isRoot) {
+      } else if (
+          type == simdjson::ondemand::json_type::object &&
+          elementType->kind() == TypeKind::ROW && isRoot) {
         SIMDJSON_TRY(VELOX_DYNAMIC_TYPE_DISPATCH(
             ExtractJsonTypeImpl<simdjson::ondemand::value>::apply,
             elementType->kind(),

--- a/velox/functions/sparksql/tests/FromJsonTest.cpp
+++ b/velox/functions/sparksql/tests/FromJsonTest.cpp
@@ -41,6 +41,15 @@ TEST_F(FromJsonTest, basicArray) {
   testFromJson(input, expected);
 }
 
+TEST_F(FromJsonTest, arrayOfRowWithScalarInput) {
+  auto input = makeFlatVector<std::string>(
+      {R"(746314092223)", R"(true)", R"("invalid")"});
+  const auto outputType = ARRAY(ROW({"text", "type"}, {VARCHAR(), VARCHAR()}));
+  auto expected =
+      BaseVector::createNullConstant(outputType, input->size(), pool());
+  testFromJson(input, expected);
+}
+
 TEST_F(FromJsonTest, basicMap) {
   auto expected = makeMapVector<std::string, int64_t>(
       {{{"a", 1}}, {{"b", 2}}, {{"c", 3}}, {{"3", 3}}});


### PR DESCRIPTION
## Summary

Fix `from_json` throwing a simdjson `SCALAR_DOCUMENT_AS_VALUE` error when a root-level scalar JSON value is parsed as `ARRAY<ROW>`.

Velox supports parsing a root-level JSON object as a single-element `ARRAY<ROW>` for Spark compatibility. Previously, this special path only checked whether the target element type was `ROW`, but did not verify that the JSON input was an object.

As a result, scalar values such as numbers, strings, and booleans were incorrectly passed from `simdjson::ondemand::document` to the row parser as `simdjson::ondemand::value`, causing an exception instead of returning `NULL`.

This change restricts the single-row compatibility path to JSON objects. Scalar inputs now return `NULL`, matching Spark behavior.

## Example

Input JSON:

```json
746314092223
```

Target type:

```text
ARRAY<ROW<text: VARCHAR, type: VARCHAR>>
```

Behavior before this change:

```text
Throws simdjson SCALAR_DOCUMENT_AS_VALUE
```

Behavior after this change:

```text
NULL
```

## Testing

Added a regression test covering numeric, boolean, and string scalar inputs.

All inputs are parsed as `ARRAY<ROW<text: VARCHAR, type: VARCHAR>>` and are expected to return `NULL`.