### PR TITLE
feat: Add Layer 2 AIMD-under-load test for RPC framework (#18311)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ of available functions [can be found here.](https://facebookincubator.github.io/
 
 Recent blog posts ([all posts](https://velox-lib.io/blog)):
 
+- [Build Once, Probe Many: Hash Table Caching in Velox](https://velox-lib.io/blog/hash-table-caching) (2026-08-03)
 - [War of the Allocators](https://velox-lib.io/blog/war-of-the-allocators) (2026-07-27)
 - [Making OpenZL Available in Nimble OSS](https://velox-lib.io/blog/openzl-in-nimble-oss) (2026-07-05)
-- [Why RIGHT SEMI JOIN Can Be Slower Than LEFT SEMI JOIN in Velox](https://velox-lib.io/blog/right-semi-join-performance) (2026-06-26)
 
 ## Community
 

--- a/velox/common/rpc/clients/MockRPCClient.cpp
+++ b/velox/common/rpc/clients/MockRPCClient.cpp
@@ -16,8 +16,11 @@
 
 #include "velox/common/rpc/clients/MockRPCClient.h"
 
+#include <fmt/format.h>
 #include <folly/futures/Future.h>
 #include <folly/futures/Promise.h>
+
+#include "velox/common/base/Exceptions.h"
 
 namespace facebook::velox::rpc {
 
@@ -27,6 +30,47 @@ namespace {
 std::mt19937& threadLocalRng() {
   thread_local std::mt19937 rng{std::random_device{}()};
   return rng;
+}
+
+// Builds an error response tagged with a typed cause, for the error-burst
+// path. Unlike MockRPCClient::generateResponse(request, /*isError=*/true),
+// which leaves errorKind at kNone, this sets errorKind so the congestion path
+// can classify the failure.
+RPCResponse makeErrorResponse(const RPCRequest& request, RPCErrorKind kind) {
+  // Every enumerator is listed explicitly (no default) so a newly added kind
+  // trips -Wswitch-enum instead of silently reusing another kind's label.
+  std::string_view label;
+  switch (kind) {
+    case RPCErrorKind::kRateLimited:
+      label = "rate-limit";
+      break;
+    case RPCErrorKind::kTimeout:
+      label = "timeout";
+      break;
+    case RPCErrorKind::kNullInput:
+      label = "null-input";
+      break;
+    case RPCErrorKind::kBackendError:
+      label = "backend";
+      break;
+    case RPCErrorKind::kEmptyResponse:
+      label = "empty-response";
+      break;
+    case RPCErrorKind::kInvalidRequest:
+      label = "invalid-request";
+      break;
+    case RPCErrorKind::kNone:
+      VELOX_UNREACHABLE(
+          "makeErrorResponse() requires a non-kNone error kind, "
+          "it is only reached on the error-burst path");
+  }
+  return RPCResponse{
+      .rowId = request.rowId,
+      .result = "",
+      .metadata = {},
+      .error =
+          fmt::format("Simulated {} error for row {}", label, request.rowId),
+      .errorKind = kind};
 }
 } // namespace
 
@@ -71,18 +115,63 @@ RPCResponse MockRPCClient::generateResponse(
       .error = std::nullopt};
 }
 
-folly::SemiFuture<RPCResponse> MockRPCClient::call(const RPCRequest& request) {
-  callCount_.fetch_add(1);
+void MockRPCClient::setErrorBurst(const ErrorBurst& burst) {
+  // Install-once, before dispatch. burstErrorKind() reads errorBurst_ without
+  // a lock, so the struct must never be written while a request could be
+  // reading it. Rejecting a second install closes the resetCallCount() path:
+  // the counter check alone would let a re-arm race with requests still in
+  // flight from the previous burst.
+  VELOX_CHECK(
+      !burstInstalled_.load(std::memory_order_acquire),
+      "setErrorBurst() may only be called once per client");
+  VELOX_CHECK_EQ(
+      callCount_.load(),
+      0,
+      "setErrorBurst() must be called before the first request is dispatched");
+  errorBurst_ = burst;
+  // Release: publishes the errorBurst_ write to any thread that subsequently
+  // observes burstInstalled_ as true through the acquire load below.
+  burstInstalled_.store(true, std::memory_order_release);
+}
 
-  // Determine if this request should fail
-  std::uniform_real_distribution<double> dist(0.0, 1.0);
-  bool shouldError = dist(threadLocalRng()) < errorRate_;
+RPCErrorKind MockRPCClient::burstErrorKind(int64_t ordinal) const {
+  // Acquire: pairs with the release store in setErrorBurst(), so the
+  // errorBurst_ fields read below are guaranteed visible on this thread.
+  // errorBurst_ is never mutated once a burst is installed, so no further
+  // synchronization is needed.
+  if (!burstInstalled_.load(std::memory_order_acquire)) {
+    return RPCErrorKind::kNone;
+  }
+  if (errorBurst_.firstCall < errorBurst_.lastCall &&
+      ordinal >= errorBurst_.firstCall && ordinal < errorBurst_.lastCall) {
+    return errorBurst_.errorKind;
+  }
+  return RPCErrorKind::kNone;
+}
+
+folly::SemiFuture<RPCResponse> MockRPCClient::call(const RPCRequest& request) {
+  const int64_t ordinal = callCount_.fetch_add(1);
+  const RPCErrorKind burstKind = burstErrorKind(ordinal);
+
+  // Draw the random error decision only on the non-burst path, so the RNG
+  // stream is consumed identically to callBatch(), which skips the draw for
+  // bursted requests. This keeps the two paths reproducible under a fixed seed.
+  bool shouldError = false;
+  if (burstKind == RPCErrorKind::kNone) {
+    std::uniform_real_distribution<double> dist(0.0, 1.0);
+    shouldError = dist(threadLocalRng()) < errorRate_;
+  }
 
   // Use folly::via with the thread pool executor for safe async execution
   return folly::via(
       executor_.get(),
-      [this, request = request, shouldError, latency = latency_]()
+      [this, request = request, shouldError, burstKind, latency = latency_]()
           -> RPCResponse {
+        // Deterministic overload burst: fail fast with a typed cause, skipping
+        // the latency sleep (overload rejections come back immediately).
+        if (burstKind != RPCErrorKind::kNone) {
+          return makeErrorResponse(request, burstKind);
+        }
         // Simulate network latency
         /* sleep override */ std::this_thread::sleep_for(latency);
         // Generate and return the response
@@ -95,12 +184,23 @@ folly::SemiFuture<std::vector<RPCResponse>> MockRPCClient::callBatch(
   // Capture error rate for thread safety
   double errorRate = errorRate_;
 
+  // Reserve this batch's ordinals on the caller thread, as call() does, so the
+  // burst window covers a fixed set of requests even when several batches are
+  // in flight. Assigning them inside the lambda would tie the mapping to
+  // executor scheduling order.
+  const int64_t firstOrdinal =
+      callCount_.fetch_add(static_cast<int64_t>(requests.size()));
+
   // Use folly::via with the thread pool executor for safe async execution
   return folly::via(
       executor_.get(),
-      [this, requests, errorRate, latency = latency_]()
+      [this, requests, errorRate, firstOrdinal, latency = latency_]()
           -> std::vector<RPCResponse> {
-        // Simulate network latency (single batch = single latency)
+        // Simulate network latency (single batch = single latency). Unlike
+        // call(), which returns a bursted request immediately, a batch pays
+        // this once up front even when some of its requests are in the burst
+        // window: the batch is one round trip, and a backend that rejects part
+        // of it still costs the caller that trip.
         /* sleep override */ std::this_thread::sleep_for(latency);
 
         std::vector<RPCResponse> responses;
@@ -111,8 +211,14 @@ folly::SemiFuture<std::vector<RPCResponse>> MockRPCClient::callBatch(
         thread_local std::mt19937 localRng{std::random_device{}()};
         std::uniform_real_distribution<double> dist(0.0, 1.0);
 
-        for (const auto& request : requests) {
-          callCount_.fetch_add(1);
+        for (size_t i = 0; i < requests.size(); ++i) {
+          const auto& request = requests[i];
+          const RPCErrorKind burstKind =
+              burstErrorKind(firstOrdinal + static_cast<int64_t>(i));
+          if (burstKind != RPCErrorKind::kNone) {
+            responses.push_back(makeErrorResponse(request, burstKind));
+            continue;
+          }
           bool shouldError = dist(localRng) < errorRate;
           responses.push_back(generateResponse(request, shouldError));
         }

--- a/velox/common/rpc/clients/MockRPCClient.h
+++ b/velox/common/rpc/clients/MockRPCClient.h
@@ -55,17 +55,46 @@ class MockRPCClient : public IRPCClient {
     return callCount_.load();
   }
 
-  /// Resets the call counter.
+  /// Resets the call counter. An installed error burst stays installed and
+  /// cannot be replaced, so ordinals restart at 0 and the same burst window
+  /// applies again. Use a fresh client to test a different burst.
   void resetCallCount() {
     callCount_.store(0);
   }
 
+  /// Configures a deterministic error burst for congestion / AIMD tests.
+  /// Requests whose 0-based call ordinal falls in [firstCall, lastCall) are
+  /// failed with a response tagged `errorKind`, simulating a timed
+  /// backend-overload window (rate-limit / timeout). Ordinals are reserved on
+  /// the caller thread, one per call() request and a contiguous run per
+  /// callBatch() request, so the burst covers a fixed, timing-independent set
+  /// of requests. Disabled when firstCall >= lastCall (the default).
+  struct ErrorBurst {
+    int64_t firstCall{0};
+    int64_t lastCall{0};
+    RPCErrorKind errorKind{RPCErrorKind::kRateLimited};
+  };
+
+  /// Installs the error burst. May be called at most once, and only before the
+  /// first request is dispatched; thereafter the burst is only read, never
+  /// mutated. Throws if called twice or after a request has been dispatched.
+  void setErrorBurst(const ErrorBurst& burst);
+
  private:
   RPCResponse generateResponse(const RPCRequest& request, bool isError);
+
+  // Returns the burst error kind for a request at 0-based `ordinal`, or kNone
+  // when the ordinal is outside the configured burst window.
+  RPCErrorKind burstErrorKind(int64_t ordinal) const;
 
   const std::chrono::milliseconds latency_;
   const double errorRate_;
   std::atomic<int64_t> callCount_{0};
+  // Guards publication of errorBurst_ to the dispatch threads: written with
+  // release in setErrorBurst(), read with acquire in burstErrorKind().
+  std::atomic<bool> burstInstalled_{false};
+  // Configured error-burst window; read only once burstInstalled_ is true.
+  ErrorBurst errorBurst_{};
 
   /// Shared executor (may be shared across clients for global throttling).
   std::shared_ptr<folly::CPUThreadPoolExecutor> executor_;

--- a/velox/exec/rpc/tests/CMakeLists.txt
+++ b/velox/exec/rpc/tests/CMakeLists.txt
@@ -118,3 +118,17 @@ target_link_libraries(
 )
 
 add_test(NAME velox_rpc_operator_test COMMAND velox_rpc_operator_test)
+
+add_executable(velox_rpc_aimd_under_load_test RPCAimdUnderLoadTest.cpp Main.cpp)
+
+target_link_libraries(
+  velox_rpc_aimd_under_load_test
+  velox_mock_rpc_client
+  velox_rpc_plan_node_translator
+  velox_async_rpc_function_registry
+  velox_exec_test_lib
+  GTest::gtest
+  Folly::folly
+)
+
+add_test(NAME velox_rpc_aimd_under_load_test COMMAND velox_rpc_aimd_under_load_test)

--- a/velox/exec/rpc/tests/RPCAimdUnderLoadTest.cpp
+++ b/velox/exec/rpc/tests/RPCAimdUnderLoadTest.cpp
@@ -1,0 +1,308 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// Layer 2 — AIMD-under-load behavioral test for the async RPC framework.
+///
+/// Layer 1 (the folly microbenchmark) proves the framework's per-row overhead
+/// is stable. This layer proves the framework's *closed-loop behavior* under a
+/// backend overload: it drives a real Task/Driver pipeline through three phases
+///   warm-up  → overload burst → recovery
+/// and asserts, from the operator's own runtime stats, that BOTH AIMD control
+/// loops reacted correctly — the per-driver congestion window shrank, the
+/// process-global rate-limiter cap backed off below its ceiling, and the cap
+/// then recovered upward once the burst cleared.
+///
+/// The burst is injected deterministically: MockRPCClient tags a fixed window
+/// of call ordinals with errorKind=kRateLimited (see
+/// MockRPCClient::ErrorBurst), and PER_ROW dispatch preserves row order, so the
+/// burst lands on a known, timing-independent slice of rows. The whole
+/// trajectory is captured in a single close()-time stats snapshot: numShrinks>0
+/// proves the window dipped; rpcRateLimiterMinCap (only emitted once the cap
+/// shrank) proves the limiter backed off; the final cap sitting above that
+/// low-water mark proves recovery.
+
+#include <gtest/gtest.h>
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/rpc/clients/MockRPCClient.h"
+#include "velox/exec/PlanNodeStats.h"
+#include "velox/exec/rpc/RPCOperator.h"
+#include "velox/exec/rpc/RPCPlanNodeTranslator.h"
+#include "velox/exec/rpc/RPCRateLimiter.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/expression/rpc/AsyncRPCFunction.h"
+#include "velox/expression/rpc/AsyncRPCFunctionRegistry.h"
+
+namespace facebook::velox::exec::rpc {
+namespace {
+
+using namespace facebook::velox::exec::test;
+using velox::rpc::MockRPCClient;
+using velox::rpc::RPCErrorKind;
+using velox::rpc::RPCRequest;
+using velox::rpc::RPCResponse;
+
+// A PER_ROW RPC function backed by a MockRPCClient that rejects a
+// deterministic window of requests with rate-limit errors. It classifies
+// rate-limit/timeout failures as backend overload (kError -> both controllers
+// back off) and clean drains as kSuccess (feed the RTT gradient / drive
+// rate-limiter recovery), exactly as a production congestion policy would.
+class BurstRPCFunction : public AsyncRPCFunction {
+ public:
+  struct Config {
+    // Requests with call ordinal in [burstFirstCall, burstLastCall) are failed.
+    int64_t burstFirstCall{0};
+    int64_t burstLastCall{0};
+    RPCErrorKind burstKind{RPCErrorKind::kRateLimited};
+    std::chrono::milliseconds latency{std::chrono::milliseconds(1)};
+    // Non-empty so the process-global rate limiter is keyed on a real tier.
+    std::string tier{"layer2.test.tier"};
+  };
+
+  explicit BurstRPCFunction(Config config) : config_{std::move(config)} {}
+
+  void initialize(
+      const core::QueryConfig& /*queryConfig*/,
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const std::vector<VectorPtr>& /*constantInputs*/) override {
+    // Call ordinals are what pin the burst to rows [kWarmupRows,
+    // kWarmupRows + kBurstRows). A second initialize() would install a fresh
+    // client whose ordinals restart at 0 and silently move the burst, so
+    // require exactly one.
+    VELOX_CHECK_NULL(client_, "initialize() must be called at most once");
+    client_ =
+        std::make_shared<MockRPCClient>(config_.latency, /*errorRate=*/0.0);
+    client_->setErrorBurst(
+        {config_.burstFirstCall, config_.burstLastCall, config_.burstKind});
+  }
+
+  std::string name() const override {
+    return "burst_rpc";
+  }
+
+  TypePtr resultType() const override {
+    return VARCHAR();
+  }
+
+  std::string tierKey() const override {
+    return config_.tier;
+  }
+
+  std::vector<std::pair<vector_size_t, folly::SemiFuture<RPCResponse>>>
+  dispatchPerRow(
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args) override {
+    std::vector<std::pair<vector_size_t, folly::SemiFuture<RPCResponse>>>
+        results;
+    VELOX_CHECK(!args.empty(), "burst_rpc expects one argument");
+    // Returning no futures for selected rows would strand them and surface far
+    // downstream, so fail here instead of degrading silently.
+    auto* promptVector = args[0]->as<SimpleVector<StringView>>();
+    VELOX_CHECK_NOT_NULL(
+        promptVector, "burst_rpc expects a VARCHAR prompt argument");
+
+    rows.applyToSelected([&](vector_size_t row) {
+      // One driver, one batch, so the row index doubles as the request id.
+      // Carrying it through makes the simulated error messages name the row
+      // they came from instead of reporting every failure as row 0.
+      if (promptVector->isNullAt(row)) {
+        results.emplace_back(
+            row,
+            folly::makeSemiFuture<RPCResponse>(RPCResponse{
+                .rowId = row,
+                .result = "",
+                .metadata = {},
+                .error = "null_input",
+                .errorKind = RPCErrorKind::kNullInput}));
+        return;
+      }
+      RPCRequest request;
+      request.rowId = row;
+      request.originalRowIndex = row;
+      request.payload = promptVector->valueAt(row).str();
+      results.emplace_back(row, client_->call(request));
+    });
+
+    return results;
+  }
+
+  // Overload classifier: rate-limit / timeout failures are backend overload
+  // (kError). A null-input error is a user error and must NOT move the window
+  // (folded into kSuccess/kNone below since it is not rate-limit/timeout). A
+  // clean drain feeds its RTT to the gradient and drives rate-limiter recovery.
+  CongestionSignal evaluateCongestion(
+      const std::vector<RPCResponse>& responses) const override {
+    for (const auto& response : responses) {
+      if (response.hasError() &&
+          (response.errorKind == RPCErrorKind::kRateLimited ||
+           response.errorKind == RPCErrorKind::kTimeout)) {
+        return CongestionSignal::kError;
+      }
+    }
+    return responses.empty() ? CongestionSignal::kNone
+                             : CongestionSignal::kSuccess;
+  }
+
+ private:
+  Config config_;
+  std::shared_ptr<MockRPCClient> client_;
+};
+
+class RPCAimdUnderLoadTest : public OperatorTestBase {
+ protected:
+  // Phase sizes (rows). PER_ROW issues one call per row in row order, so call
+  // ordinals map 1:1 to row indices: warm-up = [0, kWarmupRows), burst =
+  // [kWarmupRows, kWarmupRows + kBurstRows), recovery = the rest.
+  static constexpr int32_t kWarmupRows = 64;
+  static constexpr int32_t kBurstRows = 96;
+  static constexpr int32_t kRecoveryRows = 320;
+  static constexpr int32_t kTotalRows =
+      kWarmupRows + kBurstRows + kRecoveryRows;
+
+  // Rate-limiter AIMD bounds for the test tier. Keeping the in-flight ceiling
+  // (window 32, cap 64) below the burst size guarantees the burst drains in
+  // several waves, so the cap shrinks multiple times (64 -> 32 -> 16 -> ...)
+  // well below its ceiling before recovery.
+  static constexpr int64_t kMaxLimit = 64;
+  static constexpr int64_t kMinLimit = 4;
+  static constexpr int64_t kMaxWindow = 32;
+
+  static void SetUpTestCase() {
+    OperatorTestBase::SetUpTestCase();
+    registerRPCPlanNodeTranslator();
+    AsyncRPCFunctionRegistry::registerFunction("burst_rpc", [] {
+      return std::make_shared<BurstRPCFunction>(
+          BurstRPCFunction::Config{/*burstFirstCall=*/kWarmupRows,
+                                   /*burstLastCall=*/kWarmupRows + kBurstRows,
+                                   /*burstKind=*/RPCErrorKind::kRateLimited});
+    });
+  }
+
+  static void TearDownTestCase() {
+    OperatorTestBase::TearDownTestCase();
+    // Reset MemoryManager to shut down SharedArbitrator executor threads so
+    // TSAN does not report threads still running at process exit.
+    memory::MemoryManager::testingSetInstance({});
+  }
+
+  void TearDown() override {
+    // The rate limiter is process-global; reset it so its adaptive state does
+    // not leak into other tests.
+    RPCRateLimiter::testingResetAllState();
+    OperatorTestBase::TearDown();
+  }
+
+  core::PlanNodePtr makeRPCNode(const core::PlanNodePtr& source) {
+    const auto& sourceType = source->outputType();
+
+    // The sole argument is the prompt column, read from the source at runtime.
+    std::vector<core::TypedExprPtr> callInputs;
+    callInputs.push_back(
+        std::make_shared<core::FieldAccessTypedExpr>(
+            sourceType->findChild("prompt"), "prompt"));
+    auto call = std::make_shared<core::CallTypedExpr>(
+        VARCHAR(), std::move(callInputs), "burst_rpc");
+
+    auto outputNames = sourceType->names();
+    auto outputTypes = sourceType->children();
+    outputNames.emplace_back("__rpc_result");
+    outputTypes.push_back(VARCHAR());
+    auto outputType = ROW(std::move(outputNames), std::move(outputTypes));
+
+    // Default streaming mode is PER_ROW.
+    return std::make_shared<core::RPCNode>(
+        "rpc-0", source, std::move(call), "__rpc_result", outputType);
+  }
+};
+
+TEST_F(RPCAimdUnderLoadTest, windowAndRateLimiterBackOffThenRecover) {
+  // One input vector of distinct prompts. PER_ROW dispatch preserves row order,
+  // so the burst lands exactly on rows [kWarmupRows, kWarmupRows + kBurstRows).
+  std::vector<std::string> storage;
+  storage.reserve(kTotalRows);
+  for (int32_t i = 0; i < kTotalRows; ++i) {
+    storage.push_back("row_" + std::to_string(i));
+  }
+  std::vector<StringView> prompts;
+  prompts.reserve(kTotalRows);
+  for (const auto& prompt : storage) {
+    prompts.emplace_back(prompt);
+  }
+  auto input = makeRowVector({"prompt"}, {makeFlatVector<StringView>(prompts)});
+
+  auto plan = makeRPCNode(PlanBuilder().values({input}).planNode());
+
+  std::shared_ptr<Task> task;
+  auto result = AssertQueryBuilder(plan)
+                    .maxDrivers(1)
+                    .config("rpc.ratelimiter.adaptive_enabled", "true")
+                    .config("rpc.ratelimiter.max_limit", kMaxLimit)
+                    .config("rpc.ratelimiter.min_limit", kMinLimit)
+                    .config("rpc.ratelimiter.decrease_factor", "0.5")
+                    .config("rpc.congestion.max_window", kMaxWindow)
+                    .config("rpc.congestion.min_window", 1)
+                    .copyResults(pool(), task);
+
+  // The query completes end-to-end: every row yields an output row, and exactly
+  // the burst window errors out to NULL (proving the deterministic burst hit
+  // the rows we expect and nothing else).
+  ASSERT_EQ(result->size(), kTotalRows);
+  auto* results = result->childAt(1)->asFlatVector<StringView>();
+  int64_t numNulls{0};
+  for (vector_size_t i = 0; i < result->size(); ++i) {
+    if (results->isNullAt(i)) {
+      ++numNulls;
+    }
+  }
+  EXPECT_EQ(numNulls, kBurstRows)
+      << "exactly the burst window should error out to NULL";
+
+  auto planStats = toPlanStats(task->taskStats());
+  ASSERT_EQ(planStats.count("rpc-0"), 1);
+  const auto& customStats = planStats.at("rpc-0").customStats;
+
+  // Returns the stat's summed value, or -1 when the stat was never emitted
+  // (several are only emitted when the corresponding event actually happened).
+  auto statSum = [&](const std::string& key) -> int64_t {
+    auto it = customStats.find(key);
+    return it == customStats.end() ? -1 : it->second.sum;
+  };
+
+  // (1) The mock injected exactly the burst window of rate-limit errors, and
+  // the
+  //     operator classified them by typed cause.
+  EXPECT_EQ(statSum(RPCOperator::kRpcErrorKindRateLimited), kBurstRows);
+
+  // (2) Overload -> the per-driver congestion window shrank at least once
+  //     (this stat is only emitted when numShrinks > 0).
+  EXPECT_GT(statSum(RPCOperator::kRpcCongestionShrinks), 0);
+
+  // (3) Overload -> the process-global rate-limiter cap backed off below its
+  //     ceiling. rpcRateLimiterMinCap is only emitted once the cap shrank.
+  const int64_t minCap = statSum(RPCOperator::kRpcRateLimiterMinCap);
+  EXPECT_GT(minCap, 0);
+  EXPECT_LT(minCap, kMaxLimit) << "cap should have dipped below its ceiling";
+
+  // (4) After the burst, the clean success stream drove AIMD additive recovery:
+  //     the final cap climbed back above the low-water mark.
+  const int64_t finalCap = statSum(RPCOperator::kRpcRateLimiterCap);
+  EXPECT_GT(finalCap, minCap) << "cap should recover above its low-water mark";
+}
+
+} // namespace
+} // namespace facebook::velox::exec::rpc


### PR DESCRIPTION
Summary:

The async RPC framework throttles itself with two AIMD control loops when a backend gets overloaded: a per-driver congestion window and a process-global rate-limiter cap. Until now nothing verified that either one actually reacts. This adds a behavioral test that drives a real Task through three phases -- warm-up, an overload burst, and recovery. It then asserts from the operator's own runtime stats that the window shrank, the cap dropped below its ceiling, and the cap recovered once the burst cleared.

The burst is deterministic rather than timing-based, which is what keeps an overload test from being flaky. `MockRPCClient` gains an error-burst window: a request whose 0-based call ordinal falls in `[firstCall, lastCall)` comes back tagged `errorKind=kRateLimited`. Ordinals are assigned atomically and PER_ROW dispatch preserves row order, so the burst covers the same slice of rows no matter how the driver threads interleave. The window is empty by default, so existing `MockRPCClient` callers are unaffected.

Also regenerates the README "Recent blog posts" list. That list is enforced by the `check-readme-blogs` pre-commit hook, which has been failing on every velox pull request since the 2026-08-03 hash-table-caching post landed without the matching README entry. The regeneration here is the verbatim output of `scripts/checks/check-readme-blogs.sh`, carried so this change can land; it is unrelated to the test itself.

Reviewed By: zhichenxu-meta, sebastianopeluso

Differential Revision: D113951681
