### PR TITLE
fix(exec): Deduplicate aggregate signature errors (#18271)

### DIFF
--- a/velox/exec/AggregateFunctionRegistry.cpp
+++ b/velox/exec/AggregateFunctionRegistry.cpp
@@ -22,17 +22,8 @@
 namespace facebook::velox::exec {
 
 namespace {
-std::string makeSignatureNotSupportedError(
-    const std::string& name,
-    const std::vector<TypePtr>& argTypes,
-    const std::vector<std::shared_ptr<AggregateFunctionSignature>>&
-        signatures) {
-  std::stringstream error;
-  error << "Aggregate function signature is not supported: "
-        << toString(name, argTypes)
-        << ". Supported signatures: " << toString(signatures) << ".";
-  return error.str();
-}
+constexpr char kSignatureNotSupportedError[] =
+    "Aggregate function signature is not supported: {}. Supported signatures: {}.";
 } // namespace
 
 TypePtr resolveResultType(
@@ -47,7 +38,9 @@ TypePtr resolveResultType(
     }
 
     VELOX_USER_FAIL(
-        makeSignatureNotSupportedError(name, argTypes, signatures.value()));
+        kSignatureNotSupportedError,
+        toString(name, argTypes),
+        toString(signatures.value()));
   }
 
   VELOX_USER_FAIL("Aggregate function not registered: {}", name);
@@ -69,7 +62,9 @@ TypePtr resolveResultTypeWithCoercions(
     }
 
     VELOX_USER_FAIL(
-        makeSignatureNotSupportedError(name, argTypes, signatures.value()));
+        kSignatureNotSupportedError,
+        toString(name, argTypes),
+        toString(signatures.value()));
   }
 
   VELOX_USER_FAIL("Aggregate function not registered: {}", name);
@@ -87,7 +82,7 @@ TypePtr resolveIntermediateType(
     }
 
     VELOX_USER_FAIL(
-        "Aggregate function signature is not supported: {}. Supported signatures: {}.",
+        kSignatureNotSupportedError,
         toString(name, argTypes),
         toString(signatures.value()));
   } else {

--- a/velox/exec/tests/AggregateFunctionRegistryTest.cpp
+++ b/velox/exec/tests/AggregateFunctionRegistryTest.cpp
@@ -120,6 +120,19 @@ TEST_F(AggregateFunctionRegistryTest, wrongArgType) {
       "Aggregate function signature is not supported");
 }
 
+TEST_F(
+    AggregateFunctionRegistryTest,
+    signatureNotSupportedRecordsStableTemplate) {
+  try {
+    resolveResultType("aggregate_func", {BIGINT()});
+    FAIL() << "Expected exception";
+  } catch (const VeloxUserError& e) {
+    EXPECT_EQ(
+        e.messageTemplate(),
+        "Aggregate function signature is not supported: {}. Supported signatures: {}.");
+  }
+}
+
 TEST_F(AggregateFunctionRegistryTest, coercions) {
   // (bigint, double) -> bigint
   // (T, T) -> T


### PR DESCRIPTION
Summary:

Resolving an aggregate call whose argument types match no registered signature throws an "Aggregate function signature is not supported" error. The error recorded its fully-rendered message as the template, with the function name and argument types baked in, so every distinct call produced a distinct template and these failures never grouped into a single bucket in error dashboards.

The two throw sites built the message with a `std::stringstream` and passed it as the single argument to `VELOX_USER_FAIL`, which makes the rendered message its own template. Passing a format string with the name and signatures as arguments records a stable template instead. This makes the aggregate error consistent with the scalar resolver, which already records a parameterized template. The message a user sees is unchanged.

Before, each unsupported call recorded a per-call template:

    Aggregate function signature is not supported: sum(VARCHAR). Supported signatures: ...

After, all such failures record one template, like the scalar resolver already does:

    Aggregate function signature is not supported: {}. Supported signatures: {}.

Reviewed By: mbasmanova

Differential Revision: D113581390


