### PR TITLE
fix(cudf): Sync last-used stream before releasing owned GPU state in doClose()

### DIFF
--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -178,6 +178,12 @@ class ProbeMatchTracker {
 
 void CudfHashJoinProbe::doClose() {
   Operator::close();
+  // Wait for this instance's last doGetOutput() read of filterEvaluator_/
+  // scalars_/tree_ to finish before releasing them below - otherwise the
+  // resulting stream-ordered free could race a still-in-flight read.
+  if (lastGetOutputStream_.has_value()) {
+    lastGetOutputStream_->synchronize();
+  }
   filterEvaluator_.reset();
   scalars_.clear();
   tree_ = {};
@@ -2118,6 +2124,9 @@ RowVectorPtr CudfHashJoinProbe::doGetOutput() {
         !finished_ && isLastDriver_) {
       auto& rightTables = hashObject_.value().first;
       auto stream = cudfGlobalStreamPool().get_stream();
+      // Fresh pool stream reading hashObject_/rightMatchedFlags_ - record it
+      // so doClose()/isFinished() wait for this read before releasing them.
+      lastGetOutputStream_ = stream;
       std::vector<std::unique_ptr<cudf::table>> toConcat;
       vector_size_t unmatchedRows = 0;
       for (size_t i = 0; i < rightTables.size(); ++i) {
@@ -2197,6 +2206,11 @@ RowVectorPtr CudfHashJoinProbe::doGetOutput() {
   auto cudfInput = std::dynamic_pointer_cast<CudfVector>(input_);
   VELOX_CHECK_NOT_NULL(cudfInput);
   auto stream = cudfInput->stream();
+  // Record every doGetOutput() stream (unlike lastProbeStream_ below, which
+  // is right/full-join-only) so doClose()/isFinished() can wait for this
+  // read of hashObject_/scalars_/tree_/filterEvaluator_ before releasing
+  // them.
+  lastGetOutputStream_ = stream;
   waitForBuildReady(stream);
   // Use getTableView() to avoid expensive materialization for packed_table.
   // cudfInput is staying alive until the table view is no longer needed.
@@ -2415,8 +2429,16 @@ exec::BlockingReason CudfHashJoinProbe::isBlocked(ContinueFuture* future) {
 bool CudfHashJoinProbe::isFinished() {
   auto const isFinished = finished_ || (noMoreInput_ && input_ == nullptr);
 
-  // Release hashObject_ if finished
-  if (isFinished) {
+  // Release hashObject_ if finished. hashObject_'s tables/hash_join objects
+  // are shared (via shared_ptr) with the bridge and other probe instances,
+  // so this reset() may or may not be the one that actually triggers their
+  // destruction - but whichever instance's reset() is last must not race a
+  // read still in flight on its own last-used stream, so every instance
+  // waits for its own lastGetOutputStream_ before releasing its reference.
+  if (isFinished && hashObject_.has_value()) {
+    if (lastGetOutputStream_.has_value()) {
+      lastGetOutputStream_->synchronize();
+    }
     hashObject_.reset();
     buildReadyEvent_.reset();
     buildStream_.reset();

--- a/velox/experimental/cudf/exec/CudfHashJoin.h
+++ b/velox/experimental/cudf/exec/CudfHashJoin.h
@@ -267,6 +267,15 @@ class CudfHashJoinProbe : public CudfOperatorBase {
   /// host-synchronized all-false init state with no pending GPU work.
   std::optional<rmm::cuda_stream_view> lastProbeStream_;
 
+  /// Last CUDA stream this instance used to read build/filter state
+  /// (hashObject_'s tables, rightMatchedFlags_, scalars_, tree_,
+  /// filterEvaluator_), set unconditionally on every doGetOutput() call
+  /// (unlike lastProbeStream_ above, which is right/full-join-only). Synced
+  /// in doClose() and isFinished() before releasing that state, so a
+  /// stream-ordered free triggered by dropping this instance's reference
+  /// can't race a read still in flight on this instance's last-used stream.
+  std::optional<rmm::cuda_stream_view> lastGetOutputStream_;
+
   static constexpr auto oobPolicy = cudf::out_of_bounds_policy::NULLIFY;
 
   struct JoinOutput {

--- a/velox/experimental/cudf/exec/CudfOrderBy.cpp
+++ b/velox/experimental/cudf/exec/CudfOrderBy.cpp
@@ -102,8 +102,16 @@ RowVectorPtr CudfOrderBy::doGetOutput() {
 
 void CudfOrderBy::doClose() {
   Operator::close();
-  // Release stored inputs
-  // Release cudf memory resources
+  // inputs_ is already empty by this point (std::exchange'd away in
+  // doNoMoreInput()), so clearing it here is a no-op. outputTable_ is
+  // created (by cudf::sort_by_key, async on its own stream) in
+  // doNoMoreInput() and normally handed off via doGetOutput(), but if
+  // close() runs first - e.g. task cancellation before getOutput() is ever
+  // called - this reset() is the only reference drop, so the sort's async
+  // write could still be in flight. Wait for its creation stream first.
+  if (outputTable_) {
+    outputTable_->stream().synchronize();
+  }
   inputs_.clear();
   outputTable_.reset();
 }


### PR DESCRIPTION
## Summary

Follow-up to #18264, tracked in #18336.

#18264 fixed a build-side visibility race in `CudfNestedLoopJoinProbe`: `waitForBuildReady()` ensures probe reads never start before the build side's writes are visible. During review of that PR we identified the reverse-direction gap - nothing ensured a probe's own in-flight reads had *finished* before `doClose()` released the data it was reading, since these are cuDF objects whose destruction enqueues a stream-ordered free that could race a still-in-flight read.

Auditing every `doClose()` in `velox/experimental/cudf/exec` (prompted by that discussion) found the same class of gap in two more operators, already fixed for NLJ in #18264 itself.

## CudfHashJoinProbe

- `doClose()` cleared `filterEvaluator_`/`scalars_`/`tree_` with no preceding sync.
- `isFinished()` resets `hashObject_`/`buildReadyEvent_`/`buildStream_` - a *more* frequently-hit path than `doClose()`, since it fires on every `isFinished()` poll once the operator is done - with no sync at all.
- One previously-untracked stream: the "emit unmatched-right rows" branch in `doGetOutput()` (right/full join, last driver) reads `hashObject_`/`rightMatchedFlags_` on a fresh pool stream that was never recorded anywhere.

Fix: added `lastGetOutputStream_`, tracked unconditionally on every `doGetOutput()` call. This is intentionally distinct from the existing `lastProbeStream_`, which is deliberately narrower in scope (right/full-join-only, used for the cross-driver flag merge in `noMoreInput()`). Both `doClose()` and `isFinished()` now sync `lastGetOutputStream_` before releasing the state above.

`hashObject_`'s tables/hash_join objects are shared (via `shared_ptr`) with the bridge and other probe instances on other drivers. Whichever instance's reference-drop is actually last is the one that matters for the underlying free, but every instance still syncs its own stream before dropping its own reference - so by the time the true last drop happens, every earlier drop already waited for its own reads first.

## CudfOrderBy

`doClose()`'s `inputs_.clear()` is already a no-op (`std::exchange`'d away in `doNoMoreInput()`), but `outputTable_` (built via `cudf::sort_by_key`, async on its own stream) is kept alive as a member until `doClose()` releases it. If `close()` runs before `doGetOutput()` is ever called (e.g. task cancellation), this `reset()` is the only reference drop, so the sort's async write could still be in flight. Fix: sync `outputTable_`'s own creation stream first.

## CudfToVelox (audited, no fix needed)

Also audited per the tracking issue, but found not to need a change: every async read of `inputs_`/`veloxBuffer_` (`convertFrontToVelox()` and the GPU-concat path in `doGetOutput()`) already calls `stream.synchronize()` immediately after issuing the read, before the result is stored anywhere, and `veloxBuffer_` is host memory once converted - there's no async GPU work left in flight by the time `doClose()` runs. Noting this here since #18336 originally flagged it from a shallower pass.

## Testing

`CudfHashJoin.cpp` and `CudfOrderBy.cpp` compile cleanly in isolation. I wasn't able to get a full local test suite build in my dev container due to an unrelated, pre-existing cudf version mismatch there (26.06 vs. the 26.08 this branch of `main` actually targets) - confirmed by diffing against a pristine `origin/main` checkout, which shows the exact same local-only errors on files this PR doesn't touch. CI uses the correctly pinned cudf version.

This class of race is inherently timing-dependent, matching the same testing caveat noted in #18264 - the fixes are justified primarily by matching the already-established, correct pattern used by `CudfWindow`/`CudfFromVelox`.

Closes #18336.