### PR TITLE
Add Spark CalendarInterval type and make_interval function

### DIFF
--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -263,6 +263,32 @@ These functions support TIMESTAMP and DATE input types.
         SELECT make_ym_interval(2); -- 2-0
         SELECT make_ym_interval(); -- 0-0
 
+.. spark:function:: make_interval([years[, months[, weeks[, days[, hours[, mins[, secs]]]]]]]) -> interval
+
+    Make a calendar interval from individual fields. Returns a
+    CalendarInterval (packed int128) with three components: months (int32),
+    days (int32), and microseconds (int64).
+
+    All arguments default to 0. The ``secs`` argument is DECIMAL(p, 6) where
+    the unscaled value represents microseconds.
+
+    Computation:
+      - totalMonths = years * 12 + months
+      - totalDays = weeks * 7 + days
+      - microseconds = hours * MICROS_PER_HOUR + mins * MICROS_PER_MINUTE + secs
+
+    Throws an error when inputs lead to integer overflow. ::
+
+        SELECT make_interval(1, 2, 3, 4, 5, 6, 7.89); -- 1 years 2 months 25 days 5 hours 6 minutes 7.89 seconds
+        SELECT make_interval(1, 6); -- 1 years 6 months
+        SELECT make_interval(); -- 0 seconds
+
+    .. note::
+
+       Date/timestamp arithmetic expressions that consume CalendarInterval
+       (e.g., ``date + make_interval(...)``) are not yet supported natively
+       in Velox and will fall back to Spark execution.
+
 .. spark:function:: minute(timestamp) -> integer
 
     Returns the minutes of ``timestamp``, subject to the session timezone.

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -27,6 +27,7 @@
 #include "velox/expression/ScopedVarSetter.h"
 #include "velox/external/tzdb/time_zone.h"
 #include "velox/functions/lib/RowsTranslationUtil.h"
+#include "velox/type/CalendarInterval.h"
 #include "velox/type/CastRegistry.h"
 #include "velox/type/CppToType.h"
 #include "velox/type/Type.h"
@@ -936,6 +937,27 @@ void CastExpr::applyPeeled(
         "Cast from {} to {} is not supported",
         fromType->toString(),
         toType->toString());
+  } else if (fromType->isCalendarInterval() || toType->isCalendarInterval()) {
+    if (fromType->isCalendarInterval() && toType->kind() == TypeKind::VARCHAR) {
+      // CalendarInterval -> VARCHAR: use valueToString.
+      context.ensureWritable(rows, toType, result);
+      auto* flatResult = result->as<FlatVector<StringView>>();
+      auto* inputVector = input.as<SimpleVector<int128_t>>();
+      auto calendarType = CALENDAR_INTERVAL();
+      rows.applyToSelected([&](auto row) {
+        if (inputVector->isNullAt(row)) {
+          flatResult->setNull(row, true);
+        } else {
+          auto str = calendarType->valueToString(inputVector->valueAt(row));
+          flatResult->set(row, StringView(str));
+        }
+      });
+    } else {
+      VELOX_UNSUPPORTED(
+          "Cast from {} to {} is not supported",
+          fromType->toString(),
+          toType->toString());
+    }
   } else if (fromType->isTime()) {
     VELOX_DCHECK(fromType->equivalent(*TIME()));
     result = castFromTime(rows, input, context, toType);

--- a/velox/expression/ConstantExpr.cpp
+++ b/velox/expression/ConstantExpr.cpp
@@ -170,8 +170,15 @@ void appendSqlLiteral(
       }
       [[fallthrough]];
     }
-    case TypeKind::HUGEINT:
+    case TypeKind::HUGEINT: {
+      if (vector.type()->isCalendarInterval()) {
+        out << "INTERVAL '"
+            << vector.wrappedVector()->toString(vector.wrappedIndex(row))
+            << "'";
+        break;
+      }
       [[fallthrough]];
+    }
     case TypeKind::REAL:
       [[fallthrough]];
     case TypeKind::DOUBLE:

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -25,6 +25,7 @@
 #include "velox/functions/Registerer.h"
 #include "velox/functions/prestosql/tests/CastBaseTest.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/type/CalendarInterval.h"
 #include "velox/type/Type.h"
 #include "velox/type/tests/utils/CustomTypesForTesting.h"
 #include "velox/type/tz/TimeZoneMap.h"
@@ -2847,6 +2848,43 @@ TEST_F(CastExprTest, intervalDayTimeToVarchar) {
   VELOX_ASSERT_THROW(
       evaluate("cast('5 14:20:52.088' as interval day to second)", data),
       "Cast from VARCHAR to INTERVAL DAY TO SECOND is not supported");
+}
+
+TEST_F(CastExprTest, calendarIntervalToVarchar) {
+  // 1 hour, 2 minutes, 3 seconds in microseconds.
+  const int64_t micros = 1L * 3600000000L + 2L * 60000000L + 3L * 1000000L;
+  auto data = makeRowVector({
+      makeNullableFlatVector<int128_t>(
+          {CalendarInterval(0, 0, 0).pack(),
+           CalendarInterval(14, 0, 0).pack(),
+           CalendarInterval(0, 5, 0).pack(),
+           CalendarInterval(0, 0, micros).pack(),
+           CalendarInterval(14, 5, micros).pack(),
+           CalendarInterval(-14, 0, 0).pack(),
+           CalendarInterval(0, 0, 1500000L).pack(),
+           std::nullopt},
+          CALENDAR_INTERVAL()),
+  });
+
+  auto result = evaluate("cast(c0 as varchar)", data);
+  auto expected = makeNullableFlatVector<std::string>({
+      "0 seconds",
+      "1 years 2 months",
+      "5 days",
+      "1 hours 2 minutes 3 seconds",
+      "1 years 2 months 5 days 1 hours 2 minutes 3 seconds",
+      "-1 years -2 months",
+      "1.5 seconds",
+      std::nullopt,
+  });
+
+  assertEqualVectors(expected, result);
+
+  // CalendarInterval cast to an unsupported target type hits the
+  // SAFE_VELOX_UNSUPPORTED fallback.
+  VELOX_ASSERT_THROW(
+      evaluate("cast(c0 as bigint)", data),
+      "Cast from INTERVAL to BIGINT is not supported");
 }
 
 class BigintTypeWithCustomComparisonCastOperator final

