### PR TITLE
fix(SortBuffer): Release accumulated rows once all output is produced (#18357)

### DIFF
--- a/velox/exec/SortBuffer.cpp
+++ b/velox/exec/SortBuffer.cpp
@@ -167,6 +167,7 @@ RowVectorPtr SortBuffer::getOutput(vector_size_t maxOutputRows) {
   VELOX_CHECK(noMoreInput_);
 
   if (numOutputRows_ == numInputRows_) {
+    releaseRows();
     return nullptr;
   }
   VELOX_CHECK_GT(maxOutputRows, 0);
@@ -181,6 +182,12 @@ RowVectorPtr SortBuffer::getOutput(vector_size_t maxOutputRows) {
     getOutputWithoutSpill();
   }
   return std::move(output_);
+}
+
+void SortBuffer::releaseRows() {
+  data_->clear();
+  sortedRows_.clear();
+  sortedRows_.shrink_to_fit();
 }
 
 bool SortBuffer::hasSpilled() const {

--- a/velox/exec/SortBuffer.h
+++ b/velox/exec/SortBuffer.h
@@ -101,6 +101,12 @@ class SortBuffer {
 
   void getOutputWithSpill();
 
+  // Frees the accumulated rows once all of them have been returned as output. A
+  // driver closes its operators only after the last one finishes, so a sort
+  // that feeds another blocking operator in the same pipeline would otherwise
+  // hold its rows until the whole task completes.
+  void releaseRows();
+
   // Spill during input stage.
   void spillInput();
 

--- a/velox/exec/tests/SortBufferTest.cpp
+++ b/velox/exec/tests/SortBufferTest.cpp
@@ -450,6 +450,96 @@ TEST_P(SortBufferTest, batchOutput) {
   }
 }
 
+namespace {
+// Covers the variable-width and complex extraction paths as well as the fixed
+// width one, so that releasing the accumulated rows is exercised against every
+// way a column can be materialized into the output.
+const RowTypePtr& releaseTestInputType() {
+  static const RowTypePtr type = ROW(
+      {{"c0", BIGINT()},
+       {"c1", INTEGER()},
+       {"c2", VARCHAR()},
+       {"c3", ARRAY(BIGINT())},
+       {"c4", MAP(INTEGER(), REAL())}});
+  return type;
+}
+
+const std::vector<column_index_t> kReleaseTestSortColumnIndices{1};
+const std::vector<CompareFlags> kReleaseTestSortCompareFlags{
+    {true, true, false, CompareFlags::NullHandlingMode::kNullAsValue}};
+} // namespace
+
+TEST_P(SortBufferTest, releaseAfterOutput) {
+  exec::SpillStats spillStats;
+  auto sortBuffer = std::make_unique<SortBuffer>(
+      releaseTestInputType(),
+      kReleaseTestSortColumnIndices,
+      kReleaseTestSortCompareFlags,
+      pool_.get(),
+      &nonReclaimableSection_,
+      prefixSortConfig_,
+      nullptr,
+      &spillStats);
+
+  VectorFuzzer fuzzer({.vectorSize = 1'024}, fuzzerPool_.get());
+  for (int i = 0; i < 64; ++i) {
+    sortBuffer->addInput(fuzzer.fuzzRow(releaseTestInputType()));
+  }
+  sortBuffer->noMoreInput();
+
+  const uint64_t usedBytesAfterInput = pool_->usedBytes();
+  ASSERT_GT(usedBytesAfterInput, 0);
+
+  while (sortBuffer->getOutput(1'024) != nullptr) {
+  }
+
+  // A driver only closes its operators once the last one finishes, so in a
+  // pipeline that fuses several sorts the accumulated rows have to be freed as
+  // soon as the last output batch is produced. Otherwise every upstream sort
+  // keeps its rows resident for the lifetime of the task.
+  ASSERT_LT(pool_->usedBytes(), usedBytesAfterInput / 10);
+}
+
+TEST_P(SortBufferTest, releaseAfterOutputKeepsOutputReadable) {
+  exec::SpillStats spillStats;
+  auto sortBuffer = std::make_unique<SortBuffer>(
+      releaseTestInputType(),
+      kReleaseTestSortColumnIndices,
+      kReleaseTestSortCompareFlags,
+      pool_.get(),
+      &nonReclaimableSection_,
+      prefixSortConfig_,
+      nullptr,
+      &spillStats);
+
+  VectorFuzzer fuzzer({.vectorSize = 256}, fuzzerPool_.get());
+  constexpr int32_t kNumInputVectors = 4;
+  for (int i = 0; i < kNumInputVectors; ++i) {
+    sortBuffer->addInput(fuzzer.fuzzRow(releaseTestInputType()));
+  }
+  sortBuffer->noMoreInput();
+
+  // A streaming window keeps the batches it was fed by reference long after the
+  // sort has handed out its last row, so releasing the rows must not invalidate
+  // anything reachable from the output.
+  std::vector<RowVectorPtr> outputs;
+  while (auto output = sortBuffer->getOutput(128)) {
+    outputs.push_back(std::move(output));
+  }
+
+  vector_size_t numOutputRows = 0;
+  for (const auto& output : outputs) {
+    output->validate({});
+    numOutputRows += output->size();
+    // Reading every value dereferences the string and complex payloads, so a
+    // stale reference into the freed row container is caught under ASAN.
+    for (vector_size_t row = 0; row < output->size(); ++row) {
+      output->toString(row);
+    }
+  }
+  ASSERT_EQ(numOutputRows, kNumInputVectors * 256);
+}
+
 TEST_P(SortBufferTest, spill) {
   struct {
     bool spillEnabled;


### PR DESCRIPTION
Summary:

`SortBuffer` holds its `RowContainer` and `sortedRows_` until `OrderBy::close()`
runs, and a driver only closes its operators after the *last* operator in the
pipeline finishes (`Driver.cpp` propagates `noMoreInput()` to the next operator
and breaks; `close()` is reached only from the final operator's finish branch).
In a pipeline that fuses several blocking operators, every upstream sort keeps
its full payload resident for the lifetime of the task even though it has
already handed all of its rows downstream.

This showed up on a Spark/Gluten query with four chained `row_number()` windows
fused into one driver:

    OrderBy(1) -> Window(2) -> OrderBy(4) -> Window(5) -> OrderBy(7) -> Window(8) -> ...

At the point `OrderBy(7)` was filling (568 MiB), `OrderBy(1)` and `OrderBy(4)`
were each still holding 270.5 MiB despite having fully drained — their
downstream Windows had already fallen back to 96 KiB. That is 541 MiB of dead
weight out of the task's 1320 MiB, and the task then hit an off-heap OOM.

`Window` does not have this problem because `Window::getOutput()` calls
`WindowBuild::release()` when the last row has been processed (added in
D80433738 for this same chained-window scenario). `OrderBy`/`SortBuffer` never
got the equivalent, which is exactly the asymmetry observed above.

Free the rows from the terminal branch of `SortBuffer::getOutput()`, i.e. when
the last batch has been handed out. `RowContainer::clear()` returns the arena
and the string allocator to the memory pool, unlike `eraseRows()` which only
moves rows onto a free list. The container is cleared in place rather than
reset so that `OrderBy::reclaim()` keeps working; a released, empty container
makes a subsequent `SortBuffer::spill()` a no-op via its `numRows() == 0` early
return.

Differential Revision: D114433658


