### PR TITLE
refactor(writer): Move the writer dependencies to dwio/nimble/writer (#18362)

### DIFF
--- a/velox/connectors/hive/iceberg/tests/IcebergNimbleInsertTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergNimbleInsertTest.cpp
@@ -21,7 +21,7 @@
 #ifdef VELOX_ENABLE_NIMBLE
 
 #include "dwio/nimble/velox/reader/fb/NimbleReader.h"
-#include "dwio/nimble/velox/writer/fb/NimbleWriter.h"
+#include "dwio/nimble/writer/fb/NimbleWriter.h"
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
 #include "velox/connectors/hive/iceberg/tests/IcebergTestBase.h"

--- a/velox/connectors/hive/iceberg/tests/WriterOptionsAdapterTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/WriterOptionsAdapterTest.cpp
@@ -18,7 +18,7 @@
 
 #include <gtest/gtest.h>
 #ifdef VELOX_ENABLE_NIMBLE
-#include "dwio/nimble/velox/writer/fb/NimbleWriter.h"
+#include "dwio/nimble/writer/fb/NimbleWriter.h"
 #endif
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/nimble/pull/1053


Pure relocation, no behavior change. Groups the Nimble write path into its own top-level package ahead of merging the `NimbleWriter` adapter into `VeloxWriter`.

Addresses xiaoxmeng's review comment on `crystaldb/src/nimble_column_group_writer.cpp`: the destination is `dwio/nimble/writer/`, not `dwio/nimble/velox/writer/`. The writer never depended on being under `velox/` -- it sits alongside `dwio/nimble/{common,encodings,index,tablet,serializer}` like every other Nimble subsystem, and `dwio/nimble/velox/` is left holding the reader and the shared schema/field plumbing.

Note that `dwio/nimble/velox/writer/` already existed on trunk, holding `EncodingSelectionPolicyFactory` and the internal-only `fb/` glue. So this is two things at once: that directory is renamed up a level, and the writer core is pulled into it out of `dwio/nimble/velox/`.

Renamed out of `dwio/nimble/velox/` into `dwio/nimble/writer/`:

- `VeloxWriter.{h,cpp}`, `VeloxWriterOptions.h`, `VeloxWriterDefaultMetadataOSS.cpp`
- `BufferPolicy.h`, `FlushPolicy.{h,cpp}`, `FlushPolicyFactory.{h,cpp}`
- `EncodingLayoutTree.{h,cpp}`, `StreamChunker.{h,cpp}`
- `fb/VeloxWriterDefaultMetadata.cpp` -> `fb/`

Renamed out of `dwio/nimble/velox/writer/` into `dwio/nimble/writer/`:

- `BUCK`, `EncodingSelectionPolicyFactory.{h,cpp}`
- `fb/NimbleWriter.{h,cpp}`, `fb/NimbleWriterOptionBuilder.{h,cpp}`, `fb/NimbleFileMetadata.h`
- `fb/tests/{BUCK,NimbleWriterOptionBuilderTest.cpp,NimbleWriterStatsTest.cpp}`

Renamed out of `dwio/nimble/velox/writer/fb/` into `fb_velox/common/`:

- `KnobsFeatureGate.cpp`, and its test into `fb_velox/common/tests/`

`FeatureGate.{h,cpp}` stays in `dwio/nimble/common/` where it already lived; only its JustKnobs-backed implementation moves. `fb_velox/common/` is the right home for it -- it is a process-wide dynamic-config binding rather than anything writer-specific, and that package is already `oncall(dwios)`, so ownership is unchanged. `KnobsFeatureGate` self-registers through `link_whole`, so `nimble-write-option-builder` keeps depending on it by target and every internal write path resolves the rollout knobs exactly as before.

Buck targets move with the files:

| before | after |
| --- | --- |
| `//dwio/nimble/velox:velox_writer` | `//dwio/nimble/writer:velox_writer` |
| `//dwio/nimble/velox:velox_writer_options` | `//dwio/nimble/writer:velox_writer_options` |
| `//dwio/nimble/velox:stream_chunker` | `//dwio/nimble/writer:stream_chunker` |
| `//dwio/nimble/velox/writer:writer` | `//dwio/nimble/writer:writer` |
| `//dwio/nimble/velox/writer:nimble-write-option-builder` | `//dwio/nimble/writer:nimble-write-option-builder` |
| `//dwio/nimble/velox/writer:encoding_selection_policy_factory` | `//dwio/nimble/writer:encoding_selection_policy_factory` |
| `//dwio/nimble/velox/writer:knobs-feature-gate` | `//fb_velox/common:knobs_feature_gate` |

The rest is mechanical fallout: rewritten `#include` paths and Buck dep labels across `dwio`, `fb_velox`, `fb_presto_cpp`, `gluten`, `rexdb`, `rocks`, `laser`, `zippydb`, `crystaldb`, `datainfra`, `nimble_tensor`, `impulse_lib`, `columnstore`, `admarket`, `instagram`, `xldb`, `velox` and `scripts`. On the OSS side the `nimble_velox_writer` CMake target keeps its name and link wiring and moves to a new `dwio/nimble/writer/CMakeLists.txt`, registered from the root `CMakeLists.txt`; it picks up `ChunkedStreamWriter.cpp` by path since that file stays next to its reader-side counterparts.

Notes for the reviewer:
- `KnobsFeatureGate` introduces a `dwio/nimble` -> `fb_velox` target edge (`nimble-write-option-builder` -> `//fb_velox/common:knobs_feature_gate`). No Buck cycle, and ownership is unchanged, but it is a new direction of dependency worth a look.
- `StreamChunker.cpp` is listed in both `:stream_chunker` and `:velox_writer`. That duplication is pre-existing; it is carried over verbatim rather than fixed here to keep this diff a pure move.
- `VeloxWriterDefaultMetadataOSS.cpp` is the OSS/CMake-only stub for `nimble::detail::defaultMetadata()` (the internal build uses `fb/VeloxWriterDefaultMetadata.cpp`). It has no Buck target -- matching trunk, where the old path also had none. AUTODEPS2 initially generated an orphan `:VeloxWriterDefaultMetadataOSS` cpp_library for it during the move; that target was removed because composing it with `:velox_writer` would duplicate the `defaultMetadata()` symbol.

Rebase / non-relocation fallout, disclosed for completeness (all AUTODEPS2-driven, in BUCK files the rename already touches):
- `scripts/suryadev/experimental/dpp/BUCK`: `//caffe2:ATen-cpp` `exported_deps` -> `deps` fix.
- `dwio/nimble/tools/fb/BUCK`: `external_deps = ["sqlite"]` on `dump_nimble_tablet_to_database`.
- `dwio/nimble/tools/BUCK`: added `//dwio/nimble/tablet:tablet_reader` dep.
- `dwio/utils/BUCK`: `googletest:gtest` -> `googletest:gtest_headers`.
- `velox/connectors/hive/iceberg/BUCK` and `fb_velox/connectors/prism/tests/BUCK`: `_cpp_lib` target-name variants.
- Rebased onto master: resolved conflicts in `dwio/nimble/velox/BUCK` (removed the moved `stream_chunker`/`velox_writer` targets) and `xldb/experimental/iceberg/koski/tests/E2ETest.cpp` (kept trunk's new `iceberg/*` includes alongside the relocated `dwio/nimble/writer/VeloxWriter.h`). Trunk's newly added `//velox/buffer:velox_buffer` dep on `velox_writer` is carried onto the moved target.

Two files under `ads/nano/nano_oc/experiments/` cite the old path in prose. They are dated experiment write-ups, so they are left describing the tree as it was when the experiment ran.

Reviewed By: xiaoxmeng

Differential Revision: D114316950
