### PR TITLE
fix(hdfs): Fail cleanly when libhdfs cannot be loaded

### DIFF
--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.cpp
@@ -31,9 +31,8 @@ class HdfsFileSystem::Impl {
       const config::ConfigBase* config,
       const HdfsServiceEndpoint& endpoint) {
     auto status = filesystems::arrow::io::internal::ConnectLibHdfs(&driver_);
-    if (!status.ok()) {
-      LOG(ERROR) << "ConnectLibHdfs failed due to: " << status.ToString();
-    }
+    VELOX_CHECK(
+        status.ok(), "Failed to connect to libhdfs: {}", status.ToString());
 
     // connect to HDFS with the builder object
     hdfsBuilder* builder = driver_->NewBuilder();
@@ -91,9 +90,9 @@ class HdfsFileSystem::Impl {
   }
 
  private:
-  hdfsFS hdfsClient_;
-  filesystems::arrow::io::internal::LibHdfsShim* driver_;
-  bool closed_ = false;
+  hdfsFS hdfsClient_{nullptr};
+  filesystems::arrow::io::internal::LibHdfsShim* driver_{nullptr};
+  bool closed_{false};
 };
 
 HdfsFileSystem::HdfsFileSystem(


### PR DESCRIPTION
## Summary

`ConnectLibHdfs` returns an error when the native HDFS library is missing or has the wrong architecture (e.g. x86-64 `libhdfs.so` on an aarch64 host). The `HdfsFileSystem::Impl` constructor logged the error but continued, calling through null function pointers in the `LibHdfsShim`. This caused `HdfsFileSystemTest.rename` to hang and `HdfsInsertTest.hdfsInsertTest` to SIGSEGV.

Replace `LOG(ERROR)` with `VELOX_CHECK` so the constructor throws immediately. Also initialize `hdfsClient_` and `driver_` members inline to avoid uninitialized state.

Fixes part of #18086 (HDFS — 3 cases)

## Validated on arm64

| Test | Before | After |
|------|--------|-------|
| `HdfsFileSystemTest.read` | Fails | Fails cleanly with error message |
| `HdfsFileSystemTest.rename` | **Hangs** | Fails cleanly: `Failed to connect to libhdfs: IOError: Unable to load libhdfs` |
| `HdfsInsertTest.hdfsInsertTest` | **SIGSEGV** | Fails cleanly: `Failed to connect to libhdfs: IOError: Unable to load libhdfs` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)