### PR TITLE
feat(cuDF): Decimal32 support in filters and expressions

### DIFF
--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
@@ -36,10 +36,92 @@
 
 #include <cudf/stream_compaction.hpp>
 
+#include <limits>
+
 namespace facebook::velox::cudf_velox::connector::hive {
 
 using namespace facebook::velox::connector;
 using namespace facebook::velox::connector::hive;
+
+namespace {
+
+cudf::type_id parquetDecimalType(
+    const cudf::io::parquet::SchemaElement& schema) {
+  using ParquetType = cudf::io::parquet::Type;
+
+  switch (schema.type) {
+    case ParquetType::INT32:
+      return cudf::type_id::DECIMAL32;
+    case ParquetType::INT64:
+      return cudf::type_id::DECIMAL64;
+    case ParquetType::FIXED_LEN_BYTE_ARRAY:
+      VELOX_CHECK_GT(
+          schema.type_length, 0, "Invalid fixed-length Parquet decimal width");
+      if (schema.type_length <= sizeof(int32_t)) {
+        return cudf::type_id::DECIMAL32;
+      }
+      if (schema.type_length <= sizeof(int64_t)) {
+        return cudf::type_id::DECIMAL64;
+      }
+      if (schema.type_length <= sizeof(int128_t)) {
+        return cudf::type_id::DECIMAL128;
+      }
+      VELOX_FAIL(
+          "Unsupported fixed-length Parquet decimal width: {}",
+          schema.type_length);
+    case ParquetType::BYTE_ARRAY: {
+      auto precision = schema.decimal_precision;
+      if (schema.logical_type.has_value() &&
+          schema.logical_type->type ==
+              cudf::io::parquet::LogicalType::DECIMAL) {
+        precision = schema.logical_type->precision();
+      }
+      VELOX_CHECK_GT(
+          precision, 0, "Parquet decimal is missing a valid precision");
+      VELOX_CHECK_LE(
+          precision,
+          LongDecimalType::kMaxPrecision,
+          "Parquet decimal precision exceeds the maximum supported precision");
+      if (precision <= std::numeric_limits<int32_t>::digits10) {
+        return cudf::type_id::DECIMAL32;
+      }
+      if (precision <= std::numeric_limits<int64_t>::digits10) {
+        return cudf::type_id::DECIMAL64;
+      }
+      return cudf::type_id::DECIMAL128;
+    }
+    default:
+      VELOX_FAIL(
+          "Unsupported physical Parquet type for decimal column: {}",
+          static_cast<int32_t>(schema.type));
+  }
+}
+
+SubfieldFilterDecimalTypes parquetDecimalTypes(
+    const cudf::io::parquet::FileMetaData& metadata,
+    const RowTypePtr& readerSchema) {
+  VELOX_CHECK(
+      !metadata.schema.empty(), "Cannot build a filter from an empty schema");
+
+  SubfieldFilterDecimalTypes decimalTypes;
+  for (const auto childIndex : metadata.schema.front().children_idx) {
+    VELOX_CHECK_LT(
+        childIndex,
+        metadata.schema.size(),
+        "Parquet schema child index out of range");
+    const auto& child = metadata.schema[childIndex];
+    if (!readerSchema->containsChild(child.name)) {
+      continue;
+    }
+    const auto& logicalType = readerSchema->findChild(child.name);
+    if (logicalType->isDecimal()) {
+      decimalTypes.emplace(child.name, parquetDecimalType(child));
+    }
+  }
+  return decimalTypes;
+}
+
+} // namespace
 
 CudfHiveDataSource::CudfHiveDataSource(
     const RowTypePtr& outputType,
@@ -119,8 +201,9 @@ CudfHiveDataSource::CudfHiveDataSource(
     // readColumnNames_
   }
 
-  // Build a combined AST for all subfield filters once. This is query-constant
-  // and doesn't depend on split-specific state.
+  // Keep a logical-width AST for filters that must run after the Parquet read.
+  // A second AST with split-specific physical widths is built after reading
+  // each Parquet footer.
   if (!subfieldFilters_.empty()) {
     auto const readerFilterType = getTableRowType();
     subfieldFilterExpr_ = &createAstFromSubfieldFilters(
@@ -199,6 +282,24 @@ void CudfHiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
   convertSplit(split);
 
   cudfSplitReader_ = createCudfSplitReader();
+  if (!subfieldFilters_.empty()) {
+    const auto readerFilterType = getTableRowType();
+    cudfSplitReader_->setPushdownFilterBuilder(
+        [this,
+         readerFilterType](const cudf::io::parquet::FileMetaData& metadata)
+            -> cudf::ast::expression const* {
+          pushdownFilterTree_ = cudf::ast::tree{};
+          pushdownFilterScalars_.clear();
+          const auto decimalTypes =
+              parquetDecimalTypes(metadata, readerFilterType);
+          return &createAstFromSubfieldFilters(
+              subfieldFilters_,
+              pushdownFilterTree_,
+              pushdownFilterScalars_,
+              readerFilterType,
+              &decimalTypes);
+        });
+  }
   cudfSplitReader_->prepareSplit(runtimeStats_);
 
   // TODO: `completedBytes_` should be updated in `next()` as we read more and

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.h
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.h
@@ -135,9 +135,11 @@ class CudfHiveDataSource : public DataSource, public NvtxHelper {
   // Expression evaluator for remaining filter.
   core::ExpressionEvaluator* const expressionEvaluator_;
 
-  // Expression evaluator for subfield filter.
+  // Logical and split-specific physical AST storage for subfield filters.
   std::vector<std::unique_ptr<cudf::scalar>> subfieldScalars_;
   cudf::ast::tree subfieldTree_;
+  std::vector<std::unique_ptr<cudf::scalar>> pushdownFilterScalars_;
+  cudf::ast::tree pushdownFilterTree_;
   common::SubfieldFilters subfieldFilters_;
 };
 

--- a/velox/experimental/cudf/connectors/hive/CudfSplitReader.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfSplitReader.cpp
@@ -189,7 +189,8 @@ CudfSplitReader::CudfSplitReader(
       pool_(connectorQueryCtx->memoryPool()),
       useExperimentalCudfReader_(useExperimentalCudfReader),
       baseReaderOpts_(pool_),
-      subfieldFilterExpr_(subfieldFilterExpr) {
+      subfieldFilterExpr_(subfieldFilterExpr),
+      pushdownFilterExpr_(subfieldFilterExpr) {
   baseReaderOpts_.setDataIoStats(ioStatistics_);
   baseReaderOpts_.setMetadataIoStats(ioStatistics_);
 }
@@ -323,8 +324,12 @@ void CudfSplitReader::resetSplit() {
   fileMetaData_.clear();
 }
 
-cudf::ast::expression const* CudfSplitReader::subfieldFilter() {
+cudf::ast::expression const* CudfSplitReader::subfieldFilter() const {
   return subfieldFilterExpr_;
+}
+
+cudf::ast::expression const* CudfSplitReader::pushdownFilter() const {
+  return pushdownFilterExpr_;
 }
 
 void CudfSplitReader::setupCudfDataSource() {
@@ -445,7 +450,7 @@ void CudfSplitReader::setupReaderOptions() {
     readerOptions_.set_num_bytes(split_->size());
   }
 
-  if (auto* filter = subfieldFilter(); filter != nullptr) {
+  if (auto* filter = pushdownFilter(); filter != nullptr) {
     readerOptions_.set_filter(*filter);
   }
 
@@ -480,6 +485,14 @@ void CudfSplitReader::fileMetaDatas() {
       fileMetaData_.size(),
       1,
       "CudfSplitReader failed to read any parquet metadatas");
+
+  if (pushdownFilterBuilder_) {
+    VELOX_CHECK_EQ(
+        fileMetaData_.size(),
+        1,
+        "Split-specific subfield filters require exactly one parquet metadata");
+    pushdownFilterExpr_ = pushdownFilterBuilder_(fileMetaData_.front());
+  }
 }
 
 void CudfSplitReader::createCudfReader() {

--- a/velox/experimental/cudf/connectors/hive/CudfSplitReader.h
+++ b/velox/experimental/cudf/connectors/hive/CudfSplitReader.h
@@ -35,6 +35,9 @@
 #include <cudf/io/parquet_schema.hpp>
 #include <cudf/io/types.hpp>
 
+#include <functional>
+#include <utility>
+
 namespace facebook::velox::cudf_velox::connector::hive {
 
 using namespace facebook::velox::connector;
@@ -65,6 +68,13 @@ class CudfSplitReader : public NvtxHelper {
 
   virtual ~CudfSplitReader() = default;
 
+  using PushdownFilterBuilder = std::function<cudf::ast::expression const*(
+      const cudf::io::parquet::FileMetaData&)>;
+
+  void setPushdownFilterBuilder(PushdownFilterBuilder builder) {
+    pushdownFilterBuilder_ = std::move(builder);
+  }
+
   /// Prepare the split: open cudf reader, set up data source and options.
   /// @param runtimeStats Reference to the DataSource's runtime statistics
   virtual void prepareSplit(dwio::common::RuntimeStatistics& runtimeStats);
@@ -81,8 +91,11 @@ class CudfSplitReader : public NvtxHelper {
   // Clear splitReaders and datasources after split has been fully processed.
   virtual void resetSplit();
 
-  // Return the subfield filter.
-  virtual cudf::ast::expression const* subfieldFilter();
+  // Return the logical subfield filter used after reading.
+  cudf::ast::expression const* subfieldFilter() const;
+
+  // Return the split-specific subfield filter used for Parquet pushdown.
+  virtual cudf::ast::expression const* pushdownFilter() const;
 
   // Determine the output memory resource for the cuDF reader.
   virtual rmm::device_async_resource_ref determineCudfMemoryResource();
@@ -143,6 +156,8 @@ class CudfSplitReader : public NvtxHelper {
 
   dwio::common::ReaderOptions baseReaderOpts_;
   cudf::ast::expression const* subfieldFilterExpr_;
+  cudf::ast::expression const* pushdownFilterExpr_;
+  PushdownFilterBuilder pushdownFilterBuilder_;
 
   struct TotalScanTimeCallbackData {
     uint64_t startTimeUs;

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.cpp
@@ -188,8 +188,8 @@ void CudfIcebergSplitReader::resetSplit() {
   deleteMask_.reset();
 }
 
-cudf::ast::expression const* CudfIcebergSplitReader::subfieldFilter() {
-  return deferSubfieldFilter_ ? nullptr : CudfSplitReader::subfieldFilter();
+cudf::ast::expression const* CudfIcebergSplitReader::pushdownFilter() const {
+  return deferSubfieldFilter_ ? nullptr : CudfSplitReader::pushdownFilter();
 }
 
 rmm::device_async_resource_ref
@@ -313,7 +313,9 @@ CudfIcebergSplitReader::readNextChunk() {
 
   // Apply the deferred subfield filter.
   if (deferSubfieldFilter_) {
-    auto* filter = CudfSplitReader::subfieldFilter();
+    // The split filter matches file-backed physical widths and logical widths
+    // for injected columns, which is the layout assembled above.
+    auto* filter = CudfSplitReader::pushdownFilter();
     VELOX_CHECK_NOT_NULL(filter);
     auto filterMask = cudf::compute_column(
         cudfTable->view(), *filter, stream_, get_temp_mr());

--- a/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.h
+++ b/velox/experimental/cudf/connectors/hive/iceberg/CudfIcebergSplitReader.h
@@ -73,8 +73,8 @@ class CudfIcebergSplitReader : public CudfSplitReader {
   // Override to also clear delete readers and column injection
   void resetSplit() override;
 
-  // Override to return the subfield filter when not deferred.
-  cudf::ast::expression const* subfieldFilter() override;
+  // Skip Parquet pushdown when the subfield filter must run after reading.
+  cudf::ast::expression const* pushdownFilter() const override;
 
   // Override to determine the memory resource to construct cuDF reader.
   rmm::device_async_resource_ref determineCudfMemoryResource() override;

--- a/velox/experimental/cudf/exec/CudfGroupby.cpp
+++ b/velox/experimental/cudf/exec/CudfGroupby.cpp
@@ -42,7 +42,7 @@
 namespace {
 
 using namespace facebook::velox;
-using cudf_velox::castDecimal64InputToDecimal128;
+using cudf_velox::castDecimalInputToDecimal128;
 using cudf_velox::CountInputKind;
 using cudf_velox::finalizeDecimalAverage;
 using cudf_velox::get_output_mr;
@@ -188,7 +188,7 @@ void addDecimalRawPartialSingleSumRequest(
     rmm::cuda_stream_view stream,
     uint32_t& sumIdx,
     std::unique_ptr<cudf::column>& castedInput) {
-  auto inputView = castDecimal64InputToDecimal128(
+  auto inputView = castDecimalInputToDecimal128(
       tbl.column(inputIndex), castedInput, stream);
   auto& request = requests.emplace_back();
   sumIdx = requests.size() - 1;

--- a/velox/experimental/cudf/exec/CudfReduce.cpp
+++ b/velox/experimental/cudf/exec/CudfReduce.cpp
@@ -42,7 +42,7 @@
 namespace {
 
 using namespace facebook::velox;
-using facebook::velox::cudf_velox::castDecimal64InputToDecimal128;
+using facebook::velox::cudf_velox::castDecimalInputToDecimal128;
 using facebook::velox::cudf_velox::CountInputKind;
 using facebook::velox::cudf_velox::finalizeDecimalAverage;
 using facebook::velox::cudf_velox::get_output_mr;
@@ -269,7 +269,7 @@ std::unique_ptr<cudf::column> partialDecimalSumCountToSerializedString(
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr) {
   std::unique_ptr<cudf::column> castedInput;
-  inputCol = castDecimal64InputToDecimal128(inputCol, castedInput, stream);
+  inputCol = castDecimalInputToDecimal128(inputCol, castedInput, stream);
   auto const sumAgg = cudf::make_sum_aggregation<cudf::reduce_aggregation>();
   auto sumScalar =
       cudf::reduce(inputCol, *sumAgg, inputCol.type(), stream, get_temp_mr());
@@ -341,7 +341,7 @@ std::unique_ptr<cudf::column> singleDecimalAvgFromRawColumn(
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr) {
   std::unique_ptr<cudf::column> castedInput;
-  inputCol = castDecimal64InputToDecimal128(inputCol, castedInput, stream);
+  inputCol = castDecimalInputToDecimal128(inputCol, castedInput, stream);
   auto const sumAgg = cudf::make_sum_aggregation<cudf::reduce_aggregation>();
   auto sumScalar =
       cudf::reduce(inputCol, *sumAgg, inputCol.type(), stream, get_temp_mr());

--- a/velox/experimental/cudf/exec/CudfWindow.cpp
+++ b/velox/experimental/cudf/exec/CudfWindow.cpp
@@ -1136,7 +1136,7 @@ RowVectorPtr CudfWindow::doGetOutput() {
           : sortedView.column(*inputColIdx);
       if (baseName == "sum" &&
           func.functionCall->inputs()[0]->type()->isDecimal()) {
-        inputCol = castDecimal64InputToDecimal128(
+        inputCol = castDecimalInputToDecimal128(
             inputCol, decimalSumInputOwners[funcIndex], stream_);
       }
       const bool isFullPartition =

--- a/velox/experimental/cudf/exec/DecimalAggregationHostOps.cpp
+++ b/velox/experimental/cudf/exec/DecimalAggregationHostOps.cpp
@@ -36,11 +36,13 @@ void validateIntermediateColumnType(cudf::column_view const& column) {
       colType);
 }
 
-cudf::column_view castDecimal64InputToDecimal128(
+cudf::column_view castDecimalInputToDecimal128(
     cudf::column_view inputCol,
     std::unique_ptr<cudf::column>& holder,
     rmm::cuda_stream_view stream) {
-  if (inputCol.type().id() != cudf::type_id::DECIMAL64) {
+  const auto inputType = inputCol.type().id();
+  if (inputType != cudf::type_id::DECIMAL32 &&
+      inputType != cudf::type_id::DECIMAL64) {
     return inputCol;
   }
   holder = cudf::cast(

--- a/velox/experimental/cudf/exec/DecimalAggregationHostOps.h
+++ b/velox/experimental/cudf/exec/DecimalAggregationHostOps.h
@@ -38,18 +38,18 @@ namespace facebook::velox::cudf_velox {
 void validateIntermediateColumnType(cudf::column_view const& column);
 
 /**
- * Casts a DECIMAL64 column up to DECIMAL128 (scale preserved) so a subsequent
- * SUM accumulates in 128 bits instead of wrapping. Allocates the casted column
- * from the temporary memory resource into holder and returns its view. Lifetime
- * stays valid only while holder is alive.
+ * Casts a DECIMAL32 or DECIMAL64 column up to DECIMAL128 (scale preserved) so
+ * a subsequent SUM accumulates in 128 bits instead of wrapping. Allocates the
+ * casted column from the temporary memory resource into holder and returns its
+ * view. Lifetime stays valid only while holder is alive.
  *
- * @param inputCol DECIMAL64 input column.
+ * @param inputCol DECIMAL32, DECIMAL64, or DECIMAL128 input column.
  * @param holder receives ownership of the casted column when inputCol is
- *        DECIMAL64; unchanged otherwise.
+ *        DECIMAL32 or DECIMAL64; unchanged otherwise.
  * @param stream CUDA stream for device work.
  * @return view of inputCol or of the column stored in holder.
  */
-cudf::column_view castDecimal64InputToDecimal128(
+cudf::column_view castDecimalInputToDecimal128(
     cudf::column_view inputCol,
     std::unique_ptr<cudf::column>& holder,
     rmm::cuda_stream_view stream);

--- a/velox/experimental/cudf/expression/AstUtils.h
+++ b/velox/experimental/cudf/expression/AstUtils.h
@@ -41,16 +41,24 @@ cudf::ast::literal makeLiteralFromScalar(
     const TypePtr& type) {
   if constexpr (cudf::is_fixed_width<T>()) {
     if (type->isDecimal()) {
-      if (type->kind() == TypeKind::BIGINT) {
-        using CudfScalarType = cudf::fixed_point_scalar<numeric::decimal64>;
-        return cudf::ast::literal{*static_cast<CudfScalarType*>(&scalar)};
+      switch (scalar.type().id()) {
+        case cudf::type_id::DECIMAL32: {
+          using CudfScalarType = cudf::fixed_point_scalar<numeric::decimal32>;
+          return cudf::ast::literal{*static_cast<CudfScalarType*>(&scalar)};
+        }
+        case cudf::type_id::DECIMAL64: {
+          using CudfScalarType = cudf::fixed_point_scalar<numeric::decimal64>;
+          return cudf::ast::literal{*static_cast<CudfScalarType*>(&scalar)};
+        }
+        case cudf::type_id::DECIMAL128: {
+          using CudfScalarType = cudf::fixed_point_scalar<numeric::decimal128>;
+          return cudf::ast::literal{*static_cast<CudfScalarType*>(&scalar)};
+        }
+        default:
+          VELOX_UNREACHABLE(
+              "Invalid cuDF decimal scalar type: {}",
+              static_cast<int32_t>(scalar.type().id()));
       }
-      if (type->kind() == TypeKind::HUGEINT) {
-        using CudfScalarType = cudf::fixed_point_scalar<numeric::decimal128>;
-        return cudf::ast::literal{*static_cast<CudfScalarType*>(&scalar)};
-      }
-      VELOX_UNREACHABLE(
-          "Invalid Decimal Type (bad TypeKind: {})", type->kind());
     } else if (type->isIntervalDayTime()) {
       using CudfDurationType = cudf::duration_ms;
       if constexpr (std::is_same_v<T, CudfDurationType::rep>) {
@@ -143,29 +151,50 @@ std::unique_ptr<cudf::scalar> makeScalarFromValue(
       // Velox DECIMAL scale is positive for fractional digits
       // cuDF scale is negative for fractional digits
       // @TODO check the bigger picture here!
+      numeric::scale_type cudfScale{0};
+      cudf::type_id defaultType{cudf::type_id::EMPTY};
       if (type->kind() == TypeKind::BIGINT) {
         auto const decimalType =
             std::dynamic_pointer_cast<const ShortDecimalType>(type);
         VELOX_CHECK(decimalType, "Invalid Decimal Type (failed dynamic_cast)");
-        auto const cudfScale = numeric::scale_type{-decimalType->scale()};
-        using CudfDecimalType = cudf::fixed_point_scalar<numeric::decimal64>;
-        auto scalar = std::make_unique<CudfDecimalType>(
-            value, cudfScale, !isNull, stream, mr);
-        stream.synchronize();
-        return scalar;
+        cudfScale = numeric::scale_type{-decimalType->scale()};
+        defaultType = cudf::type_id::DECIMAL64;
       } else if (type->kind() == TypeKind::HUGEINT) {
         auto const decimalType =
             std::dynamic_pointer_cast<const LongDecimalType>(type);
         VELOX_CHECK(decimalType, "Invalid Decimal Type (failed dynamic_cast)");
-        auto const cudfScale = numeric::scale_type{-decimalType->scale()};
-        using CudfDecimalType = cudf::fixed_point_scalar<numeric::decimal128>;
-        auto scalar = std::make_unique<CudfDecimalType>(
-            value, cudfScale, !isNull, stream, mr);
-        stream.synchronize();
-        return scalar;
+        cudfScale = numeric::scale_type{-decimalType->scale()};
+        defaultType = cudf::type_id::DECIMAL128;
+      } else {
+        VELOX_UNREACHABLE(
+            "Invalid Decimal Type (bad TypeKind: {})", type->kind());
       }
-      VELOX_UNREACHABLE(
-          "Invalid Decimal Type (bad TypeKind: {})", type->kind());
+
+      std::unique_ptr<cudf::scalar> scalar;
+      const auto targetType = toType.value_or(defaultType);
+      switch (targetType) {
+        case cudf::type_id::DECIMAL32:
+          scalar =
+              std::make_unique<cudf::fixed_point_scalar<numeric::decimal32>>(
+                  static_cast<int32_t>(value), cudfScale, !isNull, stream, mr);
+          break;
+        case cudf::type_id::DECIMAL64:
+          scalar =
+              std::make_unique<cudf::fixed_point_scalar<numeric::decimal64>>(
+                  static_cast<int64_t>(value), cudfScale, !isNull, stream, mr);
+          break;
+        case cudf::type_id::DECIMAL128:
+          scalar =
+              std::make_unique<cudf::fixed_point_scalar<numeric::decimal128>>(
+                  static_cast<int128_t>(value), cudfScale, !isNull, stream, mr);
+          break;
+        default:
+          VELOX_UNREACHABLE(
+              "Invalid target cuDF decimal type: {}",
+              static_cast<int32_t>(targetType));
+      }
+      stream.synchronize();
+      return scalar;
     } else if (type->isIntervalYearMonth()) {
       VELOX_FAIL("Interval year month not supported");
     } else if (type->isIntervalDayTime()) {
@@ -249,16 +278,17 @@ cudf::ast::literal makeScalarAndLiteral(
     const TypePtr& type,
     const variant& var,
     bool isNull,
-    std::vector<std::unique_ptr<cudf::scalar>>& scalars) {
+    std::vector<std::unique_ptr<cudf::scalar>>& scalars,
+    std::optional<cudf::type_id> toType = std::nullopt) {
   using T = typename TypeTraits<kind>::NativeType;
   if constexpr (cudf::is_fixed_width<T>() || kind == TypeKind::VARCHAR) {
     if (isNull) {
-      auto scalar = makeScalarFromValue<T>(type, T{}, true);
+      auto scalar = makeScalarFromValue<T>(type, T{}, true, toType);
       scalars.emplace_back(std::move(scalar));
       return makeLiteralFromScalar<T>(*(scalars.back()), type);
     }
     auto value = var.value<T>();
-    auto scalar = makeScalarFromValue(type, value, false);
+    auto scalar = makeScalarFromValue(type, value, false, toType);
     scalars.emplace_back(std::move(scalar));
     return makeLiteralFromScalar<T>(*(scalars.back()), type);
   }
@@ -269,8 +299,9 @@ template <TypeKind kind>
 cudf::ast::literal makeScalarAndLiteral(
     const TypePtr& type,
     const variant& var,
-    std::vector<std::unique_ptr<cudf::scalar>>& scalars) {
-  return makeScalarAndLiteral<kind>(type, var, false, scalars);
+    std::vector<std::unique_ptr<cudf::scalar>>& scalars,
+    std::optional<cudf::type_id> toType = std::nullopt) {
+  return makeScalarAndLiteral<kind>(type, var, false, scalars, toType);
 }
 
 /// Returns true if expr is non-null and its output type is one the AST/JIT

--- a/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
@@ -1279,15 +1279,17 @@ class GreatestLeastFunction : public CudfFunction {
 class SwitchFunction : public CudfFunction {
  public:
   SwitchFunction(const std::shared_ptr<velox::exec::Expr>& expr)
-      : resultType_(cudf_velox::veloxToCudfDataType(expr->type())) {
-    VELOX_CHECK_EQ(
-        expr->inputs().size(), 3, "case when expects exactly 3 inputs");
+      : resultType_(cudf_velox::veloxToCudfDataType(expr->type())),
+        hasElseClause_(expr->inputs().size() == 3) {
+    VELOX_CHECK(
+        expr->inputs().size() == 2 || expr->inputs().size() == 3,
+        "single-branch case when expects 2 or 3 inputs");
     VELOX_CHECK_EQ(
         expr->inputs()[0]->type()->kind(),
         TypeKind::BOOLEAN,
         "The switch condition result type should be boolean");
     VELOX_CHECK_NULL(
-        std::dynamic_pointer_cast<velox::exec::ConstantExpr>(expr),
+        std::dynamic_pointer_cast<velox::exec::ConstantExpr>(expr->inputs()[0]),
         "The condition should not be constant");
     if (auto constExpr = std::dynamic_pointer_cast<velox::exec::ConstantExpr>(
             expr->inputs()[1])) {
@@ -1295,11 +1297,13 @@ class SwitchFunction : public CudfFunction {
       left_ = VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
           createCudfScalar, constValue->typeKind(), constValue);
     }
-    if (auto constExpr = std::dynamic_pointer_cast<velox::exec::ConstantExpr>(
-            expr->inputs()[2])) {
-      auto constValue = constExpr->value();
-      right_ = VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
-          createCudfScalar, constValue->typeKind(), constValue);
+    if (hasElseClause_) {
+      if (auto constExpr = std::dynamic_pointer_cast<velox::exec::ConstantExpr>(
+              expr->inputs()[2])) {
+        auto constValue = constExpr->value();
+        right_ = VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+            createCudfScalar, constValue->typeKind(), constValue);
+      }
     }
   }
 
@@ -1314,9 +1318,16 @@ class SwitchFunction : public CudfFunction {
     std::unique_ptr<cudf::column> rightColumn;
     std::unique_ptr<cudf::scalar> leftScalar;
     std::unique_ptr<cudf::scalar> rightScalar;
+    std::unique_ptr<cudf::scalar> nullElseScalar;
     auto const condition = asView(inputColumns[0]);
+    auto const* rightInput = right_.get();
+    if (!hasElseClause_) {
+      nullElseScalar =
+          cudf::make_default_constructed_scalar(resultType_, stream, mr);
+      rightInput = nullElseScalar.get();
+    }
 
-    if (left_ == nullptr && right_ == nullptr) {
+    if (left_ == nullptr && rightInput == nullptr) {
       auto const left =
           columnWithType(inputColumns[1], resultType_, leftColumn, stream, mr);
       auto const right =
@@ -1326,9 +1337,9 @@ class SwitchFunction : public CudfFunction {
       auto const left =
           columnWithType(inputColumns[1], resultType_, leftColumn, stream, mr);
       auto const* right =
-          scalarWithType(*right_, resultType_, rightScalar, stream, mr);
+          scalarWithType(*rightInput, resultType_, rightScalar, stream, mr);
       return cudf::copy_if_else(left, *right, condition, stream, mr);
-    } else if (right_ == nullptr) {
+    } else if (rightInput == nullptr) {
       auto const* left =
           scalarWithType(*left_, resultType_, leftScalar, stream, mr);
       auto const right =
@@ -1339,12 +1350,13 @@ class SwitchFunction : public CudfFunction {
     auto const* left =
         scalarWithType(*left_, resultType_, leftScalar, stream, mr);
     auto const* right =
-        scalarWithType(*right_, resultType_, rightScalar, stream, mr);
+        scalarWithType(*rightInput, resultType_, rightScalar, stream, mr);
     return cudf::copy_if_else(*left, *right, condition, stream, mr);
   }
 
  private:
   const cudf::data_type resultType_;
+  const bool hasElseClause_;
   std::unique_ptr<cudf::scalar> left_;
   std::unique_ptr<cudf::scalar> right_;
 };
@@ -2600,8 +2612,19 @@ bool registerBuiltinFunctions(const std::string& prefix) {
            .returnType("T")
            .argumentType("boolean")
            .argumentType("T")
+           .build(),
+       FunctionSignatureBuilder()
+           .typeVariable("T")
+           .returnType("T")
+           .argumentType("boolean")
            .argumentType("T")
-           .build()});
+           .argumentType("T")
+           .build()},
+      /*overwrite=*/true,
+      [](const std::shared_ptr<velox::exec::Expr>& expr) {
+        return !std::dynamic_pointer_cast<velox::exec::ConstantExpr>(
+            expr->inputs()[0]);
+      });
 
   registerCudfFunctions(
       // No signatures required for cast and try_cast. They are special forms.

--- a/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
@@ -199,6 +199,80 @@ std::unique_ptr<cudf::scalar> castDecimalScalar(
       mr);
 }
 
+// cuDF decimal arithmetic requires matching storage widths, but each
+// operand's scale must remain unchanged for result-scale calculation.
+cudf::data_type decimalOperandType(
+    cudf::data_type inputType,
+    cudf::data_type resultType) {
+  VELOX_DCHECK(cudf::is_fixed_point(inputType));
+  VELOX_DCHECK(cudf::is_fixed_point(resultType));
+  return cudf::data_type{resultType.id(), inputType.scale()};
+}
+
+cudf::data_type decimalDivisionWorkingType(
+    cudf::data_type lhsType,
+    cudf::data_type rhsType,
+    cudf::data_type resultType) {
+  VELOX_DCHECK(cudf::is_fixed_point(lhsType));
+  VELOX_DCHECK(cudf::is_fixed_point(rhsType));
+  VELOX_DCHECK(cudf::is_fixed_point(resultType));
+  VELOX_DCHECK(
+      resultType.id() == cudf::type_id::DECIMAL64 ||
+      resultType.id() == cudf::type_id::DECIMAL128);
+
+  // Velox represents logical decimals using DECIMAL64 or DECIMAL128, so the
+  // result already establishes DECIMAL64 as the minimum working width.
+  auto workingTypeId = cudf::type_id::DECIMAL64;
+  if (lhsType.id() == cudf::type_id::DECIMAL128 ||
+      rhsType.id() == cudf::type_id::DECIMAL128 ||
+      resultType.id() == cudf::type_id::DECIMAL128) {
+    workingTypeId = cudf::type_id::DECIMAL128;
+  }
+  return cudf::data_type{workingTypeId, resultType.scale()};
+}
+
+std::unique_ptr<cudf::column> finalizeDecimalDivision(
+    std::unique_ptr<cudf::column> result,
+    cudf::data_type resultType,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  if (result->type() == resultType) {
+    return result;
+  }
+  return cudf::cast(result->view(), resultType, stream, mr);
+}
+
+cudf::column_view columnWithType(
+    ColumnOrView& input,
+    cudf::data_type targetType,
+    std::unique_ptr<cudf::column>& converted,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  auto const view = asView(input);
+  if (view.type() == targetType) {
+    return view;
+  }
+  converted = cudf::cast(view, targetType, stream, mr);
+  return converted->view();
+}
+
+const cudf::scalar* scalarWithType(
+    const cudf::scalar& input,
+    cudf::data_type targetType,
+    std::unique_ptr<cudf::scalar>& converted,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  if (input.type() == targetType) {
+    return &input;
+  }
+
+  auto inputColumn = cudf::make_column_from_scalar(input, 1, stream, mr);
+  auto convertedColumn =
+      cudf::cast(inputColumn->view(), targetType, stream, mr);
+  converted = cudf::get_element(convertedColumn->view(), 0, stream, mr);
+  return converted.get();
+}
+
 struct CudfExpressionEvaluatorEntry {
   int priority;
   CudfExpressionEvaluatorCanEvaluate canEvaluate;
@@ -582,25 +656,25 @@ class BinaryFunction : public CudfFunction {
         auto rhsView = asView(inputColumns[1]);
         std::unique_ptr<cudf::column> lhsCast;
         std::unique_ptr<cudf::column> rhsCast;
-        if (type_.id() == cudf::type_id::DECIMAL128) {
-          if (lhsView.type().id() == cudf::type_id::DECIMAL64) {
-            auto castType = cudf::data_type{
-                cudf::type_id::DECIMAL128, lhsView.type().scale()};
-            lhsCast = cudf::cast(lhsView, castType, stream, mr);
-            lhsView = lhsCast->view();
-          }
-          if (rhsView.type().id() == cudf::type_id::DECIMAL64) {
-            auto castType = cudf::data_type{
-                cudf::type_id::DECIMAL128, rhsView.type().scale()};
-            rhsCast = cudf::cast(rhsView, castType, stream, mr);
-            rhsView = rhsCast->view();
-          }
+        auto workingType =
+            decimalDivisionWorkingType(lhsView.type(), rhsView.type(), type_);
+        auto lhsType = decimalOperandType(lhsView.type(), workingType);
+        auto rhsType = decimalOperandType(rhsView.type(), workingType);
+        if (lhsView.type() != lhsType) {
+          lhsCast = cudf::cast(lhsView, lhsType, stream, mr);
+          lhsView = lhsCast->view();
+        }
+        if (rhsView.type() != rhsType) {
+          rhsCast = cudf::cast(rhsView, rhsType, stream, mr);
+          rhsView = rhsCast->view();
         }
         auto lhsScale = -lhsView.type().scale();
         auto rhsScale = -rhsView.type().scale();
         auto outScale = -type_.scale();
         auto aRescale = outScale - lhsScale + rhsScale;
-        return decimalDivide(lhsView, rhsView, type_, aRescale, stream, mr);
+        auto result =
+            decimalDivide(lhsView, rhsView, workingType, aRescale, stream, mr);
+        return finalizeDecimalDivision(std::move(result), type_, stream, mr);
       }
       auto lhsView = asView(inputColumns[0]);
       auto rhsView = asView(inputColumns[1]);
@@ -649,19 +723,15 @@ class BinaryFunction : public CudfFunction {
         if (op_ == cudf::binary_operator::MUL) {
           std::unique_ptr<cudf::column> lhsCast;
           std::unique_ptr<cudf::column> rhsCast;
-          if (type_.id() == cudf::type_id::DECIMAL128) {
-            if (lhsView.type().id() == cudf::type_id::DECIMAL64) {
-              auto castType = cudf::data_type{
-                  cudf::type_id::DECIMAL128, lhsView.type().scale()};
-              lhsCast = cudf::cast(lhsView, castType, stream, mr);
-              lhsView = lhsCast->view();
-            }
-            if (rhsView.type().id() == cudf::type_id::DECIMAL64) {
-              auto castType = cudf::data_type{
-                  cudf::type_id::DECIMAL128, rhsView.type().scale()};
-              rhsCast = cudf::cast(rhsView, castType, stream, mr);
-              rhsView = rhsCast->view();
-            }
+          auto lhsType = decimalOperandType(lhsView.type(), type_);
+          auto rhsType = decimalOperandType(rhsView.type(), type_);
+          if (lhsView.type() != lhsType) {
+            lhsCast = cudf::cast(lhsView, lhsType, stream, mr);
+            lhsView = lhsCast->view();
+          }
+          if (rhsView.type() != rhsType) {
+            rhsCast = cudf::cast(rhsView, rhsType, stream, mr);
+            rhsView = rhsCast->view();
           }
           // @TODO Check for divide-by-zero as in the DECIMAL case above?
           return cudf::binary_operation(
@@ -676,11 +746,28 @@ class BinaryFunction : public CudfFunction {
           VELOX_USER_FAIL("Division by zero");
         }
         auto lhsView = asView(inputColumns[0]);
+        std::unique_ptr<cudf::column> lhsCast;
+        std::unique_ptr<cudf::scalar> rhsScalar;
+        auto workingType =
+            decimalDivisionWorkingType(lhsView.type(), right_->type(), type_);
+        auto lhsType = decimalOperandType(lhsView.type(), workingType);
+        auto rhsType = decimalOperandType(right_->type(), workingType);
+        if (lhsView.type() != lhsType) {
+          lhsCast = cudf::cast(lhsView, lhsType, stream, mr);
+          lhsView = lhsCast->view();
+        }
+        auto const* rhs = right_.get();
+        if (right_->type() != rhsType) {
+          rhsScalar = castDecimalScalar(*right_, rhsType, stream, mr);
+          rhs = rhsScalar.get();
+        }
         auto lhsScale = -lhsView.type().scale();
-        auto rhsScale = -right_->type().scale();
+        auto rhsScale = -rhs->type().scale();
         auto outScale = -type_.scale();
         auto aRescale = outScale - lhsScale + rhsScale;
-        return decimalDivide(lhsView, *right_, type_, aRescale, stream, mr);
+        auto result =
+            decimalDivide(lhsView, *rhs, workingType, aRescale, stream, mr);
+        return finalizeDecimalDivision(std::move(result), type_, stream, mr);
       }
       auto lhsView = asView(inputColumns[0]);
       if (isComparisonOp(op_) && cudf::is_fixed_point(lhsView.type()) &&
@@ -726,18 +813,14 @@ class BinaryFunction : public CudfFunction {
         if (op_ == cudf::binary_operator::MUL) {
           std::unique_ptr<cudf::column> lhsCast;
           std::unique_ptr<cudf::scalar> rhsScalar;
-          if (type_.id() == cudf::type_id::DECIMAL128) {
-            if (lhsView.type().id() == cudf::type_id::DECIMAL64) {
-              auto castType = cudf::data_type{
-                  cudf::type_id::DECIMAL128, lhsView.type().scale()};
-              lhsCast = cudf::cast(lhsView, castType, stream, mr);
-              lhsView = lhsCast->view();
-            }
-            if (right_->type().id() == cudf::type_id::DECIMAL64) {
-              auto castType = cudf::data_type{
-                  cudf::type_id::DECIMAL128, right_->type().scale()};
-              rhsScalar = castDecimalScalar(*right_, castType, stream, mr);
-            }
+          auto lhsType = decimalOperandType(lhsView.type(), type_);
+          auto rhsType = decimalOperandType(right_->type(), type_);
+          if (lhsView.type() != lhsType) {
+            lhsCast = cudf::cast(lhsView, lhsType, stream, mr);
+            lhsView = lhsCast->view();
+          }
+          if (right_->type() != rhsType) {
+            rhsScalar = castDecimalScalar(*right_, rhsType, stream, mr);
           }
           return cudf::binary_operation(
               lhsView,
@@ -753,11 +836,28 @@ class BinaryFunction : public CudfFunction {
     }
     if (op_ == cudf::binary_operator::DIV && cudf::is_fixed_point(type_)) {
       auto rhsView = asView(inputColumns[0]);
-      auto lhsScale = -left_->type().scale();
+      std::unique_ptr<cudf::column> rhsCast;
+      std::unique_ptr<cudf::scalar> lhsScalar;
+      auto workingType =
+          decimalDivisionWorkingType(left_->type(), rhsView.type(), type_);
+      auto lhsType = decimalOperandType(left_->type(), workingType);
+      auto rhsType = decimalOperandType(rhsView.type(), workingType);
+      if (rhsView.type() != rhsType) {
+        rhsCast = cudf::cast(rhsView, rhsType, stream, mr);
+        rhsView = rhsCast->view();
+      }
+      auto const* lhs = left_.get();
+      if (left_->type() != lhsType) {
+        lhsScalar = castDecimalScalar(*left_, lhsType, stream, mr);
+        lhs = lhsScalar.get();
+      }
+      auto lhsScale = -lhs->type().scale();
       auto rhsScale = -rhsView.type().scale();
       auto outScale = -type_.scale();
       auto aRescale = outScale - lhsScale + rhsScale;
-      return decimalDivide(*left_, rhsView, type_, aRescale, stream, mr);
+      auto result =
+          decimalDivide(*lhs, rhsView, workingType, aRescale, stream, mr);
+      return finalizeDecimalDivision(std::move(result), type_, stream, mr);
     }
     auto rhsView = asView(inputColumns[0]);
     if (isComparisonOp(op_) && cudf::is_fixed_point(left_->type()) &&
@@ -802,18 +902,14 @@ class BinaryFunction : public CudfFunction {
       if (op_ == cudf::binary_operator::MUL) {
         std::unique_ptr<cudf::column> rhsCast;
         std::unique_ptr<cudf::scalar> lhsScalar;
-        if (type_.id() == cudf::type_id::DECIMAL128) {
-          if (rhsView.type().id() == cudf::type_id::DECIMAL64) {
-            auto castType = cudf::data_type{
-                cudf::type_id::DECIMAL128, rhsView.type().scale()};
-            rhsCast = cudf::cast(rhsView, castType, stream, mr);
-            rhsView = rhsCast->view();
-          }
-          if (left_->type().id() == cudf::type_id::DECIMAL64) {
-            auto castType = cudf::data_type{
-                cudf::type_id::DECIMAL128, left_->type().scale()};
-            lhsScalar = castDecimalScalar(*left_, castType, stream, mr);
-          }
+        auto lhsType = decimalOperandType(left_->type(), type_);
+        auto rhsType = decimalOperandType(rhsView.type(), type_);
+        if (rhsView.type() != rhsType) {
+          rhsCast = cudf::cast(rhsView, rhsType, stream, mr);
+          rhsView = rhsCast->view();
+        }
+        if (left_->type() != lhsType) {
+          lhsScalar = castDecimalScalar(*left_, lhsType, stream, mr);
         }
         return cudf::binary_operation(
             lhsScalar ? *lhsScalar : *left_, rhsView, op_, type_, stream, mr);
@@ -997,7 +1093,9 @@ class UnaryFunction : public CudfFunction {
 
 class BetweenFunction : public CudfFunction {
  public:
-  BetweenFunction(const std::shared_ptr<velox::exec::Expr>& expr) {
+  BetweenFunction(const std::shared_ptr<velox::exec::Expr>& expr)
+      : operandType_(
+            cudf_velox::veloxToCudfDataType(expr->inputs()[0]->type())) {
     // must have exactly three inputs: value, min, max
     VELOX_CHECK_EQ(
         expr->inputs().size(), 3, "Between function expects exactly 3 inputs");
@@ -1027,40 +1125,53 @@ class BetweenFunction : public CudfFunction {
       rmm::cuda_stream_view stream,
       rmm::device_async_resource_ref mr) const override {
     // return (value >= min) && (value <= max)
-    std::unique_ptr<cudf::column> geResultColumn, leResultColumn;
+    std::unique_ptr<cudf::column> valueColumn;
+    std::unique_ptr<cudf::column> minColumn;
+    std::unique_ptr<cudf::column> maxColumn;
+    std::unique_ptr<cudf::scalar> minScalar;
+    std::unique_ptr<cudf::scalar> maxScalar;
+    std::unique_ptr<cudf::column> geResultColumn;
+    std::unique_ptr<cudf::column> leResultColumn;
+    auto const value =
+        columnWithType(inputColumns[0], operandType_, valueColumn, stream, mr);
+    size_t nextInput = 1;
+
     if (minLiteral_) {
+      auto const* min =
+          scalarWithType(*minLiteral_, operandType_, minScalar, stream, mr);
       geResultColumn = cudf::binary_operation(
-          asView(inputColumns[0]),
-          *minLiteral_,
+          value,
+          *min,
           cudf::binary_operator::GREATER_EQUAL,
           kBoolType,
           stream,
           mr);
     } else {
+      auto const min = columnWithType(
+          inputColumns[nextInput++], operandType_, minColumn, stream, mr);
       geResultColumn = cudf::binary_operation(
-          asView(inputColumns[0]),
-          asView(inputColumns[1]),
+          value,
+          min,
           cudf::binary_operator::GREATER_EQUAL,
           kBoolType,
           stream,
           mr);
     }
     if (maxLiteral_) {
+      auto const* max =
+          scalarWithType(*maxLiteral_, operandType_, maxScalar, stream, mr);
       leResultColumn = cudf::binary_operation(
-          asView(inputColumns[0]),
-          *maxLiteral_,
+          value,
+          *max,
           cudf::binary_operator::LESS_EQUAL,
           kBoolType,
           stream,
           mr);
     } else {
+      auto const max = columnWithType(
+          inputColumns[nextInput++], operandType_, maxColumn, stream, mr);
       leResultColumn = cudf::binary_operation(
-          asView(inputColumns[0]),
-          asView(inputColumns[2]),
-          cudf::binary_operator::LESS_EQUAL,
-          kBoolType,
-          stream,
-          mr);
+          value, max, cudf::binary_operator::LESS_EQUAL, kBoolType, stream, mr);
     }
     return cudf::binary_operation(
         geResultColumn->view(),
@@ -1073,6 +1184,7 @@ class BetweenFunction : public CudfFunction {
 
  private:
   static constexpr cudf::data_type kBoolType{cudf::type_id::BOOL8};
+  const cudf::data_type operandType_;
   std::unique_ptr<cudf::scalar> minLiteral_;
   std::unique_ptr<cudf::scalar> maxLiteral_;
 };
@@ -1166,7 +1278,8 @@ class GreatestLeastFunction : public CudfFunction {
 
 class SwitchFunction : public CudfFunction {
  public:
-  SwitchFunction(const std::shared_ptr<velox::exec::Expr>& expr) {
+  SwitchFunction(const std::shared_ptr<velox::exec::Expr>& expr)
+      : resultType_(cudf_velox::veloxToCudfDataType(expr->type())) {
     VELOX_CHECK_EQ(
         expr->inputs().size(), 3, "case when expects exactly 3 inputs");
     VELOX_CHECK_EQ(
@@ -1194,37 +1307,52 @@ class SwitchFunction : public CudfFunction {
       std::vector<ColumnOrView>& inputColumns,
       rmm::cuda_stream_view stream,
       rmm::device_async_resource_ref mr) const override {
+    // Readers may preserve narrower physical types, e.g. DECIMAL32 for a
+    // logical short decimal, while literals use Velox's DECIMAL64. cuDF
+    // requires both copy_if_else inputs to have the same physical type.
+    std::unique_ptr<cudf::column> leftColumn;
+    std::unique_ptr<cudf::column> rightColumn;
+    std::unique_ptr<cudf::scalar> leftScalar;
+    std::unique_ptr<cudf::scalar> rightScalar;
+    auto const condition = asView(inputColumns[0]);
+
     if (left_ == nullptr && right_ == nullptr) {
-      return cudf::copy_if_else(
-          asView(inputColumns[1]),
-          asView(inputColumns[2]),
-          asView(inputColumns[0]),
-          stream,
-          mr);
+      auto const left =
+          columnWithType(inputColumns[1], resultType_, leftColumn, stream, mr);
+      auto const right =
+          columnWithType(inputColumns[2], resultType_, rightColumn, stream, mr);
+      return cudf::copy_if_else(left, right, condition, stream, mr);
     } else if (left_ == nullptr) {
-      return cudf::copy_if_else(
-          asView(inputColumns[1]),
-          *right_,
-          asView(inputColumns[0]),
-          stream,
-          mr);
+      auto const left =
+          columnWithType(inputColumns[1], resultType_, leftColumn, stream, mr);
+      auto const* right =
+          scalarWithType(*right_, resultType_, rightScalar, stream, mr);
+      return cudf::copy_if_else(left, *right, condition, stream, mr);
     } else if (right_ == nullptr) {
-      return cudf::copy_if_else(
-          *left_, asView(inputColumns[1]), asView(inputColumns[0]), stream, mr);
+      auto const* left =
+          scalarWithType(*left_, resultType_, leftScalar, stream, mr);
+      auto const right =
+          columnWithType(inputColumns[1], resultType_, rightColumn, stream, mr);
+      return cudf::copy_if_else(*left, right, condition, stream, mr);
     }
-    // right != null and left != null
-    return cudf::copy_if_else(
-        *left_, *right_, asView(inputColumns[0]), stream, mr);
+
+    auto const* left =
+        scalarWithType(*left_, resultType_, leftScalar, stream, mr);
+    auto const* right =
+        scalarWithType(*right_, resultType_, rightScalar, stream, mr);
+    return cudf::copy_if_else(*left, *right, condition, stream, mr);
   }
 
  private:
+  const cudf::data_type resultType_;
   std::unique_ptr<cudf::scalar> left_;
   std::unique_ptr<cudf::scalar> right_;
 };
 
 class CoalesceFunction : public CudfFunction {
  public:
-  CoalesceFunction(const std::shared_ptr<velox::exec::Expr>& expr) {
+  CoalesceFunction(const std::shared_ptr<velox::exec::Expr>& expr)
+      : resultType_(cudf_velox::veloxToCudfDataType(expr->type())) {
     using velox::exec::ConstantExpr;
 
     // Storing the first literal that appears in inputs because we don't need to
@@ -1270,27 +1398,51 @@ class CoalesceFunction : public CudfFunction {
         VELOX_NYI("coalesce with only literal inputs is not supported");
       }
       auto size = asView(inputColumns[0]).size();
-      return cudf::make_column_from_scalar(*literalScalar_, size, stream, mr);
+      std::unique_ptr<cudf::scalar> convertedLiteral;
+      auto const* literal = scalarWithType(
+          *literalScalar_, resultType_, convertedLiteral, stream, mr);
+      return cudf::make_column_from_scalar(*literal, size, stream, mr);
     }
 
     VELOX_CHECK(
         !inputColumns.empty(),
         "coalesce requires at least one non-literal input");
-    ColumnOrView result = asView(inputColumns[0]);
+    std::unique_ptr<cudf::column> firstColumn;
+    auto const first =
+        columnWithType(inputColumns[0], resultType_, firstColumn, stream, mr);
+    ColumnOrView result = first;
+    if (firstColumn) {
+      result = std::move(firstColumn);
+    } else if (
+        std::holds_alternative<std::unique_ptr<cudf::column>>(
+            inputColumns[0])) {
+      // If the first input is an owned subexpression result, preserve its
+      // ownership. Returning only its view would leave a dangling view when
+      // FunctionExpression destroys the subexpression results.
+      result =
+          std::move(std::get<std::unique_ptr<cudf::column>>(inputColumns[0]));
+    }
+
     size_t stop = std::min(numColumnsBeforeLiteral_, inputColumns.size());
     for (size_t i = 1; i < stop && asView(result).has_nulls(); ++i) {
-      result = cudf::replace_nulls(
-          asView(result), asView(inputColumns[i]), stream, mr);
+      std::unique_ptr<cudf::column> convertedColumn;
+      auto const column = columnWithType(
+          inputColumns[i], resultType_, convertedColumn, stream, mr);
+      result = cudf::replace_nulls(asView(result), column, stream, mr);
     }
 
     if (literalScalar_ && asView(result).has_nulls()) {
-      result = cudf::replace_nulls(asView(result), *literalScalar_, stream, mr);
+      std::unique_ptr<cudf::scalar> convertedLiteral;
+      auto const* literal = scalarWithType(
+          *literalScalar_, resultType_, convertedLiteral, stream, mr);
+      result = cudf::replace_nulls(asView(result), *literal, stream, mr);
     }
 
     return result;
   }
 
  private:
+  const cudf::data_type resultType_;
   size_t numColumnsBeforeLiteral_;
   std::unique_ptr<cudf::scalar> literalScalar_;
 };

--- a/velox/experimental/cudf/expression/SubfieldFiltersToAst.cpp
+++ b/velox/experimental/cudf/expression/SubfieldFiltersToAst.cpp
@@ -28,6 +28,19 @@
 
 namespace facebook::velox::cudf_velox {
 namespace {
+std::optional<cudf::type_id> subfieldDecimalType(const TypePtr& type) {
+  if (!type->isDecimal()) {
+    return std::nullopt;
+  }
+
+  const auto [precision, _] = getDecimalPrecisionScale(*type);
+  if (precision <= std::numeric_limits<int32_t>::digits10) {
+    return cudf::type_id::DECIMAL32;
+  }
+  return type->kind() == TypeKind::BIGINT ? cudf::type_id::DECIMAL64
+                                          : cudf::type_id::DECIMAL128;
+}
+
 std::pair<int128_t, int128_t> getInt128BoundsForType(const TypePtr& type) {
   if (type->isDecimal()) {
     const auto [precision, _] = getDecimalPrecisionScale(*type);
@@ -146,8 +159,11 @@ std::reference_wrapper<const cudf::ast::expression> buildIntegerRangeExpr(
 
     auto addLiteral = [&](ValueT value) -> const cudf::ast::expression& {
       variant veloxVariant = static_cast<NativeT>(value);
-      const auto& literal =
-          makeScalarAndLiteral<Kind>(columnTypePtr, veloxVariant, scalars);
+      const auto& literal = makeScalarAndLiteral<Kind>(
+          columnTypePtr,
+          veloxVariant,
+          scalars,
+          subfieldDecimalType(columnTypePtr));
       return tree.push(literal);
     };
 
@@ -230,8 +246,11 @@ const cudf::ast::expression& buildValuesListExpr(
   std::vector<const cudf::ast::expression*> exprVec;
   for (const auto& value : values) {
     variant veloxVariant = static_cast<ValueT>(value);
-    auto const& literal = tree.push(
-        makeScalarAndLiteral<Kind>(columnTypePtr, veloxVariant, scalars));
+    auto const& literal = tree.push(makeScalarAndLiteral<Kind>(
+        columnTypePtr,
+        veloxVariant,
+        scalars,
+        subfieldDecimalType(columnTypePtr)));
     auto const& equalExpr = tree.push(
         Operation{isNegated ? Op::NOT_EQUAL : Op::EQUAL, columnRef, literal});
     exprVec.push_back(&equalExpr);
@@ -308,8 +327,11 @@ std::reference_wrapper<const cudf::ast::expression> buildIntegerInListExpr(
       }
 
       variant veloxVariant = static_cast<NativeT>(value);
-      const auto& literal =
-          makeScalarAndLiteral<Kind>(columnTypePtr, veloxVariant, scalars);
+      const auto& literal = makeScalarAndLiteral<Kind>(
+          columnTypePtr,
+          veloxVariant,
+          scalars,
+          subfieldDecimalType(columnTypePtr));
       auto const& cudfLiteral = tree.push(literal);
       auto const& equalExpr =
           tree.push(Operation{Op::EQUAL, columnRef, cudfLiteral});

--- a/velox/experimental/cudf/expression/SubfieldFiltersToAst.cpp
+++ b/velox/experimental/cudf/expression/SubfieldFiltersToAst.cpp
@@ -24,32 +24,86 @@
 #include <cudf/scalar/scalar_device_view.cuh>
 #include <cudf/types.hpp>
 
+#include <algorithm>
 #include <limits>
 
 namespace facebook::velox::cudf_velox {
 namespace {
-std::optional<cudf::type_id> subfieldDecimalType(const TypePtr& type) {
-  if (!type->isDecimal()) {
+std::optional<cudf::type_id> subfieldDecimalType(
+    const TypePtr& type,
+    const std::string& fieldName,
+    const SubfieldFilterDecimalTypes* decimalTypes) {
+  if (!type->isDecimal() || decimalTypes == nullptr) {
     return std::nullopt;
   }
 
-  const auto [precision, _] = getDecimalPrecisionScale(*type);
-  if (precision <= std::numeric_limits<int32_t>::digits10) {
-    return cudf::type_id::DECIMAL32;
+  if (const auto it = decimalTypes->find(fieldName);
+      it != decimalTypes->end()) {
+    VELOX_CHECK(
+        it->second == cudf::type_id::DECIMAL32 ||
+            it->second == cudf::type_id::DECIMAL64 ||
+            it->second == cudf::type_id::DECIMAL128,
+        "Invalid cuDF decimal storage type for field '{}'",
+        fieldName);
+    return it->second;
   }
-  return type->kind() == TypeKind::BIGINT ? cudf::type_id::DECIMAL64
-                                          : cudf::type_id::DECIMAL128;
+  return std::nullopt;
 }
 
-std::pair<int128_t, int128_t> getInt128BoundsForType(const TypePtr& type) {
+std::pair<int128_t, int128_t> getInt128BoundsForType(
+    const TypePtr& type,
+    std::optional<cudf::type_id> decimalType = std::nullopt) {
   if (type->isDecimal()) {
     const auto [precision, _] = getDecimalPrecisionScale(*type);
     const auto maxAbs = DecimalUtil::kPowersOfTen[precision] - 1;
-    return {-maxAbs, maxAbs};
+    int128_t min = -maxAbs;
+    int128_t max = maxAbs;
+    if (decimalType == cudf::type_id::DECIMAL32) {
+      min = std::max<int128_t>(min, std::numeric_limits<int32_t>::min());
+      max = std::min<int128_t>(max, std::numeric_limits<int32_t>::max());
+    } else if (decimalType == cudf::type_id::DECIMAL64) {
+      min = std::max<int128_t>(min, std::numeric_limits<int64_t>::min());
+      max = std::min<int128_t>(max, std::numeric_limits<int64_t>::max());
+    }
+    return {min, max};
   }
   return {
       std::numeric_limits<int128_t>::min(),
       std::numeric_limits<int128_t>::max()};
+}
+
+template <typename T>
+bool decimalValueIsRepresentable(
+    T value,
+    const TypePtr& type,
+    std::optional<cudf::type_id> decimalType) {
+  if (!type->isDecimal()) {
+    return true;
+  }
+  const auto [min, max] = getInt128BoundsForType(type, decimalType);
+  const auto decimalValue = static_cast<int128_t>(value);
+  return decimalValue >= min && decimalValue <= max;
+}
+
+const cudf::ast::expression& buildEqualityExpr(
+    cudf::ast::tree& tree,
+    const cudf::ast::expression& columnRef,
+    const cudf::ast::expression& literal,
+    bool isDecimal) {
+  using Op = cudf::ast::ast_operator;
+  using Operation = cudf::ast::operation;
+
+  if (!isDecimal) {
+    return tree.push(Operation{Op::EQUAL, columnRef, literal});
+  }
+
+  // cuDF's Parquet Bloom-filter path cannot probe fixed-point literals. Keep
+  // the equivalent row and statistics predicate while avoiding that optional
+  // optimization.
+  auto const& lower =
+      tree.push(Operation{Op::GREATER_EQUAL, columnRef, literal});
+  auto const& upper = tree.push(Operation{Op::LESS_EQUAL, columnRef, literal});
+  return tree.push(Operation{Op::NULL_LOGICAL_AND, lower, upper});
 }
 
 template <
@@ -129,7 +183,8 @@ std::reference_wrapper<const cudf::ast::expression> buildIntegerRangeExpr(
     cudf::ast::tree& tree,
     std::vector<std::unique_ptr<cudf::scalar>>& scalars,
     const cudf::ast::expression& columnRef,
-    const TypePtr& columnTypePtr) {
+    const TypePtr& columnTypePtr,
+    std::optional<cudf::type_id> decimalType) {
   using NativeT = typename TypeTraits<Kind>::NativeType;
 
   if constexpr (
@@ -145,7 +200,12 @@ std::reference_wrapper<const cudf::ast::expression> buildIntegerRangeExpr(
     using ValueT = std::decay_t<decltype(lower)>;
 
     const auto [minBound, maxBound] = [&]() -> std::pair<ValueT, ValueT> {
-      if constexpr (std::is_same_v<FilterT, common::HugeintRange>) {
+      if (columnTypePtr->isDecimal()) {
+        const auto [decimalMin, decimalMax] =
+            getInt128BoundsForType(columnTypePtr, decimalType);
+        return {
+            static_cast<ValueT>(decimalMin), static_cast<ValueT>(decimalMax)};
+      } else if constexpr (std::is_same_v<FilterT, common::HugeintRange>) {
         return getInt128BoundsForType(columnTypePtr);
       } else {
         return {
@@ -157,13 +217,14 @@ std::reference_wrapper<const cudf::ast::expression> buildIntegerRangeExpr(
     const bool skipLowerBound = lower <= minBound;
     const bool skipUpperBound = upper >= maxBound;
 
+    if (upper < minBound || lower > maxBound) {
+      return tree.push(Operation{Op::NOT_EQUAL, columnRef, columnRef});
+    }
+
     auto addLiteral = [&](ValueT value) -> const cudf::ast::expression& {
       variant veloxVariant = static_cast<NativeT>(value);
       const auto& literal = makeScalarAndLiteral<Kind>(
-          columnTypePtr,
-          veloxVariant,
-          scalars,
-          subfieldDecimalType(columnTypePtr));
+          columnTypePtr, veloxVariant, scalars, decimalType);
       return tree.push(literal);
     };
 
@@ -174,7 +235,8 @@ std::reference_wrapper<const cudf::ast::expression> buildIntegerRangeExpr(
         return tree.push(Operation{Op::NOT_EQUAL, columnRef, columnRef});
       }
       auto const& literal = addLiteral(lower);
-      return tree.push(Operation{Op::EQUAL, columnRef, literal});
+      return buildEqualityExpr(
+          tree, columnRef, literal, columnTypePtr->isDecimal());
     }
 
     // Range comparison: column >= lower AND column <= upper.
@@ -212,9 +274,10 @@ std::reference_wrapper<const cudf::ast::expression> buildBigintRangeExpr(
     cudf::ast::tree& tree,
     std::vector<std::unique_ptr<cudf::scalar>>& scalars,
     const cudf::ast::expression& columnRef,
-    const TypePtr& columnTypePtr) {
+    const TypePtr& columnTypePtr,
+    std::optional<cudf::type_id> decimalType) {
   return buildIntegerRangeExpr<Kind, common::BigintRange>(
-      filter, tree, scalars, columnRef, columnTypePtr);
+      filter, tree, scalars, columnRef, columnTypePtr, decimalType);
 }
 
 std::reference_wrapper<const cudf::ast::expression> buildHugeintRangeExpr(
@@ -222,9 +285,10 @@ std::reference_wrapper<const cudf::ast::expression> buildHugeintRangeExpr(
     cudf::ast::tree& tree,
     std::vector<std::unique_ptr<cudf::scalar>>& scalars,
     const cudf::ast::expression& columnRef,
-    const TypePtr& columnTypePtr) {
+    const TypePtr& columnTypePtr,
+    std::optional<cudf::type_id> decimalType) {
   return buildIntegerRangeExpr<TypeKind::HUGEINT, common::HugeintRange>(
-      filter, tree, scalars, columnRef, columnTypePtr);
+      filter, tree, scalars, columnRef, columnTypePtr, decimalType);
 }
 
 template <TypeKind Kind, typename FilterT, typename ValueT>
@@ -234,6 +298,7 @@ const cudf::ast::expression& buildValuesListExpr(
     const cudf::ast::expression& columnRef,
     std::vector<std::unique_ptr<cudf::scalar>>& scalars,
     const TypePtr& columnTypePtr,
+    std::optional<cudf::type_id> decimalType,
     bool isNegated = false) {
   using Op = cudf::ast::ast_operator;
   using Operation = cudf::ast::operation;
@@ -245,24 +310,34 @@ const cudf::ast::expression& buildValuesListExpr(
 
   std::vector<const cudf::ast::expression*> exprVec;
   for (const auto& value : values) {
+    if constexpr (!std::is_same_v<ValueT, StringView>) {
+      if (!decimalValueIsRepresentable(value, columnTypePtr, decimalType)) {
+        continue;
+      }
+    }
     variant veloxVariant = static_cast<ValueT>(value);
     auto const& literal = tree.push(makeScalarAndLiteral<Kind>(
-        columnTypePtr,
-        veloxVariant,
-        scalars,
-        subfieldDecimalType(columnTypePtr)));
-    auto const& equalExpr = tree.push(
-        Operation{isNegated ? Op::NOT_EQUAL : Op::EQUAL, columnRef, literal});
-    exprVec.push_back(&equalExpr);
+        columnTypePtr, veloxVariant, scalars, decimalType));
+    if (isNegated) {
+      auto const& notEqualExpr =
+          tree.push(Operation{Op::NOT_EQUAL, columnRef, literal});
+      exprVec.push_back(&notEqualExpr);
+    } else {
+      exprVec.push_back(&buildEqualityExpr(
+          tree, columnRef, literal, columnTypePtr->isDecimal()));
+    }
+  }
+
+  if (exprVec.empty()) {
+    return tree.push(Operation{Op::NOT_EQUAL, columnRef, columnRef});
   }
 
   const cudf::ast::expression* result = exprVec[0];
   for (size_t i = 1; i < exprVec.size(); ++i) {
-    result = &tree.push(
-        Operation{
-            isNegated ? Op::NULL_LOGICAL_AND : Op::NULL_LOGICAL_OR,
-            *result,
-            *exprVec[i]});
+    result = &tree.push(Operation{
+        isNegated ? Op::NULL_LOGICAL_AND : Op::NULL_LOGICAL_OR,
+        *result,
+        *exprVec[i]});
   }
 
   return *result;
@@ -305,7 +380,8 @@ std::reference_wrapper<const cudf::ast::expression> buildIntegerInListExpr(
     const cudf::ast::expression& columnRef,
     rmm::cuda_stream_view /*stream*/,
     rmm::device_async_resource_ref /*mr*/,
-    const TypePtr& columnTypePtr) {
+    const TypePtr& columnTypePtr,
+    std::optional<cudf::type_id> decimalType) {
   using NativeT = typename TypeTraits<Kind>::NativeType;
 
   if constexpr (std::is_integral_v<NativeT>) {
@@ -325,17 +401,16 @@ std::reference_wrapper<const cudf::ast::expression> buildIntegerInListExpr(
         // Skip values that cannot be represented in the column type.
         continue;
       }
+      if (!decimalValueIsRepresentable(value, columnTypePtr, decimalType)) {
+        continue;
+      }
 
       variant veloxVariant = static_cast<NativeT>(value);
       const auto& literal = makeScalarAndLiteral<Kind>(
-          columnTypePtr,
-          veloxVariant,
-          scalars,
-          subfieldDecimalType(columnTypePtr));
+          columnTypePtr, veloxVariant, scalars, decimalType);
       auto const& cudfLiteral = tree.push(literal);
-      auto const& equalExpr =
-          tree.push(Operation{Op::EQUAL, columnRef, cudfLiteral});
-      exprVec.push_back(&equalExpr);
+      exprVec.push_back(&buildEqualityExpr(
+          tree, columnRef, cudfLiteral, columnTypePtr->isDecimal()));
     }
 
     if (exprVec.empty()) {
@@ -363,7 +438,8 @@ cudf::ast::expression const& createAstFromSubfieldFilter(
     const common::Filter& filter,
     cudf::ast::tree& tree,
     std::vector<std::unique_ptr<cudf::scalar>>& scalars,
-    const RowTypePtr& inputRowSchema) {
+    const RowTypePtr& inputRowSchema,
+    const SubfieldFilterDecimalTypes* decimalTypes) {
   // First, create column reference from subfield
   // For now, only support simple field references
   if (subfield.path().empty() ||
@@ -392,6 +468,8 @@ cudf::ast::expression const& createAstFromSubfieldFilter(
   switch (filter.kind()) {
     case common::FilterKind::kBigintRange: {
       auto const& columnType = inputRowSchema->childAt(columnIndex);
+      const auto decimalType =
+          subfieldDecimalType(columnType, fieldName, decimalTypes);
       auto result = VELOX_DYNAMIC_TYPE_DISPATCH(
           buildBigintRangeExpr,
           columnType->kind(),
@@ -399,27 +477,34 @@ cudf::ast::expression const& createAstFromSubfieldFilter(
           tree,
           scalars,
           columnRef,
-          columnType);
+          columnType,
+          decimalType);
       return result.get();
     }
 
     case common::FilterKind::kHugeintRange: {
       auto const& columnType = inputRowSchema->childAt(columnIndex);
-      auto const& expr =
-          buildHugeintRangeExpr(filter, tree, scalars, columnRef, columnType);
+      const auto decimalType =
+          subfieldDecimalType(columnType, fieldName, decimalTypes);
+      auto const& expr = buildHugeintRangeExpr(
+          filter, tree, scalars, columnRef, columnType, decimalType);
       return expr.get();
     }
 
     case common::FilterKind::kBigintValuesUsingHashTable: {
       auto const& columnType = inputRowSchema->childAt(columnIndex);
+      const auto decimalType =
+          subfieldDecimalType(columnType, fieldName, decimalTypes);
       return buildValuesListExpr<
           TypeKind::BIGINT,
           common::BigintValuesUsingHashTable,
-          int64_t>(filter, tree, columnRef, scalars, columnType);
+          int64_t>(filter, tree, columnRef, scalars, columnType, decimalType);
     }
 
     case common::FilterKind::kBigintValuesUsingBitmask: {
       auto const& columnType = inputRowSchema->childAt(columnIndex);
+      const auto decimalType =
+          subfieldDecimalType(columnType, fieldName, decimalTypes);
       // Dispatch by the column's integer kind and cast filter values to it.
       auto result = VELOX_DYNAMIC_TYPE_DISPATCH(
           buildIntegerInListExpr,
@@ -430,16 +515,19 @@ cudf::ast::expression const& createAstFromSubfieldFilter(
           columnRef,
           stream,
           mr,
-          columnType);
+          columnType,
+          decimalType);
       return result.get();
     }
 
     case common::FilterKind::kHugeintValuesUsingHashTable: {
       auto const& columnType = inputRowSchema->childAt(columnIndex);
+      const auto decimalType =
+          subfieldDecimalType(columnType, fieldName, decimalTypes);
       return buildValuesListExpr<
           TypeKind::HUGEINT,
           common::HugeintValuesUsingHashTable,
-          int128_t>(filter, tree, columnRef, scalars, columnType);
+          int128_t>(filter, tree, columnRef, scalars, columnType, decimalType);
     }
 
     case common::FilterKind::kBytesValues: {
@@ -447,7 +535,8 @@ cudf::ast::expression const& createAstFromSubfieldFilter(
       return buildValuesListExpr<
           TypeKind::VARCHAR,
           common::BytesValues,
-          StringView>(filter, tree, columnRef, scalars, columnType);
+          StringView>(
+          filter, tree, columnRef, scalars, columnType, std::nullopt);
     }
 
     case common::FilterKind::kNegatedBytesValues: {
@@ -455,7 +544,8 @@ cudf::ast::expression const& createAstFromSubfieldFilter(
       return buildValuesListExpr<
           TypeKind::VARCHAR,
           common::NegatedBytesValues,
-          StringView>(filter, tree, columnRef, scalars, columnType, true);
+          StringView>(
+          filter, tree, columnRef, scalars, columnType, std::nullopt, true);
     }
 
     case common::FilterKind::kDoubleRange: {
@@ -475,13 +565,11 @@ cudf::ast::expression const& createAstFromSubfieldFilter(
     case common::FilterKind::kBoolValue: {
       auto* boolValue = static_cast<const common::BoolValue*>(&filter);
       auto matchesTrue = boolValue->testBool(true);
-      scalars.emplace_back(
-          std::make_unique<cudf::numeric_scalar<bool>>(
-              matchesTrue, true, stream, mr));
+      scalars.emplace_back(std::make_unique<cudf::numeric_scalar<bool>>(
+          matchesTrue, true, stream, mr));
       stream.synchronize();
-      auto const& matchesBoolExpr = tree.push(
-          cudf::ast::literal{
-              *static_cast<cudf::numeric_scalar<bool>*>(scalars.back().get())});
+      auto const& matchesBoolExpr = tree.push(cudf::ast::literal{
+          *static_cast<cudf::numeric_scalar<bool>*>(scalars.back().get())});
       return tree.push(Operation{Op::EQUAL, columnRef, matchesBoolExpr});
     }
 
@@ -517,7 +605,7 @@ cudf::ast::expression const& createAstFromSubfieldFilter(
       exprRefs.reserve(subFilters.size());
       for (const auto* subFilter : subFilters) {
         auto const& subExpr = createAstFromSubfieldFilter(
-            subfield, *subFilter, tree, scalars, inputRowSchema);
+            subfield, *subFilter, tree, scalars, inputRowSchema, decimalTypes);
         exprRefs.push_back(&subExpr);
       }
 
@@ -535,6 +623,8 @@ cudf::ast::expression const& createAstFromSubfieldFilter(
       const auto rejectedUpper = negRange->upper();
 
       auto const& columnType = inputRowSchema->childAt(columnIndex);
+      const auto decimalType =
+          subfieldDecimalType(columnType, fieldName, decimalTypes);
 
       // Build the inner range: column >= lower AND column <= upper.
       // Then negate it: NOT(column >= lower AND column <= upper).
@@ -548,7 +638,8 @@ cudf::ast::expression const& createAstFromSubfieldFilter(
           tree,
           scalars,
           columnRef,
-          columnType);
+          columnType,
+          decimalType);
       return tree.push(Operation{Op::NOT, innerResult.get()});
     }
 
@@ -565,7 +656,8 @@ cudf::ast::expression const& createAstFromSubfieldFilters(
     const common::SubfieldFilters& subfieldFilters,
     cudf::ast::tree& tree,
     std::vector<std::unique_ptr<cudf::scalar>>& scalars,
-    const RowTypePtr& inputRowSchema) {
+    const RowTypePtr& inputRowSchema,
+    const SubfieldFilterDecimalTypes* decimalTypes) {
   using Op = cudf::ast::ast_operator;
   using Operation = cudf::ast::operation;
 
@@ -577,7 +669,7 @@ cudf::ast::expression const& createAstFromSubfieldFilters(
       continue;
     }
     auto const& expr = createAstFromSubfieldFilter(
-        subfield, *filterPtr, tree, scalars, inputRowSchema);
+        subfield, *filterPtr, tree, scalars, inputRowSchema, decimalTypes);
     exprRefs.push_back(&expr);
   }
 

--- a/velox/experimental/cudf/expression/SubfieldFiltersToAst.h
+++ b/velox/experimental/cudf/expression/SubfieldFiltersToAst.h
@@ -23,6 +23,8 @@
 #include <cudf/scalar/scalar.hpp>
 
 #include <memory>
+#include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace cudf {
@@ -33,13 +35,18 @@ class tree;
 
 namespace facebook::velox::cudf_velox {
 
+// Physical cuDF decimal storage type for each top-level input field.
+using SubfieldFilterDecimalTypes =
+    std::unordered_map<std::string, cudf::type_id>;
+
 // Convert subfield filters to cudf AST
 cudf::ast::expression const& createAstFromSubfieldFilter(
     const common::Subfield& subfield,
     const common::Filter& filter,
     cudf::ast::tree& tree,
     std::vector<std::unique_ptr<cudf::scalar>>& scalars,
-    const RowTypePtr& inputRowSchema);
+    const RowTypePtr& inputRowSchema,
+    const SubfieldFilterDecimalTypes* decimalTypes = nullptr);
 
 // Build a single AST expression representing logical AND of all filters in
 // 'subfieldFilters'. The resulting expression reference is owned by the passed
@@ -48,6 +55,7 @@ cudf::ast::expression const& createAstFromSubfieldFilters(
     const common::SubfieldFilters& subfieldFilters,
     cudf::ast::tree& tree,
     std::vector<std::unique_ptr<cudf::scalar>>& scalars,
-    const RowTypePtr& inputRowSchema);
+    const RowTypePtr& inputRowSchema,
+    const SubfieldFilterDecimalTypes* decimalTypes = nullptr);
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/tests/DecimalAggregationTest.cpp
+++ b/velox/experimental/cudf/tests/DecimalAggregationTest.cpp
@@ -278,7 +278,11 @@ TEST_F(CudfDecimalTest, caseWhenNormalizesDecimal32Input) {
   auto queryCtx = core::QueryCtx::create();
   core::ExecCtx execCtx(pool(), queryCtx.get());
   auto expression = test_utils::compileExecExpr(
-      "CASE WHEN condition THEN sales_price ELSE NULL END", rowType, &execCtx);
+      "CASE WHEN condition THEN sales_price ELSE NULL END",
+      rowType,
+      &execCtx,
+      {},
+      /*enableConstantFolding=*/true);
   auto evaluator = createCudfExpression(expression, rowType);
 
   auto stream = cudf::get_default_stream();

--- a/velox/experimental/cudf/tests/DecimalAggregationTest.cpp
+++ b/velox/experimental/cudf/tests/DecimalAggregationTest.cpp
@@ -15,9 +15,12 @@
  */
 
 #include "velox/experimental/cudf/CudfConfig.h"
+#include "velox/experimental/cudf/exec/DecimalAggregationHostOps.h"
 #include "velox/experimental/cudf/exec/DecimalAggregationState.h"
 #include "velox/experimental/cudf/exec/ToCudf.h"
 #include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
+#include "velox/experimental/cudf/expression/ExpressionEvaluator.h"
+#include "velox/experimental/cudf/tests/utils/ExpressionTestUtil.h"
 
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/FileSystems.h"
@@ -31,6 +34,7 @@
 
 #include <cudf/column/column_factories.hpp>
 #include <cudf/null_mask.hpp>
+#include <cudf/reduction.hpp>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
@@ -151,8 +155,15 @@ std::unique_ptr<cudf::column> makeDecimalColumn(
     int32_t scale,
     const std::vector<bool>* valid,
     rmm::cuda_stream_view stream) {
-  cudf::type_id typeId = std::is_same_v<T, int64_t> ? cudf::type_id::DECIMAL64
-                                                    : cudf::type_id::DECIMAL128;
+  cudf::type_id typeId;
+  if constexpr (std::is_same_v<T, int32_t>) {
+    typeId = cudf::type_id::DECIMAL32;
+  } else if constexpr (std::is_same_v<T, int64_t>) {
+    typeId = cudf::type_id::DECIMAL64;
+  } else {
+    static_assert(std::is_same_v<T, __int128_t>);
+    typeId = cudf::type_id::DECIMAL128;
+  }
   cudf::data_type type{typeId, -scale};
   return makeFixedWidthColumn(type, values, valid, stream);
 }
@@ -241,6 +252,205 @@ class CudfDecimalTest : public exec::test::OperatorTestBase {
     exec::test::OperatorTestBase::TearDown();
   }
 };
+
+TEST_F(CudfDecimalTest, decimal32InputWidenedBeforeSum) {
+  auto stream = cudf::get_default_stream();
+  auto mr = cudf::get_current_device_resource_ref();
+  auto input = makeDecimalColumn<int32_t>(
+      {900'000'000, 900'000'000, 900'000'000}, 2, nullptr, stream);
+
+  std::unique_ptr<cudf::column> castedInput;
+  auto widened =
+      castDecimalInputToDecimal128(input->view(), castedInput, stream);
+  EXPECT_EQ(widened.type().id(), cudf::type_id::DECIMAL128);
+  EXPECT_EQ(widened.type().scale(), input->type().scale());
+
+  auto sumAggregation = cudf::make_sum_aggregation<cudf::reduce_aggregation>();
+  auto sum = cudf::reduce(widened, *sumAggregation, widened.type(), stream, mr);
+  auto sumColumn = cudf::make_column_from_scalar(*sum, 1, stream, mr);
+  auto result = copyColumnData<__int128_t>(sumColumn->view(), stream);
+  ASSERT_EQ(result.size(), 1);
+  EXPECT_EQ(result[0], static_cast<__int128_t>(2'700'000'000));
+}
+
+TEST_F(CudfDecimalTest, caseWhenNormalizesDecimal32Input) {
+  auto rowType = ROW({"condition", "sales_price"}, {BOOLEAN(), DECIMAL(7, 2)});
+  auto queryCtx = core::QueryCtx::create();
+  core::ExecCtx execCtx(pool(), queryCtx.get());
+  auto expression = test_utils::compileExecExpr(
+      "CASE WHEN condition THEN sales_price ELSE NULL END", rowType, &execCtx);
+  auto evaluator = createCudfExpression(expression, rowType);
+
+  auto stream = cudf::get_default_stream();
+  auto mr = cudf::get_current_device_resource_ref();
+  auto condition = makeFixedWidthColumn<int8_t>(
+      cudf::data_type{cudf::type_id::BOOL8}, {1, 0, 1, 0}, nullptr, stream);
+  auto salesPrice =
+      makeDecimalColumn<int32_t>({123, 456, -789, 1'000}, 2, nullptr, stream);
+  std::vector<cudf::column_view> inputs{condition->view(), salesPrice->view()};
+
+  auto result = evaluator->eval(inputs, stream, mr);
+  auto resultView = asView(result);
+  auto expectedType =
+      cudf::data_type{cudf::type_id::DECIMAL64, numeric::scale_type{-2}};
+  EXPECT_EQ(resultView.type(), expectedType);
+  EXPECT_EQ(resultView.null_count(), 2);
+
+  auto values = copyColumnData<int64_t>(resultView, stream);
+  auto nullMask = copyNullMask(resultView, stream);
+  EXPECT_TRUE(isValidAt(nullMask, 0));
+  EXPECT_EQ(values[0], 123);
+  EXPECT_FALSE(isValidAt(nullMask, 1));
+  EXPECT_TRUE(isValidAt(nullMask, 2));
+  EXPECT_EQ(values[2], -789);
+  EXPECT_FALSE(isValidAt(nullMask, 3));
+}
+
+TEST_F(CudfDecimalTest, multiplyNormalizesDecimal32Input) {
+  auto rowType = ROW({"quantity", "sales_price"}, {INTEGER(), DECIMAL(7, 2)});
+  auto queryCtx = core::QueryCtx::create();
+  core::ExecCtx execCtx(pool(), queryCtx.get());
+  auto expression = test_utils::compileExecExpr(
+      "CAST(quantity AS DECIMAL(10, 0)) * sales_price", rowType, &execCtx);
+  auto evaluator = createCudfExpression(expression, rowType);
+
+  auto stream = cudf::get_default_stream();
+  auto mr = cudf::get_current_device_resource_ref();
+  auto quantity = makeFixedWidthColumn<int32_t>(
+      cudf::data_type{cudf::type_id::INT32},
+      {2, -3, 1'000, 0},
+      nullptr,
+      stream);
+  auto salesPrice =
+      makeDecimalColumn<int32_t>({123, 456, -789, 100}, 2, nullptr, stream);
+  std::vector<cudf::column_view> inputs{quantity->view(), salesPrice->view()};
+
+  auto result = evaluator->eval(inputs, stream, mr);
+  auto resultView = asView(result);
+  auto expectedType =
+      cudf::data_type{cudf::type_id::DECIMAL64, numeric::scale_type{-2}};
+  EXPECT_EQ(resultView.type(), expectedType);
+  EXPECT_EQ(
+      copyColumnData<int64_t>(resultView, stream),
+      (std::vector<int64_t>{246, -1'368, -789'000, 0}));
+}
+
+TEST_F(CudfDecimalTest, divideUsesWidestDecimalStorage) {
+  auto rowType =
+      ROW({"numerator", "short_divisor", "long_divisor"},
+          {DECIMAL(7, 2), DECIMAL(7, 2), DECIMAL(20, 2)});
+  auto queryCtx = core::QueryCtx::create();
+  core::ExecCtx execCtx(pool(), queryCtx.get());
+
+  auto stream = cudf::get_default_stream();
+  auto mr = cudf::get_current_device_resource_ref();
+  auto numerator =
+      makeDecimalColumn<int32_t>({1'000, -1'000}, 2, nullptr, stream);
+  auto shortDivisor =
+      makeDecimalColumn<int32_t>({200, 400}, 2, nullptr, stream);
+  auto longDivisor = makeDecimalColumn<__int128_t>(
+      {200, static_cast<__int128_t>(1) << 64}, 2, nullptr, stream);
+  std::vector<cudf::column_view> inputs{
+      numerator->view(), shortDivisor->view(), longDivisor->view()};
+
+  auto assertExpression = [&](const std::string& sql,
+                              const std::vector<int64_t>& expected) {
+    auto expression = test_utils::compileExecExpr(sql, rowType, &execCtx);
+    auto evaluator = createCudfExpression(expression, rowType);
+    auto result = evaluator->eval(inputs, stream, mr);
+    auto resultView = asView(result);
+    auto expectedType =
+        cudf::data_type{cudf::type_id::DECIMAL64, numeric::scale_type{-2}};
+    EXPECT_EQ(resultView.type(), expectedType);
+    EXPECT_EQ(resultView.null_count(), 0);
+    EXPECT_EQ(copyColumnData<int64_t>(resultView, stream), expected);
+  };
+
+  // DECIMAL32 / DECIMAL128 -> DECIMAL64. The large divisor does not fit in
+  // DECIMAL64 and becomes zero if narrowed, so division must retain DECIMAL128
+  // working storage.
+  assertExpression("numerator / long_divisor", {500, 0});
+
+  // Column / scalar uses the same wide intermediate before narrowing the
+  // logical short-decimal result.
+  assertExpression(
+      "numerator / "
+      "CAST('184467440737095516.16' AS DECIMAL(20, 2))",
+      {0, 0});
+
+  // Scalar / column still widens a physical DECIMAL32 input to the logical
+  // DECIMAL64 working width.
+  assertExpression(
+      "CAST('10.00' AS DECIMAL(7, 2)) / short_divisor", {500, 250});
+}
+
+TEST_F(CudfDecimalTest, coalesceNormalizesDecimal32Input) {
+  auto rowType =
+      ROW({"sales_price", "return_amount"}, {DECIMAL(7, 2), DECIMAL(7, 2)});
+  auto queryCtx = core::QueryCtx::create();
+  core::ExecCtx execCtx(pool(), queryCtx.get());
+  auto expression = test_utils::compileExecExpr(
+      "sales_price - "
+      "coalesce(return_amount, CAST('0.00' AS DECIMAL(7, 2)))",
+      rowType,
+      &execCtx);
+  auto evaluator = createCudfExpression(expression, rowType);
+
+  auto stream = cudf::get_default_stream();
+  auto mr = cudf::get_current_device_resource_ref();
+  auto salesPrice = makeDecimalColumn<int32_t>(
+      {1'000, 2'000, -3'000, 4'000}, 2, nullptr, stream);
+  std::vector<bool> returnAmountValid{true, false, true, false};
+  auto returnAmount = makeDecimalColumn<int32_t>(
+      {100, 999, -250, 999}, 2, &returnAmountValid, stream);
+  std::vector<cudf::column_view> inputs{
+      salesPrice->view(), returnAmount->view()};
+
+  auto result = evaluator->eval(inputs, stream, mr);
+  auto resultView = asView(result);
+  auto expectedType =
+      cudf::data_type{cudf::type_id::DECIMAL64, numeric::scale_type{-2}};
+  EXPECT_EQ(resultView.type(), expectedType);
+  EXPECT_EQ(resultView.null_count(), 0);
+  EXPECT_EQ(
+      copyColumnData<int64_t>(resultView, stream),
+      (std::vector<int64_t>{900, 2'000, -2'750, 4'000}));
+}
+
+TEST_F(CudfDecimalTest, coalescePreservesOwnedFirstInput) {
+  auto rowType = ROW({"return_amount"}, {DECIMAL(7, 2)});
+  auto queryCtx = core::QueryCtx::create();
+  core::ExecCtx execCtx(pool(), queryCtx.get());
+  auto expression = test_utils::compileExecExpr(
+      "coalesce("
+      "CAST(return_amount AS DECIMAL(12, 2)), "
+      "CAST('0.00' AS DECIMAL(12, 2)))",
+      rowType,
+      &execCtx);
+  auto evaluator = createCudfExpression(expression, rowType);
+
+  auto stream = cudf::get_default_stream();
+  auto mr = cudf::get_current_device_resource_ref();
+  auto returnAmount =
+      makeDecimalColumn<int32_t>({100, 200, 300}, 2, nullptr, stream);
+  std::vector<cudf::column_view> inputs{returnAmount->view()};
+
+  auto result = evaluator->eval(inputs, stream, mr);
+  ASSERT_TRUE(
+      std::holds_alternative<std::unique_ptr<cudf::column>>(result));
+
+  // Mirror CudfFilterProject's materialization of an expression result after
+  // FunctionExpression has destroyed the owning subexpression results.
+  auto materialized =
+      std::make_unique<cudf::column>(asView(result), stream, mr);
+  EXPECT_EQ(
+      materialized->type(),
+      (cudf::data_type{
+          cudf::type_id::DECIMAL64, numeric::scale_type{-2}}));
+  EXPECT_EQ(
+      copyColumnData<int64_t>(materialized->view(), stream),
+      (std::vector<int64_t>{100, 200, 300}));
+}
 
 TEST_F(CudfDecimalTest, decimalAvgDecimalInput) {
   auto rowType = ROW({

--- a/velox/experimental/cudf/tests/DecimalAggregationTest.cpp
+++ b/velox/experimental/cudf/tests/DecimalAggregationTest.cpp
@@ -310,6 +310,34 @@ TEST_F(CudfDecimalTest, caseWhenNormalizesDecimal32Input) {
   EXPECT_FALSE(isValidAt(nullMask, 3));
 }
 
+TEST_F(CudfDecimalTest, betweenNormalizesDecimal32Input) {
+  auto rowType = ROW({"price"}, {DECIMAL(7, 2)});
+  auto queryCtx = core::QueryCtx::create();
+  core::ExecCtx execCtx(pool(), queryCtx.get());
+  auto expression = test_utils::compileExecExpr(
+      "price BETWEEN "
+      "CAST('0.99' AS DECIMAL(7, 2)) AND "
+      "CAST('1.49' AS DECIMAL(7, 2))",
+      rowType,
+      &execCtx,
+      {},
+      /*enableConstantFolding=*/true);
+  auto evaluator = createCudfExpression(expression, rowType);
+
+  auto stream = cudf::get_default_stream();
+  auto mr = cudf::get_current_device_resource_ref();
+  auto price =
+      makeDecimalColumn<int32_t>({98, 99, 100, 149, 150}, 2, nullptr, stream);
+  std::vector<cudf::column_view> inputs{price->view()};
+
+  auto result = evaluator->eval(inputs, stream, mr);
+  auto resultView = asView(result);
+  EXPECT_EQ(resultView.type().id(), cudf::type_id::BOOL8);
+  EXPECT_EQ(
+      copyColumnData<int8_t>(resultView, stream),
+      (std::vector<int8_t>{0, 1, 1, 1, 0}));
+}
+
 TEST_F(CudfDecimalTest, multiplyNormalizesDecimal32Input) {
   auto rowType = ROW({"quantity", "sales_price"}, {INTEGER(), DECIMAL(7, 2)});
   auto queryCtx = core::QueryCtx::create();
@@ -359,7 +387,8 @@ TEST_F(CudfDecimalTest, divideUsesWidestDecimalStorage) {
 
   auto assertExpression = [&](const std::string& sql,
                               const std::vector<int64_t>& expected) {
-    auto expression = test_utils::compileExecExpr(sql, rowType, &execCtx);
+    auto expression = test_utils::compileExecExpr(
+        sql, rowType, &execCtx, {}, /*enableConstantFolding=*/true);
     auto evaluator = createCudfExpression(expression, rowType);
     auto result = evaluator->eval(inputs, stream, mr);
     auto resultView = asView(result);
@@ -397,7 +426,9 @@ TEST_F(CudfDecimalTest, coalesceNormalizesDecimal32Input) {
       "sales_price - "
       "coalesce(return_amount, CAST('0.00' AS DECIMAL(7, 2)))",
       rowType,
-      &execCtx);
+      &execCtx,
+      {},
+      /*enableConstantFolding=*/true);
   auto evaluator = createCudfExpression(expression, rowType);
 
   auto stream = cudf::get_default_stream();
@@ -430,7 +461,9 @@ TEST_F(CudfDecimalTest, coalescePreservesOwnedFirstInput) {
       "CAST(return_amount AS DECIMAL(12, 2)), "
       "CAST('0.00' AS DECIMAL(12, 2)))",
       rowType,
-      &execCtx);
+      &execCtx,
+      {},
+      /*enableConstantFolding=*/true);
   auto evaluator = createCudfExpression(expression, rowType);
 
   auto stream = cudf::get_default_stream();

--- a/velox/experimental/cudf/tests/ExpressionEvaluatorSelectionTest.cpp
+++ b/velox/experimental/cudf/tests/ExpressionEvaluatorSelectionTest.cpp
@@ -516,8 +516,13 @@ TEST_F(CudfExpressionSelectionTest, signatureTypeVariableCoalesce) {
 
 TEST_F(CudfExpressionSelectionTest, signatureTypeVariableSwitchIf) {
   // OK: boolean + same type BIGINT
-  auto ok1 = compileExecExpr("if(true, a, b)", rowType_, execCtx_.get());
+  auto ok1 = compileExecExpr("if(a > 0, a, b)", rowType_, execCtx_.get());
   ASSERT_TRUE(canBeEvaluatedByCudf(ok1, /*deep=*/true));
+
+  // Constant conditions must be folded before cuDF expression selection.
+  auto constantCondition =
+      compileExecExpr("if(true, a, b)", rowType_, execCtx_.get());
+  ASSERT_FALSE(canBeEvaluatedByCudf(constantCondition, /*deep=*/true));
 }
 
 TEST_F(CudfExpressionSelectionTest, DISABLED_castAndTryCast) {

--- a/velox/experimental/cudf/tests/SubfieldFilterAstTest.cpp
+++ b/velox/experimental/cudf/tests/SubfieldFilterAstTest.cpp
@@ -31,6 +31,8 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>
+
 using namespace facebook::velox;
 using namespace facebook::velox::cudf_velox;
 using namespace facebook::velox::exec::test;
@@ -567,7 +569,7 @@ TEST_F(SubfieldFilterAstTest, DecimalRange) {
   testFilterExecution(rowType, columnName, *filter, vec, expr);
 }
 
-TEST_F(SubfieldFilterAstTest, Decimal32Range) {
+TEST_F(SubfieldFilterAstTest, ShortDecimalUsesLogicalWidthByDefault) {
   const std::string columnName = "c0";
   auto rowType = ROW({{columnName, DECIMAL(7, 2)}});
   auto filter = std::make_unique<common::BigintRange>(
@@ -578,6 +580,111 @@ TEST_F(SubfieldFilterAstTest, Decimal32Range) {
   std::vector<std::unique_ptr<cudf::scalar>> scalars;
   const auto& expr =
       createAstFromSubfieldFilter(subfield, *filter, tree, scalars, rowType);
+
+  ASSERT_EQ(scalars.size(), 2);
+  EXPECT_EQ(scalars[0]->type().id(), cudf::type_id::DECIMAL64);
+  EXPECT_EQ(scalars[1]->type().id(), cudf::type_id::DECIMAL64);
+
+  auto vec = makeTestVector(rowType, 100);
+  testFilterExecution(rowType, columnName, *filter, vec, expr);
+}
+
+TEST_F(SubfieldFilterAstTest, DecimalPhysicalWidthRejectsOutOfRangeFilters) {
+  const std::string columnName = "c0";
+  const auto assertAlwaysFalse =
+      [&](const RowTypePtr& rowType,
+          const common::Filter& filter,
+          cudf::type_id physicalType) {
+        common::Subfield subfield(columnName);
+        cudf::ast::tree tree;
+        std::vector<std::unique_ptr<cudf::scalar>> scalars;
+        const SubfieldFilterDecimalTypes decimalTypes{
+            {columnName, physicalType}};
+        const auto& expr = createAstFromSubfieldFilter(
+            subfield, filter, tree, scalars, rowType, &decimalTypes);
+
+        EXPECT_TRUE(scalars.empty());
+        const auto* operation =
+            dynamic_cast<const cudf::ast::operation*>(&expr);
+        ASSERT_NE(operation, nullptr);
+        EXPECT_EQ(
+            operation->get_operator(), cudf::ast::ast_operator::NOT_EQUAL);
+      };
+
+  auto shortDecimal = ROW({{columnName, DECIMAL(12, 2)}});
+  assertAlwaysFalse(
+      shortDecimal,
+      common::BigintRange(
+          int64_t{3'000'000'000},
+          int64_t{3'000'000'000},
+          /*nullAllowed*/ false),
+      cudf::type_id::DECIMAL32);
+  assertAlwaysFalse(
+      shortDecimal,
+      common::BigintRange(
+          int64_t{3'000'000'000},
+          int64_t{4'000'000'000},
+          /*nullAllowed*/ false),
+      cudf::type_id::DECIMAL32);
+
+  const auto aboveInt64 =
+      static_cast<int128_t>(std::numeric_limits<int64_t>::max()) + 1;
+  assertAlwaysFalse(
+      ROW({{columnName, DECIMAL(20, 0)}}),
+      common::HugeintRange(
+          aboveInt64, aboveInt64 + 1, /*nullAllowed*/ false),
+      cudf::type_id::DECIMAL64);
+}
+
+TEST_F(SubfieldFilterAstTest, DecimalInListSkipsOutOfPhysicalRangeValues) {
+  const std::string columnName = "c0";
+  const auto assertSinglePhysicalScalar =
+      [&](const RowTypePtr& rowType,
+          const common::Filter& filter,
+          cudf::type_id physicalType) {
+        common::Subfield subfield(columnName);
+        cudf::ast::tree tree;
+        std::vector<std::unique_ptr<cudf::scalar>> scalars;
+        const SubfieldFilterDecimalTypes decimalTypes{
+            {columnName, physicalType}};
+        createAstFromSubfieldFilter(
+            subfield, filter, tree, scalars, rowType, &decimalTypes);
+
+        ASSERT_EQ(scalars.size(), 1);
+        EXPECT_EQ(scalars.front()->type().id(), physicalType);
+      };
+
+  auto shortValues = common::createBigintValues(
+      {int64_t{-500}, int64_t{3'000'000'000}},
+      /*nullAllowed*/ false);
+  assertSinglePhysicalScalar(
+      ROW({{columnName, DECIMAL(12, 2)}}),
+      *shortValues,
+      cudf::type_id::DECIMAL32);
+
+  const auto aboveInt64 =
+      static_cast<int128_t>(std::numeric_limits<int64_t>::max()) + 1;
+  auto longValues =
+      common::createHugeintValues({int128_t{123}, aboveInt64}, false);
+  assertSinglePhysicalScalar(
+      ROW({{columnName, DECIMAL(20, 0)}}),
+      *longValues,
+      cudf::type_id::DECIMAL64);
+}
+
+TEST_F(SubfieldFilterAstTest, Decimal32Range) {
+  const std::string columnName = "c0";
+  auto rowType = ROW({{columnName, DECIMAL(7, 2)}});
+  auto filter = std::make_unique<common::BigintRange>(
+      int64_t{99}, int64_t{149}, /*nullAllowed*/ false);
+
+  common::Subfield subfield(columnName);
+  cudf::ast::tree tree;
+  std::vector<std::unique_ptr<cudf::scalar>> scalars;
+  const SubfieldFilterDecimalTypes decimalTypes{
+      {columnName, cudf::type_id::DECIMAL32}};
+  const auto& expr = createAstFromSubfieldFilter(
+      subfield, *filter, tree, scalars, rowType, &decimalTypes);
 
   ASSERT_EQ(scalars.size(), 2);
   EXPECT_EQ(scalars[0]->type().id(), cudf::type_id::DECIMAL32);
@@ -624,8 +731,10 @@ TEST_F(SubfieldFilterAstTest, Decimal32SingleValue) {
   common::Subfield subfield(columnName);
   cudf::ast::tree tree;
   std::vector<std::unique_ptr<cudf::scalar>> scalars;
-  const auto& expr =
-      createAstFromSubfieldFilter(subfield, *filter, tree, scalars, rowType);
+  const SubfieldFilterDecimalTypes decimalTypes{
+      {columnName, cudf::type_id::DECIMAL32}};
+  const auto& expr = createAstFromSubfieldFilter(
+      subfield, *filter, tree, scalars, rowType, &decimalTypes);
 
   ASSERT_EQ(scalars.size(), 1);
   EXPECT_EQ(scalars[0]->type().id(), cudf::type_id::DECIMAL32);

--- a/velox/experimental/cudf/tests/SubfieldFilterAstTest.cpp
+++ b/velox/experimental/cudf/tests/SubfieldFilterAstTest.cpp
@@ -23,9 +23,11 @@
 #include "velox/type/Filter.h"
 #include "velox/type/Subfield.h"
 
+#include <cudf/column/column_factories.hpp>
 #include <cudf/column/column_view.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/transform.hpp>
+#include <cudf/utilities/error.hpp>
 
 #include <gtest/gtest.h>
 
@@ -563,6 +565,100 @@ TEST_F(SubfieldFilterAstTest, DecimalRange) {
   EXPECT_GT(tree.size(), 0UL);
   auto vec = makeTestVector(rowType, 100);
   testFilterExecution(rowType, columnName, *filter, vec, expr);
+}
+
+TEST_F(SubfieldFilterAstTest, Decimal32Range) {
+  const std::string columnName = "c0";
+  auto rowType = ROW({{columnName, DECIMAL(7, 2)}});
+  auto filter = std::make_unique<common::BigintRange>(
+      int64_t{99}, int64_t{149}, /*nullAllowed*/ false);
+
+  common::Subfield subfield(columnName);
+  cudf::ast::tree tree;
+  std::vector<std::unique_ptr<cudf::scalar>> scalars;
+  const auto& expr =
+      createAstFromSubfieldFilter(subfield, *filter, tree, scalars, rowType);
+
+  ASSERT_EQ(scalars.size(), 2);
+  EXPECT_EQ(scalars[0]->type().id(), cudf::type_id::DECIMAL32);
+  EXPECT_EQ(scalars[1]->type().id(), cudf::type_id::DECIMAL32);
+  EXPECT_EQ(scalars[0]->type().scale(), numeric::scale_type{-2});
+  EXPECT_EQ(scalars[1]->type().scale(), numeric::scale_type{-2});
+
+  auto stream = cudf::get_default_stream();
+  auto mr = cudf::get_current_device_resource_ref();
+  std::vector<int32_t> values{98, 99, 100, 149, 150};
+  auto input = cudf::make_fixed_width_column(
+      cudf::data_type{cudf::type_id::DECIMAL32, numeric::scale_type{-2}},
+      values.size(),
+      cudf::mask_state::UNALLOCATED,
+      stream,
+      mr);
+  CUDF_CUDA_TRY(cudaMemcpyAsync(
+      input->mutable_view().data<int32_t>(),
+      values.data(),
+      values.size() * sizeof(int32_t),
+      cudaMemcpyHostToDevice,
+      stream.value()));
+
+  auto result =
+      cudf::compute_column(cudf::table_view{{input->view()}}, expr, stream, mr);
+  ASSERT_EQ(result->type().id(), cudf::type_id::BOOL8);
+  std::vector<uint8_t> actual(values.size());
+  CUDF_CUDA_TRY(cudaMemcpyAsync(
+      actual.data(),
+      result->view().data<bool>(),
+      actual.size(),
+      cudaMemcpyDeviceToHost,
+      stream.value()));
+  stream.synchronize();
+  EXPECT_EQ(actual, (std::vector<uint8_t>{0, 1, 1, 1, 0}));
+}
+
+TEST_F(SubfieldFilterAstTest, Decimal32SingleValue) {
+  const std::string columnName = "c0";
+  auto rowType = ROW({{columnName, DECIMAL(5, 2)}});
+  auto filter = std::make_unique<common::BigintRange>(
+      int64_t{-500}, int64_t{-500}, /*nullAllowed*/ false);
+
+  common::Subfield subfield(columnName);
+  cudf::ast::tree tree;
+  std::vector<std::unique_ptr<cudf::scalar>> scalars;
+  const auto& expr =
+      createAstFromSubfieldFilter(subfield, *filter, tree, scalars, rowType);
+
+  ASSERT_EQ(scalars.size(), 1);
+  EXPECT_EQ(scalars[0]->type().id(), cudf::type_id::DECIMAL32);
+  EXPECT_EQ(scalars[0]->type().scale(), numeric::scale_type{-2});
+
+  auto stream = cudf::get_default_stream();
+  auto mr = cudf::get_current_device_resource_ref();
+  std::vector<int32_t> values{-501, -500, -499};
+  auto input = cudf::make_fixed_width_column(
+      cudf::data_type{cudf::type_id::DECIMAL32, numeric::scale_type{-2}},
+      values.size(),
+      cudf::mask_state::UNALLOCATED,
+      stream,
+      mr);
+  CUDF_CUDA_TRY(cudaMemcpyAsync(
+      input->mutable_view().data<int32_t>(),
+      values.data(),
+      values.size() * sizeof(int32_t),
+      cudaMemcpyHostToDevice,
+      stream.value()));
+
+  auto result =
+      cudf::compute_column(cudf::table_view{{input->view()}}, expr, stream, mr);
+  ASSERT_EQ(result->type().id(), cudf::type_id::BOOL8);
+  std::vector<uint8_t> actual(values.size());
+  CUDF_CUDA_TRY(cudaMemcpyAsync(
+      actual.data(),
+      result->view().data<bool>(),
+      actual.size(),
+      cudaMemcpyDeviceToHost,
+      stream.value()));
+  stream.synchronize();
+  EXPECT_EQ(actual, (std::vector<uint8_t>{0, 1, 0}));
 }
 
 TEST_F(SubfieldFilterAstTest, DecimalInList) {

--- a/velox/experimental/cudf/tests/TableScanTest.cpp
+++ b/velox/experimental/cudf/tests/TableScanTest.cpp
@@ -46,7 +46,12 @@
 #include "velox/type/Type.h"
 #include "velox/type/tests/SubfieldFiltersBuilder.h"
 
+#include <cudf/column/column_factories.hpp>
 #include <cudf/io/parquet.hpp>
+#include <cudf/table/table.hpp>
+#include <cudf/utilities/error.hpp>
+
+#include <cuda_runtime.h>
 
 #include <fmt/ranges.h>
 
@@ -68,6 +73,54 @@ struct StatsFilterMetrics {
   std::optional<cudf::size_type> rowGroupsAfterStats;
   cudf::size_type outputRows{0};
 };
+
+void writeDecimal32Parquet(
+    const std::string& filePath,
+    const std::vector<int32_t>& decimalValues,
+    const std::vector<int64_t>& ids) {
+  VELOX_CHECK_EQ(decimalValues.size(), ids.size());
+
+  auto stream = cudf::get_default_stream();
+  auto mr = cudf::get_current_device_resource_ref();
+  auto decimals = cudf::make_fixed_width_column(
+      cudf::data_type{cudf::type_id::DECIMAL32, numeric::scale_type{-2}},
+      decimalValues.size(),
+      cudf::mask_state::UNALLOCATED,
+      stream,
+      mr);
+  auto idColumn = cudf::make_fixed_width_column(
+      cudf::data_type{cudf::type_id::INT64},
+      ids.size(),
+      cudf::mask_state::UNALLOCATED,
+      stream,
+      mr);
+  CUDF_CUDA_TRY(cudaMemcpyAsync(
+      decimals->mutable_view().data<int32_t>(),
+      decimalValues.data(),
+      decimalValues.size() * sizeof(int32_t),
+      cudaMemcpyHostToDevice,
+      stream.value()));
+  CUDF_CUDA_TRY(cudaMemcpyAsync(
+      idColumn->mutable_view().data<int64_t>(),
+      ids.data(),
+      ids.size() * sizeof(int64_t),
+      cudaMemcpyHostToDevice,
+      stream.value()));
+  stream.synchronize();
+
+  std::vector<std::unique_ptr<cudf::column>> columns;
+  columns.push_back(std::move(decimals));
+  columns.push_back(std::move(idColumn));
+  auto table = cudf::table{std::move(columns)};
+  auto metadata = cudf::io::table_input_metadata(table.view());
+  metadata.column_metadata[0].set_name("c0").set_decimal_precision(5);
+  metadata.column_metadata[1].set_name("c1");
+  auto options = cudf::io::parquet_writer_options::builder(
+                     cudf::io::sink_info(filePath), table.view())
+                     .metadata(metadata)
+                     .build();
+  cudf::io::write_parquet(options, stream);
+}
 
 StatsFilterMetrics readParquetWithStatsFilter(
     const std::string& filePath,
@@ -927,4 +980,63 @@ TEST_F(TableScanTest, multiLevelNestedDecimalScan) {
                {makeNullableFlatVector<int32_t>({10, std::nullopt, 30}),
                 makeArrayVector({0, 2, 4}, listElements)})})});
   assertDecimalScanRoundTrip(vector, rowType);
+}
+
+TEST_F(TableScanTest, decimalFilterUsesSplitPhysicalType) {
+  auto rowType = ROW({"c0", "c1"}, {DECIMAL(5, 2), BIGINT()});
+  auto decimal32Vector = makeRowVector(
+      {"c0", "c1"},
+      {makeFlatVector<int64_t>({100, -500, -700}, DECIMAL(5, 2)),
+       makeFlatVector<int64_t>({1, 2, 3})});
+  auto decimal64Vector = makeRowVector(
+      {"c0", "c1"},
+      {makeFlatVector<int64_t>({200, -500, -800}, DECIMAL(5, 2)),
+       makeFlatVector<int64_t>({4, 5, 6})});
+
+  auto decimal32Path = TempFilePath::create();
+  auto decimal64Path = TempFilePath::create();
+  writeDecimal32Parquet(decimal32Path->getPath(), {100, -500, -700}, {1, 2, 3});
+  writeToFile(decimal64Path->getPath(), {decimal64Vector});
+  createDuckDbTable({decimal32Vector, decimal64Vector});
+
+  auto filters = common::test::SubfieldFiltersBuilder()
+                     .add(
+                         "c0",
+                         std::make_unique<common::BigintRange>(
+                             int64_t{-500},
+                             int64_t{-500},
+                             /*nullAllowed*/ false))
+                     .build();
+  auto tableHandle =
+      makeTableHandle("parquet_table", rowType, std::move(filters), nullptr);
+  auto plan =
+      PlanBuilder()
+          .startTableScan()
+          .outputType(rowType)
+          .tableHandle(tableHandle)
+          .assignments(facebook::velox::exec::test::HiveConnectorTestBase::
+                           allRegularColumns(rowType))
+          .endTableScan()
+          .planNode();
+
+  const auto expected =
+      "SELECT c0, c1 FROM tmp "
+      "WHERE c0 = CAST('-5.00' AS DECIMAL(5, 2))";
+  for (const bool useExperimentalReader : {false, true}) {
+    auto config = std::unordered_map<std::string, std::string>{
+        {facebook::velox::cudf_velox::connector::hive::CudfHiveConfig::
+             kUseExperimentalCudfReader,
+         useExperimentalReader ? "true" : "false"}};
+    resetCudfHiveConnector(
+        std::make_shared<config::ConfigBase>(std::move(config)));
+
+    for (const auto& paths :
+         {std::vector{decimal32Path, decimal64Path},
+          std::vector{decimal64Path, decimal32Path}}) {
+      AssertQueryBuilder(plan, duckDbQueryRunner_)
+          .maxDrivers(1)
+          .splits(makeCudfHiveConnectorSplits(paths))
+          .assertResults(expected);
+    }
+  }
 }

--- a/velox/experimental/cudf/tests/utils/ExpressionTestUtil.h
+++ b/velox/experimental/cudf/tests/utils/ExpressionTestUtil.h
@@ -40,9 +40,10 @@ inline std::shared_ptr<exec::Expr> compileExecExpr(
     const std::string& sql,
     const RowTypePtr& rowType,
     core::ExecCtx* execCtx,
-    const parse::ParseOptions& options = {}) {
+    const parse::ParseOptions& options = {},
+    bool enableConstantFolding = false) {
   auto typed = parseAndInferTypedExpr(sql, rowType, execCtx, options);
-  exec::ExprSet exprSet({typed}, execCtx, /*enableConstantFolding*/ false);
+  exec::ExprSet exprSet({typed}, execCtx, enableConstantFolding);
   return exprSet.expr(0);
 }
 

--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -1397,7 +1397,7 @@ void exportToArrowImpl(
 
 // Parses the velox decimal format from the given arrow format.
 // The input format string should be in the form "d:precision,scale<,bitWidth>".
-// bitWidth is optional and may be 64 or 128 if provided.
+// bitWidth is optional and may be 32, 64, or 128 if provided.
 
 int32_t parseDecimalBitWidthOrDefault(const std::string_view format) {
   auto firstCommaIdx = format.find(',', 2);
@@ -1432,16 +1432,16 @@ TypePtr parseDecimalFormat(const std::string_view format) {
     int precision = std::stoi(&format[2], &sz);
     int scale = std::stoi(&format[firstCommaIdx + 1], &sz);
     if (secondCommaIdx != std::string_view::npos) {
-      // BitWidth is provided. We only support 64 or 128.
+      // BitWidth is provided. We only support 32, 64, or 128.
       int bitWidth = std::stoi(&format[secondCommaIdx + 1], &sz);
       // Return type depends on bitWidth.
-      if (bitWidth == 64) {
+      if (bitWidth == 32 || bitWidth == 64) {
         return std::make_shared<ShortDecimalType>(precision, scale);
       } else if (bitWidth == 128) {
         return std::make_shared<LongDecimalType>(precision, scale);
       }
       VELOX_USER_FAIL(
-          "Conversion failed for '{}'. Only 64-bit and 128-bit decimal types are supported.",
+          "Conversion failed for '{}'. Only 32-bit, 64-bit, and 128-bit decimal types are supported.",
           format);
     }
     // Otherwise return type depends on precision.
@@ -2242,6 +2242,32 @@ VectorPtr createShortDecimalVector(
       nullCount);
 }
 
+VectorPtr createShortDecimalVectorFromInt32Decimals(
+    memory::MemoryPool* pool,
+    const TypePtr& type,
+    BufferPtr nulls,
+    const int32_t* input,
+    vector_size_t length,
+    int64_t nullCount) {
+  auto values = AlignedBuffer::allocate<int64_t>(length, pool);
+  auto* rawValues = values->asMutable<int64_t>();
+  if (nulls == nullptr) {
+    for (vector_size_t i = 0; i < length; ++i) {
+      rawValues[i] = static_cast<int64_t>(input[i]);
+    }
+  } else if (length > nullCount) {
+    const auto* rawNulls = nulls->as<const uint64_t>();
+    for (vector_size_t i = 0; i < length; ++i) {
+      if (!bits::isBitNull(rawNulls, i)) {
+        rawValues[i] = static_cast<int64_t>(input[i]);
+      }
+    }
+  }
+
+  return createFlatVector<TypeKind::BIGINT>(
+      pool, type, std::move(nulls), length, values, nullCount);
+}
+
 VectorPtr createShortDecimalVectorFromLongDecimals(
     memory::MemoryPool* pool,
     const TypePtr& type,
@@ -2409,6 +2435,15 @@ VectorPtr importFromArrowImpl(
   } else if (type->isShortDecimal()) {
     // Validate the format bitWidth.
     const auto bitWidth = parseDecimalBitWidthOrDefault(arrowSchema.format);
+    if (bitWidth == 32) {
+      return createShortDecimalVectorFromInt32Decimals(
+          pool,
+          type,
+          nulls,
+          static_cast<const int32_t*>(arrowArray.buffers[1]),
+          arrowArray.length,
+          arrowArray.null_count);
+    }
     if (bitWidth == 64) {
       return createShortDecimalVector(
           pool,

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -1292,6 +1292,9 @@ class ArrowBridgeArrayImportTest : public ArrowBridgeArrayExportTest {
       if (format[0] == 't' && format[1] == 't') {
         assertTimeVectorContent(
             inputValues, output, arrowArray.null_count, format);
+      } else if (format[0] == 'd') {
+        assertShortDecimalVectorContent(
+            inputValues, output, arrowArray.null_count);
       } else {
         assertVectorContent(inputValues, output, arrowArray.null_count);
       }
@@ -1404,6 +1407,9 @@ class ArrowBridgeArrayImportTest : public ArrowBridgeArrayExportTest {
 
     testArrowImport<int64_t, int128_t>(
         "d:5,2", {1, -1, 0, 12345, -12345, std::nullopt});
+    testArrowImport<int64_t, int32_t>(
+        "d:9,2,32",
+        {1, -1, 0, 12345, -12345, 999999999, -999999999, std::nullopt});
     testArrowImport<int128_t, int128_t>(
         "d:36,2",
         {HugeInt::parse("20000000000000000"),
@@ -1631,10 +1637,11 @@ class ArrowBridgeArrayImportTest : public ArrowBridgeArrayExportTest {
   }
 
  private:
-  // Creates short decimals from int128 and asserts the content of actual vector
-  // with the expected values.
+  // Widens Arrow decimal values and asserts the content of the resulting Velox
+  // short-decimal vector.
+  template <typename T>
   void assertShortDecimalVectorContent(
-      const std::vector<std::optional<int128_t>>& expectedValues,
+      const std::vector<std::optional<T>>& expectedValues,
       const VectorPtr& actual,
       size_t nullCount) {
     std::vector<std::optional<int64_t>> decValues;

--- a/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
@@ -508,11 +508,12 @@ TEST_F(ArrowBridgeSchemaImportTest, scalar) {
   VELOX_ASSERT_THROW(
       *testSchemaImport("d2,15"),
       "Unable to convert 'd2,15' ArrowSchema decimal format to Velox decimal");
+  EXPECT_EQ(*DECIMAL(9, 2), *testSchemaImport("d:9,2,32"));
   EXPECT_EQ(*DECIMAL(10, 4), *testSchemaImport("d:10,4,64"));
   EXPECT_EQ(*DECIMAL(20, 15), *testSchemaImport("d:20,15,128"));
   VELOX_ASSERT_THROW(
       *testSchemaImport("d:10,4,256"),
-      "Conversion failed for 'd:10,4,256'. Only 64-bit and 128-bit decimal types are supported.");
+      "Conversion failed for 'd:10,4,256'. Only 32-bit, 64-bit, and 128-bit decimal types are supported.");
   VELOX_ASSERT_THROW(
       *testSchemaImport("d:10,4,"),
       "Unable to convert 'd:10,4,' ArrowSchema decimal format to Velox decimal");


### PR DESCRIPTION
## Description

This PR is a formal rebuild of an earlier experimental branch of mine.

It contains the four commits from @kjmph's `research/trusted-constraints-on-ucx-output-transport` branch from his fork that resolve the issues with TPC-DS short decimals (precision < 19) which are natively handled in Parquet as DECIMAL32.

This branch passes all Velox unit tests, and has no hard failures with Velox Testing TPC-DS Integrity Tests, at least at SF1 and on a single GPU. Some queries do fail, but with value epsilon comparisons out of range, which are likely just as much a factor of the comparison as of the query (Velox CPU behavior vs DuckDB behavior).

I have not tested larger data sizes or multiple GPUs.

## Checklist
- [ ] Resolve merge conflicts
- [ ] All Velox-cudf tests pass