### PR TITLE
feat: Match MapType::equivalent on TypeKind (#18304)

### DIFF
--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -839,7 +839,7 @@ bool MapType::equivalent(const Type& other) const {
   if (&other == this) {
     return true;
   }
-  if (!Type::hasSameTypeId(other)) {
+  if (!other.isMap()) {
     return false;
   }
   auto& otherMap = other.asMap();


### PR DESCRIPTION
Summary:

MapType::equivalent() gated on hasSameTypeId(), i.e. an exact typeid match.
That made equivalence asymmetric for logical MAP subtypes: given a plain
MapType and a MapType subclass with matching key/value types, the subclass's
own equivalent() returned true, but the plain MapType's equivalent() returned
false. Match on TypeKind (other.isMap()) instead so equivalent() is symmetric
across MAP subtypes. MapType::hash() is already TypeKind-based, so this stays
consistent with the equals/hash contract.

Differential Revision: D113927757


