### PR TITLE
fix: Use DecodedVector for IPAddress and IPPrefix casts

### DIFF
--- a/velox/functions/prestosql/tests/IPAddressCastTest.cpp
+++ b/velox/functions/prestosql/tests/IPAddressCastTest.cpp
@@ -145,6 +145,110 @@ TEST_F(IPAddressCastTest, castRoundTrip) {
   velox::test::assertEqualVectors(strings, stringsCopy);
   velox::test::assertEqualVectors(ipaddresses, ipaddressesCopy);
 }
+
+TEST_F(IPAddressCastTest, ipv6CastEncodingBug) {
+  // Regression for IPv6 CAST encoding bug where CAST from VARCHAR to
+  // IPADDRESS corrupted addresses like 2607:f0d0:1000::1 to ::1 for constant
+  // and dictionary encodings.
+  // Use canonical forms so round-trip expectation is exact.
+  auto ipv6Strings = makeFlatVector<std::string>({
+      "2607:f0d0:1000::1",
+      "2001:db8::1",
+      "2001:db8:85a3:1:1:8a2e:370:7334",
+      "::1",
+      "64:ff9b::17",
+  });
+  auto rowVector = makeRowVector({ipv6Strings});
+  // Flat evaluation gives canonical expected (same as input here)
+  auto expectedVarchar =
+      evaluate("cast(cast(c0 as ipaddress) as varchar)", rowVector);
+  // Prebuild encoded physical vectors for direct cast tests.
+  auto ipAddressVector = evaluate("cast(c0 as ipaddress)", rowVector);
+  auto varbinaryVector =
+      evaluate("cast(cast(c0 as ipaddress) as varbinary)", rowVector);
+
+  // Test cast VARCHAR -> IPADDRESS -> VARCHAR with encoded VARCHAR input.
+  // Covers castFromString.
+  {
+    auto typedExpr = makeTypedExpr(
+        "cast(cast(c0 as ipaddress) as varchar)", asRowType(rowVector->type()));
+    testEncodings(typedExpr, {ipv6Strings}, expectedVarchar);
+  }
+
+  // Test constant encoding explicitly for VARCHAR -> IPADDRESS -> VARCHAR.
+  {
+    auto constantInput = BaseVector::wrapInConstant(3, 0, ipv6Strings);
+    auto constantRow = makeRowVector({constantInput});
+    auto result =
+        evaluate("cast(cast(c0 as ipaddress) as varchar)", constantRow);
+    auto expectedConst = BaseVector::wrapInConstant(3, 0, expectedVarchar);
+    velox::test::assertEqualVectors(expectedConst, result);
+  }
+
+  // Test IPADDRESS -> VARCHAR with prebuilt encoded IPADDRESS input.
+  // Directly exercises castToString which previously used SimpleVector.
+  {
+    auto ipRow = makeRowVector({ipAddressVector});
+    auto flatResult = evaluate("cast(c0 as varchar)", ipRow);
+    auto typedExpr =
+        makeTypedExpr("cast(c0 as varchar)", asRowType(ipRow->type()));
+    testEncodings(typedExpr, {ipAddressVector}, flatResult);
+  }
+
+  // Test IPADDRESS -> VARBINARY with prebuilt encoded IPADDRESS input.
+  // Directly exercises castToVarbinary.
+  {
+    auto ipRow = makeRowVector({ipAddressVector});
+    auto flatResult = evaluate("cast(c0 as varbinary)", ipRow);
+    auto typedExpr =
+        makeTypedExpr("cast(c0 as varbinary)", asRowType(ipRow->type()));
+    testEncodings(typedExpr, {ipAddressVector}, flatResult);
+  }
+
+  // Test VARBINARY -> IPADDRESS with prebuilt encoded VARBINARY input.
+  // Directly exercises castFromVarbinary.
+  {
+    auto varbinaryRow = makeRowVector({varbinaryVector});
+    auto flatResult = evaluate("cast(c0 as ipaddress)", varbinaryRow);
+    auto typedExpr =
+        makeTypedExpr("cast(c0 as ipaddress)", asRowType(varbinaryRow->type()));
+    testEncodings(typedExpr, {varbinaryVector}, flatResult);
+  }
+
+  // Test VARBINARY -> IPADDRESS -> VARCHAR round-trip still works with
+  // encoded VARBINARY input.
+  {
+    auto varbinaryRow = makeRowVector({varbinaryVector});
+    auto flatResult =
+        evaluate("cast(cast(c0 as ipaddress) as varchar)", varbinaryRow);
+    auto typedExpr = makeTypedExpr(
+        "cast(cast(c0 as ipaddress) as varchar)",
+        asRowType(varbinaryRow->type()));
+    testEncodings(typedExpr, {varbinaryVector}, flatResult);
+  }
+
+  // Test IPPREFIX -> IPADDRESS with prebuilt encoded IPPREFIX input.
+  // Directly exercises castFromIPPrefix.
+  {
+    auto prefixStrings = makeFlatVector<std::string>({
+        "2607:f0d0:1000::/38",
+        "2001:db8::/32",
+        "2001:db8::/48",
+        "::/0",
+        "2001:db8::1/128",
+    });
+    auto prefixRowVarchar = makeRowVector({prefixStrings});
+    auto ipPrefixVector = evaluate("cast(c0 as ipprefix)", prefixRowVarchar);
+    auto ipPrefixRow = makeRowVector({ipPrefixVector});
+    auto flatResult =
+        evaluate("cast(cast(c0 as ipaddress) as varchar)", ipPrefixRow);
+    auto typedExpr = makeTypedExpr(
+        "cast(cast(c0 as ipaddress) as varchar)",
+        asRowType(ipPrefixRow->type()));
+    testEncodings(typedExpr, {ipPrefixVector}, flatResult);
+  }
+}
+
 } // namespace
 
 } // namespace facebook::velox::functions::prestosql

