### PR TITLE
feat: Add TrackedExecutor to velox/common/base (#18359)

### DIFF
--- a/velox/common/base/CMakeLists.txt
+++ b/velox/common/base/CMakeLists.txt
@@ -113,6 +113,13 @@ velox_link_libraries(
 velox_add_library(velox_status Status.cpp HEADERS Status.h)
 velox_link_libraries(velox_status PUBLIC fmt::fmt Folly::folly PRIVATE glog::glog)
 
+velox_add_library(velox_tracked_executor TrackedExecutor.cpp HEADERS TrackedExecutor.h)
+velox_link_libraries(
+  velox_tracked_executor
+  PUBLIC velox_common_base velox_exception Folly::folly fmt::fmt
+  PRIVATE velox_time
+)
+
 velox_add_library(velox_compare_flags INTERFACE HEADERS CompareFlags.h)
 
 velox_add_library(velox_macros INTERFACE HEADERS Macros.h)

--- a/velox/common/base/TrackedExecutor.cpp
+++ b/velox/common/base/TrackedExecutor.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/TrackedExecutor.h"
+
+#include <folly/ScopeGuard.h>
+#include <folly/synchronization/SanitizeThread.h>
+#include "velox/common/time/CpuWallTimer.h"
+
+namespace facebook::velox {
+
+TrackedExecutor::Metrics::Metrics() {
+  folly::annotate_benign_race_sized(
+      this,
+      sizeof(*this),
+      "velox::TrackedExecutor::Metrics is deliberately not thread safe",
+      __FILE__,
+      __LINE__);
+}
+
+TrackedExecutor::Func TrackedExecutor::wrapFunc(Func func) {
+  auto enqueueTime = std::chrono::steady_clock::now();
+  return [func = std::move(func), enqueueTime, metrics = metrics_]() mutable {
+    metrics->waitTime.addValue(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::steady_clock::now() - enqueueTime)
+            .count());
+    CpuWallTiming timing;
+    // Record on scope exit so a throwing callback still samples each metric.
+    SCOPE_EXIT {
+      metrics->executionWallTime.addValue(
+          static_cast<int64_t>(timing.wallNanos));
+      metrics->executionCpuTime.addValue(static_cast<int64_t>(timing.cpuNanos));
+    };
+    DeltaCpuWallTimer timer(
+        [&timing](const CpuWallTiming& delta) { timing = delta; });
+    func();
+  };
+}
+
+void TrackedExecutor::reportTo(
+    BaseRuntimeStatWriter& writer,
+    std::string_view prefix) const {
+  writer.setRuntimeStat(
+      fmt::format("{}-{}", prefix, kExecutorWaitNanos), metrics_->waitTime);
+  writer.setRuntimeStat(
+      fmt::format("{}-{}", prefix, kExecutorExecutionWallNanos),
+      metrics_->executionWallTime);
+  writer.setRuntimeStat(
+      fmt::format("{}-{}", prefix, kExecutorExecutionCpuNanos),
+      metrics_->executionCpuTime);
+}
+
+} // namespace facebook::velox

--- a/velox/common/base/TrackedExecutor.h
+++ b/velox/common/base/TrackedExecutor.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/Executor.h>
+#include <folly/Function.h>
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/base/RuntimeMetrics.h"
+
+namespace facebook::velox {
+
+/// Wraps an executor to measure callback wait time and execution time. All
+/// tasks submitted via add() are delegated to the underlying executor after
+/// being instrumented.
+class TrackedExecutor final : public folly::Executor {
+  using Func = folly::Function<void()>;
+
+ public:
+  /// Metric name for the time a callback spent enqueued before it started
+  /// running, in nanoseconds.
+  static constexpr std::string_view kExecutorWaitNanos{"executorWaitNanos"};
+
+  /// Metric name for the wall time a callback spent running, in nanoseconds.
+  static constexpr std::string_view kExecutorExecutionWallNanos{
+      "executorExecutionWallNanos"};
+
+  /// Metric name for the cpu time a callback spent running, in nanoseconds.
+  static constexpr std::string_view kExecutorExecutionCpuNanos{
+      "executorExecutionCpuNanos"};
+
+  /// Wraps 'executor', which must be non-null. All submitted callbacks run on
+  /// 'executor' after instrumentation.
+  explicit TrackedExecutor(folly::Executor::KeepAlive<> executor)
+      : executor_{std::move(executor)} {
+    VELOX_CHECK(executor_);
+  }
+
+  TrackedExecutor(const TrackedExecutor&) = delete;
+  TrackedExecutor& operator=(const TrackedExecutor&) = delete;
+  TrackedExecutor(TrackedExecutor&&) = delete;
+  TrackedExecutor& operator=(TrackedExecutor&&) = delete;
+  ~TrackedExecutor() override = default;
+
+  void add(Func func) override {
+    executor_->add(wrapFunc(std::move(func)));
+  }
+
+  void addWithPriority(Func func, int8_t priority) override {
+    executor_->addWithPriority(wrapFunc(std::move(func)), priority);
+  }
+
+  uint8_t getNumPriorities() const override {
+    return executor_->getNumPriorities();
+  }
+
+  /// Reports accumulated metrics to 'writer', naming each 'prefix-<metric>'.
+  void reportTo(BaseRuntimeStatWriter& writer, std::string_view prefix) const;
+
+ private:
+  // Instruments 'func' to record its enqueue-wait, wall, and cpu time into
+  // metrics_ when it runs.
+  Func wrapFunc(Func func);
+
+  folly::Executor::KeepAlive<> executor_;
+
+  struct Metrics {
+    // Not thread safe. Prefer potential inaccuracy over synchronization
+    // overhead. Construction annotates the whole struct as benignly racy so
+    // ThreadSanitizer does not flag concurrent updates from the wrapped tasks
+    // or reads from reportTo().
+    Metrics();
+
+    RuntimeMetric waitTime{RuntimeCounter::Unit::kNanos};
+    RuntimeMetric executionWallTime{RuntimeCounter::Unit::kNanos};
+    RuntimeMetric executionCpuTime{RuntimeCounter::Unit::kNanos};
+  };
+
+  const std::shared_ptr<Metrics> metrics_{std::make_shared<Metrics>()};
+};
+
+} // namespace facebook::velox

--- a/velox/common/base/tests/CMakeLists.txt
+++ b/velox/common/base/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ add_executable(
   StatsReporterTest.cpp
   StatusTest.cpp
   SuccinctPrinterTest.cpp
+  TrackedExecutorTest.cpp
 )
 velox_add_test_headers(velox_base_test GTestUtils.h)
 
@@ -48,6 +49,7 @@ target_link_libraries(
     velox_memory
     velox_time
     velox_status
+    velox_tracked_executor
     velox_exception
     velox_test_util
     Boost::filesystem

--- a/velox/common/base/tests/TrackedExecutorTest.cpp
+++ b/velox/common/base/tests/TrackedExecutorTest.cpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/TrackedExecutor.h"
+
+#include <folly/BenchmarkUtil.h>
+#include <folly/executors/InlineExecutor.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <map>
+#include <stdexcept>
+#include <string>
+
+#include "velox/common/base/RuntimeMetrics.h"
+
+namespace facebook::velox {
+namespace {
+
+// Captures the metrics that TrackedExecutor::reportTo writes so the test can
+// inspect them by name.
+class MapStatWriter : public BaseRuntimeStatWriter {
+ public:
+  void setRuntimeStat(std::string_view name, const RuntimeMetric& metric)
+      override {
+    metrics_.insert_or_assign(std::string{name}, metric);
+  }
+
+  void addRuntimeStat(std::string_view name, const RuntimeCounter& value)
+      override {
+    auto [it, inserted] =
+        metrics_.try_emplace(std::string{name}, RuntimeMetric(value.unit));
+    it->second.addValue(value.value);
+  }
+
+  const std::map<std::string, RuntimeMetric>& metrics() const {
+    return metrics_;
+  }
+
+ private:
+  std::map<std::string, RuntimeMetric> metrics_;
+};
+
+class TrackedExecutorTest : public testing::Test {};
+
+TEST_F(TrackedExecutorTest, reportsPerCallbackMetricsUnderPrefix) {
+  // Run callbacks inline so the per-metric counts are deterministic.
+  TrackedExecutor tracked{
+      folly::getKeepAliveToken(folly::InlineExecutor::instance())};
+
+  constexpr int kNumTasks{4};
+  for (int i = 0; i < kNumTasks; ++i) {
+    tracked.add([] {
+      // Spin to produce non-zero wall and cpu time for the callback.
+      double sink{0};
+      for (int j = 0; j < 1'000'000; ++j) {
+        sink += static_cast<double>(j) * 0.5;
+      }
+      folly::doNotOptimizeAway(sink);
+    });
+  }
+
+  MapStatWriter writer;
+  tracked.reportTo(writer, "myOp");
+  const auto& metrics = writer.metrics();
+
+  ASSERT_THAT(
+      metrics,
+      testing::UnorderedElementsAre(
+          testing::Key("myOp-executorWaitNanos"),
+          testing::Key("myOp-executorExecutionWallNanos"),
+          testing::Key("myOp-executorExecutionCpuNanos")));
+
+  const auto& wait = metrics.at("myOp-executorWaitNanos");
+  const auto& wall = metrics.at("myOp-executorExecutionWallNanos");
+  const auto& cpu = metrics.at("myOp-executorExecutionCpuNanos");
+
+  // Every scheduled callback contributes one sample to each metric.
+  EXPECT_EQ(wait.count, kNumTasks);
+  EXPECT_EQ(wall.count, kNumTasks);
+  EXPECT_EQ(cpu.count, kNumTasks);
+
+  EXPECT_EQ(wait.unit, RuntimeCounter::Unit::kNanos);
+  EXPECT_EQ(wall.unit, RuntimeCounter::Unit::kNanos);
+  EXPECT_EQ(cpu.unit, RuntimeCounter::Unit::kNanos);
+
+  EXPECT_GT(wall.sum, 0);
+  EXPECT_GT(cpu.sum, 0);
+  EXPECT_GE(wait.sum, 0);
+}
+
+TEST_F(TrackedExecutorTest, keepsMetricCountsAlignedWhenCallbackThrows) {
+  TrackedExecutor tracked{
+      folly::getKeepAliveToken(folly::InlineExecutor::instance())};
+
+  // Each metric records one sample even when the callback throws.
+  std::atomic<bool> shouldThrow{true};
+  EXPECT_THROW(
+      tracked.add([&shouldThrow] {
+        if (shouldThrow.load()) {
+          throw std::runtime_error("boom");
+        }
+      }),
+      std::runtime_error);
+
+  MapStatWriter writer;
+  tracked.reportTo(writer, "op");
+  const auto& metrics = writer.metrics();
+
+  EXPECT_EQ(metrics.at("op-executorWaitNanos").count, 1);
+  EXPECT_EQ(metrics.at("op-executorExecutionWallNanos").count, 1);
+  EXPECT_EQ(metrics.at("op-executorExecutionCpuNanos").count, 1);
+}
+
+} // namespace
+} // namespace facebook::velox


### PR DESCRIPTION
Summary:

Add `TrackedExecutor`, a `folly::Executor` wrapper that instruments each submitted callback - recording its enqueue-wait, wall, and CPU time as `RuntimeMetrics` - and publishes them through a `BaseRuntimeStatWriter` via `reportTo(writer, prefix)`. `add()` / `addWithPriority()` delegate to the wrapped executor after instrumentation. It lives in `common/base` alongside the `RuntimeMetric` primitives it produces.

Reviewed By: amitkdutta

Differential Revision: D114426276


