### PR TITLE
fix(docs): Render '/*argName=*/' literally in CODING_STYLE.md

### DIFF
--- a/CODING_STYLE.md
+++ b/CODING_STYLE.md
@@ -461,7 +461,7 @@ build impact analysis and selective builds.
   call.  This is particularly a problem for longer signatures with repeated
   types or constant arguments. For example, `phrobinicate(/*elements=*/{1, 2},
   /*startOffset=*/0, /*length=*/2)`
-* Use the /*argName=*/value format (note the lack of spaces). Clang-tidy
+* Use the `/*argName=*/value` format (note the lack of spaces). Clang-tidy
   supports checking the given argument name against the declaration when this
   format is used.
 


### PR DESCRIPTION
The bare "/*argName=*/value" text renders as "/argName=/value" because
GitHub Markdown parses the "*argName=*" pair as italic emphasis and drops
the asterisks. Wrap it in backticks so it renders literally, matching the
already-correct example on the line above.