--- a/velox/functions/sparksql/CMakeLists.txt
+++ b/velox/functions/sparksql/CMakeLists.txt
@@ -42,7 +42,8 @@ velox_add_library(
   GetJsonObject.cpp
   Hash.cpp
   In.cpp
-  LeastGreatest.cpp
+  LeastGreatest.cpp  MakeInterval.cpp
+
   MakeTimestamp.cpp
   Map.cpp
   RegexFunctions.cpp

--- a/velox/functions/sparksql/Hash.cpp
+++ b/velox/functions/sparksql/Hash.cpp
@@ -20,6 +20,7 @@
 #include "velox/expression/DecodedArgs.h"
 #include "velox/functions/lib/Murmur3Hash32Base.h"
 #include "velox/functions/sparksql/XxHash64.h"
+#include "velox/type/CalendarInterval.h"
 #include "velox/type/DecimalUtil.h"
 #include "velox/vector/FlatVector.h"
 
@@ -100,6 +101,9 @@ class RowVectorHasher;
 template <typename HashClass>
 class UnknowTypeVectorHasher;
 
+template <typename HashClass>
+class CalendarIntervalVectorHasher;
+
 // Class to compute hashes identical to one produced by Spark.
 // Hashes are computed using the algorithm implemented in HashClass.
 template <typename HashClass>
@@ -145,6 +149,16 @@ std::shared_ptr<SparkVectorHasher<HashClass>> createVectorHasher(
       return std::make_shared<RowVectorHasher<HashClass>>(decoded);
     case TypeKind::UNKNOWN:
       return std::make_shared<UnknowTypeVectorHasher<HashClass>>(decoded);
+    case TypeKind::HUGEINT:
+      if (decoded.base()->type()->isCalendarInterval()) {
+        return std::make_shared<CalendarIntervalVectorHasher<HashClass>>(
+            decoded);
+      }
+      return VELOX_DYNAMIC_SCALAR_TEMPLATE_TYPE_DISPATCH(
+          createPrimitiveVectorHasher,
+          HashClass,
+          decoded.base()->typeKind(),
+          decoded);
     default:
       return VELOX_DYNAMIC_SCALAR_TEMPLATE_TYPE_DISPATCH(
           createPrimitiveVectorHasher,
@@ -183,6 +197,27 @@ class UnknowTypeVectorHasher : public SparkVectorHasher<HashClass> {
   ReturnType hashNotNullAt(vector_size_t /*index*/, SeedType /*seed*/)
       override {
     VELOX_FAIL("hashNotNullAt should not be called for unknown type.");
+  }
+};
+
+// Hashes CalendarInterval matching Spark's Murmur3Hash behavior:
+// hashInt(months, hashInt(days, hashLong(microseconds, seed)))
+template <typename HashClass>
+class CalendarIntervalVectorHasher : public SparkVectorHasher<HashClass> {
+ public:
+  using SeedType = typename HashClass::SeedType;
+  using ReturnType = typename HashClass::ReturnType;
+
+  explicit CalendarIntervalVectorHasher(DecodedVector& decoded)
+      : SparkVectorHasher<HashClass>(decoded) {}
+
+  ReturnType hashNotNullAt(vector_size_t index, SeedType seed) override {
+    auto value = this->decoded_.template valueAt<int128_t>(index);
+    auto ci = CalendarInterval::unpack(value);
+    auto h = HashClass::hashInt64(ci.microseconds, seed);
+    h = HashClass::hashInt32(ci.days, h);
+    h = HashClass::hashInt32(ci.months, h);
+    return h;
   }
 };
 
@@ -370,13 +405,15 @@ void applyWithType(
     }
 
     auto kind = args[i]->typeKind();
+    bool isCalendarInterval =
+        kind == TypeKind::HUGEINT && args[i]->type()->isCalendarInterval();
     if ((kind == TypeKind::TINYINT || kind == TypeKind::SMALLINT ||
          kind == TypeKind::INTEGER || kind == TypeKind::BIGINT ||
          kind == TypeKind::REAL || kind == TypeKind::DOUBLE ||
          kind == TypeKind::TIMESTAMP || kind == TypeKind::VARCHAR ||
          kind == TypeKind::VARBINARY || kind == TypeKind::HUGEINT ||
          kind == TypeKind::UNKNOWN) &&
-        args[i]->isFlatEncoding()) {
+        args[i]->isFlatEncoding() && !isCalendarInterval) {
       hashSimd<HashClass, ReturnType>(selected, args, result, i);
       continue;
     }

--- a/velox/functions/sparksql/MakeInterval.cpp
+++ b/velox/functions/sparksql/MakeInterval.cpp
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/expression/DecodedArgs.h"
+#include "velox/expression/VectorFunction.h"
+#include "velox/type/CalendarInterval.h"
+#include "velox/type/TimestampConversion.h"
+#include "velox/type/Type.h"
+#include "velox/vector/ConstantVector.h"
+
+namespace facebook::velox::functions::sparksql {
+namespace {
+
+/// Implements Spark's make_interval(years, months, weeks, days, hours, mins,
+/// secs) function.
+///
+/// Returns CalendarIntervalType (int128_t packed as months|days|microseconds).
+///
+/// Arguments (all optional, default 0):
+///   years  - INTEGER
+///   months - INTEGER
+///   weeks  - INTEGER
+///   days   - INTEGER
+///   hours  - INTEGER
+///   mins   - INTEGER
+///   secs   - DECIMAL(precision, 6); unscaled int64 = microseconds
+///
+/// Overflow behavior: Always throws VELOX_USER_FAIL on overflow. The
+/// expression evaluation framework controls whether this propagates as an
+/// exception (ANSI mode / throwOnError=true) or gets caught and converted
+/// to null (non-ANSI mode / wrapped in TryExpr / throwOnError=false).
+/// to null (non-ANSI mode / wrapped in TryExpr / throwOnError=false).
+class MakeIntervalFunction : public exec::VectorFunction {
+ public:
+  MakeIntervalFunction() {}
+
+  /// The output type: CalendarIntervalType (int128_t packed).
+  static TypePtr outputType() {
+    return CALENDAR_INTERVAL();
+  }
+
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    context.ensureWritable(rows, outputType, result);
+    auto* flatResult = result->asFlatVector<int128_t>();
+
+    // Handle zero-argument case: all fields are 0.
+    if (args.empty()) {
+      rows.applyToSelected([&](vector_size_t row) {
+        flatResult->set(row, CalendarInterval(0, 0, 0).pack());
+      });
+      return;
+    }
+
+    exec::DecodedArgs decodedArgs(rows, args, context);
+    const auto numArgs = args.size();
+
+    // Use applyToSelectedNoThrow so exceptions are handled by the
+    // framework: throwOnError=true re-throws (ANSI), throwOnError=false
+    // stores error and nulls the row (TryExpr/non-ANSI).
+    context.applyToSelectedNoThrow(rows, [&](vector_size_t row) {
+      int32_t years = 0;
+      int32_t months = 0;
+      int32_t weeks = 0;
+      int32_t days = 0;
+      int32_t hours = 0;
+      int32_t mins = 0;
+      int64_t secsUnscaled = 0; // microseconds from DECIMAL(p,6)
+
+      if (numArgs >= 1) {
+        years = decodedArgs.at(0)->valueAt<int32_t>(row);
+      }
+      if (numArgs >= 2) {
+        months = decodedArgs.at(1)->valueAt<int32_t>(row);
+      }
+      if (numArgs >= 3) {
+        weeks = decodedArgs.at(2)->valueAt<int32_t>(row);
+      }
+      if (numArgs >= 4) {
+        days = decodedArgs.at(3)->valueAt<int32_t>(row);
+      }
+      if (numArgs >= 5) {
+        hours = decodedArgs.at(4)->valueAt<int32_t>(row);
+      }
+      if (numArgs >= 6) {
+        mins = decodedArgs.at(5)->valueAt<int32_t>(row);
+      }
+      if (numArgs >= 7) {
+        secsUnscaled = decodedArgs.at(6)->valueAt<int64_t>(row);
+      }
+
+      // Compute totalMonths with overflow check.
+      // Spark: totalMonths = Math.addExact(months, years * 12)
+      int32_t yearsAsMonths32 = 0;
+      if (__builtin_mul_overflow(
+              years, static_cast<int32_t>(12), &yearsAsMonths32)) {
+        VELOX_USER_FAIL(
+            "Integer overflow in make_interval: years({}) * 12 overflows int32",
+            years);
+      }
+
+      int32_t totalMonths32 = 0;
+      if (__builtin_add_overflow(months, yearsAsMonths32, &totalMonths32)) {
+        VELOX_USER_FAIL(
+            "Integer overflow in make_interval: months({}) + years({}) * 12 overflows int32",
+            months,
+            years);
+      }
+
+      // Compute totalDays with overflow check.
+      // Spark: totalDays = Math.addExact(days, Math.multiplyExact(weeks, 7))
+      int32_t weeksAsDays32 = 0;
+      if (__builtin_mul_overflow(
+              weeks, static_cast<int32_t>(7), &weeksAsDays32)) {
+        VELOX_USER_FAIL(
+            "Integer overflow in make_interval: weeks({}) * 7 overflows int32",
+            weeks);
+      }
+
+      int32_t totalDays32 = 0;
+      if (__builtin_add_overflow(days, weeksAsDays32, &totalDays32)) {
+        VELOX_USER_FAIL(
+            "Integer overflow in make_interval: days({}) + weeks({}) * 7 overflows int32",
+            days,
+            weeks);
+      }
+
+      // Compute microseconds matching Spark's IntervalUtils.scala:779-781
+      // left-fold order: start from secs, add hours*MICROS_PER_HOUR, then
+      // add mins*MICROS_PER_MINUTE. This ensures identical overflow points.
+      int64_t hoursMicros = 0;
+      if (__builtin_mul_overflow(hours, util::kMicrosPerHour, &hoursMicros)) {
+        VELOX_USER_FAIL(
+            "Integer overflow in make_interval: hours({}) * MICROS_PER_HOUR overflows",
+            hours);
+      }
+
+      int64_t minsMicros = 0;
+      if (__builtin_mul_overflow(mins, util::kMicrosPerMinute, &minsMicros)) {
+        VELOX_USER_FAIL(
+            "Integer overflow in make_interval: mins({}) * MICROS_PER_MINUTE overflows",
+            mins);
+      }
+
+      // Start from secsUnscaled, then add hoursMicros, then add minsMicros
+      // (matching Spark's left-fold order for identical overflow semantics).
+      int64_t totalMicros = secsUnscaled;
+      if (__builtin_add_overflow(totalMicros, hoursMicros, &totalMicros)) {
+        VELOX_USER_FAIL(
+            "Integer overflow in make_interval: secs + hours micros overflows");
+      }
+      if (__builtin_add_overflow(totalMicros, minsMicros, &totalMicros)) {
+        VELOX_USER_FAIL(
+            "Integer overflow in make_interval: secs + hours + mins micros overflows");
+      }
+
+      flatResult->set(
+          row,
+          CalendarInterval(totalMonths32, totalDays32, totalMicros).pack());
+    });
+  }
+
+  static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
+    auto outputInterval = "INTERVAL";
+    return {
+        // make_interval()
+        exec::FunctionSignatureBuilder().returnType(outputInterval).build(),
+        // make_interval(years)
+        exec::FunctionSignatureBuilder()
+            .returnType(outputInterval)
+            .argumentType("integer")
+            .build(),
+        // make_interval(years, months)
+        exec::FunctionSignatureBuilder()
+            .returnType(outputInterval)
+            .argumentType("integer")
+            .argumentType("integer")
+            .build(),
+        // make_interval(years, months, weeks)
+        exec::FunctionSignatureBuilder()
+            .returnType(outputInterval)
+            .argumentType("integer")
+            .argumentType("integer")
+            .argumentType("integer")
+            .build(),
+        // make_interval(years, months, weeks, days)
+        exec::FunctionSignatureBuilder()
+            .returnType(outputInterval)
+            .argumentType("integer")
+            .argumentType("integer")
+            .argumentType("integer")
+            .argumentType("integer")
+            .build(),
+        // make_interval(years, months, weeks, days, hours)
+        exec::FunctionSignatureBuilder()
+            .returnType(outputInterval)
+            .argumentType("integer")
+            .argumentType("integer")
+            .argumentType("integer")
+            .argumentType("integer")
+            .argumentType("integer")
+            .build(),
+        // make_interval(years, months, weeks, days, hours, mins)
+        exec::FunctionSignatureBuilder()
+            .returnType(outputInterval)
+            .argumentType("integer")
+            .argumentType("integer")
+            .argumentType("integer")
+            .argumentType("integer")
+            .argumentType("integer")
+            .argumentType("integer")
+            .build(),
+        // make_interval(years, months, weeks, days, hours, mins, secs)
+        exec::FunctionSignatureBuilder()
+            // Gluten always casts secs to Decimal(8,6), so precision ≤ 18.
+            // Restrict to short decimals (int64-backed) since we use
+            // valueAt<int64_t>. HUGEINT (precision > 18) would misread.
+            .integerVariable("precision", "min(precision, 18)")
+            .returnType(outputInterval)
+            .argumentType("integer")
+            .argumentType("integer")
+            .argumentType("integer")
+            .argumentType("integer")
+            .argumentType("integer")
+            .argumentType("integer")
+            .argumentType("decimal(precision, 6)")
+            .build(),
+    };
+  }
+
+ private:
+};
+
+} // namespace
+
+/// Factory function for make_interval.
+/// Overflow always throws; the expression framework handles null-on-overflow
+/// via TryExpr wrapping (when failOnError=false in Spark/non-ANSI mode).
+std::shared_ptr<exec::VectorFunction> makeMakeInterval(
+    const std::string& /*name*/,
+    const std::vector<exec::VectorFunctionArg>& /*inputArgs*/,
+    const core::QueryConfig& /*config*/) {
+  return std::make_shared<MakeIntervalFunction>();
+}
+
+VELOX_DECLARE_STATEFUL_VECTOR_FUNCTION(
+    udf_make_interval,
+    MakeIntervalFunction::signatures(),
+    makeMakeInterval);
+
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/registration/RegisterDatetime.cpp
+++ b/velox/functions/sparksql/registration/RegisterDatetime.cpp
@@ -105,6 +105,7 @@ void registerDatetimeFunctions(const std::string& prefix) {
       {prefix + "make_ym_interval"});
   registerFunction<MakeYMIntervalFunction, IntervalYearMonth, int32_t, int32_t>(
       {prefix + "make_ym_interval"});
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_make_interval, prefix + "make_interval");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_make_timestamp, prefix + "make_timestamp");
   registerFunction<TimestampToMicrosFunction, int64_t, Timestamp>(
       {prefix + "unix_micros"});

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -58,6 +58,7 @@ add_executable(
   LeastGreatestTest.cpp
   LuhnCheckTest.cpp
   MakeDecimalTest.cpp
+  MakeIntervalTest.cpp
   MakeTimestampTest.cpp
   MapConcatTest.cpp
   MapFromEntriesTest.cpp

--- a/velox/functions/sparksql/tests/HashTest.cpp
+++ b/velox/functions/sparksql/tests/HashTest.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/common/testutil/OptionalEmpty.h"
 #include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+#include "velox/type/CalendarInterval.h"
 
 #include <stdint.h>
 
@@ -84,6 +85,31 @@ TEST_F(HashTest, longDecimal) {
   EXPECT_EQ(hash<int128_t>(DecimalUtil::kLongDecimalMax), -817514053);
   EXPECT_EQ(hash<int128_t>(-12345678), -1198355617);
   EXPECT_EQ(hash<int128_t>(std::nullopt), 42);
+}
+
+// Spark: SELECT hash(make_interval(months, days, 0, 0, 0, 0, micros_as_secs))
+// Spark hashes CalendarInterval field-by-field:
+//   hashInt(months, hashInt(days, hashLong(microseconds, seed)))
+TEST_F(HashTest, calendarInterval) {
+  // Use vector path to exercise CalendarIntervalVectorHasher.
+  auto intervalVector = makeNullableFlatVector<int128_t>(
+      {CalendarInterval(0, 0, 0).pack(),
+       CalendarInterval(14, 5, 5400000000L).pack(),
+       CalendarInterval(-3, -10, -7200000000L).pack(),
+       CalendarInterval(0, 1, 0).pack(),
+       CalendarInterval(1, 0, 0).pack(),
+       std::nullopt},
+      CALENDAR_INTERVAL());
+
+  auto expected = makeFlatVector<int32_t>(
+      {1954791903, // (0, 0, 0)
+       1085818131, // (14, 5, 5400000000)
+       404949184, // (-3, -10, -7200000000)
+       -1328321721, // (0, 1, 0)
+       -1557981773, // (1, 0, 0)
+       42}); // null → seed
+
+  assertEqualVectors(expected, hash(intervalVector));
 }
 
 // Spark CLI select timestamp_micros(12345678) to get the Timestamp.

--- a/velox/functions/sparksql/tests/MakeIntervalTest.cpp
+++ b/velox/functions/sparksql/tests/MakeIntervalTest.cpp
@@ -1,0 +1,351 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+#include "velox/type/CalendarInterval.h"
+#include "velox/type/Type.h"
+#include "velox/vector/DecodedVector.h"
+
+namespace facebook::velox::functions::sparksql::test {
+namespace {
+
+class MakeIntervalTest : public SparkFunctionBaseTest {
+ protected:
+  struct IntervalResult {
+    int32_t months;
+    int32_t days;
+    int64_t microseconds;
+  };
+
+  // Helper to evaluate and unpack CalendarInterval from int128_t.
+  std::optional<IntervalResult> evaluateInterval(const std::string& expr) {
+    auto result = evaluate(expr, makeRowVector(ROW({}), 1));
+    SelectivityVector rows(1);
+    DecodedVector decoded(*result, rows);
+    if (decoded.isNullAt(0)) {
+      return std::nullopt;
+    }
+    auto packed = decoded.valueAt<int128_t>(0);
+    auto interval = CalendarInterval::unpack(packed);
+    return IntervalResult{
+        interval.months, interval.days, interval.microseconds};
+  }
+
+  // Helper to evaluate with input data and unpack at a specific row.
+  std::optional<IntervalResult> evaluateIntervalAt(
+      const std::string& expr,
+      const RowVectorPtr& data,
+      vector_size_t row = 0) {
+    auto result = evaluate(expr, data);
+    SelectivityVector rows(result->size());
+    DecodedVector decoded(*result, rows);
+    if (decoded.isNullAt(row)) {
+      return std::nullopt;
+    }
+    auto packed = decoded.valueAt<int128_t>(row);
+    auto interval = CalendarInterval::unpack(packed);
+    return IntervalResult{
+        interval.months, interval.days, interval.microseconds};
+  }
+};
+
+TEST_F(MakeIntervalTest, noArgs) {
+  // make_interval() → (0, 0, 0)
+  auto result = evaluateInterval("make_interval()");
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->months, 0);
+  EXPECT_EQ(result->days, 0);
+  EXPECT_EQ(result->microseconds, 0);
+}
+
+TEST_F(MakeIntervalTest, yearsOnly) {
+  // make_interval(2) → (24, 0, 0)
+  auto data = makeRowVector({makeFlatVector<int32_t>({2})});
+  auto result = evaluateIntervalAt("make_interval(c0)", data);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->months, 24); // 2*12
+  EXPECT_EQ(result->days, 0);
+  EXPECT_EQ(result->microseconds, 0);
+}
+
+TEST_F(MakeIntervalTest, yearsAndMonths) {
+  // make_interval(1, 6) → (18, 0, 0)
+  auto data = makeRowVector(
+      {makeFlatVector<int32_t>({1}), makeFlatVector<int32_t>({6})});
+  auto result = evaluateIntervalAt("make_interval(c0, c1)", data);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->months, 18); // 1*12 + 6
+  EXPECT_EQ(result->days, 0);
+  EXPECT_EQ(result->microseconds, 0);
+}
+
+TEST_F(MakeIntervalTest, weeksAndDays) {
+  // make_interval(0, 0, 2, 3) → (0, 17, 0) — 2*7 + 3 = 17 days
+  auto data = makeRowVector(
+      {makeFlatVector<int32_t>({0}),
+       makeFlatVector<int32_t>({0}),
+       makeFlatVector<int32_t>({2}),
+       makeFlatVector<int32_t>({3})});
+  auto result = evaluateIntervalAt("make_interval(c0, c1, c2, c3)", data);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->months, 0);
+  EXPECT_EQ(result->days, 17);
+  EXPECT_EQ(result->microseconds, 0);
+}
+
+TEST_F(MakeIntervalTest, hoursMinutes) {
+  // make_interval(0, 0, 0, 0, 2, 30) → (0, 0, 2*3600000000 + 30*60000000)
+  auto data = makeRowVector(
+      {makeFlatVector<int32_t>({0}),
+       makeFlatVector<int32_t>({0}),
+       makeFlatVector<int32_t>({0}),
+       makeFlatVector<int32_t>({0}),
+       makeFlatVector<int32_t>({2}),
+       makeFlatVector<int32_t>({30})});
+  auto result =
+      evaluateIntervalAt("make_interval(c0, c1, c2, c3, c4, c5)", data);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->months, 0);
+  EXPECT_EQ(result->days, 0);
+  int64_t expectedMicros = 2LL * 3600000000LL + 30LL * 60000000LL;
+  EXPECT_EQ(result->microseconds, expectedMicros);
+}
+
+TEST_F(MakeIntervalTest, allParameters) {
+  // make_interval(1, 2, 3, 4, 5, 6, 7.890000)
+  // months: 1*12 + 2 = 14
+  // days: 3*7 + 4 = 25
+  // micros: 5*3600000000 + 6*60000000 + 7890000 (7.89 secs as micros)
+  auto data = makeRowVector(
+      {makeFlatVector<int32_t>({1}),
+       makeFlatVector<int32_t>({2}),
+       makeFlatVector<int32_t>({3}),
+       makeFlatVector<int32_t>({4}),
+       makeFlatVector<int32_t>({5}),
+       makeFlatVector<int32_t>({6}),
+       makeFlatVector(std::vector<int64_t>{7890000}, DECIMAL(8, 6))});
+  auto result =
+      evaluateIntervalAt("make_interval(c0, c1, c2, c3, c4, c5, c6)", data);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->months, 14);
+  EXPECT_EQ(result->days, 25);
+  int64_t expectedMicros = 5LL * 3600000000LL + 6LL * 60000000LL + 7890000LL;
+  EXPECT_EQ(result->microseconds, expectedMicros);
+}
+
+TEST_F(MakeIntervalTest, negativeValues) {
+  // make_interval(-1, -2, -3, -4, -5, -6, -7.5)
+  // months: -1*12 + (-2) = -14
+  // days: -3*7 + (-4) = -25
+  // micros: -5*3600000000 + (-6)*60000000 + (-7500000)
+  auto data = makeRowVector(
+      {makeFlatVector<int32_t>({-1}),
+       makeFlatVector<int32_t>({-2}),
+       makeFlatVector<int32_t>({-3}),
+       makeFlatVector<int32_t>({-4}),
+       makeFlatVector<int32_t>({-5}),
+       makeFlatVector<int32_t>({-6}),
+       makeFlatVector(std::vector<int64_t>{-7500000}, DECIMAL(8, 6))});
+  auto result =
+      evaluateIntervalAt("make_interval(c0, c1, c2, c3, c4, c5, c6)", data);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->months, -14);
+  EXPECT_EQ(result->days, -25);
+  int64_t expectedMicros =
+      -5LL * 3600000000LL + (-6LL) * 60000000LL + (-7500000LL);
+  EXPECT_EQ(result->microseconds, expectedMicros);
+}
+
+TEST_F(MakeIntervalTest, monthsOverflowReturnsNull) {
+  // years = 178956971 → 178956971 * 12 = 2147483652 > INT32_MAX
+  auto data = makeRowVector({makeFlatVector<int32_t>({178956971})});
+  auto result = evaluateIntervalAt("try(make_interval(c0))", data);
+  EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(MakeIntervalTest, daysOverflowReturnsNull) {
+  // weeks = 306783379 → 306783379 * 7 = 2147483653 > INT32_MAX
+  auto data = makeRowVector(
+      {makeFlatVector<int32_t>({0}),
+       makeFlatVector<int32_t>({0}),
+       makeFlatVector<int32_t>({306783379})});
+  auto result = evaluateIntervalAt("try(make_interval(c0, c1, c2))", data);
+  EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(MakeIntervalTest, microsOverflowReturnsNull) {
+  // hours = 1, secs = INT64_MAX → secsUnscaled + hoursMicros overflows.
+  auto data = makeRowVector(
+      {makeFlatVector<int32_t>({0}),
+       makeFlatVector<int32_t>({0}),
+       makeFlatVector<int32_t>({0}),
+       makeFlatVector<int32_t>({0}),
+       makeFlatVector<int32_t>({1}),
+       makeFlatVector<int32_t>({0}),
+       makeFlatVector(
+           std::vector<int64_t>{std::numeric_limits<int64_t>::max()},
+           DECIMAL(18, 6))});
+  auto result = evaluateIntervalAt(
+      "try(make_interval(c0, c1, c2, c3, c4, c5, c6))", data);
+  EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(MakeIntervalTest, monthsAddOverflowReturnsNull) {
+  // years = 1, months = INT32_MAX → 12 + INT32_MAX overflows.
+  auto data = makeRowVector(
+      {makeFlatVector<int32_t>({1}),
+       makeFlatVector<int32_t>({std::numeric_limits<int32_t>::max()})});
+  auto result = evaluateIntervalAt("try(make_interval(c0, c1))", data);
+  EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(MakeIntervalTest, daysAddOverflowReturnsNull) {
+  // weeks = 1, days = INT32_MAX → 7 + INT32_MAX overflows.
+  auto data = makeRowVector(
+      {makeFlatVector<int32_t>({0}),
+       makeFlatVector<int32_t>({0}),
+       makeFlatVector<int32_t>({1}),
+       makeFlatVector<int32_t>({std::numeric_limits<int32_t>::max()})});
+  auto result = evaluateIntervalAt("try(make_interval(c0, c1, c2, c3))", data);
+  EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(MakeIntervalTest, microsMinsMicrosAddOverflowReturnsNull) {
+  // secs = INT64_MAX, hours = 0, mins = 1 → INT64_MAX + 60000000 overflows.
+  auto data = makeRowVector(
+      {makeFlatVector<int32_t>({0}),
+       makeFlatVector<int32_t>({0}),
+       makeFlatVector<int32_t>({0}),
+       makeFlatVector<int32_t>({0}),
+       makeFlatVector<int32_t>({0}),
+       makeFlatVector<int32_t>({1}),
+       makeFlatVector(
+           std::vector<int64_t>{std::numeric_limits<int64_t>::max()},
+           DECIMAL(18, 6))});
+  auto result = evaluateIntervalAt(
+      "try(make_interval(c0, c1, c2, c3, c4, c5, c6))", data);
+  EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(MakeIntervalTest, microsAssociativityMatchesSpark) {
+  // Verify: hours=1, mins=-60, secs=INT64_MAX
+  // Spark order: INT64_MAX + (1*3600000000) → overflow → null
+  auto data = makeRowVector(
+      {makeFlatVector<int32_t>({0}),
+       makeFlatVector<int32_t>({0}),
+       makeFlatVector<int32_t>({0}),
+       makeFlatVector<int32_t>({0}),
+       makeFlatVector<int32_t>({1}),
+       makeFlatVector<int32_t>({-60}),
+       makeFlatVector(
+           std::vector<int64_t>{std::numeric_limits<int64_t>::max()},
+           DECIMAL(18, 6))});
+  auto result = evaluateIntervalAt(
+      "try(make_interval(c0, c1, c2, c3, c4, c5, c6))", data);
+  EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(MakeIntervalTest, multipleRows) {
+  // Verify vectorized execution across multiple rows.
+  auto data = makeRowVector(
+      {makeFlatVector<int32_t>({1, 0, -1}),
+       makeFlatVector<int32_t>({0, 6, -3})});
+  auto r0 = evaluateIntervalAt("make_interval(c0, c1)", data, 0);
+  auto r1 = evaluateIntervalAt("make_interval(c0, c1)", data, 1);
+  auto r2 = evaluateIntervalAt("make_interval(c0, c1)", data, 2);
+  ASSERT_TRUE(r0.has_value());
+  ASSERT_TRUE(r1.has_value());
+  ASSERT_TRUE(r2.has_value());
+  EXPECT_EQ(r0->months, 12); // 1*12 + 0
+  EXPECT_EQ(r1->months, 6); // 0*12 + 6
+  EXPECT_EQ(r2->months, -15); // -1*12 + (-3)
+}
+
+TEST_F(MakeIntervalTest, overflowWithTryReturnsNull) {
+  // years=178956971 → overflow
+  auto data = makeRowVector(
+      {makeFlatVector<int32_t>({178956971}),
+       makeFlatVector<int32_t>({0}),
+       makeFlatVector<int32_t>({0}),
+       makeFlatVector<int32_t>({0}),
+       makeFlatVector<int32_t>({0}),
+       makeFlatVector<int32_t>({0}),
+       makeFlatVector(std::vector<int64_t>{0}, DECIMAL(18, 6))});
+  auto result = evaluateIntervalAt(
+      "try(make_interval(c0, c1, c2, c3, c4, c5, c6))", data);
+  EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(MakeIntervalTest, overflowWithoutTryThrows) {
+  // Overflow without try() throws (ANSI mode behavior).
+  auto data = makeRowVector(
+      {makeFlatVector<int32_t>({178956971}),
+       makeFlatVector<int32_t>({0}),
+       makeFlatVector<int32_t>({0}),
+       makeFlatVector<int32_t>({0}),
+       makeFlatVector<int32_t>({0}),
+       makeFlatVector<int32_t>({0}),
+       makeFlatVector(std::vector<int64_t>{0}, DECIMAL(18, 6))});
+  VELOX_ASSERT_THROW(
+      evaluate("make_interval(c0, c1, c2, c3, c4, c5, c6)", data),
+      "Integer overflow in make_interval");
+}
+
+TEST_F(MakeIntervalTest, nullInputReturnsNull) {
+  // Default null behavior: any null input produces null output.
+  auto data = makeRowVector(
+      {makeNullableFlatVector<int32_t>({std::nullopt}),
+       makeFlatVector<int32_t>({5}),
+       makeFlatVector<int32_t>({0}),
+       makeFlatVector<int32_t>({10}),
+       makeFlatVector<int32_t>({0}),
+       makeFlatVector<int32_t>({0}),
+       makeFlatVector(std::vector<int64_t>{0}, DECIMAL(18, 6))});
+  auto result =
+      evaluateIntervalAt("make_interval(c0, c1, c2, c3, c4, c5, c6)", data);
+  EXPECT_FALSE(result.has_value());
+
+  // Null in middle argument also produces null.
+  auto data2 = makeRowVector(
+      {makeFlatVector<int32_t>({1}),
+       makeFlatVector<int32_t>({2}),
+       makeNullableFlatVector<int32_t>({std::nullopt}),
+       makeFlatVector<int32_t>({10}),
+       makeFlatVector<int32_t>({0}),
+       makeFlatVector<int32_t>({0}),
+       makeFlatVector(std::vector<int64_t>{0}, DECIMAL(18, 6))});
+  auto result2 =
+      evaluateIntervalAt("make_interval(c0, c1, c2, c3, c4, c5, c6)", data2);
+  EXPECT_FALSE(result2.has_value());
+
+  // Null in last argument (secs DECIMAL) also produces null.
+  auto data3 = makeRowVector(
+      {makeFlatVector<int32_t>({1}),
+       makeFlatVector<int32_t>({2}),
+       makeFlatVector<int32_t>({0}),
+       makeFlatVector<int32_t>({10}),
+       makeFlatVector<int32_t>({3}),
+       makeFlatVector<int32_t>({4}),
+       makeNullableFlatVector(
+           std::vector<std::optional<int64_t>>{std::nullopt}, DECIMAL(18, 6))});
+  auto result3 =
+      evaluateIntervalAt("make_interval(c0, c1, c2, c3, c4, c5, c6)", data3);
+  EXPECT_FALSE(result3.has_value());
+}
+
+} // namespace
+} // namespace facebook::velox::functions::sparksql::test

--- a/velox/row/UnsafeRowFast.cpp
+++ b/velox/row/UnsafeRowFast.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/row/UnsafeRowFast.h"
+#include "velox/type/CalendarInterval.h"
 #include "velox/vector/FlatVector.h"
 
 namespace facebook::velox::row {
@@ -31,7 +32,8 @@ int32_t alignBytes(int32_t numBytes) {
 }
 
 bool isFixedWidth(const TypePtr& type) {
-  return type->isFixedWidth() && !type->isLongDecimal();
+  return type->isFixedWidth() && !type->isLongDecimal() &&
+      !type->isCalendarInterval();
 }
 } // namespace
 
@@ -112,7 +114,8 @@ void UnsafeRowFast::initialize(const TypePtr& type) {
       fixedWidthTypeKind_ = true;
       break;
     case TypeKind::HUGEINT:
-      [[fallthrough]];
+      isCalendarInterval_ = type->isCalendarInterval();
+      break;
     case TypeKind::VARCHAR:
       [[fallthrough]];
     case TypeKind::VARBINARY:
@@ -152,6 +155,10 @@ int32_t UnsafeRowFast::variableWidthRowSize(vector_size_t index) const {
       return alignBytes(value.size());
     }
     case TypeKind::HUGEINT:
+      if (isCalendarInterval_) {
+        // CalendarInterval is always 16 bytes: months(4) + days(4) + micros(8).
+        return 16;
+      }
       return DecimalUtil::getByteArrayLength(decoded_.valueAt<int128_t>(index));
     case TypeKind::ARRAY:
       return arrayRowSize(index);
@@ -218,6 +225,15 @@ int32_t UnsafeRowFast::serializeVariableWidth(vector_size_t index, char* buffer)
     }
     case TypeKind::HUGEINT: {
       auto value = decoded_.valueAt<int128_t>(index);
+      if (isCalendarInterval_) {
+        // Spark UnsafeRow CalendarInterval layout: months(4) | days(4) |
+        // microseconds(8), native byte order.
+        auto interval = CalendarInterval::unpack(value);
+        memcpy(buffer, &interval.months, sizeof(int32_t));
+        memcpy(buffer + 4, &interval.days, sizeof(int32_t));
+        memcpy(buffer + 8, &interval.microseconds, sizeof(int64_t));
+        return 16;
+      }
       return DecimalUtil::toByteArray(value, buffer);
     }
     case TypeKind::ARRAY:
@@ -699,6 +715,43 @@ VectorPtr deserializeLongDecimal(
   return flatVector;
 }
 
+VectorPtr deserializeCalendarInterval(
+    const TypePtr& type,
+    const std::vector<char*>& data,
+    const BufferPtr& nulls,
+    std::vector<size_t>& offsets,
+    memory::MemoryPool* pool) {
+  const auto numRows = data.size();
+  auto flatVector =
+      BaseVector::create<FlatVector<int128_t>>(type, numRows, pool);
+  auto rawValues = flatVector->mutableRawValues();
+
+  auto* rawNulls = nulls->as<uint64_t>();
+
+  for (auto i = 0; i < numRows; ++i) {
+    if (bits::isBitNull(rawNulls, i)) {
+      flatVector->setNull(i, true);
+    } else {
+      // Read offset+size from the fixed-width region.
+      auto offsetAndSize =
+          *reinterpret_cast<const uint64_t*>(data[i] + offsets[i]);
+      auto wordOffset = static_cast<int32_t>(offsetAndSize >> 32);
+      // Read months(4) | days(4) | microseconds(8) from variable region.
+      const char* src = data[i] + wordOffset;
+      int32_t months;
+      int32_t days;
+      int64_t microseconds;
+      memcpy(&months, src, sizeof(int32_t));
+      memcpy(&days, src + 4, sizeof(int32_t));
+      memcpy(&microseconds, src + 8, sizeof(int64_t));
+      rawValues[i] = CalendarInterval(months, days, microseconds).pack();
+    }
+    offsets[i] += kFieldWidth;
+  }
+
+  return flatVector;
+}
+
 VectorPtr deserializeUnknownArrays(
     const TypePtr& type,
     const std::vector<char*>& data,
@@ -1019,6 +1072,9 @@ VectorPtr deserialize(
 
   switch (typeKind) {
     case TypeKind::HUGEINT:
+      if (type->isCalendarInterval()) {
+        return deserializeCalendarInterval(type, data, nulls, offsets, pool);
+      }
       return deserializeLongDecimal(type, data, nulls, offsets, pool);
     case TypeKind::VARCHAR:
     case TypeKind::VARBINARY:

--- a/velox/row/UnsafeRowFast.h
+++ b/velox/row/UnsafeRowFast.h
@@ -121,6 +121,10 @@ class UnsafeRowFast {
   const TypeKind typeKind_;
   DecodedVector decoded_;
 
+  /// True if this column is CalendarIntervalType (shares HUGEINT kind with
+  /// Decimal but has a different UnsafeRow serialization format).
+  bool isCalendarInterval_{false};
+
   /// True if values of 'typeKind_' have fixed width.
   bool fixedWidthTypeKind_{false};
 

--- a/velox/row/tests/UnsafeRowTest.cpp
+++ b/velox/row/tests/UnsafeRowTest.cpp
@@ -20,6 +20,7 @@
 #include <folly/init/Init.h>
 
 #include "velox/row/UnsafeRowFast.h"
+#include "velox/type/CalendarInterval.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
@@ -245,6 +246,28 @@ TEST_F(UnsafeRowTest, timestampUtc) {
   data->childAt(0)->setNull(1, true);
   data->childAt(0)->setNull(3, true);
 
+  testRoundTrip(data);
+}
+
+TEST_F(UnsafeRowTest, calendarInterval) {
+  // Test CalendarInterval serialization round-trip through UnsafeRow.
+  auto type = ROW({CALENDAR_INTERVAL()});
+  auto numRows = 5;
+  auto flatVector = BaseVector::create<FlatVector<int128_t>>(
+      CALENDAR_INTERVAL(), numRows, pool_.get());
+
+  // Row 0: 1 year 2 months, 5 days, 1 hour 30 min (5400000000 micros)
+  flatVector->set(0, CalendarInterval(14, 5, 5400000000L).pack());
+  // Row 1: zero interval
+  flatVector->set(1, CalendarInterval(0, 0, 0).pack());
+  // Row 2: null
+  flatVector->setNull(2, true);
+  // Row 3: negative values
+  flatVector->set(3, CalendarInterval(-3, -10, -7200000000L).pack());
+  // Row 4: large values
+  flatVector->set(4, CalendarInterval(120, 365, 86400000000L).pack());
+
+  auto data = makeRowVector({flatVector});
   testRoundTrip(data);
 }
 

--- a/velox/type/CMakeLists.txt
+++ b/velox/type/CMakeLists.txt
@@ -20,6 +20,7 @@ add_subdirectory(fbhive)
 
 velox_add_library(
   velox_type
+  CalendarInterval.cpp
   CastRegistry.cpp
   Conversions.cpp
   DecimalUtil.cpp

--- a/velox/type/CalendarInterval.cpp
+++ b/velox/type/CalendarInterval.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/type/CalendarInterval.h"
+
+#include <fmt/format.h>
+#include <cmath>
+#include <sstream>
+
+namespace facebook::velox {
+
+namespace {
+constexpr int64_t kMicrosPerSecond = 1'000'000L;
+constexpr int64_t kMicrosPerMinute = 60 * kMicrosPerSecond;
+constexpr int64_t kMicrosPerHour = 60 * kMicrosPerMinute;
+} // namespace
+
+std::string CalendarInterval::toString() const {
+  if (months == 0 && days == 0 && microseconds == 0) {
+    return "0 seconds";
+  }
+
+  std::stringstream ss;
+  bool first = true;
+
+  auto append = [&](int64_t value, const char* unit) {
+    if (value != 0) {
+      if (!first) {
+        ss << " ";
+      }
+      ss << value << " " << unit;
+      first = false;
+    }
+  };
+
+  // Split months into years and remaining months (matching Spark).
+  int32_t years = months / 12;
+  int32_t remainingMonths = months % 12;
+  append(years, "years");
+  append(remainingMonths, "months");
+
+  append(days, "days");
+
+  // Split microseconds into hours, minutes, seconds (matching Spark).
+  int64_t remaining = microseconds;
+  int64_t hours = remaining / kMicrosPerHour;
+  remaining %= kMicrosPerHour;
+  int64_t minutes = remaining / kMicrosPerMinute;
+  remaining %= kMicrosPerMinute;
+
+  append(hours, "hours");
+  append(minutes, "minutes");
+
+  // For seconds, preserve sign and fractional part.
+  if (remaining != 0) {
+    int64_t fracMicros = remaining % kMicrosPerSecond;
+    if (fracMicros == 0) {
+      int64_t wholeSecs = remaining / kMicrosPerSecond;
+      append(wholeSecs, "seconds");
+    } else {
+      if (!first) {
+        ss << " ";
+      }
+      // Format fractional seconds with up to 6 digits, trimming trailing zeros.
+      double secs = static_cast<double>(std::abs(remaining)) / kMicrosPerSecond;
+      std::string secStr = fmt::format("{:.6f}", secs);
+      // Trim trailing zeros.
+      auto pos = secStr.find_last_not_of('0');
+      if (pos != std::string::npos && secStr[pos] == '.') {
+        secStr.erase(pos);
+      } else if (pos != std::string::npos) {
+        secStr.erase(pos + 1);
+      }
+      if (remaining < 0) {
+        ss << "-";
+      }
+      ss << secStr << " seconds";
+      first = false;
+    }
+  }
+
+  return ss.str();
+}
+
+} // namespace facebook::velox

--- a/velox/type/CalendarInterval.h
+++ b/velox/type/CalendarInterval.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include "velox/type/Type.h"
+
+namespace facebook::velox {
+
+/// C++ equivalent of Spark's CalendarInterval.
+/// Three independent fields: months, days, microseconds.
+/// Months and days are calendar units and must NOT be normalized.
+///
+/// Packed into int128_t matching Spark UnsafeRow layout:
+///   low  64 bits: months (low 32) | days (high 32)
+///   high 64 bits: microseconds
+struct CalendarInterval {
+  int32_t months{0};
+  int32_t days{0};
+  int64_t microseconds{0};
+
+  CalendarInterval() = default;
+
+  CalendarInterval(int32_t months, int32_t days, int64_t microseconds)
+      : months(months), days(days), microseconds(microseconds) {}
+
+  /// Pack into int128_t for storage in FlatVector<int128_t>.
+  int128_t pack() const {
+    static_assert(
+        sizeof(int128_t) == 16,
+        "int128_t must be 16 bytes for CalendarInterval packing");
+    // Use unsigned arithmetic to avoid undefined behavior from
+    // left-shifting negative signed values.
+    const uint64_t low = static_cast<uint64_t>(static_cast<uint32_t>(months)) |
+        (static_cast<uint64_t>(static_cast<uint32_t>(days)) << 32);
+    using u128 = unsigned __int128;
+    const u128 packed = static_cast<u128>(low) |
+        (static_cast<u128>(static_cast<uint64_t>(microseconds)) << 64);
+    return static_cast<int128_t>(packed);
+  }
+
+  /// Unpack from int128_t stored in FlatVector<int128_t>.
+  static CalendarInterval unpack(int128_t packed) {
+    int64_t low = static_cast<int64_t>(packed);
+    int32_t months = static_cast<int32_t>(low);
+    int32_t days = static_cast<int32_t>(static_cast<uint64_t>(low) >> 32);
+    int64_t microseconds = static_cast<int64_t>(packed >> 64);
+    return CalendarInterval(months, days, microseconds);
+  }
+
+  bool operator==(const CalendarInterval& other) const {
+    return months == other.months && days == other.days &&
+        microseconds == other.microseconds;
+  }
+
+  bool operator!=(const CalendarInterval& other) const {
+    return !(*this == other);
+  }
+
+  /// Lexicographic comparison by months, then days, then microseconds.
+  /// Used for grouping-like operations (equality partitioning).
+  /// Note: CalendarInterval is comparable but NOT orderable in Spark
+  /// because months and days are not fixed-duration units.
+  int compare(const CalendarInterval& other) const {
+    if (months != other.months) {
+      return months < other.months ? -1 : 1;
+    }
+    if (days != other.days) {
+      return days < other.days ? -1 : 1;
+    }
+    if (microseconds != other.microseconds) {
+      return microseconds < other.microseconds ? -1 : 1;
+    }
+    return 0;
+  }
+
+  /// Format matching Spark's CalendarInterval.toString().
+  /// Examples:
+  ///   {0, 0, 0}        -> "0 seconds"
+  ///   {14, 0, 0}       -> "1 years 2 months"
+  ///   {0, 5, 0}        -> "5 days"
+  ///   {0, 0, 3723000000} -> "1 hours 2 minutes 3 seconds"
+  ///   {14, 5, 3723000000} -> "1 years 2 months 5 days 1 hours 2 minutes 3
+  ///   seconds"
+  std::string toString() const;
+};
+
+} // namespace facebook::velox

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -31,6 +31,7 @@
 #include <typeindex>
 
 #include "velox/external/tzdb/exception.h"
+#include "velox/type/CalendarInterval.h"
 #include "velox/type/CastRegistry.h"
 #include "velox/type/DecimalUtil.h"
 #include "velox/type/Time.h"
@@ -348,6 +349,8 @@ void Type::registerSerDe() {
   registry.Register("DateType", DateType::deserialize);
   registry.Register("TimestampUtcType", TimestampUtcType::deserialize);
   registry.Register("TimeType", TimeTypeFactory::deserialize);
+  registry.Register(
+      "CalendarIntervalType", CalendarIntervalType::deserialize);
 }
 
 std::string ArrayType::toString() const {
@@ -1394,6 +1397,11 @@ std::string IntervalYearMonthType::valueToString(int32_t value) const {
   return oss.str();
 }
 
+std::string CalendarIntervalType::valueToString(int128_t value) const {
+  auto interval = CalendarInterval::unpack(value);
+  return interval.toString();
+}
+
 std::string DateType::toString(int32_t days) const {
   return DateType::toIso8601(days);
 }
@@ -1449,6 +1457,7 @@ const SingletonTypeMap& singletonBuiltInTypes() {
       {"TIMESTAMP UTC", TIMESTAMP_UTC()},
       {"INTERVAL DAY TO SECOND", INTERVAL_DAY_TIME()},
       {"INTERVAL YEAR TO MONTH", INTERVAL_YEAR_MONTH()},
+      {"INTERVAL", CALENDAR_INTERVAL()},
       {"DATE", DATE()},
       {"TIME", TIME()},
       {"TIME MICRO UTC", TIME_MICRO_UTC()},

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -664,6 +664,8 @@ class Type : public Tree<const TypePtr>, public velox::ISerializable {
 
   bool isIntervalDayTime() const;
 
+  bool isCalendarInterval() const;
+
   bool isTime() const;
 
   bool isDate() const;
@@ -1601,6 +1603,62 @@ INTERVAL_YEAR_MONTH() {
 FOLLY_ALWAYS_INLINE bool Type::isIntervalYearMonth() const {
   // Pointer comparison works since this type is a singleton.
   return (this == INTERVAL_YEAR_MONTH().get());
+}
+
+/// Spark CalendarInterval: {months, days, microseconds} packed into int128_t.
+/// Backed by HUGEINT to avoid adding a new TypeKind.
+/// Layout matches Spark UnsafeRow: low 64 = months(low32)|days(high32),
+/// high 64 = microseconds.
+class CalendarIntervalType final : public HugeintType {
+  CalendarIntervalType() = default;
+
+ public:
+  static std::shared_ptr<const CalendarIntervalType> get() {
+    VELOX_CONSTEXPR_SINGLETON CalendarIntervalType kInstance;
+    return {std::shared_ptr<const CalendarIntervalType>{}, &kInstance};
+  }
+
+  const char* name() const override {
+    return "INTERVAL";
+  }
+
+  /// CalendarInterval is comparable (equality for grouping) but not orderable
+  /// because months and days are calendar units without fixed duration.
+  bool isOrderable() const override {
+    return false;
+  }
+
+  bool equivalent(const Type& other) const override {
+    // Pointer comparison works since this type is a singleton.
+    return this == &other;
+  }
+
+  std::string toString() const override {
+    return name();
+  }
+
+  std::string valueToString(int128_t value) const;
+
+  folly::dynamic serialize() const override {
+    folly::dynamic obj = folly::dynamic::object;
+    obj["name"] = "CalendarIntervalType";
+    obj["type"] = name();
+    return obj;
+  }
+
+  static TypePtr deserialize(const folly::dynamic& /*obj*/) {
+    return CalendarIntervalType::get();
+  }
+};
+
+FOLLY_ALWAYS_INLINE std::shared_ptr<const CalendarIntervalType>
+CALENDAR_INTERVAL() {
+  return CalendarIntervalType::get();
+}
+
+FOLLY_ALWAYS_INLINE bool Type::isCalendarInterval() const {
+  // Pointer comparison works since this type is a singleton.
+  return (this == CALENDAR_INTERVAL().get());
 }
 
 /// Date is represented as the number of days since epoch start using int32_t.

--- a/velox/type/Variant.cpp
+++ b/velox/type/Variant.cpp
@@ -19,6 +19,7 @@
 #include "folly/json.h"
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/encode/Base64.h"
+#include "velox/type/CalendarInterval.h"
 #include "velox/type/DecimalUtil.h"
 #include "velox/type/FloatingPointUtil.h"
 
@@ -270,6 +271,9 @@ std::string Variant::toString(const TypePtr& type) const {
       return str;
     }
     case TypeKind::HUGEINT: {
+      if (type->isCalendarInterval()) {
+        return CalendarInterval::unpack(value<TypeKind::HUGEINT>()).toString();
+      }
       if (type->isLongDecimal()) {
         return DecimalUtil::toString(value<TypeKind::HUGEINT>(), type);
       }
@@ -486,6 +490,14 @@ std::string Variant::toJson(const Type& type) const {
       return target;
     }
     case TypeKind::HUGEINT: {
+      if (type.isCalendarInterval()) {
+        std::string target;
+        folly::json::escapeString(
+            CalendarInterval::unpack(value<TypeKind::HUGEINT>()).toString(),
+            target,
+            getOpts());
+        return target;
+      }
       if (type.isLongDecimal()) {
         return DecimalUtil::toString(value<TypeKind::HUGEINT>(), type);
       }
@@ -615,12 +627,19 @@ std::string Variant::toJsonUnsafe(const TypePtr& type) const {
       return target;
     }
     case TypeKind::HUGEINT: {
+      if (type && type->isCalendarInterval()) {
+        std::string target;
+        folly::json::escapeString(
+            CalendarInterval::unpack(value<TypeKind::HUGEINT>()).toString(),
+            target,
+            getOpts());
+        return target;
+      }
       if (type && type->isLongDecimal()) {
         return DecimalUtil::toString(value<TypeKind::HUGEINT>(), type);
       }
       return folly::to<std::string>(value<TypeKind::HUGEINT>());
     }
-    case TypeKind::TINYINT:
       [[fallthrough]];
     case TypeKind::SMALLINT:
       [[fallthrough]];

--- a/velox/type/tests/CMakeLists.txt
+++ b/velox/type/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_subdirectory(utils)
 
 add_executable(
   velox_type_test
+  CalendarIntervalTest.cpp
   CastRegistryTest.cpp
   ConversionsTest.cpp
   DecimalTest.cpp

--- a/velox/type/tests/CalendarIntervalTest.cpp
+++ b/velox/type/tests/CalendarIntervalTest.cpp
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/type/CalendarInterval.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox {
+
+class CalendarIntervalTest : public ::testing::Test {};
+
+// --- Pack/Unpack round-trip tests ---
+
+TEST_F(CalendarIntervalTest, packUnpackZero) {
+  CalendarInterval interval(0, 0, 0);
+  auto packed = interval.pack();
+  auto unpacked = CalendarInterval::unpack(packed);
+  EXPECT_EQ(interval, unpacked);
+  EXPECT_EQ(packed, static_cast<int128_t>(0));
+}
+
+TEST_F(CalendarIntervalTest, packUnpackPositive) {
+  CalendarInterval interval(14, 30, 3600000000L); // 1y2m, 30d, 1h
+  auto packed = interval.pack();
+  auto unpacked = CalendarInterval::unpack(packed);
+  EXPECT_EQ(interval, unpacked);
+}
+
+TEST_F(CalendarIntervalTest, packUnpackNegative) {
+  CalendarInterval interval(-14, -30, -3600000000L);
+  auto packed = interval.pack();
+  auto unpacked = CalendarInterval::unpack(packed);
+  EXPECT_EQ(interval, unpacked);
+}
+
+TEST_F(CalendarIntervalTest, packUnpackMaxValues) {
+  CalendarInterval interval(
+      std::numeric_limits<int32_t>::max(),
+      std::numeric_limits<int32_t>::max(),
+      std::numeric_limits<int64_t>::max());
+  auto packed = interval.pack();
+  auto unpacked = CalendarInterval::unpack(packed);
+  EXPECT_EQ(interval, unpacked);
+}
+
+TEST_F(CalendarIntervalTest, packUnpackMinValues) {
+  CalendarInterval interval(
+      std::numeric_limits<int32_t>::min(),
+      std::numeric_limits<int32_t>::min(),
+      std::numeric_limits<int64_t>::min());
+  auto packed = interval.pack();
+  auto unpacked = CalendarInterval::unpack(packed);
+  EXPECT_EQ(interval, unpacked);
+}
+
+TEST_F(CalendarIntervalTest, packUnpackMixed) {
+  CalendarInterval interval(-1, 5, -1000000L); // -1 month, 5 days, -1 second
+  auto packed = interval.pack();
+  auto unpacked = CalendarInterval::unpack(packed);
+  EXPECT_EQ(interval, unpacked);
+}
+
+// --- toString tests (matching Spark CalendarIntervalSuite) ---
+
+TEST_F(CalendarIntervalTest, toStringZero) {
+  CalendarInterval interval(0, 0, 0);
+  EXPECT_EQ(interval.toString(), "0 seconds");
+}
+
+TEST_F(CalendarIntervalTest, toStringYearsMonths) {
+  CalendarInterval interval(14, 0, 0); // 1 year 2 months
+  EXPECT_EQ(interval.toString(), "1 years 2 months");
+}
+
+TEST_F(CalendarIntervalTest, toStringDays) {
+  CalendarInterval interval(0, 5, 0);
+  EXPECT_EQ(interval.toString(), "5 days");
+}
+
+TEST_F(CalendarIntervalTest, toStringMicroseconds) {
+  // 1 hour, 2 minutes, 3 seconds
+  int64_t micros = 1L * 3600000000L + 2L * 60000000L + 3L * 1000000L;
+  CalendarInterval interval(0, 0, micros);
+  EXPECT_EQ(interval.toString(), "1 hours 2 minutes 3 seconds");
+}
+
+TEST_F(CalendarIntervalTest, toStringFull) {
+  int64_t micros = 1L * 3600000000L + 2L * 60000000L + 3L * 1000000L;
+  CalendarInterval interval(14, 5, micros); // 1y2m 5d 1h2m3s
+  EXPECT_EQ(
+      interval.toString(),
+      "1 years 2 months 5 days 1 hours 2 minutes 3 seconds");
+}
+
+TEST_F(CalendarIntervalTest, toStringNegativeMonths) {
+  CalendarInterval interval(-14, 0, 0); // -1 year -2 months
+  EXPECT_EQ(interval.toString(), "-1 years -2 months");
+}
+
+TEST_F(CalendarIntervalTest, toStringFractionalSeconds) {
+  CalendarInterval interval(0, 0, 1500000L); // 1.5 seconds
+  EXPECT_EQ(interval.toString(), "1.5 seconds");
+}
+
+// --- Equality and comparison ---
+
+TEST_F(CalendarIntervalTest, equality) {
+  CalendarInterval a(1, 2, 3);
+  CalendarInterval b(1, 2, 3);
+  CalendarInterval c(1, 2, 4);
+  EXPECT_EQ(a, b);
+  EXPECT_NE(a, c);
+}
+
+TEST_F(CalendarIntervalTest, compare) {
+  CalendarInterval a(1, 2, 3);
+  CalendarInterval b(1, 2, 4);
+  CalendarInterval c(1, 3, 0);
+  CalendarInterval d(2, 0, 0);
+  EXPECT_LT(a.compare(b), 0);
+  EXPECT_GT(b.compare(a), 0);
+  EXPECT_EQ(a.compare(a), 0);
+  EXPECT_LT(a.compare(c), 0);
+  EXPECT_LT(a.compare(d), 0);
+}
+
+// --- Type system tests ---
+
+TEST_F(CalendarIntervalTest, typeIdentity) {
+  auto type = CALENDAR_INTERVAL();
+  EXPECT_EQ(type->name(), std::string("INTERVAL"));
+  EXPECT_EQ(type->toString(), std::string("INTERVAL"));
+  EXPECT_EQ(type->kind(), TypeKind::HUGEINT);
+  EXPECT_TRUE(type->isCalendarInterval());
+  EXPECT_FALSE(type->isLongDecimal());
+  EXPECT_FALSE(type->isIntervalDayTime());
+  // CalendarInterval is comparable (for grouping) but not orderable.
+  EXPECT_TRUE(type->isComparable());
+  EXPECT_FALSE(type->isOrderable());
+}
+
+TEST_F(CalendarIntervalTest, typeSingleton) {
+  auto a = CALENDAR_INTERVAL();
+  auto b = CALENDAR_INTERVAL();
+  EXPECT_EQ(a.get(), b.get());
+  EXPECT_TRUE(a->equivalent(*b));
+}
+
+TEST_F(CalendarIntervalTest, typeNotEquivalentToHugeint) {
+  auto calendarType = CALENDAR_INTERVAL();
+  auto hugeintType = HUGEINT();
+  EXPECT_FALSE(calendarType->equivalent(*hugeintType));
+}
+
+TEST_F(CalendarIntervalTest, typeKindEqualsHugeint) {
+  auto calendarType = CALENDAR_INTERVAL();
+  EXPECT_TRUE(calendarType->kindEquals(HUGEINT()));
+}
+
+TEST_F(CalendarIntervalTest, typeSerde) {
+  Type::registerSerDe();
+  auto type = CALENDAR_INTERVAL();
+  auto serialized = type->serialize();
+  EXPECT_EQ(serialized["name"], "CalendarIntervalType");
+  auto deserialized = CalendarIntervalType::deserialize(serialized);
+  EXPECT_TRUE(type->equivalent(*deserialized));
+}
+
+TEST_F(CalendarIntervalTest, valueToString) {
+  auto type = CALENDAR_INTERVAL();
+  CalendarInterval interval(14, 5, 3723000000L);
+  auto packed = interval.pack();
+  auto str = type->valueToString(packed);
+  EXPECT_EQ(str, "1 years 2 months 5 days 1 hours 2 minutes 3 seconds");
+}
+
+TEST_F(CalendarIntervalTest, singletonBuiltInTypeLookup) {
+  auto type = getType("INTERVAL", {});
+  ASSERT_NE(type, nullptr);
+  EXPECT_TRUE(type->isCalendarInterval());
+}
+
+} // namespace facebook::velox

--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -22,6 +22,7 @@
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/base/CheckedArithmetic.h"
 #include "velox/common/base/Exceptions.h"
+#include "velox/type/CalendarInterval.h"
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/DictionaryVector.h"
 #include "velox/vector/FlatVector.h"
@@ -417,6 +418,14 @@ const char* exportArrowFormatStr(
       return "z"; // binary
     case TypeKind::UNKNOWN:
       return "n"; // NullType
+    case TypeKind::HUGEINT:
+      // Decimal is handled by the isDecimal() check above; only
+      // CalendarInterval reaches here.
+      if (type->isCalendarInterval()) {
+        return "tin"; // Arrow month-day-nano interval
+      }
+      SAFE_VELOX_NYI(
+          "Unable to map HUGEINT type '{}' to ArrowSchema.", type->kind());
     case TypeKind::TIMESTAMP:
       return exportArrowFormatTimestampStr(type, options, formatBuffer);
     // Complex/nested types.
@@ -841,8 +850,10 @@ bool isFlatScalarZeroCopy(const TypePtr& type, const ArrowOptions& options) {
     return !type->isTimestamp() && !needsTimeConversion;
   }
   // Short decimal requires conversion.
+  // CalendarInterval stores microseconds but Arrow MonthDayNano uses
+  // nanoseconds in the third field.
   return !type->isShortDecimal() && !type->isTimestamp() &&
-      !needsTimeConversion;
+      !needsTimeConversion && !type->isCalendarInterval();
 }
 
 // Returns the size of a single element of a given `type` in the target arrow
@@ -895,6 +906,35 @@ void exportValues(
       type->kind() == TypeKind::BIGINT && type->isTime() &&
       type->equivalent(*TIME())) {
     gatherFromTimeBuffer(vec, rows, *values);
+  } else if (type->isCalendarInterval()) {
+    // Arrow MonthDayNano layout: months(int32), days(int32), nanos(int64).
+    // Velox CalendarInterval: months(int32), days(int32), microseconds(int64).
+    // Convert microseconds -> nanoseconds (x1000).
+    auto* rawOutput = values->asMutable<int128_t>();
+    auto* rawInput = vec.values()->as<int128_t>();
+    auto isNullAt = [&](vector_size_t i) {
+      if (parentNulls && bits::isBitNull(parentNulls, i)) {
+        return true;
+      }
+      return vec.isNullAt(i);
+    };
+    vector_size_t j = 0;
+    rows.apply([&](vector_size_t i) {
+      if (!isNullAt(i)) {
+        auto ci = CalendarInterval::unpack(rawInput[i]);
+        int64_t nanos;
+        if (ci.microseconds > std::numeric_limits<int64_t>::max() / 1000 ||
+            ci.microseconds < std::numeric_limits<int64_t>::min() / 1000) {
+          nanos = ci.microseconds > 0 ? std::numeric_limits<int64_t>::max()
+                                      : std::numeric_limits<int64_t>::min();
+        } else {
+          nanos = ci.microseconds * 1000;
+        }
+        rawOutput[j++] = CalendarInterval(ci.months, ci.days, nanos).pack();
+      } else {
+        rawOutput[j++] = 0;
+      }
+    });
   } else {
     gatherFromBuffer(*type, *vec.values(), rows, options, *values);
   }
@@ -1507,6 +1547,9 @@ TypePtr importFromArrowImpl(
       }
       if (format[1] == 'i' && format[2] == 'M') {
         return INTERVAL_YEAR_MONTH();
+      }
+      if (format[1] == 'i' && format[2] == 'n') {
+        return CALENDAR_INTERVAL();
       }
       break;
 
@@ -2450,6 +2493,25 @@ VectorPtr importFromArrowImpl(
         arrowArray.length,
         arrowArray.null_count,
         wrapInBufferView);
+  } else if (type->isCalendarInterval()) {
+    // Arrow MonthDayNano stores nanoseconds; Velox stores microseconds.
+    // Convert nanos → micros (÷1000).
+    VELOX_USER_CHECK_EQ(
+        arrowArray.n_buffers,
+        2,
+        "CalendarInterval expects two buffers as input.");
+    auto length = arrowArray.length;
+    auto output = AlignedBuffer::allocate<int128_t>(length, pool);
+    auto* rawOutput = output->asMutable<int128_t>();
+    auto* rawInput = static_cast<const int128_t*>(arrowArray.buffers[1]);
+    for (int64_t i = 0; i < length; ++i) {
+      auto ci = CalendarInterval::unpack(rawInput[i]);
+      // The third field is nanoseconds in Arrow; divide by 1000 for micros.
+      rawOutput[i] =
+          CalendarInterval(ci.months, ci.days, ci.microseconds / 1000).pack();
+    }
+    return std::make_shared<FlatVector<int128_t>>(
+        pool, type, nulls, length, std::move(output), std::vector<BufferPtr>{});
   } else if (type->isRow()) {
     // Row/structs.
     return createRowVector(

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -23,6 +23,7 @@
 #include "velox/common/base/Nulls.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/core/QueryCtx.h"
+#include "velox/type/CalendarInterval.h"
 #include "velox/vector/arrow/Bridge.h"
 #include "velox/vector/tests/utils/VectorMaker.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
@@ -2361,6 +2362,164 @@ TEST_F(ArrowBridgeArrayImportAsOwnerTest, releaseCalled) {
 
   EXPECT_TRUE(TestReleaseCalled::schemaReleaseCalled);
   EXPECT_TRUE(TestReleaseCalled::arrayReleaseCalled);
+}
+
+// CalendarInterval Arrow bridge round-trip test.
+// Verifies microsecond→nanosecond (export) and nanosecond→microsecond (import)
+// conversion, including overflow clamping.
+TEST_F(ArrowBridgeArrayExportTest, calendarIntervalRoundTrip) {
+  auto type = CALENDAR_INTERVAL();
+  auto values = AlignedBuffer::allocate<int128_t>(5, pool_.get());
+  auto vec = std::make_shared<FlatVector<int128_t>>(
+      pool_.get(),
+      type,
+      BufferPtr(nullptr), // nulls
+      vector_size_t(5),
+      std::move(values),
+      std::vector<BufferPtr>{});
+
+  // Test values: zero, positive, negative, max micros, near-overflow.
+  vec->set(0, CalendarInterval(0, 0, 0).pack());
+  vec->set(1, CalendarInterval(14, 30, 3600000000L).pack()); // 1y2m, 30d, 1h
+  vec->set(2, CalendarInterval(-3, -10, -7200000000L).pack()); // negative
+  vec->set(3, CalendarInterval(0, 1, 1500L).pack()); // 1500 micros = 1.5ms
+  // Near overflow: max_int64 / 1000 micros (should not overflow on export).
+  vec->set(
+      4,
+      CalendarInterval(120, 365, std::numeric_limits<int64_t>::max() / 1000)
+          .pack());
+
+  // Export to Arrow.
+  ArrowSchema schema;
+  ArrowArray data;
+  velox::exportToArrow(vec, schema, options_);
+  velox::exportToArrow(vec, data, pool_.get(), options_);
+
+  // Verify Arrow schema is month-day-nano interval.
+  EXPECT_STREQ(schema.format, "tin");
+
+  // Import back to Velox.
+  auto result = importFromArrowAsOwner(schema, data, pool_.get());
+  ASSERT_NE(result, nullptr);
+  ASSERT_EQ(result->size(), 5);
+  EXPECT_TRUE(result->type()->isCalendarInterval());
+
+  auto* flat = result->as<FlatVector<int128_t>>();
+
+  // Values should round-trip exactly (micros * 1000 / 1000 = micros).
+  EXPECT_EQ(flat->valueAt(0), CalendarInterval(0, 0, 0).pack());
+  EXPECT_EQ(flat->valueAt(1), CalendarInterval(14, 30, 3600000000L).pack());
+  EXPECT_EQ(flat->valueAt(2), CalendarInterval(-3, -10, -7200000000L).pack());
+  EXPECT_EQ(flat->valueAt(3), CalendarInterval(0, 1, 1500L).pack());
+  EXPECT_EQ(
+      flat->valueAt(4),
+      CalendarInterval(120, 365, std::numeric_limits<int64_t>::max() / 1000)
+          .pack());
+}
+
+// Test that microsecond overflow is clamped on export.
+TEST_F(ArrowBridgeArrayExportTest, calendarIntervalOverflow) {
+  auto type = CALENDAR_INTERVAL();
+  auto values = AlignedBuffer::allocate<int128_t>(2, pool_.get());
+  auto vec = std::make_shared<FlatVector<int128_t>>(
+      pool_.get(),
+      type,
+      BufferPtr(nullptr),
+      vector_size_t(2),
+      std::move(values),
+      std::vector<BufferPtr>{});
+
+  // These micros values will overflow when multiplied by 1000.
+  vec->set(
+      0, CalendarInterval(1, 1, std::numeric_limits<int64_t>::max()).pack());
+  vec->set(
+      1, CalendarInterval(1, 1, std::numeric_limits<int64_t>::min()).pack());
+
+  // Export to Arrow — should clamp to INT64_MAX/MIN nanos.
+  ArrowSchema schema;
+  ArrowArray data;
+  velox::exportToArrow(vec, schema, options_);
+  velox::exportToArrow(vec, data, pool_.get(), options_);
+
+  // Import back — clamped nanos / 1000 gives clamped micros.
+  auto result = importFromArrowAsOwner(schema, data, pool_.get());
+  auto* flat = result->as<FlatVector<int128_t>>();
+
+  // After clamp: MAX_INT64 nanos / 1000 = MAX_INT64 / 1000 micros.
+  auto ci0 = CalendarInterval::unpack(flat->valueAt(0));
+  EXPECT_EQ(ci0.months, 1);
+  EXPECT_EQ(ci0.days, 1);
+  EXPECT_EQ(ci0.microseconds, std::numeric_limits<int64_t>::max() / 1000);
+
+  auto ci1 = CalendarInterval::unpack(flat->valueAt(1));
+  EXPECT_EQ(ci1.months, 1);
+  EXPECT_EQ(ci1.days, 1);
+  EXPECT_EQ(ci1.microseconds, std::numeric_limits<int64_t>::min() / 1000);
+}
+
+// Test CalendarInterval export as a struct child with parent nulls,
+// which exercises the compacted-index (j++) path and parentNulls propagation.
+// Mirrors rowVectorNullPropagationTimestamp.
+TEST_F(ArrowBridgeArrayExportTest, calendarIntervalParentNulls) {
+  auto type = CALENDAR_INTERVAL();
+  auto values = AlignedBuffer::allocate<int128_t>(5, pool_.get());
+  auto child = std::make_shared<FlatVector<int128_t>>(
+      pool_.get(),
+      type,
+      BufferPtr(nullptr), // no child-level nulls
+      vector_size_t(5),
+      std::move(values),
+      std::vector<BufferPtr>{});
+
+  child->set(0, CalendarInterval(1, 10, 1000000L).pack());
+  child->set(1, CalendarInterval(2, 20, 2000000L).pack());
+  child->set(2, CalendarInterval(3, 30, 3000000L).pack());
+  child->set(3, CalendarInterval(4, 40, 4000000L).pack());
+  child->set(4, CalendarInterval(5, 50, 5000000L).pack());
+
+  // Create parent with nulls at positions 1 and 3.
+  auto parent = vectorMaker_.rowVector({child});
+  parent->setNull(1, true);
+  parent->setNull(3, true);
+  parent->setNullCount(2);
+
+  ArrowArray arrowArray;
+  EXPECT_NO_THROW(
+      velox::exportToArrow(parent, arrowArray, pool_.get(), options_));
+
+  // Verify child has null propagation from parent.
+  ArrowArray* childArrow = arrowArray.children[0];
+  EXPECT_NE(nullptr, childArrow);
+  EXPECT_GE(childArrow->null_count, 2);
+
+  const uint64_t* childNulls =
+      static_cast<const uint64_t*>(childArrow->buffers[0]);
+  EXPECT_NE(nullptr, childNulls);
+  EXPECT_TRUE(bits::isBitNull(childNulls, 1));
+  EXPECT_TRUE(bits::isBitNull(childNulls, 3));
+
+  // Verify non-null values are correctly placed (compacted index).
+  const auto* rawValues = static_cast<const int128_t*>(childArrow->buffers[1]);
+  // Positions 0, 2, 4 are non-null; their values should be at indices 0, 2, 4
+  // in the exported buffer (Arrow keeps the same indexing for RowVector
+  // children since all rows are selected).
+  auto ci0 = CalendarInterval::unpack(rawValues[0]);
+  EXPECT_EQ(ci0.months, 1);
+  EXPECT_EQ(ci0.days, 10);
+  // micros converted to nanos: 1000000 * 1000 = 1000000000
+  EXPECT_EQ(ci0.microseconds, 1000000000L);
+
+  auto ci2 = CalendarInterval::unpack(rawValues[2]);
+  EXPECT_EQ(ci2.months, 3);
+  EXPECT_EQ(ci2.days, 30);
+  EXPECT_EQ(ci2.microseconds, 3000000000L);
+
+  auto ci4 = CalendarInterval::unpack(rawValues[4]);
+  EXPECT_EQ(ci4.months, 5);
+  EXPECT_EQ(ci4.days, 50);
+  EXPECT_EQ(ci4.microseconds, 5000000000L);
+
+  arrowArray.release(&arrowArray);
 }
 
 } // namespace


### PR DESCRIPTION
## Summary

Adds native support for Spark's CalendarInterval type (months, days, microseconds packed into int128_t/HUGEINT) and the make_interval() scalar function to the Velox Spark function library.

## Components

- **CalendarInterval type** (velox/type/): Custom type extending HUGEINT with pack/unpack helpers, toString, comparison (equality only, not orderable), serialization/deserialization, and singleton registration.
- **make_interval() function** (velox/functions/sparksql/): Constructs a CalendarInterval from up to 7 optional arguments (years, months, weeks, days, hours, mins, secs). Validates overflow for each component.
- **Hash support**: Spark-compatible field-by-field Murmur3 hashing that matches Spark's CalendarInterval hash contract (hash months, then mix days, then mix microseconds).
- **Cast support**: CalendarInterval -> VARCHAR using the standard Spark interval string representation.
- **UnsafeRow serialization**: Spark-compatible 16-byte layout (months i32, days i32, microseconds i64) for shuffle/exchange.
- **Arrow Bridge**: Export as Arrow MonthDayNano interval with microsecond-to-nanosecond conversion; import with nanosecond-to-microsecond conversion.
- **ConstantExpr**: Proper toString for CalendarInterval constants.

## Tests

- CalendarIntervalTest: pack/unpack, toString, comparison, type registry.
- MakeIntervalTest: all argument combinations, defaults, overflow detection.
- HashTest: CalendarInterval hashing matches expected Spark values.
- CastExprTest: CalendarInterval to VARCHAR casting.
- UnsafeRowTest: round-trip serialization/deserialization.
- ArrowBridgeArrayTest: export/import round-trip, overflow clamping, parent nulls propagation.

## Motivation

This enables Gluten/Velox to natively handle Spark's CalendarInterval type during shuffle, hashing, and expression evaluation - avoiding fallback to JVM for queries that produce or consume interval values (e.g., make_interval(), window frame specifications).

## Note

Date/timestamp arithmetic consuming CalendarInterval (e.g., date + interval) is not yet implemented and will fall back to Spark execution.