### PR TITLE
build: Build Fizz, Wangle, mvfst, and FBThrift from source

### DIFF
--- a/CMake/ResolveDependency.cmake
+++ b/CMake/ResolveDependency.cmake
@@ -88,6 +88,42 @@ macro(velox_resolve_dependency dependency_name)
   list(POP_BACK CMAKE_MESSAGE_INDENT)
 endmacro()
 
+macro(velox_fetchcontent_makeavailable_without_install dependency_name)
+  FetchContent_GetProperties(${dependency_name} POPULATED __velox_fetchcontent_populated)
+  if(__velox_fetchcontent_populated)
+    message(
+      FATAL_ERROR
+      "FetchContent dependency ${dependency_name} is already populated; "
+      "install suppression cannot be guaranteed"
+    )
+  endif()
+
+  if(DEFINED CMAKE_SKIP_INSTALL_RULES)
+    set(__velox_cmake_skip_install_rules_was_defined TRUE)
+    set(__velox_cmake_skip_install_rules_value "${CMAKE_SKIP_INSTALL_RULES}")
+  else()
+    set(__velox_cmake_skip_install_rules_was_defined FALSE)
+  endif()
+
+  set(CMAKE_SKIP_INSTALL_RULES ON)
+  FetchContent_MakeAvailable(${dependency_name})
+  FetchContent_GetProperties(${dependency_name} BINARY_DIR __velox_fetchcontent_binary_dir)
+  if(NOT __velox_fetchcontent_binary_dir)
+    message(FATAL_ERROR "No binary directory found for FetchContent dependency ${dependency_name}")
+  endif()
+  file(WRITE "${__velox_fetchcontent_binary_dir}/cmake_install.cmake" "")
+
+  if(__velox_cmake_skip_install_rules_was_defined)
+    set(CMAKE_SKIP_INSTALL_RULES "${__velox_cmake_skip_install_rules_value}")
+  else()
+    unset(CMAKE_SKIP_INSTALL_RULES)
+  endif()
+  unset(__velox_cmake_skip_install_rules_value)
+  unset(__velox_cmake_skip_install_rules_was_defined)
+  unset(__velox_fetchcontent_binary_dir)
+  unset(__velox_fetchcontent_populated)
+endmacro()
+
 # By using a macro we don't need to propagate the value into the parent scope.
 macro(velox_set_source dependency_name)
   velox_set_with_default(

--- a/CMake/resolve_dependency_modules/ApplyPatch.cmake
+++ b/CMake/resolve_dependency_modules/ApplyPatch.cmake
@@ -1,0 +1,73 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if(NOT IS_DIRECTORY "${SOURCE_DIR}")
+  message(FATAL_ERROR "Patch source directory does not exist: ${SOURCE_DIR}")
+endif()
+
+if(NOT EXISTS "${PATCH_FILE}")
+  message(FATAL_ERROR "Patch file does not exist: ${PATCH_FILE}")
+endif()
+
+find_program(GIT_EXECUTABLE NAMES git REQUIRED)
+
+# Keep patch paths rooted at SOURCE_DIR instead of an enclosing Git worktree.
+get_filename_component(source_dir "${SOURCE_DIR}" REALPATH)
+get_filename_component(source_parent_dir "${source_dir}" DIRECTORY)
+
+execute_process(
+  COMMAND
+    "${CMAKE_COMMAND}" -E env "--unset=GIT_DIR" "--unset=GIT_WORK_TREE"
+    "GIT_CEILING_DIRECTORIES=${source_parent_dir}" -- "${GIT_EXECUTABLE}" apply --reverse --check --
+    "${PATCH_FILE}"
+  WORKING_DIRECTORY "${source_dir}"
+  RESULT_VARIABLE reverse_check_result
+  OUTPUT_VARIABLE reverse_check_output
+  ERROR_VARIABLE reverse_check_error
+)
+if(reverse_check_result EQUAL 0)
+  message(STATUS "Patch already applied: ${PATCH_FILE}")
+  return()
+endif()
+
+execute_process(
+  COMMAND
+    "${CMAKE_COMMAND}" -E env "--unset=GIT_DIR" "--unset=GIT_WORK_TREE"
+    "GIT_CEILING_DIRECTORIES=${source_parent_dir}" -- "${GIT_EXECUTABLE}" apply --check --
+    "${PATCH_FILE}"
+  WORKING_DIRECTORY "${source_dir}"
+  RESULT_VARIABLE forward_check_result
+  OUTPUT_VARIABLE forward_check_output
+  ERROR_VARIABLE forward_check_error
+)
+if(NOT forward_check_result EQUAL 0)
+  message(
+    FATAL_ERROR
+    "Patch cannot be applied: ${PATCH_FILE}\n"
+    "${forward_check_output}${forward_check_error}"
+  )
+endif()
+
+execute_process(
+  COMMAND
+    "${CMAKE_COMMAND}" -E env "--unset=GIT_DIR" "--unset=GIT_WORK_TREE"
+    "GIT_CEILING_DIRECTORIES=${source_parent_dir}" -- "${GIT_EXECUTABLE}" apply -- "${PATCH_FILE}"
+  WORKING_DIRECTORY "${source_dir}"
+  RESULT_VARIABLE apply_result
+  OUTPUT_VARIABLE apply_output
+  ERROR_VARIABLE apply_error
+)
+if(NOT apply_result EQUAL 0)
+  message(FATAL_ERROR "Failed to apply patch: ${PATCH_FILE}\n${apply_output}${apply_error}")
+endif()

--- a/CMake/resolve_dependency_modules/README.md
+++ b/CMake/resolve_dependency_modules/README.md
@@ -33,10 +33,10 @@ by Velox. See details on bundling below.
 | simdjson          | 4.1.0           | Yes      ||
 | faiss             | 1.11.0          | Yes      ||
 | folly             | v2026.01.05.00  | Yes      ||
-| fizz              | v2026.01.05.00  | No       ||
-| wangle            | v2026.01.05.00  | No       ||
-| mvfst             | v2026.01.05.00  | No       ||
-| fbthrift          | v2026.01.05.00  | No       ||
+| fizz              | v2026.01.05.00  | Yes      ||
+| wangle            | v2026.01.05.00  | Yes      ||
+| mvfst             | v2026.01.05.00  | Yes      ||
+| fbthrift          | v2026.01.05.00  | Yes      ||
 | libstemmer        | 2.2.0           | Yes      ||
 | DuckDB (testing)  | 0.8.1           | Yes      ||
 | arrow             | 15.0.0          | Yes      ||

--- a/CMake/resolve_dependency_modules/boost/CMakeLists.txt
+++ b/CMake/resolve_dependency_modules/boost/CMakeLists.txt
@@ -49,13 +49,6 @@ FetchContent_Declare(
   URL_HASH ${VELOX_BOOST_BUILD_SHA256_CHECKSUM}
 )
 
-# Configure the file before adding the header only libs
-configure_file(
-  ${CMAKE_CURRENT_LIST_DIR}/FindBoost.cmake.in
-  ${CMAKE_CURRENT_LIST_DIR}/FindBoost.cmake
-  @ONLY
-)
-
 set(
   BOOST_HEADER_ONLY
   crc
@@ -68,13 +61,30 @@ set(
   uuid
   variant
 )
-list(APPEND BOOST_INCLUDE_LIBRARIES ${BOOST_HEADER_ONLY})
+list(
+  APPEND
+  BOOST_INCLUDE_LIBRARIES
+  ${BOOST_COMPONENTS}
+  ${BOOST_OPTIONAL_COMPONENTS}
+  ${BOOST_HEADER_ONLY}
+)
 
 # The `headers` target is not created by Boost cmake and leads to a warning
 list(REMOVE_ITEM BOOST_INCLUDE_LIBRARIES headers)
+list(REMOVE_DUPLICATES BOOST_INCLUDE_LIBRARIES)
+
+configure_file(
+  ${CMAKE_CURRENT_LIST_DIR}/FindBoost.cmake.in
+  ${CMAKE_CURRENT_LIST_DIR}/FindBoost.cmake
+  @ONLY
+)
+
 set(BUILD_SHARED_LIBS OFF)
 FetchContent_MakeAvailable(Boost)
 
 list(TRANSFORM BOOST_HEADER_ONLY PREPEND Boost::)
 target_link_libraries(boost_headers INTERFACE ${BOOST_HEADER_ONLY})
 add_library(Boost::headers ALIAS boost_headers)
+if(NOT TARGET Boost::boost)
+  add_library(Boost::boost ALIAS boost_headers)
+endif()

--- a/CMake/resolve_dependency_modules/fbthrift.cmake
+++ b/CMake/resolve_dependency_modules/fbthrift.cmake
@@ -1,0 +1,86 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+include_guard(GLOBAL)
+
+set(VELOX_FBTHRIFT_BUILD_VERSION v2026.01.05.00)
+set(
+  VELOX_FBTHRIFT_BUILD_SHA256_CHECKSUM
+  c266851c7a7c3b6798973250669ac713a2f838203882e312501dc390d36c3f89
+)
+set(
+  VELOX_FBTHRIFT_SOURCE_URL
+  "https://github.com/facebook/fbthrift/archive/refs/tags/${VELOX_FBTHRIFT_BUILD_VERSION}.tar.gz"
+)
+
+velox_resolve_dependency_url(FBTHRIFT)
+
+message(STATUS "Building FBThrift from source")
+FetchContent_Declare(
+  FBThrift
+  URL ${VELOX_FBTHRIFT_SOURCE_URL}
+  URL_HASH ${VELOX_FBTHRIFT_BUILD_SHA256_CHECKSUM}
+  PATCH_COMMAND
+    ${CMAKE_COMMAND} -DSOURCE_DIR=<SOURCE_DIR>
+    -DPATCH_FILE=${CMAKE_CURRENT_LIST_DIR}/fbthrift/compactv1-protocol-refiller.patch -P
+    ${CMAKE_CURRENT_LIST_DIR}/ApplyPatch.cmake COMMAND ${CMAKE_COMMAND} -DSOURCE_DIR=<SOURCE_DIR>
+    -DPATCH_FILE=${CMAKE_CURRENT_LIST_DIR}/fbthrift/cmake-generated-tcc.patch -P
+    ${CMAKE_CURRENT_LIST_DIR}/ApplyPatch.cmake
+  OVERRIDE_FIND_PACKAGE
+  SYSTEM
+  EXCLUDE_FROM_ALL
+)
+
+block()
+  set(enable_tests OFF)
+  set(BUILD_TESTS OFF)
+  set(BUILD_SHARED_LIBS OFF)
+  set(thriftpy3 OFF)
+  velox_fetchcontent_makeavailable_without_install(FBThrift)
+endblock()
+
+FetchContent_GetProperties(FBThrift SOURCE_DIR FBTHRIFT_INCLUDE_DIR)
+if(NOT IS_DIRECTORY "${FBTHRIFT_INCLUDE_DIR}/thrift")
+  message(
+    FATAL_ERROR
+    "Bundled FBThrift include root does not contain thrift/: ${FBTHRIFT_INCLUDE_DIR}"
+  )
+endif()
+if(NOT EXISTS "${FBTHRIFT_INCLUDE_DIR}/thrift/annotation/thrift.thrift")
+  message(
+    FATAL_ERROR
+    "Bundled FBThrift is missing thrift/annotation/thrift.thrift under: ${FBTHRIFT_INCLUDE_DIR}"
+  )
+endif()
+
+if(NOT TARGET thriftcpp2)
+  message(FATAL_ERROR "FBThrift did not define the required thriftcpp2 target")
+endif()
+if(NOT TARGET thriftmetadata)
+  message(FATAL_ERROR "FBThrift did not define the required thriftmetadata target")
+endif()
+if(NOT TARGET FBThrift::thriftcpp2)
+  add_library(FBThrift::thriftcpp2 ALIAS thriftcpp2)
+endif()
+if(NOT TARGET FBThrift::thriftmetadata)
+  add_library(FBThrift::thriftmetadata ALIAS thriftmetadata)
+endif()
+
+if(NOT TARGET thrift1)
+  message(FATAL_ERROR "FBThrift did not define the required thrift1 target")
+endif()
+if(NOT TARGET FBThrift::thrift1)
+  add_executable(FBThrift::thrift1 ALIAS thrift1)
+endif()
+
+set(FBThrift_FOUND true)

--- a/CMake/resolve_dependency_modules/fbthrift/cmake-generated-tcc.patch
+++ b/CMake/resolve_dependency_modules/fbthrift/cmake-generated-tcc.patch
@@ -1,0 +1,11 @@
+--- a/ThriftLibrary.cmake
++++ b/ThriftLibrary.cmake
+@@ -223,7 +223,7 @@ macro(thrift_generate
+     ${output_path}/gen-${language}/${source_file_name}_data.h
+     ${output_path}/gen-${language}/${source_file_name}_metadata.h
+     ${output_path}/gen-${language}/${source_file_name}_types.h
+-    ${output_path}/gen-${language}/${source_file_name}_types.tcch
++    ${output_path}/gen-${language}/${source_file_name}_types.tcc
+     ${output_path}/gen-${language}/${source_file_name}_types_custom_protocol.h
+   )
+   set("${target_file_name}-${language}-SOURCES"

--- a/CMake/resolve_dependency_modules/fizz.cmake
+++ b/CMake/resolve_dependency_modules/fizz.cmake
@@ -1,0 +1,72 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+include_guard(GLOBAL)
+
+set(VELOX_FIZZ_BUILD_VERSION v2026.01.05.00)
+set(
+  VELOX_FIZZ_BUILD_SHA256_CHECKSUM
+  a389a46460a7231e120d37e99130f304ce5efdf5c50e1bf6a2d69e85311a87d1
+)
+set(
+  VELOX_FIZZ_SOURCE_URL
+  "https://github.com/facebookincubator/fizz/archive/refs/tags/${VELOX_FIZZ_BUILD_VERSION}.tar.gz"
+)
+
+velox_resolve_dependency_url(FIZZ)
+
+FetchContent_Declare(
+  fizz
+  URL ${VELOX_FIZZ_SOURCE_URL}
+  URL_HASH ${VELOX_FIZZ_BUILD_SHA256_CHECKSUM}
+  SOURCE_SUBDIR
+  fizz
+  OVERRIDE_FIND_PACKAGE
+  SYSTEM
+  EXCLUDE_FROM_ALL
+)
+
+block()
+  FetchContent_GetProperties(folly SOURCE_DIR FOLLY_INCLUDE_DIR)
+  set(FOLLY_LIBRARIES Folly::folly)
+  set(BUILD_TESTS OFF)
+  set(BUILD_SHARED_LIBS OFF)
+  velox_fetchcontent_makeavailable_without_install(fizz)
+endblock()
+
+if(NOT TARGET fizz)
+  message(FATAL_ERROR "Fizz did not define the required fizz target")
+endif()
+if(NOT TARGET fizz::fizz)
+  add_library(fizz::fizz ALIAS fizz)
+endif()
+
+FetchContent_GetProperties(fizz SOURCE_DIR FIZZ_INCLUDE_DIR)
+block()
+  get_filename_component(_fizz_incorrect_include_dir "${CMAKE_SOURCE_DIR}/.." ABSOLUTE)
+  foreach(_property IN ITEMS INCLUDE_DIRECTORIES INTERFACE_INCLUDE_DIRECTORIES)
+    get_target_property(_include_directories fizz ${_property})
+    string(
+      REPLACE
+      "$<BUILD_INTERFACE:${_fizz_incorrect_include_dir}>"
+      "$<BUILD_INTERFACE:${FIZZ_INCLUDE_DIR}>"
+      _include_directories
+      "${_include_directories}"
+    )
+    set_property(TARGET fizz PROPERTY ${_property} "${_include_directories}")
+  endforeach()
+endblock()
+
+set(FIZZ_LIBRARIES fizz::fizz)
+set(Fizz_FOUND TRUE)
+set(fizz_FOUND TRUE)

--- a/CMake/resolve_dependency_modules/icu.cmake
+++ b/CMake/resolve_dependency_modules/icu.cmake
@@ -89,6 +89,7 @@ foreach(component ${icu_components})
     ICU::${component}
     PROPERTIES
       IMPORTED_LOCATION ${ICU_${component}_LIBRARY}
+      INTERFACE_INCLUDE_DIRECTORIES ${ICU_INCLUDE_DIRS}
       INTERFACE_SYSTEM_INCLUDE_DIRECTORIES ${ICU_INCLUDE_DIRS}
   )
   target_link_libraries(ICU::ICU INTERFACE ICU::${component})

--- a/CMake/resolve_dependency_modules/mvfst.cmake
+++ b/CMake/resolve_dependency_modules/mvfst.cmake
@@ -1,0 +1,60 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+include_guard(GLOBAL)
+
+set(VELOX_MVFST_BUILD_VERSION v2026.01.05.00)
+set(
+  VELOX_MVFST_BUILD_SHA256_CHECKSUM
+  761b4504e542dcf536f5692c387de200acdd287e5ae249afb724963475cd69ca
+)
+set(
+  VELOX_MVFST_SOURCE_URL
+  "https://github.com/facebook/mvfst/archive/refs/tags/${VELOX_MVFST_BUILD_VERSION}.tar.gz"
+)
+
+velox_resolve_dependency_url(MVFST)
+
+FetchContent_Declare(
+  mvfst
+  URL ${VELOX_MVFST_SOURCE_URL}
+  URL_HASH ${VELOX_MVFST_BUILD_SHA256_CHECKSUM}
+  OVERRIDE_FIND_PACKAGE
+  SYSTEM
+  EXCLUDE_FROM_ALL
+)
+
+block()
+  FetchContent_GetProperties(folly SOURCE_DIR FOLLY_INCLUDE_DIR)
+  set(FOLLY_LIBRARIES Folly::folly)
+  FetchContent_GetProperties(fizz SOURCE_DIR FIZZ_INCLUDE_DIR)
+  set(FIZZ_LIBRARIES fizz::fizz)
+  set(BUILD_TESTS OFF)
+  set(BUILD_SHARED_LIBS OFF)
+  velox_fetchcontent_makeavailable_without_install(mvfst)
+endblock()
+
+if(NOT TARGET mvfst_server)
+  message(FATAL_ERROR "mvfst did not define the required mvfst_server target")
+endif()
+if(NOT TARGET mvfst_server_async_tran)
+  message(FATAL_ERROR "mvfst did not define the required mvfst_server_async_tran target")
+endif()
+if(NOT TARGET mvfst::mvfst_server)
+  add_library(mvfst::mvfst_server ALIAS mvfst_server)
+endif()
+if(NOT TARGET mvfst::mvfst_server_async_tran)
+  add_library(mvfst::mvfst_server_async_tran ALIAS mvfst_server_async_tran)
+endif()
+
+set(mvfst_FOUND true)

--- a/CMake/resolve_dependency_modules/wangle.cmake
+++ b/CMake/resolve_dependency_modules/wangle.cmake
@@ -1,0 +1,69 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+include_guard(GLOBAL)
+
+set(VELOX_WANGLE_BUILD_VERSION v2026.01.05.00)
+set(
+  VELOX_WANGLE_BUILD_SHA256_CHECKSUM
+  bd20611ac5e40b03ba2c2a6107f064fc32a502d623eaeb914d80c283b6bd5ca7
+)
+set(
+  VELOX_WANGLE_SOURCE_URL
+  "https://github.com/facebook/wangle/archive/refs/tags/${VELOX_WANGLE_BUILD_VERSION}.tar.gz"
+)
+
+velox_resolve_dependency_url(WANGLE)
+
+FetchContent_Declare(
+  wangle
+  URL ${VELOX_WANGLE_SOURCE_URL}
+  URL_HASH ${VELOX_WANGLE_BUILD_SHA256_CHECKSUM}
+  SOURCE_SUBDIR
+  wangle
+  OVERRIDE_FIND_PACKAGE
+  SYSTEM
+  EXCLUDE_FROM_ALL
+)
+
+block()
+  FetchContent_GetProperties(folly SOURCE_DIR FOLLY_INCLUDE_DIR)
+  set(FOLLY_LIBRARIES Folly::folly)
+  set(BUILD_TESTS OFF)
+  set(BUILD_SHARED_LIBS OFF)
+  velox_fetchcontent_makeavailable_without_install(wangle)
+endblock()
+
+if(NOT TARGET wangle)
+  message(FATAL_ERROR "Wangle did not define the required wangle target")
+endif()
+if(NOT TARGET wangle::wangle)
+  add_library(wangle::wangle ALIAS wangle)
+endif()
+
+block()
+  FetchContent_GetProperties(wangle SOURCE_DIR _wangle_include_dir)
+  foreach(_property IN ITEMS INCLUDE_DIRECTORIES INTERFACE_INCLUDE_DIRECTORIES)
+    get_target_property(_include_directories wangle ${_property})
+    string(
+      REPLACE
+      "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/..>"
+      "$<BUILD_INTERFACE:${_wangle_include_dir}>"
+      _include_directories
+      "${_include_directories}"
+    )
+    set_property(TARGET wangle PROPERTY ${_property} "${_include_directories}")
+  endforeach()
+endblock()
+
+set(wangle_FOUND TRUE)

--- a/CMake/third-party/FBThriftCppLibrary.cmake
+++ b/CMake/third-party/FBThriftCppLibrary.cmake
@@ -105,6 +105,14 @@ function(add_fbthrift_cpp_library LIB_NAME THRIFT_FILE)
     "-I;$<JOIN:$<TARGET_PROPERTY:${LIB_NAME}.thrift_includes,INTERFACE_INCLUDE_DIRECTORIES>,;-I;>"
   )
 
+  if(TARGET FBThrift::thrift1)
+    set(fbthrift_compiler_command "$<TARGET_FILE:FBThrift::thrift1>")
+    set(fbthrift_compiler_dependency FBThrift::thrift1)
+  else()
+    set(fbthrift_compiler_command "${FBTHRIFT_COMPILER}")
+    set(fbthrift_compiler_dependency "${FBTHRIFT_COMPILER}")
+  endif()
+
   # Emit the rule to run the thrift compiler
   add_custom_command(
     OUTPUT
@@ -115,7 +123,7 @@ function(add_fbthrift_cpp_library LIB_NAME THRIFT_FILE)
       "${CMAKE_COMMAND}" -E make_directory "${output_dir}"
     COMMAND
       "${CMAKE_COMMAND}" -E env "LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64:$ENV{LD_LIBRARY_PATH}"
-      "${FBTHRIFT_COMPILER}"
+      "${fbthrift_compiler_command}"
       --legacy-strict
       --gen "mstch_cpp2:${GEN_ARG_STR}"
       "${thrift_include_options}"
@@ -128,7 +136,7 @@ function(add_fbthrift_cpp_library LIB_NAME THRIFT_FILE)
       "${THRIFT_FILE}"
     DEPENDS
       ${ARG_DEPENDS}
-      "${FBTHRIFT_COMPILER}"
+      "${fbthrift_compiler_dependency}"
   )
 
   add_library("${LIB_NAME}" STATIC ${generated_sources})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -578,6 +578,7 @@ set(
   context
   date_time
   filesystem
+  iostreams
   program_options
   regex
   thread
@@ -692,11 +693,17 @@ if(${VELOX_BUILD_TESTING})
 endif()
 
 if(VELOX_ENABLE_REMOTE_FUNCTIONS OR VELOX_ENABLE_PARQUET)
-  # TODO: Move this to use resolve_dependency(). For some reason, FBThrift
-  # requires clients to explicitly install fizz and wangle.
-  find_package(fizz CONFIG REQUIRED)
-  find_package(wangle CONFIG REQUIRED)
-  find_package(FBThrift CONFIG REQUIRED)
+  velox_set_source(fizz)
+  velox_resolve_dependency(fizz CONFIG REQUIRED)
+
+  velox_set_source(wangle)
+  velox_resolve_dependency(wangle CONFIG REQUIRED)
+
+  velox_set_source(mvfst)
+  velox_resolve_dependency(mvfst CONFIG REQUIRED)
+
+  velox_set_source(FBThrift)
+  velox_resolve_dependency(FBThrift CONFIG REQUIRED)
 
   # Workaround for a missing edge in the system-installed FBThrift's
   # exported CMake graph. At the pinned FB_OS_VERSION, fbthrift's own
@@ -717,11 +724,22 @@ if(VELOX_ENABLE_REMOTE_FUNCTIONS OR VELOX_ENABLE_PARQUET)
   # against that fixed fbthrift release.
   if(TARGET FBThrift::thriftmetadata)
     find_library(VELOX_XXHASH_LIB xxhash REQUIRED)
-    set_property(
-      TARGET FBThrift::thriftmetadata
-      APPEND
-      PROPERTY INTERFACE_LINK_LIBRARIES "${VELOX_XXHASH_LIB}"
-    )
+    block()
+      set(fbthrift_thriftmetadata_target FBThrift::thriftmetadata)
+      get_target_property(
+        fbthrift_thriftmetadata_aliased_target
+        FBThrift::thriftmetadata
+        ALIASED_TARGET
+      )
+      if(fbthrift_thriftmetadata_aliased_target)
+        set(fbthrift_thriftmetadata_target "${fbthrift_thriftmetadata_aliased_target}")
+      endif()
+      set_property(
+        TARGET "${fbthrift_thriftmetadata_target}"
+        APPEND
+        PROPERTY INTERFACE_LINK_LIBRARIES "${VELOX_XXHASH_LIB}"
+      )
+    endblock()
   endif()
 endif()
 


### PR DESCRIPTION
## Summary

- Resolve Fizz, Wangle, mvfst, and FBThrift through Velox's dependency
  framework, addressing the TODO introduced by #7941.
- Support building these dependencies from their pinned source releases when
  `VELOX_DEPENDENCY_SOURCE=BUNDLED` is selected.
- Use the in-tree FBThrift compiler for code generation and fix its declared
  generated output so incremental builds do not regenerate unchanged files.
- Complete the bundled dependency graph with the required Boost and ICU target
  metadata.

## Testing

- Built the Debug configuration with bundled dependencies, Parquet, tests, and
  benchmarks enabled.