### PR TITLE
Add Spark xpath_boolean and xpath_string functions

### DIFF
--- a/CMake/resolve_dependency_modules/libxml2.cmake
+++ b/CMake/resolve_dependency_modules/libxml2.cmake
@@ -1,0 +1,66 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+include_guard(GLOBAL)
+
+# This creates a separate scope so any changed variables don't affect
+# the rest of the build.
+block()
+  set(VELOX_LIBXML2_BUILD_VERSION 2.13.5)
+  set(
+    VELOX_LIBXML2_BUILD_SHA256_CHECKSUM
+    74fc163217a3964257d3be39af943e08861263c4231f9ef5b496b6f6d4c7b2b6
+  )
+  string(
+    CONCAT
+    VELOX_LIBXML2_SOURCE_URL
+    "https://download.gnome.org/sources/libxml2/2.13/"
+    "libxml2-${VELOX_LIBXML2_BUILD_VERSION}.tar.xz"
+  )
+
+  velox_resolve_dependency_url(LIBXML2)
+
+  message(STATUS "Building libxml2 from source")
+
+  # Build a minimal, self-contained libxml2: only the parser and XPath engine
+  # used by the Spark XML functions are needed. Optional subsystems and
+  # external library integrations (Python bindings, programs, tests, iconv,
+  # ICU, lzma, zlib, dynamic modules) are disabled so the bundled build does
+  # not pull in additional system dependencies. Thread support stays ON because
+  # the XPath engine relies on libxml2's per-thread error-handler state.
+  set(LIBXML2_WITH_PYTHON OFF)
+  set(LIBXML2_WITH_PROGRAMS OFF)
+  set(LIBXML2_WITH_TESTS OFF)
+  set(LIBXML2_WITH_ICONV OFF)
+  set(LIBXML2_WITH_ICU OFF)
+  set(LIBXML2_WITH_LZMA OFF)
+  set(LIBXML2_WITH_ZLIB OFF)
+  set(LIBXML2_WITH_HTTP OFF)
+  set(LIBXML2_WITH_MODULES OFF)
+  set(LIBXML2_WITH_THREADS ON)
+  set(LIBXML2_WITH_XPATH ON)
+
+  FetchContent_Declare(
+    libxml2
+    URL ${VELOX_LIBXML2_SOURCE_URL}
+    URL_HASH ${VELOX_LIBXML2_BUILD_SHA256_CHECKSUM}
+    OVERRIDE_FIND_PACKAGE
+    SYSTEM
+    EXCLUDE_FROM_ALL
+  )
+
+  set(BUILD_SHARED_LIBS OFF)
+  set(CMAKE_BUILD_TYPE Release)
+
+  FetchContent_MakeAvailable(libxml2)
+endblock()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -671,6 +671,9 @@ endif()
 velox_set_source(simdjson)
 velox_resolve_dependency(simdjson 4.1.0)
 
+velox_set_source(LibXml2)
+velox_resolve_dependency(LibXml2)
+
 velox_set_source(FastFloat)
 velox_resolve_dependency(FastFloat)
 

--- a/scripts/setup-centos9.sh
+++ b/scripts/setup-centos9.sh
@@ -73,7 +73,7 @@ function install_velox_deps_from_dnf {
   dnf_install libevent-devel \
     openssl-devel re2-devel libzstd-devel lz4-devel double-conversion-devel \
     libdwarf-devel elfutils-libelf-devel curl-devel libicu-devel bison flex \
-    libsodium-devel zlib-devel gtest-devel gmock-devel xxhash-devel
+    libsodium-devel zlib-devel gtest-devel gmock-devel xxhash-devel libxml2-devel
 
   install_faiss_deps
 }

--- a/scripts/setup-fedora.sh
+++ b/scripts/setup-fedora.sh
@@ -61,7 +61,7 @@ function install_velox_deps_from_dnf {
     elfutils-libelf-devel flex gflags-devel glog-devel gmock-devel \
     gtest-devel libdwarf-devel libevent-devel libicu-devel \
     libsodium-devel libzstd-devel lz4-devel openssl-devel-engine \
-    re2-devel snappy-devel xxhash-devel zlib-devel grpc-devel grpc-plugins
+    re2-devel snappy-devel xxhash-devel zlib-devel grpc-devel grpc-plugins libxml2-devel
 
   install_faiss_deps
 }

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -43,7 +43,7 @@ export CMAKE_POLICY_VERSION_MINIMUM="3.5"
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
 # gflags and glog are installed from source to ensure version compatibility.
 # Homebrew's glog 0.7.x has breaking API changes that are incompatible with folly.
-MACOS_VELOX_DEPS="bison double-conversion fast_float flex googletest icu4c libevent libsodium lz4 openssl simdjson snappy xz xxhash zstd"
+MACOS_VELOX_DEPS="bison double-conversion fast_float flex googletest icu4c libevent libsodium lz4 openssl simdjson snappy xz xxhash zstd libxml2"
 MACOS_BUILD_DEPS="ninja cmake"
 
 SUDO="${SUDO:-""}"

