### PR TITLE
Migrate c10::starts_with caller to std::string_view member (#18272)

### DIFF
--- a/velox/experimental/torchwave/Executor.cpp
+++ b/velox/experimental/torchwave/Executor.cpp
@@ -555,7 +555,7 @@ WaveGraphExecutor::WaveGraphExecutor(std::unique_ptr<ModelContext> modelContext)
     std::unique_ptr<nativert::OpKernel> kernel;
     if (nativert::PrimKernelRegistry()->Has(target)) {
       kernel = nativert::PrimKernelRegistry()->Create(target, node);
-    } else if (c10::starts_with(target, "torch.ops")) {
+    } else if (target.starts_with("torch.ops")) {
       kernel = std::make_unique<nativert::C10Kernel>(node);
     } else if (isScalarBinaryOp(target)) {
       kernel = std::make_unique<nativert::ScalarBinaryOpKernel>(node);


### PR DESCRIPTION
Summary:

Now that PyTorch builds with C++20, migrate the pre-C++20 `c10::starts_with`
free-function shim to the standard `std::string::starts_with` member function in
`experimental/torchwave/Executor.cpp` (1 call site). Mechanical,
behavior-preserving refactor.

Part of a series that removes all callers of the `c10::starts_with` /
`c10::ends_with` shims so the shim overloads can later be deleted from
`c10/util/string_view.h`.

Differential Revision: D113584950


