### PR TITLE
refactor(hashjoin): Refactor hashJoinTableType and isLeftNullAwareJoinWithFilter API in HashJoinBridge

### DIFF
--- a/velox/exec/HashJoinBridge.cpp
+++ b/velox/exec/HashJoinBridge.cpp
@@ -23,26 +23,27 @@ static const char* kSpillProbedFlagColumnName = "__probedFlag";
 }
 
 RowTypePtr hashJoinTableType(
-    const std::shared_ptr<const core::HashJoinNode>& joinNode) {
-  const auto inputType = joinNode->sources()[1]->outputType();
-  const auto numKeys = joinNode->rightKeys().size();
+    const std::vector<core::FieldAccessTypedExprPtr>& joinKeys,
+    const RowTypePtr& inputType,
+    bool dropDuplicates) {
+  const auto numKeys = joinKeys.size();
 
   std::vector<std::string> names;
-  names.reserve(inputType->size());
+  names.reserve(dropDuplicates ? numKeys : inputType->size());
   std::vector<TypePtr> types;
-  types.reserve(inputType->size());
+  types.reserve(dropDuplicates ? numKeys : inputType->size());
   std::unordered_set<uint32_t> keyChannelSet;
   keyChannelSet.reserve(inputType->size());
 
   for (int i = 0; i < numKeys; ++i) {
-    auto& key = joinNode->rightKeys()[i];
+    auto& key = joinKeys[i];
     auto channel = exprToChannel(key.get(), inputType);
     keyChannelSet.insert(channel);
     names.emplace_back(inputType->nameOf(channel));
     types.emplace_back(inputType->childAt(channel));
   }
 
-  if (joinNode->canDropDuplicates()) {
+  if (dropDuplicates) {
     // For left semi and anti join with no extra filter, hash table does not
     // store dependent columns.
     return ROW(std::move(names), std::move(types));
@@ -55,6 +56,13 @@ RowTypePtr hashJoinTableType(
     }
   }
   return ROW(std::move(names), std::move(types));
+}
+
+RowTypePtr hashJoinTableType(
+    const std::shared_ptr<const core::HashJoinNode>& joinNode) {
+  const auto inputType = joinNode->sources()[1]->outputType();
+  return hashJoinTableType(
+      joinNode->rightKeys(), inputType, joinNode->canDropDuplicates());
 }
 
 void HashJoinBridge::start() {
@@ -402,10 +410,20 @@ bool HashJoinBridge::testingHasMoreSpilledPartitions() {
 }
 
 bool isLeftNullAwareJoinWithFilter(
+    core::JoinType joinType,
+    bool nullAware,
+    bool withFilter) {
+  return (isAntiJoin(joinType) || isLeftSemiProjectJoin(joinType) ||
+          isLeftSemiFilterJoin(joinType)) &&
+      nullAware && withFilter;
+}
+
+bool isLeftNullAwareJoinWithFilter(
     const std::shared_ptr<const core::HashJoinNode>& joinNode) {
-  return (joinNode->isAntiJoin() || joinNode->isLeftSemiProjectJoin() ||
-          joinNode->isLeftSemiFilterJoin()) &&
-      joinNode->isNullAware() && (joinNode->filter() != nullptr);
+  return isLeftNullAwareJoinWithFilter(
+      joinNode->joinType(),
+      joinNode->isNullAware(),
+      joinNode->filter() != nullptr);
 }
 
 uint64_t HashJoinMemoryReclaimer::reclaim(

--- a/velox/exec/HashJoinBridge.h
+++ b/velox/exec/HashJoinBridge.h
@@ -205,6 +205,13 @@ class HashJoinBridge : public JoinBridge {
   friend test::HashJoinBridgeTestHelper;
 };
 
+// Indicates if join properties describe a null-aware anti or left semi join
+// with an extra filter.
+bool isLeftNullAwareJoinWithFilter(
+    core::JoinType joinType,
+    bool nullAware,
+    bool withFilter);
+
 // Indicates if 'joinNode' is null-aware anti or left semi project join type and
 // has filter set.
 bool isLeftNullAwareJoinWithFilter(
@@ -242,6 +249,14 @@ bool isHashBuildMemoryPool(const memory::MemoryPool& pool);
 bool isHashProbeMemoryPool(const memory::MemoryPool& pool);
 
 bool needRightSideJoin(core::JoinType joinType);
+
+/// Returns the hash table row type for the specified right-side join keys and
+/// input. If 'dropDuplicates' is true, keeps only key columns; otherwise
+/// appends dependent non-key columns after the keys.
+RowTypePtr hashJoinTableType(
+    const std::vector<core::FieldAccessTypedExprPtr>& joinKeys,
+    const RowTypePtr& inputType,
+    bool dropDuplicates);
 
 /// Returns the type of the hash table associated with this join.
 RowTypePtr hashJoinTableType(

--- a/velox/exec/tests/HashJoinBridgeTest.cpp
+++ b/velox/exec/tests/HashJoinBridgeTest.cpp
@@ -619,6 +619,75 @@ TEST(HashJoinBridgeTest, needRightSideJoin) {
   }
 }
 
+TEST_P(HashJoinBridgeTest, isLeftNullAwareJoinWithFilterHelper) {
+  EXPECT_TRUE(isLeftNullAwareJoinWithFilter(core::JoinType::kAnti, true, true));
+  EXPECT_TRUE(isLeftNullAwareJoinWithFilter(
+      core::JoinType::kLeftSemiProject, true, true));
+  EXPECT_TRUE(isLeftNullAwareJoinWithFilter(
+      core::JoinType::kLeftSemiFilter, true, true));
+
+  EXPECT_FALSE(
+      isLeftNullAwareJoinWithFilter(core::JoinType::kAnti, false, true));
+  EXPECT_FALSE(
+      isLeftNullAwareJoinWithFilter(core::JoinType::kAnti, true, false));
+  EXPECT_FALSE(
+      isLeftNullAwareJoinWithFilter(core::JoinType::kInner, true, true));
+
+  const auto buildSourceType = ROW({"b0", "b1"}, {BIGINT(), BIGINT()});
+  const auto probeSourceType = ROW({"p0"}, {BIGINT()});
+  const auto buildValueNode = std::make_shared<core::ValuesNode>(
+      "buildValueNode",
+      std::vector<RowVectorPtr>{std::make_shared<RowVector>(
+          pool_.get(), buildSourceType, nullptr, 0, std::vector<VectorPtr>{})});
+  const auto probeValueNode = std::make_shared<core::ValuesNode>(
+      "probeValueNode",
+      std::vector<RowVectorPtr>{std::make_shared<RowVector>(
+          pool_.get(), probeSourceType, nullptr, 0, std::vector<VectorPtr>{})});
+  const auto joinNode = std::make_shared<core::HashJoinNode>(
+      "join-bridge-test",
+      core::JoinType::kLeftSemiProject,
+      true,
+      std::vector<core::FieldAccessTypedExprPtr>{
+          std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "p0")},
+      std::vector<core::FieldAccessTypedExprPtr>{
+          std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "b0")},
+      std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), true),
+      probeValueNode,
+      buildValueNode,
+      ROW({"p0", "match"}, {BIGINT(), BOOLEAN()}));
+
+  EXPECT_EQ(
+      isLeftNullAwareJoinWithFilter(joinNode),
+      isLeftNullAwareJoinWithFilter(
+          joinNode->joinType(),
+          joinNode->isNullAware(),
+          joinNode->filter() != nullptr));
+}
+
+TEST_P(HashJoinBridgeTest, hashJoinTableTypeFromKeysAndInputType) {
+  const auto inputType =
+      ROW({"b0", "b1", "b2", "b3"}, {BIGINT(), INTEGER(), VARCHAR(), DOUBLE()});
+  const std::vector<core::FieldAccessTypedExprPtr> joinKeys{
+      std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "b1"),
+      std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "b0")};
+
+  auto keysOnlyType = hashJoinTableType(joinKeys, inputType, true);
+  ASSERT_EQ(keysOnlyType->size(), 2);
+  EXPECT_EQ(keysOnlyType->nameOf(0), "b1");
+  EXPECT_EQ(keysOnlyType->nameOf(1), "b0");
+  EXPECT_EQ(keysOnlyType->childAt(0), INTEGER());
+  EXPECT_EQ(keysOnlyType->childAt(1), BIGINT());
+
+  auto fullType = hashJoinTableType(joinKeys, inputType, false);
+  ASSERT_EQ(fullType->size(), inputType->size());
+  EXPECT_EQ(
+      fullType->names(), std::vector<std::string>({"b1", "b0", "b2", "b3"}));
+  EXPECT_EQ(fullType->childAt(0), INTEGER());
+  EXPECT_EQ(fullType->childAt(1), BIGINT());
+  EXPECT_EQ(fullType->childAt(2), VARCHAR());
+  EXPECT_EQ(fullType->childAt(3), DOUBLE());
+}
+
 TEST_P(HashJoinBridgeTest, hashJoinTableType) {
   core::TypedExprPtr filter{
       std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), true)};


### PR DESCRIPTION
Part of #18321

This PR refactors two small pieces of reusable logic out of the `HashJoinNode`-specific path:

1. Added a helper to determine whether a join is a null-aware left-side join with a filter using raw join properties:
   - `isLeftNullAwareJoinWithFilter(core::JoinType, bool nullAware, bool withFilter)`

2. Added a helper to compute the hash table row type directly from:
   - right-side join keys
   - right-side input type
   - whether duplicate dropping is allowed

   ```cpp
   hashJoinTableType(joinKeys, inputType, dropDuplicates)