### PR TITLE
perf(dwio): Push projected-key IN filter onto map-as-struct key reader

### DIFF
--- a/velox/dwio/common/SelectiveRepeatedColumnReader.cpp
+++ b/velox/dwio/common/SelectiveRepeatedColumnReader.cpp
@@ -75,6 +75,13 @@ void prepareResult(
   // makeOffsetsAndSizes.  Child vectors are handled in child column readers.
 }
 
+// Returns true for the integer key types supported by createBigintValues() and
+// makeCopyRanges().
+bool isIntegralType(const TypePtr& type) {
+  return type->isTinyint() || type->isSmallint() || type->isInteger() ||
+      type->isBigint();
+}
+
 } // namespace
 
 void SelectiveRepeatedColumnReader::ensureAllLengthsBuffer(vector_size_t size) {
@@ -574,6 +581,7 @@ SelectiveMapAsStructColumnReader::SelectiveMapAsStructColumnReader(
   mapScanSpec_.addMapKeyFieldRecursively(*requestedType_->childAt(0));
   mapScanSpec_.addMapValueFieldRecursively(*requestedType_->childAt(1));
   column_index_t maxChannel = 0;
+  std::vector<int64_t> projectedKeys;
   for (auto& childSpec : scanSpec_->children()) {
     auto field = folly::tryTo<int64_t>(childSpec->fieldName());
     VELOX_CHECK(
@@ -582,8 +590,18 @@ SelectiveMapAsStructColumnReader::SelectiveMapAsStructColumnReader(
         childSpec->fieldName());
     keyToIndex_[*field] = childSpec->channel();
     maxChannel = std::max(maxChannel, childSpec->channel());
+    projectedKeys.push_back(*field);
   }
   copyRanges_.resize(maxChannel + 1);
+
+  // Filter the key sub-reader to the projected keys so the element reader skips
+  // decoding unprojected values (otherwise the whole map is decoded per row).
+  if (isIntegralType(requestedType_->childAt(0)) && !projectedKeys.empty()) {
+    mapScanSpec_.childByName(ScanSpec::kMapKeysFieldName)
+        ->setFilter(
+            velox::common::createBigintValues(
+                projectedKeys, /*nullAllowed=*/false));
+  }
 }
 
 void SelectiveMapAsStructColumnReader::getValues(

--- a/velox/dwio/dwrf/test/ReaderTest.cpp
+++ b/velox/dwio/dwrf/test/ReaderTest.cpp
@@ -3269,6 +3269,52 @@ TEST_F(TestReader, mapAsStructAllEmpty) {
   assertEqualVectors(expected, batch);
 }
 
+// A map-as-struct read that projects only a small subset of the keys present in
+// the (regular) map on disk. The reader pushes an IN filter over the projected
+// keys onto the map key sub-reader so the element reader never decodes values
+// for unprojected keys. The output must be identical to decoding the whole map
+// and dropping unprojected keys afterward -- including rows that are missing a
+// projected key, rows whose keys are all unprojected, empty maps, and null
+// maps.
+TEST_F(TestReader, mapAsStructKeySubsetExtraction) {
+  auto row = makeRowVector({
+      makeMapVectorFromJson<int32_t, int64_t>({
+          "{1: 10, 2: 20, 3: 30, 4: 40, 5: 50}", // all keys present
+          "{2: 21, 4: 41}", // no projected key present
+          "{1: 12, 3: 32}", // both projected keys present
+          "{}", // empty map
+          "null", // null map
+      }),
+  });
+  auto [writer, reader] =
+      createWriterReader({row}, pool(), dataIoStats_, metadataIoStats_);
+  // Project only keys "3" and "1"; keys 2, 4, 5 are unprojected and must be
+  // filtered out of the element decode.
+  auto outType = ROW({"c0"}, {ROW({"3", "1"}, BIGINT())});
+  auto spec = std::make_shared<common::ScanSpec>("<root>");
+  spec->addAllChildFields(*outType);
+  spec->childByName("c0")->setFlatMapAsStruct(true);
+  RowReaderOptions rowReaderOpts;
+  rowReaderOpts.setScanSpec(spec);
+  auto rowReader = reader->createRowReader(rowReaderOpts);
+  VectorPtr batch = BaseVector::create(outType, 0, pool());
+  ASSERT_EQ(rowReader->next(10, batch), 5);
+  // Rows missing a projected key and empty maps yield a non-null struct with
+  // null children; a null map yields a null struct row (setComplexNulls).
+  auto expected = makeRowVector({
+      makeRowVector(
+          {"3", "1"},
+          {
+              makeNullableFlatVector<int64_t>(
+                  {30, std::nullopt, 32, std::nullopt, std::nullopt}),
+              makeNullableFlatVector<int64_t>(
+                  {10, std::nullopt, 12, std::nullopt, std::nullopt}),
+          },
+          /*isNullAt=*/[](vector_size_t row) { return row == 4; }),
+  });
+  assertEqualVectors(expected, batch);
+}
+
 // Verify DwrfRowReader can be destroyed while ParallelUnitLoader async load()
 // are in progress. This regression test ensures that:
 // 1. ParallelUnitLoader destructor doesn't wait for async load() operations


### PR DESCRIPTION
Summary:
When a map<K, V> column is projected as a struct (one output field per
selected key), SelectiveMapAsStructColumnReader decoded every key/value
entry in the map for each row and dropped the unselected keys afterward in
makeCopyRanges(). For wide maps with a narrow projection this materializes
far more than the query needs -- peak memory scales with the full map
cardinality rather than the projection width.

Build an IN filter over the selected keys and set it on the map key
sub-reader in the constructor. The normal (kNone) read path already narrows
nestedRows_ to the key reader's surviving rows before reading the element
reader, so the element reader now only decodes values for the selected keys.
Output is unchanged. Applies only when the key type is integral, which
createBigintValues() and makeCopyRanges() both require.

Differential Revision: D113510715


