### PR TITLE
feat(fuzzer): Add generic reader-config hook + Nimble dict-vector-stack flags (#18242)

### DIFF
--- a/velox/exec/tests/TableEvolutionFuzzer.cpp
+++ b/velox/exec/tests/TableEvolutionFuzzer.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/exec/tests/TableEvolutionFuzzer.h"
 #include "velox/common/config/Config.h"
+#include "velox/common/config/Config.h"
 #include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/connectors/hive/TableHandle.h"
@@ -1062,6 +1063,13 @@ void TableEvolutionFuzzer::runQueryShape(
   RowTypePtr fullOutSchema = buildFlatmapAsStructSchema(
       rowType, globalMapColumnKeys, globallyConsistentColumnIndexVector);
 
+  // Draw the extra reader connector config once per shape, so both scan tasks
+  // read with identical reader options and the pushdown-vs-FilterNode oracle
+  // stays valid.
+  const std::unordered_map<std::string, std::string> readConfig =
+      config_.extraReadConfig ? config_.extraReadConfig(rng_)
+                              : std::unordered_map<std::string, std::string>{};
+
   std::vector<std::shared_ptr<TaskCursor>> scanTasks(2);
   // actual: TableScan -> Aggregation (allows pushdown)
   pushdownConfig.aggregationConfig = aggConfig;
@@ -1072,7 +1080,8 @@ void TableEvolutionFuzzer::runQueryShape(
       false,
       false, // insertProjectToBlockPushdown
       fullOutSchema,
-      outputColumnNames);
+      outputColumnNames,
+      readConfig);
 
   // expected: TableScan -> Project -> Aggregation (blocks pushdown)
   // Insert a Project node to prevent aggregation pushdown
@@ -1084,7 +1093,8 @@ void TableEvolutionFuzzer::runQueryShape(
       true,
       true, // insertProjectToBlockPushdown
       fullOutSchema,
-      outputColumnNames);
+      outputColumnNames,
+      readConfig);
 
   ScopedOOMInjector oomInjectorReadPath(
       [this]() -> bool { return folly::Random::oneIn(10, rng_); },
@@ -1539,7 +1549,8 @@ std::unique_ptr<TaskCursor> TableEvolutionFuzzer::makeScanTask(
     bool useFiltersAsNode,
     bool insertProjectToBlockPushdown,
     const RowTypePtr& fullOutSchema,
-    const std::vector<std::string>& outputColumnNames) {
+    const std::vector<std::string>& outputColumnNames,
+    const std::unordered_map<std::string, std::string>& readConfig) {
   // 'insertProjectToBlockPushdown' only takes effect on the reference plan,
   // where the Project below is what blocks aggregation pushdown; it is
   // meaningless (and never applied) on the pushdown plan. Enforce the pairing
@@ -1568,6 +1579,23 @@ std::unique_ptr<TaskCursor> TableEvolutionFuzzer::makeScanTask(
 
   CursorParameters params;
   params.serialExecution = true;
+
+  // Apply the driver-supplied reader config as connector session config under
+  // this fuzzer's connectorId. The serial task cursor requires a QueryCtx with
+  // no executor supplied, so construct one explicitly here only when there is
+  // config to apply; otherwise the cursor creates its own.
+  if (!readConfig.empty()) {
+    std::unordered_map<std::string, std::shared_ptr<config::ConfigBase>>
+        connectorConfigs;
+    connectorConfigs.emplace(
+        connectorId(),
+        std::make_shared<config::ConfigBase>(
+            std::unordered_map<std::string, std::string>(readConfig)));
+    params.queryCtx = core::QueryCtx::create(
+        /*executor=*/nullptr,
+        core::QueryConfig{{}},
+        std::move(connectorConfigs));
+  }
 
   PlanBuilder builder;
   builder.filtersAsNode(useFiltersAsNode);

--- a/velox/exec/tests/TableEvolutionFuzzer.h
+++ b/velox/exec/tests/TableEvolutionFuzzer.h
@@ -49,6 +49,15 @@ class TableEvolutionFuzzer {
         dwio::common::FileFormat,
         FuzzerGenerator&)>
         extraWriteSerdeParams;
+
+    // Optional. Returns extra connector session config to apply on the read
+    // path. Called once per run() with the fuzzer rng and applied to both scan
+    // tasks (test and reference), so a driver can exercise reader options,
+    // randomized yet reproducible from the seed. The core stays
+    // format-agnostic.
+    std::function<std::unordered_map<std::string, std::string>(
+        FuzzerGenerator&)>
+        extraReadConfig;
   };
 
   /// Per-batch raw-byte target and clamp bounds for adaptive batch sizing. A
@@ -185,7 +194,8 @@ class TableEvolutionFuzzer {
       bool useFiltersAsNode,
       bool insertProjectToBlockPushdown,
       const RowTypePtr& fullOutSchema,
-      const std::vector<std::string>& outputColumnNames);
+      const std::vector<std::string>& outputColumnNames,
+      const std::unordered_map<std::string, std::string>& readConfig = {});
 
   /// Builds schema for flatmap as struct reading by converting selected map
   /// columns to struct types.

--- a/velox/exec/tests/TableEvolutionFuzzerTest.cpp
+++ b/velox/exec/tests/TableEvolutionFuzzerTest.cpp
@@ -26,6 +26,7 @@
 #include <folly/init/Init.h>
 #include <gflags/gflags.h>
 #include <gtest/gtest.h>
+#include <unordered_map>
 #include "velox/parse/TypeResolver.h"
 
 DEFINE_uint32(seed, 0, "");
@@ -284,6 +285,35 @@ TEST(TableEvolutionFuzzerTest, adaptiveVectorSizeScalesWithByteTarget) {
   EXPECT_GT(base, Fuzzer::kMinAdaptiveVectorSize);
   EXPECT_LT(doubled, Fuzzer::kMaxAdaptiveVectorSize);
   EXPECT_EQ(doubled, 2 * base);
+}
+
+// Verifies the extraReadConfig hook is invoked on the read path and that a
+// non-empty reader config exercises makeScanTask's QueryCtx connector-config
+// path while the scan still round-trips (the pushdown-vs-FilterNode oracle
+// holds). Asserts the hook fires at least once per run(). evolutionCount == 1
+// keeps it fast and deterministic.
+TEST(TableEvolutionFuzzerTest, extraReadConfigHookAppliedOncePerRun) {
+  auto pool = memory::memoryManager()->addLeafPool("TableEvolutionFuzzer");
+  auto config = makeDwrfConfig(pool.get(), 1);
+  int calls = 0;
+  config.extraReadConfig =
+      [&](FuzzerGenerator&) -> std::unordered_map<std::string, std::string> {
+    ++calls;
+    // An inert connector session key: the QueryCtx connector-config path must
+    // construct and the scan must still produce identical pushdown/reference
+    // results.
+    return {{"test.reader.key", "test.reader.value"}};
+  };
+  TableEvolutionFuzzer fuzzer(config);
+  fuzzer.setSeed(20260629);
+  constexpr int kIterations = 3;
+  for (int i = 0; i < kIterations; ++i) {
+    EXPECT_NO_THROW(fuzzer.run());
+    fuzzer.reSeed();
+  }
+  // Fires at least once per run() (once per query shape, each shared by both
+  // scan plans).
+  EXPECT_GE(calls, kIterations);
 }
 
 TEST(TableEvolutionFuzzerTest, run) {


### PR DESCRIPTION
Summary:

Adds Config::extraReadConfig, a generic reader-side config hook mirroring the write-side extraWriteSerdeParams. run() calls it once per run and passes the returned map to both scan plans (test + reference); makeScanTask attaches it as per-scan connector session config via core::QueryCtx::create(executor=nullptr, connectorConfigs[connectorId()]=ConfigBase(map)) on CursorParameters::queryCtx. When the hook is null/empty no QueryCtx is set, so default runs are byte-for-byte unchanged.

The fb_velox driver adds --nimble_dict_vector_stack; when set, extraReadConfig returns the coupled keys nimble.string-decoder-zero-copy + nimble.preserve-dictionary-encoding so the fuzzer can exercise the Nimble dictionary-vector read stack. On this stack those keys are no-ops (the connector->reader wiring for them lives in a separate stack), so behavior is unchanged here; the keys are verified to reach the connector session config under connectorId test-hive.

Differential Revision: D110052629


