### PR TITLE
feat(datetime): Add at_timezone_convert (#18314)

### DIFF
--- a/velox/core/QueryConfig.cpp
+++ b/velox/core/QueryConfig.cpp
@@ -35,6 +35,7 @@ const std::vector<config::ConfigProperty>& QueryConfig::registeredProperties() {
     VELOX_REGISTER_QUERY_CONFIG(kSessionTimezone);
     VELOX_REGISTER_QUERY_CONFIG(kSessionStartTime);
     VELOX_REGISTER_QUERY_CONFIG(kAdjustTimestampToTimezone);
+    VELOX_REGISTER_QUERY_CONFIG(kLegacyTimestampWithTimezone);
 
     // Expression evaluation.
     VELOX_REGISTER_QUERY_CONFIG(kExprEvalSimplified);

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -127,6 +127,19 @@ class QueryConfig {
       false,
       "Adjust timezone-less timestamp conversions to session timezone.")
 
+  /// If true (default), functions that read a TIMESTAMP WITH TIME ZONE (field
+  /// extraction, formatting, and date arithmetic, including the interval +/-
+  /// operators) render each value in its own embedded zone (legacy behavior).
+  /// If false, they render the UTC instant in the session timezone, so equal
+  /// values produce equal results. Does not cover CAST yet.
+  VELOX_QUERY_CONFIG(
+      kLegacyTimestampWithTimezone,
+      legacyTimestampWithTimezone,
+      "legacy_timestamp_with_timezone",
+      bool,
+      true,
+      "Render TIMESTAMP WITH TIME ZONE values in each value's embedded zone (true) or the session timezone (false).")
+
   /// Whether to use the simplified expression evaluation path. False by
   /// default.
   VELOX_QUERY_CONFIG(

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -127,6 +127,18 @@ class QueryConfig {
       false,
       "Adjust timezone-less timestamp conversions to session timezone.")
 
+  /// If true, functions that read a TIMESTAMP WITH TIME ZONE render each value
+  /// in its own embedded time zone (legacy behavior). If false, they render the
+  /// UTC instant in the session time zone, so values that compare equal produce
+  /// equal results.
+  VELOX_QUERY_CONFIG(
+      kLegacyTimestampWithTimezone,
+      legacyTimestampWithTimezone,
+      "legacy_timestamp_with_timezone",
+      bool,
+      true,
+      "Render TIMESTAMP WITH TIME ZONE values in each value's embedded zone (true) or the session timezone (false).")
+
   /// Whether to use the simplified expression evaluation path. False by
   /// default.
   VELOX_QUERY_CONFIG(

--- a/velox/core/tests/QueryConfigTest.cpp
+++ b/velox/core/tests/QueryConfigTest.cpp
@@ -301,6 +301,33 @@ TEST_F(QueryConfigTest, singleSourceExchangeOptimizationConfig) {
   }
 }
 
+TEST_F(QueryConfigTest, legacyTimestampWithTimezone) {
+  // Defaults to legacy rendering, so enabling the config is opt-in.
+  {
+    auto queryCtx = QueryCtx::create(nullptr, QueryConfig{{}});
+    const QueryConfig& config = queryCtx->queryConfig();
+    EXPECT_TRUE(config.legacyTimestampWithTimezone());
+  }
+
+  {
+    std::unordered_map<std::string, std::string> configData(
+        {{QueryConfig::kLegacyTimestampWithTimezone, "false"}});
+    auto queryCtx =
+        QueryCtx::create(nullptr, QueryConfig{std::move(configData)});
+    const QueryConfig& config = queryCtx->queryConfig();
+    EXPECT_FALSE(config.legacyTimestampWithTimezone());
+  }
+
+  {
+    std::unordered_map<std::string, std::string> configData(
+        {{QueryConfig::kLegacyTimestampWithTimezone, "true"}});
+    auto queryCtx =
+        QueryCtx::create(nullptr, QueryConfig{std::move(configData)});
+    const QueryConfig& config = queryCtx->queryConfig();
+    EXPECT_TRUE(config.legacyTimestampWithTimezone());
+  }
+}
+
 TEST_F(QueryConfigTest, operatorSpillFileCreateConfig) {
   // Test default values (empty strings)
   {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -72,6 +72,14 @@ Generic Configuration
        supplied "America/Los_Angeles", then "1970-01-01" will be converted to -28800 instead of 0. Similarly, timestamp
        to date conversions will adhere to user 'session_timezone', e.g: Timestamp(0) to Date will be -1 (number of days
        since epoch) for "America/Los_Angeles".
+   * - legacy_timestamp_with_timezone
+     - bool
+     - true
+     - If true, functions that read a TIMESTAMP WITH TIME ZONE render each value in its own embedded timezone. If false,
+       they render it in the session timezone, so values that compare equal produce equal results. Covers field
+       extraction, formatting, and date arithmetic, including the interval ``+`` and ``-`` operators. Of the interval
+       operators only ``INTERVAL YEAR TO MONTH`` is affected; ``INTERVAL DAY TO SECOND`` operates on milliseconds and
+       never consults a timezone.
    * - track_operator_cpu_usage
      - bool
      - true

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -72,6 +72,15 @@ Generic Configuration
        supplied "America/Los_Angeles", then "1970-01-01" will be converted to -28800 instead of 0. Similarly, timestamp
        to date conversions will adhere to user 'session_timezone', e.g: Timestamp(0) to Date will be -1 (number of days
        since epoch) for "America/Los_Angeles".
+   * - legacy_timestamp_with_timezone
+     - bool
+     - true
+     - Selects the time zone used to render a TIMESTAMP WITH TIME ZONE value. If true, each value renders in its own
+       embedded time zone. If false, values render the UTC instant in the session time zone, so values that compare
+       equal produce equal results. Covers field extraction, formatting, date arithmetic, and ``CAST`` to ``VARCHAR``,
+       ``DATE`` and ``TIME``. Of the interval operators only ``INTERVAL YEAR TO MONTH`` is affected; ``INTERVAL DAY TO
+       SECOND`` operates on milliseconds and never consults a time zone. ``CAST`` to ``TIMESTAMP`` is governed by
+       ``adjust_timestamp_to_session_timezone``.
    * - track_operator_cpu_usage
      - bool
      - true

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -105,6 +105,7 @@ std::unordered_map<std::string, std::shared_ptr<ExprTransformer>>
 std::unordered_map<std::string, std::shared_ptr<ArgValuesGenerator>>
     argValuesGenerators = {
         {"at_timezone", std::make_shared<AtTimezoneArgValuesGenerator>()},
+        {"at_timezone_v2", std::make_shared<AtTimezoneArgValuesGenerator>()},
         {"cast", std::make_shared<CastVarcharAndJsonArgValuesGenerator>()},
         {"json_parse", std::make_shared<JsonParseArgValuesGenerator>()},
         {"json_extract", std::make_shared<JsonExtractArgValuesGenerator>()},

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -118,6 +118,8 @@ std::unordered_map<std::string, std::shared_ptr<ExprTransformer>>
 std::unordered_map<std::string, std::shared_ptr<ArgValuesGenerator>>
     argValuesGenerators = {
         {"at_timezone", std::make_shared<AtTimezoneArgValuesGenerator>()},
+        {"at_timezone_convert",
+         std::make_shared<AtTimezoneArgValuesGenerator>()},
         {"cast", std::make_shared<CastVarcharAndJsonArgValuesGenerator>()},
         {"json_parse", std::make_shared<JsonParseArgValuesGenerator>()},
         {"json_extract", std::make_shared<JsonExtractArgValuesGenerator>()},

--- a/velox/expression/fuzzer/PrestoSkippedFunctions.cpp
+++ b/velox/expression/fuzzer/PrestoSkippedFunctions.cpp
@@ -200,6 +200,7 @@ const std::unordered_set<std::string>& prestoSkippedFunctionsSOT() {
       "map_update", // Velox-only function, not available in Presto
       "map_trim_values", // Velox-only function, not available in Presto
       "map_subset_key_in_range", // Velox-only function, not available in Presto
+      "at_timezone_v2", // Velox-only function, not available in Presto
       "noisy_empty_approx_set_sfm", // non-deterministic because of privacy.
       // https://github.com/facebookincubator/velox/issues/11034
       "cast(real) -> varchar",

--- a/velox/expression/fuzzer/PrestoSkippedFunctions.cpp
+++ b/velox/expression/fuzzer/PrestoSkippedFunctions.cpp
@@ -200,6 +200,7 @@ const std::unordered_set<std::string>& prestoSkippedFunctionsSOT() {
       "map_update", // Velox-only function, not available in Presto
       "map_trim_values", // Velox-only function, not available in Presto
       "map_subset_key_in_range", // Velox-only function, not available in Presto
+      "at_timezone_convert", // Velox-only function, not available in Presto
       "noisy_empty_approx_set_sfm", // non-deterministic because of privacy.
       // https://github.com/facebookincubator/velox/issues/11034
       "cast(real) -> varchar",

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -1966,6 +1966,78 @@ struct AtTimezoneFunction : public TimestampWithTimezoneSupport<T> {
   }
 };
 
+/// at_timezone_v2(TIMESTAMP WITH TIME ZONE, varchar) -> TIMESTAMP
+/// Converts the UTC instant to the wall clock in the target zone and drops the
+/// zone, producing a naive timestamp.
+template <typename T>
+struct AtTimezoneV2ToTimestampFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  // Target zone when the timezone argument is constant; null otherwise.
+  const tz::TimeZone* targetTimeZone_{nullptr};
+
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& /*config*/,
+      const arg_type<TimestampWithTimezone>* /*timestampWithTimezone*/,
+      const arg_type<Varchar>* timezone) {
+    if (timezone) {
+      targetTimeZone_ =
+          tz::locateZone(std::string_view(timezone->data(), timezone->size()));
+    }
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Timestamp>& result,
+      const arg_type<TimestampWithTimezone>& timestampWithTimezone,
+      const arg_type<Varchar>& timezone) {
+    const auto* targetTimeZone = targetTimeZone_ != nullptr
+        ? targetTimeZone_
+        : tz::locateZone(std::string_view(timezone.data(), timezone.size()));
+
+    Timestamp timestamp = unpackTimestampUtc(*timestampWithTimezone);
+    timestamp.toTimezone(*targetTimeZone);
+    result = timestamp;
+  }
+};
+
+/// at_timezone_v2(TIMESTAMP, varchar) -> TIMESTAMP WITH TIME ZONE
+/// Interprets the naive wall clock as being in the target zone and returns the
+/// UTC instant tagged with that zone.
+/// A DST spring-forward gap fails; a fall-back overlap resolves to the earliest
+/// instant.
+template <typename T>
+struct AtTimezoneV2ToTimestampWithTimezoneFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  // Target zone when the timezone argument is constant; null otherwise.
+  const tz::TimeZone* targetTimeZone_{nullptr};
+
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& /*config*/,
+      const arg_type<Timestamp>* /*timestamp*/,
+      const arg_type<Varchar>* timezone) {
+    if (timezone) {
+      targetTimeZone_ =
+          tz::locateZone(std::string_view(timezone->data(), timezone->size()));
+    }
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<TimestampWithTimezone>& result,
+      const arg_type<Timestamp>& timestamp,
+      const arg_type<Varchar>& timezone) {
+    const auto* targetTimeZone = targetTimeZone_ != nullptr
+        ? targetTimeZone_
+        : tz::locateZone(std::string_view(timezone.data(), timezone.size()));
+
+    Timestamp utcTime = timestamp;
+    utcTime.toGMT(*targetTimeZone);
+    result = pack(utcTime.toMillis(), targetTimeZone->id());
+  }
+};
+
 template <typename T>
 struct AtTimezoneTimeWithTimezoneFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -1964,6 +1964,78 @@ struct AtTimezoneFunction : public TimestampWithTimezoneSupport<T> {
   }
 };
 
+/// at_timezone_convert(TIMESTAMP WITH TIME ZONE, varchar) -> TIMESTAMP
+/// Converts the UTC instant to the wall clock in the target zone and drops the
+/// zone, producing a naive timestamp.
+template <typename T>
+struct AtTimezoneConvertToTimestampFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  // Target zone when the timezone argument is constant; null otherwise.
+  const tz::TimeZone* targetTimeZone_{nullptr};
+
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& /*config*/,
+      const arg_type<TimestampWithTimezone>* /*timestampWithTimezone*/,
+      const arg_type<Varchar>* timezone) {
+    if (timezone) {
+      targetTimeZone_ =
+          tz::locateZone(std::string_view(timezone->data(), timezone->size()));
+    }
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Timestamp>& result,
+      const arg_type<TimestampWithTimezone>& timestampWithTimezone,
+      const arg_type<Varchar>& timezone) {
+    const auto* targetTimeZone = targetTimeZone_ != nullptr
+        ? targetTimeZone_
+        : tz::locateZone(std::string_view(timezone.data(), timezone.size()));
+
+    Timestamp timestamp = unpackTimestampUtc(*timestampWithTimezone);
+    timestamp.toTimezone(*targetTimeZone);
+    result = timestamp;
+  }
+};
+
+/// at_timezone_convert(TIMESTAMP, varchar) -> TIMESTAMP WITH TIME ZONE
+/// Interprets the naive wall clock as being in the target zone and returns the
+/// UTC instant tagged with that zone.
+/// A DST spring-forward gap fails; a fall-back overlap resolves to the earliest
+/// instant.
+template <typename T>
+struct AtTimezoneConvertToTimestampWithTimezoneFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  // Target zone when the timezone argument is constant; null otherwise.
+  const tz::TimeZone* targetTimeZone_{nullptr};
+
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& /*config*/,
+      const arg_type<Timestamp>* /*timestamp*/,
+      const arg_type<Varchar>* timezone) {
+    if (timezone) {
+      targetTimeZone_ =
+          tz::locateZone(std::string_view(timezone->data(), timezone->size()));
+    }
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<TimestampWithTimezone>& result,
+      const arg_type<Timestamp>& timestamp,
+      const arg_type<Varchar>& timezone) {
+    const auto* targetTimeZone = targetTimeZone_ != nullptr
+        ? targetTimeZone_
+        : tz::locateZone(std::string_view(timezone.data(), timezone.size()));
+
+    Timestamp utcTime = timestamp;
+    utcTime.toGMT(*targetTimeZone);
+    result = pack(utcTime, targetTimeZone->id());
+  }
+};
+
 template <typename T>
 struct AtTimezoneTimeWithTimezoneFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -334,6 +334,26 @@ void registerSimpleFunctions(const std::string& prefix) {
       TimeWithTimezone,
       Varchar>({prefix + "at_timezone"});
 
+  registerFunction<
+      AtTimezoneV2ToTimestampFunction,
+      Timestamp,
+      TimestampWithTimezone,
+      Varchar>({prefix + "at_timezone_v2"});
+
+  registerFunction<
+      AtTimezoneV2ToTimestampWithTimezoneFunction,
+      TimestampWithTimezone,
+      Timestamp,
+      Varchar>({prefix + "at_timezone_v2"});
+
+  // TIME WITH TIME ZONE has no naive/zoned distinction, so at_timezone_v2
+  // deliberately reuses at_timezone's implementation.
+  registerFunction<
+      AtTimezoneTimeWithTimezoneFunction,
+      TimeWithTimezone,
+      TimeWithTimezone,
+      Varchar>({prefix + "at_timezone_v2"});
+
   registerFunction<ToMillisecondFunction, int64_t, IntervalDayTime>(
       {prefix + "to_milliseconds"});
 

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -334,6 +334,26 @@ void registerSimpleFunctions(const std::string& prefix) {
       TimeWithTimezone,
       Varchar>({prefix + "at_timezone"});
 
+  registerFunction<
+      AtTimezoneConvertToTimestampFunction,
+      Timestamp,
+      TimestampWithTimezone,
+      Varchar>({prefix + "at_timezone_convert"});
+
+  registerFunction<
+      AtTimezoneConvertToTimestampWithTimezoneFunction,
+      TimestampWithTimezone,
+      Timestamp,
+      Varchar>({prefix + "at_timezone_convert"});
+
+  // Reuses at_timezone's implementation, which accepts only a +HH:mm offset,
+  // not a named zone as the signatures above do.
+  registerFunction<
+      AtTimezoneTimeWithTimezoneFunction,
+      TimeWithTimezone,
+      TimeWithTimezone,
+      Varchar>({prefix + "at_timezone_convert"});
+
   registerFunction<ToMillisecondFunction, int64_t, IntervalDayTime>(
       {prefix + "to_milliseconds"});
 

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -6330,6 +6330,147 @@ TEST_F(DateTimeFunctionsTest, atTimezoneTest) {
   EXPECT_EQ(at_timezone(std::nullopt, "Pacific/Fiji"), std::nullopt);
 }
 
+TEST_F(DateTimeFunctionsTest, atTimezoneV2Test) {
+  const auto toTimestamp = [&](std::optional<int64_t> timestampWithTimezone,
+                               std::optional<std::string> targetTimezone) {
+    return evaluateOnce<Timestamp>(
+        "at_timezone_v2(c0, c1)",
+        {TIMESTAMP_WITH_TIME_ZONE(), VARCHAR()},
+        timestampWithTimezone,
+        std::move(targetTimezone));
+  };
+
+  const auto toTimestampWithTimezone =
+      [&](std::optional<Timestamp> timestamp,
+          std::optional<std::string> targetTimezone) {
+        return evaluateOnce<int64_t>(
+            "at_timezone_v2(c0, c1)",
+            {TIMESTAMP(), VARCHAR()},
+            timestamp,
+            std::move(targetTimezone));
+      };
+
+  // 2024-01-01 08:00 UTC is 2024-01-01 00:00 in Los Angeles (PST, -08:00).
+  const auto winterInstant = parseTimestamp("2024-01-01 08:00:00").toMillis();
+  EXPECT_EQ(
+      toTimestamp(
+          pack(winterInstant, tz::getTimeZoneID("UTC")), "America/Los_Angeles"),
+      parseTimestamp("2024-01-01 00:00:00"));
+  // The source zone tagged on the input is ignored; only the UTC instant
+  // matters.
+  EXPECT_EQ(
+      toTimestamp(
+          pack(winterInstant, tz::getTimeZoneID("America/New_York")),
+          "America/Los_Angeles"),
+      parseTimestamp("2024-01-01 00:00:00"));
+
+  EXPECT_EQ(
+      toTimestampWithTimezone(
+          parseTimestamp("2024-01-01 00:00:00"), "America/Los_Angeles"),
+      pack(winterInstant, tz::getTimeZoneID("America/Los_Angeles")));
+
+  const auto original = parseTimestamp("2024-06-15 12:34:56");
+  EXPECT_EQ(
+      toTimestamp(
+          toTimestampWithTimezone(original, "America/Los_Angeles").value(),
+          "America/Los_Angeles"),
+      original);
+
+  // Daylight saving shifts the Los Angeles offset to -07:00 in summer, so
+  // 2024-07-01 08:00 UTC is 2024-07-01 01:00 local.
+  EXPECT_EQ(
+      toTimestamp(
+          pack(
+              parseTimestamp("2024-07-01 08:00:00").toMillis(),
+              tz::getTimeZoneID("UTC")),
+          "America/Los_Angeles"),
+      parseTimestamp("2024-07-01 01:00:00"));
+
+  // The reverse overload also honors summer DST: 2024-07-01 01:00 local in Los
+  // Angeles (PDT, -07:00) is 2024-07-01 08:00 UTC.
+  EXPECT_EQ(
+      toTimestampWithTimezone(
+          parseTimestamp("2024-07-01 01:00:00"), "America/Los_Angeles"),
+      pack(
+          parseTimestamp("2024-07-01 08:00:00").toMillis(),
+          tz::getTimeZoneID("America/Los_Angeles")));
+
+  // A null timestamp or null zone propagates as null in both overloads.
+  EXPECT_EQ(toTimestamp(std::nullopt, "America/Los_Angeles"), std::nullopt);
+  EXPECT_EQ(
+      toTimestamp(pack(winterInstant, tz::getTimeZoneID("UTC")), std::nullopt),
+      std::nullopt);
+  EXPECT_EQ(
+      toTimestampWithTimezone(std::nullopt, "America/Los_Angeles"),
+      std::nullopt);
+  EXPECT_EQ(
+      toTimestampWithTimezone(
+          parseTimestamp("2024-01-01 00:00:00"), std::nullopt),
+      std::nullopt);
+
+  // A non-constant zone column exercises the per-row zone lookup: the same UTC
+  // instant maps to 00:00 in Los Angeles (PST, -08:00) and 03:00 in New York
+  // (EST, -05:00).
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>(
+          {pack(winterInstant, tz::getTimeZoneID("UTC")),
+           pack(winterInstant, tz::getTimeZoneID("UTC"))},
+          TIMESTAMP_WITH_TIME_ZONE()),
+      makeFlatVector<std::string>({"America/Los_Angeles", "America/New_York"}),
+  });
+  auto result = evaluate("at_timezone_v2(c0, c1)", data);
+  auto expected = makeFlatVector<Timestamp>({
+      parseTimestamp("2024-01-01 00:00:00"),
+      parseTimestamp("2024-01-01 03:00:00"),
+  });
+  assertEqualVectors(expected, result);
+
+  // A wall clock that falls in the spring-forward gap does not exist in the
+  // zone, so the conversion fails. 2024-03-10 02:30 is skipped in Los Angeles.
+  VELOX_ASSERT_THROW(
+      toTimestampWithTimezone(
+          parseTimestamp("2024-03-10 02:30:00"), "America/Los_Angeles"),
+      "is in a gap between");
+
+  // A wall clock in the fall-back overlap is ambiguous; Velox resolves it to
+  // the earliest instant (PDT, -07:00), so 2024-11-03 01:30 local is
+  // 2024-11-03 08:30 UTC.
+  EXPECT_EQ(
+      toTimestampWithTimezone(
+          parseTimestamp("2024-11-03 01:30:00"), "America/Los_Angeles"),
+      pack(
+          parseTimestamp("2024-11-03 08:30:00").toMillis(),
+          tz::getTimeZoneID("America/Los_Angeles")));
+
+  // An unrecognized target zone throws on both the constant and per-row paths.
+  VELOX_ASSERT_THROW(
+      toTimestamp(pack(winterInstant, tz::getTimeZoneID("UTC")), "Not/AZone"),
+      "Unknown time zone");
+  auto invalidZoneData = makeRowVector({
+      makeFlatVector<int64_t>(
+          {pack(winterInstant, tz::getTimeZoneID("UTC"))},
+          TIMESTAMP_WITH_TIME_ZONE()),
+      makeFlatVector<std::string>({"Not/AZone"}),
+  });
+  VELOX_ASSERT_THROW(
+      evaluate("at_timezone_v2(c0, c1)", invalidZoneData), "Unknown time zone");
+}
+
+TEST_F(DateTimeFunctionsTest, atTimezoneV2TimeWithTimezoneTest) {
+  // TIME WITH TIME ZONE shares at_timezone's implementation, so this guards the
+  // registration under the v2 name rather than the conversion itself.
+  const auto makeTimeWithTz = [](const std::string& time) -> int64_t {
+    return util::fromTimeWithTimezoneString(time.data(), time.size()).value();
+  };
+  EXPECT_EQ(
+      evaluateOnce<int64_t>(
+          "at_timezone_v2(c0, c1)",
+          {TIME_WITH_TIME_ZONE(), VARCHAR()},
+          std::optional<int64_t>(makeTimeWithTz("10:30:00+05:30")),
+          std::optional<std::string>("+08:00")),
+      makeTimeWithTz("13:00:00+08:00"));
+}
+
 TEST_F(DateTimeFunctionsTest, atTimezoneTimeWithTimezoneTest) {
   using namespace facebook::velox::util;
 

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -6368,6 +6368,173 @@ TEST_F(DateTimeFunctionsTest, atTimezoneTest) {
   EXPECT_EQ(at_timezone(std::nullopt, "Pacific/Fiji"), std::nullopt);
 }
 
+TEST_F(DateTimeFunctionsTest, atTimezoneConvertTest) {
+  const auto toTimestamp = [&](std::optional<int64_t> timestampWithTimezone,
+                               std::optional<std::string> targetTimezone) {
+    return evaluateOnce<Timestamp>(
+        "at_timezone_convert(c0, c1)",
+        {TIMESTAMP_WITH_TIME_ZONE(), VARCHAR()},
+        timestampWithTimezone,
+        std::move(targetTimezone));
+  };
+
+  const auto toTimestampWithTimezone =
+      [&](std::optional<Timestamp> timestamp,
+          std::optional<std::string> targetTimezone) {
+        return evaluateOnce<int64_t>(
+            "at_timezone_convert(c0, c1)",
+            {TIMESTAMP(), VARCHAR()},
+            timestamp,
+            std::move(targetTimezone));
+      };
+
+  // 2024-01-01 08:00 UTC is 2024-01-01 00:00 in Los Angeles (PST, -08:00).
+  const auto winterInstant = parseTimestamp("2024-01-01 08:00:00").toMillis();
+  EXPECT_EQ(
+      toTimestamp(
+          pack(winterInstant, tz::getTimeZoneID("UTC")), "America/Los_Angeles"),
+      parseTimestamp("2024-01-01 00:00:00"));
+  // The source zone tagged on the input is ignored; only the UTC instant
+  // matters.
+  EXPECT_EQ(
+      toTimestamp(
+          pack(winterInstant, tz::getTimeZoneID("America/New_York")),
+          "America/Los_Angeles"),
+      parseTimestamp("2024-01-01 00:00:00"));
+
+  EXPECT_EQ(
+      toTimestampWithTimezone(
+          parseTimestamp("2024-01-01 00:00:00"), "America/Los_Angeles"),
+      pack(winterInstant, tz::getTimeZoneID("America/Los_Angeles")));
+
+  const auto original = parseTimestamp("2024-06-15 12:34:56");
+  EXPECT_EQ(
+      toTimestamp(
+          toTimestampWithTimezone(original, "America/Los_Angeles").value(),
+          "America/Los_Angeles"),
+      original);
+
+  // Daylight saving shifts the Los Angeles offset to -07:00 in summer, so
+  // 2024-07-01 08:00 UTC is 2024-07-01 01:00 local.
+  EXPECT_EQ(
+      toTimestamp(
+          pack(
+              parseTimestamp("2024-07-01 08:00:00").toMillis(),
+              tz::getTimeZoneID("UTC")),
+          "America/Los_Angeles"),
+      parseTimestamp("2024-07-01 01:00:00"));
+
+  // The reverse overload also honors summer DST: 2024-07-01 01:00 local in Los
+  // Angeles (PDT, -07:00) is 2024-07-01 08:00 UTC.
+  EXPECT_EQ(
+      toTimestampWithTimezone(
+          parseTimestamp("2024-07-01 01:00:00"), "America/Los_Angeles"),
+      pack(
+          parseTimestamp("2024-07-01 08:00:00").toMillis(),
+          tz::getTimeZoneID("America/Los_Angeles")));
+
+  // A null timestamp or null zone propagates as null in both overloads.
+  EXPECT_EQ(toTimestamp(std::nullopt, "America/Los_Angeles"), std::nullopt);
+  EXPECT_EQ(
+      toTimestamp(pack(winterInstant, tz::getTimeZoneID("UTC")), std::nullopt),
+      std::nullopt);
+  EXPECT_EQ(
+      toTimestampWithTimezone(std::nullopt, "America/Los_Angeles"),
+      std::nullopt);
+  EXPECT_EQ(
+      toTimestampWithTimezone(
+          parseTimestamp("2024-01-01 00:00:00"), std::nullopt),
+      std::nullopt);
+
+  // A literal zone is constant across the batch, so initialize() resolves and
+  // caches it; a zone column takes the per-row lookup instead. Both paths must
+  // agree.
+  EXPECT_EQ(
+      evaluateOnce<Timestamp>(
+          "at_timezone_convert(c0, 'America/Los_Angeles')",
+          {TIMESTAMP_WITH_TIME_ZONE()},
+          std::optional<int64_t>(
+              pack(winterInstant, tz::getTimeZoneID("UTC")))),
+      parseTimestamp("2024-01-01 00:00:00"));
+  EXPECT_EQ(
+      evaluateOnce<int64_t>(
+          "at_timezone_convert(c0, 'America/Los_Angeles')",
+          {TIMESTAMP()},
+          std::optional<Timestamp>(parseTimestamp("2024-01-01 00:00:00"))),
+      pack(winterInstant, tz::getTimeZoneID("America/Los_Angeles")));
+
+  // The same UTC instant maps to 00:00 in Los Angeles (PST, -08:00) and 03:00
+  // in New York (EST, -05:00).
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>(
+          {pack(winterInstant, tz::getTimeZoneID("UTC")),
+           pack(winterInstant, tz::getTimeZoneID("UTC"))},
+          TIMESTAMP_WITH_TIME_ZONE()),
+      makeFlatVector<std::string>({"America/Los_Angeles", "America/New_York"}),
+  });
+  auto result = evaluate("at_timezone_convert(c0, c1)", data);
+  auto expected = makeFlatVector<Timestamp>({
+      parseTimestamp("2024-01-01 00:00:00"),
+      parseTimestamp("2024-01-01 03:00:00"),
+  });
+  assertEqualVectors(expected, result);
+
+  // A wall clock that falls in the spring-forward gap does not exist in the
+  // zone, so the conversion fails. 2024-03-10 02:30 is skipped in Los Angeles.
+  VELOX_ASSERT_THROW(
+      toTimestampWithTimezone(
+          parseTimestamp("2024-03-10 02:30:00"), "America/Los_Angeles"),
+      "is in a gap between");
+
+  // A wall clock in the fall-back overlap is ambiguous; Velox resolves it to
+  // the earliest instant (PDT, -07:00), so 2024-11-03 01:30 local is
+  // 2024-11-03 08:30 UTC.
+  EXPECT_EQ(
+      toTimestampWithTimezone(
+          parseTimestamp("2024-11-03 01:30:00"), "America/Los_Angeles"),
+      pack(
+          parseTimestamp("2024-11-03 08:30:00").toMillis(),
+          tz::getTimeZoneID("America/Los_Angeles")));
+
+  // An unrecognized target zone throws on both paths.
+  VELOX_ASSERT_THROW(
+      toTimestamp(pack(winterInstant, tz::getTimeZoneID("UTC")), "Not/AZone"),
+      "Unknown time zone");
+  auto invalidZoneData = makeRowVector({
+      makeFlatVector<int64_t>(
+          {pack(winterInstant, tz::getTimeZoneID("UTC"))},
+          TIMESTAMP_WITH_TIME_ZONE()),
+      makeFlatVector<std::string>({"Not/AZone"}),
+  });
+  VELOX_ASSERT_THROW(
+      evaluate("at_timezone_convert(c0, c1)", invalidZoneData),
+      "Unknown time zone");
+}
+
+TEST_F(DateTimeFunctionsTest, atTimezoneConvertTimeWithTimezoneTest) {
+  // TIME WITH TIME ZONE shares at_timezone's implementation, so this guards the
+  // registration under at_timezone_convert rather than the conversion itself.
+  const auto makeTimeWithTz = [](const std::string& time) -> int64_t {
+    return util::fromTimeWithTimezoneString(time.data(), time.size()).value();
+  };
+  EXPECT_EQ(
+      evaluateOnce<int64_t>(
+          "at_timezone_convert(c0, c1)",
+          {TIME_WITH_TIME_ZONE(), VARCHAR()},
+          std::optional<int64_t>(makeTimeWithTz("10:30:00+05:30")),
+          std::optional<std::string>("+08:00")),
+      makeTimeWithTz("13:00:00+08:00"));
+
+  // Unlike the TIMESTAMP signatures, this one takes only a +HH:mm offset.
+  VELOX_ASSERT_THROW(
+      evaluateOnce<int64_t>(
+          "at_timezone_convert(c0, c1)",
+          {TIME_WITH_TIME_ZONE(), VARCHAR()},
+          std::optional<int64_t>(makeTimeWithTz("10:30:00+05:30")),
+          std::optional<std::string>("America/Los_Angeles")),
+      "Invalid timezone offset");
+}
+
 TEST_F(DateTimeFunctionsTest, atTimezoneTimeWithTimezoneTest) {
   using namespace facebook::velox::util;
 


### PR DESCRIPTION
Summary:

Add `at_timezone_convert`, which implements the SQL-standard `AT TIME ZONE` for a zoned input. Where `at_timezone` relabels the zone, `at_timezone_convert` returns the wall clock that instant shows in the target zone, as a naive timestamp.

    at_timezone_convert(TIMESTAMP WITH TIME ZONE '2024-01-01 08:00:00 UTC', 'America/Los_Angeles')
        -> TIMESTAMP '2024-01-01 00:00:00'

The zone the input carries is ignored; only its instant is used. Returning a naive timestamp makes the result depend only on the instant and the target zone, so instants that compare equal produce equal output. A separate name leaves `at_timezone` untouched for callers that still want the zoned result.

`at_timezone_convert` takes the same two input signatures as `at_timezone`: `TIMESTAMP WITH TIME ZONE` and `TIME WITH TIME ZONE`. TIME WITH TIME ZONE reuses at_timezone's implementation.

Note: the engine, not Velox casts a naive TIMESTAMP to TIMESTAMP WITH TIME ZONE fixing the instant. Velox before the call. 

Reviewed By: bikramSingh91

Differential Revision: D113628406