--- a/scripts/setup-manylinux.sh
+++ b/scripts/setup-manylinux.sh
@@ -68,7 +68,7 @@ function install_velox_deps_from_dnf {
   dnf_install libevent-devel \
     openssl-devel re2-devel libzstd-devel lz4-devel double-conversion-devel \
     libdwarf-devel elfutils-libelf-devel curl-devel libicu-devel bison flex \
-    libsodium-devel zlib-devel gtest-devel gmock-devel xxhash-devel
+    libsodium-devel zlib-devel gtest-devel gmock-devel xxhash-devel libxml2-devel
 }
 
 function install_cxl_deps {

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -126,7 +126,8 @@ function install_velox_deps_from_apt {
     flex \
     libfl-dev \
     tzdata \
-    libxxhash-dev
+    libxxhash-dev \
+    libxml2-dev
 }
 
 function install_conda {

--- a/velox/docs/functions/spark/coverage.rst
+++ b/velox/docs/functions/spark/coverage.rst
@@ -263,14 +263,14 @@ Here is a list of all scalar, aggregate, and window functions from Spark, with f
     :spark:func:`ceil`                         from_csv                                   mean                                       :spark:func:`shiftright`                   :spark:func:`width_bucket`
     ceiling                                    from_json                                  min                                        shiftrightunsigned                         window
     char                                       :spark:func:`from_unixtime`                min_by                                     :spark:func:`shuffle`                      xpath
-    char_length                                :spark:func:`from_utc_timestamp`           :spark:func:`minute`                       :spark:func:`sign`                         :spark:func:`xpath_boolean`
+    char_length                                :spark:func:`from_utc_timestamp`           :spark:func:`minute`                       :spark:func:`sign`                         xpath_boolean
     character_length                           :spark:func:`get_json_object`              mod                                        signum                                     xpath_double
     :spark:func:`chr`                          getbit                                     :spark:func:`monotonically_increasing_id`  sin                                        xpath_float
     coalesce                                   :spark:func:`greatest`                     :spark:func:`month`                        :spark:func:`sinh`                         xpath_int
     collect_list                               grouping                                   months_between                             :spark:func:`size`                         xpath_long
     collect_set                                grouping_id                                named_struct                               skewness                                   xpath_number
     :spark:func:`concat`                       :spark:func:`hash`                         nanvl                                      :spark:func:`slice`                        xpath_short
-    concat_ws                                  :spark:func:`hex`                          negative                                   smallint                                   :spark:func:`xpath_string`
+    concat_ws                                  :spark:func:`hex`                          negative                                   smallint                                   xpath_string
     :spark:func:`conv`                         :spark:func:`hour`                         :spark:func:`next_day`                     some                                       :spark:func:`xxhash64`
     corr                                       :spark:func:`hypot`                        :spark:func:`not`                          :spark:func:`sort_array`                   :spark:func:`year`
     :spark:func:`cos`                          if                                         now                                        :spark:func:`soundex`                      :spark:func:`zip_with`

--- a/velox/docs/functions/spark/coverage.rst
+++ b/velox/docs/functions/spark/coverage.rst
@@ -263,14 +263,14 @@ Here is a list of all scalar, aggregate, and window functions from Spark, with f
     :spark:func:`ceil`                         from_csv                                   mean                                       :spark:func:`shiftright`                   :spark:func:`width_bucket`
     ceiling                                    from_json                                  min                                        shiftrightunsigned                         window
     char                                       :spark:func:`from_unixtime`                min_by                                     :spark:func:`shuffle`                      xpath
-    char_length                                :spark:func:`from_utc_timestamp`           :spark:func:`minute`                       :spark:func:`sign`                         xpath_boolean
+    char_length                                :spark:func:`from_utc_timestamp`           :spark:func:`minute`                       :spark:func:`sign`                         :spark:func:`xpath_boolean`
     character_length                           :spark:func:`get_json_object`              mod                                        signum                                     xpath_double
     :spark:func:`chr`                          getbit                                     :spark:func:`monotonically_increasing_id`  sin                                        xpath_float
     coalesce                                   :spark:func:`greatest`                     :spark:func:`month`                        :spark:func:`sinh`                         xpath_int
     collect_list                               grouping                                   months_between                             :spark:func:`size`                         xpath_long
     collect_set                                grouping_id                                named_struct                               skewness                                   xpath_number
     :spark:func:`concat`                       :spark:func:`hash`                         nanvl                                      :spark:func:`slice`                        xpath_short
-    concat_ws                                  :spark:func:`hex`                          negative                                   smallint                                   xpath_string
+    concat_ws                                  :spark:func:`hex`                          negative                                   smallint                                   :spark:func:`xpath_string`
     :spark:func:`conv`                         :spark:func:`hour`                         :spark:func:`next_day`                     some                                       :spark:func:`xxhash64`
     corr                                       :spark:func:`hypot`                        :spark:func:`not`                          :spark:func:`sort_array`                   :spark:func:`year`
     :spark:func:`cos`                          if                                         now                                        :spark:func:`soundex`                      :spark:func:`zip_with`

--- a/velox/docs/functions/spark/xml.rst
+++ b/velox/docs/functions/spark/xml.rst
@@ -1,0 +1,28 @@
+=============
+XML Functions
+=============
+
+.. spark:function:: xpath_boolean(xml, path) -> boolean
+
+    Evaluates the XPath expression ``path`` against the XML document ``xml`` and
+    returns its boolean value. A node-set result is ``true`` when it is
+    non-empty (a matching node exists); a boolean expression returns its own
+    value. Returns NULL if ``xml`` or ``path`` is NULL or empty. Throws an
+    error if ``xml`` is not a valid XML document or ``path`` is not a valid
+    XPath expression. ::
+
+        SELECT xpath_boolean('<a><b>1</b></a>', 'a/b'); -- true
+        SELECT xpath_boolean('<a><b>1</b></a>', 'a/c'); -- false
+        SELECT xpath_boolean('<a><b>1</b></a>', 'a/b = "1"'); -- true
+
+.. spark:function:: xpath_string(xml, path) -> varchar
+
+    Returns the text contents of the first node in the XML document ``xml`` that
+    matches the XPath expression ``path``. Returns an empty string if no node
+    matches. Returns NULL if ``xml`` or ``path`` is NULL or empty. Throws an
+    error if ``xml`` is not a valid XML document or ``path`` is not a valid
+    XPath expression. ::
+
+        SELECT xpath_string('<a><b>bee</b></a>', 'a/b'); -- 'bee'
+        SELECT xpath_string('<a><b>b1</b><b>b2</b></a>', 'a/b[2]'); -- 'b2'
+        SELECT xpath_string('<a><b>bee</b></a>', 'a/c'); -- ''

--- a/velox/docs/spark_functions.rst
+++ b/velox/docs/spark_functions.rst
@@ -27,6 +27,7 @@ configuration. Otherwise, it simply follows Spark's semantics in ANSI OFF mode.
     functions/spark/conversion
     functions/spark/url
     functions/spark/json
+    functions/spark/xml
 
 Here is a list of all scalar and aggregate Spark functions available in Velox.
 Function names link to function descriptions. Check out coverage maps

--- a/velox/functions/sparksql/CMakeLists.txt
+++ b/velox/functions/sparksql/CMakeLists.txt
@@ -24,6 +24,7 @@ velox_add_library(
 velox_link_libraries(velox_spark_query_config velox_config_property velox_core)
 
 add_subdirectory(specialforms)
+
 velox_add_library(
   velox_functions_spark_impl
   ArrayGetFunction.cpp
@@ -51,6 +52,7 @@ velox_add_library(
   TimestampUtils.cpp
   Transform.cpp
   UnscaledValueFunction.cpp
+  XPathUtil.cpp
   XxHash64.cpp
   HEADERS
   AnsiMode.h
@@ -105,6 +107,8 @@ velox_add_library(
   UnscaledValueFunction.h
   Uuid.h
   VarcharTypeWriteSideCheck.h
+  XPathFunctions.h
+  XPathUtil.h
   XxHash64.h
 )
 
@@ -116,6 +120,7 @@ velox_link_libraries(
   velox_functions_util
   Folly::folly
   simdjson::simdjson
+  LibXml2::LibXml2
 )
 
 if(NOT VELOX_MONO_LIBRARY)

--- a/velox/functions/sparksql/XPathFunctions.h
+++ b/velox/functions/sparksql/XPathFunctions.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstring>
+
+#include "velox/functions/Macros.h"
+#include "velox/functions/sparksql/XPathUtil.h"
+
+namespace facebook::velox::functions::sparksql {
+
+/// NOTE: Spark rejects non-foldable (non-literal) path arguments at analysis
+/// time. Velox accepts dynamic paths - this is a minor divergence but safe
+/// since Gluten only passes constant path literals.
+
+/// xpath_boolean(xml, path) -> boolean
+template <typename T>
+struct XPathBooleanFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<bool>& result,
+      const arg_type<Varchar>& xml,
+      const arg_type<Varchar>& path) {
+    if (xml.empty() || path.empty()) {
+      return false;
+    }
+    auto value =
+        xpath::evalBoolean(xml.data(), xml.size(), path.data(), path.size());
+    if (!value) {
+      return false;
+    }
+    result = *value;
+    return true;
+  }
+};
+
+/// xpath_string(xml, path) -> varchar
+template <typename T>
+struct XPathStringFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& xml,
+      const arg_type<Varchar>& path) {
+    if (xml.empty() || path.empty()) {
+      return false;
+    }
+    auto value =
+        xpath::evalString(xml.data(), xml.size(), path.data(), path.size());
+    if (!value) {
+      return false;
+    }
+    result.resize(value->size());
+    if (!value->empty()) {
+      std::memcpy(result.data(), value->data(), value->size());
+    }
+    return true;
+  }
+};
+
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/XPathUtil.cpp
+++ b/velox/functions/sparksql/XPathUtil.cpp
@@ -1,0 +1,682 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/sparksql/XPathUtil.h"
+
+#include <climits>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+#include "velox/common/base/Exceptions.h"
+
+#include <libxml/parser.h>
+#include <libxml/xpath.h>
+#include <libxml/xpathInternals.h>
+
+namespace facebook::velox::functions::sparksql {
+namespace xpath {
+
+namespace {
+
+/// No-op error handler to suppress libxml2 stderr output.
+/// In a threaded libxml2 build (the default on Linux/macOS) the generic error
+/// handler is per-thread global state, so it is installed once per thread (see
+/// ensureLibxml2Initialized). Parse errors are additionally silenced per call
+/// via XML_PARSE_NOERROR | XML_PARSE_NOWARNING on every thread. Suppression is
+/// intentional: invalid XPath syntax is surfaced as a user error and other
+/// invalid input as SQL NULL, not as stderr noise.
+void suppressError(void* /*ctx*/, const char* /*msg*/, ...) {}
+
+/// Thread-safe one-time libxml2 initialization (Meyers singleton).
+/// Suppresses libxml2 error output to stderr.
+///
+/// Security notes:
+/// - XML_PARSE_NONET prevents network access (XXE mitigation).
+/// - XML_PARSE_NOENT is NOT set, so entity substitution is off.
+/// - XML_PARSE_DTDLOAD is NOT set, so external DTDs are not loaded.
+/// - libxml2 has a built-in entity expansion depth limit (default 40) which
+///   mitigates billion-laughs style attacks. No additional configuration
+///   needed.
+void ensureLibxml2Initialized() {
+  // Process-wide one-time parser initialization (thread-safe Meyers singleton).
+  struct Libxml2Init {
+    Libxml2Init() {
+      xmlInitParser();
+    }
+  };
+  static Libxml2Init instance;
+
+  // libxml2's generic error handler lives in per-thread global state in
+  // threaded builds (the default configuration on Linux/macOS), so the stderr
+  // suppressor must be installed on every thread that evaluates XPath, not just
+  // the first one to initialize. A thread_local guard installs it once per
+  // thread; without this, XPath evaluation diagnostics on other worker threads
+  // could still leak to stderr. (The structured-error API,
+  // xmlSetStructuredErrorFunc, is the modern alternative but has the same
+  // per-thread install requirement.)
+  static thread_local bool errorHandlerInstalled = false;
+  if (!errorHandlerInstalled) {
+    xmlSetGenericErrorFunc(nullptr, suppressError);
+    errorHandlerInstalled = true;
+  }
+}
+
+/// Rewrite absolute paths in an XPath expression to go through the
+/// synthetic wrapper root "_r".  Handles "/" at start or after XPath
+/// operators/delimiters (with optional whitespace), but skips "//"
+/// (descendant-or-self axis).
+///
+/// Known limitations (heuristic approach):
+/// - String literals are skipped (both ' and " delimited), so "/" inside a
+///   literal (e.g. contains(x, "/a/b")) is preserved verbatim. The backward
+///   operator scan below inspects only characters outside string literals:
+///   a '/' is processed only when inQuote == 0 (quotes balanced up to that
+///   point), and the scan stops at the first non-whitespace char to its left,
+///   which therefore cannot lie inside a literal. So quoted operator
+///   characters can never trigger a spurious absolute-path rewrite.
+/// - The multiplication operator '*' is intentionally NOT treated as an
+///   absolute-path boundary, because '*' is overwhelmingly the wildcard
+///   name-test ("a/*", "*/b"). As a result a contrived "3 * /a/b" leaves the
+///   "/a/b" unrewritten and diverges from Spark; adding '*' would corrupt the
+///   common wildcard case ("*/b" -> "*/_r/b") and is not worth that trade-off.
+/// - Complex axis steps (e.g., "child::a/b") are not explicitly handled
+///   but work naturally since they don't start with "/".
+/// - Nested predicates with absolute paths (e.g., "a[/b=1]") are handled
+///   by the operator-boundary detection.
+std::string rewriteAbsolutePaths(const std::string& path) {
+  if (path.empty()) {
+    return path;
+  }
+
+  // Helper: check if position i is preceded by a word operator (or, and, div,
+  // mod). These are XPath 1.0 keyword operators that can precede absolute
+  // paths.
+  auto endsWithWordOperator = [&](size_t pos) -> bool {
+    // pos points to the last non-whitespace char before '/'.
+    // Check if it ends with "or", "and", "div", or "mod" that is acting as a
+    // binary operator (not an element name). Per the XPath 1.0 ExprToken
+    // disambiguation rule, an NCName is an OperatorName only when the preceding
+    // token is NOT one of '@', '::', '(', '[', ',', another Operator (which
+    // includes '/' and '//'), or the start of the expression. Equivalently, the
+    // word is an operator only when its left operand has just ended, i.e. the
+    // immediately preceding character closes an operand: whitespace, ')', ']',
+    // '*', or a string-literal quote. This avoids misclassifying a location
+    // step whose element is literally named or/and/div/mod (e.g. the very
+    // common "div") as an operator, which would otherwise splice the wrapper
+    // root into the middle of a relative path ("a/div/b" -> "a/div/_r/b").
+    static const std::vector<std::string_view> kOps = {
+        "or", "and", "div", "mod"};
+    auto isOperandEnd = [](char c) -> bool {
+      return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == ')' ||
+          c == ']' || c == '*' || c == '\'' || c == '"';
+    };
+    for (const auto& op : kOps) {
+      if (pos + 1 >= op.size()) {
+        size_t start = pos + 1 - op.size();
+        if (path.compare(start, op.size(), op) == 0) {
+          // A leading word (start == 0) can never be a binary operator.
+          if (start > 0 && isOperandEnd(path[start - 1])) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  };
+
+  std::string result;
+  result.reserve(path.size() + 16);
+  // Tracks the active string-literal delimiter (0 when not inside a literal).
+  // XPath string literals may contain '/' that must never be rewritten, e.g.
+  // a[b='(/c)'] - without this the embedded "/c" would be treated as an
+  // absolute path and corrupted to "/_r/c".
+  char inQuote = 0;
+  for (size_t i = 0; i < path.size(); ++i) {
+    const char c = path[i];
+    if (inQuote != 0) {
+      result += c;
+      if (c == inQuote) {
+        inQuote = 0;
+      }
+      continue;
+    }
+    if (c == '\'' || c == '"') {
+      inQuote = c;
+      result += c;
+      continue;
+    }
+    if (c == '/') {
+      // Skip "//" - descendant-or-self axis should not be rewritten.
+      if (i + 1 < path.size() && path[i + 1] == '/') {
+        result += c;
+        continue;
+      }
+      // Check if this is an absolute path: at start, or after operator/paren
+      // (with optional whitespace).
+      bool isAbsolute = (i == 0);
+      if (!isAbsolute) {
+        // Scan backwards past whitespace to find the preceding non-space char.
+        size_t j = i - 1;
+        while (j > 0 &&
+               (path[j] == ' ' || path[j] == '\t' || path[j] == '\n' ||
+                path[j] == '\r')) {
+          --j;
+        }
+        char prev = path[j];
+        // Operators/delimiters that can precede an absolute path:
+        // ( - function call or grouping
+        // | - union operator
+        // , - function argument separator
+        // = != < > - comparison operators
+        // + - - arithmetic operators
+        // [ - predicate start
+        if (prev == '(' || prev == '|' || prev == ',' || prev == '=' ||
+            prev == '<' || prev == '>' || prev == '+' || prev == '-' ||
+            prev == '[' || prev == '!' ||
+            (j == 0 &&
+             (prev == ' ' || prev == '\t' || prev == '\n' || prev == '\r'))) {
+          isAbsolute = true;
+        }
+        // Check for XPath word operators (or, and, div, mod).
+        if (!isAbsolute && endsWithWordOperator(j)) {
+          isAbsolute = true;
+        }
+      }
+      if (isAbsolute) {
+        result += "/_r/";
+      } else {
+        result += '/';
+      }
+    } else {
+      result += c;
+    }
+  }
+  return result;
+}
+
+/// Thread-local cache of compiled XPath expressions, keyed by the ORIGINAL
+/// (pre-rewrite) path string. Spark passes a constant path literal, so the same
+/// expression is evaluated for every row; compiling it once per thread and
+/// reusing the immutable xmlXPathCompExpr avoids a per-row rewrite + compile.
+///
+/// The cache is thread_local so each worker thread owns its compiled
+/// expressions - libxml2 compiled expressions are reused read-only within a
+/// thread (the intended xmlXPathCompile/xmlXPathCompiledEval pattern) and are
+/// never shared across threads - and frees them at thread exit.
+///
+/// The number of retained expressions is capped: the functions also accept a
+/// non-constant (per-row) path argument, so a high-cardinality path column
+/// would otherwise grow the map without bound for the thread's lifetime. Once
+/// the cap is reached the cache stops taking ownership; the caller then owns
+/// and frees any expression it compiled (see eval()), keeping memory bounded
+/// while the common constant-path case stays cached.
+class CompiledXPathCache {
+ public:
+  /// Returns the cached compiled expression for `path`, or nullptr if it is not
+  /// cached. The returned pointer is owned by the cache; the caller must NOT
+  /// free it. It stays valid for the thread's lifetime.
+  xmlXPathCompExprPtr find(const std::string& path) const {
+    auto it = cache_.find(path);
+    return it == cache_.end() ? nullptr : it->second;
+  }
+
+  /// Attempts to store `compiled` under `path`. Returns true if the cache took
+  /// ownership (the caller must NOT free it); returns false if the cache is
+  /// full, in which case the caller retains ownership and must free `compiled`.
+  bool store(const std::string& path, xmlXPathCompExprPtr compiled) {
+    if (cache_.size() >= kMaxEntries) {
+      return false;
+    }
+    cache_.emplace(path, compiled);
+    return true;
+  }
+
+  ~CompiledXPathCache() {
+    for (auto& entry : cache_) {
+      xmlXPathFreeCompExpr(entry.second);
+    }
+  }
+
+ private:
+  // Generous bound: a query uses very few distinct constant paths, so this is
+  // only reached by a pathological non-constant path column, for which we fall
+  // back to compile-per-row rather than grow without limit.
+  static constexpr size_t kMaxEntries = 1024;
+  std::unordered_map<std::string, xmlXPathCompExprPtr> cache_;
+};
+
+CompiledXPathCache& compiledXPathCache() {
+  static thread_local CompiledXPathCache cache;
+  return cache;
+}
+
+/// RAII wrapper for libxml2 XML document and XPath context.
+///
+/// SPARK-FAITHFUL ERROR SEMANTICS (XP-BUG-1):
+/// Spark's UDFXPathUtil throws RuntimeException for:
+///   - Invalid XML input (malformed tags, encoding errors)
+///   - Invalid XPath expressions (syntax errors)
+/// To avoid a NULL-vs-throw divergence on the offloaded path, this
+/// implementation also throws (VELOX_USER_FAIL) for these two cases instead of
+/// returning NULL; see evalBoolean/evalString. Null and
+/// empty inputs are short-circuited to NULL earlier (XPathFunctions.h, matching
+/// UDFXPathUtil.eval's null/empty guards), and valid input that yields an empty
+/// node-set still returns NULL/"" exactly as Spark does, so only genuinely
+/// invalid input throws. The throw is data-dependent (depends on row contents),
+/// matching Spark's per-row failure behavior.
+///
+/// Remaining accepted divergences (intentionally NOT converged):
+///   - XP-BUG-2 (XXE/DOCTYPE): external-entity references that Spark would
+///     resolve (and throw on) are stripped for security; converging would
+///     reintroduce XXE/SSRF. See the DOCTYPE-strip comment in the constructor.
+///   - XP-BUG-3 (namespaces): libxml2 is always namespace-aware whereas Spark
+///     parses namespace-unaware; see the namespace comment in the constructor.
+///
+/// Java compatibility: Spark uses Java's XPath API where relative paths like
+/// "a/b" are evaluated against the document and automatically resolve through
+/// the document element.  libxml2 2.14+ does not support this - relative paths
+/// from the document node return empty nodesets.  To match Java semantics, we
+/// wrap the input XML in a synthetic root element ("<_r>...</_r>") and set the
+/// XPath context to that wrapper so that "a/b" correctly selects child "a" of
+/// the wrapper.  Absolute paths (starting with "/") are rewritten to go through
+/// the wrapper (e.g. "/a/b" -> "/_r/a/b").
+class XmlXPathEvaluator {
+ public:
+  XmlXPathEvaluator(const char* xml, size_t xmlLen) {
+    ensureLibxml2Initialized();
+    // Guard against overflow: wrapped size is xmlLen + 9 (<_r> + </_r>).
+    // For inputs this large we leave doc_/ctx_ null so isValid() is false and
+    // the evaluator reports neither valid nor raw-malformed; evalBoolean/
+    // evalString therefore return NULL rather than throwing. This is a
+    // documented divergence from Spark (which would attempt to parse), but it
+    // is safe and unreachable in practice - Gluten string inputs are far below
+    // 2 GiB.
+    static constexpr size_t kWrapOverhead =
+        9; // strlen("<_r>") + strlen("</_r>")
+    if (xmlLen > static_cast<size_t>(INT_MAX) - kWrapOverhead) {
+      return;
+    }
+
+    // Validate that the RAW (unwrapped) input is well-formed XML before we wrap
+    // it in the synthetic <_r> root. Without this check the wrapper would make
+    // non-well-formed input parse successfully - e.g. bare text ("not xml") or
+    // trailing content after the root element ("<a/><b/>") - and the function
+    // would return empty-result defaults instead of failing. Spark parses the
+    // unwrapped document (Java DocumentBuilder) and throws RuntimeException on
+    // such input; we mirror that by flagging the input malformed so the eval*
+    // paths throw a user error (see XP-BUG-1 above). This is the authoritative
+    // signal for Spark's throw, because Spark's success/throw is decided solely
+    // by this raw parse - failures of the later wrapped parse (e.g. stripped
+    // DOCTYPE/entity, XP-BUG-2) are NOT raw-malformed and keep returning NULL.
+    {
+      xmlDocPtr rawDoc = xmlReadMemory(
+          xml,
+          static_cast<int>(xmlLen),
+          nullptr,
+          nullptr,
+          XML_PARSE_NOERROR | XML_PARSE_NOWARNING | XML_PARSE_NONET);
+      if (rawDoc == nullptr) {
+        xmlMalformed_ = true;
+        return;
+      }
+      xmlFreeDoc(rawDoc);
+    }
+
+    // Wrap in synthetic root to match Java XPath evaluation semantics.
+    // Strip XML declaration (<?xml ...?>) and DOCTYPE if present - these
+    // are invalid inside a wrapper element. Only strip at the start of
+    // the document (true prolog position).
+    //
+    // SPARK-DIVERGENCE: XP-BUG-2 (DOCTYPE strip / XXE handling)
+    // Stripping the DOCTYPE changes external-entity (XXE) semantics relative
+    // to Spark's JVM XPath: SYSTEM/external entity references that Spark would
+    // attempt to resolve (and throw on) are instead removed, so evaluation
+    // proceeds and returns NULL or a value rather than throwing. This is an
+    // intentional, security-motivated divergence:
+    //   - DTD loading and entity substitution are disabled at parse time
+    //     (XML_PARSE_NOENT and XML_PARSE_DTDLOAD are NOT set) and network
+    //     access is blocked (XML_PARSE_NONET), preventing XXE/SSRF.
+    //   - Removing the DOCTYPE here lets otherwise-valid documents parse inside
+    //     the synthetic wrapper without pulling in an external/internal subset.
+    // A further consequence: if the input both DEFINES an entity in the
+    // internal subset AND REFERENCES it in the body (e.g.
+    // "<!DOCTYPE foo [<!ENTITY x \"hi\">]><foo>&x;</foo>"), the raw
+    // well-formedness check passes (the internal subset is in scope there) but
+    // the wrapped re-parse fails because the entity definition has been
+    // stripped, so the function returns NULL. Spark expands the internal entity
+    // and returns its value. This is the same accepted NULL-vs-throw/expand
+    // divergence (see XP-BUG-1); internal-entity references in xpath inputs are
+    // rare in practice.
+    std::string_view xmlView(xml, xmlLen);
+    std::string stripped;
+
+    // Strip leading whitespace for prolog detection.
+    size_t start = 0;
+    while (start < xmlView.size() &&
+           (xmlView[start] == ' ' || xmlView[start] == '\t' ||
+            xmlView[start] == '\n' || xmlView[start] == '\r')) {
+      ++start;
+    }
+
+    // Strip <?xml ...?> declaration if at prolog position. Require a
+    // whitespace char after "<?xml" so we match only the XML declaration
+    // (spec: "<?xml" S "version"...) and not a processing instruction whose
+    // target merely begins with "xml", e.g. "<?xml-stylesheet ...?>".
+    //
+    // SPARK-DIVERGENCE: XP-BUG-2 (declared encoding is dropped)
+    // Removing the declaration discards any encoding="..." attribute, so the
+    // wrapped re-parse below always assumes UTF-8. For a document that declares
+    // a non-UTF-8 encoding this can diverge from the raw parse (which honors
+    // the declaration): bytes that are invalid UTF-8 make the re-parse fail ->
+    // SQL NULL, and bytes that happen to be valid UTF-8 are decoded as
+    // different characters. This is unreachable inside Gluten because Spark
+    // StringType inputs are already UTF-8; it is documented here for the
+    // standalone case.
+    if (xmlView.substr(start, 5) == "<?xml" && start + 5 < xmlView.size() &&
+        (xmlView[start + 5] == ' ' || xmlView[start + 5] == '\t' ||
+         xmlView[start + 5] == '\n' || xmlView[start + 5] == '\r')) {
+      auto end = xmlView.find("?>", start);
+      if (end != std::string_view::npos) {
+        stripped.append(xmlView.data() + end + 2, xmlView.size() - end - 2);
+        xmlView = stripped;
+      }
+    }
+
+    // Strip <!DOCTYPE ...> if present (must come before root element).
+    // Handles internal subsets: <!DOCTYPE foo [<!ENTITY x "val">]>
+    // by tracking bracket nesting depth before looking for closing '>'.
+    // Skips brackets inside quoted strings (single or double quotes) to
+    // handle cases like <!DOCTYPE foo [<!ENTITY x SYSTEM "file://[t]">]>, and
+    // treats comments (<!-- ... -->) and PIs (<? ... ?>) inside the internal
+    // subset as opaque so a '[', ']' or '>' within them does not corrupt the
+    // bracket depth or terminate the scan early.
+    {
+      // Advance past prolog Misc content (whitespace, comments, and
+      // processing instructions). XML's prolog grammar permits Misc*
+      // (S | Comment | PI) before the doctypedecl, so a <!DOCTYPE preceded by
+      // a comment or PI (e.g. "<!-- c --><!DOCTYPE foo>...") must still be
+      // detected; otherwise the DOCTYPE would survive into the synthetic
+      // wrapper (invalid there) and the re-parse would spuriously fail. The
+      // skipped comments/PIs are left in place (they are valid inside <_r>).
+      // An unterminated comment/PI stops the scan; such input is malformed and
+      // was already rejected by the raw well-formedness parse above.
+      size_t dtdStart = 0;
+      while (dtdStart < xmlView.size()) {
+        const char c = xmlView[dtdStart];
+        if (c == ' ' || c == '\t' || c == '\n' || c == '\r') {
+          ++dtdStart;
+        } else if (xmlView.substr(dtdStart, 4) == "<!--") {
+          const size_t commentEnd = xmlView.find("-->", dtdStart + 4);
+          if (commentEnd == std::string_view::npos) {
+            break;
+          }
+          dtdStart = commentEnd + 3;
+        } else if (xmlView.substr(dtdStart, 2) == "<?") {
+          const size_t piEnd = xmlView.find("?>", dtdStart + 2);
+          if (piEnd == std::string_view::npos) {
+            break;
+          }
+          dtdStart = piEnd + 2;
+        } else {
+          break;
+        }
+      }
+      if (xmlView.substr(dtdStart, 9) == "<!DOCTYPE") {
+        size_t i = dtdStart + 9;
+        int bracketDepth = 0;
+        char inQuote = 0; // 0 = not in quotes, '"' or '\'' = in that quote
+        size_t end = std::string_view::npos;
+        while (i < xmlView.size()) {
+          char c = xmlView[i];
+          if (inQuote) {
+            if (c == inQuote) {
+              inQuote = 0;
+            }
+          } else if (xmlView.substr(i, 4) == "<!--") {
+            // Comments inside the internal subset are opaque: a '[', ']' or
+            // '>' within a comment must not affect bracket depth or be taken
+            // as the DOCTYPE terminator. Fast-forward past "-->".
+            const size_t commentEnd = xmlView.find("-->", i + 4);
+            if (commentEnd == std::string_view::npos) {
+              break; // unterminated (malformed); leave end unset -> no strip.
+            }
+            i = commentEnd + 3;
+            continue;
+          } else if (xmlView.substr(i, 2) == "<?") {
+            // Processing instructions inside the internal subset are likewise
+            // opaque. Fast-forward past "?>".
+            const size_t piEnd = xmlView.find("?>", i + 2);
+            if (piEnd == std::string_view::npos) {
+              break; // unterminated (malformed); leave end unset -> no strip.
+            }
+            i = piEnd + 2;
+            continue;
+          } else if (c == '"' || c == '\'') {
+            inQuote = c;
+          } else if (c == '[') {
+            ++bracketDepth;
+          } else if (c == ']') {
+            --bracketDepth;
+          } else if (c == '>' && bracketDepth == 0) {
+            end = i;
+            break;
+          }
+          ++i;
+        }
+        if (end != std::string_view::npos) {
+          std::string tmp;
+          tmp.append(xmlView.data(), dtdStart);
+          tmp.append(xmlView.data() + end + 1, xmlView.size() - end - 1);
+          stripped = std::move(tmp);
+          xmlView = stripped;
+        }
+      }
+    }
+
+    static constexpr std::string_view kWrapOpen = "<_r>";
+    static constexpr std::string_view kWrapClose = "</_r>";
+    wrapped_.reserve(kWrapOpen.size() + xmlView.size() + kWrapClose.size());
+    wrapped_.append(kWrapOpen);
+    wrapped_.append(xmlView);
+    wrapped_.append(kWrapClose);
+
+    // Security: XML_PARSE_NONET prevents network access (XXE mitigation).
+    // Entity substitution is off by default (XML_PARSE_NOENT not set).
+    // DTD loading is off by default (XML_PARSE_DTDLOAD not set).
+    doc_ = xmlReadMemory(
+        wrapped_.data(),
+        static_cast<int>(wrapped_.size()),
+        nullptr,
+        nullptr,
+        XML_PARSE_NOERROR | XML_PARSE_NOWARNING | XML_PARSE_NONET);
+    if (doc_) {
+      ctx_ = xmlXPathNewContext(doc_);
+      if (ctx_) {
+        ctx_->node = xmlDocGetRootElement(doc_);
+        // SPARK-DIVERGENCE: XP-BUG-3 (XML namespace handling)
+        // libxml2 always parses namespace-aware, and we register no namespace
+        // prefixes on the XPath context. Spark/Hive (UDFXPathUtil) parse with a
+        // namespace-UNAWARE DocumentBuilder, so element names are matched
+        // literally. As a result, for namespaced input this implementation
+        // diverges from Spark:
+        //   - A prefixed step (e.g. "x:a/x:b") references an unregistered
+        //     prefix -> XPath evaluation fails -> the function returns NULL.
+        //   - Default-namespace input (<a xmlns="..">) is not matched by an
+        //     unprefixed step ("a/b") because the element is in a non-null
+        //     namespace -> empty node-set (e.g. xpath_string -> "").
+        // This is an accepted, documented divergence. Registering namespaces
+        // is intentionally not attempted because Spark's namespace-unaware
+        // matching cannot be reproduced via libxml2's always-namespace-aware
+        // XPath engine.
+      }
+    }
+  }
+
+  ~XmlXPathEvaluator() {
+    if (ctx_) {
+      xmlXPathFreeContext(ctx_);
+    }
+    if (doc_) {
+      xmlFreeDoc(doc_);
+    }
+  }
+
+  XmlXPathEvaluator(const XmlXPathEvaluator&) = delete;
+  XmlXPathEvaluator& operator=(const XmlXPathEvaluator&) = delete;
+
+  bool isValid() const {
+    return doc_ != nullptr && ctx_ != nullptr;
+  }
+
+  /// True when the RAW (unwrapped) input failed to parse as well-formed XML.
+  /// This is the Spark-faithful signal for a thrown error: Spark's
+  /// DocumentBuilder.parse fails on exactly this input. Distinct from a generic
+  /// !isValid(), which also covers wrapped-only parse failures (XP-BUG-2) that
+  /// must keep returning NULL rather than throwing.
+  bool xmlMalformed() const {
+    return xmlMalformed_;
+  }
+
+  /// Evaluate XPath expression. Caller must free result with
+  /// xmlXPathFreeObject.
+  ///
+  /// Distinguishes an XPath *syntax* error from an *evaluation-time* failure so
+  /// callers can honor Spark's error semantics precisely:
+  ///   - A syntax error (e.g. "///[invalid") fails xmlXPathCompile; Spark's
+  ///     xpath.compile throws RuntimeException, so we set pathInvalid=true and
+  ///     callers throw.
+  ///   - A syntactically valid path that fails at evaluation (e.g. an
+  ///     unregistered namespace prefix, XP-BUG-3) returns nullptr with
+  ///     pathInvalid=false; callers keep returning NULL (documented divergence,
+  ///     not a throw).
+  xmlXPathObjectPtr eval(const std::string& path, bool& pathInvalid) {
+    pathInvalid = false;
+    if (!isValid()) {
+      return nullptr;
+    }
+    // Reuse a thread-local compiled expression for this (constant) path; the
+    // cache rewrites absolute paths through the wrapper root and compiles once
+    // per thread. The compiled expression is context-free, so it is evaluated
+    // here against this row's per-document context. If the cache is full (only
+    // reached by a high-cardinality non-constant path), we own the freshly
+    // compiled expression and free it after evaluating this row.
+    auto& cache = compiledXPathCache();
+    xmlXPathCompExprPtr compiled = cache.find(path);
+    bool owned = false;
+    if (compiled == nullptr) {
+      const std::string rewritten = rewriteAbsolutePaths(path);
+      compiled =
+          xmlXPathCompile(reinterpret_cast<const xmlChar*>(rewritten.c_str()));
+      if (compiled == nullptr) {
+        pathInvalid = true;
+        return nullptr;
+      }
+      // Hand ownership to the cache when there is room; otherwise keep it and
+      // free it below after evaluation.
+      owned = !cache.store(path, compiled);
+    }
+    xmlXPathObjectPtr result = xmlXPathCompiledEval(compiled, ctx_);
+    if (owned) {
+      xmlXPathFreeCompExpr(compiled);
+    }
+    return result;
+  }
+
+ private:
+  std::string wrapped_;
+  xmlDocPtr doc_ = nullptr;
+  xmlXPathContextPtr ctx_ = nullptr;
+  bool xmlMalformed_ = false;
+};
+
+// malformed XML and on invalid XPath expressions. These helpers raise the
+// equivalent user-facing error so the offloaded Velox path matches Spark
+// instead of silently returning NULL. They are only reached for genuinely
+// invalid input (null/empty are handled in XPathFunctions.h; valid-but-empty
+// results return NULL upstream).
+[[noreturn]] void throwInvalidXml() {
+  VELOX_USER_FAIL("Invalid XML document");
+}
+
+[[noreturn]] void throwInvalidXPath(const std::string& path) {
+  VELOX_USER_FAIL("Invalid XPath '{}'", path);
+}
+
+} // namespace
+
+std::optional<bool>
+evalBoolean(const char* xml, size_t xmlLen, const char* path, size_t pathLen) {
+  XmlXPathEvaluator evaluator(xml, xmlLen);
+  if (!evaluator.isValid()) {
+    if (evaluator.xmlMalformed()) {
+      throwInvalidXml();
+    }
+    return std::nullopt;
+  }
+
+  std::string pathStr(path, pathLen);
+  bool pathInvalid = false;
+  xmlXPathObjectPtr result = evaluator.eval(pathStr, pathInvalid);
+  if (pathInvalid) {
+    throwInvalidXPath(pathStr);
+  }
+  if (!result) {
+    return std::nullopt;
+  }
+
+  bool val = xmlXPathCastToBoolean(result) != 0;
+  xmlXPathFreeObject(result);
+  return val;
+}
+
+std::optional<std::string>
+evalString(const char* xml, size_t xmlLen, const char* path, size_t pathLen) {
+  XmlXPathEvaluator evaluator(xml, xmlLen);
+  if (!evaluator.isValid()) {
+    if (evaluator.xmlMalformed()) {
+      throwInvalidXml();
+    }
+    return std::nullopt;
+  }
+
+  std::string pathStr(path, pathLen);
+  bool pathInvalid = false;
+  xmlXPathObjectPtr result = evaluator.eval(pathStr, pathInvalid);
+  if (pathInvalid) {
+    throwInvalidXPath(pathStr);
+  }
+  if (!result) {
+    return std::nullopt;
+  }
+
+  xmlChar* str = xmlXPathCastToString(result);
+  xmlXPathFreeObject(result);
+
+  if (!str) {
+    return std::nullopt;
+  }
+  // An empty node-set casts to "" (not null), so a no-match returns the empty
+  // string rather than NULL. This matches Spark's UDFXPathUtil.evalString,
+  // which evaluates with XPathConstants.STRING and likewise yields "" for a
+  // non-matching path (NULL is reserved for null/empty inputs, handled upstream
+  // in XPathFunctions.h).
+  std::string ret(reinterpret_cast<const char*>(str));
+  xmlFree(str);
+  return ret;
+}
+
+} // namespace xpath
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/XPathUtil.h
+++ b/velox/functions/sparksql/XPathUtil.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <string>
+
+namespace facebook::velox::functions::sparksql {
+namespace xpath {
+
+/// Evaluate XPath boolean expression on XML string.
+/// Throws a user error on invalid XML or invalid XPath (Spark-faithful).
+/// Returns nullopt only when the evaluation yields no value.
+std::optional<bool>
+evalBoolean(const char* xml, size_t xmlLen, const char* path, size_t pathLen);
+
+/// Evaluate XPath string expression on XML string.
+/// Throws a user error on invalid XML or invalid XPath (Spark-faithful).
+/// Returns nullopt only when the evaluation yields no value.
+std::optional<std::string>
+evalString(const char* xml, size_t xmlLen, const char* path, size_t pathLen);
+
+} // namespace xpath
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/registration/CMakeLists.txt
+++ b/velox/functions/sparksql/registration/CMakeLists.txt
@@ -28,6 +28,7 @@ velox_add_library(
   RegisterSpecialForm.cpp
   RegisterString.cpp
   RegisterUrl.cpp
+  RegisterXml.cpp
   HEADERS
   Register.h
 )

--- a/velox/functions/sparksql/registration/Register.cpp
+++ b/velox/functions/sparksql/registration/Register.cpp
@@ -32,6 +32,7 @@ extern void registerRegexpFunctions(const std::string& prefix);
 extern void registerSpecialFormGeneralFunctions(const std::string& prefix);
 extern void registerStringFunctions(const std::string& prefix);
 extern void registerUrlFunctions(const std::string& prefix);
+extern void registerXmlFunctions(const std::string& prefix);
 
 void registerFunctions(const std::string& prefix) {
   registerArrayFunctions(prefix);
@@ -47,6 +48,7 @@ void registerFunctions(const std::string& prefix) {
   registerSpecialFormGeneralFunctions(prefix);
   registerStringFunctions(prefix);
   registerUrlFunctions(prefix);
+  registerXmlFunctions(prefix);
 }
 
 std::vector<std::string> listFunctionNames() {

--- a/velox/functions/sparksql/registration/RegisterXml.cpp
+++ b/velox/functions/sparksql/registration/RegisterXml.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/lib/RegistrationHelpers.h"
+#include "velox/functions/sparksql/XPathFunctions.h"
+
+namespace facebook::velox::functions::sparksql {
+
+void registerXmlFunctions(const std::string& prefix) {
+  registerFunction<XPathBooleanFunction, bool, Varchar, Varchar>(
+      {prefix + "xpath_boolean"});
+  registerFunction<XPathStringFunction, Varchar, Varchar, Varchar>(
+      {prefix + "xpath_string"});
+}
+
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -90,6 +90,7 @@ add_executable(
   UpperLowerTest.cpp
   UuidTest.cpp
   VarcharTypeWriteSideCheckTest.cpp
+  XPathFunctionsTest.cpp
   XxHash64Test.cpp
 )
 velox_add_test_headers(velox_functions_spark_test JsonTestUtil.h)

--- a/velox/functions/sparksql/tests/XPathFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/XPathFunctionsTest.cpp
@@ -1,0 +1,300 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <optional>
+#include <string>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+namespace facebook::velox::functions::sparksql::test {
+namespace {
+
+class XPathFunctionsTest : public SparkFunctionBaseTest {
+ protected:
+  // Helper for xpath_boolean.
+  std::optional<bool> xpathBoolean(
+      const std::string& xml,
+      const std::string& path) {
+    return evaluateOnce<bool>(
+        "xpath_boolean(c0, c1)",
+        std::optional<std::string>(xml),
+        std::optional<std::string>(path));
+  }
+
+  // Helper for xpath_string.
+  std::optional<std::string> xpathString(
+      const std::string& xml,
+      const std::string& path) {
+    return evaluateOnce<std::string>(
+        "xpath_string(c0, c1)",
+        std::optional<std::string>(xml),
+        std::optional<std::string>(path));
+  }
+};
+
+TEST_F(XPathFunctionsTest, xpathBooleanBasic) {
+  {
+    SCOPED_TRACE("Node-set truthiness: true when a matching node exists.");
+    EXPECT_EQ(xpathBoolean("<a><b>1</b></a>", "a/b"), true);
+    EXPECT_EQ(xpathBoolean("<a><b>1</b></a>", "a/c"), false);
+    EXPECT_EQ(xpathBoolean("<a><b>true</b></a>", "a/b"), true);
+  }
+  {
+    // A node-set is true when non-empty regardless of the node's text, so
+    // falsy-looking text ("false", "0") must still yield true - a guard
+    // against ever testing the node text instead of its existence.
+    SCOPED_TRACE("Node existence, not node text, decides the result.");
+    EXPECT_EQ(xpathBoolean("<a><b>false</b></a>", "a/b"), true);
+    EXPECT_EQ(xpathBoolean("<a><b>0</b></a>", "a/b"), true);
+  }
+  {
+    // A boolean XPath expression returns its own evaluated value.
+    SCOPED_TRACE("Boolean expression returns its own value.");
+    EXPECT_EQ(xpathBoolean("<a><b>1</b></a>", "a/b = 1"), true);
+    EXPECT_EQ(xpathBoolean("<a><b>1</b></a>", "a/b = 2"), false);
+  }
+}
+
+TEST_F(XPathFunctionsTest, xpathBooleanNullHandling) {
+  // NULL inputs produce NULL output.
+  EXPECT_EQ(
+      evaluateOnce<bool>(
+          "xpath_boolean(c0, c1)",
+          std::optional<std::string>(std::nullopt),
+          std::optional<std::string>("a/b")),
+      std::nullopt);
+  EXPECT_EQ(
+      evaluateOnce<bool>(
+          "xpath_boolean(c0, c1)",
+          std::optional<std::string>("<a/>"),
+          std::optional<std::string>(std::nullopt)),
+      std::nullopt);
+  // Empty string inputs produce NULL.
+  EXPECT_EQ(xpathBoolean("", "a/b"), std::nullopt);
+  EXPECT_EQ(xpathBoolean("<a/>", ""), std::nullopt);
+}
+
+TEST_F(XPathFunctionsTest, xpathStringBasic) {
+  EXPECT_EQ(xpathString("<a><b>b</b><c>cc</c></a>", "a/c"), "cc");
+  EXPECT_EQ(xpathString("<a><b>b1</b><b>b2</b></a>", "a/b"), "b1");
+}
+
+TEST_F(XPathFunctionsTest, xpathStringNullAndEdge) {
+  EXPECT_EQ(xpathString("", "a/b"), std::nullopt);
+  // No match returns empty string.
+  EXPECT_EQ(xpathString("<a><b>b</b></a>", "a/c"), "");
+}
+
+TEST_F(XPathFunctionsTest, xpathStringNonNodeSetResult) {
+  // A path that is a boolean/number XPath expression (not a node-set) is cast
+  // to its string form via xmlXPathCastToString, matching Spark.
+  EXPECT_EQ(xpathString("<a><b>1</b></a>", "a/b = 1"), "true");
+  EXPECT_EQ(xpathString("<a><b>1</b></a>", "a/b = 2"), "false");
+}
+
+TEST_F(XPathFunctionsTest, invalidXmlThrows) {
+  // Spark's UDFXPathUtil throws on malformed XML; the offloaded path matches
+  // that by raising a user error instead of returning NULL.
+  VELOX_ASSERT_USER_THROW(
+      xpathBoolean("not xml", "a/b"), "Invalid XML document");
+  VELOX_ASSERT_USER_THROW(
+      xpathString("<a><b></a>", "a/b"), "Invalid XML document");
+}
+
+TEST_F(XPathFunctionsTest, invalidXPathThrows) {
+  // An XPath syntax error throws (Spark's xpath.compile throws
+  // RuntimeException), so the offloaded path raises a user error.
+  VELOX_ASSERT_USER_THROW(
+      xpathBoolean("<a><b>1</b></a>", "///[invalid"), "Invalid XPath");
+  VELOX_ASSERT_USER_THROW(
+      xpathString("<a><b>1</b></a>", "a/b["), "Invalid XPath");
+}
+
+TEST_F(XPathFunctionsTest, namespacePrefixedReturnsNull) {
+  // A prefixed step references an unregistered prefix -> evaluation fails ->
+  // NULL (Spark, namespace-unaware, would match and return "v").
+  EXPECT_EQ(
+      xpathString(
+          "<x:a xmlns:x=\"http://e\"><x:b>v</x:b></x:a>", "x:a/x:b/text()"),
+      std::nullopt);
+  // Undeclared prefix in the input parses but still fails evaluation.
+  EXPECT_EQ(
+      xpathString("<ns:a><ns:b>v</ns:b></ns:a>", "ns:a/ns:b/text()"),
+      std::nullopt);
+}
+
+TEST_F(XPathFunctionsTest, doctypeHandling) {
+  {
+    SCOPED_TRACE("DOCTYPE without internal subset is stripped.");
+    EXPECT_EQ(
+        xpathString("<!DOCTYPE foo><foo><b>val</b></foo>", "foo/b/text()"),
+        "val");
+  }
+  {
+    SCOPED_TRACE("DOCTYPE with internal subset (brackets) is stripped.");
+    EXPECT_EQ(
+        xpathString(
+            "<!DOCTYPE foo [<!ENTITY x \"hello\">]><foo><b>val</b></foo>",
+            "foo/b/text()"),
+        "val");
+  }
+  {
+    SCOPED_TRACE("Brackets inside quoted values in the internal subset.");
+    EXPECT_EQ(
+        xpathString(
+            "<!DOCTYPE foo [<!ENTITY x SYSTEM \"file://[test]\">]>"
+            "<foo><b>42</b></foo>",
+            "foo/b/text()"),
+        "42");
+  }
+  {
+    // A comment inside the internal subset whose text contains ']' and '>'
+    // must be treated as opaque; otherwise the bracket depth is corrupted and
+    // the DOCTYPE scan terminates early, mangling the document.
+    SCOPED_TRACE("Comment containing ']' and '>' inside the internal subset.");
+    EXPECT_EQ(
+        xpathString(
+            "<!DOCTYPE foo [<!-- ] --><!ENTITY y \"z\">]>"
+            "<foo><b>val</b></foo>",
+            "foo/b/text()"),
+        "val");
+  }
+  {
+    // A processing instruction inside the internal subset containing ']' and
+    // '>' is likewise opaque to the DOCTYPE scan.
+    SCOPED_TRACE("PI containing ']' and '>' inside the internal subset.");
+    EXPECT_EQ(
+        xpathString(
+            "<!DOCTYPE foo [<?pi ]> ?><!ENTITY y \"z\">]>"
+            "<foo><b>val</b></foo>",
+            "foo/b/text()"),
+        "val");
+  }
+  {
+    // SPARK-DIVERGENCE: XP-BUG-2. The input defines an entity in the internal
+    // subset AND references it in the body. Stripping the DOCTYPE removes the
+    // definition, so the wrapped re-parse fails on the now-undefined entity and
+    // the function returns NULL. Spark expands the internal entity (-> "hi").
+    SCOPED_TRACE("Internal entity reference returns NULL (XP-BUG-2).");
+    EXPECT_EQ(
+        xpathString(
+            "<!DOCTYPE foo [<!ENTITY x \"hi\">]><foo><b>&x;</b></foo>",
+            "foo/b/text()"),
+        std::nullopt);
+  }
+}
+
+TEST_F(XPathFunctionsTest, prologHandling) {
+  {
+    // A leading "<?xml-stylesheet ...?>" PI must NOT be mistaken for the XML
+    // declaration: only "<?xml" followed by whitespace is the declaration.
+    SCOPED_TRACE("xml-stylesheet PI is not treated as the XML declaration.");
+    EXPECT_EQ(
+        xpathString(
+            "<?xml-stylesheet type=\"text/xsl\" href=\"s.xsl\"?>"
+            "<a><b>val</b></a>",
+            "a/b/text()"),
+        "val");
+  }
+  {
+    SCOPED_TRACE("A real XML declaration is stripped before wrapping.");
+    EXPECT_EQ(
+        xpathString("<?xml version=\"1.0\"?><a><b>val</b></a>", "a/b/text()"),
+        "val");
+  }
+  {
+    // A comment in the prolog before the DOCTYPE must not prevent DOCTYPE
+    // stripping; otherwise the DOCTYPE would survive into the wrapper and the
+    // re-parse would spuriously fail.
+    SCOPED_TRACE("Comment before DOCTYPE still allows DOCTYPE stripping.");
+    EXPECT_EQ(
+        xpathString(
+            "<!-- lead --><!DOCTYPE foo><foo><b>val</b></foo>", "foo/b/text()"),
+        "val");
+  }
+  {
+    SCOPED_TRACE("PI before DOCTYPE still allows DOCTYPE stripping.");
+    EXPECT_EQ(
+        xpathString(
+            "<?pi data?><!DOCTYPE foo><foo><b>val</b></foo>", "foo/b/text()"),
+        "val");
+  }
+  {
+    // SPARK-DIVERGENCE: XP-BUG-2. Stripping the declaration drops
+    // encoding="...", so the wrapped re-parse assumes UTF-8. A
+    // non-UTF-8-declared document whose bytes are invalid UTF-8 (here a lone
+    // 0xE9 under ISO-8859-1) re-parses as malformed -> NULL, even though the
+    // raw parse honored the declaration.
+    SCOPED_TRACE("Non-UTF-8 declared encoding returns NULL (XP-BUG-2).");
+    EXPECT_EQ(
+        xpathString(
+            "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>"
+            "<a><b>\xe9</b></a>",
+            "a/b/text()"),
+        std::nullopt);
+  }
+}
+TEST_F(XPathFunctionsTest, absolutePath) {
+  // Absolute paths get rewritten to go through synthetic root.
+  EXPECT_EQ(xpathString("<a><b>abs</b></a>", "/a/b/text()"), "abs");
+}
+
+TEST_F(XPathFunctionsTest, descendantAxis) {
+  // "//" should NOT be rewritten - descendant-or-self axis.
+  EXPECT_EQ(xpathString("<a><x><b>deep</b></x></a>", "//b/text()"), "deep");
+}
+
+TEST_F(XPathFunctionsTest, wildcardStep) {
+  // '*' is the wildcard name-test and must NOT be treated as an absolute-path
+  // boundary; the '/' after '*' stays relative (no "*/_r/b" corruption).
+  EXPECT_EQ(xpathString("<a><x><b>w</b></x></a>", "a/*/b/text()"), "w");
+  EXPECT_EQ(xpathString("<a><b>w</b></a>", "*/b/text()"), "w");
+}
+
+TEST_F(XPathFunctionsTest, elementNamedLikeWordOperator) {
+  // An element literally named like a word operator (or/and/div/mod) must be
+  // treated as a location step, not as an operator. Otherwise the '/' after it
+  // is misclassified as an absolute path and the wrapper root is spliced into
+  // the middle of the path, silently returning empty/no-match. "div" is the
+  // common case (XHTML). Covers the step at the start of the path and mid-path.
+  EXPECT_EQ(xpathString("<div><b>v</b></div>", "div/b/text()"), "v");
+  EXPECT_EQ(xpathString("<a><div><b>v</b></div></a>", "a/div/b/text()"), "v");
+  EXPECT_EQ(xpathString("<or><b>v</b></or>", "or/b/text()"), "v");
+  EXPECT_EQ(xpathString("<a><mod><b>v</b></mod></a>", "a/mod/b/text()"), "v");
+  // A real binary operator with a left operand still rewrites the absolute
+  // operand correctly (regression guard for the legitimate case).
+  EXPECT_EQ(xpathBoolean("<a><b>1</b></a>", "true() and /a/b = 1"), true);
+}
+
+TEST_F(XPathFunctionsTest, stringLiteralWithSlash) {
+  // A '/' inside an XPath string literal must NOT be rewritten as an absolute
+  // path. Here the predicate value "(/c)" contains an operator char '(' before
+  // '/', which would be mis-rewritten to "(/_r/c)" without quote-awareness,
+  // breaking the predicate match.
+  EXPECT_EQ(xpathString("<a><b>(/c)</b></a>", "a/b[text()='(/c)']"), "(/c)");
+  // Double-quoted literal variant.
+  EXPECT_EQ(
+      xpathString("<a><b>x/y</b></a>", "a/b[text()=\"x/y\"]/text()"), "x/y");
+}
+
+// ==================== Node types ====================
+
+TEST_F(XPathFunctionsTest, attributeNode) {
+  EXPECT_EQ(xpathString("<a id=\"x123\">val</a>", "a/@id"), "x123");
+}
+
+} // namespace
+} // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
## Description

Introduces the foundation for Spark's XPath function family in Velox, backed by libxml2. This first change lands the shared XPath evaluation engine (`XPathUtil`) and the two simplest functions:

- `xpath_boolean(xml, path) -> boolean`
- `xpath_string(xml, path) -> varchar`

The remaining variants (`xpath`, `xpath_short/int/long/float/double/number`) will follow in a subsequent change that reuses this engine.

### Engine

`XPathUtil` parses XML with libxml2 using a hardened parser configuration to mitigate XXE/SSRF: network access is disabled (`XML_PARSE_NONET`), entity substitution is off (`XML_PARSE_NOENT` not set), and external DTD loading is off (`XML_PARSE_DTDLOAD` not set).

To preserve Spark/Hive (`UDFXPathUtil`) semantics on modern libxml2 (2.14+), the input document is wrapped in a synthetic root element and absolute-path expressions are rewritten to traverse that wrapper. Compiled XPath expressions are cached per-thread (bounded, so a high-cardinality non-constant path column cannot grow memory without limit).

### Spark parity and documented divergences

- Invalid XML documents and invalid XPath expressions raise a user error, matching Spark's `UDFXPathUtil` throw-vs-NULL behavior on the offloaded path. Null and empty inputs short-circuit to NULL; a valid path with no match returns NULL/`""` exactly as Spark does.
- Accepted, documented, security-motivated divergences (all return NULL rather than Spark's throw/expand): DOCTYPE/external-entity stripping (XXE-safe), and libxml2's always-namespace-aware matching vs Spark's namespace-unaware parse. These are called out inline (`XP-BUG-1/2/3`) and covered by tests.

### Dependency

libxml2 is resolved through Velox's standard dependency framework via `velox_resolve_dependency(LibXml2)`: it uses a system libxml2 when available and otherwise builds a minimal libxml2 from source through a new `CMake/resolve_dependency_modules/libxml2.cmake` (pinned version + SHA256). The setup scripts install the system package, and the sparksql function library links `LibXml2::LibXml2`.

## Tests

Adds `XPathFunctionsTest` covering boolean/string evaluation, node-set truthiness, null/empty handling, invalid-XML/invalid-XPath throws, namespace divergence, DOCTYPE/internal-subset handling (comments, PIs, quoted brackets), XML-declaration vs `<?xml-stylesheet?>` PI disambiguation, absolute/`//`/wildcard/word-operator path rewriting, string literals containing `/`, and attribute nodes.
