### PR TITLE
fix(dwrf): Fix flat map struct-key UAF on stringKeys_ realloc (#18319)

### DIFF
--- a/velox/dwio/dwrf/test/ColumnWriterTest.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTest.cpp
@@ -1306,6 +1306,62 @@ TEST_F(ColumnWriterTest, TestMapWriterNestedRow) {
   testMapWriterRowImpl<Row<int32_t, bool, StringView>>();
 }
 
+// With MAP_FLAT_COLS_STRUCT_KEYS the flat-map writer copies the struct keys
+// into stringKeys_ (reserved to MAP_FLAT_MAX_KEYS) in its constructor and
+// builds structKeys_ as StringViews into that buffer. writeRow() then calls
+// getValueWriter() per key, which for a non-inline (>12 char) key appends a
+// *second* copy into stringKeys_. Those extra copies push stringKeys_ past its
+// reserve(MAP_FLAT_MAX_KEYS) capacity, reallocating it mid-loop and dangling
+// the structKeys_ StringViews still being iterated -> heap-use-after-free (same
+// F14 dangling-key crash family as D96817300). Reproduces under ASAN.
+TEST_F(ColumnWriterTest, FlatMapStructKeysDanglingStringView) {
+  const auto rowType = ROW({{"c0", MAP(VARCHAR(), BIGINT())}});
+  const auto writerSchema = TypeWithId::create(rowType);
+  const auto mapColumn = writerSchema->childAt(0);
+
+  // 13-char keys: non-inline StringViews (>12 chars) whose backing std::string
+  // is still small-string-optimized (libstdc++ SSO capacity is 15). The
+  // StringView therefore points into the SSO buffer *inside* the vector
+  // element, so a stringKeys_ reallocation moves that buffer and dangles the
+  // view. (Keys >15 chars are heap-backed and would survive the realloc.) Count
+  // == MAP_FLAT_MAX_KEYS so the first getValueWriter() copy overflows
+  // stringKeys_'s reservation and reallocates it.
+  const size_t numKeys = 8;
+  std::vector<std::string> structKeys;
+  structKeys.reserve(numKeys);
+  for (size_t i = 0; i < numKeys; ++i) {
+    structKeys.push_back(fmt::format("flatmapkey_{:02d}", i)); // 13 chars
+  }
+
+  const auto config = std::make_shared<Config>();
+  config->set(Config::FLATTEN_MAP, true);
+  const std::vector<uint32_t> flatCols{mapColumn->column()};
+  config->set<const std::vector<uint32_t>>(Config::MAP_FLAT_COLS, flatCols);
+  const std::vector<std::vector<std::string>> structKeysCols{structKeys};
+  config->set<const std::vector<std::vector<std::string>>>(
+      Config::MAP_FLAT_COLS_STRUCT_KEYS, structKeysCols);
+  config->set<uint32_t>(
+      Config::MAP_FLAT_MAX_KEYS, static_cast<uint32_t>(numKeys));
+
+  WriterContext context{config, memory::memoryManager()->addRootPool()};
+  context.initBuffer();
+  const auto writer = BaseColumnWriter::create(context, *mapColumn);
+
+  // In struct-keys mode the MAP column is fed a RowVector whose children
+  // (BIGINT) correspond positionally to the struct keys.
+  VectorMaker vectorMaker{pool_.get()};
+  const vector_size_t numRows = 4;
+  std::vector<VectorPtr> children;
+  children.reserve(numKeys);
+  for (size_t i = 0; i < numKeys; ++i) {
+    children.push_back(vectorMaker.flatVector<int64_t>(
+        numRows, [](vector_size_t row) { return row; }));
+  }
+  const auto structInput = vectorMaker.rowVector(children);
+
+  writer->write(structInput, common::Ranges::of(0, numRows));
+}
+
 template <typename TKEY, typename TVALUE>
 void testMapWriter(
     MemoryPool& pool,

--- a/velox/dwio/dwrf/writer/FlatMapColumnWriter.cpp
+++ b/velox/dwio/dwrf/writer/FlatMapColumnWriter.cpp
@@ -37,8 +37,8 @@ StringView getKey<StringView>(const std::string& val) {
   return StringView(val);
 }
 
-template <typename KeyType>
-std::vector<KeyType> parseKeys(const std::vector<std::string>& stringKeys) {
+template <typename KeyType, typename StringContainer>
+std::vector<KeyType> parseKeys(const StringContainer& stringKeys) {
   std::vector<KeyType> keys(stringKeys.size());
   for (auto i = 0; i < stringKeys.size(); i++) {
     keys[i] = getKey<KeyType>(stringKeys[i]);
@@ -61,9 +61,6 @@ FlatMapColumnWriter<K>::FlatMapColumnWriter(
       valueType_{*type.childAt(1)},
       maxKeyCount_{context_.getConfig(Config::MAP_FLAT_MAX_KEYS)},
       collectMapStats_{context.getConfig(Config::MAP_STATISTICS)} {
-  if constexpr (std::is_same_v<KeyType, StringView>) {
-    stringKeys_.reserve(maxKeyCount_);
-  }
   auto options = StatisticsBuilder::optionsFromConfig(context.getConfigs());
   keyFileStatsBuilder_ =
       std::unique_ptr<typename TypeInfo<K>::StatisticsBuilder>(

--- a/velox/dwio/dwrf/writer/FlatMapColumnWriter.h
+++ b/velox/dwio/dwrf/writer/FlatMapColumnWriter.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <deque>
 #include "velox/dwio/dwrf/writer/ColumnWriter.h"
 
 namespace facebook::velox::dwrf {
@@ -342,8 +343,12 @@ class FlatMapColumnWriter : public BaseColumnWriter {
   std::unique_ptr<const ValueStatisticsBuilder> valueFileStatsBuilder_;
   const uint32_t maxKeyCount_;
 
-  // Stores column keys as string in case of StringView pointers
-  std::vector<std::string> stringKeys_;
+  // Stores column keys as string in case of StringView pointers. Uses a deque
+  // (not a vector) so that appending a newly-seen key never relocates the
+  // already-stored strings: structKeys_ and the F14 valueWriters_ keys hold
+  // StringViews pointing into these elements, and a reallocation would dangle
+  // them (e.g. SSO-backed 13-15 char keys).
+  std::deque<std::string> stringKeys_;
 
   // Stores column keys if writing with RowVector input
   std::vector<KeyType> structKeys_;


### PR DESCRIPTION
Summary:

`FlatMapColumnWriter` owns copies of non-inline map keys in a
`std::vector<std::string> stringKeys_` and hands out `StringView`s into it:
`structKeys_` (struct-keys mode) and the `valueWriters_` F14 map keys both
point into `stringKeys_` elements.

In struct-keys mode (`MAP_FLAT_COLS_STRUCT_KEYS`), the constructor pre-fills
`stringKeys_` with the configured keys, and `getValueWriter()` appends a
*second* owned copy of each non-inline key during `writeRow()`. These copies
can push `stringKeys_` past its `reserve(MAP_FLAT_MAX_KEYS)` capacity, causing
the vector to reallocate mid-`writeRow()`. The reallocation moves the stored
`std::string` elements, dangling every `StringView` that points into them.

This bites specifically for 13-15 character keys: they are non-inline
`StringView`s (> 12 chars) but their backing `std::string` is
small-string-optimized (libstdc++ SSO capacity is 15), so the character data
lives inside the `std::string` object and moves with it on reallocation. (Keys >15
chars are heap-backed, so their `StringView`s survive the move.) The
result is a heap-use-after-free read of `structKeys_[i]`, and on the next
`valueWriters_` probe the same dangling-key `folly::F14::rehashImpl` crash
family as https://github.com/facebookincubator/velox/pull/16800, which this follows up.

Fix: store the owned key strings in a `std::deque<std::string>` instead of a
`std::vector`. `std::deque::push_back` never relocates already-stored elements,
so the `StringView`s in `structKeys_` and `valueWriters_` stay valid regardless
of how many keys are appended or their length. Drops the now-unnecessary
`reserve` and templates `parseKeys` over the container.

Reviewed By: HuamengJiang

Differential Revision: D114021788


