### PR TITLE
fix: Correct SysMemoryReclaimer::abort and arbitratorKind comments

### DIFF
--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -121,13 +121,8 @@ class SysMemoryReclaimer : public memory::MemoryReclaimer {
     return false;
   }
 
-  /// Invoked by the memory arbitrator to abort memory 'pool' and the associated
-  /// query execution when encounters non-recoverable memory reclaim error or
-  /// fails to reclaim enough free capacity. The abort is a synchronous
-  /// operation and we expect most of used memory to be freed after the abort
-  /// completes. 'error' should be passed in as the direct cause of the
-  /// abortion. It will be propagated all the way to task level for accurate
-  /// error exposure.
+  // The system memory pool never participates in arbitration, so it is
+  // never aborted.
   void abort(MemoryPool* pool, const std::exception_ptr& error) override {
     VELOX_UNSUPPORTED("SysMemoryReclaimer::abort is not supported");
   }

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -162,7 +162,7 @@ class MemoryManager {
     /// The string kind of memory arbitrator used in the memory manager.
     ///
     /// NOTE: the arbitrator will only be created if its kind is set explicitly.
-    /// Otherwise MemoryArbitrator::create returns a nullptr.
+    /// Otherwise MemoryArbitrator::create returns a NoopArbitrator.
     std::string arbitratorKind{};
 
     /// Provided by the query system to validate the state after a memory pool


### PR DESCRIPTION
Remove the doc comment above `SysMemoryReclaimer::abort()`. It was copied
verbatim from the base class `MemoryReclaimer::abort()` (not a single word
changed), so it describes the generic arbitrator abort contract —
synchronous abort, freeing used memory, propagating the error to the
task. That contract does not apply here: this override is
VELOX_UNSUPPORTED, and the system memory pool never participates in
arbitration, so it is never aborted. Replace it with a comment stating
why abort is unsupported.

Also fix the arbitratorKind doc: `MemoryArbitrator::create()` returns a
NoopArbitrator when the kind is empty, not a nullptr.