### PR TITLE
fix(wave): Correct row counts, empty splits, Values nulls, sharded staging and a reduction barrier

### DIFF
--- a/velox/experimental/wave/dwio/FormatData.cpp
+++ b/velox/experimental/wave/dwio/FormatData.cpp
@@ -65,6 +65,10 @@ void SplitStaging::copyColumns(
   }
 }
 
+// Splits with more than this many bytes of column data are copied to the
+// staging buffer by several threads.
+constexpr int64_t kParallelStagingBytes = 2'000'000;
+
 // Shared pool of 1-2GB of pinned host memory for staging. May
 // transiently exceed 2GB but settles to 2GB after the peak.
 GpuArena& getTransferArena() {
@@ -93,12 +97,14 @@ void SplitStaging::transfer(
   WaveTime startTime = WaveTime::now();
   deviceBuffer_ = waveStream.deviceArena().allocate<char>(fill_);
   hostBuffer_ = getTransferArena().allocate<char>(fill_);
-  auto transferBuffer = hostBuffer_->as<char>();
+  // Each shard of the copy writes at 'offsets_' of the columns it copies, so
+  // every shard starts from the beginning of the staging buffer.
+  auto* transferBuffer = hostBuffer_->as<char>();
   int firstToCopy = 0;
   int64_t copySize = 0;
   auto targetCopySize = FLAGS_staging_bytes_per_thread;
   int32_t numThreads = 0;
-  if (fill_ > 2000000) {
+  if (fill_ > kParallelStagingBytes) {
     for (auto i = 0; i < staging_.size(); ++i) {
       auto columnSize = staging_[i].size;
       copySize += columnSize;
@@ -108,7 +114,6 @@ void SplitStaging::transfer(
             [i, firstToCopy, transferBuffer, this]() {
               copyColumns(firstToCopy, i + 1, transferBuffer, true);
             });
-        transferBuffer += copySize;
         copySize = 0;
         firstToCopy = i + 1;
       }

--- a/velox/experimental/wave/exec/Accumulators.cuh
+++ b/velox/experimental/wave/exec/Accumulators.cuh
@@ -115,6 +115,10 @@ __device__ __forceinline__ void sumReduce(
       }
     }
   }
+  // Consecutive accumulators in the same ungrouped aggregation reuse this
+  // scratch area, so no warp may start writing it before the first warp has
+  // finished reading it.
+  __syncthreads();
 }
 
 } // namespace facebook::velox::wave