--- a/velox/functions/prestosql/tests/IPAddressFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/IPAddressFunctionsTest.cpp
@@ -298,6 +298,78 @@ TEST_F(IPAddressFunctionsTest, IPSubnetOfIPPrefix) {
   EXPECT_EQ(isSubnetOfIPPrefix("170.0.52.0/24", "170.0.52.0/22"), false);
 }
 
+TEST_F(IPAddressFunctionsTest, ipv6IsSubnetOfBug) {
+  // Regression for IPv6 CAST encoding bug where is_subnet_of returned false
+  // for column inputs. The CAST from VARCHAR used SimpleVector which broke
+  // constant and dictionary encodings, corrupting 2607:f0d0:1000::1 to ::1.
+  EXPECT_EQ(isSubnetOfIP("2607:f0d0:1000::/38", "2607:f0d0:1000::1"), true);
+  EXPECT_EQ(isSubnetOfIP("2001:db8::/32", "2001:db8::1"), true);
+  EXPECT_EQ(isSubnetOfIP("2001:db8::/48", "2001:db8::1"), true);
+  EXPECT_EQ(isSubnetOfIP("2804:431:b000::/38", "2804:431:b000::1"), true);
+  EXPECT_EQ(isSubnetOfIP("::/0", "2001:db8::1"), true);
+  EXPECT_EQ(isSubnetOfIP("2001:db8::/128", "2001:db8::1"), false);
+  EXPECT_EQ(isSubnetOfIP("2001:db8::/32", "2001:db9::1"), false);
+
+  // Test that constant and dictionary encodings are handled correctly.
+  auto prefixStrings = makeFlatVector<std::string>({
+      "2607:f0d0:1000::/38",
+      "2001:db8::/32",
+      "2001:db8::/48",
+      "2804:431:b000::/37",
+      "::/0",
+  });
+  auto ipStrings = makeFlatVector<std::string>({
+      "2607:f0d0:1000::1",
+      "2001:db8::1",
+      "2001:db8::1",
+      "2804:431:b000::1",
+      "2001:db8::1",
+  });
+  auto expected = makeFlatVector<bool>({true, true, true, true, true});
+
+  auto rowVector = makeRowVector({prefixStrings, ipStrings});
+  auto typedExpr = makeTypedExpr(
+      "is_subnet_of(cast(c0 as ipprefix), cast(c1 as ipaddress))",
+      asRowType(rowVector->type()));
+  testEncodings(typedExpr, {prefixStrings, ipStrings}, expected);
+
+  // Also test mixed constant: one arg constant, one flat (the VALUES repro
+  // where c is column but second arg is constant literal). This exercises the
+  // exact bug where CAST with constant encoding corrupted IPv6.
+  auto constantIp = BaseVector::wrapInConstant(5, 0, ipStrings);
+  auto mixedRow = makeRowVector({prefixStrings, constantIp});
+  auto typedExpr2 = makeTypedExpr(
+      "is_subnet_of(cast(c0 as ipprefix), cast(c1 as ipaddress))",
+      asRowType(mixedRow->type()));
+  // Compute expected for constant IP 2607:f0d0:1000::1 against varied prefixes.
+  auto uniformIp = makeFlatVector<std::string>({
+      "2607:f0d0:1000::1",
+      "2607:f0d0:1000::1",
+      "2607:f0d0:1000::1",
+      "2607:f0d0:1000::1",
+      "2607:f0d0:1000::1",
+  });
+  auto uniformRow = makeRowVector({prefixStrings, uniformIp});
+  auto expectedMixed = evaluate(
+      "is_subnet_of(cast(c0 as ipprefix), cast(c1 as ipaddress))", uniformRow);
+  testEncodings(typedExpr2, {prefixStrings, constantIp}, expectedMixed);
+
+  // Test uniform prefix with constant IP to ensure all true.
+  auto singlePrefix = makeFlatVector<std::string>({
+      "2607:f0d0:1000::/38",
+      "2607:f0d0:1000::/38",
+      "2607:f0d0:1000::/38",
+      "2607:f0d0:1000::/38",
+      "2607:f0d0:1000::/38",
+  });
+  auto mixedRow2 = makeRowVector({singlePrefix, constantIp});
+  auto expected2 = makeFlatVector<bool>({true, true, true, true, true});
+  auto typedExpr3 = makeTypedExpr(
+      "is_subnet_of(cast(c0 as ipprefix), cast(c1 as ipaddress))",
+      asRowType(mixedRow2->type()));
+  testEncodings(typedExpr3, {singlePrefix, constantIp}, expected2);
+}
+
 TEST_F(IPAddressFunctionsTest, IPPrefixCollapseTest) {
   auto makeIPPrefixFunc =
       [](const std::string& ipprefix) -> std::tuple<int128_t, int8_t> {

--- a/velox/functions/prestosql/tests/IPPrefixCastTest.cpp
+++ b/velox/functions/prestosql/tests/IPPrefixCastTest.cpp
@@ -183,4 +183,45 @@ TEST_F(IPPrefixTypeTest, castToVarchar) {
   EXPECT_THROW(castToVarchar("192.1.1.1"), VeloxUserError);
   EXPECT_THROW(castToVarchar("192.1.1.1/128"), VeloxUserError);
 }
+
+TEST_F(IPPrefixTypeTest, ipv6CastEncodingBug) {
+  // Regression for IPv6 CAST encoding bug where castToString used SimpleVector
+  // for child vectors, breaking constant and dictionary encodings.
+  auto ipv6Prefixes = makeFlatVector<std::string>({
+      "2607:f0d0:1000::/38",
+      "2001:db8::/32",
+      "2001:db8::/48",
+      "2804:431:b000::/38",
+      "::/0",
+      "2001:db8::ff00:42:8329/128",
+  });
+  auto rowVector = makeRowVector({ipv6Prefixes});
+  auto expected = evaluate("cast(c0 as ipprefix)", rowVector);
+  auto expectedAsVarchar =
+      evaluate("cast(cast(c0 as ipprefix) as varchar)", rowVector);
+
+  // Test that CAST VARCHAR -> IPPREFIX -> VARCHAR round-trips correctly
+  // even with dictionary and constant encodings.
+  auto typedExpr = makeTypedExpr(
+      "cast(cast(c0 as ipprefix) as varchar)", asRowType(rowVector->type()));
+  testEncodings(typedExpr, {ipv6Prefixes}, expectedAsVarchar);
+
+  // Test IPPREFIX -> VARCHAR directly with encodings.
+  // Need to create a row vector wrapping the IPPREFIX vector
+  auto ipPrefixRow = makeRowVector({expected});
+  auto typedExpr2 =
+      makeTypedExpr("cast(c0 as varchar)", asRowType(ipPrefixRow->type()));
+  auto flatVarcharResult = evaluate("cast(c0 as varchar)", ipPrefixRow);
+  testEncodings(typedExpr2, {expected}, flatVarcharResult);
+
+  // Test constant encoding explicitly: 2607:f0d0:1000::/38 should not become
+  // ::/38
+  auto constantInput = BaseVector::wrapInConstant(3, 0, ipv6Prefixes);
+  auto constantRow = makeRowVector({constantInput});
+  auto constResult =
+      evaluate("cast(cast(c0 as ipprefix) as varchar)", constantRow);
+  auto expectedConst = BaseVector::wrapInConstant(3, 0, expectedAsVarchar);
+  velox::test::assertEqualVectors(expectedConst, constResult);
+}
+
 } // namespace facebook::velox::functions::prestosql

--- a/velox/functions/prestosql/types/IPAddressRegistration.cpp
+++ b/velox/functions/prestosql/types/IPAddressRegistration.cpp
@@ -77,11 +77,12 @@ class IPAddressCastOperator : public exec::CastOperator {
       const SelectivityVector& rows,
       BaseVector& result) {
     auto* flatResult = result.as<FlatVector<StringView>>();
-    const auto* ipaddresses = input.as<SimpleVector<int128_t>>();
+    DecodedVector decoded(input, rows);
 
     context.applyToSelectedNoThrow(rows, [&](auto row) {
+      const auto ipAddrVal = decoded.valueAt<int128_t>(row);
       exec::StringWriter result(flatResult, row);
-      result.append(IPADDRESS()->valueToString(ipaddresses->valueAt(row)));
+      result.append(IPADDRESS()->valueToString(ipAddrVal));
       result.finalize();
     });
   }
@@ -92,10 +93,10 @@ class IPAddressCastOperator : public exec::CastOperator {
       const SelectivityVector& rows,
       BaseVector& result) {
     auto* flatResult = result.as<FlatVector<int128_t>>();
-    const auto* ipAddressStrings = input.as<SimpleVector<StringView>>();
+    DecodedVector decoded(input, rows);
 
     context.applyToSelectedNoThrow(rows, [&](auto row) {
-      const auto ipAddressString = ipAddressStrings->valueAt(row);
+      const auto ipAddressString = decoded.valueAt<StringView>(row);
       // TODO: Remove explicit std::string_view cast.
       auto maybeIpAsInt128 = ipaddress::tryGetIPv6asInt128FromString(
           std::string_view(ipAddressString));
@@ -120,10 +121,10 @@ class IPAddressCastOperator : public exec::CastOperator {
       const SelectivityVector& rows,
       BaseVector& result) {
     auto* flatResult = result.as<FlatVector<StringView>>();
-    const auto* ipaddresses = input.as<SimpleVector<int128_t>>();
+    DecodedVector decoded(input, rows);
 
     context.applyToSelectedNoThrow(rows, [&](auto row) {
-      const auto intAddr = ipaddresses->valueAt(row);
+      const auto intAddr = decoded.valueAt<int128_t>(row);
       folly::ByteArray16 addrBytes;
       memcpy(&addrBytes, &intAddr, ipaddress::kIPAddressBytes);
       std::reverse(addrBytes.begin(), addrBytes.end());
@@ -167,12 +168,14 @@ class IPAddressCastOperator : public exec::CastOperator {
       const SelectivityVector& rows,
       BaseVector& result) {
     auto* flatResult = result.as<FlatVector<int128_t>>();
-    const auto* ipprefix = input.as<RowVector>();
-    const auto* ipaddr = ipprefix->childAt(ipaddress::kIpRowIndex)
-                             ->asChecked<SimpleVector<int128_t>>();
+    DecodedVector decoded(input, rows);
+    auto* rowVector = decoded.base()->as<RowVector>();
+    DecodedVector childDecoded(*rowVector->childAt(ipaddress::kIpRowIndex));
 
-    context.applyToSelectedNoThrow(
-        rows, [&](auto row) { flatResult->set(row, ipaddr->valueAt(row)); });
+    context.applyToSelectedNoThrow(rows, [&](auto row) {
+      const auto index = decoded.index(row);
+      flatResult->set(row, childDecoded.valueAt<int128_t>(index));
+    });
   }
 
   static void castFromVarbinary(
@@ -181,12 +184,12 @@ class IPAddressCastOperator : public exec::CastOperator {
       const SelectivityVector& rows,
       BaseVector& result) {
     auto* flatResult = result.as<FlatVector<int128_t>>();
-    const auto* ipAddressBinaries = input.as<SimpleVector<StringView>>();
+    DecodedVector decoded(input, rows);
 
     context.applyToSelectedNoThrow(rows, [&](auto row) {
       int128_t intAddr;
       folly::ByteArray16 addrBytes = {};
-      const auto ipAddressBinary = ipAddressBinaries->valueAt(row);
+      const auto ipAddressBinary = decoded.valueAt<StringView>(row);
 
       if (ipAddressBinary.size() == ipaddress::kIPV4AddressBytes) {
         addrBytes[ipaddress::kIPV4ToV6FFIndex] = 0xFF;

--- a/velox/functions/prestosql/types/IPPrefixRegistration.cpp
+++ b/velox/functions/prestosql/types/IPPrefixRegistration.cpp
@@ -74,18 +74,21 @@ class IPPrefixCastOperator : public exec::CastOperator {
       const SelectivityVector& rows,
       BaseVector& result) {
     auto* flatResult = result.as<FlatVector<StringView>>();
-    auto rowVector = input.as<RowVector>();
-    const auto* ipaddr = rowVector->childAt(ipaddress::kIpRowIndex)
-                             ->as<SimpleVector<int128_t>>();
-    const auto* prefix = rowVector->childAt(ipaddress::kIpPrefixRowIndex)
-                             ->as<SimpleVector<int8_t>>();
+    DecodedVector decoded(input, rows);
+    auto* rowVector = decoded.base()->as<RowVector>();
+    DecodedVector ipAddrDecoded(*rowVector->childAt(ipaddress::kIpRowIndex));
+    DecodedVector prefixDecoded(
+        *rowVector->childAt(ipaddress::kIpPrefixRowIndex));
+
     context.applyToSelectedNoThrow(rows, [&](auto row) {
-      exec::StringWriter result(flatResult, row);
-      result.resize(IPPrefixType::kMaxStringSize);
-      auto str = IPPREFIX()->valueToString(
-          ipaddr->valueAt(row), prefix->valueAt(row), result.data());
-      result.resize(str.size());
-      result.finalize();
+      const auto index = decoded.index(row);
+      const auto ipAddr = ipAddrDecoded.valueAt<int128_t>(index);
+      const auto prefix = prefixDecoded.valueAt<int8_t>(index);
+      exec::StringWriter writer(flatResult, row);
+      writer.resize(IPPrefixType::kMaxStringSize);
+      auto str = IPPREFIX()->valueToString(ipAddr, prefix, writer.data());
+      writer.resize(str.size());
+      writer.finalize();
     });
   }
 


### PR DESCRIPTION
Summary:
The query SELECT is_subnet_of(CAST(c AS ipprefix), CAST('2607:f0d0:1000::1' AS ipaddress)) FROM (VALUES '2607:f0d0:1000::/38') AS t(c) returned false in Velox but true in Presto Java. The IPv6 prefix 2607:f0d0:1000::/38 should contain 2607:f0d0:1000::1, but constant and dictionary encoded inputs were corrupted to ::/38 and ::1 during CAST from VARCHAR.

Cast operators in IPAddressRegistration read strings using SimpleVector, which assumes flat encoding and fails for constant and dictionary encodings. IPPrefixRegistration::castToString had the same issue for the child vectors of the ROW type. Switching all of them to DecodedVector makes the lookup respect the encoding and matches the already-fixed IPPrefix path.

Differential Revision: D114312988


