### PR TITLE
perf: Skip string conversion for single-element array_join (#18361)

### DIFF
--- a/velox/functions/prestosql/ArrayFunctions.h
+++ b/velox/functions/prestosql/ArrayFunctions.h
@@ -188,6 +188,7 @@ struct ArrayJoinFunction {
         inputTypes[0]->isArray(),
         "Array join's first parameter type has to be array");
     arrayElementType_ = inputTypes[0]->asArray().elementType();
+    isJsonElementType_ = isJsonType(arrayElementType_);
   }
 
   template <typename C>
@@ -252,11 +253,25 @@ struct ArrayJoinFunction {
       const arg_type<velox::Array<T>>& inputArray,
       const arg_type<velox::Varchar>& delim,
       std::optional<std::string> nullReplacement = std::nullopt) {
-    bool firstNonNull = true;
     if (inputArray.size() == 0) {
       return;
     }
 
+    // A single element is written without a delimiter, so for VARCHAR the
+    // result is the element verbatim and can be copied straight into the
+    // output, skipping the intermediate string that the conversion in
+    // writeValue() would build. JSON is excluded: its elements are unescaped.
+    if constexpr (std::is_same_v<T, Varchar>) {
+      if (inputArray.size() == 1 && !isJsonElementType_) {
+        const auto element = inputArray[0];
+        if (element.has_value()) {
+          result.append(element.value());
+          return;
+        }
+      }
+    }
+
+    bool firstNonNull{true};
     for (const auto& entry : inputArray) {
       if (entry.has_value()) {
         writeOutput(result, delim, entry.value(), firstNonNull);
@@ -286,6 +301,9 @@ struct ArrayJoinFunction {
  private:
   TimestampToStringOptions options_;
   TypePtr arrayElementType_;
+  // Whether the elements need JSON unescaping, which rules out returning them
+  // without a copy.
+  bool isJsonElementType_{false};
 };
 
 /// Function Signature: combinations(array(T), n) -> array(array(T))

--- a/velox/functions/prestosql/benchmarks/ArrayJoinBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ArrayJoinBenchmark.cpp
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "velox/benchmarks/ExpressionBenchmarkBuilder.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/functions/prestosql/types/JsonRegistration.h"
+#include "velox/functions/prestosql/types/JsonType.h"
+
+using namespace facebook::velox;
+
+namespace {
+
+constexpr vector_size_t kNumRows = 1'000;
+
+// Strings of this length are stored inline in the StringView, so joining them
+// never touches a string buffer.
+constexpr size_t kInlineElementLength = 8;
+
+// Strings of this length exceed the inline capacity of a StringView and live
+// in a string buffer, which is what a no-copy result can reference.
+constexpr size_t kBufferedElementLength = 32;
+
+// Builds an array vector of 'kNumRows' rows, each holding 'arrayLength'
+// strings of 'elementLength' characters. JSON elements are quoted so that
+// they are valid JSON scalars.
+ArrayVectorPtr makeStringArrays(
+    test::VectorMaker& vectorMaker,
+    vector_size_t arrayLength,
+    size_t elementLength,
+    const TypePtr& elementType) {
+  const bool quoteElements = isJsonType(elementType);
+  return vectorMaker.arrayVector<std::string>(
+      kNumRows,
+      [arrayLength](vector_size_t /*row*/) { return arrayLength; },
+      [elementLength, quoteElements](vector_size_t row, vector_size_t index) {
+        const std::string element(
+            elementLength, static_cast<char>('a' + (row + index) % 26));
+        return quoteElements ? "\"" + element + "\"" : element;
+      },
+      nullptr,
+      ARRAY(elementType));
+}
+
+// Builds an ARRAY(VARCHAR) vector whose odd-numbered elements are null, so
+// that the null replacement argument is actually exercised.
+ArrayVectorPtr makeVarcharArraysWithNulls(
+    test::VectorMaker& vectorMaker,
+    vector_size_t arrayLength) {
+  return vectorMaker.arrayVector<std::string>(
+      kNumRows,
+      [arrayLength](vector_size_t /*row*/) { return arrayLength; },
+      [](vector_size_t index) {
+        return std::string(
+            kBufferedElementLength, static_cast<char>('a' + index % 26));
+      },
+      nullptr,
+      [](vector_size_t index) { return index % 2 == 1; });
+}
+
+ArrayVectorPtr makeBigintArrays(
+    test::VectorMaker& vectorMaker,
+    vector_size_t arrayLength) {
+  return vectorMaker.arrayVector<int64_t>(
+      kNumRows,
+      [arrayLength](vector_size_t /*row*/) { return arrayLength; },
+      [](vector_size_t row, vector_size_t index) {
+        return static_cast<int64_t>(row) * 31 + index;
+      });
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  folly::Init init{&argc, &argv};
+  memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+
+  ExpressionBenchmarkBuilder benchmarkBuilder;
+  functions::prestosql::registerAllScalarFunctions();
+  registerJsonType();
+
+  auto& vectorMaker = benchmarkBuilder.vectorMaker();
+
+  // Varchar elements that live in a string buffer. A one-element array joins
+  // to the element itself, so it can be returned without copying; the longer
+  // arrays are controls that no single-element fast path can affect.
+  benchmarkBuilder
+      .addBenchmarkSet(
+          "array_join_varchar",
+          vectorMaker.rowVector({
+              makeStringArrays(
+                  vectorMaker, 1, kBufferedElementLength, VARCHAR()),
+              makeStringArrays(
+                  vectorMaker, 2, kBufferedElementLength, VARCHAR()),
+              makeStringArrays(
+                  vectorMaker, 4, kBufferedElementLength, VARCHAR()),
+              makeStringArrays(
+                  vectorMaker, 32, kBufferedElementLength, VARCHAR()),
+          }))
+      .addExpression("1_element", "array_join(c0, '_')")
+      .addExpression("2_elements", "array_join(c1, '_')")
+      .addExpression("4_elements", "array_join(c2, '_')")
+      .addExpression("32_elements", "array_join(c3, '_')")
+      .disableTesting();
+
+  // The same shape with inlined elements, where returning the element without
+  // copying saves the conversion but no buffer reference.
+  benchmarkBuilder
+      .addBenchmarkSet(
+          "array_join_varchar_inlined",
+          vectorMaker.rowVector({
+              makeStringArrays(vectorMaker, 1, kInlineElementLength, VARCHAR()),
+              makeStringArrays(vectorMaker, 2, kInlineElementLength, VARCHAR()),
+              makeStringArrays(
+                  vectorMaker, 32, kInlineElementLength, VARCHAR()),
+          }))
+      .addExpression("1_element", "array_join(c0, '_')")
+      .addExpression("2_elements", "array_join(c1, '_')")
+      .addExpression("32_elements", "array_join(c2, '_')")
+      .disableTesting();
+
+  // JSON elements are unescaped into a new string, so they can never be
+  // returned without copying however short the array is.
+  benchmarkBuilder
+      .addBenchmarkSet(
+          "array_join_json",
+          vectorMaker.rowVector({
+              makeStringArrays(vectorMaker, 1, kBufferedElementLength, JSON()),
+              makeStringArrays(vectorMaker, 4, kBufferedElementLength, JSON()),
+          }))
+      .addExpression("1_element", "array_join(c0, '_')")
+      .addExpression("4_elements", "array_join(c1, '_')")
+      .disableTesting();
+
+  // Non-string elements, which are always converted into a new string.
+  benchmarkBuilder
+      .addBenchmarkSet(
+          "array_join_bigint",
+          vectorMaker.rowVector({
+              makeBigintArrays(vectorMaker, 1),
+              makeBigintArrays(vectorMaker, 32),
+          }))
+      .addExpression("1_element", "array_join(c0, '_')")
+      .addExpression("32_elements", "array_join(c1, '_')")
+      .disableTesting();
+
+  // The three-argument form against the two-argument one over identical
+  // input, isolating the cost of supplying a null replacement.
+  benchmarkBuilder
+      .addBenchmarkSet(
+          "array_join_null_replacement",
+          vectorMaker.rowVector({
+              makeVarcharArraysWithNulls(vectorMaker, 4),
+          }))
+      .addExpression("without_replacement", "array_join(c0, '_')")
+      .addExpression(
+          "with_replacement",
+          "array_join(c0, '_', 'a_null_replacement_longer_than_inline')")
+      .disableTesting();
+
+  benchmarkBuilder.registerBenchmarks();
+
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/functions/prestosql/benchmarks/CMakeLists.txt
+++ b/velox/functions/prestosql/benchmarks/CMakeLists.txt
@@ -35,6 +35,15 @@ add_executable(velox_functions_prestosql_benchmarks_array_contains ArrayContains
 velox_add_test_headers(velox_functions_prestosql_benchmarks_array_contains ArrayPositionBasic.h)
 target_link_libraries(velox_functions_prestosql_benchmarks_array_contains ${BENCHMARK_DEPENDENCIES})
 
+add_executable(
+  velox_functions_prestosql_benchmarks_array_join
+  ArrayJoinBenchmark.cpp
+)
+target_link_libraries(
+  velox_functions_prestosql_benchmarks_array_join
+  ${BENCHMARK_DEPENDENCIES}
+)
+
 add_executable(velox_functions_prestosql_benchmarks_array_min_max ArrayMinMaxBenchmark.cpp)
 velox_add_test_headers(velox_functions_prestosql_benchmarks_array_min_max ArrayMinMaxBenchmark.h)
 target_link_libraries(velox_functions_prestosql_benchmarks_array_min_max ${BENCHMARK_DEPENDENCIES})

--- a/velox/functions/prestosql/tests/ArrayJoinTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayJoinTest.cpp
@@ -110,6 +110,33 @@ TEST_F(ArrayJoinTest, varcharTest) {
 
   testArrayJoinReplacement<StringView>(
       {"a"_sv, "b"_sv, std::nullopt, "c"_sv}, "-"_sv, "z"_sv, "a-b-z-c"_sv);
+
+  // A single element is written without a delimiter.
+  testArrayJoinNoReplacement<StringView>({"a"_sv}, "-"_sv, "a"_sv);
+  testArrayJoinNoReplacement<StringView>({std::nullopt}, "-"_sv, ""_sv);
+  testArrayJoinReplacement<StringView>({std::nullopt}, "-"_sv, "z"_sv, "z"_sv);
+}
+
+TEST_F(ArrayJoinTest, singleVarcharElementDoesNotAliasInput) {
+  // Joining a one-element array yields the element verbatim, but as a new
+  // string rather than a view over the input. Aliasing the input would make the
+  // result retain the whole buffer backing the elements vector, which costs far
+  // more memory than the copy saves. The strings must exceed 12 bytes, or they
+  // would be inlined in the StringView and no buffer would be shared either
+  // way.
+  const auto elements = makeFlatVector<StringView>(
+      {"first string that is not inlined"_sv,
+       "second string that is not inlined"_sv});
+  const auto arrays = makeArrayVector({0, 1}, elements);
+
+  const auto result = evaluate<FlatVector<StringView>>(
+      "array_join(c0, '-')", makeRowVector({arrays}));
+
+  assertEqualVectors(elements, result);
+  for (auto row = 0; row < elements->size(); ++row) {
+    EXPECT_NE(result->valueAt(row).data(), elements->valueAt(row).data())
+        << "Row " << row << " aliases the input, pinning its string buffers.";
+  }
 }
 
 TEST_F(ArrayJoinTest, boolTest) {


### PR DESCRIPTION
Summary:

array_join on a one-element array produces that element itself, because no delimiter is ever written. For VARCHAR elements the result is therefore the input string verbatim, but the generic loop still routed it through Converter<TypeKind::VARCHAR>::tryCast, which builds an intermediate std::string before it is appended to the output. Copy the element straight into the output instead.

The shape is common in generated SQL, which often wraps a scalar in a one-element array and then joins it back into a scalar, for example:

    SELECT array_join(ARRAY[n_name], ':') FROM nation

The fast path is limited to VARCHAR, since every other element type has to be converted before its bytes exist. JSON is excluded as well, because its elements are unescaped into a new string; that check uses an element type cached at construction rather than a per-element type test.

Add a benchmark for the function while here. Median of three alternating runs on the same host, fbcode//mode/opt:

                                              before      after    change
    array_join_varchar##1_element            43.33ms    24.03ms    -44.5%
    array_join_varchar_inlined##1_element    40.03ms    24.23ms    -39.5%

A single element is 1.8x faster when it lives in a string buffer and 1.7x faster when it is short enough to be inlined in the StringView. The other eleven cases in the benchmark are controls and stay within the +/-3% run-to-run spread, including JSON and bigint at length one, which confirms both exclusions hold. Single runs on this benchmark swing by up to 13% without reproducing, so the numbers above are medians.

The result owns its bytes rather than referencing the input's string buffers. A StringView holds no ownership of its slice, so retention is per-buffer and all-or-nothing: letting the result alias the input would make one surviving row pin the whole buffer that backs the elements vector. Measured on a one-row slice of a 1.3 MB arena, that retains all 1.3 MB to serve 128 bytes.

Reviewed By: Yuhta

Differential Revision: D114483799


