### PR TITLE
fix(build): Suppress clang-tidy nullability-completeness via --extra-arg

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -57,16 +57,6 @@ HeaderFilterRegex: '.*'
 
 WarningsAsErrors: 'bugprone-use-after-move'
 
-# clang-tidy parses the GCC compile commands with its Clang frontend, which
-# emits -Wnullability-completeness on core headers when nullability qualifiers
-# leak into a translation unit. The GCC compile commands lack the
-# -Wno-nullability-completeness that CMakeLists.txt sets only for Clang builds,
-# so under -Werror the warning becomes an error. Disabling the check in Checks
-# only filters warning-level output, not an error, so pass the suppression as a
-# real compiler flag here.
-ExtraArgs:
-  - '-Wno-nullability-completeness'
-
 CheckOptions:
   # Naming conventions as explicitly stated in CODING_STYLE.md.
   - key: readability-identifier-naming.ClassCase

--- a/scripts/checks/run-clang-tidy.py
+++ b/scripts/checks/run-clang-tidy.py
@@ -108,6 +108,17 @@ def tidy(args):
     fix = "--fix" if args.fix == "fix" else ""
     lines = f"'--line-filter={line_filter}'" if args.commit is not None else ""
 
+    # clang-tidy parses the GCC compile commands with its Clang frontend, which
+    # emits -Wnullability-completeness on core headers (e.g. StringView.h) when
+    # nullability qualifiers leak into a translation unit. The GCC compile
+    # commands lack the -Wno-nullability-completeness that CMakeLists.txt sets
+    # only for Clang builds, so under -Werror the warning escalates to an error.
+    # Pass the suppression as a real compiler flag. It must go through
+    # --extra-arg (appended after the command's -W flags) rather than the
+    # .clang-tidy ExtraArgs option, which clang-tidy 18.1.8 mis-parses as an
+    # input file.
+    extra_args = "--extra-arg=-Wno-nullability-completeness"
+
     ok = True
     build_path = args.p or os.getenv("BUILD_PATH")
     build_path_str = f"-p {build_path}" if build_path else ""
@@ -119,7 +130,7 @@ def tidy(args):
         return 0
 
     status, stdout, stderr = util.run(
-        f"xargs clang-tidy --format-style=file -header-filter='.*' --quiet {build_path_str} {fix} {lines}",
+        f"xargs clang-tidy --format-style=file -header-filter='.*' --quiet {extra_args} {build_path_str} {fix} {lines}",
         input=filtered_files,
     )
 


### PR DESCRIPTION
## Summary

The GCC clang-tidy step (e.g. `Build with GCC / Linux release with adapters`) fails on core headers such as `StringView.h` and `BitPackDecoder.h` with:

```
error: pointer is missing a nullability type specifier
    (_Nonnull, _Nullable, or _Null_unspecified) [clang-diagnostic-nullability-completeness]
```

clang-tidy parses the GCC compile commands with its Clang frontend. Those commands carry `-Werror` but not `-Wno-nullability-completeness` — that flag is set only in the Clang branch of `CMakeLists.txt`. Nullability qualifiers leak into a translation unit via adapter/Parquet headers, so Clang's default-on `-Wnullability-completeness` fires on unannotated pointers in core headers, and `-Werror` escalates it to an error. Because the errors are in widely included headers, this hits any C++ PR whose changed files pull them in.

## Why the previous fix did not work

Two earlier attempts were insufficient:

1. `-clang-diagnostic-nullability-completeness` in `.clang-tidy` `Checks:` (#18309) — the `Checks:` list only filters **warning-level** output; it cannot suppress a diagnostic that `-Werror` has already turned into an error.
2. `-Wno-nullability-completeness` via `.clang-tidy` `ExtraArgs:` (merged in #18081) — **clang-tidy 18.1.8** (pinned in `linux-build-base.yml`) mis-parses the `ExtraArgs` value as an input file and reports:

```
error: no such file or directory: '-Wno-nullability-completeness' [clang-diagnostic-error]
```

so the suppression never applied and, worse, added its own error.

## Fix

Pass `-Wno-nullability-completeness` through clang-tidy's command-line `--extra-arg` in `scripts/checks/run-clang-tidy.py`. `--extra-arg` appends the flag after the command's `-W` flags (so it wins over `-Werror`) and is not mis-parsed as a file. The broken `ExtraArgs` block is removed from `.clang-tidy`; the `-clang-diagnostic-nullability-completeness` `Checks:` entry stays as a warning-level backstop.

## Verification

Reproduced and validated locally against **clang-tidy 18.1.8** (the CI-pinned version) using CI's exact invocation form (`--format-style=file -header-filter='.*' --quiet --line-filter=...`):

| Approach | clang-tidy 18.1.8 |
|---|---|
| `Checks:` disable only | error not suppressed |
| `.clang-tidy` `ExtraArgs:` | `no such file or directory` (mis-parsed as input file) |
| `--extra-arg-before` (prepend) | not suppressed (overridden by later `-Wall`) |
| **`--extra-arg` (append)** | **suppressed, no mis-parse** |

## Test plan

- Re-run the `Build with GCC / Linux release with adapters` job; the `Install and run clang-tidy` step should pass.
