### PR TITLE
[DO NOT MERGE] Validate clang-tidy nullability fix (#18354)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -57,16 +57,6 @@ HeaderFilterRegex: '.*'
 
 WarningsAsErrors: 'bugprone-use-after-move'
 
-# clang-tidy parses the GCC compile commands with its Clang frontend, which
-# emits -Wnullability-completeness on core headers when nullability qualifiers
-# leak into a translation unit. The GCC compile commands lack the
-# -Wno-nullability-completeness that CMakeLists.txt sets only for Clang builds,
-# so under -Werror the warning becomes an error. Disabling the check in Checks
-# only filters warning-level output, not an error, so pass the suppression as a
-# real compiler flag here.
-ExtraArgs:
-  - '-Wno-nullability-completeness'
-
 CheckOptions:
   # Naming conventions as explicitly stated in CODING_STYLE.md.
   - key: readability-identifier-naming.ClassCase

--- a/scripts/checks/run-clang-tidy.py
+++ b/scripts/checks/run-clang-tidy.py
@@ -108,6 +108,17 @@ def tidy(args):
     fix = "--fix" if args.fix == "fix" else ""
     lines = f"'--line-filter={line_filter}'" if args.commit is not None else ""
 
+    # clang-tidy parses the GCC compile commands with its Clang frontend, which
+    # emits -Wnullability-completeness on core headers (e.g. StringView.h) when
+    # nullability qualifiers leak into a translation unit. The GCC compile
+    # commands lack the -Wno-nullability-completeness that CMakeLists.txt sets
+    # only for Clang builds, so under -Werror the warning escalates to an error.
+    # Pass the suppression as a real compiler flag. It must go through
+    # --extra-arg (appended after the command's -W flags) rather than the
+    # .clang-tidy ExtraArgs option, which clang-tidy 18.1.8 mis-parses as an
+    # input file.
+    extra_args = "--extra-arg=-Wno-nullability-completeness"
+
     ok = True
     build_path = args.p or os.getenv("BUILD_PATH")
     build_path_str = f"-p {build_path}" if build_path else ""
@@ -119,7 +130,7 @@ def tidy(args):
         return 0
 
     status, stdout, stderr = util.run(
-        f"xargs clang-tidy --format-style=file -header-filter='.*' --quiet {build_path_str} {fix} {lines}",
+        f"xargs clang-tidy --format-style=file -header-filter='.*' --quiet {extra_args} {build_path_str} {fix} {lines}",
         input=filtered_files,
     )
 

--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -31,6 +31,7 @@
 
 namespace facebook::velox::connector::hive::iceberg {
 
+// Trivial edit to force clang-tidy to analyze this TU (CI validation only).
 namespace {
 
 using TempFilePath = common::testutil::TempFilePath;


### PR DESCRIPTION
Draft PR to validate #18354 on real CI. Carries the fix plus a trivial change to IcebergReadTest.cpp so the clang-tidy step actually runs on a triggering TU. Watching the `Build with GCC / Linux release with adapters` -> `Install and run clang-tidy` step. Will be closed once validated.