### PR TITLE
feat: Support specifying implementation of bloom filter and hash function in `BigintValuesUsingBloomFilter`

### DIFF
--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -412,7 +412,7 @@ void HashProbe::pushdownDynamicFilters() {
                   filter.get());
           addRuntimeStat(
               std::string(HashProbe::kBloomFilterSize),
-              RuntimeCounter(bloomFilter->blocksByteSize()));
+              RuntimeCounter(bloomFilter->byteSize()));
         }
         dynamicFiltersProducedOnChannels_.insert(sourceChannel);
         for (auto* peer : findPeerOperators()) {

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -861,7 +861,7 @@ namespace {
 template <typename T>
 void partitionBloomFilterRowsImpl(
     int32_t offset,
-    const common::BigintValuesUsingBloomFilter& filter,
+    const common::SplitBlockBloomFilterBackend& bloomFilterBackend,
     const RowContainer& rowContainer,
     uint8_t partitionMask,
     RowPartitions& rowPartitions) {
@@ -872,7 +872,7 @@ void partitionBloomFilterRowsImpl(
              &iter, kHashBatchSize, RowContainer::kUnlimited, rows)) {
     for (int i = 0; i < numRows; ++i) {
       auto value = folly::loadUnaligned<T>(rows[i] + offset);
-      partitions[i] = filter.blockIndex(value) & partitionMask;
+      partitions[i] = bloomFilterBackend.blockIndex(value) & partitionMask;
     }
     rowPartitions.appendPartitions(
         folly::Range<const uint8_t*>(partitions, numRows));
@@ -882,7 +882,7 @@ void partitionBloomFilterRowsImpl(
 void partitionBloomFilterRows(
     const VectorHasher& hasher,
     int32_t offset,
-    const common::BigintValuesUsingBloomFilter& filter,
+    const common::SplitBlockBloomFilterBackend& bloomFilterBackend,
     const RowContainer& rowContainer,
     uint8_t numPartitions,
     RowPartitions& rowPartitions) {
@@ -891,11 +891,19 @@ void partitionBloomFilterRows(
   switch (hasher.typeKind()) {
     case TypeKind::INTEGER:
       partitionBloomFilterRowsImpl<int32_t>(
-          offset, filter, rowContainer, numPartitions - 1, rowPartitions);
+          offset,
+          bloomFilterBackend,
+          rowContainer,
+          numPartitions - 1,
+          rowPartitions);
       break;
     case TypeKind::BIGINT:
       partitionBloomFilterRowsImpl<int64_t>(
-          offset, filter, rowContainer, numPartitions - 1, rowPartitions);
+          offset,
+          bloomFilterBackend,
+          rowContainer,
+          numPartitions - 1,
+          rowPartitions);
       break;
     default:
       VELOX_UNREACHABLE();
@@ -965,7 +973,7 @@ void syncWorkItems(
 template <>
 bool HashTable<true>::bloomFilterSupported() const {
   if (!(bloomFilterMaxSize_ > 0 &&
-        common::BigintValuesUsingBloomFilter::numBlocks(numDistinct_) *
+        common::SplitBlockBloomFilterBackend::numBlocks(numDistinct_) *
                 sizeof(SplitBlockBloomFilter::Block) <=
             bloomFilterMaxSize_)) {
     return false;
@@ -1139,8 +1147,10 @@ void HashTable<ignoreNullKeys>::parallelJoinBuild() {
       if (!hashers_[i]->supportsBloomFilter()) {
         continue;
       }
+      auto bloomFilterBackend =
+          std::make_shared<common::SplitBlockBloomFilterBackend>(numDistinct_);
       auto filter = std::make_shared<common::BigintValuesUsingBloomFilter>(
-          numDistinct_, false);
+          bloomFilterBackend, false);
       hashers_[i]->setBloomFilter(filter);
       for (auto j = 0; j < numPartitions; ++j) {
         bool last = j == numPartitions - 1;
@@ -1150,14 +1160,14 @@ void HashTable<ignoreNullKeys>::parallelJoinBuild() {
             bloomFilterPartitionSteps,
             [hasher = hashers_[i].get(),
              offset = rows->columnAt(i).offset(),
-             filter,
+             bloomFilterBackend,
              rows,
              numBloomFilterPartitions,
              rowPartitions = rowPartitions[j].get()] {
               partitionBloomFilterRows(
                   *hasher,
                   offset,
-                  *filter,
+                  *bloomFilterBackend,
                   *rows,
                   numBloomFilterPartitions,
                   *rowPartitions);
@@ -1557,8 +1567,10 @@ void HashTable<ignoreNullKeys>::rehash(
       if (!hashers_[i]->supportsBloomFilter()) {
         continue;
       }
+      auto bloomFilterBackend =
+          std::make_shared<common::SplitBlockBloomFilterBackend>(numDistinct_);
       auto filter = std::make_shared<common::BigintValuesUsingBloomFilter>(
-          numDistinct_, false);
+          std::move(bloomFilterBackend), false);
       bloomFilters[i] = filter.get();
       hashers_[i]->setBloomFilter(filter);
     }

--- a/velox/type/Filter.cpp
+++ b/velox/type/Filter.cpp
@@ -385,10 +385,28 @@ bool BigintValuesUsingBitmask::testingEquals(const Filter& other) const {
   return false;
 }
 
+bool SplitBlockBloomFilterBackend::testingEquals(
+    const BloomFilterBackend& other) const {
+  const auto* otherBackend =
+      dynamic_cast<const SplitBlockBloomFilterBackend*>(&other);
+  return otherBackend != nullptr &&
+      blocks_.size() == otherBackend->blocks_.size() &&
+      memcmp(
+          blocks_.data(),
+          otherBackend->blocks_.data(),
+          blocks_.size() * sizeof(SplitBlockBloomFilter::Block)) == 0;
+}
+
 folly::dynamic BigintValuesUsingBloomFilter::serialize() const {
+  const auto* backend =
+      dynamic_cast<const SplitBlockBloomFilterBackend*>(backend_.get());
+  VELOX_CHECK_NOT_NULL(
+      backend,
+      "Serialization is only supported for SplitBlockBloomFilterBackend");
+
   auto obj = Filter::serializeBase();
   folly::dynamic words = folly::dynamic::array;
-  for (auto& block : blocks_) {
+  for (const auto& block : backend->blocks()) {
     for (auto word : block.data) {
       words.push_back(word);
     }
@@ -415,8 +433,8 @@ std::unique_ptr<Filter> BigintValuesUsingBloomFilter::create(
       i = 0;
     }
   }
-  return std::unique_ptr<BigintValuesUsingBloomFilter>(
-      new BigintValuesUsingBloomFilter(nullAllowed, std::move(blocks)));
+  return std::make_unique<BigintValuesUsingBloomFilter>(
+      SplitBlockBloomFilterBackend::fromBlocks(std::move(blocks)), nullAllowed);
 }
 
 bool BigintValuesUsingBloomFilter::testingEquals(const Filter& other) const {
@@ -425,11 +443,8 @@ bool BigintValuesUsingBloomFilter::testingEquals(const Filter& other) const {
   if (!typedOther) {
     return false;
   }
-  return blocks_.size() == typedOther->blocks_.size() &&
-      memcmp(
-          blocks_.data(),
-          typedOther->blocks_.data(),
-          blocks_.size() * sizeof(SplitBlockBloomFilter::Block)) == 0;
+
+  return backend_->testingEquals(*typedOther->backend_);
 }
 
 folly::dynamic NegatedBigintValuesUsingHashTable::serialize() const {

--- a/velox/type/Filter.h
+++ b/velox/type/Filter.h
@@ -1290,19 +1290,114 @@ class BigintValuesUsingBitmask final : public Filter {
   const int64_t max_;
 };
 
-class BigintValuesUsingBloomFilter final : public Filter {
+/// Backend for a Bloom filter. Implementations own the Bloom filter state and
+/// define how values are hashed before lookup or insertion.
+class BloomFilterBackend {
  public:
+  virtual ~BloomFilterBackend() = default;
+
+  /// Returns an independent copy of this backend.
+  virtual std::shared_ptr<BloomFilterBackend> clone() const = 0;
+
+  /// Returns the number of bytes used by the Bloom filter data.
+  virtual int64_t byteSize() const = 0;
+
+  /// Returns true if this backend has the same type and state as 'other'.
+  virtual bool testingEquals(const BloomFilterBackend& other) const = 0;
+
+  /// Returns true if 'value' may have been inserted. False guarantees that
+  /// 'value' was not inserted.
+  virtual bool mayContainInt64(int64_t value) const = 0;
+
+  /// Inserts 'value' into this backend.
+  virtual void insertInt64(int64_t value) = 0;
+};
+
+/// Split-block Bloom filter backend for integral values. blockIndex() and
+/// blocks() expose split-block-specific functionality and are intentionally
+/// not part of BloomFilterBackend.
+class SplitBlockBloomFilterBackend final : public BloomFilterBackend {
+ public:
+  /// Returns the number of blocks needed for 'capacity' values with a 1% false
+  /// positive probability.
   static int64_t numBlocks(int64_t capacity) {
     return SplitBlockBloomFilter::numBlocks(capacity, 0.01);
   }
 
-  BigintValuesUsingBloomFilter(int64_t capacity, bool nullAllowed)
+  /// Creates an empty backend sized for 'capacity' values.
+  explicit SplitBlockBloomFilterBackend(int64_t capacity)
+      : blocks_(numBlocks(capacity)), filter_(blocks_) {}
+
+  /// Creates a backend from previously populated blocks.
+  static std::shared_ptr<SplitBlockBloomFilterBackend> fromBlocks(
+      std::vector<SplitBlockBloomFilter::Block> blocks) {
+    return std::shared_ptr<SplitBlockBloomFilterBackend>(
+        new SplitBlockBloomFilterBackend(std::move(blocks)));
+  }
+
+  SplitBlockBloomFilterBackend(const SplitBlockBloomFilterBackend&) = delete;
+  SplitBlockBloomFilterBackend& operator=(const SplitBlockBloomFilterBackend&) =
+      delete;
+  SplitBlockBloomFilterBackend(SplitBlockBloomFilterBackend&&) = delete;
+  SplitBlockBloomFilterBackend& operator=(SplitBlockBloomFilterBackend&&) =
+      delete;
+
+  std::shared_ptr<BloomFilterBackend> clone() const override {
+    return fromBlocks(blocks_);
+  }
+
+  int64_t byteSize() const override {
+    return blocks_.size() * sizeof(SplitBlockBloomFilter::Block);
+  }
+
+  bool testingEquals(const BloomFilterBackend& other) const override;
+
+  bool mayContainInt64(int64_t value) const override {
+    return filter_.mayContain(hash(value));
+  }
+
+  void insertInt64(int64_t value) override {
+    filter_.insert(hash(value));
+  }
+
+  /// Returns the index of the block used to test or insert 'value'.
+  uint64_t blockIndex(int64_t value) const {
+    return filter_.blockIndex(hash(value));
+  }
+
+  /// Returns the blocks owned by this backend.
+  const std::vector<SplitBlockBloomFilter::Block>& blocks() const {
+    return blocks_;
+  }
+
+ private:
+  explicit SplitBlockBloomFilterBackend(
+      std::vector<SplitBlockBloomFilter::Block> blocks)
+      : blocks_(std::move(blocks)), filter_(blocks_) {}
+
+  static uint64_t hash(int64_t value) {
+    // Simple multiplication hash like the one in BigintValuesUsingHashTable
+    // does not distribute values evenly.  Maybe we need to reconsider the hash
+    // choice in BigintValuesUsingHashTable as well in the future.
+    return folly::hasher<int64_t>()(value);
+  }
+
+  std::vector<SplitBlockBloomFilter::Block> blocks_;
+  SplitBlockBloomFilter filter_;
+};
+
+class BigintValuesUsingBloomFilter final : public Filter {
+ public:
+  BigintValuesUsingBloomFilter(
+      std::shared_ptr<BloomFilterBackend> backend,
+      bool nullAllowed)
       : Filter(true, nullAllowed, FilterKind::kBigintValuesUsingBloomFilter),
-        blocks_(numBlocks(capacity)),
-        filter_(blocks_) {}
+        backend_(std::move(backend)) {
+    VELOX_CHECK_NOT_NULL(backend_);
+  }
 
   bool testInt64(int64_t value) const final {
-    return filter_.mayContain(hash(value));
+    return backend_->mayContainInt64(value);
   }
 
   xsimd::batch_bool<int64_t> testValues(xsimd::batch<int64_t> x) const final {
@@ -1324,9 +1419,8 @@ class BigintValuesUsingBloomFilter final : public Filter {
 
   std::unique_ptr<Filter> clone(
       std::optional<bool> nullAllowed) const override {
-    return std::unique_ptr<BigintValuesUsingBloomFilter>(
-        new BigintValuesUsingBloomFilter(
-            nullAllowed.value_or(nullAllowed_), blocks_));
+    return std::make_unique<BigintValuesUsingBloomFilter>(
+        backend_->clone(), nullAllowed.value_or(nullAllowed_));
   }
 
   folly::dynamic serialize() const override;
@@ -1338,35 +1432,15 @@ class BigintValuesUsingBloomFilter final : public Filter {
   std::unique_ptr<Filter> mergeWith(const Filter* other) const override;
 
   void insert(int64_t value) {
-    filter_.insert(hash(value));
+    backend_->insertInt64(value);
   }
 
-  uint64_t blockIndex(int64_t value) const {
-    return filter_.blockIndex(hash(value));
-  }
-
-  int64_t blocksByteSize() const {
-    return blocks_.size() * sizeof(SplitBlockBloomFilter::Block);
+  int64_t byteSize() const {
+    return backend_->byteSize();
   }
 
  private:
-  static uint64_t hash(int64_t value) {
-    // Simple multiplication hash like the one in BigintValuesUsingHashTable
-    // does not distribute values evenly.  Maybe we need to reconsider the hash
-    // choice in BigintValuesUsingHashTable as well in the future.
-    return folly::hasher<int64_t>()(value);
-  }
-
-  // Private constructor used by clone() and create().
-  BigintValuesUsingBloomFilter(
-      bool nullAllowed,
-      std::vector<SplitBlockBloomFilter::Block> blocks)
-      : Filter(true, nullAllowed, FilterKind::kBigintValuesUsingBloomFilter),
-        blocks_(std::move(blocks)),
-        filter_(blocks_) {}
-
-  std::vector<SplitBlockBloomFilter::Block> blocks_;
-  SplitBlockBloomFilter filter_;
+  std::shared_ptr<BloomFilterBackend> backend_;
 };
 
 // NOT IN-list filter for integral data types. Implemented as a hash table. Good

--- a/velox/type/tests/FilterTest.cpp
+++ b/velox/type/tests/FilterTest.cpp
@@ -32,6 +32,34 @@ namespace {
 using namespace facebook::velox::common;
 using namespace facebook::velox::exec;
 
+class TestBloomFilterBackend final : public BloomFilterBackend {
+ public:
+  std::shared_ptr<BloomFilterBackend> clone() const override {
+    return std::make_shared<TestBloomFilterBackend>(*this);
+  }
+
+  int64_t byteSize() const override {
+    return values_.size() * sizeof(int64_t);
+  }
+
+  bool testingEquals(const BloomFilterBackend& other) const override {
+    const auto* otherBackend =
+        dynamic_cast<const TestBloomFilterBackend*>(&other);
+    return otherBackend != nullptr && values_ == otherBackend->values_;
+  }
+
+  bool mayContainInt64(int64_t value) const override {
+    return values_.contains(value);
+  }
+
+  void insertInt64(int64_t value) override {
+    values_.insert(value);
+  }
+
+ private:
+  folly::F14FastSet<int64_t> values_;
+};
+
 TEST(FilterTest, alwaysFalse) {
   AlwaysFalse alwaysFalse;
   EXPECT_FALSE(alwaysFalse.testInt64(1));
@@ -662,7 +690,8 @@ TEST(FilterTest, negatedBigintValuesEdgeCases) {
 }
 
 TEST(FilterTest, bigintValuesUsingBloomFilter) {
-  BigintValuesUsingBloomFilter filter(10, false);
+  BigintValuesUsingBloomFilter filter(
+      std::make_shared<SplitBlockBloomFilterBackend>(10), false);
   folly::F14FastSet<int64_t> inserted;
   for (int64_t x : {2, 3, 5, 7, 11, 13, 17, 19}) {
     filter.insert(x);
@@ -689,8 +718,24 @@ TEST(FilterTest, bigintValuesUsingBloomFilter) {
   ASSERT_TRUE(nullAllowedClone->clone(false)->testingEquals(filter));
 }
 
+TEST(FilterTest, bigintValuesUsingCustomBloomFilterBackend) {
+  auto backend = std::make_shared<TestBloomFilterBackend>();
+  BigintValuesUsingBloomFilter filter(backend, false);
+
+  filter.insert(11);
+  EXPECT_TRUE(filter.testInt64(11));
+  EXPECT_FALSE(filter.testInt64(12));
+  EXPECT_EQ(filter.byteSize(), sizeof(int64_t));
+  EXPECT_TRUE(filter.clone(std::nullopt)->testingEquals(filter));
+
+  // Serde intentionally remains specific to SplitBlockBloomFilterBackend for
+  // compatibility with the existing serialized representation.
+  EXPECT_ANY_THROW(filter.serialize());
+}
+
 TEST(FilterTest, bigintValuesUsingBloomFilterMergeWith) {
-  BigintValuesUsingBloomFilter filter(4, false);
+  BigintValuesUsingBloomFilter filter(
+      std::make_shared<SplitBlockBloomFilterBackend>(4), false);
   for (int64_t x : {2, 3, 5, 7}) {
     filter.insert(x);
   }


### PR DESCRIPTION
Currently, `BigintValuesUsingBloomFilter` is tightly bound to Velox's internal bloom filter implementation `SplitBlockBloomFilter`, along with `folly::hasher` as the pre-hashing function.

The PR aims to extend an API from `BigintValuesUsingBloomFilter` to support different bloom filter backends and hash functions. Specifically, Apache Spark + Gluten rely on the general-purpose `facebook::velox::BloomFilter` and `xxhash64` as the pre-hashing function.

The PR adds a `BloomFilterBackend` abstraction layer in `BigintValuesUsingBloomFilter`, so user can specify their own `BloomFilterBackend` implementation when `BigintValuesUsingBloomFilter` is created, which can be then set to Velox's table scan, via subfield filter API or the `Task::addDynamicFilter` API. By doing the refactor, the filter kind `kBigintValuesUsingBloomFilter`, and some important backend-ignostic code in `BigintValuesUsingBloomFilter` can be reused for user backend, e.g., `BigintValuesUsingBloomFilter::mergeWith`.

To explain the change, for example, when the filter is created, before the PR:

```cpp
auto filter = std::make_shared<common::BigintValuesUsingBloomFilter>(numDistinct_, false);
```

After the PR:

```cpp
auto bloomFilterBackend = std::make_shared<common::SplitBlockBloomFilterBackend>(numDistinct_);
auto filter = std::make_shared<common::BigintValuesUsingBloomFilter>(bloomFilterBackend, false);
```

The new `BloomFilterBackend` API:

```cpp
/// Backend for a Bloom filter. Implementations own the Bloom filter state and
/// define how values are hashed before lookup or insertion.
class BloomFilterBackend {
 public:
  virtual ~BloomFilterBackend() = default;

  /// Returns true if 'value' may have been inserted. False guarantees that
  /// 'value' was not inserted.
  virtual bool mayContainInt64(int64_t value) const = 0;

  /// Inserts 'value' into this backend.
  virtual void insertInt64(int64_t value) = 0;

  /// Returns the number of bytes used by the Bloom filter data.
  virtual int64_t byteSize() const = 0;

  /// Returns true if this backend has the same type and state as 'other'.
  virtual bool testingEquals(const BloomFilterBackend& other) const = 0;

  /// Returns an independent copy of this backend.
  virtual std::shared_ptr<BloomFilterBackend> clone() const = 0;
};
```

Related to discussions in https://github.com/facebookincubator/velox/pull/18064 and https://github.com/facebookincubator/velox/issues/18084.