### PR TITLE
fix(wave): Reject decode steps the GPU dispatch does not implement

### DIFF
--- a/velox/experimental/wave/dwio/decode/DecodeStep.h
+++ b/velox/experimental/wave/dwio/decode/DecodeStep.h
@@ -100,6 +100,14 @@ enum class DecodeStep {
   kUnsupported,
 };
 
+/// Returns the name of 'step' for error messages.
+const char* decodeStepName(DecodeStep step);
+
+/// Throws if the device side decode dispatch has no case for 'step'. Call
+/// before launching a decode: a step with no case leaves the output buffer
+/// undecoded, which the host cannot tell apart from a successful decode.
+void checkDecodeStepSupported(DecodeStep step);
+
 enum class DictMode {
   // Decoded values are returned as is
   kNone,

--- a/velox/experimental/wave/dwio/decode/GpuDecoder-inl.cuh
+++ b/velox/experimental/wave/dwio/decode/GpuDecoder-inl.cuh
@@ -1318,6 +1318,11 @@ __device__ void decodeSwitch(GpuDecode& op) {
             "ERROR: Unsupported DecodeStep %d\n",
             static_cast<int32_t>(op.step));
       }
+      // checkDecodeStepSupported() rejects these before the launch, so this is
+      // unreachable. Trap rather than return: returning leaves the output
+      // undecoded and the host cannot tell that apart from a decoded result.
+      // 'assert' is not used because it is compiled out in release builds.
+      __trap();
   }
 }
 
