### PR TITLE
perf: Bound RowsStreamingWindowBuild memory for large single partitions (#18378)

### DIFF
--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -67,7 +67,11 @@ Window::Window(
   if (windowNode->inputsSorted()) {
     if (supportRowsStreaming()) {
       windowBuild_ = std::make_unique<window::RowsStreamingWindowBuild>(
-          windowNode_, pool(), spillConfig, &nonReclaimableSection_);
+          windowNode_,
+          pool(),
+          spillConfig,
+          &nonReclaimableSection_,
+          driverCtx->queryConfig().preferredOutputBatchBytes());
     } else {
       windowBuild_ = std::make_unique<window::PartitionStreamingWindowBuild>(
           windowNode, pool(), spillConfig, &nonReclaimableSection_);

--- a/velox/exec/benchmarks/RowsStreamingWindowBenchmark.cpp
+++ b/velox/exec/benchmarks/RowsStreamingWindowBenchmark.cpp
@@ -108,6 +108,37 @@ class RowsStreamingWindowBenchmark : public VectorTestBase {
          "count(v) over (partition by p order by s)",
          "min(v) over (partition by p order by s)",
          "max(v) over (partition by p order by s)"});
+
+    // The cases above omit the frame clause, which parses to RANGE. Only a
+    // ROWS frame reaches the retained-byte throttle, so these measure it.
+    addBenchmark(
+        "rowsStreamingWindowRankRowsFrame_" + sizeName,
+        data,
+        {rowsFrame("rank()")});
+    addBenchmark(
+        "rowsStreamingWindowSumRowsFrame_" + sizeName,
+        data,
+        {rowsFrame("sum(v)")});
+    addBenchmark(
+        "rowsStreamingWindowRankAndSumRowsFrame_" + sizeName,
+        data,
+        {rowsFrame("rank()"), rowsFrame("sum(v)")});
+    addBenchmark(
+        "rowsStreamingWindowSevenFunctionsRowsFrame_" + sizeName,
+        data,
+        {rowsFrame("rank()"),
+         rowsFrame("dense_rank()"),
+         rowsFrame("row_number()"),
+         rowsFrame("sum(v)"),
+         rowsFrame("count(v)"),
+         rowsFrame("min(v)"),
+         rowsFrame("max(v)")});
+  }
+
+  static std::string rowsFrame(const std::string& call) {
+    return call +
+        " over (partition by p order by s rows between unbounded preceding "
+        "and current row)";
   }
 
   void addBenchmark(

--- a/velox/exec/benchmarks/RowsStreamingWindowBenchmark.cpp
+++ b/velox/exec/benchmarks/RowsStreamingWindowBenchmark.cpp
@@ -108,6 +108,27 @@ class RowsStreamingWindowBenchmark : public VectorTestBase {
          "count(v) over (partition by p order by s)",
          "min(v) over (partition by p order by s)",
          "max(v) over (partition by p order by s)"});
+
+    // The cases above omit the frame clause, which parses to RANGE. Only a
+    // ROWS frame reaches the retained-byte throttle, so these measure it.
+    addBenchmark(
+        "rowsStreamingWindowRankRowsFrame_" + sizeName,
+        data,
+        {rowsFrame("rank()")});
+    addBenchmark(
+        "rowsStreamingWindowSumRowsFrame_" + sizeName,
+        data,
+        {rowsFrame("sum(v)")});
+    addBenchmark(
+        "rowsStreamingWindowRankAndSumRowsFrame_" + sizeName,
+        data,
+        {rowsFrame("rank()"), rowsFrame("sum(v)")});
+  }
+
+  static std::string rowsFrame(const std::string& call) {
+    return call +
+        " over (partition by p order by s rows between unbounded preceding "
+        "and current row)";
   }
 
   void addBenchmark(

--- a/velox/exec/tests/WindowTest.cpp
+++ b/velox/exec/tests/WindowTest.cpp
@@ -27,10 +27,13 @@
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/exec/window/RowsStreamingWindowBuild.h"
 #include "velox/exec/window/SortWindowBuild.h"
+#include "velox/exec/window/VectorWindowPartition.h"
 #include "velox/functions/prestosql/window/WindowFunctionsRegistration.h"
 #include "velox/vector/LazyVector.h"
 #include "velox/vector/SimpleVector.h"
 #include "velox/vector/tests/utils/VectorMaker.h"
+
+#include <limits>
 
 using namespace facebook::velox::exec::test;
 
@@ -76,8 +79,74 @@ class WindowTest : public OperatorTestBase {
       std::make_shared<folly::CPUThreadPoolExecutor>(
           folly::available_concurrency())};
 
+  // Builds one partition's worth of pre-sorted input: 'p' is constant so the
+  // build sees a single ever-growing incomplete partition, and 's' ascends from
+  // 'sortKeyOffset'. Each sort key repeats 'peerGroupSize' times, so peer
+  // groups straddle flush boundaries. 'payloadBytes' sizes the 'v' column,
+  // which is what drives the retained-byte budget; 0 means a narrow bigint.
+  RowVectorPtr makeSinglePartitionData(
+      vector_size_t size,
+      vector_size_t peerGroupSize,
+      int32_t payloadBytes,
+      int32_t sortKeyOffset) {
+    auto partitionKey =
+        makeFlatVector<int16_t>(size, [](auto /*row*/) { return 1; });
+    auto sortKey = makeFlatVector<int32_t>(
+        size, [&](auto row) { return sortKeyOffset + row / peerGroupSize; });
+    if (payloadBytes == 0) {
+      return makeRowVector(
+          {"p", "s", "v"},
+          {partitionKey, sortKey, makeFlatVector<int64_t>(size, [](auto row) {
+             return row;
+           })});
+    }
+    const std::string payload(payloadBytes, 'x');
+    return makeRowVector(
+        {"p", "s", "v"},
+        {partitionKey, sortKey, makeFlatVector<StringView>(size, [&](auto) {
+           return StringView(payload);
+         })});
+  }
+
+  // Returns the WindowNode for 'windowFunctions' over 'data', already sorted by
+  // the partition and sort keys.
+  std::shared_ptr<const core::WindowNode> makeStreamingWindowNode(
+      const std::vector<RowVectorPtr>& data,
+      const std::vector<std::string>& windowFunctions) {
+    auto plan = PlanBuilder()
+                    .values(data)
+                    .orderBy({"p", "s"}, false)
+                    .streamingWindow(windowFunctions)
+                    .planNode();
+    auto windowNode = std::dynamic_pointer_cast<const core::WindowNode>(plan);
+    VELOX_CHECK_NOT_NULL(windowNode);
+    return windowNode;
+  }
+
+  // Returns a retained-byte budget worth 'numRows' rows of 'data'.
+  uint64_t budgetForRows(const RowVectorPtr& data, int32_t numRows) {
+    const uint64_t rowSize = data->estimateFlatSize() / data->size();
+    VELOX_CHECK_GT(rowSize, 0);
+    return rowSize * numRows;
+  }
+
   tsan_atomic<bool> nonReclaimableSection_{false};
 };
