### PR TITLE
feat: Thread per-query session credential into Iceberg read and write paths

### DIFF
--- a/velox/connectors/hive/iceberg/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/CMakeLists.txt
@@ -27,6 +27,7 @@ set(
   IcebergMergeProcessor.cpp
   IcebergMergeSink.cpp
   IcebergPartitionName.cpp
+  IcebergSessionCredentials.cpp
   IcebergSplit.cpp
   IcebergSplitReader.cpp
   IcebergStatsCollector.cpp
@@ -63,6 +64,7 @@ velox_add_library(
   IcebergMetadataColumns.h
   IcebergParquetStatsCollector.h
   IcebergPartitionName.h
+  IcebergSessionCredentials.h
   IcebergSplit.h
   IcebergSplitReader.h
   IcebergStatsCollector.h

--- a/velox/connectors/hive/iceberg/IcebergConnector.cpp
+++ b/velox/connectors/hive/iceberg/IcebergConnector.cpp
@@ -18,12 +18,14 @@
 
 #include <numeric>
 
+#include "velox/common/config/Config.h"
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/hive/iceberg/IcebergConfig.h"
 #include "velox/connectors/hive/iceberg/IcebergDataSink.h"
 #include "velox/connectors/hive/iceberg/IcebergDataSource.h"
 #include "velox/connectors/hive/iceberg/IcebergDeletionVectorSink.h"
 #include "velox/connectors/hive/iceberg/IcebergMergeSink.h"
+#include "velox/connectors/hive/iceberg/IcebergSessionCredentials.h"
 
 namespace facebook::velox::connector::hive::iceberg {
 
@@ -39,6 +41,33 @@ void registerIcebergInternalFunctions(const std::string& prefix) {
   std::call_once(registerFlag, [prefix]() {
     functions::iceberg::registerFunctions(prefix);
   });
+}
+
+// Returns 'baseConfig' with the per-query session credentials named by the
+// connector's "hive.session-credential-keys" config folded in, or 'baseConfig'
+// unchanged when there is nothing to merge. The write path (createHiveFileSink)
+// builds the file sink from the build-time HiveConfig and never reads
+// ConnectorQueryCtx::sessionProperties(), so any per-query credential delivered
+// there must be copied into that config for a credential-aware FileSystem to
+// pick it up and authorize the write as the caller. Mirrors the read path
+// (IcebergSplitReader::prepareSplit) via the shared 'sessionCredentials'.
+std::shared_ptr<const HiveConfig> withSessionCredentials(
+    const std::shared_ptr<const HiveConfig>& baseConfig,
+    const ConnectorQueryCtx* connectorQueryCtx) {
+  const auto* sessionProperties = connectorQueryCtx != nullptr
+      ? connectorQueryCtx->sessionProperties()
+      : nullptr;
+  const auto credentials =
+      sessionCredentials(baseConfig->config().get(), sessionProperties);
+  if (credentials.empty()) {
+    return baseConfig;
+  }
+  auto merged = baseConfig->config()->rawConfigsCopy();
+  for (const auto& [key, value] : credentials) {
+    merged[key] = value;
+  }
+  return std::make_shared<const HiveConfig>(
+      std::make_shared<config::ConfigBase>(std::move(merged)));
 }
 
 } // namespace
@@ -75,6 +104,9 @@ std::unique_ptr<DataSink> IcebergConnector::createDataSink(
   auto icebergInsertHandle = checkedPointerCast<const IcebergInsertTableHandle>(
       connectorInsertTableHandle);
 
+  const auto mergedHiveConfig =
+      withSessionCredentials(hiveConfig_, connectorQueryCtx);
+
   switch (icebergInsertHandle->writeKind()) {
     case IcebergInsertTableHandle::WriteKind::kData:
       return std::make_unique<IcebergDataSink>(
@@ -82,7 +114,7 @@ std::unique_ptr<DataSink> IcebergConnector::createDataSink(
           icebergInsertHandle,
           connectorQueryCtx,
           commitStrategy,
-          hiveConfig_,
+          mergedHiveConfig,
           icebergConfig_);
     case IcebergInsertTableHandle::WriteKind::kDeletionVector:
       return std::make_unique<IcebergDeletionVectorSink>(
@@ -90,7 +122,7 @@ std::unique_ptr<DataSink> IcebergConnector::createDataSink(
           icebergInsertHandle,
           connectorQueryCtx,
           commitStrategy,
-          hiveConfig_);
+          mergedHiveConfig);
     case IcebergInsertTableHandle::WriteKind::kMerge: {
       // The IcebergMergeProcessor (Layer 1) emits the convention:
       //   [target cols 0..N-1, operation TINYINT @N, row_id ROW @N+1,
@@ -107,7 +139,7 @@ std::unique_ptr<DataSink> IcebergConnector::createDataSink(
           icebergInsertHandle,
           connectorQueryCtx,
           commitStrategy,
-          hiveConfig_,
+          mergedHiveConfig,
           icebergConfig_,
           std::move(targetColumnChannels),
           operationChannel,

--- a/velox/connectors/hive/iceberg/IcebergSessionCredentials.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSessionCredentials.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/IcebergSessionCredentials.h"
+
+#include <string>
+#include <vector>
+
+#include <folly/String.h>
+
+#include "velox/common/config/Config.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+folly::F14FastMap<std::string, std::string> sessionCredentials(
+    const config::ConfigBase* connectorConfig,
+    const config::ConfigBase* sessionProperties) {
+  folly::F14FastMap<std::string, std::string> credentials;
+  if (connectorConfig == nullptr || sessionProperties == nullptr) {
+    return credentials;
+  }
+  const auto keysCsv = connectorConfig->get<std::string>(
+      std::string(kSessionCredentialKeysConfig));
+  if (!keysCsv.has_value() || keysCsv.value().empty()) {
+    return credentials;
+  }
+
+  std::vector<std::string_view> keys;
+  folly::split(',', keysCsv.value(), keys);
+  for (const auto rawKey : keys) {
+    const auto key = folly::trimWhitespace(rawKey);
+    if (key.empty()) {
+      continue;
+    }
+    const auto value = sessionProperties->get<std::string>(std::string(key));
+    if (value.has_value() && !value.value().empty()) {
+      credentials[std::string(key)] = value.value();
+    }
+  }
+  return credentials;
+}
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergSessionCredentials.h
+++ b/velox/connectors/hive/iceberg/IcebergSessionCredentials.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string_view>
+
+#include <folly/container/F14Map.h>
+
+namespace facebook::velox::config {
+class ConfigBase;
+}
+
+namespace facebook::velox::connector::hive::iceberg {
+
+/// Name of the connector (build-time) config property listing, comma-separated,
+/// the session-property keys whose per-query values should be forwarded to the
+/// FileSystem. A delegated-credential FileSystem uses these values to authorize
+/// I/O as the caller rather than the service identity. Empty by default, so a
+/// stock (OSS) deployment forwards nothing and stays deployment-agnostic; the
+/// deployment-specific credential name lives in the config layer, not in code.
+inline constexpr std::string_view kSessionCredentialKeysConfig =
+    "hive.session-credential-keys";
+
+/// Reads the credential key list named by 'kSessionCredentialKeysConfig' from
+/// 'connectorConfig' and returns the key -> value pairs whose keys have a
+/// non-empty value in 'sessionProperties'. Returns an empty map when either
+/// argument is null, the config property is unset/empty, or no listed key has a
+/// value. Shared by the Iceberg read (IcebergSplitReader::prepareSplit) and
+/// write (IcebergConnector::createDataSink) paths so they cannot diverge.
+folly::F14FastMap<std::string, std::string> sessionCredentials(
+    const config::ConfigBase* connectorConfig,
+    const config::ConfigBase* sessionProperties);
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -22,10 +22,13 @@
 #include <folly/lang/Bits.h>
 
 #include "velox/common/base/Exceptions.h"
+#include "velox/common/config/Config.h"
 #include "velox/common/encode/Base64.h"
+#include "velox/connectors/hive/FileConfig.h"
 #include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
 #include "velox/connectors/hive/iceberg/IcebergDeleteFile.h"
 #include "velox/connectors/hive/iceberg/IcebergMetadataColumns.h"
+#include "velox/connectors/hive/iceberg/IcebergSessionCredentials.h"
 #include "velox/connectors/hive/iceberg/IcebergSplit.h"
 #include "velox/dwio/common/BufferUtil.h"
 #include "velox/vector/DecodedVector.h"
@@ -188,6 +191,31 @@ void IcebergSplitReader::prepareSplit(
     std::shared_ptr<common::MetadataFilter> metadataFilter,
     dwio::common::RuntimeStatistics& runtimeStats,
     const folly::F14FastMap<std::string, std::string>& fileReadOps) {
+  // Forward per-query delegated credentials into fileReadOps so delegated-auth
+  // filesystems authorize the read as the caller rather than the service
+  // identity. The session-property keys carrying the credentials are named by
+  // the connector's "hive.session-credential-keys" config; it is empty by
+  // default, so a stock deployment forwards nothing and the deployment-specific
+  // credential name stays out of the connector. Mirrors the write path
+  // (IcebergConnector::withSessionCredentials) via the shared
+  // 'sessionCredentials'. No-op for non-delegated reads.
+  const auto* sessionProperties = connectorQueryCtx_ != nullptr
+      ? connectorQueryCtx_->sessionProperties()
+      : nullptr;
+  const auto credentials = sessionCredentials(
+      fileConfig_ != nullptr ? fileConfig_->config().get() : nullptr,
+      sessionProperties);
+  // Only copy fileReadOps when there are credentials to fold in; the common
+  // (non-delegated) read path passes the original map through unchanged.
+  folly::F14FastMap<std::string, std::string> mergedFileReadOps;
+  if (!credentials.empty()) {
+    mergedFileReadOps = fileReadOps;
+    for (const auto& [key, value] : credentials) {
+      mergedFileReadOps[key] = value;
+    }
+  }
+  const auto& effectiveFileReadOps =
+      credentials.empty() ? fileReadOps : mergedFileReadOps;
   // For NIMBLE splits, switch the reader to Iceberg field-id-based column
   // resolution. The NIMBLE per-SchemaNode `attributes` slot carries
   // `iceberg.id` keys stamped on the write path; the NIMBLE reader uses
@@ -267,7 +295,7 @@ void IcebergSplitReader::prepareSplit(
         baseReaderOpts_.setFileSchema(ROW(std::move(names), std::move(types)));
       }
     }
-    createReader(fileReadOps);
+    createReader(effectiveFileReadOps);
   }
 
   if (emptySplit_) {

--- a/velox/connectors/hive/iceberg/tests/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/tests/CMakeLists.txt
@@ -70,6 +70,7 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
     IcebergConnectorTest.cpp
     IcebergInsertTest.cpp
     IcebergParquetStatsTest.cpp
+    IcebergSessionCredentialsE2ETest.cpp
     IcebergTestBase.cpp
     Main.cpp
     PartitionNameTest.cpp
@@ -101,6 +102,18 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
     velox_hive_iceberg_splitreader
     velox_exec_test_lib
     velox_dwio_common_test_utils
+    GTest::gtest
+    GTest::gtest_main
+  )
+
+  add_executable(velox_hive_iceberg_session_credentials_test IcebergSessionCredentialsTest.cpp)
+  add_test(velox_hive_iceberg_session_credentials_test velox_hive_iceberg_session_credentials_test)
+
+  target_link_libraries(
+    velox_hive_iceberg_session_credentials_test
+    velox_hive_iceberg_splitreader
+    velox_common_config
+    GTest::gmock
     GTest::gtest
     GTest::gtest_main
   )

--- a/velox/connectors/hive/iceberg/tests/IcebergSessionCredentialsE2ETest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergSessionCredentialsE2ETest.cpp
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/common/file/FileSystems.h"
+#include "velox/common/testutil/TempFilePath.h"
+#include "velox/connectors/ConnectorRegistry.h"
+#include "velox/connectors/hive/iceberg/IcebergConnector.h"
+#include "velox/connectors/hive/iceberg/IcebergSessionCredentials.h"
+#include "velox/connectors/hive/iceberg/tests/IcebergTestBase.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+namespace {
+
+using filesystems::DirectoryOptions;
+using filesystems::FileOptions;
+using filesystems::FileSystem;
+using filesystems::getFileSystem;
+using filesystems::registerFileSystem;
+
+// FileSystem wrapper that records the FileOptions::fileReadOps of every
+// openFileForRead call and otherwise delegates to the underlying real file
+// system. Used to observe that a per-query session credential reaches the
+// FileSystem boundary. Paths are prefixed with scheme() and delegated to the
+// local file system after stripping the prefix.
+class RecordingFileSystem : public FileSystem {
+ public:
+  explicit RecordingFileSystem(std::shared_ptr<const config::ConfigBase> config)
+      : FileSystem(std::move(config)) {}
+
+  static std::string scheme() {
+    return "recording:";
+  }
+
+  std::string name() const override {
+    return "RecordingFS";
+  }
+
+  std::string_view extractPath(std::string_view path) const override {
+    return path.find(scheme()) == 0 ? path.substr(scheme().length()) : path;
+  }
+
+  std::unique_ptr<ReadFile> openFileForRead(
+      std::string_view path,
+      const FileOptions& options = {}) override {
+    {
+      std::lock_guard<std::mutex> l(mutex_);
+      capturedReadOps_.push_back(options.fileReadOps);
+    }
+    const std::string delegated{extractPath(path)};
+    return delegate(delegated)->openFileForRead(delegated, options);
+  }
+
+  std::unique_ptr<WriteFile> openFileForWrite(
+      std::string_view path,
+      const FileOptions& options = {}) override {
+    const std::string delegated{extractPath(path)};
+    return delegate(delegated)->openFileForWrite(delegated, options);
+  }
+
+  void remove(std::string_view path) override {
+    const std::string delegated{extractPath(path)};
+    delegate(delegated)->remove(delegated);
+  }
+
+  void rename(
+      std::string_view oldPath,
+      std::string_view newPath,
+      bool overwrite) override {
+    const std::string from{extractPath(oldPath)};
+    const std::string to{extractPath(newPath)};
+    delegate(from)->rename(from, to, overwrite);
+  }
+
+  bool exists(std::string_view path) override {
+    const std::string delegated{extractPath(path)};
+    return delegate(delegated)->exists(delegated);
+  }
+
+  bool isDirectory(std::string_view path) const override {
+    const std::string delegated{extractPath(path)};
+    return delegate(delegated)->isDirectory(delegated);
+  }
+
+  std::vector<std::string> list(std::string_view path) override {
+    const std::string delegated{extractPath(path)};
+    return delegate(delegated)->list(delegated);
+  }
+
+  void mkdir(std::string_view path, const DirectoryOptions& options = {})
+      override {
+    const std::string delegated{extractPath(path)};
+    delegate(delegated)->mkdir(delegated, options);
+  }
+
+  void rmdir(std::string_view path) override {
+    const std::string delegated{extractPath(path)};
+    delegate(delegated)->rmdir(delegated);
+  }
+
+  void clear() {
+    std::lock_guard<std::mutex> l(mutex_);
+    capturedReadOps_.clear();
+  }
+
+  // Returns the recorded value for 'key' across all openFileForRead calls, or
+  // std::nullopt if no call carried it.
+  std::optional<std::string> readOpValue(const std::string& key) {
+    std::lock_guard<std::mutex> l(mutex_);
+    for (const auto& ops : capturedReadOps_) {
+      const auto it = ops.find(key);
+      if (it != ops.end()) {
+        return it->second;
+      }
+    }
+    return std::nullopt;
+  }
+
+ private:
+  static std::shared_ptr<FileSystem> delegate(const std::string& path) {
+    return getFileSystem(path, nullptr);
+  }
+
+  mutable std::mutex mutex_;
+  std::vector<folly::F14FastMap<std::string, std::string>> capturedReadOps_{};
+};
+
+std::shared_ptr<RecordingFileSystem> recordingFileSystem() {
+  static auto fs = std::make_shared<RecordingFileSystem>(nullptr);
+  return fs;
+}
+
+void registerRecordingFileSystem() {
+  static folly::once_flag once;
+  folly::call_once(once, [] {
+    registerFileSystem(
+        [](std::string_view path) {
+          return path.find(RecordingFileSystem::scheme()) == 0;
+        },
+        [](std::shared_ptr<const config::ConfigBase>, std::string_view) {
+          return recordingFileSystem();
+        });
+  });
+}
+
+// Session-property key naming the credential and the connector config that
+// declares it as forwardable.
+constexpr const char* kCredentialKey = "delegated_cat";
+constexpr const char* kCredentialValue = "cat-token-xyz";
+
+class IcebergSessionCredentialsE2ETest : public test::IcebergTestBase {
+ protected:
+  void SetUp() override {
+    test::IcebergTestBase::SetUp();
+    // Use DWRF so the file is written/read with the always-registered DWRF
+    // factories (Parquet is not registered in this test binary).
+    fileFormat_ = dwio::common::FileFormat::DWRF;
+    registerRecordingFileSystem();
+    recordingFileSystem()->clear();
+
+    // Re-register the Iceberg connector so its build-time config declares
+    // 'delegated_cat' as a session-credential key to forward.
+    ConnectorRegistry::global().erase(test::kIcebergConnectorId);
+    IcebergConnectorFactory factory;
+    auto connector = factory.newConnector(
+        test::kIcebergConnectorId,
+        std::make_shared<config::ConfigBase>(
+            std::unordered_map<std::string, std::string>{
+                {std::string(kSessionCredentialKeysConfig), kCredentialKey}}));
+    ConnectorRegistry::global().insert(connector->connectorId(), connector);
+  }
+};
+
+// Drives a real Iceberg table scan whose data file is opened through the
+// recording file system, and asserts the per-query session credential
+// (delivered via connector session properties) is forwarded all the way to
+// FileOptions::fileReadOps at the file-system boundary.
+TEST_F(IcebergSessionCredentialsE2ETest, forwardsSessionCredentialToReadPath) {
+  const auto rowType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
+  const auto vectors =
+      createTestData(rowType, /*numBatches=*/1, /*rowsPerBatch=*/20);
+
+  const auto dataFile = common::testutil::TempFilePath::create();
+  writeToFile(dataFile->getPath(), vectors);
+
+  // Route the read through the recording file system by prefixing its scheme.
+  const auto splits =
+      makeIcebergSplits(RecordingFileSystem::scheme() + dataFile->getPath());
+
+  const auto plan = exec::test::PlanBuilder()
+                        .startTableScan(test::kIcebergConnectorId)
+                        .outputType(rowType)
+                        .endTableScan()
+                        .planNode();
+
+  exec::test::AssertQueryBuilder(plan)
+      .connectorSessionProperties(
+          {{test::kIcebergConnectorId, {{kCredentialKey, kCredentialValue}}}})
+      .splits(splits)
+      .assertResults(vectors);
+
+  EXPECT_EQ(
+      recordingFileSystem()->readOpValue(kCredentialKey),
+      std::optional<std::string>(kCredentialValue));
+}
+
+// Without the session property set, nothing is forwarded (no-op path).
+TEST_F(IcebergSessionCredentialsE2ETest, noSessionCredentialForwardsNothing) {
+  const auto rowType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
+  const auto vectors =
+      createTestData(rowType, /*numBatches=*/1, /*rowsPerBatch=*/20);
+
+  const auto dataFile = common::testutil::TempFilePath::create();
+  writeToFile(dataFile->getPath(), vectors);
+
+  const auto splits =
+      makeIcebergSplits(RecordingFileSystem::scheme() + dataFile->getPath());
+
+  const auto plan = exec::test::PlanBuilder()
+                        .startTableScan(test::kIcebergConnectorId)
+                        .outputType(rowType)
+                        .endTableScan()
+                        .planNode();
+
+  exec::test::AssertQueryBuilder(plan).splits(splits).assertResults(vectors);
+
+  EXPECT_EQ(recordingFileSystem()->readOpValue(kCredentialKey), std::nullopt);
+}
+
+} // namespace
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/tests/IcebergSessionCredentialsTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergSessionCredentialsTest.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/IcebergSessionCredentials.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "velox/common/config/Config.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+namespace {
+
+using ::testing::IsEmpty;
+using ::testing::Pair;
+using ::testing::UnorderedElementsAre;
+
+std::shared_ptr<config::ConfigBase> makeConfig(
+    std::unordered_map<std::string, std::string> values) {
+  return std::make_shared<config::ConfigBase>(std::move(values));
+}
+
+TEST(IcebergSessionCredentialsTest, nullArgumentsReturnEmpty) {
+  const auto session = makeConfig({{"cat", "token"}});
+  const auto connector =
+      makeConfig({{std::string(kSessionCredentialKeysConfig), "cat"}});
+  EXPECT_THAT(sessionCredentials(nullptr, session.get()), IsEmpty());
+  EXPECT_THAT(sessionCredentials(connector.get(), nullptr), IsEmpty());
+}
+
+TEST(IcebergSessionCredentialsTest, noKeyListReturnsEmpty) {
+  const auto connector = makeConfig({});
+  const auto session = makeConfig({{"cat", "token"}});
+  EXPECT_THAT(sessionCredentials(connector.get(), session.get()), IsEmpty());
+}
+
+TEST(IcebergSessionCredentialsTest, emptyKeyListReturnsEmpty) {
+  const auto connector =
+      makeConfig({{std::string(kSessionCredentialKeysConfig), ""}});
+  const auto session = makeConfig({{"cat", "token"}});
+  EXPECT_THAT(sessionCredentials(connector.get(), session.get()), IsEmpty());
+}
+
+TEST(IcebergSessionCredentialsTest, collectsListedKeysWithValues) {
+  const auto connector =
+      makeConfig({{std::string(kSessionCredentialKeysConfig), "cat,dcat"}});
+  const auto session = makeConfig({{"cat", "token1"}, {"dcat", "token2"}});
+  EXPECT_THAT(
+      sessionCredentials(connector.get(), session.get()),
+      UnorderedElementsAre(Pair("cat", "token1"), Pair("dcat", "token2")));
+}
+
+TEST(IcebergSessionCredentialsTest, skipsMissingAndEmptySessionValues) {
+  const auto connector = makeConfig(
+      {{std::string(kSessionCredentialKeysConfig), "present,missing,blank"}});
+  // 'missing' has no session value; 'blank' has an empty one.
+  const auto session = makeConfig({{"present", "token"}, {"blank", ""}});
+  EXPECT_THAT(
+      sessionCredentials(connector.get(), session.get()),
+      UnorderedElementsAre(Pair("present", "token")));
+}
+
+TEST(IcebergSessionCredentialsTest, trimsKeysAndSkipsEmptyEntries) {
+  const auto connector = makeConfig(
+      {{std::string(kSessionCredentialKeysConfig), " cat , , dcat "}});
+  const auto session = makeConfig({{"cat", "token1"}, {"dcat", "token2"}});
+  EXPECT_THAT(
+      sessionCredentials(connector.get(), session.get()),
+      UnorderedElementsAre(Pair("cat", "token1"), Pair("dcat", "token2")));
+}
+
+} // namespace
+} // namespace facebook::velox::connector::hive::iceberg


### PR DESCRIPTION
Summary:
Makes the per-query delegated credential (presto_python_udf_tokens, e.g. a Manifold
CAT) reach the Iceberg data-file write so ManifoldFileSystem authorizes the write as
the caller instead of the worker service identity.

Root cause (why prior attempts failed): the write path builds the file sink from the
connector's BUILD-TIME HiveConfig -- HiveDataSink::createHiveFileSink sets
FileSink::Options.connectorProperties = hiveConfig_->config() and never reads
ConnectorQueryCtx::sessionProperties(), which is where the per-query CAT is delivered
(toConnectorConfigs folds extraCredentials into connectorSessionProperties, no allowlist).

Fix: in IcebergConnector::createDataSink, fold the CAT from
connectorQueryCtx->sessionProperties() into a per-query copy of the HiveConfig handed to
the sinks (kData / kDeletionVector / kMerge). That merged config flows unchanged through
createHiveFileSink -> connectorProperties -> createManifoldFileSink -> getFileSystem ->
ManifoldFileSystem::getCatToken() -> openFileForWrite. No-op when no token is present, so
non-delegated and non-manifold writes are unaffected. A LOG(INFO) records whether the token
is present in session properties to confirm delivery on the worker.

Reviewed By: srsuryadev

Differential Revision: D113575418


