### PR TITLE
perf(memory): Use std::memcpy in BufferInputStream::readBytes

### DIFF
--- a/velox/common/memory/ByteStream.cpp
+++ b/velox/common/memory/ByteStream.cpp
@@ -17,6 +17,7 @@
 #include "velox/common/memory/ByteStream.h"
 
 #include <algorithm>
+#include <cstring>
 
 namespace facebook::velox {
 
@@ -138,8 +139,7 @@ void BufferInputStream::readBytes(uint8_t* bytes, int32_t size) {
   for (;;) {
     const int32_t availableBytes = current_->size - current_->position;
     const int32_t readBytes = std::min(availableBytes, size);
-    simd::memcpy(
-        bytes + offset, current_->buffer + current_->position, readBytes);
+    ::memcpy(bytes + offset, current_->buffer + current_->position, readBytes);
     offset += readBytes;
     size -= readBytes;
     current_->position += readBytes;


### PR DESCRIPTION
  ## Summary

  `BufferInputStream::readBytes` is the choke point for Presto page deserialization
  bulk copies (column values, string blobs, dictionary indices). It used Velox's
  hand-rolled `simd::memcpy`, which fully unrolls only for a **compile-time-constant**
  size. Here the size is a runtime `min(availableBytes, size)`, so it degrades to a
  32-byte-per-iteration SIMD loop plus an 8/4/2/1 scalar tail whose loop/branch
  control is a large fraction of the cost.

  Replace it with the C library `memcpy` (adds `<cstring>`). For a runtime size,
  glibc performs the same movement via ERMS / wider unrolled copies, byte-for-byte
  identical (`simd::memcpy` copies exactly N bytes with no overread; src and dst are
  non-overlapping). Only the read-path copy changes; the write-side `simd::memcpy`
  is untouched.

  Codegen before/after (runtime size = branchy SIMD loop vs. a single tail-call to
  the tuned libc memcpy; a constant size unrolls either way):
  https://godbolt.org/z/Kb1MhPsTv

  ## Benchmarks

  A microbench reproducing the `readBytes` copy loop verbatim (8 B–64 KB, single-
  and multi-range), verifying byte-identical output first:

  - **x86** (Xeon Gold 6138, Skylake-SP): `std::memcpy` 1.7x @1KB, 1.9x @4KB,
    2.9x @16KB; ~parity at >=64KB; small copies <=128 B ~1.3–1.8x slower.
  - **aarch64** (Neoverse-V2): 2.5–2.9x for 1KB–64KB; <=128 B ~8–11% slower.

  Crossover at 256 B on both. Deserialized column payloads are KB-scale, i.e. the
  win region.

Differential Revision: D113830053