--- a/velox/experimental/wave/exec/TableScan.cpp
+++ b/velox/experimental/wave/exec/TableScan.cpp
@@ -28,11 +28,27 @@ std::atomic<uint64_t> TableScan::ioWaitNanos_;
 using exec::BlockingReason;
 
 BlockingReason TableScan::isBlocked(
-    WaveStream& /*stream*/,
+    WaveStream& stream,
     ContinueFuture* future) {
-  if (!dataSource_ || needNewSplit_) {
+  while (!dataSource_ || needNewSplit_) {
     nextSplit(future);
-    isNewSplit_ = true;
+    if (blockingFuture_.valid()) {
+      break;
+    }
+    if (noMoreSplits_) {
+      return BlockingReason::kNotBlocked;
+    }
+    // The row count of the first batch of a new split is taken here and not in
+    // canAdvance() because a split can produce no rows at all, for example an
+    // empty split. Such a split must be replaced by the next one, while a
+    // canAdvance() that reports no rows ends the pipeline.
+    nextAvailableRows_ = waveDataSource_->canAdvance(stream);
+    if (nextAvailableRows_ == 0) {
+      if (auto splitReader = waveDataSource_->splitReader()) {
+        updateStats(splitReader->runtimeStats(), splitReader.get());
+      }
+      needNewSplit_ = true;
+    }
   }
   if (blockingFuture_.valid()) {
     *future = std::move(blockingFuture_);
@@ -43,16 +59,10 @@ BlockingReason TableScan::isBlocked(
 
 std::vector<AdvanceResult> TableScan::canAdvance(WaveStream& stream) {
   std::vector<AdvanceResult> results;
-  if (!dataSource_ || needNewSplit_) {
+  if (!dataSource_ || needNewSplit_ || nextAvailableRows_ == 0) {
     return results;
   }
-  auto& result = results.emplace_back();
-  if (isNewSplit_) {
-    isNewSplit_ = false;
-    result.numRows = waveDataSource_->canAdvance(stream);
-  } else {
-    result.numRows = nextAvailableRows_;
-  }
+  results.emplace_back().numRows = nextAvailableRows_;
   return results;
 }
 

--- a/velox/experimental/wave/exec/TableScan.h
+++ b/velox/experimental/wave/exec/TableScan.h
@@ -147,12 +147,8 @@ class TableScan : public WaveSourceOperator {
   // global static 'ioWaitNanos_'.
   uint64_t lastIoWaitNanos_{0};
 
-  // The value returned by canAdvance() of the WaveDataSource after last
-  // schedule().
+  // The value returned by canAdvance() of the WaveDataSource after the last
+  // schedule() or after adding a split.
   int32_t nextAvailableRows_{0};
-
-  // True if canAdvance() should do waveDataSource_->canAdvance() instead of
-  // returning 'nextAvailableRows_'.
-  bool isNewSplit_{false};
 };
 } // namespace facebook::velox::wave

--- a/velox/experimental/wave/exec/Vectors.cpp
+++ b/velox/experimental/wave/exec/Vectors.cpp
@@ -67,6 +67,16 @@ void ensureVectors(
   }
 }
 
+namespace {
+// Wave marks nulls with one byte per value, Velox with one bit. Expands 'size'
+// null bits into 'bytes'.
+void nullsToBytes(const uint64_t* nulls, vector_size_t size, uint8_t* bytes) {
+  for (auto i = 0; i < size; ++i) {
+    bytes[i] = bits::isBitNull(nulls, i) ? kNull : kNotNull;
+  }
+}
+} // namespace
+
 void transferVector(
     const BaseVector* source,
     int32_t index,
@@ -74,7 +84,8 @@ void transferVector(
     std::vector<WaveVectorPtr>& waveVectors,
     std::vector<Operand>& operands,
     GpuArena& arena,
-    int64_t& totalBytes) {
+    int64_t& totalBytes,
+    std::vector<BufferPtr>& nullsStaging) {
   if (waveVectors.size() <= index) {
     waveVectors.resize(index + 1);
   }
@@ -99,8 +110,12 @@ void transferVector(
       totalBytes += bytes;
     }
     if (rawNulls) {
-      auto bytes = bits::nbytes(source->size());
-      transfers.emplace_back(rawNulls, waveVectors[index]->nulls(), bytes);
+      auto bytes = source->size();
+      auto& staging = nullsStaging.emplace_back(
+          AlignedBuffer::allocate<uint8_t>(bytes, source->pool()));
+      nullsToBytes(rawNulls, source->size(), staging->asMutable<uint8_t>());
+      transfers.emplace_back(
+          staging->as<uint8_t>(), waveVectors[index]->nulls(), bytes);
       totalBytes += bytes;
     }
   }
@@ -114,10 +129,20 @@ void vectorsToDevice(
   int64_t bytes = 0;
   std::vector<Operand> operandVector;
   std::vector<WaveVectorPtr> waveVectors;
+  // Host side byte-per-row nulls referenced by 'transfers'. startTransfer()
+  // copies the data before it returns, so these outlive their use.
+  std::vector<BufferPtr> nullsStaging;
   auto& arena = stream.arena();
   for (auto i = 0; i < source.size(); ++i) {
     transferVector(
-        source[i], i, transfers, waveVectors, operandVector, arena, bytes);
+        source[i],
+        i,
+        transfers,
+        waveVectors,
+        operandVector,
+        arena,
+        bytes,
+        nullsStaging);
   }
   Executable::startTransfer(
       ids, std::move(waveVectors), std::move(transfers), stream);

--- a/velox/experimental/wave/exec/Wave.cpp
+++ b/velox/experimental/wave/exec/Wave.cpp
@@ -896,11 +896,14 @@ LaunchControl* WaveStream::prepareProgramLaunch(
     // will show one error.
     control.params.status = addBytes<BlockStatus*>(start, statusOffset);
     deviceBlockStatus_ = control.params.status;
+    // The last block is full when the row count is a multiple of kBlockSize.
+    const int32_t rowsInLastBlock =
+        numRows_ - (inputBlocksPerExe - 1) * kBlockSize;
     // Memory is already set to all 0.
     for (auto i = 0; i < inputBlocksPerExe; ++i) {
       auto status = &control.params.status[i];
       status->numRows =
-          i == inputBlocksPerExe - 1 ? inputRows % kBlockSize : kBlockSize;
+          i == inputBlocksPerExe - 1 ? rowsInLastBlock : kBlockSize;
     }
   } else if (!inputControl) {
     // No input control and retry. the statuses are as left by the previous try.

--- a/velox/experimental/wave/exec/tests/AggregationTest.cpp
+++ b/velox/experimental/wave/exec/tests/AggregationTest.cpp
@@ -228,5 +228,126 @@ TEST_F(AggregationTest, DISABLED_tpchQ1) {
   AssertQueryBuilder(plan).assertResults(expected);
 }
 
+class AggregationBugTest : public AggregationTest {
+ protected:
+  static constexpr int32_t kRows = 100000;
+
+  // AggregationTest suppresses the base TearDown, which leaves the periodic
+  // stats reporter running and makes every subsequent SetUp throw.
+  void TearDown() override {
+    OperatorTestBase::TearDown();
+  }
+
+  // Group key is 'row % cardinality', value is a small positive int so that no
+  // sum can overflow.
+  RowVectorPtr makeGroupedInput(int32_t cardinality) {
+    return makeRowVector(
+        {"g", "v"},
+        {makeFlatVector<int64_t>(kRows, [&](int i) { return i % cardinality; }),
+         makeFlatVector<int64_t>(kRows, [](int i) { return (i % 7) + 1; })});
+  }
+
+  RowVectorPtr expectedGrouped(int32_t cardinality) {
+    std::vector<int64_t> sums(cardinality, 0);
+    for (int32_t i = 0; i < kRows; ++i) {
+      sums[i % cardinality] += (i % 7) + 1;
+    }
+    return makeRowVector(
+        {makeFlatVector<int64_t>(cardinality, folly::identity),
+         makeFlatVector<int64_t>(cardinality, [&](int i) { return sums[i]; })});
+  }
+
+  void checkCardinality(int32_t cardinality) {
+    SCOPED_TRACE(fmt::format("cardinality={}", cardinality));
+    auto plan = PlanBuilder()
+                    .values({makeGroupedInput(cardinality)})
+                    .project({"g", "v + 0 as p"})
+                    .singleAggregation({"g"}, {"sum(p)"})
+                    .planNode();
+    AssertQueryBuilder(plan).assertResults(expectedGrouped(cardinality));
+  }
+
+  void checkAccumulators(int32_t numAccumulators) {
+    SCOPED_TRACE(fmt::format("accumulators={}", numAccumulators));
+    std::vector<std::string> names;
+    std::vector<VectorPtr> columns;
+    std::vector<std::string> projections;
+    std::vector<std::string> aggregates;
+    std::vector<VectorPtr> expectedColumns;
+    for (int32_t j = 0; j < numAccumulators; ++j) {
+      names.push_back(fmt::format("c{}", j));
+      columns.push_back(makeFlatVector<int64_t>(kRows, [&](int i) {
+        return (i % 7) + j + 1;
+      }));
+      projections.push_back(fmt::format("c{} + 0 as p{}", j, j));
+      aggregates.push_back(fmt::format("sum(p{})", j));
+      int64_t sum = 0;
+      for (int32_t i = 0; i < kRows; ++i) {
+        sum += (i % 7) + j + 1;
+      }
+      expectedColumns.push_back(
+          makeFlatVector<int64_t>(1, [&](int) { return sum; }));
+    }
+    auto plan = PlanBuilder()
+                    .values({makeRowVector(names, columns)})
+                    .project(projections)
+                    .singleAggregation({}, aggregates)
+                    .planNode();
+    AssertQueryBuilder(plan).assertResults(makeRowVector(expectedColumns));
+  }
+};
+
+// Grouped sum reported wrong when the number of result groups is a multiple of
+// kBlockSize (256).
+class GroupCardinalityTest : public AggregationBugTest,
+                             public testing::WithParamInterface<int32_t> {};
+
+TEST_P(GroupCardinalityTest, groupedSum) {
+  checkCardinality(GetParam());
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AggregationBug,
+    GroupCardinalityTest,
+    testing::Values(
+        1,
+        64,
+        255,
+        256,
+        257,
+        384,
+        511,
+        512,
+        513,
+        768,
+        1000,
+        1023,
+        1024,
+        1025,
+        1536,
+        2048,
+        4096),
+    [](const testing::TestParamInfo<int32_t>& info) {
+      return fmt::format("card{}", info.param);
+    });
+
+// Ungrouped sum reported wrong once an aggregation has enough accumulators for
+// the warps to race on the shared scratch area. The threshold is not fixed; it
+// depends on how much work sits between the barriers.
+class AccumulatorCountTest : public AggregationBugTest,
+                             public testing::WithParamInterface<int32_t> {};
+
+TEST_P(AccumulatorCountTest, ungroupedSum) {
+  checkAccumulators(GetParam());
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AggregationBug,
+    AccumulatorCountTest,
+    testing::Values(1, 4, 8, 11, 12, 13, 14, 16, 24, 32),
+    [](const testing::TestParamInfo<int32_t>& info) {
+      return fmt::format("acc{}", info.param);
+    });
+
 } // namespace
 } // namespace facebook::velox::wave

--- a/velox/experimental/wave/exec/tests/CMakeLists.txt
+++ b/velox/experimental/wave/exec/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_subdirectory(utils)
 
 add_executable(
   velox_wave_exec_test
+  AggregationTest.cpp
   FilterProjectTest.cpp
   TableScanTest.cpp
   HashJoinTest.cpp

--- a/velox/experimental/wave/exec/tests/FilterProjectTest.cpp
+++ b/velox/experimental/wave/exec/tests/FilterProjectTest.cpp
@@ -105,6 +105,40 @@ TEST_F(FilterProjectTest, roundTrip) {
   AssertQueryBuilder(plan).assertResults(vectors);
 }
 
+TEST_F(FilterProjectTest, blockSizeMultiple) {
+  // A batch whose row count is an exact multiple of the thread block size must
+  // return all of its rows.
+  constexpr int32_t kNumRows = 4 * 256;
+  auto data = makeRowVector(
+      {makeFlatVector<int64_t>(kNumRows, [](auto row) { return row; })});
+  createDuckDbTable({data});
+
+  auto plan =
+      PlanBuilder().values({data}).project({"c0", "c0 + 1 as c1"}).planNode();
+  assertQuery(plan, "SELECT c0, c0 + 1 FROM tmp");
+}
+
+TEST_F(FilterProjectTest, nullableValues) {
+  // Nulls of a Values source must survive the round trip to device, where they
+  // are one byte per row instead of one bit.
+  constexpr int32_t kNumRows = 1000;
+  auto data = makeRowVector(
+      {makeFlatVector<int64_t>(
+           kNumRows,
+           [](auto row) { return row; },
+           [](auto row) {
+             return row == 0 || row == kNumRows - 1 || row % 7 == 0;
+           }),
+       makeFlatVector<int64_t>(kNumRows, [](auto row) { return row * 2; })});
+  createDuckDbTable({data});
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .project({"c0", "c1", "c0 + c1 as c2"})
+                  .planNode();
+  assertQuery(plan, "SELECT c0, c1, c0 + c1 FROM tmp");
+}
+
 TEST_F(FilterProjectTest, project) {
   std::vector<RowVectorPtr> vectors;
   for (int32_t i = 0; i < 10; ++i) {

--- a/velox/experimental/wave/exec/tests/TableScanTest.cpp
+++ b/velox/experimental/wave/exec/tests/TableScanTest.cpp
@@ -319,6 +319,27 @@ TEST_P(TableScanTest, basic) {
   ASSERT_TRUE(it != planStats.end());
 }
 
+TEST_P(TableScanTest, emptySplit) {
+  // A split that produces no rows must not end the scan. The remaining splits
+  // still have to be read.
+  auto type = ROW({"c0"}, {BIGINT()});
+  auto empty = makeRowVector({makeFlatVector<int64_t>(std::vector<int64_t>{})});
+  auto makeBatch = [&](int64_t begin) {
+    return makeRowVector(
+        {makeFlatVector<int64_t>(1000, [&](auto row) { return begin + row; })});
+  };
+  // The stripe size of the mock table is the size of the first batch, so an
+  // empty first batch makes every batch a separate split.
+  vectors_ = {empty, makeBatch(0), empty, makeBatch(1000)};
+  auto splits = makeTable("test", vectors_);
+  ASSERT_EQ(4, splits.size());
+  createDuckDbTable({vectors_[1], vectors_[3]});
+
+  numDrivers_ = 1;
+  auto plan = tableScanNode(type);
+  assertQuery(plan, splits, "SELECT * FROM tmp");
+}
+
 TEST_P(TableScanTest, filter) {
   auto type =
       ROW({"c0", "c1", "c2", "c3"}, {BIGINT(), BIGINT(), BIGINT(), BIGINT()});

--- a/velox/experimental/wave/exec/tests/TableScanTest.cpp
+++ b/velox/experimental/wave/exec/tests/TableScanTest.cpp
@@ -340,6 +340,32 @@ TEST_P(TableScanTest, emptySplit) {
   assertQuery(plan, splits, "SELECT * FROM tmp");
 }
 
+TEST_P(TableScanTest, shardedStaging) {
+  // A split with more than 'kParallelStagingBytes' of column data is copied to
+  // the staging buffer in parallel shards. Every column must arrive at its own
+  // offset in the buffer.
+  constexpr int32_t kNumColumns = 8;
+  constexpr int32_t kNumRows = 200'000;
+  std::vector<std::string> names;
+  std::vector<TypePtr> types;
+  std::vector<VectorPtr> children;
+  for (auto i = 0; i < kNumColumns; ++i) {
+    names.push_back(fmt::format("c{}", i));
+    types.push_back(BIGINT());
+    children.push_back(makeFlatVector<int64_t>(kNumRows, [i](auto row) {
+      return (row + 1) * (i + 1);
+    }));
+  }
+  auto type = ROW(std::vector<std::string>(names), std::move(types));
+  vectors_ = {makeRowVector(names, children)};
+  auto splits = makeTable("test", vectors_);
+  ASSERT_EQ(1, splits.size());
+  createDuckDbTable(vectors_);
+
+  numDrivers_ = 1;
+  assertQuery(tableScanNode(type), splits, "SELECT * FROM tmp");
+}
+
 TEST_P(TableScanTest, filter) {
   auto type =
       ROW({"c0", "c1", "c2", "c3"}, {BIGINT(), BIGINT(), BIGINT(), BIGINT()});

--- a/velox/experimental/wave/exec/tests/utils/FileFormat.cpp
+++ b/velox/experimental/wave/exec/tests/utils/FileFormat.cpp
@@ -204,6 +204,13 @@ template <typename T>
 std::unique_ptr<Column> Encoder<T>::toColumn() {
   auto column = std::make_unique<Column>();
   column->kind = kind_;
+  if (count_ == 0) {
+    // An empty stripe. 'values' must be set for the stripe to count as loaded.
+    column->encoding = kFlat;
+    column->values = AlignedBuffer::allocate<char>(1, pool_);
+    column->bitWidth = 1;
+    return column;
+  }
   if (!nulls_.empty()) {
     auto n = bits::nwords(count_);
     if (nulls_.size() < n) {

--- a/velox/experimental/wave/jit/Headers.h
+++ b/velox/experimental/wave/jit/Headers.h
@@ -1428,6 +1428,10 @@ const char* velox_experimental_wave_exec_Accumulators_cuh =
     "      }\n"
     "    }\n"
     "  }\n"
+    "  // Consecutive accumulators in the same ungrouped aggregation reuse this\n"
+    "  // scratch area, so no warp may start writing it before the first warp has\n"
+    "  // finished reading it.\n"
+    "  __syncthreads();\n"
     "}\n"
     "\n"
     "} // namespace facebook::velox::wave\n";


### PR DESCRIPTION
**Not yet ready for review. Will mark it as open and ping when it is**

- [ ] Needs fixes from #18308 for CI to pass

## Description

Five independent correctness bugs in Wave, each with a regression test.

1. **The last thread block of a batch was skipped whenever the row count was an exact multiple of 256.** `WaveStream::prepareProgramLaunch` set the last block's `BlockStatus::numRows` to `inputRows % kBlockSize`, which is `0` when `inputRows` is a multiple of `kBlockSize` (256). The final 256 rows of such a batch were silently dropped: no error, no warning, just a short result. This is shared code, so it affects the `Values` source as well as table scans. It is now computed as `numRows_ - (blocks - 1) * kBlockSize`, which is also correct on the continue path where `inputRows` is `-1`.

    The same expression also governs the *output* row count of a grouped aggregation, so this one line fixes two visible symptoms rather than one. A grouped `sum` returned wrong results whenever the number of result groups was a multiple of 256. On a continuation launch — which is how a grouped aggregation reads its result groups back — `numRows_` is reassigned from the advance result (`Wave.cpp:810`, from `AbstractReadAggregation::canAdvance`), so the block-status loop over `BlockStatus` runs across result rows rather than input rows and the same off-by-a-block arithmetic applies. `AggregationBug/GroupCardinalityTest.groupedSum` covers 17 group cardinalities over 100,000 rows: with only `rowsInLastBlock` reverted to `numRows_ % kBlockSize`, exactly the seven multiples of 256 fail and the other ten pass, cardinality 256 reporting `Expected 256, got 0` — the single block of result groups dropped entirely. It is `resultRows % 256 == 0` and not a power-of-two or hash-capacity boundary: 768 and 1536 fail, while 255/257 and 511/513 bracket failures at distance 1.

2. **A split that produced no rows ended the pipeline and abandoned the remaining splits.** `TableScan::canAdvance` returned a zero-row `AdvanceResult` for such a split, and `WaveDriver` schedules whatever `canAdvance` returns, so the scan launched a zero-row batch instead of moving on. Acquiring the first batch of a new split now happens in `TableScan::isBlocked`, which loops on to the next split when a split yields nothing; the redundant `isNewSplit_` flag is gone.

3. **Nullable input through the `Values` path produced garbage nulls on the device.** `transferVector` copied `bits::nbytes(size)` bytes of Velox bit-packed nulls straight into Wave's null buffer, but Wave represents nulls as one byte per row (`kNull`/`kNotNull`, see `Operand.h`), which is also what `WaveVector::toBits` assumes on the way back. The bits are now expanded into a per-row byte buffer staged on the host; the staging buffers are owned by `vectorsToDevice` across the `Executable::startTransfer` call, which copies them synchronously.

4. **Splits larger than 2 MB silently decoded most columns as a constant equal to the column minimum.** Once a batch exceeds `2000000` bytes, `SplitStaging::transfer` shards the host staging copy across threads, and it advanced the destination pointer by each shard's size even though `copyColumns` already writes every column at its absolute `offsets_[i]`. Each shard after the first therefore landed at double its intended offset, so most columns never reached the device, and the tail shards wrote past the end of the pinned host buffer. Single-shard copies start at the base and were always correct, which is why this only appeared above the threshold. The per-shard advance is removed.

    This is also what made Wave appear to compute correctly only at 100K-row batches. With the fix, 200K, 500K and 1M-row batches are correct, and on a matched synthetic benchmark the number of workloads agreeing with a CPU and cuDF reference went from seven of nine to nine of nine.

    On why this survived: instrumenting `SplitStaging::transfer` to log `fill_` and the shard count shows 261 staging calls across `velox_wave_exec_test`, of which only the three from the new `shardedStaging` test are multi-shard. Every pre-existing call staged at most 262,528 bytes in a single shard, so the whole suite sat in the always-correct regime.

5. **An ungrouped `sum` returned a value that was too large once an aggregation had enough accumulators.** `sumReduce` in `Accumulators.cuh` has every warp write its partial sum into a shared scratch array, then `__syncthreads()`, then warp 0 alone read the whole array and do the final reduction and the global atomic — with no barrier after that read. `SimpleAggregate.cpp` passes the same scratch pointer (`&shared->data`) to every accumulator of an aggregation, so while warp 0 is still reading accumulator *k*'s partials, the other warps have already run ahead into accumulator *k+1* and overwritten the array. Warp 0 then folds a neighbour's partials into accumulator *k*, which is why the wrong value is always too large. A trailing `__syncthreads()` leaves the scratch area free for the next caller.

    This is a race, not a deterministic miscomputation, and should not be read as having a fixed accumulator boundary: five consecutive runs of the 13-accumulator case gave five different wrong sums for the first accumulator (407419, 409819, 415579, 407739, 405499 against a correct 399995), and the count at which it starts failing moves with the shape of the plan — 11 accumulators in one shape, 13 in another. Only accumulator 0 is corrupted in practice, because warp 0's first global atomic puts it permanently behind the other warps and it then reaches every later barrier last; that is a timing accident, not a guarantee. The shared-memory sizing is fine and is not involved: `ToWave.h:459` reserves 76 bytes against 64 for `warpSum` plus 8 for `warpAny`.

    The barrier is added in both `exec/Accumulators.cuh` and `jit/Headers.h`. `Headers.h` holds a checked-in stringified copy of that header, regenerated by `jit/make_headers.sh`, and it is the copy NVRTC compiles at runtime, so changing only the `.cuh` compiles fine and fixes nothing observable. The two copies were checked to be byte-identical after the change.

    `AggregationBug/AccumulatorCountTest.ungroupedSum` covers 1 to 32 accumulators over 100,000 ungrouped rows. With the barrier reverted and rebuilt, all seven cases from 11 accumulators up fail; with it in place, three consecutive runs of those ten cases are clean. This is distinct from the `threadIdx.x < kWarpThreads` / `kNumWarps` bound that #18308 fixes in the same function; that fix is correct and this is an independent missing barrier.

Tests are added to `velox_wave_exec_test` on the existing wavemock / `Values` infrastructure, so this PR carries no dependency on the Parquet reader. Each was confirmed to fail against the unfixed code: `blockSizeMultiple` returns 768 of 1024 rows, `groupedSum` returns 0 of 256 groups, `nullableValues` mismatches 767 rows, `emptySplit` segfaults, `shardedStaging` stages 4,000,032 bytes across 8 shards and returns all 200,000 values wrong, and `ungroupedSum` overcounts from 11 accumulators up. The mock writer gains a small empty-stripe case so a zero-row split can be expressed at all. `AggregationTest.cpp` already existed but was not in the build, so the aggregation tests come with a one-line `CMakeLists.txt` addition; its fixture also had to restore the base `TearDown()`, which the existing fixture suppresses, leaving the periodic stats reporter running and making every subsequent `SetUp()` throw.

On the relationship to #18308 (Wave build warnings and out-of-bounds kernel accesses): the barrier in item 5 makes the two PRs overlap in `exec/Accumulators.cuh` and `jit/Headers.h`, which were previously disjoint. #18308 changes a bound roughly ten lines above the new barrier in the same `sumReduce` function. The two hunks share no context and merge cleanly in either order — this change was developed and tested on a tree with #18308 merged in, and applies cleanly to the pre-#18308 form of both files as well — so whoever merges second should expect no conflict. The other seven files remain disjoint from #18308.

## Checklist

* All velox-wave tests pass
* I am familiar with the contributing guide and code of conduct
