### PR TITLE
fix(text): Honor serde field.delim when writing TEXT files (#18240)

### DIFF
--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -535,13 +535,14 @@ std::unique_ptr<dwio::common::SerDeOptions> parseSerdeParameters(
   uint8_t fieldDelim = '\1';
   uint8_t collectionDelim = '\2';
   uint8_t mapKeyDelim = '\3';
-  if (fieldIt != serdeParameters.end()) {
+  // Treat an empty value as absent so parseDelimiter never sees "".
+  if (fieldIt != serdeParameters.end() && !fieldIt->second.empty()) {
     fieldDelim = parseDelimiter(fieldIt->second);
   }
-  if (collectionIt != serdeParameters.end()) {
+  if (collectionIt != serdeParameters.end() && !collectionIt->second.empty()) {
     collectionDelim = parseDelimiter(collectionIt->second);
   }
-  if (mapKeyIt != serdeParameters.end()) {
+  if (mapKeyIt != serdeParameters.end() && !mapKeyIt->second.empty()) {
     mapKeyDelim = parseDelimiter(mapKeyIt->second);
   }
 

--- a/velox/dwio/text/tests/writer/TextWriterTest.cpp
+++ b/velox/dwio/text/tests/writer/TextWriterTest.cpp
@@ -181,6 +181,53 @@ TEST_F(TextWriterTest, write) {
   EXPECT_EQ(result[2][9], "Y3Bw");
 }
 
+// The writer factory must translate the Hive serde 'field.delim' parameter on
+// WriterOptions into the writer's field separator, rather than defaulting to
+// \001.
+TEST_F(TextWriterTest, fieldDelim) {
+  auto schema = ROW({"c0", "c1", "c2"}, {INTEGER(), VARCHAR(), INTEGER()});
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({1, 2, 3}),
+      makeFlatVector<StringView>({"a", "b", "c"}, VARCHAR()),
+      makeFlatVector<int32_t>({4, 5, 6}),
+  });
+
+  WriterOptions writerOptions;
+  writerOptions.memoryPool = rootPool_.get();
+  writerOptions.schema = schema;
+  writerOptions.serdeParameters = {
+      {dwio::common::SerDeOptions::kFieldDelim, "|"}};
+
+  const auto tempPath = tempPath_->getPath();
+  const auto filename = "test_text_writer_serde.txt";
+  auto filePath = fs::path(fmt::format("{}/{}", tempPath, filename));
+  auto sink = std::make_unique<dwio::common::LocalFileSink>(
+      filePath, dwio::common::FileSink::Options{.pool = leafPool_.get()});
+
+  TextWriterFactory factory;
+  auto writer = factory.createWriter(
+      std::move(sink), std::make_shared<text::WriterOptions>(writerOptions));
+  writer->write(data);
+  writer->close();
+
+  const auto fileSystem = filesystems::getFileSystem(tempPath, nullptr);
+  const auto& file = fileSystem->openFileForRead(filePath.string());
+  BufferPtr charBuf = AlignedBuffer::allocate<char>(file->size(), pool());
+  auto rawCharBuf = charBuf->asMutable<char>();
+
+  // Parsing with '|' recovers the columns only if the file was written with it.
+  const auto serDeOptions = dwio::common::SerDeOptions('|');
+  auto result = parseTextFile(tempPath, filename, rawCharBuf, serDeOptions);
+
+  ASSERT_EQ(result.size(), 3);
+  ASSERT_EQ(result[0].size(), 3);
+  EXPECT_EQ(result[0][0], "1");
+  EXPECT_EQ(result[0][1], "a");
+  EXPECT_EQ(result[0][2], "4");
+  EXPECT_EQ(result[2][0], "3");
+  EXPECT_EQ(result[2][2], "6");
+}
+
 TEST_F(TextWriterTest, verifyWriteWithTextReader) {
   auto schema =
       ROW({"c0", "c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9"},

--- a/velox/dwio/text/writer/TextWriter.cpp
+++ b/velox/dwio/text/writer/TextWriter.cpp
@@ -17,11 +17,66 @@
 #include "velox/dwio/text/writer/TextWriter.h"
 #include "velox/common/encode/Base64.h"
 
+#include <folly/Conv.h>
+#include <cctype>
 #include <utility>
 
 namespace facebook::velox::text {
 
 using dwio::common::SerDeOptions;
+
+namespace {
+
+// Parses a Hive serde delimiter, which is either a raw character (its first
+// byte) or the decimal code of a single byte (e.g. "9" -> tab).
+uint8_t parseDelimiter(const std::string& delim) {
+  for (char const& ch : delim) {
+    if (!std::isdigit(ch)) {
+      return delim[0];
+    }
+  }
+  return stoi(delim);
+}
+
+// Builds SerDeOptions from a table's Hive serde parameters so the file is
+// written with the table's declared delimiters rather than the defaults. Absent
+// parameters fall back to the SerDeOptions defaults.
+SerDeOptions serdeOptionsFromParameters(
+    const std::map<std::string, std::string>& serdeParameters) {
+  auto find = [&](const std::string& key) -> const std::string* {
+    auto it = serdeParameters.find(key);
+    return it == serdeParameters.end() ? nullptr : &it->second;
+  };
+
+  const auto* field = find(SerDeOptions::kFieldDelim);
+  if (field == nullptr) {
+    field = find("serialization.format");
+  }
+  const auto* collection = find(SerDeOptions::kCollectionDelim);
+  const auto* mapKey = find(SerDeOptions::kMapKeyDelim);
+  const auto* escape = find(SerDeOptions::kEscapeChar);
+
+  // Treat an empty value as absent so parseDelimiter never sees "".
+  auto delimOr = [](const std::string* value, uint8_t defaultDelim) {
+    return (value != nullptr && !value->empty()) ? parseDelimiter(*value)
+                                                 : defaultDelim;
+  };
+  const uint8_t fieldDelim = delimOr(field, '\1');
+  const uint8_t collectionDelim = delimOr(collection, '\2');
+  const uint8_t mapKeyDelim = delimOr(mapKey, '\3');
+
+  if (escape == nullptr) {
+    return SerDeOptions(fieldDelim, collectionDelim, mapKeyDelim);
+  }
+  uint8_t escapeChar = '\\';
+  if (!escape->empty()) {
+    escapeChar = folly::tryTo<uint8_t>(*escape).value_or((*escape)[0]);
+  }
+  return SerDeOptions(
+      fieldDelim, collectionDelim, mapKeyDelim, escapeChar, true);
+}
+
+} // namespace
 
 template <typename T>
 std::optional<std::string> toTextStr(T val) {
@@ -375,7 +430,10 @@ std::unique_ptr<dwio::common::Writer> TextWriterFactory::createWriter(
   VELOX_CHECK_NOT_NULL(
       textOptions, "Text writer factory expected a Text WriterOptions object.");
   return std::make_unique<TextWriter>(
-      asRowType(options->schema), std::move(sink), textOptions);
+      asRowType(options->schema),
+      std::move(sink),
+      textOptions,
+      serdeOptionsFromParameters(options->serdeParameters));
 }
 
 std::unique_ptr<dwio::common::WriterOptions>


### PR DESCRIPTION
Summary:

A TEXT table declared with a non-default field delimiter is now written with that delimiter. `TextWriterFactory` previously ignored the table's serde parameters and always wrote the default `\001` separator. A table declaring `field.delim` = `,` therefore got a `\001`-separated file. Reading it back, with the reader correctly expecting `,`, collapsed every row into a single column.

`TextWriterFactory::createWriter` now builds `SerDeOptions` from `WriterOptions::serdeParameters` — the field, collection, and map-key delimiters plus the escape character — and passes them to `TextWriter`, which already honored `SerDeOptions`. This is the write-side counterpart of `parseSerdeParameters` on the read path. An empty delimiter value is now treated as absent on both paths, so an empty `field.delim` no longer throws while parsing.

`serialization.null.format` is still not applied on write: it lives on the table parameters, which the writer factory does not receive.

Reviewed By: amitkdutta

Differential Revision: D113346378


