### PR TITLE
fix(type): Keep upper 64 bits of HUGEINT in Variant serde (#18351)

### DIFF
--- a/velox/type/Variant.cpp
+++ b/velox/type/Variant.cpp
@@ -21,6 +21,7 @@
 #include "velox/common/encode/Base64.h"
 #include "velox/type/DecimalUtil.h"
 #include "velox/type/FloatingPointUtil.h"
+#include "velox/type/HugeInt.h"
 
 namespace facebook::velox {
 namespace {
@@ -746,7 +747,9 @@ folly::dynamic Variant::serialize() const {
       break;
     }
     case TypeKind::HUGEINT: {
-      objValue = value<TypeKind::HUGEINT>();
+      // folly::dynamic has no 128-bit integer type. Serializing as a number
+      // would narrow the value to int64_t and silently drop the upper 64 bits.
+      objValue = std::to_string(value<TypeKind::HUGEINT>());
       break;
     }
     case TypeKind::BOOLEAN: {
@@ -852,7 +855,7 @@ Variant Variant::create(const folly::dynamic& variantobj) {
     case TypeKind::BIGINT:
       return Variant::create<TypeKind::BIGINT>(obj.asInt());
     case TypeKind::HUGEINT:
-      return Variant::create<TypeKind::HUGEINT>(obj.asInt());
+      return Variant::create<TypeKind::HUGEINT>(HugeInt::parse(obj.asString()));
     case TypeKind::BOOLEAN: {
       return Variant(obj.asBool());
     }

--- a/velox/type/tests/VariantTest.cpp
+++ b/velox/type/tests/VariantTest.cpp
@@ -1104,6 +1104,18 @@ TEST(VariantSerializationTest, serialize) {
   testSerDe(Variant(Timestamp(1, 2)));
 }
 
+TEST(VariantSerializationTest, serializeHugeint) {
+  testSerDe(Variant(TypeKind::HUGEINT));
+  testSerDe(Variant(static_cast<int128_t>(0)));
+  testSerDe(Variant(static_cast<int128_t>(1234567)));
+  testSerDe(Variant(static_cast<int128_t>(-1234567)));
+
+  // Values whose upper 64 bits are non-zero.
+  testSerDe(Variant(HugeInt::build(0x2607f0d010000000, 1)));
+  testSerDe(Variant(std::numeric_limits<int128_t>::max()));
+  testSerDe(Variant(std::numeric_limits<int128_t>::min()));
+}
+
 TEST(VariantSerializationTest, serializeArrayTypes) {
   // Empty array.
   testSerDe(Variant::array({}));


### PR DESCRIPTION
Summary:

`Variant::serialize()` dropped the upper 64 bits of every HUGEINT value. `folly::dynamic` has no 128-bit integer type, so assigning an `int128_t` to it narrowed the value to `int64_t`. The IPADDRESS for `2607:f0d0:1000::1` serialized as:

    {"value":1,"type":"HUGEINT"}

and came back as `::1`. Any query whose plan is serialized before execution saw corrupted IPADDRESS, IPPREFIX, and long DECIMAL constants, and returned wrong results with no error. IPv4-mapped addresses were unaffected because they fit in the lower 64 bits.

HUGEINT is now written as a decimal string and read back with `HugeInt::parse`. This changes the serialized form, so a reader on an older build cannot parse the new output.

Reviewed By: amitkdutta

Differential Revision: D114405847