+
+// Wraps 'call' in the default ROWS frame. An omitted frame clause parses to
+// RANGE, and 'hasRangeFrame_' is node-wide, so a single unframed function
+// exempts the whole build from the byte budget.
+std::string rowsFrameFunction(const std::string& call) {
+  return fmt::format(
+      "{} over (partition by p order by s rows between unbounded preceding "
+      "and current row)",
+      call);
+}
+
+// Retained-byte budget for tests that are not exercising the byte-budget
+// throttle and want the build to accept input unconditionally.
+constexpr uint64_t kUnboundedRetainedBytes =
+    std::numeric_limits<uint64_t>::max();
 
 class TestingRowsStreamingWindowBuild
     : public window::RowsStreamingWindowBuild {
@@ -615,12 +684,288 @@ TEST_F(WindowTest, rowsStreamingWindowBuildDoesNotMaterializeRows) {
   ASSERT_NE(windowNode, nullptr);
 
   TestingRowsStreamingWindowBuild windowBuild(
-      windowNode, pool(), nullptr, &nonReclaimableSection_);
+      windowNode,
+      pool(),
+      nullptr,
+      &nonReclaimableSection_,
+      kUnboundedRetainedBytes);
   windowBuild.setNumRowsPerOutput(2);
   windowBuild.addInput(data);
   windowBuild.noMoreInput();
 
   ASSERT_FALSE(windowBuild.testingHasRowContainer());
+}
+
+TEST_F(WindowTest, rowsStreamingWindowBuildThrottlesLargePartition) {
+  // A single partition (constant 'p') feeds one ever-growing, not-yet-complete
+  // VectorWindowPartition, so the 'windowPartitions_.size() < 2' rule never
+  // throttles. With a retained-byte budget, needsInput() must ask the driver to
+  // stop feeding once the buffered (by-reference) input exceeds the budget so a
+  // large partition doesn't accumulate its entire input before any output.
+  const vector_size_t size = 1'000;
+  auto data = makeSinglePartitionData(size, 1, 0, 0);
+  auto windowNode =
+      makeStreamingWindowNode({data}, {rowsFrameFunction("row_number()")});
+
+  // Budget for 8 rows; one 1000-row batch far exceeds it.
+  const uint64_t budget = budgetForRows(data, 8);
+
+  {
+    TestingRowsStreamingWindowBuild windowBuild(
+        windowNode, pool(), nullptr, &nonReclaimableSection_, budget);
+    windowBuild.setNumRowsPerOutput(4);
+
+    // No input yet (no row-size estimate): needs input.
+    EXPECT_TRUE(windowBuild.needsInput());
+
+    windowBuild.addInput(data);
+    // Retained input for the single incomplete partition now far exceeds the
+    // byte budget, so it stops asking for input to let output drain.
+    EXPECT_FALSE(windowBuild.needsInput());
+  }
+
+  {
+    // With the default (unbounded) budget, a single incomplete partition is
+    // never throttled - this is the pre-fix behavior.
+    TestingRowsStreamingWindowBuild windowBuild(
+        windowNode,
+        pool(),
+        nullptr,
+        &nonReclaimableSection_,
+        kUnboundedRetainedBytes);
+    windowBuild.setNumRowsPerOutput(4);
+    windowBuild.addInput(data);
+    EXPECT_TRUE(windowBuild.needsInput());
+  }
+}
+
+TEST_F(WindowTest, rowsStreamingWindowBuildThrottleStaysDrainable) {
+  // When the byte budget is reached mid-partition before 'numRowsPerOutput_'
+  // rows accumulate, the pending rows must still be flushed into a partition so
+  // the driver can drain them. Otherwise needsInput() returns false (budget
+  // reached) while hasNextPartition() is false (nothing flushed): the Window
+  // operator can neither accept input nor produce output and the driver spins
+  // forever. This reproduces the production deadlock, where wide rows fill the
+  // budget at a handful of rows while 'numRowsPerOutput_' keeps the operator's
+  // init-time default (set from a nullopt row-size estimate).
+  const vector_size_t size = 1'000;
+  auto data = makeSinglePartitionData(size, 1, 0, 0);
+  auto windowNode =
+      makeStreamingWindowNode({data}, {rowsFrameFunction("row_number()")});
+
+  const uint64_t budget = budgetForRows(data, 8);
+
+  TestingRowsStreamingWindowBuild windowBuild(
+      windowNode, pool(), nullptr, &nonReclaimableSection_, budget);
+  // Mimic the Window operator, which fixes 'numRowsPerOutput_' at initialize()
+  // from a nullopt row-size estimate; for wide rows this default is far larger
+  // than the byte budget in rows, so the row-count flush never fires within the
+  // partition.
+  windowBuild.setNumRowsPerOutput(size * 2);
+
+  windowBuild.addInput(data);
+
+  // The byte budget stopped input for the single incomplete partition, so the
+  // build must expose a drainable partition; otherwise the driver deadlocks.
+  EXPECT_FALSE(windowBuild.needsInput());
+  EXPECT_TRUE(windowBuild.hasNextPartition());
+}
+
+TEST_F(WindowTest, rowsStreamingWindowBuildBudgetTracksGrowingRowSize) {
+  // The budget is in bytes and 'estimatedRowSize_' only grows, so a batch of
+  // much wider rows must start throttling even though the same row count of
+  // narrow rows did not. Guards against testing the budget against a stale
+  // row-width estimate taken from earlier, narrower input.
+  const vector_size_t batchSize = 100;
+  auto narrowBatch = makeSinglePartitionData(batchSize, 1, 0, 0);
+  auto secondNarrowBatch = makeSinglePartitionData(batchSize, 1, 0, batchSize);
+  auto wideBatch = makeSinglePartitionData(batchSize, 1, 4'096, 2 * batchSize);
+
+  auto windowNode = makeStreamingWindowNode(
+      {narrowBatch, secondNarrowBatch, wideBatch},
+      {rowsFrameFunction("row_number()")});
+
+  // Room for 4x the narrow batch, so two narrow batches stay under budget.
+  const uint64_t budget = budgetForRows(narrowBatch, 4 * batchSize);
+  ASSERT_LT(budgetForRows(narrowBatch, 1), budgetForRows(wideBatch, 1) / 100)
+      << "the wide payload must dominate the row-size estimate";
+
+  TestingRowsStreamingWindowBuild windowBuild(
+      windowNode, pool(), nullptr, &nonReclaimableSection_, budget);
+  // Keeps the row-count flush from firing, so throttling is driven by bytes.
+  windowBuild.setNumRowsPerOutput(10 * batchSize);
+
+  windowBuild.addInput(narrowBatch);
+  EXPECT_TRUE(windowBuild.needsInput());
+
+  // Twice the rows, still narrow: under budget, so still accepting.
+  windowBuild.addInput(secondNarrowBatch);
+  EXPECT_TRUE(windowBuild.needsInput());
+
+  // Only 50% more rows, but each ~300x wider: the re-estimated row size puts
+  // the retained bytes far over budget.
+  windowBuild.addInput(wideBatch);
+  EXPECT_FALSE(windowBuild.needsInput());
+  EXPECT_TRUE(windowBuild.hasNextPartition());
+}
+
+TEST_F(WindowTest, rowsStreamingWindowBuildBudgetFlushesOnce) {
+  // The byte-budget flush only has to make the pending rows drainable once.
+  // The budget stays exceeded until the driver drains, so re-testing it per row
+  // would flush every remaining row of the input as its own range, and
+  // VectorWindowPartition walks its ranges on each row lookup and rebuilds
+  // prefix sums on each removeProcessedRows().
+  const vector_size_t size = 1'000;
+  auto data = makeSinglePartitionData(size, 1, 0, 0);
+  auto windowNode =
+      makeStreamingWindowNode({data}, {rowsFrameFunction("row_number()")});
+
+  const uint64_t budget = budgetForRows(data, 8);
+
+  TestingRowsStreamingWindowBuild windowBuild(
+      windowNode, pool(), nullptr, &nonReclaimableSection_, budget);
+  // Keeps the row-count flush from firing, so every flush comes from the
+  // budget.
+  windowBuild.setNumRowsPerOutput(size * 2);
+
+  windowBuild.addInput(data);
+
+  auto partition = std::dynamic_pointer_cast<window::VectorWindowPartition>(
+      windowBuild.nextPartition());
+  ASSERT_NE(partition, nullptr);
+  EXPECT_EQ(partition->testingNumRanges(), 1);
+}
+
+TEST_F(WindowTest, rowsStreamingWindowBuildBudgetPreservesResults) {
+  // The byte budget changes only when the build stops accepting input and when
+  // it flushes; it must not change results. Heavy ties on the sort key put peer
+  // groups across the flush boundaries the budget creates, which is where
+  // rank/dense_rank would break if a partial partition were mistaken for a
+  // complete one.
+  //
+  // Every function needs an explicit ROWS frame. An omitted frame clause parses
+  // to RANGE, and 'hasRangeFrame_' is node-wide, so a single unframed function
+  // exempts the whole build from the budget and makes this comparison vacuous.
+  const vector_size_t size = 500;
+  auto data = makeSinglePartitionData(size, 7, 4'096, 0);
+  createDuckDbTable({data});
+
+  auto windowNode = makeStreamingWindowNode(
+      {data},
+      {rowsFrameFunction("rank()"),
+       rowsFrameFunction("dense_rank()"),
+       rowsFrameFunction("row_number()"),
+       rowsFrameFunction("sum(s)")});
+  for (const auto& function : windowNode->windowFunctions()) {
+    ASSERT_EQ(function.frame.type, core::WindowNode::WindowType::kRows)
+        << "a RANGE function would exempt the build from the byte budget";
+  }
+
+  auto tiny = AssertQueryBuilder(windowNode)
+                  .config(core::QueryConfig::kPreferredOutputBatchBytes, "1024")
+                  .config(core::QueryConfig::kPreferredOutputBatchRows, "10000")
+                  .copyResults(pool());
+  auto unbounded =
+      AssertQueryBuilder(windowNode)
+          .config(core::QueryConfig::kPreferredOutputBatchBytes, "1000000000")
+          .config(core::QueryConfig::kPreferredOutputBatchRows, "10000")
+          .copyResults(pool());
+
+  ASSERT_EQ(tiny->size(), size);
+  ASSERT_EQ(unbounded->size(), size);
+  for (auto row = 0; row < size; ++row) {
+    ASSERT_TRUE(tiny->equalValueAt(unbounded.get(), row, row))
+        << "row " << row << ": tiny=" << tiny->toString(row)
+        << " unbounded=" << unbounded->toString(row);
+  }
+
+  AssertQueryBuilder(windowNode, duckDbQueryRunner_)
+      .config(core::QueryConfig::kPreferredOutputBatchBytes, "1024")
+      .config(core::QueryConfig::kPreferredOutputBatchRows, "10000")
+      .assertResults(
+          "SELECT p, s, v, "
+          "rank() over (partition by p order by s rows between unbounded "
+          "preceding and current row), "
+          "dense_rank() over (partition by p order by s rows between unbounded "
+          "preceding and current row), "
+          "row_number() over (partition by p order by s rows between unbounded "
+          "preceding and current row), "
+          "sum(s) over (partition by p order by s rows between unbounded "
+          "preceding and current row) FROM tmp");
+}
+
+DEBUG_ONLY_TEST_F(
+    WindowTest,
+    rowsStreamingWindowBuildBudgetPreservesResultsNonDefaultFrame) {
+  // The default-frame restriction in Window::supportRowsStreaming() applies
+  // only to aggregates, so ranking functions reach this build under any frame,
+  // including one that extends past the current row. They ignore the frame -
+  // both Rank::apply() and RowNumber::apply() discard frameStarts/frameEnds -
+  // but the byte budget must not change their results either way. The RANGE
+  // case additionally covers the path where the budget is disabled outright.
+  const vector_size_t size = 500;
+  auto data = makeSinglePartitionData(size, 7, 4'096, 0);
+  createDuckDbTable({data});
+
+  for (const auto& frame :
+       {"rows between current row and unbounded following",
+        "rows between 3 preceding and 2 following",
+        "range between unbounded preceding and current row"}) {
+    SCOPED_TRACE(frame);
+    std::atomic_bool isStreamCreated{false};
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::window::RowsStreamingWindowBuild::RowsStreamingWindowBuild",
+        std::function<void(window::RowsStreamingWindowBuild*)>(
+            [&](window::RowsStreamingWindowBuild*) {
+              isStreamCreated.store(true);
+            }));
+    auto windowNode = makeStreamingWindowNode(
+        {data},
+        {fmt::format("rank() over (partition by p order by s {})", frame),
+         fmt::format(
+             "row_number() over (partition by p order by s {})", frame)});
+
+    auto tiny =
+        AssertQueryBuilder(windowNode)
+            .config(core::QueryConfig::kPreferredOutputBatchBytes, "1024")
+            .config(core::QueryConfig::kPreferredOutputBatchRows, "10000")
+            .copyResults(pool());
+    auto unbounded =
+        AssertQueryBuilder(windowNode)
+            .config(core::QueryConfig::kPreferredOutputBatchBytes, "1000000000")
+            .config(core::QueryConfig::kPreferredOutputBatchRows, "10000")
+            .copyResults(pool());
+
+    // These frames do reach this build; if the gate ever tightens, the
+    // invariant below stops being about the byte budget.
+    EXPECT_TRUE(isStreamCreated.load());
+    ASSERT_EQ(tiny->size(), size);
+    for (auto row = 0; row < size; ++row) {
+      ASSERT_TRUE(tiny->equalValueAt(unbounded.get(), row, row))
+          << "row " << row << ": tiny=" << tiny->toString(row)
+          << " unbounded=" << unbounded->toString(row);
+    }
+  }
+}
+
+TEST_F(WindowTest, rowsStreamingWindowBuildWideRowsSinglePartition) {
+  // End-to-end counterpart of the two throttle tests above. Rows wide enough
+  // that the retained-byte budget is reached almost immediately, a single
+  // partition that stays incomplete until the input ends, and an output-row
+  // target far above the budget in rows. The build refusing input and the
+  // operator producing output have to interleave, otherwise the driver makes no
+  // progress.
+  const vector_size_t size = 200;
+  auto data = makeSinglePartitionData(size, 1, 4'096, 0);
+  auto windowNode =
+      makeStreamingWindowNode({data}, {rowsFrameFunction("row_number()")});
+
+  auto result =
+      AssertQueryBuilder(windowNode)
+          .config(core::QueryConfig::kPreferredOutputBatchBytes, "1024")
+          .config(core::QueryConfig::kPreferredOutputBatchRows, "10000")
+          .copyResults(pool());
+  ASSERT_EQ(result->size(), size);
 }
 
 TEST_F(WindowTest, rowsStreamingWindowBuildLoadsOnlyBoundaryColumns) {
@@ -656,7 +1001,11 @@ TEST_F(WindowTest, rowsStreamingWindowBuildLoadsOnlyBoundaryColumns) {
   ASSERT_NE(windowNode, nullptr);
 
   TestingRowsStreamingWindowBuild windowBuild(
-      windowNode, pool(), nullptr, &nonReclaimableSection_);
+      windowNode,
+      pool(),
+      nullptr,
+      &nonReclaimableSection_,
+      kUnboundedRetainedBytes);
   windowBuild.setNumRowsPerOutput(2);
   windowBuild.addInput(data);
 
@@ -693,7 +1042,11 @@ TEST_F(
   ASSERT_NE(windowNode, nullptr);
 
   TestingRowsStreamingWindowBuild windowBuild(
-      windowNode, pool(), nullptr, &nonReclaimableSection_);
+      windowNode,
+      pool(),
+      nullptr,
+      &nonReclaimableSection_,
+      kUnboundedRetainedBytes);
   windowBuild.setNumRowsPerOutput(10);
   windowBuild.addInput(data);
   EXPECT_FALSE(payload->isLoaded());
@@ -776,7 +1129,11 @@ TEST_F(WindowTest, rowsStreamingWindowBuildRetainsEncodedRows) {
   ASSERT_NE(windowNode, nullptr);
 
   TestingRowsStreamingWindowBuild windowBuild(
-      windowNode, pool(), nullptr, &nonReclaimableSection_);
+      windowNode,
+      pool(),
+      nullptr,
+      &nonReclaimableSection_,
+      kUnboundedRetainedBytes);
   windowBuild.setNumRowsPerOutput(4);
   for (const auto& input : inputs) {
     windowBuild.addInput(input);
@@ -815,7 +1172,11 @@ TEST_F(WindowTest, rowsStreamingWindowBuildExtractsNegativeRowsAsNull) {
   ASSERT_NE(windowNode, nullptr);
 
   TestingRowsStreamingWindowBuild windowBuild(
-      windowNode, pool(), nullptr, &nonReclaimableSection_);
+      windowNode,
+      pool(),
+      nullptr,
+      &nonReclaimableSection_,
+      kUnboundedRetainedBytes);
   windowBuild.setNumRowsPerOutput(10);
   windowBuild.addInput(data);
   windowBuild.noMoreInput();
@@ -851,7 +1212,11 @@ TEST_F(WindowTest, rowsStreamingWindowBuildKRangeFrameNanBounds) {
   ASSERT_NE(windowNode, nullptr);
 
   TestingRowsStreamingWindowBuild windowBuild(
-      windowNode, pool(), nullptr, &nonReclaimableSection_);
+      windowNode,
+      pool(),
+      nullptr,
+      &nonReclaimableSection_,
+      kUnboundedRetainedBytes);
   windowBuild.setNumRowsPerOutput(10);
   windowBuild.addInput(data);
   windowBuild.noMoreInput();
@@ -901,7 +1266,11 @@ TEST_F(WindowTest, rowsStreamingWindowBuildKRangeFramePeerBounds) {
   ASSERT_NE(windowNode, nullptr);
 
   TestingRowsStreamingWindowBuild windowBuild(
-      windowNode, pool(), nullptr, &nonReclaimableSection_);
+      windowNode,
+      pool(),
+      nullptr,
+      &nonReclaimableSection_,
+      kUnboundedRetainedBytes);
   windowBuild.setNumRowsPerOutput(10);
   windowBuild.addInput(data);
   windowBuild.noMoreInput();
@@ -956,7 +1325,11 @@ TEST_F(WindowTest, rowsStreamingWindowBuildPeerContinuesAcrossInputBatches) {
   ASSERT_NE(windowNode, nullptr);
 
   TestingRowsStreamingWindowBuild windowBuild(
-      windowNode, pool(), nullptr, &nonReclaimableSection_);
+      windowNode,
+      pool(),
+      nullptr,
+      &nonReclaimableSection_,
+      kUnboundedRetainedBytes);
   windowBuild.setNumRowsPerOutput(2);
   windowBuild.addInput(firstBatch);
   windowBuild.addInput(secondBatch);
@@ -1000,7 +1373,11 @@ TEST_F(WindowTest, rowsStreamingWindowBuildKRangeFrameSearchBounds) {
     ASSERT_NE(windowNode, nullptr);
 
     TestingRowsStreamingWindowBuild windowBuild(
-        windowNode, pool(), nullptr, &nonReclaimableSection_);
+        windowNode,
+        pool(),
+        nullptr,
+        &nonReclaimableSection_,
+        kUnboundedRetainedBytes);
     windowBuild.setNumRowsPerOutput(10);
     auto splitData = split(data, 4);
     for (const auto& input : splitData) {

--- a/velox/exec/window/RowsStreamingWindowBuild.cpp
+++ b/velox/exec/window/RowsStreamingWindowBuild.cpp
@@ -77,9 +77,11 @@ RowsStreamingWindowBuild::RowsStreamingWindowBuild(
     const std::shared_ptr<const core::WindowNode>& windowNode,
     velox::memory::MemoryPool* pool,
     const common::SpillConfig* spillConfig,
-    tsan_atomic<bool>* nonReclaimableSection)
+    tsan_atomic<bool>* nonReclaimableSection,
+    uint64_t maxRetainedBytes)
     : WindowBuild(windowNode, pool, spillConfig, nonReclaimableSection),
       hasRangeFrame_(hasRangeFrame(windowNode)),
+      maxRetainedBytes_(std::max<uint64_t>(maxRetainedBytes, 1)),
       partitionKeyValues_(keyChannels(partitionKeyInfo_, inputChannels_), pool),
       peerKeyValues_(keyChannels(sortKeyInfo_, inputChannels_), pool),
       boundaryKeyChannels_(
@@ -91,9 +93,69 @@ RowsStreamingWindowBuild::RowsStreamingWindowBuild(
       this);
 }
 
+int64_t RowsStreamingWindowBuild::numRetainedRows() const {
+  int64_t numRows = pendingRowCount_;
+  for (const auto& windowPartition : windowPartitions_) {
+    numRows += windowPartition->numRows();
+  }
+  return numRows;
+}
+
+bool RowsStreamingWindowBuild::reachedRetainedBytesBudget() const {
+  // RANGE frames must retain the whole incomplete peer group, so they are never
+  // throttled on bytes.
+  if (hasRangeFrame_ || !estimatedRowSize_.has_value()) {
+    return false;
+  }
+  const uint64_t retainedBytes =
+      static_cast<uint64_t>(numRetainedRows()) * estimatedRowSize_.value();
+  return retainedBytes >= maxRetainedBytes_;
+}
+
+void RowsStreamingWindowBuild::updatePendingRowBudget() {
+  if (!estimatedRowSize_.has_value()) {
+    return;
+  }
+  const uint64_t rowBudget = maxRetainedBytes_ / estimatedRowSize_.value();
+  maxPendingRows_ = static_cast<vector_size_t>(std::min<uint64_t>(
+      std::max<uint64_t>(rowBudget, 1),
+      std::numeric_limits<vector_size_t>::max()));
+}
+
+bool RowsStreamingWindowBuild::hasRowsToDrain() const {
+  for (const auto& windowPartition : windowPartitions_) {
+    if (windowPartition->numRows() > 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
 bool RowsStreamingWindowBuild::needsInput() {
-  // We need input if there is no or only partition.
-  return windowPartitions_.size() < 2;
+  // Stop accepting input once two partitions are buffered: the head can be
+  // output while the tail keeps accepting input.
+  if (windowPartitions_.size() >= 2) {
+    return false;
+  }
+
+  // Within a single not-yet-complete partition, 'windowPartitions_.size()'
+  // stays 1, so the check above never throttles and a large partition would
+  // accumulate its entire input (held by reference) before any output. For
+  // ROWS-frame functions (e.g. row_number/rank) every buffered row is
+  // immediately emittable, so once the retained input reaches the byte budget,
+  // ask the driver to drain output instead - draining calls
+  // 'removeProcessedRows()', which releases the retained input vectors.
+  // On the same condition 'addInput()' flushes the pending rows into a
+  // partition, so a drainable partition always exists when this returns false.
+  if (!reachedRetainedBytesBudget()) {
+    return true;
+  }
+
+  // Only throttle while the operator still has rows it can emit. Refusing
+  // input when nothing is emittable would leave the driver unable to either
+  // feed or drain this operator, and the task would stall. Accepting input
+  // past the budget grows memory, which is the lesser failure.
+  return !hasRowsToDrain();
 }
 
 void RowsStreamingWindowBuild::ensureInputPartition() {
@@ -131,6 +193,19 @@ void RowsStreamingWindowBuild::addPartitionInputs(bool finished) {
 void RowsStreamingWindowBuild::addInput(RowVectorPtr input) {
   loadBoundaryColumns(input);
 
+  // Skipped for RANGE frames, which are never throttled on bytes and so have no
+  // use for the estimate: 'estimateFlatSize()' walks the vector on every batch.
+  if (!hasRangeFrame_ && input->size() > 0) {
+    // Floored at one byte: an encoded input can estimate to fewer bytes than
+    // rows, and a zero row size would make the retained-byte total zero and
+    // silently disable throttling.
+    const int64_t rowSize = std::max<int64_t>(
+        static_cast<int64_t>(input->estimateFlatSize()) / input->size(), 1);
+    estimatedRowSize_ =
+        std::max<int64_t>(estimatedRowSize_.value_or(0), rowSize);
+    updatePendingRowBudget();
+  }
+
   vector_size_t rangeStart = 0;
   for (auto row = 0; row < input->size(); ++row) {
     const bool hasPreviousRow = row > 0 || partitionKeyValues_.hasValue();
@@ -139,7 +214,16 @@ void RowsStreamingWindowBuild::addInput(RowVectorPtr input) {
       addPartitionInputs(true);
       rangeStart = row;
     }
-    if (hasPreviousRow && pendingRowCount_ >= numRowsPerOutput_) {
+    // Flush pending rows into a partition once the output-row target is hit,
+    // or once the retained-byte budget is reached with nothing yet drainable.
+    // The byte-budget trigger exists only so 'needsInput()' never throttles a
+    // single wide partition without leaving output for the driver to drain;
+    // gating it on 'hasRowsToDrain()' keeps it to one flush, instead of
+    // splitting every remaining row of this input into its own range while the
+    // budget stays exceeded.
+    if (hasPreviousRow &&
+        (pendingRowCount_ >= numRowsPerOutput_ ||
+         (pendingRowCount_ >= maxPendingRows_ && !hasRowsToDrain()))) {
       // Needs to wait the peer group ready for range frame.
       if (hasRangeFrame_) {
         if (isNewPeerGroup(input, row)) {

--- a/velox/exec/window/RowsStreamingWindowBuild.h
+++ b/velox/exec/window/RowsStreamingWindowBuild.h
@@ -21,6 +21,7 @@
 #include "velox/exec/window/WindowBuild.h"
 
 #include <deque>
+#include <limits>
 #include <optional>
 #include <vector>
 
@@ -39,9 +40,17 @@ class RowsStreamingWindowBuild : public WindowBuild {
       const std::shared_ptr<const core::WindowNode>& windowNode,
       velox::memory::MemoryPool* pool,
       const common::SpillConfig* spillConfig,
-      tsan_atomic<bool>* nonReclaimableSection);
+      tsan_atomic<bool>* nonReclaimableSection,
+      // Byte budget for input retained within a single not-yet-complete
+      // partition before 'needsInput()' asks the driver to drain. The Window
+      // operator passes 'preferredOutputBatchBytes'.
+      uint64_t maxRetainedBytes);
 
   void addInput(RowVectorPtr input) override;
+
+  std::optional<int64_t> estimateRowSize() override {
+    return estimatedRowSize_;
+  }
 
   void spill() override {
     VELOX_UNREACHABLE();
@@ -92,8 +101,43 @@ class RowsStreamingWindowBuild : public WindowBuild {
   // Loads only key columns needed to detect partition and peer boundaries.
   void loadBoundaryColumns(const RowVectorPtr& input) const;
 
+  // Returns the number of buffered input rows not yet consumed by output:
+  // rows pending in 'currentRanges_' plus unconsumed rows in
+  // 'windowPartitions_'. Widened to 64 bits because it sums row counts across
+  // partitions and so is not bounded by 'vector_size_t'.
+  int64_t numRetainedRows() const;
+
+  // Returns true for a ROWS-frame build whose retained (by-reference) input for
+  // the current not-yet-complete partition has reached 'maxRetainedBytes_'.
+  // Drives throttling in 'needsInput()', and in 'addInput()' the flush that
+  // makes the pending rows drainable, so the build never stops requesting
+  // input without leaving output to drain.
+  bool reachedRetainedBytesBudget() const;
+
+  // Recomputes 'maxPendingRows_' from the current row-size estimate. Called
+  // once per input rather than per row.
+  void updatePendingRowBudget();
+
+  // Returns true if some partition holds rows the window operator can emit.
+  // 'hasNextPartition()' is not sufficient for this: it also reports true for
+  // an incomplete partition holding no rows, which the operator turns into a
+  // null output.
+  bool hasRowsToDrain() const;
+
   // Sets to true if this window node has range frames.
   const bool hasRangeFrame_;
+
+  // Upper bound on the estimated bytes of input retained (by reference) for a
+  // single not-yet-complete partition before 'needsInput()' asks the driver to
+  // stop feeding and drain output. Bounds peak memory for large partitions.
+  const uint64_t maxRetainedBytes_;
+
+  // Largest per-batch average row size in bytes seen so far: the maximum over
+  // each input's 'estimateFlatSize() / size()'. Converts the retained row count
+  // into bytes. A maximum rather than a running average, so that a batch of
+  // wide rows is not masked by earlier narrow ones, which would leave the build
+  // accepting input well past the byte budget.
+  std::optional<int64_t> estimatedRowSize_;
 
   // Ranges of input rows buffered for the current partition.
   std::vector<RowRange> currentRanges_;
@@ -114,6 +158,14 @@ class RowsStreamingWindowBuild : public WindowBuild {
 
   // Number of rows accumulated since the last partial flush.
   vector_size_t pendingRowCount_{0};
+
+  // 'maxRetainedBytes_' expressed in rows at the current 'estimatedRowSize_',
+  // so the per-row check in 'addInput()' is an integer compare rather than a
+  // walk of 'windowPartitions_'. Valid there only because that flush also
+  // requires '!hasRowsToDrain()', i.e. every partition holds zero rows, which
+  // makes 'pendingRowCount_' the whole retained-row count. Left at the maximum
+  // for RANGE frames, which are never throttled on bytes.
+  vector_size_t maxPendingRows_{std::numeric_limits<vector_size_t>::max()};
 
   // The output gets next partition from the head of 'windowPartitions_' and
   // input adds to the next partition from the tail of 'windowPartitions_'.

--- a/velox/exec/window/RowsStreamingWindowBuild.h
+++ b/velox/exec/window/RowsStreamingWindowBuild.h
@@ -21,6 +21,7 @@
 #include "velox/exec/window/WindowBuild.h"
 
 #include <deque>
+#include <limits>
 #include <optional>
 #include <vector>
 
@@ -39,7 +40,11 @@ class RowsStreamingWindowBuild : public WindowBuild {
       const std::shared_ptr<const core::WindowNode>& windowNode,
       velox::memory::MemoryPool* pool,
       const common::SpillConfig* spillConfig,
-      tsan_atomic<bool>* nonReclaimableSection);
+      tsan_atomic<bool>* nonReclaimableSection,
+      // Byte budget for input retained within a single not-yet-complete
+      // partition before 'needsInput()' asks the driver to drain. The Window
+      // operator passes 'preferredOutputBatchBytes'.
+      uint64_t maxRetainedBytes);
 
   void addInput(RowVectorPtr input) override;
 
@@ -92,8 +97,43 @@ class RowsStreamingWindowBuild : public WindowBuild {
   // Loads only key columns needed to detect partition and peer boundaries.
   void loadBoundaryColumns(const RowVectorPtr& input) const;
 
+  // Returns the number of buffered input rows not yet consumed by output:
+  // rows pending in 'currentRanges_' plus unconsumed rows in
+  // 'windowPartitions_'. Widened to 64 bits because it sums row counts across
+  // partitions and so is not bounded by 'vector_size_t'.
+  int64_t numRetainedRows() const;
+
+  // Returns true for a ROWS-frame build whose retained (by-reference) input for
+  // the current not-yet-complete partition has reached 'maxRetainedBytes_'.
+  // Drives throttling in 'needsInput()', and in 'addInput()' the flush that
+  // makes the pending rows drainable, so the build never stops requesting
+  // input without leaving output to drain.
+  bool reachedRetainedBytesBudget() const;
+
+  // Recomputes 'maxPendingRows_' from the current row-size estimate. Called
+  // once per input rather than per row.
+  void updatePendingRowBudget();
+
+  // Returns true if some partition holds rows the window operator can emit.
+  // 'hasNextPartition()' is not sufficient for this: it also reports true for
+  // an incomplete partition holding no rows, which the operator turns into a
+  // null output.
+  bool hasRowsToDrain() const;
+
   // Sets to true if this window node has range frames.
   const bool hasRangeFrame_;
+
+  // Upper bound on the estimated bytes of input retained (by reference) for a
+  // single not-yet-complete partition before 'needsInput()' asks the driver to
+  // stop feeding and drain output. Bounds peak memory for large partitions.
+  const uint64_t maxRetainedBytes_;
+
+  // Largest per-batch average row size in bytes seen so far: the maximum over
+  // each input's 'estimateFlatSize() / size()'. Converts the retained row count
+  // into bytes. A maximum rather than a running average, so that a batch of
+  // wide rows is not masked by earlier narrow ones, which would leave the build
+  // accepting input well past the byte budget.
+  std::optional<int64_t> estimatedRowSize_;
 
   // Ranges of input rows buffered for the current partition.
   std::vector<RowRange> currentRanges_;
@@ -114,6 +154,14 @@ class RowsStreamingWindowBuild : public WindowBuild {
 
   // Number of rows accumulated since the last partial flush.
   vector_size_t pendingRowCount_{0};
+
+  // 'maxRetainedBytes_' expressed in rows at the current 'estimatedRowSize_',
+  // so the per-row check in 'addInput()' is an integer compare rather than a
+  // walk of 'windowPartitions_'. Valid there only because that flush also
+  // requires '!hasRowsToDrain()', i.e. every partition holds zero rows, which
+  // makes 'pendingRowCount_' the whole retained-row count. Left at the maximum
+  // for RANGE frames, which are never throttled on bytes.
+  vector_size_t maxPendingRows_{std::numeric_limits<vector_size_t>::max()};
 
   // The output gets next partition from the head of 'windowPartitions_' and
   // input adds to the next partition from the tail of 'windowPartitions_'.

--- a/velox/exec/window/VectorWindowPartition.h
+++ b/velox/exec/window/VectorWindowPartition.h
@@ -103,6 +103,13 @@ class VectorWindowPartition : public WindowPartition {
       vector_size_t* rawFrameBounds,
       SelectivityVector& validFrames) const override;
 
+  /// Returns the number of retained input vector ranges. Row lookup and
+  /// 'removeProcessedRows()' both walk these, so a caller that adds rows in
+  /// many small ranges pays for it on every access.
+  size_t testingNumRanges() const {
+    return ranges_.size();
+  }
+
  private:
   class VectorAccessor;
 


### PR DESCRIPTION
Summary:

RowsStreamingWindowBuild (used for ROWS-frame ranking functions like
row_number when input is pre-sorted) retains its input RowVectors by
reference (VectorWindowPartition) rather than copying them, and its
needsInput() only throttles on windowPartitions_.size() < 2. For a single
large partition, windowPartitions_.size() stays 1, so the driver keeps
feeding input and the whole partition accumulates in memory (charged to the
upstream operator's pool, since that pool allocated the vectors) before any
output drains it. On multi-row_number Gluten/Spark plans with wide rows this
manifests as an off-heap OOM attributed to the upstream OrderBy.

This gates needsInput() on a retained-byte budget for ROWS-frame functions:
once the buffered (by-reference) input for a not-yet-complete partition
exceeds the budget, needsInput() returns false so the driver drains output,
which calls removeProcessedRows() and releases the retained input. RANGE
frames must retain the incomplete peer group and are left unchanged.

The budget is preferredOutputBatchBytes, plumbed from the Window operator.
Converting it to a row count needs a row size, and this build has no
RowContainer to ask, so addInput() tracks the largest per-batch average
(estimateFlatSize() / size()) it has seen. That is deliberately a maximum
rather than a running average: a batch of wide rows must not be masked by
earlier narrow ones, or the build keeps accepting input well past the budget.
The estimate is skipped entirely for RANGE frames, which never consult it.

Reviewed By: tanjialiang

Differential Revision: D114433657


