### PR TITLE
folly::format -> fmt::format in velox (#18281)

### DIFF
--- a/velox/duckdb/conversion/DuckParser.cpp
+++ b/velox/duckdb/conversion/DuckParser.cpp
@@ -32,6 +32,7 @@
 #include <duckdb/parser/expression/window_expression.hpp> // @manual
 #include <duckdb/parser/parser.hpp> // @manual
 #include <duckdb/parser/parser_options.hpp> // @manual
+#include <fmt/format.h>
 
 namespace facebook::velox::duckdb {
 
@@ -401,7 +402,7 @@ core::ExprPtr parseConjunctionExpr(
 
   if (conjExpr.children.size() < 2) {
     throw std::invalid_argument(
-        folly::sformat(
+        fmt::format(
             "Malformed conjunction expression "
             "(expected at least 2 input columns, got {}).",
             conjExpr.children.size()));

--- a/velox/dwio/dwrf/test/ColumnWriterTest.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <fmt/format.h>
 #include <folly/Random.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -3762,7 +3763,7 @@ struct StringColumnWriterTestCase {
 
         for (size_t k = 0; k != sv->size(); ++k) {
           if (!sv->isNullAt(k)) {
-            EXPECT_EQ(sv->valueAt(k), resultSv->valueAt(k)) << folly::sformat(
+            EXPECT_EQ(sv->valueAt(k), resultSv->valueAt(k)) << fmt::format(
                 "Mismatch on {}-th element. \nExpected: {}\n Actual: {}",
                 k,
                 sv->valueAt(k).str(),

--- a/velox/dwio/dwrf/test/IntEncoderBenchmark.cpp
+++ b/velox/dwio/dwrf/test/IntEncoderBenchmark.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <fmt/format.h>
 #include <folly/Benchmark.h>
 #include <folly/Varint.h>
 #include <folly/init/Init.h>
@@ -118,7 +119,7 @@ FOLLY_ALWAYS_INLINE static int32_t findSetBitsNew(uint64_t value) {
       return 1;
   }
   DWIO_RAISE(
-      folly::sformat(
+      fmt::format(
           "Unexpected leading zeros {} for value {}", leadingZeros, value));
 }
 


### PR DESCRIPTION
Summary:

Mechanical migration of `folly::sformat(...)` call sites to `fmt::format(...)`
(adding `#include <fmt/format.h>` where needed) in `velox`.

`folly::sformat` and `fmt::format` share identical format-string syntax, so this
is a semantically-equivalent, token-level rewrite produced by the
`folly-to-fmt-format` clang codemod, run via the migration farm in
`fbcode/scripts/rbarnes/folly_to_fmt` (D112466250). Part of the fbcode-wide
`folly::format` -> `fmt::format` migration.

This diff covers 3 file(s).

Differential Revision: D113304304


