### PR TITLE
fix(iceberg): Default-initialize FieldIdColumnSpec::requiredSubfields

### DIFF
--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -104,7 +104,7 @@ class IcebergReadTest : public test::IcebergTestBase {
     std::string dataName;
     TypePtr type;
     parquet::ParquetFieldId fieldId;
-    std::vector<std::string> requiredSubfields;
+    std::vector<std::string> requiredSubfields{};
   };
 
   ColumnHandleMap makeFieldIdAssignments(


### PR DESCRIPTION
Summary:
The clang-22 `release with adapters` OSS build (`-Wextra -Werror`) fails to compile `IcebergReadTest.cpp` with 17 `-Wmissing-field-initializers` errors. The `FieldIdColumnSpec` test struct (added in "feat(parquet): Read columns by field ID") has a trailing `requiredSubfields` member, and the aggregate-init sites (e.g. `{"id", "id", BIGINT(), makeFieldId(1)}`) omit it. Newer clang flags a missing initializer even for a non-trivial trailing member.

Add a brace default member initializer (`{}`) to `requiredSubfields` so it is treated as explicitly initialized, silencing the warning at every init site without editing them. `FieldIdColumnSpec` remains an aggregate under C++20.

Seems to be causing the failure on my PR here: https://github.com/facebookincubator/velox/actions/runs/30783616637/job/91592927049

Differential Revision: D114602859


