### PR TITLE
feat(aggregates): VARBINARY compare in N-arg min_by/max_by

### DIFF
--- a/velox/functions/prestosql/aggregates/MinMaxByAggregateBase.h
+++ b/velox/functions/prestosql/aggregates/MinMaxByAggregateBase.h
@@ -1049,6 +1049,8 @@ std::unique_ptr<exec::Aggregate> createNArg(
       return std::make_unique<NAggregate<W, float>>(resultType);
     case TypeKind::DOUBLE:
       return std::make_unique<NAggregate<W, double>>(resultType);
+    case TypeKind::VARBINARY:
+      [[fallthrough]];
     case TypeKind::VARCHAR:
       return std::make_unique<NAggregate<W, StringView>>(resultType);
     case TypeKind::TIMESTAMP:
@@ -1156,6 +1158,7 @@ std::vector<exec::AggregateRegistrationResult> registerMinMaxBy(
       "real",
       "double",
       "varchar",
+      "varbinary",
       "date",
       "timestamp"};
 

--- a/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
@@ -2153,6 +2153,40 @@ TEST_F(MinMaxByNTest, groupByVarchar) {
       {data}, {"c0"}, {"min_by(c1, c2, 3)", "max_by(c1, c2, 4)"}, {expected});
 }
 
+TEST_F(MinMaxByNTest, varbinaryCompare) {
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({1, 2, 3, 4, 5, 6, 7}),
+      makeFlatVector<std::string>(
+          {"a", "b", "c", "d", "e", "f", "g"}, VARBINARY()),
+      makeFlatVector<bool>({false, false, false, false, true, true, true}),
+  });
+
+  // Global.
+  auto expected = makeRowVector({
+      makeArrayVector<int32_t>({
+          {1, 2, 3},
+      }),
+      makeArrayVector<int32_t>({
+          {7, 6, 5, 4},
+      }),
+  });
+  testAggregations(
+      {data}, {}, {"min_by(c0, c1, 3)", "max_by(c0, c1, 4)"}, {expected});
+  testReadFromFiles(
+      {data}, {}, {"min_by(c0, c1, 3)", "max_by(c0, c1, 4)"}, {expected});
+
+  // Group-by.
+  expected = makeRowVector({
+      makeFlatVector<bool>({false, true}),
+      makeArrayVector<int32_t>({{1, 2}, {5, 6}}),
+      makeArrayVector<int32_t>({{4, 3}, {7, 6}}),
+  });
+  testAggregations(
+      {data}, {"c2"}, {"min_by(c0, c1, 2)", "max_by(c0, c1, 2)"}, {expected});
+  testReadFromFiles(
+      {data}, {"c2"}, {"min_by(c0, c1, 2)", "max_by(c0, c1, 2)"}, {expected});
+}
+
 TEST_F(MinMaxByNTest, stringComparison) {
   std::string s[6];
   for (int i = 0; i < 6; ++i) {


### PR DESCRIPTION
Summary:
The 3-argument forms min_by(x, y, n) and max_by(x, y, n) rejected a VARBINARY comparison column. This comes up when a hash is the comparator, to keep a deterministic top-N — for example:

    SELECT min_by(id, xxhash64(to_big_endian_64(id)), 2000) FROM t

where the xxhash64 result is VARBINARY. It fails with:

    Aggregate function signature is not supported: min_by(BIGINT, VARBINARY, BIGINT)

The N-argument variant builds its signatures from an enumerated list of comparison types that omitted varbinary, and its creation switch had no VARBINARY case. The 2-argument forms already accepted it. Add varbinary to the list and route it through the same StringView byte-compare path used for varchar, since VARBINARY orders by bytes.

Differential Revision: D113705680


