### PR TITLE
feat(cudf): Attribute GPU memory to operator instances in Nsight Systems

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -342,6 +342,7 @@ void Driver::initializeOperators() {
   }
   operatorsInitialized_ = true;
   for (auto& op : operators_) {
+    RuntimeStatWriterScopeGuard statsWriterGuard(op.get());
     op->initialize();
   }
 }
@@ -929,6 +930,7 @@ void Driver::initializeOperatorStats(std::vector<OperatorStats>& stats) {
 void Driver::closeOperators() {
   // Close operators.
   for (auto& op : operators_) {
+    RuntimeStatWriterScopeGuard statsWriterGuard(op.get());
     op->close();
   }
 

--- a/velox/experimental/cudf/CudfConfig.h
+++ b/velox/experimental/cudf/CudfConfig.h
@@ -28,6 +28,8 @@ struct CudfConfig {
   /// Keys used by the initialize() method.
   static constexpr const char* kCudfEnabled{"cudf.enabled"};
   static constexpr const char* kCudfDebugEnabled{"cudf.debug_enabled"};
+  static constexpr const char* kCudfMemoryTrackingEnabled{
+      "cudf.memory_tracking_enabled"};
   static constexpr const char* kCudfMemoryResource{"cudf.memory_resource"};
   static constexpr const char* kCudfMemoryPercent{"cudf.memory_percent"};
   static constexpr const char* kCudfFunctionNamePrefix{
@@ -66,6 +68,13 @@ struct CudfConfig {
 
   /// Enable debug printing.
   bool debugEnabled{false};
+
+  /// Attributes GPU allocations to operator instances and publishes them as
+  /// NVTX counters.
+  ///
+  /// This installs a tracking wrapper around the RMM resource, so it is off by
+  /// default; the NVTX emission it feeds is itself free when unprofiled.
+  bool memoryTrackingEnabled{false};
 
   /// Allow fallback to CPU operators if GPU operator replacement fails.
   bool allowCpuFallback{true};

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSink.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSink.cpp
@@ -129,7 +129,8 @@ CudfHiveDataSink::CudfHiveDataSink(
     const ConnectorQueryCtx* connectorQueryCtx,
     CommitStrategy commitStrategy,
     const std::shared_ptr<const CudfHiveConfig>& parquetConfig)
-    : inputType_(std::move(inputType)),
+    : NvtxHelper(nvtx3::rgb{64, 224, 208} /* Turquoise */),
+      inputType_(std::move(inputType)),
       insertTableHandle_(std::move(insertTableHandle)),
       connectorQueryCtx_(connectorQueryCtx),
       commitStrategy_(commitStrategy),
@@ -154,6 +155,7 @@ CudfHiveDataSink::CudfHiveDataSink(
 }
 
 void CudfHiveDataSink::appendData(RowVectorPtr input) {
+  VELOX_NVTX_OPERATOR_FUNC_RANGE();
   checkRunning();
 
   // Convert the input RowVectorPtr to cudf::table
@@ -384,6 +386,7 @@ void CudfHiveDataSink::checkStateTransition(State oldState, State newState) {
 }
 
 bool CudfHiveDataSink::finish() {
+  VELOX_NVTX_OPERATOR_FUNC_RANGE();
   VELOX_CHECK_NOT_NULL(writer_, "CudfHiveDataSink has no writer");
 
   setState(State::kFinishing);
@@ -391,6 +394,7 @@ bool CudfHiveDataSink::finish() {
 }
 
 std::vector<std::string> CudfHiveDataSink::close() {
+  VELOX_NVTX_OPERATOR_FUNC_RANGE();
   setState(State::kClosed);
   closeInternal();
 

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSink.h
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSink.h
@@ -18,6 +18,7 @@
 #include "velox/experimental/cudf/connectors/hive/CudfHiveConfig.h"
 #include "velox/experimental/cudf/connectors/hive/CudfHiveTableHandle.h"
 #include "velox/experimental/cudf/connectors/hive/WriterOptions.h"
+#include "velox/experimental/cudf/exec/NvtxHelper.h"
 
 #include "velox/common/compression/Compression.h"
 #include "velox/connectors/Connector.h"
@@ -265,7 +266,7 @@ class CudfHiveInsertTableHandle : public ConnectorInsertTableHandle {
   const std::shared_ptr<dwio::common::WriterOptions> writerOptions_;
 };
 
-class CudfHiveDataSink : public DataSink {
+class CudfHiveDataSink : public DataSink, public NvtxHelper {
  public:
   /// The list of runtime stats reported by parquet data sink
   static constexpr const char* kEarlyFlushedRawBytes = "earlyFlushedRawBytes";

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
@@ -195,6 +195,7 @@ void CudfHiveDataSource::convertSplit(std::shared_ptr<ConnectorSplit> split) {
 }
 
 void CudfHiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
+  VELOX_NVTX_OPERATOR_FUNC_RANGE();
   // Virtual method for class-specific conversion of the split
   convertSplit(split);
 
@@ -223,6 +224,7 @@ void CudfHiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
 std::optional<RowVectorPtr> CudfHiveDataSource::next(
     uint64_t size,
     velox::ContinueFuture& /* future */) {
+  VELOX_NVTX_OPERATOR_FUNC_RANGE();
   VELOX_CHECK_NOT_NULL(split_, "No split present. Call addSplit() first.");
   VELOX_CHECK_NOT_NULL(cudfSplitReader_, "No split to process.");
   auto chunkOpt = cudfSplitReader_->next(size);

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
@@ -216,6 +216,7 @@ void CudfHiveDataSource::convertSplit(std::shared_ptr<ConnectorSplit> split) {
 }
 
 void CudfHiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
+  VELOX_NVTX_OPERATOR_FUNC_RANGE();
   // Virtual method for class-specific conversion of the split
   convertSplit(split);
 
@@ -244,6 +245,7 @@ void CudfHiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
 std::optional<RowVectorPtr> CudfHiveDataSource::next(
     uint64_t size,
     velox::ContinueFuture& /* future */) {
+  VELOX_NVTX_OPERATOR_FUNC_RANGE();
   VELOX_CHECK_NOT_NULL(split_, "No split present. Call addSplit() first.");
   VELOX_CHECK_NOT_NULL(cudfSplitReader_, "No split to process.");
   auto chunkOpt = cudfSplitReader_->next(size);

--- a/velox/experimental/cudf/exec/CMakeLists.txt
+++ b/velox/experimental/cudf/exec/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(
   DecimalAggregationDevice.cu
   DecimalAggregationHostOps.cpp
   DecimalAggregationState.cpp
+  GpuMemoryPlanPath.cpp
   GpuResources.cpp
   OperatorAdapters.cpp
   PrestoAggregateFunctions.cpp

--- a/velox/experimental/cudf/exec/CMakeLists.txt
+++ b/velox/experimental/cudf/exec/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(
   DecimalAggregationDevice.cu
   DecimalAggregationHostOps.cpp
   DecimalAggregationState.cpp
+  GpuMemoryNvtx.cpp
   GpuMemoryPlanPath.cpp
   GpuResources.cpp
   OperatorAdapters.cpp

--- a/velox/experimental/cudf/exec/CMakeLists.txt
+++ b/velox/experimental/cudf/exec/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(
   DecimalAggregationDevice.cu
   DecimalAggregationHostOps.cpp
   DecimalAggregationState.cpp
+  GpuMemoryNvtx.cpp
   GpuMemoryPlanPath.cpp
   GpuResources.cpp
   OperatorAdapters.cpp

--- a/velox/experimental/cudf/exec/CMakeLists.txt
+++ b/velox/experimental/cudf/exec/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(
   DecimalAggregationDevice.cu
   DecimalAggregationHostOps.cpp
   DecimalAggregationState.cpp
+  GpuMemoryPlanPath.cpp
   GpuResources.cpp
   OperatorAdapters.cpp
   PrestoAggregateFunctions.cpp

--- a/velox/experimental/cudf/exec/CMakeLists.txt
+++ b/velox/experimental/cudf/exec/CMakeLists.txt
@@ -37,8 +37,10 @@ add_library(
   DecimalAggregationDevice.cu
   DecimalAggregationHostOps.cpp
   DecimalAggregationState.cpp
+  GpuMemoryLedger.cpp
   GpuMemoryNvtx.cpp
   GpuMemoryPlanPath.cpp
+  GpuMemoryTracker.cpp
   GpuResources.cpp
   OperatorAdapters.cpp
   PrestoAggregateFunctions.cpp

--- a/velox/experimental/cudf/exec/CMakeLists.txt
+++ b/velox/experimental/cudf/exec/CMakeLists.txt
@@ -38,8 +38,10 @@ add_library(
   DecimalAggregationDevice.cu
   DecimalAggregationHostOps.cpp
   DecimalAggregationState.cpp
+  GpuMemoryLedger.cpp
   GpuMemoryNvtx.cpp
   GpuMemoryPlanPath.cpp
+  GpuMemoryTracker.cpp
   GpuResources.cpp
   OperatorAdapters.cpp
   PrestoAggregateFunctions.cpp

--- a/velox/experimental/cudf/exec/GpuMemoryLedger.cpp
+++ b/velox/experimental/cudf/exec/GpuMemoryLedger.cpp
@@ -1,0 +1,560 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/cudf/exec/GpuMemoryLedger.h"
+#include "velox/experimental/cudf/exec/GpuMemoryNvtx.h"
+
+#include "velox/exec/Driver.h"
+#include "velox/exec/Operator.h"
+#include "velox/exec/Task.h"
+
+#include <folly/concurrency/ConcurrentHashMap.h>
+#include <folly/hash/Hash.h>
+
+#include <algorithm>
+#include <atomic>
+#include <deque>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+namespace facebook::velox::cudf_velox {
+
+namespace {
+
+/// Separates fields of a composite key, so concatenation cannot collide with a
+/// different split of the same characters.
+constexpr char kKeySeparator = '\x1f';
+
+/// The owner and process levels, the only two that report all three values.
+///
+/// Cache-line padded: adjacent records are updated by different threads, and
+/// false sharing between them would reintroduce the contention this design
+/// exists to remove.
+struct alignas(64) AtomicLiveBytes {
+  std::atomic<int64_t> current{0};
+  std::atomic<int64_t> peak{0};
+  std::atomic<int64_t> total{0};
+};
+
+/// The query level. Every operator in a query hits this one record, so counters
+/// no reader consumes are omitted rather than contended.
+struct alignas(64) QueryLiveBytes {
+  std::atomic<int64_t> current{0};
+  std::atomic<int64_t> peak{0};
+};
+
+/// The fragment and plan node levels. No peak: the maximum of a level's own
+/// live row already carries it.
+struct alignas(64) SharedLiveBytes {
+  std::atomic<int64_t> current{0};
+};
+
+/// Spins only while memory is growing, so it is uncontended in steady state.
+void raisePeak(std::atomic<int64_t>& peak, int64_t updated) {
+  auto observed = peak.load(std::memory_order_relaxed);
+  while (observed < updated &&
+         !peak.compare_exchange_weak(
+             observed, updated, std::memory_order_relaxed)) {
+  }
+}
+
+/// 'current' is acq_rel rather than relaxed so that a reader seeing the new
+/// live value also sees the total that was raised before it. That ordering is
+/// the only reason the "live never exceeds total" invariant holds mid-flight.
+int64_t applyDelta(AtomicLiveBytes& counter, int64_t deltaBytes) {
+  if (deltaBytes >= 0) {
+    counter.total.fetch_add(deltaBytes, std::memory_order_relaxed);
+  }
+  const auto updated =
+      counter.current.fetch_add(deltaBytes, std::memory_order_acq_rel) +
+      deltaBytes;
+  if (deltaBytes >= 0) {
+    raisePeak(counter.peak, updated);
+  }
+  return updated;
+}
+
+int64_t applyDelta(QueryLiveBytes& counter, int64_t deltaBytes) {
+  const auto updated =
+      counter.current.fetch_add(deltaBytes, std::memory_order_relaxed) +
+      deltaBytes;
+  if (deltaBytes >= 0) {
+    raisePeak(counter.peak, updated);
+  }
+  return updated;
+}
+
+int64_t applyDelta(SharedLiveBytes& counter, int64_t deltaBytes) {
+  return counter.current.fetch_add(deltaBytes, std::memory_order_relaxed) +
+      deltaBytes;
+}
+
+uint64_t toUnsigned(int64_t value) {
+  return value < 0 ? 0 : static_cast<uint64_t>(value);
+}
+
+GpuMemoryOwner unattributedOwner() {
+  return GpuMemoryOwner{
+      .taskUuid = "<unattributed>",
+      .taskId = "<unattributed>",
+      .queryId = "<unattributed>",
+      .planNodeId = "<unattributed>",
+      .planNodeType = "<unattributed>",
+      .pipelineId = -1,
+      .driverId = -1,
+      .operatorId = -1,
+      .operatorType = "<unattributed>"};
+}
+
+bool isEmptyOwner(const GpuMemoryOwner& owner) {
+  return owner.taskUuid.empty() && owner.taskId.empty() &&
+      owner.queryId.empty() && owner.planNodeId.empty() &&
+      owner.pipelineId < 0 && owner.driverId < 0 && owner.operatorId < 0 &&
+      owner.operatorType.empty();
+}
+
+void hashCombine(std::size_t& seed, std::size_t value) {
+  seed ^= value + 0x9e3779b97f4a7c15ULL + (seed << 6) + (seed >> 2);
+}
+
+struct GpuMemoryOwnerHash {
+  std::size_t operator()(const GpuMemoryOwner& owner) const {
+    std::size_t result = std::hash<std::string>{}(owner.taskUuid);
+    hashCombine(result, std::hash<std::string>{}(owner.taskId));
+    hashCombine(result, std::hash<std::string>{}(owner.queryId));
+    hashCombine(result, std::hash<std::string>{}(owner.planNodeId));
+    hashCombine(result, std::hash<int32_t>{}(owner.pipelineId));
+    hashCombine(result, std::hash<int32_t>{}(owner.driverId));
+    hashCombine(result, std::hash<int32_t>{}(owner.operatorId));
+    hashCombine(result, std::hash<std::string>{}(owner.operatorType));
+    return result;
+  }
+};
+
+/// Ancestor counters and NVTX ids are resolved once here, which is what leaves
+/// the allocation path with no lookups.
+struct OwnerRecord {
+  GpuMemoryOwnerHandle handle;
+  GpuMemoryOwner owner;
+  AtomicLiveBytes bytes;
+  QueryLiveBytes* query{nullptr};
+  SharedLiveBytes* task{nullptr};
+  SharedLiveBytes* planNode{nullptr};
+  GpuMemoryNvtxCounters nvtxCounters;
+};
+
+struct LiveAllocation {
+  uint64_t ownerId{0};
+  uint64_t bytes{0};
+};
+
+/// Spreads device addresses across the map's segments.
+///
+/// folly picks a segment from the low bits of the hash, std::hash of a pointer
+/// is the identity, and device allocations are at least 256-byte aligned. The
+/// default hash therefore lands every allocation in segment 0.
+struct AllocationAddressHash {
+  std::size_t operator()(const void* address) const noexcept {
+    return folly::hash::twang_mix64(reinterpret_cast<std::uintptr_t>(address));
+  }
+};
+
+} // namespace
+
+class GpuMemoryLedger::Impl {
+ public:
+  Impl() {
+    // Explicit, so an allocation made outside any operator is reported rather
+    // than dropped or guessed at.
+    auto* record = createOwnerLocked(
+        unattributedOwner(), 0, "<unattributed>", GpuMemoryPlanLocation{});
+    VELOX_CHECK_EQ(record->handle.ownerId, 0);
+  }
+
+  GpuMemoryOwnerHandle registerOwner(
+      const GpuMemoryOwner& owner,
+      const GpuMemoryPlanLocation& planLocation) {
+    if (isEmptyOwner(owner)) {
+      return {};
+    }
+
+    std::lock_guard<std::mutex> lock(registrationMutex_);
+    const auto existing = ownerIds_.find(owner);
+    if (existing != ownerIds_.end()) {
+      return existing->second->handle;
+    }
+    // Keyed on the resolved plan node, not the operator's own id: synthetic
+    // conversion operators carry a suffixed id that resolves to the same node,
+    // and the raw value would split that node's bytes across two aggregates.
+    const auto* resolvedNode = planLocation.node();
+    const auto& resolvedPlanNodeId =
+        resolvedNode == nullptr ? owner.planNodeId : resolvedNode->planNodeId;
+    return createOwnerLocked(
+               owner,
+               nextOwnerId_++,
+               planNodeKeyFor(owner, resolvedPlanNodeId),
+               planLocation)
+        ->handle;
+  }
+
+  std::optional<GpuMemoryOwnerHandle> findOwner(
+      const GpuMemoryOwner& owner) const {
+    if (isEmptyOwner(owner)) {
+      return std::nullopt;
+    }
+    std::lock_guard<std::mutex> lock(registrationMutex_);
+    const auto existing = ownerIds_.find(owner);
+    if (existing == ownerIds_.end()) {
+      return std::nullopt;
+    }
+    return existing->second->handle;
+  }
+
+  std::optional<GpuMemoryUpdate> recordAllocation(
+      void* address,
+      std::size_t bytes,
+      GpuMemoryOwnerHandle handle) noexcept {
+    if (address == nullptr) {
+      return std::nullopt;
+    }
+
+    try {
+      auto* record = ownerRecord(handle.ownerId);
+      if (record == nullptr) {
+        noteDataLoss("allocation for an unregistered owner");
+        return std::nullopt;
+      }
+
+      const auto inserted = allocations_.insert(
+          address, LiveAllocation{record->handle.ownerId, bytes});
+      if (!inserted.second) {
+        noteDataLoss("duplicate live allocation address");
+        return std::nullopt;
+      }
+
+      const auto update =
+          applyToAllLevels(*record, static_cast<int64_t>(bytes));
+      if (record->handle.ownerId == 0) {
+        ensureUnattributedCountersRegistered(*record);
+      }
+      sampleGpuMemoryNvtxCounters(record->nvtxCounters, update);
+      return update;
+    } catch (...) {
+      noteDataLoss("allocation accounting exception");
+      return std::nullopt;
+    }
+  }
+
+  std::optional<GpuMemoryUpdate> recordDeallocation(
+      void* address,
+      std::size_t reportedBytes) noexcept {
+    if (address == nullptr) {
+      return std::nullopt;
+    }
+
+    try {
+      // Safe as a separate find and erase because the wrapper erases before
+      // calling upstream, so the address cannot be recycled in between.
+      const auto allocation = allocations_.find(address);
+      if (allocation == allocations_.cend()) {
+        noteDataLoss("unknown deallocation address");
+        return std::nullopt;
+      }
+      const auto live = allocation->second;
+      allocations_.erase(address);
+
+      // The allocator contract guarantees these match. A disagreement would
+      // skew a counter, so surface it instead.
+      if (reportedBytes != live.bytes) {
+        noteDataLoss("deallocation size disagrees with recorded size");
+      }
+
+      auto* record = ownerRecord(live.ownerId);
+      if (record == nullptr) {
+        noteDataLoss("deallocation for an unregistered owner");
+        return std::nullopt;
+      }
+      const auto update =
+          applyToAllLevels(*record, -static_cast<int64_t>(live.bytes));
+      sampleGpuMemoryNvtxCounters(record->nvtxCounters, update);
+      return update;
+    } catch (...) {
+      noteDataLoss("deallocation accounting exception");
+      return std::nullopt;
+    }
+  }
+
+  GpuMemoryUpdate currentState(GpuMemoryOwnerHandle handle) const noexcept {
+    try {
+      const auto* record = ownerRecord(handle.ownerId);
+      if (record == nullptr) {
+        record = ownerRecord(0);
+      }
+      if (record == nullptr) {
+        return {};
+      }
+      return GpuMemoryUpdate{
+          record->handle.ownerId,
+          record->handle.planNodeKey,
+          toUnsigned(global_.current.load(std::memory_order_relaxed)),
+          toUnsigned(global_.peak.load(std::memory_order_relaxed)),
+          toUnsigned(record->query->current.load(std::memory_order_relaxed)),
+          toUnsigned(record->query->peak.load(std::memory_order_relaxed)),
+          toUnsigned(record->task->current.load(std::memory_order_relaxed)),
+          toUnsigned(record->planNode->current.load(std::memory_order_relaxed)),
+          toUnsigned(record->bytes.current.load(std::memory_order_relaxed))};
+    } catch (...) {
+      return {};
+    }
+  }
+
+  GpuMemorySnapshot snapshot() const {
+    GpuMemorySnapshot result;
+    result.currentBytes = toUnsigned(global_.current.load());
+    result.peakBytes = toUnsigned(global_.peak.load());
+    result.totalBytes = toUnsigned(global_.total.load());
+    result.liveAllocations = allocations_.size();
+    result.dataLossEvents = dataLossEvents_.load();
+
+    // Only pointers are gathered under the lock. Records never move and are
+    // never erased, so copying each owner's identity strings happens afterwards
+    // rather than on the mutex that registration also needs.
+    std::vector<const OwnerRecord*> records;
+    {
+      std::lock_guard<std::mutex> lock(registrationMutex_);
+      records.reserve(owners_.size());
+      for (const auto& record : owners_) {
+        records.push_back(record.get());
+      }
+    }
+
+    result.owners.reserve(records.size());
+    for (const auto* record : records) {
+      result.owners.push_back(
+          GpuMemoryOwnerSnapshot{
+              record->handle,
+              record->owner,
+              toUnsigned(record->bytes.current.load()),
+              toUnsigned(record->bytes.peak.load()),
+              toUnsigned(record->bytes.total.load())});
+    }
+
+    std::sort(
+        result.owners.begin(),
+        result.owners.end(),
+        [](const auto& left, const auto& right) {
+          if (left.currentBytes != right.currentBytes) {
+            return left.currentBytes > right.currentBytes;
+          }
+          return left.handle.ownerId < right.handle.ownerId;
+        });
+    return result;
+  }
+
+ private:
+  std::string planNodeKeyFor(
+      const GpuMemoryOwner& owner,
+      const std::string& resolvedPlanNodeId) const {
+    return owner.queryId + kKeySeparator + owner.taskUuid + kKeySeparator +
+        resolvedPlanNodeId;
+  }
+
+  /// Creates the owner record and any missing ancestor records. Callers hold
+  /// 'registrationMutex_', except the constructor.
+  ///
+  /// Takes 'planLocation' rather than letting the caller apply it, because the
+  /// record is inserted into the lock-free lookup maps only once complete: it
+  /// must never be reachable while a field is still being assigned.
+  OwnerRecord* createOwnerLocked(
+      const GpuMemoryOwner& owner,
+      uint64_t ownerId,
+      const std::string& planNodeKey,
+      const GpuMemoryPlanLocation& planLocation) {
+    auto* query = &queryLevels_[std::string(gpuMemoryQueryKey(owner))];
+    auto* task = &sharedLevels_[owner.taskUuid + kKeySeparator + "task"];
+
+    auto planNode = planNodeKeys_.find(planNodeKey);
+    if (planNode == planNodeKeys_.end()) {
+      planNode = planNodeKeys_.emplace(planNodeKey, nextPlanNodeKey_++).first;
+    }
+    auto* planNodeBytes = &sharedLevels_[planNodeKey + kKeySeparator + "plan"];
+
+    owners_.push_back(std::make_unique<OwnerRecord>());
+    auto* record = owners_.back().get();
+    record->handle = GpuMemoryOwnerHandle{ownerId, planNode->second};
+    record->owner = owner;
+    record->query = query;
+    record->task = task;
+    record->planNode = planNodeBytes;
+    // Owner 0 registers its row on first use instead. See
+    // ensureUnattributedCountersRegistered().
+    if (ownerId != 0) {
+      record->nvtxCounters = registerGpuMemoryNvtxOwner(
+          record->handle.ownerId,
+          record->handle.planNodeKey,
+          owner,
+          planLocation);
+    }
+
+    // Published last, now that every field is set.
+    ownerIds_.emplace(owner, record);
+    ownerById_.insert(ownerId, record);
+    return record;
+  }
+
+  OwnerRecord* ownerRecord(uint64_t ownerId) const {
+    const auto found = ownerById_.find(ownerId);
+    return found == ownerById_.cend() ? nullptr : found->second;
+  }
+
+  /// Registers the unattributed owner's row on first use, so a process that
+  /// never allocates outside an operator shows no always-zero row.
+  ///
+  /// Unlike every other record this one is already reachable, having been built
+  /// by the constructor, so the flag orders its single write against later
+  /// reads.
+  void ensureUnattributedCountersRegistered(OwnerRecord& record) {
+    if (unattributedRegistered_.load(std::memory_order_acquire)) {
+      return;
+    }
+    std::lock_guard<std::mutex> lock(registrationMutex_);
+    if (unattributedRegistered_.load(std::memory_order_relaxed)) {
+      return;
+    }
+    record.nvtxCounters = registerGpuMemoryNvtxUnattributedOwner();
+    unattributedRegistered_.store(true, std::memory_order_release);
+  }
+
+  /// Applies one transition to the owner, plan node, task, query and process
+  /// counters and returns the resulting values.
+  GpuMemoryUpdate applyToAllLevels(OwnerRecord& record, int64_t deltaBytes) {
+    const auto ownerCurrent = applyDelta(record.bytes, deltaBytes);
+    const auto planNodeCurrent = applyDelta(*record.planNode, deltaBytes);
+    const auto taskCurrent = applyDelta(*record.task, deltaBytes);
+    const auto queryCurrent = applyDelta(*record.query, deltaBytes);
+    const auto globalCurrent = applyDelta(global_, deltaBytes);
+
+    return GpuMemoryUpdate{
+        record.handle.ownerId,
+        record.handle.planNodeKey,
+        toUnsigned(globalCurrent),
+        toUnsigned(global_.peak.load(std::memory_order_relaxed)),
+        toUnsigned(queryCurrent),
+        toUnsigned(record.query->peak.load(std::memory_order_relaxed)),
+        toUnsigned(taskCurrent),
+        toUnsigned(planNodeCurrent),
+        toUnsigned(ownerCurrent)};
+  }
+
+  void noteDataLoss(std::string_view reason) noexcept {
+    dataLossEvents_.fetch_add(1, std::memory_order_relaxed);
+    markGpuMemoryDataLoss(reason);
+  }
+
+  AtomicLiveBytes global_;
+  std::atomic<uint64_t> dataLossEvents_{0};
+
+  /// Pointer ownership. Lock-free reads, fine-grained locking on writes.
+  folly::ConcurrentHashMap<const void*, LiveAllocation, AllocationAddressHash>
+      allocations_;
+  /// Lock-free owner lookup on the allocation path.
+  folly::ConcurrentHashMap<uint64_t, OwnerRecord*> ownerById_;
+
+  /// Registration-only below. Records never move and are never erased, so the
+  /// raw pointers published above stay valid for the ledger's lifetime.
+  mutable std::mutex registrationMutex_;
+  /// Whether the unattributed owner's counter row has been registered.
+  std::atomic<bool> unattributedRegistered_{false};
+  std::deque<std::unique_ptr<OwnerRecord>> owners_;
+  std::unordered_map<GpuMemoryOwner, OwnerRecord*, GpuMemoryOwnerHash>
+      ownerIds_;
+  /// Byte counters for the query, task and plan node levels, keyed by a
+  /// level-qualified name. std::unordered_map never relocates its values.
+  /// Node-based, so pointers cached in owner records survive growth.
+  std::unordered_map<std::string, QueryLiveBytes> queryLevels_;
+  /// Fragment and plan node levels, keyed by identifier and level.
+  std::unordered_map<std::string, SharedLiveBytes> sharedLevels_;
+  std::unordered_map<std::string, uint64_t> planNodeKeys_;
+  uint64_t nextOwnerId_{1};
+  /// Starts at zero so the unattributed owner, registered first, keeps the
+  /// all-zero handle that callers use to mean "no attribution".
+  uint64_t nextPlanNodeKey_{0};
+};
+
+GpuMemoryLedger::GpuMemoryLedger() : impl_(std::make_unique<Impl>()) {}
+
+GpuMemoryLedger::~GpuMemoryLedger() = default;
+
+GpuMemoryOwnerHandle GpuMemoryLedger::registerOwner(
+    const GpuMemoryOwner& owner,
+    const GpuMemoryPlanLocation& planLocation) {
+  return impl_->registerOwner(owner, planLocation);
+}
+
+GpuMemoryOwnerHandle GpuMemoryLedger::registerOperator(exec::Operator* op) {
+  if (op == nullptr) {
+    return {};
+  }
+
+  const auto* driverCtx = op->operatorCtx()->driverCtx();
+  GpuMemoryOwner owner{
+      .taskUuid = op->operatorCtx()->task()->uuid(),
+      .taskId = op->taskId(),
+      .queryId = op->operatorCtx()->task()->queryCtx()->queryId(),
+      .planNodeId = op->planNodeId(),
+      // Filled in below from the resolved plan node, and display-only, so it is
+      // deliberately absent from the identity the lookup above uses.
+      .planNodeType = "",
+      .pipelineId = driverCtx->pipelineId,
+      .driverId = driverCtx->driverId,
+      .operatorId = op->operatorId(),
+      .operatorType = op->operatorType()};
+  if (const auto existing = impl_->findOwner(owner)) {
+    return *existing;
+  }
+
+  const auto planLocation =
+      gpuMemoryPlanLocation(*op->operatorCtx()->task(), op->planNodeId());
+  if (const auto* node = planLocation.node()) {
+    owner.planNodeType = node->planNodeType;
+  }
+  return impl_->registerOwner(owner, planLocation);
+}
+
+std::optional<GpuMemoryUpdate> GpuMemoryLedger::recordAllocation(
+    void* address,
+    std::size_t bytes,
+    GpuMemoryOwnerHandle handle) noexcept {
+  return impl_->recordAllocation(address, bytes, handle);
+}
+
+std::optional<GpuMemoryUpdate> GpuMemoryLedger::recordDeallocation(
+    void* address,
+    std::size_t bytes) noexcept {
+  return impl_->recordDeallocation(address, bytes);
+}
+
+GpuMemoryUpdate GpuMemoryLedger::currentState(
+    GpuMemoryOwnerHandle handle) const noexcept {
+  return impl_->currentState(handle);
+}
+
+GpuMemorySnapshot GpuMemoryLedger::snapshot() const {
+  return impl_->snapshot();
+}
+
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/GpuMemoryLedger.h
+++ b/velox/experimental/cudf/exec/GpuMemoryLedger.h
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/experimental/cudf/exec/GpuMemoryOwner.h"
+#include "velox/experimental/cudf/exec/GpuMemoryPlanPath.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <vector>
+
+namespace facebook::velox::exec {
+class Operator;
+}
+
+namespace facebook::velox::cudf_velox {
+
+struct GpuMemoryOwnerSnapshot {
+  GpuMemoryOwnerHandle handle;
+  /// Identity captured at registration.
+  GpuMemoryOwner owner;
+  uint64_t currentBytes{0};
+  uint64_t peakBytes{0};
+  /// Allocated successfully over the ledger's lifetime.
+  uint64_t totalBytes{0};
+};
+
+/// A process-wide view of the accounting.
+///
+/// Exists to make the accounting testable; no production code reads it. It
+/// carries only what separates correct accounting from incorrect: what is live,
+/// what the peak was, what was ever allocated, whether the pointer map drained,
+/// and whether anything was lost. Anything more would be state maintained on
+/// the allocation path for no reader.
+///
+/// Levels are updated independently and without a shared lock, so a snapshot
+/// taken mid-flight can catch them at slightly different instants. It is exact
+/// single-threaded and once allocation activity quiesces.
+struct GpuMemorySnapshot {
+  uint64_t currentBytes{0};
+  uint64_t peakBytes{0};
+  uint64_t totalBytes{0};
+  /// Counted from the pointer map rather than tracked separately.
+  uint64_t liveAllocations{0};
+  /// Accounting events that could not be represented.
+  uint64_t dataLossEvents{0};
+  /// Ordered by descending live bytes.
+  std::vector<GpuMemoryOwnerSnapshot> owners;
+};
+
+/// Attributes every tracked GPU allocation to the operator instance that made
+/// it, and maintains live, peak and total byte counters per operator instance,
+/// plan node, task, query and process.
+///
+/// The allocation and deallocation paths take no shared lock. Pointer ownership
+/// lives in a concurrent hash map, every counter is an atomic, and each owner
+/// record caches the ancestor counters and NVTX counter ids it needs, so a
+/// transition performs no lookup outside that map. A registration mutex guards
+/// the creation of records, which then keep stable addresses for their
+/// lifetime.
+///
+/// That holds only while callers reuse the handle they were issued. Resolving
+/// an owner from an operator takes the registration mutex, so a caller that
+/// resolves per allocation rather than caching reintroduces the serialization.
+///
+/// A free is always charged to the allocation-time owner, even when it happens
+/// on another thread or under another active operator, which is what makes an
+/// owner breakdown at a later process peak meaningful.
+class GpuMemoryLedger {
+ public:
+  GpuMemoryLedger();
+  ~GpuMemoryLedger();
+
+  GpuMemoryLedger(const GpuMemoryLedger&) = delete;
+  GpuMemoryLedger& operator=(const GpuMemoryLedger&) = delete;
+
+  /// Registers an owner and returns its stable handle.
+  ///
+  /// 'planLocation' places the owner in the NVTX counter hierarchy. An
+  /// unresolved location reports it as unmapped. Registering an already known
+  /// owner returns the existing handle without creating a second record.
+  GpuMemoryOwnerHandle registerOwner(
+      const GpuMemoryOwner& owner,
+      const GpuMemoryPlanLocation& planLocation = {});
+
+  /// Resolves the operator's display type and plan path only when the owner is
+  /// new, since that walks the plan tree.
+  GpuMemoryOwnerHandle registerOperator(exec::Operator* op);
+
+  /// Returns the resulting counter values, or nothing for a null address. A
+  /// duplicate live address is reported as data loss.
+  std::optional<GpuMemoryUpdate> recordAllocation(
+      void* address,
+      std::size_t bytes,
+      GpuMemoryOwnerHandle handle) noexcept;
+
+  /// Debits the allocation-time owner, using the size recorded at allocation
+  /// rather than 'bytes'. A disagreement between the two, like an unknown
+  /// address, is reported as data loss.
+  std::optional<GpuMemoryUpdate> recordDeallocation(
+      void* address,
+      std::size_t bytes) noexcept;
+
+  /// Counters as they stand, for the allocation-failure marker.
+  GpuMemoryUpdate currentState(GpuMemoryOwnerHandle handle) const noexcept;
+
+  /// See GpuMemorySnapshot for what this guarantees under concurrency.
+  [[nodiscard]] GpuMemorySnapshot snapshot() const;
+
+ private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/GpuMemoryNvtx.cpp
+++ b/velox/experimental/cudf/exec/GpuMemoryNvtx.cpp
@@ -1,0 +1,528 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/cudf/exec/GpuMemoryNvtx.h"
+
+#include <nvtx3/nvToolsExt.h>
+#include <nvtx3/nvToolsExtCounters.h>
+#include <nvtx3/nvToolsExtPayload.h>
+#include <nvtx3/nvToolsExtSemanticsCounters.h>
+
+#include <fmt/format.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cstddef>
+#include <limits>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
+
+namespace facebook::velox::cudf_velox {
+
+namespace {
+
+/// Counter names must be unique within a capture: the SQLite export records the
+/// scope tree in NVTX_SCOPES and the samples in GENERIC_EVENTS, but nothing
+/// ties a counter to the scope it was registered against, so same-named
+/// counters are indistinguishable afterwards. This ordinal supplies the
+/// uniqueness, and a registration marker carrying it supplies the full
+/// identity.
+uint64_t nextCounterOrdinal() {
+  static std::atomic<uint64_t> ordinal{0};
+  return ordinal.fetch_add(1, std::memory_order_relaxed) + 1;
+}
+
+/// The default domain, not the "velox" domain that carries the operator ranges.
+/// Nsight renders a named domain as an extra level between a scope and its
+/// counters, which buries the plan nesting. The cost is that
+/// --nvtx-domain-include=velox keeps the ranges but drops these counters.
+nvtxDomainHandle_t counterDomain() {
+  return nullptr;
+}
+
+const nvtxSemanticsCounter_t& byteCounterSemantics() {
+  static const auto semantics = [] {
+    nvtxSemanticsCounter_t result{};
+    result.header.structSize = sizeof(nvtxSemanticsCounter_t);
+    result.header.semanticId = NVTX_SEMANTIC_ID_COUNTERS_V1;
+    result.header.version = NVTX_COUNTER_SEMANTIC_VERSION;
+    result.header.next = nullptr;
+    result.flags = NVTX_COUNTER_FLAG_LIMIT_MIN |
+        NVTX_COUNTER_FLAG_VALUETYPE_ABSOLUTE |
+        NVTX_COUNTER_FLAG_INTERPOLATION_UNTIL_NEXT;
+    result.unit = "bytes";
+    result.unitScaleNumerator = 1;
+    result.unitScaleDenominator = 1;
+    result.limitType = NVTX_COUNTER_LIMIT_I64;
+    result.min.i64 = 0;
+    return result;
+  }();
+  return semantics;
+}
+
+uint64_t registerScope(const std::string& path, uint64_t parentScope) {
+  nvtxScopeAttr_t attributes{};
+  attributes.structSize = sizeof(nvtxScopeAttr_t);
+  attributes.path = path.c_str();
+  attributes.parentScope = parentScope;
+  attributes.scopeId = NVTX_SCOPE_NONE;
+  return nvtxScopeRegister(counterDomain(), &attributes);
+}
+
+uint64_t registerByteCounter(const std::string& name, uint64_t scopeId) {
+  nvtxCounterAttr_t attributes{};
+  attributes.structSize = sizeof(nvtxCounterAttr_t);
+  attributes.schemaId = NVTX_PAYLOAD_ENTRY_TYPE_INT64;
+  attributes.name = name.c_str();
+  attributes.description =
+      "Logical requested GPU allocation bytes attributed by Velox-cuDF.";
+  attributes.scopeId = scopeId;
+  attributes.semantics = &byteCounterSemantics().header;
+  attributes.counterId = NVTX_COUNTER_ID_NONE;
+  return nvtxCounterRegister(counterDomain(), &attributes);
+}
+
+int64_t clampToInt64(uint64_t bytes) {
+  return static_cast<int64_t>(std::min(
+      bytes, static_cast<uint64_t>(std::numeric_limits<int64_t>::max())));
+}
+
+/// NVTX timestamps the sample here, which is when the ledger recorded the
+/// transition.
+void sampleCounter(uint64_t counterId, uint64_t bytes) {
+  // The unattributed owner has no ancestor levels, so part of its set is
+  // legitimately unregistered.
+  if (counterId == NVTX_COUNTER_ID_NONE) {
+    return;
+  }
+  nvtxCounterSampleInt64(counterDomain(), counterId, clampToInt64(bytes));
+}
+
+void emitMark(const std::string& text) {
+  nvtxEventAttributes_t attributes{};
+  attributes.version = NVTX_VERSION;
+  attributes.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+  attributes.messageType = NVTX_MESSAGE_TYPE_ASCII;
+  attributes.message.ascii = text.c_str();
+  nvtxDomainMarkEx(counterDomain(), &attributes);
+}
+
+std::string displayField(std::string_view value) {
+  return value.empty() ? std::string{"<none>"} : std::string{value};
+}
+
+/// Escapes the NVTX scope path separators so a value cannot forge a level.
+std::string escapeScopeField(std::string_view value) {
+  std::string result;
+  result.reserve(value.size());
+  for (const auto character : value) {
+    if (character == '\\' || character == '/' || character == '[' ||
+        character == ']') {
+      result.push_back('\\');
+    }
+    result.push_back(character);
+  }
+  return result;
+}
+
+// One label per hierarchy level. The registered counter name is the label plus
+// " #<ordinal>". The "logical requested live bytes" qualifier lives in the
+// counter description rather than the label, to keep rows readable in a narrow
+// column without losing the distinction from physical memory.
+
+std::string queryScopeLabel(const GpuMemoryOwner& owner) {
+  return "query " + escapeScopeField(displayField(owner.queryId));
+}
+
+std::string fragmentScopeLabel(const GpuMemoryOwner& owner) {
+  // A Presto task executes exactly one plan fragment, so the task identifier
+  // names the fragment instance.
+  return "fragment " + escapeScopeField(displayField(owner.taskId));
+}
+
+/// Zero-padded pre-order index plus one dash per level of depth, so Nsight's
+/// lexical row sort reproduces EXPLAIN order and nesting stays legible.
+std::string planNodeScopeLabel(const GpuMemoryPlanLocation& location) {
+  const auto* node = location.node();
+  if (node == nullptr) {
+    return "unmapped";
+  }
+  return fmt::format(
+      "{:03d} {}{} [{}]",
+      location.order,
+      std::string(location.depth(), '-') + (location.depth() > 0 ? " " : ""),
+      escapeScopeField(node->planNodeType),
+      escapeScopeField(node->planNodeId));
+}
+
+std::string operatorCounterLabel(const GpuMemoryOwner& owner) {
+  return fmt::format(
+      "op{} {} d{}",
+      owner.operatorId,
+      escapeScopeField(displayField(owner.operatorType)),
+      owner.driverId);
+}
+
+struct ScopeCounter {
+  uint64_t scopeId{NVTX_SCOPE_NONE};
+  uint64_t counterId{NVTX_COUNTER_ID_NONE};
+  /// Only queries publish a high-water mark, as a flat reference against their
+  /// live row. Deeper levels would repeat information their own live row's
+  /// maximum already gives.
+  uint64_t peakCounterId{NVTX_COUNTER_ID_NONE};
+};
+
+/// Registration cycle of the ids currently handed out.
+///
+/// A reset retires every id, so a counter set cached by the ledger before it
+/// must not be sampled afterwards. Read once per transition instead of taking
+/// the registration lock.
+std::atomic<uint64_t> counterEpoch{1};
+
+struct CounterState {
+  std::mutex mutex;
+  bool initialized{false};
+  uint64_t rootScopeId{NVTX_SCOPE_NONE};
+  uint64_t globalCounterId{NVTX_COUNTER_ID_NONE};
+  /// Keyed by queryId.
+  std::unordered_map<std::string, ScopeCounter> queries;
+  /// Keyed by taskUuid.
+  std::unordered_map<std::string, ScopeCounter> tasks;
+  /// Keyed by taskUuid and plan node identifier, so that the same plan node
+  /// identifier in concurrent tasks stays separate.
+  std::unordered_map<std::string, uint64_t> planNodeScopes;
+  /// Keyed by taskUuid, plan node identifier and pipeline.
+  std::unordered_map<std::string, uint64_t> pipelineScopes;
+  /// Keyed by the ledger's plan node handle.
+  std::unordered_map<uint64_t, uint64_t> planNodeCounters;
+  std::unordered_map<uint64_t, GpuMemoryNvtxCounters> owners;
+  /// Every registration marker emitted so far, replayed when a new query
+  /// appears.
+  ///
+  /// Replay is quadratic in the number of queries a worker runs, so the list is
+  /// bounded. Past the bound later registrations are still emitted once, but no
+  /// longer restated into subsequent captures.
+  std::vector<std::string> registrationMarkers;
+  /// Whether the bound above has been reached, so a capture can say so rather
+  /// than appear to be missing counters.
+  bool markersTruncated{false};
+};
+
+CounterState& counterState() {
+  // Intentionally leaked: driver threads may emit during static destruction.
+  static auto* state = new CounterState;
+  return *state;
+}
+
+/// Roughly six markers per operator instance and a few hundred instances per
+/// query, so this spans dozens of queries before it engages.
+constexpr size_t kMaxRegistrationMarkers = 20'000;
+
+/// Emits the marker mapping this counter's ordinal to the full owner identity,
+/// which is what makes a capture self-describing.
+uint64_t registerLevelCounter(
+    std::string_view label,
+    uint64_t scopeId,
+    std::string_view identity,
+    CounterState& state) {
+  const auto ordinal = nextCounterOrdinal();
+  const auto name = fmt::format("{} #{}", label, ordinal);
+  const auto counterId = registerByteCounter(name, scopeId);
+  const auto marker = fmt::format(
+      "velox-gpu-memory-counter #{} name=[{}] {}", ordinal, name, identity);
+  emitMark(marker);
+  if (state.registrationMarkers.size() < kMaxRegistrationMarkers) {
+    state.registrationMarkers.push_back(marker);
+  } else {
+    state.markersTruncated = true;
+  }
+  sampleCounter(counterId, 0);
+  return counterId;
+}
+
+std::string planNodeScopeKey(
+    std::string_view taskUuid,
+    std::string_view planNodeId) {
+  return std::string{taskUuid} + '\x1f' + std::string{planNodeId};
+}
+
+std::string ownerIdentity(const GpuMemoryOwner& owner, std::string_view level) {
+  return fmt::format(
+      "level={} query=[{}] taskId=[{}] taskUuid=[{}] plan=[{}] planType=[{}] "
+      "operator={} operatorType=[{}] pipeline={} driver={}",
+      level,
+      displayField(owner.queryId),
+      displayField(owner.taskId),
+      displayField(owner.taskUuid),
+      displayField(owner.planNodeId),
+      displayField(owner.planNodeType),
+      owner.operatorId,
+      displayField(owner.operatorType),
+      owner.pipelineId,
+      owner.driverId);
+}
+
+/// Opens a counter session: the root scope and the process-wide counter.
+void initializeLocked(CounterState& state) {
+  if (state.initialized) {
+    return;
+  }
+  state.rootScopeId = registerScope("Velox GPU memory", NVTX_SCOPE_ROOT);
+  state.globalCounterId = registerLevelCounter(
+      "overall live bytes", state.rootScopeId, "level=global", state);
+  state.initialized = true;
+}
+
+/// Registers the query, task and plan node scopes on the owner's path, then
+/// returns the scope the operator's own counter belongs to.
+uint64_t resolveOwnerScopeLocked(
+    CounterState& state,
+    const GpuMemoryOwner& owner,
+    const GpuMemoryPlanLocation& planLocation,
+    uint64_t planNodeKey,
+    GpuMemoryNvtxCounters& counters) {
+  auto query = state.queries.find(std::string(gpuMemoryQueryKey(owner)));
+  if (query == state.queries.end()) {
+    // A new query means a new capture window is plausible. Nsight replays scope
+    // registrations into each session but not markers, so restate the identity
+    // of everything registered earlier or a capture that did not span a
+    // counter's registration cannot resolve it.
+    for (const auto& marker : state.registrationMarkers) {
+      emitMark(marker);
+    }
+    if (state.markersTruncated) {
+      emitMark(
+          "velox-gpu-memory-counter-registrations-truncated "
+          "reason=[replay bound reached]");
+    }
+    const auto label = queryScopeLabel(owner);
+    ScopeCounter entry;
+    entry.scopeId = registerScope(label, state.rootScopeId);
+    entry.counterId = registerLevelCounter(
+        label, entry.scopeId, ownerIdentity(owner, "query"), state);
+    entry.peakCounterId = registerLevelCounter(
+        label + " peak",
+        entry.scopeId,
+        ownerIdentity(owner, "query-peak"),
+        state);
+    query = state.queries.emplace(std::string(gpuMemoryQueryKey(owner)), entry)
+                .first;
+  }
+  counters.queryCounterId = query->second.counterId;
+  counters.queryPeakCounterId = query->second.peakCounterId;
+
+  auto task = state.tasks.find(owner.taskUuid);
+  if (task == state.tasks.end()) {
+    const auto label = fragmentScopeLabel(owner);
+    ScopeCounter entry;
+    entry.scopeId = registerScope(label, query->second.scopeId);
+    entry.counterId = registerLevelCounter(
+        label, entry.scopeId, ownerIdentity(owner, "fragment"), state);
+    task = state.tasks.emplace(owner.taskUuid, entry).first;
+  }
+  counters.taskCounterId = task->second.counterId;
+
+  // Plan nodes are siblings under the task rather than nested by the plan.
+  // Nesting them mirrors the plan faithfully, but a TPC-H plan is over twenty
+  // levels deep, which indents every counter off the right of the timeline and
+  // makes a node's own aggregate render below its children's subtree. A flat
+  // list keeps each plan node and its operator instances readable together.
+  const auto* node = planLocation.node();
+  const auto planNodeId =
+      node == nullptr ? std::string{"<unmapped>"} : node->planNodeId;
+  const auto label = planNodeScopeLabel(planLocation);
+
+  const auto key = planNodeScopeKey(owner.taskUuid, planNodeId);
+  auto scope = state.planNodeScopes.find(key);
+  if (scope == state.planNodeScopes.end()) {
+    const auto scopeId = registerScope(label, task->second.scopeId);
+    scope = state.planNodeScopes.emplace(key, scopeId).first;
+  }
+  const auto planNodeScopeId = scope->second;
+
+  // Velox executes a task as pipelines of drivers, and a single plan node can
+  // span two of them: a hash join's build and probe run in different pipelines.
+  // Giving the pipeline its own level makes that split visible instead of
+  // hiding it in the operator label.
+  const auto pipelineKey = planNodeScopeKey(
+      owner.taskUuid, planNodeId + '\x1f' + std::to_string(owner.pipelineId));
+  auto pipeline = state.pipelineScopes.find(pipelineKey);
+  if (pipeline == state.pipelineScopes.end()) {
+    const auto scopeId = registerScope(
+        fmt::format("pipeline {}", owner.pipelineId), planNodeScopeId);
+    pipeline = state.pipelineScopes.emplace(pipelineKey, scopeId).first;
+  }
+
+  auto planNodeCounter = state.planNodeCounters.find(planNodeKey);
+  if (planNodeCounter == state.planNodeCounters.end()) {
+    const auto counterId = registerLevelCounter(
+        label, planNodeScopeId, ownerIdentity(owner, "planNode"), state);
+    planNodeCounter =
+        state.planNodeCounters.emplace(planNodeKey, counterId).first;
+  }
+  counters.planNodeCounterId = planNodeCounter->second;
+
+  return pipeline->second;
+}
+
+} // namespace
+
+GpuMemoryNvtxCounters registerGpuMemoryNvtxOwner(
+    uint64_t ownerId,
+    uint64_t planNodeKey,
+    const GpuMemoryOwner& owner,
+    const GpuMemoryPlanLocation& planLocation) noexcept {
+  try {
+    auto& state = counterState();
+    std::lock_guard<std::mutex> lock(state.mutex);
+    initializeLocked(state);
+    if (const auto known = state.owners.find(ownerId);
+        known != state.owners.end()) {
+      return known->second;
+    }
+
+    GpuMemoryNvtxCounters counters;
+    counters.epoch = counterEpoch.load(std::memory_order_relaxed);
+    counters.globalCounterId = state.globalCounterId;
+
+    if (ownerId == 0) {
+      counters.ownerCounterId = registerLevelCounter(
+          "unattributed", state.rootScopeId, "level=unattributed", state);
+    } else {
+      const auto ownerScopeId = resolveOwnerScopeLocked(
+          state, owner, planLocation, planNodeKey, counters);
+      counters.ownerCounterId = registerLevelCounter(
+          operatorCounterLabel(owner),
+          ownerScopeId,
+          ownerIdentity(owner, "operator"),
+          state);
+    }
+    state.owners.emplace(ownerId, counters);
+    return counters;
+  } catch (...) {
+    // Profiler diagnostics must never alter query execution.
+    return {};
+  }
+}
+
+GpuMemoryNvtxCounters registerGpuMemoryNvtxUnattributedOwner() noexcept {
+  return registerGpuMemoryNvtxOwner(
+      0, 0, GpuMemoryOwner{}, GpuMemoryPlanLocation{});
+}
+
+void sampleGpuMemoryNvtxCounters(
+    const GpuMemoryNvtxCounters& counters,
+    const GpuMemoryUpdate& update) noexcept {
+  if (counters.epoch != counterEpoch.load(std::memory_order_acquire)) {
+    return;
+  }
+  try {
+    sampleCounter(counters.globalCounterId, update.globalCurrentBytes);
+    sampleCounter(counters.queryCounterId, update.queryCurrentBytes);
+    sampleCounter(counters.queryPeakCounterId, update.queryPeakBytes);
+    sampleCounter(counters.taskCounterId, update.taskCurrentBytes);
+    sampleCounter(counters.planNodeCounterId, update.planNodeCurrentBytes);
+    sampleCounter(counters.ownerCounterId, update.ownerCurrentBytes);
+  } catch (...) {
+    // Profiler diagnostics must never alter query execution.
+  }
+}
+
+void markGpuMemoryAllocationFailure(
+    uint64_t ownerId,
+    std::size_t requestedBytes,
+    const GpuMemoryUpdate& state,
+    std::size_t cudaFreeBytes,
+    std::size_t cudaTotalBytes,
+    std::string_view cudaStatus) noexcept {
+  try {
+    emitMark(
+        fmt::format(
+            "velox-gpu-memory-allocation-failure owner={} requestedBytes={} "
+            "globalCurrentBytes={} globalPeakBytes={} planNodeCurrentBytes={} "
+            "ownerCurrentBytes={} cudaFreeBytes={} cudaTotalBytes={} cudaStatus=[{}]",
+            ownerId,
+            requestedBytes,
+            state.globalCurrentBytes,
+            state.globalPeakBytes,
+            state.planNodeCurrentBytes,
+            state.ownerCurrentBytes,
+            cudaFreeBytes,
+            cudaTotalBytes,
+            cudaStatus));
+  } catch (...) {
+    // Failure markers must not mask the original allocation failure.
+  }
+}
+
+void markGpuMemoryDataLoss(std::string_view reason) noexcept {
+  try {
+    emitMark(fmt::format("velox-gpu-memory-data-loss reason=[{}]", reason));
+  } catch (...) {
+    // Diagnostics only.
+  }
+}
+
+/// Closes the current counter session.
+///
+/// The epoch is retired before the zeroes are written. That stops every counter
+/// set the ledger still holds, including the sets held by tracked resources
+/// that deliberately outlive unregistration, so a late allocation cannot leave
+/// a counter high after this has finished.
+void resetGpuMemoryNvtxCounters() noexcept {
+  try {
+    auto& state = counterState();
+    std::lock_guard<std::mutex> lock(state.mutex);
+    if (!state.initialized) {
+      return;
+    }
+    counterEpoch.fetch_add(1, std::memory_order_release);
+
+    for (const auto& [ownerId, counters] : state.owners) {
+      sampleCounter(counters.ownerCounterId, 0);
+    }
+    for (const auto& [planNodeKey, counterId] : state.planNodeCounters) {
+      sampleCounter(counterId, 0);
+    }
+    for (const auto& [taskUuid, entry] : state.tasks) {
+      sampleCounter(entry.counterId, 0);
+    }
+    for (const auto& [queryId, entry] : state.queries) {
+      sampleCounter(entry.peakCounterId, 0);
+      sampleCounter(entry.counterId, 0);
+    }
+    sampleCounter(state.globalCounterId, 0);
+
+    state.owners.clear();
+    state.planNodeCounters.clear();
+    state.planNodeScopes.clear();
+    state.pipelineScopes.clear();
+    state.tasks.clear();
+    state.queries.clear();
+    state.registrationMarkers.clear();
+    // Every counter and scope id above has just been retired, so the next
+    // session rebuilds the tree from a fresh root rather than sampling ids that
+    // no longer have an owner.
+    state.globalCounterId = NVTX_COUNTER_ID_NONE;
+    state.rootScopeId = NVTX_SCOPE_NONE;
+    state.initialized = false;
+  } catch (...) {
+    // Profiler diagnostics must never alter query execution.
+  }
+}
+
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/GpuMemoryNvtx.cpp
+++ b/velox/experimental/cudf/exec/GpuMemoryNvtx.cpp
@@ -20,15 +20,22 @@
 #include <nvtx3/nvToolsExtCounters.h>
 #include <nvtx3/nvToolsExtPayload.h>
 #include <nvtx3/nvToolsExtSemanticsCounters.h>
+#include <nvtx3/nvToolsExtSemanticsTime.h>
 
 #include <fmt/format.h>
 
 #include <algorithm>
 #include <atomic>
+#include <chrono>
 #include <cstddef>
+#include <ctime>
+#include <initializer_list>
 #include <limits>
 #include <mutex>
+#include <thread>
+#include <tuple>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace facebook::velox::cudf_velox {
@@ -54,13 +61,32 @@ nvtxDomainHandle_t counterDomain() {
   return nullptr;
 }
 
+int64_t nowNanos() {
+  timespec now{};
+  clock_gettime(CLOCK_MONOTONIC_RAW, &now);
+  return now.tv_sec * 1'000'000'000LL + now.tv_nsec;
+}
+
+const nvtxSemanticsTime_t& timeSemantics() {
+  static const auto semantics = [] {
+    nvtxSemanticsTime_t result{};
+    result.header.structSize = sizeof(nvtxSemanticsTime_t);
+    result.header.semanticId = NVTX_SEMANTIC_ID_TIME_V1;
+    result.header.version = NVTX_TIME_SEMANTIC_VERSION;
+    result.header.next = nullptr;
+    result.timeDomainId = NVTX_TIMESTAMP_TYPE_CPU_CLOCK_GETTIME_MONOTONIC_RAW;
+    return result;
+  }();
+  return semantics;
+}
+
 const nvtxSemanticsCounter_t& byteCounterSemantics() {
   static const auto semantics = [] {
     nvtxSemanticsCounter_t result{};
     result.header.structSize = sizeof(nvtxSemanticsCounter_t);
     result.header.semanticId = NVTX_SEMANTIC_ID_COUNTERS_V1;
     result.header.version = NVTX_COUNTER_SEMANTIC_VERSION;
-    result.header.next = nullptr;
+    result.header.next = &timeSemantics().header;
     result.flags = NVTX_COUNTER_FLAG_LIMIT_MIN |
         NVTX_COUNTER_FLAG_VALUETYPE_ABSOLUTE |
         NVTX_COUNTER_FLAG_INTERPOLATION_UNTIL_NEXT;
@@ -101,15 +127,171 @@ int64_t clampToInt64(uint64_t bytes) {
       bytes, static_cast<uint64_t>(std::numeric_limits<int64_t>::max())));
 }
 
-/// NVTX timestamps the sample here, which is when the ledger recorded the
-/// transition.
-void sampleCounter(uint64_t counterId, uint64_t bytes) {
-  // The unattributed owner has no ancestor levels, so part of its set is
-  // legitimately unregistered.
+/// Nsight records immediate samples but renders their Velox timeline rows as
+/// zero; deferred batches of real chronological samples render correctly.
+struct BufferedSample {
+  uint64_t counterId;
+  int64_t value;
+  int64_t timestamp;
+};
+
+BufferedSample
+bufferedSample(uint64_t counterId, uint64_t bytes, int64_t timestamp) {
+  return {counterId, clampToInt64(bytes), timestamp};
+}
+
+struct CounterSeries {
+  std::vector<int64_t> values;
+  std::vector<int64_t> timestamps;
+};
+
+struct SubmissionState {
+  std::mutex mutex;
+  std::unordered_map<uint64_t, int64_t> lastTimestamps;
+};
+
+SubmissionState& submissionState() {
+  static auto* state = new SubmissionState;
+  return *state;
+}
+
+void submitSamples(std::vector<BufferedSample> samples) {
+  if (samples.empty()) {
+    return;
+  }
+  // Nsight's timeline renderer rejects overlapping or unsorted series, so
+  // merge every producer and enforce strict order across flushes.
+  std::sort(
+      samples.begin(), samples.end(), [](const auto& left, const auto& right) {
+        return std::tie(left.counterId, left.timestamp) <
+            std::tie(right.counterId, right.timestamp);
+      });
+  std::unordered_map<uint64_t, CounterSeries> grouped;
+  for (const auto& sample : samples) {
+    auto& series = grouped[sample.counterId];
+    auto& lastTimestamp = submissionState().lastTimestamps[sample.counterId];
+    const auto timestamp = lastTimestamp == 0
+        ? sample.timestamp
+        : std::max(sample.timestamp, lastTimestamp + 1);
+    series.values.push_back(sample.value);
+    series.timestamps.push_back(timestamp);
+    lastTimestamp = timestamp;
+  }
+  for (const auto& [counterId, series] : grouped) {
+    nvtxCounterBatch_t batch{};
+    batch.counterId = counterId;
+    batch.counters = series.values.data();
+    batch.countersSize = series.values.size() * sizeof(int64_t);
+    batch.flags = NVTX_BATCH_FLAG_TIME_SORTED;
+    batch.timestamps = series.timestamps.data();
+    batch.timestampsSize = series.timestamps.size() * sizeof(int64_t);
+    nvtxCounterBatchSubmit(counterDomain(), &batch);
+  }
+}
+
+class ThreadSampleBuffer;
+
+struct BufferRegistry {
+  std::mutex mutex;
+  std::unordered_set<ThreadSampleBuffer*> buffers;
+  std::vector<BufferedSample> retiredSamples;
+};
+
+BufferRegistry& bufferRegistry() {
+  static auto* registry = new BufferRegistry;
+  return *registry;
+}
+
+void flushAllThreadBuffers();
+
+/// A process-lifetime drain avoids teardown ordering and restart state. The
+/// short cadence keeps an idle driver's tail inside the active capture.
+void startSampleFlusher() {
+  static const bool started = [] {
+    std::thread([] {
+      while (true) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        flushAllThreadBuffers();
+      }
+    }).detach();
+    return true;
+  }();
+  static_cast<void>(started);
+}
+
+class ThreadSampleBuffer {
+ public:
+  ThreadSampleBuffer() {
+    auto& registry = bufferRegistry();
+    {
+      std::lock_guard<std::mutex> lock(registry.mutex);
+      registry.buffers.insert(this);
+    }
+    startSampleFlusher();
+  }
+
+  ~ThreadSampleBuffer() {
+    auto& registry = bufferRegistry();
+    std::lock_guard<std::mutex> lock(registry.mutex);
+    registry.buffers.erase(this);
+    auto samples = drain();
+    registry.retiredSamples.insert(
+        registry.retiredSamples.end(), samples.begin(), samples.end());
+  }
+
+  void append(std::initializer_list<BufferedSample> samples) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (const auto& sample : samples) {
+      if (sample.counterId != NVTX_COUNTER_ID_NONE) {
+        samples_.push_back(sample);
+      }
+    }
+  }
+
+  std::vector<BufferedSample> drain() {
+    std::vector<BufferedSample> samples;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      samples.swap(samples_);
+    }
+    return samples;
+  }
+
+ private:
+  std::mutex mutex_;
+  std::vector<BufferedSample> samples_;
+};
+
+ThreadSampleBuffer& threadSampleBuffer() {
+  thread_local ThreadSampleBuffer buffer;
+  return buffer;
+}
+
+void flushAllThreadBuffers() {
+  auto& submission = submissionState();
+  std::lock_guard<std::mutex> submissionLock(submission.mutex);
+  auto& registry = bufferRegistry();
+  std::vector<BufferedSample> samples;
+  {
+    std::lock_guard<std::mutex> lock(registry.mutex);
+    samples.swap(registry.retiredSamples);
+    for (auto* buffer : registry.buffers) {
+      auto buffered = buffer->drain();
+      samples.insert(samples.end(), buffered.begin(), buffered.end());
+    }
+  }
+  submitSamples(std::move(samples));
+}
+
+void sampleCounter(uint64_t counterId, uint64_t bytes, int64_t timestamp) {
   if (counterId == NVTX_COUNTER_ID_NONE) {
     return;
   }
-  nvtxCounterSampleInt64(counterDomain(), counterId, clampToInt64(bytes));
+  threadSampleBuffer().append({bufferedSample(counterId, bytes, timestamp)});
+}
+
+void sampleCounter(uint64_t counterId, uint64_t bytes) {
+  sampleCounter(counterId, bytes, nowNanos());
 }
 
 void emitMark(const std::string& text) {
@@ -431,12 +613,21 @@ void sampleGpuMemoryNvtxCounters(
     return;
   }
   try {
-    sampleCounter(counters.globalCounterId, update.globalCurrentBytes);
-    sampleCounter(counters.queryCounterId, update.queryCurrentBytes);
-    sampleCounter(counters.queryPeakCounterId, update.queryPeakBytes);
-    sampleCounter(counters.taskCounterId, update.taskCurrentBytes);
-    sampleCounter(counters.planNodeCounterId, update.planNodeCurrentBytes);
-    sampleCounter(counters.ownerCounterId, update.ownerCurrentBytes);
+    const auto timestamp = nowNanos();
+    threadSampleBuffer().append({
+        bufferedSample(
+            counters.globalCounterId, update.globalCurrentBytes, timestamp),
+        bufferedSample(
+            counters.queryCounterId, update.queryCurrentBytes, timestamp),
+        bufferedSample(
+            counters.queryPeakCounterId, update.queryPeakBytes, timestamp),
+        bufferedSample(
+            counters.taskCounterId, update.taskCurrentBytes, timestamp),
+        bufferedSample(
+            counters.planNodeCounterId, update.planNodeCurrentBytes, timestamp),
+        bufferedSample(
+            counters.ownerCounterId, update.ownerCurrentBytes, timestamp),
+    });
   } catch (...) {
     // Profiler diagnostics must never alter query execution.
   }
@@ -491,6 +682,7 @@ void resetGpuMemoryNvtxCounters() noexcept {
       return;
     }
     counterEpoch.fetch_add(1, std::memory_order_release);
+    flushAllThreadBuffers();
 
     for (const auto& [ownerId, counters] : state.owners) {
       sampleCounter(counters.ownerCounterId, 0);
@@ -506,6 +698,7 @@ void resetGpuMemoryNvtxCounters() noexcept {
       sampleCounter(entry.counterId, 0);
     }
     sampleCounter(state.globalCounterId, 0);
+    flushAllThreadBuffers();
 
     state.owners.clear();
     state.planNodeCounters.clear();

--- a/velox/experimental/cudf/exec/GpuMemoryNvtx.h
+++ b/velox/experimental/cudf/exec/GpuMemoryNvtx.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/experimental/cudf/exec/GpuMemoryOwner.h"
+#include "velox/experimental/cudf/exec/GpuMemoryPlanPath.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+
+namespace facebook::velox::cudf_velox {
+
+/// Publishes Velox-cuDF logical GPU memory as NVTX counters.
+///
+/// Counters are registered in the NVTX default domain rather than the "velox"
+/// domain that carries the operator ranges, because Nsight renders a named
+/// domain as an extra level above every counter row.
+///
+/// Their scopes form one tree under a single root scope: query, then plan
+/// fragment, then one scope per plan node, then one per pipeline, with each
+/// operator instance a counter leaf. Plan nodes are siblings of one another
+/// rather than nested by the plan tree; their labels carry the plan order.
+///
+/// Every entry point is safe to call when no profiler is attached, in which
+/// case NVTX resolves its entry points to no-ops, and none of them can throw.
+
+/// The counters one operator instance moves on every transition.
+///
+/// Held by the caller so that sampling needs neither a lookup nor a lock. Zero
+/// is NVTX's "no counter" value, so a default-constructed set samples nothing.
+struct GpuMemoryNvtxCounters {
+  /// Registration cycle these ids belong to. A reset retires every id, and a
+  /// set cached before it must not be sampled afterwards.
+  uint64_t epoch{0};
+  uint64_t globalCounterId{0};
+  uint64_t ownerCounterId{0};
+  uint64_t queryCounterId{0};
+  uint64_t queryPeakCounterId{0};
+  /// A task executes one plan fragment, so this is the fragment level.
+  uint64_t taskCounterId{0};
+  uint64_t planNodeCounterId{0};
+};
+
+/// Registers the scope tree and counters for one owner, and returns the
+/// counters its transitions move. Idempotent per owner and per shared level.
+///
+/// An empty 'planLocation' places the operator under the fragment's "unmapped"
+/// scope, so an unresolved plan node id still reports its bytes.
+GpuMemoryNvtxCounters registerGpuMemoryNvtxOwner(
+    uint64_t ownerId,
+    uint64_t planNodeKey,
+    const GpuMemoryOwner& owner,
+    const GpuMemoryPlanLocation& planLocation) noexcept;
+
+/// For allocations made outside any operator. Called lazily, so a process that
+/// never makes one shows no always-zero row.
+GpuMemoryNvtxCounters registerGpuMemoryNvtxUnattributedOwner() noexcept;
+
+/// Takes no lock. Does nothing for a counter set that is empty or predates a
+/// reset.
+void sampleGpuMemoryNvtxCounters(
+    const GpuMemoryNvtxCounters& counters,
+    const GpuMemoryUpdate& update) noexcept;
+
+/// Emits a factual allocation-failure marker with the logical state at failure.
+///
+/// 'cudaStatus' reports whether the device byte counts could be collected on
+/// this cold path.
+void markGpuMemoryAllocationFailure(
+    uint64_t ownerId,
+    std::size_t requestedBytes,
+    const GpuMemoryUpdate& state,
+    std::size_t cudaFreeBytes,
+    std::size_t cudaTotalBytes,
+    std::string_view cudaStatus) noexcept;
+
+/// Emits a diagnostic marker when ledger accounting loses an event.
+void markGpuMemoryDataLoss(std::string_view reason) noexcept;
+
+/// Zeroes every counter and clears the registered hierarchy.
+void resetGpuMemoryNvtxCounters() noexcept;
+
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/GpuMemoryOwner.h
+++ b/velox/experimental/cudf/exec/GpuMemoryOwner.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+namespace facebook::velox::cudf_velox {
+
+/// Identifies one concrete operator instance that originated an allocation.
+struct GpuMemoryOwner {
+  std::string taskUuid;
+  std::string taskId;
+  std::string queryId;
+  std::string planNodeId;
+  /// Display only. Deliberately excluded from equality and hashing, because
+  /// registerOperator() looks an owner up before it can resolve the type.
+  std::string planNodeType;
+  int32_t pipelineId{-1};
+  int32_t driverId{-1};
+  /// Position within the pipeline.
+  int32_t operatorId{-1};
+  std::string operatorType;
+
+  bool operator==(const GpuMemoryOwner& other) const {
+    return taskUuid == other.taskUuid && taskId == other.taskId &&
+        queryId == other.queryId && planNodeId == other.planNodeId &&
+        pipelineId == other.pipelineId && driverId == other.driverId &&
+        operatorId == other.operatorId && operatorType == other.operatorType;
+  }
+};
+
+/// Returns what identifies the query level, which is not always the query id.
+///
+/// QueryCtx::create() defaults queryId to empty and only some embeddings fill
+/// it in. Keying on it alone would merge unrelated queries into one row. A task
+/// belongs to one query, so its uuid is a safe fallback; the cost is one row
+/// per task where the id is missing. The id still labels the row.
+inline std::string_view gpuMemoryQueryKey(const GpuMemoryOwner& owner) {
+  return owner.queryId.empty() ? owner.taskUuid : owner.queryId;
+}
+
+/// Refers to stable owner and plan node records in the ledger.
+struct GpuMemoryOwnerHandle {
+  uint64_t ownerId{0};
+  /// The ledger's numeric handle for the plan node aggregate, unrelated to
+  /// GpuMemoryOwner::planNodeId.
+  uint64_t planNodeKey{0};
+
+  bool operator==(const GpuMemoryOwnerHandle&) const = default;
+};
+
+/// Every counter affected by one logical-memory transition, after it.
+///
+/// Each value comes from an independent atomic, so they agree with one another
+/// only in single-threaded execution and once allocation activity quiesces.
+struct GpuMemoryUpdate {
+  uint64_t ownerId{0};
+  uint64_t planNodeKey{0};
+  uint64_t globalCurrentBytes{0};
+  /// Monotonic for the life of the process, so it is reported through the
+  /// snapshot and the allocation-failure marker rather than as a counter, where
+  /// it would carry one query's peak into every later query.
+  uint64_t globalPeakBytes{0};
+  uint64_t queryCurrentBytes{0};
+  uint64_t queryPeakBytes{0};
+  /// A task executes exactly one plan fragment, so this is the fragment level.
+  uint64_t taskCurrentBytes{0};
+  uint64_t planNodeCurrentBytes{0};
+  uint64_t ownerCurrentBytes{0};
+};
+
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/GpuMemoryPlanPath.cpp
+++ b/velox/experimental/cudf/exec/GpuMemoryPlanPath.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/cudf/exec/GpuMemoryPlanPath.h"
+
+#include "velox/core/PlanNode.h"
+#include "velox/exec/Task.h"
+
+#include <array>
+
+namespace facebook::velox::cudf_velox {
+
+namespace {
+
+/// Suffixes appended to plan node identifiers of synthetic conversion
+/// operators, which have no plan node of their own.
+constexpr std::array<std::string_view, 2> kConversionSuffixes{
+    "-from-velox",
+    "-to-velox"};
+
+std::string displayPlanNodeType(const core::PlanNode& planNode) {
+  auto type = std::string{planNode.name()};
+  if (!type.ends_with("Node")) {
+    type += "Node";
+  }
+  return type;
+}
+
+/// Depth first, in the order EXPLAIN prints.
+///
+/// 'nextOrder' advances for every node visited, so a subtree that does not
+/// contain the target still shifts the index of everything after it. Returns as
+/// soon as the target matches, leaving 'location' untouched when it does not.
+bool findPlanLocation(
+    const core::PlanNode& node,
+    std::string_view planNodeId,
+    int32_t& nextOrder,
+    GpuMemoryPlanLocation& location) {
+  const auto order = nextOrder++;
+  location.path.push_back(
+      GpuMemoryPlanPathEntry{
+          std::string{node.id()}, displayPlanNodeType(node)});
+  if (node.id() == planNodeId) {
+    location.order = order;
+    return true;
+  }
+  for (const auto& source : node.sources()) {
+    if (source != nullptr &&
+        findPlanLocation(*source, planNodeId, nextOrder, location)) {
+      return true;
+    }
+  }
+  location.path.pop_back();
+  return false;
+}
+
+} // namespace
+
+GpuMemoryPlanLocation gpuMemoryPlanLocationFromRoot(
+    const core::PlanNode* planRoot,
+    std::string_view planNodeId) {
+  GpuMemoryPlanLocation location;
+  if (planRoot == nullptr || planNodeId.empty()) {
+    return location;
+  }
+
+  int32_t nextOrder = 0;
+  if (findPlanLocation(*planRoot, planNodeId, nextOrder, location)) {
+    return location;
+  }
+
+  for (const auto suffix : kConversionSuffixes) {
+    if (planNodeId.ends_with(suffix)) {
+      auto sourceId = planNodeId;
+      sourceId.remove_suffix(suffix.size());
+      location = GpuMemoryPlanLocation{};
+      nextOrder = 0;
+      if (findPlanLocation(*planRoot, sourceId, nextOrder, location)) {
+        return location;
+      }
+      break;
+    }
+  }
+  return GpuMemoryPlanLocation{};
+}
+
+GpuMemoryPlanLocation gpuMemoryPlanLocation(
+    const exec::Task& task,
+    std::string_view planNodeId) {
+  return gpuMemoryPlanLocationFromRoot(
+      task.planFragment().planNode.get(), planNodeId);
+}
+
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/GpuMemoryPlanPath.h
+++ b/velox/experimental/cudf/exec/GpuMemoryPlanPath.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace facebook::velox::core {
+class PlanNode;
+}
+
+namespace facebook::velox::exec {
+class Task;
+}
+
+namespace facebook::velox::cudf_velox {
+
+struct GpuMemoryPlanPathEntry {
+  std::string planNodeId;
+  /// From PlanNode::name(), with "Node" appended when absent.
+  std::string planNodeType;
+};
+
+/// Where one plan node sits within its fragment. Empty path and order -1 when
+/// the node does not resolve.
+struct GpuMemoryPlanLocation {
+  /// Fragment root to the node, inclusive.
+  std::vector<GpuMemoryPlanPathEntry> path;
+  /// Position in a depth-first pre-order walk, which is the order EXPLAIN
+  /// prints.
+  int32_t order{-1};
+
+  /// Zero for the fragment root.
+  int32_t depth() const {
+    return path.empty() ? 0 : static_cast<int32_t>(path.size()) - 1;
+  }
+
+  const GpuMemoryPlanPathEntry* node() const {
+    return path.empty() ? nullptr : &path.back();
+  }
+};
+
+/// Locates 'planNodeId' within the task's plan fragment.
+///
+/// Synthetic conversion operators carry a "-from-velox" or "-to-velox" suffix,
+/// which is stripped before one retry. Callers represent an unresolved id as an
+/// unmapped position rather than dropping the operator.
+GpuMemoryPlanLocation gpuMemoryPlanLocation(
+    const exec::Task& task,
+    std::string_view planNodeId);
+
+/// Exposed so tests can supply a plan tree without building a Task.
+GpuMemoryPlanLocation gpuMemoryPlanLocationFromRoot(
+    const core::PlanNode* planRoot,
+    std::string_view planNodeId);
+
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/GpuMemoryTracker.cpp
+++ b/velox/experimental/cudf/exec/GpuMemoryTracker.cpp
@@ -1,0 +1,286 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/cudf/CudfConfig.h"
+#include "velox/experimental/cudf/exec/GpuMemoryNvtx.h"
+#include "velox/experimental/cudf/exec/GpuMemoryTracker.h"
+
+#include "velox/common/base/RuntimeMetrics.h"
+#include "velox/exec/Operator.h"
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/mr/failure_callback_resource_adaptor.hpp>
+
+#include <cuda_runtime_api.h>
+
+#include <glog/logging.h>
+
+#include <memory>
+#include <string_view>
+#include <utility>
+
+namespace facebook::velox::cudf_velox {
+
+namespace {
+
+/// The process-wide ledger. Atomic rather than mutex-guarded because reading it
+/// is the whole operation; nothing else needs to be consistent with it.
+std::atomic<std::shared_ptr<GpuMemoryLedger>> installedLedger;
+
+/// Advanced once per compiled driver and whenever the ledger is replaced, which
+/// is rare relative to allocation. See discardGpuMemoryOwnerCache().
+std::atomic<uint64_t> resolutionGeneration{0};
+
+std::shared_ptr<GpuMemoryLedger> currentLedger() {
+  return installedLedger.load(std::memory_order_acquire);
+}
+
+/// Velox points the thread-local stat writer at the operator it is running,
+/// which is how an allocation finds its owner without threading one through
+/// every cuDF call.
+exec::Operator* runtimeOperator() {
+  return dynamic_cast<exec::Operator*>(getThreadLocalRunTimeStatWriter());
+}
+
+/// A driver thread runs one operator at a time and allocates repeatedly within
+/// each call, so a single entry absorbs almost every lookup. Without it every
+/// allocation copies five identity strings and takes the ledger's registration
+/// mutex only to rediscover a handle it already issued.
+struct ResolvedOwner {
+  const GpuMemoryLedger* ledger{nullptr};
+  const exec::Operator* op{nullptr};
+  uint64_t generation{0};
+  GpuMemoryOwnerHandle handle;
+};
+
+thread_local ResolvedOwner resolvedOwner;
+
+GpuMemoryOwnerHandle resolveOwner(
+    const std::shared_ptr<GpuMemoryLedger>& ledger) noexcept {
+  auto* op = runtimeOperator();
+  if (op == nullptr) {
+    return {};
+  }
+
+  const auto generation = resolutionGeneration.load(std::memory_order_acquire);
+  if (resolvedOwner.op == op && resolvedOwner.ledger == ledger.get() &&
+      resolvedOwner.generation == generation) {
+    return resolvedOwner.handle;
+  }
+
+  try {
+    const auto handle = ledger->registerOperator(op);
+    resolvedOwner = ResolvedOwner{ledger.get(), op, generation, handle};
+    return handle;
+  } catch (...) {
+    // Fall through to the explicit unattributed owner.
+    return {};
+  }
+}
+
+class TrackingResourceImpl {
+ public:
+  TrackingResourceImpl(
+      GpuMemoryResource upstream,
+      std::shared_ptr<GpuMemoryLedger> ledger)
+      : upstream_(std::move(upstream)), ledger_(std::move(ledger)) {}
+
+  void*
+  allocate(cuda::stream_ref stream, std::size_t bytes, std::size_t alignment) {
+    if (bytes == 0) {
+      return nullptr;
+    }
+
+    const auto owner = resolveOwner(ledger_);
+    auto* address = upstream_.allocate(stream, bytes, alignment);
+    ledger_->recordAllocation(address, bytes, owner);
+    return address;
+  }
+
+  void deallocate(
+      cuda::stream_ref stream,
+      void* address,
+      std::size_t bytes,
+      std::size_t alignment) noexcept {
+    // Not also on bytes == 0: allocate() returns nullptr for a zero-byte
+    // request, so this is the only guard needed, and skipping on size would
+    // turn a caller that reports the wrong size into a silent leak.
+    if (address == nullptr) {
+      return;
+    }
+
+    // Before calling upstream, so an immediately reused address cannot be
+    // erased by a delayed cross-thread deallocation.
+    ledger_->recordDeallocation(address, bytes);
+    upstream_.deallocate(stream, address, bytes, alignment);
+  }
+
+  void* allocate_sync(std::size_t bytes, std::size_t alignment) {
+    return allocate(rmm::cuda_stream_default, bytes, alignment);
+  }
+
+  void deallocate_sync(
+      void* address,
+      std::size_t bytes,
+      std::size_t alignment) noexcept {
+    deallocate(rmm::cuda_stream_default, address, bytes, alignment);
+  }
+
+  bool operator==(const TrackingResourceImpl& other) const noexcept {
+    return this == &other;
+  }
+
+  bool operator!=(const TrackingResourceImpl& other) const noexcept {
+    return !(*this == other);
+  }
+
+  friend void get_property(
+      const TrackingResourceImpl&,
+      cuda::mr::device_accessible) noexcept {}
+
+ private:
+  GpuMemoryResource upstream_;
+  std::shared_ptr<GpuMemoryLedger> ledger_;
+};
+
+class TrackingResource final
+    : public cuda::mr::shared_resource<TrackingResourceImpl> {
+  using SharedBase = cuda::mr::shared_resource<TrackingResourceImpl>;
+
+ public:
+  TrackingResource(
+      GpuMemoryResource upstream,
+      std::shared_ptr<GpuMemoryLedger> ledger)
+      : SharedBase(
+            cuda::mr::make_shared_resource<TrackingResourceImpl>(
+                std::move(upstream),
+                std::move(ledger))) {}
+
+  friend void get_property(
+      const TrackingResource&,
+      cuda::mr::device_accessible) noexcept {}
+};
+
+static_assert(
+    cuda::mr::resource_with<TrackingResource, cuda::mr::device_accessible>);
+
+void reportAllocationFailure(
+    std::size_t bytes,
+    const std::shared_ptr<GpuMemoryLedger>& ledger) noexcept {
+  // Runs from RMM's failure callback while an out-of-memory condition unwinds.
+  // Formatting and logging can throw there, and an exception leaving a noexcept
+  // function terminates, so the whole body is guarded.
+  try {
+    const auto owner = resolveOwner(ledger);
+    const auto state = ledger->currentState(owner);
+
+    std::size_t freeBytes{0};
+    std::size_t totalBytes{0};
+    const auto cudaStatus = cudaMemGetInfo(&freeBytes, &totalBytes);
+    const std::string_view cudaStatusName{cudaGetErrorName(cudaStatus)};
+
+    if (state.ownerId == 0) {
+      registerGpuMemoryNvtxUnattributedOwner();
+    }
+    markGpuMemoryAllocationFailure(
+        state.ownerId, bytes, state, freeBytes, totalBytes, cudaStatusName);
+    LOG(ERROR) << "GPU_MEMORY_OOM requested_bytes=" << bytes
+               << " logical_live_bytes=" << state.globalCurrentBytes
+               << " owner_id=" << state.ownerId
+               << " plan_node_track_id=" << state.planNodeKey
+               << " owner_live_bytes=" << state.ownerCurrentBytes
+               << " plan_node_live_bytes=" << state.planNodeCurrentBytes
+               << " cuda_free_bytes=" << freeBytes
+               << " cuda_total_bytes=" << totalBytes
+               << " cuda_status=" << cudaStatusName;
+  } catch (...) {
+    // The allocation failure is reported to the caller by RMM regardless.
+  }
+}
+
+GpuMemoryResource makeTrackedResource(
+    GpuMemoryResource upstream,
+    const std::shared_ptr<GpuMemoryLedger>& ledger) {
+  TrackingResource trackingResource(std::move(upstream), ledger);
+  // rmm::bad_alloc rather than its subclass rmm::out_of_memory: a failure for
+  // any other reason equally deserves a marker naming the operator that asked.
+  rmm::mr::failure_callback_resource_adaptor<rmm::bad_alloc> failureResource(
+      GpuMemoryResource{std::move(trackingResource)},
+      [ledger](std::size_t bytes, void*) {
+        reportAllocationFailure(bytes, ledger);
+        return false;
+      },
+      nullptr);
+  return GpuMemoryResource{std::move(failureResource)};
+}
+
+} // namespace
+
+GpuMemoryResourcePair createGpuMemoryTrackingResources(
+    GpuMemoryResource mainUpstream,
+    GpuMemoryResource outputUpstream) {
+  auto ledger = std::make_shared<GpuMemoryLedger>();
+  auto main = makeTrackedResource(std::move(mainUpstream), ledger);
+  auto output = makeTrackedResource(std::move(outputUpstream), ledger);
+  installedLedger.store(std::move(ledger), std::memory_order_release);
+  resolutionGeneration.fetch_add(1, std::memory_order_release);
+  return {std::move(main), std::move(output)};
+}
+
+bool installGpuMemoryTracking(
+    GpuMemoryResource& mainMr,
+    GpuMemoryResource& outputMr) {
+  if (!CudfConfig::getInstance().memoryTrackingEnabled) {
+    resetGpuMemoryTracking();
+    return false;
+  }
+
+  auto tracked =
+      createGpuMemoryTrackingResources(std::move(mainMr), std::move(outputMr));
+  mainMr = std::move(tracked.main);
+  outputMr = std::move(tracked.output);
+  return true;
+}
+
+void registerGpuMemoryOperator(exec::Operator* op) noexcept {
+  const auto ledger = currentLedger();
+  if (ledger == nullptr) {
+    return;
+  }
+
+  try {
+    ledger->registerOperator(op);
+  } catch (...) {
+    // Registration only affects diagnostics, never execution.
+  }
+}
+
+void discardGpuMemoryOwnerCache() noexcept {
+  resolutionGeneration.fetch_add(1, std::memory_order_release);
+}
+
+void resetGpuMemoryTracking() {
+  installedLedger.store(nullptr, std::memory_order_release);
+  resolutionGeneration.fetch_add(1, std::memory_order_release);
+  resetGpuMemoryNvtxCounters();
+}
+
+GpuMemorySnapshot getGpuMemorySnapshot() {
+  const auto ledger = currentLedger();
+  return ledger == nullptr ? GpuMemorySnapshot{} : ledger->snapshot();
+}
+
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/GpuMemoryTracker.h
+++ b/velox/experimental/cudf/exec/GpuMemoryTracker.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/experimental/cudf/exec/GpuMemoryLedger.h"
+
+#include <cuda/memory_resource>
+
+namespace facebook::velox::exec {
+class Operator;
+}
+
+namespace facebook::velox::cudf_velox {
+
+using GpuMemoryResource = cuda::mr::any_resource<cuda::mr::device_accessible>;
+
+/// The default and output resources, both feeding one ledger: simultaneous
+/// ownership across the two is the useful signal when debugging an OOM.
+struct GpuMemoryResourcePair {
+  GpuMemoryResource main;
+  GpuMemoryResource output;
+};
+
+/// Wraps both resources in place so every allocation they serve is attributed
+/// to the operator that made it. Leaves them untouched and returns false when
+/// cudf.memory_tracking_enabled is off.
+bool installGpuMemoryTracking(
+    GpuMemoryResource& mainMr,
+    GpuMemoryResource& outputMr);
+
+/// Gives 'op' a counter row before it allocates, so a capture can tell an
+/// operator that held no memory from one that never ran.
+///
+/// Which operators get a row is a display choice only. Attribution correctness
+/// rests on discardGpuMemoryOwnerCache().
+void registerGpuMemoryOperator(exec::Operator* op) noexcept;
+
+/// Drops every thread's cached operator-to-owner resolution.
+///
+/// That cache is keyed on the raw exec::Operator address, and a destroyed
+/// driver's addresses can be reused by a later one. Call this for every
+/// compiled driver, not just for operators that get a counter row: an operator
+/// without a row still allocates, and would be charged to whoever last held its
+/// address.
+void discardGpuMemoryOwnerCache() noexcept;
+
+/// Two wrappers over one shared ledger, published as the process-wide ledger.
+[[nodiscard]] GpuMemoryResourcePair createGpuMemoryTrackingResources(
+    GpuMemoryResource mainUpstream,
+    GpuMemoryResource outputUpstream);
+
+/// Drops the process-wide ledger and zeroes its counters.
+void resetGpuMemoryTracking();
+
+/// An empty snapshot when no ledger is installed.
+[[nodiscard]] GpuMemorySnapshot getGpuMemorySnapshot();
+
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -23,6 +23,7 @@
 #include "velox/experimental/cudf/exec/CudfOrderBy.h"
 #include "velox/experimental/cudf/exec/CudfReduce.h"
 #include "velox/experimental/cudf/exec/CudfTopN.h"
+#include "velox/experimental/cudf/exec/GpuMemoryTracker.h"
 #include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/exec/OperatorAdapters.h"
 #include "velox/experimental/cudf/exec/PrestoAggregateFunctions.h"
@@ -34,14 +35,13 @@
 #include "folly/Conv.h"
 #include "velox/exec/Driver.h"
 #include "velox/exec/Operator.h"
+#include "velox/exec/TableScan.h"
 #include "velox/exec/Values.h"
 
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
-#include <cuda.h>
-
-#include <iostream>
+#include <vector>
 
 static const std::string kCudfAdapterName = "cuDF";
 
@@ -255,16 +255,16 @@ bool CompileState::compile(bool allowCpuFallback) {
 
   if (debugEnabled) {
     // Print before/after together for easy comparison.
-    LOG(INFO) << "Operators " << "before adapting for cuDF"
-              << ": count [" << beforeOperators.size() << "]";
+    LOG(INFO) << "Operators " << "before adapting for cuDF" << ": count ["
+              << beforeOperators.size() << "]";
     for (const auto& [id, desc] : beforeOperators) {
       LOG(INFO) << "  Operator: ID " << id << ": " << desc;
     }
     LOG(INFO) << "allowCpuFallback = " << allowCpuFallback;
 
     operators = driver_.operators();
-    LOG(INFO) << "Operators " << "after adapting for cuDF"
-              << ": count [" << operators.size() << "]";
+    LOG(INFO) << "Operators " << "after adapting for cuDF" << ": count ["
+              << operators.size() << "]";
     for (const auto& op : operators) {
       LOG(INFO) << "  Operator: ID " << op->operatorId() << ": "
                 << op->toString();
@@ -280,14 +280,34 @@ struct CudfDriverAdapter {
 
   // Call operator needed by DriverAdapter
   bool operator()(const exec::DriverFactory& factory, exec::Driver& driver) {
+    const auto trackingEnabled =
+        CudfConfig::getInstance().memoryTrackingEnabled;
+    if (trackingEnabled) {
+      // This driver's operators are new, and may sit at addresses freed by a
+      // destroyed driver. Done before the early return below, because an
+      // operator that allocates on the GPU is not always one this adapter
+      // replaces: a TableWriter driving CudfHiveDataSink is neither a
+      // CudfOperatorBase nor a TableScan.
+      discardGpuMemoryOwnerCache();
+    }
     if (!driver.driverCtx()->queryConfig().get<bool>(
             CudfConfig::kCudfEnabled, CudfConfig::getInstance().enabled) &&
         allowCpuFallback_) {
       return false;
     }
     auto state = CompileState(factory, driver);
-    auto res = state.compile(allowCpuFallback_);
-    return res;
+    const auto replacementsMade = state.compile(allowCpuFallback_);
+    if (trackingEnabled) {
+      // Which operators get a counter row is only a display choice; an
+      // unregistered operator still allocates and is still attributed.
+      for (auto* op : driver.operators()) {
+        if (dynamic_cast<CudfOperatorBase*>(op) != nullptr ||
+            dynamic_cast<exec::TableScan*>(op) != nullptr) {
+          registerGpuMemoryOperator(op);
+        }
+      }
+    }
+    return replacementsMade;
   }
 
  private:
@@ -316,18 +336,23 @@ void registerCudf() {
   cudaFree(nullptr); // Initialize CUDA context at startup
 
   const std::string mrMode = CudfConfig::getInstance().memoryResource;
-  auto mr = cudf_velox::createMemoryResource(
+  auto mainMr = cudf_velox::createMemoryResource(
       mrMode, CudfConfig::getInstance().memoryPercent);
-  cudf::set_current_device_resource(mr);
-  mr_ = std::move(mr);
 
   const auto& outputMrMode = CudfConfig::getInstance().outputMemoryResource;
+  auto outputMr = mainMr;
   if (!outputMrMode.empty() && outputMrMode != mrMode) {
-    output_mr_ = cudf_velox::createMemoryResource(
+    outputMr = cudf_velox::createMemoryResource(
         outputMrMode, CudfConfig::getInstance().memoryPercent);
-  } else {
-    output_mr_ = mr_;
   }
+
+  installGpuMemoryTracking(mainMr, outputMr);
+  mr_ = std::move(mainMr);
+  output_mr_ = std::move(outputMr);
+  // RMM takes an owning copy, so it keeps this resource alive on its own and
+  // there is nothing to restore later: registerCudf() and unregisterCudf() run
+  // once at worker startup and shutdown.
+  cudf::set_current_device_resource(mr_.value());
 
   exec::Operator::registerOperator(
       std::make_unique<CudfHashJoinBridgeTranslator>());
@@ -351,6 +376,7 @@ void registerCudf() {
 void unregisterCudf() {
   output_mr_.reset();
   mr_.reset();
+  resetGpuMemoryTracking();
   exec::DriverFactory::adapters.erase(
       std::remove_if(
           exec::DriverFactory::adapters.begin(),
@@ -375,6 +401,9 @@ void CudfConfig::initialize(
   }
   if (config.find(kCudfDebugEnabled) != config.end()) {
     debugEnabled = folly::to<bool>(config[kCudfDebugEnabled]);
+  }
+  if (config.find(kCudfMemoryTrackingEnabled) != config.end()) {
+    memoryTrackingEnabled = folly::to<bool>(config[kCudfMemoryTrackingEnabled]);
   }
   if (config.find(kCudfMemoryResource) != config.end()) {
     memoryResource = config[kCudfMemoryResource];

--- a/velox/experimental/cudf/tests/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/CMakeLists.txt
@@ -114,6 +114,12 @@ velox_add_cudf_test(
 )
 
 velox_add_cudf_test(
+  NAME velox_cudf_gpu_memory_nvtx_test
+  SOURCES Main.cpp GpuMemoryNvtxTest.cpp
+  LIBS ${CUDF_TEST_DEFAULT_LIBS}
+)
+
+velox_add_cudf_test(
   NAME velox_cudf_decimal_aggregation_test
   SOURCES Main.cpp DecimalAggregationTest.cpp
   LIBS ${CUDF_TEST_DEFAULT_LIBS} velox_functions_test_lib

--- a/velox/experimental/cudf/tests/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/CMakeLists.txt
@@ -119,6 +119,12 @@ velox_add_cudf_test(
 )
 
 velox_add_cudf_test(
+  NAME velox_cudf_gpu_memory_nvtx_test
+  SOURCES Main.cpp GpuMemoryNvtxTest.cpp
+  LIBS ${CUDF_TEST_DEFAULT_LIBS}
+)
+
+velox_add_cudf_test(
   NAME velox_cudf_decimal_aggregation_test
   SOURCES Main.cpp DecimalAggregationTest.cpp
   LIBS ${CUDF_TEST_DEFAULT_LIBS} velox_functions_test_lib

--- a/velox/experimental/cudf/tests/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/CMakeLists.txt
@@ -112,6 +112,11 @@ velox_add_cudf_test(
   SOURCES Main.cpp CudfSplitReaderTest.cpp
   LIBS velox_cudf_exec_test_lib velox_cudf_hive_connector
 )
+velox_add_cudf_test(
+  NAME velox_cudf_gpu_memory_plan_path_test
+  SOURCES Main.cpp GpuMemoryPlanPathTest.cpp
+  LIBS ${CUDF_TEST_DEFAULT_LIBS}
+)
 
 velox_add_cudf_test(
   NAME velox_cudf_decimal_aggregation_test

--- a/velox/experimental/cudf/tests/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/CMakeLists.txt
@@ -112,6 +112,13 @@ velox_add_cudf_test(
   SOURCES Main.cpp CudfSplitReaderTest.cpp
   LIBS velox_cudf_exec_test_lib velox_cudf_hive_connector
 )
+
+velox_add_cudf_test(
+  NAME velox_cudf_gpu_memory_tracker_test
+  SOURCES Main.cpp GpuMemoryTrackerTest.cpp
+  LIBS ${CUDF_TEST_DEFAULT_LIBS} rmm::rmm
+)
+
 velox_add_cudf_test(
   NAME velox_cudf_gpu_memory_plan_path_test
   SOURCES Main.cpp GpuMemoryPlanPathTest.cpp

--- a/velox/experimental/cudf/tests/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/CMakeLists.txt
@@ -108,6 +108,12 @@ velox_add_cudf_test(
 )
 
 velox_add_cudf_test(
+  NAME velox_cudf_gpu_memory_tracker_test
+  SOURCES Main.cpp GpuMemoryTrackerTest.cpp
+  LIBS ${CUDF_TEST_DEFAULT_LIBS} rmm::rmm
+)
+
+velox_add_cudf_test(
   NAME velox_cudf_gpu_memory_plan_path_test
   SOURCES Main.cpp GpuMemoryPlanPathTest.cpp
   LIBS ${CUDF_TEST_DEFAULT_LIBS}

--- a/velox/experimental/cudf/tests/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/CMakeLists.txt
@@ -108,6 +108,12 @@ velox_add_cudf_test(
 )
 
 velox_add_cudf_test(
+  NAME velox_cudf_gpu_memory_plan_path_test
+  SOURCES Main.cpp GpuMemoryPlanPathTest.cpp
+  LIBS ${CUDF_TEST_DEFAULT_LIBS}
+)
+
+velox_add_cudf_test(
   NAME velox_cudf_decimal_aggregation_test
   SOURCES Main.cpp DecimalAggregationTest.cpp
   LIBS ${CUDF_TEST_DEFAULT_LIBS} velox_functions_test_lib

--- a/velox/experimental/cudf/tests/ConfigTest.cpp
+++ b/velox/experimental/cudf/tests/ConfigTest.cpp
@@ -20,10 +20,16 @@
 
 namespace facebook::velox::cudf_velox::test {
 
+TEST(ConfigTest, MemoryTrackingDisabledByDefault) {
+  CudfConfig config;
+  EXPECT_FALSE(config.memoryTrackingEnabled);
+}
+
 TEST(ConfigTest, CudfConfig) {
   std::unordered_map<std::string, std::string> options = {
       {CudfConfig::kCudfEnabled, "false"},
       {CudfConfig::kCudfDebugEnabled, "true"},
+      {CudfConfig::kCudfMemoryTrackingEnabled, "true"},
       {CudfConfig::kCudfMemoryResource, "arena"},
       {CudfConfig::kCudfMemoryPercent, "25"},
       {CudfConfig::kCudfFunctionNamePrefix, "presto"},
@@ -33,6 +39,7 @@ TEST(ConfigTest, CudfConfig) {
   config.initialize(std::move(options));
   ASSERT_EQ(config.enabled, false);
   ASSERT_EQ(config.debugEnabled, true);
+  ASSERT_EQ(config.memoryTrackingEnabled, true);
   ASSERT_EQ(config.memoryResource, "arena");
   ASSERT_EQ(config.memoryPercent, 25);
   ASSERT_EQ(config.functionNamePrefix, "presto");

--- a/velox/experimental/cudf/tests/GpuMemoryNvtxTest.cpp
+++ b/velox/experimental/cudf/tests/GpuMemoryNvtxTest.cpp
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/cudf/exec/GpuMemoryNvtx.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <thread>
+#include <vector>
+
+// These tests run without a profiler attached, so NVTX resolves its entry
+// points to no-ops and hands back id 0 for every counter it is asked to
+// register. What is exercised here is this module's own bookkeeping: that
+// registration is idempotent per owner, that a counter set carries the epoch it
+// was issued in, that a reset retires those sets, and that none of the entry
+// points throws or races. Whether Nsight renders the result can only be checked
+// against a real capture.
+
+namespace facebook::velox::cudf_velox {
+namespace {
+
+GpuMemoryOwner makeOwner(int32_t operatorId, std::string planNodeId = "3") {
+  GpuMemoryOwner owner;
+  owner.taskUuid = "task-uuid";
+  owner.taskId = "task-id.0.0.0";
+  owner.queryId = "query-1";
+  owner.planNodeId = std::move(planNodeId);
+  owner.planNodeType = "TableScanNode";
+  owner.pipelineId = 0;
+  owner.driverId = 0;
+  owner.operatorId = operatorId;
+  owner.operatorType = "TableScan";
+  return owner;
+}
+
+GpuMemoryPlanLocation makeLocation(std::string planNodeId = "3") {
+  GpuMemoryPlanLocation location;
+  location.path.push_back(
+      GpuMemoryPlanPathEntry{std::move(planNodeId), "TableScanNode"});
+  location.order = 0;
+  return location;
+}
+
+class GpuMemoryNvtxTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    resetGpuMemoryNvtxCounters();
+  }
+
+  void TearDown() override {
+    resetGpuMemoryNvtxCounters();
+  }
+};
+
+TEST_F(GpuMemoryNvtxTest, RegistrationIssuesACurrentEpoch) {
+  const auto counters =
+      registerGpuMemoryNvtxOwner(1, 10, makeOwner(1), makeLocation());
+  EXPECT_NE(counters.epoch, 0u)
+      << "a registered owner must be distinguishable from an unregistered one";
+}
+
+TEST_F(GpuMemoryNvtxTest, RegistrationIsIdempotentPerOwner) {
+  const auto first =
+      registerGpuMemoryNvtxOwner(1, 10, makeOwner(1), makeLocation());
+  const auto second =
+      registerGpuMemoryNvtxOwner(1, 10, makeOwner(1), makeLocation());
+
+  EXPECT_EQ(first.epoch, second.epoch);
+  EXPECT_EQ(first.ownerCounterId, second.ownerCounterId);
+  EXPECT_EQ(first.queryCounterId, second.queryCounterId);
+  EXPECT_EQ(first.planNodeCounterId, second.planNodeCounterId);
+}
+
+TEST_F(GpuMemoryNvtxTest, OwnersOfOneQueryShareTheirAncestorCounters) {
+  const auto first =
+      registerGpuMemoryNvtxOwner(1, 10, makeOwner(1), makeLocation());
+  const auto second =
+      registerGpuMemoryNvtxOwner(2, 10, makeOwner(2), makeLocation());
+
+  EXPECT_EQ(first.queryCounterId, second.queryCounterId);
+  EXPECT_EQ(first.taskCounterId, second.taskCounterId);
+  EXPECT_EQ(first.planNodeCounterId, second.planNodeCounterId)
+      << "same plan node key must resolve to one aggregate";
+}
+
+TEST_F(GpuMemoryNvtxTest, UnattributedOwnerHasNoAncestorCounters) {
+  const auto counters = registerGpuMemoryNvtxUnattributedOwner();
+
+  EXPECT_NE(counters.epoch, 0u);
+  EXPECT_EQ(counters.queryCounterId, 0u);
+  EXPECT_EQ(counters.taskCounterId, 0u);
+  EXPECT_EQ(counters.planNodeCounterId, 0u)
+      << "an allocation outside any operator belongs to no query or plan node";
+}
+
+TEST_F(GpuMemoryNvtxTest, ResetRetiresPreviouslyIssuedCounters) {
+  const auto before =
+      registerGpuMemoryNvtxOwner(1, 10, makeOwner(1), makeLocation());
+  resetGpuMemoryNvtxCounters();
+  const auto after =
+      registerGpuMemoryNvtxOwner(1, 10, makeOwner(1), makeLocation());
+
+  EXPECT_NE(before.epoch, after.epoch)
+      << "a set cached across a reset must stop sampling";
+
+  // Sampling a retired set is a no-op rather than a write into a counter that
+  // no longer has a scope.
+  GpuMemoryUpdate update;
+  update.ownerId = 1;
+  update.globalCurrentBytes = 1024;
+  sampleGpuMemoryNvtxCounters(before, update);
+  sampleGpuMemoryNvtxCounters(after, update);
+}
+
+TEST_F(GpuMemoryNvtxTest, SamplingAnUnregisteredSetIsANoOp) {
+  GpuMemoryUpdate update;
+  update.ownerId = 7;
+  update.globalCurrentBytes = 2048;
+  sampleGpuMemoryNvtxCounters(GpuMemoryNvtxCounters{}, update);
+}
+
+TEST_F(GpuMemoryNvtxTest, ConcurrentRegistrationAndSamplingAgree) {
+  constexpr int kThreads = 8;
+  constexpr int kPerThread = 500;
+
+  std::atomic<int> mismatches{0};
+  std::vector<std::thread> threads;
+  threads.reserve(kThreads);
+  for (int thread = 0; thread < kThreads; ++thread) {
+    threads.emplace_back([thread, &mismatches] {
+      const auto ownerId = static_cast<uint64_t>(thread + 1);
+      const auto expected = registerGpuMemoryNvtxOwner(
+          ownerId, 10, makeOwner(thread), makeLocation());
+      for (int i = 0; i < kPerThread; ++i) {
+        // Re-registering must keep returning the same set while other threads
+        // register and sample concurrently.
+        const auto counters = registerGpuMemoryNvtxOwner(
+            ownerId, 10, makeOwner(thread), makeLocation());
+        if (counters.ownerCounterId != expected.ownerCounterId ||
+            counters.epoch != expected.epoch) {
+          mismatches.fetch_add(1);
+        }
+        GpuMemoryUpdate update;
+        update.ownerId = ownerId;
+        update.globalCurrentBytes = static_cast<uint64_t>(i);
+        update.ownerCurrentBytes = static_cast<uint64_t>(i);
+        sampleGpuMemoryNvtxCounters(counters, update);
+      }
+    });
+  }
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  EXPECT_EQ(mismatches.load(), 0);
+}
+
+TEST_F(GpuMemoryNvtxTest, MarkersDoNotThrow) {
+  markGpuMemoryDataLoss("test reason");
+
+  GpuMemoryUpdate state;
+  state.ownerId = 1;
+  state.globalCurrentBytes = 4096;
+  markGpuMemoryAllocationFailure(1, 512, state, 128, 4096, "cudaSuccess");
+}
+
+} // namespace
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/tests/GpuMemoryPlanPathTest.cpp
+++ b/velox/experimental/cudf/tests/GpuMemoryPlanPathTest.cpp
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/cudf/exec/GpuMemoryPlanPath.h"
+
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec::test;
+
+namespace facebook::velox::cudf_velox::test {
+
+class GpuMemoryPlanPathTest : public OperatorTestBase {
+ protected:
+  /// Returns the plan node identifiers along a resolved chain, which is the
+  /// order the counter hierarchy nests by.
+  static std::vector<std::string> ids(const GpuMemoryPlanLocation& location) {
+    std::vector<std::string> result;
+    result.reserve(location.path.size());
+    for (const auto& entry : location.path) {
+      result.push_back(entry.planNodeId);
+    }
+    return result;
+  }
+
+  RowVectorPtr makeInput() {
+    return makeRowVector(
+        {makeFlatVector<int64_t>(10, [](auto row) { return row; })});
+  }
+};
+
+TEST_F(GpuMemoryPlanPathTest, resolvesEachNodeToItsChainAndDisplayType) {
+  auto idGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  core::PlanNodeId valuesId;
+  core::PlanNodeId filterId;
+  const auto plan = PlanBuilder(idGenerator)
+                        .values({makeInput()})
+                        .capturePlanNodeId(valuesId)
+                        .filter("c0 > 0")
+                        .capturePlanNodeId(filterId)
+                        .planNode();
+
+  EXPECT_EQ(
+      ids(gpuMemoryPlanLocationFromRoot(plan.get(), filterId)),
+      (std::vector<std::string>{filterId}));
+
+  const auto values = gpuMemoryPlanLocationFromRoot(plan.get(), valuesId);
+  EXPECT_EQ(ids(values), (std::vector<std::string>{filterId, valuesId}));
+  // The display type is what the counter label carries.
+  EXPECT_EQ(values.node()->planNodeType, "ValuesNode");
+}
+
+/// A node with several sources is where the operator-instance graph stops being
+/// a tree, so both branches must resolve to chains that share only the common
+/// prefix. This is what lets fan-in become sibling leaves in the counter tree.
+TEST_F(GpuMemoryPlanPathTest, multipleSourcesResolveThroughTheirOwnBranch) {
+  auto idGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  core::PlanNodeId leftId;
+  core::PlanNodeId rightId;
+  core::PlanNodeId partitionId;
+
+  auto left = PlanBuilder(idGenerator)
+                  .values({makeInput()})
+                  .capturePlanNodeId(leftId)
+                  .planNode();
+  auto right = PlanBuilder(idGenerator)
+                   .values({makeInput()})
+                   .capturePlanNodeId(rightId)
+                   .planNode();
+  const auto plan = PlanBuilder(idGenerator)
+                        .localPartition({}, {left, right})
+                        .capturePlanNodeId(partitionId)
+                        .planNode();
+
+  EXPECT_EQ(
+      ids(gpuMemoryPlanLocationFromRoot(plan.get(), leftId)),
+      (std::vector<std::string>{partitionId, leftId}));
+  EXPECT_EQ(
+      ids(gpuMemoryPlanLocationFromRoot(plan.get(), rightId)),
+      (std::vector<std::string>{partitionId, rightId}));
+
+  // Sources are walked left to right, and both sit one level below the parent.
+  EXPECT_EQ(gpuMemoryPlanLocationFromRoot(plan.get(), partitionId).order, 0);
+  EXPECT_EQ(gpuMemoryPlanLocationFromRoot(plan.get(), leftId).order, 1);
+  EXPECT_EQ(gpuMemoryPlanLocationFromRoot(plan.get(), rightId).order, 2);
+  EXPECT_EQ(gpuMemoryPlanLocationFromRoot(plan.get(), leftId).depth(), 1);
+  EXPECT_EQ(gpuMemoryPlanLocationFromRoot(plan.get(), rightId).depth(), 1);
+}
+
+TEST_F(GpuMemoryPlanPathTest, conversionSuffixesResolveThroughSourceNode) {
+  auto idGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  core::PlanNodeId valuesId;
+  const auto plan = PlanBuilder(idGenerator)
+                        .values({makeInput()})
+                        .capturePlanNodeId(valuesId)
+                        .planNode();
+
+  for (const std::string suffix : {"-from-velox", "-to-velox"}) {
+    const auto location =
+        gpuMemoryPlanLocationFromRoot(plan.get(), valuesId + suffix);
+    ASSERT_EQ(location.path.size(), 1) << "suffix " << suffix;
+    EXPECT_EQ(location.node()->planNodeId, valuesId) << "suffix " << suffix;
+  }
+}
+
+TEST_F(GpuMemoryPlanPathTest, unresolvableIdentifiersReportUnmapped) {
+  auto idGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  const auto plan = PlanBuilder(idGenerator).values({makeInput()}).planNode();
+
+  // An unknown identifier, an unknown identifier that still carries a
+  // conversion suffix, an empty identifier, and an absent plan fragment all
+  // report an empty chain rather than guessing a place in the hierarchy.
+  for (const auto* id : {"no-such-node", "no-such-node-to-velox", ""}) {
+    const auto location = gpuMemoryPlanLocationFromRoot(plan.get(), id);
+    EXPECT_TRUE(location.path.empty()) << "id " << id;
+    EXPECT_EQ(location.node(), nullptr) << "id " << id;
+    // Not given a plausible-looking position either.
+    EXPECT_EQ(location.order, -1) << "id " << id;
+  }
+  EXPECT_TRUE(gpuMemoryPlanLocationFromRoot(nullptr, "0").path.empty());
+}
+
+/// The plan node label is sorted lexically by Nsight, so the pre-order index
+/// and depth are what reproduce EXPLAIN order and nesting in a flat row list.
+TEST_F(GpuMemoryPlanPathTest, reportsPreOrderIndexAndDepth) {
+  auto idGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  core::PlanNodeId valuesId;
+  core::PlanNodeId filterId;
+  core::PlanNodeId projectId;
+  const auto plan = PlanBuilder(idGenerator)
+                        .values({makeInput()})
+                        .capturePlanNodeId(valuesId)
+                        .filter("c0 > 0")
+                        .capturePlanNodeId(filterId)
+                        .project({"c0"})
+                        .capturePlanNodeId(projectId)
+                        .planNode();
+
+  // Pre-order from the fragment root: project, filter, values.
+  const auto project = gpuMemoryPlanLocationFromRoot(plan.get(), projectId);
+  EXPECT_EQ(project.order, 0);
+  EXPECT_EQ(project.depth(), 0);
+
+  const auto filter = gpuMemoryPlanLocationFromRoot(plan.get(), filterId);
+  EXPECT_EQ(filter.order, 1);
+  EXPECT_EQ(filter.depth(), 1);
+
+  const auto values = gpuMemoryPlanLocationFromRoot(plan.get(), valuesId);
+  EXPECT_EQ(values.order, 2);
+  EXPECT_EQ(values.depth(), 2);
+}
+
+} // namespace facebook::velox::cudf_velox::test

--- a/velox/experimental/cudf/tests/GpuMemoryTrackerTest.cpp
+++ b/velox/experimental/cudf/tests/GpuMemoryTrackerTest.cpp
@@ -1,0 +1,713 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/cudf/exec/GpuMemoryTracker.h"
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_buffer.hpp>
+#include <rmm/error.hpp>
+#include <rmm/resource_ref.hpp>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#pragma GCC diagnostic pop
+
+#include <folly/ScopeGuard.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <condition_variable>
+#include <cstddef>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace facebook::velox::cudf_velox::test {
+namespace {
+
+struct RecordingResourceState {
+  std::mutex mutex;
+  std::vector<std::size_t> allocationAlignments;
+  std::vector<std::size_t> deallocationAlignments;
+  bool throwOnAllocation{false};
+};
+
+class RecordingResource {
+ public:
+  explicit RecordingResource(std::shared_ptr<RecordingResourceState> state)
+      : state_(std::move(state)) {}
+
+  void* allocate(
+      cuda::stream_ref /*stream*/,
+      std::size_t bytes,
+      std::size_t alignment) {
+    return allocateImpl(bytes, alignment);
+  }
+
+  void deallocate(
+      cuda::stream_ref /*stream*/,
+      void* address,
+      std::size_t /*bytes*/,
+      std::size_t alignment) noexcept {
+    {
+      std::lock_guard<std::mutex> lock(state_->mutex);
+      state_->deallocationAlignments.push_back(alignment);
+    }
+    std::free(address);
+  }
+
+  void* allocate_sync(std::size_t bytes, std::size_t alignment) {
+    return allocateImpl(bytes, alignment);
+  }
+
+  void deallocate_sync(
+      void* address,
+      std::size_t /*bytes*/,
+      std::size_t alignment) noexcept {
+    {
+      std::lock_guard<std::mutex> lock(state_->mutex);
+      state_->deallocationAlignments.push_back(alignment);
+    }
+    std::free(address);
+  }
+
+  bool operator==(const RecordingResource& other) const noexcept {
+    return state_ == other.state_;
+  }
+
+  bool operator!=(const RecordingResource& other) const noexcept {
+    return !(*this == other);
+  }
+
+  friend void get_property(
+      const RecordingResource&,
+      cuda::mr::device_accessible) noexcept {}
+
+ private:
+  void* allocateImpl(std::size_t bytes, std::size_t alignment) {
+    {
+      std::lock_guard<std::mutex> lock(state_->mutex);
+      state_->allocationAlignments.push_back(alignment);
+      if (state_->throwOnAllocation) {
+        throw rmm::out_of_memory("deterministic test allocation failure");
+      }
+    }
+
+    const auto allocationSize =
+        std::max(alignment, ((bytes + alignment - 1) / alignment) * alignment);
+    auto* address = std::aligned_alloc(alignment, allocationSize);
+    if (address == nullptr) {
+      throw rmm::out_of_memory("host allocation failed in test resource");
+    }
+    return address;
+  }
+
+  std::shared_ptr<RecordingResourceState> state_;
+};
+
+static_assert(
+    cuda::mr::resource_with<RecordingResource, cuda::mr::device_accessible>);
+
+struct AddressReusingResourceState {
+  std::mutex mutex;
+  std::condition_variable condition;
+  bool allocated{false};
+  bool blockNextDeallocation{true};
+  bool addressFreed{false};
+  bool releaseDeallocation{false};
+  alignas(256) std::array<std::byte, 256> storage;
+};
+
+class AddressReusingResource {
+ public:
+  explicit AddressReusingResource(
+      std::shared_ptr<AddressReusingResourceState> state)
+      : state_(std::move(state)) {}
+
+  void* allocate(
+      cuda::stream_ref /*stream*/,
+      std::size_t /*bytes*/,
+      std::size_t /*alignment*/) {
+    return allocateImpl();
+  }
+
+  void deallocate(
+      cuda::stream_ref /*stream*/,
+      void* address,
+      std::size_t /*bytes*/,
+      std::size_t /*alignment*/) noexcept {
+    deallocateImpl(address);
+  }
+
+  void* allocate_sync(std::size_t /*bytes*/, std::size_t /*alignment*/) {
+    return allocateImpl();
+  }
+
+  void deallocate_sync(
+      void* address,
+      std::size_t /*bytes*/,
+      std::size_t /*alignment*/) noexcept {
+    deallocateImpl(address);
+  }
+
+  bool operator==(const AddressReusingResource& other) const noexcept {
+    return state_ == other.state_;
+  }
+
+  bool operator!=(const AddressReusingResource& other) const noexcept {
+    return !(*this == other);
+  }
+
+  friend void get_property(
+      const AddressReusingResource&,
+      cuda::mr::device_accessible) noexcept {}
+
+ private:
+  void* allocateImpl() {
+    std::unique_lock<std::mutex> lock(state_->mutex);
+    state_->condition.wait(lock, [&] { return !state_->allocated; });
+    state_->allocated = true;
+    return state_->storage.data();
+  }
+
+  void deallocateImpl(void* address) noexcept {
+    std::unique_lock<std::mutex> lock(state_->mutex);
+    if (address != state_->storage.data()) {
+      std::terminate();
+    }
+    state_->allocated = false;
+    if (state_->blockNextDeallocation) {
+      state_->blockNextDeallocation = false;
+      state_->addressFreed = true;
+      state_->condition.notify_all();
+      state_->condition.wait(lock, [&] { return state_->releaseDeallocation; });
+    }
+    state_->condition.notify_all();
+  }
+
+  std::shared_ptr<AddressReusingResourceState> state_;
+};
+
+static_assert(cuda::mr::resource_with<
+              AddressReusingResource,
+              cuda::mr::device_accessible>);
+
+GpuMemoryOwner makeOwner(
+    std::string taskSuffix,
+    std::string planNodeId,
+    int32_t pipelineId,
+    int32_t driverId,
+    int32_t operatorId) {
+  return GpuMemoryOwner{
+      .taskUuid = "task-" + taskSuffix + "-uuid",
+      .taskId = "task-" + taskSuffix,
+      .queryId = "query-" + taskSuffix,
+      .planNodeId = std::move(planNodeId),
+      .planNodeType = "TestPlanNode",
+      .pipelineId = pipelineId,
+      .driverId = driverId,
+      .operatorId = operatorId,
+      .operatorType = "TestOperator"};
+}
+
+const GpuMemoryOwnerSnapshot* findOwner(
+    const GpuMemorySnapshot& snapshot,
+    GpuMemoryOwnerHandle handle) {
+  const auto it = std::find_if(
+      snapshot.owners.begin(), snapshot.owners.end(), [&](const auto& owner) {
+        return owner.handle == handle;
+      });
+  return it == snapshot.owners.end() ? nullptr : &*it;
+}
+
+/// Holds once activity quiesces. The allocation path takes no shared lock, so
+/// it does not hold instant by instant while allocations are in flight.
+bool isCoherent(const GpuMemorySnapshot& snapshot) {
+  uint64_t ownerBytes{0};
+  for (const auto& owner : snapshot.owners) {
+    ownerBytes += owner.currentBytes;
+  }
+  return snapshot.currentBytes == ownerBytes;
+}
+
+} // namespace
+
+TEST(GpuMemoryTrackerTest, TracksAllocationOriginAndOrderedTransitions) {
+  GpuMemoryLedger tracker;
+  const auto ownerA = makeOwner("shared", "plan-a", 1, 7, 2);
+  auto ownerB = ownerA;
+  ownerB.driverId = 8;
+
+  const auto handleA = tracker.registerOwner(ownerA);
+  const auto duplicateHandleA = tracker.registerOwner(ownerA);
+  const auto handleB = tracker.registerOwner(ownerB);
+  EXPECT_EQ(duplicateHandleA, handleA);
+  EXPECT_NE(handleB.ownerId, handleA.ownerId);
+  auto relabeledOwnerA = ownerA;
+  relabeledOwnerA.planNodeType = "RelabeledPlanNode";
+  EXPECT_EQ(tracker.registerOwner(relabeledOwnerA), handleA);
+  EXPECT_EQ(handleB.planNodeKey, handleA.planNodeKey);
+
+  auto otherTaskOwner = ownerA;
+  otherTaskOwner.taskUuid = "other-task-uuid";
+  otherTaskOwner.taskId = "other-task";
+  const auto otherTaskHandle = tracker.registerOwner(otherTaskOwner);
+  EXPECT_NE(otherTaskHandle.planNodeKey, handleA.planNodeKey);
+
+  int allocationA;
+  int allocationB;
+  const auto first = tracker.recordAllocation(&allocationA, 100, handleA);
+  ASSERT_TRUE(first.has_value());
+  EXPECT_EQ(first->ownerId, handleA.ownerId);
+  EXPECT_EQ(first->planNodeKey, handleA.planNodeKey);
+  EXPECT_EQ(first->globalCurrentBytes, 100);
+  EXPECT_EQ(first->globalPeakBytes, 100);
+  EXPECT_EQ(first->queryCurrentBytes, 100);
+  EXPECT_EQ(first->taskCurrentBytes, 100);
+  EXPECT_EQ(first->planNodeCurrentBytes, 100);
+  EXPECT_EQ(first->ownerCurrentBytes, 100);
+
+  const auto second = tracker.recordAllocation(&allocationB, 60, handleB);
+  ASSERT_TRUE(second.has_value());
+  EXPECT_EQ(second->globalCurrentBytes, 160);
+  EXPECT_EQ(second->globalPeakBytes, 160);
+  EXPECT_EQ(second->queryCurrentBytes, 160);
+  EXPECT_EQ(second->taskCurrentBytes, 160);
+  EXPECT_EQ(second->planNodeCurrentBytes, 160);
+  EXPECT_EQ(second->ownerCurrentBytes, 60);
+
+  std::optional<GpuMemoryUpdate> deallocation;
+  std::thread orphanDeallocator(
+      [&] { deallocation = tracker.recordDeallocation(&allocationA, 100); });
+  orphanDeallocator.join();
+
+  ASSERT_TRUE(deallocation.has_value());
+  EXPECT_EQ(deallocation->ownerId, handleA.ownerId);
+  EXPECT_EQ(deallocation->planNodeKey, handleA.planNodeKey);
+  EXPECT_EQ(deallocation->globalCurrentBytes, 60);
+  EXPECT_EQ(deallocation->globalPeakBytes, 160);
+  EXPECT_EQ(deallocation->queryCurrentBytes, 60);
+  EXPECT_EQ(deallocation->taskCurrentBytes, 60);
+  EXPECT_EQ(deallocation->planNodeCurrentBytes, 60);
+  EXPECT_EQ(deallocation->ownerCurrentBytes, 0);
+
+  const auto snapshot = tracker.snapshot();
+  EXPECT_TRUE(isCoherent(snapshot));
+  EXPECT_EQ(snapshot.currentBytes, 60);
+  EXPECT_EQ(snapshot.peakBytes, 160);
+  EXPECT_EQ(snapshot.totalBytes, 160);
+  EXPECT_EQ(snapshot.dataLossEvents, 0);
+
+  const auto* ownerASnapshot = findOwner(snapshot, handleA);
+  ASSERT_NE(ownerASnapshot, nullptr);
+  EXPECT_EQ(ownerASnapshot->currentBytes, 0);
+  EXPECT_EQ(ownerASnapshot->peakBytes, 100);
+  EXPECT_EQ(ownerASnapshot->totalBytes, 100);
+
+  const auto* ownerBSnapshot = findOwner(snapshot, handleB);
+  ASSERT_NE(ownerBSnapshot, nullptr);
+  EXPECT_EQ(ownerBSnapshot->currentBytes, 60);
+  EXPECT_EQ(ownerBSnapshot->peakBytes, 60);
+  EXPECT_EQ(ownerBSnapshot->totalBytes, 60);
+
+  const auto final = tracker.recordDeallocation(&allocationB, 60);
+  ASSERT_TRUE(final.has_value());
+  EXPECT_EQ(final->globalCurrentBytes, 0);
+  EXPECT_EQ(final->queryCurrentBytes, 0);
+  EXPECT_EQ(final->taskCurrentBytes, 0);
+  EXPECT_EQ(final->planNodeCurrentBytes, 0);
+  EXPECT_EQ(final->ownerCurrentBytes, 0);
+}
+
+/// Why no retirement list is needed: rmm::device_buffer stores an owning
+/// any_resource, so the wrapper, ledger and upstream all outlive unregistration
+/// for as long as something holds memory from them. Freeing through the buffer
+/// after the reset is what faults if that ever stops being true.
+TEST(GpuMemoryTrackerTest, BufferOutlivesTheResourceThatIsReset) {
+  auto state = std::make_shared<RecordingResourceState>();
+  std::optional<rmm::device_buffer> buffer;
+  {
+    auto resources = createGpuMemoryTrackingResources(
+        cuda::mr::any_resource<cuda::mr::device_accessible>{
+            RecordingResource{state}},
+        cuda::mr::any_resource<cuda::mr::device_accessible>{
+            RecordingResource{state}});
+    buffer.emplace(256, rmm::cuda_stream_default, resources.main);
+    EXPECT_EQ(getGpuMemorySnapshot().currentBytes, 256);
+
+    resetGpuMemoryTracking();
+    // Both wrappers go out of scope here while the buffer still holds memory.
+  }
+
+  EXPECT_EQ(getGpuMemorySnapshot().currentBytes, 0)
+      << "the reset ledger is no longer the process-wide one";
+  // Frees through the resource the buffer still owns.
+  buffer.reset();
+
+  std::lock_guard<std::mutex> lock(state->mutex);
+  EXPECT_EQ(state->allocationAlignments.size(), 1);
+  EXPECT_EQ(state->deallocationAlignments.size(), 1)
+      << "the upstream must still have been reachable to free through";
+}
+
+/// Velox permits an empty query identifier, and two unrelated queries would
+/// otherwise share one set of query counters whose total means neither.
+TEST(GpuMemoryTrackerTest, TasksWithNoQueryIdKeepSeparateQueryCounters) {
+  GpuMemoryLedger ledger;
+  auto ownerA = makeOwner("a", "plan-a", 1, 0, 2);
+  ownerA.queryId = "";
+  auto ownerB = makeOwner("b", "plan-b", 1, 0, 2);
+  ownerB.queryId = "";
+
+  const auto handleA = ledger.registerOwner(ownerA);
+  const auto handleB = ledger.registerOwner(ownerB);
+
+  int allocationA;
+  int allocationB;
+  const auto first = ledger.recordAllocation(&allocationA, 100, handleA);
+  ASSERT_TRUE(first.has_value());
+  const auto second = ledger.recordAllocation(&allocationB, 60, handleB);
+  ASSERT_TRUE(second.has_value());
+
+  EXPECT_EQ(first->queryCurrentBytes, 100);
+  EXPECT_EQ(second->queryCurrentBytes, 60)
+      << "the second task must not accumulate onto the first task's query";
+}
+
+TEST(GpuMemoryTrackerTest, TracksQueryAndTaskAggregates) {
+  GpuMemoryLedger tracker;
+  const auto ownerA = makeOwner("shared", "plan-a", 1, 7, 2);
+  auto ownerB = ownerA;
+  ownerB.taskUuid = "task-other-uuid";
+  ownerB.taskId = "task-other";
+  ownerB.planNodeId = "plan-b";
+
+  const auto handleA = tracker.registerOwner(ownerA);
+  const auto handleB = tracker.registerOwner(ownerB);
+  int allocationA;
+  int allocationB;
+
+  const auto first = tracker.recordAllocation(&allocationA, 100, handleA);
+  ASSERT_TRUE(first.has_value());
+  EXPECT_EQ(first->queryCurrentBytes, 100);
+  EXPECT_EQ(first->taskCurrentBytes, 100);
+
+  const auto second = tracker.recordAllocation(&allocationB, 60, handleB);
+  ASSERT_TRUE(second.has_value());
+  EXPECT_EQ(second->queryCurrentBytes, 160);
+  EXPECT_EQ(second->taskCurrentBytes, 60);
+  EXPECT_EQ(second->planNodeCurrentBytes, 60);
+
+  const auto firstDeallocation = tracker.recordDeallocation(&allocationA, 100);
+  ASSERT_TRUE(firstDeallocation.has_value());
+  EXPECT_EQ(firstDeallocation->queryCurrentBytes, 60);
+  EXPECT_EQ(firstDeallocation->taskCurrentBytes, 0);
+
+  const auto secondDeallocation = tracker.recordDeallocation(&allocationB, 60);
+  ASSERT_TRUE(secondDeallocation.has_value());
+  EXPECT_EQ(secondDeallocation->queryCurrentBytes, 0);
+  EXPECT_EQ(secondDeallocation->taskCurrentBytes, 0);
+}
+
+/// Every counter must be exact as its own sequence of transitions: once
+/// activity quiesces, live bytes return to zero and totals match what was
+/// allocated.
+TEST(GpuMemoryTrackerTest, ConcurrentAllocationsReconcileAtQuiescence) {
+  constexpr int kThreads = 8;
+  constexpr int kPerThread = 2'000;
+  constexpr uint64_t kBytes = 64;
+
+  GpuMemoryLedger ledger;
+  std::vector<GpuMemoryOwnerHandle> handles;
+  for (int driver = 0; driver < kThreads; ++driver) {
+    handles.push_back(
+        ledger.registerOwner(makeOwner("concurrent", "plan-a", 1, driver, 2)));
+  }
+
+  std::vector<std::thread> threads;
+  threads.reserve(kThreads);
+  for (int thread = 0; thread < kThreads; ++thread) {
+    threads.emplace_back([&, thread] {
+      std::vector<std::unique_ptr<char[]>> storage;
+      storage.reserve(kPerThread);
+      for (int i = 0; i < kPerThread; ++i) {
+        storage.push_back(std::make_unique<char[]>(kBytes));
+        EXPECT_TRUE(
+            ledger
+                .recordAllocation(storage.back().get(), kBytes, handles[thread])
+                .has_value());
+      }
+      for (auto& allocation : storage) {
+        EXPECT_TRUE(
+            ledger.recordDeallocation(allocation.get(), kBytes).has_value());
+      }
+    });
+  }
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  const auto snapshot = ledger.snapshot();
+  EXPECT_EQ(snapshot.currentBytes, 0);
+  EXPECT_EQ(snapshot.dataLossEvents, 0);
+  EXPECT_EQ(snapshot.totalBytes, kThreads * kPerThread * kBytes);
+  EXPECT_LE(snapshot.peakBytes, snapshot.totalBytes);
+  EXPECT_GT(snapshot.peakBytes, 0);
+
+  for (const auto& handle : handles) {
+    const auto* owner = findOwner(snapshot, handle);
+    ASSERT_NE(owner, nullptr);
+    EXPECT_EQ(owner->currentBytes, 0);
+    EXPECT_EQ(owner->totalBytes, kPerThread * kBytes);
+  }
+}
+
+TEST(GpuMemoryTrackerTest, DeallocationSizeMismatchIsReportedAsDataLoss) {
+  GpuMemoryLedger ledger;
+  const auto handle =
+      ledger.registerOwner(makeOwner("mismatch", "plan-a", 1, 2, 3));
+
+  int allocation;
+  ASSERT_TRUE(ledger.recordAllocation(&allocation, 1'024, handle).has_value());
+  ASSERT_TRUE(ledger.recordDeallocation(&allocation, 2'048).has_value());
+
+  const auto snapshot = ledger.snapshot();
+  EXPECT_EQ(snapshot.dataLossEvents, 1);
+  // The recorded size is used for the debit, so the ledger still balances.
+  EXPECT_EQ(snapshot.currentBytes, 0);
+}
+
+TEST(GpuMemoryTrackerTest, InvalidPointerEventsDoNotCorruptLedger) {
+  GpuMemoryLedger tracker;
+  const auto handle =
+      tracker.registerOwner(makeOwner("invalid", "plan-a", 1, 2, 3));
+
+  int allocation;
+  ASSERT_TRUE(tracker.recordAllocation(&allocation, 64, handle).has_value());
+  EXPECT_FALSE(tracker.recordAllocation(&allocation, 128, handle).has_value());
+
+  int unknownAllocation;
+  EXPECT_FALSE(tracker.recordDeallocation(&unknownAllocation, 32).has_value());
+
+  auto snapshot = tracker.snapshot();
+  EXPECT_TRUE(isCoherent(snapshot));
+  EXPECT_EQ(snapshot.currentBytes, 64);
+  EXPECT_EQ(snapshot.dataLossEvents, 2);
+
+  ASSERT_TRUE(tracker.recordDeallocation(&allocation, 64).has_value());
+  snapshot = tracker.snapshot();
+  EXPECT_TRUE(isCoherent(snapshot));
+  EXPECT_EQ(snapshot.currentBytes, 0);
+  EXPECT_EQ(snapshot.dataLossEvents, 2);
+}
+
+TEST(GpuMemoryTrackerTest, TrackedResourcesShareCombinedSnapshot) {
+  auto mainState = std::make_shared<RecordingResourceState>();
+  auto outputState = std::make_shared<RecordingResourceState>();
+  auto resources = createGpuMemoryTrackingResources(
+      cuda::mr::any_resource<cuda::mr::device_accessible>{
+          RecordingResource{mainState}},
+      cuda::mr::any_resource<cuda::mr::device_accessible>{
+          RecordingResource{outputState}});
+  auto resetGuard = folly::makeGuard([] { resetGpuMemoryTracking(); });
+
+  auto mainResource = rmm::device_async_resource_ref{resources.main};
+  auto outputResource = rmm::device_async_resource_ref{resources.output};
+  auto* mainAddress = mainResource.allocate(rmm::cuda_stream_default, 256, 256);
+  auto* outputAddress =
+      outputResource.allocate(rmm::cuda_stream_default, 512, 256);
+
+  auto snapshot = getGpuMemorySnapshot();
+  EXPECT_TRUE(isCoherent(snapshot));
+  EXPECT_EQ(snapshot.currentBytes, 768);
+  EXPECT_EQ(snapshot.peakBytes, 768);
+  EXPECT_EQ(snapshot.totalBytes, 768);
+
+  mainResource.deallocate(rmm::cuda_stream_default, mainAddress, 256, 256);
+  outputResource.deallocate(rmm::cuda_stream_default, outputAddress, 512, 256);
+
+  snapshot = getGpuMemorySnapshot();
+  EXPECT_TRUE(isCoherent(snapshot));
+  EXPECT_EQ(snapshot.currentBytes, 0);
+  EXPECT_EQ(snapshot.peakBytes, 768);
+}
+
+TEST(GpuMemoryTrackerTest, PreservesAllocationAlignment) {
+  auto state = std::make_shared<RecordingResourceState>();
+  auto upstream = cuda::mr::any_resource<cuda::mr::device_accessible>{
+      RecordingResource{state}};
+  auto outputUpstream = upstream;
+  auto resources = createGpuMemoryTrackingResources(
+      std::move(upstream), std::move(outputUpstream));
+  auto resetGuard = folly::makeGuard([] { resetGpuMemoryTracking(); });
+
+  constexpr std::size_t kAlignment = 4'096;
+  auto resource = rmm::device_async_resource_ref{resources.main};
+  auto* address = resource.allocate(rmm::cuda_stream_default, 64, kAlignment);
+  resource.deallocate(rmm::cuda_stream_default, address, 64, kAlignment);
+
+  std::lock_guard<std::mutex> lock(state->mutex);
+  ASSERT_EQ(state->allocationAlignments.size(), 1);
+  EXPECT_EQ(state->allocationAlignments.front(), kAlignment);
+  ASSERT_EQ(state->deallocationAlignments.size(), 1);
+  EXPECT_EQ(state->deallocationAlignments.front(), kAlignment);
+}
+
+TEST(GpuMemoryTrackerTest, ZeroSizeAllocationIsUntracked) {
+  auto state = std::make_shared<RecordingResourceState>();
+  auto upstream = cuda::mr::any_resource<cuda::mr::device_accessible>{
+      RecordingResource{state}};
+  auto outputUpstream = upstream;
+  auto resources = createGpuMemoryTrackingResources(
+      std::move(upstream), std::move(outputUpstream));
+  auto resetGuard = folly::makeGuard([] { resetGpuMemoryTracking(); });
+
+  auto resource = rmm::device_async_resource_ref{resources.main};
+  auto* address = resource.allocate(rmm::cuda_stream_default, 0, 256);
+  EXPECT_EQ(address, nullptr);
+  resource.deallocate(rmm::cuda_stream_default, address, 0, 256);
+
+  const auto snapshot = getGpuMemorySnapshot();
+  EXPECT_TRUE(isCoherent(snapshot));
+  EXPECT_EQ(snapshot.currentBytes, 0);
+  EXPECT_EQ(snapshot.dataLossEvents, 0);
+
+  std::lock_guard<std::mutex> lock(state->mutex);
+  EXPECT_TRUE(state->allocationAlignments.empty());
+  EXPECT_TRUE(state->deallocationAlignments.empty());
+}
+
+/// Exercises the wrapper rather than the ledger: this is the path that resolves
+/// an owner from the thread-local cache.
+TEST(GpuMemoryTrackerTest, ConcurrentWrapperUseReconciles) {
+  auto mainState = std::make_shared<RecordingResourceState>();
+  auto outputState = std::make_shared<RecordingResourceState>();
+  auto resources = createGpuMemoryTrackingResources(
+      cuda::mr::any_resource<cuda::mr::device_accessible>{
+          RecordingResource{mainState}},
+      cuda::mr::any_resource<cuda::mr::device_accessible>{
+          RecordingResource{outputState}});
+  auto resetGuard = folly::makeGuard([] { resetGpuMemoryTracking(); });
+
+  auto mainResource = rmm::device_async_resource_ref{resources.main};
+  auto outputResource = rmm::device_async_resource_ref{resources.output};
+
+  constexpr int kWorkerCount = 4;
+  constexpr int kIterations = 2'000;
+  std::vector<std::thread> workers;
+  workers.reserve(kWorkerCount);
+  for (int worker = 0; worker < kWorkerCount; ++worker) {
+    workers.emplace_back([&, worker] {
+      for (int iteration = 0; iteration < kIterations; ++iteration) {
+        auto resource =
+            ((worker + iteration) % 2 == 0) ? mainResource : outputResource;
+        const std::size_t bytes = 64 + (iteration % 4) * 64;
+        auto* address = resource.allocate(rmm::cuda_stream_default, bytes, 256);
+        resource.deallocate(rmm::cuda_stream_default, address, bytes, 256);
+      }
+    });
+  }
+  for (auto& worker : workers) {
+    worker.join();
+  }
+
+  const auto snapshot = getGpuMemorySnapshot();
+  EXPECT_TRUE(isCoherent(snapshot));
+  EXPECT_EQ(snapshot.currentBytes, 0);
+  EXPECT_EQ(snapshot.liveAllocations, 0);
+  EXPECT_EQ(snapshot.dataLossEvents, 0);
+}
+
+TEST(GpuMemoryTrackerTest, ReusedAddressKeepsReplacementAllocation) {
+  auto state = std::make_shared<AddressReusingResourceState>();
+  auto upstream = cuda::mr::any_resource<cuda::mr::device_accessible>{
+      AddressReusingResource{state}};
+  auto outputUpstream = upstream;
+  auto resources = createGpuMemoryTrackingResources(
+      std::move(upstream), std::move(outputUpstream));
+  auto resetGuard = folly::makeGuard([] { resetGpuMemoryTracking(); });
+
+  auto mainResource = rmm::device_async_resource_ref{resources.main};
+  auto outputResource = rmm::device_async_resource_ref{resources.output};
+  auto* originalAddress =
+      mainResource.allocate(rmm::cuda_stream_default, 64, 256);
+
+  std::thread deallocator([&] {
+    mainResource.deallocate(rmm::cuda_stream_default, originalAddress, 64, 256);
+  });
+  {
+    std::unique_lock<std::mutex> lock(state->mutex);
+    state->condition.wait(lock, [&] { return state->addressFreed; });
+  }
+
+  auto* replacementAddress =
+      outputResource.allocate(rmm::cuda_stream_default, 128, 256);
+  {
+    std::lock_guard<std::mutex> lock(state->mutex);
+    state->releaseDeallocation = true;
+  }
+  state->condition.notify_all();
+  deallocator.join();
+
+  ASSERT_EQ(replacementAddress, originalAddress);
+  const auto replacementSnapshot = getGpuMemorySnapshot();
+  EXPECT_TRUE(isCoherent(replacementSnapshot));
+  EXPECT_EQ(replacementSnapshot.currentBytes, 128);
+  EXPECT_EQ(replacementSnapshot.dataLossEvents, 0);
+
+  outputResource.deallocate(
+      rmm::cuda_stream_default, replacementAddress, 128, 256);
+  const auto finalSnapshot = getGpuMemorySnapshot();
+  EXPECT_TRUE(isCoherent(finalSnapshot));
+  EXPECT_EQ(finalSnapshot.currentBytes, 0);
+}
+
+TEST(GpuMemoryTrackerTest, AllocationFailureRethrowsWithoutCounting) {
+  auto failingState = std::make_shared<RecordingResourceState>();
+  failingState->throwOnAllocation = true;
+  auto outputState = std::make_shared<RecordingResourceState>();
+  auto resources = createGpuMemoryTrackingResources(
+      cuda::mr::any_resource<cuda::mr::device_accessible>{
+          RecordingResource{failingState}},
+      cuda::mr::any_resource<cuda::mr::device_accessible>{
+          RecordingResource{outputState}});
+  auto resetGuard = folly::makeGuard([] { resetGpuMemoryTracking(); });
+
+  constexpr std::size_t kAlignment = 4'096;
+  auto resource = rmm::device_async_resource_ref{resources.main};
+  EXPECT_THROW(
+      resource.allocate(rmm::cuda_stream_default, 1'234, kAlignment),
+      rmm::out_of_memory);
+
+  {
+    std::lock_guard<std::mutex> lock(failingState->mutex);
+    ASSERT_EQ(failingState->allocationAlignments.size(), 1);
+    EXPECT_EQ(failingState->allocationAlignments.front(), kAlignment);
+  }
+
+  const auto snapshot = getGpuMemorySnapshot();
+  EXPECT_TRUE(isCoherent(snapshot));
+  EXPECT_EQ(snapshot.currentBytes, 0);
+  EXPECT_EQ(snapshot.peakBytes, 0);
+  EXPECT_EQ(snapshot.totalBytes, 0);
+}
+
+} // namespace facebook::velox::cudf_velox::test


### PR DESCRIPTION
> **The question this answers:** a query dies with `std::bad_alloc` at 46 GiB on a
> 48 GiB card. *Which operator was holding the memory?* Until now, nothing could say.

With `cudf.memory_tracking_enabled=true`, every GPU allocation is charged to the
operator instance that made it and published as NVTX counters. Each operator instance
gets its own memory timeline in Nsight Systems, nested under its plan node, fragment
and query — in the same report as the CUDA kernels, so an operator's memory line sits
directly above the work that produced it.

At TPC-H SF1000, Q10 dies under the async allocator, and the capture names the culprit:
**one `TableScan` instance holding 33.8 GiB of the 45.6 GiB live** when a 1.75 GiB
request failed with 11.8 MiB free on the card.

No second trace file, no vendored tracing SDK, no post-capture toolchain.

## What you see

```text
Velox GPU memory                                [root scope]
├── overall live bytes #1                       counter
└── query 20260730_053421_00000                 [scope]
    ├── query 20260730_053421_00000 #2
    ├── query 20260730_053421_00000 peak #3
    └── fragment 20260730_053421_00000.0.0.0    [scope]
        ├── fragment 20260730_053421_00000.0.0.0 #4
        ├── 008 -------- HashJoinNode [1584]    [scope]
        │   ├── 008 -------- HashJoinNode [1584] #23   plan-node total
        │   ├── pipeline 2                      [scope]
        │   │   ├── op3 CudfHashJoinProbe d0 #38
        │   │   └── op3 CudfHashJoinProbe d1 #45
        │   └── pipeline 5                      [scope]
        │       ├── op1 CudfHashJoinBuild d0 #61
        │       └── op1 CudfHashJoinBuild d1 #66
        ├── 009 --------- HashJoinNode [1517]   [scope]
        ├── 010 ---------- FilterNode [1755]    [scope]
        └── 011 ----------- TableScanNode [3]   [scope]
```

The levels are Velox's own: a query runs as fragments, each executed by one task; a
task runs pipelines of drivers; a driver runs a chain of operators. The pipeline level
is what makes a join readable — build and probe run in different pipelines, so they
land under separate scopes instead of four indistinguishable siblings.

When an allocation fails, a marker records the state at that instant. From the SF1000
Q10 failure above:

```text
requestedBytes      = 1874984411   1.75 GiB request that failed
globalCurrentBytes  = 49010526195  45.6 GiB live
cudaFreeBytes       = 12386304     11.8 MiB free of 47.4 GiB
ownerCurrentBytes   = 36293670355  33.8 GiB held by the owning TableScan
```

Run the same query with a managed resource and it succeeds by oversubscribing device
memory, peaking at 63.6 GiB — which the counters show just as readily.

## How it works

```mermaid
flowchart LR
    A["cuDF asks RMM<br/><code>allocate(N)</code>"] --> B["Tracking wrapper<br/>GpuMemoryTracker"]
    B --> C["Ledger<br/>atomic counters"]
    C --> D["NVTX<br/>buffer + ordered batch"]
    D --> E["Nsight timeline<br/>one row per operator"]
    B -.->|"who is running?"| F["thread-local stat writer<br/>→ Operator*"]
```

Only the two middle boxes are new code. The dotted edge is the whole trick: Velox
already points a thread-local runtime stat writer at the operator it is executing, and
that writer *is* the operator — so nothing has to be threaded through cuDF calls.
Publishing appends the six samples to a per-thread buffer; a background thread submits
them as time-ordered NVTX counter batches, for the reason in Reading the code #7.

## What the numbers mean

| | |
|---|---|
| **What a counter reports** | Logical requested live bytes: allocation sizes that succeeded and are not yet freed. Exact for every call the wrapper sees; identical for async and managed RMM resources. |
| **What it is not** | Physical residency. It will not match `nvidia-smi`, and a pooling allocator holds far more device memory than this reports. |
| **Who a free is charged to** | Always the operator that allocated — even if the free happens on another thread, or while a different operator is running. That is what makes "who held memory at the peak" answerable. |

## Turning it on

One worker config key, plus running the worker under a profiler:

```properties
cudf.memory_tracking_enabled=true
```

```bash
nsys launch -t nvtx,cuda <presto_server|worker>
nsys start -o q8.nsys-rep     # per query, so one report holds one query
# ... run the query ...
nsys stop
```

The allocator is an independent choice: `cudf.memory_resource` can be `async`,
`prefetch_managed` or anything else, and all are tracked identically, because the
wrapper sits above the resource rather than inside it. Comparing the same query across
two resources is a good use of this — an async run that dies with `bad_alloc` and a
managed run that completes produce directly comparable timelines.

Nothing else is required of the surrounding harness. Per-query `nsys start`/`stop` is
what keeps one report to one query; a single capture spanning many queries also works
and simply contains a scope per query.

---

# Reading the code: the parts that aren't obvious

Several things here look like they could be simpler, and each is the way it is for a
reason that isn't visible from the code alone. Expand any of them.

<details>
<summary><b>1. Why counting is cheap — each record caches its ancestors</b></summary>

<br/>

One allocation has to move five counters. It does that with no lookups and no locks,
because every owner record resolves its ancestor counters **once, at registration**:

```mermaid
flowchart LR
    OP["<b>OwnerRecord</b><br/>op1 CudfHashJoinBuild d0<br/>own: current / peak / total"]
    PN["plan node 008<br/>live"]
    FR["fragment 0.0.0<br/>live"]
    Q["query …00000<br/>live + peak"]
    G["process<br/>live + peak"]
    OP -->|cached pointer| PN
    OP -->|cached pointer| FR
    OP -->|cached pointer| Q
    OP -->|cached pointer| G
```

The counter set is trimmed per level, so no record contends on a value nobody reads:

| Level | current | peak | total | Why |
|---|:-:|:-:|:-:|---|
| process | ✓ | ✓ | ✓ | Single record; peak here is exact |
| query | ✓ | ✓ | | The only level whose peak is meaningful (see #4) |
| fragment | ✓ | | | Peak is already the max of its own live row |
| plan node | ✓ | | | Same |
| operator | ✓ | ✓ | ✓ | The leaf a reader actually inspects |

Records are cache-line aligned so hot owners on different threads don't false-share.

**Cost of one allocation, steady state:**

| Step | Cost |
|---|---|
| Is an operator running? (thread-local read) | 1 load |
| Cache hit on that operator? | 2 compares + 1 atomic load |
| Insert pointer → owner in the concurrent map | 1 hash + 1 segment lock |
| Bump the five levels | 7 `fetch_add`, plus up to 3 peak CAS while growing |
| Buffer 6 samples for the background flusher | 1 clock read + 1 thread-local lock |

No global mutex on the hot path, no string work, no `dynamic_cast`; the NVTX batch
submission runs off-thread (Reading the code #7).

**The one caveat of taking no lock:** each counter is individually exact and never
negative, and lifetime totals are raised *before* live values so a reader can never see
live bytes exceed their own total. But cross-level sums agree only once activity
quiesces, not instant by instant — the atomics land a few instructions apart, far below
timeline resolution.

</details>

<details>
<summary><b>2. Why plan nodes are siblings instead of nested by the plan tree</b></summary>

<br/>

Nesting them faithfully was tried first. It is unusable for two independent reasons:

```text
  NESTED (tried, rejected)                    FLAT (what ships)

  fragment                                    fragment
   └── SortNode                                ├── 001 - SortNode
       └── AggregationNode                     ├── 002 -- AggregationNode
           └── ProjectNode                     ├── 003 --- ProjectNode
               └── HashJoinNode                ├── 004 ---- HashJoinNode
                   └── FilterNode              ├── 005 ----- FilterNode
                       └── ...                 ├── ...
                           └── TableScan       └── 021 --------- TableScan
                                                    ↑
   ↑ 20+ levels: every counter row              plan order and depth survive,
     indents off the right edge                 no indentation cost
```

1. A TPC-H plan is over twenty levels deep, so every counter indents off the screen.
2. Nsight lists a scope's own counters *after* its child scopes — so a plan node's
   total renders *below* its children's entire subtree and reads as if it belongs to them.

Plan order is preserved differently: Nsight sorts scope rows lexically, so each label
leads with its zero-padded index in a depth-first pre-order walk (the order `EXPLAIN`
prints), followed by one dash per level of depth. Rows read top-to-bottom as the plan
does, and the join tree is legible from the dashes.

Indices are **sparse on purpose** — only a plan node with a GPU operator gets a
counter, so a gap means the node ran on the CPU or was fused away. That is worth seeing.

This also sidesteps a representational problem: the operator instance graph is *not* a
tree (`LocalPartition` fans N producers into M consumers) while NVTX scopes must be one.
Making operator instances always leaves means no instance ever parents another, so
fan-out becomes sibling leaves under a shared plan node.

</details>

<details>
<summary><b>3. Why every counter carries an ordinal, and why registrations are replayed</b></summary>

<br/>

A counter's registered name is its label plus a globally unique ordinal:

```text
op1 CudfHashJoinBuild d0 #61
```

Alongside it, registration emits a marker mapping that ordinal to the full identity:

```text
velox-gpu-memory-counter #61 name=[op1 CudfHashJoinBuild d0 #61] level=owner
  query=[20260731_193139_00000] taskId=[...] taskUuid=[...] plan=[2135]
  planType=[HashJoinNode] operator=1 operatorType=[CudfHashJoinBuild]
  pipeline=3 driver=0
```

That looks redundant with the scope the counter already sits in. It is forced by the
export format:

| `nsys export --type sqlite` writes | Contains | Missing |
|---|---|---|
| `NVTX_SCOPES` | the scope tree, including `parentScopeId` | — |
| `GENERIC_EVENTS` | every counter sample | **`scopeId`** |

`scopeId` appears nowhere outside `NVTX_SCOPES`, so nothing associates a sample with
the scope its counter was registered against. The ordinal is what makes a counter
identifiable at all after capture, and the marker is what makes the capture
self-describing. The scope tree still drives the GUI nesting — it just can't be joined
to the samples.

**The markers are replayed when a new query appears.** Nsight replays *scope*
registrations into each `nsys start`/`stop` session but not markers, so in a
long-running worker only the session that spanned a counter's registration would be
able to name it. Replay is quadratic in the number of queries, so the list is bounded
at 20,000 markers; past the bound later registrations are still emitted once but no
longer restated, and the capture records that it was truncated rather than appearing to
be missing counters.

This is also why subtree totals aren't emitted at capture time. Collapsing a scope in
Nsight hides rows rather than summing them, so inclusive totals would cost one extra
sample per ancestor on every allocation — ten to twenty on a TPC-H plan. They can be
derived after capture by walking `parentScopeId` instead, at zero runtime cost.

</details>

<details>
<summary><b>4. Why only the query level publishes a peak</b></summary>

<br/>

A process-wide peak counter was emitted at first and had to be removed. The ledger's
process peak is monotonic for the worker's lifetime, so it reports one query's high
water mark for every query that follows:

```text
   process-wide peak (removed)          query-level peak (ships)

   Q1  ████████  33 GiB → peak 33      Q1  ████████  33 GiB → peak 33  ✓
   Q2  ██         4 GiB → peak 33  ✗   Q2  ██         4 GiB → peak  4  ✓
   Q3  ███        7 GiB → peak 33  ✗   Q3  ███        7 GiB → peak  7  ✓
        live row varies underneath
        while the peak row lies flat
```

The query level is the coarsest scope whose peak resets naturally, and it stays correct
when queries overlap.

</details>

<details>
<summary><b>5. Three orderings that look arbitrary and are not</b></summary>

<br/>

**The pointer entry is erased before the upstream free.** If it were erased after, the
address could be recycled by another thread and reinserted in between — the erase would
then remove the *new* owner's entry. Erasing first is also why find-then-erase needs no
atomic extract.

**Lifetime totals are raised before live values.** This is what makes "live never
exceeds its own total" hold mid-flight, so a reader sampling during a burst can't see
an impossible pair.

**A reset bumps an epoch before zeroing.** Counter ids are handed out to callers and
cached, so a longer-lived holder could otherwise keep writing into counters whose scope
no longer exists. Advancing the epoch retires every id already issued; a stale set
silently stops publishing instead.

</details>

<details>
<summary><b>6. Two edge cases in plan-node resolution</b></summary>

<br/>

**Synthetic conversion operators** carry `-from-velox` / `-to-velox` suffixes on their
plan node ID and own no plan node. The suffix is stripped before one retry. Critically,
the ledger keys its plan-node total on the **resolved** ID: keying on the raw one gave
a single node two totals, each holding part of its bytes.

**Anything still unresolved** attaches to an `unmapped` scope under the fragment, and
an allocation made outside any operator is charged to an explicit unattributed owner.
Nothing is guessed at and nothing is dropped.

Owner identity is `queryId`, `taskUuid`, `taskId`, `planNodeId`, `pipelineId`,
`driverId`, `operatorId`, `operatorType`. `taskUuid` is in there because human-readable
task IDs get reused, and reuse would merge unrelated instances.

</details>

<details>
<summary><b>7. Why samples are buffered and submitted as ordered batches</b></summary>

<br/>

Counters are not published with the immediate `nvtxCounterSampleInt64`. Each thread
appends `{counterId, value, timestamp}` — the timestamp read from `CLOCK_MONOTONIC_RAW`
when the ledger records the transition — to a private buffer. One background thread
drains every buffer every 5 ms, sorts each counter's samples by time, keeps the
timestamps strictly increasing per counter across flushes, and submits them with
`nvtxCounterBatchSubmit` under `NVTX_BATCH_FLAG_TIME_SORTED`.

Two reasons, both load-bearing:

- **Rendering.** An operator is not pinned to a thread: a driver runs until it blocks or
  yields, is parked, and is resumed later by another executor thread. So one operator
  counter is sampled by several threads over its life, while the shared query and
  fragment counters above it are sampled concurrently. Fed through the immediate API,
  that stream is stored correctly in the SQLite export but the timeline row draws empty
  (older viewers) or throws an internal `RangeViewAdapter` error (2026.4.1). Globally
  ordered batches render. A standalone reproducer that forces the migration pattern is
  filed with the Nsight Systems team.
- **Cost.** Over 1.2 M samples on nsys 2026.4.1, the immediate call cost ~235 ns/sample
  under a profiler against ~26 ns/sample amortized through batch submission — roughly 9×
  — and one allocation moves six samples.

Fidelity is unaffected: each sample carries the allocation's own timestamp, not the time
it is flushed. The periodic drain is required rather than tidy — an idle driver would
otherwise hold its last samples past the end of the capture — and a session reset
flushes explicitly before and after zeroing so counters return to zero in the report.

End to end, async allocator only: SF10 Q9 under capture with tracking on versus off
measured +7.5 ms mean (+1.95%) over ten hot runs, inside run-to-run noise. Managed-memory
timings are excluded from this comparison because managed migration cost dominates and
would overstate the number.

</details>

---

## The one core Velox change

`Driver::initializeOperators()` and `closeOperators()` both ran outside any
`RuntimeStatWriterScopeGuard`, and `addThreadLocalRuntimeStat()` discards a value when
no writer is set. So **every runtime stat recorded during operator startup and shutdown
was silently dropped** — and memory released during `close()` had no owner. Setting the
guard per operator fixes both.

This is a standalone fix, useful independently of the rest of the PR.

## Modules

| File | Owns | Depends on |
|---|---|---|
| `GpuMemoryOwner.h` | Value types: who an allocation belongs to | nothing |
| `GpuMemoryPlanPath.{h,cpp}` | Plan node → `EXPLAIN` order and depth | `core::PlanNode` |
| `GpuMemoryLedger.{h,cpp}` | Counting: pointer→owner map, atomic counters | Owner, PlanPath |
| `GpuMemoryNvtx.{h,cpp}` | Publishing: scope tree, counters, markers | Owner, PlanPath |
| `GpuMemoryTracker.{h,cpp}` | Interception: RMM wrapper + lifecycle | Ledger, Nvtx, `exec::Operator` |

The split is by verb — intercept, count, publish. Ledger and Nvtx never call each
other's internals: Ledger hands Nvtx a finished update, Nvtx hands back an opaque set
of counter ids that Ledger caches. `GpuMemoryPlanPath` is separate because it is a pure
function over a `PlanNode` tree, which makes plan-order logic testable against
`PlanBuilder` plans with no `Task`, RMM resource or ledger.

The pointer map's only irreplaceable job is remembering *which* owner allocated a
pointer, since RMM passes the size back to `deallocate`. It stores the size anyway and
compares it against what RMM reports, raising a data-loss event on a mismatch rather
than skewing a counter silently.

## Requirements and limits

- **Off by default.** `cudf.memory_tracking_enabled` gates everything, because enabling
  it wraps the RMM allocation path. The flag gates the ledger, not NVTX — NVTX emission
  is free with no profiler attached, since it resolves its entry points to no-ops.
- **View the capture in Nsight Systems 2026.3 or newer.** Recording works further back —
  2025.3.2, 2025.5.1 and 2025.6.1 all store every counter sample correctly, including
  through `nsys launch` with `nsys start`/`stop` session control. It is the *viewer* that
  matters: the 2025.6.1 GUI shows the scope tree but draws no counter rows at all, while
  2026.4.1 renders those same captures correctly. NVTX counters left preview at 2026.3,
  which is the recommended floor. A too-old viewer looks like the feature produced
  nothing rather than like an error.
- **Counters are submitted as ordered NVTX batches, not immediate samples.** The
  immediate path records every value but leaves the timeline row empty or errors for
  this concurrent, thread-migrating workload; see Reading the code #7.
- **Counters register in the NVTX default domain**, not a named one, because a named
  domain renders as an extra level above every counter row. The cost: a capture filtered
  to a single domain won't contain them.
- **Out of scope:** physical VRAM residency, pool reservation, fragmentation,
  managed-memory migration, and any CUDA allocation not going through the wrapped RMM
  resource; separating input/output/temporary/pool memory (both resources feed one
  ledger, so a reader cannot double-count the peak); inclusive subtree totals at capture
  time; aggregating several worker processes into one report.

## Tests

| Binary | Covers |
|---|---|
| `velox_cudf_gpu_memory_tracker_test` | Attribution through the RMM wrapper: cross-thread and cross-operator frees charging back to the allocating owner, the unattributed owner, per-level counter arithmetic and peaks, size-mismatch and double-free data-loss events, allocation-failure reporting, concurrent use reconciling once quiesced, tasks with no query ID keeping separate counters, a buffer outliving the resource that allocated it |
| `velox_cudf_gpu_memory_plan_path_test` | Plan order and depth over `PlanBuilder` plans, the conversion-operator suffixes, the unresolvable case |
| `velox_cudf_gpu_memory_nvtx_test` | Registration idempotency, shared ancestor counters, the unattributed owner, epoch retirement on reset, concurrent registration and sampling |

`ConfigTest` covers the new config key.
