### PR TITLE
fix(build): Suppress nullability-completeness via ExtraArgs

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -23,7 +23,6 @@ bugprone-use-after-move,
 clang-diagnostic-*,
 -clang-diagnostic-nrvo,
 -clang-diagnostic-missing-designated-field-initializers,
--clang-diagnostic-nullability-completeness,
 cppcoreguidelines-narrowing-conversions,
 cppcoreguidelines-pro-type-member-init,
 cppcoreguidelines-special-member-functions,
@@ -56,6 +55,9 @@ readability-redundant-string-init,
 HeaderFilterRegex: '.*'
 
 WarningsAsErrors: 'bugprone-use-after-move'
+
+ExtraArgs:
+  - '-Wno-nullability-completeness'
 
 CheckOptions:
   # Naming conventions as explicitly stated in CODING_STYLE.md.


### PR DESCRIPTION
Summary:
The Ubuntu adapters clang-tidy job fails on core headers such as `StringView.h` with:

    error: pointer is missing a nullability type specifier [clang-diagnostic-nullability-completeness]

clang-tidy parses the GCC build's compile commands, which omit the Clang-only `-Wno-nullability-completeness` set in `CMakeLists.txt`, so the Clang frontend emits the diagnostic and `-Werror` turns it into an error. Disabling `clang-diagnostic-nullability-completeness` in the `Checks` list does not help -- that only filters clang-tidy's warning findings, not a compiler error. Pass `-Wno-nullability-completeness` through `ExtraArgs` so the frontend never emits it.

Context:
This started showing up after https://github.com/facebookincubator/velox/pull/18260 explicitly enabled clang-diagnostic-*. In GCC-based CI, clang-tidy parses GCC compile commands using Clang, exposing nullability-completeness diagnostics that GCC never added suppression flags for.

Differential Revision: D114124982


