### PR TITLE
fix: PushDictionaryToRowVectorLeaves loses struct nulls under a null-free dictionary

### DIFF
--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -826,12 +826,20 @@ VectorPtr pushDictionaryToRowVectorLeavesImpl(
     }
     case VectorEncoding::Simple::ROW: {
       VELOX_CHECK_EQ(values->typeKind(), TypeKind::ROW);
+      // Re-index the struct's own nulls through the wrappers to align with the
+      // wrapped children. Needed whenever the struct has nulls (not only when a
+      // wrapper does), else a null-free dictionary leaves them misaligned.
       auto nulls = values->nulls();
-      for (auto& wrapper : wrappers) {
+      bool anyWrapperNulls = false;
+      for (const auto& wrapper : wrappers) {
         if (wrapper.encoded->nulls()) {
-          nulls = combineNulls(wrappers, size, values->rawNulls(), pool);
+          anyWrapperNulls = true;
           break;
         }
+      }
+      if (!wrappers.empty() &&
+          (values->rawNulls() != nullptr || anyWrapperNulls)) {
+        nulls = combineNulls(wrappers, size, values->rawNulls(), pool);
       }
       auto children = values->asUnchecked<RowVector>()->children();
       for (auto& child : children) {

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -4151,6 +4151,25 @@ TEST_F(VectorTest, pushDictionaryToRowVectorLeaves) {
     ASSERT_EQ(c0c1->encoding(), VectorEncoding::Simple::DICTIONARY);
   }
   {
+    SCOPED_TRACE("Struct with own nulls under null-free dictionary");
+    // A null-free dictionary (e.g. row selection during deletion) wraps a
+    // RowVector whose child struct carries its OWN nulls -- not wrapper nulls.
+    // The struct's nulls must be re-indexed through the dictionary so they
+    // align with the wrapped rows; otherwise they stay at the pre-dictionary
+    // row positions and the output is wrong.
+    input = wrapInDictionary(
+        makeIndicesInReverse(10),
+        makeRowVector({
+            makeRowVector({iota, iota}, nullEvery(4)),
+        }));
+    output = RowVector::pushDictionaryToRowVectorLeaves(input);
+    test::assertEqualVectors(input, output);
+    auto* c0 =
+        output->asChecked<RowVector>()->childAt(0)->asChecked<RowVector>();
+    ASSERT_EQ(c0->childAt(0)->encoding(), VectorEncoding::Simple::DICTIONARY);
+    ASSERT_EQ(c0->childAt(1)->encoding(), VectorEncoding::Simple::DICTIONARY);
+  }
+  {
     SCOPED_TRACE("Constant");
     input = makeRowVector({
         // c0: Constant primitive.


### PR DESCRIPTION
Summary:
`RowVector::pushDictionaryToRowVectorLeaves` did not re-index a struct's own null mask through the dictionary wrappers unless one of the wrappers itself carried nulls. When a struct that has its own nulls is wrapped in a dictionary with no nulls (e.g. a pure row-selection dictionary), the pushed-down output kept the struct's nulls at their pre-dictionary row positions while the children were re-indexed and the vector length shrank to the dictionary size. The struct nulls were therefore misaligned (and could be dropped), producing incorrect results for any consumer that reads the pushed vector.

Fix: in the ROW case of `pushDictionaryToRowVectorLeavesImpl`, re-index the struct's own nulls through the wrappers (via `combineNulls`) whenever the struct has nulls, not only when a wrapper carries nulls.

Differential Revision: D114162146


