### PR TITLE
Fix lock-order-inversion in RPCState waiter wakeup (#18310)

### DIFF
--- a/velox/exec/rpc/RPCState.cpp
+++ b/velox/exec/rpc/RPCState.cpp
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <utility>
 
 #include <folly/executors/InlineExecutor.h>
 
@@ -41,6 +42,15 @@ int64_t steadyNowNs() {
   return std::chrono::duration_cast<std::chrono::nanoseconds>(
              std::chrono::steady_clock::now().time_since_epoch())
       .count();
+}
+
+// Wake blocked drivers by fulfilling their promises. Must run with no RPCState
+// lock held: setValue() may synchronously drive an inline continuation that
+// reacquires the driver/operator locks (see RPCState::takeWaitersLocked).
+void fulfillWaiters(std::vector<ContinuePromise>& waiters) {
+  for (auto& promise : waiters) {
+    promise.setValue();
+  }
 }
 } // namespace
 
@@ -191,26 +201,30 @@ void RPCState::completeRow(
     RowLocation location,
     RPCResponse response,
     int64_t rttNs) {
-  std::lock_guard<std::mutex> l(mutex_);
-  readyRows_.push_back(
-      ReadyRow{
-          .rowId = rowId,
-          .location = location,
-          .response = std::move(response),
-          .rttNs = rttNs});
-  inFlight_--;
+  std::vector<ContinuePromise> waiters;
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    readyRows_.push_back(
+        ReadyRow{
+            .rowId = rowId,
+            .location = location,
+            .response = std::move(response),
+            .rttNs = rttNs});
+    inFlight_--;
 
-  if (rttNs > 0) {
-    rttMinNs_ = std::min(rttMinNs_, rttNs);
-    rttMaxNs_ = std::max(rttMaxNs_, rttNs);
-    ++numRttSamples_;
+    if (rttNs > 0) {
+      rttMinNs_ = std::min(rttMinNs_, rttNs);
+      rttMaxNs_ = std::max(rttMaxNs_, rttNs);
+      ++numRttSamples_;
+    }
+
+    RPC_STATE_VLOG(2) << "Row completed: rowId=" << rowId
+                      << ", readyRows=" << readyRows_.size()
+                      << ", inFlight=" << inFlight_;
+
+    waiters = takeWaitersLocked();
   }
-
-  RPC_STATE_VLOG(2) << "Row completed: rowId=" << rowId
-                    << ", readyRows=" << readyRows_.size()
-                    << ", inFlight=" << inFlight_;
-
-  notifyWaitersLocked();
+  fulfillWaiters(waiters);
 }
 
 RPCState::ClaimResult RPCState::tryClaimOrWait(
@@ -299,20 +313,24 @@ void RPCState::addPendingBatch(
             completionTimeNs->store(steadyNowNs(), std::memory_order_relaxed);
             RPC_STATE_VLOG(1)
                 << "Batch completed with " << responses.size() << " responses";
+            std::vector<ContinuePromise> waiters;
             {
               std::lock_guard<std::mutex> l(state->mutex_);
-              state->notifyWaitersLocked();
+              waiters = state->takeWaitersLocked();
             }
+            fulfillWaiters(waiters);
             return responses;
           })
           .thenError([state = selfPtr,
                       completionTimeNs](folly::exception_wrapper ew) {
             completionTimeNs->store(steadyNowNs(), std::memory_order_relaxed);
             RPC_STATE_LOG(ERROR) << "Batch failed: " << ew.what();
+            std::vector<ContinuePromise> waiters;
             {
               std::lock_guard<std::mutex> l(state->mutex_);
-              state->notifyWaitersLocked();
+              waiters = state->takeWaitersLocked();
             }
+            fulfillWaiters(waiters);
             return folly::makeSemiFuture<std::vector<RPCResponse>>(
                 std::move(ew));
           })
