### PR TITLE
feat(fuzzer): Cross-config dictionary read path verification in TableEvolutionFuzzer (#18295)

### DIFF
--- a/velox/exec/tests/TableEvolutionFuzzer.cpp
+++ b/velox/exec/tests/TableEvolutionFuzzer.cpp
@@ -956,6 +956,12 @@ void TableEvolutionFuzzer::runQueryShape(
         generatedRemainingFilters,
     const std::unordered_map<std::string, std::string>& columnNameMapping,
     folly::Executor& executor) {
+  readSessionProperties_ = config_.extraReadSessionProperties
+      ? config_.extraReadSessionProperties(rng_)
+      : std::pair<
+            std::unordered_map<std::string, std::string>,
+            std::unordered_map<std::string, std::string>>{};
+
   // Rebuild the scan splits per shape: makeScanTask moves them, and a fresh
   // bucket selection lets shapes exercise different buckets. This only
   // reconstructs Split objects from the existing write results; it does not
@@ -1072,7 +1078,8 @@ void TableEvolutionFuzzer::runQueryShape(
       false,
       false, // insertProjectToBlockPushdown
       fullOutSchema,
-      outputColumnNames);
+      outputColumnNames,
+      readSessionProperties_.first);
 
   // expected: TableScan -> Project -> Aggregation (blocks pushdown)
   // Insert a Project node to prevent aggregation pushdown
@@ -1084,7 +1091,8 @@ void TableEvolutionFuzzer::runQueryShape(
       true,
       true, // insertProjectToBlockPushdown
       fullOutSchema,
-      outputColumnNames);
+      outputColumnNames,
+      readSessionProperties_.second);
 
   ScopedOOMInjector oomInjectorReadPath(
       [this]() -> bool { return folly::Random::oneIn(10, rng_); },
@@ -1099,7 +1107,17 @@ void TableEvolutionFuzzer::runQueryShape(
   // Skip result verification when OOM injection is enabled
   if (!FLAGS_enable_oom_injection_write_path &&
       !FLAGS_enable_oom_injection_read_path) {
-    checkResultsEqual(scanResults[0], scanResults[1]);
+    try {
+      checkResultsEqual(scanResults[0], scanResults[1]);
+    } catch (const std::exception&) {
+      for (const auto& [key, value] : readSessionProperties_.first) {
+        LOG(ERROR) << "Pushdown scan property: " << key << "=" << value;
+      }
+      for (const auto& [key, value] : readSessionProperties_.second) {
+        LOG(ERROR) << "Reference scan property: " << key << "=" << value;
+      }
+      throw;
+    }
   }
 }
 
@@ -1539,7 +1557,8 @@ std::unique_ptr<TaskCursor> TableEvolutionFuzzer::makeScanTask(
     bool useFiltersAsNode,
     bool insertProjectToBlockPushdown,
     const RowTypePtr& fullOutSchema,
-    const std::vector<std::string>& outputColumnNames) {
+    const std::vector<std::string>& outputColumnNames,
+    const std::unordered_map<std::string, std::string>& readSessionProperties) {
   // 'insertProjectToBlockPushdown' only takes effect on the reference plan,
   // where the Project below is what blocks aggregation pushdown; it is
   // meaningless (and never applied) on the pushdown plan. Enforce the pairing
@@ -1623,6 +1642,13 @@ std::unique_ptr<TaskCursor> TableEvolutionFuzzer::makeScanTask(
   }
 
   params.planNode = builder.planNode();
+
+  if (!readSessionProperties.empty()) {
+    params.queryCtx = core::QueryCtx::create();
+    params.queryCtx->setConnectorSessionOverridesUnsafe(
+        connectorId(),
+        std::unordered_map<std::string, std::string>(readSessionProperties));
+  }
 
   auto cursor = TaskCursor::create(params);
   for (auto& split : splits) {

--- a/velox/exec/tests/TableEvolutionFuzzer.h
+++ b/velox/exec/tests/TableEvolutionFuzzer.h
@@ -49,6 +49,16 @@ class TableEvolutionFuzzer {
         dwio::common::FileFormat,
         FuzzerGenerator&)>
         extraWriteSerdeParams;
+
+    /// Returns a pair of connector session property maps, one per scan task in
+    /// a query shape. The two maps may differ so that the pushdown and
+    /// reference scans exercise different read-side configs (e.g. dictionary
+    /// preservation on vs off), turning the existing result comparison into a
+    /// cross-config correctness check. Called once per query shape.
+    std::function<std::pair<
+        std::unordered_map<std::string, std::string>,
+        std::unordered_map<std::string, std::string>>(FuzzerGenerator&)>
+        extraReadSessionProperties;
   };
 
   /// Per-batch raw-byte target and clamp bounds for adaptive batch sizing. A
@@ -185,7 +195,9 @@ class TableEvolutionFuzzer {
       bool useFiltersAsNode,
       bool insertProjectToBlockPushdown,
       const RowTypePtr& fullOutSchema,
-      const std::vector<std::string>& outputColumnNames);
+      const std::vector<std::string>& outputColumnNames,
+      const std::unordered_map<std::string, std::string>&
+          readSessionProperties);
 
   /// Builds schema for flatmap as struct reading by converting selected map
   /// columns to struct types.
@@ -258,6 +270,13 @@ class TableEvolutionFuzzer {
   VectorFuzzer vectorFuzzer_;
   unsigned currentSeed_;
   FuzzerGenerator rng_;
+  /// Per-query-shape read-side connector session properties for the pushdown
+  /// scan (first) and the reference scan (second). Computed once per shape in
+  /// runQueryShape() and passed to makeScanTask(); logged on failure.
+  std::pair<
+      std::unordered_map<std::string, std::string>,
+      std::unordered_map<std::string, std::string>>
+      readSessionProperties_;
   int64_t sequenceNumber_ = 0;
 };
 

--- a/velox/exec/tests/TableEvolutionFuzzerTest.cpp
+++ b/velox/exec/tests/TableEvolutionFuzzerTest.cpp
@@ -286,6 +286,29 @@ TEST(TableEvolutionFuzzerTest, adaptiveVectorSizeScalesWithByteTarget) {
   EXPECT_EQ(doubled, 2 * base);
 }
 
+TEST(TableEvolutionFuzzerTest, extraReadSessionPropertiesApplied) {
+  auto pool = memory::memoryManager()->addLeafPool("TableEvolutionFuzzer");
+  auto config = makeDwrfConfig(pool.get(), 1);
+  int calls = 0;
+  config.extraReadSessionProperties =
+      [&](FuzzerGenerator&) -> std::pair<
+                                std::unordered_map<std::string, std::string>,
+                                std::unordered_map<std::string, std::string>> {
+    ++calls;
+    return {
+        {{"test.reader.key", "pushdown.value"}},
+        {{"test.reader.key", "reference.value"}}};
+  };
+  TableEvolutionFuzzer fuzzer(config);
+  fuzzer.setSeed(20260629);
+  constexpr int kIterations = 3;
+  for (int i = 0; i < kIterations; ++i) {
+    EXPECT_NO_THROW(fuzzer.run());
+    fuzzer.reSeed();
+  }
+  EXPECT_GE(calls, kIterations);
+}
+
 TEST(TableEvolutionFuzzerTest, run) {
   auto pool = memory::memoryManager()->addLeafPool("TableEvolutionFuzzer");
   exec::test::TableEvolutionFuzzer::Config config;


### PR DESCRIPTION
Summary:

- Add `extraReadSessionProperties` callback to `TableEvolutionFuzzer::Config` returning a pair of property maps — one per scan task — so the two scans can exercise different read-side configs within the same query shape
- Internal runner independently coin-flips dictionary read path (50/50) for each scan, giving four combinations per query shape: both off (25%), cross-compare on-vs-off (50%), both on (25%)
- Log both scan property sets on verification failure for reproducibility
- Add `extraReadSessionPropertiesApplied` unit test verifying the callback is invoked and the fuzzer passes with per-scan properties

Reviewed By: HuamengJiang, xiaoxmeng

Differential Revision: D113709321


