### PR TITLE
refactor(cache): Extract AsyncDataCache eviction logic to EvictionPolicy interface (#18263)

### DIFF
--- a/velox/common/caching/ApproxLrfuEvictionPolicy.cpp
+++ b/velox/common/caching/ApproxLrfuEvictionPolicy.cpp
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/caching/ApproxLrfuEvictionPolicy.h"
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/caching/AsyncDataCache.h"
+
+namespace facebook::velox::cache {
+
+namespace {
+
+class ApproxLrfuCursor : public EvictionCandidateCursor {
+ public:
+  ApproxLrfuCursor(
+      ApproxLrfuShardState& state,
+      const std::deque<std::unique_ptr<AsyncDataCacheEntry>>& entries,
+      uint32_t& clockHand,
+      uint32_t& eventCounter,
+      int32_t maxEvictionSamples,
+      int32_t evictionPercentile,
+      bool evictAllUnpinned)
+      : state_(state),
+        entries_(entries),
+        clockHand_(clockHand),
+        eventCounter_(eventCounter),
+        maxEvictionSamples_(maxEvictionSamples),
+        evictionPercentile_(evictionPercentile),
+        evictAllUnpinned_(evictAllUnpinned),
+        size_(entries.size()),
+        entryIndex_(size_ == 0 ? 0 : clockHand % size_),
+        iter_(size_ == 0 ? entries.begin() : entries.begin() + entryIndex_),
+        now_(accessTime()) {}
+
+  Candidate next() override {
+    if (size_ == 0) {
+      return {};
+    }
+    while (++counter_ <= size_) {
+      advance();
+      auto* candidate = iter_->get();
+      if (candidate == nullptr) {
+        continue;
+      }
+      ++numChecked_;
+      if (state_.evictionThreshold == ApproxLrfuEvictionPolicy::kNoThreshold ||
+          eventCounter_ > size_ / 4 || numChecked_ > size_ / 8) {
+        now_ = accessTime();
+        calibrateThreshold();
+        numChecked_ = 0;
+        eventCounter_ = 0;
+      }
+      if (candidate->numPins() != 0) {
+        continue;
+      }
+      if (evictAllUnpinned_ || !candidate->key().fileNum.hasValue()) {
+        return {candidate, static_cast<int32_t>(entryIndex_), 0};
+      }
+      const int32_t score = candidate->score(now_);
+      if (score >= state_.evictionThreshold) {
+        return {candidate, static_cast<int32_t>(entryIndex_), score};
+      }
+    }
+    return {};
+  }
+
+ private:
+  void advance() {
+    if (++iter_ == entries_.end()) {
+      iter_ = entries_.begin();
+      entryIndex_ = 0;
+    } else {
+      ++entryIndex_;
+    }
+    ++clockHand_;
+  }
+
+  void calibrateThreshold() {
+    const auto numSamples = std::min<int32_t>(maxEvictionSamples_, size_);
+    const auto sampleNow = accessTime();
+    auto sampleIndex = clockHand_ % size_;
+    const auto step = size_ / numSamples;
+    auto sampleIter = entries_.begin() + sampleIndex;
+    state_.evictionThreshold = percentile<int32_t>(
+        [&]() -> int32_t {
+          AsyncDataCacheEntry* element = sampleIter->get();
+          const int32_t s = element ? element->score(sampleNow) : 0;
+          if (sampleIndex + step >= size_) {
+            sampleIndex = (sampleIndex + step) % size_;
+            sampleIter = entries_.begin() + sampleIndex;
+          } else {
+            sampleIndex += step;
+            sampleIter += step;
+          }
+          return s;
+        },
+        numSamples,
+        evictionPercentile_);
+  }
+
+  ApproxLrfuShardState& state_;
+  const std::deque<std::unique_ptr<AsyncDataCacheEntry>>& entries_;
+  uint32_t& clockHand_;
+  uint32_t& eventCounter_;
+  const int32_t maxEvictionSamples_;
+  const int32_t evictionPercentile_;
+  const bool evictAllUnpinned_;
+  const size_t size_;
+  size_t entryIndex_;
+  std::deque<std::unique_ptr<AsyncDataCacheEntry>>::const_iterator iter_;
+  AccessTime now_;
+  size_t counter_{0};
+  int32_t numChecked_{0};
+};
+
+} // namespace
+
+ApproxLrfuEvictionPolicy::ApproxLrfuEvictionPolicy(
+    int32_t maxEvictionSamples,
+    int32_t evictionPercentile)
+    : maxEvictionSamples_(maxEvictionSamples),
+      evictionPercentile_(evictionPercentile) {
+  VELOX_CHECK_GT(maxEvictionSamples_, 0);
+  VELOX_CHECK_GT(evictionPercentile_, 0);
+  VELOX_CHECK_LE(evictionPercentile_, 100);
+}
+
+std::unique_ptr<EvictionPolicyShardState>
+ApproxLrfuEvictionPolicy::makeShardState() const {
+  return std::make_unique<ApproxLrfuShardState>();
+}
+
+std::unique_ptr<EvictionCandidateCursor>
+ApproxLrfuEvictionPolicy::createEvictionCursorLocked(
+    EvictionPolicyShardState& baseState,
+    const std::deque<std::unique_ptr<AsyncDataCacheEntry>>& entries,
+    uint32_t& clockHand,
+    uint32_t& eventCounter,
+    bool evictAllUnpinned) const {
+  auto& state = static_cast<ApproxLrfuShardState&>(baseState);
+  return std::make_unique<ApproxLrfuCursor>(
+      state,
+      entries,
+      clockHand,
+      eventCounter,
+      maxEvictionSamples_,
+      evictionPercentile_,
+      evictAllUnpinned);
+}
+
+} // namespace facebook::velox::cache

--- a/velox/common/caching/ApproxLrfuEvictionPolicy.h
+++ b/velox/common/caching/ApproxLrfuEvictionPolicy.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <limits>
+
+#include "velox/common/caching/EvictionPolicy.h"
+
+namespace facebook::velox::cache {
+
+/// Holds per-shard state for ApproxLrfuEvictionPolicy. evictionThreshold is
+/// the maximum retainable score; entries scoring at or above it are
+/// evictable.
+class ApproxLrfuShardState : public EvictionPolicyShardState {
+ public:
+  int32_t evictionThreshold{std::numeric_limits<int32_t>::max()};
+};
+
+/// Implements the adaptive approx-LRFU policy. Retention score is
+/// (now - lastUse) / (1 + numUses); the eviction threshold is the
+/// evictionPercentile-th percentile of maxEvictionSamples sampled scores,
+/// recalibrated when hit or scan counters exceed shard-size fractions.
+class ApproxLrfuEvictionPolicy : public EvictionPolicy {
+ public:
+  static constexpr int32_t kNoThreshold = std::numeric_limits<int32_t>::max();
+  static constexpr int32_t kDefaultMaxEvictionSamples = 10;
+  static constexpr int32_t kDefaultEvictionPercentile = 80;
+
+  explicit ApproxLrfuEvictionPolicy(
+      int32_t maxEvictionSamples = kDefaultMaxEvictionSamples,
+      int32_t evictionPercentile = kDefaultEvictionPercentile);
+
+  std::unique_ptr<EvictionPolicyShardState> makeShardState() const override;
+
+  void onEntryAccessLocked(
+      AsyncDataCacheEntry& /*entry*/,
+      EvictionPolicyShardState& /*shardState*/) const override {}
+
+  void onEntryInsertedLocked(
+      AsyncDataCacheEntry& /*entry*/,
+      EvictionPolicyShardState& /*shardState*/) const override {}
+
+  void onEntryRemovedLocked(
+      AsyncDataCacheEntry& /*entry*/,
+      EvictionPolicyShardState& /*shardState*/) const override {}
+
+  std::unique_ptr<EvictionCandidateCursor> createEvictionCursorLocked(
+      EvictionPolicyShardState& shardState,
+      const std::deque<std::unique_ptr<AsyncDataCacheEntry>>& entries,
+      uint32_t& clockHand,
+      uint32_t& eventCounter,
+      bool evictAllUnpinned) const override;
+
+  int32_t maxEvictionSamples() const {
+    return maxEvictionSamples_;
+  }
+
+  int32_t evictionPercentile() const {
+    return evictionPercentile_;
+  }
+
+ private:
+  const int32_t maxEvictionSamples_;
+  const int32_t evictionPercentile_;
+};
+
+} // namespace facebook::velox::cache

--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/common/caching/AsyncDataCache.h"
+#include "velox/common/caching/EvictionPolicy.h"
 #include "velox/common/caching/FileIds.h"
 #include "velox/common/caching/SsdCache.h"
 #include "velox/common/caching/SsdFile.h"
@@ -137,10 +138,18 @@ memory::MachinePageCount AsyncDataCacheEntry::setPrefetch(bool flag) {
   return shard_->cache()->incrementPrefetchPages(flag ? numPages : -numPages);
 }
 
-void AsyncDataCacheEntry::initialize(FileCacheKey key, bool contiguous) {
+void AsyncDataCacheEntry::setKeyLocked(
+    RawFileCacheKey key,
+    int32_t entryIndex) {
   VELOX_CHECK(isExclusive());
+  key_ = FileCacheKey{StringIdLease(fileIds(), key.fileNum), key.offset};
+  entryIndex_ = entryIndex;
+}
+
+void AsyncDataCacheEntry::initialize(bool contiguous) {
+  VELOX_CHECK(isExclusive());
+  VELOX_CHECK(key_.fileNum.hasValue());
   setSsdFile(nullptr, 0);
-  key_ = std::move(key);
   auto* cache = shard_->cache();
   ClockTimer t(shard_->allocClocks());
   if (size_ < AsyncDataCacheEntry::kTinyDataSize) {
@@ -279,6 +288,7 @@ std::optional<CachePin> CacheShard::lookupLocked(
     return std::nullopt;
   }
   foundEntry->touch();
+  policy_->onEntryAccessLocked(*foundEntry, *policyState_);
   if (foundEntry->isPrefetch()) {
     foundEntry->isFirstUse_ = true;
     foundEntry->setPrefetch(false);
@@ -311,20 +321,24 @@ CachePin CacheShard::findOrCreate(
     newEntry->promise_ = nullptr;
     entryToInit = newEntry.get();
     entryMap_[key] = newEntry.get();
+    int32_t entryIndex;
     if (emptySlots_.empty()) {
       entries_.push_back(std::move(newEntry));
+      entryIndex = static_cast<int32_t>(entries_.size() - 1);
     } else {
-      const auto index = emptySlots_.back();
+      entryIndex = emptySlots_.back();
       emptySlots_.pop_back();
-      entries_[index] = std::move(newEntry);
+      entries_[entryIndex] = std::move(newEntry);
     }
     ++numNew_;
     // Inside the shard mutex.
     VELOX_CHECK_EQ(entryToInit->size_, 0);
     entryToInit->size_ = size;
     entryToInit->isFirstUse_ = true;
+    entryToInit->setKeyLocked(key, entryIndex);
+    policy_->onEntryInsertedLocked(*entryToInit, *policyState_);
   }
-  return initEntry(key, contiguous, entryToInit);
+  return initEntry(contiguous, entryToInit);
 }
 
 std::optional<CachePin> CacheShard::find(
@@ -364,18 +378,13 @@ bool CacheShard::testingIsEvictable(RawFileCacheKey key) const {
   return it->second->testingIsEvictable();
 }
 
-CachePin CacheShard::initEntry(
-    RawFileCacheKey key,
-    bool contiguous,
-    AsyncDataCacheEntry* entry) {
+CachePin CacheShard::initEntry(bool contiguous, AsyncDataCacheEntry* entry) {
   // The new entry is in the map and is in exclusive mode and is otherwise
   // uninitialized. Other threads may find it and may add a promise or wait for
   // a promise that another one has added. The new entry is otherwise volatile
   // and uninterpretable except for this thread. Non access serializing members
   // can be set outside of 'mutex_'.
-  entry->initialize(
-      FileCacheKey{StringIdLease(fileIds(), key.fileNum), key.offset},
-      contiguous);
+  entry->initialize(contiguous);
   cache_->incrementNew(entry->size());
   CachePin pin;
   pin.setEntry(entry);
@@ -457,6 +466,7 @@ std::unique_ptr<folly::SharedPromise<bool>> CacheShard::removeEntry(
 }
 
 void CacheShard::removeEntryLocked(AsyncDataCacheEntry* entry) {
+  policy_->onEntryRemovedLocked(*entry, *policyState_);
   if (entry->key_.fileNum.hasValue()) {
     const auto it = entryMap_.find(
         RawFileCacheKey{entry->key_.fileNum.id(), entry->key_.offset});
@@ -522,75 +532,51 @@ uint64_t CacheShard::evict(
   auto* ssdCache = cache_->ssdCache();
   const bool skipSsdSaveable =
       (ssdCache != nullptr) && ssdCache->writeInProgress();
-  auto now = accessTime();
   AcquiredMemory toFree;
   int64_t tinyEvicted = 0;
   int64_t largeEvicted = 0;
   int32_t evictSaveableSkipped = 0;
   {
     std::lock_guard<std::mutex> l(mutex_);
-    const size_t size = entries_.size();
-    if (size == 0) {
+    if (entries_.empty()) {
       return 0;
     }
-    int32_t counter = 0;
-    int32_t numChecked = 0;
-    auto entryIndex = (clockHand_ % size);
-    auto iter = entries_.begin() + entryIndex;
-    while (++counter <= size) {
-      if (++iter == entries_.end()) {
-        iter = entries_.begin();
-        entryIndex = 0;
-      } else {
-        ++entryIndex;
+    auto cursor = policy_->createEvictionCursorLocked(
+        *policyState_, entries_, clockHand_, eventCounter_, evictAllUnpinned);
+    while (true) {
+      auto candidate = cursor->next();
+      if (candidate.entry == nullptr) {
+        break;
       }
-
       ++numEvictChecks_;
-      ++clockHand_;
-      auto candidate = iter->get();
-      if (candidate == nullptr) {
+      if (candidate.entry->numPins_ != 0) {
         continue;
       }
-
-      ++numChecked;
-      if (evictionThreshold_ == kNoThreshold ||
-          eventCounter_ > entries_.size() / 4 ||
-          numChecked > entries_.size() / 8) {
-        now = accessTime();
-        calibrateThresholdLocked();
-        numChecked = 0;
-        eventCounter_ = 0;
+      if (skipSsdSaveable && candidate.entry->ssdSaveable() &&
+          !evictAllUnpinned) {
+        ++evictSaveableSkipped;
+        continue;
       }
+      if (candidate.entry->ssdSaveable()) {
+        ++numSavableEvict_;
+      }
+      acquireEvictedData(
+          candidate.entry,
+          bytesToAcquire,
+          acquired,
+          toFree,
+          largeEvicted,
+          tinyEvicted);
 
-      int32_t score = 0;
-      if (candidate->numPins_ == 0 &&
-          (!candidate->key_.fileNum.hasValue() || evictAllUnpinned ||
-           (score = candidate->score(now)) >= evictionThreshold_)) {
-        if (skipSsdSaveable && candidate->ssdSaveable() && !evictAllUnpinned) {
-          ++evictSaveableSkipped;
-          continue;
-        }
-        if (candidate->ssdSaveable()) {
-          ++numSavableEvict_;
-        }
-        acquireEvictedData(
-            candidate,
-            bytesToAcquire,
-            acquired,
-            toFree,
-            largeEvicted,
-            tinyEvicted);
-
-        removeEntryLocked(candidate);
-        emptySlots_.push_back(entryIndex);
-        tryAddFreeEntry(std::move(*iter));
-        ++numEvict_;
-        if (score > 0) {
-          sumEvictScore_ += score;
-        }
-        if (largeEvicted + tinyEvicted > bytesToFree) {
-          break;
-        }
+      removeEntryLocked(candidate.entry);
+      emptySlots_.push_back(candidate.entryIndex);
+      tryAddFreeEntry(std::move(entries_[candidate.entryIndex]));
+      ++numEvict_;
+      if (candidate.score > 0) {
+        sumEvictScore_ += candidate.score;
+      }
+      if (largeEvicted + tinyEvicted > bytesToFree) {
+        break;
       }
     }
   }
@@ -621,29 +607,6 @@ void CacheShard::tryAddFreeEntry(std::unique_ptr<AsyncDataCacheEntry>&& entry) {
   if (freeEntries_.size() >= kMaxFreeEntries) {
     freeEntries_.resize(kMaxFreeEntries >> 1);
   }
-}
-
-void CacheShard::calibrateThresholdLocked() {
-  auto numSamples = std::min<int32_t>(kMaxEvictionSamples, entries_.size());
-  auto now = accessTime();
-  auto entryIndex = (clockHand_ % entries_.size());
-  auto step = entries_.size() / numSamples;
-  auto iter = entries_.begin() + entryIndex;
-  evictionThreshold_ = percentile<int32_t>(
-      [&]() -> int32_t {
-        AsyncDataCacheEntry* element = iter->get();
-        int32_t score = element ? element->score(now) : 0;
-        if (entryIndex + step >= entries_.size()) {
-          entryIndex = (entryIndex + step) % entries_.size();
-          iter = entries_.begin() + entryIndex;
-        } else {
-          entryIndex += step;
-          iter += step;
-        }
-        return score;
-      },
-      numSamples,
-      kEvictionPercentile);
 }
 
 void CacheShard::updateStats(CacheStats& stats) {
@@ -801,18 +764,40 @@ CacheStats CacheStats::operator-(const CacheStats& other) const {
 
 AsyncDataCache::AsyncDataCache(
     memory::MemoryAllocator* allocator,
-    std::unique_ptr<SsdCache> ssdCache)
-    : AsyncDataCache({}, allocator, std::move(ssdCache)) {}
+    std::unique_ptr<SsdCache> ssdCache,
+    std::unique_ptr<EvictionPolicy> evictionPolicy)
+    : AsyncDataCache(
+          {},
+          allocator,
+          std::move(ssdCache),
+          std::move(evictionPolicy)) {}
+
+AsyncDataCache::Options::Options(
+    double _maxWriteRatio,
+    double _ssdSavableRatio,
+    int32_t _minSsdSavableBytes,
+    int32_t _numShards,
+    uint64_t _ssdFlushThresholdBytes)
+    : maxWriteRatio(_maxWriteRatio),
+      ssdSavableRatio(_ssdSavableRatio),
+      minSsdSavableBytes(_minSsdSavableBytes),
+      numShards(_numShards),
+      ssdFlushThresholdBytes(_ssdFlushThresholdBytes) {}
 
 AsyncDataCache::AsyncDataCache(
     const Options& options,
     memory::MemoryAllocator* allocator,
-    std::unique_ptr<SsdCache> ssdCache)
+    std::unique_ptr<SsdCache> ssdCache,
+    std::unique_ptr<EvictionPolicy> evictionPolicy)
     : opts_(options),
       numShards_(opts_.numShards),
       shardMask_(numShards_ - 1),
       allocator_(allocator),
       ssdCache_(std::move(ssdCache)),
+      evictionPolicy_(
+          evictionPolicy
+              ? std::move(evictionPolicy)
+              : EvictionPolicy::create(EvictionPolicyKind::kApproxLrfu)),
       cachedPages_(0) {
   VELOX_CHECK_GT(numShards_, 0, "numShards must be positive");
   VELOX_CHECK_EQ(
@@ -821,9 +806,20 @@ AsyncDataCache::AsyncDataCache(
       "numShards must be a power of 2, got {}",
       numShards_);
   for (auto i = 0; i < numShards_; ++i) {
-    shards_.push_back(std::make_unique<CacheShard>(this, opts_.maxWriteRatio));
+    shards_.push_back(
+        std::make_unique<CacheShard>(
+            this, opts_.maxWriteRatio, evictionPolicy_.get()));
   }
 }
+
+CacheShard::CacheShard(
+    AsyncDataCache* cache,
+    double maxWriteRatio,
+    EvictionPolicy* policy)
+    : cache_(cache),
+      maxWriteRatio_(maxWriteRatio),
+      policy_(policy),
+      policyState_(policy_->makeShardState()) {}
 
 AsyncDataCache::~AsyncDataCache() = default;
 
@@ -831,9 +827,10 @@ AsyncDataCache::~AsyncDataCache() = default;
 std::shared_ptr<AsyncDataCache> AsyncDataCache::create(
     memory::MemoryAllocator* allocator,
     std::unique_ptr<SsdCache> ssdCache,
-    const AsyncDataCache::Options& options) {
-  auto cache =
-      std::make_shared<AsyncDataCache>(options, allocator, std::move(ssdCache));
+    const AsyncDataCache::Options& options,
+    std::unique_ptr<EvictionPolicy> evictionPolicy) {
+  auto cache = std::make_shared<AsyncDataCache>(
+      options, allocator, std::move(ssdCache), std::move(evictionPolicy));
   allocator->registerCache(cache);
   return cache;
 }

--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -28,6 +28,7 @@
 #include "velox/common/base/CoalesceIo.h"
 #include "velox/common/base/Portability.h"
 #include "velox/common/base/SelectivityInfo.h"
+#include "velox/common/caching/EvictionPolicy.h"
 #include "velox/common/caching/FileGroupStats.h"
 #include "velox/common/caching/ScanTracker.h"
 #include "velox/common/caching/StringIdMap.h"
@@ -161,11 +162,16 @@ class AsyncDataCacheEntry {
   explicit AsyncDataCacheEntry(CacheShard* shard);
   ~AsyncDataCacheEntry();
 
-  /// Sets the key and allocates the entry's memory. Resets all other state.
-  /// The entry must be held exclusively and must hold no memory when calling
-  /// this. If 'contiguous' is true, allocates a single contiguous region
-  /// instead of a potentially non-contiguous Allocation.
-  void initialize(FileCacheKey key, bool contiguous = false);
+  /// Sets the cache key and the entry's slot index in the shard's entries
+  /// deque. Called under the owning shard's mutex before the
+  /// EvictionPolicy insert hook fires so policies can inspect both.
+  void setKeyLocked(RawFileCacheKey key, int32_t entryIndex);
+
+  /// Allocates the entry's memory. Preconditions: setKeyLocked() has been
+  /// called and size_ has been set. The entry must be held exclusively.
+  /// If 'contiguous' is true, allocates a single contiguous region instead
+  /// of a potentially non-contiguous Allocation.
+  void initialize(bool contiguous = false);
 
   memory::Allocation& nonContiguousData() {
     return nonContiguousData_;
@@ -224,6 +230,12 @@ class AsyncDataCacheEntry {
 
   int32_t size() const {
     return size_;
+  }
+
+  /// Position of this entry in shard_->entries_. Stable for the entry's
+  /// lifetime; set by setKeyLocked().
+  int32_t entryIndex() const {
+    return entryIndex_;
   }
 
   /// Returns the allocated capacity in bytes for this entry's data,
@@ -352,6 +364,7 @@ class AsyncDataCacheEntry {
 
   std::unique_ptr<folly::SharedPromise<bool>> promise_;
   int32_t size_{0};
+  int32_t entryIndex_{-1};
 
   // Setting this from 0 to 1 or to kExclusive requires owning shard_->mutex_.
   std::atomic<int32_t> numPins_{0};
@@ -621,8 +634,10 @@ class CacheShard {
  public:
   static constexpr uint64_t kMinBytesToEvict = 8UL << 20; // 8MB
 
-  CacheShard(AsyncDataCache* cache, double maxWriteRatio)
-      : cache_(cache), maxWriteRatio_(maxWriteRatio) {}
+  CacheShard(
+      AsyncDataCache* cache,
+      double maxWriteRatio,
+      EvictionPolicy* policy);
 
   /// See AsyncDataCache::findOrCreate. If 'contiguous' is true, the
   /// entry's data is allocated as a single contiguous region.
@@ -706,11 +721,6 @@ class CacheShard {
 
  private:
   static constexpr uint32_t kMaxFreeEntries = 1 << 10;
-  static constexpr int32_t kNoThreshold = std::numeric_limits<int32_t>::max();
-  static constexpr int32_t kMaxEvictionSamples = 10;
-  static constexpr int32_t kEvictionPercentile = 80;
-
-  void calibrateThresholdLocked();
 
   void removeEntryLocked(AsyncDataCacheEntry* entry);
 
@@ -720,8 +730,7 @@ class CacheShard {
   // already has the right amount of memory associated with it.
   std::unique_ptr<AsyncDataCacheEntry> getFreeEntryLocked();
 
-  CachePin
-  initEntry(RawFileCacheKey key, bool contiguous, AsyncDataCacheEntry* entry);
+  CachePin initEntry(bool contiguous, AsyncDataCacheEntry* entry);
 
   // Looks up 'key' in the cache under mutex_. 'size' is the minimum acceptable
   // entry size: pass 0 from find() to accept any size, or the required size
@@ -749,6 +758,8 @@ class CacheShard {
 
   AsyncDataCache* const cache_;
   const double maxWriteRatio_;
+  EvictionPolicy* const policy_;
+  std::unique_ptr<EvictionPolicyShardState> policyState_;
 
   mutable std::mutex mutex_;
   folly::F14FastMap<RawFileCacheKey, AsyncDataCacheEntry*> entryMap_;
@@ -764,8 +775,6 @@ class CacheShard {
   uint32_t clockHand_{0};
   // Number of gets since last stats sampling.
   uint32_t eventCounter_{0};
-  // Maximum retainable entry score(). Anything above this is evictable.
-  int32_t evictionThreshold_{kNoThreshold};
   // Cumulative count of cache hits.
   uint64_t numHit_{0};
   // Cumulative Sum of bytes in cache hits.
@@ -805,12 +814,7 @@ class AsyncDataCache : public memory::Cache {
         double _ssdSavableRatio = 0.125,
         int32_t _minSsdSavableBytes = 1 << 24,
         int32_t _numShards = kDefaultNumShards,
-        uint64_t _ssdFlushThresholdBytes = 0)
-        : maxWriteRatio(_maxWriteRatio),
-          ssdSavableRatio(_ssdSavableRatio),
-          minSsdSavableBytes(_minSsdSavableBytes),
-          numShards(_numShards),
-          ssdFlushThresholdBytes(_ssdFlushThresholdBytes) {}
+        uint64_t _ssdFlushThresholdBytes = 0);
 
     /// The max ratio of the number of in-memory cache entries being written to
     /// SSD cache over the total number of cache entries. This is to control SSD
@@ -844,18 +848,21 @@ class AsyncDataCache : public memory::Cache {
   AsyncDataCache(
       const Options& options,
       memory::MemoryAllocator* allocator,
-      std::unique_ptr<SsdCache> ssdCache = nullptr);
+      std::unique_ptr<SsdCache> ssdCache = nullptr,
+      std::unique_ptr<EvictionPolicy> evictionPolicy = nullptr);
 
   AsyncDataCache(
       memory::MemoryAllocator* allocator,
-      std::unique_ptr<SsdCache> ssdCache = nullptr);
+      std::unique_ptr<SsdCache> ssdCache = nullptr,
+      std::unique_ptr<EvictionPolicy> evictionPolicy = nullptr);
 
   ~AsyncDataCache() override;
 
   static std::shared_ptr<AsyncDataCache> create(
       memory::MemoryAllocator* allocator,
       std::unique_ptr<SsdCache> ssdCache = nullptr,
-      const AsyncDataCache::Options& = {});
+      const AsyncDataCache::Options& = {},
+      std::unique_ptr<EvictionPolicy> evictionPolicy = nullptr);
 
   static AsyncDataCache* getInstance();
 
@@ -1031,6 +1038,7 @@ class AsyncDataCache : public memory::Cache {
   const int32_t shardMask_;
   memory::MemoryAllocator* const allocator_;
   std::unique_ptr<SsdCache> ssdCache_;
+  const std::unique_ptr<EvictionPolicy> evictionPolicy_;
   std::vector<std::unique_ptr<CacheShard>> shards_;
   std::atomic<int32_t> shardCounter_{0};
   std::atomic<memory::MachinePageCount> cachedPages_{0};

--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -28,6 +28,7 @@
 #include "velox/common/base/CoalesceIo.h"
 #include "velox/common/base/Portability.h"
 #include "velox/common/base/SelectivityInfo.h"
+#include "velox/common/caching/EvictionPolicy.h"
 #include "velox/common/caching/FileGroupStats.h"
 #include "velox/common/caching/ScanTracker.h"
 #include "velox/common/caching/StringIdMap.h"
@@ -161,11 +162,16 @@ class AsyncDataCacheEntry {
   explicit AsyncDataCacheEntry(CacheShard* shard);
   ~AsyncDataCacheEntry();
 
-  /// Sets the key and allocates the entry's memory. Resets all other state.
+  /// Sets the cache key and the entry's slot index in the owning shard.
+  /// The entry must be held exclusively and the caller must hold the
+  /// shard's mutex.
+  void setKeyLocked(RawFileCacheKey key, int32_t entryIndex);
+
+  /// Allocates the entry's memory. Resets all other state.
   /// The entry must be held exclusively and must hold no memory when calling
   /// this. If 'contiguous' is true, allocates a single contiguous region
   /// instead of a potentially non-contiguous Allocation.
-  void initialize(FileCacheKey key, bool contiguous = false);
+  void initialize(bool contiguous = false);
 
   memory::Allocation& nonContiguousData() {
     return nonContiguousData_;
@@ -224,6 +230,12 @@ class AsyncDataCacheEntry {
 
   int32_t size() const {
     return size_;
+  }
+
+  /// Position of this entry in shard_->entries_. Stable for the entry's
+  /// lifetime; set by setKeyLocked().
+  int32_t entryIndex() const {
+    return entryIndex_;
   }
 
   /// Returns the allocated capacity in bytes for this entry's data,
@@ -352,6 +364,7 @@ class AsyncDataCacheEntry {
 
   std::unique_ptr<folly::SharedPromise<bool>> promise_;
   int32_t size_{0};
+  int32_t entryIndex_{-1};
 
   // Setting this from 0 to 1 or to kExclusive requires owning shard_->mutex_.
   std::atomic<int32_t> numPins_{0};
@@ -621,8 +634,10 @@ class CacheShard {
  public:
   static constexpr uint64_t kMinBytesToEvict = 8UL << 20; // 8MB
 
-  CacheShard(AsyncDataCache* cache, double maxWriteRatio)
-      : cache_(cache), maxWriteRatio_(maxWriteRatio) {}
+  CacheShard(
+      AsyncDataCache* cache,
+      double maxWriteRatio,
+      EvictionPolicy* policy);
 
   /// See AsyncDataCache::findOrCreate. If 'contiguous' is true, the
   /// entry's data is allocated as a single contiguous region.
@@ -706,11 +721,6 @@ class CacheShard {
 
  private:
   static constexpr uint32_t kMaxFreeEntries = 1 << 10;
-  static constexpr int32_t kNoThreshold = std::numeric_limits<int32_t>::max();
-  static constexpr int32_t kMaxEvictionSamples = 10;
-  static constexpr int32_t kEvictionPercentile = 80;
-
-  void calibrateThresholdLocked();
 
   void removeEntryLocked(AsyncDataCacheEntry* entry);
 
@@ -720,8 +730,7 @@ class CacheShard {
   // already has the right amount of memory associated with it.
   std::unique_ptr<AsyncDataCacheEntry> getFreeEntryLocked();
 
-  CachePin
-  initEntry(RawFileCacheKey key, bool contiguous, AsyncDataCacheEntry* entry);
+  CachePin initEntry(bool contiguous, AsyncDataCacheEntry* entry);
 
   // Looks up 'key' in the cache under mutex_. 'size' is the minimum acceptable
   // entry size: pass 0 from find() to accept any size, or the required size
@@ -749,6 +758,8 @@ class CacheShard {
 
   AsyncDataCache* const cache_;
   const double maxWriteRatio_;
+  EvictionPolicy* const policy_;
+  std::unique_ptr<EvictionPolicyShardState> policyState_;
 
   mutable std::mutex mutex_;
   folly::F14FastMap<RawFileCacheKey, AsyncDataCacheEntry*> entryMap_;
@@ -764,8 +775,6 @@ class CacheShard {
   uint32_t clockHand_{0};
   // Number of gets since last stats sampling.
   uint32_t eventCounter_{0};
-  // Maximum retainable entry score(). Anything above this is evictable.
-  int32_t evictionThreshold_{kNoThreshold};
   // Cumulative count of cache hits.
   uint64_t numHit_{0};
   // Cumulative Sum of bytes in cache hits.
@@ -805,12 +814,7 @@ class AsyncDataCache : public memory::Cache {
         double _ssdSavableRatio = 0.125,
         int32_t _minSsdSavableBytes = 1 << 24,
         int32_t _numShards = kDefaultNumShards,
-        uint64_t _ssdFlushThresholdBytes = 0)
-        : maxWriteRatio(_maxWriteRatio),
-          ssdSavableRatio(_ssdSavableRatio),
-          minSsdSavableBytes(_minSsdSavableBytes),
-          numShards(_numShards),
-          ssdFlushThresholdBytes(_ssdFlushThresholdBytes) {}
+        uint64_t _ssdFlushThresholdBytes = 0);
 
     /// The max ratio of the number of in-memory cache entries being written to
     /// SSD cache over the total number of cache entries. This is to control SSD
@@ -844,18 +848,21 @@ class AsyncDataCache : public memory::Cache {
   AsyncDataCache(
       const Options& options,
       memory::MemoryAllocator* allocator,
-      std::unique_ptr<SsdCache> ssdCache = nullptr);
+      std::unique_ptr<SsdCache> ssdCache = nullptr,
+      std::unique_ptr<EvictionPolicy> evictionPolicy = nullptr);
 
   AsyncDataCache(
       memory::MemoryAllocator* allocator,
-      std::unique_ptr<SsdCache> ssdCache = nullptr);
+      std::unique_ptr<SsdCache> ssdCache = nullptr,
+      std::unique_ptr<EvictionPolicy> evictionPolicy = nullptr);
 
   ~AsyncDataCache() override;
 
   static std::shared_ptr<AsyncDataCache> create(
       memory::MemoryAllocator* allocator,
       std::unique_ptr<SsdCache> ssdCache = nullptr,
-      const AsyncDataCache::Options& = {});
+      const AsyncDataCache::Options& = {},
+      std::unique_ptr<EvictionPolicy> evictionPolicy = nullptr);
 
   static AsyncDataCache* getInstance();
 
@@ -1031,6 +1038,7 @@ class AsyncDataCache : public memory::Cache {
   const int32_t shardMask_;
   memory::MemoryAllocator* const allocator_;
   std::unique_ptr<SsdCache> ssdCache_;
+  const std::unique_ptr<EvictionPolicy> evictionPolicy_;
   std::vector<std::unique_ptr<CacheShard>> shards_;
   std::atomic<int32_t> shardCounter_{0};
   std::atomic<memory::MachinePageCount> cachedPages_{0};

--- a/velox/common/caching/CMakeLists.txt
+++ b/velox/common/caching/CMakeLists.txt
@@ -14,8 +14,10 @@
 
 velox_add_library(
   velox_caching
+  ApproxLrfuEvictionPolicy.cpp
   AsyncDataCache.cpp
   CacheTTLController.cpp
+  EvictionPolicy.cpp
   FileHandle.cpp
   FileIds.cpp
   ScanTracker.cpp
@@ -24,8 +26,10 @@ velox_add_library(
   SsdFileTracker.cpp
   StringIdMap.cpp
   HEADERS
+  ApproxLrfuEvictionPolicy.h
   AsyncDataCache.h
   CacheTTLController.h
+  EvictionPolicy.h
   FileGroupStats.h
   FileHandle.h
   FileIds.h

--- a/velox/common/caching/EvictionPolicy.cpp
+++ b/velox/common/caching/EvictionPolicy.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/caching/EvictionPolicy.h"
+
+#include "velox/common/EnumDefine.h"
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/caching/ApproxLrfuEvictionPolicy.h"
+
+namespace facebook::velox::cache {
+
+namespace {
+
+const auto& evictionPolicyKindNames() {
+  static const folly::F14FastMap<EvictionPolicyKind, std::string_view> kNames =
+      {
+          {EvictionPolicyKind::kApproxLrfu, "sampled-lrfu"},
+      };
+  return kNames;
+}
+
+} // namespace
+
+VELOX_DEFINE_ENUM_NAME(EvictionPolicyKind, evictionPolicyKindNames);
+
+std::unique_ptr<EvictionPolicy> EvictionPolicy::create(
+    EvictionPolicyKind kind) {
+  switch (kind) {
+    case EvictionPolicyKind::kApproxLrfu:
+      return std::make_unique<ApproxLrfuEvictionPolicy>();
+  }
+  VELOX_FAIL("Unknown eviction policy kind: {}", static_cast<int>(kind));
+}
+
+} // namespace facebook::velox::cache

--- a/velox/common/caching/EvictionPolicy.h
+++ b/velox/common/caching/EvictionPolicy.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <deque>
+#include <memory>
+
+#include "velox/common/EnumDeclare.h"
+
+namespace facebook::velox::cache {
+
+class AsyncDataCacheEntry;
+
+/// Enumerates the concrete eviction policies known to the cache.
+enum class EvictionPolicyKind : uint8_t {
+  kApproxLrfu,
+};
+VELOX_DECLARE_ENUM_NAME(EvictionPolicyKind);
+
+/// Per-shard mutable state opaque to CacheShard. Each EvictionPolicy defines
+/// its own subclass.
+class EvictionPolicyShardState {
+ public:
+  virtual ~EvictionPolicyShardState() = default;
+};
+
+/// Iterates eviction candidates for a single evict() call. Constructed by the
+/// policy under the shard mutex and walked once.
+class EvictionCandidateCursor {
+ public:
+  virtual ~EvictionCandidateCursor() = default;
+
+  /// Represents a single candidate returned by next(). entry == nullptr
+  /// signals the cursor is exhausted. entryIndex is the position of entry in
+  /// the shard's entries deque, used by the shard to reclaim the slot after
+  /// eviction. score is meaningful for score-based policies (LRFU) and zero
+  /// for others.
+  struct Candidate {
+    AsyncDataCacheEntry* entry{nullptr};
+    int32_t entryIndex{-1};
+    int32_t score{0};
+  };
+
+  /// Yields the next candidate the policy considers evictable, in
+  /// policy-defined priority order.
+  virtual Candidate next() = 0;
+};
+
+/// Provides a pluggable RAM cache eviction policy. Instances are shared
+/// across shards; per-shard mutable state lives in EvictionPolicyShardState.
+/// All methods are called under the owning shard's mutex.
+class EvictionPolicy {
+ public:
+  virtual ~EvictionPolicy() = default;
+
+  /// Constructs an instance for the given kind, with policy-specific
+  /// defaults.
+  static std::unique_ptr<EvictionPolicy> create(EvictionPolicyKind kind);
+
+  virtual std::unique_ptr<EvictionPolicyShardState> makeShardState() const = 0;
+
+  /// Called on cache hit after AccessStats::touch(). Override to update
+  /// per-entry state that isn't captured by AccessStats.
+  virtual void onEntryAccessLocked(
+      AsyncDataCacheEntry& entry,
+      EvictionPolicyShardState& shardState) const = 0;
+
+  /// Called after a new entry becomes visible in the shard. Override to
+  /// register the entry in policy-owned data structures (e.g. 2Q queue).
+  virtual void onEntryInsertedLocked(
+      AsyncDataCacheEntry& entry,
+      EvictionPolicyShardState& shardState) const = 0;
+
+  /// Called before an entry is unlinked from the shard (eviction, aging, or
+  /// file removal). Override to unregister the entry from policy-owned data
+  /// structures.
+  virtual void onEntryRemovedLocked(
+      AsyncDataCacheEntry& entry,
+      EvictionPolicyShardState& shardState) const = 0;
+
+  /// Builds a cursor for a single evict() call. Cursor lifetime is scoped to
+  /// that call, all under the shard mutex. eventCounter is the shard's
+  /// hit-count-based recalibration trigger; the cursor may read and reset it.
+  /// evictAllUnpinned is a panic mode: cursor should yield every entry
+  /// regardless of the algorithm's normal ordering.
+  virtual std::unique_ptr<EvictionCandidateCursor> createEvictionCursorLocked(
+      EvictionPolicyShardState& shardState,
+      const std::deque<std::unique_ptr<AsyncDataCacheEntry>>& entries,
+      uint32_t& clockHand,
+      uint32_t& eventCounter,
+      bool evictAllUnpinned) const = 0;
+};
+
+} // namespace facebook::velox::cache

--- a/velox/common/caching/tests/CMakeLists.txt
+++ b/velox/common/caching/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ set(
   VELOX_CACHE_TEST_SOURCES
   AsyncDataCacheTest.cpp
   CacheTTLControllerTest.cpp
+  EvictionPolicyTest.cpp
   SsdFileTest.cpp
   SsdFileTrackerTest.cpp
   StringIdMapTest.cpp
@@ -41,6 +42,7 @@ set(
   glog::glog
   GTest::gtest
   GTest::gtest_main
+  GTest::gmock
 )
 
 velox_add_grouped_tests(

--- a/velox/common/caching/tests/CacheTestUtil.h
+++ b/velox/common/caching/tests/CacheTestUtil.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "velox/common/caching/EvictionPolicy.h"
 #include "velox/common/caching/SsdCache.h"
 #include "velox/common/caching/SsdFile.h"
 #include "velox/common/process/TraceContext.h"
@@ -143,6 +144,15 @@ class AsyncDataCacheEntryTestHelper {
     return asyncDataCacheEntry_->accessStats_;
   }
 
+  void setAccessStats(AccessTime lastUse, int32_t numUses) {
+    asyncDataCacheEntry_->accessStats_.lastUse = lastUse;
+    asyncDataCacheEntry_->accessStats_.numUses = numUses;
+  }
+
+  void clearKey() {
+    asyncDataCacheEntry_->key_.fileNum.clear();
+  }
+
   bool firstUse() const {
     return asyncDataCacheEntry_->isFirstUse_;
   }
@@ -174,6 +184,14 @@ class CacheShardTestHelper {
     return entries;
   }
 
+  const EvictionPolicyShardState* policyState() const {
+    return cacheShard_->policyState_.get();
+  }
+
+  const std::deque<std::unique_ptr<AsyncDataCacheEntry>>& entries() const {
+    return cacheShard_->entries_;
+  }
+
  private:
   CacheShard* const cacheShard_;
 };
@@ -202,6 +220,10 @@ class AsyncDataCacheTestHelper {
 
   int32_t numShards() const {
     return asyncDataCache_->shards_.size();
+  }
+
+  CacheShard* shard(int32_t index) const {
+    return asyncDataCache_->shards_[index].get();
   }
 
  private:

--- a/velox/common/caching/tests/EvictionPolicyTest.cpp
+++ b/velox/common/caching/tests/EvictionPolicyTest.cpp
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/caching/EvictionPolicy.h"
+
+#include "velox/common/caching/ApproxLrfuEvictionPolicy.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "velox/common/caching/AsyncDataCache.h"
+#include "velox/common/caching/FileIds.h"
+#include "velox/common/caching/tests/CacheTestUtil.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/common/memory/MmapAllocator.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::cache;
+
+class EvictionPolicyTest : public ::testing::Test {
+ protected:
+  static constexpr int32_t kEntrySize = 4096;
+
+  void SetUp() override {
+    memory::MemoryManager::Options options;
+    options.useMmapAllocator = true;
+    options.allocatorCapacity = 1L << 28;
+    options.arbitratorCapacity = 1L << 28;
+    options.trackDefaultUsage = true;
+    manager_ = std::make_unique<memory::MemoryManager>(options);
+    allocator_ = static_cast<memory::MmapAllocator*>(manager_->allocator());
+    auto policy = std::make_unique<ApproxLrfuEvictionPolicy>();
+    policy_ = policy.get();
+    AsyncDataCache::Options cacheOptions;
+    cacheOptions.numShards = 1;
+    cache_ = AsyncDataCache::create(
+        allocator_, nullptr, cacheOptions, std::move(policy));
+    fileName_ = StringIdLease(fileIds(), "eviction_policy_test_file");
+  }
+
+  void TearDown() override {
+    pin_.clear();
+    if (cache_) {
+      cache_->shutdown();
+    }
+    cache_.reset();
+    fileName_ = StringIdLease{};
+    fileIds().testingReset();
+  }
+
+  AsyncDataCacheEntry* addEntry(
+      uint64_t offset,
+      AccessTime lastUse,
+      int32_t numUses,
+      bool leavePinned = false) {
+    RawFileCacheKey key{fileName_.id(), offset};
+    folly::SemiFuture<bool> wait(false);
+    auto pin =
+        cache_->findOrCreate(key, kEntrySize, /*contiguous=*/false, &wait);
+    VELOX_CHECK(!pin.empty());
+    auto* entry = pin.checkedEntry();
+    VELOX_CHECK(entry->isExclusive());
+    entry->setExclusiveToShared(/*ssdSavable=*/false);
+    test::AsyncDataCacheEntryTestHelper(entry).setAccessStats(lastUse, numUses);
+    if (leavePinned) {
+      pin_.push_back(std::move(pin));
+    }
+    return entry;
+  }
+
+  test::CacheShardTestHelper shardHelper() {
+    return test::CacheShardTestHelper(
+        test::AsyncDataCacheTestHelper(cache_.get()).shard(0));
+  }
+
+  ApproxLrfuShardState& lrfuState() {
+    return const_cast<ApproxLrfuShardState&>(
+        static_cast<const ApproxLrfuShardState&>(*shardHelper().policyState()));
+  }
+
+  std::unique_ptr<EvictionCandidateCursor> makeCursor(
+      uint32_t& clockHand,
+      uint32_t& eventCounter,
+      bool evictAllUnpinned) {
+    return policy_->createEvictionCursorLocked(
+        lrfuState(),
+        shardHelper().entries(),
+        clockHand,
+        eventCounter,
+        evictAllUnpinned);
+  }
+
+  static std::vector<AsyncDataCacheEntry*> drainCursor(
+      EvictionCandidateCursor& cursor) {
+    std::vector<AsyncDataCacheEntry*> yielded;
+    while (true) {
+      auto candidate = cursor.next();
+      if (candidate.entry == nullptr) {
+        break;
+      }
+      yielded.push_back(candidate.entry);
+    }
+    return yielded;
+  }
+
+  std::unique_ptr<memory::MemoryManager> manager_;
+  memory::MmapAllocator* allocator_{nullptr};
+  std::shared_ptr<AsyncDataCache> cache_;
+  ApproxLrfuEvictionPolicy* policy_{nullptr};
+  StringIdLease fileName_;
+  std::vector<CachePin> pin_;
+};
+
+TEST_F(EvictionPolicyTest, cursorEvictAllUnpinnedYieldsAllUnpinnedEntries) {
+  constexpr int32_t kNumUnpinned = 15;
+  constexpr int32_t kNumPinned = 5;
+  const auto now = accessTime();
+  std::vector<AsyncDataCacheEntry*> expected;
+  for (int32_t i = 0; i < kNumUnpinned + kNumPinned; ++i) {
+    const bool pinned =
+        (i % 4 == 0) && (static_cast<int32_t>(pin_.size()) < kNumPinned);
+    auto* entry = addEntry(
+        /*offset=*/i * kEntrySize, now, /*numUses=*/0, /*leavePinned=*/pinned);
+    if (!pinned) {
+      expected.push_back(entry);
+    }
+  }
+
+  uint32_t clockHand = 0;
+  uint32_t eventCounter = 0;
+  auto cursor = makeCursor(clockHand, eventCounter, /*evictAllUnpinned=*/true);
+  EXPECT_THAT(
+      drainCursor(*cursor), testing::UnorderedElementsAreArray(expected));
+}
+
+TEST_F(EvictionPolicyTest, cursorSkipsPinnedInThresholdMode) {
+  constexpr int32_t kNumEntries = 10;
+  const auto now = accessTime();
+  std::vector<AsyncDataCacheEntry*> expected;
+  for (int32_t i = 0; i < kNumEntries; ++i) {
+    const bool pinned = (i == 2 || i == 5 || i == 8);
+    auto* entry = addEntry(
+        /*offset=*/i * kEntrySize,
+        now - 1'000'000,
+        /*numUses=*/0,
+        /*leavePinned=*/pinned);
+    if (!pinned) {
+      expected.push_back(entry);
+    }
+  }
+  lrfuState().evictionThreshold = 1;
+
+  uint32_t clockHand = 0;
+  uint32_t eventCounter = 0;
+  auto cursor = makeCursor(clockHand, eventCounter, /*evictAllUnpinned=*/false);
+  EXPECT_THAT(
+      drainCursor(*cursor), testing::UnorderedElementsAreArray(expected));
+}
+
+TEST_F(EvictionPolicyTest, cursorExhaustsAfterOnePass) {
+  constexpr int32_t kNumEntries = 5;
+  const auto now = accessTime();
+  for (int32_t i = 0; i < kNumEntries; ++i) {
+    addEntry(/*offset=*/i * kEntrySize, now - 1'000'000, /*numUses=*/0);
+  }
+
+  uint32_t clockHand = 0;
+  uint32_t eventCounter = 0;
+  auto cursor = makeCursor(clockHand, eventCounter, /*evictAllUnpinned=*/true);
+  int32_t yielded = 0;
+  while (cursor->next().entry != nullptr) {
+    ++yielded;
+  }
+  EXPECT_EQ(yielded, kNumEntries);
+  EXPECT_EQ(cursor->next().entry, nullptr);
+}
+
+TEST_F(EvictionPolicyTest, emptyKeyEntriesAlwaysYielded) {
+  constexpr int32_t kNumEntries = 5;
+  const auto now = accessTime();
+  for (int32_t i = 0; i < kNumEntries; ++i) {
+    addEntry(/*offset=*/i * kEntrySize, now, /*numUses=*/1'000'000);
+  }
+  lrfuState().evictionThreshold = std::numeric_limits<int32_t>::max() - 1;
+  auto* emptyKeyEntry = shardHelper().entries()[2].get();
+  test::AsyncDataCacheEntryTestHelper(emptyKeyEntry).clearKey();
+
+  uint32_t clockHand = 0;
+  uint32_t eventCounter = 0;
+  auto cursor = makeCursor(clockHand, eventCounter, /*evictAllUnpinned=*/false);
+  EXPECT_THAT(drainCursor(*cursor), testing::Contains(emptyKeyEntry));
+}
+
+TEST_F(EvictionPolicyTest, recalibrationOnEventCounter) {
+  constexpr int32_t kNumEntries = 20;
+  const auto now = accessTime();
+  for (int32_t i = 0; i < kNumEntries; ++i) {
+    addEntry(
+        /*offset=*/i * kEntrySize,
+        now - (i * 1'000),
+        /*numUses=*/0);
+  }
+  auto& state = lrfuState();
+  constexpr int32_t kPresetThreshold = 42;
+  state.evictionThreshold = kPresetThreshold;
+
+  uint32_t clockHand = 0;
+  uint32_t eventCounter = kNumEntries / 4 + 1;
+  auto cursor = makeCursor(clockHand, eventCounter, /*evictAllUnpinned=*/false);
+  cursor->next();
+  EXPECT_EQ(eventCounter, 0);
+  EXPECT_NE(state.evictionThreshold, kPresetThreshold);
+}
+
+TEST_F(EvictionPolicyTest, recalibrationOnInitialSentinel) {
+  constexpr int32_t kNumEntries = 12;
+  const auto now = accessTime();
+  for (int32_t i = 0; i < kNumEntries; ++i) {
+    addEntry(
+        /*offset=*/i * kEntrySize,
+        now - (i * 1'000),
+        /*numUses=*/0);
+  }
+  auto& state = lrfuState();
+  ASSERT_EQ(state.evictionThreshold, ApproxLrfuEvictionPolicy::kNoThreshold);
+
+  uint32_t clockHand = 0;
+  uint32_t eventCounter = 0;
+  auto cursor = makeCursor(clockHand, eventCounter, /*evictAllUnpinned=*/false);
+  cursor->next();
+  EXPECT_NE(state.evictionThreshold, ApproxLrfuEvictionPolicy::kNoThreshold);
+}


### PR DESCRIPTION
Summary:

Tracking issue: https://github.com/facebookincubator/velox/issues/18261

Extract the RAM cache eviction algorithm from `CacheShard` into a
pluggable `EvictionPolicy` interface. The default
`ApproxLrfuEvictionPolicy` retains the existing LRFU logic (same score
formula, adaptive percentile threshold, and recalibration triggers), now
moved out of `CacheShard::evict` and `CacheShard::calibrateThresholdLocked`.

Interface (`velox/common/caching/EvictionPolicy.h`):
- `EvictionPolicy` — algorithm; one instance shared across shards.
  Exposes lifecycle hooks (`onEntryAccessLocked`, `onEntryInsertedLocked`,
  `onEntryRemovedLocked`) and a `createEvictionCursorLocked` factory.
- `EvictionPolicyShardState` — opaque per-shard state (thresholds,
  sketches, intrusive lists). Each policy subclasses it.
- `EvictionCandidateCursor` — one-shot iterator for a single `evict()`
  call; `next()` yields `{entry, entryIndex, score}` in policy-defined
  priority order.

Threshold-based policies (LRFU, LRU-K) fit the "shard walks, asks policy
per entry" shape; queue-based policies (2Q, W-TinyLFU) want O(1)
tail-pop from intrusive queues. The cursor lets each policy own its
victim-selection strategy without leaking it into shared types.

`ApproxLrfuEvictionPolicy` and its shard state live in
`ApproxLrfuEvictionPolicy.{h,cpp}`. Ctor takes `maxEvictionSamples` and
`evictionPercentile` as tunable parameters (defaults 10 and 80) with
`VELOX_CHECK` validation. Config-string selection uses
`VELOX_DECLARE_ENUM_NAME(EvictionPolicyKind)` (map entry
`"sampled-lrfu" -> kApproxLrfu`); `EvictionPolicy::create(kind)`
dispatches to the impl.

`AsyncDataCache::Options` stays backward-compatible: the new nullable
`evictionPolicy` field defaults to LRFU, so existing callsites continue
to work unchanged.

Differential Revision: D112608426


