### PR TITLE
fix(rpc): Size RPCOperator output from preferredOutputBatchRows (#18298)

### DIFF
--- a/velox/exec/rpc/RPCOperator.cpp
+++ b/velox/exec/rpc/RPCOperator.cpp
@@ -111,9 +111,13 @@ void RPCOperator::initialize() {
 
   tierKey_ = function_->tierKey();
 
+  const auto& queryConfig = operatorCtx_->driverCtx()->queryConfig();
+
+  // Size output vectors from config; see getOutput().
+  outputBatchRows_ = queryConfig.preferredOutputBatchRows();
+
   // Configure the process-global adaptive rate limiter from QueryConfig. This
   // is idempotent and cluster-default-driven; off by default (static cap).
-  const auto& queryConfig = operatorCtx_->driverCtx()->queryConfig();
   RPCRateLimiter::setAdaptiveConfig(
       queryConfig.rpcRateLimiterAdaptiveEnabled(),
       queryConfig.rpcRateLimiterMinLimit(),
@@ -466,7 +470,7 @@ RowVectorPtr RPCOperator::getOutput() {
 
     // Drain additional ready rows (non-blocking) for batched output.
     // This amortizes RowVector allocation across multiple completed rows.
-    state_->drainReadyRows(claimedRows_, 1'024);
+    state_->drainReadyRows(claimedRows_, outputBatchRows_);
 
     // Materialize responses, locations, and round-trip latencies once — reused
     // for the congestion signal and the output vector (no extra copy).

--- a/velox/exec/rpc/RPCOperator.h
+++ b/velox/exec/rpc/RPCOperator.h
@@ -218,6 +218,11 @@ class RPCOperator : public exec::Operator {
   // > 0 = fire flushBatch() every N rows during addInput().
   int32_t dispatchBatchSize_{0};
 
+  // Max rows per output vector, from QueryConfig::preferredOutputBatchRows (set
+  // in initialize()). The kPerRow path drains at most this many ready rows per
+  // getOutput() call.
+  int32_t outputBatchRows_{1'024};
+
   // Claimed rows/batch from isBlocked() for use in getOutput().
   // State is derived from these: if non-empty, we have output ready.
   std::vector<RPCState::ReadyRow> claimedRows_;

--- a/velox/exec/rpc/tests/RPCOperatorTest.cpp
+++ b/velox/exec/rpc/tests/RPCOperatorTest.cpp
@@ -23,6 +23,7 @@
 #include <gtest/gtest.h>
 
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/rpc/RPCPlanNodeTranslator.h"
 #include "velox/exec/rpc/RPCRateLimiter.h"
 #include "velox/exec/rpc/tests/DemoBatchRPCFunction.h"
@@ -189,6 +190,26 @@ TEST_F(RPCOperatorTest, basicPerRow) {
   EXPECT_EQ(rows["hello world"], "Response for: hello world");
   EXPECT_EQ(rows["test prompt"], "Response for: test prompt");
   EXPECT_EQ(rows["third row"], "Response for: third row");
+}
+
+// kPerRow output is sized from QueryConfig::preferredOutputBatchRows: 50 rows
+// with a cap of 10 emit at least 5 output vectors.
+TEST_F(RPCOperatorTest, outputBatchSizeFromConfig) {
+  auto input =
+      makeRowVector({"prompt"}, {makeFlatVector<std::string>(50, [](auto row) {
+                      return fmt::format("row {}", row);
+                    })});
+  auto plan = makeRPCNode(PlanBuilder().values({input}).planNode(), {"prompt"});
+
+  std::shared_ptr<exec::Task> task;
+  auto result = AssertQueryBuilder(plan)
+                    .config(core::QueryConfig::kPreferredOutputBatchRows, "10")
+                    .copyResults(pool(), task);
+  EXPECT_EQ(result->size(), 50);
+
+  // 50 rows capped at 10 per output vector => at least 5 vectors.
+  const auto planStats = toPlanStats(task->taskStats());
+  EXPECT_GE(planStats.at(plan->id()).outputVectors, 5);
 }
 
 /// Null input rows should produce null in the RPC result column.


### PR DESCRIPTION
Summary:

velox #18181: RPCOperator's PER_ROW path drained a hardcoded 1024 ready rows into each output vector, ignoring QueryConfig::preferredOutputBatchRows that every other operator honors. Read the config in initialize() and size the output drain from it. Independent of the #18182 capability work.

Reviewed By: mbasmanova

Differential Revision: D113347631


