### PR TITLE
fix(iceberg): Issue when column with default value has filter

### DIFF
--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -81,6 +81,32 @@ void fillNullsWithInt64(
 namespace facebook::velox::connector::hive::iceberg {
 namespace {
 
+// Indexes IcebergColumnHandles by their underlying data-column name.
+// Covers output-projected handles (columnHandles) and, when tableHandle is
+// non-null, filter-only handles (tableHandle->filterColumnHandles()) too.
+std::unordered_map<std::string, const IcebergColumnHandle*>
+buildIcebergHandleByName(
+    const ColumnHandleMap* columnHandles,
+    const FileTableHandle* tableHandle = nullptr) {
+  std::unordered_map<std::string, const IcebergColumnHandle*> handleByName;
+  const auto addHandle = [&handleByName](const auto& handle) {
+    if (auto* h = dynamic_cast<const IcebergColumnHandle*>(handle.get())) {
+      handleByName.emplace(h->name(), h);
+    }
+  };
+  if (columnHandles) {
+    for (const auto& [_, handle] : *columnHandles) {
+      addHandle(handle);
+    }
+  }
+  if (tableHandle) {
+    for (const auto& handle : tableHandle->filterColumnHandles()) {
+      addHandle(handle);
+    }
+  }
+  return handleByName;
+}
+
 /// Returns true if a delete/update file should be skipped based on sequence
 /// number conflict resolution. Per the Iceberg spec (V2+):
 ///   - Equality deletes apply when deleteSeqNum > dataSeqNum (i.e., skip when
@@ -171,22 +197,8 @@ std::vector<dwio::common::ParquetFieldId> IcebergSplitReader::buildFieldIds()
   }
   // Column handles are keyed by output alias; index them by the underlying
   // data-column name so we can align to dataColumns() order.
-  std::unordered_map<std::string, const IcebergColumnHandle*> handleByName;
-  const auto addIcebergHandle = [&handleByName](const auto& handle) {
-    if (auto* icebergHandle =
-            dynamic_cast<const IcebergColumnHandle*>(handle.get())) {
-      handleByName.emplace(icebergHandle->name(), icebergHandle);
-    }
-  };
-  for (const auto& columnHandle : *columnHandles_) {
-    addIcebergHandle(columnHandle.second);
-  }
-  // Remaining filters can add columns to the reader output that are not
-  // projected by the table scan. Include those handles so filter-only columns
-  // are still matched by Iceberg field ID.
-  for (const auto& handle : tableHandle_->filterColumnHandles()) {
-    addIcebergHandle(handle);
-  }
+  const auto handleByName =
+      buildIcebergHandleByName(columnHandles_.get(), tableHandle_.get());
   if (handleByName.empty()) {
     return fieldIds;
   }
@@ -248,13 +260,7 @@ void IcebergSplitReader::prepareSplit(
       // IcebergColumnHandle's field-id tree (per-input-column).
       // Column handles are keyed by output alias; index them by physical name
       // to mirror buildFieldIds() and support renamed columns.
-      std::unordered_map<std::string, const IcebergColumnHandle*> handleByName;
-      for (const auto& [outputName, handle] : *columnHandles_) {
-        if (auto* icebergHandle =
-                dynamic_cast<const IcebergColumnHandle*>(handle.get())) {
-          handleByName.emplace(icebergHandle->name(), icebergHandle);
-        }
-      }
+      const auto handleByName = buildIcebergHandleByName(columnHandles_.get());
       std::vector<dwio::common::ParquetFieldId> fieldIds;
       fieldIds.reserve(fileSchema->size());
       bool allResolved = true;
@@ -925,6 +931,12 @@ std::vector<TypePtr> IcebergSplitReader::adaptColumns(
   const bool readTimestampAsLocalTime =
       fileConfig_->readTimestampPartitionValueAsLocalTime(
           connectorQueryCtx_->sessionProperties());
+
+  // Index all Iceberg column handles by data-column name for O(1) default-value
+  // lookup inside the loop.
+  const auto handleByName =
+      buildIcebergHandleByName(columnHandles_.get(), tableHandle_.get());
+
   // Iceberg table stores all column's data in data file.
   for (const auto& childSpec : childrenSpecs) {
     const std::string& fieldName = childSpec->fieldName();
@@ -1045,40 +1057,21 @@ std::vector<TypePtr> IcebergSplitReader::adaptColumns(
                    partitionIt != fileSplit_->partitionKeys.end()) {
           setPartitionValue(childSpec.get(), fieldName, partitionIt->second);
         } else {
-          // Check if column has an initial-default value (Iceberg V3)
-          bool hasDefaultValue = false;
-          // The columnHandles_ map is keyed by output name (which may be an
-          // alias). We need to find the column handle where the handle's name()
-          // matches fieldName. fieldName is the table column name from
-          // readerOutputType_.
-          for (const auto& [outputName, handle] : *columnHandles_) {
-            if (handle->name() == fieldName) {
-              auto icebergColumnHandle =
-                  std::dynamic_pointer_cast<const IcebergColumnHandle>(handle);
-              if (icebergColumnHandle &&
-                  icebergColumnHandle->initialDefaultValue().has_value()) {
-                // Use initial-default value for schema evolution.
-                auto columnType = tableSchema->findChild(fieldName);
-                VELOX_CHECK_NOT_NULL(
-                    columnType,
-                    "Column '{}' not found in table schema",
-                    fieldName);
-                auto constant = newConstantFromString(
-                    columnType,
-                    icebergColumnHandle->initialDefaultValue().value(),
-                    connectorQueryCtx_->memoryPool(),
-                    readTimestampAsLocalTime,
-                    false);
-                childSpec->setConstantValue(constant);
-                hasDefaultValue = true;
-                break;
-              }
-            }
-          }
-
-          // Fall back to NULL if no default value
-          if (!hasDefaultValue) {
-            auto columnType = tableSchema->findChild(fieldName);
+          // Check if column has an initial-default value (Iceberg V3).
+          // Use the pre-built handleByName map that covers both output
+          // column handles and filter column handles.
+          auto it = handleByName.find(fieldName);
+          auto columnType = tableSchema->findChild(fieldName);
+          if (it != handleByName.end() &&
+              it->second->initialDefaultValue().has_value()) {
+            childSpec->setConstantValue(newConstantFromString(
+                columnType,
+                it->second->initialDefaultValue().value(),
+                connectorQueryCtx_->memoryPool(),
+                readTimestampAsLocalTime,
+                false));
+          } else {
+            // Fall back to NULL if no default value.
             VELOX_CHECK_NOT_NULL(
                 columnType, "Column '{}' not found in table schema", fieldName);
             childSpec->setConstantValue(

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -81,6 +81,32 @@ void fillNullsWithInt64(
 namespace facebook::velox::connector::hive::iceberg {
 namespace {
 
+// Indexes IcebergColumnHandles by their underlying data-column name.
+// Covers output-projected handles (columnHandles) and, when tableHandle is
+// non-null, filter-only handles (tableHandle->filterColumnHandles()) too.
+std::unordered_map<std::string, const IcebergColumnHandle*>
+buildIcebergHandleByName(
+    const ColumnHandleMap* columnHandles,
+    const FileTableHandle* tableHandle = nullptr) {
+  std::unordered_map<std::string, const IcebergColumnHandle*> handleByName;
+  const auto addHandle = [&handleByName](const auto& handle) {
+    if (auto* h = dynamic_cast<const IcebergColumnHandle*>(handle.get())) {
+      handleByName.emplace(h->name(), h);
+    }
+  };
+  if (columnHandles) {
+    for (const auto& [_, handle] : *columnHandles) {
+      addHandle(handle);
+    }
+  }
+  if (tableHandle) {
+    for (const auto& handle : tableHandle->filterColumnHandles()) {
+      addHandle(handle);
+    }
+  }
+  return handleByName;
+}
+
 /// Returns true if a delete/update file should be skipped based on sequence
 /// number conflict resolution. Per the Iceberg spec (V2+):
 ///   - Equality deletes apply when deleteSeqNum > dataSeqNum (i.e., skip when
@@ -171,22 +197,8 @@ std::vector<dwio::common::ParquetFieldId> IcebergSplitReader::buildFieldIds()
   }
   // Column handles are keyed by output alias; index them by the underlying
   // data-column name so we can align to dataColumns() order.
-  std::unordered_map<std::string, const IcebergColumnHandle*> handleByName;
-  const auto addIcebergHandle = [&handleByName](const auto& handle) {
-    if (auto* icebergHandle =
-            dynamic_cast<const IcebergColumnHandle*>(handle.get())) {
-      handleByName.emplace(icebergHandle->name(), icebergHandle);
-    }
-  };
-  for (const auto& columnHandle : *columnHandles_) {
-    addIcebergHandle(columnHandle.second);
-  }
-  // Remaining filters can add columns to the reader output that are not
-  // projected by the table scan. Include those handles so filter-only columns
-  // are still matched by Iceberg field ID.
-  for (const auto& handle : tableHandle_->filterColumnHandles()) {
-    addIcebergHandle(handle);
-  }
+  const auto handleByName =
+      buildIcebergHandleByName(columnHandles_.get(), tableHandle_.get());
   if (handleByName.empty()) {
     return fieldIds;
   }
@@ -248,13 +260,7 @@ void IcebergSplitReader::prepareSplit(
       // IcebergColumnHandle's field-id tree (per-input-column).
       // Column handles are keyed by output alias; index them by physical name
       // to mirror buildFieldIds() and support renamed columns.
-      std::unordered_map<std::string, const IcebergColumnHandle*> handleByName;
-      for (const auto& [outputName, handle] : *columnHandles_) {
-        if (auto* icebergHandle =
-                dynamic_cast<const IcebergColumnHandle*>(handle.get())) {
-          handleByName.emplace(icebergHandle->name(), icebergHandle);
-        }
-      }
+      const auto handleByName = buildIcebergHandleByName(columnHandles_.get());
       std::vector<dwio::common::ParquetFieldId> fieldIds;
       fieldIds.reserve(fileSchema->size());
       bool allResolved = true;
@@ -925,6 +931,12 @@ std::vector<TypePtr> IcebergSplitReader::adaptColumns(
   const bool readTimestampAsLocalTime =
       fileConfig_->readTimestampPartitionValueAsLocalTime(
           connectorQueryCtx_->sessionProperties());
+
+  // Index all Iceberg column handles by data-column name for O(1) default-value
+  // lookup inside the loop.
+  const auto handleByName =
+      buildIcebergHandleByName(columnHandles_.get(), tableHandle_.get());
+
   // Iceberg table stores all column's data in data file.
   for (const auto& childSpec : childrenSpecs) {
     const std::string& fieldName = childSpec->fieldName();
@@ -1045,39 +1057,20 @@ std::vector<TypePtr> IcebergSplitReader::adaptColumns(
                    partitionIt != fileSplit_->partitionKeys.end()) {
           setPartitionValue(childSpec.get(), fieldName, partitionIt->second);
         } else {
-          // Check if column has an initial-default value (Iceberg V3)
-          bool hasDefaultValue = false;
-          // The columnHandles_ map is keyed by output name (which may be an
-          // alias). We need to find the column handle where the handle's name()
-          // matches fieldName. fieldName is the table column name from
-          // readerOutputType_.
-          for (const auto& [outputName, handle] : *columnHandles_) {
-            if (handle->name() == fieldName) {
-              auto icebergColumnHandle =
-                  std::dynamic_pointer_cast<const IcebergColumnHandle>(handle);
-              if (icebergColumnHandle &&
-                  icebergColumnHandle->initialDefaultValue().has_value()) {
-                // Use initial-default value for schema evolution.
-                auto columnType = tableSchema->findChild(fieldName);
-                VELOX_CHECK_NOT_NULL(
-                    columnType,
-                    "Column '{}' not found in table schema",
-                    fieldName);
-                auto constant = newConstantFromString(
-                    columnType,
-                    icebergColumnHandle->initialDefaultValue().value(),
-                    connectorQueryCtx_->memoryPool(),
-                    readTimestampAsLocalTime,
-                    false);
-                childSpec->setConstantValue(constant);
-                hasDefaultValue = true;
-                break;
-              }
-            }
-          }
-
-          // Fall back to NULL if no default value
-          if (!hasDefaultValue) {
+          // Check if column has an initial-default value (Iceberg V3).
+          // Use the pre-built handleByName map that covers both output
+          // column handles and filter column handles.
+          auto it = handleByName.find(fieldName);
+          if (it != handleByName.end() &&
+              it->second->initialDefaultValue().has_value()) {
+            childSpec->setConstantValue(newConstantFromString(
+                it->second->dataType(),
+                it->second->initialDefaultValue().value(),
+                connectorQueryCtx_->memoryPool(),
+                readTimestampAsLocalTime,
+                false));
+          } else {
+            // Fall back to NULL if no default value.
             auto columnType = tableSchema->findChild(fieldName);
             VELOX_CHECK_NOT_NULL(
                 columnType, "Column '{}' not found in table schema", fieldName);

--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -1443,5 +1443,114 @@ TEST_F(IcebergReadTest, flatMapAsStruct) {
       .assertResults({expected});
 }
 
+TEST_F(IcebergReadTest, filterPushdownWithInitialDefaultInFilterColumnHandles) {
+  // Test's a scenario where filter on default value column is used in the query
+  // TABLE = [id int , country varchar(defaultValue='IN')]
+  // QUERY = SELECT id FROM table WHERE country = 'IN'
+  // When filter pushdown is enabled, column handle for 'country' is present
+  // only in filterColumnHandles_ of HiveTableHandle. adaptColumns was searching
+  // only in columnHandles_ for the default value, missing it and creating null
+  // vector.
+
+  // Old data file: only the 'id' column present.
+  std::vector<RowVectorPtr> dataVectors = {
+      makeRowVector({makeFlatVector<int64_t>({1, 2, 3})})};
+  auto dataFilePath = TempFilePath::create();
+  writeToFile(dataFilePath->getPath(), dataVectors);
+
+  auto outputType = ROW({"id"}, {BIGINT()});
+
+  ColumnHandleMap assignments;
+  assignments["id"] = makeIcebergHandle("id", BIGINT(), 1);
+
+  // filterColumnHandles carries country WITH initialDefaultValue="IN".
+  std::vector<HiveColumnHandlePtr> filterHandles = {
+      makeIcebergHandle("country", VARCHAR(), 2, "IN")};
+
+  // Expected: all 3 rows (country filter passes via default constant).
+  std::vector<RowVectorPtr> allRowsIN = {
+      makeRowVector(outputType->names(), {makeFlatVector<int64_t>({1, 2, 3})})};
+
+  // Full schema used for subfieldFilter expression parsing (country must be
+  // reachable even though it is not in outputType).
+  auto fullSchema = ROW({"id", "country"}, {BIGINT(), VARCHAR()});
+
+  auto assertFilter =
+      [&](const std::string& subfieldFilter,
+          const std::vector<RowVectorPtr>& expected,
+          const std::vector<std::shared_ptr<ConnectorSplit>>& splits,
+          int32_t numSplitsSkipped = 0) {
+        auto plan = exec::test::PlanBuilder()
+                        .startTableScan()
+                        .connectorId(test::kIcebergConnectorId)
+                        .outputType(outputType)
+                        .dataColumns(fullSchema)
+                        .assignments(assignments)
+                        .filterColumnHandles(filterHandles)
+                        .subfieldFilter(subfieldFilter)
+                        .endTableScan()
+                        .planNode();
+        auto task =
+            exec::test::AssertQueryBuilder(plan).splits(splits).assertResults(
+                expected);
+        ASSERT_EQ(
+            task->taskStats()
+                .pipelineStats[0]
+                .operatorStats[0]
+                .runtimeStats["skippedSplits"]
+                .sum,
+            numSplitsSkipped)
+            << "Unexpected skipped splits for filter: " << subfieldFilter;
+      };
+
+  // Bug scenario: country absent from file, assignments handle has no default.
+  // Without fix: adaptColumns finds no default → sets NULL → testFilters skips
+  //              file (NULL != 'IN') → 0 rows, numSplitsSkipped=1. WRONG.
+  // With fix:    adaptColumns finds default 'IN' in filterColumnHandles →
+  //              constant 'IN' → testFilters passes → 3 rows. CORRECT.
+  // Note: splits must be recreated for each assertFilter call — ConnectorSplit
+  // objects have their dataSource set during execution and cannot be reused.
+  assertFilter(
+      "country = 'IN'",
+      allRowsIN,
+      makeIcebergSplits(dataFilePath->getPath()),
+      /*numSplitsSkipped=*/0);
+
+  // Non-matching default: constant 'IN' != 'US' → file skipped regardless.
+  assertFilter(
+      "country = 'US'",
+      {},
+      makeIcebergSplits(dataFilePath->getPath()),
+      /*numSplitsSkipped=*/1);
+
+  // New file written AFTER ALTER TABLE: country physically present = 'US'.
+  // Output still only has {id} — country is filter-only.
+  std::vector<RowVectorPtr> newData = {makeRowVector(
+      {"id", "country"},
+      {makeFlatVector<int64_t>({4, 5}),
+       makeFlatVector<std::string>({"US", "US"})})};
+  auto newFilePath = TempFilePath::create();
+  writeToFile(newFilePath->getPath(), newData);
+
+  auto makeTwoSplits = [&]() {
+    auto s1 = makeIcebergSplits(dataFilePath->getPath());
+    auto s2 = makeIcebergSplits(newFilePath->getPath());
+    s1.insert(s1.end(), s2.begin(), s2.end());
+    return s1;
+  };
+
+  // country='IN': old file passes (constant 'IN'), new file skipped ('US').
+  // 1 split skipped, rows {1,2,3} from old file.
+  assertFilter(
+      "country = 'IN'", allRowsIN, makeTwoSplits(), /*numSplitsSkipped=*/1);
+
+  // country='US': old file skipped (constant 'IN'!='US'), new file passes.
+  // 1 split skipped, rows {4,5} from new file.
+  std::vector<RowVectorPtr> newRowsUS = {
+      makeRowVector(outputType->names(), {makeFlatVector<int64_t>({4, 5})})};
+  assertFilter(
+      "country = 'US'", newRowsUS, makeTwoSplits(), /*numSplitsSkipped=*/1);
+}
+
 } // namespace
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -391,9 +391,9 @@ TEST_F(IcebergReadTest, readParquetFlatSchemaEvolutionByFieldId) {
           ROW({"enabled", "id"}, {BOOLEAN(), BIGINT()}),
           ROW({"id", "flag", "status"}, {BIGINT(), BOOLEAN(), VARCHAR()}),
           {
-              {"id", "id", BIGINT(), makeFieldId(1)},
-              {"enabled", "flag", BOOLEAN(), makeFieldId(2)},
-              {"status", "status", VARCHAR(), makeFieldId(3)},
+              {"id", "id", BIGINT(), makeFieldId(1), {}},
+              {"enabled", "flag", BOOLEAN(), makeFieldId(2), {}},
+              {"status", "status", VARCHAR(), makeFieldId(3), {}},
           },
           makeRowVector(
               {"enabled", "id"},
@@ -407,10 +407,10 @@ TEST_F(IcebergReadTest, readParquetFlatSchemaEvolutionByFieldId) {
           ROW({"id", "flag", "status", "score"},
               {BIGINT(), BOOLEAN(), VARCHAR(), INTEGER()}),
           {
-              {"id", "id", BIGINT(), makeFieldId(1)},
-              {"flag", "flag", BOOLEAN(), makeFieldId(2)},
-              {"status", "status", VARCHAR(), makeFieldId(3)},
-              {"score", "score", INTEGER(), makeFieldId(4)},
+              {"id", "id", BIGINT(), makeFieldId(1), {}},
+              {"flag", "flag", BOOLEAN(), makeFieldId(2), {}},
+              {"status", "status", VARCHAR(), makeFieldId(3), {}},
+              {"score", "score", INTEGER(), makeFieldId(4), {}},
           },
           makeRowVector(
               {"id", "flag", "status", "score"},
@@ -425,8 +425,8 @@ TEST_F(IcebergReadTest, readParquetFlatSchemaEvolutionByFieldId) {
           ROW({"id", "status"}, {BIGINT(), VARCHAR()}),
           ROW({"id", "status"}, {BIGINT(), VARCHAR()}),
           {
-              {"id", "id", BIGINT(), makeFieldId(1)},
-              {"status", "status", VARCHAR(), makeFieldId(3)},
+              {"id", "id", BIGINT(), makeFieldId(1), {}},
+              {"status", "status", VARCHAR(), makeFieldId(3), {}},
           },
           makeRowVector(
               {"id", "status"},
@@ -438,7 +438,7 @@ TEST_F(IcebergReadTest, readParquetFlatSchemaEvolutionByFieldId) {
           ROW({"score"}, {INTEGER()}),
           ROW({"score"}, {INTEGER()}),
           {
-              {"score", "score", INTEGER(), makeFieldId(4)},
+              {"score", "score", INTEGER(), makeFieldId(4), {}},
           },
           makeRowVector(
               {"score"},
@@ -450,8 +450,8 @@ TEST_F(IcebergReadTest, readParquetFlatSchemaEvolutionByFieldId) {
           ROW({"id", "status"}, {BIGINT(), BOOLEAN()}),
           ROW({"id", "status"}, {BIGINT(), BOOLEAN()}),
           {
-              {"id", "id", BIGINT(), makeFieldId(1)},
-              {"status", "status", BOOLEAN(), makeFieldId(4)},
+              {"id", "id", BIGINT(), makeFieldId(1), {}},
+              {"status", "status", BOOLEAN(), makeFieldId(4), {}},
           },
           makeRowVector(
               {"id", "status"},
@@ -481,7 +481,7 @@ TEST_F(IcebergReadTest, readParquetFilterOnlyColumnByFieldId) {
           .outputType(ROW({"id"}, {BIGINT()}))
           .dataColumns(testData.writeType)
           .assignments(makeFieldIdAssignments({
-              {"id", "id", BIGINT(), makeFieldId(1)},
+              {"id", "id", BIGINT(), makeFieldId(1), {}},
           }))
           .filterColumnHandles({
               makeIcebergHandle("status", VARCHAR(), makeFieldId(3)),
@@ -573,8 +573,8 @@ TEST_F(IcebergReadTest, readParquetArrayByFieldId) {
             {"items",
              "items",
              nestedReadType->childAt(0),
-             makeFieldId(
-                 1, {makeFieldId(2, {makeFieldId(4), makeFieldId(3)})})},
+             makeFieldId(1, {makeFieldId(2, {makeFieldId(4), makeFieldId(3)})}),
+             {}},
         },
         {nestedExpected});
   }
@@ -596,7 +596,8 @@ TEST_F(IcebergReadTest, readParquetArrayByFieldId) {
             {"items",
              "items",
              nestedProjectedReadType->childAt(0),
-             makeFieldId(1, {makeFieldId(2, {makeFieldId(4)})})},
+             makeFieldId(1, {makeFieldId(2, {makeFieldId(4)})}),
+             {}},
         },
         {nestedProjectedExpected});
   }
@@ -645,7 +646,8 @@ TEST_F(IcebergReadTest, readParquetMapByFieldId) {
              makeFieldId(
                  1,
                  {makeFieldId(2),
-                  makeFieldId(3, {makeFieldId(5), makeFieldId(4)})})},
+                  makeFieldId(3, {makeFieldId(5), makeFieldId(4)})}),
+             {}},
         },
         {mapExpected});
   }
@@ -671,8 +673,8 @@ TEST_F(IcebergReadTest, readParquetMapByFieldId) {
             {"attributes",
              "attributes",
              mapProjectedReadType->childAt(0),
-             makeFieldId(
-                 1, {makeFieldId(2), makeFieldId(3, {makeFieldId(5)})})},
+             makeFieldId(1, {makeFieldId(2), makeFieldId(3, {makeFieldId(5)})}),
+             {}},
         },
         {mapProjectedExpected});
   }


### PR DESCRIPTION
When pushdown_filter_enabled config is true, and a filter is used on a column with default value, it is incorrectly applied leading to incorrect results. The simple test case is 

```
CREATE TABLE iceberg_v3.default.employee (
    id INT,
    name VARCHAR
)
WITH ("format-version"='3');

INSERT INTO iceberg_v3.default.employee VALUES
(1,'Alice'),
(2,'Bob'),
(3,'Charlie');

ALTER TABLE iceberg_v3.default.employee
ADD COLUMN country VARCHAR DEFAULT 'IN';

SET SESSION iceberg_v3.pushdown_filter_enabled=true;

-- Should return 3 rows, but returns 0 rows
SELECT id, name, country
FROM iceberg_v3.default.employee
WHERE country = 'IN';
```

The issue is when pushdown filter is enabled, the column handles get separated into predicate column handles and non-predicate column handles. `IcebergSplitReader::adaptColumns()` method had the code to search for default value for a column only in non-predicate column handles. Fixed is to search in predicate column handles too and apply the default value.