### PR TITLE
fix: Forward an optional post-processor through IcebergColumnHandle (#18301)

### DIFF
--- a/velox/connectors/hive/iceberg/IcebergColumnHandle.cpp
+++ b/velox/connectors/hive/iceberg/IcebergColumnHandle.cpp
@@ -33,15 +33,17 @@ IcebergColumnHandle::IcebergColumnHandle(
     parquet::ParquetFieldId icebergField,
     std::vector<common::Subfield> requiredSubfields,
     std::optional<std::string> initialDefaultValue,
-    IcebergFieldMetadata icebergMetadata)
+    IcebergFieldMetadata icebergMetadata,
+    std::function<void(VectorPtr&)> postProcessor)
     : HiveColumnHandle(
           name,
           columnType,
           dataType,
           dataType,
           std::move(requiredSubfields),
-          ColumnParseParameters{ColumnParseParameters::
-                                    PartitionDateValueFormat::kDaysSinceEpoch}),
+          ColumnParseParameters{
+              ColumnParseParameters::PartitionDateValueFormat::kDaysSinceEpoch},
+          std::move(postProcessor)),
       field_(std::move(icebergField)),
       initialDefaultValue_(std::move(initialDefaultValue)),
       icebergMetadata_(std::move(icebergMetadata)) {}

--- a/velox/connectors/hive/iceberg/IcebergColumnHandle.h
+++ b/velox/connectors/hive/iceberg/IcebergColumnHandle.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <functional>
 #include <optional>
 #include <string>
 #include <vector>
@@ -36,7 +37,8 @@ class IcebergColumnHandle : public HiveColumnHandle {
       parquet::ParquetFieldId icebergField,
       std::vector<common::Subfield> requiredSubfields = {},
       std::optional<std::string> initialDefaultValue = std::nullopt,
-      IcebergFieldMetadata icebergMetadata = {});
+      IcebergFieldMetadata icebergMetadata = {},
+      std::function<void(VectorPtr&)> postProcessor = {});
 
   const parquet::ParquetFieldId& field() const;
 

--- a/velox/connectors/hive/iceberg/tests/IcebergConnectorTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergConnectorTest.cpp
@@ -18,7 +18,9 @@
 #include <gtest/gtest.h>
 #include "velox/connectors/ConnectorRegistry.h"
 #include "velox/connectors/hive/HiveConfig.h"
+#include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
 #include "velox/connectors/hive/iceberg/tests/IcebergTestBase.h"
+#include "velox/type/Type.h"
 
 namespace facebook::velox::connector::hive::iceberg {
 
@@ -65,6 +67,38 @@ TEST_F(IcebergConnectorTest, connectorProperties) {
   ASSERT_TRUE(icebergConnector->canAddDynamicFilter());
   ASSERT_TRUE(icebergConnector->supportsSplitPreload());
   ASSERT_NE(icebergConnector->ioExecutor(), nullptr);
+}
+
+TEST_F(IcebergConnectorTest, columnHandleForwardsPostProcessor) {
+  auto called = std::make_shared<bool>(false);
+  std::function<void(VectorPtr&)> postProcessor = [called](VectorPtr&) {
+    *called = true;
+  };
+
+  IcebergColumnHandle handle(
+      "c0",
+      HiveColumnHandle::ColumnType::kRegular,
+      BIGINT(),
+      parquet::ParquetFieldId{1, {}},
+      /*requiredSubfields=*/{},
+      /*initialDefaultValue=*/std::nullopt,
+      /*icebergMetadata=*/{},
+      postProcessor);
+
+  ASSERT_TRUE(handle.postProcessor());
+  VectorPtr unused;
+  handle.postProcessor()(unused);
+  EXPECT_TRUE(*called);
+}
+
+TEST_F(IcebergConnectorTest, columnHandleDefaultsToNoPostProcessor) {
+  IcebergColumnHandle handle(
+      "c0",
+      HiveColumnHandle::ColumnType::kRegular,
+      BIGINT(),
+      parquet::ParquetFieldId{1, {}});
+
+  EXPECT_FALSE(handle.postProcessor());
 }
 
 } // namespace


### PR DESCRIPTION
Summary:

`IcebergColumnHandle` delegated to the 7-argument `HiveColumnHandle`
constructor and stopped before the trailing `postProcessor` slot, so any
post-processor a caller wanted to attach was silently dropped. The plain
`HiveColumnHandle` path (`makeColumnHandle`) already forwards one, e.g. the
null-padding post-processor used for feature-projected map-as-struct columns.

Add an optional `std::function<void(VectorPtr&)> postProcessor` parameter to
`IcebergColumnHandle` and forward it to the `HiveColumnHandle` base. The
parameter defaults to empty, so existing callers are unaffected. This lets a
caller attach a post-processor while still carrying Iceberg field-id metadata,
matching the Hive path.

Reviewed By: raymondlin1

Differential Revision: D113856616


