### PR TITLE
refactor(type): Consolidate is_shared_ptr trait into Type.h (#18365)

### DIFF
--- a/velox/core/Metaprogramming.h
+++ b/velox/core/Metaprogramming.h
@@ -21,12 +21,6 @@
 
 namespace facebook::velox::util {
 
-template <typename T>
-struct is_shared_ptr : std::false_type {};
-
-template <typename T>
-struct is_shared_ptr<std::shared_ptr<T>> : std::true_type {};
-
 template <template <typename> class Transformer, typename E>
 struct tuple_xform {};
 

--- a/velox/expression/ComplexViewTypes.h
+++ b/velox/expression/ComplexViewTypes.h
@@ -463,7 +463,7 @@ auto materializeElement(const T& element) {
     return element.materialize();
   } else {
     using unwrapped_type = typename UnwrapCustomType<VeloxType>::type;
-    if constexpr (util::is_shared_ptr<unwrapped_type>::value) {
+    if constexpr (is_shared_ptr<unwrapped_type>::value) {
       return *element;
     } else {
       return element;

--- a/velox/expression/ComplexWriterTypes.h
+++ b/velox/expression/ComplexWriterTypes.h
@@ -311,7 +311,7 @@ class ArrayWriter {
         auto& writer = add_item();
         // Handle copy_from for opaque and opaque custom types.
         using unwrapped_type = typename UnwrapCustomType<V>::type;
-        if constexpr (util::is_shared_ptr<unwrapped_type>::value) {
+        if constexpr (is_shared_ptr<unwrapped_type>::value) {
           writer =
               std::make_shared<typename unwrapped_type::element_type>(item);
         } else {

--- a/velox/type/SimpleFunctionApi.h
+++ b/velox/type/SimpleFunctionApi.h
@@ -120,11 +120,9 @@ template <typename T, bool comparable, bool orderable>
 struct isGenericType<Generic<T, comparable, orderable>>
     : public std::true_type {};
 
-template <typename>
-struct isOpaqueType : public std::false_type {};
-
+// std::shared_ptr<T> is the C++ representation of the OPAQUE type.
 template <typename T>
-struct isOpaqueType<std::shared_ptr<T>> : public std::true_type {};
+struct isOpaqueType : public is_shared_ptr<T> {};
 
 template <typename KEY, typename VALUE>
 struct Map {

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1467,6 +1467,14 @@ class OpaqueType : public TypeBase<TypeKind::OPAQUE> {
 
 using OpaqueTypePtr = std::shared_ptr<const OpaqueType>;
 
+/// Evaluates to true only for std::shared_ptr<T>, the physical value type
+/// stored in OPAQUE vectors.
+template <typename>
+struct is_shared_ptr : public std::false_type {};
+
+template <typename T>
+struct is_shared_ptr<std::shared_ptr<T>> : public std::true_type {};
+
 using IntegerType = ScalarType<TypeKind::INTEGER>;
 using BooleanType = ScalarType<TypeKind::BOOLEAN>;
 using TinyintType = ScalarType<TypeKind::TINYINT>;


### PR DESCRIPTION
Summary:

`is_shared_ptr` (true only for `std::shared_ptr<T>`) is useful below the
simple-function layer: `std::shared_ptr` is the physical value type stored in
OPAQUE vectors, so `velox/vector` needs it to tell which reads would incur an
atomic refcount bump (see the child diff). It previously lived in
`velox/core/Metaprogramming.h`, which `velox/vector` cannot include without a
`velox/vector` -> `velox/core` layering inversion.

This moves the trait to `Type.h` -- the lowest layer that both `velox/vector` and
`velox/core` already depend on -- and removes the `velox::util` copy so there is
a single definition rather than the same predicate under two namespaces.

The trait keeps its snake_case name, matching Velox's convention for generic,
STL-style type predicates. `SimpleFunctionApi.h::isOpaqueType` is now a one-line
alias derived from it -- the same predicate, since the C++ representation of
OPAQUE is `std::shared_ptr` -- so its callers are unchanged.

Note `Metaprogramming.h::is_smart_pointer` is a separate, independent trait and
is untouched.

Differential Revision: D114486542


