### PR TITLE
feat(dwrf): Optionally verify compressed pages round-trip on write

### DIFF
--- a/velox/dwio/common/DataBufferHolder.h
+++ b/velox/dwio/common/DataBufferHolder.h
@@ -115,6 +115,12 @@ class DataBufferHolder {
     return size_;
   }
 
+  /// Returns the maximum size of a single page buffer, i.e. the compression
+  /// block size.
+  uint64_t maxSize() const {
+    return maxSize_;
+  }
+
   /// Tries to resize the buffer. Returned buffer follows below rules
   /// - size() == capacity()
   /// - size() >= min buffer size + header size

--- a/velox/dwio/common/compression/Compression.cpp
+++ b/velox/dwio/common/compression/Compression.cpp
@@ -756,4 +756,38 @@ std::unique_ptr<dwio::common::SeekableInputStream> createDecompressor(
       decompressCounter);
 }
 
+std::unique_ptr<Decompressor> createBlockDecompressor(
+    CompressionKind kind,
+    uint64_t blockSize,
+    const CompressionOptions& options,
+    const std::string& streamDebugInfo) {
+  switch (static_cast<int64_t>(kind)) {
+    case CompressionKind::CompressionKind_NONE:
+      return nullptr;
+    case CompressionKind::CompressionKind_ZLIB:
+      return std::make_unique<ZlibDecompressor>(
+          blockSize, options.format.zlib.windowBits, streamDebugInfo, false);
+    case CompressionKind::CompressionKind_GZIP:
+      return std::make_unique<ZlibDecompressor>(
+          blockSize, options.format.zlib.windowBits, streamDebugInfo, true);
+    case CompressionKind::CompressionKind_SNAPPY:
+      return std::make_unique<SnappyDecompressor>(blockSize, streamDebugInfo);
+    case CompressionKind::CompressionKind_LZO:
+      return std::make_unique<LzoDecompressor>(
+          blockSize,
+          options.format.lz4_lzo.isHadoopFrameFormat,
+          streamDebugInfo);
+    case CompressionKind::CompressionKind_LZ4:
+    case CompressionKind::CompressionKind_LZ4_HADOOP:
+      return std::make_unique<Lz4Decompressor>(
+          blockSize,
+          options.format.lz4_lzo.isHadoopFrameFormat,
+          streamDebugInfo);
+    case CompressionKind::CompressionKind_ZSTD:
+      return std::make_unique<ZstdDecompressor>(blockSize, streamDebugInfo);
+    default:
+      DWIO_RAISE_FMT("Unknown compression codec {}", kind);
+  }
+}
+
 } // namespace facebook::velox::dwio::common::compression

--- a/velox/dwio/common/compression/Compression.h
+++ b/velox/dwio/common/compression/Compression.h
@@ -61,6 +61,11 @@ class Decompressor {
       char* dest,
       uint64_t destLength) = 0;
 
+  /// Returns the human-readable stream identity used in error messages.
+  const std::string& streamDebugInfo() const {
+    return streamDebugInfo_;
+  }
+
  protected:
   int64_t blockSize_;
   const std::string streamDebugInfo_;
@@ -121,5 +126,14 @@ std::unique_ptr<dwio::common::SeekableInputStream> createDecompressor(
 std::unique_ptr<Compressor> createCompressor(
     facebook::velox::common::CompressionKind kind,
     const CompressionOptions& options);
+
+/// Creates a one-shot, block-level decompressor for 'kind', used by the writer
+/// to verify that a freshly compressed page round-trips to its source bytes.
+/// Returns nullptr for CompressionKind_NONE.
+std::unique_ptr<Decompressor> createBlockDecompressor(
+    facebook::velox::common::CompressionKind kind,
+    uint64_t blockSize,
+    const CompressionOptions& options,
+    const std::string& streamDebugInfo);
 
 } // namespace facebook::velox::dwio::common::compression

