### PR TITLE
feat(memory): Include allocator failure message in allocateAligned error

### DIFF
--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -668,10 +668,11 @@ void* MemoryPoolImpl::allocateAligned(int64_t size, uint32_t alignment) {
     release(alignedSize);
     VELOX_MEM_ALLOC_ERROR(
         fmt::format(
-            "allocateAligned failed with {} aligned to {} from {}",
+            "allocateAligned failed with {} aligned to {} from {} {}",
             succinctBytes(size),
             alignment,
-            toString()));
+            toString(),
+            allocator_->getAndClearFailureMessage()));
   }
   return buffer;
 }


### PR DESCRIPTION
allocateAligned's failure error previously reported only size, alignment,
and pool, omitting the underlying allocator's recorded failure reason.
Append `allocator_->getAndClearFailureMessage()` so the error carries the
root cause, consistent with other allocation-failure paths.