### PR TITLE
fix: UBSan misaligned-load failures

### DIFF
--- a/velox/dwio/common/DecoderUtil.h
+++ b/velox/dwio/common/DecoderUtil.h
@@ -17,6 +17,11 @@
 #pragma once
 
 #include <algorithm>
+#include <cstring>
+#include <type_traits>
+
+#include <folly/lang/Bits.h>
+
 #include "velox/common/base/Portability.h"
 #include "velox/common/memory/RawVector.h"
 #include "velox/common/process/ProcessBase.h"
@@ -145,12 +150,25 @@ inline int32_t firstNullIndex(const uint64_t* nulls, int32_t numRows) {
   return first;
 }
 
+template <typename T>
+const char*
+fixedWidthValueBytes(const T* buffer, int32_t row, int32_t rowOffset) {
+  return reinterpret_cast<const char*>(buffer) + (row - rowOffset) * sizeof(T);
+}
+
 template <typename T, typename Any>
 void scatterDense(
     const Any* data,
     const int32_t* indices,
     int32_t size,
     T* target) {
+  if constexpr (std::is_same_v<Any, char>) {
+    for (auto i = 0; i < size; ++i) {
+      target[indices[i]] = folly::loadUnaligned<T>(data + i * sizeof(T));
+    }
+    return;
+  }
+
   auto source = reinterpret_cast<const T*>(data);
   if (source >= target && source < target + indices[size - 1]) {
     for (int32_t i = size - 1; i >= 0; --i) {
@@ -309,8 +327,7 @@ void fixedWidthScan(
           if (isDense(&rows[rowIndex], numRowsInBuffer)) {
             std::memcpy(
                 rawValues + numValues,
-                reinterpret_cast<const char*>(buffer) +
-                    (rows[rowIndex] - rowOffset) * sizeof(T),
+                fixedWidthValueBytes<T>(buffer, rows[rowIndex], rowOffset),
                 sizeof(T) * numRowsInBuffer);
             numValues += numRowsInBuffer;
             return;
@@ -323,18 +340,16 @@ void fixedWidthScan(
             [&](int32_t rowIndex) {
               auto firstRow = rows[rowIndex];
               if (!hasFilter) {
-                auto* firstValue = reinterpret_cast<const char*>(buffer) +
-                    (firstRow - rowOffset) * sizeof(T);
+                auto* firstValue =
+                    fixedWidthValueBytes<T>(buffer, firstRow, rowOffset);
                 if (hasHook) {
                   T values[kStep];
                   std::memcpy(values, firstValue, sizeof(T) * kStep);
                   hook.addValues(scatterRows + rowIndex, values, kStep);
                 } else {
                   if (scatter) {
-                    T values[kStep];
-                    std::memcpy(values, firstValue, sizeof(T) * kStep);
                     scatterDense(
-                        values, scatterRows + rowIndex, kStep, rawValues);
+                        firstValue, scatterRows + rowIndex, kStep, rawValues);
                   } else {
                     FOLLY_BUILTIN_MEMCPY(
                         rawValues + numValues, firstValue, sizeof(T) * kStep);

--- a/velox/dwio/common/DecoderUtil.h
+++ b/velox/dwio/common/DecoderUtil.h
@@ -309,7 +309,8 @@ void fixedWidthScan(
           if (isDense(&rows[rowIndex], numRowsInBuffer)) {
             std::memcpy(
                 rawValues + numValues,
-                buffer + rows[rowIndex] - rowOffset,
+                reinterpret_cast<const char*>(buffer) +
+                    (rows[rowIndex] - rowOffset) * sizeof(T),
                 sizeof(T) * numRowsInBuffer);
             numValues += numRowsInBuffer;
             return;
@@ -322,23 +323,21 @@ void fixedWidthScan(
             [&](int32_t rowIndex) {
               auto firstRow = rows[rowIndex];
               if (!hasFilter) {
+                auto* firstValue = reinterpret_cast<const char*>(buffer) +
+                    (firstRow - rowOffset) * sizeof(T);
                 if (hasHook) {
-                  hook.addValues(
-                      scatterRows + rowIndex,
-                      buffer + firstRow - rowOffset,
-                      kStep);
+                  T values[kStep];
+                  std::memcpy(values, firstValue, sizeof(T) * kStep);
+                  hook.addValues(scatterRows + rowIndex, values, kStep);
                 } else {
                   if (scatter) {
+                    T values[kStep];
+                    std::memcpy(values, firstValue, sizeof(T) * kStep);
                     scatterDense(
-                        buffer + firstRow - rowOffset,
-                        scatterRows + rowIndex,
-                        kStep,
-                        rawValues);
+                        values, scatterRows + rowIndex, kStep, rawValues);
                   } else {
                     FOLLY_BUILTIN_MEMCPY(
-                        rawValues + numValues,
-                        buffer + firstRow - rowOffset,
-                        sizeof(T) * kStep);
+                        rawValues + numValues, firstValue, sizeof(T) * kStep);
                   }
                 }
                 numValues += kStep;

--- a/velox/dwio/common/DecoderUtil.h
+++ b/velox/dwio/common/DecoderUtil.h
@@ -150,6 +150,7 @@ inline int32_t firstNullIndex(const uint64_t* nulls, int32_t numRows) {
   return first;
 }
 
+// Returns raw bytes because fixed-width page data may be unaligned.
 template <typename T>
 const char*
 fixedWidthValueBytes(const T* buffer, int32_t row, int32_t rowOffset) {

--- a/velox/dwio/parquet/reader/PageReader.cpp
+++ b/velox/dwio/parquet/reader/PageReader.cpp
@@ -627,7 +627,7 @@ void PageReader::prepareDictionary(const PageHeader& pageHeader) {
       }
       auto header = strings;
       for (auto i = 0; i < dictionary_.numValues; ++i) {
-        auto length = *reinterpret_cast<const int32_t*>(header);
+        auto length = folly::loadUnaligned<int32_t>(header);
         values[i] = StringView(header + sizeof(int32_t), length);
         header += length + sizeof(int32_t);
       }

--- a/velox/dwio/parquet/reader/PageReader.h
+++ b/velox/dwio/parquet/reader/PageReader.h
@@ -16,8 +16,7 @@
 
 #pragma once
 
-#include <cstring>
-#include <type_traits>
+#include <folly/lang/Bits.h>
 
 #include "velox/common/compression/Compression.h"
 #include "velox/dwio/common/BitConcatenation.h"
@@ -255,9 +254,7 @@ class PageReader {
 
   template <typename T>
   T readField(const char* FOLLY_NONNULL& ptr) {
-    static_assert(std::is_trivially_copyable_v<T>);
-    T data;
-    std::memcpy(&data, ptr, sizeof(T));
+    T data = folly::loadUnaligned<T>(ptr);
     ptr += sizeof(T);
     return data;
   }

--- a/velox/dwio/parquet/reader/PageReader.h
+++ b/velox/dwio/parquet/reader/PageReader.h
@@ -16,6 +16,9 @@
 
 #pragma once
 
+#include <cstring>
+#include <type_traits>
+
 #include "velox/common/compression/Compression.h"
 #include "velox/dwio/common/BitConcatenation.h"
 #include "velox/dwio/common/DirectDecoder.h"
@@ -252,7 +255,9 @@ class PageReader {
 
   template <typename T>
   T readField(const char* FOLLY_NONNULL& ptr) {
-    T data = *reinterpret_cast<const T*>(ptr);
+    static_assert(std::is_trivially_copyable_v<T>);
+    T data;
+    std::memcpy(&data, ptr, sizeof(T));
     ptr += sizeof(T);
     return data;
   }

--- a/velox/dwio/parquet/reader/RleBpDecoder.cpp
+++ b/velox/dwio/parquet/reader/RleBpDecoder.cpp
@@ -17,6 +17,7 @@
 #include "velox/dwio/parquet/reader/RleBpDecoder.h"
 
 #include <folly/Varint.h>
+#include <folly/lang/Bits.h>
 
 namespace facebook::velox::parquet {
 
@@ -103,7 +104,7 @@ void RleBpDecoder::readHeader() {
     // Do not load past buffer end. Reports error in valgrind and could in
     // principle run into unmapped addresses.
     if (bufferStart_ <= lastSafeWord_) {
-      value_ = *reinterpret_cast<const int64_t*>(bufferStart_) & bitMask_;
+      value_ = folly::loadUnaligned<int64_t>(bufferStart_) & bitMask_;
     } else {
       value_ = bits::loadPartialWord(
           reinterpret_cast<const uint8_t*>(bufferStart_), byteWidth_);

--- a/velox/dwio/parquet/reader/StringDecoder.h
+++ b/velox/dwio/parquet/reader/StringDecoder.h
@@ -17,8 +17,9 @@
 #pragma once
 
 #include <cstdint>
-#include <cstring>
 #include <string_view>
+
+#include <folly/lang/Bits.h>
 
 #include "velox/common/base/Nulls.h"
 #include "velox/common/base/SimdUtil.h"
@@ -101,9 +102,7 @@ class StringDecoder {
 
  private:
   int32_t lengthAt(const char* buffer) {
-    int32_t length;
-    std::memcpy(&length, buffer, sizeof(length));
-    return length;
+    return folly::loadUnaligned<int32_t>(buffer);
   }
 
   std::string_view readString() {

--- a/velox/dwio/parquet/reader/StringDecoder.h
+++ b/velox/dwio/parquet/reader/StringDecoder.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cstdint>
+#include <cstring>
 #include <string_view>
 
 #include "velox/common/base/Nulls.h"
@@ -100,7 +101,9 @@ class StringDecoder {
 
  private:
   int32_t lengthAt(const char* buffer) {
-    return *reinterpret_cast<const int32_t*>(buffer);
+    int32_t length;
+    std::memcpy(&length, buffer, sizeof(length));
+    return length;
   }
 
   std::string_view readString() {

--- a/velox/dwio/parquet/tests/reader/RleBpDecoderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/RleBpDecoderTest.cpp
@@ -14,14 +14,19 @@
  * limitations under the License.
  */
 
+#include "velox/dwio/parquet/reader/RleBpDecoder.h"
 #include "velox/dwio/common/BitPackDecoder.h"
 #include "velox/dwio/parquet/common/RleEncodingInternal.h"
+
+#include <algorithm>
+#include <vector>
 
 #include <gtest/gtest.h>
 
 using namespace facebook::velox;
 using namespace facebook::velox::dwio::common;
 
+using facebook::velox::parquet::RleBpDecoder;
 using facebook::velox::parquet::RleEncoder;
 
 template <typename T>
@@ -139,4 +144,37 @@ TEST(RleBpDecoderTest, DISABLED_allOnes) {
   std::vector<uint8_t> allOnesVector(1024, 1);
   RleBpDecoderTest<uint8_t> test;
   test.testDecodeSuppliedData(allOnesVector, 1);
+}
+
+TEST(RleBpDecoderTest, unalignedRepeatingValue) {
+  constexpr int32_t kCount = 3;
+  constexpr int32_t kValue = 0x12345678;
+
+  std::vector<uint8_t> encoded = {
+      static_cast<uint8_t>(kCount << 1),
+      0x78,
+      0x56,
+      0x34,
+      0x12,
+      0,
+      0,
+      0,
+      0,
+  };
+
+  std::vector<uint8_t> unaligned(1 + encoded.size(), 0);
+  std::copy(encoded.begin(), encoded.end(), unaligned.begin() + 1);
+
+  RleBpDecoder decoder(
+      reinterpret_cast<const char*>(unaligned.data() + 1),
+      reinterpret_cast<const char*>(unaligned.data() + unaligned.size()),
+      32);
+
+  std::vector<int32_t> output(kCount);
+  auto* outputPtr = output.data();
+  decoder.next(outputPtr, output.size());
+
+  for (auto value : output) {
+    ASSERT_EQ(value, kValue);
+  }
 }

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -479,9 +479,8 @@ TEST_F(ParquetWriterTest, compression) {
   auto rowReader = createRowReaderFromReader(*reader, schema);
   assertReadWithReaderAndExpected(schema, *rowReader, data, *leafPool_);
 }
-// TODO: Re-enable after fixing unaligned reads reported by UBSan.
-// https://github.com/facebookincubator/velox/issues/18329
-TEST_F(ParquetWriterTest, DISABLED_compressionRoundTripAcrossPages) {
+
+TEST_F(ParquetWriterTest, compressionRoundTripAcrossPages) {
   // Writes multi-page data with every writable codec and verifies the values
   // round-trip. Small data pages force many compressed pages per column, so the
   // reader's per-codec decompression paths (the Snappy/ZSTD/GZIP direct paths


### PR DESCRIPTION
Fix UBSan misaligned-load failures when reading Parquet page data from compressed page buffers.

Parquet page payloads are byte streams and are not guaranteed to be naturally aligned for fixed-width C++ types. The new multi-page compression round-trip test can expose page data at unaligned offsets, causing direct typed loads such as reinterpret_cast<const int32_t*>, reinterpret_cast<const uint32_t*>, and reinterpret_cast<const double*> to trigger undefined behavior under UBSan.

This change replaces the affected typed loads with memcpy-based reads in:

- Parquet page field decoding
- Plain string length decoding
- Fixed-width dense value handling

Fix https://github.com/facebookincubator/velox/issues/18329.
