### PR TITLE
fix(qdigest): Correct full-range REAL node level decode (#18276)

### DIFF
--- a/velox/functions/lib/QuantileDigest.h
+++ b/velox/functions/lib/QuantileDigest.h
@@ -511,7 +511,8 @@ int8_t QuantileDigest<T, Allocator>::calculateLevel(int8_t nodeStructure) {
   auto level =
       static_cast<int8_t>(static_cast<uint8_t>(nodeStructure) >> 2 & 63);
   if constexpr (std::is_same_v<U, int32_t>) {
-    level = (level == 64) ? 32 : level;
+    // REAL full-range node uses the 64-bit wire sentinel 63, map back to 31.
+    level = static_cast<int8_t>((level == 63) ? 31 : level);
   }
   return level;
 }

--- a/velox/functions/lib/tests/QuantileDigestTest.cpp
+++ b/velox/functions/lib/tests/QuantileDigestTest.cpp
@@ -799,6 +799,35 @@ TEST_F(QuantileDigestTest, mergeWithEmpty) {
   testMergeEmpty<float>(false);
 }
 
+TEST_F(QuantileDigestTest, mergeSerializedFullRangeReal) {
+  constexpr double kAccuracy = 0.01;
+  QuantileDigest<float> first{StlAllocator<float>(allocator()), kAccuracy};
+  QuantileDigest<float> second{StlAllocator<float>(allocator()), kAccuracy};
+  first.add(-2.0f, 1.0);
+  first.add(1.0f, 1.0);
+  second.add(-1.0f, 1.0);
+  second.add(2.0f, 1.0);
+  first.compress();
+  second.compress();
+
+  auto serializeDigest = [](QuantileDigest<float>& digest) {
+    std::string buf(digest.serializedByteSize(), '\0');
+    digest.serialize(buf.data());
+    return buf;
+  };
+  const std::string buf1 = serializeDigest(first);
+  const std::string buf2 = serializeDigest(second);
+
+  QuantileDigest<float> result{StlAllocator<float>(allocator()), kAccuracy};
+  result.mergeSerialized(buf1.data());
+  result.mergeSerialized(buf2.data());
+
+  EXPECT_EQ(result.getCount(), 4.0);
+  EXPECT_EQ(result.getMin(), -2.0f);
+  EXPECT_EQ(result.getMax(), 2.0f);
+  EXPECT_EQ(result.estimateQuantile(0.5), 1.0f);
+}
+
 TEST_F(QuantileDigestTest, infinity) {
   const double kInf = std::numeric_limits<double>::infinity();
   const float kFInf = std::numeric_limits<float>::infinity();


### PR DESCRIPTION
Summary:

Merging serialized REAL (`qdigest(real)`) digests could corrupt the heap and crash the worker. A digest whose values straddle zero produces a full-range node that decodes to an out-of-range level, causing an undefined `uint32_t` shift in `inSameSubtree` during `mergeSerialized`. For example:

    SELECT values_at_quantiles(qdigest_agg(CAST(c0 AS REAL), 1), ARRAY[0.5]) FROM t

crashes when partial aggregates from mixed-sign data are merged.

`calculateLevel` now recovers the correct level in the int32 branch. Before: the sentinel decoded to 63, the caller's `+1` gave 64, and `inSameSubtree` shifted `(uint32_t)bits >> 64` (UB). After: it decodes to 31, `+1` gives 32, and `inSameSubtree` short-circuits at 32 before shifting.

Serialized bytes are unchanged; only the previously-crashing full-range case decodes differently. This is int32/REAL-only and restores parity with the Java reference.

Differential Revision: D113683588


