### PR TITLE
fix(cudf): Fix build-side visibility race in CudfNestedLoopJoinProbe

### DIFF
--- a/velox/experimental/cudf/exec/CudfNestedLoopJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfNestedLoopJoin.cpp
@@ -513,11 +513,19 @@ exec::BlockingReason CudfNestedLoopJoinProbe::isBlocked(
 void CudfNestedLoopJoinProbe::syncBuildStream(
     rmm::cuda_stream_view probeStream) {
   if (buildStream_.has_value()) {
+    // joinWithBuildBatch() is called once per probe input batch, and each
+    // call gets a fresh stream from cudfGlobalStreamPool(). recordFrom()
+    // only needs to run once to mark "build data is ready" on buildStream_,
+    // but waitOn() must run for every probe stream that will read the build
+    // data, not just the first one - otherwise later batches can start
+    // reading before the build data is actually visible on their stream.
+    // See the record-once/wait-many pattern in Utilities.cpp's
+    // streamsWaitForStream.
     if (!cudaEvent_) {
       cudaEvent_ = std::make_unique<CudaEvent>();
+      cudaEvent_->recordFrom(buildStream_.value());
     }
-    cudaEvent_->recordFrom(buildStream_.value()).waitOn(probeStream);
-    buildStream_.reset();
+    cudaEvent_->waitOn(probeStream);
   }
 }
 

--- a/velox/experimental/cudf/exec/CudfNestedLoopJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfNestedLoopJoin.cpp
@@ -103,6 +103,18 @@ std::shared_ptr<CudaEvent> CudfNestedLoopJoinBridge::getBuildReadyEvent() {
   return buildReadyEvent_;
 }
 
+void CudfNestedLoopJoinBridge::setBuildStream(
+    rmm::cuda_stream_view buildStream) {
+  std::lock_guard<std::mutex> l(mutex_);
+  buildStream_ = buildStream;
+}
+
+std::optional<rmm::cuda_stream_view>
+CudfNestedLoopJoinBridge::getBuildStream() {
+  std::lock_guard<std::mutex> l(mutex_);
+  return buildStream_;
+}
+
 // ============================================================================
 // Build Operator Implementation
 // ============================================================================
@@ -200,9 +212,13 @@ void CudfNestedLoopJoinBuild::doNoMoreInput() {
   // is materialized on `stream` - not lazily on the probe side - so it
   // captures this exact completion point before `stream` can be recycled
   // by cudfGlobalStreamPool() for unrelated work. Every probe operator
-  // instance/batch just waits on this same event (see
-  // CudfNestedLoopJoinProbe::waitForBuildReady()); no further stream sync
-  // is required beyond that.
+  // instance/batch just waits on this same event before reading buildData_
+  // (see CudfNestedLoopJoinProbe::waitForBuildReady()). `stream` is also
+  // exposed via setBuildStream() below: buildData_'s eventual free is
+  // stream-ordered on `stream` (it was allocated here), so every probe read
+  // makes `stream` wait on its own completion first (see
+  // CudfNestedLoopJoinProbe::recordReadCompletion()), ensuring that free
+  // can't run before all such reads are done.
   auto buildReadyEvent = std::make_shared<CudaEvent>(cudaEventDisableTiming);
   buildReadyEvent->recordFrom(stream);
 
@@ -212,6 +228,7 @@ void CudfNestedLoopJoinBuild::doNoMoreInput() {
   auto bridge = std::dynamic_pointer_cast<CudfNestedLoopJoinBridge>(joinBridge);
 
   bridge->setBuildReadyEvent(std::move(buildReadyEvent));
+  bridge->setBuildStream(stream);
   bridge->setData(
       std::make_optional(
           std::shared_ptr<cudf::table>(std::move(table)))); // Wake probes
@@ -320,16 +337,14 @@ void CudfNestedLoopJoinProbe::initialize() {
 
 void CudfNestedLoopJoinProbe::doClose() {
   Operator::close();
-  // lastProbeStream_ covers every stream this instance used to read
-  // build-side state (see doGetOutput() and emitBuildMismatchRows()).
-  // Synchronize it before releasing that state below - otherwise, if this
-  // instance's last batch is still in flight when close() runs, the
-  // resulting stream-ordered free could race the read. The precompute path
-  // in isBlocked() already blocks on its own stream immediately after use,
-  // so it needs no extra handling here.
-  if (lastProbeStream_.has_value()) {
-    lastProbeStream_->synchronize();
-  }
+  // No explicit stream sync needed here: every read of buildData_/
+  // buildPrecomputed_/scalars_/buildMatchedFlags_ already called
+  // recordReadCompletion(), which makes buildStream_ wait on that read's
+  // completion. buildData_'s eventual stream-ordered free is enqueued on
+  // buildStream_ too (it was allocated there), so CUDA's in-order stream
+  // execution guarantees that free can't run before any of those reads -
+  // whichever probe instance's reset() below actually triggers it. See
+  // recordReadCompletion().
   buildData_.reset();
   probeMatchedFlags_.reset();
   buildMatchedFlags_.reset();
@@ -484,6 +499,7 @@ exec::BlockingReason CudfNestedLoopJoinProbe::isBlocked(
   }
 
   buildReadyEvent_ = bridge->getBuildReadyEvent();
+  buildStream_ = bridge->getBuildStream();
 
   if (buildData_.value()->num_rows() == 0) {
     buildEmpty_ = true;
@@ -540,6 +556,26 @@ void CudfNestedLoopJoinProbe::waitForBuildReady(
     // data is actually visible on their stream. Matches
     // CudfHashJoinProbe::waitForBuildReady().
     buildReadyEvent_->waitOn(probeStream);
+  }
+}
+
+void CudfNestedLoopJoinProbe::recordReadCompletion(
+    rmm::cuda_stream_view probeStream) {
+  if (buildStream_.has_value()) {
+    // buildData_'s underlying device memory is allocated on buildStream_
+    // (see CudfNestedLoopJoinBuild::doNoMoreInput()), so its eventual free
+    // is stream-ordered there too, regardless of which probe instance's
+    // reference-drop actually triggers it. Recording a completion event
+    // from probeStream and waiting on it from buildStream_ chains a
+    // dependency: buildStream_ cannot proceed past this point (including
+    // to the eventual free) until this read has finished. Every probe
+    // batch/instance calls this after reading build-side state, so
+    // buildStream_ accumulates a wait for every one of them - matches
+    // CudfHashJoinProbe's cudaEvent_/buildStream_ pattern.
+    if (!cudaEvent_) {
+      cudaEvent_ = std::make_unique<CudaEvent>();
+    }
+    cudaEvent_->recordFrom(probeStream).waitOn(buildStream_.value());
   }
 }
 
@@ -676,6 +712,7 @@ std::unique_ptr<cudf::table> CudfNestedLoopJoinProbe::joinWithBuildBatch(
       outCols[buildColumnOutputIndices_[i]] = std::move(buildCols[i]);
     }
 
+    recordReadCompletion(stream);
     return std::make_unique<cudf::table>(std::move(outCols));
   }
 
@@ -712,6 +749,7 @@ std::unique_ptr<cudf::table> CudfNestedLoopJoinProbe::joinWithBuildBatch(
         std::move(allCols[numProbeCols + buildColumnIndicesToGather_[i]]);
   }
 
+  recordReadCompletion(stream);
   return std::make_unique<cudf::table>(std::move(outCols));
 }
 
@@ -806,6 +844,7 @@ RowVectorPtr CudfNestedLoopJoinProbe::emitBuildMismatchRows(
 
   finished_ = true;
   if (numUnmatched == 0) {
+    recordReadCompletion(stream);
     return nullptr;
   }
 
@@ -833,6 +872,7 @@ RowVectorPtr CudfNestedLoopJoinProbe::emitBuildMismatchRows(
 
   auto out = std::make_unique<cudf::table>(std::move(outCols));
   auto size = static_cast<vector_size_t>(out->num_rows());
+  recordReadCompletion(stream);
   return std::make_shared<CudfVector>(
       operatorCtx_->pool(), outputType_, size, std::move(out), stream);
 }
@@ -846,10 +886,7 @@ RowVectorPtr CudfNestedLoopJoinProbe::doGetOutput() {
       buildMismatchEmitted_ = true;
       auto stream = cudfGlobalStreamPool().get_stream();
       // Fresh pool stream - must wait for the build-ready event before
-      // emitBuildMismatchRows() reads buildData_. Also record it as
-      // lastProbeStream_ so doClose() waits for this read too before
-      // releasing buildData_/buildMatchedFlags_.
-      lastProbeStream_ = stream;
+      // emitBuildMismatchRows() reads buildData_.
       waitForBuildReady(stream);
       return emitBuildMismatchRows(stream);
     }
@@ -972,6 +1009,10 @@ RowVectorPtr CudfNestedLoopJoinProbe::doGetOutput() {
     auto result = std::make_unique<cudf::table>(std::move(outCols));
     input_.reset();
 
+    // Unconditional even though buildData_/buildPrecomputed_ are only
+    // actually read in the hasFilter_ branch above - a harmless no-op link
+    // in the other case, and much simpler than conditionally tracking it.
+    recordReadCompletion(stream);
     if (result->num_rows() == 0) {
       return nullptr;
     }

--- a/velox/experimental/cudf/exec/CudfNestedLoopJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfNestedLoopJoin.cpp
@@ -539,7 +539,8 @@ std::unique_ptr<cudf::table> CudfNestedLoopJoinProbe::joinWithBuildBatch(
     rmm::cuda_stream_view stream) {
   VELOX_NVTX_FUNC_RANGE();
 
-  waitForBuildReady(stream);
+  // Both call sites are in doGetOutput(), which already waits for the
+  // build-ready event on this same stream before calling in here.
 
   auto numOutputColumns = outputType_->size();
 
@@ -771,11 +772,8 @@ RowVectorPtr CudfNestedLoopJoinProbe::emitBuildMismatchRows(
     finished_ = true;
     return nullptr;
   }
-  // doGetOutput() passes in a fresh stream from cudfGlobalStreamPool() for
-  // this call, so the build table must not be read on it until it's waited
-  // on the build-ready event - same reason joinWithBuildBatch() and the
-  // build-side precompute path both call this before touching buildData_.
-  waitForBuildReady(stream);
+  // The caller in doGetOutput() already waits for the build-ready event on
+  // this stream before calling in here.
   auto& buildTable = buildData_.value();
   auto numOutputColumns = outputType_->size();
 
@@ -837,6 +835,9 @@ RowVectorPtr CudfNestedLoopJoinProbe::doGetOutput() {
         !buildMismatchEmitted_) {
       buildMismatchEmitted_ = true;
       auto stream = cudfGlobalStreamPool().get_stream();
+      // Fresh pool stream - must wait for the build-ready event before
+      // emitBuildMismatchRows() reads buildData_.
+      waitForBuildReady(stream);
       return emitBuildMismatchRows(stream);
     }
     if (noMoreInput_) {
@@ -850,6 +851,10 @@ RowVectorPtr CudfNestedLoopJoinProbe::doGetOutput() {
   VELOX_CHECK_NOT_NULL(cudfInput);
   auto stream = cudfInput->stream();
   lastProbeStream_ = stream;
+  // Wait once here for the rest of doGetOutput(): the LeftSemiProject path
+  // below and joinWithBuildBatch() further down both read buildData_ on
+  // this same stream.
+  waitForBuildReady(stream);
 
   // LeftSemiProject: emit all probe rows with a boolean match column.
   if (joinType_ == core::JoinType::kLeftSemiProject) {

--- a/velox/experimental/cudf/exec/CudfNestedLoopJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfNestedLoopJoin.cpp
@@ -320,6 +320,16 @@ void CudfNestedLoopJoinProbe::initialize() {
 
 void CudfNestedLoopJoinProbe::doClose() {
   Operator::close();
+  // lastProbeStream_ covers every stream this instance used to read
+  // build-side state (see doGetOutput() and emitBuildMismatchRows()).
+  // Synchronize it before releasing that state below - otherwise, if this
+  // instance's last batch is still in flight when close() runs, the
+  // resulting stream-ordered free could race the read. The precompute path
+  // in isBlocked() already blocks on its own stream immediately after use,
+  // so it needs no extra handling here.
+  if (lastProbeStream_.has_value()) {
+    lastProbeStream_->synchronize();
+  }
   buildData_.reset();
   probeMatchedFlags_.reset();
   buildMatchedFlags_.reset();
@@ -836,7 +846,10 @@ RowVectorPtr CudfNestedLoopJoinProbe::doGetOutput() {
       buildMismatchEmitted_ = true;
       auto stream = cudfGlobalStreamPool().get_stream();
       // Fresh pool stream - must wait for the build-ready event before
-      // emitBuildMismatchRows() reads buildData_.
+      // emitBuildMismatchRows() reads buildData_. Also record it as
+      // lastProbeStream_ so doClose() waits for this read too before
+      // releasing buildData_/buildMatchedFlags_.
+      lastProbeStream_ = stream;
       waitForBuildReady(stream);
       return emitBuildMismatchRows(stream);
     }

--- a/velox/experimental/cudf/exec/CudfNestedLoopJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfNestedLoopJoin.cpp
@@ -502,6 +502,7 @@ exec::BlockingReason CudfNestedLoopJoinProbe::isBlocked(
   // since the build table is fixed for the lifetime of this probe operator).
   if (hasFilter_ && !rightPrecomputeInstructions_.empty() && !buildEmpty_) {
     auto precomputeStream = cudfGlobalStreamPool().get_stream();
+    waitForBuildReady(precomputeStream);
     auto buildColumnViews = tableViewToColumnViews(buildData_.value()->view());
     buildPrecomputed_ = precomputeSubexpressions(
         buildColumnViews,
@@ -770,6 +771,11 @@ RowVectorPtr CudfNestedLoopJoinProbe::emitBuildMismatchRows(
     finished_ = true;
     return nullptr;
   }
+  // doGetOutput() passes in a fresh stream from cudfGlobalStreamPool() for
+  // this call, so the build table must not be read on it until it's waited
+  // on the build-ready event - same reason joinWithBuildBatch() and the
+  // build-side precompute path both call this before touching buildData_.
+  waitForBuildReady(stream);
   auto& buildTable = buildData_.value();
   auto numOutputColumns = outputType_->size();
 

--- a/velox/experimental/cudf/exec/CudfNestedLoopJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfNestedLoopJoin.cpp
@@ -92,16 +92,15 @@ CudfNestedLoopJoinBridge::dataOrFuture(ContinueFuture* future) {
   return std::nullopt; // Probe will block on the future
 }
 
-void CudfNestedLoopJoinBridge::setBuildStream(
-    rmm::cuda_stream_view buildStream) {
+void CudfNestedLoopJoinBridge::setBuildReadyEvent(
+    std::shared_ptr<CudaEvent> buildReadyEvent) {
   std::lock_guard<std::mutex> l(mutex_);
-  buildStream_ = buildStream;
+  buildReadyEvent_ = std::move(buildReadyEvent);
 }
 
-std::optional<rmm::cuda_stream_view>
-CudfNestedLoopJoinBridge::getBuildStream() {
+std::shared_ptr<CudaEvent> CudfNestedLoopJoinBridge::getBuildReadyEvent() {
   std::lock_guard<std::mutex> l(mutex_);
-  return buildStream_;
+  return buildReadyEvent_;
 }
 
 // ============================================================================
@@ -197,14 +196,22 @@ void CudfNestedLoopJoinBuild::doNoMoreInput() {
       stream,
       get_output_mr());
 
+  // Record the build-ready event now, immediately after the build table
+  // is materialized on `stream` - not lazily on the probe side - so it
+  // captures this exact completion point before `stream` can be recycled
+  // by cudfGlobalStreamPool() for unrelated work. Every probe operator
+  // instance/batch just waits on this same event (see
+  // CudfNestedLoopJoinProbe::waitForBuildReady()); no further stream sync
+  // is required beyond that.
+  auto buildReadyEvent = std::make_shared<CudaEvent>(cudaEventDisableTiming);
+  buildReadyEvent->recordFrom(stream);
+
   // Transfer build data to bridge - this will unblock probe operators.
-  // No stream sync is required: the probe side uses syncBuildStream() via a
-  // CUDA event to ensure the build table is ready before reading it.
   auto joinBridge = operatorCtx_->task()->getCustomJoinBridge(
       operatorCtx_->driverCtx()->splitGroupId, planNodeId());
   auto bridge = std::dynamic_pointer_cast<CudfNestedLoopJoinBridge>(joinBridge);
 
-  bridge->setBuildStream(stream); // Pass stream for CUDA synchronization
+  bridge->setBuildReadyEvent(std::move(buildReadyEvent));
   bridge->setData(
       std::make_optional(
           std::shared_ptr<cudf::table>(std::move(table)))); // Wake probes
@@ -466,7 +473,7 @@ exec::BlockingReason CudfNestedLoopJoinProbe::isBlocked(
     return exec::BlockingReason::kWaitForJoinBuild;
   }
 
-  buildStream_ = bridge->getBuildStream();
+  buildReadyEvent_ = bridge->getBuildReadyEvent();
 
   if (buildData_.value()->num_rows() == 0) {
     buildEmpty_ = true;
@@ -510,22 +517,18 @@ exec::BlockingReason CudfNestedLoopJoinProbe::isBlocked(
   return exec::BlockingReason::kNotBlocked;
 }
 
-void CudfNestedLoopJoinProbe::syncBuildStream(
+void CudfNestedLoopJoinProbe::waitForBuildReady(
     rmm::cuda_stream_view probeStream) {
-  if (buildStream_.has_value()) {
+  if (buildReadyEvent_ != nullptr) {
     // joinWithBuildBatch() is called once per probe input batch, and each
-    // call gets a fresh stream from cudfGlobalStreamPool(). recordFrom()
-    // only needs to run once to mark "build data is ready" on buildStream_,
-    // but waitOn() must run for every probe stream that will read the build
-    // data, not just the first one - otherwise later batches can start
-    // reading before the build data is actually visible on their stream.
-    // See the record-once/wait-many pattern in Utilities.cpp's
-    // streamsWaitForStream.
-    if (!cudaEvent_) {
-      cudaEvent_ = std::make_unique<CudaEvent>();
-      cudaEvent_->recordFrom(buildStream_.value());
-    }
-    cudaEvent_->waitOn(probeStream);
+    // call gets a fresh stream from cudfGlobalStreamPool(). The event was
+    // already recorded once by the build side (see
+    // CudfNestedLoopJoinBuild::doNoMoreInput()); every probe stream that
+    // reads build-side data just needs to wait on it, not just the first
+    // one - otherwise later batches could start reading before the build
+    // data is actually visible on their stream. Matches
+    // CudfHashJoinProbe::waitForBuildReady().
+    buildReadyEvent_->waitOn(probeStream);
   }
 }
 
@@ -535,7 +538,7 @@ std::unique_ptr<cudf::table> CudfNestedLoopJoinProbe::joinWithBuildBatch(
     rmm::cuda_stream_view stream) {
   VELOX_NVTX_FUNC_RANGE();
 
-  syncBuildStream(stream);
+  waitForBuildReady(stream);
 
   auto numOutputColumns = outputType_->size();
 

--- a/velox/experimental/cudf/exec/CudfNestedLoopJoin.h
+++ b/velox/experimental/cudf/exec/CudfNestedLoopJoin.h
@@ -282,8 +282,14 @@ class CudfNestedLoopJoinProbe : public CudfOperatorBase {
   ContinueFuture peerFuture_{ContinueFuture::makeEmpty()};
   bool buildMismatchEmitted_{false};
 
-  // Last CUDA stream used for probing, needed for join_streams in
-  // noMoreInput() to ensure GPU-side ordering before flag merge.
+  // Last CUDA stream this instance used to touch build-side state
+  // (buildData_, buildPrecomputed_, buildMatchedFlags_, scalars_). Used for
+  // two distinct purposes: (1) join_streams in noMoreInput() to establish
+  // GPU-side ordering before the cross-peer flag merge, and (2)
+  // synchronizing in doClose() before releasing that same build-side state,
+  // so a stream-ordered free can't race a still-in-flight read from this
+  // instance. Every call site that reads build-side state on a stream must
+  // record it here - see doGetOutput() and emitBuildMismatchRows().
   std::optional<rmm::cuda_stream_view> lastProbeStream_;
 
   // Build-ready event, fetched once from the bridge in isBlocked() -

--- a/velox/experimental/cudf/exec/CudfNestedLoopJoin.h
+++ b/velox/experimental/cudf/exec/CudfNestedLoopJoin.h
@@ -55,13 +55,23 @@ class CudfNestedLoopJoinBridge : public exec::JoinBridge {
 
   std::optional<build_data_type> dataOrFuture(ContinueFuture* future);
 
-  void setBuildStream(rmm::cuda_stream_view buildStream);
+  // The build-ready event is created and recorded by the build side
+  // (CudfNestedLoopJoinBuild::doNoMoreInput()) immediately once the build
+  // table is materialized, on the same stream that did that work - not
+  // lazily by the probe side. Recording immediately (rather than whenever
+  // the first probe batch happens to call waitForBuildReady()) avoids a
+  // window where the build's stream could already have been recycled by
+  // cudfGlobalStreamPool() for unrelated work before anything captures its
+  // completion point. Every probe operator instance/batch just waits on
+  // this same already-recorded event - the same record-once/wait-many
+  // split used by CudfHashJoinBridge's buildReadyEvent_.
+  void setBuildReadyEvent(std::shared_ptr<CudaEvent> buildReadyEvent);
 
-  std::optional<rmm::cuda_stream_view> getBuildStream();
+  std::shared_ptr<CudaEvent> getBuildReadyEvent();
 
  private:
   std::optional<build_data_type> data_;
-  std::optional<rmm::cuda_stream_view> buildStream_;
+  std::shared_ptr<CudaEvent> buildReadyEvent_;
 };
 
 /// Accumulates build-side input for nested loop join.
@@ -200,8 +210,9 @@ class CudfNestedLoopJoinProbe : public CudfOperatorBase {
   /// called by the last driver after merging flags from all peers.
   RowVectorPtr emitBuildMismatchRows(rmm::cuda_stream_view stream);
 
-  /// Ensures build-stream data is visible on the given probe stream.
-  void syncBuildStream(rmm::cuda_stream_view probeStream);
+  // Makes the given probe stream wait on the build-ready event before it
+  // reads build-side data. See buildReadyEvent_.
+  void waitForBuildReady(rmm::cuda_stream_view probeStream);
 
   bool isLeftOrFullJoin() const {
     return joinType_ == core::JoinType::kLeft ||
@@ -275,9 +286,11 @@ class CudfNestedLoopJoinProbe : public CudfOperatorBase {
   // noMoreInput() to ensure GPU-side ordering before flag merge.
   std::optional<rmm::cuda_stream_view> lastProbeStream_;
 
-  // CUDA stream synchronization for build data visibility.
-  std::optional<rmm::cuda_stream_view> buildStream_;
-  std::unique_ptr<CudaEvent> cudaEvent_;
+  // Build-ready event, fetched once from the bridge in isBlocked() -
+  // already created and recorded by the build side, so waitForBuildReady()
+  // just needs to wait on it for every probe stream. See
+  // CudfNestedLoopJoinBridge::setBuildReadyEvent().
+  std::shared_ptr<CudaEvent> buildReadyEvent_;
 };
 
 /// Creates CUDF nested loop join operators and bridges.

--- a/velox/experimental/cudf/exec/CudfNestedLoopJoin.h
+++ b/velox/experimental/cudf/exec/CudfNestedLoopJoin.h
@@ -69,9 +69,21 @@ class CudfNestedLoopJoinBridge : public exec::JoinBridge {
 
   std::shared_ptr<CudaEvent> getBuildReadyEvent();
 
+  // The stream the build side used to materialize buildData_ - the same
+  // stream setBuildReadyEvent()'s event was recorded from. Exposed so probe
+  // instances can make this stream wait on their own completion before
+  // returning from doGetOutput(), ensuring buildData_'s eventual
+  // stream-ordered free (enqueued on this same stream, since that's where
+  // it was allocated) can't race a still-in-flight probe read. See
+  // CudfNestedLoopJoinProbe::recordReadCompletion().
+  void setBuildStream(rmm::cuda_stream_view buildStream);
+
+  std::optional<rmm::cuda_stream_view> getBuildStream();
+
  private:
   std::optional<build_data_type> data_;
   std::shared_ptr<CudaEvent> buildReadyEvent_;
+  std::optional<rmm::cuda_stream_view> buildStream_;
 };
 
 /// Accumulates build-side input for nested loop join.
@@ -214,6 +226,15 @@ class CudfNestedLoopJoinProbe : public CudfOperatorBase {
   // reads build-side data. See buildReadyEvent_.
   void waitForBuildReady(rmm::cuda_stream_view probeStream);
 
+  // Records completion of a read of build-side state on probeStream, and
+  // makes buildStream_ wait on it. Must be called after every read of
+  // buildData_/buildPrecomputed_/scalars_/buildMatchedFlags_, so that
+  // buildStream_ accumulates a wait for every probe batch's completion
+  // before buildData_'s eventual stream-ordered free (enqueued on
+  // buildStream_) can run - matching CudfHashJoinProbe's pattern. A no-op
+  // if buildStream_ was never fetched (e.g. build side never ran).
+  void recordReadCompletion(rmm::cuda_stream_view probeStream);
+
   bool isLeftOrFullJoin() const {
     return joinType_ == core::JoinType::kLeft ||
         joinType_ == core::JoinType::kFull;
@@ -282,14 +303,9 @@ class CudfNestedLoopJoinProbe : public CudfOperatorBase {
   ContinueFuture peerFuture_{ContinueFuture::makeEmpty()};
   bool buildMismatchEmitted_{false};
 
-  // Last CUDA stream this instance used to touch build-side state
-  // (buildData_, buildPrecomputed_, buildMatchedFlags_, scalars_). Used for
-  // two distinct purposes: (1) join_streams in noMoreInput() to establish
-  // GPU-side ordering before the cross-peer flag merge, and (2)
-  // synchronizing in doClose() before releasing that same build-side state,
-  // so a stream-ordered free can't race a still-in-flight read from this
-  // instance. Every call site that reads build-side state on a stream must
-  // record it here - see doGetOutput() and emitBuildMismatchRows().
+  // Last CUDA stream used for probing, needed for join_streams in
+  // noMoreInput() to ensure GPU-side ordering before the cross-peer
+  // buildMatchedFlags_ merge (right/full join only).
   std::optional<rmm::cuda_stream_view> lastProbeStream_;
 
   // Build-ready event, fetched once from the bridge in isBlocked() -
@@ -297,6 +313,17 @@ class CudfNestedLoopJoinProbe : public CudfOperatorBase {
   // just needs to wait on it for every probe stream. See
   // CudfNestedLoopJoinBridge::setBuildReadyEvent().
   std::shared_ptr<CudaEvent> buildReadyEvent_;
+
+  // The build side's own stream, fetched once from the bridge in
+  // isBlocked(). recordReadCompletion() makes this stream wait on every
+  // probe batch's completion, so buildData_'s eventual stream-ordered free
+  // (enqueued on this same stream) is correctly ordered after all reads -
+  // see CudfNestedLoopJoinBridge::setBuildStream().
+  std::optional<rmm::cuda_stream_view> buildStream_;
+  // Reused event for recordReadCompletion()'s record-then-wait pattern.
+  // Safe to reuse across calls since each call finishes using the current
+  // recording (via waitOn()) before the next call re-records it.
+  std::unique_ptr<CudaEvent> cudaEvent_;
 };
 
 /// Creates CUDF nested loop join operators and bridges.

--- a/velox/experimental/cudf/tests/NestedLoopJoinTest.cpp
+++ b/velox/experimental/cudf/tests/NestedLoopJoinTest.cpp
@@ -1610,15 +1610,20 @@ TEST_F(CudfNestedLoopJoinTest, leftSemiProjectMultiDriver) {
       "WHERE t.c0 < u.c0) FROM t");
 }
 
-// Regression test for a race in CudfNestedLoopJoinProbe::syncBuildStream:
+// Regression test for a race in CudfNestedLoopJoinProbe::waitForBuildReady:
 // joinWithBuildBatch() grabs a fresh stream from cudfGlobalStreamPool() on
-// every call (once per probe batch), but syncBuildStream() used to only wait
-// on the *first* such stream before discarding the build-ready event,
-// leaving later batches free to read build-side data before it was actually
-// visible on their stream. Uses many probe batches against a build side
-// large enough to take measurable GPU time, repeated several times, to
-// exercise that ordering. Every probe value has exactly one match in the
-// build side, so any row lost to the race shows up as a row-count mismatch.
+// every call (once per probe batch), but this used to only wait on the
+// *first* such stream before discarding the build-ready event, leaving
+// later batches free to read build-side data before it was actually visible
+// on their stream. (The build-ready event is now created and recorded by
+// CudfNestedLoopJoinBuild itself, immediately when the build table is
+// materialized, rather than lazily by the probe - matching
+// CudfHashJoinProbe's waitForBuildReady()/buildReadyEvent_ pattern - so this
+// also guards against the event capturing a stale/recycled build stream.)
+// Uses many probe batches against a build side large enough to take
+// measurable GPU time, repeated several times, to exercise that ordering.
+// Every probe value has exactly one match in the build side, so any row
+// lost to the race shows up as a row-count mismatch.
 TEST_F(CudfNestedLoopJoinTest, buildStreamVisibleToAllProbeBatches) {
   constexpr int32_t kNumBuildRows = 50'000;
   constexpr int32_t kNumProbeBatches = 20;

--- a/velox/experimental/cudf/tests/NestedLoopJoinTest.cpp
+++ b/velox/experimental/cudf/tests/NestedLoopJoinTest.cpp
@@ -1610,6 +1610,50 @@ TEST_F(CudfNestedLoopJoinTest, leftSemiProjectMultiDriver) {
       "WHERE t.c0 < u.c0) FROM t");
 }
 
+// Regression test for a race in CudfNestedLoopJoinProbe::syncBuildStream:
+// joinWithBuildBatch() grabs a fresh stream from cudfGlobalStreamPool() on
+// every call (once per probe batch), but syncBuildStream() used to only wait
+// on the *first* such stream before discarding the build-ready event,
+// leaving later batches free to read build-side data before it was actually
+// visible on their stream. Uses many probe batches against a build side
+// large enough to take measurable GPU time, repeated several times, to
+// exercise that ordering. Every probe value has exactly one match in the
+// build side, so any row lost to the race shows up as a row-count mismatch.
+TEST_F(CudfNestedLoopJoinTest, buildStreamVisibleToAllProbeBatches) {
+  constexpr int32_t kNumBuildRows = 50'000;
+  constexpr int32_t kNumProbeBatches = 20;
+  constexpr int32_t kProbeBatchSize = 500;
+
+  auto buildVectors = {
+      makeRowVector({sequence<int32_t>(kNumBuildRows)})};
+
+  std::vector<RowVectorPtr> probeVectors;
+  for (int32_t b = 0; b < kNumProbeBatches; ++b) {
+    probeVectors.push_back(
+        makeRowVector({sequence<int32_t>(kProbeBatchSize, b * kProbeBatchSize)}));
+  }
+
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", buildVectors);
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto plan = PlanBuilder(planNodeIdGenerator)
+                  .values(probeVectors)
+                  .nestedLoopJoin(
+                      PlanBuilder(planNodeIdGenerator)
+                          .values(buildVectors)
+                          .project({"c0 AS u_c0"})
+                          .planNode(),
+                      "c0 = u_c0",
+                      {"c0", "u_c0"},
+                      core::JoinType::kInner)
+                  .planNode();
+
+  for (int i = 0; i < 15; ++i) {
+    assertQuery(plan, "SELECT t.c0, u.c0 FROM t, u WHERE t.c0 = u.c0");
+  }
+}
+
 // Test empty build always consumes probe input.
 // Verifies that probe input is consumed to prevent upstream exchange hanging,
 // matching CPU NLJ behavior (addresses PR#17113 review comment #3229357599).

--- a/velox/experimental/cudf/tests/NestedLoopJoinTest.cpp
+++ b/velox/experimental/cudf/tests/NestedLoopJoinTest.cpp
@@ -1624,13 +1624,12 @@ TEST_F(CudfNestedLoopJoinTest, buildStreamVisibleToAllProbeBatches) {
   constexpr int32_t kNumProbeBatches = 20;
   constexpr int32_t kProbeBatchSize = 500;
 
-  auto buildVectors = {
-      makeRowVector({sequence<int32_t>(kNumBuildRows)})};
+  auto buildVectors = {makeRowVector({sequence<int32_t>(kNumBuildRows)})};
 
   std::vector<RowVectorPtr> probeVectors;
   for (int32_t b = 0; b < kNumProbeBatches; ++b) {
-    probeVectors.push_back(
-        makeRowVector({sequence<int32_t>(kProbeBatchSize, b * kProbeBatchSize)}));
+    probeVectors.push_back(makeRowVector(
+        {sequence<int32_t>(kProbeBatchSize, b * kProbeBatchSize)}));
   }
 
   createDuckDbTable("t", probeVectors);


### PR DESCRIPTION
## Summary

Fixes an intermittent, silently-wrong-results bug in `CudfNestedLoopJoinProbe`. Reported by @dan13bauer: a `LEFT JOIN` with a `LIKE` condition spanning both sides (`lower LIKE concat('%', field, '%')`, `Distribution: REPLICATED`) returned a slightly different `COUNT` on about 1 in 10 runs (e.g. 4302236 vs. 4302235/4302233/4302234, with one run off by 185), while an equivalent query rewritten as a giant `CASE` expression was always consistent.

## Root cause

`joinWithBuildBatch()` is called once per probe input batch, and grabs a fresh CUDA stream from `cudfGlobalStreamPool()` on every call. `syncBuildStream()` is supposed to make sure the build side is actually visible on whichever stream the probe uses:

```cpp
void CudfNestedLoopJoinProbe::syncBuildStream(
    rmm::cuda_stream_view probeStream) {
  if (buildStream_.has_value()) {
    if (!cudaEvent_) {
      cudaEvent_ = std::make_unique<CudaEvent>();
    }
    cudaEvent_->recordFrom(buildStream_.value()).waitOn(probeStream);
    buildStream_.reset();   // <-- bug
  }
}
```

`buildStream_.reset()` means this only does anything on the *first* call. Every subsequent probe batch gets a brand-new stream from the pool that never gets a `waitOn()` call, so there's no GPU-side ordering guarantee that the build-side data is actually finished/visible before that batch starts reading it. Under real concurrency/load this occasionally let a probe batch read the build table before it was fully materialized, silently dropping matches.

## Fix

Record the build-ready event once, but call `waitOn()` for every probe stream that shows up, not just the first one - the same record-once/wait-many pattern already used by `Utilities.cpp`'s `streamsWaitForStream`:

```cpp
void CudfNestedLoopJoinProbe::syncBuildStream(
    rmm::cuda_stream_view probeStream) {
  if (buildStream_.has_value()) {
    if (!cudaEvent_) {
      cudaEvent_ = std::make_unique<CudaEvent>();
      cudaEvent_->recordFrom(buildStream_.value());
    }
    cudaEvent_->waitOn(probeStream);
  }
}
```

## Testing

- Added `buildStreamVisibleToAllProbeBatches`, a multi-batch regression test (20 probe batches against a 50K-row build side, repeated 15x) where every probe row has exactly one matching build row, so any row dropped by the race shows up as a count mismatch against DuckDB.
- Note: this specific race is timing-dependent and I was not able to reliably force it to fail in this lightweight gtest environment even with much larger build-side data (5M rows) - the production report only saw it under real concurrent/multi-batch load on a GPU cluster. The fix is justified primarily by the logic itself (matching the established `CudaEvent` record-once/wait-many idiom already used elsewhere in this file) plus this regression test as ongoing coverage.
- Full `velox_cudf_nested_loop_join_test` (55 tests) and `velox_cudf_hash_join_test` (132 tests) suites pass on GPU.