### PR TITLE
feat: Stamp Iceberg field-ids on NIMBLE schema nodes by pre-order node id (#18269)

### DIFF
--- a/velox/connectors/hive/iceberg/WriterOptionsAdapter.h
+++ b/velox/connectors/hive/iceberg/WriterOptionsAdapter.h
@@ -58,7 +58,7 @@ class WriterOptionsAdapter {
 /// `icebergFieldIds` carries the per-input-column Iceberg field-id tree.
 /// Honored only by the NIMBLE adapter, which uses it to stamp
 /// `iceberg.id` (and other Iceberg V3 keys) onto each NIMBLE schema node
-/// via `VeloxWriterOptions::attributesByColumn`. Pass an empty
+/// via `VeloxWriterOptions::schemaAttributes`. Pass an empty
 /// `IcebergFieldId{}` for formats / call sites that have no field-id tree
 /// available (the NIMBLE adapter then produces files without
 /// `iceberg.id` attributes, the same wire shape as a pre-attributes

--- a/velox/connectors/hive/iceberg/tests/IcebergNimbleInsertTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergNimbleInsertTest.cpp
@@ -240,5 +240,75 @@ TEST_F(IcebergNimbleInsertTest, fieldIdNestedStructReorderDrop) {
       .assertResults({expected});
 }
 
+// No schema evolution, complex types: array, map, struct, and array-of-struct
+// columns written and read back unchanged. Exercises the collection write+read
+// path and confirms iceberg.id stamping on collection nodes does not perturb
+// the round trip.
+TEST_F(IcebergNimbleInsertTest, roundTripComplexTypes) {
+  auto rowType =
+      ROW({"c1", "arr", "kv", "s", "arrStruct"},
+          {BIGINT(),
+           ARRAY(INTEGER()),
+           MAP(INTEGER(), VARCHAR()),
+           ROW({"x", "y"}, {INTEGER(), VARCHAR()}),
+           ARRAY(ROW({"a", "b"}, {INTEGER(), VARCHAR()}))});
+  test(rowType, 0.2);
+}
+
+// Schema evolution nested under a LIST: the element struct's fields are renamed
+// (name -> label, age -> years) while keeping their Iceberg field-ids. This
+// only resolves because the writer now stamps iceberg.id on the list element's
+// struct children; without it the FieldIdResolver would fall back to name and
+// the renamed fields would read as null. Golden coverage for the
+// collection-nested field-id write path.
+TEST_F(IcebergNimbleInsertTest, fieldIdRenameInsideArrayStruct) {
+  // items: array<struct<name VARCHAR, age INTEGER>>, two array rows.
+  auto elements = makeRowVector(
+      {"name", "age"},
+      {makeFlatVector<std::string>({"a", "b", "c"}),
+       makeFlatVector<int32_t>({1, 2, 3})});
+  auto items = makeArrayVector({0, 2}, elements);
+  auto writeVector = makeRowVector({"items"}, {items});
+
+  const auto dir = TempDirectoryPath::create();
+  const auto path = dir->getPath();
+  createDataSinkAndAppendData({writeVector}, path)->close();
+  auto splits = createSplitsForDirectory(path);
+
+  // Written field ids (depth-first pre-order): items=1, element struct=2,
+  // name=3, age=4. The read schema renames name->label and age->years but keeps
+  // the ids, so resolution must match by id through the list element.
+  auto readElementType = ROW({"label", "years"}, {VARCHAR(), INTEGER()});
+  auto readItemsType = ARRAY(readElementType);
+  auto readSchema = ROW({"items"}, {readItemsType});
+  std::
+      unordered_map<std::string, std::shared_ptr<const connector::ColumnHandle>>
+          assignments{
+              {"items",
+               makeIcebergColumnHandle(
+                   "items", readItemsType, {1, {{2, {{3, {}}, {4, {}}}}}})}};
+
+  auto plan = exec::test::PlanBuilder()
+                  .startTableScan()
+                  .connectorId(test::kIcebergConnectorId)
+                  .outputType(readSchema)
+                  .dataColumns(readSchema)
+                  .assignments(assignments)
+                  .endTableScan()
+                  .planNode();
+
+  auto expectedElements = makeRowVector(
+      {"label", "years"},
+      {makeFlatVector<std::string>({"a", "b", "c"}),
+       makeFlatVector<int32_t>({1, 2, 3})});
+  auto expected =
+      makeRowVector({"items"}, {makeArrayVector({0, 2}, expectedElements)});
+  exec::test::AssertQueryBuilder(plan)
+      .connectorSessionProperty(
+          test::kIcebergConnectorId, kSelectiveNimbleReaderEnabled, "false")
+      .splits(splits)
+      .assertResults({expected});
+}
+
 } // namespace
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/tests/WriterOptionsAdapterTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/WriterOptionsAdapterTest.cpp
@@ -199,7 +199,7 @@ TEST(WriterOptionsAdapterTest, toManifestFormatStringThrowsForUnsupported) {
 // compatibility, and populated trees produce correct per-column attributes.
 // ---------------------------------------------------------------------------
 
-// Verifies an empty Iceberg field-id tree is a no-op: attributesByColumn
+// Verifies an empty Iceberg field-id tree is a no-op: schemaAttributes
 // stays empty after applyPostConfigs. This is the no-op upgrade path for
 // every existing NIMBLE writer call site -- the on-disk file is
 // byte-identical to pre-stack output.
@@ -212,12 +212,13 @@ TEST(WriterOptionsAdapterTest, nimbleApplyPostConfigsEmptyTreeIsNoOp) {
   options.schema = ROW({"a"}, {INTEGER()});
   adapter->applyPostConfigs(options);
 
-  EXPECT_TRUE(options.attributesByColumn.empty());
+  EXPECT_TRUE(options.schemaAttributes.empty());
 }
 
-// Verifies the NIMBLE adapter stamps `iceberg.id` onto top-level columns
-// in the dotted-path keyed map. The walk goes through the schema in
-// lockstep with the field-id tree, so each column gets the right id.
+// Verifies the NIMBLE adapter stamps `iceberg.id` onto top-level columns keyed
+// by pre-order node id. The walk goes through the schema in lockstep with the
+// field-id tree, so each column gets the right id (root row = 0; id = 1,
+// name = 2).
 TEST(WriterOptionsAdapterTest, nimbleApplyPostConfigsStampsTopLevelIcebergIds) {
   // Build a synthetic top-level wrapper with one child per column,
   // matching how IcebergDataSink constructs the tree.
@@ -236,9 +237,9 @@ TEST(WriterOptionsAdapterTest, nimbleApplyPostConfigsStampsTopLevelIcebergIds) {
 
   adapter->applyPostConfigs(options);
 
-  ASSERT_EQ(options.attributesByColumn.size(), 2u);
-  ASSERT_EQ(options.attributesByColumn.count("id"), 1u);
-  ASSERT_EQ(options.attributesByColumn.count("name"), 1u);
+  ASSERT_EQ(options.schemaAttributes.size(), 2u);
+  ASSERT_EQ(options.schemaAttributes.count(1), 1u);
+  ASSERT_EQ(options.schemaAttributes.count(2), 1u);
 
   const std::vector<std::pair<std::string, std::string>> kIdAttrs = {
       {"iceberg.id", "7"},
@@ -246,14 +247,12 @@ TEST(WriterOptionsAdapterTest, nimbleApplyPostConfigsStampsTopLevelIcebergIds) {
   const std::vector<std::pair<std::string, std::string>> kNameAttrs = {
       {"iceberg.id", "12"},
   };
-  EXPECT_EQ(options.attributesByColumn.at("id"), kIdAttrs);
-  EXPECT_EQ(options.attributesByColumn.at("name"), kNameAttrs);
+  EXPECT_EQ(options.schemaAttributes.at(1), kIdAttrs);
+  EXPECT_EQ(options.schemaAttributes.at(2), kNameAttrs);
 }
 
-// Verifies the NIMBLE adapter recurses into nested struct (RowType)
-// children, producing dotted-path keys like "user.name". Diff B's
-// writer-side resolveDottedPath supports this case directly. Array/Map
-// nested field-ids are deferred to a follow-up.
+// Verifies the NIMBLE adapter recurses into nested struct (RowType) children,
+// numbering them in pre-order (user = 1, name = 2, age = 3).
 TEST(WriterOptionsAdapterTest, nimbleApplyPostConfigsStampsNestedStructIds) {
   IcebergFieldId icebergFieldIds;
   // Top-level child 0 = column "user" (id 1) with two nested struct
@@ -277,7 +276,7 @@ TEST(WriterOptionsAdapterTest, nimbleApplyPostConfigsStampsNestedStructIds) {
   adapter->applyPostConfigs(options);
 
   // Parent struct + both leaves all annotated with their field-ids.
-  ASSERT_EQ(options.attributesByColumn.size(), 3u);
+  ASSERT_EQ(options.schemaAttributes.size(), 3u);
   const std::vector<std::pair<std::string, std::string>> kUserAttrs = {
       {"iceberg.id", "1"},
   };
@@ -287,9 +286,63 @@ TEST(WriterOptionsAdapterTest, nimbleApplyPostConfigsStampsNestedStructIds) {
   const std::vector<std::pair<std::string, std::string>> kAgeAttrs = {
       {"iceberg.id", "3"},
   };
-  EXPECT_EQ(options.attributesByColumn.at("user"), kUserAttrs);
-  EXPECT_EQ(options.attributesByColumn.at("user.name"), kNameAttrs);
-  EXPECT_EQ(options.attributesByColumn.at("user.age"), kAgeAttrs);
+  EXPECT_EQ(options.schemaAttributes.at(1), kUserAttrs);
+  EXPECT_EQ(options.schemaAttributes.at(2), kNameAttrs);
+  EXPECT_EQ(options.schemaAttributes.at(3), kAgeAttrs);
+}
+
+// Verifies the NIMBLE adapter recurses into ARRAY / MAP children, numbering
+// them in pre-order: tags = 1, element = 2, props = 3, key = 4, value = 5. The
+// field-id tree is walked in lockstep (array = 1 child, map = 2 children).
+TEST(WriterOptionsAdapterTest, nimbleApplyPostConfigsStampsCollectionIds) {
+  IcebergFieldId icebergFieldIds;
+  // Column 0 = "tags" list<int> (id 1) with element (id 2).
+  IcebergFieldId tagsField;
+  tagsField.fieldId = 1;
+  tagsField.children.emplace_back(
+      IcebergFieldId{/*fieldId*/ 2, /*children*/ {}});
+  icebergFieldIds.children.emplace_back(std::move(tagsField));
+  // Column 1 = "props" map<int,long> (id 3) with key (id 4) and value (id 5).
+  IcebergFieldId propsField;
+  propsField.fieldId = 3;
+  propsField.children.emplace_back(
+      IcebergFieldId{/*fieldId*/ 4, /*children*/ {}});
+  propsField.children.emplace_back(
+      IcebergFieldId{/*fieldId*/ 5, /*children*/ {}});
+  icebergFieldIds.children.emplace_back(std::move(propsField));
+
+  auto adapter = createWriterOptionsAdapter(
+      dwio::common::FileFormat::NIMBLE, std::move(icebergFieldIds));
+  ASSERT_NE(adapter, nullptr);
+
+  velox::nimble::NimbleWriterOptions options;
+  options.schema =
+      ROW({"tags", "props"}, {ARRAY(INTEGER()), MAP(INTEGER(), BIGINT())});
+
+  adapter->applyPostConfigs(options);
+
+  // Collection node + element / key / value all annotated.
+  ASSERT_EQ(options.schemaAttributes.size(), 5u);
+  const std::vector<std::pair<std::string, std::string>> kTagsAttrs = {
+      {"iceberg.id", "1"},
+  };
+  const std::vector<std::pair<std::string, std::string>> kElementAttrs = {
+      {"iceberg.id", "2"},
+  };
+  const std::vector<std::pair<std::string, std::string>> kPropsAttrs = {
+      {"iceberg.id", "3"},
+  };
+  const std::vector<std::pair<std::string, std::string>> kKeyAttrs = {
+      {"iceberg.id", "4"},
+  };
+  const std::vector<std::pair<std::string, std::string>> kValueAttrs = {
+      {"iceberg.id", "5"},
+  };
+  EXPECT_EQ(options.schemaAttributes.at(1), kTagsAttrs);
+  EXPECT_EQ(options.schemaAttributes.at(2), kElementAttrs);
+  EXPECT_EQ(options.schemaAttributes.at(3), kPropsAttrs);
+  EXPECT_EQ(options.schemaAttributes.at(4), kKeyAttrs);
+  EXPECT_EQ(options.schemaAttributes.at(5), kValueAttrs);
 }
 
 // Verifies the NIMBLE adapter stamps the Iceberg V3 type attributes carried
@@ -324,7 +377,7 @@ TEST(WriterOptionsAdapterTest, nimbleApplyPostConfigsStampsV3Attributes) {
       {"iceberg.binary-type", "UUID"},
       {"iceberg.length", "16"},
   };
-  EXPECT_EQ(options.attributesByColumn.at("u"), kExpected);
+  EXPECT_EQ(options.schemaAttributes.at(1), kExpected);
 }
 
 // Verifies V3 attributes are stamped only on the columns that supply them;
@@ -362,12 +415,12 @@ TEST(
   const std::vector<std::pair<std::string, std::string>> kPlainAttrs = {
       {"iceberg.id", "2"},
   };
-  EXPECT_EQ(options.attributesByColumn.at("a"), kRequiredAttrs);
-  EXPECT_EQ(options.attributesByColumn.at("b"), kPlainAttrs);
+  EXPECT_EQ(options.schemaAttributes.at(1), kRequiredAttrs);
+  EXPECT_EQ(options.schemaAttributes.at(2), kPlainAttrs);
 }
 
 // Verifies the V3 attribute tree is walked in lockstep with nested struct
-// children, so each leaf gets its own attributes at the right dotted path.
+// children, so each leaf gets its own attributes at the right node id.
 TEST(WriterOptionsAdapterTest, nimbleApplyPostConfigsStampsNestedStructV3) {
   IcebergFieldId icebergFieldIds;
   IcebergFieldId userField;
@@ -408,8 +461,8 @@ TEST(WriterOptionsAdapterTest, nimbleApplyPostConfigsStampsNestedStructV3) {
       {"iceberg.id", "3"},
       {"iceberg.timestamp-unit", "MICROS"},
   };
-  EXPECT_EQ(options.attributesByColumn.at("user.id"), kIdAttrs);
-  EXPECT_EQ(options.attributesByColumn.at("user.ts"), kTsAttrs);
+  EXPECT_EQ(options.schemaAttributes.at(2), kIdAttrs);
+  EXPECT_EQ(options.schemaAttributes.at(3), kTsAttrs);
 }
 
 // Defends against passing a non-NIMBLE WriterOptions to


### PR DESCRIPTION
Summary:

Enables Iceberg field-id-based schema evolution for NIMBLE (Alpha) Iceberg
tables by stamping `iceberg.id` (and Iceberg V3 type) attributes on every schema
node -- top-level columns, nested struct fields, and list element / map
key/value at any depth -- matching DWRF's schemaAttributes.

Following review of the initial dotted-path approach (D113527853/D113527854),
per-node attributes are keyed by pre-order schema node id (matching the writer's
TypeWithId::id()), exactly like DWRF's Writer::schemaAttributes. Node-id
addressing is unambiguous (no field-name collisions or dot-in-name hazard),
needs no field-name alignment between the Iceberg and engine schemas, and is the
representation the writer already used internally.

- Native (nimble): VeloxWriterOptions::attributesByColumn -> schemaAttributes
  keyed by uint32 pre-order node id; the writer stamps directly by nodeId in the
  typeAddedHandler (deleted resolveDottedPath). NimbleWriterOptions bridge and
  NimbleWriterOptionBuilder::withSchemaAttributes retyped to match.
- alpha_jni transport: proto column_attributes -> map<uint32, ColumnAttributes>;
  AlphaWriterJNI and the Java JniAlphaWriter / JniAlphaWriterOptions /
  AlphaPageWriterOptions retyped to integer keys.
- Producers: NimbleWriterOptionsAdapter (native Presto) and
  NimbleFormats.buildColumnAttributes (Flink/Spark) emit pre-order node-id keys,
  walking the Iceberg field-id tree in lockstep with the schema. Dropped the
  now-unneeded validateColumnAttributeAlignment and engine-path collectors --
  positional addressing needs no name alignment.

Reviewed By: xiaoxmeng

Differential Revision: D113527853


