### PR TITLE
fix(parquet): Preserve explicit writer options

### DIFF
--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -107,6 +107,34 @@ class ArrowDataBufferSink : public ::arrow::io::OutputStream {
   int64_t bytesFlushed_ = 0;
 };
 
+void ParquetWriterOptions::merge(
+    const dwio::common::FormatSpecificOptions& overrides) {
+  const auto* parquetOverrides =
+      dynamic_cast<const ParquetWriterOptions*>(&overrides);
+  VELOX_CHECK_NOT_NULL(
+      parquetOverrides,
+      "Cannot merge Parquet writer options with a different "
+      "FormatSpecificOptions type.");
+
+  const auto mergeIfSet = [](auto& value, const auto& overrideValue) {
+    if (overrideValue.has_value()) {
+      value = overrideValue;
+    }
+  };
+  mergeIfSet(
+      parquetWriteTimestampUnit, parquetOverrides->parquetWriteTimestampUnit);
+  mergeIfSet(enableDictionary, parquetOverrides->enableDictionary);
+  mergeIfSet(
+      enableStoreDecimalAsInteger,
+      parquetOverrides->enableStoreDecimalAsInteger);
+  mergeIfSet(
+      dictionaryPageSizeLimit, parquetOverrides->dictionaryPageSizeLimit);
+  mergeIfSet(useParquetDataPageV2, parquetOverrides->useParquetDataPageV2);
+  mergeIfSet(dataPageSize, parquetOverrides->dataPageSize);
+  mergeIfSet(batchSize, parquetOverrides->batchSize);
+  mergeIfSet(createdBy, parquetOverrides->createdBy);
+}
+
 struct ArrowContext {
   std::unique_ptr<FileWriter> writer;
   std::shared_ptr<::arrow::Schema> schema;

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -118,23 +118,7 @@ class LambdaFlushPolicy : public DefaultFlushPolicy {
 struct ParquetWriterOptions : public dwio::common::FormatSpecificOptions {
   /// Overlays session or connector Parquet config values on top of this options
   /// object while preserving caller-provided non-config fields.
-  void merge(const dwio::common::FormatSpecificOptions& overrides) override {
-    const auto* parquetOverrides =
-        dynamic_cast<const ParquetWriterOptions*>(&overrides);
-    VELOX_CHECK_NOT_NULL(
-        parquetOverrides,
-        "Cannot merge Parquet writer options with a different "
-        "FormatSpecificOptions type.");
-
-    parquetWriteTimestampUnit = parquetOverrides->parquetWriteTimestampUnit;
-    enableDictionary = parquetOverrides->enableDictionary;
-    enableStoreDecimalAsInteger = parquetOverrides->enableStoreDecimalAsInteger;
-    dictionaryPageSizeLimit = parquetOverrides->dictionaryPageSizeLimit;
-    useParquetDataPageV2 = parquetOverrides->useParquetDataPageV2;
-    dataPageSize = parquetOverrides->dataPageSize;
-    batchSize = parquetOverrides->batchSize;
-    createdBy = parquetOverrides->createdBy;
-  }
+  void merge(const dwio::common::FormatSpecificOptions& overrides) override;
 
   // Growth ratio passed to ArrowDataBufferSink. The default value is a
   // heuristic borrowed from


### PR DESCRIPTION
`ParquetWriterTest.timestampUnitAndTimeZone` expected a requested microsecond timestamp unit, but absent session overrides replaced it with the nanosecond default.

Apply only overrides that contain values. This matches how other writer options handle optional overrides and preserves explicit caller settings.