### PR TITLE
fix(fuzzer): Exclude UNKNOWN base type from HLL input generator

### DIFF
--- a/velox/functions/prestosql/types/fuzzer_utils/HyperLogLogInputGenerator.cpp
+++ b/velox/functions/prestosql/types/fuzzer_utils/HyperLogLogInputGenerator.cpp
@@ -26,13 +26,12 @@ HyperLogLogInputGenerator::HyperLogLogInputGenerator(
     const size_t seed,
     const double nullRatio,
     memory::MemoryPool* pool,
-    int32_t minNumValues)
+    int32_t minNumValues,
+    std::vector<TypePtr> baseTypes)
     : AbstractInputGenerator{seed, HYPERLOGLOG(), nullptr, nullRatio},
       minNumValues_{minNumValues},
       pool_{pool} {
-  static const std::vector<TypePtr> kBaseTypes{
-      BIGINT(), VARCHAR(), DOUBLE(), UNKNOWN()};
-  baseType_ = kBaseTypes[rand<int32_t>(rng_, 0, kBaseTypes.size() - 1)];
+  baseType_ = baseTypes[rand<int32_t>(rng_, 0, baseTypes.size() - 1)];
   error_ = rand<double>(rng_, 0.0040625, 0.26000);
 }
 

--- a/velox/functions/prestosql/types/fuzzer_utils/HyperLogLogInputGenerator.h
+++ b/velox/functions/prestosql/types/fuzzer_utils/HyperLogLogInputGenerator.h
@@ -32,7 +32,9 @@ class HyperLogLogInputGenerator : public AbstractInputGenerator {
       const size_t seed,
       const double nullRatio,
       memory::MemoryPool* pool,
-      int32_t minNumValues = 1);
+      int32_t minNumValues = 1,
+      std::vector<TypePtr> baseTypes =
+          {BIGINT(), VARCHAR(), DOUBLE(), UNKNOWN()});
 
   variant generate() override;
 

--- a/velox/functions/prestosql/types/fuzzer_utils/P4HyperLogLogInputGenerator.cpp
+++ b/velox/functions/prestosql/types/fuzzer_utils/P4HyperLogLogInputGenerator.cpp
@@ -24,10 +24,17 @@ P4HyperLogLogInputGenerator::P4HyperLogLogInputGenerator(
     const size_t seed,
     const double nullRatio,
     memory::MemoryPool* pool)
-    : HyperLogLogInputGenerator(seed, nullRatio, pool, 100) {
-  // P4HyperLogLog only supports dense format, unlike HyperLogLog which
-  // supports sparse and dense representations. 100 is the minimum number that
-  // generate sufficient values to trigger dense format.
+    : HyperLogLogInputGenerator(
+          seed,
+          nullRatio,
+          pool,
+          100,
+          {BIGINT(), VARCHAR(), DOUBLE()}) {
+  // P4HyperLogLog only supports dense format. Exclude UNKNOWN from base
+  // types because approx_set ignores nulls, so an UNKNOWN base type
+  // appends no values and the accumulator stays sparse. 100 is the
+  // minimum number that generates sufficient values to trigger dense
+  // format.
   type_ = P4HYPERLOGLOG();
 }
 


### PR DESCRIPTION
## Summary

`HyperLogLogInputGenerator` randomly picks a base type from `{BIGINT, VARCHAR, DOUBLE, UNKNOWN}` using `FuzzerGenerator` (`folly::detail::DefaultGenerator`). When `UNKNOWN` is selected, `generateTyped<UnknownValue>` appends no values (`approx_set` ignores nulls), so the HLL stays in sparse format. P4HyperLogLog requires dense format.

The base type selection differs across environments because `FuzzerGenerator` aliases `folly::detail::DefaultGenerator`, which resolves to different RNG algorithms depending on the folly version (`std::mt19937` in older folly, `folly::xoshiro256pp_32` in newer). Different algorithms produce different sequences for the same seed, so the base type picked varies across build environments.

Add a `baseTypes` constructor parameter to `HyperLogLogInputGenerator` so subclasses can restrict the type list. `P4HyperLogLogInputGenerator` passes `{BIGINT, VARCHAR, DOUBLE}`, excluding `UNKNOWN`. The base class default remains `{BIGINT, VARCHAR, DOUBLE, UNKNOWN}`, preserving UNKNOWN/sparse coverage for regular HLL tests.

Fixes part of #18086 (P4 HLL — 1 case)

## Validated on arm64

| Test | Before | After |
|------|--------|-------|
| `P4HyperLogLogInputGeneratorTest.generate` | Fail (sparse HLL) | **Pass** |
| `HyperLogLogInputGeneratorTest.generate` | Pass | **Pass** (UNKNOWN still in base class default) |

Verified on DGX Spark (aarch64, GCC 14) and Mac M3 (arm64, Apple Clang).

🤖 Generated with [Claude Code](https://claude.com/claude-code)