### PR TITLE
feat(torchwave): Per-graph config override, parallel sweep (#18251)

### DIFF
--- a/velox/experimental/torchwave/Compile.cpp
+++ b/velox/experimental/torchwave/Compile.cpp
@@ -2205,7 +2205,10 @@ std::unique_ptr<CompiledNode> CompileCtx::compileNode(ProjectNode& project) {
     return nullptr;
   }
   auto compositeKernel = std::make_unique<CompositeKernel>(
-      std::move(opStorage_), std::move(kernelOpStorage_), includes_);
+      std::move(opStorage_),
+      std::move(kernelOpStorage_),
+      includes_,
+      nextKernelId());
   // Values whose last use is in this node (graph outputs already excluded);
   // WaveConfig::freeIntermediates releases their frame tensors after execute().
   std::vector<nativert::ValueId> lastUseIds;

--- a/velox/experimental/torchwave/Compile.h
+++ b/velox/experimental/torchwave/Compile.h
@@ -292,7 +292,12 @@ class CompileCtx {
 
   void placeKernelLaunch(Launch launch);
 
-  static int32_t nextKernelId();
+  /// Returns the next kernel id for this compilation. The counter is per
+  /// CompileCtx (one per WaveGraph construction), so kernel names are
+  /// deterministic per graph regardless of how many graphs compile
+  /// concurrently. This keeps NVRTC cache keys stable (warm-cache hits) and
+  /// makes parallel compilation of different configs well-defined.
+  int32_t nextKernelId();
 
   KernelOperation* generatingOp() const {
     return generatingOp_;
@@ -322,7 +327,11 @@ class CompileCtx {
   Subgraph variantSubgraph(const Subgraph& sg, VariantMode mode);
 
  private:
-  inline static std::atomic<int32_t> kernelCounter_{0};
+  // Per-CompileCtx (one per WaveGraph construction), not process-wide, so no
+  // atomicity is needed: concurrent compilations use distinct CompileCtx
+  // instances, keeping kernel ids deterministic per graph for NVRTC cache-key
+  // stability.
+  int32_t kernelCounter_{0};
 
   template <typename Func>
   bool allReachable(

--- a/velox/experimental/torchwave/CompiledOp.cpp
+++ b/velox/experimental/torchwave/CompiledOp.cpp
@@ -28,6 +28,7 @@
 #include <folly/ScopeGuard.h>
 #include <gflags/gflags.h>
 #include <algorithm>
+#include <atomic>
 #include <fstream>
 #include <iostream>
 #include <sstream>
@@ -1064,9 +1065,9 @@ LaunchData::LaunchData(
 CompositeKernel::CompositeKernel(
     std::vector<std::unique_ptr<ProjectOperation>>&& ops,
     std::vector<std::unique_ptr<KernelOperation>>&& kernelOps,
-    const std::unordered_set<std::string>& includes)
+    const std::unordered_set<std::string>& includes,
+    int32_t kernelId)
     : ops_(std::move(ops)), kernelOpStorage_(std::move(kernelOps)) {
-  auto kernelId = CompileCtx::nextKernelId();
   auto kernelName = "torchwave" + std::to_string(kernelId);
   auto entryPoint = "torch::wave::" + kernelName;
 
@@ -1211,8 +1212,12 @@ CompositeKernel::CompositeKernel(
 
   auto code = ss.str();
 
-  // Save to /tmp for debugging.
-  auto filePath = "/tmp/kernel" + std::to_string(kernelId) + ".cu";
+  // Save to /tmp for debugging. Kernel ids are per-construction (not globally
+  // unique), so append a process-wide ordinal to keep filenames distinct when
+  // several graphs compile concurrently.
+  static std::atomic<int64_t> debugDumpOrdinal{0};
+  auto filePath = "/tmp/kernel" + std::to_string(kernelId) + "_" +
+      std::to_string(debugDumpOrdinal++) + ".cu";
   {
     std::ofstream out(filePath);
     out << code;
@@ -1630,8 +1635,10 @@ void fillLaunchParams(
           i,
           " isNone ",
           ivalue.isNone());
-      bool isShapeOnly = i < launch.actualOutputDescs.size() &&
-          launch.actualOutputDescs[i].shapeOnly;
+      bool isShapeOnly = false;
+      if (i < launch.actualOutputDescs.size()) {
+        isShapeOnly = launch.actualOutputDescs[i].shapeOnly;
+      }
       if (isShapeOnly) {
         fillShapeOnlyTensorParam(ivalue.toTensor(), dest);
         launch.shapeOnlyTensorIndices.insert(launch.tensorsInFrame.size());

--- a/velox/experimental/torchwave/CompiledOp.h
+++ b/velox/experimental/torchwave/CompiledOp.h
@@ -188,7 +188,8 @@ class CompositeKernel {
   CompositeKernel(
       std::vector<std::unique_ptr<ProjectOperation>>&& ops,
       std::vector<std::unique_ptr<KernelOperation>>&& kernelOps,
-      const std::unordered_set<std::string>& includes);
+      const std::unordered_set<std::string>& includes,
+      int32_t kernelId);
 
   /// Launches the kernel on the given stream.
   void launch(

--- a/velox/experimental/torchwave/Executor.cpp
+++ b/velox/experimental/torchwave/Executor.cpp
@@ -825,7 +825,10 @@ void checkValueBeforeFree(
   std::optional<at::Tensor> actual = iv.isTensor()
       ? std::optional<at::Tensor>(iv.toTensor())
       : scalarLikeToTensor(iv);
-  if (!actual || !actual->defined() || actual->numel() == 0) {
+  // A shape-only (meta) tensor carries no data; comparing it would force a
+  // .cpu() copy that throws "Cannot copy out of meta tensor". Skip it.
+  if (!actual || !actual->defined() || actual->numel() == 0 ||
+      actual->is_meta()) {
     return;
   }
   const auto& refTensor = it->second.toTensor();
@@ -937,8 +940,12 @@ void WaveGraphExecutor::executeWave(
   if (!prevWaveGraph) {
     threadWaveGraph = &waveGraph;
   }
+  auto*& threadConfigOverride = torch::wave::waveConfigOverride();
+  auto* prevConfigOverride = threadConfigOverride;
+  threadConfigOverride = waveGraph.configOverride();
   SCOPE_EXIT {
     threadWaveGraph = prevWaveGraph;
+    threadConfigOverride = prevConfigOverride;
   };
 
   Timer w("top exec", WaveConfig::get().printTiming);

--- a/velox/experimental/torchwave/WaveConfig.h
+++ b/velox/experimental/torchwave/WaveConfig.h
@@ -31,6 +31,15 @@ struct IValue;
 
 namespace torch::wave {
 
+struct WaveConfig;
+
+/// Returns a mutable reference to the thread-local WaveConfig override pointer.
+/// While it is non-null, WaveConfig::get() returns the pointee instead of the
+/// global singleton, so wave graphs compiled and executed with different
+/// configs can run concurrently on different threads. Null on threads with no
+/// active override.
+WaveConfig*& waveConfigOverride();
+
 /// Process-wide configuration for wave graph execution (block size, tracing,
 /// grid hints).
 struct WaveConfig {
@@ -135,8 +144,14 @@ struct WaveConfig {
   // them until the whole graph finishes. Off by default.
   bool freeIntermediates{false};
 
-  /// Not thread-safe. All mutations must happen before concurrent reads.
+  /// Returns the active config: the thread-local override set by
+  /// waveConfigOverride() when non-null, otherwise the process-wide singleton.
+  /// The singleton is not thread-safe; all of its mutations must happen before
+  /// concurrent reads.
   FOLLY_EXPORT static WaveConfig& get() {
+    if (auto* configOverride = waveConfigOverride()) {
+      return *configOverride;
+    }
     static WaveConfig instance;
     return instance;
   }

--- a/velox/experimental/torchwave/WaveGraph.cpp
+++ b/velox/experimental/torchwave/WaveGraph.cpp
@@ -134,6 +134,11 @@ WaveGraph*& waveGraph() {
   return threadWaveGraph;
 }
 
+WaveConfig*& waveConfigOverride() {
+  static thread_local WaveConfig* threadConfigOverride{nullptr};
+  return threadConfigOverride;
+}
+
 const Metadata* nodeMeta(NodeCP node) {
   auto* graph = waveGraph();
   TORCH_CHECK(graph, "No WaveGraph on this thread");
@@ -172,10 +177,15 @@ std::unique_ptr<WaveGraph> WaveGraph::optimizeOnly(
 }
 
 WaveGraph::WaveGraph(ModelContext* modelContext)
-    : graph_(modelContext->graph.get()), modelContext_(modelContext) {
+    : graph_(modelContext->graph.get()),
+      modelContext_(modelContext),
+      configOverride_(std::move(modelContext->configOverride)) {
   waveGraph() = this;
+  auto* prevConfigOverride = waveConfigOverride();
+  waveConfigOverride() = configOverride_.get();
   SCOPE_EXIT {
     waveGraph() = nullptr;
+    waveConfigOverride() = prevConfigOverride;
   };
 
   initValueTypes(*graph_, types_, metaStorage_);

--- a/velox/experimental/torchwave/WaveGraph.h
+++ b/velox/experimental/torchwave/WaveGraph.h
@@ -33,6 +33,7 @@
 #include <torch/nativert/kernels/KernelFactory.h>
 #include "velox/experimental/torchwave/KernelOperation.h"
 #include "velox/experimental/torchwave/Registry.h"
+#include "velox/experimental/torchwave/WaveConfig.h"
 
 namespace facebook::velox::wave {
 class CompiledKernel;
@@ -118,6 +119,12 @@ struct ModelContext {
   std::unique_ptr<nativert::Graph> graph;
   std::shared_ptr<nativert::Weights> weights;
   nativert::ExecutorConfig config;
+
+  /// Optional per-graph WaveConfig. When set, it is moved into the WaveGraph at
+  /// construction and installed as the thread-local override during that
+  /// graph's compilation and execution, so graphs with different configs can
+  /// run concurrently. Null => use the global WaveConfig.
+  std::shared_ptr<WaveConfig> configOverride;
 
   /// Creates OpKernels for all nodes in the graph.
   std::vector<std::unique_ptr<nativert::OpKernel>> makeKernels() const {
@@ -316,6 +323,12 @@ class WaveGraph {
     return modelContext_;
   }
 
+  /// Returns this graph's WaveConfig override, or nullptr if it uses the global
+  /// config. Installed into waveConfigOverride() during execution.
+  WaveConfig* configOverride() const {
+    return configOverride_.get();
+  }
+
   folly::F14FastMap<NodeCP, NodeInfo>& nodeInfos() {
     return nodeInfos_;
   }
@@ -394,6 +407,11 @@ class WaveGraph {
 
   // Retained for recreating OpKernels after graph mutations.
   ModelContext* modelContext_;
+
+  // Per-graph config override, moved from the ModelContext at construction and
+  // installed into the thread-local waveConfigOverride() during construction
+  // and execution. Null => this graph reads the global WaveConfig.
+  std::shared_ptr<WaveConfig> configOverride_;
 
   // Set during construction, cleared after.
   CompileCtx* compileCtx_{nullptr};

--- a/velox/experimental/torchwave/tests/ExecutorTestBase.cpp
+++ b/velox/experimental/torchwave/tests/ExecutorTestBase.cpp
@@ -25,6 +25,7 @@
 #include <fstream>
 #include <iostream>
 #include <map>
+#include <thread>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -665,7 +666,8 @@ void ExecutorTestBase::SetUpTestSuite() {
 std::vector<c10::IValue> ExecutorTestBase::executeSerialWithTrace(
     const nativert::Graph& graph,
     nativert::ExecutionFrame& frame,
-    std::vector<std::unique_ptr<nativert::OpKernel>> nodeKernels) {
+    std::vector<std::unique_ptr<nativert::OpKernel>> nodeKernels,
+    bool captureRefOutputs) {
   auto traceState = parseTraceValues(FLAGS_trace_values);
 
   // Trace user inputs already in the frame.
@@ -683,7 +685,7 @@ std::vector<c10::IValue> ExecutorTestBase::executeSerialWithTrace(
   // they are dead after the index_put. Skip recording them to avoid false
   // positives.
   std::unordered_set<int64_t> inPlaceSelfIds;
-  if (!FLAGS_save_reference_frame.empty()) {
+  if (captureRefOutputs) {
     for (size_t scanIdx = 1; scanIdx + 1 < nodeKernels.size(); ++scanIdx) {
       auto* scanNode = nodeKernels[scanIdx]->node();
       std::string target(scanNode->target());
@@ -711,8 +713,7 @@ std::vector<c10::IValue> ExecutorTestBase::executeSerialWithTrace(
         // OOMs). copy=true forces a fresh tensor even when the value is already
         // on CPU. Skip scratch self-args of index_put (see inPlaceSelfIds
         // above).
-        if (!FLAGS_save_reference_frame.empty() &&
-            !inPlaceSelfIds.count(output->id())) {
+        if (captureRefOutputs && !inPlaceSelfIds.count(output->id())) {
           const auto& iv = frame.getIValue(output->id());
           if (iv.isTensor() && iv.toTensor().numel() > 0) {
             capturedRefOutputs_[output->id()] = iv.toTensor().detach().to(
@@ -777,8 +778,11 @@ RunTiming ExecutorTestBase::runSerial(
     auto traceKernels = fixture.makeKernels();
     nativert::SerialGraphExecutor tempExecutor(
         graph, std::move(traceKernels), serialConfig);
-    outputs =
-        executeSerialWithTrace(graph, *frame, tempExecutor.stealKernels());
+    outputs = executeSerialWithTrace(
+        graph,
+        *frame,
+        tempExecutor.stealKernels(),
+        /*captureRefOutputs=*/!FLAGS_save_reference_frame.empty());
   } else {
     outputs = executor.executeWithPrefilledFrame(*frame);
   }
@@ -1404,10 +1408,17 @@ std::vector<c10::IValue> ExecutorTestBase::runNativertReferenceWithInputs(
   rewriteGpuIncompatibleOps(graph);
   insertCpuOnlyCopies(graph);
 
+  // When saving a reference frame, disable nativert's free-after-last-use so
+  // intermediates are not reclaimed before they are captured (they are copied
+  // to CPU on-produce below, so the frame is not held on the GPU).
+  auto refConfig = fixture.config;
+  if (!refFramePath.empty()) {
+    refConfig.tryFreeUnmanagedValuesAfterUse = false;
+  }
   nativert::SerialGraphExecutor executor(
-      graph, fixture.makeKernels(), fixture.config);
+      graph, fixture.makeKernels(), refConfig);
   auto frame = std::make_unique<nativert::ExecutionFrame>(
-      graph, *fixture.weights, fixture.config);
+      graph, *fixture.weights, refConfig);
 
   auto [deviceInputs, dataMovUs] = inputsToDevice(inputs);
   auto* waveDevice = facebook::velox::wave::currentDevice();
@@ -1417,11 +1428,72 @@ std::vector<c10::IValue> ExecutorTestBase::runNativertReferenceWithInputs(
   at::cuda::set_device(static_cast<c10::DeviceIndex>(waveDevice->deviceId));
 
   fillFrameFromUserInputs(graph, *frame, deviceInputs);
-  auto outputs = executor.executeWithPrefilledFrame(*frame);
+
+  std::vector<c10::IValue> outputs;
   if (!refFramePath.empty()) {
-    saveReferenceFrame(*frame, graph, refFramePath);
+    // Capture every intermediate on-produce (node by node), the same way the
+    // sigmoid --reference_from_gpu path does. A plain executeWithPrefilledFrame
+    // frees each intermediate right after its last use, so a post-run frame
+    // snapshot would only retain outputs and persistent values (the strict
+    // per-intermediate check then covers almost nothing). The 4-arg
+    // saveReferenceFrame prefers these captured copies, so the reference frame
+    // covers all intermediates.
+    capturedRefOutputs_.clear();
+    outputs = executeSerialWithTrace(
+        graph, *frame, executor.stealKernels(), /*captureRefOutputs=*/true);
+    saveReferenceFrame(*frame, graph, capturedRefOutputs_, refFramePath);
+  } else {
+    outputs = executor.executeWithPrefilledFrame(*frame);
   }
   return outputsToHost(outputs, "synthetic-ref");
+}
+
+void ExecutorTestBase::executeAndCompareWave(
+    WaveGraphExecutor& waveExec,
+    const std::vector<c10::IValue>& deviceInputs,
+    const std::vector<c10::IValue>& expected,
+    const std::string& label,
+    bool haveRefFrame) {
+  auto& graph = waveExec.graph();
+  auto pooledFrame = waveExec.getFrame();
+  fillFrameFromUserInputs(graph, *pooledFrame, deviceInputs);
+  auto waveOutputs = waveExec.executeWithPrefilledFrame(*pooledFrame);
+  waveExec.returnFrame(std::move(pooledFrame));
+
+  lastRefTensorsChecked_ = waveExec.numRefTensorsChecked();
+  lastRefNodesChecked_ = waveExec.numRefNodesChecked();
+  if (haveRefFrame) {
+    LOG(INFO) << label << " reference frame: checked " << lastRefTensorsChecked_
+              << " tensors, " << lastRefNodesChecked_ << " nodes";
+  }
+
+  auto hostOutputs = outputsToHost(waveOutputs, label);
+
+  // Compare wave outputs against the nativert reference the way the sigmoid
+  // [refout] check does: tensors only, non-fatal, counting mismatches. Some
+  // final outputs are legitimately None in wave (unmaterialized), so a strict
+  // verifyOutputs would spuriously fail; the per-intermediate reference-frame
+  // check is the strict correctness gate.
+  size_t numToCheck = std::min(hostOutputs.size(), expected.size());
+  int compared = 0, mismatched = 0, skipped = 0;
+  for (size_t i = 0; i < numToCheck; ++i) {
+    if (!expected[i].isTensor() || !hostOutputs[i].isTensor()) {
+      ++skipped;
+      continue;
+    }
+    ++compared;
+    auto actual = hostOutputs[i].toTensor();
+    auto exp = expected[i].toTensor();
+    if (actual.sizes() != exp.sizes() || !tensorsMatch(actual, exp)) {
+      ++mismatched;
+      LOG(ERROR) << label << " output " << i
+                 << " differs from reference: " << firstDifference(actual, exp);
+    }
+  }
+  LOG(INFO) << label << ": " << compared << " outputs compared, " << mismatched
+            << " mismatched, " << skipped << " skipped (non-tensor)";
+  EXPECT_EQ(mismatched, 0) << label << ": " << mismatched
+                           << " output(s) differ from the nativert reference";
 }
 
 void ExecutorTestBase::runWaveWithInputs(
@@ -1436,51 +1508,172 @@ void ExecutorTestBase::runWaveWithInputs(
   }
 
   WaveGraphExecutor waveExec(fixture.makeModelContext());
-  auto& graph = waveExec.graph();
-  auto pooledFrame = waveExec.getFrame();
-
   auto [deviceInputs, dataMovUs] = inputsToDevice(inputs);
-  fillFrameFromUserInputs(graph, *pooledFrame, deviceInputs);
-  auto waveOutputs = waveExec.executeWithPrefilledFrame(*pooledFrame);
-  waveExec.returnFrame(std::move(pooledFrame));
+  executeAndCompareWave(
+      waveExec,
+      deviceInputs,
+      expected,
+      "synthetic-wave",
+      !refFramePath.empty());
 
-  lastRefTensorsChecked_ = waveExec.numRefTensorsChecked();
-  lastRefNodesChecked_ = waveExec.numRefNodesChecked();
   WaveConfig::get().referenceFrame = nullptr;
-  if (!refFramePath.empty()) {
-    LOG(INFO) << "synthetic-wave reference frame: checked "
-              << lastRefTensorsChecked_ << " tensors, " << lastRefNodesChecked_
-              << " nodes";
+}
+
+void ExecutorTestBase::runSyntheticSweep(
+    const std::string& path,
+    std::optional<uint64_t> seed) {
+  std::string pt2Path = path + ".pt2";
+  const std::string specPath = path + ".spec";
+
+  std::string tempPt2;
+  if (!std::filesystem::exists(pt2Path) &&
+      std::filesystem::exists(pt2Path + ".gz")) {
+    tempPt2 = decompressGzToTemp(pt2Path + ".gz");
+    pt2Path = tempPt2;
   }
 
-  auto hostOutputs = outputsToHost(waveOutputs, "synthetic-wave");
+  auto* waveDevice = facebook::velox::wave::currentDevice();
+  if (!waveDevice) {
+    waveDevice = facebook::velox::wave::getDevice();
+  }
+  c10::Device weightDevice(
+      c10::kCUDA, static_cast<c10::DeviceIndex>(waveDevice->deviceId));
 
-  // Compare wave outputs against the nativert reference the way the sigmoid
-  // [refout] check does: tensors only, non-fatal, counting mismatches. Some
-  // final outputs are legitimately None in wave (unmaterialized), so a strict
-  // verifyOutputs would spuriously fail; the per-intermediate reference-frame
-  // check above is the strict correctness gate.
-  size_t numToCheck = std::min(hostOutputs.size(), expected.size());
-  int compared = 0, mismatched = 0, skipped = 0;
-  for (size_t i = 0; i < numToCheck; ++i) {
-    if (!expected[i].isTensor() || !hostOutputs[i].isTensor()) {
-      ++skipped;
+  // Generate data and run the nativert-GPU reference exactly once; every config
+  // verifies against this single reference (outputs plus the reference frame).
+  auto refFixture = loadSyntheticFixture(pt2Path);
+  ASSERT_NE(refFixture, nullptr);
+  auto generated =
+      generateFromSpec(*refFixture->model.graph, specPath, seed, weightDevice);
+  refFixture->weights = generated.weights;
+
+  const std::string refFramePath =
+      "/tmp/torchwave_synthetic_ref_" + std::to_string(getpid()) + ".pt";
+  auto expected = runNativertReferenceWithInputs(
+      *refFixture, generated.userInputs, refFramePath);
+
+  // Load the reference frame once. Verification only reads it and executions
+  // are serial, so all configs share this single map.
+  auto refFrame = loadReferenceFrame(refFramePath);
+
+  struct SweepConfig {
+    const char* name{};
+    std::optional<bool> cg;
+    std::optional<bool> single;
+    bool autoAdjustCost{};
+    bool freeIntermediates{};
+  };
+  const SweepConfig configs[] = {
+      {"auto", std::nullopt, std::nullopt, false, false},
+      {"auto", std::nullopt, std::nullopt, false, true},
+      {"cg=1",
+       std::optional<bool>(true),
+       std::optional<bool>(false),
+       true,
+       false},
+      {"cg=1",
+       std::optional<bool>(true),
+       std::optional<bool>(false),
+       true,
+       true},
+      {"cg=0,multi",
+       std::optional<bool>(false),
+       std::optional<bool>(false),
+       false,
+       false},
+      {"cg=0,multi",
+       std::optional<bool>(false),
+       std::optional<bool>(false),
+       false,
+       true},
+      {"single_block", std::nullopt, std::optional<bool>(true), false, false},
+      {"single_block", std::nullopt, std::optional<bool>(true), false, true},
+  };
+  const size_t numConfigs = sizeof(configs) / sizeof(configs[0]);
+
+  // Build one ModelContext per config on this thread (graph load, rewrites and
+  // device placement are serial to avoid graph-mutation races). Each context
+  // carries its own WaveConfig override: a copy of the current config (so
+  // kernelCacheDir / trace / blockSize etc. are preserved) with this mode's
+  // grid and freeing flags and a pointer to the shared reference frame.
+  const WaveConfig baseConfig = WaveConfig::get();
+  std::vector<std::unique_ptr<ModelContext>> contexts(numConfigs);
+  std::vector<std::string> labels(numConfigs);
+  for (size_t i = 0; i < numConfigs; ++i) {
+    auto fixture = loadSyntheticFixture(pt2Path);
+    ASSERT_NE(fixture, nullptr);
+    fixture->weights = generated.weights;
+    stripDataAsserts(*fixture->model.graph);
+    applySyntheticGraphRewrites(*fixture->model.graph);
+    setGraphDevice(fixture->model.graph.get(), true);
+
+    auto ctx = fixture->makeModelContext();
+    auto cfg = std::make_shared<WaveConfig>(baseConfig);
+    cfg->isCg = configs[i].cg;
+    cfg->useSingleBlock = configs[i].single;
+    cfg->autoAdjustCost = configs[i].autoAdjustCost;
+    cfg->freeIntermediates = configs[i].freeIntermediates;
+    cfg->referenceFrame = &refFrame;
+    ctx->configOverride = std::move(cfg);
+    contexts[i] = std::move(ctx);
+    labels[i] = std::string("synthetic-wave[") + configs[i].name +
+        " free=" + (configs[i].freeIntermediates ? "true" : "false") + "]";
+  }
+
+  // Compile all configs' executors in parallel (construction is the compile
+  // step). The WaveConfig thread-local override makes each construction use its
+  // own config, and per-construction kernel ids keep cache keys stable. gtest
+  // assertions are not thread-safe, so a construction failure is captured as an
+  // exception and surfaced on this thread after the joins.
+  std::vector<std::unique_ptr<WaveGraphExecutor>> execs(numConfigs);
+  std::vector<std::exception_ptr> compileErrors(numConfigs);
+  {
+    std::vector<std::thread> threads;
+    threads.reserve(numConfigs);
+    for (size_t i = 0; i < numConfigs; ++i) {
+      threads.emplace_back([&, i] {
+        try {
+          auto* device = facebook::velox::wave::currentDevice();
+          if (!device) {
+            device = facebook::velox::wave::getDevice();
+          }
+          facebook::velox::wave::setDevice(device);
+          execs[i] =
+              std::make_unique<WaveGraphExecutor>(std::move(contexts[i]));
+        } catch (...) {
+          compileErrors[i] = std::current_exception();
+        }
+      });
+    }
+    for (auto& thread : threads) {
+      thread.join();
+    }
+  }
+  LOG(INFO) << "synthetic sweep: compiled " << numConfigs
+            << " configs in parallel";
+
+  // Execute serially so only one config's intermediates are resident at a time.
+  auto [deviceInputs, dataMovUs] = inputsToDevice(generated.userInputs);
+  for (size_t i = 0; i < numConfigs; ++i) {
+    LOG(INFO) << "==== synthetic sweep: " << labels[i] << " ====";
+    if (compileErrors[i]) {
+      try {
+        std::rethrow_exception(compileErrors[i]);
+      } catch (const std::exception& e) {
+        ADD_FAILURE() << labels[i] << " failed to compile: " << e.what();
+      }
       continue;
     }
-    ++compared;
-    auto actual = hostOutputs[i].toTensor();
-    auto exp = expected[i].toTensor();
-    if (actual.sizes() != exp.sizes() || !tensorsMatch(actual, exp)) {
-      ++mismatched;
-      LOG(ERROR) << "synthetic-wave output " << i
-                 << " differs from reference: " << firstDifference(actual, exp);
-    }
+    executeAndCompareWave(
+        *execs[i], deviceInputs, expected, labels[i], /*haveRefFrame=*/true);
+    // Release this config's executor before the next runs to bound memory.
+    execs[i].reset();
   }
-  LOG(INFO) << "synthetic-wave: " << compared << " outputs compared, "
-            << mismatched << " mismatched, " << skipped
-            << " skipped (non-tensor)";
-  EXPECT_EQ(mismatched, 0) << "synthetic-wave: " << mismatched
-                           << " output(s) differ from the nativert reference";
+
+  std::remove(refFramePath.c_str());
+  if (!tempPt2.empty()) {
+    std::remove(tempPt2.c_str());
+  }
 }
 
 void ExecutorTestBase::runSynthetic(

--- a/velox/experimental/torchwave/tests/ExecutorTestBase.h
+++ b/velox/experimental/torchwave/tests/ExecutorTestBase.h
@@ -202,11 +202,16 @@ class ExecutorTestBase : public ::testing::Test {
       const std::string& label = "");
 
   /// Executes a pre-filled frame node by node using the given kernels,
-  /// tracing values in trace_values. Returns the user outputs.
+  /// tracing values in trace_values. Returns the user outputs. When
+  /// 'captureRefOutputs' is true, deep-copies every node output to CPU into
+  /// capturedRefOutputs_ the instant it is produced (before nativert can free
+  /// it or an in-place op can overwrite it), so a reference frame saved from
+  /// those copies covers all intermediates.
   std::vector<c10::IValue> executeSerialWithTrace(
       const nativert::Graph& graph,
       nativert::ExecutionFrame& frame,
-      std::vector<std::unique_ptr<nativert::OpKernel>> nodeKernels);
+      std::vector<std::unique_ptr<nativert::OpKernel>> nodeKernels,
+      bool captureRefOutputs);
 
   virtual std::string dataDir() const {
     return "velox/experimental/torchwave/tests";
@@ -241,6 +246,17 @@ class ExecutorTestBase : public ::testing::Test {
       const std::string& path,
       std::optional<uint64_t> seed = std::nullopt);
 
+  /// Like runSynthetic, but sweeps every wave execution mode (auto /
+  /// cooperative / multi-block / single-block) with intermediate freeing off
+  /// and on. Runs the nativert-GPU reference once and reuses it for all
+  /// configs; compiles every config's executor in parallel (each under its own
+  /// WaveConfig override) and then executes them serially so only one config's
+  /// intermediates are resident at a time. A failure in one config is recorded
+  /// but does not stop the others.
+  void runSyntheticSweep(
+      const std::string& path,
+      std::optional<uint64_t> seed = std::nullopt);
+
   /// Runs 'fixture' through the nativert serial executor on GPU with explicit
   /// 'inputs' (not loadSampleInputs). Applies applySyntheticGraphRewrites, then
   /// GPU placement (setGraphDevice / rewriteGpuIncompatibleOps /
@@ -261,6 +277,18 @@ class ExecutorTestBase : public ::testing::Test {
       std::vector<c10::IValue> inputs,
       const std::vector<c10::IValue>& expected,
       const std::string& refFramePath);
+
+  /// Executes an already-built wave executor on 'deviceInputs' and compares its
+  /// outputs against 'expected' (tensors only, non-fatal, counting mismatches),
+  /// prefixing log/failure messages with 'label'. 'haveRefFrame' controls the
+  /// reference-frame summary log. Shared by runWaveWithInputs and
+  /// runSyntheticSweep.
+  void executeAndCompareWave(
+      WaveGraphExecutor& waveExec,
+      const std::vector<c10::IValue>& deviceInputs,
+      const std::vector<c10::IValue>& expected,
+      const std::string& label,
+      bool haveRefFrame);
 
   /// Counters copied from WaveGraphExecutor after runWave.
   int64_t lastRefTensorsChecked_{0};

--- a/velox/experimental/torchwave/tests/reverseBenchmark.cu
+++ b/velox/experimental/torchwave/tests/reverseBenchmark.cu
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Microbenchmark: does coalesced global memory run as fast descending as
+// ascending?
+//
+// A 4 GB int64 array is filled with src[i] = i and copied in reverse
+// (dst[i] = src[n-1-i]) three ways, each a grid-strided loop launched with an
+// occupancy-full grid (numSMs * maxActiveBlocksPerSM):
+//   forwardCopy   dst[i] = src[i]                 -- baseline, both ascending.
+//   reverseDirect dst[n-1-i] = src[i]             -- ascending read, DESCENDING
+//                                                    write.
+//   reverseShared read a block chunk ascending into shared, then write the
+//                 mirrored chunk with an ascending global write whose values
+//                 come from a reversed shared read -- both global accesses
+//                 ascending, the reversal is confined to shared memory.
+//
+// If descending coalesced access is as fast as ascending, reverseDirect matches
+// forwardCopy and there is nothing to gain from reverseShared.
+
+#include <cuda_runtime.h>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+
+namespace {
+
+constexpr int kBlockSize = 256;
+constexpr int kIters = 10;
+
+#define CUDA_CHECK(expr)              \
+  do {                                \
+    cudaError_t err = (expr);         \
+    if (err != cudaSuccess) {         \
+      fprintf(                        \
+          stderr,                     \
+          "CUDA error %s at %s:%d\n", \
+          cudaGetErrorString(err),    \
+          __FILE__,                   \
+          __LINE__);                  \
+      std::abort();                   \
+    }                                 \
+  } while (0)
+
+__global__ void fillIota(int64_t* src, int64_t n) {
+  int64_t stride = static_cast<int64_t>(gridDim.x) * blockDim.x;
+  for (int64_t i = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+       i < n;
+       i += stride) {
+    src[i] = i;
+  }
+}
+
+__global__ void forwardCopy(const int64_t* src, int64_t* dst, int64_t n) {
+  int64_t stride = static_cast<int64_t>(gridDim.x) * blockDim.x;
+  for (int64_t i = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+       i < n;
+       i += stride) {
+    dst[i] = src[i];
+  }
+}
+
+__global__ void reverseDirect(const int64_t* src, int64_t* dst, int64_t n) {
+  int64_t stride = static_cast<int64_t>(gridDim.x) * blockDim.x;
+  for (int64_t i = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+       i < n;
+       i += stride) {
+    // Ascending read, descending write.
+    dst[n - 1 - i] = src[i];
+  }
+}
+
+// One block-sized chunk of src is read ascending into shared, then written to
+// its mirrored position in dst with an ascending global write whose value comes
+// from a reversed shared read. Both global accesses are ascending. Requires
+// n % blockDim.x == 0.
+__global__ void reverseShared(const int64_t* src, int64_t* dst, int64_t n) {
+  __shared__ int64_t tile[kBlockSize];
+  int64_t numChunks = n / blockDim.x;
+  for (int64_t chunk = blockIdx.x; chunk < numChunks; chunk += gridDim.x) {
+    int64_t base = chunk * blockDim.x;
+    tile[threadIdx.x] = src[base + threadIdx.x];
+    __syncthreads();
+    // The mirror of the source chunk [base, base + B) is dst [n-base-B,
+    // n-base).
+    int64_t dstBase = n - base - blockDim.x;
+    dst[dstBase + threadIdx.x] = tile[blockDim.x - 1 - threadIdx.x];
+    __syncthreads();
+  }
+}
+
+__global__ void
+countErrors(const int64_t* dst, int64_t n, bool reversed, int* errors) {
+  int64_t stride = static_cast<int64_t>(gridDim.x) * blockDim.x;
+  for (int64_t i = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+       i < n;
+       i += stride) {
+    int64_t expected = reversed ? (n - 1 - i) : i;
+    if (dst[i] != expected) {
+      atomicAdd(errors, 1);
+    }
+  }
+}
+
+int occupancyGrid(const void* kernel, size_t sharedBytes, int numSms) {
+  int blocksPerSm = 0;
+  CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+      &blocksPerSm, kernel, kBlockSize, sharedBytes));
+  return numSms * blocksPerSm;
+}
+
+// Times 'kIters' launches of 'launch' with CUDA events and returns the average
+// milliseconds per launch.
+template <typename Launch>
+float timeMs(Launch launch) {
+  cudaEvent_t start;
+  cudaEvent_t stop;
+  CUDA_CHECK(cudaEventCreate(&start));
+  CUDA_CHECK(cudaEventCreate(&stop));
+  launch(); // warmup
+  CUDA_CHECK(cudaDeviceSynchronize());
+  CUDA_CHECK(cudaEventRecord(start));
+  for (int i = 0; i < kIters; ++i) {
+    launch();
+  }
+  CUDA_CHECK(cudaEventRecord(stop));
+  CUDA_CHECK(cudaEventSynchronize(stop));
+  float ms = 0;
+  CUDA_CHECK(cudaEventElapsedTime(&ms, start, stop));
+  CUDA_CHECK(cudaEventDestroy(start));
+  CUDA_CHECK(cudaEventDestroy(stop));
+  return ms / kIters;
+}
+
+int64_t verify(const int64_t* dst, int64_t n, bool reversed, int numSms) {
+  int* dErrors = nullptr;
+  CUDA_CHECK(cudaMalloc(&dErrors, sizeof(int)));
+  CUDA_CHECK(cudaMemset(dErrors, 0, sizeof(int)));
+  countErrors<<<numSms * 32, kBlockSize>>>(dst, n, reversed, dErrors);
+  CUDA_CHECK(cudaDeviceSynchronize());
+  int hErrors = 0;
+  CUDA_CHECK(
+      cudaMemcpy(&hErrors, dErrors, sizeof(int), cudaMemcpyDeviceToHost));
+  CUDA_CHECK(cudaFree(dErrors));
+  return hErrors;
+}
+
+} // namespace
+
+int main() {
+  int device = 0;
+  CUDA_CHECK(cudaGetDevice(&device));
+  cudaDeviceProp prop;
+  CUDA_CHECK(cudaGetDeviceProperties(&prop, device));
+  int numSms = prop.multiProcessorCount;
+  // Nominal (theoretical peak) HBM bandwidth: 2 (DDR) * clock(Hz) * bytes/txn.
+  double nominalGbps = 2.0 * static_cast<double>(prop.memoryClockRate) * 1.0e3 *
+      (prop.memoryBusWidth / 8) / 1.0e9;
+
+  const int64_t kArrayBytes = 4LL * 1024 * 1024 * 1024; // 4 GiB per array.
+  int64_t n = kArrayBytes / static_cast<int64_t>(sizeof(int64_t));
+  n = (n / kBlockSize) * kBlockSize;
+  double gib =
+      static_cast<double>(n * sizeof(int64_t)) / (1024.0 * 1024.0 * 1024.0);
+  // Each copy reads the whole array and writes the whole array.
+  double bytesPerCopy = 2.0 * static_cast<double>(n) * sizeof(int64_t);
+
+  printf(
+      "GPU: %s, %d SMs. Array: %ld int64 (%.2f GiB), copy moves %.2f GiB "
+      "(read+write). %d iters/kernel. Nominal BW: %.1f GB/s.\n",
+      prop.name,
+      numSms,
+      static_cast<long>(n),
+      gib,
+      2 * gib,
+      kIters,
+      nominalGbps);
+
+  int64_t* src = nullptr;
+  int64_t* dst = nullptr;
+  CUDA_CHECK(cudaMalloc(&src, n * sizeof(int64_t)));
+  CUDA_CHECK(cudaMalloc(&dst, n * sizeof(int64_t)));
+
+  int gridFill = occupancyGrid((const void*)fillIota, 0, numSms);
+  fillIota<<<gridFill, kBlockSize>>>(src, n);
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  // For each kernel, sweep achieved occupancy by launching one wave at a
+  // fraction of the max resident blocks/SM (grid = numSms * round(frac *
+  // blocksPerSm)). This models the effect register pressure would have: fewer
+  // resident blocks/SM. A memory-bound copy that already saturates below 100%
+  // occupancy will hold its throughput as the fraction drops.
+  auto run =
+      [&](const char* name, auto kernel, size_t sharedBytes, bool reversed) {
+        int blocksPerSm = 0;
+        CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+            &blocksPerSm, (const void*)kernel, kBlockSize, sharedBytes));
+        printf(
+            "  %-14s max occupancy: %d blocks/SM (%d threads/SM)\n",
+            name,
+            blocksPerSm,
+            blocksPerSm * kBlockSize);
+        const double fracs[] = {1.0, 0.75, 0.5};
+        for (double frac : fracs) {
+          int bps = static_cast<int>(llround(frac * blocksPerSm));
+          if (bps < 1) {
+            bps = 1;
+          }
+          int grid = numSms * bps;
+          CUDA_CHECK(cudaMemset(dst, 0, n * sizeof(int64_t)));
+          kernel<<<grid, kBlockSize>>>(src, dst, n);
+          CUDA_CHECK(cudaDeviceSynchronize());
+          int64_t errors = verify(dst, n, reversed, numSms);
+          float ms =
+              timeMs([&]() { kernel<<<grid, kBlockSize>>>(src, dst, n); });
+          double gbps = bytesPerCopy / (ms / 1000.0) / 1.0e9;
+          printf(
+              "    occ %3.0f%% (%d blk/SM, grid=%d)  %.3f ms  %.1f GB/s  "
+              "(%.0f%% nominal)  errors=%ld\n",
+              frac * 100.0,
+              bps,
+              grid,
+              ms,
+              gbps,
+              100.0 * gbps / nominalGbps,
+              static_cast<long>(errors));
+        }
+      };
+
+  printf("\n");
+  run("forwardCopy", forwardCopy, 0, /*reversed=*/false);
+  run("reverseDirect", reverseDirect, 0, /*reversed=*/true);
+  run("reverseShared",
+      reverseShared,
+      kBlockSize * sizeof(int64_t),
+      /*reversed=*/true);
+
+  CUDA_CHECK(cudaFree(src));
+  CUDA_CHECK(cudaFree(dst));
+  return 0;
+}


### PR DESCRIPTION
Summary:

A WaveGraph can now carry its own WaveConfig instead of reading one process-wide singleton. `WaveConfig::get()` first checks a thread-local override and falls back to the global config when none is set, so single-config runs are unchanged. This lets graphs with different configs compile and run at the same time on different threads.

The heavy synthetic ROO tests use this to cut a long serial run. They sweep eight configs: four grid modes, each with intermediate freeing off and on. Previously each config was an independent run that recompiled its kernels and re-ran the full nativert-GPU reference. The sweep now runs the nativert reference once, compiles all eight executors in parallel (each under its own config), then executes them one at a time so only one config's intermediates are resident at once.

Two supporting changes make the parallel path sound. Kernel ids are now assigned per graph instead of from a process-wide counter. Kernel names (and the NVRTC cache keys derived from them) then stay deterministic when several graphs compile at once, and identical kernels from different graphs share one cache entry. The synthetic reference is captured node by node as each value is produced, so the per-intermediate check covers every intermediate, not only the values that survive nativert's free-after-last-use.

Merge-and-dedup ranking is now tolerant of out-of-order input. The rank stage requires each feature group's active entries to be ascending by order key. Production order features already arrive sorted, so the kernel detects that in parallel -- a block-wide AND over adjacent within-group pairs -- and skips sorting entirely on the common path. When a group is actually unsorted (e.g. synthetic test data, or otherwise badly ordered input) it falls back to a stable per-group insertion sort that deterministically repairs the order, with equal keys keeping their original position to match the base op's (orderKey, position) total order. This makes the op easy to exercise with synthetic data that is not pre-sorted, and hardens it against bad ordering the same way its SparseNN equivalent is.

Reviewed By: Yuhta

Differential Revision: D112166574


