### PR TITLE
feat(hive): Add database name to FileScanBatchEvent (#18249)

### DIFF
--- a/velox/connectors/hive/FileDataSource.cpp
+++ b/velox/connectors/hive/FileDataSource.cpp
@@ -637,6 +637,7 @@ void FileDataSource::fireScanBatchCallback(core::ScanBatchEvent event) {
   fileEvent.wallTimeMicros = event.wallTimeMicros;
   if (tableHandle_) {
     fileEvent.tableName = tableHandle_->name();
+    fileEvent.dbName = tableHandle_->dbName();
   }
   if (split_) {
     fileEvent.filePath = split_->filePath;

--- a/velox/connectors/hive/FileDataSource.h
+++ b/velox/connectors/hive/FileDataSource.h
@@ -33,10 +33,13 @@
 
 namespace facebook::velox::connector::hive {
 
-/// File-specific scan batch event with split metadata.
+/// File-specific scan batch event with split metadata. Non-owning fields are
+/// valid only for the duration of the scan batch callback.
 struct FileScanBatchEvent : public core::ScanBatchEvent {
   /// Table name from the connector table handle.
   std::string_view tableName;
+  /// Database / namespace name from the connector table handle.
+  std::string_view dbName;
   /// File path of the current split.
   std::string_view filePath;
   /// Non-owning pointer to the current split's partition keys.

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -7045,17 +7045,33 @@ TEST_F(TableScanTest, scanBatchCallback) {
   uint64_t totalRows{0};
   uint64_t callbackCount{0};
   std::string receivedTableName;
+  std::string receivedDbName;
   auto queryCtx = core::QueryCtx::create(executor_.get());
   queryCtx->setScanBatchCallback([&](const core::ScanBatchEvent& event) {
     totalRows += event.numRows;
     if (const auto* fileEvent =
             dynamic_cast<const connector::hive::FileScanBatchEvent*>(&event)) {
       receivedTableName = std::string(fileEvent->tableName);
+      receivedDbName = std::string(fileEvent->dbName);
     }
     ++callbackCount;
   });
 
-  auto plan = tableScanNode();
+  auto tableHandle = makeTableHandle(
+      /*subfieldFilters=*/{},
+      /*remainingFilter=*/nullptr,
+      "scan_callback_table",
+      rowType_,
+      /*indexColumns=*/std::vector<std::string>{},
+      /*storageParameters=*/std::unordered_map<std::string, std::string>{},
+      "scan_callback_db");
+  auto plan = PlanBuilder(pool_.get())
+                  .startTableScan()
+                  .outputType(rowType_)
+                  .tableHandle(tableHandle)
+                  .assignments(allRegularColumns(rowType_))
+                  .endTableScan()
+                  .planNode();
   auto task = AssertQueryBuilder(plan)
                   .splits(makeHiveConnectorSplits({filePath}))
                   .queryCtx(queryCtx)
@@ -7063,7 +7079,8 @@ TEST_F(TableScanTest, scanBatchCallback) {
 
   EXPECT_GT(totalRows, 0);
   EXPECT_GT(callbackCount, 0);
-  EXPECT_FALSE(receivedTableName.empty());
+  EXPECT_EQ(receivedTableName, "scan_callback_table");
+  EXPECT_EQ(receivedDbName, "scan_callback_db");
 }
 
 TEST_F(TableScanTest, scanBatchCallbackPartitionKeys) {

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -136,7 +136,8 @@ class HiveConnectorTestBase : public OperatorTestBase {
       const RowTypePtr& dataColumns = nullptr,
       const std::vector<std::string>& indexColumns = {},
       const std::unordered_map<std::string, std::string>& storageParameters =
-          {}) {
+          {},
+      std::string dbName = "") {
     return std::make_shared<connector::hive::HiveTableHandle>(
         kHiveConnectorId,
         tableName,
@@ -144,7 +145,10 @@ class HiveConnectorTestBase : public OperatorTestBase {
         remainingFilter,
         dataColumns,
         indexColumns,
-        storageParameters);
+        storageParameters,
+        std::vector<connector::hive::HiveColumnHandlePtr>{},
+        /*sampleRate=*/1.0,
+        std::move(dbName));
   }
 
   /// @param name Column name.


### PR DESCRIPTION
Summary:

FileScanBatchEvent surfaces per-scan metadata (table name, file path, and
partition keys) to scan batch callbacks, but does not expose the database
(namespace) that the scanned table belongs to. Callbacks that key their
metrics on the fully qualified table identity cannot distinguish tables that
share a name across different databases.

Add a `dbName` field to `FileScanBatchEvent` and populate it from
`HiveTableHandle::dbName()` in `FileDataSource::fireScanBatchCallback`, next to
the existing `tableName`. Like the other members it is a non-owning
`std::string_view` that is valid only for the duration of the callback.

Reviewed By: amberMZ

Differential Revision: D112051174