@@ -413,12 +431,16 @@ std::optional<RPCState::ReadyBatch> RPCState::tryPollReady() {
 // ===== Common =====
 
 void RPCState::setNoMoreInput() {
-  std::lock_guard<std::mutex> l(mutex_);
-  noMoreInput_ = true;
-  RPC_STATE_VLOG(1) << "setNoMoreInput: inFlight=" << inFlight_
-                    << ", pendingBatches=" << pendingBatches_.size()
-                    << ", readyRows=" << readyRows_.size();
-  notifyWaitersLocked();
+  std::vector<ContinuePromise> waiters;
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    noMoreInput_ = true;
+    RPC_STATE_VLOG(1) << "setNoMoreInput: inFlight=" << inFlight_
+                      << ", pendingBatches=" << pendingBatches_.size()
+                      << ", readyRows=" << readyRows_.size();
+    waiters = takeWaitersLocked();
+  }
+  fulfillWaiters(waiters);
 }
 
 bool RPCState::isFinished() {
@@ -473,13 +495,10 @@ void RPCState::onUnitSamples(const std::vector<int64_t>& rttNsList) {
   }
 }
 
-void RPCState::notifyWaitersLocked() {
-  // Fulfill all promises to wake up blocked drivers.
-  // Called while mutex_ is held.
-  for (auto& promise : promises_) {
-    promise.setValue();
-  }
-  promises_.clear();
+std::vector<ContinuePromise> RPCState::takeWaitersLocked() {
+  // Hand the waiter promises back to the caller to fulfill after releasing
+  // mutex_. See the header for why setValue() must not run under mutex_.
+  return std::exchange(promises_, {});
 }
 
 RPCState::OperatorSnapshot RPCState::operatorSnapshot() const {

--- a/velox/exec/rpc/RPCState.h
+++ b/velox/exec/rpc/RPCState.h
@@ -59,7 +59,8 @@ struct InputBatchRef {
 ///
 /// Thread safety: All public methods are thread-safe. The mutex_ protects
 /// all mutable state. Completion callbacks from the RPC client's executor
-/// threads call notifyWaitersLocked() to wake the driver thread.
+/// threads take the waiter promises under the lock (takeWaitersLocked) and
+/// fulfill them after releasing it to wake the driver thread.
 ///
 /// Two streaming modes:
 /// - PER_ROW: Rows are emitted as they complete individually (out-of-order).
@@ -315,8 +316,14 @@ class RPCState {
       RPCResponse response,
       int64_t rttNs);
 
-  /// Fulfill all waiting promises and clear. Called under lock.
-  void notifyWaitersLocked();
+  // Extract the pending waiter promises and clear the queue, returning them
+  // so the caller can fulfill them AFTER releasing mutex_. Must be called with
+  // mutex_ held. Promises must not be fulfilled under mutex_: setValue() runs
+  // any inline future continuation synchronously (e.g. Driver::setResume ->
+  // Operator::recordBlockingTime, which takes the Operator stats lock), which
+  // would acquire that lock under mutex_ and invert lock order against the
+  // driver thread (a potential deadlock TSAN flags).
+  [[nodiscard]] std::vector<ContinuePromise> takeWaitersLocked();
 
   /// Extract the ready batch referenced by `it`: compute its round-trip
   /// latency, move out the responses (capturing any error), erase the entry,


### PR DESCRIPTION
Summary:

RPCState::notifyWaitersLocked() fulfilled waiter promises while holding
mutex_. ContinuePromise::setValue() runs any inline future continuation
synchronously; for a blocked driver that continuation is
BlockingState::setResume -> Operator::recordBlockingTime, which acquires
the Operator's stats SharedMutex. So the completion path took the
operator stats lock while holding the RPC mutex_ (M0->M1), inverting the
normal driver order where the stats lock is held first (M1->M0). Under
load TSAN flags the cycle as a potential deadlock.

Fix: fulfill promises outside mutex_. notifyWaitersLocked() becomes
takeWaitersLocked(), which moves the promise queue out under the lock;
each of the four completion sites (PER_ROW completeRow, BATCH
success/error, setNoMoreInput) fulfills the returned promises after
releasing the lock via the fulfillWaiters() helper.

Reviewed By: zhichenxu-meta

Differential Revision: D113951677


