### PR TITLE
perf(function): Add dictionary-encoding fast path to MakeRowFromMap (#18313)

### DIFF
--- a/velox/functions/lib/MakeRowFromMap.h
+++ b/velox/functions/lib/MakeRowFromMap.h
@@ -114,6 +114,13 @@ struct MakeRowFromMapOptions {
 
   /// If true, duplicate keys are allowed and the last value is used.
   bool throwOnDuplicateKeys{true};
+
+  /// If true, each projected field is produced as a dictionary vector that
+  /// references the map's value vector directly instead of deep-copying the
+  /// projected values. Only applied when 'replaceNulls', 'allowTopLevelNulls',
+  /// and 'throwOnDuplicateKeys' are all false; otherwise the values are copied
+  /// as usual.
+  bool useDictionaryEncoding{false};
 };
 
 ///  A utility class for projecting specific keys from a vector of MAP type
@@ -143,6 +150,7 @@ class MakeRowFromMap {
       : replaceNulls_(options.replaceNulls),
         allowTopLevelNulls_(options.allowTopLevelNulls),
         throwOnDuplicateKeys_(options.throwOnDuplicateKeys),
+        useDictionaryEncoding_(options.useDictionaryEncoding),
         outputFieldNames_(options.outputFieldNames),
         inputKeyType_(options.keysToProject->type()) {
     VELOX_USER_CHECK_NOT_NULL(options.keysToProject);
@@ -213,6 +221,71 @@ class MakeRowFromMap {
     auto* offsets = mapBase->rawOffsets();
     auto* sizes = mapBase->rawSizes();
     auto outputSize = rows.end();
+
+    // Fast path: when values are neither null-replaced nor top-level-nullable
+    // and duplicate keys are tolerated, avoid deep-copying the projected
+    // values. Each output field is produced as a dictionary vector that
+    // references the map's value vector directly, with a per-field indices
+    // buffer pointing at the matching entry and a nulls buffer marking rows
+    // without a matching (non-null) value.
+    if (useDictionaryEncoding_ && !replaceNulls_ && !allowTopLevelNulls_ &&
+        !throwOnDuplicateKeys_) {
+      const auto numFields = keyToIndex_.size();
+      auto* valuesPool = mapBase->pool();
+      const auto& valuesVector =
+          BaseVector::loadedVectorShared(mapBase->mapValues());
+
+      std::vector<BufferPtr> indicesBuffers(numFields);
+      std::vector<BufferPtr> nullsBuffers(numFields);
+      std::vector<vector_size_t*> rawIndices(numFields);
+      std::vector<uint64_t*> rawFieldNulls(numFields);
+      for (size_t field = 0; field < numFields; ++field) {
+        indicesBuffers[field] = allocateIndices(outputSize, valuesPool);
+        nullsBuffers[field] =
+            allocateNulls(outputSize, valuesPool, bits::kNull);
+        rawIndices[field] = indicesBuffers[field]->asMutable<vector_size_t>();
+        rawFieldNulls[field] = nullsBuffers[field]->asMutable<uint64_t>();
+      }
+
+      rows.applyToSelected([&](vector_size_t row) {
+        if (decodedMap->isNullAt(row)) {
+          return;
+        }
+        auto decodedIndex = decodedMap->index(row);
+        auto offset = offsets[decodedIndex];
+        auto size = sizes[decodedIndex];
+        for (auto i = offset; i < offset + size; ++i) {
+          if (decodedKeys->isNullAt(i) || decodedValues->isNullAt(i)) {
+            continue;
+          }
+          auto it = keyToIndex_.find(decodedKeys->valueAt<KeyType>(i));
+          if (it == keyToIndex_.end()) {
+            continue;
+          }
+          auto index = it->second;
+          rawIndices[index][row] = i;
+          bits::clearNull(rawFieldNulls[index], row);
+        }
+      });
+
+      std::vector<VectorPtr> children;
+      children.reserve(numFields);
+      for (size_t field = 0; field < numFields; ++field) {
+        children.push_back(
+            BaseVector::wrapInDictionary(
+                std::move(nullsBuffers[field]),
+                std::move(indicesBuffers[field]),
+                outputSize,
+                valuesVector));
+      }
+
+      return std::make_shared<RowVector>(
+          vector.pool(),
+          ROW(outputFieldNames_, valueType),
+          nullptr,
+          outputSize,
+          std::move(children));
+    }
 
     std::vector<VectorPtr> children;
     children.reserve(keyToIndex_.size());
@@ -310,6 +383,7 @@ class MakeRowFromMap {
   const bool replaceNulls_{false};
   const bool allowTopLevelNulls_{false};
   const bool throwOnDuplicateKeys_{true};
+  const bool useDictionaryEncoding_{false};
   const std::vector<std::string> outputFieldNames_;
   const TypePtr inputKeyType_;
   folly::F14FastMap<KeyType, size_t> keyToIndex_;

--- a/velox/functions/lib/tests/MakeRowFromMapTest.cpp
+++ b/velox/functions/lib/tests/MakeRowFromMapTest.cpp
@@ -353,6 +353,64 @@ class MakeRowFroMapTest : public testing::Test, public test::VectorTestBase {
     }
   }
 
+  // Verifies the 'useDictionaryEncoding' fast path against the deep-copy slow
+  // path for the fast-path-eligible config (replaceNulls, allowTopLevelNulls
+  // and throwOnDuplicateKeys all false). Projects 'input' twice, once with
+  // useDictionaryEncoding=true and once with the default false, and asserts the
+  // two RowVectors are equal for every selectivity pattern. Also confirms the
+  // fast-path children are dictionary-encoded so the test cannot silently pass
+  // on the slow path.
+  void verifyDictionaryEncodingFastPath(const BaseVector& input) {
+    auto keysToProject = makeFlatVector<int64_t>({1, 2});
+    auto outputFieldNames = std::vector<std::string>{"key1", "key2"};
+    MakeRowFromMapOptions slowOptions{
+        .keysToProject = keysToProject,
+        .outputFieldNames = outputFieldNames,
+        .replaceNulls = false,
+        .allowTopLevelNulls = false,
+        .throwOnDuplicateKeys = false,
+        .useDictionaryEncoding = false};
+    MakeRowFromMapOptions fastOptions = slowOptions;
+    fastOptions.useDictionaryEncoding = true;
+
+    for (std::string selectedRowsStr :
+         {"all", "start", "end", "mid", "scattered"}) {
+      for (bool useEvalCtx : {false, true}) {
+        SCOPED_TRACE(
+            "Selected Rows: " + selectedRowsStr +
+            " useEvalCtx: " + std::to_string(useEvalCtx) +
+            " InputType: " + input.type()->toString() + " InputEncoding: " +
+            std::to_string(static_cast<int>(input.encoding())));
+        auto rows = createSelectivityVector(input.size(), selectedRowsStr);
+
+        VectorPtr slowResult;
+        VectorPtr fastResult;
+        if (useEvalCtx) {
+          exec::EvalCtx evalCtx(
+              execCtx_.get(), &dummyExprSet, dummyRowVector.get());
+          slowResult =
+              toRowVector<TypeKind::BIGINT>(input, slowOptions, rows, &evalCtx);
+          fastResult =
+              toRowVector<TypeKind::BIGINT>(input, fastOptions, rows, &evalCtx);
+        } else {
+          slowResult = toRowVector<TypeKind::BIGINT>(input, slowOptions, rows);
+          fastResult = toRowVector<TypeKind::BIGINT>(input, fastOptions, rows);
+        }
+
+        // The dictionary-wrapped output must be equivalent to the deep-copy
+        // output over the selected rows.
+        test::assertEqualVectors(slowResult, fastResult, rows);
+
+        // Ensure the fast path actually produced dictionary-encoded children.
+        auto* fastRow = fastResult->as<RowVector>();
+        ASSERT_NE(fastRow, nullptr);
+        for (const auto& child : fastRow->children()) {
+          ASSERT_EQ(child->encoding(), VectorEncoding::Simple::DICTIONARY);
+        }
+      }
+    }
+  }
+
   std::shared_ptr<core::QueryCtx> queryCtx_{velox::core::QueryCtx::create()};
   std::unique_ptr<core::ExecCtx> execCtx_{
       std::make_unique<core::ExecCtx>(pool_.get(), queryCtx_.get())};
@@ -594,6 +652,59 @@ TEST_F(MakeRowFroMapTest, duplicateKey) {
   options.throwOnDuplicateKeys = true;
   result = toRowVector<TypeKind::BIGINT>(*testCase, options, rows);
   test::assertEqualVectors(expected, result, rows);
+}
+
+TEST_F(MakeRowFroMapTest, dictionaryEncoding) {
+  EXPECT_EQ(NonPOD::alive, 0);
+  auto testCases = makeTestCases();
+  for (auto& testCase : testCases) {
+    verifyDictionaryEncodingFastPath(*testCase);
+  }
+  testCases.clear();
+  EXPECT_EQ(NonPOD::alive, 0);
+}
+
+TEST_F(MakeRowFroMapTest, dictionaryEncodingEncodedInputs) {
+  EXPECT_EQ(NonPOD::alive, 0);
+  auto testCases = makeTestCases();
+  auto reverseIndices = makeIndicesInReverse(testCases[0]->size());
+  auto reverseElementIndices =
+      makeIndicesInReverse(testCases[0]->mapKeys()->size());
+
+  // Wrap the top level map with a dictionary and a constant encoding.
+  for (auto& testCase : testCases) {
+    auto dictOnMap = BaseVector::wrapInDictionary(
+        nullptr, reverseIndices, testCase->size(), testCase);
+    verifyDictionaryEncodingFastPath(*dictOnMap);
+
+    auto constOnMap =
+        BaseVector::wrapInConstant(testCase->size(), 0, dictOnMap);
+    verifyDictionaryEncodingFastPath(*constOnMap);
+  }
+
+  // Wrap the keys and values with a dictionary encoding.
+  for (auto& testCase : testCases) {
+    auto elementsSizes = testCase->mapValues()->size();
+    auto dictKeys = BaseVector::wrapInDictionary(
+        nullptr, reverseElementIndices, elementsSizes, testCase->mapKeys());
+    auto dictValues = BaseVector::wrapInDictionary(
+        nullptr, reverseElementIndices, elementsSizes, testCase->mapValues());
+    testCase->setKeysAndValues(dictKeys, dictValues);
+    verifyDictionaryEncodingFastPath(*testCase);
+  }
+  testCases.clear();
+  EXPECT_EQ(NonPOD::alive, 0);
+}
+
+TEST_F(MakeRowFroMapTest, dictionaryEncodingDuplicateKeys) {
+  // makeTestCases() maps contain no duplicate keys, so exercise the fast
+  // path's last-value-wins branch explicitly and confirm it matches the
+  // deep-copy slow path.
+  auto testCase = makeMapVector<int64_t, int64_t>({
+      {{1, 1}, {2, 2}, {2, 3}},
+      {{1, 10}, {2, 20}, {3, 30}},
+  });
+  verifyDictionaryEncodingFastPath(*testCase);
 }
 
 class MakeRowFromMapDefaultsTest : public testing::Test,


### PR DESCRIPTION
Summary:

This diff is created by PerfAICT to optimize `facebook::koski::scribe::generateConvertor::{lambda#1}::operator()` in "fbcode/koski/connect/scribe/common/FeatureProjectionConverter.cpp", by reducing CPU cycles spent in this function.

### Optimization Details

Added an opt-in `useDictionaryEncoding` option to `MakeRowFromMapOptions` (default false, so existing velox callers and tests are unaffected). When enabled together with `replaceNulls`, `allowTopLevelNulls`, and `throwOnDuplicateKeys` all false, `MakeRowFromMap::toRowVectorImpl` produces each projected field as a dictionary vector that references the map's existing value vector through per-field indices and nulls buffers, instead of allocating fresh flat child vectors, null-filling them, and deep-copying values via `ArrayVector::copyRanges`. The fast path preserves identical logical output: last-value-wins on duplicate keys, null output where a key is missing or its value is null, and null maps yielding all-null fields. The flag is enabled in koski's `generateConvertor` so the projection converter avoids the per-element deep copy while keeping the unchanged slow path for null-padding columns.

Differential Revision: D113632417


