### PR TITLE
refactor(nimble): Rename leftover chunkIndex identifiers to chunkStats (#18328)

### DIFF
--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -989,15 +989,15 @@ class ReaderOptions : public io::ReaderOptions {
     preloadIndex_ = value;
   }
 
-  /// Whether to load and initialize the chunk index during file open.
-  /// When true, the chunk index section is preloaded and the structured
-  /// ChunkIndex object is created. Default true.
-  bool loadChunkIndex() const {
-    return loadChunkIndex_;
+  /// Whether to load and initialize the chunk stats during file open.
+  /// When true, the chunk stats section is preloaded and the structured
+  /// ChunkStats object is created. Default true.
+  bool loadChunkStats() const {
+    return loadChunkStats_;
   }
 
-  void setLoadChunkIndex(bool value) {
-    loadChunkIndex_ = value;
+  void setLoadChunkStats(bool value) {
+    loadChunkStats_ = value;
   }
 
   bool allowEmptyFile() const {
@@ -1060,7 +1060,7 @@ class ReaderOptions : public io::ReaderOptions {
   bool cacheData_{true};
   bool loadClusterIndex_{false};
   bool preloadIndex_{false};
-  bool loadChunkIndex_{true};
+  bool loadChunkStats_{true};
   bool allowEmptyFile_{false};
   const FileHandle* fileHandle_{nullptr};
   cache::AsyncDataCache* cache_{nullptr};


### PR DESCRIPTION
Summary:


X-link: https://github.com/facebookincubator/nimble/pull/1037

The ChunkIndex class was renamed to ChunkStats. This is the follow-up
cleanup that renames the remaining `chunkIndex` identifiers to `chunkStats`
for consistency: the reader/writer section plumbing (chunkStatsWriter_,
hasChunkStats, initChunkStats, writeChunkStatsRoot, addStreamChunkStats,
chunkStatsCache_, chunkStatsMinAvgChunks, the chunkStats() accessor), the
reader-side `loadChunkStats` option in velox Options, and the associated
test helpers (createChunkStats, testChunkStats_, chunkStatsGroups, ...).

Kept as-is on purpose:
- enableChunkIndex / ENABLE_CHUNK_INDEX ("nimble.chunk.index.enabled") — the
  positional chunk-index knob, left untouched so it can gate rollout
  independently of the chunk-stats knob.
- ChunkLocation.chunkIndex, chunkNullCount(chunkIndex),
  lookupChunk(...).chunkIndex, and the loop/position counters — these are a
  chunk *position*, not the ChunkStats section, so they keep their names.

Nimble-only; DWRF does not use any of these identifiers. Pure rename, no
behavior change.

Differential Revision: D113984664


