### PR TITLE
feat(remote): Only send selected rows to the remote server (#18379)

### DIFF
--- a/velox/functions/remote/client/RemoteVectorFunction.cpp
+++ b/velox/functions/remote/client/RemoteVectorFunction.cpp
@@ -30,6 +30,40 @@ std::string serializeType(const TypePtr& type) {
   return type::fbhive::HiveTypeSerializer::serialize(type);
 }
 
+// Maps compacted position -> original row number, for the selected rows only.
+BufferPtr compactedToOriginalIndices(
+    const SelectivityVector& rows,
+    memory::MemoryPool* pool) {
+  BufferPtr indices =
+      AlignedBuffer::allocate<vector_size_t>(rows.countSelected(), pool);
+  auto* rawIndices = indices->asMutable<vector_size_t>();
+  vector_size_t compactedPosition = 0;
+  rows.applyToSelected(
+      [&](vector_size_t row) { rawIndices[compactedPosition++] = row; });
+  return indices;
+}
+
+// Maps original row number -> compacted position, inverting
+// 'compactedToOriginal' so the remote result can be scattered back onto the
+// rows the caller selected. Unselected positions are never read, so they are
+// left pointing at the first compacted row.
+BufferPtr originalToCompactedIndices(
+    const BufferPtr& compactedToOriginal,
+    vector_size_t numCompacted,
+    vector_size_t size,
+    memory::MemoryPool* pool) {
+  BufferPtr indices = AlignedBuffer::allocate<vector_size_t>(size, pool);
+  auto* rawIndices = indices->asMutable<vector_size_t>();
+  std::fill(rawIndices, rawIndices + size, 0);
+
+  const auto* rawCompactedToOriginal = compactedToOriginal->as<vector_size_t>();
+  for (vector_size_t compactedPosition = 0; compactedPosition < numCompacted;
+       ++compactedPosition) {
+    rawIndices[rawCompactedToOriginal[compactedPosition]] = compactedPosition;
+  }
+  return indices;
+}
+
 } // namespace
 
 RemoteVectorFunction::RemoteVectorFunction(
@@ -76,12 +110,24 @@ void RemoteVectorFunction::applyRemote(
     const TypePtr& outputType,
     exec::EvalCtx& context,
     VectorPtr& result) const {
+  const vector_size_t numSelected = rows.countSelected();
+  const bool shouldCompact =
+      !preserveEncoding_ && numSelected > 0 && numSelected < rows.end();
+
+  BufferPtr compactedToOriginal;
+  if (shouldCompact) {
+    compactedToOriginal = compactedToOriginalIndices(rows, context.pool());
+    for (auto& arg : args) {
+      arg = BaseVector::wrapInDictionary(
+          BufferPtr{}, compactedToOriginal, numSelected, arg);
+    }
+  }
   // Create type and row vector for serialization.
   auto remoteRowVector = std::make_shared<RowVector>(
       context.pool(),
       remoteInputType_,
       BufferPtr{},
-      rows.end(),
+      shouldCompact ? numSelected : rows.end(),
       std::move(args));
 
   // Create the thrift payload.
@@ -97,17 +143,12 @@ void RemoteVectorFunction::applyRemote(
   requestInputs->rowCount() = remoteRowVector->size();
   requestInputs->pageFormat() = serdeFormat_;
 
-  // TODO: serialize only active rows.
   if (preserveEncoding_) {
     requestInputs->payload_ref() = rowVectorToIOBufBatch(
-        remoteRowVector,
-        rows.end(),
-        *context.pool(),
-        serde_.get(),
-        serdeOptions_.get());
+        remoteRowVector, *context.pool(), serde_.get(), serdeOptions_.get());
   } else {
-    requestInputs->payload_ref() = rowVectorToIOBuf(
-        remoteRowVector, rows.end(), *context.pool(), serde_.get());
+    requestInputs->payload_ref() =
+        rowVectorToIOBuf(remoteRowVector, *context.pool(), serde_.get());
   }
 
   std::unique_ptr<remote::RemoteFunctionResponse> remoteResponse;
@@ -130,6 +171,14 @@ void RemoteVectorFunction::applyRemote(
       *context.pool(),
       serde_.get());
   result = outputRowVector->childAt(0);
+  if (shouldCompact) {
+    result = BaseVector::wrapInDictionary(
+        BufferPtr{},
+        originalToCompactedIndices(
+            compactedToOriginal, numSelected, rows.end(), context.pool()),
+        rows.end(),
+        result);
+  }
 
   if (auto errorPayload = remoteResult.errorPayload()) {
     auto errorsRowVector = IOBufToRowVector(
@@ -139,6 +188,11 @@ void RemoteVectorFunction::applyRemote(
         errorsVector,
         "Remote function error payload should be convertible to flat vector.");
 
+    // Error rows are positions in the payload that was sent, so they need the
+    // same mapping back to original rows that the result does.
+    const auto* rawCompactedToOriginal =
+        shouldCompact ? compactedToOriginal->as<vector_size_t>() : nullptr;
+
     SelectivityVector selectedRows(errorsRowVector->size());
     selectedRows.applyToSelected([&](vector_size_t i) {
       if (errorsVector->isNullAt(i)) {
@@ -147,7 +201,9 @@ void RemoteVectorFunction::applyRemote(
       try {
         VELOX_USER_FAIL("{}", errorsVector->valueAt(i));
       } catch (const std::exception&) {
-        context.setError(i, std::current_exception());
+        context.setError(
+            rawCompactedToOriginal != nullptr ? rawCompactedToOriginal[i] : i,
+            std::current_exception());
       }
     });
   }

--- a/velox/functions/remote/client/tests/RemoteFunctionTest.cpp
+++ b/velox/functions/remote/client/tests/RemoteFunctionTest.cpp
@@ -294,9 +294,11 @@ class MockRemoteFunctionTest : public functions::test::FunctionBaseTest {
   /// Registers a remote function with a mock client factory.
   void registerMockRemoteFunction(
       const std::string& name,
-      std::vector<exec::FunctionSignaturePtr> signatures) {
+      std::vector<exec::FunctionSignaturePtr> signatures,
+      bool preserveEncoding) {
     RemoteThriftVectorFunctionMetadata metadata;
     metadata.serdeFormat = remote::PageFormat::PRESTO_PAGE;
+    metadata.preserveEncoding = preserveEncoding;
     // Location doesn't matter since we're using a mock client.
     metadata.location = folly::SocketAddress("127.0.0.1", 12345);
 
@@ -340,13 +342,15 @@ class MockRemoteFunctionTest : public functions::test::FunctionBaseTest {
 
   /// Registers a mock remote function with signature (bigint, bigint) ->
   /// bigint.
-  void registerMockRemotePlusFunction(const std::string& name) {
+  void registerMockRemotePlusFunction(
+      const std::string& name,
+      bool preserveEncoding) {
     auto signatures = {exec::FunctionSignatureBuilder()
                            .returnType("bigint")
                            .argumentType("bigint")
                            .argumentType("bigint")
                            .build()};
-    registerMockRemoteFunction(name, std::move(signatures));
+    registerMockRemoteFunction(name, std::move(signatures), preserveEncoding);
   }
 
  protected:
@@ -360,7 +364,8 @@ TEST_F(MockRemoteFunctionTest, mockClientIsCalled) {
                          .argumentType("bigint")
                          .argumentType("bigint")
                          .build()};
-  registerMockRemoteFunction("mock_plus", signatures);
+  registerMockRemoteFunction(
+      "mock_plus", signatures, /*preserveEncoding=*/false);
 
   // Set up the mock to return a valid response.
   EXPECT_CALL(*mockClient_, invokeFunction)
@@ -381,13 +386,138 @@ TEST_F(MockRemoteFunctionTest, mockClientIsCalled) {
   assertEqualVectors(expected, results);
 }
 
+TEST_F(MockRemoteFunctionTest, serializesOnlyActiveRows) {
+  registerMockRemotePlusFunction(
+      "mock_plus_active_rows", /*preserveEncoding=*/false);
+
+  EXPECT_CALL(*mockClient_, invokeFunction)
+      .WillOnce([&](remote::RemoteFunctionResponse& response,
+                    const remote::RemoteFunctionRequest& request) {
+        // Only the two selected rows should be sent. Distinct values per row
+        // let the assertions below verify that each result lands back on the
+        // row it came from.
+        EXPECT_EQ(request.inputs()->rowCount().value(), 2);
+        setMockResponse(
+            response, makeRowVector({makeFlatVector<int64_t>({100, 101})}));
+      });
+
+  auto data =
+      makeRowVector({makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6, 7, 8, 9, 10})});
+  exec::ExprSet exprSet(
+      {makeTypedExpr("mock_plus_active_rows(c0, c0)", asRowType(data->type()))},
+      &execCtx_);
+  exec::EvalCtx context(&execCtx_, &exprSet, data.get());
+  std::vector<VectorPtr> results(1);
+
+  // Select the first and last rows only: countSelected() is 2 while end() is
+  // 10, so serializing [0, end()) would ship 8 rows the expression did not ask
+  // for -- and the remote side evaluates every row it receives.
+  SelectivityVector rows(data->size(), false);
+  rows.setValid(0, true);
+  rows.setValid(9, true);
+  rows.updateBounds();
+
+  exprSet.eval(rows, context, results);
+
+  // Results must be scattered back onto the original row positions.
+  auto resultVector = results[0]->as<SimpleVector<int64_t>>();
+  ASSERT_TRUE(resultVector != nullptr);
+  EXPECT_EQ(resultVector->valueAt(0), 100);
+  EXPECT_EQ(resultVector->valueAt(9), 101);
+}
+
+TEST_F(MockRemoteFunctionTest, scattersErrorsBackToOriginalRows) {
+  registerMockRemotePlusFunction(
+      "mock_plus_active_row_errors", /*preserveEncoding=*/false);
+
+  // Fails the second serialized row. When only rows 0 and 9 are selected that
+  // is compacted position 1, which must surface as an error on row 9 -- not on
+  // row 1, which was never even sent.
+  EXPECT_CALL(*mockClient_, invokeFunction)
+      .WillOnce([&](remote::RemoteFunctionResponse& response,
+                    const remote::RemoteFunctionRequest& request) {
+        const auto rowCount = request.inputs()->rowCount().value();
+        std::vector<int64_t> values(rowCount);
+        std::iota(values.begin(), values.end(), 100);
+        setMockResponse(response, makeRowVector({makeFlatVector(values)}));
+
+        auto errors = makeNullableFlatVector<StringView>(
+            {std::nullopt, StringView("remote boom")});
+        auto serde = getSerde(remote::PageFormat::PRESTO_PAGE);
+        response.result()->errorPayload() =
+            rowVectorToIOBuf(makeRowVector({errors}), *pool(), serde.get());
+      });
+
+  auto data =
+      makeRowVector({makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6, 7, 8, 9, 10})});
+  exec::ExprSet exprSet(
+      {makeTypedExpr(
+          "TRY(mock_plus_active_row_errors(c0, c0))", asRowType(data->type()))},
+      &execCtx_);
+  exec::EvalCtx context(&execCtx_, &exprSet, data.get());
+  std::vector<VectorPtr> results(1);
+
+  SelectivityVector rows(data->size(), false);
+  rows.setValid(0, true);
+  rows.setValid(9, true);
+  rows.updateBounds();
+
+  exprSet.eval(rows, context, results);
+
+  auto resultVector = results[0]->as<SimpleVector<int64_t>>();
+  ASSERT_TRUE(resultVector != nullptr);
+  EXPECT_FALSE(resultVector->isNullAt(0));
+  EXPECT_EQ(resultVector->valueAt(0), 100);
+  EXPECT_TRUE(resultVector->isNullAt(9));
+}
+
+TEST_F(MockRemoteFunctionTest, preserveEncodingSendsAllRows) {
+  registerMockRemotePlusFunction(
+      "mock_plus_preserve_encoding", /*preserveEncoding=*/true);
+
+  EXPECT_CALL(*mockClient_, invokeFunction)
+      .WillOnce([&](remote::RemoteFunctionResponse& response,
+                    const remote::RemoteFunctionRequest& request) {
+        // Rows are not compacted when the encoding is preserved, so all 10 are
+        // sent even though only 2 are selected: the dictionary wrap would
+        // still carry the full base vector across the wire.
+        EXPECT_EQ(request.inputs()->rowCount().value(), 10);
+        std::vector<int64_t> values(10);
+        std::iota(values.begin(), values.end(), 100);
+        setMockResponse(response, makeRowVector({makeFlatVector(values)}));
+      });
+
+  auto data =
+      makeRowVector({makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6, 7, 8, 9, 10})});
+  exec::ExprSet exprSet(
+      {makeTypedExpr(
+          "mock_plus_preserve_encoding(c0, c0)", asRowType(data->type()))},
+      &execCtx_);
+  exec::EvalCtx context(&execCtx_, &exprSet, data.get());
+  std::vector<VectorPtr> results(1);
+
+  SelectivityVector rows(data->size(), false);
+  rows.setValid(0, true);
+  rows.setValid(9, true);
+  rows.updateBounds();
+
+  exprSet.eval(rows, context, results);
+
+  // Without compaction the result needs no scatter: row N holds position N.
+  auto resultVector = results[0]->as<SimpleVector<int64_t>>();
+  ASSERT_TRUE(resultVector != nullptr);
+  EXPECT_EQ(resultVector->valueAt(0), 100);
+  EXPECT_EQ(resultVector->valueAt(9), 109);
+}
+
 TEST_F(MockRemoteFunctionTest, mockClientThrowsException) {
   // Register a mock remote function.
   auto signatures = {exec::FunctionSignatureBuilder()
                          .returnType("bigint")
                          .argumentType("bigint")
                          .build()};
-  registerMockRemoteFunction("mock_throwing", signatures);
+  registerMockRemoteFunction(
+      "mock_throwing", signatures, /*preserveEncoding=*/false);
 
   // Set up the mock to throw an exception.
   EXPECT_CALL(*mockClient_, invokeFunction)
@@ -406,7 +536,7 @@ TEST_F(MockRemoteFunctionTest, mockClientThrowsException) {
 }
 
 TEST_F(MockRemoteFunctionTest, mockClientRepeatedCoroutineCalls) {
-  registerMockRemotePlusFunction("mock_repeated");
+  registerMockRemotePlusFunction("mock_repeated", /*preserveEncoding=*/false);
 
   EXPECT_CALL(*mockClient_, invokeFunction)
       .Times(3)
@@ -430,7 +560,7 @@ TEST_F(MockRemoteFunctionTest, mockClientRepeatedCoroutineCalls) {
 // Tests that exceptions thrown during the coroutine path don't leave the
 // function in a broken state.
 TEST_F(MockRemoteFunctionTest, coroutineExceptionThenRecovery) {
-  registerMockRemotePlusFunction("mock_recover");
+  registerMockRemotePlusFunction("mock_recover", /*preserveEncoding=*/false);
 
   // First call throws, second call succeeds.
   EXPECT_CALL(*mockClient_, invokeFunction)
@@ -466,7 +596,8 @@ TEST_F(MockRemoteFunctionTest, coroutineLargePayload) {
                          .returnType("bigint")
                          .argumentType("bigint")
                          .build()};
-  registerMockRemoteFunction("mock_large", signatures);
+  registerMockRemoteFunction(
+      "mock_large", signatures, /*preserveEncoding=*/false);
 
   constexpr int kSize = 1000;
   std::vector<int64_t> expectedValues(kSize);


### PR DESCRIPTION
Summary:

We found a regression when moving an UDF from in-process to sidecar and after some debugging we realized it was evaluating filtered out rows (via selectivity vector). There's a TODO to not serialize those which we're addressing in this diff.

The idea is to "merge" the selectivity vector as dictionary encoding. The vector serializer doesn't know about selectivity vector but does know about dictionary encoding.

Reviewed By: xiaoxmeng

Differential Revision: D114501061


