### PR TITLE
fix(test): Load lazy vectors before DuckDB ingestion in test harness

### DIFF
--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -895,6 +895,11 @@ void DuckDbQueryRunner::createTable(
       for (int32_t column = 0; column < rowType.size(); column++) {
         auto columnVector = vector->childAt(column);
         auto type = rowType.childAt(column);
+        // Resolve lazy vectors before per-row access. duckValueAt casts
+        // the vector to SimpleVector which returns null for a LazyVector.
+        if (columnVector->isLazy()) {
+          columnVector = BaseVector::loadedVectorShared(columnVector);
+        }
         if (columnVector->isNullAt(row)) {
           appender.Append(nullptr);
         } else if (type->isArray()) {

--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -890,10 +890,22 @@ void DuckDbQueryRunner::createTable(
 
   ::duckdb::Appender appender(con, name);
   for (auto& vector : data) {
+    // Resolve lazy vectors once per batch. duckValueAt casts each column to
+    // SimpleVector, which returns null for a LazyVector, so materialize any
+    // lazy child before the per-row loop.
+    std::vector<VectorPtr> columnVectors;
+    columnVectors.reserve(rowType.size());
+    for (int32_t column = 0; column < rowType.size(); column++) {
+      auto columnVector = vector->childAt(column);
+      if (columnVector->isLazy()) {
+        columnVector = BaseVector::loadedVectorShared(columnVector);
+      }
+      columnVectors.push_back(std::move(columnVector));
+    }
     for (int32_t row = 0; row < vector->size(); row++) {
       appender.BeginRow();
       for (int32_t column = 0; column < rowType.size(); column++) {
-        auto columnVector = vector->childAt(column);
+        const auto& columnVector = columnVectors[column];
         auto type = rowType.childAt(column);
         if (columnVector->isNullAt(row)) {
           appender.Append(nullptr);


### PR DESCRIPTION
## Summary

`DuckDbQueryRunner::createTable` passes column vectors to `duckValueAt`, which casts them to `SimpleVector` via `as<SimpleVector<T>>()`. For lazy vectors this cast returns null, causing a SIGSEGV when `valueAt` dereferences it. On x86, the test data happens to not contain lazy columns when `createDuckDbTable` is called. On ARM64, the spill-injected test run reuses lazy probe vectors for the DuckDB reference table, triggering the crash.

Resolve lazy vectors via `BaseVector::loadedVectorShared` before the per-row loop so `duckValueAt` receives a materialized vector.

Fixes part of #18086 (Multi-threaded hash join — 1 case)

## Validated on arm64

| Test | Before | After |
|------|--------|-------|
| `MultiThreadedHashJoinTest.hashJoinWithLazyProbeInputAndSpill` (all 4 variants) | SIGSEGV | **Pass** |

Verified on DGX Spark (aarch64, GCC 14) and Mac M3 (arm64, Apple Clang).

🤖 Generated with [Claude Code](https://claude.com/claude-code)