### PR TITLE
fix(docs): Fix configs.rst Parquet options table rendering in GitHub preview

### DIFF
--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -1068,14 +1068,14 @@ Parquet Options (prefix ``hive.parquet.``)
        "1GB". Zero means no limit (default). File rotation is not supported for bucketed tables or
        sorted writes.
 
-      Session: ``parquet_writer_max_target_file_size``.
+       Session: ``parquet_writer_max_target_file_size``.
 
-      Row-group sizing is independent of this setting and is not user-configurable: a row group is
-      flushed at a 128MB byte target or 1,048,576 rows, whichever comes first. The byte target is
-      soft - a row group may slightly exceed it, since the writer flushes only after buffered bytes
-      reach the target; the row count is a hard cap. When ``writer.max-target-file-size`` is set,
-      the writer may flush the current row group early so the accumulated file size is visible and
-      rotation can occur.
+       Row-group sizing is independent of this setting and is not user-configurable: a row group is
+       flushed at a 128MB byte target or 1,048,576 rows, whichever comes first. The byte target is
+       soft - a row group may slightly exceed it, since the writer flushes only after buffered bytes
+       reach the target; the row count is a hard cap. When ``writer.max-target-file-size`` is set,
+       the writer may flush the current row group early so the accumulated file size is visible and
+       rotation can occur.
    * - ``writer.enable-dictionary``
      - bool
      - true


### PR DESCRIPTION
Fix the empty Parquet options table caused by incorrect RST indentation.

<img width="1023" height="85" alt="image" src="https://github.com/user-attachments/assets/13c82a62-d657-47c8-a35c-3651bd5e9071" />
