### PR TITLE
fix: Correct Iceberg deletion-vector-v1 CRC-32 to match spec (#18296)

### DIFF
--- a/velox/connectors/hive/iceberg/DeletionVectorReader.cpp
+++ b/velox/connectors/hive/iceberg/DeletionVectorReader.cpp
@@ -18,8 +18,8 @@
 
 #include "velox/connectors/hive/iceberg/DeletionVectorFormat.h"
 
-#include <folly/hash/Checksum.h>
 #include <folly/lang/Bits.h>
+#include <zlib.h>
 
 #include <cstring>
 #include <string_view>
@@ -70,9 +70,14 @@ std::string_view unframeDeletionVector(const std::string& blob) {
 
   const uint32_t storedCrc =
       readBigEndian32(blob.data() + kLengthSize + magicAndVectorLength);
-  const uint32_t computedCrc = folly::crc32(
-      reinterpret_cast<const uint8_t*>(blob.data() + kLengthSize),
-      magicAndVectorLength);
+  // Iceberg stores the standard CRC-32 (java.util.zip.CRC32) over magic +
+  // bitmap. zlib's crc32 is that same finalized IEEE 802.3 CRC-32.
+  uLong crc = crc32(0L, Z_NULL, 0);
+  crc = crc32(
+      crc,
+      reinterpret_cast<const Bytef*>(blob.data() + kLengthSize),
+      static_cast<uInt>(magicAndVectorLength));
+  const auto computedCrc = static_cast<uint32_t>(crc);
   VELOX_CHECK_EQ(storedCrc, computedCrc, "Deletion-vector-v1 CRC-32 mismatch.");
 
   return std::string_view(blob).substr(

--- a/velox/connectors/hive/iceberg/DeletionVectorWriter.cpp
+++ b/velox/connectors/hive/iceberg/DeletionVectorWriter.cpp
@@ -20,9 +20,9 @@
 
 #include <algorithm>
 
-#include <folly/hash/Checksum.h>
 #include <folly/json.h>
 #include <folly/lang/Bits.h>
+#include <zlib.h>
 
 #include "velox/common/base/Exceptions.h"
 #include "velox/dwio/common/DataBuffer.h"
@@ -81,9 +81,14 @@ std::string frameDeletionVector(const std::string& bitmap) {
   magicAndVector.append(kDeletionVectorMagic, kDeletionVectorMagicSize);
   magicAndVector.append(bitmap);
 
-  const uint32_t crc = folly::crc32(
-      reinterpret_cast<const uint8_t*>(magicAndVector.data()),
-      magicAndVector.size());
+  // Iceberg stores the standard CRC-32 (java.util.zip.CRC32) over magic +
+  // bitmap. zlib's crc32 is that same finalized IEEE 802.3 CRC-32.
+  uLong crcState = crc32(0L, Z_NULL, 0);
+  crcState = crc32(
+      crcState,
+      reinterpret_cast<const Bytef*>(magicAndVector.data()),
+      static_cast<uInt>(magicAndVector.size()));
+  const auto crc = static_cast<uint32_t>(crcState);
 
   std::string framed;
   framed.reserve(sizeof(uint32_t) + magicAndVector.size() + sizeof(uint32_t));

--- a/velox/connectors/hive/iceberg/tests/DeletionVectorReaderTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/DeletionVectorReaderTest.cpp
@@ -16,9 +16,12 @@
 
 #include "velox/connectors/hive/iceberg/DeletionVectorReader.h"
 
+#include "velox/connectors/hive/iceberg/DeletionVectorFormat.h"
+
 #include <fstream>
 
 #include <gtest/gtest.h>
+#include <zlib.h>
 
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/base/tests/GTestUtils.h"
@@ -93,7 +96,50 @@ std::string serializeRoaringBitmapNoRun(const std::vector<int64_t>& positions) {
   return data;
 }
 
-// Serializes a roaring bitmap in the portable format with run containers
+// Concatenates the deletion-vector-v1 magic bytes with a serialized roaring
+// bitmap. The frame's length prefix and CRC-32 both cover these bytes.
+std::string magicAndVectorBytes(const std::string& bitmap) {
+  std::string bytes;
+  bytes.append(kDeletionVectorMagic, kDeletionVectorMagicSize);
+  bytes.append(bitmap);
+  return bytes;
+}
+
+// Wraps a serialized roaring bitmap in the Iceberg deletion-vector-v1 blob
+// frame: [length: 4B BE][magic D1 D3 39 64][bitmap][CRC-32: 4B BE], where the
+// length and CRC-32 cover magic + bitmap. 'crc' is the checksum stored in the
+// trailing 4 bytes; tests pass it explicitly so they can exercise both the
+// spec-compliant CRC and a deliberately wrong one.
+std::string frameDeletionVectorV1(const std::string& bitmap, uint32_t crc) {
+  const std::string magicAndVector = magicAndVectorBytes(bitmap);
+
+  auto appendBigEndian32 = [](std::string& out, uint32_t value) {
+    const char bytes[4] = {
+        static_cast<char>((value >> 24) & 0xFF),
+        static_cast<char>((value >> 16) & 0xFF),
+        static_cast<char>((value >> 8) & 0xFF),
+        static_cast<char>(value & 0xFF)};
+    out.append(bytes, sizeof(bytes));
+  };
+
+  std::string framed;
+  framed.reserve(sizeof(uint32_t) + magicAndVector.size() + sizeof(uint32_t));
+  appendBigEndian32(framed, static_cast<uint32_t>(magicAndVector.size()));
+  framed.append(magicAndVector);
+  appendBigEndian32(framed, crc);
+  return framed;
+}
+
+// Standard CRC-32 (IEEE 802.3, as computed by java.util.zip.CRC32 used by
+// Iceberg). zlib's crc32 is the reference implementation of that algorithm.
+uint32_t standardCrc32(const std::string& data) {
+  uLong crc = crc32(0L, Z_NULL, 0);
+  crc = crc32(
+      crc,
+      reinterpret_cast<const Bytef*>(data.data()),
+      static_cast<uInt>(data.size()));
+  return static_cast<uint32_t>(crc);
+}
 // (cookie = 12347). All containers are run-encoded.
 std::string serializeRoaringBitmapWithRuns(
     const std::vector<
@@ -272,6 +318,55 @@ TEST_F(DeletionVectorReaderTest, basicArrayContainer) {
   auto setBits = getSetBits(bitmap, 100);
   EXPECT_EQ(setBits, (std::vector<uint64_t>{0, 5, 10, 99}));
   EXPECT_TRUE(reader.noMoreData());
+}
+
+// Anchors standardCrc32() to the canonical CRC-32 test vector so the framed-DV
+// tests below assert against the true Iceberg (java.util.zip.CRC32) checksum,
+// not whatever the reader happens to compute.
+TEST_F(DeletionVectorReaderTest, standardCrc32TestVector) {
+  EXPECT_EQ(standardCrc32("123456789"), 0xCBF43926u);
+}
+
+// A deletion-vector-v1 blob written by Iceberg/Spark stores the standard
+// CRC-32 (java.util.zip.CRC32) over magic + bitmap. The reader must validate
+// against that same checksum and parse the inner bitmap.
+TEST_F(DeletionVectorReaderTest, framedBlobStandardCrc) {
+  std::vector<int64_t> positions = {0, 5, 10, 99};
+  const auto bitmap = serializeRoaringBitmapNoRun(positions);
+  const uint32_t crc = standardCrc32(magicAndVectorBytes(bitmap));
+  const auto framed = frameDeletionVectorV1(bitmap, crc);
+
+  auto tempFile = writeDvFile(framed);
+  auto dvFile = makeDvDeleteFile(
+      tempFile->getPath(), positions.size(), framed.size(), 0, framed.size());
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  auto bitmapBuffer = allocateBitmap(100);
+  reader.readDeletePositions(0, 100, bitmapBuffer);
+
+  auto setBits = getSetBits(bitmapBuffer, 100);
+  EXPECT_EQ(setBits, (std::vector<uint64_t>{0, 5, 10, 99}));
+}
+
+// A frame carrying the old un-inverted checksum (the standard CRC-32 without
+// the final one's-complement — the bug this test guards against) must be
+// rejected: it is not the CRC-32 Iceberg stores.
+TEST_F(DeletionVectorReaderTest, framedBlobRejectsUninvertedCrc) {
+  std::vector<int64_t> positions = {0, 5, 10, 99};
+  const auto bitmap = serializeRoaringBitmapNoRun(positions);
+  const auto magicAndVector = magicAndVectorBytes(bitmap);
+  const uint32_t uninvertedCrc = ~standardCrc32(magicAndVector);
+  const auto framed = frameDeletionVectorV1(bitmap, uninvertedCrc);
+
+  auto tempFile = writeDvFile(framed);
+  auto dvFile = makeDvDeleteFile(
+      tempFile->getPath(), positions.size(), framed.size(), 0, framed.size());
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get(), nullptr);
+  auto bitmapBuffer = allocateBitmap(100);
+  VELOX_ASSERT_THROW(
+      reader.readDeletePositions(0, 100, bitmapBuffer),
+      "Deletion-vector-v1 CRC-32 mismatch");
 }
 
 TEST_F(DeletionVectorReaderTest, batchRangeFiltering) {

--- a/velox/connectors/hive/iceberg/tests/DeletionVectorWriterTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/DeletionVectorWriterTest.cpp
@@ -18,9 +18,8 @@
 
 #include <fstream>
 
-#include <folly/hash/Checksum.h>
-#include <folly/lang/Bits.h>
 #include <gtest/gtest.h>
+#include <zlib.h>
 
 #include <cstring>
 
@@ -343,9 +342,11 @@ TEST_F(DeletionVectorWriterTest, deletionVectorV1FrameLayout) {
   ASSERT_EQ(blob.size(), bitmap.size() + 12);
 
   auto readBigEndian = [](const char* p) {
-    uint32_t value;
-    std::memcpy(&value, p, sizeof(value));
-    return folly::Endian::big(value);
+    const auto* bytes = reinterpret_cast<const unsigned char*>(p);
+    return (static_cast<uint32_t>(bytes[0]) << 24) |
+        (static_cast<uint32_t>(bytes[1]) << 16) |
+        (static_cast<uint32_t>(bytes[2]) << 8) |
+        static_cast<uint32_t>(bytes[3]);
   };
 
   // [length: 4B BE] covers magic (4) + bitmap.
@@ -359,11 +360,17 @@ TEST_F(DeletionVectorWriterTest, deletionVectorV1FrameLayout) {
   // [bitmap] matches the writer's serialize() output.
   EXPECT_EQ(blob.substr(8, bitmap.size()), bitmap);
 
-  // [CRC-32: 4B BE] over magic + bitmap.
+  // [CRC-32: 4B BE] over magic + bitmap. Iceberg stores the standard CRC-32
+  // (java.util.zip.CRC32); zlib's crc32 is the reference implementation of that
+  // same IEEE 802.3 algorithm.
   const uint32_t storedCrc =
       readBigEndian(blob.data() + 4 + magicAndVectorLength);
-  const uint32_t expectedCrc = folly::crc32(
-      reinterpret_cast<const uint8_t*>(blob.data() + 4), magicAndVectorLength);
+  uLong crcState = crc32(0L, Z_NULL, 0);
+  crcState = crc32(
+      crcState,
+      reinterpret_cast<const Bytef*>(blob.data() + 4),
+      static_cast<uInt>(magicAndVectorLength));
+  const auto expectedCrc = static_cast<uint32_t>(crcState);
   EXPECT_EQ(storedCrc, expectedCrc);
 }
 

--- a/velox/connectors/hive/iceberg/tests/IcebergDeletionVectorReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergDeletionVectorReadTest.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/DeletionVectorWriter.h"
+#include "velox/connectors/hive/iceberg/tests/IcebergTestBase.h"
+
+#include <numeric>
+
+#include <folly/Singleton.h>
+
+#include "velox/dwio/common/FileSink.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+namespace {
+
+using TempFilePath = common::testutil::TempFilePath;
+using TempDirectoryPath = common::testutil::TempDirectoryPath;
+
+// End-to-end reproduction of GitHub issue #18126: querying an Iceberg V3 table
+// whose rows are removed by a Spark-written deletion vector (a Puffin
+// deletion-vector-v1 blob) failed with "Deletion-vector-v1 CRC-32 mismatch"
+// because the reader validated the trailing CRC-32 with the wrong (un-inverted)
+// algorithm. This exercises the full TableScan path -- data file + Puffin DV ->
+// scan -> deleted rows filtered out -- against a spec-compliant DV frame that
+// carries the standard IEEE CRC-32 Iceberg/Spark writes.
+class IcebergDeletionVectorReadTest : public test::IcebergTestBase {
+ protected:
+  void SetUp() override {
+    test::IcebergTestBase::SetUp();
+    folly::SingletonVault::singleton()->registrationComplete();
+    fileFormat_ = dwio::common::FileFormat::DWRF;
+    dwio::common::LocalFileSink::registerFactory();
+  }
+
+  // Writes a spec-compliant Puffin deletion-vector-v1 file (PFA1 frame + magic
+  // + portable roaring bitmap + standard CRC-32) for 'deletedPositions',
+  // mirroring what Spark/Iceberg emits, and returns an IcebergDeleteFile
+  // pointing at the DV blob inside it. The returned TempDirectoryPath keeps the
+  // Puffin file alive for the duration of the scan.
+  std::pair<std::shared_ptr<TempDirectoryPath>, IcebergDeleteFile>
+  writeDeletionVector(
+      const std::string& referencedDataFile,
+      const std::vector<int64_t>& deletedPositions) {
+    DeletionVectorWriter writer;
+    writer.addDeletedPositions(deletedPositions);
+    const auto blob = writer.serialize();
+
+    // LocalFileSink refuses to open an existing file, so write the Puffin into
+    // a fresh path under a temp directory rather than a pre-created TempFile.
+    auto puffinDir = TempDirectoryPath::create();
+    const std::string puffinPath = puffinDir->getPath() + "/deletes.puffin";
+    auto sink = dwio::common::FileSink::create(
+        "file:" + puffinPath, {.pool = pool_.get()});
+    const auto [blobOffset, blobLength] = writePuffinFile(
+        *sink,
+        *pool_,
+        blob,
+        referencedDataFile,
+        static_cast<int64_t>(deletedPositions.size()));
+    sink->close();
+
+    IcebergDeleteFile dvFile(
+        FileContent::kDeletionVector,
+        puffinPath,
+        fileFormat_,
+        /*recordCount=*/deletedPositions.size(),
+        /*fileSizeInBytes=*/getFileSize(puffinPath),
+        /*equalityFieldIds=*/{},
+        /*lowerBounds=*/{},
+        /*upperBounds=*/{},
+        /*dataSequenceNumber=*/0,
+        /*contentOffset=*/static_cast<int64_t>(blobOffset),
+        /*contentLength=*/static_cast<int64_t>(blobLength),
+        /*referencedDataFile=*/referencedDataFile);
+    return {puffinDir, dvFile};
+  }
+};
+
+TEST_F(IcebergDeletionVectorReadTest, deletionVectorFiltersDeletedRowsInScan) {
+  // Data file: 10 rows whose value equals their row position (0..9).
+  std::vector<int64_t> values(10);
+  std::iota(values.begin(), values.end(), 0);
+  auto dataFile = TempFilePath::create();
+  writeToFile(
+      dataFile->getPath(), {makeRowVector({makeFlatVector<int64_t>(values)})});
+
+  // Delete positions 8 and 9 (mirrors the issue's DELETE of ids 8, 9).
+  auto [puffinDir, dvFile] = writeDeletionVector(dataFile->getPath(), {8, 9});
+
+  auto splits = makeIcebergSplits(dataFile->getPath(), {dvFile});
+
+  auto plan = exec::test::PlanBuilder()
+                  .startTableScan(test::kIcebergConnectorId)
+                  .outputType(ROW({"c0"}, {BIGINT()}))
+                  .endTableScan()
+                  .planNode();
+
+  // Positions 8 and 9 are deleted, so values 0..7 remain.
+  auto expected =
+      makeRowVector({makeFlatVector<int64_t>({0, 1, 2, 3, 4, 5, 6, 7})});
+  exec::test::AssertQueryBuilder(plan).splits(splits).assertResults(expected);
+}
+
+} // namespace
+} // namespace facebook::velox::connector::hive::iceberg


### PR DESCRIPTION
Summary:

Querying an Iceberg V3 table with a Spark/Iceberg-written deletion vector failed with "Deletion-vector-v1 CRC-32 mismatch". The deletion-vector-v1 blob stores a CRC-32 over the magic bytes + roaring bitmap, computed by Iceberg with java.util.zip.CRC32 (the standard finalized IEEE 802.3 CRC-32).

Velox computed the checksum with folly::crc32(), which returns the un-inverted internal state (it omits the final one's-complement), so it never matches the value Iceberg stores. Because both the reader and writer used folly::crc32, velox-to-velox roundtrips passed and masked the bug, but any DV produced by a spec-compliant engine (Spark) was rejected (and velox-written DVs would fail a strict Iceberg reader).

The reported error numbers confirm it exactly: ~289569291 (computed) == 4005398004 (stored).

Fix: compute the checksum with zlib's crc32() -- the reference implementation of the same IEEE 802.3 CRC-32 that java.util.zip.CRC32 uses -- in both the reader (unframeDeletionVector) and writer (frameDeletionVector). zlib is already a Velox dependency, so this works identically in OSS Velox and matches Apache Iceberg (verified against iceberg-core BitmapPositionDeleteIndex.java: java.util.zip.CRC32 over magic+bitmap, magic 0x6439D3D1 -> bytes D1 D3 39 64, big-endian length and CRC).

Reviewed By: srsuryadev

Differential Revision: D113801418