@@ -1387,6 +1392,7 @@ template <int kBlockSize>
 void decodeGlobal(GpuDecode* plan, int numBlocks, cudaStream_t stream) {
   int32_t sharedSize = 0;
   for (auto i = 0; i < numBlocks; ++i) {
+    checkDecodeStepSupported(plan[i].step);
     sharedSize = std::max(
         sharedSize,
         detail::sharedMemorySizeForDecode<kBlockSize>(plan[i].step));

--- a/velox/experimental/wave/dwio/decode/GpuDecoder.cu
+++ b/velox/experimental/wave/dwio/decode/GpuDecoder.cu
@@ -14,13 +14,131 @@
  * limitations under the License.
  */
 
+#include <fmt/format.h>
 #include "velox/experimental/wave/common/Buffer.h"
 #include "velox/experimental/wave/common/Cuda.h"
 #include "velox/experimental/wave/common/CudaUtil.cuh"
+#include "velox/experimental/wave/common/Exception.h"
 #include "velox/experimental/wave/common/GpuArena.h"
 #include "velox/experimental/wave/dwio/decode/GpuDecoder.cuh"
 
 namespace facebook::velox::wave {
+
+const char* decodeStepName(DecodeStep step) {
+  switch (step) {
+    case DecodeStep::kSelective32:
+      return "kSelective32";
+    case DecodeStep::kCompact64:
+      return "kCompact64";
+    case DecodeStep::kSelective64:
+      return "kSelective64";
+    case DecodeStep::kSelective32Chunked:
+      return "kSelective32Chunked";
+    case DecodeStep::kSelective64Chunked:
+      return "kSelective64Chunked";
+    case DecodeStep::kConstant32:
+      return "kConstant32";
+    case DecodeStep::kConstant64:
+      return "kConstant64";
+    case DecodeStep::kConstantChar:
+      return "kConstantChar";
+    case DecodeStep::kConstantBool:
+      return "kConstantBool";
+    case DecodeStep::kConstantBytes:
+      return "kConstantBytes";
+    case DecodeStep::kTrivial:
+      return "kTrivial";
+    case DecodeStep::kTrivialNoOp:
+      return "kTrivialNoOp";
+    case DecodeStep::kMainlyConstant:
+      return "kMainlyConstant";
+    case DecodeStep::kBitpack32:
+      return "kBitpack32";
+    case DecodeStep::kBitpack64:
+      return "kBitpack64";
+    case DecodeStep::kRleTotalLength:
+      return "kRleTotalLength";
+    case DecodeStep::kRleBool:
+      return "kRleBool";
+    case DecodeStep::kRle:
+      return "kRle";
+    case DecodeStep::kDictionary:
+      return "kDictionary";
+    case DecodeStep::kDictionaryOnBitpack:
+      return "kDictionaryOnBitpack";
+    case DecodeStep::kVarint:
+      return "kVarint";
+    case DecodeStep::kNullable:
+      return "kNullable";
+    case DecodeStep::kSentinel:
+      return "kSentinel";
+    case DecodeStep::kSparseBool:
+      return "kSparseBool";
+    case DecodeStep::kMakeScatterIndices:
+      return "kMakeScatterIndices";
+    case DecodeStep::kScatter32:
+      return "kScatter32";
+    case DecodeStep::kScatter64:
+      return "kScatter64";
+    case DecodeStep::kLengthToOffset:
+      return "kLengthToOffset";
+    case DecodeStep::kMissing:
+      return "kMissing";
+    case DecodeStep::kStruct:
+      return "kStruct";
+    case DecodeStep::kArray:
+      return "kArray";
+    case DecodeStep::kMap:
+      return "kMap";
+    case DecodeStep::kFlatMap:
+      return "kFlatMap";
+    case DecodeStep::kFlatMapNode:
+      return "kFlatMapNode";
+    case DecodeStep::kRowCountNoFilter:
+      return "kRowCountNoFilter";
+    case DecodeStep::kCountBits:
+      return "kCountBits";
+    case DecodeStep::kUnsupported:
+      return "kUnsupported";
+  }
+  return "<invalid>";
+}
+
+namespace {
+// The steps detail::decodeSwitch() has a case for. Keep in sync with it.
+bool isSupportedDecodeStep(DecodeStep step) {
+  switch (step) {
+    case DecodeStep::kSelective32:
+    case DecodeStep::kSelective64:
+    case DecodeStep::kSelective32Chunked:
+    case DecodeStep::kSelective64Chunked:
+    case DecodeStep::kCompact64:
+    case DecodeStep::kCountBits:
+    case DecodeStep::kTrivial:
+    case DecodeStep::kDictionaryOnBitpack:
+    case DecodeStep::kSparseBool:
+    case DecodeStep::kMainlyConstant:
+    case DecodeStep::kVarint:
+    case DecodeStep::kRleTotalLength:
+    case DecodeStep::kRle:
+    case DecodeStep::kMakeScatterIndices:
+    case DecodeStep::kRowCountNoFilter:
+      return true;
+    default:
+      return false;
+  }
+}
+} // namespace
+
+void checkDecodeStepSupported(DecodeStep step) {
+  if (!isSupportedDecodeStep(step)) {
+    waveError(
+        fmt::format(
+            "Wave GPU decode does not implement DecodeStep {} ({})",
+            decodeStepName(step),
+            static_cast<int32_t>(step)));
+  }
+}
 
 int32_t GpuDecode::tempSize() const {
   // 1 int32 per lane as an upper limit.
@@ -88,6 +206,7 @@ void launchDecode(
     }
     numOps += numSteps;
     for (auto& step : program) {
+      checkDecodeStepSupported(step->step);
       shared = std::max(
           shared, detail::sharedMemorySizeForDecode<kBlockSize>(step->step));
     }

--- a/velox/experimental/wave/dwio/decode/tests/GpuDecoderTest.cu
+++ b/velox/experimental/wave/dwio/decode/tests/GpuDecoderTest.cu
@@ -737,6 +737,27 @@ class GpuDecoderTest : public ::testing::Test {
     }
   }
 
+  void testUnsupportedStep(DecodeStep step) {
+    DecodePrograms programs;
+    programs.programs.emplace_back();
+    programs.programs.back().push_back(std::make_unique<GpuDecode>());
+    programs.programs.back().front()->step = step;
+    auto stream = std::make_unique<Stream>();
+    LaunchParams params(*arena_);
+    // Velox's exception headers do not compile under nvcc, so match on
+    // std::exception rather than using VELOX_ASSERT_THROW.
+    auto expected = fmt::format(
+        "Wave GPU decode does not implement DecodeStep {}",
+        decodeStepName(step));
+    try {
+      launchDecode(programs, params, stream.get());
+      FAIL() << "Expected a throw for " << expected;
+    } catch (const std::exception& e) {
+      EXPECT_NE(std::string(e.what()).find(expected), std::string::npos)
+          << e.what();
+    }
+  }
+
  private:
   std::unique_ptr<GpuArena> arena_;
 
@@ -804,6 +825,16 @@ TEST_F(GpuDecoderTest, countBits) {
   testCountBits(20000, 512);
   testCountBits(30000, 1024);
   testCountBits(100000, 2048);
+}
+
+TEST_F(GpuDecoderTest, unsupportedStep) {
+  // A step the decode dispatch has no case for must be reported instead of
+  // leaving the output undecoded. kDictionary and kBitpack64 are declared in
+  // DecodeStep but not implemented, and kRleBool has a shared memory size but
+  // still no case in the dispatch.
+  testUnsupportedStep(DecodeStep::kDictionary);
+  testUnsupportedStep(DecodeStep::kBitpack64);
+  testUnsupportedStep(DecodeStep::kRleBool);
 }
 
 TEST_F(GpuDecoderTest, streamApi) {


### PR DESCRIPTION
## Description

A Wave GPU decode of an unsupported encoding silently returns undecoded data. The
dispatch in `GpuDecoder-inl.cuh` ends with

```
    default:
      if (threadIdx.x == 0) {
        printf("ERROR: Unsupported DecodeStep %d\n", static_cast<int32_t>(op.step));
      }
  }
```

which falls through, so the output buffer keeps whatever it held before and the host
treats the decode as successful. The only signal is a device `printf` that is easy to
lose among thousands of blocks. `DecodeStep` declares 35 steps and the dispatch
implements 15, so every other step behaves this way.

This is latent for the current fixtures, which are PLAIN, uncompressed and
dictionary-off and therefore route to `kTrivial`. It becomes reachable as soon as
dictionaries or compression are enabled, or an encoding Wave does not implement is
added.

The fix follows the error handling this code already uses. `checkDecodeStepSupported()`
throws through `waveError()`, the same path `CUDA_CHECK` takes, and is called from both
launch entry points before the kernel starts: `launchDecode()` and the host
`decodeGlobal()` wrapper. Both already walk every op to size shared memory, so this
covers every op of every program regardless of which call site built it, and the error
names the step: `Wave GPU decode does not implement DecodeStep kDictionary (18)`.

The device `default` case additionally traps rather than returning, as a backstop if
validation is ever bypassed. `assert()` is not used because it is compiled out in
release builds, which is where this would matter.

Worth noting for reviewers: `sharedMemorySizeForDecode()` lists `kRleBool` and
`kLengthToOffset` as needing scan storage even though the dispatch has no case for
them, so the two lists had drifted. The supported set here mirrors the dispatch, and
the new test asserts `kRleBool` is rejected.

No behaviour changes for supported steps; the validation only rejects steps that would
previously have produced undecoded output.

Testing: `velox_wave_decode_test` 13/13, `velox_wave_common_test` 33/33,
`velox_wave_exec_test` 40 passed / 1 skipped (the pre-existing upstream
`FilterProjectTest.ifs` skip). Those counts are with #18308 merged locally, since
without its kernel fixes this base fails `GpuDecoderTest.countBits` and nine
`scanAgg`/`scanDictAgg`/`scan2GroupBy` cases; CI may need #18308 for a green run. No
dependency on #18312. The new `GpuDecoderTest.unsupportedStep` fails without this
change, reporting `Expected a throw` while the kernel only prints
`ERROR: Unsupported DecodeStep 18`.

## Checklist

- [x] All velox-wave tests pass
- [x] I am familiar with the contributing guide and code of conduct