### PR TITLE
feat(rpc): Derive dispatch mode from capabilities (safety-gate)

### DIFF
--- a/velox/common/rpc/RPCTypes.h
+++ b/velox/common/rpc/RPCTypes.h
@@ -122,6 +122,34 @@ enum class RPCErrorKind {
   kInvalidRequest,
 };
 
+/// Declares what a transport/function supports, so the RPCOperator can DERIVE
+/// the dispatch strategy (per-row vs native batch vs async job) and
+/// flow-control bounds from backend capability instead of a user-set
+/// streaming_mode knob. Queried once after initialize(); assumed immutable for
+/// the query lifetime. NOTE: this immutability is an assumption, NOT enforced —
+/// the operator reads capabilities() once at initialize(), so a per-row
+/// inference_backend switch (resolved after initialize) would violate it.
+struct RPCClientCapabilities {
+  /// True if BATCH dispatch mode is feasible — the operator may accumulate rows
+  /// and flush via callBatch() without failing. Covers both a native
+  /// multi-input endpoint (batch_predict/batch_encode) and a client-side
+  /// fan-out inside callBatch(); it does NOT assert the wire is natively
+  /// batched. False means the operator must dispatch per row.
+  bool supportsBatchDispatch{false};
+
+  /// True if the backend is an asynchronous offline job (submit -> poll ->
+  /// fetch) needing a dedicated non-blocking controller rather than the
+  /// per-row / sync-batch dispatch paths.
+  bool isAsyncJob{false};
+
+  /// Server-side limit on requests per callBatch(); 0 = unlimited/unknown.
+  int32_t maxBatchRows{0};
+
+  /// Client-side accumulation guard (approx tokens) to bound memory and force
+  /// an early flush before OOM; 0 = no token-based bound.
+  int64_t maxBatchTokens{0};
+};
+
 /// Generic response structure from RPC calls.
 /// This is a minimal, domain-agnostic structure that works for any backend.
 struct RPCResponse {

--- a/velox/core/QueryConfig.cpp
+++ b/velox/core/QueryConfig.cpp
@@ -267,6 +267,9 @@ const std::vector<config::ConfigProperty>& QueryConfig::registeredProperties() {
     VELOX_REGISTER_QUERY_CONFIG(kRpcRateLimiterDecreaseFactor);
     VELOX_REGISTER_QUERY_CONFIG(kRpcRateLimiterMaxLimit);
 
+    // RPC capability-driven dispatch.
+    VELOX_REGISTER_QUERY_CONFIG(kRpcCapabilitiesDispatch);
+
 #undef VELOX_REGISTER_QUERY_CONFIG
 
     return properties;

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -1436,6 +1436,20 @@ class QueryConfig {
       "admission-controlled dispatch this ceiling now actually bounds in-flight "
       "rows, so it must be sized for the backend's healthy concurrency.")
 
+  /// Enables worker-side capability-driven RPC dispatch-mode derivation
+  /// (RPCOperator). The rollout gate for capability-driven dispatch.
+  VELOX_QUERY_CONFIG(
+      kRpcCapabilitiesDispatch,
+      rpcCapabilitiesDispatch,
+      "rpc.capabilities_dispatch",
+      bool,
+      false,
+      "When true, RPCOperator derives the dispatch mode (PER_ROW / BATCH) from "
+      "the RPC function's declared capabilities() after initialize(), instead "
+      "of the plan-time streaming mode. Off by default, in which case the "
+      "plan-time mode (resolved coordinator-side) stands. This is the rollout "
+      "gate for capability-driven dispatch.")
+
   /// Enables the adaptive per-tier RPC rate limiter (RPCRateLimiter).
   VELOX_QUERY_CONFIG(
       kRpcRateLimiterAdaptiveEnabled,

--- a/velox/exec/rpc/RPCOperator.cpp
+++ b/velox/exec/rpc/RPCOperator.cpp
@@ -87,10 +87,60 @@ void RPCOperator::initialize() {
     RPCRateLimiter::setMaxPending(tierKey_, rlMax);
   }
 
+  // Capability-driven dispatch (off by default). Once the function is
+  // initialized, its declared capabilities are known. Capability acts as a
+  // SAFETY GATE over the plan-time streaming mode — not a preference override.
+  // The plan-time mode already reflects the caller's explicit choice or the
+  // coordinator's AUTOMATIC/row-count decision, so:
+  //   - Downgrade an unsupported BATCH -> PER_ROW, so a batch mode never hits a
+  //     backend with no native batch endpoint (which would fail at flush).
+  //   - Never force BATCH over a PER_ROW choice — that is the caller's
+  //     latency-vs-throughput lever, which capability alone must not remove.
+  // Re-driving state_'s mode here — before any dispatch — is the single
+  // override point: addInput/getOutput/isBlocked/noMoreInput read
+  // state_->streamingMode().
+  if (queryConfig.rpcCapabilitiesDispatch()) {
+    const auto caps = function_->capabilities();
+    const auto planMode = state_->streamingMode();
+    // TODO: route caps.isAsyncJob to a dedicated async-job controller; until it
+    // exists, an async-job backend runs PER_ROW.
+    auto effectiveMode = planMode;
+    if (planMode == RPCStreamingMode::kBatch && !caps.supportsBatchDispatch) {
+      effectiveMode = RPCStreamingMode::kPerRow;
+    }
+    if (effectiveMode != planMode) {
+      state_->setStreamingMode(
+          effectiveMode,
+          queryConfig.rpcCongestionMinWindow(),
+          queryConfig.rpcCongestionStepCoef(),
+          queryConfig.rpcCongestionMaxWindow());
+    }
+    // When running BATCH, clamp the flush gate to the backend's server-side
+    // batch limit. maxBatchRows is an upper bound, not a preference: clamp
+    // rather than replace so a smaller caller-set dispatch batch size (a
+    // latency lever) is preserved. dispatchBatchSize_ == 0 means "no row cap"
+    // (token-only), so adopt the backend limit directly in that case.
+    if (effectiveMode == RPCStreamingMode::kBatch && caps.maxBatchRows > 0) {
+      const auto backendLimit = static_cast<int32_t>(caps.maxBatchRows);
+      dispatchBatchSize_ = dispatchBatchSize_ > 0
+          ? std::min(dispatchBatchSize_, backendLimit)
+          : backendLimit;
+    }
+    RPC_OP_VLOG(1) << "capability-driven dispatch for function '"
+                   << rpcNode_->functionName() << "': plan "
+                   << (planMode == RPCStreamingMode::kBatch ? "BATCH"
+                                                            : "PER_ROW")
+                   << " -> effective "
+                   << (effectiveMode == RPCStreamingMode::kBatch ? "BATCH"
+                                                                 : "PER_ROW")
+                   << " (supportsBatchDispatch=" << caps.supportsBatchDispatch
+                   << ", maxBatchRows=" << caps.maxBatchRows << ")";
+  }
+
   RPC_OP_VLOG(1) << "Created operator for function '"
                  << rpcNode_->functionName() << "', planNodeId=" << planNodeId()
                  << ", operatorId=" << operatorId() << ", streamingMode="
-                 << (rpcNode_->streamingMode() == RPCStreamingMode::kBatch
+                 << (state_->streamingMode() == RPCStreamingMode::kBatch
                          ? "BATCH"
                          : "PER_ROW");
 

--- a/velox/exec/rpc/tests/DemoBatchRPCFunction.h
+++ b/velox/exec/rpc/tests/DemoBatchRPCFunction.h
@@ -64,6 +64,14 @@ class DemoBatchRPCFunction : public AsyncRPCFunction {
     return VARCHAR();
   }
 
+  // Declares native batch support so capability-driven dispatch (when the
+  // rpc.capabilities_dispatch config is on) derives BATCH for this function.
+  RPCClientCapabilities capabilities() const override {
+    RPCClientCapabilities caps;
+    caps.supportsBatchDispatch = true;
+    return caps;
+  }
+
   /// With failOnError=true, mimics the meta_ai_on_error='fail' policy: any
   /// errored response hard-fails the query (VELOX_USER_FAIL) instead of NULLing
   /// the row. Otherwise defers to the base (errors -> NULL).

--- a/velox/exec/rpc/tests/RPCOperatorTest.cpp
+++ b/velox/exec/rpc/tests/RPCOperatorTest.cpp
@@ -104,7 +104,8 @@ class RPCOperatorTest : public OperatorTestBase {
       const core::PlanNodePtr& source,
       const std::vector<std::string>& argumentColumnNames,
       const std::string& functionName = "demo_batch_rpc",
-      int32_t dispatchBatchSize = 0) {
+      int32_t dispatchBatchSize = 0,
+      RPCStreamingMode streamingMode = RPCStreamingMode::kBatch) {
     auto sourceType = source->outputType();
 
     std::vector<std::string> argCols;
@@ -132,7 +133,7 @@ class RPCOperatorTest : public OperatorTestBase {
         argCols,
         argTypes,
         constantInputs,
-        RPCStreamingMode::kBatch,
+        streamingMode,
         dispatchBatchSize);
   }
 
@@ -264,6 +265,71 @@ TEST_F(RPCOperatorTest, multipleColumns) {
   EXPECT_EQ(ids->valueAt(i2), 200);
   EXPECT_EQ(extras->valueAt(i2), 2.5);
   EXPECT_EQ(results->valueAt(i2).str(), "Response for: question two");
+}
+
+// ============================================================
+// Capability-driven dispatch — capability gates the plan-time mode
+// ============================================================
+
+// Safety gate: with rpc.capabilities_dispatch on, a BATCH plan node whose
+// function has no native batch (demo_rpc, supportsBatchDispatch=false) is
+// downgraded to PER_ROW, so a batch mode never hits a backend that cannot
+// batch. With the flag off, BATCH stands and hits demo_rpc's (unimplemented)
+// accumulateBatch — the query fails.
+TEST_F(RPCOperatorTest, capabilityDrivenDowngradesUnsupportedBatch) {
+  auto input = makeRowVector(
+      {"prompt"}, {makeFlatVector<StringView>({"hello", "world", "third"})});
+
+  // BATCH plan node, but demo_rpc has no native batch endpoint.
+  auto plan = makeBatchRPCNode(
+      PlanBuilder().values({input}).planNode(), {"prompt"}, "demo_rpc");
+
+  // Flag off: BATCH stands -> demo_rpc can't accumulate -> fails.
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()), "accumulateBatch");
+
+  // Flag on: capability downgrades BATCH -> PER_ROW -> succeeds.
+  auto result = AssertQueryBuilder(plan)
+                    .config(core::QueryConfig::kRpcCapabilitiesDispatch, "true")
+                    .copyResults(pool());
+
+  ASSERT_EQ(result->size(), 3);
+  auto* prompts = result->childAt(0)->asFlatVector<StringView>();
+  auto* results = result->childAt(1)->asFlatVector<StringView>();
+  for (vector_size_t i = 0; i < result->size(); ++i) {
+    ASSERT_FALSE(results->isNullAt(i));
+    // demo_rpc's per-row path produces "Response for: <prompt>".
+    EXPECT_EQ(
+        results->valueAt(i).str(),
+        "Response for: " + prompts->valueAt(i).str());
+  }
+}
+
+// Respect a supported BATCH: a BATCH plan node on a batch-capable function
+// (demo_batch_rpc, supportsBatchDispatch=true) stays BATCH under the flag — the
+// gate never downgrades a mode the backend supports.
+TEST_F(RPCOperatorTest, capabilityDrivenKeepsSupportedBatch) {
+  auto input = makeRowVector(
+      {"prompt"}, {makeFlatVector<StringView>({"hello", "world", "batch"})});
+
+  auto plan = makeBatchRPCNode(
+      PlanBuilder().values({input}).planNode(), {"prompt"}, "demo_batch_rpc");
+
+  auto result = AssertQueryBuilder(plan)
+                    .config(core::QueryConfig::kRpcCapabilitiesDispatch, "true")
+                    .copyResults(pool());
+
+  ASSERT_EQ(result->size(), 3);
+  auto* prompts = result->childAt(0)->asFlatVector<StringView>();
+  auto* results = result->childAt(1)->asFlatVector<StringView>();
+  std::map<std::string, std::string> rows;
+  for (vector_size_t i = 0; i < result->size(); ++i) {
+    rows[prompts->valueAt(i).str()] = results->valueAt(i).str();
+  }
+  // "Batch response for:" prefix is produced only by the batch path.
+  EXPECT_EQ(rows["hello"], "Batch response for: hello");
+  EXPECT_EQ(rows["world"], "Batch response for: world");
+  EXPECT_EQ(rows["batch"], "Batch response for: batch");
 }
 
 // ============================================================

--- a/velox/expression/rpc/AsyncRPCFunction.h
+++ b/velox/expression/rpc/AsyncRPCFunction.h
@@ -34,6 +34,7 @@ namespace facebook::velox::exec::rpc {
 
 // Import core RPC types from velox/common/rpc into this namespace so that
 // existing code in velox/expression/rpc can use them unqualified.
+using velox::rpc::RPCClientCapabilities;
 using velox::rpc::RPCRequest;
 using velox::rpc::RPCResponse;
 using velox::rpc::RPCStreamingMode;
@@ -95,6 +96,20 @@ class AsyncRPCFunction {
   /// Empty string means "no tier configured — uses global default limit."
   virtual std::string tierKey() const {
     return "";
+  }
+
+  /// Declares the backend's capabilities so the RPCOperator can derive the
+  /// dispatch strategy (per-row / native batch / async job) and flow-control
+  /// bounds — replacing the user-facing streaming_mode / dispatchBatchSize
+  /// knobs (see RPCClientCapabilities).
+  ///
+  /// This is the single, backend-agnostic declaration point: it covers every
+  /// backend a function may hold, including transports outside the IRPCClient
+  /// hierarchy. An implementation returns a fixed shape (or derives it from its
+  /// client's config). Default is the conservative per-row, no-batch-dispatch
+  /// shape so existing functions keep today's behavior until they opt in.
+  virtual RPCClientCapabilities capabilities() const {
+    return {};
   }
 
   // ── PER_ROW mode ──────────────────────────────────────────────


### PR DESCRIPTION
Summary:
First consumer of the RPCClientCapabilities interface. With the new
`rpc.capabilities_dispatch` QueryConfig flag on (default false), RPCOperator
reconciles the plan-time dispatch mode against the function's declared
`capabilities()` at `initialize()`, before any dispatch. When off, the plan-time
mode (resolved coordinator-side) stands unchanged, so there is no behavior change.

Capabilities are a feasibility floor, not a mandate — the gate only ever
*downgrades* an infeasible request and never overrides a feasible caller choice:

- Downgrade-only: a BATCH plan on a backend that declares
  `supportsBatchDispatch=false` is forced to PER_ROW, so BATCH never reaches a
  backend with no native batch endpoint (which would fail at flush).
- Never upgrades: a PER_ROW plan is always left PER_ROW. PER_ROW vs BATCH is the
  caller's latency-vs-throughput lever, and capability alone must not remove it.
  An explicit `rpc_streaming_mode=PER_ROW|BATCH` is honored for any mode the
  backend supports. The "system chooses" path is the coordinator-side execution
  policy (AUTOMATIC); an explicit choice overrides it — the system's pick is a
  default, not a lock-in, because the automatic decision cannot always be perfect.
- BATCH sizing: when the effective mode is BATCH, the flush bounds are taken from
  the backend's server-side limits — `dispatchBatchSize_` from `caps.maxBatchRows`
  and `maxBatchTokens_` from `caps.maxBatchTokens` (each 0 = unbounded).

Mechanics:
- QueryConfig: add `rpc.capabilities_dispatch` (bool, default false).
- `RPCOperator::initialize()`: the single override point — re-drives
  `state_->setStreamingMode(...)` so the runtime branches (addInput / getOutput /
  isBlocked / noMoreInput), which all read `state_->streamingMode()`, observe the
  reconciled mode. Async-job derivation (`caps.isAsyncJob`) is deferred: such a
  backend runs PER_ROW with a TODO until a dedicated async-job controller exists.
- Native bridge: `native_rpc_capabilities_dispatch` maps to
  `QueryConfig::kRpcCapabilitiesDispatch`, so the flag is settable per query.

This complements the coordinator-side execution policy rather than replacing it:
the plan-time mode remains authoritative until the flag is flipped, which is the
rollout seam for capability-driven dispatch.

Differential Revision: D113107742


