### PR TITLE
fix: Align fixed-width UnsafeRow array sizes (#18305)

### DIFF
--- a/velox/row/UnsafeRowFast.cpp
+++ b/velox/row/UnsafeRowFast.cpp
@@ -311,7 +311,7 @@ int32_t UnsafeRowFast::arrayRowSize(
 
   int32_t rowSize = kFieldWidth + nullBytes;
   if (fixedWidth) {
-    return rowSize + size * elements.valueBytes();
+    return alignBytes(rowSize + size * elements.valueBytes());
   }
 
   rowSize += size * kFieldWidth;
@@ -343,7 +343,7 @@ int32_t UnsafeRowFast::serializeAsArray(
 
   auto childSize = fixedWidth ? elements.valueBytes() : kFieldWidth;
 
-  int64_t variableWidthOffset = fixedWidthOffset + size * childSize;
+  int32_t variableWidthOffset = fixedWidthOffset + size * childSize;
 
   if (elements.supportsBulkCopy_) {
     if (elements.decoded_.mayHaveNulls()) {
@@ -354,7 +354,7 @@ int32_t UnsafeRowFast::serializeAsArray(
       }
     }
     elements.serializeFixedWidth(offset, size, buffer + fixedWidthOffset);
-    return variableWidthOffset;
+    return alignBytes(variableWidthOffset);
   }
 
   for (auto i = 0; i < size; ++i) {
@@ -369,7 +369,8 @@ int32_t UnsafeRowFast::serializeAsArray(
             offset + i, buffer + variableWidthOffset);
 
         // Write size and offset.
-        uint64_t sizeAndOffset = variableWidthOffset << 32 | serializedBytes;
+        uint64_t sizeAndOffset =
+            static_cast<uint64_t>(variableWidthOffset) << 32 | serializedBytes;
         reinterpret_cast<uint64_t*>(buffer + fixedWidthOffset)[i] =
             sizeAndOffset;
 
@@ -377,7 +378,7 @@ int32_t UnsafeRowFast::serializeAsArray(
       }
     }
   }
-  return variableWidthOffset;
+  return alignBytes(variableWidthOffset);
 }
 
 int32_t UnsafeRowFast::rowRowSize(vector_size_t index) const {

--- a/velox/row/tests/UnsafeRowTest.cpp
+++ b/velox/row/tests/UnsafeRowTest.cpp
@@ -16,6 +16,8 @@
 
 #include <gtest/gtest.h>
 
+#include <cstring>
+
 #include <folly/Random.h>
 #include <folly/init/Init.h>
 
@@ -27,6 +29,13 @@ namespace facebook::velox::row {
 namespace {
 
 using namespace facebook::velox::test;
+
+template <typename T>
+T readValue(const char* data) {
+  T value;
+  std::memcpy(&value, data, sizeof(T));
+  return value;
+}
 
 class UnsafeRowTest : public ::testing::Test, public VectorTestBase {
  public:
@@ -213,6 +222,88 @@ TEST_F(UnsafeRowTest, nestedMaps) {
   auto keys = makeFlatVector<int32_t>({1, 2, 3, 4, 5, 6});
   auto values = makeMapVector({0, 2, 2, 3, 4, 5}, keys, innerMaps, {1});
   auto data = makeRowVector({values});
+  testRoundTrip(data);
+}
+
+TEST_F(UnsafeRowTest, mapWithFixedWidthArraysUsesAlignedRowSize) {
+  auto keys = makeFlatVector<int32_t>({1});
+  auto values = makeFlatVector<int32_t>({10});
+  auto map = makeMapVector({0}, keys, values);
+  auto data = makeRowVector({map});
+
+  UnsafeRowFast row(data);
+  ASSERT_EQ(row.rowSize(0), 72);
+
+  std::vector<char> buffer(row.rowSize(0), 0);
+  EXPECT_EQ(row.serialize(0, buffer.data()), 72);
+
+  const auto fieldOffsetAndSize = readValue<uint64_t>(buffer.data() + 8);
+  const auto mapSize = static_cast<uint32_t>(fieldOffsetAndSize);
+  EXPECT_EQ(mapSize, 56);
+
+  testRoundTrip(data);
+}
+
+TEST_F(UnsafeRowTest, mapWithFixedWidthKeysPadsKeyArraySize) {
+  auto keys = makeFlatVector<int32_t>({1});
+  auto values = makeArrayVector<int64_t>({{10, 20}});
+  auto map = makeMapVector({0}, keys, values);
+  auto data = makeRowVector({map});
+
+  UnsafeRowFast row(data);
+  std::vector<char> buffer(row.rowSize(0), 0);
+  ASSERT_EQ(row.serialize(0, buffer.data()), row.rowSize(0));
+
+  const auto fieldOffsetAndSize = readValue<uint64_t>(buffer.data() + 8);
+  const auto mapOffset = static_cast<uint32_t>(fieldOffsetAndSize >> 32);
+  const auto mapSize = static_cast<uint32_t>(fieldOffsetAndSize);
+  ASSERT_EQ(mapOffset, 16);
+
+  const char* mapPayload = buffer.data() + mapOffset;
+  const auto keyArraySize = readValue<int64_t>(mapPayload);
+  EXPECT_EQ(keyArraySize, 24);
+  EXPECT_EQ(keyArraySize % 8, 0);
+  EXPECT_LE(sizeof(int64_t) + keyArraySize, mapSize);
+
+  const char* keyArray = mapPayload + sizeof(int64_t);
+  EXPECT_EQ(readValue<int64_t>(keyArray), 1);
+  EXPECT_EQ(readValue<int32_t>(keyArray + 16), 1);
+  EXPECT_EQ(readValue<int32_t>(keyArray + 20), 0);
+
+  const char* valueArray = mapPayload + sizeof(int64_t) + keyArraySize;
+  EXPECT_EQ(readValue<int64_t>(valueArray), 1);
+
+  testRoundTrip(data);
+}
+
+TEST_F(UnsafeRowTest, mapWithNonBulkFixedWidthKeysPadsKeyArraySize) {
+  auto keys = makeFlatVector<bool>({true});
+  auto values = makeArrayVector<int64_t>({{10, 20}});
+  auto map = makeMapVector({0}, keys, values);
+  auto data = makeRowVector({map});
+
+  UnsafeRowFast row(data);
+  std::vector<char> buffer(row.rowSize(0), 0);
+  ASSERT_EQ(row.serialize(0, buffer.data()), row.rowSize(0));
+
+  const auto fieldOffsetAndSize = readValue<uint64_t>(buffer.data() + 8);
+  const auto mapOffset = static_cast<uint32_t>(fieldOffsetAndSize >> 32);
+  const auto mapSize = static_cast<uint32_t>(fieldOffsetAndSize);
+  ASSERT_EQ(mapOffset, 16);
+
+  const char* mapPayload = buffer.data() + mapOffset;
+  const auto keyArraySize = readValue<int64_t>(mapPayload);
+  EXPECT_EQ(keyArraySize, 24);
+  EXPECT_EQ(keyArraySize % 8, 0);
+  EXPECT_LE(sizeof(int64_t) + keyArraySize, mapSize);
+
+  const char* keyArray = mapPayload + sizeof(int64_t);
+  EXPECT_EQ(readValue<int64_t>(keyArray), 1);
+  EXPECT_TRUE(readValue<bool>(keyArray + 16));
+
+  const char* valueArray = mapPayload + sizeof(int64_t) + keyArraySize;
+  EXPECT_EQ(readValue<int64_t>(valueArray), 1);
+
   testRoundTrip(data);
 }
 


### PR DESCRIPTION
Summary:

UnsafeRowFast converts Velox vectors into Spark's binary UnsafeRow format. In this format, each serialized array must occupy a multiple of eight bytes. UnsafeRowFast wrote the fixed-width array elements correctly, but returned the raw, unpadded array size. As a result, the data following such an array could begin at an unaligned offset.

UnsafeMapData makes the problem easy to see. A serialized map has this layout:

```
+0                      8-byte key-array size
+8                      key array
+8 + key-array size     value array
```

The map does not store a separate offset for the value array. Its location is calculated from the key-array size in the map header.

For a map with one INTEGER key, the key array contains:

```
8 bytes  array header
8 bytes  null bitset
4 bytes  INTEGER value
--------
20 bytes raw size
24 bytes after 8-byte alignment
```

This produced the following layouts, with offsets relative to the beginning of the map:

```
Previous layout:
+0    key-array size = 20
+8    key array (20 bytes)
+28   value array                 <- not 8-byte aligned

Corrected layout:
+0    key-array size = 24
+8    key array (20 bytes + 4 bytes of padding)
+32   value array                 <- 8-byte aligned
```

Align the calculated and serialized sizes of fixed-width arrays in both the bulk-copy and element-by-element serialization paths. Arrays that were already aligned keep the same size; only arrays with an unaligned raw size gain the required padding. Add regression coverage for row-size calculation, bulk-copy INTEGER keys, and non-bulk BOOLEAN keys.

Differential Revision: D111494496


