### PR TITLE
fix(rpc): Park instead of busy-spinning under mid-stream BATCH back-pressure (#18300)

### DIFF
--- a/velox/exec/rpc/RPCOperator.cpp
+++ b/velox/exec/rpc/RPCOperator.cpp
@@ -678,18 +678,6 @@ exec::BlockingReason RPCOperator::isBlocked(ContinueFuture* future) {
   } else {
     // BATCH mode
     if (!noMoreInput_ && !isDraining()) {
-      // TODO: back-pressure contract gap. needsInput() returns
-      // false under pending-batch back-pressure
-      // (state_->isUnderBackpressure()), but this mid-stream path polls without
-      // registering a waiter and returns kNotBlocked below even when no batch
-      // is ready -- i.e. "full but not blocked". The standard Velox contract
-      // (cf. PartitionedOutput / LocalPartition) signals fullness via
-      // isBlocked() returning a future. A driver that stops its upstream walk
-      // at a full operator (transitive back-pressure) can therefore busy-spin
-      // here until an in-flight batch completes instead of parking off-thread.
-      // Fix: when under back-pressure with no ready batch, return kWaitForRPC
-      // on the oldest pending batch (route through a promise-registering poll
-      // like tryPollBatchOrWait) rather than tryPollReady + kNotBlocked.
       auto readyBatch = state_->tryPollReady();
       if (readyBatch) {
         if (readyBatch->error.has_value()) {
@@ -697,6 +685,39 @@ exec::BlockingReason RPCOperator::isBlocked(ContinueFuture* future) {
               << "Received batch with error: " << readyBatch->error.value();
         }
         claimedBatch_ = std::move(*readyBatch);
+        return exec::BlockingReason::kNotBlocked;
+      }
+      // No ready batch. Under back-pressure (in-flight batches at the window
+      // limit, so needsInput() returns false), PARK on an in-flight batch
+      // rather than returning kNotBlocked: otherwise a driver that halts its
+      // upstream walk at this full operator (transitive back-pressure) would
+      // busy-spin here until a batch completes, monopolizing its thread and
+      // starving co-scheduled queries. When not under back-pressure we can
+      // still accept input, so report not-blocked and let the driver call
+      // needsInput()/addInput(). tryPollBatchOrWait registers a waiter that a
+      // batch completion fulfills, so this cannot hang while batches are
+      // in-flight (guaranteed by isUnderBackpressure()).
+      if (state_->isUnderBackpressure()) {
+        ContinueFuture waitFuture{ContinueFuture::makeEmpty()};
+        std::optional<RPCState::ReadyBatch> polledBatch;
+        switch (state_->tryPollBatchOrWait(&waitFuture, &polledBatch)) {
+          case RPCState::BatchPollResult::kGotBatch:
+            if (polledBatch->error.has_value()) {
+              RPC_OP_LOG(WARNING) << "Received batch with error: "
+                                  << polledBatch->error.value();
+            }
+            claimedBatch_ = std::move(*polledBatch);
+            return exec::BlockingReason::kNotBlocked;
+          case RPCState::BatchPollResult::kMustWait:
+            *future = std::move(waitFuture);
+            blockWaitStartNs_ = getCurrentTimeNano();
+            blockWaitIsBackpressure_ = false;
+            return exec::BlockingReason::kWaitForRPC;
+          case RPCState::BatchPollResult::kFinished:
+            // Not expected mid-stream (noMoreInput_ is false); fall through to
+            // not-blocked defensively.
+            break;
+        }
       }
       return exec::BlockingReason::kNotBlocked;
     }

--- a/velox/exec/rpc/RPCState.cpp
+++ b/velox/exec/rpc/RPCState.cpp
@@ -395,26 +395,73 @@ RPCState::ReadyBatch RPCState::extractReadyBatchLocked(
 RPCState::BatchPollResult RPCState::tryPollBatchOrWait(
     ContinueFuture* future,
     std::optional<ReadyBatch>* readyBatch) {
-  std::lock_guard<std::mutex> l(mutex_);
+  // Any self-wake fulfillment (Step 3 below) runs AFTER releasing mutex_:
+  // setValue() may inline-drive a continuation that reacquires the
+  // driver/operator locks, so it must never run under mutex_ -- the lock-order
+  // inversion D113951677 fixed. This mirrors addPendingBatch, which drains
+  // waiters under the lock but fulfills them outside it.
+  std::optional<ContinuePromise> selfWake;
+  {
+    std::lock_guard<std::mutex> l(mutex_);
 
-  // Step 1: Check for a ready batch (out-of-order: first ready wins).
-  for (auto it = pendingBatches_.begin(); it != pendingBatches_.end(); ++it) {
-    if (it->future.isReady()) {
-      *readyBatch = extractReadyBatchLocked(it);
-      return BatchPollResult::kGotBatch;
+    // Step 1: Check for a ready batch (out-of-order: first ready wins).
+    for (auto it = pendingBatches_.begin(); it != pendingBatches_.end(); ++it) {
+      if (it->future.isReady()) {
+        *readyBatch = extractReadyBatchLocked(it);
+        return BatchPollResult::kGotBatch;
+      }
+    }
+
+    // Step 2: Check finish condition.
+    if (noMoreInput_ && pendingBatches_.empty()) {
+      RPC_STATE_VLOG(1) << "tryPollBatchOrWait: finish condition met";
+      return BatchPollResult::kFinished;
+    }
+
+    // Step 3: Must wait. Register a waiter that a batch completion fulfills.
+    //
+    // Guard against the completion-drain race. A batch's completion callback
+    // stamps completionTimeNs before it drains the waiter list under mutex_
+    // (see addPendingBatch), and the batch future only becomes ready after that
+    // callback returns. So there is a window -- waiters drained, callback not
+    // yet returned -- in which Step 1 above sees future.isReady() == false even
+    // though the drain has already passed. A waiter registered in that window
+    // would be orphaned: the completing batch will never fulfill it, and at an
+    // in-flight window of 1 (the last batch) no later completion would either,
+    // parking the single-consumer driver for good.
+    //
+    // completionTimeNs != 0 on any pending batch is the reliable under-lock
+    // signal that a completion is in progress: the callback stamps it before
+    // taking mutex_ to drain, so the mutex we hold synchronizes-with that drain
+    // and an already-drained completion is always visible here. When set,
+    // self-fulfill the waiter (below, outside the lock) so the caller re-polls
+    // and claims the now/soon-ready batch instead of parking off a promise no
+    // completion will wake.
+    bool completionInProgress = false;
+    for (const auto& batch : pendingBatches_) {
+      if (batch.completionTimeNs->load(std::memory_order_acquire) != 0) {
+        completionInProgress = true;
+        break;
+      }
+    }
+    RPC_STATE_VLOG(2) << "tryPollBatchOrWait: must wait"
+                      << (completionInProgress
+                              ? " (self-woken: RPC completion racing)"
+                              : "");
+    promises_.emplace_back("RPCState::tryPollBatchOrWait");
+    *future = promises_.back().getSemiFuture();
+    if (completionInProgress) {
+      // Move the waiter out and drop it from the list so a later
+      // takeWaitersLocked cannot double-fulfill it; it is fulfilled below, once
+      // the lock is released.
+      selfWake = std::move(promises_.back());
+      promises_.pop_back();
     }
   }
 
-  // Step 2: Check finish condition.
-  if (noMoreInput_ && pendingBatches_.empty()) {
-    RPC_STATE_VLOG(1) << "tryPollBatchOrWait: finish condition met";
-    return BatchPollResult::kFinished;
+  if (selfWake.has_value()) {
+    selfWake->setValue();
   }
-
-  // Step 3: Must wait.
-  RPC_STATE_VLOG(2) << "tryPollBatchOrWait: must wait";
-  promises_.emplace_back("RPCState::tryPollBatchOrWait");
-  *future = promises_.back().getSemiFuture();
   return BatchPollResult::kMustWait;
 }
 

--- a/velox/exec/rpc/tests/RPCOperatorTest.cpp
+++ b/velox/exec/rpc/tests/RPCOperatorTest.cpp
@@ -33,6 +33,13 @@
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/expression/rpc/AsyncRPCFunctionRegistry.h"
 
+#include <folly/executors/CPUThreadPoolExecutor.h>
+#include <folly/futures/Future.h>
+
+#include <chrono>
+
+#include "velox/exec/Task.h"
+
 namespace facebook::velox::exec::rpc {
 
 using namespace facebook::velox::exec::test;
@@ -523,6 +530,141 @@ TEST_F(RPCOperatorTest, batchPipelinedDispatch) {
   for (vector_size_t i = 0; i < result->size(); ++i) {
     EXPECT_FALSE(results->isNullAt(i));
   }
+}
+
+namespace {
+
+// BATCH RPC function whose flushBatch completes after a fixed latency on a
+// SEPARATE executor (mirroring a real transport). Lets a test create sustained
+// mid-stream BATCH back-pressure with in-flight batches to wait on.
+class SlowBatchRPCFunction : public AsyncRPCFunction {
+ public:
+  SlowBatchRPCFunction(
+      std::chrono::milliseconds latency,
+      std::shared_ptr<folly::CPUThreadPoolExecutor> executor)
+      : latency_(latency), executor_(std::move(executor)) {}
+
+  void initialize(
+      const core::QueryConfig&,
+      const std::vector<TypePtr>&,
+      const std::vector<VectorPtr>&) override {}
+
+  std::string name() const override {
+    return "slow_batch_rpc";
+  }
+
+  TypePtr resultType() const override {
+    return VARCHAR();
+  }
+
+  std::vector<std::pair<vector_size_t, folly::SemiFuture<RPCResponse>>>
+  dispatchPerRow(const SelectivityVector&, const std::vector<VectorPtr>&)
+      override {
+    VELOX_UNSUPPORTED("slow_batch_rpc is batch-only");
+  }
+
+  std::vector<vector_size_t> accumulateBatch(
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& /*args*/) override {
+    std::vector<vector_size_t> indices;
+    rows.applyToSelected([&](vector_size_t row) {
+      indices.push_back(row);
+      ++pending_;
+    });
+    return indices;
+  }
+
+  folly::SemiFuture<std::vector<RPCResponse>> flushBatch(
+      int32_t maxRows) override {
+    const int32_t n =
+        maxRows > 0 ? std::min<int32_t>(maxRows, pending_) : pending_;
+    pending_ -= n;
+    std::vector<RPCResponse> responses;
+    responses.reserve(n);
+    for (int32_t i = 0; i < n; ++i) {
+      RPCResponse response;
+      response.rowId = i;
+      response.result = "ok";
+      responses.push_back(std::move(response));
+    }
+    // Complete after `latency_` on the transport executor (NOT the driver
+    // thread), so the operator has a genuinely in-flight batch to park on. Use
+    // a futures-based delay rather than a blocking sleep so no executor thread
+    // is parked for the latency.
+    return folly::futures::sleep(latency_)
+        .via(executor_.get())
+        .thenValue([responses = std::move(responses)](auto&&) mutable {
+          return std::move(responses);
+        })
+        .semi();
+  }
+
+  int32_t pendingBatchSize() const override {
+    return pending_;
+  }
+
+ private:
+  const std::chrono::milliseconds latency_;
+  std::shared_ptr<folly::CPUThreadPoolExecutor> executor_;
+  int32_t pending_{0};
+};
+
+} // namespace
+
+// Regression proof for the BATCH mid-stream back-pressure yield.
+//
+// Before the fix, RPCOperator::isBlocked returned kNotBlocked while a batch was
+// in flight under mid-stream back-pressure, so the driver busy-spun on its
+// thread (never reporting itself blocked) until the batch completed. After the
+// fix it parks (kWaitForRPC) on an in-flight batch, so the driver's
+// blockedWallNanos reflects the batch waits.
+//
+// The plan feeds many single-row Values vectors (input keeps arriving, so
+// noMoreInput_ stays false) into a BATCH RPCNode with dispatchBatchSize=1 and a
+// slow (200ms) batch. With the BATCH window of 2 this produces repeated
+// mid-stream back-pressure. We assert the RPC operator's blockedWallNanos is
+// several multiples of the batch latency (parked). On the pre-fix code it is at
+// most ~one latency (the end-of-input wait only), which fails this assertion.
+TEST_F(RPCOperatorTest, batchMidStreamBackpressureParksNotSpins) {
+  constexpr std::chrono::milliseconds kLatency{200};
+  auto rpcExecutor = std::make_shared<folly::CPUThreadPoolExecutor>(4);
+  AsyncRPCFunctionRegistry::registerFunction(
+      "slow_batch_rpc", [kLatency, rpcExecutor]() {
+        return std::make_shared<SlowBatchRPCFunction>(kLatency, rpcExecutor);
+      });
+
+  constexpr int kRows = 8;
+  std::vector<RowVectorPtr> inputs;
+  inputs.reserve(kRows);
+  for (int i = 0; i < kRows; ++i) {
+    inputs.push_back(makeRowVector(
+        {"prompt"}, {makeFlatVector<StringView>({StringView("hi")})}));
+  }
+
+  auto plan = makeBatchRPCNode(
+      PlanBuilder().values(inputs).planNode(),
+      {"prompt"},
+      "slow_batch_rpc",
+      /*dispatchBatchSize=*/1);
+
+  std::shared_ptr<exec::Task> task;
+  auto result = AssertQueryBuilder(plan).copyResults(pool(), task);
+  ASSERT_EQ(result->size(), kRows);
+
+  uint64_t blockedNs = 0;
+  for (const auto& pipeline : task->taskStats().pipelineStats) {
+    for (const auto& op : pipeline.operatorStats) {
+      if (op.operatorType == "RPC") {
+        blockedNs += op.blockedWallNanos;
+      }
+    }
+  }
+
+  const uint64_t latencyNs =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(kLatency).count();
+  EXPECT_GT(blockedNs, 2 * latencyNs)
+      << "RPC operator did not park under mid-stream BATCH back-pressure: "
+      << "blockedWallNanos=" << blockedNs << " latencyNs=" << latencyNs;
 }
 
 /// PER_ROW congestion path. On the function's overload verdict

--- a/velox/exec/rpc/tests/RPCStateTest.cpp
+++ b/velox/exec/rpc/tests/RPCStateTest.cpp
@@ -46,6 +46,7 @@
 #include <folly/futures/Promise.h>
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <chrono>
 #include <functional>
 #include <set>
@@ -738,6 +739,68 @@ TEST_F(RPCStateTest, batchRttExcludesPollDelay) {
       std::chrono::duration_cast<std::chrono::nanoseconds>(
           std::chrono::milliseconds(kPollDelayMs))
           .count());
+}
+
+TEST_F(RPCStateTest, batchWaiterNotOrphanedByCompletionDrainRace) {
+  // Regression guard for the completion-drain race in tryPollBatchOrWait. The
+  // batch completion callback stamps completionTimeNs and drains the waiter
+  // list under mutex_ BEFORE the batch future becomes ready (the future readies
+  // only when the callback returns). A poller that registers a waiter in that
+  // window
+  // -- drain already passed, future not yet ready -- would be orphaned, and at
+  // a window of 1 (the completing batch is the last in flight) the
+  // single-consumer driver would park forever. Race a completing batch against
+  // a poller many times and assert every park is fulfilled promptly (self-woken
+  // via the completionTimeNs guard), never orphaned.
+  constexpr int kIterations = 500;
+  for (int iter = 0; iter < kIterations; ++iter) {
+    auto state = std::make_shared<RPCState>();
+    state->setStreamingMode(RPCStreamingMode::kBatch);
+    state->setMaxWindow(1); // the completing batch is the last in flight
+
+    auto [promise, future] =
+        folly::makePromiseContract<std::vector<RPCResponse>>();
+    state->addPendingBatch(state, std::move(future), {});
+
+    // Complete on another thread so its inline drain races the poller below;
+    // the atomic gate aligns the two so the interleaving is exercised.
+    std::atomic<bool> go{false};
+    std::thread completer([&go, p = std::move(promise)]() mutable {
+      while (!go.load(std::memory_order_acquire)) {
+      }
+      p.setValue(std::vector<RPCResponse>{});
+    });
+
+    go.store(true, std::memory_order_release);
+    bool claimed = false;
+    while (!claimed) {
+      ContinueFuture waitFuture{ContinueFuture::makeEmpty()};
+      std::optional<RPCState::ReadyBatch> readyBatch;
+      switch (state->tryPollBatchOrWait(&waitFuture, &readyBatch)) {
+        case RPCState::BatchPollResult::kGotBatch:
+          claimed = true;
+          break;
+        case RPCState::BatchPollResult::kMustWait: {
+          // A legitimately-registered or self-woken waiter is fulfilled
+          // promptly; an orphaned one never is. Bound the wait so a regression
+          // fails cleanly instead of hanging the test.
+          auto f = std::move(waitFuture);
+          auto deadline =
+              std::chrono::steady_clock::now() + std::chrono::seconds(10);
+          while (!f.isReady()) {
+            ASSERT_LT(std::chrono::steady_clock::now(), deadline)
+                << "waiter orphaned by completion-drain race at iter " << iter;
+            /* sleep override */
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+          }
+          break;
+        }
+        case RPCState::BatchPollResult::kFinished:
+          FAIL() << "unexpected kFinished while a batch is in flight";
+      }
+    }
+    completer.join();
+  }
 }
 
 } // namespace


### PR DESCRIPTION
Summary:

RPCOperator::isBlocked() in BATCH mode returned kNotBlocked while a batch was in
flight under mid-stream back-pressure (needsInput() already returns false via
state_->isUnderBackpressure()). Returning no blocking future means a driver that
halts its upstream walk at this full operator busy-spins on its thread
(getOutput -> nullptr, isBlocked -> kNotBlocked) until the in-flight batch
completes, monopolizing a driver-pool thread and starving co-scheduled queries
for the batch's duration.

Fix: when under back-pressure with no ready batch, park on an in-flight batch by
routing through tryPollBatchOrWait (which registers a waiter fulfilled by batch
completion) and returning kWaitForRPC -- mirroring the end-of-input path. When
not under back-pressure, keep returning kNotBlocked so the driver can still
accept more input. PER_ROW already parked correctly and is unchanged.

Completion-drain race (found in review by aakashef): the batch completion
callback stamps completionTimeNs and drains the waiter list under mutex_ BEFORE
the batch future becomes ready (it readies only when the callback returns). A
poller acquiring mutex_ in that window sees future-not-ready and would register a
waiter the just-completed batch never fulfills; at an in-flight window of 1
(default rpc.congestion.min_window) that last-batch waiter would park the
single-consumer driver forever. tryPollBatchOrWait now guards waiter
registration on completionTimeNs (stamped before the drain, so guaranteed
visible under the mutex we hold): when a completion is in progress it
self-fulfills the waiter so the caller re-polls and claims the ready batch
instead of parking. The guard lives in tryPollBatchOrWait, so it also closes the
pre-existing end-of-input exposure aakashda noted.

Why this is correct (no lost wakeup): a parked waiter is either self-woken when a
completion is racing (completionTimeNs already set under our lock), or -- since
its registration then happens-before any drain that could have skipped it -- is
fulfilled by that batch's completion. Each waiter is fulfilled exactly once
(self-wake pops it from the list before setValue, so no drain double-fulfills
it), and setValue never runs under mutex_, preserving the D113951677 lock-order
invariant. The park is taken only under isUnderBackpressure(), i.e. with >= 1
in-flight batch, so a completer always exists to deliver the wakeup. A full proof
(no-lost-wakeup / fulfilled-once / deadlock-free) is in the review thread.

Depends on D113951677, which fixes the RPCState waiter-wakeup lock-order
inversion (TSAN M0->M1->M0) that this diff's regression test surfaces: parking
here relies on an in-flight batch completion fulfilling the waiter promise, and
D113951677 moves that fulfillment outside RPCState::mutex_ so the wakeup cannot
deadlock.

Reviewed By: abhinavmuk04, sebastianopeluso, zacw7

Differential Revision: D113862194


