### PR TITLE
test(parquet): Disable compression round-trip test (#18330)

### DIFF
--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -479,8 +479,9 @@ TEST_F(ParquetWriterTest, compression) {
   auto rowReader = createRowReaderFromReader(*reader, schema);
   assertReadWithReaderAndExpected(schema, *rowReader, data, *leafPool_);
 }
-
-TEST_F(ParquetWriterTest, compressionRoundTripAcrossPages) {
+// TODO: Re-enable after fixing unaligned reads reported by UBSan.
+// https://github.com/facebookincubator/velox/issues/18329
+TEST_F(ParquetWriterTest, DISABLED_compressionRoundTripAcrossPages) {
   // Writes multi-page data with every writable codec and verifies the values
   // round-trip. Small data pages force many compressed pages per column, so the
   // reader's per-codec decompression paths (the Snappy/ZSTD/GZIP direct paths


### PR DESCRIPTION
Summary:

`ParquetWriterTest.compressionRoundTripAcrossPages` triggers UndefinedBehaviorSanitizer failures because Parquet readers dereference values at addresses that do not satisfy their alignment requirements.

Disable the test until the unaligned reads are fixed. Filed https://github.com/facebookincubator/velox/issues/18329 for follow up

Differential Revision: D114122977


