### PR TITLE
fix(cudf): Add allPeersFinished coordination to CudfDistinct for multi-driver correctness

### DIFF
--- a/velox/experimental/cudf/exec/CudfDistinct.cpp
+++ b/velox/experimental/cudf/exec/CudfDistinct.cpp
@@ -20,6 +20,7 @@
 
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/HashAggregation.h"
+#include "velox/exec/Task.h"
 
 #include <cudf/concatenate.hpp>
 #include <cudf/detail/utilities/stream_pool.hpp>
@@ -193,7 +194,10 @@ RowVectorPtr CudfDistinct::doGetOutput() {
     return nullptr;
   }
 
-  if (inputs_.empty() && !noMoreInput_) {
+  if (inputs_.empty()) {
+    // Non-last drivers have their inputs moved away by the last driver during
+    // allPeersFinished coordination. Nothing left to process.
+    finished_ = true;
     return nullptr;
   }
 
@@ -217,9 +221,50 @@ RowVectorPtr CudfDistinct::doGetOutput() {
 
 void CudfDistinct::doNoMoreInput() {
   Operator::noMoreInput();
-  if (isPartialOutput_ && inputs_.empty()) {
-    finished_ = true;
+  if (isPartialOutput_) {
+    if (inputs_.empty()) {
+      finished_ = true;
+    }
+    return;
   }
+
+  // FINAL distinct: coordinate across peer drivers so that one driver
+  // collects all inputs and produces a single globally-distinct result.
+  std::vector<ContinuePromise> promises;
+  std::vector<std::shared_ptr<exec::Driver>> peers;
+
+  if (!operatorCtx_->task()->allPeersFinished(
+          planNodeId(), operatorCtx_->driver(), &future_, promises, peers)) {
+    return; // Not the last driver — block until peer finishes
+  }
+
+  // Wake up peer drivers when we finish collecting data, even on exception.
+  SCOPE_EXIT {
+    peers.clear();
+    for (auto& promise : promises) {
+      promise.setValue();
+    }
+  };
+
+  // This driver was chosen to collect data from all peers.
+  for (auto& peer : peers) {
+    auto op = peer->findOperator(planNodeId());
+    auto* peerDistinct = dynamic_cast<CudfDistinct*>(op);
+    VELOX_CHECK_NOT_NULL(peerDistinct);
+    inputs_.insert(
+        inputs_.end(),
+        std::make_move_iterator(peerDistinct->inputs_.begin()),
+        std::make_move_iterator(peerDistinct->inputs_.end()));
+    peerDistinct->inputs_.clear();
+  }
+}
+
+exec::BlockingReason CudfDistinct::isBlocked(ContinueFuture* future) {
+  if (!future_.valid()) {
+    return exec::BlockingReason::kNotBlocked;
+  }
+  *future = std::move(future_);
+  return exec::BlockingReason::kWaitForAggregationPeers;
 }
 
 bool CudfDistinct::isFinished() {

--- a/velox/experimental/cudf/exec/CudfDistinct.cpp
+++ b/velox/experimental/cudf/exec/CudfDistinct.cpp
@@ -248,7 +248,9 @@ void CudfDistinct::doNoMoreInput() {
 
   // This driver was chosen to collect data from all peers.
   for (auto& peer : peers) {
-    auto op = peer->findOperator(planNodeId());
+    // findOperator(planNodeId()) may return a CudfBatchConcat (same plan node
+    // ID) instead of the CudfDistinct, so search by operatorId which is unique.
+    auto* op = peer->findOperator(operatorCtx_->operatorId());
     auto* peerDistinct = dynamic_cast<CudfDistinct*>(op);
     VELOX_CHECK_NOT_NULL(peerDistinct);
     inputs_.insert(

--- a/velox/experimental/cudf/exec/CudfDistinct.h
+++ b/velox/experimental/cudf/exec/CudfDistinct.h
@@ -33,9 +33,7 @@ class CudfDistinct : public CudfOperatorBase {
     return !noMoreInput_;
   }
 
-  exec::BlockingReason isBlocked(ContinueFuture* /* unused */) override {
-    return exec::BlockingReason::kNotBlocked;
-  }
+  exec::BlockingReason isBlocked(ContinueFuture* future) override;
 
   bool isFinished() override;
 
@@ -66,6 +64,10 @@ class CudfDistinct : public CudfOperatorBase {
   int64_t numInputRows_ = 0;
 
   bool finished_ = false;
+
+  /// Future used to block non-last drivers during allPeersFinished
+  /// coordination in the FINAL aggregation step.
+  ContinueFuture future_{ContinueFuture::makeEmpty()};
 
   std::vector<CudfVectorPtr> inputs_;
   TypePtr inputType_;

--- a/velox/experimental/cudf/tests/AggregationTest.cpp
+++ b/velox/experimental/cudf/tests/AggregationTest.cpp
@@ -1809,4 +1809,65 @@ TEST_F(AggregationTest, zeroColumnThroughCudfFromVelox) {
       .assertResults("SELECT count(*) FROM tmp WHERE c0 > 0");
 }
 
+// FINAL distinct with multiple drivers receiving overlapping keys.
+// parallelizable=true on Values splits batches across drivers directly,
+// avoiding local exchange buffering issues. With maxDrivers=2 and 4 batches,
+// driver 0 gets batches {1,2,3,4,5} and {5,6,7,8,9}, driver 1 gets
+// {3,4,5,6,7} and {1,5,9,10,11} — keys 3,4,5 appear on both drivers.
+// Without allPeersFinished coordination in CudfDistinct, each driver
+// independently produces locally-distinct results and duplicate keys are
+// emitted.
+TEST_F(AggregationTest, distinctFinalMultiDriver) {
+  std::vector<RowVectorPtr> data = {
+      makeRowVector({makeFlatVector<int64_t>({1, 2, 3, 4, 5})}),
+      makeRowVector({makeFlatVector<int64_t>({3, 4, 5, 6, 7})}),
+      makeRowVector({makeFlatVector<int64_t>({5, 6, 7, 8, 9})}),
+      makeRowVector({makeFlatVector<int64_t>({1, 5, 9, 10, 11})}),
+  };
+  createDuckDbTable(data);
+
+  auto plan = PlanBuilder()
+                  .values(data, /*parallelizable=*/true)
+                  .singleAggregation({"c0"}, {})
+                  .planNode();
+
+  AssertQueryBuilder(duckDbQueryRunner_)
+      .maxDrivers(2)
+      .plan(plan)
+      .assertResults("SELECT DISTINCT c0 FROM tmp");
+}
+
+// Same as above but with multiple grouping keys.
+TEST_F(AggregationTest, distinctFinalMultiDriverMultiKey) {
+  std::vector<RowVectorPtr> data = {
+      makeRowVector({
+          makeFlatVector<int64_t>({1, 1, 2, 2, 3}),
+          makeFlatVector<int32_t>({10, 20, 10, 20, 10}),
+      }),
+      makeRowVector({
+          makeFlatVector<int64_t>({2, 3, 3, 4, 4}),
+          makeFlatVector<int32_t>({20, 10, 30, 10, 20}),
+      }),
+      makeRowVector({
+          makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+          makeFlatVector<int32_t>({10, 10, 10, 10, 10}),
+      }),
+      makeRowVector({
+          makeFlatVector<int64_t>({3, 5, 5, 1, 2}),
+          makeFlatVector<int32_t>({10, 10, 20, 20, 20}),
+      }),
+  };
+  createDuckDbTable(data);
+
+  auto plan = PlanBuilder()
+                  .values(data, /*parallelizable=*/true)
+                  .singleAggregation({"c0", "c1"}, {})
+                  .planNode();
+
+  AssertQueryBuilder(duckDbQueryRunner_)
+      .maxDrivers(2)
+      .plan(plan)
+      .assertResults("SELECT DISTINCT c0, c1 FROM tmp");
+}
+
 } // namespace facebook::velox::exec::test


### PR DESCRIPTION
### Summary

CudfDistinct was missing peer coordination in `doNoMoreInput()` for non-partial (SINGLE/FINAL) aggregation steps. When multiple drivers ran distinct on overlapping keys, each independently produced locally-distinct results, causing duplicate keys in the output.

Without `allPeersFinished` coordination, each driver calls `doGetOutput()` independently — concatenating only its own inputs, running `cudf::distinct`, and emitting a result. Keys present on multiple drivers appear in multiple
outputs.

### Fix
Add an `allPeersFinished` barrier in `doNoMoreInput()` so the last driver collects `inputs_` from all peers and produces a single globally-distinct result. Non-last drivers block on `kWaitForAggregationPeers` and finish with
empty output.

### Testing
Added `distinctFinalMultiDriver` and `distinctFinalMultiDriverMultiKey` tests using `values(data, parallelizable=true)` with `maxDrivers(2)` to reliably distribute overlapping keys across both drivers. Without the fix, these tests produce 2x the expected row count (every distinct key emitted twice).