### PR TITLE
fix: Suppress clang-tidy nullability-completeness via command-line flag

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -57,16 +57,6 @@ HeaderFilterRegex: '.*'
 
 WarningsAsErrors: 'bugprone-use-after-move'
 
-# clang-tidy parses the GCC compile commands with its Clang frontend, which
-# emits -Wnullability-completeness on core headers when nullability qualifiers
-# leak into a translation unit. The GCC compile commands lack the
-# -Wno-nullability-completeness that CMakeLists.txt sets only for Clang builds,
-# so under -Werror the warning becomes an error. Disabling the check in Checks
-# only filters warning-level output, not an error, so pass the suppression as a
-# real compiler flag here.
-ExtraArgs:
-  - '-Wno-nullability-completeness'
-
 CheckOptions:
   # Naming conventions as explicitly stated in CODING_STYLE.md.
   - key: readability-identifier-naming.ClassCase

--- a/scripts/checks/run-clang-tidy.py
+++ b/scripts/checks/run-clang-tidy.py
@@ -108,6 +108,16 @@ def tidy(args):
     fix = "--fix" if args.fix == "fix" else ""
     lines = f"'--line-filter={line_filter}'" if args.commit is not None else ""
 
+    # Suppress -Wnullability-completeness at the Clang frontend. clang-tidy
+    # parses the GCC build's compile commands, which omit the Clang-only
+    # -Wno-nullability-completeness set in CMakeLists.txt, so the frontend emits
+    # the diagnostic and -Werror turns it into an error on core headers such as
+    # StringView.h. This must be passed on the command line (--extra-arg): the
+    # same flag placed in .clang-tidy's ExtraArgs is mishandled by clang-tidy
+    # 18 for these compile commands ("no such file or directory:
+    # '-Wno-nullability-completeness'") and never takes effect.
+    extra_args = "--extra-arg=-Wno-nullability-completeness"
+
     ok = True
     build_path = args.p or os.getenv("BUILD_PATH")
     build_path_str = f"-p {build_path}" if build_path else ""
@@ -119,7 +129,7 @@ def tidy(args):
         return 0
 
     status, stdout, stderr = util.run(
-        f"xargs clang-tidy --format-style=file -header-filter='.*' --quiet {build_path_str} {fix} {lines}",
+        f"xargs clang-tidy --format-style=file -header-filter='.*' --quiet {extra_args} {build_path_str} {fix} {lines}",
         input=filtered_files,
     )
 


### PR DESCRIPTION
## Summary

The clang-tidy CI step (run inside the GCC "Linux release with adapters" build) parses the GCC build's `compile_commands.json` with its Clang frontend. Those commands omit the `-Wno-nullability-completeness` flag that `CMakeLists.txt` sets only for Clang builds, so the frontend emits `-Wnullability-completeness` on core headers such as `StringView.h` and `EvalCtx.h`, and `-Werror` promotes it to a hard error. This fails otherwise-unrelated sparksql PRs.

The suppression currently lives in `.clang-tidy`'s `ExtraArgs`, but clang-tidy 18 mishandles it for these compile commands, emitting `error: no such file or directory: '-Wno-nullability-completeness'`, so it never takes effect.

## Fix

- `scripts/checks/run-clang-tidy.py`: pass `--extra-arg=-Wno-nullability-completeness` on the clang-tidy command line, which is applied reliably.
- `.clang-tidy`: remove the broken `ExtraArgs` block that produced the spurious "no such file" error.

## Testing

Reproduced the `-Wnullability-completeness` trigger locally (a header with a `_Nullable` pointer inside a `#pragma clang assume_nonnull` region plus a bare pointer, compiled with `-Werror`). Confirmed the diagnostic fires without suppression and is cleanly suppressed by the command-line `--extra-arg` form.