### PR TITLE
fix(test): Increase data size in spillPartitionBitsOverlap test

### DIFF
--- a/velox/exec/tests/HashJoinTestExtra.cpp
+++ b/velox/exec/tests/HashJoinTestExtra.cpp
@@ -2187,13 +2187,17 @@ TEST_P(HashJoinTest, spillFileSize) {
 }
 
 TEST_P(HashJoinTest, spillPartitionBitsOverlap) {
+  // Use enough rows so the hash table exits array mode and sizeBits exceeds
+  // spillStartPartitionBit. checkHashBitsOverlap is skipped in array mode.
+  // folly::xoshiro256pp_32 produces different sequences on ARM64 vs x86,
+  // and narrower key distributions can keep the table in array mode.
   auto builder =
       HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
           .numDrivers(numDrivers_)
           .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
           .keyTypes({BIGINT(), BIGINT()})
-          .probeVectors(2'000, 3)
-          .buildVectors(2'000, 3)
+          .probeVectors(5'000, 3)
+          .buildVectors(5'000, 3)
           .referenceQuery(
               "SELECT t_k0, t_k1, t_data, u_k0, u_k1, u_data FROM t, u WHERE t_k0 = u_k0 and t_k1 = u_k1")
           .config(core::QueryConfig::kSpillStartPartitionBit, "8")


### PR DESCRIPTION
## Summary

The test expects `checkHashBitsOverlap` to throw when `sizeBits` overlaps with `spillStartPartitionBit=8`. The hash table's mode and sizing depend on the generated random data. `FuzzerGenerator` (`folly::detail::DefaultGenerator`) resolves to different RNG algorithms depending on the folly version (`std::mt19937` in older folly, `folly::xoshiro256pp_32` in newer). Different algorithms produce different data distributions for the same seed, and narrower distributions can keep the hash table in **array mode** where `checkHashBitsOverlap` is skipped entirely.

Increase from 2000 to 5000 rows per batch to produce enough distinct keys with a wide enough range to exit array mode regardless of the RNG algorithm or data distribution.

Fixes part of #18086 (Hash join spill overlap — 2 cases)

## Validated on arm64

| Test | Before | After |
|------|--------|-------|
| `HashJoinTest.spillPartitionBitsOverlap` (both variants) | "Expected an exception" — table in array mode | **Pass** (sizeBits=14 vs. 8) |

Verified on DGX Spark (aarch64, GCC 14) and Mac M3 (arm64, Apple Clang).

🤖 Generated with [Claude Code](https://claude.com/claude-code)