### PR TITLE
fix(exec): disable useListRowIndex in SortBuffer to avoid addInput OOM

### DIFF
--- a/velox/exec/SortBuffer.cpp
+++ b/velox/exec/SortBuffer.cpp
@@ -73,8 +73,19 @@ SortBuffer::SortBuffer(
     sortedSpillColumnNames.emplace_back(input->nameOf(i));
   }
 
+  // NOTE: do not enable 'useListRowIndex' here. It makes RowContainer::newRow()
+  // eagerly push each row pointer into a pool-backed 'rowPointers_' vector,
+  // which grows by doubling reallocation during input accumulation. Under
+  // memory pressure (e.g. a large/skewed OrderBy), that reallocation goes
+  // through memory arbitration (growCapacity) and can OOM in addInput -- the
+  // sort cannot spill its way out because the index is not spillable. The
+  // listRowsFast speedup is not worth this failure mode; listRows() falls back
+  // to scanning when the index is absent.
   data_ = std::make_unique<RowContainer>(
-      sortedColumnTypes, nonSortedColumnTypes, /*useListRowIndex=*/true, pool_);
+      sortedColumnTypes,
+      nonSortedColumnTypes,
+      /*useListRowIndex=*/false,
+      pool_);
   spillerStoreType_ =
       ROW(std::move(sortedSpillColumnNames), std::move(sortedSpillColumnTypes));
 }

--- a/velox/exec/SortBuffer.h
+++ b/velox/exec/SortBuffer.h
@@ -69,6 +69,13 @@ class SortBuffer {
 
   std::optional<uint64_t> estimateOutputRowSize() const;
 
+  /// Returns the row container that holds the accumulated input rows. Used only
+  /// for testing the RowContainer's construction (e.g. that the non-spillable
+  /// row-pointer index is not enabled).
+  const RowContainer* testingData() const {
+    return data_.get();
+  }
+
  private:
   // Ensures there is sufficient memory reserved to process 'input'.
   void ensureInputFits(const VectorPtr& input);

--- a/velox/exec/tests/SortBufferTest.cpp
+++ b/velox/exec/tests/SortBufferTest.cpp
@@ -566,6 +566,38 @@ TEST_P(SortBufferTest, spill) {
   }
 }
 
+// Regression test for an addInput OOM. Enabling 'useListRowIndex' on
+// SortBuffer's RowContainer (Velox #15698) makes RowContainer::newRow() push
+// each row pointer into a pool-backed 'rowPointers_' vector as input is
+// accumulated. That vector grows by doubling reallocation, is not spillable,
+// and can OOM addInput on a large/skewed sort -- the sort cannot spill its way
+// out. SortBuffer never uses listRowsFast (noMoreInput() uses the scanning
+// listRows()), so the index must stay disabled. Guard the invariant directly:
+// no row-pointer index is built while accumulating input.
+TEST_P(SortBufferTest, noRowPointerIndexDuringInput) {
+  exec::SpillStats spillStats;
+  auto sortBuffer = std::make_unique<SortBuffer>(
+      inputType_,
+      sortColumnIndices_,
+      sortCompareFlags_,
+      pool_.get(),
+      &nonReclaimableSection_,
+      prefixSortConfig_,
+      /*spillConfig=*/nullptr,
+      &spillStats);
+
+  VectorFuzzer fuzzer({.vectorSize = 1024}, fuzzerPool_.get());
+  constexpr int kNumInputs = 10;
+  for (int i = 0; i < kNumInputs; ++i) {
+    sortBuffer->addInput(fuzzer.fuzzRow(inputType_));
+  }
+
+  // Rows accumulated, but the non-spillable row-pointer index must be empty:
+  // populating it here is what regresses addInput into an unspillable OOM.
+  EXPECT_EQ(sortBuffer->testingData()->numRows(), kNumInputs * 1024);
+  EXPECT_TRUE(sortBuffer->testingData()->testingRowPointers().empty());
+}
+
 DEBUG_ONLY_TEST_P(SortBufferTest, spillDuringInput) {
   auto spillDirectory = TempDirectoryPath::create();
   const auto spillConfig = getSpillConfig(spillDirectory->getPath());


### PR DESCRIPTION
Summary:
SortBuffer builds its RowContainer with useListRowIndex=true (opted in
by Velox #15698, f8b32e7ef). With it on, RowContainer::newRow() eagerly
pushes each row pointer into a pool-backed rowPointers_ vector during
input accumulation. That vector grows by doubling reallocation through
memory arbitration (growCapacity) and is not spillable, so under memory
pressure (large/skewed OrderBy) it OOMs in SortBuffer::addInput -- the
sort cannot spill its way out.

Observed on metalake DELETE ... WHERE $row_id IN (...) with DISTINCT,
e.g. query 20260723_180338_46197_34mjk (14 GB per-node cap), which OOMs
in OrderBy[1805] -> SortBuffer::addInput -> growCapacity.

SortBuffer never calls listRowsFast; noMoreInput() uses listRows(),
which scans when the index is absent. So disabling useListRowIndex is a
pure perf revert with no behavior change and no plan/optimizer change.

Differential Revision: D113500365


