### PR TITLE
fix(ci): Fix pyvelox wheels workflow (#18340)

### DIFF
--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [8-core-ubuntu, macos-13, macos-14]
+        os: [16-core-ubuntu]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
@@ -107,7 +107,7 @@ jobs:
           retention-days: 90
 
       - name: Create sdist
-        if: matrix.os == '8-core-ubuntu'
+        if: matrix.os == '16-core-ubuntu'
         env:
           BUILD_VERSION: ${{ inputs.version }}
         run: |

--- a/velox/common/file/tests/CMakeLists.txt
+++ b/velox/common/file/tests/CMakeLists.txt
@@ -23,22 +23,24 @@ velox_add_test_headers(
 
 target_link_libraries(velox_file_test_utils PUBLIC velox_file)
 
-add_executable(
-  velox_file_test
-  FileTest.cpp
-  FileInputStreamTest.cpp
-  FileIoTracerTest.cpp
-  FileUtilsTest.cpp
-)
-add_test(velox_file_test velox_file_test)
-target_link_libraries(
-  velox_file_test
-  PRIVATE
-    velox_buffer
-    velox_file
-    velox_file_test_utils
-    velox_test_util
-    GTest::gmock
-    GTest::gtest
-    GTest::gtest_main
-)
+if(VELOX_BUILD_TESTING)
+  add_executable(
+    velox_file_test
+    FileTest.cpp
+    FileInputStreamTest.cpp
+    FileIoTracerTest.cpp
+    FileUtilsTest.cpp
+  )
+  add_test(velox_file_test velox_file_test)
+  target_link_libraries(
+    velox_file_test
+    PRIVATE
+      velox_buffer
+      velox_file
+      velox_file_test_utils
+      velox_test_util
+      GTest::gmock
+      GTest::gtest
+      GTest::gtest_main
+  )
+endif()


### PR DESCRIPTION
Summary:

macOS is not supported for the Build Pyvelox Wheels workflow, so remove the `macos-13` and `macos-14` matrix entries and keep only the Ubuntu wheel and sdist build. Also move the Ubuntu wheel job from `8-core-ubuntu` to `16-core-ubuntu`, because the 8-core runner runs out of memory building the wheels.

Additionally, Pyvelox inadvertently built velox_file_test with outdated GoogleMock causing build failure. This change restricts the test executable to VELOX_BUILD_TESTING while retaining its required test utilities.

Reviewed By: kgpai

Differential Revision: D114252327


