### PR TITLE
fix: Support dictionary-wrapped approx_percentile intermediate arrays

### DIFF
--- a/velox/functions/lib/aggregates/ApproxPercentileAggregateBase.h
+++ b/velox/functions/lib/aggregates/ApproxPercentileAggregateBase.h
@@ -760,12 +760,6 @@ class ApproxPercentileAggregateBase : public exec::Aggregate {
            ++i) {
         VELOX_USER_CHECK(rowVec->childAt(i)->isFlatEncoding());
       }
-      for (int i = static_cast<int>(Idx::kItems);
-           i <= static_cast<int>(Idx::kLevels);
-           ++i) {
-        VELOX_USER_CHECK(
-            rowVec->childAt(i)->encoding() == VectorEncoding::Simple::ARRAY);
-      }
     } else {
       VELOX_CHECK(rowVec);
     }
@@ -798,10 +792,12 @@ class ApproxPercentileAggregateBase : public exec::Aggregate {
                         ->asUnchecked<SimpleVector<T>>();
     auto maxValue = rowVec->childAt(static_cast<int>(Idx::kMaxValue))
                         ->asUnchecked<SimpleVector<T>>();
-    auto items = rowVec->childAt(static_cast<int>(Idx::kItems))
-                     ->asUnchecked<ArrayVector>();
-    auto levels = rowVec->childAt(static_cast<int>(Idx::kLevels))
-                      ->asUnchecked<ArrayVector>();
+    DecodedVector decodedItems(
+        *rowVec->childAt(static_cast<int>(Idx::kItems)), *baseRows);
+    DecodedVector decodedLevels(
+        *rowVec->childAt(static_cast<int>(Idx::kLevels)), *baseRows);
+    auto items = decodedItems.base()->asUnchecked<ArrayVector>();
+    auto levels = decodedLevels.base()->asUnchecked<ArrayVector>();
 
     auto itemsElements = items->elements()->asFlatVector<T>();
     auto levelElements = levels->elements()->asFlatVector<int32_t>();
@@ -825,6 +821,8 @@ class ApproxPercentileAggregateBase : public exec::Aggregate {
         return;
       }
       int i = decoded.index(row);
+      int itemsIndex = decodedItems.index(i);
+      int levelsIndex = decodedLevels.index(i);
       if (percentileIsArray->isNullAt(i)) {
         return;
       }
@@ -876,8 +874,8 @@ class ApproxPercentileAggregateBase : public exec::Aggregate {
       if constexpr (checkIntermediateInputs) {
         VELOX_USER_CHECK(
             !(k->isNullAt(i) || n->isNullAt(i) || minValue->isNullAt(i) ||
-              maxValue->isNullAt(i) || items->isNullAt(i) ||
-              levels->isNullAt(i)));
+              maxValue->isNullAt(i) || decodedItems.isNullAt(i) ||
+              decodedLevels.isNullAt(i)));
       }
       detail::KllView<T> v{
           .k = static_cast<uint32_t>(k->valueAt(i)),
@@ -885,11 +883,11 @@ class ApproxPercentileAggregateBase : public exec::Aggregate {
           .minValue = minValue->valueAt(i),
           .maxValue = maxValue->valueAt(i),
           .items =
-              {rawItems + items->offsetAt(i),
-               static_cast<size_t>(items->sizeAt(i))},
+              {rawItems + items->offsetAt(itemsIndex),
+               static_cast<size_t>(items->sizeAt(itemsIndex))},
           .levels =
-              {rawLevels + levels->offsetAt(i),
-               static_cast<size_t>(levels->sizeAt(i))},
+              {rawLevels + levels->offsetAt(levelsIndex),
+               static_cast<size_t>(levels->sizeAt(levelsIndex))},
       };
       if constexpr (kSingleGroup) {
         views.push_back(v);

--- a/velox/functions/sparksql/aggregates/tests/ApproxPercentileAggregateTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/ApproxPercentileAggregateTest.cpp
@@ -22,6 +22,7 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/lib/aggregates/ApproxPercentileAggregateBase.h"
 #include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
 #include "velox/functions/sparksql/aggregates/Register.h"
 
@@ -428,6 +429,36 @@ TEST_F(ApproxPercentileAggregateTest, nonFlatPercentileArray) {
                   .planNode();
   auto expected = makeRowVector({makeArrayVector<int32_t>({{0, 5, 9}})});
   AssertQueryBuilder(plan).assertResults(expected);
+}
+
+// Test Partial + Final aggregation with dictionary-wrapped intermediate arrays.
+TEST_F(ApproxPercentileAggregateTest, dictionaryWrappedIntermediateArrays) {
+  auto partial =
+      PlanBuilder()
+          .values({makeRowVector({makeFlatVector<int32_t>({1, 5, 9})})})
+          .partialAggregation({}, {"spark_approx_percentile(c0, 0.5)"})
+          .planNode();
+  auto partialResult = AssertQueryBuilder(partial).copyResults(pool());
+  auto state = partialResult->childAt(0)->as<RowVector>();
+
+  auto indices = makeIndicesInReverse(state->size());
+  auto children = state->children();
+  using Idx = ApproxPercentileIntermediateTypeChildIndex;
+  children[static_cast<int>(Idx::kItems)] = wrapInDictionary(
+      indices, state->size(), children[static_cast<int>(Idx::kItems)]);
+  children[static_cast<int>(Idx::kLevels)] = wrapInDictionary(
+      indices, state->size(), children[static_cast<int>(Idx::kLevels)]);
+  auto wrappedIntermediate = makeRowVector({makeRowVector(children)});
+
+  auto mergeExtract =
+      PlanBuilder()
+          .values({wrappedIntermediate})
+          .singleAggregation(
+              {}, {"spark_approx_percentile_merge_extract_integer(c0)"})
+          .planNode();
+  auto expectedResult =
+      makeRowVector({makeFlatVector(std::vector<int32_t>{5})});
+  AssertQueryBuilder(mergeExtract).assertResults(expectedResult);
 }
 
 // Test when all input values are NULL.


### PR DESCRIPTION
## Problem
`approx_percentile` may receive dictionary-wrapped `items` and `levels` children when an intermediate state flows through expression evaluation with null propagation. This would cause error:
```bash
C++ exception with description "Exception: VeloxUserError
Error Source: USER
Error Code: INVALID_ARGUMENT
Retriable: False
Expression: rowVec->childAt(i)->encoding() == VectorEncoding::Simple::ARRAY
Function: addIntermediateImpl
```

## Fix
This PR remove the original encoding check of `items` and `levels`, and decode them like `percentiles` to support dictionary or constant wrappers around them.