### PR TITLE
fix: Correct addLeafPool threadSafe comment in Memory

### DIFF
--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -240,7 +240,7 @@ class MemoryManager {
   /// 'name'. If 'name' is missing, the memory manager generates a default name
   /// internally to ensure uniqueness. The leaf memory pool is created as the
   /// child of the memory manager's default root memory pool. If 'threadSafe' is
-  /// true, then we track its memory usage in a non-thread-safe mode to reduce
+  /// false, then we track its memory usage in a non-thread-safe mode to reduce
   /// its cpu cost.
   std::shared_ptr<MemoryPool> addLeafPool(
       const std::string& name = "",


### PR DESCRIPTION
The comment stated non-thread-safe tracking happens when 'threadSafe' is
true, which is backwards. MemoryPool takes the thread-safe path when
threadSafe_ is true (MemoryPool.cpp), so non-thread-safe tracking occurs
when 'threadSafe' is false. Correct the comment accordingly.

No functional changes.