### PR TITLE
perf: Optimize probing misses using bloom filter for kLeft / kLeftSemiProject / kAnti hash join

### DIFF
--- a/velox/core/QueryConfig.cpp
+++ b/velox/core/QueryConfig.cpp
@@ -150,6 +150,8 @@ const std::vector<config::ConfigProperty>& QueryConfig::registeredProperties() {
     VELOX_REGISTER_QUERY_CONFIG(kHashProbeDynamicFilterPushdownEnabled);
     VELOX_REGISTER_QUERY_CONFIG(kHashProbeStringDynamicFilterPushdownEnabled);
     VELOX_REGISTER_QUERY_CONFIG(kHashProbeBloomFilterPushdownMaxSize);
+    VELOX_REGISTER_QUERY_CONFIG(kBypassHashProbeBloomFilterMinRows);
+    VELOX_REGISTER_QUERY_CONFIG(kBypassHashProbeBloomFilterMinPct);
     VELOX_REGISTER_QUERY_CONFIG(kMinTableRowsForParallelJoinBuild);
 
     // Debug and validation.

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -890,6 +890,28 @@ class QueryConfig {
       0,
       "Maximum byte size of Bloom filter from hash probe. 0 disables.")
 
+  /// Number of probe rows used to decide whether to bypass the build-side
+  /// Bloom filter. 0 disables local Bloom filter probing.
+  VELOX_QUERY_CONFIG(
+      kBypassHashProbeBloomFilterMinRows,
+      bypassHashProbeBloomFilterMinRows,
+      "bypass_hash_probe_bloom_filter_min_rows",
+      int32_t,
+      0,
+      "Number of probe rows used to decide whether to bypass the build-side "
+      "Bloom filter. 0 disables local Bloom filter probing.")
+
+  /// Bypass the build-side Bloom filter if its acceptance percentage meets
+  /// or exceeds this value. 0 bypasses the Bloom filter without sampling.
+  VELOX_QUERY_CONFIG(
+      kBypassHashProbeBloomFilterMinPct,
+      bypassHashProbeBloomFilterMinPct,
+      "bypass_hash_probe_bloom_filter_min_pct",
+      int32_t,
+      85,
+      "Bypass the build-side Bloom filter if its acceptance percentage meets "
+      "or exceeds this value. 0 bypasses the Bloom filter without sampling.")
+
   /// The minimum number of table rows that can trigger the parallel hash join
   /// table build.
   VELOX_QUERY_CONFIG(

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -891,7 +891,8 @@ class QueryConfig {
       "Maximum byte size of Bloom filter from hash probe. 0 disables.")
 
   /// Number of probe rows used to decide whether to bypass the build-side
-  /// Bloom filter. 0 disables local Bloom filter probing.
+  /// Bloom filter for left joins and non-null-aware left semi-project and left
+  /// anti joins. 0 disables local Bloom filter probing.
   VELOX_QUERY_CONFIG(
       kBypassHashProbeBloomFilterMinRows,
       bypassHashProbeBloomFilterMinRows,
@@ -899,7 +900,8 @@ class QueryConfig {
       int32_t,
       0,
       "Number of probe rows used to decide whether to bypass the build-side "
-      "Bloom filter. 0 disables local Bloom filter probing.")
+      "Bloom filter for left joins and non-null-aware left semi-project and "
+      "left anti joins. 0 disables local Bloom filter probing.")
 
   /// Bypass the build-side Bloom filter if its acceptance percentage meets
   /// or exceeds this value. 0 bypasses the Bloom filter without sampling.

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -173,6 +173,17 @@ Generic Configuration
        probe.  When set to 0, no Bloom filter will be generated.  To achieve
        optimal performance, this should not be too larger than the CPU cache
        size on the host.
+   * - bypass_hash_probe_bloom_filter_min_rows
+     - integer
+     - 0
+     - The number of probe rows used to decide whether to bypass the build-side
+       Bloom filter. When set to 0, local Bloom filter probing is disabled.
+   * - bypass_hash_probe_bloom_filter_min_pct
+     - integer
+     - 85
+     - Bypass the build-side Bloom filter if its acceptance percentage meets
+       or exceeds this value. When set to 0, the Bloom filter is bypassed
+       without sampling.
    * - debug.validate_output_from_operators
      - bool
      - false

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -177,7 +177,8 @@ Generic Configuration
      - integer
      - 0
      - The number of probe rows used to decide whether to bypass the build-side
-       Bloom filter. When set to 0, local Bloom filter probing is disabled.
+       Bloom filter for left joins and non-null-aware left semi-project and left
+       anti joins. When set to 0, local Bloom filter probing is disabled.
    * - bypass_hash_probe_bloom_filter_min_pct
      - integer
      - 85

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -510,6 +510,9 @@ void HashProbe::applyBloomFilterForJoinProbe() {
     if (bloomFilterSampledRows_ >= bypassBloomFilterMinRows_) {
       bypassBloomFilter_ = bloomFilterSampleAcceptedRows_ * 100 >=
           bloomFilterSampledRows_ * bypassBloomFilterMinPct_;
+      if (bypassBloomFilter_) {
+        addRuntimeStat(std::string(kBloomFilterBypassed), RuntimeCounter(1));
+      }
     }
   }
 

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -33,6 +33,22 @@ namespace {
 
 // Batch size used when iterating the row container.
 constexpr int kBatchSize = 1024;
+
+template <typename T>
+int64_t applyBloomFilter(
+    const common::BigintValuesUsingBloomFilter& filter,
+    const DecodedVector& decoded,
+    SelectivityVector& rows) {
+  int64_t numAccepted = 0;
+  rows.applyToSelected([&](vector_size_t row) {
+    if (filter.testInt64(decoded.valueAt<T>(row))) {
+      ++numAccepted;
+    } else {
+      rows.setValid(row, false);
+    }
+  });
+  return numAccepted;
+}
 } // namespace
 
 // static
@@ -136,9 +152,18 @@ HashProbe::HashProbe(
       joinBridge_(operatorCtx_->task()->getHashJoinBridgeLocked(
           operatorCtx_->driverCtx()->splitGroupId,
           planNodeId())),
+      bypassBloomFilterMinRows_{
+          driverCtx->queryConfig().bypassHashProbeBloomFilterMinRows()},
+      bypassBloomFilterMinPct_{
+          driverCtx->queryConfig().bypassHashProbeBloomFilterMinPct()},
+      bypassBloomFilter_{
+          bypassBloomFilterMinRows_ <= 0 || bypassBloomFilterMinPct_ <= 0},
       filterResult_(1),
       outputTableRowsCapacity_(outputBatchSize_) {
   VELOX_CHECK_NOT_NULL(joinBridge_);
+  VELOX_USER_CHECK_GE(bypassBloomFilterMinRows_, 0);
+  VELOX_USER_CHECK_GE(bypassBloomFilterMinPct_, 0);
+  VELOX_USER_CHECK_LE(bypassBloomFilterMinPct_, 100);
 }
 
 void HashProbe::initialize() {
@@ -428,6 +453,71 @@ void HashProbe::pushdownDynamicFilters() {
       tableOutputProjections_.empty() && !filter_ && numFilters > 0 &&
       !table_->hashers()[0]->getBloomFilter() && !isRightJoin(joinType_)) {
     canReplaceWithDynamicFilter_ = true;
+  }
+}
+
+void HashProbe::applyBloomFilterForJoinProbe() {
+  // TODO: Add Bloom filter support for full joins.
+  if (bypassBloomFilter_ || nullAware_ || isSpillInput() ||
+      needToSpillInput() ||
+      !(isLeftJoin(joinType_) || isLeftSemiProjectJoin(joinType_) ||
+        isAntiJoin(joinType_))) {
+    return;
+  }
+
+  bool hasBloomFilter = false;
+  for (const auto& hasher : table_->hashers()) {
+    if (hasher->getBloomFilter()) {
+      hasBloomFilter = true;
+      break;
+    }
+  }
+  if (!hasBloomFilter) {
+    bypassBloomFilter_ = true;
+    return;
+  }
+
+  const int64_t numTested = activeRows_.countSelected();
+  int64_t numAccepted = numTested;
+  const bool isSampling = bloomFilterSampledRows_ < bypassBloomFilterMinRows_;
+  for (auto i = 0; i < hashers_.size(); ++i) {
+    const auto& filter = table_->hashers()[i]->getBloomFilter();
+    if (!filter) {
+      continue;
+    }
+    const auto* bloomFilter =
+        checkedPointerCast<const common::BigintValuesUsingBloomFilter>(
+            filter.get());
+    const auto& decoded = hashers_[i]->decodedVector();
+    switch (hashers_[i]->typeKind()) {
+      case TypeKind::INTEGER:
+        numAccepted =
+            applyBloomFilter<int32_t>(*bloomFilter, decoded, activeRows_);
+        break;
+      case TypeKind::BIGINT:
+        numAccepted =
+            applyBloomFilter<int64_t>(*bloomFilter, decoded, activeRows_);
+        break;
+      default:
+        VELOX_UNREACHABLE();
+    }
+  }
+  activeRows_.updateBounds();
+
+  if (isSampling) {
+    bloomFilterSampledRows_ += numTested;
+    bloomFilterSampleAcceptedRows_ += numAccepted;
+    if (bloomFilterSampledRows_ >= bypassBloomFilterMinRows_) {
+      bypassBloomFilter_ = bloomFilterSampleAcceptedRows_ * 100 >=
+          bloomFilterSampledRows_ * bypassBloomFilterMinPct_;
+    }
+  }
+
+  if (numTested > 0) {
+    addRuntimeStat(
+        std::string(kBloomFilterTestedRows), RuntimeCounter(numTested));
+    addRuntimeStat(
+        std::string(kBloomFilterAcceptedRows), RuntimeCounter(numAccepted));
   }
 }
 
@@ -771,6 +861,9 @@ void HashProbe::addInput(RowVectorPtr input) {
     lockedStats->numNullKeys +=
         activeRows_.size() - activeRows_.countSelected();
   }
+
+  // Remove proven misses before probing the hash table.
+  applyBloomFilterForJoinProbe();
 
   table_->prepareForJoinProbe(*lookup_.get(), input_, activeRows_, false);
 

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -37,6 +37,9 @@ class HashProbe : public Operator {
   /// Number of local Bloom-filter tests that required a hash table lookup.
   static constexpr std::string_view kBloomFilterAcceptedRows =
       "bloomFilterAcceptedRows";
+  /// Number of times local Bloom filter probing was bypassed after sampling.
+  static constexpr std::string_view kBloomFilterBypassed =
+      "bloomFilterBypassed";
   /// Number of rows bypassed via dynamic filter replacement.
   static constexpr std::string_view kReplacedWithDynamicFilterRows =
       "replacedWithDynamicFilterRows";

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -31,6 +31,12 @@ class HashProbe : public Operator {
   /// Runtime stat keys for hash probe.
   /// Size of the bloom filter in bytes.
   static constexpr std::string_view kBloomFilterSize = "bloomFilterSize";
+  /// Number of probe rows tested by the build-side Bloom filter locally.
+  static constexpr std::string_view kBloomFilterTestedRows =
+      "bloomFilterTestedRows";
+  /// Number of local Bloom-filter tests that required a hash table lookup.
+  static constexpr std::string_view kBloomFilterAcceptedRows =
+      "bloomFilterAcceptedRows";
   /// Number of rows bypassed via dynamic filter replacement.
   static constexpr std::string_view kReplacedWithDynamicFilterRows =
       "replacedWithDynamicFilterRows";
@@ -138,6 +144,10 @@ class HashProbe : public Operator {
   bool allProbeGroupFinished() const;
 
   void pushdownDynamicFilters();
+
+  // Uses build-side Bloom filters to remove rows from activeRows_ when a
+  // miss can be handled by the join's existing unmatched-row path.
+  void applyBloomFilterForJoinProbe();
 
   // Invoked to wait for the hash table to be built by the hash build operators
   // asynchronously. The function also sets up the internal state for
@@ -449,6 +459,13 @@ class HashProbe : public Operator {
   std::vector<column_index_t> keyChannels_;
 
   folly::F14FastSet<column_index_t> dynamicFiltersProducedOnChannels_;
+
+  // Build-side Bloom filter bypass configuration, state, and metrics.
+  const int32_t bypassBloomFilterMinRows_;
+  const int32_t bypassBloomFilterMinPct_;
+  bool bypassBloomFilter_;
+  uint64_t bloomFilterSampledRows_{0};
+  uint64_t bloomFilterSampleAcceptedRows_{0};
 
   // True if the join can become a no-op starting with the next batch of input.
   bool canReplaceWithDynamicFilter_{false};

--- a/velox/exec/benchmarks/CMakeLists.txt
+++ b/velox/exec/benchmarks/CMakeLists.txt
@@ -98,6 +98,16 @@ target_link_libraries(
   Folly::follybenchmark
 )
 
+add_executable(velox_hash_join_left_benchmark HashJoinLeftBenchmark.cpp)
+
+target_link_libraries(
+  velox_hash_join_left_benchmark
+  velox_exec
+  velox_exec_test_lib
+  velox_vector_test_lib
+  Folly::follybenchmark
+)
+
 add_executable(velox_hash_join_prepare_join_table_benchmark HashJoinPrepareJoinTableBenchmark.cpp)
 
 target_link_libraries(

--- a/velox/exec/benchmarks/HashJoinLeftBenchmark.cpp
+++ b/velox/exec/benchmarks/HashJoinLeftBenchmark.cpp
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/hash/Hash.h>
+#include <folly/init/Init.h>
+
+#include "velox/common/memory/Memory.h"
+#include "velox/core/QueryConfig.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/parse/TypeResolver.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec::test;
+using namespace facebook::velox::test;
+
+namespace {
+
+constexpr vector_size_t kBatchSize = 100'000;
+constexpr int64_t kProbePatternRows = 10'000'000;
+constexpr int32_t kProbeRepeats = 500;
+constexpr int64_t kNumProbeRows = kProbePatternRows * kProbeRepeats;
+constexpr uint64_t kBloomFilterMaxBytes = 256UL << 20;
+
+struct BenchmarkParams {
+  int64_t numBuildRows;
+  int32_t hitPct;
+  bool enableBloomFilter;
+};
+
+struct BenchmarkCase {
+  BenchmarkParams params;
+  std::shared_ptr<std::vector<RowVectorPtr>> buildVectors;
+  std::shared_ptr<std::vector<RowVectorPtr>> probeVectors;
+};
+
+int64_t buildKey(uint64_t row) {
+  return static_cast<int64_t>(folly::hash::twang_mix64(row) & ~uint64_t{1});
+}
+
+template <typename MakeBatch>
+std::vector<RowVectorPtr> makeBatches(int64_t numRows, MakeBatch makeBatch) {
+  std::vector<RowVectorPtr> batches;
+  for (int64_t row = 0; row < numRows; row += kBatchSize) {
+    const auto size = static_cast<vector_size_t>(
+        std::min<int64_t>(kBatchSize, numRows - row));
+    batches.push_back(makeBatch(row, size));
+  }
+  return batches;
+}
+
+class HashJoinLeftBenchmark : public VectorTestBase {
+ public:
+  std::vector<RowVectorPtr> prepareBuildData(int64_t numBuildRows) {
+    return makeBatches(numBuildRows, [&](int64_t row, vector_size_t size) {
+      return makeRowVector(
+          {"u0", "u1"},
+          {
+              makeFlatVector<int64_t>(
+                  size,
+                  [&](vector_size_t index) { return buildKey(row + index); }),
+              makeFlatVector<int64_t>(
+                  size, [&](vector_size_t index) { return row + index; }),
+          });
+    });
+  }
+
+  std::vector<RowVectorPtr> prepareProbeData(
+      int64_t numBuildRows,
+      int32_t hitPct) {
+    auto pattern =
+        makeBatches(kProbePatternRows, [&](int64_t row, vector_size_t size) {
+          return makeRowVector(
+              {"t0"}, {makeFlatVector<int64_t>(size, [&](vector_size_t index) {
+                const auto probeRow = row + index;
+                const auto random = folly::hash::twang_mix64(probeRow);
+                if (random % 100 < hitPct) {
+                  return buildKey(random % numBuildRows);
+                }
+                return static_cast<int64_t>(random | uint64_t{1});
+              })});
+        });
+    std::vector<RowVectorPtr> probeVectors;
+    for (int32_t repeat = 0; repeat < kProbeRepeats; ++repeat) {
+      probeVectors.insert(probeVectors.end(), pattern.begin(), pattern.end());
+    }
+    return probeVectors;
+  }
+
+  void run(
+      const BenchmarkParams& params,
+      const std::vector<RowVectorPtr>& buildVectors,
+      const std::vector<RowVectorPtr>& probeVectors) {
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+    auto plan = PlanBuilder(planNodeIdGenerator, pool_.get())
+                    .values(probeVectors)
+                    .hashJoin(
+                        {"t0"},
+                        {"u0"},
+                        PlanBuilder(planNodeIdGenerator, pool_.get())
+                            .values(buildVectors)
+                            .planNode(),
+                        "",
+                        {"t0", "u1"},
+                        core::JoinType::kLeft)
+                    .singleAggregation({}, {"count(1)"})
+                    .planNode();
+
+    AssertQueryBuilder query(plan);
+    query.maxDrivers(1)
+        .config(
+            core::QueryConfig::kHashProbeBloomFilterPushdownMaxSize,
+            std::to_string(kBloomFilterMaxBytes))
+        .config(
+            core::QueryConfig::kBypassHashProbeBloomFilterMinRows,
+            params.enableBloomFilter ? std::to_string(100'000)
+                                     : std::to_string(0))
+        .config(
+            core::QueryConfig::kBypassHashProbeBloomFilterMinPct,
+            std::to_string(85));
+    auto result = query.copyResults(pool());
+    VELOX_CHECK_EQ(result->size(), 1);
+    VELOX_CHECK_EQ(
+        result->childAt(0)->as<SimpleVector<int64_t>>()->valueAt(0),
+        kNumProbeRows);
+  }
+};
+
+std::string benchmarkName(const BenchmarkParams& params) {
+  return fmt::format(
+      "build_{}M_probe_5B_hit_{}pct_bloom_{}",
+      params.numBuildRows / 1'000'000,
+      params.hitPct,
+      params.enableBloomFilter ? "enabled" : "disabled");
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  folly::Init init{&argc, &argv};
+  memory::MemoryManager::initialize(memory::MemoryManager::Options{});
+  functions::prestosql::registerAllScalarFunctions();
+  aggregate::prestosql::registerAllAggregateFunctions();
+  parse::registerTypeResolver();
+
+  auto benchmark = std::make_unique<HashJoinLeftBenchmark>();
+  std::vector<BenchmarkCase> benchmarkCases;
+  for (const auto numBuildRows : {1'000'000, 10'000'000}) {
+    auto buildVectors = std::make_shared<std::vector<RowVectorPtr>>(
+        benchmark->prepareBuildData(numBuildRows));
+    for (const auto hitPct : {1, 10, 100}) {
+      auto probeVectors = std::make_shared<std::vector<RowVectorPtr>>(
+          benchmark->prepareProbeData(numBuildRows, hitPct));
+      for (const auto enableBloomFilter : {false, true}) {
+        benchmarkCases.push_back(
+            {{numBuildRows, hitPct, enableBloomFilter},
+             buildVectors,
+             probeVectors});
+      }
+    }
+  }
+
+  for (const auto& benchmarkCase : benchmarkCases) {
+    folly::addBenchmark(
+        __FILE__,
+        benchmarkName(benchmarkCase.params),
+        [&benchmark, &benchmarkCase]() {
+          benchmark->run(
+              benchmarkCase.params,
+              *benchmarkCase.buildVectors,
+              *benchmarkCase.probeVectors);
+          return 1;
+        });
+  }
+
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -1945,7 +1945,7 @@ TEST_P(HashJoinTest, bloomFilterLocalProbe) {
       },
   };
 
-  const auto numRows = 10'000 + VectorHasher::kMaxDistinct;
+  constexpr auto numRows = 10'000 + VectorHasher::kMaxDistinct;
   auto probe =
       makeRowVector({"t_k0"}, {makeFlatVector<int64_t>(numRows, [](auto row) {
                       return row * 1'000 + 1;
@@ -1956,9 +1956,11 @@ TEST_P(HashJoinTest, bloomFilterLocalProbe) {
 
   for (const auto& testCase : testCases) {
     SCOPED_TRACE(testCase.name);
+    bool verifiedSpillRun = false;
+    bool verifiedNonSpillRun = false;
     HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(1)
-        .injectSpill(false)
+        .injectSpill(true)
         .probeType(asRowType(probe->type()))
         .probeKeys({"t_k0"})
         .probeVectors({probe})
@@ -1972,8 +1974,7 @@ TEST_P(HashJoinTest, bloomFilterLocalProbe) {
             core::QueryConfig::kHashProbeBloomFilterPushdownMaxSize, "1048576")
         .config(core::QueryConfig::kBypassHashProbeBloomFilterMinRows, "100")
         .config(core::QueryConfig::kBypassHashProbeBloomFilterMinPct, "85")
-        .verifier([numRows](const std::shared_ptr<Task>& task, bool hasSpill) {
-          ASSERT_FALSE(hasSpill);
+        .verifier([&](const std::shared_ptr<Task>& task, bool hasSpill) {
           const auto testedRows =
               getOperatorRuntimeStats(
                   task, 1, std::string(HashProbe::kBloomFilterTestedRows))
@@ -1982,16 +1983,124 @@ TEST_P(HashJoinTest, bloomFilterLocalProbe) {
               getOperatorRuntimeStats(
                   task, 1, std::string(HashProbe::kBloomFilterAcceptedRows))
                   .sum;
-          EXPECT_EQ(testedRows, numRows);
-          EXPECT_LT(acceptedRows, numRows * 10 / 100);
+          if (hasSpill) {
+            verifiedSpillRun = true;
+            EXPECT_EQ(0, testedRows);
+            EXPECT_EQ(0, acceptedRows);
+          } else {
+            verifiedNonSpillRun = true;
+            EXPECT_EQ(testedRows, numRows);
+            EXPECT_LT(acceptedRows, numRows * 10 / 100);
+          }
         })
         .run();
+    EXPECT_TRUE(verifiedSpillRun);
+    EXPECT_TRUE(verifiedNonSpillRun);
   }
 }
 
+TEST_P(HashJoinTest, bloomFilterLocalProbeInt32Keys) {
+  // Covers negative INT32 keys, multi-key AND filtering, and 50% acceptance.
+  constexpr auto numRows = 10'000 + VectorHasher::kMaxDistinct;
+  constexpr int32_t kMissingKeyOffset = 1'000'000;
+  constexpr int32_t minBuildKey = -numRows / 2;
+
+  auto probe = makeRowVector(
+      {"t_k0", "t_k1"},
+      {
+          makeFlatVector<int32_t>(
+              numRows,
+              [minBuildKey](auto row) {
+                if (row % 4 == 1) {
+                  return kMissingKeyOffset + row;
+                }
+                return minBuildKey + row;
+              }),
+          makeFlatVector<int32_t>(
+              numRows,
+              [minBuildKey](auto row) {
+                if (row % 4 == 3) {
+                  return kMissingKeyOffset + row;
+                }
+                return minBuildKey + row;
+              }),
+      });
+  auto build = makeRowVector(
+      {"u_k0", "u_k1"},
+      {
+          makeFlatVector<int32_t>(
+              numRows, [minBuildKey](auto row) { return minBuildKey + row; }),
+          makeFlatVector<int32_t>(
+              numRows, [minBuildKey](auto row) { return minBuildKey + row; }),
+      });
+
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .numDrivers(1)
+      .injectSpill(false)
+      .probeType(asRowType(probe->type()))
+      .probeKeys({"t_k0", "t_k1"})
+      .probeVectors({probe})
+      .buildType(asRowType(build->type()))
+      .buildKeys({"u_k0", "u_k1"})
+      .buildVectors({build})
+      .joinType(core::JoinType::kLeft)
+      .joinOutputLayout({"t_k0", "t_k1", "u_k0", "u_k1"})
+      .referenceQuery(
+          "SELECT t.t_k0, t.t_k1, u.u_k0, u.u_k1 FROM t LEFT JOIN u "
+          "ON t.t_k0 = u.u_k0 AND t.t_k1 = u.u_k1")
+      .config(
+          core::QueryConfig::kHashProbeBloomFilterPushdownMaxSize, "1048576")
+      .config(core::QueryConfig::kBypassHashProbeBloomFilterMinRows, "100")
+      .config(core::QueryConfig::kBypassHashProbeBloomFilterMinPct, "85")
+      .verifier([numRows](const std::shared_ptr<Task>& task, bool hasSpill) {
+        ASSERT_FALSE(hasSpill);
+        const auto testedRows =
+            getOperatorRuntimeStats(
+                task, 1, std::string(HashProbe::kBloomFilterTestedRows))
+                .sum;
+        const auto acceptedRows =
+            getOperatorRuntimeStats(
+                task, 1, std::string(HashProbe::kBloomFilterAcceptedRows))
+                .sum;
+        EXPECT_EQ(testedRows, numRows);
+        EXPECT_GE(acceptedRows, numRows * 50 / 100);
+        EXPECT_LT(acceptedRows, numRows * 60 / 100);
+      })
+      .run();
+}
+
 TEST_P(HashJoinTest, bypassBloomFilterLocalProbe) {
+  struct TestCase {
+    const char* name;
+    core::JoinType joinType;
+    std::vector<std::string> outputLayout;
+    const char* referenceQuery;
+  };
+  const std::vector<TestCase> testCases = {
+      {
+          "left",
+          core::JoinType::kLeft,
+          {"t_k0", "u_k0"},
+          "SELECT t.t_k0, u.u_k0 FROM t LEFT JOIN u "
+          "ON t.t_k0 = u.u_k0",
+      },
+      {
+          "left semi project",
+          core::JoinType::kLeftSemiProject,
+          {"t_k0", "match"},
+          "SELECT t.t_k0, t.t_k0 IN (SELECT u.u_k0 FROM u) FROM t",
+      },
+      {
+          "anti",
+          core::JoinType::kAnti,
+          {"t_k0"},
+          "SELECT t.t_k0 FROM t WHERE NOT EXISTS "
+          "(SELECT 1 FROM u WHERE t.t_k0 = u.u_k0)",
+      },
+  };
+
   constexpr int32_t kSampleRows = 100;
-  const auto numRows = 10'000 + VectorHasher::kMaxDistinct;
+  constexpr auto numRows = 10'000 + VectorHasher::kMaxDistinct;
   auto sampleProbe = makeRowVector(
       {"t_k0"}, {makeFlatVector<int64_t>(kSampleRows, [](auto row) {
         return row * 1'000;
@@ -2004,43 +2113,45 @@ TEST_P(HashJoinTest, bypassBloomFilterLocalProbe) {
       {"u_k0"},
       {makeFlatVector<int64_t>(numRows, [](auto row) { return row * 1'000; })});
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
-      .numDrivers(1)
-      .injectSpill(false)
-      .probeType(asRowType(sampleProbe->type()))
-      .probeKeys({"t_k0"})
-      .probeVectors({sampleProbe, remainingProbe})
-      .buildType(asRowType(build->type()))
-      .buildKeys({"u_k0"})
-      .buildVectors({build})
-      .joinType(core::JoinType::kLeft)
-      .joinOutputLayout({"t_k0", "u_k0"})
-      .referenceQuery(
-          "SELECT t.t_k0, u.u_k0 FROM t LEFT JOIN u ON t.t_k0 = u.u_k0")
-      .config(
-          core::QueryConfig::kHashProbeBloomFilterPushdownMaxSize, "1048576")
-      .config(
-          core::QueryConfig::kBypassHashProbeBloomFilterMinRows,
-          std::to_string(kSampleRows))
-      .config(core::QueryConfig::kBypassHashProbeBloomFilterMinPct, "85")
-      .verifier([](const std::shared_ptr<Task>& task, bool hasSpill) {
-        ASSERT_FALSE(hasSpill);
-        const auto testedRows =
-            getOperatorRuntimeStats(
-                task, 1, std::string(HashProbe::kBloomFilterTestedRows))
-                .sum;
-        const auto acceptedRows =
-            getOperatorRuntimeStats(
-                task, 1, std::string(HashProbe::kBloomFilterAcceptedRows))
-                .sum;
-        EXPECT_EQ(100, testedRows);
-        EXPECT_EQ(100, acceptedRows);
-      })
-      .run();
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.name);
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+        .numDrivers(1)
+        .injectSpill(false)
+        .probeType(asRowType(sampleProbe->type()))
+        .probeKeys({"t_k0"})
+        .probeVectors({sampleProbe, remainingProbe})
+        .buildType(asRowType(build->type()))
+        .buildKeys({"u_k0"})
+        .buildVectors({build})
+        .joinType(testCase.joinType)
+        .joinOutputLayout(std::vector<std::string>(testCase.outputLayout))
+        .referenceQuery(testCase.referenceQuery)
+        .config(
+            core::QueryConfig::kHashProbeBloomFilterPushdownMaxSize, "1048576")
+        .config(
+            core::QueryConfig::kBypassHashProbeBloomFilterMinRows,
+            std::to_string(kSampleRows))
+        .config(core::QueryConfig::kBypassHashProbeBloomFilterMinPct, "85")
+        .verifier([](const std::shared_ptr<Task>& task, bool hasSpill) {
+          ASSERT_FALSE(hasSpill);
+          const auto testedRows =
+              getOperatorRuntimeStats(
+                  task, 1, std::string(HashProbe::kBloomFilterTestedRows))
+                  .sum;
+          const auto acceptedRows =
+              getOperatorRuntimeStats(
+                  task, 1, std::string(HashProbe::kBloomFilterAcceptedRows))
+                  .sum;
+          EXPECT_EQ(100, testedRows);
+          EXPECT_EQ(100, acceptedRows);
+        })
+        .run();
+  }
 }
 
 TEST_P(HashJoinTest, bypassBloomFilterLocalProbeWithoutSampling) {
-  const auto numRows = 10'000 + VectorHasher::kMaxDistinct;
+  constexpr auto numRows = 10'000 + VectorHasher::kMaxDistinct;
   auto probe = makeRowVector(
       {"t_k0"},
       {makeFlatVector<int64_t>(numRows, [](auto row) { return row * 1'000; })});

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -2143,8 +2143,13 @@ TEST_P(HashJoinTest, bypassBloomFilterLocalProbe) {
               getOperatorRuntimeStats(
                   task, 1, std::string(HashProbe::kBloomFilterAcceptedRows))
                   .sum;
+          const auto bypassed =
+              getOperatorRuntimeStats(
+                  task, 1, std::string(HashProbe::kBloomFilterBypassed))
+                  .sum;
           EXPECT_EQ(100, testedRows);
           EXPECT_EQ(100, acceptedRows);
+          EXPECT_EQ(1, bypassed);
         })
         .run();
   }

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -1915,6 +1915,172 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoinWithFilterEmptyBatch) {
       .run();
 }
 
+TEST_P(HashJoinTest, bloomFilterLocalProbe) {
+  struct TestCase {
+    const char* name;
+    core::JoinType joinType;
+    std::vector<std::string> outputLayout;
+    const char* referenceQuery;
+  };
+  const std::vector<TestCase> testCases = {
+      {
+          "left",
+          core::JoinType::kLeft,
+          {"t_k0", "u_k0"},
+          "SELECT t.t_k0, u.u_k0 FROM t LEFT JOIN u "
+          "ON t.t_k0 = u.u_k0",
+      },
+      {
+          "left semi project",
+          core::JoinType::kLeftSemiProject,
+          {"t_k0", "match"},
+          "SELECT t.t_k0, t.t_k0 IN (SELECT u.u_k0 FROM u) FROM t",
+      },
+      {
+          "anti",
+          core::JoinType::kAnti,
+          {"t_k0"},
+          "SELECT t.t_k0 FROM t WHERE NOT EXISTS "
+          "(SELECT 1 FROM u WHERE t.t_k0 = u.u_k0)",
+      },
+  };
+
+  const auto numRows = 10'000 + VectorHasher::kMaxDistinct;
+  auto probe =
+      makeRowVector({"t_k0"}, {makeFlatVector<int64_t>(numRows, [](auto row) {
+                      return row * 1'000 + 1;
+                    })});
+  auto build = makeRowVector(
+      {"u_k0"},
+      {makeFlatVector<int64_t>(numRows, [](auto row) { return row * 1'000; })});
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.name);
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+        .numDrivers(1)
+        .injectSpill(false)
+        .probeType(asRowType(probe->type()))
+        .probeKeys({"t_k0"})
+        .probeVectors({probe})
+        .buildType(asRowType(build->type()))
+        .buildKeys({"u_k0"})
+        .buildVectors({build})
+        .joinType(testCase.joinType)
+        .joinOutputLayout(std::vector<std::string>(testCase.outputLayout))
+        .referenceQuery(testCase.referenceQuery)
+        .config(
+            core::QueryConfig::kHashProbeBloomFilterPushdownMaxSize, "1048576")
+        .config(core::QueryConfig::kBypassHashProbeBloomFilterMinRows, "100")
+        .config(core::QueryConfig::kBypassHashProbeBloomFilterMinPct, "85")
+        .verifier([numRows](const std::shared_ptr<Task>& task, bool hasSpill) {
+          ASSERT_FALSE(hasSpill);
+          const auto testedRows =
+              getOperatorRuntimeStats(
+                  task, 1, std::string(HashProbe::kBloomFilterTestedRows))
+                  .sum;
+          const auto acceptedRows =
+              getOperatorRuntimeStats(
+                  task, 1, std::string(HashProbe::kBloomFilterAcceptedRows))
+                  .sum;
+          EXPECT_EQ(testedRows, numRows);
+          EXPECT_LT(acceptedRows, numRows * 10 / 100);
+        })
+        .run();
+  }
+}
+
+TEST_P(HashJoinTest, bypassBloomFilterLocalProbe) {
+  constexpr int32_t kSampleRows = 100;
+  const auto numRows = 10'000 + VectorHasher::kMaxDistinct;
+  auto sampleProbe = makeRowVector(
+      {"t_k0"}, {makeFlatVector<int64_t>(kSampleRows, [](auto row) {
+        return row * 1'000;
+      })});
+  auto remainingProbe = makeRowVector(
+      {"t_k0"}, {makeFlatVector<int64_t>(numRows - kSampleRows, [](auto row) {
+        return (row + kSampleRows) * 1'000;
+      })});
+  auto build = makeRowVector(
+      {"u_k0"},
+      {makeFlatVector<int64_t>(numRows, [](auto row) { return row * 1'000; })});
+
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .numDrivers(1)
+      .injectSpill(false)
+      .probeType(asRowType(sampleProbe->type()))
+      .probeKeys({"t_k0"})
+      .probeVectors({sampleProbe, remainingProbe})
+      .buildType(asRowType(build->type()))
+      .buildKeys({"u_k0"})
+      .buildVectors({build})
+      .joinType(core::JoinType::kLeft)
+      .joinOutputLayout({"t_k0", "u_k0"})
+      .referenceQuery(
+          "SELECT t.t_k0, u.u_k0 FROM t LEFT JOIN u ON t.t_k0 = u.u_k0")
+      .config(
+          core::QueryConfig::kHashProbeBloomFilterPushdownMaxSize, "1048576")
+      .config(
+          core::QueryConfig::kBypassHashProbeBloomFilterMinRows,
+          std::to_string(kSampleRows))
+      .config(core::QueryConfig::kBypassHashProbeBloomFilterMinPct, "85")
+      .verifier([](const std::shared_ptr<Task>& task, bool hasSpill) {
+        ASSERT_FALSE(hasSpill);
+        const auto testedRows =
+            getOperatorRuntimeStats(
+                task, 1, std::string(HashProbe::kBloomFilterTestedRows))
+                .sum;
+        const auto acceptedRows =
+            getOperatorRuntimeStats(
+                task, 1, std::string(HashProbe::kBloomFilterAcceptedRows))
+                .sum;
+        EXPECT_EQ(100, testedRows);
+        EXPECT_EQ(100, acceptedRows);
+      })
+      .run();
+}
+
+TEST_P(HashJoinTest, bypassBloomFilterLocalProbeWithoutSampling) {
+  const auto numRows = 10'000 + VectorHasher::kMaxDistinct;
+  auto probe = makeRowVector(
+      {"t_k0"},
+      {makeFlatVector<int64_t>(numRows, [](auto row) { return row * 1'000; })});
+  auto build = makeRowVector(
+      {"u_k0"},
+      {makeFlatVector<int64_t>(numRows, [](auto row) { return row * 1'000; })});
+
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .numDrivers(1)
+      .injectSpill(false)
+      .probeType(asRowType(probe->type()))
+      .probeKeys({"t_k0"})
+      .probeVectors({probe})
+      .buildType(asRowType(build->type()))
+      .buildKeys({"u_k0"})
+      .buildVectors({build})
+      .joinType(core::JoinType::kLeft)
+      .joinOutputLayout({"t_k0", "u_k0"})
+      .referenceQuery(
+          "SELECT t.t_k0, u.u_k0 FROM t LEFT JOIN u ON t.t_k0 = u.u_k0")
+      .config(
+          core::QueryConfig::kHashProbeBloomFilterPushdownMaxSize, "1048576")
+      .config(core::QueryConfig::kBypassHashProbeBloomFilterMinRows, "100")
+      .config(core::QueryConfig::kBypassHashProbeBloomFilterMinPct, "0")
+      .verifier([](const std::shared_ptr<Task>& task, bool hasSpill) {
+        ASSERT_FALSE(hasSpill);
+        const auto testedRows =
+            getOperatorRuntimeStats(
+                task, 1, std::string(HashProbe::kBloomFilterTestedRows))
+                .sum;
+        const auto acceptedRows =
+            getOperatorRuntimeStats(
+                task, 1, std::string(HashProbe::kBloomFilterAcceptedRows))
+                .sum;
+        EXPECT_EQ(0, testedRows);
+        EXPECT_EQ(0, acceptedRows);
+      })
+      .run();
+}
+
 VELOX_INSTANTIATE_TEST_SUITE_P(
     MultiThreadedHashJoinTest,
     MultiThreadedHashJoinTest,


### PR DESCRIPTION
### Introduction

In hash join, for the join types `kLeft` / `kLeftSemiProject` / `kAnti`, Bloom filter can not be pushed down through HashProbe because the missed probes should still be preserved in the output. The PR optimizes these cases by applying the bloom filter inside the HashProbe operator during its execution before accessing the hash table, to reduce the overall hash table accesses for much better cache locality. The proven-misses will still be yielded to the output with their corresponding build rows (e.g., NULL for `kLeft`) to match the semantic. 

The feature is now skipped on null-aware or spilled hash joins for implementation simplicity, though most of the valuable cases can be covered.

A runtime sampling strategy is also added to let Velox be able to smartly skip the bloom filter if the pre-filtering doesn't reduce the probing data amount effectively. This behavior is controlled by query config `kBypassHashProbeBloomFilterMinRows` and `kBypassHashProbeBloomFilterMinPct`.

By default, `kBypassHashProbeBloomFilterMinRows` is `0` and the bloom filter is skipped.

This in-probe bloom filter can only be enabled when basic bloom filter pushdown is enabled (`hashProbeBloomFilterPushdownMaxSize` is non-zero).

### Statistics

Three new runtime metrics are added for monitoring: `bloomFilterTestedRows` / `bloomFilterAcceptedRows` / `bloomFilterBypassed`.

### Benchmark

A corresponding benchmark `velox_hash_join_left_benchmark` is added.

A local benchmark run shows up to 97.2% end-to-end SQL speedup in the low-hit left outer join case.

Bechmark result: 

| Build Size | Probe Size | Hit Rate | Bloom Disabled | Bloom Enabled | Speedup |
|------------|-------|----------|----------------:|--------------:|---------:|
| 1M | 5B | 1% | 2.16 min | 1.28 min | +68.8% |
| 1M | 5B | 10% | 2.46 min | 1.78 min | +38.2% |
| 1M | 5B | 100% | 4.18 min | 4.22 min | -0.9% |
| 10M | 5B | 1% | 3.49 min | 1.77 min | +97.2% |
| 10M | 5B | 10% | 4.17 min | 2.71 min | +53.9% |
| 10M | 5B | 100% | 7.97 min | 7.97 min | 0.0% |




