### PR TITLE
refactor(writer): Rename fb/NimbleWriter to WriterFactory (#18363)

### DIFF
--- a/velox/connectors/hive/iceberg/tests/IcebergNimbleInsertTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergNimbleInsertTest.cpp
@@ -21,7 +21,7 @@
 #ifdef VELOX_ENABLE_NIMBLE
 
 #include "dwio/nimble/velox/reader/fb/NimbleReader.h"
-#include "dwio/nimble/writer/fb/NimbleWriter.h"
+#include "dwio/nimble/writer/WriterFactory.h"
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
 #include "velox/connectors/hive/iceberg/tests/IcebergTestBase.h"

--- a/velox/connectors/hive/iceberg/tests/IcebergNimbleInsertTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergNimbleInsertTest.cpp
@@ -21,7 +21,7 @@
 #ifdef VELOX_ENABLE_NIMBLE
 
 #include "dwio/nimble/velox/reader/fb/NimbleReader.h"
-#include "dwio/nimble/velox/writer/fb/NimbleWriter.h"
+#include "dwio/nimble/writer/fb/NimbleWriter.h"
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
 #include "velox/connectors/hive/iceberg/tests/IcebergTestBase.h"

--- a/velox/connectors/hive/iceberg/tests/WriterOptionsAdapterTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/WriterOptionsAdapterTest.cpp
@@ -18,7 +18,7 @@
 
 #include <gtest/gtest.h>
 #ifdef VELOX_ENABLE_NIMBLE
-#include "dwio/nimble/writer/fb/NimbleWriter.h"
+#include "dwio/nimble/writer/WriterFactory.h"
 #endif
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
@@ -197,9 +197,10 @@ TEST(WriterOptionsAdapterTest, toManifestFormatStringThrowsForUnsupported) {
 // type attributes onto Nimble writer options via the WriterOptionsAdapter.
 // The adapter converts the IcebergFieldId tree into dotted-path attributes
 // (e.g., "a.b" -> {"iceberg.id":"2", "iceberg.required":"true"}) that survive
-// through NimbleWriterFactory into the Nimble file schema. These tests ensure
-// the writer-side contract is preserved: empty trees are no-ops for backward
-// compatibility, and populated trees produce correct per-column attributes.
+// through the Nimble WriterFactory into the Nimble file schema. These tests
+// ensure the writer-side contract is preserved: empty trees are no-ops for
+// backward compatibility, and populated trees produce correct per-column
+// attributes.
 // ---------------------------------------------------------------------------
 
 // Verifies an empty Iceberg field-id tree is a no-op: schemaAttributes

--- a/velox/connectors/hive/iceberg/tests/WriterOptionsAdapterTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/WriterOptionsAdapterTest.cpp
@@ -18,7 +18,7 @@
 
 #include <gtest/gtest.h>
 #ifdef VELOX_ENABLE_NIMBLE
-#include "dwio/nimble/velox/writer/fb/NimbleWriter.h"
+#include "dwio/nimble/writer/fb/NimbleWriter.h"
 #endif
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/nimble/pull/1056


Naming and placement cleanup, no behavior change.

After the preceding diffs moved the writer internals into `VeloxWriter` and deleted `NimbleWriterAdapter`, `fb/NimbleWriter.{h,cpp}` no longer contains a writer. What is left is the Velox connector registration surface:

- `NimbleWriterOptions : dwio::common::WriterOptions` -- connector-facing options (`encodingExecutor`, `schemaAttributes`) plus `processConfigs()`, which maps session and connector config onto serde params
- `WriterFactory : dwio::common::WriterFactory` -- `createWriter()` (serde params to `VeloxWriterOptions`, optional `BufferedWriteFile` wrapping, sink dispatch) and `createWriterOptions()`
- `registerNimbleWriterFactory()` / `unregisterNimbleWriterFactory()`, which is what Prestissimo and Gluten call
- `kNimbleWriteFileBufferSizeBytesKey`

So the file is renamed to `WriterFactory.{h,cpp}` to say what it holds, and moved out of `fb/` up to `dwio/nimble/writer/`. Every header it includes is OSS-clean; the one remaining internal edge is a Buck dep rather than an include -- `//fb_velox/common:knobs_feature_gate`, reached indirectly through `nimble-write-option-builder`, which exists so the JustKnobs gate self-registers via `link_whole`. The file therefore stays internal-only in practice: `dwio/nimble/writer/CMakeLists.txt` does not list it.

The Buck target keeps its name (`//dwio/nimble/writer:writer`), so dependents are unaffected.

**What the rename does and does not cover.** The class drops its `Nimble` prefix because it already lives in namespace `facebook::velox::nimble`, so call sites now read `velox::nimble::WriterFactory` instead of the stuttering `velox::nimble::NimbleWriterFactory`. Two names deliberately keep the prefix:

- `registerNimbleWriterFactory()` / `unregisterNimbleWriterFactory()` are the registration API that Prestissimo, Gluten, Axel, Axiom, and the Prism connector call, often unqualified or alongside `registerDwrfWriterFactory()`. Renaming them would churn every caller for no clarity gain, and `registerWriterFactory()` would collide with the `dwio::common` free function of that name.
- `NimbleWriterOptions` cannot become `WriterOptions`: that is the name of its own base class, `dwio::common::WriterOptions`.

Note the one non-obvious consequence of the rename, already called out inline: the constructor's base initializer must be spelled `dwio::common::WriterFactory(...)`, because an unqualified `WriterFactory(...)` now resolves to the derived class and would silently become a delegating constructor to itself.

Twenty-three `#include` sites move to the new header path, and two sites name the class directly (`admarket/.../DeltaWriter.cpp` and `fb_velox/dwio/nimble/tests/NimbleWriterTest.cpp`).

`NimbleWriterOptionBuilder` stays in `fb/` for now. It is a shared builder with ten consumers outside this package, so folding it into the factory is not a rename -- it would be a real API consolidation, and is deliberately left for later.

Reviewed By: xiaoxmeng

Differential Revision: D114495630
