### PR TITLE
fix(rpc): Size RPCOperator output from preferredOutputBatchRows

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -4387,6 +4387,73 @@ PlanNodePtr MixedUnionNode::create(const folly::dynamic& obj, void* context) {
 RPCNode::RPCNode(
     const PlanNodeId& id,
     PlanNodePtr source,
+    core::CallTypedExprPtr call,
+    std::string outputColumn,
+    RowTypePtr outputType,
+    rpc::RPCStreamingMode streamingMode,
+    int32_t dispatchBatchSize)
+    : PlanNode(id),
+      sources_{std::move(source)},
+      call_(std::move(call)),
+      outputColumn_(std::move(outputColumn)),
+      outputType_(std::move(outputType)),
+      streamingMode_(streamingMode),
+      dispatchBatchSize_(dispatchBatchSize) {
+  VELOX_CHECK_NOT_NULL(call_, "RPCNode call must not be null");
+  VELOX_CHECK(
+      outputType_->containsChild(outputColumn_),
+      "RPCNode outputType must contain the RPC result column: {}",
+      outputColumn_);
+  VELOX_CHECK(
+      *call_->type() == *outputType_->findChild(outputColumn_),
+      "RPCNode call result type ({}) must match the '{}' output column type ({})",
+      call_->type()->toString(),
+      outputColumn_,
+      outputType_->findChild(outputColumn_)->toString());
+}
+
+namespace {
+// Builds the RPC CallTypedExpr from the legacy flattened call fields. Each
+// argument becomes a FieldAccessTypedExpr on argumentColumns[i], except
+// positions with a non-null constantInputs[i], which become a ConstantTypedExpr
+// wrapping that constant vector. Mirrors the backward-compat deserialization
+// path in RPCNode::create().
+core::CallTypedExprPtr rpcCallFromLegacyFields(
+    std::string functionName,
+    TypePtr functionResultType,
+    const std::vector<std::string>& argumentColumns,
+    const std::vector<TypePtr>& argumentTypes,
+    const std::vector<VectorPtr>& constantInputs) {
+  VELOX_CHECK_EQ(
+      argumentColumns.size(),
+      argumentTypes.size(),
+      "RPCNode argumentColumns and argumentTypes must have the same size");
+  VELOX_CHECK_EQ(
+      argumentColumns.size(),
+      constantInputs.size(),
+      "RPCNode argumentColumns and constantInputs must have the same size");
+  std::vector<TypedExprPtr> callInputs;
+  callInputs.reserve(argumentColumns.size());
+  for (size_t i = 0; i < argumentColumns.size(); ++i) {
+    if (constantInputs[i] != nullptr) {
+      callInputs.push_back(
+          std::make_shared<ConstantTypedExpr>(constantInputs[i]));
+    } else {
+      callInputs.push_back(
+          std::make_shared<FieldAccessTypedExpr>(
+              argumentTypes[i], argumentColumns[i]));
+    }
+  }
+  return std::make_shared<CallTypedExpr>(
+      std::move(functionResultType),
+      std::move(callInputs),
+      std::move(functionName));
+}
+} // namespace
+
+RPCNode::RPCNode(
+    const PlanNodeId& id,
+    PlanNodePtr source,
     std::string functionName,
     TypePtr functionResultType,
     std::string outputColumn,
@@ -4396,33 +4463,57 @@ RPCNode::RPCNode(
     std::vector<VectorPtr> constantInputs,
     rpc::RPCStreamingMode streamingMode,
     int32_t dispatchBatchSize)
-    : PlanNode(id),
-      sources_{std::move(source)},
-      functionName_(std::move(functionName)),
-      resultType_(std::move(functionResultType)),
-      outputColumn_(std::move(outputColumn)),
-      outputType_(std::move(outputType)),
-      argumentColumns_(std::move(argumentColumns)),
-      argumentTypes_(std::move(argumentTypes)),
-      constantInputs_(std::move(constantInputs)),
-      streamingMode_(streamingMode),
-      dispatchBatchSize_(dispatchBatchSize) {
-  VELOX_CHECK_EQ(
-      argumentColumns_.size(),
-      argumentTypes_.size(),
-      "argumentColumns and argumentTypes must have the same size");
-  VELOX_CHECK_EQ(
-      argumentColumns_.size(),
-      constantInputs_.size(),
-      "argumentColumns and constantInputs must have the same size");
-  VELOX_CHECK(
-      outputType_->containsChild(outputColumn_),
-      "RPCNode outputType must contain the RPC result column: {}",
-      outputColumn_);
+    : RPCNode(
+          id,
+          std::move(source),
+          rpcCallFromLegacyFields(
+              std::move(functionName),
+              std::move(functionResultType),
+              argumentColumns,
+              argumentTypes,
+              constantInputs),
+          std::move(outputColumn),
+          std::move(outputType),
+          streamingMode,
+          dispatchBatchSize) {}
+
+std::vector<std::string> RPCNode::argumentColumns() const {
+  std::vector<std::string> columns;
+  columns.reserve(call_->inputs().size());
+  for (const auto& input : call_->inputs()) {
+    if (auto* field = dynamic_cast<const FieldAccessTypedExpr*>(input.get())) {
+      columns.push_back(field->name());
+    } else {
+      columns.emplace_back();
+    }
+  }
+  return columns;
+}
+
+std::vector<TypePtr> RPCNode::argumentTypes() const {
+  std::vector<TypePtr> types;
+  types.reserve(call_->inputs().size());
+  for (const auto& input : call_->inputs()) {
+    types.push_back(input->type());
+  }
+  return types;
+}
+
+std::vector<VectorPtr> RPCNode::constantInputs() const {
+  std::vector<VectorPtr> constants;
+  constants.reserve(call_->inputs().size());
+  for (const auto& input : call_->inputs()) {
+    if (auto* constant = dynamic_cast<const ConstantTypedExpr*>(input.get())) {
+      constants.push_back(constant->valueVector());
+    } else {
+      constants.push_back(nullptr);
+    }
+  }
+  return constants;
 }
 
 void RPCNode::addDetails(std::stringstream& stream) const {
-  stream << "function: " << functionName_ << ", outputColumn: " << outputColumn_
+  stream << "function: " << call_->name() << ", outputColumn: " << outputColumn_
          << ", streamingMode: "
          << (streamingMode_ == rpc::RPCStreamingMode::kBatch ? "BATCH"
                                                              : "PER_ROW");
@@ -4433,32 +4524,7 @@ void RPCNode::addDetails(std::stringstream& stream) const {
 
 folly::dynamic RPCNode::serialize() const {
   auto obj = PlanNode::serialize();
-  obj["functionName"] = functionName_;
-  obj["resultType"] = resultType_->serialize();
-
-  // Serialize argument columns (string names).
-  auto colsArray = folly::dynamic::array();
-  for (const auto& col : argumentColumns_) {
-    colsArray.push_back(col);
-  }
-  obj["argumentColumns"] = std::move(colsArray);
-
-  // Serialize argument types.
-  obj["argumentTypes"] = ISerializable::serialize(argumentTypes_);
-
-  // Serialize constant inputs as ConstantTypedExpr for round-trip fidelity.
-  auto constArray = folly::dynamic::array();
-  for (size_t i = 0; i < constantInputs_.size(); ++i) {
-    if (constantInputs_[i]) {
-      auto constExpr =
-          std::make_shared<core::ConstantTypedExpr>(constantInputs_[i]);
-      constArray.push_back(constExpr->serialize());
-    } else {
-      constArray.push_back(nullptr);
-    }
-  }
-  obj["constantInputs"] = std::move(constArray);
-
+  obj["call"] = call_->serialize();
   obj["outputColumn"] = outputColumn_;
   obj["outputType"] = outputType_->serialize();
   obj["streamingMode"] =
@@ -4470,39 +4536,61 @@ folly::dynamic RPCNode::serialize() const {
 // static
 PlanNodePtr RPCNode::create(const folly::dynamic& obj, void* context) {
   auto source = deserializeSingleSource(obj, context);
-  auto functionName = obj["functionName"].asString();
-  auto resultType = ISerializable::deserialize<Type>(obj["resultType"]);
+  auto outputColumn = obj["outputColumn"].asString();
 
-  // Deserialize argument columns.
-  std::vector<std::string> argumentColumns;
-  if (obj.count("argumentColumns")) {
-    for (const auto& col : obj["argumentColumns"]) {
-      argumentColumns.push_back(col.asString());
-    }
-  }
+  core::CallTypedExprPtr call;
+  if (obj.count("call")) {
+    call = std::dynamic_pointer_cast<const CallTypedExpr>(
+        ISerializable::deserialize<ITypedExpr>(obj["call"], context));
+    VELOX_CHECK_NOT_NULL(call, "RPCNode 'call' must be a CallTypedExpr");
+  } else {
+    // Backward compat: rebuild the call from the legacy flattened fields
+    // (functionName / resultType / argumentColumns / argumentTypes /
+    // constantInputs). Column arguments become FieldAccessTypedExpr; positions
+    // with a non-null legacy constantInput become ConstantTypedExpr.
+    auto functionName = obj["functionName"].asString();
+    auto resultType = ISerializable::deserialize<Type>(obj["resultType"]);
 
-  // Deserialize argument types.
-  auto argumentTypes =
-      ISerializable::deserialize<std::vector<Type>>(obj["argumentTypes"]);
-
-  // Deserialize constant inputs from ConstantTypedExpr.
-  std::vector<VectorPtr> constantInputs;
-  if (obj.count("constantInputs")) {
-    for (const auto& item : obj["constantInputs"]) {
-      if (item.isNull()) {
-        constantInputs.push_back(nullptr);
-      } else {
-        auto constExpr = std::dynamic_pointer_cast<const ConstantTypedExpr>(
-            ISerializable::deserialize<ITypedExpr>(item, context));
-        VELOX_CHECK_NOT_NULL(
-            constExpr, "Expected ConstantTypedExpr for constant input");
-        auto* pool = static_cast<memory::MemoryPool*>(context);
-        constantInputs.push_back(constExpr->toConstantVector(pool));
+    std::vector<std::string> argumentColumns;
+    if (obj.count("argumentColumns")) {
+      for (const auto& col : obj["argumentColumns"]) {
+        argumentColumns.push_back(col.asString());
       }
     }
-  }
+    auto argumentTypes =
+        ISerializable::deserialize<std::vector<Type>>(obj["argumentTypes"]);
 
-  auto outputColumn = obj["outputColumn"].asString();
+    std::vector<TypedExprPtr> callInputs;
+    callInputs.reserve(argumentColumns.size());
+    VELOX_CHECK_EQ(
+        argumentTypes.size(),
+        argumentColumns.size(),
+        "Legacy RPCNode argumentTypes and argumentColumns must have the same size");
+    for (size_t i = 0; i < argumentColumns.size(); ++i) {
+      callInputs.push_back(
+          std::make_shared<FieldAccessTypedExpr>(
+              argumentTypes[i], argumentColumns[i]));
+    }
+    if (obj.count("constantInputs")) {
+      VELOX_CHECK_EQ(
+          obj["constantInputs"].size(),
+          argumentColumns.size(),
+          "Legacy RPCNode constantInputs must match argumentColumns size");
+      size_t i = 0;
+      for (const auto& item : obj["constantInputs"]) {
+        if (!item.isNull() && i < callInputs.size()) {
+          auto constExpr = std::dynamic_pointer_cast<const ConstantTypedExpr>(
+              ISerializable::deserialize<ITypedExpr>(item, context));
+          VELOX_CHECK_NOT_NULL(
+              constExpr, "Expected ConstantTypedExpr for constant input");
+          callInputs[i] = constExpr;
+        }
+        ++i;
+      }
+    }
+    call = std::make_shared<CallTypedExpr>(
+        std::move(resultType), std::move(callInputs), std::move(functionName));
+  }
 
   // Deserialize explicit output type.
   RowTypePtr outputType;
@@ -4521,7 +4609,7 @@ PlanNodePtr RPCNode::create(const folly::dynamic& obj, void* context) {
       }
     }
     names.push_back(outputColumn);
-    types.push_back(resultType);
+    types.push_back(call->type());
     outputType = ROW(std::move(names), std::move(types));
   }
 
@@ -4533,13 +4621,9 @@ PlanNodePtr RPCNode::create(const folly::dynamic& obj, void* context) {
   return std::make_shared<RPCNode>(
       deserializePlanNodeId(obj),
       std::move(source),
-      std::move(functionName),
-      std::move(resultType),
+      std::move(call),
       std::move(outputColumn),
       std::move(outputType),
-      std::move(argumentColumns),
-      std::move(argumentTypes),
-      std::move(constantInputs),
       streamingMode,
       dispatchBatchSize);
 }

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -6437,17 +6437,21 @@ class PlanNodeVisitor {
 
 /// Plan node for async RPC execution (e.g., LLM inference, embeddings).
 ///
-/// Stores the function name, result type, argument columns, and streaming
-/// mode. The RPCNode does NOT evaluate argument expressions — a ProjectNode
-/// inserted before this node by the plan rewriter computes argument columns.
+/// Stores the RPC call (function name, result type, and argument expressions)
+/// and streaming mode. Each call argument is either a FieldAccessTypedExpr (an
+/// input column read from the source) or a ConstantTypedExpr (a literal). A
+/// ProjectNode inserted before this node by the plan rewriter computes any
+/// non-constant argument columns; the RPCNode does NOT evaluate argument
+/// expressions itself.
 ///
 /// Architecture:
 ///   SQL: SELECT rpc_function(col1, 'model_name') FROM table
 ///            |
 ///            v (Plan Rewriter)
-///     ProjectNode (__rpc_arg_0 = col1, __rpc_arg_1 = 'model_name')
+///     ProjectNode (__rpc_arg_0 = col1)
 ///           |
-///        RPCNode (argumentColumns = [__rpc_arg_0, __rpc_arg_1])
+///        RPCNode (call = rpc_function(
+///                     FieldAccess(__rpc_arg_0), Constant('model_name')))
 ///           |
 ///       source[0]
 ///           |
@@ -6456,23 +6460,39 @@ class RPCNode : public PlanNode {
  public:
   /// @param id Unique identifier for this plan node.
   /// @param source Data source (the only source).
-  /// @param functionName Name of the registered AsyncRPCFunction.
-  /// @param functionResultType Velox type of the RPC result column.
+  /// @param call The RPC call. Its name() is the registered AsyncRPCFunction,
+  ///        its type() is the Velox type of the RPC result column, and its
+  ///        inputs() are the call arguments in order. Each argument is either a
+  ///        FieldAccessTypedExpr (an input column read from the source at
+  ///        runtime) or a ConstantTypedExpr (a literal materialized by the
+  ///        operator). Their types are passed to
+  ///        AsyncRPCFunction::initialize().
   /// @param outputColumn Name of the output column for RPC responses.
   /// @param outputType Explicit output type. Must contain outputColumn
   ///        and any passthrough source columns needed by downstream.
   ///        Specified explicitly (like AbstractJoinNode) to support column
   ///        pruning.
-  /// @param argumentColumns Names of input columns containing pre-evaluated
-  ///        argument values. RPCOperator reads these columns in addInput().
-  /// @param argumentTypes Types of each argument (aligned with
-  ///        argumentColumns). Passed to AsyncRPCFunction::initialize().
-  /// @param constantInputs Constant argument values (aligned with
-  ///        argumentColumns). nullptr for non-constant args, single-element
-  ///        ConstantVectors for constant args. Passed to initialize().
   /// @param streamingMode The streaming mode for RPC execution.
   /// @param dispatchBatchSize For BATCH mode pipelining: fire callBatch()
   ///        every N rows during addInput() instead of collecting all rows.
+  RPCNode(
+      const PlanNodeId& id,
+      PlanNodePtr source,
+      core::CallTypedExprPtr call,
+      std::string outputColumn,
+      RowTypePtr outputType,
+      rpc::RPCStreamingMode streamingMode = rpc::RPCStreamingMode::kPerRow,
+      int32_t dispatchBatchSize = 0);
+
+  /// Legacy constructor. Prefer the CallTypedExpr constructor above.
+  ///
+  /// Accepts the flattened call fields and builds the CallTypedExpr internally:
+  /// each argument becomes a FieldAccessTypedExpr referencing
+  /// argumentColumns[i] (type argumentTypes[i]), except positions with a
+  /// non-null constantInputs[i], which become a ConstantTypedExpr wrapping that
+  /// constant vector. Retained so existing callers keep compiling during the
+  /// expand/migrate/contract migration (see the diff summary); removed once all
+  /// callers use the CallTypedExpr constructor.
   RPCNode(
       const PlanNodeId& id,
       PlanNodePtr source,
@@ -6490,28 +6510,31 @@ class RPCNode : public PlanNode {
     return sources_[0];
   }
 
+  /// The RPC call: function name, result type, and argument expressions.
+  const core::CallTypedExprPtr& call() const {
+    return call_;
+  }
+
   const std::string& functionName() const {
-    return functionName_;
+    return call_->name();
   }
 
   const TypePtr& rpcResultType() const {
-    return resultType_;
+    return call_->type();
   }
+
+  /// Legacy accessors over the folded call, each derived from call()->inputs().
+  /// Retained so pre-migration callers (e.g. the presto-cpp conversion test)
+  /// keep compiling; removed in the CONTRACT step once every caller uses
+  /// call()->inputs() directly. argumentColumns() yields the FieldAccess name
+  /// for column arguments and an empty string for constants; constantInputs()
+  /// yields the constant vector for constant arguments and nullptr for columns.
+  std::vector<std::string> argumentColumns() const;
+  std::vector<TypePtr> argumentTypes() const;
+  std::vector<VectorPtr> constantInputs() const;
 
   const std::string& outputColumn() const {
     return outputColumn_;
-  }
-
-  const std::vector<std::string>& argumentColumns() const {
-    return argumentColumns_;
-  }
-
-  const std::vector<TypePtr>& argumentTypes() const {
-    return argumentTypes_;
-  }
-
-  const std::vector<VectorPtr>& constantInputs() const {
-    return constantInputs_;
   }
 
   rpc::RPCStreamingMode streamingMode() const {
@@ -6542,13 +6565,9 @@ class RPCNode : public PlanNode {
   void addDetails(std::stringstream& stream) const override;
 
   std::vector<PlanNodePtr> sources_;
-  std::string functionName_;
-  TypePtr resultType_;
+  core::CallTypedExprPtr call_;
   std::string outputColumn_;
   RowTypePtr outputType_;
-  std::vector<std::string> argumentColumns_;
-  std::vector<TypePtr> argumentTypes_;
-  std::vector<VectorPtr> constantInputs_;
   rpc::RPCStreamingMode streamingMode_;
   int32_t dispatchBatchSize_{0};
 };

--- a/velox/core/tests/PlanNodeTest.cpp
+++ b/velox/core/tests/PlanNodeTest.cpp
@@ -607,13 +607,14 @@ TEST_F(PlanNodeTest, rpcNodeSerdePerRowMode) {
   auto rpcNode = std::make_shared<core::RPCNode>(
       "rpc-1",
       valuesNode,
-      "test_function",
-      VARCHAR(),
+      std::make_shared<core::CallTypedExpr>(
+          VARCHAR(),
+          std::vector<core::TypedExprPtr>{
+              std::make_shared<core::FieldAccessTypedExpr>(
+                  VARCHAR(), "prompt")},
+          "test_function"),
       "response",
       ROW({"prompt", "response"}, {VARCHAR(), VARCHAR()}),
-      std::vector<std::string>{"prompt"},
-      std::vector<TypePtr>{VARCHAR()},
-      std::vector<VectorPtr>{nullptr},
       rpc::RPCStreamingMode::kPerRow,
       0);
 
@@ -633,10 +634,12 @@ TEST_F(PlanNodeTest, rpcNodeSerdePerRowMode) {
   EXPECT_EQ(copyRpc->streamingMode(), rpc::RPCStreamingMode::kPerRow);
   EXPECT_EQ(copyRpc->dispatchBatchSize(), 0);
   EXPECT_EQ(*copyRpc->rpcResultType(), *VARCHAR());
-  EXPECT_EQ(copyRpc->argumentColumns().size(), 1);
-  EXPECT_EQ(copyRpc->argumentColumns()[0], "prompt");
-  EXPECT_EQ(copyRpc->argumentTypes().size(), 1);
-  EXPECT_EQ(*copyRpc->argumentTypes()[0], *VARCHAR());
+  ASSERT_EQ(copyRpc->call()->inputs().size(), 1);
+  auto* field = dynamic_cast<const core::FieldAccessTypedExpr*>(
+      copyRpc->call()->inputs()[0].get());
+  ASSERT_NE(field, nullptr);
+  EXPECT_EQ(field->name(), "prompt");
+  EXPECT_EQ(*field->type(), *VARCHAR());
 }
 
 TEST_F(PlanNodeTest, rpcNodeSerdeBatchMode) {
@@ -654,13 +657,14 @@ TEST_F(PlanNodeTest, rpcNodeSerdeBatchMode) {
   auto rpcNode = std::make_shared<core::RPCNode>(
       "rpc-2",
       valuesNode,
-      "batch_function",
-      VARCHAR(),
+      std::make_shared<core::CallTypedExpr>(
+          VARCHAR(),
+          std::vector<core::TypedExprPtr>{
+              std::make_shared<core::FieldAccessTypedExpr>(VARCHAR(), "prompt"),
+              std::make_shared<core::FieldAccessTypedExpr>(VARCHAR(), "model")},
+          "batch_function"),
       "result",
       ROW({"prompt", "model", "result"}, {VARCHAR(), VARCHAR(), VARCHAR()}),
-      std::vector<std::string>{"prompt", "model"},
-      std::vector<TypePtr>{VARCHAR(), VARCHAR()},
-      std::vector<VectorPtr>{nullptr, nullptr},
       rpc::RPCStreamingMode::kBatch,
       50);
 
@@ -676,9 +680,15 @@ TEST_F(PlanNodeTest, rpcNodeSerdeBatchMode) {
   EXPECT_EQ(copyRpc->outputColumn(), "result");
   EXPECT_EQ(copyRpc->streamingMode(), rpc::RPCStreamingMode::kBatch);
   EXPECT_EQ(copyRpc->dispatchBatchSize(), 50);
-  EXPECT_EQ(copyRpc->argumentColumns().size(), 2);
-  EXPECT_EQ(copyRpc->argumentColumns()[0], "prompt");
-  EXPECT_EQ(copyRpc->argumentColumns()[1], "model");
+  ASSERT_EQ(copyRpc->call()->inputs().size(), 2);
+  auto* field0 = dynamic_cast<const core::FieldAccessTypedExpr*>(
+      copyRpc->call()->inputs()[0].get());
+  auto* field1 = dynamic_cast<const core::FieldAccessTypedExpr*>(
+      copyRpc->call()->inputs()[1].get());
+  ASSERT_NE(field0, nullptr);
+  ASSERT_NE(field1, nullptr);
+  EXPECT_EQ(field0->name(), "prompt");
+  EXPECT_EQ(field1->name(), "model");
 }
 
 TEST_F(PlanNodeTest, rpcNodeSerdeWithConstants) {
@@ -698,19 +708,30 @@ TEST_F(PlanNodeTest, rpcNodeSerdeWithConstants) {
   auto rpcNode = std::make_shared<core::RPCNode>(
       "rpc-3",
       valuesNode,
-      "test_function",
-      VARCHAR(),
+      std::make_shared<core::CallTypedExpr>(
+          VARCHAR(),
+          std::vector<core::TypedExprPtr>{
+              std::make_shared<core::FieldAccessTypedExpr>(VARCHAR(), "prompt"),
+              std::make_shared<core::ConstantTypedExpr>(modelConstant),
+              std::make_shared<core::ConstantTypedExpr>(systemPromptConstant)},
+          "test_function"),
       "response",
-      ROW({"prompt", "response"}, {VARCHAR(), VARCHAR()}),
-      std::vector<std::string>{"prompt", "model", "system_prompt"},
-      std::vector<TypePtr>{VARCHAR(), VARCHAR(), VARCHAR()},
-      std::vector<VectorPtr>{nullptr, modelConstant, systemPromptConstant});
+      ROW({"prompt", "response"}, {VARCHAR(), VARCHAR()}));
 
-  // Verify constants before serde.
-  ASSERT_EQ(rpcNode->constantInputs().size(), 3);
-  EXPECT_EQ(rpcNode->constantInputs()[0], nullptr);
-  EXPECT_NE(rpcNode->constantInputs()[1], nullptr);
-  EXPECT_NE(rpcNode->constantInputs()[2], nullptr);
+  // Verify the argument kinds before serde: one column, two constants.
+  ASSERT_EQ(rpcNode->call()->inputs().size(), 3);
+  EXPECT_NE(
+      dynamic_cast<const core::FieldAccessTypedExpr*>(
+          rpcNode->call()->inputs()[0].get()),
+      nullptr);
+  EXPECT_NE(
+      dynamic_cast<const core::ConstantTypedExpr*>(
+          rpcNode->call()->inputs()[1].get()),
+      nullptr);
+  EXPECT_NE(
+      dynamic_cast<const core::ConstantTypedExpr*>(
+          rpcNode->call()->inputs()[2].get()),
+      nullptr);
 
   // Serialize and deserialize.
   const auto serialized = rpcNode->serialize();
@@ -720,21 +741,27 @@ TEST_F(PlanNodeTest, rpcNodeSerdeWithConstants) {
   auto* copyRpc = dynamic_cast<const core::RPCNode*>(copy.get());
   ASSERT_NE(copyRpc, nullptr);
   EXPECT_EQ(copyRpc->functionName(), "test_function");
-  EXPECT_EQ(copyRpc->argumentColumns().size(), 3);
+  ASSERT_EQ(copyRpc->call()->inputs().size(), 3);
 
-  // Verify constants survive the round-trip.
-  ASSERT_EQ(copyRpc->constantInputs().size(), 3);
-  EXPECT_EQ(copyRpc->constantInputs()[0], nullptr);
-  ASSERT_NE(copyRpc->constantInputs()[1], nullptr);
-  ASSERT_NE(copyRpc->constantInputs()[2], nullptr);
+  // Verify the argument kinds survive the round-trip.
+  EXPECT_NE(
+      dynamic_cast<const core::FieldAccessTypedExpr*>(
+          copyRpc->call()->inputs()[0].get()),
+      nullptr);
+  auto* modelConst = dynamic_cast<const core::ConstantTypedExpr*>(
+      copyRpc->call()->inputs()[1].get());
+  auto* promptConst = dynamic_cast<const core::ConstantTypedExpr*>(
+      copyRpc->call()->inputs()[2].get());
+  ASSERT_NE(modelConst, nullptr);
+  ASSERT_NE(promptConst, nullptr);
 
-  // Verify constant values.
-  auto modelVec = copyRpc->constantInputs()[1];
+  // Verify constant values survive the round-trip.
+  auto modelVec = modelConst->toConstantVector(pool_.get());
   EXPECT_TRUE(modelVec->isConstantEncoding());
   EXPECT_EQ(
       modelVec->as<ConstantVector<StringView>>()->valueAt(0).str(), "llama3");
 
-  auto promptVec = copyRpc->constantInputs()[2];
+  auto promptVec = promptConst->toConstantVector(pool_.get());
   EXPECT_TRUE(promptVec->isConstantEncoding());
   EXPECT_EQ(
       promptVec->as<ConstantVector<StringView>>()->valueAt(0).str(),

--- a/velox/exec/rpc/RPCOperator.cpp
+++ b/velox/exec/rpc/RPCOperator.cpp
@@ -111,6 +111,11 @@ void RPCOperator::initialize() {
 
   tierKey_ = function_->tierKey();
 
+  // Size output vectors like every other operator, from config, instead of a
+  // hardcoded cap (see getOutput()).
+  outputBatchRows_ =
+      operatorCtx_->driverCtx()->queryConfig().preferredOutputBatchRows();
+
   // Configure the process-global adaptive rate limiter from QueryConfig. This
   // is idempotent and cluster-default-driven; off by default (static cap).
   const auto& queryConfig = operatorCtx_->driverCtx()->queryConfig();
@@ -466,7 +471,7 @@ RowVectorPtr RPCOperator::getOutput() {
 
     // Drain additional ready rows (non-blocking) for batched output.
     // This amortizes RowVector allocation across multiple completed rows.
-    state_->drainReadyRows(claimedRows_, 1'024);
+    state_->drainReadyRows(claimedRows_, outputBatchRows_);
 
     // Materialize responses, locations, and round-trip latencies once — reused
     // for the congestion signal and the output vector (no extra copy).

--- a/velox/exec/rpc/RPCOperator.cpp
+++ b/velox/exec/rpc/RPCOperator.cpp
@@ -64,12 +64,50 @@ void RPCOperator::initialize() {
       "AsyncRPCFunctionRegistry::registerFunction() before query execution.",
       rpcNode_->functionName());
 
+  // Walk the RPC call's argument expressions once, in order, to build:
+  //  - argumentSources_: how addInput() sources each arg (column vs constant),
+  //  - inputTypes: each argument's Velox type,
+  //  - constantInputs: single-element constant vector for constant args and
+  //    nullptr for column args. This keeps AsyncRPCFunction::initialize()'s
+  //    interface unchanged (types + aligned constant values).
+  auto sourceType = rpcNode_->source()->outputType();
+  const auto& callInputs = rpcNode_->call()->inputs();
+  argumentSources_.reserve(callInputs.size());
+  std::vector<TypePtr> inputTypes;
+  std::vector<VectorPtr> constantInputs;
+  inputTypes.reserve(callInputs.size());
+  constantInputs.reserve(callInputs.size());
+  auto* pool = operatorCtx_->pool();
+  for (const auto& input : callInputs) {
+    inputTypes.push_back(input->type());
+    if (auto* field =
+            dynamic_cast<const core::FieldAccessTypedExpr*>(input.get())) {
+      const auto idx = sourceType->getChildIdx(field->name());
+      argumentSources_.push_back(
+          ArgumentSource{
+              .isConstant = false,
+              .sourceChannel = static_cast<column_index_t>(idx)});
+      constantInputs.push_back(nullptr);
+    } else if (
+        auto* constant =
+            dynamic_cast<const core::ConstantTypedExpr*>(input.get())) {
+      auto constantValue = constant->toConstantVector(pool);
+      constantInputs.push_back(constantValue);
+      argumentSources_.push_back(
+          ArgumentSource{
+              .isConstant = true, .constantValue = std::move(constantValue)});
+    } else {
+      VELOX_FAIL(
+          "RPC call argument must be a FieldAccessTypedExpr or "
+          "ConstantTypedExpr, got: {}",
+          input->toString());
+    }
+  }
+
   // Initialize the function with query config, argument types, and constants.
   // The function creates/caches its own transport and clients internally.
   function_->initialize(
-      operatorCtx_->driverCtx()->queryConfig(),
-      rpcNode_->argumentTypes(),
-      rpcNode_->constantInputs());
+      operatorCtx_->driverCtx()->queryConfig(), inputTypes, constantInputs);
 
   tierKey_ = function_->tierKey();
 
@@ -94,19 +132,11 @@ void RPCOperator::initialize() {
                          ? "BATCH"
                          : "PER_ROW");
 
-  // Precompute argument column indices for addInput().
-  const auto& argCols = rpcNode_->argumentColumns();
-  if (!argCols.empty()) {
-    auto sourceType = rpcNode_->source()->outputType();
-    argumentColumnIndices_.reserve(argCols.size());
-    for (const auto& colName : argCols) {
-      auto idx = sourceType->getChildIdx(colName);
-      argumentColumnIndices_.push_back(static_cast<column_index_t>(idx));
-    }
-    RPC_OP_VLOG(1) << "Initialized with " << argCols.size()
-                   << " argument columns";
+  if (!argumentSources_.empty()) {
+    RPC_OP_VLOG(1) << "Initialized with " << argumentSources_.size()
+                   << " call arguments";
   } else {
-    RPC_OP_VLOG(1) << "Initialized with no argument columns "
+    RPC_OP_VLOG(1) << "Initialized with no call arguments "
                    << "(fallback to all input columns)";
   }
 
@@ -152,12 +182,21 @@ void RPCOperator::addInput(RowVectorPtr input) {
 
   SelectivityVector rows(input->size());
 
-  // Read pre-computed argument columns by precomputed index.
+  // Build per-call arguments in call()->inputs() order: a column argument reads
+  // the source column; a constant argument wraps its single-element constant to
+  // the batch row count, so the function sees the same arg list (order + count)
+  // as it would for a column. Keeps null-input handling identical.
   std::vector<VectorPtr> args;
-  if (!argumentColumnIndices_.empty()) {
-    args.reserve(argumentColumnIndices_.size());
-    for (auto idx : argumentColumnIndices_) {
-      args.push_back(input->childAt(idx));
+  if (!argumentSources_.empty()) {
+    args.reserve(argumentSources_.size());
+    for (const auto& argSource : argumentSources_) {
+      if (argSource.isConstant) {
+        args.push_back(
+            BaseVector::wrapInConstant(
+                input->size(), 0, argSource.constantValue));
+      } else {
+        args.push_back(input->childAt(argSource.sourceChannel));
+      }
     }
   } else {
     // Fallback: use all input columns as arguments.

--- a/velox/exec/rpc/RPCOperator.h
+++ b/velox/exec/rpc/RPCOperator.h
@@ -169,9 +169,20 @@ class RPCOperator : public exec::Operator {
   // Tier key for per-tier rate limiting (from function_->tierKey()).
   std::string tierKey_;
 
-  // Precomputed argument column indices for reading from input in addInput().
-  // Initialized in initialize() by looking up argumentColumns in source type.
-  std::vector<column_index_t> argumentColumnIndices_;
+  // Precomputed per-argument sources, in call()->inputs() order. Built once in
+  // initialize() by walking the RPC call's argument expressions. A
+  // FieldAccessTypedExpr argument resolves to a source column index
+  // (isConstant=false); a ConstantTypedExpr argument materializes a
+  // single-element constant vector (isConstant=true), which addInput() wraps to
+  // the batch row count so the function receives the same arg list as a column.
+  struct ArgumentSource {
+    bool isConstant;
+    // Valid when !isConstant: index of the argument column in the source type.
+    column_index_t sourceChannel{0};
+    // Valid when isConstant: single-element constant vector for the literal.
+    VectorPtr constantValue{};
+  };
+  std::vector<ArgumentSource> argumentSources_;
 
   // Collected row locations for current batch (BATCH mode).
   // Passed to addPendingBatch() when the batch is flushed.

--- a/velox/exec/rpc/RPCOperator.h
+++ b/velox/exec/rpc/RPCOperator.h
@@ -218,6 +218,12 @@ class RPCOperator : public exec::Operator {
   // > 0 = fire flushBatch() every N rows during addInput().
   int32_t dispatchBatchSize_{0};
 
+  // Max rows per output vector, from QueryConfig::preferredOutputBatchRows (set
+  // in initialize()). The PER_ROW path drains at most this many ready rows per
+  // getOutput() call so RPCOperator sizes its output like every other operator
+  // instead of a hardcoded cap.
+  int32_t outputBatchRows_{1'024};
+
   // Claimed rows/batch from isBlocked() for use in getOutput().
   // State is derived from these: if non-empty, we have output ready.
   std::vector<RPCState::ReadyRow> claimedRows_;

--- a/velox/exec/rpc/RPCPlanNodeTranslator.cpp
+++ b/velox/exec/rpc/RPCPlanNodeTranslator.cpp
@@ -49,16 +49,15 @@ std::optional<uint32_t> RPCPlanNodeTranslator::maxDrivers(
     // AddLocalExchanges optimizer inserts a ROUND_ROBIN LocalExchange that
     // distributes this single row across N drivers, causing N-1 drivers to
     // finish empty and the result to be lost. Force single-driver execution.
-    const auto& constantInputs = rpcNode->constantInputs();
-    const auto& argumentColumns = rpcNode->argumentColumns();
-    bool allConstant = !constantInputs.empty() &&
-        std::all_of(
-            constantInputs.begin(), constantInputs.end(), [](const auto& v) {
-              return v != nullptr;
-            });
+    const auto& callInputs = rpcNode->call()->inputs();
+    bool allConstant = !callInputs.empty() &&
+        std::all_of(callInputs.begin(), callInputs.end(), [](const auto& e) {
+          return dynamic_cast<const core::ConstantTypedExpr*>(e.get()) !=
+              nullptr;
+        });
     if (allConstant) {
       auto sourceType = rpcNode->source()->outputType();
-      if (sourceType->size() <= argumentColumns.size()) {
+      if (sourceType->size() <= callInputs.size()) {
         return 1;
       }
     }

--- a/velox/exec/rpc/tests/RPCNodeTest.cpp
+++ b/velox/exec/rpc/tests/RPCNodeTest.cpp
@@ -114,13 +114,10 @@ TEST_F(RPCNodeTest, rpcNodeCreation) {
   auto rpcNode = std::make_shared<core::RPCNode>(
       "rpc-1",
       nullptr,
-      "mock_rpc_function",
-      VARCHAR(),
+      std::make_shared<core::CallTypedExpr>(
+          VARCHAR(), std::vector<core::TypedExprPtr>{}, "mock_rpc_function"),
       "response",
-      ROW({"response"}, {VARCHAR()}),
-      std::vector<std::string>{},
-      std::vector<TypePtr>{},
-      std::vector<VectorPtr>{});
+      ROW({"response"}, {VARCHAR()}));
 
   EXPECT_EQ(rpcNode->id(), "rpc-1");
   EXPECT_EQ(rpcNode->name(), "RPC");
@@ -134,13 +131,10 @@ TEST_F(RPCNodeTest, rpcNodeWithBatchMode) {
   auto rpcNode = std::make_shared<core::RPCNode>(
       "rpc-2",
       nullptr,
-      "mock_rpc_function",
-      VARCHAR(),
+      std::make_shared<core::CallTypedExpr>(
+          VARCHAR(), std::vector<core::TypedExprPtr>{}, "mock_rpc_function"),
       "result",
       ROW({"result"}, {VARCHAR()}),
-      std::vector<std::string>{},
-      std::vector<TypePtr>{},
-      std::vector<VectorPtr>{},
       rpc::RPCStreamingMode::kBatch,
       100);
 
@@ -209,13 +203,10 @@ TEST_F(RPCNodeTest, planNodeToString) {
   auto rpcNode = std::make_shared<core::RPCNode>(
       "rpc-1",
       nullptr,
-      "mock_rpc_function",
-      VARCHAR(),
+      std::make_shared<core::CallTypedExpr>(
+          VARCHAR(), std::vector<core::TypedExprPtr>{}, "mock_rpc_function"),
       "response",
-      ROW({"response"}, {VARCHAR()}),
-      std::vector<std::string>{},
-      std::vector<TypePtr>{},
-      std::vector<VectorPtr>{});
+      ROW({"response"}, {VARCHAR()}));
 
   std::string str = rpcNode->toString(/*detailed=*/true);
 
@@ -227,13 +218,10 @@ TEST_F(RPCNodeTest, planNodeSingleSource) {
   auto rpcNode = std::make_shared<core::RPCNode>(
       "rpc-1",
       nullptr,
-      "mock_rpc_function",
-      VARCHAR(),
+      std::make_shared<core::CallTypedExpr>(
+          VARCHAR(), std::vector<core::TypedExprPtr>{}, "mock_rpc_function"),
       "response",
-      ROW({"response"}, {VARCHAR()}),
-      std::vector<std::string>{},
-      std::vector<TypePtr>{},
-      std::vector<VectorPtr>{});
+      ROW({"response"}, {VARCHAR()}));
 
   ASSERT_EQ(rpcNode->sources().size(), 1);
   EXPECT_EQ(rpcNode->source().get(), nullptr);

--- a/velox/exec/rpc/tests/RPCOperatorTest.cpp
+++ b/velox/exec/rpc/tests/RPCOperatorTest.cpp
@@ -107,14 +107,14 @@ class RPCOperatorTest : public OperatorTestBase {
       int32_t dispatchBatchSize = 0) {
     auto sourceType = source->outputType();
 
-    std::vector<std::string> argCols;
-    std::vector<TypePtr> argTypes;
-    std::vector<VectorPtr> constantInputs;
+    std::vector<core::TypedExprPtr> callInputs;
     for (const auto& colName : argumentColumnNames) {
-      argCols.push_back(colName);
-      argTypes.push_back(sourceType->findChild(colName));
-      constantInputs.push_back(nullptr);
+      callInputs.push_back(
+          std::make_shared<core::FieldAccessTypedExpr>(
+              sourceType->findChild(colName), colName));
     }
+    auto call = std::make_shared<core::CallTypedExpr>(
+        VARCHAR(), std::move(callInputs), functionName);
 
     auto outputNames = sourceType->names();
     auto outputTypes = sourceType->children();
@@ -125,13 +125,9 @@ class RPCOperatorTest : public OperatorTestBase {
     return std::make_shared<core::RPCNode>(
         "rpc-0",
         source,
-        functionName,
-        VARCHAR(),
+        std::move(call),
         "__rpc_result",
         outputType,
-        argCols,
-        argTypes,
-        constantInputs,
         RPCStreamingMode::kBatch,
         dispatchBatchSize);
   }
@@ -143,14 +139,15 @@ class RPCOperatorTest : public OperatorTestBase {
       const std::vector<std::string>& argumentColumnNames) {
     auto sourceType = source->outputType();
 
-    std::vector<std::string> argCols;
-    std::vector<TypePtr> argTypes;
-    std::vector<VectorPtr> constantInputs;
+    std::vector<core::TypedExprPtr> callInputs;
     for (const auto& colName : argumentColumnNames) {
-      argCols.push_back(colName);
-      argTypes.push_back(sourceType->findChild(colName));
-      constantInputs.push_back(nullptr); // Variable, not constant.
+      // Variable (column) argument, not a constant.
+      callInputs.push_back(
+          std::make_shared<core::FieldAccessTypedExpr>(
+              sourceType->findChild(colName), colName));
     }
+    auto call = std::make_shared<core::CallTypedExpr>(
+        VARCHAR(), std::move(callInputs), "demo_rpc");
 
     // Output type = all source columns + RPC result column.
     auto outputNames = sourceType->names();
@@ -160,15 +157,7 @@ class RPCOperatorTest : public OperatorTestBase {
     auto outputType = ROW(std::move(outputNames), std::move(outputTypes));
 
     return std::make_shared<core::RPCNode>(
-        "rpc-0",
-        source,
-        "demo_rpc",
-        VARCHAR(),
-        "__rpc_result",
-        outputType,
-        argCols,
-        argTypes,
-        constantInputs);
+        "rpc-0", source, std::move(call), "__rpc_result", outputType);
   }
 };
 

--- a/velox/exec/rpc/tests/RPCOperatorTest.cpp
+++ b/velox/exec/rpc/tests/RPCOperatorTest.cpp
@@ -189,6 +189,37 @@ TEST_F(RPCOperatorTest, basicPerRow) {
   EXPECT_EQ(rows["third row"], "Response for: third row");
 }
 
+// PER_ROW output is sized from QueryConfig::preferredOutputBatchRows, not a
+// hardcoded cap: 50 rows with a cap of 10 must emit at least 5 output vectors.
+TEST_F(RPCOperatorTest, outputBatchSizeFromConfig) {
+  std::vector<std::string> storage(50);
+  std::vector<StringView> prompts;
+  prompts.reserve(storage.size());
+  for (size_t i = 0; i < storage.size(); ++i) {
+    storage[i] = fmt::format("row {}", i);
+    prompts.emplace_back(storage[i]);
+  }
+  auto input = makeRowVector({"prompt"}, {makeFlatVector<StringView>(prompts)});
+  auto plan = makeRPCNode(PlanBuilder().values({input}).planNode(), {"prompt"});
+
+  std::shared_ptr<exec::Task> task;
+  auto result = AssertQueryBuilder(plan)
+                    .config(core::QueryConfig::kPreferredOutputBatchRows, "10")
+                    .copyResults(pool(), task);
+  EXPECT_EQ(result->size(), 50);
+
+  int64_t rpcOutputVectors = 0;
+  for (const auto& pipeline : task->taskStats().pipelineStats) {
+    for (const auto& op : pipeline.operatorStats) {
+      if (op.operatorType == "RPC") {
+        rpcOutputVectors += op.outputVectors;
+      }
+    }
+  }
+  // 50 rows capped at 10 per output vector => at least 5 vectors.
+  EXPECT_GE(rpcOutputVectors, 5);
+}
+
 /// Null input rows should produce null in the RPC result column.
 TEST_F(RPCOperatorTest, nullInput) {
   auto promptVector =


### PR DESCRIPTION
Summary: velox #18181: RPCOperator's PER_ROW path drained a hardcoded 1024 ready rows into each output vector, ignoring QueryConfig::preferredOutputBatchRows that every other operator honors. Read the config in initialize() and size the output drain from it. Independent of the #18182 capability work.

Differential Revision: D113347631
