### PR TITLE
fix(cudf): Use operator IDs for hash join peer probe lookup

### DIFF
--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -686,7 +686,7 @@ void CudfHashJoinProbe::doNoMoreInput() {
         if (peer.get() == operatorCtx_->driver()) {
           continue;
         }
-        auto op = peer->findOperator(planNodeId());
+        auto op = peer->findOperator(operatorCtx_->operatorId());
         auto* probe = dynamic_cast<CudfHashJoinProbe*>(op);
         if (probe != nullptr && probe->lastProbeStream_.has_value()) {
           inputStreams.push_back(probe->lastProbeStream_.value());
@@ -700,7 +700,7 @@ void CudfHashJoinProbe::doNoMoreInput() {
         if (peer.get() == operatorCtx_->driver()) {
           continue;
         }
-        auto op = peer->findOperator(planNodeId());
+        auto op = peer->findOperator(operatorCtx_->operatorId());
         auto* probe = dynamic_cast<CudfHashJoinProbe*>(op);
         if (probe == nullptr) {
           continue;
@@ -732,7 +732,7 @@ void CudfHashJoinProbe::doNoMoreInput() {
   // Handling RightSemiFilterJoin
   // Collect results from peers
   for (auto& peer : peers) {
-    auto op = peer->findOperator(planNodeId());
+    auto op = peer->findOperator(operatorCtx_->operatorId());
     auto* probe = dynamic_cast<CudfHashJoinProbe*>(op);
     VELOX_CHECK_NOT_NULL(probe);
     inputs_.insert(inputs_.end(), probe->inputs_.begin(), probe->inputs_.end());

--- a/velox/experimental/cudf/tests/BatchConcatTest.cpp
+++ b/velox/experimental/cudf/tests/BatchConcatTest.cpp
@@ -329,6 +329,52 @@ TEST_F(CudfBatchConcatTest, concatBeforeHashJoinProbe) {
       << "CudfBatchConcat should produce fewer output batches than input";
 }
 
+TEST_F(CudfBatchConcatTest, rightJoinCollectsMatchedRowsFromPeerProbes) {
+  updateCudfConfig(/*min=*/30, /*max=*/std::nullopt);
+  CudfConfig::getInstance().concatOptimizationEnabled = true;
+
+  std::vector<RowVectorPtr> probeVectors;
+  for (int i = 0; i < 6; ++i) {
+    probeVectors.push_back(makeRowVector(
+        {"c0", "c1"},
+        {makeConstant<int64_t>(i, 10), makeFlatSequence<int64_t>(i * 10, 10)}));
+  }
+  auto buildVector = makeRowVector(
+      {"u_c0"}, {makeFlatSequence<int64_t>(0, probeVectors.size())});
+
+  createDuckDbTable("probe", probeVectors);
+  createDuckDbTable("build", {buildVector});
+
+  auto generator = std::make_shared<core::PlanNodeIdGenerator>();
+  core::PlanNodeId joinNodeId;
+  auto plan = PlanBuilder(generator)
+                  .addNode([&](auto id, auto pool) {
+                    return createFragmentedSource(probeVectors, generator);
+                  })
+                  .hashJoin(
+                      {"c0"},
+                      {"u_c0"},
+                      PlanBuilder(generator).values({buildVector}).planNode(),
+                      "",
+                      {"c0", "c1", "u_c0"},
+                      core::JoinType::kRight)
+                  .capturePlanNodeId(joinNodeId)
+                  .planNode();
+
+  auto task = AssertQueryBuilder(duckDbQueryRunner_)
+                  .plan(plan)
+                  .maxDrivers(3)
+                  .assertResults(
+                      "SELECT p.c0, p.c1, b.u_c0 FROM probe p "
+                      "RIGHT JOIN build b ON p.c0 = b.u_c0");
+
+  auto planStats = toPlanStats(task->taskStats());
+  auto& nodeStats = planStats.at(joinNodeId);
+  ASSERT_NE(nodeStats.operatorStats.count("CudfBatchConcat"), 0);
+  ASSERT_NE(nodeStats.operatorStats.count("CudfHashJoinProbe"), 0);
+  ASSERT_EQ(nodeStats.operatorStats.at("CudfHashJoinProbe")->numDrivers, 3);
+}
+
 TEST_F(CudfBatchConcatTest, concatSplitsZeroColumnBatchesAtMaxThreshold) {
   updateCudfConfig(/*min=*/30, /*max=*/20);
   CudfConfig::getInstance().concatOptimizationEnabled = true;


### PR DESCRIPTION
Use physical operator IDs to find corresponding cuDF hash-probe operators across peer drivers.

The cuDF hash join adapter can insert `CudfBatchConcat` before `CudfHashJoinProbe`. Both operators share the hash join's `planNodeId`, making the previous `findOperator(planNodeId())` lookup ambiguous.

Use `operatorId` instead, which uniquely identifies the corresponding probe operator in each peer driver. 
Added a multi-driver RIGHT join regression test with batch concatenation enabled: `CudfBatchConcatTest.rightJoinCollectsMatchedRowsFromPeerProbes`