### PR TITLE
fix(cudf): Fix CudfBatchConcat assertion failure for HashJoinNode

### DIFF
--- a/velox/experimental/cudf/exec/CudfBatchConcat.cpp
+++ b/velox/experimental/cudf/exec/CudfBatchConcat.cpp
@@ -35,9 +35,7 @@ RowTypePtr getConcatOutputType(
         "CudfBatchConcat expects a join plan node to have exactly 2 sources");
   } else {
     VELOX_CHECK_EQ(
-        numSources,
-        1,
-        "CudfBatchConcat expects a single-source plan node");
+        numSources, 1, "CudfBatchConcat expects a single-source plan node");
   }
   return planNode->sources()[0]->outputType();
 }

--- a/velox/experimental/cudf/exec/CudfBatchConcat.cpp
+++ b/velox/experimental/cudf/exec/CudfBatchConcat.cpp
@@ -27,10 +27,18 @@ namespace {
 
 RowTypePtr getConcatOutputType(
     const std::shared_ptr<const core::PlanNode>& planNode) {
-  VELOX_CHECK_EQ(
-      planNode->sources().size(),
-      1,
-      "CudfBatchConcat expects a single-source plan node");
+  const auto numSources = planNode->sources().size();
+  if (planNode->is<core::AbstractJoinNode>()) {
+    VELOX_CHECK_EQ(
+        numSources,
+        2,
+        "CudfBatchConcat expects a join plan node to have exactly 2 sources");
+  } else {
+    VELOX_CHECK_EQ(
+        numSources,
+        1,
+        "CudfBatchConcat expects a single-source plan node");
+  }
   return planNode->sources()[0]->outputType();
 }
 

--- a/velox/experimental/cudf/tests/BatchConcatTest.cpp
+++ b/velox/experimental/cudf/tests/BatchConcatTest.cpp
@@ -270,6 +270,66 @@ TEST_F(CudfBatchConcatTest, concatPreservesZeroColumnRowCountForCountStar) {
   EXPECT_EQ(concatIt->second->outputVectors, 1);
 }
 
+// Verifies that CudfBatchConcat is inserted before the hash join probe and
+// correctly handles the 2-source HashJoinNode plan node.
+TEST_F(CudfBatchConcatTest, concatBeforeHashJoinProbe) {
+  updateCudfConfig(/*min=*/30, /*max=*/std::nullopt);
+  CudfConfig::getInstance().concatOptimizationEnabled = true;
+
+  // Probe side: 6 batches of 10 rows each.
+  std::vector<RowVectorPtr> probeVectors;
+  for (int i = 0; i < 6; ++i) {
+    probeVectors.push_back(makeRowVector(
+        {"c0", "c1"},
+        {makeFlatVector<int64_t>(10, [i](auto row) { return row % 3; }),
+         makeFlatSequence<int64_t>(i * 10, 10)}));
+  }
+
+  // Build side: small dimension table.
+  auto buildVector = makeRowVector(
+      {"u_c0"}, {makeFlatVector<int64_t>({0, 1, 2})});
+
+  createDuckDbTable("probe", probeVectors);
+  createDuckDbTable("build", {buildVector});
+
+  auto generator = std::make_shared<core::PlanNodeIdGenerator>();
+  core::PlanNodeId joinNodeId;
+
+  auto plan =
+      PlanBuilder(generator)
+          .addNode([&](auto id, auto pool) {
+            return createFragmentedSource(probeVectors, generator);
+          })
+          .hashJoin(
+              {"c0"},
+              {"u_c0"},
+              PlanBuilder(generator).values({buildVector}).planNode(),
+              "",
+              {"c0", "c1"},
+              core::JoinType::kInner)
+          .capturePlanNodeId(joinNodeId)
+          .planNode();
+
+  auto task =
+      AssertQueryBuilder(duckDbQueryRunner_)
+          .plan(plan)
+          .maxDrivers(1)
+          .assertResults(
+              "SELECT p.c0, p.c1 FROM probe p INNER JOIN build b ON p.c0 = b.u_c0");
+
+  auto planStats = toPlanStats(task->taskStats());
+  auto& nodeStats = planStats.at(joinNodeId);
+  auto concatIt = nodeStats.operatorStats.find("CudfBatchConcat");
+  ASSERT_NE(concatIt, nodeStats.operatorStats.end())
+      << "CudfBatchConcat should be present before hash join probe";
+
+  auto& concatStats = *concatIt->second;
+  EXPECT_EQ(concatStats.inputVectors, 6)
+      << "CudfBatchConcat should have received all 6 probe batches";
+  EXPECT_LT(concatStats.outputVectors, concatStats.inputVectors)
+      << "CudfBatchConcat should produce fewer output batches than input";
+}
+
 TEST_F(CudfBatchConcatTest, concatSplitsZeroColumnBatchesAtMaxThreshold) {
   updateCudfConfig(/*min=*/30, /*max=*/20);
   CudfConfig::getInstance().concatOptimizationEnabled = true;

--- a/velox/experimental/cudf/tests/BatchConcatTest.cpp
+++ b/velox/experimental/cudf/tests/BatchConcatTest.cpp
@@ -286,8 +286,8 @@ TEST_F(CudfBatchConcatTest, concatBeforeHashJoinProbe) {
   }
 
   // Build side: small dimension table.
-  auto buildVector = makeRowVector(
-      {"u_c0"}, {makeFlatVector<int64_t>({0, 1, 2})});
+  auto buildVector =
+      makeRowVector({"u_c0"}, {makeFlatVector<int64_t>({0, 1, 2})});
 
   createDuckDbTable("probe", probeVectors);
   createDuckDbTable("build", {buildVector});
@@ -295,20 +295,19 @@ TEST_F(CudfBatchConcatTest, concatBeforeHashJoinProbe) {
   auto generator = std::make_shared<core::PlanNodeIdGenerator>();
   core::PlanNodeId joinNodeId;
 
-  auto plan =
-      PlanBuilder(generator)
-          .addNode([&](auto id, auto pool) {
-            return createFragmentedSource(probeVectors, generator);
-          })
-          .hashJoin(
-              {"c0"},
-              {"u_c0"},
-              PlanBuilder(generator).values({buildVector}).planNode(),
-              "",
-              {"c0", "c1"},
-              core::JoinType::kInner)
-          .capturePlanNodeId(joinNodeId)
-          .planNode();
+  auto plan = PlanBuilder(generator)
+                  .addNode([&](auto id, auto pool) {
+                    return createFragmentedSource(probeVectors, generator);
+                  })
+                  .hashJoin(
+                      {"c0"},
+                      {"u_c0"},
+                      PlanBuilder(generator).values({buildVector}).planNode(),
+                      "",
+                      {"c0", "c1"},
+                      core::JoinType::kInner)
+                  .capturePlanNodeId(joinNodeId)
+                  .planNode();
 
   auto task =
       AssertQueryBuilder(duckDbQueryRunner_)


### PR DESCRIPTION
### Summary

When instantiated before the HashJoinNode, CudfBatchConcat crashes at runtime. The assertion in getConcatOutputType() assumes that the plan node receives a single source, but since the hash join node accepts two source - one for the build and one for the probe - getConcatOutputType() throws an error.
The solution:
- Replace the blanket check with a type-aware assertion: AbstractJoinNode subclasses must have exactly 2 sources, all others must have exactly 1
- Add concatBeforeHashJoinProbe test that exercises the hash join code path