### PR TITLE
fix(exec): Compile OutputTransportEntry under Clang 15 (#18307)

### DIFF
--- a/velox/exec/OutputTransportRegistry.h
+++ b/velox/exec/OutputTransportRegistry.h
@@ -39,13 +39,19 @@ namespace facebook::velox::exec {
 /// its matching output operator, keyed by transport id. Registering the two
 /// together ensures a transport's operator and manager cannot diverge. Build
 /// entries with make(), which binds the operator to this manager and rejects
-/// null halves; direct aggregate initialization is for tests passing real
-/// values.
+/// null halves; direct construction is for tests passing real values.
 struct OutputTransportEntry {
   std::shared_ptr<OutputBufferManager> manager;
 
   /// Builds this transport's output operator, binding 'manager'.
   PartitionedOutputFactory makeOutputOperator;
+
+  /// Constructs an entry from a manager and the operator builder bound to it.
+  OutputTransportEntry(
+      std::shared_ptr<OutputBufferManager> manager,
+      PartitionedOutputFactory makeOutputOperator)
+      : manager(std::move(manager)),
+        makeOutputOperator(std::move(makeOutputOperator)) {}
 
   /// Preferred way to build an entry: pairs 'manager' with an operator builder
   /// that receives that same manager, so the operator can't be wired to a


### PR DESCRIPTION
Summary:

The `Ubuntu debug with bundled dependencies` build (Clang 15) failed to compile with:

    error: no matching constructor for initialization of 'OutputTransportEntry'

`OutputTransportEntry` is an aggregate built through `std::make_shared<OutputTransportEntry>(manager, builder)`. `make_shared` constructs the object from a parenthesized argument list, which for an aggregate requires parenthesized aggregate initialization (C++20 P0960). Clang 15 does not implement P0960 (added in Clang 16; GCC has had it since 10), so it finds no viable constructor. This change makes it compatible by adding an explicit two-argument constructor so `make_shared` binds to it on every toolchain.

Reviewed By: apurva-meta

Differential Revision: D113934413