--- a/velox/dwio/common/compression/CompressionBufferPool.h
+++ b/velox/dwio/common/compression/CompressionBufferPool.h
@@ -29,6 +29,16 @@ class CompressionBufferPool {
 
   virtual void returnBuffer(
       std::unique_ptr<dwio::common::DataBuffer<char>> buffer) = 0;
+
+  /// Returns the shared buffer used to hold decompressed bytes during
+  /// write-side compression verification. Symmetric with getBuffer(); a
+  /// separate buffer is needed because the compression buffer holds the
+  /// compressed page being verified and so cannot be reused as the scratch.
+  virtual std::unique_ptr<dwio::common::DataBuffer<char>>
+  getDecompressionBuffer(uint64_t size) = 0;
+
+  virtual void returnDecompressionBuffer(
+      std::unique_ptr<dwio::common::DataBuffer<char>> buffer) = 0;
 };
 
 } // namespace facebook::velox::dwio::common::compression

--- a/velox/dwio/common/compression/PagedOutputStream.cpp
+++ b/velox/dwio/common/compression/PagedOutputStream.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/dwio/common/compression/PagedOutputStream.h"
 
+#include <cstring>
+
 namespace facebook::velox::dwio::common::compression {
 
 std::vector<std::string_view> PagedOutputStream::createPage() {
@@ -44,6 +46,10 @@ std::vector<std::string_view> PagedOutputStream::createPage() {
     writeHeader(compressionBuffer_->data(), compressedSize, false);
     compressed = std::string_view(
         compressionBuffer_->data(), compressedSize + pageHeaderSize_);
+    if (verifyDecompressor_ != nullptr) {
+      verifyCompressedPage(
+          compressed, buffer_.data() + pageHeaderSize_, origSize);
+    }
   }
 
   if (encryptor_ == nullptr) {
@@ -84,6 +90,60 @@ void PagedOutputStream::resetBuffers() {
     pool_->returnBuffer(std::move(compressionBuffer_));
   }
   encryptionBuffer_ = nullptr;
+}
+
+void PagedOutputStream::verifyCompressedPage(
+    std::string_view compressedPage,
+    const char* uncompressed,
+    uint64_t uncompressedSize) {
+  // Parse the 3-byte page header the same way the reader does, so a wrong
+  // header length is exercised too.
+  const auto* header = reinterpret_cast<const uint8_t*>(compressedPage.data());
+  const uint32_t compressedSize = (static_cast<uint32_t>(header[0]) >> 1) |
+      (static_cast<uint32_t>(header[1]) << 7) |
+      (static_cast<uint32_t>(header[2]) << 15);
+  // Only pages that were actually compressed reach here.
+  VELOX_CHECK_EQ(header[0] & 1, 0);
+
+  // Borrow the shared decompression buffer from the pool; return it on every
+  // exit. The compression buffer cannot be reused as the scratch: it holds the
+  // compressed page being verified.
+  auto decompressionBuffer = pool_->getDecompressionBuffer(uncompressedSize);
+  const auto returnGuard = folly::makeGuard([&]() {
+    pool_->returnDecompressionBuffer(std::move(decompressionBuffer));
+  });
+
+  const char* const payload = compressedPage.data() + pageHeaderSize_;
+  uint64_t decompressedSize{0};
+  std::string decodeError;
+  try {
+    decompressedSize = verifyDecompressor_->decompress(
+        payload, compressedSize, decompressionBuffer->data(), uncompressedSize);
+  } catch (const std::exception& e) {
+    decodeError = e.what();
+  }
+
+  const bool verified = decodeError.empty() &&
+      decompressedSize == uncompressedSize &&
+      ::memcmp(decompressionBuffer->data(), uncompressed, uncompressedSize) ==
+          0;
+  if (verified) {
+    return;
+  }
+
+  // Throw so the call site aborts and retries the write; the useful state
+  // travels in the message. The corruption is nondeterministic, so a retry
+  // usually succeeds.
+  VELOX_FAIL(
+      "DWRF write-side compression verification failed: the freshly compressed "
+      "page does not decode back to the original bytes; aborting the write to "
+      "avoid persisting a corrupt file. stream={} uncompressedSize={} "
+      "compressedSize={} decompressedSize={} decodeError={}",
+      verifyDecompressor_->streamDebugInfo(),
+      uncompressedSize,
+      compressedSize,
+      decompressedSize,
+      decodeError.empty() ? std::string{"none"} : decodeError);
 }
 
 uint64_t PagedOutputStream::flush() {

--- a/velox/dwio/common/compression/PagedOutputStream.h
+++ b/velox/dwio/common/compression/PagedOutputStream.h
@@ -24,19 +24,24 @@ namespace facebook::velox::dwio::common::compression {
 
 class PagedOutputStream : public BufferedOutputStream {
  public:
+  /// 'verifyDecompressor', when non-null, enables write-side verification: each
+  /// compressed page is immediately decompressed and compared against its
+  /// source bytes, throwing on mismatch so a corrupt frame is never persisted.
   PagedOutputStream(
       CompressionBufferPool& pool,
       DataBufferHolder& bufferHolder,
       uint32_t compressionThreshold,
       uint8_t pageHeaderSize,
       std::unique_ptr<Compressor> compressor,
-      const dwio::common::encryption::Encrypter* encryptor)
+      const dwio::common::encryption::Encrypter* encryptor,
+      std::unique_ptr<Decompressor> verifyDecompressor = nullptr)
       : BufferedOutputStream(bufferHolder),
         pool_{&pool},
         compressor_{std::move(compressor)},
         encryptor_{encryptor},
         threshold_{compressionThreshold},
-        pageHeaderSize_{pageHeaderSize} {
+        pageHeaderSize_{pageHeaderSize},
+        verifyDecompressor_{std::move(verifyDecompressor)} {
     VELOX_CHECK(
         compressor_ || encryptor_,
         "Neither compressor or encryptor is set for paged output stream");
@@ -73,6 +78,14 @@ class PagedOutputStream : public BufferedOutputStream {
 
   void resetBuffers();
 
+  // Decompresses 'compressedPage' (page header + payload) and checks it matches
+  // the 'uncompressedSize' original bytes at 'uncompressed'. Throws on decode
+  // failure or content mismatch.
+  void verifyCompressedPage(
+      std::string_view compressedPage,
+      const char* uncompressed,
+      uint64_t uncompressedSize);
+
   CompressionBufferPool* const pool_;
 
   const std::unique_ptr<Compressor> compressor_;
@@ -90,6 +103,11 @@ class PagedOutputStream : public BufferedOutputStream {
 
   // buffer that holds encrypted data
   std::unique_ptr<folly::IOBuf> encryptionBuffer_{nullptr};
+
+  // Decompressor used to verify each freshly compressed page round-trips to its
+  // source bytes. Null when write-side verification is disabled. The scratch
+  // buffer for the decompressed bytes is borrowed from 'pool_'.
+  const std::unique_ptr<Decompressor> verifyDecompressor_;
 };
 
 } // namespace facebook::velox::dwio::common::compression

--- a/velox/dwio/dwrf/common/Compression.h
+++ b/velox/dwio/dwrf/common/Compression.h
@@ -64,7 +64,8 @@ inline std::unique_ptr<dwio::common::BufferedOutputStream> createCompressor(
     CompressionBufferPool& bufferPool,
     dwio::common::DataBufferHolder& bufferHolder,
     const Config& config,
-    const dwio::common::encryption::Encrypter* encrypter = nullptr) {
+    const dwio::common::encryption::Encrypter* encrypter = nullptr,
+    const std::string& streamDebugInfo = "") {
   CompressionOptions dwrfOrcCompressionOptions = getDwrfOrcCompressionOptions(
       kind,
       config.get(Config::COMPRESSION_THRESHOLD),
@@ -76,13 +77,25 @@ inline std::unique_ptr<dwio::common::BufferedOutputStream> createCompressor(
       return std::make_unique<dwio::common::BufferedOutputStream>(bufferHolder);
     }
   }
+  // When the VERIFY_COMPRESSION writer option is set, build a matching
+  // block decompressor so PagedOutputStream can round-trip each compressed
+  // page and throw before a corrupt frame is persisted.
+  std::unique_ptr<Decompressor> verifyDecompressor;
+  if (compressor && config.get(Config::VERIFY_COMPRESSION)) {
+    verifyDecompressor = createBlockDecompressor(
+        kind,
+        bufferHolder.maxSize(),
+        dwrfOrcCompressionOptions,
+        streamDebugInfo);
+  }
   return std::make_unique<PagedOutputStream>(
       bufferPool,
       bufferHolder,
       dwrfOrcCompressionOptions.compressionThreshold,
       PAGE_HEADER_SIZE,
       std::move(compressor),
-      encrypter);
+      encrypter,
+      std::move(verifyDecompressor));
 }
 
 inline CompressionOptions getDwrfOrcDecompressionOptions(

--- a/velox/dwio/dwrf/common/Config.cpp
+++ b/velox/dwio/dwrf/common/Config.cpp
@@ -53,6 +53,8 @@ Config::Entry<uint32_t> Config::COMPRESSION_THRESHOLD(
     "orc.compression.threshold",
     256);
 
+Config::Entry<bool> Config::VERIFY_COMPRESSION("orc.compression.verify", false);
+
 Config::Entry<bool> Config::CREATE_INDEX{"hive.exec.orc.create.index", true};
 
 Config::Entry<uint32_t> Config::ROW_INDEX_STRIDE{

--- a/velox/dwio/dwrf/common/Config.h
+++ b/velox/dwio/dwrf/common/Config.h
@@ -43,6 +43,7 @@ class Config : public config::ConfigBase {
   static Entry<uint64_t> COMPRESSION_BLOCK_SIZE_MIN;
   static Entry<float> COMPRESSION_BLOCK_SIZE_EXTEND_RATIO;
   static Entry<uint32_t> COMPRESSION_THRESHOLD;
+  static Entry<bool> VERIFY_COMPRESSION;
   static Entry<bool> CREATE_INDEX;
   static Entry<uint32_t> ROW_INDEX_STRIDE;
   static Entry<proto::ChecksumAlgorithm> CHECKSUM_ALGORITHM;

--- a/velox/dwio/dwrf/test/CompressionTest.cpp
+++ b/velox/dwio/dwrf/test/CompressionTest.cpp
@@ -44,6 +44,9 @@ class TestBufferPool : public CompressionBufferPool {
   TestBufferPool(MemoryPool& pool, uint64_t blockSize)
       : buffer_{std::make_unique<DataBuffer<char>>(
             pool,
+            blockSize + PAGE_HEADER_SIZE)},
+        decompressionBuffer_{std::make_unique<DataBuffer<char>>(
+            pool,
             blockSize + PAGE_HEADER_SIZE)} {}
 
   std::unique_ptr<DataBuffer<char>> getBuffer(uint64_t /* unused */) override {
@@ -57,8 +60,37 @@ class TestBufferPool : public CompressionBufferPool {
     buffer_ = std::move(buffer);
   }
 
+  std::unique_ptr<DataBuffer<char>> getDecompressionBuffer(
+      uint64_t /* unused */) override {
+    VELOX_CHECK_NOT_NULL(decompressionBuffer_);
+    return std::move(decompressionBuffer_);
+  }
+
+  void returnDecompressionBuffer(
+      std::unique_ptr<DataBuffer<char>> buffer) override {
+    VELOX_CHECK_NULL(decompressionBuffer_);
+    VELOX_CHECK_NOT_NULL(buffer);
+    decompressionBuffer_ = std::move(buffer);
+  }
+
  private:
   std::unique_ptr<DataBuffer<char>> buffer_;
+  std::unique_ptr<DataBuffer<char>> decompressionBuffer_;
+};
+
+// Test-only compressor that emits bytes shorter than its input (forcing the
+// compressed-page branch) that are not a valid frame for any real codec, so a
+// round-trip decompress must fail.
+class CorruptingCompressor : public Compressor {
+ public:
+  CorruptingCompressor() : Compressor{1} {}
+
+  uint64_t compress(const void* /* src */, void* dest, uint64_t length)
+      override {
+    const uint64_t fakeSize = std::min<uint64_t>(length, 8);
+    ::memset(dest, 0, fakeSize);
+    return fakeSize;
+  }
 };
 
 void generateRandomData(char* data, size_t size, bool letter) {
@@ -479,4 +511,81 @@ TEST(CompressionOptionsTest, testCompressionOptions) {
 
   EXPECT_EQ(options.format.zstd.compressionLevel, 7);
   EXPECT_EQ(options.compressionThreshold, 256);
+}
+
+class WriteVerificationTest : public testing::Test {
+ public:
+  static void SetUpTestCase() {
+    MemoryManager::testingSetInstance(MemoryManager::Options{});
+  }
+
+ protected:
+  std::shared_ptr<MemoryPool> pool_ = memoryManager()->addLeafPool();
+};
+
+// With write-side verification enabled, a page whose compressed bytes do not
+// decode back to the source must abort the write via a throw.
+TEST_F(WriteVerificationTest, throwsOnCorruptCompressedPage) {
+  constexpr uint64_t block = 1024;
+  MemorySink memSink(DEFAULT_MEM_STREAM_SIZE, {.pool = pool_.get()});
+  TestBufferPool bufferPool(*pool_, block);
+  DataBufferHolder holder{
+      *pool_, block, 0, DEFAULT_PAGE_GROW_RATIO, std::addressof(memSink)};
+
+  CompressionOptions options{};
+  options.format.zstd.compressionLevel = 1;
+  auto verifyDecompressor = createBlockDecompressor(
+      CompressionKind_ZSTD, block, options, "corrupt-stream");
+
+  PagedOutputStream stream(
+      bufferPool,
+      holder,
+      /*compressionThreshold=*/1,
+      PAGE_HEADER_SIZE,
+      std::make_unique<CorruptingCompressor>(),
+      /*encryptor=*/nullptr,
+      std::move(verifyDecompressor));
+
+  char data[512];
+  std::memset(data, 'a', sizeof(data));
+  void* buffer;
+  int32_t bufferSize = 0;
+  ASSERT_TRUE(stream.Next(&buffer, &bufferSize, sizeof(data)));
+  std::memcpy(buffer, data, sizeof(data));
+  stream.BackUp(bufferSize - static_cast<int32_t>(sizeof(data)));
+
+  VELOX_ASSERT_THROW(stream.flush(), "compression verification failed");
+}
+
+// A well-formed ZSTD page must pass verification and still round-trip on read.
+TEST_F(WriteVerificationTest, verifiesGoodZstdPageThroughWriterOption) {
+  constexpr uint64_t block = 1024;
+  MemorySink memSink(DEFAULT_MEM_STREAM_SIZE, {.pool = pool_.get()});
+  TestBufferPool bufferPool(*pool_, block);
+  DataBufferHolder holder{
+      *pool_, block, 0, DEFAULT_PAGE_GROW_RATIO, std::addressof(memSink)};
+
+  Config config;
+  config.set<bool>(Config::VERIFY_COMPRESSION, true);
+  config.set<uint32_t>(Config::COMPRESSION_THRESHOLD, 32);
+  auto stream = createCompressor(
+      CompressionKind_ZSTD, bufferPool, holder, config, nullptr, "good-stream");
+
+  char data[512];
+  std::memset(data, 'a', sizeof(data));
+  void* buffer;
+  int32_t bufferSize = 0;
+  ASSERT_TRUE(stream->Next(&buffer, &bufferSize, sizeof(data)));
+  std::memcpy(buffer, data, sizeof(data));
+  stream->BackUp(bufferSize - static_cast<int32_t>(sizeof(data)));
+  stream->flush();
+
+  decompressAndVerify(
+      memSink,
+      CompressionKind_ZSTD,
+      block,
+      data,
+      sizeof(data),
+      *pool_,
+      nullptr);
 }

--- a/velox/dwio/dwrf/writer/WriterContext.cpp
+++ b/velox/dwio/dwrf/writer/WriterContext.cpp
@@ -111,6 +111,10 @@ void WriterContext::initBuffer() {
   if (compression_ != common::CompressionKind_NONE) {
     compressionBuffer_ = std::make_unique<dwio::common::DataBuffer<char>>(
         *generalPool_, compressionBlockSize_ + PAGE_HEADER_SIZE);
+    if (getConfig(Config::VERIFY_COMPRESSION)) {
+      decompressionBuffer_ = std::make_unique<dwio::common::DataBuffer<char>>(
+          *generalPool_, compressionBlockSize_ + PAGE_HEADER_SIZE);
+    }
   }
 }
 
@@ -171,6 +175,7 @@ int64_t WriterContext::releaseMemoryReservation() {
 
 void WriterContext::abort() {
   compressionBuffer_.reset();
+  decompressionBuffer_.reset();
   physicalSizeAggregators_.clear();
   streams_.clear();
   dictEncoders_.clear();

--- a/velox/dwio/dwrf/writer/WriterContext.h
+++ b/velox/dwio/dwrf/writer/WriterContext.h
@@ -90,7 +90,7 @@ class WriterContext : public CompressionBufferPool {
         ? std::addressof(
               handler_->getEncryptionProvider(stream.encodingKey().node()))
         : nullptr;
-    return newStream(compression_, holder, encrypter);
+    return newStream(compression_, holder, encrypter, stream.toString());
   }
 
   std::unique_ptr<DataBufferHolder> newDataBufferHolder(
@@ -106,8 +106,10 @@ class WriterContext : public CompressionBufferPool {
   std::unique_ptr<BufferedOutputStream> newStream(
       common::CompressionKind kind,
       DataBufferHolder& holder,
-      const dwio::common::encryption::Encrypter* encrypter = nullptr) {
-    return createCompressor(kind, *this, holder, *config_, encrypter);
+      const dwio::common::encryption::Encrypter* encrypter = nullptr,
+      const std::string& streamDebugInfo = "") {
+    return createCompressor(
+        kind, *this, holder, *config_, encrypter, streamDebugInfo);
   }
 
   template <typename T>
@@ -269,6 +271,20 @@ class WriterContext : public CompressionBufferPool {
     VELOX_CHECK_NOT_NULL(buffer);
     VELOX_CHECK_NULL(compressionBuffer_);
     compressionBuffer_ = std::move(buffer);
+  }
+
+  std::unique_ptr<dwio::common::DataBuffer<char>> getDecompressionBuffer(
+      uint64_t size) override {
+    VELOX_CHECK_NOT_NULL(decompressionBuffer_);
+    VELOX_CHECK_GE(decompressionBuffer_->size(), size);
+    return std::move(decompressionBuffer_);
+  }
+
+  void returnDecompressionBuffer(
+      std::unique_ptr<dwio::common::DataBuffer<char>> buffer) override {
+    VELOX_CHECK_NOT_NULL(buffer);
+    VELOX_CHECK_NULL(decompressionBuffer_);
+    decompressionBuffer_ = std::move(buffer);
   }
 
   void incrementNodeSize(uint32_t node, uint64_t size) {
@@ -661,6 +677,10 @@ class WriterContext : public CompressionBufferPool {
       std::unique_ptr<BufferedOutputStream>)>
       indexBuilderFactory_;
   std::unique_ptr<dwio::common::DataBuffer<char>> compressionBuffer_;
+  // Shared buffer holding decompressed bytes during write-side compression
+  // verification. Allocated only when the VERIFY_COMPRESSION writer option is
+  // set; null otherwise.
+  std::unique_ptr<dwio::common::DataBuffer<char>> decompressionBuffer_;
   // A pool of reusable DecodedVectors.
   std::vector<std::unique_ptr<velox::DecodedVector>> decodedVectorPool_;
   // Reusable SelectivityVector


### PR DESCRIPTION
Summary:
DWRF writers can emit a compressed page that later fails to decode, surfacing far downstream as a read-time error such as:

    ZSTD returned an error: Data corruption detected

By then the file is already committed and the producing job's context is gone. This adds an opt-in write-side check so the failure is caught at write time and the file is aborted rather than persisted. It is controlled by the writer option `orc.compression.verify` and is off by default.

When enabled, each freshly compressed page is decompressed with the reader's own codec and compared against the original bytes before it reaches the sink. A decode error or byte mismatch throws with the stream identity and page sizes, aborting the write. The corruption is nondeterministic, so the retried write usually succeeds.

This is frame-level verification only. It does not catch a stripe footer that records a wrong offset or length for a stream and so points the reader at the wrong span. A close-time full-file re-read would catch that and is left as a follow-up.

Reviewed By: kevinwilfong

Differential Revision: D114189708


